### PR TITLE
Hide Dotfiles (Explorer Only) v1.0.1

### DIFF
--- a/mods/hide-dotfiles-explorer.wh.cpp
+++ b/mods/hide-dotfiles-explorer.wh.cpp
@@ -170,8 +170,8 @@ bool ShouldHideFile(std::wstring_view fileName) noexcept {
     }
     
     auto matchesPattern = [](std::wstring_view name, const std::vector<std::wstring>& patterns) noexcept -> bool {
-        return std::ranges::any_of(patterns, [name](const std::wstring& pattern) {
-            std::wstring temp(name);
+        std::wstring temp(name);
+        return std::ranges::any_of(patterns, [&temp](const std::wstring& pattern) {
             return PathMatchSpecW(temp.c_str(), pattern.c_str()) != FALSE;
         });
     };


### PR DESCRIPTION
Implements COM interface hooking to filter dot-prefixed files/folders from Explorer views while maintaining full system accessibility. Designed for cross-platform developers who want clean GUI browsing without breaking toolchain workflows.

Coexists with Global Solutions: Designed to work alongside system-wide dotfile hiding mods like [dot-hide](https://windhawk.net/mods/dot-hide)

In other words: this Hide Dotfiles functionality is purely cosmetic - it only hides files from view **only** in explorer.exe