### PR TITLE
Update word-local-autosave.wh.cpp

### DIFF
--- a/mods/word-local-autosave.wh.cpp
+++ b/mods/word-local-autosave.wh.cpp
@@ -2,7 +2,7 @@
 // @id              word-local-autosave
 // @name            Word Local AutoSave
 // @description     Enables AutoSave functionality for local documents in Microsoft Word by sending Ctrl+S
-// @version         1.3
+// @version         1.4
 // @author          communism420
 // @github          https://github.com/communism420
 // @include         WINWORD.EXE
@@ -29,7 +29,7 @@ short delay.
 - Optional minimum interval between saves to prevent excessive disk writes
 - Works with any locally saved Word document
 - Only saves when Word is the active window
-- Waits for ALL keys to be released before saving to prevent shortcut conflicts
+- Requires a quiet period (no key presses) before saving to prevent shortcut conflicts
 
 ## Settings
 
@@ -45,7 +45,7 @@ short delay.
 - The mod simulates pressing Ctrl+S, so it behaves exactly like manual saving.
 - Manual Ctrl+S presses are detected and reset the auto-save timer.
 - Auto-save only triggers when Microsoft Word is the foreground window.
-- Auto-save waits for all keys to be released to avoid triggering wrong shortcuts.
+- Auto-save requires 100ms of keyboard inactivity to prevent triggering wrong shortcuts.
 */
 // ==/WindhawkModReadme==
 
@@ -68,11 +68,15 @@ struct {
     int minTimeBetweenSaves;
 } g_settings;
 
+// Minimum quiet time before saving (no key presses for this duration)
+const DWORD QUIET_PERIOD_MS = 100;
+
 // Global state
 UINT_PTR g_saveTimerId = 0;
 UINT_PTR g_retryTimerId = 0;
 DWORD g_lastSaveTime = 0;
 DWORD g_lastInputTime = 0;
+DWORD g_lastKeyPressTime = 0;  // Track actual key press time for quiet period
 bool g_isSendingCtrlS = false;
 DWORD g_wordProcessId = 0;
 int g_retryCount = 0;
@@ -99,63 +103,63 @@ bool IsWordForeground() {
     return (foregroundProcessId == g_wordProcessId);
 }
 
