### PR TITLE
Add Windows 11 Start Power Text Renamer mod

### DIFF
--- a/mods/win11-start-power-text-renamer.wh.cpp
+++ b/mods/win11-start-power-text-renamer.wh.cpp
@@ -4,7 +4,7 @@
 // @description     Rename the Windows 11 Start menu power options (Lock, Sleep, Shut down, Restart) to any custom text.
 // @version         1.0.1
 // @author          BGsteppin
-// @github          https://github.com/BGsteppin/win11-start-power-text-renamer
+// @github          https://github.com/BGsteppin
 // @include         StartMenuExperienceHost.exe
 // @license         MIT
 // ==/WindhawkMod==


### PR DESCRIPTION
Adds a new Windhawk mod that allows renaming the Windows 11 Start menu
power options (Lock, Sleep, Shut down, Restart) without changing layout
or behavior.
