### PR TITLE
Color Picker Dialog Hex Input 1.0.0

### DIFF
--- a/mods/color-picker-dialog-hex-input.wh.cpp
+++ b/mods/color-picker-dialog-hex-input.wh.cpp
@@ -180,8 +180,8 @@ LRESULT CALLBACK HexInputSubclassProc(
                             if (!IsGoodCharacter(*psz))
                             {
                                 MessageBeep(MB_OK);
-                                CloseClipboard();
                                 GlobalUnlock(hData);
+                                CloseClipboard();
                                 return 0;
                             }
                         }


### PR DESCRIPTION
Windows' native color picker dialog does not come with a way to input hex codes. This mod adds an input that allows you to type hex colors in both the standard 6-digit format and the CSS 3-digit format (for example, `ABC` would result in `AABBCC`).

**Preview**:
![Preview](https://raw.githubusercontent.com/aubymori/images/refs/heads/main/color-picker-dialog-hex-input.png)