### PR TITLE
Update classic-theme-uifile-fix.wh.cpp

### DIFF
--- a/mods/classic-theme-uifile-fix.wh.cpp
+++ b/mods/classic-theme-uifile-fix.wh.cpp
@@ -2,7 +2,7 @@
 // @id              classic-theme-uifile-fix
 // @name            Classic Theme UIFILE Fix
 // @description     Fixes Control Panel pages that don't display in Windows Classic theme
-// @version         1.0.0
+// @version         1.1.0
 // @author          Anixx
 // @github          https://github.com/Anixx
 // @include         explorer.exe


### PR DESCRIPTION
- Avoid replacing gtc's which have CONTROLPANELSTYLE inside so to address issue of hyperlinks becoming black

- If Explorer is themed, just do nothing