### PR TITLE
WindowsBar Companion 1.0

### DIFF
--- a/mods/windowsbar-companion.wh.cpp
+++ b/mods/windowsbar-companion.wh.cpp
@@ -5,7 +5,7 @@
 // @version         1.0
 // @author          Meti0X7CB
 // @github          https://github.com/Meti0X7CB
-// @twitter         https://x.com/Meti0X7CB
+// @twitter         https://twitter.com/Meti0X7CB
 // @include         explorer.exe
 // @include         StartMenuExperienceHost.exe
 // @architecture    x86-64


### PR DESCRIPTION
This is a modified version of Taskbar on top for Windows 11 by m417z. This mod moves the Windows 11 Start, search and action center window to the top of the screen while keeping the taskbar in place. The goal is to run this along side WindowsBar to achieve the desired user experience. 