### PR TITLE
Add mod to fix taskbar keyboard layout indicator

### DIFF
--- a/mods/fix-legacy-taskbar-tray-input-indicator.wh.cpp
+++ b/mods/fix-legacy-taskbar-tray-input-indicator.wh.cpp
@@ -5,6 +5,7 @@
 // @version         1.0.0
 // @author          Anixx
 // @github          https://github.com/Anixx
+// @architecture    x86-64
 // @include         explorer.exe
 // @compilerOptions -lgdi32 -luser32
 // ==/WindhawkMod==


### PR DESCRIPTION
This mod fixes the keyboard layout indicator text orientation when using the classic Windows taskbar from Windows 10 running under Windows 11 24H2.