### PR TITLE
Update Taskbar Fade to v2.1.1

### DIFF
--- a/mods/taskbar-fade.wh.cpp
+++ b/mods/taskbar-fade.wh.cpp
@@ -76,7 +76,7 @@ This mod is designed to prevent OLED burn-in and reduce visual distractions by l
 std::atomic<bool> g_stopThread(false);
 std::thread g_workerThread;
 std::mutex g_settingsMutex;
-std::atomic<bool> g_weHidIcons(false); // Tracks if WE were the ones who hid the icons
+std::atomic<bool> g_weHidIcons(false); // Tracks if we were the ones who hid the icons
 
 // State Machine
 enum class FadeState {


### PR DESCRIPTION
Fixed unintended desktop icon show/hide state override. The mod now checks if the user has naturally hidden their desktop icons via the Windows context menu, and will no longer force them to reappear when the taskbar wakes up or when the mod unloads.