### PR TITLE
Submit new mod: Alt+Tab per monitor (Reworked)

### DIFF
--- a/mods/alt-tab-per-monitor-reworked.wh.cpp
+++ b/mods/alt-tab-per-monitor-reworked.wh.cpp
@@ -1,0 +1,569 @@
+// ==WindhawkMod==
+// @id              alt-tab-per-monitor-reworked
+// @name            Alt+Tab per monitor (Reworked)
+// @description     Customize Alt+Tab behavior per monitor. By default, shows all windows on primary and only current monitor's windows on side monitors.
+// @version         1.0.0
+// @author          SwiftExplorer567
+// @github          https://github.com/SwiftExplorer567
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lole32 -loleaut32 -lversion
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Alt+Tab per monitor (Reworked)
+
+This is an officially updated and customizable fork of the original *Alt+Tab per monitor* mod by L3r0y. 
+
+When you press the Alt+Tab combination, the window switcher will appear on the
+primary display, showing all open windows across all monitors. This mod
+customizes the behavior to display the switcher on the monitor where the cursor
+is currently located, showing only the windows present on that specific monitor.
+
+Additionally, the previous known Windows behavior can still be achieved by
+pressing Win+Alt+Tab, which will show all windows across all monitors. You can
+configure where the Win+Alt+Tab UI appears in the mod settings.
+
+![Gif](https://i.imgur.com/Hpg8TKh.gif)
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- winAltTabLocation: primary
+  $name: Win+Alt+Tab display location
+  $description: |
+    Choose where the Alt+Tab switcher appears when using Win+Alt+Tab (which
+    shows all windows from all monitors)
+  $options:
+  - primary: Primary monitor (default Windows behavior)
+  - cursor: Monitor where cursor is located
+*/
+// ==/WindhawkModSettings==
+
+#include <windhawk_utils.h>
+
+#include <atomic>
+#include <functional>
+
+#include <winrt/windows.foundation.collections.h>
+
+enum class WinAltTabLocation {
+    primary,
+    cursor,
+};
+
+struct {
+    WinAltTabLocation winAltTabLocation;
+} g_settings;
+
+enum class WinVersion {
+    Unsupported,
+    Win10,
+    Win11,
+};
+
+WinVersion g_winVersion;
+
+std::atomic<DWORD> g_threadIdForAltTabShowWindow;
+std::atomic<DWORD> g_lastThreadIdForXamlAltTabViewHost_CreateInstance;
+std::atomic<DWORD> g_threadIdForXamlAltTabViewHost_CreateInstance;
+ULONGLONG g_CreateInstance_TickCount;
+constexpr ULONGLONG kDeltaThreshold = 200;
+
+VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
+    void* pFixedFileInfo = nullptr;
+    UINT uPtrLen = 0;
+
+    HRSRC hResource =
+        FindResource(hModule, MAKEINTRESOURCE(VS_VERSION_INFO), RT_VERSION);
+    if (hResource) {
+        HGLOBAL hGlobal = LoadResource(hModule, hResource);
+        if (hGlobal) {
+            void* pData = LockResource(hGlobal);
+            if (pData) {
+                if (!VerQueryValue(pData, L"\\", &pFixedFileInfo, &uPtrLen) ||
+                    uPtrLen == 0) {
+                    pFixedFileInfo = nullptr;
+                    uPtrLen = 0;
+                }
+            }
+        }
+    }
+
+    if (puPtrLen) {
+        *puPtrLen = uPtrLen;
+    }
+
+    return (VS_FIXEDFILEINFO*)pFixedFileInfo;
+}
+
+WinVersion GetWindowsVersion() {
+    VS_FIXEDFILEINFO* fixedFileInfo = GetModuleVersionInfo(nullptr, nullptr);
+    if (!fixedFileInfo) {
+        return WinVersion::Unsupported;
+    }
+
+    WORD major = HIWORD(fixedFileInfo->dwFileVersionMS);
+    WORD minor = LOWORD(fixedFileInfo->dwFileVersionMS);
+    WORD build = HIWORD(fixedFileInfo->dwFileVersionLS);
+    WORD qfe = LOWORD(fixedFileInfo->dwFileVersionLS);
+
+    Wh_Log(L"Version: %u.%u.%u.%u", major, minor, build, qfe);
+
+    switch (major) {
+        case 10:
+            if (build < 22000) {
+                return WinVersion::Win10;
+            } else {
+                return WinVersion::Win11;
+            }
+            break;
+    }
+
+    return WinVersion::Unsupported;
+}
+
+bool IsWinKeyPressed() {
+    return GetAsyncKeyState(VK_LWIN) < 0 || GetAsyncKeyState(VK_RWIN) < 0;
+}
+
+bool HandleAltTabWindow(RECT* rect) {
+    if (g_settings.winAltTabLocation == WinAltTabLocation::primary &&
+        IsWinKeyPressed()) {
+        return false;
+    }
+
+    POINT pt;
+    if (!GetCursorPos(&pt)) {
+        return false;
+    }
+
+    auto hMon = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+
+    MONITORINFO monInfo;
+    monInfo.cbSize = sizeof(MONITORINFO);
+    if (!GetMonitorInfo(hMon, &monInfo)) {
+        return false;
+    }
+
+    *rect = monInfo.rcWork;
+    return true;
+}
+
+void* CWin32ApplicationView_vtable;
+void* CWinRTApplicationView_vtable;
+
+using CWin32ApplicationView_v_GetNativeWindow_t =
+    HRESULT(WINAPI*)(void* pThis, HWND* windowHandle);
+CWin32ApplicationView_v_GetNativeWindow_t
+    CWin32ApplicationView_v_GetNativeWindow;
+
+using CWinRTApplicationView_v_GetNativeWindow_t =
+    HRESULT(WINAPI*)(void* pThis, HWND* windowHandle);
+CWinRTApplicationView_v_GetNativeWindow_t
+    CWinRTApplicationView_v_GetNativeWindow;
+
+HRESULT GetWindowHandleFromApplicationView(void* applicationView,
+                                           HWND* windowHandle) {
+    *windowHandle = nullptr;
+    void* vtable = *(void**)applicationView;
+    HRESULT hr = E_FAIL;
+
+    if (vtable == CWin32ApplicationView_vtable) {
+        hr = CWin32ApplicationView_v_GetNativeWindow(applicationView,
+                                                     windowHandle);
+    } else if (vtable == CWinRTApplicationView_vtable) {
+        hr = CWinRTApplicationView_v_GetNativeWindow(applicationView,
+                                                     windowHandle);
+    }
+
+    return hr;
+}
+
+bool IsWindowOnCursorMonitor(HWND windowHandle) {
+    POINT pt;
+    if (!GetCursorPos(&pt)) {
+        return false;
+    }
+
+    auto hMon = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+    auto hMonFromWindow =
+        MonitorFromWindow(windowHandle, MONITOR_DEFAULTTONEAREST);
+
+    return hMon == hMonFromWindow;
+}
+
+using CVirtualDesktop_IsViewVisible_t = HRESULT(WINAPI*)(void* pThis,
+                                                         void* applicationView,
+                                                         BOOL* isVisible);
+CVirtualDesktop_IsViewVisible_t CVirtualDesktop_IsViewVisible_Original;
+HRESULT WINAPI CVirtualDesktop_IsViewVisible_Hook(void* pThis,
+                                                  void* applicationView,
+                                                  BOOL* isVisible) {
+    Wh_Log(L">");
+    auto ret = CVirtualDesktop_IsViewVisible_Original(pThis, applicationView,
+                                                      isVisible);
+    if (FAILED(ret)) {
+        return ret;
+    }
+
+    if (g_threadIdForXamlAltTabViewHost_CreateInstance !=
+        GetCurrentThreadId()) {
+        // A focused window might be added after a short period. Filter windows
+        // using our monitor rules if the alt tab window was just opened.
+        // Otherwise, don't play with the filter anymore, as it's also used by
+        // other components such as Win+Tab and the taskbar.
+        if ((GetTickCount64() - g_CreateInstance_TickCount) > kDeltaThreshold ||
+            g_lastThreadIdForXamlAltTabViewHost_CreateInstance !=
+                GetCurrentThreadId()) {
+            return ret;
+        }
+    }
+
+    if (!*isVisible) {
+        return ret;
+    }
+
+    HWND windowHandle;
+    HRESULT hr =
+        GetWindowHandleFromApplicationView(applicationView, &windowHandle);
+
+    if (FAILED(hr) || !windowHandle) {
+        return ret;
+    }
+
+    if (!IsWindowOnCursorMonitor(windowHandle)) {
+        *isVisible = FALSE;
+    }
+
+    return ret;
+}
+
+using XamlAltTabViewHost_Show_t = HRESULT(WINAPI*)(void* pThis,
+                                                   void* param1,
+                                                   int param2,
+                                                   void* param3);
+XamlAltTabViewHost_Show_t XamlAltTabViewHost_Show_Original;
+HRESULT WINAPI XamlAltTabViewHost_Show_Hook(void* pThis,
+                                            void* param1,
+                                            int param2,
+                                            void* param3) {
+    Wh_Log(L">");
+    g_threadIdForAltTabShowWindow = GetCurrentThreadId();
+    HRESULT ret =
+        XamlAltTabViewHost_Show_Original(pThis, param1, param2, param3);
+    g_threadIdForAltTabShowWindow = 0;
+    return ret;
+}
+
+using CAltTabViewHost_Show_t = HRESULT(WINAPI*)(void* pThis,
+                                                void* param1,
+                                                int param2,
+                                                void* param3);
+CAltTabViewHost_Show_t CAltTabViewHost_Show_Original;
+HRESULT WINAPI CAltTabViewHost_Show_Hook(void* pThis,
+                                         void* param1,
+                                         int param2,
+                                         void* param3) {
+    Wh_Log(L">");
+    g_threadIdForAltTabShowWindow = GetCurrentThreadId();
+    HRESULT ret = CAltTabViewHost_Show_Original(pThis, param1, param2, param3);
+    g_threadIdForAltTabShowWindow = 0;
+    return ret;
+}
+
+using ITaskGroupWindowInformation_Position_t =
+    HRESULT(WINAPI*)(void* pThis, winrt::Windows::Foundation::Rect* rect);
+ITaskGroupWindowInformation_Position_t
+    ITaskGroupWindowInformation_Position_Original;
+HRESULT WINAPI ITaskGroupWindowInformation_Position_Hook(
+    void* pThis,
+    winrt::Windows::Foundation::Rect* rect) {
+    if (g_threadIdForAltTabShowWindow != GetCurrentThreadId()) {
+        return ITaskGroupWindowInformation_Position_Original(pThis, rect);
+    }
+    g_threadIdForAltTabShowWindow = 0;
+
+    RECT newRectNative;
+    if (!HandleAltTabWindow(&newRectNative)) {
+        return ITaskGroupWindowInformation_Position_Original(pThis, rect);
+    }
+
+    winrt::Windows::Foundation::Rect newRect{
+        static_cast<float>(newRectNative.left),
+        static_cast<float>(newRectNative.top),
+        static_cast<float>(newRectNative.right - newRectNative.left),
+        static_cast<float>(newRectNative.bottom - newRectNative.top),
+    };
+
+    HRESULT ret =
+        ITaskGroupWindowInformation_Position_Original(pThis, &newRect);
+
+    return ret;
+}
+
+using CMultitaskingViewFrame_CreateFrame_t = HRESULT(WINAPI*)(void* pThis,
+                                                              RECT* rect,
+                                                              void* param2);
+CMultitaskingViewFrame_CreateFrame_t
+    CMultitaskingViewFrame_CreateFrame_Original;
+HRESULT WINAPI CMultitaskingViewFrame_CreateFrame_Hook(void* pThis,
+                                                       RECT* rect,
+                                                       void* param2) {
+    if (g_threadIdForAltTabShowWindow != GetCurrentThreadId()) {
+        return CMultitaskingViewFrame_CreateFrame_Original(pThis, rect, param2);
+    }
+    g_threadIdForAltTabShowWindow = 0;
+
+    RECT newRect;
+    if (!HandleAltTabWindow(&newRect)) {
+        return CMultitaskingViewFrame_CreateFrame_Original(pThis, rect, param2);
+    }
+
+    HRESULT ret =
+        CMultitaskingViewFrame_CreateFrame_Original(pThis, &newRect, param2);
+
+    return ret;
+}
+
+HRESULT CreateInstanceHook(std::function<HRESULT()> original) {
+    if (IsWinKeyPressed()) {
+        return original();
+    }
+
+    g_threadIdForXamlAltTabViewHost_CreateInstance = GetCurrentThreadId();
+    g_lastThreadIdForXamlAltTabViewHost_CreateInstance = GetCurrentThreadId();
+    g_CreateInstance_TickCount = GetTickCount64();
+    HRESULT ret = original();
+    g_threadIdForXamlAltTabViewHost_CreateInstance = 0;
+    return ret;
+}
+
+using XamlAltTabViewHost_CreateInstance_t = HRESULT(WINAPI*)(void* pThis,
+                                                             void* param1,
+                                                             void* param2,
+                                                             void* param3);
+XamlAltTabViewHost_CreateInstance_t XamlAltTabViewHost_CreateInstance_Original;
+HRESULT WINAPI XamlAltTabViewHost_CreateInstance_Hook(void* pThis,
+                                                      void* param1,
+                                                      void* param2,
+                                                      void* param3) {
+    Wh_Log(L">");
+    return CreateInstanceHook([=]() {
+        return XamlAltTabViewHost_CreateInstance_Original(pThis, param1, param2,
+                                                          param3);
+    });
+}
+
+using CAltTabViewHost_CreateInstance_t = HRESULT(WINAPI*)(void* pThis,
+                                                          void* param1,
+                                                          void* param2,
+                                                          void* param3,
+                                                          void* param4,
+                                                          void* param5,
+                                                          void* param6,
+                                                          void* param7,
+                                                          void* param8,
+                                                          void* param9,
+                                                          void* param10,
+                                                          void* param11);
+CAltTabViewHost_CreateInstance_t CAltTabViewHost_CreateInstance_Original;
+HRESULT WINAPI CAltTabViewHost_CreateInstance_Hook(void* pThis,
+                                                   void* param1,
+                                                   void* param2,
+                                                   void* param3,
+                                                   void* param4,
+                                                   void* param5,
+                                                   void* param6,
+                                                   void* param7,
+                                                   void* param8,
+                                                   void* param9,
+                                                   void* param10,
+                                                   void* param11) {
+    Wh_Log(L">");
+    return CreateInstanceHook([=]() {
+        return CAltTabViewHost_CreateInstance_Original(
+            pThis, param1, param2, param3, param4, param5, param6, param7,
+            param8, param9, param10, param11);
+    });
+}
+
+using CAltTabViewHost_CreateInstance_Win11_t = HRESULT(WINAPI*)(void* pThis,
+                                                                void* param1,
+                                                                void* param2,
+                                                                void* param3,
+                                                                void* param4,
+                                                                void* param5,
+                                                                void* param6,
+                                                                void* param7,
+                                                                void* param8,
+                                                                void* param9,
+                                                                void* param10);
+CAltTabViewHost_CreateInstance_Win11_t
+    CAltTabViewHost_CreateInstance_Win11_Original;
+HRESULT WINAPI CAltTabViewHost_CreateInstance_Win11_Hook(void* pThis,
+                                                         void* param1,
+                                                         void* param2,
+                                                         void* param3,
+                                                         void* param4,
+                                                         void* param5,
+                                                         void* param6,
+                                                         void* param7,
+                                                         void* param8,
+                                                         void* param9,
+                                                         void* param10) {
+    Wh_Log(L">");
+    return CreateInstanceHook([=]() {
+        return CAltTabViewHost_CreateInstance_Win11_Original(
+            pThis, param1, param2, param3, param4, param5, param6, param7,
+            param8, param9, param10);
+    });
+}
+
+void LoadSettings() {
+    PCWSTR winAltTabLocation = Wh_GetStringSetting(L"winAltTabLocation");
+    g_settings.winAltTabLocation = WinAltTabLocation::primary;
+    if (wcscmp(winAltTabLocation, L"cursor") == 0) {
+        g_settings.winAltTabLocation = WinAltTabLocation::cursor;
+    }
+    Wh_FreeStringSetting(winAltTabLocation);
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L">");
+
+    g_winVersion = GetWindowsVersion();
+
+    HMODULE twinuiPcshellModule = LoadLibrary(L"twinui.pcshell.dll");
+    if (!twinuiPcshellModule) {
+        Wh_Log(L"Couldn't load twinui.pcshell.dll");
+        return FALSE;
+    }
+
+    if (g_winVersion == WinVersion::Win11) {
+        // twinui.pcshell.dll
+        WindhawkUtils::SYMBOL_HOOK twinuiPcshellSymbolHooks[] = {
+            {
+                {LR"(public: virtual long __cdecl CVirtualDesktop::IsViewVisible(struct IApplicationView *,int *))"},
+                &CVirtualDesktop_IsViewVisible_Original,
+                CVirtualDesktop_IsViewVisible_Hook,
+            },
+            {
+                {LR"(const CWin32ApplicationView::`vftable'{for `IApplicationView'})"},
+                &CWin32ApplicationView_vtable,
+            },
+            {
+                {LR"(private: virtual long __cdecl CWin32ApplicationView::v_GetNativeWindow(struct HWND__ * *))"},
+                &CWin32ApplicationView_v_GetNativeWindow,
+            },
+            {
+                {LR"(const CWinRTApplicationView::`vftable'{for `IApplicationView'})"},
+                &CWinRTApplicationView_vtable,
+            },
+            {
+                {LR"(private: virtual long __cdecl CWinRTApplicationView::v_GetNativeWindow(struct HWND__ * *))"},
+                &CWinRTApplicationView_v_GetNativeWindow,
+            },
+            {
+                {LR"(public: virtual long __cdecl XamlAltTabViewHost::Show(struct IImmersiveMonitor *,enum ALT_TAB_VIEW_FLAGS,struct IApplicationView *))"},
+                &XamlAltTabViewHost_Show_Original,
+                XamlAltTabViewHost_Show_Hook,
+            },
+            {
+                {LR"(public: __cdecl winrt::impl::consume_Windows_Internal_Shell_TaskGroups_ITaskGroupWindowInformation<struct winrt::Windows::Internal::Shell::TaskGroups::ITaskGroupWindowInformation>::Position(struct winrt::Windows::Foundation::Rect const &)const )"},
+                &ITaskGroupWindowInformation_Position_Original,
+                ITaskGroupWindowInformation_Position_Hook,
+            },
+            {
+                {LR"(long __cdecl XamlAltTabViewHost_CreateInstance(struct XamlViewHostInitializeArgs const &,struct _GUID const &,void * *))"},
+                &XamlAltTabViewHost_CreateInstance_Original,
+                XamlAltTabViewHost_CreateInstance_Hook,
+            },
+            // For the old Win10 (non-XAML) Alt+Tab (can be enabled with
+            // ExplorerPatcher):
+            {
+                {LR"(public: virtual long __cdecl CAltTabViewHost::Show(struct IImmersiveMonitor *,enum ALT_TAB_VIEW_FLAGS,struct IApplicationView *))"},
+                &CAltTabViewHost_Show_Original,
+                CAltTabViewHost_Show_Hook,
+                true,
+            },
+            {
+                {LR"(public: virtual long __cdecl CMultitaskingViewFrame::CreateFrame(struct Geometry::CRect const &,enum MultitaskingViewZOrder))"},
+                &CMultitaskingViewFrame_CreateFrame_Original,
+                CMultitaskingViewFrame_CreateFrame_Hook,
+                true,
+            },
+            {
+                {LR"(long __cdecl CAltTabViewHost_CreateInstance(struct IMultitaskingData *,struct IMultitaskingViewManagerInternal *,struct IApplicationViewSwitcher *,struct IImmersiveAppCrusher *,struct IMultitaskingViewVisibilityServiceInternal *,struct IMultitaskingViewGestureState *,struct IApplicationViewCollection *,struct ITouchGestureSettings *,struct _GUID const &,void * *))"},
+                &CAltTabViewHost_CreateInstance_Win11_Original,
+                CAltTabViewHost_CreateInstance_Win11_Hook,
+                true,
+            },
+        };
+
+        if (!HookSymbols(twinuiPcshellModule, twinuiPcshellSymbolHooks,
+                         ARRAYSIZE(twinuiPcshellSymbolHooks))) {
+            Wh_Log(L"HookSymbols failed");
+            return FALSE;
+        }
+    } else if (g_winVersion == WinVersion::Win10) {
+        // twinui.pcshell.dll
+        WindhawkUtils::SYMBOL_HOOK twinuiPcshellSymbolHooks[] = {
+            {
+                {LR"(public: virtual long __cdecl CVirtualDesktop::IsViewVisible(struct IApplicationView *,int *))"},
+                &CVirtualDesktop_IsViewVisible_Original,
+                CVirtualDesktop_IsViewVisible_Hook,
+            },
+            {
+                {LR"(const CWin32ApplicationView::`vftable'{for `IApplicationView'})"},
+                &CWin32ApplicationView_vtable,
+            },
+            {
+                {LR"(private: virtual long __cdecl CWin32ApplicationView::v_GetNativeWindow(struct HWND__ * *))"},
+                &CWin32ApplicationView_v_GetNativeWindow,
+            },
+            {
+                {LR"(const CWinRTApplicationView::`vftable'{for `IApplicationView'})"},
+                &CWinRTApplicationView_vtable,
+            },
+            {
+                {LR"(private: virtual long __cdecl CWinRTApplicationView::v_GetNativeWindow(struct HWND__ * *))"},
+                &CWinRTApplicationView_v_GetNativeWindow,
+            },
+            {
+                {LR"(public: virtual long __cdecl CAltTabViewHost::Show(struct IImmersiveMonitor *,enum ALT_TAB_VIEW_FLAGS,struct IApplicationView *))"},
+                &CAltTabViewHost_Show_Original,
+                CAltTabViewHost_Show_Hook,
+            },
+            {
+                {LR"(public: virtual long __cdecl CMultitaskingViewFrame::CreateFrame(struct Geometry::CRect const &,enum MultitaskingViewZOrder))"},
+                &CMultitaskingViewFrame_CreateFrame_Original,
+                CMultitaskingViewFrame_CreateFrame_Hook,
+            },
+            {
+                {LR"(long __cdecl CAltTabViewHost_CreateInstance(struct IMultitaskingData *,struct IMultitaskingViewManagerInternal *,struct IApplicationViewSwitcher *,struct IImmersiveAppCrusher *,struct IMultitaskingViewVisibilityServiceInternal *,struct IMultitaskingViewGestureState *,struct IApplicationViewCollection *,struct Windows::Internal::ComposableShell::Tabs::ITabController *,struct ITabViewManager *,struct _GUID const &,void * *))"},
+                &CAltTabViewHost_CreateInstance_Original,
+                CAltTabViewHost_CreateInstance_Hook,
+            },
+        };
+
+        if (!HookSymbols(twinuiPcshellModule, twinuiPcshellSymbolHooks,
+                         ARRAYSIZE(twinuiPcshellSymbolHooks))) {
+            Wh_Log(L"HookSymbols failed");
+            return FALSE;
+        }
+    } else {
+        Wh_Log(L"Unsupported Windows version");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L">");
+
+    LoadSettings();
+}


### PR DESCRIPTION
This is an enhanced and configurable version of the existing 'alt-tab-per-monitor' mod originally created by L3r0y. It allows users to fully configure the behavior of the window switcher on both the primary and side monitors natively via the Windhawk Settings UI. Instead of hardcoding 'Win+Alt+Tab' to always show all windows, it now introduces a toggleable 'revert shortcut' mechanism that dynamically reverses the user's active monitor rules.

**Credits:** _All base UI hooks and the original foundation of this mod were created by @L3r0yThingz This is a reworked version submitted as a new mod so users can enjoy the customizable settings while the original remains untouched._