### PR TITLE
Add Explorer Ctrl+Q to New Folder mod

### DIFF
--- a/mods/explorer-ctrlq-new-folder.wh.cpp
+++ b/mods/explorer-ctrlq-new-folder.wh.cpp
@@ -1,5 +1,5 @@
 // ==WindhawkMod==
-// @id              explorer-ctrlq-newfolder
+// @id              explorer-ctrlq-new-folder
 // @name            Explorer Ctrl+Q to New Folder
 // @description     Press Ctrl+Q in Explorer and create a new folder in current path, including desktop.
 // @version         1.2


### PR DESCRIPTION
Introduces a Windhawk mod that maps Ctrl+Q in Windows Explorer to create a new folder in the current directory,  The mod avoids shortcut conflicts, ensures stability with shell notifications and thread synchronization, and programmatically selects and renames the new folder.
