### PR TITLE
Add Taskbar Auto-Hide Instant Show mod

### DIFF
--- a/mods/taskbar-autohide-instant-show.wh.cpp
+++ b/mods/taskbar-autohide-instant-show.wh.cpp
@@ -448,6 +448,7 @@ bool HookTaskbarSymbols() {
         }
     }
 
+    // explorer.exe, taskbar.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {LR"(public: virtual void __cdecl TrayUI::SlideWindow(struct HWND__ *,struct tagRECT const *,struct HMONITOR__ *,bool,bool))"},


### PR DESCRIPTION
## New Mod: Taskbar Auto-Hide Instant Show

Removes the built-in delay before the auto-hidden taskbar starts appearing and adds custom animation types.

### Features
- **Zero delay** - Taskbar reacts instantly when mouse hits the screen edge (hooks SetTimer to eliminate the ~300-500ms Windows delay)
- **5 animation types**: Slide (with speedup), Elastic (spring overshoot), Bounce, Fade (opacity), Slide + Fade
- **Configurable** - Animation speed, duration, and frame rate settings
- **DWM synced** - Fade animations use DwmFlush() for flicker-free rendering
- **Compatible** - Windows 10 & 11, with ExplorerPatcher support

### Preview

**Elastic**
![Elastic](https://raw.githubusercontent.com/Bo0ii/windhawk-mods/main/taskbar-autohide-instant-show/elastic.gif)

**Fade**
![Fade](https://raw.githubusercontent.com/Bo0ii/windhawk-mods/main/taskbar-autohide-instant-show/Fade.gif)

**Slide + Fade**
![Slide + Fade](https://raw.githubusercontent.com/Bo0ii/windhawk-mods/main/taskbar-autohide-instant-show/fade-slide.gif)