### PR TITLE
Windows 11 Start Menu Styler v1.4

### DIFF
--- a/mods/windows-11-start-menu-styler.wh.cpp
+++ b/mods/windows-11-start-menu-styler.wh.cpp
@@ -2,7 +2,7 @@
 // @id              windows-11-start-menu-styler
 // @name            Windows 11 Start Menu Styler
 // @description     Customize the start menu with themes contributed by others or create your own
-// @version         1.3.3
+// @version         1.4
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -86,9 +86,15 @@ Windows11_Metro10Minimal](https://github.com/ramensoftware/windows-11-start-menu
 \
 Everblush](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/Themes/Everblush/README.md)
 
-[![21996](https://raw.githubusercontent.com/ramensoftware/windows-11-start-menu-styling-guide/main/Themes/21996/screenshot-small.png)
+[![SunValley](https://raw.githubusercontent.com/ramensoftware/windows-11-start-menu-styling-guide/main/Themes/SunValley/screenshot-small.png)
 \
-21996](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/Themes/21996/README.md)
+SunValley](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/Themes/SunValley/README.md)
+
+[![SunValley
+(Legacy)](https://raw.githubusercontent.com/ramensoftware/windows-11-start-menu-styling-guide/main/Themes/21996/screenshot-small.png)
+\
+SunValley
+(Legacy)](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/Themes/21996/README.md)
 
 [![UniMenu](https://raw.githubusercontent.com/ramensoftware/windows-11-start-menu-styling-guide/main/Themes/UniMenu/screenshot-small.png)
 \
@@ -113,6 +119,18 @@ Fluid](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob
 [![Oversimplified&Accentuated](https://raw.githubusercontent.com/ramensoftware/windows-11-start-menu-styling-guide/main/Themes/Oversimplified&Accentuated/screenshot-small.png)
 \
 Oversimplified&Accentuated](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/Themes/Oversimplified&Accentuated/README.md)
+
+[![LiquidGlass](https://raw.githubusercontent.com/ramensoftware/windows-11-start-menu-styling-guide/main/Themes/LiquidGlass/screenshot-small.png)
+\
+LiquidGlass](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/Themes/LiquidGlass/README.md)
+
+[![Windows10X](https://raw.githubusercontent.com/ramensoftware/windows-11-start-menu-styling-guide/main/Themes/Windows10X/screenshot-small.png)
+\
+Windows10X](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/Themes/Windows10X/README.md)
+
+[![TintedGlass](https://raw.githubusercontent.com/ramensoftware/windows-11-start-menu-styling-guide/main/Themes/TintedGlass/screenshot-small.png)
+\
+TintedGlass](https://github.com/ramensoftware/windows-11-start-menu-styling-guide/blob/main/Themes/TintedGlass/README.md)
 
 More themes can be found in the **Themes** section of [The Windows 11 start menu
 styling
@@ -173,13 +191,66 @@ specified visual state.
 
 For the XAML syntax, in addition to the built-in taskbar objects, the mod
 provides a built-in blur brush via the `WindhawkBlur` object, which supports the
-`BlurAmount`, `TintColor`, and `TintOpacity` properties. For example:
+`BlurAmount`, `TintColor`, `TintOpacity`, `TintLuminosityOpacity`,
+`TintSaturation`, `NoiseOpacity`, and `NoiseDensity` properties. For example:
 `Fill:=<WindhawkBlur BlurAmount="10" TintColor="#80FF00FF"/>`. Theme resources
 are also supported, for example: `Fill:=<WindhawkBlur BlurAmount="18"
 TintColor="{ThemeResource SystemAccentColorDark1}" TintOpacity="0.5"/>`.
 
 Targets and styles starting with two slashes (`//`) are ignored. This can be
 useful for temporarily disabling a target or style.
+
+### Resource variables
+
+Some variables, such as size and padding for various controls, colors, and
+brushes, are defined as resource variables. You can override existing resources
+or define new theme-aware resources.
+
+#### Overriding existing resources
+
+Use `key=value` to override an existing resource.
+
+#### Defining theme-aware resources
+
+Use `Key@Dark=value` and `Key@Light=value` to define new resources with
+different values for dark and light themes. These can then be referenced in
+styles using `{ThemeResource key}`.
+
+For example, to define a custom accent color that automatically adjusts based on
+the system theme:
+
+```
+AutoAccent@Dark={ThemeResource SystemAccentColorDark1}
+AutoAccent@Light={ThemeResource SystemAccentColorLight2}
+```
+
+Then use it in a style:
+
+```
+Background:=<SolidColorBrush Color="{ThemeResource AutoAccent}" />
+```
+
+The value will automatically update when the system accent color changes.
+
+### Style constants
+
+Style constants allow defining a value once and referencing it in multiple
+styles. Each entry contains a name and value, separated by `=`, for example:
+
+```
+mainColor=#fafad2
+```
+
+The constant can then be used in style definitions by prepending `$`, for
+example:
+
+```
+Fill=$mainColor
+Background:=<AcrylicBrush TintColor="$mainColor" TintOpacity="0.3" />
+```
+
+Some themes use style constants to allow easy customization. Refer to the
+theme page for details on which constants are available.
 
 ### Search WebView styles
 
@@ -208,11 +279,6 @@ const s=document.createElement('script');s.setAttribute('src','https://m417z.git
 To reset all side-effects of the injected scripts, clear the custom code in the
 mod settings and then terminate the search host process. It will be relaunched
 automatically by Windows.
-
-### Resource variables
-
-Some variables, such as size and padding for various controls, are defined as
-resource variables.
 
 ## Implementation notes
 
@@ -249,20 +315,34 @@ from the **TranslucentTB** project.
   - RosePine: RosePine
   - Windows11_Metro10Minimal: Windows11_Metro10Minimal
   - Everblush: Everblush
-  - 21996: "21996"
+  - SunValley: SunValley
+  - 21996: SunValley (Legacy)
   - UniMenu: UniMenu
   - LegacyFluent: LegacyFluent
   - OnlySearch: OnlySearch
   - WindowGlass: WindowGlass (for the redesigned Start menu)
-  - WindowGlass_variant_Minimal: WindowGlass (Minimal) (for the redesigned Start menu)
+  - WindowGlass_variant_Minimal: WindowGlass (Minimal) (legacy, use WindowGlass)
   - Fluid: Fluid (for the redesigned Start menu)
   - Oversimplified&Accentuated: Oversimplified&Accentuated
-- disableNewStartMenuLayout: false
+  - LiquidGlass: LiquidGlass (for the redesigned Start menu)
+  - Windows10X: Windows10X
+  - TintedGlass: TintedGlass
+- disableNewStartMenuLayout: ""
   $name: Disable the new start menu layout
   $description: >-
     Allows to disable the new start menu layout which is incompatible with some
-    themes. The start menu Phone Link pane can't be used when the new layout is
-    disabled.
+    themes.
+  $options:
+  - "": Don't disable (use Windows default)
+  - 1: Disable new layout and Phone Link
+  - disableNewLayoutKeepPhoneLink: Disable new layout but keep Phone Link
+  - forceNewLayout: Force new layout (if available)
+- styleConstants: [""]
+  $name: Style constants
+  $description: >-
+    Some themes support style constants for customization, such as colors. Refer
+    to the theme page for available constants. For technical details, refer to
+    the mod description.
 - controlStyles:
   - - target: ""
       $name: Target
@@ -277,27 +357,13 @@ from the **TranslucentTB** project.
   $name: Search WebView styles
 - webContentCustomJs: ""
   $name: Search WebView custom JavaScript code
-- styleConstants: [""]
-  $name: Style constants
-  $description: >-
-    Constants which can be defined once and used in multiple styles.
-
-    Each entry contains a style name and value, separated by '=', for example:
-
-    mainColor=#fafad2
-
-    The constant can then be used in style definitions by prepending '$', for
-    example:
-
-    Fill=$mainColor
-
-    Background:=<AcrylicBrush TintColor="$mainColor" TintOpacity="0.3" />
-- resourceVariables:
-  - - variableKey: ""
-      $name: Variable key
-    - value: ""
-      $name: Value
+- themeResourceVariables: [""]
   $name: Resource variables
+  $description: >-
+    Use "Key=Value" to override an existing resource with a new value.
+
+    Use "Key@Dark=Value" or "Key@Light=Value" to define theme-aware resources
+    that can be referenced with {ThemeResource Key} in styles.
 */
 // ==/WindhawkModSettings==
 
@@ -507,7 +573,13 @@ const Theme g_themeTranslucentStartMenu_variant_ClassicStartMenu = {{
         L"CornerRadius=16",
         L"Margin=-1"}},
     ThemeTargetStyles{L"Border#DropShadow", {
-        L"CornerRadius=15"}},
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Border#StartDropShadow", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Border#RootGridDropShadow", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Border#RightCompanionDropShadow", {
+        L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"StartDocked.AllAppsGridListViewItem > Grid#ContentBorder@CommonStates", {
         L"Background@PointerOver:=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#15C0C0C0\"/>",
         L"CornerRadius=4"}},
@@ -524,7 +596,7 @@ const Theme g_themeNoRecommendedSection = {{
         L"RenderTransform:=<TranslateTransform Y=\"8\"/>"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#ShowMoreSuggestionsButton > Grid > Windows.UI.Xaml.Controls.ContentPresenter > Windows.UI.Xaml.Controls.StackPanel > Windows.UI.Xaml.Controls.TextBlock", {
         L"Text=Recommended"}},
-    ThemeTargetStyles{L"Grid#TopLevelSuggestionsRoot > Grid[2] ", {
+    ThemeTargetStyles{L"Grid#TopLevelSuggestionsRoot > Grid[2]", {
         L"MinHeight=0"}},
     ThemeTargetStyles{L"Grid#TopLevelSuggestionsRoot", {
         L"Grid.Row=0"}},
@@ -546,6 +618,8 @@ const Theme g_themeNoRecommendedSection_variant_ClassicStartMenu = {{
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#NoTopLevelSuggestionsText", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#TopLevelSuggestionsContainer", {
+        L"Height=0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridView#RecommendedList", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ShowMoreSuggestions", {
         L"Visibility=Collapsed"}},
@@ -554,12 +628,9 @@ const Theme g_themeNoRecommendedSection_variant_ClassicStartMenu = {{
 }};
 
 const Theme g_themeSideBySide = {{
-    ThemeTargetStyles{L"StartDocked.PowerOptionsView", {
-        L"Margin=-740,0,0,0"}},
-    ThemeTargetStyles{L"StartDocked.UserTileView", {
-        L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"StartMenu.PinnedList", {
-        L"MaxHeight=275"}},
+        L"MinHeight=420",
+        L"MaxHeight=420"}},
     ThemeTargetStyles{L"StartMenu.ExpandedFolderList > Grid > Border", {
         L"Margin=-40,0,40,0",
         L"Width=325"}},
@@ -577,14 +648,16 @@ const Theme g_themeSideBySide = {{
         L"Margin=0,-70,0,0"}},
     ThemeTargetStyles{L"GridView#PinnedList", {
         L"MaxWidth=480",
-        L"RenderTransform:=<TranslateTransform X=\"-145\" Y=\"750\"/>"}},
+        L"RenderTransform:=<TranslateTransform X=\"-145\" Y=\"790\"/>",
+        L"MinHeight=420",
+        L"MaxHeight=420"}},
     ThemeTargetStyles{L"GridView#AllAppsGrid > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid", {
         L"Width=280",
         L"Margin=55,12,-55,0"}},
     ThemeTargetStyles{L"GridView#AllAppsGrid > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter", {
         L"RenderTransform:=<TranslateTransform Y=\"-795\"/>"}},
     ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton", {
-        L"Margin=-60,305,60,-305",
+        L"Margin=-60,170,60,-170",
         L"FontWeight=SemiBold",
         L"Height=32",
         L"Width=200",
@@ -593,7 +666,7 @@ const Theme g_themeSideBySide = {{
         L"Margin=0,-35,0,35"}},
     ThemeTargetStyles{L"TextBlock#PinnedListHeaderText", {
         L"Visibility=Visible",
-        L"RenderTransform:=<TranslateTransform X=\"4\" Y=\"788.5\"/>",
+        L"RenderTransform:=<TranslateTransform X=\"-4\" Y=\"788.5\"/>",
         L"FontWeight=SemiBold"}},
     ThemeTargetStyles{L"StartMenu.StartHome", {
         L"RenderTransform:=<TranslateTransform Y=\"-1\"/>"}},
@@ -604,16 +677,17 @@ const Theme g_themeSideBySide = {{
         L"TextLineBounds=0",
         L"HorizontalAlignment=1"}},
     ThemeTargetStyles{L"Grid#TopLevelSuggestionsRoot", {
-        L"RenderTransform:=<TranslateTransform X=\"-160\" Y=\"990\"/>",
+        L"RenderTransform:=<TranslateTransform X=\"-160\" Y=\"800\"/>",
         L"Width=450",
+        L"MinHeight=129",
         L"BorderThickness=0,1,0,0",
         L"BorderBrush=#22BBBBBB"}},
     ThemeTargetStyles{L"TextBlock#TopLevelSuggestionsListHeaderText", {
         L"RenderTransform:=<TranslateTransform X=\"-50\" />"}},
     ThemeTargetStyles{L"Button#ShowMoreSuggestionsButton", {
         L"RenderTransform:=<TranslateTransform X=\"50\" />"}},
-    ThemeTargetStyles{L"GridView#AllAppsGrid > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid ", {
-        L"Margin=485,310,0,0"}},
+    ThemeTargetStyles{L"GridView#AllAppsGrid > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid", {
+        L"Margin=485,175,0,0"}},
     ThemeTargetStyles{L"GridView#RecommendedList > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid > GridViewItem > Border", {
         L"MaxWidth=185",
         L"HorizontalAlignment=2"}},
@@ -627,8 +701,9 @@ const Theme g_themeSideBySide = {{
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ScrollBar", {
         L"Height=650",
         L"RenderTransform:=<TranslateTransform Y=\"-50\" />"}},
+    ThemeTargetStyles{L"Grid#MainMenu > Grid#MainContent > Grid", {
+        L"Canvas.ZIndex=1"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridView#PinnedList > Border > Windows.UI.Xaml.Controls.ScrollViewer", {
-        L" MaxHeight=260",
         L"ScrollViewer.VerticalScrollMode=2"}},
 }};
 
@@ -642,11 +717,15 @@ const Theme g_themeSideBySide_variant_ClassicStartMenu = {{
         L"Padding=-40,0,110,0",
         L"Background:=<AcrylicBrush TintColor=\"{ThemeResource CardStrokeColorDefaultSolid}\" FallbackColor=\"{ThemeResource CardStrokeColorDefaultSolid}\" TintOpacity=\"0\" TintLuminosityOpacity=\"1\" Opacity=\"1\"/>",
         L"Margin=-300,0,745,1"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootPanel > Grid#RootGrid > Grid#RootContent > Grid#MainContent > Grid#InnerContent > Grid#AllAppsRoot", {
+        L"Margin=-516,0,745,1"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#CloseAllAppsButton", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"StartDocked.StartSizingFrame", {
         L"MaxWidth=860",
         L"Width=860"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootPanel > Grid#RootGrid", {
+        L"Width=644"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#ShowAllAppsButton", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock#PinnedListHeaderText", {
@@ -692,10 +771,11 @@ const Theme g_themeSideBySide_variant_ClassicStartMenu = {{
 }};
 
 const Theme g_themeSideBySide2 = {{
-    ThemeTargetStyles{L"StartDocked.PowerOptionsView", {
-        L"Margin=-740,0,0,0"}},
-    ThemeTargetStyles{L"StartDocked.UserTileView", {
-        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"StartDocked.NavigationPaneView#UserControl > Grid#RootPanel", {
+        L"FlowDirection=1"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList", {
+        L"MinHeight=420",
+        L"MaxHeight=420"}},
     ThemeTargetStyles{L"StartMenu.ExpandedFolderList > Grid > Border", {
         L"Margin=-40,0,40,0",
         L"Width=325"}},
@@ -713,14 +793,16 @@ const Theme g_themeSideBySide2 = {{
         L"Margin=0,-70,0,0"}},
     ThemeTargetStyles{L"GridView#PinnedList", {
         L"MaxWidth=480",
-        L"RenderTransform:=<TranslateTransform X=\"345\" Y=\"790\"/>"}},
+        L"RenderTransform:=<TranslateTransform X=\"345\" Y=\"752\"/>",
+        L"MinHeight=420",
+        L"MaxHeight=420"}},
     ThemeTargetStyles{L"GridView#AllAppsGrid > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid", {
         L"Width=280",
         L"Margin=-55,12,55,0"}},
     ThemeTargetStyles{L"GridView#AllAppsGrid > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter", {
         L"RenderTransform:=<TranslateTransform X=\"-200\" Y=\"-760\"/>"}},
     ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton", {
-        L"Margin=-440,400,400,-440",
+        L"Margin=-390,132,390,-132",
         L"FontWeight=SemiBold",
         L"Height=32",
         L"Width=200"}},
@@ -728,7 +810,7 @@ const Theme g_themeSideBySide2 = {{
         L"Margin=0,-35,0,35"}},
     ThemeTargetStyles{L"TextBlock#PinnedListHeaderText", {
         L"Visibility=Visible",
-        L"RenderTransform:=<TranslateTransform X=\"485\" Y=\"788.5\"/>",
+        L"RenderTransform:=<TranslateTransform X=\"485\" Y=\"753\"/>",
         L"FontWeight=SemiBold"}},
     ThemeTargetStyles{L"StartMenu.StartHome", {
         L"RenderTransform:=<TranslateTransform Y=\"-1\"/>"}},
@@ -739,17 +821,18 @@ const Theme g_themeSideBySide2 = {{
         L"TextLineBounds=0",
         L"HorizontalAlignment=1"}},
     ThemeTargetStyles{L"Grid#TopLevelSuggestionsRoot", {
-        L"RenderTransform:=<TranslateTransform X=\"360\" Y=\"880\"/>",
+        L"RenderTransform:=<TranslateTransform X=\"360\" Y=\"784\"/>",
         L"Width=450",
+        L"MinHeight=129",
         L"BorderThickness=0,1,0,0",
         L"BorderBrush=#22BBBBBB"}},
     ThemeTargetStyles{L"TextBlock#TopLevelSuggestionsListHeaderText", {
         L"RenderTransform:=<TranslateTransform X=\"-50\" />"}},
     ThemeTargetStyles{L"Button#ShowMoreSuggestionsButton", {
         L"RenderTransform:=<TranslateTransform X=\"50\" />"}},
-    ThemeTargetStyles{L"GridView#AllAppsGrid > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid ", {
+    ThemeTargetStyles{L"GridView#AllAppsGrid > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid", {
         L"RenderTransform:=<TranslateTransform X=\"-40\" />",
-        L"Margin=0,420,0,0"}},
+        L"Margin=0,134,0,0"}},
     ThemeTargetStyles{L"ScrollViewer", {
         L"ScrollViewer.VerticalScrollMode=2"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ItemsWrapGrid", {
@@ -764,6 +847,8 @@ const Theme g_themeSideBySide2 = {{
         L"Margin=-25,0,-25,0"}},
     ThemeTargetStyles{L"StartDocked.AppListView", {
         L"Margin=15,0,-15,0"}},
+    ThemeTargetStyles{L"Grid#MainMenu > Grid#MainContent > Grid", {
+        L"Canvas.ZIndex=1"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ScrollBar", {
         L"Height=650",
         L"RenderTransform:=<TranslateTransform Y=\"-50\" />"}},
@@ -775,15 +860,24 @@ const Theme g_themeSideBySide2_variant_ClassicStartMenu = {{
         L"Width=510",
         L"MinHeight=585",
         L"Margin=264,0,0,0"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootPanel > Grid#RootGrid > Grid#RootContent > Grid#MainContent > Grid#InnerContent > Grid#UndockedRoot", {
+        L"Width=320"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#AllAppsRoot", {
         L"Visibility=Visible",
         L"Width=320",
         L"Transform3D:=<CompositeTransform3D TranslateX=\"-1060\" />"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootPanel > Grid#RootGrid > Grid#RootContent > Grid#MainContent > Grid#InnerContent > Grid#AllAppsRoot", {
+        L"Transform3D:=<CompositeTransform3D TranslateX=\"-833\" />",
+        L"HorizontalAlignment=Left"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#CloseAllAppsButton", {
         L"Visibility=1"}},
     ThemeTargetStyles{L"StartDocked.StartSizingFrame", {
         L"MinWidth=776",
         L"MaxWidth=776"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootPanel > Grid#RootGrid", {
+        L"Width=560"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootPanel > Grid#RootGrid > Grid#RootContent", {
+        L"MinWidth=560"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ShowMoreSuggestions", {
         L"Visibility=0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#ShowAllAppsButton", {
@@ -804,7 +898,7 @@ const Theme g_themeSideBySide2_variant_ClassicStartMenu = {{
         L"FlowDirection=0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ItemsStackPanel > Windows.UI.Xaml.Controls.ListViewItem", {
         L"FlowDirection=0"}},
-    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox", {
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootGrid > Grid#RootContent > Grid#MainContent > Grid#InnerContent > StartDocked.SearchBoxToggleButton#StartMenuSearchBox", {
         L"Margin=23,1,23,14"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock#NoSuggestionsWithoutSettingsLink", {
         L"Margin=11,0,48,0"}},
@@ -882,7 +976,8 @@ const Theme g_themeSideBySideMinimal = {{
     ThemeTargetStyles{L"StartDocked.UserTileView", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"StartMenu.PinnedList", {
-        L"MinHeight=504"}},
+        L"MinHeight=504",
+        L"MaxHeight=504"}},
     ThemeTargetStyles{L"StartMenu.ExpandedFolderList > Grid > Border", {
         L"Margin=-40,0,40,0",
         L"Width=325"}},
@@ -933,6 +1028,8 @@ const Theme g_themeSideBySideMinimal = {{
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"StartMenu.CategoryControl", {
         L"Margin=20,20,-20,-20"}},
+    ThemeTargetStyles{L"Grid#MainMenu > Grid#MainContent > Grid", {
+        L"Canvas.ZIndex=1"}},
 }};
 
 const Theme g_themeSideBySideMinimal_variant_ClassicStartMenu = {{
@@ -944,6 +1041,8 @@ const Theme g_themeSideBySideMinimal_variant_ClassicStartMenu = {{
         L"Visibility=Visible",
         L"Width=320",
         L"Margin=-830,-42,830,0"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootPanel > Grid#RootGrid > Grid#RootContent > Grid#MainContent > Grid#InnerContent > Grid#AllAppsRoot", {
+        L"Margin=-1046,-42,1046,0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ShowMoreSuggestions", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#SuggestionsParentContainer", {
@@ -985,11 +1084,13 @@ const Theme g_themeDown_Aero = {{
         L"MaxHeight=520"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#TopLevelSuggestionsListHeader", {
         L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Grid#ShowMoreSuggestions", {
+        L"Visibility=Visible"}},
     ThemeTargetStyles{L"Button#ShowMoreSuggestionsButton", {
         L"Margin=0,-77,147,0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#NoTopLevelSuggestionsText", {
         L"Height=0"}},
-    ThemeTargetStyles{L" Button#ShowMoreSuggestionsButton > Grid > ContentPresenter > StackPanel > TextBlock", {
+    ThemeTargetStyles{L"Button#ShowMoreSuggestionsButton > Grid > ContentPresenter > StackPanel > TextBlock", {
         L"Text=Recommended",
         L"Visibility=Visible"}},
     ThemeTargetStyles{L"Border#StartDropShadow", {
@@ -1008,7 +1109,7 @@ const Theme g_themeDown_Aero = {{
         L"Margin=0,-65,0,0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#AllAppsRoot", {
         L"Margin=0,-90,0,90"}},
-    ThemeTargetStyles{L"Grid#MainContent ", {
+    ThemeTargetStyles{L"Grid#MainContent", {
         L"Grid.Row=0",
         L"VerticalAlignment=0",
         L"MinHeight=Auto"}},
@@ -1026,7 +1127,7 @@ const Theme g_themeDown_Aero = {{
     ThemeTargetStyles{L"StartDocked.NavigationPaneButton#UserTileButton > Grid > Border#BackgroundBorder", {
         L"Background:=<AcrylicBrush TintColor=\"{ThemeResource CardStrokeColorDefaultSolid}\" FallbackColor=\"{ThemeResource CardStrokeColorDefaultSolid}\" TintOpacity=\"0\" TintLuminosityOpacity=\".5\" Opacity=\"1\"/>",
         L"CornerRadius=18"}},
-    ThemeTargetStyles{L"Grid#TopLevelHeader > Grid > Button[AutomationProperties.Name=Show all] > Grid@CommonStates  > Border", {
+    ThemeTargetStyles{L"Grid#TopLevelHeader > Grid > Button[AutomationProperties.Name=Show all] > Grid@CommonStates > Border", {
         L"Background@Normal:=<SolidColorBrush Color=\"{ThemeResource SystemChromeAltHighColor}\" Opacity=\".8\"/>",
         L"Background@PointerOver:=<SolidColorBrush Color=\"{ThemeResource SystemBaseLowColor}\" Opacity=\"1\" />",
         L"Padding=10,7",
@@ -1046,7 +1147,7 @@ const Theme g_themeDown_Aero = {{
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#HideMoreSuggestionsButton", {
         L"Background:=<SolidColorBrush Color=\"{ThemeResource SystemChromeMediumLowColor}\" Opacity=\"1\"/>",
         L"CornerRadius=15"}},
-    ThemeTargetStyles{L"StartDocked.NavigationPaneView > Windows.UI.Xaml.Controls.Grid#RootPanel ", {
+    ThemeTargetStyles{L"StartDocked.NavigationPaneView > Windows.UI.Xaml.Controls.Grid#RootPanel", {
         L"Grid.Row=2"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Frame", {
         L"Margin=0,-65,0,0"}},
@@ -1058,7 +1159,7 @@ const Theme g_themeDown_Aero = {{
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridView#AllAppsGrid > Border > Windows.UI.Xaml.Controls.ScrollViewer > Border > Grid > Windows.UI.Xaml.Controls.ScrollContentPresenter > Windows.UI.Xaml.Controls.ItemsPresenter > Windows.UI.Xaml.Controls.ItemsWrapGrid", {
         L"Margin=45,-180,45,0"}},
-    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton > Grid@CommonStates ", {
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton > Grid@CommonStates", {
         L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SystemChromeAltHighColor}\" Opacity=\".8\"/>",
         L"Background:=<SolidColorBrush Color=\"{ThemeResource SystemAltMediumLowColor}\" Opacity=\"1\" />",
         L"BorderThickness=0,2,2,2",
@@ -1067,8 +1168,7 @@ const Theme g_themeDown_Aero = {{
         L"BorderBrush@PointerOver:=<SolidColorBrush Color=\"{ThemeResource SystemBaseLowColor}\" Opacity=\"1\"/>",
         L"Background@PointerOver:=<SolidColorBrush Color=\"{ThemeResource SystemBaseLowColor}\" Opacity=\".7\" />"}},
     ThemeTargetStyles{L"StartMenu.PinnedList", {
-        L"Margin=0,20,-40,180",
-        L"Height=168"}},
+        L"Margin=0,20,-40,180"}},
     ThemeTargetStyles{L"Grid#TopLevelSuggestionsRoot", {
         L"Grid.Row=1"}},
     ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton", {
@@ -1122,9 +1222,17 @@ const Theme g_themeDown_Aero_variant_ClassicStartMenu = {{
         L"CornerRadius=30"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#StartDropShadow", {
         L"CornerRadius=30"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#RootGridDropShadow", {
+        L"CornerRadius=30"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#RightCompanionDropShadow", {
+        L"CornerRadius=30"}},
     ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootGrid > Grid#RootContent > Grid#MainContent > Grid#InnerContent > Rectangle", {
         L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootPanel > Grid#RootGrid > Grid#RootContent > Grid#MainContent > Grid#InnerContent", {
+        L"Margin=0"}},
     ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton", {
+        L"Height=0"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootGrid > Grid#RootContent > Grid#MainContent > Grid#InnerContent > StartDocked.SearchBoxToggleButton", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Border#AcrylicBorder", {
         L"CornerRadius=30",
@@ -1179,6 +1287,8 @@ const Theme g_themeDown_Aero_variant_ClassicStartMenu = {{
         L"Padding=10,6",
         L"Margin=0,0,-35,0",
         L"CornerRadius=15"}},
+    ThemeTargetStyles{L"StartDocked.StartMenuCompanion#RightCompanion > Grid#CompanionRoot > Grid#MainContent > Grid#AdaptiveCardContent", {
+        L"MaxHeight=350"}},
 }};
 
 const Theme g_themeWindows10 = {{
@@ -1280,7 +1390,7 @@ const Theme g_themeWindows10 = {{
         L"BorderThickness=1,2,1,0",
         L"Background@Pressed:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
         L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0\"/>"}},
-    ThemeTargetStyles{L"StartDocked.NavigationPaneButton#PowerButton > Grid@CommonStates ", {
+    ThemeTargetStyles{L"StartDocked.NavigationPaneButton#PowerButton > Grid@CommonStates", {
         L"BorderThickness=0,0,1,1",
         L"Margin=0.5,2.5,0.5,0",
         L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.8\"/>",
@@ -1294,9 +1404,9 @@ const Theme g_themeWindows10 = {{
         L"BorderBrush@Pressed:=<RevealBorderBrush Color=\"#22FFFFFF\" TargetTheme=\"1\" Opacity=\"1\"/>",
         L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0\"/>"}},
     ThemeTargetStyles{L"Cortana.UI.Views.TaskbarSearchPage > Grid > Grid", {
-        L"Margin=0,0,0,-12",
-        L"Width=750",
-        L"Height=750"}},
+        L"Width=880",
+        L"Height=886",
+        L"Margin=-60,-10,0,-28"}},
     ThemeTargetStyles{L"Border#AppBorder", {
         L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
         L"Width=750",
@@ -1318,7 +1428,7 @@ const Theme g_themeWindows10 = {{
         L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>"}},
     ThemeTargetStyles{L"Grid#MainContent", {
         L"Margin=0,-63,1,-63"}},
-    ThemeTargetStyles{L"Grid#TopLevelHeader > Grid[2] ", {
+    ThemeTargetStyles{L"Grid#TopLevelHeader > Grid[2]", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridView#AllAppsGrid", {
         L"Margin=10,0,-10,0"}},
@@ -1381,7 +1491,7 @@ const Theme g_themeWindows10 = {{
         L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
         L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
         L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0\"/>"}},
-    ThemeTargetStyles{L"StartMenu.CategoryControl ", {
+    ThemeTargetStyles{L"StartMenu.CategoryControl", {
         L"Margin=-12,-8,-12,-16",
         L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>"}},
     ThemeTargetStyles{L"Button#SeeAllButton", {
@@ -1400,10 +1510,10 @@ const Theme g_themeWindows10 = {{
     ThemeTargetStyles{L"Grid#CompanionRoot > Grid#MainContent > Border#AcrylicOverlay", {
         L"Margin=1,1,1,-62",
         L"BorderThickness=12,2,2,1"}},
-    ThemeTargetStyles{L"StartMenu.StartMenuCompanion ", {
+    ThemeTargetStyles{L"StartMenu.StartMenuCompanion", {
         L"Canvas.ZIndex=0",
         L"Margin=-10,0,0,0"}},
-    ThemeTargetStyles{L"Grid#RightCompanionContainerGrid ", {
+    ThemeTargetStyles{L"Grid#RightCompanionContainerGrid", {
         L"Margin=-8,0,0,0",
         L"Canvas.ZIndex=1"}},
     ThemeTargetStyles{L"AdaptiveCards.Rendering.Uwp.WholeItemsPanel > Grid > Border", {
@@ -1422,13 +1532,13 @@ const Theme g_themeWindows10 = {{
         L"MaxHeight=92"}},
     ThemeTargetStyles{L"Button#Header > Border > TextBlock", {
         L"Margin=-4,0,4,0"}},
-    ThemeTargetStyles{L"ItemsWrapGrid > ListViewItem > Grid@CommonStates ", {
+    ThemeTargetStyles{L"ItemsWrapGrid > ListViewItem > Grid@CommonStates", {
         L"BorderThickness=1",
         L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"#34FFFFFF\" TargetTheme=\"1\" Opacity=\"1\"/>",
         L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
         L"CornerRadius=5",
         L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0\"/>"}},
-    ThemeTargetStyles{L"ListViewItem > Grid#ContentBorder@CommonStates ", {
+    ThemeTargetStyles{L"ListViewItem > Grid#ContentBorder@CommonStates", {
         L"BorderThickness=1",
         L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"#34FFFFFF\" TargetTheme=\"1\" Opacity=\"1\"/>",
         L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
@@ -1644,8 +1754,7 @@ const Theme g_themeWindows10_variant_Minimal = {{
     ThemeTargetStyles{L"Grid#FrameRoot", {
         L"Height=754",
         L"Margin=-3,0,220,-4",
-        L"Padding=0",
-        L"BorderThickness=2"}},
+        L"Padding=0"}},
     ThemeTargetStyles{L"Grid#MainMenu > Windows.UI.Xaml.Controls.Border#AcrylicBorder", {
         L"Margin=0",
         L"BorderThickness=42,2,0,0",
@@ -1700,8 +1809,8 @@ const Theme g_themeWindows10_variant_Minimal = {{
     ThemeTargetStyles{L"StartMenu.PinnedList#StartMenuPinnedList", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ScrollBar", {
-        L"Margin=0,-8,28,0",
-        L"Height=745"}},
+        L"Margin=0,0,34,0",
+        L"Height=740"}},
     ThemeTargetStyles{L"MenuFlyoutSeparator", {
         L"Margin=0,-2,0,-2",
         L"Padding=4"}},
@@ -1712,13 +1821,13 @@ const Theme g_themeWindows10_variant_Minimal = {{
     ThemeTargetStyles{L"MenuFlyoutPresenter > Border > ScrollViewer", {
         L"CornerRadius=8",
         L"Padding=-3,0,-1,0"}},
-    ThemeTargetStyles{L"StartMenu.ExpandedFolderList > Grid > Border", {
+    ThemeTargetStyles{L"StartMenu.FolderModal", {
         L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.8\"/>",
-        L"Margin=-145,0,145,0",
-        L"Width=312"}},
-    ThemeTargetStyles{L"StartMenu.ExpandedFolderList > Grid > Grid", {
+        L"Margin=-102,0,102,0",
+        L"MinWidth=300"}},
+    ThemeTargetStyles{L"StartMenu.FolderModal > Grid > Border", {
         L"CornerRadius=8",
-        L"Width=350"}},
+        L"Width=330"}},
     ThemeTargetStyles{L"Border#UninstallFlyoutPresenterBorder", {
         L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.8\"/>"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ContentDialog", {
@@ -1758,9 +1867,9 @@ const Theme g_themeWindows10_variant_Minimal = {{
         L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
         L"CornerRadius=4"}},
     ThemeTargetStyles{L"Cortana.UI.Views.TaskbarSearchPage > Grid > Grid", {
-        L"Width=650",
-        L"Height=750",
-        L"Margin=0,8,0,0"}},
+        L"Width=690",
+        L"Height=886",
+        L"Margin=-20,-10,0,-24"}},
     ThemeTargetStyles{L"Border#AppBorder", {
         L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>"}},
     ThemeTargetStyles{L"Grid#QueryFormulationRoot", {
@@ -1778,20 +1887,20 @@ const Theme g_themeWindows10_variant_Minimal = {{
         L"CornerRadius=8"}},
     ThemeTargetStyles{L"Grid#MainContent", {
         L"Margin=0,-63,1,-63"}},
-    ThemeTargetStyles{L"Grid#TopLevelHeader > Grid[2] ", {
+    ThemeTargetStyles{L"Grid#TopLevelHeader > Grid[2]", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridView#AllAppsGrid", {
         L"Width=420",
-        L"HorizontalAlignment=1"}},
+        L"HorizontalAlignment=0"}},
     ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton", {
-        L"Margin=-375,50,374,-50",
+        L"Margin=-382,50,381,-50",
         L"Width=32",
         L"Padding=0,4,0,4",
         L"Style:=<StaticResource ResourceKey=\"ButtonRevealStyle\"/>"}},
     ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton", {
-        L"Margin=-593,92,593-92",
+        L"Margin=-567,92,567-92",
         L"Style:=<StaticResource ResourceKey=\"ButtonRevealStyle\"/>",
         L"Width=32"}},
     ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton > Grid > Windows.UI.Xaml.Controls.ContentPresenter > TextBlock", {
@@ -1829,7 +1938,7 @@ const Theme g_themeWindows10_variant_Minimal = {{
     ThemeTargetStyles{L"StartMenu.StartMenuCompanion", {
         L"Margin=-10,-1,0,0"}},
     ThemeTargetStyles{L"AdaptiveCards.Rendering.Uwp.WholeItemsPanel > Grid > Border", {
-        L"Margin=25,0,0,0"}},
+        L"RenderTransform:=<TranslateTransform X=\"25\"/>"}},
     ThemeTargetStyles{L"Border#Root > Grid > ScrollContentPresenter > AdaptiveCards.Rendering.Uwp.WholeItemsPanel > Border > AdaptiveCards.Rendering.Uwp.WholeItemsPanel > Grid > Border > AdaptiveCards.Rendering.Uwp.WholeItemsPanel > TextBlock", {
         L"Margin=36,0,0,0",
         L"Text=Recent",
@@ -1837,7 +1946,7 @@ const Theme g_themeWindows10_variant_Minimal = {{
         L"Text=Recent Phone Activity"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock[Text=View your recent calls, messages, photos, and more.]", {
         L"TextAlignment=0"}},
-    ThemeTargetStyles{L"Border > AdaptiveCards.Rendering.Uwp.WholeItemsPanel > Border > AdaptiveCards.Rendering.Uwp.WholeItemsPanel > Border", {
+    ThemeTargetStyles{L"Button > Grid#RootGrid > Windows.UI.Xaml.Controls.ContentPresenter > Border > AdaptiveCards.Rendering.Uwp.WholeItemsPanel > Border > AdaptiveCards.Rendering.Uwp.WholeItemsPanel > Border", {
         L"Margin=40,0,0,0"}},
     ThemeTargetStyles{L"AdaptiveCards.Rendering.Uwp.WholeItemsPanel > Grid > Windows.UI.Xaml.Controls.Image", {
         L"MaxWidth=52",
@@ -1880,15 +1989,16 @@ const Theme g_themeWindows10_variant_Minimal = {{
     ThemeTargetStyles{L"StartMenu.CategoryControl", {
         L"Margin=-20,-8,-20,-16",
         L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
-        L"RenderTransform:=<TranslateTransform X=\"16\"  />"}},
+        L"RenderTransform:=<TranslateTransform X=\"16\"/>"}},
     ThemeTargetStyles{L"Grid#MainMenu > Grid#MainContent > Grid", {
-        L"Canvas.ZIndex=1",
-        L"Margin=0,-4,0,4"}},
+        L"Canvas.ZIndex=1"}},
     ThemeTargetStyles{L"Button#SeeAllButton > Grid@CommonStates", {
         L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
         L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
         L"CornerRadius=5",
         L"BorderThickness=1"}},
+    ThemeTargetStyles{L"Border#dropshadow", {
+        L"Visibility=Collapsed"}},
 }};
 
 const Theme g_themeWindows10_variant_Minimal_ClassicStartMenu = {{
@@ -2080,7 +2190,7 @@ const Theme g_themeWindows11_Metro10 = {{
     ThemeTargetStyles{L"GridView#AllAppsGrid > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid", {
         L"Visibility=Visible",
         L"Width=300",
-        L"Margin=-150,-632,150,0"}},
+        L"Margin=-150,-600,150,0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#CloseAllAppsButton", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Grid#MainMenu", {
@@ -2150,7 +2260,7 @@ const Theme g_themeWindows11_Metro10 = {{
         L"Margin=165,0,-165,0",
         L"Width=300"}},
     ThemeTargetStyles{L"Grid#AllListHeading", {
-        L"RenderTransform:=<TranslateTransform X=\"-325\" Y=\"-636\"/>"}},
+        L"RenderTransform:=<TranslateTransform X=\"-334\" Y=\"-604\"/>"}},
     ThemeTargetStyles{L"Grid#TopLevelSuggestionsListHeader", {
         L"RenderTransform:=<TranslateTransform X=\"252\" Y=\"-58\" />"}},
     ThemeTargetStyles{L"Grid#TopLevelHeader > Grid > TextBlock", {
@@ -2177,13 +2287,13 @@ const Theme g_themeWindows11_Metro10 = {{
         L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.3\"/>",
         L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.3\"/>",
         L"BorderThickness=1"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ListViewItem > Grid#ContentBorder@CommonStates ", {
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ListViewItem > Grid#ContentBorder@CommonStates", {
         L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.3\"/>",
         L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.3\"/>",
         L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.7\"/>",
         L"BorderThickness=1",
         L"CornerRadius=5"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#ContentBorder > Windows.UI.Xaml.Controls.Grid#DroppedFlickerWorkaroundWrapper  > Border#HighContrastBorder", {
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#ContentBorder > Windows.UI.Xaml.Controls.Grid#DroppedFlickerWorkaroundWrapper > Border#HighContrastBorder", {
         L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.3\"/>",
         L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.7\"/>",
         L"BorderThickness=1"}},
@@ -2213,8 +2323,12 @@ const Theme g_themeWindows11_Metro10 = {{
         L"Height=57",
         L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
         L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>"}},
-    ThemeTargetStyles{L"Button#FolderPlate ", {
+    ThemeTargetStyles{L"Button#FolderPlate", {
         L"Margin=4,-1,-4,0"}},
+    ThemeTargetStyles{L"Grid#MainMenu > Grid#MainContent > Grid", {
+        L"Canvas.ZIndex=1"}},
+    ThemeTargetStyles{L"Grid#TopLevelSuggestionsRoot", {
+        L"MinHeight=129"}},
 }};
 
 const Theme g_themeWindows11_Metro10_variant_ClassicStartMenu = {{
@@ -2487,7 +2601,7 @@ const Theme g_themeFluent2Inspired = {{
         L"Margin=0,0,-1,0"}},
     ThemeTargetStyles{L"Rectangle#TextCaret", {
         L"Visibility=Collapsed"}},
-    ThemeTargetStyles{L"Grid#RootGrid@SearchBoxLocationStates ", {
+    ThemeTargetStyles{L"Grid#RootGrid@SearchBoxLocationStates", {
         L"Margin@SearchBoxOnBottomWithoutQFMargin=-32,10,32,-10"}},
     ThemeTargetStyles{L"Grid#RootGrid@SearchBoxLocationStates > Cortana.UI.Views.CortanaRichSearchBox > Grid > TextBlock#PlaceholderTextContentPresenter", {
         L"FontSize=16"}},
@@ -2993,6 +3107,8 @@ const Theme g_themeWindows11_Metro10Minimal = {{
     ThemeTargetStyles{L"StartMenu.CategoryControl", {
         L"Margin=-15,0-15,0",
         L"RenderTransform:=<TranslateTransform X=\"24\" />"}},
+    ThemeTargetStyles{L"Grid#MainMenu > Grid#MainContent > Grid", {
+        L"Canvas.ZIndex=1"}},
 }};
 
 const Theme g_themeWindows11_Metro10Minimal_variant_ClassicStartMenu = {{
@@ -3183,21 +3299,215 @@ const Theme g_themeEverblush_variant_ClassicStartMenu = {{
         L"Foreground=#232a2d"}},
 }};
 
+const Theme g_themeSunValley = {{
+    ThemeTargetStyles{L"Cortana.UI.Views.TaskbarSearchPage", {
+        L"Margin=-2,0,0,0"}},
+    ThemeTargetStyles{L"Border#TaskbarMargin", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Border#TaskbarSearchBackground", {
+        L"Grid.Row=3",
+        L"Margin=0,0,0,2",
+        L"Background:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeAltHighColor}\" TintOpacity=\"0.6\" TintLuminosityOpacity=\"0.6\" FallbackColor=\"{ThemeResource SystemChromeMediumColor}\" />",
+        L"Height=44",
+        L"VerticalAlignment=2",
+        L"CornerRadius=0,0,7,7",
+        L"BorderThickness=0,0,1,1"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichSearchBoxControl#SearchBoxControl", {
+        L"Margin=0,0,0,2",
+        L"Grid.Row=3",
+        L"Height=44",
+        L"VerticalAlignment=2",
+        L"HorizontalAlignment=0",
+        L"Width=340"}},
+    ThemeTargetStyles{L"ScrollViewer > ScrollContentPresenter > Border", {
+        L"Margin=0,0,0,0"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichSearchBoxControl#SearchBoxControl > Grid@SearchBoxStates", {
+        L"Background:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeMediumHighColor}\" TintOpacity=\"0\" TintLuminosityOpacity=\"1\" FallbackColor=\"{ThemeResource SystemChromeMediumColor}\" />",
+        L"BorderThickness=1",
+        L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SystemBaseHighColor}\" Opacity=\"0.2\" />",
+        L"CornerRadius=4"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.AnimatedIcon#SearchIconPlayer", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Button#SearchGlyphContainer", {
+        L"Visibility=Visible",
+        L"Width=35",
+        L"Margin=2,0,-11,0"}},
+    ThemeTargetStyles{L"Button#SearchGlyphContainer > Grid > ContentPresenter > FontIcon", {
+        L"FontFamily=Segoe Fluent Icons",
+        L"FontSize=17",
+        L"Foreground:=<SolidColorBrush Color=\"{ThemeResource SystemBaseHighColor}\" Opacity=\"0.8\" />"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.CortanaRichSearchBox#SearchTextBox > Grid > TextBlock#PlaceholderTextContentPresenter", {
+        L"Text=Type here to search",
+        L"FontFamily=Segoe UI",
+        L"FontSize=15",
+        L"Padding=39,0,0,0",
+        L"Foreground:=<SolidColorBrush Color=\"{ThemeResource SystemBaseHighColor}\" Opacity=\"0.8\" />"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.CortanaRichSearchBox#SearchTextBox > Grid > ScrollViewer > Border > Grid > ScrollContentPresenter", {
+        L"Margin=38,0,0,0",
+        L"FontSize=15"}},
+    ThemeTargetStyles{L"Grid#SearchBoxOnTaskbarGleamContainer > Grid", {
+        L"Margin=0,0,-3,0",
+        L"CornerRadius=4"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.TaskbarSearchPage > Grid#RootGrid > Grid#OuterBorderGrid > Grid#BorderGrid > Border", {
+        L"CornerRadius=7,7,0,0"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.TaskbarSearchPage > Grid#RootGrid > Grid#OuterBorderGrid > Grid#BorderGrid > Border#AppBorder", {
+        L"Background:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeAltHighColor}\" TintOpacity=\"0.4\" TintLuminosityOpacity=\"0.4\" FallbackColor=\"{ThemeResource SystemChromeMediumColor}\" />",
+        L"Visibility=Visible",
+        L"BorderThickness=1,1,1,0"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.TaskbarSearchPage > Grid#RootGrid > Grid#OuterBorderGrid > Grid#BorderGrid > Border#dropshadow", {
+        L"Opacity=0"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichSearchBoxControl#SearchBoxControl > Grid > Grid#UnderlineContainer", {
+        L"Visibility=0",
+        L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SystemAccentColor}\" />",
+        L"BorderThickness=0,0,0,2",
+        L"CornerRadius=5",
+        L"Margin=-3,0,-3,0"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton > Grid > ContentPresenter > TextBlock#PlaceholderText", {
+        L"Margin=28,0,0,0",
+        L"Text=Type here to search"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox > Grid > Border#BorderElement", {
+        L"BorderThickness=0,0,0,2",
+        L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight1}\" />"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox > Grid > FontIcon#SearchGlyph", {
+        L"Foreground:=<SolidColorBrush Color=\"{ThemeResource SystemBaseHighColor}\" Opacity=\"0.5\" />",
+        L"Margin=13,0,-13,1",
+        L"Visibility=Visible"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox > Grid", {
+        L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SystemBaseHighColor}\" Opacity=\"0.1\" />",
+        L"CornerRadius=4",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton", {
+        L"CornerRadius=4",
+        L"Height=40"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#ShowAllAppsButton > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter > Windows.UI.Xaml.Controls.StackPanel > Windows.UI.Xaml.Controls.TextBlock#ShowAllAppsButtonText", {
+        L"Text=All apps"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock#AllAppsHeading", {
+        L"Text=All apps"}},
+    ThemeTargetStyles{L"Image#SearchIconOn", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Image#SearchIconOff", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton > Grid > Border", {
+        L"CornerRadius=0",
+        L"BorderThickness=0,0,0,2",
+        L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SystemAccentColor}\"/>",
+        L"Background:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"0\" TintLuminosityOpacity=\"0.7\" FallbackColor=\"{ThemeResource SystemChromeMediumColor}\" />"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock#AllListHeadingText", {
+        L"Text=All apps"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton > Grid@CommonStates", {
+        L"Background@Normal:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorDefault}\" />",
+        L"Background@PointerOver:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorSecondary}\" />",
+        L"Background@Pressed:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorTertiary}\" />",
+        L"BorderBrush:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeHighColor}\" FallbackColor=\"{ThemeResource SystemChromeMediumHighColor}\" TintOpacity=\"0\" />",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton > Grid > ContentPresenter > TextBlock#PlaceholderText", {
+        L"Text=Type here to search",
+        L"Margin=24,0,0,0",
+        L"Foreground:=<SolidColorBrush Color=\"{ThemeResource SystemBaseHighColor}\" Opacity=\"0.5\" />"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton", {
+        L"Height=40"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton > Grid > Rectangle#TextCaret", {
+        L"Margin=24,0,0,0"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton > Grid", {
+        L"BorderThickness=1",
+        L"BorderBrush:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeHighColor}\" FallbackColor=\"{ThemeResource SystemChromeMediumHighColor}\" TintOpacity=\"0\" />",
+        L"CornerRadius=4"}},
+    ThemeTargetStyles{L"Grid#TopLevelHeader > Grid > Button > Grid@CommonStates", {
+        L"BorderBrush:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeHighColor}\" FallbackColor=\"{ThemeResource SystemChromeMediumHighColor}\" TintOpacity=\"0\" />",
+        L"BorderThickness=1",
+        L"CornerRadius=5"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton#ShowHideCompanion > Border", {
+        L"BorderBrush:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeHighColor}\" FallbackColor=\"{ThemeResource SystemChromeMediumHighColor}\" TintOpacity=\"0\" />",
+        L"BorderThickness=1",
+        L"CornerRadius=5"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton#ShowHideCompanion > Border > ContentPresenter", {
+        L"Height=40",
+        L"Width=40"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton#ShowHideCompanion", {
+        L"Height=40",
+        L"Width=40"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton#ShowHideCompanion > Border > ContentPresenter > FontIcon > Grid > TextBlock", {
+        L"FontSize=20"}},
+    ThemeTargetStyles{L"Grid#TopLevelHeader > Grid > Button > Grid@CommonStates > Border#BackgroundBorder", {
+        L"Background@Normal:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorDefault}\" />",
+        L"Background@PointerOver:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorSecondary}\" />",
+        L"Background@Pressed:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorTertiary}\" />"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton > Grid > FontIcon#SearchGlyph", {
+        L"Visibility=Visible",
+        L"Foreground:=<SolidColorBrush Color=\"{ThemeResource SystemBaseHighColor}\" Opacity=\"0.5\" />",
+        L"Margin=13,0,-13,1"}},
+    ThemeTargetStyles{L"Grid#AnimationRoot > Grid#MainMenu > Windows.UI.Xaml.Controls.Border#AcrylicBorder", {
+        L"Opacity=0.5"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#MainContent", {
+        L"Background:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeAltHighColor}\" TintOpacity=\"0.4\" TintLuminosityOpacity=\"0.4\" FallbackColor=\"{ThemeResource SystemChromeMediumColor}\" />",
+        L"CornerRadius=7"}},
+    ThemeTargetStyles{L"Button#ShowMoreSuggestionsButton > Grid@CommonStates", {
+        L"BorderBrush:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeHighColor}\" FallbackColor=\"{ThemeResource SystemChromeMediumHighColor}\" TintOpacity=\"0\" />",
+        L"BorderThickness=1",
+        L"CornerRadius=5"}},
+    ThemeTargetStyles{L"Button#ShowMoreSuggestionsButton > Grid@CommonStates > Border#BackgroundBorder", {
+        L"Background@Normal:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorDefault}\" />",
+        L"Background@PointerOver:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorSecondary}\" />",
+        L"Background@Pressed:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorTertiary}\" />"}},
+    ThemeTargetStyles{L"Button#HideMoreSuggestionsButton > Grid@CommonStates", {
+        L"BorderBrush:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeHighColor}\" FallbackColor=\"{ThemeResource SystemChromeMediumHighColor}\" TintOpacity=\"0\" />",
+        L"BorderThickness=1",
+        L"CornerRadius=5"}},
+    ThemeTargetStyles{L"Button#HideMoreSuggestionsButton > Grid@CommonStates > Border#BackgroundBorder", {
+        L"Background@Normal:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorDefault}\" />",
+        L"Background@PointerOver:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorSecondary}\" />",
+        L"Background@Pressed:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorTertiary}\" />"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichComposerBoxControl > Grid > Cortana.UI.Views.CortanaRichSearchBox", {
+        L"CornerRadius=4",
+        L"Grid.Row=3",
+        L"Margin=-1,0,-1,0"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichComposerBoxControl > Grid", {
+        L"Transform3D:=<CompositeTransform3D TranslateY=\"60\" />",
+        L"Background:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"0\" TintLuminosityOpacity=\"0.7\" FallbackColor=\"{ThemeResource SystemChromeMediumColor}\" />",
+        L"BorderThickness=1",
+        L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SystemBaseHighColor}\" Opacity=\"0.2\" />",
+        L"Height=44",
+        L"CornerRadius=4"}},
+    ThemeTargetStyles{L"Grid#SearchBoxOnTaskbarGleamContainer > Grid > Image", {
+        L"Height=40"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichComposerBoxControl", {
+        L"Margin=-4,22,-4,0"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichComposerBoxControl > Grid > Grid#ComposerBoxOnTaskbarGleamContainer", {
+        L"Padding=12,6,6,6"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichComposerBoxControl > Grid > Cortana.UI.Views.CortanaRichSearchBox > Grid", {
+        L"BorderThickness=0,0,0,2",
+        L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SystemAccentColor}\" />",
+        L"CornerRadius=4"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichComposerBoxControl > Grid > Cortana.UI.Views.CortanaRichSearchBox > Grid > ScrollViewer", {
+        L"Margin=8,0,8,0"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichComposerBoxControl > Grid > Cortana.UI.Views.CortanaRichSearchBox > Grid > TextBlock", {
+        L"Margin=8,0,0,1",
+        L"Text=Ask me anything"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichComposerBoxControl > Grid > StackPanel", {
+        L"Margin=0,0,5,0"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichComposerBoxControl > Grid > StackPanel > Grid > Button > ContentPresenter", {
+        L"CornerRadius=6"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootGrid > Grid#RootContent > Border#AcrylicBorder", {
+        L"Opacity=0.5"}},
+}};
+
 const Theme g_theme21996 = {{
     ThemeTargetStyles{L"Border#TaskbarSearchBackground", {
         L"CornerRadius=4",
-        L"BorderThickness=0",
+        L"BorderThickness=0,0,0,0",
         L"Height=33",
         L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource ControlStrokeColorDefault}\"/>"}},
-    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton > Grid > ContentPresenter > TextBlock#PlaceholderText", {
-        L"Margin=0,0,0,2"}},
-    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#StartMenuSearchBox > Grid > Border#BorderElement", {
-        L"BorderThickness=0,0,0,2",
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton > Grid > ContentPresenter > TextBlock#PlaceholderText", {
+        L"Margin=28,0,0,2",
+        L"Text=Type here to search"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox > Grid > Border#BorderElement", {
+        L"BorderThickness=2",
         L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight1}\"/>"}},
-    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton > Grid > FontIcon > Grid > TextBlock", {
+    ThemeTargetStyles{L"FontIcon#SearchGlyph", {
         L"Foreground:=<SolidColorBrush Color=\"gray\" />",
-        L"Margin=0,0,0,1",
-        L"Transform3D:=<CompositeTransform3D RotationY=\"180\" TranslateX=\"16\" />"}},
+        L"Margin=13,0,-13,1",
+        L"Transform3D:=<CompositeTransform3D RotationY=\"180\" TranslateX=\"16\" />",
+        L"Visibility=Visible"}},
     ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.AnimatedIcon#SearchIconPlayer", {
         L"Visibility=1",
         L"FlowDirection=1",
@@ -3210,7 +3520,7 @@ const Theme g_theme21996 = {{
         L"RequestedTheme=1",
         L"Transform3D:=<CompositeTransform3D RotationY=\"180\" TranslateX=\"23\" TranslateY=\"0.5\" />",
         L"FontSize=17"}},
-    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#StartMenuSearchBox > Grid", {
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox > Grid", {
         L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource ControlStrokeColorDefault}\"/>",
         L"BorderThickness=1,1,1,0",
         L"CornerRadius=4"}},
@@ -3219,7 +3529,7 @@ const Theme g_theme21996 = {{
         L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight1}\" />",
         L"BorderThickness=2,2,2,2",
         L"Margin=-2,-0,0,-2"}},
-    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton", {
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton", {
         L"CornerRadius=4",
         L"Height=40"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#SearchBoxOnTaskbarGleamContainer", {
@@ -3231,10 +3541,17 @@ const Theme g_theme21996 = {{
         L"Transform3D:=<CompositeTransform3D RotationY=\"180\" TranslateX=\"16\" TranslateY=\"-1\" />"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Image#SearchIconOn", {
         L"Transform3D:=<CompositeTransform3D RotationY=\"180\" TranslateX=\"16\" TranslateY=\"-1\" />"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock#AllListHeadingText", {
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#ShowAllAppsButton > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter > Windows.UI.Xaml.Controls.StackPanel > Windows.UI.Xaml.Controls.TextBlock#ShowAllAppsButtonText", {
         L"Text=All apps"}},
-    ThemeTargetStyles{L"Grid#FrameRoot", {
-        L"MaxHeight=650"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock#AllAppsHeading", {
+        L"Text=All apps"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton", {
+        L"Height=0",
+        L"Margin=0,0,0,32"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame", {
+        L"Height=670"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#InnerContent", {
+        L"Margin=0,0,0,0"}},
     ThemeTargetStyles{L"Cortana.UI.Views.HostedWebViewControl#QueryFormulationHostedWebView", {
         L"Background:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"1\" TintLuminosityOpacity=\"1\" FallbackColor=\"{ThemeResource SystemChromeLowColor}\" />"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#QueryFormulationRoot", {
@@ -3246,31 +3563,34 @@ const Theme g_theme21996 = {{
         L"CornerRadius=7"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#AppBorder", {
         L"Background:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"0\" TintLuminosityOpacity=\"0.7\" FallbackColor=\"{ThemeResource SystemChromeLowColor}\" />"}},
-    ThemeTargetStyles{L"Grid#MainMenu", {
-        L"Width=650"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Frame", {
-        L"Margin=0,-70,0,0"}},
-    ThemeTargetStyles{L"Border#AcrylicOverlay", {
-        L"Margin=0,-70,0,0"}},
-    ThemeTargetStyles{L"Grid#MainContent > Grid > StartMenu.SearchBoxToggleButton", {
+    ThemeTargetStyles{L"Border#FullBleedBackground", {
+        L"Background:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"0.76\" TintLuminosityOpacity=\"0.77\" FallbackColor=\"{ThemeResource SystemChromeLowColor}\" />"}},
+    ThemeTargetStyles{L"Image#SearchIconOn", {
         L"Visibility=Collapsed"}},
-    ThemeTargetStyles{L"GridView#AllAppsGrid", {
-        L"Margin=0,10,0,0"}},
-    ThemeTargetStyles{L"Grid#MainMenu > Grid#MainContent > Grid", {
-        L"Canvas.ZIndex=1"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton", {
-        L"Margin=5,10,-5,-10",
-        L"Style:=",
-        L"Background:=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#15000000\"/>",
-        L"Width=32",
-        L"Height=32",
-        L"Padding=0",
-        L"Margin=0,1,-12,0"}},
-    ThemeTargetStyles{L"StartMenu.StartHome", {
-        L"Margin=0,-10,0,0"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ScrollBar", {
-        L"Height=550",
-        L"Margin=0,2,0,-2"}},
+    ThemeTargetStyles{L"Image#SearchIconOff", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton > Grid > Border", {
+        L"CornerRadius=3",
+        L"BorderThickness=2",
+        L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SystemAccentColor}\"/>",
+        L"Background:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeMediumHighColor}\" TintOpacity=\"0\" TintLuminosityOpacity=\"0.7\" FallbackColor=\"{ThemeResource SystemChromeMediumColor}\" />"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock#AllListHeadingText", {
+        L"Text=All apps"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton > Grid@CommonStates", {
+        L"Background@Normal:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeMediumHighColor}\" FallbackColor=\"{ThemeResource SystemChromeMediumHighColor}\" TintOpacity=\"0\" TintLuminosityOpacity=\"1\" />",
+        L"BorderBrush:=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeHighColor}\" FallbackColor=\"{ThemeResource SystemChromeMediumHighColor}\" TintOpacity=\"0\" />",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton > Grid > ContentPresenter > TextBlock#PlaceholderText", {
+        L"Text=Type here to search",
+        L"Margin=24,0,0,0"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton", {
+        L"Height=40"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton > Grid > Rectangle#TextCaret", {
+        L"Margin=24,0,0,0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock#PlaceholderTextContentPresenter", {
+        L"Text=Type here to search",
+        L"Width=750",
+        L"TextAlignment=Left"}},
 }};
 
 const Theme g_theme21996_variant_ClassicStartMenu = {{
@@ -3348,13 +3668,8 @@ const Theme g_theme21996_variant_ClassicStartMenu = {{
 const Theme g_themeUniMenu = {{
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#NoTopLevelSuggestionsText", {
         L"Visibility=Collapsed"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#TopLevelSuggestionsListHeader", {
-        L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Grid#MoreSuggestionsRoot > Grid", {
         L"RenderTransform:=<TranslateTransform Y=\"24\" />"}},
-    ThemeTargetStyles{L"Grid#TopLevelSuggestionsRoot", {
-        L"Height=42",
-        L"Grid.Row=0"}},
     ThemeTargetStyles{L"StartDocked.UserTileView", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"StartDocked.AppListView", {
@@ -3381,7 +3696,7 @@ const Theme g_themeUniMenu = {{
         L"Canvas.ZIndex=99"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridView#PinnedList > Windows.UI.Xaml.Controls.Border > Windows.UI.Xaml.Controls.ScrollViewer > Windows.UI.Xaml.Controls.Border > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.ScrollContentPresenter > Windows.UI.Xaml.Controls.ItemsPresenter > Windows.UI.Xaml.Controls.ItemsWrapGrid > Windows.UI.Xaml.Controls.GridViewItem", {
         L"Margin=5,0,0,0",
-        L"Padding=-1,-4"}},
+        L"Padding=-1,0"}},
     ThemeTargetStyles{L"StartMenu.PinnedList > Grid#Root", {
         L"Padding=0"}},
     ThemeTargetStyles{L"TextBlock#PinnedListHeaderText", {
@@ -3429,7 +3744,7 @@ const Theme g_themeUniMenu = {{
     ThemeTargetStyles{L"Grid#TopLevelHeader > Grid[2] > Button", {
         L"Width=40",
         L"Height=40",
-        L"Margin=-79,-6,79,6"}},
+        L"Margin=-73,-6,73,6"}},
     ThemeTargetStyles{L"TextBlock#ShowMorePinnedButtonText", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.FontIcon[Glyph=\uE70D]", {
@@ -3439,7 +3754,7 @@ const Theme g_themeUniMenu = {{
     ThemeTargetStyles{L"Grid#FrameRoot", {
         L"Margin=0,-58,0,0"}},
     ThemeTargetStyles{L"StartMenu.StartHome", {
-        L"Margin=0,57,0,-52"}},
+        L"Margin=0,-17,0,-52"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton", {
         L"Height=40",
         L"Width=40"}},
@@ -3461,7 +3776,7 @@ const Theme g_themeUniMenu = {{
         L"Background=Transparent",
         L"BorderBrush:=<AcrylicBrush TintColor=\"{ThemeResource CardStrokeColorDefaultSolid}\" FallbackColor=\"{ThemeResource CardStrokeColorDefaultSolid}\" TintOpacity=\"0\" TintLuminosityOpacity=\".65\" Opacity=\"1\"/>",
         L"Padding=-1.5,-1.5,-1.5,-6"}},
-    ThemeTargetStyles{L"StartMenu.StartMenuCompanion#RightCompanion > Grid ", {
+    ThemeTargetStyles{L"StartMenu.StartMenuCompanion#RightCompanion > Grid", {
         L"Margin=0"}},
     ThemeTargetStyles{L"Grid#CompanionRoot > Grid#MainContent > Border#AcrylicOverlay", {
         L"Margin=0,-64,0,-58",
@@ -3607,6 +3922,10 @@ const Theme g_themeUniMenu_variant_ClassicStartMenu = {{
     ThemeTargetStyles{L"Border#DropShadow", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Border#StartDropShadow", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Border#RootGridDropShadow", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Border#RightCompanionDropShadow", {
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Cortana.UI.Views.TaskbarSearchPage", {
         L"Margin=5,0,0,8"}},
@@ -3828,7 +4147,7 @@ const Theme g_themeLegacyFluent = {{
         L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Grid#TopLevelSuggestionsRoot", {
         L"Margin=0,0,0,-190"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#ShowMoreSuggestionsButton ", {
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#ShowMoreSuggestionsButton", {
         L"Style:=<Style x:Key=\"RevealButtonStyle\" TargetType=\"Button\" />"}},
     ThemeTargetStyles{L"Button#CloseStartAccessibleButton", {
         L"Visibility=Collapsed"}},
@@ -4072,6 +4391,10 @@ const Theme g_themeOnlySearch = {{
         L"MinHeight=100"}},
     ThemeTargetStyles{L"Border#AcrylicOverlay", {
         L"Height=3"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton#ShowHideCompanion", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Grid#RightCompanionContainerGrid", {
+        L"Visibility=Collapsed"}},
 }};
 
 const Theme g_themeOnlySearch_variant_ClassicStartMenu = {{
@@ -4084,59 +4407,18 @@ const Theme g_themeOnlySearch_variant_ClassicStartMenu = {{
 }};
 
 const Theme g_themeWindowGlass = {{
-    ThemeTargetStyles{L"Border#AcrylicOverlay", {
-        L"Margin=0",
-        L"BorderThickness=0",
-        L"CornerRadius=10",
-        L"Visibility=Collapsed"}},
-    ThemeTargetStyles{L"Border#AcrylicBorder", {
-        L"Background:=$Background",
-        L"CornerRadius=$CornerRadius",
-        L"BorderThickness=$BorderThickness",
-        L"BorderBrush:=$BorderBrush"}},
-    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton", {
-        L"Visibility=Visible",
-        L"Width=340",
-        L"Height=50",
-        L"RenderTransform:=<TranslateTransform X=\"-185\" Y=\"35\"/>",
-        L"Margin=0,-30,0,-50"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#AppBorder", {
-        L"Background:=$Background",
-        L"BorderBrush:=$BorderBrush",
-        L"BorderThickness=$BorderThickness"}},
-    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.Border#BorderElement", {
-        L"BorderThickness=$BorderThickness",
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#AppBorder", {
-        L"Background:=$Background",
-        L"BorderBrush:=$BorderBrush",
-        L"BorderThickness=$BorderThickness",
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Cortana.UI.Views.RichSearchBoxControl#SearchBoxControl", {
-        L"Width=500",
-        L"RenderTransform:=<TranslateTransform X=\"-120\" />"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#BorderElement", {
-        L"Background=Transparent",
-        L"BorderThickness=$BorderThickness"}},
-    ThemeTargetStyles{L"StartMenu.CategoryControl > Windows.UI.Xaml.Controls.Grid#RootGrid > Windows.UI.Xaml.Controls.Border ", {
-        L"BorderThickness=$ElementBorderThickness",
-        L"CornerRadius=$ElementCornerRadius",
-        L"BorderBrush:=$ElementBorderBrush",
-        L"Background:=$ElementBG"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#BorderUnderline", {
-        L"Visibility=Visible"}},
     ThemeTargetStyles{L"StackPanel#TimeAndDatePanel", {
         L"VerticalAlignment=Top",
         L"HorizontalAlignment=Center",
         L"RenderTransform:=<TranslateTransform X=\"0\" />"}},
     ThemeTargetStyles{L"StackPanel#TimePanel > TextBlock#Time", {
-        L"HorizontalAlignment=Center",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"50\" />",
-        L"FontFamily=vivo Sans Clock Stencil Regular",
+        L"HorizontalAlignment:=Center",
+        L"RenderTransform:=<TransformGroup><TranslateTransform X=\"-30\" Y=\"-10\" /><ScaleTransform ScaleX=\"3.3\" ScaleY=\"6\" /></TransformGroup>",
+        L"FontFamily=Morganite SemiBold",
         L"Foreground:=$ClockBG"}},
     ThemeTargetStyles{L"StackPanel#TimeAndDatePanel > TextBlock#Date", {
         L"HorizontalAlignment=Center",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"-150\" />",
+        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"-110\" />",
         L"FontFamily=vivo Sans EN VF",
         L"Foreground:=$ClockBG"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#WidgetFrameGrid", {
@@ -4154,135 +4436,136 @@ const Theme g_themeWindowGlass = {{
         L"CornerRadius=$CornerRadius"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#MediaControlsContainer", {
         L"Visibility=Visible",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"-785\" />",
+        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"-250\" />",
         L"Margin=0,0,0,0",
         L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#BorderElement", {
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton#ShowHideCompanion", {
-        L"RenderTransform:=<TranslateTransform X=\"-120\" />",
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#RootPanel > Windows.UI.Xaml.Controls.Grid#RootGrid > Windows.UI.Xaml.Controls.Grid#RootContent", {
+        L"Margin=-20,-20,-20,0"}},
+    ThemeTargetStyles{L"StartDocked.StartSizingFrame", {
+        L"Width=860"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#RootGridDropShadow", {
         L"Visibility=1"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#CompanionRoot > Windows.UI.Xaml.Controls.Border#AcrylicOverlay", {
-        L"BorderThickness=0"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#Root > Windows.UI.Xaml.Controls.Border", {
-        L"BorderBrush:=$BorderBrush",
-        L"Background:=$Background",
-        L"BorderThickness=$BorderThickness",
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#StartDropShadow", {
-        L"CornerRadius=$CornerRadius"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#RightCompanionDropShadow", {
-        L"CornerRadius=$CornerRadius",
         L"Visibility=1"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#DroppedFlickerWorkaroundWrapper > Windows.UI.Xaml.Controls.Border#BackgroundBorder", {
-        L"Background@PointerOver:=$Background",
-        L"Background@Pressed:=$Background",
-        L"Background@Selected:=$Background"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#BackgroundBorder", {
-        L"CornerRadius=10"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ContentBorder", {
-        L"CornerRadius=10"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#LayerBorder", {
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#OuterBorderGrid", {
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.PopupRoot", {
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ContentPresenter#ZoomedInPresenter > Windows.UI.Xaml.Controls.GridView#AllAppsGrid > Windows.UI.Xaml.Controls.Border > Windows.UI.Xaml.Controls.ScrollViewer#ScrollViewer > Windows.UI.Xaml.Controls.Border#Root > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.ScrollContentPresenter#ScrollContentPresenter > Windows.UI.Xaml.Controls.ItemsPresenter > Windows.UI.Xaml.Controls.ItemsWrapGrid", {
-        L"MaximumRowsOrColumns=2"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#RightCompanionContainerGrid", {
-        L"Margin=-420,142,0,50",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"-90\" />",
-        L"Width=300",
-        L"Height=Auto",
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#StartDropShadow", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#DropShadowDismissTarget", {
+        L"Background:=$Background",
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=$BorderThickness",
         L"CornerRadius=$CornerRadius",
-        L"MaxHeight:=700",
-        L"MinHeight:=300"}},
-    ThemeTargetStyles{L"StartMenu.PinnedList#StartMenuPinnedList", {
-        L"Visibility=0",
-        L"Margin=30,0,25,0",
-        L"RenderTransform:=<TranslateTransform X=\"-0\" Y=\"0\" />",
-        L"Height=Auto",
-        L"MinHeight:=200",
-        L"MaxHeight:=1000"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock#PinnedListHeaderText", {
-        L"Visibility=0",
-        L"Margin=0",
-        L"RenderTransform:=<TranslateTransform X=\"60\" Y=\"-10\" />"}},
-    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton#ViewSelectionButton", {
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"0\" />"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#NavPanePlaceholder", {
-        L"Width=Auto",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"0\" />",
+        L"Margin=2",
+        L"Padding=0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#RootContent > Windows.UI.Xaml.Controls.Border#AcrylicBorder", {
         L"Background:=$ElementBG",
         L"BorderBrush:=$ElementBorderBrush",
+        L"BorderThickness=$ElementBorderThickness",
         L"CornerRadius=$ElementCornerRadius",
-        L"BorderThickness=$ElementBorderThickness",
-        L"Height=70",
-        L"Padding=5",
-        L"Margin=420,-100,0,0",
-        L"MaxWidth:=300",
-        L"MinWidth:=200"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ScrollBar#VerticalScrollBar", {
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"0\" />"}},
-    ThemeTargetStyles{L"StartMenu.PinnedList#StartMenuPinnedList > Windows.UI.Xaml.Controls.Grid#Root > Windows.UI.Xaml.Controls.GridView#PinnedList > Windows.UI.Xaml.Controls.Border", {
-        L"Background:=$ElementBG",
-        L"BorderBrush:=$ElementBorderBrush",
-        L"CornerRadius=$CornerRadius",
-        L"BorderThickness=$ElementBorderThickness",
-        L"Padding:=20,10,0,10"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#TopLevelHeader > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.Button", {
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"-5\" />"}},
-    ThemeTargetStyles{L"StartMenu.PinnedListTile > Windows.UI.Xaml.Controls.Grid#Root > Windows.UI.Xaml.Controls.Grid#DisplayNameAndDownloadIconContainer > Windows.UI.Xaml.Controls.TextBlock", {
-        L"Visibility=0"}},
-    ThemeTargetStyles{L"StartMenu.StartHome > Windows.UI.Xaml.Controls.Grid#FrameRoot", {
-        L"Margin=190,40,190,0",
-        L"RenderTransform:=<TranslateTransform X=\"-190\" Y=\"0\" />",
-        L"Padding=0,0,0-20"}},
-    ThemeTargetStyles{L"StartMenu.StartMenuCompanion#RightCompanion > Windows.UI.Xaml.Controls.Grid#CompanionRoot > Windows.UI.Xaml.Controls.Border#AcrylicBorder", {
+        L"Margin=0,60,0,10",
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#AcrylicOverlay", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox", {
+        L"Width=650",
+        L"Height=50",
+        L"Margin=0,-15,0,0"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.Border#BorderElement", {
         L"Background:=$ElementBG",
         L"BorderBrush:=$ElementBorderBrush",
         L"BorderThickness=$ElementBorderThickness",
         L"CornerRadius=$ElementCornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#TopLevelHeader > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.Button", {
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter > Windows.UI.Xaml.Controls.TextBlock#PlaceholderText", {
+        L"Text=Search This Precision"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#TopLevelRoot > Windows.UI.Xaml.Controls.Grid", {
         L"Visibility=1"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.MenuFlyoutPresenter > Windows.UI.Xaml.Controls.Border", {
+    ThemeTargetStyles{L"StartDocked.NavigationPaneView#NavigationPane", {
+        L"Width=550",
+        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"10\" />"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#ShowAllAppsButton", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList#StartMenuPinnedList", {
+        L"Margin=0",
+        L"Height=280"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList#StartMenuPinnedList > Windows.UI.Xaml.Controls.Grid#Root", {
+        L"Background:=$ElementBG",
+        L"BorderBrush:=$ElementBorderBrush",
+        L"BorderThickness=$ElementBorderThickness",
+        L"CornerRadius=$ElementCornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#UndockedRoot", {
+        L"Visibility=0",
+        L"Width=650",
+        L"Margin=0,-130,0,230",
+        L"Canvas.ZIndex=1",
+        L"MaxHeight:=340"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#AllAppsRoot", {
+        L"Visibility=0",
+        L"Margin=-1600,190,115,-100",
+        L"MaxHeight=330",
+        L"Background:=$ElementBG",
+        L"CornerRadius=$ElementCornerRadius",
+        L"Width=650",
+        L"BorderBrush:=$ElementBorderBrush",
+        L"BorderThickness=$ElementBorderThickness"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#CloseAllAppsButton", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock#AllAppsHeading", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"StartDocked.AllAppsPane#AllAppsPanel", {
+        L"Margin=-20,-20,20,20"}},
+    ThemeTargetStyles{L"StartDocked.StartMenuCompanion#RightCompanion > Windows.UI.Xaml.Controls.Grid#CompanionRoot > Windows.UI.Xaml.Controls.Border#AcrylicBorder", {
+        L"Background:=$ElementBG",
+        L"BorderBrush:=$ElementBorderBrush",
+        L"BorderThickness=$ElementBorderThickness",
+        L"CornerRadius:=$ElementCornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#CompanionRoot > Windows.UI.Xaml.Controls.Grid#MainContent > Windows.UI.Xaml.Controls.Grid#ActionsBar > Windows.UI.Xaml.Controls.Button#PrimaryActionBarButton > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter", {
+        L"Background:=$ElementBG",
         L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=$BorderThickness",
+        L"CornerRadius=$ElementCornerRadius",
+        L"Height=40"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ActionsBar > Windows.UI.Xaml.Controls.Button#ActionBarOverflowButton", {
+        L"Background:=$ElementBG",
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=$BorderThickness",
+        L"CornerRadius=$ElementCornerRadius",
+        L"Height=40"}},
+    ThemeTargetStyles{L"StartDocked.StartMenuCompanion#RightCompanion > Windows.UI.Xaml.Controls.Grid#CompanionRoot", {
+        L"Height=730",
+        L"Margin=0,-10,0,-10",
+        L"Padding=10,0,-2,0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#OverflowFlyoutBackgroundBorder", {
         L"Background:=$Background",
-        L"CornerRadius=15",
-        L"BorderThickness=$BorderThickness"}},
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=$BorderThickness",
+        L"CornerRadius=$ElementCornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.MenuFlyoutPresenter > Windows.UI.Xaml.Controls.Border", {
+        L"Background:=$Background",
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=$BorderThickness",
+        L"CornerRadius=$ElementCornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#HoverFlyoutGrid > Windows.UI.Xaml.Controls.Border#HoverFlyoutBackground", {
+        L"Background:=$Background",
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=$BorderThickness",
+        L"CornerRadius=$ElementCornerRadius"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.TaskbarSearchPage > Windows.UI.Xaml.Controls.Grid#RootGrid > Windows.UI.Xaml.Controls.Grid#OuterBorderGrid", {
+        L"Background:=$Background",
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness=$BorderThickness",
+        L"CornerRadius=$CornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#LayerBorder", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#AccentLayerBorder", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#dropshadow", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#AppBorder", {
+        L"Visibility=1"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ToolTip > Windows.UI.Xaml.Controls.ContentPresenter#LayoutRoot", {
         L"Background:=$Background",
         L"BorderBrush:=$BorderBrush",
         L"BorderThickness=$BorderThickness",
         L"CornerRadius=15"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#AddButton", {
-        L"Background:=$Background",
-        L"BorderBrush:=$BorderBrush",
-        L"BorderThickness=$BorderThickness",
-        L"CornerRadius=15"}},
-    ThemeTargetStyles{L"StartMenu.StartBlendedFlexFrame > Windows.UI.Xaml.Controls.Grid#FrameRoot", {
-        L"Width=Auto",
-        L"HorizontalAlignment=Center",
-        L"MaxWidth:=1000",
-        L"MinWidth:=500"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridView#PinnedList > Border > Windows.UI.Xaml.Controls.ScrollViewer", {
-        L"ScrollViewer.VerticalScrollMode=2",
-        L"MaxHeight:=330",
-        L"MinHeight:=100",
-        L"Height=Auto"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridView#PinnedList > Border > Windows.UI.Xaml.Controls.ScrollViewer", {
-        L"ScrollViewer.VerticalScrollMode=2",
-        L"MaxHeight:=330",
-        L"MinHeight:=100",
-        L"Height=Auto"}},
-    ThemeTargetStyles{L"StartMenu.CategoryControl", {
-        L"MaxWidth:=200",
-        L"MinWidth:=100",
-        L"Width=Auto",
-        L"Margin=0,0,-10,0"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridViewHeaderItem > Windows.UI.Xaml.Controls.Border > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter > Windows.UI.Xaml.Controls.Button#Header > Windows.UI.Xaml.Controls.Border#Border", {
-        L"CornerRadius=10"}},
     ThemeTargetStyles{L"StartMenu.FolderModal#StartFolderModal > Windows.UI.Xaml.Controls.Grid#Root", {
         L"MaxHeight:=420",
         L"MaxWidth:=420",
@@ -4291,254 +4574,96 @@ const Theme g_themeWindowGlass = {{
     ThemeTargetStyles{L"StartMenu.FolderModal#StartFolderModal > Windows.UI.Xaml.Controls.Grid#Root > Windows.UI.Xaml.Controls.ContentControl#ContentControl > Windows.UI.Xaml.Controls.ContentPresenter > StartMenu.UniversalTileContainer#UniversalTileContainer > Windows.UI.Xaml.Controls.Grid#GridViewContainer", {
         L"Width=400",
         L"Height=400"}},
-    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton > Windows.UI.Xaml.Controls.Grid", {
-        L"Background:=$ElementBG",
-        L"BorderBrush:=$ElementBorderBrush",
-        L"BorderThickness=$ElementBorderThickness",
-        L"CornerRadius=20"}},
-}, {}, {
-    L"Background=<WindhawkBlur BlurAmount=\"15\" TintColor=\"#10808080\"/>",
-    L"BorderBrush2=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"{ThemeResource SystemChromeHighColor}\" Offset=\"0.0\" /><GradientStop Color=\"{ThemeResource SystemChromeAltHighColor}\" Offset=\"0.25\" /><GradientStop Color=\"{ThemeResource SystemChromeHighColor}\" Offset=\"1\" /></LinearGradientBrush>",
-    L"BorderThickness=0.3,1,0.3,0.3",
-    L"CornerRadius=20",
-    L"ClockBG=<WindhawkBlur BlurAmount=\"20\" TintColor=\"{ThemeResource SystemAccentColorLight2}\" TintOpacity=\"0.3\" />",
-    L"SearchBoxRadius=15",
-    L"Background2=Transparent",
-    L"Background2=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeAltHighColor}\" TintOpacity=\"0.3\" FallbackColor=\"{ThemeResource SystemChromeAltHighColor}\" />",
-    L"ElementBG=<SolidColorBrush Color=\"{ThemeResource SystemChromeAltHighColor}\" Opacity=\"0.3\" />",
-    L"ElementBorderThickness=0.3,0.3,0.3,1",
-    L"ElementCornerRadius=20",
-    L"ElementBorderBrush=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#50808080\" Offset=\"1\" /><GradientStop Color=\"#50606060\" Offset=\"0.15\" /></LinearGradientBrush>",
-    L"BorderBrush=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#50808080\" Offset=\"0.0\" /><GradientStop Color=\"#50404040\" Offset=\"0.25\" /><GradientStop Color=\"#50808080\" Offset=\"1\" /></LinearGradientBrush>",
-}};
-
-const Theme g_themeWindowGlass_variant_Minimal = {{
-    ThemeTargetStyles{L"Border#AcrylicOverlay", {
-        L"Margin=0",
-        L"BorderThickness=0",
-        L"CornerRadius=10",
-        L"Visibility=Collapsed"}},
-    ThemeTargetStyles{L"Border#AcrylicBorder", {
-        L"Background:=$Background",
-        L"CornerRadius=$CornerRadius",
-        L"BorderThickness=$BorderThickness",
-        L"BorderBrush:=$BorderBrush"}},
-    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton", {
-        L"Visibility=Visible",
-        L"Width=330",
-        L"Height=50",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"40\"/>",
-        L"Margin=0,-10,0,20"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#AppBorder", {
-        L"Background:=$Background",
-        L"BorderBrush:=$BorderBrush",
-        L"BorderThickness=$BorderThickness"}},
-    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.Border#BorderElement", {
-        L"BorderThickness=$BorderThickness",
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#AppBorder", {
-        L"Background:=$Background",
-        L"BorderBrush:=$BorderBrush",
-        L"BorderThickness=$BorderThickness",
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Cortana.UI.Views.RichSearchBoxControl#SearchBoxControl", {
-        L"Width=500",
-        L"RenderTransform:=<TranslateTransform X=\"-120\" />"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#BorderElement", {
-        L"Background=Transparent",
-        L"BorderThickness=$BorderThickness"}},
-    ThemeTargetStyles{L"StartMenu.CategoryControl > Windows.UI.Xaml.Controls.Grid#RootGrid > Windows.UI.Xaml.Controls.Border ", {
-        L"BorderThickness=$ElementBorderThickness",
-        L"CornerRadius=$ElementCornerRadius",
-        L"BorderBrush:=$ElementBorderBrush",
-        L"Background:=$ElementBG"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#BorderUnderline", {
-        L"Visibility=Visible"}},
-    ThemeTargetStyles{L"StackPanel#TimeAndDatePanel", {
-        L"VerticalAlignment=Top",
-        L"HorizontalAlignment=Center",
-        L"RenderTransform:=<TranslateTransform X=\"0\" />"}},
-    ThemeTargetStyles{L"StackPanel#TimePanel > TextBlock#Time", {
-        L"HorizontalAlignment=Center",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"0\" />",
-        L"FontFamily=vivo Sans Clock Stencil Regular",
-        L"Foreground:=$ClockBG",
-        L"Margin=0,50,0,0",
-        L"VerticalAlignment=Center"}},
-    ThemeTargetStyles{L"StackPanel#TimeAndDatePanel > TextBlock#Date", {
-        L"HorizontalAlignment=Center",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"0\" />",
-        L"FontFamily=vivo Sans EN VF",
-        L"Foreground:=$ClockBG",
-        L"Margin=0,-180,0,180",
-        L"VerticalAlignment=Center"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#WidgetFrameGrid", {
-        L"Background:=$Background",
-        L"BorderBrush:=$BorderBrush",
-        L"BorderThickness=$BorderThickness",
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#WidgetCanvasPanel", {
-        L"HorizontalAlignment=Center",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"50\" />"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#MediaTransportControls", {
-        L"Background:=$Background",
-        L"BorderBrush:=$BorderBrush",
-        L"BorderThickness=$BorderThickness",
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#MediaControlsContainer", {
-        L"Visibility=Visible",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"0\" />",
-        L"Margin=0,-800,0,800",
-        L"CornerRadius=$CornerRadius",
-        L"VerticalAlignment=Center",
-        L"HorizontalAlignment=Center"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#BorderElement", {
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton#ShowHideCompanion", {
-        L"RenderTransform:=<TranslateTransform X=\"-120\" />",
-        L"Visibility=Collapsed"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#CompanionRoot > Windows.UI.Xaml.Controls.Border#AcrylicOverlay", {
-        L"BorderThickness=0",
-        L"Visibility=Collapsed"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#Root > Windows.UI.Xaml.Controls.Border", {
-        L"BorderBrush:=$BorderBrush",
         L"Background:=$Background",
+        L"BorderBrush:=$BorderBrush",
         L"BorderThickness=$BorderThickness",
         L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#StartDropShadow", {
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#RightCompanionDropShadow", {
-        L"CornerRadius=$CornerRadius",
+    ThemeTargetStyles{L"StartMenu.ExpandedFolderList", {
+        L"Margin=0,30,0,-120"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#MainMenu > Windows.UI.Xaml.Controls.Border#AcrylicBorder", {
         L"Visibility=1"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#DroppedFlickerWorkaroundWrapper > Windows.UI.Xaml.Controls.Border#BackgroundBorder", {
-        L"Background@PointerOver:=$Background",
-        L"Background@Pressed:=$Background",
-        L"Background@Selected:=$Background"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#BackgroundBorder", {
-        L"CornerRadius=10"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#ContentBorder", {
-        L"CornerRadius=10"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Border#LayerBorder", {
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#OuterBorderGrid", {
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.PopupRoot", {
-        L"CornerRadius=$CornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ContentPresenter#ZoomedInPresenter > Windows.UI.Xaml.Controls.GridView#AllAppsGrid > Windows.UI.Xaml.Controls.Border > Windows.UI.Xaml.Controls.ScrollViewer#ScrollViewer > Windows.UI.Xaml.Controls.Border#Root > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.ScrollContentPresenter#ScrollContentPresenter > Windows.UI.Xaml.Controls.ItemsPresenter > Windows.UI.Xaml.Controls.ItemsWrapGrid", {
-        L"MaximumRowsOrColumns=2",
-        L"Margin=5,-100,5,0",
-        L"Width=Auto",
-        L"MinWidth:=100",
-        L"MaxWidth:=350"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#RightCompanionContainerGrid", {
-        L"Visibility=Collapsed"}},
-    ThemeTargetStyles{L"StartMenu.PinnedList#StartMenuPinnedList", {
-        L"Visibility=0",
-        L"Margin=0,0,0,50",
-        L"RenderTransform:=<TranslateTransform X=\"-0\" Y=\"0\" />",
-        L"Height=Auto",
-        L"MinHeight:=200",
-        L"MaxHeight:=1000"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton", {
+        L"Height=50",
+        L"Margin=-20,20,-20,-20",
+        L"Width=400"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.Border#BorderElement", {
+        L"Background:=$ElementBG",
+        L"BorderBrush:=$ElementBorderBrush",
+        L"BorderThickness=$ElementBorderThickness",
+        L"CornerRadius:=$ElementCornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton#ShowHideCompanion", {
+        L"Margin=-50,40,0,0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.TextBlock#PinnedListHeaderText", {
-        L"Visibility=0",
-        L"Margin=0,50,0,0",
-        L"RenderTransform:=<TranslateTransform X=\"60\" Y=\"-10\" />"}},
-    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton#ViewSelectionButton", {
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"0\" />"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#NavPanePlaceholder", {
-        L"Width=Auto",
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"0\" />",
-        L"Background:=$ElementBG",
-        L"BorderBrush:=$ElementBorderBrush",
-        L"CornerRadius=$ElementCornerRadius",
-        L"BorderThickness=$ElementBorderThickness",
-        L"Height=70",
-        L"Padding=5",
-        L"Margin=0,-100,0,0",
-        L"MaxWidth:=300",
-        L"MinWidth=200"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ScrollBar#VerticalScrollBar", {
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"0\" />"}},
-    ThemeTargetStyles{L"StartMenu.PinnedList#StartMenuPinnedList > Windows.UI.Xaml.Controls.Grid#Root > Windows.UI.Xaml.Controls.GridView#PinnedList > Windows.UI.Xaml.Controls.Border", {
-        L"Background:=$ElementBG",
-        L"BorderBrush:=$ElementBorderBrush",
-        L"CornerRadius=$CornerRadius",
-        L"BorderThickness=$ElementBorderThickness",
-        L"Padding:=20,10,0,10"}},
+        L"Visibility=1"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#AllListHeading", {
-        L"RenderTransform:=<TranslateTransform X=\"0\" Y=\"-70\" />",
-        L"Margin=0,10,0,50"}},
-    ThemeTargetStyles{L"StartMenu.PinnedListTile > Windows.UI.Xaml.Controls.Grid#Root > Windows.UI.Xaml.Controls.Grid#DisplayNameAndDownloadIconContainer > Windows.UI.Xaml.Controls.TextBlock", {
-        L"Visibility=0"}},
-    ThemeTargetStyles{L"StartMenu.StartHome", {
-        L"Margin=0,0,0,100",
-        L"Padding=0"}},
-    ThemeTargetStyles{L"StartMenu.StartMenuCompanion#RightCompanion > Windows.UI.Xaml.Controls.Grid#CompanionRoot > Windows.UI.Xaml.Controls.Border#AcrylicBorder", {
+        L"Margin=0,-10,0,0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#AllListHeading > Windows.UI.Xaml.Controls.TextBlock#AllListHeadingText", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"StartMenu.CategoryControl > Windows.UI.Xaml.Controls.Grid#RootGrid > Windows.UI.Xaml.Controls.Border", {
         L"Background:=$ElementBG",
         L"BorderBrush:=$ElementBorderBrush",
         L"BorderThickness=$ElementBorderThickness",
         L"CornerRadius=$ElementCornerRadius"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#TopLevelHeader > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.Button", {
-        L"Visibility=1"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.MenuFlyoutPresenter > Windows.UI.Xaml.Controls.Border", {
-        L"BorderBrush:=$BorderBrush",
-        L"Background:=$Background",
-        L"CornerRadius=15",
-        L"BorderThickness=$BorderThickness"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.ToolTip > Windows.UI.Xaml.Controls.ContentPresenter#LayoutRoot", {
-        L"Background:=$Background",
-        L"BorderBrush:=$BorderBrush",
-        L"BorderThickness=$BorderThickness",
-        L"CornerRadius=15"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Button#AddButton", {
-        L"Background:=$Background",
-        L"BorderBrush:=$BorderBrush",
-        L"BorderThickness=$BorderThickness",
-        L"CornerRadius=15"}},
-    ThemeTargetStyles{L"StartMenu.StartBlendedFlexFrame > Windows.UI.Xaml.Controls.Grid#FrameRoot", {
-        L"HorizontalAlignment=Center",
-        L"Margin=0,0,450,0"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#MainMenu", {
-        L"MaxWidth:=400"}},
+        L"Width=460"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList#StartMenuPinnedList", {
+        L"Width=400",
+        L"Height=450",
+        L"Margin=0,0,0,30"}},
     ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridView#PinnedList > Border > Windows.UI.Xaml.Controls.ScrollViewer", {
         L"ScrollViewer.VerticalScrollMode=2",
-        L"MaxHeight:=330",
+        L"MaxHeight:=336",
         L"MinHeight:=100",
-        L"Height=Auto"}},
-    ThemeTargetStyles{L"StartMenu.CategoryControl", {
-        L"MaxWidth:=200",
-        L"MinWidth:=100",
-        L"Width=Auto",
-        L"Margin=10,0,-20,0"}},
-    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridViewHeaderItem > Windows.UI.Xaml.Controls.Border > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter > Windows.UI.Xaml.Controls.Button#Header > Windows.UI.Xaml.Controls.Border#Border", {
-        L"CornerRadius=10"}},
-    ThemeTargetStyles{L"StartMenu.FolderModal#StartFolderModal > Windows.UI.Xaml.Controls.Grid#Root", {
-        L"MaxHeight:=400",
-        L"MaxWidth:=400",
-        L"Height=Auto",
-        L"Width=Auto"}},
-    ThemeTargetStyles{L"StartMenu.FolderModal#StartFolderModal > Windows.UI.Xaml.Controls.Grid#Root > Windows.UI.Xaml.Controls.ContentControl#ContentControl > Windows.UI.Xaml.Controls.ContentPresenter > StartMenu.UniversalTileContainer#UniversalTileContainer > Windows.UI.Xaml.Controls.Grid#GridViewContainer", {
-        L"Width=350",
-        L"Height=350"}},
-    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton > Windows.UI.Xaml.Controls.Grid", {
+        L"Width=300",
+        L"Margin=0,0,60,0"}},
+    ThemeTargetStyles{L"StartMenu.StartMenuCompanion#RightCompanion", {
+        L"Height=810",
+        L"Margin=15,0,30,0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#CompanionRoot > Windows.UI.Xaml.Controls.Border#AcrylicBorder", {
         L"Background:=$ElementBG",
         L"BorderBrush:=$ElementBorderBrush",
         L"BorderThickness=$ElementBorderThickness",
-        L"CornerRadius=20"}},
+        L"CornerRadius=$ElementCornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridView#AllAppsGrid > Windows.UI.Xaml.Controls.ItemsWrapGrid", {
+        L"Visibility=0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.GridView#AllAppsGrid", {
+        L"Margin=0,15,0,0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#TopLevelHeader > Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.Button", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.FlyoutPresenter", {
+        L"Background:=$Background",
+        L"BorderBrush:=$BorderBrush",
+        L"BorderThickness:=$BorderThickness",
+        L"CornerRadius:=$ElementCornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.MenuFlyoutPresenter", {
+        L"CornerRadius:=$ElementCornerRadius"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Grid#AllListHeading > Microsoft.UI.Xaml.Controls.DropDownButton#ViewSelectionButton > Grid#RootGrid", {
+        L"CornerRadius=$HoverCornerRadius",
+        L"Margin=-12,0,12,0"}},
+    ThemeTargetStyles{L"MenuFlyoutItem", {
+        L"CornerRadius:=$HoverCornerRadius",
+        L"Margin=4,0,4,0"}},
+    ThemeTargetStyles{L"ToggleMenuFlyoutItem", {
+        L"CornerRadius:=$HoverCornerRadius",
+        L"Margin=4,0,4,0"}},
 }, {}, {
-    L"Background=<WindhawkBlur BlurAmount=\"15\" TintColor=\"#10808080\"/>",
-    L"BorderBrush2=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"{ThemeResource SystemChromeHighColor}\" Offset=\"0.0\" /><GradientStop Color=\"{ThemeResource SystemChromeAltHighColor}\" Offset=\"0.25\" /><GradientStop Color=\"{ThemeResource SystemChromeHighColor}\" Offset=\"1\" /></LinearGradientBrush>",
-    L"BorderThickness=0.3,1,0.3,0.3",
-    L"CornerRadius=20",
-    L"ClockBG=<WindhawkBlur BlurAmount=\"20\" TintColor=\"{ThemeResource SystemAccentColorLight2}\" TintOpacity=\"0.3\" />",
-    L"SearchBoxRadius=15",
-    L"Background2=Transparent",
-    L"Background2=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeAltHighColor}\" TintOpacity=\"0.3\" FallbackColor=\"{ThemeResource SystemChromeAltHighColor}\" />",
+    L"Glass=<WindhawkBlur BlurAmount=\"5\" TintColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"0.7\" />",
+    L"Frosted=<WindhawkBlur BlurAmount=\"20\" TintColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"0.7\" />",
+    L"Acrylic=<WindhawkBlur BlurAmount=\"30\" TintColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"0.8\" />",
+    L"Background=$Frosted",
+    L"BorderBrush=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#60808080\" Offset=\"0.0\" /><GradientStop Color=\"#50404040\" Offset=\"0.25\" /><GradientStop Color=\"#40808080\" Offset=\"1\" /></LinearGradientBrush>",
+    L"BorderBrush2=<WindhawkBlur BlurAmount=\"10\" TintColor=\"#909090\" TintOpacity=\"0.3\"/>",
+    L"ClockBG=<SolidColorBrush Color=\"{ThemeResource SystemAccentColor}\" Opacity=\"1\"/>",
+    L"BorderThickness=0.3,1,0.3,1",
+    L"CornerRadius=35",
+    L"SearchBoxRadius=20",
     L"ElementBG=<SolidColorBrush Color=\"{ThemeResource SystemChromeAltHighColor}\" Opacity=\"0.3\" />",
     L"ElementBorderThickness=0.3,0.3,0.3,1",
-    L"ElementCornerRadius=20",
+    L"ElementCornerRadius=25",
     L"ElementBorderBrush=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#50808080\" Offset=\"1\" /><GradientStop Color=\"#50606060\" Offset=\"0.15\" /></LinearGradientBrush>",
-    L"BorderBrush=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#50808080\" Offset=\"0.0\" /><GradientStop Color=\"#50404040\" Offset=\"0.25\" /><GradientStop Color=\"#50808080\" Offset=\"1\" /></LinearGradientBrush>",
+    L"ElementBorderBrush2=<WindhawkBlur BlurAmount=\"30\" TintColor=\"#909090\" TintOpacity=\"0.3\"/>",
+    L"HoverCornerRadius=15",
 }};
 
 const Theme g_themeFluid = {{
@@ -4740,6 +4865,12 @@ const Theme g_themeOversimplified_Accentuated = {{
     ThemeTargetStyles{L"Grid#LogosContainer", {
         L"Height=68",
         L"Width=68"}},
+    ThemeTargetStyles{L"ItemsControl#LogosItemsControl", {
+        L"Height=50",
+        L"Width=50"}},
+    ThemeTargetStyles{L"ItemsControl#LogosItemsControl > ItemsPresenter > ItemsWrapGrid > ContentPresenter > Windows.UI.Xaml.Controls.Grid", {
+        L"Height=22",
+        L"Width=22"}},
     ThemeTargetStyles{L"Grid#Root > Border", {
         L"Background:=$DarkAccent",
         L"BorderBrush:=Transparent",
@@ -4849,6 +4980,965 @@ const Theme g_themeOversimplified_Accentuated = {{
     L"DarkAccent=<AcrylicBrush TintColor=\"{ThemeResource SystemAccentColorDark1}\" TintOpacity=\"0.6\" TintLuminosityOpacity=\"0.3\" FallbackColor=\"{ThemeResource SystemAccentColorDark1}\" />",
     L"SolidAccent=<SolidColorBrush Color=\"{ThemeResource SystemAccentColor}\" Opacity=\"1\"/>",
     L"Reveal=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\" />",
+}};
+
+const Theme g_themeLiquidGlass = {{
+    ThemeTargetStyles{L"Border#AcrylicOverlay", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Border#AcrylicBorder", {
+        L"Background:=$background",
+        L"BorderBrush:=$borderColor",
+        L"BorderThickness=$borderThickness",
+        L"CornerRadius=$cornerRadius"}},
+    ThemeTargetStyles{L"Border#AccentAppBorder", {
+        L"Background:=$background",
+        L"BorderBrush:=$borderColor",
+        L"BorderThickness=$borderThickness",
+        L"CornerRadius=$cornerRadius"}},
+    ThemeTargetStyles{L"Border#ContentBorder@CommonStates > Grid > Border#BackgroundBorder", {
+        L"BorderThickness=$borderThickness2",
+        L"BorderBrush@PointerOver:=$borderColor2",
+        L"BorderBrush@Pressed:=$borderColor2",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"Button > Grid@CommonStates > Border#BackgroundBorder", {
+        L"BorderThickness=$borderThickness2",
+        L"BorderBrush@PointerOver:=$borderColor2",
+        L"BorderBrush@Pressed:=$borderColor2",
+        L"BackgroundSizing=InnerBorderEdge",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"StartMenu.CategoryControl > Grid > Border", {
+        L"BorderThickness=$borderThickness2",
+        L"BorderBrush:=$borderColor2",
+        L"BackgroundSizing=InnerBorderEdge",
+        L"Background:=$background",
+        L"Opacity=0.8",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"Grid#LayoutRoot", {
+        L"BackgroundTransition:=<BrushTransition Duration=\"0:0:0.083\" />"}},
+    ThemeTargetStyles{L"Border#BackgroundBorder", {
+        L"BackgroundTransition:=<BrushTransition Duration=\"0:0:0.083\" />"}},
+    ThemeTargetStyles{L"Button#Header > Border@CommonStates", {
+        L"BorderThickness=$borderThickness2",
+        L"BorderBrush@PointerOver:=$borderColor2",
+        L"BorderBrush@Pressed:=$borderColor2",
+        L"BackgroundSizing=InnerBorderEdge",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"ListViewItem > Grid@CommonStates > Border#BorderBackground", {
+        L"BorderThickness=$borderThickness2",
+        L"BorderBrush@PointerOver:=$borderColor2",
+        L"BorderBrush@Pressed:=$borderColor2",
+        L"BackgroundSizing=InnerBorderEdge",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton > Grid@CommonStates > Border#BorderElement", {
+        L"CornerRadius=$cornerRadius2",
+        L"BorderThickness=$borderThickness2",
+        L"BorderBrush:=$borderColor2",
+        L"Background@Checked:=$background",
+        L"Background@CheckedPointerOver:=$background",
+        L"Background@CheckedPressed:=$background",
+        L"BackgroundTransition:=<BrushTransition Duration=\"0:0:0.083\" />"}},
+    ThemeTargetStyles{L"Button#HideMoreSuggestionsButton > Grid@CommonStates > Border#BackgroundBorder", {
+        L"Background@Normal:=$background",
+        L"BorderBrush@Normal:=$borderColor2",
+        L"BorderBrush@PointerOver:=$borderColor2",
+        L"BorderBrush@Pressed:=$borderColor2",
+        L"Background@PointerOver:=$background",
+        L"Background@Pressed:=$background",
+        L"BorderThickness=1",
+        L"Margin=2",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"Button#ShowMoreSuggestionsButton > Grid@CommonStates > Border#BackgroundBorder", {
+        L"Background@Normal:=$background",
+        L"BorderBrush@Normal:=$borderColor2",
+        L"BorderBrush@PointerOver:=$borderColor2",
+        L"BorderBrush@Pressed:=$borderColor2",
+        L"Background@PointerOver:=$background",
+        L"Background@Pressed:=$background",
+        L"BorderThickness=$borderThickness2",
+        L"Margin=2",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"StartMenu.FolderModal > Grid#Root > Border", {
+        L"BorderThickness=$borderThickness",
+        L"BorderBrush:=$borderColor",
+        L"CornerRadius=$cornerRadius"}},
+    ThemeTargetStyles{L"MenuFlyoutPresenter > Border", {
+        L"BorderThickness=$borderThickness",
+        L"BorderBrush:=$borderColor",
+        L"CornerRadius=$cornerRadius"}},
+    ThemeTargetStyles{L"Border#ContentBorder@CommonStates > Grid#DroppedFlickerWorkaroundWrapper > ContentPresenter#ContentPresenter > ContentControl > Grid#RootGrid > Border#LogoBackgroundPlate > Image#AllAppsItemLogo", {
+        L"RenderTransform@Pressed:=<ScaleTransform ScaleX=\"0.8\" ScaleY=\"0.8\" />",
+        L"RenderTransformOrigin=0.5,0.5",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"StartDocked.NavigationPaneButton > Grid@CommonStates > Border#BackgroundBorder", {
+        L"BorderThickness=$borderThickness2",
+        L"BorderBrush@PointerOver:=$borderColor2",
+        L"BorderBrush@Pressed:=$borderColor2",
+        L"BackgroundSizing=InnerBorderEdge",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"StartDocked.AppListViewItem > Grid@CommonStates > Border#BackgroundBorder", {
+        L"BorderThickness=$borderThickness",
+        L"BorderBrush@PointerOver:=$borderColor",
+        L"BorderBrush@Pressed:=$borderColor",
+        L"BackgroundSizing=InnerBorderEdge",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton > Grid@CommonStates", {
+        L"Background@PointerOver:=$background",
+        L"Background@Pressed:=$background",
+        L"BorderBrush@PointerOver:=$borderColor2",
+        L"BorderBrush@Pressed:=$borderColor2",
+        L"BackgroundSizing=InnerBorderEdge",
+        L"Background@Normal:=$background",
+        L"BorderBrush@Normal:=$borderColor2",
+        L"Padding=9,3,7,4",
+        L"CornerRadius=$cornerRadius2",
+        L"BorderThickness@Normal=$borderThickness2",
+        L"BorderThickness@PointerOver=$borderThickness2",
+        L"BorderThickness@Pressed=$borderThickness2"}},
+    ThemeTargetStyles{L"Border#ContentBorder@CommonStates > Grid#DroppedFlickerWorkaroundWrapper > ContentPresenter#ContentPresenter > ContentControl > Grid#RootGrid > Grid#LogoContainer > Image#AllAppsTileLogo", {
+        L"RenderTransform@Pressed:=<ScaleTransform ScaleX=\"0.8\" ScaleY=\"0.8\" />",
+        L"RenderTransformOrigin=0.5,0.5",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"Border#ContentBorder@CommonStates > Grid#DroppedFlickerWorkaroundWrapper > ContentPresenter > Grid > Grid#LogoContainer > Grid", {
+        L"RenderTransform@Pressed:=<ScaleTransform ScaleX=\"0.8\" ScaleY=\"0.8\" />",
+        L"RenderTransformOrigin=0.5,0.5",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"Grid#ContentBorder@CommonStates > Grid#DroppedFlickerWorkaroundWrapper > ContentPresenter > Grid > Grid#LogoContainer > Grid", {
+        L"RenderTransform@Pressed:=<ScaleTransform ScaleX=\"0.8\" ScaleY=\"0.8\" />",
+        L"RenderTransformOrigin=0.5,0.5",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"ScrollViewer#MenuFlyoutPresenterScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > StackPanel", {
+        L"ChildrenTransitions:=<TransitionCollection><EntranceThemeTransition IsStaggeringEnabled=\"False\" FromHorizontalOffset=\"-25\" FromVerticalOffset=\"0\" /></TransitionCollection>"}},
+    ThemeTargetStyles{L"FlyoutPresenter > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ContentPresenter > Border", {
+        L"BorderBrush:=$borderColor",
+        L"BorderThickness=$borderThickness",
+        L"CornerRadius=$cornerRadius"}},
+    ThemeTargetStyles{L"Button > ContentPresenter#ContentPresenter@CommonStates", {
+        L"Background@PointerOver:=$background",
+        L"Background@Pressed:=$background",
+        L"BorderBrush@PointerOver:=$borderColor2",
+        L"BorderBrush@Pressed:=$borderColor2",
+        L"BorderThickness=$borderThickness2",
+        L"Background@Normal=$background",
+        L"CornerRadius=$cornerRadius2"}},
+    ThemeTargetStyles{L"Grid@SearchBoxInputStates > Border#TaskbarSearchBackground", {
+        L"CornerRadius=$cornerRadius2",
+        L"Background@ActiveInput:=$background",
+        L"BorderBrush:=$borderColor2",
+        L"BorderThickness=$borderThickness2",
+        L"Background@SearchBoxHover:=$background",
+        L"Background@NoFocus:=$background",
+        L"BackgroundTransition:=<BrushTransition Duration=\"0:0:0.083\" />"}},
+    ThemeTargetStyles{L"Border@CommonStates > Grid#DroppedFlickerWorkaroundWrapper > ContentPresenter > Grid > Grid#LogoContainer > Image", {
+        L"RenderTransform@Pressed:=<ScaleTransform ScaleX=\"0.8\" ScaleY=\"0.8\" />",
+        L"RenderTransformOrigin=0.5,0.5"}},
+    ThemeTargetStyles{L"Grid#ContentBorder@CommonStates > ContentPresenter > Grid > Grid#LogoContainer > Grid", {
+        L"RenderTransform@Pressed:=<ScaleTransform ScaleX=\"0.8\" ScaleY=\"0.8\" />",
+        L"RenderTransformOrigin=0.5,0.5"}},
+}, {
+    ThemeTargetStyles{L"*", {
+        L"transition: background-color 0.083s ease-in-out !important"}},
+}, {
+    L"borderColor=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#50808080\" Offset=\"0.0\" /><GradientStop Color=\"#50404040\" Offset=\"0.25\" /><GradientStop Color=\"#50808080\" Offset=\"1\" /></LinearGradientBrush>\"",
+    L"borderColor2=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#50808080\" Offset=\"1\" /><GradientStop Color=\"#50606060\" Offset=\"0.15\" /></LinearGradientBrush>",
+    L"background=<WindhawkBlur BlurAmount=\"10\" TintColor=\"#25323232\" TintOpacity=\"0.2\" />",
+    L"borderThickness=0.3,1,0.3,0.3",
+    L"borderThickness2=0.3,0.3,0.3,1",
+    L"cornerRadius=6",
+    L"cornerRadius2=4",
+}};
+
+const Theme g_themeWindows10X = {{
+    ThemeTargetStyles{L"Grid#ShowMoreSuggestions", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Grid#TopLevelSuggestionsListHeader", {
+        L"Margin=0,10,-180,0",
+        L"BorderThickness=0,1,0,0",
+        L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SurfaceStrokeColorDefault}\" Opacity=\".5\"/>"}},
+    ThemeTargetStyles{L"Grid#TopLevelHeader > Grid > Button > Grid@CommonStates > Border#BackgroundBorder", {
+        L"Background:=$button",
+        L"Background@PointerOver:=$buttonHover",
+        L"Background@Pressed:=$buttonPress",
+        L"CornerRadius=12",
+        L"Height=23"}},
+    ThemeTargetStyles{L"Border#AcrylicBorder", {
+        L"Background:=$acrylic",
+        L"CornerRadius=4",
+        L"BorderThickness=0,1,0,0",
+        L"BorderBrush:=$button",
+        L"BackgroundSizing=1"}},
+    ThemeTargetStyles{L"Grid#MainContent", {
+        L"CornerRadius=3",
+        L"Margin=0"}},
+    ThemeTargetStyles{L"TextBlock#PinnedListHeaderText", {
+        L"Margin=78,0,0,0",
+        L"Text=My apps and websites",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"Border#TaskbarSearchBackground", {
+        L"CornerRadius=4,4,5,5",
+        L"Margin=79,35,79,1",
+        L"BorderThickness=0,0,0,4",
+        L"Height=48",
+        L"BorderBrush:=$fakeShadow"}},
+    ThemeTargetStyles{L"Border#AppBorder", {
+        L"Background:=$acrylic",
+        L"CornerRadius=4",
+        L"BorderThickness=0,1,0,0",
+        L"BorderBrush:=$button",
+        L"BackgroundSizing=1"}},
+    ThemeTargetStyles{L"Border#dropshadow", {
+        L"Canvas.ZIndex=-1",
+        L"CornerRadius=4"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichSearchBoxControl#SearchBoxControl", {
+        L"Margin=79,39,79,10"}},
+    ThemeTargetStyles{L"Border#ContentBorder", {
+        L"CornerRadius=4"}},
+    ThemeTargetStyles{L"ItemsWrapGrid > GridViewItem > Border > Grid > ContentPresenter > ContentControl > Grid > TextBlock", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Border#LayerBorder", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Border#LogoBackgroundPlate", {
+        L"CornerRadius=2"}},
+    ThemeTargetStyles{L"TextBlock#AppDisplayName", {
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"Grid#WebViewGrid", {
+        L"Background=Transparent",
+        L"Margin=0"}},
+    ThemeTargetStyles{L"Button#Header > Border#Border > TextBlock#Text", {
+        L"FontWeight=600",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"Grid#QueryFormulationRoot", {
+        L"CornerRadius=0",
+        L"BorderThickness=0",
+        L"Margin=0,31,0,0",
+        L"Background:=$buttonPress"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootGrid > Grid#RootContent > Grid#MainContent > Grid#InnerContent > Rectangle", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Border#AcrylicOverlay", {
+        L"Margin=0,51,0,-64",
+        L"Padding=0,1,0,1",
+        L"BorderThickness=0",
+        L"CornerRadius=0"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichSearchBoxControl#SearchBoxControl > Grid#RootGrid", {
+        L"CornerRadius=3",
+        L"Margin=0,1,0,0",
+        L"BorderThickness=0"}},
+    ThemeTargetStyles{L"FontIcon#SearchBoxOnTaskbarSearchGlyph", {
+        L"Visibility=0",
+        L"FontFamily=Segoe MDL2 Assets",
+        L"Glyph=\uE721",
+        L"Margin=16,0,0,0"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.AnimatedIcon#SearchIconPlayer", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Border#LayerBorder", {
+        L"CornerRadius=4"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.TaskbarSearchPage", {
+        L"Margin=-28,42,-28,0",
+        L"MaxWidth=790",
+        L"Width=790",
+        L"Height=708",
+        L"VerticalAlignment=2"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.TaskbarSearchPage > Grid#RootGrid@SearchBoxInputStates > Border#TaskbarSearchBackground", {
+        L"Background:=<SolidColorBrush Color=\"{ThemeResource ControlFillColorInputActive}\"/>"}},
+    ThemeTargetStyles{L"Image#SearchIconOn", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"FontIcon#SearchGlyph", {
+        L"Visibility=0",
+        L"Glyph=\uE721"}},
+    ThemeTargetStyles{L"Image#SearchIconOff", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"StartDocked.UserTileView", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"FontIcon", {
+        L"FontFamily=Segoe MDL2 Assets"}},
+    ThemeTargetStyles{L"MenuFlyoutPresenter", {
+        L"CornerRadius=4",
+        L"BorderThickness=0,1,0,0",
+        L"BorderBrush:=$button",
+        L"Background:=$acrylicMenu",
+        L"BackgroundSizing=1"}},
+    ThemeTargetStyles{L"TextBlock#DisplayName", {
+        L"Margin=0,6,0,-16",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"TextBlock#AllAppsHeading", {
+        L"Margin=17,0,0,0",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"TextBlock#TopLevelSuggestionsListHeaderText", {
+        L"Margin=80,25,0,0",
+        L"Text=Recent",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"GridView#RecommendedList > Border > ScrollViewer#ScrollViewer > Border#Root > Grid > ScrollContentPresenter#ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid > GridViewItem > Border#ContentBorder > Grid#DroppedFlickerWorkaroundWrapper", {
+        L"Margin=29,0,0,0"}},
+    ThemeTargetStyles{L"StartDocked.PowerOptionsView#PowerButton", {
+        L"Margin=-121,-1230,0,0"}},
+    ThemeTargetStyles{L"StartDocked.NavigationPaneButton#PowerButton > Grid > ContentPresenter > Grid > FontIcon", {
+        L"FontFamily=Segoe MDL2 Assets",
+        L"Glyph=\uE720"}},
+    ThemeTargetStyles{L"MenuFlyoutItem", {
+        L"CornerRadius=0",
+        L"Margin=-4,-2,-4,-2"}},
+    ThemeTargetStyles{L"TextBlock#Title", {
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"TextBlock#Subtitle", {
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"GridViewItem > Border#ContentBorder > Grid#DroppedFlickerWorkaroundWrapper > Border#BackgroundBorder", {
+        L"FocusVisualPrimaryThickness=0",
+        L"FocusVisualSecondaryThickness=0"}},
+    ThemeTargetStyles{L"JumpViewUI.JumpListListView > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > ItemsStackPanel > ListViewItem", {
+        L"CornerRadius=0"}},
+    ThemeTargetStyles{L"MenuFlyoutSubItem", {
+        L"CornerRadius=0",
+        L"Margin=-4,0,-4,0",
+        L"Padding=11,4,11,5"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootPanel > Grid#RootGrid > Grid#RootContent > Grid#MainContent > Grid#InnerContent > Rectangle", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"StartMenu.StartBlendedFlexFrame > Grid#FrameRoot", {
+        L"Height=708"}},
+    ThemeTargetStyles{L"Grid#MainMenu > Grid#MainContent > Grid", {
+        L"Margin=0,0,0,-40"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton", {
+        L"Margin=79,14,79,0",
+        L"CornerRadius=4",
+        L"Height=48"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton > Grid@CommonStates > Border#BorderElement", {
+        L"Background:=$button",
+        L"Background@PointerOver:=$buttonHover",
+        L"Background@Pressed:=$buttonPress",
+        L"Background@Checked:=$button",
+        L"Background@CheckedPointerOver:=$buttonHover",
+        L"Background@CheckedPressed:=$buttonPress",
+        L"BorderThickness=0"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton#SearchBoxToggleButton > Grid", {
+        L"BorderThickness=0,0,0,4",
+        L"BorderBrush:=$fakeShadow",
+        L"CornerRadius=0,0,4,4"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton > Grid > ContentPresenter > TextBlock#PlaceholderText", {
+        L"Text=Search the web and your devices",
+        L"Foreground:=$textSecondary",
+        L"FontFamily=Segoe UI",
+        L"Opacity=1"}},
+    ThemeTargetStyles{L"Rectangle#TextCaret", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Grid#MainMenu", {
+        L"MaxWidth=766",
+        L"Width=766"}},
+    ThemeTargetStyles{L"GridView#AllAppsGrid > Border > ScrollViewer", {
+        L"Margin=0,51,0,0"}},
+    ThemeTargetStyles{L"Grid#TopLevelHeader > Grid > Button > Grid > ContentPresenter > StackPanel > FontIcon", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"TextBlock#ShowMorePinnedButtonText", {
+        L"Text=Show all",
+        L"FontFamily=Segoe UI",
+        L"Margin=0",
+        L"FontSize=12",
+        L"Padding=5,0,5,0"}},
+    ThemeTargetStyles{L"Grid#TopLevelHeader > Grid > Button", {
+        L"Margin=-79,-2,79,0"}},
+    ThemeTargetStyles{L"Frame#StartFrame", {
+        L"Margin=0,0,0,-65"}},
+    ThemeTargetStyles{L"GridView#AllAppsGrid > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid", {
+        L"Margin=78,8,78,0"}},
+    ThemeTargetStyles{L"Grid#AllListHeading", {
+        L"BorderThickness=0,1,0,0",
+        L"BorderBrush:=<SolidColorBrush Color=\"{ThemeResource SurfaceStrokeColorDefault}\" Opacity=\".5\"/>",
+        L"Margin=0,25,0,0"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton#ViewSelectionButton > Grid@CommonStates", {
+        L"Background:=$button",
+        L"Background@PointerOver:=$buttonHover",
+        L"Background@Pressed:=$buttonPress",
+        L"CornerRadius=12"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton#ViewSelectionButton", {
+        L"Height=23",
+        L"Margin=0,25,81,0",
+        L"Padding=10,0,10,0"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton#ViewSelectionButton > Grid > ContentPresenter > TextBlock", {
+        L"FontSize=12",
+        L"Margin=0,1,0,0",
+        L"Padding=5,0,5,0"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton#ViewSelectionButton > Grid > Microsoft.UI.Xaml.Controls.AnimatedIcon#ChevronIcon", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton#ViewSelectionButton > Grid > ContentPresenter", {
+        L"Height=24",
+        L"Margin=0,-2,0,0",
+        L"Padding=0,0,0,2"}},
+    ThemeTargetStyles{L"TextBlock#AllListHeadingText", {
+        L"Margin=81,25,0,0"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList#StartMenuPinnedList > Grid#Root", {
+        L"Padding=0,6,0,-6",
+        L"MaxWidth=760"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList#StartMenuPinnedList > Grid#Root > GridView#PinnedList > Border > ScrollViewer#ScrollViewer > Border#Root > Grid > ScrollContentPresenter#ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid > GridViewItem", {
+        L"Margin=0,0,31,0"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList#StartMenuPinnedList", {
+        L"Margin=79,0,0,0"}},
+    ThemeTargetStyles{L"GridViewHeaderItem", {
+        L"Padding=0"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList#StartMenuPinnedList > Grid#Root > GridView#PinnedList > Border > ScrollViewer#ScrollViewer", {
+        L"VerticalScrollBarVisibility=Auto",
+        L"ScrollViewer.VerticalScrollMode=1"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton#ShowHideCompanion", {
+        L"Margin=-60,10,0,0",
+        L"Height=40",
+        L"Width=40"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ToggleButton#ShowHideCompanion > Border > ContentPresenter", {
+        L"Height=40",
+        L"Width=40"}},
+}, {
+    ThemeTargetStyles{L"#qfPreviewPane, #qfPreviewPane *, .leftPill::before, #temporaryMessages, .scope-with-background__backButton, #gr11, #pp_Share, #pp_Review, #chatButtonRight, .curatedSettingsGroup, .scope-with-background__rightCaret, #topHitHeader, .userProfileMenuIcon, .scope-tile__button, .additionalInfoText.annotation, #root:not(.zeroInput19H1):not(.fileExplorer) .topResults .openPreviewPaneBtn .iconContent, .openPreviewIcon .iconContent.cortanaFontIcon, #scopesHeader, #scopesHeader *, #gr36, div[data-region=\"TopApps\"], #gr43, .openPreviewPaneBtn, .suggContainer.largerSearchIcon14 .secondaryText", {
+        L"display: none !important",
+        L"visibility: hidden !important"}},
+    ThemeTargetStyles{L"#qfContainer", {
+        L"max-width: 100% !important",
+        L"margin-inline: 75px !important",
+        L"margin-top: 7px !important"}},
+    ThemeTargetStyles{L".cortanaFontIcon, .iconContent", {
+        L"font-family: 'Segoe MDL2 Assets' !important"}},
+    ThemeTargetStyles{L".leftPill", {
+        L"border-left: 3px solid var(--accent11) !important",
+        L"border-radius: 2px !important"}},
+    ThemeTargetStyles{L".darkTheme .leftPill", {
+        L"border-left: 3px solid var(--accent12) !important"}},
+    ThemeTargetStyles{L"*", {
+        L"scrollbar-width: none !important",
+        L"border-color: transparent !important",
+        L"cursor: default !important"}},
+    ThemeTargetStyles{L".groupContainer.topItemsGroup", {
+        L"order: -1 !important"}},
+    ThemeTargetStyles{L".leftPaneZIsuggestions", {
+        L"margin-left: -19px !important"}},
+    ThemeTargetStyles{L"#root.win11.zeroInput19H1:not(.fileExplorer) .groupContainer:not(.curatedSettingsGroup) .suggestion.selectable:not(.focusable), .suggContainer", {
+        L"border-radius: 2px !important",
+        L"transition: all 83ms ease-out"}},
+    ThemeTargetStyles{L"div[data-region=\"MRUHistory\"] > .suggsList, div[data-region=\"MRUHistory\"] .suggContainer", {
+        L"width: 600px !important"}},
+    ThemeTargetStyles{L".suggestion:not(.groupHeader)", {
+        L"border-radius: 4px !important",
+        L"clip-path: inset(1px 0px 1px 3px round 4px 2px 2px 4px) !important"}},
+    ThemeTargetStyles{L".suggestion[aria-selected=\"true\"] .iconContainer, .suggestion[aria-selected=\"true\"] .details", {
+        L"margin-left: -3px !important"}},
+    ThemeTargetStyles{L".groupHeader", {
+        L"margin-inline: 3px 4px !important"}},
+    ThemeTargetStyles{L".topResults .suggDetailsContainer", {
+        L"min-height: 0px !important"}},
+    ThemeTargetStyles{L".suggDetailsContainer.limitScaleRange", {
+        L"background: transparent !important"}},
+    ThemeTargetStyles{L".topResults .suggDetailsContainer .primaryText", {
+        L"margin-bottom: -2px !important"}},
+}, {
+    L"lightAccent=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorDark1}\"/>",
+    L"lightAccentHover=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorDark1}\" Opacity=\".9\"/>",
+    L"lightAccentPress=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorDark1}\" Opacity=\".8\"/>",
+    L"darkAccent=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight2}\"/>",
+    L"darkAccentHover=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight2}\" Opacity=\".9\"/>",
+    L"darkAccentPress=<SolidColorBrush Color=\"{ThemeResource SystemAccentColorLight2}\" Opacity=\".8\"/>",
+    L"subtleButtonHover=<SolidColorBrush Color=\"{ThemeResource SubtleFillColorSecondary}\"/>",
+    L"subtleButtonPress=<SolidColorBrush Color=\"{ThemeResource SubtleFillColorTertiary}\"/>",
+    L"button=<SolidColorBrush Color=\"{ThemeResource ControlFillColorDefault}\"/>",
+    L"buttonHover=<SolidColorBrush Color=\"{ThemeResource ControlFillColorSecondary}\"/>",
+    L"buttonPress=<SolidColorBrush Color=\"{ThemeResource ControlFillColorTertiary}\"/>",
+    L"textPrimary=<SolidColorBrush Color=\"{ThemeResource TextFillColorPrimary}\"/>",
+    L"textSecondary=<SolidColorBrush Color=\"{ThemeResource TextFillColorSecondary}\"/>",
+    L"textDisabled=<SolidColorBrush Color=\"{ThemeResource TextFillColorDisabled}\"/>",
+    L"textInverse=<SolidColorBrush Color=\"{ThemeResource TextFillColorInverse}\"/>",
+    L"acrylic=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeMediumColor}\" FallbackColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\".0\" TintLuminosityOpacity=\".86\"/>",
+    L"fakeShadow=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#10000000\" Offset=\"0.84\" /><GradientStop Color=\"#26000000\" Offset=\"0.85\" /><GradientStop Color=\"#00000000\" Offset=\"1.0\" /></LinearGradientBrush>",
+    L"acrylicMenu=<AcrylicBrush TintColor=\"{ThemeResource LayerOnMicaBaseAltFillColorTertiary}\" FallbackColor=\"{ThemeResource SystemChromeHighColor}\" TintOpacity=\".0\" TintLuminosityOpacity=\".75\"/>",
+}};
+
+const Theme g_themeWindows10X_variant_ClassicStartMenu = {{
+    ThemeTargetStyles{L"Button#CloseAllAppsButton", {
+        L"Margin=0,0,16,0",
+        L"Padding=16,3,16,3.5",
+        L"CornerRadius=12",
+        L"BorderThickness=0"}},
+    ThemeTargetStyles{L"Grid#ShowMoreSuggestions", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Grid#TopLevelSuggestionsListHeader", {
+        L"Margin=0,-23,-180,0",
+        L"BorderThickness=0,1,0,0",
+        L"BorderBrush:=$separator"}},
+    ThemeTargetStyles{L"Button#ShowAllAppsButton", {
+        L"Margin=0,0,80,0",
+        L"CornerRadius=12",
+        L"BorderThickness=0",
+        L"Padding=16,3,16,3.5"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton", {
+        L"Margin=80,5,80,46",
+        L"Height=48"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.PipsPager#PinnedListPipsPager", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Border#AcrylicBorder", {
+        L"Background:=$acrylic",
+        L"CornerRadius=4",
+        L"BorderThickness=0,1,0,0",
+        L"BorderBrush:=$button",
+        L"BackgroundSizing=1"}},
+    ThemeTargetStyles{L"Grid#MainContent", {
+        L"CornerRadius=3",
+        L"Margin=0"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList", {
+        L"Height=252",
+        L"Margin=24,0,0,0",
+        L"Width=610"}},
+    ThemeTargetStyles{L"TextBlock#PinnedListHeaderText", {
+        L"Margin=16,0,0,0",
+        L"Text=My apps and websites",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"Border#TaskbarSearchBackground", {
+        L"CornerRadius=4,4,6,6",
+        L"Margin=80,36,80,1",
+        L"BorderThickness=0,0,0,4",
+        L"Height=48",
+        L"BorderBrush:=$fakeShadow"}},
+    ThemeTargetStyles{L"Border#AppBorder", {
+        L"Background:=$acrylic",
+        L"CornerRadius=4",
+        L"BorderThickness=0,1,0,0",
+        L"BorderBrush:=$button",
+        L"BackgroundSizing=1"}},
+    ThemeTargetStyles{L"Border#dropshadow", {
+        L"Canvas.ZIndex=-1",
+        L"CornerRadius=4"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichSearchBoxControl#SearchBoxControl", {
+        L"Margin=79,39,79,10"}},
+    ThemeTargetStyles{L"Border#ContentBorder", {
+        L"CornerRadius=4"}},
+    ThemeTargetStyles{L"TextBlock#StatusMessage", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Border#LayerBorder", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Border#LogoBackgroundPlate", {
+        L"CornerRadius=2"}},
+    ThemeTargetStyles{L"TextBlock#AppDisplayName", {
+        L"Margin=-4,0,0,0",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"Grid#WebViewGrid", {
+        L"Background=Transparent",
+        L"Margin=0"}},
+    ThemeTargetStyles{L"Border#DropShadow", {
+        L"Canvas.ZIndex=-1",
+        L"CornerRadius=4"}},
+    ThemeTargetStyles{L"Button#Header > Border#Border > TextBlock#Text", {
+        L"FontWeight=600",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"Grid#QueryFormulationRoot", {
+        L"CornerRadius=0",
+        L"BorderThickness=0",
+        L"Margin=0,31,0,0",
+        L"Background:=$buttonPress"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton > Grid > ContentPresenter > TextBlock#PlaceholderText", {
+        L"Text=Search the web or your devices",
+        L"Margin=0",
+        L"Foreground:=$textSecondary",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"TextBlock#ShowAllAppsButtonText", {
+        L"Margin=0",
+        L"Text=Show all",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"Button#CloseAllAppsButton > ContentPresenter > StackPanel > TextBlock", {
+        L"Margin=8,-1,0,0",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"Button#CloseAllAppsButton > ContentPresenter > StackPanel > FontIcon > Grid > TextBlock", {
+        L"Margin=-2,0,0,0",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootGrid > Grid#RootContent > Grid#MainContent > Grid#InnerContent > Rectangle", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Border#AcrylicOverlay", {
+        L"Margin=0,115,0,-64",
+        L"Padding=0,1,0,1",
+        L"BorderThickness=0",
+        L"CornerRadius=0"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.RichSearchBoxControl#SearchBoxControl > Grid#RootGrid", {
+        L"CornerRadius=3",
+        L"Margin=0,1,0,0",
+        L"BorderThickness=0"}},
+    ThemeTargetStyles{L"FontIcon#SearchBoxOnTaskbarSearchGlyph", {
+        L"Visibility=0"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.AnimatedIcon#SearchIconPlayer", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox > Grid@CommonStates", {
+        L"CornerRadius=0,0,5,5",
+        L"BorderThickness=0,0,0,4",
+        L"BorderBrush:=$fakeShadow",
+        L"Background:=transparent"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox > Grid@CommonStates > Border#BorderElement", {
+        L"CornerRadius=3",
+        L"Margin=-1,0,-1,0",
+        L"Background=Transparent",
+        L"BorderThickness=0"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox > Grid@CommonStates > FontIcon > Grid > TextBlock", {
+        L"Margin=-1,0,0,1",
+        L"FontFamily=Segoe MDL2 Assets",
+        L"Text=\uE721",
+        L"Foreground:=<SolidColorBrush Color=\"{ThemeResource FocusStrokeColorOuter}\"/>"}},
+    ThemeTargetStyles{L"Border#LayerBorder", {
+        L"CornerRadius=4"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.TaskbarSearchPage", {
+        L"Margin=-28,42,-28,0",
+        L"MaxWidth=790",
+        L"Width=790",
+        L"Height=708",
+        L"VerticalAlignment=2"}},
+    ThemeTargetStyles{L"Cortana.UI.Views.TaskbarSearchPage > Grid#RootGrid@SearchBoxInputStates > Border#TaskbarSearchBackground", {
+        L"Background:=$inputActive"}},
+    ThemeTargetStyles{L"Image#SearchIconOn", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"FontIcon#SearchGlyph", {
+        L"Visibility=0"}},
+    ThemeTargetStyles{L"Image#SearchIconOff", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"FontIcon#SearchBoxOnTaskbarSearchGlyph", {
+        L"FontFamily=Segoe MDL2 Assets",
+        L"Glyph=\uE721"}},
+    ThemeTargetStyles{L"GridView#PinnedList > Border > ScrollViewer > Border#Root > Grid > ScrollContentPresenter > ItemsPresenter > GridViewItem > Border#ContentBorder > Grid#DroppedFlickerWorkaroundWrapper > ContentPresenter#ContentPresenter > Grid", {
+        L"Height=84",
+        L"Width=100"}},
+    ThemeTargetStyles{L"GridView#PinnedList", {
+        L"ScrollViewer.VerticalScrollMode=1"}},
+    ThemeTargetStyles{L"StartDocked.UserTileView", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Button#ShowAllAppsButton > ContentPresenter > StackPanel > FontIcon", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Button#CloseAllAppsButton > ContentPresenter > StackPanel > FontIcon", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"Button#CloseAllAppsButton > ContentPresenter > StackPanel > TextBlock", {
+        L"Margin=0",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"StartDocked.AllAppsPane#AllAppsPanel", {
+        L"Margin=28,0,28,-65"}},
+    ThemeTargetStyles{L"FontIcon", {
+        L"FontFamily=Segoe MDL2 Assets"}},
+    ThemeTargetStyles{L"MenuFlyoutPresenter", {
+        L"CornerRadius=4",
+        L"BorderThickness=0,1,0,0",
+        L"BorderBrush:=$button",
+        L"BackgroundSizing=1"}},
+    ThemeTargetStyles{L"StartDocked.StartSizingFrame", {
+        L"MaxHeight=684",
+        L"Height=684",
+        L"MaxWidth=766",
+        L"MinWidth=766"}},
+    ThemeTargetStyles{L"TextBlock#DisplayName", {
+        L"Margin=0,6,0,-16",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"TextBlock#AllAppsHeading", {
+        L"Margin=17,0,0,0",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"TextBlock#TopLevelSuggestionsListHeaderText", {
+        L"Margin=80,25,0,0",
+        L"Text=Recent",
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"GridView#RecommendedList > Border > ScrollViewer#ScrollViewer > Border#Root > Grid > ScrollContentPresenter#ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid > GridViewItem > Border#ContentBorder > Grid#DroppedFlickerWorkaroundWrapper", {
+        L"Margin=0"}},
+    ThemeTargetStyles{L"GridView#RecommendedList", {
+        L"Margin=77,0,0,0"}},
+    ThemeTargetStyles{L"Windows.UI.Xaml.Controls.Primitives.ScrollBar#VerticalScrollBar", {
+        L"Margin=0,0,42,0"}},
+    ThemeTargetStyles{L"StartDocked.PowerOptionsView#PowerButton", {
+        L"Margin=-70,-1188,0,0"}},
+    ThemeTargetStyles{L"StartDocked.NavigationPaneButton#PowerButton > Grid > ContentPresenter > Grid > FontIcon", {
+        L"FontFamily=Segoe MDL2 Assets",
+        L"Glyph=\uE720"}},
+    ThemeTargetStyles{L"MenuFlyoutItem", {
+        L"CornerRadius=0",
+        L"Margin=-4,-2,-4,-2"}},
+    ThemeTargetStyles{L"GridView#PinnedList > ItemsWrapGrid > GridViewItem > Border#ContentBorder > Grid#DroppedFlickerWorkaroundWrapper", {
+        L"Margin=0,0,0,0"}},
+    ThemeTargetStyles{L"TextBlock#Title", {
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"TextBlock#Subtitle", {
+        L"FontFamily=Segoe UI"}},
+    ThemeTargetStyles{L"GridViewItem > Border#ContentBorder > Grid#DroppedFlickerWorkaroundWrapper > Border#BackgroundBorder", {
+        L"FocusVisualPrimaryThickness=0",
+        L"FocusVisualSecondaryThickness=0"}},
+    ThemeTargetStyles{L"JumpViewUI.JumpListListView > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > ItemsStackPanel > ListViewItem", {
+        L"CornerRadius=0"}},
+    ThemeTargetStyles{L"MenuFlyoutSubItem", {
+        L"CornerRadius=0",
+        L"Margin=-4,0,-4,0",
+        L"Padding=11,4,11,5"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootPanel > Grid#RootGrid > Grid#RootContent > Grid#MainContent > Grid#InnerContent > Rectangle", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"StartDocked.LauncherFrame > Grid#RootPanel > Grid#RootGrid", {
+        L"MinWidth=766"}},
+    ThemeTargetStyles{L"Grid#UndockedRoot", {
+        L"Height=553",
+        L"Margin=0,0,0,-64"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox > Grid@CommonStates > Border#BorderElement", {
+        L"Background:=$button",
+        L"Background@PointerOver:=$buttonHover",
+        L"Background@Pressed:=$buttonPress",
+        L"Background@Checked:=$button",
+        L"Background@CheckedPointerOver:=$buttonHover",
+        L"Background@CheckedPressed:=$buttonPress",
+        L"CornerRadius=4",
+        L"Margin=0"}},
+    ThemeTargetStyles{L"Grid#NoTopLevelSuggestionsText", {
+        L"Margin=152,0,0,0"}},
+    ThemeTargetStyles{L"TextBlock#NoSuggestionsWithoutSettingsLink", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"TextBlock#NoSuggestionsWithSettingsLink", {
+        L"Visibility=1"}},
+    ThemeTargetStyles{L"GridView#PinnedList > Border > ScrollViewer > Border > Grid > ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid > GridViewItem", {
+        L"Margin=0,0,24,0"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList > Grid#Root", {
+        L"Padding=5,0,0,0"}},
+    ThemeTargetStyles{L"GridView#RecommendedList > Border > ScrollViewer#ScrollViewer > Border#Root > Grid > ScrollContentPresenter#ScrollContentPresenter > ItemsPresenter > ItemsWrapGrid > GridViewItem", {
+        L"Margin=0"}},
+    ThemeTargetStyles{L"GridView#PinnedList > Border > ScrollViewer > Border#Root > Grid > ScrollContentPresenter > ItemsPresenter", {
+        L"MinHeight=340"}},
+}, {
+    ThemeTargetStyles{L"#qfPreviewPane, #qfPreviewPane *, .leftPill::before, #temporaryMessages, .scope-with-background__backButton, #gr11, #pp_Share, #pp_Review, #chatButtonRight, .curatedSettingsGroup, .scope-with-background__rightCaret, #topHitHeader, .userProfileMenuIcon, .scope-tile__button, .additionalInfoText.annotation, #root:not(.zeroInput19H1):not(.fileExplorer) .topResults .openPreviewPaneBtn .iconContent, .openPreviewIcon .iconContent.cortanaFontIcon, #scopesHeader, #scopesHeader *, #gr36, div[data-region=\"TopApps\"], #gr43, .openPreviewPaneBtn, .suggContainer.largerSearchIcon14 .secondaryText", {
+        L"display: none !important",
+        L"visibility: hidden !important"}},
+    ThemeTargetStyles{L"#qfContainer", {
+        L"max-width: 100% !important",
+        L"margin-inline: 75px !important",
+        L"margin-top: 7px !important"}},
+    ThemeTargetStyles{L".cortanaFontIcon, .iconContent", {
+        L"font-family: 'Segoe MDL2 Assets' !important"}},
+    ThemeTargetStyles{L".leftPill", {
+        L"border-left: 3px solid var(--accent11) !important",
+        L"border-radius: 2px !important"}},
+    ThemeTargetStyles{L".darkTheme .leftPill", {
+        L"border-left: 3px solid var(--accent12) !important"}},
+    ThemeTargetStyles{L"*", {
+        L"scrollbar-width: none !important",
+        L"border-color: transparent !important",
+        L"cursor: default !important"}},
+    ThemeTargetStyles{L".groupContainer.topItemsGroup", {
+        L"order: -1 !important"}},
+    ThemeTargetStyles{L".leftPaneZIsuggestions", {
+        L"margin-left: -19px !important"}},
+    ThemeTargetStyles{L"#root.win11.zeroInput19H1:not(.fileExplorer) .groupContainer:not(.curatedSettingsGroup) .suggestion.selectable:not(.focusable), .suggContainer", {
+        L"border-radius: 2px !important",
+        L"transition: all 83ms ease-out"}},
+    ThemeTargetStyles{L"div[data-region=\"MRUHistory\"] > .suggsList, div[data-region=\"MRUHistory\"] .suggContainer", {
+        L"width: 578px !important"}},
+    ThemeTargetStyles{L".suggestion:not(.groupHeader)", {
+        L"border-radius: 4px !important",
+        L"clip-path: inset(1px 0px 1px 3px round 4px 2px 2px 4px) !important"}},
+    ThemeTargetStyles{L".suggestion[aria-selected=\"true\"] .iconContainer, .suggestion[aria-selected=\"true\"] .details", {
+        L"margin-left: -3px !important"}},
+    ThemeTargetStyles{L".groupHeader", {
+        L"margin-inline: 3px 4px !important"}},
+    ThemeTargetStyles{L".topResults .suggDetailsContainer", {
+        L"min-height: 0px !important"}},
+    ThemeTargetStyles{L".suggDetailsContainer.limitScaleRange", {
+        L"background: transparent !important"}},
+    ThemeTargetStyles{L".topResults .suggDetailsContainer .primaryText", {
+        L"margin-bottom: -2px !important"}},
+}, {
+    L"accent=<SolidColorBrush Color=\"{ThemeResource SystemAccentColor}\"/>",
+    L"accentHover=<SolidColorBrush Color=\"{ThemeResource SystemAccentColor}\" Opacity=\".9\"/>",
+    L"accentPress=<SolidColorBrush Color=\"{ThemeResource SystemAccentColor}\" Opacity=\".8\"/>",
+    L"subtleButtonHover=<SolidColorBrush Color=\"{ThemeResource SubtleFillColorSecondary}\"/>",
+    L"subtleButtonPress=<SolidColorBrush Color=\"{ThemeResource SubtleFillColorTertiary}\"/>",
+    L"button=<SolidColorBrush Color=\"{ThemeResource ControlFillColorDefault}\"/>",
+    L"buttonHover=<SolidColorBrush Color=\"{ThemeResource ControlFillColorSecondary}\"/>",
+    L"buttonPress=<SolidColorBrush Color=\"{ThemeResource ControlFillColorTertiary}\"/>",
+    L"textPrimary=<SolidColorBrush Color=\"{ThemeResource TextFillColorPrimary}\"/>",
+    L"textSecondary=<SolidColorBrush Color=\"{ThemeResource TextFillColorSecondary}\"/>",
+    L"textDisabled=<SolidColorBrush Color=\"{ThemeResource TextFillColorDisabled}\"/>",
+    L"textInverse=<SolidColorBrush Color=\"{ThemeResource TextFillColorInverse}\"/>",
+    L"acrylic=<AcrylicBrush TintColor=\"{ThemeResource SystemChromeMediumColor}\" FallbackColor=\"{ThemeResource SystemChromeMediumColor}\" TintOpacity=\"0\" TintLuminosityOpacity=\"1\"/>",
+    L"fakeShadow=<LinearGradientBrush StartPoint=\"0,0\" EndPoint=\"0,1\"><GradientStop Color=\"#10000000\" Offset=\"0.84\" /><GradientStop Color=\"#26000000\" Offset=\"0.85\" /><GradientStop Color=\"#00000000\" Offset=\"1.0\" /></LinearGradientBrush>",
+    L"inputActive=<SolidColorBrush Color=\"{ThemeResource ControlFillColorInputActive}\"/>",
+    L"separator=<SolidColorBrush Color=\"{ThemeResource SurfaceStrokeColorDefault}\" Opacity=\".5\"/>",
+}};
+
+const Theme g_themeTintedGlass = {{
+    ThemeTargetStyles{L"Border#AcrylicBorder", {
+        L"Background:=$CommonBgBrush",
+        L"BorderThickness=0",
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"Border#AcrylicOverlay", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Border#BorderElement", {
+        L"Background:=<WindhawkBlur BlurAmount=\"18\" TintColor=\"#1AFFFFFF\"/>",
+        L"BorderThickness=0",
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"MenuFlyoutPresenter > Border", {
+        L"Background:=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#22000000\"/>",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"Border#AppBorder", {
+        L"Background:=$CommonBgBrush",
+        L"BorderThickness=0",
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"Border#AccentAppBorder", {
+        L"Background:=$CommonBgBrush",
+        L"BorderThickness=0",
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"Border#LayerBorder", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Border#TaskbarSearchBackground", {
+        L"Background:=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#15000000\"/>",
+        L"BorderThickness=0",
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"Border#ContentBorder@CommonStates > Grid#DroppedFlickerWorkaroundWrapper > Border", {
+        L"Background@Normal:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.2\"/>",
+        L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.3\"/>",
+        L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
+        L"Background@Pressed:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.3\"/>",
+        L"BorderBrush@Pressed:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>"}},
+    ThemeTargetStyles{L"Button#ShowAllAppsButton > ContentPresenter@CommonStates", {
+        L"Background@Normal:=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#15C0C0C0\"/>",
+        L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.5\"/>",
+        L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"StartMenu.SearchBoxToggleButton > Grid > Border#BorderElement", {
+        L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"StartDocked.NavigationPaneButton#UserTileButton > Grid@CommonStates > Border", {
+        L"Background@Normal:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.2\"/>",
+        L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.5\"/>",
+        L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.8\"/>",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"StartDocked.AppListViewItem > Grid@CommonStates > Border", {
+        L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.45\"/>",
+        L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.7\"/>",
+        L"BorderThickness=1",
+        L"Margin@Normal=4"}},
+    ThemeTargetStyles{L"StartDocked.NavigationPaneButton#PowerButton > Grid@CommonStates > Border", {
+        L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.45\"/>",
+        L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.7\"/>",
+        L"BorderThickness=1",
+        L"Margin@Normal=4"}},
+    ThemeTargetStyles{L"ToolTip > ContentPresenter#LayoutRoot", {
+        L"Background:=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#22000000\"/>"}},
+    ThemeTargetStyles{L"Border#dropshadow", {
+        L"CornerRadius=14",
+        L"Margin=-1"}},
+    ThemeTargetStyles{L"Border#StartDropShadow", {
+        L"CornerRadius=14",
+        L"Margin=-1"}},
+    ThemeTargetStyles{L"Grid#TopLevelSuggestionsRoot", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"TextBlock#Text", {
+        L"Foreground=White"}},
+    ThemeTargetStyles{L"Microsoft.UI.Xaml.Controls.DropDownButton > Grid#RootGrid", {
+        L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.3\"/>",
+        L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.6\"/>",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"Button > Grid@CommonStates > Border", {
+        L"Background@Normal:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.2\"/>",
+        L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.3\"/>",
+        L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.6\"/>",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"DropDownButton", {
+        L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.2\"/>"}},
+    ThemeTargetStyles{L"Button#Header > Border#Border@CommonStates", {
+        L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0\"/>",
+        L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.6\"/>",
+        L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.8\"/>"}},
+    ThemeTargetStyles{L"StartMenu.FolderModal > Grid > Border", {
+        L"Background:=$CommonBgBrush",
+        L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.8\"/>",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"ListViewItem > Grid#ContentBorder@CommonStates", {
+        L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.8\"/>",
+        L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
+        L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0\"/>",
+        L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.9\"/>",
+        L"BorderThickness=1",
+        L"CornerRadius=5"}},
+}, {}, {
+    L"CommonBgBrush=<WindhawkBlur BlurAmount=\"18\" TintColor=\"#80000000\"/>",
+}};
+
+const Theme g_themeTintedGlass_variant_ClassicStartMenu = {{
+    ThemeTargetStyles{L"Border#AcrylicBorder", {
+        L"Background:=$CommonBgBrush",
+        L"BorderThickness=0",
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"Border#AcrylicOverlay", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Border#BorderElement", {
+        L"Background:=<WindhawkBlur BlurAmount=\"18\" TintColor=\"#1AFFFFFF\"/>",
+        L"BorderThickness=0",
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"Grid#ShowMoreSuggestions", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Grid#SuggestionsParentContainer", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"Grid#TopLevelSuggestionsListHeader", {
+        L"Visibility=Collapsed"}},
+    ThemeTargetStyles{L"StartMenu.PinnedList", {
+        L"Height=504"}},
+    ThemeTargetStyles{L"MenuFlyoutPresenter > Border", {
+        L"Background:=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#00000000\"/>",
+        L"BorderThickness=0"}},
+    ThemeTargetStyles{L"Border#AppBorder", {
+        L"Background:=$CommonBgBrush",
+        L"BorderThickness=0",
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"Border#AccentAppBorder", {
+        L"Background:=$CommonBgBrush",
+        L"BorderThickness=0",
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"Border#TaskbarSearchBackground", {
+        L"Background:=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#15000000\"/>",
+        L"BorderThickness=0",
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"Border#ContentBorder@CommonStates > Grid#DroppedFlickerWorkaroundWrapper > Border", {
+        L"Background@Normal:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"0\" Opacity=\"0.2\"/>",
+        L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.3\"/>",
+        L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
+        L"Margin=1",
+        L"Background@Pressed:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.3\"/>",
+        L"BorderBrush@Pressed:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>"}},
+    ThemeTargetStyles{L"Button#ShowAllAppsButton > ContentPresenter@CommonStates", {
+        L"Background@Normal:=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#15000000\"/>",
+        L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.5\"/>",
+        L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"StartDocked.SearchBoxToggleButton#StartMenuSearchBox > Grid > Border#BorderElement", {
+        L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"StartDocked.NavigationPaneButton#UserTileButton > Grid@CommonStates > Border", {
+        L"Background@Normal:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"0\" Opacity=\"0.2\"/>",
+        L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.5\"/>",
+        L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.8\"/>",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"StartDocked.AppListViewItem > Grid@CommonStates > Border", {
+        L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.45\"/>",
+        L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.7\"/>",
+        L"BorderThickness=1",
+        L"Margin@Normal=4"}},
+    ThemeTargetStyles{L"StartDocked.NavigationPaneButton#PowerButton > Grid@CommonStates > Border", {
+        L"Background:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.45\"/>",
+        L"BorderBrush:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.7\"/>",
+        L"BorderThickness=1",
+        L"Margin@Normal=4"}},
+    ThemeTargetStyles{L"ToolTip > ContentPresenter#LayoutRoot", {
+        L"Background:=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#15000000\"/>"}},
+    ThemeTargetStyles{L"StartDocked.AllAppsGridListViewItem > Grid@CommonStates > Border", {
+        L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.8\"/>",
+        L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.55\"/>",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"Button#CloseAllAppsButton > ContentPresenter@CommonStates", {
+        L"Background@Normal:=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#15000000\"/>",
+        L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.5\"/>",
+        L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"1\"/>",
+        L"BorderThickness=1"}},
+    ThemeTargetStyles{L"StartDocked.AllAppsZoomListViewItem > Grid@CommonStates > Border", {
+        L"Background@Normal:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"0\" Opacity=\"0.2\"/>",
+        L"Background@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.3\"/>",
+        L"BorderBrush@PointerOver:=<RevealBorderBrush Color=\"Transparent\" TargetTheme=\"1\" Opacity=\"0.6\"/>"}},
+    ThemeTargetStyles{L"Border#dropshadow", {
+        L"CornerRadius=14",
+        L"Margin=-1"}},
+    ThemeTargetStyles{L"Border#DropShadow", {
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"Border#StartDropShadow", {
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"Border#RootGridDropShadow", {
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"Border#RightCompanionDropShadow", {
+        L"CornerRadius=14"}},
+    ThemeTargetStyles{L"StartDocked.AllAppsGridListViewItem > Grid#ContentBorder@CommonStates", {
+        L"Background@PointerOver:=<WindhawkBlur BlurAmount=\"25\" TintColor=\"#15C0C0C0\"/>",
+        L"CornerRadius=14"}},
+}, {}, {
+    L"CommonBgBrush=<WindhawkBlur BlurAmount=\"18\" TintColor=\"#80000000\"/>",
 }};
 
 // clang-format on
@@ -4965,7 +6055,10 @@ VisualTreeWatcher::~VisualTreeWatcher()
 void VisualTreeWatcher::UnadviseVisualTreeChange()
 {
     Wh_Log(L"UnadviseVisualTreeChange VisualTreeWatcher");
-    winrt::check_hresult(m_XamlDiagnostics.as<IVisualTreeService3>()->UnadviseVisualTreeChange(this));
+    HRESULT hr = m_XamlDiagnostics.as<IVisualTreeService3>()->UnadviseVisualTreeChange(this);
+    if (FAILED(hr)) {
+        Wh_Log(L"UnadviseVisualTreeChange failed with error %08X", hr);
+    }
 }
 
 HRESULT VisualTreeWatcher::OnVisualTreeChange(ParentChildRelation, VisualElement element, VisualMutationType mutationType) try
@@ -5225,9 +6318,12 @@ HRESULT InjectWindhawkTAP() noexcept
 // clang-format on
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <algorithm>
+#include <cmath>
 #include <list>
 #include <mutex>
 #include <optional>
+#include <random>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -5238,22 +6334,37 @@ HRESULT InjectWindhawkTAP() noexcept
 
 using namespace std::string_view_literals;
 
+#include <initguid.h>
+
 #include <commctrl.h>
+#include <d2d1_1.h>
 #include <roapi.h>
+#include <windows.graphics.effects.h>
 #include <winstring.h>
 
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Graphics.Effects.h>
 #include <winrt/Windows.Networking.Connectivity.h>
+#include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Windows.System.h>
+#include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Text.h>
+#include <winrt/Windows.UI.ViewManagement.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Windows.UI.Xaml.Media.Imaging.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.h>
 
 using namespace winrt::Windows::UI::Xaml;
+
+namespace wge = winrt::Windows::Graphics::Effects;
+namespace wuc = winrt::Windows::UI::Composition;
+namespace wuxh = wux::Hosting;
+namespace awge = ABI::Windows::Graphics::Effects;
 
 enum class Target {
     StartMenu,
@@ -5306,6 +6417,10 @@ struct XamlBlurBrushParams {
     winrt::Windows::UI::Color tint;
     std::optional<uint8_t> tintOpacity;
     std::wstring tintThemeResourceKey;  // Empty if not from ThemeResource
+    std::optional<float> tintLuminosityOpacity;
+    std::optional<float> tintSaturation;
+    std::optional<float> noiseOpacity;
+    std::optional<float> noiseDensity;
 };
 
 using PropertyOverrideValue =
@@ -5330,6 +6445,7 @@ std::vector<ElementCustomizationRules> g_elementsCustomizationRules;
 struct ElementPropertyCustomizationState {
     std::optional<winrt::Windows::Foundation::IInspectable> originalValue;
     std::optional<PropertyOverrideValue> customValue;
+    winrt::Windows::Foundation::IInspectable lastAppliedValue{nullptr};
     int64_t propertyChangedToken = 0;
 };
 
@@ -5369,7 +6485,14 @@ bool g_elementPropertyModifying;
 winrt::Windows::Foundation::IAsyncOperation<bool>
     g_delayedAllAppsRootVisibilitySet;
 
-bool g_disableNewStartMenuLayout;
+enum class DisableNewStartMenuLayout {
+    windowsDefault,
+    disableNewLayoutAndPhoneLink,
+    disableNewLayoutKeepPhoneLink,
+    forceNewLayout,
+};
+
+DisableNewStartMenuLayout g_disableNewStartMenuLayout;
 
 // Global list to track ImageBrushes with failed loads for retry on network
 // reconnection.
@@ -5393,45 +6516,178 @@ std::vector<winrt::weak_ref<winrt::Windows::System::DispatcherQueue>>
     g_failedImageBrushesRegistry;
 winrt::event_token g_networkStatusChangedToken;
 
+enum class ResourceVariableTheme {
+    None,
+    Dark,
+    Light,
+};
+
+struct ResourceVariableEntry {
+    std::wstring key;
+    std::wstring value;
+    ResourceVariableTheme theme;
+};
+
+// Track original resource values for restoration (per-thread since
+// Application::Current().Resources() is per-thread).
+std::unordered_map<std::wstring, winrt::Windows::Foundation::IInspectable>
+    g_originalResourceValues;
+
+// Track our merged theme dictionary for cleanup (per-thread).
+ResourceDictionary g_resourceVariablesThemeDict{nullptr};
+bool g_resourceVariablesThemeDictMerged = false;
+
+// Track theme resource entries that reference {ThemeResource ...} for refresh
+// (per-thread).
+std::vector<ResourceVariableEntry> g_themeResourceEntries;
+
+// For listening to theme color changes (per-thread).
+winrt::Windows::UI::ViewManagement::UISettings g_uiSettings{nullptr};
+thread_local winrt::event_token g_colorValuesChangedToken;
+
 winrt::Windows::Foundation::IInspectable ReadLocalValueWithWorkaround(
     DependencyObject elementDo,
     DependencyProperty property) {
-    const auto value = elementDo.ReadLocalValue(property);
-    if (value && winrt::get_class_name(value) ==
-                     L"Windows.UI.Xaml.Data.BindingExpressionBase") {
-        // BindingExpressionBase was observed to be returned for XAML properties
-        // that were declared as following:
-        //
-        // <Border ... CornerRadius="{TemplateBinding CornerRadius}" />
-        //
-        // Calling SetValue with it fails with an error, so we won't be able to
-        // use it to restore the value. As a workaround, we use
-        // GetAnimationBaseValue to get the value.
-        return elementDo.GetAnimationBaseValue(property);
+    // Workaround for AcrylicBrushes returning an incorrect background brush.
+    // When restored, it doesn't look correct.
+    bool getValueWorkaround = false;
+    if (property == Controls::Border::BackgroundProperty()) {
+        auto border = elementDo.try_as<Controls::Border>();
+        if (border && border.Name() == L"AcrylicBorder") {
+            Wh_Log(L"Using GetValue workaround for AcrylicBorder background");
+            getValueWorkaround = true;
+        }
+    } else if (property == FrameworkElement::MaxHeightProperty()) {
+        auto grid = elementDo.try_as<Controls::Grid>();
+        if (grid && grid.Name() == L"FrameRoot") {
+            Wh_Log(L"Using GetValue workaround for FrameRoot MaxHeight");
+            getValueWorkaround = true;
+        }
+    } else if (property == FrameworkElement::WidthProperty()) {
+        auto grid = elementDo.try_as<Controls::Grid>();
+        if (grid && grid.Name() == L"MainMenu") {
+            Wh_Log(L"Using GetValue workaround for MainMenu Width");
+            getValueWorkaround = true;
+        }
     }
 
+    auto value = getValueWorkaround ? elementDo.GetValue(property)
+                                    : elementDo.ReadLocalValue(property);
+    if (value) {
+        auto className = winrt::get_class_name(value);
+        if (className == L"Windows.UI.Xaml.Data.BindingExpressionBase" ||
+            className == L"Windows.UI.Xaml.Data.BindingExpression") {
+            // BindingExpressionBase was observed to be returned for XAML
+            // properties that were declared as following:
+            //
+            // <Border ... CornerRadius="{TemplateBinding CornerRadius}" />
+            //
+            // Calling SetValue with it fails with an error, so we won't be able
+            // to use it to restore the value. As a workaround, we use
+            // GetAnimationBaseValue to get the value.
+            Wh_Log(L"ReadLocalValue returned %s, using GetAnimationBaseValue",
+                   className.c_str());
+            value = elementDo.GetAnimationBaseValue(property);
+        }
+    }
+
+    Wh_Log(L"Read property value %s",
+           value ? (value == DependencyProperty::UnsetValue()
+                        ? L"(unset)"
+                        : winrt::get_class_name(value).c_str())
+                 : L"(null)");
+
     return value;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Noise generation
+//
+// Generates a tileable noise BMP in memory. Density controls the brightness
+// distribution curve via a power function (lower density = sparser bright
+// pixels). Opacity is handled downstream by the composition effect graph.
+winrt::Windows::Storage::Streams::IRandomAccessStream CreateNoiseStream(
+    float density) {
+    // Cache the last stream to avoid regenerating when density hasn't changed.
+    // The cached stream is never read directly; callers get independent clones
+    // via CloneStream() so they don't share a seek cursor.
+    thread_local float cachedDensity = std::numeric_limits<float>::quiet_NaN();
+    thread_local winrt::Windows::Storage::Streams::InMemoryRandomAccessStream
+        cachedStream{nullptr};
+
+    if (density == cachedDensity && cachedStream) {
+        return cachedStream.CloneStream();
+    }
+
+    // Use 256x256 to minimize visible tiling seams.
+    constexpr int kSize = 256;
+    constexpr DWORD kBpp = 32;
+    constexpr DWORD rowSize = kSize * (kBpp / 8);
+    constexpr DWORD dataSize = rowSize * kSize;
+
+    BITMAPFILEHEADER fileHeader{
+        .bfType = 0x4D42,  // "BM"
+        .bfSize =
+            sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + dataSize,
+        .bfOffBits = sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER),
+    };
+
+    BITMAPINFOHEADER infoHeader{
+        .biSize = sizeof(BITMAPINFOHEADER),
+        .biWidth = kSize,
+        .biHeight = kSize,
+        .biPlanes = 1,
+        .biBitCount = kBpp,
+        .biSizeImage = dataSize,
+    };
+
+    std::vector<uint8_t> pixels(dataSize);
+
+    // Precompute the density power curve as a lookup table so that
+    // std::pow is called 256 times instead of once per pixel (65536).
+    float safeDensity = std::clamp(density, 0.001f, 1.0f);
+    float exponent = 1.0f / safeDensity;
+
+    uint8_t lut[256];
+    for (int i = 0; i < 256; i++) {
+        lut[i] = static_cast<uint8_t>(std::pow(i / 255.0f, exponent) * 255.0f);
+    }
+
+    std::mt19937 rng(0);
+    std::uniform_int_distribution<int> dist(0, 255);
+
+    for (size_t i = 0; i < pixels.size(); i += 4) {
+        uint8_t gray = lut[dist(rng)];
+
+        // Fully opaque; opacity is applied downstream by ColorMatrixEffect.
+        pixels[i] = gray;
+        pixels[i + 1] = gray;
+        pixels[i + 2] = gray;
+        pixels[i + 3] = 255;
+    }
+
+    winrt::Windows::Storage::Streams::InMemoryRandomAccessStream stream;
+    winrt::Windows::Storage::Streams::DataWriter writer(stream);
+    writer.WriteBytes(winrt::array_view<const uint8_t>(
+        reinterpret_cast<const uint8_t*>(&fileHeader), sizeof(fileHeader)));
+    writer.WriteBytes(winrt::array_view<const uint8_t>(
+        reinterpret_cast<const uint8_t*>(&infoHeader), sizeof(infoHeader)));
+    writer.WriteBytes(pixels);
+    writer.StoreAsync().get();
+    writer.DetachStream();
+
+    cachedStream = std::move(stream);
+    cachedDensity = density;
+
+    return cachedStream.CloneStream();
 }
 
 // Blur background implementation, copied from TranslucentTB.
 ////////////////////////////////////////////////////////////////////////////////
 // clang-format off
-
-#include <initguid.h>
-
-#include <winrt/Windows.UI.Xaml.Hosting.h>
-
-namespace wge = winrt::Windows::Graphics::Effects;
-namespace wuc = winrt::Windows::UI::Composition;
-namespace wuxh = wux::Hosting;
-
 template <> inline constexpr winrt::guid winrt::impl::guid_v<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>{
     winrt::impl::guid_v<winrt::Windows::Foundation::IPropertyValue>
 };
-
-#ifndef E_BOUNDS
-#define E_BOUNDS (HRESULT)(0x8000000BL)
-#endif
 
 typedef enum MY_D2D1_GAUSSIANBLUR_OPTIMIZATION
 {
@@ -5444,46 +6700,40 @@ typedef enum MY_D2D1_GAUSSIANBLUR_OPTIMIZATION
 
 ////////////////////////////////////////////////////////////////////////////////
 // XamlBlurBrush.h
-#include <winrt/Windows.Foundation.Numerics.h>
-#include <winrt/Windows.UI.Composition.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.ViewManagement.h>
-
 class XamlBlurBrush : public wux::Media::XamlCompositionBrushBaseT<XamlBlurBrush>
 {
 public:
-	XamlBlurBrush(wuc::Compositor compositor,
-	              float blurAmount,
-	              winrt::Windows::UI::Color tint,
-	              std::optional<uint8_t> tintOpacity,
-	              winrt::hstring tintThemeResourceKey);
+    XamlBlurBrush(wuc::Compositor compositor,
+                  float blurAmount,
+                  winrt::Windows::UI::Color tint,
+                  std::optional<uint8_t> tintOpacity,
+                  winrt::hstring tintThemeResourceKey,
+                  std::optional<float> tintLuminosityOpacity,
+                  std::optional<float> tintSaturation,
+                  std::optional<float> noiseOpacity,
+                  std::optional<float> noiseDensity);
 
-	void OnConnected();
-	void OnDisconnected();
+    void OnConnected();
+    void OnDisconnected();
 
 private:
-	void RefreshThemeTint();
-	void OnThemeRefreshed();
+    void RefreshThemeTint();
+    void OnThemeRefreshed();
 
-	wuc::Compositor m_compositor;
-	float m_blurAmount;
-	winrt::Windows::UI::Color m_tint;
-	std::optional<uint8_t> m_tintOpacity;
-	winrt::hstring m_tintThemeResourceKey;
-	winrt::Windows::UI::ViewManagement::UISettings m_uiSettings;
+    wuc::Compositor m_compositor;
+    float m_blurAmount;
+    winrt::Windows::UI::Color m_tint;
+    std::optional<uint8_t> m_tintOpacity;
+    winrt::hstring m_tintThemeResourceKey;
+    std::optional<float> m_tintLuminosityOpacity;
+    std::optional<float> m_tintSaturation;
+    std::optional<float> m_noiseOpacity;
+    std::optional<float> m_noiseDensity;
+    winrt::Windows::UI::ViewManagement::UISettings m_uiSettings;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-// CompositeEffect.h
-#include <d2d1effects.h>
-#include <d2d1_1.h>
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.Graphics.Effects.h>
-// #include <windows.graphics.effects.interop.h>
-
-#include <windows.graphics.effects.h>
-#include <sdkddkver.h>
-
+// windows.graphics.effects.interop.h
 #ifndef BUILD_WINDOWS
 namespace ABI {
 #endif
@@ -5506,7 +6756,7 @@ typedef enum GRAPHICS_EFFECT_PROPERTY_MAPPING
     GRAPHICS_EFFECT_PROPERTY_MAPPING_RECT_TO_VECTOR4,
     GRAPHICS_EFFECT_PROPERTY_MAPPING_RADIANS_TO_DEGREES,
     GRAPHICS_EFFECT_PROPERTY_MAPPING_COLORMATRIX_ALPHA_MODE,
-    GRAPHICS_EFFECT_PROPERTY_MAPPING_COLOR_TO_VECTOR3, 
+    GRAPHICS_EFFECT_PROPERTY_MAPPING_COLOR_TO_VECTOR3,
     GRAPHICS_EFFECT_PROPERTY_MAPPING_COLOR_TO_VECTOR4
 } GRAPHICS_EFFECT_PROPERTY_MAPPING;
 
@@ -5559,7 +6809,7 @@ DECLARE_INTERFACE_IID_(IGraphicsEffectD2D1Interop, IUnknown, "2FC57384-A068-44D7
 } // namespace Graphics
 } // namespace Windows
 #ifndef BUILD_WINDOWS
-} // namespace ABI 
+} // namespace ABI
 #endif
 
 template <> inline constexpr winrt::guid winrt::impl::guid_v<ABI::Windows::Graphics::Effects::IGraphicsEffectD2D1Interop>{
@@ -5567,552 +6817,946 @@ template <> inline constexpr winrt::guid winrt::impl::guid_v<ABI::Windows::Graph
 };
 
 
-
-namespace awge = ABI::Windows::Graphics::Effects;
-
+////////////////////////////////////////////////////////////////////////////////
+// CompositeEffect.h
 struct CompositeEffect : winrt::implements<CompositeEffect, wge::IGraphicsEffect, wge::IGraphicsEffectSource, awge::IGraphicsEffectD2D1Interop>
 {
 public:
-	// IGraphicsEffectD2D1Interop
-	HRESULT STDMETHODCALLTYPE GetEffectId(GUID* id) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetPropertyCount(UINT* count) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetSource(UINT index, awge::IGraphicsEffectSource** source) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetSourceCount(UINT* count) noexcept override;
+    // IGraphicsEffectD2D1Interop
+    HRESULT STDMETHODCALLTYPE GetEffectId(GUID* id) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetPropertyCount(UINT* count) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetSource(UINT index, awge::IGraphicsEffectSource** source) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetSourceCount(UINT* count) noexcept override;
 
-	// IGraphicsEffect
-	winrt::hstring Name();
-	void Name(winrt::hstring name);
+    // IGraphicsEffect
+    winrt::hstring Name();
+    void Name(winrt::hstring name);
 
-	std::vector<wge::IGraphicsEffectSource> Sources;
-	D2D1_COMPOSITE_MODE Mode = D2D1_COMPOSITE_MODE_SOURCE_OVER;
+    std::vector<wge::IGraphicsEffectSource> Sources;
+    D2D1_COMPOSITE_MODE Mode = D2D1_COMPOSITE_MODE_SOURCE_OVER;
 private:
-	winrt::hstring m_name = L"CompositeEffect";
+    winrt::hstring m_name = L"CompositeEffect";
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 // CompositeEffect.cpp
 HRESULT CompositeEffect::GetEffectId(GUID* id) noexcept
 {
-	if (id == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (id == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	*id = CLSID_D2D1Composite;
-	return S_OK;
+    *id = CLSID_D2D1Composite;
+    return S_OK;
 }
 
 HRESULT CompositeEffect::GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept
 {
-	if (index == nullptr || mapping == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (index == nullptr || mapping == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	const std::wstring_view nameView(name);
-	if (nameView == L"Mode")
-	{
-		*index = D2D1_COMPOSITE_PROP_MODE;
-		*mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
+    const std::wstring_view nameView(name);
+    if (nameView == L"Mode")
+    {
+        *index = D2D1_COMPOSITE_PROP_MODE;
+        *mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
 
-		return S_OK;
-	}
+        return S_OK;
+    }
 
-	return E_INVALIDARG;
+    return E_INVALIDARG;
 }
 
 HRESULT CompositeEffect::GetPropertyCount(UINT* count) noexcept
 {
-	if (count == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (count == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	*count = 1;
-	return S_OK;
+    *count = 1;
+    return S_OK;
 }
 
 HRESULT CompositeEffect::GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept try
 {
-	if (value == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (value == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	switch (index)
-	{
-		case D2D1_COMPOSITE_PROP_MODE:
-			*value = wf::PropertyValue::CreateUInt32((UINT32)Mode).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
-			break;
+    switch (index)
+    {
+        case D2D1_COMPOSITE_PROP_MODE:
+            *value = wf::PropertyValue::CreateUInt32((UINT32)Mode).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
+            break;
 
-		default:
-			return E_BOUNDS;
-	}
+        default:
+            return E_BOUNDS;
+    }
 
-	return S_OK;
+    return S_OK;
 }
 catch (...)
 {
-	return winrt::to_hresult();
+    return winrt::to_hresult();
 }
 
 HRESULT CompositeEffect::GetSource(UINT index, awge::IGraphicsEffectSource** source) noexcept try
 {
-	if (source == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (source == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	winrt::copy_to_abi(Sources.at(index), *reinterpret_cast<void**>(source));
-	return S_OK;
+    winrt::copy_to_abi(Sources.at(index), *reinterpret_cast<void**>(source));
+    return S_OK;
 }
 catch (...)
 {
-	return winrt::to_hresult();
+    return winrt::to_hresult();
 }
 
 HRESULT CompositeEffect::GetSourceCount(UINT* count) noexcept
 {
-	if (count == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (count == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	*count = static_cast<UINT>(Sources.size());
-	return S_OK;
+    *count = static_cast<UINT>(Sources.size());
+    return S_OK;
 }
 
 winrt::hstring CompositeEffect::Name()
 {
-	return m_name;
+    return m_name;
 }
 
 void CompositeEffect::Name(winrt::hstring name)
 {
-	m_name = name;
+    m_name = name;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // FloodEffect.h
-#include <d2d1effects.h>
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.Foundation.Numerics.h>
-#include <winrt/Windows.Graphics.Effects.h>
-// #include <windows.graphics.effects.interop.h>
-
-namespace awge = ABI::Windows::Graphics::Effects;
-
 struct FloodEffect : winrt::implements<FloodEffect, wge::IGraphicsEffect, wge::IGraphicsEffectSource, awge::IGraphicsEffectD2D1Interop>
 {
 public:
-	// IGraphicsEffectD2D1Interop
-	HRESULT STDMETHODCALLTYPE GetEffectId(GUID* id) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetPropertyCount(UINT* count) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetSource(UINT index, awge::IGraphicsEffectSource** source) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetSourceCount(UINT* count) noexcept override;
+    // IGraphicsEffectD2D1Interop
+    HRESULT STDMETHODCALLTYPE GetEffectId(GUID* id) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetPropertyCount(UINT* count) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetSource(UINT index, awge::IGraphicsEffectSource** source) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetSourceCount(UINT* count) noexcept override;
 
-	// IGraphicsEffect
-	winrt::hstring Name();
-	void Name(winrt::hstring name);
+    // IGraphicsEffect
+    winrt::hstring Name();
+    void Name(winrt::hstring name);
 
-	winrt::Windows::UI::Color Color{};
+    winrt::Windows::UI::Color Color{};
 private:
-	winrt::hstring m_name = L"FloodEffect";
+    winrt::hstring m_name = L"FloodEffect";
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 // FloodEffect.cpp
 HRESULT FloodEffect::GetEffectId(GUID* id) noexcept
 {
-	if (id == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (id == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	*id = CLSID_D2D1Flood;
-	return S_OK;
+    *id = CLSID_D2D1Flood;
+    return S_OK;
 }
 
 HRESULT FloodEffect::GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept
 {
-	if (index == nullptr || mapping == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (index == nullptr || mapping == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	const std::wstring_view nameView(name);
-	if (nameView == L"Color")
-	{
-		*index = D2D1_FLOOD_PROP_COLOR;
-		*mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
+    const std::wstring_view nameView(name);
+    if (nameView == L"Color")
+    {
+        *index = D2D1_FLOOD_PROP_COLOR;
+        *mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
 
-		return S_OK;
-	}
+        return S_OK;
+    }
 
-	return E_INVALIDARG;
+    return E_INVALIDARG;
 }
 
 HRESULT FloodEffect::GetPropertyCount(UINT* count) noexcept
 {
-	if (count == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (count == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	*count = 1;
-	return S_OK;
+    *count = 1;
+    return S_OK;
 }
 
 HRESULT FloodEffect::GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept try
 {
-	if (value == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (value == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	switch (index)
-	{
-		case D2D1_FLOOD_PROP_COLOR:
-			*value = wf::PropertyValue::CreateSingleArray({
-				Color.R / 255.0f,
-				Color.G / 255.0f,
-				Color.B / 255.0f,
-				Color.A / 255.0f,
-			}).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
-			break;
+    switch (index)
+    {
+        case D2D1_FLOOD_PROP_COLOR:
+            *value = wf::PropertyValue::CreateSingleArray({
+                Color.R / 255.0f,
+                Color.G / 255.0f,
+                Color.B / 255.0f,
+                Color.A / 255.0f,
+            }).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
+            break;
 
-		default:
-			return E_BOUNDS;
-	}
+        default:
+            return E_BOUNDS;
+    }
 
-	return S_OK;
+    return S_OK;
 }
 catch (...)
 {
-	return winrt::to_hresult();
+    return winrt::to_hresult();
 }
 
 HRESULT FloodEffect::GetSource(UINT, awge::IGraphicsEffectSource** source) noexcept
 {
-	if (source == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (source == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	return E_BOUNDS;
+    return E_BOUNDS;
 }
 
 HRESULT FloodEffect::GetSourceCount(UINT* count) noexcept
 {
-	if (count == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (count == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	*count = 0;
-	return S_OK;
+    *count = 0;
+    return S_OK;
 }
 
 winrt::hstring FloodEffect::Name()
 {
-	return m_name;
+    return m_name;
 }
 
 void FloodEffect::Name(winrt::hstring name)
 {
-	m_name = name;
+    m_name = name;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BorderEffect.h
+struct BorderEffect : winrt::implements<BorderEffect, wge::IGraphicsEffect, wge::IGraphicsEffectSource, awge::IGraphicsEffectD2D1Interop>
+{
+public:
+    // IGraphicsEffectD2D1Interop
+    HRESULT STDMETHODCALLTYPE GetEffectId(GUID* id) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetPropertyCount(UINT* count) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetSource(UINT index, awge::IGraphicsEffectSource** source) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetSourceCount(UINT* count) noexcept override;
+
+    // IGraphicsEffect
+    winrt::hstring Name();
+    void Name(winrt::hstring name);
+
+    wge::IGraphicsEffectSource Source{nullptr};
+    D2D1_BORDER_EDGE_MODE ExtendX = D2D1_BORDER_EDGE_MODE_WRAP;
+    D2D1_BORDER_EDGE_MODE ExtendY = D2D1_BORDER_EDGE_MODE_WRAP;
+private:
+    winrt::hstring m_name = L"BorderEffect";
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// BorderEffect.cpp
+HRESULT BorderEffect::GetEffectId(GUID* id) noexcept
+{
+    if (!id)
+    {
+        return E_INVALIDARG;
+    }
+
+    *id = CLSID_D2D1Border;
+    return S_OK;
+}
+
+HRESULT BorderEffect::GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept
+{
+    if (!index || !mapping)
+    {
+        return E_INVALIDARG;
+    }
+
+    const std::wstring_view nameView(name);
+    if (nameView == L"ExtendX")
+    {
+        *index = D2D1_BORDER_PROP_EDGE_MODE_X;
+        *mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
+
+        return S_OK;
+    }
+
+    if (nameView == L"ExtendY")
+    {
+        *index = D2D1_BORDER_PROP_EDGE_MODE_Y;
+        *mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
+
+        return S_OK;
+    }
+
+    return E_INVALIDARG;
+}
+
+HRESULT BorderEffect::GetPropertyCount(UINT* count) noexcept
+{
+    if (!count)
+    {
+        return E_INVALIDARG;
+    }
+
+    *count = 2;
+    return S_OK;
+}
+
+HRESULT BorderEffect::GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept try
+{
+    if (!value)
+    {
+        return E_INVALIDARG;
+    }
+
+    switch (index)
+    {
+        case D2D1_BORDER_PROP_EDGE_MODE_X:
+            *value = wf::PropertyValue::CreateUInt32((UINT32)ExtendX).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
+            break;
+
+        case D2D1_BORDER_PROP_EDGE_MODE_Y:
+            *value = wf::PropertyValue::CreateUInt32((UINT32)ExtendY).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
+            break;
+
+        default:
+            return E_BOUNDS;
+    }
+
+    return S_OK;
+}
+catch (...)
+{
+    return winrt::to_hresult();
+}
+
+HRESULT BorderEffect::GetSource(UINT index, awge::IGraphicsEffectSource** source) noexcept
+{
+    if (!source)
+    {
+        return E_INVALIDARG;
+    }
+
+    if (index == 0 && Source)
+    {
+        winrt::copy_to_abi(Source, *reinterpret_cast<void**>(source));
+        return S_OK;
+    }
+
+    return E_BOUNDS;
+}
+
+HRESULT BorderEffect::GetSourceCount(UINT* count) noexcept
+{
+    if (!count)
+    {
+        return E_INVALIDARG;
+    }
+
+    *count = 1;
+    return S_OK;
+}
+
+winrt::hstring BorderEffect::Name()
+{
+    return m_name;
+}
+
+void BorderEffect::Name(winrt::hstring name)
+{
+    m_name = name;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // GaussianBlurEffect.h
-#include <d2d1effects.h>
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.Graphics.Effects.h>
-// #include <windows.graphics.effects.interop.h>
-
-namespace wge = winrt::Windows::Graphics::Effects;
-namespace awge = ABI::Windows::Graphics::Effects;
-
 struct GaussianBlurEffect : winrt::implements<GaussianBlurEffect, wge::IGraphicsEffect, wge::IGraphicsEffectSource, awge::IGraphicsEffectD2D1Interop>
 {
 public:
-	// IGraphicsEffectD2D1Interop
-	HRESULT STDMETHODCALLTYPE GetEffectId(GUID* id) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetPropertyCount(UINT* count) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetSource(UINT index, awge::IGraphicsEffectSource** source) noexcept override;
-	HRESULT STDMETHODCALLTYPE GetSourceCount(UINT* count) noexcept override;
+    // IGraphicsEffectD2D1Interop
+    HRESULT STDMETHODCALLTYPE GetEffectId(GUID* id) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetPropertyCount(UINT* count) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetSource(UINT index, awge::IGraphicsEffectSource** source) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetSourceCount(UINT* count) noexcept override;
 
-	// IGraphicsEffect
-	winrt::hstring Name();
-	void Name(winrt::hstring name);
+    // IGraphicsEffect
+    winrt::hstring Name();
+    void Name(winrt::hstring name);
 
-	wge::IGraphicsEffectSource Source;
+    wge::IGraphicsEffectSource Source;
 
-	float BlurAmount = 3.0f;
-	MY_D2D1_GAUSSIANBLUR_OPTIMIZATION Optimization = MY_D2D1_GAUSSIANBLUR_OPTIMIZATION_BALANCED;
-	D2D1_BORDER_MODE BorderMode = D2D1_BORDER_MODE_SOFT;
+    float BlurAmount = 3.0f;
+    MY_D2D1_GAUSSIANBLUR_OPTIMIZATION Optimization = MY_D2D1_GAUSSIANBLUR_OPTIMIZATION_BALANCED;
+    D2D1_BORDER_MODE BorderMode = D2D1_BORDER_MODE_SOFT;
 private:
-	winrt::hstring m_name = L"GaussianBlurEffect";
+    winrt::hstring m_name = L"GaussianBlurEffect";
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 // GaussianBlurEffect.cpp
 HRESULT GaussianBlurEffect::GetEffectId(GUID* id) noexcept
 {
-	if (id == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (id == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	*id = CLSID_D2D1GaussianBlur;
-	return S_OK;
+    *id = CLSID_D2D1GaussianBlur;
+    return S_OK;
 }
 
 HRESULT GaussianBlurEffect::GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept
 {
-	if (index == nullptr || mapping == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (index == nullptr || mapping == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	const std::wstring_view nameView(name);
-	if (nameView == L"BlurAmount")
-	{
-		*index = D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION;
-		*mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
+    const std::wstring_view nameView(name);
+    if (nameView == L"BlurAmount")
+    {
+        *index = D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION;
+        *mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
 
-		return S_OK;
-	}
-	else if (nameView == L"Optimization")
-	{
-		*index = D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION;
-		*mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
+        return S_OK;
+    }
+    else if (nameView == L"Optimization")
+    {
+        *index = D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION;
+        *mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
 
-		return S_OK;
-	}
-	else if (nameView == L"BorderMode")
-	{
-		*index = D2D1_GAUSSIANBLUR_PROP_BORDER_MODE;
-		*mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
+        return S_OK;
+    }
+    else if (nameView == L"BorderMode")
+    {
+        *index = D2D1_GAUSSIANBLUR_PROP_BORDER_MODE;
+        *mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
 
-		return S_OK;
-	}
+        return S_OK;
+    }
 
-	return E_INVALIDARG;
+    return E_INVALIDARG;
 }
 
 HRESULT GaussianBlurEffect::GetPropertyCount(UINT* count) noexcept
 {
-	if (count == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (count == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	*count = 3;
-	return S_OK;
+    *count = 3;
+    return S_OK;
 }
 
 HRESULT GaussianBlurEffect::GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept try
 {
-	if (value == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (value == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	switch (index)
-	{
-		case D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION:
-			*value = wf::PropertyValue::CreateSingle(BlurAmount).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
-			break;
+    switch (index)
+    {
+        case D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION:
+            *value = wf::PropertyValue::CreateSingle(BlurAmount).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
+            break;
 
-		case D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION:
-			*value = wf::PropertyValue::CreateUInt32((UINT32)Optimization).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
-			break;
+        case D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION:
+            *value = wf::PropertyValue::CreateUInt32((UINT32)Optimization).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
+            break;
 
-		case D2D1_GAUSSIANBLUR_PROP_BORDER_MODE:
-			*value = wf::PropertyValue::CreateUInt32((UINT32)BorderMode).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
-			break;
+        case D2D1_GAUSSIANBLUR_PROP_BORDER_MODE:
+            *value = wf::PropertyValue::CreateUInt32((UINT32)BorderMode).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
+            break;
 
-		default:
-			return E_BOUNDS;
-	}
+        default:
+            return E_BOUNDS;
+    }
 
-	return S_OK;
+    return S_OK;
 }
 catch (...)
 {
-	return winrt::to_hresult();
+    return winrt::to_hresult();
 }
 
 HRESULT GaussianBlurEffect::GetSource(UINT index, awge::IGraphicsEffectSource** source) noexcept
 {
-	if (source == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (source == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	if (index == 0)
-	{
-		winrt::copy_to_abi(Source, *reinterpret_cast<void**>(source));
-		return S_OK;
-	}
-	else
-	{
-		return E_BOUNDS;
-	}
+    if (index == 0)
+    {
+        winrt::copy_to_abi(Source, *reinterpret_cast<void**>(source));
+        return S_OK;
+    }
+    else
+    {
+        return E_BOUNDS;
+    }
 }
 
 HRESULT GaussianBlurEffect::GetSourceCount(UINT* count) noexcept
 {
-	if (count == nullptr) [[unlikely]]
-	{
-		return E_INVALIDARG;
-	}
+    if (count == nullptr) [[unlikely]]
+    {
+        return E_INVALIDARG;
+    }
 
-	*count = 1;
-	return S_OK;
+    *count = 1;
+    return S_OK;
 }
 
 winrt::hstring GaussianBlurEffect::Name()
 {
-	return m_name;
+    return m_name;
 }
 
 void GaussianBlurEffect::Name(winrt::hstring name)
 {
-	m_name = name;
+    m_name = name;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ColorMatrixEffect.h
+struct ColorMatrixEffect : winrt::implements<ColorMatrixEffect, wge::IGraphicsEffect, wge::IGraphicsEffectSource, awge::IGraphicsEffectD2D1Interop>
+{
+public:
+    // IGraphicsEffectD2D1Interop
+    HRESULT STDMETHODCALLTYPE GetEffectId(GUID* id) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetPropertyCount(UINT* count) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetSource(UINT index, awge::IGraphicsEffectSource** source) noexcept override;
+    HRESULT STDMETHODCALLTYPE GetSourceCount(UINT* count) noexcept override;
+
+    // IGraphicsEffect
+    winrt::hstring Name();
+    void Name(winrt::hstring name);
+
+    wge::IGraphicsEffectSource Source{nullptr};
+
+    // D2D1_MATRIX_5X4_F: 5 rows x 4 columns (20 floats), initialized to identity.
+    float Matrix[20] = {
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+        0, 0, 0, 0,
+    };
+
+    uint32_t AlphaMode = D2D1_COLORMATRIX_ALPHA_MODE_PREMULTIPLIED;
+    bool ClampOutput = false;
+private:
+    winrt::hstring m_name = L"ColorMatrixEffect";
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// ColorMatrixEffect.cpp
+HRESULT ColorMatrixEffect::GetEffectId(GUID* id) noexcept
+{
+    if (!id)
+    {
+        return E_INVALIDARG;
+    }
+
+    *id = CLSID_D2D1ColorMatrix;
+    return S_OK;
+}
+
+HRESULT ColorMatrixEffect::GetNamedPropertyMapping(LPCWSTR name, UINT* index, awge::GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping) noexcept
+{
+    if (!index || !mapping)
+    {
+        return E_INVALIDARG;
+    }
+
+    const std::wstring_view nameView(name);
+    if (nameView == L"ColorMatrix")
+    {
+        *index = D2D1_COLORMATRIX_PROP_COLOR_MATRIX;
+        *mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
+
+        return S_OK;
+    }
+
+    if (nameView == L"AlphaMode")
+    {
+        *index = D2D1_COLORMATRIX_PROP_ALPHA_MODE;
+        *mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
+
+        return S_OK;
+    }
+
+    if (nameView == L"ClampOutput")
+    {
+        *index = D2D1_COLORMATRIX_PROP_CLAMP_OUTPUT;
+        *mapping = awge::GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
+
+        return S_OK;
+    }
+
+    return E_INVALIDARG;
+}
+
+HRESULT ColorMatrixEffect::GetPropertyCount(UINT* count) noexcept
+{
+    if (!count)
+    {
+        return E_INVALIDARG;
+    }
+
+    *count = 3;
+    return S_OK;
+}
+
+HRESULT ColorMatrixEffect::GetProperty(UINT index, winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>** value) noexcept try
+{
+    if (!value)
+    {
+        return E_INVALIDARG;
+    }
+
+    switch (index)
+    {
+        case D2D1_COLORMATRIX_PROP_COLOR_MATRIX:
+            *value = wf::PropertyValue::CreateSingleArray(
+                winrt::array_view<const float>(Matrix, Matrix + 20)
+            ).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
+            break;
+
+        case D2D1_COLORMATRIX_PROP_ALPHA_MODE:
+            *value = wf::PropertyValue::CreateUInt32(AlphaMode).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
+            break;
+
+        case D2D1_COLORMATRIX_PROP_CLAMP_OUTPUT:
+            *value = wf::PropertyValue::CreateBoolean(ClampOutput).as<winrt::impl::abi_t<winrt::Windows::Foundation::IPropertyValue>>().detach();
+            break;
+
+        default:
+            return E_BOUNDS;
+    }
+
+    return S_OK;
+}
+catch (...)
+{
+    return winrt::to_hresult();
+}
+
+HRESULT ColorMatrixEffect::GetSource(UINT index, awge::IGraphicsEffectSource** source) noexcept
+{
+    if (!source)
+    {
+        return E_INVALIDARG;
+    }
+
+    if (index == 0 && Source)
+    {
+        winrt::copy_to_abi(Source, *reinterpret_cast<void**>(source));
+        return S_OK;
+    }
+
+    return E_BOUNDS;
+}
+
+HRESULT ColorMatrixEffect::GetSourceCount(UINT* count) noexcept
+{
+    if (!count)
+    {
+        return E_INVALIDARG;
+    }
+
+    *count = 1;
+    return S_OK;
+}
+
+winrt::hstring ColorMatrixEffect::Name()
+{
+    return m_name;
+}
+
+void ColorMatrixEffect::Name(winrt::hstring name)
+{
+    m_name = name;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // XamlBlurBrush.cpp
-#include <winrt/Windows.System.h>
-
 XamlBlurBrush::XamlBlurBrush(wuc::Compositor compositor,
                              float blurAmount,
                              winrt::Windows::UI::Color tint,
                              std::optional<uint8_t> tintOpacity,
-                             winrt::hstring tintThemeResourceKey) :
-	m_compositor(std::move(compositor)),
-	m_blurAmount(blurAmount),
-	m_tint(tint),
-	m_tintOpacity(tintOpacity),
-	m_tintThemeResourceKey(std::move(tintThemeResourceKey))
+                             winrt::hstring tintThemeResourceKey,
+                             std::optional<float> tintLuminosityOpacity,
+                             std::optional<float> tintSaturation,
+                             std::optional<float> noiseOpacity,
+                             std::optional<float> noiseDensity) :
+    m_compositor(std::move(compositor)),
+    m_blurAmount(blurAmount),
+    m_tint(tint),
+    m_tintOpacity(tintOpacity),
+    m_tintThemeResourceKey(std::move(tintThemeResourceKey)),
+    m_tintLuminosityOpacity(tintLuminosityOpacity),
+    m_tintSaturation(tintSaturation),
+    m_noiseOpacity(noiseOpacity),
+    m_noiseDensity(noiseDensity)
 {
-	if (!m_tintThemeResourceKey.empty())
-	{
-		RefreshThemeTint();
+    if (!m_tintThemeResourceKey.empty())
+    {
+        RefreshThemeTint();
 
-		auto dq = winrt::Windows::System::DispatcherQueue::GetForCurrentThread();
+        auto dq = winrt::Windows::System::DispatcherQueue::GetForCurrentThread();
 
-		m_uiSettings.ColorValuesChanged([weakThis = get_weak(), dq] (auto const&, auto const&)
-		{
-			dq.TryEnqueue([weakThis]
-			{
-				if (auto self = weakThis.get())
-				{
-					self->OnThemeRefreshed();
-				}
-			});
-		});
-	}
+        m_uiSettings.ColorValuesChanged([weakThis = get_weak(), dq] (auto const&, auto const&)
+        {
+            dq.TryEnqueue([weakThis]
+            {
+                if (auto self = weakThis.get())
+                {
+                    self->OnThemeRefreshed();
+                }
+            });
+        });
+    }
 }
 
 void XamlBlurBrush::OnConnected()
 {
-	if (!CompositionBrush())
-	{
-		auto backdropBrush = m_compositor.CreateBackdropBrush();
+    if (!CompositionBrush())
+    {
+        auto backdropBrush = m_compositor.CreateBackdropBrush();
 
-		auto blurEffect = winrt::make_self<GaussianBlurEffect>();
-		blurEffect->Source = wuc::CompositionEffectSourceParameter(L"backdrop");
-		blurEffect->BlurAmount = m_blurAmount;
+        // Rec. 709 luma coefficients, used for saturation and luminosity.
+        constexpr float kLumaR = 0.2126f;
+        constexpr float kLumaG = 0.7152f;
+        constexpr float kLumaB = 0.0722f;
 
-		auto floodEffect = winrt::make_self<FloodEffect>();
-		floodEffect->Color = m_tint;
+        // 1. Blur
+        auto blurEffect = winrt::make_self<GaussianBlurEffect>();
+        blurEffect->Source = wuc::CompositionEffectSourceParameter(L"backdrop");
+        blurEffect->BlurAmount = m_blurAmount;
+        blurEffect->Name(L"BlurEffect");
 
-		auto compositeEffect = winrt::make_self<CompositeEffect>();
-		compositeEffect->Sources.push_back(*blurEffect);
-		compositeEffect->Sources.push_back(*floodEffect);
-		compositeEffect->Mode = D2D1_COMPOSITE_MODE_SOURCE_OVER;
+        wge::IGraphicsEffectSource topOfStack = *blurEffect;
 
-		auto factory = m_compositor.CreateEffectFactory(
-			*compositeEffect,
-			// List of animatable properties.
-			{L"FloodEffect.Color"}
-		);
-		auto blurBrush = factory.CreateBrush();
-		blurBrush.SetSourceParameter(L"backdrop", backdropBrush);
+        // 2. Saturation (optional)
+        if (m_tintSaturation && *m_tintSaturation != 1.0f)
+        {
+            float s = std::max(*m_tintSaturation, 0.0f);
+            float invS = 1.0f - s;
 
-		CompositionBrush(blurBrush);
-	}
+            auto satMatrix = winrt::make_self<ColorMatrixEffect>();
+            satMatrix->Source = topOfStack;
+
+            // Standard saturation matrix: lerp between luminance and identity.
+            auto& m = satMatrix->Matrix;
+            m[0]  = invS * kLumaR + s; m[1]  = invS * kLumaR;     m[2]  = invS * kLumaR;     m[3]  = 0.0f;
+            m[4]  = invS * kLumaG;     m[5]  = invS * kLumaG + s; m[6]  = invS * kLumaG;     m[7]  = 0.0f;
+            m[8]  = invS * kLumaB;     m[9]  = invS * kLumaB;     m[10] = invS * kLumaB + s; m[11] = 0.0f;
+            m[12] = 0.0f;              m[13] = 0.0f;              m[14] = 0.0f;              m[15] = 1.0f;
+
+            satMatrix->Name(L"SaturationEffect");
+            topOfStack = *satMatrix;
+        }
+
+        // 3. Luminosity (optional) - shifts pixel luminance towards the tint's
+        // luminance, blended by the opacity factor.
+        if (m_tintLuminosityOpacity && *m_tintLuminosityOpacity > 0.0f)
+        {
+            float op = std::clamp(*m_tintLuminosityOpacity, 0.0f, 1.0f);
+
+            float tintLum = (m_tint.R / 255.0f) * kLumaR +
+                            (m_tint.G / 255.0f) * kLumaG +
+                            (m_tint.B / 255.0f) * kLumaB;
+
+            auto lumMatrix = winrt::make_self<ColorMatrixEffect>();
+            lumMatrix->Source = topOfStack;
+
+            auto& m = lumMatrix->Matrix;
+            m[0]  = 1.0f - (kLumaR * op); m[1]  = -(kLumaR * op);       m[2]  = -(kLumaR * op);       m[3]  = 0.0f;
+            m[4]  = -(kLumaG * op);       m[5]  = 1.0f - (kLumaG * op); m[6]  = -(kLumaG * op);       m[7]  = 0.0f;
+            m[8]  = -(kLumaB * op);       m[9]  = -(kLumaB * op);       m[10] = 1.0f - (kLumaB * op); m[11] = 0.0f;
+            m[12] = 0.0f;                 m[13] = 0.0f;                 m[14] = 0.0f;                 m[15] = 1.0f;
+            m[16] = tintLum * op;         m[17] = tintLum * op;         m[18] = tintLum * op;         m[19] = 0.0f;
+
+            lumMatrix->Name(L"LuminosityBlend");
+            topOfStack = *lumMatrix;
+        }
+
+        // 4. Noise overlay (optional) - procedural tiled noise with adjustable
+        // density and opacity.
+        wuc::CompositionSurfaceBrush noiseBrush{nullptr};
+        if (m_noiseOpacity && *m_noiseOpacity > 0.0f)
+        {
+            float density = m_noiseDensity.value_or(1.0f);
+
+            auto stream = CreateNoiseStream(density);
+            auto surface =
+                wux::Media::LoadedImageSurface::StartLoadFromStream(stream);
+            noiseBrush = m_compositor.CreateSurfaceBrush(surface);
+            noiseBrush.Stretch(wuc::CompositionStretch::None);
+
+            // Tile via border effect (wrap mode).
+            auto borderEffect = winrt::make_self<BorderEffect>();
+            borderEffect->Source =
+                wuc::CompositionEffectSourceParameter(L"NoiseSource");
+
+            // Scale all channels by opacity for premultiplied blending.
+            float nOp = std::clamp(*m_noiseOpacity, 0.0f, 1.0f);
+
+            auto opacityEffect = winrt::make_self<ColorMatrixEffect>();
+            opacityEffect->Source = *borderEffect;
+            // Matrix: Scale all channels by opacity (for premultiplied blending).
+            opacityEffect->Matrix[0] = nOp;
+            opacityEffect->Matrix[5] = nOp;
+            opacityEffect->Matrix[10] = nOp;
+            opacityEffect->Matrix[15] = nOp;
+            opacityEffect->Name(L"NoiseOpacityEffect");
+
+            // Composite noise over the current stack.
+            auto noiseComposite = winrt::make_self<CompositeEffect>();
+            noiseComposite->Mode = D2D1_COMPOSITE_MODE_SOURCE_OVER;
+            noiseComposite->Sources.push_back(topOfStack);
+            noiseComposite->Sources.push_back(*opacityEffect);
+            noiseComposite->Name(L"NoiseComposite");
+            topOfStack = *noiseComposite;
+        }
+
+        // 5. Tint (flood color composited over the stack).
+        auto floodEffect = winrt::make_self<FloodEffect>();
+        floodEffect->Color = m_tint;
+        floodEffect->Name(L"FloodEffect");
+
+        auto compositeEffect = winrt::make_self<CompositeEffect>();
+        compositeEffect->Mode = D2D1_COMPOSITE_MODE_SOURCE_OVER;
+        compositeEffect->Sources.push_back(topOfStack);
+        compositeEffect->Sources.push_back(*floodEffect);
+
+        auto factory = m_compositor.CreateEffectFactory(
+            *compositeEffect,
+            // List of animatable properties.
+            {L"FloodEffect.Color"}
+        );
+        auto brush = factory.CreateBrush();
+
+        brush.SetSourceParameter(L"backdrop", backdropBrush);
+
+        // Bind the noise brush if we created one.
+        if (noiseBrush)
+        {
+            brush.SetSourceParameter(L"NoiseSource", noiseBrush);
+        }
+
+        CompositionBrush(brush);
+    }
 }
 
 void XamlBlurBrush::OnDisconnected()
 {
-	if (const auto brush = CompositionBrush())
-	{
-		brush.Close();
-		CompositionBrush(nullptr);
-	}
+    if (const auto brush = CompositionBrush())
+    {
+        brush.Close();
+        CompositionBrush(nullptr);
+    }
 }
 
 void XamlBlurBrush::RefreshThemeTint()
 {
-	if (m_tintThemeResourceKey.empty())
-	{
-		return;
-	}
+    if (m_tintThemeResourceKey.empty())
+    {
+        return;
+    }
 
-	auto resources = Application::Current().Resources();
-	auto resource = resources.TryLookup(winrt::box_value(m_tintThemeResourceKey));
-	if (!resource)
-	{
-		Wh_Log(L"Failed to find resource");
-		return;
-	}
+    auto resources = Application::Current().Resources();
+    auto resource = resources.TryLookup(winrt::box_value(m_tintThemeResourceKey));
+    if (!resource)
+    {
+        Wh_Log(L"Failed to find resource");
+        return;
+    }
 
-	if (auto colorBrush = resource.try_as<wux::Media::SolidColorBrush>())
-	{
-		m_tint = colorBrush.Color();
-	}
-	else if (auto color = resource.try_as<winrt::Windows::UI::Color>())
-	{
-		m_tint = *color;
-	}
-	else
-	{
-		Wh_Log(L"Resource type is unsupported: %s",
-			winrt::get_class_name(resource).c_str());
-		return;
-	}
+    if (auto colorBrush = resource.try_as<wux::Media::SolidColorBrush>())
+    {
+        m_tint = colorBrush.Color();
+    }
+    else if (auto color = resource.try_as<winrt::Windows::UI::Color>())
+    {
+        m_tint = *color;
+    }
+    else
+    {
+        Wh_Log(L"Resource type is unsupported: %s",
+            winrt::get_class_name(resource).c_str());
+        return;
+    }
 
-	if (m_tintOpacity)
-	{
-		m_tint.A = *m_tintOpacity;
-	}
+    if (m_tintOpacity)
+    {
+        m_tint.A = *m_tintOpacity;
+    }
 }
 
 void XamlBlurBrush::OnThemeRefreshed()
 {
-	Wh_Log(L"Theme refreshed");
+    Wh_Log(L"Theme refreshed");
 
-	auto prevTint = m_tint;
+    auto prevTint = m_tint;
 
-	RefreshThemeTint();
+    RefreshThemeTint();
 
-	if (prevTint != m_tint)
-	{
-		if (auto effectBrush = CompositionBrush().try_as<wuc::CompositionEffectBrush>())
-		{
-			effectBrush.Properties().InsertColor(L"FloodEffect.Color", m_tint);
-		}
-	}
+    if (prevTint != m_tint)
+    {
+        if (auto effectBrush = CompositionBrush().try_as<wuc::CompositionEffectBrush>())
+        {
+            effectBrush.Properties().InsertColor(L"FloodEffect.Color", m_tint);
+        }
+    }
 }
 
 // clang-format on
@@ -6286,7 +7930,10 @@ void SetOrClearValue(DependencyObject elementDo,
             value = winrt::make<XamlBlurBrush>(
                 std::move(compositor), blurBrushParams->blurAmount,
                 blurBrushParams->tint, blurBrushParams->tintOpacity,
-                winrt::hstring(blurBrushParams->tintThemeResourceKey));
+                winrt::hstring(blurBrushParams->tintThemeResourceKey),
+                blurBrushParams->tintLuminosityOpacity,
+                blurBrushParams->tintSaturation, blurBrushParams->noiseOpacity,
+                blurBrushParams->noiseDensity);
         } else {
             Wh_Log(L"Can't get UIElement for blur brush");
             return;
@@ -6314,12 +7961,14 @@ void SetOrClearValue(DependencyObject elementDo,
                      property = std::move(property),
                      value = std::move(value)]() {
                         Wh_Log(L"Running delayed SetValue for AllAppsRoot");
+                        g_elementPropertyModifying = true;
                         try {
                             elementDo.SetValue(property, value);
                         } catch (winrt::hresult_error const& ex) {
                             Wh_Log(L"Error %08X: %s", ex.code(),
                                    ex.message().c_str());
                         }
+                        g_elementPropertyModifying = false;
                         g_delayedAllAppsRootVisibilitySet = nullptr;
                     });
             return;
@@ -6331,9 +7980,17 @@ void SetOrClearValue(DependencyObject elementDo,
     }
 
     if (value == DependencyProperty::UnsetValue()) {
-        elementDo.ClearValue(property);
+        Wh_Log(L"Clearing property value");
+        try {
+            elementDo.ClearValue(property);
+        } catch (winrt::hresult_error const& ex) {
+            Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
+        }
         return;
     }
+
+    Wh_Log(L"Setting property value %s",
+           value ? winrt::get_class_name(value).c_str() : L"(null)");
 
     // Track ImageBrush with remote ImageSource for retry on network
     // reconnection. This handles cases where an ImageBrush is set as a property
@@ -6479,6 +8136,10 @@ std::optional<PropertyOverrideValue> ParseNonXamlPropertyOverrideValue(
     std::wstring tintThemeResourceKey;
     winrt::Windows::UI::Color tint{};
     float tintOpacity = std::numeric_limits<float>::quiet_NaN();
+    float tintLuminosityOpacity = std::numeric_limits<float>::quiet_NaN();
+    float tintSaturation = std::numeric_limits<float>::quiet_NaN();
+    float noiseOpacity = std::numeric_limits<float>::quiet_NaN();
+    float noiseDensity = std::numeric_limits<float>::quiet_NaN();
     float blurAmount = 0;
 
     constexpr auto kTintColorThemeResourcePrefix =
@@ -6486,6 +8147,10 @@ std::optional<PropertyOverrideValue> ParseNonXamlPropertyOverrideValue(
     constexpr auto kTintColorThemeResourceSuffix = L"}\""sv;
     constexpr auto kTintColorPrefix = L"TintColor=\"#"sv;
     constexpr auto kTintOpacityPrefix = L"TintOpacity=\""sv;
+    constexpr auto kTintLuminosityOpacityPrefix = L"TintLuminosityOpacity=\""sv;
+    constexpr auto kTintSaturationPrefix = L"TintSaturation=\""sv;
+    constexpr auto kNoiseOpacityPrefix = L"NoiseOpacity=\""sv;
+    constexpr auto kNoiseDensityPrefix = L"NoiseDensity=\""sv;
     constexpr auto kBlurAmountPrefix = L"BlurAmount=\""sv;
     for (const auto prop : SplitStringView(substr, L" ")) {
         const auto propSubstr = TrimStringView(prop);
@@ -6553,6 +8218,43 @@ std::optional<PropertyOverrideValue> ParseNonXamlPropertyOverrideValue(
             continue;
         }
 
+        if (propSubstr.starts_with(kTintLuminosityOpacityPrefix) &&
+            propSubstr.back() == L'\"') {
+            auto valStr = propSubstr.substr(
+                std::size(kTintLuminosityOpacityPrefix),
+                propSubstr.size() - std::size(kTintLuminosityOpacityPrefix) -
+                    1);
+            tintLuminosityOpacity = std::stof(std::wstring(valStr));
+            continue;
+        }
+
+        if (propSubstr.starts_with(kTintSaturationPrefix) &&
+            propSubstr.back() == L'\"') {
+            auto valStr = propSubstr.substr(
+                std::size(kTintSaturationPrefix),
+                propSubstr.size() - std::size(kTintSaturationPrefix) - 1);
+            tintSaturation = std::stof(std::wstring(valStr));
+            continue;
+        }
+
+        if (propSubstr.starts_with(kNoiseOpacityPrefix) &&
+            propSubstr.back() == L'\"') {
+            auto valStr = propSubstr.substr(
+                std::size(kNoiseOpacityPrefix),
+                propSubstr.size() - std::size(kNoiseOpacityPrefix) - 1);
+            noiseOpacity = std::stof(std::wstring(valStr));
+            continue;
+        }
+
+        if (propSubstr.starts_with(kNoiseDensityPrefix) &&
+            propSubstr.back() == L'\"') {
+            auto valStr = propSubstr.substr(
+                std::size(kNoiseDensityPrefix),
+                propSubstr.size() - std::size(kNoiseDensityPrefix) - 1);
+            noiseDensity = std::stof(std::wstring(valStr));
+            continue;
+        }
+
         if (propSubstr.starts_with(kBlurAmountPrefix) &&
             propSubstr.back() == L'\"') {
             auto valStr = propSubstr.substr(
@@ -6586,6 +8288,16 @@ std::optional<PropertyOverrideValue> ParseNonXamlPropertyOverrideValue(
         .tintOpacity =
             !std::isnan(tintOpacity) ? std::optional(tint.A) : std::nullopt,
         .tintThemeResourceKey = std::move(tintThemeResourceKey),
+        .tintLuminosityOpacity = !std::isnan(tintLuminosityOpacity)
+                                     ? std::optional(tintLuminosityOpacity)
+                                     : std::nullopt,
+        .tintSaturation = !std::isnan(tintSaturation)
+                              ? std::optional(tintSaturation)
+                              : std::nullopt,
+        .noiseOpacity = !std::isnan(noiseOpacity) ? std::optional(noiseOpacity)
+                                                  : std::nullopt,
+        .noiseDensity = !std::isnan(noiseDensity) ? std::optional(noiseDensity)
+                                                  : std::nullopt,
     };
 }
 
@@ -7000,45 +8712,52 @@ void ApplyCustomizationsForVisualStateGroup(
             propertyCustomizationState.customValue = it->second;
             SetOrClearValue(element, property, it->second,
                             /*initialApply=*/true);
+            propertyCustomizationState.lastAppliedValue =
+                ReadLocalValueWithWorkaround(element, property);
         }
 
-        propertyCustomizationState
-            .propertyChangedToken = elementDo.RegisterPropertyChangedCallback(
-            property,
-            [&propertyCustomizationState](DependencyObject sender,
-                                          DependencyProperty property) {
-                if (g_elementPropertyModifying) {
-                    return;
-                }
+        propertyCustomizationState.propertyChangedToken =
+            elementDo.RegisterPropertyChangedCallback(
+                property,
+                [&propertyCustomizationState](DependencyObject sender,
+                                              DependencyProperty property) {
+                    if (g_elementPropertyModifying) {
+                        return;
+                    }
 
-                auto element = sender.try_as<FrameworkElement>();
-                if (!element) {
-                    return;
-                }
+                    auto element = sender.try_as<FrameworkElement>();
+                    if (!element) {
+                        return;
+                    }
 
-                if (!propertyCustomizationState.customValue) {
-                    return;
-                }
+                    if (!propertyCustomizationState.customValue) {
+                        return;
+                    }
 
-                Wh_Log(L"Re-applying style for %s",
-                       winrt::get_class_name(element).c_str());
+                    auto localValue =
+                        ReadLocalValueWithWorkaround(element, property);
 
-                auto localValue =
-                    ReadLocalValueWithWorkaround(element, property);
-
-                if (auto* customValue =
-                        std::get_if<winrt::Windows::Foundation::IInspectable>(
-                            &*propertyCustomizationState.customValue)) {
-                    if (*customValue != localValue) {
+                    // Only update originalValue if the local value was changed
+                    // externally (e.g. by a Setter). When an animation changes
+                    // only the effective value, the local value still matches
+                    // what we set, so updating originalValue would corrupt it
+                    // with our own brush - causing the brush to survive cleanup
+                    // and crash when the mod's DLL is unloaded.
+                    if (localValue !=
+                        propertyCustomizationState.lastAppliedValue) {
                         propertyCustomizationState.originalValue = localValue;
                     }
-                }
 
-                g_elementPropertyModifying = true;
-                SetOrClearValue(element, property,
-                                *propertyCustomizationState.customValue);
-                g_elementPropertyModifying = false;
-            });
+                    Wh_Log(L"Re-applying style for %s",
+                           winrt::get_class_name(element).c_str());
+
+                    g_elementPropertyModifying = true;
+                    SetOrClearValue(element, property,
+                                    *propertyCustomizationState.customValue);
+                    propertyCustomizationState.lastAppliedValue =
+                        ReadLocalValueWithWorkaround(element, property);
+                    g_elementPropertyModifying = false;
+                });
     }
 
     if (visualStateGroup) {
@@ -7095,6 +8814,8 @@ void ApplyCustomizationsForVisualStateGroup(
 
                             propertyCustomizationState.customValue = it->second;
                             SetOrClearValue(element, property, it->second);
+                            propertyCustomizationState.lastAppliedValue =
+                                ReadLocalValueWithWorkaround(element, property);
                         } else {
                             if (propertyCustomizationState.originalValue) {
                                 SetOrClearValue(
@@ -7103,6 +8824,8 @@ void ApplyCustomizationsForVisualStateGroup(
                                 propertyCustomizationState.originalValue
                                     .reset();
                             }
+                            propertyCustomizationState.lastAppliedValue =
+                                nullptr;
 
                             propertyCustomizationState.customValue.reset();
                         }
@@ -7123,8 +8846,12 @@ void RestoreCustomizationsForVisualStateGroup(
         for (const auto& [property, state] :
              elementCustomizationStateForVisualStateGroup
                  .propertyCustomizationStates) {
-            element.UnregisterPropertyChangedCallback(
-                property, state.propertyChangedToken);
+            try {
+                element.UnregisterPropertyChangedCallback(
+                    property, state.propertyChangedToken);
+            } catch (winrt::hresult_error const& ex) {
+                Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
+            }
 
             if (state.originalValue) {
                 SetOrClearValue(element, property, *state.originalValue);
@@ -7137,9 +8864,13 @@ void RestoreCustomizationsForVisualStateGroup(
                                     : nullptr;
     if (visualStateGroupIter && elementCustomizationStateForVisualStateGroup
                                     .visualStateGroupCurrentStateChangedToken) {
-        visualStateGroupIter.CurrentStateChanged(
-            elementCustomizationStateForVisualStateGroup
-                .visualStateGroupCurrentStateChangedToken);
+        try {
+            visualStateGroupIter.CurrentStateChanged(
+                elementCustomizationStateForVisualStateGroup
+                    .visualStateGroupCurrentStateChangedToken);
+        } catch (winrt::hresult_error const& ex) {
+            Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
+        }
     }
 }
 
@@ -7467,6 +9198,15 @@ void ClearWebViewCustomizations(
 void ApplyCustomizations(InstanceHandle handle,
                          FrameworkElement element,
                          PCWSTR fallbackClassName) {
+    // Merge resource dictionary on first element add. Merging it eariler on
+    // window creation doesn't work, perhaps merged dictionaries are reset
+    // during initialization.
+    if (!g_resourceVariablesThemeDictMerged) {
+        auto resources = Application::Current().Resources();
+        resources.MergedDictionaries().Append(g_resourceVariablesThemeDict);
+        g_resourceVariablesThemeDictMerged = true;
+    }
+
     if (!g_webContentCss.empty() || !g_webContentJs.empty()) {
         try {
             ApplyCustomizationsIfWebView(handle, element);
@@ -7543,59 +9283,6 @@ void CleanupCustomizations(InstanceHandle handle) {
 using StyleConstant = std::pair<std::wstring, std::wstring>;
 using StyleConstants = std::vector<StyleConstant>;
 
-std::optional<StyleConstant> ParseStyleConstant(std::wstring_view constant) {
-    // Skip if commented.
-    if (constant.starts_with(L"//")) {
-        return std::nullopt;
-    }
-
-    auto eqPos = constant.find(L'=');
-    if (eqPos == constant.npos) {
-        Wh_Log(L"Skipping entry with no '=': %.*s",
-               static_cast<int>(constant.length()), constant.data());
-        return std::nullopt;
-    }
-
-    auto key = TrimStringView(constant.substr(0, eqPos));
-    auto val = TrimStringView(constant.substr(eqPos + 1));
-
-    return StyleConstant{std::wstring(key), std::wstring(val)};
-}
-
-StyleConstants LoadStyleConstants(
-    const std::vector<PCWSTR>& themeStyleConstants) {
-    StyleConstants result;
-
-    for (const auto themeStyleConstant : themeStyleConstants) {
-        if (auto parsed = ParseStyleConstant(themeStyleConstant)) {
-            result.push_back(std::move(*parsed));
-        }
-    }
-
-    for (int i = 0;; i++) {
-        string_setting_unique_ptr constantSetting(
-            Wh_GetStringSetting(L"styleConstants[%d]", i));
-        if (!*constantSetting.get()) {
-            break;
-        }
-
-        if (auto parsed = ParseStyleConstant(constantSetting.get())) {
-            result.push_back(std::move(*parsed));
-        }
-    }
-
-    // Reverse the order to allow overriding definitions with the same name.
-    std::reverse(result.begin(), result.end());
-
-    // Sort by name length to replace long names first.
-    std::stable_sort(result.begin(), result.end(),
-                     [](const StyleConstant& a, const StyleConstant& b) {
-                         return a.first.size() > b.first.size();
-                     });
-
-    return result;
-}
-
 std::wstring ApplyStyleConstants(std::wstring_view style,
                                  const StyleConstants& styleConstants) {
     std::wstring result;
@@ -7625,6 +9312,65 @@ std::wstring ApplyStyleConstants(std::wstring_view style,
 
     // Care for the rest after last occurrence.
     result += style.substr(lastPos);
+
+    return result;
+}
+
+std::optional<StyleConstant> ParseStyleConstant(
+    std::wstring_view constant,
+    const StyleConstants& styleConstants) {
+    // Skip if commented.
+    if (constant.starts_with(L"//")) {
+        return std::nullopt;
+    }
+
+    auto eqPos = constant.find(L'=');
+    if (eqPos == constant.npos) {
+        Wh_Log(L"Skipping entry with no '=': %.*s",
+               static_cast<int>(constant.length()), constant.data());
+        return std::nullopt;
+    }
+
+    auto key = TrimStringView(constant.substr(0, eqPos));
+    auto valueRaw = TrimStringView(constant.substr(eqPos + 1));
+    auto value = ApplyStyleConstants(valueRaw, styleConstants);
+
+    return StyleConstant{std::wstring(key), std::move(value)};
+}
+
+StyleConstants LoadStyleConstants(
+    const std::vector<PCWSTR>& themeStyleConstants) {
+    StyleConstants result;
+
+    auto addToResult = [&result](StyleConstant sc) {
+        // Keep sorted by name length to replace long names first. Reverse the
+        // order to allow overriding definitions with the same name.
+        auto insertIndex = std::lower_bound(
+            result.begin(), result.end(), sc,
+            [](const StyleConstant& a, const StyleConstant& b) {
+                return a.first.size() > b.first.size();
+            });
+
+        result.insert(insertIndex, std::move(sc));
+    };
+
+    for (const auto themeStyleConstant : themeStyleConstants) {
+        if (auto parsed = ParseStyleConstant(themeStyleConstant, result)) {
+            addToResult(std::move(*parsed));
+        }
+    }
+
+    for (int i = 0;; i++) {
+        string_setting_unique_ptr constantSetting(
+            Wh_GetStringSetting(L"styleConstants[%d]", i));
+        if (!*constantSetting.get()) {
+            break;
+        }
+
+        if (auto parsed = ParseStyleConstant(constantSetting.get(), result)) {
+            addToResult(std::move(*parsed));
+        }
+    }
 
     return result;
 }
@@ -7969,6 +9715,8 @@ void ProcessAllStylesFromSettings() {
         theme = g_isRedesignedStartMenu
                     ? &g_themeEverblush
                     : &g_themeEverblush_variant_ClassicStartMenu;
+    } else if (wcscmp(themeName, L"SunValley") == 0) {
+        theme = &g_themeSunValley;
     } else if (wcscmp(themeName, L"21996") == 0) {
         theme = g_isRedesignedStartMenu
                     ? &g_theme21996
@@ -7988,11 +9736,22 @@ void ProcessAllStylesFromSettings() {
     } else if (wcscmp(themeName, L"WindowGlass") == 0) {
         theme = &g_themeWindowGlass;
     } else if (wcscmp(themeName, L"WindowGlass_variant_Minimal") == 0) {
-        theme = &g_themeWindowGlass_variant_Minimal;
+        // Same as WindowGlass, kept for backward compatibility.
+        theme = &g_themeWindowGlass;
     } else if (wcscmp(themeName, L"Fluid") == 0) {
         theme = &g_themeFluid;
     } else if (wcscmp(themeName, L"Oversimplified&Accentuated") == 0) {
         theme = &g_themeOversimplified_Accentuated;
+    } else if (wcscmp(themeName, L"LiquidGlass") == 0) {
+        theme = &g_themeLiquidGlass;
+    } else if (wcscmp(themeName, L"Windows10X") == 0) {
+        theme = g_isRedesignedStartMenu
+                    ? &g_themeWindows10X
+                    : &g_themeWindows10X_variant_ClassicStartMenu;
+    } else if (wcscmp(themeName, L"TintedGlass") == 0) {
+        theme = g_isRedesignedStartMenu
+                    ? &g_themeTintedGlass
+                    : &g_themeTintedGlass_variant_ClassicStartMenu;
     }
     Wh_FreeStringSetting(themeName);
 
@@ -8037,23 +9796,106 @@ void ProcessAllStylesFromSettings() {
     }
 }
 
-bool ProcessSingleResourceVariableFromSettings(int index) {
-    string_setting_unique_ptr variableKeyStringSetting(
-        Wh_GetStringSetting(L"resourceVariables[%d].variableKey", index));
-    if (!*variableKeyStringSetting.get()) {
+std::optional<ResourceVariableEntry> ParseResourceVariable(
+    std::wstring_view entry,
+    const StyleConstants& styleConstants) {
+    // Skip if commented.
+    if (entry.starts_with(L"//")) {
+        return std::nullopt;
+    }
+
+    // Find the first '=' to split key and value.
+    auto eqPos = entry.find(L'=');
+    if (eqPos == entry.npos) {
+        Wh_Log(L"Skipping entry with no '=': %.*s",
+               static_cast<int>(entry.length()), entry.data());
+        return std::nullopt;
+    }
+
+    auto keyPart = TrimStringView(entry.substr(0, eqPos));
+    auto valueRaw = TrimStringView(entry.substr(eqPos + 1));
+    auto value = ApplyStyleConstants(valueRaw, styleConstants);
+
+    ResourceVariableTheme theme = ResourceVariableTheme::None;
+    std::wstring key;
+
+    // Check for @theme suffix in key part.
+    auto atPos = keyPart.find(L'@');
+    if (atPos != keyPart.npos) {
+        key = TrimStringView(keyPart.substr(0, atPos));
+        auto themePart = TrimStringView(keyPart.substr(atPos + 1));
+        if (themePart == L"Dark") {
+            theme = ResourceVariableTheme::Dark;
+        } else if (themePart == L"Light") {
+            theme = ResourceVariableTheme::Light;
+        } else {
+            Wh_Log(L"Unknown theme '%.*s', expected 'Dark' or 'Light'",
+                   static_cast<int>(themePart.size()), themePart.data());
+            return std::nullopt;
+        }
+    } else {
+        key = std::wstring(keyPart);
+    }
+
+    return ResourceVariableEntry{std::move(key), std::move(value), theme};
+}
+
+constexpr std::wstring_view kThemeResourcePrefix = L"{ThemeResource ";
+
+bool IsThemeResourceReference(std::wstring_view value) {
+    return value.starts_with(kThemeResourcePrefix) && value.ends_with(L"}");
+}
+
+winrt::Windows::Foundation::IInspectable ResolveResourceVariableValue(
+    ResourceDictionary resources,
+    std::wstring_view value) {
+    // Check for {ThemeResource X} syntax - look up the resource directly
+    // to preserve dynamic theme-aware behavior.
+    if (IsThemeResourceReference(value)) {
+        auto resourceKey =
+            value.substr(kThemeResourcePrefix.size(),
+                         value.size() - kThemeResourcePrefix.size() - 1);
+        return resources.Lookup(
+            winrt::box_value(winrt::hstring(TrimStringView(resourceKey))));
+    }
+
+    // For other values, use boxed string (works for colors, etc.).
+    return winrt::box_value(winrt::hstring(value));
+}
+
+// Returns true if a theme resource was added.
+bool ProcessResourceVariableFromSetting(ResourceDictionary resources,
+                                        ResourceDictionary darkDict,
+                                        ResourceDictionary lightDict,
+                                        const ResourceVariableEntry& entry) {
+    auto boxedKey = winrt::box_value(entry.key);
+
+    if (entry.theme != ResourceVariableTheme::None) {
+        // Key@Dark= or Key@Light= - add to theme dict.
+        auto value = ResolveResourceVariableValue(resources, entry.value);
+        if (entry.theme == ResourceVariableTheme::Dark) {
+            darkDict.Insert(boxedKey, value);
+        } else {
+            lightDict.Insert(boxedKey, value);
+        }
+        return true;
+    }
+
+    // key= - convert using existing resource type.
+    auto existingResource = resources.TryLookup(boxedKey);
+    if (!existingResource) {
+        Wh_Log(L"Resource variable key '%s' not found, skipping",
+               entry.key.c_str());
         return false;
     }
 
-    Wh_Log(L"Processing resource variable %s", variableKeyStringSetting.get());
+    if (!g_originalResourceValues.contains(entry.key)) {
+        g_originalResourceValues[entry.key] = existingResource;
+    }
 
-    std::wstring_view variableKey = variableKeyStringSetting.get();
+    auto resourceClassName = winrt::get_class_name(existingResource);
 
-    auto resources = Application::Current().Resources();
-
-    auto resource = resources.Lookup(winrt::box_value(variableKey));
-
-    // Example: Windows.Foundation.IReference`1<Windows.UI.Xaml.Thickness>
-    auto resourceClassName = winrt::get_class_name(resource);
+    // Unwrap IReference<T> to get inner type name.
     if (resourceClassName.starts_with(L"Windows.Foundation.IReference`1<") &&
         resourceClassName.ends_with(L'>')) {
         size_t prefixSize = sizeof("Windows.Foundation.IReference`1<") - 1;
@@ -8062,31 +9904,142 @@ bool ProcessSingleResourceVariableFromSettings(int index) {
                            resourceClassName.size() - prefixSize - 1);
     }
 
-    auto resourceTypeName = Interop::TypeName{resourceClassName};
+    resources.Insert(boxedKey, Markup::XamlBindingHelper::ConvertValue(
+                                   Interop::TypeName{resourceClassName},
+                                   winrt::box_value(entry.value)));
+    return false;
+}
 
-    string_setting_unique_ptr valueStringSetting(
-        Wh_GetStringSetting(L"resourceVariables[%d].value", index));
+void RefreshThemeResourceEntries() {
+    if (g_themeResourceEntries.empty()) {
+        return;
+    }
 
-    std::wstring_view value = valueStringSetting.get();
+    Wh_Log(L"Refreshing %zu theme resource entries",
+           g_themeResourceEntries.size());
 
-    resources.Insert(winrt::box_value(variableKey),
-                     Markup::XamlBindingHelper::ConvertValue(
-                         resourceTypeName, winrt::box_value(value)));
+    auto resources = Application::Current().Resources();
 
-    return true;
+    auto darkDict = g_resourceVariablesThemeDict.ThemeDictionaries()
+                        .TryLookup(winrt::box_value(L"Dark"))
+                        .try_as<ResourceDictionary>();
+    auto lightDict = g_resourceVariablesThemeDict.ThemeDictionaries()
+                         .TryLookup(winrt::box_value(L"Light"))
+                         .try_as<ResourceDictionary>();
+
+    for (const auto& entry : g_themeResourceEntries) {
+        try {
+            auto boxedKey = winrt::box_value(entry.key);
+            auto value = ResolveResourceVariableValue(resources, entry.value);
+
+            if (entry.theme == ResourceVariableTheme::Dark && darkDict) {
+                darkDict.Insert(boxedKey, value);
+            } else if (entry.theme == ResourceVariableTheme::Light &&
+                       lightDict) {
+                lightDict.Insert(boxedKey, value);
+            }
+        } catch (winrt::hresult_error const& ex) {
+            Wh_Log(L"Error refreshing '%s': %08X", entry.key.c_str(),
+                   ex.code());
+        }
+    }
 }
 
 void ProcessResourceVariablesFromSettings() {
+    StyleConstants styleConstants = LoadStyleConstants(std::vector<PCWSTR>{});
+
+    auto resources = Application::Current().Resources();
+
+    // Create theme dictionaries for @Dark/@Light resources.
+    g_resourceVariablesThemeDict = ResourceDictionary();
+    ResourceDictionary darkDict;
+    ResourceDictionary lightDict;
+    bool hasThemeResources = false;
+
     for (int i = 0;; i++) {
+        string_setting_unique_ptr setting(
+            Wh_GetStringSetting(L"themeResourceVariables[%d]", i));
+        if (!*setting.get()) {
+            break;
+        }
+
+        Wh_Log(L"Processing theme resource variable %s", setting.get());
+
+        auto parsed = ParseResourceVariable(setting.get(), styleConstants);
+        if (!parsed) {
+            continue;
+        }
+
         try {
-            if (!ProcessSingleResourceVariableFromSettings(i)) {
-                break;
+            if (ProcessResourceVariableFromSetting(resources, darkDict,
+                                                   lightDict, *parsed)) {
+                hasThemeResources = true;
+
+                // Track entries with {ThemeResource ...} for refresh on color
+                // change.
+                if (IsThemeResourceReference(parsed->value)) {
+                    g_themeResourceEntries.push_back(*parsed);
+                }
             }
         } catch (winrt::hresult_error const& ex) {
             Wh_Log(L"Error %08X: %s", ex.code(), ex.message().c_str());
         } catch (std::exception const& ex) {
             Wh_Log(L"Error: %S", ex.what());
         }
+    }
+
+    if (hasThemeResources) {
+        g_resourceVariablesThemeDict.ThemeDictionaries().Insert(
+            winrt::box_value(L"Dark"), darkDict);
+        g_resourceVariablesThemeDict.ThemeDictionaries().Insert(
+            winrt::box_value(L"Light"), lightDict);
+    }
+
+    // Register for color changes to refresh theme resource references.
+    if (!g_themeResourceEntries.empty()) {
+        g_uiSettings = winrt::Windows::UI::ViewManagement::UISettings();
+        auto dispatcherQueue =
+            winrt::Windows::System::DispatcherQueue::GetForCurrentThread();
+        g_colorValuesChangedToken =
+            g_uiSettings.ColorValuesChanged([dispatcherQueue](auto&&, auto&&) {
+                dispatcherQueue.TryEnqueue(
+                    []() { RefreshThemeResourceEntries(); });
+            });
+    }
+}
+
+void UninitializeResourceVariables() {
+    // Unregister color change handler.
+    if (g_colorValuesChangedToken) {
+        g_uiSettings.ColorValuesChanged(g_colorValuesChangedToken);
+        g_colorValuesChangedToken = {};
+    }
+    g_uiSettings = nullptr;
+    g_themeResourceEntries.clear();
+
+    // Restore original resource values.
+    auto resources = Application::Current().Resources();
+    for (const auto& [key, originalValue] : g_originalResourceValues) {
+        try {
+            resources.Insert(winrt::box_value(key), originalValue);
+        } catch (...) {
+            HRESULT hr = winrt::to_hresult();
+            Wh_Log(L"Error %08X", hr);
+        }
+    }
+    g_originalResourceValues.clear();
+
+    // Remove our merged theme dictionary.
+    if (g_resourceVariablesThemeDict) {
+        if (g_resourceVariablesThemeDictMerged) {
+            auto merged = resources.MergedDictionaries();
+            uint32_t index;
+            if (merged.IndexOf(g_resourceVariablesThemeDict, index)) {
+                merged.RemoveAt(index);
+            }
+            g_resourceVariablesThemeDictMerged = false;
+        }
+        g_resourceVariablesThemeDict = nullptr;
     }
 }
 
@@ -8116,6 +10069,8 @@ void UninitializeSettingsAndTap() {
 
     g_elementsCustomizationRules.clear();
 
+    UninitializeResourceVariables();
+
     for (const auto& [handle, webViewCustomizationState] :
          g_webViewsCustomizationState) {
         try {
@@ -8144,119 +10099,6 @@ void InitializeSettingsAndTap() {
     if (FAILED(hr)) {
         Wh_Log(L"Error %08X", hr);
     }
-
-    // Unregister global network status change handler.
-    if (g_networkStatusChangedToken) {
-        try {
-            winrt::Windows::Networking::Connectivity::NetworkInformation::
-                NetworkStatusChanged(g_networkStatusChangedToken);
-            Wh_Log(L"Unregistered global network status change handler");
-        } catch (winrt::hresult_error const& ex) {
-            Wh_Log(L"Error unregistering network status handler %08X: %s",
-                   ex.code(), ex.message().c_str());
-        }
-        g_networkStatusChangedToken = {};
-    }
-
-    // Clear the dispatcher registry.
-    {
-        std::lock_guard<std::mutex> lock(g_failedImageBrushesRegistryMutex);
-        g_failedImageBrushesRegistry.clear();
-    }
-}
-
-using CreateWindowInBand_t = HWND(WINAPI*)(DWORD dwExStyle,
-                                           LPCWSTR lpClassName,
-                                           LPCWSTR lpWindowName,
-                                           DWORD dwStyle,
-                                           int X,
-                                           int Y,
-                                           int nWidth,
-                                           int nHeight,
-                                           HWND hWndParent,
-                                           HMENU hMenu,
-                                           HINSTANCE hInstance,
-                                           PVOID lpParam,
-                                           DWORD dwBand);
-CreateWindowInBand_t CreateWindowInBand_Original;
-HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle,
-                                    LPCWSTR lpClassName,
-                                    LPCWSTR lpWindowName,
-                                    DWORD dwStyle,
-                                    int X,
-                                    int Y,
-                                    int nWidth,
-                                    int nHeight,
-                                    HWND hWndParent,
-                                    HMENU hMenu,
-                                    HINSTANCE hInstance,
-                                    PVOID lpParam,
-                                    DWORD dwBand) {
-    HWND hWnd = CreateWindowInBand_Original(
-        dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight,
-        hWndParent, hMenu, hInstance, lpParam, dwBand);
-    if (!hWnd) {
-        return hWnd;
-    }
-
-    BOOL bTextualClassName = ((ULONG_PTR)lpClassName & ~(ULONG_PTR)0xffff) != 0;
-
-    if (bTextualClassName &&
-        _wcsicmp(lpClassName, L"Windows.UI.Core.CoreWindow") == 0) {
-        Wh_Log(L"Initializing - Created core window: %08X",
-               (DWORD)(ULONG_PTR)hWnd);
-        InitializeSettingsAndTap();
-    }
-
-    return hWnd;
-}
-
-using CreateWindowInBandEx_t = HWND(WINAPI*)(DWORD dwExStyle,
-                                             LPCWSTR lpClassName,
-                                             LPCWSTR lpWindowName,
-                                             DWORD dwStyle,
-                                             int X,
-                                             int Y,
-                                             int nWidth,
-                                             int nHeight,
-                                             HWND hWndParent,
-                                             HMENU hMenu,
-                                             HINSTANCE hInstance,
-                                             PVOID lpParam,
-                                             DWORD dwBand,
-                                             DWORD dwTypeFlags);
-CreateWindowInBandEx_t CreateWindowInBandEx_Original;
-HWND WINAPI CreateWindowInBandEx_Hook(DWORD dwExStyle,
-                                      LPCWSTR lpClassName,
-                                      LPCWSTR lpWindowName,
-                                      DWORD dwStyle,
-                                      int X,
-                                      int Y,
-                                      int nWidth,
-                                      int nHeight,
-                                      HWND hWndParent,
-                                      HMENU hMenu,
-                                      HINSTANCE hInstance,
-                                      PVOID lpParam,
-                                      DWORD dwBand,
-                                      DWORD dwTypeFlags) {
-    HWND hWnd = CreateWindowInBandEx_Original(
-        dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight,
-        hWndParent, hMenu, hInstance, lpParam, dwBand, dwTypeFlags);
-    if (!hWnd) {
-        return hWnd;
-    }
-
-    BOOL bTextualClassName = ((ULONG_PTR)lpClassName & ~(ULONG_PTR)0xffff) != 0;
-
-    if (bTextualClassName &&
-        _wcsicmp(lpClassName, L"Windows.UI.Core.CoreWindow") == 0) {
-        Wh_Log(L"Initializing - Created core window: %08X",
-               (DWORD)(ULONG_PTR)hWnd);
-        InitializeSettingsAndTap();
-    }
-
-    return hWnd;
 }
 
 using RunFromWindowThreadProc_t = void(WINAPI*)(PVOID parameter);
@@ -8309,6 +10151,169 @@ bool RunFromWindowThread(HWND hWnd,
     UnhookWindowsHookEx(hook);
 
     return true;
+}
+
+bool RunFromWindowThreadViaPostMessage(HWND hWnd,
+                                       RunFromWindowThreadProc_t proc,
+                                       PVOID procParam) {
+    static const UINT runFromWindowThreadRegisteredMsgViaPostMessage =
+        RegisterWindowMessage(
+            L"Windhawk_RunFromWindowThreadViaPostMessage_" WH_MOD_ID);
+
+    struct RUN_FROM_WINDOW_THREAD_PARAM {
+        RunFromWindowThreadProc_t proc;
+        PVOID procParam;
+        HHOOK hook;
+    };
+
+    DWORD dwThreadId = GetWindowThreadProcessId(hWnd, nullptr);
+    if (dwThreadId == 0) {
+        return false;
+    }
+
+    HHOOK hook = SetWindowsHookEx(
+        WH_GETMESSAGE,
+        [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
+            if (nCode == HC_ACTION && wParam == PM_REMOVE) {
+                MSG* msg = (MSG*)lParam;
+                if (msg->message ==
+                    runFromWindowThreadRegisteredMsgViaPostMessage) {
+                    auto* param = (RUN_FROM_WINDOW_THREAD_PARAM*)msg->lParam;
+                    if (param) {
+                        param->proc(param->procParam);
+                        UnhookWindowsHookEx(param->hook);
+                        delete param;
+                        msg->lParam = 0;
+                    }
+                }
+            }
+
+            return CallNextHookEx(nullptr, nCode, wParam, lParam);
+        },
+        nullptr, dwThreadId);
+    if (!hook) {
+        return false;
+    }
+
+    auto* param = new RUN_FROM_WINDOW_THREAD_PARAM{
+        .proc = proc,
+        .procParam = procParam,
+        .hook = hook,
+    };
+    if (!PostMessage(hWnd, runFromWindowThreadRegisteredMsgViaPostMessage, 0,
+                     (LPARAM)param)) {
+        UnhookWindowsHookEx(hook);
+        delete param;
+        return false;
+    }
+
+    return true;
+}
+
+void OnWindowCreated(HWND hWnd, LPCWSTR lpClassName, PCSTR funcName) {
+    BOOL bTextualClassName = ((ULONG_PTR)lpClassName & ~(ULONG_PTR)0xffff) != 0;
+
+    switch (g_target) {
+        case Target::StartMenu:
+            if (bTextualClassName &&
+                _wcsicmp(lpClassName, L"Windows.UI.Core.CoreWindow") == 0) {
+                Wh_Log(L"Initializing - Created core window: %08X via %S",
+                       (DWORD)(ULONG_PTR)hWnd, funcName);
+                InitializeSettingsAndTap();
+            }
+            break;
+
+        case Target::SearchHost:
+            if (bTextualClassName &&
+                _wcsicmp(lpClassName, L"Windows.UI.Core.CoreWindow") == 0) {
+                Wh_Log(L"Initializing - Created core window: %08X via %S",
+                       (DWORD)(ULONG_PTR)hWnd, funcName);
+                // Initializing at this point is too early and doesn't work.
+                RunFromWindowThreadViaPostMessage(
+                    hWnd, [](PVOID) { InitializeSettingsAndTap(); }, nullptr);
+            }
+            break;
+    }
+}
+
+using CreateWindowInBand_t = HWND(WINAPI*)(DWORD dwExStyle,
+                                           LPCWSTR lpClassName,
+                                           LPCWSTR lpWindowName,
+                                           DWORD dwStyle,
+                                           int X,
+                                           int Y,
+                                           int nWidth,
+                                           int nHeight,
+                                           HWND hWndParent,
+                                           HMENU hMenu,
+                                           HINSTANCE hInstance,
+                                           PVOID lpParam,
+                                           DWORD dwBand);
+CreateWindowInBand_t CreateWindowInBand_Original;
+HWND WINAPI CreateWindowInBand_Hook(DWORD dwExStyle,
+                                    LPCWSTR lpClassName,
+                                    LPCWSTR lpWindowName,
+                                    DWORD dwStyle,
+                                    int X,
+                                    int Y,
+                                    int nWidth,
+                                    int nHeight,
+                                    HWND hWndParent,
+                                    HMENU hMenu,
+                                    HINSTANCE hInstance,
+                                    PVOID lpParam,
+                                    DWORD dwBand) {
+    HWND hWnd = CreateWindowInBand_Original(
+        dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight,
+        hWndParent, hMenu, hInstance, lpParam, dwBand);
+    if (!hWnd) {
+        return hWnd;
+    }
+
+    OnWindowCreated(hWnd, lpClassName, __FUNCTION__);
+
+    return hWnd;
+}
+
+using CreateWindowInBandEx_t = HWND(WINAPI*)(DWORD dwExStyle,
+                                             LPCWSTR lpClassName,
+                                             LPCWSTR lpWindowName,
+                                             DWORD dwStyle,
+                                             int X,
+                                             int Y,
+                                             int nWidth,
+                                             int nHeight,
+                                             HWND hWndParent,
+                                             HMENU hMenu,
+                                             HINSTANCE hInstance,
+                                             PVOID lpParam,
+                                             DWORD dwBand,
+                                             DWORD dwTypeFlags);
+CreateWindowInBandEx_t CreateWindowInBandEx_Original;
+HWND WINAPI CreateWindowInBandEx_Hook(DWORD dwExStyle,
+                                      LPCWSTR lpClassName,
+                                      LPCWSTR lpWindowName,
+                                      DWORD dwStyle,
+                                      int X,
+                                      int Y,
+                                      int nWidth,
+                                      int nHeight,
+                                      HWND hWndParent,
+                                      HMENU hMenu,
+                                      HINSTANCE hInstance,
+                                      PVOID lpParam,
+                                      DWORD dwBand,
+                                      DWORD dwTypeFlags) {
+    HWND hWnd = CreateWindowInBandEx_Original(
+        dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight,
+        hWndParent, hMenu, hInstance, lpParam, dwBand, dwTypeFlags);
+    if (!hWnd) {
+        return hWnd;
+    }
+
+    OnWindowCreated(hWnd, lpClassName, __FUNCTION__);
+
+    return hWnd;
 }
 
 HWND GetCoreWnd() {
@@ -8381,12 +10386,29 @@ int NTAPI RtlQueryFeatureConfiguration_Hook(UINT32 featureId,
         // Disable the Start Menu Phone Link layout feature.
         // https://winaero.com/enable-phone-link-flyout-start-menu/
         case 48697323:
+            Wh_Log(L"%u", featureId);
+            if (g_disableNewStartMenuLayout ==
+                DisableNewStartMenuLayout::forceNewLayout) {
+                config->enabledState = FEATURE_ENABLED_STATE_ENABLED;
+            } else if (g_disableNewStartMenuLayout ==
+                       DisableNewStartMenuLayout::
+                           disableNewLayoutAndPhoneLink) {
+                config->enabledState = FEATURE_ENABLED_STATE_DISABLED;
+            }
+            break;
+
         // Disable the revamped Start menu experience.
         // https://x.com/phantomofearth/status/1907877141540118888
         case 47205210:
         // case 49221331:
         case 49402389:
-            config->enabledState = FEATURE_ENABLED_STATE_DISABLED;
+            Wh_Log(L"%u", featureId);
+            if (g_disableNewStartMenuLayout ==
+                DisableNewStartMenuLayout::forceNewLayout) {
+                config->enabledState = FEATURE_ENABLED_STATE_ENABLED;
+            } else {
+                config->enabledState = FEATURE_ENABLED_STATE_DISABLED;
+            }
             break;
     }
 
@@ -8436,7 +10458,7 @@ bool StartStatsTimer() {
     static constexpr WCHAR kStatsBaseUrl[] =
         L"https://github.com/ramensoftware/"
         L"windows-11-start-menu-styling-guide/"
-        L"releases/download/stats-v2/";
+        L"releases/download/stats-v3/";
 
     ULONGLONG lastStatsTime = 0;
     Wh_GetBinaryValue(L"statsTimerLastTime", &lastStatsTime,
@@ -8556,16 +10578,27 @@ void StopStatsTimer() {
     }
 }
 
+DisableNewStartMenuLayout GetDisableNewStartMenuLayout() {
+    PCWSTR disableNewStartMenuLayoutStr =
+        Wh_GetStringSetting(L"disableNewStartMenuLayout");
+    DisableNewStartMenuLayout disableNewStartMenuLayout =
+        DisableNewStartMenuLayout::windowsDefault;
+    if (wcscmp(disableNewStartMenuLayoutStr, L"1") == 0) {
+        disableNewStartMenuLayout =
+            DisableNewStartMenuLayout::disableNewLayoutAndPhoneLink;
+    } else if (wcscmp(disableNewStartMenuLayoutStr,
+                      L"disableNewLayoutKeepPhoneLink") == 0) {
+        disableNewStartMenuLayout =
+            DisableNewStartMenuLayout::disableNewLayoutKeepPhoneLink;
+    } else if (wcscmp(disableNewStartMenuLayoutStr, L"forceNewLayout") == 0) {
+        disableNewStartMenuLayout = DisableNewStartMenuLayout::forceNewLayout;
+    }
+    Wh_FreeStringSetting(disableNewStartMenuLayoutStr);
+    return disableNewStartMenuLayout;
+}
+
 BOOL Wh_ModInit() {
     Wh_Log(L">");
-
-    g_disableNewStartMenuLayout =
-        Wh_GetIntSetting(L"disableNewStartMenuLayout");
-
-    g_isRedesignedStartMenu = !g_disableNewStartMenuLayout &&
-                              IsOsFeatureEnabled(47205210).value_or(false) &&
-                              IsOsFeatureEnabled(49221331).value_or(false) &&
-                              IsOsFeatureEnabled(49402389).value_or(false);
 
     g_target = Target::StartMenu;
 
@@ -8590,6 +10623,42 @@ BOOL Wh_ModInit() {
             break;
     }
 
+    g_disableNewStartMenuLayout = GetDisableNewStartMenuLayout();
+
+    if (g_disableNewStartMenuLayout !=
+        DisableNewStartMenuLayout::windowsDefault) {
+#ifdef _WIN64
+        const size_t OFFSET_SAME_TEB_FLAGS = 0x17EE;
+#else
+        const size_t OFFSET_SAME_TEB_FLAGS = 0x0FCA;
+#endif
+        bool isInitialThread =
+            *(USHORT*)((BYTE*)NtCurrentTeb() + OFFSET_SAME_TEB_FLAGS) & 0x0400;
+        if (!isInitialThread) {
+            // Throttle to avoid exiting in a loop if something goes wrong.
+            WCHAR lastExitTickCountKey[64];
+            swprintf_s(lastExitTickCountKey, L"lastExitTickCount_%d",
+                       static_cast<int>(g_target));
+            DWORD lastTickCount =
+                (DWORD)Wh_GetIntValue(lastExitTickCountKey, 0);
+            DWORD currentTickCount = GetTickCount();
+            if (currentTickCount - lastTickCount > 10 * 1000) {
+                Wh_SetIntValue(lastExitTickCountKey, currentTickCount);
+                // Exit to have the new setting take effect. The process will be
+                // relaunched automatically.
+                ExitProcess(0);
+            }
+        }
+    }
+
+    g_isRedesignedStartMenu = g_disableNewStartMenuLayout ==
+                                  DisableNewStartMenuLayout::forceNewLayout ||
+                              (g_disableNewStartMenuLayout ==
+                                   DisableNewStartMenuLayout::windowsDefault &&
+                               IsOsFeatureEnabled(47205210).value_or(false) &&
+                               IsOsFeatureEnabled(49221331).value_or(false) &&
+                               IsOsFeatureEnabled(49402389).value_or(false));
+
     HMODULE user32Module =
         LoadLibraryEx(L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (user32Module) {
@@ -8610,7 +10679,8 @@ BOOL Wh_ModInit() {
         }
     }
 
-    if (g_target == Target::StartMenu && g_disableNewStartMenuLayout) {
+    if (g_disableNewStartMenuLayout !=
+        DisableNewStartMenuLayout::windowsDefault) {
         HMODULE hNtDll = LoadLibraryW(L"ntdll.dll");
         RtlQueryFeatureConfiguration_t pRtlQueryFeatureConfiguration =
             (RtlQueryFeatureConfiguration_t)GetProcAddress(
@@ -8645,13 +10715,14 @@ void Wh_ModAfterInit() {
 void Wh_ModUninit() {
     Wh_Log(L">");
 
-    if (g_target == Target::StartMenu) {
-        if (g_disableNewStartMenuLayout) {
-            // Exit to have the new setting take effect. The process will be
-            // relaunched automatically.
-            ExitProcess(0);
-        }
+    if (g_disableNewStartMenuLayout !=
+        DisableNewStartMenuLayout::windowsDefault) {
+        // Exit to have the new setting take effect. The process will be
+        // relaunched automatically.
+        ExitProcess(0);
+    }
 
+    if (g_target == Target::StartMenu) {
         StopStatsTimer();
     }
 
@@ -8666,14 +10737,31 @@ void Wh_ModUninit() {
         RunFromWindowThread(
             hCoreWnd, [](PVOID) { UninitializeSettingsAndTap(); }, nullptr);
     }
+
+    // Unregister global network status change handler.
+    if (g_networkStatusChangedToken) {
+        try {
+            winrt::Windows::Networking::Connectivity::NetworkInformation::
+                NetworkStatusChanged(g_networkStatusChangedToken);
+            Wh_Log(L"Unregistered global network status change handler");
+        } catch (winrt::hresult_error const& ex) {
+            Wh_Log(L"Error unregistering network status handler %08X: %s",
+                   ex.code(), ex.message().c_str());
+        }
+        g_networkStatusChangedToken = {};
+    }
+
+    // Clear the dispatcher registry.
+    {
+        std::lock_guard<std::mutex> lock(g_failedImageBrushesRegistryMutex);
+        g_failedImageBrushesRegistry.clear();
+    }
 }
 
 void Wh_ModSettingsChanged() {
     Wh_Log(L">");
 
-    if (g_target == Target::StartMenu &&
-        Wh_GetIntSetting(L"disableNewStartMenuLayout") !=
-            g_disableNewStartMenuLayout) {
+    if (GetDisableNewStartMenuLayout() != g_disableNewStartMenuLayout) {
         // Exit to have the new setting take effect. The process will be
         // relaunched automatically.
         ExitProcess(0);


### PR DESCRIPTION
* Added more layout options to the mod settings. Now the classic layout with Phone Link can be selected, as well as the new (redesigned) layout.
* Added the following themes: SunValley, LiquidGlass, Windows10X, TintedGlass.
* Update the following themes:
  * Classic start menu: TranslucentStartMenu, NoRecommendedSection, Down Aero.
  * Redesigned start menu: Windows10_Minimal, Windows11_Metro10, Windows11_Metro10Minimal, SunValley (Legacy, formerly 21996), OnlySearch, WindowGlass, Oversimplified&Accentuated.
  * Both variants: SideBySide, SideBySide2, SideBySideMinimal, UniMenu.
* Added the following properties to `WindhawkBlur`: `TintLuminosityOpacity`, `TintSaturation`, `NoiseOpacity`, and `NoiseDensity`. The implementation was contributed by [Jhen](https://github.com/Lockframe). For details, refer to [the styling guide](https://github.com/ramensoftware/windows-11-start-menu-styling-guide).
* Added a way to define theme-aware resources. For example, different colors for an element can be defined for light mode and dark mode.