### PR TITLE
Windows 11 Notification Center Styler v1.4

### DIFF
--- a/mods/windows-11-notification-center-styler.wh.cpp
+++ b/mods/windows-11-notification-center-styler.wh.cpp
@@ -2,7 +2,7 @@
 // @id              windows-11-notification-center-styler
 // @name            Windows 11 Notification Center Styler
 // @description     Customize the Notification Center and Action Center with themes contributed by others or create your own
-// @version         1.3.3
+// @version         1.4
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -59,6 +59,14 @@ WindowGlass](https://github.com/ramensoftware/windows-11-notification-center-sty
 [![Oversimplified&Accentuated](https://raw.githubusercontent.com/ramensoftware/windows-11-notification-center-styling-guide/main/Themes/Oversimplified&Accentuated/screenshot-small.png)
 \
 Oversimplified&Accentuated](https://github.com/ramensoftware/windows-11-notification-center-styling-guide/blob/main/Themes/Oversimplified&Accentuated/README.md)
+
+[![TintedGlass](https://raw.githubusercontent.com/ramensoftware/windows-11-notification-center-styling-guide/main/Themes/TintedGlass/screenshot-small.png)
+\
+TintedGlass](https://github.com/ramensoftware/windows-11-notification-center-styling-guide/blob/main/Themes/TintedGlass/README.md)
+
+[![Fluid](https://raw.githubusercontent.com/ramensoftware/windows-11-notification-center-styling-guide/main/Themes/Fluid/screenshot-small.png)
+\
+Fluid](https://github.com/ramensoftware/windows-11-notification-center-styling-guide/blob/main/Themes/Fluid/README.md)
 
 More themes can be found in the **Themes** section of [The Windows 11
 notification center styling
@@ -162,8 +170,35 @@ Makes panel non full-height when there are fewer notifications (fit to size). \
 
 ### Resource variables
 
-Some variables, such as size and padding for various controls, are defined as
-resource variables.
+Some variables, such as size and padding for various controls, colors, and
+brushes, are defined as resource variables. You can override existing resources
+or define new theme-aware resources.
+
+#### Overriding existing resources
+
+Use `key=value` to override an existing resource.
+
+#### Defining theme-aware resources
+
+Use `Key@Dark=value` and `Key@Light=value` to define new resources with
+different values for dark and light themes. These can then be referenced in
+styles using `{ThemeResource key}`.
+
+For example, to define a custom accent color that automatically adjusts based on
+the system theme:
+
+```
+AutoAccent@Dark={ThemeResource SystemAccentColorDark1}
+AutoAccent@Light={ThemeResource SystemAccentColorLight2}
+```
+
+Then use it in a style:
+
+```
+Background:=<SolidColorBrush Color="{ThemeResource AutoAccent}" />
+```
+
+The value will automatically update when the system accent color changes.
 
 ## Implementation notes
 
@@ -194,6 +229,8 @@ from the **TranslucentTB** project.
   - WindowGlass: WindowGlass
   - WindowGlass_variant_alternative: WindowGlass (Alternative)
   - Oversimplified&Accentuated: Oversimplified&Accentuated
+  - TintedGlass: TintedGlass
+  - Fluid: Fluid
 - controlStyles:
   - - target: ""
       $name: Target
@@ -215,12 +252,13 @@ from the **TranslucentTB** project.
     Fill=$mainColor
 
     Background:=<AcrylicBrush TintColor="$mainColor" TintOpacity="0.3" />
-- resourceVariables:
-  - - variableKey: ""
-      $name: Variable key
-    - value: ""
-      $name: Value
+- themeResourceVariables: [""]
   $name: Resource variables
+  $description: >-
+    Use "Key=Value" to override an existing resource with a new value.
+
+    Use "Key@Dark=Value" or "Key@Light=Value" to define theme-aware resources
+    that can be referenced with {ThemeResource Key} in styles.
 */
 // ==/WindhawkModSettings==
 
@@ -306,15 +344,14 @@ const Theme g_themeTranslucentShell = {{
     ThemeTargetStyles{L"ActionCenter.FlexibleItemView", {
         L"CornerRadius=15"}},
     ThemeTargetStyles{L"ControlCenter.MediaTransportControls#MediaTransportControls > Windows.UI.Xaml.Controls.Grid#MediaTransportControlsRegion", {
-        L"Height=470"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#AlbumTextAndArtContainer", {
-        L"Height=350"}},
+        L"Height=Auto"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ThumbnailImage", {
-        L"Width=300",
-        L"Height=300",
+        L"Width=$thumbnailImageSize",
+        L"Height=$thumbnailImageSize",
         L"HorizontalAlignment=Center",
         L"VerticalAlignment=Top",
-        L"Grid.Column=1"}},
+        L"Grid.Column=1",
+        L"Margin=0,2,0,45"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ThumbnailImage > Windows.UI.Xaml.Controls.Border", {
         L"CornerRadius=10"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.StackPanel#PrimaryAndSecondaryTextContainer", {
@@ -326,6 +363,7 @@ const Theme g_themeTranslucentShell = {{
         L"TextAlignment=Center"}},
 }, {
     L"CommonBgBrush=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#25323232\"/>",
+    L"thumbnailImageSize=300",
 }};
 
 const Theme g_themeMatter = {{
@@ -453,21 +491,20 @@ const Theme g_themeMatter = {{
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.Thumb#HorizontalThumb", {
         L"Visibility = 1"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#MediaTransportControlsRegion", {
-        L"Height=470",
+        L"Height=Auto",
         L"CornerRadius=$r1",
         L"BorderThickness = 0",
         L"Background:=$base",
         L"Shadow :=",
+        L"Padding = 0,0,0,12",
         L"Margin = 0,0,0,12"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#AlbumTextAndArtContainer", {
-        L"Height=347"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ThumbnailImage", {
-        L"Width=300",
-        L"Height=300",
+        L"Width=$thumbnailImageSize",
+        L"Height=$thumbnailImageSize",
         L"HorizontalAlignment=Center",
         L"VerticalAlignment=Top",
         L"Grid.Column=1",
-        L"Margin=0,2,0,0",
+        L"Margin=0,2,0,45",
         L"CornerRadius=$r2"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.StackPanel#PrimaryAndSecondaryTextContainer", {
         L"VerticalAlignment=Bottom",
@@ -602,6 +639,7 @@ const Theme g_themeMatter = {{
     L"r1 = 18",
     L"r2 = 14",
     L"r3 = 12",
+    L"thumbnailImageSize = 300",
 }};
 
 const Theme g_themeUnified = {{
@@ -731,61 +769,58 @@ const Theme g_themeWindowGlass = {{
         L"BorderBrush:=$BorderBrush"}},
     ThemeTargetStyles{L"ScrollViewer#CalendarControlScrollViewer", {
         L"Background:=$ElementBG",
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"Margin=-10,11,-10,-14",
         L"BorderBrush:=$ElementBorderBrush",
         L"BorderThickness=$ElementBorderThickness"}},
     ThemeTargetStyles{L"Border#CalendarHeaderMinimizedOverlay", {
         L"Background:=$ElementBG",
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"Margin=-10,-6,-10,-8",
         L"Height=45",
         L"BorderBrush:=$ElementBorderBrush",
         L"BorderThickness=$ElementBorderThickness"}},
     ThemeTargetStyles{L"ActionCenter.FocusSessionControl#FocusSessionControl > Grid#FocusGrid", {
         L"Background:=$Background",
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"Margin=6,7,6,6",
         L"BorderThickness=$BorderThickness",
         L"BorderBrush:=$BorderBrush"}},
-    ThemeTargetStyles{L"MenuFlyoutPresenter", {
+    ThemeTargetStyles{L"MenuFlyoutPresenter > Border", {
         L"Background:=$Background",
         L"BorderThickness=$BorderThickness",
-        L"CornerRadius=$r3",
+        L"CornerRadius=$CR3",
         L"Padding=1,2,1,2",
         L"BorderBrush:=$BorderBrush"}},
     ThemeTargetStyles{L"Border#JumpListRestyledAcrylic", {
         L"Background:=$Background",
         L"BorderThickness=$BorderThickness",
-        L"CornerRadius=$r3",
+        L"CornerRadius=$CR3",
         L"Margin=-2,-2,-2,-2",
         L"BorderBrush:=$BorderBrush"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ControlCenterRegion", {
         L"Background:=$Background",
         L"CornerRadius=$CornerRadius",
         L"BorderThickness=$BorderThickness",
-        L"BorderBrush:=$BorderBrush",
-        L"Height=Auto",
-        L"MaxHeight:=380",
-        L"MinHeight:=300"}},
+        L"BorderBrush:=$BorderBrush"}},
     ThemeTargetStyles{L"ContentPresenter#PageContent", {
-        L"Background:=$transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"ContentPresenter#PageContent > Grid > Border", {
         L"Background:=$overlay",
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"Margin=8,0,8,2"}},
     ThemeTargetStyles{L"QuickActions.ControlCenter.AccessibleWindow#PageWindow > ContentPresenter > Grid#FullScreenPageRoot", {
-        L"Background:=$transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"QuickActions.ControlCenter.AccessibleWindow#PageWindow > ContentPresenter > Grid#FullScreenPageRoot > ContentPresenter#PageHeader", {
         L"Background:=$overlay",
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"Margin=7,7,7,7"}},
     ThemeTargetStyles{L"ScrollViewer#ListContent", {
         L"Background:=$overlay",
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"Margin=8,0,8,0"}},
     ThemeTargetStyles{L"ActionCenter.FlexibleToastView#FlexibleNormalToastView", {
-        L"Background:=$transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"Border#ToastBackgroundBorder2", {
         L"Background:=$Background",
         L"BorderThickness=$BorderThickness",
@@ -799,19 +834,19 @@ const Theme g_themeWindowGlass = {{
     ThemeTargetStyles{L"ActionCenter.FlexibleItemView", {
         L"CornerRadius=16"}},
     ThemeTargetStyles{L"Grid#NotificationCenterTopBanner", {
-        L"Background:=Transparent",
-        L"CornerRadius=$r2",
+        L"Background=Transparent",
+        L"CornerRadius=$CR2",
         L"Margin=6"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#L1Grid > Border", {
-        L"Background:=$transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ContentPresenter", {
         L"BorderThickness=0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#FooterButton[AutomationProperties.Name=Edit quick settings]", {
         L"Margin=0,0,8,0",
-        L"CornerRadius=$r3"}},
+        L"CornerRadius=$CR3"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button[AutomationProperties.AutomationId=Microsoft.QuickAction.Battery]", {
         L"Margin=2,0,0,0",
-        L"CornerRadius=$r3"}},
+        L"CornerRadius=$CR3"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#FooterButton[AutomationProperties.Name=All settings]", {
         L"Margin=0,0,-1,0",
         L"CornerRadius=13",
@@ -841,12 +876,12 @@ const Theme g_themeWindowGlass = {{
         L"CornerRadius=$CornerRadius",
         L"BorderThickness=$BorderThickness",
         L"Background:=$Background",
-        L"Margin=0,10,0,10",
+        L"Margin=0,10,0,0",
         L"BorderBrush:=$BorderBrush",
         L"Grid.Row=1"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#AlbumTextAndArtContainer", {
         L"Height=55",
-        L"MaxWidth:=150",
+        L"MaxWidth=150",
         L"HorizontalAlignment=Left"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ThumbnailImage", {
         L"Visibility=1"}},
@@ -888,7 +923,7 @@ const Theme g_themeWindowGlass = {{
         L"Height=20",
         L"Width=20"}},
     ThemeTargetStyles{L"Grid#MediaTransportControlsRoot", {
-        L"Background:=$transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"Grid#ToastPeekRegion", {
         L"Background=",
         L"RenderTransform:=<TranslateTransform Y=\"-495\" X=\"395\" />",
@@ -916,20 +951,20 @@ const Theme g_themeWindowGlass = {{
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ScrollContentPresenter#ScrollContentPresenter", {
         L"Margin=1,2,1,2"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#WeekDayNames", {
-        L"Background :=$ElementSysColor",
+        L"Background:=$ElementSysColor",
         L"CornerRadius=8",
         L"Margin=4,0,4,0",
         L"Padding=0,-5,0,-3"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ListViewItem", {
-        L"CornerRadius=$r3"}},
+        L"CornerRadius=$CR3"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#RootGrid > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter", {
         L"Background:=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight1}\" Opacity=\"0.5\"/>",
         L"BorderThickness=0",
         L"CornerRadius=8"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.Border#ItemOpaquePlating", {
-        L"Background :=$overlay2",
+        L"Background:=$overlay2",
         L"BorderThickness=0",
-        L"CornerRadius=$r3"}},
+        L"CornerRadius=$CR3"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#StandardHeroContainer", {
         L"Margin=12,0,12,0",
         L"CornerRadius=0",
@@ -939,7 +974,7 @@ const Theme g_themeWindowGlass = {{
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#SliderContainer", {
         L"Margin=0-2,0,0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#BackButton", {
-        L"CornerRadius=$r3"}},
+        L"CornerRadius=$CR3"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Shapes.Rectangle#OuterBorder", {
         L"RadiusX=8",
         L"RadiusY=8",
@@ -966,7 +1001,7 @@ const Theme g_themeWindowGlass = {{
     ThemeTargetStyles{L"Button#ExpandCollapseButton", {
         L"AccessKey=e"}},
     ThemeTargetStyles{L"ControlCenter.PaginatedToggleButton#ToggleButton > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter", {
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"BorderThickness=$ElementBorderThickness",
         L"BorderBrush:=$ElementBorderBrush"}},
     ThemeTargetStyles{L"ControlCenter.PaginatedToggleButton#SplitL2Button > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter", {
@@ -990,19 +1025,19 @@ const Theme g_themeWindowGlass = {{
         L"Foreground@PointerOver:=$ElementSysColor2",
         L"Foreground@Pressed:=$ElementSysColor3",
         L"Foreground@Disabled:=$ElementSysColor4",
-        L"Background:=Transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#PlayPauseButton > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter@CommonStates", {
         L"Foreground@Normal:=$ElementSysColor",
         L"Foreground@PointerOver:=$ElementSysColor2",
         L"Foreground@Pressed:=$ElementSysColor3",
         L"Foreground@Disabled:=$ElementSysColor4",
-        L"Background:=Transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.RepeatButton#NextButton > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter@CommonStates", {
         L"Foreground@Normal:=$ElementSysColor",
         L"Foreground@PointerOver:=$ElementSysColor2",
         L"Foreground@Pressed:=$ElementSysColor3",
         L"Foreground@Disabled:=$ElementSysColor4",
-        L"Background:=Transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"Grid#ControlCenterRegion", {
         L"Grid.Row=0"}},
     ThemeTargetStyles{L"ControlCenter.MediaTransportControls", {
@@ -1013,21 +1048,23 @@ const Theme g_themeWindowGlass = {{
         L"VerticalAlignment=3",
         L"MinHeight=0"}},
 }, {
-    L"transparent=<SolidColorBrush Color=\"Transparent\"/>",
-    L"Background=<WindhawkBlur BlurAmount=\"15\" TintColor=\"#10808080\"/>",
+    L"Translucent=<WindhawkBlur BlurAmount=\"15\" TintColor=\"#10808080\"/>",
+    L"Glass=<WindhawkBlur BlurAmount=\"3\" TintColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"0.7\" />",
+    L"Frosted=<WindhawkBlur BlurAmount=\"20\" TintColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"0.7\" />",
+    L"Acrylic=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeAltHighColor}\" TintOpacity=\"0.3\" FallbackColor=\"{ThemeResource SystemChromeAltHighColor}\" />",
+    L"Background=$Translucent",
+    L"BorderBrush=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#50808080\" Offset=\"0.0\" /><GradientStop Color=\"#50404040\" Offset=\"0.25\" /><GradientStop Color=\"#50808080\" Offset=\"1\" /></LinearGradientBrush>",
+    L"BorderBrush2=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"{ThemeResource SystemChromeHighColor}\" Offset=\"0.0\" /><GradientStop Color=\"{ThemeResource SystemChromeLowColor}\" Offset=\"0.15\" /><GradientStop Color=\"{ThemeResource SystemChromeHighColor}\" Offset=\"0.95\" /></LinearGradientBrush>",
     L"overlay=<SolidColorBrush Color=\"{ThemeResource SystemChromeAltHighColor}\" Opacity=\"0.1\" />",
     L"overlay2=<WindhawkBlur BlurAmount=\"20\" TintColor=\"#60353535\"/>",
     L"CornerRadius=20",
-    L"r2=14",
-    L"r3=12",
+    L"CR2=14",
+    L"CR3=12",
     L"BorderThickness=0.3,1,0.3,0.3",
-    L"BorderBrush2=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"{ThemeResource SystemChromeHighColor}\" Offset=\"0.0\" /><GradientStop Color=\"{ThemeResource SystemChromeLowColor}\" Offset=\"0.15\" /><GradientStop Color=\"{ThemeResource SystemChromeHighColor}\" Offset=\"0.95\" /></LinearGradientBrush>",
-    L"Background2=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeAltHighColor}\" TintOpacity=\"0.3\" FallbackColor=\"{ThemeResource SystemChromeAltHighColor}\" />",
     L"ElementBG=<SolidColorBrush Color=\"{ThemeResource SystemChromeAltHighColor}\" Opacity=\"0.3\" />",
     L"ElementBorderBrush=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#50808080\" Offset=\"1\" /><GradientStop Color=\"#50606060\" Offset=\"0.15\" /></LinearGradientBrush>",
     L"ElementCornerRadius=20",
     L"ElementBorderThickness=0.3,0.3,0.3,1",
-    L"BorderBrush=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#50808080\" Offset=\"0.0\" /><GradientStop Color=\"#50404040\" Offset=\"0.25\" /><GradientStop Color=\"#50808080\" Offset=\"1\" /></LinearGradientBrush>",
     L"ElementSysColor=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight1}\" Opacity=\"1\" />",
     L"ElementSysColor2=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight2}\" Opacity=\"1\" />",
     L"ElementSysColor3=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight3}\" Opacity=\"1\" />",
@@ -1044,68 +1081,64 @@ const Theme g_themeWindowGlass_variant_alternative = {{
         L"Background:=$Background",
         L"BorderThickness=$BorderThickness",
         L"CornerRadius=$CornerRadius",
-        L"Margin = 0,6,0,6",
-        L"MinHeight = 40",
+        L"Margin=0,6,0,6",
+        L"MinHeight=40",
         L"BorderBrush:=$BorderBrush"}},
     ThemeTargetStyles{L"ScrollViewer#CalendarControlScrollViewer", {
         L"Background:=$ElementBG",
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"Margin=-10,11,-10,-14",
         L"BorderBrush:=$ElementBorderBrush",
         L"BorderThickness=$ElementBorderThickness"}},
     ThemeTargetStyles{L"Border#CalendarHeaderMinimizedOverlay", {
         L"Background:=$ElementBG",
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"Margin=-10,-6,-10,-8",
         L"Height=45",
         L"BorderBrush:=$ElementBorderBrush",
         L"BorderThickness=$ElementBorderThickness"}},
     ThemeTargetStyles{L"ActionCenter.FocusSessionControl#FocusSessionControl > Grid#FocusGrid", {
         L"Background:=$Background",
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"Margin=6,7,6,6",
         L"BorderThickness=$BorderThickness",
         L"BorderBrush:=$BorderBrush"}},
-    ThemeTargetStyles{L"MenuFlyoutPresenter", {
+    ThemeTargetStyles{L"MenuFlyoutPresenter > Border", {
         L"Background:=$Background",
         L"BorderThickness=$BorderThickness",
-        L"CornerRadius=$r3",
+        L"CornerRadius=$CR3",
         L"Padding=1,2,1,2",
         L"BorderBrush:=$BorderBrush"}},
     ThemeTargetStyles{L"Border#JumpListRestyledAcrylic", {
         L"Background:=$Background",
         L"BorderThickness=$BorderThickness",
-        L"CornerRadius=$r3",
+        L"CornerRadius=$CR3",
         L"Margin=-2,-2,-2,-2",
         L"BorderBrush:=$BorderBrush"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ControlCenterRegion", {
         L"Background:=$Background",
         L"CornerRadius=$CornerRadius",
         L"BorderThickness=$BorderThickness",
-        L"Margin=0,5,0,10",
-        L"BorderBrush:=$BorderBrush",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"0\"/>",
-        L"Height=Auto",
-        L"MaxHeight:=380",
-        L"MinHeight:=300"}},
+        L"Margin=0,5,0,0",
+        L"BorderBrush:=$BorderBrush"}},
     ThemeTargetStyles{L"ContentPresenter#PageContent", {
-        L"Background:= $transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"ContentPresenter#PageContent > Grid > Border", {
         L"Background:=$overlay",
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"Margin=8,0,8,2"}},
     ThemeTargetStyles{L"QuickActions.ControlCenter.AccessibleWindow#PageWindow > ContentPresenter > Grid#FullScreenPageRoot", {
-        L"Background:= $transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"QuickActions.ControlCenter.AccessibleWindow#PageWindow > ContentPresenter > Grid#FullScreenPageRoot > ContentPresenter#PageHeader", {
         L"Background:=$overlay",
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"Margin=7,7,7,7"}},
     ThemeTargetStyles{L"ScrollViewer#ListContent", {
         L"Background:=$overlay",
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"Margin=8,0,8,0"}},
     ThemeTargetStyles{L"ActionCenter.FlexibleToastView#FlexibleNormalToastView", {
-        L"Background:= $transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"Border#ToastBackgroundBorder2", {
         L"Background:=$Background",
         L"BorderThickness=$BorderThickness",
@@ -1119,27 +1152,27 @@ const Theme g_themeWindowGlass_variant_alternative = {{
     ThemeTargetStyles{L"ActionCenter.FlexibleItemView", {
         L"CornerRadius=16"}},
     ThemeTargetStyles{L"Grid#NotificationCenterTopBanner", {
-        L"Background:=Transparent",
-        L"CornerRadius=$r2",
+        L"Background=Transparent",
+        L"CornerRadius=$CR2",
         L"Margin=6"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#L1Grid > Border", {
-        L"Background:= $transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ContentPresenter", {
         L"BorderThickness=0"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#FooterButton[AutomationProperties.Name = Edit quick settings]", {
-        L"Margin = 0,0,8,0",
-        L"CornerRadius=$r3"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button[AutomationProperties.AutomationId = Microsoft.QuickAction.Battery]", {
-        L"Margin = 2,0,0,0",
-        L"CornerRadius=$r3"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#FooterButton[AutomationProperties.Name = All settings]", {
-        L"Margin = 0,0,-1,0",
-        L"CornerRadius = 13",
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#FooterButton[AutomationProperties.Name=Edit quick settings]", {
+        L"Margin=0,0,8,0",
+        L"CornerRadius=$CR3"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button[AutomationProperties.AutomationId=Microsoft.QuickAction.Battery]", {
+        L"Margin=2,0,0,0",
+        L"CornerRadius=$CR3"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#FooterButton[AutomationProperties.Name=All settings]", {
+        L"Margin=0,0,-1,0",
+        L"CornerRadius=13",
         L"BorderThickness=$BorderThickness"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button[AutomationProperties.AutomationId = Microsoft.QuickAction.Volume]", {
-        L"CornerRadius = 10"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#VolumeL2Button[AutomationProperties.Name = Select a sound output]", {
-        L"CornerRadius = 10"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button[AutomationProperties.AutomationId=Microsoft.QuickAction.Volume]", {
+        L"CornerRadius=10"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#VolumeL2Button[AutomationProperties.Name=Select a sound output]", {
+        L"CornerRadius=10"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Shapes.Rectangle#HorizontalTrackRect", {
         L"Height=10",
         L"Fill:=$overlay",
@@ -1162,11 +1195,10 @@ const Theme g_themeWindowGlass_variant_alternative = {{
         L"BorderThickness=$BorderThickness",
         L"Background:=$Background",
         L"Margin=0,20,0,5",
-        L"BorderBrush:=$BorderBrush",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"0\"/>"}},
+        L"BorderBrush:=$BorderBrush"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#AlbumTextAndArtContainer", {
         L"Height=55",
-        L"MaxWidth:=150",
+        L"MaxWidth=150",
         L"HorizontalAlignment=Left"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ThumbnailImage", {
         L"Visibility=1"}},
@@ -1180,7 +1212,7 @@ const Theme g_themeWindowGlass_variant_alternative = {{
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.StackPanel#PrimaryAndSecondaryTextContainer > Windows.UI.Xaml.Controls.TextBlock#Subtitle", {
         L"TextAlignment=Center",
         L"FontFamily=vivo Sans EN VF",
-        L"Margin = 0,3,0,0",
+        L"Margin=0,3,0,0",
         L"FontWeight=600"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ListView#MediaButtonsListView", {
         L"VerticalAlignment=Center",
@@ -1195,98 +1227,98 @@ const Theme g_themeWindowGlass_variant_alternative = {{
         L"Margin=10,0,0,0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#PlayPauseButton", {
         L"Width=40",
-        L"Height = 40",
+        L"Height=40",
         L"Margin=0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.RepeatButton#NextButton", {
         L"Width=40",
-        L"Height = 30",
+        L"Height=30",
         L"Margin=0,0,10,0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock#AppNameText", {
         L"FontFamily=vivo Sans EN VF",
-        L"FontSize = 16"}},
+        L"FontSize=16"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Image#IconImage", {
-        L"Height = 20",
-        L"Width = 20"}},
+        L"Height=20",
+        L"Width=20"}},
     ThemeTargetStyles{L"Grid#MediaTransportControlsRoot", {
-        L"Background:= $transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"Grid#ToastPeekRegion", {
-        L"Background =",
+        L"Background=",
         L"RenderTransform:=<TranslateTransform Y=\"-495\" X=\"395\" />",
-        L"Grid.Column = 0",
-        L"Grid.Row = 2"}},
+        L"Grid.Column=0",
+        L"Grid.Row=2"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.CalendarViewDayItem > Windows.UI.Xaml.Controls.Border", {
-        L"CornerRadius = 8",
-        L"Margin = 1,2,1,2"}},
+        L"CornerRadius=8",
+        L"Margin=1,2,1,2"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.CalendarViewDayItem", {
-        L"CornerRadius = 8"}},
+        L"CornerRadius=8"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Control > Windows.UI.Xaml.Controls.Border", {
-        L"CornerRadius = 8"}},
+        L"CornerRadius=8"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.CalendarViewItem", {
-        L"CornerRadius = 8"}},
+        L"CornerRadius=8"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ListViewHeaderItem", {
-        L"Margin = 50,6,50,2",
-        L"CornerRadius = 8",
-        L"Height = 35"}},
+        L"Margin=50,6,50,2",
+        L"CornerRadius=8",
+        L"Height=35"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#SettingsButton", {
-        L"CornerRadius = 4"}},
+        L"CornerRadius=4"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#DismissButton", {
-        L"CornerRadius = 4"}},
+        L"CornerRadius=4"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.StackPanel#CalendarHeader", {
-        L"Margin = 6,0,0,0"}},
+        L"Margin=6,0,0,0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ScrollContentPresenter#ScrollContentPresenter", {
-        L"Margin = 1,2,1,2"}},
+        L"Margin=1,2,1,2"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#WeekDayNames", {
-        L"Background :=$ElementSysColor",
-        L"CornerRadius = 8",
-        L"Margin = 4,0,4,0",
-        L"Padding = 0,-5,0,-3"}},
+        L"Background:=$ElementSysColor",
+        L"CornerRadius=8",
+        L"Margin=4,0,4,0",
+        L"Padding=0,-5,0,-3"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ListViewItem", {
-        L"CornerRadius=$r3"}},
+        L"CornerRadius=$CR3"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#RootGrid > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter", {
-        L"Background:=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight1}\" Opacity =\"0.5\"/>",
+        L"Background:=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight1}\" Opacity=\"0.5\"/>",
         L"BorderThickness=0",
         L"CornerRadius=8"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.Border#ItemOpaquePlating", {
-        L"Background := $overlay2",
-        L"BorderThickness = 0",
-        L"CornerRadius=$r3"}},
+        L"Background:=$overlay2",
+        L"BorderThickness=0",
+        L"CornerRadius=$CR3"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#StandardHeroContainer", {
-        L"Margin = 12,0,12,0",
-        L"CornerRadius = 0",
-        L"Height = 150"}},
+        L"Margin=12,0,12,0",
+        L"CornerRadius=0",
+        L"Height=150"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ScrollBar#VerticalScrollBar", {
-        L"Visibility = 1"}},
+        L"Visibility=1"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#SliderContainer", {
-        L"Margin = 0-2,0,0"}},
+        L"Margin=0-2,0,0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#BackButton", {
-        L"CornerRadius=$r3"}},
+        L"CornerRadius=$CR3"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Shapes.Rectangle#OuterBorder", {
-        L"RadiusX = 8",
-        L"RadiusY = 8",
-        L"Height = 18"}},
+        L"RadiusX=8",
+        L"RadiusY=8",
+        L"Height=18"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Shapes.Rectangle#SwitchKnobOff", {
-        L"RadiusY = 8",
-        L"RadiusX = 8"}},
+        L"RadiusY=8",
+        L"RadiusX=8"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#SwitchKnobOn", {
-        L"CornerRadius =8"}},
+        L"CornerRadius=8"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Shapes.Rectangle#SwitchKnobBounds", {
-        L"RadiusX =8",
-        L"RadiusY =8",
-        L"Height = 18"}},
+        L"RadiusX=8",
+        L"RadiusY=8",
+        L"Height=18"}},
     ThemeTargetStyles{L"ActionCenter.NotificationListViewItem", {
-        L"Margin = 5,2,5,3"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid[AutomationProperties.LocalizedLandmarkType = Footer]", {
-        L"BorderThickness = 0"}},
+        L"Margin=5,2,5,3"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid[AutomationProperties.LocalizedLandmarkType=Footer]", {
+        L"BorderThickness=0"}},
     ThemeTargetStyles{L"NetworkUX.View.SettingsListViewItem > Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter#Root", {
-        L"CornerRadius = 12"}},
+        L"CornerRadius=12"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ContentPresenter > Windows.UI.Xaml.Controls.Border", {
-        L"BorderThickness = 0"}},
+        L"BorderThickness=0"}},
     ThemeTargetStyles{L"Button#ClearAll", {
         L"AccessKey=x"}},
     ThemeTargetStyles{L"Button#ExpandCollapseButton", {
         L"AccessKey=e"}},
     ThemeTargetStyles{L"ControlCenter.PaginatedToggleButton#ToggleButton > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter", {
-        L"CornerRadius=$r2",
+        L"CornerRadius=$CR2",
         L"BorderThickness=$ElementBorderThickness",
         L"BorderBrush:=$ElementBorderBrush"}},
     ThemeTargetStyles{L"ControlCenter.PaginatedToggleButton#SplitL2Button > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter", {
@@ -1310,35 +1342,37 @@ const Theme g_themeWindowGlass_variant_alternative = {{
         L"Foreground@PointerOver:=$ElementSysColor2",
         L"Foreground@Pressed:=$ElementSysColor3",
         L"Foreground@Disabled:=$ElementSysColor4",
-        L"Background:=Transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#PlayPauseButton > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter@CommonStates", {
         L"Foreground@Normal:=$ElementSysColor",
         L"Foreground@PointerOver:=$ElementSysColor2",
         L"Foreground@Pressed:=$ElementSysColor3",
         L"Foreground@Disabled:=$ElementSysColor4",
-        L"Background:=Transparent"}},
+        L"Background=Transparent"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.RepeatButton#NextButton > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter@CommonStates", {
         L"Foreground@Normal:=$ElementSysColor",
         L"Foreground@PointerOver:=$ElementSysColor2",
         L"Foreground@Pressed:=$ElementSysColor3",
         L"Foreground@Disabled:=$ElementSysColor4",
-        L"Background:=Transparent"}},
+        L"Background=Transparent"}},
 }, {
-    L"transparent=<SolidColorBrush Color=\"Transparent\"/>",
-    L"Background=<WindhawkBlur BlurAmount=\"15\" TintColor=\"#10808080\"/>",
+    L"Translucent=<WindhawkBlur BlurAmount=\"15\" TintColor=\"#10808080\"/>",
+    L"Glass=<WindhawkBlur BlurAmount=\"3\" TintColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"0.7\" />",
+    L"Frosted=<WindhawkBlur BlurAmount=\"20\" TintColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"0.7\" />",
+    L"Acrylic=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeAltHighColor}\" TintOpacity=\"0.3\" FallbackColor=\"{ThemeResource SystemChromeAltHighColor}\" />",
+    L"Background=$Translucent",
+    L"BorderBrush=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#50808080\" Offset=\"0.0\" /><GradientStop Color=\"#50404040\" Offset=\"0.25\" /><GradientStop Color=\"#50808080\" Offset=\"1\" /></LinearGradientBrush>",
+    L"BorderBrush2=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"{ThemeResource SystemChromeHighColor}\" Offset=\"0.0\" /><GradientStop Color=\"{ThemeResource SystemChromeLowColor}\" Offset=\"0.15\" /><GradientStop Color=\"{ThemeResource SystemChromeHighColor}\" Offset=\"0.95\" /></LinearGradientBrush>",
     L"overlay=<SolidColorBrush Color=\"{ThemeResource SystemChromeAltHighColor}\" Opacity=\"0.1\" />",
     L"overlay2=<WindhawkBlur BlurAmount=\"20\" TintColor=\"#60353535\"/>",
     L"CornerRadius=20",
-    L"r2=14",
-    L"r3=12",
+    L"CR2=14",
+    L"CR3=12",
     L"BorderThickness=0.3,1,0.3,0.3",
-    L"BorderBrush2=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"{ThemeResource SystemChromeHighColor}\" Offset=\"0.0\" /><GradientStop Color=\"{ThemeResource SystemChromeLowColor}\" Offset=\"0.15\" /><GradientStop Color=\"{ThemeResource SystemChromeHighColor}\" Offset=\"0.95\" /></LinearGradientBrush>",
-    L"Background2=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeAltHighColor}\" TintOpacity=\"0.3\" FallbackColor=\"{ThemeResource SystemChromeAltHighColor}\" />",
     L"ElementBG=<SolidColorBrush Color=\"{ThemeResource SystemChromeAltHighColor}\" Opacity=\"0.3\" />",
     L"ElementBorderBrush=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#50808080\" Offset=\"1\" /><GradientStop Color=\"#50606060\" Offset=\"0.15\" /></LinearGradientBrush>",
     L"ElementCornerRadius=20",
     L"ElementBorderThickness=0.3,0.3,0.3,1",
-    L"BorderBrush=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#50808080\" Offset=\"0.0\" /><GradientStop Color=\"#50404040\" Offset=\"0.25\" /><GradientStop Color=\"#50808080\" Offset=\"1\" /></LinearGradientBrush>",
     L"ElementSysColor=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight1}\" Opacity=\"1\" />",
     L"ElementSysColor2=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight2}\" Opacity=\"1\" />",
     L"ElementSysColor3=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight3}\" Opacity=\"1\" />",
@@ -1619,6 +1653,193 @@ const Theme g_themeOversimplified_Accentuated = {{
     L"Reveal = <RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\" />",
 }};
 
+const Theme g_themeTintedGlass = {{
+    ThemeTargetStyles{L"Grid#NotificationCenterGrid", {
+        L"Background:=$Base",
+        L"BorderThickness=0,0,0,0",
+        L"CornerRadius=$Radius"}},
+    ThemeTargetStyles{L"Grid#CalendarCenterGrid", {
+        L"Background:=$Base",
+        L"BorderThickness=0,0,0,0",
+        L"CornerRadius=$Radius"}},
+    ThemeTargetStyles{L"ScrollViewer#CalendarControlScrollViewer", {
+        L"BorderThickness=0,0,0,0",
+        L"Background:=$Transparent"}},
+    ThemeTargetStyles{L"Border#CalendarHeaderMinimizedOverlay", {
+        L"Background:=$Transparent",
+        L"BorderThickness=0,0,0,0"}},
+    ThemeTargetStyles{L"ActionCenter.FocusSessionControl#FocusSessionControl > Grid#FocusGrid", {
+        L"Background:=$Transparent",
+        L"BorderThickness=0,0,0,0"}},
+    ThemeTargetStyles{L"MenuFlyoutPresenter > Border", {
+        L"Background:=$Overlay",
+        L"BorderThickness=0,0,0,0",
+        L"CornerRadius=$Radius",
+        L"Padding=2,4,2,4"}},
+    ThemeTargetStyles{L"Border#JumpListRestyledAcrylic", {
+        L"Background:=$Base",
+        L"BorderThickness=0,0,0,0",
+        L"CornerRadius=$Radius",
+        L"Margin=-2,-2,-2,-2"}},
+    ThemeTargetStyles{L"Grid#ControlCenterRegion", {
+        L"Background:=$Base",
+        L"BorderThickness=0,0,0,0",
+        L"CornerRadius=$Radius"}},
+    ThemeTargetStyles{L"Grid#L1Grid > Border", {
+        L"Background:=$Transparent",
+        L"BorderThickness=0,0,0,0"}},
+    ThemeTargetStyles{L"Grid#MediaTransportControlsRegion", {
+        L"Background:=$Base",
+        L"BorderThickness=0,0,0,0",
+        L"CornerRadius=$Radius"}},
+    ThemeTargetStyles{L"Grid#MediaTransportControlsRoot", {
+        L"Background:=$Transparent"}},
+    ThemeTargetStyles{L"ContentPresenter#PageContent", {
+        L"Background:=$Transparent"}},
+    ThemeTargetStyles{L"ContentPresenter#PageContent > Grid > Border", {
+        L"Background:=$Transparent"}},
+    ThemeTargetStyles{L"QuickActions.ControlCenter.AccessibleWindow#PageWindow > ContentPresenter > Grid#FullScreenPageRoot", {
+        L"Background:=$Transparent"}},
+    ThemeTargetStyles{L"QuickActions.ControlCenter.AccessibleWindow#PageWindow > ContentPresenter > Grid#FullScreenPageRoot > ContentPresenter#PageHeader", {
+        L"Background:=$Transparent"}},
+    ThemeTargetStyles{L"ScrollViewer#ListContent", {
+        L"Background:=$Transparent"}},
+    ThemeTargetStyles{L"ActionCenter.FlexibleToastView#FlexibleNormalToastView", {
+        L"Background:=$Transparent"}},
+    ThemeTargetStyles{L"Border#ToastBackgroundBorder2", {
+        L"Background:=$Base",
+        L"BorderThickness=0,0,0,0",
+        L"CornerRadius=$Radius"}},
+    ThemeTargetStyles{L"JumpViewUI.SystemItemListViewItem > Grid#LayoutRoot > Border#BackgroundBorder", {
+        L"Background:=$Transparent",
+        L"CornerRadius=$Radius"}},
+    ThemeTargetStyles{L"JumpViewUI.JumpListListViewItem > Grid#LayoutRoot > Border#BackgroundBorder", {
+        L"CornerRadius=$Radius"}},
+    ThemeTargetStyles{L"ActionCenter.FlexibleItemView", {
+        L"CornerRadius=$Radius"}},
+    ThemeTargetStyles{L"Grid#MediaTransportControlsRegion", {
+        L"Height=Auto"}},
+    ThemeTargetStyles{L"Grid#ThumbnailImage", {
+        L"Width=$thumbnailImageSize",
+        L"Height=$thumbnailImageSize",
+        L"HorizontalAlignment=Center",
+        L"VerticalAlignment=Top",
+        L"Grid.Column=1",
+        L"Margin=0,2,0,45"}},
+    ThemeTargetStyles{L"Grid#ThumbnailImage > Border", {
+        L"CornerRadius=$Radius"}},
+    ThemeTargetStyles{L"StackPanel#PrimaryAndSecondaryTextContainer", {
+        L"VerticalAlignment=Bottom",
+        L"Grid.Column=0"}},
+    ThemeTargetStyles{L"StackPanel#PrimaryAndSecondaryTextContainer > TextBlock#TitleText", {
+        L"TextAlignment=Center"}},
+    ThemeTargetStyles{L"StackPanel#PrimaryAndSecondaryTextContainer > TextBlock#SubtitleText", {
+        L"TextAlignment=Center"}},
+    ThemeTargetStyles{L"ContentControl#TogglesGroup > ContentPresenter > ControlCenter.PaginatedGridView > Grid", {
+        L"BorderThickness=0,0,0,0"}},
+    ThemeTargetStyles{L"Grid#FooterGrid", {
+        L"BorderThickness=0,0,0,0"}},
+}, {
+    L"Base=<WindhawkBlur BlurAmount=\"18\" TintColor=\"#80000000\"/>",
+    L"Radius=14",
+    L"Transparent=<SolidColorBrush Color=\"Transparent\"/>",
+    L"Accent=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight1}\" Opacity = \"1\" />",
+    L"Overlay=<WindhawkBlur BlurAmount=\"18\" TintColor=\"#1AFFFFFF\"/>",
+    L"thumbnailImageSize=300",
+}};
+
+const Theme g_themeFluid = {{
+    ThemeTargetStyles{L"MenuFlyoutPresenter", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"ToolTip > ContentPresenter#LayoutRoot", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Grid#NotificationCenterGrid", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius",
+        L"VerticalAlignment=2"}},
+    ThemeTargetStyles{L"Grid#ControlCenterRegion", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Button#ClearAll", {
+        L"AccessKey=x"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton#DoNotDisturbButton", {
+        L"AccessKey=d"}},
+    ThemeTargetStyles{L"Button#ExpandCollapseButton", {
+        L"AccessKey=e"}},
+    ThemeTargetStyles{L"Border#ItemOpaquePlating", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=$BorderThickness",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Border#PopupBorder", {
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Border#ToastBackgroundBorder2", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Grid#CalendarCenterGrid", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Border#CalendarHeaderMinimizedOverlay", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"ScrollViewer#CalendarControlScrollViewer", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=$BorderThickness",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"CalendarViewDayItem", {
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"CalendarViewDayItem > Border", {
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.CalendarPanel#YearViewPanel > Control", {
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.CalendarPanel#YearViewPanel > Control > Border", {
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.CalendarPanel#DecadeViewPanel > Control", {
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.CalendarPanel#DecadeViewPanel > Control > Border", {
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Grid > Microsoft.UI.Xaml.Controls.AnimatedIcon", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=$BorderThickness",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"ContentPresenter > Grid#FullScreenPageRoot", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"ContentPresenter#PageContent > Grid > Border", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Grid > ScrollViewer#ListContent", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Grid#MediaTransportControlsRoot", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Grid#MediaTransportControlsRegion", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Border#JumpListRestyledAcrylic", {
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=1",
+        L"CornerRadius=$CornerRadius"}},
+}, {
+    L"BorderBrush=<LinearGradientBrush x:Key=\"ShellTaskbarItemGradientStrokeColorSecondaryBrush\" MappingMode=\"Absolute\" StartPoint=\"0,0\" EndPoint=\"0,3\"><LinearGradientBrush.GradientStops><GradientStop Offset=\"0.33\" Color=\"#1AFFFFFF\" /><GradientStop Offset=\"1\" Color=\"#0FFFFFFF\" /></LinearGradientBrush.GradientStops></LinearGradientBrush>",
+    L"BorderThickness=2",
+    L"CornerRadius=4",
+}};
+
 // clang-format on
 
 std::atomic<bool> g_initialized;
