### PR TITLE
Add Invisible Window Borders mod

### DIFF
--- a/mods/invisible-borders.wh.cpp
+++ b/mods/invisible-borders.wh.cpp
@@ -1,0 +1,235 @@
+// ==WindhawkMod==
+// @id              invisible-borders
+// @name            Invisible Window Borders
+// @description     Makes window borders invisible while keeping rounded corners
+// @version         1.0.0
+// @author          Bo0ii
+// @github          https://github.com/Bo0ii
+// @homepage        https://github.com/Bo0ii/windhawk-mods
+// @include         *
+// @exclude         devenv.exe
+// @compilerOptions -ldwmapi -luser32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Invisible Window Borders
+
+Makes window borders invisible while preserving rounded corners.
+
+![Comparison](https://raw.githubusercontent.com/Bo0ii/windhawk-mods/main/invisible-borders/onoff.png)
+
+## Features
+
+- **Invisible Borders**: Removes border color while keeping frame structure
+- **Preserves Rounded Corners**: Keeps window frame intact for corner rendering
+- **Universal**: Works with all applications
+- **Lightweight**: Minimal performance impact
+
+## Compatibility
+
+- Windows 10 (version 1809 and later)
+- Windows 11 (all versions)
+- Requires DWM (Desktop Window Manager) to be enabled
+
+## Support
+
+Report issues at: https://github.com/Bo0ii/windhawk-mods/issues
+
+## License
+
+MIT License - Feel free to modify and distribute
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- SpecialWindows: false
+  $name: Apply to Special Windows
+  $description: Also apply to special windows like dialogs
+*/
+// ==/WindhawkModSettings==
+
+#include <dwmapi.h>
+#include <windhawk_api.h>
+
+// Special DWM color values
+#ifndef DWMWA_COLOR_NONE
+#define DWMWA_COLOR_NONE 0xFFFFFFFE
+#endif
+
+const COLORREF BorderInvisible = DWMWA_COLOR_NONE;  // No border color
+const COLORREF ColorDefault = DWMWA_COLOR_DEFAULT;
+
+bool SpecialWindows = false;
+
+BOOL IsValidWindow(HWND hWnd) {
+    DWORD dwStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+    // Better exclude context menus
+    return (dwStyle & WS_THICKFRAME) == WS_THICKFRAME ||
+           (dwStyle & WS_CAPTION) == WS_CAPTION ||
+           (SpecialWindows && (dwStyle & WS_OVERLAPPED) == WS_OVERLAPPED && (dwStyle & WS_POPUP) != WS_POPUP);
+}
+
+using DwmSetWindowAttribute_t = decltype(&DwmSetWindowAttribute);
+DwmSetWindowAttribute_t DwmSetWindowAttribute_orig;
+HRESULT WINAPI DwmSetWindowAttribute_hook(HWND hwnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute) {
+    if (dwAttribute == DWMWA_BORDER_COLOR && IsValidWindow(hwnd)) {
+        Wh_Log(L"Intercepted DWMWA_BORDER_COLOR - setting to invisible");
+        // Override with invisible border
+        return DwmSetWindowAttribute_orig(hwnd, dwAttribute, &BorderInvisible, sizeof(BorderInvisible));
+    }
+
+    return DwmSetWindowAttribute_orig(hwnd, dwAttribute, pvAttribute, cbAttribute);
+}
+
+void SetBorderInvisible(HWND hWnd)
+{
+    if (!IsValidWindow(hWnd))
+        return;
+
+    Wh_Log(L"Setting invisible border");
+    DwmSetWindowAttribute_orig(hWnd, DWMWA_BORDER_COLOR, &BorderInvisible, sizeof(BorderInvisible));
+}
+
+using DefWindowProcA_t = decltype(&DefWindowProcA);
+DefWindowProcA_t DefWindowProcA_orig;
+LRESULT WINAPI DefWindowProcA_hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    LRESULT result = DefWindowProcA_orig(hWnd, uMsg, wParam, lParam);
+
+    switch (uMsg) {
+        case WM_ACTIVATE:
+        case WM_NCACTIVATE:
+        case WM_DWMCOLORIZATIONCOLORCHANGED:
+            SetBorderInvisible(hWnd);
+            break;
+    }
+
+    return result;
+}
+
+using DefWindowProcW_t = decltype(&DefWindowProcW);
+DefWindowProcW_t DefWindowProcW_orig;
+LRESULT WINAPI DefWindowProcW_hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    LRESULT result = DefWindowProcW_orig(hWnd, uMsg, wParam, lParam);
+
+    switch (uMsg) {
+        case WM_ACTIVATE:
+        case WM_NCACTIVATE:
+        case WM_DWMCOLORIZATIONCOLORCHANGED:
+            SetBorderInvisible(hWnd);
+            break;
+    }
+
+    return result;
+}
+
+using DefDlgProcA_t = decltype(&DefDlgProcA);
+DefDlgProcA_t DefDlgProcA_orig;
+LRESULT WINAPI DefDlgProcA_hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    LRESULT result = DefDlgProcA_orig(hWnd, uMsg, wParam, lParam);
+
+    switch (uMsg) {
+        case WM_NCACTIVATE:
+            SetBorderInvisible(hWnd);
+            break;
+    }
+
+    return result;
+}
+
+using DefDlgProcW_t = decltype(&DefDlgProcW);
+DefDlgProcW_t DefDlgProcW_orig;
+LRESULT WINAPI DefDlgProcW_hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    LRESULT result = DefDlgProcW_orig(hWnd, uMsg, wParam, lParam);
+
+    switch (uMsg) {
+        case WM_NCACTIVATE:
+            SetBorderInvisible(hWnd);
+            break;
+    }
+
+    return result;
+}
+
+BOOL CALLBACK EnableEnumWindowsCallback(HWND hWnd, LPARAM lParam) {
+    DWORD pid = lParam;
+
+    DWORD wPid = 0;
+    GetWindowThreadProcessId(hWnd, &wPid);
+
+    if (pid == wPid) {
+        SetBorderInvisible(hWnd);
+    }
+
+    return TRUE;
+}
+
+BOOL CALLBACK DisableEnumWindowsCallback(HWND hWnd, LPARAM lParam) {
+    DWORD pid = lParam;
+    DWORD wPid = 0;
+    GetWindowThreadProcessId(hWnd, &wPid);
+
+    if (pid == wPid && IsValidWindow(hWnd))
+        DwmSetWindowAttribute_orig(hWnd, DWMWA_BORDER_COLOR, &ColorDefault, sizeof(ColorDefault));
+
+    return TRUE;
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"Init - Invisible Borders");
+
+    SpecialWindows = Wh_GetIntSetting(L"SpecialWindows");
+
+    Wh_SetFunctionHook(
+        (void *)DwmSetWindowAttribute,
+        (void *)DwmSetWindowAttribute_hook,
+        (void **)&DwmSetWindowAttribute_orig);
+
+    Wh_SetFunctionHook(
+        (void *)DefWindowProcW,
+        (void *)DefWindowProcW_hook,
+        (void **)&DefWindowProcW_orig
+    );
+
+    Wh_SetFunctionHook(
+        (void *)DefWindowProcA,
+        (void *)DefWindowProcA_hook,
+        (void **)&DefWindowProcA_orig
+    );
+
+    Wh_SetFunctionHook(
+        (void *)DefDlgProcW,
+        (void *)DefDlgProcW_hook,
+        (void **)&DefDlgProcW_orig
+    );
+
+    Wh_SetFunctionHook(
+        (void *)DefDlgProcA,
+        (void *)DefDlgProcA_hook,
+        (void **)&DefDlgProcA_orig
+    );
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    Wh_Log(L"AfterInit - Applying invisible borders");
+    EnumWindows(EnableEnumWindowsCallback, GetCurrentProcessId());
+}
+
+void Wh_ModBeforeUninit() {
+    Wh_Log(L"BeforeUninit - Restoring default borders");
+    EnumWindows(DisableEnumWindowsCallback, GetCurrentProcessId());
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L"SettingsChanged");
+    EnumWindows(DisableEnumWindowsCallback, GetCurrentProcessId());
+    SpecialWindows = Wh_GetIntSetting(L"SpecialWindows");
+    EnumWindows(EnableEnumWindowsCallback, GetCurrentProcessId());
+}


### PR DESCRIPTION
This mod makes window borders invisible while preserving rounded corners.

Features:
- Invisible borders while keeping rounded corners
- Works with all applications
- Lightweight and minimal performance impact
- Compatible with Windows 10 (1809+) and Windows 11

Author: Bo0ii