### PR TITLE
Click on empty taskbar space v1.1

### DIFF
--- a/mods/taskbar-empty-space-clicks.wh.cpp
+++ b/mods/taskbar-empty-space-clicks.wh.cpp
@@ -1104,11 +1104,17 @@ bool isMouseDoubleClick(LPARAM lParam)
         ((currentTime - lastPointerDownTime) <= GetDoubleClickTime()))
     {
         result = true;
-    }
 
-    // Update the time and location of the last WM_POINTERDOWN event
-    lastPointerDownTime = currentTime;
-    lastPointerDownLocation = currentLocation;
+        // Update the time and location to defaults, otherwise a triple-click will be detected as two double-clicks
+        lastPointerDownTime = 0;
+        lastPointerDownLocation = {0, 0};
+    }
+    else
+    {
+        // Update the time and location of the last WM_POINTERDOWN event
+        lastPointerDownTime = currentTime;
+        lastPointerDownLocation = currentLocation;
+    }
 
     return result;
 }

--- a/mods/taskbar-empty-space-clicks.wh.cpp
+++ b/mods/taskbar-empty-space-clicks.wh.cpp
@@ -32,7 +32,7 @@ This mod lets you assign an action to a mouse click on Windows taskbar. Double-c
 5. **Taskbar auto-hide** - Toggle Windows taskbar auto-hide feature
 6. **Win+Tab** - Opens Win+Tab dialog
 7. **Hide desktop icons** - Toggle show/hide of all desktop icons
-7. **Combine Taskbar buttons** - Toggle combining of Taskbar buttons between two states set in the Settings menu
+7. **Combine Taskbar buttons** - Toggle combining of Taskbar buttons between two states set in the Settings menu (not available on older Windows 11 versions)
 7. **Open Start menu** - Sends Win key press to open Start menu
 
 ## Example
@@ -98,7 +98,7 @@ If you have request for new functions, suggestions or you are experiencing some 
     - COMBINE_ALWAYS: Always combine
     - COMBINE_WHEN_FULL: Combine when taskbar is full
     - COMBINE_NEVER: Never combine
-  - State2: COMBINE_ALWAYS
+  - State2: COMBINE_NEVER
     $options:
     - COMBINE_ALWAYS: Always combine
     - COMBINE_WHEN_FULL: Combine when taskbar is full

--- a/mods/taskbar-empty-space-clicks.wh.cpp
+++ b/mods/taskbar-empty-space-clicks.wh.cpp
@@ -703,7 +703,6 @@ protected:
     bool initialized;
 } g_comInitializer;
 
-static int nWinVersion;
 static TaskBarVersion g_taskbarVersion = UNKNOWN_TASKBAR;
 
 static DWORD g_dwTaskbarThreadId;
@@ -1069,162 +1068,6 @@ HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWST
 
 #pragma endregion // hook_magic
 