@@ -1734,7 +1955,10 @@ VisualTreeWatcher::~VisualTreeWatcher()
 void VisualTreeWatcher::UnadviseVisualTreeChange()
 {
     Wh_Log(L"UnadviseVisualTreeChange VisualTreeWatcher");
-    winrt::check_hresult(m_XamlDiagnostics.as<IVisualTreeService3>()->UnadviseVisualTreeChange(this));
+    HRESULT hr = m_XamlDiagnostics.as<IVisualTreeService3>()->UnadviseVisualTreeChange(this);
+    if (FAILED(hr)) {
+        Wh_Log(L"UnadviseVisualTreeChange failed with error %08X", hr);
+    }
 }
 
 HRESULT VisualTreeWatcher::OnVisualTreeChange(ParentChildRelation, VisualElement element, VisualMutationType mutationType) try
@@ -2013,11 +2237,14 @@ using namespace std::string_view_literals;
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Networking.Connectivity.h>
+#include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Text.h>
+#include <winrt/Windows.UI.ViewManagement.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Windows.UI.Xaml.Media.Imaging.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Shapes.h>
 #include <winrt/Windows.UI.Xaml.h>
 
 using namespace winrt::Windows::UI::Xaml;
@@ -2142,22 +2369,75 @@ std::vector<winrt::weak_ref<winrt::Windows::System::DispatcherQueue>>
     g_failedImageBrushesRegistry;
 winrt::event_token g_networkStatusChangedToken;
 
