### PR TITLE
Add Spotify Taskbar Widget Windhawk mod

### DIFF
--- a/mods/taskbar-spotify-widget.wh.cpp
+++ b/mods/taskbar-spotify-widget.wh.cpp
@@ -4,6 +4,7 @@
 // @description     A native-style Spotify widget for the taskbar. Windows 10/11 
 // @version         1.0
 // @author          memeri121
+// @github          https://github.com/memeri121
 // @include         explorer.exe
 // @compilerOptions -lole32 -ldwmapi -lgdi32 -luser32 -lwindowsapp -lshcore -lgdiplus -lshell32 -lcomctl32
 // ==/WindhawkMod==
@@ -1597,4 +1598,5 @@ void Wh_ModUninit() {
 
     WhTool_ModUninit();
     ExitProcess(0);
+
 }


### PR DESCRIPTION
Adds a Spotify widget directly to the Windows taskbar.

Features:
- play / pause
- previous / next track
- seekbar
- hover time tooltip
- transparent background

This mod allows controlling Spotify directly from the Windows taskbar.