### PR TITLE
Add Two-sided Snapping mod for Windows 11

### DIFF
--- a/mods/two-sided-snapping.wh.cpp
+++ b/mods/two-sided-snapping.wh.cpp
@@ -28,7 +28,7 @@ HRESULT WINAPI windowsudkshellcommon_SLGetWindowsInformationDWORDHook(PCWSTR pws
 {
     HRESULT hr = SLGetWindowsInformationDWORDFunc(pwszValueName, pdwValue);
 
-    if (SUCCEEDED(hr) &&(!wcsncmp(pwszValueName, L"Shell-Windowing-LimitSnappedWindows", 35)))
+    if (SUCCEEDED(hr) && !wcscmp(pwszValueName, L"Shell-Windowing-LimitSnappedWindows"))
         *pdwValue = 1;
 
     return hr;


### PR DESCRIPTION
This mod disables corner snapping while enabling two-sided snapping in Windows 11, restoring the behavior of Windows 10.