-#pragma region helper_defines
-// taken from https://github.com/m417z/7-Taskbar-Tweaker/blob/6d529922a8609b68d6d4492d91dcc704c0dfbe4d/dll/functions.h
-
-#define WIN_VERSION_UNSUPPORTED (-1)
-#define WIN_VERSION_7 0
-#define WIN_VERSION_8 1
-#define WIN_VERSION_81 2
-#define WIN_VERSION_811 3
-#define WIN_VERSION_10_T1 4        // 1507
-#define WIN_VERSION_10_T2 5        // 1511
-#define WIN_VERSION_10_R1 6        // 1607
-#define WIN_VERSION_10_R2 7        // 1703
-#define WIN_VERSION_10_R3 8        // 1709
-#define WIN_VERSION_10_R4 9        // 1803
-#define WIN_VERSION_10_R5 10       // 1809
-#define WIN_VERSION_10_19H1 11     // 1903, 1909
-#define WIN_VERSION_10_20H1 12     // 2004, 20H2, 21H1, 21H2, 22H2
-#define WIN_VERSION_SERVER_2022 13 // Server 2022
-#define WIN_VERSION_11_21H2 14
-#define WIN_VERSION_11_22H2 15
-
-// helper macros
-#define FIRST_NONEMPTY_ARG_2(a, b) \
-    ((sizeof(#a) > sizeof("")) ? (a + 0) : (b))
-#define FIRST_NONEMPTY_ARG_3(a, b, c) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_2(b, c))
-#define FIRST_NONEMPTY_ARG_4(a, b, c, d) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_3(b, c, d))
-#define FIRST_NONEMPTY_ARG_5(a, b, c, d, e) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_4(b, c, d, e))
-#define FIRST_NONEMPTY_ARG_6(a, b, c, d, e, f) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_5(b, c, d, e, f))
-#define FIRST_NONEMPTY_ARG_7(a, b, c, d, e, f, g) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_6(b, c, d, e, f, g))
-#define FIRST_NONEMPTY_ARG_8(a, b, c, d, e, f, g, h) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_7(b, c, d, e, f, g, h))
-#define FIRST_NONEMPTY_ARG_9(a, b, c, d, e, f, g, h, i) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_8(b, c, d, e, f, g, h, i))
-#define FIRST_NONEMPTY_ARG_10(a, b, c, d, e, f, g, h, i, j) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_9(b, c, d, e, f, g, h, i, j))
-#define FIRST_NONEMPTY_ARG_11(a, b, c, d, e, f, g, h, i, j, k) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_10(b, c, d, e, f, g, h, i, j, k))
-#define FIRST_NONEMPTY_ARG_12(a, b, c, d, e, f, g, h, i, j, k, l) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_11(b, c, d, e, f, g, h, i, j, k, l))
-#define FIRST_NONEMPTY_ARG_13(a, b, c, d, e, f, g, h, i, j, k, l, m) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_12(b, c, d, e, f, g, h, i, j, k, l, m))
-#define FIRST_NONEMPTY_ARG_14(a, b, c, d, e, f, g, h, i, j, k, l, m, n) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_13(b, c, d, e, f, g, h, i, j, k, l, m, n))
-#define FIRST_NONEMPTY_ARG_15(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_14(b, c, d, e, f, g, h, i, j, k, l, m, n, o))
-#define FIRST_NONEMPTY_ARG_16(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_15(b, c, d, e, f, g, h, i, j, k, l, m, n, o, p))
-#define FIRST_NONEMPTY_ARG_17(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) \
-    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_16(b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q))
-
-#define DO2(d7, dx) ((nWinVersion > WIN_VERSION_7) ? FIRST_NONEMPTY_ARG_2(dx, d7) : (d7))
-#define DO3(d7, d8, dx) ((nWinVersion > WIN_VERSION_8) ? FIRST_NONEMPTY_ARG_3(dx, d8, d7) : DO2(d7, d8))
-#define DO4(d7, d8, d81, dx) ((nWinVersion > WIN_VERSION_81) ? FIRST_NONEMPTY_ARG_4(dx, d81, d8, d7) : DO3(d7, d8, d81))
-#define DO5(d7, d8, d81, d811, dx) ((nWinVersion > WIN_VERSION_811) ? FIRST_NONEMPTY_ARG_5(dx, d811, d81, d8, d7) : DO4(d7, d8, d81, d811))
-#define DO6(d7, d8, d81, d811, d10_t1, dx) \
-    ((nWinVersion > WIN_VERSION_10_T1) ? FIRST_NONEMPTY_ARG_6(dx, d10_t1, d811, d81, d8, d7) : DO5(d7, d8, d81, d811, d10_t1))
-#define DO7(d7, d8, d81, d811, d10_t1, d10_t2, dx) \
-    ((nWinVersion > WIN_VERSION_10_T2) ? FIRST_NONEMPTY_ARG_7(dx, d10_t2, d10_t1, d811, d81, d8, d7) : DO6(d7, d8, d81, d811, d10_t1, d10_t2))
-#define DO8(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, dx) \
-    ((nWinVersion > WIN_VERSION_10_R1) ? FIRST_NONEMPTY_ARG_8(dx, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO7(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1))
-#define DO9(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, dx) \
-    ((nWinVersion > WIN_VERSION_10_R2) ? FIRST_NONEMPTY_ARG_9(dx, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO8(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2))
-#define DO10(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, dx) \
-    ((nWinVersion > WIN_VERSION_10_R3) ? FIRST_NONEMPTY_ARG_10(dx, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO9(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3))
-#define DO11(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, dx) \
-    ((nWinVersion > WIN_VERSION_10_R4) ? FIRST_NONEMPTY_ARG_11(dx, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO10(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4))
-#define DO12(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, dx) \
-    ((nWinVersion > WIN_VERSION_10_R5) ? FIRST_NONEMPTY_ARG_12(dx, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO11(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5))
-#define DO13(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, dx) \
-    ((nWinVersion > WIN_VERSION_10_19H1) ? FIRST_NONEMPTY_ARG_13(dx, d10_19h1, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO12(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1))
-#define DO14(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, dx) \
-    ((nWinVersion > WIN_VERSION_10_20H1) ? FIRST_NONEMPTY_ARG_14(dx, d10_20h1, d10_19h1, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO13(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1))
-#define DO15(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022, dx) \
-    ((nWinVersion > WIN_VERSION_SERVER_2022) ? FIRST_NONEMPTY_ARG_15(dx, ds_2022, d10_20h1, d10_19h1, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO14(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022))
-#define DO16(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022, d11_21h2, dx) \
-    ((nWinVersion > WIN_VERSION_11_21H2) ? FIRST_NONEMPTY_ARG_16(dx, d11_21h2, ds_2022, d10_20h1, d10_19h1, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO15(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022, d11_21h2))
-#define DO17(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022, d11_21h2, d11_22h2, dx) \
-    DO16(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022, d11_21h2, d11_22h2)
-
-#ifdef _WIN64
-#define DEF3264(d32, d64) (d64)
-#else
-#define DEF3264(d32, d64) (d32)
-#endif
-
-#define DO2_3264(d7_32, d7_64, dx_32, dx_64) \
-    DEF3264(DO2(d7_32, dx_32),               \
-            DO2(d7_64, dx_64))
-
-#define DO3_3264(d7_32, d7_64, d8_32, d8_64, dx_32, dx_64) \
-    DEF3264(DO3(d7_32, d8_32, dx_32),                      \
-            DO3(d7_64, d8_64, dx_64))
-
-#define DO4_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, dx_32, dx_64) \
-    DEF3264(DO4(d7_32, d8_32, d81_32, dx_32),                              \
-            DO4(d7_64, d8_64, d81_64, dx_64))
-
-#define DO5_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, dx_32, dx_64) \
-    DEF3264(DO5(d7_32, d8_32, d81_32, d811_32, dx_32),                                       \
-            DO5(d7_64, d8_64, d81_64, d811_64, dx_64))
-
-#define DO6_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, dx_32, dx_64) \
-    DEF3264(DO6(d7_32, d8_32, d81_32, d811_32, d10_t1_32, dx_32),                                                  \
-            DO6(d7_64, d8_64, d81_64, d811_64, d10_t1_64, dx_64))
-
-#define DO7_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, dx_32, dx_64) \
-    DEF3264(DO7(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, dx_32),                                                             \
-            DO7(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, dx_64))
-
-#define DO8_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, dx_32, dx_64) \
-    DEF3264(DO8(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, dx_32),                                                                        \
-            DO8(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, dx_64))
-
-#define DO9_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, dx_32, dx_64) \
-    DEF3264(DO9(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, dx_32),                                                                                   \
-            DO9(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, dx_64))
-
-#define DO10_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, dx_32, dx_64) \
-    DEF3264(DO10(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, dx_32),                                                                                              \
-            DO10(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, dx_64))
-
-#define DO11_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, dx_32, dx_64) \
-    DEF3264(DO11(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, dx_32),                                                                                                         \
-            DO11(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, dx_64))
-
-#define DO12_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, d10_r5_32, d10_r5_64, dx_32, dx_64) \
-    DEF3264(DO12(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, dx_32),                                                                                                                    \
-            DO12(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, dx_64))
-
-#define DO13_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, d10_r5_32, d10_r5_64, d10_19h1_32, d10_19h1_64, dx_32, dx_64) \
-    DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, dx_32),                                                                                                                                 \
-            DO13(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, dx_64))
-
-#define DO14_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, d10_r5_32, d10_r5_64, d10_19h1_32, d10_19h1_64, d10_20h1_32, d10_20h1_64, dx_64) \
-    DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, d10_20h1_32),                                                                                                                                              \
-            DO14(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, d10_20h1_64, dx_64))
-
-#define DO15_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, d10_r5_32, d10_r5_64, d10_19h1_32, d10_19h1_64, d10_20h1_32, d10_20h1_64, ds_2022_64, dx_64) \
-    DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, d10_20h1_32),                                                                                                                                                          \
-            DO15(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, d10_20h1_64, ds_2022_64, dx_64))
-
-#define DO16_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, d10_r5_32, d10_r5_64, d10_19h1_32, d10_19h1_64, d10_20h1_32, d10_20h1_64, ds_2022_64, d11_21h2_64, dx_64) \
-    DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, d10_20h1_32),                                                                                                                                                                       \
-            DO16(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, d10_20h1_64, ds_2022_64, d11_21h2_64, dx_64))
-
-#define DO17_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, d10_r5_32, d10_r5_64, d10_19h1_32, d10_19h1_64, d10_20h1_32, d10_20h1_64, ds_2022_64, d11_21h2_64, d11_22h2_64, dx_64) \
-    DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, d10_20h1_32),                                                                                                                                                                                    \
-            DO17(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, d10_20h1_64, ds_2022_64, d11_21h2_64, d11_22h2_64, dx_64))
-
-#pragma endregion
-
 #pragma region functions
 
 bool IsTaskbarWindow(HWND hWnd)
@@ -1301,8 +1144,6 @@ VS_FIXEDFILEINFO *GetModuleVersionInfo(HMODULE hModule, UINT *puPtrLen)
 
 BOOL WindowsVersionInit()
 {
-    nWinVersion = WIN_VERSION_UNSUPPORTED;
-
     VS_FIXEDFILEINFO *pFixedFileInfo = GetModuleVersionInfo(NULL, NULL);
     if (!pFixedFileInfo)
         return FALSE;
@@ -1312,63 +1153,6 @@ BOOL WindowsVersionInit()
     WORD nBuild = HIWORD(pFixedFileInfo->dwFileVersionLS);
     WORD nQFE = LOWORD(pFixedFileInfo->dwFileVersionLS);
     Wh_Log(L"Windows version (major.minor.build): %d.%d.%d", nMajor, nMinor, nBuild);
-
-    // windows version needed for macros and functions ported from 7+Taskbar to work
-    switch (nMajor)
-    {
-    case 6:
-        switch (nMinor)
-        {
-        case 1:
-            nWinVersion = WIN_VERSION_7;
-            break;
-
-        case 2:
-            nWinVersion = WIN_VERSION_8;
-            break;
-
-        case 3:
-            if (nQFE < 17000)
-                nWinVersion = WIN_VERSION_81;
-            else
-                nWinVersion = WIN_VERSION_811;
-            break;
-
-        case 4:
-            nWinVersion = WIN_VERSION_10_T1;
-            break;
-        }
-        break;
-
-    case 10:
-        if (nBuild <= 10240)
-            nWinVersion = WIN_VERSION_10_T1;
-        else if (nBuild <= 10586)
-            nWinVersion = WIN_VERSION_10_T2;
-        else if (nBuild <= 14393)
-            nWinVersion = WIN_VERSION_10_R1;
-        else if (nBuild <= 15063)
-            nWinVersion = WIN_VERSION_10_R2;
-        else if (nBuild <= 16299)
-            nWinVersion = WIN_VERSION_10_R3;
-        else if (nBuild <= 17134)
-            nWinVersion = WIN_VERSION_10_R4;
-        else if (nBuild <= 17763)
-            nWinVersion = WIN_VERSION_10_R5;
-        else if (nBuild <= 18362)
-            nWinVersion = WIN_VERSION_10_19H1;
-        else if (nBuild <= 19041)
-            nWinVersion = WIN_VERSION_10_20H1;
-        else if (nBuild <= 20348)
-            nWinVersion = WIN_VERSION_SERVER_2022;
-        else if (nBuild <= 22000)
-            nWinVersion = WIN_VERSION_11_21H2;
-        else
-        {
-            nWinVersion = WIN_VERSION_11_22H2;
-        }
-        break;
-    }
 
     if (nMajor == 6)
     {

--- a/mods/taskbar-empty-space-clicks.wh.cpp
+++ b/mods/taskbar-empty-space-clicks.wh.cpp
@@ -29,7 +29,7 @@ This mod lets you assign an action to a mouse click on Windows taskbar. Double-c
 2. **Ctrl+Alt+Tab** - Opens Ctrl+Alt+Tab dialog
 3. **Task Manager** - Opens Windows default task manager
 4. **Mute system volume** - Toggle mute of system volume (all sound)
-5. **Taskbar auto-hide** - Toggle Windows taskbar auto-hide feature 
+5. **Taskbar auto-hide** - Toggle Windows taskbar auto-hide feature
 6. **Win+Tab** - Opens Win+Tab dialog
 7. **Hide desktop icons** - Toggle show/hide of all desktop icons
 
@@ -43,9 +43,9 @@ Following animation shows **Taskbar auto-hide** feature. Feature gets toggled wh
 - Windows 10 22H2 (prior versions are not tested, but should work as well)
 - Windows 11 21H2 - latest major
 
-I will not supporting Insider preview or other minor versions of Windows. However, feel free to [report any issues](https://github.com/m1lhaus/windhawk-mods/issues) related to those versions. I'll appreciate the heads-up in advance.  
+I will not supporting Insider preview or other minor versions of Windows. However, feel free to [report any issues](https://github.com/m1lhaus/windhawk-mods/issues) related to those versions. I'll appreciate the heads-up in advance.
 
-In case you are using old Windows taskbar on Windows 11 (**ExplorerPatcher** or a similar tool), enable corresponding option on Settings menu. This options will be tested only with the latest major version of Windows 11 (e.g. 23H2). 
+In case you are using old Windows taskbar on Windows 11 (**ExplorerPatcher** or a similar tool), enable corresponding option on Settings menu. This options will be tested only with the latest major version of Windows 11 (e.g. 23H2).
 
 */
 // ==/WindhawkModReadme==
@@ -62,7 +62,7 @@ In case you are using old Windows taskbar on Windows 11 (**ExplorerPatcher** or 
   - ACTION_MUTE: Mute system volume
   - ACTION_TASKBAR_AUTOHIDE: Taskbar auto-hide
   - ACTION_WIN_TAB: Win+Tab
-  - ACTION_HIDE_ICONS: Hide desktop icons 
+  - ACTION_HIDE_ICONS: Hide desktop icons
   - ACTION_COMBINE_TASKBAR_BUTTONS: Combine Taskbar buttons
 - middleClickAction: ACTION_NOTHING
   $name: Middle click on empty space
@@ -74,7 +74,7 @@ In case you are using old Windows taskbar on Windows 11 (**ExplorerPatcher** or 
   - ACTION_MUTE: Mute system volume
   - ACTION_TASKBAR_AUTOHIDE: Taskbar auto-hide
   - ACTION_WIN_TAB: Win+Tab
-  - ACTION_HIDE_ICONS: Hide desktop icons 
+  - ACTION_HIDE_ICONS: Hide desktop icons
   - ACTION_COMBINE_TASKBAR_BUTTONS: Combine Taskbar buttons
 - oldTaskbarOnWin11: false
   $name: Use the old taskbar on Windows 11
@@ -190,9 +190,15 @@ typedef void *UIA_HWND;
 //     ProviderOptions_UseClientCoordinates    = 0x100
 // };
 
-enum SupportedTextSelection { SupportedTextSelection_None = 0, SupportedTextSelection_Single = 1, SupportedTextSelection_Multiple = 2 };
+enum SupportedTextSelection
+{
+    SupportedTextSelection_None = 0,
+    SupportedTextSelection_Single = 1,
+    SupportedTextSelection_Multiple = 2
+};
 
-enum TextUnit {
+enum TextUnit
+{
     TextUnit_Character = 0,
     TextUnit_Format = 1,
     TextUnit_Word = 2,
@@ -202,9 +208,14 @@ enum TextUnit {
     TextUnit_Document = 6
 };
 
-enum TextPatternRangeEndpoint { TextPatternRangeEndpoint_Start = 0, TextPatternRangeEndpoint_End = 1 };
+enum TextPatternRangeEndpoint
+{
+    TextPatternRangeEndpoint_Start = 0,
+    TextPatternRangeEndpoint_End = 1
+};
 
-enum TextDecorationLineStyle {
+enum TextDecorationLineStyle
+{
     TextDecorationLineStyle_None = 0,
     TextDecorationLineStyle_Single = 1,
     TextDecorationLineStyle_WordsOnly = 2,
@@ -226,13 +237,29 @@ enum TextDecorationLineStyle {
     TextDecorationLineStyle_Other = -1
 };
 
-enum CaretPosition { CaretPosition_Unknown = 0, CaretPosition_EndOfLine = 1, CaretPosition_BeginningOfLine = 2 };
+enum CaretPosition
+{
+    CaretPosition_Unknown = 0,
+    CaretPosition_EndOfLine = 1,
+    CaretPosition_BeginningOfLine = 2
+};
 
-enum ToggleState { ToggleState_Off = 0, ToggleState_On = 1, ToggleState_Indeterminate = 2 };
+enum ToggleState
+{
+    ToggleState_Off = 0,
+    ToggleState_On = 1,
+    ToggleState_Indeterminate = 2
+};
 
-enum RowOrColumnMajor { RowOrColumnMajor_RowMajor = 0, RowOrColumnMajor_ColumnMajor = 1, RowOrColumnMajor_Indeterminate = 2 };
+enum RowOrColumnMajor
+{
+    RowOrColumnMajor_RowMajor = 0,
+    RowOrColumnMajor_ColumnMajor = 1,
+    RowOrColumnMajor_Indeterminate = 2
+};
 
-enum TreeScope {
+enum TreeScope
+{
     TreeScope_None = 0,
     TreeScope_Element = 0x1,
     TreeScope_Children = 0x2,
@@ -242,13 +269,28 @@ enum TreeScope {
     TreeScope_Subtree = TreeScope_Element | TreeScope_Children | TreeScope_Descendants
 };
 
-enum OrientationType { OrientationType_None = 0, OrientationType_Horizontal = 1, OrientationType_Vertical = 2 };
+enum OrientationType
+{
+    OrientationType_None = 0,
+    OrientationType_Horizontal = 1,
+    OrientationType_Vertical = 2
+};
 
-enum PropertyConditionFlags { PropertyConditionFlags_None = 0, PropertyConditionFlags_IgnoreCase = 1 };
+enum PropertyConditionFlags
+{
+    PropertyConditionFlags_None = 0,
+    PropertyConditionFlags_IgnoreCase = 1
+};
 
-enum WindowVisualState { WindowVisualState_Normal = 0, WindowVisualState_Maximized = 1, WindowVisualState_Minimized = 2 };
+enum WindowVisualState
+{
+    WindowVisualState_Normal = 0,
+    WindowVisualState_Maximized = 1,
+    WindowVisualState_Minimized = 2
+};
 
-enum WindowInteractionState {
+enum WindowInteractionState
+{
     WindowInteractionState_Running = 0,
     WindowInteractionState_Closing = 1,
     WindowInteractionState_ReadyForUserInteraction = 2,
@@ -256,7 +298,8 @@ enum WindowInteractionState {
     WindowInteractionState_NotResponding = 4
 };
 
-enum ExpandCollapseState {
+enum ExpandCollapseState
+{
     ExpandCollapseState_Collapsed = 0,
     ExpandCollapseState_Expanded = 1,
     ExpandCollapseState_PartiallyExpanded = 2,
@@ -270,7 +313,8 @@ enum ExpandCollapseState {
 //     double height;
 // };
 
-struct UiaPoint {
+struct UiaPoint
+{
     double x;
     double y;
 };
@@ -318,8 +362,9 @@ struct IAccessible;
 #define __IUIAutomationElement_INTERFACE_DEFINED__
 DEFINE_GUID(IID_IUIAutomationElement, 0xd22108aa, 0x8ac5, 0x49a5, 0x83, 0x7b, 0x37, 0xbb, 0xb3, 0xd7, 0x59, 0x1e);
 MIDL_INTERFACE("d22108aa-8ac5-49a5-837b-37bbb3d7591e")
-IUIAutomationElement : public IUnknown {
-  public:
+IUIAutomationElement : public IUnknown
+{
+public:
     virtual HRESULT STDMETHODCALLTYPE SetFocus() = 0;
     virtual HRESULT STDMETHODCALLTYPE GetRuntimeId(__RPC__deref_out_opt SAFEARRAY * *runtimeId) = 0;
     virtual HRESULT STDMETHODCALLTYPE FindFirst(enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
@@ -419,8 +464,9 @@ __CRT_UUID_DECL(IUIAutomationElement, 0xd22108aa, 0x8ac5, 0x49a5, 0x83, 0x7b, 0x
 #define __IUIAutomation_INTERFACE_DEFINED__
 DEFINE_GUID(IID_IUIAutomation, 0x30cbe57d, 0xd9d0, 0x452a, 0xab, 0x13, 0x7a, 0xc5, 0xac, 0x48, 0x25, 0xee);
 MIDL_INTERFACE("30cbe57d-d9d0-452a-ab13-7ac5ac4825ee")
-IUIAutomation : public IUnknown {
-  public:
+IUIAutomation : public IUnknown
+{
+public:
     virtual HRESULT STDMETHODCALLTYPE CompareElements(__RPC__in_opt IUIAutomationElement * el1, __RPC__in_opt IUIAutomationElement * el2,
                                                       __RPC__out BOOL * areSame) = 0;
     virtual HRESULT STDMETHODCALLTYPE CompareRuntimeIds(__RPC__in SAFEARRAY * runtimeId1, __RPC__in SAFEARRAY * runtimeId2,
@@ -530,8 +576,9 @@ __CRT_UUID_DECL(IUIAutomation, 0x30cbe57d, 0xd9d0, 0x452a, 0xab, 0x13, 0x7a, 0xc
 #define __IUIAutomationTreeWalker_INTERFACE_DEFINED__
 DEFINE_GUID(IID_IUIAutomationTreeWalker, 0x4042c624, 0x389c, 0x4afc, 0xa6, 0x30, 0x9d, 0xf8, 0x54, 0xa5, 0x41, 0xfc);
 MIDL_INTERFACE("4042c624-389c-4afc-a630-9df854a541fc")
-IUIAutomationTreeWalker : public IUnknown {
-  public:
+IUIAutomationTreeWalker : public IUnknown
+{
+public:
     virtual HRESULT STDMETHODCALLTYPE GetParentElement(__RPC__in_opt IUIAutomationElement * element,
                                                        __RPC__deref_out_opt IUIAutomationElement * *parent) = 0;
     virtual HRESULT STDMETHODCALLTYPE GetFirstChildElement(__RPC__in_opt IUIAutomationElement * element,
@@ -579,13 +626,15 @@ typedef class CUIAutomation CUIAutomation;
 
 // =====================================================================
 
-enum TaskBarVersion { 
-    WIN_10_TASKBAR = 0, 
-    WIN_11_TASKBAR, 
-    UNKNOWN_TASKBAR 
+enum TaskBarVersion
+{
+    WIN_10_TASKBAR = 0,
+    WIN_11_TASKBAR,
+    UNKNOWN_TASKBAR
 };
 
-enum TaskBarAction {
+enum TaskBarAction
+{
     ACTION_NOTHING = 0,
     ACTION_SHOW_DESKTOP,
     ACTION_ALT_TAB,
@@ -597,13 +646,15 @@ enum TaskBarAction {
     ACTION_COMBINE_TASKBAR_BUTTONS
 };
 
-enum TaskBarButtonsState {
+enum TaskBarButtonsState
+{
     COMBINE_ALWAYS = 0,
     COMBINE_WHEN_FULL,
     COMBINE_NEVER,
 };
 
-static struct {
+static struct
+{
     bool oldTaskbarOnWin11;
     TaskBarAction doubleClickTaskbarAction;
     TaskBarAction middleClickTaskbarAction;
@@ -612,26 +663,32 @@ static struct {
 } g_settings;
 
 // wrapper to always call COM de-initialization
-class COMInitializer {
-  public:
+class COMInitializer
+{
+public:
     COMInitializer() : initialized(false) {}
 
-    bool Init() {
-        if (!initialized) {
+    bool Init()
+    {
+        if (!initialized)
+        {
             initialized = SUCCEEDED(CoInitializeEx(NULL, COINIT_MULTITHREADED));
         }
         return initialized;
     }
 
-    void Uninit() {
-        if (initialized) {
+    void Uninit()
+    {
+        if (initialized)
+        {
             CoUninitialize();
             initialized = false;
             Wh_Log(L"COM de-initialized");
         }
     }
 
-    ~COMInitializer() {
+    ~COMInitializer()
+    {
         Uninit();
     }
 
@@ -655,7 +712,6 @@ static HWND g_hDesktopWnd;
 static com_ptr<IUIAutomation> g_pUIAutomation;
 static com_ptr<IMMDeviceEnumerator> g_pDeviceEnumerator;
 
-
 // since the mod can't be split to multiple files, the definition order becomes somehow complicated
 bool IsTaskbarWindow(HWND hWnd);
 bool isMouseDoubleClick(LPARAM lParam);
@@ -667,10 +723,12 @@ bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam, TaskBarAction taskbar
 
 // wParam - TRUE to subclass, FALSE to unsubclass
 // lParam - subclass data
-UINT g_subclassRegisteredMsg = RegisterWindowMessage(L"Windhawk_SetWindowSubclassFromAnyThread_toggle-taskbar-autohide");
+UINT g_subclassRegisteredMsg = RegisterWindowMessage(L"Windhawk_SetWindowSubclassFromAnyThread_empty-space-clicks");
 
-BOOL SetWindowSubclassFromAnyThread(HWND hWnd, SUBCLASSPROC pfnSubclass, UINT_PTR uIdSubclass, DWORD_PTR dwRefData) {
-    struct SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM {
+BOOL SetWindowSubclassFromAnyThread(HWND hWnd, SUBCLASSPROC pfnSubclass, UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
+{
+    struct SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM
+    {
         SUBCLASSPROC pfnSubclass;
         UINT_PTR uIdSubclass;
         DWORD_PTR dwRefData;
@@ -678,20 +736,25 @@ BOOL SetWindowSubclassFromAnyThread(HWND hWnd, SUBCLASSPROC pfnSubclass, UINT_PT
     };
 
     DWORD dwThreadId = GetWindowThreadProcessId(hWnd, nullptr);
-    if (dwThreadId == 0) {
+    if (dwThreadId == 0)
+    {
         return FALSE;
     }
 
-    if (dwThreadId == GetCurrentThreadId()) {
+    if (dwThreadId == GetCurrentThreadId())
+    {
         return SetWindowSubclass(hWnd, pfnSubclass, uIdSubclass, dwRefData);
     }
 
     HHOOK hook = SetWindowsHookEx(
         WH_CALLWNDPROC,
-        [](int nCode, WPARAM wParam, LPARAM lParam) WINAPI_LAMBDA_RETURN(LRESULT) {
-            if (nCode == HC_ACTION) {
+        [](int nCode, WPARAM wParam, LPARAM lParam) WINAPI_LAMBDA_RETURN(LRESULT)
+        {
+            if (nCode == HC_ACTION)
+            {
                 const CWPSTRUCT *cwp = (const CWPSTRUCT *)lParam;
-                if (cwp->message == g_subclassRegisteredMsg && cwp->wParam) {
+                if (cwp->message == g_subclassRegisteredMsg && cwp->wParam)
+                {
                     SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM *param = (SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM *)cwp->lParam;
                     param->result = SetWindowSubclass(cwp->hwnd, param->pfnSubclass, param->uIdSubclass, param->dwRefData);
                 }
@@ -700,7 +763,8 @@ BOOL SetWindowSubclassFromAnyThread(HWND hWnd, SUBCLASSPROC pfnSubclass, UINT_PT
             return CallNextHookEx(nullptr, nCode, wParam, lParam);
         },
         nullptr, dwThreadId);
-    if (!hook) {
+    if (!hook)
+    {
         return FALSE;
     }
 
@@ -717,31 +781,40 @@ BOOL SetWindowSubclassFromAnyThread(HWND hWnd, SUBCLASSPROC pfnSubclass, UINT_PT
 }
 
 // proc handler for older Windows (nonXAML taskbar) versions
-LRESULT CALLBACK TaskbarWindowSubclassProc(_In_ HWND hWnd, _In_ UINT uMsg, _In_ WPARAM wParam, _In_ LPARAM lParam, 
-                                           _In_ UINT_PTR uIdSubclass, _In_ DWORD_PTR dwRefData) {
-    if (uMsg == WM_NCDESTROY || (uMsg == g_subclassRegisteredMsg && !wParam)) {
+LRESULT CALLBACK TaskbarWindowSubclassProc(_In_ HWND hWnd, _In_ UINT uMsg, _In_ WPARAM wParam, _In_ LPARAM lParam,
+                                           _In_ UINT_PTR uIdSubclass, _In_ DWORD_PTR dwRefData)
+{
+    if (uMsg == WM_NCDESTROY || (uMsg == g_subclassRegisteredMsg && !wParam))
+    {
         RemoveWindowSubclass(hWnd, TaskbarWindowSubclassProc, 0);
     }
 
     // Wh_Log(L"Message: 0x%x", uMsg);
 
     LRESULT result = 0;
-    switch (uMsg) {
+    switch (uMsg)
+    {
     // catch middle mouse button on both main and secondary taskbars
     case WM_NCMBUTTONDOWN:
     case WM_MBUTTONDOWN:
-        if ((g_taskbarVersion == WIN_10_TASKBAR) && OnMouseClick(hWnd, wParam, lParam, g_settings.middleClickTaskbarAction)) {
+        if ((g_taskbarVersion == WIN_10_TASKBAR) && OnMouseClick(hWnd, wParam, lParam, g_settings.middleClickTaskbarAction))
+        {
             result = 0;
-        } else {
+        }
+        else
+        {
             result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
         }
         break;
 
     case WM_LBUTTONDBLCLK:
     case WM_NCLBUTTONDBLCLK:
-        if ((g_taskbarVersion == WIN_10_TASKBAR) && OnMouseClick(hWnd, wParam, lParam, g_settings.doubleClickTaskbarAction)) {
+        if ((g_taskbarVersion == WIN_10_TASKBAR) && OnMouseClick(hWnd, wParam, lParam, g_settings.doubleClickTaskbarAction))
+        {
             result = 0;
-        } else {
+        }
+        else
+        {
             result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
         }
         break;
@@ -749,7 +822,8 @@ LRESULT CALLBACK TaskbarWindowSubclassProc(_In_ HWND hWnd, _In_ UINT uMsg, _In_ 
     case WM_NCDESTROY:
         result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
 
-        if (hWnd != g_hTaskbarWnd) {
+        if (hWnd != g_hTaskbarWnd)
+        {
             g_secondaryTaskbarWindows.erase(hWnd);
         }
         break;
@@ -764,22 +838,31 @@ LRESULT CALLBACK TaskbarWindowSubclassProc(_In_ HWND hWnd, _In_ UINT uMsg, _In_ 
 
 // proc handler for newer Windows versions (Windows 11 21H2 and newer)
 WNDPROC InputSiteWindowProc_Original;
-LRESULT CALLBACK InputSiteWindowProc_Hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
+LRESULT CALLBACK InputSiteWindowProc_Hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
     // Wh_Log(L"Message: 0x%x", uMsg);
 
-    switch (uMsg) {
+    switch (uMsg)
+    {
     case WM_POINTERDOWN:
         HWND hRootWnd = GetAncestor(hWnd, GA_ROOT);
-        if (IsTaskbarWindow(hRootWnd)) {
+        if (IsTaskbarWindow(hRootWnd))
+        {
             TaskBarAction action;
-            if (IS_POINTER_THIRDBUTTON_WPARAM(wParam)) {
+            if (IS_POINTER_THIRDBUTTON_WPARAM(wParam))
+            {
                 action = g_settings.middleClickTaskbarAction;
-            } else if (IS_POINTER_FIRSTBUTTON_WPARAM(wParam) && isMouseDoubleClick(lParam)) {
+            }
+            else if (IS_POINTER_FIRSTBUTTON_WPARAM(wParam) && isMouseDoubleClick(lParam))
+            {
                 action = g_settings.doubleClickTaskbarAction;
-            } else {
+            }
+            else
+            {
                 action = ACTION_NOTHING;
             }
-            if(OnMouseClick(hRootWnd, wParam, lParam, action)) {
+            if (OnMouseClick(hRootWnd, wParam, lParam, action))
+            {
                 return 0;
             }
         }
@@ -789,28 +872,34 @@ LRESULT CALLBACK InputSiteWindowProc_Hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
     return InputSiteWindowProc_Original(hWnd, uMsg, wParam, lParam);
 }
 
-void SubclassTaskbarWindow(HWND hWnd) { 
-    SetWindowSubclassFromAnyThread(hWnd, TaskbarWindowSubclassProc, 0, 0); 
+void SubclassTaskbarWindow(HWND hWnd)
+{
+    SetWindowSubclassFromAnyThread(hWnd, TaskbarWindowSubclassProc, 0, 0);
 }
 
-void UnsubclassTaskbarWindow(HWND hWnd) { 
-    SendMessage(hWnd, g_subclassRegisteredMsg, FALSE, 0); 
+void UnsubclassTaskbarWindow(HWND hWnd)
+{
+    SendMessage(hWnd, g_subclassRegisteredMsg, FALSE, 0);
 }
 
-void HandleIdentifiedInputSiteWindow(HWND hWnd) {
-    if (!g_dwTaskbarThreadId || GetWindowThreadProcessId(hWnd, nullptr) != g_dwTaskbarThreadId) {
+void HandleIdentifiedInputSiteWindow(HWND hWnd)
+{
+    if (!g_dwTaskbarThreadId || GetWindowThreadProcessId(hWnd, nullptr) != g_dwTaskbarThreadId)
+    {
         return;
     }
 
     HWND hParentWnd = GetParent(hWnd);
     WCHAR szClassName[64];
     if (!hParentWnd || !GetClassName(hParentWnd, szClassName, ARRAYSIZE(szClassName)) ||
-        _wcsicmp(szClassName, L"Windows.UI.Composition.DesktopWindowContentBridge") != 0) {
+        _wcsicmp(szClassName, L"Windows.UI.Composition.DesktopWindowContentBridge") != 0)
+    {
         return;
     }
 
     hParentWnd = GetParent(hParentWnd);
-    if (!hParentWnd || !IsTaskbarWindow(hParentWnd)) {
+    if (!hParentWnd || !IsTaskbarWindow(hParentWnd))
+    {
         return;
     }
 
@@ -820,7 +909,8 @@ void HandleIdentifiedInputSiteWindow(HWND hWnd) {
     void *wndProc = (void *)GetWindowLongPtr(hWnd, GWLP_WNDPROC);
     Wh_SetFunctionHook(wndProc, (void *)InputSiteWindowProc_Hook, (void **)&InputSiteWindowProc_Original);
 
-    if (g_initialized) {
+    if (g_initialized)
+    {
         Wh_ApplyHookOperations();
     }
 
@@ -828,38 +918,48 @@ void HandleIdentifiedInputSiteWindow(HWND hWnd) {
     g_inputSiteProcHooked = true;
 }
 
-void HandleIdentifiedTaskbarWindow(HWND hWnd) {
+void HandleIdentifiedTaskbarWindow(HWND hWnd)
+{
     g_hTaskbarWnd = hWnd;
     g_dwTaskbarThreadId = GetWindowThreadProcessId(hWnd, nullptr);
     SubclassTaskbarWindow(hWnd);
-    for (HWND hSecondaryWnd : g_secondaryTaskbarWindows) {
+    for (HWND hSecondaryWnd : g_secondaryTaskbarWindows)
+    {
         SubclassTaskbarWindow(hSecondaryWnd);
     }
 
-    if ((g_taskbarVersion == WIN_11_TASKBAR) && !g_inputSiteProcHooked) {
+    if ((g_taskbarVersion == WIN_11_TASKBAR) && !g_inputSiteProcHooked)
+    {
         HWND hXamlIslandWnd = FindWindowEx(hWnd, nullptr, L"Windows.UI.Composition.DesktopWindowContentBridge", nullptr);
-        if (hXamlIslandWnd) {
+        if (hXamlIslandWnd)
+        {
             HWND hInputSiteWnd = FindWindowEx(hXamlIslandWnd, nullptr, L"Windows.UI.Input.InputSite.WindowClass", nullptr);
-            if (hInputSiteWnd) {
+            if (hInputSiteWnd)
+            {
                 HandleIdentifiedInputSiteWindow(hInputSiteWnd);
             }
         }
     }
 }
 
-void HandleIdentifiedSecondaryTaskbarWindow(HWND hWnd) {
-    if (!g_dwTaskbarThreadId || GetWindowThreadProcessId(hWnd, nullptr) != g_dwTaskbarThreadId) {
+void HandleIdentifiedSecondaryTaskbarWindow(HWND hWnd)
+{
+    if (!g_dwTaskbarThreadId || GetWindowThreadProcessId(hWnd, nullptr) != g_dwTaskbarThreadId)
+    {
         return;
     }
 
     g_secondaryTaskbarWindows.insert(hWnd);
     SubclassTaskbarWindow(hWnd);
 
-    if ((g_taskbarVersion == WIN_11_TASKBAR) && !g_inputSiteProcHooked) {
+    if ((g_taskbarVersion == WIN_11_TASKBAR) && !g_inputSiteProcHooked)
+    {
         HWND hXamlIslandWnd = FindWindowEx(hWnd, nullptr, L"Windows.UI.Composition.DesktopWindowContentBridge", nullptr);
-        if (hXamlIslandWnd) {
+        if (hXamlIslandWnd)
+        {
             HWND hInputSiteWnd = FindWindowEx(hXamlIslandWnd, nullptr, L"Windows.UI.Input.InputSite.WindowClass", nullptr);
-            if (hInputSiteWnd) {
+            if (hInputSiteWnd)
+            {
                 HandleIdentifiedInputSiteWindow(hInputSiteWnd);
             }
         }
@@ -869,8 +969,10 @@ void HandleIdentifiedSecondaryTaskbarWindow(HWND hWnd) {
 // finds main task bar and returns its hWnd,
 // optinally it finds also secondary taskbars and fills them to the set
 // secondaryTaskbarWindows
-HWND FindCurrentProcessTaskbarWindows(std::unordered_set<HWND> *secondaryTaskbarWindows) {
-    struct ENUM_WINDOWS_PARAM {
+HWND FindCurrentProcessTaskbarWindows(std::unordered_set<HWND> *secondaryTaskbarWindows)
+{
+    struct ENUM_WINDOWS_PARAM
+    {
         HWND *hWnd;
         std::unordered_set<HWND> *secondaryTaskbarWindows;
     };
@@ -878,7 +980,8 @@ HWND FindCurrentProcessTaskbarWindows(std::unordered_set<HWND> *secondaryTaskbar
     HWND hWnd = nullptr;
     ENUM_WINDOWS_PARAM param = {&hWnd, secondaryTaskbarWindows};
     EnumWindows(
-        [](HWND hWnd, LPARAM lParam) WINAPI_LAMBDA_RETURN(BOOL) {
+        [](HWND hWnd, LPARAM lParam) WINAPI_LAMBDA_RETURN(BOOL)
+        {
             ENUM_WINDOWS_PARAM &param = *(ENUM_WINDOWS_PARAM *)lParam;
 
             DWORD dwProcessId = 0;
@@ -889,9 +992,12 @@ HWND FindCurrentProcessTaskbarWindows(std::unordered_set<HWND> *secondaryTaskbar
             if (GetClassName(hWnd, szClassName, ARRAYSIZE(szClassName)) == 0)
                 return TRUE;
 
-            if (_wcsicmp(szClassName, L"Shell_TrayWnd") == 0) {
+            if (_wcsicmp(szClassName, L"Shell_TrayWnd") == 0)
+            {
                 *param.hWnd = hWnd;
-            } else if (_wcsicmp(szClassName, L"Shell_SecondaryTrayWnd") == 0) {
+            }
+            else if (_wcsicmp(szClassName, L"Shell_SecondaryTrayWnd") == 0)
+            {
                 param.secondaryTaskbarWindows->insert(hWnd);
             }
 
@@ -904,19 +1010,24 @@ HWND FindCurrentProcessTaskbarWindows(std::unordered_set<HWND> *secondaryTaskbar
 
 using CreateWindowExW_t = decltype(&CreateWindowExW);
 CreateWindowExW_t CreateWindowExW_Original;
-HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
-                                 HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam) {
-    HWND hWnd = CreateWindowExW_Original(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y,
+                                 int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
+{
+    HWND hWnd = CreateWindowExW_Original(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent,
+                                         hMenu, hInstance, lpParam);
 
     if (!hWnd)
         return hWnd;
 
     BOOL bTextualClassName = ((ULONG_PTR)lpClassName & ~(ULONG_PTR)0xffff) != 0;
 
-    if (bTextualClassName && _wcsicmp(lpClassName, L"Shell_TrayWnd") == 0) {
+    if (bTextualClassName && _wcsicmp(lpClassName, L"Shell_TrayWnd") == 0)
+    {
         Wh_Log(L"Taskbar window created: %08X", (DWORD)(ULONG_PTR)hWnd);
         HandleIdentifiedTaskbarWindow(hWnd);
-    } else if (bTextualClassName && _wcsicmp(lpClassName, L"Shell_SecondaryTrayWnd") == 0) {
+    }
+    else if (bTextualClassName && _wcsicmp(lpClassName, L"Shell_SecondaryTrayWnd") == 0)
+    {
         Wh_Log(L"Secondary taskbar window created: %08X", (DWORD)(ULONG_PTR)hWnd);
         HandleIdentifiedSecondaryTaskbarWindow(hWnd);
     }
@@ -924,21 +1035,26 @@ HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR l
     return hWnd;
 }
 
-using CreateWindowInBand_t = HWND(WINAPI *)(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth,
-                                            int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam, DWORD dwBand);
+using CreateWindowInBand_t = HWND(WINAPI *)(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle,
+                                            int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu,
+                                            HINSTANCE hInstance, LPVOID lpParam, DWORD dwBand);
 CreateWindowInBand_t CreateWindowInBand_Original;
-HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
-                                    HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam, DWORD dwBand) {
-    HWND hWnd = CreateWindowInBand_Original(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance,
-                                            lpParam, dwBand);
+HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y,
+                                    int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance,
+                                    LPVOID lpParam, DWORD dwBand)
+{
+    HWND hWnd = CreateWindowInBand_Original(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent,
+                                            hMenu, hInstance, lpParam, dwBand);
     if (!hWnd)
         return hWnd;
 
     BOOL bTextualClassName = ((ULONG_PTR)lpClassName & ~(ULONG_PTR)0xffff) != 0;
 
-    if (bTextualClassName && _wcsicmp(lpClassName, L"Windows.UI.Input.InputSite.WindowClass") == 0) {
+    if (bTextualClassName && _wcsicmp(lpClassName, L"Windows.UI.Input.InputSite.WindowClass") == 0)
+    {
         Wh_Log(L"InputSite window created: %08X", (DWORD)(ULONG_PTR)hWnd);
-        if ((g_taskbarVersion == WIN_11_TASKBAR) && !g_inputSiteProcHooked) {
+        if ((g_taskbarVersion == WIN_11_TASKBAR) && !g_inputSiteProcHooked)
+        {
             HandleIdentifiedInputSiteWindow(hWnd);
         }
     }
@@ -971,173 +1087,154 @@ HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWST
 
 // helper macros
 #define FIRST_NONEMPTY_ARG_2(a, b) \
-                                   ( (sizeof(#a) > sizeof("")) ? (a+0) : (b) )
+    ((sizeof(#a) > sizeof("")) ? (a + 0) : (b))
 #define FIRST_NONEMPTY_ARG_3(a, b, c) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_2(b, c))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_2(b, c))
 #define FIRST_NONEMPTY_ARG_4(a, b, c, d) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_3(b, c, d))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_3(b, c, d))
 #define FIRST_NONEMPTY_ARG_5(a, b, c, d, e) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_4(b, c, d, e))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_4(b, c, d, e))
 #define FIRST_NONEMPTY_ARG_6(a, b, c, d, e, f) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_5(b, c, d, e, f))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_5(b, c, d, e, f))
 #define FIRST_NONEMPTY_ARG_7(a, b, c, d, e, f, g) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_6(b, c, d, e, f, g))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_6(b, c, d, e, f, g))
 #define FIRST_NONEMPTY_ARG_8(a, b, c, d, e, f, g, h) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_7(b, c, d, e, f, g, h))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_7(b, c, d, e, f, g, h))
 #define FIRST_NONEMPTY_ARG_9(a, b, c, d, e, f, g, h, i) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_8(b, c, d, e, f, g, h, i))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_8(b, c, d, e, f, g, h, i))
 #define FIRST_NONEMPTY_ARG_10(a, b, c, d, e, f, g, h, i, j) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_9(b, c, d, e, f, g, h, i, j))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_9(b, c, d, e, f, g, h, i, j))
 #define FIRST_NONEMPTY_ARG_11(a, b, c, d, e, f, g, h, i, j, k) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_10(b, c, d, e, f, g,  h, i, j, k))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_10(b, c, d, e, f, g, h, i, j, k))
 #define FIRST_NONEMPTY_ARG_12(a, b, c, d, e, f, g, h, i, j, k, l) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_11(b, c, d, e, f, g, h, i, j, k, l))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_11(b, c, d, e, f, g, h, i, j, k, l))
 #define FIRST_NONEMPTY_ARG_13(a, b, c, d, e, f, g, h, i, j, k, l, m) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_12(b, c, d, e, f, g, h, i, j, k, l, m))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_12(b, c, d, e, f, g, h, i, j, k, l, m))
 #define FIRST_NONEMPTY_ARG_14(a, b, c, d, e, f, g, h, i, j, k, l, m, n) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_13(b, c, d, e, f, g, h, i, j, k, l, m, n))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_13(b, c, d, e, f, g, h, i, j, k, l, m, n))
 #define FIRST_NONEMPTY_ARG_15(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_14(b, c, d, e, f, g, h, i, j, k, l, m, n, o))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_14(b, c, d, e, f, g, h, i, j, k, l, m, n, o))
 #define FIRST_NONEMPTY_ARG_16(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_15(b, c, d, e, f, g, h, i, j, k, l, m, n, o, p))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_15(b, c, d, e, f, g, h, i, j, k, l, m, n, o, p))
 #define FIRST_NONEMPTY_ARG_17(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) \
-                                   FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_16(b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q))
+    FIRST_NONEMPTY_ARG_2(a, FIRST_NONEMPTY_ARG_16(b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q))
 
-#define DO2(d7, dx)                ( (nWinVersion > WIN_VERSION_7) ? FIRST_NONEMPTY_ARG_2(dx, d7) : (d7) )
-#define DO3(d7, d8, dx)            ( (nWinVersion > WIN_VERSION_8) ? FIRST_NONEMPTY_ARG_3(dx, d8, d7) : DO2(d7, d8) )
-#define DO4(d7, d8, d81, dx)       ( (nWinVersion > WIN_VERSION_81) ? FIRST_NONEMPTY_ARG_4(dx, d81, d8, d7) : DO3(d7, d8, d81) )
-#define DO5(d7, d8, d81, d811, dx) ( (nWinVersion > WIN_VERSION_811) ? FIRST_NONEMPTY_ARG_5(dx, d811, d81, d8, d7) : DO4(d7, d8, d81, d811) )
+#define DO2(d7, dx) ((nWinVersion > WIN_VERSION_7) ? FIRST_NONEMPTY_ARG_2(dx, d7) : (d7))
+#define DO3(d7, d8, dx) ((nWinVersion > WIN_VERSION_8) ? FIRST_NONEMPTY_ARG_3(dx, d8, d7) : DO2(d7, d8))
+#define DO4(d7, d8, d81, dx) ((nWinVersion > WIN_VERSION_81) ? FIRST_NONEMPTY_ARG_4(dx, d81, d8, d7) : DO3(d7, d8, d81))
+#define DO5(d7, d8, d81, d811, dx) ((nWinVersion > WIN_VERSION_811) ? FIRST_NONEMPTY_ARG_5(dx, d811, d81, d8, d7) : DO4(d7, d8, d81, d811))
 #define DO6(d7, d8, d81, d811, d10_t1, dx) \
-                                   ( (nWinVersion > WIN_VERSION_10_T1) ? \
-                                     FIRST_NONEMPTY_ARG_6(dx, d10_t1, d811, d81, d8, d7) : \
-                                     DO5(d7, d8, d81, d811, d10_t1) )
+    ((nWinVersion > WIN_VERSION_10_T1) ? FIRST_NONEMPTY_ARG_6(dx, d10_t1, d811, d81, d8, d7) : DO5(d7, d8, d81, d811, d10_t1))
 #define DO7(d7, d8, d81, d811, d10_t1, d10_t2, dx) \
-                                   ( (nWinVersion > WIN_VERSION_10_T2) ? \
-                                     FIRST_NONEMPTY_ARG_7(dx, d10_t2, d10_t1, d811, d81, d8, d7) : \
-                                     DO6(d7, d8, d81, d811, d10_t1, d10_t2) )
+    ((nWinVersion > WIN_VERSION_10_T2) ? FIRST_NONEMPTY_ARG_7(dx, d10_t2, d10_t1, d811, d81, d8, d7) : DO6(d7, d8, d81, d811, d10_t1, d10_t2))
 #define DO8(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, dx) \
-                                   ( (nWinVersion > WIN_VERSION_10_R1) ? \
-                                     FIRST_NONEMPTY_ARG_8(dx, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : \
-                                     DO7(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1) )
+    ((nWinVersion > WIN_VERSION_10_R1) ? FIRST_NONEMPTY_ARG_8(dx, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO7(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1))
 #define DO9(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, dx) \
-                                   ( (nWinVersion > WIN_VERSION_10_R2) ? \
-                                     FIRST_NONEMPTY_ARG_9(dx, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : \
-                                     DO8(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2) )
+    ((nWinVersion > WIN_VERSION_10_R2) ? FIRST_NONEMPTY_ARG_9(dx, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO8(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2))
 #define DO10(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, dx) \
-                                   ( (nWinVersion > WIN_VERSION_10_R3) ? \
-                                     FIRST_NONEMPTY_ARG_10(dx, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : \
-                                     DO9(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3) )
+    ((nWinVersion > WIN_VERSION_10_R3) ? FIRST_NONEMPTY_ARG_10(dx, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO9(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3))
 #define DO11(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, dx) \
-                                   ( (nWinVersion > WIN_VERSION_10_R4) ? \
-                                     FIRST_NONEMPTY_ARG_11(dx, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : \
-                                     DO10(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4) )
+    ((nWinVersion > WIN_VERSION_10_R4) ? FIRST_NONEMPTY_ARG_11(dx, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO10(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4))
 #define DO12(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, dx) \
-                                   ( (nWinVersion > WIN_VERSION_10_R5) ? \
-                                     FIRST_NONEMPTY_ARG_12(dx, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : \
-                                     DO11(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5) )
+    ((nWinVersion > WIN_VERSION_10_R5) ? FIRST_NONEMPTY_ARG_12(dx, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO11(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5))
 #define DO13(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, dx) \
-                                   ( (nWinVersion > WIN_VERSION_10_19H1) ? \
-                                     FIRST_NONEMPTY_ARG_13(dx, d10_19h1, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : \
-                                     DO12(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1) )
+    ((nWinVersion > WIN_VERSION_10_19H1) ? FIRST_NONEMPTY_ARG_13(dx, d10_19h1, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO12(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1))
 #define DO14(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, dx) \
-                                   ( (nWinVersion > WIN_VERSION_10_20H1) ? \
-                                     FIRST_NONEMPTY_ARG_14(dx, d10_20h1, d10_19h1, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : \
-                                     DO13(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1) )
+    ((nWinVersion > WIN_VERSION_10_20H1) ? FIRST_NONEMPTY_ARG_14(dx, d10_20h1, d10_19h1, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO13(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1))
 #define DO15(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022, dx) \
-                                   ( (nWinVersion > WIN_VERSION_SERVER_2022) ? \
-                                     FIRST_NONEMPTY_ARG_15(dx, ds_2022, d10_20h1, d10_19h1, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : \
-                                     DO14(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022) )
+    ((nWinVersion > WIN_VERSION_SERVER_2022) ? FIRST_NONEMPTY_ARG_15(dx, ds_2022, d10_20h1, d10_19h1, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO14(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022))
 #define DO16(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022, d11_21h2, dx) \
-                                   ( (nWinVersion > WIN_VERSION_11_21H2) ? \
-                                     FIRST_NONEMPTY_ARG_16(dx, d11_21h2, ds_2022, d10_20h1, d10_19h1, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : \
-                                     DO15(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022, d11_21h2) )
+    ((nWinVersion > WIN_VERSION_11_21H2) ? FIRST_NONEMPTY_ARG_16(dx, d11_21h2, ds_2022, d10_20h1, d10_19h1, d10_r5, d10_r4, d10_r3, d10_r2, d10_r1, d10_t2, d10_t1, d811, d81, d8, d7) : DO15(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022, d11_21h2))
 #define DO17(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022, d11_21h2, d11_22h2, dx) \
-                                   DO16(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022, d11_21h2, d11_22h2)
+    DO16(d7, d8, d81, d811, d10_t1, d10_t2, d10_r1, d10_r2, d10_r3, d10_r4, d10_r5, d10_19h1, d10_20h1, ds_2022, d11_21h2, d11_22h2)
 
 #ifdef _WIN64
-#define DEF3264(d32, d64)          (d64)
+#define DEF3264(d32, d64) (d64)
 #else
-#define DEF3264(d32, d64)          (d32)
+#define DEF3264(d32, d64) (d32)
 #endif
 
 #define DO2_3264(d7_32, d7_64, dx_32, dx_64) \
-                                   DEF3264(DO2(d7_32, dx_32), \
-                                           DO2(d7_64, dx_64))
+    DEF3264(DO2(d7_32, dx_32),               \
+            DO2(d7_64, dx_64))
 
 #define DO3_3264(d7_32, d7_64, d8_32, d8_64, dx_32, dx_64) \
-                                   DEF3264(DO3(d7_32, d8_32, dx_32), \
-                                           DO3(d7_64, d8_64, dx_64))
+    DEF3264(DO3(d7_32, d8_32, dx_32),                      \
+            DO3(d7_64, d8_64, dx_64))
 
 #define DO4_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, dx_32, dx_64) \
-                                   DEF3264(DO4(d7_32, d8_32, d81_32, dx_32), \
-                                           DO4(d7_64, d8_64, d81_64, dx_64))
+    DEF3264(DO4(d7_32, d8_32, d81_32, dx_32),                              \
+            DO4(d7_64, d8_64, d81_64, dx_64))
 
 #define DO5_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, dx_32, dx_64) \
-                                   DEF3264(DO5(d7_32, d8_32, d81_32, d811_32, dx_32), \
-                                           DO5(d7_64, d8_64, d81_64, d811_64, dx_64))
+    DEF3264(DO5(d7_32, d8_32, d81_32, d811_32, dx_32),                                       \
+            DO5(d7_64, d8_64, d81_64, d811_64, dx_64))
 
 #define DO6_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, dx_32, dx_64) \
-                                   DEF3264(DO6(d7_32, d8_32, d81_32, d811_32, d10_t1_32, dx_32), \
-                                           DO6(d7_64, d8_64, d81_64, d811_64, d10_t1_64, dx_64))
+    DEF3264(DO6(d7_32, d8_32, d81_32, d811_32, d10_t1_32, dx_32),                                                  \
+            DO6(d7_64, d8_64, d81_64, d811_64, d10_t1_64, dx_64))
 
 #define DO7_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, dx_32, dx_64) \
-                                   DEF3264(DO7(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, dx_32), \
-                                           DO7(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, dx_64))
+    DEF3264(DO7(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, dx_32),                                                             \
+            DO7(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, dx_64))
 
 #define DO8_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, dx_32, dx_64) \
-                                   DEF3264(DO8(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, dx_32), \
-                                           DO8(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, dx_64))
+    DEF3264(DO8(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, dx_32),                                                                        \
+            DO8(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, dx_64))
 
 #define DO9_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, dx_32, dx_64) \
-                                   DEF3264(DO9(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, dx_32), \
-                                           DO9(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, dx_64))
+    DEF3264(DO9(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, dx_32),                                                                                   \
+            DO9(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, dx_64))
 
 #define DO10_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, dx_32, dx_64) \
-                                   DEF3264(DO10(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, dx_32), \
-                                           DO10(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, dx_64))
+    DEF3264(DO10(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, dx_32),                                                                                              \
+            DO10(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, dx_64))
 
 #define DO11_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, dx_32, dx_64) \
-                                   DEF3264(DO11(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, dx_32), \
-                                           DO11(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, dx_64))
+    DEF3264(DO11(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, dx_32),                                                                                                         \
+            DO11(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, dx_64))
 
 #define DO12_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, d10_r5_32, d10_r5_64, dx_32, dx_64) \
-                                   DEF3264(DO12(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, dx_32), \
-                                           DO12(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, dx_64))
+    DEF3264(DO12(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, dx_32),                                                                                                                    \
+            DO12(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, dx_64))
 
 #define DO13_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, d10_r5_32, d10_r5_64, d10_19h1_32, d10_19h1_64, dx_32, dx_64) \
-                                   DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, dx_32), \
-                                           DO13(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, dx_64))
+    DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, dx_32),                                                                                                                                 \
+            DO13(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, dx_64))
 
 #define DO14_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, d10_r5_32, d10_r5_64, d10_19h1_32, d10_19h1_64, d10_20h1_32, d10_20h1_64, dx_64) \
-                                   DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, d10_20h1_32), \
-                                           DO14(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, d10_20h1_64, dx_64))
+    DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, d10_20h1_32),                                                                                                                                              \
+            DO14(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, d10_20h1_64, dx_64))
 
 #define DO15_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, d10_r5_32, d10_r5_64, d10_19h1_32, d10_19h1_64, d10_20h1_32, d10_20h1_64, ds_2022_64, dx_64) \
-                                   DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, d10_20h1_32), \
-                                           DO15(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, d10_20h1_64, ds_2022_64, dx_64))
+    DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, d10_20h1_32),                                                                                                                                                          \
+            DO15(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, d10_20h1_64, ds_2022_64, dx_64))
 
 #define DO16_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, d10_r5_32, d10_r5_64, d10_19h1_32, d10_19h1_64, d10_20h1_32, d10_20h1_64, ds_2022_64, d11_21h2_64, dx_64) \
-                                   DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, d10_20h1_32), \
-                                           DO16(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, d10_20h1_64, ds_2022_64, d11_21h2_64, dx_64))
+    DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, d10_20h1_32),                                                                                                                                                                       \
+            DO16(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, d10_20h1_64, ds_2022_64, d11_21h2_64, dx_64))
 
 #define DO17_3264(d7_32, d7_64, d8_32, d8_64, d81_32, d81_64, d811_32, d811_64, d10_t1_32, d10_t1_64, d10_t2_32, d10_t2_64, d10_r1_32, d10_r1_64, d10_r2_32, d10_r2_64, d10_r3_32, d10_r3_64, d10_r4_32, d10_r4_64, d10_r5_32, d10_r5_64, d10_19h1_32, d10_19h1_64, d10_20h1_32, d10_20h1_64, ds_2022_64, d11_21h2_64, d11_22h2_64, dx_64) \
-                                   DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, d10_20h1_32), \
-                                           DO17(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, d10_20h1_64, ds_2022_64, d11_21h2_64, d11_22h2_64, dx_64))
+    DEF3264(DO13(d7_32, d8_32, d81_32, d811_32, d10_t1_32, d10_t2_32, d10_r1_32, d10_r2_32, d10_r3_32, d10_r4_32, d10_r5_32, d10_19h1_32, d10_20h1_32),                                                                                                                                                                                    \
+            DO17(d7_64, d8_64, d81_64, d811_64, d10_t1_64, d10_t2_64, d10_r1_64, d10_r2_64, d10_r3_64, d10_r4_64, d10_r5_64, d10_19h1_64, d10_20h1_64, ds_2022_64, d11_21h2_64, d11_22h2_64, dx_64))
 
 #pragma endregion
 
 #pragma region functions
 
-bool IsTaskbarWindow(HWND hWnd) {
+bool IsTaskbarWindow(HWND hWnd)
+{
     WCHAR szClassName[32];
-    if (!GetClassName(hWnd, szClassName, ARRAYSIZE(szClassName))) {
+    if (!GetClassName(hWnd, szClassName, ARRAYSIZE(szClassName)))
+    {
         return false;
     }
 
     return _wcsicmp(szClassName, L"Shell_TrayWnd") == 0 || _wcsicmp(szClassName, L"Shell_SecondaryTrayWnd") == 0;
 }
 
-bool isMouseDoubleClick(LPARAM lParam) {
+bool isMouseDoubleClick(LPARAM lParam)
+{
     static DWORD lastPointerDownTime = 0;
     static POINT lastPointerDownLocation = {0, 0};
 
@@ -1162,7 +1259,8 @@ bool isMouseDoubleClick(LPARAM lParam) {
     return result;
 }
 
-VS_FIXEDFILEINFO *GetModuleVersionInfo(HMODULE hModule, UINT *puPtrLen) {
+VS_FIXEDFILEINFO *GetModuleVersionInfo(HMODULE hModule, UINT *puPtrLen)
+{
     HRSRC hResource;
     HGLOBAL hGlobal;
     void *pData;
@@ -1173,12 +1271,16 @@ VS_FIXEDFILEINFO *GetModuleVersionInfo(HMODULE hModule, UINT *puPtrLen) {
     uPtrLen = 0;
 
     hResource = FindResource(hModule, MAKEINTRESOURCE(VS_VERSION_INFO), RT_VERSION);
-    if (hResource != NULL) {
+    if (hResource != NULL)
+    {
         hGlobal = LoadResource(hModule, hResource);
-        if (hGlobal != NULL) {
+        if (hGlobal != NULL)
+        {
             pData = LockResource(hGlobal);
-            if (pData != NULL) {
-                if (!VerQueryValue(pData, L"\\", &pFixedFileInfo, &uPtrLen) || uPtrLen == 0) {
+            if (pData != NULL)
+            {
+                if (!VerQueryValue(pData, L"\\", &pFixedFileInfo, &uPtrLen) || uPtrLen == 0)
+                {
                     pFixedFileInfo = NULL;
                     uPtrLen = 0;
                 }
@@ -1192,7 +1294,8 @@ VS_FIXEDFILEINFO *GetModuleVersionInfo(HMODULE hModule, UINT *puPtrLen) {
     return (VS_FIXEDFILEINFO *)pFixedFileInfo;
 }
 
-BOOL WindowsVersionInit() {
+BOOL WindowsVersionInit()
+{
     nWinVersion = WIN_VERSION_UNSUPPORTED;
 
     VS_FIXEDFILEINFO *pFixedFileInfo = GetModuleVersionInfo(NULL, NULL);
@@ -1205,10 +1308,12 @@ BOOL WindowsVersionInit() {
     WORD nQFE = LOWORD(pFixedFileInfo->dwFileVersionLS);
     Wh_Log(L"Windows version (major.minor.build): %d.%d.%d", nMajor, nMinor, nBuild);
 
-    // windows version needed for macros and functions ported from 7+Taskbar to work 
-    switch (nMajor) {
+    // windows version needed for macros and functions ported from 7+Taskbar to work
+    switch (nMajor)
+    {
     case 6:
-        switch (nMinor) {
+        switch (nMinor)
+        {
         case 1:
             nWinVersion = WIN_VERSION_7;
             break;
@@ -1253,28 +1358,38 @@ BOOL WindowsVersionInit() {
             nWinVersion = WIN_VERSION_SERVER_2022;
         else if (nBuild <= 22000)
             nWinVersion = WIN_VERSION_11_21H2;
-        else {
+        else
+        {
             nWinVersion = WIN_VERSION_11_22H2;
         }
         break;
     }
 
-    if (nMajor == 6) {
+    if (nMajor == 6)
+    {
         g_taskbarVersion = WIN_10_TASKBAR;
-    } else if (nMajor == 10) {
-        if (nBuild < 22000) { // 21H2
+    }
+    else if (nMajor == 10)
+    {
+        if (nBuild < 22000)
+        { // 21H2
             g_taskbarVersion = WIN_10_TASKBAR;
-        } else {
+        }
+        else
+        {
             g_taskbarVersion = WIN_11_TASKBAR;
         }
-    } else {
+    }
+    else
+    {
         g_taskbarVersion = UNKNOWN_TASKBAR;
     }
 
     return TRUE;
 }
 
-HWND GetWindows10ImmersiveWorkerWindow(void) {
+HWND GetWindows10ImmersiveWorkerWindow(void)
+{
     HWND hApplicationManagerDesktopShellWindow = FindWindow(L"ApplicationManager_DesktopShellWindow", NULL);
     if (!hApplicationManagerDesktopShellWindow)
         return NULL;
@@ -1296,30 +1411,51 @@ HWND GetWindows10ImmersiveWorkerWindow(void) {
     return *(HWND *)(lpImmersiveWindowMessageService + DO10_3264(0, 0, , , , , , , 0x4C, 0x80, , , 0x50, 0x88, , , 0x58, 0x98, 0x54, 0x90));
 }
 
-TaskBarAction ParseMouseActionSetting(const wchar_t *option) {
+TaskBarAction ParseMouseActionSetting(const wchar_t *option)
+{
     const auto value = Wh_GetStringSetting(option);
-    const auto equals = [](const wchar_t *str1, const wchar_t *str2) { return wcscmp(str1, str2) == 0; };
+    const auto equals = [](const wchar_t *str1, const wchar_t *str2)
+    { return wcscmp(str1, str2) == 0; };
 
     TaskBarAction action = ACTION_NOTHING;
-    if (equals(value, L"ACTION_NOTHING")) {
+    if (equals(value, L"ACTION_NOTHING"))
+    {
         action = ACTION_NOTHING;
-    } else if (equals(value, L"ACTION_SHOW_DESKTOP")) {
+    }
+    else if (equals(value, L"ACTION_SHOW_DESKTOP"))
+    {
         action = ACTION_SHOW_DESKTOP;
-    } else if (equals(value, L"ACTION_ALT_TAB")) {
+    }
+    else if (equals(value, L"ACTION_ALT_TAB"))
+    {
         action = ACTION_ALT_TAB;
-    } else if (equals(value, L"ACTION_TASK_MANAGER")) {
+    }
+    else if (equals(value, L"ACTION_TASK_MANAGER"))
+    {
         action = ACTION_TASK_MANAGER;
-    } else if (equals(value, L"ACTION_MUTE")) {
+    }
+    else if (equals(value, L"ACTION_MUTE"))
+    {
         action = ACTION_MUTE;
-    } else if (equals(value, L"ACTION_TASKBAR_AUTOHIDE")) {
+    }
+    else if (equals(value, L"ACTION_TASKBAR_AUTOHIDE"))
+    {
         action = ACTION_TASKBAR_AUTOHIDE;
-    } else if (equals(value, L"ACTION_WIN_TAB")) {
+    }
+    else if (equals(value, L"ACTION_WIN_TAB"))
+    {
         action = ACTION_WIN_TAB;
-    } else if (equals(value, L"ACTION_HIDE_ICONS")) {
+    }
+    else if (equals(value, L"ACTION_HIDE_ICONS"))
+    {
         action = ACTION_HIDE_ICONS;
-    } else if (equals(value, L"ACTION_COMBINE_TASKBAR_BUTTONS")) {
+    }
+    else if (equals(value, L"ACTION_COMBINE_TASKBAR_BUTTONS"))
+    {
         action = ACTION_COMBINE_TASKBAR_BUTTONS;
-    } else {
+    }
+    else
+    {
         Wh_Log(L"Error: unknown action '%s' for option '%s'!", value, option);
         action = ACTION_NOTHING;
     }
@@ -1329,18 +1465,27 @@ TaskBarAction ParseMouseActionSetting(const wchar_t *option) {
     return action;
 }
 
-TaskBarButtonsState ParseTaskBarButtonsState(const wchar_t *option) {
+TaskBarButtonsState ParseTaskBarButtonsState(const wchar_t *option)
+{
     const auto value = Wh_GetStringSetting(option);
-    const auto equals = [](const wchar_t *str1, const wchar_t *str2) { return wcscmp(str1, str2) == 0; };
+    const auto equals = [](const wchar_t *str1, const wchar_t *str2)
+    { return wcscmp(str1, str2) == 0; };
 
     TaskBarButtonsState state = COMBINE_ALWAYS;
-    if (equals(value, L"COMBINE_ALWAYS")) {
+    if (equals(value, L"COMBINE_ALWAYS"))
+    {
         state = COMBINE_ALWAYS;
-    } else if (equals(value, L"COMBINE_WHEN_FULL")) {
+    }
+    else if (equals(value, L"COMBINE_WHEN_FULL"))
+    {
         state = COMBINE_WHEN_FULL;
-    } else if (equals(value, L"COMBINE_NEVER")) {
+    }
+    else if (equals(value, L"COMBINE_NEVER"))
+    {
         state = COMBINE_NEVER;
-    } else {
+    }
+    else
+    {
         Wh_Log(L"Error: unknown state '%s' for option '%s'!", value, option);
         state = COMBINE_ALWAYS;
     }
@@ -1350,7 +1495,8 @@ TaskBarButtonsState ParseTaskBarButtonsState(const wchar_t *option) {
     return state;
 }
 
-void LoadSettings() {
+void LoadSettings()
+{
     g_settings.oldTaskbarOnWin11 = Wh_GetIntSetting(L"oldTaskbarOnWin11");
     g_settings.doubleClickTaskbarAction = ParseMouseActionSetting(L"doubleClickAction");
     g_settings.middleClickTaskbarAction = ParseMouseActionSetting(L"middleClickAction");
@@ -1358,8 +1504,10 @@ void LoadSettings() {
     g_settings.taskBarButtonsState2 = ParseTaskBarButtonsState(L"CombineTaskbarButtons.State2");
 }
 
-bool GetTaskbarAutohideState() {
-    if (g_hTaskbarWnd == NULL) {
+bool GetTaskbarAutohideState()
+{
+    if (g_hTaskbarWnd == NULL)
+    {
         return false;
     }
     APPBARDATA msgData{};
@@ -1369,8 +1517,10 @@ bool GetTaskbarAutohideState() {
     return state & ABS_AUTOHIDE;
 }
 
-void SetTaskbarAutohide(bool enabled) {
-    if (g_hTaskbarWnd == NULL) {
+void SetTaskbarAutohide(bool enabled)
+{
+    if (g_hTaskbarWnd == NULL)
+    {
         return;
     }
 
@@ -1381,18 +1531,22 @@ void SetTaskbarAutohide(bool enabled) {
     SHAppBarMessage(ABM_SETSTATE, &msgData);
 }
 
-bool FindDesktopWindow() {
-    HWND hParentWnd = FindWindow(L"Progman", NULL);     // Program Manager window
-    if (!hParentWnd) {
+bool FindDesktopWindow()
+{
+    HWND hParentWnd = FindWindow(L"Progman", NULL); // Program Manager window
+    if (!hParentWnd)
+    {
         Wh_Log(L"Failed to find Progman window");
         return false;
     }
 
-    HWND hChildWnd = FindWindowEx(hParentWnd, NULL, L"SHELLDLL_DefView", NULL);     // parent window of the desktop
+    HWND hChildWnd = FindWindowEx(hParentWnd, NULL, L"SHELLDLL_DefView", NULL); // parent window of the desktop
     if (!hChildWnd)
     {
         DWORD dwThreadId = GetWindowThreadProcessId(hParentWnd, NULL);
-        EnumThreadWindows(dwThreadId, [](HWND hWnd, LPARAM lParam) WINAPI_LAMBDA_RETURN(BOOL) {
+        EnumThreadWindows(
+            dwThreadId, [](HWND hWnd, LPARAM lParam) WINAPI_LAMBDA_RETURN(BOOL)
+            {
             WCHAR szClassName[16];
             if (GetClassName(hWnd, szClassName, _countof(szClassName)) == 0)
                 return TRUE;
@@ -1405,11 +1559,12 @@ bool FindDesktopWindow() {
                 return TRUE;
 
             *(HWND *)lParam = hChildWnd;
-            return FALSE;
-        }, (LPARAM)&hChildWnd);
+            return FALSE; },
+            (LPARAM)&hChildWnd);
     }
 
-    if (!hChildWnd) {
+    if (!hChildWnd)
+    {
         Wh_Log(L"Failed to find SHELLDLL_DefView window");
         return false;
     }
@@ -1421,41 +1576,49 @@ bool FindDesktopWindow() {
 
 #pragma region features
 
-bool ToggleTaskbarAutohide() {
+bool ToggleTaskbarAutohide()
+{
     const bool isEnabled = GetTaskbarAutohideState();
     Wh_Log(L"Setting taskbar autohide state to %s", !isEnabled ? L"enabled" : L"disabled");
     SetTaskbarAutohide(!isEnabled);
     return !isEnabled;
 }
 
-void ShowDesktop(HWND taskbarhWnd) {
+void ShowDesktop(HWND taskbarhWnd)
+{
     Wh_Log(L"Sending ShowDesktop message");
     SendMessage(taskbarhWnd, WM_COMMAND, MAKELONG(407, 0), 0);
 }
 
-void SendAltTab() {
+void SendAltTab()
+{
     HWND hImmersiveWorkerWnd = GetWindows10ImmersiveWorkerWindow();
-    if (hImmersiveWorkerWnd) {
+    if (hImmersiveWorkerWnd)
+    {
         WPARAM wHotkeyIdentifier = DO9(0, , , , 47, , , , 45);
         Wh_Log(L"Sending AltTab message");
         PostMessage(hImmersiveWorkerWnd, WM_HOTKEY, wHotkeyIdentifier, MAKELPARAM(MOD_ALT | MOD_CONTROL, VK_TAB));
     }
 }
 
-void SendWinTab() {
+void SendWinTab()
+{
     HWND hImmersiveWorkerWnd = GetWindows10ImmersiveWorkerWindow();
-    if (hImmersiveWorkerWnd) {
+    if (hImmersiveWorkerWnd)
+    {
         Wh_Log(L"Sending WinTab message");
         PostMessage(hImmersiveWorkerWnd, WM_HOTKEY, 11, MAKELPARAM(MOD_WIN, VK_TAB));
     }
 }
 
-void OpenTaskManager(HWND taskbarhWnd) {
+void OpenTaskManager(HWND taskbarhWnd)
+{
     Wh_Log(L"Sending OpenTaskManager message");
     SendMessage(taskbarhWnd, WM_COMMAND, MAKELONG(420, 0), 0);
 }
 
-BOOL ToggleVolMuted() {
+BOOL ToggleVolMuted()
+{
     IMMDevice *defaultDevice = NULL;
     IAudioEndpointVolume *endpointVolume = NULL;
     HRESULT hr;
@@ -1465,12 +1628,16 @@ BOOL ToggleVolMuted() {
     const GUID XIID_IAudioEndpointVolume = {0x5CDF2C82, 0x841E, 0x4546, {0x97, 0x22, 0x0C, 0xF7, 0x40, 0x78, 0x22, 0x9A}};
 
     hr = g_pDeviceEnumerator->GetDefaultAudioEndpoint(eRender, eConsole, &defaultDevice);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr))
+    {
         hr = defaultDevice->Activate(XIID_IAudioEndpointVolume, CLSCTX_INPROC_SERVER, NULL, (LPVOID *)&endpointVolume);
-        if (SUCCEEDED(hr)) {
-            if (SUCCEEDED(endpointVolume->GetMute(&bMuted))) {
+        if (SUCCEEDED(hr))
+        {
+            if (SUCCEEDED(endpointVolume->GetMute(&bMuted)))
+            {
                 Wh_Log(L"Toggling volume mute");
-                if (SUCCEEDED(endpointVolume->SetMute(!bMuted, NULL))) {
+                if (SUCCEEDED(endpointVolume->SetMute(!bMuted, NULL)))
+                {
                     bSuccess = TRUE;
                 }
             }
@@ -1482,22 +1649,26 @@ BOOL ToggleVolMuted() {
     return bSuccess;
 }
 
-void HideIcons() {
-    if (g_hDesktopWnd != NULL) {
+void HideIcons()
+{
+    if (g_hDesktopWnd != NULL)
+    {
         Wh_Log(L"Sending hide icons message");
         PostMessage(g_hDesktopWnd, WM_COMMAND, 0x7402, 0);
-    } 
+    }
 }
 
-void CombineTaskbarButtons(unsigned int option)
+void SetCombineTaskbarButtons(unsigned int option)
 {
-    if (option <= 2) {  // 0 = Always, 1 = When taskbar is full, 2 = Never
+    if (option <= 2)
+    { // 0 = Always, 1 = When taskbar is full, 2 = Never
         HKEY hKey = NULL;
-        LONG result = RegOpenKeyEx(HKEY_CURRENT_USER, TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced"), 0, KEY_SET_VALUE, &hKey);
+        LONG result = RegOpenKeyEx(HKEY_CURRENT_USER, TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced"),
+                                   0, KEY_SET_VALUE, &hKey);
         if (result == ERROR_SUCCESS)
         {
-            DWORD dwValue = option; 
-            RegSetValueEx(hKey, TEXT("TaskbarGlomLevel"), 0, REG_DWORD, (BYTE*)&dwValue, sizeof(dwValue));
+            DWORD dwValue = option;
+            RegSetValueEx(hKey, TEXT("TaskbarGlomLevel"), 0, REG_DWORD, (BYTE *)&dwValue, sizeof(dwValue));
             RegCloseKey(hKey);
 
             // Notify all applications of the change
@@ -1511,22 +1682,28 @@ void CombineTaskbarButtons(unsigned int option)
 // =====================================================================
 
 // main body of the mod called every time a taskbar is clicked
-bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam, TaskBarAction taskbarAction) {
-    if ((GetCapture() != NULL) || (taskbarAction == ACTION_NOTHING)) {
+bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam, TaskBarAction taskbarAction)
+{
+    if ((GetCapture() != NULL) || (taskbarAction == ACTION_NOTHING))
+    {
         return false;
     }
 
     // old Windows mouse handling of WM_MBUTTONDOWN message
     POINT pointerLocation{};
-    if (g_taskbarVersion == WIN_10_TASKBAR) {
+    if (g_taskbarVersion == WIN_10_TASKBAR)
+    {
         // message carries mouse position relative to the client window so use GetCursorPos() instead
-        if (!GetCursorPos(&pointerLocation)) {
+        if (!GetCursorPos(&pointerLocation))
+        {
             Wh_Log(L"Failed to get mouse position");
             return false;
         }
 
         // new Windows sends different message - WM_POINTERDOWN
-    } else {
+    }
+    else
+    {
         pointerLocation.x = GET_X_LPARAM(lParam);
         pointerLocation.y = GET_Y_LPARAM(lParam);
     }
@@ -1539,14 +1716,16 @@ bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam, TaskBarAction taskbar
 
     com_ptr<IUIAutomationElement> pWindowElement = NULL;
     HRESULT hr = g_pUIAutomation->ElementFromPoint(pointerLocation, pWindowElement.put());
-    if (FAILED(hr) || !pWindowElement) {
+    if (FAILED(hr) || !pWindowElement)
+    {
         Wh_Log(L"Failed to retrieve UI element from mouse click");
         return false;
     }
 
     bstr_ptr className;
     hr = pWindowElement->get_CurrentClassName(className.GetAddress());
-    if (FAILED(hr) || !className) {
+    if (FAILED(hr) || !className)
+    {
         Wh_Log(L"Failed to retrieve the Name of the UI element clicked.");
         return false;
     }
@@ -1555,29 +1734,47 @@ bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam, TaskBarAction taskbar
                                 (wcscmp(className.GetBSTR(), L"Shell_SecondaryTrayWnd") == 0) ||               // Windows 10 secondary taskbar
                                 (wcscmp(className.GetBSTR(), L"Taskbar.TaskbarFrameAutomationPeer") == 0) ||   // Windows 11 taskbar
                                 (wcscmp(className.GetBSTR(), L"Windows.UI.Input.InputSite.WindowClass") == 0); // Windows 11 21H2 taskbar
-    if (!taskbarClicked) {
+    if (!taskbarClicked)
+    {
         return false;
     }
 
-    if (taskbarAction == ACTION_SHOW_DESKTOP) {
+    if (taskbarAction == ACTION_SHOW_DESKTOP)
+    {
         ShowDesktop(hWnd);
-    } else if (taskbarAction == ACTION_ALT_TAB) {
+    }
+    else if (taskbarAction == ACTION_ALT_TAB)
+    {
         SendAltTab();
-    } else if (taskbarAction == ACTION_TASK_MANAGER) {
+    }
+    else if (taskbarAction == ACTION_TASK_MANAGER)
+    {
         OpenTaskManager(hWnd);
-    } else if (taskbarAction == ACTION_MUTE) {
+    }
+    else if (taskbarAction == ACTION_MUTE)
+    {
         ToggleVolMuted();
-    } else if (taskbarAction == ACTION_TASKBAR_AUTOHIDE) {
+    }
+    else if (taskbarAction == ACTION_TASKBAR_AUTOHIDE)
+    {
         (void)ToggleTaskbarAutohide();
-    } else if (taskbarAction == ACTION_WIN_TAB) {
+    }
+    else if (taskbarAction == ACTION_WIN_TAB)
+    {
         SendWinTab();
-    } else if (taskbarAction == ACTION_HIDE_ICONS) {
+    }
+    else if (taskbarAction == ACTION_HIDE_ICONS)
+    {
         HideIcons();
-    } else if (taskbarAction == ACTION_COMBINE_TASKBAR_BUTTONS) {
+    }
+    else if (taskbarAction == ACTION_COMBINE_TASKBAR_BUTTONS)
+    {
         static bool zigzag;
         zigzag = !zigzag;
-        CombineTaskbarButtons(zigzag ? g_settings.taskBarButtonsState1 : g_settings.taskBarButtonsState2);
-    } else {
+        SetCombineTaskbarButtons(zigzag ? g_settings.taskBarButtonsState1 : g_settings.taskBarButtonsState2);
+    }
+    else
+    {
         Wh_Log(L"Error: Unknown taskbar action '%d'", taskbarAction);
     }
 
@@ -1586,65 +1783,86 @@ bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam, TaskBarAction taskbar
 
 ////////////////////////////////////////////////////////////
 
-BOOL Wh_ModInit() {
+BOOL Wh_ModInit()
+{
     Wh_Log(L">");
 
     LoadSettings();
 
-    if (!WindowsVersionInit() || (g_taskbarVersion == UNKNOWN_TASKBAR)) {
+    if (!WindowsVersionInit() || (g_taskbarVersion == UNKNOWN_TASKBAR))
+    {
         Wh_Log(L"Unsupported Windows version, ModInit failed");
         return FALSE;
     }
     // treat Windows 11 taskbar as on older windows
-    if ((g_taskbarVersion == WIN_11_TASKBAR) && g_settings.oldTaskbarOnWin11) {
+    if ((g_taskbarVersion == WIN_11_TASKBAR) && g_settings.oldTaskbarOnWin11)
+    {
         g_taskbarVersion = WIN_10_TASKBAR;
     }
     Wh_Log(L"Using taskbar version: %d");
 
     // init COM for UIAutomation and Volume control
-    if (!g_comInitializer.Init()) {
+    if (!g_comInitializer.Init())
+    {
         Wh_Log(L"COM initialization failed, ModInit failed");
         return FALSE;
-    } else {
+    }
+    else
+    {
         Wh_Log(L"COM initilized");
     }
 
     // init COM interface for UIAutomation
-    if (FAILED(CoCreateInstance(CLSID_CUIAutomation, NULL, CLSCTX_INPROC_SERVER, __uuidof(IUIAutomation), g_pUIAutomation.put_void())) || !g_pUIAutomation) {
+    if (FAILED(CoCreateInstance(CLSID_CUIAutomation, NULL, CLSCTX_INPROC_SERVER, __uuidof(IUIAutomation),
+                                g_pUIAutomation.put_void())) ||
+        !g_pUIAutomation)
+    {
         Wh_Log(L"Failed to create UIAutomation COM instance, ModInit failed");
         return FALSE;
-    } else {
+    }
+    else
+    {
         Wh_Log(L"UIAutomation COM initilized");
     }
 
     // init COM interface for Volume control
     const GUID XIID_IMMDeviceEnumerator = {0xA95664D2, 0x9614, 0x4F35, {0xA7, 0x46, 0xDE, 0x8D, 0xB6, 0x36, 0x17, 0xE6}};
     const GUID XIID_MMDeviceEnumerator = {0xBCDE0395, 0xE52F, 0x467C, {0x8E, 0x3D, 0xC4, 0x57, 0x92, 0x91, 0x69, 0x2E}};
-    if (FAILED(CoCreateInstance(XIID_MMDeviceEnumerator, NULL, CLSCTX_INPROC_SERVER, XIID_IMMDeviceEnumerator, g_pDeviceEnumerator.put_void())) || !g_pDeviceEnumerator) {
+    if (FAILED(CoCreateInstance(XIID_MMDeviceEnumerator, NULL, CLSCTX_INPROC_SERVER, XIID_IMMDeviceEnumerator,
+                                g_pDeviceEnumerator.put_void())) ||
+        !g_pDeviceEnumerator)
+    {
         Wh_Log(L"Failed to create DeviceEnumerator COM instance, ModInit failed");
         return FALSE;
-    } else {
+    }
+    else
+    {
         Wh_Log(L"DeviceEnumerator COM initilized");
     }
 
     // optional feature, not critical for the mod
-    if (!FindDesktopWindow()) {
+    if (!FindDesktopWindow())
+    {
         Wh_Log(L"Failed to find Desktop window. Hide icons feature will not be available!");
     }
 
     // hook magic
     Wh_SetFunctionHook((void *)CreateWindowExW, (void *)CreateWindowExW_Hook, (void **)&CreateWindowExW_Original);
     HMODULE user32Module = LoadLibrary(L"user32.dll");
-    if (user32Module) {
+    if (user32Module)
+    {
         void *pCreateWindowInBand = (void *)GetProcAddress(user32Module, "CreateWindowInBand");
-        if (pCreateWindowInBand) {
+        if (pCreateWindowInBand)
+        {
             Wh_SetFunctionHook(pCreateWindowInBand, (void *)CreateWindowInBand_Hook, (void **)&CreateWindowInBand_Original);
         }
     }
     WNDCLASS wndclass;
-    if (GetClassInfo(GetModuleHandle(NULL), L"Shell_TrayWnd", &wndclass)) {
+    if (GetClassInfo(GetModuleHandle(NULL), L"Shell_TrayWnd", &wndclass))
+    {
         HWND hWnd = FindCurrentProcessTaskbarWindows(&g_secondaryTaskbarWindows);
-        if (hWnd) {
+        if (hWnd)
+        {
             HandleIdentifiedTaskbarWindow(hWnd);
         }
     }
@@ -1652,7 +1870,8 @@ BOOL Wh_ModInit() {
     return TRUE;
 }
 
-BOOL Wh_ModSettingsChanged(BOOL *bReload) {
+BOOL Wh_ModSettingsChanged(BOOL *bReload)
+{
     Wh_Log(L">");
     bool prevOldTaskbarOnWin11 = g_settings.oldTaskbarOnWin11;
     LoadSettings();
@@ -1660,13 +1879,16 @@ BOOL Wh_ModSettingsChanged(BOOL *bReload) {
     return TRUE;
 }
 
-void Wh_ModUninit() {
+void Wh_ModUninit()
+{
     Wh_Log(L">");
 
-    if (g_hTaskbarWnd) {
+    if (g_hTaskbarWnd)
+    {
         UnsubclassTaskbarWindow(g_hTaskbarWnd);
 
-        for (HWND hSecondaryWnd : g_secondaryTaskbarWindows) {
+        for (HWND hSecondaryWnd : g_secondaryTaskbarWindows)
+        {
             UnsubclassTaskbarWindow(hSecondaryWnd);
         }
     }

--- a/mods/taskbar-empty-space-clicks.wh.cpp
+++ b/mods/taskbar-empty-space-clicks.wh.cpp
@@ -47,7 +47,13 @@ Following animation shows **Taskbar auto-hide** feature. Feature gets toggled wh
 
 I will not supporting Insider preview or other minor versions of Windows. However, feel free to [report any issues](https://github.com/m1lhaus/windhawk-mods/issues) related to those versions. I'll appreciate the heads-up in advance.
 
+## Classic taskbar on Windows 11
+
 In case you are using old Windows taskbar on Windows 11 (**ExplorerPatcher** or a similar tool), enable corresponding option on Settings menu. This options will be tested only with the latest major version of Windows 11 (e.g. 23H2).
+
+## Suggestions and new features
+
+If you have request for new functions, suggestions or you are experiencing some issues, please post an [Issue on Github page](https://github.com/m1lhaus/windhawk-mods/issues).
 
 */
 // ==/WindhawkModReadme==

--- a/mods/taskbar-empty-space-clicks.wh.cpp
+++ b/mods/taskbar-empty-space-clicks.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-empty-space-clicks
 // @name            Click on empty taskbar space
 // @description     Trigger custom action when empty space on a taskbar is double/middle clicked
-// @version         1.01
+// @version         1.1
 // @author          m1lhaus
 // @github          https://github.com/m1lhaus
 // @include         explorer.exe

--- a/mods/taskbar-empty-space-clicks.wh.cpp
+++ b/mods/taskbar-empty-space-clicks.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-empty-space-clicks
 // @name            Click on empty taskbar space
 // @description     Trigger custom action when empty space on a taskbar is double/middle clicked.
-// @version         0.1
+// @version         1.0
 // @author          m1lhaus
 // @github          https://github.com/m1lhaus
 // @include         explorer.exe

--- a/mods/toggle-taskbar-autohide.wh.cpp
+++ b/mods/toggle-taskbar-autohide.wh.cpp
@@ -1,0 +1,1798 @@
+// ==WindhawkMod==
+// @id              toggle-taskbar-autohide
+// @name            Toggle taskbar autohide
+// @description     Toggle taskbar autohide feature with middle mouse click on the taskbar.
+// @version         1.0
+// @author          m1lhaus
+// @github          https://github.com/m1lhaus
+// @include         explorer.exe
+// @compilerOptions -DWINVER=0x0602 -lcomctl32 -ldwmapi -lole32 -lversion
+// ==/WindhawkMod==
+
+// Source code is published under The GNU General Public License v3.0.
+//
+// For bug reports and feature requests, please open an issue here:
+// https://github.com/ramensoftware/windhawk-mods/issues
+//
+// For pull requests, development takes place here:
+// https://github.com/m1lhaus/windhawk-mods
+
+// ==WindhawkModReadme==
+/*
+# Toggle taskbar autohide
+Toggle taskbar autohide feature with middle mouse click on the taskbar. Whenever you middle click on a free space on your taskbar (outside other UI elemwnts on the taskbar), taskbar's autohide feature gets turned on or off.
+
+![Demonstration](https://i.imgur.com/B6mtUj9.gif)
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- volumeIndicator: win11
+  $name: Volume control indicator
+  $options:
+  - win11: Windows 11
+  - modern: Windows 10
+  - classic: Windows 7
+  - none: None
+- scrollArea: taskbar
+  $name: Scroll area
+  $options:
+  - taskbar: The taskbar
+  - notification_area: The notification area
+- middleClickToMute: true
+  $name: Middle click to mute
+  $description: >-
+    With this option enabled, middle clicking the volume tray icon will
+    mute/unmute the system volume (Windows 11 version 22H2 or newer).
+- noAutomaticMuteToggle: false
+  $name: No automatic mute toggle
+  $description: >-
+    For the Windows 11 indicator, this option causes volume scrolling to be
+    disabled when the volume is muted. For the None control indicator: By
+    default, the output device is muted once the volume reaches zero, and is
+    unmuted on any change to a non-zero volume. Enabling this option turns off
+    this functionality, such that the device mute status is not changed.
+- volumeChangeStep: 2
+  $name: Volume change step
+  $description: >-
+    Allows to configure the volume change that will occur with each notch of
+    mouse wheel movement. This option has effect only for the Windows 11, None
+    control indicators. For the Windows 11 indicator, must be a multiple of 2.
+- oldTaskbarOnWin11: false
+  $name: Customize the old taskbar on Windows 11
+  $description: >-
+    Enable this option to customize the old taskbar on Windows 11 (if using
+    Explorer Patcher or a similar tool). Note: For Windhawk versions older
+    than 1.3, you have to disable and re-enable the mod to apply this option.
+*/
+// ==/WindhawkModSettings==
+
+#include <commctrl.h>
+#include <dwmapi.h>
+#include <endpointvolume.h>
+#include <mmdeviceapi.h>
+#include <objbase.h>
+#include <oleauto.h>
+#include <uiautomation.h>
+#include <windhawk_api.h>
+#include <windowsx.h>
+#include <winerror.h>
+#include <winuser.h>
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+#if defined(__GNUC__) && __GNUC__ > 8
+#define WINAPI_LAMBDA_RETURN(return_t) ->return_t WINAPI
+#elif defined(__GNUC__)
+#define WINAPI_LAMBDA_RETURN(return_t) WINAPI->return_t
+#else
+#define WINAPI_LAMBDA_RETURN(return_t) ->return_t
+#endif
+
+#ifndef WM_POINTERDOWN
+#define WM_POINTERDOWN 0x0246
+#endif
+
+// =====================================================================
+
+#pragma region uiautomation_includes
+
+#include <initguid.h>
+
+// Pasted below and commented duplicate definitions:
+// https://github.com/qt/qtbase/blob/dev/src/gui/accessible/windows/apisupport/uiatypes_p.h
+// https://github.com/qt/qtbase/blob/dev/src/gui/accessible/windows/apisupport/uiaclientinterfaces_p.h
+
+// Copyright (C) 2017 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR
+// GPL-2.0-only OR GPL-3.0-only
+
+#ifndef UIATYPES_H
+#define UIATYPES_H
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Qt API. It exists purely as an
+// implementation detail. This header file may change from version to
+// version without notice, or even be removed.
+//
+// We mean it.
+//
+
+typedef int PROPERTYID;
+typedef int PATTERNID;
+typedef int EVENTID;
+typedef int TEXTATTRIBUTEID;
+typedef int CONTROLTYPEID;
+typedef int LANDMARKTYPEID;
+typedef int METADATAID;
+
+typedef void* UIA_HWND;
+
+// enum NavigateDirection {
+//     NavigateDirection_Parent           = 0,
+//     NavigateDirection_NextSibling      = 1,
+//     NavigateDirection_PreviousSibling  = 2,
+//     NavigateDirection_FirstChild       = 3,
+//     NavigateDirection_LastChild        = 4
+// };
+
+// enum ProviderOptions {
+//     ProviderOptions_ClientSideProvider      = 0x1,
+//     ProviderOptions_ServerSideProvider      = 0x2,
+//     ProviderOptions_NonClientAreaProvider   = 0x4,
+//     ProviderOptions_OverrideProvider        = 0x8,
+//     ProviderOptions_ProviderOwnsSetFocus    = 0x10,
+//     ProviderOptions_UseComThreading         = 0x20,
+//     ProviderOptions_RefuseNonClientSupport  = 0x40,
+//     ProviderOptions_HasNativeIAccessible    = 0x80,
+//     ProviderOptions_UseClientCoordinates    = 0x100
+// };
+
+enum SupportedTextSelection {
+    SupportedTextSelection_None = 0,
+    SupportedTextSelection_Single = 1,
+    SupportedTextSelection_Multiple = 2
+};
+
+enum TextUnit {
+    TextUnit_Character = 0,
+    TextUnit_Format = 1,
+    TextUnit_Word = 2,
+    TextUnit_Line = 3,
+    TextUnit_Paragraph = 4,
+    TextUnit_Page = 5,
+    TextUnit_Document = 6
+};
+
+enum TextPatternRangeEndpoint {
+    TextPatternRangeEndpoint_Start = 0,
+    TextPatternRangeEndpoint_End = 1
+};
+
+enum TextDecorationLineStyle {
+    TextDecorationLineStyle_None = 0,
+    TextDecorationLineStyle_Single = 1,
+    TextDecorationLineStyle_WordsOnly = 2,
+    TextDecorationLineStyle_Double = 3,
+    TextDecorationLineStyle_Dot = 4,
+    TextDecorationLineStyle_Dash = 5,
+    TextDecorationLineStyle_DashDot = 6,
+    TextDecorationLineStyle_DashDotDot = 7,
+    TextDecorationLineStyle_Wavy = 8,
+    TextDecorationLineStyle_ThickSingle = 9,
+    TextDecorationLineStyle_DoubleWavy = 11,
+    TextDecorationLineStyle_ThickWavy = 12,
+    TextDecorationLineStyle_LongDash = 13,
+    TextDecorationLineStyle_ThickDash = 14,
+    TextDecorationLineStyle_ThickDashDot = 15,
+    TextDecorationLineStyle_ThickDashDotDot = 16,
+    TextDecorationLineStyle_ThickDot = 17,
+    TextDecorationLineStyle_ThickLongDash = 18,
+    TextDecorationLineStyle_Other = -1
+};
+
+enum CaretPosition {
+    CaretPosition_Unknown = 0,
+    CaretPosition_EndOfLine = 1,
+    CaretPosition_BeginningOfLine = 2
+};
+
+enum ToggleState {
+    ToggleState_Off = 0,
+    ToggleState_On = 1,
+    ToggleState_Indeterminate = 2
+};
+
+enum RowOrColumnMajor {
+    RowOrColumnMajor_RowMajor = 0,
+    RowOrColumnMajor_ColumnMajor = 1,
+    RowOrColumnMajor_Indeterminate = 2
+};
+
+enum TreeScope {
+    TreeScope_None = 0,
+    TreeScope_Element = 0x1,
+    TreeScope_Children = 0x2,
+    TreeScope_Descendants = 0x4,
+    TreeScope_Parent = 0x8,
+    TreeScope_Ancestors = 0x10,
+    TreeScope_Subtree =
+        TreeScope_Element | TreeScope_Children | TreeScope_Descendants
+};
+
+enum OrientationType {
+    OrientationType_None = 0,
+    OrientationType_Horizontal = 1,
+    OrientationType_Vertical = 2
+};
+
+enum PropertyConditionFlags {
+    PropertyConditionFlags_None = 0,
+    PropertyConditionFlags_IgnoreCase = 1
+};
+
+enum WindowVisualState {
+    WindowVisualState_Normal = 0,
+    WindowVisualState_Maximized = 1,
+    WindowVisualState_Minimized = 2
+};
+
+enum WindowInteractionState {
+    WindowInteractionState_Running = 0,
+    WindowInteractionState_Closing = 1,
+    WindowInteractionState_ReadyForUserInteraction = 2,
+    WindowInteractionState_BlockedByModalWindow = 3,
+    WindowInteractionState_NotResponding = 4
+};
+
+enum ExpandCollapseState {
+    ExpandCollapseState_Collapsed = 0,
+    ExpandCollapseState_Expanded = 1,
+    ExpandCollapseState_PartiallyExpanded = 2,
+    ExpandCollapseState_LeafNode = 3
+};
+
+// struct UiaRect {
+//     double left;
+//     double top;
+//     double width;
+//     double height;
+// };
+
+struct UiaPoint {
+    double x;
+    double y;
+};
+
+#endif
+
+// Copyright (C) 2017 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR
+// GPL-2.0-only OR GPL-3.0-only
+
+#ifndef UIACLIENTINTERFACES_H
+#define UIACLIENTINTERFACES_H
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Qt API. It exists purely as an
+// implementation detail. This header file may change from version to
+// version without notice, or even be removed.
+//
+// We mean it.
+//
+
+#include <unknwn.h>
+
+#ifndef __IUIAutomationElement_INTERFACE_DEFINED__
+
+struct IUIAutomationCondition;
+struct IUIAutomationCacheRequest;
+struct IUIAutomationElementArray;
+struct IUIAutomationTreeWalker;
+struct IUIAutomationEventHandler;
+struct IUIAutomationPropertyChangedEventHandler;
+struct IUIAutomationStructureChangedEventHandler;
+struct IUIAutomationFocusChangedEventHandler;
+struct IUIAutomationProxyFactory;
+struct IUIAutomationProxyFactoryEntry;
+struct IUIAutomationProxyFactoryMapping;
+#ifndef __IAccessible_FWD_DEFINED__
+#define __IAccessible_FWD_DEFINED__
+struct IAccessible;
+#endif /* __IAccessible_FWD_DEFINED__ */
+
+#define __IUIAutomationElement_INTERFACE_DEFINED__
+DEFINE_GUID(IID_IUIAutomationElement,
+            0xd22108aa,
+            0x8ac5,
+            0x49a5,
+            0x83,
+            0x7b,
+            0x37,
+            0xbb,
+            0xb3,
+            0xd7,
+            0x59,
+            0x1e);
+MIDL_INTERFACE("d22108aa-8ac5-49a5-837b-37bbb3d7591e")
+IUIAutomationElement : public IUnknown {
+   public:
+    virtual HRESULT STDMETHODCALLTYPE SetFocus() = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetRuntimeId(
+        __RPC__deref_out_opt SAFEARRAY * *runtimeId) = 0;
+    virtual HRESULT STDMETHODCALLTYPE FindFirst(
+        enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
+        __RPC__deref_out_opt IUIAutomationElement * *found) = 0;
+    virtual HRESULT STDMETHODCALLTYPE FindAll(
+        enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
+        __RPC__deref_out_opt IUIAutomationElementArray * *found) = 0;
+    virtual HRESULT STDMETHODCALLTYPE FindFirstBuildCache(
+        enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement * *found) = 0;
+    virtual HRESULT STDMETHODCALLTYPE FindAllBuildCache(
+        enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElementArray * *found) = 0;
+    virtual HRESULT STDMETHODCALLTYPE BuildUpdatedCache(
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement * *updatedElement) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCurrentPropertyValue(
+        PROPERTYID propertyId, __RPC__out VARIANT * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCurrentPropertyValueEx(
+        PROPERTYID propertyId, BOOL ignoreDefaultValue,
+        __RPC__out VARIANT * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedPropertyValue(
+        PROPERTYID propertyId, __RPC__out VARIANT * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedPropertyValueEx(
+        PROPERTYID propertyId, BOOL ignoreDefaultValue,
+        __RPC__out VARIANT * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCurrentPatternAs(
+        PATTERNID patternId, __RPC__in REFIID riid,
+        __RPC__deref_out_opt void** patternObject) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedPatternAs(
+        PATTERNID patternId, __RPC__in REFIID riid,
+        __RPC__deref_out_opt void** patternObject) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCurrentPattern(
+        PATTERNID patternId,
+        __RPC__deref_out_opt IUnknown * *patternObject) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedPattern(
+        PATTERNID patternId,
+        __RPC__deref_out_opt IUnknown * *patternObject) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedParent(
+        __RPC__deref_out_opt IUIAutomationElement * *parent) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedChildren(
+        __RPC__deref_out_opt IUIAutomationElementArray * *children) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentProcessId(
+        __RPC__out int* retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentControlType(
+        __RPC__out CONTROLTYPEID * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentLocalizedControlType(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentName(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentAcceleratorKey(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentAccessKey(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentHasKeyboardFocus(
+        __RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsKeyboardFocusable(
+        __RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsEnabled(__RPC__out BOOL *
+                                                           retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentAutomationId(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentClassName(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentHelpText(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentCulture(
+        __RPC__out int* retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsControlElement(
+        __RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsContentElement(
+        __RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsPassword(__RPC__out BOOL *
+                                                            retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentNativeWindowHandle(
+        __RPC__deref_out_opt UIA_HWND * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentItemType(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsOffscreen(__RPC__out BOOL *
+                                                             retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentOrientation(
+        __RPC__out enum OrientationType * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentFrameworkId(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsRequiredForForm(
+        __RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentItemStatus(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentBoundingRectangle(
+        __RPC__out RECT * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentLabeledBy(
+        __RPC__deref_out_opt IUIAutomationElement * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentAriaRole(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentAriaProperties(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsDataValidForForm(
+        __RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentControllerFor(
+        __RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentDescribedBy(
+        __RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentFlowsTo(
+        __RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentProviderDescription(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedProcessId(
+        __RPC__out int* retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedControlType(
+        __RPC__out CONTROLTYPEID * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedLocalizedControlType(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedName(__RPC__deref_out_opt BSTR *
+                                                     retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedAcceleratorKey(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedAccessKey(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedHasKeyboardFocus(
+        __RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsKeyboardFocusable(
+        __RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsEnabled(__RPC__out BOOL *
+                                                          retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedAutomationId(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedClassName(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedHelpText(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedCulture(
+        __RPC__out int* retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsControlElement(
+        __RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsContentElement(
+        __RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsPassword(__RPC__out BOOL *
+                                                           retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedNativeWindowHandle(
+        __RPC__deref_out_opt UIA_HWND * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedItemType(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsOffscreen(__RPC__out BOOL *
+                                                            retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedOrientation(
+        __RPC__out enum OrientationType * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedFrameworkId(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsRequiredForForm(
+        __RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedItemStatus(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedBoundingRectangle(
+        __RPC__out RECT * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedLabeledBy(
+        __RPC__deref_out_opt IUIAutomationElement * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedAriaRole(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedAriaProperties(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsDataValidForForm(
+        __RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedControllerFor(
+        __RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedDescribedBy(
+        __RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedFlowsTo(
+        __RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedProviderDescription(
+        __RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetClickablePoint(
+        __RPC__out POINT * clickable, __RPC__out BOOL * gotClickable) = 0;
+};
+#ifdef __CRT_UUID_DECL
+__CRT_UUID_DECL(IUIAutomationElement,
+                0xd22108aa,
+                0x8ac5,
+                0x49a5,
+                0x83,
+                0x7b,
+                0x37,
+                0xbb,
+                0xb3,
+                0xd7,
+                0x59,
+                0x1e)
+#endif
+#endif
+
+#ifndef __IUIAutomation_INTERFACE_DEFINED__
+#define __IUIAutomation_INTERFACE_DEFINED__
+DEFINE_GUID(IID_IUIAutomation,
+            0x30cbe57d,
+            0xd9d0,
+            0x452a,
+            0xab,
+            0x13,
+            0x7a,
+            0xc5,
+            0xac,
+            0x48,
+            0x25,
+            0xee);
+MIDL_INTERFACE("30cbe57d-d9d0-452a-ab13-7ac5ac4825ee")
+IUIAutomation : public IUnknown {
+   public:
+    virtual HRESULT STDMETHODCALLTYPE CompareElements(
+        __RPC__in_opt IUIAutomationElement * el1,
+        __RPC__in_opt IUIAutomationElement * el2,
+        __RPC__out BOOL * areSame) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CompareRuntimeIds(
+        __RPC__in SAFEARRAY * runtimeId1, __RPC__in SAFEARRAY * runtimeId2,
+        __RPC__out BOOL * areSame) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetRootElement(
+        __RPC__deref_out_opt IUIAutomationElement * *root) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ElementFromHandle(
+        __RPC__in UIA_HWND hwnd,
+        __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ElementFromPoint(
+        POINT pt, __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetFocusedElement(
+        __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetRootElementBuildCache(
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement * *root) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ElementFromHandleBuildCache(
+        __RPC__in UIA_HWND hwnd,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ElementFromPointBuildCache(
+        POINT pt, __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetFocusedElementBuildCache(
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateTreeWalker(
+        __RPC__in_opt IUIAutomationCondition * pCondition,
+        __RPC__deref_out_opt IUIAutomationTreeWalker * *walker) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ControlViewWalker(
+        __RPC__deref_out_opt IUIAutomationTreeWalker * *walker) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ContentViewWalker(
+        __RPC__deref_out_opt IUIAutomationTreeWalker * *walker) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_RawViewWalker(
+        __RPC__deref_out_opt IUIAutomationTreeWalker * *walker) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_RawViewCondition(
+        __RPC__deref_out_opt IUIAutomationCondition * *condition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ControlViewCondition(
+        __RPC__deref_out_opt IUIAutomationCondition * *condition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ContentViewCondition(
+        __RPC__deref_out_opt IUIAutomationCondition * *condition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateCacheRequest(
+        __RPC__deref_out_opt IUIAutomationCacheRequest * *cacheRequest) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateTrueCondition(
+        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateFalseCondition(
+        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreatePropertyCondition(
+        PROPERTYID propertyId, VARIANT value,
+        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreatePropertyConditionEx(
+        PROPERTYID propertyId, VARIANT value, enum PropertyConditionFlags flags,
+        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateAndCondition(
+        __RPC__in_opt IUIAutomationCondition * condition1,
+        __RPC__in_opt IUIAutomationCondition * condition2,
+        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateAndConditionFromArray(
+        __RPC__in_opt SAFEARRAY * conditions,
+        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateAndConditionFromNativeArray(
+        __RPC__in_ecount_full(conditionCount) IUIAutomationCondition *
+            *conditions,
+        int conditionCount,
+        __RPC__deref_out_opt IUIAutomationCondition** newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateOrCondition(
+        __RPC__in_opt IUIAutomationCondition * condition1,
+        __RPC__in_opt IUIAutomationCondition * condition2,
+        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateOrConditionFromArray(
+        __RPC__in_opt SAFEARRAY * conditions,
+        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateOrConditionFromNativeArray(
+        __RPC__in_ecount_full(conditionCount) IUIAutomationCondition *
+            *conditions,
+        int conditionCount,
+        __RPC__deref_out_opt IUIAutomationCondition** newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateNotCondition(
+        __RPC__in_opt IUIAutomationCondition * condition,
+        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE AddAutomationEventHandler(
+        EVENTID eventId, __RPC__in_opt IUIAutomationElement * element,
+        enum TreeScope scope,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__in_opt IUIAutomationEventHandler * handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RemoveAutomationEventHandler(
+        EVENTID eventId, __RPC__in_opt IUIAutomationElement * element,
+        __RPC__in_opt IUIAutomationEventHandler * handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE AddPropertyChangedEventHandlerNativeArray(
+        __RPC__in_opt IUIAutomationElement * element, enum TreeScope scope,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__in_opt IUIAutomationPropertyChangedEventHandler * handler,
+        __RPC__in_ecount_full(propertyCount) PROPERTYID * propertyArray,
+        int propertyCount) = 0;
+    virtual HRESULT STDMETHODCALLTYPE AddPropertyChangedEventHandler(
+        __RPC__in_opt IUIAutomationElement * element, enum TreeScope scope,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__in_opt IUIAutomationPropertyChangedEventHandler * handler,
+        __RPC__in SAFEARRAY * propertyArray) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RemovePropertyChangedEventHandler(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__in_opt IUIAutomationPropertyChangedEventHandler * handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE AddStructureChangedEventHandler(
+        __RPC__in_opt IUIAutomationElement * element, enum TreeScope scope,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__in_opt IUIAutomationStructureChangedEventHandler * handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RemoveStructureChangedEventHandler(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__in_opt IUIAutomationStructureChangedEventHandler * handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE AddFocusChangedEventHandler(
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__in_opt IUIAutomationFocusChangedEventHandler * handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RemoveFocusChangedEventHandler(
+        __RPC__in_opt IUIAutomationFocusChangedEventHandler * handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RemoveAllEventHandlers() = 0;
+    virtual HRESULT STDMETHODCALLTYPE IntNativeArrayToSafeArray(
+        __RPC__in_ecount_full(arrayCount) int* array, int arrayCount,
+        __RPC__deref_out_opt SAFEARRAY** safeArray) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IntSafeArrayToNativeArray(
+        __RPC__in SAFEARRAY * intArray,
+        __RPC__deref_out_ecount_full_opt(*arrayCount) int** array,
+        __RPC__out int* arrayCount) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RectToVariant(
+        RECT rc, __RPC__out VARIANT * var) = 0;
+    virtual HRESULT STDMETHODCALLTYPE VariantToRect(VARIANT var,
+                                                    __RPC__out RECT * rc) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SafeArrayToRectNativeArray(
+        __RPC__in SAFEARRAY * rects,
+        __RPC__deref_out_ecount_full_opt(*rectArrayCount) RECT * *rectArray,
+        __RPC__out int* rectArrayCount) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateProxyFactoryEntry(
+        __RPC__in_opt IUIAutomationProxyFactory * factory,
+        __RPC__deref_out_opt IUIAutomationProxyFactoryEntry *
+            *factoryEntry) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ProxyFactoryMapping(
+        __RPC__deref_out_opt IUIAutomationProxyFactoryMapping *
+        *factoryMapping) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetPropertyProgrammaticName(
+        PROPERTYID property, __RPC__deref_out_opt BSTR * name) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetPatternProgrammaticName(
+        PATTERNID pattern, __RPC__deref_out_opt BSTR * name) = 0;
+    virtual HRESULT STDMETHODCALLTYPE PollForPotentialSupportedPatterns(
+        __RPC__in_opt IUIAutomationElement * pElement,
+        __RPC__deref_out_opt SAFEARRAY * *patternIds,
+        __RPC__deref_out_opt SAFEARRAY * *patternNames) = 0;
+    virtual HRESULT STDMETHODCALLTYPE PollForPotentialSupportedProperties(
+        __RPC__in_opt IUIAutomationElement * pElement,
+        __RPC__deref_out_opt SAFEARRAY * *propertyIds,
+        __RPC__deref_out_opt SAFEARRAY * *propertyNames) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CheckNotSupported(
+        VARIANT value, __RPC__out BOOL * isNotSupported) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ReservedNotSupportedValue(
+        __RPC__deref_out_opt IUnknown * *notSupportedValue) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ReservedMixedAttributeValue(
+        __RPC__deref_out_opt IUnknown * *mixedAttributeValue) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ElementFromIAccessible(
+        __RPC__in_opt IAccessible * accessible, int childId,
+        __RPC__deref_out_opt IUIAutomationElement** element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ElementFromIAccessibleBuildCache(
+        __RPC__in_opt IAccessible * accessible, int childId,
+        __RPC__in_opt IUIAutomationCacheRequest* cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement** element) = 0;
+};
+#ifdef __CRT_UUID_DECL
+__CRT_UUID_DECL(IUIAutomation,
+                0x30cbe57d,
+                0xd9d0,
+                0x452a,
+                0xab,
+                0x13,
+                0x7a,
+                0xc5,
+                0xac,
+                0x48,
+                0x25,
+                0xee)
+#endif
+#endif
+
+#ifndef __IUIAutomationTreeWalker_INTERFACE_DEFINED__
+#define __IUIAutomationTreeWalker_INTERFACE_DEFINED__
+DEFINE_GUID(IID_IUIAutomationTreeWalker,
+            0x4042c624,
+            0x389c,
+            0x4afc,
+            0xa6,
+            0x30,
+            0x9d,
+            0xf8,
+            0x54,
+            0xa5,
+            0x41,
+            0xfc);
+MIDL_INTERFACE("4042c624-389c-4afc-a630-9df854a541fc")
+IUIAutomationTreeWalker : public IUnknown {
+   public:
+    virtual HRESULT STDMETHODCALLTYPE GetParentElement(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__deref_out_opt IUIAutomationElement * *parent) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetFirstChildElement(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__deref_out_opt IUIAutomationElement * *first) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetLastChildElement(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__deref_out_opt IUIAutomationElement * *last) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetNextSiblingElement(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__deref_out_opt IUIAutomationElement * *next) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetPreviousSiblingElement(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__deref_out_opt IUIAutomationElement * *previous) = 0;
+    virtual HRESULT STDMETHODCALLTYPE NormalizeElement(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__deref_out_opt IUIAutomationElement * *normalized) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetParentElementBuildCache(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement * *parent) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetFirstChildElementBuildCache(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement * *first) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetLastChildElementBuildCache(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement * *last) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetNextSiblingElementBuildCache(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement * *next) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetPreviousSiblingElementBuildCache(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement * *previous) = 0;
+    virtual HRESULT STDMETHODCALLTYPE NormalizeElementBuildCache(
+        __RPC__in_opt IUIAutomationElement * element,
+        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__deref_out_opt IUIAutomationElement * *normalized) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Condition(
+        __RPC__deref_out_opt IUIAutomationCondition * *condition) = 0;
+};
+#ifdef __CRT_UUID_DECL
+__CRT_UUID_DECL(IUIAutomationTreeWalker,
+                0x4042c624,
+                0x389c,
+                0x4afc,
+                0xa6,
+                0x30,
+                0x9d,
+                0xf8,
+                0x54,
+                0xa5,
+                0x41,
+                0xfc)
+#endif
+#endif
+
+DEFINE_GUID(CLSID_CUIAutomation,
+            0xff48dba4,
+            0x60ef,
+            0x4201,
+            0xaa,
+            0x87,
+            0x54,
+            0x10,
+            0x3e,
+            0xef,
+            0x59,
+            0x4e);
+
+#endif
+
+typedef class CUIAutomation CUIAutomation;
+
+#pragma endregion
+
+// =====================================================================
+
+struct {
+    int volumeIndicator;
+    int scrollArea;
+    bool middleClickToMute;
+    bool noAutomaticMuteToggle;
+    int volumeChangeStep;
+    bool oldTaskbarOnWin11;
+} g_settings;
+
+enum {
+    WIN_VERSION_UNSUPPORTED = 0,
+    WIN_VERSION_7,
+    WIN_VERSION_8,
+    WIN_VERSION_81,
+    WIN_VERSION_811,
+    WIN_VERSION_10_T1,        // 1507
+    WIN_VERSION_10_T2,        // 1511
+    WIN_VERSION_10_R1,        // 1607
+    WIN_VERSION_10_R2,        // 1703
+    WIN_VERSION_10_R3,        // 1709
+    WIN_VERSION_10_R4,        // 1803
+    WIN_VERSION_10_R5,        // 1809
+    WIN_VERSION_10_19H1,      // 1903, 1909
+    WIN_VERSION_10_20H1,      // 2004, 20H2, 21H1, 21H2
+    WIN_VERSION_SERVER_2022,  // Server 2022
+    WIN_VERSION_11_21H2,
+    WIN_VERSION_11_22H2,
+};
+
+struct SYMBOL_HOOK {
+    std::vector<std::wstring_view> symbols;
+    void** pOriginalFunction;
+    void* hookFunction = nullptr;
+    bool optional = false;
+};
+
+class UIAutomationWrapper {
+   public:
+    UIAutomationWrapper()
+        : isCOMInitialized(false),
+          isUIAutomationInitialized(false),
+          uiAutomationInstance(NULL) {}
+
+    ~UIAutomationWrapper() { deinit(); }
+
+    bool isInitialized() const {
+        return isUIAutomationInitialized && isCOMInitialized;
+    }
+
+    IUIAutomation* getInstance() const { return uiAutomationInstance; }
+
+    bool init() {
+        HRESULT result = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+        if (SUCCEEDED(result)) {
+            isCOMInitialized = true;
+        } else {
+            Wh_Log(L"CoInitializeEx failed\n");
+            return false;
+        }
+
+        result = CoCreateInstance(CLSID_CUIAutomation, NULL,
+                                  CLSCTX_INPROC_SERVER, __uuidof(IUIAutomation),
+                                  (void**)&uiAutomationInstance);
+        if (SUCCEEDED(result)) {
+            isUIAutomationInitialized = true;
+        } else {
+            Wh_Log(L"CoCreateInstance failed\n");
+            return false;
+        }
+        Wh_Log(L"UIAutomationWrapper initilized\n");
+        return true;
+    }
+
+    void deinit() {
+        if (isUIAutomationInitialized) {
+            uiAutomationInstance->Release();
+            uiAutomationInstance = NULL;
+            isUIAutomationInitialized = false;
+        }
+
+        if (isCOMInitialized) {
+            CoUninitialize();
+            isCOMInitialized = false;
+        }
+    }
+
+   private:
+    bool isCOMInitialized;
+    bool isUIAutomationInitialized;
+
+    IUIAutomation* uiAutomationInstance;
+};
+
+static int g_nWinVersion;
+static int g_nExplorerVersion;
+static HWND g_hTaskbarWnd;
+static DWORD g_dwTaskbarThreadId;
+static bool g_initialized = false;
+static bool g_inputSiteProcHooked = false;
+static std::unordered_set<HWND> g_secondaryTaskbarWindows;
+static UIAutomationWrapper g_UIAutomation;
+
+bool IsTaskbarWindow(HWND hWnd);
+VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen);
+BOOL WindowsVersionInit();
+bool GetTaskbarAutohideState();
+void SetTaskbarAutohide(bool enabled);
+bool ToggleTaskbarAutohide();
+bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam);
+
+// =====================================================================
+
+#pragma region hook_magic
+
+// wParam - TRUE to subclass, FALSE to unsubclass
+// lParam - subclass data
+UINT g_subclassRegisteredMsg = RegisterWindowMessage(
+    L"Windhawk_SetWindowSubclassFromAnyThread_taskbar-volume-control");
+
+BOOL SetWindowSubclassFromAnyThread(HWND hWnd,
+                                    SUBCLASSPROC pfnSubclass,
+                                    UINT_PTR uIdSubclass,
+                                    DWORD_PTR dwRefData) {
+    struct SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM {
+        SUBCLASSPROC pfnSubclass;
+        UINT_PTR uIdSubclass;
+        DWORD_PTR dwRefData;
+        BOOL result;
+    };
+
+    DWORD dwThreadId = GetWindowThreadProcessId(hWnd, nullptr);
+    if (dwThreadId == 0) {
+        return FALSE;
+    }
+
+    if (dwThreadId == GetCurrentThreadId()) {
+        return SetWindowSubclass(hWnd, pfnSubclass, uIdSubclass, dwRefData);
+    }
+
+    HHOOK hook = SetWindowsHookEx(
+        WH_CALLWNDPROC,
+        [](int nCode, WPARAM wParam,
+           LPARAM lParam) WINAPI_LAMBDA_RETURN(LRESULT) {
+            if (nCode == HC_ACTION) {
+                const CWPSTRUCT* cwp = (const CWPSTRUCT*)lParam;
+                if (cwp->message == g_subclassRegisteredMsg && cwp->wParam) {
+                    SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM* param =
+                        (SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM*)cwp->lParam;
+                    param->result =
+                        SetWindowSubclass(cwp->hwnd, param->pfnSubclass,
+                                          param->uIdSubclass, param->dwRefData);
+                }
+            }
+
+            return CallNextHookEx(nullptr, nCode, wParam, lParam);
+        },
+        nullptr, dwThreadId);
+    if (!hook) {
+        return FALSE;
+    }
+
+    SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM param;
+    param.pfnSubclass = pfnSubclass;
+    param.uIdSubclass = uIdSubclass;
+    param.dwRefData = dwRefData;
+    param.result = FALSE;
+    SendMessage(hWnd, g_subclassRegisteredMsg, TRUE, (WPARAM)&param);
+
+    UnhookWindowsHookEx(hook);
+
+    return param.result;
+}
+
+LRESULT CALLBACK TaskbarWindowSubclassProc(_In_ HWND hWnd,
+                                           _In_ UINT uMsg,
+                                           _In_ WPARAM wParam,
+                                           _In_ LPARAM lParam,
+                                           _In_ UINT_PTR uIdSubclass,
+                                           _In_ DWORD_PTR dwRefData) {
+    if (uMsg == WM_NCDESTROY || (uMsg == g_subclassRegisteredMsg && !wParam)) {
+        RemoveWindowSubclass(hWnd, TaskbarWindowSubclassProc, 0);
+    }
+
+    LRESULT result = 0;
+    switch (uMsg) {
+        case WM_COPYDATA: {
+            result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+
+            typedef struct _notifyiconidentifier_internal {
+                DWORD dwMagic;    // 0x34753423
+                DWORD dwRequest;  // 1 for (x,y) | 2 for (w,h)
+                DWORD cbSize;     // 0x20
+                DWORD hWndHigh;
+                DWORD hWndLow;
+                UINT uID;
+                GUID guidItem;
+            } NOTIFYICONIDENTIFIER_INTERNAL;
+
+            COPYDATASTRUCT* p_copydata = (COPYDATASTRUCT*)lParam;
+
+            // Change Shell_NotifyIconGetRect handling result for the volume
+            // icon. In case it's not visible, or in Windows 11, it returns 0,
+            // which causes sndvol.exe to ignore the command line position.
+            if (result == 0 && p_copydata->dwData == 0x03 &&
+                p_copydata->cbData == sizeof(NOTIFYICONIDENTIFIER_INTERNAL)) {
+                NOTIFYICONIDENTIFIER_INTERNAL* p_icon_ident =
+                    (NOTIFYICONIDENTIFIER_INTERNAL*)p_copydata->lpData;
+                if (p_icon_ident->dwMagic == 0x34753423 &&
+                    (p_icon_ident->dwRequest == 0x01 ||
+                     p_icon_ident->dwRequest == 0x02) &&
+                    p_icon_ident->cbSize == 0x20 &&
+                    memcmp(&p_icon_ident->guidItem,
+                           "\x73\xAE\x20\x78\xE3\x23\x29\x42\x82\xC1\xE4"
+                           "\x1C\xB6\x7D\x5B\x9C",
+                           sizeof(GUID)) == 0) {
+                    RECT rc;
+                    GetWindowRect(hWnd, &rc);
+
+                    if (p_icon_ident->dwRequest == 0x01)
+                        result = MAKEWORD(rc.left, rc.top);
+                    else
+                        result =
+                            MAKEWORD(rc.right - rc.left, rc.bottom - rc.top);
+                }
+            }
+            break;
+        }
+
+        case WM_POINTERDOWN:
+            if (g_nExplorerVersion < WIN_VERSION_11_21H2 &&
+                OnMouseClick(hWnd, wParam, lParam)) {
+                result = 0;
+            } else {
+                result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+            }
+            break;
+
+        case WM_NCDESTROY:
+            result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+
+            if (hWnd != g_hTaskbarWnd) {
+                g_secondaryTaskbarWindows.erase(hWnd);
+            }
+            break;
+
+        default:
+            result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+            break;
+    }
+
+    return result;
+}
+
+// taskbar event processing method from our hook that waits for mouse middle
+// click
+WNDPROC InputSiteWindowProc_Original;
+LRESULT CALLBACK InputSiteWindowProc_Hook(HWND hWnd,
+                                          UINT uMsg,
+                                          WPARAM wParam,
+                                          LPARAM lParam) {
+    switch (uMsg) {
+        case WM_POINTERDOWN:
+            if (HWND hRootWnd = GetAncestor(hWnd, GA_ROOT);
+                IsTaskbarWindow(hRootWnd) &&
+                OnMouseClick(hRootWnd, wParam, lParam)) {
+                return 0;
+            }
+            break;
+    }
+
+    return InputSiteWindowProc_Original(hWnd, uMsg, wParam, lParam);
+}
+
+void SubclassTaskbarWindow(HWND hWnd) {
+    SetWindowSubclassFromAnyThread(hWnd, TaskbarWindowSubclassProc, 0, 0);
+}
+
+void UnsubclassTaskbarWindow(HWND hWnd) {
+    SendMessage(hWnd, g_subclassRegisteredMsg, FALSE, 0);
+}
+
+// hook to modern taskbar event processing
+void HandleIdentifiedInputSiteWindow(HWND hWnd) {
+    if (!g_dwTaskbarThreadId ||
+        GetWindowThreadProcessId(hWnd, nullptr) != g_dwTaskbarThreadId) {
+        return;
+    }
+
+    HWND hParentWnd = GetParent(hWnd);
+    WCHAR szClassName[64];
+    if (!hParentWnd ||
+        !GetClassName(hParentWnd, szClassName, ARRAYSIZE(szClassName)) ||
+        _wcsicmp(szClassName,
+                 L"Windows.UI.Composition.DesktopWindowContentBridge") != 0) {
+        return;
+    }
+
+    hParentWnd = GetParent(hParentWnd);
+    if (!hParentWnd || !IsTaskbarWindow(hParentWnd)) {
+        return;
+    }
+
+    // At first, I tried to subclass the window instead of hooking its wndproc,
+    // but the inputsite.dll code checks that the value wasn't changed, and
+    // crashes otherwise.
+    void* wndProc = (void*)GetWindowLongPtr(hWnd, GWLP_WNDPROC);
+    Wh_SetFunctionHook(wndProc, (void*)InputSiteWindowProc_Hook,
+                       (void**)&InputSiteWindowProc_Original);
+
+    if (g_initialized) {
+        Wh_ApplyHookOperations();
+    }
+
+    Wh_Log(L"Hooked InputSite wndproc %p", wndProc);
+    g_inputSiteProcHooked = true;
+}
+
+void HandleIdentifiedTaskbarWindow(HWND hWnd) {
+    g_hTaskbarWnd = hWnd;
+    g_dwTaskbarThreadId = GetWindowThreadProcessId(hWnd, nullptr);
+    SubclassTaskbarWindow(hWnd);
+    for (HWND hSecondaryWnd : g_secondaryTaskbarWindows) {
+        SubclassTaskbarWindow(hSecondaryWnd);
+    }
+
+    if (g_nExplorerVersion >= WIN_VERSION_11_21H2 && !g_inputSiteProcHooked) {
+        HWND hXamlIslandWnd = FindWindowEx(
+            hWnd, nullptr, L"Windows.UI.Composition.DesktopWindowContentBridge",
+            nullptr);
+        if (hXamlIslandWnd) {
+            HWND hInputSiteWnd = FindWindowEx(
+                hXamlIslandWnd, nullptr,
+                L"Windows.UI.Input.InputSite.WindowClass", nullptr);
+            if (hInputSiteWnd) {
+                HandleIdentifiedInputSiteWindow(hInputSiteWnd);
+            }
+        }
+    }
+}
+
+void HandleIdentifiedSecondaryTaskbarWindow(HWND hWnd) {
+    if (!g_dwTaskbarThreadId ||
+        GetWindowThreadProcessId(hWnd, nullptr) != g_dwTaskbarThreadId) {
+        return;
+    }
+
+    g_secondaryTaskbarWindows.insert(hWnd);
+    SubclassTaskbarWindow(hWnd);
+
+    if (g_nExplorerVersion >= WIN_VERSION_11_21H2 && !g_inputSiteProcHooked) {
+        HWND hXamlIslandWnd = FindWindowEx(
+            hWnd, nullptr, L"Windows.UI.Composition.DesktopWindowContentBridge",
+            nullptr);
+        if (hXamlIslandWnd) {
+            HWND hInputSiteWnd = FindWindowEx(
+                hXamlIslandWnd, nullptr,
+                L"Windows.UI.Input.InputSite.WindowClass", nullptr);
+            if (hInputSiteWnd) {
+                HandleIdentifiedInputSiteWindow(hInputSiteWnd);
+            }
+        }
+    }
+}
+
+// finds main task bar and returns its hWnd,
+// optinally it finds also secondary taskbars and fills them to the set
+// secondaryTaskbarWindows
+HWND FindCurrentProcessTaskbarWindows(
+    std::unordered_set<HWND>* secondaryTaskbarWindows) {
+    struct ENUM_WINDOWS_PARAM {
+        HWND* hWnd;
+        std::unordered_set<HWND>* secondaryTaskbarWindows;
+    };
+
+    HWND hWnd = nullptr;
+    ENUM_WINDOWS_PARAM param = {&hWnd, secondaryTaskbarWindows};
+    EnumWindows(
+        [](HWND hWnd, LPARAM lParam) WINAPI_LAMBDA_RETURN(BOOL) {
+            ENUM_WINDOWS_PARAM& param = *(ENUM_WINDOWS_PARAM*)lParam;
+
+            DWORD dwProcessId = 0;
+            if (!GetWindowThreadProcessId(hWnd, &dwProcessId) ||
+                dwProcessId != GetCurrentProcessId())
+                return TRUE;
+
+            WCHAR szClassName[32];
+            if (GetClassName(hWnd, szClassName, ARRAYSIZE(szClassName)) == 0)
+                return TRUE;
+
+            if (_wcsicmp(szClassName, L"Shell_TrayWnd") == 0) {
+                *param.hWnd = hWnd;
+            } else if (_wcsicmp(szClassName, L"Shell_SecondaryTrayWnd") == 0) {
+                param.secondaryTaskbarWindows->insert(hWnd);
+            }
+
+            return TRUE;
+        },
+        (LPARAM)&param);
+
+    return hWnd;
+}
+
+using CreateWindowExW_t = decltype(&CreateWindowExW);
+CreateWindowExW_t CreateWindowExW_Original;
+HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle,
+                                 LPCWSTR lpClassName,
+                                 LPCWSTR lpWindowName,
+                                 DWORD dwStyle,
+                                 int X,
+                                 int Y,
+                                 int nWidth,
+                                 int nHeight,
+                                 HWND hWndParent,
+                                 HMENU hMenu,
+                                 HINSTANCE hInstance,
+                                 LPVOID lpParam) {
+    HWND hWnd = CreateWindowExW_Original(dwExStyle, lpClassName, lpWindowName,
+                                         dwStyle, X, Y, nWidth, nHeight,
+                                         hWndParent, hMenu, hInstance, lpParam);
+
+    if (!hWnd)
+        return hWnd;
+
+    BOOL bTextualClassName = ((ULONG_PTR)lpClassName & ~(ULONG_PTR)0xffff) != 0;
+
+    if (bTextualClassName && _wcsicmp(lpClassName, L"Shell_TrayWnd") == 0) {
+        Wh_Log(L"Taskbar window created: %08X", (DWORD)(ULONG_PTR)hWnd);
+        HandleIdentifiedTaskbarWindow(hWnd);
+    } else if (bTextualClassName &&
+               _wcsicmp(lpClassName, L"Shell_SecondaryTrayWnd") == 0) {
+        Wh_Log(L"Secondary taskbar window created: %08X",
+               (DWORD)(ULONG_PTR)hWnd);
+        HandleIdentifiedSecondaryTaskbarWindow(hWnd);
+    }
+
+    return hWnd;
+}
+
+using CreateWindowInBand_t = HWND(WINAPI*)(DWORD dwExStyle,
+                                           LPCWSTR lpClassName,
+                                           LPCWSTR lpWindowName,
+                                           DWORD dwStyle,
+                                           int X,
+                                           int Y,
+                                           int nWidth,
+                                           int nHeight,
+                                           HWND hWndParent,
+                                           HMENU hMenu,
+                                           HINSTANCE hInstance,
+                                           LPVOID lpParam,
+                                           DWORD dwBand);
+CreateWindowInBand_t CreateWindowInBand_Original;
+HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle,
+                                    LPCWSTR lpClassName,
+                                    LPCWSTR lpWindowName,
+                                    DWORD dwStyle,
+                                    int X,
+                                    int Y,
+                                    int nWidth,
+                                    int nHeight,
+                                    HWND hWndParent,
+                                    HMENU hMenu,
+                                    HINSTANCE hInstance,
+                                    LPVOID lpParam,
+                                    DWORD dwBand) {
+    HWND hWnd = CreateWindowInBand_Original(
+        dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight,
+        hWndParent, hMenu, hInstance, lpParam, dwBand);
+    if (!hWnd)
+        return hWnd;
+
+    BOOL bTextualClassName = ((ULONG_PTR)lpClassName & ~(ULONG_PTR)0xffff) != 0;
+
+    if (bTextualClassName &&
+        _wcsicmp(lpClassName, L"Windows.UI.Input.InputSite.WindowClass") == 0) {
+        Wh_Log(L"InputSite window created: %08X", (DWORD)(ULONG_PTR)hWnd);
+        if (g_nExplorerVersion >= WIN_VERSION_11_21H2 &&
+            !g_inputSiteProcHooked) {
+            HandleIdentifiedInputSiteWindow(hWnd);
+        }
+    }
+
+    return hWnd;
+}
+
+bool HookSymbols(HMODULE module,
+                 const SYMBOL_HOOK* symbolHooks,
+                 size_t symbolHooksCount) {
+    const WCHAR cacheVer = L'1';
+    const WCHAR cacheSep = L'#';
+    constexpr size_t cacheMaxSize = 10240;
+
+    WCHAR moduleFilePath[MAX_PATH];
+    if (!GetModuleFileName(module, moduleFilePath, ARRAYSIZE(moduleFilePath))) {
+        Wh_Log(L"GetModuleFileName failed");
+        return false;
+    }
+
+    PCWSTR moduleFileName = wcsrchr(moduleFilePath, L'\\');
+    if (!moduleFileName) {
+        Wh_Log(L"GetModuleFileName returned an unsupported path");
+        return false;
+    }
+
+    moduleFileName++;
+
+    WCHAR cacheBuffer[cacheMaxSize + 1];
+    std::wstring cacheStrKey = std::wstring(L"symbol-cache-") + moduleFileName;
+    Wh_GetStringValue(cacheStrKey.c_str(), cacheBuffer, ARRAYSIZE(cacheBuffer));
+
+    std::wstring_view cacheBufferView(cacheBuffer);
+
+    // https://stackoverflow.com/a/46931770
+    auto splitStringView = [](std::wstring_view s, WCHAR delimiter) {
+        size_t pos_start = 0, pos_end;
+        std::wstring_view token;
+        std::vector<std::wstring_view> res;
+
+        while ((pos_end = s.find(delimiter, pos_start)) !=
+               std::wstring_view::npos) {
+            token = s.substr(pos_start, pos_end - pos_start);
+            pos_start = pos_end + 1;
+            res.push_back(token);
+        }
+
+        res.push_back(s.substr(pos_start));
+        return res;
+    };
+
+    auto cacheParts = splitStringView(cacheBufferView, cacheSep);
+
+    std::vector<bool> symbolResolved(symbolHooksCount, false);
+    std::wstring newSystemCacheStr;
+
+    auto onSymbolResolved = [symbolHooks, symbolHooksCount, &symbolResolved,
+                             &newSystemCacheStr,
+                             module](std::wstring_view symbol, void* address) {
+        for (size_t i = 0; i < symbolHooksCount; i++) {
+            if (symbolResolved[i]) {
+                continue;
+            }
+
+            bool match = false;
+            for (auto hookSymbol : symbolHooks[i].symbols) {
+                if (hookSymbol == symbol) {
+                    match = true;
+                    break;
+                }
+            }
+
+            if (!match) {
+                continue;
+            }
+
+            if (symbolHooks[i].hookFunction) {
+                Wh_SetFunctionHook(address, symbolHooks[i].hookFunction,
+                                   symbolHooks[i].pOriginalFunction);
+                Wh_Log(L"Hooked %p: %.*s", address, symbol.length(),
+                       symbol.data());
+            } else {
+                *symbolHooks[i].pOriginalFunction = address;
+                Wh_Log(L"Found %p: %.*s", address, symbol.length(),
+                       symbol.data());
+            }
+
+            symbolResolved[i] = true;
+
+            newSystemCacheStr += cacheSep;
+            newSystemCacheStr += symbol;
+            newSystemCacheStr += cacheSep;
+            newSystemCacheStr +=
+                std::to_wstring((ULONG_PTR)address - (ULONG_PTR)module);
+
+            break;
+        }
+    };
+
+    IMAGE_DOS_HEADER* dosHeader = (IMAGE_DOS_HEADER*)module;
+    IMAGE_NT_HEADERS* header =
+        (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
+    auto timeStamp = std::to_wstring(header->FileHeader.TimeDateStamp);
+    auto imageSize = std::to_wstring(header->OptionalHeader.SizeOfImage);
+
+    newSystemCacheStr += cacheVer;
+    newSystemCacheStr += cacheSep;
+    newSystemCacheStr += timeStamp;
+    newSystemCacheStr += cacheSep;
+    newSystemCacheStr += imageSize;
+
+    if (cacheParts.size() >= 3 &&
+        cacheParts[0] == std::wstring_view(&cacheVer, 1) &&
+        cacheParts[1] == timeStamp && cacheParts[2] == imageSize) {
+        for (size_t i = 3; i + 1 < cacheParts.size(); i += 2) {
+            auto symbol = cacheParts[i];
+            auto address = cacheParts[i + 1];
+            if (address.length() == 0) {
+                continue;
+            }
+
+            void* addressPtr =
+                (void*)(std::stoull(std::wstring(address), nullptr, 10) +
+                        (ULONG_PTR)module);
+
+            onSymbolResolved(symbol, addressPtr);
+        }
+
+        for (size_t i = 0; i < symbolHooksCount; i++) {
+            if (symbolResolved[i] || !symbolHooks[i].optional) {
+                continue;
+            }
+
+            size_t noAddressMatchCount = 0;
+            for (size_t j = 3; j + 1 < cacheParts.size(); j += 2) {
+                auto symbol = cacheParts[j];
+                auto address = cacheParts[j + 1];
+                if (address.length() != 0) {
+                    continue;
+                }
+
+                for (auto hookSymbol : symbolHooks[i].symbols) {
+                    if (hookSymbol == symbol) {
+                        noAddressMatchCount++;
+                        break;
+                    }
+                }
+            }
+
+            if (noAddressMatchCount == symbolHooks[i].symbols.size()) {
+                Wh_Log(L"Optional symbol %d doesn't exist (from cache)", i);
+                symbolResolved[i] = true;
+            }
+        }
+
+        if (std::all_of(symbolResolved.begin(), symbolResolved.end(),
+                        [](bool b) { return b; })) {
+            return true;
+        }
+    }
+
+    Wh_Log(L"Couldn't resolve all symbols from cache");
+
+    WH_FIND_SYMBOL findSymbol;
+    HANDLE findSymbolHandle = Wh_FindFirstSymbol(module, nullptr, &findSymbol);
+    if (!findSymbolHandle) {
+        Wh_Log(L"Wh_FindFirstSymbol failed");
+        return false;
+    }
+
+    do {
+        onSymbolResolved(findSymbol.symbol, findSymbol.address);
+    } while (Wh_FindNextSymbol(findSymbolHandle, &findSymbol));
+
+    Wh_FindCloseSymbol(findSymbolHandle);
+
+    for (size_t i = 0; i < symbolHooksCount; i++) {
+        if (symbolResolved[i]) {
+            continue;
+        }
+
+        if (!symbolHooks[i].optional) {
+            Wh_Log(L"Unresolved symbol: %d", i);
+            return false;
+        }
+
+        Wh_Log(L"Optional symbol %d doesn't exist", i);
+
+        for (auto hookSymbol : symbolHooks[i].symbols) {
+            newSystemCacheStr += cacheSep;
+            newSystemCacheStr += hookSymbol;
+            newSystemCacheStr += cacheSep;
+        }
+    }
+
+    if (newSystemCacheStr.length() <= cacheMaxSize) {
+        Wh_SetStringValue(cacheStrKey.c_str(), newSystemCacheStr.c_str());
+    } else {
+        Wh_Log(L"Cache is too large (%Iu)", newSystemCacheStr.length());
+    }
+
+    return true;
+}
+
+bool GetTaskbarViewDllPath(WCHAR path[MAX_PATH]) {
+    WCHAR szWindowsDirectory[MAX_PATH];
+    if (!GetWindowsDirectory(szWindowsDirectory,
+                             ARRAYSIZE(szWindowsDirectory))) {
+        Wh_Log(L"GetWindowsDirectory failed");
+        return false;
+    }
+
+    // Windows 11 version 22H2.
+    wcscpy_s(path, MAX_PATH, szWindowsDirectory);
+    wcscat_s(
+        path, MAX_PATH,
+        LR"(\SystemApps\MicrosoftWindows.Client.Core_cw5n1h2txyewy\Taskbar.View.dll)");
+    if (GetFileAttributes(path) != INVALID_FILE_ATTRIBUTES) {
+        return true;
+    }
+
+    // Windows 11 version 21H2.
+    wcscpy_s(path, MAX_PATH, szWindowsDirectory);
+    wcscat_s(
+        path, MAX_PATH,
+        LR"(\SystemApps\MicrosoftWindows.Client.CBS_cw5n1h2txyewy\ExplorerExtensions.dll)");
+    if (GetFileAttributes(path) != INVALID_FILE_ATTRIBUTES) {
+        return true;
+    }
+
+    return false;
+}
+
+#pragma endregion  // hook_magic
+
+// =====================================================================
+
+#pragma region functions
+
+bool IsTaskbarWindow(HWND hWnd) {
+    WCHAR szClassName[32];
+    if (!GetClassName(hWnd, szClassName, ARRAYSIZE(szClassName))) {
+        return false;
+    }
+
+    return _wcsicmp(szClassName, L"Shell_TrayWnd") == 0 ||
+           _wcsicmp(szClassName, L"Shell_SecondaryTrayWnd") == 0;
+}
+
+VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
+    HRSRC hResource;
+    HGLOBAL hGlobal;
+    void* pData;
+    void* pFixedFileInfo;
+    UINT uPtrLen;
+
+    pFixedFileInfo = NULL;
+    uPtrLen = 0;
+
+    hResource =
+        FindResource(hModule, MAKEINTRESOURCE(VS_VERSION_INFO), RT_VERSION);
+    if (hResource != NULL) {
+        hGlobal = LoadResource(hModule, hResource);
+        if (hGlobal != NULL) {
+            pData = LockResource(hGlobal);
+            if (pData != NULL) {
+                if (!VerQueryValue(pData, L"\\", &pFixedFileInfo, &uPtrLen) ||
+                    uPtrLen == 0) {
+                    pFixedFileInfo = NULL;
+                    uPtrLen = 0;
+                }
+            }
+        }
+    }
+
+    if (puPtrLen)
+        *puPtrLen = uPtrLen;
+
+    return (VS_FIXEDFILEINFO*)pFixedFileInfo;
+}
+
+BOOL WindowsVersionInit() {
+    g_nWinVersion = WIN_VERSION_UNSUPPORTED;
+
+    VS_FIXEDFILEINFO* pFixedFileInfo = GetModuleVersionInfo(NULL, NULL);
+    if (!pFixedFileInfo)
+        return FALSE;
+
+    WORD nMajor = HIWORD(pFixedFileInfo->dwFileVersionMS);
+    WORD nMinor = LOWORD(pFixedFileInfo->dwFileVersionMS);
+    WORD nBuild = HIWORD(pFixedFileInfo->dwFileVersionLS);
+    WORD nQFE = LOWORD(pFixedFileInfo->dwFileVersionLS);
+
+    switch (nMajor) {
+        case 6:
+            switch (nMinor) {
+                case 1:
+                    g_nWinVersion = WIN_VERSION_7;
+                    break;
+
+                case 2:
+                    g_nWinVersion = WIN_VERSION_8;
+                    break;
+
+                case 3:
+                    if (nQFE < 17000)
+                        g_nWinVersion = WIN_VERSION_81;
+                    else
+                        g_nWinVersion = WIN_VERSION_811;
+                    break;
+
+                case 4:
+                    g_nWinVersion = WIN_VERSION_10_T1;
+                    break;
+            }
+            break;
+
+        case 10:
+            if (nBuild <= 10240)
+                g_nWinVersion = WIN_VERSION_10_T1;
+            else if (nBuild <= 10586)
+                g_nWinVersion = WIN_VERSION_10_T2;
+            else if (nBuild <= 14393)
+                g_nWinVersion = WIN_VERSION_10_R1;
+            else if (nBuild <= 15063)
+                g_nWinVersion = WIN_VERSION_10_R2;
+            else if (nBuild <= 16299)
+                g_nWinVersion = WIN_VERSION_10_R3;
+            else if (nBuild <= 17134)
+                g_nWinVersion = WIN_VERSION_10_R4;
+            else if (nBuild <= 17763)
+                g_nWinVersion = WIN_VERSION_10_R5;
+            else if (nBuild <= 18362)
+                g_nWinVersion = WIN_VERSION_10_19H1;
+            else if (nBuild <= 19041)
+                g_nWinVersion = WIN_VERSION_10_20H1;
+            else if (nBuild <= 20348)
+                g_nWinVersion = WIN_VERSION_SERVER_2022;
+            else if (nBuild <= 22000)
+                g_nWinVersion = WIN_VERSION_11_21H2;
+            else
+                g_nWinVersion = WIN_VERSION_11_22H2;
+            break;
+    }
+
+    if (g_nWinVersion == WIN_VERSION_UNSUPPORTED)
+        return FALSE;
+
+    return TRUE;
+}
+
+bool GetTaskbarAutohideState() {
+    if (g_hTaskbarWnd == NULL) {
+        return false;
+    }
+    APPBARDATA msgData{};
+    msgData.cbSize = sizeof(msgData);
+    msgData.hWnd = g_hTaskbarWnd;
+    LPARAM state = SHAppBarMessage(ABM_GETSTATE, &msgData);
+    return state & ABS_AUTOHIDE;
+}
+
+void SetTaskbarAutohide(bool enabled) {
+    if (g_hTaskbarWnd == NULL) {
+        return;
+    }
+
+    APPBARDATA msgData{};
+    msgData.cbSize = sizeof(msgData);
+    msgData.hWnd = g_hTaskbarWnd;
+    msgData.lParam = enabled ? ABS_AUTOHIDE : ABS_ALWAYSONTOP;
+    SHAppBarMessage(ABM_SETSTATE, &msgData);
+}
+
+bool ToggleTaskbarAutohide() {
+    const bool isEnabled = GetTaskbarAutohideState();
+    SetTaskbarAutohide(!isEnabled);
+    return !isEnabled;
+}
+
+#pragma endregion  // functions
+
+// =====================================================================
+
+// main body of the mod called every time a taskbar is clicked
+bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam) {
+    if (GetCapture() != NULL) {
+        return false;
+    }
+
+    if (IS_POINTER_THIRDBUTTON_WPARAM(wParam) == 0) {
+        return false;
+    }
+
+    POINTER_INFO pointerInfo{};
+    BOOL success = GetPointerInfo(GET_POINTERID_WPARAM(wParam), &pointerInfo);
+    if (!success) {
+        return false;
+    }
+
+    POINT pointerLocation = pointerInfo.ptPixelLocation;
+    Wh_Log(L"Middle mouse clicked at x=%ld, y=%ld", pointerLocation.x,
+           pointerLocation.y);
+
+    IUIAutomation* pUIAutomation = g_UIAutomation.getInstance();
+    if (pUIAutomation == NULL) {
+        Wh_Log(L"UIAutomationWrapper failed to get instance\n");
+        return false;
+    }
+
+    IUIAutomationElement* pWindowElementRaw = NULL;
+    HRESULT hr =
+        pUIAutomation->ElementFromPoint(pointerLocation, &pWindowElementRaw);
+    if (FAILED(hr) || (pWindowElementRaw == NULL)) {
+        Wh_Log(L"Failed to retrieve UI element from mouse click\n");
+        return false;
+    }
+
+    BSTR currentAutomationId;
+    hr = pWindowElementRaw->get_CurrentAutomationId(&currentAutomationId);
+    if (FAILED(hr)) {
+        Wh_Log(L"Failed to retrieve the name of the UI element clicked.");
+        pWindowElementRaw->Release();
+        return false;
+    }
+
+    Wh_Log(L"Clicked element: %s", currentAutomationId);
+
+    if (wcscmp(currentAutomationId, L"TaskbarFrame") == 0) {
+        const bool isAutohideEnabled = ToggleTaskbarAutohide();
+        Wh_Log(L"Setting taskbar autohide state to %s",
+               isAutohideEnabled ? L"enabled" : L"disabled");
+    }
+
+    SysFreeString(currentAutomationId);      
+    pWindowElementRaw->Release();
+    return false;
+}
+
+////////////////////////////////////////////////////////////
+
+BOOL Wh_ModInit() {
+    Wh_Log(L">");
+
+    if (!WindowsVersionInit()) {
+        Wh_Log(L"Unsupported Windows version");
+        return FALSE;
+    }
+
+    g_nExplorerVersion = g_nWinVersion;
+    if (g_nExplorerVersion >= WIN_VERSION_11_21H2 &&
+        g_settings.oldTaskbarOnWin11) {
+        g_nExplorerVersion = WIN_VERSION_10_20H1;
+    }
+
+    Wh_SetFunctionHook((void*)CreateWindowExW, (void*)CreateWindowExW_Hook,
+                       (void**)&CreateWindowExW_Original);
+
+    HMODULE user32Module = LoadLibrary(L"user32.dll");
+    if (user32Module) {
+        void* pCreateWindowInBand =
+            (void*)GetProcAddress(user32Module, "CreateWindowInBand");
+        if (pCreateWindowInBand) {
+            Wh_SetFunctionHook(pCreateWindowInBand,
+                               (void*)CreateWindowInBand_Hook,
+                               (void**)&CreateWindowInBand_Original);
+        }
+    }
+
+    WNDCLASS wndclass;
+    if (GetClassInfo(GetModuleHandle(NULL), L"Shell_TrayWnd", &wndclass)) {
+        HWND hWnd =
+            FindCurrentProcessTaskbarWindows(&g_secondaryTaskbarWindows);
+        if (hWnd) {
+            HandleIdentifiedTaskbarWindow(hWnd);
+        }
+    }
+
+    if (!g_UIAutomation.init()) {
+        Wh_Log(L"UIAutomationWrapper failed to initialize\n");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L">");
+
+    if (g_hTaskbarWnd) {
+        UnsubclassTaskbarWindow(g_hTaskbarWnd);
+
+        for (HWND hSecondaryWnd : g_secondaryTaskbarWindows) {
+            UnsubclassTaskbarWindow(hSecondaryWnd);
+        }
+    }
+
+    g_UIAutomation.deinit();
+}

--- a/mods/toggle-taskbar-autohide.wh.cpp
+++ b/mods/toggle-taskbar-autohide.wh.cpp
@@ -20,7 +20,8 @@
 // ==WindhawkModReadme==
 /*
 # Toggle taskbar autohide
-Toggle taskbar autohide feature with middle mouse click on the taskbar. Whenever you middle click on a free space on your taskbar (outside other UI elemwnts on the taskbar), taskbar's autohide feature gets turned on or off.
+Toggle taskbar autohide feature with middle mouse click on the taskbar. Whenever you middle click on a free space on your taskbar (outside other UI
+elemwnts on the taskbar), taskbar's autohide feature gets turned on or off.
 
 ![Demonstration](https://i.imgur.com/B6mtUj9.gif)
 */
@@ -100,6 +101,7 @@ Toggle taskbar autohide feature with middle mouse click on the taskbar. Whenever
 
 // =====================================================================
 
+// following include are taken from Qt project since builtin compiler is missing those definitions
 #pragma region uiautomation_includes
 
 #include <initguid.h>
@@ -134,7 +136,7 @@ typedef int CONTROLTYPEID;
 typedef int LANDMARKTYPEID;
 typedef int METADATAID;
 
-typedef void* UIA_HWND;
+typedef void *UIA_HWND;
 
 // enum NavigateDirection {
 //     NavigateDirection_Parent           = 0,
@@ -156,11 +158,7 @@ typedef void* UIA_HWND;
 //     ProviderOptions_UseClientCoordinates    = 0x100
 // };
 
-enum SupportedTextSelection {
-    SupportedTextSelection_None = 0,
-    SupportedTextSelection_Single = 1,
-    SupportedTextSelection_Multiple = 2
-};
+enum SupportedTextSelection { SupportedTextSelection_None = 0, SupportedTextSelection_Single = 1, SupportedTextSelection_Multiple = 2 };
 
 enum TextUnit {
     TextUnit_Character = 0,
@@ -172,10 +170,7 @@ enum TextUnit {
     TextUnit_Document = 6
 };
 
-enum TextPatternRangeEndpoint {
-    TextPatternRangeEndpoint_Start = 0,
-    TextPatternRangeEndpoint_End = 1
-};
+enum TextPatternRangeEndpoint { TextPatternRangeEndpoint_Start = 0, TextPatternRangeEndpoint_End = 1 };
 
 enum TextDecorationLineStyle {
     TextDecorationLineStyle_None = 0,
@@ -199,23 +194,11 @@ enum TextDecorationLineStyle {
     TextDecorationLineStyle_Other = -1
 };
 
-enum CaretPosition {
-    CaretPosition_Unknown = 0,
-    CaretPosition_EndOfLine = 1,
-    CaretPosition_BeginningOfLine = 2
-};
+enum CaretPosition { CaretPosition_Unknown = 0, CaretPosition_EndOfLine = 1, CaretPosition_BeginningOfLine = 2 };
 
-enum ToggleState {
-    ToggleState_Off = 0,
-    ToggleState_On = 1,
-    ToggleState_Indeterminate = 2
-};
+enum ToggleState { ToggleState_Off = 0, ToggleState_On = 1, ToggleState_Indeterminate = 2 };
 
-enum RowOrColumnMajor {
-    RowOrColumnMajor_RowMajor = 0,
-    RowOrColumnMajor_ColumnMajor = 1,
-    RowOrColumnMajor_Indeterminate = 2
-};
+enum RowOrColumnMajor { RowOrColumnMajor_RowMajor = 0, RowOrColumnMajor_ColumnMajor = 1, RowOrColumnMajor_Indeterminate = 2 };
 
 enum TreeScope {
     TreeScope_None = 0,
@@ -224,26 +207,14 @@ enum TreeScope {
     TreeScope_Descendants = 0x4,
     TreeScope_Parent = 0x8,
     TreeScope_Ancestors = 0x10,
-    TreeScope_Subtree =
-        TreeScope_Element | TreeScope_Children | TreeScope_Descendants
+    TreeScope_Subtree = TreeScope_Element | TreeScope_Children | TreeScope_Descendants
 };
 
-enum OrientationType {
-    OrientationType_None = 0,
-    OrientationType_Horizontal = 1,
-    OrientationType_Vertical = 2
-};
+enum OrientationType { OrientationType_None = 0, OrientationType_Horizontal = 1, OrientationType_Vertical = 2 };
 
-enum PropertyConditionFlags {
-    PropertyConditionFlags_None = 0,
-    PropertyConditionFlags_IgnoreCase = 1
-};
+enum PropertyConditionFlags { PropertyConditionFlags_None = 0, PropertyConditionFlags_IgnoreCase = 1 };
 
-enum WindowVisualState {
-    WindowVisualState_Normal = 0,
-    WindowVisualState_Maximized = 1,
-    WindowVisualState_Minimized = 2
-};
+enum WindowVisualState { WindowVisualState_Normal = 0, WindowVisualState_Maximized = 1, WindowVisualState_Minimized = 2 };
 
 enum WindowInteractionState {
     WindowInteractionState_Running = 0,
@@ -313,503 +284,260 @@ struct IAccessible;
 #endif /* __IAccessible_FWD_DEFINED__ */
 
 #define __IUIAutomationElement_INTERFACE_DEFINED__
-DEFINE_GUID(IID_IUIAutomationElement,
-            0xd22108aa,
-            0x8ac5,
-            0x49a5,
-            0x83,
-            0x7b,
-            0x37,
-            0xbb,
-            0xb3,
-            0xd7,
-            0x59,
-            0x1e);
+DEFINE_GUID(IID_IUIAutomationElement, 0xd22108aa, 0x8ac5, 0x49a5, 0x83, 0x7b, 0x37, 0xbb, 0xb3, 0xd7, 0x59, 0x1e);
 MIDL_INTERFACE("d22108aa-8ac5-49a5-837b-37bbb3d7591e")
 IUIAutomationElement : public IUnknown {
-   public:
+  public:
     virtual HRESULT STDMETHODCALLTYPE SetFocus() = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetRuntimeId(
-        __RPC__deref_out_opt SAFEARRAY * *runtimeId) = 0;
-    virtual HRESULT STDMETHODCALLTYPE FindFirst(
-        enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
-        __RPC__deref_out_opt IUIAutomationElement * *found) = 0;
-    virtual HRESULT STDMETHODCALLTYPE FindAll(
-        enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
-        __RPC__deref_out_opt IUIAutomationElementArray * *found) = 0;
-    virtual HRESULT STDMETHODCALLTYPE FindFirstBuildCache(
-        enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement * *found) = 0;
-    virtual HRESULT STDMETHODCALLTYPE FindAllBuildCache(
-        enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElementArray * *found) = 0;
-    virtual HRESULT STDMETHODCALLTYPE BuildUpdatedCache(
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement * *updatedElement) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetCurrentPropertyValue(
-        PROPERTYID propertyId, __RPC__out VARIANT * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetCurrentPropertyValueEx(
-        PROPERTYID propertyId, BOOL ignoreDefaultValue,
-        __RPC__out VARIANT * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetCachedPropertyValue(
-        PROPERTYID propertyId, __RPC__out VARIANT * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetCachedPropertyValueEx(
-        PROPERTYID propertyId, BOOL ignoreDefaultValue,
-        __RPC__out VARIANT * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetCurrentPatternAs(
-        PATTERNID patternId, __RPC__in REFIID riid,
-        __RPC__deref_out_opt void** patternObject) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetCachedPatternAs(
-        PATTERNID patternId, __RPC__in REFIID riid,
-        __RPC__deref_out_opt void** patternObject) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetCurrentPattern(
-        PATTERNID patternId,
-        __RPC__deref_out_opt IUnknown * *patternObject) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetCachedPattern(
-        PATTERNID patternId,
-        __RPC__deref_out_opt IUnknown * *patternObject) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetCachedParent(
-        __RPC__deref_out_opt IUIAutomationElement * *parent) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetCachedChildren(
-        __RPC__deref_out_opt IUIAutomationElementArray * *children) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentProcessId(
-        __RPC__out int* retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentControlType(
-        __RPC__out CONTROLTYPEID * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentLocalizedControlType(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentName(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentAcceleratorKey(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentAccessKey(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentHasKeyboardFocus(
-        __RPC__out BOOL * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsKeyboardFocusable(
-        __RPC__out BOOL * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsEnabled(__RPC__out BOOL *
-                                                           retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentAutomationId(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentClassName(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentHelpText(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentCulture(
-        __RPC__out int* retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsControlElement(
-        __RPC__out BOOL * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsContentElement(
-        __RPC__out BOOL * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsPassword(__RPC__out BOOL *
-                                                            retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentNativeWindowHandle(
-        __RPC__deref_out_opt UIA_HWND * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentItemType(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsOffscreen(__RPC__out BOOL *
-                                                             retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentOrientation(
-        __RPC__out enum OrientationType * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentFrameworkId(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsRequiredForForm(
-        __RPC__out BOOL * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentItemStatus(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentBoundingRectangle(
-        __RPC__out RECT * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentLabeledBy(
-        __RPC__deref_out_opt IUIAutomationElement * *retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentAriaRole(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentAriaProperties(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsDataValidForForm(
-        __RPC__out BOOL * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentControllerFor(
-        __RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentDescribedBy(
-        __RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentFlowsTo(
-        __RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CurrentProviderDescription(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedProcessId(
-        __RPC__out int* retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedControlType(
-        __RPC__out CONTROLTYPEID * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedLocalizedControlType(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedName(__RPC__deref_out_opt BSTR *
-                                                     retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedAcceleratorKey(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedAccessKey(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedHasKeyboardFocus(
-        __RPC__out BOOL * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedIsKeyboardFocusable(
-        __RPC__out BOOL * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedIsEnabled(__RPC__out BOOL *
-                                                          retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedAutomationId(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedClassName(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedHelpText(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedCulture(
-        __RPC__out int* retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedIsControlElement(
-        __RPC__out BOOL * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedIsContentElement(
-        __RPC__out BOOL * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedIsPassword(__RPC__out BOOL *
-                                                           retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedNativeWindowHandle(
-        __RPC__deref_out_opt UIA_HWND * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedItemType(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedIsOffscreen(__RPC__out BOOL *
-                                                            retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedOrientation(
-        __RPC__out enum OrientationType * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedFrameworkId(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedIsRequiredForForm(
-        __RPC__out BOOL * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedItemStatus(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedBoundingRectangle(
-        __RPC__out RECT * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedLabeledBy(
-        __RPC__deref_out_opt IUIAutomationElement * *retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedAriaRole(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedAriaProperties(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedIsDataValidForForm(
-        __RPC__out BOOL * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedControllerFor(
-        __RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedDescribedBy(
-        __RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedFlowsTo(
-        __RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_CachedProviderDescription(
-        __RPC__deref_out_opt BSTR * retVal) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetClickablePoint(
-        __RPC__out POINT * clickable, __RPC__out BOOL * gotClickable) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetRuntimeId(__RPC__deref_out_opt SAFEARRAY * *runtimeId) = 0;
+    virtual HRESULT STDMETHODCALLTYPE FindFirst(enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
+                                                __RPC__deref_out_opt IUIAutomationElement * *found) = 0;
+    virtual HRESULT STDMETHODCALLTYPE FindAll(enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
+                                              __RPC__deref_out_opt IUIAutomationElementArray * *found) = 0;
+    virtual HRESULT STDMETHODCALLTYPE FindFirstBuildCache(enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
+                                                          __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                          __RPC__deref_out_opt IUIAutomationElement * *found) = 0;
+    virtual HRESULT STDMETHODCALLTYPE FindAllBuildCache(enum TreeScope scope, __RPC__in_opt IUIAutomationCondition * condition,
+                                                        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                        __RPC__deref_out_opt IUIAutomationElementArray * *found) = 0;
+    virtual HRESULT STDMETHODCALLTYPE BuildUpdatedCache(__RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                        __RPC__deref_out_opt IUIAutomationElement * *updatedElement) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCurrentPropertyValue(PROPERTYID propertyId, __RPC__out VARIANT * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCurrentPropertyValueEx(PROPERTYID propertyId, BOOL ignoreDefaultValue, __RPC__out VARIANT * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedPropertyValue(PROPERTYID propertyId, __RPC__out VARIANT * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedPropertyValueEx(PROPERTYID propertyId, BOOL ignoreDefaultValue, __RPC__out VARIANT * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCurrentPatternAs(PATTERNID patternId, __RPC__in REFIID riid, __RPC__deref_out_opt void **patternObject) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedPatternAs(PATTERNID patternId, __RPC__in REFIID riid, __RPC__deref_out_opt void **patternObject) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCurrentPattern(PATTERNID patternId, __RPC__deref_out_opt IUnknown * *patternObject) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedPattern(PATTERNID patternId, __RPC__deref_out_opt IUnknown * *patternObject) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedParent(__RPC__deref_out_opt IUIAutomationElement * *parent) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedChildren(__RPC__deref_out_opt IUIAutomationElementArray * *children) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentProcessId(__RPC__out int *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentControlType(__RPC__out CONTROLTYPEID * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentLocalizedControlType(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentName(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentAcceleratorKey(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentAccessKey(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentHasKeyboardFocus(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsKeyboardFocusable(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsEnabled(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentAutomationId(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentClassName(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentHelpText(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentCulture(__RPC__out int *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsControlElement(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsContentElement(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsPassword(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentNativeWindowHandle(__RPC__deref_out_opt UIA_HWND * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentItemType(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsOffscreen(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentOrientation(__RPC__out enum OrientationType * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentFrameworkId(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsRequiredForForm(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentItemStatus(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentBoundingRectangle(__RPC__out RECT * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentLabeledBy(__RPC__deref_out_opt IUIAutomationElement * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentAriaRole(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentAriaProperties(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentIsDataValidForForm(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentControllerFor(__RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentDescribedBy(__RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentFlowsTo(__RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CurrentProviderDescription(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedProcessId(__RPC__out int *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedControlType(__RPC__out CONTROLTYPEID * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedLocalizedControlType(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedName(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedAcceleratorKey(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedAccessKey(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedHasKeyboardFocus(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsKeyboardFocusable(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsEnabled(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedAutomationId(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedClassName(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedHelpText(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedCulture(__RPC__out int *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsControlElement(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsContentElement(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsPassword(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedNativeWindowHandle(__RPC__deref_out_opt UIA_HWND * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedItemType(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsOffscreen(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedOrientation(__RPC__out enum OrientationType * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedFrameworkId(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsRequiredForForm(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedItemStatus(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedBoundingRectangle(__RPC__out RECT * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedLabeledBy(__RPC__deref_out_opt IUIAutomationElement * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedAriaRole(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedAriaProperties(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedIsDataValidForForm(__RPC__out BOOL * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedControllerFor(__RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedDescribedBy(__RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedFlowsTo(__RPC__deref_out_opt IUIAutomationElementArray * *retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_CachedProviderDescription(__RPC__deref_out_opt BSTR * retVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetClickablePoint(__RPC__out POINT * clickable, __RPC__out BOOL * gotClickable) = 0;
 };
 #ifdef __CRT_UUID_DECL
-__CRT_UUID_DECL(IUIAutomationElement,
-                0xd22108aa,
-                0x8ac5,
-                0x49a5,
-                0x83,
-                0x7b,
-                0x37,
-                0xbb,
-                0xb3,
-                0xd7,
-                0x59,
-                0x1e)
+__CRT_UUID_DECL(IUIAutomationElement, 0xd22108aa, 0x8ac5, 0x49a5, 0x83, 0x7b, 0x37, 0xbb, 0xb3, 0xd7, 0x59, 0x1e)
 #endif
 #endif
 
 #ifndef __IUIAutomation_INTERFACE_DEFINED__
 #define __IUIAutomation_INTERFACE_DEFINED__
-DEFINE_GUID(IID_IUIAutomation,
-            0x30cbe57d,
-            0xd9d0,
-            0x452a,
-            0xab,
-            0x13,
-            0x7a,
-            0xc5,
-            0xac,
-            0x48,
-            0x25,
-            0xee);
+DEFINE_GUID(IID_IUIAutomation, 0x30cbe57d, 0xd9d0, 0x452a, 0xab, 0x13, 0x7a, 0xc5, 0xac, 0x48, 0x25, 0xee);
 MIDL_INTERFACE("30cbe57d-d9d0-452a-ab13-7ac5ac4825ee")
 IUIAutomation : public IUnknown {
-   public:
-    virtual HRESULT STDMETHODCALLTYPE CompareElements(
-        __RPC__in_opt IUIAutomationElement * el1,
-        __RPC__in_opt IUIAutomationElement * el2,
-        __RPC__out BOOL * areSame) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CompareRuntimeIds(
-        __RPC__in SAFEARRAY * runtimeId1, __RPC__in SAFEARRAY * runtimeId2,
-        __RPC__out BOOL * areSame) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetRootElement(
-        __RPC__deref_out_opt IUIAutomationElement * *root) = 0;
-    virtual HRESULT STDMETHODCALLTYPE ElementFromHandle(
-        __RPC__in UIA_HWND hwnd,
-        __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
-    virtual HRESULT STDMETHODCALLTYPE ElementFromPoint(
-        POINT pt, __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetFocusedElement(
-        __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetRootElementBuildCache(
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement * *root) = 0;
-    virtual HRESULT STDMETHODCALLTYPE ElementFromHandleBuildCache(
-        __RPC__in UIA_HWND hwnd,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
-    virtual HRESULT STDMETHODCALLTYPE ElementFromPointBuildCache(
-        POINT pt, __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetFocusedElementBuildCache(
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreateTreeWalker(
-        __RPC__in_opt IUIAutomationCondition * pCondition,
-        __RPC__deref_out_opt IUIAutomationTreeWalker * *walker) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_ControlViewWalker(
-        __RPC__deref_out_opt IUIAutomationTreeWalker * *walker) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_ContentViewWalker(
-        __RPC__deref_out_opt IUIAutomationTreeWalker * *walker) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_RawViewWalker(
-        __RPC__deref_out_opt IUIAutomationTreeWalker * *walker) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_RawViewCondition(
-        __RPC__deref_out_opt IUIAutomationCondition * *condition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_ControlViewCondition(
-        __RPC__deref_out_opt IUIAutomationCondition * *condition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_ContentViewCondition(
-        __RPC__deref_out_opt IUIAutomationCondition * *condition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreateCacheRequest(
-        __RPC__deref_out_opt IUIAutomationCacheRequest * *cacheRequest) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreateTrueCondition(
-        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreateFalseCondition(
-        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreatePropertyCondition(
-        PROPERTYID propertyId, VARIANT value,
-        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreatePropertyConditionEx(
-        PROPERTYID propertyId, VARIANT value, enum PropertyConditionFlags flags,
-        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreateAndCondition(
-        __RPC__in_opt IUIAutomationCondition * condition1,
-        __RPC__in_opt IUIAutomationCondition * condition2,
-        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreateAndConditionFromArray(
-        __RPC__in_opt SAFEARRAY * conditions,
-        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreateAndConditionFromNativeArray(
-        __RPC__in_ecount_full(conditionCount) IUIAutomationCondition *
-            *conditions,
-        int conditionCount,
-        __RPC__deref_out_opt IUIAutomationCondition** newCondition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreateOrCondition(
-        __RPC__in_opt IUIAutomationCondition * condition1,
-        __RPC__in_opt IUIAutomationCondition * condition2,
-        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreateOrConditionFromArray(
-        __RPC__in_opt SAFEARRAY * conditions,
-        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreateOrConditionFromNativeArray(
-        __RPC__in_ecount_full(conditionCount) IUIAutomationCondition *
-            *conditions,
-        int conditionCount,
-        __RPC__deref_out_opt IUIAutomationCondition** newCondition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreateNotCondition(
-        __RPC__in_opt IUIAutomationCondition * condition,
-        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
-    virtual HRESULT STDMETHODCALLTYPE AddAutomationEventHandler(
-        EVENTID eventId, __RPC__in_opt IUIAutomationElement * element,
-        enum TreeScope scope,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__in_opt IUIAutomationEventHandler * handler) = 0;
-    virtual HRESULT STDMETHODCALLTYPE RemoveAutomationEventHandler(
-        EVENTID eventId, __RPC__in_opt IUIAutomationElement * element,
-        __RPC__in_opt IUIAutomationEventHandler * handler) = 0;
+  public:
+    virtual HRESULT STDMETHODCALLTYPE CompareElements(__RPC__in_opt IUIAutomationElement * el1, __RPC__in_opt IUIAutomationElement * el2,
+                                                      __RPC__out BOOL * areSame) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CompareRuntimeIds(__RPC__in SAFEARRAY * runtimeId1, __RPC__in SAFEARRAY * runtimeId2,
+                                                        __RPC__out BOOL * areSame) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetRootElement(__RPC__deref_out_opt IUIAutomationElement * *root) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ElementFromHandle(__RPC__in UIA_HWND hwnd, __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ElementFromPoint(POINT pt, __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetFocusedElement(__RPC__deref_out_opt IUIAutomationElement * *element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetRootElementBuildCache(__RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                               __RPC__deref_out_opt IUIAutomationElement * *root) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ElementFromHandleBuildCache(__RPC__in UIA_HWND hwnd, __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                                  __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ElementFromPointBuildCache(POINT pt, __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                                 __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetFocusedElementBuildCache(__RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                                  __RPC__deref_out_opt IUIAutomationElement * *element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateTreeWalker(__RPC__in_opt IUIAutomationCondition * pCondition,
+                                                       __RPC__deref_out_opt IUIAutomationTreeWalker * *walker) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ControlViewWalker(__RPC__deref_out_opt IUIAutomationTreeWalker * *walker) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ContentViewWalker(__RPC__deref_out_opt IUIAutomationTreeWalker * *walker) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_RawViewWalker(__RPC__deref_out_opt IUIAutomationTreeWalker * *walker) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_RawViewCondition(__RPC__deref_out_opt IUIAutomationCondition * *condition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ControlViewCondition(__RPC__deref_out_opt IUIAutomationCondition * *condition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ContentViewCondition(__RPC__deref_out_opt IUIAutomationCondition * *condition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateCacheRequest(__RPC__deref_out_opt IUIAutomationCacheRequest * *cacheRequest) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateTrueCondition(__RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateFalseCondition(__RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreatePropertyCondition(PROPERTYID propertyId, VARIANT value,
+                                                              __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreatePropertyConditionEx(PROPERTYID propertyId, VARIANT value, enum PropertyConditionFlags flags,
+                                                                __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateAndCondition(__RPC__in_opt IUIAutomationCondition * condition1,
+                                                         __RPC__in_opt IUIAutomationCondition * condition2,
+                                                         __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateAndConditionFromArray(__RPC__in_opt SAFEARRAY * conditions,
+                                                                  __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateAndConditionFromNativeArray(__RPC__in_ecount_full(conditionCount) IUIAutomationCondition * *conditions,
+                                                                        int conditionCount,
+                                                                        __RPC__deref_out_opt IUIAutomationCondition **newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateOrCondition(__RPC__in_opt IUIAutomationCondition * condition1,
+                                                        __RPC__in_opt IUIAutomationCondition * condition2,
+                                                        __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateOrConditionFromArray(__RPC__in_opt SAFEARRAY * conditions,
+                                                                 __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateOrConditionFromNativeArray(__RPC__in_ecount_full(conditionCount) IUIAutomationCondition * *conditions,
+                                                                       int conditionCount,
+                                                                       __RPC__deref_out_opt IUIAutomationCondition **newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateNotCondition(__RPC__in_opt IUIAutomationCondition * condition,
+                                                         __RPC__deref_out_opt IUIAutomationCondition * *newCondition) = 0;
+    virtual HRESULT STDMETHODCALLTYPE AddAutomationEventHandler(EVENTID eventId, __RPC__in_opt IUIAutomationElement * element, enum TreeScope scope,
+                                                                __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                                __RPC__in_opt IUIAutomationEventHandler * handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RemoveAutomationEventHandler(EVENTID eventId, __RPC__in_opt IUIAutomationElement * element,
+                                                                   __RPC__in_opt IUIAutomationEventHandler * handler) = 0;
     virtual HRESULT STDMETHODCALLTYPE AddPropertyChangedEventHandlerNativeArray(
-        __RPC__in_opt IUIAutomationElement * element, enum TreeScope scope,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__in_opt IUIAutomationPropertyChangedEventHandler * handler,
-        __RPC__in_ecount_full(propertyCount) PROPERTYID * propertyArray,
+        __RPC__in_opt IUIAutomationElement * element, enum TreeScope scope, __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__in_opt IUIAutomationPropertyChangedEventHandler * handler, __RPC__in_ecount_full(propertyCount) PROPERTYID * propertyArray,
         int propertyCount) = 0;
     virtual HRESULT STDMETHODCALLTYPE AddPropertyChangedEventHandler(
-        __RPC__in_opt IUIAutomationElement * element, enum TreeScope scope,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__in_opt IUIAutomationPropertyChangedEventHandler * handler,
-        __RPC__in SAFEARRAY * propertyArray) = 0;
-    virtual HRESULT STDMETHODCALLTYPE RemovePropertyChangedEventHandler(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__in_opt IUIAutomationPropertyChangedEventHandler * handler) = 0;
-    virtual HRESULT STDMETHODCALLTYPE AddStructureChangedEventHandler(
-        __RPC__in_opt IUIAutomationElement * element, enum TreeScope scope,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__in_opt IUIAutomationStructureChangedEventHandler * handler) = 0;
-    virtual HRESULT STDMETHODCALLTYPE RemoveStructureChangedEventHandler(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__in_opt IUIAutomationStructureChangedEventHandler * handler) = 0;
-    virtual HRESULT STDMETHODCALLTYPE AddFocusChangedEventHandler(
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__in_opt IUIAutomationFocusChangedEventHandler * handler) = 0;
-    virtual HRESULT STDMETHODCALLTYPE RemoveFocusChangedEventHandler(
-        __RPC__in_opt IUIAutomationFocusChangedEventHandler * handler) = 0;
+        __RPC__in_opt IUIAutomationElement * element, enum TreeScope scope, __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+        __RPC__in_opt IUIAutomationPropertyChangedEventHandler * handler, __RPC__in SAFEARRAY * propertyArray) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RemovePropertyChangedEventHandler(__RPC__in_opt IUIAutomationElement * element,
+                                                                        __RPC__in_opt IUIAutomationPropertyChangedEventHandler * handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE AddStructureChangedEventHandler(__RPC__in_opt IUIAutomationElement * element, enum TreeScope scope,
+                                                                      __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                                      __RPC__in_opt IUIAutomationStructureChangedEventHandler * handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RemoveStructureChangedEventHandler(__RPC__in_opt IUIAutomationElement * element,
+                                                                         __RPC__in_opt IUIAutomationStructureChangedEventHandler * handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE AddFocusChangedEventHandler(__RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                                  __RPC__in_opt IUIAutomationFocusChangedEventHandler * handler) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RemoveFocusChangedEventHandler(__RPC__in_opt IUIAutomationFocusChangedEventHandler * handler) = 0;
     virtual HRESULT STDMETHODCALLTYPE RemoveAllEventHandlers() = 0;
-    virtual HRESULT STDMETHODCALLTYPE IntNativeArrayToSafeArray(
-        __RPC__in_ecount_full(arrayCount) int* array, int arrayCount,
-        __RPC__deref_out_opt SAFEARRAY** safeArray) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IntNativeArrayToSafeArray(__RPC__in_ecount_full(arrayCount) int *array, int arrayCount,
+                                                                __RPC__deref_out_opt SAFEARRAY **safeArray) = 0;
     virtual HRESULT STDMETHODCALLTYPE IntSafeArrayToNativeArray(
-        __RPC__in SAFEARRAY * intArray,
-        __RPC__deref_out_ecount_full_opt(*arrayCount) int** array,
-        __RPC__out int* arrayCount) = 0;
-    virtual HRESULT STDMETHODCALLTYPE RectToVariant(
-        RECT rc, __RPC__out VARIANT * var) = 0;
-    virtual HRESULT STDMETHODCALLTYPE VariantToRect(VARIANT var,
-                                                    __RPC__out RECT * rc) = 0;
+        __RPC__in SAFEARRAY * intArray, __RPC__deref_out_ecount_full_opt(*arrayCount) int **array, __RPC__out int *arrayCount) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RectToVariant(RECT rc, __RPC__out VARIANT * var) = 0;
+    virtual HRESULT STDMETHODCALLTYPE VariantToRect(VARIANT var, __RPC__out RECT * rc) = 0;
     virtual HRESULT STDMETHODCALLTYPE SafeArrayToRectNativeArray(
-        __RPC__in SAFEARRAY * rects,
-        __RPC__deref_out_ecount_full_opt(*rectArrayCount) RECT * *rectArray,
-        __RPC__out int* rectArrayCount) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CreateProxyFactoryEntry(
-        __RPC__in_opt IUIAutomationProxyFactory * factory,
-        __RPC__deref_out_opt IUIAutomationProxyFactoryEntry *
-            *factoryEntry) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_ProxyFactoryMapping(
-        __RPC__deref_out_opt IUIAutomationProxyFactoryMapping *
-        *factoryMapping) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetPropertyProgrammaticName(
-        PROPERTYID property, __RPC__deref_out_opt BSTR * name) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetPatternProgrammaticName(
-        PATTERNID pattern, __RPC__deref_out_opt BSTR * name) = 0;
-    virtual HRESULT STDMETHODCALLTYPE PollForPotentialSupportedPatterns(
-        __RPC__in_opt IUIAutomationElement * pElement,
-        __RPC__deref_out_opt SAFEARRAY * *patternIds,
-        __RPC__deref_out_opt SAFEARRAY * *patternNames) = 0;
-    virtual HRESULT STDMETHODCALLTYPE PollForPotentialSupportedProperties(
-        __RPC__in_opt IUIAutomationElement * pElement,
-        __RPC__deref_out_opt SAFEARRAY * *propertyIds,
-        __RPC__deref_out_opt SAFEARRAY * *propertyNames) = 0;
-    virtual HRESULT STDMETHODCALLTYPE CheckNotSupported(
-        VARIANT value, __RPC__out BOOL * isNotSupported) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_ReservedNotSupportedValue(
-        __RPC__deref_out_opt IUnknown * *notSupportedValue) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_ReservedMixedAttributeValue(
-        __RPC__deref_out_opt IUnknown * *mixedAttributeValue) = 0;
-    virtual HRESULT STDMETHODCALLTYPE ElementFromIAccessible(
-        __RPC__in_opt IAccessible * accessible, int childId,
-        __RPC__deref_out_opt IUIAutomationElement** element) = 0;
-    virtual HRESULT STDMETHODCALLTYPE ElementFromIAccessibleBuildCache(
-        __RPC__in_opt IAccessible * accessible, int childId,
-        __RPC__in_opt IUIAutomationCacheRequest* cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement** element) = 0;
+        __RPC__in SAFEARRAY * rects, __RPC__deref_out_ecount_full_opt(*rectArrayCount) RECT * *rectArray, __RPC__out int *rectArrayCount) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateProxyFactoryEntry(__RPC__in_opt IUIAutomationProxyFactory * factory,
+                                                              __RPC__deref_out_opt IUIAutomationProxyFactoryEntry * *factoryEntry) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ProxyFactoryMapping(__RPC__deref_out_opt IUIAutomationProxyFactoryMapping * *factoryMapping) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetPropertyProgrammaticName(PROPERTYID property, __RPC__deref_out_opt BSTR * name) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetPatternProgrammaticName(PATTERNID pattern, __RPC__deref_out_opt BSTR * name) = 0;
+    virtual HRESULT STDMETHODCALLTYPE PollForPotentialSupportedPatterns(__RPC__in_opt IUIAutomationElement * pElement,
+                                                                        __RPC__deref_out_opt SAFEARRAY * *patternIds,
+                                                                        __RPC__deref_out_opt SAFEARRAY * *patternNames) = 0;
+    virtual HRESULT STDMETHODCALLTYPE PollForPotentialSupportedProperties(__RPC__in_opt IUIAutomationElement * pElement,
+                                                                          __RPC__deref_out_opt SAFEARRAY * *propertyIds,
+                                                                          __RPC__deref_out_opt SAFEARRAY * *propertyNames) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CheckNotSupported(VARIANT value, __RPC__out BOOL * isNotSupported) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ReservedNotSupportedValue(__RPC__deref_out_opt IUnknown * *notSupportedValue) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_ReservedMixedAttributeValue(__RPC__deref_out_opt IUnknown * *mixedAttributeValue) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ElementFromIAccessible(__RPC__in_opt IAccessible * accessible, int childId,
+                                                             __RPC__deref_out_opt IUIAutomationElement **element) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ElementFromIAccessibleBuildCache(__RPC__in_opt IAccessible * accessible, int childId,
+                                                                       __RPC__in_opt IUIAutomationCacheRequest *cacheRequest,
+                                                                       __RPC__deref_out_opt IUIAutomationElement **element) = 0;
 };
 #ifdef __CRT_UUID_DECL
-__CRT_UUID_DECL(IUIAutomation,
-                0x30cbe57d,
-                0xd9d0,
-                0x452a,
-                0xab,
-                0x13,
-                0x7a,
-                0xc5,
-                0xac,
-                0x48,
-                0x25,
-                0xee)
+__CRT_UUID_DECL(IUIAutomation, 0x30cbe57d, 0xd9d0, 0x452a, 0xab, 0x13, 0x7a, 0xc5, 0xac, 0x48, 0x25, 0xee)
 #endif
 #endif
 
 #ifndef __IUIAutomationTreeWalker_INTERFACE_DEFINED__
 #define __IUIAutomationTreeWalker_INTERFACE_DEFINED__
-DEFINE_GUID(IID_IUIAutomationTreeWalker,
-            0x4042c624,
-            0x389c,
-            0x4afc,
-            0xa6,
-            0x30,
-            0x9d,
-            0xf8,
-            0x54,
-            0xa5,
-            0x41,
-            0xfc);
+DEFINE_GUID(IID_IUIAutomationTreeWalker, 0x4042c624, 0x389c, 0x4afc, 0xa6, 0x30, 0x9d, 0xf8, 0x54, 0xa5, 0x41, 0xfc);
 MIDL_INTERFACE("4042c624-389c-4afc-a630-9df854a541fc")
 IUIAutomationTreeWalker : public IUnknown {
-   public:
-    virtual HRESULT STDMETHODCALLTYPE GetParentElement(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__deref_out_opt IUIAutomationElement * *parent) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetFirstChildElement(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__deref_out_opt IUIAutomationElement * *first) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetLastChildElement(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__deref_out_opt IUIAutomationElement * *last) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetNextSiblingElement(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__deref_out_opt IUIAutomationElement * *next) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetPreviousSiblingElement(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__deref_out_opt IUIAutomationElement * *previous) = 0;
-    virtual HRESULT STDMETHODCALLTYPE NormalizeElement(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__deref_out_opt IUIAutomationElement * *normalized) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetParentElementBuildCache(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement * *parent) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetFirstChildElementBuildCache(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement * *first) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetLastChildElementBuildCache(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement * *last) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetNextSiblingElementBuildCache(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement * *next) = 0;
-    virtual HRESULT STDMETHODCALLTYPE GetPreviousSiblingElementBuildCache(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement * *previous) = 0;
-    virtual HRESULT STDMETHODCALLTYPE NormalizeElementBuildCache(
-        __RPC__in_opt IUIAutomationElement * element,
-        __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
-        __RPC__deref_out_opt IUIAutomationElement * *normalized) = 0;
-    virtual HRESULT STDMETHODCALLTYPE get_Condition(
-        __RPC__deref_out_opt IUIAutomationCondition * *condition) = 0;
+  public:
+    virtual HRESULT STDMETHODCALLTYPE GetParentElement(__RPC__in_opt IUIAutomationElement * element,
+                                                       __RPC__deref_out_opt IUIAutomationElement * *parent) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetFirstChildElement(__RPC__in_opt IUIAutomationElement * element,
+                                                           __RPC__deref_out_opt IUIAutomationElement * *first) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetLastChildElement(__RPC__in_opt IUIAutomationElement * element,
+                                                          __RPC__deref_out_opt IUIAutomationElement * *last) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetNextSiblingElement(__RPC__in_opt IUIAutomationElement * element,
+                                                            __RPC__deref_out_opt IUIAutomationElement * *next) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetPreviousSiblingElement(__RPC__in_opt IUIAutomationElement * element,
+                                                                __RPC__deref_out_opt IUIAutomationElement * *previous) = 0;
+    virtual HRESULT STDMETHODCALLTYPE NormalizeElement(__RPC__in_opt IUIAutomationElement * element,
+                                                       __RPC__deref_out_opt IUIAutomationElement * *normalized) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetParentElementBuildCache(__RPC__in_opt IUIAutomationElement * element,
+                                                                 __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                                 __RPC__deref_out_opt IUIAutomationElement * *parent) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetFirstChildElementBuildCache(__RPC__in_opt IUIAutomationElement * element,
+                                                                     __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                                     __RPC__deref_out_opt IUIAutomationElement * *first) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetLastChildElementBuildCache(__RPC__in_opt IUIAutomationElement * element,
+                                                                    __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                                    __RPC__deref_out_opt IUIAutomationElement * *last) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetNextSiblingElementBuildCache(__RPC__in_opt IUIAutomationElement * element,
+                                                                      __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                                      __RPC__deref_out_opt IUIAutomationElement * *next) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetPreviousSiblingElementBuildCache(__RPC__in_opt IUIAutomationElement * element,
+                                                                          __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                                          __RPC__deref_out_opt IUIAutomationElement * *previous) = 0;
+    virtual HRESULT STDMETHODCALLTYPE NormalizeElementBuildCache(__RPC__in_opt IUIAutomationElement * element,
+                                                                 __RPC__in_opt IUIAutomationCacheRequest * cacheRequest,
+                                                                 __RPC__deref_out_opt IUIAutomationElement * *normalized) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Condition(__RPC__deref_out_opt IUIAutomationCondition * *condition) = 0;
 };
 #ifdef __CRT_UUID_DECL
-__CRT_UUID_DECL(IUIAutomationTreeWalker,
-                0x4042c624,
-                0x389c,
-                0x4afc,
-                0xa6,
-                0x30,
-                0x9d,
-                0xf8,
-                0x54,
-                0xa5,
-                0x41,
-                0xfc)
+__CRT_UUID_DECL(IUIAutomationTreeWalker, 0x4042c624, 0x389c, 0x4afc, 0xa6, 0x30, 0x9d, 0xf8, 0x54, 0xa5, 0x41, 0xfc)
 #endif
 #endif
 
-DEFINE_GUID(CLSID_CUIAutomation,
-            0xff48dba4,
-            0x60ef,
-            0x4201,
-            0xaa,
-            0x87,
-            0x54,
-            0x10,
-            0x3e,
-            0xef,
-            0x59,
-            0x4e);
+DEFINE_GUID(CLSID_CUIAutomation, 0xff48dba4, 0x60ef, 0x4201, 0xaa, 0x87, 0x54, 0x10, 0x3e, 0xef, 0x59, 0x4e);
 
 #endif
 
@@ -834,41 +562,37 @@ enum {
     WIN_VERSION_8,
     WIN_VERSION_81,
     WIN_VERSION_811,
-    WIN_VERSION_10_T1,        // 1507
-    WIN_VERSION_10_T2,        // 1511
-    WIN_VERSION_10_R1,        // 1607
-    WIN_VERSION_10_R2,        // 1703
-    WIN_VERSION_10_R3,        // 1709
-    WIN_VERSION_10_R4,        // 1803
-    WIN_VERSION_10_R5,        // 1809
-    WIN_VERSION_10_19H1,      // 1903, 1909
-    WIN_VERSION_10_20H1,      // 2004, 20H2, 21H1, 21H2
-    WIN_VERSION_SERVER_2022,  // Server 2022
+    WIN_VERSION_10_T1,       // 1507
+    WIN_VERSION_10_T2,       // 1511
+    WIN_VERSION_10_R1,       // 1607
+    WIN_VERSION_10_R2,       // 1703
+    WIN_VERSION_10_R3,       // 1709
+    WIN_VERSION_10_R4,       // 1803
+    WIN_VERSION_10_R5,       // 1809
+    WIN_VERSION_10_19H1,     // 1903, 1909
+    WIN_VERSION_10_20H1,     // 2004, 20H2, 21H1, 21H2, 22H2
+    WIN_VERSION_SERVER_2022, // Server 2022
     WIN_VERSION_11_21H2,
     WIN_VERSION_11_22H2,
 };
 
 struct SYMBOL_HOOK {
     std::vector<std::wstring_view> symbols;
-    void** pOriginalFunction;
-    void* hookFunction = nullptr;
+    void **pOriginalFunction;
+    void *hookFunction = nullptr;
     bool optional = false;
 };
 
+// wrapper around UIAutomation COM interface to be sure that it gets closed and released properly
 class UIAutomationWrapper {
-   public:
-    UIAutomationWrapper()
-        : isCOMInitialized(false),
-          isUIAutomationInitialized(false),
-          uiAutomationInstance(NULL) {}
+  public:
+    UIAutomationWrapper() : isCOMInitialized(false), isUIAutomationInitialized(false), uiAutomationInstance(NULL) {}
 
     ~UIAutomationWrapper() { deinit(); }
 
-    bool isInitialized() const {
-        return isUIAutomationInitialized && isCOMInitialized;
-    }
+    bool isInitialized() const { return isUIAutomationInitialized && isCOMInitialized; }
 
-    IUIAutomation* getInstance() const { return uiAutomationInstance; }
+    IUIAutomation *getInstance() const { return uiAutomationInstance; }
 
     bool init() {
         HRESULT result = CoInitializeEx(NULL, COINIT_MULTITHREADED);
@@ -879,9 +603,7 @@ class UIAutomationWrapper {
             return false;
         }
 
-        result = CoCreateInstance(CLSID_CUIAutomation, NULL,
-                                  CLSCTX_INPROC_SERVER, __uuidof(IUIAutomation),
-                                  (void**)&uiAutomationInstance);
+        result = CoCreateInstance(CLSID_CUIAutomation, NULL, CLSCTX_INPROC_SERVER, __uuidof(IUIAutomation), (void **)&uiAutomationInstance);
         if (SUCCEEDED(result)) {
             isUIAutomationInitialized = true;
         } else {
@@ -905,11 +627,11 @@ class UIAutomationWrapper {
         }
     }
 
-   private:
+  private:
     bool isCOMInitialized;
     bool isUIAutomationInitialized;
 
-    IUIAutomation* uiAutomationInstance;
+    IUIAutomation *uiAutomationInstance;
 };
 
 static int g_nWinVersion;
@@ -922,7 +644,7 @@ static std::unordered_set<HWND> g_secondaryTaskbarWindows;
 static UIAutomationWrapper g_UIAutomation;
 
 bool IsTaskbarWindow(HWND hWnd);
-VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen);
+VS_FIXEDFILEINFO *GetModuleVersionInfo(HMODULE hModule, UINT *puPtrLen);
 BOOL WindowsVersionInit();
 bool GetTaskbarAutohideState();
 void SetTaskbarAutohide(bool enabled);
@@ -935,13 +657,9 @@ bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam);
 
 // wParam - TRUE to subclass, FALSE to unsubclass
 // lParam - subclass data
-UINT g_subclassRegisteredMsg = RegisterWindowMessage(
-    L"Windhawk_SetWindowSubclassFromAnyThread_taskbar-volume-control");
+UINT g_subclassRegisteredMsg = RegisterWindowMessage(L"Windhawk_SetWindowSubclassFromAnyThread_taskbar-volume-control");
 
-BOOL SetWindowSubclassFromAnyThread(HWND hWnd,
-                                    SUBCLASSPROC pfnSubclass,
-                                    UINT_PTR uIdSubclass,
-                                    DWORD_PTR dwRefData) {
+BOOL SetWindowSubclassFromAnyThread(HWND hWnd, SUBCLASSPROC pfnSubclass, UINT_PTR uIdSubclass, DWORD_PTR dwRefData) {
     struct SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM {
         SUBCLASSPROC pfnSubclass;
         UINT_PTR uIdSubclass;
@@ -960,16 +678,12 @@ BOOL SetWindowSubclassFromAnyThread(HWND hWnd,
 
     HHOOK hook = SetWindowsHookEx(
         WH_CALLWNDPROC,
-        [](int nCode, WPARAM wParam,
-           LPARAM lParam) WINAPI_LAMBDA_RETURN(LRESULT) {
+        [](int nCode, WPARAM wParam, LPARAM lParam) WINAPI_LAMBDA_RETURN(LRESULT) {
             if (nCode == HC_ACTION) {
-                const CWPSTRUCT* cwp = (const CWPSTRUCT*)lParam;
+                const CWPSTRUCT *cwp = (const CWPSTRUCT *)lParam;
                 if (cwp->message == g_subclassRegisteredMsg && cwp->wParam) {
-                    SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM* param =
-                        (SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM*)cwp->lParam;
-                    param->result =
-                        SetWindowSubclass(cwp->hwnd, param->pfnSubclass,
-                                          param->uIdSubclass, param->dwRefData);
+                    SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM *param = (SET_WINDOW_SUBCLASS_FROM_ANY_THREAD_PARAM *)cwp->lParam;
+                    param->result = SetWindowSubclass(cwp->hwnd, param->pfnSubclass, param->uIdSubclass, param->dwRefData);
                 }
             }
 
@@ -992,127 +706,111 @@ BOOL SetWindowSubclassFromAnyThread(HWND hWnd,
     return param.result;
 }
 
-LRESULT CALLBACK TaskbarWindowSubclassProc(_In_ HWND hWnd,
-                                           _In_ UINT uMsg,
-                                           _In_ WPARAM wParam,
-                                           _In_ LPARAM lParam,
-                                           _In_ UINT_PTR uIdSubclass,
+// proc handler for older Windows (Windows 11 21H1 and older) versions 
+LRESULT CALLBACK TaskbarWindowSubclassProc(_In_ HWND hWnd, _In_ UINT uMsg, _In_ WPARAM wParam, _In_ LPARAM lParam, _In_ UINT_PTR uIdSubclass,
                                            _In_ DWORD_PTR dwRefData) {
     if (uMsg == WM_NCDESTROY || (uMsg == g_subclassRegisteredMsg && !wParam)) {
         RemoveWindowSubclass(hWnd, TaskbarWindowSubclassProc, 0);
     }
 
+    // Wh_Log(L"Message: 0x%x", uMsg);
+
     LRESULT result = 0;
     switch (uMsg) {
-        case WM_COPYDATA: {
-            result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+    case WM_COPYDATA: {
+        result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
 
-            typedef struct _notifyiconidentifier_internal {
-                DWORD dwMagic;    // 0x34753423
-                DWORD dwRequest;  // 1 for (x,y) | 2 for (w,h)
-                DWORD cbSize;     // 0x20
-                DWORD hWndHigh;
-                DWORD hWndLow;
-                UINT uID;
-                GUID guidItem;
-            } NOTIFYICONIDENTIFIER_INTERNAL;
+        typedef struct _notifyiconidentifier_internal {
+            DWORD dwMagic;   // 0x34753423
+            DWORD dwRequest; // 1 for (x,y) | 2 for (w,h)
+            DWORD cbSize;    // 0x20
+            DWORD hWndHigh;
+            DWORD hWndLow;
+            UINT uID;
+            GUID guidItem;
+        } NOTIFYICONIDENTIFIER_INTERNAL;
 
-            COPYDATASTRUCT* p_copydata = (COPYDATASTRUCT*)lParam;
+        COPYDATASTRUCT *p_copydata = (COPYDATASTRUCT *)lParam;
 
-            // Change Shell_NotifyIconGetRect handling result for the volume
-            // icon. In case it's not visible, or in Windows 11, it returns 0,
-            // which causes sndvol.exe to ignore the command line position.
-            if (result == 0 && p_copydata->dwData == 0x03 &&
-                p_copydata->cbData == sizeof(NOTIFYICONIDENTIFIER_INTERNAL)) {
-                NOTIFYICONIDENTIFIER_INTERNAL* p_icon_ident =
-                    (NOTIFYICONIDENTIFIER_INTERNAL*)p_copydata->lpData;
-                if (p_icon_ident->dwMagic == 0x34753423 &&
-                    (p_icon_ident->dwRequest == 0x01 ||
-                     p_icon_ident->dwRequest == 0x02) &&
-                    p_icon_ident->cbSize == 0x20 &&
-                    memcmp(&p_icon_ident->guidItem,
-                           "\x73\xAE\x20\x78\xE3\x23\x29\x42\x82\xC1\xE4"
-                           "\x1C\xB6\x7D\x5B\x9C",
-                           sizeof(GUID)) == 0) {
-                    RECT rc;
-                    GetWindowRect(hWnd, &rc);
+        // Change Shell_NotifyIconGetRect handling result for the volume
+        // icon. In case it's not visible, or in Windows 11, it returns 0,
+        // which causes sndvol.exe to ignore the command line position.
+        if (result == 0 && p_copydata->dwData == 0x03 && p_copydata->cbData == sizeof(NOTIFYICONIDENTIFIER_INTERNAL)) {
+            NOTIFYICONIDENTIFIER_INTERNAL *p_icon_ident = (NOTIFYICONIDENTIFIER_INTERNAL *)p_copydata->lpData;
+            if (p_icon_ident->dwMagic == 0x34753423 && (p_icon_ident->dwRequest == 0x01 || p_icon_ident->dwRequest == 0x02) &&
+                p_icon_ident->cbSize == 0x20 &&
+                memcmp(&p_icon_ident->guidItem,
+                       "\x73\xAE\x20\x78\xE3\x23\x29\x42\x82\xC1\xE4"
+                       "\x1C\xB6\x7D\x5B\x9C",
+                       sizeof(GUID)) == 0) {
+                RECT rc;
+                GetWindowRect(hWnd, &rc);
 
-                    if (p_icon_ident->dwRequest == 0x01)
-                        result = MAKEWORD(rc.left, rc.top);
-                    else
-                        result =
-                            MAKEWORD(rc.right - rc.left, rc.bottom - rc.top);
-                }
+                if (p_icon_ident->dwRequest == 0x01)
+                    result = MAKEWORD(rc.left, rc.top);
+                else
+                    result = MAKEWORD(rc.right - rc.left, rc.bottom - rc.top);
             }
-            break;
         }
+        break;
+    }
 
-        case WM_POINTERDOWN:
-            if (g_nExplorerVersion < WIN_VERSION_11_21H2 &&
-                OnMouseClick(hWnd, wParam, lParam)) {
-                result = 0;
-            } else {
-                result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
-            }
-            break;
-
-        case WM_NCDESTROY:
+    // catch middle mouse button on both main and secondary taskbars
+    case WM_NCMBUTTONDOWN:
+    case WM_MBUTTONDOWN:
+        if (g_nExplorerVersion < WIN_VERSION_11_21H2 && OnMouseClick(hWnd, wParam, lParam)) {
+            result = 0;
+        } else {
             result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+        }
+        break;
 
-            if (hWnd != g_hTaskbarWnd) {
-                g_secondaryTaskbarWindows.erase(hWnd);
-            }
-            break;
+    case WM_NCDESTROY:
+        result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
 
-        default:
-            result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
-            break;
+        if (hWnd != g_hTaskbarWnd) {
+            g_secondaryTaskbarWindows.erase(hWnd);
+        }
+        break;
+
+    default:
+        result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+        break;
     }
 
     return result;
 }
 
-// taskbar event processing method from our hook that waits for mouse middle
-// click
+// proc handler for newer Windows versions (Windows 11 21H2 and newer)
 WNDPROC InputSiteWindowProc_Original;
-LRESULT CALLBACK InputSiteWindowProc_Hook(HWND hWnd,
-                                          UINT uMsg,
-                                          WPARAM wParam,
-                                          LPARAM lParam) {
+LRESULT CALLBACK InputSiteWindowProc_Hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
+    // Wh_Log(L"Message: 0x%x", uMsg);
+
     switch (uMsg) {
-        case WM_POINTERDOWN:
-            if (HWND hRootWnd = GetAncestor(hWnd, GA_ROOT);
-                IsTaskbarWindow(hRootWnd) &&
-                OnMouseClick(hRootWnd, wParam, lParam)) {
-                return 0;
-            }
-            break;
+    case WM_POINTERDOWN:
+        if (HWND hRootWnd = GetAncestor(hWnd, GA_ROOT); IsTaskbarWindow(hRootWnd) && OnMouseClick(hRootWnd, wParam, lParam)) {
+            return 0;
+        }
+        break;
     }
 
     return InputSiteWindowProc_Original(hWnd, uMsg, wParam, lParam);
 }
 
-void SubclassTaskbarWindow(HWND hWnd) {
-    SetWindowSubclassFromAnyThread(hWnd, TaskbarWindowSubclassProc, 0, 0);
-}
+void SubclassTaskbarWindow(HWND hWnd) { SetWindowSubclassFromAnyThread(hWnd, TaskbarWindowSubclassProc, 0, 0); }
 
-void UnsubclassTaskbarWindow(HWND hWnd) {
-    SendMessage(hWnd, g_subclassRegisteredMsg, FALSE, 0);
-}
+void UnsubclassTaskbarWindow(HWND hWnd) { SendMessage(hWnd, g_subclassRegisteredMsg, FALSE, 0); }
 
 // hook to modern taskbar event processing
 void HandleIdentifiedInputSiteWindow(HWND hWnd) {
-    if (!g_dwTaskbarThreadId ||
-        GetWindowThreadProcessId(hWnd, nullptr) != g_dwTaskbarThreadId) {
+    if (!g_dwTaskbarThreadId || GetWindowThreadProcessId(hWnd, nullptr) != g_dwTaskbarThreadId) {
         return;
     }
 
     HWND hParentWnd = GetParent(hWnd);
     WCHAR szClassName[64];
-    if (!hParentWnd ||
-        !GetClassName(hParentWnd, szClassName, ARRAYSIZE(szClassName)) ||
-        _wcsicmp(szClassName,
-                 L"Windows.UI.Composition.DesktopWindowContentBridge") != 0) {
+    if (!hParentWnd || !GetClassName(hParentWnd, szClassName, ARRAYSIZE(szClassName)) ||
+        _wcsicmp(szClassName, L"Windows.UI.Composition.DesktopWindowContentBridge") != 0) {
         return;
     }
 
@@ -1124,9 +822,8 @@ void HandleIdentifiedInputSiteWindow(HWND hWnd) {
     // At first, I tried to subclass the window instead of hooking its wndproc,
     // but the inputsite.dll code checks that the value wasn't changed, and
     // crashes otherwise.
-    void* wndProc = (void*)GetWindowLongPtr(hWnd, GWLP_WNDPROC);
-    Wh_SetFunctionHook(wndProc, (void*)InputSiteWindowProc_Hook,
-                       (void**)&InputSiteWindowProc_Original);
+    void *wndProc = (void *)GetWindowLongPtr(hWnd, GWLP_WNDPROC);
+    Wh_SetFunctionHook(wndProc, (void *)InputSiteWindowProc_Hook, (void **)&InputSiteWindowProc_Original);
 
     if (g_initialized) {
         Wh_ApplyHookOperations();
@@ -1145,13 +842,9 @@ void HandleIdentifiedTaskbarWindow(HWND hWnd) {
     }
 
     if (g_nExplorerVersion >= WIN_VERSION_11_21H2 && !g_inputSiteProcHooked) {
-        HWND hXamlIslandWnd = FindWindowEx(
-            hWnd, nullptr, L"Windows.UI.Composition.DesktopWindowContentBridge",
-            nullptr);
+        HWND hXamlIslandWnd = FindWindowEx(hWnd, nullptr, L"Windows.UI.Composition.DesktopWindowContentBridge", nullptr);
         if (hXamlIslandWnd) {
-            HWND hInputSiteWnd = FindWindowEx(
-                hXamlIslandWnd, nullptr,
-                L"Windows.UI.Input.InputSite.WindowClass", nullptr);
+            HWND hInputSiteWnd = FindWindowEx(hXamlIslandWnd, nullptr, L"Windows.UI.Input.InputSite.WindowClass", nullptr);
             if (hInputSiteWnd) {
                 HandleIdentifiedInputSiteWindow(hInputSiteWnd);
             }
@@ -1160,8 +853,7 @@ void HandleIdentifiedTaskbarWindow(HWND hWnd) {
 }
 
 void HandleIdentifiedSecondaryTaskbarWindow(HWND hWnd) {
-    if (!g_dwTaskbarThreadId ||
-        GetWindowThreadProcessId(hWnd, nullptr) != g_dwTaskbarThreadId) {
+    if (!g_dwTaskbarThreadId || GetWindowThreadProcessId(hWnd, nullptr) != g_dwTaskbarThreadId) {
         return;
     }
 
@@ -1169,13 +861,9 @@ void HandleIdentifiedSecondaryTaskbarWindow(HWND hWnd) {
     SubclassTaskbarWindow(hWnd);
 
     if (g_nExplorerVersion >= WIN_VERSION_11_21H2 && !g_inputSiteProcHooked) {
-        HWND hXamlIslandWnd = FindWindowEx(
-            hWnd, nullptr, L"Windows.UI.Composition.DesktopWindowContentBridge",
-            nullptr);
+        HWND hXamlIslandWnd = FindWindowEx(hWnd, nullptr, L"Windows.UI.Composition.DesktopWindowContentBridge", nullptr);
         if (hXamlIslandWnd) {
-            HWND hInputSiteWnd = FindWindowEx(
-                hXamlIslandWnd, nullptr,
-                L"Windows.UI.Input.InputSite.WindowClass", nullptr);
+            HWND hInputSiteWnd = FindWindowEx(hXamlIslandWnd, nullptr, L"Windows.UI.Input.InputSite.WindowClass", nullptr);
             if (hInputSiteWnd) {
                 HandleIdentifiedInputSiteWindow(hInputSiteWnd);
             }
@@ -1186,22 +874,20 @@ void HandleIdentifiedSecondaryTaskbarWindow(HWND hWnd) {
 // finds main task bar and returns its hWnd,
 // optinally it finds also secondary taskbars and fills them to the set
 // secondaryTaskbarWindows
-HWND FindCurrentProcessTaskbarWindows(
-    std::unordered_set<HWND>* secondaryTaskbarWindows) {
+HWND FindCurrentProcessTaskbarWindows(std::unordered_set<HWND> *secondaryTaskbarWindows) {
     struct ENUM_WINDOWS_PARAM {
-        HWND* hWnd;
-        std::unordered_set<HWND>* secondaryTaskbarWindows;
+        HWND *hWnd;
+        std::unordered_set<HWND> *secondaryTaskbarWindows;
     };
 
     HWND hWnd = nullptr;
     ENUM_WINDOWS_PARAM param = {&hWnd, secondaryTaskbarWindows};
     EnumWindows(
         [](HWND hWnd, LPARAM lParam) WINAPI_LAMBDA_RETURN(BOOL) {
-            ENUM_WINDOWS_PARAM& param = *(ENUM_WINDOWS_PARAM*)lParam;
+            ENUM_WINDOWS_PARAM &param = *(ENUM_WINDOWS_PARAM *)lParam;
 
             DWORD dwProcessId = 0;
-            if (!GetWindowThreadProcessId(hWnd, &dwProcessId) ||
-                dwProcessId != GetCurrentProcessId())
+            if (!GetWindowThreadProcessId(hWnd, &dwProcessId) || dwProcessId != GetCurrentProcessId())
                 return TRUE;
 
             WCHAR szClassName[32];
@@ -1223,21 +909,9 @@ HWND FindCurrentProcessTaskbarWindows(
 
 using CreateWindowExW_t = decltype(&CreateWindowExW);
 CreateWindowExW_t CreateWindowExW_Original;
-HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle,
-                                 LPCWSTR lpClassName,
-                                 LPCWSTR lpWindowName,
-                                 DWORD dwStyle,
-                                 int X,
-                                 int Y,
-                                 int nWidth,
-                                 int nHeight,
-                                 HWND hWndParent,
-                                 HMENU hMenu,
-                                 HINSTANCE hInstance,
-                                 LPVOID lpParam) {
-    HWND hWnd = CreateWindowExW_Original(dwExStyle, lpClassName, lpWindowName,
-                                         dwStyle, X, Y, nWidth, nHeight,
-                                         hWndParent, hMenu, hInstance, lpParam);
+HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
+                                 HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam) {
+    HWND hWnd = CreateWindowExW_Original(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 
     if (!hWnd)
         return hWnd;
@@ -1247,56 +921,29 @@ HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle,
     if (bTextualClassName && _wcsicmp(lpClassName, L"Shell_TrayWnd") == 0) {
         Wh_Log(L"Taskbar window created: %08X", (DWORD)(ULONG_PTR)hWnd);
         HandleIdentifiedTaskbarWindow(hWnd);
-    } else if (bTextualClassName &&
-               _wcsicmp(lpClassName, L"Shell_SecondaryTrayWnd") == 0) {
-        Wh_Log(L"Secondary taskbar window created: %08X",
-               (DWORD)(ULONG_PTR)hWnd);
+    } else if (bTextualClassName && _wcsicmp(lpClassName, L"Shell_SecondaryTrayWnd") == 0) {
+        Wh_Log(L"Secondary taskbar window created: %08X", (DWORD)(ULONG_PTR)hWnd);
         HandleIdentifiedSecondaryTaskbarWindow(hWnd);
     }
 
     return hWnd;
 }
 
-using CreateWindowInBand_t = HWND(WINAPI*)(DWORD dwExStyle,
-                                           LPCWSTR lpClassName,
-                                           LPCWSTR lpWindowName,
-                                           DWORD dwStyle,
-                                           int X,
-                                           int Y,
-                                           int nWidth,
-                                           int nHeight,
-                                           HWND hWndParent,
-                                           HMENU hMenu,
-                                           HINSTANCE hInstance,
-                                           LPVOID lpParam,
-                                           DWORD dwBand);
+using CreateWindowInBand_t = HWND(WINAPI *)(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth,
+                                            int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam, DWORD dwBand);
 CreateWindowInBand_t CreateWindowInBand_Original;
-HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle,
-                                    LPCWSTR lpClassName,
-                                    LPCWSTR lpWindowName,
-                                    DWORD dwStyle,
-                                    int X,
-                                    int Y,
-                                    int nWidth,
-                                    int nHeight,
-                                    HWND hWndParent,
-                                    HMENU hMenu,
-                                    HINSTANCE hInstance,
-                                    LPVOID lpParam,
-                                    DWORD dwBand) {
-    HWND hWnd = CreateWindowInBand_Original(
-        dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight,
-        hWndParent, hMenu, hInstance, lpParam, dwBand);
+HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
+                                    HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam, DWORD dwBand) {
+    HWND hWnd = CreateWindowInBand_Original(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance,
+                                            lpParam, dwBand);
     if (!hWnd)
         return hWnd;
 
     BOOL bTextualClassName = ((ULONG_PTR)lpClassName & ~(ULONG_PTR)0xffff) != 0;
 
-    if (bTextualClassName &&
-        _wcsicmp(lpClassName, L"Windows.UI.Input.InputSite.WindowClass") == 0) {
+    if (bTextualClassName && _wcsicmp(lpClassName, L"Windows.UI.Input.InputSite.WindowClass") == 0) {
         Wh_Log(L"InputSite window created: %08X", (DWORD)(ULONG_PTR)hWnd);
-        if (g_nExplorerVersion >= WIN_VERSION_11_21H2 &&
-            !g_inputSiteProcHooked) {
+        if (g_nExplorerVersion >= WIN_VERSION_11_21H2 && !g_inputSiteProcHooked) {
             HandleIdentifiedInputSiteWindow(hWnd);
         }
     }
@@ -1304,9 +951,7 @@ HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle,
     return hWnd;
 }
 
-bool HookSymbols(HMODULE module,
-                 const SYMBOL_HOOK* symbolHooks,
-                 size_t symbolHooksCount) {
+bool HookSymbols(HMODULE module, const SYMBOL_HOOK *symbolHooks, size_t symbolHooksCount) {
     const WCHAR cacheVer = L'1';
     const WCHAR cacheSep = L'#';
     constexpr size_t cacheMaxSize = 10240;
@@ -1337,8 +982,7 @@ bool HookSymbols(HMODULE module,
         std::wstring_view token;
         std::vector<std::wstring_view> res;
 
-        while ((pos_end = s.find(delimiter, pos_start)) !=
-               std::wstring_view::npos) {
+        while ((pos_end = s.find(delimiter, pos_start)) != std::wstring_view::npos) {
             token = s.substr(pos_start, pos_end - pos_start);
             pos_start = pos_end + 1;
             res.push_back(token);
@@ -1353,9 +997,7 @@ bool HookSymbols(HMODULE module,
     std::vector<bool> symbolResolved(symbolHooksCount, false);
     std::wstring newSystemCacheStr;
 
-    auto onSymbolResolved = [symbolHooks, symbolHooksCount, &symbolResolved,
-                             &newSystemCacheStr,
-                             module](std::wstring_view symbol, void* address) {
+    auto onSymbolResolved = [symbolHooks, symbolHooksCount, &symbolResolved, &newSystemCacheStr, module](std::wstring_view symbol, void *address) {
         for (size_t i = 0; i < symbolHooksCount; i++) {
             if (symbolResolved[i]) {
                 continue;
@@ -1374,14 +1016,11 @@ bool HookSymbols(HMODULE module,
             }
 
             if (symbolHooks[i].hookFunction) {
-                Wh_SetFunctionHook(address, symbolHooks[i].hookFunction,
-                                   symbolHooks[i].pOriginalFunction);
-                Wh_Log(L"Hooked %p: %.*s", address, symbol.length(),
-                       symbol.data());
+                Wh_SetFunctionHook(address, symbolHooks[i].hookFunction, symbolHooks[i].pOriginalFunction);
+                Wh_Log(L"Hooked %p: %.*s", address, symbol.length(), symbol.data());
             } else {
                 *symbolHooks[i].pOriginalFunction = address;
-                Wh_Log(L"Found %p: %.*s", address, symbol.length(),
-                       symbol.data());
+                Wh_Log(L"Found %p: %.*s", address, symbol.length(), symbol.data());
             }
 
             symbolResolved[i] = true;
@@ -1389,16 +1028,14 @@ bool HookSymbols(HMODULE module,
             newSystemCacheStr += cacheSep;
             newSystemCacheStr += symbol;
             newSystemCacheStr += cacheSep;
-            newSystemCacheStr +=
-                std::to_wstring((ULONG_PTR)address - (ULONG_PTR)module);
+            newSystemCacheStr += std::to_wstring((ULONG_PTR)address - (ULONG_PTR)module);
 
             break;
         }
     };
 
-    IMAGE_DOS_HEADER* dosHeader = (IMAGE_DOS_HEADER*)module;
-    IMAGE_NT_HEADERS* header =
-        (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
+    IMAGE_DOS_HEADER *dosHeader = (IMAGE_DOS_HEADER *)module;
+    IMAGE_NT_HEADERS *header = (IMAGE_NT_HEADERS *)((BYTE *)dosHeader + dosHeader->e_lfanew);
     auto timeStamp = std::to_wstring(header->FileHeader.TimeDateStamp);
     auto imageSize = std::to_wstring(header->OptionalHeader.SizeOfImage);
 
@@ -1408,9 +1045,7 @@ bool HookSymbols(HMODULE module,
     newSystemCacheStr += cacheSep;
     newSystemCacheStr += imageSize;
 
-    if (cacheParts.size() >= 3 &&
-        cacheParts[0] == std::wstring_view(&cacheVer, 1) &&
-        cacheParts[1] == timeStamp && cacheParts[2] == imageSize) {
+    if (cacheParts.size() >= 3 && cacheParts[0] == std::wstring_view(&cacheVer, 1) && cacheParts[1] == timeStamp && cacheParts[2] == imageSize) {
         for (size_t i = 3; i + 1 < cacheParts.size(); i += 2) {
             auto symbol = cacheParts[i];
             auto address = cacheParts[i + 1];
@@ -1418,9 +1053,7 @@ bool HookSymbols(HMODULE module,
                 continue;
             }
 
-            void* addressPtr =
-                (void*)(std::stoull(std::wstring(address), nullptr, 10) +
-                        (ULONG_PTR)module);
+            void *addressPtr = (void *)(std::stoull(std::wstring(address), nullptr, 10) + (ULONG_PTR)module);
 
             onSymbolResolved(symbol, addressPtr);
         }
@@ -1452,8 +1085,7 @@ bool HookSymbols(HMODULE module,
             }
         }
 
-        if (std::all_of(symbolResolved.begin(), symbolResolved.end(),
-                        [](bool b) { return b; })) {
+        if (std::all_of(symbolResolved.begin(), symbolResolved.end(), [](bool b) { return b; })) {
             return true;
         }
     }
@@ -1503,26 +1135,21 @@ bool HookSymbols(HMODULE module,
 
 bool GetTaskbarViewDllPath(WCHAR path[MAX_PATH]) {
     WCHAR szWindowsDirectory[MAX_PATH];
-    if (!GetWindowsDirectory(szWindowsDirectory,
-                             ARRAYSIZE(szWindowsDirectory))) {
+    if (!GetWindowsDirectory(szWindowsDirectory, ARRAYSIZE(szWindowsDirectory))) {
         Wh_Log(L"GetWindowsDirectory failed");
         return false;
     }
 
     // Windows 11 version 22H2.
     wcscpy_s(path, MAX_PATH, szWindowsDirectory);
-    wcscat_s(
-        path, MAX_PATH,
-        LR"(\SystemApps\MicrosoftWindows.Client.Core_cw5n1h2txyewy\Taskbar.View.dll)");
+    wcscat_s(path, MAX_PATH, LR"(\SystemApps\MicrosoftWindows.Client.Core_cw5n1h2txyewy\Taskbar.View.dll)");
     if (GetFileAttributes(path) != INVALID_FILE_ATTRIBUTES) {
         return true;
     }
 
     // Windows 11 version 21H2.
     wcscpy_s(path, MAX_PATH, szWindowsDirectory);
-    wcscat_s(
-        path, MAX_PATH,
-        LR"(\SystemApps\MicrosoftWindows.Client.CBS_cw5n1h2txyewy\ExplorerExtensions.dll)");
+    wcscat_s(path, MAX_PATH, LR"(\SystemApps\MicrosoftWindows.Client.CBS_cw5n1h2txyewy\ExplorerExtensions.dll)");
     if (GetFileAttributes(path) != INVALID_FILE_ATTRIBUTES) {
         return true;
     }
@@ -1530,7 +1157,7 @@ bool GetTaskbarViewDllPath(WCHAR path[MAX_PATH]) {
     return false;
 }
 
-#pragma endregion  // hook_magic
+#pragma endregion // hook_magic
 
 // =====================================================================
 
@@ -1542,29 +1169,26 @@ bool IsTaskbarWindow(HWND hWnd) {
         return false;
     }
 
-    return _wcsicmp(szClassName, L"Shell_TrayWnd") == 0 ||
-           _wcsicmp(szClassName, L"Shell_SecondaryTrayWnd") == 0;
+    return _wcsicmp(szClassName, L"Shell_TrayWnd") == 0 || _wcsicmp(szClassName, L"Shell_SecondaryTrayWnd") == 0;
 }
 
-VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
+VS_FIXEDFILEINFO *GetModuleVersionInfo(HMODULE hModule, UINT *puPtrLen) {
     HRSRC hResource;
     HGLOBAL hGlobal;
-    void* pData;
-    void* pFixedFileInfo;
+    void *pData;
+    void *pFixedFileInfo;
     UINT uPtrLen;
 
     pFixedFileInfo = NULL;
     uPtrLen = 0;
 
-    hResource =
-        FindResource(hModule, MAKEINTRESOURCE(VS_VERSION_INFO), RT_VERSION);
+    hResource = FindResource(hModule, MAKEINTRESOURCE(VS_VERSION_INFO), RT_VERSION);
     if (hResource != NULL) {
         hGlobal = LoadResource(hModule, hResource);
         if (hGlobal != NULL) {
             pData = LockResource(hGlobal);
             if (pData != NULL) {
-                if (!VerQueryValue(pData, L"\\", &pFixedFileInfo, &uPtrLen) ||
-                    uPtrLen == 0) {
+                if (!VerQueryValue(pData, L"\\", &pFixedFileInfo, &uPtrLen) || uPtrLen == 0) {
                     pFixedFileInfo = NULL;
                     uPtrLen = 0;
                 }
@@ -1575,13 +1199,13 @@ VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
     if (puPtrLen)
         *puPtrLen = uPtrLen;
 
-    return (VS_FIXEDFILEINFO*)pFixedFileInfo;
+    return (VS_FIXEDFILEINFO *)pFixedFileInfo;
 }
 
 BOOL WindowsVersionInit() {
     g_nWinVersion = WIN_VERSION_UNSUPPORTED;
 
-    VS_FIXEDFILEINFO* pFixedFileInfo = GetModuleVersionInfo(NULL, NULL);
+    VS_FIXEDFILEINFO *pFixedFileInfo = GetModuleVersionInfo(NULL, NULL);
     if (!pFixedFileInfo)
         return FALSE;
 
@@ -1590,57 +1214,61 @@ BOOL WindowsVersionInit() {
     WORD nBuild = HIWORD(pFixedFileInfo->dwFileVersionLS);
     WORD nQFE = LOWORD(pFixedFileInfo->dwFileVersionLS);
 
+    Wh_Log(L"Windows version (major.minor.build): %d.%d.%d", nMajor, nMinor, nBuild);
+
     switch (nMajor) {
-        case 6:
-            switch (nMinor) {
-                case 1:
-                    g_nWinVersion = WIN_VERSION_7;
-                    break;
-
-                case 2:
-                    g_nWinVersion = WIN_VERSION_8;
-                    break;
-
-                case 3:
-                    if (nQFE < 17000)
-                        g_nWinVersion = WIN_VERSION_81;
-                    else
-                        g_nWinVersion = WIN_VERSION_811;
-                    break;
-
-                case 4:
-                    g_nWinVersion = WIN_VERSION_10_T1;
-                    break;
-            }
+    case 6:
+        switch (nMinor) {
+        case 1:
+            g_nWinVersion = WIN_VERSION_7;
             break;
 
-        case 10:
-            if (nBuild <= 10240)
-                g_nWinVersion = WIN_VERSION_10_T1;
-            else if (nBuild <= 10586)
-                g_nWinVersion = WIN_VERSION_10_T2;
-            else if (nBuild <= 14393)
-                g_nWinVersion = WIN_VERSION_10_R1;
-            else if (nBuild <= 15063)
-                g_nWinVersion = WIN_VERSION_10_R2;
-            else if (nBuild <= 16299)
-                g_nWinVersion = WIN_VERSION_10_R3;
-            else if (nBuild <= 17134)
-                g_nWinVersion = WIN_VERSION_10_R4;
-            else if (nBuild <= 17763)
-                g_nWinVersion = WIN_VERSION_10_R5;
-            else if (nBuild <= 18362)
-                g_nWinVersion = WIN_VERSION_10_19H1;
-            else if (nBuild <= 19041)
-                g_nWinVersion = WIN_VERSION_10_20H1;
-            else if (nBuild <= 20348)
-                g_nWinVersion = WIN_VERSION_SERVER_2022;
-            else if (nBuild <= 22000)
-                g_nWinVersion = WIN_VERSION_11_21H2;
+        case 2:
+            g_nWinVersion = WIN_VERSION_8;
+            break;
+
+        case 3:
+            if (nQFE < 17000)
+                g_nWinVersion = WIN_VERSION_81;
             else
-                g_nWinVersion = WIN_VERSION_11_22H2;
+                g_nWinVersion = WIN_VERSION_811;
             break;
+
+        case 4:
+            g_nWinVersion = WIN_VERSION_10_T1;
+            break;
+        }
+        break;
+
+    case 10:
+        if (nBuild <= 10240)
+            g_nWinVersion = WIN_VERSION_10_T1;
+        else if (nBuild <= 10586)
+            g_nWinVersion = WIN_VERSION_10_T2;
+        else if (nBuild <= 14393)
+            g_nWinVersion = WIN_VERSION_10_R1;
+        else if (nBuild <= 15063)
+            g_nWinVersion = WIN_VERSION_10_R2;
+        else if (nBuild <= 16299)
+            g_nWinVersion = WIN_VERSION_10_R3;
+        else if (nBuild <= 17134)
+            g_nWinVersion = WIN_VERSION_10_R4;
+        else if (nBuild <= 17763)
+            g_nWinVersion = WIN_VERSION_10_R5;
+        else if (nBuild <= 18362)
+            g_nWinVersion = WIN_VERSION_10_19H1;
+        else if (nBuild <= 19045)
+            g_nWinVersion = WIN_VERSION_10_20H1;
+        else if (nBuild <= 20348)
+            g_nWinVersion = WIN_VERSION_SERVER_2022;
+        else if (nBuild <= 22000)
+            g_nWinVersion = WIN_VERSION_11_21H2;
+        else
+            g_nWinVersion = WIN_VERSION_11_22H2;
+        break;
     }
+
+    Wh_Log(L"Detected windows version: %d", g_nWinVersion);
 
     if (g_nWinVersion == WIN_VERSION_UNSUPPORTED)
         return FALSE;
@@ -1677,7 +1305,7 @@ bool ToggleTaskbarAutohide() {
     return !isEnabled;
 }
 
-#pragma endregion  // functions
+#pragma endregion // functions
 
 // =====================================================================
 
@@ -1687,52 +1315,80 @@ bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam) {
         return false;
     }
 
-    if (IS_POINTER_THIRDBUTTON_WPARAM(wParam) == 0) {
-        return false;
+    POINT pointerLocation{};
+
+    // old Windows mouse handling of WM_MBUTTONDOWN message
+    if (g_nExplorerVersion < WIN_VERSION_11_21H2) {
+        // message carries mouse position relative to the client window so use GetCursorPos() instead
+        if (!GetCursorPos(&pointerLocation)) {
+            Wh_Log(L"Failed to get mouse position");
+            return false;
+        }
+
+    // new Windows sends different message - WM_POINTERDOWN
+    } else {
+        if (IS_POINTER_THIRDBUTTON_WPARAM(wParam) == 0) {
+            return false;
+        }
+        POINTER_INFO pointerInfo{};
+        BOOL success = GetPointerInfo(GET_POINTERID_WPARAM(wParam), &pointerInfo);
+        if (!success) {
+            return false;
+        }
+        pointerLocation = pointerInfo.ptPixelLocation;
     }
 
-    POINTER_INFO pointerInfo{};
-    BOOL success = GetPointerInfo(GET_POINTERID_WPARAM(wParam), &pointerInfo);
-    if (!success) {
-        return false;
-    }
+    Wh_Log(L"Middle mouse clicked at x=%ld, y=%ld", pointerLocation.x, pointerLocation.y);
 
-    POINT pointerLocation = pointerInfo.ptPixelLocation;
-    Wh_Log(L"Middle mouse clicked at x=%ld, y=%ld", pointerLocation.x,
-           pointerLocation.y);
-
-    IUIAutomation* pUIAutomation = g_UIAutomation.getInstance();
+    IUIAutomation *pUIAutomation = g_UIAutomation.getInstance();
     if (pUIAutomation == NULL) {
         Wh_Log(L"UIAutomationWrapper failed to get instance\n");
         return false;
     }
 
-    IUIAutomationElement* pWindowElementRaw = NULL;
-    HRESULT hr =
-        pUIAutomation->ElementFromPoint(pointerLocation, &pWindowElementRaw);
-    if (FAILED(hr) || (pWindowElementRaw == NULL)) {
+    IUIAutomationElement *pWindowElement = NULL;
+    HRESULT hr = pUIAutomation->ElementFromPoint(pointerLocation, &pWindowElement);
+    if (FAILED(hr) || (pWindowElement == NULL)) {
         Wh_Log(L"Failed to retrieve UI element from mouse click\n");
         return false;
     }
 
-    BSTR currentAutomationId;
-    hr = pWindowElementRaw->get_CurrentAutomationId(&currentAutomationId);
-    if (FAILED(hr)) {
-        Wh_Log(L"Failed to retrieve the name of the UI element clicked.");
-        pWindowElementRaw->Release();
-        return false;
+    // old Windows 10 taskbar
+    bool taskbarClicked = false;
+    if (g_nExplorerVersion < WIN_VERSION_11_21H2) {
+        BSTR className = NULL;
+        hr = pWindowElement->get_CurrentClassName(&className);
+        if (FAILED(hr) || (className == NULL)) { 
+            Wh_Log(L"Failed to retrieve the Name of the UI element clicked.");
+            pWindowElement->Release();
+            return false;
+        }
+        Wh_Log(L"Clicked UI element ClassName: %s", className);
+        taskbarClicked = (wcscmp(className, L"Shell_TrayWnd") == 0) || (wcscmp(className, L"Shell_SecondaryTrayWnd") == 0);
+        SysFreeString(className);
+        pWindowElement->Release();
+
+    // new Windows 11 taskbar
+    } else {
+        BSTR automationId = NULL;
+        hr = pWindowElement->get_CurrentAutomationId(&automationId);     // lets hope automationID will stay the same in future
+        if (FAILED(hr) || (automationId == NULL)) {
+            Wh_Log(L"Failed to retrieve the AutomationID of the UI element clicked.");
+            pWindowElement->Release();
+            return false;
+        }
+
+        Wh_Log(L"Clicked UI element AutomationID: %s", automationId);
+        taskbarClicked = wcscmp(automationId, L"TaskbarFrame") == 0;
+        SysFreeString(automationId);
+        pWindowElement->Release();
     }
 
-    Wh_Log(L"Clicked element: %s", currentAutomationId);
-
-    if (wcscmp(currentAutomationId, L"TaskbarFrame") == 0) {
+    if (taskbarClicked) {
         const bool isAutohideEnabled = ToggleTaskbarAutohide();
-        Wh_Log(L"Setting taskbar autohide state to %s",
-               isAutohideEnabled ? L"enabled" : L"disabled");
+        Wh_Log(L"Setting taskbar autohide state to %s", isAutohideEnabled ? L"enabled" : L"disabled");
     }
 
-    SysFreeString(currentAutomationId);      
-    pWindowElementRaw->Release();
     return false;
 }
 
@@ -1746,30 +1402,25 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
+    // treat Windows 11 taskbar as on older windows
     g_nExplorerVersion = g_nWinVersion;
-    if (g_nExplorerVersion >= WIN_VERSION_11_21H2 &&
-        g_settings.oldTaskbarOnWin11) {
+    if (g_nExplorerVersion >= WIN_VERSION_11_21H2 && g_settings.oldTaskbarOnWin11) {
         g_nExplorerVersion = WIN_VERSION_10_20H1;
     }
 
-    Wh_SetFunctionHook((void*)CreateWindowExW, (void*)CreateWindowExW_Hook,
-                       (void**)&CreateWindowExW_Original);
+    Wh_SetFunctionHook((void *)CreateWindowExW, (void *)CreateWindowExW_Hook, (void **)&CreateWindowExW_Original);
 
     HMODULE user32Module = LoadLibrary(L"user32.dll");
     if (user32Module) {
-        void* pCreateWindowInBand =
-            (void*)GetProcAddress(user32Module, "CreateWindowInBand");
+        void *pCreateWindowInBand = (void *)GetProcAddress(user32Module, "CreateWindowInBand");
         if (pCreateWindowInBand) {
-            Wh_SetFunctionHook(pCreateWindowInBand,
-                               (void*)CreateWindowInBand_Hook,
-                               (void**)&CreateWindowInBand_Original);
+            Wh_SetFunctionHook(pCreateWindowInBand, (void *)CreateWindowInBand_Hook, (void **)&CreateWindowInBand_Original);
         }
     }
 
     WNDCLASS wndclass;
     if (GetClassInfo(GetModuleHandle(NULL), L"Shell_TrayWnd", &wndclass)) {
-        HWND hWnd =
-            FindCurrentProcessTaskbarWindows(&g_secondaryTaskbarWindows);
+        HWND hWnd = FindCurrentProcessTaskbarWindows(&g_secondaryTaskbarWindows);
         if (hWnd) {
             HandleIdentifiedTaskbarWindow(hWnd);
         }

--- a/mods/toggle-taskbar-autohide.wh.cpp
+++ b/mods/toggle-taskbar-autohide.wh.cpp
@@ -21,9 +21,16 @@
 /*
 # Toggle taskbar autohide
 Toggle taskbar autohide feature with middle mouse click on the taskbar. Whenever you middle click on a free space on your taskbar (outside other UI
-elemwnts on the taskbar), taskbar's autohide feature gets turned on or off.
+elements on the taskbar), taskbar's autohide feature gets turned on or off.
 
-![Demonstration](https://i.imgur.com/B6mtUj9.gif)
+![Demonstration of Toggle taskbar autohide mod for Windhawk](https://i.imgur.com/BRQrVnX.gif)
+
+## Supported Windows versions are:
+- Windows 10 22H2 (prior versions are not tested, but should work as well)
+- Windows 11 21H2-latest 
+
+In case you are using old Windows taskbar on Windows 11 (Explorer Patcher or a similar tool), enable corresponding option on Settings menu.
+
 */
 // ==/WindhawkModReadme==
 

--- a/mods/toggle-taskbar-autohide.wh.cpp
+++ b/mods/toggle-taskbar-autohide.wh.cpp
@@ -6,7 +6,7 @@
 // @author          m1lhaus
 // @github          https://github.com/m1lhaus
 // @include         explorer.exe
-// @compilerOptions -DWINVER=0x0602 -lcomctl32 -ldwmapi -lole32 -lversion
+// @compilerOptions -DWINVER=0x0602 -lcomctl32 -loleaut32 -ldwmapi -lole32 -lversion
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.

--- a/mods/toggle-taskbar-autohide.wh.cpp
+++ b/mods/toggle-taskbar-autohide.wh.cpp
@@ -6,13 +6,13 @@
 // @author          m1lhaus
 // @github          https://github.com/m1lhaus
 // @include         explorer.exe
-// @compilerOptions -DWINVER=0x0602 -lcomctl32 -loleaut32 -ldwmapi -lole32 -lversion
+// @compilerOptions -DWINVER=0x0602 -lcomctl32 -loleaut32 -lole32 -lversion
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
 //
 // For bug reports and feature requests, please open an issue here:
-// https://github.com/ramensoftware/windhawk-mods/issues
+// https://github.com/m1lhaus/windhawk-mods/issues
 //
 // For pull requests, development takes place here:
 // https://github.com/m1lhaus/windhawk-mods
@@ -46,20 +46,15 @@ In case you are using old Windows taskbar on Windows 11 (Explorer Patcher or a s
 // ==/WindhawkModSettings==
 
 #include <commctrl.h>
-#include <dwmapi.h>
-#include <endpointvolume.h>
-#include <mmdeviceapi.h>
-#include <objbase.h>
-#include <oleauto.h>
-#include <uiautomation.h>
 #include <windhawk_api.h>
-#include <windowsx.h>
 #include <winerror.h>
 #include <winuser.h>
 
-#include <algorithm>
+#include <UIAnimation.h>
+#include <UIAutomationClient.h>
+#include <UIAutomationCore.h>
+
 #include <string>
-#include <string_view>
 #include <unordered_set>
 #include <vector>
 

--- a/mods/toggle-taskbar-autohide.wh.cpp
+++ b/mods/toggle-taskbar-autohide.wh.cpp
@@ -27,9 +27,11 @@ elements on the taskbar), taskbar's autohide feature gets turned on or off.
 
 ## Supported Windows versions are:
 - Windows 10 22H2 (prior versions are not tested, but should work as well)
-- Windows 11 21H2-latest 
+- Windows 11 21H2 - latest major
 
-In case you are using old Windows taskbar on Windows 11 (Explorer Patcher or a similar tool), enable corresponding option on Settings menu.
+I will not supporting Insider preview or other minor versions of Windows. However, feel free to [report any issues](https://github.com/m1lhaus/windhawk-mods/issues) related to those versions. I'll appreciate the heads-up in advance.  
+
+In case you are using old Windows taskbar on Windows 11 (**Explorer Patcher** or a similar tool), enable corresponding option on Settings menu. This options will be tested only with the latest major version of Windows 11 (e.g. 23H2). 
 
 */
 // ==/WindhawkModReadme==

--- a/mods/toggle-taskbar-autohide.wh.cpp
+++ b/mods/toggle-taskbar-autohide.wh.cpp
@@ -6,7 +6,7 @@
 // @author          m1lhaus
 // @github          https://github.com/m1lhaus
 // @include         explorer.exe
-// @compilerOptions -DWINVER=0x0602 -lcomctl32 -loleaut32 -lole32 -lversion
+// @compilerOptions -DWINVER=0x0602 -D_WIN32_WINNT=0x0602 -lcomctl32 -loleaut32 -lole32 -lversion
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -45,6 +45,8 @@ In case you are using old Windows taskbar on Windows 11 (Explorer Patcher or a s
 */
 // ==/WindhawkModSettings==
 
+// Note: If intellisense is giving you a trouble, add -DWINVER=0x0602 -D_WIN32_WINNT=0x0602 flags to compile_flags.txt (Ctrl+E).
+
 #include <commctrl.h>
 #include <windhawk_api.h>
 #include <winerror.h>
@@ -64,10 +66,6 @@ In case you are using old Windows taskbar on Windows 11 (Explorer Patcher or a s
 #define WINAPI_LAMBDA_RETURN(return_t) WINAPI->return_t
 #else
 #define WINAPI_LAMBDA_RETURN(return_t) ->return_t
-#endif
-
-#ifndef WM_POINTERDOWN
-#define WM_POINTERDOWN 0x0246
 #endif
 
 // =====================================================================

--- a/mods/toggle-taskbar-autohide.wh.cpp
+++ b/mods/toggle-taskbar-autohide.wh.cpp
@@ -552,7 +552,7 @@ class UIAutomationWrapper {
         if (SUCCEEDED(result)) {
             isCOMInitialized = true;
         } else {
-            Wh_Log(L"CoInitializeEx failed\n");
+            Wh_Log(L"CoInitializeEx failed");
             return false;
         }
 
@@ -560,10 +560,10 @@ class UIAutomationWrapper {
         if (SUCCEEDED(result)) {
             isUIAutomationInitialized = true;
         } else {
-            Wh_Log(L"CoCreateInstance failed\n");
+            Wh_Log(L"CoCreateInstance failed");
             return false;
         }
-        Wh_Log(L"UIAutomationWrapper initilized\n");
+        Wh_Log(L"UIAutomationWrapper initilized");
         return true;
     }
 
@@ -1009,14 +1009,14 @@ bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam) {
 
     IUIAutomation *pUIAutomation = g_UIAutomation.getInstance();
     if (pUIAutomation == NULL) {
-        Wh_Log(L"UIAutomationWrapper failed to get instance\n");
+        Wh_Log(L"UIAutomationWrapper failed to get instance");
         return false;
     }
 
     winrt::com_ptr<IUIAutomationElement> pWindowElement = NULL;
     HRESULT hr = pUIAutomation->ElementFromPoint(pointerLocation, pWindowElement.put());
     if (FAILED(hr) || !pWindowElement) {
-        Wh_Log(L"Failed to retrieve UI element from mouse click\n");
+        Wh_Log(L"Failed to retrieve UI element from mouse click");
         return false;
     }
 
@@ -1059,7 +1059,7 @@ BOOL Wh_ModInit() {
 
     // init UIAutomation before hooks, otherwise subclass won't be unset and Explorer will crash if UIAutomation fails
     if (!g_UIAutomation.init()) {
-        Wh_Log(L"UIAutomationWrapper failed to initialize\n");
+        Wh_Log(L"UIAutomationWrapper failed to initialize");
         return FALSE;
     }
 

--- a/mods/toggle-taskbar-autohide.wh.cpp
+++ b/mods/toggle-taskbar-autohide.wh.cpp
@@ -1226,9 +1226,8 @@ bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam) {
         return false;
     }
 
-    POINT pointerLocation{};
-
     // old Windows mouse handling of WM_MBUTTONDOWN message
+    POINT pointerLocation{};
     if (g_taskbarVersion == WIN_10_TASKBAR) {
         // message carries mouse position relative to the client window so use GetCursorPos() instead
         if (!GetCursorPos(&pointerLocation)) {
@@ -1248,8 +1247,12 @@ bool OnMouseClick(HWND hWnd, WPARAM wParam, LPARAM lParam) {
         }
         pointerLocation = pointerInfo.ptPixelLocation;
     }
-
     Wh_Log(L"Middle mouse clicked at x=%ld, y=%ld", pointerLocation.x, pointerLocation.y);
+
+    // Note: The reason why UIAutomation interface is used is that it reliably returns a className of the element clicked.
+    // If standard Windows API is used, the className returned is always Shell_TrayWnd which is a parrent window wrapping the taskbar.
+    // From that we can't really tell reliably whether user clicked on the taskbar empty space or on some UI element on that taskbar, like 
+    // opened window, icon, start menu, etc. 
 
     IUIAutomation *pUIAutomation = g_UIAutomation.getInstance();
     if (pUIAutomation == NULL) {


### PR DESCRIPTION
Updated version of Click on empty taskbar space mod

Changelog:
- code reformatted by clang formatter - Visual Studio style (it makes the diff a pain in the ass I know and I am sorry for that - I will stick to this format from now on)
- removed 7+TT code used for Ctrl+Alt+Tab and Win+Tab (replaced by virtual keypress)
- implemented Open Start menu feature (sends Win keypress)
- implemented "Combine taskbar butons toggle" (works only on Windows 10 and newer Windows 11 versions) - closes #463
- prevent multiple double-clicks when tripple-clicking

Other features from https://github.com/m1lhaus/windhawk-mods/issues will be implemented later on.