### PR TITLE
Add Taskbar Music Lounge Multiple v1.0.0

### DIFF
--- a/mods/taskbar-music-lounge-multiple.wh.cpp
+++ b/mods/taskbar-music-lounge-multiple.wh.cpp
@@ -4,7 +4,7 @@
 // @description     A native-style music ticker with multiple media controls.
 // @version         1.0.0
 // @author          Messij
-// @github          https://github.com/Messij/Windhawk---Multiple-Taskbar-Music-Lounge
+// @github          https://github.com/Messij
 // @include         explorer.exe
 // @compilerOptions -lole32 -ldwmapi -lgdi32 -luser32 -lwindowsapp -lshcore -lgdiplus -lshell32
 // ==/WindhawkMod==


### PR DESCRIPTION
This mod is a fork of the original "Taskbar Music Lounge" by Hashah2311
As the github page https://github.com/Hashah2311 and Hashah2311 profile are unfoundable, I decided to fork the original "Taskbar Music Lounge" and create a new mod.
Thanks to the original creator of the mod.

# 🌟 Taskbar Music Lounge Multiple 🌟
📦 Github : https://github.com/Messij/Windhawk---Multiple-Taskbar-Music-Lounge
 
## 📼 Trailer 📼
https://www.youtube.com/watch?v=ujvPYtALrno
<img width="445" height="58" alt="image" src="https://github.com/user-attachments/assets/dfcdda9d-3650-4e75-a3e7-6f73786e0f80" />

## V1 Features
- Title and Artist-Album on two lines
- Multiple medias view and control
- Each media session has it's own dedicated art
- Clic an art will play it and pause the others
- Pause current media session when launching a new one
- Middle clic to close media (in the mode, not the app)