### PR TITLE
Add Explorer Navigation Pane Tweaks mod

### DIFF
--- a/mods/explorer-navigation-pane-tweaks.wh.cpp
+++ b/mods/explorer-navigation-pane-tweaks.wh.cpp
@@ -551,3 +551,4 @@ BOOL Wh_ModSettingsChanged(BOOL* bReload)
 
     return TRUE;
 }
+

--- a/mods/explorer-navigation-pane-tweaks.wh.cpp
+++ b/mods/explorer-navigation-pane-tweaks.wh.cpp
@@ -4,7 +4,7 @@
 // @description     Adjusts the navigation pane tree indent and treeview visual styles in Windows Explorer
 // @version         1.0
 // @author          Languster
-// @github          https://github.com/Languster/
+// @github          https://github.com/Languster
 // @include         %SystemRoot%\explorer.exe
 // @architecture    x86-64
 // @compilerOptions -lcomctl32

--- a/mods/explorer-navigation-pane-tweaks.wh.cpp
+++ b/mods/explorer-navigation-pane-tweaks.wh.cpp
@@ -4,7 +4,7 @@
 // @description     Adjusts the navigation pane tree indent and treeview visual styles in Windows Explorer
 // @version         1.0
 // @author          Languster
-// @github          https://github.com/Languster/ExplorerNavHook
+// @github          https://github.com/Languster
 // @include         %SystemRoot%\explorer.exe
 // @architecture    x86-64
 // @compilerOptions -lcomctl32

--- a/mods/explorer-navigation-pane-tweaks.wh.cpp
+++ b/mods/explorer-navigation-pane-tweaks.wh.cpp
@@ -10,6 +10,7 @@
 // @compilerOptions -lcomctl32
 // @license         MIT
 // ==/WindhawkMod==
+
 // ==WindhawkModReadme==
 /*
 # Explorer Navigation Pane Tweaks
@@ -39,7 +40,6 @@ Adjusts the indentation and visual tree style of the navigation pane in Windows 
 - **Remove TVS_HASBUTTONS**: removes tree buttons
 - **Remove TVS_HASLINES**: removes connector lines
 - **Remove TVS_LINESATROOT**: removes root lines
-- **Enable log**: writes debug messages to the Windhawk log
 
 ## Compatibility
 
@@ -78,12 +78,9 @@ Adjusts the indentation and visual tree style of the navigation pane in Windows 
 - RemoveLinesAtRoot: true
   $name: Remove root lines
   $description: Removes root-level tree lines and the first root expand visual
-
-- EnableLog: false
-  $name: Enable debug logging
-  $description: Writes debug messages to the Windhawk log
 */
 // ==/WindhawkModSettings==
+
 #include <windows.h>
 #include <commctrl.h>
 #include <vector>
@@ -100,11 +97,10 @@ static DWORD g_WorkerThreadId = 0;
 static HWINEVENTHOOK g_hEventHookShow = nullptr;
 static HWINEVENTHOOK g_hEventHookCreate = nullptr;
 
-static int  g_TargetIndent = 25;
+static int g_TargetIndent = 25;
 static BOOL g_RemoveHasButtons = TRUE;
 static BOOL g_RemoveHasLines = TRUE;
 static BOOL g_RemoveLinesAtRoot = TRUE;
-static BOOL g_EnableLog = FALSE;
 
 static CRITICAL_SECTION g_StateLock;
 static std::vector<ExplorerState> g_States;
@@ -112,52 +108,33 @@ static std::vector<ExplorerState> g_States;
 #define TABMODE_REPATCH_DELAY1_MS 120
 #define TABMODE_REPATCH_DELAY2_MS 320
 
-static void Log(const wchar_t* text)
-{
-    if (g_EnableLog)
-        Wh_Log(L"%s", text);
-}
-
-static void LogFmt(const wchar_t* fmt, UINT_PTR a = 0, UINT_PTR b = 0)
-{
-    wchar_t buf[512] = {};
-    wsprintfW(buf, fmt, a, b);
-    Log(buf);
-}
-
 static void LoadSettings()
 {
     g_TargetIndent = Wh_GetIntSetting(L"TargetIndent");
     g_RemoveHasButtons = Wh_GetIntSetting(L"RemoveHasButtons");
     g_RemoveHasLines = Wh_GetIntSetting(L"RemoveHasLines");
     g_RemoveLinesAtRoot = Wh_GetIntSetting(L"RemoveLinesAtRoot");
-    g_EnableLog = Wh_GetIntSetting(L"EnableLog");
 
-    LogFmt(L"[ExplorerNavHook] settings loaded, indent=%u", (UINT_PTR)g_TargetIndent);
+    Wh_Log(L"Settings loaded, indent=%d", g_TargetIndent);
 }
