### PR TITLE
Windows 11 Start Menu Styler v1.1

### DIFF
--- a/mods/windows-11-start-menu-styler.wh.cpp
+++ b/mods/windows-11-start-menu-styler.wh.cpp
@@ -2,7 +2,7 @@
 // @id              windows-11-start-menu-styler
 // @name            Windows 11 Start Menu Styler
 // @description     An advanced mod to override style attributes of the start menu control elements
-// @version         1.0.2
+// @version         1.1
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -30,10 +30,38 @@ An advanced mod to override style attributes of the start menu control elements.
 
 Also check out the **Windows 11 Taskbar Styler** mod.
 
-The settings have two sections: control styles and resource variables. Control
-styles allow to override styles, such as size and color, for the target
-elements. Resource variables allow to override predefined variables. For a more
-detailed explanation and examples, refer to the sections below.
+## Themes
+
+Themes are collections of styles. The following themes are integrated into the
+mod and can be selected in the settings:
+
+![NoRecommendedSection](https://raw.githubusercontent.com/ramensoftware/windows-11-start-menu-styling-guide/main/Themes/NoRecommendedSection/screenshot-small.png)
+\
+[NoRecommendedSection](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/Themes/NoRecommendedSection/README.md)
+
+![SideBySide](https://raw.githubusercontent.com/ramensoftware/windows-11-start-menu-styling-guide/main/Themes/SideBySide/screenshot-small.png)
+\
+[SideBySide](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/Themes/SideBySide/README.md)
+
+![SideBySide2](https://raw.githubusercontent.com/ramensoftware/windows-11-start-menu-styling-guide/main/Themes/SideBySide2/screenshot-small.png)
+\
+[SideBySide2](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/Themes/SideBySide2/README.md)
+
+![SideBySideMinimal](https://raw.githubusercontent.com/ramensoftware/windows-11-start-menu-styling-guide/main/Themes/SideBySideMinimal/screenshot-small.png)
+\
+[SideBySideMinimal](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/Themes/SideBySideMinimal/README.md)
+
+More themes can be found in the **Themes** section of [The Windows 11 start menu
+styling
+guide](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/README.md#themes).
+Contributions of new themes are welcome!
+
+## Advanced styling
+
+Aside from themes, the settings have two sections: control styles and resource
+variables. Control styles allow to override styles, such as size and color, for
+the target elements. Resource variables allow to override predefined variables.
+For a more detailed explanation and examples, refer to the sections below.
 
 The start menu's XAML resources can help find out which elements and resource
 variables can be customized. To the best of my knowledge, there are no public
@@ -49,22 +77,22 @@ For a collection of commonly requested taskbar styling customizations, check out
 [The Windows 11 start menu styling
 guide](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/README.md).
 
-## Control styles
+### Control styles
 
 Each entry has a target control and a list of styles.
 
-The target control is written as `Control` or `Control#Name`, i.e. the target
-control tag name, such as `StartMenu:StartInnerFrame` or `Rectangle`, optionally
-followed by `#` and the target control's `x:Name` attribute. The target control
-can also include:
-* Child control index, for example: `Control#Name[2]` will only match the
-  relevant control that's also the second child among all of its parent's child
-  controls.
+The target control is written as `Class` or `Class#Name`, i.e. the target
+control class name (the tag name in XAML resource files), such as
+`StartMenu.StartInnerFrame` or `Rectangle`, optionally followed by `#` and the
+target control's name (`x:Name` attribute in XAML resource files). The target
+control can also include:
+* Child control index, for example: `Class#Name[2]` will only match the relevant
+  control that's also the second child among all of its parent's child controls.
 * Control properties, for example:
-  `Control#Name[Property1=Value1][Property2=Value2]`.
-* Parent controls, separated by `>`, for example: `ParentControl#ParentName >
-  Control#Name`.
-* Visual state group name, for example: `Control#Name@VisualStateGroupName`. It
+  `Class#Name[Property1=Value1][Property2=Value2]`.
+* Parent controls, separated by `>`, for example: `ParentClass#ParentName >
+  Class#Name`.
+* Visual state group name, for example: `Class#Name@VisualStateGroupName`. It
   can be specified for the target control or for a parent control, but can be
   specified only once per target. The visual state group can be used in styles
   as specified below.
@@ -78,7 +106,7 @@ Color="Red"/>`. In addition, a visual state can be specified as following:
 `Style@VisualState=Value`, in which case the style will only apply when the
 visual state group specified in the target matches the specified visual state.
 
-## Resource variables
+### Resource variables
 
 Some variables, such as size and padding for various controls, are defined as
 resource variables.
@@ -93,6 +121,18 @@ code from the **TranslucentTB** project.
 
 // ==WindhawkModSettings==
 /*
+- theme: ""
+  $name: Theme
+  $description: >-
+    Themes are collections of styles. For details about the themes below, or for
+    information about submitting your own theme, refer to the relevant section
+    in the mod details.
+  $options:
+  - "": None
+  - NoRecommendedSection: NoRecommendedSection
+  - SideBySide: SideBySide
+  - SideBySide2: SideBySide2
+  - SideBySideMinimal: SideBySideMinimal
 - controlStyles:
   - - target: Border#AcrylicBorder
       $name: Target
@@ -112,15 +152,207 @@ code from the **TranslucentTB** project.
 #include <xamlom.h>
 
 #include <atomic>
+#include <vector>
 
 #undef GetCurrentTime
 
 #include <winrt/Windows.UI.Xaml.h>
 
+struct ThemeTargetStyles {
+    PCWSTR target;
+    std::vector<PCWSTR> styles;
+};
+
+struct Theme {
+    std::vector<ThemeTargetStyles> targetStyles;
+};
+
+/*
+JSON settings to C++ theme conversion code, quick'n'dirty & AI-generated:
+
+json_str = R"""
+{...}
+"""
+
+def json_to_cpp(json_data):
+    def cmp(x):
+        key_prefix = x[0].removeprefix("controlStyles[")
+        index1 = int(key_prefix.split("]")[0])
+        if ".target" in key_prefix:
+            index2 = -1
+        elif ".styles" in key_prefix:
+            index2 = int(key_prefix.split("[")[1].split("]")[0])
+        else:
+            assert False
+        return index1, index2
+
+    cpp_code = "{{\n"
+    for key, value in sorted(json_data.items(), key=cmp):
+        value_escaped = value.replace('"', '\\"')
+        if ".target" in key:
+            if cpp_code != "{{\n":
+                cpp_code = cpp_code.removesuffix(", ")
+                cpp_code += "}},\n"
+            cpp_code += "    ThemeTargetStyles{\n"
+            cpp_code += f"        L\"{value_escaped}\",\n"
+            cpp_code += "        {"
+        elif ".styles" in key:
+            cpp_code += f"L\"{value_escaped}\", "
+        else:
+            assert False
+    cpp_code = cpp_code.removesuffix(", ")
+    cpp_code += "}},\n"
+    cpp_code += "}};"
+    return cpp_code
+
+json_input = json.loads(json_str)
+
+cpp_output = json_to_cpp(json_input)
+print(cpp_output)
+*/
+
+const Theme g_themeNoRecommendedSection = {{
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ShowMoreSuggestions",
+                      {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.Grid#SuggestionsParentContainer",
+        {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.Grid#TopLevelSuggestionsListHeader",
+        {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList", {L"Height=504"}},
+}};
+
+// Author: kaoshipaws (https://k4oshi.top/)
+const Theme g_themeSideBySide = {{
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.Grid#UndockedRoot",
+        {L"Visibility=Visible", L"MaxWidth=700", L"Margin=0,0,300,0"}},
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.Grid#AllAppsRoot",
+        {L"Visibility=Visible", L"Width=350",
+         L"Transform3D:=<CompositeTransform3D TranslateX=\"-602\" />"}},
+    ThemeTargetStyles{
+        L"StartDocked.AllAppsGridListView > ScrollViewer > Border > Grid > "
+        L"ScrollContentPresenter > ItemsPresenter > TileGrid",
+        {L"Transform3D:=<CompositeTransform3D TranslateX=\"20\" />"}},
+    ThemeTargetStyles{
+        L"Grid#AllAppsPaneHeader",
+        {L"Transform3D:=<CompositeTransform3D TranslateX=\"20\" />"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#CloseAllAppsButton",
+                      {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"StartDocked.StartSizingFrame",
+                      {L"MinWidth=850", L"MaxWidth=850"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ShowMoreSuggestions",
+                      {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#ShowAllAppsButton",
+                      {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.ContentControl",
+        {L"Transform3D:=<CompositeTransform3D TranslateX=\"-200\" />"}},
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.GridView#RecommendedList > "
+        L"Windows.UI.Xaml.Controls.Border > "
+        L"Windows.UI.Xaml.Controls.ScrollViewer#ScrollViewer > "
+        L"Windows.UI.Xaml.Controls.Border#Root > Windows.UI.Xaml.Controls.Grid "
+        L"> "
+        L"Windows.UI.Xaml.Controls.ScrollContentPresenter#"
+        L"ScrollContentPresenter > Windows.UI.Xaml.Controls.ItemsPresenter > "
+        L"Windows.UI.Xaml.Controls.ItemsWrapGrid > "
+        L"Windows.UI.Xaml.Controls.GridViewItem",
+        {L"MaxWidth=220", L"MinWidth=100"}},
+}};
+
+// Author: Pyxisynth
+const Theme g_themeSideBySide2 = {{
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.Grid#UndockedRoot",
+        {L"Visibility=Visible", L"MaxWidth=700", L"Margin=232,0,0,0"}},
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.Grid#AllAppsRoot",
+        {L"Visibility=Visible", L"Width=322",
+         L"Transform3D:=<CompositeTransform3D TranslateX=\"-1059\" />"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#CloseAllAppsButton",
+                      {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"StartDocked.StartSizingFrame",
+                      {L"MinWidth=776", L"MaxWidth=776"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ShowMoreSuggestions",
+                      {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#ShowAllAppsButton",
+                      {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.GridView#RecommendedList > "
+        L"Windows.UI.Xaml.Controls.Border > "
+        L"Windows.UI.Xaml.Controls.ScrollViewer#ScrollViewer > "
+        L"Windows.UI.Xaml.Controls.Border#Root > Windows.UI.Xaml.Controls.Grid "
+        L"> "
+        L"Windows.UI.Xaml.Controls.ScrollContentPresenter#"
+        L"ScrollContentPresenter > Windows.UI.Xaml.Controls.ItemsPresenter > "
+        L"Windows.UI.Xaml.Controls.ItemsWrapGrid > "
+        L"Windows.UI.Xaml.Controls.GridViewItem",
+        {L"MaxWidth=220", L"MinWidth=220"}},
+    ThemeTargetStyles{L"StartDocked.AllAppsGridListView#AppsList",
+                      {L"Padding=48,3,-36,32"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#AllAppsPaneHeader",
+                      {L"Margin=97,0,0,0"}},
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.Grid#SuggestionsParentContainer",
+        {L"Height=168"}},
+    ThemeTargetStyles{L"StartDocked.NavigationPaneView#NavigationPane",
+                      {L"FlowDirection=1", L"Margin=30,0,30,0"}},
+    ThemeTargetStyles{L"StartDocked.PowerOptionsView#PowerButton",
+                      {L"FlowDirection=0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ItemsStackPanel",
+                      {L"FlowDirection=1"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ListViewItem",
+                      {L"FlowDirection=0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ItemsStackPanel > "
+                      L"Windows.UI.Xaml.Controls.ListViewItem",
+                      {L"FlowDirection=0"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox",
+                      {L"Margin=23,1,23,14"}},
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.TextBlock#NoSuggestionsWithoutSettingsLink",
+        {L"Margin=11,0,48,0"}},
+}};
+
+// Author: Windows XP (6.1.7601)
+const Theme g_themeSideBySideMinimal = {{
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.Grid#UndockedRoot",
+        {L"Visibility=Visible", L"Width=348",
+         L"Transform3D:=<CompositeTransform3D TranslateX=\"178\" />",
+         L"Margin=-80,-20,0,0", L"Padding=0,0,0,0"}},
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.Grid#AllAppsRoot",
+        {L"Visibility=Visible", L"Width=320",
+         L"Transform3D:=<CompositeTransform3D TranslateX=\"-800\" />",
+         L"Margin=-30,-20,0,0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ShowMoreSuggestions",
+                      {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.Grid#SuggestionsParentContainer",
+        {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{
+        L"Windows.UI.Xaml.Controls.Grid#TopLevelSuggestionsListHeader",
+        {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton",
+                      {L"Height=0", L"Width=0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#TopLevelRoot > "
+                      L"Windows.UI.Xaml.Controls.Border",
+                      {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#CloseAllAppsButton",
+                      {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"StartDocked.PowerOptionsView", {L"Margin=-575,0,0,0"}},
+    ThemeTargetStyles{L"StartDocked.UserTileView", {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList", {L"Height=504"}},
+}};
+
 std::atomic<DWORD> g_targetThreadId = 0;
 
 void ApplyCustomizations(InstanceHandle handle,
-                         winrt::Windows::UI::Xaml::FrameworkElement element);
+                         winrt::Windows::UI::Xaml::FrameworkElement element,
+                         PCWSTR fallbackClassName);
 void CleanupCustomizations(InstanceHandle handle);
 
 HMODULE GetCurrentModuleHandle() {
@@ -262,7 +494,7 @@ HRESULT VisualTreeWatcher::OnVisualTreeChange(ParentChildRelation, VisualElement
         if (frameworkElement)
         {
             Wh_Log(L"FrameworkElement name: %s", frameworkElement.Name().c_str());
-            ApplyCustomizations(element.Handle, frameworkElement);
+            ApplyCustomizations(element.Handle, frameworkElement, element.Type);
         }
     }
     else if (mutationType == Remove)
@@ -472,6 +704,7 @@ HRESULT InjectWindhawkTAP() noexcept
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 #include <commctrl.h>
@@ -500,13 +733,18 @@ using string_setting_unique_ptr =
 using PropertyKeyValue =
     std::pair<DependencyProperty, winrt::Windows::Foundation::IInspectable>;
 
+using PropertyValuesUnresolved =
+    std::vector<std::pair<std::wstring, std::wstring>>;
+using PropertyValues = std::vector<PropertyKeyValue>;
+using PropertyValuesMaybeUnresolved =
+    std::variant<PropertyValuesUnresolved, PropertyValues>;
+
 struct ElementMatcher {
     std::wstring type;
     std::wstring name;
     std::optional<std::wstring> visualStateGroupName;
     int oneBasedIndex = 0;
-    std::vector<std::pair<std::wstring, std::wstring>> propertyValuesStr;
-    std::vector<PropertyKeyValue> propertyValues;
+    PropertyValuesMaybeUnresolved propertyValues;
 };
 
 struct StyleRule {
@@ -516,18 +754,22 @@ struct StyleRule {
     bool isXamlValue = false;
 };
 
+using PropertyOverridesUnresolved = std::vector<StyleRule>;
+
 // Property -> visual state -> value.
 using PropertyOverrides = std::unordered_map<
     DependencyProperty,
     std::unordered_map<std::wstring, winrt::Windows::Foundation::IInspectable>>;
 
+using PropertyOverridesMaybeUnresolved =
+    std::variant<PropertyOverridesUnresolved, PropertyOverrides>;
+
 struct ElementCustomizationRules {
     ElementMatcher elementMatcher;
     std::vector<ElementMatcher> parentElementMatchers;
-    PropertyOverrides propertyOverrides;
+    PropertyOverridesMaybeUnresolved propertyOverrides;
 };
 
-bool g_elementsCustomizationRulesLoaded;
 std::vector<ElementCustomizationRules> g_elementsCustomizationRules;
 
 struct ElementPropertyCustomizationState {
@@ -549,6 +791,216 @@ std::unordered_map<InstanceHandle, ElementCustomizationState>
 
 bool g_elementPropertyModifying;
 
+// https://stackoverflow.com/a/5665377
+std::wstring EscapeXmlAttribute(std::wstring_view data) {
+    std::wstring buffer;
+    buffer.reserve(data.size());
+    for (size_t pos = 0; pos != data.size(); ++pos) {
+        switch (data[pos]) {
+            case '&':
+                buffer.append(L"&amp;");
+                break;
+            case '\"':
+                buffer.append(L"&quot;");
+                break;
+            // case '\'':
+            //     buffer.append(L"&apos;");
+            //     break;
+            case '<':
+                buffer.append(L"&lt;");
+                break;
+            case '>':
+                buffer.append(L"&gt;");
+                break;
+            default:
+                buffer.append(&data[pos], 1);
+                break;
+        }
+    }
+
+    return buffer;
+}
+
+// https://stackoverflow.com/a/54364173
+std::wstring_view TrimStringView(std::wstring_view s) {
+    s.remove_prefix(std::min(s.find_first_not_of(L" \t\r\v\n"), s.size()));
+    s.remove_suffix(
+        std::min(s.size() - s.find_last_not_of(L" \t\r\v\n") - 1, s.size()));
+    return s;
+}
+
+// https://stackoverflow.com/a/46931770
+std::vector<std::wstring_view> SplitStringView(std::wstring_view s,
+                                               std::wstring_view delimiter) {
+    size_t pos_start = 0, pos_end, delim_len = delimiter.length();
+    std::wstring_view token;
+    std::vector<std::wstring_view> res;
+
+    while ((pos_end = s.find(delimiter, pos_start)) !=
+           std::wstring_view::npos) {
+        token = s.substr(pos_start, pos_end - pos_start);
+        pos_start = pos_end + delim_len;
+        res.push_back(token);
+    }
+
+    res.push_back(s.substr(pos_start));
+    return res;
+}
+
+Style GetStyleFromXamlSetters(const std::wstring_view type,
+                              const std::wstring_view xamlStyleSetters) {
+    std::wstring xaml =
+        LR"(<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls")";
+
+    if (auto pos = type.rfind('.'); pos != type.npos) {
+        auto typeNamespace = std::wstring_view(type).substr(0, pos);
+        auto typeName = std::wstring_view(type).substr(pos + 1);
+
+        xaml += L"\n    xmlns:windhawkstyler=\"using:";
+        xaml += EscapeXmlAttribute(typeNamespace);
+        xaml +=
+            L"\">\n"
+            L"    <Style TargetType=\"windhawkstyler:";
+        xaml += EscapeXmlAttribute(typeName);
+        xaml += L"\">\n";
+    } else {
+        xaml +=
+            L">\n"
+            L"    <Style TargetType=\"";
+        xaml += EscapeXmlAttribute(type);
+        xaml += L"\">\n";
+    }
+
+    xaml += xamlStyleSetters;
+
+    xaml +=
+        L"    </Style>\n"
+        L"</ResourceDictionary>";
+
+    Wh_Log(L"======================================== XAML:");
+    std::wstringstream ss(xaml);
+    std::wstring line;
+    while (std::getline(ss, line, L'\n')) {
+        Wh_Log(L"%s", line.c_str());
+    }
+    Wh_Log(L"========================================");
+
+    auto resourceDictionary =
+        Markup::XamlReader::Load(xaml).as<ResourceDictionary>();
+
+    auto [styleKey, styleInspectable] = resourceDictionary.First().Current();
+    return styleInspectable.as<Style>();
+}
+
+const PropertyOverrides& GetResolvedPropertyOverrides(
+    const std::wstring_view type,
+    PropertyOverridesMaybeUnresolved* propertyOverridesMaybeUnresolved) {
+    if (const auto* resolved =
+            std::get_if<PropertyOverrides>(propertyOverridesMaybeUnresolved)) {
+        return *resolved;
+    }
+
+    PropertyOverrides propertyOverrides;
+
+    try {
+        const auto& styleRules = std::get<PropertyOverridesUnresolved>(
+            *propertyOverridesMaybeUnresolved);
+        if (!styleRules.empty()) {
+            std::wstring xaml;
+
+            for (const auto& rule : styleRules) {
+                xaml += L"        <Setter Property=\"";
+                xaml += EscapeXmlAttribute(rule.name);
+                xaml += L"\"";
+                if (!rule.isXamlValue) {
+                    xaml += L" Value=\"";
+                    xaml += EscapeXmlAttribute(rule.value);
+                    xaml += L"\" />\n";
+                } else {
+                    xaml +=
+                        L">\n"
+                        L"            <Setter.Value>\n";
+                    xaml += rule.value;
+                    xaml +=
+                        L"\n"
+                        L"            </Setter.Value>\n"
+                        L"        </Setter>\n";
+                }
+            }
+
+            auto style = GetStyleFromXamlSetters(type, xaml);
+
+            for (size_t i = 0; i < styleRules.size(); i++) {
+                const auto setter = style.Setters().GetAt(i).as<Setter>();
+                propertyOverrides[setter.Property()]
+                                 [styleRules[i].visualState] = setter.Value();
+            }
+        }
+
+        Wh_Log(L"%.*s: %zu override styles", static_cast<int>(type.length()),
+               type.data(), propertyOverrides.size());
+    } catch (winrt::hresult_error const& ex) {
+        Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
+    } catch (std::exception const& ex) {
+        Wh_Log(L"Error: %S", ex.what());
+    }
+
+    *propertyOverridesMaybeUnresolved = std::move(propertyOverrides);
+    return std::get<PropertyOverrides>(*propertyOverridesMaybeUnresolved);
+}
+
+const PropertyValues& GetResolvedPropertyValues(
+    const std::wstring_view type,
+    PropertyValuesMaybeUnresolved* propertyValuesMaybeUnresolved) {
+    if (const auto* resolved =
+            std::get_if<PropertyValues>(propertyValuesMaybeUnresolved)) {
+        return *resolved;
+    }
+
+    PropertyValues propertyValues;
+
+    try {
+        const auto& propertyValuesStr =
+            std::get<PropertyValuesUnresolved>(*propertyValuesMaybeUnresolved);
+        if (!propertyValuesStr.empty()) {
+            std::wstring xaml;
+
+            for (const auto& [property, value] : propertyValuesStr) {
+                xaml += L"        <Setter Property=\"";
+                xaml += EscapeXmlAttribute(property);
+                xaml += L"\" Value=\"";
+                xaml += EscapeXmlAttribute(value);
+                xaml += L"\" />\n";
+            }
+
+            auto style = GetStyleFromXamlSetters(type, xaml);
+
+            for (size_t i = 0; i < propertyValuesStr.size(); i++) {
+                const auto setter = style.Setters().GetAt(i).as<Setter>();
+                propertyValues.push_back({
+                    setter.Property(),
+                    setter.Value(),
+                });
+            }
+        }
+
+        Wh_Log(L"%.*s: %zu matcher styles", static_cast<int>(type.length()),
+               type.data(), propertyValues.size());
+    } catch (winrt::hresult_error const& ex) {
+        Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
+    } catch (std::exception const& ex) {
+        Wh_Log(L"Error: %S", ex.what());
+    }
+
+    *propertyValuesMaybeUnresolved = std::move(propertyValues);
+    return std::get<PropertyValues>(*propertyValuesMaybeUnresolved);
+}
+
 // https://stackoverflow.com/a/12835139
 VisualStateGroup GetVisualStateGroup(FrameworkElement element,
                                      std::wstring_view visualStateGroupName) {
@@ -564,10 +1016,12 @@ VisualStateGroup GetVisualStateGroup(FrameworkElement element,
 }
 
 bool TestElementMatcher(FrameworkElement element,
-                        const ElementMatcher& matcher,
-                        VisualStateGroup* visualStateGroup) {
+                        ElementMatcher& matcher,
+                        VisualStateGroup* visualStateGroup,
+                        PCWSTR fallbackClassName) {
     if (!matcher.type.empty() &&
-        matcher.type != winrt::get_class_name(element)) {
+        matcher.type != winrt::get_class_name(element) &&
+        (!fallbackClassName || matcher.type != fallbackClassName)) {
         return false;
     }
 
@@ -591,7 +1045,8 @@ bool TestElementMatcher(FrameworkElement element,
 
     auto elementDo = element.as<DependencyObject>();
 
-    for (const auto& propertyValue : matcher.propertyValues) {
+    for (const auto& propertyValue :
+         GetResolvedPropertyValues(matcher.type, &matcher.propertyValues)) {
         const auto value = elementDo.ReadLocalValue(propertyValue.first);
         const auto className = winrt::get_class_name(value);
         const auto expectedClassName =
@@ -641,19 +1096,20 @@ bool TestElementMatcher(FrameworkElement element,
     return true;
 }
 
-const ElementCustomizationRules* FindElementCustomizationRules(
+ElementCustomizationRules* FindElementCustomizationRules(
     FrameworkElement element,
-    VisualStateGroup* visualStateGroup) {
-    for (const auto& override : g_elementsCustomizationRules) {
+    VisualStateGroup* visualStateGroup,
+    PCWSTR fallbackClassName) {
+    for (auto& override : g_elementsCustomizationRules) {
         if (!TestElementMatcher(element, override.elementMatcher,
-                                visualStateGroup)) {
+                                visualStateGroup, fallbackClassName)) {
             continue;
         }
 
         auto parentElementIter = element;
         bool parentElementMatchFailed = false;
 
-        for (const auto& matcher : override.parentElementMatchers) {
+        for (auto& matcher : override.parentElementMatchers) {
             // Using parentElementIter.Parent() was sometimes returning null.
             parentElementIter =
                 Media::VisualTreeHelper::GetParent(parentElementIter)
@@ -664,7 +1120,7 @@ const ElementCustomizationRules* FindElementCustomizationRules(
             }
 
             if (!TestElementMatcher(parentElementIter, matcher,
-                                    visualStateGroup)) {
+                                    visualStateGroup, nullptr)) {
                 parentElementMatchFailed = true;
                 break;
             }
@@ -678,18 +1134,12 @@ const ElementCustomizationRules* FindElementCustomizationRules(
     return nullptr;
 }
 
-void ProcessAllStylesFromSettings();
-void ProcessResourceVariablesFromSettings();
-
-void ApplyCustomizations(InstanceHandle handle, FrameworkElement element) {
-    if (!g_elementsCustomizationRulesLoaded) {
-        ProcessAllStylesFromSettings();
-        ProcessResourceVariablesFromSettings();
-        g_elementsCustomizationRulesLoaded = true;
-    }
-
+void ApplyCustomizations(InstanceHandle handle,
+                         FrameworkElement element,
+                         PCWSTR fallbackClassName) {
     VisualStateGroup visualStateGroup;
-    auto rules = FindElementCustomizationRules(element, &visualStateGroup);
+    auto rules = FindElementCustomizationRules(element, &visualStateGroup,
+                                               fallbackClassName);
     if (!rules) {
         return;
     }
@@ -734,7 +1184,8 @@ void ApplyCustomizations(InstanceHandle handle, FrameworkElement element) {
     std::wstring currentVisualStateName(
         currentVisualState ? currentVisualState.Name() : L"");
 
-    for (auto& [property, valuesPerVisualState] : rules->propertyOverrides) {
+    for (auto& [property, valuesPerVisualState] : GetResolvedPropertyOverrides(
+             rules->elementMatcher.type, &rules->propertyOverrides)) {
         const auto [propertyCustomizationStatesIt, inserted] =
             elementCustomizationState.propertyCustomizationStates.insert(
                 {property, {}});
@@ -811,7 +1262,9 @@ void ApplyCustomizations(InstanceHandle handle, FrameworkElement element) {
                         elementCustomizationState.propertyCustomizationStates;
 
                     for (auto& [property, valuesPerVisualState] :
-                         rules->propertyOverrides) {
+                         GetResolvedPropertyOverrides(
+                             rules->elementMatcher.type,
+                             &rules->propertyOverrides)) {
                         auto& propertyCustomizationState =
                             propertyCustomizationStates.at(property);
 
@@ -890,174 +1343,9 @@ void CleanupCustomizations(InstanceHandle handle) {
     g_elementsCustomizationState.erase(it);
 }
 
-// https://stackoverflow.com/a/5665377
-std::wstring EscapeXmlAttribute(std::wstring_view data) {
-    std::wstring buffer;
-    buffer.reserve(data.size());
-    for (size_t pos = 0; pos != data.size(); ++pos) {
-        switch (data[pos]) {
-            case '&':
-                buffer.append(L"&amp;");
-                break;
-            case '\"':
-                buffer.append(L"&quot;");
-                break;
-            // case '\'':
-            //     buffer.append(L"&apos;");
-            //     break;
-            case '<':
-                buffer.append(L"&lt;");
-                break;
-            case '>':
-                buffer.append(L"&gt;");
-                break;
-            default:
-                buffer.append(&data[pos], 1);
-                break;
-        }
-    }
-
-    return buffer;
-}
-
-// https://stackoverflow.com/a/54364173
-std::wstring_view TrimStringView(std::wstring_view s) {
-    s.remove_prefix(std::min(s.find_first_not_of(L" \t\r\v\n"), s.size()));
-    s.remove_suffix(
-        std::min(s.size() - s.find_last_not_of(L" \t\r\v\n") - 1, s.size()));
-    return s;
-}
-
-// https://stackoverflow.com/a/46931770
-std::vector<std::wstring_view> SplitStringView(std::wstring_view s,
-                                               std::wstring_view delimiter) {
-    size_t pos_start = 0, pos_end, delim_len = delimiter.length();
-    std::wstring_view token;
-    std::vector<std::wstring_view> res;
-
-    while ((pos_end = s.find(delimiter, pos_start)) !=
-           std::wstring_view::npos) {
-        token = s.substr(pos_start, pos_end - pos_start);
-        pos_start = pos_end + delim_len;
-        res.push_back(token);
-    }
-
-    res.push_back(s.substr(pos_start));
-    return res;
-}
-
-void ResolveTypeAndStyles(ElementMatcher* elementMatcher,
-                          std::vector<StyleRule> styleRules = {},
-                          PropertyOverrides* propertyOverrides = nullptr) {
-    std::wstring xaml =
-        LR"(<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    xmlns:StartMenu="using:StartMenu")";
-
-    if (auto pos = elementMatcher->type.rfind('.');
-        pos != elementMatcher->type.npos) {
-        auto typeNamespace =
-            std::wstring_view(elementMatcher->type).substr(0, pos);
-        auto typeName = std::wstring_view(elementMatcher->type).substr(pos + 1);
-
-        xaml += L"\n    xmlns:windhawkstyler=\"using:";
-        xaml += EscapeXmlAttribute(typeNamespace);
-        xaml +=
-            L"\">\n"
-            L"    <Style TargetType=\"windhawkstyler:";
-        xaml += EscapeXmlAttribute(typeName);
-        xaml += L"\">\n";
-    } else {
-        xaml +=
-            L">\n"
-            L"    <Style TargetType=\"";
-        xaml += EscapeXmlAttribute(elementMatcher->type);
-        xaml += L"\">\n";
-    }
-
-    for (const auto& [property, value] : elementMatcher->propertyValuesStr) {
-        xaml += L"        <Setter Property=\"";
-        xaml += EscapeXmlAttribute(property);
-        xaml += L"\" Value=\"";
-        xaml += EscapeXmlAttribute(value);
-        xaml += L"\" />\n";
-    }
-
-    for (const auto& rule : styleRules) {
-        xaml += L"        <Setter Property=\"";
-        xaml += EscapeXmlAttribute(rule.name);
-        xaml += L"\"";
-        if (!rule.isXamlValue) {
-            xaml += L" Value=\"";
-            xaml += EscapeXmlAttribute(rule.value);
-            xaml += L"\" />\n";
-        } else {
-            xaml +=
-                L">\n"
-                L"            <Setter.Value>\n";
-            xaml += rule.value;
-            xaml +=
-                L"\n"
-                L"            </Setter.Value>\n"
-                L"        </Setter>\n";
-        }
-    }
-
-    xaml +=
-        L"    </Style>\n"
-        L"</ResourceDictionary>";
-
-    Wh_Log(L"======================================== XAML:");
-    std::wstringstream ss(xaml);
-    std::wstring line;
-    while (std::getline(ss, line, L'\n')) {
-        Wh_Log(L"%s", line.c_str());
-    }
-    Wh_Log(L"========================================");
-
-    auto resourceDictionary =
-        Markup::XamlReader::Load(xaml).as<ResourceDictionary>();
-
-    auto [styleKey, styleInspectable] = resourceDictionary.First().Current();
-    auto style = styleInspectable.as<Style>();
-    size_t styleIndex = 0;
-
-    elementMatcher->type = style.TargetType().Name;
-    elementMatcher->propertyValues.clear();
-
-    for (size_t i = 0; i < elementMatcher->propertyValuesStr.size(); i++) {
-        const auto setter = style.Setters().GetAt(styleIndex++).as<Setter>();
-        elementMatcher->propertyValues.push_back({
-            setter.Property(),
-            setter.Value(),
-        });
-    }
-
-    Wh_Log(L"%s: %zu matcher styles", elementMatcher->type.c_str(),
-           elementMatcher->propertyValues.size());
-
-    if (propertyOverrides) {
-        propertyOverrides->clear();
-
-        for (size_t i = 0; i < styleRules.size(); i++) {
-            const auto setter =
-                style.Setters().GetAt(styleIndex++).as<Setter>();
-
-            (*propertyOverrides)[setter.Property()][styleRules[i].visualState] =
-                setter.Value();
-        }
-
-        Wh_Log(L"%s: %zu styles", elementMatcher->type.c_str(),
-               styleRules.size());
-    }
-}
-
 ElementMatcher ElementMatcherFromString(std::wstring_view str) {
     ElementMatcher result;
+    PropertyValuesUnresolved propertyValuesUnresolved;
 
     auto i = str.find_first_of(L"#@[");
     result.type = TrimStringView(str.substr(0, i));
@@ -1123,7 +1411,7 @@ ElementMatcher ElementMatcherFromString(std::wstring_view str) {
                         "Bad target syntax, empty property name");
                 }
 
-                result.propertyValuesStr.push_back(
+                propertyValuesUnresolved.push_back(
                     {std::wstring(ruleKey), std::wstring(ruleVal)});
                 break;
             }
@@ -1134,6 +1422,8 @@ ElementMatcher ElementMatcherFromString(std::wstring_view str) {
 
         i = iNext;
     }
+
+    result.propertyValues = std::move(propertyValuesUnresolved);
 
     return result;
 }
@@ -1177,6 +1467,28 @@ StyleRule StyleRuleFromString(std::wstring_view str) {
     return result;
 }
 
+std::wstring AdjustTypeName(std::wstring_view type) {
+    if (auto i = type.find_first_of(L".:"); i == type.npos) {
+        return L"Microsoft.UI.Xaml.Control." + std::wstring{type};
+    }
+
+    static const std::vector<std::pair<std::wstring_view, std::wstring_view>>
+        adjustments = {
+            {L"StartMenu:", L"StartMenu."},
+            {L"muxc:", L"Microsoft.UI.Xaml.Control."},
+        };
+
+    for (const auto& adjustment : adjustments) {
+        if (type.starts_with(adjustment.first)) {
+            auto result = std::wstring{adjustment.second};
+            result += type.substr(adjustment.first.size());
+            return result;
+        }
+    }
+
+    return std::wstring{type};
+}
+
 void AddElementCustomizationRules(std::wstring_view target,
                                   std::vector<std::wstring> styles) {
     ElementCustomizationRules elementCustomizationRules;
@@ -1189,6 +1501,7 @@ void AddElementCustomizationRules(std::wstring_view target,
         const auto& targetPart = *i;
 
         auto matcher = ElementMatcherFromString(targetPart);
+        matcher.type = AdjustTypeName(matcher.type);
 
         if (matcher.visualStateGroupName) {
             if (hasVisualStateGroup) {
@@ -1205,11 +1518,9 @@ void AddElementCustomizationRules(std::wstring_view target,
                 styleRules.push_back(StyleRuleFromString(style));
             }
 
-            ResolveTypeAndStyles(&matcher, std::move(styleRules),
-                                 &elementCustomizationRules.propertyOverrides);
             elementCustomizationRules.elementMatcher = std::move(matcher);
+            elementCustomizationRules.propertyOverrides = std::move(styleRules);
         } else {
-            ResolveTypeAndStyles(&matcher);
             elementCustomizationRules.parentElementMatchers.push_back(
                 std::move(matcher));
         }
@@ -1239,6 +1550,11 @@ bool ProcessSingleTargetStylesFromSettings(int index) {
             break;
         }
 
+        // Skip if commented.
+        if (styleSetting[0] == L'/' && styleSetting[1] == L'/') {
+            continue;
+        }
+
         styles.push_back(styleSetting.get());
     }
 
@@ -1257,9 +1573,38 @@ void ProcessAllStylesFromSettings() {
                 break;
             }
         } catch (winrt::hresult_error const& ex) {
-            Wh_Log(L"Error %08X", ex.code());
+            Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
         } catch (std::exception const& ex) {
             Wh_Log(L"Error: %S", ex.what());
+        }
+    }
+
+    PCWSTR themeName = Wh_GetStringSetting(L"theme");
+    const Theme* theme = nullptr;
+    if (wcscmp(themeName, L"NoRecommendedSection") == 0) {
+        theme = &g_themeNoRecommendedSection;
+    } else if (wcscmp(themeName, L"SideBySide") == 0) {
+        theme = &g_themeSideBySide;
+    } else if (wcscmp(themeName, L"SideBySide2") == 0) {
+        theme = &g_themeSideBySide2;
+    } else if (wcscmp(themeName, L"SideBySideMinimal") == 0) {
+        theme = &g_themeSideBySideMinimal;
+    }
+    Wh_FreeStringSetting(themeName);
+
+    if (theme) {
+        for (const auto& themeTargetStyle : theme->targetStyles) {
+            try {
+                std::vector<std::wstring> styles{
+                    themeTargetStyle.styles.begin(),
+                    themeTargetStyle.styles.end()};
+                AddElementCustomizationRules(themeTargetStyle.target,
+                                             std::move(styles));
+            } catch (winrt::hresult_error const& ex) {
+                Wh_Log(L"Error %08X", ex.code());
+            } catch (std::exception const& ex) {
+                Wh_Log(L"Error: %S", ex.what());
+            }
         }
     }
 }
@@ -1310,7 +1655,7 @@ void ProcessResourceVariablesFromSettings() {
                 break;
             }
         } catch (winrt::hresult_error const& ex) {
-            Wh_Log(L"Error %08X", ex.code());
+            Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
         } catch (std::exception const& ex) {
             Wh_Log(L"Error: %S", ex.what());
         }
@@ -1347,7 +1692,6 @@ void UninitializeSettingsAndTap() {
 
     g_elementsCustomizationState.clear();
 
-    g_elementsCustomizationRulesLoaded = false;
     g_elementsCustomizationRules.clear();
 
     g_targetThreadId = 0;
@@ -1359,6 +1703,9 @@ void InitializeSettingsAndTap() {
                                                   GetCurrentThreadId())) {
         return;
     }
+
+    ProcessAllStylesFromSettings();
+    ProcessResourceVariablesFromSettings();
 
     HRESULT hr = InjectWindhawkTAP();
     if (FAILED(hr)) {


### PR DESCRIPTION
* Added themes! Currently, four themes are integrated into the mod and can be selected in the settings.
* Added support for customizing some elements which weren't customizable before.
* Fixed: Only parse styles when the target element is available. Previously styling some elements could cause a crash on startup.