### PR TITLE
Start Menu Size v1.1

### DIFF
--- a/mods/start-menu-size.wh.cpp
+++ b/mods/start-menu-size.wh.cpp
@@ -1,13 +1,14 @@
 // ==WindhawkMod==
 // @id              start-menu-size
 // @name            Start Menu Size
-// @description     Set a custom size for the Start menu on Windows 11
-// @version         1.0.1
+// @description     Set a custom size for the Start menu and search menu on Windows 11
+// @version         1.1
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
 // @homepage        https://m417z.com/
 // @include         StartMenuExperienceHost.exe
+// @include         explorer.exe
 // @architecture    x86-64
 // @compilerOptions -lole32 -loleaut32 -lruntimeobject
 // ==/WindhawkMod==
@@ -24,14 +25,15 @@
 /*
 # Start Menu Size
 
-Set a custom size for the Start menu on Windows 11.
+Set a custom size for the Start menu and search menu on Windows 11.
 
-Allows you to override the default width and height of the Start menu.
+Allows you to override the default width and height of the Start menu and the
+search menu.
 
-The classic menu width is 642, and the height is 726. [The redesigned Start
+The classic menu width is 666, and the height is 750. [The redesigned Start
 menu](https://microsoft.design/articles/start-fresh-redesigning-windows-start-menu/)
-width is 834, and the height occupies the full screen height. The sizes might
-vary for smaller screen sizes.
+width is 858, and the height is 890. The sizes might vary for smaller screen
+sizes.
 
 ![Screenshot](https://i.imgur.com/FoFSFOV.png) \
 _Example for making the Start menu smaller_
@@ -41,15 +43,25 @@ _Example for making the Start menu smaller_
 // ==WindhawkModSettings==
 /*
 - width: 0
-  $name: Width
+  $name: Start menu width
   $description: >-
     A custom width for the Start menu in pixels. Set to 0 to use the default
     system value.
 - height: 0
-  $name: Height
+  $name: Start menu height
   $description: >-
     A custom height for the Start menu in pixels. Set to 0 to use the default
     system value.
+- searchWidth: 0
+  $name: Search menu width
+  $description: >-
+    A custom width for the search menu in pixels. Set to 0 to use the Start
+    menu width value. Set to -1 to use the system default.
+- searchHeight: 0
+  $name: Search menu height
+  $description: >-
+    A custom height for the search menu in pixels. Set to 0 to use the Start
+    menu height value. Set to -1 to use the system default.
 */
 // ==/WindhawkModSettings==
 
@@ -73,9 +85,18 @@ _Example for making the Start menu smaller_
 
 using namespace winrt::Windows::UI::Xaml;
 
+enum class Target {
+    StartMenu,
+    Explorer,
+};
+
+Target g_target;
+
 struct {
     int width;
     int height;
+    int searchWidth;
+    int searchHeight;
 } g_settings;
 
 std::atomic<bool> g_unloading;
@@ -189,9 +210,10 @@ std::optional<OriginalWidthParams> g_originalClassicWidth;
 std::optional<OriginalWidthParams> g_originalClassicRootGridWidth;
 std::optional<OriginalHeightParams> g_originalClassicHeight;
 
-// Redesigned start menu: mainMenu for width, frameRoot for height.
+// Redesigned start menu: mainMenu for width, frameRoot for height and margin.
 std::optional<OriginalWidthParams> g_originalMainMenuWidth;
 std::optional<OriginalHeightParams> g_originalFrameRootHeight;