+
 static bool IsExplorerTopWindow(HWND hwnd)
 {
     if (!IsWindow(hwnd))
         return false;
 
     wchar_t cls[128] = {};
-    GetClassNameW(hwnd, cls, 128);
+    GetClassNameW(hwnd, cls, ARRAYSIZE(cls));
 
-    return (lstrcmpiW(cls, L"CabinetWClass") == 0 ||
-            lstrcmpiW(cls, L"ExploreWClass") == 0);
+    return lstrcmpiW(cls, L"CabinetWClass") == 0 ||
+           lstrcmpiW(cls, L"ExploreWClass") == 0;
 }
 
 static HWND FindExplorerTopWindowFromChild(HWND hwnd)
 {
-    HWND cur = hwnd;
-
-    for (int i = 0; i < 20 && cur; ++i)
-    {
-        if (IsExplorerTopWindow(cur))
-            return cur;
-
-        cur = GetParent(cur);
-    }
+    HWND root = GetAncestor(hwnd, GA_ROOT);
+    if (root && IsExplorerTopWindow(root))
+        return root;
 
     return nullptr;
 }
@@ -168,7 +145,7 @@ static bool IsLikelyNavTree(HWND hwnd)
         return false;
 
     wchar_t cls[128] = {};
-    GetClassNameW(hwnd, cls, 128);
+    GetClassNameW(hwnd, cls, ARRAYSIZE(cls));
 
     if (lstrcmpiW(cls, WC_TREEVIEWW) != 0 &&
         lstrcmpiW(cls, L"SysTreeView32") != 0)
@@ -211,13 +188,12 @@ static void PatchTree(HWND hTree)
         hTree,
         nullptr,
         0, 0, 0, 0,
-        SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED
-    );
+        SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
 
     InvalidateRect(hTree, nullptr, TRUE);
     UpdateWindow(hTree);
 
-    LogFmt(L"[ExplorerNavHook] patched tree hwnd=%p", (UINT_PTR)hTree);
+    Wh_Log(L"Patched tree hwnd=%p", hTree);
 }
 
 static BOOL CALLBACK FindTreeEnumProc(HWND hwnd, LPARAM lParam)
