### PR TITLE
Add new mod: VLC Discord Rich Presence (vlc-discord-rpc)

### DIFF
--- a/mods/vlc-discord-rpc.wh.cpp
+++ b/mods/vlc-discord-rpc.wh.cpp
@@ -2,7 +2,7 @@
 // @id              vlc-discord-rpc
 // @name            VLC Discord Rich Presence
 // @description     Shows your playing status, quality tags (4K/HDR), and interactive buttons on Discord.
-// @version         1.0.1
+// @version         1.0.3
 // @author          ciizerr
 // @github          https://github.com/ciizerr
 // @include         vlc.exe


### PR DESCRIPTION
This PR adds a new mod **VLC Discord Rich Presence** (`vlc-discord-rpc`).

### Mod Description
This mod seamlessly integrates VLC Media Player with Discord to display rich playback status, media metadata (movies, TV shows, anime), and quality tags (e.g., 4K, HDR).

### Key Features
*   **Smart Recognition:** Automatically parses media titles to identify Show Name, Season, Episode, or Movie titles.
*   **Quality Tags:** displaying tags for resolution (4K, 1080p) and HDR status.
*   **Interactive Buttons:** Adds a "Search This" button redirecting to Google, IMDb, or YouTube.
*   **Customizable:** Users can switch between "Default" and "Dark" icon themes and configure the Search Provider via Mod Settings.

### Verification
*   Checked that `@id` matches the filename.
*   Included valid `@github` metadata.
*   Verified functionality with VLC Web Interface enabled (Port 8080).