### PR TITLE
Update Remove Context Menu Items to 1.8.0

### DIFF
--- a/mods/remove-context-menu-items.wh.cpp
+++ b/mods/remove-context-menu-items.wh.cpp
@@ -40,8 +40,7 @@ Clean up your Windows context menus by removing bloatware and unwanted items:
 - `Ask Copilot`
 - `Scan with Microsoft Defender`
 - `Create with Designer`
-- `Edit with Clipchamp`
-- `Ask Microsoft 365 Copilot`
+- ...and more!
 
 ### Basic Items
 - `Open`


### PR DESCRIPTION
- Added `Ask Microsoft 365 Copilot` to Bloatware Items with translations for `cs-CZ`, `de-DE`, `pt-BR`, and `pt-PT`
- Fixed `Paste` removal to only hide the item when greyed out, preserving it when clickable