### PR TITLE
Hide music lounge when taskbar or screen is fullscreen

### DIFF
--- a/mods/taskbar-music-lounge.wh.cpp
+++ b/mods/taskbar-music-lounge.wh.cpp
@@ -3,8 +3,8 @@
 // @name            Taskbar Music Lounge
 // @description     A native-style music ticker with media controls.
 // @version         3.1
-// @author          Hashah2311
-// @github          https://github.com/Hashah2311
+// @author          dogukannparlak
+// @github          https://github.com/dogukannparlak
 // @include         explorer.exe
 // @compilerOptions -lole32 -ldwmapi -lgdi32 -luser32 -lwindowsapp -lshcore -lgdiplus
 // ==/WindhawkMod==
@@ -819,3 +819,4 @@ void Wh_ModUninit() {
     WhTool_ModUninit();
     ExitProcess(0);
 }
+


### PR DESCRIPTION
Summary Hides the Music Lounge panel when the taskbar is not visible or when a fullscreen window is in the foreground, so the widget does not stay on top of games or fullscreen apps.  Changes  Taskbar visibility: Panel is shown only when the taskbar is visible (IsWindowVisible). Taskbar size: If the taskbar is collapsed (e.g. auto-hide, height/width < 10px), the panel is hidden. Fullscreen detection: If the foreground window covers the monitor (within 10px), the panel is hidden. Show/hide: ShowWindow(SW_HIDE) when conditions above are not met; ShowWindow(SW_SHOWNOACTIVATE) when the taskbar is visible and no fullscreen window is active. Version: 3.0 → 3.1