### PR TITLE
Adjustment for painting multi-row horisontal taskbar that is fully populated in all rows

### DIFF
--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -65,11 +65,24 @@ I would like to thank @Anixx for testing the mod during its development and illu
 // ==/WindhawkModSettings==
 
 
+#include <windowsx.h>
+#include <winnt.h>      //defines HRESULT, needed for Visual Studio intellisense only, in clang the HRESULT seems to be defined already elsewhere, but the include does not harm either
+//#include <uxtheme.h>    //currently not needed since we use our own declaration of DrawThemeParentBackground and DrawThemeParentBackgroundEx
+
 #include <map>
 #include <mutex>
 #include <new>          //std::nothrow
-#include <windowsx.h>
-#include <uxtheme.h>
+
+
+
+template <typename T>
+BOOL Wh_SetFunctionHookT(
+    FARPROC targetFunction,
+    T hookFunction,
+    T* originalFunction
+) {
+    return Wh_SetFunctionHook((void*)targetFunction, (void*)hookFunction, (void**)originalFunction);
+}
 
 
 //clang compiler does not have these macros defined. Definitions taken from <minwindef.h>
@@ -92,16 +105,6 @@ enum class CompatWithTaskbarButtonsModsConfig {
     classicTaskbarButtonsLite,
     no
 };
-
-
-template <typename T>
-BOOL Wh_SetFunctionHookT(
-    FARPROC targetFunction,
-    T hookFunction,
-    T* originalFunction
-) {
-    return Wh_SetFunctionHook((void*)targetFunction, (void*)hookFunction, (void**)originalFunction);
-}
 
 
 const COLORREF black = RGB(0, 0, 0);

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -54,12 +54,6 @@ After:
 #include <windowsx.h>
 
 
