### PR TITLE
Create classic-taskbar-buttons-lite-vs-without-spacing.wh.cpp

### DIFF
--- a/mods/classic-taskbar-buttons-lite-vs-without-spacing.wh.cpp
+++ b/mods/classic-taskbar-buttons-lite-vs-without-spacing.wh.cpp
@@ -1,0 +1,140 @@
+// ==WindhawkMod==
+// @id              classic-taskbar-buttons-lite-vs-without-spacing
+// @name            Classic Taskbar 3D buttons with extended compatibility
+// @description     Restoring the 3D taskbar buttons with support for visual styles and the taskbar without labels
+// @version         1.0
+// @author          OrthodoxWin32
+// @github          https://github.com/OrthodoxWindows
+// @include         explorer.exe
+// @compilerOptions -lgdi32 -lUxTheme
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Classic Taskbar Fix
+Restores 3D buttons on taskbar when using Windows Classic theme or Windows Visual Style. Based on mod by Anixx (https://github.com/anixx), itself founded from a mod by Aubymori (https://github.com/aubymori).
+Known issue : Under the classic theme, icons have no space between them. It is possible to add space, but this prevents the taskbar from functioning correctly if the labels are hidden.
+*/
+// ==/WindhawkModReadme==
+
+#include <windhawk_utils.h>
+#include <windows.h>
+#include <uxtheme.h>
+#include <tmschema.h>
+
+
+typedef struct tagBUTTONRENDERINFOSTATES {
+    char data[12];
+} BUTTONRENDERINFOSTATES, *PBUTTONRENDERINFOSTATES;
+
+/* Remove clock hover effect */
+typedef void (* GDIHelpers_FillRectARGB_t)(HDC, LPCRECT, BYTE, DWORD, bool);
+GDIHelpers_FillRectARGB_t GDIHelpers_FillRectARGB_orig;
+void __cdecl GDIHelpers_FillRectARGB_hook(
+    HDC     hDC,
+    LPCRECT lprc,
+    BYTE    btUnknown,
+    DWORD   dwUnknown,
+    bool    bUnknown
+)
+{
+    return;
+}
+
+/* Draw taskbar item */
+typedef void (* CTaskBtnGroup__DrawBar_t)(void *, HDC, void *, void *);
+CTaskBtnGroup__DrawBar_t CTaskBtnGroup__DrawBar_orig;
+void __cdecl CTaskBtnGroup__DrawBar_hook(
+    void *pThis,
+    HDC   hDC,
+    void *pRenderInfo,
+    PBUTTONRENDERINFOSTATES pRenderStates
+)
+{
+    LPRECT lprcDest = (LPRECT)((char *)pRenderInfo + 4);
+
+    HTHEME hTheme = OpenThemeData(NULL, L"BUTTON");
+
+    if (hTheme) {
+        int iStateId = PBS_NORMAL; 
+
+        if (pRenderStates->data[2]) {
+
+            iStateId = PBS_PRESSED; // or use PBS_HOT if you prefer
+
+        } else if (pRenderStates->data[4]) {
+
+            iStateId = PBS_PRESSED;
+
+        }
+
+        // Draw the button with the current theme.
+
+        DrawThemeBackground(hTheme, hDC, BP_PUSHBUTTON, iStateId, lprcDest, NULL);
+
+
+        // Close the theme data handle when done.
+
+        CloseThemeData(hTheme);
+    } else
+    {
+        // Fallback to non-themed drawing if themes are not available.
+
+        UINT uState = DFCS_BUTTONPUSH;
+        if (pRenderStates->data[2])
+        {
+            uState |= DFCS_CHECKED;
+        }
+        else if (pRenderStates->data[4])
+        {
+            uState |= DFCS_PUSHED;
+        }
+
+        DrawFrameControl(hDC, lprcDest, DFC_BUTTON, uState);
+    };
+
+
+    /* If button is pushed in, offset the rect for the icon and text draw */
+    if (pRenderStates->data[2]
+    ||  pRenderStates->data[4])
+    {
+        lprcDest->top++;
+        lprcDest->bottom++;
+        lprcDest->left++;
+        lprcDest->right++;
+    }
+
+    return;
+}
+
+BOOL Wh_ModInit(void)
+{
+    HMODULE hExplorer = GetModuleHandleW(NULL);
+
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+        {
+            {
+                L"void __cdecl GDIHelpers::FillRectARGB(struct HDC__ *,struct tagRECT const *,unsigned char,unsigned long,bool)"
+            },
+            (void **)&GDIHelpers_FillRectARGB_orig,
+            (void *)GDIHelpers_FillRectARGB_hook,
+            FALSE
+        },
+        {
+            {
+                L"private: void __cdecl CTaskBtnGroup::_DrawBar(struct HDC__ *,struct BUTTONRENDERINFO const &,struct BUTTONRENDERINFOSTATES const &)"
+            },
+            (void **)&CTaskBtnGroup__DrawBar_orig,
+            (void *)CTaskBtnGroup__DrawBar_hook,
+            FALSE
+        }
+    };
+
+    if (!WindhawkUtils::HookSymbols(hExplorer, hooks, ARRAYSIZE(hooks)))
+    {
+        Wh_Log(L"Failed to hook one or more functions");
+        return FALSE;
+    }
+
+    return TRUE;
+}

