### PR TITLE
Update Remove Unwanted Context Menu Items to 1.5.0

### DIFF
--- a/mods/remove-context-menu-items.wh.cpp
+++ b/mods/remove-context-menu-items.wh.cpp
@@ -1202,6 +1202,10 @@ BOOL WINAPI TrackPopupMenuEx_Hook(
     HWND hWnd,
     LPTPMPARAMS lptpm
 ) {
+    // Initialize COM on this thread (hook runs on different thread than Wh_ModInit)
+    HRESULT hrCom = CoInitialize(NULL);
+    bool comInitialized = SUCCEEDED(hrCom);
+    
     // Clear any stale file paths from previous calls
     g_threadFilePaths.clear();
     
@@ -1223,6 +1227,11 @@ BOOL WINAPI TrackPopupMenuEx_Hook(
     // Clear file paths after processing
     g_threadFilePaths.clear();
     
+    // Uninitialize COM on this thread
+    if (comInitialized) {
+        CoUninitialize();
+    }
+    
     return TrackPopupMenuEx_Original(hMenu, uFlags, x, y, hWnd, lptpm);
 }
 
@@ -1236,6 +1245,10 @@ BOOL WINAPI TrackPopupMenu_Hook(
     HWND hWnd,
     const RECT* prcRect
 ) {
+    // Initialize COM on this thread (hook runs on different thread than Wh_ModInit)
+    HRESULT hrCom = CoInitialize(NULL);
+    bool comInitialized = SUCCEEDED(hrCom);
+    
     // Clear any stale file paths from previous calls
     g_threadFilePaths.clear();
     
@@ -1256,6 +1269,11 @@ BOOL WINAPI TrackPopupMenu_Hook(
     
     // Clear file paths after processing
     g_threadFilePaths.clear();
+    
+    // Uninitialize COM on this thread
+    if (comInitialized) {
+        CoUninitialize();
+    }
     
     return TrackPopupMenu_Original(hMenu, uFlags, x, y, nReserved, hWnd, prcRect);
 }
@@ -1363,9 +1381,6 @@ BOOL Wh_ModInit() {
     Wh_Log(L"Initializing context menu cleaner mod");
     Wh_Log(L"NOTE: Predefined options are in English. For other languages, use Custom Items in settings.");
     
-    // Initialize COM
-    CoInitialize(NULL);
-    
     LoadSettings();
     
     if (!Wh_SetFunctionHook(
@@ -1399,5 +1414,4 @@ void Wh_ModSettingsChanged() {
 // Windhawk mod cleanup
 void Wh_ModUninit() {
     Wh_Log(L"Uninitializing context menu cleaner mod");
-    CoUninitialize();
 }


### PR DESCRIPTION
1.5.0

* Expanded predefined toggle compatibility beyond English to include support for several additional native languages:
    * Čeština (Czech)
    * English (United Kingdom & Australia)
    * Portuguese (Brazil & Portugal)
* Implemented a smart filtering system for "Edit in Notepad" and "Edit in Notepad++." 
    * Users can now restrict these menu items to appear only for specific file extensions (e.g., .txt, .cfg, .log, .json).
    * This prevents menu clutter when right-clicking non-text files while maintaining functionality for relevant documents.
    * Known Limitation: In Explorer windows with multiple tabs, the mod currently only retrieves file context from the first (primary active) tab.
* Added support for hiding more menu items including Cut, Copy, Paste, Rename, Delete, Create Shortcut, View, Sort by, Group by, Display settings, and Personalization.
* Added support for hiding app-specific items such as "Open in Terminal," "Edit in Notepad++," and OneDrive-specific actions like "Always keep on this device" and "Free up space."
* Restructured the settings interface into four distinct categories for improved usability:
    1.  Bloatware Items
    2.  Basic Items
    3.  App-specific Items
    4. Custom Items
    5.  Extension Filtering
* Refined the algorithm responsible for removing duplicate separators to ensure the context menu maintains a clean visual structure after item removal.