### PR TITLE
Message Box Fix 2.0.0

### DIFF
--- a/mods/msg-box-font-fix.wh.cpp
+++ b/mods/msg-box-font-fix.wh.cpp
@@ -6,7 +6,7 @@
 // @author          aubymori
 // @github          https://github.com/aubymori
 // @include         *
-// @compilerOptions -luser32 -lgdi32 -lcomctl32
+// @compilerOptions -luser32 -lgdi32 -lcomctl32 -DWINVER=0x0A00
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==

--- a/mods/msg-box-font-fix.wh.cpp
+++ b/mods/msg-box-font-fix.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              msg-box-font-fix
 // @name            Message Box Fix
-// @description     Fixes the MessageBox font size and background
-// @version         1.5.0
+// @description     Fixes the MessageBox font size and optionally make them like Windows XP
+// @version         2.0.0
 // @author          aubymori
 // @github          https://github.com/aubymori
 // @include         *
@@ -12,15 +12,12 @@
 // ==WindhawkModReadme==
 /*
 # Message Box Fix
-Starting with Windows Vista, message boxes render the "Window" color in their upper half.
-
 Starting with Windows 10 1709, message boxes render their font size 1pt less than the
-user-defined size.\* You cannot just set this size higher, as many applications still query
-it, and will show up with bigger fonts.
+user-defined size. You cannot just set this size higher, as many applications still query
+the font with the user-defined size, and will show up with bigger fonts. Also, starting with
+Windows Vista, message boxes got a visual overhaul.
 
 This mod fixes both of those things.
-
-**This mod will only work on Windhawk v1.4 and greater.**
 
 **Before:**
 
@@ -31,289 +28,1120 @@ This mod fixes both of those things.
 
 ![After](https://raw.githubusercontent.com/aubymori/images/main/message-box-font-fix-after.png)
 ![After (classic)](https://raw.githubusercontent.com/aubymori/images/main/message-box-fix-after-classic.png)
-
-*\*Microsoft changed the way the font size was calculator for Per-Monitor V2 DPI awareness. It ALWAYS gets
-1pt below the font size, even when on a higher DPI. This is because Microsoft decided to do some weird math
-instead of just using `SystemParametersInfoForDpi` like a normal person.*
 */
 // ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
 /*
-- font: true
-  $name: Fix font size
-  $description: Fix the message box font being too small
 - background: false
-  $name: Remove "Window" background
-  $description: Remove the "Window" color from the background, much like XP and before
+  $name: Classic style
+  $description: Make message boxes look like Windows XP and before
 */
 // ==/WindhawkModSettings==
 
 #include <windhawk_utils.h>
 
-struct {
-    BOOL font;
-    BOOL background;
-} settings;
+HMODULE g_hUser32 = NULL;
+bool g_bClassic = false;
 
 /* Only available in Windows 10 version 1607 and greater. */
-typedef UINT (WINAPI *GetDpiForWindow_t)(HWND);
-GetDpiForWindow_t GetDpiForWindow;
+WINUSERAPI UINT WINAPI GetDpiForWindow(HWND hWnd);
+WINUSERAPI BOOL WINAPI SystemParametersInfoForDpi(UINT uiAction, UINT uiParam, PVOID pvParam, UINT fWinIni, UINT dpi);
 
-typedef BOOL (WINAPI *SystemParametersInfoForDpi_t)(UINT, UINT, PVOID, UINT, UINT);
-SystemParametersInfoForDpi_t SystemParametersInfoForDpi;
+/* Imported from win32u.dll */
+typedef DWORD (NTAPI *NtUserCallOneParam_t)(DWORD Param, DWORD Routine);
+NtUserCallOneParam_t NtUserCallOneParam = nullptr;
 
-/* Message box text windows that have been
-   subclassed for background removal.
-   
-   See WM_PAINT on MsgBoxTextSubclassProc. */
-std::vector<HWND> g_subclassed;
-
-typedef HFONT (__fastcall *GetMessageBoxFontForDpi_t)(UINT);
-GetMessageBoxFontForDpi_t GetMessageBoxFontForDpi_orig;
+HFONT (__fastcall *GetMessageBoxFontForDpi_orig)(UINT);
 HFONT __fastcall GetMessageBoxFontForDpi_hook(
     UINT nDpi
 )
 {
-    if (!settings.font)
-    {
-        return GetMessageBoxFontForDpi_orig(
-            nDpi
-        );
-    }
-
     NONCLIENTMETRICSW ncm;
     ncm.cbSize = sizeof(NONCLIENTMETRICSW);
-
-    BOOL bResult;
-    if (SystemParametersInfoForDpi)
-    {
-        bResult = SystemParametersInfoForDpi(
-            SPI_GETNONCLIENTMETRICS,
-            sizeof(NONCLIENTMETRICSW),
-            &ncm,
-            0,
-            nDpi
-        );
-    }
-    else
-    {
-        bResult = SystemParametersInfoW(
-            SPI_GETNONCLIENTMETRICS,
-            sizeof(NONCLIENTMETRICSW),
-            &ncm,
-            0
-        );
-    }
-
-    if (bResult)
+    if (SystemParametersInfoForDpi(
+        SPI_GETNONCLIENTMETRICS,
+        sizeof(NONCLIENTMETRICSW),
+        &ncm,
+        0,
+        nDpi
+    ))
     {
         return CreateFontIndirectW(&ncm.lfMessageFont);
     }
     return NULL;
 }
 
