### PR TITLE
New Mod: App Theme Crash Fixer

### DIFF
--- a/mods/app-theme-crash-fixer.wh.cpp
+++ b/mods/app-theme-crash-fixer.wh.cpp
@@ -12,46 +12,46 @@
 
 // ==WindhawkModReadme==
 /*
- # * App Theme Crash Fixer
+# App Theme Crash Fixer
 
- This mod helps fix stability issues in specific applications when using third-party Windows themes (e.g., via SecureUXTheme or UltraUXThemePatcher).
+This mod helps fix stability issues in specific applications when using third-party Windows themes (e.g., via SecureUXTheme or UltraUXThemePatcher).
 
- Some legacy or poorly written applications may crash if they try to load a custom `.msstyles` file that is missing specific resources or metrics. This mod provides two methods to fix these crashes without uninstalling your theme.
+Some legacy or poorly written applications may crash if they try to load a custom `.msstyles` file that is missing specific resources or metrics. This mod provides two methods to fix these crashes without uninstalling your theme.
 
- ## Features
+## Features
 
- 1.  **Force Light Mode (Soft Fix):**
- Spoofs the Registry to tell the application that Windows is running in the default "Light" mode.
- Useful for apps that only crash when "Dark Mode" is active.
+1.  **Force Light Mode (Soft Fix):**
+Spoofs the Registry to tell the application that Windows is running in the default "Light" mode.
+Useful for apps that only crash when "Dark Mode" is active.
 
- 2.  **Disable Visual Styles (Hard Fix):**
- Completely disables the theming engine for the target application.
- The application will look like Windows 98/2000 (Classic Theme), but it will stop crashing.
- Also spoofs `GetCurrentThemeName` to return the default Aero path, preventing the app from attempting to read corrupt theme files.
+2.  **Disable Visual Styles (Hard Fix):**
+Completely disables the theming engine for the target application.
+The application will look like Windows 98/2000 (Classic Theme), but it will stop crashing.
+Also spoofs `GetCurrentThemeName` to return the default Aero path, preventing the app from attempting to read corrupt theme files.
 
- ## Usage
+## Usage
 
- Go to the **Settings** tab and add a new entry for each problematic application:
- **Executable Name:** The process name (e.g., `program.exe`).
- **Disable Visual Styles:** Check this if the app crashes on startup.
- **Force Light Mode:** Check this if the app looks broken in Dark Mode.
- */
+Go to the **Settings** tab and add a new entry for each problematic application:
+**Executable Name:** The process name (e.g., `program.exe`).
+**Disable Visual Styles:** Check this if the app crashes on startup.
+**Force Light Mode:** Check this if the app looks broken in Dark Mode.
+*/
 // ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
 /*
- - * apps:
- - - exeName: example.exe
- $name: Executable Name
- $description: The process name of the application (e.g., notepad.exe).
- - disableTheming: true
- $name: Disable Visual Styles
- $description: Forces the application to use Windows Classic styling. Recommended if the app crashes immediately with custom themes.
- - forceLight: true
- $name: Force Light Mode
- $description: Spoofs the registry to make the application believe Windows is in Light Mode.
- $name: Target Applications
- */
+- apps:
+  - - exeName: example.exe
+      $name: Executable Name
+      $description: The process name of the application (e.g., notepad.exe).
+    - disableTheming: true
+      $name: Disable Visual Styles
+      $description: Forces the application to use Windows Classic styling. Recommended if the app crashes immediately with custom themes.
+    - forceLight: true
+      $name: Force Light Mode
+      $description: Spoofs the registry to make the application believe Windows is in Light Mode.
+  $name: Target Applications
+*/
 // ==/WindhawkModSettings==
 
 #include <ntdef.h>


### PR DESCRIPTION
Adds a new mod that prevents applications from crashing when using 3rd party themes (e.g., via SecureUXTheme or UltraUXThemePatcher).

Some legacy or sensitive applications fail to handle custom `.msstyles` files properly, leading to crashes on startup. This mod provides a per-app solution with two methods:

1. **Force Light Mode:** Spoofs the registry (`AppsUseLightTheme`) to force the app into Light Mode, which resolves crashes for apps that only break in Dark Mode.
2. **Disable Visual Styles (Hard Fix):** Calls `SetThemeAppProperties(0)` to disable the theming engine entirely for the target process. It also hooks `GetCurrentThemeName` to return the default Aero path, preventing the app from attempting to read potentially incompatible theme resources.

Useful for keeping a system-wide custom theme while excluding specific buggy apps.