### PR TITLE
Taskbar Labels for Windows 11 v1.4.2

### DIFF
--- a/mods/taskbar-labels.wh.cpp
+++ b/mods/taskbar-labels.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-labels
 // @name            Taskbar Labels for Windows 11
 // @description     Customize text labels and combining for running programs on the taskbar (Windows 11 only)
-// @version         1.4.1
+// @version         1.4.2
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -1095,6 +1095,9 @@ void UpdateTaskListButtonWithLabelStyle(
                                       winrt::box_value(2));
         }
 
+        double maxWidth = std::max(taskListButtonWidth - 6, 0.0);
+        indicatorElement.MaxWidth(maxWidth);
+
         double minWidth = 0;
 
         double indicatorElementWidth = indicatorElement.Width();
@@ -1112,6 +1115,10 @@ void UpdateTaskListButtonWithLabelStyle(
                 if (minWidth < 0) {
                     minWidth = 0;
                 }
+            }
+
+            if (minWidth > maxWidth) {
+                minWidth = maxWidth;
             }
         }
 
@@ -2023,7 +2030,8 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 }
 
 bool HookTaskbarDllSymbols() {
-    HMODULE module = LoadLibrary(L"taskbar.dll");
+    HMODULE module =
+        LoadLibraryEx(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (!module) {
         Wh_Log(L"Failed to load taskbar.dll");
         return false;
@@ -2046,7 +2054,8 @@ bool HookTaskbarDllSymbols() {
 }
 
 bool HookTaskbarDllSymbolsOldImplementation() {
-    HMODULE module = LoadLibrary(L"taskbar.dll");
+    HMODULE module =
+        LoadLibraryEx(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (!module) {
         Wh_Log(L"Failed to load taskbar.dll");
         return false;


### PR DESCRIPTION
* In [a recent update](https://blogs.windows.com/windows-insider/2025/05/05/announcing-windows-11-insider-preview-build-26120-3950-beta-channel/#:~:text=We%20have%20adjusted%20the%20needy%20state%20pill%20under%20apps%20on%20the%20taskbar%20that%20need%20attention%20to%20be%20wider%20and%20more%20visible.), Windows adjusted the running indicator for taskbar items that need attention to be wider and more visible. The update improves compatibility with this change.