### PR TITLE
Added New Mod Volume Hid Sender

### DIFF
--- a/mods/volume-hid-sender.wh.cpp
+++ b/mods/volume-hid-sender.wh.cpp
@@ -264,11 +264,11 @@ void Set_Hooks() {
     if (user32Module) {
         // SendMessageW_t * pSendMessageW =
         //     GetProcAddress(user32Module, "SendMessageW");
-        if (true) {
+
             WindhawkUtils::SetFunctionHook(SendMessageW,
                                SendMessage_Hook,
                                &SendMessageW_Original);
-        }
+        
     }
 
 }


### PR DESCRIPTION
This mod allows you to send HID input for the MOUNTAIN EVEREST MAX keyboard everytime the volume is changed. This solution is not perfect. The volume will frequently be off by one. It is also possible to desync the volume temporarily (until next volume update) by taking a very long time to decide which volume you want.

Custom timeouts may be supported in the future

Arbritary HID output will be supported in the future

Requires HID HIDApiTester.

Special thanks to Borked on discord for coming up with the idea and helping me when I encountered issues. 