-LRESULT CALLBACK MsgBoxTextSubclassProc(
-    HWND      hWnd,
-    UINT      uMsg,
-    WPARAM    wParam,
-    LPARAM    lParam,
-    DWORD_PTR dwRefData
-)
+#pragma region "Classic style"
+
+typedef struct _MSGBOXDATA {
+    // BEGIN MSGBOXPARAMS
+    UINT        cbSize;
+    HWND        hwndOwner;
+    HINSTANCE   hInstance;
+    LPCWSTR     lpszText;
+    LPCWSTR     lpszCaption;
+    DWORD       dwStyle;
+    LPCWSTR     lpszIcon;
+    DWORD_PTR   dwContextHelpId;
+    MSGBOXCALLBACK      lpfnMsgBoxCallback;
+    DWORD       dwLanguageId;
+    // END MSGBOXPARAMS
+    HWND    HWNDOwner;
+    DWORD   dwPadding;
+    WORD    wLanguageId;
+    const INT *pidButton;
+    LPCWSTR *ppszButtonText;
+    DWORD   cButtons;
+    UINT    DefButton;
+    UINT    CancelId;
+    DWORD   dwTimeout;
+    HWND *phwndList;
+    DWORD   dwReserved[20];
+} MSGBOXDATA, *PMSGBOXDATA, *LPMSGBOXDATA;
+
+static CONST WCHAR szEmpty[] = L"";
+
+// IDs and such
+#define MAX_RES_STRING 256
+#define UNICODE_RLM 0x200F  // RIGHT-TO-LEFT MARK      (RLM)
+#define IDUSERICON      20
+#define BUTTONCODE	  0x80
+#define STATICCODE	  0x82
+#define SFI_PLAYEVENTSOUND 57
+
+// Macros
+#define MAXUSHORT       (0xFFFF)
+#define IS_PTR(p)       ((((ULONG_PTR)(p)) & ~MAXUSHORT) != 0)
+#define PTR_TO_ID(p)    ((USHORT)(((ULONG_PTR)(p)) & MAXUSHORT))
+#define SYSMET(i)               GetSystemMetrics( SM_##i )
+#define XPixFromXDU(x, cxChar)       MulDiv(x, cxChar, 4)
+#define YPixFromYDU(y, cyChar)       MulDiv(y, cyChar, 8)
+#define XDUFromXPix(x, cxChar)       MulDiv(x, 4, cxChar)
+#define YDUFromYPix(y, cyChar)       MulDiv(y, 8, cyChar)
+#define NextWordBoundary(p)     ((PBYTE)(p) + ((ULONG_PTR)(p) & 1))
+#define NextDWordBoundary(p)    ((PBYTE)(p) + ((ULONG_PTR)(-(LONG_PTR)(p)) & 3))
+#define USERGLOBALLOCK(h, p)   p = (LPWSTR)GlobalLock((HANDLE)(h))
+#define USERGLOBALUNLOCK(h)             GlobalUnlock((HANDLE)(h))
+#define max(a,b) (((a) > (b)) ? (a) : (b))
+#define min(a,b) (((a) < (b)) ? (a) : (b))
+
+// Dialog unit dimensions
+#define DU_OUTERMARGIN    7
+#define DU_INNERMARGIN    10
+#define DU_BTNGAP         4   // D.U. of space between buttons
+#define DU_BTNHEIGHT      14  // D.U. of button height
+#define DU_BTNWIDTH       50  // D.U. of minimum button width in a message box
+
+// Custom struct and function because we can't use gpsi
+typedef struct tagMSGBOXMETRICS
 {
-    if (settings.background)
+    WORD cxMsgFontChar;
+    WORD cyMsgFontChar;
+    WORD wMaxBtnSize;
+    HFONT hCaptionFont;
+    HFONT hMessageFont;
+} MSGBOXMETRICS, *LPMSGBOXMETRICS;
+MSGBOXMETRICS mbm;
+
+BOOL GetMessageBoxMetrics(LPMSGBOXMETRICS pmbm)
+{  
+    if (!pmbm)
+        return FALSE;
+
+    ZeroMemory(pmbm, sizeof(MSGBOXMETRICS));
+    BOOL succeeded = TRUE;
+    HDC hDesktopDC = GetDC(NULL);
+    HDC hMemDC = CreateCompatibleDC(hDesktopDC);
+
+    HFONT hf = GetMessageBoxFontForDpi_hook(GetDeviceCaps(hMemDC, LOGPIXELSX));
+    SelectObject(hMemDC, hf);
+
+    NONCLIENTMETRICSW ncm;
+    ncm.cbSize = sizeof(NONCLIENTMETRICSW);
+    SystemParametersInfoForDpi(
+        SPI_GETNONCLIENTMETRICS,
+        sizeof(ncm),
+        &ncm,
+        0,
+        GetDeviceCaps(hMemDC, LOGPIXELSX)
+    );
+    
+    TEXTMETRICW tm;
+    succeeded = GetTextMetricsW(hMemDC, &tm);
+    if (succeeded)
     {
-        switch (uMsg)
-        {
-            /* I literally could not find any style or anything that could
-               remove the background on this, so I just paint it myself.
-               Sorry. */
-            case WM_PAINT:
-            {
-                PAINTSTRUCT ps;
-                HDC hDC = BeginPaint(hWnd, &ps);
-
-                RECT rcClient;
-                GetClientRect(hWnd, &rcClient);
-
-                int len = GetWindowTextLengthW(hWnd) + 1;
-                LPWSTR szText = new WCHAR[len];
-                GetWindowTextW(hWnd, szText, len);
-
-                HFONT hfMsg;
-                if (settings.font || !GetDpiForWindow)
-                {
-                    hfMsg = GetMessageBoxFontForDpi_hook(
-                        GetDpiForWindow ? GetDpiForWindow(hWnd) : 96
-                    );
-                }
-                else
-                {
-                    hfMsg = GetMessageBoxFontForDpi_orig(GetDpiForWindow(hWnd));
-                }
-                HFONT hfOld = (HFONT)SelectObject(hDC, hfMsg);
-
-                SetBkMode(hDC, TRANSPARENT);
-                SetTextColor(hDC, GetSysColor(COLOR_BTNTEXT));
-
-                DRAWTEXTPARAMS dtp = { sizeof(DRAWTEXTPARAMS) };
-                dtp.uiLengthDrawn = wcslen(szText);
-
-                DrawTextExW(
-                    hDC,
-                    szText,
-                    -1,
-                    &rcClient,
-                    DT_LEFT | DT_WORDBREAK | DT_EDITCONTROL,
-                    &dtp
-                );
-
-                SelectObject(hDC, hfOld);
-                DeleteObject(hfMsg);
-                delete[] szText;
-                EndPaint(hWnd, &ps);
-                return 0;
-            }
-            case WM_DESTROY:
-                g_subclassed.erase(std::remove_if(
-                    g_subclassed.begin(),
-                    g_subclassed.end(),
-                    [hWnd](HWND hw)
-                    {
-                        return hw == hWnd;
-                    }
-                ));
-                return 0;
-        }
+        pmbm->cxMsgFontChar = tm.tmAveCharWidth;
+        pmbm->cyMsgFontChar = tm.tmHeight;
+        pmbm->wMaxBtnSize = XPixFromXDU(DU_BTNWIDTH, tm.tmAveCharWidth);
+        pmbm->hCaptionFont = CreateFontIndirectW(&ncm.lfCaptionFont);
+        pmbm->hMessageFont = hf;
     }
 
-    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+    DeleteDC(hMemDC);
+    ReleaseDC(NULL, hDesktopDC);
+    return succeeded;
 }
 
