### PR TITLE
DWM Unextend Frames 1.2.0: Remove `IsThreadDesktopComposited` hook, a…

### DIFF
--- a/mods/dwm-unextend-frames.wh.cpp
+++ b/mods/dwm-unextend-frames.wh.cpp
@@ -2,11 +2,10 @@
 // @id              dwm-unextend-frames
 // @name            DWM Unextend Frames
 // @description     Makes applications think DWM is disabled
-// @version         1.1.0
+// @version         1.2.0
 // @author          aubymori
 // @github          https://github.com/aubymori
 // @include         *
-// @exclude         vmware-vmx.exe
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -15,12 +14,6 @@
 This mod makes applications think DWM is disabled when in reality it
 is not. This is useful for anyone doing a setup with non-DWM frames
 (Classic, XP, Vista/7 Basic).
-
-# IMPORTANT: READ!
-This mod works a bit *too* well. With it enabled, DWM window frames
-will be entirely unable to be interacted with. You'll need a basic
-themer like [BasicThemer5](https://github.com/arukateru/BasicThemer5)
-to use this mod properly.
 
 **This mod requires Windhawk v1.4 or greater.**
 
@@ -38,6 +31,14 @@ to use this mod properly.
 
 #include <dwmapi.h>
 #include <windhawk_utils.h>
+
+#ifdef _WIN64
+#   define THISCALL  __cdecl
+#   define STHISCALL L"__cdecl"
+#else
+#   define THISCALL  __thiscall
+#   define STHISCALL L"__thiscall"
+#endif
 
 /* Not defined for some reason */
 #ifndef DWM_E_COMPOSITIONDISABLED
@@ -96,7 +97,7 @@ HRESULT WINAPI DwmSetWindowAttribute_hook(
     DWORD   dwAttribute,
     LPCVOID pvAttribute,
     DWORD   cbAttribute
-    )
+)
 {
     if (dwAttribute != DWMWA_EXTENDED_FRAME_BOUNDS)
     {
@@ -132,11 +133,21 @@ BOOL WINAPI SetWindowCompositionAttribute_hook(
     return TRUE;
 }
 
-typedef BOOL (WINAPI *IsThreadDesktopComposited_t)(void);
-IsThreadDesktopComposited_t IsThreadDesktopComposited_orig;
-BOOL WINAPI IsThreadDesktopComposited_hook(void)
+/* comctl32.dll hooks */
+
+#ifdef _WIN64
+#   define DUIXmlParser_Composited(pThis) *((DWORD *)pThis + 27)
+#else
+#   define DUIXmlParser_Composited(pThis) *((DWORD *)pThis + 16)
+#endif
+
+HRESULT (THISCALL *DirectUI_DUIXmlParser__InitializeTables_orig)(void *);
+HRESULT THISCALL DirectUI_DUIXmlParser__InitializeTables_hook(
+    void *pThis
+)
 {
-    return FALSE;
+    DUIXmlParser_Composited(pThis) = FALSE;
+    return DirectUI_DUIXmlParser__InitializeTables_orig(pThis);
 }
 
 #define MODULE_VARNAME(NAME) hMod_ ## NAME
@@ -150,16 +161,75 @@ if (!MODULE_VARNAME(NAME))                                       \
     return FALSE;                                                \
 }
 
-#define HOOK_FUNCTION(MODULE, FUNCTION)                                    \
-if (!WindhawkUtils::Wh_SetFunctionHookT(                                   \
-    (FUNCTION ## _t)GetProcAddress(MODULE_VARNAME(MODULE), #FUNCTION),     \
-    FUNCTION ## _hook,                                                     \
-    &FUNCTION ## _orig                                                     \
-))                                                                         \
-{                                                                          \
-    Wh_Log(L"Failed to hook" WSTR(FUNCTION) L" in " WSTR(MODULE) L".dll"); \
-    return FALSE;                                                          \
+#define HOOK_FUNCTION(MODULE, FUNCTION)                                     \
+if (!WindhawkUtils::Wh_SetFunctionHookT(                                    \
+    (FUNCTION ## _t)GetProcAddress(MODULE_VARNAME(MODULE), #FUNCTION),      \
+    FUNCTION ## _hook,                                                      \
+    &FUNCTION ## _orig                                                      \
+))                                                                          \
+{                                                                           \
+    Wh_Log(L"Failed to hook " WSTR(FUNCTION) L" in " WSTR(MODULE) L".dll"); \
+    return FALSE;                                                           \
 }
+
+#ifdef _WIN64
+#   define PATHCACHE_VALNAME L"last-comctl32-v6-path"
+#else
+#   define PATHCACHE_VALNAME L"last-comctl32-v6-path-wow64"
+#endif
+
+#define COMCTL_582_SEARCH    L"microsoft.windows.common-controls_6595b64144ccf1df_5.82"
+
+/* Load the ComCtl32 module */
+HMODULE LoadComCtlModule(void)
+{
+    HMODULE hComCtl = LoadLibraryW(L"comctl32.dll");
+    if (!hComCtl)
+    {
+        return NULL;
+    }
+
+    WCHAR szPath[MAX_PATH];
+    GetModuleFileNameW(hComCtl, szPath, MAX_PATH);
+
+    WCHAR szv6Path[MAX_PATH];
+    BOOL bNoCache = FALSE;
+    if (!Wh_GetStringValue(PATHCACHE_VALNAME, szv6Path, MAX_PATH))
+    {
+        bNoCache = TRUE;
+    }
+
+    /**
+      * the !bNoCache check here is nested because we only want to fall through
+      * to the cacher if the current comctl32 path is NOT 5.82.
+      */
+    if (wcsstr(szPath, COMCTL_582_SEARCH)
+    || wcsstr(szPath, L"\\Windows\\System32")
+    || wcsstr(szPath, L"\\Windows\\SysWOW64"))
+    {
+        if (!bNoCache)
+        {
+            hComCtl = LoadLibraryW(szv6Path);
+        }
+    }
+    else if (bNoCache || wcsicmp(szPath, szv6Path))
+    {
+        Wh_SetStringValue(PATHCACHE_VALNAME, szPath);
+    }
+
+    return hComCtl;
+}
+
+const WindhawkUtils::SYMBOL_HOOK comctl32_hook = {
+    {
+        L"public: long "
+        STHISCALL
+        L" DirectUI::DUIXmlParser::_InitializeTables(void)"
+    },
+    &DirectUI_DUIXmlParser__InitializeTables_orig,
+    DirectUI_DUIXmlParser__InitializeTables_hook,
+    false
+};
 
 BOOL Wh_ModInit(void)
 {
@@ -174,7 +244,23 @@ BOOL Wh_ModInit(void)
 
     LOAD_MODULE(user32)
     HOOK_FUNCTION(user32, SetWindowCompositionAttribute)
-    HOOK_FUNCTION(user32, IsThreadDesktopComposited)
+
+    HMODULE hComCtl = LoadComCtlModule();
+    if (!hComCtl)
+    {
+        Wh_Log(L"Failed to load comctl32.dll");
+        return FALSE;
+    }
+
+    if (!WindhawkUtils::HookSymbols(
+        hComCtl,
+        &comctl32_hook,
+        1
+    ))
+    {
+        Wh_Log(L"Failed to hook DirectUI::DUIXmlParser::_InitializeTables in comctl32.dll");
+        return FALSE;
+    }
 
     return TRUE;
 }


### PR DESCRIPTION
…dd comctl32 hook for Aero wizards

As it turns out, `IsThreadDesktopComposited` is a REALLY low-level function and will break a lot of applications if hooked.