### PR TITLE
Command Prompt Folder Larp 1.0

### DIFF
--- a/mods/cmd-folder-larp.wh.cpp
+++ b/mods/cmd-folder-larp.wh.cpp
@@ -207,7 +207,11 @@ void WINAPI SetConsoleTitleW_hook(LPCWSTR szTitle)
 const WindhawkUtils::SYMBOL_HOOK g_rghookCmd[] = {
     {
         {
+#ifdef _WIN64
             L"void __cdecl PrintPrompt(void)",
+#else
+            L"void __stdcall PrintPrompt(void)",
+#endif
         },
         &PrintPrompt_orig,
         PrintPrompt_hook,


### PR DESCRIPTION
Make the current directory in Command Prompt appear as though it's a different folder.

This is an eyecandy tweak to make it seem like an older version of Windows, where, for example, the "Users" folder was known as "Documents and Settings".

This mod does not currently change the behaviour of `cd` or `dir` commands.