### PR TITLE
Fix Qt scrollbar grippers 1.1: Fix control detection

### DIFF
--- a/mods/fix-qt-scrollbar-grippers.wh.cpp
+++ b/mods/fix-qt-scrollbar-grippers.wh.cpp
@@ -24,6 +24,13 @@ that.
 
 These were removed in Qt [because the developers thought that these changes wouldn't affect Windows 10](https://github.com/qt/qtbase/commit/5f5c342924a0d9a2856b2f2d6db373e25723f2b0).
 They were wrong.
+
+## How to enable the mod for a program
+This mod targets the Interactive Disassembler (IDA) by default. Other applications must be manually specified
+for injection.
+In Windhawk, go to the "Advanced" tab and scroll down to 
+"Custom process inclusion list". In that box, put the filename of the `.exe`. 
+The mod will immediately apply to those programs after you click "Save". 
 */
 // ==/WindhawkModReadme==
 

--- a/mods/fix-qt-scrollbar-grippers.wh.cpp
+++ b/mods/fix-qt-scrollbar-grippers.wh.cpp
@@ -26,8 +26,10 @@ These were removed in Qt [because the developers thought that these changes woul
 They were wrong.
 
 ## How to enable the mod for a program
+
 This mod targets the Interactive Disassembler (IDA) by default. Other applications must be manually specified
 for injection.
+
 In Windhawk, go to the "Advanced" tab and scroll down to 
 "Custom process inclusion list". In that box, put the filename of the `.exe`. 
 The mod will immediately apply to those programs after you click "Save". 


### PR DESCRIPTION
Previously, we attempted to draw the gripper overlay for any control that existed, not just scrollbars. This is because the control theme opened by the HTHEME was not checked. Now, we only try drawing scrollbar grippers if we know the control itself is a scrollbar.