### PR TITLE
Aerexplorer 1.8.1

### DIFF
--- a/mods/aerexplorer.wh.cpp
+++ b/mods/aerexplorer.wh.cpp
@@ -92,7 +92,7 @@ Feel free to try it on other versions, but it may not work.
   $description: Dropdown icon width in address bar. Address toolbar sizing must be set to "Custom".
 - refreshwidth: 25
   $name: Refresh icon width
-  $description: Refresh icon widFth in address bar. Address toolbar sizing must be set to "Custom".
+  $description: Refresh icon width in address bar. Address toolbar sizing must be set to "Custom".
 - oldsearch: true
   $name: Old search box
   $description: Disable the EdgeHTML-based search box and use the old one instead. You must enable this option to fix the bug where the placeholder disappears.

--- a/mods/aerexplorer.wh.cpp
+++ b/mods/aerexplorer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              aerexplorer
 // @name            Aerexplorer
 // @description     Various tweaks for Windows Explorer to make it more like older versions.
-// @version         1.8.0
+// @version         1.8.1
 // @author          aubymori
 // @github          https://github.com/aubymori
 // @include         *
@@ -92,7 +92,7 @@ Feel free to try it on other versions, but it may not work.
   $description: Dropdown icon width in address bar. Address toolbar sizing must be set to "Custom".
 - refreshwidth: 25
   $name: Refresh icon width
-  $description: Refresh icon width in address bar. Address toolbar sizing must be set to "Custom".
+  $description: Refresh icon widFth in address bar. Address toolbar sizing must be set to "Custom".
 - oldsearch: true
   $name: Old search box
   $description: Disable the EdgeHTML-based search box and use the old one instead. You must enable this option to fix the bug where the placeholder disappears.
@@ -2356,7 +2356,15 @@ void THISCALL CSplitButton__UpdateDisplay_hook(
 )
 {
     if (settings.cmdbaricons)
-        CSplitButton_UpdateIcon_orig(pThis, ExplorerCommandItem_iconIndex(pItem));
+    {
+        int nIndex = ExplorerCommandItem_iconIndex(pItem);
+        // The "Open" command on EXE files has no icon, unlike Vista.
+        // If that's the case, just grab the default document icon (the
+        // blank page)
+        if (nIndex == -1)
+            nIndex = Shell_GetCachedImageIndexW(L"shell32.dll", -1, 0);
+        CSplitButton_UpdateIcon_orig(pThis, nIndex);
+    }
     CSplitButton__UpdateDisplay_orig(pThis, pItem);
 }
 
@@ -3142,14 +3150,13 @@ BOOL Wh_ModInit(void)
     LOAD_FUNCTION(propsys, VariantToBuffer)
 
     LOAD_MODULE(ExplorerFrame)
-    HOOK_SYMBOLS(ExplorerFrame, explorerframeDllHooks)
-
     VS_FIXEDFILEINFO *pVerInfo = GetModuleVersionInfo(ExplorerFrame, nullptr);
     if (!pVerInfo || HIWORD(pVerInfo->dwFileVersionLS) > 21332)
     {
         Wh_Log(L"Rejecting invalid or Windows 11 ExplorerFrame.dll");
         return FALSE;
     }
+    HOOK_SYMBOLS(ExplorerFrame, explorerframeDllHooks)
 
     LOAD_MODULE(shell32)
     HOOK_SYMBOLS(shell32, shell32DllHooks)


### PR DESCRIPTION
- Hook `ExplorerFrame.dll` symbols *after* checking its version
- Fix the "Open" command for EXE files not having an icon with the Command bar icons option enabled