### PR TITLE
Add winui-context-menu-animation mod

### DIFF
--- a/mods/winui-context-menu-animation.wh.cpp
+++ b/mods/winui-context-menu-animation.wh.cpp
@@ -7,7 +7,7 @@
 // @description:pt  Adiciona animações suaves de deslizamento vertical no estilo WinUI aos menus de contexto Win32 clássicos no Windows 11
 // @description:es  Agrega animaciones de deslizamiento verticales suaves al estilo WinUI a los menús contextuales clásicos de Win32 en Windows 11
 // @version         1.0
-// @author          crazyboyybs, aubymori
+// @author          crazyboyybs
 // @github          https://github.com/crazyboyybs
 // @include         *
 // @compilerOptions -lgdi32 -lcomctl32 -lmsimg32


### PR DESCRIPTION
This mod brings a WinUI-like animation to classic context menus in Windows 11.

It is a fork of the mod Menu/Tooltip Slide Animation by @aubymori  -

https://windhawk.net/mods/menu-tooltip-slide-animation

All credits to her for the inspiration and part of the code.

The original mod restored the classic Windows 98/XP menu animation system.

This fork adapts the animation engine to replicate the modern WinUI motion style used throughout Windows 11.

Changes in this version include:

• Replacing the classic animation with a WinUI-style vertical easing motion
• Removing tooltip animation logic
• Removing horizontal animation
• Improving submenu direction detection
• Implementing an accurate cubic-bezier solver for smooth motion