### PR TITLE
Update Remove Unwanted Context Menu Items to 1.7.0

### DIFF
--- a/mods/remove-context-menu-items.wh.cpp
+++ b/mods/remove-context-menu-items.wh.cpp
@@ -249,7 +249,7 @@ If you find a mistake and for additional details, please click [here](https://gi
   - enableExtensionFiltering: false
     $name: Enable Notepad extension filtering
     $description: >-
-      When enabled, "Edit in Notepad" and "Edit in Notepad++" will ONLY appear for files whose extensions are in the Notepad whitelist below. They are hidden for all other file types. (Note: Requires "Edit in Notepad" or "Edit in Notepad++" menu items to be enabled.)
+      When enabled, the "Edit in Notepad" and "Edit in Notepad++" menu items will ONLY appear for files whose extensions are in the Notepad whitelist below. They are hidden for all other file types. (Note: Requires "Edit in Notepad" or "Edit in Notepad++" items to be enabled.)
 
         Known Limitation: In Explorer window with multiple tabs, the mod currently retrieves file context from the first tab (active primary tab) rather than the other tabs currently being viewed or clicked.
   - notepadExtensions:
@@ -276,7 +276,7 @@ If you find a mistake and for additional details, please click [here](https://gi
   - enableWinRARFiltering: false
     $name: Enable WinRAR extension filtering
     $description: >-
-      When enabled, the WinRAR menu item will ONLY appear for files whose extensions are in the WinRAR whitelist below. It is hidden for all other file types. (Note: Requires "WinRAR" menu item to be enabled.)
+      When enabled, the WinRAR menu item will ONLY appear for files whose extensions are in the WinRAR whitelist below. It is hidden for all other file types. (Note: Requires "WinRAR" item to be enabled.)
 
         Known Limitation: In Explorer window with multiple tabs, the mod currently retrieves file context from the first tab (active primary tab) rather than the other tabs currently being viewed or clicked.
   - winrarExtensions:


### PR DESCRIPTION
- Added `WinRAR Extension Filtering` toggle under the newly improved `Extension Filtering` section. When enabled alongside the WinRAR removal toggle, the WinRAR context menu item will only appear for archive/compressed files (.zip, .rar, .7z, .iso, .tar, .gzip, .xz, .zst, .cab). It is hidden for all other file types.
- Added a new `Modifier Key Override` section. When enabled, holding a modifier key (Ctrl, Alt, or Both) while right-clicking temporarily bypasses the mod and shows all original context menu items. Useful for accessing a hidden item without changing settings. (thanks, Schleifenkratzer!)
- Renamed and reorganized the `Extension Filtering` section to accommodate both Notepad and WinRAR filtering, with improved descriptions throughout.