--- a/mods/classic-taskbar-buttons-lite-vs-without-spacing.wh.cpp
+++ b/mods/classic-taskbar-buttons-lite-vs-without-spacing.wh.cpp
@@ -22,22 +22,14 @@ Known issue : Under the classic theme, icons have no space between them. It is p
 #include <uxtheme.h>
 #include <vssym32.h>
 
-#ifdef _WIN64
-#define CALCON __cdecl
-#define SCALCON L"__cdecl"
-#else
-#define CALCON __thiscall
-#define SCALCON L"__thiscall"
-#endif
-
 typedef struct tagBUTTONRENDERINFOSTATES {
     char data[12];
 } BUTTONRENDERINFOSTATES, *PBUTTONRENDERINFOSTATES;
 
 /* Remove clock hover effect */
-typedef void (* GDIHelpers_FillRectARGB_t)(HDC, LPCRECT, BYTE, DWORD, bool);
+typedef void (*__cdecl GDIHelpers_FillRectARGB_t)(HDC, LPCRECT, BYTE, DWORD, bool);
 GDIHelpers_FillRectARGB_t GDIHelpers_FillRectARGB_orig;
-void CALCON GDIHelpers_FillRectARGB_hook(
+void __cdecl GDIHelpers_FillRectARGB_hook(
     HDC     hDC,
     LPCRECT lprc,
     BYTE    btUnknown,
@@ -49,9 +41,9 @@ void CALCON GDIHelpers_FillRectARGB_hook(
 }
 
 /* Draw taskbar item */
-typedef void (* CTaskBtnGroup__DrawBar_t)(void *, HDC, void *, void *);
+typedef void (*__cdecl CTaskBtnGroup__DrawBar_t)(void *, HDC, void *, void *);
 CTaskBtnGroup__DrawBar_t CTaskBtnGroup__DrawBar_orig;
-void CALCON CTaskBtnGroup__DrawBar_hook(
+void __cdecl CTaskBtnGroup__DrawBar_hook(
     void *pThis,
     HDC   hDC,
     void *pRenderInfo,
@@ -121,19 +113,15 @@ BOOL Wh_ModInit(void)
     WindhawkUtils::SYMBOL_HOOK hooks[] = {
         {
             {
-                L"void "
-                SCALCON
-                L" GDIHelpers::FillRectARGB(struct HDC__ *,struct tagRECT const *,unsigned char,unsigned long,bool)"
+                L"void __cdecl GDIHelpers::FillRectARGB(struct HDC__ *,struct tagRECT const *,unsigned char,unsigned long,bool)"
             },
-            (void **)&GDIHelpers_FillRectARGB_orig,
-            (void *)GDIHelpers_FillRectARGB_hook,
+            &GDIHelpers_FillRectARGB_orig,
+            GDIHelpers_FillRectARGB_hook,
             FALSE
         },
         {
             {
-                L"private: void "
-                SCALCON
-                L" CTaskBtnGroup::_DrawBar(struct HDC__ *,struct BUTTONRENDERINFO const &,struct BUTTONRENDERINFOSTATES const &)"
+                L"private: void __cdecl CTaskBtnGroup::_DrawBar(struct HDC__ *,struct BUTTONRENDERINFO const &,struct BUTTONRENDERINFOSTATES const &)"
             },
             (void **)&CTaskBtnGroup__DrawBar_orig,
             (void *)CTaskBtnGroup__DrawBar_hook,

--- a/mods/classic-taskbar-buttons-lite-vs-without-spacing.wh.cpp
+++ b/mods/classic-taskbar-buttons-lite-vs-without-spacing.wh.cpp
@@ -22,6 +22,13 @@ Known issue : Under the classic theme, icons have no space between them. It is p
 #include <uxtheme.h>
 #include <tmschema.h>
 
+#ifdef _WIN64
+#define CALCON __cdecl
+#define SCALCON L"__cdecl"
+#else
+#define CALCON __thiscall
+#define SCALCON L"__thiscall"
+#endif
 
 typedef struct tagBUTTONRENDERINFOSTATES {
     char data[12];
@@ -30,7 +37,7 @@ typedef struct tagBUTTONRENDERINFOSTATES {
 /* Remove clock hover effect */
 typedef void (* GDIHelpers_FillRectARGB_t)(HDC, LPCRECT, BYTE, DWORD, bool);
 GDIHelpers_FillRectARGB_t GDIHelpers_FillRectARGB_orig;
-void __cdecl GDIHelpers_FillRectARGB_hook(
+void CALCON GDIHelpers_FillRectARGB_hook(
     HDC     hDC,
     LPCRECT lprc,
     BYTE    btUnknown,
@@ -44,7 +51,7 @@ void __cdecl GDIHelpers_FillRectARGB_hook(
 /* Draw taskbar item */
 typedef void (* CTaskBtnGroup__DrawBar_t)(void *, HDC, void *, void *);
 CTaskBtnGroup__DrawBar_t CTaskBtnGroup__DrawBar_orig;
-void __cdecl CTaskBtnGroup__DrawBar_hook(
+void CALCON CTaskBtnGroup__DrawBar_hook(
     void *pThis,
     HDC   hDC,
     void *pRenderInfo,
@@ -114,7 +121,9 @@ BOOL Wh_ModInit(void)
     WindhawkUtils::SYMBOL_HOOK hooks[] = {
         {
             {
-                L"void __cdecl GDIHelpers::FillRectARGB(struct HDC__ *,struct tagRECT const *,unsigned char,unsigned long,bool)"
+                L"void "
+                SCALCON
+                L" GDIHelpers::FillRectARGB(struct HDC__ *,struct tagRECT const *,unsigned char,unsigned long,bool)"
             },
             (void **)&GDIHelpers_FillRectARGB_orig,
             (void *)GDIHelpers_FillRectARGB_hook,
@@ -122,7 +131,9 @@ BOOL Wh_ModInit(void)
         },
         {
             {
-                L"private: void __cdecl CTaskBtnGroup::_DrawBar(struct HDC__ *,struct BUTTONRENDERINFO const &,struct BUTTONRENDERINFOSTATES const &)"
+                L"private: void "
+                SCALCON
+                L" CTaskBtnGroup::_DrawBar(struct HDC__ *,struct BUTTONRENDERINFO const &,struct BUTTONRENDERINFOSTATES const &)"
             },
             (void **)&CTaskBtnGroup__DrawBar_orig,
             (void *)CTaskBtnGroup__DrawBar_hook,

--- a/mods/classic-taskbar-buttons-lite-vs-without-spacing.wh.cpp
+++ b/mods/classic-taskbar-buttons-lite-vs-without-spacing.wh.cpp
@@ -41,7 +41,7 @@ void __cdecl GDIHelpers_FillRectARGB_hook(
 }
 
 /* Draw taskbar item */
-typedef void (*__cdecl CTaskBtnGroup__DrawBar_t)(void *, HDC, void *, void *);
+typedef void (*__cdecl CTaskBtnGroup__DrawBar_t)(void *, HDC, void *, PBUTTONRENDERINFOSTATES);
 CTaskBtnGroup__DrawBar_t CTaskBtnGroup__DrawBar_orig;
 void __cdecl CTaskBtnGroup__DrawBar_hook(
     void *pThis,
@@ -123,8 +123,8 @@ BOOL Wh_ModInit(void)
             {
                 L"private: void __cdecl CTaskBtnGroup::_DrawBar(struct HDC__ *,struct BUTTONRENDERINFO const &,struct BUTTONRENDERINFOSTATES const &)"
             },
-            (void **)&CTaskBtnGroup__DrawBar_orig,
-            (void *)CTaskBtnGroup__DrawBar_hook,
+            &CTaskBtnGroup__DrawBar_orig,
+            CTaskBtnGroup__DrawBar_hook,
             FALSE
         }
     };

--- a/mods/classic-taskbar-buttons-lite-vs-without-spacing.wh.cpp
+++ b/mods/classic-taskbar-buttons-lite-vs-without-spacing.wh.cpp
@@ -20,7 +20,7 @@ Known issue : Under the classic theme, icons have no space between them. It is p
 #include <windhawk_utils.h>
 #include <windows.h>
 #include <uxtheme.h>
-#include <tmschema.h>
+#include <vssym32.h>
 
 #ifdef _WIN64
 #define CALCON __cdecl


### PR DESCRIPTION
Added "Classic Taskbar 3D buttons with extended compatibility" mod. This mod is close to the equivalent of anixx, but it supports visual styles, and does not contain spacing between icons (which, under the classic theme, fixes the problem when displaying icons without the labels).