### PR TITLE
Add Windows 11 Start Menu Power Buttons mod

### DIFF
--- a/mods/win11-power-buttons.wh.cpp
+++ b/mods/win11-power-buttons.wh.cpp
@@ -46,7 +46,7 @@ Adds customizable one-click Shutdown, Restart, Sign out, Sleep, and Hibernate bu
 
 - confirm_before_action: false
   $name: Confirm before power actions
-  $name:zh-CN: 执行电源操作前确认
+  $name:zh-CN: 执行前确认
   $description: Show a confirmation dialog before executing power actions.
   $description:zh-CN: 在执行电源操作前显示确认对话框。
 


### PR DESCRIPTION
This mod adds customizable one-click Shutdown, Restart, Sign out, Sleep, and Hibernate buttons to the Windows 11 Start menu, replacing the default power flyout.

Users can customize which buttons to display and their order via the mod settings.