### PR TITLE
Added safe launch option to "Custom Shutdown Dialog Mod"

### DIFF
--- a/mods/custom-shutdown-dialog.wh.cpp
+++ b/mods/custom-shutdown-dialog.wh.cpp
@@ -2,7 +2,7 @@
 // @id              custom-shutdown-dialog
 // @name            Custom Shutdown Dialog
 // @description     Override the classic shutdown dialog in Explorer with your own
-// @version         1.2.0
+// @version         1.2.1
 // @author          aubymori
 // @github          https://github.com/aubymori
 // @include         explorer.exe


### PR DESCRIPTION
Added key wait option to support rectify11. This makes the mod wait until you release `ALT`+`F4` before launching the executable, preventing the self-close bug.