+enum class ResourceVariableTheme {
+    None,
+    Dark,
+    Light,
+};
+
+struct ResourceVariableEntry {
+    std::wstring key;
+    std::wstring value;
+    ResourceVariableTheme theme;
+};
+
+// Track original resource values for restoration (per-thread since
+// Application::Current().Resources() is per-thread).
+thread_local std::unordered_map<std::wstring,
+                                winrt::Windows::Foundation::IInspectable>
+    g_originalResourceValues;
+
+// Track our merged theme dictionary for cleanup (per-thread).
+thread_local ResourceDictionary g_resourceVariablesThemeDict{nullptr};
+
+// Track theme resource entries that reference {ThemeResource ...} for refresh
+// (per-thread).
+thread_local std::vector<ResourceVariableEntry> g_themeResourceEntries;
+
+// For listening to theme color changes (per-thread).
+thread_local winrt::Windows::UI::ViewManagement::UISettings g_uiSettings{
+    nullptr};
+thread_local winrt::event_token g_colorValuesChangedToken;
+
 winrt::Windows::Foundation::IInspectable ReadLocalValueWithWorkaround(
     DependencyObject elementDo,
     DependencyProperty property) {
-    const auto value = elementDo.ReadLocalValue(property);
-    if (value && winrt::get_class_name(value) ==
-                     L"Windows.UI.Xaml.Data.BindingExpressionBase") {
-        // BindingExpressionBase was observed to be returned for XAML properties
-        // that were declared as following:
-        //
-        // <Border ... CornerRadius="{TemplateBinding CornerRadius}" />
-        //
-        // Calling SetValue with it fails with an error, so we won't be able to
-        // use it to restore the value. As a workaround, we use
-        // GetAnimationBaseValue to get the value.
-        return elementDo.GetAnimationBaseValue(property);
+    auto value = elementDo.ReadLocalValue(property);
+    if (value) {
+        auto className = winrt::get_class_name(value);
+        if (className == L"Windows.UI.Xaml.Data.BindingExpressionBase" ||
+            className == L"Windows.UI.Xaml.Data.BindingExpression") {
+            // BindingExpressionBase was observed to be returned for XAML
+            // properties that were declared as following:
+            //
+            // <Border ... CornerRadius="{TemplateBinding CornerRadius}" />
+            //
+            // Calling SetValue with it fails with an error, so we won't be able
+            // to use it to restore the value. As a workaround, we use
+            // GetAnimationBaseValue to get the value.
+            Wh_Log(L"ReadLocalValue returned %s, using GetAnimationBaseValue",
+                   className.c_str());
+            value = elementDo.GetAnimationBaseValue(property);
+        }
+    } else {
+        // A workaround for Fill of HorizontalTrackRect which can't be read by
+        // ReadLocalValue for some reason (null is returned instead).
+        auto rect = elementDo.try_as<Shapes::Rectangle>();
+        if (rect && rect.Name() == L"HorizontalTrackRect") {
+            auto value2 = elementDo.GetValue(property);
+            if (value2 && winrt::get_class_name(value2) ==
+                              L"Windows.UI.Xaml.Media.SolidColorBrush") {
+                Wh_Log(L"Using GetValue workaround for HorizontalTrackRect");
+                value = std::move(value2);
+            }
+        }
     }
+
+    Wh_Log(L"Read property value %s",
+           value ? (value == DependencyProperty::UnsetValue()
+                        ? L"(unset)"
+                        : winrt::get_class_name(value).c_str())
+                 : L"(null)");
 
     return value;
 }
@@ -3056,9 +3336,13 @@ void SetOrClearValue(DependencyObject elementDo,
     }
 
     if (value == DependencyProperty::UnsetValue()) {
+        Wh_Log(L"Clearing property value");
         elementDo.ClearValue(property);
         return;
     }
+
+    Wh_Log(L"Setting property value %s",
+           value ? winrt::get_class_name(value).c_str() : L"(null)");
 
     // Track ImageBrush with remote ImageSource for retry on network
     // reconnection. This handles cases where an ImageBrush is set as a property
@@ -3926,59 +4210,6 @@ void CleanupCustomizations(InstanceHandle handle) {
 using StyleConstant = std::pair<std::wstring, std::wstring>;
 using StyleConstants = std::vector<StyleConstant>;
 
-std::optional<StyleConstant> ParseStyleConstant(std::wstring_view constant) {
-    // Skip if commented.
-    if (constant.starts_with(L"//")) {
-        return std::nullopt;
-    }
-
-    auto eqPos = constant.find(L'=');
-    if (eqPos == constant.npos) {
-        Wh_Log(L"Skipping entry with no '=': %.*s",
-               static_cast<int>(constant.length()), constant.data());
-        return std::nullopt;
-    }
-
-    auto key = TrimStringView(constant.substr(0, eqPos));
-    auto val = TrimStringView(constant.substr(eqPos + 1));
-
-    return StyleConstant{std::wstring(key), std::wstring(val)};
-}
-
-StyleConstants LoadStyleConstants(
-    const std::vector<PCWSTR>& themeStyleConstants) {
-    StyleConstants result;
-
-    for (const auto themeStyleConstant : themeStyleConstants) {
-        if (auto parsed = ParseStyleConstant(themeStyleConstant)) {
-            result.push_back(std::move(*parsed));
-        }
-    }
-
-    for (int i = 0;; i++) {
-        string_setting_unique_ptr constantSetting(
-            Wh_GetStringSetting(L"styleConstants[%d]", i));
-        if (!*constantSetting.get()) {
-            break;
-        }
-
-        if (auto parsed = ParseStyleConstant(constantSetting.get())) {
-            result.push_back(std::move(*parsed));
-        }
-    }
-
-    // Reverse the order to allow overriding definitions with the same name.
-    std::reverse(result.begin(), result.end());
-
-    // Sort by name length to replace long names first.
-    std::stable_sort(result.begin(), result.end(),
-                     [](const StyleConstant& a, const StyleConstant& b) {
-                         return a.first.size() > b.first.size();
-                     });
-
-    return result;
-}
-
 std::wstring ApplyStyleConstants(std::wstring_view style,
                                  const StyleConstants& styleConstants) {
     std::wstring result;
@@ -4008,6 +4239,65 @@ std::wstring ApplyStyleConstants(std::wstring_view style,
 
     // Care for the rest after last occurrence.
     result += style.substr(lastPos);
+
+    return result;
+}
+
+std::optional<StyleConstant> ParseStyleConstant(
+    std::wstring_view constant,
+    const StyleConstants& styleConstants) {
+    // Skip if commented.
+    if (constant.starts_with(L"//")) {
+        return std::nullopt;
+    }
+
+    auto eqPos = constant.find(L'=');
+    if (eqPos == constant.npos) {
+        Wh_Log(L"Skipping entry with no '=': %.*s",
+               static_cast<int>(constant.length()), constant.data());
+        return std::nullopt;
+    }
+
+    auto key = TrimStringView(constant.substr(0, eqPos));
+    auto valueRaw = TrimStringView(constant.substr(eqPos + 1));
+    auto value = ApplyStyleConstants(valueRaw, styleConstants);
+
+    return StyleConstant{std::wstring(key), std::move(value)};
+}
+
+StyleConstants LoadStyleConstants(
+    const std::vector<PCWSTR>& themeStyleConstants) {
+    StyleConstants result;
+
+    auto addToResult = [&result](StyleConstant sc) {
+        // Keep sorted by name length to replace long names first. Reverse the
+        // order to allow overriding definitions with the same name.
+        auto insertIndex = std::lower_bound(
+            result.begin(), result.end(), sc,
+            [](const StyleConstant& a, const StyleConstant& b) {
+                return a.first.size() > b.first.size();
+            });
+
+        result.insert(insertIndex, std::move(sc));
+    };
+
+    for (const auto themeStyleConstant : themeStyleConstants) {
+        if (auto parsed = ParseStyleConstant(themeStyleConstant, result)) {
+            addToResult(std::move(*parsed));
+        }
+    }
+
+    for (int i = 0;; i++) {
+        string_setting_unique_ptr constantSetting(
+            Wh_GetStringSetting(L"styleConstants[%d]", i));
+        if (!*constantSetting.get()) {
+            break;
+        }
+
+        if (auto parsed = ParseStyleConstant(constantSetting.get(), result)) {
+            addToResult(std::move(*parsed));
+        }
+    }
 
     return result;
 }
@@ -4256,6 +4546,10 @@ void ProcessAllStylesFromSettings() {
         theme = &g_themeWindowGlass_variant_alternative;
     } else if (wcscmp(themeName, L"Oversimplified&Accentuated") == 0) {
         theme = &g_themeOversimplified_Accentuated;
+    } else if (wcscmp(themeName, L"TintedGlass") == 0) {
+        theme = &g_themeTintedGlass;
+    } else if (wcscmp(themeName, L"Fluid") == 0) {
+        theme = &g_themeFluid;
     }
     Wh_FreeStringSetting(themeName);
 
@@ -4294,23 +4588,106 @@ void ProcessAllStylesFromSettings() {
     }
 }
 
-bool ProcessSingleResourceVariableFromSettings(int index) {
-    string_setting_unique_ptr variableKeyStringSetting(
-        Wh_GetStringSetting(L"resourceVariables[%d].variableKey", index));
-    if (!*variableKeyStringSetting.get()) {
+std::optional<ResourceVariableEntry> ParseResourceVariable(
+    std::wstring_view entry,
+    const StyleConstants& styleConstants) {
+    // Skip if commented.
+    if (entry.starts_with(L"//")) {
+        return std::nullopt;
+    }
+
+    // Find the first '=' to split key and value.
+    auto eqPos = entry.find(L'=');
+    if (eqPos == entry.npos) {
+        Wh_Log(L"Skipping entry with no '=': %.*s",
+               static_cast<int>(entry.length()), entry.data());
+        return std::nullopt;
+    }
+
+    auto keyPart = TrimStringView(entry.substr(0, eqPos));
+    auto valueRaw = TrimStringView(entry.substr(eqPos + 1));
+    auto value = ApplyStyleConstants(valueRaw, styleConstants);
+
+    ResourceVariableTheme theme = ResourceVariableTheme::None;
+    std::wstring key;
+
+    // Check for @theme suffix in key part.
+    auto atPos = keyPart.find(L'@');
+    if (atPos != keyPart.npos) {
+        key = TrimStringView(keyPart.substr(0, atPos));
+        auto themePart = TrimStringView(keyPart.substr(atPos + 1));
+        if (themePart == L"Dark") {
+            theme = ResourceVariableTheme::Dark;
+        } else if (themePart == L"Light") {
+            theme = ResourceVariableTheme::Light;
+        } else {
+            Wh_Log(L"Unknown theme '%.*s', expected 'Dark' or 'Light'",
+                   static_cast<int>(themePart.size()), themePart.data());
+            return std::nullopt;
+        }
+    } else {
+        key = std::wstring(keyPart);
+    }
+
+    return ResourceVariableEntry{std::move(key), std::move(value), theme};
+}
+
+constexpr std::wstring_view kThemeResourcePrefix = L"{ThemeResource ";
+
+bool IsThemeResourceReference(std::wstring_view value) {
+    return value.starts_with(kThemeResourcePrefix) && value.ends_with(L"}");
+}
+
+winrt::Windows::Foundation::IInspectable ResolveResourceVariableValue(
+    ResourceDictionary resources,
+    std::wstring_view value) {
+    // Check for {ThemeResource X} syntax - look up the resource directly
+    // to preserve dynamic theme-aware behavior.
+    if (IsThemeResourceReference(value)) {
+        auto resourceKey =
+            value.substr(kThemeResourcePrefix.size(),
+                         value.size() - kThemeResourcePrefix.size() - 1);
+        return resources.Lookup(
+            winrt::box_value(winrt::hstring(TrimStringView(resourceKey))));
+    }
+
+    // For other values, use boxed string (works for colors, etc.).
+    return winrt::box_value(winrt::hstring(value));
+}
+
+// Returns true if a theme resource was added.
+bool ProcessResourceVariableFromSetting(ResourceDictionary resources,
+                                        ResourceDictionary darkDict,
+                                        ResourceDictionary lightDict,
+                                        const ResourceVariableEntry& entry) {
+    auto boxedKey = winrt::box_value(entry.key);
+
+    if (entry.theme != ResourceVariableTheme::None) {
+        // Key@Dark= or Key@Light= - add to theme dict.
+        auto value = ResolveResourceVariableValue(resources, entry.value);
+        if (entry.theme == ResourceVariableTheme::Dark) {
+            darkDict.Insert(boxedKey, value);
+        } else {
+            lightDict.Insert(boxedKey, value);
+        }
+        return true;
+    }
+
+    // key= - convert using existing resource type.
+    auto existingResource = resources.TryLookup(boxedKey);
+    if (!existingResource) {
+        Wh_Log(L"Resource variable key '%s' not found, skipping",
+               entry.key.c_str());
         return false;
     }
 
-    Wh_Log(L"Processing resource variable %s", variableKeyStringSetting.get());
+    if (!g_originalResourceValues.contains(entry.key)) {
+        g_originalResourceValues[entry.key] = existingResource;
+    }
 
-    std::wstring_view variableKey = variableKeyStringSetting.get();
+    auto resourceClassName = winrt::get_class_name(existingResource);
 
-    auto resources = Application::Current().Resources();
-
-    auto resource = resources.Lookup(winrt::box_value(variableKey));
-
-    // Example: Windows.Foundation.IReference`1<Windows.UI.Xaml.Thickness>
-    auto resourceClassName = winrt::get_class_name(resource);
+    // Unwrap IReference<T> to get inner type name.
     if (resourceClassName.starts_with(L"Windows.Foundation.IReference`1<") &&
         resourceClassName.ends_with(L'>')) {
         size_t prefixSize = sizeof("Windows.Foundation.IReference`1<") - 1;
@@ -4319,31 +4696,140 @@ bool ProcessSingleResourceVariableFromSettings(int index) {
                            resourceClassName.size() - prefixSize - 1);
     }
 
-    auto resourceTypeName = Interop::TypeName{resourceClassName};
+    resources.Insert(boxedKey, Markup::XamlBindingHelper::ConvertValue(
+                                   Interop::TypeName{resourceClassName},
+                                   winrt::box_value(entry.value)));
+    return false;
+}
 
-    string_setting_unique_ptr valueStringSetting(
-        Wh_GetStringSetting(L"resourceVariables[%d].value", index));
+void RefreshThemeResourceEntries() {
+    if (g_themeResourceEntries.empty()) {
+        return;
+    }
 
-    std::wstring_view value = valueStringSetting.get();
+    Wh_Log(L"Refreshing %zu theme resource entries",
+           g_themeResourceEntries.size());
 
-    resources.Insert(winrt::box_value(variableKey),
-                     Markup::XamlBindingHelper::ConvertValue(
-                         resourceTypeName, winrt::box_value(value)));
+    auto resources = Application::Current().Resources();
 
-    return true;
+    auto darkDict = g_resourceVariablesThemeDict.ThemeDictionaries()
+                        .TryLookup(winrt::box_value(L"Dark"))
+                        .try_as<ResourceDictionary>();
+    auto lightDict = g_resourceVariablesThemeDict.ThemeDictionaries()
+                         .TryLookup(winrt::box_value(L"Light"))
+                         .try_as<ResourceDictionary>();
+
+    for (const auto& entry : g_themeResourceEntries) {
+        try {
+            auto boxedKey = winrt::box_value(entry.key);
+            auto value = ResolveResourceVariableValue(resources, entry.value);
+
+            if (entry.theme == ResourceVariableTheme::Dark && darkDict) {
+                darkDict.Insert(boxedKey, value);
+            } else if (entry.theme == ResourceVariableTheme::Light &&
+                       lightDict) {
+                lightDict.Insert(boxedKey, value);
+            }
+        } catch (winrt::hresult_error const& ex) {
+            Wh_Log(L"Error refreshing '%s': %08X", entry.key.c_str(),
+                   ex.code());
+        }
+    }
 }
 
 void ProcessResourceVariablesFromSettings() {
+    StyleConstants styleConstants = LoadStyleConstants(std::vector<PCWSTR>{});
+
+    auto resources = Application::Current().Resources();
+
+    // Create theme dictionaries for @Dark/@Light resources.
+    g_resourceVariablesThemeDict = ResourceDictionary();
+    ResourceDictionary darkDict;
+    ResourceDictionary lightDict;
+    bool hasThemeResources = false;
+
     for (int i = 0;; i++) {
+        string_setting_unique_ptr setting(
+            Wh_GetStringSetting(L"themeResourceVariables[%d]", i));
+        if (!*setting.get()) {
+            break;
+        }
+
+        Wh_Log(L"Processing theme resource variable %s", setting.get());
+
+        auto parsed = ParseResourceVariable(setting.get(), styleConstants);
+        if (!parsed) {
+            continue;
+        }
+
         try {
-            if (!ProcessSingleResourceVariableFromSettings(i)) {
-                break;
+            if (ProcessResourceVariableFromSetting(resources, darkDict,
+                                                   lightDict, *parsed)) {
+                hasThemeResources = true;
+
+                // Track entries with {ThemeResource ...} for refresh on color
+                // change.
+                if (IsThemeResourceReference(parsed->value)) {
+                    g_themeResourceEntries.push_back(*parsed);
+                }
             }
         } catch (winrt::hresult_error const& ex) {
             Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
         } catch (std::exception const& ex) {
             Wh_Log(L"Error: %S", ex.what());
         }
+    }
+
+    if (hasThemeResources) {
+        g_resourceVariablesThemeDict.ThemeDictionaries().Insert(
+            winrt::box_value(L"Dark"), darkDict);
+        g_resourceVariablesThemeDict.ThemeDictionaries().Insert(
+            winrt::box_value(L"Light"), lightDict);
+        resources.MergedDictionaries().Append(g_resourceVariablesThemeDict);
+    }
+
+    // Register for color changes to refresh theme resource references.
+    if (!g_themeResourceEntries.empty()) {
+        g_uiSettings = winrt::Windows::UI::ViewManagement::UISettings();
+        auto dispatcherQueue =
+            winrt::Windows::System::DispatcherQueue::GetForCurrentThread();
+        g_colorValuesChangedToken =
+            g_uiSettings.ColorValuesChanged([dispatcherQueue](auto&&, auto&&) {
+                dispatcherQueue.TryEnqueue(
+                    []() { RefreshThemeResourceEntries(); });
+            });
+    }
+}
+
+void UninitializeResourceVariables() {
+    // Unregister color change handler.
+    if (g_colorValuesChangedToken) {
+        g_uiSettings.ColorValuesChanged(g_colorValuesChangedToken);
+        g_colorValuesChangedToken = {};
+    }
+    g_uiSettings = nullptr;
+    g_themeResourceEntries.clear();
+
+    // Restore original resource values.
+    auto resources = Application::Current().Resources();
+    for (const auto& [key, originalValue] : g_originalResourceValues) {
+        try {
+            resources.Insert(winrt::box_value(key), originalValue);
+        } catch (...) {
+            HRESULT hr = winrt::to_hresult();
+            Wh_Log(L"Error %08X", hr);
+        }
+    }
+    g_originalResourceValues.clear();
+
+    // Remove our merged theme dictionary.
+    if (g_resourceVariablesThemeDict) {
+        auto merged = resources.MergedDictionaries();
+        uint32_t index;
+        if (merged.IndexOf(g_resourceVariablesThemeDict, index)) {
+            merged.RemoveAt(index);
+        }
+        g_resourceVariablesThemeDict = nullptr;
     }
 }
 
@@ -4367,6 +4853,8 @@ void UninitializeForCurrentThread() {
     g_elementsCustomizationState.clear();
 
     g_elementsCustomizationRules.clear();
+
+    UninitializeResourceVariables();
 
     g_initializedForThread = false;
 }
@@ -4674,7 +5162,7 @@ bool StartStatsTimer() {
     static constexpr WCHAR kStatsBaseUrl[] =
         L"https://github.com/ramensoftware/"
         L"windows-11-notification-center-styling-guide/"
-        L"releases/download/stats-v2/";
+        L"releases/download/stats-v3/";
 
     ULONGLONG lastStatsTime = 0;
     Wh_GetBinaryValue(L"statsTimerLastTime", &lastStatsTime,


### PR DESCRIPTION
* Added new themes: TintedGlass, Fluid.
* Updated themes: TranslucentShell, Matter, WindowGlass.
  * TranslucentShell, Matter, and the new TintedGlass theme now allow to customize the media thumbnail size, which may be too large for small screens. Refer to the the theme's readme for details.
  * WindowGlass now allows to select alternative background styles. Refer to the the theme's readme for details.
* Added a way to define theme-aware resources. For example, different colors for an element can be defined for light mode and dark mode.
* Fixed some styles failing to restore properly.