### PR TITLE
Aerexplorer 1.8.0

### DIFF
--- a/mods/aerexplorer.wh.cpp
+++ b/mods/aerexplorer.wh.cpp
@@ -92,7 +92,7 @@ Feel free to try it on other versions, but it may not work.
   $description: Dropdown icon width in address bar. Address toolbar sizing must be set to "Custom".
 - refreshwidth: 25
   $name: Refresh icon width
-  $description: Refresh icon width in address bar. Address toolbar sizing must be set to "Custom".
+  $description: Refresh icon widFth in address bar. Address toolbar sizing must be set to "Custom".
 - oldsearch: true
   $name: Old search box
   $description: Disable the EdgeHTML-based search box and use the old one instead. You must enable this option to fix the bug where the placeholder disappears.
@@ -3145,9 +3145,9 @@ BOOL Wh_ModInit(void)
     HOOK_SYMBOLS(ExplorerFrame, explorerframeDllHooks)
 
     VS_FIXEDFILEINFO *pVerInfo = GetModuleVersionInfo(ExplorerFrame, nullptr);
-    if (HIWORD(pVerInfo->dwFileVersionLS) > 21332)
+    if (!pVerInfo || HIWORD(pVerInfo->dwFileVersionLS) > 21332)
     {
-        Wh_Log(L"Rejecting Windows 11 ExplorerFrame.dll");
+        Wh_Log(L"Rejecting invalid or Windows 11 ExplorerFrame.dll");
         return FALSE;
     }
 

--- a/mods/aerexplorer.wh.cpp
+++ b/mods/aerexplorer.wh.cpp
@@ -92,7 +92,7 @@ Feel free to try it on other versions, but it may not work.
   $description: Dropdown icon width in address bar. Address toolbar sizing must be set to "Custom".
 - refreshwidth: 25
   $name: Refresh icon width
-  $description: Refresh icon widFth in address bar. Address toolbar sizing must be set to "Custom".
+  $description: Refresh icon width in address bar. Address toolbar sizing must be set to "Custom".
 - oldsearch: true
   $name: Old search box
   $description: Disable the EdgeHTML-based search box and use the old one instead. You must enable this option to fix the bug where the placeholder disappears.

--- a/mods/aerexplorer.wh.cpp
+++ b/mods/aerexplorer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              aerexplorer
 // @name            Aerexplorer
 // @description     Various tweaks for Windows Explorer to make it more like older versions.
-// @version         1.7.1
+// @version         1.8.0
 // @author          aubymori
 // @github          https://github.com/aubymori
 // @include         *
@@ -145,6 +145,12 @@ Feel free to try it on other versions, but it may not work.
 - beta8navbarbg: false
   $name: Windows 8 beta navigation bar background
   $description: Changes the background of the navigation bar to match Windows 8 betas.
+- leftviews: false
+  $name: Views dropdown on left
+  $description: Moves the views dropdown to the left after the "Organize" button, like Windows Vista.
+- cmdbaricons: false
+  $name: Command bar icons
+  $description: Shows icons on all command bar items, like Windows Vista.
 */
 // ==/WindhawkModSettings==
 
@@ -215,6 +221,8 @@ struct
     bool             nopcfolders;
     bool             vistasearchplaceholder;
     bool             beta8navbarbg;
+    bool             leftviews;
+    bool             cmdbaricons;
 } settings = { 0 };
 
 typedef HRESULT (WINAPI *VariantToBuffer_t)(LPVARIANT, void *, UINT);
