### PR TITLE
Classic Conhost [Deprecated] 1.0.4

### DIFF
--- a/mods/classic-conhost.wh.cpp
+++ b/mods/classic-conhost.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              classic-conhost
-// @name            Classic Conhost
+// @name            Classic Conhost [Deprecated]
 // @description     Forces classic theme and optionally client edge on console windows
-// @version         1.0.3
+// @version         1.0.4
 // @author          aubymori
 // @github          https://github.com/aubymori
 // @include         *
@@ -12,17 +12,16 @@
 
 // ==WindhawkModReadme==
 /*
-# Classic Conhost
-
-This mod will apply classic theme and optionally client edge to console windows.
-
-# Deprecation notice
+# ⚠️ DEPRECATION NOTICE ⚠️
 As Windhawk hooking is unable to hook into `conhost.exe` reliably, this mod has many
 issues. For this reason, I forked the Windows Terminal's OpenConsole (which itself is
 basically the exact same as Windows' built-in conhost), and made it include the features
 from this mod. You can get my fork, ConhostEX, [here](https://github.com/aubymori/ConhostEX).
 Since this mod is outdated and has a successor, it is deprecated, will not receive any future
 updates, and I highly advise against using it.
+
+# Classic Conhost
+This mod will apply classic theme and optionally client edge to console windows.
 
 # IMPORTANT: READ!
 Windhawk and this mod need to inject into `conhost.exe` for this mod to work properly.
@@ -154,7 +153,6 @@ BOOL Wh_ModInit(void)
     }
 
     g_hObserverThread = CreateThread(NULL, NULL, ObserverThreadProc, NULL, NULL, NULL);
-    SetPriorityClass(g_hObserverThread, REALTIME_PRIORITY_CLASS);
     SetThreadPriority(g_hObserverThread, THREAD_PRIORITY_TIME_CRITICAL);
 
     return TRUE;


### PR DESCRIPTION
- Remove erroneous `SetPriorityClass` call
- Update mod title and README to make deprecation more clear