### PR TITLE
Control Panel Color Fix v1.0

### DIFF
--- a/mods/control-panel-color-fix.wh.cpp
+++ b/mods/control-panel-color-fix.wh.cpp
@@ -91,7 +91,7 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
-    HMODULE hMod = LoadLibraryW(L"dui70.dll");
+    HMODULE hMod = LoadLibraryExW(L"dui70.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (!hMod) {
         Wh_Log(L"Failed to load dui70.dll.");
         return FALSE;


### PR DESCRIPTION
A Windhawk mod that repaints the hardcoded white header and sidebar in Control Panel
using the current theme background color. Windows 11 only.
