### PR TITLE
Classic UWP Fix 0.3

### DIFF
--- a/mods/classic-uwp-fix.wh.cpp
+++ b/mods/classic-uwp-fix.wh.cpp
@@ -7,6 +7,7 @@
 // @github          https://github.com/Ingan121
 // @homepage        https://www.ingan121.com/
 // @include         ApplicationFrameHost.exe
+// @architecture    x86-64
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -22,9 +23,9 @@ This works by hardcoding the splash fade animation values instead of fetching th
 
 #include <windhawk_utils.h>
 
-typedef INT64 (* AnimationHelpers__LoadThemeTransform_t)(void *, UINT, INT64 *, struct TA_TRANSFORM *, INT64 *, struct TA_TIMINGFUNCTION *);
+typedef INT64 (* WINAPI AnimationHelpers__LoadThemeTransform_t)(void *, UINT, INT64 *, struct TA_TRANSFORM *, INT64 *, struct TA_TIMINGFUNCTION *);
 AnimationHelpers__LoadThemeTransform_t AnimationHelpers__LoadThemeTransform_orig;
-INT64 __fastcall AnimationHelpers__LoadThemeTransform_hook(
+INT64 WINAPI AnimationHelpers__LoadThemeTransform_hook(
     void *pThis,
     UINT a2,
     INT64 *out,

--- a/mods/classic-uwp-fix.wh.cpp
+++ b/mods/classic-uwp-fix.wh.cpp
@@ -1,0 +1,81 @@
+// ==WindhawkMod==
+// @id              classic-uwp-fix
+// @name            Classic UWP Fix
+// @description     Fix for UWPs breaking with Classic theme
+// @version         0.2
+// @author          Ingan121
+// @github          https://github.com/Ingan121
+// @homepage        https://www.ingan121.com/
+// @include         ApplicationFrameHost.exe
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Classic UWP Fix
+This mod fixes UWP apps getting stuck at the splash screen when using the Classic theme.
+
+No more need to run ApplicationFrameHost before enabling Classic!
+
+This works by hardcoding the splash fade animation values instead of fetching them from msstyles.
+*/
+// ==/WindhawkModReadme==
+
+#include <windhawk_utils.h>
+
+typedef INT64 (* AnimationHelpers__LoadThemeTransform_t)(void *, UINT, INT64 *, struct TA_TRANSFORM *, INT64 *, struct TA_TIMINGFUNCTION *);
+AnimationHelpers__LoadThemeTransform_t AnimationHelpers__LoadThemeTransform_orig;
+INT64 __fastcall AnimationHelpers__LoadThemeTransform_hook(
+    void *pThis,
+    UINT a2,
+    INT64 *out,
+    struct TA_TRANSFORM *a4,
+    INT64 *a5,
+    struct TA_TIMINGFUNCTION *a6
+){
+    out[0] = 2;
+    out[1] = 0;
+    out[2] = 2;
+    out[3] = 1065353216;
+    out[4] = 1;
+    out[5] = 0;
+    out[6] = 1065353216;
+    return 0;
+}
+
+// The mod is being initialized, load settings, hook functions, and do other
+// initialization stuff if required.
+BOOL Wh_ModInit() {
+    Wh_Log(L"Init");
+
+    HMODULE hAppFrameModule = LoadLibraryW(L"ApplicationFrame.dll");
+    if(!hAppFrameModule) {
+        Wh_Log(L"Failed to load ApplicationFrame.dll");
+        return FALSE;
+    }
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+        {
+            {
+                L"long __cdecl AnimationHelpers::LoadThemeTransform(int,int,struct TA_TRANSFORM *,unsigned long,struct TA_TIMINGFUNCTION *,unsigned long)"
+            },
+            (void **)&AnimationHelpers__LoadThemeTransform_orig,
+            (void *)AnimationHelpers__LoadThemeTransform_hook,
+            false
+        }
+    };
+
+    if (!WindhawkUtils::HookSymbols(
+        hAppFrameModule,
+        hooks,
+        ARRAYSIZE(hooks)
+    )) {
+        Wh_Log(L"Failed to hook");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+// The mod is being unloaded, free all allocated resources.
+void Wh_ModUninit() {
+    Wh_Log(L"Uninit");
+}

--- a/mods/classic-uwp-fix.wh.cpp
+++ b/mods/classic-uwp-fix.wh.cpp
@@ -2,11 +2,14 @@
 // @id              classic-uwp-fix
 // @name            Classic UWP Fix
 // @description     Fix for UWPs breaking with Classic theme
-// @version         0.2
+// @version         0.3
 // @author          Ingan121
 // @github          https://github.com/Ingan121
 // @homepage        https://www.ingan121.com/
 // @include         ApplicationFrameHost.exe
+// @include         explorer.exe
+// @include         ShellAppRuntime.exe
+// @include         CustomShellHost.exe
 // @architecture    x86-64
 // ==/WindhawkMod==
 
@@ -23,23 +26,27 @@ This works by hardcoding the splash fade animation values instead of fetching th
 
 #include <windhawk_utils.h>
 
-typedef INT64 (* WINAPI AnimationHelpers__LoadThemeTransform_t)(void *, UINT, INT64 *, struct TA_TRANSFORM *, INT64 *, struct TA_TIMINGFUNCTION *);
+typedef INT64 (* WINAPI AnimationHelpers__LoadThemeTransform_t)(void *, UINT, INT64 *, int, INT64 *, struct TA_TIMINGFUNCTION *);
 AnimationHelpers__LoadThemeTransform_t AnimationHelpers__LoadThemeTransform_orig;
 INT64 WINAPI AnimationHelpers__LoadThemeTransform_hook(
     void *pThis,
     UINT a2,
     INT64 *out,
-    struct TA_TRANSFORM *a4,
+    int type,
     INT64 *a5,
     struct TA_TIMINGFUNCTION *a6
 ){
-    out[0] = 2;
-    out[1] = 0;
-    out[2] = 2;
-    out[3] = 1065353216;
-    out[4] = 1;
-    out[5] = 0;
-    out[6] = 1065353216;
+    if (type == 28) {
+        out[0] = 2;
+        out[1] = 0;
+        out[2] = 2;
+        out[3] = 1.0f;
+        out[4] = 1;
+        out[5] = 0;
+        out[6] = 1.0f;
+    } else {
+        AnimationHelpers__LoadThemeTransform_orig(pThis, a2, out, type, a5, a6);
+    }
     return 0;
 }
 

--- a/mods/fake-high-contrast.wh.cpp
+++ b/mods/fake-high-contrast.wh.cpp
@@ -1,0 +1,57 @@
+// ==WindhawkMod==
+// @id              fake-high-contrast
+// @name            Fake High Contrast
+// @description     Fake High Contrast status for apps
+// @version         1.0.0
+// @author          Ingan121
+// @github          https://github.com/Ingan121
+// @homepage        https://www.ingan121.com/
+// @include         *
+// @exclude         explorer.exe
+// @exclude         dwm.exe
+// ==/WindhawkMod==
+// hooking explorer makes it change the real HiContrast status every time user switches back to current desktop (e.g. after UAC or Ctrl+Alt+Del)
+// hooking dwm adds undesirable HiContrast borders
+
+// ==WindhawkModReadme==
+/*
+# Fake High Contrast
+* Makes applications think as if high contrast mode is enabled (disabled), even if it's not.
+* Useful if you want more applications to follow your Win32 msstyles / classic schemes. Even UWP apps!
+## Known issues
+* UIRibbon is not affected at all.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- fakeoff: false
+  $name: Fake high contrast is disabled
+  $description: Enable this if you use a real high contrast theme. This will make apps think that high contrast is disabled.
+*/
+// ==/WindhawkModSettings==
+
+using SystemParametersInfoW_t = decltype(&SystemParametersInfoW);
+SystemParametersInfoW_t pOriginalSystemParametersInfoW;
+BOOL WINAPI SystemParametersInfoW_Hook(
+    UINT  uiAction,
+    UINT  uiParam,
+    PVOID pvParam,
+    UINT  fWinIni
+)
+{
+    if (uiAction == SPI_GETHIGHCONTRAST)
+    {
+        DWORD flag = Wh_GetIntSetting(L"fakeoff") ? HCF_AVAILABLE : HCF_HIGHCONTRASTON;
+        HIGHCONTRAST info = { .cbSize = sizeof(info), .dwFlags = flag };
+        *(HIGHCONTRAST*)pvParam = info;
+        return TRUE;
+    }
+
+    return pOriginalSystemParametersInfoW(uiAction, uiParam, pvParam, fWinIni);
+}
+
+BOOL Wh_ModInit() {
+    Wh_SetFunctionHook((void*)SystemParametersInfoW, (void*)SystemParametersInfoW_Hook, (void**)&pOriginalSystemParametersInfoW);
+    return TRUE;
+}


### PR DESCRIPTION
Added support for the UWP MSA sign-in window, hosted by explorer.exe (or ShellAppRuntime or CustomShellHost).
To get the Explorer hooking working without crashing, I had to add checks to ensure that the program requested the UWP splash fade animation. Explorer uses the same function on startup to fetch a different animation.