### PR TITLE
Per-app Language Preferences 1.1

### DIFF
--- a/mods/per-app-language-preferences.wh.cpp
+++ b/mods/per-app-language-preferences.wh.cpp
@@ -154,7 +154,7 @@ BOOL Wh_ModInit() {
 void Wh_ModSettingsChanged() {
     Wh_Log(L">");
 
-    // determine_my_langid();
+    determine_my_langid();
 }
 
 // The mod is being unloaded, free all allocated resources.


### PR DESCRIPTION
The `GetUserDefaultUILanguage` is actually called very often in some apps such as `explorer.exe`. As I have observed, allocating the image path buffer and determining the language for each call can add much overhead. Now I choose to determine the language ID only once for each process at startup, and then return the pre-determined language ID for subsequent calls.

This approach seems to work fine, but may not be entirely correct. Please let me know if there is some better way of implementing this.