### PR TITLE
CEF/Spotify Tweaks 1.6

### DIFF
--- a/mods/cef-titlebar-enabler-universal.wh.cpp
+++ b/mods/cef-titlebar-enabler-universal.wh.cpp
@@ -81,12 +81,12 @@
     * `minWidth`: The minimum width of the main window. Returns -1 if no minimum width is set with `setMinSize()`
     * `minHeight`: The minimum height of the main window. Returns -1 if no minimum height is set with `setMinSize()`
     * `titleLocked`: Whether the title bar text is locked (by `lockTitle()`)
-    * `dpi`: The DPI of the main window
+    * `dpi`: The DPI of the main window. 96 for 100%, 120 for 125%, etc.
     * `playbackSpeed`: The current playback speed as a decimal number (by `setPlaybackSpeed()`)
     * `speedModSupported`: Whether playback speed modification is supported
     * `immediateSpeedChange`: Whether playback speed changes are applied immediately
     * Various mod settings as boolean properties (described below)
-* `extendFrame(int: left, int: top, int: right, int: bottom)`
+* `extendFrame(int: left, int: right, int: top, int: bottom)`
     * Extends the window frame into the client area by the given number of pixels on each side. Use `-1, -1, -1, -1` to extend to the entire window.
 * `minimize()`
     * Minimizes the main window.


### PR DESCRIPTION
* Add support for Spotify 1.2.76 to 1.2.80
* Add a 'transparent mode', which allows full transparency when the transparent rendering is enabled, and native frames are disabled
  * To activate, call the `setTransparent(true)` function of the mod's JavaScript API
  * This mode conflicts with DWM effect applicators like MicaForEveryone and Translucent Windows, and the Basic Themer Windhawk mod that has the Spotify window excluded by the exclusion options or the 'secure desktop only' mode.
  * Please exclude Spotify from MicaForEveryone/Translucent Windows, and for the Basic Themer mod, Spotify must be included in the mod's basic theme apply list, or the mod must be fully disabled.
* Add support for removing DWM effects with the JS API via `setBackdrop('none')`.
* Update the readme and add documentation for the mod's JavaScript API.