@@ -272,7 +248,7 @@ static void CleanupDeadStates()
 {
     EnterCriticalSection(&g_StateLock);
 
-    for (size_t i = 0; i < g_States.size(); )
+    for (size_t i = 0; i < g_States.size();)
     {
         if (!IsWindow(g_States[i].hExplorer))
             g_States.erase(g_States.begin() + i);
@@ -301,14 +277,14 @@ static DWORD WINAPI RepatchThreadProc(LPVOID param)
     if (IsWindow(hExplorer))
     {
         PatchExplorerWindow(hExplorer);
-        Log(L"[ExplorerNavHook] tabmode repatch #1 done");
+        Wh_Log(L"Tabmode repatch #1 done");
     }
 
     Sleep(TABMODE_REPATCH_DELAY2_MS - TABMODE_REPATCH_DELAY1_MS);
     if (IsWindow(hExplorer))
     {
         PatchExplorerWindow(hExplorer);
-        Log(L"[ExplorerNavHook] tabmode repatch #2 done");
+        Wh_Log(L"Tabmode repatch #2 done");
     }
 
     EnterCriticalSection(&g_StateLock);
@@ -351,7 +327,7 @@ static void ScheduleTabModeRepatch(HWND hExplorer)
     if (hThread)
     {
         CloseHandle(hThread);
-        Log(L"[ExplorerNavHook] tabmode repatch scheduled");
+        Wh_Log(L"Tabmode repatch scheduled");
     }
     else
     {
@@ -406,8 +382,7 @@ static void UpdateExplorerStateAndMaybeRepatch(HWND hExplorer)
 
     if (needRepatch)
     {
-        LogFmt(L"[ExplorerNavHook] tree hwnd changed old=%p new=%p",
-               (UINT_PTR)oldTree, (UINT_PTR)currentTree);
+        Wh_Log(L"Tree hwnd changed old=%p new=%p", oldTree, currentTree);
         ScheduleTabModeRepatch(hExplorer);
     }
 }
@@ -418,9 +393,7 @@ static BOOL CALLBACK EnumTopWindowsProc(HWND hwnd, LPARAM)
     GetWindowThreadProcessId(hwnd, &pid);
 
     if (pid == GetCurrentProcessId() && IsExplorerTopWindow(hwnd))
-    {
         UpdateExplorerStateAndMaybeRepatch(hwnd);
-    }
 
     return TRUE;
 }
@@ -449,8 +422,7 @@ static void CALLBACK WinEventProc(
 
     if (IsExplorerTopWindow(hwnd))
     {
-        LogFmt(L"[ExplorerNavHook] top explorer event=%u hwnd=%p",
-               (UINT_PTR)event, (UINT_PTR)hwnd);
+        Wh_Log(L"Top explorer event=%u hwnd=%p", event, hwnd);
         UpdateExplorerStateAndMaybeRepatch(hwnd);
         return;
     }
@@ -460,8 +432,7 @@ static void CALLBACK WinEventProc(
         HWND hExplorer = FindExplorerTopWindowFromChild(hwnd);
         if (hExplorer)
         {
-            LogFmt(L"[ExplorerNavHook] nav tree event=%u hwnd=%p",
-                   (UINT_PTR)event, (UINT_PTR)hwnd);
+            Wh_Log(L"Nav tree event=%u hwnd=%p", event, hwnd);
             UpdateExplorerStateAndMaybeRepatch(hExplorer);
         }
         else
@@ -473,16 +444,14 @@ static void CALLBACK WinEventProc(
 
     HWND hExplorer = FindExplorerTopWindowFromChild(hwnd);
     if (hExplorer)
-    {
         UpdateExplorerStateAndMaybeRepatch(hExplorer);
-    }
 }
 
 static DWORD WINAPI WorkerThreadProc(LPVOID)
 {
     InitializeCriticalSection(&g_StateLock);
 
-    Log(L"[ExplorerNavHook] worker started");
+    Wh_Log(L"Worker started");
 
     InitialPatchAllExplorerWindows();
 
@@ -495,8 +464,7 @@ static DWORD WINAPI WorkerThreadProc(LPVOID)
         WinEventProc,
         pid,
         0,
-        WINEVENT_OUTOFCONTEXT
-    );
+        WINEVENT_OUTOFCONTEXT);
 
     g_hEventHookCreate = SetWinEventHook(
         EVENT_OBJECT_CREATE,
@@ -505,13 +473,12 @@ static DWORD WINAPI WorkerThreadProc(LPVOID)
         WinEventProc,
         pid,
         0,
-        WINEVENT_OUTOFCONTEXT
-    );
+        WINEVENT_OUTOFCONTEXT);
 
     if (!g_hEventHookShow || !g_hEventHookCreate)
-        Log(L"[ExplorerNavHook] failed to install WinEvent hook");
+        Wh_Log(L"Failed to install WinEvent hook");
     else
-        Log(L"[ExplorerNavHook] WinEvent hooks installed");
+        Wh_Log(L"WinEvent hooks installed");
 
     MSG msg;
     while (GetMessageW(&msg, nullptr, 0, 0) > 0)
@@ -534,9 +501,10 @@ static DWORD WINAPI WorkerThreadProc(LPVOID)
 
     DeleteCriticalSection(&g_StateLock);
 
-    Log(L"[ExplorerNavHook] worker stopped");
+    Wh_Log(L"Worker stopped");
     return 0;
 }
+
 BOOL Wh_ModInit()
 {
     LoadSettings();
@@ -547,27 +515,24 @@ BOOL Wh_ModInit()
         WorkerThreadProc,
         nullptr,
         0,
-        &g_WorkerThreadId
-    );
+        &g_WorkerThreadId);
 
     if (!g_hWorkerThread)
     {
-        Wh_Log(L"[ExplorerNavHook] failed to create worker thread");
+        Wh_Log(L"Failed to create worker thread");
         return FALSE;
     }
 
