### PR TITLE
feat: add Disable Taskbar mod to completely hide the taskbar on all monitors

### DIFF
--- a/mods/disable-taskbar.wh.cpp
+++ b/mods/disable-taskbar.wh.cpp
@@ -4,7 +4,7 @@
 // @description     Completely hides the taskbar on all monitors
 // @version         1.0
 // @author          miraquel
-// @github          miraquel
+// @github          https://github.com/miraquel
 // @include         explorer.exe
 // @include         StartMenuExperienceHost.exe
 // @architecture    x86-64


### PR DESCRIPTION
## Add mod: Disable Taskbar (`disable-taskbar`)

Completely hides the Windows taskbar on all monitors — primary and secondary — and prevents it from reappearing.

### What it does

- Hides `Shell_TrayWnd` and all `Shell_SecondaryTrayWnd` windows on load.
- Optionally removes the taskbar's desktop space reservation via `SHAppBarMessage(ABM_REMOVE)` so applications can use the full monitor area.
- Blocks all known paths by which Windows can re-show the taskbar:
  - `ShowWindow` — direct show calls
  - `SetWindowPos(SWP_SHOWWINDOW)` — position-and-show calls
  - `AnimateWindow` — slide/fade animations used by the taskbar
  - `SetWindowLongW/Ptr(GWL_STYLE, WS_VISIBLE)` — direct style bit manipulation
  - `EVENT_OBJECT_SHOW` via a background WinEvent hook — catches kernel-level `NtUserShowWindow` calls that bypass all of the above (triggered by notification popups, etc.)
- Corrects the Start menu's vertical position when the taskbar is hidden. Because `StartMenuExperienceHost.exe` positions its window at process startup, the mod repositions it at show-time (Win key press) to close the gap left by the missing taskbar. A second WinEvent hook (`EVENT_OBJECT_LOCATIONCHANGE`) acts as a universal safety net for any repositioning code path.
- Restores the taskbar fully when the mod is disabled or removed.

### Target processes

| Process | Purpose |
|---|---|
| `explorer.exe` | Hide and suppress the taskbar |
| `StartMenuExperienceHost.exe` | Fix the Start menu's Y position |

### Tested on

Windows 11 (64-bit)