### PR TITLE
Double f2: timeless method

### DIFF
--- a/mods/explorer-double-f2-rename-extension.wh.cpp
+++ b/mods/explorer-double-f2-rename-extension.wh.cpp
@@ -32,11 +32,12 @@ This mod works great together with
 /*
 - DoubleF2MilliSeconds: 1000
   $name: Double F2 timing
-  $description: Time window for double press (milliseconds, 100-10000)
+  $description: >
+    Time window for double press (milliseconds, 100-10000)
 - ReverseCycle: false
   $name: Swap double/triple F2
-  $description: 'Select the whole name on double F2 and the extension on triple
-F2?'
+  $description: >
+    Select the whole name on double F2 and the extension on triple F2?
 */
 // ==/WindhawkModSettings==
 


### PR DESCRIPTION
As requested by @nmatt, Double F2 could work without even taking time into account. I tested this on some files and found no problemms, changing the settings also works fine.

Changelog:
- minor refactor
- option to loop selection based on current selection instead of hotkey timing