### PR TITLE
Add Taskbar Numberer for Windows 11 mod

### DIFF
--- a/mods/taskbar-numberer.wh.cpp
+++ b/mods/taskbar-numberer.wh.cpp
@@ -352,7 +352,6 @@ FrameworkElement CreateNumberOverlay(int number) {
         SetNumberPosition(textContainer);
 
         textContainer.Margin(Thickness{4, 2, 4, 2});
-        Canvas::SetZIndex(textContainer, 0);
 
         if (number > 10) {
             textContainer.Visibility(Visibility::Collapsed);
@@ -519,7 +518,10 @@ void UpdateButtonOverlay(FrameworkElement button, int number) {
 
             auto newOverlay = CreateNumberOverlay(number);
             if (newOverlay) {
-                iconPanelElement.as<Panel>().Children().Append(newOverlay);
+                auto children = iconPanelElement.as<Panel>().Children();
+                
+                // Insert the new overlay just before the last child to ensure it appears above the icon, but below any other elements like badges or progress indicators
+                children.InsertAt(children.Size() - 1, newOverlay);
                 buttonInfo.overlay = newOverlay;
             }
         }


### PR DESCRIPTION
A mod that display keyboard shortcut numbers to taskbar items like 7+ Taskbar Numberer.

Heavily based on [this PR](https://github.com/ramensoftware/windhawk-mods/pull/2260) by @jsfdez, so massive thanks to him. I there also included him as author and mentioned in Special Thanks. If he prefers to pick this one back up again by himself, please let us know here!

The most prominent change is fixing the issue that taskbar items of the same app origin still incremented the number (when task bar items are not combined). 

<img width="660" height="69" alt="Screenshot of Taskbar Numberer for Windows 11 mod" src="https://github.com/user-attachments/assets/79f065c0-471f-4baf-b162-5ad1cb87c27b" />