-typedef INT_PTR (CALLBACK *MB_DlgProc_t)(HWND, UINT, WPARAM, LPARAM);
-MB_DlgProc_t MB_DlgProc_orig;
-INT_PTR CALLBACK MB_DlgProc_hook(
-    HWND   hWnd,
-    UINT   uMsg,
+UINT MB_GetIconOrdNum(UINT rgBits)
+{
+    switch (rgBits & MB_ICONMASK) {
+    case MB_USERICON:
+    case MB_ICONHAND:
+        return PtrToUlong(IDI_HAND);
+
+    case MB_ICONQUESTION:
+        return PtrToUlong(IDI_QUESTION);
+
+    case MB_ICONEXCLAMATION:
+        return PtrToUlong(IDI_EXCLAMATION);
+
+    case MB_ICONASTERISK:
+        return PtrToUlong(IDI_ASTERISK);
+    }
+
+    return 0;
+}
+
+
+UINT MB_FindDlgTemplateSize(LPMSGBOXDATA lpmb)
+{
+    ULONG_PTR cbLen;
+    UINT cbT;
+    UINT i;
+    UINT wCount;
+
+    wCount = lpmb->cButtons;
+
+    /* Start with dialog header's size */
+    cbLen = (ULONG_PTR)NextWordBoundary(sizeof(DLGTEMPLATE) + sizeof(WCHAR));
+    cbLen = (ULONG_PTR)NextWordBoundary(cbLen + sizeof(WCHAR));
+    cbLen += wcslen(lpmb->lpszCaption) * sizeof(WCHAR) + sizeof(WCHAR);
+    cbLen += sizeof(WORD);                   // Font height
+    cbLen = (ULONG_PTR)NextDWordBoundary(cbLen);
+
+    /* Check if an icon is present */
+    if (lpmb->dwStyle & MB_ICONMASK)
+        cbLen += (ULONG_PTR)NextDWordBoundary(sizeof(DLGITEMTEMPLATE) + 7 * sizeof(WCHAR));
+
+    /* Find the number of buttons in the msg box */
+    for (i = 0; i < wCount; i++) {
+        cbLen = (ULONG_PTR)NextWordBoundary(cbLen + sizeof(DLGITEMTEMPLATE) +
+            (2 * sizeof(WCHAR)));
+        cbT = (wcslen(lpmb->ppszButtonText[i]) + 1) * sizeof(WCHAR);
+        cbLen = (ULONG_PTR)NextWordBoundary(cbLen + cbT);
+        cbLen += sizeof(WCHAR);
+        cbLen = (ULONG_PTR)NextDWordBoundary(cbLen);
+    }
+
+    /* Add in the space required for the text message (if there is one) */
+    if (lpmb->lpszText != NULL) {
+        cbLen = (ULONG_PTR)NextWordBoundary(cbLen + sizeof(DLGITEMTEMPLATE) +
+            (2 * sizeof(WCHAR)));
+        cbT = (wcslen(lpmb->lpszText) + 1) * sizeof(WCHAR);
+        cbLen = (ULONG_PTR)NextWordBoundary(cbLen + cbT);
+        cbLen += sizeof(WCHAR);
+        cbLen = (ULONG_PTR)NextDWordBoundary(cbLen);
+    }
+
+    return (UINT)cbLen;
+}
+
+LPBYTE MB_UpdateDlgHdr(
+    LPDLGTEMPLATE lpDlgTmp,
+    long lStyle,
+    long lExtendedStyle,
+    BYTE bItemCount,
+    int iX,
+    int iY,
+    int iCX,
+    int iCY,
+    LPWSTR lpszCaption,
+    int cchCaptionLen)
+{
+    LPTSTR lpStr;
+    RECT rc;
+
+    rc.left = iX + SYSMET(CXFIXEDFRAME) + SYSMET(CXPADDEDBORDER);
+    rc.top = iY + SYSMET(CYFIXEDFRAME) + SYSMET(CXPADDEDBORDER);
+    rc.right = iX + iCX - SYSMET(CXFIXEDFRAME) - SYSMET(CXPADDEDBORDER);
+    rc.bottom = iY + iCY - SYSMET(CYFIXEDFRAME) - SYSMET(CXPADDEDBORDER);
+    rc.top += SYSMET(CYCAPTION);
+
+    lpDlgTmp->style = lStyle;
+    lpDlgTmp->dwExtendedStyle = lExtendedStyle;
+    lpDlgTmp->cdit = bItemCount;
+    lpDlgTmp->x = XDUFromXPix(rc.left, mbm.cxMsgFontChar);
+    lpDlgTmp->y = YDUFromYPix(rc.top, mbm.cyMsgFontChar);
+    lpDlgTmp->cx = XDUFromXPix(rc.right - rc.left, mbm.cxMsgFontChar);
+    lpDlgTmp->cy = YDUFromYPix(rc.bottom - rc.top, mbm.cyMsgFontChar);
+
+    /*
+     * Move pointer to variable length fields.  No menu resource for
+     * message box, a zero window class (means dialog box class).
+     */
+    lpStr = (LPWSTR)(lpDlgTmp + 1);
+    *lpStr++ = 0;                           // Menu
+    lpStr = (LPWSTR)NextWordBoundary(lpStr);
+    *lpStr++ = 0;                           // Class
+    lpStr = (LPWSTR)NextWordBoundary(lpStr);
+
+    /*
+     * NOTE: iCaptionLen may be less than the length of the Caption string;
+     * So, DO NOT USE lstrcpy();
+     */
+    RtlCopyMemory(lpStr, lpszCaption, cchCaptionLen * sizeof(WCHAR));
+    lpStr += cchCaptionLen;
+    *lpStr++ = TEXT('\0');
+
+    /* Font height of 0x7FFF means use the message box font */
+    *lpStr++ = 0x7FFF;
+
+    return NextDWordBoundary(lpStr);
+}
+
+LPBYTE MB_UpdateDlgItem(
+    LPDLGITEMTEMPLATE lpDlgItem,
+    int iCtrlId,
+    long lStyle,
+    long lExtendedStyle,
+    int iX,
+    int iY,
+    int iCX,
+    int iCY,
+    LPWSTR lpszText,
+    UINT cchTextLen,
+    int iControlClass)
+{
+    LPWSTR lpStr;
+    BOOL fIsOrdNum;
+
+
+    lpDlgItem->x = XDUFromXPix(iX, mbm.cxMsgFontChar);
+    lpDlgItem->y = YDUFromYPix(iY, mbm.cyMsgFontChar);
+    lpDlgItem->cx = XDUFromXPix(iCX, mbm.cxMsgFontChar);
+    lpDlgItem->cy = YDUFromYPix(iCY, mbm.cyMsgFontChar);
+    lpDlgItem->id = (WORD)iCtrlId;
+    lpDlgItem->style = lStyle;
+    lpDlgItem->dwExtendedStyle = lExtendedStyle;
+
+    if (iControlClass == STATICCODE &&
+        (((lStyle & 0x0F) == SS_LEFT) || ((lStyle & 0x0F) == SS_RIGHT)))
+    {
+        lpDlgItem->cx++;
+        lpDlgItem->cy++;
+    }
+
+    lpStr = (LPWSTR)(lpDlgItem + 1);
+
+    *lpStr++ = 0xFFFF;
+    *lpStr++ = (BYTE)iControlClass;
+    lpStr = (LPWSTR)NextWordBoundary(lpStr);
+
+    fIsOrdNum = ((*lpszText == 0xFFFF) && (cchTextLen == sizeof(DWORD) / sizeof(WCHAR)));
+
+    RtlCopyMemory(lpStr, lpszText, cchTextLen * sizeof(WCHAR));
+    lpStr = lpStr + cchTextLen;
+    if (!fIsOrdNum)
+    {
+        *lpStr = TEXT('\0');
+        lpStr = (LPWSTR)NextWordBoundary(lpStr + 1);
+    }
+
+    *lpStr++ = 0;
+
+    return NextDWordBoundary(lpStr);
+}
+
+LPBYTE MB_AddPushButtons(
+    LPDLGITEMTEMPLATE  lpDlgTmp,
+    LPMSGBOXDATA       lpmb,
+    UINT               wLEdge,
+    UINT               wBEdge)
+{
+    UINT   wYValue;
+    UINT   i;
+    UINT   wHeight;
+    UINT   wCount = lpmb->cButtons;
+
+    wHeight = YPixFromYDU(DU_BTNHEIGHT, mbm.cyMsgFontChar);
+
+    wYValue = wBEdge - wHeight;         // Y coord for push buttons
+
+    for (i = 0; i < wCount; i++) {
+
+        lpDlgTmp = (LPDLGITEMTEMPLATE)MB_UpdateDlgItem(
+            lpDlgTmp,                       /* Ptr to template */
+            lpmb->pidButton[i],             /* Control Id */
+            WS_TABSTOP | WS_CHILD | WS_VISIBLE | (i == 0 ? WS_GROUP : 0) |
+            ((UINT)i == lpmb->DefButton ? BS_DEFPUSHBUTTON : BS_PUSHBUTTON),
+            0,
+            wLEdge,                         /* X coord */
+            wYValue,                        /* Y coord */
+            mbm.wMaxBtnSize,                /* CX */
+            wHeight,                        /* CY */
+            (LPWSTR)lpmb->ppszButtonText[i],        /* String for button */
+            (UINT)wcslen(lpmb->ppszButtonText[i]),/* Length */
+            BUTTONCODE);
+
+        /* Get the X coord for the next push button */
+        wLEdge += mbm.wMaxBtnSize + XPixFromXDU(DU_BTNGAP, mbm.cxMsgFontChar);
+    }
+
+    return (LPBYTE)lpDlgTmp;
+}
+
+void MB_CopyToClipboard(HWND hwndDlg)
+{
+    LPCWSTR lpszRead;
+    LPWSTR lpszAll, lpszWrite;
+    HANDLE hData;
+    static  CONST WCHAR   szLine[] = L"---------------------------\r\n";
+    UINT cBufSize, i, cWrote;
+    LPMSGBOXDATA lpmb;
+
+    if (!(lpmb = (LPMSGBOXDATA)GetWindowLongPtr(hwndDlg, GWLP_USERDATA))) {
+        return;
+    }
+
+    if (!OpenClipboard(hwndDlg)) {
+        return;
+    }
+
+    /*
+     * Calculate the buffer size:
+     *      - the message text can be all \n, that will become \r\n
+     *      - there are a few extra \r\n (that's why 8)
+     */
+    cBufSize = (lpmb->lpszCaption ? wcslen(lpmb->lpszCaption) : 0) +
+        (lpmb->lpszText ? 2 * wcslen(lpmb->lpszText) : 0) +
+        4 * sizeof(szLine) +
+        lpmb->cButtons * mbm.wMaxBtnSize +
+        8;
+
+    cBufSize *= sizeof(WCHAR);
+
+    if (!(hData = GlobalAlloc(LHND, (LONG)(cBufSize)))) {
+        goto CloseClip;
+    }
+
+    USERGLOBALLOCK(hData, lpszAll);
+
+    cWrote = wsprintf(lpszAll, L"%s%s\r\n%s",
+        szLine,
+        lpmb->lpszCaption ? lpmb->lpszCaption : L"",
+        szLine);
+
+    lpszWrite = lpszAll + cWrote;
+    lpszRead = lpmb->lpszText;
+    /*
+     * Change \n to \r\n in the text
+     */
+    for (i = 0; *lpszRead; i++) {
+
+        if (*lpszRead == L'\n')
+            *lpszWrite++ = L'\r';
+
+        *lpszWrite++ = *lpszRead++;
+    }
+
+    cWrote = wsprintf(lpszWrite, L"\r\n%s", szLine);
+    lpszWrite += cWrote;
+
+    /*
+     * Remove & from the button texts
+     */
+    for (i = 0; i < lpmb->cButtons; i++) {
+
+        lpszRead = lpmb->ppszButtonText[i];
+        while (*lpszRead) {
+            if (*lpszRead != L'&') {
+                *lpszWrite++ = *lpszRead;
+            }
+            lpszRead++;
+        }
+        *lpszWrite++ = L' ';
+        *lpszWrite++ = L' ';
+        *lpszWrite++ = L' ';
+    }
+    wsprintf(lpszWrite, L"\r\n%s\0", szLine);
+
+    USERGLOBALUNLOCK(hData);
+
+    EmptyClipboard();
+
+    SetClipboardData(CF_UNICODETEXT, hData);
+
+CloseClip:
+    CloseClipboard();
+
+}
+
+INT_PTR CALLBACK MB_DlgProc(
+    HWND hwndDlg,
+    UINT wMsg,
     WPARAM wParam,
-    LPARAM lParam
-)
+    LPARAM lParam)
 {
-    if (settings.background)
-    {
-        switch (uMsg)
-        {
-            case WM_CTLCOLORDLG:
-            case WM_CTLCOLORSTATIC:
-                return (INT_PTR)GetSysColorBrush(COLOR_3DFACE);
-            /* The static window used for the text must be subclassed
-               to completely override painting */
-            case WM_INITDIALOG:
-            {                   
-                HWND hTxt = GetDlgItem(hWnd, 0xFFFF);
-                if (WindhawkUtils::SetWindowSubclassFromAnyThread(hTxt, MsgBoxTextSubclassProc, NULL))
-                {
-                    g_subclassed.push_back(hTxt);
-                }
+    HWND hwndT;
+    int iCount;
+    LPMSGBOXDATA lpmb;
+    HWND hwndOwner;
+    PVOID lpfnCallback;
+    BOOL bTimedOut = FALSE;
 
-                return MB_DlgProc_orig(hWnd, uMsg, wParam, lParam);
-            }
-            case WM_PAINT:
-            {
-                PAINTSTRUCT ps;
-                BeginPaint(hWnd, &ps);
-                EndPaint(hWnd, &ps);
-                return TRUE;
+    switch (wMsg) {
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+        return DefWindowProcW(hwndDlg, WM_CTLCOLORMSGBOX,
+            wParam, lParam);
+
+    case WM_TIMER:
+        if (!bTimedOut) {
+            bTimedOut = TRUE;
+            EndDialog(hwndDlg, IDTIMEOUT);
+        }
+        break;
+
+    case WM_NCDESTROY:
+        if ((lpmb = (LPMSGBOXDATA)GetWindowLongPtr(hwndDlg, GWLP_USERDATA))) {
+            if (lpmb->dwTimeout != INFINITE) {
+                KillTimer(hwndDlg, 0);
+                lpmb->dwTimeout = INFINITE;
             }
         }
-    }
+        return DefWindowProcW(hwndDlg, wMsg,
+            wParam, lParam);
 
-    return MB_DlgProc_orig(hWnd, uMsg, wParam, lParam);
-}
 
-#define LoadIntSetting(NAME) settings.NAME = Wh_GetIntSetting(L ## #NAME)
-
-void LoadSettings(void)
-{
-    LoadIntSetting(font);
-    LoadIntSetting(background);
-}
-
-BOOL Wh_ModInit(void)
-{
-    LoadSettings();
-
-    HMODULE hUser32 = LoadLibraryW(L"user32.dll");
-    if (!hUser32)
+    case WM_INITDIALOG:
     {
-        MessageBoxW(
+        lpmb = (LPMSGBOXDATA)lParam;
+        SetWindowLongPtr(hwndDlg, GWLP_USERDATA, (ULONG_PTR)lParam);
+
+        if (lpmb->dwStyle & MB_TOPMOST) {
+            SetWindowPos(hwndDlg,
+                HWND_TOPMOST,
+                0, 0, 0, 0,
+                SWP_NOMOVE | SWP_NOSIZE);
+        }
+
+        if (lpmb->dwStyle & MB_USERICON) {
+            SendDlgItemMessage(hwndDlg, IDUSERICON, STM_SETICON, (WPARAM)(lpmb->lpszIcon), 0);
+            iCount = ALERT_SYSTEM_WARNING;
+        }
+        else {
+            /*
+             * Generate an alert notification
+             */
+            switch (lpmb->dwStyle & MB_ICONMASK) {
+            case MB_ICONWARNING:
+                iCount = ALERT_SYSTEM_WARNING;
+                break;
+
+            case MB_ICONQUESTION:
+                iCount = ALERT_SYSTEM_QUERY;
+                break;
+
+            case MB_ICONERROR:
+                iCount = ALERT_SYSTEM_ERROR;
+                break;
+
+            case MB_ICONINFORMATION:
+            default:
+                iCount = ALERT_SYSTEM_INFORMATIONAL;
+                break;
+            }
+        }
+
+        NotifyWinEvent(EVENT_SYSTEM_ALERT, hwndDlg, OBJID_ALERT, iCount);
+
+        hwndT = GetWindow(hwndDlg, GW_CHILD);
+        iCount = lpmb->DefButton;
+        while (iCount--)
+            hwndT = GetWindow(hwndT, GW_HWNDNEXT);
+
+        SetFocus(hwndT);
+
+        hwndT = hwndDlg;
+
+        if (lpmb->CancelId == 0) {
+            HMENU hMenu;
+
+            if (hMenu = GetSystemMenu(hwndDlg, FALSE)) {
+                DeleteMenu(hMenu, SC_CLOSE, (UINT)MF_BYCOMMAND);
+            }
+        }
+
+        if ((lpmb->dwStyle & MB_TYPEMASK) == MB_OK) {
+            hwndDlg = GetDlgItem(hwndDlg, IDOK);
+
+            if (hwndDlg != NULL) {
+                SetWindowLongPtr(hwndDlg, GWLP_ID, IDCANCEL);
+            }
+        }
+
+        if (lpmb->dwTimeout != INFINITE) {
+            if (SetTimer(hwndT, 0, lpmb->dwTimeout, NULL) == 0) {
+                /*
+                 * Couldn't create the timer, so "clear" out the timeout value
+                 * for future reference.
+                 */
+                lpmb->dwTimeout = INFINITE;
+            }
+        }
+
+        // hack because xp's positioning code is broken on 10
+        // this centers it properly
+        HMONITOR hm = MonitorFromWindow(hwndT, MONITOR_DEFAULTTOPRIMARY);
+        MONITORINFO mi;
+        mi.cbSize = sizeof(mi);
+        GetMonitorInfoW(hm, &mi);
+        RECT rc;
+        GetWindowRect(hwndT, &rc);
+        int x = (mi.rcWork.right - mi.rcWork.left) / 2;
+        x -= (rc.right - rc.left) / 2;
+        int y = (mi.rcWork.bottom - mi.rcWork.top) / 2;
+        y -= (rc.bottom - rc.top) /2;
+        SetWindowPos(
+            hwndT,
             NULL,
-            L"Failed to load user32.dll. There is something seriously wrong with either your Windows install or Windhawk.",
-            L"Windhawk: Message Box Fix",
-            MB_ICONERROR
+            x, y,
+            0, 0,
+            SWP_NOZORDER | SWP_NOSIZE
         );
+
         return FALSE;
     }
+    case WM_COMMAND:
+        switch (LOWORD(wParam)) {
+        case IDOK:
+        case IDCANCEL:
+            //
+            // Check if a control exists with the given ID; This
+            // check is needed because DlgManager returns IDCANCEL
+            // blindly when ESC is pressed even if a button with
+            // IDCANCEL is not present.
+            //
+            if (!GetDlgItem(hwndDlg, LOWORD(wParam)))
+                return FALSE;
 
-    GetDpiForWindow = (GetDpiForWindow_t)GetProcAddress(hUser32, "GetDpiForWindow");
-    SystemParametersInfoForDpi = (SystemParametersInfoForDpi_t)GetProcAddress(hUser32, "SystemParametersInfoForDpi");
 
-    WindhawkUtils::SYMBOL_HOOK hooks[] = {
-        {
-            {
-                L"struct HFONT__ * "
-                #ifdef _WIN64
-                L"__cdecl"
-                #else
-                L"__stdcall"
-                #endif
-                L" GetMessageBoxFontForDpi(unsigned int)"
-            },
-            &GetMessageBoxFontForDpi_orig,
-            GetMessageBoxFontForDpi_hook,
-            false
-        },
-        {
-            {
-                #ifdef _WIN64
-                L"__int64 __cdecl MB_DlgProc(struct HWND__ *,unsigned int,unsigned __int64,__int64)"
-                #else
-                L"int __stdcall MB_DlgProc(struct HWND__ *,unsigned int,unsigned int,long)"
-                #endif
-            },
-            &MB_DlgProc_orig,
-            MB_DlgProc_hook,
-            false
+            // else FALL THRO....This is intentional.
+        case IDABORT:
+        case IDIGNORE:
+        case IDNO:
+        case IDRETRY:
+        case IDYES:
+        case IDTRYAGAIN:
+        case IDCONTINUE:
+            EndDialog(hwndDlg, LOWORD(wParam));
+            break;
+
+        default:
+            return FALSE;
+            break;
         }
-    };
+        break;
 
-    if (!WindhawkUtils::HookSymbols(
-        hUser32,
-        hooks,
-        ARRAYSIZE(hooks)
-    ))
-    {
-        Wh_Log(L"Failed to hook one or more symbol functions");
+    case WM_COPY:
+        MB_CopyToClipboard(hwndDlg);
+        break;
+
+    default:
         return FALSE;
     }
 
     return TRUE;
 }
 
-/**
-  * Remove any subclasses from message box texts that are still there
-  * If we don't do this, programs with open message boxes will crash
-  */
-void Wh_ModUninit(void)
+int SoftModalMessageBox_XP(
+    LPMSGBOXDATA lpmb)
 {
-    size_t len = g_subclassed.size();
-    for (size_t i = 0; i < len; i++)
-    {
-        WindhawkUtils::RemoveWindowSubclassFromAnyThread(
-            g_subclassed[i],
-            MsgBoxTextSubclassProc
-        );
+    LPBYTE              lpDlgTmp;
+    int                 cyIcon, cxIcon;
+    int                 cxButtons;
+    int                 cxMBMax;
+    int                 cxText, cyText, xText;
+    int                 cxBox, cyBox;
+    int                 cxFoo, cxCaption;
+    int                 xMB, yMB;
+    HDC                 hdc;
+    DWORD               wIconOrdNum;
+    DWORD               wCaptionLen;
+    DWORD               wTextLen;
+    WORD                OrdNum[2];  // Must be an array or WORDs
+    RECT                rc;
+    RECT                rcWork;
+    HCURSOR             hcurOld;
+    DWORD               dwStyleMsg, dwStyleText;
+    DWORD               dwExStyleMsg = 0;
+    DWORD               dwStyleDlg;
+    HWND                hwndOwner;
+    LPWSTR              lpsz;
+    int                 iRetVal = 0;
+    HICON               hIcon;
+    HGLOBAL             hTemplate = NULL;
+    HGLOBAL             hCaption = NULL;
+    HGLOBAL             hText = NULL;
+    HINSTANCE           hInstMsg = lpmb->hInstance;
+    SIZE                size;
+    HFONT               hFontOld = NULL;
+    int                 cntMBox;
+    HMONITOR            hMonitor;
+    MONITORINFO         mi;
+
+    GetMessageBoxMetrics(&mbm);
+
+    dwStyleMsg = lpmb->dwStyle;
+
+    if (dwStyleMsg & MB_RIGHT) {
+        dwExStyleMsg |= WS_EX_RIGHT;
     }
+
+    if (!IS_PTR(lpmb->lpszCaption)) {
+        /*
+         * Won't ever be NULL because MessageBox sticks "Error!" on error.
+         */
+        if (hInstMsg && (hCaption = LocalAlloc(LPTR, MAX_RES_STRING * sizeof(WCHAR)))) {
+            lpsz = (LPWSTR)hCaption;
+            LoadString(hInstMsg, PTR_TO_ID(lpmb->lpszCaption), lpsz, MAX_RES_STRING);
+        }
+        else {
+            lpsz = NULL;
+        }
+
+        lpmb->lpszCaption = lpsz ? lpsz : szEmpty;
+    }
+
+    if (!IS_PTR(lpmb->lpszText)) {
+        // NULL not allowed
+        if (hInstMsg && (hText = LocalAlloc(LPTR, MAX_RES_STRING * sizeof(WCHAR)))) {
+            lpsz = (LPWSTR)hText;
+            LoadString(hInstMsg, PTR_TO_ID(lpmb->lpszText), lpsz, MAX_RES_STRING);
+        }
+        else {
+            lpsz = NULL;
+        }
+
+        lpmb->lpszText = lpsz ? lpsz : szEmpty;
+    }
+
+    if ((dwStyleMsg & MB_RTLREADING) ||
+        (lpmb->lpszText != NULL && (lpmb->lpszText[0] == UNICODE_RLM) &&
+            (lpmb->lpszText[1] == UNICODE_RLM))) {
+        //
+        // Set Mirroring so that MessageBox and its child controls
+        // get mirrored. Otherwise, the message box and its child controls
+        // are Left-To-Right.
+        //
+        dwExStyleMsg |= WS_EX_LAYOUTRTL;
+
+        //
+        // And turn off any conflicting flags.
+        //
+        dwExStyleMsg &= ~WS_EX_RIGHT;
+        if (dwStyleMsg & MB_RTLREADING) {
+            dwStyleMsg &= ~MB_RTLREADING;
+            dwStyleMsg ^= MB_RIGHT;
+        }
+    }
+
+    if ((dwStyleMsg & MB_ICONMASK) == MB_USERICON)
+        hIcon = LoadIcon(hInstMsg, lpmb->lpszIcon);
+    else
+        hIcon = NULL;
+
+    // For compatibility reasons, we still allow the message box to come up.
+    hwndOwner = lpmb->hwndOwner;
+
+getthedc:
+    // Check if we're out of cache DCs until robustness...
+    if (!(hdc = GetDCEx(NULL, NULL, DCX_WINDOW | DCX_CACHE))) {
+
+        /*
+         * The above call might fail for TIF_RESTRICTED processes
+         * so check for the DC from the owner window
+         */
+        if (!(hdc = GetDCEx(hwndOwner, NULL, DCX_WINDOW | DCX_CACHE)))
+            goto SMB_Exit;
+    }
+
+    // Figure out the types and dimensions of buttons
+    cxButtons = (lpmb->cButtons * mbm.wMaxBtnSize) + ((lpmb->cButtons - 1) * XPixFromXDU(DU_BTNGAP, mbm.cxMsgFontChar));
+
+    // Ditto for the icon, if there is one.  If not, cxIcon & cyIcon are 0.
+
+    if (wIconOrdNum = MB_GetIconOrdNum(dwStyleMsg)) {
+        cxIcon = SYSMET(CXICON) + XPixFromXDU(DU_INNERMARGIN, mbm.cxMsgFontChar);
+        cyIcon = SYSMET(CYICON);
+    }
+    else
+        cxIcon = cyIcon = 0;
+
+    hFontOld = (HFONT)SelectObject(hdc, mbm.hCaptionFont);
+
+    // Find the max between the caption text and the buttons
+    wCaptionLen = wcslen(lpmb->lpszCaption);
+    GetTextExtentPointW(hdc, lpmb->lpszCaption, wCaptionLen, &size);
+    cxCaption = size.cx + 2 * SYSMET(CXSIZE);
+
+    //
+    // The max width of the message box is 5/8 of the work area for most
+    // countries.  We will then try 6/8 and 7/8 if it won't fit.  Then
+    // we will use whole screen.
+    //
+    hMonitor = MonitorFromWindow(hwndOwner, MONITOR_DEFAULTTOPRIMARY);
+    mi.cbSize = sizeof(MONITORINFO);
+    GetMonitorInfoW(hMonitor, &mi);
+    CopyRect(&rcWork, &mi.rcWork);
+    cxMBMax = MulDiv(rcWork.right - rcWork.left, 5, 8);
+
+    cxFoo = 2 * XPixFromXDU(DU_OUTERMARGIN, mbm.cxMsgFontChar);
+
+    SelectObject(hdc, mbm.hMessageFont);
+
+    //
+    // If the text doesn't fit in 5/8, try 7/8 of the screen
+    //
+ReSize:
+    //
+    // The message box is as big as needed to hold the caption/text/buttons,
+    // but not bigger than the maximum width.
+    //
+
+    cxBox = cxMBMax - 2 * SYSMET(CXFIXEDFRAME);
+
+    // Ask DrawText for the right cx and cy
+    rc.left = 0;
+    rc.top = 0;
+    rc.right = cxBox - cxFoo - cxIcon;
+    rc.bottom = rcWork.bottom - rcWork.top;
+    cyText = DrawTextExW(hdc, (LPWSTR)lpmb->lpszText, -1, &rc,
+        DT_CALCRECT | DT_WORDBREAK | DT_EXPANDTABS |
+        DT_NOPREFIX | DT_EXTERNALLEADING | DT_EDITCONTROL, NULL);
+    //
+    // Make sure we have enough width to hold the buttons, in addition to
+    // the icon+text.  Always force the buttons.  If they don't fit, it's
+    // because the working area is small.
+    //
+    //
+    // The buttons are centered underneath the icon/text.
+    //
+    cxText = rc.right - rc.left + cxIcon + cxFoo;
+    cxBox = min(cxBox, max(cxText, cxCaption));
+    cxBox = max(cxBox, cxButtons + cxFoo);
+    cxText = cxBox - cxFoo - cxIcon;
+
+    //
+    // Now we know the text width for sure.  Really calculate how high the
+    // text will be.
+    //
+    rc.left = 0;
+    rc.top = 0;
+    rc.right = cxText;
+    rc.bottom = rcWork.bottom - rcWork.top;
+    cyText = DrawTextExW(hdc, (LPWSTR)lpmb->lpszText, -1, &rc, DT_CALCRECT | DT_WORDBREAK
+        | DT_EXPANDTABS | DT_NOPREFIX | DT_EXTERNALLEADING | DT_EDITCONTROL, NULL);
+
+    // Find the window size.
+    cxBox += 2 * SYSMET(CXFIXEDFRAME);
+    cyBox = 2 * SYSMET(CYFIXEDFRAME) + SYSMET(CYCAPTION) + YPixFromYDU(2 * DU_OUTERMARGIN +
+        DU_INNERMARGIN + DU_BTNHEIGHT, mbm.cyMsgFontChar);
+
+    cyBox += max(cyIcon, cyText);
+
+    //
+    // If the message box doesn't fit on the working area, we'll try wider
+    // sizes successively:  6/8 of work then 7/8 of screen.
+    //
+    if (cyBox > rcWork.bottom - rcWork.top) {
+        int cxTemp;
+
+        cxTemp = MulDiv(rcWork.right - rcWork.left, 6, 8);
+
+        if (cxMBMax == MulDiv(rcWork.right - rcWork.left, 5, 8)) {
+            cxMBMax = cxTemp;
+            goto ReSize;
+        }
+        else if (cxMBMax == cxTemp) {
+            // then let's try with rcMonitor
+            CopyRect(&rcWork, &mi.rcMonitor);
+            cxMBMax = MulDiv(rcWork.right - rcWork.left, 7, 8);
+            goto ReSize;
+        }
+    }
+
+    if (hFontOld) {
+        SelectObject(hdc, hFontOld);
+    }
+    ReleaseDC(NULL, hdc);
+
+    // Find the window position
+    // HELP: how the fuck do you get cntMBox in 10?
+    cntMBox = 0;// GetClientInfo()->pDeskInfo->cntMBox;
+
+    xMB = (rcWork.left + rcWork.right - cxBox) / 2 + (cntMBox * SYSMET(CXSIZE));
+    xMB = max(xMB, rcWork.left);
+    yMB = (rcWork.top + rcWork.bottom - cyBox) / 2 + (cntMBox * SYSMET(CYSIZE));
+    yMB = max(yMB, rcWork.top);
+
+    //
+    // Bottom, right justify if we're going off the screen--but leave a
+    // little gap.
+    //
+    if (xMB + cxBox > rcWork.right) {
+        xMB = rcWork.right - SYSMET(CXEDGE) - cxBox;
+    }
+
+    //
+    // Pin to the working area.  If it won't fit, then pin to the screen
+    // height.  Bottom justify it at least if too big even for that, so
+    // that the buttons are visible.
+    //
+    if (yMB + cyBox > rcWork.bottom) {
+        yMB = rcWork.bottom - SYSMET(CYEDGE) - cyBox;
+        if (yMB < rcWork.top) {
+            yMB = mi.rcMonitor.bottom - SYSMET(CYEDGE) - cyBox;
+        }
+    }
+
+    wTextLen = wcslen(lpmb->lpszText);
+
+    // Find out the memory required for the Dlg template and try to alloc it
+    hTemplate = LocalAlloc(LPTR, MB_FindDlgTemplateSize(lpmb));
+    if (!hTemplate) {
+        goto SMB_Exit;
+    }
+
+    lpDlgTmp = (LPBYTE)hTemplate;
+
+    //
+    // Setup the dialog style for the message box
+    //
+    dwStyleDlg = WS_POPUPWINDOW | WS_CAPTION | DS_ABSALIGN | DS_NOIDLEMSG |
+        DS_SETFONT | DS_3DLOOK;
+
+    if ((dwStyleMsg & MB_MODEMASK) == MB_SYSTEMMODAL) {
+        dwStyleDlg |= DS_SYSMODAL | DS_SETFOREGROUND;
+    }
+    else {
+        dwStyleDlg |= DS_MODALFRAME | WS_SYSMENU;
+    }
+
+    if (dwStyleMsg & MB_SETFOREGROUND) {
+        dwStyleDlg |= DS_SETFOREGROUND;
+    }
+
+    // Add the Header of the Dlg Template
+    // BOGUS !!!  don't ADD bools
+    lpDlgTmp = MB_UpdateDlgHdr((LPDLGTEMPLATE)lpDlgTmp, dwStyleDlg, dwExStyleMsg,
+        (BYTE)(lpmb->cButtons + (wIconOrdNum != 0) + (lpmb->lpszText != NULL)),
+        xMB, yMB, cxBox, cyBox, (LPWSTR)lpmb->lpszCaption, wCaptionLen);
+
+    //
+    // Center the buttons
+    //
+
+    cxFoo = (cxBox - 2 * SYSMET(CXFIXEDFRAME) - cxButtons) / 2;
+
+    lpDlgTmp = MB_AddPushButtons((LPDLGITEMTEMPLATE)lpDlgTmp, lpmb, cxFoo,
+        cyBox - SYSMET(CYCAPTION) - (2 * SYSMET(CYFIXEDFRAME)) -
+        YPixFromYDU(DU_OUTERMARGIN, mbm.cyMsgFontChar));
+
+    // Add Icon, if any, to the Dlg template
+    //
+    // The icon is always top justified.  If the text is shorter than the
+    // height of the icon, we center it.  Otherwise the text will start at
+    // the top.
+    //
+    if (wIconOrdNum) {
+        OrdNum[0] = 0xFFFF;  // To indicate that an Ordinal number follows
+        OrdNum[1] = (WORD)wIconOrdNum;
+
+        lpDlgTmp = MB_UpdateDlgItem((LPDLGITEMTEMPLATE)lpDlgTmp, IDUSERICON,        // Control Id
+            SS_ICON | WS_GROUP | WS_CHILD | WS_VISIBLE, 0,
+            XPixFromXDU(DU_OUTERMARGIN, mbm.cxMsgFontChar),   // X co-ordinate
+            YPixFromYDU(DU_OUTERMARGIN, mbm.cyMsgFontChar),   // Y co-ordinate
+            0, 0,          // For Icons, CX and CY are ignored, can be zero
+            (LPWSTR)OrdNum,    // Ordinal number of Icon
+            ARRAYSIZE(OrdNum), // Length of OrdNum
+            STATICCODE);
+    }
+
+    // Add the Text of the Message to the Dlg Template
+    if (lpmb->lpszText) {
+        //
+        // Center the text if shorter than the icon.
+        //
+        if (cyText >= cyIcon)
+            cxFoo = 0;
+        else
+            cxFoo = (cyIcon - cyText) / 2;
+
+        dwStyleText = SS_NOPREFIX | WS_GROUP | WS_CHILD | WS_VISIBLE | SS_EDITCONTROL;
+        if (dwStyleMsg & MB_RIGHT) {
+            dwStyleText |= SS_RIGHT;
+            xText = cxBox - (SYSMET(CXSIZE) + cxText);
+        }
+        else {
+            dwStyleText |= SS_LEFT;
+            xText = cxIcon + XPixFromXDU(DU_INNERMARGIN, mbm.cxMsgFontChar);
+        }
+
+        MB_UpdateDlgItem((LPDLGITEMTEMPLATE)lpDlgTmp, -1, dwStyleText, dwExStyleMsg, xText,
+            YPixFromYDU(DU_OUTERMARGIN, mbm.cyMsgFontChar) + cxFoo,
+            cxText, cyText,
+            (LPWSTR)lpmb->lpszText, wTextLen, STATICCODE);
+    }
+
+    // The dialog template is ready
+
+    //
+    // Set the normal cursor
+    //
+    hcurOld = SetCursor(LoadCursorW(NULL, IDC_ARROW));
+
+    lpmb->lpszIcon = (LPWSTR)hIcon;
+
+    if (!(lpmb->dwStyle & MB_USERICON))
+    {
+        int wBeep = LOWORD(lpmb->dwStyle & MB_ICONMASK);
+        NtUserCallOneParam(wBeep, SFI_PLAYEVENTSOUND);
+    }
+
+    iRetVal = (int)DialogBoxIndirectParamW(g_hUser32,
+        (LPCDLGTEMPLATEW)hTemplate, hwndOwner,
+        MB_DlgProc, (LPARAM)lpmb);
+
+    //
+    // Fix up return value
+    if (iRetVal == -1)
+        iRetVal = 0;                /* Messagebox should also return error */
+
+    //
+    // If the messagebox contains only OK button, then its ID is changed as
+    // IDCANCEL in MB_DlgProc; So, we must change it back to IDOK irrespective
+    // of whether ESC is pressed or Carriage return is pressed;
+    //
+    if (((dwStyleMsg & MB_TYPEMASK) == MB_OK) && iRetVal)
+        iRetVal = IDOK;
+
+
+    //
+    // Restore the previous cursor
+    //
+    if (hcurOld)
+        SetCursor(hcurOld);
+
+SMB_Exit:
+    if (hTemplate)
+    {
+        LocalFree(hTemplate);
+    }
+
+    if (hCaption)
+    {
+        LocalFree(hCaption);
+    }
+
+    if (hText)
+    {
+        LocalFree(hText);
+    }
+
+    if (mbm.hCaptionFont)
+    {
+        DeleteObject(mbm.hCaptionFont);
+    }
+
+    if (mbm.hMessageFont)
+    {
+        DeleteObject(mbm.hMessageFont);
+    }
+
+    return iRetVal;
+}
+
+int (WINAPI *SoftModalMessageBox_orig)(LPMSGBOXDATA);
+int WINAPI SoftModalMessageBox_hook(LPMSGBOXDATA lpmb)
+{
+    if (g_bClassic)
+        return SoftModalMessageBox_XP(lpmb);
+    return SoftModalMessageBox_orig(lpmb);
+}
+
+#pragma endregion // "Classic style"
+
+void LoadSettings(void)
+{
+    g_bClassic = Wh_GetIntSetting(L"background");
+}
+
+const WindhawkUtils::SYMBOL_HOOK user32DllHooks[] = {
+    {
+        {
+            L"struct HFONT__ * "
+#ifdef _WIN64
+            L"__cdecl"
+#else
+            L"__stdcall"
+#endif
+            L" GetMessageBoxFontForDpi(unsigned int)"
+        },
+        &GetMessageBoxFontForDpi_orig,
+        GetMessageBoxFontForDpi_hook,
+        false
+    }
+};
+
+BOOL Wh_ModInit(void)
+{
+    LoadSettings();
+
+    // Load undocumented NtUserCallOneParam function for playing message box sound
+    HMODULE hWin32U = GetModuleHandleW(L"win32u.dll");
+    if (!hWin32U)
+    {
+        Wh_Log(L"Failed to get handle to win32u.dll");
+        return FALSE;
+    }
+    NtUserCallOneParam = (NtUserCallOneParam_t)GetProcAddress(hWin32U, "NtUserCallOneParam");
+    if (!NtUserCallOneParam)
+    {
+        Wh_Log(L"Failed to find NtUserCallOneParam in win32u.dll");
+        return FALSE;
+    }
+
+    g_hUser32 = GetModuleHandleW(L"user32.dll");
+    void *SoftModalMessageBox = (void *)GetProcAddress(g_hUser32, "SoftModalMessageBox");
+    if (!SoftModalMessageBox)
+    {
+        Wh_Log(L"Failed to find SoftModalMessageBox in user32.dll");
+        return FALSE;
+    }
+
+    if (!Wh_SetFunctionHook(
+        SoftModalMessageBox,
+        (void *)SoftModalMessageBox_hook,
+        (void **)&SoftModalMessageBox_orig
+    ))
+    {
+        Wh_Log(L"Failed to hook SoftModalMessageBox in user32.dll");
+        return FALSE;
+    }
+
+    if (!WindhawkUtils::HookSymbols(
+        g_hUser32,
+        user32DllHooks,
+        ARRAYSIZE(user32DllHooks)
+    ))
+    {
+        Wh_Log(L"Failed to hook GetMessageBoxFontForDpi in user32.dll");
+        return FALSE;
+    }
+
+    return TRUE;
 }
 
 void Wh_ModSettingsChanged(void)


### PR DESCRIPTION
- Restructure code to match modern conventions
- Remove option to fix the font and make it always fix it; there's not much use to having it disabled.
- Revamp "Remove background" option
  - Renamed to "Classic style"
  - Now shows message boxes with Windows XP positioning and scaling
  - May break with per-monitor DPI, have not tested. Regardless, I don't think anyone using a Windows XP/2000 theme would want per-monitor DPI.

Here's what classic style looked like before:
![message-box-fix-after-classic](https://github.com/user-attachments/assets/bee4c2b2-2c00-47a4-a037-344fa208b4d8)

And now:
![image](https://github.com/user-attachments/assets/966d697d-a7d5-4d51-9da8-304bfd1fc4a4)
