### PR TITLE
Word MathType Dark Mode Fix

### DIFF
--- a/mods/word-mathtype-dark-fix.wh.cpp
+++ b/mods/word-mathtype-dark-fix.wh.cpp
@@ -72,7 +72,7 @@ void ScanAndHookWwlib() {
     if (!hWwlib || g_wwlibHooked.exchange(true)) return;
     
     // wwlib.dll
-    WindhawkUtils::SYMBOL_HOOK wwlibDllHook[] = {
+    WindhawkUtils::SYMBOL_HOOK wwlibHook[] = {
         {
             { SYM_SetDarkMode },
             (void**)&pOrig_SetDarkMode,
@@ -87,7 +87,7 @@ void ScanAndHookWwlib() {
     options.onlineCacheUrl = L"";        // Disable online cache to force using local symbol file, which is expected to be already downloaded by Windhawk
 
     Wh_Log(L"[Init] Attempting to hook wwlib.dll...");
-    if (WindhawkUtils::HookSymbols(hWwlib, wwlibDllHook, ARRAYSIZE(wwlibDllHook), &options)) {
+    if (WindhawkUtils::HookSymbols(hWwlib, wwlibHook, ARRAYSIZE(wwlibHook), &options)) {
         Wh_ApplyHookOperations();
         Wh_Log(L"[Success] DarkModeState::SetDarkMode hooked successfully.");
     } else {


### PR DESCRIPTION
This change adds a Windhawk mod that improves MathType equation readability in **Microsoft Word dark mode** by intercepting Word’s dark mode state and dynamically adjusting drawing colors on the document canvas.

**Key points**
- Hooks **`DarkModeState::SetDarkMode` in `wwlib.dll`** (via symbols/PDB) to track when Word enters/leaves dark mode.
- Hooks **GDI rendering APIs** (e.g., `SelectObject`, `SetDCBrushColor`, `SetDCPenColor`, `SetTextColor`) to remap brush/pen/text colors to dark-mode-friendly equivalents **only for the document canvas** (avoids Ribbon/backstage/UI by checking DC/map mode/window class).
- Adds **RGB↔HSL-based dynamic color inversion** with slight saturation reduction, plus special handling for pure black/white to map to configured text/background colors.
- Hooks **GDI+ `GdipCreateHatchBrush`** to fix the diagonal hatch overlay shown when editing OLE/formula objects (forces black foreground hatch to a visible semi-transparent white in dark mode).
- Uses **brush/pen caching** to avoid GDI handle leaks and improve performance.
- Hooks **`LoadLibraryW/LoadLibraryExW`** so the `wwlib.dll` / `gdiplus.dll` hooks are applied even if those DLLs load after the mod initializes.

**Notes**
- Requires `wwlib.dll` PDB symbols (Windhawk downloads them automatically); Office updates may require re-downloading symbols.