### PR TITLE
Update hide-action-center-icon.wh.cpp

### DIFF
--- a/mods/hide-action-center-icon.wh.cpp
+++ b/mods/hide-action-center-icon.wh.cpp
@@ -2,7 +2,7 @@
 // @id              hide-action-center-icon
 // @name            Hide Action Center icon
 // @description     Hides Action Center icon from Win10 taskbar
-// @version         1.0.0
+// @version         1.0.1
 // @author          anixx
 // @github          https://github.com/Anixx
 // @include         explorer.exe

--- a/mods/hide-action-center-icon.wh.cpp
+++ b/mods/hide-action-center-icon.wh.cpp
@@ -10,9 +10,9 @@
 
 // ==WindhawkModReadme==
 /* 
-Removes the Action Center icon (cogwheel) from Win10 taskbar. After application of the mod,
+Removes the Action Center icon (cogwheel) from the Win10 taskbar, running under Winedows 10 or Windows 11. After application of the mod,
 File Explorer should be restarted.
-The code is based on the corresponding code from Explorer Patcher and can stop working in the future.
+The code is based on the corresponding code from Explorer Patcher.
 */
 // ==/WindhawkModReadme==
 


### PR DESCRIPTION
Will not stop working in the future as the Win10 taskbar will not get any changes.