### PR TITLE
Classic Minimize/Maximize Animations 1.1.0

### DIFF
--- a/mods/classic-min-max-animations.wh.cpp
+++ b/mods/classic-min-max-animations.wh.cpp
@@ -1080,9 +1080,19 @@ VS_FIXEDFILEINFO *GetModuleVersionInfo(HMODULE hModule, UINT *puPtrLen)
 
 BOOL Wh_ModInit(void)
 {
-    /* Disable window animations */
     ANIMATIONINFO ai;
     ai.cbSize = sizeof(ai);
+
+    if (Wh_GetIntValue(L"MinAnimate", -1) == -1)
+    {
+        SystemParametersInfoW(SPI_GETANIMATION, sizeof(ai), &ai, FALSE);
+        if (ai.iMinAnimate)
+        {
+            Wh_SetIntValue(L"MinAnimate", 1);
+        }
+    }
+    
+    /* Disable window animations */
     ai.iMinAnimate = FALSE;
     SystemParametersInfoW(SPI_SETANIMATION, sizeof(ai), &ai, TRUE);
 


### PR DESCRIPTION
- Hook SystemParametersInfo to handle SPI_(GET|SET)ANIMATION
  - Enabling/disabling "Animate windows when minimizing and maximizing" with the mod enabled will now control the mod's animation, not the system's
- Call SystemParametersInfo to automatically disable the DWM window animations at init and to enable them at uninit if MinAnimate is still enabled