### PR TITLE
Update Magnifier Headless mod to version 1.0

### DIFF
--- a/mods/magnifier-headless.wh.cpp
+++ b/mods/magnifier-headless.wh.cpp
@@ -2,13 +2,12 @@
 // @id              magnifier-headless
 // @name            Magnifier Headless Mode
 // @description     Blocks the Magnifier window creation, keeping zoom functionality with win+"-" and win+"+" keyboard shortcuts.
-// @version         0.9.5.4
+// @version         1.0
 // @author          BCRTVKCS
 // @github          https://github.com/bcrtvkcs
 // @twitter         https://x.com/bcrtvkcs
 // @homepage        https://grdigital.pro
 // @include         magnify.exe
-// @compilerOptions -lcomctl32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -17,343 +16,92 @@
 
 ![Screenshot](https://i.imgur.com/m5w78pe.png)
 
-This mod blocks the Magnifier window from ever appearing, while keeping the zoom functionality (Win + `-` and Win + `+`) available. It also prevents the Magnifier from showing up in the taskbar.
+Hides the Windows Magnifier window while keeping zoom functionality fully
+working with Win + Plus and Win + Minus keyboard shortcuts.
 
 ## Features
-- Completely hides the Magnifier UI while preserving zoom functionality
-- **Fixes Mouse Cursor Freeze**: Eliminates the 5-6 second mouse cursor freeze that occurs when Magnifier touch controls appear on startup (a known Windows Magnifier bug affecting users even without touch devices)
-- **Blocks Touch Interface**: Completely hides the Magnifier touch controls (semi-transparent squares with black borders at screen corners), unnecessary for non-touch users
-- Thread-safe implementation with race condition protection
-- Performance optimized with HWND caching
-- Comprehensive API coverage for all window visibility methods
+- Completely hides the Magnifier UI window
+- Removes the Magnifier icon from the taskbar and Alt+Tab
+- Fixes the 5-6 second mouse cursor freeze on Magnifier startup (a known
+  Windows bug caused by touch controls appearing, even on non-touch devices)
+- Hides Magnifier touch overlay controls (semi-transparent squares at screen
+  corners)
+- Zoom keyboard shortcuts continue to work normally
 
-## Hooked APIs
-The mod hooks multiple Windows API functions to ensure complete coverage:
+## Usage
+1. Install the mod in Windhawk
+2. Launch Windows Magnifier (Win + Plus)
+3. Use magnification as normal -- the UI window will not appear
 
-**Core Window APIs:**
-- `CreateWindowExW` - Intercepts window creation
-- `ShowWindow` - Blocks window showing
-- `SetWindowPos` - Prevents position-based showing
-- `SetWindowLongPtrW` - Blocks style changes
+### Keyboard Shortcuts
+- **Win + Plus**: Zoom in
+- **Win + Minus**: Zoom out
+- **Win + Esc**: Exit Magnifier
 
-**Layered Window APIs:**
-- `UpdateLayeredWindow` - Blocks layered window updates
-- `SetLayeredWindowAttributes` - Blocks transparency changes
-
-**Animation & Foreground APIs:**
-- `AnimateWindow` - Blocks animated showing
-- `BringWindowToTop` - Prevents bringing to front
-- `SetForegroundWindow` - Blocks foreground activation
-
-**Advanced APIs:**
-- `SetWindowRgn` - Blocks region-based visibility
-- `DwmSetWindowAttribute` - Blocks DWM attribute changes (Windows 11+)
-
-**Window Message Interception:**
-- Window Procedure Subclassing - Direct interception of window messages
-  * Blocks `WM_SHOWWINDOW` (show requests)
-  * Modifies `WM_WINDOWPOSCHANGING` (prevents showing via position changes)
-  * Enforces hiding on `WM_WINDOWPOSCHANGED`
-  * Blocks `WM_ACTIVATE` and `WM_NCACTIVATE` (activation prevention)
-  * Suppresses `WM_PAINT` and `WM_ERASEBKGND` (no visual artifacts)
-  * Blocks `WM_SETFOCUS` (focus prevention)
-  * Blocks `WM_MOUSEACTIVATE` (mouse activation prevention)
-  * Blocks `WM_SYSCOMMAND` (SC_RESTORE, SC_MAXIMIZE prevention)
-- `WH_CALLWNDPROC` hook - Detects Magnifier windows and applies subclassing automatically
-
-## Technical Implementation
-- Uses `WindhawkUtils::SetWindowSubclassFromAnyThread` for safe multi-mod window subclassing
-- Compatible with other Windhawk mods that subclass the same window
-- Uses CRITICAL_SECTION for thread-safe global state management
-- Atomic operations (InterlockedExchange) for initialization flags
-- LRU cache (16 entries) with fast window detection and eviction strategy
-- RAII pattern (AutoCriticalSection) for safe lock management
-- Proper hook ordering to prevent race conditions
-
-## Performance Optimizations
-- Process ID fast-path filtering to skip non-Magnifier windows instantly
-- Inline IsMagnifierWindow with optimized string comparison (first character check)
-- High-frequency message suppression (WM_PAINT, WM_TIMER, WM_NCHITTEST)
-- Reduced atomic operation overhead (simple read instead of InterlockedCompareExchange)
-- LRU cache eviction for optimal memory usage
-- Conditional logging to minimize overhead
-- Optimized critical section usage with double-check locking
-
-## Error Handling & Robustness
-- Safe wrapper functions for all critical Windows API calls
-- Comprehensive null pointer and window handle validation
-- Automatic retry mechanism for recoverable errors (up to 3 attempts)
-- Detailed error logging with GetLastError() codes
-- Graceful fallbacks for non-critical failures
-- Thread-safe error recovery in multi-threaded scenarios
-- Defensive programming with bounds checking and parameter validation
-- Return value validation for all API calls
+## Compatibility
+- Windows 10 and Windows 11
+- Targets magnify.exe only
 */
 // ==/WindhawkModReadme==
 
 #include <windows.h>
-#include <windhawk_api.h>
-#include <windhawk_utils.h>
-#include <dwmapi.h>
-#include <commctrl.h>
 
-#pragma comment(lib, "dwmapi.lib")
+// Global state
+HWND g_hHostWnd = NULL;
+BOOL g_bInitialized = FALSE;
 
-// ===========================
-// THREAD-SAFE GLOBAL STATE
-// ===========================
-
-// Critical section to protect global state
-CRITICAL_SECTION g_csGlobalState;
-BOOL g_bCriticalSectionInitialized = FALSE;
-
-// Global handle to our hidden host window (protected by g_csGlobalState)
-volatile HWND g_hHostWnd = NULL;
-
-// Atomic flag to track initialization status
-volatile LONG g_lInitialized = 0;
-
-// HWND cache for fast magnifier window detection (protected by g_csGlobalState)
-#define MAX_CACHED_MAGNIFIER_WINDOWS 16
-struct {
-    HWND hwnd;
-    BOOL isMagnifier;
-    DWORD lastAccessTick; // For LRU eviction
-} g_windowCache[MAX_CACHED_MAGNIFIER_WINDOWS] = {0};
-int g_cacheIndex = 0;
-
-// Performance: Suppress high-frequency message logs
-#define LOG_HIGH_FREQ_MESSAGES FALSE
-
-// Error handling: Enable detailed error logging
-#define LOG_ERROR_DETAILS TRUE
-
-// Error handling: Maximum retry attempts for recoverable errors
-#define MAX_RETRY_ATTEMPTS 3
-
-// Window procedure hook handle
-HHOOK g_hCallWndProcHook = NULL;
-
-// Subclassed Magnifier window HWND (protected by g_csGlobalState)
-// Using WindhawkUtils::SetWindowSubclassFromAnyThread for safe multi-mod subclassing
-HWND g_hSubclassedMagnifierWnd = NULL;
-
-// Helper: Safe enter/leave critical section
-class AutoCriticalSection {
-private:
-    CRITICAL_SECTION* m_pCs;
-    BOOL m_bEntered;
-public:
-    AutoCriticalSection(CRITICAL_SECTION* pCs) : m_pCs(pCs), m_bEntered(FALSE) {
-        if (g_bCriticalSectionInitialized && pCs) {
-            EnterCriticalSection(pCs);
-            m_bEntered = TRUE;
-        }
-    }
-    ~AutoCriticalSection() {
-        if (m_bEntered && m_pCs) {
-            LeaveCriticalSection(m_pCs);
-        }
-    }
-};
-
-// --- ERROR HANDLING HELPERS ---
-
-// Safe window validation with comprehensive checks
-inline BOOL SafeIsWindow(HWND hwnd) {
-    if (!hwnd) {
-        return FALSE;
-    }
-    return IsWindow(hwnd);
-}
-
-// Safe GetClassNameW with error handling
-inline BOOL SafeGetClassName(HWND hwnd, LPWSTR lpClassName, int nMaxCount) {
-    if (!hwnd || !lpClassName || nMaxCount <= 0) {
-        return FALSE;
-    }
-
-    int result = GetClassNameW(hwnd, lpClassName, nMaxCount);
-    if (result == 0) {
-        DWORD dwError = GetLastError();
-        if (LOG_ERROR_DETAILS && dwError != ERROR_SUCCESS) {
-            Wh_Log(L"Magnifier Headless: GetClassNameW failed for HWND 0x%p (error: %lu)", hwnd, dwError);
-        }
-        return FALSE;
-    }
-    return TRUE;
-}
-
-// Safe SetWindowLongPtrW with validation
-inline LONG_PTR SafeSetWindowLongPtrW(HWND hwnd, int nIndex, LONG_PTR dwNewLong) {
-    if (!SafeIsWindow(hwnd)) {
-        return 0;
-    }
-
-    SetLastError(0);
-    LONG_PTR result = SetWindowLongPtrW(hwnd, nIndex, dwNewLong);
-    DWORD dwError = GetLastError();
-
-    if (result == 0 && dwError != ERROR_SUCCESS) {
-        if (LOG_ERROR_DETAILS) {
-            Wh_Log(L"Magnifier Headless: SetWindowLongPtrW failed for HWND 0x%p, index %d (error: %lu)",
-                   hwnd, nIndex, dwError);
-        }
-    }
-    return result;
-}
-
-// Safe SetParent with validation and retry
-inline HWND SafeSetParent(HWND hWndChild, HWND hWndNewParent) {
-    if (!SafeIsWindow(hWndChild)) {
-        return NULL;
-    }
-
-    for (int attempt = 0; attempt < MAX_RETRY_ATTEMPTS; attempt++) {
-        SetLastError(0);
-        HWND result = SetParent(hWndChild, hWndNewParent);
-        DWORD dwError = GetLastError();
-
-        if (result || dwError == ERROR_SUCCESS) {
-            return result;
-        }
-
-        if (LOG_ERROR_DETAILS && attempt == MAX_RETRY_ATTEMPTS - 1) {
-            Wh_Log(L"Magnifier Headless: SetParent failed after %d attempts for HWND 0x%p (error: %lu)",
-                   MAX_RETRY_ATTEMPTS, hWndChild, dwError);
-        }
-
-        // Brief sleep before retry
-        if (attempt < MAX_RETRY_ATTEMPTS - 1) {
-            Sleep(10);
-        }
-    }
-
-    return NULL;
-}
-
-// Optimized inline function to check if a window is the Magnifier window
+// Check if a window belongs to the Magnifier UI
 inline BOOL IsMagnifierWindow(HWND hwnd) {
-    // Fast path: null check
-    if (!hwnd) {
+    if (!hwnd || !IsWindow(hwnd)) {
         return FALSE;
     }
 
-    // Note: Removed process ID filtering to allow detection of helper windows
-    // created by other Windows processes (CSPNotify, MSCTFIME, etc.)
-
-    // Fast path: Check cache first (thread-safe with minimal locking)
-    DWORD currentTick = GetTickCount();
-    {
-        AutoCriticalSection lock(&g_csGlobalState);
-        for (int i = 0; i < MAX_CACHED_MAGNIFIER_WINDOWS; i++) {
-            if (g_windowCache[i].hwnd == hwnd) {
-                g_windowCache[i].lastAccessTick = currentTick; // Update LRU
-                return g_windowCache[i].isMagnifier;
-            }
-        }
-    }
-
-    // Slow path: Not in cache, check class name
-    wchar_t className[32] = {0}; // Reduced size for performance
-    if (!SafeGetClassName(hwnd, className, 32)) {
+    wchar_t className[64] = {0};
+    if (GetClassNameW(hwnd, className, 64) == 0) {
         return FALSE;
     }
 
-    // Optimized string comparison (check first character first)
-    BOOL isMagnifier = FALSE;
-    if (className[0] == L'M' && wcscmp(className, L"MagUIClass") == 0) {
-        isMagnifier = TRUE;
-    } else if (className[0] == L'S' && wcscmp(className, L"ScreenMagnifierUIWnd") == 0) {
-        isMagnifier = TRUE;
-    } else if (wcsncmp(className, L"GDI+", 4) == 0) {
-        // GDI+ helper windows (e.g., "GDI+ Hook Window Class")
-        isMagnifier = TRUE;
-    } else if (wcsstr(className, L"CSpNotify") != NULL) {
-        // CSpNotify windows (C uppercase, S uppercase, p lowercase)
-        isMagnifier = TRUE;
-    } else if (wcsstr(className, L"MSCTFIME") != NULL) {
-        // MSCTFIME UI (Input Method Editor helper window)
-        isMagnifier = TRUE;
-    }
-
-    // NOTE: "Magnifier Touch" windows are handled separately via IsTouchOverlayWindow()
-    // They are moved off-screen (-32000, -32000) AND sized to 0x0 (safest approach)
-
-    // Add to cache with LRU eviction (thread-safe)
-    {
-        AutoCriticalSection lock(&g_csGlobalState);
-
-        // Find oldest entry for eviction
-        int oldestIndex = 0;
-        DWORD oldestTick = g_windowCache[0].lastAccessTick;
-        for (int i = 1; i < MAX_CACHED_MAGNIFIER_WINDOWS; i++) {
-            if (g_windowCache[i].lastAccessTick < oldestTick) {
-                oldestTick = g_windowCache[i].lastAccessTick;
-                oldestIndex = i;
-            }
-        }
-
-        // Use circular buffer index or LRU eviction
-        int targetIndex = (g_windowCache[g_cacheIndex].hwnd == NULL) ? g_cacheIndex : oldestIndex;
-
-        g_windowCache[targetIndex].hwnd = hwnd;
-        g_windowCache[targetIndex].isMagnifier = isMagnifier;
-        g_windowCache[targetIndex].lastAccessTick = currentTick;
-
-        g_cacheIndex = (g_cacheIndex + 1) % MAX_CACHED_MAGNIFIER_WINDOWS;
-    }
-
-    return isMagnifier;
+    return (wcscmp(className, L"MagUIClass") == 0 ||
+            wcscmp(className, L"ScreenMagnifierUIWnd") == 0);
 }
 
-// Check if a window is the Magnifier Touch overlay (handled differently - off-screen + 0x0 size)
+// Check if a window is the Magnifier Touch overlay
 inline BOOL IsTouchOverlayWindow(HWND hwnd) {
     if (!hwnd) {
         return FALSE;
     }
-    wchar_t windowTitle[64] = {0};
-    if (GetWindowTextW(hwnd, windowTitle, 64) > 0) {
-        if (wcsstr(windowTitle, L"Magnifier Touch") != NULL) {
-            return TRUE;
-        }
-    }
-    return FALSE;
+    wchar_t title[64] = {0};
+    return (GetWindowTextW(hwnd, title, 64) > 0 &&
+            wcsstr(title, L"Magnifier Touch") != NULL);
 }
 
 // --- HOOKS ---
 
-// ShowWindow hook to catch attempts to show the Magnifier window
 using ShowWindow_t = decltype(&ShowWindow);
 ShowWindow_t ShowWindow_Original = nullptr;
 BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
-    // Fast path: Check initialization once
-    if (!g_lInitialized) {
-        return ShowWindow_Original ? ShowWindow_Original(hWnd, nCmdShow) : FALSE;
-    }
-
-    // Skip touch overlay windows - let them show (they are off-screen + 0x0 size)
-    if (IsTouchOverlayWindow(hWnd)) {
+    if (!g_bInitialized) {
         return ShowWindow_Original(hWnd, nCmdShow);
     }
 
-    if (IsMagnifierWindow(hWnd) && nCmdShow != SW_HIDE) {
-        return TRUE; // Pretend success
+    if ((IsMagnifierWindow(hWnd) || IsTouchOverlayWindow(hWnd)) && nCmdShow != SW_HIDE) {
+        return TRUE;
     }
     return ShowWindow_Original(hWnd, nCmdShow);
 }
 
-// SetWindowPos hook to catch attempts to show the Magnifier window via position changes
 using SetWindowPos_t = decltype(&SetWindowPos);
 SetWindowPos_t SetWindowPos_Original = nullptr;
-BOOL WINAPI SetWindowPos_Hook(HWND hWnd, HWND hWndInsertAfter, int X, int Y, int cx, int cy, UINT uFlags) {
-    if (!g_lInitialized) {
-        return SetWindowPos_Original ? SetWindowPos_Original(hWnd, hWndInsertAfter, X, Y, cx, cy, uFlags) : FALSE;
+BOOL WINAPI SetWindowPos_Hook(HWND hWnd, HWND hWndInsertAfter, int X, int Y,
+                               int cx, int cy, UINT uFlags) {
+    if (!g_bInitialized) {
+        return SetWindowPos_Original(hWnd, hWndInsertAfter, X, Y, cx, cy, uFlags);
     }
 
-    // For touch overlay: Force position off-screen (-32000, -32000) AND size to 0x0 (safest)
+    // Move touch overlay off-screen with zero size and force hidden
     if (IsTouchOverlayWindow(hWnd)) {
-        return SetWindowPos_Original(hWnd, hWndInsertAfter, -32000, -32000, 0, 0, uFlags);
+        return SetWindowPos_Original(hWnd, hWndInsertAfter, -32000, -32000, 0, 0,
+                                      uFlags | SWP_HIDEWINDOW);
     }
 
     if (IsMagnifierWindow(hWnd)) {
@@ -363,15 +111,14 @@ BOOL WINAPI SetWindowPos_Hook(HWND hWnd, HWND hWndInsertAfter, int X, int Y, int
     return SetWindowPos_Original(hWnd, hWndInsertAfter, X, Y, cx, cy, uFlags);
 }
 
-// SetWindowLongPtrW hook to catch attempts to make the window visible or add it to the taskbar
 using SetWindowLongPtrW_t = decltype(&SetWindowLongPtrW);
 SetWindowLongPtrW_t SetWindowLongPtrW_Original = nullptr;
 LONG_PTR WINAPI SetWindowLongPtrW_Hook(HWND hWnd, int nIndex, LONG_PTR dwNewLong) {
-    if (!g_lInitialized) {
-        return SetWindowLongPtrW_Original ? SetWindowLongPtrW_Original(hWnd, nIndex, dwNewLong) : 0;
+    if (!g_bInitialized) {
+        return SetWindowLongPtrW_Original(hWnd, nIndex, dwNewLong);
     }
 
-    // Touch overlay: Enforce WS_EX_TOOLWINDOW to hide from Alt+Tab
+    // Hide touch overlay from Alt+Tab
     if (IsTouchOverlayWindow(hWnd) && nIndex == GWL_EXSTYLE) {
         dwNewLong &= ~WS_EX_APPWINDOW;
         dwNewLong |= WS_EX_TOOLWINDOW;
@@ -388,262 +135,6 @@ LONG_PTR WINAPI SetWindowLongPtrW_Hook(HWND hWnd, int nIndex, LONG_PTR dwNewLong
     return SetWindowLongPtrW_Original(hWnd, nIndex, dwNewLong);
 }
 
-// UpdateLayeredWindow hook to prevent layered window updates from showing the window
-using UpdateLayeredWindow_t = decltype(&UpdateLayeredWindow);
-UpdateLayeredWindow_t UpdateLayeredWindow_Original = nullptr;
-BOOL WINAPI UpdateLayeredWindow_Hook(
-    HWND hWnd, HDC hdcDst, POINT* pptDst, SIZE* psize,
-    HDC hdcSrc, POINT* pptSrc, COLORREF crKey,
-    BLENDFUNCTION* pblend, DWORD dwFlags) {
-
-    if (!g_lInitialized) {
-        return UpdateLayeredWindow_Original ? UpdateLayeredWindow_Original(hWnd, hdcDst, pptDst, psize,
-                                              hdcSrc, pptSrc, crKey, pblend, dwFlags) : FALSE;
-    }
-
-    // Touch overlay is handled via off-screen positioning, not transparency
-    // So no special handling needed here
-
-    if (IsMagnifierWindow(hWnd)) {
-        return TRUE; // Pretend success
-    }
-    return UpdateLayeredWindow_Original(hWnd, hdcDst, pptDst, psize, hdcSrc, pptSrc, crKey, pblend, dwFlags);
-}
-
-// SetLayeredWindowAttributes hook to prevent layered window attribute changes
-using SetLayeredWindowAttributes_t = decltype(&SetLayeredWindowAttributes);
-SetLayeredWindowAttributes_t SetLayeredWindowAttributes_Original = nullptr;
-BOOL WINAPI SetLayeredWindowAttributes_Hook(HWND hWnd, COLORREF crKey, BYTE bAlpha, DWORD dwFlags) {
-    if (!g_lInitialized) {
-        return SetLayeredWindowAttributes_Original ? SetLayeredWindowAttributes_Original(hWnd, crKey, bAlpha, dwFlags) : FALSE;
-    }
-
-    // Touch overlay is handled via off-screen positioning, not transparency
-
-    if (IsMagnifierWindow(hWnd)) {
-        return TRUE; // Pretend success
-    }
-    return SetLayeredWindowAttributes_Original(hWnd, crKey, bAlpha, dwFlags);
-}
-
-// AnimateWindow hook to prevent animated window showing
-using AnimateWindow_t = decltype(&AnimateWindow);
-AnimateWindow_t AnimateWindow_Original = nullptr;
-BOOL WINAPI AnimateWindow_Hook(HWND hWnd, DWORD dwTime, DWORD dwFlags) {
-    if (!g_lInitialized) {
-        return AnimateWindow_Original ? AnimateWindow_Original(hWnd, dwTime, dwFlags) : FALSE;
-    }
-
-    if (IsMagnifierWindow(hWnd) && !(dwFlags & AW_HIDE)) {
-        return TRUE; // Block show animations
-    }
-    return AnimateWindow_Original(hWnd, dwTime, dwFlags);
-}
-
-// BringWindowToTop hook to prevent bringing window to foreground
-using BringWindowToTop_t = decltype(&BringWindowToTop);
-BringWindowToTop_t BringWindowToTop_Original = nullptr;
-BOOL WINAPI BringWindowToTop_Hook(HWND hWnd) {
-    if (!g_lInitialized) {
-        return BringWindowToTop_Original ? BringWindowToTop_Original(hWnd) : FALSE;
-    }
-
-    if (IsMagnifierWindow(hWnd)) {
-        return TRUE; // Pretend success
-    }
-    return BringWindowToTop_Original(hWnd);
-}
-
-// SetForegroundWindow hook to prevent setting as foreground window
-using SetForegroundWindow_t = decltype(&SetForegroundWindow);
-SetForegroundWindow_t SetForegroundWindow_Original = nullptr;
-BOOL WINAPI SetForegroundWindow_Hook(HWND hWnd) {
-    if (!g_lInitialized) {
-        return SetForegroundWindow_Original ? SetForegroundWindow_Original(hWnd) : FALSE;
-    }
-
-    if (IsMagnifierWindow(hWnd)) {
-        return TRUE; // Pretend success
-    }
-    return SetForegroundWindow_Original(hWnd);
-}
-
-// SetWindowRgn hook to prevent region changes that might make window visible
-using SetWindowRgn_t = decltype(&SetWindowRgn);
-SetWindowRgn_t SetWindowRgn_Original = nullptr;
-int WINAPI SetWindowRgn_Hook(HWND hWnd, HRGN hRgn, BOOL bRedraw) {
-    if (!g_lInitialized) {
-        return SetWindowRgn_Original ? SetWindowRgn_Original(hWnd, hRgn, bRedraw) : 0;
-    }
-
-    if (IsMagnifierWindow(hWnd)) {
-        bRedraw = FALSE; // Disable redraw
-    }
-    return SetWindowRgn_Original(hWnd, hRgn, bRedraw);
-}
-
-// DwmSetWindowAttribute hook for Windows 11+ DWM features
-using DwmSetWindowAttribute_t = HRESULT (WINAPI*)(HWND, DWORD, LPCVOID, DWORD);
-DwmSetWindowAttribute_t DwmSetWindowAttribute_Original = nullptr;
-HRESULT WINAPI DwmSetWindowAttribute_Hook(HWND hWnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute) {
-    if (!g_lInitialized) {
-        return DwmSetWindowAttribute_Original ? DwmSetWindowAttribute_Original(hWnd, dwAttribute, pvAttribute, cbAttribute) : E_FAIL;
-    }
-
-    if (IsMagnifierWindow(hWnd) && (dwAttribute == DWMWA_CLOAK || dwAttribute == DWMWA_NCRENDERING_ENABLED)) {
-        return S_OK; // Block these attributes
-    }
-    return DwmSetWindowAttribute_Original(hWnd, dwAttribute, pvAttribute, cbAttribute);
-}
-
-// --- WINDOW PROCEDURE HOOK ---
-
-// Subclassed window procedure for Magnifier window
-// Uses WindhawkUtils::SetWindowSubclassFromAnyThread for safe multi-mod subclassing
-// Note: WindhawkUtils uses a 5-parameter callback signature (without uIdSubclass)
-LRESULT CALLBACK MagnifierWndProc_Hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData) {
-    // Validate window handle
-    if (!SafeIsWindow(hWnd)) {
-        return DefSubclassProc(hWnd, uMsg, wParam, lParam);
-    }
-
-    // Fast path: Handle high-frequency messages without logging
-    switch (uMsg) {
-    case WM_PAINT:
-    case WM_ERASEBKGND:
-        // Suppress painting (no log for performance)
-        ValidateRect(hWnd, NULL);
-        return 0;
-
-    case WM_NCPAINT:
-    case WM_SYNCPAINT:
-    case WM_TIMER:
-    case WM_NCHITTEST:
-        // Silently ignore high-frequency messages
-        return 0;
-
-    case WM_SHOWWINDOW:
-        // Block WM_SHOWWINDOW if trying to show
-        if (wParam) {
-            if (LOG_HIGH_FREQ_MESSAGES) {
-                Wh_Log(L"Magnifier Headless: Blocked WM_SHOWWINDOW in WndProc");
-            }
-            return 0;
-        }
-        break;
-
-    case WM_WINDOWPOSCHANGING:
-        // Modify WINDOWPOS structure to prevent showing
-        if (lParam) {
-            WINDOWPOS* pWp = (WINDOWPOS*)lParam;
-            if (!(pWp->flags & SWP_NOACTIVATE)) {
-                pWp->flags |= SWP_NOACTIVATE;
-            }
-            if (pWp->flags & SWP_SHOWWINDOW) {
-                pWp->flags &= ~SWP_SHOWWINDOW;
-                pWp->flags |= SWP_HIDEWINDOW;
-            }
-        }
-        break;
-
-    case WM_WINDOWPOSCHANGED:
-        // Ensure window remains hidden after position change
-        if (IsWindowVisible(hWnd)) {
-            if (ShowWindow_Original) {
-                ShowWindow_Original(hWnd, SW_HIDE);
-            }
-        }
-        break;
-
-    case WM_ACTIVATE:
-    case WM_NCACTIVATE:
-        // Block activation
-        if (wParam != WA_INACTIVE) {
-            return 0;
-        }
-        break;
-
-    case WM_SETFOCUS:
-        // Block focus
-        SetFocus(NULL);
-        return 0;
-
-    case WM_MOUSEACTIVATE:
-        // Prevent mouse activation
-        return MA_NOACTIVATE;
-
-    case WM_SYSCOMMAND:
-        // Block system commands that might show the window
-        if (wParam == SC_RESTORE || wParam == SC_MAXIMIZE) {
-            return 0;
-        }
-        break;
-
-    case WM_NCDESTROY:
-        // Window is being destroyed, clean up subclass tracking
-        {
-            AutoCriticalSection lock(&g_csGlobalState);
-            if (g_hSubclassedMagnifierWnd == hWnd) {
-                g_hSubclassedMagnifierWnd = NULL;
-            }
-        }
-        break;
-    }
-
-    // Call next subclass procedure in chain (or original window procedure)
-    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
-}
-
-// CallWndProc hook to detect and subclass Magnifier windows
-// Uses WindhawkUtils::SetWindowSubclassFromAnyThread for safe multi-mod subclassing
-LRESULT CALLBACK CallWndProc_Hook(int nCode, WPARAM wParam, LPARAM lParam) {
-    if (nCode >= 0 && g_lInitialized) {
-        // Validate lParam
-        if (!lParam) {
-            return CallNextHookEx(g_hCallWndProcHook, nCode, wParam, lParam);
-        }
-
-        CWPSTRUCT* pCwp = (CWPSTRUCT*)lParam;
-
-        // Validate CWPSTRUCT and window handle
-        if (pCwp && SafeIsWindow(pCwp->hwnd) && IsMagnifierWindow(pCwp->hwnd)) {
-            // Fast path: Check if already subclassed without lock
-            if (g_hSubclassedMagnifierWnd != pCwp->hwnd) {
-                // Thread-safe subclassing check
-                BOOL shouldSubclass = FALSE;
-                {
-                    AutoCriticalSection lock(&g_csGlobalState);
-                    if (g_hSubclassedMagnifierWnd != pCwp->hwnd) {
-                        g_hSubclassedMagnifierWnd = pCwp->hwnd;
-                        shouldSubclass = TRUE;
-                    }
-                }
-
-                if (shouldSubclass) {
-                    // Use WindhawkUtils::SetWindowSubclassFromAnyThread for safe multi-mod subclassing
-                    // This method properly chains subclass procedures and works across threads
-                    BOOL result = WindhawkUtils::SetWindowSubclassFromAnyThread(
-                        pCwp->hwnd, MagnifierWndProc_Hook, 0);
-
-                    if (result) {
-                        Wh_Log(L"Magnifier Headless: Subclassed Magnifier window using SetWindowSubclassFromAnyThread (HWND: 0x%p)", pCwp->hwnd);
-                    } else if (LOG_ERROR_DETAILS) {
-                        Wh_Log(L"Magnifier Headless: Failed to subclass window (HWND: 0x%p)", pCwp->hwnd);
-                        // Reset tracking on failure
-                        AutoCriticalSection lock(&g_csGlobalState);
-                        if (g_hSubclassedMagnifierWnd == pCwp->hwnd) {
-                            g_hSubclassedMagnifierWnd = NULL;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    return CallNextHookEx(g_hCallWndProcHook, nCode, wParam, lParam);
-}
-
-// CreateWindowExW hook to catch Magnifier window creation (optimized)
 using CreateWindowExW_t = decltype(&CreateWindowExW);
 CreateWindowExW_t CreateWindowExW_Original = nullptr;
 HWND WINAPI CreateWindowExW_Hook(
@@ -651,286 +142,138 @@ HWND WINAPI CreateWindowExW_Hook(
     int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu,
     HINSTANCE hInstance, LPVOID lpParam) {
 
-    if (!g_lInitialized) {
-        return CreateWindowExW_Original ? CreateWindowExW_Original(dwExStyle, lpClassName, lpWindowName,
-                                          dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam) : NULL;
+    if (!g_bInitialized) {
+        return CreateWindowExW_Original(dwExStyle, lpClassName, lpWindowName,
+            dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
     }
 
     BOOL isMagnifierClass = FALSE;
     BOOL isTouchOverlay = FALSE;
 
-    // Check for touch overlay first (by window title)
+    // Check for touch overlay by window title
     if (lpWindowName && wcsstr(lpWindowName, L"Magnifier Touch") != NULL) {
         isTouchOverlay = TRUE;
-        // Hide from Alt+Tab and Task Manager
+        dwStyle &= ~WS_VISIBLE;
         dwExStyle &= ~WS_EX_APPWINDOW;
         dwExStyle |= WS_EX_TOOLWINDOW;
-        Wh_Log(L"Magnifier Headless: Detected Magnifier Touch window (title: %ls) - hiding from Alt+Tab", lpWindowName);
+        Wh_Log(L"Magnifier Headless: Detected Magnifier Touch window");
     }
 
-    // Check for other magnifier classes (only if not touch overlay)
+    // Check for magnifier window classes (only if class name is a string, not an atom)
     if (!isTouchOverlay && ((ULONG_PTR)lpClassName & ~(ULONG_PTR)0xffff) != 0) {
-        // Optimized: Check first character before full string comparison
-        if ((lpClassName[0] == L'M' && wcscmp(lpClassName, L"MagUIClass") == 0) ||
-            (lpClassName[0] == L'S' && wcscmp(lpClassName, L"ScreenMagnifierUIWnd") == 0) ||
-            wcsncmp(lpClassName, L"GDI+", 4) == 0 ||
-            wcsstr(lpClassName, L"CSpNotify") != NULL ||
-            wcsstr(lpClassName, L"MSCTFIME") != NULL) {
+        if (wcscmp(lpClassName, L"MagUIClass") == 0 ||
+            wcscmp(lpClassName, L"ScreenMagnifierUIWnd") == 0) {
             isMagnifierClass = TRUE;
             dwStyle &= ~WS_VISIBLE;
             dwExStyle &= ~WS_EX_APPWINDOW;
             dwExStyle |= WS_EX_TOOLWINDOW;
-            Wh_Log(L"Magnifier Headless: Intercepting Magnifier window creation (class: %ls)", lpClassName);
+            Wh_Log(L"Magnifier Headless: Intercepting window creation (class: %ls)",
+                   lpClassName);
         }
     }
 
-    HWND hwnd = CreateWindowExW_Original(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y,
-                                  nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+    HWND hwnd = CreateWindowExW_Original(dwExStyle, lpClassName, lpWindowName,
+        dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 
     if (hwnd && isTouchOverlay) {
-        // Hide from Alt+Tab and Task Manager by forcing WS_EX_TOOLWINDOW after creation
-        if (SetWindowLongPtrW_Original && SafeIsWindow(hwnd)) {
-            LONG_PTR currentExStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
-            SetWindowLongPtrW_Original(hwnd, GWL_EXSTYLE, (currentExStyle & ~WS_EX_APPWINDOW) | WS_EX_TOOLWINDOW);
-        }
-
-        // For touch overlay: Move off-screen (-32000, -32000) AND set size to 0x0 (safest)
-        // This preserves zoom functionality while making the overlay completely invisible
+        // Force off-screen position, zero size, and hidden
         if (SetWindowPos_Original) {
             SetWindowPos_Original(hwnd, NULL, -32000, -32000, 0, 0,
-                                 SWP_NOZORDER | SWP_NOACTIVATE);
+                                  SWP_NOZORDER | SWP_NOACTIVATE);
         }
-        Wh_Log(L"Magnifier Headless: Hid Magnifier Touch window from Alt+Tab (HWND: 0x%p)", hwnd);
-    } else if (hwnd && isMagnifierClass) {
-        // For other magnifier windows: Hide completely
-        // Fast path: Read g_hHostWnd without lock (it's stable after init)
-        HWND hostWnd = g_hHostWnd;
-        if (hostWnd && SafeIsWindow(hostWnd)) {
-            SafeSetParent(hwnd, hostWnd);
-        }
-
-        // Hide window with safety check
-        if (ShowWindow_Original && SafeIsWindow(hwnd)) {
+        if (ShowWindow_Original) {
             ShowWindow_Original(hwnd, SW_HIDE);
         }
-
-        // Force update styles with safe API
-        if (SetWindowLongPtrW_Original && SafeIsWindow(hwnd)) {
-            LONG_PTR currentStyle = GetWindowLongPtrW(hwnd, GWL_STYLE);
-            SafeSetWindowLongPtrW(hwnd, GWL_STYLE, currentStyle & ~WS_VISIBLE);
-
-            LONG_PTR currentExStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
-            SafeSetWindowLongPtrW(hwnd, GWL_EXSTYLE, (currentExStyle & ~WS_EX_APPWINDOW) | WS_EX_TOOLWINDOW);
+    } else if (hwnd && isMagnifierClass) {
+        // Reparent to hidden host window and hide
+        if (g_hHostWnd) {
+            SetParent(hwnd, g_hHostWnd);
+        }
+        if (ShowWindow_Original) {
+            ShowWindow_Original(hwnd, SW_HIDE);
         }
     }
 
     return hwnd;
 }
 
-// --- HELPER FUNCTION FOR EXISTING WINDOWS ---
+// Callback for hiding existing magnifier windows (scoped to current process)
+BOOL CALLBACK EnumWindowsProc_HideMagnifier(HWND hwnd, LPARAM lParam) {
+    DWORD dwProcessId = 0;
+    GetWindowThreadProcessId(hwnd, &dwProcessId);
+    if (dwProcessId != GetCurrentProcessId()) {
+        return TRUE;
+    }
 
-// Enumerate and hide existing magnifier-related windows
-BOOL CALLBACK EnumWindowsProc_HideMagnifierWindows(HWND hwnd, LPARAM lParam) {
     if (IsMagnifierWindow(hwnd)) {
-        Wh_Log(L"Magnifier Headless: Found existing magnifier window (HWND: 0x%p), hiding...", hwnd);
-
-        // Hide window if detected
-        if (ShowWindow_Original && SafeIsWindow(hwnd)) {
+        Wh_Log(L"Magnifier Headless: Found existing magnifier window (HWND: 0x%p), hiding",
+               hwnd);
+        if (ShowWindow_Original) {
             ShowWindow_Original(hwnd, SW_HIDE);
         }
-
-        // Update styles to prevent visibility
-        if (SetWindowLongPtrW_Original && SafeIsWindow(hwnd)) {
-            LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
-            SafeSetWindowLongPtrW(hwnd, GWL_STYLE, style & ~WS_VISIBLE);
-
-            LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
-            SafeSetWindowLongPtrW(hwnd, GWL_EXSTYLE,
-                (exStyle & ~WS_EX_APPWINDOW) | WS_EX_TOOLWINDOW);
-        }
     }
-    return TRUE; // Continue enumeration
+    return TRUE;
 }
 
-// --- MOD INITIALIZATION ---
+// --- MOD LIFECYCLE ---
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"Magnifier Headless: Initializing (performance-optimized version)...");
+    Wh_Log(L"Magnifier Headless: Initializing...");
 
-    // Initialize critical section first (before any hook operations)
-    if (!InitializeCriticalSectionAndSpinCount(&g_csGlobalState, 0x400)) {
-        Wh_Log(L"Magnifier Headless: Failed to initialize critical section.");
-        return FALSE;
-    }
-    g_bCriticalSectionInitialized = TRUE;
-
-    // Set up all hooks BEFORE creating windows to prevent race conditions
-    Wh_Log(L"Magnifier Headless: Setting up function hooks...");
-
-    // Core window hooks
-    if (!Wh_SetFunctionHook((void*)CreateWindowExW, (void*)CreateWindowExW_Hook, (void**)&CreateWindowExW_Original) ||
-        !Wh_SetFunctionHook((void*)ShowWindow, (void*)ShowWindow_Hook, (void**)&ShowWindow_Original) ||
-        !Wh_SetFunctionHook((void*)SetWindowPos, (void*)SetWindowPos_Hook, (void**)&SetWindowPos_Original) ||
-        !Wh_SetFunctionHook((void*)SetWindowLongPtrW, (void*)SetWindowLongPtrW_Hook, (void**)&SetWindowLongPtrW_Original)) {
-        Wh_Log(L"Magnifier Headless: Failed to set up core window hooks.");
-        DeleteCriticalSection(&g_csGlobalState);
-        g_bCriticalSectionInitialized = FALSE;
+    // Set up hooks
+    if (!Wh_SetFunctionHook((void*)CreateWindowExW,
+                             (void*)CreateWindowExW_Hook,
+                             (void**)&CreateWindowExW_Original) ||
+        !Wh_SetFunctionHook((void*)ShowWindow,
+                             (void*)ShowWindow_Hook,
+                             (void**)&ShowWindow_Original) ||
+        !Wh_SetFunctionHook((void*)SetWindowPos,
+                             (void*)SetWindowPos_Hook,
+                             (void**)&SetWindowPos_Original) ||
+        !Wh_SetFunctionHook((void*)SetWindowLongPtrW,
+                             (void*)SetWindowLongPtrW_Hook,
+                             (void**)&SetWindowLongPtrW_Original)) {
+        Wh_Log(L"Magnifier Headless: Failed to set up hooks");
         return FALSE;
     }
 
-    // Layered window hooks
-    if (!Wh_SetFunctionHook((void*)UpdateLayeredWindow, (void*)UpdateLayeredWindow_Hook, (void**)&UpdateLayeredWindow_Original) ||
-        !Wh_SetFunctionHook((void*)SetLayeredWindowAttributes, (void*)SetLayeredWindowAttributes_Hook, (void**)&SetLayeredWindowAttributes_Original)) {
-        Wh_Log(L"Magnifier Headless: Failed to set up layered window hooks.");
-        DeleteCriticalSection(&g_csGlobalState);
-        g_bCriticalSectionInitialized = FALSE;
-        return FALSE;
-    }
-
-    // Animation and foreground hooks
-    if (!Wh_SetFunctionHook((void*)AnimateWindow, (void*)AnimateWindow_Hook, (void**)&AnimateWindow_Original) ||
-        !Wh_SetFunctionHook((void*)BringWindowToTop, (void*)BringWindowToTop_Hook, (void**)&BringWindowToTop_Original) ||
-        !Wh_SetFunctionHook((void*)SetForegroundWindow, (void*)SetForegroundWindow_Hook, (void**)&SetForegroundWindow_Original)) {
-        Wh_Log(L"Magnifier Headless: Failed to set up animation/foreground hooks.");
-        DeleteCriticalSection(&g_csGlobalState);
-        g_bCriticalSectionInitialized = FALSE;
-        return FALSE;
-    }
-
-    // Region hook
-    if (!Wh_SetFunctionHook((void*)SetWindowRgn, (void*)SetWindowRgn_Hook, (void**)&SetWindowRgn_Original)) {
-        Wh_Log(L"Magnifier Headless: Failed to set up region hook.");
-        DeleteCriticalSection(&g_csGlobalState);
-        g_bCriticalSectionInitialized = FALSE;
-        return FALSE;
-    }
-
-    // DWM hook (optional - may not exist on older Windows versions)
-    HMODULE hDwmapi = LoadLibraryW(L"dwmapi.dll");
-    if (hDwmapi) {
-        DwmSetWindowAttribute_Original = (DwmSetWindowAttribute_t)GetProcAddress(hDwmapi, "DwmSetWindowAttribute");
-        if (DwmSetWindowAttribute_Original) {
-            if (!Wh_SetFunctionHook((void*)DwmSetWindowAttribute_Original, (void*)DwmSetWindowAttribute_Hook, (void**)&DwmSetWindowAttribute_Original)) {
-                Wh_Log(L"Magnifier Headless: Warning - Failed to set up DWM hook (non-critical).");
-            } else {
-                Wh_Log(L"Magnifier Headless: DWM hook set up successfully.");
-            }
-        }
-    }
-
-    Wh_Log(L"Magnifier Headless: All hooks set up successfully.");
-
-    // Install window procedure hook to intercept messages
-    Wh_Log(L"Magnifier Headless: Installing window procedure hook...");
-    g_hCallWndProcHook = SetWindowsHookExW(WH_CALLWNDPROC, CallWndProc_Hook, NULL, GetCurrentThreadId());
-    if (!g_hCallWndProcHook) {
-        Wh_Log(L"Magnifier Headless: Warning - Failed to install window procedure hook (error: %lu).", GetLastError());
-        // Non-critical, continue anyway
-    } else {
-        Wh_Log(L"Magnifier Headless: Window procedure hook installed successfully.");
-    }
-
-    // Now create the hidden window (after hooks are in place)
-    Wh_Log(L"Magnifier Headless: Creating hidden host window...");
+    // Create hidden message-only host window
     WNDCLASSW wc = {};
     wc.lpfnWndProc = DefWindowProcW;
     wc.lpszClassName = L"MagnifierHeadlessHost";
     wc.hInstance = GetModuleHandle(NULL);
 
     if (!RegisterClassW(&wc)) {
-        DWORD dwError = GetLastError();
-        if (dwError != ERROR_CLASS_ALREADY_EXISTS) {
-            Wh_Log(L"Magnifier Headless: Failed to register window class (error: %lu).", dwError);
-            DeleteCriticalSection(&g_csGlobalState);
-            g_bCriticalSectionInitialized = FALSE;
+        if (GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
+            Wh_Log(L"Magnifier Headless: Failed to register window class");
             return FALSE;
         }
     }
 
-    HWND hHostWnd = CreateWindowExW(
-        0, wc.lpszClassName, L"Magnifier Headless Host", 0,
-        0, 0, 0, 0, HWND_MESSAGE, NULL, wc.hInstance, NULL
-    );
-
-    if (!hHostWnd) {
-        Wh_Log(L"Magnifier Headless: Failed to create host window (error: %lu).", GetLastError());
-        DeleteCriticalSection(&g_csGlobalState);
-        g_bCriticalSectionInitialized = FALSE;
+    g_hHostWnd = CreateWindowExW(0, wc.lpszClassName, NULL, 0,
+        0, 0, 0, 0, HWND_MESSAGE, NULL, wc.hInstance, NULL);
+    if (!g_hHostWnd) {
+        Wh_Log(L"Magnifier Headless: Failed to create host window");
         return FALSE;
     }
 
-    // Thread-safe assignment using atomic operation
-    {
-        AutoCriticalSection lock(&g_csGlobalState);
-        g_hHostWnd = hHostWnd;
-    }
+    g_bInitialized = TRUE;
 
-    Wh_Log(L"Magnifier Headless: Host window created (HWND: 0x%p).", hHostWnd);
-
-    // Mark initialization as complete (atomic operation)
-    InterlockedExchange(&g_lInitialized, 1);
-
-    // Enumerate and hide any existing magnifier windows that were created before mod loaded
-    Wh_Log(L"Magnifier Headless: Enumerating existing windows to hide any magnifier-related windows...");
-    EnumWindows(EnumWindowsProc_HideMagnifierWindows, 0);
-
-    Wh_Log(L"Magnifier Headless: Initialization complete. All systems ready.");
+    Wh_Log(L"Magnifier Headless: Initialization complete");
     return TRUE;
 }
 
+// Called by Windhawk after all hooks are activated and original function
+// pointers are valid. Safe to call ShowWindow_Original here.
+void Wh_ModAfterInit() {
+    Wh_Log(L"Magnifier Headless: Hiding existing magnifier windows...");
+    EnumWindows(EnumWindowsProc_HideMagnifier, 0);
+}
+
 void Wh_ModUninit() {
-    Wh_Log(L"Magnifier Headless: Uninitializing...");
-
-    // Mark as uninitialized (atomic operation)
-    InterlockedExchange(&g_lInitialized, 0);
-
-    // Unhook window procedure hook
-    if (g_hCallWndProcHook) {
-        UnhookWindowsHookEx(g_hCallWndProcHook);
-        g_hCallWndProcHook = NULL;
-        Wh_Log(L"Magnifier Headless: Window procedure hook removed.");
-    }
-
-    // Remove window subclass explicitly
-    // WindhawkUtils::SetWindowSubclassFromAnyThread does NOT handle cleanup automatically
-    {
-        AutoCriticalSection lock(&g_csGlobalState);
-        if (g_hSubclassedMagnifierWnd && SafeIsWindow(g_hSubclassedMagnifierWnd)) {
-            WindhawkUtils::RemoveWindowSubclassFromAnyThread(
-                g_hSubclassedMagnifierWnd, MagnifierWndProc_Hook);
-            Wh_Log(L"Magnifier Headless: Removed subclass from HWND 0x%p", g_hSubclassedMagnifierWnd);
-        }
-        g_hSubclassedMagnifierWnd = NULL;
-    }
-
-    // Thread-safe cleanup
-    HWND hHostWnd = NULL;
-    {
-        AutoCriticalSection lock(&g_csGlobalState);
-        hHostWnd = g_hHostWnd;
-        g_hHostWnd = NULL;
-
-        // Clear cache
-        for (int i = 0; i < MAX_CACHED_MAGNIFIER_WINDOWS; i++) {
-            g_windowCache[i].hwnd = NULL;
-            g_windowCache[i].isMagnifier = FALSE;
-        }
-        g_cacheIndex = 0;
-    }
-
-    if (hHostWnd && SafeIsWindow(hHostWnd)) {
-        if (DestroyWindow(hHostWnd)) {
-            Wh_Log(L"Magnifier Headless: Host window destroyed.");
-        } else if (LOG_ERROR_DETAILS) {
-            Wh_Log(L"Magnifier Headless: Failed to destroy host window (error: %lu)", GetLastError());
-        }
-    }
-
-    // Cleanup critical section
-    if (g_bCriticalSectionInitialized) {
-        DeleteCriticalSection(&g_csGlobalState);
-        g_bCriticalSectionInitialized = FALSE;
-    }
-
-    Wh_Log(L"Magnifier Headless: Uninitialization complete.");
+    Wh_Log(L"Magnifier Headless: Uninitializing - terminating process for clean state");
+    // Restoring state (unhiding windows, unregistering class, destroying the
+    // host window from the correct thread) is not feasible. Terminate so that
+    // magnify.exe can be restarted cleanly without the mod.
+    TerminateProcess(GetCurrentProcess(), 0);
 }


### PR DESCRIPTION
## Huge Code Refactor - v1.0 Initial Release

refactor: Remove over-engineering and fix Windhawk compliance issues

- Remove 7 unnecessary API hooks (`AnimateWindow`, `BringWindowToTop`,
  `SetForegroundWindow`, `UpdateLayeredWindow`, `SetLayeredWindowAttributes`,
  `SetWindowRgn`, `DwmSetWindowAttribute`) — the 4 core hooks
  (`CreateWindowExW`, `ShowWindow`, `SetWindowPos`, `SetWindowLongPtrW`) fully
  cover all window visibility paths for Magnify.exe
- Remove `CallWndProc` hook + window subclassing infrastructure (150+ lines)
  that duplicated what the API hooks already handle
- Remove LRU cache (16-entry tick-based eviction for a process with ~5
  windows)
- Remove Safe wrapper functions with retry mechanisms (`SafeSetParent Sleep+retry`, `SafeSetWindowLongPtrW`, `SafeGetClassName`, `SafeIsWindow`)
- Remove `AutoCriticalSection` class and CRITICAL_SECTION — no longer needed without subclassing or cache
- Remove `CSpNotify` and `MSCTFIME` from `IsMagnifierWindow` detection — these are system-wide accessibility/IME windows, hiding them breaks accessibility features in an accessibility tool
- Remove GDI+ helper window detection — not Magnifier-specific
- Remove MSVC-only #pragma comment(lib) — Windhawk uses Clang/mingw-w64
- Remove redundant #include directives (`windhawk_api.h` is auto-included)
- Remove `@compilerOptions -lcomctl32` (only needed for removed subclassing)
- Fix `EnumWindows` to scope to current process only via `GetCurrentProcessId`
- Rewrite `WindhawkModReadme` section to be user-focused instead of implementation docs
- Bump version to 1.0

fix: Hide Magnifier Touch window from Alt+Tab
The touch overlay was still appearing in Alt+Tab because `ShowWindow_Hook` was letting show commands pass through for touch overlay windows.
- `ShowWindow_Hook` blocks show commands for touch overlays (same as magnifier)
- `SetWindowPos_Hook` adds `SWP_HIDEWINDOW` flag for touch overlays
- `CreateWindowExW_Hook` calls `ShowWindow` (`SW_HIDE`) after creating touch overlay
- `CreateWindowExW_Hook` strips `WS_VISIBLE` from touch overlay before creation