### PR TITLE
Command Prompt Folder Larp 1.1

### DIFF
--- a/mods/cmd-folder-larp.wh.cpp
+++ b/mods/cmd-folder-larp.wh.cpp
@@ -208,7 +208,7 @@ HRESULT __cdecl StringCchPrintfW_hook(LPWSTR szBuffer, size_t size, LPCWSTR szTe
         LPCWSTR szFirstStringArgument = va_arg(vaMut, LPCWSTR);
 
         if (
-            !IsBadStringPtrW(szFirstStringArgument, MAX_PATH) &&
+            (szTemplate[0] == L'%' && szTemplate[1] == L's') &&
             wcscmp(szFirstStringArgument, g_pszCurrentDirectory) == 0
         )
         {


### PR DESCRIPTION
Fixed a bug where the actual path was clobbered for some commands, resulting in an error messaging stating that the path is not valid and no command running.