### PR TITLE
Click on empty taskbar space v2.3

### DIFF
--- a/mods/taskbar-empty-space-clicks.wh.cpp
+++ b/mods/taskbar-empty-space-clicks.wh.cpp
@@ -2606,7 +2606,7 @@ void CombineTaskbarButtons(const TaskBarButtonsState primaryTaskBarButtonsState1
     }
     if (shallNotify)
     {
-        SendMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)TEXT("TraySettings"));
+        SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)TEXT("TraySettings"), SMTO_ABORTIFHUNG, 100, NULL);
     }
 }
 
@@ -2787,7 +2787,7 @@ void ToggleTaskbarAlignment()
     if (SetTaskbarAlignment(newAlignment))
     {
         // Notify all applications of the change
-        SendMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)TEXT("TraySettings"));
+        SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)TEXT("TraySettings"), SMTO_ABORTIFHUNG, 100, NULL);
     }
 }
 


### PR DESCRIPTION
Changelog:
- send virtual key press to the last active window with `focusPreviousWindow` option - https://github.com/m1lhaus/windhawk-mods/issues/34
- added new action `Toggle Taskbar alignment` to toggle between `Left` and `Center` taskbar icons alignment - https://github.com/m1lhaus/windhawk-mods/issues/31
- implemented autodetection of ExplorerPatcher - https://github.com/m1lhaus/windhawk-mods/issues/46
- added taskbar type (primary/secondary) as a new condition to action trigger - https://github.com/m1lhaus/windhawk-mods/issues/45