### PR TITLE
Taskbar height and icon size v1.2.10

### DIFF
--- a/mods/taskbar-icon-size.wh.cpp
+++ b/mods/taskbar-icon-size.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-icon-size
 // @name            Taskbar height and icon size
 // @description     Control the taskbar height and icon size, improve icon quality (Windows 11 only)
-// @version         1.2.9
+// @version         1.2.10
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -101,14 +101,13 @@ struct {
 WCHAR g_taskbarViewDllPath[MAX_PATH];
 std::atomic<bool> g_taskbarViewDllLoaded;
 std::atomic<bool> g_applyingSettings;
-std::atomic<bool> g_pendingFrameSizeChange;
 std::atomic<bool> g_pendingMeasureOverride;
 std::atomic<bool> g_unloading;
 std::atomic<int> g_hookCallCounter;
 
 int g_originalTaskbarHeight;
 int g_taskbarHeight;
-bool g_inSystemTraySecondaryController_UpdateFrameSize;
+bool g_inSystemTrayController_UpdateFrameSize;
 bool g_inAugmentedEntryPointButton_UpdateButtonPadding;
 
 double* double_48_value_Original;
@@ -292,6 +291,24 @@ int WINAPI TaskListItemViewModel_GetIconHeight_Hook(void* pThis,
     return ret;
 }
 
+using TaskListGroupViewModel_GetIconHeight_t = int(WINAPI*)(void* pThis,
+                                                            void* param1,
+                                                            double* iconHeight);
+TaskListGroupViewModel_GetIconHeight_t
+    TaskListGroupViewModel_GetIconHeight_Original;
+int WINAPI TaskListGroupViewModel_GetIconHeight_Hook(void* pThis,
+                                                     void* param1,
+                                                     double* iconHeight) {
+    int ret = TaskListGroupViewModel_GetIconHeight_Original(pThis, param1,
+                                                            iconHeight);
+
+    if (!g_unloading) {
+        *iconHeight = g_settings.iconSize;
+    }
+
+    return ret;
+}
+
 using TaskbarConfiguration_GetIconHeightInViewPixels_taskbarSizeEnum_t =
     double(WINAPI*)(int enumTaskbarSize);
 TaskbarConfiguration_GetIconHeightInViewPixels_taskbarSizeEnum_t
@@ -370,21 +387,43 @@ double WINAPI TaskbarConfiguration_GetFrameSize_Hook(int enumTaskbarSize) {
     return TaskbarConfiguration_GetFrameSize_Original(enumTaskbarSize);
 }
 
-using TaskbarFrame_MaxHeight_double_t = void(WINAPI*)(void* pThis,
-                                                      double value);
-TaskbarFrame_MaxHeight_double_t TaskbarFrame_MaxHeight_double_Original;
-
-using TaskbarFrame_Height_double_t = void(WINAPI*)(void* pThis, double value);
-TaskbarFrame_Height_double_t TaskbarFrame_Height_double_Original;
-void WINAPI TaskbarFrame_Height_double_Hook(void* pThis, double value) {
+using SystemTrayController_UpdateFrameSize_t = void(WINAPI*)(void* pThis);
+SystemTrayController_UpdateFrameSize_t
+    SystemTrayController_UpdateFrameSize_SymbolAddress;
+SystemTrayController_UpdateFrameSize_t
+    SystemTrayController_UpdateFrameSize_Original;
+void WINAPI SystemTrayController_UpdateFrameSize_Hook(void* pThis) {
     Wh_Log(L">");
 
-    if (TaskbarFrame_MaxHeight_double_Original) {
-        TaskbarFrame_MaxHeight_double_Original(
-            pThis, std::numeric_limits<double>::infinity());
+    // Find the last height offset and reset the height value.
+    //
+    // 66 0f 2e b3 b0 00 00 00 UCOMISD    uVar4,qword ptr [RBX + 0xb0]
+    // 7a 4c                   JP         LAB_180075641
+    // 75 4a                   JNZ        LAB_180075641
+
+    DWORD lastHeightOffset = 0;
+    const BYTE* start =
+        (const BYTE*)SystemTrayController_UpdateFrameSize_SymbolAddress;
+    const BYTE* end = start + 0x200;
+    for (const BYTE* p = start; p != end; p++) {
+        if (p[0] == 0x66 && p[1] == 0x0F && p[2] == 0x2E && p[3] == 0xB3 &&
+            p[8] == 0x7A && p[10] == 0x75) {
+            lastHeightOffset = *(DWORD*)(p + 4);
+            break;
+        }
     }
 
-    return TaskbarFrame_Height_double_Original(pThis, value);
+    Wh_Log(L"lastHeightOffset=0x%X", lastHeightOffset);
+
+    if (lastHeightOffset) {
+        *(double*)((BYTE*)pThis + lastHeightOffset) = 0;
+    }
+
+    g_inSystemTrayController_UpdateFrameSize = true;
+
+    SystemTrayController_UpdateFrameSize_Original(pThis);
+
+    g_inSystemTrayController_UpdateFrameSize = false;
 }
 
 using SystemTraySecondaryController_UpdateFrameSize_t =
@@ -394,11 +433,11 @@ SystemTraySecondaryController_UpdateFrameSize_t
 void WINAPI SystemTraySecondaryController_UpdateFrameSize_Hook(void* pThis) {
     Wh_Log(L">");
 
-    g_inSystemTraySecondaryController_UpdateFrameSize = true;
+    g_inSystemTrayController_UpdateFrameSize = true;
 
     SystemTraySecondaryController_UpdateFrameSize_Original(pThis);
 
-    g_inSystemTraySecondaryController_UpdateFrameSize = false;
+    g_inSystemTrayController_UpdateFrameSize = false;
 }
 
 using SystemTrayFrame_Height_t = void(WINAPI*)(void* pThis, double value);
@@ -406,37 +445,38 @@ SystemTrayFrame_Height_t SystemTrayFrame_Height_Original;
 void WINAPI SystemTrayFrame_Height_Hook(void* pThis, double value) {
     // Wh_Log(L">");
 
-    if (g_inSystemTraySecondaryController_UpdateFrameSize) {
-        // Set the secondary taskbar clock height to NaN, otherwise it may not
-        // match the custom taskbar height.
+    if (g_inSystemTrayController_UpdateFrameSize) {
+        Wh_Log(L">");
+        // Set the system tray height to NaN, otherwise it may not match the
+        // custom taskbar height.
         value = std::numeric_limits<double>::quiet_NaN();
     }
 
     SystemTrayFrame_Height_Original(pThis, value);
 }
 
-using TaskbarController_OnFrameSizeChanged_t = void(WINAPI*)(void* pThis);
-TaskbarController_OnFrameSizeChanged_t
-    TaskbarController_OnFrameSizeChanged_Original;
-void WINAPI TaskbarController_OnFrameSizeChanged_Hook(void* pThis) {
-    Wh_Log(L">");
-
-    TaskbarController_OnFrameSizeChanged_Original(pThis);
-
-    g_pendingFrameSizeChange = false;
-}
-
-using TaskbarFrame_MeasureOverride_t = winrt::Windows::Foundation::Size*(
-    WINAPI*)(void* pThis, void* param1, void* param2);
+using TaskbarFrame_MeasureOverride_t =
+    int(WINAPI*)(void* pThis,
+                 void* param1,
+                 winrt::Windows::Foundation::Size* resultSize);
 TaskbarFrame_MeasureOverride_t TaskbarFrame_MeasureOverride_Original;
-winrt::Windows::Foundation::Size* WINAPI
-TaskbarFrame_MeasureOverride_Hook(void* pThis, void* param1, void* param2) {
+int WINAPI TaskbarFrame_MeasureOverride_Hook(
+    void* pThis,
+    void* param1,
+    winrt::Windows::Foundation::Size* resultSize) {
     g_hookCallCounter++;
 
     Wh_Log(L">");
 
-    winrt::Windows::Foundation::Size* ret =
-        TaskbarFrame_MeasureOverride_Original(pThis, param1, param2);
+    FrameworkElement taskbarFrameElement = nullptr;
+    ((IUnknown*)pThis)
+        ->QueryInterface(winrt::guid_of<FrameworkElement>(),
+                         winrt::put_abi(taskbarFrameElement));
+    if (taskbarFrameElement) {
+        taskbarFrameElement.MaxHeight(std::numeric_limits<double>::infinity());
+    }
+
+    int ret = TaskbarFrame_MeasureOverride_Original(pThis, param1, resultSize);
 
     g_pendingMeasureOverride = false;
 
@@ -654,7 +694,6 @@ void ApplySettings(int taskbarHeight) {
     g_applyingSettings = true;
 
     if (taskbarHeight == g_taskbarHeight) {
-        g_pendingFrameSizeChange = true;
         g_pendingMeasureOverride = true;
 
         // Temporarily change the height to force a UI refresh.
@@ -672,9 +711,7 @@ void ApplySettings(int taskbarHeight) {
 
         // Wait for the change to apply.
         for (int i = 0; i < 100; i++) {
-            if (TaskbarFrame_MeasureOverride_Original
-                    ? !g_pendingMeasureOverride
-                    : !g_pendingFrameSizeChange) {
+            if (!g_pendingMeasureOverride) {
                 break;
             }
 
@@ -682,7 +719,6 @@ void ApplySettings(int taskbarHeight) {
         }
     }
 
-    g_pendingFrameSizeChange = true;
     g_pendingMeasureOverride = true;
 
     g_taskbarHeight = taskbarHeight;
@@ -698,8 +734,7 @@ void ApplySettings(int taskbarHeight) {
 
     // Wait for the change to apply.
     for (int i = 0; i < 100; i++) {
-        if (TaskbarFrame_MeasureOverride_Original ? !g_pendingMeasureOverride
-                                                  : !g_pendingFrameSizeChange) {
+        if (!g_pendingMeasureOverride) {
             break;
         }
 
@@ -934,7 +969,14 @@ bool HookSymbols(HMODULE module,
 
             if (noAddressMatchCount == symbolHooks[i].symbols.size()) {
                 Wh_Log(L"Optional symbol %d doesn't exist (from cache)", i);
+
                 symbolResolved[i] = true;
+
+                for (auto hookSymbol : symbolHooks[i].symbols) {
+                    newSystemCacheStr += cacheSep;
+                    newSystemCacheStr += hookSymbol;
+                    newSystemCacheStr += cacheSep;
+                }
             }
         }
 
@@ -1198,13 +1240,28 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
                 true,  // Gone in KB5040527 (Taskbar.View.dll 2124.16310.10.0).
             },
             {
-                {LR"(public: static double __cdecl winrt::Taskbar::implementation::TaskbarConfiguration::GetIconHeightInViewPixels(enum winrt::WindowsUdk::UI::Shell::TaskbarSize))"},
+                {
+                    LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListGroupViewModel,struct winrt::Taskbar::ITaskbarAppItemViewModel>::GetIconHeight(void *,double *))",
+                    LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListGroupViewModel,struct winrt::Taskbar::ITaskbarAppItemViewModel>::GetIconHeight(void * __ptr64,double * __ptr64) __ptr64)",
+                },
+                (void**)&TaskListGroupViewModel_GetIconHeight_Original,
+                (void*)TaskListGroupViewModel_GetIconHeight_Hook,
+                true,  // Missing in older Windows 11 versions.
+            },
+            {
+                {
+                    LR"(public: static double __cdecl winrt::Taskbar::implementation::TaskbarConfiguration::GetIconHeightInViewPixels(enum winrt::WindowsUdk::UI::Shell::TaskbarSize))",
+                    LR"(public: static double __cdecl winrt::Taskbar::implementation::TaskbarConfiguration::GetIconHeightInViewPixels(enum winrt::WindowsUdk::UI::Shell::TaskbarSize) __ptr64)",
+                },
                 (void**)&TaskbarConfiguration_GetIconHeightInViewPixels_taskbarSizeEnum_Original,
                 (void*)
                     TaskbarConfiguration_GetIconHeightInViewPixels_taskbarSizeEnum_Hook,
             },
             {
-                {LR"(public: static double __cdecl winrt::Taskbar::implementation::TaskbarConfiguration::GetIconHeightInViewPixels(double))"},
+                {
+                    LR"(public: static double __cdecl winrt::Taskbar::implementation::TaskbarConfiguration::GetIconHeightInViewPixels(double))",
+                    LR"(public: static double __cdecl winrt::Taskbar::implementation::TaskbarConfiguration::GetIconHeightInViewPixels(double) __ptr64)",
+                },
                 (void**)&TaskbarConfiguration_GetIconHeightInViewPixels_double_Original,
                 (void*)
                     TaskbarConfiguration_GetIconHeightInViewPixels_double_Hook,
@@ -1217,7 +1274,7 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
                 },
                 (void**)&SystemTrayController_GetFrameSize_Original,
                 (void*)SystemTrayController_GetFrameSize_Hook,
-                true,  // From Windows 11 version 22H2.
+                true,  // From Windows 11 version 22H2, inlined sometimes.
             },
             {
                 {
@@ -1239,24 +1296,12 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
             },
             {
                 {
-                    LR"(public: __cdecl winrt::impl::consume_Windows_UI_Xaml_IFrameworkElement<struct winrt::Taskbar::implementation::TaskbarFrame>::MaxHeight(double)const )",
-                    LR"(public: __cdecl winrt::impl::consume_Windows_UI_Xaml_IFrameworkElement<struct winrt::Taskbar::implementation::TaskbarFrame>::MaxHeight(double)const __ptr64)",
+                    LR"(private: void __cdecl winrt::SystemTray::implementation::SystemTrayController::UpdateFrameSize(void))",
+                    LR"(private: void __cdecl winrt::SystemTray::implementation::SystemTrayController::UpdateFrameSize(void) __ptr64)",
                 },
-                (void**)&TaskbarFrame_MaxHeight_double_Original,
-                nullptr,
-                true,  // From Windows 11 version 22H2.
-            },
-            {
-                {
-                    LR"(public: __cdecl winrt::impl::consume_Windows_UI_Xaml_IFrameworkElement<struct winrt::Taskbar::implementation::TaskbarFrame>::Height(double)const )",
-                    LR"(public: __cdecl winrt::impl::consume_Windows_UI_Xaml_IFrameworkElement<struct winrt::Taskbar::implementation::TaskbarFrame>::Height(double)const __ptr64)",
-
-                    // Windows 11 version 21H2.
-                    LR"(public: void __cdecl winrt::impl::consume_Windows_UI_Xaml_IFrameworkElement<struct winrt::Taskbar::implementation::TaskbarFrame>::Height(double)const )",
-                    LR"(public: void __cdecl winrt::impl::consume_Windows_UI_Xaml_IFrameworkElement<struct winrt::Taskbar::implementation::TaskbarFrame>::Height(double)const __ptr64)",
-                },
-                (void**)&TaskbarFrame_Height_double_Original,
-                (void*)TaskbarFrame_Height_double_Hook,
+                (void**)&SystemTrayController_UpdateFrameSize_SymbolAddress,
+                nullptr,  // Hooked manually, we need the symbol address.
+                true,     // Missing in older Windows 11 versions.
             },
             {
                 {
@@ -1265,7 +1310,7 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
                 },
                 (void**)&SystemTraySecondaryController_UpdateFrameSize_Original,
                 (void*)SystemTraySecondaryController_UpdateFrameSize_Hook,
-                true,
+                true,  // Missing in older Windows 11 versions.
             },
             {
                 {
@@ -1274,24 +1319,15 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
                 },
                 (void**)&SystemTrayFrame_Height_Original,
                 (void*)SystemTrayFrame_Height_Hook,
-                true,
+                true,  // From Windows 11 version 22H2.
             },
             {
                 {
-                    LR"(private: void __cdecl winrt::Taskbar::implementation::TaskbarController::OnFrameSizeChanged(void))",
-                    LR"(private: void __cdecl winrt::Taskbar::implementation::TaskbarController::OnFrameSizeChanged(void) __ptr64)",
-                },
-                (void**)&TaskbarController_OnFrameSizeChanged_Original,
-                (void*)TaskbarController_OnFrameSizeChanged_Hook,
-            },
-            {
-                {
-                    LR"(public: struct winrt::Windows::Foundation::Size __cdecl winrt::Taskbar::implementation::TaskbarFrame::MeasureOverride(struct winrt::Windows::Foundation::Size))",
-                    LR"(public: struct winrt::Windows::Foundation::Size __cdecl winrt::Taskbar::implementation::TaskbarFrame::MeasureOverride(struct winrt::Windows::Foundation::Size) __ptr64)",
+                    LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarFrame,struct winrt::Windows::UI::Xaml::IFrameworkElementOverrides>::MeasureOverride(struct winrt::Windows::Foundation::Size,struct winrt::Windows::Foundation::Size *))",
+                    LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarFrame,struct winrt::Windows::UI::Xaml::IFrameworkElementOverrides>::MeasureOverride(struct winrt::Windows::Foundation::Size,struct winrt::Windows::Foundation::Size * __ptr64) __ptr64)",
                 },
                 (void**)&TaskbarFrame_MeasureOverride_Original,
                 (void*)TaskbarFrame_MeasureOverride_Hook,
-                true,  // From Windows 11 version 22H2.
             },
             {
                 {
@@ -1312,8 +1348,19 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
             },
         };
 
-    return HookSymbolsWithOnlineCacheFallback(module, symbolHooks,
-                                              ARRAYSIZE(symbolHooks));
+    if (!HookSymbolsWithOnlineCacheFallback(module, symbolHooks,
+                                            ARRAYSIZE(symbolHooks))) {
+        return false;
+    }
+
+    if (SystemTrayController_UpdateFrameSize_SymbolAddress) {
+        Wh_SetFunctionHook(
+            (void*)SystemTrayController_UpdateFrameSize_SymbolAddress,
+            (void*)SystemTrayController_UpdateFrameSize_Hook,
+            (void**)&SystemTrayController_UpdateFrameSize_Original);
+    }
+
+    return true;
 }
 
 bool HookTaskbarDllSymbols() {


### PR DESCRIPTION
* Added support for Windows 11 version 24H2.