### PR TITLE
feat(tilling-helper): always tile, drag to untile

### DIFF
--- a/mods/tiling-helper.wh.cpp
+++ b/mods/tiling-helper.wh.cpp
@@ -2,7 +2,7 @@
 // @id              tiling-helper
 // @name            Tiling Helper
 // @description     Tile windows on the current monitor with customizable layouts and hotkeys
-// @version         1.0.0
+// @version         2.0.0
 // @author          u2x1
 // @github          https://github.com/u2x1
 // @include         windhawk.exe
@@ -13,25 +13,22 @@
 /*
 # Tiling Helper
 
-A focused window tiling tool for Windows 10/11. Tile windows on the current monitor, cycle layouts, and keep
-resize-adjusted ratios per virtual desktop.
+A focused window tiling tool for Windows 10/11. Tile windows on the current monitor with the `MasterStack` layout,
+and keep resize-adjusted ratios per virtual desktop.
 
 ## Features
 - Manual tiling hotkey
-- Layout cycle hotkey
-- 6 layouts: Master+Stack (Vertical/Horizontal), Columns, Rows, BSP, Monocle
+- Single layout: Master+Stack
 - Adjustable margin, gap, and master size
 - Remembers resize adjustments per virtual desktop + monitor (auto-retile can be disabled)
-- Optional capture of current window sizes when tiling (useful if auto-retile is off)
+- Captures current window sizes when tiling (useful if auto-retile is off)
 
 ## Default Hotkeys
-- Tile windows: Alt + D
-- Cycle layout: Alt + L
-- Toggle retile-on-resize + reset memory: Alt + R
+- Tile windows: Alt + D (always available)
+- Pause/resume automatic tiling + reset memory: Alt + R
 
 ## Notes
-- The layout selection is global (one current layout), while the tiling state (ratios/weights) is stored per
-  virtual desktop and monitor.
+- Tiling state (ratios/weights) is stored per virtual desktop and monitor.
 - If Virtual Desktop APIs are unavailable, tiling still works but per-desktop memory is disabled.
 */
 // ==/WindhawkModReadme==
@@ -48,21 +45,21 @@ resize-adjusted ratios per virtual desktop.
     - win11_22621: Windows 11 (Build 22621/22631/23H2)
     - win11_26100: Windows 11 (Build 26100+ / 24H2)
 
-- EnableTiling: true
-  $name: '[Tiling] Enable'
-  $description: Enable hotkey to tile windows on current monitor
+- EnableTileNewWin: false
+  $name: '[Tiling] Tile New Windows'
+  $description: Automatically retile when a new window is created
 
 - EnableResizeRetile: true
   $name: '[Tiling] Retile On Resize'
-  $description: Automatically retile when a tiled window is resized (only applies when tiling is enabled)
+  $description: Automatically retile when a tiled window is resized
 
 - RetileToggleKey: "R"
   $name: '[Tiling] Retile Toggle Key'
-  $description: 'Key to pause/resume retile-on-resize and reset tiling memory. Only active when Retile On Resize is enabled.'
+  $description: 'Key to pause/resume automatic tiling and reset tiling memory. Manual tiling remains available.'
 
-- CaptureLayoutOnTile: true
-  $name: '[Tiling] Capture Layout On Tile'
-  $description: Use current window sizes as layout weights when tiling (useful when auto-retile is disabled)
+- SwapMasterKey: "C"
+  $name: '[Tiling] Switch Master Window Key'
+  $description: 'Key to set another master window while tiling is not paused.'
 
 - TilingModifier: alt
   $name: '[Tiling] Modifier'
@@ -78,36 +75,24 @@ resize-adjusted ratios per virtual desktop.
   $name: '[Tiling] Key'
   $description: 'Key to tile all windows on the current monitor. Examples: D, T, Space, `, -'
 
-- DefaultLayout: master_stack
-  $name: '[Tiling] Default Layout'
-  $description: The initial tiling layout when the mod starts (only applies when tiling is enabled)
-  $options:
-    - master_stack: Master + Stack (Vertical)
-    - master_stack_h: Master + Stack (Horizontal)
-    - columns: Columns
-    - rows: Rows
-    - bsp: BSP (Binary Space Partition)
-    - monocle: Monocle (Fullscreen)
-
 - TileMargin: 4
   $name: '[Tiling] Margin (pixels)'
-  $description: Gap between tiled windows and screen edges (0-100, only applies when tiling is enabled)
+  $description: Gap between tiled windows and screen edges (0-100)
 
 - TileGap: 4
   $name: '[Tiling] Gap (pixels)'
-  $description: Gap between adjacent tiled windows (0-100, only applies when tiling is enabled)
+  $description: Gap between adjacent tiled windows (0-100)
+
+- LayoutOrientation: vertical
+  $name: '[Tiling] Layout Orientation'
+  $description: 'Master window position: horizontal (master on left, stack on right), vertical (master on top, stack on bottom)'
+  $options:
+    - vertical: Vertical (Master Top)
+    - horizontal: Horizontal (Master Left)
 
 - MasterPercent: 50
   $name: '[Tiling] Master Size (%)'
-  $description: Size percentage of the master window in Master+Stack layouts (1-99, only applies when tiling is enabled)
-
-- EnableLayoutCycle: true
-  $name: '[Tiling] Enable Layout Cycle'
-  $description: Enable hotkey to cycle through tiling layouts (only works when tiling hotkey is enabled)
-
-- LayoutKey: "L"
-  $name: '[Tiling] Layout Cycle Key'
-  $description: 'Key to cycle through tiling layouts. Examples: L, Tab, =, ], /'
+  $description: Size percentage of the master window in `masterh` layout (1-99)
 */
 // ==/WindhawkModSettings==
 
@@ -121,6 +106,7 @@ resize-adjusted ratios per virtual desktop.
 #include <algorithm>
 #include <cmath>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #define SAFE_RELEASE(p) \
@@ -177,8 +163,6 @@ static const VersionIIDs g_versionIIDs[] = {
      false},
 };
 
-static int g_windowsVersionIndex = 4;
-
 //=============================================================================
 // COM Interface Definitions (undocumented, reverse-engineered)
 //=============================================================================
@@ -192,40 +176,80 @@ struct IVirtualDesktopManagerInternal : public IUnknown {};
 //=============================================================================
 // Global State
 //=============================================================================
-static IServiceProvider* g_pServiceProvider = nullptr;
-static IVirtualDesktopManagerInternal* g_pDesktopManagerInternal = nullptr;
-static IVirtualDesktopManager* g_pDesktopManager = nullptr;
-static bool g_bInitialized = false;
 
-static HANDLE g_hThread = nullptr;
-static DWORD g_threadId = 0;
-static HANDLE g_hReadyEvent = nullptr;
-static volatile bool g_stopHotkeyThread = false;
+static inline LONG RectW(const RECT& r) { return r.right - r.left; }
+static inline LONG RectH(const RECT& r) { return r.bottom - r.top; }
+
+enum class Axis { X, Y };
+
+inline Axis OrthogonalAxis(Axis axis) {
+  return axis == Axis::X ? Axis::Y : Axis::X;
+}
+
+inline LONG AxisStart(const RECT& rect, Axis axis) {
+  return axis == Axis::X ? rect.left : rect.top;
+}
+
+inline LONG AxisEnd(const RECT& rect, Axis axis) {
+  return axis == Axis::X ? rect.right : rect.bottom;
+}
+
+inline LONG AxisSpan(const RECT& rect, Axis axis) {
+  return axis == Axis::X ? RectW(rect) : RectH(rect);
+}
+
+inline RECT ReplaceAxisRange(const RECT& rect, Axis axis, LONG start, LONG end) {
+  RECT out = rect;
+  if (axis == Axis::X) {
+    out.left = start;
+    out.right = end;
+  } else {
+    out.top = start;
+    out.bottom = end;
+  }
+  return out;
+}
+
+struct DesktopApiState {
+  IServiceProvider* serviceProvider = nullptr;
+  IVirtualDesktopManagerInternal* managerInternal = nullptr;
+  IVirtualDesktopManager* manager = nullptr;
+  bool initialized = false;
+  int windowsVersionIndex = 4;
+};
+
+struct HotkeyThreadState {
+  HANDLE thread = nullptr;
+  DWORD threadId = 0;
+  HANDLE readyEvent = nullptr;
+  volatile bool stopRequested = false;
+};
+
+struct SettingsState {
+  UINT tilingModifiers = MOD_ALT;
+  UINT tileKey = 'D';
+  UINT retileToggleKey = 'R';
+  UINT swapMasterKey = 'M';
+  LONG tileMargin = 4;
+  LONG tileGap = 4;
+  LONG masterPercent = 50;
+  bool enableResizeRetile = true;
+  bool retileSuspended = false;
+  bool enableTileNewWin = false;
+  Axis masterAxis = Axis::Y;  // Y = horizontal (master left), X = vertical (master top)
+};
 
 // Hotkey IDs
 enum HotkeyIds {
   HK_TILE = 1,
-  HK_LAYOUT = 2,
-  HK_RETILE_TOGGLE = 3
+  HK_RETILE_TOGGLE = 2,
+  HK_SWAP_MASTER = 3
 };
 
