### PR TITLE
Add mod to hide ghost windows and inactive Groupy 2 tabs in Alt+Tab

### DIFF
--- a/mods/alt-tab-hide-ghost-windows.wh.cpp
+++ b/mods/alt-tab-hide-ghost-windows.wh.cpp
@@ -1,6 +1,6 @@
 // ==WindhawkMod==
 // @id              alt-tab-hide-ghost-windows
-// @name            Alt+Tab: Hide ghost windows, inactive Groupy 2 tabs and/or minimized windows
+// @name            Alt+Tab: Hide ghost windows
 // @description     Hides windows in Alt+Tab that are too small or have no title, preventing "ghost" windows from cluttering the switcher. Can also hide inactive Groupy 2 tabs and/or minimized windows.
 // @version         1.0
 // @author          David Trapp (CherryDT)


### PR DESCRIPTION
This mod filters out small or titleless windows from the Alt+Tab window switcher, preventing "ghost" windows from appearing in the list (for example, the ThinkPad External Keyboard with Trackpoint Driver is notorious for having two 0x0 windows that show up in Alt+Tab all the time, and this mod will get rid of them).

It can also hide inactive Groupy 2 tabs (which unlike in Groupy 1 do show up in Alt+Tab by default) and/or all minimized windows, depending on settings.