### PR TITLE
add Discord Transparency Resize Fix

### DIFF
--- a/mods/resizable-discord.wh.cpp
+++ b/mods/resizable-discord.wh.cpp
@@ -2,7 +2,7 @@
 // @id              resizable-discord
 // @name            Discord Transparency Resize Fix
 // @description     Forces discord to be resizable with vencord window transparency
-// @version         1.0.0
+// @version         1.0.1
 // @author          gameknight963
 // @include         discord.exe
 // @github          https://github.com/Gameknight963
@@ -12,7 +12,7 @@
 /*
 This mod forces resizing on Discord when using window transparency + native titlebar.
 
-How it works: It enables WS_THICKFRAME for proper resizing behavior,
+How it works: It enables WS_THICKFRAME by hooking ,
 which Discord disables because it uses a custom titlebar, and Electron handles
 the resize logic through software in this custom titlebar mode.
 
@@ -24,21 +24,31 @@ the window is not resizable. This mod fixes that.
 
 #include <windows.h>
 
+typedef BOOL(WINAPI* ShowWindow_t)(HWND, int);
+ShowWindow_t ShowWindow_Original;
+
 void HookWindow(HWND hWnd)
 {
-    wchar_t className[256];
-    GetClassNameW(hWnd, className, 256);
-    if (wcscmp(className, L"Chrome_WidgetWin_1") != 0)
-        return;
+    DWORD pid;
+    GetWindowThreadProcessId(hWnd, &pid);
+    if (pid != GetCurrentProcessId()) return;
 
     LONG_PTR style = GetWindowLongPtr(hWnd, GWL_STYLE);
+    if (style & WS_POPUP)
+        return;
     SetWindowLongPtr(hWnd, GWL_STYLE, style | WS_THICKFRAME);
+}
+
+BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
+    HookWindow(hWnd);
+    return ShowWindow_Original(hWnd, nCmdShow);
 }
 
 BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM) { HookWindow(hWnd); return TRUE; }
 
 BOOL Wh_ModInit()
 {
+    Wh_SetFunctionHook((void*)ShowWindow, (void*)ShowWindow_Hook, (void**)&ShowWindow_Original);
     EnumWindows(EnumWindowsProc, 0);
     return TRUE;
 }

--- a/mods/resizable-discord.wh.cpp
+++ b/mods/resizable-discord.wh.cpp
@@ -1,0 +1,44 @@
+// ==WindhawkMod==
+// @id              resizable-discord
+// @name            Discord Transparency Resize Fix
+// @description     Forces discord to be resizable with vencord window transparency
+// @version         1.0.0
+// @author          gameknight963
+// @include         discord.exe
+// @github          https://github.com/Gameknight963
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+This mod forces resizing on Discord when using window transparency + native titlebar.
+
+How it works: It enables WS_THICKFRAME for proper resizing behavior,
+which Discord disables because it uses a custom titlebar, and Electron handles
+the resize logic through software in this custom titlebar mode.
+
+When Vencord turns on custom titlebar, it doesn't set WS_THICKFRAME, so
+the window is not resizable. This mod fixes that.
+
+*/
+// ==/WindhawkModReadme==
+
+#include <windows.h>
+
+void HookWindow(HWND hWnd)
+{
+    wchar_t className[256];
+    GetClassNameW(hWnd, className, 256);
+    if (wcscmp(className, L"Chrome_WidgetWin_1") != 0)
+        return;
+
+    LONG_PTR style = GetWindowLongPtr(hWnd, GWL_STYLE);
+    SetWindowLongPtr(hWnd, GWL_STYLE, style | WS_THICKFRAME);
+}
+
+BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM) { HookWindow(hWnd); return TRUE; }
+
+BOOL Wh_ModInit()
+{
+    EnumWindows(EnumWindowsProc, 0);
+    return TRUE;
+}

--- a/mods/resizable-discord.wh.cpp
+++ b/mods/resizable-discord.wh.cpp
@@ -12,13 +12,12 @@
 /*
 This mod forces resizing on Discord when using window transparency + native titlebar.
 
-How it works: It enables WS_THICKFRAME by hooking ,
-which Discord disables because it uses a custom titlebar, and Electron handles
-the resize logic through software in this custom titlebar mode.
+How it works: It hooks ShowWindow to enable WS_THICKFRAME, which Discord 
+disables because it uses a custom titlebar. When it's disabled, Electron handles
+the resize logic through software. When Vencord turns on custom titlebar, it doesn't 
+set WS_THICKFRAME, so the window is not resizable. This mod fixes that.
 
-When Vencord turns on custom titlebar, it doesn't set WS_THICKFRAME, so
-the window is not resizable. This mod fixes that.
-
+![Image showing resizable cursor on border](https://i.imgur.com/GNRdQ5A.png)
 */
 // ==/WindhawkModReadme==
 


### PR DESCRIPTION
Adds a mod that fixes Discord being non-resizable when using Vencord's window transparency + native titlebar option, by setting WS_THICKFRAME on Discord's window.

## Changelog

* Initial release

## Mod authorship

This mod was created by:

- - [x] Manually by the submitter (with AI assistance)
- - [ ] Claude Code
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 
