### PR TITLE
double-f2: support triple f2 and beyond

### DIFF
--- a/mods/explorer-double-f2-rename-extension.wh.cpp
+++ b/mods/explorer-double-f2-rename-extension.wh.cpp
@@ -111,7 +111,7 @@ class Selection {
         Wh_Log(L"Selected whole name \"%s\".", text.c_str());
     }
 
-    static std::optional<Selection> inside(HWND editControl) {
+    static std::optional<Selection> InsideControl(HWND editControl) {
         // typical max filename length
         std::wstring text(260, L'\0');
         int copied = GetWindowTextW(editControl, text.data(), (int)text.size());
@@ -302,7 +302,7 @@ static bool ApplyMultiF2Selection(WPARAM pressedKey) {
         if (focus != nullptr && ExplorerUtils::IsEditControl(focus)) {
             Wh_Log(L"Applying selection for %d times F2 in an Edit field.",
                    f2Count);
-            auto selection = Selection::inside(focus);
+            auto selection = Selection::InsideControl(focus);
             if (selection.has_value()) {
                 auto timesF2 = f2Count % 3;
                 switch (timesF2) {


### PR DESCRIPTION
In response to a request from @grandoth that had also crossed my mind, I added triple F2 (select full name) and cycling to the logic. The rest of the changes is a lot of refactoring to separate (api integration from core logic) and encapsulate (callbacks, timing, selection, ...) different concerns. More verbose but easier to make sense of. The actual logic didn't actually change, aside from removing explicit desktop hooking which is already covered by window enumeration. The same system calls happen with the same parameters etc.

Probably best to squash at merge. He and I have been testdriving it for a week, I've found no problems and did the refactors carefully.