-    Wh_Log(L"[ExplorerNavHook] mod initialized");
+    Wh_Log(L"Mod initialized");
     return TRUE;
 }
 
 void Wh_ModUninit()
 {
-    Wh_Log(L"[ExplorerNavHook] uninitializing");
+    Wh_Log(L"Uninitializing");
 
     if (g_WorkerThreadId)
-    {
         PostThreadMessageW(g_WorkerThreadId, WM_QUIT, 0, 0);
-    }
 
     if (g_hWorkerThread)
     {

--- a/mods/explorer-navigation-pane-tweaks.wh.cpp
+++ b/mods/explorer-navigation-pane-tweaks.wh.cpp
@@ -4,7 +4,7 @@
 // @description     Adjusts the navigation pane tree indent and treeview visual styles in Windows Explorer
 // @version         1.0
 // @author          Languster
-// @github          https://github.com/Languster
+// @github          https://github.com/Languster/
 // @include         %SystemRoot%\explorer.exe
 // @architecture    x86-64
 // @compilerOptions -lcomctl32
@@ -41,34 +41,46 @@ Adjusts the indentation and visual tree style of the navigation pane in Windows 
 - **Remove TVS_LINESATROOT**: removes root lines
 - **Enable log**: writes debug messages to the Windhawk log
 
+## Compatibility
+
+- designed for Windows Explorer (`explorer.exe`)
+- tested with the original ExplorerNavHook behavior migrated to Windhawk
+- behavior may vary between different Windows builds and Explorer variants
+
 ## Notes
 
 - targets `explorer.exe`
 - based on the original ExplorerNavHook project
 - changes apply to the Explorer navigation tree
+
+## Limitations
+
+- this mod targets the navigation tree in Explorer, not every tree view in the system
+- some Explorer variants or future Windows updates may behave differently
+- visual results depend on the current Explorer implementation
 */
 // ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
 /*
 - TargetIndent: 25
-  $name: Target indent
-  $description: Tree indent value for the Explorer navigation pane
+  $name: Navigation tree indent
+  $description: Controls the horizontal indent of items in the Explorer navigation pane
 
 - RemoveHasButtons: true
-  $name: Remove TVS_HASBUTTONS
-  $description: Removes expand/collapse buttons from the tree style
+  $name: Remove expand/collapse buttons
+  $description: Removes the tree expand/collapse buttons in the navigation pane
 
 - RemoveHasLines: true
-  $name: Remove TVS_HASLINES
-  $description: Removes connector lines from the tree style
+  $name: Remove connector lines
+  $description: Removes the tree connector lines in the navigation pane
 
 - RemoveLinesAtRoot: true
-  $name: Remove TVS_LINESATROOT
-  $description: Removes root lines / the first root expand visual
+  $name: Remove root lines
+  $description: Removes root-level tree lines and the first root expand visual
 
 - EnableLog: false
-  $name: Enable log
+  $name: Enable debug logging
   $description: Writes debug messages to the Windhawk log
 */
 // ==/WindhawkModSettings==
@@ -220,7 +232,6 @@ static BOOL CALLBACK FindTreeEnumProc(HWND hwnd, LPARAM lParam)
         return FALSE;
     }
 
-    EnumChildWindows(hwnd, FindTreeEnumProc, lParam);
     return TRUE;
 }
 