-#ifndef WH_MOD
-#define WH_MOD
-#include <mods_api.h>
-#endif
-
-
 enum class RepaintDesktopButtonConfig {
     yes,
     highlightOnHover,

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -67,6 +67,7 @@ I would like to thank @Anixx for testing the mod during its development and illu
 
 #include <map>
 #include <mutex>
+#include <new>          //std::nothrow
 #include <windowsx.h>
 #include <uxtheme.h>
 
@@ -321,7 +322,7 @@ void ConditionalFillRect(HDC hdc, const RECT& rect, COLORREF oldColor, COLORREF 
                     bmi.bmiHeader.biBitCount = 32;  //32-bit color depth
                     bmi.bmiHeader.biCompression = BI_RGB;
 
-                    COLORREF* pixels = new COLORREF[pixelCount];
+                    COLORREF* pixels = new(std::nothrow) COLORREF[pixelCount];
                     if (!pixels) {
                         Wh_Log(L"Allocating pixels array failed");
                     }

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -278,7 +278,7 @@ BOOL Wh_ModInit() {
 
 
     bool abort = false;
-    if (TryInit(&abort, /*canTriggerRepaint*/false)) {    //NB! calling Wh_ApplyHookOperations() is not allowed during Wh_ModInit()
+    if (TryInit(&abort, /*canTriggerRepaint*/false)) {    //NB! calling TriggerTaskbarRepaint() would be premature during Wh_ModInit()
         //set hooks at the end and then exit the function
     }
     else if (abort) {

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -305,7 +305,7 @@ BOOL Wh_ModInit() {
             /*dwStackSize = */0,
             InitThreadFunc,
             /*lpParameter = */NULL,
-            /*dwCreationFlags = */CREATE_SUSPENDED, 	//The thread does NOT run immediately after creation. This is in order to avoid any race conditions in calling Wh_ApplyHookOperations() before Wh_ModInit() has completed and Wh_ModAfterInit() has started
+            /*dwCreationFlags = */CREATE_SUSPENDED, 	//The thread does NOT run immediately after creation. This is in order to avoid any race conditions in calling TriggerTaskbarRepaint() from the thread before Wh_ModInit() has completed and hooks are activated
             /*lpThreadId = */NULL
         );
 

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -74,7 +74,8 @@ bool WindowNeedsBackgroundRepaint(HWND hWnd) {
     WCHAR szClassName[32];
     if (hWnd && GetClassName(hWnd, szClassName, ARRAYSIZE(szClassName))) {
         return
-            _wcsicmp(szClassName, L"Shell_TrayWnd") == 0        //around of start button
+            _wcsicmp(szClassName, L"Shell_TrayWnd") == 0
+            || _wcsicmp(szClassName, L"Start") == 0                     //around of start button
             || _wcsicmp(szClassName, L"Shell_SecondaryTrayWnd") == 0        //secondary taskbar
             || _wcsicmp(szClassName, L"MSTaskListWClass") == 0      //around of taskbar buttons
             || _wcsicmp(szClassName, L"TrayNotifyWnd") == 0     //around of tray

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -563,12 +563,12 @@ BOOL WINAPI DrawFrameControlHook(
 
                     if (g_compatWithTaskbarButtonsModsConfig == CompatWithTaskbarButtonsModsConfig::classicTaskbarButtonsLite) {
 
-                        fillRect.left = max(fillRect.left - 2, hdcRect.left);
-                        fillRect.right = min(fillRect.right + 2, hdcRect.right);
+                        fillRect.left = max(fillRect.left - 3, hdcRect.left);
+                        fillRect.right = min(fillRect.right + 3, hdcRect.right);
                     }
                     else {
-                        fillRect.left = max(fillRect.left - 1, hdcRect.left);  
-                        fillRect.right = min(fillRect.right + 1, hdcRect.right);
+                        fillRect.left = max(fillRect.left - 2, hdcRect.left);  
+                        fillRect.right = min(fillRect.right + 2, hdcRect.right);
                     }
                 }
 

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -2,7 +2,7 @@
 // @id              classic-taskbar-background-fix
 // @name            Classic Taskbar background fix
 // @description     Fixes Taskbar background in classic theme by replacing black background with a classic button face colour
-// @version         1.0
+// @version         1.0.1
 // @author          Roland Pihlakas
 // @github          https://github.com/levitation
 // @homepage        https://www.simplify.ee/
@@ -699,7 +699,11 @@ BOOL WINAPI DrawFrameControlHook(
                     //It is safe to extend the rect more pixels towards right since the buttons are always drawn in left to right order, so the extended rect does not overdraw the next button. 
                     //In contrast, it would not be safe to extend the rect towards left too much since that would overdraw the previous button.
 
-                    fillRect.right = min(fillRect.right + 10, hdcRect.right);
+                    //extend the rect by +3px or +4px at most in order to keep room for flood fill to spread in case of multi-row horisontal taskbar is fully populated in all rows
+                    if (callerIsClassicTaskbarButtonsLiteMod)
+                        fillRect.right = min(fillRect.right + 4, hdcRect.right);
+                    else
+                        fillRect.right = min(fillRect.right + 3, hdcRect.right);   
                 }
                 else {  //vertical taskbar
 

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -26,11 +26,11 @@ Fixes Taskbar background in classic theme by replacing black background with a c
 
 Before:
 
-![Before](https://github.com/levitation-opensource/my-windhawk-mods/screenshots/after-classic-taskbar-background-fix.png)
+![Before](https://raw.githubusercontent.com/levitation-opensource/my-windhawk-mods/main/screenshots/before-classic-taskbar-background-fix.png)
 
 After:
 
-![After](https://github.com/levitation-opensource/my-windhawk-mods/screenshots/before-classic-taskbar-background-fix.png)
+![After](https://raw.githubusercontent.com/levitation-opensource/my-windhawk-mods/main/screenshots/after-classic-taskbar-background-fix.png)
 */
 // ==/WindhawkModReadme==
 
@@ -324,6 +324,7 @@ void Wh_ModSettingsChanged() {
 void Wh_ModUninit() {
 
     Wh_Log(L"Uniniting...");
+
 
     if (g_initThread) {
 

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -1,0 +1,363 @@
+// ==WindhawkMod==
+// @id              classic-taskbar-background-fix
+// @name            Classic Taskbar background fix
+// @description     Fixes Taskbar background in classic theme by replacing black background with a classic button face colour
+// @version         1.0
+// @author          Roland Pihlakas
+// @github          https://github.com/levitation
+// @homepage        https://www.simplify.ee/
+// @compilerOptions -luser32 -lgdi32
+// @include         explorer.exe
+// ==/WindhawkMod==
+
+// Source code is published under The GNU General Public License v3.0.
+//
+// For bug reports and feature requests, please open an issue here:
+// https://github.com/levitation-opensource/my-windhawk-mods/issues
+//
+// For pull requests, development takes place here:
+// https://github.com/levitation-opensource/my-windhawk-mods/
+
+// ==WindhawkModReadme==
+/*
+# Classic Taskbar background fix
+
+Fixes Taskbar background in classic theme by replacing black background with a classic button face colour.
+
+Before:
+
+![Before](https://github.com/levitation-opensource/my-windhawk-mods/screenshots/after-classic-taskbar-background-fix.png)
+
+After:
+
+![After](https://github.com/levitation-opensource/my-windhawk-mods/screenshots/before-classic-taskbar-background-fix.png)
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- RepaintDesktopButton: yes
+  $name: Repaint the "Show desktop button"
+  $options:
+  - yes: Yes
+  - no: No
+*/
+// ==/WindhawkModSettings==
+
+
+#include <windowsx.h>
+
+
+#ifndef WH_MOD
+#define WH_MOD
+#include <mods_api.h>
+#endif
+
+
+template <typename T>
+BOOL Wh_SetFunctionHookT(
+    FARPROC targetFunction,
+    T hookFunction,
+    T* originalFunction
+) {
+    return Wh_SetFunctionHook((void*)targetFunction, (void*)hookFunction, (void**)originalFunction);
+}
+
+
+bool g_retryInitInAThread = false;
+HANDLE g_initThread = NULL;
+HANDLE g_initThreadStopSignal = NULL;
+
+bool g_repaintDesktopButton = false;
+
+
+typedef BOOL(WINAPI* EndPaint_t)(HWND, const PAINTSTRUCT*);
+EndPaint_t pOriginalEndPaint;
+
+
+bool WindowNeedsBackgroundRepaint(HWND hWnd) {
+
+    WCHAR szClassName[32];
+    if (hWnd && GetClassName(hWnd, szClassName, ARRAYSIZE(szClassName))) {
+        return
+            _wcsicmp(szClassName, L"Shell_TrayWnd") == 0        //around of start button
+            || _wcsicmp(szClassName, L"Shell_SecondaryTrayWnd") == 0        //secondary taskbar
+            || _wcsicmp(szClassName, L"MSTaskListWClass") == 0      //around of taskbar buttons
+            || _wcsicmp(szClassName, L"TrayNotifyWnd") == 0     //around of tray
+            || _wcsicmp(szClassName, L"Button") == 0        //three dots 
+            || _wcsicmp(szClassName, L"ToolbarWindow32") == 0      //tray icons
+            || _wcsicmp(szClassName, L"TrayClockWClass") == 0       //clock
+            || _wcsicmp(szClassName, L"TrayButton") == 0        //action center button
+            || (g_repaintDesktopButton && _wcsicmp(szClassName, L"TrayShowDesktopButtonWClass") == 0)   //show desktop button
+            ;
+    }
+    else {
+        return false;
+    }
+}
+
+void ConditionalFillRect(HDC hdc, const RECT& rect, COLORREF oldColor, COLORREF newColor) {
+
+    //create a compatible DC and bitmap
+    HDC memDC = CreateCompatibleDC(hdc);
+    HBITMAP memBitmap = CreateCompatibleBitmap(hdc, rect.right - rect.left, rect.bottom - rect.top);
+    HGDIOBJ oldBitmap = SelectObject(memDC, memBitmap);
+
+    //copy the existing content from hdc
+    BitBlt(memDC, 0, 0, rect.right - rect.left, rect.bottom - rect.top, hdc, rect.left, rect.top, SRCCOPY);
+
+    //get pixels array from bitmap
+    BITMAPINFO bmi = {};
+    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth = rect.right - rect.left;
+    bmi.bmiHeader.biHeight = -(rect.bottom - rect.top);     //negative height to ensure top-down bitmap
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;  //32-bit color depth
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    int pixelCount = (rect.right - rect.left) * (rect.bottom - rect.top);
+    COLORREF* pixels = new COLORREF[pixelCount];
+    GetDIBits(memDC, memBitmap, 0, rect.bottom - rect.top, pixels, &bmi, DIB_RGB_COLORS);
+
+    //modify the pixels
+    for (int i = 0; i < pixelCount; ++i) {
+        if (pixels[i] == oldColor)
+            pixels[i] = newColor;
+    }
+
+    //save pixels array back to bitmap
+    SetDIBits(memDC, memBitmap, 0, rect.bottom - rect.top, pixels, &bmi, DIB_RGB_COLORS);
+    delete[] pixels;
+
+    //blit the modified content back to hdc
+    BitBlt(hdc, rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, memDC, 0, 0, SRCCOPY);
+
+    //clean up
+    SelectObject(memDC, oldBitmap);
+    DeleteObject(memBitmap);
+    DeleteDC(memDC);
+}
+
+BOOL WINAPI EndPaintHook(
+    IN HWND                 hWnd,
+    IN const PAINTSTRUCT*   lpPaint
+) {
+    if (lpPaint && lpPaint->hdc && WindowNeedsBackgroundRepaint(hWnd)) {
+
+        COLORREF black = RGB(0, 0, 0);
+        COLORREF buttonFace = GetSysColor(COLOR_3DFACE);
+        if (buttonFace != black)
+            ConditionalFillRect(lpPaint->hdc, lpPaint->rcPaint, black, buttonFace);
+    }
+
+    return pOriginalEndPaint(hWnd, lpPaint);
+}
+
+
+void TriggerTaskbarRepaint(HWND hwndTaskbar) {
+
+    if (!hwndTaskbar) {     //is taskbar hwnd already detected?
+        hwndTaskbar = FindWindowW(L"Shell_TrayWnd", NULL);
+        Wh_Log(L"hwndTaskbar: 0x%llX", (long long)hwndTaskbar);
+    }
+
+    if (hwndTaskbar)
+        RedrawWindow(hwndTaskbar, NULL, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN);
+}
+
+bool TryInit(bool* abort, bool callApplyHookOperations) {
+
+    HWND hwndTaskbar = FindWindowW(L"Shell_TrayWnd", NULL);
+    Wh_Log(L"hwndTaskbar: 0x%llX", (long long)hwndTaskbar);
+    if (!hwndTaskbar)
+        return false;   //retry
+
+    DWORD taskbarProcessId;
+    if (!GetWindowThreadProcessId(hwndTaskbar, &taskbarProcessId))
+        return false;   //retry
+
+    Wh_Log(L"taskbarProcessId: %u", taskbarProcessId);
+    if (taskbarProcessId != GetCurrentProcessId()) {
+        Wh_Log(L"Not a taskbar process, not hooking");
+        *abort = true;
+        return false;
+    }
+
+
+    Wh_Log(L"Initialising hooks...");
+
+
+    HMODULE hUser32 = GetModuleHandle(L"user32.dll"); 	//when we reach here then we can be sure that user32.dll has been already loaded
+    if (!hUser32) {
+        Wh_Log(L"Loading user32.dll failed");
+        *abort = true;
+        return false;
+    }
+
+    FARPROC pEndPaint = GetProcAddress(hUser32, "EndPaint");
+    if (!pEndPaint) {
+        Wh_Log(L"Finding hookable functions from user32.dll failed");
+        *abort = true;
+        return false;
+    }
+
+
+    Wh_SetFunctionHookT(pEndPaint, EndPaintHook, &pOriginalEndPaint);
+
+
+    if (callApplyHookOperations)
+        Wh_ApplyHookOperations();   //we are running in a separate thread outside of Wh_ModInit() therefore need to call Wh_ApplyHookOperations manually
+
+
+    //apply the new colour immediately
+    TriggerTaskbarRepaint(hwndTaskbar);
+
+
+    Wh_Log(L"Initialising hooks done");
+
+    return true;
+}
+
+DWORD WINAPI InitThreadFunc(LPVOID param) {
+
+    Wh_Log(L"InitThreadFunc enter");
+
+    bool isRetry = false;
+retry:  //wait until taskbar has properly initialised in order to detect whether current process will become taskbar or not
+    if (isRetry) {
+        if (WaitForSingleObject(g_initThreadStopSignal, 1000) != WAIT_TIMEOUT) {
+            Wh_Log(L"Shutting down InitThreadFunc before success");
+            return FALSE;
+        }
+    }
+    isRetry = true;
+
+    bool abort = false;
+    if (TryInit(&abort, /*callApplyHookOperations*/true)) {
+        return TRUE;  //hooks done
+    }
+    else if (abort) {
+        return FALSE;   //if the taskbar process is already running then subsequent non-taskbar related explorer.exe instances will not be hooked
+    }
+    else {      //taskbar was not yet found, so we need to retry later
+        goto retry;
+    }
+}
+
+void Wh_ModAfterInit(void) {
+    //Run the hook thread only after Wh_ModAfterInit() has been called. This is in order to avoid race condition in calling Wh_ApplyHookOperations().
+    if (g_retryInitInAThread) {
+
+        if (ResumeThread(g_initThread)) {
+            Wh_Log(L"ResumeThread successful");
+            g_retryInitInAThread = false;
+        }
+        else {
+            Wh_Log(L"ResumeThread failed");
+        }
+    }
+}
+
+void LoadSettings() {
+
+    //config option to keep "show desktop" button black
+    //TODO: option to use some other colour, for example the colour of hidden tray icons popup panel background
+    PCWSTR configString = Wh_GetStringSetting(L"RepaintDesktopButton");
+    g_repaintDesktopButton = (wcscmp(configString, L"no") != 0);        //default is yes, so if it is not "no" then it is yes
+    Wh_FreeStringSetting(configString);     
+}
+
+BOOL Wh_ModInit() {
+
+    LoadSettings();
+
+    Wh_Log(L"Init");
+
+
+    bool abort = false;
+    if (TryInit(&abort, /*callApplyHookOperations*/false)) {    //NB! calling Wh_ApplyHookOperations() is not allowed during Wh_ModInit()
+        return TRUE;  //hooks done
+    }
+    else if (abort) {
+        return FALSE;   //if the taskbar process is already running then subsequent non-taskbar related explorer.exe instances will not be hooked
+    }
+    else {      //taskbar was not yet found, maybe it is still initialising in the current process, so we need to retry later
+        g_initThreadStopSignal = CreateEvent(
+            /*lpEventAttributes = */NULL,           // default security attributes
+            /*bManualReset = */TRUE,				// manual-reset event
+            /*bInitialState = */FALSE,              // initial state is nonsignaled
+            /*lpName = */NULL						// object name
+        );
+
+        if (!g_initThreadStopSignal) {
+            Wh_Log(L"CreateEvent failed");
+            return FALSE;
+        }
+
+        g_initThread = CreateThread(
+            /*lpThreadAttributes = */NULL,
+            /*dwStackSize = */0,
+            InitThreadFunc,
+            /*lpParameter = */NULL,
+            /*dwCreationFlags = */CREATE_SUSPENDED, 	//The thread does NOT run immediately after creation. This is in order to avoid any race conditions in calling Wh_ApplyHookOperations() before Wh_ModInit() has completed and Wh_ModAfterInit() has started     //TODO: is this concern important?
+            /*lpThreadId = */NULL
+        );
+
+        if (g_initThread) {
+            Wh_Log(L"InitThread created");
+            g_retryInitInAThread = true;
+            return TRUE;
+        }
+        else {
+            Wh_Log(L"CreateThread failed");
+            CloseHandle(g_initThreadStopSignal);
+            g_initThreadStopSignal = NULL;
+            return FALSE;
+        }
+    }
+}
+
+void Wh_ModSettingsChanged() {
+
+    Wh_Log(L"Wh_ModSettingsChanged");
+
+    LoadSettings();
+
+    //apply the updated colour immediately
+    TriggerTaskbarRepaint(NULL);
+}
+
+void Wh_ModUninit() {
+
+    Wh_Log(L"Uniniting...");
+
+    if (g_initThread) {
+
+        if (g_retryInitInAThread) {     //was the thread successfully resumed?
+            if (ResumeThread(g_initThread))
+                g_retryInitInAThread = false;
+        }
+
+        if (!g_retryInitInAThread) {     //was the thread successfully resumed?
+            SetEvent(g_initThreadStopSignal);
+            WaitForSingleObject(g_initThread, INFINITE);
+            CloseHandle(g_initThread);
+            g_initThread = NULL;
+        }
+    }
+
+    if (
+        g_initThreadStopSignal
+        && !g_retryInitInAThread     //was the thread successfully resumed?
+    ) {
+        CloseHandle(g_initThreadStopSignal);
+        g_initThreadStopSignal = NULL;
+    }
+
+
+    //apply the default colour immediately
+    TriggerTaskbarRepaint(NULL);
+
+
+    Wh_Log(L"Uninit complete");
+}

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -22,9 +22,9 @@
 /*
 # Classic Taskbar background fix
 
-Fixes Taskbar **background** in classic theme by replacing **black background** with a classic button face colour.
+Fixes Taskbar **background** in classic theme by replacing **black background** with a classic button face colour. 
 
-NB! This mod does not fix the buttons' colour, for that there are other mods available.
+NB! Install this mod only if you have issues with **black background** around taskbar buttons and tray icons, like illustrated in the picture below. This mod does not fix the buttons' colour, for that purpose there are other mods available.
 
 Before:
 

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -22,7 +22,9 @@
 /*
 # Classic Taskbar background fix
 
-Fixes Taskbar background in classic theme by replacing black background with a classic button face colour.
+Fixes Taskbar **background** in classic theme by replacing **black background** with a classic button face colour.
+
+NB! This mod does not fix the buttons' colour, for that there are other mods available.
 
 Before:
 

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -24,11 +24,9 @@
 
 Fixes Taskbar background in classic theme by replacing black background with a classic button face colour. 
 
-Install this mod if you have issues with black background around taskbar buttons and tray icons, like illustrated in the picture below. 
+Install this mod if you have issues with black background around taskbar buttons and tray icons, like illustrated in the pictures below.
 
-**Note**: This mod does not fix the buttons' appearance, for that purpose there are other mods available. This is by design, for you to be able to choose your favourite buttons mod.
-
-When combined with a classic Taskbar buttons mod, this Taskbar background mod can be considered as an alternative to installing the @valinet's modified version of OpenShell StartMenuDLL.dll.
+**When combined with some classic Taskbar buttons mod**, then this Taskbar background mod can be considered as an alternative to installing the @valinet's modified version of OpenShell StartMenuDLL.dll.
 
 Before:
 
@@ -36,16 +34,21 @@ Before:
 
 After:
 
-![After](https://raw.githubusercontent.com/levitation-opensource/my-windhawk-mods/main/screenshots/after-classic-taskbar-background-fix.png)
+![After](https://raw.githubusercontent.com/levitation-opensource/my-windhawk-mods/main/screenshots/after-classic-taskbar-background-fix.png) 
+
+
+## Note: This mod requires a complementary buttons mod to be activated
+
+**This mod does not fix the buttons' appearance, for that purpose there are other mods available. This is by design, for you to be able to choose your favourite buttons mod.** Currently known Windhawk buttons mods are "Classic Taskbar 3D buttons Lite" and "Classic Taskbar 3D buttons with extended compatibility". Both are 3D buttons mods. At the time of this mod's release, there is no flat buttons mod available, but hopefully there may appear such mod later.
 
 
 ## Mod configuration
 
-If you use 'Classic Taskbar 3D buttons Lite' and you have issues with vertical black lines around buttons then go to the settings of the current Taskbar background mod and under "Compatibility with classic Taskbar buttons mods" choose "Enhance compatibility with 'Classic Taskbar 3D buttons Lite'". Usually the presence of 'Classic Taskbar 3D buttons Lite' should be detected automatically, but if there will be forks which still have the same increased button spacing behaviour, then you may need to set this setting manually.
+If you use 'Classic Taskbar 3D buttons Lite' and you have issues with vertical black lines around buttons then go to the settings of the current Taskbar background mod and under "Compatibility with classic Taskbar buttons mods" choose "Enhance compatibility with 'Classic Taskbar 3D buttons Lite'". Usually the presence of 'Classic Taskbar 3D buttons Lite' should be detected automatically, but if there will be forks which still have the same increased button spacing behaviour, but a different mod id, then you may need to set this setting manually.
 
 
 ## Acknowledgements
-I would like to thank @Anixx for testing the mod during its development and illustrating the issues found.
+I would like to thank @Anixx and @OrthodoxWindows for testing the mod during its development and illustrating the issues found.
 */
 // ==/WindhawkModReadme==
 

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -48,12 +48,6 @@ After:
 #include <windowsx.h>
 
 
-#ifndef WH_MOD
-#define WH_MOD
-#include <mods_api.h>
-#endif
-
-
 template <typename T>
 BOOL Wh_SetFunctionHookT(
     FARPROC targetFunction,

--- a/mods/classic-taskbar-background-fix.wh.cpp
+++ b/mods/classic-taskbar-background-fix.wh.cpp
@@ -45,7 +45,7 @@ After:
   $options:
   - yes: Yes
   - highlightOnHover: Yes, and use highlight colour on mouse over
-  - windowBackgroundOnHover: Yes, and use window background colour on mouse over
+  - blackOnHover: Yes, and use black colour on mouse over
   - no: No
 */
 // ==/WindhawkModSettings==
@@ -60,7 +60,7 @@ After:
 enum class RepaintDesktopButtonConfig {
     yes,
     highlightOnHover,
-    windowBackgroundOnHover,
+    blackOnHover,
     no
 };
 
@@ -118,8 +118,8 @@ RepaintDesktopButtonConfig DesktopButtonConfigFromString(PCWSTR string) {
     else if (wcscmp(string, L"highlightOnHover") == 0) {
         return RepaintDesktopButtonConfig::highlightOnHover;
     }
-    else if (wcscmp(string, L"windowBackgroundOnHover") == 0) {
-        return RepaintDesktopButtonConfig::windowBackgroundOnHover;
+    else if (wcscmp(string, L"blackOnHover") == 0) {
+        return RepaintDesktopButtonConfig::blackOnHover;
     }
     else {
         return RepaintDesktopButtonConfig::yes;
@@ -135,9 +135,10 @@ bool WindowNeedsBackgroundRepaint(OUT int* colorIndex, HWND hWnd, const RECT* pa
         && GetClassNameW(hWnd, szClassName, ARRAYSIZE(szClassName))
     ) {
         if (
-            (
+            isDrawThemeParentBackgroundCall
+            && (
                 g_repaintDesktopButtonConfig == RepaintDesktopButtonConfig::highlightOnHover
-                || g_repaintDesktopButtonConfig == RepaintDesktopButtonConfig::windowBackgroundOnHover
+                || g_repaintDesktopButtonConfig == RepaintDesktopButtonConfig::blackOnHover
             )
             && _wcsicmp(szClassName, L"TrayShowDesktopButtonWClass") == 0
         ) {
@@ -156,7 +157,7 @@ bool WindowNeedsBackgroundRepaint(OUT int* colorIndex, HWND hWnd, const RECT* pa
                         if (g_repaintDesktopButtonConfig == RepaintDesktopButtonConfig::highlightOnHover)
                             *colorIndex = COLOR_HIGHLIGHT;
                         else
-                            *colorIndex = COLOR_WINDOW;
+                            *colorIndex = blackColorIndex;
                     }
                     else {
                         *colorIndex = COLOR_3DFACE;
@@ -167,7 +168,7 @@ bool WindowNeedsBackgroundRepaint(OUT int* colorIndex, HWND hWnd, const RECT* pa
             }
         }
         else if (
-            isDrawThemeParentBackgroundCall        //painting the "show desktop" button black agains since withtout it earlier calls to DrawThemeParentBackground would remove the black color from "show desktop" button as a side effect of painting other tray areas
+            isDrawThemeParentBackgroundCall        //painting the "show desktop" button black again since without it earlier calls to DrawThemeParentBackground would remove the black color from "show desktop" button as a side effect of painting other tray areas
             && g_repaintDesktopButtonConfig == RepaintDesktopButtonConfig::no
             && _wcsicmp(szClassName, L"TrayShowDesktopButtonWClass") == 0   //show desktop button
         ) {


### PR DESCRIPTION
Without this adjustment, small horisontal black lines appear at the end of taskbar buttons area in case of multi-row horisontal taskbar that is fully populated in all rows