### PR TITLE
Add ctrl-to-cross-monitors v0.1

### DIFF
--- a/mods/ctrl-to-cross-monitors.wh.cpp
+++ b/mods/ctrl-to-cross-monitors.wh.cpp
@@ -5,7 +5,7 @@
 // @version         0.1
 // @author          manudesir
 // @github          https://github.com/manudesir
-// @include         explorer.exe
+// @include         windhawk.exe
 // @compilerOptions -luser32
 // @license         MIT
 // ==/WindhawkMod==
@@ -26,6 +26,7 @@ Ctrl is currently held down.
 
 ## Notes
 - This is a single-file Windhawk mod, which matches Windhawk's documented mod format. ([github.com](https://github.com/ramensoftware/windhawk/wiki/Creating-a-new-mod))
+- It runs as a dedicated Windhawk tool process rather than inside Explorer. ([github.com](https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process))
 - It uses a low-level mouse hook (`WH_MOUSE_LL`), which Microsoft says should run
   on a dedicated thread with a message loop and return quickly. ([learn.microsoft.com](https://learn.microsoft.com/en-us/windows/win32/winmsg/lowlevelmouseproc))
 - It checks Ctrl with `GetAsyncKeyState(VK_CONTROL)`. Microsoft documents `VK_CONTROL`
@@ -33,8 +34,8 @@ Ctrl is currently held down.
 
 ## Limitation
 If this still has absolutely no effect on your machine, the likely issue is that
-Windhawk didn't actually get the hook active in the target process, not the logic
-itself.
+the dedicated Windhawk tool process didn't start correctly or the hook didn't
+become active, not the core cursor logic itself.
 */
 // ==/WindhawkModReadme==
 
@@ -48,6 +49,7 @@ itself.
 // ==/WindhawkModSettings==
 
 #include <windows.h>
+#include <strsafe.h>
 
 struct Settings {
     bool enabled;
@@ -60,11 +62,18 @@ static HMODULE g_moduleHandle = nullptr;
 static HANDLE g_hookThread = nullptr;
 static DWORD g_hookThreadId = 0;
 static HANDLE g_threadReadyEvent = nullptr;
+static bool g_isToolModProcessLauncher = false;
+static HANDLE g_toolModProcessMutex = nullptr;
 
-static bool g_ignoreForcedPoint = false;
-static POINT g_forcedPoint{};
-static POINT g_lastPoint{};
-static bool g_haveLastPoint = false;
+struct CursorState {
+    POINT lastPoint{};
+    HMONITOR lastMonitor = nullptr;
+    POINT forcedPoint{};
+    bool hasLastPoint = false;
+    bool ignoreForcedPoint = false;
+};
+
+static CursorState g_cursorState{};
 
 static void LoadSettings() {
     g_settings.enabled = Wh_GetIntSetting(L"enabled") != 0;
@@ -83,75 +92,120 @@ static bool IsCtrlHeld() {
     return GetAsyncKeyState(VK_CONTROL) < 0;
 }
 
+static bool AreSamePoint(const POINT& left, const POINT& right) {
+    return left.x == right.x && left.y == right.y;
+}
+
+static void CloseHandleIfValid(HANDLE& handle) {
+    if (handle) {
+        CloseHandle(handle);
+        handle = nullptr;
+    }
+}
+
+static void ResetCursorState() {
+    g_cursorState = {};
+}
+
+static void RememberCursorPosition(const POINT& point, HMONITOR monitor = nullptr) {
+    g_cursorState.lastPoint = point;
+    g_cursorState.lastMonitor =
+        monitor ? monitor : MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST);
+    g_cursorState.hasLastPoint = true;
+}
+
+static void RememberCursorPointOnly(const POINT& point) {
+    g_cursorState.lastPoint = point;
+    g_cursorState.lastMonitor = nullptr;
+    g_cursorState.hasLastPoint = true;
+}
+
+static void LogMonitorCrossing(bool blocked,
+                               const POINT& previousPoint,
+                               const POINT& currentPoint) {
+    if (!g_settings.logTransitions) {
+        return;
+    }
+
+    if (blocked) {
+        Wh_Log(L"Blocked monitor crossing from (%d, %d) to (%d, %d)",
+               previousPoint.x,
+               previousPoint.y,
+               currentPoint.x,
+               currentPoint.y);
+        return;
+    }
+
+    Wh_Log(L"Allowed monitor crossing with Ctrl from (%d, %d) to (%d, %d)",
+           previousPoint.x,
+           previousPoint.y,
+           currentPoint.x,
+           currentPoint.y);
+}
+
 static void ForceCursorTo(const POINT& point) {
-    g_forcedPoint = point;
-    g_ignoreForcedPoint = true;
+    g_cursorState.forcedPoint = point;
+    g_cursorState.ignoreForcedPoint = true;
     SetCursorPos(point.x, point.y);
 }
 
 static LRESULT CALLBACK LowLevelMouseProc(int nCode, WPARAM wParam, LPARAM lParam) {
-    if (nCode < 0) {
-        return CallNextHookEx(nullptr, nCode, wParam, lParam);
-    }
-
-    if (wParam != WM_MOUSEMOVE) {
+    if (nCode < 0 || wParam != WM_MOUSEMOVE) {
         return CallNextHookEx(nullptr, nCode, wParam, lParam);
     }
 
     const auto* mouseInfo = reinterpret_cast<const MSLLHOOKSTRUCT*>(lParam);
     const POINT currentPoint = mouseInfo->pt;
 
-    if (g_ignoreForcedPoint &&
-        currentPoint.x == g_forcedPoint.x &&
-        currentPoint.y == g_forcedPoint.y) {
-        g_ignoreForcedPoint = false;
-        g_lastPoint = currentPoint;
-        g_haveLastPoint = true;
+    if (g_cursorState.ignoreForcedPoint &&
+        AreSamePoint(currentPoint, g_cursorState.forcedPoint)) {
+        g_cursorState.ignoreForcedPoint = false;
+        RememberCursorPosition(currentPoint, g_cursorState.lastMonitor);
         return CallNextHookEx(nullptr, nCode, wParam, lParam);
     }
 
     if (!g_settings.enabled) {
-        g_lastPoint = currentPoint;
-        g_haveLastPoint = true;
+        RememberCursorPointOnly(currentPoint);
         return CallNextHookEx(nullptr, nCode, wParam, lParam);
     }
 
-    if (!g_haveLastPoint) {
-        g_lastPoint = currentPoint;
-        g_haveLastPoint = true;
+    if (!g_cursorState.hasLastPoint) {
+        RememberCursorPosition(currentPoint);
         return CallNextHookEx(nullptr, nCode, wParam, lParam);
     }
 
-    HMONITOR lastMonitor = MonitorFromPoint(g_lastPoint, MONITOR_DEFAULTTONEAREST);
-    HMONITOR currentMonitor = MonitorFromPoint(currentPoint, MONITOR_DEFAULTTONEAREST);
+    if (AreSamePoint(currentPoint, g_cursorState.lastPoint)) {
+        return CallNextHookEx(nullptr, nCode, wParam, lParam);
+    }
 
-    if (lastMonitor && currentMonitor && lastMonitor != currentMonitor && !IsCtrlHeld()) {
-        if (g_settings.logTransitions) {
-            Wh_Log(L"Blocked monitor crossing from (%d, %d) to (%d, %d)",
-                   g_lastPoint.x,
-                   g_lastPoint.y,
-                   currentPoint.x,
-                   currentPoint.y);
-        }
+    HMONITOR lastMonitor = g_cursorState.lastMonitor;
+    if (!lastMonitor) {
+        lastMonitor = MonitorFromPoint(g_cursorState.lastPoint,
+                                       MONITOR_DEFAULTTONEAREST);
+        g_cursorState.lastMonitor = lastMonitor;
+    }
 
-        ForceCursorTo(g_lastPoint);
+    const HMONITOR currentMonitor =
+        MonitorFromPoint(currentPoint, MONITOR_DEFAULTTONEAREST);
+    const bool crossedMonitor =
+        lastMonitor && currentMonitor && lastMonitor != currentMonitor;
+
+    if (crossedMonitor && !IsCtrlHeld()) {
+        LogMonitorCrossing(true, g_cursorState.lastPoint, currentPoint);
+        ForceCursorTo(g_cursorState.lastPoint);
         return 1;
     }
 
-    if (lastMonitor && currentMonitor && lastMonitor != currentMonitor && g_settings.logTransitions) {
-        Wh_Log(L"Allowed monitor crossing with Ctrl from (%d, %d) to (%d, %d)",
-               g_lastPoint.x,
-               g_lastPoint.y,
-               currentPoint.x,
-               currentPoint.y);
+    if (crossedMonitor) {
+        LogMonitorCrossing(false, g_cursorState.lastPoint, currentPoint);
     }
 
-    g_lastPoint = currentPoint;
+    RememberCursorPosition(currentPoint, currentMonitor);
     return CallNextHookEx(nullptr, nCode, wParam, lParam);
 }
 
 static DWORD WINAPI HookThreadProc(void*) {
-    MSG msg;
+    MSG msg{};
     PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
 
     g_mouseHook = SetWindowsHookExW(WH_MOUSE_LL, LowLevelMouseProc, g_moduleHandle, 0);
@@ -174,7 +228,7 @@ static DWORD WINAPI HookThreadProc(void*) {
     return 0;
 }
 
-BOOL Wh_ModInit() {
+BOOL WhTool_ModInit() {
     LoadSettings();
 
     if (!GetCurrentModuleHandle(&g_moduleHandle) || !g_moduleHandle) {
@@ -191,8 +245,7 @@ BOOL Wh_ModInit() {
     g_hookThread = CreateThread(nullptr, 0, HookThreadProc, nullptr, 0, &g_hookThreadId);
     if (!g_hookThread) {
         Wh_Log(L"CreateThread failed: %u", GetLastError());
-        CloseHandle(g_threadReadyEvent);
-        g_threadReadyEvent = nullptr;
+        CloseHandleIfValid(g_threadReadyEvent);
         return FALSE;
     }
 
@@ -200,10 +253,8 @@ BOOL Wh_ModInit() {
 
     if (!g_mouseHook) {
         WaitForSingleObject(g_hookThread, INFINITE);
-        CloseHandle(g_hookThread);
-        g_hookThread = nullptr;
-        CloseHandle(g_threadReadyEvent);
-        g_threadReadyEvent = nullptr;
+        CloseHandleIfValid(g_hookThread);
+        CloseHandleIfValid(g_threadReadyEvent);
         return FALSE;
     }
 
@@ -211,40 +262,200 @@ BOOL Wh_ModInit() {
     return TRUE;
 }
 
-void Wh_ModBeforeUninit() {
+void WhTool_ModUninit() {
     if (g_hookThreadId) {
         PostThreadMessageW(g_hookThreadId, WM_QUIT, 0, 0);
     }
-}
 
-void Wh_ModUninit() {
     if (g_hookThread) {
         WaitForSingleObject(g_hookThread, INFINITE);
-        CloseHandle(g_hookThread);
-        g_hookThread = nullptr;
     }
+    CloseHandleIfValid(g_hookThread);
 
-    if (g_threadReadyEvent) {
-        CloseHandle(g_threadReadyEvent);
-        g_threadReadyEvent = nullptr;
-    }
+    CloseHandleIfValid(g_threadReadyEvent);
 
     g_mouseHook = nullptr;
     g_hookThreadId = 0;
-    g_haveLastPoint = false;
-    g_ignoreForcedPoint = false;
+    ResetCursorState();
 
     Wh_Log(L"Hold Ctrl to cross monitors uninitialized");
 }
 
-BOOL Wh_ModSettingsChanged(BOOL* reload) {
+void WhTool_ModSettingsChanged() {
     LoadSettings();
-    g_haveLastPoint = false;
-    g_ignoreForcedPoint = false;
+    ResetCursorState();
+}
 
-    if (reload) {
-        *reload = FALSE;
+// Everything below is Windhawk tool boilerplate; the cursor behavior lives above.
+////////////////////////////////////////////////////////////////////////////////
+// Windhawk tool mod implementation for mods which don't need to inject to other
+// processes or hook other functions. Context:
+// [https://github.com/ramensoftware/windhawk-mods/pull/1916](https://github.com/ramensoftware/windhawk-mods/pull/1916)
+//
+// The mod will load and run in a dedicated windhawk.exe process.
+//
+// Paste the code below as part of the mod code, and use these callbacks:
+// * WhTool_ModInit
+// * WhTool_ModSettingsChanged
+// * WhTool_ModUninit
+//
+// Currently, other callbacks are not supported.
+
+void WINAPI EntryPoint_Hook() {
+    ExitThread(0);
+}
+
+BOOL Wh_ModInit() {
+    bool isService = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+    int argc;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
+    if (!argv) {
+        Wh_Log(L"CommandLineToArgvW failed");
+        return FALSE;
     }
 
+    for (int i = 1; i < argc; i++) {
+        if (wcscmp(argv[i], L"-service") == 0) {
+            isService = true;
+            break;
+        }
+    }
+
+    for (int i = 1; i < argc - 1; i++) {
+        if (wcscmp(argv[i], L"-tool-mod") == 0) {
+            isToolModProcess = true;
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
+                isCurrentToolModProcess = true;
+            }
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isService) {
+        return FALSE;
+    }
+
+    if (isCurrentToolModProcess) {
+        g_toolModProcessMutex =
+            CreateMutexW(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
+        if (!g_toolModProcessMutex) {
+            Wh_Log(L"CreateMutex failed");
+            ExitProcess(1);
+        }
+
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
+            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
+            ExitProcess(1);
+        }
+
+        if (!WhTool_ModInit()) {
+            ExitProcess(1);
+        }
+
+        IMAGE_DOS_HEADER* dosHeader =
+            reinterpret_cast<IMAGE_DOS_HEADER*>(GetModuleHandleW(nullptr));
+        IMAGE_NT_HEADERS* ntHeaders = reinterpret_cast<IMAGE_NT_HEADERS*>(
+            reinterpret_cast<BYTE*>(dosHeader) + dosHeader->e_lfanew);
+
+        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
+        void* entryPoint = reinterpret_cast<BYTE*>(dosHeader) + entryPointRVA;
+
+        Wh_SetFunctionHook(entryPoint, reinterpret_cast<void*>(EntryPoint_Hook),
+                           nullptr);
+        return TRUE;
+    }
+
+    if (isToolModProcess) {
+        return FALSE;
+    }
+
+    g_isToolModProcessLauncher = true;
     return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (!g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WCHAR currentProcessPath[MAX_PATH];
+    switch (GetModuleFileNameW(nullptr, currentProcessPath,
+                               ARRAYSIZE(currentProcessPath))) {
+        case 0:
+        case ARRAYSIZE(currentProcessPath):
+            Wh_Log(L"GetModuleFileName failed");
+            return;
+    }
+
+    WCHAR commandLine[MAX_PATH + 2 +
+                      (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") /
+                           sizeof(WCHAR)) -
+                      1];
+    if (FAILED(StringCchPrintfW(commandLine, ARRAYSIZE(commandLine),
+                                L"\"%s\" -tool-mod \"%s\"",
+                                currentProcessPath, WH_MOD_ID))) {
+        Wh_Log(L"StringCchPrintfW failed");
+        return;
+    }
+
+    HMODULE kernelModule = GetModuleHandleW(L"kernelbase.dll");
+    if (!kernelModule) {
+        kernelModule = GetModuleHandleW(L"kernel32.dll");
+        if (!kernelModule) {
+            Wh_Log(L"No kernelbase.dll/kernel32.dll");
+            return;
+        }
+    }
+
+    using CreateProcessInternalW_t = BOOL(WINAPI*)(
+        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+        LPSECURITY_ATTRIBUTES lpProcessAttributes,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
+        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
+        LPSTARTUPINFOW lpStartupInfo,
+        LPPROCESS_INFORMATION lpProcessInformation,
+        PHANDLE hRestrictedUserToken);
+    CreateProcessInternalW_t pCreateProcessInternalW =
+        reinterpret_cast<CreateProcessInternalW_t>(
+            GetProcAddress(kernelModule, "CreateProcessInternalW"));
+    if (!pCreateProcessInternalW) {
+        Wh_Log(L"No CreateProcessInternalW");
+        return;
+    }
+
+    STARTUPINFOW si{
+        .cb = sizeof(STARTUPINFOW),
+        .dwFlags = STARTF_FORCEOFFFEEDBACK,
+    };
+    PROCESS_INFORMATION pi{};
+    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
+                                 nullptr, nullptr, FALSE, CREATE_NO_WINDOW,
+                                 nullptr, nullptr, &si, &pi, nullptr)) {
+        Wh_Log(L"CreateProcess failed");
+        return;
+    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+}
+
+void Wh_ModSettingsChanged() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModSettingsChanged();
+}
+
+void Wh_ModUninit() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModUninit();
+    CloseHandleIfValid(g_toolModProcessMutex);
 }


### PR DESCRIPTION
Summary:
This mod prevents the mouse cursor from moving to another monitor unless Ctrl is held while moving the mouse.

Tested:
- manual testing on a multi-monitor setup
- movement within a monitor is unaffected
- crossing to another monitor is blocked when Ctrl is not held
- crossing is allowed when Ctrl is held

## Known limitation
When the Windhawk app window is focused, the cursor restriction does not work. But it works the rest of the time

Author GitHub:
https://github.com/manudesir

License:
MIT