### PR TITLE
Add Remember folder positions mod

### DIFF
--- a/mods/remember-folder-positions.wh.cpp
+++ b/mods/remember-folder-positions.wh.cpp
@@ -3,6 +3,8 @@
 // @name            Remembers the folder windows' positions
 // @description     Remembers the folder windows positions the way it was pre-Vista (Win95-WinXP)
 // @version         1.0
+// @author          Anixx
+// @github 			https://github.com/Anixx
 // @include         explorer.exe
 // @compilerOptions -lcomctl32 -lgdi32
 


### PR DESCRIPTION
This mod restores the functionality of remembering folder window positions, which was removed after Windows XP.

The previous request failed for some reason, so I made a new request.