-// Check if any keys are currently pressed that could interfere with Ctrl+S
+// Check if enough quiet time has passed since last key press
+bool HasQuietPeriodPassed() {
+    DWORD currentTime = GetTickCount();
+    DWORD timeSinceLastKey = currentTime - g_lastKeyPressTime;
+    
+    if (timeSinceLastKey < QUIET_PERIOD_MS) {
+        Wh_Log(L"Only %lu ms since last keypress, need %lu ms quiet period", 
+               timeSinceLastKey, QUIET_PERIOD_MS);
+        return false;
+    }
+    return true;
+}
+
+// Check if any keys are physically pressed right now using GetAsyncKeyState
 bool AreAnyKeysPressed() {
-    BYTE keyState[256];
-    if (!GetKeyboardState(keyState)) {
-        return false;  // If we can't get state, assume no keys pressed
-    }
-    
-    // Check letters A-Z (0x41-0x5A) - if any letter is held, wait
+    // Check all letter keys A-Z
     for (int i = 0x41; i <= 0x5A; i++) {
-        if (keyState[i] & 0x80) {
-            Wh_Log(L"Key 0x%02X is pressed, delaying save", i);
+        if (GetAsyncKeyState(i) & 0x8000) {
+            Wh_Log(L"Key %c is physically pressed", (char)i);
             return true;
         }
     }
     
-    // Check numbers 0-9 (0x30-0x39)
+    // Check numbers 0-9
     for (int i = 0x30; i <= 0x39; i++) {
-        if (keyState[i] & 0x80) {
-            Wh_Log(L"Key 0x%02X is pressed, delaying save", i);
-            return true;
-        }
+        if (GetAsyncKeyState(i) & 0x8000) return true;
     }
     
-    // Check Shift and Alt (we don't want Ctrl+Shift+S or Ctrl+Alt+S)
-    if (keyState[VK_SHIFT] & 0x80) {
-        Wh_Log(L"Shift is pressed, delaying save");
+    // Check modifiers
+    if (GetAsyncKeyState(VK_SHIFT) & 0x8000) {
+        Wh_Log(L"Shift is physically pressed");
         return true;
     }
-    if (keyState[VK_LSHIFT] & 0x80) return true;
-    if (keyState[VK_RSHIFT] & 0x80) return true;
-    
-    if (keyState[VK_MENU] & 0x80) {  // Alt
-        Wh_Log(L"Alt is pressed, delaying save");
+    if (GetAsyncKeyState(VK_MENU) & 0x8000) {
+        Wh_Log(L"Alt is physically pressed");
         return true;
     }
-    if (keyState[VK_LMENU] & 0x80) return true;
-    if (keyState[VK_RMENU] & 0x80) return true;
     
     // Check common editing keys
-    if (keyState[VK_SPACE] & 0x80) return true;
-    if (keyState[VK_RETURN] & 0x80) return true;
-    if (keyState[VK_TAB] & 0x80) return true;
-    if (keyState[VK_BACK] & 0x80) return true;
-    if (keyState[VK_DELETE] & 0x80) return true;
+    if (GetAsyncKeyState(VK_SPACE) & 0x8000) return true;
+    if (GetAsyncKeyState(VK_RETURN) & 0x8000) return true;
+    if (GetAsyncKeyState(VK_TAB) & 0x8000) return true;
+    if (GetAsyncKeyState(VK_BACK) & 0x8000) return true;
+    if (GetAsyncKeyState(VK_DELETE) & 0x8000) return true;
     
-    // Check numpad keys
+    // Check numpad
     for (int i = VK_NUMPAD0; i <= VK_DIVIDE; i++) {
-        if (keyState[i] & 0x80) return true;
+        if (GetAsyncKeyState(i) & 0x8000) return true;
     }
     
-    // Check OEM keys (punctuation, brackets, etc.)
+    // Check OEM keys
     int oemKeys[] = {
         VK_OEM_1, VK_OEM_2, VK_OEM_3, VK_OEM_4, VK_OEM_5, VK_OEM_6, VK_OEM_7, VK_OEM_8,
-        VK_OEM_PLUS, VK_OEM_COMMA, VK_OEM_MINUS, VK_OEM_PERIOD
+        VK_OEM_PLUS, VK_OEM_COMMA, VK_OEM_MINUS, VK_OEM_PERIOD, VK_OEM_102
     };
     for (int key : oemKeys) {
-        if (keyState[key] & 0x80) return true;
+        if (GetAsyncKeyState(key) & 0x8000) return true;
     }
     
     return false;
@@ -202,7 +206,7 @@ void CALLBACK RetryTimerProc(HWND hwnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTim
     TrySave();
 }
 
-// Try to perform save, retry if any keys are pressed
+// Try to perform save, retry if any keys are pressed or quiet period hasn't passed
 void TrySave() {
     // Verify Word is still the foreground window
     if (!IsWordForeground()) {
@@ -211,8 +215,8 @@ void TrySave() {
         return;
     }
 
-    // Check if ANY keys are currently pressed
-    if (AreAnyKeysPressed()) {
+    // Check if ANY keys are currently pressed OR if quiet period hasn't passed
+    if (AreAnyKeysPressed() || !HasQuietPeriodPassed()) {
         g_retryCount++;
         
         // Retry up to 50 times (5 seconds total with 100ms intervals)
@@ -229,7 +233,9 @@ void TrySave() {
 
     g_retryCount = 0;
     
-    // All keys released - safe to send Ctrl+S
+    Wh_Log(L"Quiet period passed and no keys pressed - sending Ctrl+S");
+    
+    // All keys released and quiet period passed - safe to send Ctrl+S
     SendCtrlS();
     
     g_lastSaveTime = GetTickCount();
@@ -343,9 +349,17 @@ bool IsEditingKey(WPARAM wParam) {
 
 // Hooked TranslateMessage
 BOOL WINAPI TranslateMessage_Hook(const MSG* lpMsg) {
-    if (lpMsg && lpMsg->message == WM_KEYDOWN) {
-        if (IsEditingKey(lpMsg->wParam)) {
-            ScheduleSave();
+    if (lpMsg) {
+        // Track ALL key presses for quiet period detection
+        if (lpMsg->message == WM_KEYDOWN || lpMsg->message == WM_SYSKEYDOWN) {
+            g_lastKeyPressTime = GetTickCount();
+        }
+        
+        // Schedule save only for editing keys
+        if (lpMsg->message == WM_KEYDOWN) {
+            if (IsEditingKey(lpMsg->wParam)) {
+                ScheduleSave();
+            }
         }
     }
 
@@ -371,7 +385,7 @@ void LoadSettings() {
 
 // Mod initialization
 BOOL Wh_ModInit() {
-    Wh_Log(L"Word Local AutoSave mod v1.3 initializing...");
+    Wh_Log(L"Word Local AutoSave mod v1.4 initializing...");
 
     // Store current process ID for foreground window check
     g_wordProcessId = GetCurrentProcessId();


### PR DESCRIPTION
## Fix race condition causing random shortcuts to trigger

### Problem

Despite checking if keys were pressed before sending Ctrl+S, random Word shortcuts would still trigger:
- Ctrl+H (Find and Replace)
- Ctrl+F (Navigation)
- Ctrl+Shift+S (Apply Styles)

This happened because of a **race condition**: between the moment the mod checked keyboard state and the moment it sent the Ctrl key, the user could press a new key. Word would then receive Ctrl+[that key] instead of Ctrl+S.

### Root Cause

`GetKeyboardState()` returns keyboard state from the message queue, not the actual physical state. The check and send operations were not atomic, allowing new keypresses to slip in between.

### Solution

Implemented a **quiet period** mechanism: the mod now tracks the timestamp of every keypress and only saves after 100ms of complete keyboard inactivity.

### Changes

- **Added `g_lastKeyPressTime`** — tracks the timestamp of every key press (including non-editing keys)
- **Added `QUIET_PERIOD_MS` constant** — 100ms minimum quiet time before saving
- **Added `HasQuietPeriodPassed()` function** — checks if enough time has passed since last keypress
- **Track ALL keypresses** — now monitors `WM_KEYDOWN` and `WM_SYSKEYDOWN` for quiet period, not just editing keys
- **Switched to `GetAsyncKeyState()`** — checks physical key state in real-time instead of message queue state
- **Dual safety check** — save only triggers when BOTH conditions are met:
  1. No keys physically pressed (`AreAnyKeysPressed() == false`)
  2. 100ms passed since last keypress (`HasQuietPeriodPassed() == true`)
- Version bumped to 1.4