### PR TITLE
Classic Minimize/Maximize Animations 1.0.0

### DIFF
--- a/mods/classic-min-max-animations.wh.cpp
+++ b/mods/classic-min-max-animations.wh.cpp
@@ -1,0 +1,887 @@
+// ==WindhawkMod==
+// @id              classic-min-max-animations
+// @name            Classic Minimize/Maximize Animations
+// @description     Restores the classic minimize/maximize animations used without DWM
+// @version         1.0.0
+// @author          aubymori
+// @github          https://github.com/aubymori
+// @include         *
+// @compilerOptions -lgdi32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Classic Minimize/Maximize Animations
+From Windows 95 to XP, and in Vista and above without DWM running, windows had
+a minimize/maximize animation that involved the titlebar moving across the screen.
+This mod makes that animation play with DWM enabled by reimplementing it.
+
+## Usage note
+You must turn off the regular window animations in order for this mod to look correct.
+To do this:
+1. Run `sysdm.cpl` either from Start search or the Run dialog (WinKey + R).
+2. Go to the "Advanced" tab.
+3. Click "Settings..." under "Performance"
+4. Uncheck "Animate windows when minimizing and maximizing"
+5. Click Apply.
+
+## Previews
+**Top-level window**:
+
+![Top-level window](https://raw.githubusercontent.com/aubymori/images/refs/heads/main/classic-min-max-animations/toplevel.gif)
+
+**MDI child window**:
+
+![MDI child window](https://raw.githubusercontent.com/aubymori/images/refs/heads/main/classic-min-max-animations/mdi.gif)
+*/
+// ==/WindhawkModReadme==
+
+#include <windhawk_utils.h>
+
+/* Defines */
+#ifdef _WIN64
+#   define FASTCALL_STR L"__cdecl"
+#else
+#   define FASTCALL_STR L"__fastcall"
+#endif
+#define min(x, y)       ((x) > (y)) ? (y) : (x)
+#define max(x, y)       ((x) > (y)) ? (x) : (y)
+#define RECTWIDTH(rc)   ((rc).right - (rc).left)
+#define RECTHEIGHT(rc)  ((rc).bottom - (rc).top)
+
+/* Globals */
+UINT       g_uMsgMinMax      =     -1;
+bool       g_fAnimating      =  false;
+bool       g_fDisabled       =  false;
+HINSTANCE  g_hinst           =   NULL;
+HWND       g_hwndAnim        =   NULL;
+HANDLE     g_hAnimWndThread  =   NULL;
+
+/* Type and function definitions */
+typedef BOOL (WINAPI *GetWindowMinimizeRect_t)(HWND hwnd, LPRECT prcMin);
+GetWindowMinimizeRect_t GetWindowMinimizeRect;
+typedef HICON (WINAPI *InternalGetWindowIcon_t)(HWND hwnd, UINT uIconType);
+InternalGetWindowIcon_t InternalGetWindowIcon;
+
+typedef struct tagWND WND, *PWND;
+
+typedef struct _MINMAXPARAMS
+{
+    HWND   hwnd;
+    HICON  hIcon;
+    WCHAR  szCaptionText[256];
+    RECT   rcMax;
+} MINMAXPARAMS, *LPMINMAXPARAMS;
+
+BOOL (__fastcall *GetWindowBordersForDpi)(LONG lStyle, DWORD dwExStyle, BOOL fWindow, BOOL fClient, UINT dpi);
+PWND (__fastcall *ValidateHwnd)(HWND hWnd);
+#ifndef _M_IX86
+BOOL (WINAPI *_HasCaptionIcon)(PWND pwnd);
+#else // x86-32 calling convention nonsense
+BOOL (WINAPI *_HasCaptionIcon)(PWND pwnd, int);
+#define _HasCaptionIcon(pwnd) _HasCaptionIcon(pwnd, 0)
+#endif
+
+DWORD CALLBACK AnimWndThreadProc(HANDLE hEvent);
+
+#pragma region "DWP hooks"
+
+LPMINMAXPARAMS CreateMinMaxParams(HWND hwnd, UINT cmd)
+{
+    LPMINMAXPARAMS lpmmp = (LPMINMAXPARAMS)GlobalAlloc(GPTR, sizeof(MINMAXPARAMS));
+    if (!lpmmp)
+        return nullptr;
+
+    lpmmp->hwnd = hwnd;
+
+    lpmmp->hIcon = InternalGetWindowIcon(hwnd, ICON_SMALL);
+
+    /* The window's thread is blocked by the animation, and DrawCaption is unabled
+       to send WM_GETTEXT to get the text, so we draw it ourselves. The array size
+       is accurate to the amount of characters Windows displays in the titlebar. */
+    lpmmp->szCaptionText[0] = L'\0';
+    GetWindowTextW(hwnd, lpmmp->szCaptionText, ARRAYSIZE(lpmmp->szCaptionText));
+
+    /* We also need to get the maximize rect while we still have access to the message
+       queue. We construct a default maximized rect and then send that over to the window's
+       WM_GETMINMAXINFO handler to get the true maximized size, which may not be the same
+       as the monitor work area (Conhost V1). */
+    if (cmd == SC_MAXIMIZE || cmd == SC_RESTORE)
+    {
+        MINMAXINFO mmi = {};
+        int cBorders = GetWindowBordersForDpi(
+            GetWindowLongW(hwnd, GWL_STYLE),
+            GetWindowLongW(hwnd, GWL_EXSTYLE),
+            TRUE, FALSE, GetDpiForWindow(hwnd)
+        );
+        HMONITOR hmon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTOPRIMARY);
+        MONITORINFO mi = { sizeof(mi) };
+        GetMonitorInfoW(hmon, &mi);
+        InflateRect(&mi.rcWork, cBorders, cBorders);
+        
+        mmi.ptMaxPosition.x = mi.rcWork.left;
+        mmi.ptMaxPosition.y = mi.rcWork.top;
+        mmi.ptMaxSize.x     = RECTWIDTH(mi.rcWork);
+        mmi.ptMaxSize.y     = RECTHEIGHT(mi.rcWork);
+
+        SendMessageW(hwnd, WM_GETMINMAXINFO, 0, (LPARAM)&mmi);
+        lpmmp->rcMax.left   = mmi.ptMaxPosition.x;
+        lpmmp->rcMax.top    = mmi.ptMaxPosition.y;
+        lpmmp->rcMax.right  = mmi.ptMaxPosition.x + mmi.ptMaxSize.x;
+        lpmmp->rcMax.bottom = mmi.ptMaxPosition.y + mmi.ptMaxSize.y;
+    }
+    
+    return lpmmp;
+}
+
+bool WaitForAnimWndThread(void)
+{
+    /* If we don't have the animation thread yet, start it and wait for the
+        window to come up. */
+    if (!g_hAnimWndThread)
+    {
+        HANDLE hEvent = CreateEventW(nullptr, TRUE, FALSE, L"UAH_MinMax_WaitForWindow");
+        g_hAnimWndThread = CreateThread(nullptr, 0, AnimWndThreadProc, hEvent, 0, nullptr);
+        // If it doesn't come up after one second, we messed up bad somehow.
+        DWORD dwWait = WaitForSingleObject(hEvent, 1000);
+        if (dwWait != WAIT_OBJECT_0)
+        {
+            MessageBoxW(
+                NULL,
+                L"Somehow, creating the animation window failed. For your convenience, the mod "
+                L"has been disabled for this process.",
+                // =================================== //
+                L"Windhawk: Classic Minimize/Maximize Animations",
+                MB_ICONERROR
+            );
+            g_fDisabled = true;
+            return false;
+        }
+        CloseHandle(hEvent);
+
+        // Extra sleep to circumvent a race condition
+        Sleep(30);
+    }
+    return true;
+}
+
+void MinMaxWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    if (g_fDisabled)
+        return;
+
+    switch (uMsg)
+    {
+        case WM_SYSCOMMAND:
+        {
+            UINT cmd = wParam & 0xFFF0;
+            switch (cmd)
+            {
+                case SC_MINIMIZE:
+                case SC_MAXIMIZE:
+                case SC_RESTORE:
+                {
+                    if (!WaitForAnimWndThread() || g_fAnimating)
+                        return;
+
+                    LPMINMAXPARAMS lpmmp = CreateMinMaxParams(hwnd, cmd);
+                    if (!lpmmp)
+                        return;
+
+                    SendMessageW(g_hwndAnim, g_uMsgMinMax, cmd, (LPARAM)lpmmp);
+                    break;
+                }
+            }
+            return;
+        }
+        default:
+            return;
+    }
+}
+
+#define DWP_HOOK_(name, defArgs, callArgs) \
+LRESULT (CALLBACK *name ## _orig) defArgs; \
+LRESULT CALLBACK name ## _hook  defArgs \
+{ \
+    MinMaxWndProc(hWnd, uMsg, wParam, lParam); \
+    return name ## _orig  callArgs; \
+}
+
+#define DWP_HOOK(name, defArgs, callArgs)  \
+    DWP_HOOK_(name ## A, defArgs, callArgs) \
+    DWP_HOOK_(name ## W, defArgs, callArgs) \
+
+DWP_HOOK(
+    DefWindowProc,
+    (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam),
+    (hWnd, uMsg, wParam, lParam))
+DWP_HOOK(
+    DefFrameProc,
+    (HWND hWnd, HWND hWndMDIClient, UINT uMsg, WPARAM wParam, LPARAM lParam),
+    (hWnd, hWndMDIClient, uMsg, wParam, lParam))
+DWP_HOOK(
+    DefMDIChildProc,
+    (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam),
+    (hWnd, uMsg, wParam, lParam))
+DWP_HOOK(
+    DefDlgProc,
+    (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam),
+    (hWnd, uMsg, wParam, lParam))
+
+using ShowWindow_t = decltype(&ShowWindow);
+ShowWindow_t ShowWindow_orig;
+BOOL WINAPI ShowWindow_hook(HWND hWnd, int nCmdShow)
+{
+    if (g_fDisabled || g_fAnimating || !IsWindowVisible(hWnd))
+        return ShowWindow_orig(hWnd, nCmdShow);
+
+    DWORD dwStyle = GetWindowLongW(hWnd, GWL_STYLE);
+    // Don't want to animate a window without a caption.
+    if (!(dwStyle & WS_CAPTION))
+        return ShowWindow_orig(hWnd, nCmdShow);
+
+    UINT cmd;
+    switch (nCmdShow)
+    {
+        case SW_MAXIMIZE:
+            cmd = SC_MAXIMIZE;
+            break;
+        case SW_MINIMIZE:
+            cmd = SC_MINIMIZE;
+            break;
+        case SW_RESTORE:
+            cmd = SC_RESTORE;
+            break;
+        default:
+            return ShowWindow_orig(hWnd, nCmdShow);
+    }
+    
+    if (!WaitForAnimWndThread())
+        return ShowWindow_orig(hWnd, nCmdShow);
+
+    LPMINMAXPARAMS lpmmp = CreateMinMaxParams(hWnd, cmd);
+    if (!lpmmp)
+        return ShowWindow_orig(hWnd, nCmdShow);
+
+    SendMessageW(g_hwndAnim, g_uMsgMinMax, cmd, (LPARAM)lpmmp);
+    return ShowWindow_orig(hWnd, nCmdShow);
+}
+
+using ShowWindowAsync_t = decltype(&ShowWindowAsync);
+ShowWindowAsync_t ShowWindowAsync_orig;
+BOOL WINAPI ShowWindowAsync_hook(HWND hWnd, int nCmdShow)
+{
+    if (g_fDisabled || g_fAnimating || !IsWindowVisible(hWnd))
+        return ShowWindowAsync_orig(hWnd, nCmdShow);
+
+    DWORD dwStyle = GetWindowLongW(hWnd, GWL_STYLE);
+    // Don't want to animate a window without a caption.
+    if (!(dwStyle & WS_CAPTION))
+        return ShowWindowAsync_orig(hWnd, nCmdShow);
+
+    UINT cmd;
+    switch (nCmdShow)
+    {
+        case SW_MAXIMIZE:
+            cmd = SC_MAXIMIZE;
+            break;
+        case SW_MINIMIZE:
+            cmd = SC_MINIMIZE;
+            break;
+        case SW_RESTORE:
+            cmd = SC_RESTORE;
+            break;
+        default:
+            return ShowWindowAsync_orig(hWnd, nCmdShow);
+    }
+    
+    if (!WaitForAnimWndThread())
+        return ShowWindowAsync_orig(hWnd, nCmdShow);
+
+    LPMINMAXPARAMS lpmmp = CreateMinMaxParams(hWnd, cmd);
+    if (!lpmmp)
+        return ShowWindowAsync_orig(hWnd, nCmdShow);
+
+    SendMessageW(g_hwndAnim, g_uMsgMinMax, cmd, (LPARAM)lpmmp);
+    return ShowWindowAsync_orig(hWnd, nCmdShow);
+}
+
+#pragma endregion // "DWP hooks"
+
+#pragma region "Animation implementation"
+
+void AdjustRectForWindowBorder(HWND hwnd, LPRECT prc)
+{
+    int cBorders = GetWindowBordersForDpi(
+        GetWindowLongPtrW(hwnd, GWL_STYLE),
+        GetWindowLongPtrW(hwnd, GWL_EXSTYLE),
+        TRUE, FALSE,
+        GetDpiForWindow(hwnd)
+    );
+    InflateRect(prc, -cBorders, 0);
+    OffsetRect(prc, 0, cBorders);
+    prc->bottom -= 2 * cBorders;
+}
+
+LRESULT CALLBACK AnimWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    if (uMsg == g_uMsgMinMax)
+    {
+        constexpr UINT ANIMATION_DURATION_MS = 250;
+
+        g_fAnimating = true;
+
+        UINT cmd = (UINT)wParam;
+        LPMINMAXPARAMS lpmmp = (LPMINMAXPARAMS)lParam;
+        HWND hwndTarget = lpmmp->hwnd;
+        UINT dpi = GetDpiForWindow(hwndTarget);
+
+        bool fAnimate = false;
+        DWORD dwStyle = GetWindowLongW(hwndTarget, GWL_STYLE);
+        switch (cmd)
+        {
+            case SC_MAXIMIZE:
+                fAnimate = !(dwStyle & WS_MAXIMIZE);
+                break;
+            case SC_MINIMIZE:
+                fAnimate = !(dwStyle & WS_MINIMIZE);
+                break;
+            case SC_RESTORE:
+                fAnimate = (dwStyle & WS_MAXIMIZE) || (dwStyle & WS_MINIMIZE);
+                break;
+        }
+        if (!fAnimate)
+        {
+            g_fAnimating = false;
+            if (lpmmp->hIcon)
+            {
+                DestroyIcon(lpmmp->hIcon);
+                lpmmp->hIcon = NULL;
+            }
+            GlobalFree(lpmmp);
+            return 0;
+        }
+
+        /* Screenshot desktop */
+        HDC hdcDesk = GetDC(NULL);
+        HDC hdcMem  = CreateCompatibleDC(hdcDesk);
+
+        int xVirtualScreen  = GetSystemMetrics(SM_XVIRTUALSCREEN);
+        int yVirtualScreen  = GetSystemMetrics(SM_YVIRTUALSCREEN);
+        int cxVirtualScreen = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+        int cyVirtualScreen = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+
+        HBITMAP hbmDesk = CreateCompatibleBitmap(hdcDesk, cxVirtualScreen, cyVirtualScreen);
+        SelectObject(hdcMem, hbmDesk);
+        BitBlt(
+            hdcMem,
+            0, 0,
+            cxVirtualScreen, cyVirtualScreen,
+            hdcDesk,
+            xVirtualScreen, yVirtualScreen,
+            SRCCOPY
+        );
+
+        DeleteDC(hdcMem);
+        ReleaseDC(NULL, hdcDesk);
+
+        /* Update window position and size */
+        SetWindowPos(
+            hwnd,
+            HWND_TOPMOST,
+            xVirtualScreen,
+            yVirtualScreen,
+            cxVirtualScreen,
+            cyVirtualScreen,
+            SWP_NOACTIVATE
+        );
+
+        RECT rcFrom, rcTo;
+
+        /* Get initial rect */
+        GetWindowRect(hwndTarget, &rcFrom);
+        // Window is minimized, get the minimize rect instead of the regular
+        // window rect
+        if (rcFrom.left == -32000)
+        {
+            GetWindowMinimizeRect(hwndTarget, &rcFrom);
+        }
+        AdjustRectForWindowBorder(hwndTarget, &rcFrom);
+
+        /* Get rect after animation */
+        switch (cmd)
+        {
+            case SC_MINIMIZE:
+                GetWindowMinimizeRect(hwndTarget, &rcTo);
+                break;
+            case SC_MAXIMIZE:
+            {
+GetMaximizeRect:
+                CopyRect(&rcTo, &lpmmp->rcMax);
+                AdjustRectForWindowBorder(hwndTarget, &rcTo);
+                break;
+            }
+            case SC_RESTORE:
+            {
+                WINDOWPLACEMENT wp = { sizeof(wp) };
+                GetWindowPlacement(hwndTarget, &wp);
+                if ((dwStyle & WS_MINIMIZE)
+                && (wp.flags & WPF_RESTORETOMAXIMIZED))
+                {
+                    goto GetMaximizeRect;
+                }
+                else
+                {
+                    CopyRect(&rcTo, &wp.rcNormalPosition);
+                    if (!(dwStyle & WS_CHILD))
+                    {
+                        // If the window is not a child window (MDI), the rectangle
+                        // received in rcNormalPosition after calling GetWindowPlacement
+                        // has the distance from the top left of the monitor's work area
+                        // to the monitor's top left edge subtracted. I don't know why they
+                        // do this, and it's not referenced in any official documentation...
+                        MONITORINFO mi = { sizeof(mi) };
+                        HMONITOR hmon = MonitorFromWindow(hwndTarget, MONITOR_DEFAULTTOPRIMARY);
+                        if (hmon && GetMonitorInfoW(hmon, &mi))
+                        {
+                            OffsetRect(&rcTo,
+                                -(mi.rcMonitor.left - mi.rcWork.left),
+                                -(mi.rcMonitor.top - mi.rcWork.top));
+                        }
+                    }
+                    AdjustRectForWindowBorder(hwndTarget, &rcTo);
+                }
+                break;
+            }
+        }
+
+        // Adjust child coords to screen coords (MDI)
+        // For some reason only the destination rect is in child coords
+        HWND hwndParent;
+        if ((dwStyle & WS_CHILD) && (hwndParent = GetParent(hwndTarget)))
+        {
+            MapWindowPoints(hwndParent, HWND_DESKTOP, (LPPOINT)&rcTo, 2);
+        }
+        
+        // Convert from screen coordinates to window coordinates
+        OffsetRect(&rcFrom, -xVirtualScreen, -yVirtualScreen);
+        OffsetRect(&rcTo,   -xVirtualScreen, -yVirtualScreen);
+
+        /* Show window and start the animation */
+
+        // Make window fully transparent before showing it. Otherwise, there is a chance
+        // that the last frame of the previous animation (or a completely white screen
+        // if no animation was played before) will show before we blit the desktop.
+        SetLayeredWindowAttributes(hwnd, 0, 0, LWA_ALPHA);
+        ShowWindow_orig(hwnd, SW_SHOW);
+
+        HDC hdc = GetDC(hwnd);
+        // Desktop image DC:
+        hdcDesk = CreateCompatibleDC(hdc);
+        SelectObject(hdcDesk, hbmDesk);
+        // Double buffer DC:
+        hdcMem = CreateCompatibleDC(hdc);
+        HBITMAP hbmMem = CreateCompatibleBitmap(hdcDesk, cxVirtualScreen, cyVirtualScreen);
+        SelectObject(hdcMem, hbmMem);
+
+        // Blit full desktop image first:
+        BitBlt(hdc, 0, 0, cxVirtualScreen, cyVirtualScreen, hdcDesk, 0, 0, SRCCOPY);
+        // Make window opaque after drawing the desktop
+        SetLayeredWindowAttributes(hwnd, 0, 255, LWA_ALPHA);
+
+        // Then start animation:
+        UINT64 uStartTime = GetTickCount64();
+        UINT64 uElapsedTime = 0;
+        RECT rcCurrent;
+        CopyRect(&rcCurrent, &rcFrom);
+
+        // Icon metrics:
+        int cxIcon    = GetSystemMetricsForDpi(SM_CXSMICON, dpi);
+        int cyIcon    = GetSystemMetricsForDpi(SM_CYSMICON, dpi);
+        int cyCaption = GetSystemMetricsForDpi(SM_CYCAPTION, dpi) - 1;
+
+        // Offsets from the top left (or right) to the icon.
+        int dxIcon = (cyCaption - cxIcon) / 2;
+        int dyIcon = (cyCaption - cyIcon) / 2;
+        
+        // Set to caption height
+        rcCurrent.bottom = rcCurrent.top + cyCaption;
+
+        // Check if we should draw gradients on the caption
+        BOOL fGradient = FALSE;
+        SystemParametersInfoW(SPI_GETGRADIENTCAPTIONS, 0, &fGradient, 0);
+        
+        // Check if we should draw the icon and if the window is right-to-left
+        PWND pwnd     = ValidateHwnd(hwndTarget);
+        bool fHasIcon = _HasCaptionIcon(pwnd);
+        bool fRtl     = (GetWindowLongW(hwndTarget, GWL_EXSTYLE) & WS_EX_LAYOUTRTL) != 0;
+        
+        // Colors
+        COLORREF clrCaption         = GetSysColor(COLOR_ACTIVECAPTION);
+        COLORREF clrCaptionGradient = GetSysColor(COLOR_GRADIENTACTIVECAPTION);
+        COLORREF clrCaptionText     = GetSysColor(COLOR_CAPTIONTEXT);
+
+        // Brush used for solid fills (icon box, non-gradient caption)
+        // and DrawIconEx "flicker-free brush"
+        HBRUSH hbrCaption = GetSysColorBrush(COLOR_ACTIVECAPTION);
+
+        // Caption text font
+        NONCLIENTMETRICSW ncm = { sizeof(ncm) };
+        SystemParametersInfoForDpi(SPI_GETNONCLIENTMETRICS, sizeof(ncm), &ncm, FALSE, dpi);
+        HFONT hfontCaption = CreateFontIndirectW(&ncm.lfCaptionFont);
+
+        // Actual animation loop
+        while ((uElapsedTime = GetTickCount64() - uStartTime) <= ANIMATION_DURATION_MS)
+        {
+            // Create a new rect using delta time:
+            RECT rcOld = rcCurrent;
+            rcCurrent.left   = rcFrom.left  + MulDiv(rcTo.left  - rcFrom.left,  uElapsedTime, ANIMATION_DURATION_MS);
+            rcCurrent.top    = rcFrom.top   + MulDiv(rcTo.top   - rcFrom.top,   uElapsedTime, ANIMATION_DURATION_MS);
+            rcCurrent.right  = rcFrom.right + MulDiv(rcTo.right - rcFrom.right, uElapsedTime, ANIMATION_DURATION_MS);
+            rcCurrent.bottom = rcCurrent.top + cyCaption;
+
+            // Combine the old and new rects to form a dirty area that needs to be
+            // filled with the desktop image. We paint the desktop image over the old
+            // area and the new caption bar in one blit, which lessens flickering. We
+            // waste a little bit of time blitting the area not covered by the old
+            // or new caption in the corners of this rect, but it's preferable to
+            // the flickering that would occur without doing this.
+            RECT rcDirty;
+            rcDirty.left   = min(rcCurrent.left,     rcOld.left);
+            rcDirty.top    = min(rcCurrent.top,       rcOld.top);
+            rcDirty.right  = max(rcCurrent.right,   rcOld.right);
+            rcDirty.bottom = max(rcCurrent.bottom, rcOld.bottom);
+
+            // Paint desktop over old area:
+            BitBlt(
+                hdcMem,
+                rcDirty.left, rcDirty.top,
+                RECTWIDTH(rcDirty),
+                RECTHEIGHT(rcDirty),
+                hdcDesk,
+                rcDirty.left, rcDirty.top,
+                SRCCOPY
+            );
+            
+            // Draw background
+            if (fGradient)
+            {
+                // Gradient captions draw the regular caption color behind the icon,
+                // the gradient caption color behind the caption buttons, and the gradient
+                // in the area between those. We don't need to worry about caption buttons here,
+                // since the animated caption never shows them.
+
+                int iCaptionOffset = 0;
+                if (fHasIcon)
+                {
+                    RECT rcIconBox;
+                    rcIconBox.top = rcCurrent.top;
+                    rcIconBox.bottom = rcCurrent.bottom;
+                    if (fRtl)
+                    {
+                        rcIconBox.left = rcCurrent.right - cyCaption;
+                        rcIconBox.right = rcCurrent.right;
+                    }
+                    else
+                    {
+                        rcIconBox.left = rcCurrent.left;
+                        rcIconBox.right = rcCurrent.left + cyCaption;
+                    }
+
+                    iCaptionOffset = RECTWIDTH(rcIconBox);
+                    FillRect(hdcMem, &rcIconBox, hbrCaption);
+                }
+
+                RECT rcGradient = rcCurrent;
+                if (fRtl)
+                    rcGradient.right -= iCaptionOffset;
+                else
+                    rcGradient.left += iCaptionOffset;
+
+                // If the window is RTL, we need to draw the gradient
+                // from the right, so just flip the colors.
+                COLORREF clrLeft  = fRtl ? clrCaptionGradient : clrCaption;
+                COLORREF clrRight = fRtl ? clrCaption : clrCaptionGradient;
+
+                // TRIVERTEX structs store colors in a higher resolution than
+                // standard 32-bit RGB, so we must multiply the color values
+                // by 256 (shift left by 8) in order for them to show up right.
+                TRIVERTEX vertices[2];
+                vertices[0].x     = rcGradient.left;
+                vertices[0].y     = rcGradient.top;
+                vertices[0].Red   = GetRValue(clrLeft) << 8;
+                vertices[0].Green = GetGValue(clrLeft) << 8;
+                vertices[0].Blue  = GetBValue(clrLeft) << 8;
+                vertices[0].Alpha = 0;
+                vertices[1].x     = rcGradient.right;
+                vertices[1].y     = rcGradient.bottom;
+                vertices[1].Red   = GetRValue(clrRight) << 8;
+                vertices[1].Green = GetGValue(clrRight) << 8;
+                vertices[1].Blue  = GetBValue(clrRight) << 8;
+                vertices[1].Alpha = 0;
+
+                GRADIENT_RECT mesh = { 1, 0 };
+                GdiGradientFill(hdcMem, vertices, ARRAYSIZE(vertices), &mesh, 1, GRADIENT_FILL_RECT_H);
+            }
+            else
+            {
+                FillRect(hdcMem, &rcCurrent, hbrCaption);
+            }
+
+            // Draw icon
+            if (fHasIcon)
+            {
+                int xIcon;
+                if (fRtl)
+                    xIcon = rcCurrent.right - dxIcon - cxIcon;
+                else
+                    xIcon = rcCurrent.left + dxIcon;
+                int yIcon = rcCurrent.top + dyIcon;
+
+                DrawIconEx(
+                    hdcMem,
+                    xIcon, yIcon,
+                    lpmmp->hIcon,
+                    cxIcon, cyIcon,
+                    0,
+                    hbrCaption,
+                    DI_NORMAL
+                );
+            }
+
+            // Draw caption text
+            if (lpmmp->szCaptionText[0])
+            {
+                RECT rcText;
+                CopyRect(&rcText, &rcCurrent);
+                
+                if (fRtl)
+                    rcText.right -= 1 + (fHasIcon ? cyCaption : 0);
+                else
+                    rcText.left  += 1 + (fHasIcon ? cyCaption : 0);
+                
+                HFONT hfontOld = (HFONT)SelectObject(hdcMem, hfontCaption);
+                COLORREF clrOld = SetTextColor(hdcMem, clrCaptionText);
+                int iBkOld = SetBkMode(hdcMem, TRANSPARENT);
+                UINT uFormat = DT_SINGLELINE | DT_VCENTER;
+                if (fRtl)
+                    uFormat |= DT_RIGHT;
+
+                DrawTextW(
+                    hdcMem,
+                    lpmmp->szCaptionText, -1,
+                    &rcText, uFormat
+                );
+
+                SelectObject(hdcMem, hfontOld);
+                SetTextColor(hdcMem, clrOld);
+                SetBkMode(hdcMem, iBkOld);
+            }
+
+            // Then blit it all to the main DC.
+            BitBlt(
+                hdc,
+                rcDirty.left, rcDirty.top,
+                RECTWIDTH(rcDirty), RECTHEIGHT(rcDirty),
+                hdcMem,
+                rcDirty.left, rcDirty.top,
+                SRCCOPY
+            );
+        }
+
+        /* Clean up and hide animation window */
+        DeleteDC(hdcDesk);
+        DeleteDC(hdcMem);
+        DeleteObject(hbmMem);
+        DeleteObject(hbmDesk);
+        DeleteObject(hfontCaption);
+        if (lpmmp->hIcon)
+        {
+            DestroyIcon(lpmmp->hIcon);
+            lpmmp->hIcon = NULL;
+        }
+        GlobalFree(lpmmp);
+
+        // We must set the animation window to non-topmost before returning, or else
+        // the window being animated may erroneously gain topmost status.
+        SetWindowPos(
+            hwnd,
+            HWND_BOTTOM,
+            0, 0, 0, 0,
+            SWP_NOACTIVATE
+        );
+
+        ShowWindow_orig(hwnd, SW_HIDE);
+        g_fAnimating = false;
+
+        return 0;
+    }
+
+    switch (uMsg)
+    {
+        case WM_PAINT:
+        case WM_ERASEBKGND:
+            return 0;
+        // Make click-thru
+        case WM_NCHITTEST:
+            return HTNOWHERE;
+        default:
+            return DefWindowProcW_orig(hwnd, uMsg, wParam, lParam);
+    }
+}
+
+static LPCWSTR c_szAnimClassName = L"Windhawk_UAH_MinMax";
+
+DWORD CALLBACK AnimWndThreadProc(HANDLE hEvent)
+{
+    WNDCLASSW wc = { 0 };
+    wc.lpfnWndProc = AnimWndProc;
+    wc.hInstance = g_hinst;
+    wc.lpszClassName = c_szAnimClassName;
+    RegisterClassW(&wc);
+
+    g_hwndAnim = CreateWindowExW(
+        WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
+        c_szAnimClassName,  L"UAH MinMax Animation Window",
+        WS_VISIBLE | WS_POPUP,
+        0, 0, 0, 0,
+        NULL, NULL, g_hinst, NULL
+    );
+
+    // Setting these styles on window creation results in the window
+    // being completely invisible, rather than click through.
+    DWORD dwExStyle = GetWindowLongPtrW(g_hwndAnim, GWL_EXSTYLE);
+    dwExStyle |= WS_EX_LAYERED | WS_EX_TRANSPARENT;
+    SetWindowLongPtrW(g_hwndAnim, GWL_EXSTYLE, dwExStyle);
+
+    g_uMsgMinMax = RegisterWindowMessageW(L"UAH_MinMax");
+
+    // Animation is ready. Tell the window that needs to be animated
+    // it is.
+    SetEvent(hEvent);
+
+    MSG msg;
+    while (GetMessageW(&msg, g_hwndAnim, 0, 0))
+    {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+    ExitThread(0);
+    return 0;
+}
+
+#pragma endregion // "Animation implementation"
+
+HMODULE GetCurrentModule()
+{
+	HMODULE hModule = NULL;
+	GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+						| GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+						(LPCWSTR)GetCurrentModule, &hModule);
+	return hModule;
+}
+
+const WindhawkUtils::SYMBOL_HOOK user32DllHooks[] = {
+    {
+        {
+#ifdef _WIN64
+            L"GetWindowBordersForDpi"
+#else
+            L"_GetWindowBordersForDpi@20"
+#endif
+        },
+        &GetWindowBordersForDpi,
+        nullptr,
+        false
+    },
+    {
+        {
+            L"struct tagWND * "
+            FASTCALL_STR
+            L" ValidateHwnd(struct HWND__ *)"
+        },
+        &ValidateHwnd,
+        nullptr,
+        false
+    },
+    {
+        {
+#ifdef _WIN64
+            L"_HasCaptionIcon"
+#else
+            L"__HasCaptionIcon@8"
+#endif
+        },
+        &_HasCaptionIcon,
+        nullptr,
+        false
+    },
+};
+
+BOOL Wh_ModInit(void)
+{
+    HMODULE hmUser = GetModuleHandleW(L"user32.dll");
+    if (!hmUser)
+    {
+        Wh_Log(L"Failed to get handle to user32.dll");
+        return FALSE;
+    }
+
+    GetWindowMinimizeRect = (GetWindowMinimizeRect_t)GetProcAddress(hmUser, "GetWindowMinimizeRect");
+    if (!GetWindowMinimizeRect)
+    {
+        Wh_Log(L"Failed to get address of GetWindowMinimzeRect");
+        return FALSE;
+    }
+
+    InternalGetWindowIcon = (InternalGetWindowIcon_t)GetProcAddress(hmUser, "InternalGetWindowIcon");
+    if (!InternalGetWindowIcon)
+    {
+        Wh_Log(L"Failed to get address of InternalGetWindowIcon");
+        return FALSE;
+    }
+
+    if (!WindhawkUtils::HookSymbols(
+        hmUser,
+        user32DllHooks,
+        ARRAYSIZE(user32DllHooks)
+    ))
+    {
+        Wh_Log(L"Failed to find one or more symbols in user32.dll");
+        return FALSE;
+    }
+
+#define HOOK(func)                                                                         \
+    if (!Wh_SetFunctionHook((void *)func, (void *)func ## _hook, (void **)&func ## _orig)) \
+    {                                                                                      \
+        Wh_Log(L"Failed to hook %s", L ## #func);                                          \
+        return FALSE;                                                                      \
+    }
+
+#define HOOK_A_W(func) HOOK(func ## A) HOOK(func ## W)
+
+    HOOK_A_W(DefWindowProc)
+    HOOK_A_W(DefFrameProc)
+    HOOK_A_W(DefMDIChildProc)
+    HOOK_A_W(DefDlgProc)
+    HOOK(ShowWindow)
+    HOOK(ShowWindowAsync)
+
+    g_hinst = GetCurrentModule();
+
+    return TRUE;
+}
+
+void Wh_ModUninit(void)
+{
+    if (g_hwndAnim && IsWindow(g_hwndAnim))
+    {
+        DestroyWindow(g_hwndAnim);
+        UnregisterClassW(c_szAnimClassName, g_hinst);
+    }
+    if (g_hAnimWndThread)
+    {
+        TerminateThread(g_hAnimWndThread, 0);
+        CloseHandle(g_hAnimWndThread);
+    }
+}


### PR DESCRIPTION
From Windows 95 to XP, and in Vista and above without DWM running, windows had a minimize/maximize animation that involved the titlebar moving across the screen. This mod makes that animation play with DWM enabled by reimplementing it.

## Previews

**Top-level window**:
![Top-level window](https://raw.githubusercontent.com/aubymori/images/refs/heads/main/classic-min-max-animations/toplevel.gif)

**MDI child window**:
![MDI child window](https://raw.githubusercontent.com/aubymori/images/refs/heads/main/classic-min-max-animations/mdi.gif)