### PR TITLE
Retry virtual desktop notification registration after Explorer restart

### DIFF
--- a/mods/taskbar-desktop-indicator.wh.cpp
+++ b/mods/taskbar-desktop-indicator.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-desktop-indicator
 // @name            Taskbar Desktop Indicator
 // @description     Displays the current virtual desktop as a number or marker in the Windows 11 taskbar clock area
-// @version         1.2.0
+// @version         1.2.1
 // @author          Simon Benedict
 // @github          https://github.com/simon-ami
 // @include         explorer.exe


### PR DESCRIPTION
Fixes the case where taskbar-desktop-indicator can stop updating after explorer.exe restarts if notification registration initially fails and polling fallback is disabled.

This keeps the notification thread alive and retries registration until the virtual desktop notification service becomes available, instead of attempting registration only once during startup.

Related issue: #3520