### PR TITLE
Add Fluid Taskbar Animation: High-performance macOS-style icons

### DIFF
--- a/mods/fluid-taskbar-animation.wh.cpp
+++ b/mods/fluid-taskbar-animation.wh.cpp
@@ -664,13 +664,13 @@ HMODULE GetTaskbarViewModuleHandle() {
 
 bool HookTaskbarViewDllSymbols(HMODULE module) {
     // Taskbar.View.dll, ExplorerExtensions.dll
-    WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
         { { LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarFrame,struct winrt::Windows::UI::Xaml::Controls::IControlOverrides>::OnPointerMoved(void *))" },
           &TaskbarFrame_OnPointerMoved_Original, TaskbarFrame_OnPointerMoved_Hook },
         { { LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarFrame,struct winrt::Windows::UI::Xaml::Controls::IControlOverrides>::OnPointerExited(void *))" },
           &TaskbarFrame_OnPointerExited_Original, TaskbarFrame_OnPointerExited_Hook },
     };
-    return HookSymbols(module, taskbarViewDllHooks, ARRAYSIZE(taskbarViewDllHooks));
+    return HookSymbols(module, hooks, ARRAYSIZE(hooks));
 }
 
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);


### PR DESCRIPTION
This mod is an evolved version of the taskbar dock animation concept, focusing on performance and visual seamlessness.

**Key Enhancements:**
- **O(1) Dirty Checking:** Uses a width/count-based detection system to avoid repetitive expensive UI tree scans.
- **State Preservation:** Unlike previous versions, icon animation states are preserved during layout refreshes (e.g., when opening/closing apps), eliminating visual stutters or "snapping."
- **Refined Physics:** Implements smooth Lerp and an optional subtle bounce for a more organic feel.
- **Multilingual Support:** Added Traditional Chinese metadata.

Testing has been done on Windows 11 with stable results across different taskbar alignment settings.