### PR TITLE
Windows 11 Taskbar Styler v1.3

### DIFF
--- a/mods/windows-11-taskbar-styler.wh.cpp
+++ b/mods/windows-11-taskbar-styler.wh.cpp
@@ -2,7 +2,7 @@
 // @id              windows-11-taskbar-styler
 // @name            Windows 11 Taskbar Styler
 // @description     An advanced mod to override style attributes of the taskbar control elements
-// @version         1.2.3
+// @version         1.3
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -28,10 +28,26 @@ An advanced mod to override style attributes of the taskbar control elements.
 
 Also check out the **Windows 11 Start Menu Styler** mod.
 
-The settings have two sections: control styles and resource variables. Control
-styles allow to override styles, such as size and color, for the target
-elements. Resource variables allow to override predefined variables. For a more
-detailed explanation and examples, refer to the sections below.
+## Themes
+
+Themes are collections of styles. The following themes are integrated into the
+mod and can be selected in the settings:
+
+![WinXP](https://raw.githubusercontent.com/ramensoftware/windows-11-taskbar-styling-guide/main/Themes/WinXP/screenshot-small.png)
+\
+[WinXP](https://github.com/ramensoftware/windows-11-taskbar-styling-guide/blob/main/Themes/WinXP/README.md)
+
+More themes can be found in the **Themes** section of [The Windows 11 taskbar
+styling
+guide](https://github.com/ramensoftware/windows-11-taskbar-styling-guide/blob/main/README.md#themes).
+Contributions of new themes are welcome!
+
+## Advanced styling
+
+Aside from themes, the settings have two sections: control styles and resource
+variables. Control styles allow to override styles, such as size and color, for
+the target elements. Resource variables allow to override predefined variables.
+For a more detailed explanation and examples, refer to the sections below.
 
 The taskbar's XAML resources can help find out which elements and resource
 variables can be customized. To the best of my knowledge, there are no public
@@ -47,22 +63,22 @@ For a collection of commonly requested taskbar styling customizations, check out
 [The Windows 11 taskbar styling
 guide](https://github.com/ramensoftware/windows-11-taskbar-styling-guide/blob/main/README.md).
 
-## Control styles
+### Control styles
 
 Each entry has a target control and a list of styles.
 
-The target control is written as `Control` or `Control#Name`, i.e. the target
-control tag name, such as `taskbar:TaskListButton` or `Rectangle`, optionally
-followed by `#` and the target control's `x:Name` attribute. The target control
-can also include:
-* Child control index, for example: `Control#Name[2]` will only match the
-  relevant control that's also the second child among all of its parent's child
-  controls.
+The target control is written as `Class` or `Class#Name`, i.e. the target
+control class name (the tag name in XAML resource files), such as
+`Taskbar.TaskListButton` or `Rectangle`, optionally followed by `#` and the
+target control's name (`x:Name` attribute in XAML resource files). The target
+control can also include:
+* Child control index, for example: `Class#Name[2]` will only match the relevant
+  control that's also the second child among all of its parent's child controls.
 * Control properties, for example:
-  `Control#Name[Property1=Value1][Property2=Value2]`.
-* Parent controls, separated by `>`, for example: `ParentControl#ParentName >
-  Control#Name`.
-* Visual state group name, for example: `Control#Name@VisualStateGroupName`. It
+  `Class#Name[Property1=Value1][Property2=Value2]`.
+* Parent controls, separated by `>`, for example: `ParentClass#ParentName >
+  Class#Name`.
+* Visual state group name, for example: `Class#Name@VisualStateGroupName`. It
   can be specified for the target control or for a parent control, but can be
   specified only once per target. The visual state group can be used in styles
   as specified below.
@@ -78,18 +94,18 @@ visual state group specified in the target matches the specified visual state.
 
 A couple of practical examples:
 
-### Task list button corner radius
+#### Task list button corner radius
 
 ![Screenshot](https://i.imgur.com/zDATi9K.png)
 
-* Target: `taskbar:TaskListButton`
+* Target: `Taskbar.TaskListButton`
 * Style: `CornerRadius=0`
 
-### Running indicator size and color
+#### Running indicator size and color
 
 ![Screenshot](https://i.imgur.com/mR5c3F5.png)
 
-* Target: `taskbar:TaskListLabeledButtonPanel@RunningIndicatorStates >
+* Target: `Taskbar.TaskListLabeledButtonPanel@RunningIndicatorStates >
   Rectangle#RunningIndicator`
 * Styles:
     * `Fill=#FFED7014`
@@ -98,34 +114,34 @@ A couple of practical examples:
     * `Fill@ActiveRunningIndicator=Red`
     * `Width@ActiveRunningIndicator=20`
 
-### Task list button background gradient
+#### Task list button background gradient
 
 ![Screenshot](https://i.imgur.com/LNPcw0G.png)
 
 * Targets:
-    * `taskbar:TaskListButtonPanel > Border#BackgroundElement`
-    * `taskbar:TaskListLabeledButtonPanel > Border#BackgroundElement`
+    * `Taskbar.TaskListButtonPanel > Border#BackgroundElement`
+    * `Taskbar.TaskListLabeledButtonPanel > Border#BackgroundElement`
 * Style: `Background:=<LinearGradientBrush StartPoint="0.5,0"
   EndPoint="0.5,1"><GradientStop Offset="0" Color="DodgerBlue"/><GradientStop
   Offset="1" Color="Yellow"/></LinearGradientBrush>`
 
-### Hide the start button
+#### Hide the start button
 
 * Target:
-  `taskbar:ExperienceToggleButton#LaunchListButton[AutomationProperties.AutomationId=StartButton]`
+  `Taskbar.ExperienceToggleButton#LaunchListButton[AutomationProperties.AutomationId=StartButton]`
 * Style: `Visibility=Collapsed`
 
-### Hide the network notification icon
+#### Hide the network notification icon
 
-* Target: `systemtray:OmniButton#ControlCenterButton > Grid > ContentPresenter >
-  ItemsPresenter > StackPanel > ContentPresenter[1] > systemtray:IconView > Grid
-  > Grid`
+* Target: `SystemTray.OmniButton#ControlCenterButton > Grid > ContentPresenter >
+  ItemsPresenter > StackPanel > ContentPresenter[1] > SystemTray.IconView >
+  Grid > Grid`
 * Style: `Visibility=Collapsed`
 
 **Note**: To hide the volume notification icon instead, use `[2]` instead of
 `[1]`.
 
-## Resource variables
+### Resource variables
 
 Some variables, such as size and padding for various controls, are defined as
 resource variables. Here are several examples:
@@ -151,8 +167,17 @@ relevant `#pragma region` regions in the code editor.
 
 // ==WindhawkModSettings==
 /*
+- theme: ""
+  $name: Theme
+  $description: >-
+    Themes are collections of styles. For details about the themes below, or for
+    information about submitting your own theme, refer to the relevant section
+    in the mod details.
+  $options:
+  - "": None
+  - WinXP: WinXP
 - controlStyles:
-  - - target: taskbar:TaskListButton
+  - - target: Taskbar.TaskListButton
       $name: Target
     - styles: [CornerRadius=0]
       $name: Styles
@@ -1049,15 +1074,132 @@ extern RPC_IF_HANDLE __MIDL_itf_windows2Eui2Examl2Ehosting2Edesktopwindowxamlsou
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <atomic>
+#include <vector>
 
 #undef GetCurrentTime
 
 #include <winrt/Windows.UI.Xaml.h>
 
+struct ThemeTargetStyles {
+    PCWSTR target;
+    std::vector<PCWSTR> styles;
+};
+
+struct Theme {
+    std::vector<ThemeTargetStyles> targetStyles;
+};
+
+/*
+JSON settings to C++ theme conversion code, quick'n'dirty & AI-generated:
+
+json_str = R"""
+{...}
+"""
+
+def json_to_cpp(json_data):
+    def cmp(x):
+        key_prefix = x[0].removeprefix("controlStyles[")
+        index1 = int(key_prefix.split("]")[0])
+        if ".target" in key_prefix:
+            index2 = -1
+        elif ".styles" in key_prefix:
+            index2 = int(key_prefix.split("[")[1].split("]")[0])
+        else:
+            assert False
+        return index1, index2
+
+    cpp_code = "{{\n"
+    for key, value in sorted(json_data.items(), key=cmp):
+        value_escaped = value.replace('"', '\\"')
+        if ".target" in key:
+            if cpp_code != "{{\n":
+                cpp_code = cpp_code.removesuffix(", ")
+                cpp_code += "}},\n"
+            cpp_code += "    ThemeTargetStyles{\n"
+            cpp_code += f"        L\"{value_escaped}\",\n"
+            cpp_code += "        {"
+        elif ".styles" in key:
+            cpp_code += f"L\"{value_escaped}\", "
+        else:
+            assert False
+    cpp_code = cpp_code.removesuffix(", ")
+    cpp_code += "}},\n"
+    cpp_code += "}};"
+    return cpp_code
+
+json_input = json.loads(json_str)
+
+cpp_output = json_to_cpp(json_input)
+print(cpp_output)
+*/
+
+const Theme g_themeWinXP = {{
+    ThemeTargetStyles{
+        L"Rectangle#BackgroundStroke",
+        {L"Fill:=<LinearGradientBrush StartPoint=\"0.5,0\" EndPoint=\"0.5,1\"> "
+         L"<GradientStop Color=\"#3168d5\" Offset=\"0.0\" /> <GradientStop "
+         L"Color=\"#4993E6\" Offset=\"0.1\" /> <GradientStop Color=\"#2157D7\" "
+         L"Offset=\"0.35\" /> <GradientStop Color=\"#2663E0\" Offset=\"0.8\" "
+         L"/> <GradientStop Color=\"#1941A5\" Offset=\"1.0\" "
+         L"/></LinearGradientBrush>",
+         L"VerticalAlignment=Stretch", L"Height=Auto"}},
+    ThemeTargetStyles{L"Taskbar.ExperienceToggleButton#LaunchListButton["
+                      L"AutomationProperties.AutomationId=StartButton]",
+                      {L"CornerRadius=0"}},
+    ThemeTargetStyles{
+        L"Taskbar.ExperienceToggleButton#LaunchListButton[AutomationProperties."
+        L"AutomationId=StartButton] > Taskbar.TaskListButtonPanel",
+        {L"Padding=0",
+         L"Background:=<LinearGradientBrush StartPoint=\"0.5,0\" "
+         L"EndPoint=\"0.5,1\"> <GradientStop Color=\"#388238\" Offset=\"0.0\" "
+         L"/> <GradientStop Color=\"#71B571\" Offset=\"0.1\" /> <GradientStop "
+         L"Color=\"#71B571\" Offset=\"0.35\" /> <GradientStop "
+         L"Color=\"#47AA47\" Offset=\"0.8\" /> <GradientStop Color=\"#307443\" "
+         L"Offset=\"1.0\" /></LinearGradientBrush>"}},
+    ThemeTargetStyles{L"Taskbar.ExperienceToggleButton#LaunchListButton["
+                      L"AutomationProperties.AutomationId=StartButton] > "
+                      L"Taskbar.TaskListButtonPanel > Border#BackgroundElement",
+                      {L"Background:=<ImageBrush Stretch=\"None\" "
+                       L"ImageSource=\"https://i.imgur.com/BvXJlkj.png\" />"}},
+    ThemeTargetStyles{
+        L"Taskbar.ExperienceToggleButton#LaunchListButton[AutomationProperties."
+        L"AutomationId=StartButton] > Taskbar.TaskListButtonPanel > "
+        L"Microsoft.UI.Xaml.Controls.AnimatedVisualPlayer#Icon",
+        {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"TextBlock#LabelControl", {L"Foreground=White"}},
+    ThemeTargetStyles{L"Rectangle#RunningIndicator", {L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"TextBlock#TimeInnerTextBlock", {L"Foreground=White"}},
+    ThemeTargetStyles{L"TextBlock#DateInnerTextBlock", {L"Foreground=White"}},
+    ThemeTargetStyles{L"SystemTray.TextIconContent > Grid > "
+                      L"SystemTray.AdaptiveTextBlock#Base > TextBlock",
+                      {L"Foreground=White"}},
+    ThemeTargetStyles{
+        L"Taskbar.TaskListLabeledButtonPanel@RunningIndicatorStates > "
+        L"Border#BackgroundElement",
+        {L"Background@NoRunningIndicator=Transparent",
+         L"Background@ActiveRunningIndicator:=<LinearGradientBrush "
+         L"StartPoint=\"0.5,0\" EndPoint=\"0.5,1\"> <GradientStop "
+         L"Color=\"#1B67D7\" Offset=\"0.0\" /> <GradientStop Color=\"#1542A8\" "
+         L"Offset=\"0.1\" /> <GradientStop Color=\"#1951BA\" Offset=\"0.15\" "
+         L"/> <GradientStop Color=\"#1951BA\" Offset=\"0.95\" /> <GradientStop "
+         L"Color=\"#1542A8\" Offset=\"1.0\" /></LinearGradientBrush>",
+         L"Background:=<LinearGradientBrush StartPoint=\"0.5,0\" "
+         L"EndPoint=\"0.5,1\"> <GradientStop Color=\"#3358B5\" Offset=\"0.0\" "
+         L"/> <GradientStop Color=\"#8AC4FD\" Offset=\"0.1\" /> <GradientStop "
+         L"Color=\"#56A3FF\" Offset=\"0.2\" /> <GradientStop Color=\"#56A3FF\" "
+         L"Offset=\"0.85\" /> <GradientStop Color=\"#378DF6\" Offset=\"0.9\" "
+         L"/> <GradientStop Color=\"#163E95\" Offset=\"1.0\" "
+         L"/></LinearGradientBrush>",
+         L"BorderThickness=1", L"BorderBrush@NoRunningIndicator=Transparent",
+         L"BorderBrush@ActiveRunningIndicator=#1B67D7",
+         L"BorderBrush=#3358B5"}},
+}};
+
 std::atomic<DWORD> g_targetThreadId = 0;
 
 void ApplyCustomizations(InstanceHandle handle,
-                         winrt::Windows::UI::Xaml::FrameworkElement element);
+                         winrt::Windows::UI::Xaml::FrameworkElement element,
+                         PCWSTR fallbackClassName);
 void CleanupCustomizations(InstanceHandle handle);
 
 HMODULE GetCurrentModuleHandle() {
@@ -1173,7 +1315,7 @@ HRESULT VisualTreeWatcher::OnVisualTreeChange(ParentChildRelation, VisualElement
         if (frameworkElement)
         {
             Wh_Log(L"FrameworkElement name: %s", frameworkElement.Name().c_str());
-            ApplyCustomizations(element.Handle, frameworkElement);
+            ApplyCustomizations(element.Handle, frameworkElement, element.Type);
         }
     }
     else if (mutationType == Remove)
@@ -1385,6 +1527,7 @@ HRESULT InjectWindhawkTAP() noexcept
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 #include <commctrl.h>
@@ -1413,13 +1556,18 @@ using string_setting_unique_ptr =
 using PropertyKeyValue =
     std::pair<DependencyProperty, winrt::Windows::Foundation::IInspectable>;
 
+using PropertyValuesUnresolved =
+    std::vector<std::pair<std::wstring, std::wstring>>;
+using PropertyValues = std::vector<PropertyKeyValue>;
+using PropertyValuesMaybeUnresolved =
+    std::variant<PropertyValuesUnresolved, PropertyValues>;
+
 struct ElementMatcher {
     std::wstring type;
     std::wstring name;
     std::optional<std::wstring> visualStateGroupName;
     int oneBasedIndex = 0;
-    std::vector<std::pair<std::wstring, std::wstring>> propertyValuesStr;
-    std::vector<PropertyKeyValue> propertyValues;
+    PropertyValuesMaybeUnresolved propertyValues;
 };
 
 struct StyleRule {
@@ -1429,18 +1577,22 @@ struct StyleRule {
     bool isXamlValue = false;
 };
 
+using PropertyOverridesUnresolved = std::vector<StyleRule>;
+
 // Property -> visual state -> value.
 using PropertyOverrides = std::unordered_map<
     DependencyProperty,
     std::unordered_map<std::wstring, winrt::Windows::Foundation::IInspectable>>;
 
+using PropertyOverridesMaybeUnresolved =
+    std::variant<PropertyOverridesUnresolved, PropertyOverrides>;
+
 struct ElementCustomizationRules {
     ElementMatcher elementMatcher;
     std::vector<ElementMatcher> parentElementMatchers;
-    PropertyOverrides propertyOverrides;
+    PropertyOverridesMaybeUnresolved propertyOverrides;
 };
 
-bool g_elementsCustomizationRulesLoaded;
 std::vector<ElementCustomizationRules> g_elementsCustomizationRules;
 
 struct ElementPropertyCustomizationState {
@@ -1464,6 +1616,216 @@ bool g_elementPropertyModifying;
 
 bool g_inTaskbarBackground_OnApplyTemplate;
 
+// https://stackoverflow.com/a/5665377
+std::wstring EscapeXmlAttribute(std::wstring_view data) {
+    std::wstring buffer;
+    buffer.reserve(data.size());
+    for (size_t pos = 0; pos != data.size(); ++pos) {
+        switch (data[pos]) {
+            case '&':
+                buffer.append(L"&amp;");
+                break;
+            case '\"':
+                buffer.append(L"&quot;");
+                break;
+            // case '\'':
+            //     buffer.append(L"&apos;");
+            //     break;
+            case '<':
+                buffer.append(L"&lt;");
+                break;
+            case '>':
+                buffer.append(L"&gt;");
+                break;
+            default:
+                buffer.append(&data[pos], 1);
+                break;
+        }
+    }
+
+    return buffer;
+}
+
+// https://stackoverflow.com/a/54364173
+std::wstring_view TrimStringView(std::wstring_view s) {
+    s.remove_prefix(std::min(s.find_first_not_of(L" \t\r\v\n"), s.size()));
+    s.remove_suffix(
+        std::min(s.size() - s.find_last_not_of(L" \t\r\v\n") - 1, s.size()));
+    return s;
+}
+
+// https://stackoverflow.com/a/46931770
+std::vector<std::wstring_view> SplitStringView(std::wstring_view s,
+                                               std::wstring_view delimiter) {
+    size_t pos_start = 0, pos_end, delim_len = delimiter.length();
+    std::wstring_view token;
+    std::vector<std::wstring_view> res;
+
+    while ((pos_end = s.find(delimiter, pos_start)) !=
+           std::wstring_view::npos) {
+        token = s.substr(pos_start, pos_end - pos_start);
+        pos_start = pos_end + delim_len;
+        res.push_back(token);
+    }
+
+    res.push_back(s.substr(pos_start));
+    return res;
+}
+
+Style GetStyleFromXamlSetters(const std::wstring_view type,
+                              const std::wstring_view xamlStyleSetters) {
+    std::wstring xaml =
+        LR"(<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls")";
+
+    if (auto pos = type.rfind('.'); pos != type.npos) {
+        auto typeNamespace = std::wstring_view(type).substr(0, pos);
+        auto typeName = std::wstring_view(type).substr(pos + 1);
+
+        xaml += L"\n    xmlns:windhawkstyler=\"using:";
+        xaml += EscapeXmlAttribute(typeNamespace);
+        xaml +=
+            L"\">\n"
+            L"    <Style TargetType=\"windhawkstyler:";
+        xaml += EscapeXmlAttribute(typeName);
+        xaml += L"\">\n";
+    } else {
+        xaml +=
+            L">\n"
+            L"    <Style TargetType=\"";
+        xaml += EscapeXmlAttribute(type);
+        xaml += L"\">\n";
+    }
+
+    xaml += xamlStyleSetters;
+
+    xaml +=
+        L"    </Style>\n"
+        L"</ResourceDictionary>";
+
+    Wh_Log(L"======================================== XAML:");
+    std::wstringstream ss(xaml);
+    std::wstring line;
+    while (std::getline(ss, line, L'\n')) {
+        Wh_Log(L"%s", line.c_str());
+    }
+    Wh_Log(L"========================================");
+
+    auto resourceDictionary =
+        Markup::XamlReader::Load(xaml).as<ResourceDictionary>();
+
+    auto [styleKey, styleInspectable] = resourceDictionary.First().Current();
+    return styleInspectable.as<Style>();
+}
+
+const PropertyOverrides& GetResolvedPropertyOverrides(
+    const std::wstring_view type,
+    PropertyOverridesMaybeUnresolved* propertyOverridesMaybeUnresolved) {
+    if (const auto* resolved =
+            std::get_if<PropertyOverrides>(propertyOverridesMaybeUnresolved)) {
+        return *resolved;
+    }
+
+    PropertyOverrides propertyOverrides;
+
+    try {
+        const auto& styleRules = std::get<PropertyOverridesUnresolved>(
+            *propertyOverridesMaybeUnresolved);
+        if (!styleRules.empty()) {
+            std::wstring xaml;
+
+            for (const auto& rule : styleRules) {
+                xaml += L"        <Setter Property=\"";
+                xaml += EscapeXmlAttribute(rule.name);
+                xaml += L"\"";
+                if (!rule.isXamlValue) {
+                    xaml += L" Value=\"";
+                    xaml += EscapeXmlAttribute(rule.value);
+                    xaml += L"\" />\n";
+                } else {
+                    xaml +=
+                        L">\n"
+                        L"            <Setter.Value>\n";
+                    xaml += rule.value;
+                    xaml +=
+                        L"\n"
+                        L"            </Setter.Value>\n"
+                        L"        </Setter>\n";
+                }
+            }
+
+            auto style = GetStyleFromXamlSetters(type, xaml);
+
+            for (size_t i = 0; i < styleRules.size(); i++) {
+                const auto setter = style.Setters().GetAt(i).as<Setter>();
+                propertyOverrides[setter.Property()]
+                                 [styleRules[i].visualState] = setter.Value();
+            }
+        }
+
+        Wh_Log(L"%.*s: %zu override styles", static_cast<int>(type.length()),
+               type.data(), propertyOverrides.size());
+    } catch (winrt::hresult_error const& ex) {
+        Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
+    } catch (std::exception const& ex) {
+        Wh_Log(L"Error: %S", ex.what());
+    }
+
+    *propertyOverridesMaybeUnresolved = std::move(propertyOverrides);
+    return std::get<PropertyOverrides>(*propertyOverridesMaybeUnresolved);
+}
+
+const PropertyValues& GetResolvedPropertyValues(
+    const std::wstring_view type,
+    PropertyValuesMaybeUnresolved* propertyValuesMaybeUnresolved) {
+    if (const auto* resolved =
+            std::get_if<PropertyValues>(propertyValuesMaybeUnresolved)) {
+        return *resolved;
+    }
+
+    PropertyValues propertyValues;
+
+    try {
+        const auto& propertyValuesStr =
+            std::get<PropertyValuesUnresolved>(*propertyValuesMaybeUnresolved);
+        if (!propertyValuesStr.empty()) {
+            std::wstring xaml;
+
+            for (const auto& [property, value] : propertyValuesStr) {
+                xaml += L"        <Setter Property=\"";
+                xaml += EscapeXmlAttribute(property);
+                xaml += L"\" Value=\"";
+                xaml += EscapeXmlAttribute(value);
+                xaml += L"\" />\n";
+            }
+
+            auto style = GetStyleFromXamlSetters(type, xaml);
+
+            for (size_t i = 0; i < propertyValuesStr.size(); i++) {
+                const auto setter = style.Setters().GetAt(i).as<Setter>();
+                propertyValues.push_back({
+                    setter.Property(),
+                    setter.Value(),
+                });
+            }
+        }
+
+        Wh_Log(L"%.*s: %zu matcher styles", static_cast<int>(type.length()),
+               type.data(), propertyValues.size());
+    } catch (winrt::hresult_error const& ex) {
+        Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
+    } catch (std::exception const& ex) {
+        Wh_Log(L"Error: %S", ex.what());
+    }
+
+    *propertyValuesMaybeUnresolved = std::move(propertyValues);
+    return std::get<PropertyValues>(*propertyValuesMaybeUnresolved);
+}
+
 // https://stackoverflow.com/a/12835139
 VisualStateGroup GetVisualStateGroup(FrameworkElement element,
                                      std::wstring_view visualStateGroupName) {
@@ -1479,10 +1841,12 @@ VisualStateGroup GetVisualStateGroup(FrameworkElement element,
 }
 
 bool TestElementMatcher(FrameworkElement element,
-                        const ElementMatcher& matcher,
-                        VisualStateGroup* visualStateGroup) {
+                        ElementMatcher& matcher,
+                        VisualStateGroup* visualStateGroup,
+                        PCWSTR fallbackClassName) {
     if (!matcher.type.empty() &&
-        matcher.type != winrt::get_class_name(element)) {
+        matcher.type != winrt::get_class_name(element) &&
+        (!fallbackClassName || matcher.type != fallbackClassName)) {
         return false;
     }
 
@@ -1506,7 +1870,8 @@ bool TestElementMatcher(FrameworkElement element,
 
     auto elementDo = element.as<DependencyObject>();
 
-    for (const auto& propertyValue : matcher.propertyValues) {
+    for (const auto& propertyValue :
+         GetResolvedPropertyValues(matcher.type, &matcher.propertyValues)) {
         const auto value = elementDo.ReadLocalValue(propertyValue.first);
         const auto className = winrt::get_class_name(value);
         const auto expectedClassName =
@@ -1556,19 +1921,20 @@ bool TestElementMatcher(FrameworkElement element,
     return true;
 }
 
-const ElementCustomizationRules* FindElementCustomizationRules(
+ElementCustomizationRules* FindElementCustomizationRules(
     FrameworkElement element,
-    VisualStateGroup* visualStateGroup) {
-    for (const auto& override : g_elementsCustomizationRules) {
+    VisualStateGroup* visualStateGroup,
+    PCWSTR fallbackClassName) {
+    for (auto& override : g_elementsCustomizationRules) {
         if (!TestElementMatcher(element, override.elementMatcher,
-                                visualStateGroup)) {
+                                visualStateGroup, fallbackClassName)) {
             continue;
         }
 
         auto parentElementIter = element;
         bool parentElementMatchFailed = false;
 
-        for (const auto& matcher : override.parentElementMatchers) {
+        for (auto& matcher : override.parentElementMatchers) {
             // Using parentElementIter.Parent() was sometimes returning null.
             parentElementIter =
                 Media::VisualTreeHelper::GetParent(parentElementIter)
@@ -1579,7 +1945,7 @@ const ElementCustomizationRules* FindElementCustomizationRules(
             }
 
             if (!TestElementMatcher(parentElementIter, matcher,
-                                    visualStateGroup)) {
+                                    visualStateGroup, nullptr)) {
                 parentElementMatchFailed = true;
                 break;
             }
@@ -1593,18 +1959,12 @@ const ElementCustomizationRules* FindElementCustomizationRules(
     return nullptr;
 }
 
-void ProcessAllStylesFromSettings();
-void ProcessResourceVariablesFromSettings();
-
-void ApplyCustomizations(InstanceHandle handle, FrameworkElement element) {
-    if (!g_elementsCustomizationRulesLoaded) {
-        ProcessAllStylesFromSettings();
-        ProcessResourceVariablesFromSettings();
-        g_elementsCustomizationRulesLoaded = true;
-    }
-
+void ApplyCustomizations(InstanceHandle handle,
+                         FrameworkElement element,
+                         PCWSTR fallbackClassName) {
     VisualStateGroup visualStateGroup;
-    auto rules = FindElementCustomizationRules(element, &visualStateGroup);
+    auto rules = FindElementCustomizationRules(element, &visualStateGroup,
+                                               fallbackClassName);
     if (!rules) {
         return;
     }
@@ -1649,7 +2009,8 @@ void ApplyCustomizations(InstanceHandle handle, FrameworkElement element) {
     std::wstring currentVisualStateName(
         currentVisualState ? currentVisualState.Name() : L"");
 
-    for (auto& [property, valuesPerVisualState] : rules->propertyOverrides) {
+    for (auto& [property, valuesPerVisualState] : GetResolvedPropertyOverrides(
+             rules->elementMatcher.type, &rules->propertyOverrides)) {
         const auto [propertyCustomizationStatesIt, inserted] =
             elementCustomizationState.propertyCustomizationStates.insert(
                 {property, {}});
@@ -1726,7 +2087,9 @@ void ApplyCustomizations(InstanceHandle handle, FrameworkElement element) {
                         elementCustomizationState.propertyCustomizationStates;
 
                     for (auto& [property, valuesPerVisualState] :
-                         rules->propertyOverrides) {
+                         GetResolvedPropertyOverrides(
+                             rules->elementMatcher.type,
+                             &rules->propertyOverrides)) {
                         auto& propertyCustomizationState =
                             propertyCustomizationStates.at(property);
 
@@ -1805,176 +2168,9 @@ void CleanupCustomizations(InstanceHandle handle) {
     g_elementsCustomizationState.erase(it);
 }
 
-// https://stackoverflow.com/a/5665377
-std::wstring EscapeXmlAttribute(std::wstring_view data) {
-    std::wstring buffer;
-    buffer.reserve(data.size());
-    for (size_t pos = 0; pos != data.size(); ++pos) {
-        switch (data[pos]) {
-            case '&':
-                buffer.append(L"&amp;");
-                break;
-            case '\"':
-                buffer.append(L"&quot;");
-                break;
-            // case '\'':
-            //     buffer.append(L"&apos;");
-            //     break;
-            case '<':
-                buffer.append(L"&lt;");
-                break;
-            case '>':
-                buffer.append(L"&gt;");
-                break;
-            default:
-                buffer.append(&data[pos], 1);
-                break;
-        }
-    }
-
-    return buffer;
-}
-
-// https://stackoverflow.com/a/54364173
-std::wstring_view TrimStringView(std::wstring_view s) {
-    s.remove_prefix(std::min(s.find_first_not_of(L" \t\r\v\n"), s.size()));
-    s.remove_suffix(
-        std::min(s.size() - s.find_last_not_of(L" \t\r\v\n") - 1, s.size()));
-    return s;
-}
-
-// https://stackoverflow.com/a/46931770
-std::vector<std::wstring_view> SplitStringView(std::wstring_view s,
-                                               std::wstring_view delimiter) {
-    size_t pos_start = 0, pos_end, delim_len = delimiter.length();
-    std::wstring_view token;
-    std::vector<std::wstring_view> res;
-
-    while ((pos_end = s.find(delimiter, pos_start)) !=
-           std::wstring_view::npos) {
-        token = s.substr(pos_start, pos_end - pos_start);
-        pos_start = pos_end + delim_len;
-        res.push_back(token);
-    }
-
-    res.push_back(s.substr(pos_start));
-    return res;
-}
-
-void ResolveTypeAndStyles(ElementMatcher* elementMatcher,
-                          std::vector<StyleRule> styleRules = {},
-                          PropertyOverrides* propertyOverrides = nullptr) {
-    std::wstring xaml =
-        LR"(<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    xmlns:taskbar="using:Taskbar"
-    xmlns:udk="using:WindowsUdk.UI.Shell"
-    xmlns:systemtray="using:SystemTray")";
-
-    if (auto pos = elementMatcher->type.rfind('.');
-        pos != elementMatcher->type.npos) {
-        auto typeNamespace =
-            std::wstring_view(elementMatcher->type).substr(0, pos);
-        auto typeName = std::wstring_view(elementMatcher->type).substr(pos + 1);
-
-        xaml += L"\n    xmlns:windhawkstyler=\"using:";
-        xaml += EscapeXmlAttribute(typeNamespace);
-        xaml +=
-            L"\">\n"
-            L"    <Style TargetType=\"windhawkstyler:";
-        xaml += EscapeXmlAttribute(typeName);
-        xaml += L"\">\n";
-    } else {
-        xaml +=
-            L">\n"
-            L"    <Style TargetType=\"";
-        xaml += EscapeXmlAttribute(elementMatcher->type);
-        xaml += L"\">\n";
-    }
-
-    for (const auto& [property, value] : elementMatcher->propertyValuesStr) {
-        xaml += L"        <Setter Property=\"";
-        xaml += EscapeXmlAttribute(property);
-        xaml += L"\" Value=\"";
-        xaml += EscapeXmlAttribute(value);
-        xaml += L"\" />\n";
-    }
-
-    for (const auto& rule : styleRules) {
-        xaml += L"        <Setter Property=\"";
-        xaml += EscapeXmlAttribute(rule.name);
-        xaml += L"\"";
-        if (!rule.isXamlValue) {
-            xaml += L" Value=\"";
-            xaml += EscapeXmlAttribute(rule.value);
-            xaml += L"\" />\n";
-        } else {
-            xaml +=
-                L">\n"
-                L"            <Setter.Value>\n";
-            xaml += rule.value;
-            xaml +=
-                L"\n"
-                L"            </Setter.Value>\n"
-                L"        </Setter>\n";
-        }
-    }
-
-    xaml +=
-        L"    </Style>\n"
-        L"</ResourceDictionary>";
-
-    Wh_Log(L"======================================== XAML:");
-    std::wstringstream ss(xaml);
-    std::wstring line;
-    while (std::getline(ss, line, L'\n')) {
-        Wh_Log(L"%s", line.c_str());
-    }
-    Wh_Log(L"========================================");
-
-    auto resourceDictionary =
-        Markup::XamlReader::Load(xaml).as<ResourceDictionary>();
-
-    auto [styleKey, styleInspectable] = resourceDictionary.First().Current();
-    auto style = styleInspectable.as<Style>();
-    size_t styleIndex = 0;
-
-    elementMatcher->type = style.TargetType().Name;
-    elementMatcher->propertyValues.clear();
-
-    for (size_t i = 0; i < elementMatcher->propertyValuesStr.size(); i++) {
-        const auto setter = style.Setters().GetAt(styleIndex++).as<Setter>();
-        elementMatcher->propertyValues.push_back({
-            setter.Property(),
-            setter.Value(),
-        });
-    }
-
-    Wh_Log(L"%s: %zu matcher styles", elementMatcher->type.c_str(),
-           elementMatcher->propertyValues.size());
-
-    if (propertyOverrides) {
-        propertyOverrides->clear();
-
-        for (size_t i = 0; i < styleRules.size(); i++) {
-            const auto setter =
-                style.Setters().GetAt(styleIndex++).as<Setter>();
-
-            (*propertyOverrides)[setter.Property()][styleRules[i].visualState] =
-                setter.Value();
-        }
-
-        Wh_Log(L"%s: %zu styles", elementMatcher->type.c_str(),
-               styleRules.size());
-    }
-}
-
 ElementMatcher ElementMatcherFromString(std::wstring_view str) {
     ElementMatcher result;
+    PropertyValuesUnresolved propertyValuesUnresolved;
 
     auto i = str.find_first_of(L"#@[");
     result.type = TrimStringView(str.substr(0, i));
@@ -2040,7 +2236,7 @@ ElementMatcher ElementMatcherFromString(std::wstring_view str) {
                         "Bad target syntax, empty property name");
                 }
 
-                result.propertyValuesStr.push_back(
+                propertyValuesUnresolved.push_back(
                     {std::wstring(ruleKey), std::wstring(ruleVal)});
                 break;
             }
@@ -2051,6 +2247,8 @@ ElementMatcher ElementMatcherFromString(std::wstring_view str) {
 
         i = iNext;
     }
+
+    result.propertyValues = std::move(propertyValuesUnresolved);
 
     return result;
 }
@@ -2094,6 +2292,34 @@ StyleRule StyleRuleFromString(std::wstring_view str) {
     return result;
 }
 
+std::wstring AdjustTypeName(std::wstring_view type) {
+    if (type.find_first_of(L".:") == type.npos) {
+        if (type == L"Rectangle") {
+            return L"Windows.UI.Xaml.Shapes.Rectangle";
+        }
+
+        return L"Windows.UI.Xaml.Controls." + std::wstring{type};
+    }
+
+    static const std::vector<std::pair<std::wstring_view, std::wstring_view>>
+        adjustments = {
+            {L"taskbar:", L"Taskbar."},
+            {L"systemtray:", L"SystemTray."},
+            {L"udk:", L"WindowsUdk.UI.Shell."},
+            {L"muxc:", L"Microsoft.UI.Xaml.Controls."},
+        };
+
+    for (const auto& adjustment : adjustments) {
+        if (type.starts_with(adjustment.first)) {
+            auto result = std::wstring{adjustment.second};
+            result += type.substr(adjustment.first.size());
+            return result;
+        }
+    }
+
+    return std::wstring{type};
+}
+
 void AddElementCustomizationRules(std::wstring_view target,
                                   std::vector<std::wstring> styles) {
     ElementCustomizationRules elementCustomizationRules;
@@ -2106,6 +2332,7 @@ void AddElementCustomizationRules(std::wstring_view target,
         const auto& targetPart = *i;
 
         auto matcher = ElementMatcherFromString(targetPart);
+        matcher.type = AdjustTypeName(matcher.type);
 
         if (matcher.visualStateGroupName) {
             if (hasVisualStateGroup) {
@@ -2122,11 +2349,9 @@ void AddElementCustomizationRules(std::wstring_view target,
                 styleRules.push_back(StyleRuleFromString(style));
             }
 
-            ResolveTypeAndStyles(&matcher, std::move(styleRules),
-                                 &elementCustomizationRules.propertyOverrides);
             elementCustomizationRules.elementMatcher = std::move(matcher);
+            elementCustomizationRules.propertyOverrides = std::move(styleRules);
         } else {
-            ResolveTypeAndStyles(&matcher);
             elementCustomizationRules.parentElementMatchers.push_back(
                 std::move(matcher));
         }
@@ -2156,6 +2381,11 @@ bool ProcessSingleTargetStylesFromSettings(int index) {
             break;
         }
 
+        // Skip if commented.
+        if (styleSetting[0] == L'/' && styleSetting[1] == L'/') {
+            continue;
+        }
+
         styles.push_back(styleSetting.get());
     }
 
@@ -2174,9 +2404,32 @@ void ProcessAllStylesFromSettings() {
                 break;
             }
         } catch (winrt::hresult_error const& ex) {
-            Wh_Log(L"Error %08X", ex.code());
+            Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
         } catch (std::exception const& ex) {
             Wh_Log(L"Error: %S", ex.what());
+        }
+    }
+
+    PCWSTR themeName = Wh_GetStringSetting(L"theme");
+    const Theme* theme = nullptr;
+    if (wcscmp(themeName, L"WinXP") == 0) {
+        theme = &g_themeWinXP;
+    }
+    Wh_FreeStringSetting(themeName);
+
+    if (theme) {
+        for (const auto& themeTargetStyle : theme->targetStyles) {
+            try {
+                std::vector<std::wstring> styles{
+                    themeTargetStyle.styles.begin(),
+                    themeTargetStyle.styles.end()};
+                AddElementCustomizationRules(themeTargetStyle.target,
+                                             std::move(styles));
+            } catch (winrt::hresult_error const& ex) {
+                Wh_Log(L"Error %08X", ex.code());
+            } catch (std::exception const& ex) {
+                Wh_Log(L"Error: %S", ex.what());
+            }
         }
     }
 }
@@ -2227,7 +2480,7 @@ void ProcessResourceVariablesFromSettings() {
                 break;
             }
         } catch (winrt::hresult_error const& ex) {
-            Wh_Log(L"Error %08X", ex.code());
+            Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
         } catch (std::exception const& ex) {
             Wh_Log(L"Error: %S", ex.what());
         }
@@ -2245,11 +2498,19 @@ void UninitializeSettingsAndTap() {
                     property, state.propertyChangedToken);
 
                 if (state.originalValue) {
-                    if (*state.originalValue ==
-                        DependencyProperty::UnsetValue()) {
-                        oldElement.ClearValue(property);
-                    } else {
-                        oldElement.SetValue(property, *state.originalValue);
+                    try {
+                        // Sometimes this fails with error 80004002: No such
+                        // interface supported. Can be reproduced by setting
+                        // "CornerRadius=0" for the "Border" target.
+                        if (*state.originalValue ==
+                            DependencyProperty::UnsetValue()) {
+                            oldElement.ClearValue(property);
+                        } else {
+                            oldElement.SetValue(property, *state.originalValue);
+                        }
+                    } catch (winrt::hresult_error const& ex) {
+                        Wh_Log(L"Error %08X: %s", ex.code(),
+                               ex.message().c_str());
                     }
                 }
             }
@@ -2264,7 +2525,6 @@ void UninitializeSettingsAndTap() {
 
     g_elementsCustomizationState.clear();
 
-    g_elementsCustomizationRulesLoaded = false;
     g_elementsCustomizationRules.clear();
 
     g_targetThreadId = 0;
@@ -2276,6 +2536,9 @@ void InitializeSettingsAndTap() {
                                                   GetCurrentThreadId())) {
         return;
     }
+
+    ProcessAllStylesFromSettings();
+    ProcessResourceVariablesFromSettings();
 
     HRESULT hr = InjectWindhawkTAP();
     if (FAILED(hr)) {
@@ -2363,7 +2626,7 @@ bool RunFromWindowThread(HWND hWnd,
     RUN_FROM_WINDOW_THREAD_PARAM param;
     param.proc = proc;
     param.procParam = procParam;
-    SendMessage(hWnd, runFromWindowThreadRegisteredMsg, 0, (WPARAM)&param);
+    SendMessage(hWnd, runFromWindowThreadRegisteredMsg, 0, (LPARAM)&param);
 
     UnhookWindowsHookEx(hook);
 
@@ -2406,7 +2669,7 @@ bool WINAPI Foundation_operator_eq_Hook(void** p1, void** p2) {
         // The code inside TaskbarBackground::OnApplyTemplate throws an
         // exception if operator== returns true in some cases, and that happens
         // if the background is customized, in which case two null pointers are
-        // compared. It can be trigerred with the following example:
+        // compared. It can be triggered with the following example:
         // * Target: Rectangle#BackgroundFill
         // * Style: Fill=Red
         if (p1 && p2 && !*p1 && !*p2) {


### PR DESCRIPTION
* Added themes! Currently, only the sample WinXP theme is integrated into the mod and can be selected in the settings.
* Added support for customizing some elements which weren't customizable before.
* Fixed: Only parse styles when the target element is available. Previously styling some elements could cause a crash on startup.