### PR TITLE
Disable Taskbar Thumbnails v1.1

### DIFF
--- a/mods/taskbar-thumbnails.wh.cpp
+++ b/mods/taskbar-thumbnails.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-thumbnails
 // @name            Disable Taskbar Thumbnails
 // @description     Disable taskbar thumbnails on hover, or replace them with a list
-// @version         1.0
+// @version         1.1
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -46,6 +46,9 @@ or a similar tool), enable the relevant option in the mod's settings.
   - thumbnails: Thumbnails
 - noTooltips: false
   $name: Disable tooltips on hover
+  $description: >-
+    Only works for classic thumbnail previews, not for the new Windows 11
+    implementation of thumbnail previews
 - oldTaskbarOnWin11: false
   $name: Customize the old taskbar on Windows 11
   $description: >-
@@ -55,6 +58,10 @@ or a similar tool), enable the relevant option in the mod's settings.
 // ==/WindhawkModSettings==
 
 #include <windhawk_utils.h>
+
+#include <psapi.h>
+
+#include <atomic>
 
 enum class Mode {
     disabled,
@@ -72,9 +79,43 @@ enum class WinVersion {
     Unsupported,
     Win10,
     Win11,
+    Win11_24H2,
 };
 
 WinVersion g_winVersion;
+
+std::atomic<bool> g_initialized;
+std::atomic<bool> g_explorerPatcherInitialized;
+
+using HoverFlyoutModel_TransitionToFlyoutVisibleState_t =
+    void(WINAPI*)(void* pThis, void* param1);
+HoverFlyoutModel_TransitionToFlyoutVisibleState_t
+    HoverFlyoutModel_TransitionToFlyoutVisibleState_Original;
+void WINAPI HoverFlyoutModel_TransitionToFlyoutVisibleState_Hook(void* pThis,
+                                                                 void* param1) {
+    Wh_Log(L">");
+
+    if (g_settings.mode == Mode::disabled) {
+        return;
+    }
+
+    HoverFlyoutModel_TransitionToFlyoutVisibleState_Original(pThis, param1);
+}
+
+using FlyoutFrame_CanFitAndUpdateScaleFactor_t = bool(WINAPI*)(void* pThis,
+                                                               void* param1);
+FlyoutFrame_CanFitAndUpdateScaleFactor_t
+    FlyoutFrame_CanFitAndUpdateScaleFactor_Original;
+bool WINAPI FlyoutFrame_CanFitAndUpdateScaleFactor_Hook(void* pThis,
+                                                        void* param1) {
+    Wh_Log(L">");
+
+    if (g_settings.mode == Mode::list) {
+        return false;
+    }
+
+    return FlyoutFrame_CanFitAndUpdateScaleFactor_Original(pThis, param1);
+}
 
 using CTaskListWnd__DisplayExtendedUI_t = HRESULT(WINAPI*)(void* pThis,
                                                            void* taskBtnGroup,
@@ -134,6 +175,87 @@ void WINAPI CTaskListWnd__ShowToolTip_Hook(void* pThis, DWORD flags) {
     CTaskListWnd__ShowToolTip_Original(pThis, flags);
 }
 
+bool HookTaskbarViewDllSymbols() {
+    WCHAR dllPath[MAX_PATH];
+    if (!GetWindowsDirectory(dllPath, ARRAYSIZE(dllPath))) {
+        Wh_Log(L"GetWindowsDirectory failed");
+        return false;
+    }
+
+    wcscat_s(
+        dllPath, MAX_PATH,
+        LR"(\SystemApps\MicrosoftWindows.Client.Core_cw5n1h2txyewy\Taskbar.View.dll)");
+
+    HMODULE module =
+        LoadLibraryEx(dllPath, nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
+    if (!module) {
+        Wh_Log(L"Taskbar view module couldn't be loaded");
+        return false;
+    }
+
+    // Taskbar.View.dll
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {LR"(private: void __cdecl winrt::Taskbar::implementation::HoverFlyoutModel::TransitionToFlyoutVisibleState(struct winrt::hstring))"},
+            &HoverFlyoutModel_TransitionToFlyoutVisibleState_Original,
+            HoverFlyoutModel_TransitionToFlyoutVisibleState_Hook,
+            true,  // New XAML thumbnails, enabled in late Windows 11 24H2.
+        },
+        {
+            {LR"(private: bool __cdecl winrt::Taskbar::implementation::FlyoutFrame::CanFitAndUpdateScaleFactor(struct winrt::Windows::Foundation::Collections::IVector<struct winrt::Windows::Foundation::IInspectable> const &))"},
+            &FlyoutFrame_CanFitAndUpdateScaleFactor_Original,
+            FlyoutFrame_CanFitAndUpdateScaleFactor_Hook,
+            true,  // New XAML thumbnails, enabled in late Windows 11 24H2.
+        },
+    };
+
+    if (!HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks))) {
+        Wh_Log(L"HookSymbols failed");
+        return false;
+    }
+
+    return true;
+}
+
+bool HookTaskbarSymbols() {
+    HMODULE module;
+    if (g_winVersion <= WinVersion::Win10) {
+        module = GetModuleHandle(nullptr);
+    } else {
+        module = LoadLibrary(L"taskbar.dll");
+        if (!module) {
+            Wh_Log(L"Couldn't load taskbar.dll");
+            return false;
+        }
+    }
+
+    // Taskbar.dll, explorer.exe
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {LR"(protected: long __cdecl CTaskListWnd::_DisplayExtendedUI(struct ITaskBtnGroup *,int,unsigned long,int))"},
+            &CTaskListWnd__DisplayExtendedUI_Original,
+            CTaskListWnd__DisplayExtendedUI_Hook,
+        },
+        {
+            {LR"(private: int __cdecl CTaskListThumbnailWnd::_CanShowThumbnails(class CDPA<struct ITaskThumbnail,class CTContainer_PolicyUnOwned<struct ITaskThumbnail> > const *,int,int))"},
+            &CTaskListThumbnailWnd__CanShowThumbnails_Original,
+            CTaskListThumbnailWnd__CanShowThumbnails_Hook,
+        },
+        {
+            {LR"(protected: void __cdecl CTaskListWnd::_ShowToolTip(enum ShowToolTipFlags))"},
+            &CTaskListWnd__ShowToolTip_Original,
+            CTaskListWnd__ShowToolTip_Hook,
+        },
+    };
+
+    if (!HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks))) {
+        Wh_Log(L"HookSymbols failed");
+        return false;
+    }
+
+    return true;
+}
+
 VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
     void* pFixedFileInfo = nullptr;
     UINT uPtrLen = 0;
