### PR TITLE
New mod Windows 11 Start Menu Buttons

### DIFF
--- a/mods/windows-11-start-menu-buttons.wh.cpp
+++ b/mods/windows-11-start-menu-buttons.wh.cpp
@@ -268,6 +268,8 @@ static void LoadSettings() {
 
     std::lock_guard<std::mutex> lock(g_settingsMutex);
     g_settings = newSettings;
+
+    Wh_Log(L"Settings Loaded: CloseStartMenu = %d", newSettings.closeStartMenu);
 }
 
 static std::wstring GetSettingStringIndex(const wchar_t* key, int index) {
@@ -388,13 +390,19 @@ static inline void CloseStartMenuAfterClick() {
         auto dq = winrt::Windows::System::DispatcherQueue::GetForCurrentThread();
         if (dq) {
             dq.TryEnqueue(winrt::Windows::System::DispatcherQueuePriority::Low, []() {
-                SendEscapeKey();
+                std::thread([]() {
+                    Sleep(100); 
+                    SendEscapeKey();
+                }).detach();
             });
             return;
         }
     } catch (...) {}
 
-    SendEscapeKey();
+    std::thread([]() {
+        Sleep(100);
+        SendEscapeKey();
+    }).detach();
 }
 
 // -------------------- executing actions --------------------
@@ -642,7 +650,7 @@ static DWORD WINAPI ProxyWindowThread(LPVOID) {
     }
 
     UnregisterClassW(PROXY_WINDOW_CLASS, GetModuleHandleW(nullptr));
-    g_proxyWindow = NULL;
+    g_proxyWindow = NULL; 
     return 0;
 }
 
@@ -1067,6 +1075,8 @@ static void WINAPI InitOnWindowThread(PVOID param) {
 
 BOOL Wh_ModInit() {
     Wh_Log(L"Init");
+    LoadSettings();
+    BuildButtons();
 
     if (IsExplorerProcess()) {
         StartProxyThread();


### PR DESCRIPTION
This mod replaces the default bottom row of the Windows 11 Start menu with custom buttons.
Each button has three fields:

1. **Name** — tooltip text.
2. **Icon** — a [Segoe Fluent Icons / Segoe UI Symbol](https://learn.microsoft.com/en-us/windows/apps/design/iconography/segoe-ui-symbol-font) glyph, for example `\uE7E8`. 

3. **Action** — what the button does.

### Action formats

- `cmd:explorer.exe` — runs through `cmd.exe`.
- `shell:shutdown /r` — runs console window.
- `"C:\Program Files"` — opens a folder.
- `"C:\Program Files\Google\Chrome\Application\chrome.exe"` — оpens a file or app.
- `~Downloads` — searches for a folder by name in common system locations.
- `~chrome.exe` — searches for a file by name in common system locations.
- `https://www.youtube.com/` — opens a website.
- `{ "Restart", "\uE777", "shell:shutdown /r /f /t 0" }, { "Shut down", "\uE7E8", "shell:shutdown /s /f /t 0" }` — a submenu with multiple items.