### PR TITLE
taskbar-disappearing-tray-icons-fix.wh.cpp Patch GDI handle leak and disable passive mode by default

### DIFF
--- a/mods/taskbar-disappearing-tray-icons-fix.wh.cpp
+++ b/mods/taskbar-disappearing-tray-icons-fix.wh.cpp
@@ -357,6 +357,7 @@ void Wh_ModUninit() {
     Wh_Log(L"Uninitialized");
 }
 
-void Wh_ModSettingsChanged() {
-    LoadSettings();
+BOOL Wh_ModSettingsChanged(BOOL* bReload) {
+    *bReload = TRUE;
+    return TRUE;
 }


### PR DESCRIPTION
There's a GDI handle leak that *appears* to be coming from LoadImageW in a suspiciously identical amount of icons that would be in my "quick settings tray". This adds hooks to LoadImageW, CreateIconIndirect, CopyIcon, and CreateIconFromResourceEx as possible culprits for handle leaks.

These hooks only run during passive mode. I'm making a tradeoff for reliability since a one-time rebroadcasting is unlikely to cause 10000 GDI handles to be created. Passive mode is also now off by default.