### PR TITLE
 Improved window control: try ShowWindowAsync first, then fall back to PostMessage (WM_SYSCOMMAND) if it fails

### DIFF
--- a/mods/win-d-per-monitor.wh.cpp
+++ b/mods/win-d-per-monitor.wh.cpp
@@ -7,7 +7,7 @@
 // @author          easyatm
 // @github          https://github.com/easyatm
 // @include         explorer.exe
-// @compilerOptions -luser32 -lDwmapi -lshell32
+// @compilerOptions -luser32 -lDwmapi
 // ==/WindhawkMod==
 
 // ==WindhawkModSettings==
@@ -77,7 +77,6 @@ Fixes:
 #include <list>
 #include <map>
 #include <set>
-#include <shlobj.h>
 #include <string>
 #include <vector>
 #include <windhawk_api.h>


### PR DESCRIPTION
### 2026-03-30 (v1.3.260330)
- Improved window control: try ShowWindowAsync first, then fall back to PostMessage (WM_SYSCOMMAND) if it fails
- 改进窗口控制：优先尝试 ShowWindowAsync，失败时回退到 PostMessage（WM_SYSCOMMAND）
- Added custom ignored windows support by class name or window title
- 新增自定义忽略窗口支持（按类名或窗口标题）