### PR TITLE
new mod: Explorer double F2 to rename file extension

### DIFF
--- a/mods/explorer-double-f2-rename-extension.wh.cpp
+++ b/mods/explorer-double-f2-rename-extension.wh.cpp
@@ -16,7 +16,8 @@ second press selects just the extension. That's handy to e.g. rename a zip file
 to a cbz file. This mod implements that same feature: double-press F2
 in Explorer to rename a file's extension.
 
-This works great together with [extension-change-no-warning](https://windhawk.net/mods/extension-change-no-warning).
+This works great together with
+[extension-change-no-warning](https://windhawk.net/mods/extension-change-no-warning).
 */
 // ==/WindhawkModReadme==
 
@@ -31,24 +32,106 @@ This works great together with [extension-change-no-warning](https://windhawk.ne
 // ChatGPT and the Windhawk Discord server.
 
 #include <string>
+#include <vector>
 
-DWORD explorerThreadId;
-HHOOK keyboardHook;
+static void SelectExtension(HWND editControl) {
+    // typical max filename length
+    std::wstring buffer(260, L'\0');
+    int copied = GetWindowTextW(editControl, buffer.data(), (int)buffer.size());
+    if (copied <= 0) {
+        return;
+    }
+    // trim to actual length
+    buffer.resize(copied);
+
+    size_t dotIndex = buffer.find_last_of(L'.');
+    if (dotIndex > 0 && dotIndex != std::wstring::npos) {
+        int start = (int)dotIndex + 1;
+        SendMessageW(editControl, EM_SETSEL, start, (WPARAM)buffer.size());
+        std::wstring extension = buffer.substr(dotIndex + 1);
+        Wh_Log(L"Selected extension \"%s\".", extension.c_str());
+    }
+}
 
 static ULONGLONG lastF2Time = 0;
 static bool lastWasF2 = false;
+static bool CALLBACK DoHandleKeyboard(int nCode, WPARAM wParam, LPARAM lParam) {
+    bool shouldProcess = nCode >= 0;
+    bool isKeyUp = lParam & 0x80000000;
+    if (!shouldProcess || !isKeyUp) {
+        return false;
+    }
 
-static void SelectExtension(HWND edit) {
-    int length = GetWindowTextLengthW(edit);
-    if (length > 0) {
-        std::wstring buffer(length, L'\0');
-        GetWindowTextW(edit, &buffer[0], length + 1);
+    bool isF2 = wParam == VK_F2;
+    if (!isF2) {
+        lastWasF2 = false;
+        return false;
+    }
 
-        size_t dotIndex = buffer.find_last_of(L'.');
-        int start = (dotIndex != std::wstring::npos && dotIndex != 0)
-                        ? (int)dotIndex + 1
-                        : 0;
-        SendMessageW(edit, EM_SETSEL, start, length);
+    auto doubleF2Time = (DWORD)Wh_GetIntSetting(L"DoubleF2MilliSeconds");
+    ULONGLONG now = GetTickCount64();
+
+    auto delta = now - lastF2Time;
+    lastF2Time = now;
+    bool isDouble = lastWasF2 && (delta <= doubleF2Time);
+    lastWasF2 = true;
+
+    Wh_Log(L"F2 pressed: isDouble=%d, delta=%llu.", isDouble, delta);
+
+    if (isDouble) {
+        HWND focus = GetFocus();
+        if (focus != nullptr) {
+            wchar_t cls[32];
+            GetClassNameW(focus, cls, _countof(cls));
+            if (_wcsicmp(cls, L"Edit") == 0) {
+                Wh_Log(L"Double F2 in edit control, selecting extension.");
+                SelectExtension(focus);
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+static LRESULT CALLBACK HandleKeyboard(int nCode,
+                                       WPARAM wParam,
+                                       LPARAM lParam) {
+    bool handled = DoHandleKeyboard(nCode, wParam, lParam);
+    return handled ? 0 : CallNextHookEx(nullptr, nCode, wParam, lParam);
+}
+
+static std::vector<HHOOK> keyboardHooks;
+static void AddKeyboardHook(DWORD threadId) {
+    HHOOK hook =
+        SetWindowsHookExW(WH_KEYBOARD, HandleKeyboard, nullptr, threadId);
+    if (hook != nullptr) {
+        keyboardHooks.push_back(hook);
+        Wh_Log(L"Installed keyboard hook %p on thread %u", hook, threadId);
+    }
+}
+static void RemoveKeyboardHooks() {
+    for (HHOOK hook : keyboardHooks) {
+        if (hook != nullptr) {
+            bool ok = UnhookWindowsHookEx(hook);
+            Wh_Log(L"Unhook %p -> %d", hook, ok);
+        }
+    }
+    keyboardHooks.clear();
+}
+
+static void HookIfExplorer(HWND windowHandle) {
+    if (windowHandle != nullptr && IsWindow(windowHandle)) {
+        wchar_t clazz[64];
+        if (GetClassNameW(windowHandle, clazz, _countof(clazz))) {
+            if (_wcsicmp(clazz, L"CabinetWClass") == 0 ||
+                _wcsicmp(clazz, L"ExploreWClass") == 0) {
+                DWORD threadId =
+                    GetWindowThreadProcessId(windowHandle, nullptr);
+                AddKeyboardHook(threadId);
+                Wh_Log(L"Hooked Explorer window: hwnd=0x%p class=%s.",
+                       windowHandle, clazz);
+            }
+        }
     }
 }
 
@@ -64,47 +147,6 @@ static HWND(WINAPI* originalCreateWindowExW)(DWORD dwExStyle,
                                              HMENU hMenu,
                                              HINSTANCE hInstance,
                                              LPVOID lpParam);
-
-static LRESULT CALLBACK HandleKeyboard(int nCode,
-                                       WPARAM wParam,
-                                       LPARAM lParam) {
-    auto shouldProcess = nCode >= 0;
-    auto isF2 = wParam == VK_F2;
-    auto isKeyUp = lParam & 0x80000000;
-
-    if (shouldProcess && isKeyUp) {
-        if (isF2) {
-            ULONGLONG now = GetTickCount64();
-            auto doubleF2Time = (DWORD)Wh_GetIntSetting(L"DoubleF2MilliSeconds");
-            bool isDouble = lastWasF2 && (now - lastF2Time <= doubleF2Time);
-
-            lastWasF2 = true;
-            lastF2Time = now;
-
-            Wh_Log(L"F2 pressed: isDouble=%d, delta=%llu.", isDouble ? 1 : 0,
-                   now - lastF2Time);
-
-            if (isDouble) {
-                HWND focus = GetFocus();
-                if (focus != nullptr) {
-                    wchar_t cls[32];
-                    GetClassNameW(focus, cls, _countof(cls));
-                    if (_wcsicmp(cls, L"Edit") == 0) {
-                        Wh_Log(
-                            L"Double F2 in edit control, selecting extension.");
-                        SelectExtension(focus);
-                        return 0;  // swallow
-                    }
-                }
-            }
-        } else {
-            lastWasF2 = false;
-        }
-    }
-
-    return CallNextHookEx(keyboardHook, nCode, wParam, lParam);
-}
-
 static HWND WINAPI HookedCreateWindowExW(DWORD dwExStyle,
                                          LPCWSTR lpClassName,
                                          LPCWSTR lpWindowName,
@@ -121,32 +163,27 @@ static HWND WINAPI HookedCreateWindowExW(DWORD dwExStyle,
     HWND hwnd = originalCreateWindowExW(dwExStyle, lpClassName, lpWindowName,
                                         dwStyle, X, Y, nWidth, nHeight,
                                         hWndParent, hMenu, hInstance, lpParam);
-
-    // only proceed if hwnd is valid and fully created
-    if (hwnd && IsWindow(hwnd)) {
-        wchar_t cls[64];
-        if (GetClassNameW(hwnd, cls, _countof(cls))) {
-            if (_wcsicmp(cls, L"CabinetWClass") == 0 ||
-                _wcsicmp(cls, L"ExploreWClass") == 0) {
-                Wh_Log(L"New Explorer window created: hwnd=0x%p class=%s.",
-                       hwnd, cls);
-                explorerThreadId = GetWindowThreadProcessId(hwnd, nullptr);
-                keyboardHook = SetWindowsHookExW(WH_KEYBOARD, HandleKeyboard,
-                                                 nullptr, explorerThreadId);
-            }
-        }
-    }
-
+    HookIfExplorer(hwnd);
     return hwnd;
+}
+
+static BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
+    HookIfExplorer(hwnd);
+    // continue enumeration
+    return true;
 }
 
 void Wh_ModInit() {
     Wh_Log(L"Double F2 initializing.");
-    HWND shellWnd = GetShellWindow();
-    explorerThreadId = GetWindowThreadProcessId(shellWnd, nullptr);
-    keyboardHook = SetWindowsHookExW(WH_KEYBOARD, HandleKeyboard, nullptr,
-                                     explorerThreadId);
 
+    Wh_Log(L"Hooking the desktop (shell) thread.");
+    DWORD shellThreadId = GetWindowThreadProcessId(GetShellWindow(), nullptr);
+    AddKeyboardHook(shellThreadId);
+
+    Wh_Log(L"Hooking already open Explorer windows.");
+    EnumWindows(EnumWindowsProc, 0);
+
+    Wh_Log(L"Hooking Explorer window creation.");
     Wh_SetFunctionHook((void*)CreateWindowExW, (void*)HookedCreateWindowExW,
                        (void**)&originalCreateWindowExW);
 }
@@ -154,18 +191,6 @@ void Wh_ModInit() {
 void Wh_ModUninit() {
     Wh_Log(L"Double F2 uninitializing.");
 
-    if (keyboardHook != nullptr) {
-        BOOL ok = UnhookWindowsHookEx(keyboardHook);
-        Wh_Log(L"UnhookWindowsHookEx(keyboardHook) -> %d", ok ? 1 : 0);
-        keyboardHook = nullptr;
-    }
-
-    // If you ever installed additional per-window hooks when new explorer
-    // windows were created, make sure you unhook them when you replace them.
-    // Example: if you set a new keyboardHook in hookedCreateWindowExW, you must
-    // unhook the previous one before overwriting the variable.
-    //
-    // Windhawk removes the function hook you installed with Wh_SetFunctionHook
-    // automatically, so you don't need to explicitly restore
-    // originalCreateWindowExW here.
+    Wh_Log(L"Removing all keyboard hooks.");
+    RemoveKeyboardHooks();
 }

--- a/mods/explorer-double-f2-rename-extension.wh.cpp
+++ b/mods/explorer-double-f2-rename-extension.wh.cpp
@@ -1,0 +1,171 @@
+// ==WindhawkMod==
+// @id              explorer-double-f2-rename-extension
+// @name            Select filename extension on double F2
+// @description     When pressing F2 in Explorer to rename a file, the filename is selected as usual, but double-pressing now selects the extension.
+// @version         1
+// @author          Marnes <leaumar@sent.com>
+// @github          https://github.com/leaumar
+// @include         explorer.exe
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+QTTabbar and some other tools provide a feature where double-pressing F2 to
+rename a file first selects the entire name (existing Explorer behavior) but the
+second press selects just the extension. That's handy to e.g. rename a zip file
+to a cbz file. This mod implements that same feature: double-press F2
+in Explorer to rename a file's extension.
+
+This works great together with [extension-change-no-warning](https://windhawk.net/mods/extension-change-no-warning).
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- DoubleF2MilliSeconds: 1000
+*/
+// ==/WindhawkModSettings==
+
+// I am not an experienced C++ programmer and do not know the Windows APIs.
+// This code was cobbled together with a lot trial & error, using input from
+// ChatGPT and the Windhawk Discord server.
+
+#include <string>
+
+DWORD explorerThreadId;
+HHOOK keyboardHook;
+
+static ULONGLONG lastF2Time = 0;
+static bool lastWasF2 = false;
+
+static void SelectExtension(HWND edit) {
+    int length = GetWindowTextLengthW(edit);
+    if (length > 0) {
+        std::wstring buffer(length, L'\0');
+        GetWindowTextW(edit, &buffer[0], length + 1);
+
+        size_t dotIndex = buffer.find_last_of(L'.');
+        int start = (dotIndex != std::wstring::npos && dotIndex != 0)
+                        ? (int)dotIndex + 1
+                        : 0;
+        SendMessageW(edit, EM_SETSEL, start, length);
+    }
+}
+
+static HWND(WINAPI* originalCreateWindowExW)(DWORD dwExStyle,
+                                             LPCWSTR lpClassName,
+                                             LPCWSTR lpWindowName,
+                                             DWORD dwStyle,
+                                             int X,
+                                             int Y,
+                                             int nWidth,
+                                             int nHeight,
+                                             HWND hWndParent,
+                                             HMENU hMenu,
+                                             HINSTANCE hInstance,
+                                             LPVOID lpParam);
+
+static LRESULT CALLBACK HandleKeyboard(int nCode,
+                                       WPARAM wParam,
+                                       LPARAM lParam) {
+    auto shouldProcess = nCode >= 0;
+    auto isF2 = wParam == VK_F2;
+    auto isKeyUp = lParam & 0x80000000;
+
+    if (shouldProcess && isKeyUp) {
+        if (isF2) {
+            ULONGLONG now = GetTickCount64();
+            auto doubleF2Time = (DWORD)Wh_GetIntSetting(L"DoubleF2MilliSeconds");
+            bool isDouble = lastWasF2 && (now - lastF2Time <= doubleF2Time);
+
+            lastWasF2 = true;
+            lastF2Time = now;
+
+            Wh_Log(L"F2 pressed: isDouble=%d, delta=%llu.", isDouble ? 1 : 0,
+                   now - lastF2Time);
+
+            if (isDouble) {
+                HWND focus = GetFocus();
+                if (focus != nullptr) {
+                    wchar_t cls[32];
+                    GetClassNameW(focus, cls, _countof(cls));
+                    if (_wcsicmp(cls, L"Edit") == 0) {
+                        Wh_Log(
+                            L"Double F2 in edit control, selecting extension.");
+                        SelectExtension(focus);
+                        return 0;  // swallow
+                    }
+                }
+            }
+        } else {
+            lastWasF2 = false;
+        }
+    }
+
+    return CallNextHookEx(keyboardHook, nCode, wParam, lParam);
+}
+
+static HWND WINAPI HookedCreateWindowExW(DWORD dwExStyle,
+                                         LPCWSTR lpClassName,
+                                         LPCWSTR lpWindowName,
+                                         DWORD dwStyle,
+                                         int X,
+                                         int Y,
+                                         int nWidth,
+                                         int nHeight,
+                                         HWND hWndParent,
+                                         HMENU hMenu,
+                                         HINSTANCE hInstance,
+                                         LPVOID lpParam) {
+    // always call the original first
+    HWND hwnd = originalCreateWindowExW(dwExStyle, lpClassName, lpWindowName,
+                                        dwStyle, X, Y, nWidth, nHeight,
+                                        hWndParent, hMenu, hInstance, lpParam);
+
+    // only proceed if hwnd is valid and fully created
+    if (hwnd && IsWindow(hwnd)) {
+        wchar_t cls[64];
+        if (GetClassNameW(hwnd, cls, _countof(cls))) {
+            if (_wcsicmp(cls, L"CabinetWClass") == 0 ||
+                _wcsicmp(cls, L"ExploreWClass") == 0) {
+                Wh_Log(L"New Explorer window created: hwnd=0x%p class=%s.",
+                       hwnd, cls);
+                explorerThreadId = GetWindowThreadProcessId(hwnd, nullptr);
+                keyboardHook = SetWindowsHookExW(WH_KEYBOARD, HandleKeyboard,
+                                                 nullptr, explorerThreadId);
+            }
+        }
+    }
+
+    return hwnd;
+}
+
+void Wh_ModInit() {
+    Wh_Log(L"Double F2 initializing.");
+    HWND shellWnd = GetShellWindow();
+    explorerThreadId = GetWindowThreadProcessId(shellWnd, nullptr);
+    keyboardHook = SetWindowsHookExW(WH_KEYBOARD, HandleKeyboard, nullptr,
+                                     explorerThreadId);
+
+    Wh_SetFunctionHook((void*)CreateWindowExW, (void*)HookedCreateWindowExW,
+                       (void**)&originalCreateWindowExW);
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"Double F2 uninitializing.");
+
+    if (keyboardHook != nullptr) {
+        BOOL ok = UnhookWindowsHookEx(keyboardHook);
+        Wh_Log(L"UnhookWindowsHookEx(keyboardHook) -> %d", ok ? 1 : 0);
+        keyboardHook = nullptr;
+    }
+
+    // If you ever installed additional per-window hooks when new explorer
+    // windows were created, make sure you unhook them when you replace them.
+    // Example: if you set a new keyboardHook in hookedCreateWindowExW, you must
+    // unhook the previous one before overwriting the variable.
+    //
+    // Windhawk removes the function hook you installed with Wh_SetFunctionHook
+    // automatically, so you don't need to explicitly restore
+    // originalCreateWindowExW here.
+}


### PR DESCRIPTION
As the comment in the mod says, I only have basic C++ experience and none using windows shell apis. I did test this in every way I could think and found no problems after fixing initial issues like crashes on unloading (not unhooking my function in uninit).

Usecase: I often rename zip files to cbz (image sets), misnamed videos/images from websites to the right extension, js to ts, that kind of stuff. Qdir/Qttabbar and some other tools implement this same feature and I miss having it in vanilla explorer. There's already the mod to suppress the rename warning, now let's make the rename itself easier to get to. Ctrl-backspace in explorer's rename field works weirdly so changing just the extension has always been a PITA.

Edit: reference to [extension-change-no-warning](https://windhawk.net/mods/extension-change-no-warning)