-static UINT g_tilingModifiers = MOD_ALT;
-static UINT g_tileKey = 'D';
-static UINT g_layoutKey = 'L';
-static UINT g_retileToggleKey = 'R';
-
-static LONG g_tileMargin = 4;
-static LONG g_tileGap = 4;
-static LONG g_masterPercent = 50;
-
-enum class TileLayout { MasterStack, Columns, Rows, MasterStackH, BSP, Monocle, COUNT };
-static TileLayout g_currentLayout = TileLayout::MasterStack;
-
-static bool g_enableTiling = true;
-static bool g_enableResizeRetile = true;
-static bool g_captureLayoutOnTile = true;
-static bool g_enableLayoutCycle = true;
-static bool g_retileSuspended = false;
+// Messages to hotkey thread
+constexpr UINT WM_APP_RETILE = WM_APP + 1;
+constexpr UINT WM_APP_TILE = WM_APP + 2;
+constexpr UINT WM_APP_PRUNE_DESTROY = WM_APP + 3;
 
 // Per-desktop + monitor state
 struct GuidHash {
@@ -263,18 +287,90 @@ struct DesktopMonitorKeyEqual {
 };
 
 struct TilingState {
-  TileLayout layout = TileLayout::MasterStack;
   std::vector<HWND> windows;
   double masterRatio = 0.5;
   std::vector<double> stackWeights;
-  std::vector<double> gridWeights;
 };
 
-static std::unordered_map<DesktopMonitorKey, TilingState, DesktopMonitorKeyHash, DesktopMonitorKeyEqual>
-    g_tilingStateMap;
-static SRWLOCK g_tilingStateLock = SRWLOCK_INIT;
-static volatile LONG g_retileInProgress = 0;
-static HWINEVENTHOOK g_hMoveSizeHook = nullptr;
+struct TilingStore {
+  std::unordered_map<DesktopMonitorKey, TilingState, DesktopMonitorKeyHash, DesktopMonitorKeyEqual> tilingStateMap;
+  SRWLOCK tilingStateLock = SRWLOCK_INIT;
+  std::unordered_set<HWND> untiledWindows;
+  SRWLOCK untiledWindowsLock = SRWLOCK_INIT;
+  SRWLOCK moveSizeRectsLock = SRWLOCK_INIT;
+  volatile LONG retileInProgress = 0;
+  std::unordered_map<HWND, RECT> moveSizeStartRects;
+  std::unordered_map<HWND, RECT> moveSizeEndRects;
+};
+
+struct HookState {
+  HWINEVENTHOOK moveSizeHook = nullptr;
+  HWINEVENTHOOK minimizeHook = nullptr;
+  HWINEVENTHOOK hideDestroyHook = nullptr;
+  HWINEVENTHOOK cloakHook = nullptr;
+};
+
+static DesktopApiState g_desktopApi;
+static HotkeyThreadState g_hotkeyThread;
+static SettingsState g_settings;
+static TilingStore g_store;
+static HookState g_hooks;
+
+//=============================================================================
+//Move detection
+//=============================================================================
+
+static inline bool Differs(LONG a, LONG b, LONG tol = 1) {
+  return (a > b) ? (a - b > tol) : (b - a > tol);
+}
+
+bool IsMoveOnlyRectChange(const RECT& before, const RECT& after, LONG tol = 1) {
+  bool xChanged = Differs(before.left, after.left, tol);
+  bool yChanged = Differs(before.top, after.top, tol);
+  bool wChanged = Differs(RectW(before), RectW(after), tol);
+  bool hChanged = Differs(RectH(before), RectH(after), tol);
+  return (xChanged || yChanged) && !wChanged && !hChanged;
+}
+
+//=============================================================================
+// Internal Module Interfaces
+//=============================================================================
+struct RetileContext;
+struct WindowEventContext;
+// Desktop API
+bool InitializeVirtualDesktopAPI();
+bool GetCurrentDesktopId(GUID* outGuid);
+bool GetWindowDesktopIdSafe(HWND hwnd, GUID* outGuid);
+void CleanupVirtualDesktopAPI();
+// Layout + tiling
+bool IsWindowCloaked(HWND hwnd);
+bool IsTileEligible(HWND hwnd, HMONITOR targetMonitor);
+std::vector<HWND> CollectTileWindows(HMONITOR monitor);
+void TileWindows(HWND preferredWindow, bool allowWhenSuspended = false);
+void SwapMaster();
+// Store helpers
+bool TryGetSavedState(const DesktopMonitorKey& key, TilingState* outState);
+void StoreTilingState(const DesktopMonitorKey& key, const TilingState& state);
+void StoreOrEraseTilingState(const DesktopMonitorKey& key, const TilingState& state);
+bool GetTiledWorkArea(HMONITOR monitor, RECT* outRect);
+bool TryGetDesktopMonitorContext(HWND hwnd, DesktopMonitorKey* outKey, RECT* outWorkArea);
+void ClearMoveSizeRects(HWND hwnd);
+bool TakeResizeRects(HWND hwnd, RECT* outStartRect, RECT* outEndRect);
+void ResetTilingStateMemory();
+// Engine
+static HWND PruneDestroyedAndPickAnchor(HWND deadHwnd);
+static bool HandleTrivialState(const DesktopMonitorKey& key, TilingState& state, const RECT& workArea);
+void RetileFromResize(HWND hwnd);
+void OnWindowResizeEnd(HWND hwnd);
+// Events
+void CALLBACK WinEventProc(HWINEVENTHOOK, DWORD event, HWND hwnd, LONG idObject, LONG idChild, DWORD, DWORD);
+void InstallWinEventHooks();
+void RemoveWinEventHooks();
+// Runtime
+void LoadSettings();
+DWORD WINAPI HotkeyThreadProc(LPVOID);
+bool StartHotkeyThread();
+void StopHotkeyThread();
 
 //=============================================================================
 // Helper Functions
@@ -285,7 +381,7 @@ T GetVTableFunction(void* pInterface, int index) {
   return reinterpret_cast<T>((*reinterpret_cast<void***>(pInterface))[index]);
 }
 
-bool UsesHMonitorParameter() { return g_versionIIDs[g_windowsVersionIndex].usesHMonitor; }
+bool UsesHMonitorParameter() { return g_versionIIDs[g_desktopApi.windowsVersionIndex].usesHMonitor; }
 
 UINT ParseModifiers(PCWSTR str) {
   UINT modifiers = 0;
@@ -303,16 +399,6 @@ T LookupTable(PCWSTR str, const std::pair<PCWSTR, T>* table, size_t count, T def
   return defaultVal;
 }
 
-TileLayout ParseLayoutSetting(PCWSTR str) {
-  static const std::pair<PCWSTR, TileLayout> kLayoutMap[] = {{L"master_stack", TileLayout::MasterStack},
-                                                             {L"master_stack_h", TileLayout::MasterStackH},
-                                                             {L"columns", TileLayout::Columns},
-                                                             {L"rows", TileLayout::Rows},
-                                                             {L"bsp", TileLayout::BSP},
-                                                             {L"monocle", TileLayout::Monocle}};
-  return LookupTable(str, kLayoutMap, _countof(kLayoutMap), TileLayout::MasterStack);
-}
-
 int ParseWindowsVersion(PCWSTR str) {
   static const std::pair<PCWSTR, int> kVersionMap[] = {
       {L"win10_old", 0}, {L"win10_20348", 1}, {L"win11_22000", 2}, {L"win11_22621", 3}, {L"win11_26100", 4}};
@@ -327,11 +413,9 @@ T ReadStringSetting(PCWSTR name, Parser parser, T defaultVal) {
   return result ? result : defaultVal;
 }
 
-UINT ReadModifierSetting(PCWSTR name, UINT defaultVal) {
-  PCWSTR str = Wh_GetStringSetting(name);
-  UINT result = ParseModifiers(str);
-  Wh_FreeStringSetting(str);
-  return result ? result : defaultVal;
+LONG ReadClampedIntSetting(PCWSTR name, LONG minVal, LONG maxVal, LONG defaultVal) {
+  LONG value = Wh_GetIntSetting(name);
+  return value >= minVal && value <= maxVal ? value : defaultVal;
 }
 
 inline double ClampDouble(double value, double minVal, double maxVal) {
@@ -356,10 +440,17 @@ bool GetMonitorWorkArea(HMONITOR monitor, RECT* outRect) {
   return true;
 }
 
-bool AreSameWindows(const std::vector<HWND>& a, const std::vector<HWND>& b) {
+bool HaveSameWindowSet(const std::vector<HWND>& a, const std::vector<HWND>& b) {
   if (a.size() != b.size()) return false;
-  for (size_t i = 0; i < a.size(); ++i) {
-    if (a[i] != b[i]) return false;
+  for (HWND hwndA : a) {
+    bool found = false;
+    for (HWND hwndB : b) {
+      if (hwndA == hwndB) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) return false;
   }
   return true;
 }
@@ -368,13 +459,55 @@ std::vector<double> DefaultWeights(size_t count) {
   return std::vector<double>(count, 1.0);
 }
 
-bool IsTileEligible(HWND hwnd, HMONITOR targetMonitor);
-
 bool ContainsWindow(const std::vector<HWND>& windows, HWND hwnd) {
   for (HWND w : windows) {
     if (w == hwnd) return true;
   }
   return false;
+}
+
+HWND NormalizeTrackedWindow(HWND hwnd) {
+  if (!hwnd) return nullptr;
+  HWND root = GetAncestor(hwnd, GA_ROOTOWNER);
+  return root ? root : hwnd;
+}
+
+bool IsWindowMarkedUntiled(HWND hwnd) {
+  hwnd = NormalizeTrackedWindow(hwnd);
+  if (!hwnd) return false;
+
+  AcquireSRWLockShared(&g_store.untiledWindowsLock);
+  bool isUntiled = g_store.untiledWindows.find(hwnd) != g_store.untiledWindows.end();
+  ReleaseSRWLockShared(&g_store.untiledWindowsLock);
+
+  return isUntiled;
+}
+
+void MarkWindowUntiled(HWND hwnd) {
+  hwnd = NormalizeTrackedWindow(hwnd);
+  if (!hwnd) return;
+
+  AcquireSRWLockExclusive(&g_store.untiledWindowsLock);
+  g_store.untiledWindows.insert(hwnd);
+  ReleaseSRWLockExclusive(&g_store.untiledWindowsLock);
+}
+
+void ClearWindowUntiled(HWND hwnd) {
+  hwnd = NormalizeTrackedWindow(hwnd);
+  if (!hwnd) return;
+
+  AcquireSRWLockExclusive(&g_store.untiledWindowsLock);
+  g_store.untiledWindows.erase(hwnd);
+  ReleaseSRWLockExclusive(&g_store.untiledWindowsLock);
+}
+
+void RemoveUntiledWindows(std::vector<HWND>& windows) {
+  AcquireSRWLockShared(&g_store.untiledWindowsLock);
+  windows.erase(std::remove_if(windows.begin(), windows.end(), [&](HWND hwnd) {
+                  return g_store.untiledWindows.find(NormalizeTrackedWindow(hwnd)) != g_store.untiledWindows.end();
+                }),
+                windows.end());
+  ReleaseSRWLockShared(&g_store.untiledWindowsLock);
 }
 
 HWND ResolveEquivalentWindow(HWND hwnd, const std::vector<HWND>& candidates) {
@@ -459,106 +592,138 @@ std::vector<HWND> CollectTileWindows(HMONITOR monitor) {
   return windows;
 }
 
-TilingState BuildStateFromWindows(TileLayout layout, const RECT& workArea, const std::vector<HWND>& windows,
-                                  HMONITOR monitor) {
+struct WindowInfo {
+  HWND hwnd;
+  RECT rect;
+};
+
+LONG ClampSpanMin1(LONG value) {
+  return value < 1 ? 1 : value;
+}
+
+size_t FindWindowIndex(const std::vector<HWND>& windows, HWND hwnd) {
+  for (size_t i = 0; i < windows.size(); ++i) {
+    if (windows[i] == hwnd) return i;
+  }
+  return (size_t)-1;
+}
+
+TilingState MakeDefaultState(const std::vector<HWND>& windows) {
   TilingState state;
-  state.layout = layout;
   state.windows = windows;
-  if (windows.empty()) return state;
+  state.masterRatio = ClampDouble(g_settings.masterPercent / 100.0, 0.1, 0.9);
+  return state;
+}
 
-  if (layout == TileLayout::MasterStack || layout == TileLayout::MasterStackH) {
-    bool horizontal = (layout == TileLayout::MasterStackH);
-    struct WindowInfo {
-      HWND hwnd;
-      RECT rect;
-    };
-    std::vector<WindowInfo> infos;
-    infos.reserve(windows.size());
-    for (HWND w : windows) {
-      RECT rect = {};
-      if (!GetWindowFrameRect(w, &rect)) {
-        rect = workArea;
-      }
-      if (MonitorFromRect(&rect, MONITOR_DEFAULTTONULL) != monitor) {
-        rect = workArea;
-      }
-      infos.push_back({w, rect});
+void NormalizeState(TilingState& state) {
+  state.masterRatio = ClampDouble(state.masterRatio, 0.1, 0.9);
+
+  size_t stackCount = state.windows.empty() ? 0 : state.windows.size() - 1;
+  if (state.stackWeights.size() != stackCount) {
+    state.stackWeights = DefaultWeights(stackCount);
+  }
+}
+
+std::vector<WindowInfo> CollectWindowInfo(const std::vector<HWND>& windows, const RECT& fallbackRect,
+                                          HMONITOR monitor = nullptr) {
+  std::vector<WindowInfo> infos;
+  infos.reserve(windows.size());
+
+  for (HWND hwnd : windows) {
+    RECT rect = {};
+    if (!GetWindowFrameRect(hwnd, &rect)) {
+      rect = fallbackRect;
     }
-
-    size_t masterIndex = 0;
-    LONG bestSize = -1;
-    for (size_t i = 0; i < infos.size(); ++i) {
-      LONG size = horizontal ? (infos[i].rect.bottom - infos[i].rect.top) : (infos[i].rect.right - infos[i].rect.left);
-      if (size > bestSize) {
-        bestSize = size;
-        masterIndex = i;
-      }
+    if (monitor && MonitorFromRect(&rect, MONITOR_DEFAULTTONULL) != monitor) {
+      rect = fallbackRect;
     }
-
-    WindowInfo master = infos[masterIndex];
-    std::vector<WindowInfo> stack;
-    stack.reserve(infos.size() - 1);
-    for (size_t i = 0; i < infos.size(); ++i) {
-      if (i == masterIndex) continue;
-      stack.push_back(infos[i]);
-    }
-
-    std::sort(stack.begin(), stack.end(), [horizontal](const WindowInfo& a, const WindowInfo& b) {
-      return horizontal ? (a.rect.left < b.rect.left) : (a.rect.top < b.rect.top);
-    });
-
-    state.windows.clear();
-    state.windows.push_back(master.hwnd);
-    for (const auto& item : stack) state.windows.push_back(item.hwnd);
-
-    LONG totalSize = horizontal ? (workArea.bottom - workArea.top) : (workArea.right - workArea.left);
-    if (totalSize > g_tileGap + 1) {
-      LONG masterSize = horizontal ? (master.rect.bottom - master.rect.top) : (master.rect.right - master.rect.left);
-      if (masterSize < 1) masterSize = 1;
-      state.masterRatio = ClampDouble((double)masterSize / (double)(totalSize - g_tileGap), 0.1, 0.9);
-    } else {
-      state.masterRatio = ClampDouble(g_masterPercent / 100.0, 0.1, 0.9);
-    }
-
-    state.stackWeights.clear();
-    for (const auto& item : stack) {
-      LONG size = horizontal ? (item.rect.right - item.rect.left) : (item.rect.bottom - item.rect.top);
-      if (size < 1) size = 1;
-      state.stackWeights.push_back(static_cast<double>(size));
-    }
-  } else if (layout == TileLayout::Columns || layout == TileLayout::Rows) {
-    bool horizontal = (layout == TileLayout::Rows);
-    struct WindowInfo {
-      HWND hwnd;
-      RECT rect;
-    };
-    std::vector<WindowInfo> infos;
-    infos.reserve(windows.size());
-    for (HWND w : windows) {
-      RECT rect = {};
-      if (!GetWindowFrameRect(w, &rect)) {
-        rect = workArea;
-      }
-      if (MonitorFromRect(&rect, MONITOR_DEFAULTTONULL) != monitor) {
-        rect = workArea;
-      }
-      infos.push_back({w, rect});
-    }
-
-    std::sort(infos.begin(), infos.end(), [horizontal](const WindowInfo& a, const WindowInfo& b) {
-      return horizontal ? (a.rect.top < b.rect.top) : (a.rect.left < b.rect.left);
-    });
-
-    state.windows.clear();
-    state.gridWeights.clear();
-    for (const auto& item : infos) {
-      state.windows.push_back(item.hwnd);
-      LONG size = horizontal ? (item.rect.bottom - item.rect.top) : (item.rect.right - item.rect.left);
-      if (size < 1) size = 1;
-      state.gridWeights.push_back(static_cast<double>(size));
-    }
+    infos.push_back({hwnd, rect});
   }
 
+  return infos;
+}
+
+void SortWindowInfoByAxis(std::vector<WindowInfo>& infos, Axis axis) {
+  std::stable_sort(infos.begin(), infos.end(), [axis](const WindowInfo& a, const WindowInfo& b) {
+    return AxisStart(a.rect, axis) < AxisStart(b.rect, axis);
+  });
+}
+
+size_t PickMasterWindowIndex(const std::vector<WindowInfo>& infos, const RECT& workArea, Axis masterAxis,
+                             HWND preferredFirstWin) {
+  struct Candidate {
+    long long score;
+    long long axisPos;
+    size_t index;
+  };
+
+  std::vector<Candidate> candidates;
+  candidates.reserve(infos.size());
+
+  for (size_t i = 0; i < infos.size(); ++i) {
+    const RECT& rect = infos[i].rect;
+    long long edges[] = {
+        (long long)std::llabs((long long)rect.left - (long long)workArea.left),
+        (long long)std::llabs((long long)rect.top - (long long)workArea.top),
+        (long long)std::llabs((long long)rect.right - (long long)workArea.right),
+        (long long)std::llabs((long long)rect.bottom - (long long)workArea.bottom),
+    };
+    std::sort(edges, edges + 4);
+
+    candidates.push_back({
+        .score = edges[0] + edges[1] + edges[2],
+        .axisPos = (long long)std::llabs((long long)AxisStart(rect, masterAxis) -
+                                         (long long)AxisStart(workArea, masterAxis)),
+        .index = i,
+    });
+  }
+
+  std::stable_sort(candidates.begin(), candidates.end(), [preferredFirstWin, &infos](const Candidate& a,
+                                                                                      const Candidate& b) {
+    bool aPreferred = preferredFirstWin && infos[a.index].hwnd == preferredFirstWin;
+    bool bPreferred = preferredFirstWin && infos[b.index].hwnd == preferredFirstWin;
+    if (aPreferred != bPreferred) return aPreferred;
+    if (a.score != b.score) return a.score < b.score;
+    return a.axisPos < b.axisPos;
+  });
+
+  return candidates.empty() ? 0 : candidates.front().index;
+}
+
+TilingState BuildStateFromWindows(const RECT& workArea, const std::vector<HWND>& windows,
+                                  HMONITOR monitor, HWND preferredFirstWin = nullptr) {
+  TilingState state = MakeDefaultState(windows);
+  if (windows.empty()) return state;
+
+  std::vector<WindowInfo> infos = CollectWindowInfo(windows, workArea, monitor);
+  size_t masterIndex = PickMasterWindowIndex(infos, workArea, g_settings.masterAxis, preferredFirstWin);
+
+  WindowInfo master = infos[masterIndex];
+
+  std::vector<WindowInfo> stack;
+  stack.reserve(infos.size() - 1);
+  for (size_t i = 0; i < infos.size(); ++i) {
+    if (i != masterIndex) stack.push_back(infos[i]);
+  }
+  SortWindowInfoByAxis(stack, OrthogonalAxis(g_settings.masterAxis));
+
+  state.windows.clear();
+  state.windows.push_back(master.hwnd);
+  for (const auto& item : stack) state.windows.push_back(item.hwnd);
+
+  LONG totalSize = AxisSpan(workArea, g_settings.masterAxis);
+  if (totalSize > g_settings.tileGap + 1) {
+    LONG masterSize = ClampSpanMin1(AxisSpan(master.rect, g_settings.masterAxis));
+    state.masterRatio = ClampDouble((double)masterSize / (double)(totalSize - g_settings.tileGap), 0.1, 0.9);
+  }
+
+  state.stackWeights.clear();
+  for (const auto& item : stack) {
+    LONG stackWidth = ClampSpanMin1(AxisSpan(item.rect, OrthogonalAxis(g_settings.masterAxis)));
+    state.stackWeights.push_back((double)stackWidth);
+  }
+
+  NormalizeState(state);
   return state;
 }
 
@@ -582,9 +747,10 @@ std::vector<LONG> ComputeWeightedSizes(LONG totalSize, LONG gap, const std::vect
     LONG size = 0;
     if (i == count - 1) {
       size = available - used;
+
     } else {
       double ratio = w / remainingSum;
-      size = static_cast<LONG>(std::llround(static_cast<double>(available) * ratio));
+      size = static_cast<LONG>(std::llround(static_cast<double>(available - used) * ratio));
       if (size < 1) size = 1;
       LONG maxSize = available - used - remainingSlots;
       if (size > maxSize) size = maxSize;
@@ -597,62 +763,187 @@ std::vector<LONG> ComputeWeightedSizes(LONG totalSize, LONG gap, const std::vect
   return sizes;
 }
 
-std::vector<LONG> ComputeWeightedSizesWithFixed(LONG totalSize, LONG gap, const std::vector<double>& weights,
-                                                size_t fixedIndex, LONG fixedSize) {
-  size_t count = weights.size();
+std::vector<LONG> ComputeWeightedSizesWithFixed(
+    LONG totalSize, LONG gap, const std::vector<double>& weights,
+    size_t fixedIndex, LONG fixedSize) {
+
+  const size_t count = weights.size();
   std::vector<LONG> sizes(count, 0);
   if (count == 0) return sizes;
   if (fixedIndex >= count) return ComputeWeightedSizes(totalSize, gap, weights);
 
-  LONG available = totalSize - gap * (LONG)(count - 1);
+  const LONG available = totalSize - gap * (LONG)(count - 1);
   if (available <= 0) return sizes;
 
-  LONG minFixed = 1;
-  LONG maxFixed = available - (LONG)(count - 1);
-  if (maxFixed < 1) maxFixed = 1;
-  if (fixedSize < minFixed) fixedSize = minFixed;
-  if (fixedSize > maxFixed) fixedSize = maxFixed;
+  // Clamp fixed size so remaining windows can still be >=1
+  const LONG minFixed = 1;
+  const LONG maxFixed = std::max<LONG>(1, available - (LONG)(count - 1));
+  fixedSize = std::clamp(fixedSize, minFixed, maxFixed);
+
+  sizes[fixedIndex] = fixedSize;
 
   LONG remaining = available - fixedSize;
+  if (count == 1) return sizes;
 
-  std::vector<double> otherWeights;
-  otherWeights.reserve(count - 1);
+  // Sum weights for non-fixed slots
+  double sum = 0.0;
   for (size_t i = 0; i < count; ++i) {
     if (i == fixedIndex) continue;
-    otherWeights.push_back(weights[i]);
+    sum += (weights[i] > 0.0 ? weights[i] : 1.0);
   }
+  if (sum <= 0.0) sum = (double)(count - 1);
 
-  std::vector<LONG> otherSizes = ComputeWeightedSizes(remaining, gap, otherWeights);
+  LONG used = 0;
+  double remainingSum = sum;
 
-  size_t otherIndex = 0;
+  // Distribute remaining across non-fixed indices (no gap math here)
   for (size_t i = 0; i < count; ++i) {
-    if (i == fixedIndex) {
-      sizes[i] = fixedSize;
+    if (i == fixedIndex) continue;
+
+    // how many non-fixed slots remain after i?
+    LONG slotsLeft = 0;
+    for (size_t j = i + 1; j < count; ++j) if (j != fixedIndex) ++slotsLeft;
+
+    double w = (weights[i] > 0.0 ? weights[i] : 1.0);
+    LONG size = 0;
+
+    if (slotsLeft == 0) {
+      size = remaining - used;
     } else {
-      sizes[i] = otherSizes[otherIndex++];
+      const double ratio = w / remainingSum;
+      size = (LONG)std::llround((double)(remaining - used) * ratio);
+      if (size < 1) size = 1;
+
+      const LONG maxSize = (remaining - used) - slotsLeft; // leave >=1 for each remaining slot
+      if (size > maxSize) size = maxSize;
     }
+
+    sizes[i] = size;
+    used += size;
+    remainingSum -= w;
+    if (remainingSum <= 0.0) remainingSum = 1.0;
   }
+
   return sizes;
 }
 
-void LayoutGridWeighted(const RECT& area, size_t windowCount, std::vector<RECT>& outRects, bool horizontal,
-                        const std::vector<double>& weights) {
-  outRects.resize(windowCount);
-  if (windowCount == 0) return;
+static std::vector<LONG> ComputeWeightedSizesWithFixedAnchored(
+    LONG totalSize, LONG gap, const std::vector<double>& weights,
+    const std::vector<LONG>& currentSizes, size_t fixedIndex, LONG fixedSize,
+    bool preserveBeforeFixed, bool preserveAfterFixed) {
+  const size_t count = weights.size();
+  if (count == 0 || currentSizes.size() != count || fixedIndex >= count ||
+      preserveBeforeFixed == preserveAfterFixed) {
+    return ComputeWeightedSizesWithFixed(totalSize, gap, weights, fixedIndex, fixedSize);
+  }
 
-  LONG totalSize = horizontal ? (area.bottom - area.top) : (area.right - area.left);
-  std::vector<LONG> sizes = ComputeWeightedSizes(totalSize, g_tileGap, weights);
-  LONG position = horizontal ? area.top : area.left;
+  const LONG available = totalSize - gap * (LONG)(count - 1);
+  if (available <= 0) return std::vector<LONG>(count, 0);
 
-  for (size_t i = 0; i < windowCount; ++i) {
-    LONG size = sizes[i];
-    LONG end = (i == windowCount - 1) ? (horizontal ? area.bottom : area.right) : position + size;
-    outRects[i] = horizontal ? RECT{area.left, position, area.right, end} : RECT{position, area.top, end, area.bottom};
-    position = end + g_tileGap;
+  const LONG minFixed = 1;
+  const LONG maxFixed = std::max<LONG>(1, available - (LONG)(count - 1));
+  fixedSize = std::clamp(fixedSize, minFixed, maxFixed);
+
+  std::vector<LONG> sizes(count, 0);
+  sizes[fixedIndex] = fixedSize;
+
+  LONG reserved = fixedSize;
+  size_t freeStart = 0;
+  size_t freeEnd = count;
+
+  if (preserveBeforeFixed) {
+    freeStart = fixedIndex + 1;
+    for (size_t i = 0; i < fixedIndex; ++i) {
+      LONG preserved = std::max<LONG>(1, currentSizes[i]);
+      sizes[i] = preserved;
+      reserved += preserved;
+    }
+  } else {
+    freeEnd = fixedIndex;
+    for (size_t i = fixedIndex + 1; i < count; ++i) {
+      LONG preserved = std::max<LONG>(1, currentSizes[i]);
+      sizes[i] = preserved;
+      reserved += preserved;
+    }
+  }
+
+  const size_t freeCount = freeEnd - freeStart;
+  if (freeCount == 0) {
+    return reserved == available ? sizes
+                                 : ComputeWeightedSizesWithFixed(totalSize, gap, weights, fixedIndex, fixedSize);
+  }
+
+  const LONG remaining = available - reserved;
+  if (remaining < (LONG)freeCount) {
+    return ComputeWeightedSizesWithFixed(totalSize, gap, weights, fixedIndex, fixedSize);
+  }
+
+  double sum = 0.0;
+  for (size_t i = freeStart; i < freeEnd; ++i) {
+    sum += (weights[i] > 0.0 ? weights[i] : 1.0);
+  }
+  if (sum <= 0.0) sum = static_cast<double>(freeCount);
+
+  LONG used = 0;
+  double remainingSum = sum;
+  for (size_t i = freeStart; i < freeEnd; ++i) {
+    double w = (weights[i] > 0.0 ? weights[i] : 1.0);
+    LONG slotsLeft = (LONG)(freeEnd - i - 1);
+    LONG size = 0;
+
+    if (slotsLeft == 0) {
+      size = remaining - used;
+    } else {
+      double ratio = w / remainingSum;
+      size = static_cast<LONG>(std::llround(static_cast<double>(remaining - used) * ratio));
+      if (size < 1) size = 1;
+      LONG maxSize = remaining - used - slotsLeft;
+      if (size > maxSize) size = maxSize;
+    }
+
+    sizes[i] = size;
+    used += size;
+    remainingSum -= w;
+    if (remainingSum <= 0.0) remainingSum = 1.0;
+  }
+
+  return sizes;
+}
+
+void LayoutStripFromSizes(const RECT& area, Axis axis, const std::vector<LONG>& sizes, std::vector<RECT>& outRects) {
+  outRects.resize(sizes.size());
+  if (sizes.empty()) return;
+
+  LONG position = AxisStart(area, axis);
+  LONG finalEnd = AxisEnd(area, axis);
+  for (size_t i = 0; i < sizes.size(); ++i) {
+    LONG end = (i == sizes.size() - 1) ? finalEnd : position + sizes[i];
+    outRects[i] = ReplaceAxisRange(area, axis, position, end);
+    position = end + g_settings.tileGap;
   }
 }
 
-void LayoutMasterStackWeighted(const RECT& area, size_t windowCount, std::vector<RECT>& outRects, bool horizontal,
+void LayoutStripWeighted(const RECT& area, size_t count, Axis axis, const std::vector<double>& weights,
+                         std::vector<RECT>& outRects) {
+  outRects.resize(count);
+  if (count == 0) return;
+  if (count == 1) {
+    outRects[0] = area;
+    return;
+  }
+
+  LONG totalSize = AxisSpan(area, axis);
+  if (totalSize <= g_settings.tileGap * (LONG)(count - 1)) {
+    outRects.assign(count, area);
+    return;
+  }
+
+  std::vector<double> normalizedWeights = weights;
+  if (normalizedWeights.size() != count) normalizedWeights = DefaultWeights(count);
+  LayoutStripFromSizes(area, axis, ComputeWeightedSizes(totalSize, g_settings.tileGap, normalizedWeights), outRects);
+}
+
+void LayoutMasterStackWeighted(const RECT& area, size_t windowCount, std::vector<RECT>& outRects, Axis masterAxis,
                                double masterRatio, const std::vector<double>& stackWeights) {
   outRects.resize(windowCount);
   if (windowCount == 0) return;
@@ -661,56 +952,32 @@ void LayoutMasterStackWeighted(const RECT& area, size_t windowCount, std::vector
     return;
   }
 
-  LONG totalSize = horizontal ? (area.bottom - area.top) : (area.right - area.left);
-  LONG masterSize = static_cast<LONG>(std::llround((totalSize - g_tileGap) * masterRatio));
-  if (masterSize < 1) masterSize = 1;
-  if (masterSize > totalSize - g_tileGap - 1) masterSize = totalSize - g_tileGap - 1;
-
-  size_t stackCount = windowCount - 1;
-  std::vector<double> weights = stackWeights;
-  if (weights.size() != stackCount) weights = DefaultWeights(stackCount);
-
-  if (horizontal) {
-    outRects[0] = {area.left, area.top, area.right, area.top + masterSize};
-    LONG stackTop = area.top + masterSize + g_tileGap;
-    std::vector<LONG> sizes = ComputeWeightedSizes(area.right - area.left, g_tileGap, weights);
-    LONG x = area.left;
-    for (size_t i = 0; i < stackCount; ++i) {
-      LONG end = (i == stackCount - 1) ? area.right : x + sizes[i];
-      outRects[i + 1] = {x, stackTop, end, area.bottom};
-      x = end + g_tileGap;
-    }
-  } else {
-    outRects[0] = {area.left, area.top, area.left + masterSize, area.bottom};
-    LONG stackLeft = area.left + masterSize + g_tileGap;
-    std::vector<LONG> sizes = ComputeWeightedSizes(area.bottom - area.top, g_tileGap, weights);
-    LONG y = area.top;
-    for (size_t i = 0; i < stackCount; ++i) {
-      LONG end = (i == stackCount - 1) ? area.bottom : y + sizes[i];
-      outRects[i + 1] = {stackLeft, y, area.right, end};
-      y = end + g_tileGap;
-    }
-  }
-}
-
-void LayoutBSP(const RECT& area, size_t startIndex, size_t count, int depth, std::vector<RECT>& outRects) {
-  if (count == 0) return;
-  if (count == 1) {
-    outRects[startIndex] = area;
+  LONG totalSize = AxisSpan(area, masterAxis);
+  if (totalSize <= g_settings.tileGap + 1) {
+    outRects.assign(windowCount, area);
     return;
   }
 
-  bool splitVertical = (depth % 2 == 0);
-  LONG mid = splitVertical ? area.left + (area.right - area.left - g_tileGap) / 2
-                           : area.top + (area.bottom - area.top - g_tileGap) / 2;
+  LONG masterSize = (LONG)std::llround((double)(totalSize - g_settings.tileGap) * ClampDouble(masterRatio, 0.1, 0.9));
+  masterSize = std::clamp(masterSize, 1L, totalSize - g_settings.tileGap - 1);
 
-  outRects[startIndex] =
-      splitVertical ? RECT{area.left, area.top, mid, area.bottom} : RECT{area.left, area.top, area.right, mid};
+  LONG areaStart = AxisStart(area, masterAxis);
+  LONG masterEnd = areaStart + masterSize;
+  RECT masterRect = ReplaceAxisRange(area, masterAxis, areaStart, masterEnd);
+  RECT stackArea = ReplaceAxisRange(area, masterAxis, masterEnd + g_settings.tileGap, AxisEnd(area, masterAxis));
 
-  RECT remaining = splitVertical ? RECT{mid + g_tileGap, area.top, area.right, area.bottom}
-                                 : RECT{area.left, mid + g_tileGap, area.right, area.bottom};
+  outRects[0] = masterRect;
+  std::vector<RECT> stackRects;
+  LayoutStripWeighted(stackArea, windowCount - 1, OrthogonalAxis(masterAxis), stackWeights, stackRects);
+  for (size_t i = 0; i < stackRects.size(); ++i) {
+    outRects[i + 1] = stackRects[i];
+  }
+}
 
-  LayoutBSP(remaining, startIndex + 1, count - 1, depth + 1, outRects);
+void LayoutStateRects(const RECT& workArea, TilingState& state, std::vector<RECT>& outRects) {
+  NormalizeState(state);
+  LayoutMasterStackWeighted(workArea, state.windows.size(), outRects, g_settings.masterAxis,
+                            state.masterRatio, state.stackWeights);
 }
 
 //=============================================================================
@@ -721,27 +988,27 @@ static const int VTABLE_GET_CURRENT_DESKTOP = 6;
 
 bool InitializeVirtualDesktopAPIOnce() {
   HRESULT hr = CoCreateInstance(CLSID_ImmersiveShell, nullptr, CLSCTX_LOCAL_SERVER, IID_IServiceProvider,
-                                (void**)&g_pServiceProvider);
-  if (FAILED(hr) || !g_pServiceProvider) {
+                                (void**)&g_desktopApi.serviceProvider);
+  if (FAILED(hr) || !g_desktopApi.serviceProvider) {
     Wh_Log(L"Failed to create ImmersiveShell: 0x%08X", hr);
     return false;
   }
 
-  hr = g_pServiceProvider->QueryService(CLSID_VirtualDesktopManagerInternal,
-                                        g_versionIIDs[g_windowsVersionIndex].managerInternal,
-                                        (void**)&g_pDesktopManagerInternal);
-  if (FAILED(hr) || !g_pDesktopManagerInternal) {
+  hr = g_desktopApi.serviceProvider->QueryService(CLSID_VirtualDesktopManagerInternal,
+                                        g_versionIIDs[g_desktopApi.windowsVersionIndex].managerInternal,
+                                        (void**)&g_desktopApi.managerInternal);
+  if (FAILED(hr) || !g_desktopApi.managerInternal) {
     Wh_Log(L"Failed to get VirtualDesktopManagerInternal: 0x%08X", hr);
-    SAFE_RELEASE(g_pServiceProvider);
+    SAFE_RELEASE(g_desktopApi.serviceProvider);
     return false;
   }
 
   hr = CoCreateInstance(CLSID_VirtualDesktopManager, nullptr, CLSCTX_INPROC_SERVER, IID_IVirtualDesktopManager,
-                        (void**)&g_pDesktopManager);
-  if (FAILED(hr) || !g_pDesktopManager) {
+                        (void**)&g_desktopApi.manager);
+  if (FAILED(hr) || !g_desktopApi.manager) {
     Wh_Log(L"Failed to create VirtualDesktopManager: 0x%08X", hr);
-    SAFE_RELEASE(g_pDesktopManagerInternal);
-    SAFE_RELEASE(g_pServiceProvider);
+    SAFE_RELEASE(g_desktopApi.managerInternal);
+    SAFE_RELEASE(g_desktopApi.serviceProvider);
     return false;
   }
 
@@ -752,23 +1019,23 @@ void CleanupVirtualDesktopAPI() {
   HWND hShell = GetShellWindow();
   if (!hShell || !IsWindow(hShell)) {
     Wh_Log(L"Explorer not available, skipping COM cleanup to avoid hang");
-    g_pDesktopManager = nullptr;
-    g_pDesktopManagerInternal = nullptr;
-    g_pServiceProvider = nullptr;
-    g_bInitialized = false;
+    g_desktopApi.manager = nullptr;
+    g_desktopApi.managerInternal = nullptr;
+    g_desktopApi.serviceProvider = nullptr;
+    g_desktopApi.initialized = false;
     return;
   }
 
-  SAFE_RELEASE(g_pDesktopManager);
-  SAFE_RELEASE(g_pDesktopManagerInternal);
-  SAFE_RELEASE(g_pServiceProvider);
-  g_bInitialized = false;
+  SAFE_RELEASE(g_desktopApi.manager);
+  SAFE_RELEASE(g_desktopApi.managerInternal);
+  SAFE_RELEASE(g_desktopApi.serviceProvider);
+  g_desktopApi.initialized = false;
 }
 
 bool InitializeVirtualDesktopAPI() {
-  if (g_bInitialized) return true;
+  if (g_desktopApi.initialized) return true;
   if (InitializeVirtualDesktopAPIOnce()) {
-    g_bInitialized = true;
+    g_desktopApi.initialized = true;
     return true;
   }
   return false;
@@ -782,21 +1049,21 @@ bool ReinitializeVirtualDesktopAPI() {
 template <typename TResult>
 HRESULT CallManagerInternal(int vtableIndex, TResult* outResult) {
   if (UsesHMonitorParameter()) {
-    auto pfn = GetVTableFunction<HRESULT(STDMETHODCALLTYPE*)(void*, HMONITOR, TResult*)>(g_pDesktopManagerInternal,
+    auto pfn = GetVTableFunction<HRESULT(STDMETHODCALLTYPE*)(void*, HMONITOR, TResult*)>(g_desktopApi.managerInternal,
                                                                                          vtableIndex);
-    HRESULT hr = pfn(g_pDesktopManagerInternal, nullptr, outResult);
+    HRESULT hr = pfn(g_desktopApi.managerInternal, nullptr, outResult);
     if (FAILED(hr) && ReinitializeVirtualDesktopAPI()) {
-      pfn = GetVTableFunction<HRESULT(STDMETHODCALLTYPE*)(void*, HMONITOR, TResult*)>(g_pDesktopManagerInternal,
+      pfn = GetVTableFunction<HRESULT(STDMETHODCALLTYPE*)(void*, HMONITOR, TResult*)>(g_desktopApi.managerInternal,
                                                                                       vtableIndex);
-      hr = pfn(g_pDesktopManagerInternal, nullptr, outResult);
+      hr = pfn(g_desktopApi.managerInternal, nullptr, outResult);
     }
     return hr;
   } else {
-    auto pfn = GetVTableFunction<HRESULT(STDMETHODCALLTYPE*)(void*, TResult*)>(g_pDesktopManagerInternal, vtableIndex);
-    HRESULT hr = pfn(g_pDesktopManagerInternal, outResult);
+    auto pfn = GetVTableFunction<HRESULT(STDMETHODCALLTYPE*)(void*, TResult*)>(g_desktopApi.managerInternal, vtableIndex);
+    HRESULT hr = pfn(g_desktopApi.managerInternal, outResult);
     if (FAILED(hr) && ReinitializeVirtualDesktopAPI()) {
-      pfn = GetVTableFunction<HRESULT(STDMETHODCALLTYPE*)(void*, TResult*)>(g_pDesktopManagerInternal, vtableIndex);
-      hr = pfn(g_pDesktopManagerInternal, outResult);
+      pfn = GetVTableFunction<HRESULT(STDMETHODCALLTYPE*)(void*, TResult*)>(g_desktopApi.managerInternal, vtableIndex);
+      hr = pfn(g_desktopApi.managerInternal, outResult);
     }
     return hr;
   }
@@ -804,7 +1071,7 @@ HRESULT CallManagerInternal(int vtableIndex, TResult* outResult) {
 
 bool GetCurrentDesktopId(GUID* outGuid) {
   if (!outGuid) return false;
-  if (!g_pDesktopManagerInternal) return false;
+  if (!g_desktopApi.managerInternal) return false;
 
   IVirtualDesktop* desktop = nullptr;
   HRESULT hr = CallManagerInternal(VTABLE_GET_CURRENT_DESKTOP, &desktop);
@@ -820,8 +1087,8 @@ bool GetCurrentDesktopId(GUID* outGuid) {
 
 bool GetWindowDesktopIdSafe(HWND hwnd, GUID* outGuid) {
   if (!outGuid) return false;
-  if (!InitializeVirtualDesktopAPI() || !g_pDesktopManager) return false;
-  return SUCCEEDED(g_pDesktopManager->GetWindowDesktopId(hwnd, outGuid));
+  if (!InitializeVirtualDesktopAPI() || !g_desktopApi.manager) return false;
+  return SUCCEEDED(g_desktopApi.manager->GetWindowDesktopId(hwnd, outGuid));
 }
 
 //=============================================================================
@@ -837,23 +1104,65 @@ bool IsWindowCloaked(HWND hwnd) {
   return cloaked;
 }
 
-bool IsTileEligible(HWND hwnd, HMONITOR targetMonitor) {
-  if (!IsWindowVisible(hwnd) || IsIconic(hwnd) || !IsWindowEnabled(hwnd)) return false;
-  if (GetAncestor(hwnd, GA_ROOT) != hwnd || GetWindow(hwnd, GW_OWNER)) return false;
+static bool IsWindowTrackedInAnyState(HWND hwnd) {
+  hwnd = NormalizeTrackedWindow(hwnd);
+  if (!hwnd) return false;
+
+  bool tracked = false;
+
+  AcquireSRWLockShared(&g_store.tilingStateLock);
+  for (const auto& kv : g_store.tilingStateMap) {
+    const TilingState& st = kv.second;
+    // Fast membership test (linear, but st.windows is small)
+    if (ContainsWindow(st.windows, hwnd)) {
+      tracked = true;
+      break;
+    }
+  }
+  ReleaseSRWLockShared(&g_store.tilingStateLock);
+
+  return tracked;
+}
+
+static bool CouldBeTileEligible(HWND hwnd) {
+  if (!hwnd) return false;
+  if (IsWindowMarkedUntiled(hwnd)) return false;
+  if (GetAncestor(hwnd, GA_ROOT) != hwnd) return false;
+  if (GetWindow(hwnd, GW_OWNER)) return false;
 
   LONG_PTR style = GetWindowLongPtr(hwnd, GWL_STYLE);
-  if ((style & WS_CHILD) || !(style & WS_SIZEBOX)) return false;
+  if (style & WS_CHILD) return false;
+  if (!(style & WS_SIZEBOX) && !IsWindowTrackedInAnyState(hwnd)) return false;
 
   LONG_PTR exStyle = GetWindowLongPtr(hwnd, GWL_EXSTYLE);
-  if (exStyle & (WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE)) return false;
+  if (exStyle & WS_EX_TOOLWINDOW) return false;
+  if (exStyle & WS_EX_NOACTIVATE) return false;
 
-  if (IsWindowCloaked(hwnd)) return false;
-
-  wchar_t className[64];
-  if (GetClassNameW(hwnd, className, 64)) {
+  wchar_t className[64] = {};
+  if (GetClassNameW(hwnd, className, ARRAYSIZE(className))) {
     for (const auto* ignoredClass : kIgnoredWindowClasses) {
       if (_wcsicmp(className, ignoredClass) == 0) return false;
     }
+  }
+
+  return true;
+}
+
+bool IsTileEligible(HWND hwnd, HMONITOR targetMonitor) {
+  // window might become temporarily disabled
+  // (example: VSCode unstaged commit dialog)
+  if (!IsWindowTrackedInAnyState(hwnd) && !IsWindowEnabled(hwnd)) return false;
+
+  if (!IsWindowVisible(hwnd) || IsIconic(hwnd)) return false;
+  if (!CouldBeTileEligible(hwnd)) return false;
+  if (IsWindowCloaked(hwnd)) return false;
+
+  // Virtual desktop filter: other desktops' windows may not yet be cloaked
+  // at the moment we enumerate (race between uncloak/cloak during switch).
+  if (g_desktopApi.manager) {
+    BOOL onCurrent = FALSE;
+    if (SUCCEEDED(g_desktopApi.manager->IsWindowOnCurrentVirtualDesktop(hwnd, &onCurrent)) && !onCurrent)
+      return false;
   }
 
   RECT frameRect;
@@ -882,10 +1191,178 @@ void PlaceWindow(HWND hwnd, const RECT& targetRect) {
   SetWindowPos(hwnd, nullptr, targetRect.left - offsetLeft, targetRect.top - offsetTop,
                targetRect.right - targetRect.left + offsetLeft + offsetRight,
                targetRect.bottom - targetRect.top + offsetTop + offsetBottom,
-               SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE | SWP_NOSENDCHANGING | SWP_ASYNCWINDOWPOS);
+               SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE | SWP_NOSENDCHANGING); 
 }
 
-void TileWindows() {
+void SwapMaster() {
+  if (g_settings.retileSuspended) return;
+
+  HWND fg = GetForegroundWindow();
+  if (!fg) return;
+
+  DesktopMonitorKey key{};
+  RECT workArea = {};
+  if (!TryGetDesktopMonitorContext(fg, &key, &workArea)) return;
+
+  if (InterlockedCompareExchange(&g_store.retileInProgress, 1, 0) != 0) return;
+
+  bool didSwap = false;
+  HWND oldMaster = nullptr;
+  HWND resolved = nullptr;
+  RECT rMaster{}, rResolved{};
+
+  AcquireSRWLockExclusive(&g_store.tilingStateLock);
+  do {
+    auto it = g_store.tilingStateMap.find(key);
+    if (it == g_store.tilingStateMap.end() || it->second.windows.size() < 2) break;
+
+    TilingState& state = it->second;
+    resolved = ResolveToTiledWindow(fg, state.windows);
+    size_t index = FindWindowIndex(state.windows, resolved);
+    if (index == (size_t)-1 || index == 0) break;
+
+    oldMaster = state.windows[0];
+    if (!GetWindowFrameRect(oldMaster, &rMaster) || !GetWindowFrameRect(resolved, &rResolved)) break;
+
+    std::swap(state.windows[0], state.windows[index]);
+    didSwap = true;
+  } while (false);
+  ReleaseSRWLockExclusive(&g_store.tilingStateLock);
+
+  if (didSwap) {
+    PlaceWindow(oldMaster, rResolved);
+    PlaceWindow(resolved, rMaster);
+    ClearMoveSizeRects(oldMaster);
+    ClearMoveSizeRects(resolved);
+  }
+
+  InterlockedExchange(&g_store.retileInProgress, 0);
+}
+
+// Small helpers for TileWindows()
+static inline long long RectAreaLL(const RECT& r) {
+  long long w = (long long)r.right - (long long)r.left;
+  long long h = (long long)r.bottom - (long long)r.top;
+  if (w <= 0 || h <= 0) return 0;
+  return w * h;
+}
+// Also helper for TileWindows()
+static inline long long WindowAreaOnWorkArea(HWND hwnd, const RECT& workArea) {
+  RECT r{};
+  if (!GetWindowFrameRect(hwnd, &r)) return 0;
+
+  RECT inter{};
+  if (!IntersectRect(&inter, &r, &workArea)) return 0;
+
+  return RectAreaLL(inter);
+}
+
+bool TryGetSavedState(const DesktopMonitorKey& key, TilingState* outState) {
+  AcquireSRWLockShared(&g_store.tilingStateLock);
+  auto it = g_store.tilingStateMap.find(key);
+  bool found = it != g_store.tilingStateMap.end();
+  if (found && outState) {
+    *outState = it->second;
+  }
+  ReleaseSRWLockShared(&g_store.tilingStateLock);
+  return found;
+}
+
+void StoreTilingState(const DesktopMonitorKey& key, const TilingState& state) {
+  AcquireSRWLockExclusive(&g_store.tilingStateLock);
+  g_store.tilingStateMap[key] = state;
+  ReleaseSRWLockExclusive(&g_store.tilingStateLock);
+}
+
+void StoreOrEraseTilingState(const DesktopMonitorKey& key, const TilingState& state) {
+  AcquireSRWLockExclusive(&g_store.tilingStateLock);
+  if (state.windows.size() > 1) {
+    g_store.tilingStateMap[key] = state;
+  } else {
+    g_store.tilingStateMap.erase(key);
+  }
+  ReleaseSRWLockExclusive(&g_store.tilingStateLock);
+}
+
+bool GetTiledWorkArea(HMONITOR monitor, RECT* outRect) {
+  RECT monitorWork = {};
+  if (!outRect || !GetMonitorWorkArea(monitor, &monitorWork)) return false;
+
+  *outRect = {monitorWork.left + g_settings.tileMargin, monitorWork.top + g_settings.tileMargin,
+              monitorWork.right - g_settings.tileMargin, monitorWork.bottom - g_settings.tileMargin};
+  return outRect->right > outRect->left && outRect->bottom > outRect->top;
+}
+
+bool TryGetDesktopMonitorContext(HWND hwnd, DesktopMonitorKey* outKey, RECT* outWorkArea) {
+  if (!hwnd || !outKey || !outWorkArea) return false;
+
+  HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONULL);
+  if (!monitor || !GetTiledWorkArea(monitor, outWorkArea)) return false;
+
+  GUID desktopId = {};
+  if (!GetWindowDesktopIdSafe(hwnd, &desktopId)) return false;
+
+  *outKey = DesktopMonitorKey{desktopId, monitor};
+  return true;
+}
+
+void ClearMoveSizeRects(HWND hwnd) {
+  AcquireSRWLockExclusive(&g_store.moveSizeRectsLock);
+  g_store.moveSizeStartRects.erase(hwnd);
+  g_store.moveSizeEndRects.erase(hwnd);
+  ReleaseSRWLockExclusive(&g_store.moveSizeRectsLock);
+}
+
+bool TakeResizeRects(HWND hwnd, RECT* outStartRect, RECT* outEndRect) {
+  bool haveRects = false;
+
+  AcquireSRWLockExclusive(&g_store.moveSizeRectsLock);
+  auto itStart = g_store.moveSizeStartRects.find(hwnd);
+  auto itEnd = g_store.moveSizeEndRects.find(hwnd);
+
+  if (itStart != g_store.moveSizeStartRects.end() && itEnd != g_store.moveSizeEndRects.end()) {
+    if (outStartRect) *outStartRect = itStart->second;
+    if (outEndRect) *outEndRect = itEnd->second;
+    haveRects = true;
+  }
+
+  if (itStart != g_store.moveSizeStartRects.end()) {
+    g_store.moveSizeStartRects.erase(itStart);
+  }
+  if (itEnd != g_store.moveSizeEndRects.end()) {
+    g_store.moveSizeEndRects.erase(itEnd);
+  }
+  ReleaseSRWLockExclusive(&g_store.moveSizeRectsLock);
+
+  return haveRects;
+}
+
+bool ShouldCaptureLayout(const RECT& workArea, const std::vector<HWND>& windows, bool hasDesktopId) {
+  if (!hasDesktopId) return true;
+
+  const long long workAreaArea = RectAreaLL(workArea);
+  long long sumArea = 0;
+  for (HWND hwnd : windows) {
+    sumArea += WindowAreaOnWorkArea(hwnd, workArea);
+  }
+
+  const long long lo = (workAreaArea * 85) / 100;
+  const long long hi = windows.size() <= 2 ? (workAreaArea * 115) / 100 : (workAreaArea * 105) / 100;
+  return sumArea >= lo && sumArea <= hi;
+}
+
+HMONITOR ResolveTileMonitor(HWND preferredWindow) {
+  if (preferredWindow && IsWindow(preferredWindow)) {
+    RECT rect = {};
+    if (GetWindowFrameRect(preferredWindow, &rect)) {
+      HMONITOR preferredMonitor = MonitorFromRect(&rect, MONITOR_DEFAULTTONULL);
+      if (preferredMonitor) return preferredMonitor;
+    }
+
+    HMONITOR preferredMonitor = MonitorFromWindow(preferredWindow, MONITOR_DEFAULTTONULL);
+    if (preferredMonitor) return preferredMonitor;
+  }
+
   HWND foregroundWindow = GetForegroundWindow();
   HMONITOR monitor = foregroundWindow ? MonitorFromWindow(foregroundWindow, MONITOR_DEFAULTTONULL) : nullptr;
 
@@ -895,415 +1372,599 @@ void TileWindows() {
       monitor = MonitorFromPoint(cursorPos, MONITOR_DEFAULTTONEAREST);
     }
   }
-  if (!monitor) return;
 
-  RECT monitorWork = {};
-  if (!GetMonitorWorkArea(monitor, &monitorWork)) return;
+  return monitor;
+}
 
-  RECT workArea = {monitorWork.left + g_tileMargin, monitorWork.top + g_tileMargin,
-                   monitorWork.right - g_tileMargin, monitorWork.bottom - g_tileMargin};
+void TileWindows(HWND preferredWindow, bool allowWhenSuspended) {
+  if (g_settings.retileSuspended && !allowWhenSuspended) return;
 
-  if (workArea.right <= workArea.left || workArea.bottom <= workArea.top) return;
+  HMONITOR monitor = ResolveTileMonitor(preferredWindow);
+  RECT workArea = {};
+  if (!monitor || !GetTiledWorkArea(monitor, &workArea)) return;
 
   std::vector<HWND> windows = CollectTileWindows(monitor);
   if (windows.empty()) return;
-
-  TileLayout layout = g_currentLayout;
 
   GUID desktopId = {};
   bool hasDesktopId = InitializeVirtualDesktopAPI() && GetCurrentDesktopId(&desktopId);
   DesktopMonitorKey key{desktopId, monitor};
 
-  double masterRatio = ClampDouble(g_masterPercent / 100.0, 0.1, 0.9);
-  std::vector<double> stackWeights;
-  std::vector<double> gridWeights;
+  TilingState state = MakeDefaultState(windows);
+  TilingState savedState;
+  bool hasSavedState = hasDesktopId && TryGetSavedState(key, &savedState);
+  bool canReuseSavedState = hasSavedState && HaveSameWindowSet(savedState.windows, windows);
+  HWND preferredFirstWin = hasSavedState && !savedState.windows.empty() ? savedState.windows.front() : nullptr;
 
-  bool usedCaptured = false;
-  if (g_captureLayoutOnTile) {
-    TilingState capturedState = BuildStateFromWindows(layout, workArea, windows, monitor);
+  if (canReuseSavedState) {
+    state = savedState;
+  } else if (hasSavedState) {
+    // Preserve masterRatio and existing stackWeights when new windows join
+    // Start from savedState and add new windows
+    state = savedState;
+    // Calculate average weight for new windows
+    double avgWeight = 1.0;
+    if (!state.stackWeights.empty()) {
+      double sum = 0.0;
+      for (double w : state.stackWeights) sum += (w > 0.0 ? w : 1.0);
+      avgWeight = sum / state.stackWeights.size();
+    }
+    // Add new windows to the end (they become stack windows with average weight)
+    for (HWND hwnd : windows) {
+      if (!ContainsWindow(state.windows, hwnd)) {
+        state.windows.push_back(hwnd);
+        state.stackWeights.push_back(avgWeight);
+      }
+    }
+    // Remove windows that no longer exist
+    for (size_t i = state.windows.size(); i > 0; --i) {
+      if (!ContainsWindow(windows, state.windows[i - 1])) {
+        state.windows.erase(state.windows.begin() + i - 1);
+        // Remove corresponding stackWeight
+        // For master (i==1): remove first stackWeight since second window becomes new master
+        // For stack window (i>1): remove stackWeights[i-2]
+        if (i == 1 && !state.stackWeights.empty()) {
+          state.stackWeights.erase(state.stackWeights.begin());
+        } else if (i > 1 && i - 2 < state.stackWeights.size()) {
+          state.stackWeights.erase(state.stackWeights.begin() + i - 2);
+        }
+      }
+    }
+    NormalizeState(state);
+  } else if (ShouldCaptureLayout(workArea, windows, hasDesktopId)) {
+    TilingState capturedState = BuildStateFromWindows(workArea, windows, monitor, preferredFirstWin);
     if (!capturedState.windows.empty()) {
-      windows = capturedState.windows;
-      masterRatio = ClampDouble(capturedState.masterRatio, 0.1, 0.9);
-      stackWeights = capturedState.stackWeights;
-      gridWeights = capturedState.gridWeights;
-      usedCaptured = true;
+      state = std::move(capturedState);
     }
   }
 
-  if (!usedCaptured && hasDesktopId) {
-    AcquireSRWLockShared(&g_tilingStateLock);
-    auto it = g_tilingStateMap.find(key);
-    if (it != g_tilingStateMap.end() && it->second.layout == layout && AreSameWindows(it->second.windows, windows)) {
-      masterRatio = ClampDouble(it->second.masterRatio, 0.1, 0.9);
-      stackWeights = it->second.stackWeights;
-      gridWeights = it->second.gridWeights;
-    }
-    ReleaseSRWLockShared(&g_tilingStateLock);
-  }
-
-  std::vector<RECT> windowRects(windows.size());
-  switch (layout) {
-    case TileLayout::MasterStack:
-      LayoutMasterStackWeighted(workArea, windows.size(), windowRects, false, masterRatio, stackWeights);
-      break;
-    case TileLayout::MasterStackH:
-      LayoutMasterStackWeighted(workArea, windows.size(), windowRects, true, masterRatio, stackWeights);
-      break;
-    case TileLayout::Columns:
-      if (gridWeights.size() != windows.size()) gridWeights = DefaultWeights(windows.size());
-      LayoutGridWeighted(workArea, windows.size(), windowRects, false, gridWeights);
-      break;
-    case TileLayout::Rows:
-      if (gridWeights.size() != windows.size()) gridWeights = DefaultWeights(windows.size());
-      LayoutGridWeighted(workArea, windows.size(), windowRects, true, gridWeights);
-      break;
-    case TileLayout::BSP:
-      LayoutBSP(workArea, 0, windows.size(), 0, windowRects);
-      break;
-    case TileLayout::Monocle:
-      windowRects.assign(windows.size(), workArea);
-      break;
-    default:
-      break;
-  }
-
-  for (size_t i = 0; i < windows.size(); ++i) {
-    PlaceWindow(windows[i], windowRects[i]);
-  }
-
-  if (hasDesktopId) {
-    TilingState state;
-    state.layout = layout;
-    state.windows = windows;
-    state.masterRatio = masterRatio;
-    if (layout == TileLayout::MasterStack || layout == TileLayout::MasterStackH) {
-      if (stackWeights.size() != windows.size() - 1) stackWeights = DefaultWeights(windows.size() - 1);
-      state.stackWeights = stackWeights;
-      state.gridWeights.clear();
-    } else if (layout == TileLayout::Columns || layout == TileLayout::Rows) {
-      if (gridWeights.size() != windows.size()) gridWeights = DefaultWeights(windows.size());
-      state.gridWeights = gridWeights;
-      state.stackWeights.clear();
-    } else {
-      state.stackWeights.clear();
-      state.gridWeights.clear();
-    }
-
-    AcquireSRWLockExclusive(&g_tilingStateLock);
-    g_tilingStateMap[key] = std::move(state);
-    ReleaseSRWLockExclusive(&g_tilingStateLock);
-  }
-
-  Wh_Log(L"Tiled %zu windows with layout %d", windows.size(), static_cast<int>(layout));
-}
-
-void RetileFromResize(HWND hwnd) {
-  if (!g_enableTiling || !IsWindow(hwnd)) {
-    return;
-  }
-
-  HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONULL);
-  RECT monitorWork = {};
-  if (!monitor || !GetMonitorWorkArea(monitor, &monitorWork)) {
-    return;
-  }
-
-  GUID desktopId = {};
-  bool hasDesktopId = GetWindowDesktopIdSafe(hwnd, &desktopId);
-  if (!hasDesktopId) {
-    return;
-  }
-
-  DesktopMonitorKey key{desktopId, monitor};
-  TilingState state;
-  bool hasState = false;
-
-  AcquireSRWLockShared(&g_tilingStateLock);
-  auto it = g_tilingStateMap.find(key);
-  if (it != g_tilingStateMap.end()) {
-    state = it->second;
-    hasState = true;
-  }
-  ReleaseSRWLockShared(&g_tilingStateLock);
-
-  RECT workArea = {monitorWork.left + g_tileMargin, monitorWork.top + g_tileMargin,
-                   monitorWork.right - g_tileMargin, monitorWork.bottom - g_tileMargin};
-
-  if (workArea.right <= workArea.left || workArea.bottom <= workArea.top) {
-    return;
-  }
-
-  HWND resizedHwnd = hwnd;
-
-  if (hasState) {
-    if (!ContainsWindow(state.windows, resizedHwnd)) {
-      HWND resolved = ResolveToTiledWindow(resizedHwnd, state.windows);
-      if (resolved) {
-        resizedHwnd = resolved;
-      } else {
-        return;
-      }
-    }
-  } else {
-    std::vector<HWND> windows = CollectTileWindows(monitor);
-    if (windows.empty()) {
-      return;
-    }
-    if (!ContainsWindow(windows, resizedHwnd)) {
-      HWND resolved = ResolveToTiledWindow(resizedHwnd, windows);
-      if (resolved) {
-        resizedHwnd = resolved;
-      } else {
-        return;
-      }
-    }
-
-    TileLayout layout = g_currentLayout;
-    state = BuildStateFromWindows(layout, workArea, windows, monitor);
-    state.layout = layout;
-    hasState = true;
-  }
-
-  if (state.windows.empty()) {
-    return;
-  }
-
-  for (HWND w : state.windows) {
-    RECT rect = {};
-    if (!GetWindowFrameRect(w, &rect)) {
-      TileWindows();
-      return;
-    }
-    if (MonitorFromRect(&rect, MONITOR_DEFAULTTONULL) != monitor) {
-      TileWindows();
-      return;
-    }
-  }
-
-  std::vector<RECT> windowRects(state.windows.size());
-  if (state.layout == TileLayout::MasterStack || state.layout == TileLayout::MasterStackH) {
-    bool horizontal = (state.layout == TileLayout::MasterStackH);
-    LONG totalSize = horizontal ? (workArea.bottom - workArea.top) : (workArea.right - workArea.left);
-    if (totalSize <= g_tileGap + 1) {
-      return;
-    }
-
-    size_t resizedIndex = 0;
-    for (size_t i = 0; i < state.windows.size(); ++i) {
-      if (state.windows[i] == resizedHwnd) {
-        resizedIndex = i;
-        break;
-      }
-    }
-
-    RECT resizedRect = {};
-    if (!GetWindowFrameRect(resizedHwnd, &resizedRect)) {
-      return;
-    }
-
-    LONG resizedSize = horizontal ? (resizedRect.bottom - resizedRect.top) : (resizedRect.right - resizedRect.left);
-    if (resizedSize < 1) resizedSize = 1;
-
-    LONG masterSize = resizedSize;
-    if (resizedIndex != 0) {
-      LONG candidateSize = horizontal ? (resizedRect.top - workArea.top - g_tileGap)
-                                      : (resizedRect.left - workArea.left - g_tileGap);
-      LONG maxMaster = totalSize - g_tileGap - 1;
-      if (candidateSize >= 1 && candidateSize <= maxMaster) {
-        masterSize = candidateSize;
-      } else {
-        RECT masterRect = {};
-        if (!GetWindowFrameRect(state.windows[0], &masterRect)) {
-          return;
-        }
-        masterSize = horizontal ? (masterRect.bottom - masterRect.top) : (masterRect.right - masterRect.left);
-        if (masterSize < 1) masterSize = 1;
-      }
-    }
-
-    state.masterRatio = ClampDouble((double)masterSize / (double)(totalSize - g_tileGap), 0.1, 0.9);
-
-    RECT masterRect = workArea;
-    if (horizontal) {
-      masterRect.bottom = masterRect.top + masterSize;
-      if (masterRect.bottom > workArea.bottom - g_tileGap) {
-        masterRect.bottom = workArea.bottom - g_tileGap;
-      }
-    } else {
-      masterRect.right = masterRect.left + masterSize;
-      if (masterRect.right > workArea.right - g_tileGap) {
-        masterRect.right = workArea.right - g_tileGap;
-      }
-    }
-
-    RECT stackArea = workArea;
-    if (horizontal) {
-      stackArea.top = masterRect.bottom + g_tileGap;
-    } else {
-      stackArea.left = masterRect.right + g_tileGap;
-    }
-
-    size_t stackCount = state.windows.size() - 1;
-    state.stackWeights.clear();
-    state.stackWeights.reserve(stackCount);
-    for (size_t i = 1; i < state.windows.size(); ++i) {
-      RECT rect = {};
-      if (!GetWindowFrameRect(state.windows[i], &rect)) {
-        state.stackWeights.push_back(1.0);
-        continue;
-      }
-      LONG size = horizontal ? (rect.right - rect.left) : (rect.bottom - rect.top);
-      if (size < 1) size = 1;
-      state.stackWeights.push_back(static_cast<double>(size));
-    }
-
-    std::vector<LONG> stackSizes;
-    if (stackCount > 0) {
-      size_t fixedIndex = (resizedIndex == 0) ? (size_t)-1 : (resizedIndex - 1);
-      if (fixedIndex != (size_t)-1) {
-        LONG fixedSize = horizontal ? (resizedRect.right - resizedRect.left) : (resizedRect.bottom - resizedRect.top);
-        if (fixedSize < 1) fixedSize = 1;
-        LONG stackTotal = horizontal ? (stackArea.right - stackArea.left) : (stackArea.bottom - stackArea.top);
-        stackSizes = ComputeWeightedSizesWithFixed(stackTotal, g_tileGap, state.stackWeights, fixedIndex, fixedSize);
-      } else {
-        LONG stackTotal = horizontal ? (stackArea.right - stackArea.left) : (stackArea.bottom - stackArea.top);
-        stackSizes = ComputeWeightedSizes(stackTotal, g_tileGap, state.stackWeights);
-      }
-    }
-
-    windowRects[0] = masterRect;
-    if (stackCount > 0) {
-      if (horizontal) {
-        LONG x = stackArea.left;
-        for (size_t i = 0; i < stackCount; ++i) {
-          LONG end = (i == stackCount - 1) ? stackArea.right : x + stackSizes[i];
-          windowRects[i + 1] = {x, stackArea.top, end, stackArea.bottom};
-          x = end + g_tileGap;
-        }
-      } else {
-        LONG y = stackArea.top;
-        for (size_t i = 0; i < stackCount; ++i) {
-          LONG end = (i == stackCount - 1) ? stackArea.bottom : y + stackSizes[i];
-          windowRects[i + 1] = {stackArea.left, y, stackArea.right, end};
-          y = end + g_tileGap;
-        }
-      }
-    }
-  } else if (state.layout == TileLayout::Columns || state.layout == TileLayout::Rows) {
-    bool horizontal = (state.layout == TileLayout::Rows);
-
-    struct OrderedWindow {
-      HWND hwnd;
-      RECT rect;
-    };
-
-    std::vector<OrderedWindow> ordered;
-    ordered.reserve(state.windows.size());
-    for (HWND w : state.windows) {
-      RECT rect = {};
-      if (!GetWindowFrameRect(w, &rect)) {
-        rect = workArea;
-      }
-      ordered.push_back({w, rect});
-    }
-
-    std::sort(ordered.begin(), ordered.end(), [horizontal](const OrderedWindow& a, const OrderedWindow& b) {
-      return horizontal ? (a.rect.top < b.rect.top) : (a.rect.left < b.rect.left);
-    });
-
-    size_t resizedIndex = 0;
-    for (size_t i = 0; i < ordered.size(); ++i) {
-      if (ordered[i].hwnd == hwnd) {
-        resizedIndex = i;
-        break;
-      }
-    }
-
-    state.gridWeights.clear();
-    for (const auto& item : ordered) {
-      LONG size = horizontal ? (item.rect.bottom - item.rect.top) : (item.rect.right - item.rect.left);
-      if (size < 1) size = 1;
-      state.gridWeights.push_back(static_cast<double>(size));
-    }
-
-    LONG totalSize = horizontal ? (workArea.bottom - workArea.top) : (workArea.right - workArea.left);
-    LONG fixedSize = horizontal ? (ordered[resizedIndex].rect.bottom - ordered[resizedIndex].rect.top)
-                                : (ordered[resizedIndex].rect.right - ordered[resizedIndex].rect.left);
-    if (fixedSize < 1) fixedSize = 1;
-
-    std::vector<LONG> sizes =
-        ComputeWeightedSizesWithFixed(totalSize, g_tileGap, state.gridWeights, resizedIndex, fixedSize);
-
-    LONG position = horizontal ? workArea.top : workArea.left;
-    for (size_t i = 0; i < ordered.size(); ++i) {
-      LONG end = (i == ordered.size() - 1) ? (horizontal ? workArea.bottom : workArea.right) : position + sizes[i];
-      RECT rect = horizontal ? RECT{workArea.left, position, workArea.right, end}
-                             : RECT{position, workArea.top, end, workArea.bottom};
-      windowRects[i] = rect;
-      position = end + g_tileGap;
-    }
-
-    std::vector<HWND> newOrder;
-    newOrder.reserve(ordered.size());
-    for (const auto& item : ordered) newOrder.push_back(item.hwnd);
-    state.windows = std::move(newOrder);
-  } else if (state.layout == TileLayout::BSP) {
-    LayoutBSP(workArea, 0, state.windows.size(), 0, windowRects);
-  } else if (state.layout == TileLayout::Monocle) {
-    windowRects.assign(state.windows.size(), workArea);
-  }
-
+  std::vector<RECT> windowRects;
+  LayoutStateRects(workArea, state, windowRects);
   for (size_t i = 0; i < state.windows.size(); ++i) {
     PlaceWindow(state.windows[i], windowRects[i]);
   }
 
-  AcquireSRWLockExclusive(&g_tilingStateLock);
-  g_tilingStateMap[key] = state;
-  ReleaseSRWLockExclusive(&g_tilingStateLock);
+  if (hasDesktopId) {
+    StoreOrEraseTilingState(key, state);
+  }
+
+  Wh_Log(L"Tiled %zu windows", state.windows.size());
+}
+
+// Helper for window destroy handling
+static HWND PruneDestroyedAndPickAnchor(HWND deadHwnd) {
+  HWND fg = GetForegroundWindow();
+  HWND anchor = nullptr;
+
+  ClearMoveSizeRects(deadHwnd);
+
+  // Get current desktopID
+  GUID curDesk{};
+  bool haveDesk = false;
+  if (fg && IsWindow(fg)) {
+    haveDesk = GetWindowDesktopIdSafe(fg, &curDesk);   // foreground's desktop
+  }
+  if (!haveDesk) {
+    haveDesk = InitializeVirtualDesktopAPI() && GetCurrentDesktopId(&curDesk);  // fallback
+  }
+  if (!haveDesk) return nullptr; // Don't pick a fallback at all if getdesktop fails
+
+  HMONITOR curMon = fg ? MonitorFromWindow(fg, MONITOR_DEFAULTTONULL) : nullptr;
+  if (!curMon) {
+    POINT p{};
+    if (!GetCursorPos(&p)) p = POINT{0, 0};
+    curMon = MonitorFromPoint(p, MONITOR_DEFAULTTONEAREST);
+  }
+
+  AcquireSRWLockExclusive(&g_store.tilingStateLock);
+
+  for (auto it = g_store.tilingStateMap.begin(); it != g_store.tilingStateMap.end(); ) {
+    const DesktopMonitorKey key = it->first;
+    TilingState& st = it->second;
+
+    // Erase dead hwnd & empty state
+    // also marks whether current state has been touched or not (affected)
+    size_t before = st.windows.size();
+    st.windows.erase(std::remove(st.windows.begin(), st.windows.end(), deadHwnd), st.windows.end());
+    bool affected = (st.windows.size() != before);
+
+    if (st.windows.empty()) {
+      it = g_store.tilingStateMap.erase(it);
+      continue;
+    }
+    // ignoring last window (st.windows() = 1) case here
+    // so that RetileOnResize() can pick up the erase + placement job later...
+
+    // Pick anchor once: prefer foreground if it maps into this state's windows
+    // otherwise: pick first entry in st.window with the same "monitor % desktopID" pair as fg
+    bool keyMatches = (IsEqualGUID(key.desktopId, curDesk)) &&
+                      (key.monitor == curMon);
+
+    if (!anchor && keyMatches && affected) {
+      if (fg && IsWindow(fg)) {
+        HWND resolved = ResolveToTiledWindow(fg, st.windows);
+        if (resolved && IsWindow(resolved)) anchor = resolved;
+      }
+      if (!anchor) {
+        for (HWND w : st.windows) {
+          if (w && IsWindow(w) && !IsIconic(w)) { anchor = w; break; }
+        }
+      }
+      // If all windows are minimized (rare-case): 
+      // skip minimiization check to at least return an anchor
+      if (!anchor) {
+        for (HWND w : st.windows) {
+          if (w && IsWindow(w)) { anchor = w; break; }
+        }
+      }
+  }
+
+    ++it;
+  }
+
+  ReleaseSRWLockExclusive(&g_store.tilingStateLock);
+  return anchor;
+}
+
+// Helper for HandleTrivialState()
+static void EraseState(const DesktopMonitorKey & key){
+  AcquireSRWLockExclusive(&g_store.tilingStateLock);
+  g_store.tilingStateMap.erase(key);
+  ReleaseSRWLockExclusive(&g_store.tilingStateLock);
+}
+
+// true: handled "<=1 windows in TilingState" case; false otherwise
+// returns "true": caller should (probably) also return
+static bool HandleTrivialState(const DesktopMonitorKey & key, TilingState & state, const RECT & workArea){
+  if (state.windows.empty()){
+    EraseState(key);
+    return true;
+  }
+
+  else if (state.windows.size() == 1){
+    PlaceWindow(state.windows[0], workArea);
+    EraseState(key);
+    return true;
+  }
+
+  return false;
+}
+
+static void LayoutMasterStackFromResize(const RECT& workArea, HWND resizedHwnd, bool haveResizeRects,
+                                        const RECT& resizeStartRect, const RECT& resizeEndRect,
+                                        TilingState& state, std::vector<RECT>& windowRects) {
+  constexpr LONG kMinRetileSpan = 80;
+  Axis masterAxis = g_settings.masterAxis;
+  Axis stackAxis = OrthogonalAxis(masterAxis);
+  LONG totalSize = AxisSpan(workArea, masterAxis);
+  if (totalSize <= g_settings.tileGap + 1) return;
+
+  size_t resizedIndex = FindWindowIndex(state.windows, resizedHwnd);
+  if (resizedIndex == (size_t)-1) return;
+
+  RECT resizedRect = {};
+  if (!GetWindowFrameRect(resizedHwnd, &resizedRect)) return;
+
+  LONG masterSize = std::max<LONG>(AxisSpan(resizedRect, masterAxis), kMinRetileSpan);
+  if (resizedIndex != 0) {
+    LONG candidateSize = AxisStart(resizedRect, masterAxis) - AxisStart(workArea, masterAxis) - g_settings.tileGap;
+    LONG maxMaster = totalSize - g_settings.tileGap - 1;
+    if (candidateSize >= 1 && candidateSize <= maxMaster) {
+      masterSize = candidateSize;
+    } else {
+      RECT currentMasterRect = {};
+      if (!GetWindowFrameRect(state.windows[0], &currentMasterRect)) return;
+      masterSize = std::max<LONG>(AxisSpan(currentMasterRect, masterAxis), kMinRetileSpan);
+    }
+  }
+
+  state.masterRatio = ClampDouble((double)masterSize / (double)(totalSize - g_settings.tileGap), 0.1, 0.9);
+
+  LONG masterStart = AxisStart(workArea, masterAxis);
+  LONG masterEnd = std::min<LONG>(masterStart + masterSize, AxisEnd(workArea, masterAxis) - g_settings.tileGap);
+  RECT masterRect = ReplaceAxisRange(workArea, masterAxis, masterStart, masterEnd);
+  RECT stackArea = ReplaceAxisRange(workArea, masterAxis, masterEnd + g_settings.tileGap, AxisEnd(workArea, masterAxis));
+
+  size_t stackCount = state.windows.size() - 1;
+  std::vector<LONG> measuredStackSizes;
+  measuredStackSizes.reserve(stackCount);
+  state.stackWeights.clear();
+  state.stackWeights.reserve(stackCount);
+
+  for (size_t i = 1; i < state.windows.size(); ++i) {
+    RECT rect = {};
+    if (!GetWindowFrameRect(state.windows[i], &rect)) {
+      measuredStackSizes.push_back(1);
+      state.stackWeights.push_back(1.0);
+      continue;
+    }
+
+    LONG size = ClampSpanMin1(AxisSpan(rect, stackAxis));
+    measuredStackSizes.push_back(size);
+    state.stackWeights.push_back((double)size);
+  }
+
+  std::vector<LONG> stackSizes;
+  if (stackCount > 0) {
+    size_t fixedIndex = resizedIndex == 0 ? (size_t)-1 : resizedIndex - 1;
+    LONG stackTotal = AxisSpan(stackArea, stackAxis);
+    if (fixedIndex != (size_t)-1) {
+      LONG fixedSize = std::max<LONG>(AxisSpan(resizedRect, stackAxis), kMinRetileSpan);
+
+      bool preserveBeforeFixed = false;
+      bool preserveAfterFixed = false;
+      if (haveResizeRects) {
+        LONG beforeStart = AxisStart(resizeStartRect, stackAxis);
+        LONG beforeEnd = AxisEnd(resizeStartRect, stackAxis);
+        LONG afterStart = AxisStart(resizeEndRect, stackAxis);
+        LONG afterEnd = AxisEnd(resizeEndRect, stackAxis);
+        bool startChanged = Differs(beforeStart, afterStart, 1);
+        bool endChanged = Differs(beforeEnd, afterEnd, 1);
+
+        preserveBeforeFixed = !startChanged && endChanged && fixedIndex > 0;
+        preserveAfterFixed = startChanged && !endChanged && fixedIndex + 1 < stackCount;
+      }
+
+      stackSizes = (preserveBeforeFixed || preserveAfterFixed)
+                       ? ComputeWeightedSizesWithFixedAnchored(stackTotal, g_settings.tileGap, state.stackWeights,
+                                                              measuredStackSizes, fixedIndex, fixedSize,
+                                                              preserveBeforeFixed, preserveAfterFixed)
+                       : ComputeWeightedSizesWithFixed(stackTotal, g_settings.tileGap, state.stackWeights, fixedIndex, fixedSize);
+    } else {
+      stackSizes = ComputeWeightedSizes(stackTotal, g_settings.tileGap, state.stackWeights);
+    }
+  }
+
+  windowRects.assign(state.windows.size(), workArea);
+  windowRects[0] = masterRect;
+  if (stackCount > 0) {
+    std::vector<RECT> stackRects;
+    LayoutStripFromSizes(stackArea, stackAxis, stackSizes, stackRects);
+    for (size_t i = 0; i < stackRects.size(); ++i) {
+      windowRects[i + 1] = stackRects[i];
+    }
+  }
+}
+
+struct RetileContext {
+  DesktopMonitorKey key{};
+  RECT workArea{};
+  TilingState state;
+  HWND resizedHwnd = nullptr;
+  RECT resizeStartRect{};
+  RECT resizeEndRect{};
+  bool haveResizeRects = false;
+  bool dragUntiledWindow = false;
+};
+
+bool StopIfTrivialState(RetileContext* context) {
+  return HandleTrivialState(context->key, context->state, context->workArea);
+}
+
+void RemoveWindowFromState(TilingState* state, HWND hwnd) {
+  state->windows.erase(std::remove(state->windows.begin(), state->windows.end(), hwnd), state->windows.end());
+}
+
+void RetargetResizedWindow(RetileContext* context) {
+  if (context->state.windows.empty() || ContainsWindow(context->state.windows, context->resizedHwnd)) return;
+  context->resizedHwnd = context->state.windows.front();
+  context->state.stackWeights.clear();
+}
+
+bool TryBuildRetileContext(HWND hwnd, RetileContext* outContext) {
+  if (!outContext || g_settings.retileSuspended || !IsWindow(hwnd)) return false;
+
+  hwnd = NormalizeTrackedWindow(hwnd);
+  if (!hwnd) return false;
+
+  RetileContext context;
+  if (!TryGetDesktopMonitorContext(hwnd, &context.key, &context.workArea)) return false;
+  if (!TryGetSavedState(context.key, &context.state)) {
+    Wh_Log(L"Tiling not set up for current desktop");
+    return false;
+  }
+
+  context.resizedHwnd = hwnd;
+  if (!ContainsWindow(context.state.windows, context.resizedHwnd)) {
+    Wh_Log(L"Resized window not part of current tiling state");
+    return false;
+  }
+
+  *outContext = std::move(context);
+  return true;
+}
+
+bool PrepareRetileContext(RetileContext* context) {
+  RemoveUntiledWindows(context->state.windows);
+  return !StopIfTrivialState(context);
+}
+
+bool ConsumeResizeOutcome(RetileContext* context) {
+  context->haveResizeRects = TakeResizeRects(context->resizedHwnd, &context->resizeStartRect, &context->resizeEndRect);
+  if (!context->haveResizeRects || !IsMoveOnlyRectChange(context->resizeStartRect, context->resizeEndRect)) {
+    return true;
+  }
+
+  context->dragUntiledWindow = true;
+  MarkWindowUntiled(context->resizedHwnd);
+  RemoveWindowFromState(&context->state, context->resizedHwnd);
+  if (StopIfTrivialState(context)) return false;
+
+  RetargetResizedWindow(context);
+  StoreTilingState(context->key, context->state);
+  return true;
+}
+
+void RemoveStaleStateWindows(TilingState* state) {
+  state->windows.erase(std::remove_if(state->windows.begin(), state->windows.end(), [&](HWND hwnd) {
+                        RECT rect = {};
+                        return !IsWindow(hwnd) || !GetWindowFrameRect(hwnd, &rect);
+                      }),
+                      state->windows.end());
+}
+
+bool PruneRetileState(RetileContext* context) {
+  RemoveStaleStateWindows(&context->state);
+  RemoveUntiledWindows(context->state.windows);
+  if (StopIfTrivialState(context)) return false;
+
+  RetargetResizedWindow(context);
+  for (auto it = context->state.windows.begin(); it != context->state.windows.end();) {
+    HWND window = *it;
+    RECT rect = {};
+    if (!GetWindowFrameRect(window, &rect)) {
+      it = context->state.windows.erase(it);
+      if (StopIfTrivialState(context)) return false;
+      RetargetResizedWindow(context);
+      continue;
+    }
+
+    if (MonitorFromRect(&rect, MONITOR_DEFAULTTONULL) == context->key.monitor) {
+      ++it;
+      continue;
+    }
+
+    if (!IsIconic(window)) {
+      Wh_Log(L"Window not on monitor && not minimized; retile as fallback");
+      TileWindows(nullptr, false);
+      return false;
+    }
+
+    it = context->state.windows.erase(it);
+    if (StopIfTrivialState(context)) return false;
+    RetargetResizedWindow(context);
+  }
+
+  return true;
+}
+
+bool ApplyRetileContext(RetileContext* context) {
+  std::vector<RECT> windowRects;
+  LayoutMasterStackFromResize(context->workArea, context->resizedHwnd, context->haveResizeRects,
+                              context->resizeStartRect, context->resizeEndRect, context->state, windowRects);
+  if (windowRects.size() != context->state.windows.size()) return false;
+
+  for (size_t i = 0; i < context->state.windows.size(); ++i) {
+    PlaceWindow(context->state.windows[i], windowRects[i]);
+  }
+
+  StoreTilingState(context->key, context->state);
+  return true;
+}
+
+void RetileFromResize(HWND hwnd) {
+  RetileContext context;
+  if (!TryBuildRetileContext(hwnd, &context)) return;
+  if (!PrepareRetileContext(&context)) return;
+  if (!ConsumeResizeOutcome(&context)) return;
+  if (!g_settings.enableResizeRetile && !context.dragUntiledWindow) return;
+  if (!PruneRetileState(&context)) return;
+  ApplyRetileContext(&context);
 }
 
 void OnWindowResizeEnd(HWND hwnd) {
-  if (!g_enableTiling || !g_enableResizeRetile || g_retileSuspended || !IsWindow(hwnd)) return;
-  if (InterlockedCompareExchange(&g_retileInProgress, 1, 0) != 0) {
+  if (g_settings.retileSuspended || !IsWindow(hwnd)) return;
+  if (InterlockedCompareExchange(&g_store.retileInProgress, 1, 0) != 0) {
     return;
   }
 
-  if (!g_threadId) {
-    InterlockedExchange(&g_retileInProgress, 0);
+  if (!g_hotkeyThread.threadId) {
+    InterlockedExchange(&g_store.retileInProgress, 0);
     return;
   }
 
-  if (!PostThreadMessage(g_threadId, WM_APP + 1, reinterpret_cast<WPARAM>(hwnd), 0)) {
-    InterlockedExchange(&g_retileInProgress, 0);
+  if (!PostThreadMessage(g_hotkeyThread.threadId, WM_APP_RETILE, reinterpret_cast<WPARAM>(hwnd), 0)) {
+    InterlockedExchange(&g_store.retileInProgress, 0);
   }
+}
+
+static void RequestTileWindows(HWND triggerHwnd) {
+  if (g_settings.retileSuspended) return;
+  if (!g_hotkeyThread.threadId) return;
+
+  PostThreadMessage(g_hotkeyThread.threadId, WM_APP_TILE, reinterpret_cast<WPARAM>(triggerHwnd), 0);
+}
+
+static void RequestPruneDestroyed(HWND dead) {
+  if (g_settings.retileSuspended) return;
+  if (!dead) return;
+  if (!g_hotkeyThread.threadId) return;
+  if (InterlockedCompareExchange(&g_store.retileInProgress, 1, 0) != 0) return;
+
+  if (!PostThreadMessage(g_hotkeyThread.threadId, WM_APP_PRUNE_DESTROY, (WPARAM)dead, 0)) {
+    InterlockedExchange(&g_store.retileInProgress, 0);   
+  }
+}
+
+struct WindowEventContext {
+  DWORD event = 0;
+  HWND hwnd = nullptr;
+  HWND trackedHwnd = nullptr;
+  HWND candidateHwnd = nullptr;
+  bool tracked = false;
+};
+
+bool IsHandledWindowEvent(DWORD event) {
+  switch (event) {
+    case EVENT_SYSTEM_MOVESIZESTART:
+    case EVENT_SYSTEM_MOVESIZEEND:
+    case EVENT_SYSTEM_MINIMIZESTART:
+    case EVENT_SYSTEM_MINIMIZEEND:
+    case EVENT_OBJECT_DESTROY:
+    case EVENT_OBJECT_SHOW:
+    case EVENT_OBJECT_HIDE:
+    case EVENT_OBJECT_UNCLOAKED:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool TryBuildWindowEventContext(DWORD event, HWND hwnd, LONG idObject, LONG idChild, WindowEventContext* outContext) {
+  if (!outContext || !IsHandledWindowEvent(event)) return false;
+  if (!hwnd || idObject != OBJID_WINDOW || idChild != CHILDID_SELF) return false;
+
+  outContext->event = event;
+  outContext->hwnd = hwnd;
+  outContext->trackedHwnd = NormalizeTrackedWindow(hwnd);
+  outContext->candidateHwnd = outContext->trackedHwnd ? outContext->trackedHwnd : hwnd;
+  outContext->tracked = outContext->trackedHwnd && IsWindowTrackedInAnyState(outContext->trackedHwnd);
+  return true;
+}
+
+void CacheMoveSizeRect(HWND hwnd, bool isStartRect) {
+  AcquireSRWLockExclusive(&g_store.moveSizeRectsLock);
+  RECT rect = {};
+  if (GetWindowFrameRect(hwnd, &rect)) {
+    if (isStartRect) {
+      g_store.moveSizeStartRects[hwnd] = rect;
+    } else {
+      g_store.moveSizeEndRects[hwnd] = rect;
+    }
+  }
+  ReleaseSRWLockExclusive(&g_store.moveSizeRectsLock);
+}
+
+bool HandleMoveSizeEvent(const WindowEventContext& context) {
+  if (context.event != EVENT_SYSTEM_MOVESIZESTART && context.event != EVENT_SYSTEM_MOVESIZEEND) return false;
+  if (!context.trackedHwnd || !context.tracked) return true;
+
+  CacheMoveSizeRect(context.trackedHwnd, context.event == EVENT_SYSTEM_MOVESIZESTART);
+  if (context.event == EVENT_SYSTEM_MOVESIZEEND) {
+    OnWindowResizeEnd(context.trackedHwnd);
+  }
+  return true;
+}
+
+bool HandleMinimizeStartEvent(const WindowEventContext& context) {
+  if (context.event != EVENT_SYSTEM_MINIMIZESTART) return false;
+
+  ClearWindowUntiled(context.hwnd);
+  if (context.trackedHwnd && context.tracked && IsIconic(context.trackedHwnd)) {
+    OnWindowResizeEnd(context.trackedHwnd);
+  }
+  return true;
+}
+
+bool HandleDestroyOrHideEvent(const WindowEventContext& context) {
+  if (context.event != EVENT_OBJECT_DESTROY && context.event != EVENT_OBJECT_HIDE) return false;
+
+  if (context.event == EVENT_OBJECT_DESTROY) {
+    ClearWindowUntiled(context.hwnd);
+  }
+  if (context.tracked) {
+    RequestPruneDestroyed(context.hwnd);
+  }
+  return true;
+}
+
+bool ShouldTileCandidateWindow(const WindowEventContext& context) {
+  return g_settings.enableTileNewWin && !context.tracked && CouldBeTileEligible(context.candidateHwnd);
+}
+
+bool HandleTileNewWindowEvent(const WindowEventContext& context) {
+  if (context.event == EVENT_SYSTEM_MINIMIZEEND) {
+    if (ShouldTileCandidateWindow(context)) {
+      RequestTileWindows(context.candidateHwnd);
+    }
+    return true;
+  }
+
+  if (context.event != EVENT_OBJECT_SHOW && context.event != EVENT_OBJECT_UNCLOAKED) {
+    return false;
+  }
+
+  if (ShouldTileCandidateWindow(context)) {
+    RequestTileWindows(context.candidateHwnd);
+  }
+  return true;
 }
 
 void CALLBACK WinEventProc(HWINEVENTHOOK, DWORD event, HWND hwnd, LONG idObject, LONG idChild, DWORD, DWORD) {
-  if (event != EVENT_SYSTEM_MOVESIZEEND) return;
-  if (idObject != OBJID_WINDOW || idChild != CHILDID_SELF) return;
-  if (!hwnd) return;
-  OnWindowResizeEnd(hwnd);
+  WindowEventContext context;
+  if (!TryBuildWindowEventContext(event, hwnd, idObject, idChild, &context)) return;
+  if (HandleMoveSizeEvent(context)) return;
+  if (HandleMinimizeStartEvent(context)) return;
+  if (HandleDestroyOrHideEvent(context)) return;
+  HandleTileNewWindowEvent(context);
 }
 
-void InstallMoveSizeHook() {
-  if (g_hMoveSizeHook) return;
-  g_hMoveSizeHook = SetWinEventHook(EVENT_SYSTEM_MOVESIZEEND, EVENT_SYSTEM_MOVESIZEEND, nullptr, WinEventProc, 0, 0,
-                                   WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
-  if (!g_hMoveSizeHook) {
-    Wh_Log(L"Failed to install move/size hook");
-  }
+void InstallWinEventHookRange(HWINEVENTHOOK* hook, DWORD eventMin, DWORD eventMax, PCWSTR errorMessage) {
+  if (*hook) return;
+
+  *hook = SetWinEventHook(eventMin, eventMax, nullptr, WinEventProc, 0, 0,
+                          WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
+  if (!*hook) Wh_Log(L"%s", errorMessage);
 }
 
-void RemoveMoveSizeHook() {
-  if (!g_hMoveSizeHook) return;
-  UnhookWinEvent(g_hMoveSizeHook);
-  g_hMoveSizeHook = nullptr;
+void RemoveWinEventHookIfNeeded(HWINEVENTHOOK* hook) {
+  if (!*hook) return;
+  UnhookWinEvent(*hook);
+  *hook = nullptr;
+}
+
+void InstallWinEventHooks() {
+  InstallWinEventHookRange(&g_hooks.moveSizeHook, EVENT_SYSTEM_MOVESIZESTART, EVENT_SYSTEM_MOVESIZEEND,
+                           L"Failed to install move/size hook");
+  InstallWinEventHookRange(&g_hooks.minimizeHook, EVENT_SYSTEM_MINIMIZESTART, EVENT_SYSTEM_MINIMIZEEND,
+                           L"Failed to install minimization hook");
+  InstallWinEventHookRange(&g_hooks.hideDestroyHook, EVENT_OBJECT_DESTROY, EVENT_OBJECT_HIDE,
+                           L"Failed to install hide/destroy hook");
+  InstallWinEventHookRange(&g_hooks.cloakHook, EVENT_OBJECT_UNCLOAKED, EVENT_OBJECT_UNCLOAKED,
+                           L"Failed to install uncloak hook");
+}
+
+void RemoveWinEventHooks() {
+  RemoveWinEventHookIfNeeded(&g_hooks.moveSizeHook);
+  RemoveWinEventHookIfNeeded(&g_hooks.minimizeHook);
+  RemoveWinEventHookIfNeeded(&g_hooks.hideDestroyHook);
+  RemoveWinEventHookIfNeeded(&g_hooks.cloakHook);
 }
 
 void ResetTilingStateMemory() {
-  AcquireSRWLockExclusive(&g_tilingStateLock);
-  g_tilingStateMap.clear();
-  ReleaseSRWLockExclusive(&g_tilingStateLock);
+  AcquireSRWLockExclusive(&g_store.tilingStateLock);
+  g_store.tilingStateMap.clear();
+  ReleaseSRWLockExclusive(&g_store.tilingStateLock);
 }
 
 //=============================================================================
@@ -1348,162 +2009,202 @@ UINT ParseSingleCharKey(PCWSTR str) {
 
 void LoadSettings() {
   PCWSTR version = Wh_GetStringSetting(L"WindowsVersion");
-  g_windowsVersionIndex = ParseWindowsVersion(version);
+  g_desktopApi.windowsVersionIndex = ParseWindowsVersion(version);
   Wh_FreeStringSetting(version);
 
-  g_tilingModifiers = ReadModifierSetting(L"TilingModifier", MOD_ALT);
+  g_settings.tilingModifiers = ReadStringSetting(L"TilingModifier", ParseModifiers, (UINT)MOD_ALT);
 
-  g_tileMargin = Wh_GetIntSetting(L"TileMargin");
-  if (g_tileMargin < 0 || g_tileMargin > 100) g_tileMargin = 4;
-  g_tileGap = Wh_GetIntSetting(L"TileGap");
-  if (g_tileGap < 0 || g_tileGap > 100) g_tileGap = 4;
-  g_masterPercent = Wh_GetIntSetting(L"MasterPercent");
-  if (g_masterPercent < 1 || g_masterPercent > 99) g_masterPercent = 50;
+  g_settings.tileMargin = ReadClampedIntSetting(L"TileMargin", 0, 100, 4);
+  g_settings.tileGap = ReadClampedIntSetting(L"TileGap", 0, 100, 4);
+  g_settings.masterPercent = ReadClampedIntSetting(L"MasterPercent", 1, 99, 50);
 
-  PCWSTR layout = Wh_GetStringSetting(L"DefaultLayout");
-  g_currentLayout = ParseLayoutSetting(layout);
-  Wh_FreeStringSetting(layout);
+  g_settings.enableResizeRetile = Wh_GetIntSetting(L"EnableResizeRetile") != 0;
+  g_settings.enableTileNewWin = Wh_GetIntSetting(L"EnableTileNewWin") != 0;
+  g_settings.retileSuspended = false;
 
-  g_enableTiling = Wh_GetIntSetting(L"EnableTiling") != 0;
-  g_enableResizeRetile = Wh_GetIntSetting(L"EnableResizeRetile") != 0;
-  g_captureLayoutOnTile = Wh_GetIntSetting(L"CaptureLayoutOnTile") != 0;
-  g_enableLayoutCycle = Wh_GetIntSetting(L"EnableLayoutCycle") != 0;
-  g_retileSuspended = false;
+  g_settings.tileKey = ReadStringSetting(L"TileKey", ParseSingleCharKey, (UINT)'D');
+  g_settings.retileToggleKey = ReadStringSetting(L"RetileToggleKey", ParseSingleCharKey, (UINT)'R');
+  g_settings.swapMasterKey = ReadStringSetting(L"SwapMasterKey", ParseSingleCharKey, (UINT)'M');
 
-  g_tileKey = ReadStringSetting(L"TileKey", ParseSingleCharKey, (UINT)'D');
-  g_layoutKey = ReadStringSetting(L"LayoutKey", ParseSingleCharKey, (UINT)'L');
-  g_retileToggleKey = ReadStringSetting(L"RetileToggleKey", ParseSingleCharKey, (UINT)'R');
+  PCWSTR orientation = Wh_GetStringSetting(L"LayoutOrientation");
+  g_settings.masterAxis = (wcscmp(orientation, L"vertical") == 0) ? Axis::X : Axis::Y;
+  Wh_FreeStringSetting(orientation);
+}
+
+void RegisterConfiguredHotkeys() {
+  RegisterHotKey(nullptr, HK_TILE, g_settings.tilingModifiers, g_settings.tileKey);
+  RegisterHotKey(nullptr, HK_SWAP_MASTER, g_settings.tilingModifiers, g_settings.swapMasterKey);
+  RegisterHotKey(nullptr, HK_RETILE_TOGGLE, g_settings.tilingModifiers, g_settings.retileToggleKey);
+}
+
+void UnregisterConfiguredHotkeys() {
+  UnregisterHotKey(nullptr, HK_TILE);
+  UnregisterHotKey(nullptr, HK_SWAP_MASTER);
+  UnregisterHotKey(nullptr, HK_RETILE_TOGGLE);
+}
+
+void MaybeTileCurrentWorkplaceOnStartup() {
+  if (!g_settings.enableTileNewWin) return;
+
+  if (InterlockedCompareExchange(&g_store.retileInProgress, 1, 0) == 0) {
+    TileWindows(nullptr, false);
+    InterlockedExchange(&g_store.retileInProgress, 0);
+  }
+  Wh_Log(L"TileNewWin Enabled: Tiled current workplace on startup");
+}
+
+void ProcessRetileMessage(HWND resizedHwnd) {
+  RetileFromResize(resizedHwnd);
+  InterlockedExchange(&g_store.retileInProgress, 0);
+}
+
+void ProcessTileMessage(HWND triggerHwnd, bool allowWhenSuspended = false) {
+  if (g_settings.retileSuspended && !allowWhenSuspended) return;
+  if (InterlockedCompareExchange(&g_store.retileInProgress, 1, 0) != 0) return;
+
+  TileWindows(triggerHwnd, allowWhenSuspended);
+  InterlockedExchange(&g_store.retileInProgress, 0);
+}
+
+void ProcessPruneDestroyedMessage(HWND dead) {
+  HWND anchor = PruneDestroyedAndPickAnchor(dead);
+  if (anchor) RetileFromResize(anchor);
+  InterlockedExchange(&g_store.retileInProgress, 0);
+}
+
+void ToggleRetileSuspension() {
+  g_settings.retileSuspended = !g_settings.retileSuspended;
+  if (g_settings.retileSuspended) {
+    RemoveWinEventHooks();
+    InterlockedExchange(&g_store.retileInProgress, 0);
+    ResetTilingStateMemory();
+    return;
+  }
+
+  InstallWinEventHooks();
+}
+
+void HandleHotkeyMessage(UINT hotkeyId) {
+  switch (hotkeyId) {
+    case HK_TILE:
+      ProcessTileMessage(nullptr, true);
+      return;
+    case HK_SWAP_MASTER:
+      SwapMaster();
+      return;
+    case HK_RETILE_TOGGLE:
+      ToggleRetileSuspension();
+      return;
+    default:
+      return;
+  }
+}
+
+bool HandleHotkeyThreadMessage(const MSG& msg) {
+  switch (msg.message) {
+    case WM_QUIT:
+      return false;
+    case WM_APP_RETILE:
+      ProcessRetileMessage(reinterpret_cast<HWND>(msg.wParam));
+      return true;
+    case WM_APP_TILE:
+      ProcessTileMessage(reinterpret_cast<HWND>(msg.wParam));
+      return true;
+    case WM_APP_PRUNE_DESTROY:
+      ProcessPruneDestroyedMessage(reinterpret_cast<HWND>(msg.wParam));
+      return true;
+    case WM_HOTKEY:
+      HandleHotkeyMessage(static_cast<UINT>(msg.wParam));
+      return true;
+    default:
+      return true;
+  }
+}
+
+void CleanupHotkeyThread() {
+  UnregisterConfiguredHotkeys();
+  RemoveWinEventHooks();
+  CleanupVirtualDesktopAPI();
+  CoUninitialize();
 }
 
 DWORD WINAPI HotkeyThreadProc(LPVOID) {
-  g_threadId = GetCurrentThreadId();
-  Wh_Log(L"Hotkey thread started, thread ID: %lu", g_threadId);
+  g_hotkeyThread.threadId = GetCurrentThreadId();
+  Wh_Log(L"Hotkey thread started, thread ID: %lu", g_hotkeyThread.threadId);
 
   HRESULT coHr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
   Wh_Log(L"CoInitializeEx result: 0x%08X", coHr);
 
   MSG msg;
   PeekMessage(&msg, nullptr, 0, 0, PM_NOREMOVE);
-  SetEvent(g_hReadyEvent);
+  SetEvent(g_hotkeyThread.readyEvent);
 
-  if (g_enableTiling && g_enableResizeRetile && !g_retileSuspended) {
-    InstallMoveSizeHook();
+  if (!g_settings.retileSuspended) {
+    InstallWinEventHooks();
   }
 
-  if (g_enableTiling) {
-    RegisterHotKey(nullptr, HK_TILE, g_tilingModifiers, g_tileKey);
-    if (g_enableLayoutCycle) {
-      RegisterHotKey(nullptr, HK_LAYOUT, g_tilingModifiers, g_layoutKey);
-    }
-    if (g_enableResizeRetile) {
-      RegisterHotKey(nullptr, HK_RETILE_TOGGLE, g_tilingModifiers, g_retileToggleKey);
-    }
-  }
+  RegisterConfiguredHotkeys();
   Wh_Log(L"Hotkeys registered");
+  MaybeTileCurrentWorkplaceOnStartup();
 
-  while (!g_stopHotkeyThread) {
-    DWORD waitResult = MsgWaitForMultipleObjects(0, nullptr, FALSE, 100, QS_ALLINPUT);
+  while (!g_hotkeyThread.stopRequested) {
+    if (MsgWaitForMultipleObjects(0, nullptr, FALSE, INFINITE, QS_ALLINPUT) != WAIT_OBJECT_0) {
+      continue;
+    }
 
-    if (waitResult == WAIT_OBJECT_0) {
-      while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE)) {
-        if (msg.message == WM_QUIT) {
-          goto cleanup;
-        }
-        if (msg.message == WM_APP + 1) {
-          HWND resizedHwnd = reinterpret_cast<HWND>(msg.wParam);
-          RetileFromResize(resizedHwnd);
-          InterlockedExchange(&g_retileInProgress, 0);
-          continue;
-        }
-        if (msg.message == WM_HOTKEY) {
-          UINT hotkeyId = static_cast<UINT>(msg.wParam);
-          if (hotkeyId == HK_TILE) {
-            TileWindows();
-            continue;
-          }
-          if (hotkeyId == HK_LAYOUT) {
-            g_currentLayout =
-                static_cast<TileLayout>((static_cast<int>(g_currentLayout) + 1) % static_cast<int>(TileLayout::COUNT));
-            TileWindows();
-            continue;
-          }
-          if (hotkeyId == HK_RETILE_TOGGLE && g_enableResizeRetile) {
-            g_retileSuspended = !g_retileSuspended;
-            if (g_retileSuspended) {
-              RemoveMoveSizeHook();
-              InterlockedExchange(&g_retileInProgress, 0);
-              ResetTilingStateMemory();
-              Wh_Log(L"Retile-on-resize suspended; tiling memory reset");
-            } else {
-              InstallMoveSizeHook();
-              Wh_Log(L"Retile-on-resize resumed");
-            }
-            continue;
-          }
-        }
+    while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE)) {
+      if (!HandleHotkeyThreadMessage(msg)) {
+        CleanupHotkeyThread();
+        return 0;
       }
     }
   }
 
-cleanup:
-  if (g_enableTiling) {
-    UnregisterHotKey(nullptr, HK_TILE);
-    if (g_enableLayoutCycle) {
-      UnregisterHotKey(nullptr, HK_LAYOUT);
-    }
-    if (g_enableResizeRetile) {
-      UnregisterHotKey(nullptr, HK_RETILE_TOGGLE);
-    }
-  }
-
-  RemoveMoveSizeHook();
-
-  CleanupVirtualDesktopAPI();
-  CoUninitialize();
+  CleanupHotkeyThread();
   return 0;
 }
 
 bool StartHotkeyThread() {
-  g_hReadyEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
-  g_hThread = CreateThread(nullptr, 0, HotkeyThreadProc, nullptr, 0, nullptr);
+  g_hotkeyThread.readyEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+  g_hotkeyThread.thread = CreateThread(nullptr, 0, HotkeyThreadProc, nullptr, 0, nullptr);
 
-  if (!g_hThread || WaitForSingleObject(g_hReadyEvent, 5000) != WAIT_OBJECT_0) {
+  if (!g_hotkeyThread.thread || WaitForSingleObject(g_hotkeyThread.readyEvent, 5000) != WAIT_OBJECT_0) {
     Wh_Log(L"Failed to start hotkey thread");
-    if (g_hThread) {
-      CloseHandle(g_hThread);
-      g_hThread = nullptr;
+    if (g_hotkeyThread.thread) {
+      CloseHandle(g_hotkeyThread.thread);
+      g_hotkeyThread.thread = nullptr;
     }
-    CloseHandle(g_hReadyEvent);
-    g_hReadyEvent = nullptr;
+    CloseHandle(g_hotkeyThread.readyEvent);
+    g_hotkeyThread.readyEvent = nullptr;
     return false;
   }
 
-  CloseHandle(g_hReadyEvent);
-  g_hReadyEvent = nullptr;
+  CloseHandle(g_hotkeyThread.readyEvent);
+  g_hotkeyThread.readyEvent = nullptr;
   return true;
 }
 
 void StopHotkeyThread() {
-  g_stopHotkeyThread = true;
-  InterlockedExchange(&g_retileInProgress, 0);
+  g_hotkeyThread.stopRequested = true;
+  InterlockedExchange(&g_store.retileInProgress, 0);
 
-  g_bInitialized = false;
+  g_desktopApi.initialized = false;
 
-  if (g_threadId) {
-    PostThreadMessage(g_threadId, WM_QUIT, 0, 0);
+  if (g_hotkeyThread.threadId) {
+    PostThreadMessage(g_hotkeyThread.threadId, WM_QUIT, 0, 0);
   }
 
-  if (g_hThread) {
-    DWORD waitResult = WaitForSingleObject(g_hThread, 5000);
+  if (g_hotkeyThread.thread) {
+    DWORD waitResult = WaitForSingleObject(g_hotkeyThread.thread, 5000);
     if (waitResult == WAIT_TIMEOUT) {
       Wh_Log(L"WARNING: Hotkey thread cleanup timeout, thread may be stuck in CoUninitialize");
     }
-    CloseHandle(g_hThread);
-    g_hThread = nullptr;
+    CloseHandle(g_hotkeyThread.thread);
+    g_hotkeyThread.thread = nullptr;
   }
 
-  g_threadId = 0;
-  g_stopHotkeyThread = false;
+  g_hotkeyThread.threadId = 0;
+  g_hotkeyThread.stopRequested = false;
 }
 
 //=============================================================================
@@ -1530,9 +2231,7 @@ void WhTool_ModUninit() {
 void WhTool_ModSettingsChanged() {
   Wh_Log(L"Settings changed, reloading...");
   StopHotkeyThread();
-  AcquireSRWLockExclusive(&g_tilingStateLock);
-  g_tilingStateMap.clear();
-  ReleaseSRWLockExclusive(&g_tilingStateLock);
+  ResetTilingStateMemory();
   LoadSettings();
   if (!StartHotkeyThread()) {
     Wh_Log(L"Failed to restart hotkey thread after settings change");
@@ -1550,10 +2249,7 @@ void WhTool_ModSettingsChanged() {
 bool g_isToolModProcessLauncher;
 HANDLE g_toolModProcessMutex;
 
-void WINAPI EntryPoint_Hook() {
-  Wh_Log(L">");
-  ExitThread(0);
-}
+void WINAPI EntryPoint_Hook() { ExitThread(0); }
 
 BOOL Wh_ModInit() {
   bool isService = false;


### PR DESCRIPTION
* Reworked Tiling Helper around a simpler always-on `Master+Stack` workflow. After tiling a monitor, windows stay managed until automatic tiling is paused.
* Dragging a tiled window now untile it and removes it from the current layout, while the remaining tiled windows are rearranged automatically.
* Removed layout cycling and the extra layouts, and focused the settings on a single configurable `Master+Stack` layout with horizontal/vertical orientation and adjustable master size.
* Updated hotkeys and controls: the retile toggle now pauses/resumes automatic tiling without disabling manual tiling, and a new shortcut can switch which window is the master.

Credit to @Meteony for the majority of code changes in this release.