### PR TITLE
Taskbar height and icon size v1.3

### DIFF
--- a/mods/taskbar-icon-size.wh.cpp
+++ b/mods/taskbar-icon-size.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-icon-size
 // @name            Taskbar height and icon size
 // @description     Control the taskbar height and icon size, improve icon quality (Windows 11 only)
-// @version         1.2.17
+// @version         1.3
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -34,16 +34,16 @@ change the size of icons, and so the original quality icons can be used, as well
 as any other icon size.
 
 ![Before screenshot](https://i.imgur.com/TLza5fp.png) \
-*Icon size: 24x24, taskbar height: 48 (Windows 11 default)*
+*Taskbar height: 48, icon size: 24x24 (Windows 11 default)*
 
 ![After screenshot, large icons](https://i.imgur.com/3b8h40F.png) \
-*Icon size: 32x32, taskbar height: 52*
+*Taskbar height: 52, icon size: 32x32*
 
 ![After screenshot, small icons](https://i.imgur.com/Xy04Zcu.png) \
-*Icon size: 16x16, taskbar height: 34*
+*Taskbar height: 34, icon size: 16x16*
 
 ![After screenshot, small and narrow icons](https://i.imgur.com/fsx8C56.png) \
-*Icon size: 16x16, taskbar height: 34, taskbar button width: 28*
+*Taskbar height: 34, icon size: 16x16, taskbar button width: 28*
 
 Only Windows 11 is supported. For older Windows versions check out [7+ Taskbar
 Tweaker](https://tweaker.ramensoftware.com/).
@@ -54,18 +54,32 @@ Also check out the **Taskbar tray icon spacing** mod.
 
 // ==WindhawkModSettings==
 /*
-- IconSize: 32
-  $name: Icon size
-  $description: >-
-    The size, in pixels, of icons on the taskbar (Windows 11 default: 24)
 - TaskbarHeight: 52
   $name: Taskbar height
   $description: >-
     The height, in pixels, of the taskbar (Windows 11 default: 48)
+- IconSize: 32
+  $name: Icon size
+  $description: >-
+    The size, in pixels, of icons on the taskbar (Windows 11 default: 24)
 - TaskbarButtonWidth: 44
   $name: Taskbar button width
   $description: >-
     The width, in pixels, of the taskbar buttons (Windows 11 default: 44)
+- IconSizeSmall: 16
+  $name: Small icon size
+  $description: >-
+    The size, in pixels, of small icons on the taskbar (Windows 11 default: 16)
+
+    Used in newer Windows 11 builds with support for small taskbar icons (around
+    July 2025)
+- TaskbarButtonWidthSmall: 32
+  $name: Small taskbar button width
+  $description: >-
+    The width, in pixels, of the small taskbar buttons (Windows 11 default: 32)
+
+    Used in newer Windows 11 builds with support for small taskbar icons (around
+    July 2025)
 */
 // ==/WindhawkModSettings==
 
@@ -74,6 +88,7 @@ Also check out the **Taskbar tray icon spacing** mod.
 #undef GetCurrentTime
 
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 
@@ -81,31 +96,30 @@ Also check out the **Taskbar tray icon spacing** mod.
 #include <functional>
 #include <limits>
 #include <optional>
-
-#ifdef _M_ARM64
 #include <regex>
-#endif
 
 using namespace winrt::Windows::UI::Xaml;
 
-#ifndef SPI_SETLOGICALDPIOVERRIDE
-#define SPI_SETLOGICALDPIOVERRIDE 0x009F
-#endif
-
 struct {
-    int iconSize;
     int taskbarHeight;
+    int iconSize;
     int taskbarButtonWidth;
+    int iconSizeSmall;
+    int taskbarButtonWidthSmall;
 } g_settings;
 
 std::atomic<bool> g_taskbarViewDllLoaded;
+std::atomic<bool> g_searchUxUiDllLoaded;
 std::atomic<bool> g_applyingSettings;
 std::atomic<bool> g_pendingMeasureOverride;
 std::atomic<bool> g_unloading;
 std::atomic<int> g_hookCallCounter;
 
+bool g_hasDynamicIconScaling;
+bool g_smallIconSize;
 int g_originalTaskbarHeight;
 int g_taskbarHeight;
+std::atomic<DWORD> g_shellIconLoaderV2_LoadAsyncIcon__ResumeCoro_ThreadId;
 bool g_inSystemTrayController_UpdateFrameSize;
 bool g_taskbarButtonWidthCustomized;
 bool g_inAugmentedEntryPointButton_UpdateButtonPadding;
@@ -123,6 +137,94 @@ STDAPI GetDpiForMonitor(HMONITOR hmonitor,
                         MONITOR_DPI_TYPE dpiType,
                         UINT* dpiX,
                         UINT* dpiY);
+
+size_t OffsetFromAssemblyRegex(void* func,
+                               size_t defValue,
+                               std::regex regex,
+                               int limit = 30) {
+    BYTE* p = (BYTE*)func;
+    for (int i = 0; i < limit; i++) {
+        WH_DISASM_RESULT result;
+        if (!Wh_Disasm(p, &result)) {
+            break;
+        }
+
+        p += result.length;
+
+        std::string_view s = result.text;
+        if (s == "ret") {
+            break;
+        }
+
+        std::match_results<std::string_view::const_iterator> match;
+        if (std::regex_match(s.begin(), s.end(), match, regex)) {
+            // Wh_Log(L"%S", result.text);
+            return std::stoull(match[1], nullptr, 16);
+        }
+    }
+
+    Wh_Log(L"Failed for %p", func);
+    return defValue;
+}
+
+std::optional<bool> IsOsFeatureEnabled(UINT32 featureId) {
+    enum FEATURE_ENABLED_STATE {
+        FEATURE_ENABLED_STATE_DEFAULT = 0,
+        FEATURE_ENABLED_STATE_DISABLED = 1,
+        FEATURE_ENABLED_STATE_ENABLED = 2,
+    };
+
+#pragma pack(push, 1)
+    struct RTL_FEATURE_CONFIGURATION {
+        unsigned int featureId;
+        unsigned __int32 group : 4;
+        FEATURE_ENABLED_STATE enabledState : 2;
+        unsigned __int32 enabledStateOptions : 1;
+        unsigned __int32 unused1 : 1;
+        unsigned __int32 variant : 6;
+        unsigned __int32 variantPayloadKind : 2;
+        unsigned __int32 unused2 : 16;
+        unsigned int payload;
+    };
+#pragma pack(pop)
+
+    using RtlQueryFeatureConfiguration_t =
+        int(NTAPI*)(UINT32, int, INT64*, RTL_FEATURE_CONFIGURATION*);
+    static RtlQueryFeatureConfiguration_t pRtlQueryFeatureConfiguration = []() {
+        HMODULE hNtDll = GetModuleHandle(L"ntdll.dll");
+        return hNtDll ? (RtlQueryFeatureConfiguration_t)GetProcAddress(
+                            hNtDll, "RtlQueryFeatureConfiguration")
+                      : nullptr;
+    }();
+
+    if (!pRtlQueryFeatureConfiguration) {
+        Wh_Log(L"RtlQueryFeatureConfiguration not found");
+        return std::nullopt;
+    }
+
+    RTL_FEATURE_CONFIGURATION feature = {0};
+    INT64 changeStamp = 0;
+    HRESULT hr =
+        pRtlQueryFeatureConfiguration(featureId, 1, &changeStamp, &feature);
+    if (SUCCEEDED(hr)) {
+        Wh_Log(L"RtlQueryFeatureConfiguration result for %u: %d", featureId,
+               feature.enabledState);
+
+        switch (feature.enabledState) {
+            case FEATURE_ENABLED_STATE_DISABLED:
+                return false;
+            case FEATURE_ENABLED_STATE_ENABLED:
+                return true;
+            case FEATURE_ENABLED_STATE_DEFAULT:
+                return std::nullopt;
+        }
+    } else {
+        Wh_Log(L"RtlQueryFeatureConfiguration error for %u: %08X", featureId,
+               hr);
+    }
+
+    return std::nullopt;
+}
 
 FrameworkElement EnumChildElements(
     FrameworkElement element,
@@ -158,38 +260,86 @@ FrameworkElement FindChildByClassName(FrameworkElement element,
     });
 }
 
-using ResourceDictionary_Lookup_t = winrt::Windows::Foundation::IInspectable*(
-    WINAPI*)(void* pThis,
-             void** result,
-             winrt::Windows::Foundation::IInspectable* key);
-ResourceDictionary_Lookup_t ResourceDictionary_Lookup_Original;
+void OverrideResourceDirectoryLookup(
+    PCSTR sourceFunctionName,
+    const winrt::Windows::Foundation::IInspectable* key,
+    winrt::Windows::Foundation::IInspectable* value) {
+    if (g_unloading) {
+        return;
+    }
+
+    const auto keyString = key->try_as<winrt::hstring>();
+    if (!keyString) {
+        return;
+    }
+
+    double newValueDouble;
+    if (*keyString == L"MediumTaskbarButtonExtent") {
+        newValueDouble = g_settings.taskbarButtonWidth;
+    } else if (*keyString == L"SmallTaskbarButtonExtent") {
+        newValueDouble = g_settings.taskbarButtonWidthSmall;
+    } else {
+        return;
+    }
+
+    const auto valueDouble = value->try_as<double>();
+    if (!valueDouble) {
+        return;
+    }
+
+    if (newValueDouble != *valueDouble) {
+        Wh_Log(L"[%S] Overriding value %s: %f->%f", sourceFunctionName,
+               keyString->c_str(), *valueDouble, newValueDouble);
+        *value = winrt::box_value(newValueDouble);
+    }
+}
+
+using ResourceDictionary_Lookup_TaskbarView_t =
+    winrt::Windows::Foundation::IInspectable*(
+        WINAPI*)(void* pThis,
+                 void** result,
+                 winrt::Windows::Foundation::IInspectable* key);
+ResourceDictionary_Lookup_TaskbarView_t
+    ResourceDictionary_Lookup_TaskbarView_Original;
 winrt::Windows::Foundation::IInspectable* WINAPI
-ResourceDictionary_Lookup_Hook(void* pThis,
-                               void** result,
-                               winrt::Windows::Foundation::IInspectable* key) {
+ResourceDictionary_Lookup_TaskbarView_Hook(
+    void* pThis,
+    void** result,
+    winrt::Windows::Foundation::IInspectable* key) {
     // Wh_Log(L">");
 
-    auto ret = ResourceDictionary_Lookup_Original(pThis, result, key);
+    auto ret =
+        ResourceDictionary_Lookup_TaskbarView_Original(pThis, result, key);
     if (!*ret) {
         return ret;
     }
 
-    auto keyString = key->try_as<winrt::hstring>();
-    if (!keyString || keyString != L"MediumTaskbarButtonExtent") {
+    OverrideResourceDirectoryLookup(__FUNCTION__, key, ret);
+
+    return ret;
+}
+
+using ResourceDictionary_Lookup_SearchUxUi_t =
+    winrt::Windows::Foundation::IInspectable*(
+        WINAPI*)(void* pThis,
+                 void** result,
+                 winrt::Windows::Foundation::IInspectable* key);
+ResourceDictionary_Lookup_SearchUxUi_t
+    ResourceDictionary_Lookup_SearchUxUi_Original;
+winrt::Windows::Foundation::IInspectable* WINAPI
+ResourceDictionary_Lookup_SearchUxUi_Hook(
+    void* pThis,
+    void** result,
+    winrt::Windows::Foundation::IInspectable* key) {
+    // Wh_Log(L">");
+
+    auto ret =
+        ResourceDictionary_Lookup_SearchUxUi_Original(pThis, result, key);
+    if (!*ret) {
         return ret;
     }
 
-    auto valueDouble = ret->try_as<double>();
-    if (!valueDouble) {
-        return ret;
-    }
-
-    double newValueDouble = g_settings.taskbarButtonWidth;
-    if (newValueDouble != *valueDouble) {
-        Wh_Log(L"Overriding value %s: %f->%f", keyString->c_str(), *valueDouble,
-               newValueDouble);
-        *ret = winrt::box_value(newValueDouble);
-    }
+    OverrideResourceDirectoryLookup(__FUNCTION__, key, ret);
 
     return ret;
 }
@@ -199,6 +349,11 @@ using IconUtils_GetIconSize_t = void(WINAPI*)(bool isSmall,
                                               SIZE* size);
 IconUtils_GetIconSize_t IconUtils_GetIconSize_Original;
 void WINAPI IconUtils_GetIconSize_Hook(bool isSmall, int type, SIZE* size) {
+    if (g_hasDynamicIconScaling) {
+        IconUtils_GetIconSize_Original(isSmall, type, size);
+        return;
+    }
+
     IconUtils_GetIconSize_Original(isSmall, type, size);
 
     if (!g_unloading && !isSmall) {
@@ -215,6 +370,11 @@ IconContainer_IsStorageRecreationRequired_t
 bool WINAPI IconContainer_IsStorageRecreationRequired_Hook(void* pThis,
                                                            void* param1,
                                                            int flags) {
+    if (g_hasDynamicIconScaling) {
+        return IconContainer_IsStorageRecreationRequired_Original(pThis, param1,
+                                                                  flags);
+    }
+
     if (g_applyingSettings) {
         return true;
     }
@@ -251,6 +411,11 @@ CIconLoadingFunctions_GetClassLongPtrW_t
 ULONG_PTR WINAPI CIconLoadingFunctions_GetClassLongPtrW_Hook(void* pThis,
                                                              HWND hWnd,
                                                              int nIndex) {
+    if (g_hasDynamicIconScaling) {
+        return CIconLoadingFunctions_GetClassLongPtrW_Original(pThis, hWnd,
+                                                               nIndex);
+    }
+
     Wh_Log(L">");
 
     if (!g_unloading && nIndex == GCLP_HICON && g_settings.iconSize <= 16) {
@@ -281,6 +446,11 @@ CIconLoadingFunctions_SendMessageCallbackW_Hook(void* pThis,
                                                 LPARAM lParam,
                                                 SENDASYNCPROC lpResultCallBack,
                                                 ULONG_PTR dwData) {
+    if (g_hasDynamicIconScaling) {
+        return CIconLoadingFunctions_SendMessageCallbackW_Original(
+            pThis, hWnd, Msg, wParam, lParam, lpResultCallBack, dwData);
+    }
+
     Wh_Log(L">");
 
     if (!g_unloading && Msg == WM_GETICON && wParam == ICON_BIG &&
@@ -292,6 +462,26 @@ CIconLoadingFunctions_SendMessageCallbackW_Hook(void* pThis,
         pThis, hWnd, Msg, wParam, lParam, lpResultCallBack, dwData);
 
     return ret;
+}
+
+using ShellIconLoaderV2_LoadAsyncIcon__ResumeCoro_t =
+    void(WINAPI*)(void* pThis);
+ShellIconLoaderV2_LoadAsyncIcon__ResumeCoro_t
+    ShellIconLoaderV2_LoadAsyncIcon__ResumeCoro_Original;
+void WINAPI ShellIconLoaderV2_LoadAsyncIcon__ResumeCoro_Hook(void* pThis) {
+    if (g_hasDynamicIconScaling) {
+        ShellIconLoaderV2_LoadAsyncIcon__ResumeCoro_Original(pThis);
+        return;
+    }
+
+    Wh_Log(L">");
+
+    g_shellIconLoaderV2_LoadAsyncIcon__ResumeCoro_ThreadId =
+        GetCurrentThreadId();
+
+    ShellIconLoaderV2_LoadAsyncIcon__ResumeCoro_Original(pThis);
+
+    g_shellIconLoaderV2_LoadAsyncIcon__ResumeCoro_ThreadId = 0;
 }
 
 using TrayUI__StuckTrayChange_t = void(WINAPI*)(void* pThis);
@@ -325,6 +515,11 @@ TaskListItemViewModel_GetIconHeight_t
 int WINAPI TaskListItemViewModel_GetIconHeight_Hook(void* pThis,
                                                     void* param1,
                                                     double* iconHeight) {
+    if (g_hasDynamicIconScaling) {
+        return TaskListItemViewModel_GetIconHeight_Original(pThis, param1,
+                                                            iconHeight);
+    }
+
     int ret =
         TaskListItemViewModel_GetIconHeight_Original(pThis, param1, iconHeight);
 
@@ -343,6 +538,11 @@ TaskListGroupViewModel_GetIconHeight_t
 int WINAPI TaskListGroupViewModel_GetIconHeight_Hook(void* pThis,
                                                      void* param1,
                                                      double* iconHeight) {
+    if (g_hasDynamicIconScaling) {
+        return TaskListGroupViewModel_GetIconHeight_Original(pThis, param1,
+                                                             iconHeight);
+    }
+
     int ret = TaskListGroupViewModel_GetIconHeight_Original(pThis, param1,
                                                             iconHeight);
 
@@ -360,6 +560,11 @@ TaskbarConfiguration_GetIconHeightInViewPixels_taskbarSizeEnum_t
 double WINAPI
 TaskbarConfiguration_GetIconHeightInViewPixels_taskbarSizeEnum_Hook(
     int enumTaskbarSize) {
+    if (g_hasDynamicIconScaling) {
+        return TaskbarConfiguration_GetIconHeightInViewPixels_taskbarSizeEnum_Original(
+            enumTaskbarSize);
+    }
+
     Wh_Log(L"> %d", enumTaskbarSize);
 
     if (!g_unloading && (enumTaskbarSize == 1 || enumTaskbarSize == 2)) {
@@ -376,12 +581,91 @@ TaskbarConfiguration_GetIconHeightInViewPixels_double_t
     TaskbarConfiguration_GetIconHeightInViewPixels_double_Original;
 double WINAPI
 TaskbarConfiguration_GetIconHeightInViewPixels_double_Hook(double baseHeight) {
+    if (g_hasDynamicIconScaling) {
+        return TaskbarConfiguration_GetIconHeightInViewPixels_double_Original(
+            baseHeight);
+    }
+
     if (!g_unloading) {
         return g_settings.iconSize;
     }
 
     return TaskbarConfiguration_GetIconHeightInViewPixels_double_Original(
         baseHeight);
+}
+
+using TaskbarConfiguration_GetIconHeightInViewPixels_method_t =
+    double(WINAPI*)(void* pThis);
+TaskbarConfiguration_GetIconHeightInViewPixels_method_t
+    TaskbarConfiguration_GetIconHeightInViewPixels_method_Original;
+double WINAPI
+TaskbarConfiguration_GetIconHeightInViewPixels_method_Hook(void* pThis) {
+    double iconSize =
+        TaskbarConfiguration_GetIconHeightInViewPixels_method_Original(pThis);
+
+    if (!g_unloading) {
+        return iconSize <= 16 ? g_settings.iconSizeSmall : g_settings.iconSize;
+    }
+
+    return iconSize;
+}
+
+using TaskListButton_IconHeight_t = void(WINAPI*)(void* pThis, double height);
+TaskListButton_IconHeight_t TaskListButton_IconHeight_SymbolAddress;
+
+size_t GetIconHeightOffset() {
+    static size_t iconHeightOffset = []() {
+        size_t offset =
+#if defined(_M_X64)
+            OffsetFromAssemblyRegex(
+                (void*)TaskListButton_IconHeight_SymbolAddress, 0,
+                std::regex(R"(movsd xmm\d+, qword ptr \[rcx\+0x([0-9a-f]+)\])",
+                           std::regex_constants::icase),
+                30);
+#elif defined(_M_ARM64)
+            OffsetFromAssemblyRegex(
+                (void*)TaskListButton_IconHeight_SymbolAddress, 0,
+                std::regex(R"(ldr\s+d\d+, \[x\d+, #0x([0-9a-f]+)\])",
+                           std::regex_constants::icase),
+                30);
+#else
+#error "Unsupported architecture"
+#endif
+        Wh_Log(L"iconHeightOffset=0x%X", offset);
+        return offset;
+    }();
+
+    return iconHeightOffset;
+}
+
+void TaskListButton_IconHeight_InitOffsets() {
+    GetIconHeightOffset();
+}
+
+TaskListButton_IconHeight_t TaskListButton_IconHeight_Original;
+void WINAPI TaskListButton_IconHeight_Hook(void* pThis, double height) {
+    Wh_Log(L">");
+
+    size_t iconHeightOffset = GetIconHeightOffset();
+    if (!iconHeightOffset || iconHeightOffset > 0xFFFF) {
+        TaskListButton_IconHeight_Original(pThis, height);
+        return;
+    }
+
+    double* iconHeight = (double*)((BYTE*)pThis + iconHeightOffset);
+
+    if (g_applyingSettings) {
+        // Make sure the function doesn't think that the value wasn't changed.
+        *iconHeight = 1;
+    }
+
+    TaskListButton_IconHeight_Original(pThis, height);
+
+    if (!g_unloading) {
+        // Make sure to use a different value for other calculations such as
+        // padding.
+        *iconHeight = g_smallIconSize ? 16 : 24;
+    }
 }
 
 using SystemTrayController_GetFrameSize_t =
@@ -440,11 +724,8 @@ thread_local double* g_TaskbarConfiguration_UpdateFrameSize_frameSize;
 using TaskbarConfiguration_UpdateFrameSize_t = void(WINAPI*)(void* pThis);
 TaskbarConfiguration_UpdateFrameSize_t
     TaskbarConfiguration_UpdateFrameSize_SymbolAddress;
-TaskbarConfiguration_UpdateFrameSize_t
-    TaskbarConfiguration_UpdateFrameSize_Original;
-void WINAPI TaskbarConfiguration_UpdateFrameSize_Hook(void* pThis) {
-    Wh_Log(L">");
 
+LONG GetFrameSizeOffset() {
     static LONG frameSizeOffset = []() -> LONG {
         // Find the offset to the frame size.
         // str d16, [x19, #0x50]
@@ -478,6 +759,19 @@ void WINAPI TaskbarConfiguration_UpdateFrameSize_Hook(void* pThis) {
         return 0;
     }();
 
+    return frameSizeOffset;
+}
+
+void TaskbarConfiguration_UpdateFrameSize_InitOffsets() {
+    GetFrameSizeOffset();
+}
+
+TaskbarConfiguration_UpdateFrameSize_t
+    TaskbarConfiguration_UpdateFrameSize_Original;
+void WINAPI TaskbarConfiguration_UpdateFrameSize_Hook(void* pThis) {
+    Wh_Log(L">");
+
+    LONG frameSizeOffset = GetFrameSizeOffset();
     if (frameSizeOffset <= 0) {
         Wh_Log(L"frameSizeOffset <= 0");
         TaskbarConfiguration_UpdateFrameSize_Original(pThis);
@@ -515,11 +809,8 @@ void WINAPI Event_operator_call_Hook(void* pThis) {
 using SystemTrayController_UpdateFrameSize_t = void(WINAPI*)(void* pThis);
 SystemTrayController_UpdateFrameSize_t
     SystemTrayController_UpdateFrameSize_SymbolAddress;
-SystemTrayController_UpdateFrameSize_t
-    SystemTrayController_UpdateFrameSize_Original;
-void WINAPI SystemTrayController_UpdateFrameSize_Hook(void* pThis) {
-    Wh_Log(L">");
 
+LONG GetLastHeightOffset() {
     static LONG lastHeightOffset = []() -> LONG {
     // Find the last height offset to reset the height value.
 #if defined(_M_X64)
@@ -595,6 +886,19 @@ void WINAPI SystemTrayController_UpdateFrameSize_Hook(void* pThis) {
         return 0;
     }();
 
+    return lastHeightOffset;
+}
+
+void SystemTrayController_UpdateFrameSize_InitOffsets() {
+    GetLastHeightOffset();
+}
+
+SystemTrayController_UpdateFrameSize_t
+    SystemTrayController_UpdateFrameSize_Original;
+void WINAPI SystemTrayController_UpdateFrameSize_Hook(void* pThis) {
+    Wh_Log(L">");
+
+    LONG lastHeightOffset = GetLastHeightOffset();
     if (lastHeightOffset > 0) {
         *(double*)((BYTE*)pThis + lastHeightOffset) = 0;
     }
@@ -883,6 +1187,8 @@ void WINAPI TaskListButton_UpdateVisualStates_Hook(void* pThis) {
         }();
 
         if (mediumTaskbarButtonExtentOffset > 0) {
+            bool updateButtonPadding = false;
+
             double* mediumTaskbarButtonExtent =
                 (double*)((BYTE*)pThis + mediumTaskbarButtonExtentOffset);
             if (*mediumTaskbarButtonExtent >= 1 &&
@@ -895,16 +1201,37 @@ void WINAPI TaskListButton_UpdateVisualStates_Hook(void* pThis) {
                         L"TaskListButton: %f->%f",
                         *mediumTaskbarButtonExtent, newValue);
                     *mediumTaskbarButtonExtent = newValue;
-                    g_taskbarButtonWidthCustomized = true;
-                    TaskListButton_UpdateButtonPadding_Original(pThis);
+                    updateButtonPadding = true;
                 }
+            }
+
+            double* smallTaskbarButtonExtent =
+                g_hasDynamicIconScaling ? mediumTaskbarButtonExtent - 1
+                                        : nullptr;
+            if (smallTaskbarButtonExtent && *smallTaskbarButtonExtent >= 1 &&
+                *smallTaskbarButtonExtent < 10000) {
+                double newValue =
+                    g_unloading ? 32 : g_settings.taskbarButtonWidthSmall;
+                if (newValue != *smallTaskbarButtonExtent) {
+                    Wh_Log(
+                        L"Updating SmallTaskbarButtonExtent for "
+                        L"TaskListButton: %f->%f",
+                        *smallTaskbarButtonExtent, newValue);
+                    *smallTaskbarButtonExtent = newValue;
+                    updateButtonPadding = true;
+                }
+            }
+
+            if (updateButtonPadding) {
+                g_taskbarButtonWidthCustomized = true;
+                TaskListButton_UpdateButtonPadding_Original(pThis);
             }
         }
     }
 
     TaskListButton_UpdateVisualStates_Original(pThis);
 
-    if (g_applyingSettings) {
+    if (g_applyingSettings && !g_hasDynamicIconScaling) {
         FrameworkElement taskListButtonElement = nullptr;
         ((IUnknown*)pThis + 3)
             ->QueryInterface(winrt::guid_of<FrameworkElement>(),
@@ -923,6 +1250,20 @@ void WINAPI TaskListButton_UpdateVisualStates_Hook(void* pThis) {
     }
 }
 
+using LaunchListItemViewModel_IconHeight_t = void(WINAPI*)(void* pThis,
+                                                           double iconHeight);
+LaunchListItemViewModel_IconHeight_t
+    LaunchListItemViewModel_IconHeight_Original;
+void WINAPI LaunchListItemViewModel_IconHeight_Hook(void* pThis,
+                                                    double iconHeight) {
+    Wh_Log(L">");
+
+    g_smallIconSize = iconHeight == g_settings.iconSizeSmall &&
+                      iconHeight != g_settings.iconSize;
+
+    LaunchListItemViewModel_IconHeight_Original(pThis, iconHeight);
+}
+
 using ExperienceToggleButton_UpdateButtonPadding_t = void(WINAPI*)(void* pThis);
 ExperienceToggleButton_UpdateButtonPadding_t
     ExperienceToggleButton_UpdateButtonPadding_Original;
@@ -931,7 +1272,7 @@ void WINAPI ExperienceToggleButton_UpdateButtonPadding_Hook(void* pThis) {
 
     ExperienceToggleButton_UpdateButtonPadding_Original(pThis);
 
-    if (!g_applyingSettings) {
+    if (g_hasDynamicIconScaling && g_unloading) {
         return;
     }
 
@@ -949,9 +1290,15 @@ void WINAPI ExperienceToggleButton_UpdateButtonPadding_Hook(void* pThis) {
         return;
     }
 
+    double defaultWidthExtra = 0;
+
     auto className = winrt::get_class_name(toggleButtonElement);
     if (className == L"Taskbar.ExperienceToggleButton") {
-        // OK.
+        auto automationId = Automation::AutomationProperties::GetAutomationId(
+            toggleButtonElement);
+        if (automationId == L"StartButton") {
+            defaultWidthExtra = 11;
+        }
     } else if (className == L"Taskbar.SearchBoxButton") {
         // Only if search icon and not a search box.
         auto searchBoxTextBlock =
@@ -969,12 +1316,69 @@ void WINAPI ExperienceToggleButton_UpdateButtonPadding_Hook(void* pThis) {
         return;
     }
 
-    auto buttonPadding = panelElement.Padding();
-    double newWidth = (g_unloading ? 44 : g_settings.taskbarButtonWidth) - 4 +
-                      (buttonPadding.Left + buttonPadding.Right);
+    double defaultWidth = g_smallIconSize ? 32 : 44;
+    double overrideWidth =
+        g_unloading ? defaultWidth
+                    : (g_smallIconSize ? g_settings.taskbarButtonWidthSmall
+                                       : g_settings.taskbarButtonWidth);
+
+    double newWidth = overrideWidth + defaultWidthExtra;
     if (newWidth != buttonWidth) {
         Wh_Log(L"Updating MediumTaskbarButtonExtent for %s: %f->%f",
                className.c_str(), buttonWidth, newWidth);
+        panelElement.Width(newWidth);
+    }
+}
+
+using SearchButtonBase_UpdateButtonPadding_t = void(WINAPI*)(void* pThis);
+SearchButtonBase_UpdateButtonPadding_t
+    SearchButtonBase_UpdateButtonPadding_Original;
+void WINAPI SearchButtonBase_UpdateButtonPadding_Hook(void* pThis) {
+    Wh_Log(L">");
+
+    SearchButtonBase_UpdateButtonPadding_Original(pThis);
+
+    if (g_hasDynamicIconScaling && g_unloading) {
+        return;
+    }
+
+    FrameworkElement toggleButtonElement = nullptr;
+    ((IUnknown**)pThis)[1]->QueryInterface(winrt::guid_of<FrameworkElement>(),
+                                           winrt::put_abi(toggleButtonElement));
+    if (!toggleButtonElement) {
+        return;
+    }
+
+    auto panelElement =
+        FindChildByName(toggleButtonElement, L"SearchBoxButtonRootPanel")
+            .try_as<Controls::Grid>();
+    if (!panelElement) {
+        return;
+    }
+
+    // Only if search icon and not a search box.
+    auto searchBoxTextBlock =
+        FindChildByName(panelElement, L"SearchBoxTextBlock");
+    if (searchBoxTextBlock &&
+        searchBoxTextBlock.Visibility() != Visibility::Collapsed) {
+        return;
+    }
+
+    double buttonWidth = panelElement.Width();
+    if (!(buttonWidth > 0)) {
+        return;
+    }
+
+    double defaultWidth = g_smallIconSize ? 32 : 44;
+    double overrideWidth =
+        g_unloading ? defaultWidth
+                    : (g_smallIconSize ? g_settings.taskbarButtonWidthSmall
+                                       : g_settings.taskbarButtonWidth);
+
+    double newWidth = overrideWidth;
+    if (newWidth != buttonWidth) {
+        Wh_Log(L"Updating MediumTaskbarButtonExtent: %f->%f", buttonWidth,
+               newWidth);
         panelElement.Width(newWidth);
     }
 }
@@ -984,6 +1388,11 @@ using AugmentedEntryPointButton_UpdateButtonPadding_t =
 AugmentedEntryPointButton_UpdateButtonPadding_t
     AugmentedEntryPointButton_UpdateButtonPadding_Original;
 void WINAPI AugmentedEntryPointButton_UpdateButtonPadding_Hook(void* pThis) {
+    if (g_hasDynamicIconScaling) {
+        AugmentedEntryPointButton_UpdateButtonPadding_Original(pThis);
+        return;
+    }
+
     Wh_Log(L">");
 
     g_inAugmentedEntryPointButton_UpdateButtonPadding = true;
@@ -996,6 +1405,11 @@ void WINAPI AugmentedEntryPointButton_UpdateButtonPadding_Hook(void* pThis) {
 using RepeatButton_Width_t = void(WINAPI*)(void* pThis, double width);
 RepeatButton_Width_t RepeatButton_Width_Original;
 void WINAPI RepeatButton_Width_Hook(void* pThis, double width) {
+    if (g_hasDynamicIconScaling) {
+        RepeatButton_Width_Original(pThis, width);
+        return;
+    }
+
     Wh_Log(L">");
 
     RepeatButton_Width_Original(pThis, width);
@@ -1161,20 +1575,55 @@ auto WINAPI SHAppBarMessage_Hook(DWORD dwMessage, PAPPBARDATA pData) {
     return ret;
 }
 
-void LoadSettings() {
-    g_settings.iconSize = Wh_GetIntSetting(L"IconSize");
-    g_settings.taskbarHeight = Wh_GetIntSetting(L"TaskbarHeight");
-    g_settings.taskbarButtonWidth = Wh_GetIntSetting(L"TaskbarButtonWidth");
+using SendMessageTimeoutW_t = decltype(&SendMessageTimeoutW);
+SendMessageTimeoutW_t SendMessageTimeoutW_Original;
+LRESULT WINAPI SendMessageTimeoutW_Hook(HWND hWnd,
+                                        UINT Msg,
+                                        WPARAM wParam,
+                                        LPARAM lParam,
+                                        UINT fuFlags,
+                                        UINT uTimeout,
+                                        PDWORD_PTR lpdwResult) {
+    if (g_shellIconLoaderV2_LoadAsyncIcon__ResumeCoro_ThreadId ==
+            GetCurrentThreadId() &&
+        !g_unloading && Msg == WM_GETICON && wParam == ICON_BIG &&
+        (g_smallIconSize ? g_settings.iconSizeSmall : g_settings.iconSize) <=
+            16) {
+        wParam = ICON_SMALL2;
+    }
+
+    LRESULT ret = SendMessageTimeoutW_Original(hWnd, Msg, wParam, lParam,
+                                               fuFlags, uTimeout, lpdwResult);
+
+    return ret;
 }
 
-HWND GetTaskbarWnd() {
-    HWND hTaskbarWnd = FindWindow(L"Shell_TrayWnd", nullptr);
+void LoadSettings() {
+    g_settings.taskbarHeight = Wh_GetIntSetting(L"TaskbarHeight");
+    g_settings.iconSize = Wh_GetIntSetting(L"IconSize");
+    g_settings.taskbarButtonWidth = Wh_GetIntSetting(L"TaskbarButtonWidth");
+    g_settings.iconSizeSmall = Wh_GetIntSetting(L"IconSizeSmall");
+    g_settings.taskbarButtonWidthSmall =
+        Wh_GetIntSetting(L"TaskbarButtonWidthSmall");
+}
 
-    DWORD processId = 0;
-    if (!hTaskbarWnd || !GetWindowThreadProcessId(hTaskbarWnd, &processId) ||
-        processId != GetCurrentProcessId()) {
-        return nullptr;
-    }
+HWND FindCurrentProcessTaskbarWnd() {
+    HWND hTaskbarWnd = nullptr;
+
+    EnumWindows(
+        [](HWND hWnd, LPARAM lParam) -> BOOL {
+            DWORD dwProcessId;
+            WCHAR className[32];
+            if (GetWindowThreadProcessId(hWnd, &dwProcessId) &&
+                dwProcessId == GetCurrentProcessId() &&
+                GetClassName(hWnd, className, ARRAYSIZE(className)) &&
+                _wcsicmp(className, L"Shell_TrayWnd") == 0) {
+                *reinterpret_cast<HWND*>(lParam) = hWnd;
+                return FALSE;
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&hTaskbarWnd));
 
     return hTaskbarWnd;
 }
@@ -1195,7 +1644,7 @@ void ApplySettings(int taskbarHeight) {
         taskbarHeight = 2;
     }
 
-    HWND hTaskbarWnd = GetTaskbarWnd();
+    HWND hTaskbarWnd = FindCurrentProcessTaskbarWnd();
     if (!hTaskbarWnd) {
         Wh_Log(L"No taskbar found");
         g_taskbarHeight = taskbarHeight;
@@ -1294,33 +1743,47 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
                     // Windows 11 version 21H2.
                     LR"(public: struct winrt::Windows::Foundation::IInspectable __cdecl winrt::impl::consume_Windows_Foundation_Collections_IMap<struct winrt::Windows::UI::Xaml::ResourceDictionary,struct winrt::Windows::Foundation::IInspectable,struct winrt::Windows::Foundation::IInspectable>::Lookup(struct winrt::Windows::Foundation::IInspectable const &)const )",
                 },
-                &ResourceDictionary_Lookup_Original,
-                ResourceDictionary_Lookup_Hook,
+                &ResourceDictionary_Lookup_TaskbarView_Original,
+                ResourceDictionary_Lookup_TaskbarView_Hook,
             },
             {
+                // Pre-DynamicIconScaling.
                 {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListItemViewModel,struct winrt::Taskbar::ITaskListItemViewModel>::GetIconHeight(void *,double *))"},
                 &TaskListItemViewModel_GetIconHeight_Original,
                 TaskListItemViewModel_GetIconHeight_Hook,
                 true,  // Gone in KB5040527 (Taskbar.View.dll 2124.16310.10.0).
             },
             {
+                // Pre-DynamicIconScaling.
                 {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListGroupViewModel,struct winrt::Taskbar::ITaskbarAppItemViewModel>::GetIconHeight(void *,double *))"},
                 &TaskListGroupViewModel_GetIconHeight_Original,
                 TaskListGroupViewModel_GetIconHeight_Hook,
                 true,  // Missing in older Windows 11 versions.
             },
             {
+                // Pre-DynamicIconScaling.
                 {LR"(public: static double __cdecl winrt::Taskbar::implementation::TaskbarConfiguration::GetIconHeightInViewPixels(enum winrt::WindowsUdk::UI::Shell::TaskbarSize))"},
                 &TaskbarConfiguration_GetIconHeightInViewPixels_taskbarSizeEnum_Original,
-
                 TaskbarConfiguration_GetIconHeightInViewPixels_taskbarSizeEnum_Hook,
             },
             {
+                // Pre-DynamicIconScaling.
                 {LR"(public: static double __cdecl winrt::Taskbar::implementation::TaskbarConfiguration::GetIconHeightInViewPixels(double))"},
                 &TaskbarConfiguration_GetIconHeightInViewPixels_double_Original,
-
                 TaskbarConfiguration_GetIconHeightInViewPixels_double_Hook,
                 true,  // From Windows 11 version 22H2.
+            },
+            {
+                {LR"(public: double __cdecl winrt::Taskbar::implementation::TaskbarConfiguration::GetIconHeightInViewPixels(void))"},
+                &TaskbarConfiguration_GetIconHeightInViewPixels_method_Original,
+                TaskbarConfiguration_GetIconHeightInViewPixels_method_Hook,
+                true,  // From KB5044384 (October 2024).
+            },
+            {
+                {LR"(public: void __cdecl winrt::Taskbar::implementation::TaskListButton::IconHeight(double))"},
+                &TaskListButton_IconHeight_SymbolAddress,
+                nullptr,  // Hooked manually, we need the symbol address.
+                true,     // From KB5058499 (May 2025).
             },
             {
                 {LR"(private: double __cdecl winrt::SystemTray::implementation::SystemTrayController::GetFrameSize(enum winrt::WindowsUdk::UI::Shell::TaskbarSize))"},
@@ -1424,16 +1887,23 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
                 TaskListButton_UpdateVisualStates_Hook,
             },
             {
+                {LR"(public: virtual void __cdecl winrt::Taskbar::implementation::LaunchListItemViewModel::IconHeight(double))"},
+                &LaunchListItemViewModel_IconHeight_Original,
+                LaunchListItemViewModel_IconHeight_Hook,
+            },
+            {
                 {LR"(protected: virtual void __cdecl winrt::Taskbar::implementation::ExperienceToggleButton::UpdateButtonPadding(void))"},
                 &ExperienceToggleButton_UpdateButtonPadding_Original,
                 ExperienceToggleButton_UpdateButtonPadding_Hook,
             },
             {
+                // Pre-DynamicIconScaling.
                 {LR"(protected: virtual void __cdecl winrt::Taskbar::implementation::AugmentedEntryPointButton::UpdateButtonPadding(void))"},
                 &AugmentedEntryPointButton_UpdateButtonPadding_Original,
                 AugmentedEntryPointButton_UpdateButtonPadding_Hook,
             },
             {
+                // Pre-DynamicIconScaling.
                 {LR"(public: __cdecl winrt::impl::consume_Windows_UI_Xaml_IFrameworkElement<struct winrt::Windows::UI::Xaml::Controls::Primitives::RepeatButton>::Width(double)const )"},
                 &RepeatButton_Width_Original,
                 RepeatButton_Width_Hook,
@@ -1446,8 +1916,17 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
         return false;
     }
 
+    if (TaskListButton_IconHeight_SymbolAddress) {
+        TaskListButton_IconHeight_InitOffsets();
+        WindhawkUtils::Wh_SetFunctionHookT(
+            TaskListButton_IconHeight_SymbolAddress,
+            TaskListButton_IconHeight_Hook,
+            &TaskListButton_IconHeight_Original);
+    }
+
 #ifdef _M_ARM64
     if (TaskbarConfiguration_UpdateFrameSize_SymbolAddress) {
+        TaskbarConfiguration_UpdateFrameSize_InitOffsets();
         WindhawkUtils::Wh_SetFunctionHookT(
             TaskbarConfiguration_UpdateFrameSize_SymbolAddress,
             TaskbarConfiguration_UpdateFrameSize_Hook,
@@ -1456,17 +1935,49 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
 #endif
 
     if (SystemTrayController_UpdateFrameSize_SymbolAddress) {
+        SystemTrayController_UpdateFrameSize_InitOffsets();
         WindhawkUtils::Wh_SetFunctionHookT(
             SystemTrayController_UpdateFrameSize_SymbolAddress,
             SystemTrayController_UpdateFrameSize_Hook,
             &SystemTrayController_UpdateFrameSize_Original);
     }
 
+    constexpr UINT kDynamicIconScaling = 29785184;
+    if (TaskbarConfiguration_GetIconHeightInViewPixels_method_Original &&
+        IsOsFeatureEnabled(kDynamicIconScaling).value_or(true)) {
+        g_hasDynamicIconScaling = true;
+        Wh_Log(L"Dynamic icon scaling is enabled");
+    }
+
+    return true;
+}
+
+bool HookSearchUxUiDllSymbols(HMODULE module) {
+    // SearchUx.UI.dll
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {LR"(public: __cdecl winrt::impl::consume_Windows_Foundation_Collections_IMap<struct winrt::Windows::UI::Xaml::ResourceDictionary,struct winrt::Windows::Foundation::IInspectable,struct winrt::Windows::Foundation::IInspectable>::Lookup(struct winrt::Windows::Foundation::IInspectable const &)const )"},
+            &ResourceDictionary_Lookup_SearchUxUi_Original,
+            ResourceDictionary_Lookup_SearchUxUi_Hook,
+        },
+        {
+            {LR"(protected: virtual void __cdecl winrt::SearchUx::SearchUI::implementation::SearchButtonBase::UpdateButtonPadding(void))"},
+            &SearchButtonBase_UpdateButtonPadding_Original,
+            SearchButtonBase_UpdateButtonPadding_Hook,
+        },
+    };
+
+    if (!HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks))) {
+        Wh_Log(L"HookSymbols failed");
+        return false;
+    }
+
     return true;
 }
 
 bool HookTaskbarDllSymbols() {
-    HMODULE module = LoadLibrary(L"taskbar.dll");
+    HMODULE module =
+        LoadLibraryEx(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (!module) {
         Wh_Log(L"Failed to load taskbar.dll");
         return false;
@@ -1474,11 +1985,13 @@ bool HookTaskbarDllSymbols() {
 
     WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
         {
+            // Pre-DynamicIconScaling.
             {LR"(void __cdecl IconUtils::GetIconSize(bool,enum IconUtils::IconType,struct tagSIZE *))"},
             &IconUtils_GetIconSize_Original,
             IconUtils_GetIconSize_Hook,
         },
         {
+            // Pre-DynamicIconScaling.
             {LR"(public: virtual bool __cdecl IconContainer::IsStorageRecreationRequired(class CCoSimpleArray<unsigned int,4294967294,class CSimpleArrayStandardCompareHelper<unsigned int> > const &,enum IconContainerFlags))"},
             &IconContainer_IsStorageRecreationRequired_Original,
             IconContainer_IsStorageRecreationRequired_Hook,
@@ -1490,14 +2003,22 @@ bool HookTaskbarDllSymbols() {
             true,
         },
         {
+            // Pre-DynamicIconScaling.
             {LR"(public: virtual unsigned __int64 __cdecl CIconLoadingFunctions::GetClassLongPtrW(struct HWND__ *,int))"},
             &CIconLoadingFunctions_GetClassLongPtrW_Original,
             CIconLoadingFunctions_GetClassLongPtrW_Hook,
         },
         {
+            // Pre-DynamicIconScaling.
             {LR"(public: virtual int __cdecl CIconLoadingFunctions::SendMessageCallbackW(struct HWND__ *,unsigned int,unsigned __int64,__int64,void (__cdecl*)(struct HWND__ *,unsigned int,unsigned __int64,__int64),unsigned __int64))"},
             &CIconLoadingFunctions_SendMessageCallbackW_Original,
             CIconLoadingFunctions_SendMessageCallbackW_Hook,
+        },
+        {
+            // Pre-DynamicIconScaling.
+            {LR"(static  ShellIconLoaderV2::LoadAsyncIcon$_ResumeCoro$1())"},
+            &ShellIconLoaderV2_LoadAsyncIcon__ResumeCoro_Original,
+            ShellIconLoaderV2_LoadAsyncIcon__ResumeCoro_Hook,
         },
         {
             {LR"(public: void __cdecl TrayUI::_StuckTrayChange(void))"},
@@ -1527,6 +2048,10 @@ HMODULE GetTaskbarViewModuleHandle() {
     return module;
 }
 
+HMODULE GetSearchUxUiModuleHandle() {
+    return GetModuleHandle(L"SearchUx.UI.dll");
+}
+
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 LoadLibraryExW_t LoadLibraryExW_Original;
 HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
@@ -1546,6 +2071,15 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
         }
     }
 
+    if (!g_searchUxUiDllLoaded && GetSearchUxUiModuleHandle() == module &&
+        !g_searchUxUiDllLoaded.exchange(true)) {
+        Wh_Log(L"Loaded %s", lpLibFileName);
+
+        if (HookSearchUxUiDllSymbols(module)) {
+            Wh_ApplyHookOperations();
+        }
+    }
+
     return module;
 }
 
@@ -1558,8 +2092,7 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
-    WindhawkUtils::Wh_SetFunctionHookT(SHAppBarMessage, SHAppBarMessage_Hook,
-                                       &SHAppBarMessage_Original);
+    bool delayLoadingNeeded = false;
 
     if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
         g_taskbarViewDllLoaded = true;
@@ -1568,7 +2101,20 @@ BOOL Wh_ModInit() {
         }
     } else {
         Wh_Log(L"Taskbar view module not loaded yet");
+        delayLoadingNeeded = true;
+    }
 
+    if (HMODULE searchUxUiModule = GetSearchUxUiModuleHandle()) {
+        g_searchUxUiDllLoaded = true;
+        if (!HookSearchUxUiDllSymbols(searchUxUiModule)) {
+            return FALSE;
+        }
+    } else {
+        Wh_Log(L"Search UX UI module not loaded yet");
+        delayLoadingNeeded = true;
+    }
+
+    if (delayLoadingNeeded) {
         HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
         auto pKernelBaseLoadLibraryExW =
             (decltype(&LoadLibraryExW))GetProcAddress(kernelBaseModule,
@@ -1577,6 +2123,13 @@ BOOL Wh_ModInit() {
                                            LoadLibraryExW_Hook,
                                            &LoadLibraryExW_Original);
     }
+
+    WindhawkUtils::Wh_SetFunctionHookT(SHAppBarMessage, SHAppBarMessage_Hook,
+                                       &SHAppBarMessage_Original);
+
+    WindhawkUtils::Wh_SetFunctionHookT(SendMessageTimeoutW,
+                                       SendMessageTimeoutW_Hook,
+                                       &SendMessageTimeoutW_Original);
 
     return TRUE;
 }
@@ -1590,6 +2143,18 @@ void Wh_ModAfterInit() {
                 Wh_Log(L"Got Taskbar.View.dll");
 
                 if (HookTaskbarViewDllSymbols(taskbarViewModule)) {
+                    Wh_ApplyHookOperations();
+                }
+            }
+        }
+    }
+
+    if (!g_searchUxUiDllLoaded) {
+        if (HMODULE searchUxUiModule = GetSearchUxUiModuleHandle()) {
+            if (!g_searchUxUiDllLoaded.exchange(true)) {
+                Wh_Log(L"Got SearchUx.UI.dll");
+
+                if (HookSearchUxUiDllSymbols(searchUxUiModule)) {
                     Wh_ApplyHookOperations();
                 }
             }


### PR DESCRIPTION
* Added support for newer Windows 11 builds with support for smaller taskbar icons. For the newer builds, on Settings > Personalization > Taskbar, the “Taskbar behaviors” settings now include the “Show smaller taskbar buttons” option. If the option is available, the mod is now able to customize both the large icons and the small icons.
* Improved compatibility with status bar programs such as YASB and Zebar.
* Improved the quality of small 16x16 icons.
* Fixed sizing of the search button in recent Windows 11 builds.