@@ -178,13 +300,137 @@ WinVersion GetExplorerVersion() {
         case 10:
             if (build < 22000) {
                 return WinVersion::Win10;
-            } else {
+            } else if (build < 26100) {
                 return WinVersion::Win11;
+            } else {
+                return WinVersion::Win11_24H2;
             }
             break;
     }
 
     return WinVersion::Unsupported;
+}
+
+struct EXPLORER_PATCHER_HOOK {
+    PCSTR symbol;
+    void** pOriginalFunction;
+    void* hookFunction = nullptr;
+    bool optional = false;
+
+    template <typename Prototype>
+    EXPLORER_PATCHER_HOOK(
+        PCSTR symbol,
+        Prototype** originalFunction,
+        std::type_identity_t<Prototype*> hookFunction = nullptr,
+        bool optional = false)
+        : symbol(symbol),
+          pOriginalFunction(reinterpret_cast<void**>(originalFunction)),
+          hookFunction(reinterpret_cast<void*>(hookFunction)),
+          optional(optional) {}
+};
+
+bool HookExplorerPatcherSymbols(HMODULE explorerPatcherModule) {
+    if (g_explorerPatcherInitialized.exchange(true)) {
+        return true;
+    }
+
+    if (g_winVersion >= WinVersion::Win11) {
+        g_winVersion = WinVersion::Win10;
+    }
+
+    EXPLORER_PATCHER_HOOK hooks[] = {
+        {R"(?_DisplayExtendedUI@CTaskListWnd@@IEAAJPEAUITaskBtnGroup@@HKH@Z)",
+         &CTaskListWnd__DisplayExtendedUI_Original,
+         CTaskListWnd__DisplayExtendedUI_Hook},
+        {R"(?_CanShowThumbnails@CTaskListThumbnailWnd@@AEAAHPEBV?$CDPA@UITaskThumbnail@@V?$CTContainer_PolicyUnOwned@UITaskThumbnail@@@@@@HH@Z)",
+         &CTaskListThumbnailWnd__CanShowThumbnails_Original,
+         CTaskListThumbnailWnd__CanShowThumbnails_Hook},
+        {R"(?_ShowToolTip@CTaskListWnd@@IEAAXW4ShowToolTipFlags@@@Z)",
+         &CTaskListWnd__ShowToolTip_Original, CTaskListWnd__ShowToolTip_Hook},
+    };
+
+    bool succeeded = true;
+
+    for (const auto& hook : hooks) {
+        void* ptr = (void*)GetProcAddress(explorerPatcherModule, hook.symbol);
+        if (!ptr) {
+            Wh_Log(L"ExplorerPatcher symbol%s doesn't exist: %S",
+                   hook.optional ? L" (optional)" : L"", hook.symbol);
+            if (!hook.optional) {
+                succeeded = false;
+            }
+            continue;
+        }
+
+        if (hook.hookFunction) {
+            Wh_SetFunctionHook(ptr, hook.hookFunction, hook.pOriginalFunction);
+        } else {
+            *hook.pOriginalFunction = ptr;
+        }
+    }
+
+    if (!succeeded) {
+        Wh_Log(L"HookExplorerPatcherSymbols failed");
+    } else if (g_initialized) {
+        Wh_ApplyHookOperations();
+    }
+
+    return succeeded;
+}
+
+bool IsExplorerPatcherModule(HMODULE module) {
+    WCHAR moduleFilePath[MAX_PATH];
+    switch (
+        GetModuleFileName(module, moduleFilePath, ARRAYSIZE(moduleFilePath))) {
+        case 0:
+        case ARRAYSIZE(moduleFilePath):
+            return false;
+    }
+
+    PCWSTR moduleFileName = wcsrchr(moduleFilePath, L'\\');
+    if (!moduleFileName) {
+        return false;
+    }
+
+    moduleFileName++;
+
+    if (_wcsnicmp(L"ep_taskbar.", moduleFileName, sizeof("ep_taskbar.") - 1) ==
+        0) {
+        Wh_Log(L"ExplorerPatcher taskbar module: %s", moduleFileName);
+        return true;
+    }
+
+    return false;
+}
+
+bool HandleLoadedExplorerPatcher() {
+    HMODULE hMods[1024];
+    DWORD cbNeeded;
+    if (EnumProcessModules(GetCurrentProcess(), hMods, sizeof(hMods),
+                           &cbNeeded)) {
+        for (size_t i = 0; i < cbNeeded / sizeof(HMODULE); i++) {
+            if (IsExplorerPatcherModule(hMods[i])) {
+                return HookExplorerPatcherSymbols(hMods[i]);
+            }
+        }
+    }
+
+    return true;
+}
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t LoadLibraryExW_Original;
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
+                                   HANDLE hFile,
+                                   DWORD dwFlags) {
+    HMODULE module = LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
+    if (module && !((ULONG_PTR)module & 3) && !g_explorerPatcherInitialized) {
+        if (IsExplorerPatcherModule(module)) {
+            HookExplorerPatcherSymbols(module);
+        }
+    }
+
+    return module;
 }
 
 void LoadSettings() {
@@ -213,53 +459,61 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
-    if (g_winVersion >= WinVersion::Win11 && g_settings.oldTaskbarOnWin11) {
-        g_winVersion = WinVersion::Win10;
-    }
+    if (g_settings.oldTaskbarOnWin11) {
+        bool hasWin10Taskbar = g_winVersion < WinVersion::Win11_24H2;
 
-    // Taskbar.dll, explorer.exe
-    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
-        {
-            {
-                LR"(protected: long __cdecl CTaskListWnd::_DisplayExtendedUI(struct ITaskBtnGroup *,int,unsigned long,int))",
-            },
-            &CTaskListWnd__DisplayExtendedUI_Original,
-            CTaskListWnd__DisplayExtendedUI_Hook,
-        },
-        {
-            {
-                LR"(private: int __cdecl CTaskListThumbnailWnd::_CanShowThumbnails(class CDPA<struct ITaskThumbnail,class CTContainer_PolicyUnOwned<struct ITaskThumbnail> > const *,int,int))",
-            },
-            &CTaskListThumbnailWnd__CanShowThumbnails_Original,
-            CTaskListThumbnailWnd__CanShowThumbnails_Hook,
-        },
-        {
-            {
-                LR"(protected: void __cdecl CTaskListWnd::_ShowToolTip(enum ShowToolTipFlags))",
-            },
-            &CTaskListWnd__ShowToolTip_Original,
-            CTaskListWnd__ShowToolTip_Hook,
-        },
-    };
+        if (g_winVersion >= WinVersion::Win11) {
+            g_winVersion = WinVersion::Win10;
+        }
 
-    if (g_winVersion <= WinVersion::Win10) {
-        if (!HookSymbols(GetModuleHandle(nullptr), symbolHooks,
-                         ARRAYSIZE(symbolHooks))) {
+        if (hasWin10Taskbar && !HookTaskbarSymbols()) {
+            return FALSE;
+        }
+    } else if (g_winVersion >= WinVersion::Win11) {
+        // For the new XAML thumbnail.
+        if (g_winVersion >= WinVersion::Win11_24H2 &&
+            !HookTaskbarViewDllSymbols()) {
+            return FALSE;
+        }
+
+        if (!HookTaskbarSymbols()) {
             return FALSE;
         }
     } else {
-        HMODULE taskbarModule = LoadLibrary(L"taskbar.dll");
-        if (!taskbarModule) {
-            Wh_Log(L"Couldn't load taskbar.dll");
-            return FALSE;
-        }
-
-        if (!HookSymbols(taskbarModule, symbolHooks, ARRAYSIZE(symbolHooks))) {
+        if (!HookTaskbarSymbols()) {
             return FALSE;
         }
     }
 
+    if (!HandleLoadedExplorerPatcher()) {
+        Wh_Log(L"HandleLoadedExplorerPatcher failed");
+        return FALSE;
+    }
+
+    HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
+    auto pKernelBaseLoadLibraryExW = (decltype(&LoadLibraryExW))GetProcAddress(
+        kernelBaseModule, "LoadLibraryExW");
+    WindhawkUtils::Wh_SetFunctionHookT(pKernelBaseLoadLibraryExW,
+                                       LoadLibraryExW_Hook,
+                                       &LoadLibraryExW_Original);
+
+    g_initialized = true;
+
     return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    Wh_Log(L">");
+
+    // Try again in case there's a race between the previous attempt and the
+    // LoadLibraryExW hook.
+    if (!g_explorerPatcherInitialized) {
+        HandleLoadedExplorerPatcher();
+    }
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L">");
 }
 
 BOOL Wh_ModSettingsChanged(BOOL* bReload) {


### PR DESCRIPTION
* Added support for the new thumbnail previews implementation in Windows 11.
* Added support for the ExplorerPatcher taskbar.