@@ -471,7 +482,6 @@ static DWORD WINAPI WorkerThreadProc(LPVOID)
 {
     InitializeCriticalSection(&g_StateLock);
 
-    LoadSettings();
     Log(L"[ExplorerNavHook] worker started");
 
     InitialPatchAllExplorerWindows();

--- a/mods/explorer-navigation-pane-tweaks.wh.cpp
+++ b/mods/explorer-navigation-pane-tweaks.wh.cpp
@@ -1,0 +1,578 @@
+// ==WindhawkMod==
+// @id              explorer-navigation-pane-tweaks
+// @name            Explorer Navigation Pane Tweaks
+// @description     Adjusts the navigation pane tree indent and treeview visual styles in Windows Explorer
+// @version         1.0
+// @author          Languster
+// @github          https://github.com/Languster/ExplorerNavHook
+// @include         %SystemRoot%\explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lcomctl32
+// @license         MIT
+// ==/WindhawkMod==
+// ==WindhawkModReadme==
+/*
+# Explorer Navigation Pane Tweaks
+
+Adjusts the indentation and visual tree style of the navigation pane in Windows Explorer.
+
+## Before / After
+
+### Default Explorer
+
+![Before](https://raw.githubusercontent.com/Languster/ExplorerNavHook/main/screenshots/before.jpg)
+
+### With Explorer Navigation Pane Tweaks
+
+![After](https://raw.githubusercontent.com/Languster/ExplorerNavHook/main/screenshots/after.jpg)
+
+## Features
+
+- changes the navigation tree indent
+- can remove expand/collapse buttons
+- can remove connector lines
+- can remove root lines
+
+## Settings
+
+- **Target indent**: controls how far the tree items are shifted
+- **Remove TVS_HASBUTTONS**: removes tree buttons
+- **Remove TVS_HASLINES**: removes connector lines
+- **Remove TVS_LINESATROOT**: removes root lines
+- **Enable log**: writes debug messages to the Windhawk log
+
+## Notes
+
+- targets `explorer.exe`
+- based on the original ExplorerNavHook project
+- changes apply to the Explorer navigation tree
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- TargetIndent: 25
+  $name: Target indent
+  $description: Tree indent value for the Explorer navigation pane
+
+- RemoveHasButtons: true
+  $name: Remove TVS_HASBUTTONS
+  $description: Removes expand/collapse buttons from the tree style
+
+- RemoveHasLines: true
+  $name: Remove TVS_HASLINES
+  $description: Removes connector lines from the tree style
+
+- RemoveLinesAtRoot: true
+  $name: Remove TVS_LINESATROOT
+  $description: Removes root lines / the first root expand visual
+
+- EnableLog: false
+  $name: Enable log
+  $description: Writes debug messages to the Windhawk log
+*/
+// ==/WindhawkModSettings==
+#include <windows.h>
+#include <commctrl.h>
+#include <vector>
+
+struct ExplorerState
+{
+    HWND hExplorer;
+    HWND hTree;
+    bool repatchPending;
+};
+
+static HANDLE g_hWorkerThread = nullptr;
+static DWORD g_WorkerThreadId = 0;
+static HWINEVENTHOOK g_hEventHookShow = nullptr;
+static HWINEVENTHOOK g_hEventHookCreate = nullptr;
+
+static int  g_TargetIndent = 25;
+static BOOL g_RemoveHasButtons = TRUE;
+static BOOL g_RemoveHasLines = TRUE;
+static BOOL g_RemoveLinesAtRoot = TRUE;
+static BOOL g_EnableLog = FALSE;
+
+static CRITICAL_SECTION g_StateLock;
+static std::vector<ExplorerState> g_States;
+
+#define TABMODE_REPATCH_DELAY1_MS 120
+#define TABMODE_REPATCH_DELAY2_MS 320
+
+static void Log(const wchar_t* text)
+{
+    if (g_EnableLog)
+        Wh_Log(L"%s", text);
+}
+
+static void LogFmt(const wchar_t* fmt, UINT_PTR a = 0, UINT_PTR b = 0)
+{
+    wchar_t buf[512] = {};
+    wsprintfW(buf, fmt, a, b);
+    Log(buf);
+}
+
+static void LoadSettings()
+{
+    g_TargetIndent = Wh_GetIntSetting(L"TargetIndent");
+    g_RemoveHasButtons = Wh_GetIntSetting(L"RemoveHasButtons");
+    g_RemoveHasLines = Wh_GetIntSetting(L"RemoveHasLines");
+    g_RemoveLinesAtRoot = Wh_GetIntSetting(L"RemoveLinesAtRoot");
+    g_EnableLog = Wh_GetIntSetting(L"EnableLog");
+
+    LogFmt(L"[ExplorerNavHook] settings loaded, indent=%u", (UINT_PTR)g_TargetIndent);
+}
+static bool IsExplorerTopWindow(HWND hwnd)
+{
+    if (!IsWindow(hwnd))
+        return false;
+
+    wchar_t cls[128] = {};
+    GetClassNameW(hwnd, cls, 128);
+
+    return (lstrcmpiW(cls, L"CabinetWClass") == 0 ||
+            lstrcmpiW(cls, L"ExploreWClass") == 0);
+}
+
+static HWND FindExplorerTopWindowFromChild(HWND hwnd)
+{
+    HWND cur = hwnd;
+
+    for (int i = 0; i < 20 && cur; ++i)
+    {
+        if (IsExplorerTopWindow(cur))
+            return cur;
+
+        cur = GetParent(cur);
+    }
+
+    return nullptr;
+}
+
+static bool IsLikelyNavTree(HWND hwnd)
+{
+    if (!IsWindow(hwnd))
+        return false;
+
+    wchar_t cls[128] = {};
+    GetClassNameW(hwnd, cls, 128);
+
+    if (lstrcmpiW(cls, WC_TREEVIEWW) != 0 &&
+        lstrcmpiW(cls, L"SysTreeView32") != 0)
+        return false;
+
+    RECT rc{};
+    if (!GetWindowRect(hwnd, &rc))
+        return false;
+
+    int w = rc.right - rc.left;
+    int h = rc.bottom - rc.top;
+
+    if (w < 120 || h < 200)
+        return false;
+
+    return FindExplorerTopWindowFromChild(hwnd) != nullptr;
+}
+
+static void PatchTree(HWND hTree)
+{
+    if (!IsWindow(hTree))
+        return;
+
+    LONG_PTR style = GetWindowLongPtrW(hTree, GWL_STYLE);
+
+    if (g_RemoveHasButtons)
+        style &= ~TVS_HASBUTTONS;
+
+    if (g_RemoveHasLines)
+        style &= ~TVS_HASLINES;
+
+    if (g_RemoveLinesAtRoot)
+        style &= ~TVS_LINESATROOT;
+
+    SetWindowLongPtrW(hTree, GWL_STYLE, style);
+
+    SendMessageW(hTree, TVM_SETINDENT, (WPARAM)g_TargetIndent, 0);
+
+    SetWindowPos(
+        hTree,
+        nullptr,
+        0, 0, 0, 0,
+        SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED
+    );
+
+    InvalidateRect(hTree, nullptr, TRUE);
+    UpdateWindow(hTree);
+
+    LogFmt(L"[ExplorerNavHook] patched tree hwnd=%p", (UINT_PTR)hTree);
+}
+
+static BOOL CALLBACK FindTreeEnumProc(HWND hwnd, LPARAM lParam)
+{
+    HWND* pFound = (HWND*)lParam;
+    if (*pFound)
+        return FALSE;
+
+    if (IsLikelyNavTree(hwnd))
+    {
+        *pFound = hwnd;
+        return FALSE;
+    }
+
+    EnumChildWindows(hwnd, FindTreeEnumProc, lParam);
+    return TRUE;
+}
+
+static HWND FindNavTreeInExplorer(HWND hExplorer)
+{
+    if (!IsExplorerTopWindow(hExplorer))
+        return nullptr;
+
+    HWND found = nullptr;
+    EnumChildWindows(hExplorer, FindTreeEnumProc, (LPARAM)&found);
+    return found;
+}
+
+static void PatchExplorerWindow(HWND hExplorer)
+{
+    HWND hTree = FindNavTreeInExplorer(hExplorer);
+    if (hTree)
+        PatchTree(hTree);
+}
+
+static ExplorerState* GetOrCreateState_NoLock(HWND hExplorer)
+{
+    for (auto& s : g_States)
+    {
+        if (s.hExplorer == hExplorer)
+            return &s;
+    }
+
+    ExplorerState s{};
+    s.hExplorer = hExplorer;
+    s.hTree = nullptr;
+    s.repatchPending = false;
+    g_States.push_back(s);
+    return &g_States.back();
+}
+
+static void CleanupDeadStates()
+{
+    EnterCriticalSection(&g_StateLock);
+
+    for (size_t i = 0; i < g_States.size(); )
+    {
+        if (!IsWindow(g_States[i].hExplorer))
+            g_States.erase(g_States.begin() + i);
+        else
+            ++i;
+    }
+
+    LeaveCriticalSection(&g_StateLock);
+}
+
+struct RepatchContext
+{
+    HWND hExplorer;
+};
+
+static DWORD WINAPI RepatchThreadProc(LPVOID param)
+{
+    RepatchContext* ctx = (RepatchContext*)param;
+    if (!ctx)
+        return 0;
+
+    HWND hExplorer = ctx->hExplorer;
+    delete ctx;
+
+    Sleep(TABMODE_REPATCH_DELAY1_MS);
+    if (IsWindow(hExplorer))
+    {
+        PatchExplorerWindow(hExplorer);
+        Log(L"[ExplorerNavHook] tabmode repatch #1 done");
+    }
+
+    Sleep(TABMODE_REPATCH_DELAY2_MS - TABMODE_REPATCH_DELAY1_MS);
+    if (IsWindow(hExplorer))
+    {
+        PatchExplorerWindow(hExplorer);
+        Log(L"[ExplorerNavHook] tabmode repatch #2 done");
+    }
+
+    EnterCriticalSection(&g_StateLock);
+    for (auto& s : g_States)
+    {
+        if (s.hExplorer == hExplorer)
+        {
+            s.repatchPending = false;
+            break;
+        }
+    }
+    LeaveCriticalSection(&g_StateLock);
+
+    return 0;
+}
+
+static void ScheduleTabModeRepatch(HWND hExplorer)
+{
+    if (!IsWindow(hExplorer))
+        return;
+
+    bool shouldStart = false;
+
+    EnterCriticalSection(&g_StateLock);
+    ExplorerState* s = GetOrCreateState_NoLock(hExplorer);
+    if (s && !s->repatchPending)
+    {
+        s->repatchPending = true;
+        shouldStart = true;
+    }
+    LeaveCriticalSection(&g_StateLock);
+
+    if (!shouldStart)
+        return;
+
+    RepatchContext* ctx = new RepatchContext{};
+    ctx->hExplorer = hExplorer;
+
+    HANDLE hThread = CreateThread(nullptr, 0, RepatchThreadProc, ctx, 0, nullptr);
+    if (hThread)
+    {
+        CloseHandle(hThread);
+        Log(L"[ExplorerNavHook] tabmode repatch scheduled");
+    }
+    else
+    {
+        EnterCriticalSection(&g_StateLock);
+        for (auto& s : g_States)
+        {
+            if (s.hExplorer == hExplorer)
+            {
+                s.repatchPending = false;
+                break;
+            }
+        }
+        LeaveCriticalSection(&g_StateLock);
+
+        delete ctx;
+    }
+}
+
+static void UpdateExplorerStateAndMaybeRepatch(HWND hExplorer)
+{
+    if (!IsExplorerTopWindow(hExplorer))
+        return;
+
+    HWND currentTree = FindNavTreeInExplorer(hExplorer);
+    if (!currentTree)
+        return;
+
+    bool needRepatch = false;
+    HWND oldTree = nullptr;
+
+    EnterCriticalSection(&g_StateLock);
+
+    ExplorerState* s = GetOrCreateState_NoLock(hExplorer);
+    if (s)
+    {
+        oldTree = s->hTree;
+
+        if (s->hTree == nullptr)
+        {
+            s->hTree = currentTree;
+        }
+        else if (s->hTree != currentTree)
+        {
+            s->hTree = currentTree;
+            needRepatch = true;
+        }
+    }
+
+    LeaveCriticalSection(&g_StateLock);
+
+    PatchTree(currentTree);
+
+    if (needRepatch)
+    {
+        LogFmt(L"[ExplorerNavHook] tree hwnd changed old=%p new=%p",
+               (UINT_PTR)oldTree, (UINT_PTR)currentTree);
+        ScheduleTabModeRepatch(hExplorer);
+    }
+}
+
+static BOOL CALLBACK EnumTopWindowsProc(HWND hwnd, LPARAM)
+{
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hwnd, &pid);
+
+    if (pid == GetCurrentProcessId() && IsExplorerTopWindow(hwnd))
+    {
+        UpdateExplorerStateAndMaybeRepatch(hwnd);
+    }
+
+    return TRUE;
+}
+
+static void InitialPatchAllExplorerWindows()
+{
+    EnumWindows(EnumTopWindowsProc, 0);
+}
+
+static void CALLBACK WinEventProc(
+    HWINEVENTHOOK,
+    DWORD event,
+    HWND hwnd,
+    LONG idObject,
+    LONG,
+    DWORD,
+    DWORD)
+{
+    if (!hwnd)
+        return;
+
+    if (idObject != OBJID_WINDOW)
+        return;
+
+    CleanupDeadStates();
+
+    if (IsExplorerTopWindow(hwnd))
+    {
+        LogFmt(L"[ExplorerNavHook] top explorer event=%u hwnd=%p",
+               (UINT_PTR)event, (UINT_PTR)hwnd);
+        UpdateExplorerStateAndMaybeRepatch(hwnd);
+        return;
+    }
+
+    if (IsLikelyNavTree(hwnd))
+    {
+        HWND hExplorer = FindExplorerTopWindowFromChild(hwnd);
+        if (hExplorer)
+        {
+            LogFmt(L"[ExplorerNavHook] nav tree event=%u hwnd=%p",
+                   (UINT_PTR)event, (UINT_PTR)hwnd);
+            UpdateExplorerStateAndMaybeRepatch(hExplorer);
+        }
+        else
+        {
+            PatchTree(hwnd);
+        }
+        return;
+    }
+
+    HWND hExplorer = FindExplorerTopWindowFromChild(hwnd);
+    if (hExplorer)
+    {
+        UpdateExplorerStateAndMaybeRepatch(hExplorer);
+    }
+}
+
+static DWORD WINAPI WorkerThreadProc(LPVOID)
+{
+    InitializeCriticalSection(&g_StateLock);
+
+    LoadSettings();
+    Log(L"[ExplorerNavHook] worker started");
+
+    InitialPatchAllExplorerWindows();
+
+    DWORD pid = GetCurrentProcessId();
+
+    g_hEventHookShow = SetWinEventHook(
+        EVENT_OBJECT_SHOW,
+        EVENT_OBJECT_SHOW,
+        nullptr,
+        WinEventProc,
+        pid,
+        0,
+        WINEVENT_OUTOFCONTEXT
+    );
+
+    g_hEventHookCreate = SetWinEventHook(
+        EVENT_OBJECT_CREATE,
+        EVENT_OBJECT_CREATE,
+        nullptr,
+        WinEventProc,
+        pid,
+        0,
+        WINEVENT_OUTOFCONTEXT
+    );
+
+    if (!g_hEventHookShow || !g_hEventHookCreate)
+        Log(L"[ExplorerNavHook] failed to install WinEvent hook");
+    else
+        Log(L"[ExplorerNavHook] WinEvent hooks installed");
+
+    MSG msg;
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0)
+    {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    if (g_hEventHookShow)
+    {
+        UnhookWinEvent(g_hEventHookShow);
+        g_hEventHookShow = nullptr;
+    }
+
+    if (g_hEventHookCreate)
+    {
+        UnhookWinEvent(g_hEventHookCreate);
+        g_hEventHookCreate = nullptr;
+    }
+
+    DeleteCriticalSection(&g_StateLock);
+
+    Log(L"[ExplorerNavHook] worker stopped");
+    return 0;
+}
+BOOL Wh_ModInit()
+{
+    LoadSettings();
+
+    g_hWorkerThread = CreateThread(
+        nullptr,
+        0,
+        WorkerThreadProc,
+        nullptr,
+        0,
+        &g_WorkerThreadId
+    );
+
+    if (!g_hWorkerThread)
+    {
+        Wh_Log(L"[ExplorerNavHook] failed to create worker thread");
+        return FALSE;
+    }
+
+    Wh_Log(L"[ExplorerNavHook] mod initialized");
+    return TRUE;
+}
+
+void Wh_ModUninit()
+{
+    Wh_Log(L"[ExplorerNavHook] uninitializing");
+
+    if (g_WorkerThreadId)
+    {
+        PostThreadMessageW(g_WorkerThreadId, WM_QUIT, 0, 0);
+    }
+
+    if (g_hWorkerThread)
+    {
+        WaitForSingleObject(g_hWorkerThread, 3000);
+        CloseHandle(g_hWorkerThread);
+        g_hWorkerThread = nullptr;
+    }
+
+    g_WorkerThreadId = 0;
+}
+
+BOOL Wh_ModSettingsChanged(BOOL* bReload)
+{
+    if (bReload)
+        *bReload = TRUE;
+
+    return TRUE;
+}

--- a/mods/explorer-navigation-pane-tweaks.wh.cpp
+++ b/mods/explorer-navigation-pane-tweaks.wh.cpp
@@ -551,4 +551,3 @@ BOOL Wh_ModSettingsChanged(BOOL* bReload)
 
     return TRUE;
 }
-


### PR DESCRIPTION
## What this PR adds

A new Windhawk mod: **Explorer Navigation Pane Tweaks**

It adjusts the indentation and visual tree style of the navigation pane in Windows Explorer.

### Main features

- changes the navigation tree indent
- can remove expand/collapse buttons
- can remove connector lines
- can remove root lines

### Notes

- based on my original ExplorerNavHook project
- GitHub project: https://github.com/Languster/ExplorerNavHook

<!-- ⚠️ Please don't remove the template below. Add your content above the template. -->

## Changelog

* Initial release

## Mod authorship

This mod was created by:

- [x] Manually by the submitter (with AI assistance)
- [ ] Claude Code
- [x] ChatGPT
- [ ] Gemini
- [ ] Another AI (please specify):
- [ ] Other (please specify):