### PR TITLE
classic-maximized-windows-fix v2.1

### DIFF
--- a/mods/classic-maximized-windows-fix.wh.cpp
+++ b/mods/classic-maximized-windows-fix.wh.cpp
@@ -1,5 +1,5 @@
 // ==WindhawkMod==
-// @id              classic-maximized-windows-fix-2
+// @id              classic-maximized-windows-fix
 // @name            Fix Classic Theme Maximized Windows
 // @description     Fix maximized windows having borders that spill out onto additional displays when using the classic theme.
 // @version         2.1


### PR DESCRIPTION
- Improved compatibility with Aero Snap. This was done by migrating to the undocumented `SetWindowRgnEx` function rather than the older public function.
- Rewrote the symbol hook wrapper CmwfHookSymbols for initial load with multiple symbol hooks.