### PR TITLE
Taskbar auto-hide fine tuning v2.2

### DIFF
--- a/mods/taskbar-auto-hide-keyboard-only.wh.cpp
+++ b/mods/taskbar-auto-hide-keyboard-only.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-auto-hide-keyboard-only
 // @name            Taskbar auto-hide fine tuning
 // @description     Fine-tune taskbar auto-hide: keyboard-only unhide, prevent the taskbar from showing at all, hotkeys and mouse events to show or toggle visibility
-// @version         2.1
+// @version         2.2
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -91,6 +91,11 @@ Optionally override what happens when the Win key is pressed:
   - disabled: Disabled
   - middleClick: Middle click
   - doubleClick: Double click
+- showTemporarilyDurationMs: 1000
+  $name: Show temporarily minimum duration (ms)
+  $description: >-
+    Minimum time in milliseconds the taskbar stays visible after being shown
+    temporarily. Set to 0 for default duration.
 - winKeyAction: defaultWindowsBehavior
   $name: Win key action
   $description: The action to perform when the Win key is pressed.
@@ -151,6 +156,7 @@ struct {
     std::wstring showTemporarilyHotkey;
     std::wstring toggleAlwaysShowHotkey;
     ToggleAlwaysShowMouseEvent toggleAlwaysShowMouseEvent;
+    int showTemporarilyDurationMs;
     WinKeyAction winKeyAction;
     bool oldTaskbarOnWin11;
 } g_settings;
@@ -194,6 +200,7 @@ enum {
     UI_APPLY_SETTINGS,
     UI_BEFORE_UNINIT,
     UI_SHOW_TASKBAR_TEMPORARILY,
+    UI_SHOW_MAIN_TASKBAR_TEMPORARILY_IF_HIDDEN,
     UI_TOGGLE_ALWAYS_SHOW,
 };
 
@@ -216,9 +223,9 @@ struct SnappedFlyout {
 SnappedFlyout g_snappedStartMenu{};
 SnappedFlyout g_snappedSearchMenu{};
 
-// Win10: HWND -> TrayUI WndProc pThis.
+// HWND -> TrayUI WndProc pThis.
 std::unordered_map<HWND, void*> g_hwndToWndProcPThis;
-// Win10: HWND -> CSecondaryTray WndProc pThis.
+// HWND -> CSecondaryTray WndProc pThis.
 std::unordered_map<HWND, void*> g_hwndToSecondaryPThis;
 // Win11: HWND -> ViewCoordinator pThis.
 std::unordered_map<HWND, void*> g_hwndToViewCoordinator;
@@ -786,7 +793,7 @@ UINT_PTR WINAPI SetTimer_Hook(HWND hWnd,
                               TIMERPROC lpTimerFunc) {
     if (g_settings.mode != AutoHideMode::WindowsDefault &&
         nIDEvent == kTrayUITimerUnhide && IsTaskbarWindow(hWnd)) {
-        Wh_Log(L">");
+        Wh_Log(L"Blocking unhide timer (non-default mode)");
         return 1;
     }
 
@@ -794,6 +801,13 @@ UINT_PTR WINAPI SetTimer_Hook(HWND hWnd,
         IsTaskbarWindow(hWnd)) {
         Wh_Log(L"Blocking hide timer (always-show mode)");
         return 1;
+    }
+
+    if (nIDEvent == kTrayUITimerHide && g_modTriggeredUnhide &&
+        g_settings.showTemporarilyDurationMs > 0 && IsTaskbarWindow(hWnd)) {
+        Wh_Log(L"Extending hide timer to %d ms",
+               g_settings.showTemporarilyDurationMs);
+        uElapse = g_settings.showTemporarilyDurationMs;
     }
 
     UINT_PTR ret = SetTimer_Original(hWnd, nIDEvent, uElapse, lpTimerFunc);
@@ -835,6 +849,9 @@ void WINAPI TrayUI_SlideWindow_Hook(void* pThis,
         g_modTriggeredUnhide = false;
     }
 }
+
+using TrayUI_GetAutoHideFlags_t = DWORD(WINAPI*)(void* pThis);
+TrayUI_GetAutoHideFlags_t TrayUI_GetAutoHideFlags_Original;
 
 // Vtable pointers for interface navigation.
 void* TrayUI_vftable_ITrayComponentHost;
@@ -1030,17 +1047,23 @@ void UpdateViewCoordinatorIsExpanded(HWND hWnd) {
     }
 }
 
