### PR TITLE
Explorer Tab Utility Window Hider - A New Mod

### DIFF
--- a/mods/explorer-tab-utility-window-hider.wh.cpp
+++ b/mods/explorer-tab-utility-window-hider.wh.cpp
@@ -2,7 +2,7 @@
 // @id              explorer-tab-utility-window-hider
 // @name            Explorer Tab Utility Window Hider
 // @description     Hides the Explorer Tab Utility window completely, allowing it to run only in the background
-// @version         1.0.1
+// @version         1.0.2
 // @author          BCRTVKCS
 // @github          https://github.com/bcrtvkcs
 // @twitter         https://x.com/bcrtvkcs
@@ -14,7 +14,7 @@
 /*
 # Explorer Tab Utility Window Hider
 
-This mod prevents w4po's Explorer Tab Utility (https://github.com/w4po/ExplorerTabUtility) from showing its window at startup and all times. The program will continue to run in the background with all its functionality, but the configuration window will never appear.
+This mod prevents w4po's [Explorer Tab Utility](https://github.com/w4po/ExplorerTabUtility) from showing its window at startup and all times. The program will continue to run in the background with all its functionality, but the configuration window will never appear.
 
 ## How it works
 
@@ -37,6 +37,13 @@ HWND g_mainWindow = NULL;
 // Check if a window belongs to the main application window class
 bool IsMainAppWindow(HWND hWnd) {
     if (!hWnd) return false;
+
+    // Check if the window belongs to the current process
+    DWORD windowProcessId = 0;
+    GetWindowThreadProcessId(hWnd, &windowProcessId);
+    if (windowProcessId != GetCurrentProcessId()) {
+        return false;
+    }
 
     // Check window class name
     WCHAR className[256];


### PR DESCRIPTION
# Explorer Tab Utility Window Hider - Windhawk Mod
This is a Windhawk mod that prevents w4po's Explorer Tab Utility program (https://github.com/w4po/ExplorerTabUtility) window from appearing and being visible. The program continues to run in the background, but its window never appears.

## Problem
Explorer Tab Utility normally runs in the background, but sometimes its window becomes visible at computer startup and needs to be manually closed.

## Solution
This Windhawk mod completely blocks the Explorer Tab Utility window. The program continues to run in the background with all its functionality, but its configuration window never appears.