### PR TITLE
Disable Virtual Desktop Transition Animations v1.1: Windows 11 support

### DIFF
--- a/mods/disable-virtual-desktop-transition.wh.cpp
+++ b/mods/disable-virtual-desktop-transition.wh.cpp
@@ -408,6 +408,7 @@ BOOL Wh_ModInit()
         );
 
         // On Windows 11, we install hooks into TWinUI.PCShell.
+        // twinui.pcshell.dll
         WindhawkUtils::SYMBOL_HOOK twinui_pcshellHooks[] = {
             {
                 {


### PR DESCRIPTION
This update adds support for Windows 11. I tested on `10.0.22631.2428`, but the Windows 11 approach is general enough that it should work for all versions.

In Windows 11, they moved the animation to reside in `TWinUI.PCShell.dll`, which is loaded into the main shell process `explorer.exe`. In Windows 10, it resided in `uDWM.dll` which ran in `dwm.exe`.