### PR TITLE
virtual-desktop-helper v2.4.0: clarify Previous/Next/Last desktop naming (#3176)

### DIFF
--- a/mods/virtual-desktop-helper.wh.cpp
+++ b/mods/virtual-desktop-helper.wh.cpp
@@ -2,7 +2,7 @@
 // @id              virtual-desktop-helper
 // @name            Virtual Desktop Helper
 // @description     Switch virtual desktops, move windows between desktops, and pin windows with customizable hotkeys
-// @version         2.3.0
+// @version         2.4.0
 // @author          u2x1
 // @github          https://github.com/u2x1
 // @include         windhawk.exe
@@ -22,8 +22,8 @@ Based on VD.ahk by FuPeiJiang.
 ### Virtual Desktop Management
 - **Quick Switch**: Jump directly to any desktop (1-9) with a single hotkey
 - **Move Windows**: Send the active window to any desktop instantly
-- **Previous Desktop (Index)**: Switch to the previous desktop (idx-1, wraps around)
-- **Next Desktop (Index)**: Switch to the next desktop (idx+1, wraps around)
+- **Previous Desktop**: Switch to the previous desktop by index (wraps around)
+- **Next Desktop**: Switch to the next desktop by index (wraps around)
 - **Last Desktop**: Toggle back to the last visited desktop
 - **Pin Windows**: Pin/unpin windows to appear on all desktops
 
@@ -33,12 +33,14 @@ Based on VD.ahk by FuPeiJiang.
 |--------|----------------|
 | Switch to desktop 1-9 | `Alt + 1-9` |
 | Move window to desktop 1-9 | `Alt + Shift + 1-9` |
-| Switch to previous desktop (idx-1) | `Alt + Z` (configurable modifier) |
-| Switch to next desktop (idx+1) | `Alt + X` (configurable modifier) |
-| Toggle last desktop | `Alt + Q` (configurable modifier) |
+| Switch to previous desktop | `Alt + Z` (configurable modifier) |
+| Switch to next desktop | `Alt + X` (configurable modifier) |
+| Switch to last visited desktop | `Alt + Q` (configurable modifier) |
 | Pin/unpin window | `Alt + P` (configurable modifier) |
 
-Note: The modifier for utility hotkeys (Previous/Next Desktop (Index), Last Desktop, Pin) can be changed in settings. Previous/next cycling is limited by the "Maximum Desktops" setting.
+Note: The modifier for all hotkey groups can be freely configured using any combination of Alt, Ctrl, Shift, and Win keys. Previous/next desktop cycling is limited by the "Maximum Desktops" setting.
+
+**⚠️ Win key note:** Win+number keys conflict with Windows taskbar shortcuts. If it doesn't work for you, you may need to disable these Win-combinations by yourself.
 
 ## Customization
 
@@ -48,7 +50,7 @@ Settings are organized by feature. Each feature has an **Enable** toggle and its
 
 - **[Switch Desktop]** - Alt+1-9 to switch desktops
 - **[Move Window]** - Alt+Shift+1-9 to move windows between desktops
-- **[Prev/Next Desktop]** - Previous/next by index and last-desktop toggle (Alt+Z, Alt+X, Alt+Q by default)
+- **[Previous/Next/Last Desktop]** - Previous/next desktop by index and last-visited desktop toggle (Alt+Z, Alt+X, Alt+Q by default)
 - **[Pin Window]** - Pin/unpin windows to all desktops (Alt+P by default)
 ### Key Binding Format
 
@@ -84,6 +86,10 @@ Select your Windows version in settings for correct functionality:
 - Windows 11 (Build 22621/22631/23H2)
 - Windows 11 (Build 26100+ / 24H2)
 
+## See Also
+
+- [Tiling Helper](https://windhawk.net/mods/tiling-helper) - Tiling window management
+
 */
 // ==/WindhawkModReadme==
 
@@ -105,13 +111,7 @@ Select your Windows version in settings for correct functionality:
 
 - SwitchDesktopModifier: alt
   $name: '[Switch Desktop] Modifier'
-  $description: Modifier keys for switching to desktop (combined with number keys 1-9)
-  $options:
-    - alt: Alt
-    - ctrl: Ctrl
-    - alt+shift: Alt + Shift
-    - ctrl+alt: Ctrl + Alt
-    - ctrl+shift: Ctrl + Shift
+  $description: 'Modifier keys for switching to desktop (combined with number keys 1-9). Combine with +: alt, ctrl, shift, win. Examples: alt, ctrl+shift, win+alt'
 
 - EnableMoveWindow: true
   $name: '[Move Window] Enable'
@@ -119,11 +119,7 @@ Select your Windows version in settings for correct functionality:
 
 - MoveWindowModifier: alt+shift
   $name: '[Move Window] Modifier'
-  $description: Modifier keys for moving active window to desktop (combined with number keys 1-9)
-  $options:
-    - alt+shift: Alt + Shift
-    - ctrl+alt: Ctrl + Alt
-    - ctrl+shift: Ctrl + Shift
+  $description: 'Modifier keys for moving active window to desktop (combined with number keys 1-9). Combine with +: alt, ctrl, shift, win. Examples: alt+shift, ctrl+alt, win+shift'
 
 - FollowMovedWindow: false
   $name: Follow Moved Window
@@ -134,30 +130,24 @@ Select your Windows version in settings for correct functionality:
   $description: Number of desktops to register hotkeys for (1-9). Set lower if you use fewer desktops to avoid hotkey conflicts.
 
 - EnablePrevNextDesktop: true
-  $name: '[Prev/Next Desktop] Enable'
-  $description: Enable hotkeys to cycle between desktops
+  $name: '[Previous/Next/Last Desktop] Enable'
+  $description: Enable hotkeys to cycle between desktops and toggle to the last visited desktop
 
 - UtilityModifier: alt
-  $name: '[Prev/Next Desktop] Modifier'
-  $description: Modifier keys for previous/next desktop hotkeys
-  $options:
-    - alt: Alt
-    - ctrl: Ctrl
-    - alt+shift: Alt + Shift
-    - ctrl+alt: Ctrl + Alt
-    - ctrl+shift: Ctrl + Shift
+  $name: '[Previous/Next/Last Desktop] Modifier'
+  $description: 'Modifier keys for previous/next/last desktop hotkeys. Combine with +: alt, ctrl, shift, win. Examples: alt, ctrl+shift, win'
 
-- PrevDesktopKey: "Q"
-  $name: '[Prev/Next Desktop] Last Desktop Key'
-  $description: 'Key to toggle back to the last visited desktop. Examples: Q, F, ~, !, [, Tab, Space'
-
-- PrevIndexKey: "Z"
-  $name: '[Prev/Next Desktop] Previous Desktop (Index) Key'
-  $description: 'Key to switch to the previous desktop by index (idx-1, wraps around). Examples: Z, A, <, ,, Tab'
+- PrevDesktopKey: "Z"
+  $name: '[Previous/Next/Last Desktop] Previous Desktop Key'
+  $description: 'Key to switch to the previous desktop by index (wraps around). Examples: Z, A, <, ,, Tab'
 
 - NextDesktopKey: "X"
-  $name: '[Prev/Next Desktop] Next Key'
-  $description: 'Key to switch to the next desktop (wraps around). Examples: X, E, N, Z, @, ], Enter'
+  $name: '[Previous/Next/Last Desktop] Next Desktop Key'
+  $description: 'Key to switch to the next desktop by index (wraps around). Examples: X, E, N, Z, @, ], Enter'
+
+- LastDesktopKey: "Q"
+  $name: '[Previous/Next/Last Desktop] Last Desktop Key'
+  $description: 'Key to toggle back to the last visited desktop. Examples: Q, F, ~, !, [, Tab, Space'
 
 - EnablePinWindow: true
   $name: '[Pin Window] Enable'
@@ -327,22 +317,22 @@ static bool g_hasPreviousDesktop = false;
 // Hotkey ID ranges:
 // HK_MOVE_BASE (1-9): Move window to desktop 1-9
 // HK_SWITCH_BASE (10-18): Switch to desktop 1-9
-// HK_PREV (19): Toggle to previous desktop
+// HK_LAST (19): Toggle to last visited desktop
 // HK_PIN (20): Pin/unpin current window
 // HK_NEXT (21): Switch to next desktop (wrap around)
-// HK_PREV_INDEX (22): Switch to previous desktop by index (wrap around)
+// HK_PREV (22): Switch to previous desktop by index (wrap around)
 enum HotkeyIds {
   HK_MOVE_BASE = 1,
   HK_SWITCH_BASE = 10,
-  HK_PREV = 19,
+  HK_LAST = 19,
   HK_PIN = 20,
   HK_NEXT = 21,
-  HK_PREV_INDEX = 22
+  HK_PREV = 22
 };
 
-static UINT g_prevDesktopKey = 'Q';
-static UINT g_prevIndexKey = 'Z';
+static UINT g_prevDesktopKey = 'Z';
 static UINT g_nextDesktopKey = 'X';
+static UINT g_lastDesktopKey = 'Q';
 static UINT g_pinKey = 'P';
 
 static bool g_enableSwitchDesktop = true;
@@ -390,6 +380,7 @@ UINT ParseModifiers(PCWSTR str) {
   if (wcsstr(str, L"alt")) modifiers |= MOD_ALT;
   if (wcsstr(str, L"ctrl")) modifiers |= MOD_CONTROL;
   if (wcsstr(str, L"shift")) modifiers |= MOD_SHIFT;
+  if (wcsstr(str, L"win")) modifiers |= MOD_WIN;
   return modifiers;
 }
 
@@ -419,6 +410,8 @@ T ReadStringSetting(PCWSTR name, Parser parser, T defaultVal) {
 UINT ReadModifierSetting(PCWSTR name, UINT defaultVal) {
   PCWSTR str = Wh_GetStringSetting(name);
   UINT result = ParseModifiers(str);
+  Wh_Log(L"ReadModifierSetting: name=%s, raw=\"%s\", parsed=0x%X, default=0x%X, using=0x%X",
+         name, str, result, defaultVal, result ? result : defaultVal);
   Wh_FreeStringSetting(str);
   return result ? result : defaultVal;
 }
@@ -478,6 +471,9 @@ void LoadSettings() {
   g_switchModifiers = ReadModifierSetting(L"SwitchDesktopModifier", MOD_ALT);
   g_utilityModifiers = ReadModifierSetting(L"UtilityModifier", MOD_ALT);
 
+  Wh_Log(L"LoadSettings: moveModifiers=0x%X, switchModifiers=0x%X, utilityModifiers=0x%X",
+         g_moveModifiers, g_switchModifiers, g_utilityModifiers);
+
   g_followMovedWindow = Wh_GetIntSetting(L"FollowMovedWindow") != 0;
   g_maxDesktops = Wh_GetIntSetting(L"MaxDesktops");
   if (g_maxDesktops < 1 || g_maxDesktops > 9) g_maxDesktops = 9;
@@ -489,9 +485,9 @@ void LoadSettings() {
   g_enablePinWindow = Wh_GetIntSetting(L"EnablePinWindow") != 0;
 
   // Load hotkey settings (single character input supporting A-Z, 0-9, and special chars)
-  g_prevDesktopKey = ReadStringSetting(L"PrevDesktopKey", ParseSingleCharKey, (UINT)'Q');
-  g_prevIndexKey = ReadStringSetting(L"PrevIndexKey", ParseSingleCharKey, (UINT)'Z');
+  g_prevDesktopKey = ReadStringSetting(L"PrevDesktopKey", ParseSingleCharKey, (UINT)'Z');
   g_nextDesktopKey = ReadStringSetting(L"NextDesktopKey", ParseSingleCharKey, (UINT)'X');
+  g_lastDesktopKey = ReadStringSetting(L"LastDesktopKey", ParseSingleCharKey, (UINT)'Q');
   g_pinKey = ReadStringSetting(L"PinKey", ParseSingleCharKey, (UINT)'P');
 }
 
@@ -843,7 +839,7 @@ bool GoToDesktopNum(int desktopNum, HWND preferredFocusHwnd = nullptr) {
   return success;
 }
 
-bool SwitchToPreviousDesktop() {
+bool SwitchToLastDesktop() {
   if (!g_hasPreviousDesktop) return false;
   if (!InitializeVirtualDesktopAPI()) return false;
 
@@ -861,28 +857,28 @@ bool SwitchToPreviousDesktop() {
   return GoToDesktopNum(index + 1);
 }
 
-bool SwitchToPreviousIndexDesktop() {
-  Wh_Log(L"SwitchToPreviousIndexDesktop called");
+bool SwitchToPreviousDesktop() {
+  Wh_Log(L"SwitchToPreviousDesktop called");
   if (!InitializeVirtualDesktopAPI()) {
-    Wh_Log(L"SwitchToPreviousIndexDesktop: API not initialized");
+    Wh_Log(L"SwitchToPreviousDesktop: API not initialized");
     return false;
   }
 
   GUID currentDesktopId = {};
   if (!GetCurrentDesktopId(&currentDesktopId)) {
-    Wh_Log(L"SwitchToPreviousIndexDesktop: Failed to get current desktop ID");
+    Wh_Log(L"SwitchToPreviousDesktop: Failed to get current desktop ID");
     return false;
   }
 
   int currentIndex = GetDesktopIndexById(currentDesktopId);
   if (currentIndex < 0) {
-    Wh_Log(L"SwitchToPreviousIndexDesktop: Invalid current index");
+    Wh_Log(L"SwitchToPreviousDesktop: Invalid current index");
     return false;
   }
 
   IObjectArray* desktops = GetDesktops();
   if (!desktops) {
-    Wh_Log(L"SwitchToPreviousIndexDesktop: Failed to get desktops");
+    Wh_Log(L"SwitchToPreviousDesktop: Failed to get desktops");
     return false;
   }
 
@@ -890,7 +886,7 @@ bool SwitchToPreviousIndexDesktop() {
   desktops->GetCount(&desktopCount);
   desktops->Release();
 
-  Wh_Log(L"SwitchToPreviousIndexDesktop: currentIndex=%d, desktopCount=%u, maxDesktops=%d", currentIndex,
+  Wh_Log(L"SwitchToPreviousDesktop: currentIndex=%d, desktopCount=%u, maxDesktops=%d", currentIndex,
          desktopCount, g_maxDesktops);
 
   int cycleCount = (int)desktopCount;
@@ -898,7 +894,7 @@ bool SwitchToPreviousIndexDesktop() {
   if (cycleCount <= 0) return false;
 
   int prevIndex = (currentIndex - 1 + cycleCount) % cycleCount;
-  Wh_Log(L"SwitchToPreviousIndexDesktop: Switching to desktop %d", prevIndex + 1);
+  Wh_Log(L"SwitchToPreviousDesktop: Switching to desktop %d", prevIndex + 1);
   return GoToDesktopNum(prevIndex + 1);
 }
 
@@ -1027,21 +1023,34 @@ DWORD WINAPI HotkeyThreadProc(LPVOID) {
 
   if (g_enableMoveWindow) {
     for (int i = 1; i <= g_maxDesktops; ++i) {
-      RegisterHotKey(nullptr, HK_MOVE_BASE + i - 1, g_moveModifiers, '0' + i);
+      BOOL ok = RegisterHotKey(nullptr, HK_MOVE_BASE + i - 1, g_moveModifiers, '0' + i);
+      Wh_Log(L"RegisterHotKey MOVE_%d: modifiers=0x%X, vk=0x%X, result=%d, error=%lu",
+             i, g_moveModifiers, '0' + i, ok, ok ? 0 : GetLastError());
     }
   }
   if (g_enableSwitchDesktop) {
     for (int i = 1; i <= g_maxDesktops; ++i) {
-      RegisterHotKey(nullptr, HK_SWITCH_BASE + i - 1, g_switchModifiers, '0' + i);
+      BOOL ok = RegisterHotKey(nullptr, HK_SWITCH_BASE + i - 1, g_switchModifiers, '0' + i);
+      Wh_Log(L"RegisterHotKey SWITCH_%d: modifiers=0x%X, vk=0x%X, result=%d, error=%lu",
+             i, g_switchModifiers, '0' + i, ok, ok ? 0 : GetLastError());
     }
   }
   if (g_enablePrevNextDesktop) {
-    RegisterHotKey(nullptr, HK_PREV, g_utilityModifiers, g_prevDesktopKey);
-    RegisterHotKey(nullptr, HK_PREV_INDEX, g_utilityModifiers, g_prevIndexKey);
-    RegisterHotKey(nullptr, HK_NEXT, g_utilityModifiers, g_nextDesktopKey);
+    BOOL ok;
+    ok = RegisterHotKey(nullptr, HK_PREV, g_utilityModifiers, g_prevDesktopKey);
+    Wh_Log(L"RegisterHotKey PREV: modifiers=0x%X, vk=0x%X, result=%d, error=%lu",
+           g_utilityModifiers, g_prevDesktopKey, ok, ok ? 0 : GetLastError());
+    ok = RegisterHotKey(nullptr, HK_NEXT, g_utilityModifiers, g_nextDesktopKey);
+    Wh_Log(L"RegisterHotKey NEXT: modifiers=0x%X, vk=0x%X, result=%d, error=%lu",
+           g_utilityModifiers, g_nextDesktopKey, ok, ok ? 0 : GetLastError());
+    ok = RegisterHotKey(nullptr, HK_LAST, g_utilityModifiers, g_lastDesktopKey);
+    Wh_Log(L"RegisterHotKey LAST: modifiers=0x%X, vk=0x%X, result=%d, error=%lu",
+           g_utilityModifiers, g_lastDesktopKey, ok, ok ? 0 : GetLastError());
   }
   if (g_enablePinWindow) {
-    RegisterHotKey(nullptr, HK_PIN, g_utilityModifiers, g_pinKey);
+    BOOL ok = RegisterHotKey(nullptr, HK_PIN, g_utilityModifiers, g_pinKey);
+    Wh_Log(L"RegisterHotKey PIN: modifiers=0x%X, vk=0x%X, result=%d, error=%lu",
+           g_utilityModifiers, g_pinKey, ok, ok ? 0 : GetLastError());
   }
   Wh_Log(L"Hotkeys registered");
 
@@ -1076,10 +1085,10 @@ DWORD WINAPI HotkeyThreadProc(LPVOID) {
             GoToDesktopNum(hotkeyId - HK_SWITCH_BASE + 1);
           } else if (hotkeyId == HK_PREV) {
             SwitchToPreviousDesktop();
-          } else if (hotkeyId == HK_PREV_INDEX) {
-            SwitchToPreviousIndexDesktop();
           } else if (hotkeyId == HK_NEXT) {
             SwitchToNextDesktop();
+          } else if (hotkeyId == HK_LAST) {
+            SwitchToLastDesktop();
           } else if (hotkeyId == HK_PIN) {
             TogglePinWindow();
           }
@@ -1102,8 +1111,8 @@ cleanup:
   }
   if (g_enablePrevNextDesktop) {
     UnregisterHotKey(nullptr, HK_PREV);
-    UnregisterHotKey(nullptr, HK_PREV_INDEX);
     UnregisterHotKey(nullptr, HK_NEXT);
+    UnregisterHotKey(nullptr, HK_LAST);
   }
   if (g_enablePinWindow) {
     UnregisterHotKey(nullptr, HK_PIN);


### PR DESCRIPTION
Rename confusingly named cycling functions for clarity:
- SwitchToPreviousDesktop (toggle last visited) → SwitchToLastDesktop
- SwitchToPreviousIndexDesktop (idx-1) → SwitchToPreviousDesktop
- Rename HK_PREV → HK_LAST, HK_PREV_INDEX → HK_PREV
- Rename settings keys: PrevDesktopKey → LastDesktopKey, PrevIndexKey → PrevDesktopKey
- Reorder and clarify settings group as [Previous/Next/Last Desktop]
- Update README with clearer descriptions and add See Also link
- Customize modifer keys with string 
- Bump version to 2.4.0