### PR TITLE
Shrink Address Bar Height 1.0.0

### DIFF
--- a/mods/shrink-address-bar-height.wh.cpp
+++ b/mods/shrink-address-bar-height.wh.cpp
@@ -13,6 +13,8 @@
 # Shrink Address Bar Height
 This mod shrinks the address bar height in file explorer.
 
+Note: This mod applies to explorer folders as well as save/open dialogs in all programs.
+
 The code is based on the implementation in [ExplorerPatcher](https://github.com/valinet/ExplorerPatcher).
 
 ![Screenshot](https://raw.githubusercontent.com/ItsProfessional/Screenshots/main/Windhawk/shrink-address-bar-height.png)

--- a/mods/shrink-address-bar-height.wh.cpp
+++ b/mods/shrink-address-bar-height.wh.cpp
@@ -15,7 +15,7 @@ This mod shrinks the address bar height in file explorer.
 
 The code is based on the implementation in [ExplorerPatcher](https://github.com/valinet/ExplorerPatcher).
 
-![Screenshot](https://raw.githubusercontent.com/ItsProfessional/Screenshots/main/Windhawk/win7-command-bar.png)
+![Screenshot](https://raw.githubusercontent.com/ItsProfessional/Screenshots/main/Windhawk/shrink-address-bar-height.png)
 */
 // ==/WindhawkModReadme==
 

--- a/mods/shrink-address-bar-height.wh.cpp
+++ b/mods/shrink-address-bar-height.wh.cpp
@@ -1,0 +1,38 @@
+// ==WindhawkMod==
+// @id              shrink-address-bar-height
+// @name            Shrink Address Bar Height
+// @description     Shrinks the address bar height in file explorer
+// @version         1.0.0
+// @author          ItsProfessional
+// @github          https://github.com/ItsProfessional
+// @include         *
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Shrink Address Bar Height
+This mod shrinks the address bar height in file explorer.
+
+The code is based on the implementation in [ExplorerPatcher](https://github.com/valinet/ExplorerPatcher).
+
+![Screenshot](https://raw.githubusercontent.com/ItsProfessional/Screenshots/main/Windhawk/win7-command-bar.png)
+*/
+// ==/WindhawkModReadme==
+
+int (*ExplorerFrame_GetSystemMetricsForDpiOrig)(int nIndex, UINT dpi);
+int ExplorerFrame_GetSystemMetricsForDpiHook(int nIndex, UINT dpi)
+{
+    if (nIndex == SM_CYFIXEDFRAME) return 0;
+    
+    return ExplorerFrame_GetSystemMetricsForDpiOrig(nIndex, dpi);
+}
+
+
+BOOL Wh_ModInit() {
+    HMODULE hUser32 = GetModuleHandle(L"user32.dll");
+
+    void* origFunc = (void*)GetProcAddress(hUser32, "GetSystemMetricsForDpi");
+    Wh_SetFunctionHook(origFunc, (void*)ExplorerFrame_GetSystemMetricsForDpiHook, (void**)&ExplorerFrame_GetSystemMetricsForDpiOrig);
+
+    return TRUE;
+}


### PR DESCRIPTION
This mod shrinks the address bar height in file explorer.
Note: It hooks into every process, because if I only hook explorer.exe, it won't work on save/open dialogs.