### PR TITLE
New Mod: Windows 11 Taskbar Application Icon Opacity

### DIFF
--- a/mods/windows-11-taskbar-icon-opacity.wh.cpp
+++ b/mods/windows-11-taskbar-icon-opacity.wh.cpp
@@ -313,6 +313,7 @@ bool InstallHooks(HMODULE module) {
 
     Wh_Log(L"Installing hooks for module: %p", module);
 
+    // Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {LR"(private: void __cdecl winrt::Taskbar::implementation::TaskListButton::UpdateVisualStates(void))"},


### PR DESCRIPTION
# Description

This PR introduces a new mod for Windows 11 that allows users to customize the opacity of taskbar application icons.

### Features
*   **Customizable Opacity:** Users can set a specific opacity level (0-100%) for inactive taskbar icons.
*   **Hover Effect:** Icons automatically restore to 100% opacity when hovered over.
*   **Search Box Control:** A setting to choose whether the search box should be dimmed along with the icons or remain fully opaque.

### Video Demo

https://github.com/user-attachments/assets/4505abda-98a7-489f-b7f4-3b1e81ad6a9d