### PR TITLE
Create auto-time-sync-on-startup.wh.cpp

### DIFF
--- a/mods/auto-time-sync-on-startup.wh.cpp
+++ b/mods/auto-time-sync-on-startup.wh.cpp
@@ -88,7 +88,7 @@ constexpr DWORD kSyncConfirmationPollMs = 2000;
 constexpr PCWSTR kAdminBrokerArguments = L"ForceTimeSync 0";
 constexpr PCWSTR kRunGuardKey = L"Software";
 constexpr PCWSTR kRunGuardValueName =
-    L"Windhawk\\" WH_MOD_ID L"_SessionRunGuard_Claimed";
+    L"Windhawk_" WH_MOD_ID L"_SessionRunGuard_Claimed";
 constexpr UINT kNotificationIconId = 1;
 constexpr PCWSTR kNotificationWindowClassName =
     L"AutoTimeSyncNotificationWindow_" WH_MOD_ID;


### PR DESCRIPTION
Automatically requests Windows time synchronization after sign-in when Explorer starts, then shows a notification once the sync is confirmed. Uses the standard Windows sync flow and respects your current system time settings.