### PR TITLE
Office UI Reverter (32/64-bit Universal)

### DIFF
--- a/mods/office-ui-reverter-universal.wh.cpp
+++ b/mods/office-ui-reverter-universal.wh.cpp
@@ -6,6 +6,7 @@
 // @description:zh-CN 将 Office 2022+/365 的 UI 界面外观还原为 Office 2016/2019
 // @version       1.0
 // @author        Joe Ye
+// @github        https://github.com/JoeYe-233
 // @include       WINWORD.EXE
 // @include       EXCEL.EXE
 // @include       POWERPNT.EXE


### PR DESCRIPTION
This pull request introduces a new Windhawk mod, `office-ui-reverter-universal.wh.cpp`, which enables users to revert the UI of Microsoft Office 2022+/365 applications back to the look of Office 2016 or 2019. The mod supports both 32-bit and 64-bit Office versions by hooking into the relevant UI styling function using PDB symbol hooking. It also includes user-configurable settings and robust lifecycle management for applying the UI changes.

Key additions and features:

**New Windhawk Mod for Office UI Reversion:**

* Introduces a universal Windhawk mod that allows reverting the UI of Office 2022+/365 (including WINWORD.EXE, EXCEL.EXE, POWERPNT.EXE, and others) to the Office 2016 or 2019 style, with support for both 32-bit and 64-bit versions via PDB symbol hooking.
* Provides user-facing settings to select the desired UI style (default, Office 2019, or Office 2016), with multilingual support for descriptions and options.
* Implements core logic to hook the `GetVisualStyleForSurface` function in `mso40uiWin32Client.dll` using symbol hooking, ensuring the selected UI style is applied.