### PR TITLE
Taskbar Thumbnail Reorder v1.0.6

### DIFF
--- a/mods/taskbar-thumbnail-reorder.wh.cpp
+++ b/mods/taskbar-thumbnail-reorder.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-thumbnail-reorder
 // @name            Taskbar Thumbnail Reorder
 // @description     Reorder taskbar thumbnails with the left mouse button
-// @version         1.0.5
+// @version         1.0.6
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -1017,7 +1017,7 @@ BOOL Wh_ModInit() {
         },
         {
             {
-                LR"(public: virtual struct HWND__ * __cdecl CTaskListThumbnailWnd::GetHwnd(void) __ptr64)",
+                LR"(public: virtual struct HWND__ * __ptr64 __cdecl CTaskListThumbnailWnd::GetHwnd(void) __ptr64)",
                 LR"(public: virtual struct HWND__ * __cdecl CTaskListThumbnailWnd::GetHwnd(void))",
             },
             (void**)&CTaskListThumbnailWnd_GetHwnd,


### PR DESCRIPTION
* Fixed mod not working if installed with an old Windhawk version.