### PR TITLE
Add Taskbar Split by Monitor mod

### DIFF
--- a/mods/taskbar-split-by-monitor.wh.cpp
+++ b/mods/taskbar-split-by-monitor.wh.cpp
@@ -6,7 +6,7 @@
 // @description:ja  各モニターのタスクバーにそのモニター上のウィンドウのみを表示します
 // @version         1.1.0
 // @author          ajisaiflow
-// @github          lighfu
+// @github          https://github.com/lighfu
 // @include         explorer.exe
 // @include         ShellHost.exe
 // @architecture    x86-64


### PR DESCRIPTION
## Summary

- Adds a new mod that forces each monitor's taskbar to only display windows located on that specific monitor
- Hooks `RegQueryValueExW` and `RegGetValueW` to enforce multi-monitor taskbar settings (`MMTaskbarMode`, `MMTaskbarEnabled`)
- Supports two modes: per-monitor only (default) and main + per-monitor
- Compatible with Windows 10, Windows 11, and Windows 11 24H2 (ShellHost.exe)

## Test plan

- [x] Tested on Windows 11 Home with dual monitors
- [x] Verified each taskbar shows only its monitor's windows
- [x] Verified settings change (filter mode) applies without explorer restart
- [x] Verified original settings restore on mod disable

🤖 Generated with [Claude Code](https://claude.com/claude-code)