### PR TITLE
Change Qt App Icon 1.0.0

### DIFF
--- a/mods/change-qt-app-icon.wh.cpp
+++ b/mods/change-qt-app-icon.wh.cpp
@@ -71,7 +71,6 @@ LRESULT WINAPI SendMessageW_hook(
                     GetCurrentProcess(), hQWindows, &mi, sizeof(mi));
                 s_uQWindowsBase = (ULONG_PTR)mi.lpBaseOfDll;
                 s_uQWindowsEnd  = (ULONG_PTR)mi.lpBaseOfDll + mi.SizeOfImage;
-                FreeLibrary(hQWindows);
             }
         }
 


### PR DESCRIPTION
This mod allows you to change the window icon of all windows for a Qt application.

**Example**: *IDA 9.2 with its pre-6.0 icon*
![Example: IDA 9.2 with its pre-6.0 icon](https://raw.githubusercontent.com/aubymori/images/refs/heads/main/change-qt-app-icon-example.png)