### PR TITLE
Taskbar Labels for Windows 11 v1.1

### DIFF
--- a/mods/taskbar-labels.wh.cpp
+++ b/mods/taskbar-labels.wh.cpp
@@ -2,14 +2,14 @@
 // @id              taskbar-labels
 // @name            Taskbar Labels for Windows 11
 // @description     Show text labels for running programs on the taskbar (Windows 11 only)
-// @version         1.0.3
+// @version         1.1
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
 // @homepage        https://m417z.com/
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -lruntimeobject
+// @compilerOptions -loleaut32 -lole32 -lruntimeobject
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -31,10 +31,10 @@ After:
 
 ![After screenshot](https://i.imgur.com/qpc4iFh.png)
 
-## Known limitations
+Additional customization is available in the settings. For example, you can
+choose one of the following running indicator styles:
 
-* When there are too many items, the rightmost items become unreachable.
-* Switching between virtual desktops might result in missing labels.
+![Running indicator styles](https://i.imgur.com/HpytGBO.png)
 */
 // ==/WindhawkModReadme==
 
@@ -42,1021 +42,375 @@ After:
 /*
 - taskbarItemWidth: 160
   $name: Taskbar item width
+- runningIndicatorStyle: centerFixed
+  $name: Running indicator style
+  $options:
+  - centerFixed: Centered, fixed size
+  - centerDynamic: Centered, dynamic size
+  - left: On the left (below the icon)
+  - fullWidth: Full width
+- fontSize: 12
+  $name: Font size
+- leftAndRightPaddingSize: 10
+  $name: Left and right padding size
+- spaceBetweenIconAndLabel: 8
+  $name: Space between icon and label
+- labelForSingleItem: "%name%"
+  $name: Label for a single item
   $description: >-
-    The width of taskbar items for which text labels are added
+    The following variables can be used: %name%, %amount%
+- labelForMultipleItems: "[%amount%] %name%"
+  $name: Label for multiple items
 */
 // ==/WindhawkModSettings==
 
+#undef GetCurrentTime
+
 #include <initguid.h>  // must come before knownfolders.h
 
-#include <hstring.h>
 #include <inspectable.h>
 #include <knownfolders.h>
-#include <roapi.h>
 #include <shlobj.h>
-#include <winstring.h>
-#include <wrl/client.h>
-#include <wrl/wrappers/corewrappers.h>
 
-#include <memory>
-#include <regex>
-#include <type_traits>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Markup.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+using namespace winrt::Windows::UI::Xaml;
 
 // #define EXTRA_DBG_LOG
 
+enum class RunningIndicatorStyle {
+    centerFixed,
+    centerDynamic,
+    left,
+    fullWidth,
+};
+
 struct {
     int taskbarItemWidth;
+    RunningIndicatorStyle runningIndicatorStyle;
+    int fontSize;
+    int leftAndRightPaddingSize;
+    int spaceBetweenIconAndLabel;
+    PCWSTR labelForSingleItem;
+    PCWSTR labelForMultipleItems;
 } g_settings;
 
 bool g_applyingSettings = false;
 bool g_unloading = false;
 
+double g_initialTaskbarItemWidth;
+
+UINT_PTR g_invalidateTaskListButtonTimer;
+std::unordered_set<FrameworkElement> g_taskListButtonsWithLabelMissing;
+
 #ifndef SPI_SETLOGICALDPIOVERRIDE
 #define SPI_SETLOGICALDPIOVERRIDE 0x009F
 #endif
 
-////////////////////////////////////////////////////////////////////////////////
-
-using Microsoft::WRL::ComPtr;
-using Microsoft::WRL::Wrappers::HStringReference;
-
-using HString = std::unique_ptr<std::remove_pointer_t<HSTRING>,
-                                decltype(&WindowsDeleteString)>;
-
-interface IVector : public IInspectable {
-    // read methods
-    virtual HRESULT STDMETHODCALLTYPE GetAt(_In_opt_ unsigned index,
-                                            _Out_ void** item) = 0;
-    virtual /* propget */ HRESULT STDMETHODCALLTYPE
-    get_Size(_Out_ unsigned* size) = 0;
-    virtual HRESULT STDMETHODCALLTYPE
-    GetView(_Outptr_result_maybenull_ void* view) = 0;
-    virtual HRESULT STDMETHODCALLTYPE IndexOf(_In_opt_ void* value,
-                                              _Out_ unsigned* index,
-                                              _Out_ boolean* found) = 0;
-
-    // write methods
-    virtual HRESULT STDMETHODCALLTYPE SetAt(_In_ unsigned index,
-                                            _In_opt_ void* item) = 0;
-    virtual HRESULT STDMETHODCALLTYPE InsertAt(_In_ unsigned index,
-                                               _In_opt_ void* item) = 0;
-    virtual HRESULT STDMETHODCALLTYPE RemoveAt(_In_ unsigned index) = 0;
-    virtual HRESULT STDMETHODCALLTYPE Append(_In_opt_ void* item) = 0;
-    virtual HRESULT STDMETHODCALLTYPE RemoveAtEnd() = 0;
-    virtual HRESULT STDMETHODCALLTYPE Clear() = 0;
-
-    // bulk transfer methods
-    virtual HRESULT STDMETHODCALLTYPE
-    GetMany(_In_ unsigned startIndex,
-            _In_ unsigned capacity,
-            _Out_writes_to_(capacity, *actual) void** value,
-            _Out_ unsigned* actual) = 0;
-    virtual HRESULT STDMETHODCALLTYPE
-    ReplaceAll(_In_ unsigned count, _In_reads_(count) void** value) = 0;
-};
-
-// Some of the definitions below are based on the source code of Explorer
-// Patcher. Reference:
-// https://github.com/valinet/ExplorerPatcher/blob/db576425272023b1ead811e7627823cb8b5517f2/ExplorerPatcher/lvt.h
-
-typedef struct _Windows_UI_Xaml_Thickness {
-    double Left;
-    double Top;
-    double Right;
-    double Bottom;
-} Windows_UI_Xaml_Thickness;
-
-typedef enum _Windows_UI_Xaml_Visibility {
-    Windows_UI_Xaml_Visibility_Visible = 0,
-    Windows_UI_Xaml_Visibility_Collapsed = 1
-} Windows_UI_Xaml_Visibility;
-
-typedef enum _Windows_UI_Xaml_HorizontalAlignment {
-    Windows_UI_Xaml_HorizontalAlignment_Left = 0,
-    Windows_UI_Xaml_HorizontalAlignment_Center = 1,
-    Windows_UI_Xaml_HorizontalAlignment_Right = 2,
-    Windows_UI_Xaml_HorizontalAlignment_Stretch = 3
-} Windows_UI_Xaml_HorizontalAlignment;
-
-#pragma region "Windows.UI.Xaml.IDependencyObject"
-
-DEFINE_GUID(IID_Windows_UI_Xaml_IDependencyObject,
-            0x5c526665,
-            0xf60e,
-            0x4912,
-            0xaf,
-            0x59,
-            0x5f,
-            0xe0,
-            0x68,
-            0x0f,
-            0x08,
-            0x9d);
-
-interface Windows_UI_Xaml_IDependencyObject : public IInspectable {
-    virtual HRESULT STDMETHODCALLTYPE GetValue(
-        /* [in] */ __RPC__in IInspectable* dp,
-        /* [out] */ __RPC__out IInspectable** result) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE SetValue(
-        /* [in] */ __RPC__in IInspectable* dp,
-        /* [in] */ __RPC__in IInspectable* value) = 0;
-};
-
-#pragma endregion
-
-#pragma region "Windows.UI.Xaml.Markup.IXamlReaderStatics"
-
-DEFINE_GUID(IID_Windows_UI_Xaml_Markup_IXamlReaderStatics,
-            0x9891c6bd,
-            0x534f,
-            0x4955,
-            0xb8,
-            0x5a,
-            0x8a,
-            0x8d,
-            0xc0,
-            0xdc,
-            0xa6,
-            0x02);
-
-interface Windows_UI_Xaml_Markup_IXamlReaderStatics : public IInspectable {
-    virtual HRESULT STDMETHODCALLTYPE Load(
-        /* [in] */ __RPC__in HSTRING xaml,
-        /* [out][retval] */ __RPC__deref_out_opt IInspectable**
-            returnValue) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE LoadWithInitialTemplateValidation(
-        /* [in] */ __RPC__in HSTRING xaml,
-        /* [out][retval] */ __RPC__deref_out_opt IInspectable**
-            returnValue) = 0;
-};
-
-#pragma endregion
-
-#pragma region "Windows.UI.Xaml.IVisualTreeHelperStatics"
-
-DEFINE_GUID(IID_Windows_UI_Xaml_IVisualTreeHelperStatics,
-            0xe75758c4,
-            0xd25d,
-            0x4b1d,
-            0x97,
-            0x1f,
-            0x59,
-            0x6f,
-            0x17,
-            0xf1,
-            0x2b,
-            0xaa);
-
-interface Windows_UI_Xaml_IVisualTreeHelperStatics : public IInspectable {
-    virtual HRESULT STDMETHODCALLTYPE FindElementsInHostCoordinatesPoint() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE FindElementsInHostCoordinatesRect() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE
-    FindAllElementsInHostCoordinatesPoint() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE
-    FindAllElementsInHostCoordinatesRect() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE GetChild(
-        /* [in] */ __RPC__in Windows_UI_Xaml_IDependencyObject* reference,
-        /* [in] */ __RPC__in INT32 childIndex,
-        /* [out] */ __RPC__out Windows_UI_Xaml_IDependencyObject** result) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE GetChildrenCount(
-        /* [in] */ __RPC__in Windows_UI_Xaml_IDependencyObject* reference,
-        /* [out] */ __RPC__out INT32* result) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE GetParent(
-        /* [in] */ __RPC__in Windows_UI_Xaml_IDependencyObject* reference,
-        /* [out] */ __RPC__out Windows_UI_Xaml_IDependencyObject** result) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE DisconnectChildrenRecursive() = 0;
-};
-
-#pragma endregion
-
-#pragma region "Windows.UI.Xaml.IFrameworkElement"
-
-DEFINE_GUID(IID_Windows_UI_Xaml_IFrameworkElement,
-            0xa391d09b,
-            0x4a99,
-            0x4b7c,
-            0x9d,
-            0x8d,
-            0x6f,
-            0xa5,
-            0xd0,
-            0x1f,
-            0x6f,
-            0xbf);
-
-interface Windows_UI_Xaml_IFrameworkElement : public IInspectable {
-    virtual HRESULT STDMETHODCALLTYPE get_Triggers() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Resources() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_Resources() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Tag() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_Tag() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Language() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_Language() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_ActualWidth(
-        /* [out] */ __RPC__out DOUBLE* value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_ActualHeight(
-        /* [out] */ __RPC__out DOUBLE* value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Width(
-        /* [out] */ __RPC__out DOUBLE* value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_Width(
-        /* [in] */ __RPC__in DOUBLE value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Height(
-        /* [out] */ __RPC__out DOUBLE* value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_Height(
-        /* [in] */ __RPC__in DOUBLE value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_MinWidth() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_MinWidth() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_MaxWidth() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_MaxWidth() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_MinHeight() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_MinHeight() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_MaxHeight() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_MaxHeight() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_HorizontalAlignment(
-        /* [out] */ __RPC__out int32_t* value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_HorizontalAlignment(
-        /* [in] */ __RPC__in int32_t value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_VerticalAlignment(
-        /* [out] */ __RPC__out int32_t* value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_VerticalAlignment(
-        /* [in] */ __RPC__in int32_t value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Margin(
-        /* [out] */ __RPC__out Windows_UI_Xaml_Thickness* value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_Margin(
-        /* [in] */ __RPC__in Windows_UI_Xaml_Thickness value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Name(
-        /* [out] */ __RPC__deref_out_opt HSTRING* value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_Name() = 0;
-
-    // ...
-};
-
-#pragma endregion
-
-#pragma region "Windows.UI.Xaml.Controls.IPanel"
-
-DEFINE_GUID(IID_Windows_UI_Xaml_Controls_IPanel,
-            0xa50a4bbd,
-            0x8361,
-            0x469c,
-            0x90,
-            0xda,
-            0xe9,
-            0xa4,
-            0x0c,
-            0x74,
-            0x74,
-            0xdf);
-
-interface Windows_UI_Xaml_Controls_IPanel : public IInspectable {
-    virtual HRESULT STDMETHODCALLTYPE get_Children(
-        /* [out] */ __RPC__out IVector** value) = 0;
-
-    // ...
-};
-
-#pragma endregion
-
-#pragma region "Windows.UI.Xaml.Controls.ITextBlock"
-
-DEFINE_GUID(IID_Windows_UI_Xaml_Controls_ITextBlock,
-            0xae2d9271,
-            0x3b4a,
-            0x45fc,
-            0x84,
-            0x68,
-            0xf7,
-            0x94,
-            0x95,
-            0x48,
-            0xf4,
-            0xd5);
-
-interface Windows_UI_Xaml_Controls_ITextBlock : public IInspectable {
-    virtual HRESULT STDMETHODCALLTYPE get_FontSize(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE put_FontSize(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_FontFamily(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE put_FontFamily(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_FontWeight(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE put_FontWeight(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_FontStyle(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE put_FontStyle(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_FontStretch(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE put_FontStretch(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE
-        get_CharacterSpacing(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE
-        put_CharacterSpacing(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_Foreground(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE put_Foreground(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_TextWrapping(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE put_TextWrapping(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_TextTrimming(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE put_TextTrimming(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_TextAlignment(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE put_TextAlignment(/*to-be-filled*/) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Text(
-        /* [out] */ __RPC__deref_out_opt HSTRING* value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_Text(
-        /* [in] */ __RPC__in HSTRING value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Inlines(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_Padding(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE put_Padding(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_LineHeight(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE put_LineHeight(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE
-        get_LineStackingStrategy(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE
-        put_LineStackingStrategy(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE
-        get_IsTextSelectionEnabled(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE
-        put_IsTextSelectionEnabled(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_SelectedText(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_ContentStart(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_ContentEnd(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_SelectionStart(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_SelectionEnd(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_BaselineOffset(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE
-        add_SelectionChanged(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE
-        remove_SelectionChanged(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE
-        add_ContextMenuOpening(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE
-        remove_ContextMenuOpening(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE SelectAll(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE Select(/*to-be-filled*/) = 0;
-    virtual HRESULT STDMETHODCALLTYPE Focus(/*to-be-filled*/) = 0;
-};
-
-#pragma endregion
-
-#pragma region "Windows.UI.Xaml.IUIElement"
-
-DEFINE_GUID(IID_Windows_UI_Xaml_IUIElement,
-            0x676d0be9,
-            0xb65c,
-            0x41c6,
-            0xba,
-            0x40,
-            0x58,
-            0xcf,
-            0x87,
-            0xf2,
-            0x01,
-            0xc1);
-
-interface Windows_UI_Xaml_IUIElement : public IInspectable {
-    virtual HRESULT STDMETHODCALLTYPE get_DesiredSize() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_AllowDrop() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_AllowDrop() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Opacity() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_Opacity() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Clip() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_Clip() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_RenderTransform() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_RenderTransform() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Projection() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_Projection() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_RenderTransformOrigin() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_RenderTransformOrigin() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_IsHitTestVisible() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_IsHitTestVisible() = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE get_Visibility(
-        /* [out] */ __RPC__out Windows_UI_Xaml_Visibility* value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE put_Visibility(
-        /* [in] */ __RPC__in Windows_UI_Xaml_Visibility value) = 0;
-
-    virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_RenderSize(
-        /* [out][retval] */ __RPC__out /*ABI::Windows::Foundation::Size*/ void*
-            value) = 0;
-
-    virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_UseLayoutRounding(
-        /* [out][retval] */ __RPC__out boolean* value) = 0;
-
-    virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_UseLayoutRounding(
-        /* [in] */ boolean value) = 0;
-
-    virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_Transitions(
-        /* [out][retval] */
-        __RPC__deref_out_opt /*__FIVector_1_Windows__CUI__CXaml__CMedia__CAnimation__CTransition*/
-        void** value) = 0;
-
-    virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_Transitions(
-        /* [in] */
-        __RPC__in_opt /*__FIVector_1_Windows__CUI__CXaml__CMedia__CAnimation__CTransition*/
-        void* value) = 0;
-
-    virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_CacheMode(
-        /* [out][retval] */
-        __RPC__deref_out_opt /*ABI::Windows::UI::Xaml::Media::ICacheMode*/
-        void** value) = 0;
-
-    virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_CacheMode(
-        /* [in] */ __RPC__in_opt /*ABI::Windows::UI::Xaml::Media::ICacheMode*/
-        void* value) = 0;
-
-    virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_IsTapEnabled(
-        /* [out][retval] */ __RPC__out boolean* value) = 0;
-
-    virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_IsTapEnabled(
-        /* [in] */ boolean value) = 0;
-
-    virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_IsDoubleTapEnabled(
-        /* [out][retval] */ __RPC__out boolean* value) = 0;
-
-    virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_IsDoubleTapEnabled(
-        /* [in] */ boolean value) = 0;
-
-    virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_IsRightTapEnabled(
-        /* [out][retval] */ __RPC__out boolean* value) = 0;
-
-    virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_IsRightTapEnabled(
-        /* [in] */ boolean value) = 0;
-
-    virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_IsHoldingEnabled(
-        /* [out][retval] */ __RPC__out boolean* value) = 0;
-
-    virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_IsHoldingEnabled(
-        /* [in] */ boolean value) = 0;
-
-    virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_ManipulationMode(
-        /* [out][retval] */
-        __RPC__out /*ABI::Windows::UI::Xaml::Input::ManipulationModes*/ void*
-            value) = 0;
-
-    virtual /* [propput] */ HRESULT STDMETHODCALLTYPE put_ManipulationMode(
-        /* [in] */ /*ABI::Windows::UI::Xaml::Input::ManipulationModes*/ int
-            value) = 0;
-
-    virtual /* [propget] */ HRESULT STDMETHODCALLTYPE get_PointerCaptures(
-        /* [out][retval] */
-        __RPC__deref_out_opt /*__FIVectorView_1_Windows__CUI__CXaml__CInput__CPointer*/
-        void** value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_KeyUp(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IKeyEventHandler*/ void*
-            value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_KeyUp(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_KeyDown(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IKeyEventHandler*/ void*
-            value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_KeyDown(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_GotFocus(
-        /* [in] */ __RPC__in_opt /*ABI::Windows::UI::Xaml::IRoutedEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_GotFocus(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_LostFocus(
-        /* [in] */ __RPC__in_opt /*ABI::Windows::UI::Xaml::IRoutedEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_LostFocus(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_DragEnter(
-        /* [in] */ __RPC__in_opt /*ABI::Windows::UI::Xaml::IDragEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_DragEnter(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_DragLeave(
-        /* [in] */ __RPC__in_opt /*ABI::Windows::UI::Xaml::IDragEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_DragLeave(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_DragOver(
-        /* [in] */ __RPC__in_opt /*ABI::Windows::UI::Xaml::IDragEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_DragOver(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_Drop(
-        /* [in] */ __RPC__in_opt /*ABI::Windows::UI::Xaml::IDragEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_Drop(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_PointerPressed(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IPointerEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_PointerPressed(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_PointerMoved(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IPointerEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_PointerMoved(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_PointerReleased(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IPointerEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_PointerReleased(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_PointerEntered(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IPointerEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_PointerEntered(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_PointerExited(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IPointerEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_PointerExited(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_PointerCaptureLost(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IPointerEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_PointerCaptureLost(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_PointerCanceled(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IPointerEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_PointerCanceled(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_PointerWheelChanged(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IPointerEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_PointerWheelChanged(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_Tapped(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::ITappedEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_Tapped(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_DoubleTapped(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IDoubleTappedEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_DoubleTapped(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_Holding(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IHoldingEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_Holding(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_RightTapped(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IRightTappedEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_RightTapped(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_ManipulationStarting(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IManipulationStartingEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_ManipulationStarting(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_ManipulationInertiaStarting(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IManipulationInertiaStartingEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_ManipulationInertiaStarting(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_ManipulationStarted(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IManipulationStartedEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_ManipulationStarted(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_ManipulationDelta(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IManipulationDeltaEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_ManipulationDelta(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE add_ManipulationCompleted(
-        /* [in] */
-        __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IManipulationCompletedEventHandler*/
-        void* value,
-        /* [out][retval] */ __RPC__out /*EventRegistrationToken*/ int64_t*
-            token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE remove_ManipulationCompleted(
-        /* [in] */ /*EventRegistrationToken*/ int64_t token) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE Measure(
-        /* [in] */ /*ABI::Windows::Foundation::Size*/ int availableSize) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE Arrange(
-        /* [in] */ /*ABI::Windows::Foundation::Rect*/ void* finalRect) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE CapturePointer(
-        /* [in] */ __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IPointer*/
-        void* value,
-        /* [out][retval] */ __RPC__out boolean* returnValue) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE ReleasePointerCapture(
-        /* [in] */ __RPC__in_opt /*ABI::Windows::UI::Xaml::Input::IPointer*/
-        void* value) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE ReleasePointerCaptures(void) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE AddHandler(
-        /* [in] */ __RPC__in_opt /*ABI::Windows::UI::Xaml::IRoutedEvent*/ void*
-            routedEvent,
-        /* [in] */ __RPC__in_opt IInspectable* handler,
-        /* [in] */ boolean handledEventsToo) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE RemoveHandler(
-        /* [in] */ __RPC__in_opt /*ABI::Windows::UI::Xaml::IRoutedEvent*/ void*
-            routedEvent,
-        /* [in] */ __RPC__in_opt IInspectable* handler) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE TransformToVisual(
-        /* [in] */ __RPC__in_opt /*ABI::Windows::UI::Xaml::IUIElement*/ void*
-            visual,
-        /* [out][retval] */
-        __RPC__deref_out_opt /*ABI::Windows::UI::Xaml::Media::IGeneralTransform*/
-        void** returnValue) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE InvalidateMeasure(void) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE InvalidateArrange(void) = 0;
-
-    virtual HRESULT STDMETHODCALLTYPE UpdateLayout(void) = 0;
-};
-
-#pragma endregion
-
-////////////////////////////////////////////////////////////////////////////////
-
-ComPtr<Windows_UI_Xaml_IUIElement> LoadXamlControl(PCWSTR xaml) {
-    HRESULT hr;
-
-    HStringReference hsMarkupXamlReaderStatics(
-        L"Windows.UI.Xaml.Markup.XamlReader");
-    ComPtr<Windows_UI_Xaml_Markup_IXamlReaderStatics> pMarkupXamlReaderStatics;
-    hr = RoGetActivationFactory(hsMarkupXamlReaderStatics.Get(),
-                                IID_Windows_UI_Xaml_Markup_IXamlReaderStatics,
-                                (void**)&pMarkupXamlReaderStatics);
-    if (SUCCEEDED(hr)) {
-        HStringReference xamlRef(xaml);
-        ComPtr<IInspectable> pResult;
-        hr = pMarkupXamlReaderStatics->Load(xamlRef.Get(), &pResult);
-        if (SUCCEEDED(hr)) {
-            ComPtr<Windows_UI_Xaml_IUIElement> pUIElement;
-            hr = pResult->QueryInterface(IID_Windows_UI_Xaml_IUIElement,
-                                         (void**)&pUIElement);
-            if (SUCCEEDED(hr)) {
-                return pUIElement;
-            }
+FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name) {
+    int childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
+
+    for (int i = 0; i < childrenCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i)
+                         .try_as<FrameworkElement>();
+        if (!child) {
+            Wh_Log(L"Failed to get child %d of %d", i + 1, childrenCount);
+            continue;
+        }
+
+        if (child.Name() == name) {
+            return child;
         }
     }
 
     return nullptr;
 }
 
-// Based on code from Explorer Patcher.
-ComPtr<Windows_UI_Xaml_IDependencyObject> FindChildByClassName(
-    Windows_UI_Xaml_IDependencyObject* pRootDependencyObject,
-    Windows_UI_Xaml_IVisualTreeHelperStatics* pVisualTreeHelperStatics,
-    LPCWSTR pwszRefName,
-    INT* prevIndex) {
-    // WCHAR wszDebug[MAX_PATH];
-    HRESULT hr = S_OK;
-    INT32 Count = -1;
-    hr = pVisualTreeHelperStatics->GetChildrenCount(pRootDependencyObject,
-                                                    &Count);
-    if (SUCCEEDED(hr)) {
-        for (INT32 Index = (prevIndex ? *prevIndex : 0); Index < Count;
-             ++Index) {
-            ComPtr<Windows_UI_Xaml_IDependencyObject> pChild;
-            hr = pVisualTreeHelperStatics->GetChild(pRootDependencyObject,
-                                                    Index, &pChild);
-            if (SUCCEEDED(hr)) {
-                HString hsChild(nullptr, &WindowsDeleteString);
-                {
-                    HSTRING hs = nullptr;
-                    hr = pChild->GetRuntimeClassName(&hs);
-                    if (SUCCEEDED(hr))
-                        hsChild.reset(hs);
-                }
+FrameworkElement FindChildByClassName(FrameworkElement element,
+                                      PCWSTR className) {
+    int childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
 
-                if (hsChild) {
-                    PCWSTR pwszName =
-                        WindowsGetStringRawBuffer(hsChild.get(), 0);
-                    // swprintf_s(wszDebug, MAX_PATH, L"Name: %s\n", pwszName);
-                    // OutputDebugStringW(wszDebug);
-                    if (!_wcsicmp(pwszName, pwszRefName)) {
-                        if (prevIndex)
-                            *prevIndex = Index + 1;
-                        return pChild;
-                    }
-                }
-            }
+    for (int i = 0; i < childrenCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i)
+                         .try_as<FrameworkElement>();
+        if (!child) {
+            Wh_Log(L"Failed to get child %d of %d", i + 1, childrenCount);
+            continue;
         }
-    }
 
-    if (prevIndex)
-        *prevIndex = Count;
-    return nullptr;
-}
-
-// Based on code from Explorer Patcher.
-ComPtr<Windows_UI_Xaml_IDependencyObject> FindChildByName(
-    Windows_UI_Xaml_IDependencyObject* pRootDependencyObject,
-    Windows_UI_Xaml_IVisualTreeHelperStatics* pVisualTreeHelperStatics,
-    LPCWSTR pwszRefName) {
-    // WCHAR wszDebug[MAX_PATH];
-    HRESULT hr = S_OK;
-    INT32 Count = -1;
-    hr = pVisualTreeHelperStatics->GetChildrenCount(pRootDependencyObject,
-                                                    &Count);
-    if (SUCCEEDED(hr)) {
-        for (INT32 Index = 0; Index < Count; ++Index) {
-            ComPtr<Windows_UI_Xaml_IDependencyObject> pChild;
-            hr = pVisualTreeHelperStatics->GetChild(pRootDependencyObject,
-                                                    Index, &pChild);
-            if (SUCCEEDED(hr)) {
-                ComPtr<Windows_UI_Xaml_IFrameworkElement> pFrameworkElement;
-                hr = pChild->QueryInterface(
-                    IID_Windows_UI_Xaml_IFrameworkElement,
-                    (void**)&pFrameworkElement);
-                if (SUCCEEDED(hr)) {
-                    HString hsChild(nullptr, &WindowsDeleteString);
-                    {
-                        HSTRING hs = nullptr;
-                        hr = pFrameworkElement->get_Name(&hs);
-                        if (SUCCEEDED(hr))
-                            hsChild.reset(hs);
-                    }
-
-                    if (hsChild) {
-                        PCWSTR pwszName =
-                            WindowsGetStringRawBuffer(hsChild.get(), 0);
-                        // swprintf_s(wszDebug, MAX_PATH, L"Name: %s\n",
-                        // pwszName); OutputDebugStringW(wszDebug);
-                        if (!_wcsicmp(pwszName, pwszRefName)) {
-                            return pChild;
-                        }
-                    }
-                }
-            }
+        if (winrt::get_class_name(child) == className) {
+            return child;
         }
     }
 
     return nullptr;
 }
 
-#if defined(EXTRA_DBG_LOG)
+HWND GetTaskbarWnd() {
+    static HWND hTaskbarWnd;
 
-void LogElement(Windows_UI_Xaml_IDependencyObject* pChild, int depth) {
-    HRESULT hr;
+    if (!hTaskbarWnd) {
+        HWND hWnd = FindWindow(L"Shell_TrayWnd", nullptr);
 
-    {
-        HString hsChild(nullptr, &WindowsDeleteString);
-        {
-            HSTRING hs = nullptr;
-            hr = pChild->GetRuntimeClassName(&hs);
-            if (SUCCEEDED(hr))
-                hsChild.reset(hs);
+        DWORD processId = 0;
+        if (hWnd && GetWindowThreadProcessId(hWnd, &processId) &&
+            processId == GetCurrentProcessId()) {
+            hTaskbarWnd = hWnd;
         }
-
-        PCWSTR pwszName =
-            hsChild ? WindowsGetStringRawBuffer(hsChild.get(), 0) : L"-";
-
-        WCHAR padding[MAX_PATH]{};
-        for (int i = 0; i < depth * 4; i++) {
-            padding[i] = L' ';
-        }
-        Wh_Log(L"%sClass: %s", padding, pwszName);
     }
 
-    ComPtr<Windows_UI_Xaml_IFrameworkElement> pFrameworkElement;
-    hr = pChild->QueryInterface(IID_Windows_UI_Xaml_IFrameworkElement,
-                                (void**)&pFrameworkElement);
-    if (SUCCEEDED(hr)) {
-        HString hsChild(nullptr, &WindowsDeleteString);
-        {
-            HSTRING hs = nullptr;
-            hr = pFrameworkElement->get_Name(&hs);
-            if (SUCCEEDED(hr))
-                hsChild.reset(hs);
-        }
-
-        PCWSTR pwszName =
-            hsChild ? WindowsGetStringRawBuffer(hsChild.get(), 0) : L"-";
-
-        WCHAR padding[MAX_PATH]{};
-        for (int i = 0; i < depth * 4; i++) {
-            padding[i] = L' ';
-        }
-        Wh_Log(L"%sName: %s", padding, pwszName);
-    }
+    return hTaskbarWnd;
 }
 
-void LogElementTreeAux(
-    Windows_UI_Xaml_IDependencyObject* pRootDependencyObject,
-    Windows_UI_Xaml_IVisualTreeHelperStatics* pVisualTreeHelperStatics,
-    int depth) {
-    if (!pRootDependencyObject) {
+void RecalculateLabels() {
+    HWND hTaskbarWnd = GetTaskbarWnd();
+    if (!hTaskbarWnd) {
         return;
     }
 
-    LogElement(pRootDependencyObject, depth);
+    HWND hReBarWindow32 =
+        FindWindowEx(hTaskbarWnd, nullptr, L"ReBarWindow32", nullptr);
+    if (!hReBarWindow32) {
+        return;
+    }
 
-    HRESULT hr = S_OK;
-    INT32 Count = -1;
-    hr = pVisualTreeHelperStatics->GetChildrenCount(pRootDependencyObject,
-                                                    &Count);
-    if (SUCCEEDED(hr)) {
-        for (INT32 Index = 0; Index < Count; ++Index) {
-            ComPtr<Windows_UI_Xaml_IDependencyObject> pChild;
-            hr = pVisualTreeHelperStatics->GetChild(pRootDependencyObject,
-                                                    Index, &pChild);
-            if (SUCCEEDED(hr)) {
-                LogElementTreeAux(pChild.Get(), pVisualTreeHelperStatics,
-                                  depth + 1);
+    HWND hMSTaskSwWClass =
+        FindWindowEx(hReBarWindow32, nullptr, L"MSTaskSwWClass", nullptr);
+    if (!hMSTaskSwWClass) {
+        return;
+    }
+
+    g_applyingSettings = true;
+
+    // Trigger TrayUI::_HandleSettingChange.
+    // SendMessage(hTaskbarWnd, WM_SETTINGCHANGE, SPI_SETLOGICALDPIOVERRIDE, 0);
+
+    // Trigger CTaskBand::_HandleSyncDisplayChange.
+    SendMessage(hMSTaskSwWClass, 0x452, 3, 0);
+
+    g_applyingSettings = false;
+}
+
+#if defined(EXTRA_DBG_LOG)
+void LogAllElementsAux(FrameworkElement element, int nesting = 0) {
+    std::string padding(nesting * 2, ' ');
+
+    int childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
+
+    for (int i = 0; i < childrenCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i)
+                         .try_as<FrameworkElement>();
+        if (!child) {
+            Wh_Log(L"%SFailed to get child %d of %d", padding.c_str(), i + 1,
+                   childrenCount);
+            continue;
+        }
+
+        auto className = winrt::get_class_name(child);
+        Wh_Log(L"%SClass: %s", padding.c_str(), className.c_str());
+        Wh_Log(L"%SName: %s", padding.c_str(), child.Name().c_str());
+
+        auto offset = child.ActualOffset();
+        Wh_Log(L"%SPosition: %f, %f", padding.c_str(), offset.x, offset.y);
+        Wh_Log(L"%SSize: %f x %f", padding.c_str(), child.ActualWidth(),
+               child.ActualHeight());
+
+        if (child.Name() == L"WindhawkText") {
+            auto windhawkTextControl = child.as<Controls::TextBlock>();
+            Wh_Log(L"%SText: %s", padding.c_str(),
+                   windhawkTextControl.Text().c_str());
+        }
+
+        LogAllElementsAux(child, nesting + 1);
+    }
+}
+
+void LogAllElements(FrameworkElement element) {
+    try {
+        auto rootElement = element;
+        while (true) {
+            auto parent = Media::VisualTreeHelper::GetParent(rootElement)
+                              .as<FrameworkElement>();
+            if (!parent) {
+                break;
+            }
+            rootElement = parent;
+        }
+
+        Wh_Log(L">>> LogAllElements");
+        LogAllElementsAux(rootElement);
+        Wh_Log(L"<<< LogAllElements");
+    } catch (winrt::hresult_error const& ex) {
+        Wh_Log(L"LogAllElements failed: %08X", ex.code());
+    }
+}
+#endif  // defined(EXTRA_DBG_LOG)
+
+using TaskListButton_get_IsRunning_t = HRESULT(WINAPI*)(void* pThis,
+                                                        bool* running);
+TaskListButton_get_IsRunning_t TaskListButton_get_IsRunning_Original;
+
+bool TaskListButton_IsRunning(FrameworkElement taskListButtonElement) {
+    bool isRunning = false;
+    TaskListButton_get_IsRunning_Original(
+        winrt::get_abi(
+            taskListButtonElement.as<winrt::Windows::Foundation::IUnknown>()),
+        &isRunning);
+    return isRunning;
+}
+
+// {0BD894F2-EDFC-5DDF-A166-2DB14BBFDF35}
+constexpr winrt::guid IItemsRepeater{
+    0x0BD894F2,
+    0xEDFC,
+    0x5DDF,
+    {0xA1, 0x66, 0x2D, 0xB1, 0x4B, 0xBF, 0xDF, 0x35}};
+
+FrameworkElement ItemsRepeater_TryGetElement(
+    FrameworkElement taskbarFrameRepeaterElement,
+    int index) {
+    winrt::Windows::Foundation::IUnknown pThis = nullptr;
+    taskbarFrameRepeaterElement.as(IItemsRepeater, winrt::put_abi(pThis));
+
+    using TryGetElement_t =
+        void*(WINAPI*)(void* pThis, int index, void** uiElement);
+
+    void** vtable = *(void***)winrt::get_abi(pThis);
+    auto TryGetElement = (TryGetElement_t)vtable[20];
+
+    void* uiElement = nullptr;
+    TryGetElement(winrt::get_abi(pThis), index, &uiElement);
+
+    return UIElement{uiElement, winrt::take_ownership_from_abi}
+        .try_as<FrameworkElement>();
+}
+
+double CalculateTaskbarItemWidth(FrameworkElement taskbarFrameRepeaterElement,
+                                 double minWidth,
+                                 double maxWidth) {
+#if defined(EXTRA_DBG_LOG)
+    LogAllElements(taskbarFrameRepeaterElement);
+#endif  // defined(EXTRA_DBG_LOG)
+
+    double taskbarFrameRepeaterEndOffset = 0;
+
+    auto rootGridElement =
+        Media::VisualTreeHelper::GetParent(taskbarFrameRepeaterElement)
+            .as<FrameworkElement>();
+    if (rootGridElement && rootGridElement.Name() == L"RootGrid") {
+        auto taskbarFrameElement =
+            Media::VisualTreeHelper::GetParent(rootGridElement)
+                .as<FrameworkElement>();
+        if (taskbarFrameElement &&
+            taskbarFrameElement.Name() == L"TaskbarFrame") {
+            auto containerGridElement =
+                Media::VisualTreeHelper::GetParent(taskbarFrameElement)
+                    .as<FrameworkElement>();
+            if (containerGridElement &&
+                winrt::get_class_name(containerGridElement) ==
+                    L"Windows.UI.Xaml.Controls.Grid") {
+                auto systemTrayFrameElement = FindChildByClassName(
+                    containerGridElement, L"SystemTray.SystemTrayFrame");
+                if (systemTrayFrameElement) {
+                    taskbarFrameRepeaterEndOffset =
+                        systemTrayFrameElement.ActualOffset().x;
+                }
             }
         }
     }
-}
 
-void LogElementTree(IInspectable* pElement) {
-    HRESULT hr;
+    // For older versions (pre-KB5022913). Only works correctly on primary
+    // monitor.
+    if (!taskbarFrameRepeaterEndOffset) {
+        HWND hTaskbarWnd = GetTaskbarWnd();
+        if (!hTaskbarWnd) {
+            return minWidth;
+        }
 
-    HStringReference hsVisualTreeHelperStatics(
-        L"Windows.UI.Xaml.Media.VisualTreeHelper");
-    ComPtr<Windows_UI_Xaml_IVisualTreeHelperStatics> pVisualTreeHelperStatics;
-    hr = RoGetActivationFactory(hsVisualTreeHelperStatics.Get(),
-                                IID_Windows_UI_Xaml_IVisualTreeHelperStatics,
-                                (void**)&pVisualTreeHelperStatics);
-    if (SUCCEEDED(hr)) {
-        ComPtr<Windows_UI_Xaml_IDependencyObject> pRootDependencyObject;
-        hr = pElement->QueryInterface(IID_Windows_UI_Xaml_IDependencyObject,
-                                      (void**)&pRootDependencyObject);
-        if (SUCCEEDED(hr)) {
-            LogElementTreeAux(pRootDependencyObject.Get(),
-                              pVisualTreeHelperStatics.Get(), 0);
+        HWND hTrayNotifyWnd =
+            FindWindowEx(hTaskbarWnd, nullptr, L"TrayNotifyWnd", nullptr);
+        if (!hTrayNotifyWnd) {
+            return minWidth;
+        }
+
+        RECT rcTrayNotify{};
+        if (!GetWindowRect(hTrayNotifyWnd, &rcTrayNotify)) {
+            return minWidth;
+        }
+
+        MapWindowPoints(HWND_DESKTOP, hTaskbarWnd, (LPPOINT)&rcTrayNotify, 2);
+
+        taskbarFrameRepeaterEndOffset = rcTrayNotify.left;
+    }
+
+    bool hasOverflowButton = false;
+    int taskListRunningButtonsCount = 0;
+    double otherElementsWidth = 0;
+
+    for (int i = 0;; i++) {
+        auto child =
+            ItemsRepeater_TryGetElement(taskbarFrameRepeaterElement, i);
+        if (!child) {
+            break;
+        }
+
+        auto childOffset = child.ActualOffset();
+        auto childWidth = child.ActualWidth();
+
+        if (childOffset.x + childWidth < 0) {
+            continue;
+        }
+
+        bool isRunningTaskListButton = false;
+        if (child.Name() == L"TaskListButton") {
+            if (TaskListButton_IsRunning(child)) {
+                isRunningTaskListButton = true;
+            }
+        } else if (child.Name() == L"OverflowButton") {
+            hasOverflowButton = true;
+        }
+
+        if (isRunningTaskListButton) {
+            taskListRunningButtonsCount++;
+        } else {
+            otherElementsWidth += childWidth;
         }
     }
+
+    if (hasOverflowButton) {
+        return minWidth;
+    }
+
+    if (taskListRunningButtonsCount == 0) {
+        return minWidth;
+    }
+
+    double width = (taskbarFrameRepeaterEndOffset - otherElementsWidth) /
+                   taskListRunningButtonsCount;
+
+    // Wh_Log(L"(%f-%f) / %d = %f", taskbarFrameRepeaterEndOffset,
+    //        otherElementsWidth, taskListRunningButtonsCount, width);
+
+    if (width < minWidth) {
+        return minWidth;
+    }
+
+    if (width > maxWidth) {
+        return maxWidth;
+    }
+
+    return width;
 }
-
-#endif  // defined(EXTRA_DBG_LOG)
-
-////////////////////////////////////////////////////////////////////////////////
 
 using CTaskListWnd__GetTBGroupFromGroup_t = void*(WINAPI*)(void* pThis,
                                                            void* taskGroup,
@@ -1091,6 +445,80 @@ bool WINAPI IconContainer_IsStorageRecreationRequired_Hook(void* pThis,
                                                               flags);
 }
 
+int StringCopyTruncated(PWSTR dest,
+                        size_t destSize,
+                        PCWSTR src,
+                        bool* truncated) {
+    if (destSize == 0) {
+        *truncated = *src;
+        return 0;
+    }
+
+    size_t i;
+    for (i = 0; i < destSize - 1 && *src; i++) {
+        *dest++ = *src++;
+    }
+
+    *dest = L'\0';
+    *truncated = *src;
+    return i;
+}
+
+int FormatLabel(PCWSTR name,
+                int numItems,
+                PWSTR buffer,
+                size_t bufferSize,
+                PCWSTR format) {
+    if (bufferSize == 0) {
+        return 0;
+    }
+
+    WCHAR tempNumberBuffer[16];
+
+    PWSTR bufferStart = buffer;
+    PWSTR bufferEnd = bufferStart + bufferSize;
+    while (*format && bufferEnd - buffer > 1) {
+        if (*format == L'%') {
+            PCWSTR srcStr = nullptr;
+            size_t formatTokenLen;
+
+            if (wcsncmp(L"%name%", format, sizeof("%name%") - 1) == 0) {
+                srcStr = name;
+                formatTokenLen = sizeof("%name%") - 1;
+            } else if (wcsncmp(L"%amount%", format, sizeof("%amount%") - 1) ==
+                       0) {
+                swprintf_s(tempNumberBuffer, L"%d", numItems);
+                srcStr = tempNumberBuffer;
+                formatTokenLen = sizeof("%amount%") - 1;
+            }
+
+            if (srcStr) {
+                bool truncated;
+                buffer += StringCopyTruncated(buffer, bufferEnd - buffer,
+                                              srcStr, &truncated);
+                if (truncated) {
+                    break;
+                }
+
+                format += formatTokenLen;
+                continue;
+            }
+        }
+
+        *buffer++ = *format++;
+    }
+
+    if (*format && bufferSize >= 4) {
+        buffer[-1] = L'.';
+        buffer[-2] = L'.';
+        buffer[-3] = L'.';
+    }
+
+    *buffer = L'\0';
+
+    return buffer - bufferStart;
+}
+
 bool g_inGroupChanged;
 WCHAR g_taskBtnGroupTitleInGroupChanged[256];
 
@@ -1115,17 +543,14 @@ LONG_PTR WINAPI CTaskListWnd_GroupChanged_Hook(void* pThis,
         }
     }
 
-    WCHAR* textBuffer = g_taskBtnGroupTitleInGroupChanged;
-    int textBufferSize = ARRAYSIZE(g_taskBtnGroupTitleInGroupChanged);
-
-    if (numItems > 1) {
-        int written = wsprintf(textBuffer, L"[%d] ", numItems);
-        textBuffer += written;
-        textBufferSize -= written;
-    }
-
+    WCHAR textBuffer[256] = L"";
     CTaskGroup_GetTitleText_Original(taskGroup, taskItem, textBuffer,
-                                     textBufferSize);
+                                     ARRAYSIZE(textBuffer));
+
+    FormatLabel(textBuffer, numItems, g_taskBtnGroupTitleInGroupChanged,
+                ARRAYSIZE(g_taskBtnGroupTitleInGroupChanged),
+                numItems > 1 ? g_settings.labelForMultipleItems
+                             : g_settings.labelForSingleItem);
 
     g_inGroupChanged = true;
     LONG_PTR ret =
@@ -1158,186 +583,236 @@ LONG_PTR WINAPI CTaskListWnd_TaskDestroyed_Hook(void* pThis,
     return ret;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-
-double* double_48_value_Original;
-
-using ITaskListButton_get_IsRunning_t = HRESULT(WINAPI*)(void* pThis,
-                                                         bool* running);
-ITaskListButton_get_IsRunning_t ITaskListButton_get_IsRunning_Original;
-
-void UpdateTaskListButtonCustomizations(void* pTaskListButtonImpl) {
-    HRESULT hr;
-
-    IInspectable* pTaskListButton = *(IInspectable**)pTaskListButtonImpl;
-
-    ComPtr<Windows_UI_Xaml_IFrameworkElement> pTaskListButtonElement;
-    ComPtr<Windows_UI_Xaml_IFrameworkElement> pIconPanelElement;
-    ComPtr<Windows_UI_Xaml_IFrameworkElement> pIconElement;
-    ComPtr<Windows_UI_Xaml_IFrameworkElement> pWindhawkTextElement;
-
-    hr = pTaskListButton->QueryInterface(IID_Windows_UI_Xaml_IFrameworkElement,
-                                         (void**)&pTaskListButtonElement);
-
-    HStringReference hsVisualTreeHelperStatics(
-        L"Windows.UI.Xaml.Media.VisualTreeHelper");
-    ComPtr<Windows_UI_Xaml_IVisualTreeHelperStatics> pVisualTreeHelperStatics;
-    hr = RoGetActivationFactory(hsVisualTreeHelperStatics.Get(),
-                                IID_Windows_UI_Xaml_IVisualTreeHelperStatics,
-                                (void**)&pVisualTreeHelperStatics);
-    if (SUCCEEDED(hr)) {
-        ComPtr<Windows_UI_Xaml_IDependencyObject> pRootDependencyObject;
-        hr = pTaskListButton->QueryInterface(
-            IID_Windows_UI_Xaml_IDependencyObject,
-            (void**)&pRootDependencyObject);
-        if (SUCCEEDED(hr)) {
-            ComPtr<Windows_UI_Xaml_IDependencyObject> pIconPanel =
-                FindChildByName(pRootDependencyObject.Get(),
-                                pVisualTreeHelperStatics.Get(), L"IconPanel");
-            if (pIconPanel) {
-                hr = pIconPanel->QueryInterface(
-                    IID_Windows_UI_Xaml_IFrameworkElement,
-                    (void**)&pIconPanelElement);
-
-                ComPtr<Windows_UI_Xaml_IDependencyObject> pIcon =
-                    FindChildByName(pIconPanel.Get(),
-                                    pVisualTreeHelperStatics.Get(), L"Icon");
-                if (pIcon) {
-                    hr = pIcon->QueryInterface(
-                        IID_Windows_UI_Xaml_IFrameworkElement,
-                        (void**)&pIconElement);
-                }
-
-                ComPtr<Windows_UI_Xaml_IDependencyObject> pWindhawkText =
-                    FindChildByName(pIconPanel.Get(),
-                                    pVisualTreeHelperStatics.Get(),
-                                    L"WindhawkText");
-                if (pWindhawkText) {
-                    hr = pWindhawkText->QueryInterface(
-                        IID_Windows_UI_Xaml_IFrameworkElement,
-                        (void**)&pWindhawkTextElement);
-                }
-            }
-        }
-    }
-
-    if (!pTaskListButtonElement || !pIconPanelElement || !pIconElement) {
+void UpdateTaskListButtonWidth(FrameworkElement taskListButtonElement,
+                               double widthToSet,
+                               bool showLabels) {
+    auto iconPanelElement =
+        FindChildByName(taskListButtonElement, L"IconPanel");
+    if (!iconPanelElement) {
         return;
     }
 
-    double taskListButtonWidth = 0;
-    pTaskListButtonElement->get_ActualWidth(&taskListButtonWidth);
+    auto iconElement = FindChildByName(iconPanelElement, L"Icon");
+    if (!iconElement) {
+        return;
+    }
 
-    double iconPanelWidth = 0;
-    pIconPanelElement->get_ActualWidth(&iconPanelWidth);
+    // Reset in case an old version of the mod was installed.
+    taskListButtonElement.Width(std::numeric_limits<double>::quiet_NaN());
+
+    iconPanelElement.Width(widthToSet);
+
+    iconElement.HorizontalAlignment(showLabels ? HorizontalAlignment::Left
+                                               : HorizontalAlignment::Stretch);
+
+    iconElement.Margin(Thickness{
+        .Left = showLabels ? g_settings.leftAndRightPaddingSize : 0.0,
+    });
+
+    auto overlayIconElement = FindChildByName(iconPanelElement, L"OverlayIcon");
+    if (overlayIconElement) {
+        overlayIconElement.Margin(Thickness{
+            .Right = showLabels ? (widthToSet - iconElement.ActualWidth() -
+                                   g_settings.leftAndRightPaddingSize - 4)
+                                : 0.0,
+        });
+    }
+
+    PCWSTR indicatorClassNames[] = {
+        L"RunningIndicator",
+        L"ProgressIndicator",
+    };
+    for (auto indicatorClassName : indicatorClassNames) {
+        auto indicatorElement =
+            FindChildByName(iconPanelElement, indicatorClassName);
+        if (!indicatorElement) {
+            continue;
+        }
+
+        double minWidth = 0;
+
+        if (!g_unloading) {
+            if (g_settings.runningIndicatorStyle ==
+                RunningIndicatorStyle::centerDynamic) {
+                minWidth = indicatorElement.Width() * widthToSet /
+                           g_initialTaskbarItemWidth;
+            } else if (g_settings.runningIndicatorStyle ==
+                       RunningIndicatorStyle::fullWidth) {
+                minWidth = widthToSet - 6;
+            }
+        }
+
+        indicatorElement.MinWidth(minWidth);
+
+        if (wcscmp(indicatorClassName, L"ProgressIndicator") == 0) {
+            auto element = indicatorElement;
+            if ((element = FindChildByName(element, L"LayoutRoot")) &&
+                (element = FindChildByName(element, L"ProgressBarRoot")) &&
+                (element = FindChildByClassName(
+                     element, L"Windows.UI.Xaml.Controls.Border")) &&
+                (element = FindChildByClassName(
+                     element, L"Windows.UI.Xaml.Controls.Grid")) &&
+                (element = FindChildByName(element, L"ProgressBarTrack"))) {
+                element.MinWidth(minWidth);
+            }
+        }
+
+        indicatorElement.Margin(Thickness{
+            .Right = g_settings.runningIndicatorStyle ==
+                                 RunningIndicatorStyle::left &&
+                             showLabels
+                         ? (widthToSet - iconElement.ActualWidth() -
+                            g_settings.leftAndRightPaddingSize * 2 - 4)
+                         : 0.0,
+        });
+    }
+
+    // Don't remove, for some reason it causes a bug - the running indicator
+    // ends up being behind the semi-transparent rectangle of the active
+    // button. Hide it instead.
+    auto windhawkTextControl =
+        FindChildByName(iconPanelElement, L"WindhawkText")
+            .as<Controls::TextBlock>();
+    if (windhawkTextControl) {
+        if (!showLabels) {
+            windhawkTextControl.Visibility(Visibility::Collapsed);
+        }
+
+        windhawkTextControl.Margin(Thickness{
+            .Left = g_settings.leftAndRightPaddingSize +
+                    iconElement.ActualWidth() +
+                    g_settings.spaceBetweenIconAndLabel,
+            .Right = static_cast<double>(g_settings.leftAndRightPaddingSize),
+            .Bottom = 2,
+        });
+
+        if (windhawkTextControl.FontSize() != g_settings.fontSize) {
+            windhawkTextControl.FontSize(g_settings.fontSize);
+        }
+
+        if (showLabels) {
+            windhawkTextControl.Visibility(Visibility::Visible);
+        }
+    }
+}
+
+void UpdateTaskListButtonCustomizations(
+    FrameworkElement taskListButtonElement) {
+    auto iconPanelElement =
+        FindChildByName(taskListButtonElement, L"IconPanel");
+    if (!iconPanelElement) {
+        return;
+    }
+
+    auto iconElement = FindChildByName(iconPanelElement, L"Icon");
+    if (!iconElement) {
+        return;
+    }
+
+    auto taskbarFrameRepeaterElement =
+        Media::VisualTreeHelper::GetParent(taskListButtonElement)
+            .as<FrameworkElement>();
+
+    if (!taskbarFrameRepeaterElement ||
+        taskbarFrameRepeaterElement.Name() != L"TaskbarFrameRepeater") {
+        // Can also be "OverflowFlyoutListRepeater".
+        return;
+    }
+
+    double taskListButtonWidth = taskListButtonElement.ActualWidth();
+
+    double iconPanelWidth = iconPanelElement.ActualWidth();
 
     // Check if non-positive or NaN.
     if (!(taskListButtonWidth > 0) || !(iconPanelWidth > 0)) {
         return;
     }
 
-    static double initialWidth = iconPanelWidth;
-
-    void* taskListButtonProducer = (BYTE*)pTaskListButtonImpl + 0x10;
-
-    bool isRunning = false;
-    hr = ITaskListButton_get_IsRunning_Original(taskListButtonProducer,
-                                                &isRunning);
-
-    bool showLabels = isRunning && !g_unloading;
-
-    double widthToSet = showLabels ? g_settings.taskbarItemWidth : initialWidth;
-
-    if (widthToSet != taskListButtonWidth || widthToSet != iconPanelWidth) {
-        pTaskListButtonElement->put_Width(widthToSet);
-        pIconPanelElement->put_Width(widthToSet);
-
-        int32_t horizontalAlignment =
-            (int32_t)(showLabels ? Windows_UI_Xaml_HorizontalAlignment_Left
-                                 : Windows_UI_Xaml_HorizontalAlignment_Center);
-        pIconElement->put_HorizontalAlignment(horizontalAlignment);
-
-        Windows_UI_Xaml_Thickness margin{};
-        if (showLabels) {
-            margin.Left = 10;
-        }
-        pIconElement->put_Margin(margin);
+    if (!g_initialTaskbarItemWidth) {
+        g_initialTaskbarItemWidth = iconPanelWidth;
     }
 
-    if (showLabels && !pWindhawkTextElement) {
-        ComPtr<Windows_UI_Xaml_Controls_IPanel> pIconPanel;
-        hr = pIconPanelElement->QueryInterface(
-            IID_Windows_UI_Xaml_Controls_IPanel, (void**)&pIconPanel);
-        if (SUCCEEDED(hr)) {
-            ComPtr<IVector> children;
-            hr = pIconPanel->get_Children(&children);
-            if (SUCCEEDED(hr)) {
-                PCWSTR xaml =
-                    LR"(
-                        <TextBlock
-                            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                            xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                            mc:Ignorable="d"
-                            Name="WindhawkText"
-                            VerticalAlignment="Center"
-                            FontSize="12"
-                            TextTrimming="CharacterEllipsis"
-                        />
-                    )";
+    bool isRunning = TaskListButton_IsRunning(taskListButtonElement);
+    bool showLabels = isRunning && !g_unloading;
 
-                Microsoft::WRL::ComPtr<Windows_UI_Xaml_IUIElement> pUIElement =
-                    LoadXamlControl(xaml);
-                if (pUIElement) {
-                    children->Append(pUIElement.Get());
+    double widthToSet;
 
-                    ComPtr<Windows_UI_Xaml_IFrameworkElement> pAddedElement;
-                    hr = pUIElement->QueryInterface(
-                        IID_Windows_UI_Xaml_IFrameworkElement,
-                        (void**)&pAddedElement);
-                    if (SUCCEEDED(hr)) {
-                        Windows_UI_Xaml_Thickness margin{};
-                        margin.Left = 10 + 24 + 8;
-                        margin.Right = 10;
-                        margin.Bottom = 2;
-                        pAddedElement->put_Margin(margin);
-                    }
-                }
-            }
-        }
-    } else if (!showLabels && pWindhawkTextElement) {
-        // Don't remove, for some reason it causes a bug - the running indicator
-        // ends up being behind the semi-transparent rectangle of the active
-        // button.
-        /*
-        ComPtr<Windows_UI_Xaml_Controls_IPanel> pIconPanel;
-        hr = pIconPanelElement->QueryInterface(
-            IID_Windows_UI_Xaml_Controls_IPanel, (void**)&pIconPanel);
-        if (SUCCEEDED(hr)) {
-            ComPtr<IVector> children;
-            hr = pIconPanel->get_Children(&children);
-            if (SUCCEEDED(hr)) {
-                unsigned int index = -1;
-                boolean found = false;
-                hr = children->IndexOf(pWindhawkTextElement.Get(), &index,
-                                       &found);
-                if (SUCCEEDED(hr) && found) {
-                    hr = children->RemoveAt(index);
-                }
-            }
-        }
-        */
+    if (showLabels) {
+        widthToSet = CalculateTaskbarItemWidth(taskbarFrameRepeaterElement,
+                                               g_initialTaskbarItemWidth,
+                                               g_settings.taskbarItemWidth);
 
-        // Set empty text instead.
-        ComPtr<Windows_UI_Xaml_Controls_ITextBlock> pWindhawkTextControl;
-        hr = pWindhawkTextElement->QueryInterface(
-            IID_Windows_UI_Xaml_Controls_ITextBlock,
-            (void**)&pWindhawkTextControl);
-        if (pWindhawkTextControl) {
-            HStringReference hsTitle(L"");
-            pWindhawkTextControl->put_Text(hsTitle.Get());
+        if (widthToSet <= g_initialTaskbarItemWidth + 16) {
+            showLabels = false;
         }
+    } else {
+        widthToSet = g_initialTaskbarItemWidth;
+    }
+
+    auto windhawkTextControl =
+        FindChildByName(iconPanelElement, L"WindhawkText")
+            .as<Controls::TextBlock>();
+    if (!windhawkTextControl) {
+        PCWSTR xaml =
+            LR"(
+                <TextBlock
+                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    mc:Ignorable="d"
+                    Name="WindhawkText"
+                    VerticalAlignment="Center"
+                    FontSize="12"
+                    TextTrimming="CharacterEllipsis"
+                />
+            )";
+
+        windhawkTextControl =
+            Markup::XamlReader::Load(xaml).as<Controls::TextBlock>();
+
+        windhawkTextControl.FontSize(g_settings.fontSize);
+
+        iconPanelElement.as<Controls::Panel>().Children().Append(
+            windhawkTextControl);
+    }
+
+    UpdateTaskListButtonWidth(taskListButtonElement, widthToSet, showLabels);
+
+    bool textLabelMissing = false;
+
+    if (!isRunning) {
+        // The check is important. Without it, there's an infinite rerendering
+        // loop.
+        if (windhawkTextControl.Text() != L"") {
+            windhawkTextControl.Text(L"");
+        }
+    } else if (showLabels) {
+        if (windhawkTextControl.Text() == L"") {
+            textLabelMissing = true;
+        }
+    }
+
+    if (textLabelMissing && !g_unloading) {
+        g_taskListButtonsWithLabelMissing.insert(windhawkTextControl);
+
+        g_invalidateTaskListButtonTimer =
+            SetTimer(nullptr, g_invalidateTaskListButtonTimer, 200,
+                     [](HWND hwnd,  // handle of window for timer messages
+                        UINT uMsg,  // WM_TIMER message
+                        UINT_PTR idEvent,  // timer identifier
+                        DWORD dwTime       // current system time
+                        ) WINAPI {
+                         KillTimer(nullptr, g_invalidateTaskListButtonTimer);
+                         g_invalidateTaskListButtonTimer = 0;
+
+                         if (!g_taskListButtonsWithLabelMissing.empty()) {
+                             g_taskListButtonsWithLabelMissing.clear();
+                             RecalculateLabels();
+                         }
+                     });
+    } else if (!textLabelMissing && g_invalidateTaskListButtonTimer) {
+        g_taskListButtonsWithLabelMissing.erase(windhawkTextControl);
     }
 }
 
@@ -1348,16 +823,13 @@ void WINAPI TaskListButton_UpdateVisualStates_Hook(void* pThis) {
 
     TaskListButton_UpdateVisualStates_Original(pThis);
 
-    void* pTaskListButtonImpl = (BYTE*)pThis + 0x08;
+    void* taskListButtonIUnknownPtr = (void**)pThis + 3;
+    winrt::Windows::Foundation::IUnknown taskListButtonIUnknown;
+    winrt::copy_from_abi(taskListButtonIUnknown, taskListButtonIUnknownPtr);
 
-#if defined(EXTRA_DBG_LOG)
-    Wh_Log(L"=====");
-    IInspectable* pTaskListButton = *(IInspectable**)pTaskListButtonImpl;
-    LogElementTree(pTaskListButton);
-    Wh_Log(L"=====");
-#endif  // defined(EXTRA_DBG_LOG)
+    auto taskListButtonElement = taskListButtonIUnknown.as<FrameworkElement>();
 
-    UpdateTaskListButtonCustomizations(pTaskListButtonImpl);
+    UpdateTaskListButtonCustomizations(taskListButtonElement);
 }
 
 using TaskListButton_UpdateButtonPadding_t = void(WINAPI*)(void* pThis);
@@ -1368,9 +840,59 @@ void WINAPI TaskListButton_UpdateButtonPadding_Hook(void* pThis) {
 
     TaskListButton_UpdateButtonPadding_Original(pThis);
 
-    void* pTaskListButtonImpl = (BYTE*)pThis + 0x08;
+    void* taskListButtonIUnknownPtr = (void**)pThis + 3;
+    winrt::Windows::Foundation::IUnknown taskListButtonIUnknown;
+    winrt::copy_from_abi(taskListButtonIUnknown, taskListButtonIUnknownPtr);
 
-    UpdateTaskListButtonCustomizations(pTaskListButtonImpl);
+    auto taskListButtonElement = taskListButtonIUnknown.as<FrameworkElement>();
+
+    UpdateTaskListButtonCustomizations(taskListButtonElement);
+}
+
+using TaskbarFrame_OnTaskbarLayoutChildBoundsChanged_t =
+    void(WINAPI*)(void* pThis);
+TaskbarFrame_OnTaskbarLayoutChildBoundsChanged_t
+    TaskbarFrame_OnTaskbarLayoutChildBoundsChanged_Original;
+void WINAPI TaskbarFrame_OnTaskbarLayoutChildBoundsChanged_Hook(void* pThis) {
+    Wh_Log(L">");
+
+    TaskbarFrame_OnTaskbarLayoutChildBoundsChanged_Original(pThis);
+
+    void* taskbarFrameIUnknownPtr = (void**)pThis + 3;
+    winrt::Windows::Foundation::IUnknown taskbarFrameIUnknown;
+    winrt::copy_from_abi(taskbarFrameIUnknown, taskbarFrameIUnknownPtr);
+
+    auto taskbarFrameElement = taskbarFrameIUnknown.as<FrameworkElement>();
+
+    auto taskbarFrameRepeaterContainerElement =
+        FindChildByName(taskbarFrameElement, L"RootGrid");
+    if (!taskbarFrameRepeaterContainerElement) {
+        // For older versions (pre-KB5022913).
+        taskbarFrameRepeaterContainerElement =
+            FindChildByName(taskbarFrameElement, L"TaskbarFrameBorder");
+    }
+
+    if (!taskbarFrameRepeaterContainerElement) {
+        return;
+    }
+
+    auto taskbarFrameRepeaterElement = FindChildByName(
+        taskbarFrameRepeaterContainerElement, L"TaskbarFrameRepeater");
+    if (!taskbarFrameRepeaterElement) {
+        return;
+    }
+
+    for (int i = 0;; i++) {
+        auto child =
+            ItemsRepeater_TryGetElement(taskbarFrameRepeaterElement, i);
+        if (!child) {
+            break;
+        }
+
+        if (child.Name() == L"TaskListButton") {
+            UpdateTaskListButtonCustomizations(child);
+        }
+    }
 }
 
 using TaskListButton_Icon_t = void(WINAPI*)(void* pThis,
@@ -1385,169 +907,260 @@ void WINAPI TaskListButton_Icon_Hook(void* pThis, LONG_PTR randomAccessStream) {
         return;
     }
 
-    void* pTaskListButtonImpl = (BYTE*)pThis + 0x08;
+    void* taskListButtonIUnknownPtr = (void**)pThis + 3;
+    winrt::Windows::Foundation::IUnknown taskListButtonIUnknown;
+    winrt::copy_from_abi(taskListButtonIUnknown, taskListButtonIUnknownPtr);
 
-    HRESULT hr;
+    auto taskListButtonElement = taskListButtonIUnknown.as<FrameworkElement>();
 
-    IInspectable* pTaskListButton = *(IInspectable**)pTaskListButtonImpl;
-
-    ComPtr<Windows_UI_Xaml_Controls_ITextBlock> pWindhawkTextControl;
-
-    HStringReference hsVisualTreeHelperStatics(
-        L"Windows.UI.Xaml.Media.VisualTreeHelper");
-    ComPtr<Windows_UI_Xaml_IVisualTreeHelperStatics> pVisualTreeHelperStatics;
-    hr = RoGetActivationFactory(hsVisualTreeHelperStatics.Get(),
-                                IID_Windows_UI_Xaml_IVisualTreeHelperStatics,
-                                (void**)&pVisualTreeHelperStatics);
-    if (SUCCEEDED(hr)) {
-        ComPtr<Windows_UI_Xaml_IDependencyObject> pRootDependencyObject;
-        hr = pTaskListButton->QueryInterface(
-            IID_Windows_UI_Xaml_IDependencyObject,
-            (void**)&pRootDependencyObject);
-        if (SUCCEEDED(hr)) {
-            ComPtr<Windows_UI_Xaml_IDependencyObject> pIconPanel =
-                FindChildByName(pRootDependencyObject.Get(),
-                                pVisualTreeHelperStatics.Get(), L"IconPanel");
-            if (pIconPanel) {
-                ComPtr<Windows_UI_Xaml_IDependencyObject> pWindhawkText =
-                    FindChildByName(pIconPanel.Get(),
-                                    pVisualTreeHelperStatics.Get(),
-                                    L"WindhawkText");
-                if (pWindhawkText) {
-                    hr = pWindhawkText->QueryInterface(
-                        IID_Windows_UI_Xaml_Controls_ITextBlock,
-                        (void**)&pWindhawkTextControl);
-                }
-            }
+    auto iconPanelElement =
+        FindChildByName(taskListButtonElement, L"IconPanel");
+    if (iconPanelElement) {
+        auto windhawkTextControl =
+            FindChildByName(iconPanelElement, L"WindhawkText")
+                .as<Controls::TextBlock>();
+        if (windhawkTextControl) {
+            // Avoid setting empty text as it's used for missing titles.
+            windhawkTextControl.Text(*g_taskBtnGroupTitleInGroupChanged
+                                         ? g_taskBtnGroupTitleInGroupChanged
+                                         : L" ");
         }
-    }
-
-    if (pWindhawkTextControl) {
-        HStringReference hsTitle(g_taskBtnGroupTitleInGroupChanged);
-        pWindhawkTextControl->put_Text(hsTitle.Get());
     }
 }
 
 void LoadSettings() {
     g_settings.taskbarItemWidth = Wh_GetIntSetting(L"taskbarItemWidth");
+
+    PCWSTR runningIndicatorStyle =
+        Wh_GetStringSetting(L"runningIndicatorStyle");
+    g_settings.runningIndicatorStyle = RunningIndicatorStyle::centerFixed;
+    if (wcscmp(runningIndicatorStyle, L"centerDynamic") == 0) {
+        g_settings.runningIndicatorStyle = RunningIndicatorStyle::centerDynamic;
+    } else if (wcscmp(runningIndicatorStyle, L"left") == 0) {
+        g_settings.runningIndicatorStyle = RunningIndicatorStyle::left;
+    } else if (wcscmp(runningIndicatorStyle, L"fullWidth") == 0) {
+        g_settings.runningIndicatorStyle = RunningIndicatorStyle::fullWidth;
+    }
+    Wh_FreeStringSetting(runningIndicatorStyle);
+
+    g_settings.fontSize = Wh_GetIntSetting(L"fontSize");
+    g_settings.leftAndRightPaddingSize =
+        Wh_GetIntSetting(L"leftAndRightPaddingSize");
+    g_settings.spaceBetweenIconAndLabel =
+        Wh_GetIntSetting(L"spaceBetweenIconAndLabel");
+    g_settings.labelForSingleItem = Wh_GetStringSetting(L"labelForSingleItem");
+    g_settings.labelForMultipleItems =
+        Wh_GetStringSetting(L"labelForMultipleItems");
 }
 
 void FreeSettings() {
-    // Nothing for now.
-}
-
-bool ProtectAndMemcpy(DWORD protect, void* dst, const void* src, size_t size) {
-    DWORD oldProtect;
-    if (!VirtualProtect(dst, size, protect, &oldProtect)) {
-        return false;
-    }
-
-    memcpy(dst, src, size);
-    VirtualProtect(dst, size, oldProtect, &oldProtect);
-    return true;
+    Wh_FreeStringSetting(g_settings.labelForSingleItem);
+    Wh_FreeStringSetting(g_settings.labelForMultipleItems);
 }
 
 void ApplySettings() {
-    HWND hTaskbarWnd = FindWindow(L"Shell_TrayWnd", nullptr);
-    DWORD dwTaskbarProcessId = 0;
-    if (hTaskbarWnd && GetWindowThreadProcessId(hTaskbarWnd, &dwTaskbarProcessId) &&
-        dwTaskbarProcessId != GetCurrentProcessId()) {
-        hTaskbarWnd = nullptr;
-    }
-
-    if (!hTaskbarWnd) {
-        return;
-    }
-
-    g_applyingSettings = true;
-
-    double prevTaskbarHeight = *double_48_value_Original;
-
-    RECT taskbarRect{};
-    GetWindowRect(hTaskbarWnd, &taskbarRect);
-
-    // Temporarily change the height to force a UI refresh.
-    double tempTaskbarHeight = 1;
-    ProtectAndMemcpy(PAGE_READWRITE, double_48_value_Original,
-                     &tempTaskbarHeight, sizeof(double));
-
-    // Trigger TrayUI::_HandleSettingChange.
-    SendMessage(hTaskbarWnd, WM_SETTINGCHANGE, SPI_SETLOGICALDPIOVERRIDE, 0);
-
-    // Wait for the change to apply.
-    RECT newTaskbarRect{};
-    int counter = 0;
-    while (GetWindowRect(hTaskbarWnd, &newTaskbarRect) && newTaskbarRect.top == taskbarRect.top) {
-        if (++counter >= 100) {
-            break;
-        }
-        Sleep(100);
-    }
-
-    ProtectAndMemcpy(PAGE_READWRITE, double_48_value_Original,
-                     &prevTaskbarHeight, sizeof(double));
-
-    if (hTaskbarWnd) {
-        // Trigger TrayUI::_HandleSettingChange.
-        SendMessage(hTaskbarWnd, WM_SETTINGCHANGE, SPI_SETLOGICALDPIOVERRIDE,
-                    0);
-
-        HWND hReBarWindow32 =
-            FindWindowEx(hTaskbarWnd, nullptr, L"ReBarWindow32", nullptr);
-        if (hReBarWindow32) {
-            HWND hMSTaskSwWClass = FindWindowEx(hReBarWindow32, nullptr,
-                                                L"MSTaskSwWClass", nullptr);
-            if (hMSTaskSwWClass) {
-                // Trigger CTaskBand::_HandleSyncDisplayChange.
-                SendMessage(hMSTaskSwWClass, 0x452, 3, 0);
-            }
-        }
-    }
-
-    g_applyingSettings = false;
+    RecalculateLabels();
 }
 
 struct SYMBOL_HOOK {
-    std::wregex symbolRegex;
+    std::vector<std::wstring_view> symbols;
     void** pOriginalFunction;
     void* hookFunction = nullptr;
     bool optional = false;
 };
 
 bool HookSymbols(HMODULE module,
-                 SYMBOL_HOOK* symbolHooks,
+                 const SYMBOL_HOOK* symbolHooks,
                  size_t symbolHooksCount) {
-    WH_FIND_SYMBOL symbol;
-    HANDLE findSymbol = Wh_FindFirstSymbol(module, nullptr, &symbol);
-    if (!findSymbol) {
+    const WCHAR cacheVer = L'1';
+    const WCHAR cacheSep = L'#';
+    constexpr size_t cacheMaxSize = 10240;
+
+    WCHAR moduleFilePath[MAX_PATH];
+    if (!GetModuleFileName(module, moduleFilePath, ARRAYSIZE(moduleFilePath))) {
+        Wh_Log(L"GetModuleFileName failed");
+        return false;
+    }
+
+    PCWSTR moduleFileName = wcsrchr(moduleFilePath, L'\\');
+    if (!moduleFileName) {
+        Wh_Log(L"GetModuleFileName returned unsupported path");
+        return false;
+    }
+
+    moduleFileName++;
+
+    WCHAR cacheBuffer[cacheMaxSize + 1];
+    std::wstring cacheStrKey = std::wstring(L"symbol-cache-") + moduleFileName;
+    Wh_GetStringValue(cacheStrKey.c_str(), cacheBuffer, ARRAYSIZE(cacheBuffer));
+
+    std::wstring_view cacheBufferView(cacheBuffer);
+
+    // https://stackoverflow.com/a/46931770
+    auto splitStringView = [](std::wstring_view s, WCHAR delimiter) {
+        size_t pos_start = 0, pos_end;
+        std::wstring_view token;
+        std::vector<std::wstring_view> res;
+
+        while ((pos_end = s.find(delimiter, pos_start)) !=
+               std::wstring_view::npos) {
+            token = s.substr(pos_start, pos_end - pos_start);
+            pos_start = pos_end + 1;
+            res.push_back(token);
+        }
+
+        res.push_back(s.substr(pos_start));
+        return res;
+    };
+
+    auto cacheParts = splitStringView(cacheBufferView, cacheSep);
+
+    std::vector<bool> symbolResolved(symbolHooksCount, false);
+    std::wstring newSystemCacheStr;
+
+    auto onSymbolResolved = [symbolHooks, symbolHooksCount, &symbolResolved,
+                             cacheSep, &newSystemCacheStr,
+                             module](std::wstring_view symbol, void* address) {
+        for (size_t i = 0; i < symbolHooksCount; i++) {
+            if (symbolResolved[i]) {
+                continue;
+            }
+
+            bool match = false;
+            for (auto hookSymbol : symbolHooks[i].symbols) {
+                if (hookSymbol == symbol) {
+                    match = true;
+                    break;
+                }
+            }
+
+            if (!match) {
+                continue;
+            }
+
+            if (symbolHooks[i].hookFunction) {
+                Wh_SetFunctionHook(address, symbolHooks[i].hookFunction,
+                                   symbolHooks[i].pOriginalFunction);
+                Wh_Log(L"Hooked %p: %.*s", address, symbol.length(),
+                       symbol.data());
+            } else {
+                *symbolHooks[i].pOriginalFunction = address;
+                Wh_Log(L"Found %p: %.*s", address, symbol.length(),
+                       symbol.data());
+            }
+
+            symbolResolved[i] = true;
+
+            newSystemCacheStr += cacheSep;
+            newSystemCacheStr += symbol;
+            newSystemCacheStr += cacheSep;
+            newSystemCacheStr +=
+                std::to_wstring((ULONG_PTR)address - (ULONG_PTR)module);
+
+            break;
+        }
+    };
+
+    IMAGE_DOS_HEADER* dosHeader = (IMAGE_DOS_HEADER*)module;
+    IMAGE_NT_HEADERS* header =
+        (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
+    auto timeStamp = std::to_wstring(header->FileHeader.TimeDateStamp);
+    auto imageSize = std::to_wstring(header->OptionalHeader.SizeOfImage);
+
+    newSystemCacheStr += cacheVer;
+    newSystemCacheStr += cacheSep;
+    newSystemCacheStr += timeStamp;
+    newSystemCacheStr += cacheSep;
+    newSystemCacheStr += imageSize;
+
+    if (cacheParts.size() >= 3 &&
+        cacheParts[0] == std::wstring_view(&cacheVer, 1) &&
+        cacheParts[1] == timeStamp && cacheParts[2] == imageSize) {
+        for (size_t i = 3; i + 1 < cacheParts.size(); i += 2) {
+            auto symbol = cacheParts[i];
+            auto address = cacheParts[i + 1];
+            if (address.length() == 0) {
+                continue;
+            }
+
+            void* addressPtr =
+                (void*)(std::stoull(std::wstring(address), nullptr, 10) +
+                        (ULONG_PTR)module);
+
+            onSymbolResolved(symbol, addressPtr);
+        }
+
+        for (size_t i = 0; i < symbolHooksCount; i++) {
+            if (symbolResolved[i] || !symbolHooks[i].optional) {
+                continue;
+            }
+
+            int noAddressMatchCount = 0;
+            for (size_t j = 3; j + 1 < cacheParts.size(); j += 2) {
+                auto symbol = cacheParts[j];
+                auto address = cacheParts[j + 1];
+                if (address.length() != 0) {
+                    continue;
+                }
+
+                for (auto hookSymbol : symbolHooks[i].symbols) {
+                    if (hookSymbol == symbol) {
+                        noAddressMatchCount++;
+                        break;
+                    }
+                }
+            }
+
+            if (noAddressMatchCount == symbolHooks[i].symbols.size()) {
+                Wh_Log(L"Optional symbol %d doesn't exist (from cache)", i);
+                symbolResolved[i] = true;
+            }
+        }
+
+        if (std::all_of(symbolResolved.begin(), symbolResolved.end(),
+                        [](bool b) { return b; })) {
+            return true;
+        }
+    }
+
+    Wh_Log(L"Couldn't resolve all symbols from cache");
+
+    WH_FIND_SYMBOL findSymbol;
+    HANDLE findSymbolHandle = Wh_FindFirstSymbol(module, nullptr, &findSymbol);
+    if (!findSymbolHandle) {
+        Wh_Log(L"Wh_FindFirstSymbol failed");
         return false;
     }
 
     do {
-        for (size_t i = 0; i < symbolHooksCount; i++) {
-            if (!*symbolHooks[i].pOriginalFunction &&
-                std::regex_match(symbol.symbol, symbolHooks[i].symbolRegex)) {
-                if (symbolHooks[i].hookFunction) {
-                    Wh_SetFunctionHook(symbol.address,
-                                       symbolHooks[i].hookFunction,
-                                       symbolHooks[i].pOriginalFunction);
-                    Wh_Log(L"Hooked %p (%s)", symbol.address, symbol.symbol);
-                } else {
-                    *symbolHooks[i].pOriginalFunction = symbol.address;
-                    Wh_Log(L"Found %p (%s)", symbol.address, symbol.symbol);
-                }
-                break;
-            }
-        }
-    } while (Wh_FindNextSymbol(findSymbol, &symbol));
+        onSymbolResolved(findSymbol.symbol, findSymbol.address);
+    } while (Wh_FindNextSymbol(findSymbolHandle, &findSymbol));
 
-    Wh_FindCloseSymbol(findSymbol);
+    Wh_FindCloseSymbol(findSymbolHandle);
 
     for (size_t i = 0; i < symbolHooksCount; i++) {
-        if (!symbolHooks[i].optional && !*symbolHooks[i].pOriginalFunction) {
-            Wh_Log(L"Missing symbol: %d", i);
+        if (symbolResolved[i]) {
+            continue;
+        }
+
+        if (!symbolHooks[i].optional) {
+            Wh_Log(L"Unresolved symbol: %d", i);
             return false;
         }
+
+        Wh_Log(L"Optional symbol %d doesn't exist", i);
+
+        for (auto hookSymbol : symbolHooks[i].symbols) {
+            newSystemCacheStr += cacheSep;
+            newSystemCacheStr += hookSymbol;
+            newSystemCacheStr += cacheSep;
+        }
+    }
+
+    if (newSystemCacheStr.length() <= cacheMaxSize) {
+        Wh_SetStringValue(cacheStrKey.c_str(), newSystemCacheStr.c_str());
+    } else {
+        Wh_Log(L"Cache is too large (%zu)", newSystemCacheStr.length());
     }
 
     return true;
@@ -1561,36 +1174,58 @@ bool HookTaskbarDllSymbols() {
     }
 
     SYMBOL_HOOK symbolHooks[] = {
-        {std::wregex(
-             LR"(protected: struct ITaskBtnGroup \* __ptr64 __cdecl CTaskListWnd::_GetTBGroupFromGroup\(struct ITaskGroup \* __ptr64,int \* __ptr64\) __ptr64)"),
-         (void**)&CTaskListWnd__GetTBGroupFromGroup_Original, nullptr},
-
-        {std::wregex(
-             LR"(public: virtual int __cdecl CTaskBtnGroup::GetNumItems\(void\) __ptr64)"),
-         (void**)&CTaskBtnGroup_GetNumItems_Original, nullptr},
-
-        {std::wregex(
-             LR"(public: virtual struct ITaskItem \* __ptr64 __cdecl CTaskBtnGroup::GetTaskItem\(int\) __ptr64)"),
-         (void**)&CTaskBtnGroup_GetTaskItem_Original, nullptr},
-
-        {std::wregex(
-             LR"(public: virtual long __cdecl CTaskGroup::GetTitleText\(struct ITaskItem \* __ptr64,unsigned short \* __ptr64,int\) __ptr64)"),
-         (void**)&CTaskGroup_GetTitleText_Original, nullptr},
-
-        {std::wregex(
-             LR"(public: virtual bool __cdecl IconContainer::IsStorageRecreationRequired\(class CCoSimpleArray<unsigned int,4294967294,class CSimpleArrayStandardCompareHelper<unsigned int> > const & __ptr64,enum IconContainerFlags\) __ptr64)"),
-         (void**)&IconContainer_IsStorageRecreationRequired_Original,
-         (void*)IconContainer_IsStorageRecreationRequired_Hook},
-
-        {std::wregex(
-             LR"(public: virtual void __cdecl CTaskListWnd::GroupChanged\(struct ITaskGroup \* __ptr64,enum winrt::WindowsUdk::UI::Shell::TaskGroupProperty\) __ptr64)"),
-         (void**)&CTaskListWnd_GroupChanged_Original,
-         (void*)CTaskListWnd_GroupChanged_Hook},
-
-        {std::wregex(
-             LR"(public: virtual long __cdecl CTaskListWnd::TaskDestroyed\(struct ITaskGroup \* __ptr64,struct ITaskItem \* __ptr64,enum TaskDestroyedFlags\) __ptr64)"),
-         (void**)&CTaskListWnd_TaskDestroyed_Original,
-         (void*)CTaskListWnd_TaskDestroyed_Hook},
+        {
+            {
+                LR"(protected: struct ITaskBtnGroup * __cdecl CTaskListWnd::_GetTBGroupFromGroup(struct ITaskGroup *,int *))",
+                LR"(protected: struct ITaskBtnGroup * __ptr64 __cdecl CTaskListWnd::_GetTBGroupFromGroup(struct ITaskGroup * __ptr64,int * __ptr64) __ptr64)",
+            },
+            (void**)&CTaskListWnd__GetTBGroupFromGroup_Original,
+        },
+        {
+            {
+                LR"(public: virtual int __cdecl CTaskBtnGroup::GetNumItems(void))",
+                LR"(public: virtual int __cdecl CTaskBtnGroup::GetNumItems(void) __ptr64)",
+            },
+            (void**)&CTaskBtnGroup_GetNumItems_Original,
+        },
+        {
+            {
+                LR"(public: virtual struct ITaskItem * __cdecl CTaskBtnGroup::GetTaskItem(int))",
+                LR"(public: virtual struct ITaskItem * __ptr64 __cdecl CTaskBtnGroup::GetTaskItem(int) __ptr64)",
+            },
+            (void**)&CTaskBtnGroup_GetTaskItem_Original,
+        },
+        {
+            {
+                LR"(public: virtual long __cdecl CTaskGroup::GetTitleText(struct ITaskItem *,unsigned short *,int))",
+                LR"(public: virtual long __cdecl CTaskGroup::GetTitleText(struct ITaskItem * __ptr64,unsigned short * __ptr64,int) __ptr64)",
+            },
+            (void**)&CTaskGroup_GetTitleText_Original,
+        },
+        {
+            {
+                LR"(public: virtual bool __cdecl IconContainer::IsStorageRecreationRequired(class CCoSimpleArray<unsigned int,4294967294,class CSimpleArrayStandardCompareHelper<unsigned int> > const &,enum IconContainerFlags))",
+                LR"(public: virtual bool __cdecl IconContainer::IsStorageRecreationRequired(class CCoSimpleArray<unsigned int,4294967294,class CSimpleArrayStandardCompareHelper<unsigned int> > const & __ptr64,enum IconContainerFlags) __ptr64)",
+            },
+            (void**)&IconContainer_IsStorageRecreationRequired_Original,
+            (void*)IconContainer_IsStorageRecreationRequired_Hook,
+        },
+        {
+            {
+                LR"(public: virtual void __cdecl CTaskListWnd::GroupChanged(struct ITaskGroup *,enum winrt::WindowsUdk::UI::Shell::TaskGroupProperty))",
+                LR"(public: virtual void __cdecl CTaskListWnd::GroupChanged(struct ITaskGroup * __ptr64,enum winrt::WindowsUdk::UI::Shell::TaskGroupProperty) __ptr64)",
+            },
+            (void**)&CTaskListWnd_GroupChanged_Original,
+            (void*)CTaskListWnd_GroupChanged_Hook,
+        },
+        {
+            {
+                LR"(public: virtual long __cdecl CTaskListWnd::TaskDestroyed(struct ITaskGroup *,struct ITaskItem *,enum TaskDestroyedFlags))",
+                LR"(public: virtual long __cdecl CTaskListWnd::TaskDestroyed(struct ITaskGroup * __ptr64,struct ITaskItem * __ptr64,enum TaskDestroyedFlags) __ptr64)",
+            },
+            (void**)&CTaskListWnd_TaskDestroyed_Original,
+            (void*)CTaskListWnd_TaskDestroyed_Hook,
+        },
     };
 
     return HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks));
@@ -1695,27 +1330,45 @@ bool HookTaskbarViewDllSymbols() {
     }
 
     SYMBOL_HOOK symbolHooks[] = {
-        {std::wregex(LR"(__real@4048000000000000)"),
-         (void**)&double_48_value_Original, nullptr},
-
-        {std::wregex(
-             LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListButton,struct winrt::Taskbar::ITaskListButton>::get_IsRunning\(bool \* __ptr64\) __ptr64)"),
-         (void**)&ITaskListButton_get_IsRunning_Original, nullptr},
-
-        {std::wregex(
-             LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates\(void\) __ptr64)"),
-         (void**)&TaskListButton_UpdateVisualStates_Original,
-         (void*)TaskListButton_UpdateVisualStates_Hook},
-
-        {std::wregex(
-             LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateButtonPadding\(void\) __ptr64)"),
-         (void**)&TaskListButton_UpdateButtonPadding_Original,
-         (void*)TaskListButton_UpdateButtonPadding_Hook},
-
-        {std::wregex(
-             LR"(public: void __cdecl winrt::Taskbar::implementation::TaskListButton::Icon\(struct winrt::Windows::Storage::Streams::IRandomAccessStream\) __ptr64)"),
-         (void**)&TaskListButton_Icon_Original,
-         (void*)TaskListButton_Icon_Hook},
+        {
+            {
+                LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListButton,struct winrt::Taskbar::ITaskListButton>::get_IsRunning(bool *))",
+                LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListButton,struct winrt::Taskbar::ITaskListButton>::get_IsRunning(bool * __ptr64) __ptr64)",
+            },
+            (void**)&TaskListButton_get_IsRunning_Original,
+        },
+        {
+            {
+                LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void))",
+                LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void) __ptr64)",
+            },
+            (void**)&TaskListButton_UpdateVisualStates_Original,
+            (void*)TaskListButton_UpdateVisualStates_Hook,
+        },
+        {
+            {
+                LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateButtonPadding(void))",
+                LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateButtonPadding(void) __ptr64)",
+            },
+            (void**)&TaskListButton_UpdateButtonPadding_Original,
+            (void*)TaskListButton_UpdateButtonPadding_Hook,
+        },
+        {
+            {
+                LR"(private: void __cdecl winrt::Taskbar::implementation::TaskbarFrame::OnTaskbarLayoutChildBoundsChanged(void))",
+                LR"(private: void __cdecl winrt::Taskbar::implementation::TaskbarFrame::OnTaskbarLayoutChildBoundsChanged(void) __ptr64)",
+            },
+            (void**)&TaskbarFrame_OnTaskbarLayoutChildBoundsChanged_Original,
+            (void*)TaskbarFrame_OnTaskbarLayoutChildBoundsChanged_Hook,
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::Taskbar::implementation::TaskListButton::Icon(struct winrt::Windows::Storage::Streams::IRandomAccessStream))",
+                LR"(public: void __cdecl winrt::Taskbar::implementation::TaskListButton::Icon(struct winrt::Windows::Storage::Streams::IRandomAccessStream) __ptr64)",
+            },
+            (void**)&TaskListButton_Icon_Original,
+            (void*)TaskListButton_Icon_Hook,
+        },
     };
 
     return HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks));
@@ -1748,6 +1401,10 @@ void Wh_ModBeforeUninit() {
 
     g_unloading = true;
     ApplySettings();
+
+    // This is required to give time for taskbar buttons of UWP apps to update
+    // the layout.
+    Sleep(400);
 }
 
 void Wh_ModUninit() {


### PR DESCRIPTION
* Implemented adaptive sizing when there are too many items.
* Fixed missing labels when switching between virtual desktops or moving windows between monitors.
* Fixed wrong badge placement.
* Added several customization options such as running indicator style, font size and label string format.
* Improved compatibility with the Large Taskbar Icons mod.
* Improved loading speed by caching symbols.