### PR TITLE
Magnifier Touch Alt+Tab Fix - Magnifier Headless Mode 

### DIFF
--- a/mods/magnifier-headless.wh.cpp
+++ b/mods/magnifier-headless.wh.cpp
@@ -2,7 +2,7 @@
 // @id              magnifier-headless
 // @name            Magnifier Headless Mode
 // @description     Blocks the Magnifier window creation, keeping zoom functionality with win+"-" and win+"+" keyboard shortcuts.
-// @version         0.9.5.3
+// @version         0.9.5.4
 // @author          BCRTVKCS
 // @github          https://github.com/bcrtvkcs
 // @twitter         https://x.com/bcrtvkcs
@@ -688,13 +688,19 @@ HWND WINAPI CreateWindowExW_Hook(
                                   nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 
     if (hwnd && isTouchOverlay) {
+        // Hide from Alt+Tab and Task Manager by forcing WS_EX_TOOLWINDOW after creation
+        if (SetWindowLongPtrW_Original && SafeIsWindow(hwnd)) {
+            LONG_PTR currentExStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+            SetWindowLongPtrW_Original(hwnd, GWL_EXSTYLE, (currentExStyle & ~WS_EX_APPWINDOW) | WS_EX_TOOLWINDOW);
+        }
+
         // For touch overlay: Move off-screen (-32000, -32000) AND set size to 0x0 (safest)
         // This preserves zoom functionality while making the overlay completely invisible
         if (SetWindowPos_Original) {
             SetWindowPos_Original(hwnd, NULL, -32000, -32000, 0, 0,
                                  SWP_NOZORDER | SWP_NOACTIVATE);
-            Wh_Log(L"Magnifier Headless: Moved Magnifier Touch window off-screen with 0x0 size (HWND: 0x%p)", hwnd);
         }
+        Wh_Log(L"Magnifier Headless: Hid Magnifier Touch window from Alt+Tab (HWND: 0x%p)", hwnd);
     } else if (hwnd && isMagnifierClass) {
         // For other magnifier windows: Hide completely
         // Fast path: Read g_hHostWnd without lock (it's stable after init)


### PR DESCRIPTION
## Summary
This change ensures that the Magnifier touch overlay window is properly hidden from Alt+Tab switcher and Task Manager by enforcing the `WS_EX_TOOLWINDOW` extended window style. Also, a screenshot of the mod has been added to Windhawk Mod Readme.

## Key Changes
- **CreateWindowExW hook**: When detecting the Magnifier Touch window during creation, explicitly set `WS_EX_TOOLWINDOW` and remove `WS_EX_APPWINDOW` from the extended window style flags
- **SetWindowLongPtrW hook**: Added handling for touch overlay windows to enforce the same style flags when the extended window style is modified after window creation
- **Logging**: Updated log message to reflect the new behavior of hiding from Alt+Tab instead of just positioning off-screen

## Implementation Details
The changes apply the standard Windows pattern for tool windows that should not appear in the Alt+Tab switcher or Task Manager. By setting `WS_EX_TOOLWINDOW` and clearing `WS_EX_APPWINDOW`, the touch overlay window becomes a tool window that remains hidden from user-facing window enumeration while still functioning normally.

Both the window creation and style modification paths are covered to ensure the flags persist even if the application attempts to change them after window creation.