### PR TITLE
Add "Disable Windows Ink modifier tooltips"

### DIFF
--- a/mods/no-windows-ink-tooltips.wh.cpp
+++ b/mods/no-windows-ink-tooltips.wh.cpp
@@ -72,6 +72,7 @@ const WindhawkUtils::SYMBOL_HOOK udwmDllHooks[] = {
 BOOL Wh_ModInit() {
 	if(!WindhawkUtils::HookSymbols(GetModuleHandleW(L"udwm.dll"), udwmDllHooks, ARRAYSIZE(udwmDllHooks))){
 		Wh_Log(L"Cannot hook uDWM.dll");
+		return FALSE;
 	}
 	return TRUE;
 }


### PR DESCRIPTION
This PR adds a mod that hooks into DWM to disable the following functions:

- `CTrackingTooltip::Initialize`
- `CTrackingTooltip::Update`
- `CTrackingTooltip::UpdateTooltipLocation`

These functions are related to Windows Ink. When holding down a modifier key, DWM renders a cursor-tracking tooltip that displays which modifiers are held.