### PR TITLE
Taskbar Thumbnail Size v1.2.1

### DIFF
--- a/mods/taskbar-thumbnail-size.wh.cpp
+++ b/mods/taskbar-thumbnail-size.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-thumbnail-size
 // @name            Taskbar Thumbnail Size
 // @description     Customize the size of the new taskbar thumbnails in Windows 11
-// @version         1.1
+// @version         1.2.1
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -29,7 +29,8 @@ Customize the size of the new taskbar thumbnails in Windows 11.
 By default, this mod uses simple percentage-based scaling. You can optionally
 enable absolute sizing mode to set specific pixel dimensions for thumbnails.
 
-For older Windows versions, the size of taskbar thumbnails can be changed via the registry:
+For older Windows versions, the size of taskbar thumbnails can be changed via
+the registry:
 
 * [Change Size of Taskbar Thumbnail Previews in Windows
   11](https://www.elevenforum.com/t/change-size-of-taskbar-thumbnail-previews-in-windows-11.6340/)
@@ -45,7 +46,8 @@ For older Windows versions, the size of taskbar thumbnails can be changed via th
 /*
 - size: 150
   $name: Thumbnail size (percentage)
-  $description: Percentage of the original size. Used when absolute sizing is disabled.
+  $description: >-
+    Percentage of the original size. Used when absolute sizing is disabled.
 - useAbsoluteSize: false
   $name: Use absolute sizing
   $description: >-
@@ -56,15 +58,15 @@ For older Windows versions, the size of taskbar thumbnails can be changed via th
   $description: >-
     Minimum thumbnail width in pixels. Only used when absolute sizing is
     enabled. Set to 0 to disable.
-- maxWidth: 180
-  $name: Maximum width (pixels)
-  $description: >-
-    Maximum thumbnail width in pixels. Only used when absolute sizing is
-    enabled. Set to 0 to disable.
 - minHeight: 120
   $name: Minimum height (pixels)
   $description: >-
     Minimum thumbnail height in pixels. Only used when absolute sizing is
+    enabled. Set to 0 to disable.
+- maxWidth: 180
+  $name: Maximum width (pixels)
+  $description: >-
+    Maximum thumbnail width in pixels. Only used when absolute sizing is
     enabled. Set to 0 to disable.
 - maxHeight: 120
   $name: Maximum height (pixels)
@@ -74,14 +76,15 @@ For older Windows versions, the size of taskbar thumbnails can be changed via th
 - preserveAspectRatio: true
   $name: Preserve aspect ratio
   $description: >-
-    When enabled, maintains the original aspect ratio when applying constraints.
-    Only used when absolute sizing is enabled.
+    Forcibly preserves thumbnail aspect ratios while fitting Maximum
+    constraints. Fits Minimum constraints as best as possible.
 */
 // ==/WindhawkModSettings==
 
 #include <windhawk_utils.h>
 
 #include <atomic>
+#include <cmath>
 
 #undef GetCurrentTime
 
@@ -104,14 +107,14 @@ std::atomic<bool> g_taskbarViewDllLoaded;
 
 using ThumbnailHelpers_GetScaledThumbnailSize_t =
     winrt::Windows::Foundation::Size*(
-        WINAPI*)(winrt::Windows::Foundation::Size* result,
+        WINAPI*)(winrt::Windows::Foundation::Size* resultBuffer,
                  winrt::Windows::Foundation::Size size,
                  float scale);
 ThumbnailHelpers_GetScaledThumbnailSize_t
     ThumbnailHelpers_GetScaledThumbnailSize_Original;
 winrt::Windows::Foundation::Size* WINAPI
 ThumbnailHelpers_GetScaledThumbnailSize_Hook(
-    winrt::Windows::Foundation::Size* result,
+    winrt::Windows::Foundation::Size* resultBuffer,
     winrt::Windows::Foundation::Size size,
     float scale) {
     Wh_Log(L"> %fx%f %f", size.Width, size.Height, scale);
@@ -120,74 +123,97 @@ ThumbnailHelpers_GetScaledThumbnailSize_Hook(
         // Original percentage-based behavior
         winrt::Windows::Foundation::Size* ret =
             ThumbnailHelpers_GetScaledThumbnailSize_Original(
-                result, size, scale * g_settings.size / 100.0);
+                resultBuffer, size, scale * g_settings.size / 100.0);
 
         Wh_Log(L"%fx%f", ret->Width, ret->Height);
         return ret;
     }
 
     // Absolute sizing mode
-    winrt::Windows::Foundation::Size* originalResult =
-        ThumbnailHelpers_GetScaledThumbnailSize_Original(result, size, scale);
+    winrt::Windows::Foundation::Size* result =
+        ThumbnailHelpers_GetScaledThumbnailSize_Original(resultBuffer, size,
+                                                         scale);
 
-    float currentWidth = originalResult->Width;
-    float currentHeight = originalResult->Height;
-    float aspectRatio = (currentWidth > 0) ? (currentHeight / currentWidth) : 1.0f;
+    float currentWidth = result->Width;
+    float currentHeight = result->Height;
+
+    if (currentWidth <= 0 || currentHeight <= 0) {
+        // Avoid division by zero and invalid sizes
+        Wh_Log(L"Invalid original size %fx%f, skipping", currentWidth,
+               currentHeight);
+        return result;
+    }
+
+    if (g_settings.preserveAspectRatio) {
+        // Calculate the scale factors needed to satisfy each constraint
+        // A scale > 1 means we need to enlarge, < 1 means shrink
+        float minScaleForWidth = 1.0f;
+        float minScaleForHeight = 1.0f;
+        float maxScaleForWidth = std::numeric_limits<float>::infinity();
+        float maxScaleForHeight = std::numeric_limits<float>::infinity();
+
+        if (g_settings.minWidth > 0) {
+            minScaleForWidth = g_settings.minWidth / currentWidth;
+        }
+        if (g_settings.minHeight > 0) {
+            minScaleForHeight = g_settings.minHeight / currentHeight;
+        }
+        if (g_settings.maxWidth > 0) {
+            maxScaleForWidth = g_settings.maxWidth / currentWidth;
+        }
+        if (g_settings.maxHeight > 0) {
+            maxScaleForHeight = g_settings.maxHeight / currentHeight;
+        }
+
+        // The minimum scale we must apply (to satisfy min constraints)
+        float minRequiredScale = std::fmax(minScaleForWidth, minScaleForHeight);
+        // The maximum scale we can apply (to satisfy max constraints)
+        float maxAllowedScale = std::fmin(maxScaleForWidth, maxScaleForHeight);
+
+        // Choose the scale that results in minimal change from original
+        float finalScale = 1.0f;
+
+        if (maxAllowedScale >= minRequiredScale) {
+            // Constraints are satisfiable - pick scale closest to 1.0
+            if (minRequiredScale > 1.0f) {
+                // Need to enlarge to meet minimum constraints
+                finalScale = minRequiredScale;
+            } else if (maxAllowedScale < 1.0f) {
+                // Need to shrink to meet maximum constraints
+                finalScale = maxAllowedScale;
+            }
+            // else: current size already satisfies all constraints, keep
+            // scale = 1.0
+        } else {
+            // Constraints conflict - prioritize max constraints (fit within
+            // bounds)
+            finalScale = maxAllowedScale;
+        }
+
+        winrt::Windows::Foundation::Size* ret =
+            finalScale == 1.0f
+                ? result
+                : ThumbnailHelpers_GetScaledThumbnailSize_Original(
+                      resultBuffer, size, scale * finalScale);
+        Wh_Log(L"%fx%f", ret->Width, ret->Height);
+        return ret;
+    }
 
     float targetWidth = currentWidth;
     float targetHeight = currentHeight;
 
-    if (g_settings.preserveAspectRatio) {
-        // Apply width constraints
-        if (g_settings.minWidth > 0 && targetWidth < g_settings.minWidth) {
-            targetWidth = static_cast<float>(g_settings.minWidth);
-        }
-        if (g_settings.maxWidth > 0 && targetWidth > g_settings.maxWidth) {
-            targetWidth = static_cast<float>(g_settings.maxWidth);
-        }
-
-        // Calculate height from width
-        targetHeight = targetWidth * aspectRatio;
-
-        // Check height constraints
-        bool heightAdjusted = false;
-        if (g_settings.minHeight > 0 && targetHeight < g_settings.minHeight) {
-            targetHeight = static_cast<float>(g_settings.minHeight);
-            heightAdjusted = true;
-        }
-        if (g_settings.maxHeight > 0 && targetHeight > g_settings.maxHeight) {
-            targetHeight = static_cast<float>(g_settings.maxHeight);
-            heightAdjusted = true;
-        }
-
-        // Recalculate width if height was adjusted
-        if (heightAdjusted) {
-            targetWidth = targetHeight / aspectRatio;
-
-            // Re-apply width constraints
-            if (g_settings.minWidth > 0 && targetWidth < g_settings.minWidth) {
-                targetWidth = static_cast<float>(g_settings.minWidth);
-                targetHeight = targetWidth * aspectRatio;
-            }
-            if (g_settings.maxWidth > 0 && targetWidth > g_settings.maxWidth) {
-                targetWidth = static_cast<float>(g_settings.maxWidth);
-                targetHeight = targetWidth * aspectRatio;
-            }
-        }
-    } else {
-        // Apply constraints independently (may distort aspect ratio)
-        if (g_settings.minWidth > 0 && targetWidth < g_settings.minWidth) {
-            targetWidth = static_cast<float>(g_settings.minWidth);
-        }
-        if (g_settings.maxWidth > 0 && targetWidth > g_settings.maxWidth) {
-            targetWidth = static_cast<float>(g_settings.maxWidth);
-        }
-        if (g_settings.minHeight > 0 && targetHeight < g_settings.minHeight) {
-            targetHeight = static_cast<float>(g_settings.minHeight);
-        }
-        if (g_settings.maxHeight > 0 && targetHeight > g_settings.maxHeight) {
-            targetHeight = static_cast<float>(g_settings.maxHeight);
-        }
+    // Apply constraints without regard to aspect ratio
+    if (g_settings.minWidth > 0 && targetWidth < g_settings.minWidth) {
+        targetWidth = g_settings.minWidth;
+    }
+    if (g_settings.maxWidth > 0 && targetWidth > g_settings.maxWidth) {
+        targetWidth = g_settings.maxWidth;
+    }
+    if (g_settings.minHeight > 0 && targetHeight < g_settings.minHeight) {
+        targetHeight = g_settings.minHeight;
+    }
+    if (g_settings.maxHeight > 0 && targetHeight > g_settings.maxHeight) {
+        targetHeight = g_settings.maxHeight;
     }
 
     result->Width = targetWidth;
@@ -286,8 +312,8 @@ void LoadSettings() {
     g_settings.size = Wh_GetIntSetting(L"size");
     g_settings.useAbsoluteSize = Wh_GetIntSetting(L"useAbsoluteSize");
     g_settings.minWidth = Wh_GetIntSetting(L"minWidth");
-    g_settings.maxWidth = Wh_GetIntSetting(L"maxWidth");
     g_settings.minHeight = Wh_GetIntSetting(L"minHeight");
+    g_settings.maxWidth = Wh_GetIntSetting(L"maxWidth");
     g_settings.maxHeight = Wh_GetIntSetting(L"maxHeight");
     g_settings.preserveAspectRatio = Wh_GetIntSetting(L"preserveAspectRatio");
 }


### PR DESCRIPTION
* When "preserve aspect ratio" is selected, the respected bounds are now the width and height maximums. Minimum bounds are attempted to be respected, but not guaranteed. Fixes [issue #2957](https://github.com/ramensoftware/windhawk-mods/issues/2957). Contributed by [iZack](https://github.com/alchemyyy).