### PR TITLE
Improved support for touch screens

### DIFF
--- a/mods/taskbar-empty-space-clicks.wh.cpp
+++ b/mods/taskbar-empty-space-clicks.wh.cpp
@@ -2094,9 +2094,16 @@ bool IsDoubleClick()
         return false;
     }
 
+    if (previousClick.hWnd != currentClick.hWnd)
+    {
+        return false;
+    }
+
+    UINT dpi = GetDpiForWindow(currentClick.hWnd);
+
     // Check if the current event is within the double-click time and distance
-    bool result = abs(previousClick.position.x - currentClick.position.x) <= GetSystemMetrics(SM_CXDOUBLECLK) &&
-                  abs(previousClick.position.y - currentClick.position.y) <= GetSystemMetrics(SM_CYDOUBLECLK) &&
+    bool result = abs(previousClick.position.x - currentClick.position.x) <= MulDiv(GetSystemMetrics(SM_CXDOUBLECLK), dpi, 96) &&
+                  abs(previousClick.position.y - currentClick.position.y) <= MulDiv(GetSystemMetrics(SM_CYDOUBLECLK), dpi, 96) &&
                   ((currentClick.timestamp - previousClick.timestamp) <= GetDoubleClickTime());
     return result;
 }
@@ -2117,12 +2124,11 @@ bool IsDoubleTap(const MouseClick &previousClick, const MouseClick &currentClick
 
     HWND hWnd = currentClick.hWnd;
     UINT dpi = GetDpiForWindow(hWnd);
-    float dpiScale = static_cast<float>(dpi) / 96.0f; // 96 DPI is the standard scaling factor
 
     // GetSystemMetrics(SM_CXDOUBLECLK) is suitable just for mouse, not really for touch
     const int MAX_POS_OFFSET_PX = 15;
     // if user has hi-res screen, every slight movement result in big pixel offset
-    const int MAX_POS_OFFSET_PX_SCALED = dpiScale * MAX_POS_OFFSET_PX;
+    const int MAX_POS_OFFSET_PX_SCALED = MulDiv(MAX_POS_OFFSET_PX, dpi, 96);
 
     // Check if the current event is within the double-click time and distance
     bool result = abs(previousClick.position.x - currentClick.position.x) <= MAX_POS_OFFSET_PX_SCALED &&

--- a/mods/taskbar-empty-space-clicks.wh.cpp
+++ b/mods/taskbar-empty-space-clicks.wh.cpp
@@ -21,7 +21,7 @@
 /*
 # Click on empty taskbar space
 
-This mod lets you assign an action to a mouse click on Windows taskbar. Double-click and middle-click actions are supported. This mod only modifies behaviour when empty space of the taskbar is clicked. Buttons, menus or other function of the taskbar are not affected. Both primary and secondary taskbars are supported.
+This mod lets you assign an action to a mouse click on Windows taskbar. Double-click and middle-click actions are supported. Additionally double tap and triple tap on touch screens are supported. This mod only modifies behaviour when empty space of the taskbar is clicked. Buttons, menus or other function of the taskbar are not affected. Both primary and secondary taskbars are supported.
 
 ## Supported actions:
 
@@ -65,7 +65,7 @@ If you have request for new functions, suggestions or you are experiencing some 
 // ==WindhawkModSettings==
 /*
 - doubleClickAction: ACTION_NOTHING
-  $name: Double click on empty space
+  $name: Double click / double tap on empty space
   $options:
   - ACTION_NOTHING: Nothing (default)
   - ACTION_SHOW_DESKTOP: Show desktop
@@ -80,7 +80,7 @@ If you have request for new functions, suggestions or you are experiencing some 
   - ACTION_SEND_KEYPRESS: Virtual key press
   - ACTION_START_PROCESS: Start application
 - middleClickAction: ACTION_NOTHING
-  $name: Middle click on empty space
+  $name: Middle click / triple tap on empty space
   $options:
   - ACTION_NOTHING: Nothing (default)
   - ACTION_SHOW_DESKTOP: Show desktop


### PR DESCRIPTION
Double tap on touch screens is now much more benevolent in terms of click position on the screen. It takes into account screen DPI since in hi-res screens (like my 14'' 4k laptop) the position diffs between clicks when performing double tap can be significant. Also, since middle mouse button click is not possible with touch and detecting touch gesture is quite cumbersome (to work reliably across both Windows 10 and Windows 11 taskbars), I implemented support for triple tap which activates middle mouse click action. Fixes https://github.com/m1lhaus/windhawk-mods/issues/11