### PR TITLE
Update "Classic notepad multi step undo" to 1.1

### DIFF
--- a/mods/classic-notepad-multi-step-undo.wh.cpp
+++ b/mods/classic-notepad-multi-step-undo.wh.cpp
@@ -121,6 +121,7 @@ UndoState GetCurrentState(HWND hWnd) {
 void SetCurrentState(HWND hWnd, const UndoState& state) {
   SendMessage(hWnd, WM_SETTEXT, 0, (LPARAM)state.text.c_str());
   SendMessage(hWnd, EM_SETSEL, state.selStart, state.selEnd);
+  SendMessage(hWnd, EM_SCROLLCARET, 0, 0);
   SendMessage(hWnd, EM_SETMODIFY, TRUE, 0);
   SendMessage(GetParent(hWnd), WM_COMMAND, MAKEWPARAM(GetDlgCtrlID(hWnd), EN_UPDATE), (LPARAM)hWnd);
   SendMessage(GetParent(hWnd), WM_COMMAND, MAKEWPARAM(GetDlgCtrlID(hWnd), EN_CHANGE), (LPARAM)hWnd);


### PR DESCRIPTION
* Automatically using a translated string for "Redo" based on Anixx's suggestion
* Pressing a key other than Delete or Backspace while having a selection (resulting in overwriting many characters at once) now also saves the state first