### PR TITLE
Old Regedit Tree Icons 1.0.0

### DIFF
--- a/mods/old-regedit-tree-icons.wh.cpp
+++ b/mods/old-regedit-tree-icons.wh.cpp
@@ -97,23 +97,16 @@ DECLARE_HOOK_FUNCTION(void, WINAPI, AddSystemImageIcon,
 
 #define STDCALL_STR FOR_64_32(L"__cdecl", L"__stdcall")
 
-#define BEGIN_SYMBOL_HOOKS(name) const WindhawkUtils::SYMBOL_HOOK name[] = {
-
-#define SIMPLE_SYMBOL_HOOK(name, ...) \
-{                                     \
-    {                                 \
-        __VA_ARGS__                   \
-    },                                \
-    &name ## _orig,                   \
-    name ## _hook,                    \
-    false                             \
-},
-
-#define END_SYMBOL_HOOKS()       };
-
-BEGIN_SYMBOL_HOOKS(regeditExeHooks)
-    SIMPLE_SYMBOL_HOOK(AddSystemImageIcon, L"void " STDCALL_STR L" AddSystemImageIcon(struct _IMAGELIST *,enum SHSTOCKICONID)")
-END_SYMBOL_HOOKS()
+const WindhawkUtils::SYMBOL_HOOK regeditExeHooks[] = {
+    {
+        {
+            L"void " STDCALL_STR L" AddSystemImageIcon(struct _IMAGELIST *,enum SHSTOCKICONID)"
+        },
+        &AddSystemImageIcon_orig,
+        AddSystemImageIcon_hook,
+        false
+    }
+};
 
 BOOL Wh_ModInit(void)
 {


### PR DESCRIPTION
In Windows XP and before, the Registry Editor's tree view had its own icons instead of using system icons. This mod reverts that behavior and makes it use its own icons again.

**Before**:
![Before](https://raw.githubusercontent.com/aubymori/images/refs/heads/main/old-regedit-tree-icons/before.png)

**After**:
![After](https://raw.githubusercontent.com/aubymori/images/refs/heads/main/old-regedit-tree-icons/after.png)