-void ShowTaskbarTemporarily() {
+void ShowTaskbarTemporarily(bool mainTaskbar = false) {
     Wh_Log(L">");
 
     if (g_alwaysShowMode) {
         return;
     }
 
-    // Only unhide the taskbar on the monitor where the mouse cursor is.
-    POINT pt;
-    GetCursorPos(&pt);
-    HMONITOR cursorMonitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+    HMONITOR monitor;
+    if (mainTaskbar) {
+        // Unhide primary monitor's taskbar.
+        monitor = MonitorFromPoint({0, 0}, MONITOR_DEFAULTTOPRIMARY);
+    } else {
+        // Only unhide the taskbar on the monitor where the mouse cursor is.
+        POINT pt;
+        GetCursorPos(&pt);
+        monitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+    }
 
     // Restore any flyouts that were snapped to monitor bottom.
     RestoreAllSnappedFlyouts();
@@ -1053,7 +1076,7 @@ void ShowTaskbarTemporarily() {
 
     // Old auto-hide path.
     for (auto& [hWnd, pThis] : g_hwndToWndProcPThis) {
-        if ((HMONITOR)GetProp(hWnd, L"TaskbarMonitor") != cursorMonitor) {
+        if ((HMONITOR)GetProp(hWnd, L"TaskbarMonitor") != monitor) {
             continue;
         }
         void* pThisHost =
@@ -1062,7 +1085,7 @@ void ShowTaskbarTemporarily() {
     }
 
     for (auto& [hWnd, pThis] : g_hwndToSecondaryPThis) {
-        if ((HMONITOR)GetProp(hWnd, L"TaskbarMonitor") != cursorMonitor) {
+        if ((HMONITOR)GetProp(hWnd, L"TaskbarMonitor") != monitor) {
             continue;
         }
         CSecondaryTray__Unhide_Original(pThis, 0, 0);
@@ -1071,7 +1094,7 @@ void ShowTaskbarTemporarily() {
     // Win11 ViewCoordinator path.
     if (ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original) {
         for (auto& [hWnd, pThis] : g_hwndToViewCoordinator) {
-            if ((HMONITOR)GetProp(hWnd, L"TaskbarMonitor") != cursorMonitor) {
+            if ((HMONITOR)GetProp(hWnd, L"TaskbarMonitor") != monitor) {
                 continue;
             }
             ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
@@ -1229,10 +1252,14 @@ HRESULT WINAPI XamlLauncher_ShowStartView_Hook(void* pThis,
                 break;
             }
             if (hTaskBandWnd) {
-                PostMessage(hTaskBandWnd, g_uiThreadCallbackMsg,
-                            UI_SHOW_TASKBAR_TEMPORARILY, 0);
+                bool shown =
+                    SendMessage(hTaskBandWnd, g_uiThreadCallbackMsg,
+                                UI_SHOW_MAIN_TASKBAR_TEMPORARILY_IF_HIDDEN, 0);
+                if (shown) {
+                    return S_OK;
+                }
             }
-            return S_OK;
+            break;
 
         case WinKeyAction::TogglePermanentVisibility:
             if (hTaskBandWnd) {
@@ -1356,6 +1383,24 @@ LRESULT WINAPI CTaskBand_v_WndProc_Hook(void* pThis,
                     case UI_SHOW_TASKBAR_TEMPORARILY:
                         ShowTaskbarTemporarily();
                         break;
+                    case UI_SHOW_MAIN_TASKBAR_TEMPORARILY_IF_HIDDEN: {
+                        bool shown = false;
+                        for (auto& [hWnd, pThis] : g_hwndToWndProcPThis) {
+                            DWORD flags =
+                                TrayUI_GetAutoHideFlags_Original(pThis);
+                            Wh_Log(L"GetAutoHideFlags: %08X", flags);
+                            if (!(flags & 0x02)) {
+                                shown = true;
+                                break;
+                            }
+                        }
+
+                        if (!shown) {
+                            ShowTaskbarTemporarily(/*mainTaskbar=*/true);
+                            result = 1;
+                        }
+                        break;
+                    }
                     case UI_TOGGLE_ALWAYS_SHOW:
                         ToggleAlwaysShow();
                         break;
@@ -1542,6 +1587,10 @@ bool HookTaskbarSymbols() {
             CSecondaryTray__Unhide_Hook,
         },
         {
+            {LR"(public: virtual unsigned int __cdecl TrayUI::GetAutoHideFlags(void))"},
+            &TrayUI_GetAutoHideFlags_Original,
+        },
+        {
             {LR"(public: virtual __int64 __cdecl TrayUI::WndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64,bool *))"},
             &TrayUI_WndProc_Original,
             TrayUI_WndProc_Hook,
@@ -1688,6 +1737,8 @@ bool HookExplorerPatcherSymbols(HMODULE explorerPatcherModule) {
          &TrayUI_Unhide_Original, TrayUI_Unhide_Hook},
         {R"(?_Unhide@CSecondaryTray@@AEAAXW4TrayUnhideFlags@TrayCommon@@W4UnhideRequest@3@@Z)",
          &CSecondaryTray__Unhide_Original, CSecondaryTray__Unhide_Hook},
+        {R"(?GetAutoHideFlags@TrayUI@@UEAAIXZ)",
+         &TrayUI_GetAutoHideFlags_Original},
         {R"(?WndProc@TrayUI@@UEAA_JPEAUHWND__@@I_K_JPEA_N@Z)",
          &TrayUI_WndProc_Original, TrayUI_WndProc_Hook},
         {R"(?v_WndProc@CSecondaryTray@@EEAA_JPEAUHWND__@@I_K_J@Z)",
@@ -1822,6 +1873,9 @@ void LoadSettings() {
             ToggleAlwaysShowMouseEvent::Disabled;
     }
     Wh_FreeStringSetting(mouseEvent);
+
+    g_settings.showTemporarilyDurationMs =
+        Wh_GetIntSetting(L"showTemporarilyDurationMs");
 
     PCWSTR winKeyAction = Wh_GetStringSetting(L"winKeyAction");
     if (wcscmp(winKeyAction, L"showTaskbar") == 0) {


### PR DESCRIPTION
* Added an option to configure the time the taskbar stays visible after being shown temporarily.
* Improved "Show taskbar, open Start menu if already shown" Win key action to always trigger the primary taskbar, and to open the Start menu even if the taskbar wasn't shown by the mod (e.g. by hovering).