### PR TITLE
Create mod "Maintain colour temperature of f.lux"

### DIFF
--- a/mods/maintain-flux-colour-temperature.wh.cpp
+++ b/mods/maintain-flux-colour-temperature.wh.cpp
@@ -10,6 +10,14 @@
 // @include         flux.exe
 // ==/WindhawkMod==
 
+// Source code is published under The GNU General Public License v3.0.
+//
+// For bug reports and feature requests, please open an issue here:
+// https://github.com/levitation-opensource/my-windhawk-mods/issues
+//
+// For pull requests, development takes place here:
+// https://github.com/levitation-opensource/my-windhawk-mods/
+
 // ==WindhawkModReadme==
 /*
 # Maintain colour temperature of f.lux

--- a/mods/maintain-flux-colour-temperature.wh.cpp
+++ b/mods/maintain-flux-colour-temperature.wh.cpp
@@ -53,12 +53,6 @@ There are many posts in f.lux forum asking for this functionality since 2016. Un
 #include <windowsx.h>
 
 
-#ifndef WH_MOD
-#define WH_MOD
-#include <mods_api.h>
-#endif
-
-
 template <typename T>
 BOOL Wh_SetFunctionHookT(
     FARPROC targetFunction,

--- a/mods/maintain-flux-colour-temperature.wh.cpp
+++ b/mods/maintain-flux-colour-temperature.wh.cpp
@@ -4,7 +4,7 @@
 // @description     Keeps your preferred f.lux colour temperature settings, eliminating automatic changes
 // @version         1.0
 // @author          Roland Pihlakas
-// @github          https://github.com/levitation-opensource/
+// @github          https://github.com/levitation/
 // @homepage        https://www.simplify.ee/
 // @compilerOptions -lkernel32
 // @include         flux.exe

--- a/mods/maintain-flux-colour-temperature.wh.cpp
+++ b/mods/maintain-flux-colour-temperature.wh.cpp
@@ -4,7 +4,7 @@
 // @description     Keeps your preferred f.lux colour temperature settings, eliminating automatic changes
 // @version         1.0
 // @author          Roland Pihlakas
-// @github          https://github.com/levitation/
+// @github          https://github.com/levitation
 // @homepage        https://www.simplify.ee/
 // @compilerOptions -lkernel32
 // @include         flux.exe


### PR DESCRIPTION
Maintain colour temperature of f.lux. 

Keeps your preferred f.lux colour temperature settings, eliminating automatic changes. You can choose the desired colour temperature from f.lux dropdown menu, and f.lux will not change it later automatically.