+std::optional<Thickness> g_originalFrameRootMargin;
 
 HWND GetCoreWnd() {
     struct ENUM_WINDOWS_PARAM {
@@ -357,12 +379,18 @@ void ApplyStyleClassicStartMenu(FrameworkElement content) {
             g_originalClassicHeight.reset();
         }
     } else {
+        // The settings define the outer window size. The classic start menu has
+        // a fixed padding of 12px on each edge between the window edge and
+        // startSizingFrame (the Canvas is full-screen).
+        constexpr double kPadding = 12 * 2;
+
         if (g_settings.width > 0) {
             if (!g_originalClassicWidth) {
                 g_originalClassicWidth.emplace();
                 SaveWidth(startSizingFrame, *g_originalClassicWidth);
             }
-            double width = static_cast<double>(g_settings.width);
+            double width =
+                std::fmax(static_cast<double>(g_settings.width) - kPadding, 0);
             startSizingFrame.Width(width);
             startSizingFrame.MinWidth(width);
             startSizingFrame.MaxWidth(width);
@@ -397,7 +425,8 @@ void ApplyStyleClassicStartMenu(FrameworkElement content) {
                 g_originalClassicHeight.emplace();
                 SaveHeight(startSizingFrame, *g_originalClassicHeight);
             }
-            double height = static_cast<double>(g_settings.height);
+            double height =
+                std::fmax(static_cast<double>(g_settings.height) - kPadding, 0);
             startSizingFrame.Height(height);
             startSizingFrame.MinHeight(height);
             startSizingFrame.MaxHeight(height);
@@ -440,6 +469,10 @@ void ApplyStyleRedesignedStartMenu(FrameworkElement content) {
             RestoreHeight(frameRoot, *g_originalFrameRootHeight);
             g_originalFrameRootHeight.reset();
         }
+        if (g_originalFrameRootMargin) {
+            frameRoot.Margin(*g_originalFrameRootMargin);
+            g_originalFrameRootMargin.reset();
+        }
     } else {
         constexpr int kMinWidth = 270;
 
@@ -448,8 +481,20 @@ void ApplyStyleRedesignedStartMenu(FrameworkElement content) {
                 g_originalMainMenuWidth.emplace();
                 SaveWidth(mainMenu, *g_originalMainMenuWidth);
             }
+
+            // The requested width is the overall visible width. MainMenu is
+            // nested inside frameRoot > AnimationRoot, so subtract any
+            // padding/margin between them to get the correct inner width.
+            double frameRootActualWidth = frameRoot.ActualWidth();
+            double mainMenuActualWidth = mainMenu.ActualWidth();
+            double padding = 0;
+            if (frameRootActualWidth > 0 && mainMenuActualWidth > 0) {
+                padding = frameRootActualWidth - mainMenuActualWidth;
+            }
+
             double width =
                 static_cast<double>(std::fmax(g_settings.width, kMinWidth));
+            width = std::fmax(width - padding, kMinWidth);
             mainMenu.Width(width);
             mainMenu.MinWidth(width);
             mainMenu.MaxWidth(width);
@@ -467,9 +512,18 @@ void ApplyStyleRedesignedStartMenu(FrameworkElement content) {
             frameRoot.Height(height);
             frameRoot.MinHeight(height);
             frameRoot.MaxHeight(height);
+
+            if (!g_originalFrameRootMargin) {
+                g_originalFrameRootMargin = frameRoot.Margin();
+            }
+            frameRoot.Margin(Thickness{0, 0, 0, 0});
         } else if (g_originalFrameRootHeight) {
             RestoreHeight(frameRoot, *g_originalFrameRootHeight);
             g_originalFrameRootHeight.reset();
+            if (g_originalFrameRootMargin) {
+                frameRoot.Margin(*g_originalFrameRootMargin);
+                g_originalFrameRootMargin.reset();
+            }
         }
     }
 }
@@ -597,9 +651,176 @@ HRESULT WINAPI RoGetActivationFactory_Hook(HSTRING activatableClassId,
 
 }  // namespace StartMenuUI
 
+namespace ExplorerUI {
+
+int GetMonitorInfoDpi(const void* monitorInfo) {
+    int dpi = *reinterpret_cast<const int*>(
+        static_cast<const char*>(monitorInfo) + 0x38);
+    if (dpi < 96 || dpi > 960) {
+        Wh_Log(L"Unexpected DPI value: %d", dpi);
+        dpi = 96;
+    }
+    return dpi;
+}
+
+int GetEffectiveSearchWidth() {
+    if (g_settings.searchWidth == -1) {
+        return 0;  // Use system default.
+    }
+    return g_settings.searchWidth > 0 ? g_settings.searchWidth
+                                      : g_settings.width;
+}
+
+int GetEffectiveSearchHeight() {
+    if (g_settings.searchHeight == -1) {
+        return 0;  // Use system default.
+    }
+    return g_settings.searchHeight > 0 ? g_settings.searchHeight
+                                       : g_settings.height;
+}
+
+using GetSearchPaneWidthAndHeight_t = int*(WINAPI*)(void* pThis,
+                                                    int out[2],
+                                                    const void* monitorInfo,
+                                                    bool flag);
+GetSearchPaneWidthAndHeight_t GetSearchPaneWidthAndHeight_Original;
+int* WINAPI GetSearchPaneWidthAndHeight_Hook(void* pThis,
+                                             int out[2],
+                                             const void* monitorInfo,
+                                             bool flag) {
+    int* ret =
+        GetSearchPaneWidthAndHeight_Original(pThis, out, monitorInfo, flag);
+
+    Wh_Log(L"GetSearchPaneWidthAndHeight: %dx%d", out[0], out[1]);
+
+    if (!g_unloading) {
+        int dpi = GetMonitorInfoDpi(monitorInfo);
+
+        int w = GetEffectiveSearchWidth();
+        int h = GetEffectiveSearchHeight();
+        if (w > 0) {
+            out[0] = MulDiv(w, dpi, 96);
+        }
+        if (h > 0) {
+            out[1] = MulDiv(h, dpi, 96);
+        }
+    }
+
+    return ret;
+}
+
+using GetDefaultStartSearchAppPopupHeight_t = int(WINAPI*)(void* pThis,
+                                                           int trayStuckPlace,
+                                                           const RECT* rect,
+                                                           int dpi);
+GetDefaultStartSearchAppPopupHeight_t
+    GetDefaultStartSearchAppPopupHeight_Original;
+int WINAPI GetDefaultStartSearchAppPopupHeight_Hook(void* pThis,
+                                                    int trayStuckPlace,
+                                                    const RECT* rect,
+                                                    int dpi) {
+    int result = GetDefaultStartSearchAppPopupHeight_Original(
+        pThis, trayStuckPlace, rect, dpi);
+
+    Wh_Log(L"GetDefaultStartSearchAppPopupHeight: %d", result);
+
+    int h = GetEffectiveSearchHeight();
+    if (!g_unloading && h > 0) {
+        result = h;
+    }
+
+    return result;
+}
+
+using GetDefaultStartSearchAppWidth_t = int(WINAPI*)(void* pThis,
+                                                     const void* monitorInfo);
+GetDefaultStartSearchAppWidth_t GetDefaultStartSearchAppWidth_Original;
+int WINAPI GetDefaultStartSearchAppWidth_Hook(void* pThis,
+                                              const void* monitorInfo) {
+    int result = GetDefaultStartSearchAppWidth_Original(pThis, monitorInfo);
+
+    Wh_Log(L"GetDefaultStartSearchAppWidth: %d", result);
+
+    int w = GetEffectiveSearchWidth();
+    if (!g_unloading && w > 0) {
+        result = w;
+    }
+
+    return result;
+}
+
+using GetSearchSize_t = float*(WINAPI*)(float out[2],
+                                        const RECT* rect,
+                                        int dpi);
+GetSearchSize_t GetSearchSize_Original;
+float* WINAPI GetSearchSize_Hook(float out[2], const RECT* rect, int dpi) {
+    float* ret = GetSearchSize_Original(out, rect, dpi);
+
+    Wh_Log(L"GetSearchSize: %.0fx%.0f", out[0], out[1]);
+
+    if (!g_unloading) {
+        int w = GetEffectiveSearchWidth();
+        int h = GetEffectiveSearchHeight();
+        if (w > 0) {
+            out[0] = static_cast<float>(w);
+        }
+        if (h > 0) {
+            out[1] = static_cast<float>(h);
+        }
+    }
+
+    return ret;
+}
+
+bool HookTwinuiPcshellSymbols() {
+    HMODULE module = LoadLibraryEx(L"twinui.pcshell.dll", nullptr,
+                                   LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!module) {
+        Wh_Log(L"Failed to load twinui.pcshell.dll");
+        return false;
+    }
+
+    // twinui.pcshell.dll
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {LR"(private: struct std::pair<int,int> __cdecl SearchBoxOnTaskbarSearchAppPositioner::GetSearchPaneWidthAndHeight(struct MonitorInfo const &,bool)const )"},
+            &GetSearchPaneWidthAndHeight_Original,
+            GetSearchPaneWidthAndHeight_Hook,
+        },
+        {
+            {LR"(private: int __cdecl SearchBoxOnTaskbarSearchAppPositioner::GetDefaultStartSearchAppPopupHeight(enum EDGEUI_TRAYSTUCKPLACE,struct tagRECT,int))"},
+            &GetDefaultStartSearchAppPopupHeight_Original,
+            GetDefaultStartSearchAppPopupHeight_Hook,
+        },
+        {
+            {LR"(private: int __cdecl SearchBoxOnTaskbarSearchAppPositioner::GetDefaultStartSearchAppWidth(struct MonitorInfo const &))"},
+            &GetDefaultStartSearchAppWidth_Original,
+            GetDefaultStartSearchAppWidth_Hook,
+            true,  // Missing in older builds (e.g. 10.0.26100.6584).
+        },
+        {
+            {LR"(struct winrt::Windows::Foundation::Size __cdecl GetSearchSize(struct tagRECT const &,int))"},
+            &GetSearchSize_Original,
+            GetSearchSize_Hook,
+            true,  // Missing in older builds (e.g. 10.0.26100.6584).
+        },
+    };
+
+    if (!HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks))) {
+        Wh_Log(L"HookSymbols failed");
+        return false;
+    }
+
+    return true;
+}
+
+}  // namespace ExplorerUI
+
 void LoadSettings() {
     g_settings.width = Wh_GetIntSetting(L"width");
     g_settings.height = Wh_GetIntSetting(L"height");
+    g_settings.searchWidth = Wh_GetIntSetting(L"searchWidth");
+    g_settings.searchHeight = Wh_GetIntSetting(L"searchHeight");
 }
 
 BOOL Wh_ModInit() {
@@ -607,13 +828,42 @@ BOOL Wh_ModInit() {
 
     LoadSettings();
 
-    HMODULE winrtModule = GetModuleHandle(L"api-ms-win-core-winrt-l1-1-0.dll");
-    auto pRoGetActivationFactory =
-        (decltype(&RoGetActivationFactory))GetProcAddress(
-            winrtModule, "RoGetActivationFactory");
-    WindhawkUtils::SetFunctionHook(
-        pRoGetActivationFactory, StartMenuUI::RoGetActivationFactory_Hook,
-        &StartMenuUI::RoGetActivationFactory_Original);
+    g_target = Target::StartMenu;
+
+    WCHAR moduleFilePath[MAX_PATH];
+    switch (
+        GetModuleFileName(nullptr, moduleFilePath, ARRAYSIZE(moduleFilePath))) {
+        case 0:
+        case ARRAYSIZE(moduleFilePath):
+            Wh_Log(L"GetModuleFileName failed");
+            break;
+
+        default:
+            if (PCWSTR moduleFileName = wcsrchr(moduleFilePath, L'\\')) {
+                moduleFileName++;
+                if (_wcsicmp(moduleFileName, L"explorer.exe") == 0) {
+                    g_target = Target::Explorer;
+                }
+            } else {
+                Wh_Log(L"GetModuleFileName returned an unsupported path");
+            }
+            break;
+    }
+
+    if (g_target == Target::StartMenu) {
+        HMODULE winrtModule =
+            GetModuleHandle(L"api-ms-win-core-winrt-l1-1-0.dll");
+        auto pRoGetActivationFactory =
+            (decltype(&RoGetActivationFactory))GetProcAddress(
+                winrtModule, "RoGetActivationFactory");
+        WindhawkUtils::SetFunctionHook(
+            pRoGetActivationFactory, StartMenuUI::RoGetActivationFactory_Hook,
+            &StartMenuUI::RoGetActivationFactory_Original);
+    } else {
+        if (!ExplorerUI::HookTwinuiPcshellSymbols()) {
+            return FALSE;
+        }
+    }
 
     return TRUE;
 }
@@ -621,11 +871,13 @@ BOOL Wh_ModInit() {
 void Wh_ModAfterInit() {
     Wh_Log(L">");
 
-    HWND hCoreWnd = StartMenuUI::GetCoreWnd();
-    if (hCoreWnd) {
-        Wh_Log(L"Initializing - Found core window");
-        RunFromWindowThread(
-            hCoreWnd, [](PVOID) { StartMenuUI::Init(); }, nullptr);
+    if (g_target == Target::StartMenu) {
+        HWND hCoreWnd = StartMenuUI::GetCoreWnd();
+        if (hCoreWnd) {
+            Wh_Log(L"Initializing - Found core window");
+            RunFromWindowThread(
+                hCoreWnd, [](PVOID) { StartMenuUI::Init(); }, nullptr);
+        }
     }
 }
 
@@ -634,11 +886,13 @@ void Wh_ModBeforeUninit() {
 
     g_unloading = true;
 
-    HWND hCoreWnd = StartMenuUI::GetCoreWnd();
-    if (hCoreWnd) {
-        Wh_Log(L"Uninitializing - Found core window");
-        RunFromWindowThread(
-            hCoreWnd, [](PVOID) { StartMenuUI::Uninit(); }, nullptr);
+    if (g_target == Target::StartMenu) {
+        HWND hCoreWnd = StartMenuUI::GetCoreWnd();
+        if (hCoreWnd) {
+            Wh_Log(L"Uninitializing - Found core window");
+            RunFromWindowThread(
+                hCoreWnd, [](PVOID) { StartMenuUI::Uninit(); }, nullptr);
+        }
     }
 }
 
@@ -651,10 +905,13 @@ void Wh_ModSettingsChanged() {
 
     LoadSettings();
 
-    HWND hCoreWnd = StartMenuUI::GetCoreWnd();
-    if (hCoreWnd) {
-        Wh_Log(L"Applying settings - Found core window");
-        RunFromWindowThread(
-            hCoreWnd, [](PVOID) { StartMenuUI::SettingsChanged(); }, nullptr);
+    if (g_target == Target::StartMenu) {
+        HWND hCoreWnd = StartMenuUI::GetCoreWnd();
+        if (hCoreWnd) {
+            Wh_Log(L"Applying settings - Found core window");
+            RunFromWindowThread(
+                hCoreWnd, [](PVOID) { StartMenuUI::SettingsChanged(); },
+                nullptr);
+        }
     }
 }


### PR DESCRIPTION
* Added support for setting the search menu size as well. By default, the size that's configured for the Start menu is used for the search menu as well.
* Minor fixes and size calculation improvements.