@@ -869,65 +877,71 @@ HRESULT STDCALL CSearchBox_SetCueAndTooltipText_hook(
 
 #define CAddressBand__hwnd(pThis) *((HWND *)pThis + 9)
 
+#ifdef _WIN64
+#   define CAddressBand__hwndTools(pThis) *((HWND *)pThis + 29)
+#else
+#   define CAddressBand__hwndTools(pThis) *((HWND *)pThis + 31)
+#endif
+
 /* Fix address bar position and toolbar size */
 void (THISCALL *CAddressBand__PositionChildWindows_orig)(void *) = nullptr;
 void THISCALL CAddressBand__PositionChildWindows_hook(
     void *pThis
 )
 {
-    HWND hWnd = CAddressBand__hwnd(pThis);
-    if (settings.tbst != TBST_DEFAULT && hWnd && IsWindow(hWnd))
+    if (settings.tbst != TBST_DEFAULT)
     {
-        HWND hProg = FindWindowExW(hWnd, NULL, L"msctls_progress32", NULL);
-        if (hProg)
+        HWND hwndTools = CAddressBand__hwndTools(pThis);
+        if (hwndTools)
         {
-            HWND hToolbar = FindWindowExW(hProg, NULL, L"ToolbarWindow32", NULL);
-            if (hToolbar)
+            TBBUTTONINFOW tbi;
+            tbi.cbSize = sizeof(TBBUTTONINFOW);
+            tbi.dwMask = TBIF_SIZE;
+
+            /* Spacer band that only gets added on classic. For some reason,
+               it's huge by default. */
+            tbi.cx = 2;
+            SendMessageW(hwndTools, TB_SETBUTTONINFOW, 203, (LPARAM)&tbi);
+
+            /* Dropdown width */
+            switch (settings.tbst)
             {
-                TBBUTTONINFOW tbi;
-                tbi.cbSize = sizeof(TBBUTTONINFOW);
-                tbi.dwMask = TBIF_SIZE;
+                case TBST_SEVEN:
+                    tbi.cx = ScaleForDPI(19);
+                    break;
+                case TBST_TEN:
+                    tbi.cx = ScaleForDPI(20);
+                    break;
+                case TBST_TENNEW:
+                    tbi.cx = ScaleForDPI(17);
+                    break;
+                case TBST_CUSTOM:
+                    tbi.cx = ScaleForDPI(settings.dropdownwidth);
+                    break;
+            }
+            SendMessageW(hwndTools, TB_SETBUTTONINFOW, 202, (LPARAM)&tbi);
 
-                /* Dropdown width */
-                switch (settings.tbst)
-                {
-                    case TBST_SEVEN:
-                        tbi.cx = ScaleForDPI(19);
-                        break;
-                    case TBST_TEN:
-                        tbi.cx = ScaleForDPI(20);
-                        break;
-                    case TBST_TENNEW:
-                        tbi.cx = ScaleForDPI(17);
-                        break;
-                    case TBST_CUSTOM:
-                        tbi.cx = ScaleForDPI(settings.dropdownwidth);
-                        break;
-                }
-                SendMessageW(hToolbar, TB_SETBUTTONINFOW, 202, (LPARAM)&tbi);
+            /* Refresh width */
+            switch (settings.tbst)
+            {
+                case TBST_SEVEN:
+                    tbi.cx = ScaleForDPI(25);
+                    break;
+                case TBST_TEN:
+                    tbi.cx = ScaleForDPI(20);
+                    break;
+                case TBST_TENNEW:
+                    tbi.cx = ScaleForDPI(17);
+                    break;
+                case TBST_CUSTOM:
+                    tbi.cx = ScaleForDPI(settings.refreshwidth);
+                    break;
+            }
 
-                /* Refresh width */
-                switch (settings.tbst)
-                {
-                    case TBST_SEVEN:
-                        tbi.cx = ScaleForDPI(25);
-                        break;
-                    case TBST_TEN:
-                        tbi.cx = ScaleForDPI(20);
-                        break;
-                    case TBST_TENNEW:
-                        tbi.cx = ScaleForDPI(17);
-                        break;
-                    case TBST_CUSTOM:
-                        tbi.cx = ScaleForDPI(settings.refreshwidth);
-                        break;
-                }
-
-                /* Toolbar buttons 100-102 are go, stop, and refresh respectively */
-                for (int i = 100; i <= 102; i++)
-                {
-                    SendMessageW(hToolbar, TB_SETBUTTONINFOW, i, (LPARAM)&tbi);
-                }                   
+            /* Toolbar buttons 100-102 are go, stop, and refresh respectively */
+            for (int i = 100; i <= 102; i++)
+            {
+                SendMessageW(hwndTools, TB_SETBUTTONINFOW, i, (LPARAM)&tbi);
             }
         }
     }
@@ -1738,12 +1752,15 @@ LRESULT CALLBACK TravelBandToolbarSubclassProc(
     DWORD_PTR dwRefData
 )
 {
+    if (uMsg == TB_SETBUTTONSIZE)
+    {
+        return DefSubclassProc(hWnd, TB_SETBUTTONSIZE, 0, 0);
+    }
+
     if (settings.aerotravel)
     {
         switch (uMsg)
         {
-            case TB_SETBUTTONSIZE:
-                return DefSubclassProc(hWnd, TB_SETBUTTONSIZE, 0, 0);
             case TB_SETPADDING:
                 return DefSubclassProc(hWnd, TB_SETPADDING, 0, MAKELPARAM(1, 0));
         }
@@ -2289,6 +2306,60 @@ FOLDERFLAGS THISCALL IViewSettings_GetFolderFlags_hook(
     return ff;
 }
 
+/* Views dropdown on left */
+
+BOOL (__fastcall *IsRightSideCommand_orig)(REFGUID);
+BOOL __fastcall IsRightSideCommand_hook(REFGUID rguidCmd)
+{
+    return settings.leftviews ? FALSE : IsRightSideCommand_orig(rguidCmd);
+}
+
+HRESULT (THISCALL *CCommandFolder__AppendRightSideCommands_orig)(void *, IUnknown *);
+HRESULT THISCALL CCommandFolder__AppendRightSideCommands_hook(void *pThis, IUnknown *punk)
+{
+    return settings.leftviews ? S_OK : CCommandFolder__AppendRightSideCommands_orig(pThis, punk);
+}
+
+HRESULT (THISCALL *CCommandFolder__AppendOrganizeCommand_orig)(void *, IUnknown *);
+HRESULT THISCALL CCommandFolder__AppendOrganizeCommand_hook(void *pThis, IUnknown *punk)
+{
+    HRESULT hr = CCommandFolder__AppendOrganizeCommand_orig(pThis, punk);
+    if (settings.leftviews && SUCCEEDED(hr))
+    {
+        hr = CCommandFolder__AppendRightSideCommands_orig(pThis, punk);
+    }
+    return hr;
+}
+
+/* Command bar icons */
+
+#ifdef _WIN64
+#   define ExplorerCommandItem_iconIndex(pThis)  *((DWORD *)pThis + 10)
+#else
+#   define ExplorerCommandItem_iconIndex(pThis)  *((DWORD *)pThis + 8)
+#endif
+
+void (THISCALL *CSplitButton_UpdateIcon_orig)(void *, int);
+void THISCALL CSplitButton_UpdateIcon_hook(
+    void *pThis,
+    int nIndex
+)
+{
+    if (!settings.cmdbaricons)
+        CSplitButton_UpdateIcon_orig(pThis, nIndex);
+}
+
+void (THISCALL *CSplitButton__UpdateDisplay_orig)(void *pThis, const struct ExplorerCommandItem *);
+void THISCALL CSplitButton__UpdateDisplay_hook(
+    void *pThis,
+    const struct ExplorerCommandItem *pItem
+)
+{
+    if (settings.cmdbaricons)
+        CSplitButton_UpdateIcon_orig(pThis, ExplorerCommandItem_iconIndex(pItem));
+    CSplitButton__UpdateDisplay_orig(pThis, pItem);
+}
+
 #pragma endregion // "shell32.dll hooks"
 
 #pragma region "windows.storage.dll hooks"
@@ -2484,6 +2555,8 @@ void LoadSettings(void)
     LOAD_INT_SETTING(nopcfolders);
     LOAD_INT_SETTING(vistasearchplaceholder);
     LOAD_INT_SETTING(beta8navbarbg);
+    LOAD_INT_SETTING(leftviews);
+    LOAD_INT_SETTING(cmdbaricons);
 
     LPCWSTR szNpst = Wh_GetStringSetting(L"npst");
     if (0 == wcscmp(szNpst, L"vista"))
@@ -2565,7 +2638,7 @@ VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT *puPtrLen)
   */
 HMODULE LoadComCtlModule(void)
 {
-    HMODULE hShell32 = LoadLibraryW(L"shell32.dll");
+    HMODULE hShell32 = LoadLibraryExW(L"shell32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
     ACTCTXW actCtx = { sizeof(actCtx) };
     actCtx.dwFlags = ACTCTX_FLAG_RESOURCE_NAME_VALID | ACTCTX_FLAG_HMODULE_VALID;
     actCtx.lpResourceName = MAKEINTRESOURCEW(124);
@@ -2573,7 +2646,7 @@ HMODULE LoadComCtlModule(void)
     HANDLE hActCtx = CreateActCtxW(&actCtx);
     ULONG_PTR ulCookie;
     ActivateActCtx(hActCtx, &ulCookie);
-    HMODULE hComCtl = LoadLibraryW(L"comctl32.dll");
+    HMODULE hComCtl = LoadLibraryExW(L"comctl32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
     /**
       * Certain processes will ignore the activation context and load
       * comctl32.dll 5.82 anyway. If that occurs, just reject it.
@@ -2947,6 +3020,56 @@ const WindhawkUtils::SYMBOL_HOOK shell32DllHooks[] = {
         &IViewSettings_GetFolderFlags_orig,
         IViewSettings_GetFolderFlags_hook,
         false
+    },
+    {
+        {
+            L"int "
+            SSTDCALL
+            " IsRightSideCommand(struct _GUID const &)"
+        },
+        &IsRightSideCommand_orig,
+        IsRightSideCommand_hook,
+        false
+    },
+    {
+        {
+            L"private: long "
+            STHISCALL
+            " CCommandFolder::_AppendRightSideCommands(struct IUnknown *)"
+        },
+        &CCommandFolder__AppendRightSideCommands_orig,
+        CCommandFolder__AppendRightSideCommands_hook,
+        false
+    },
+    {
+        {
+            L"private: long "
+            STHISCALL
+            " CCommandFolder::_AppendOrganizeCommand(struct IUnknown *)"
+        },
+        &CCommandFolder__AppendOrganizeCommand_orig,
+        CCommandFolder__AppendOrganizeCommand_hook,
+        false
+    },
+    {
+        {
+            L"private: void "
+            STHISCALL
+            L" CSplitButton::UpdateIcon(int)"
+        },
+        &CSplitButton_UpdateIcon_orig,
+        CSplitButton_UpdateIcon_hook,
+        false
+    },
+    {
+        {
+            L"private: void "
+            STHISCALL
+            L" CSplitButton::_UpdateDisplay(struct ExplorerCommandItem const *)"
+        },
+        &CSplitButton__UpdateDisplay_orig,
+        CSplitButton__UpdateDisplay_hook,
+        false
     }
 };
 
@@ -2964,12 +3087,12 @@ const WindhawkUtils::SYMBOL_HOOK windowsStorageHooks[] = {
     }
 };
 
-#define LOAD_MODULE_(module, varName)                    \
-    HMODULE varName = LoadLibraryW(L ## #module ".dll"); \
-    if (!varName)                                        \
-    {                                                    \
-        Wh_Log(L"Failed to load " #module ".dll");       \
-        return FALSE;                                    \
+#define LOAD_MODULE_(module, varName)                                                          \
+    HMODULE varName = LoadLibraryExW(L ## #module ".dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32); \
+    if (!varName)                                                                              \
+    {                                                                                          \
+        Wh_Log(L"Failed to load " #module ".dll");                                             \
+        return FALSE;                                                                          \
     }
 
 #define LOAD_MODULE(name) LOAD_MODULE_(name, name)
@@ -3020,6 +3143,13 @@ BOOL Wh_ModInit(void)
 
     LOAD_MODULE(ExplorerFrame)
     HOOK_SYMBOLS(ExplorerFrame, explorerframeDllHooks)
+
+    VS_FIXEDFILEINFO *pVerInfo = GetModuleVersionInfo(ExplorerFrame, nullptr);
+    if (HIWORD(pVerInfo->dwFileVersionLS) > 21332)
+    {
+        Wh_Log(L"Rejecting Windows 11 ExplorerFrame.dll");
+        return FALSE;
+    }
 
     LOAD_MODULE(shell32)
     HOOK_SYMBOLS(shell32, shell32DllHooks)


### PR DESCRIPTION
- Fixes for classic theme
  - NOTE: Arrows not showing on the navigation pane is a bug in comctl32.dll that will probably be fixed in a separate mod at another time.
- Use `LoadLibraryExW` with `LOAD_LIBRARY_SEARCH_SYSTEM32` (#2063)
- Option for "Views" dropdown on left like Windows Vista
- Option for icons on all command bar items like Windows Vista
- Reject ExplorerFrame.dll with a build number higher than 21332 (#1618)