### PR TITLE
Taskbar auto-hide fine tuning v2.0

### DIFF
--- a/mods/taskbar-auto-hide-keyboard-only.wh.cpp
+++ b/mods/taskbar-auto-hide-keyboard-only.wh.cpp
@@ -1,15 +1,15 @@
 // ==WindhawkMod==
 // @id              taskbar-auto-hide-keyboard-only
-// @name            Taskbar keyboard-only auto-hide
-// @description     When taskbar auto-hide is enabled, the taskbar will only be unhidden with the keyboard, hovering the mouse over the taskbar will not unhide it
-// @version         1.1.2
+// @name            Taskbar auto-hide fine tuning
+// @description     Fine-tune taskbar auto-hide: keyboard-only unhide, prevent the taskbar from showing at all, hotkeys and mouse events to show or toggle visibility
+// @version         2.0
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
 // @homepage        https://m417z.com/
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -ldwmapi -lversion
+// @compilerOptions -lcomctl32 -ldwmapi -loleaut32 -lruntimeobject -lversion
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -22,11 +22,34 @@
 
 // ==WindhawkModReadme==
 /*
-# Taskbar keyboard-only auto-hide
+# Taskbar auto-hide fine tuning
 
-When taskbar auto-hide is enabled, the taskbar will only be unhidden with the
-keyboard, hovering the mouse over the taskbar will not unhide it. For example,
-the Win key or Ctrl+Esc will unhide the taskbar.
+Fine-tune taskbar auto-hide with multiple modes and hotkeys. When taskbar
+auto-hide is enabled, this mod gives you control over when and how the taskbar
+appears.
+
+## Auto-hide modes
+
+- **Windows default**: Standard auto-hide behavior. Use this if you only want
+  the hotkeys.
+- **Keyboard or mouse click**: The taskbar only unhides via the keyboard or by
+  clicking at the bottom edge of the screen. Mouse hover no longer shows the
+  taskbar.
+- **Keyboard only**: The taskbar is completely hidden. It can only be shown via
+  the keyboard.
+- **Never**: The taskbar never shows for any reason (notifications, Win key,
+  etc.). Only the mod's hotkeys can show it. The Start menu still opens but the
+  taskbar stays hidden.
+
+## Hotkeys
+
+- **Show temporarily**: Briefly shows the taskbar. It hides again when you stop
+  interacting with it.
+- **Toggle always-show**: Toggles permanent taskbar visibility. Press again to
+  return to auto-hide behavior.
+
+On Windows 11, you can also toggle always-show via a mouse event (middle click
+or double click) on the taskbar.
 
 **Note:** To customize the old taskbar on Windows 11 (if using ExplorerPatcher
 or a similar tool), enable the relevant option in the mod's settings.
@@ -35,13 +58,33 @@ or a similar tool), enable the relevant option in the mod's settings.
 
 // ==WindhawkModSettings==
 /*
-- fullyHide: false
-  $name: Fully hide
+- mode: keyboardOnlyShowOnClick
+  $name: Auto-hide mode
+  $description: Refer to the mod description for details about each mode.
+  $options:
+  - windowsDefault: Windows default
+  - keyboardOnlyShowOnClick: Keyboard or mouse click
+  - keyboardOnlyFullyHide: Keyboard only
+  - never: Never
+- showTemporarilyHotkey: Alt+Escape
+  $name: Show temporarily hotkey
   $description: >-
-    Normally, the taskbar is hidden to a thin line which can be clicked to
-    unhide it. This option makes it so that the taskbar is fully hidden on
-    auto-hide, leaving no traces at all. With this option, the taskbar can only
-    be unhidden via the keyboard.
+    Hotkey to temporarily show the taskbar (e.g. Alt+Escape or Ctrl+Alt+T). The
+    taskbar hides again when you stop interacting with it.
+- toggleAlwaysShowHotkey: Alt+`
+  $name: Toggle always-show hotkey
+  $description: >-
+    Hotkey to toggle permanent taskbar visibility (e.g. Alt+` or Ctrl+Alt+Y).
+    Press again to return to the configured auto-hide behavior.
+- toggleAlwaysShowMouseEvent: disabled
+  $name: Toggle always-show mouse event (Win11 only)
+  $description: >-
+    Mouse event on the taskbar to toggle permanent visibility, similar to the
+    toggle always-show hotkey.
+  $options:
+  - disabled: Disabled
+  - middleClick: Middle click
+  - doubleClick: Double click
 - oldTaskbarOnWin11: false
   $name: Customize the old taskbar on Windows 11
   $description: >-
@@ -52,15 +95,42 @@ or a similar tool), enable the relevant option in the mod's settings.
 
 #include <windhawk_utils.h>
 
+#include <commctrl.h>
 #include <dwmapi.h>
 #include <psapi.h>
 
+#undef GetCurrentTime
+
+#include <winrt/Windows.UI.Input.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Input.h>
+
+#include <algorithm>
 #include <atomic>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 #include <vector>
 
+enum class AutoHideMode {
+    WindowsDefault,
+    KeyboardOnlyShowOnClick,
+    KeyboardOnlyFullyHide,
+    Never,
+};
+
+enum class ToggleAlwaysShowMouseEvent {
+    Disabled,
+    MiddleClick,
+    DoubleClick,
+};
+
 struct {
-    bool fullyHide;
+    AutoHideMode mode;
     bool oldTaskbarOnWin11;
+    std::wstring showTemporarilyHotkey;
+    std::wstring toggleAlwaysShowHotkey;
+    ToggleAlwaysShowMouseEvent toggleAlwaysShowMouseEvent;
 } g_settings;
 
 enum class WinVersion {
@@ -72,6 +142,7 @@ enum class WinVersion {
 
 WinVersion g_winVersion;
 
+std::atomic<bool> g_taskbarViewDllLoaded;
 std::atomic<bool> g_initialized;
 std::atomic<bool> g_explorerPatcherInitialized;
 
@@ -79,6 +150,55 @@ enum {
     kTrayUITimerHide = 2,
     kTrayUITimerUnhide = 3,
 };
+
+// Hotkey IDs.
+enum {
+    kHotkeyIdShowTemporarily = 1773615305,  // from epochconverter.com
+    kHotkeyIdToggleAlwaysShow,
+};
+
+// Message dispatched to the taskbar subclass proc for UI-thread operations.
+static UINT g_uiThreadCallbackMsg =
+    RegisterWindowMessage(L"Windhawk_uiThreadCallback_" WH_MOD_ID);
+
+// Message to capture pThis in WndProc hooks after late load.
+static UINT g_captureThisMsg =
+    RegisterWindowMessage(L"Windhawk_captureThis_" WH_MOD_ID);
+
+// Operations dispatched to the UI thread via g_uiThreadCallbackMsg.
+enum {
+    UI_REGISTER_HOTKEYS,
+    UI_UNREGISTER_HOTKEYS,
+    UI_APPLY_SETTINGS,
+    UI_BEFORE_UNINIT,
+};
+
+// Hotkey state.
+HWND g_hTaskbarWnd;
+bool g_showTempHotkeyRegistered;
+bool g_toggleAlwaysHotkeyRegistered;
+
+// Always-show state.
+bool g_alwaysShowMode;
+
+// Set during mod-triggered unhide to bypass Never mode blocking.
+bool g_modTriggeredUnhide;
+
+// Flyout snapping state for Never mode. Tracks the window and its original
+// gap (in 96-DPI units) so we can restore position when leaving Never mode.
+struct SnappedFlyout {
+    HWND hwnd;
+    int gapDip;  // original gap in DIP (96 DPI)
+};
+SnappedFlyout g_snappedStartMenu{};
+SnappedFlyout g_snappedSearchMenu{};
+
+// Win10: HWND -> TrayUI WndProc pThis.
+std::unordered_map<HWND, void*> g_hwndToWndProcPThis;
+// Win10: HWND -> CSecondaryTray WndProc pThis.
+std::unordered_map<HWND, void*> g_hwndToSecondaryPThis;
+// Win11: HWND -> ViewCoordinator pThis.
+std::unordered_map<HWND, void*> g_hwndToViewCoordinator;
 
 bool IsTaskbarWindow(HWND hWnd) {
     WCHAR szClassName[32];
@@ -152,14 +272,487 @@ void CloakWindow(HWND hWnd, BOOL cloak) {
     DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &cloak, sizeof(cloak));
 }
 
+void* QueryViaVtable(void* object, void* vtable) {
+    void* ptr = object;
+    while (*(void**)ptr != vtable) {
+        ptr = (void**)ptr + 1;
+    }
+    return ptr;
+}
+
+bool FromStringHotKey(std::wstring_view hotkeyString,
+                      UINT* modifiersOut,
+                      UINT* vkOut) {
+    static const std::unordered_map<std::wstring_view, UINT> modifiersMap = {
+        {L"ALT", MOD_ALT},           {L"CTRL", MOD_CONTROL},
+        {L"NOREPEAT", MOD_NOREPEAT}, {L"SHIFT", MOD_SHIFT},
+        {L"WIN", MOD_WIN},
+    };
+
+    static const std::unordered_map<std::wstring_view, UINT> vkMap = {
+        // Letters A-Z
+        {L"A", 0x41},
+        {L"B", 0x42},
+        {L"C", 0x43},
+        {L"D", 0x44},
+        {L"E", 0x45},
+        {L"F", 0x46},
+        {L"G", 0x47},
+        {L"H", 0x48},
+        {L"I", 0x49},
+        {L"J", 0x4A},
+        {L"K", 0x4B},
+        {L"L", 0x4C},
+        {L"M", 0x4D},
+        {L"N", 0x4E},
+        {L"O", 0x4F},
+        {L"P", 0x50},
+        {L"Q", 0x51},
+        {L"R", 0x52},
+        {L"S", 0x53},
+        {L"T", 0x54},
+        {L"U", 0x55},
+        {L"V", 0x56},
+        {L"W", 0x57},
+        {L"X", 0x58},
+        {L"Y", 0x59},
+        {L"Z", 0x5A},
+        // Numbers 0-9
+        {L"0", 0x30},
+        {L"1", 0x31},
+        {L"2", 0x32},
+        {L"3", 0x33},
+        {L"4", 0x34},
+        {L"5", 0x35},
+        {L"6", 0x36},
+        {L"7", 0x37},
+        {L"8", 0x38},
+        {L"9", 0x39},
+        // Function keys F1-F24
+        {L"F1", 0x70},
+        {L"F2", 0x71},
+        {L"F3", 0x72},
+        {L"F4", 0x73},
+        {L"F5", 0x74},
+        {L"F6", 0x75},
+        {L"F7", 0x76},
+        {L"F8", 0x77},
+        {L"F9", 0x78},
+        {L"F10", 0x79},
+        {L"F11", 0x7A},
+        {L"F12", 0x7B},
+        {L"F13", 0x7C},
+        {L"F14", 0x7D},
+        {L"F15", 0x7E},
+        {L"F16", 0x7F},
+        {L"F17", 0x80},
+        {L"F18", 0x81},
+        {L"F19", 0x82},
+        {L"F20", 0x83},
+        {L"F21", 0x84},
+        {L"F22", 0x85},
+        {L"F23", 0x86},
+        {L"F24", 0x87},
+        // Common keys
+        {L"BACKSPACE", 0x08},
+        {L"TAB", 0x09},
+        {L"ENTER", 0x0D},
+        {L"RETURN", 0x0D},
+        {L"PAUSE", 0x13},
+        {L"CAPSLOCK", 0x14},
+        {L"ESCAPE", 0x1B},
+        {L"ESC", 0x1B},
+        {L"SPACE", 0x20},
+        {L"SPACEBAR", 0x20},
+        {L"PAGEUP", 0x21},
+        {L"PAGEDOWN", 0x22},
+        {L"END", 0x23},
+        {L"HOME", 0x24},
+        {L"LEFT", 0x25},
+        {L"UP", 0x26},
+        {L"RIGHT", 0x27},
+        {L"DOWN", 0x28},
+        {L"PRINTSCREEN", 0x2C},
+        {L"PRTSC", 0x2C},
+        {L"INSERT", 0x2D},
+        {L"INS", 0x2D},
+        {L"DELETE", 0x2E},
+        {L"DEL", 0x2E},
+        {L"HELP", 0x2F},
+        {L"SLEEP", 0x5F},
+        {L"APPS", 0x5D},
+        {L"MENU", 0x5D},
+        // Numpad keys
+        {L"NUMPAD0", 0x60},
+        {L"NUMPAD1", 0x61},
+        {L"NUMPAD2", 0x62},
+        {L"NUMPAD3", 0x63},
+        {L"NUMPAD4", 0x64},
+        {L"NUMPAD5", 0x65},
+        {L"NUMPAD6", 0x66},
+        {L"NUMPAD7", 0x67},
+        {L"NUMPAD8", 0x68},
+        {L"NUMPAD9", 0x69},
+        {L"NUM0", 0x60},
+        {L"NUM1", 0x61},
+        {L"NUM2", 0x62},
+        {L"NUM3", 0x63},
+        {L"NUM4", 0x64},
+        {L"NUM5", 0x65},
+        {L"NUM6", 0x66},
+        {L"NUM7", 0x67},
+        {L"NUM8", 0x68},
+        {L"NUM9", 0x69},
+        {L"MULTIPLY", 0x6A},
+        {L"ADD", 0x6B},
+        {L"SUBTRACT", 0x6D},
+        {L"DECIMAL", 0x6E},
+        {L"DIVIDE", 0x6F},
+        {L"NUMLOCK", 0x90},
+        {L"SCROLLLOCK", 0x91},
+        // Media keys
+        {L"VOLUMEMUTE", 0xAD},
+        {L"VOLUMEDOWN", 0xAE},
+        {L"VOLUMEUP", 0xAF},
+        {L"MEDIANEXT", 0xB0},
+        {L"MEDIAPREV", 0xB1},
+        {L"MEDIASTOP", 0xB2},
+        {L"MEDIAPLAYPAUSE", 0xB3},
+        // Browser keys
+        {L"BROWSERBACK", 0xA6},
+        {L"BROWSERFORWARD", 0xA7},
+        {L"BROWSERREFRESH", 0xA8},
+        {L"BROWSERSTOP", 0xA9},
+        {L"BROWSERSEARCH", 0xAA},
+        {L"BROWSERFAVORITES", 0xAB},
+        {L"BROWSERHOME", 0xAC},
+        // Modifier keys (for use as the key itself)
+        {L"LWIN", 0x5B},
+        {L"RWIN", 0x5C},
+        {L"LSHIFT", 0xA0},
+        {L"RSHIFT", 0xA1},
+        {L"LCTRL", 0xA2},
+        {L"RCTRL", 0xA3},
+        {L"LALT", 0xA4},
+        {L"RALT", 0xA5},
+        // VK_ prefixed versions
+        {L"VK_LBUTTON", 0x01},
+        {L"VK_RBUTTON", 0x02},
+        {L"VK_CANCEL", 0x03},
+        {L"VK_MBUTTON", 0x04},
+        {L"VK_XBUTTON1", 0x05},
+        {L"VK_XBUTTON2", 0x06},
+        {L"VK_CLEAR", 0x0C},
+        {L"VK_SHIFT", 0x10},
+        {L"VK_CONTROL", 0x11},
+        {L"VK_MENU", 0x12},
+        {L"VK_KANA", 0x15},
+        {L"VK_HANGUL", 0x15},
+        {L"VK_IME_ON", 0x16},
+        {L"VK_JUNJA", 0x17},
+        {L"VK_FINAL", 0x18},
+        {L"VK_HANJA", 0x19},
+        {L"VK_KANJI", 0x19},
+        {L"VK_IME_OFF", 0x1A},
+        {L"VK_CONVERT", 0x1C},
+        {L"VK_NONCONVERT", 0x1D},
+        {L"VK_ACCEPT", 0x1E},
+        {L"VK_MODECHANGE", 0x1F},
+        {L"VK_SELECT", 0x29},
+        {L"VK_PRINT", 0x2A},
+        {L"VK_EXECUTE", 0x2B},
+        {L"VK_SEPARATOR", 0x6C},
+        {L"VK_LAUNCH_MAIL", 0xB4},
+        {L"VK_LAUNCH_MEDIA_SELECT", 0xB5},
+        {L"VK_LAUNCH_APP1", 0xB6},
+        {L"VK_LAUNCH_APP2", 0xB7},
+        {L"VK_OEM_1", 0xBA},
+        {L"VK_OEM_PLUS", 0xBB},
+        {L"VK_OEM_COMMA", 0xBC},
+        {L"VK_OEM_MINUS", 0xBD},
+        {L"VK_OEM_PERIOD", 0xBE},
+        {L"VK_OEM_2", 0xBF},
+        {L"VK_OEM_3", 0xC0},
+        {L"VK_OEM_4", 0xDB},
+        {L"VK_OEM_5", 0xDC},
+        {L"VK_OEM_6", 0xDD},
+        {L"VK_OEM_7", 0xDE},
+        {L"VK_OEM_8", 0xDF},
+        {L"VK_OEM_102", 0xE2},
+        {L"VK_PROCESSKEY", 0xE5},
+        {L"VK_PACKET", 0xE7},
+        {L"VK_ATTN", 0xF6},
+        {L"VK_CRSEL", 0xF7},
+        {L"VK_EXSEL", 0xF8},
+        {L"VK_EREOF", 0xF9},
+        {L"VK_PLAY", 0xFA},
+        {L"VK_ZOOM", 0xFB},
+        {L"VK_NONAME", 0xFC},
+        {L"VK_PA1", 0xFD},
+        {L"VK_OEM_CLEAR", 0xFE},
+        // US keyboard character aliases for OEM keys.
+        {L";", 0xBA},   // VK_OEM_1
+        {L":", 0xBA},   // VK_OEM_1
+        {L"=", 0xBB},   // VK_OEM_PLUS
+        {L"+", 0xBB},   // VK_OEM_PLUS
+        {L",", 0xBC},   // VK_OEM_COMMA
+        {L"<", 0xBC},   // VK_OEM_COMMA
+        {L"-", 0xBD},   // VK_OEM_MINUS
+        {L"_", 0xBD},   // VK_OEM_MINUS
+        {L".", 0xBE},   // VK_OEM_PERIOD
+        {L">", 0xBE},   // VK_OEM_PERIOD
+        {L"/", 0xBF},   // VK_OEM_2
+        {L"?", 0xBF},   // VK_OEM_2
+        {L"`", 0xC0},   // VK_OEM_3
+        {L"~", 0xC0},   // VK_OEM_3
+        {L"[", 0xDB},   // VK_OEM_4
+        {L"{", 0xDB},   // VK_OEM_4
+        {L"\\", 0xDC},  // VK_OEM_5
+        {L"|", 0xDC},   // VK_OEM_5
+        {L"]", 0xDD},   // VK_OEM_6
+        {L"}", 0xDD},   // VK_OEM_6
+        {L"'", 0xDE},   // VK_OEM_7
+        {L"\"", 0xDE},  // VK_OEM_7
+    };
+
+    auto splitStringView = [](std::wstring_view s, WCHAR delimiter) {
+        size_t pos_start = 0, pos_end;
+        std::wstring_view token;
+        std::vector<std::wstring_view> res;
+
+        while ((pos_end = s.find(delimiter, pos_start)) !=
+               std::wstring_view::npos) {
+            token = s.substr(pos_start, pos_end - pos_start);
+            pos_start = pos_end + 1;
+            res.push_back(token);
+        }
+
+        res.push_back(s.substr(pos_start));
+        return res;
+    };
+
+    auto trimStringView = [](std::wstring_view s) {
+        s.remove_prefix(std::min(s.find_first_not_of(L" \t\r\v\n"), s.size()));
+        s.remove_suffix(std::min(
+            s.size() - s.find_last_not_of(L" \t\r\v\n") - 1, s.size()));
+        return s;
+    };
+
+    UINT modifiers = 0;
+    UINT vk = 0;
+
+    auto hotkeyParts = splitStringView(hotkeyString, '+');
+    for (auto hotkeyPart : hotkeyParts) {
+        hotkeyPart = trimStringView(hotkeyPart);
+        std::wstring hotkeyPartUpper{hotkeyPart};
+        std::transform(hotkeyPartUpper.begin(), hotkeyPartUpper.end(),
+                       hotkeyPartUpper.begin(), ::toupper);
+
+        if (auto it = modifiersMap.find(hotkeyPartUpper);
+            it != modifiersMap.end()) {
+            modifiers |= it->second;
+            continue;
+        }
+
+        if (vk) {
+            // Only one key is allowed.
+            return false;
+        }
+
+        if (auto it = vkMap.find(hotkeyPartUpper); it != vkMap.end()) {
+            vk = it->second;
+            continue;
+        }
+
+        size_t pos;
+        try {
+            vk = std::stoi(hotkeyPartUpper, &pos, 0);
+            if (hotkeyPartUpper[pos] != L'\0' || !vk) {
+                return false;
+            }
+        } catch (const std::exception&) {
+            return false;
+        }
+    }
+
+    if (!vk) {
+        return false;
+    }
+
+    *modifiersOut = modifiers;
+    *vkOut = vk;
+    return true;
+}
+
+std::wstring GetProcessFileName(DWORD dwProcessId) {
+    HANDLE hProcess =
+        OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, dwProcessId);
+    if (!hProcess) {
+        return std::wstring{};
+    }
+
+    WCHAR processPath[MAX_PATH];
+    DWORD dwSize = ARRAYSIZE(processPath);
+    if (!QueryFullProcessImageName(hProcess, 0, processPath, &dwSize)) {
+        CloseHandle(hProcess);
+        return std::wstring{};
+    }
+
+    CloseHandle(hProcess);
+
+    PCWSTR processFileName = wcsrchr(processPath, L'\\');
+    if (!processFileName) {
+        return std::wstring{};
+    }
+
+    processFileName++;
+    return processFileName;
+}
+
+// Restore a snapped flyout back to its original position (gap from monitor
+// bottom), e.g. when leaving Never mode or when the taskbar becomes visible.
+void RestoreSnappedFlyout(SnappedFlyout& flyout) {
+    if (!flyout.hwnd || !IsWindow(flyout.hwnd)) {
+        flyout = {};
+        return;
+    }
+
+    RECT rcWindow;
+    if (!GetWindowRect(flyout.hwnd, &rcWindow)) {
+        flyout = {};
+        return;
+    }
+
+    HMONITOR monitor = MonitorFromWindow(flyout.hwnd, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO mi = {.cbSize = sizeof(MONITORINFO)};
+    if (!GetMonitorInfo(monitor, &mi)) {
+        flyout = {};
+        return;
+    }
+
+    UINT dpi = GetDpiForWindow(flyout.hwnd);
+    int gapPx = MulDiv(flyout.gapDip, dpi, 96);
+    int targetBottom = mi.rcMonitor.bottom - gapPx;
+    int dy = targetBottom - rcWindow.bottom;
+    if (dy != 0) {
+        Wh_Log(L"Restoring flyout %08X (dy=%d, gapDip=%d)",
+               (DWORD)(DWORD_PTR)flyout.hwnd, dy, flyout.gapDip);
+        SetWindowPos(flyout.hwnd, nullptr, rcWindow.left, rcWindow.top + dy, 0,
+                     0, SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSIZE);
+    }
+
+    flyout = {};
+}
+
+void RestoreAllSnappedFlyouts() {
+    RestoreSnappedFlyout(g_snappedStartMenu);
+    RestoreSnappedFlyout(g_snappedSearchMenu);
+}
+
+using DwmSetWindowAttribute_t = decltype(&DwmSetWindowAttribute);
+DwmSetWindowAttribute_t DwmSetWindowAttribute_Original;
+HRESULT WINAPI DwmSetWindowAttribute_Hook(HWND hwnd,
+                                          DWORD dwAttribute,
+                                          LPCVOID pvAttribute,
+                                          DWORD cbAttribute) {
+    auto original = [=]() {
+        return DwmSetWindowAttribute_Original(hwnd, dwAttribute, pvAttribute,
+                                              cbAttribute);
+    };
+
+    if (dwAttribute != DWMWA_CLOAK || cbAttribute != sizeof(BOOL)) {
+        return original();
+    }
+
+    BOOL cloak = *(const BOOL*)pvAttribute;
+    if (cloak) {
+        return original();
+    }
+
+    // Only act in Never mode.
+    if (g_settings.mode != AutoHideMode::Never) {
+        return original();
+    }
+
+    DWORD processId = 0;
+    DWORD threadId = GetWindowThreadProcessId(hwnd, &processId);
+    if (!processId || !threadId) {
+        return original();
+    }
+
+    std::wstring processFileName = GetProcessFileName(processId);
+
+    enum class FlyoutKind { None, StartMenu, SearchMenu };
+    FlyoutKind kind = FlyoutKind::None;
+    if (_wcsicmp(processFileName.c_str(), L"StartMenuExperienceHost.exe") ==
+        0) {
+        kind = FlyoutKind::StartMenu;
+    } else if (_wcsicmp(processFileName.c_str(), L"SearchHost.exe") == 0) {
+        kind = FlyoutKind::SearchMenu;
+    }
+
+    if (kind == FlyoutKind::None) {
+        return original();
+    }
+
+    RECT rcWindow;
+    if (!GetWindowRect(hwnd, &rcWindow)) {
+        return original();
+    }
+
+    HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO mi = {.cbSize = sizeof(MONITORINFO)};
+    if (!GetMonitorInfo(monitor, &mi)) {
+        return original();
+    }
+
+    SnappedFlyout& flyout = (kind == FlyoutKind::StartMenu)
+                                ? g_snappedStartMenu
+                                : g_snappedSearchMenu;
+
+    bool taskbarShown = g_alwaysShowMode || g_modTriggeredUnhide;
+
+    Wh_Log(L"Taskbar shown: %d", taskbarShown);
+
+    if (taskbarShown) {
+        // Taskbar is visible — the system positioned the flyout correctly
+        // relative to the visible taskbar. Nothing to adjust.
+    } else {
+        // Taskbar is hidden — snap flyout to monitor bottom and save the
+        // original gap (DPI-neutral) so we can restore it later.
+        int gap = mi.rcMonitor.bottom - rcWindow.bottom;
+        if (gap > 0) {
+            UINT dpi = GetDpiForWindow(hwnd);
+            int gapDip = MulDiv(gap, 96, dpi);
+            flyout = {hwnd, gapDip};
+
+            Wh_Log(
+                L"Snapping flyout %08X to monitor bottom (gap=%d, "
+                L"gapDip=%d)",
+                (DWORD)(DWORD_PTR)hwnd, gap, gapDip);
+            SetWindowPos(hwnd, nullptr, rcWindow.left, rcWindow.top + gap, 0, 0,
+                         SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSIZE);
+        }
+    }
+
+    return original();
+}
+
 using SetTimer_t = decltype(&SetTimer);
 SetTimer_t SetTimer_Original;
 UINT_PTR WINAPI SetTimer_Hook(HWND hWnd,
                               UINT_PTR nIDEvent,
                               UINT uElapse,
                               TIMERPROC lpTimerFunc) {
-    if (nIDEvent == kTrayUITimerUnhide && IsTaskbarWindow(hWnd)) {
+    if (g_settings.mode != AutoHideMode::WindowsDefault &&
+        nIDEvent == kTrayUITimerUnhide && IsTaskbarWindow(hWnd)) {
         Wh_Log(L">");
+        return 1;
+    }
+
+    if (nIDEvent == kTrayUITimerHide && g_alwaysShowMode &&
+        IsTaskbarWindow(hWnd)) {
+        Wh_Log(L"Blocking hide timer (always-show mode)");
         return 1;
     }
 
@@ -183,14 +776,594 @@ void WINAPI TrayUI_SlideWindow_Hook(void* pThis,
                                     bool flag) {
     Wh_Log(L">");
 
-    if (show && g_settings.fullyHide) {
+    bool shouldCloak = g_settings.mode == AutoHideMode::KeyboardOnlyFullyHide ||
+                       g_settings.mode == AutoHideMode::Never;
+
+    if (show && shouldCloak) {
         CloakWindow(hWnd, FALSE);
     }
 
     TrayUI_SlideWindow_Original(pThis, hWnd, rc, monitor, show, flag);
 
-    if (!show && g_settings.fullyHide) {
+    if (!show && shouldCloak) {
         CloakWindow(hWnd, TRUE);
+    }
+
+    // Clear mod-triggered flag when the old taskbar hides (equivalent of
+    // ViewCoordinator's pointer-leave clearing for Win11).
+    if (!show && g_modTriggeredUnhide) {
+        g_modTriggeredUnhide = false;
+    }
+}
+
+// Vtable pointers for interface navigation.
+void* TrayUI_vftable_ITrayComponentHost;
+void* CSecondaryTray_vftable_ISecondaryTray;
+
+// TrayUI::_Hide hook — block hide in always-show mode.
+using TrayUI__Hide_t = void(WINAPI*)(void* pThis);
+TrayUI__Hide_t TrayUI__Hide_Original;
+void WINAPI TrayUI__Hide_Hook(void* pThis) {
+    if (g_alwaysShowMode) {
+        Wh_Log(L"Blocking hide (always-show mode)");
+        return;
+    }
+
+    TrayUI__Hide_Original(pThis);
+}
+
+// CSecondaryTray::_AutoHide hook — block hide in always-show mode.
+using CSecondaryTray__AutoHide_t = void(WINAPI*)(void* pThis, bool param1);
+CSecondaryTray__AutoHide_t CSecondaryTray__AutoHide_Original;
+void WINAPI CSecondaryTray__AutoHide_Hook(void* pThis, bool param1) {
+    if (g_alwaysShowMode) {
+        Wh_Log(L"Blocking auto-hide (always-show mode)");
+        return;
+    }
+
+    CSecondaryTray__AutoHide_Original(pThis, param1);
+}
+
+// TrayUI::Unhide — block in Never mode (mod calls _Original to bypass).
+using TrayUI_Unhide_t = void(WINAPI*)(void* pThis,
+                                      int trayUnhideFlags,
+                                      int unhideRequest);
+TrayUI_Unhide_t TrayUI_Unhide_Original;
+void WINAPI TrayUI_Unhide_Hook(void* pThis,
+                               int trayUnhideFlags,
+                               int unhideRequest) {
+    if (g_settings.mode == AutoHideMode::Never && !g_alwaysShowMode) {
+        Wh_Log(L"Blocking unhide (never mode)");
+        return;
+    }
+
+    TrayUI_Unhide_Original(pThis, trayUnhideFlags, unhideRequest);
+}
+
+// CSecondaryTray::_Unhide — block in Never mode (mod calls _Original to
+// bypass).
+using CSecondaryTray__Unhide_t = void(WINAPI*)(void* pThis,
+                                               int trayUnhideFlags,
+                                               int unhideRequest);
+CSecondaryTray__Unhide_t CSecondaryTray__Unhide_Original;
+void WINAPI CSecondaryTray__Unhide_Hook(void* pThis,
+                                        int trayUnhideFlags,
+                                        int unhideRequest) {
+    if (g_settings.mode == AutoHideMode::Never && !g_alwaysShowMode) {
+        Wh_Log(L"Blocking unhide (never mode)");
+        return;
+    }
+
+    CSecondaryTray__Unhide_Original(pThis, trayUnhideFlags, unhideRequest);
+}
+
+// TrayUI::WndProc hook — capture pThis-to-HWND mapping.
+using TrayUI_WndProc_t = LRESULT(WINAPI*)(void* pThis,
+                                          HWND hWnd,
+                                          UINT Msg,
+                                          WPARAM wParam,
+                                          LPARAM lParam,
+                                          bool* flag);
+TrayUI_WndProc_t TrayUI_WndProc_Original;
+LRESULT WINAPI TrayUI_WndProc_Hook(void* pThis,
+                                   HWND hWnd,
+                                   UINT Msg,
+                                   WPARAM wParam,
+                                   LPARAM lParam,
+                                   bool* flag) {
+    if (Msg == WM_NCCREATE || Msg == g_captureThisMsg) {
+        g_hwndToWndProcPThis[hWnd] = pThis;
+    } else if (Msg == WM_NCDESTROY) {
+        g_hwndToWndProcPThis.erase(hWnd);
+        g_hwndToViewCoordinator.erase(hWnd);
+    }
+
+    return TrayUI_WndProc_Original(pThis, hWnd, Msg, wParam, lParam, flag);
+}
+
+// CSecondaryTray::v_WndProc hook — capture pThis-to-HWND mapping.
+using CSecondaryTray_v_WndProc_t = LRESULT(
+    WINAPI*)(void* pThis, HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+CSecondaryTray_v_WndProc_t CSecondaryTray_v_WndProc_Original;
+LRESULT WINAPI CSecondaryTray_v_WndProc_Hook(void* pThis,
+                                             HWND hWnd,
+                                             UINT Msg,
+                                             WPARAM wParam,
+                                             LPARAM lParam) {
+    if (Msg == WM_NCCREATE || Msg == g_captureThisMsg) {
+        g_hwndToSecondaryPThis[hWnd] = pThis;
+    } else if (Msg == WM_NCDESTROY) {
+        g_hwndToSecondaryPThis.erase(hWnd);
+        g_hwndToViewCoordinator.erase(hWnd);
+    }
+
+    return CSecondaryTray_v_WndProc_Original(pThis, hWnd, Msg, wParam, lParam);
+}
+
+bool g_isPointerOverTaskbarFrame;
+
+using ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_t =
+    void(WINAPI*)(void* pThis,
+                  HWND hMMTaskbarWnd,
+                  bool isPointerOver,
+                  int inputDeviceKind);
+ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_t
+    ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original;
+void WINAPI ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook(
+    void* pThis,
+    HWND hMMTaskbarWnd,
+    bool isPointerOver,
+    int inputDeviceKind) {
+    Wh_Log(L"> isPointerOver=%d", isPointerOver);
+
+    g_isPointerOverTaskbarFrame = isPointerOver;
+
+    ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
+        pThis, hMMTaskbarWnd, isPointerOver, inputDeviceKind);
+
+    g_isPointerOverTaskbarFrame = false;
+
+    // In Never mode, clear the mod-triggered flag when the pointer leaves
+    // so ShouldTaskbarBeExpanded resumes blocking expansion.
+    if (!isPointerOver && g_modTriggeredUnhide) {
+        g_modTriggeredUnhide = false;
+    }
+}
+
+// From ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged.
+constexpr int kReasonIsPointerOverTaskbarFrameChanged = 7;
+// From TaskbarFrame::OnScreenEdgeStrokePointerEntered
+constexpr int kReasonOnScreenEdgeStrokePointerEntered = 8;
+
+using ViewCoordinator_ShouldTaskbarBeExpanded_t =
+    bool(WINAPI*)(void* pThis, HWND hMMTaskbarWnd, bool expanded);
+ViewCoordinator_ShouldTaskbarBeExpanded_t
+    ViewCoordinator_ShouldTaskbarBeExpanded_Original;
+bool WINAPI ViewCoordinator_ShouldTaskbarBeExpanded_Hook(void* pThis,
+                                                         HWND hMMTaskbarWnd,
+                                                         bool expanded) {
+    g_hwndToViewCoordinator[hMMTaskbarWnd] = pThis;
+
+    if (g_alwaysShowMode) {
+        return true;
+    }
+
+    // In Never mode, block all expansion unless the mod triggered it.
+    if (g_settings.mode == AutoHideMode::Never && !g_modTriggeredUnhide) {
+        // Returning false here breaks the taskbar layout with the old auto-hide
+        // implementation.
+        // TODO: test this with the new implementation.
+        // return false;
+    }
+
+    return ViewCoordinator_ShouldTaskbarBeExpanded_Original(
+        pThis, hMMTaskbarWnd, expanded);
+}
+
+using ViewCoordinator_UpdateIsExpanded_t = void(WINAPI*)(void* pThis,
+                                                         HWND hMMTaskbarWnd,
+                                                         int reason);
+ViewCoordinator_UpdateIsExpanded_t ViewCoordinator_UpdateIsExpanded_Original;
+void WINAPI ViewCoordinator_UpdateIsExpanded_Hook(void* pThis,
+                                                  HWND hMMTaskbarWnd,
+                                                  int reason) {
+    Wh_Log(L"> reason=%d", reason);
+
+    if (g_settings.mode != AutoHideMode::WindowsDefault &&
+        ((reason == kReasonIsPointerOverTaskbarFrameChanged &&
+          g_isPointerOverTaskbarFrame) ||
+         reason == kReasonOnScreenEdgeStrokePointerEntered)) {
+        Wh_Log(L"Blocking mouse-triggered unhide");
+        return;
+    }
+
+    ViewCoordinator_UpdateIsExpanded_Original(pThis, hMMTaskbarWnd, reason);
+}
+
+void UpdateViewCoordinatorIsExpanded(HWND hWnd) {
+    if (ViewCoordinator_UpdateIsExpanded_Original) {
+        auto it = g_hwndToViewCoordinator.find(hWnd);
+        if (it != g_hwndToViewCoordinator.end()) {
+            ViewCoordinator_UpdateIsExpanded_Original(
+                it->second, hWnd, kReasonIsPointerOverTaskbarFrameChanged);
+        }
+    }
+}
+
+void ShowTaskbarTemporarily() {
+    Wh_Log(L">");
+
+    if (g_alwaysShowMode) {
+        return;
+    }
+
+    // Only unhide the taskbar on the monitor where the mouse cursor is.
+    POINT pt;
+    GetCursorPos(&pt);
+    HMONITOR cursorMonitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+
+    // Restore any flyouts that were snapped to monitor bottom.
+    RestoreAllSnappedFlyouts();
+
+    // Set before both paths so DwmSetWindowAttribute_Hook and
+    // ShouldTaskbarBeExpanded know the taskbar is shown by the mod.
+    // Cleared by ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook
+    // (Win11) or TrayUI_SlideWindow_Hook when hiding (old taskbar).
+    g_modTriggeredUnhide = true;
+
+    // Old auto-hide path.
+    for (auto& [hWnd, pThis] : g_hwndToWndProcPThis) {
+        if ((HMONITOR)GetProp(hWnd, L"TaskbarMonitor") != cursorMonitor) {
+            continue;
+        }
+        void* pThisHost =
+            QueryViaVtable(pThis, TrayUI_vftable_ITrayComponentHost);
+        TrayUI_Unhide_Original(pThisHost, 0, 0);
+    }
+
+    for (auto& [hWnd, pThis] : g_hwndToSecondaryPThis) {
+        if ((HMONITOR)GetProp(hWnd, L"TaskbarMonitor") != cursorMonitor) {
+            continue;
+        }
+        CSecondaryTray__Unhide_Original(pThis, 0, 0);
+    }
+
+    // Win11 ViewCoordinator path.
+    if (ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original) {
+        for (auto& [hWnd, pThis] : g_hwndToViewCoordinator) {
+            if ((HMONITOR)GetProp(hWnd, L"TaskbarMonitor") != cursorMonitor) {
+                continue;
+            }
+            ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
+                pThis, hWnd, true, 0);
+        }
+    }
+}
+
+void CloakAllTaskbars(BOOL cloak);
+
+void HideAllTaskbars() {
+    std::vector<HWND> secondaryTaskbarWindows;
+    HWND hTaskbarWnd = FindTaskbarWindows(&secondaryTaskbarWindows);
+    if (hTaskbarWnd) {
+        SetTimer(hTaskbarWnd, kTrayUITimerHide, 0, nullptr);
+    }
+    for (HWND hWnd : secondaryTaskbarWindows) {
+        SetTimer(hWnd, kTrayUITimerHide, 0, nullptr);
+    }
+
+    for (auto& [hWnd, pThis] : g_hwndToViewCoordinator) {
+        UpdateViewCoordinatorIsExpanded(hWnd);
+    }
+}
+
+void ToggleAlwaysShow() {
+    g_alwaysShowMode = !g_alwaysShowMode;
+    Wh_Log(L"Always-show mode: %d", g_alwaysShowMode);
+
+    std::vector<HWND> secondaryTaskbarWindows;
+    HWND hTaskbarWnd = FindTaskbarWindows(&secondaryTaskbarWindows);
+
+    if (g_alwaysShowMode) {
+        // Restore any flyouts snapped to monitor bottom.
+        RestoreAllSnappedFlyouts();
+
+        // Kill any pending hide timers.
+        if (hTaskbarWnd) {
+            KillTimer(hTaskbarWnd, kTrayUITimerHide);
+        }
+        for (HWND hWnd : secondaryTaskbarWindows) {
+            KillTimer(hWnd, kTrayUITimerHide);
+        }
+
+        // Uncloak if fully hidden.
+        if (g_settings.mode == AutoHideMode::KeyboardOnlyFullyHide ||
+            g_settings.mode == AutoHideMode::Never) {
+            CloakAllTaskbars(FALSE);
+        }
+
+        // Old auto-hide path.
+        for (auto& [hWnd, pThis] : g_hwndToWndProcPThis) {
+            void* pThisHost =
+                QueryViaVtable(pThis, TrayUI_vftable_ITrayComponentHost);
+            TrayUI_Unhide_Original(pThisHost, 0, 0);
+        }
+
+        for (auto& [hWnd, pThis] : g_hwndToSecondaryPThis) {
+            CSecondaryTray__Unhide_Original(pThis, 0, 0);
+        }
+
+        // Win11 ViewCoordinator path.
+        for (auto& [hWnd, pThis] : g_hwndToViewCoordinator) {
+            UpdateViewCoordinatorIsExpanded(hWnd);
+        }
+    } else {
+        HideAllTaskbars();
+    }
+}
+
+void RegisterHotkeys(HWND hWnd) {
+    UINT modifiers, vk;
+
+    if (!g_settings.showTemporarilyHotkey.empty()) {
+        if (FromStringHotKey(g_settings.showTemporarilyHotkey, &modifiers,
+                             &vk)) {
+            if (RegisterHotKey(hWnd, kHotkeyIdShowTemporarily, modifiers, vk)) {
+                g_showTempHotkeyRegistered = true;
+                Wh_Log(L"Registered show-temporarily hotkey: %s",
+                       g_settings.showTemporarilyHotkey.c_str());
+            } else {
+                Wh_Log(L"Failed to register show-temporarily hotkey: %s",
+                       g_settings.showTemporarilyHotkey.c_str());
+            }
+        } else {
+            Wh_Log(L"Failed to parse show-temporarily hotkey: %s",
+                   g_settings.showTemporarilyHotkey.c_str());
+        }
+    }
+
+    if (!g_settings.toggleAlwaysShowHotkey.empty()) {
+        if (FromStringHotKey(g_settings.toggleAlwaysShowHotkey, &modifiers,
+                             &vk)) {
+            if (RegisterHotKey(hWnd, kHotkeyIdToggleAlwaysShow, modifiers,
+                               vk)) {
+                g_toggleAlwaysHotkeyRegistered = true;
+                Wh_Log(L"Registered toggle-always-show hotkey: %s",
+                       g_settings.toggleAlwaysShowHotkey.c_str());
+            } else {
+                Wh_Log(L"Failed to register toggle-always-show hotkey: %s",
+                       g_settings.toggleAlwaysShowHotkey.c_str());
+            }
+        } else {
+            Wh_Log(L"Failed to parse toggle-always-show hotkey: %s",
+                   g_settings.toggleAlwaysShowHotkey.c_str());
+        }
+    }
+}
+
+void UnregisterHotkeys(HWND hWnd) {
+    if (g_showTempHotkeyRegistered) {
+        UnregisterHotKey(hWnd, kHotkeyIdShowTemporarily);
+        g_showTempHotkeyRegistered = false;
+    }
+
+    if (g_toggleAlwaysHotkeyRegistered) {
+        UnregisterHotKey(hWnd, kHotkeyIdToggleAlwaysShow);
+        g_toggleAlwaysHotkeyRegistered = false;
+    }
+}
+
+void LoadSettings();
+
+// Called on the UI thread via SendMessage(UI_APPLY_SETTINGS).
+void ApplySettingsOnUIThread(HWND hWnd) {
+    UnregisterHotkeys(hWnd);
+
+    AutoHideMode prevMode = g_settings.mode;
+
+    LoadSettings();
+
+    // If always-show was active and all toggle methods were removed, disable it.
+    if (g_alwaysShowMode && g_settings.toggleAlwaysShowHotkey.empty() &&
+        g_settings.toggleAlwaysShowMouseEvent ==
+            ToggleAlwaysShowMouseEvent::Disabled) {
+        g_alwaysShowMode = false;
+        Wh_Log(L"Always-show disabled (toggle methods removed)");
+        HideAllTaskbars();
+    }
+
+    bool wasCloaked = prevMode == AutoHideMode::KeyboardOnlyFullyHide ||
+                      prevMode == AutoHideMode::Never;
+    bool isCloaked = g_settings.mode == AutoHideMode::KeyboardOnlyFullyHide ||
+                     g_settings.mode == AutoHideMode::Never;
+    if (isCloaked != wasCloaked) {
+        CloakAllTaskbars(isCloaked ? TRUE : FALSE);
+    }
+
+    // When leaving Never mode, restore any flyouts that were snapped to the
+    // monitor bottom back to their natural position (with taskbar gap).
+    if (prevMode == AutoHideMode::Never &&
+        g_settings.mode != AutoHideMode::Never) {
+        RestoreAllSnappedFlyouts();
+    }
+
+    RegisterHotkeys(hWnd);
+}
+
+// Called on the UI thread via SendMessage(UI_BEFORE_UNINIT).
+void BeforeUninitCleanupOnUIThread(HWND hWnd) {
+    if (g_alwaysShowMode) {
+        g_alwaysShowMode = false;
+        HideAllTaskbars();
+    }
+
+    // Restore flyouts snapped to monitor bottom back to their natural position.
+    if (g_settings.mode == AutoHideMode::Never) {
+        RestoreAllSnappedFlyouts();
+    }
+
+    UnregisterHotkeys(hWnd);
+}
+
+LRESULT CALLBACK TaskbarSubclassProc(HWND hWnd,
+                                     UINT uMsg,
+                                     WPARAM wParam,
+                                     LPARAM lParam,
+                                     DWORD_PTR dwRefData) {
+    if (uMsg == WM_HOTKEY) {
+        if ((int)wParam == kHotkeyIdShowTemporarily) {
+            Wh_Log(L"Show-temporarily hotkey triggered");
+            ShowTaskbarTemporarily();
+            return 0;
+        } else if ((int)wParam == kHotkeyIdToggleAlwaysShow) {
+            Wh_Log(L"Toggle-always-show hotkey triggered");
+            ToggleAlwaysShow();
+            return 0;
+        }
+    }
+
+    if (uMsg == g_uiThreadCallbackMsg) {
+        switch (wParam) {
+            case UI_REGISTER_HOTKEYS:
+                RegisterHotkeys(hWnd);
+                break;
+            case UI_UNREGISTER_HOTKEYS:
+                UnregisterHotkeys(hWnd);
+                break;
+            case UI_APPLY_SETTINGS:
+                ApplySettingsOnUIThread(hWnd);
+                break;
+            case UI_BEFORE_UNINIT:
+                BeforeUninitCleanupOnUIThread(hWnd);
+                break;
+        }
+        return 0;
+    }
+
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+// Double-click state for mouse toggle.
+DWORD g_lastPressTime;
+
+using TaskbarFrame_OnPointerPressed_t = int(WINAPI*)(void* pThis, void* pArgs);
+TaskbarFrame_OnPointerPressed_t TaskbarFrame_OnPointerPressed_Original;
+int TaskbarFrame_OnPointerPressed_Hook(void* pThis, void* pArgs) {
+    Wh_Log(L">");
+
+    auto original = [=]() {
+        return TaskbarFrame_OnPointerPressed_Original(pThis, pArgs);
+    };
+
+    if (g_settings.toggleAlwaysShowMouseEvent ==
+        ToggleAlwaysShowMouseEvent::Disabled) {
+        return original();
+    }
+
+    winrt::Windows::UI::Xaml::UIElement taskbarFrame = nullptr;
+    ((IUnknown*)pThis)
+        ->QueryInterface(winrt::guid_of<winrt::Windows::UI::Xaml::UIElement>(),
+                         winrt::put_abi(taskbarFrame));
+
+    if (!taskbarFrame) {
+        return original();
+    }
+
+    if (winrt::get_class_name(taskbarFrame) != L"Taskbar.TaskbarFrame") {
+        return original();
+    }
+
+    winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs args{nullptr};
+    winrt::copy_from_abi(args, pArgs);
+    if (!args) {
+        return original();
+    }
+
+    auto properties = args.GetCurrentPoint(taskbarFrame).Properties();
+
+    bool shouldToggle = false;
+
+    if (g_settings.toggleAlwaysShowMouseEvent ==
+        ToggleAlwaysShowMouseEvent::MiddleClick) {
+        if (properties.IsMiddleButtonPressed()) {
+            shouldToggle = true;
+        }
+    } else if (g_settings.toggleAlwaysShowMouseEvent ==
+               ToggleAlwaysShowMouseEvent::DoubleClick) {
+        DWORD now = GetTickCount();
+        if (now - g_lastPressTime <= GetDoubleClickTime()) {
+            g_lastPressTime = 0;
+            shouldToggle = true;
+        } else {
+            g_lastPressTime = now;
+        }
+    }
+
+    if (!shouldToggle) {
+        return original();
+    }
+
+    ToggleAlwaysShow();
+
+    args.Handled(true);
+    return 0;
+}
+
+bool HookTaskbarViewDllSymbols(HMODULE module) {
+    // Taskbar.View.dll, ExplorerExtensions.dll
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {LR"(public: void __cdecl winrt::Taskbar::implementation::ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged(unsigned __int64,bool,enum winrt::WindowsUdk::UI::Shell::InputDeviceKind))"},
+            &ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original,
+            ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook,
+            true,
+        },
+        {
+            {LR"(public: bool __cdecl winrt::Taskbar::implementation::ViewCoordinator::ShouldTaskbarBeExpanded(unsigned __int64,bool))"},
+            &ViewCoordinator_ShouldTaskbarBeExpanded_Original,
+            ViewCoordinator_ShouldTaskbarBeExpanded_Hook,
+            true,
+        },
+        {
+            {LR"(public: void __cdecl winrt::Taskbar::implementation::ViewCoordinator::UpdateIsExpanded(unsigned __int64,enum TaskbarTipTest::TaskbarExpandCollapseReason))"},
+            &ViewCoordinator_UpdateIsExpanded_Original,
+            ViewCoordinator_UpdateIsExpanded_Hook,
+            true,
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskbarFrame,struct winrt::Windows::UI::Xaml::Controls::IControlOverrides>::OnPointerPressed(void *))"},
+            &TaskbarFrame_OnPointerPressed_Original,
+            TaskbarFrame_OnPointerPressed_Hook,
+            true,
+        },
+    };
+
+    if (!HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks))) {
+        Wh_Log(L"HookSymbols failed");
+        return false;
+    }
+
+    return true;
+}
+
+HMODULE GetTaskbarViewModuleHandle() {
+    HMODULE module = GetModuleHandle(L"Taskbar.View.dll");
+    if (!module) {
+        module = GetModuleHandle(L"ExplorerExtensions.dll");
+    }
+
+    return module;
+}
+
+void HandleLoadedModuleIfTaskbarView(HMODULE module, LPCWSTR lpLibFileName) {
+    if (g_winVersion >= WinVersion::Win11 && !g_taskbarViewDllLoaded &&
+        GetTaskbarViewModuleHandle() == module &&
+        !g_taskbarViewDllLoaded.exchange(true)) {
+        Wh_Log(L"Loaded %s", lpLibFileName);
+
+        if (HookTaskbarViewDllSymbols(module)) {
+            Wh_ApplyHookOperations();
+        }
     }
 }
 
@@ -210,9 +1383,47 @@ bool HookTaskbarSymbols() {
     // Taskbar.dll, explorer.exe
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
+            {LR"(const TrayUI::`vftable'{for `ITrayComponentHost'})"},
+            &TrayUI_vftable_ITrayComponentHost,
+        },
+        {
+            {LR"(const CSecondaryTray::`vftable'{for `ISecondaryTray'})"},
+            &CSecondaryTray_vftable_ISecondaryTray,
+        },
+        {
             {LR"(public: virtual void __cdecl TrayUI::SlideWindow(struct HWND__ *,struct tagRECT const *,struct HMONITOR__ *,bool,bool))"},
             &TrayUI_SlideWindow_Original,
             TrayUI_SlideWindow_Hook,
+        },
+        {
+            {LR"(public: void __cdecl TrayUI::_Hide(void))"},
+            &TrayUI__Hide_Original,
+            TrayUI__Hide_Hook,
+        },
+        {
+            {LR"(private: void __cdecl CSecondaryTray::_AutoHide(bool))"},
+            &CSecondaryTray__AutoHide_Original,
+            CSecondaryTray__AutoHide_Hook,
+        },
+        {
+            {LR"(public: virtual void __cdecl TrayUI::Unhide(enum TrayCommon::TrayUnhideFlags,enum TrayCommon::UnhideRequest))"},
+            &TrayUI_Unhide_Original,
+            TrayUI_Unhide_Hook,
+        },
+        {
+            {LR"(private: void __cdecl CSecondaryTray::_Unhide(enum TrayCommon::TrayUnhideFlags,enum TrayCommon::UnhideRequest))"},
+            &CSecondaryTray__Unhide_Original,
+            CSecondaryTray__Unhide_Hook,
+        },
+        {
+            {LR"(public: virtual __int64 __cdecl TrayUI::WndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64,bool *))"},
+            &TrayUI_WndProc_Original,
+            TrayUI_WndProc_Hook,
+        },
+        {
+            {LR"(private: virtual __int64 __cdecl CSecondaryTray::v_WndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64))"},
+            &CSecondaryTray_v_WndProc_Original,
+            CSecondaryTray_v_WndProc_Hook,
         },
     };
 
@@ -307,8 +1518,26 @@ bool HookExplorerPatcherSymbols(HMODULE explorerPatcherModule) {
     }
 
     EXPLORER_PATCHER_HOOK hooks[] = {
+        {R"(??_7TrayUI@@6BITrayComponentHost@@@)",
+         &TrayUI_vftable_ITrayComponentHost},
+        {R"(??_7CSecondaryTray@@6BISecondaryTray@@@)",
+         &CSecondaryTray_vftable_ISecondaryTray},
         {R"(?SlideWindow@TrayUI@@UEAAXPEAUHWND__@@PEBUtagRECT@@PEAUHMONITOR__@@_N3@Z)",
          &TrayUI_SlideWindow_Original, TrayUI_SlideWindow_Hook},
+        {R"(?_Hide@TrayUI@@QEAAXXZ)", &TrayUI__Hide_Original,
+         TrayUI__Hide_Hook},
+        {R"(?_AutoHide@CSecondaryTray@@AEAAX_N@Z)",
+         &CSecondaryTray__AutoHide_Original, CSecondaryTray__AutoHide_Hook},
+        {R"(?Unhide@TrayUI@@UEAAXW4TrayUnhideFlags@TrayCommon@@W4UnhideRequest@3@@Z)",
+         &TrayUI_Unhide_Original, TrayUI_Unhide_Hook},
+        {R"(?_Unhide@CSecondaryTray@@AEAAXW4TrayUnhideFlags@TrayCommon@@W4UnhideRequest@3@@Z)",
+         &CSecondaryTray__Unhide_Original, CSecondaryTray__Unhide_Hook},
+        {R"(?WndProc@TrayUI@@UEAA_JPEAUHWND__@@I_K_JPEA_N@Z)",
+         &TrayUI_WndProc_Original, TrayUI_WndProc_Hook},
+        {R"(?v_WndProc@CSecondaryTray@@EEAA_JPEAUHWND__@@I_K_J@Z)",
+         &CSecondaryTray_v_WndProc_Original, CSecondaryTray_v_WndProc_Hook,
+         // Available in versions newer than 67.1.
+         true},
     };
 
     bool succeeded = true;
@@ -380,24 +1609,63 @@ bool HandleLoadedExplorerPatcher() {
     return true;
 }
 
+void HandleLoadedModuleIfExplorerPatcher(HMODULE module) {
+    if (module && !((ULONG_PTR)module & 3) && !g_explorerPatcherInitialized) {
+        if (IsExplorerPatcherModule(module)) {
+            HookExplorerPatcherSymbols(module);
+        }
+    }
+}
+
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 LoadLibraryExW_t LoadLibraryExW_Original;
 HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
                                    HANDLE hFile,
                                    DWORD dwFlags) {
     HMODULE module = LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
-    if (module && !((ULONG_PTR)module & 3) && !g_explorerPatcherInitialized) {
-        if (IsExplorerPatcherModule(module)) {
-            HookExplorerPatcherSymbols(module);
-        }
+    if (module) {
+        HandleLoadedModuleIfExplorerPatcher(module);
+        HandleLoadedModuleIfTaskbarView(module, lpLibFileName);
     }
 
     return module;
 }
 
 void LoadSettings() {
-    g_settings.fullyHide = Wh_GetIntSetting(L"fullyHide");
+    PCWSTR mode = Wh_GetStringSetting(L"mode");
+    if (wcscmp(mode, L"windowsDefault") == 0) {
+        g_settings.mode = AutoHideMode::WindowsDefault;
+    } else if (wcscmp(mode, L"keyboardOnlyFullyHide") == 0) {
+        g_settings.mode = AutoHideMode::KeyboardOnlyFullyHide;
+    } else if (wcscmp(mode, L"never") == 0) {
+        g_settings.mode = AutoHideMode::Never;
+    } else {
+        g_settings.mode = AutoHideMode::KeyboardOnlyShowOnClick;
+    }
+    Wh_FreeStringSetting(mode);
+
     g_settings.oldTaskbarOnWin11 = Wh_GetIntSetting(L"oldTaskbarOnWin11");
+
+    PCWSTR showTemp = Wh_GetStringSetting(L"showTemporarilyHotkey");
+    g_settings.showTemporarilyHotkey = showTemp;
+    Wh_FreeStringSetting(showTemp);
+
+    PCWSTR toggleAlways = Wh_GetStringSetting(L"toggleAlwaysShowHotkey");
+    g_settings.toggleAlwaysShowHotkey = toggleAlways;
+    Wh_FreeStringSetting(toggleAlways);
+
+    PCWSTR mouseEvent = Wh_GetStringSetting(L"toggleAlwaysShowMouseEvent");
+    if (wcscmp(mouseEvent, L"middleClick") == 0) {
+        g_settings.toggleAlwaysShowMouseEvent =
+            ToggleAlwaysShowMouseEvent::MiddleClick;
+    } else if (wcscmp(mouseEvent, L"doubleClick") == 0) {
+        g_settings.toggleAlwaysShowMouseEvent =
+            ToggleAlwaysShowMouseEvent::DoubleClick;
+    } else {
+        g_settings.toggleAlwaysShowMouseEvent =
+            ToggleAlwaysShowMouseEvent::Disabled;
+    }
+    Wh_FreeStringSetting(mouseEvent);
 }
 
 BOOL Wh_ModInit() {
@@ -421,8 +1689,21 @@ BOOL Wh_ModInit() {
         if (hasWin10Taskbar && !HookTaskbarSymbols()) {
             return FALSE;
         }
-    } else if (!HookTaskbarSymbols()) {
-        return FALSE;
+    } else {
+        if (!HookTaskbarSymbols()) {
+            return FALSE;
+        }
+
+        if (g_winVersion >= WinVersion::Win11) {
+            if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
+                g_taskbarViewDllLoaded = true;
+                if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
+                    return FALSE;
+                }
+            } else {
+                Wh_Log(L"Taskbar view module not loaded yet");
+            }
+        }
     }
 
     if (!HandleLoadedExplorerPatcher()) {
@@ -433,12 +1714,15 @@ BOOL Wh_ModInit() {
     HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
     auto pKernelBaseLoadLibraryExW = (decltype(&LoadLibraryExW))GetProcAddress(
         kernelBaseModule, "LoadLibraryExW");
-    WindhawkUtils::Wh_SetFunctionHookT(pKernelBaseLoadLibraryExW,
-                                       LoadLibraryExW_Hook,
-                                       &LoadLibraryExW_Original);
+    WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
+                                   LoadLibraryExW_Hook,
+                                   &LoadLibraryExW_Original);
 
-    WindhawkUtils::Wh_SetFunctionHookT(SetTimer, SetTimer_Hook,
-                                       &SetTimer_Original);
+    WindhawkUtils::SetFunctionHook(SetTimer, SetTimer_Hook, &SetTimer_Original);
+
+    WindhawkUtils::SetFunctionHook(DwmSetWindowAttribute,
+                                   DwmSetWindowAttribute_Hook,
+                                   &DwmSetWindowAttribute_Original);
 
     g_initialized = true;
 
@@ -448,7 +1732,9 @@ BOOL Wh_ModInit() {
 void CloakAllTaskbars(BOOL cloak) {
     std::vector<HWND> secondaryTaskbarWindows;
     HWND taskbarWindow = FindTaskbarWindows(&secondaryTaskbarWindows);
-    CloakWindow(taskbarWindow, cloak);
+    if (taskbarWindow) {
+        CloakWindow(taskbarWindow, cloak);
+    }
     for (HWND hWnd : secondaryTaskbarWindows) {
         CloakWindow(hWnd, cloak);
     }
@@ -457,39 +1743,95 @@ void CloakAllTaskbars(BOOL cloak) {
 void Wh_ModAfterInit() {
     Wh_Log(L">");
 
+    if (g_winVersion >= WinVersion::Win11 && !g_taskbarViewDllLoaded) {
+        if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
+            if (!g_taskbarViewDllLoaded.exchange(true)) {
+                Wh_Log(L"Got Taskbar.View.dll");
+
+                if (HookTaskbarViewDllSymbols(taskbarViewModule)) {
+                    Wh_ApplyHookOperations();
+                }
+            }
+        }
+    }
+
     // Try again in case there's a race between the previous attempt and the
     // LoadLibraryExW hook.
     if (!g_explorerPatcherInitialized) {
         HandleLoadedExplorerPatcher();
     }
 
-    if (g_settings.fullyHide) {
+    if (g_settings.mode == AutoHideMode::KeyboardOnlyFullyHide ||
+        g_settings.mode == AutoHideMode::Never) {
         CloakAllTaskbars(TRUE);
+    }
+
+    // Send a message to each taskbar window to trigger the WndProc hooks
+    // and populate pThis maps (WM_NCCREATE already fired before mod loaded).
+    {
+        std::vector<HWND> secondaryTaskbarWindows;
+        HWND hTaskbarWnd = FindTaskbarWindows(&secondaryTaskbarWindows);
+        if (hTaskbarWnd) {
+            SendMessage(hTaskbarWnd, g_captureThisMsg, 0, 0);
+        }
+        for (HWND hWnd : secondaryTaskbarWindows) {
+            SendMessage(hWnd, g_captureThisMsg, 0, 0);
+        }
+    }
+
+    // Subclass the taskbar window and register hotkeys.
+    g_hTaskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (g_hTaskbarWnd) {
+        if (WindhawkUtils::SetWindowSubclassFromAnyThread(
+                g_hTaskbarWnd, TaskbarSubclassProc, 0)) {
+            Wh_Log(L"Taskbar window %p subclassed", g_hTaskbarWnd);
+        } else {
+            Wh_Log(L"Failed to subclass taskbar window %p", g_hTaskbarWnd);
+        }
+
+        SendMessage(g_hTaskbarWnd, g_uiThreadCallbackMsg, UI_REGISTER_HOTKEYS,
+                    0);
+    }
+}
+
+void Wh_ModBeforeUninit() {
+    Wh_Log(L">");
+
+    if (g_hTaskbarWnd) {
+        SendMessage(g_hTaskbarWnd, g_uiThreadCallbackMsg, UI_BEFORE_UNINIT, 0);
     }
 }
 
 void Wh_ModUninit() {
     Wh_Log(L">");
 
-    if (g_settings.fullyHide) {
+    if (g_hTaskbarWnd) {
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(g_hTaskbarWnd,
+                                                         TaskbarSubclassProc);
+        g_hTaskbarWnd = nullptr;
+    }
+
+    if (g_settings.mode == AutoHideMode::KeyboardOnlyFullyHide ||
+        g_settings.mode == AutoHideMode::Never) {
         CloakAllTaskbars(FALSE);
     }
+
+    g_hwndToWndProcPThis.clear();
+    g_hwndToSecondaryPThis.clear();
+    g_hwndToViewCoordinator.clear();
 }
 
 BOOL Wh_ModSettingsChanged(BOOL* bReload) {
     Wh_Log(L">");
 
     bool prevOldTaskbarOnWin11 = g_settings.oldTaskbarOnWin11;
-    bool prevFullyHide = g_settings.fullyHide;
 
-    LoadSettings();
-
-    if (g_settings.fullyHide != prevFullyHide) {
-        if (g_settings.fullyHide) {
-            CloakAllTaskbars(TRUE);
-        } else {
-            CloakAllTaskbars(FALSE);
-        }
+    // All UI work (unregister old hotkeys, load settings, cloak/uncloak,
+    // register new hotkeys) runs on the UI thread.
+    if (g_hTaskbarWnd) {
+        SendMessage(g_hTaskbarWnd, g_uiThreadCallbackMsg, UI_APPLY_SETTINGS, 0);
+    } else {
+        LoadSettings();
     }
 
     *bReload = g_settings.oldTaskbarOnWin11 != prevOldTaskbarOnWin11;


### PR DESCRIPTION
* Renamed from "Taskbar keyboard-only auto-hide" to "Taskbar auto-hide fine tuning".
* Added multiple auto-hide modes: Keyboard or mouse click, Keyboard only (previously "Fully hide"), and Never (blocks all unhiding including notifications and Win key).
* Added configurable hotkeys for showing the taskbar temporarily and toggling permanent visibility (always-show mode).
* Added a mouse event option (middle click or double click) on the Win11 taskbar to toggle always-show mode.