### PR TITLE
hotcorner-hotkeys: v2.4 - add 3 new actions, extended opacity args, c…

### DIFF
--- a/mods/hotcorner-hotkeys.wh.cpp
+++ b/mods/hotcorner-hotkeys.wh.cpp
@@ -1,12 +1,12 @@
 // ==WindhawkMod==
-// @id              hotcorner-hotkeys
-// @name            HotCorner Hotkeys
-// @description     Global hotkeys routed by cursor zone (corner/edge) to run different actions; no-match consumes the hotkey.
-// @version         2.0
-// @author          webberlv
-// @github          https://github.com/webberLV
-// @license         GPL-3.0-only
-// @include         explorer.exe
+// @id                   hotcorner-hotkeys
+// @name                 HotCorner Hotkeys
+// @description          Assign configurable keyboard hotkeys to up to 8 actions, gated by cursor zones (four corners + four edges) of the active monitor.
+// @version              2.4
+// @author               webberlv
+// @github               https://github.com/webberLV
+// @license              GPL-3.0-only
+// @include             explorer.exe
 // @compilerOptions -lcomctl32 -loleaut32 -lole32 -lversion
 // ==/WindhawkMod==
 
@@ -19,13 +19,9 @@
 /*
 # HotCorner Hotkeys
 
-This mod assigns global keyboard shortcuts to Windows actions.
-Each shortcut is registered once per unique key combination. When triggered,
-the current cursor position is sampled and used to dispatch the action mapped
-to the active screen zone (corner, edge). 
+This mod binds configurable keyboard hotkeys to screen zones defined by the four corners and four edges of the active monitor. Each hotkey is registered once per unique key combination and evaluated at trigger time using the current cursor position.
 
-A single hotkey may execute different actions depending on cursor location. If no zone is selected hotkey is consumed nothing happens. If you were hoping for the hotkey to function globally without a zone selection check out 
-[keyboard-shortcut-actions](https://windhawk.net/mods/keyboard-shortcut-actions) instead.
+When a hotkey is pressed, the cursor location determines which zone is active and dispatches the corresponding action. A single hotkey can therefore invoke up to eight distinct actions. If the cursor is not within a defined zone, the hotkey is intercepted and no action is executed. This mod is zone-gated by design and does not provide unconditional global hotkeys. If you were hoping for the hotkey to function globally without a zone selection restriction check out [keyboard-shortcut-actions](https://windhawk.net/mods/keyboard-shortcut-actions) instead. 
 
 ## Architecture
 
@@ -35,10 +31,7 @@ A single hotkey may execute different actions depending on cursor location. If n
   as a global hotkey.
 - **Dispatch**: On `WM_HOTKEY`, the cursor zone is computed and the
   `(hotkey, zone)` mapping is resolved and executed.
-
-
 ### Rules
-
 - Action identity is `(hotkey, zone)`
 - Zones are used only during dispatch
 - A hotkey may map to multiple actions across different zones
@@ -47,75 +40,60 @@ A single hotkey may execute different actions depending on cursor location. If n
 - If no action exists for the active cursor zone:
   - No action is executed
   - The hotkey is still consumed 
-
 ## Zones
-
 Zones are computed from the active monitor bounds using `GatePx`
 (pixel thickness).
-
 Corner zones take precedence over edge zones when regions overlap.
-
 Supported values:
-
 `NONE, LEFT, TOP_LEFT, TOP, TOP_RIGHT, RIGHT, BOTTOM_RIGHT, BOTTOM, BOTTOM_LEFT`
-
 `NONE` matches only when the cursor is outside all edge and corner gate regions.
-
 ## Supported actions
-
 1. **Show desktop**  
    Toggle desktop visibility
-
 2. **Ctrl+Alt+Tab**  
    Open the Ctrl+Alt+Tab dialog
-
 3. **Task Manager**  
    Open Windows Task Manager
-
 4. **Mute system volume**  
    Toggle system-wide mute
-
 5. **Taskbar auto-hide**  
    Toggle taskbar auto-hide
-
 6. **Win+Tab**  
    Open Task View
-
 7. **Hide desktop icons**  
    Toggle visibility of all desktop icons
-
 8. **Combine taskbar buttons**  
    Toggle taskbar button grouping between two states
-
 9. **Toggle taskbar alignment**  
    Toggle taskbar icon alignment (left/center, Windows 11 only)
-
 10. **Open Start menu**  
     Send the Win key
-
 11. **Virtual key press**  
     Send a virtual key sequence
-
 12. **Open application, path, or URL**  
     Launch an executable, open a path, or open a URL
-
 13. **Media Play/Pause**
-
 14. **Media Next Track**
-
 15. **Media Previous Track**
 
-## Hotkey format
+16. **Toggle Always On Top (active window)**  
+    Toggles `WS_EX_TOPMOST` on the current foreground window
+
+17. **Opacity Up (active window)**  
+    Increases window opacity
+
+18. **Opacity Down (active window)**  
+    Decreases window opacity
+
+# Hotkey format
 
 Hotkeys use the form:
 
 `Modifier+Modifier+Key`
 
-### Modifiers
-
+## Modifiers
 `Alt`, `Ctrl`, `Shift`, `Win`
-
-### Keys
+#### Keys
 
 - Letters: `A–Z`
 - Numbers: `0–9`
@@ -139,10 +117,10 @@ Hotkeys use the form:
 - `Ctrl+Shift+F1`
 - `Alt+Home`
 - `Win+Numpad1`
-
 ## Additional arguments
 
-Only actions **8**, **11**, and **12** accept `AdditionalArgs`.
+Actions 8, 11, 12, 17, and 18 accept AdditionalArgs.
+
 Arguments are separated by semicolons.
 
 ### 8. Combine taskbar buttons
@@ -187,6 +165,25 @@ Examples:
 - `"C:\Program Files\App\app.exe" --arg`
 - `https://example.com`
 - `uac;C:\Windows\System32\cmd.exe`
+
+### 17/18. Opacity Up / Down (active window)
+
+Tokens (semicolon separated). All tokens are optional.  
+Unspecified values use default behavior.
+
+- `step<number>`: Opacity step per press (default `0.05`)
+- `min<number>`: Minimum opacity clamp (default `0.10`)
+- `max<number>`: Maximum opacity clamp (default `1.00`)
+- `allApp`: Apply to all top-level windows in the same process as the foreground window
+- `dontLayer`: Do not automatically add `WS_EX_LAYERED`
+
+Examples:
+
+- `step0.03`
+- `step0.02;min0.30;max0.95`
+- `allApp;step0.02`
+- `allApp;dontLayer;min0.25;max0.90`
+
 
 ## Credits
 
@@ -254,6 +251,10 @@ by [m417z](https://github.com/m417z).
       - ACTION_MEDIA_PLAY_PAUSE: Media Play/Pause
       - ACTION_MEDIA_NEXT: Media Next Track
       - ACTION_MEDIA_PREV: Media Previous Track
+      - ACTION_TOGGLE_ALWAYSONTOP_ACTIVE: Toggle Always On Top (active window)
+      - ACTION_OPACITY_UP_ACTIVE: Opacity Up (active window)
+      - ACTION_OPACITY_DOWN_ACTIVE: Opacity Down (active window)
+
     - AdditionalArgs: ""
       $name: Additional Args
       $description: Additional arguments for the action (see Details tab).
@@ -334,6 +335,10 @@ enum class HotkeyActionType {
     MediaPlayPause,
     MediaNext,
     MediaPrev,
+    ToggleAlwaysOnTopActive,
+    OpacityUpActive,
+    OpacityDownActive,
+
 };
 
 enum class Zone : uint8_t {
@@ -1395,6 +1400,197 @@ void StartProcess(std::wstring command) {
         }
     }
 }
+// ===================== Window targeting + always-on-top + opacity =====================
+
+static HWND GetActiveTopLevelWindow() {
+    HWND h = GetForegroundWindow();
+    if (!h) return nullptr;
+
+    h = GetAncestor(h, GA_ROOT);
+    if (!h) return nullptr;
+
+    if (g_hTaskbarWnd && h == g_hTaskbarWnd) return nullptr;
+    if (!IsWindowVisible(h)) return nullptr;
+    return h;
+}
+
+static bool IsTopmost(HWND hWnd) {
+    LONG ex = GetWindowLong(hWnd, GWL_EXSTYLE);
+    return (ex & WS_EX_TOPMOST) != 0;
+}
+
+static void ToggleAlwaysOnTopActive() {
+    HWND h = GetActiveTopLevelWindow();
+    if (!h) return;
+
+    const bool cur = IsTopmost(h);
+    SetWindowPos(h, cur ? HWND_NOTOPMOST : HWND_TOPMOST,
+                 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+}
+
+struct OpacityConfig {
+    double step = 0.05;      // default (old hardcoded)
+    double min  = 0.10;      // default (old hardcoded)
+    double max  = 1.00;      // default (old hardcoded)
+    bool forceLayered = true; // default (old behavior)
+    bool applyToApp   = false; // default off
+};
+
+static bool EnsureLayered(HWND hWnd) {
+    LONG ex = GetWindowLong(hWnd, GWL_EXSTYLE);
+    if ((ex & WS_EX_LAYERED) == 0) {
+        SetWindowLong(hWnd, GWL_EXSTYLE, ex | WS_EX_LAYERED);
+    }
+    return true;
+}
+
+static double GetOpacity(HWND hWnd) {
+    LONG ex = GetWindowLong(hWnd, GWL_EXSTYLE);
+    if ((ex & WS_EX_LAYERED) == 0) return 1.0;
+
+    COLORREF cr = 0;
+    BYTE alpha = 255;
+    DWORD flags = 0;
+    if (!GetLayeredWindowAttributes(hWnd, &cr, &alpha, &flags)) return 1.0;
+    if ((flags & LWA_ALPHA) == 0) return 1.0;
+
+    return (double)alpha / 255.0;
+}
+
+static void SetOpacity(HWND hWnd, double opacity01, bool forceLayered) {
+    if (!hWnd) return;
+
+    if (opacity01 < 0.0) opacity01 = 0.0;
+    if (opacity01 > 1.0) opacity01 = 1.0;
+
+    LONG ex = GetWindowLong(hWnd, GWL_EXSTYLE);
+    if ((ex & WS_EX_LAYERED) == 0) {
+        if (!forceLayered) {
+            // Don't touch styles: cannot apply alpha if not already layered.
+            return;
+        }
+        EnsureLayered(hWnd);
+    }
+
+    int a = (int)lround(opacity01 * 255.0);
+    if (a < 0) a = 0;
+    if (a > 255) a = 255;
+
+    SetLayeredWindowAttributes(hWnd, 0, (BYTE)a, LWA_ALPHA);
+}
+
+static bool TryParseDoubleSuffix(const std::wstring& tokenLower,
+                                 const std::wstring& prefixLower,
+                                 double& out) {
+    if (tokenLower.rfind(prefixLower, 0) != 0) return false; // not prefix
+    std::wstring num = stringtools::trim(tokenLower.substr(prefixLower.size()));
+    if (num.empty()) return false;
+
+    try {
+        size_t pos = 0;
+        out = std::stod(num, &pos);
+        return pos == num.size();
+    } catch (...) {
+        return false;
+    }
+}
+
+static OpacityConfig ParseOpacityArgs_NoEquals(const std::wstring& args) {
+    OpacityConfig cfg; // defaults
+
+    auto parts = SplitArgs(args, L';');
+    for (auto p0 : parts) {
+        std::wstring p = stringtools::toLower(stringtools::trim(p0));
+        if (p.empty()) continue;
+
+        // flags
+        if (p == L"allapp" || p == L"app" || p == L"all") {
+            cfg.applyToApp = true;
+            continue;
+        }
+        if (p == L"dontlayer" || p == L"nostyle" || p == L"noexlayered") {
+            cfg.forceLayered = false;
+            continue;
+        }
+        if (p == L"layered" || p == L"forcelayered" || p == L"force-layered") {
+            cfg.forceLayered = true;
+            continue;
+        }
+
+        // prefix+number
+        double v = 0.0;
+        if (TryParseDoubleSuffix(p, L"step", v)) { cfg.step = v; continue; }
+        if (TryParseDoubleSuffix(p, L"min",  v)) { cfg.min  = v; continue; }
+        if (TryParseDoubleSuffix(p, L"max",  v)) { cfg.max  = v; continue; }
+    }
+
+    // sanitize
+    cfg.step = std::max(0.001, std::min(cfg.step, 1.0));
+    cfg.min  = std::max(0.0,   std::min(cfg.min,  1.0));
+    cfg.max  = std::max(0.0,   std::min(cfg.max,  1.0));
+    if (cfg.min > cfg.max) std::swap(cfg.min, cfg.max);
+
+    return cfg;
+}
+
+static bool IsEligibleOpacityTarget(HWND hWnd) {
+    if (!hWnd) return false;
+    if (!IsWindowVisible(hWnd)) return false;
+    if (g_hTaskbarWnd && hWnd == g_hTaskbarWnd) return false;
+    return true;
+}
+
+struct ApplyOpacityCtx {
+    DWORD pid = 0;
+    double opacity01 = 1.0;
+    const OpacityConfig* cfg = nullptr;
+};
+
+static BOOL CALLBACK EnumWindowsApplyOpacityProc(HWND hWnd, LPARAM lp) {
+    auto* ctx = reinterpret_cast<ApplyOpacityCtx*>(lp);
+    if (!ctx || !ctx->cfg) return TRUE;
+
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hWnd, &pid);
+    if (pid != ctx->pid) return TRUE;
+
+    if (!IsEligibleOpacityTarget(hWnd)) return TRUE;
+
+    SetOpacity(hWnd, ctx->opacity01, ctx->cfg->forceLayered);
+    return TRUE;
+}
+
+static void ChangeOpacityActive(double delta, const OpacityConfig& cfg) {
+    HWND h = GetActiveTopLevelWindow();
+    if (!h) return;
+
+    double cur = GetOpacity(h);
+    double next = cur + delta;
+
+    if (next < cfg.min) next = cfg.min;
+    if (next > cfg.max) next = cfg.max;
+
+    if (!cfg.applyToApp) {
+        SetOpacity(h, next, cfg.forceLayered);
+        return;
+    }
+
+    DWORD pid = 0;
+    GetWindowThreadProcessId(h, &pid);
+    if (!pid) return;
+
+    ApplyOpacityCtx ctx;
+    ctx.pid = pid;
+    ctx.opacity01 = next;
+    ctx.cfg = &cfg;
+
+    EnumWindows(EnumWindowsApplyOpacityProc, reinterpret_cast<LPARAM>(&ctx));
+}
+
+static void OpacityUpActive(const OpacityConfig& cfg)   { ChangeOpacityActive(+cfg.step, cfg); }
+static void OpacityDownActive(const OpacityConfig& cfg) { ChangeOpacityActive(-cfg.step, cfg); }
+
+// ===================== Virtual key press parsing stays same =====================
 
 std::vector<int> ParseVirtualKeypressSetting(const std::wstring& args) {
     std::vector<int> keys;
@@ -1438,6 +1634,9 @@ std::optional<HotkeyActionType> TryParseActionType(const std::wstring& actionNam
         {L"ACTION_MEDIA_PLAY_PAUSE", HotkeyActionType::MediaPlayPause},
         {L"ACTION_MEDIA_NEXT", HotkeyActionType::MediaNext},
         {L"ACTION_MEDIA_PREV", HotkeyActionType::MediaPrev},
+        {L"ACTION_TOGGLE_ALWAYSONTOP_ACTIVE", HotkeyActionType::ToggleAlwaysOnTopActive},
+        {L"ACTION_OPACITY_UP_ACTIVE", HotkeyActionType::OpacityUpActive},
+        {L"ACTION_OPACITY_DOWN_ACTIVE", HotkeyActionType::OpacityDownActive},
     };
 
     auto it = actionMap.find(key);
@@ -1465,6 +1664,9 @@ const wchar_t* ActionTypeToString(HotkeyActionType actionType) {
         case HotkeyActionType::MediaPlayPause: return L"MediaPlayPause";
         case HotkeyActionType::MediaNext: return L"MediaNext";
         case HotkeyActionType::MediaPrev: return L"MediaPrev";
+        case HotkeyActionType::ToggleAlwaysOnTopActive: return L"ToggleAlwaysOnTopActive";
+        case HotkeyActionType::OpacityUpActive: return L"OpacityUpActive";
+        case HotkeyActionType::OpacityDownActive: return L"OpacityDownActive";
     }
     return L"Unknown";
 }
@@ -1562,6 +1764,22 @@ bool TryBuildActionExecutor(HotkeyActionType actionType,
         case HotkeyActionType::MediaPrev:
             executorOut = []() { MediaPrev(); };
             return true;
+
+        case HotkeyActionType::ToggleAlwaysOnTopActive:
+            executorOut = []() { ToggleAlwaysOnTopActive(); };
+            return true;
+
+        case HotkeyActionType::OpacityUpActive: {
+            const OpacityConfig cfg = ParseOpacityArgs_NoEquals(args);
+            executorOut = [cfg]() { OpacityUpActive(cfg); };
+            return true;
+        }
+
+        case HotkeyActionType::OpacityDownActive: {
+            const OpacityConfig cfg = ParseOpacityArgs_NoEquals(args);
+            executorOut = [cfg]() { OpacityDownActive(cfg); };
+            return true;
+        }
     }
 
     errorOut = L"Unknown action type";
@@ -1593,7 +1811,6 @@ LRESULT CALLBACK TaskbarWindowSubclassProc(_In_ HWND hWnd,
 
         bool anyIdMatch = false;
         bool executed = false;
-
         for (const auto& action : g_settings.hotkeyActions) {
             if (!action.registered) {
                 continue;
@@ -1601,7 +1818,6 @@ LRESULT CALLBACK TaskbarWindowSubclassProc(_In_ HWND hWnd,
             if (action.hotkeyId != hotkeyId) {
                 continue;
             }
-
             anyIdMatch = true;
 
             if (action.zone != zone) {
@@ -2035,5 +2251,4 @@ void Wh_ModSettingsChanged() {
         SendMessage(g_hTaskbarWnd, g_hotkeyRegisteredMsg, HOTKEY_REGISTER, 0);
     }
 }
-
-#pragma endregion  // windhawk_exports
+#pragma endregion // windhawk_exports

--- a/mods/hotcorner-hotkeys.wh.cpp
+++ b/mods/hotcorner-hotkeys.wh.cpp
@@ -357,6 +357,7 @@ enum TaskBarButtonsState {
 };
 
 // Enum for hotkey actions
+
 enum class HotkeyActionType {
     Nothing,
     ShowDesktop,
@@ -372,14 +373,14 @@ enum class HotkeyActionType {
     SendKeypress,
     StartProcess,
     CopyRun,
-    MediaPlayPause,
-    MediaNext,
-    MediaPrev,
+    SelectActiveInExplorer,
     OpacityUp,
     OpacityDown,
     ToggleAlwaysOnTop,
     ForceKillActive,
-    SelectActiveInExplorer,
+    MediaPlayPause,
+    MediaNext,
+    MediaPrev,
     Invalid,
 };
 

--- a/mods/hotcorner-hotkeys.wh.cpp
+++ b/mods/hotcorner-hotkeys.wh.cpp
@@ -306,6 +306,7 @@ by [m417z](https://github.com/m417z).
 #include <string>
 #include <string_view>
 #include <unordered_map>
+
 #include <vector>
 
 #if defined(__GNUC__) && __GNUC__ > 8
@@ -1750,41 +1751,78 @@ HotkeyActionType TryParseActionType(const std::wstring& raw) {
 }
 
 const wchar_t* RegionNameToString(HotkeyRegionName region) {
-    if (region == HotkeyRegionName::TOP_LEFT) return L"TOP_LEFT";
-    if (region == HotkeyRegionName::TOP) return L"TOP";
-    if (region == HotkeyRegionName::TOP_RIGHT) return L"TOP_RIGHT";
-    if (region == HotkeyRegionName::LEFT) return L"LEFT";
-    if (region == HotkeyRegionName::Elsewhere) return L"Elsewhere";
-    if (region == HotkeyRegionName::RIGHT) return L"RIGHT";
-    if (region == HotkeyRegionName::BOTTOM_LEFT) return L"BOTTOM_LEFT";
-    if (region == HotkeyRegionName::BOTTOM) return L"BOTTOM";
-    if (region == HotkeyRegionName::BOTTOM_RIGHT) return L"BOTTOM_RIGHT";
-    return L"Unknown";
+    switch (region) {
+        case HotkeyRegionName::TOP_LEFT:
+            return L"TOP_LEFT";
+        case HotkeyRegionName::TOP:
+            return L"TOP";
+        case HotkeyRegionName::TOP_RIGHT:
+            return L"TOP_RIGHT";
+        case HotkeyRegionName::LEFT:
+            return L"LEFT";
+        case HotkeyRegionName::Elsewhere:
+            return L"Elsewhere";
+        case HotkeyRegionName::RIGHT:
+            return L"RIGHT";
+        case HotkeyRegionName::BOTTOM_LEFT:
+            return L"BOTTOM_LEFT";
+        case HotkeyRegionName::BOTTOM:
+            return L"BOTTOM";
+        case HotkeyRegionName::BOTTOM_RIGHT:
+            return L"BOTTOM_RIGHT";
+        case HotkeyRegionName::Invalid:
+            return L"Invalid";
+    }
+   return L"Unknown";
 }
 
 // Converts action enum to string for logging
 const wchar_t* ActionTypeToString(HotkeyActionType actionType) {
-    if (actionType == HotkeyActionType::Nothing) return L"Nothing";
-    if (actionType == HotkeyActionType::ShowDesktop) return L"ShowDesktop";
-    if (actionType == HotkeyActionType::AltTab) return L"AltTab";
-    if (actionType == HotkeyActionType::TaskManager) return L"TaskManager";
-    if (actionType == HotkeyActionType::Mute) return L"Mute";
-    if (actionType == HotkeyActionType::TaskbarAutohide) return L"TaskbarAutohide";
-    if (actionType == HotkeyActionType::WinTab) return L"WinTab";
-    if (actionType == HotkeyActionType::HideIcons) return L"HideIcons";
-    if (actionType == HotkeyActionType::CombineTaskbarButtons) return L"CombineTaskbarButtons";
-    if (actionType == HotkeyActionType::ToggleTaskbarAlignment) return L"ToggleTaskbarAlignment";
-    if (actionType == HotkeyActionType::OpenStartMenu) return L"OpenStartMenu";
-    if (actionType == HotkeyActionType::SendKeypress) return L"SendKeypress";
-    if (actionType == HotkeyActionType::StartProcess) return L"StartProcess";
-    if (actionType == HotkeyActionType::MediaPlayPause) return L"MediaPlayPause";
-    if (actionType == HotkeyActionType::MediaNext) return L"MediaNext";
-    if (actionType == HotkeyActionType::MediaPrev) return L"MediaPrev";
-    if (actionType == HotkeyActionType::SelectActiveInExplorer) return L"SelectActiveInExplorer";
-    if (actionType == HotkeyActionType::OpacityUp) return L"OpacityUp";
-    if (actionType == HotkeyActionType::OpacityDown) return L"OpacityDown";
-    if (actionType == HotkeyActionType::ToggleAlwaysOnTop) return L"ToggleAlwaysOnTop";
-    return L"Unknown";
+    switch (actionType) {
+        case HotkeyActionType::Nothing:
+            return L"Nothing";
+        case HotkeyActionType::ShowDesktop:
+            return L"ShowDesktop";
+        case HotkeyActionType::AltTab:
+            return L"AltTab";
+        case HotkeyActionType::TaskManager:
+            return L"TaskManager";
+        case HotkeyActionType::Mute:
+            return L"Mute";
+        case HotkeyActionType::TaskbarAutohide:
+            return L"TaskbarAutohide";
+        case HotkeyActionType::WinTab:
+            return L"WinTab";
+        case HotkeyActionType::HideIcons:
+            return L"HideIcons";
+        case HotkeyActionType::CombineTaskbarButtons:
+            return L"CombineTaskbarButtons";
+        case HotkeyActionType::ToggleTaskbarAlignment:
+            return L"ToggleTaskbarAlignment";
+        case HotkeyActionType::OpenStartMenu:
+            return L"OpenStartMenu";
+        case HotkeyActionType::SendKeypress:
+            return L"SendKeypress";
+        case HotkeyActionType::StartProcess:
+            return L"StartProcess";
+        case HotkeyActionType::MediaPlayPause:
+            return L"MediaPlayPause";
+        case HotkeyActionType::MediaNext:
+            return L"MediaNext";
+        case HotkeyActionType::MediaPrev:
+            return L"MediaPrev";
+        case HotkeyActionType::SelectActiveInExplorer:
+            return L"SelectActiveInExplorer";
+        case HotkeyActionType::OpacityUp:
+            return L"OpacityUp";
+        case HotkeyActionType::OpacityDown:
+            return L"OpacityDown";
+        case HotkeyActionType::ToggleAlwaysOnTop:
+            return L"ToggleAlwaysOnTop";
+        case HotkeyActionType::Invalid:
+            return L"Invalid";
+    }
+   return L"Unknown";
 }
 
 // Creates action executor from action type and arguments
@@ -1809,8 +1847,9 @@ std::function<void()> ParseActionSetting(HotkeyActionType actionType,
             return []() { HideIcons(); };
         case HotkeyActionType::CombineTaskbarButtons: {
             const auto [s1, s2, s3, s4] = ParseTaskBarButtonsState(args);
-            return [s1, s2, s3, s4]() { CombineTaskbarButtons(s1, s2, s3, s4); };
-        }
+            return
+                [s1, s2, s3, s4]() { CombineTaskbarButtons(s1, s2, s3, s4); };
+       }
         case HotkeyActionType::ToggleTaskbarAlignment:
             return []() { ToggleTaskbarAlignment(); };
         case HotkeyActionType::OpenStartMenu:
@@ -1844,9 +1883,10 @@ std::function<void()> ParseActionSetting(HotkeyActionType actionType,
             return []() { MediaNext(); };
         case HotkeyActionType::MediaPrev:
             return []() { MediaPrev(); };
-        default:
+        case HotkeyActionType::Invalid:
             return []() {};
     }
+    return []() {};
 }
 
 #pragma endregion  // actions

--- a/mods/hotcorner-hotkeys.wh.cpp
+++ b/mods/hotcorner-hotkeys.wh.cpp
@@ -135,6 +135,38 @@ uac;"C:\Tools\app.exe" args
 
 ---
 
+### Clipboard Run
+
+One or more semicolon-separated aliases or URL prefixes. The clipboard contents are URL-encoded once and appended to every token, opening each result as a separate target. Clipboard is read a single time per invocation regardless of how many targets are listed.
+
+**Single target:**
+
+```
+yt
+google
+https://www.bing.com/search?q=
+```
+
+**Multiple targets (opens all simultaneously):**
+
+```
+yt;google
+yt;google;reddit
+gpt;copilot
+```
+
+| Alias       | Expands to                                    |
+|-------------|-----------------------------------------------|
+| `gpt`       | https://chatgpt.com/?q=                       |
+| `yt`        | https://www.youtube.com/results?search_query= |
+| `google`    | https://www.google.com/search?q=              |
+| `copilot`   | https://copilot.microsoft.com/?sendquery=1&q= |
+| `x`         | https://twitter.com/search?q=                 |
+| `reddit`    | https://www.reddit.com/search/?q=             |
+| `translate` | https://translate.google.com/?text=           |
+
+---
+
 ### Combine taskbar buttons
 
 Up to 4 semicolon-separated state values: `primaryState1; primaryState2; secondaryState1; secondaryState2`
@@ -200,37 +232,6 @@ Some windows may not respond to layered window attributes.
 
 ---
 
-### Clipboard Run
-
-One or more semicolon-separated aliases or URL prefixes. The clipboard contents are URL-encoded once and appended to every token, opening each result as a separate target. Clipboard is read a single time per invocation regardless of how many targets are listed.
-
-**Single target:**
-
-```
-yt
-google
-https://www.bing.com/search?q=
-```
-
-**Multiple targets (opens all simultaneously):**
-
-```
-yt;google
-yt;google;reddit
-gpt;copilot
-```
-
-| Alias       | Expands to                                    |
-|-------------|-----------------------------------------------|
-| `gpt`       | https://chatgpt.com/?q=                       |
-| `yt`        | https://www.youtube.com/results?search_query= |
-| `google`    | https://www.google.com/search?q=              |
-| `copilot`   | https://copilot.microsoft.com/?sendquery=1&q= |
-| `x`         | https://twitter.com/search?q=                 |
-| `reddit`    | https://www.reddit.com/search/?q=             |
-| `translate` | https://translate.google.com/?text=           |
-
----
 
 
 

--- a/mods/hotcorner-hotkeys.wh.cpp
+++ b/mods/hotcorner-hotkeys.wh.cpp
@@ -2,12 +2,13 @@
 // @id                   hotcorner-hotkeys
 // @name                 HotCorner Hotkeys
 // @description          Assign up to 9 distinct actions per hotkey, dispatched based on which screen zone the cursor is in when pressed (4 corners, 4 edges, or elsewhere).
-// @version              3.51
+// @version              3.56
 // @author               webberlv
 // @github               https://github.com/webberLV
 // @license              GPL-3.0-only
 // @include             explorer.exe
 // @compilerOptions -lcomctl32 -loleaut32 -lole32 -lversion
+
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -19,220 +20,238 @@
 /*
 # HotCorner Hotkeys
 
+Assign actions to global hotkeys, with the action chosen by the cursor's
+current screen zone when the hotkey is pressed. Each hotkey can have separate
+actions for the four corners, four edges, and everywhere else.
+
 ## Cursor zones
 
-When a hotkey fires, the mod determines which action to run using a
-**fallback chain** based on the current cursor zone.
+Zones are detected from the **physical monitor edges**, not the taskbar or work
+area. A zone becomes active when the cursor is within **12 pixels** of that
+monitor edge.
+
+When a hotkey is pressed, the mod first checks the exact zone under the cursor.
+If nothing is configured there, it follows the fallback chain below until it
+finds a configured action. If nothing matches, no action is run.
 
 | Cursor zone  | Fallback order                            |
 |--------------|-------------------------------------------|
-| TOP_LEFT     | TOP_LEFT → TOP → LEFT → Elsewhere         |
-| TOP_RIGHT    | TOP_RIGHT → TOP → RIGHT → Elsewhere       |
-| BOTTOM_LEFT  | BOTTOM_LEFT → BOTTOM → LEFT → Elsewhere   |
-| BOTTOM_RIGHT | BOTTOM_RIGHT → BOTTOM → RIGHT → Elsewhere |
-| Top          | Top → Elsewhere                           |
-| Bottom       | Bottom → Elsewhere                        |
-| Left         | Left → Elsewhere                          |
-| Right        | Right → Elsewhere                         |
-| Elsewhere    | Elsewhere                                 |
-
-
----
+| `TOP_LEFT`   | `TOP_LEFT` → `TOP` → `LEFT` → `ELSEWHERE` |
+| `TOP_RIGHT`  | `TOP_RIGHT` → `TOP` → `RIGHT` → `ELSEWHERE` |
+| `BOTTOM_LEFT` | `BOTTOM_LEFT` → `BOTTOM` → `LEFT` → `ELSEWHERE` |
+| `BOTTOM_RIGHT` | `BOTTOM_RIGHT` → `BOTTOM` → `RIGHT` → `ELSEWHERE` |
+| `TOP`        | `TOP` → `ELSEWHERE`                       |
+| `BOTTOM`     | `BOTTOM` → `ELSEWHERE`                    |
+| `LEFT`       | `LEFT` → `ELSEWHERE`                      |
+| `RIGHT`      | `RIGHT` → `ELSEWHERE`                     |
+| `ELSEWHERE`  | `ELSEWHERE`                               |
 
 ## Supported actions
 
-1. **Show desktop** — Toggles the desktop view using the taskbar Show Desktop command.
-2. **Ctrl+Alt+Tab** — Opens the Ctrl+Alt+Tab task switcher.
-3. **Task Manager** — Opens the default Windows Task Manager.
-4. **Mute system volume** — Toggles mute for all active render audio devices.
-5. **Taskbar auto-hide** — Toggles the Windows taskbar auto-hide setting.
-6. **Win+Tab** — Opens Task View.
-7. **Hide desktop icons** — Toggles visibility of desktop icons.
-8. **Combine Taskbar buttons** — Toggles taskbar button combine mode between two configured states.
-9. **Toggle Taskbar alignment** — Toggles the taskbar alignment registry setting between left and center.
-10. **Open Start menu** — Simulates the Windows key to open Start.
-11. **Virtual key press** — Sends one or more virtual key presses or shortcuts using `SendInput`.
-12. **Open application, path or URL** — Launches an executable, opens a file/folder path, or opens a URL.
-13. **Clipboard Run** — URL-encodes the clipboard contents and opens the result using a built-in alias or custom URL prefix provided as the additional argument.
-14. **Open parsed title path in explorer, with fallback to exe** — Selects the active file in an Explorer window, falling back to the foreground executable if no file path could be parsed from the title.
-15. **Opacity Up (active window)** — Increases the foreground window's opacity toward a configurable maximum.
-16. **Opacity Down (active window)** — Decreases the foreground window's opacity toward a configurable minimum.
-17. **Toggle Always On Top (active window)** — Toggles the foreground window's always-on-top state.
-18. **Force Kill Active Window** — Terminates the foreground window's process, except for the current `explorer.exe` host process.
-19. **Media Play/Pause**
-20. **Media Next Track**
-21. **Media Previous Track**
+1. **Show desktop**: Toggles desktop view using the taskbar's Show Desktop command.
+2. **Ctrl+Alt+Tab**: Opens the Ctrl+Alt+Tab task switcher.
+3. **Task Manager**: Opens Windows Task Manager.
+4. **Mute system volume**: Toggles mute on all active render audio devices.
+5. **Taskbar auto-hide**: Toggles the Windows taskbar auto-hide setting.
+6. **Win+Tab**: Opens Task View.
+7. **Hide desktop icons**: Toggles desktop icon visibility.
+8. **Combine Taskbar buttons**: Toggles taskbar button combine mode between configured states. Uses Additional Arguments.
+9. **Toggle Taskbar alignment**: Toggles taskbar alignment between left and center.
+10. **Open Start menu**: Sends the Windows key to open Start.
+11. **Virtual key press**: Sends one or more parsed virtual keys with `SendInput`. Uses Additional Arguments.
+12. **Open application, path or URL**: Opens a target through `ShellExecuteEx`. Uses Additional Arguments.
+13. **Clipboard Run**: Reads the current clipboard text, appends it to a configured alias or target string, and opens the result. Uses Additional Arguments.
+14. **Open parsed title path in explorer, with fallback to exe**: Tries to extract a file path from the foreground window title and select it in Explorer; if that fails, it selects the foreground process executable instead.
+15. **Opacity Up (active window)**: Raises the active window's opacity through fixed levels. If the window is already layered and reaches the top step, the layered style is removed to restore full opacity.
+16. **Opacity Down (active window)**: Lowers the active window's opacity through fixed levels. If the window is not layered yet, it becomes layered and starts at 226.
+17. **Toggle Always On Top (active window)**: Toggles the active window between normal and topmost.
+18. **Force Kill Active Window**: Terminates the foreground window's process, except for the current `explorer.exe` host process.
+19. **Media Play/Pause**: Sends the media play/pause key.
+20. **Media Next Track**: Sends the media next-track key.
+21. **Media Previous Track**: Sends the media previous-track key.
 
 ## Hotkey format
 
-Hotkeys are specified in the format: `Modifier+Modifier+Key`
+Use this format:
 
-**Modifiers:** `Alt`, `Ctrl`, `Shift`, `Win`
-
-**Keys:**
-- **Letters:** `A`–`Z`
-- **Numbers:** `0`–`9`
-- **Function keys:** `F1`–`F24`
-- **Navigation:** `Home`, `End`, `PageUp`, `PageDown`, `Insert`, `Delete`, `Left`, `Right`, `Up`, `Down`
-- **Common:** `Enter`, `Tab`, `Space`, `Backspace`, `Escape` (or `Esc`), `CapsLock`, `PrintScreen`, `Pause`
-- **Numpad:** `Numpad0`–`Numpad9` (or `Num0`–`Num9`), `NumLock`, `Add`, `Subtract`, `Multiply`, `Divide`, `Decimal`
-- **Media:** `VolumeMute`, `VolumeUp`, `VolumeDown`, `MediaPlayPause`, `MediaNext`, `MediaPrev`, `MediaStop`
-- **Modifier keys (for Virtual key press):** `LWin`, `RWin`, `LShift`, `RShift`, `LCtrl`, `RCtrl`, `LAlt`, `RAlt`
-- Some of the `VK_*` codes from [Virtual-Key Codes](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes)
-
-**Examples:**
-
-```
-Ctrl+Alt+D        — Ctrl + Alt + D
-Ctrl+Shift+F1     — Ctrl + Shift + F1
-Alt+Home          — Alt + Home
-Win+Numpad1       — Windows key + Numpad 1
+```text
+Modifier+Modifier+Key
 ```
 
-## Additional args
-AdditionalArgs are optional and only used by the actions below.
+Rules:
 
----
+- Use exactly one non-modifier key.
+- Modifiers can appear in any order.
+- Hotkey names are case-insensitive.
+
+Supported modifiers:
+
+- `Alt`
+- `Ctrl`
+- `Shift`
+- `Win`
+- `NoRepeat`
+
+Common key names:
+
+- Letters: `A` to `Z`
+- Numbers: `0` to `9`
+- Function keys: `F1` to `F24`
+- Navigation: `Home`, `End`, `PageUp`, `PageDown`, `Insert`, `Delete`, `Left`, `Right`, `Up`, `Down`
+- Common: `Enter`, `Tab`, `Space`, `Backspace`, `Escape` or `Esc`, `CapsLock`, `PrintScreen`, `Pause`
+- Numpad: `Numpad0` to `Numpad9` or `Num0` to `Num9`, plus `NumLock`, `Add`, `Subtract`, `Multiply`, `Divide`, `Decimal`
+- Media: `VolumeMute`, `VolumeUp`, `VolumeDown`, `MediaPlayPause`, `MediaNext`, `MediaPrev`, `MediaStop`
+- Extra keys used mainly by **Virtual key press**: `LWin`, `RWin`, `LShift`, `RShift`, `LCtrl`, `RCtrl`, `LAlt`, `RAlt`
+- Some additional `VK_*` names from [Virtual-Key Codes](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes)
+- Numeric virtual-key codes are also accepted, such as `0x70`
+
+Examples:
+
+```text
+Ctrl+Alt+D
+Ctrl+Shift+F1
+Alt+Home
+Win+Numpad1
+NoRepeat+Ctrl+Z
+```
+
+## Additional Arguments
+
+Only these actions use `Additional Arguments`:
+
+- **Combine Taskbar buttons**
+- **Virtual key press**
+- **Open application, path or URL**
+- **Clipboard Run**
+
+All other actions ignore this field.
+
 ### Virtual key press
 
-Semicolon-separated key combinations are parsed left to right.
+Use one or more semicolon-separated hotkey-style entries.
 
-> **Note:** All parsed keys are sent together in one `SendInput` batch, rather than as fully separate sequential shortcuts. If modifier keys are still physically held down when the action fires, sending is deferred until they are released (up to ~500 ms), then sent automatically.
+Each entry is parsed, then all parsed keys are flattened into one list and sent
+together in a single `SendInput` batch. That means `Ctrl+C;Alt+Tab` does **not**
+send Copy and then Alt+Tab as two separate shortcuts. It presses all parsed keys
+together in one batch.
 
-**Examples:**
+If any modifier key is still physically held when the action fires, sending is
+deferred briefly until those modifier keys are released, with a timeout of about
+500 ms.
 
-```
+Examples:
+
+```text
 Ctrl+C
 Alt+F4
 Ctrl+Shift+Esc
 VolumeMute
-Ctrl+C;Alt+Tab
+LWin+Tab
 ```
-
----
 
 ### Open application, path or URL
 
-A command, path, or URL passed to `ShellExecuteEx`.
+This value is passed to `ShellExecuteEx`.
 
-**Examples:**
+It can be:
 
-```
+- An executable
+- A document, folder, or path
+- A URL
+- An executable plus arguments
+
+The target is opened on the monitor where the cursor is currently located.
+
+Examples:
+
+```text
 notepad.exe
 C:\Windows\System32\cmd.exe
 "C:\Program Files\Everything\Everything.exe"
-explorer.exe C:
+explorer.exe C:\
 https://example.com
 ```
 
-Prefix with `uac;` to request elevation:
+To request elevation, prefix the value with `uac;`:
 
-```
+```text
 uac;cmd.exe
-uac;"C:\Tools\app.exe" args
+uac;"C:\Tools\app.exe" --example
 ```
-
----
 
 ### Clipboard Run
 
-One or more semicolon-separated aliases or URL prefixes. The clipboard contents are URL-encoded once and appended to every token, opening each result as a separate target. Clipboard is read a single time per invocation regardless of how many targets are listed.
+This action reads the current clipboard text. If the clipboard is empty, nothing
+happens.
 
-**Single target:**
+`Additional Arguments` can be:
 
-```
-yt
-google
-https://www.bing.com/search?q=
-```
+- A built-in alias
+- A custom target string, typically a URL prefix such as `https://example.com/search?q=`
+- The same value prefixed with `uac;`
 
-**Multiple targets (opens all simultaneously):**
+The clipboard text is appended **as-is** to the configured target string, and
+the result is opened through `ShellExecuteEx` on the monitor where the cursor is
+currently located.
 
-```
-yt;google
-yt;google;reddit
-gpt;copilot
-```
+Built-in aliases:
 
 | Alias       | Expands to                                    |
 |-------------|-----------------------------------------------|
-| `gpt`       | https://chatgpt.com/?q=                       |
-| `yt`        | https://www.youtube.com/results?search_query= |
-| `google`    | https://www.google.com/search?q=              |
-| `copilot`   | https://copilot.microsoft.com/?sendquery=1&q= |
-| `x`         | https://twitter.com/search?q=                 |
-| `reddit`    | https://www.reddit.com/search/?q=             |
-| `translate` | https://translate.google.com/?text=           |
+| `gpt`       | `https://chatgpt.com/?q=`                     |
+| `yt`        | `https://www.youtube.com/results?search_query=` |
+| `google`    | `https://www.google.com/search?q=`            |
+| `copilot`   | `https://copilot.microsoft.com/?sendquery=1&q=` |
+| `x`         | `https://twitter.com/search?q=`               |
+| `reddit`    | `https://www.reddit.com/search/?q=`           |
+| `translate` | `https://translate.google.com/?text=`         |
 
----
+Examples:
+
+```text
+gpt
+google
+https://www.bing.com/search?q=
+uac;https://example.com/search?q=
+```
 
 ### Combine taskbar buttons
 
-Up to 4 semicolon-separated state values: `primaryState1; primaryState2; secondaryState1; secondaryState2`
+Use up to four semicolon-separated state values:
 
-**Valid state values:**
-
+```text
+primaryState1;primaryState2;secondaryState1;secondaryState2
 ```
+
+Valid values:
+
+```text
 COMBINE_ALWAYS
 COMBINE_WHEN_FULL
 COMBINE_NEVER
 ```
 
-The action toggles between the two primary states on each press. Toggle direction is determined by reading the current registry state on each press — immune to external changes and always deterministic. The optional secondary pair controls taskbars on secondary monitors.
+The action toggles between the first two values for the primary taskbar. If the
+third and fourth values are also provided, they control the same toggle for
+secondary taskbars.
+
+Toggle direction is tracked by an internal variable that is initialized from the
+registry the first time the action runs. If you change the registry externally
+between presses, the next toggle may be out of sync.
 
 **Example:**
 
-```
+```text
 COMBINE_ALWAYS;COMBINE_NEVER
 ```
 
----
+## Notes
 
-### Opacity Up (active window)
-
-Format: `max;step`
-
-| Parameter | Description                        | Default |
-|-----------|------------------------------------|---------|
-| `max`     | Upper alpha clamp, 0–255           | `255`   |
-| `step`    | Amount added per press, 1–255      | `25`    |
-
-Omitting both values uses all defaults.
-Providing only the first value sets min while keeping the default step.
-To modifiy step you must include max first. 
-Some windows may not respond to layered window attributes.
-
-**Example:**
-
-```
-200;15
-```
-
----
-
-### Opacity Down (active window)
-
-Format: `min;step`
-
-| Parameter | Description                        | Default |
-|-----------|------------------------------------|---------|
-| `min`     | Lower alpha clamp, 0–255           | `5`     |
-| `step`    | Amount subtracted per press, 1–255 | `25`    |
-
-Omitting both values uses all defaults.
-Providing only the first value sets min while keeping the default step.
-To modifiy step you must include min first. 
-Some windows may not respond to layered window attributes.
-**Example:**
-
-```
-5;25
-```
-
----
-
-
-
+- Zone detection is based on the monitor under the cursor at the moment the hotkey fires.
+- `Open parsed title path in explorer, with fallback to exe` checks the foreground window title from right to left, splitting on ` - `. It only accepts absolute paths that resolve to real files. If none are found, it falls back to the foreground process executable.
+- `Opacity Up (active window)` uses these fixed levels when increasing: `56`, `85`, `113`, `141`, `170`, `198`, `226`. It only works on windows that are already layered.
+- `Opacity Down (active window)` uses these fixed levels when decreasing: `226`, `198`, `170`, `141`, `113`, `85`, `56`, `0`. If the window is not layered yet, it is first made layered and set to `226`.
+- `Toggle Always On Top (active window)` and `Force Kill Active Window` operate on the current foreground window.
 
 ## Credits
 
@@ -246,6 +265,7 @@ by [m417z](https://github.com/m417z).
 
 */
 // ==/WindhawkModReadme==
+
 
 // ==WindhawkModSettings==
 /*
@@ -296,8 +316,12 @@ by [m417z](https://github.com/m417z).
           - ACTION_MEDIA_NEXT: Media Next Track
           - ACTION_MEDIA_PREV: Media Previous Track
         - AdditionalArgs: ""
-          $name: Additional Args
-          $description: Optional arguments for this action (e.g., Ctrl+C, uac;cmd.exe, google, 200;15). See Details tab.
+          $name: Additional Arguments
+          $description: >-
+            Optional. Only used by Virtual key press, Open application/path/URL,
+            Clipboard Run, and Combine Taskbar Buttons.
+            Examples: Ctrl+C • uac;cmd.exe • google; • COMBINE_ALWAYS;COMBINE_NEVER
+            See the Details tab for full documentation.
   $name: Keyboard Shortcut Actions
 */
 // ==/WindhawkModSettings==
@@ -320,7 +344,6 @@ by [m417z](https://github.com/m417z).
 #include <string>
 #include <string_view>
 #include <unordered_map>
-
 #include <vector>
 
 #if defined(__GNUC__) && __GNUC__ > 8
@@ -384,15 +407,15 @@ enum class HotkeyActionType {
 };
 
 enum class HotkeyRegionName {
-    TOP_LEFT,
-    TOP,
-    TOP_RIGHT,
-    LEFT,
+    TopLeft,
+    Top,
+    TopRight,
+    Left,
     Elsewhere,
-    RIGHT,
-    BOTTOM_LEFT,
-    BOTTOM,
-    BOTTOM_RIGHT,
+    Right,
+    BottomLeft,
+    Bottom,
+    BottomRight,
     Invalid,
 };
 
@@ -405,7 +428,7 @@ struct HotkeyBinding {
     UINT modifiers;
     UINT vk;
     int hotkeyId;
-    bool registered;
+    bool ownsRegistration;
 };
 
 static struct {
@@ -505,6 +528,22 @@ std::wstring trim(const std::wstring& s) {
     return rtrim(ltrim(s));
 }
 
+std::wstring trimDecorated(std::wstring s) {
+    if (!s.empty() && s.front() == L'*') {
+        s.erase(0, 1);
+    }
+
+    s = trim(s);
+
+    if (s.size() >= 2 &&
+        ((s.front() == L'"' && s.back() == L'"') ||
+         (s.front() == L'\'' && s.back() == L'\''))) {
+        s = s.substr(1, s.size() - 2);
+    }
+
+    return s;
+}
+
 std::wstring toLower(const std::wstring& s) {
     std::wstring result = s;
     std::transform(result.begin(), result.end(), result.begin(), ::towlower);
@@ -517,13 +556,14 @@ bool startsWith(const std::wstring& s, const std::wstring& prefix) {
     }
     return std::equal(prefix.begin(), prefix.end(), s.begin());
 }
+
 }  // namespace stringtools
 
 static HWND g_hTaskbarWnd = nullptr;
 static DWORD g_dwTaskbarThreadId = 0;
 
 // Base hotkey ID - each action gets base + index
-static const int kHotkeyIdBase = 1768250635;  // from epochconverter.com
+static const int kHotkeyIdBase = 1775748064;  // from epochconverter.com
 
 // Message for hotkey registration management
 static UINT g_hotkeyRegisteredMsg =
@@ -852,56 +892,68 @@ bool FromStringHotKey(std::wstring_view hotkeyString,
 
 // =====================================================================
 
+
 #pragma region hotkey_registration
 
 void RegisterHotkeys(HWND hWnd) {
-    std::unordered_map<uint64_t, int> registeredCombos;
-
-    for (size_t i = 0; i < g_settings.hotkeyActions.size(); i++) {
-        auto& entry = g_settings.hotkeyActions[i];
-
+    for (auto& entry : g_settings.hotkeyActions) {
         entry.hotkeyId = 0;
-        entry.registered = false;
+        entry.ownsRegistration = false;
+    }
 
-        uint64_t comboKey = (static_cast<uint64_t>(entry.modifiers) << 32) | entry.vk;
-        auto existing = registeredCombos.find(comboKey);
-        if (existing == registeredCombos.end()) {
-            int id = kHotkeyIdBase + static_cast<int>(i);
-            if (RegisterHotKey(hWnd, id, entry.modifiers, entry.vk)) {
-                entry.hotkeyId = id;
-                entry.registered = true;
-                registeredCombos[comboKey] = id;
-            } else {
-                Wh_Log(L"Hotkey '%s': failed to register (error=%lu)",
-                       entry.hotkeyString.c_str(), GetLastError());
-            }
-            continue;
+    for (size_t i = 0; i < g_settings.hotkeyActions.size();) {
+        auto& first = g_settings.hotkeyActions[i];
+        const UINT modifiers = first.modifiers;
+        const UINT vk = first.vk;
+
+        size_t end = i + 1;
+        while (end < g_settings.hotkeyActions.size() &&
+               g_settings.hotkeyActions[end].modifiers == modifiers &&
+               g_settings.hotkeyActions[end].vk == vk) {
+            ++end;
         }
 
-        entry.hotkeyId = existing->second;
-        entry.registered = true;
+        int id = kHotkeyIdBase + static_cast<int>(i);
+
+        if (RegisterHotKey(hWnd, id, modifiers, vk)) {
+            first.hotkeyId = id;
+            first.ownsRegistration = true;
+
+            Wh_Log(L"Registered hotkey '%s' (id=%d)",
+                   first.hotkeyString.c_str(), id);
+
+            for (size_t j = i + 1; j < end; ++j) {
+                g_settings.hotkeyActions[j].hotkeyId = id;
+                g_settings.hotkeyActions[j].ownsRegistration = false;
+
+                Wh_Log(L"Hotkey '%s' region %s: sharing id=%d",
+                       g_settings.hotkeyActions[j].hotkeyString.c_str(),
+                       RegionNameToString(g_settings.hotkeyActions[j].region),
+                       id);
+            }
+        } else {
+            Wh_Log(L"Hotkey '%s': failed to register (error=%lu)",
+                   first.hotkeyString.c_str(), GetLastError());
+       }
+
+        i = end;
     }
 }
 
 void UnregisterHotkeys(HWND hWnd) {
-    for (size_t k = 0; k < g_settings.hotkeyActions.size(); k++) {
-        auto& entry = g_settings.hotkeyActions[k];
-        if (!entry.registered) {
-            continue;
-        }
-
-        int id = entry.hotkeyId;
-        UnregisterHotKey(hWnd, id);
-        entry.registered = false;
-        for (size_t m = k + 1; m < g_settings.hotkeyActions.size(); m++) {
-            if (g_settings.hotkeyActions[m].hotkeyId == id) {
-                g_settings.hotkeyActions[m].registered = false;
+    for (auto& entry : g_settings.hotkeyActions) {
+        if (entry.ownsRegistration && entry.hotkeyId != 0) {
+            if (!UnregisterHotKey(hWnd, entry.hotkeyId)) {
+                Wh_Log(L"UnregisterHotKey(id=%d) failed (error=%lu)",
+                       entry.hotkeyId, GetLastError());
             }
-        }
+       }
+
+        entry.ownsRegistration = false;
+        entry.hotkeyId = 0;
     }
 }
 #pragma endregion  // hotkey_registration
-
 // =====================================================================
 
 #pragma region actions
@@ -931,6 +983,16 @@ std::vector<std::wstring> SplitArgs(const std::wstring& args,
         result.push_back(substring);
     }
     return result;
+}
+
+// Sends show desktop command to taskbar
+void ShowDesktop() {
+    if (g_hTaskbarWnd) {
+        Wh_Log(L"Sending ShowDesktop message");
+        SendMessage(g_hTaskbarWnd, WM_COMMAND, MAKELONG(407, 0), 0);
+    } else {
+        Wh_Log(L"Failed to show desktop - taskbar not found");
+    }
 }
 
 // Returns current taskbar autohide state
@@ -968,271 +1030,6 @@ void ToggleTaskbarAutohide() {
     }
 }
 
-// Sends show desktop command to taskbar
-void ShowDesktop() {
-    if (g_hTaskbarWnd) {
-        Wh_Log(L"Sending ShowDesktop message");
-        SendMessage(g_hTaskbarWnd, WM_COMMAND, MAKELONG(407, 0), 0);
-    } else {
-        Wh_Log(L"Failed to show desktop - taskbar not found");
-    }
-}
-
-// Checks if any modifier keys are currently pressed
-bool AreModifierKeysPressed() {
-    return (GetAsyncKeyState(VK_CONTROL) & 0x8000) ||
-           (GetAsyncKeyState(VK_MENU) & 0x8000) ||  // Alt
-           (GetAsyncKeyState(VK_SHIFT) & 0x8000) ||
-           (GetAsyncKeyState(VK_LWIN) & 0x8000) ||
-           (GetAsyncKeyState(VK_RWIN) & 0x8000);
-}
-
-// Internal function to send virtual key sequence
-void SendKeypressInternal(const std::vector<int>& keys) {
-    if (keys.empty()) {
-        return;
-    }
-
-    const int NUM_KEYS = static_cast<int>(keys.size());
-    std::unique_ptr<INPUT[]> input(new INPUT[NUM_KEYS * 2]);
-
-    for (int i = 0; i < NUM_KEYS; i++) {
-        input[i].type = INPUT_KEYBOARD;
-        input[i].ki.wScan = 0;
-        input[i].ki.time = 0;
-        input[i].ki.dwExtraInfo = 0;
-        input[i].ki.wVk = static_cast<WORD>(keys[i]);
-        input[i].ki.dwFlags = 0;  // KEYDOWN
-    }
-
-    for (int i = 0; i < NUM_KEYS; i++) {
-        input[NUM_KEYS + i].type = INPUT_KEYBOARD;
-        input[NUM_KEYS + i].ki.wScan = 0;
-        input[NUM_KEYS + i].ki.time = 0;
-        input[NUM_KEYS + i].ki.dwExtraInfo = 0;
-        input[NUM_KEYS + i].ki.wVk = static_cast<WORD>(keys[i]);
-        input[NUM_KEYS + i].ki.dwFlags = KEYEVENTF_KEYUP;
-    }
-
-    SendInput(NUM_KEYS * 2, input.get(), sizeof(input[0]));
-}
-
-// Timer callback to retry sending keypress when modifier keys are released
-void CALLBACK KeypressRetryTimerProc(HWND, UINT, UINT_PTR timerId, DWORD) {
-    if (!AreModifierKeysPressed()) {
-        // Keys released, send the keypress
-        KillTimer(nullptr, timerId);
-        g_keypressTimerId = 0;
-        Wh_Log(L"Modifier keys released, sending deferred keypress");
-        SendKeypressInternal(g_pendingKeypressKeys);
-        g_pendingKeypressKeys.clear();
-    } else if (++g_pendingKeypressRetryCount >= kMaxKeypressRetryCount) {
-        // Timeout - send anyway
-        KillTimer(nullptr, timerId);
-        g_keypressTimerId = 0;
-        Wh_Log(L"Timeout waiting for modifier keys, sending anyway");
-        SendKeypressInternal(g_pendingKeypressKeys);
-        g_pendingKeypressKeys.clear();
-    }
-}
-
-// Sends virtual key sequence, deferring if modifier keys are pressed
-void SendKeypress(const std::vector<int>& keys) {
-    if (keys.empty()) {
-        return;
-    }
-
-    // Cancel any pending keypress
-    if (g_keypressTimerId) {
-        KillTimer(nullptr, g_keypressTimerId);
-        g_keypressTimerId = 0;
-    }
-
-    if (AreModifierKeysPressed()) {
-        // Defer keypress - store and start thread timer
-        g_pendingKeypressKeys = keys;
-        g_pendingKeypressRetryCount = 0;
-        g_keypressTimerId = SetTimer(nullptr, 0, kKeypressRetryIntervalMs,
-                                     KeypressRetryTimerProc);
-        Wh_Log(L"Modifier keys pressed, deferring keypress");
-        return;
-    }
-
-    SendKeypressInternal(keys);
-}
-
-void SendCtrlAltTabKeypress() {
-    Wh_Log(L"Sending Ctrl+Alt+Tab");
-    SendKeypress({VK_LCONTROL, VK_LMENU, VK_TAB});
-}
-
-void SendWinTabKeypress() {
-    Wh_Log(L"Sending Win+Tab");
-    SendKeypress({VK_LWIN, VK_TAB});
-}
-
-void MediaPlayPause() {
-    Wh_Log(L"Sending Media Play/Pause");
-    SendKeypress({VK_MEDIA_PLAY_PAUSE});
-}
-
-void MediaNext() {
-    Wh_Log(L"Sending Media Next Track");
-    SendKeypress({VK_MEDIA_NEXT_TRACK});
-}
-
-void MediaPrev() {
-    Wh_Log(L"Sending Media Previous Track");
-    SendKeypress({VK_MEDIA_PREV_TRACK});
-}
-
-void OpenStartMenu() {
-    Wh_Log(L"Sending Win keypress for Start menu");
-    SendKeypress({VK_LWIN});
-}
-
-void OpenTaskManager() {
-    Wh_Log(L"Opening Task Manager");
-
-    WCHAR szWindowsDirectory[MAX_PATH];
-    GetWindowsDirectory(szWindowsDirectory, ARRAYSIZE(szWindowsDirectory));
-    std::wstring taskmgrPath = szWindowsDirectory;
-    taskmgrPath += L"\\System32\\Taskmgr.exe";
-
-    SHELLEXECUTEINFO sei = {sizeof(sei)};
-    sei.lpVerb = L"open";
-    sei.lpFile = taskmgrPath.c_str();
-    sei.nShow = SW_SHOW;
-
-    if (!ShellExecuteEx(&sei)) {
-        DWORD error = GetLastError();
-        if (error != ERROR_CANCELLED) {
-            Wh_Log(L"Failed to start Task Manager, error: %d", error);
-        }
-    }
-}
-
-// Returns mute state of default audio device
-BOOL IsAudioMuted(com_ptr<IMMDeviceEnumerator> pDeviceEnumerator) {
-    const GUID XIID_IAudioEndpointVolume = {
-        0x5CDF2C82,
-        0x841E,
-        0x4546,
-        {0x97, 0x22, 0x0C, 0xF7, 0x40, 0x78, 0x22, 0x9A}};
-
-    BOOL isMuted = FALSE;
-    com_ptr<IMMDevice> defaultAudioDevice;
-    if (SUCCEEDED(pDeviceEnumerator->GetDefaultAudioEndpoint(
-            eRender, eConsole, defaultAudioDevice.put()))) {
-        com_ptr<IAudioEndpointVolume> endpointVolume;
-        if (SUCCEEDED(defaultAudioDevice->Activate(
-                XIID_IAudioEndpointVolume, CLSCTX_INPROC_SERVER, NULL,
-                endpointVolume.put_void()))) {
-            endpointVolume->GetMute(&isMuted);
-        }
-    }
-    return isMuted;
-}
-
-// Toggles mute state for all active audio devices
-void ToggleVolMuted() {
-    if (!g_audioCOM.IsInitialized()) {
-        if (!g_audioCOM.Init()) {
-            Wh_Log(L"Failed to initialize audio COM");
-            return;
-        }
-    }
-
-    auto pDeviceEnumerator = g_audioCOM.GetDeviceEnumerator();
-    if (!pDeviceEnumerator) {
-        Wh_Log(L"Failed to get device enumerator");
-        return;
-    }
-
-    Wh_Log(L"Toggling volume mute");
-
-    const GUID XIID_IAudioEndpointVolume = {
-        0x5CDF2C82,
-        0x841E,
-        0x4546,
-        {0x97, 0x22, 0x0C, 0xF7, 0x40, 0x78, 0x22, 0x9A}};
-
-    const BOOL isMuted = IsAudioMuted(pDeviceEnumerator);
-
-    com_ptr<IMMDeviceCollection> pDeviceCollection;
-    if (FAILED(pDeviceEnumerator->EnumAudioEndpoints(
-            eRender, DEVICE_STATE_ACTIVE, pDeviceCollection.put()))) {
-        return;
-    }
-
-    UINT deviceCount = 0;
-    if (FAILED(pDeviceCollection->GetCount(&deviceCount))) {
-        return;
-    }
-
-    for (UINT i = 0; i < deviceCount; i++) {
-        com_ptr<IMMDevice> pDevice;
-        if (SUCCEEDED(pDeviceCollection->Item(i, pDevice.put()))) {
-            com_ptr<IAudioEndpointVolume> endpointVolume;
-            if (SUCCEEDED(pDevice->Activate(XIID_IAudioEndpointVolume,
-                                            CLSCTX_INPROC_SERVER, NULL,
-                                            endpointVolume.put_void()))) {
-                endpointVolume->SetMute(!isMuted, NULL);
-            }
-        }
-    }
-}
-
-// Finds desktop window for show/hide icons command
-HWND FindDesktopWindow() {
-    HWND hParentWnd = FindWindow(L"Progman", NULL);
-    if (!hParentWnd) {
-        return NULL;
-    }
-
-    HWND hChildWnd = FindWindowEx(hParentWnd, NULL, L"SHELLDLL_DefView", NULL);
-    if (!hChildWnd) {
-        DWORD dwThreadId = GetWindowThreadProcessId(hParentWnd, NULL);
-        EnumThreadWindows(
-            dwThreadId,
-            [](HWND hWnd, LPARAM lParam) WINAPI_LAMBDA_RETURN(BOOL) {
-                WCHAR szClassName[16];
-                if (GetClassName(hWnd, szClassName, _countof(szClassName)) ==
-                    0) {
-                    return TRUE;
-                }
-
-                if (lstrcmp(szClassName, L"WorkerW") != 0) {
-                    return TRUE;
-                }
-
-                HWND hChildWnd =
-                    FindWindowEx(hWnd, NULL, L"SHELLDLL_DefView", NULL);
-                if (!hChildWnd) {
-                    return TRUE;
-                }
-
-                *(HWND*)lParam = hChildWnd;
-                return FALSE;
-            },
-            (LPARAM)&hChildWnd);
-    }
-
-    return hChildWnd;
-}
-
-// Toggles desktop icon visibility
-void HideIcons() {
-    HWND hDesktopWnd = FindDesktopWindow();
-    if (hDesktopWnd != NULL) {
-        Wh_Log(L"Toggling desktop icons");
-        PostMessage(hDesktopWnd, WM_COMMAND, 0x7402, 0);
-    } else {
-        Wh_Log(L"Failed to find desktop window");
-    }
-}
-
-// Parses taskbar button combine states from arg string
 std::tuple<TaskBarButtonsState,
            TaskBarButtonsState,
            TaskBarButtonsState,
@@ -1374,6 +1171,220 @@ void ToggleTaskbarAlignment() {
     }
 }
 
+// Finds desktop window for show/hide icons command
+HWND FindDesktopWindow() {
+    HWND hParentWnd = FindWindow(L"Progman", NULL);
+    if (!hParentWnd) {
+        return NULL;
+    }
+
+    HWND hChildWnd = FindWindowEx(hParentWnd, NULL, L"SHELLDLL_DefView", NULL);
+    if (!hChildWnd) {
+        DWORD dwThreadId = GetWindowThreadProcessId(hParentWnd, NULL);
+        EnumThreadWindows(
+            dwThreadId,
+            [](HWND hWnd, LPARAM lParam) WINAPI_LAMBDA_RETURN(BOOL) {
+                WCHAR szClassName[16];
+                if (GetClassName(hWnd, szClassName, _countof(szClassName)) ==
+                    0) {
+                    return TRUE;
+                }
+
+                if (lstrcmp(szClassName, L"WorkerW") != 0) {
+                    return TRUE;
+                }
+
+                HWND hChildWnd =
+                    FindWindowEx(hWnd, NULL, L"SHELLDLL_DefView", NULL);
+                if (!hChildWnd) {
+                    return TRUE;
+                }
+
+                *(HWND*)lParam = hChildWnd;
+                return FALSE;
+            },
+            (LPARAM)&hChildWnd);
+    }
+
+    return hChildWnd;
+}
+
+// Toggles desktop icon visibility
+void HideIcons() {
+    HWND hDesktopWnd = FindDesktopWindow();
+    if (hDesktopWnd != NULL) {
+        Wh_Log(L"Toggling desktop icons");
+        PostMessage(hDesktopWnd, WM_COMMAND, 0x7402, 0);
+    } else {
+        Wh_Log(L"Failed to find desktop window");
+    }
+}
+
+void OpenTaskManager() {
+    Wh_Log(L"Opening Task Manager");
+
+    WCHAR szWindowsDirectory[MAX_PATH];
+    GetWindowsDirectory(szWindowsDirectory, ARRAYSIZE(szWindowsDirectory));
+    std::wstring taskmgrPath = szWindowsDirectory;
+    taskmgrPath += L"\\System32\\Taskmgr.exe";
+
+    SHELLEXECUTEINFO sei = {sizeof(sei)};
+    sei.lpVerb = L"open";
+    sei.lpFile = taskmgrPath.c_str();
+    sei.nShow = SW_SHOW;
+
+    if (!ShellExecuteEx(&sei)) {
+        DWORD error = GetLastError();
+        if (error != ERROR_CANCELLED) {
+            Wh_Log(L"Failed to start Task Manager, error: %d", error);
+        }
+    }
+}
+
+// Checks if any modifier keys are currently pressed
+bool AreModifierKeysPressed() {
+    return (GetAsyncKeyState(VK_CONTROL) & 0x8000) ||
+           (GetAsyncKeyState(VK_MENU) & 0x8000) ||  // Alt
+           (GetAsyncKeyState(VK_SHIFT) & 0x8000) ||
+           (GetAsyncKeyState(VK_LWIN) & 0x8000) ||
+           (GetAsyncKeyState(VK_RWIN) & 0x8000);
+}
+
+// Internal function to send virtual key sequence
+void SendKeypressInternal(const std::vector<int>& keys) {
+    if (keys.empty()) {
+        return;
+    }
+
+    const int NUM_KEYS = static_cast<int>(keys.size());
+    std::unique_ptr<INPUT[]> input(new INPUT[NUM_KEYS * 2]);
+
+    for (int i = 0; i < NUM_KEYS; i++) {
+        input[i].type = INPUT_KEYBOARD;
+        input[i].ki.wScan = 0;
+        input[i].ki.time = 0;
+        input[i].ki.dwExtraInfo = 0;
+        input[i].ki.wVk = static_cast<WORD>(keys[i]);
+        input[i].ki.dwFlags = 0;  // KEYDOWN
+    }
+
+    for (int i = 0; i < NUM_KEYS; i++) {
+        input[NUM_KEYS + i].type = INPUT_KEYBOARD;
+        input[NUM_KEYS + i].ki.wScan = 0;
+        input[NUM_KEYS + i].ki.time = 0;
+        input[NUM_KEYS + i].ki.dwExtraInfo = 0;
+        input[NUM_KEYS + i].ki.wVk = static_cast<WORD>(keys[i]);
+        input[NUM_KEYS + i].ki.dwFlags = KEYEVENTF_KEYUP;
+    }
+
+    SendInput(NUM_KEYS * 2, input.get(), sizeof(input[0]));
+}
+
+// Timer callback to retry sending keypress when modifier keys are released
+void CALLBACK KeypressRetryTimerProc(HWND, UINT, UINT_PTR timerId, DWORD) {
+    if (!AreModifierKeysPressed()) {
+        // Keys released, send the keypress
+        KillTimer(nullptr, timerId);
+        g_keypressTimerId = 0;
+        Wh_Log(L"Modifier keys released, sending deferred keypress");
+        SendKeypressInternal(g_pendingKeypressKeys);
+        g_pendingKeypressKeys.clear();
+    } else if (++g_pendingKeypressRetryCount >= kMaxKeypressRetryCount) {
+        // Timeout - send anyway
+        KillTimer(nullptr, timerId);
+        g_keypressTimerId = 0;
+        Wh_Log(L"Timeout waiting for modifier keys, sending anyway");
+        SendKeypressInternal(g_pendingKeypressKeys);
+        g_pendingKeypressKeys.clear();
+    }
+}
+
+// Sends virtual key sequence, deferring if modifier keys are pressed
+void SendKeypress(const std::vector<int>& keys) {
+    if (keys.empty()) {
+        return;
+    }
+
+    // Cancel any pending keypress
+    if (g_keypressTimerId) {
+        KillTimer(nullptr, g_keypressTimerId);
+        g_keypressTimerId = 0;
+    }
+
+    if (AreModifierKeysPressed()) {
+        // Defer keypress - store and start thread timer
+        g_pendingKeypressKeys = keys;
+        g_pendingKeypressRetryCount = 0;
+        g_keypressTimerId = SetTimer(nullptr, 0, kKeypressRetryIntervalMs,
+                                     KeypressRetryTimerProc);
+        Wh_Log(L"Modifier keys pressed, deferring keypress");
+        return;
+    }
+
+    SendKeypressInternal(keys);
+}
+
+void SendCtrlAltTabKeypress() {
+    Wh_Log(L"Sending Ctrl+Alt+Tab");
+    SendKeypress({VK_LCONTROL, VK_LMENU, VK_TAB});
+}
+
+void SendWinTabKeypress() {
+    Wh_Log(L"Sending Win+Tab");
+    SendKeypress({VK_LWIN, VK_TAB});
+}
+
+void OpenStartMenu() {
+    Wh_Log(L"Sending Win keypress for Start menu");
+    SendKeypress({VK_LWIN});
+}
+
+std::vector<int> ParseVirtualKeypressSetting(const std::wstring& args) {
+    std::vector<int> keys;
+
+    const auto argsSplit = SplitArgs(args);
+    for (const auto& arg : argsSplit) {
+        UINT modifiers = 0;
+        UINT vk = 0;
+        if (FromStringHotKey(arg, &modifiers, &vk)) {
+            // Add modifier keys first
+            if (modifiers & MOD_CONTROL) {
+                keys.push_back(VK_LCONTROL);
+            }
+            if (modifiers & MOD_ALT) {
+                keys.push_back(VK_LMENU);
+            }
+            if (modifiers & MOD_SHIFT) {
+                keys.push_back(VK_LSHIFT);
+            }
+            if (modifiers & MOD_WIN) {
+                keys.push_back(VK_LWIN);
+            }
+            // Add the main key
+            keys.push_back(static_cast<int>(vk));
+        } else {
+            Wh_Log(L"Failed to parse key: %s", arg.c_str());
+        }
+    }
+
+    return keys;
+}
+
+void MediaPlayPause() {
+    Wh_Log(L"Sending Media Play/Pause");
+    SendKeypress({VK_MEDIA_PLAY_PAUSE});
+}
+
+void MediaNext() {
+    Wh_Log(L"Sending Media Next Track");
+    SendKeypress({VK_MEDIA_NEXT_TRACK});
+}
+
+void MediaPrev() {
+    Wh_Log(L"Sending Media Previous Track");
+    SendKeypress({VK_MEDIA_PREV_TRACK});
+}
+
 // Parses command line into executable path and parameters
 std::tuple<std::wstring, std::wstring> ParseExecutableAndParameters(
     const std::wstring& command) {
@@ -1448,43 +1459,41 @@ void StartProcess(std::wstring command) {
     }
 }
 
-
-std::wstring ParseCopyRunTarget(const std::wstring& token,
-                                const std::wstring& encodedClip) {
-    static const std::unordered_map<std::wstring, std::wstring> kUrlAliases = {
-        {L"gpt",       L"https://chatgpt.com/?q="},
-        {L"yt",        L"https://www.youtube.com/results?search_query="},
-        {L"google",    L"https://www.google.com/search?q="},
-        {L"copilot",   L"https://copilot.microsoft.com/?sendquery=1&q="},
-        {L"x",         L"https://twitter.com/search?q="},
-        {L"reddit",    L"https://www.reddit.com/search/?q="},
-        {L"translate", L"https://translate.google.com/?text="},
-    };
-
-    std::wstring key = stringtools::trim(token);
-    if (key.empty()) {
-        return L"";
+std::tuple<std::wstring, std::wstring> ParseCopyRunCommand(const std::wstring& command) {
+    std::wstring verb = L"open";
+    std::wstring arg = stringtools::trim(command);
+    if (arg.empty()) {
+        return {verb, L""};
     }
 
-    std::wstring prefix;
-    auto it = kUrlAliases.find(stringtools::toLower(key));
-    if (it != kUrlAliases.end()) {
-        prefix = it->second;
-    } else if (stringtools::startsWith(key, L"http://") ||
-               stringtools::startsWith(key, L"https://")) {
-        prefix = key;
-    } else {
-        prefix = L"https://" + key;
+    std::vector<std::wstring> parts = SplitArgs(command, L';');
+    if (stringtools::toLower(parts[0]) == L"uac") {
+        verb = L"runas";
+        arg = stringtools::ltrim(command.substr(parts[0].length() + 1));
     }
 
-    return prefix + encodedClip;
+    arg = stringtools::trim(arg);
+    if (arg.empty()) {
+        return {verb, L""};
+    }
+
+    std::wstring lower = stringtools::toLower(arg);
+
+    if (lower == L"gpt") return {verb, L"https://chatgpt.com/?q="};
+    if (lower == L"yt") return {verb, L"https://www.youtube.com/results?search_query="};
+    if (lower == L"reddit") return {verb, L"https://www.reddit.com/search/?q="};
+    if (lower == L"google") return {verb, L"https://www.google.com/search?q="};
+    if (lower == L"copilot") return {verb, L"https://copilot.microsoft.com/?sendquery=1&q="};
+    if (lower == L"x") return {verb, L"https://twitter.com/search?q="};
+    if (lower == L"translate") return {verb, L"https://translate.google.com/?text="};
+
+    return {verb, arg};
 }
 
+void CopyRun(std::wstring command) {
+    const auto [verb, base] = ParseCopyRunCommand(command);
+    if (base.empty()) return;
 
-void CopyRun(const std::wstring& args) {
-    if (args.empty()) {
-        return;
-    }
     std::wstring clip;
     if (OpenClipboard(nullptr)) {
         if (HANDLE hData = GetClipboardData(CF_UNICODETEXT)) {
@@ -1496,178 +1505,127 @@ void CopyRun(const std::wstring& args) {
         }
         CloseClipboard();
     }
+    if (clip.empty()) return;
 
-    std::wstring encodedClip;
-    if (!clip.empty()) {
-        int size = WideCharToMultiByte(CP_UTF8, 0, clip.c_str(), -1,
-                                       nullptr, 0, nullptr, nullptr);
-        std::string utf8;
-        if (size > 1) {
-            utf8.resize(size);
-            WideCharToMultiByte(CP_UTF8, 0, clip.c_str(), -1,
-                                utf8.data(), size, nullptr, nullptr);
-            utf8.pop_back();  // drop null terminator
-        }
-        for (unsigned char c : utf8) {
-            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
-                (c >= '0' && c <= '9') ||
-                c == '-' || c == '_' || c == '.' || c == '~') {
-                encodedClip += static_cast<wchar_t>(c);
-            } else {
-                wchar_t buf[4];
-                swprintf(buf, 4, L"%%%02X", c);
-                encodedClip += buf;
-            }
-        }
-    }
+    std::wstring url = base + clip;
 
-    // --- Split args on ';' and launch one URL per token ---
-    POINT cursorPos;
-    GetCursorPos(&cursorPos);
-    HMONITOR hMonitor = MonitorFromPoint(cursorPos, MONITOR_DEFAULTTONEAREST);
+    POINT pt{};
+    GetCursorPos(&pt);
+    HMONITOR mon = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
 
-    const std::vector<std::wstring> tokens = SplitArgs(args);
-    for (const std::wstring& token : tokens) {
-        std::wstring target = ParseCopyRunTarget(token, encodedClip);
-        if (target.empty()) {
-            continue;
-        }
+    SHELLEXECUTEINFOW sei{};
+    sei.cbSize = sizeof(sei);
+    sei.fMask = SEE_MASK_HMONITOR | SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI;
+    sei.lpVerb = verb.c_str();  // ← same as StartProcess
+    sei.lpFile = url.c_str();
+    sei.nShow = SW_SHOWNORMAL;
+    sei.hMonitor = mon;
 
-        Wh_Log(L"CopyRun: %s", target.c_str());
-
-        SHELLEXECUTEINFO sei = {sizeof(sei)};
-        sei.fMask = SEE_MASK_HMONITOR | SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI;
-        sei.lpVerb = L"open";
-        sei.lpFile = target.c_str();
-        sei.lpParameters = nullptr;
-        sei.nShow = SW_SHOWNORMAL;
-        sei.hMonitor = hMonitor;
-
-        if (!ShellExecuteEx(&sei)) {
-            DWORD err = GetLastError();
-            if (err != ERROR_CANCELLED) {
-                Wh_Log(L"CopyRun failed for '%s': %d", token.c_str(), err);
-            }
-        }
-    }
+    ShellExecuteExW(&sei);
 }
 
-std::vector<int> ParseVirtualKeypressSetting(const std::wstring& args) {
-    std::vector<int> keys;
+bool GetForegroundWindowPathOrExe(std::wstring& outPath) {
+    outPath.clear();
 
-    const auto argsSplit = SplitArgs(args);
-    for (const auto& arg : argsSplit) {
-        UINT modifiers = 0;
-        UINT vk = 0;
-        if (FromStringHotKey(arg, &modifiers, &vk)) {
-            // Add modifier keys first
-            if (modifiers & MOD_CONTROL) {
-                keys.push_back(VK_LCONTROL);
-            }
-            if (modifiers & MOD_ALT) {
-                keys.push_back(VK_LMENU);
-            }
-            if (modifiers & MOD_SHIFT) {
-                keys.push_back(VK_LSHIFT);
-            }
-            if (modifiers & MOD_WIN) {
-                keys.push_back(VK_LWIN);
-            }
-            // Add the main key
-            keys.push_back(static_cast<int>(vk));
-        } else {
-            Wh_Log(L"Failed to parse key: %s", arg.c_str());
-        }
+    HWND hWnd = GetForegroundWindow();
+    if (!hWnd ||
+        hWnd == g_hTaskbarWnd ||
+        !IsWindow(hWnd) ||
+        !IsWindowVisible(hWnd)) {
+        return false;
     }
 
-    return keys;
-}
+    auto isAbsolutePath = [](const std::wstring& s) {
+        return
+            (s.size() >= 3 &&
+             iswalpha(s[0]) &&
+             s[1] == L':' &&
+             (s[2] == L'\\' || s[2] == L'/')) ||
+            (s.rfind(L"\\\\", 0) == 0);
+    };
 
-// Returns foreground window, excluding the taskbar itself
-HWND ForegroundWindow() {
-    HWND hRoot = GetAncestor(GetForegroundWindow(), GA_ROOT);
-    return (hRoot && hRoot != g_hTaskbarWnd) ? hRoot : nullptr;
-}
+    // 1) Try window title -> real file path
+    int len = GetWindowTextLengthW(hWnd);
+    if (len > 0) {
+        std::wstring title(len + 1, L'\0');
+        int copied = GetWindowTextW(hWnd, title.data(), len + 1);
+        title.resize(copied > 0 ? copied : 0);
 
-// Opens Explorer with the foreground window's file selected
-void SelectActiveInExplorer() {
-    HWND hWnd = ForegroundWindow();
-    if (!hWnd) {
-        return;
-    }
+        std::wstring current = stringtools::trimDecorated(title);
 
-    std::wstring path;
+        for (;;) {
+            std::wstring candidate = stringtools::trimDecorated(current);
 
-    // First try: extract path from window title.
-    {
-        int len = GetWindowTextLengthW(hWnd);
-        if (len > 0) {
-            std::wstring title(len + 1, L'\0');
-            title.resize(GetWindowTextW(hWnd, title.data(), len + 1));
-
-            if (!title.empty() && title.front() == L'*') {
-                title.erase(0, 1);
-            }
-            title = stringtools::trim(title);
-
-            size_t sep = title.find(L" - ");
-            std::wstring candidate = stringtools::trim(
-                sep == std::wstring::npos ? title : title.substr(0, sep));
-
-            if (candidate.size() >= 2 &&
-                ((candidate.front() == L'"' && candidate.back() == L'"') ||
-                 (candidate.front() == L'\'' && candidate.back() == L'\''))) {
-                candidate = stringtools::trim(
-                    candidate.substr(1, candidate.size() - 2));
-            }
-
-            if (candidate.find(L":\\") != std::wstring::npos ||
-                candidate.rfind(L"\\\\", 0) == 0) {
+            if (isAbsolutePath(candidate)) {
                 std::error_code ec;
-                if (std::filesystem::exists(candidate, ec)) {
-                    path = std::move(candidate);
+                if (std::filesystem::is_regular_file(candidate, ec)) {
+                    outPath = std::move(candidate);
+                    return true;
                 }
             }
+
+            size_t sep = current.rfind(L" - ");
+            if (sep == std::wstring::npos) {
+                break;
+            }
+
+            current.resize(sep);
         }
     }
 
-    // Second try: use the process executable path.
-    if (path.empty()) {
-        DWORD pid = 0;
-        GetWindowThreadProcessId(hWnd, &pid);
-        if (pid) {
-            HANDLE hProc =
-                OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-            if (hProc) {
-                std::wstring exe(32768, L'\0');
-                DWORD size = static_cast<DWORD>(exe.size());
-                if (QueryFullProcessImageNameW(hProc, 0, exe.data(), &size) &&
-                    size) {
-                    exe.resize(size);
-                    std::error_code ec;
-                    if (std::filesystem::exists(exe, ec)) {
-                        path = std::move(exe);
-                    }
-                }
-                CloseHandle(hProc);
-            }
+    // 2) Fallback -> process executable
+    DWORD pid = 0;
+    if (!GetWindowThreadProcessId(hWnd, &pid) || pid == 0) {
+        return false;
+    }
+
+    HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (!hProc) {
+        return false;
+    }
+
+    std::wstring exe(32768, L'\0');
+    DWORD size = static_cast<DWORD>(exe.size());
+
+    if (QueryFullProcessImageNameW(hProc, 0, exe.data(), &size) && size > 0) {
+        exe.resize(size);
+
+        std::error_code ec;
+        if (std::filesystem::is_regular_file(exe, ec)) {
+            CloseHandle(hProc);
+            outPath = std::move(exe);
+            return true;
         }
     }
 
-    if (path.empty()) {
+    CloseHandle(hProc);
+    return false;
+}
+
+void SelectActiveInExplorer() {
+    std::wstring path;
+    if (!GetForegroundWindowPathOrExe(path)) {
         Wh_Log(L"SelectActiveInExplorer: could not resolve path");
         return;
     }
 
     Wh_Log(L"SelectActiveInExplorer: %s", path.c_str());
+
     std::wstring explorerArgs = L"/select,\"" + path + L"\"";
-    SHELLEXECUTEINFOW sei{sizeof(sei)};
-    sei.fMask = SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI;
+
+    POINT cursorPos;
+    GetCursorPos(&cursorPos);
+    HMONITOR hMonitor = MonitorFromPoint(cursorPos, MONITOR_DEFAULTTONEAREST);
+
+    SHELLEXECUTEINFO sei = { sizeof(sei) };
+    sei.fMask = SEE_MASK_HMONITOR | SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI;
     sei.lpVerb = L"open";
     sei.lpFile = L"explorer.exe";
     sei.lpParameters = explorerArgs.c_str();
     sei.nShow = SW_SHOWNORMAL;
-    if (!ShellExecuteExW(&sei)) {
+    sei.hMonitor = hMonitor;
+
+    if (!ShellExecuteEx(&sei)) {
         DWORD err = GetLastError();
         if (err != ERROR_CANCELLED) {
             Wh_Log(L"SelectActiveInExplorer: launch failed (%lu)", err);
@@ -1675,85 +1633,129 @@ void SelectActiveInExplorer() {
     }
 }
 
-static std::pair<int,int> ParseOpacityUpArgs(const std::wstring& args) {
-    int max = 255, step = 25;
-    const auto parts = SplitArgs(stringtools::trim(args));
-    if (parts.size() >= 1) try { max  = std::clamp(std::stoi(parts[0]), 1, 255); } catch (...) {}
-    if (parts.size() >= 2) try { step = std::clamp(std::stoi(parts[1]), 1, 255); } catch (...) {}
-    return {max, step};
-}
-
-static std::pair<int,int> ParseOpacityDownArgs(const std::wstring& args) {
-    int min = 5, step = 25;
-    const auto parts = SplitArgs(stringtools::trim(args));
-    if (parts.size() >= 1) try { min  = std::clamp(std::stoi(parts[0]), 0, 254); } catch (...) {}
-    if (parts.size() >= 2) try { step = std::clamp(std::stoi(parts[1]), 1, 255); } catch (...) {}
-    return {min, step};
-}
-void OpacityAdjust(HWND hWnd, int delta, int clampMin, int clampMax) {
-    LONG_PTR ex = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
-    BYTE cur = 255;
-    DWORD flags = 0;
-    if ((ex & WS_EX_LAYERED) &&
-        GetLayeredWindowAttributes(hWnd, nullptr, &cur, &flags) &&
-        !(flags & LWA_ALPHA)) {
-        cur = 255;
-    }
-
-    int target = std::clamp(static_cast<int>(cur) + delta, clampMin, clampMax);
-    if (target == static_cast<int>(cur)) {
+void OpacityUp() {
+    HWND hWnd = GetForegroundWindow();
+    if (!hWnd ||
+        hWnd == g_hTaskbarWnd ||
+        !IsWindow(hWnd) ||
+        !IsWindowVisible(hWnd)) {
         return;
     }
 
-    if (!(ex & WS_EX_LAYERED)) {
+    LONG_PTR ex = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
+    const bool isLayered = (ex & WS_EX_LAYERED) != 0;
+
+    auto resetOpacity = [&]() {
+        Wh_Log(L"OpacityUp: reset to full opacity");
+        SetWindowLongPtrW(hWnd, GWL_EXSTYLE, ex & ~WS_EX_LAYERED);
+    };
+
+    static const BYTE kLevels[] = {0, 56, 85, 113, 141, 170, 198, 226};
+
+    if (!isLayered) {
+        // Already at full opacity, nothing to increase.
+        return;
+    }
+
+    BYTE cur = 255;
+    DWORD flags = 0;
+    if (!GetLayeredWindowAttributes(hWnd, nullptr, &cur, &flags) ||
+        !(flags & LWA_ALPHA)) {
+        return;
+    }
+
+    if (cur >= 226) {
+        resetOpacity();
+        return;
+    }
+
+    for (BYTE level : kLevels) {
+        if (cur < level) {
+            SetLayeredWindowAttributes(hWnd, 0, level, LWA_ALPHA);
+            return;
+        }
+    }
+
+    resetOpacity();
+}
+
+void OpacityDown() {
+    HWND hWnd = GetForegroundWindow();
+    if (!hWnd ||
+        hWnd == g_hTaskbarWnd ||
+        !IsWindow(hWnd) ||
+        !IsWindowVisible(hWnd)) {
+        return;
+    }
+
+    LONG_PTR ex = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
+    const bool isLayered = (ex & WS_EX_LAYERED) != 0;
+
+    static const BYTE kLevels[] = {226, 198, 170, 141, 113, 85, 56, 0};
+
+    if (!isLayered) {
+        Wh_Log(L"OpacityDown: starting at 226");
         SetWindowLongPtrW(hWnd, GWL_EXSTYLE, ex | WS_EX_LAYERED);
+        SetLayeredWindowAttributes(hWnd, 0, 226, LWA_ALPHA);
+        return;
     }
 
-    SetLayeredWindowAttributes(hWnd, 0, static_cast<BYTE>(target), LWA_ALPHA);
-    Wh_Log(L"Opacity: %u -> %d (delta=%+d clamp=[%d,%d])", cur, target, delta,
-           clampMin, clampMax);
-}
-
-// Increases foreground window opacity
-void OpacityUp(int maxAlpha, int step) {
-    HWND hWnd = ForegroundWindow();
-    if (hWnd) {
-        OpacityAdjust(hWnd, +step, 0, maxAlpha);
+    BYTE cur = 255;
+    DWORD flags = 0;
+    if (!GetLayeredWindowAttributes(hWnd, nullptr, &cur, &flags) ||
+        !(flags & LWA_ALPHA)) {
+        return;
     }
-}
 
-// Decreases foreground window opacity
-void OpacityDown(int minAlpha, int step) {
-    HWND hWnd = ForegroundWindow();
-    if (hWnd) {
-        OpacityAdjust(hWnd, -step, minAlpha, 255);
+    if (cur > 226) {
+        SetLayeredWindowAttributes(hWnd, 0, 226, LWA_ALPHA);
+        return;
     }
+
+    for (BYTE level : kLevels) {
+        if (cur > level) {
+            SetLayeredWindowAttributes(hWnd, 0, level, LWA_ALPHA);
+            return;
+        }
+    }
+
+    SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
 }
 
 // Toggles always-on-top state of foreground window
 void ToggleAlwaysOnTop() {
-    HWND hWnd = ForegroundWindow();
-    if (!hWnd) {
+    HWND hWnd = GetForegroundWindow();
+    if (!hWnd ||
+        hWnd == g_hTaskbarWnd ||
+        !IsWindow(hWnd) ||
+        !IsWindowVisible(hWnd)) {
         return;
     }
 
     bool topmost = (GetWindowLongPtrW(hWnd, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0;
-    SetWindowPos(hWnd, topmost ? HWND_NOTOPMOST : HWND_TOPMOST, 0, 0, 0, 0,
-                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+
+    SetWindowPos(hWnd,
+                 topmost ? HWND_NOTOPMOST : HWND_TOPMOST,
+                 0, 0, 0, 0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
     Wh_Log(L"ToggleAlwaysOnTop: %s -> %s",
            topmost ? L"topmost" : L"normal",
            topmost ? L"normal" : L"topmost");
 }
 
 void ForceKillActiveWindow() {
-    HWND hWnd = ForegroundWindow();
-    if (!hWnd) {
+    HWND hWnd = GetForegroundWindow();
+    if (!hWnd ||
+        hWnd == g_hTaskbarWnd ||
+        !IsWindow(hWnd) ||
+        !IsWindowVisible(hWnd)) {
         return;
     }
 
     DWORD pid = 0;
-    GetWindowThreadProcessId(hWnd, &pid);
-    if (pid == 0 || pid == GetCurrentProcessId()) {
+    if (!GetWindowThreadProcessId(hWnd, &pid) ||
+        pid == 0 ||
+        pid == GetCurrentProcessId()) {
         return;
     }
 
@@ -1767,18 +1769,89 @@ void ForceKillActiveWindow() {
     }
 }
 
+// Returns mute state of default audio device
+BOOL IsAudioMuted(com_ptr<IMMDeviceEnumerator> pDeviceEnumerator) {
+    const GUID XIID_IAudioEndpointVolume = {
+        0x5CDF2C82,
+        0x841E,
+        0x4546,
+        {0x97, 0x22, 0x0C, 0xF7, 0x40, 0x78, 0x22, 0x9A}};
+
+    BOOL isMuted = FALSE;
+    com_ptr<IMMDevice> defaultAudioDevice;
+    if (SUCCEEDED(pDeviceEnumerator->GetDefaultAudioEndpoint(
+            eRender, eConsole, defaultAudioDevice.put()))) {
+        com_ptr<IAudioEndpointVolume> endpointVolume;
+        if (SUCCEEDED(defaultAudioDevice->Activate(
+                XIID_IAudioEndpointVolume, CLSCTX_INPROC_SERVER, NULL,
+                endpointVolume.put_void()))) {
+            endpointVolume->GetMute(&isMuted);
+        }
+    }
+    return isMuted;
+}
+
+// Toggles mute state for all active audio devices
+void ToggleVolMuted() {
+    if (!g_audioCOM.IsInitialized()) {
+        if (!g_audioCOM.Init()) {
+            Wh_Log(L"Failed to initialize audio COM");
+            return;
+        }
+    }
+
+    auto pDeviceEnumerator = g_audioCOM.GetDeviceEnumerator();
+    if (!pDeviceEnumerator) {
+        Wh_Log(L"Failed to get device enumerator");
+        return;
+    }
+
+    Wh_Log(L"Toggling volume mute");
+
+    const GUID XIID_IAudioEndpointVolume = {
+        0x5CDF2C82,
+        0x841E,
+        0x4546,
+        {0x97, 0x22, 0x0C, 0xF7, 0x40, 0x78, 0x22, 0x9A}};
+
+    const BOOL isMuted = IsAudioMuted(pDeviceEnumerator);
+
+    com_ptr<IMMDeviceCollection> pDeviceCollection;
+    if (FAILED(pDeviceEnumerator->EnumAudioEndpoints(
+            eRender, DEVICE_STATE_ACTIVE, pDeviceCollection.put()))) {
+        return;
+    }
+
+    UINT deviceCount = 0;
+    if (FAILED(pDeviceCollection->GetCount(&deviceCount))) {
+        return;
+    }
+
+    for (UINT i = 0; i < deviceCount; i++) {
+        com_ptr<IMMDevice> pDevice;
+        if (SUCCEEDED(pDeviceCollection->Item(i, pDevice.put()))) {
+            com_ptr<IAudioEndpointVolume> endpointVolume;
+            if (SUCCEEDED(pDevice->Activate(XIID_IAudioEndpointVolume,
+                                            CLSCTX_INPROC_SERVER, NULL,
+                                            endpointVolume.put_void()))) {
+                endpointVolume->SetMute(!isMuted, NULL);
+            }
+        }
+    }
+}
+
 HotkeyRegionName TryParseRegionName(const std::wstring& raw) {
     static const std::unordered_map<std::wstring, HotkeyRegionName> regionMap = 
         {
-            {L"top_left", HotkeyRegionName::TOP_LEFT},
-            {L"top", HotkeyRegionName::TOP},
-            {L"top_right", HotkeyRegionName::TOP_RIGHT},
-            {L"left", HotkeyRegionName::LEFT},
+            {L"top_left", HotkeyRegionName::TopLeft},
+            {L"top", HotkeyRegionName::Top},
+            {L"top_right", HotkeyRegionName::TopRight},
+            {L"left", HotkeyRegionName::Left},
             {L"elsewhere", HotkeyRegionName::Elsewhere},
-            {L"right", HotkeyRegionName::RIGHT},
-            {L"bottom_left", HotkeyRegionName::BOTTOM_LEFT},
-            {L"bottom", HotkeyRegionName::BOTTOM},
-            {L"bottom_right", HotkeyRegionName::BOTTOM_RIGHT},
+            {L"right", HotkeyRegionName::Right},
+            {L"bottom_left", HotkeyRegionName::BottomLeft},
+            {L"bottom", HotkeyRegionName::Bottom},
+            {L"bottom_right", HotkeyRegionName::BottomRight},
         };
 
         auto normalized = stringtools::toLower(stringtools::trim(raw));
@@ -1809,9 +1882,7 @@ HotkeyActionType TryParseActionType(const std::wstring& raw) {
             {L"action_open_start_menu", HotkeyActionType::OpenStartMenu},
             {L"action_send_keypress", HotkeyActionType::SendKeypress},
             {L"action_start_process", HotkeyActionType::StartProcess},
-            {L"action_media_play_pause", HotkeyActionType::MediaPlayPause},
-            {L"action_media_next", HotkeyActionType::MediaNext},
-            {L"action_media_prev", HotkeyActionType::MediaPrev},
+            {L"action_copyrun", HotkeyActionType::CopyRun},
             {L"action_select_active_in_explorer",
              HotkeyActionType::SelectActiveInExplorer},
             {L"action_opacity_up_active", HotkeyActionType::OpacityUp},
@@ -1819,7 +1890,9 @@ HotkeyActionType TryParseActionType(const std::wstring& raw) {
             {L"action_toggle_alwaysontop_active",
              HotkeyActionType::ToggleAlwaysOnTop},
             {L"action_force_kill_active", HotkeyActionType::ForceKillActive},
-            {L"action_copyrun", HotkeyActionType::CopyRun},
+            {L"action_media_play_pause", HotkeyActionType::MediaPlayPause},
+            {L"action_media_next", HotkeyActionType::MediaNext},
+            {L"action_media_prev", HotkeyActionType::MediaPrev},
         };
 
     auto normalized = stringtools::toLower(stringtools::trim(raw));
@@ -1828,29 +1901,28 @@ HotkeyActionType TryParseActionType(const std::wstring& raw) {
         return it->second;
     }
 
-    Wh_Log(L"Unknown action: %s", raw.c_str());
     return HotkeyActionType::Invalid;
 }
 
 const wchar_t* RegionNameToString(HotkeyRegionName region) {
     switch (region) {
-        case HotkeyRegionName::TOP_LEFT:
+        case HotkeyRegionName::TopLeft:
             return L"TOP_LEFT";
-        case HotkeyRegionName::TOP:
+        case HotkeyRegionName::Top:
             return L"TOP";
-        case HotkeyRegionName::TOP_RIGHT:
+        case HotkeyRegionName::TopRight:
             return L"TOP_RIGHT";
-        case HotkeyRegionName::LEFT:
+        case HotkeyRegionName::Left:
             return L"LEFT";
         case HotkeyRegionName::Elsewhere:
-            return L"Elsewhere";
-        case HotkeyRegionName::RIGHT:
+            return L"ELSEWHERE";
+        case HotkeyRegionName::Right:
             return L"RIGHT";
-        case HotkeyRegionName::BOTTOM_LEFT:
+        case HotkeyRegionName::BottomLeft:
             return L"BOTTOM_LEFT";
-        case HotkeyRegionName::BOTTOM:
+        case HotkeyRegionName::Bottom:
             return L"BOTTOM";
-        case HotkeyRegionName::BOTTOM_RIGHT:
+        case HotkeyRegionName::BottomRight:
             return L"BOTTOM_RIGHT";
         case HotkeyRegionName::Invalid:
             return L"Invalid";
@@ -1952,19 +2024,15 @@ std::function<void()> ParseActionSetting(HotkeyActionType actionType,
             return [cmd]() { StartProcess(cmd); };
         }
         case HotkeyActionType::CopyRun: {
-            std::wstring copyRunArgs = stringtools::trim(args);
-            return [copyRunArgs]() { CopyRun(copyRunArgs); };
+            std::wstring cmd = stringtools::trim(args);
+            return [cmd]() { CopyRun(cmd); };
         }
         case HotkeyActionType::SelectActiveInExplorer:
             return []() { SelectActiveInExplorer(); };
-        case HotkeyActionType::OpacityUp: {
-            const auto [max, step] = ParseOpacityUpArgs(args);
-            return [max, step]() { OpacityUp(max, step); };
-        }
-        case HotkeyActionType::OpacityDown: {
-            const auto [min, step] = ParseOpacityDownArgs(args);
-            return [min, step]() { OpacityDown(min, step); };
-        }
+        case HotkeyActionType::OpacityUp:
+            return []() { OpacityUp(); };
+        case HotkeyActionType::OpacityDown:
+            return []() { OpacityDown(); };
         case HotkeyActionType::ToggleAlwaysOnTop:
             return []() { ToggleAlwaysOnTop(); };
         case HotkeyActionType::ForceKillActive:
@@ -1980,7 +2048,6 @@ std::function<void()> ParseActionSetting(HotkeyActionType actionType,
     }
     return []() {};
 }
-
 #pragma endregion  // actions
 
 // =====================================================================
@@ -1996,12 +2063,22 @@ LRESULT CALLBACK TaskbarWindowSubclassProc(_In_ HWND hWnd,
         case WM_HOTKEY: {
             int hotkeyId = static_cast<int>(wParam);
 
+            auto hotkeyIt = std::find_if(
+                g_settings.hotkeyActions.begin(),
+                g_settings.hotkeyActions.end(),
+                [&](const HotkeyBinding& e) {
+                    return e.hotkeyId == hotkeyId;
+                });
+            if (hotkeyIt == g_settings.hotkeyActions.end()) {
+                break;
+            }
+
             auto tryFire = [&](HotkeyRegionName r) -> bool {
                 auto it = std::find_if(
                     g_settings.hotkeyActions.begin(),
                     g_settings.hotkeyActions.end(),
                     [&](const HotkeyBinding& e) {
-                        return e.registered && e.hotkeyId == hotkeyId && e.region == r;
+                        return e.hotkeyId == hotkeyId && e.region == r;
                     });
                 if (it == g_settings.hotkeyActions.end()) return false;
                 Wh_Log(L"Hotkey '%s' fired in region %s, executing %s",
@@ -2027,25 +2104,25 @@ LRESULT CALLBACK TaskbarWindowSubclassProc(_In_ HWND hWnd,
 
             bool fired = false;
             if (atTop && atLeft) {
-                fired = tryFire(HotkeyRegionName::TOP_LEFT)
-                     || tryFire(HotkeyRegionName::TOP)
-                     || tryFire(HotkeyRegionName::LEFT);
+                fired = tryFire(HotkeyRegionName::TopLeft)
+                     || tryFire(HotkeyRegionName::Top)
+                     || tryFire(HotkeyRegionName::Left);
             } else if (atTop && atRight) {
-                fired = tryFire(HotkeyRegionName::TOP_RIGHT)
-                     || tryFire(HotkeyRegionName::TOP)
-                     || tryFire(HotkeyRegionName::RIGHT);
+                fired = tryFire(HotkeyRegionName::TopRight)
+                     || tryFire(HotkeyRegionName::Top)
+                     || tryFire(HotkeyRegionName::Right);
             } else if (atBottom && atLeft) {
-                fired = tryFire(HotkeyRegionName::BOTTOM_LEFT)
-                     || tryFire(HotkeyRegionName::BOTTOM)
-                     || tryFire(HotkeyRegionName::LEFT);
+                fired = tryFire(HotkeyRegionName::BottomLeft)
+                     || tryFire(HotkeyRegionName::Bottom)
+                     || tryFire(HotkeyRegionName::Left);
             } else if (atBottom && atRight) {
-                fired = tryFire(HotkeyRegionName::BOTTOM_RIGHT)
-                     || tryFire(HotkeyRegionName::BOTTOM)
-                     || tryFire(HotkeyRegionName::RIGHT);
-            } else if (atTop)    { fired = tryFire(HotkeyRegionName::TOP); }
-            else if (atBottom)   { fired = tryFire(HotkeyRegionName::BOTTOM); }
-            else if (atLeft)     { fired = tryFire(HotkeyRegionName::LEFT); }
-            else if (atRight)    { fired = tryFire(HotkeyRegionName::RIGHT); }
+                fired = tryFire(HotkeyRegionName::BottomRight)
+                     || tryFire(HotkeyRegionName::Bottom)
+                     || tryFire(HotkeyRegionName::Right);
+            } else if (atTop)    { fired = tryFire(HotkeyRegionName::Top); }
+            else if (atBottom)   { fired = tryFire(HotkeyRegionName::Bottom); }
+            else if (atLeft)     { fired = tryFire(HotkeyRegionName::Left); }
+            else if (atRight)    { fired = tryFire(HotkeyRegionName::Right); }
             if (!fired) tryFire(HotkeyRegionName::Elsewhere);
             return 0;
         }
@@ -2194,26 +2271,37 @@ void LoadSettings() {
             auto regionStr = stringtools::trim(std::wstring(
                 StringSetting::make(L"HotkeyActions[%d].Regions[%d].Region", i, j)
                     .get()));
-            auto actionStr = stringtools::trim(std::wstring(
+            auto actionStrRaw = stringtools::trim(std::wstring(
                 StringSetting::make(L"HotkeyActions[%d].Regions[%d].Action", i, j)
                     .get()));
 
-            if (regionStr.empty() && actionStr.empty()) {
+            if (regionStr.empty() && actionStrRaw.empty()) {
                 break;
             }
 
             auto regionName = TryParseRegionName(regionStr);
-            auto actionType = TryParseActionType(actionStr);
-
             if (regionName == HotkeyRegionName::Invalid) {
                 Wh_Log(L"Hotkey[%d] Region[%d]: unknown region '%s', skipping row",
                        i, j, regionStr.c_str());
                 continue;
             }
 
+            auto it = std::find_if(
+                g_settings.hotkeyActions.begin() + startIdx,
+                g_settings.hotkeyActions.end(),
+                [&](const HotkeyBinding& e) {
+                    return e.region == regionName;
+                });
+
+            if (it != g_settings.hotkeyActions.end()) {
+                Wh_Log(L"Hotkey[%d] Region[%d]: duplicate region '%s', first row wins, skipping",
+                       i, j, RegionNameToString(regionName));
+                continue;
+            }
+            auto actionType = TryParseActionType(actionStrRaw);
             if (actionType == HotkeyActionType::Invalid) {
                 Wh_Log(L"Hotkey[%d] Region[%d]: unknown action '%s', skipping row",
-                       i, j, actionStr.c_str());
+                       i, j, actionStrRaw.c_str());
                 continue;
             }
 
@@ -2235,21 +2323,11 @@ void LoadSettings() {
             entry.modifiers = modifiers;
             entry.vk = vk;
             entry.hotkeyId = 0;
-            entry.registered = false;
+            entry.ownsRegistration = false;
 
-            auto it = std::find_if(
-                g_settings.hotkeyActions.begin() + startIdx,
-                g_settings.hotkeyActions.end(),
-                [&](const HotkeyBinding& e) { return e.region == regionName; });
+            g_settings.hotkeyActions.push_back(std::move(entry));
+        }
 
-              if (it != g_settings.hotkeyActions.end()) {
-                Wh_Log(L"Hotkey[%d]: duplicate region '%s', first row wins, skipping",
-                    i, RegionNameToString(regionName));
-                  } else {
-                    g_settings.hotkeyActions.push_back(std::move(entry));
-                 }
-            }
-      
         if (g_settings.hotkeyActions.size() == startIdx) {
             Wh_Log(L"Hotkey[%d] '%s': no non-Nothing region rows configured, skipping",
                    i, hotkeyStr.c_str());
@@ -2260,7 +2338,6 @@ void LoadSettings() {
                hotkeyStr.c_str(), g_settings.hotkeyActions.size() - startIdx);
     }
 }
-
 #pragma endregion  // settings
 
 // =====================================================================

--- a/mods/hotcorner-hotkeys.wh.cpp
+++ b/mods/hotcorner-hotkeys.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id                   hotcorner-hotkeys
 // @name                 HotCorner Hotkeys
-// @description          Assign configurable keyboard hotkeys to up to 8 actions, gated by cursor zones (four corners + four edges) of the active monitor.
-// @version              2.4
+// @description          Assign up to 9 distinct actions per hotkey, dispatched based on which screen zone the cursor is in when pressed (4 corners, 4 edges, or elsewhere).
+// @version              3
 // @author               webberlv
 // @github               https://github.com/webberLV
 // @license              GPL-3.0-only
@@ -13,187 +13,222 @@
 // Source code is published under The GNU General Public License v3.0.
 //
 // For pull requests, development takes place here:
-// https://github.com/webberlv/windhawk-mods
+// https://github.com/webberlv/windhawk-mods/tree/hotcorner-hotkeys
 
 // ==WindhawkModReadme==
 /*
 # HotCorner Hotkeys
 
-This mod binds configurable keyboard hotkeys to screen zones defined by the four corners and four edges of the active monitor. Each hotkey is registered once per unique key combination and evaluated at trigger time using the current cursor position.
+## Cursor zones
 
-When a hotkey is pressed, the cursor location determines which zone is active and dispatches the corresponding action. A single hotkey can therefore invoke up to eight distinct actions. If the cursor is not within a defined zone, the hotkey is intercepted and no action is executed. This mod is zone-gated by design and does not provide unconditional global hotkeys. If you were hoping for the hotkey to function globally without a zone selection restriction check out [keyboard-shortcut-actions](https://windhawk.net/mods/keyboard-shortcut-actions) instead. 
+When a hotkey fires, the mod determines which action to run using a
+**fallback chain** based on the current cursor zone.
 
-## Architecture
+| Cursor zone  | Fallback order                            |
+|--------------|-------------------------------------------|
+| TOP_LEFT     | TOP_LEFT → TOP → LEFT → Elsewhere         |
+| TOP_RIGHT    | TOP_RIGHT → TOP → RIGHT → Elsewhere       |
+| BOTTOM_LEFT  | BOTTOM_LEFT → BOTTOM → LEFT → Elsewhere   |
+| BOTTOM_RIGHT | BOTTOM_RIGHT → BOTTOM → RIGHT → Elsewhere |
+| Top          | Top → Elsewhere                           |
+| Bottom       | Bottom → Elsewhere                        |
+| Left         | Left → Elsewhere                          |
+| Right        | Right → Elsewhere                         |
+| Elsewhere    | Elsewhere                                 |
 
-### Registration vs. dispatch
-
-- **Registration**: Each unique key combination is registered exactly once
-  as a global hotkey.
-- **Dispatch**: On `WM_HOTKEY`, the cursor zone is computed and the
-  `(hotkey, zone)` mapping is resolved and executed.
-### Rules
-- Action identity is `(hotkey, zone)`
-- Zones are used only during dispatch
-- A hotkey may map to multiple actions across different zones
-- Duplicate `(hotkey, zone)` mappings are invalid and rejected at load time
-- Each key combination is registered once globally
-- If no action exists for the active cursor zone:
-  - No action is executed
-  - The hotkey is still consumed 
-## Zones
-Zones are computed from the active monitor bounds using `GatePx`
-(pixel thickness).
-Corner zones take precedence over edge zones when regions overlap.
-Supported values:
-`NONE, LEFT, TOP_LEFT, TOP, TOP_RIGHT, RIGHT, BOTTOM_RIGHT, BOTTOM, BOTTOM_LEFT`
-`NONE` matches only when the cursor is outside all edge and corner gate regions.
 ## Supported actions
-1. **Show desktop**  
-   Toggle desktop visibility
-2. **Ctrl+Alt+Tab**  
-   Open the Ctrl+Alt+Tab dialog
-3. **Task Manager**  
-   Open Windows Task Manager
-4. **Mute system volume**  
-   Toggle system-wide mute
-5. **Taskbar auto-hide**  
-   Toggle taskbar auto-hide
-6. **Win+Tab**  
-   Open Task View
-7. **Hide desktop icons**  
-   Toggle visibility of all desktop icons
-8. **Combine taskbar buttons**  
-   Toggle taskbar button grouping between two states
-9. **Toggle taskbar alignment**  
-   Toggle taskbar icon alignment (left/center, Windows 11 only)
-10. **Open Start menu**  
-    Send the Win key
-11. **Virtual key press**  
-    Send a virtual key sequence
-12. **Open application, path, or URL**  
-    Launch an executable, open a path, or open a URL
+
+1. **Show desktop** — Toggles the desktop view using the taskbar Show Desktop command.
+2. **Ctrl+Alt+Tab** — Opens the Ctrl+Alt+Tab task switcher.
+3. **Task Manager** — Opens the default Windows Task Manager.
+4. **Mute system volume** — Toggles mute for all active render audio devices.
+5. **Taskbar auto-hide** — Toggles the Windows taskbar auto-hide setting.
+6. **Win+Tab** — Opens Task View.
+7. **Hide desktop icons** — Toggles visibility of desktop icons.
+8. **Combine Taskbar buttons** — Toggles taskbar button combine mode between two configured states.
+9. **Toggle Taskbar alignment** — Toggles the taskbar alignment registry setting between left and center.
+10. **Open Start menu** — Simulates the Windows key to open Start.
+11. **Virtual key press** — Sends one or more virtual key presses or shortcuts using `SendInput`.
+12. **Open application, path or URL** — Launches an executable, opens a file/folder path, or opens a URL.
 13. **Media Play/Pause**
 14. **Media Next Track**
 15. **Media Previous Track**
+16. **Open parsed title path in explorer, with fallback to exe** — Selects the active file in an Explorer window, falling back to the foreground executable if no file path could be parsed from the title.
+17. **Opacity Up (active window)** — Increases the foreground window's opacity toward a configurable maximum.
+18. **Opacity Down (active window)** — Decreases the foreground window's opacity toward a configurable minimum.
+19. **Toggle Always On Top (active window)** — Toggles the foreground window's always-on-top state.
 
-16. **Toggle Always On Top (active window)**  
-    Toggles `WS_EX_TOPMOST` on the current foreground window
+## Hotkey format
 
-17. **Opacity Up (active window)**  
-    Increases window opacity
+Hotkeys are specified in the format: `Modifier+Modifier+Key`
 
-18. **Opacity Down (active window)**  
-    Decreases window opacity
+**Modifiers:** `Alt`, `Ctrl`, `Shift`, `Win`
 
-# Hotkey format
+**Keys:**
+- **Letters:** `A`–`Z`
+- **Numbers:** `0`–`9`
+- **Function keys:** `F1`–`F24`
+- **Navigation:** `Home`, `End`, `PageUp`, `PageDown`, `Insert`, `Delete`, `Left`, `Right`, `Up`, `Down`
+- **Common:** `Enter`, `Tab`, `Space`, `Backspace`, `Escape` (or `Esc`), `CapsLock`, `PrintScreen`, `Pause`
+- **Numpad:** `Numpad0`–`Numpad9` (or `Num0`–`Num9`), `NumLock`, `Add`, `Subtract`, `Multiply`, `Divide`, `Decimal`
+- **Media:** `VolumeMute`, `VolumeUp`, `VolumeDown`, `MediaPlayPause`, `MediaNext`, `MediaPrev`, `MediaStop`
+- **Modifier keys (for Virtual key press):** `LWin`, `RWin`, `LShift`, `RShift`, `LCtrl`, `RCtrl`, `LAlt`, `RAlt`
+- Some of the `VK_*` codes from [Virtual-Key Codes](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes)
 
-Hotkeys use the form:
+**Examples:**
 
-`Modifier+Modifier+Key`
+```
+Ctrl+Alt+D        — Ctrl + Alt + D
+Ctrl+Shift+F1     — Ctrl + Shift + F1
+Alt+Home          — Alt + Home
+Win+Numpad1       — Windows key + Numpad 1
+```
 
-## Modifiers
-`Alt`, `Ctrl`, `Shift`, `Win`
-#### Keys
+## Additional args
+AdditionalArgs are optional and only used by the actions below.
 
-- Letters: `A–Z`
-- Numbers: `0–9`
-- Function keys: `F1–F24`
-- Navigation: `Home`, `End`, `PageUp`, `PageDown`, `Insert`, `Delete`,
-  `Left`, `Right`, `Up`, `Down`
-- Common: `Enter`, `Tab`, `Space`, `Backspace`, `Escape` (`Esc`),
-  `CapsLock`, `PrintScreen`, `Pause`
-- Numpad: `Numpad0–Numpad9` (`Num0–Num9`), `NumLock`,
-  `Add`, `Subtract`, `Multiply`, `Divide`, `Decimal`
-- Media: `VolumeMute`, `VolumeUp`, `VolumeDown`,
-  `MediaPlayPause`, `MediaNext`, `MediaPrev`, `MediaStop`
-- Modifier keys (Virtual Key Press only):
-  `LWin`, `RWin`, `LShift`, `RShift`,
-  `LCtrl`, `RCtrl`, `LAlt`, `RAlt`
-- Selected `VK_*` virtual-key codes (numeric forms accepted where supported)
+---
+### Virtual key press
 
-### Examples
+Semicolon-separated key combinations are parsed left to right.
 
-- `Ctrl+Alt+D`
-- `Ctrl+Shift+F1`
-- `Alt+Home`
-- `Win+Numpad1`
-## Additional arguments
+> **Note:** All parsed keys are sent together in one `SendInput` batch, rather than as fully separate sequential shortcuts. If modifier keys are still physically held down when the action fires, sending is deferred until they are released (up to ~500 ms), then sent automatically.
 
-Actions 8, 11, 12, 17, and 18 accept AdditionalArgs.
+**Examples:**
 
-Arguments are separated by semicolons.
+```
+Ctrl+C
+Alt+F4
+Ctrl+Shift+Esc
+VolumeMute
+Ctrl+C;Alt+Tab
+```
 
-### 8. Combine taskbar buttons
+---
 
-`priState1;priState2;secState1;secState2`
+### Open application, path or URL
 
-States:
-- `COMBINE_ALWAYS`
-- `COMBINE_WHEN_FULL`
-- `COMBINE_NEVER`
+A command, path, or URL passed to `ShellExecuteEx`.
 
-Example:
-`COMBINE_ALWAYS;COMBINE_NEVER;COMBINE_ALWAYS;COMBINE_NEVER`
+**Examples:**
 
-### 11. Virtual key press
+```
+notepad.exe
+C:\Windows\System32\cmd.exe
+"C:\Program Files\Everything\Everything.exe"
+explorer.exe C:
+https://example.com
+```
 
-`key1;key2;...;keyN`  
-or  
-`Modifier+Key`
+Prefix with `uac;` to request elevation:
 
-Notes:
-- Each key may be a key name (`A`, `Enter`, `VK_OEM_3`)
-  or a chord (`Ctrl+Shift+Escape`)
-- Multi-key sequences press keys in order, then release
+```
+uac;cmd.exe
+uac;"C:\Tools\app.exe" --example
+```
 
-Examples:
-- `Win+E`
-- `Ctrl+Shift+Escape`
-- `LCtrl;C`
+Prefix with `clip;` to URL-encode the clipboard contents and append them to the remainder of the argument. Built-in aliases are supported:
 
-### 12. Open application, path, or URL
+```
+clip;gpt
+clip;yt
+clip;google
+clip;copilot
+clip;x
+clip;reddit
+clip;translate
+clip;https://www.bing.com/search?q=
+```
 
-`command`
+The `uac;` and `clip;` prefixes can be combined (`uac;` must come first).
 
-Notes:
-- Starts an executable (with optional arguments),
-  opens a filesystem path, or opens a URL
-- Prefix with `uac;` to request elevation
+| Alias       | Expands to                                    |
+|-------------|-----------------------------------------------|
+| `gpt`       | https://chatgpt.com/?q=                       |
+| `yt`        | https://www.youtube.com/results?search_query= |
+| `google`    | https://www.google.com/search?q=              |
+| `copilot`   | https://copilot.microsoft.com/?sendquery=1&q= |
+| `x`         | https://twitter.com/search?q=                 |
+| `reddit`    | https://www.reddit.com/search/?q=             |
+| `translate` | https://translate.google.com/?text=           |
 
-Examples:
-- `notepad.exe`
-- `"C:\Program Files\App\app.exe" --arg`
-- `https://example.com`
-- `uac;C:\Windows\System32\cmd.exe`
+---
 
-### 17/18. Opacity Up / Down (active window)
+### Combine taskbar buttons
 
-Tokens (semicolon separated). All tokens are optional.  
-Unspecified values use default behavior.
+Up to 4 semicolon-separated state values: `primaryState1; primaryState2; secondaryState1; secondaryState2`
 
-- `step<number>`: Opacity step per press (default `0.05`)
-- `min<number>`: Minimum opacity clamp (default `0.10`)
-- `max<number>`: Maximum opacity clamp (default `1.00`)
-- `allApp`: Apply to all top-level windows in the same process as the foreground window
-- `dontLayer`: Do not automatically add `WS_EX_LAYERED`
+**Valid state values:**
 
-Examples:
+```
+COMBINE_ALWAYS
+COMBINE_WHEN_FULL
+COMBINE_NEVER
+```
 
-- `step0.03`
-- `step0.02;min0.30;max0.95`
-- `allApp;step0.02`
-- `allApp;dontLayer;min0.25;max0.90`
+The action toggles between the two primary states on each press. Toggle direction is determined by reading the current registry state on each press — immune to external changes and always deterministic. The optional secondary pair controls taskbars on secondary monitors.
 
+**Example:**
+
+```
+COMBINE_ALWAYS;COMBINE_NEVER
+```
+
+---
+
+### Opacity Up (active window)
+
+Format: `max;step`
+
+| Parameter | Description                        | Default |
+|-----------|------------------------------------|---------|
+| `max`     | Upper alpha clamp, 0–255           | `255`   |
+| `step`    | Amount added per press, 1–255      | `25`    |
+
+Omitting both values uses all defaults.
+Providing only the first value sets min while keeping the default step.
+To modifiy step you must include max first. 
+
+**Example:**
+
+```
+200;15
+```
+
+---
+
+### Opacity Down (active window)
+
+Format: `min;step`
+
+| Parameter | Description                        | Default |
+|-----------|------------------------------------|---------|
+| `min`     | Lower alpha clamp, 0–255           | `5`     |
+| `step`    | Amount subtracted per press, 1–255 | `25`    |
+
+Omitting both values uses all defaults.
+Providing only the first value sets min while keeping the default step.
+To modifiy step you must include min first. 
+
+**Example:**
+
+```
+5;25
+```
+
+## Notes
+
+- The mod runs inside `explorer.exe` and uses global hotkey registration.
+- Each unique key combination is registered with Windows exactly once.
+- Some windows may not respond to layered window attributes.
 
 ## Credits
 
-## Credits
-
-The actions in this mod are based on
+15 of the actions in this mod are based on
 [Click on empty taskbar space](https://windhawk.net/mods/taskbar-empty-space-clicks)
 by [m1lhaus](https://github.com/m1lhaus).
 
-The global hotkey triggering mechanism is based on 
+The global hotkey triggering mechanism is based on
 [keyboard-shortcut-actions](https://windhawk.net/mods/keyboard-shortcut-actions)
 by [m417z](https://github.com/m417z).
 
@@ -202,12 +237,6 @@ by [m417z](https://github.com/m417z).
 
 // ==WindhawkModSettings==
 /*
-- GatePx: 12
-  $name: Zone gate thickness (px)
-  $description: >-
-    Pixel thickness used to determine edge/corner zones from the monitor bounds.
-    Corners take precedence over edges. Used only for dispatcher routing.
-
 - HotkeyActions:
   - - Hotkey: ""
       $name: Keyboard Shortcut
@@ -215,49 +244,46 @@ by [m417z](https://github.com/m417z).
         Hotkey in format: Modifier+Key (e.g., Ctrl+Alt+D).
         Modifiers: Alt, Ctrl, Shift, Win.
         Keys: A-Z, 0-9, F1-F24, Enter, Space, Home, End, Insert, Delete, etc.
-    - Zone: NONE
-      $name: Zone
-      $description: >-
-        Cursor zone required for this mapping. Zone affects dispatcher routing
-        only. NONE matches only when the cursor is not within any edge/corner
-        gate region.
-      $options:
-      - NONE: None (interior)
-      - LEFT: Left edge
-      - TOP_LEFT: Top-left corner
-      - TOP: Top edge
-      - TOP_RIGHT: Top-right corner
-      - RIGHT: Right edge
-      - BOTTOM_RIGHT: Bottom-right corner
-      - BOTTOM: Bottom edge
-      - BOTTOM_LEFT: Bottom-left corner
-    - Action: ACTION_NOTHING
-      $name: Action
-      $description: Action to invoke when the hotkey is pressed.
-      $options:
-      - ACTION_NOTHING: Nothing (default)
-      - ACTION_SHOW_DESKTOP: Show desktop
-      - ACTION_ALT_TAB: Ctrl+Alt+Tab
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_MUTE: Mute system volume
-      - ACTION_TASKBAR_AUTOHIDE: Taskbar auto-hide
-      - ACTION_WIN_TAB: Win+Tab
-      - ACTION_HIDE_ICONS: Hide desktop icons
-      - ACTION_COMBINE_TASKBAR_BUTTONS: Combine Taskbar buttons
-      - ACTION_TOGGLE_TASKBAR_ALIGNMENT: Toggle Taskbar alignment
-      - ACTION_OPEN_START_MENU: Open Start menu
-      - ACTION_SEND_KEYPRESS: Virtual key press
-      - ACTION_START_PROCESS: Open application, path or URL
-      - ACTION_MEDIA_PLAY_PAUSE: Media Play/Pause
-      - ACTION_MEDIA_NEXT: Media Next Track
-      - ACTION_MEDIA_PREV: Media Previous Track
-      - ACTION_TOGGLE_ALWAYSONTOP_ACTIVE: Toggle Always On Top (active window)
-      - ACTION_OPACITY_UP_ACTIVE: Opacity Up (active window)
-      - ACTION_OPACITY_DOWN_ACTIVE: Opacity Down (active window)
-
-    - AdditionalArgs: ""
-      $name: Additional Args
-      $description: Additional arguments for the action (see Details tab).
+    - Regions:
+      - - Region: ELSEWHERE
+          $name: Region
+          $options:
+          - ELSEWHERE: ELSEWHERE
+          - TOP_LEFT: Top-left corner
+          - TOP: Top edge
+          - TOP_RIGHT: Top-right corner
+          - LEFT: Left edge
+          - RIGHT: Right edge
+          - BOTTOM_LEFT: Bottom-left corner
+          - BOTTOM: Bottom edge
+          - BOTTOM_RIGHT: Bottom-right corner
+        - Action: ACTION_NOTHING
+          $name: Action
+          $description: Action to invoke when the hotkey is pressed in this region.
+          $options:
+          - ACTION_NOTHING: Nothing
+          - ACTION_SHOW_DESKTOP: Show desktop
+          - ACTION_ALT_TAB: Ctrl+Alt+Tab
+          - ACTION_TASK_MANAGER: Task Manager
+          - ACTION_MUTE: Mute system volume
+          - ACTION_TASKBAR_AUTOHIDE: Taskbar auto-hide
+          - ACTION_WIN_TAB: Win+Tab
+          - ACTION_HIDE_ICONS: Hide desktop icons
+          - ACTION_COMBINE_TASKBAR_BUTTONS: Combine Taskbar buttons
+          - ACTION_TOGGLE_TASKBAR_ALIGNMENT: Toggle Taskbar alignment
+          - ACTION_OPEN_START_MENU: Open Start menu
+          - ACTION_SEND_KEYPRESS: Virtual key press
+          - ACTION_START_PROCESS: Open application, path or URL
+          - ACTION_MEDIA_PLAY_PAUSE: Media Play/Pause
+          - ACTION_MEDIA_NEXT: Media Next Track
+          - ACTION_MEDIA_PREV: Media Previous Track
+          - ACTION_SELECT_ACTIVE_IN_EXPLORER: Open parsed title path in explorer, with fallback to exe.
+          - ACTION_OPACITY_UP_ACTIVE: Opacity Up (active window)
+          - ACTION_OPACITY_DOWN_ACTIVE: Opacity Down (active window)
+          - ACTION_TOGGLE_ALWAYSONTOP_ACTIVE: Toggle Always On Top (active window)
+        - AdditionalArgs: ""
+          $name: Additional Args
+          $description: Optional arguments for this action (e.g., Ctrl+C, uac;cmd.exe, clip;google, 200;15). See Details tab.
   $name: Keyboard Shortcut Actions
 */
 // ==/WindhawkModSettings==
@@ -274,17 +300,12 @@ by [m417z](https://github.com/m417z).
 #include <winuser.h>
 
 #include <algorithm>
-#include <cstdint>
 #include <cwctype>
 #include <filesystem>
 #include <functional>
-#include <memory>
-#include <optional>
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #if defined(__GNUC__) && __GNUC__ > 8
@@ -311,6 +332,7 @@ using winrt::com_ptr;
 
 #pragma region declarations
 
+// Enum for taskbar buttons state
 enum TaskBarButtonsState {
     COMBINE_ALWAYS = 0,
     COMBINE_WHEN_FULL,
@@ -318,6 +340,7 @@ enum TaskBarButtonsState {
     COMBINE_INVALID
 };
 
+// Enum for hotkey actions
 enum class HotkeyActionType {
     Nothing,
     ShowDesktop,
@@ -335,74 +358,43 @@ enum class HotkeyActionType {
     MediaPlayPause,
     MediaNext,
     MediaPrev,
-    ToggleAlwaysOnTopActive,
-    OpacityUpActive,
-    OpacityDownActive,
-
+    SelectActiveInExplorer,
+    OpacityUp,
+    OpacityDown,
+    ToggleAlwaysOnTop,
+    Invalid,
 };
 
-enum class Zone : uint8_t {
-    NONE = 0,
-    LEFT,
+enum class HotkeyRegionName {
     TOP_LEFT,
     TOP,
     TOP_RIGHT,
+    LEFT,
+    Elsewhere,
     RIGHT,
-    BOTTOM_RIGHT,
-    BOTTOM,
     BOTTOM_LEFT,
+    BOTTOM,
+    BOTTOM_RIGHT,
+    Invalid,
 };
 
-static const wchar_t* ZoneToString(Zone z) {
-    switch (z) {
-        case Zone::NONE: return L"NONE";
-        case Zone::LEFT: return L"LEFT";
-        case Zone::TOP_LEFT: return L"TOP_LEFT";
-        case Zone::TOP: return L"TOP";
-        case Zone::TOP_RIGHT: return L"TOP_RIGHT";
-        case Zone::RIGHT: return L"RIGHT";
-        case Zone::BOTTOM_RIGHT: return L"BOTTOM_RIGHT";
-        case Zone::BOTTOM: return L"BOTTOM";
-        case Zone::BOTTOM_LEFT: return L"BOTTOM_LEFT";
-    }
-    return L"UNKNOWN";
-}
-
-static uint64_t MakeHotkeyKey(UINT modifiers, UINT vk) {
-    return (static_cast<uint64_t>(modifiers) << 32) | static_cast<uint64_t>(vk);
-}
-
-struct HotkeyAction {
+struct HotkeyBinding {
     std::wstring hotkeyString;
-    Zone zone;
+    HotkeyRegionName region;
     HotkeyActionType actionType;
     std::wstring additionalArgs;
-
-    // executor present only if row validated and loaded
     std::function<void()> actionExecutor;
-
     UINT modifiers;
     UINT vk;
     int hotkeyId;
     bool registered;
 };
 
-struct HotkeyStats {
-    uint64_t hits_total = 0;
-    uint64_t hits_matched = 0;
-    uint64_t hits_no_match = 0;
-};
-
 static struct {
-    int gatePx;
-    std::vector<HotkeyAction> hotkeyActions;
-
-    // diagnostics derived from loaded actions
-    std::unordered_map<int, HotkeyStats> statsByHotkeyId;
-    std::unordered_set<uint64_t> loggedNoMatchByIdZone;  // (id<<8)|zone
-    std::unordered_set<int> loggedUnknownId;             // id only
+    std::vector<HotkeyBinding> hotkeyActions;
 } g_settings;
 
+// Wrapper for COM API initialization (audio device enumeration only)
 class AudioCOMAPI {
    public:
     AudioCOMAPI()
@@ -501,12 +493,6 @@ std::wstring toLower(const std::wstring& s) {
     return result;
 }
 
-std::wstring toUpper(const std::wstring& s) {
-    std::wstring result = s;
-    std::transform(result.begin(), result.end(), result.begin(), ::towupper);
-    return result;
-}
-
 bool startsWith(const std::wstring& s, const std::wstring& prefix) {
     if (s.length() < prefix.length()) {
         return false;
@@ -518,8 +504,10 @@ bool startsWith(const std::wstring& s, const std::wstring& prefix) {
 static HWND g_hTaskbarWnd = nullptr;
 static DWORD g_dwTaskbarThreadId = 0;
 
+// Base hotkey ID - each action gets base + index
 static const int kHotkeyIdBase = 1768250635;  // from epochconverter.com
 
+// Message for hotkey registration management
 static UINT g_hotkeyRegisteredMsg =
     RegisterWindowMessage(L"Windhawk_hotkey_" WH_MOD_ID);
 
@@ -528,33 +516,32 @@ enum {
     HOTKEY_UNREGISTER,
 };
 
+// Message to uninit COM from GUI thread
 static const UINT g_uninitCOMMsg =
     RegisterWindowMessage(L"Windhawk_UnInit_COM_" WH_MOD_ID);
 
-static const int kMaxKeypressRetryCount = 50;
+// Timer constants for keypress retry when modifier keys are pressed
+static const int kMaxKeypressRetryCount = 50;  // ~500ms max wait
 static const UINT kKeypressRetryIntervalMs = 10;
 
+// Pending keypress storage for deferred send
 static std::vector<int> g_pendingKeypressKeys;
 static int g_pendingKeypressRetryCount = 0;
 static UINT_PTR g_keypressTimerId = 0;
 
+// Forward declarations
 void LoadSettings();
 bool FromStringHotKey(std::wstring_view hotkeyString,
                       UINT* modifiersOut,
                       UINT* vkOut);
 void RegisterHotkeys(HWND hWnd);
 void UnregisterHotkeys(HWND hWnd);
-
-std::optional<HotkeyActionType> TryParseActionType(const std::wstring& actionName);
+HotkeyRegionName TryParseRegionName(const std::wstring& raw);
+HotkeyActionType TryParseActionType(const std::wstring& raw);
+const wchar_t* RegionNameToString(HotkeyRegionName region);
 const wchar_t* ActionTypeToString(HotkeyActionType actionType);
-
-bool TryBuildActionExecutor(HotkeyActionType actionType,
-                            const std::wstring& args,
-                            std::function<void()>& executorOut,
-                            std::wstring& errorOut);
-
-bool TryParseZone(std::wstring_view zoneString, Zone* zoneOut);
-Zone GetCursorZone(int gatePx);
+std::function<void()> ParseActionSetting(HotkeyActionType actionType,
+                                         const std::wstring& args);
 
 #pragma endregion  // declarations
 
@@ -572,57 +559,205 @@ bool FromStringHotKey(std::wstring_view hotkeyString,
     };
 
     static const std::unordered_map<std::wstring_view, UINT> vkMap = {
-        {L"A", 0x41},{L"B", 0x42},{L"C", 0x43},{L"D", 0x44},{L"E", 0x45},
-        {L"F", 0x46},{L"G", 0x47},{L"H", 0x48},{L"I", 0x49},{L"J", 0x4A},
-        {L"K", 0x4B},{L"L", 0x4C},{L"M", 0x4D},{L"N", 0x4E},{L"O", 0x4F},
-        {L"P", 0x50},{L"Q", 0x51},{L"R", 0x52},{L"S", 0x53},{L"T", 0x54},
-        {L"U", 0x55},{L"V", 0x56},{L"W", 0x57},{L"X", 0x58},{L"Y", 0x59},
+        // Letters A-Z
+        {L"A", 0x41},
+        {L"B", 0x42},
+        {L"C", 0x43},
+        {L"D", 0x44},
+        {L"E", 0x45},
+        {L"F", 0x46},
+        {L"G", 0x47},
+        {L"H", 0x48},
+        {L"I", 0x49},
+        {L"J", 0x4A},
+        {L"K", 0x4B},
+        {L"L", 0x4C},
+        {L"M", 0x4D},
+        {L"N", 0x4E},
+        {L"O", 0x4F},
+        {L"P", 0x50},
+        {L"Q", 0x51},
+        {L"R", 0x52},
+        {L"S", 0x53},
+        {L"T", 0x54},
+        {L"U", 0x55},
+        {L"V", 0x56},
+        {L"W", 0x57},
+        {L"X", 0x58},
+        {L"Y", 0x59},
         {L"Z", 0x5A},
-        {L"0", 0x30},{L"1", 0x31},{L"2", 0x32},{L"3", 0x33},{L"4", 0x34},
-        {L"5", 0x35},{L"6", 0x36},{L"7", 0x37},{L"8", 0x38},{L"9", 0x39},
-        {L"F1", 0x70},{L"F2", 0x71},{L"F3", 0x72},{L"F4", 0x73},{L"F5", 0x74},
-        {L"F6", 0x75},{L"F7", 0x76},{L"F8", 0x77},{L"F9", 0x78},{L"F10", 0x79},
-        {L"F11", 0x7A},{L"F12", 0x7B},{L"F13", 0x7C},{L"F14", 0x7D},{L"F15", 0x7E},
-        {L"F16", 0x7F},{L"F17", 0x80},{L"F18", 0x81},{L"F19", 0x82},{L"F20", 0x83},
-        {L"F21", 0x84},{L"F22", 0x85},{L"F23", 0x86},{L"F24", 0x87},
-        {L"BACKSPACE", 0x08},{L"TAB", 0x09},{L"ENTER", 0x0D},{L"RETURN", 0x0D},
-        {L"PAUSE", 0x13},{L"CAPSLOCK", 0x14},{L"ESCAPE", 0x1B},{L"ESC", 0x1B},
-        {L"SPACE", 0x20},{L"SPACEBAR", 0x20},{L"PAGEUP", 0x21},{L"PAGEDOWN", 0x22},
-        {L"END", 0x23},{L"HOME", 0x24},{L"LEFT", 0x25},{L"UP", 0x26},{L"RIGHT", 0x27},
-        {L"DOWN", 0x28},{L"PRINTSCREEN", 0x2C},{L"PRTSC", 0x2C},{L"INSERT", 0x2D},
-        {L"INS", 0x2D},{L"DELETE", 0x2E},{L"DEL", 0x2E},{L"HELP", 0x2F},
-        {L"SLEEP", 0x5F},{L"APPS", 0x5D},{L"MENU", 0x5D},
-        {L"NUMPAD0", 0x60},{L"NUMPAD1", 0x61},{L"NUMPAD2", 0x62},{L"NUMPAD3", 0x63},
-        {L"NUMPAD4", 0x64},{L"NUMPAD5", 0x65},{L"NUMPAD6", 0x66},{L"NUMPAD7", 0x67},
-        {L"NUMPAD8", 0x68},{L"NUMPAD9", 0x69},
-        {L"NUM0", 0x60},{L"NUM1", 0x61},{L"NUM2", 0x62},{L"NUM3", 0x63},{L"NUM4", 0x64},
-        {L"NUM5", 0x65},{L"NUM6", 0x66},{L"NUM7", 0x67},{L"NUM8", 0x68},{L"NUM9", 0x69},
-        {L"MULTIPLY", 0x6A},{L"ADD", 0x6B},{L"SUBTRACT", 0x6D},{L"DECIMAL", 0x6E},
-        {L"DIVIDE", 0x6F},{L"NUMLOCK", 0x90},{L"SCROLLLOCK", 0x91},
-        {L"VOLUMEMUTE", 0xAD},{L"VOLUMEDOWN", 0xAE},{L"VOLUMEUP", 0xAF},
-        {L"MEDIANEXT", 0xB0},{L"MEDIAPREV", 0xB1},{L"MEDIASTOP", 0xB2},
+        // Numbers 0-9
+        {L"0", 0x30},
+        {L"1", 0x31},
+        {L"2", 0x32},
+        {L"3", 0x33},
+        {L"4", 0x34},
+        {L"5", 0x35},
+        {L"6", 0x36},
+        {L"7", 0x37},
+        {L"8", 0x38},
+        {L"9", 0x39},
+        // Function keys F1-F24
+        {L"F1", 0x70},
+        {L"F2", 0x71},
+        {L"F3", 0x72},
+        {L"F4", 0x73},
+        {L"F5", 0x74},
+        {L"F6", 0x75},
+        {L"F7", 0x76},
+        {L"F8", 0x77},
+        {L"F9", 0x78},
+        {L"F10", 0x79},
+        {L"F11", 0x7A},
+        {L"F12", 0x7B},
+        {L"F13", 0x7C},
+        {L"F14", 0x7D},
+        {L"F15", 0x7E},
+        {L"F16", 0x7F},
+        {L"F17", 0x80},
+        {L"F18", 0x81},
+        {L"F19", 0x82},
+        {L"F20", 0x83},
+        {L"F21", 0x84},
+        {L"F22", 0x85},
+        {L"F23", 0x86},
+        {L"F24", 0x87},
+        // Common keys (friendly names)
+        {L"BACKSPACE", 0x08},
+        {L"TAB", 0x09},
+        {L"ENTER", 0x0D},
+        {L"RETURN", 0x0D},
+        {L"PAUSE", 0x13},
+        {L"CAPSLOCK", 0x14},
+        {L"ESCAPE", 0x1B},
+        {L"ESC", 0x1B},
+        {L"SPACE", 0x20},
+        {L"SPACEBAR", 0x20},
+        {L"PAGEUP", 0x21},
+        {L"PAGEDOWN", 0x22},
+        {L"END", 0x23},
+        {L"HOME", 0x24},
+        {L"LEFT", 0x25},
+        {L"UP", 0x26},
+        {L"RIGHT", 0x27},
+        {L"DOWN", 0x28},
+        {L"PRINTSCREEN", 0x2C},
+        {L"PRTSC", 0x2C},
+        {L"INSERT", 0x2D},
+        {L"INS", 0x2D},
+        {L"DELETE", 0x2E},
+        {L"DEL", 0x2E},
+        {L"HELP", 0x2F},
+        {L"SLEEP", 0x5F},
+        {L"APPS", 0x5D},
+        {L"MENU", 0x5D},
+        // Numpad keys
+        {L"NUMPAD0", 0x60},
+        {L"NUMPAD1", 0x61},
+        {L"NUMPAD2", 0x62},
+        {L"NUMPAD3", 0x63},
+        {L"NUMPAD4", 0x64},
+        {L"NUMPAD5", 0x65},
+        {L"NUMPAD6", 0x66},
+        {L"NUMPAD7", 0x67},
+        {L"NUMPAD8", 0x68},
+        {L"NUMPAD9", 0x69},
+        {L"NUM0", 0x60},
+        {L"NUM1", 0x61},
+        {L"NUM2", 0x62},
+        {L"NUM3", 0x63},
+        {L"NUM4", 0x64},
+        {L"NUM5", 0x65},
+        {L"NUM6", 0x66},
+        {L"NUM7", 0x67},
+        {L"NUM8", 0x68},
+        {L"NUM9", 0x69},
+        {L"MULTIPLY", 0x6A},
+        {L"ADD", 0x6B},
+        {L"SUBTRACT", 0x6D},
+        {L"DECIMAL", 0x6E},
+        {L"DIVIDE", 0x6F},
+        {L"NUMLOCK", 0x90},
+        {L"SCROLLLOCK", 0x91},
+        // Media keys
+        {L"VOLUMEMUTE", 0xAD},
+        {L"VOLUMEDOWN", 0xAE},
+        {L"VOLUMEUP", 0xAF},
+        {L"MEDIANEXT", 0xB0},
+        {L"MEDIAPREV", 0xB1},
+        {L"MEDIASTOP", 0xB2},
         {L"MEDIAPLAYPAUSE", 0xB3},
-        {L"BROWSERBACK", 0xA6},{L"BROWSERFORWARD", 0xA7},{L"BROWSERREFRESH", 0xA8},
-        {L"BROWSERSTOP", 0xA9},{L"BROWSERSEARCH", 0xAA},{L"BROWSERFAVORITES", 0xAB},
+        // Browser keys
+        {L"BROWSERBACK", 0xA6},
+        {L"BROWSERFORWARD", 0xA7},
+        {L"BROWSERREFRESH", 0xA8},
+        {L"BROWSERSTOP", 0xA9},
+        {L"BROWSERSEARCH", 0xAA},
+        {L"BROWSERFAVORITES", 0xAB},
         {L"BROWSERHOME", 0xAC},
-        {L"LWIN", 0x5B},{L"RWIN", 0x5C},{L"LSHIFT", 0xA0},{L"RSHIFT", 0xA1},
-        {L"LCTRL", 0xA2},{L"RCTRL", 0xA3},{L"LALT", 0xA4},{L"RALT", 0xA5},
-        {L"VK_LBUTTON", 0x01},{L"VK_RBUTTON", 0x02},{L"VK_CANCEL", 0x03},
-        {L"VK_MBUTTON", 0x04},{L"VK_XBUTTON1", 0x05},{L"VK_XBUTTON2", 0x06},
-        {L"VK_CLEAR", 0x0C},{L"VK_SHIFT", 0x10},{L"VK_CONTROL", 0x11},{L"VK_MENU", 0x12},
-        {L"VK_KANA", 0x15},{L"VK_HANGUL", 0x15},{L"VK_IME_ON", 0x16},{L"VK_JUNJA", 0x17},
-        {L"VK_FINAL", 0x18},{L"VK_HANJA", 0x19},{L"VK_KANJI", 0x19},{L"VK_IME_OFF", 0x1A},
-        {L"VK_CONVERT", 0x1C},{L"VK_NONCONVERT", 0x1D},{L"VK_ACCEPT", 0x1E},
-        {L"VK_MODECHANGE", 0x1F},{L"VK_SELECT", 0x29},{L"VK_PRINT", 0x2A},
-        {L"VK_EXECUTE", 0x2B},{L"VK_SEPARATOR", 0x6C},{L"VK_LAUNCH_MAIL", 0xB4},
-        {L"VK_LAUNCH_MEDIA_SELECT", 0xB5},{L"VK_LAUNCH_APP1", 0xB6},{L"VK_LAUNCH_APP2", 0xB7},
-        {L"VK_OEM_1", 0xBA},{L"VK_OEM_PLUS", 0xBB},{L"VK_OEM_COMMA", 0xBC},
-        {L"VK_OEM_MINUS", 0xBD},{L"VK_OEM_PERIOD", 0xBE},{L"VK_OEM_2", 0xBF},
-        {L"VK_OEM_3", 0xC0},{L"VK_OEM_4", 0xDB},{L"VK_OEM_5", 0xDC},
-        {L"VK_OEM_6", 0xDD},{L"VK_OEM_7", 0xDE},{L"VK_OEM_8", 0xDF},
-        {L"VK_OEM_102", 0xE2},{L"VK_PROCESSKEY", 0xE5},{L"VK_PACKET", 0xE7},
-        {L"VK_ATTN", 0xF6},{L"VK_CRSEL", 0xF7},{L"VK_EXSEL", 0xF8},{L"VK_EREOF", 0xF9},
-        {L"VK_PLAY", 0xFA},{L"VK_ZOOM", 0xFB},{L"VK_NONAME", 0xFC},{L"VK_PA1", 0xFD},
+        // Modifier keys (for use in Virtual key press action)
+        {L"LWIN", 0x5B},
+        {L"RWIN", 0x5C},
+        {L"LSHIFT", 0xA0},
+        {L"RSHIFT", 0xA1},
+        {L"LCTRL", 0xA2},
+        {L"RCTRL", 0xA3},
+        {L"LALT", 0xA4},
+        {L"RALT", 0xA5},
+        // VK_ prefixed versions (only keys without friendly aliases)
+        {L"VK_LBUTTON", 0x01},
+        {L"VK_RBUTTON", 0x02},
+        {L"VK_CANCEL", 0x03},
+        {L"VK_MBUTTON", 0x04},
+        {L"VK_XBUTTON1", 0x05},
+        {L"VK_XBUTTON2", 0x06},
+        {L"VK_CLEAR", 0x0C},
+        {L"VK_SHIFT", 0x10},
+        {L"VK_CONTROL", 0x11},
+        {L"VK_MENU", 0x12},
+        {L"VK_KANA", 0x15},
+        {L"VK_HANGUL", 0x15},
+        {L"VK_IME_ON", 0x16},
+        {L"VK_JUNJA", 0x17},
+        {L"VK_FINAL", 0x18},
+        {L"VK_HANJA", 0x19},
+        {L"VK_KANJI", 0x19},
+        {L"VK_IME_OFF", 0x1A},
+        {L"VK_CONVERT", 0x1C},
+        {L"VK_NONCONVERT", 0x1D},
+        {L"VK_ACCEPT", 0x1E},
+        {L"VK_MODECHANGE", 0x1F},
+        {L"VK_SELECT", 0x29},
+        {L"VK_PRINT", 0x2A},
+        {L"VK_EXECUTE", 0x2B},
+        {L"VK_SEPARATOR", 0x6C},
+        {L"VK_LAUNCH_MAIL", 0xB4},
+        {L"VK_LAUNCH_MEDIA_SELECT", 0xB5},
+        {L"VK_LAUNCH_APP1", 0xB6},
+        {L"VK_LAUNCH_APP2", 0xB7},
+        {L"VK_OEM_1", 0xBA},
+        {L"VK_OEM_PLUS", 0xBB},
+        {L"VK_OEM_COMMA", 0xBC},
+        {L"VK_OEM_MINUS", 0xBD},
+        {L"VK_OEM_PERIOD", 0xBE},
+        {L"VK_OEM_2", 0xBF},
+        {L"VK_OEM_3", 0xC0},
+        {L"VK_OEM_4", 0xDB},
+        {L"VK_OEM_5", 0xDC},
+        {L"VK_OEM_6", 0xDD},
+        {L"VK_OEM_7", 0xDE},
+        {L"VK_OEM_8", 0xDF},
+        {L"VK_OEM_102", 0xE2},
+        {L"VK_PROCESSKEY", 0xE5},
+        {L"VK_PACKET", 0xE7},
+        {L"VK_ATTN", 0xF6},
+        {L"VK_CRSEL", 0xF7},
+        {L"VK_EXSEL", 0xF8},
+        {L"VK_EREOF", 0xF9},
+        {L"VK_PLAY", 0xFA},
+        {L"VK_ZOOM", 0xFB},
+        {L"VK_NONAME", 0xFC},
+        {L"VK_PA1", 0xFD},
         {L"VK_OEM_CLEAR", 0xFE},
     };
 
@@ -666,6 +801,7 @@ bool FromStringHotKey(std::wstring_view hotkeyString,
         }
 
         if (vk) {
+            // Only one key is allowed.
             return false;
         }
 
@@ -698,190 +834,61 @@ bool FromStringHotKey(std::wstring_view hotkeyString,
 
 // =====================================================================
 
-#pragma region zoning
-
-bool TryParseZone(std::wstring_view zoneString, Zone* zoneOut) {
-    if (zoneString.empty()) {
-        *zoneOut = Zone::NONE;
-        return true;
-    }
-
-    std::wstring s{zoneString};
-    s = stringtools::trim(s);
-    if (s.empty()) {
-        *zoneOut = Zone::NONE;
-        return true;
-    }
-
-    std::transform(s.begin(), s.end(), s.begin(), ::towupper);
-
-    static const std::unordered_map<std::wstring, Zone> kMap = {
-        {L"NONE", Zone::NONE},
-        {L"LEFT", Zone::LEFT},
-        {L"TOP_LEFT", Zone::TOP_LEFT},
-        {L"TOP", Zone::TOP},
-        {L"TOP_RIGHT", Zone::TOP_RIGHT},
-        {L"RIGHT", Zone::RIGHT},
-        {L"BOTTOM_RIGHT", Zone::BOTTOM_RIGHT},
-        {L"BOTTOM", Zone::BOTTOM},
-        {L"BOTTOM_LEFT", Zone::BOTTOM_LEFT},
-    };
-
-    auto it = kMap.find(s);
-    if (it == kMap.end()) {
-        return false;
-    }
-    *zoneOut = it->second;
-    return true;
-}
-
-Zone GetCursorZone(int gatePx) {
-    if (gatePx <= 0) {
-        return Zone::NONE;
-    }
-
-    POINT pt{};
-    if (!GetCursorPos(&pt)) {
-        return Zone::NONE;
-    }
-
-    HMONITOR hMon = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
-    MONITORINFO mi{};
-    mi.cbSize = sizeof(mi);
-    if (!GetMonitorInfo(hMon, &mi)) {
-        return Zone::NONE;
-    }
-
-    const RECT& rc = mi.rcMonitor;
-
-    const bool inLeft = pt.x < (rc.left + gatePx);
-    const bool inRight = pt.x >= (rc.right - gatePx);
-    const bool inTop = pt.y < (rc.top + gatePx);
-    const bool inBottom = pt.y >= (rc.bottom - gatePx);
-
-    if (inTop && inLeft) return Zone::TOP_LEFT;
-    if (inTop && inRight) return Zone::TOP_RIGHT;
-    if (inBottom && inRight) return Zone::BOTTOM_RIGHT;
-    if (inBottom && inLeft) return Zone::BOTTOM_LEFT;
-
-    if (inLeft) return Zone::LEFT;
-    if (inTop) return Zone::TOP;
-    if (inRight) return Zone::RIGHT;
-    if (inBottom) return Zone::BOTTOM;
-
-    return Zone::NONE;
-}
-
-#pragma endregion  // zoning
-
-// =====================================================================
-
 #pragma region hotkey_registration
 
 void RegisterHotkeys(HWND hWnd) {
-    // Reset stats/log state on each registration cycle.
-    g_settings.statsByHotkeyId.clear();
-    g_settings.loggedNoMatchByIdZone.clear();
-    g_settings.loggedUnknownId.clear();
+    std::unordered_map<uint64_t, int> registeredCombos;
 
-    // Assign one hotkeyId per unique (modifiers,vk).
-    std::unordered_map<uint64_t, int> keyToId;
-    std::vector<uint64_t> uniqueKeys;
-    keyToId.reserve(g_settings.hotkeyActions.size());
-    uniqueKeys.reserve(g_settings.hotkeyActions.size());
+    for (size_t i = 0; i < g_settings.hotkeyActions.size(); i++) {
+        auto& entry = g_settings.hotkeyActions[i];
 
-    int nextIdOffset = 0;
-    for (auto& action : g_settings.hotkeyActions) {
-        const uint64_t key = MakeHotkeyKey(action.modifiers, action.vk);
-        auto it = keyToId.find(key);
-        if (it == keyToId.end()) {
-            const int id = kHotkeyIdBase + nextIdOffset++;
-            keyToId.emplace(key, id);
-            uniqueKeys.push_back(key);
-            action.hotkeyId = id;
-        } else {
-            action.hotkeyId = it->second;
-        }
-        action.registered = false;
-    }
+        entry.hotkeyId = 0;
+        entry.registered = false;
 
-    // Register each unique hotkey exactly once.
-    std::unordered_map<uint64_t, bool> keyRegistered;
-    keyRegistered.reserve(uniqueKeys.size());
-
-    for (uint64_t key : uniqueKeys) {
-        const UINT modifiers = static_cast<UINT>(key >> 32);
-        const UINT vk = static_cast<UINT>(key & 0xFFFFFFFFu);
-        const int id = keyToId.at(key);
-
-        const BOOL ok = RegisterHotKey(hWnd, id, modifiers, vk);
-        keyRegistered.emplace(key, ok ? true : false);
-
-        const HotkeyAction* sample = nullptr;
-        int affectedMappings = 0;
-        for (const auto& a : g_settings.hotkeyActions) {
-            if (MakeHotkeyKey(a.modifiers, a.vk) == key) {
-                affectedMappings++;
-                if (!sample) sample = &a;
-            }
-        }
-
-        if (ok) {
-            if (sample) {
-                Wh_Log(L"Registered hotkey %s (id=%d) [mappings=%d]",
-                       sample->hotkeyString.c_str(), id, affectedMappings);
+        uint64_t comboKey = (static_cast<uint64_t>(entry.modifiers) << 32) | entry.vk;
+        auto existing = registeredCombos.find(comboKey);
+        if (existing == registeredCombos.end()) {
+            int id = kHotkeyIdBase + static_cast<int>(i);
+            if (RegisterHotKey(hWnd, id, entry.modifiers, entry.vk)) {
+                entry.hotkeyId = id;
+                entry.registered = true;
+                registeredCombos[comboKey] = id;
             } else {
-                Wh_Log(L"Registered hotkey (id=%d) [mappings=%d]", id, affectedMappings);
+                Wh_Log(L"Hotkey '%s': failed to register (error=%lu)",
+                       entry.hotkeyString.c_str(), GetLastError());
             }
-            g_settings.statsByHotkeyId.emplace(id, HotkeyStats{});
-        } else {
-            const DWORD err = GetLastError();
-            if (sample) {
-                Wh_Log(L"Failed to register hotkey: %s (error=%d) [mappings=%d]",
-                       sample->hotkeyString.c_str(), err, affectedMappings);
-            } else {
-                Wh_Log(L"Failed to register hotkey (id=%d, error=%d) [mappings=%d]",
-                       id, err, affectedMappings);
-            }
+            continue;
         }
-    }
 
-    // Propagate registered flag to all zone mappings of that hotkey.
-    for (auto& action : g_settings.hotkeyActions) {
-        const uint64_t key = MakeHotkeyKey(action.modifiers, action.vk);
-        auto it = keyRegistered.find(key);
-        action.registered = (it != keyRegistered.end()) ? it->second : false;
+        entry.hotkeyId = existing->second;
+        entry.registered = true;
     }
-
-    // Registration summary.
-    int uniqueCount = static_cast<int>(uniqueKeys.size());
-    int okCount = 0;
-    for (auto& kv : keyRegistered) if (kv.second) okCount++;
-    Wh_Log(L"Hotkey registration summary: unique=%d ok=%d failed=%d",
-           uniqueCount, okCount, uniqueCount - okCount);
 }
 
 void UnregisterHotkeys(HWND hWnd) {
-    std::unordered_set<int> unregistered;
-    unregistered.reserve(g_settings.hotkeyActions.size());
-
-    for (auto& action : g_settings.hotkeyActions) {
-        if (!action.registered) {
+    for (size_t k = 0; k < g_settings.hotkeyActions.size(); k++) {
+        auto& entry = g_settings.hotkeyActions[k];
+        if (!entry.registered) {
             continue;
         }
-        if (unregistered.insert(action.hotkeyId).second) {
-            UnregisterHotKey(hWnd, action.hotkeyId);
+
+        int id = entry.hotkeyId;
+        UnregisterHotKey(hWnd, id);
+        entry.registered = false;
+        for (size_t m = k + 1; m < g_settings.hotkeyActions.size(); m++) {
+            if (g_settings.hotkeyActions[m].hotkeyId == id) {
+                g_settings.hotkeyActions[m].registered = false;
+            }
         }
-        action.registered = false;
     }
 }
-
 #pragma endregion  // hotkey_registration
 
 // =====================================================================
 
 #pragma region actions
 
+// Splits semicolon-separated argument string into vector
 std::vector<std::wstring> SplitArgs(const std::wstring& args,
                                     const wchar_t delimiter = L';') {
     std::vector<std::wstring> result;
@@ -908,6 +915,7 @@ std::vector<std::wstring> SplitArgs(const std::wstring& args,
     return result;
 }
 
+// Returns current taskbar autohide state
 bool GetTaskbarAutohideState() {
     if (g_hTaskbarWnd != NULL) {
         APPBARDATA msgData{};
@@ -919,6 +927,7 @@ bool GetTaskbarAutohideState() {
     return false;
 }
 
+// Sets taskbar autohide state
 void SetTaskbarAutohide(bool enabled) {
     if (g_hTaskbarWnd != NULL) {
         APPBARDATA msgData{};
@@ -929,6 +938,7 @@ void SetTaskbarAutohide(bool enabled) {
     }
 }
 
+// Toggles taskbar autohide state
 void ToggleTaskbarAutohide() {
     if (g_hTaskbarWnd != NULL) {
         const bool isEnabled = GetTaskbarAutohideState();
@@ -940,6 +950,7 @@ void ToggleTaskbarAutohide() {
     }
 }
 
+// Sends show desktop command to taskbar
 void ShowDesktop() {
     if (g_hTaskbarWnd) {
         Wh_Log(L"Sending ShowDesktop message");
@@ -949,14 +960,16 @@ void ShowDesktop() {
     }
 }
 
+// Checks if any modifier keys are currently pressed
 bool AreModifierKeysPressed() {
     return (GetAsyncKeyState(VK_CONTROL) & 0x8000) ||
-           (GetAsyncKeyState(VK_MENU) & 0x8000) ||
+           (GetAsyncKeyState(VK_MENU) & 0x8000) ||  // Alt
            (GetAsyncKeyState(VK_SHIFT) & 0x8000) ||
            (GetAsyncKeyState(VK_LWIN) & 0x8000) ||
            (GetAsyncKeyState(VK_RWIN) & 0x8000);
 }
 
+// Internal function to send virtual key sequence
 void SendKeypressInternal(const std::vector<int>& keys) {
     if (keys.empty()) {
         return;
@@ -971,7 +984,7 @@ void SendKeypressInternal(const std::vector<int>& keys) {
         input[i].ki.time = 0;
         input[i].ki.dwExtraInfo = 0;
         input[i].ki.wVk = static_cast<WORD>(keys[i]);
-        input[i].ki.dwFlags = 0;
+        input[i].ki.dwFlags = 0;  // KEYDOWN
     }
 
     for (int i = 0; i < NUM_KEYS; i++) {
@@ -986,14 +999,17 @@ void SendKeypressInternal(const std::vector<int>& keys) {
     SendInput(NUM_KEYS * 2, input.get(), sizeof(input[0]));
 }
 
+// Timer callback to retry sending keypress when modifier keys are released
 void CALLBACK KeypressRetryTimerProc(HWND, UINT, UINT_PTR timerId, DWORD) {
     if (!AreModifierKeysPressed()) {
+        // Keys released, send the keypress
         KillTimer(nullptr, timerId);
         g_keypressTimerId = 0;
         Wh_Log(L"Modifier keys released, sending deferred keypress");
         SendKeypressInternal(g_pendingKeypressKeys);
         g_pendingKeypressKeys.clear();
     } else if (++g_pendingKeypressRetryCount >= kMaxKeypressRetryCount) {
+        // Timeout - send anyway
         KillTimer(nullptr, timerId);
         g_keypressTimerId = 0;
         Wh_Log(L"Timeout waiting for modifier keys, sending anyway");
@@ -1002,21 +1018,24 @@ void CALLBACK KeypressRetryTimerProc(HWND, UINT, UINT_PTR timerId, DWORD) {
     }
 }
 
+// Sends virtual key sequence, deferring if modifier keys are pressed
 void SendKeypress(const std::vector<int>& keys) {
     if (keys.empty()) {
         return;
     }
 
+    // Cancel any pending keypress
     if (g_keypressTimerId) {
         KillTimer(nullptr, g_keypressTimerId);
         g_keypressTimerId = 0;
     }
 
     if (AreModifierKeysPressed()) {
+        // Defer keypress - store and start thread timer
         g_pendingKeypressKeys = keys;
         g_pendingKeypressRetryCount = 0;
-        g_keypressTimerId =
-            SetTimer(nullptr, 0, kKeypressRetryIntervalMs, KeypressRetryTimerProc);
+        g_keypressTimerId = SetTimer(nullptr, 0, kKeypressRetryIntervalMs,
+                                     KeypressRetryTimerProc);
         Wh_Log(L"Modifier keys pressed, deferring keypress");
         return;
     }
@@ -1075,6 +1094,7 @@ void OpenTaskManager() {
     }
 }
 
+// Returns mute state of default audio device
 BOOL IsAudioMuted(com_ptr<IMMDeviceEnumerator> pDeviceEnumerator) {
     const GUID XIID_IAudioEndpointVolume = {
         0x5CDF2C82,
@@ -1096,6 +1116,7 @@ BOOL IsAudioMuted(com_ptr<IMMDeviceEnumerator> pDeviceEnumerator) {
     return isMuted;
 }
 
+// Toggles mute state for all active audio devices
 void ToggleVolMuted() {
     if (!g_audioCOM.IsInitialized()) {
         if (!g_audioCOM.Init()) {
@@ -1144,6 +1165,7 @@ void ToggleVolMuted() {
     }
 }
 
+// Finds desktop window for show/hide icons command
 HWND FindDesktopWindow() {
     HWND hParentWnd = FindWindow(L"Progman", NULL);
     if (!hParentWnd) {
@@ -1181,6 +1203,7 @@ HWND FindDesktopWindow() {
     return hChildWnd;
 }
 
+// Toggles desktop icon visibility
 void HideIcons() {
     HWND hDesktopWnd = FindDesktopWindow();
     if (hDesktopWnd != NULL) {
@@ -1191,6 +1214,7 @@ void HideIcons() {
     }
 }
 
+// Parses taskbar button combine states from arg string
 std::tuple<TaskBarButtonsState,
            TaskBarButtonsState,
            TaskBarButtonsState,
@@ -1231,7 +1255,8 @@ DWORD GetCombineTaskbarButtons(const wchar_t* optionName) {
     DWORD dwValue = 0;
     DWORD dwBufferSize = sizeof(DWORD);
     if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                     TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced"),
+                     TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Explor"
+                          "er\\Advanced"),
                      0, KEY_QUERY_VALUE, &hKey) == ERROR_SUCCESS) {
         RegQueryValueEx(hKey, optionName, NULL, NULL, (LPBYTE)&dwValue,
                         &dwBufferSize);
@@ -1245,7 +1270,8 @@ bool SetCombineTaskbarButtons(const wchar_t* optionName, unsigned int option) {
     if (option <= 2) {
         HKEY hKey = NULL;
         if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                         TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced"),
+                         TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Ex"
+                              "plorer\\Advanced"),
                          0, KEY_SET_VALUE, &hKey) == ERROR_SUCCESS) {
             DWORD dwValue = option;
             if (RegSetValueEx(hKey, optionName, 0, REG_DWORD, (BYTE*)&dwValue,
@@ -1287,11 +1313,12 @@ void CombineTaskbarButtons(const TaskBarButtonsState primaryState1,
 
 DWORD GetTaskbarAlignment() {
     HKEY hKey = NULL;
-    DWORD dwValue = 1;
+    DWORD dwValue = 1;  // Default to center
     DWORD dwBufferSize = sizeof(DWORD);
 
     if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                     TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced"),
+                     TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Explor"
+                          "er\\Advanced"),
                      0, KEY_QUERY_VALUE, &hKey) == ERROR_SUCCESS) {
         RegQueryValueEx(hKey, TEXT("TaskbarAl"), NULL, NULL, (LPBYTE)&dwValue,
                         &dwBufferSize);
@@ -1305,7 +1332,8 @@ bool SetTaskbarAlignment(DWORD alignment) {
     bool success = false;
 
     if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                     TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced"),
+                     TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Explor"
+                          "er\\Advanced"),
                      0, KEY_SET_VALUE, &hKey) == ERROR_SUCCESS) {
         if (RegSetValueEx(hKey, TEXT("TaskbarAl"), 0, REG_DWORD,
                           (BYTE*)&alignment,
@@ -1328,6 +1356,7 @@ void ToggleTaskbarAlignment() {
     }
 }
 
+// Parses command line into executable path and parameters
 std::tuple<std::wstring, std::wstring> ParseExecutableAndParameters(
     const std::wstring& command) {
     std::wstring executable = command;
@@ -1367,231 +1396,103 @@ std::tuple<std::wstring, std::wstring> ParseExecutableAndParameters(
 }
 
 void StartProcess(std::wstring command) {
-    if (command.empty()) {
+    if (command.empty())
         return;
-    }
-
-    std::vector<std::wstring> uac_args = SplitArgs(command, L';');
+    static const std::unordered_map<std::wstring, std::wstring> kUrlAliases = {
+        {L"gpt",       L"https://chatgpt.com/?q="},
+        {L"yt",        L"https://www.youtube.com/results?search_query="},
+        {L"google",    L"https://www.google.com/search?q="},
+        {L"copilot",   L"https://copilot.microsoft.com/?sendquery=1&q="},
+        {L"x",         L"https://twitter.com/search?q="},
+        {L"reddit",    L"https://www.reddit.com/search/?q="},
+        {L"translate", L"https://translate.google.com/?text="},
+    };
+    auto toLowerCopy = [&](std::wstring s) {
+        return stringtools::toLower(std::move(s));
+    };
+    auto getClipboardText = [&]() -> std::wstring {
+        std::wstring result;
+        if (OpenClipboard(nullptr)) {
+            if (HANDLE hData = GetClipboardData(CF_UNICODETEXT)) {
+                if (const wchar_t* p = (const wchar_t*)GlobalLock(hData)) {
+                    result = p;
+                    GlobalUnlock(hData);
+                }
+            }
+            CloseClipboard();
+        }
+        return result;
+    };
+    auto percentEncode = [&](const std::wstring& input) {
+        std::wstring encoded;
+        encoded.reserve(input.size() * 3);
+        for (wchar_t wc : input) {
+            if ((wc >= L'A' && wc <= L'Z') ||
+                (wc >= L'a' && wc <= L'z') ||
+                (wc >= L'0' && wc <= L'9') ||
+                wc == L'-' || wc == L'_' || wc == L'.' || wc == L'~') {
+                encoded += wc;
+            } else if (wc <= 0x7F) {
+                wchar_t buf[4];
+                swprintf(buf, 4, L"%%%02X", (unsigned)wc);
+                encoded += buf;
+            } else {
+                char utf8[4];
+                int n = WideCharToMultiByte(CP_UTF8, 0, &wc, 1, utf8, 4, nullptr, nullptr);
+                for (int i = 0; i < n; i++) {
+                    wchar_t buf[4];
+                    swprintf(buf, 4, L"%%%02X", (unsigned char)utf8[i]);
+                    encoded += buf;
+                }
+            }
+        }
+        return encoded;
+    };
+    std::vector<std::wstring> args = SplitArgs(command);
     std::wstring verb = L"open";
-    if (!uac_args.empty() && stringtools::toLower(uac_args[0]) == L"uac") {
-        verb = L"runas";
-        command = stringtools::ltrim(command.substr(uac_args[0].length() + 1));
+    if (!args.empty() && toLowerCopy(args[0]) == L"uac") 
+        {
+            verb = L"runas";
+            command = stringtools::ltrim(command.substr(args[0].length() + 1));
+            args = SplitArgs(command);    
+        }
+    bool isClip = !args.empty() && toLowerCopy(args[0]) == L"clip";
+    std::wstring finalTarget;
+    if (isClip) {
+        command = stringtools::trim(
+            stringtools::ltrim(command.substr(args[0].length() + 1))
+        );
+        std::wstring key = command;
+        std::wstring urlPrefix;
+        auto it = kUrlAliases.find(toLowerCopy(key));
+        urlPrefix = (it != kUrlAliases.end()) ? it->second : key;
+        std::wstring clip = getClipboardText();
+        std::wstring encoded = percentEncode(clip);
+        finalTarget = urlPrefix + encoded;
+        Wh_Log(L"clip; resolved to: %s", finalTarget.c_str());
+    } else {
+        finalTarget = command;
     }
-
-    const auto [executable, parameters] = ParseExecutableAndParameters(command);
-    Wh_Log(L"Starting: %s %s", executable.c_str(), parameters.c_str());
-
-    POINT cursorPos;
-    GetCursorPos(&cursorPos);
-    HMONITOR hMonitor = MonitorFromPoint(cursorPos, MONITOR_DEFAULTTONEAREST);
-
-    SHELLEXECUTEINFO sei = {sizeof(sei)};
+    const auto [exe, params] = ParseExecutableAndParameters(finalTarget);
+    POINT pt;
+    GetCursorPos(&pt);
+    HMONITOR mon = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+    SHELLEXECUTEINFO sei = { sizeof(sei) };
     sei.fMask = SEE_MASK_HMONITOR | SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI;
     sei.lpVerb = verb.c_str();
-    sei.lpFile = executable.c_str();
-    sei.lpParameters = parameters.empty() ? NULL : parameters.c_str();
+    sei.lpFile = exe.c_str();
+    sei.lpParameters = params.empty() ? nullptr : params.c_str();
     sei.nShow = SW_SHOWNORMAL;
-    sei.hMonitor = hMonitor;
-
+    sei.hMonitor = mon;
     if (!ShellExecuteEx(&sei)) {
-        DWORD error = GetLastError();
-        if (error != ERROR_CANCELLED) {
-            Wh_Log(L"ShellExecuteEx failed, error: %d", error);
+        DWORD err = GetLastError();
+        if (err != ERROR_CANCELLED) {
+            Wh_Log(L"ShellExecuteEx failed, error: %d", err);
         }
     }
 }
-// ===================== Window targeting + always-on-top + opacity =====================
 
-static HWND GetActiveTopLevelWindow() {
-    HWND h = GetForegroundWindow();
-    if (!h) return nullptr;
-
-    h = GetAncestor(h, GA_ROOT);
-    if (!h) return nullptr;
-
-    if (g_hTaskbarWnd && h == g_hTaskbarWnd) return nullptr;
-    if (!IsWindowVisible(h)) return nullptr;
-    return h;
-}
-
-static bool IsTopmost(HWND hWnd) {
-    LONG ex = GetWindowLong(hWnd, GWL_EXSTYLE);
-    return (ex & WS_EX_TOPMOST) != 0;
-}
-
-static void ToggleAlwaysOnTopActive() {
-    HWND h = GetActiveTopLevelWindow();
-    if (!h) return;
-
-    const bool cur = IsTopmost(h);
-    SetWindowPos(h, cur ? HWND_NOTOPMOST : HWND_TOPMOST,
-                 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
-}
-
-struct OpacityConfig {
-    double step = 0.05;      // default (old hardcoded)
-    double min  = 0.10;      // default (old hardcoded)
-    double max  = 1.00;      // default (old hardcoded)
-    bool forceLayered = true; // default (old behavior)
-    bool applyToApp   = false; // default off
-};
-
-static bool EnsureLayered(HWND hWnd) {
-    LONG ex = GetWindowLong(hWnd, GWL_EXSTYLE);
-    if ((ex & WS_EX_LAYERED) == 0) {
-        SetWindowLong(hWnd, GWL_EXSTYLE, ex | WS_EX_LAYERED);
-    }
-    return true;
-}
-
-static double GetOpacity(HWND hWnd) {
-    LONG ex = GetWindowLong(hWnd, GWL_EXSTYLE);
-    if ((ex & WS_EX_LAYERED) == 0) return 1.0;
-
-    COLORREF cr = 0;
-    BYTE alpha = 255;
-    DWORD flags = 0;
-    if (!GetLayeredWindowAttributes(hWnd, &cr, &alpha, &flags)) return 1.0;
-    if ((flags & LWA_ALPHA) == 0) return 1.0;
-
-    return (double)alpha / 255.0;
-}
-
-static void SetOpacity(HWND hWnd, double opacity01, bool forceLayered) {
-    if (!hWnd) return;
-
-    if (opacity01 < 0.0) opacity01 = 0.0;
-    if (opacity01 > 1.0) opacity01 = 1.0;
-
-    LONG ex = GetWindowLong(hWnd, GWL_EXSTYLE);
-    if ((ex & WS_EX_LAYERED) == 0) {
-        if (!forceLayered) {
-            // Don't touch styles: cannot apply alpha if not already layered.
-            return;
-        }
-        EnsureLayered(hWnd);
-    }
-
-    int a = (int)lround(opacity01 * 255.0);
-    if (a < 0) a = 0;
-    if (a > 255) a = 255;
-
-    SetLayeredWindowAttributes(hWnd, 0, (BYTE)a, LWA_ALPHA);
-}
-
-static bool TryParseDoubleSuffix(const std::wstring& tokenLower,
-                                 const std::wstring& prefixLower,
-                                 double& out) {
-    if (tokenLower.rfind(prefixLower, 0) != 0) return false; // not prefix
-    std::wstring num = stringtools::trim(tokenLower.substr(prefixLower.size()));
-    if (num.empty()) return false;
-
-    try {
-        size_t pos = 0;
-        out = std::stod(num, &pos);
-        return pos == num.size();
-    } catch (...) {
-        return false;
-    }
-}
-
-static OpacityConfig ParseOpacityArgs_NoEquals(const std::wstring& args) {
-    OpacityConfig cfg; // defaults
-
-    auto parts = SplitArgs(args, L';');
-    for (auto p0 : parts) {
-        std::wstring p = stringtools::toLower(stringtools::trim(p0));
-        if (p.empty()) continue;
-
-        // flags
-        if (p == L"allapp" || p == L"app" || p == L"all") {
-            cfg.applyToApp = true;
-            continue;
-        }
-        if (p == L"dontlayer" || p == L"nostyle" || p == L"noexlayered") {
-            cfg.forceLayered = false;
-            continue;
-        }
-        if (p == L"layered" || p == L"forcelayered" || p == L"force-layered") {
-            cfg.forceLayered = true;
-            continue;
-        }
-
-        // prefix+number
-        double v = 0.0;
-        if (TryParseDoubleSuffix(p, L"step", v)) { cfg.step = v; continue; }
-        if (TryParseDoubleSuffix(p, L"min",  v)) { cfg.min  = v; continue; }
-        if (TryParseDoubleSuffix(p, L"max",  v)) { cfg.max  = v; continue; }
-    }
-
-    // sanitize
-    cfg.step = std::max(0.001, std::min(cfg.step, 1.0));
-    cfg.min  = std::max(0.0,   std::min(cfg.min,  1.0));
-    cfg.max  = std::max(0.0,   std::min(cfg.max,  1.0));
-    if (cfg.min > cfg.max) std::swap(cfg.min, cfg.max);
-
-    return cfg;
-}
-
-static bool IsEligibleOpacityTarget(HWND hWnd) {
-    if (!hWnd) return false;
-    if (!IsWindowVisible(hWnd)) return false;
-    if (g_hTaskbarWnd && hWnd == g_hTaskbarWnd) return false;
-    return true;
-}
-
-struct ApplyOpacityCtx {
-    DWORD pid = 0;
-    double opacity01 = 1.0;
-    const OpacityConfig* cfg = nullptr;
-};
-
-static BOOL CALLBACK EnumWindowsApplyOpacityProc(HWND hWnd, LPARAM lp) {
-    auto* ctx = reinterpret_cast<ApplyOpacityCtx*>(lp);
-    if (!ctx || !ctx->cfg) return TRUE;
-
-    DWORD pid = 0;
-    GetWindowThreadProcessId(hWnd, &pid);
-    if (pid != ctx->pid) return TRUE;
-
-    if (!IsEligibleOpacityTarget(hWnd)) return TRUE;
-
-    SetOpacity(hWnd, ctx->opacity01, ctx->cfg->forceLayered);
-    return TRUE;
-}
-
-static void ChangeOpacityActive(double delta, const OpacityConfig& cfg) {
-    HWND h = GetActiveTopLevelWindow();
-    if (!h) return;
-
-    double cur = GetOpacity(h);
-    double next = cur + delta;
-
-    if (next < cfg.min) next = cfg.min;
-    if (next > cfg.max) next = cfg.max;
-
-    if (!cfg.applyToApp) {
-        SetOpacity(h, next, cfg.forceLayered);
-        return;
-    }
-
-    DWORD pid = 0;
-    GetWindowThreadProcessId(h, &pid);
-    if (!pid) return;
-
-    ApplyOpacityCtx ctx;
-    ctx.pid = pid;
-    ctx.opacity01 = next;
-    ctx.cfg = &cfg;
-
-    EnumWindows(EnumWindowsApplyOpacityProc, reinterpret_cast<LPARAM>(&ctx));
-}
-
-static void OpacityUpActive(const OpacityConfig& cfg)   { ChangeOpacityActive(+cfg.step, cfg); }
-static void OpacityDownActive(const OpacityConfig& cfg) { ChangeOpacityActive(-cfg.step, cfg); }
-
-// ===================== Virtual key press parsing stays same =====================
-
+// Parses virtual key codes from settings string using FromStringHotKey
 std::vector<int> ParseVirtualKeypressSetting(const std::wstring& args) {
     std::vector<int> keys;
 
@@ -1600,10 +1501,20 @@ std::vector<int> ParseVirtualKeypressSetting(const std::wstring& args) {
         UINT modifiers = 0;
         UINT vk = 0;
         if (FromStringHotKey(arg, &modifiers, &vk)) {
-            if (modifiers & MOD_CONTROL) keys.push_back(VK_LCONTROL);
-            if (modifiers & MOD_ALT) keys.push_back(VK_LMENU);
-            if (modifiers & MOD_SHIFT) keys.push_back(VK_LSHIFT);
-            if (modifiers & MOD_WIN) keys.push_back(VK_LWIN);
+            // Add modifier keys first
+            if (modifiers & MOD_CONTROL) {
+                keys.push_back(VK_LCONTROL);
+            }
+            if (modifiers & MOD_ALT) {
+                keys.push_back(VK_LMENU);
+            }
+            if (modifiers & MOD_SHIFT) {
+                keys.push_back(VK_LSHIFT);
+            }
+            if (modifiers & MOD_WIN) {
+                keys.push_back(VK_LWIN);
+            }
+            // Add the main key
             keys.push_back(static_cast<int>(vk));
         } else {
             Wh_Log(L"Failed to parse key: %s", arg.c_str());
@@ -1613,177 +1524,329 @@ std::vector<int> ParseVirtualKeypressSetting(const std::wstring& args) {
     return keys;
 }
 
-std::optional<HotkeyActionType> TryParseActionType(const std::wstring& actionName) {
-    // Be tolerant of user casing/whitespace.
-    const std::wstring key = stringtools::toUpper(stringtools::trim(actionName));
-
-    static const std::unordered_map<std::wstring, HotkeyActionType> actionMap = {
-        {L"ACTION_NOTHING", HotkeyActionType::Nothing},
-        {L"ACTION_SHOW_DESKTOP", HotkeyActionType::ShowDesktop},
-        {L"ACTION_ALT_TAB", HotkeyActionType::AltTab},
-        {L"ACTION_TASK_MANAGER", HotkeyActionType::TaskManager},
-        {L"ACTION_MUTE", HotkeyActionType::Mute},
-        {L"ACTION_TASKBAR_AUTOHIDE", HotkeyActionType::TaskbarAutohide},
-        {L"ACTION_WIN_TAB", HotkeyActionType::WinTab},
-        {L"ACTION_HIDE_ICONS", HotkeyActionType::HideIcons},
-        {L"ACTION_COMBINE_TASKBAR_BUTTONS", HotkeyActionType::CombineTaskbarButtons},
-        {L"ACTION_TOGGLE_TASKBAR_ALIGNMENT", HotkeyActionType::ToggleTaskbarAlignment},
-        {L"ACTION_OPEN_START_MENU", HotkeyActionType::OpenStartMenu},
-        {L"ACTION_SEND_KEYPRESS", HotkeyActionType::SendKeypress},
-        {L"ACTION_START_PROCESS", HotkeyActionType::StartProcess},
-        {L"ACTION_MEDIA_PLAY_PAUSE", HotkeyActionType::MediaPlayPause},
-        {L"ACTION_MEDIA_NEXT", HotkeyActionType::MediaNext},
-        {L"ACTION_MEDIA_PREV", HotkeyActionType::MediaPrev},
-        {L"ACTION_TOGGLE_ALWAYSONTOP_ACTIVE", HotkeyActionType::ToggleAlwaysOnTopActive},
-        {L"ACTION_OPACITY_UP_ACTIVE", HotkeyActionType::OpacityUpActive},
-        {L"ACTION_OPACITY_DOWN_ACTIVE", HotkeyActionType::OpacityDownActive},
-    };
-
-    auto it = actionMap.find(key);
-    if (it == actionMap.end()) {
-        return std::nullopt;
-    }
-    return it->second;
+// Returns foreground window, excluding the taskbar itself
+HWND ForegroundWindow() {
+    HWND hRoot = GetAncestor(GetForegroundWindow(), GA_ROOT);
+    return (hRoot && hRoot != g_hTaskbarWnd) ? hRoot : nullptr;
 }
 
-const wchar_t* ActionTypeToString(HotkeyActionType actionType) {
-    switch (actionType) {
-        case HotkeyActionType::Nothing: return L"Nothing";
-        case HotkeyActionType::ShowDesktop: return L"ShowDesktop";
-        case HotkeyActionType::AltTab: return L"AltTab";
-        case HotkeyActionType::TaskManager: return L"TaskManager";
-        case HotkeyActionType::Mute: return L"Mute";
-        case HotkeyActionType::TaskbarAutohide: return L"TaskbarAutohide";
-        case HotkeyActionType::WinTab: return L"WinTab";
-        case HotkeyActionType::HideIcons: return L"HideIcons";
-        case HotkeyActionType::CombineTaskbarButtons: return L"CombineTaskbarButtons";
-        case HotkeyActionType::ToggleTaskbarAlignment: return L"ToggleTaskbarAlignment";
-        case HotkeyActionType::OpenStartMenu: return L"OpenStartMenu";
-        case HotkeyActionType::SendKeypress: return L"SendKeypress";
-        case HotkeyActionType::StartProcess: return L"StartProcess";
-        case HotkeyActionType::MediaPlayPause: return L"MediaPlayPause";
-        case HotkeyActionType::MediaNext: return L"MediaNext";
-        case HotkeyActionType::MediaPrev: return L"MediaPrev";
-        case HotkeyActionType::ToggleAlwaysOnTopActive: return L"ToggleAlwaysOnTopActive";
-        case HotkeyActionType::OpacityUpActive: return L"OpacityUpActive";
-        case HotkeyActionType::OpacityDownActive: return L"OpacityDownActive";
+// Opens Explorer with the foreground window's file selected
+void SelectActiveInExplorer() {
+    HWND hWnd = ForegroundWindow();
+    if (!hWnd) {
+        return;
     }
+
+    std::wstring path;
+
+    // First try: extract path from window title.
+    {
+        int len = GetWindowTextLengthW(hWnd);
+        if (len > 0) {
+            std::wstring title(len + 1, L'\0');
+            title.resize(GetWindowTextW(hWnd, title.data(), len + 1));
+
+            if (!title.empty() && title.front() == L'*') {
+                title.erase(0, 1);
+            }
+            title = stringtools::trim(title);
+
+            size_t sep = title.find(L" - ");
+            std::wstring candidate = stringtools::trim(
+                sep == std::wstring::npos ? title : title.substr(0, sep));
+
+            if (candidate.size() >= 2 &&
+                ((candidate.front() == L'"' && candidate.back() == L'"') ||
+                 (candidate.front() == L'\'' && candidate.back() == L'\''))) {
+                candidate = stringtools::trim(
+                    candidate.substr(1, candidate.size() - 2));
+            }
+
+            if (candidate.find(L":\\") != std::wstring::npos ||
+                candidate.rfind(L"\\\\", 0) == 0) {
+                std::error_code ec;
+                if (std::filesystem::exists(candidate, ec)) {
+                    path = std::move(candidate);
+                }
+            }
+        }
+    }
+
+    // Second try: use the process executable path.
+    if (path.empty()) {
+        DWORD pid = 0;
+        GetWindowThreadProcessId(hWnd, &pid);
+        if (pid) {
+            HANDLE hProc =
+                OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+            if (hProc) {
+                std::wstring exe(32768, L'\0');
+                DWORD size = static_cast<DWORD>(exe.size());
+                if (QueryFullProcessImageNameW(hProc, 0, exe.data(), &size) &&
+                    size) {
+                    exe.resize(size);
+                    std::error_code ec;
+                    if (std::filesystem::exists(exe, ec)) {
+                        path = std::move(exe);
+                    }
+                }
+                CloseHandle(hProc);
+            }
+        }
+    }
+
+    if (path.empty()) {
+        Wh_Log(L"SelectActiveInExplorer: could not resolve path");
+        return;
+    }
+
+    Wh_Log(L"SelectActiveInExplorer: %s", path.c_str());
+    std::wstring explorerArgs = L"/select,\"" + path + L"\"";
+    SHELLEXECUTEINFOW sei{sizeof(sei)};
+    sei.fMask = SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI;
+    sei.lpVerb = L"open";
+    sei.lpFile = L"explorer.exe";
+    sei.lpParameters = explorerArgs.c_str();
+    sei.nShow = SW_SHOWNORMAL;
+    if (!ShellExecuteExW(&sei)) {
+        DWORD err = GetLastError();
+        if (err != ERROR_CANCELLED) {
+            Wh_Log(L"SelectActiveInExplorer: launch failed (%lu)", err);
+        }
+    }
+}
+
+static std::pair<int,int> ParseOpacityUpArgs(const std::wstring& args) {
+    int max = 255, step = 25;
+    const auto parts = SplitArgs(stringtools::trim(args));
+    if (parts.size() >= 1) try { max  = std::clamp(std::stoi(parts[0]), 1, 255); } catch (...) {}
+    if (parts.size() >= 2) try { step = std::clamp(std::stoi(parts[1]), 1, 255); } catch (...) {}
+    return {max, step};
+}
+
+static std::pair<int,int> ParseOpacityDownArgs(const std::wstring& args) {
+    int min = 5, step = 25;
+    const auto parts = SplitArgs(stringtools::trim(args));
+    if (parts.size() >= 1) try { min  = std::clamp(std::stoi(parts[0]), 0, 254); } catch (...) {}
+    if (parts.size() >= 2) try { step = std::clamp(std::stoi(parts[1]), 1, 255); } catch (...) {}
+    return {min, step};
+}
+void OpacityAdjust(HWND hWnd, int delta, int clampMin, int clampMax) {
+    LONG_PTR ex = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
+    BYTE cur = 255;
+    DWORD flags = 0;
+    if ((ex & WS_EX_LAYERED) &&
+        GetLayeredWindowAttributes(hWnd, nullptr, &cur, &flags) &&
+        !(flags & LWA_ALPHA)) {
+        cur = 255;
+    }
+
+    int target = std::clamp(static_cast<int>(cur) + delta, clampMin, clampMax);
+    if (target == static_cast<int>(cur)) {
+        return;
+    }
+
+    if (!(ex & WS_EX_LAYERED)) {
+        SetWindowLongPtrW(hWnd, GWL_EXSTYLE, ex | WS_EX_LAYERED);
+    }
+
+    SetLayeredWindowAttributes(hWnd, 0, static_cast<BYTE>(target), LWA_ALPHA);
+    Wh_Log(L"Opacity: %u -> %d (delta=%+d clamp=[%d,%d])", cur, target, delta,
+           clampMin, clampMax);
+}
+
+// Increases foreground window opacity
+void OpacityUp(int maxAlpha, int step) {
+    HWND hWnd = ForegroundWindow();
+    if (hWnd) {
+        OpacityAdjust(hWnd, +step, 0, maxAlpha);
+    }
+}
+
+// Decreases foreground window opacity
+void OpacityDown(int minAlpha, int step) {
+    HWND hWnd = ForegroundWindow();
+    if (hWnd) {
+        OpacityAdjust(hWnd, -step, minAlpha, 255);
+    }
+}
+
+// Toggles always-on-top state of foreground window
+void ToggleAlwaysOnTop() {
+    HWND hWnd = ForegroundWindow();
+    if (!hWnd) {
+        return;
+    }
+
+    bool topmost = (GetWindowLongPtrW(hWnd, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0;
+    SetWindowPos(hWnd, topmost ? HWND_NOTOPMOST : HWND_TOPMOST, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+    Wh_Log(L"ToggleAlwaysOnTop: %s -> %s",
+           topmost ? L"topmost" : L"normal",
+           topmost ? L"normal" : L"topmost");
+}
+
+HotkeyRegionName TryParseRegionName(const std::wstring& raw) {
+    static const std::unordered_map<std::wstring, HotkeyRegionName> regionMap = 
+        {
+            {L"top_left", HotkeyRegionName::TOP_LEFT},
+            {L"top", HotkeyRegionName::TOP},
+            {L"top_right", HotkeyRegionName::TOP_RIGHT},
+            {L"left", HotkeyRegionName::LEFT},
+            {L"elsewhere", HotkeyRegionName::Elsewhere},
+            {L"right", HotkeyRegionName::RIGHT},
+            {L"bottom_left", HotkeyRegionName::BOTTOM_LEFT},
+            {L"bottom", HotkeyRegionName::BOTTOM},
+            {L"bottom_right", HotkeyRegionName::BOTTOM_RIGHT},
+        };
+
+        auto normalized = stringtools::toLower(stringtools::trim(raw));
+        auto it = regionMap.find(normalized);
+        if (it != regionMap.end()) {
+            return it->second;
+        }
+
+        return HotkeyRegionName::Invalid;
+    }
+
+// Parses action string to enum
+HotkeyActionType TryParseActionType(const std::wstring& raw) {
+    static const std::unordered_map<std::wstring, HotkeyActionType> actionMap =
+        {
+            {L"action_nothing", HotkeyActionType::Nothing},
+            {L"action_show_desktop", HotkeyActionType::ShowDesktop},
+            {L"action_alt_tab", HotkeyActionType::AltTab},
+            {L"action_task_manager", HotkeyActionType::TaskManager},
+            {L"action_mute", HotkeyActionType::Mute},
+            {L"action_taskbar_autohide", HotkeyActionType::TaskbarAutohide},
+            {L"action_win_tab", HotkeyActionType::WinTab},
+            {L"action_hide_icons", HotkeyActionType::HideIcons},
+            {L"action_combine_taskbar_buttons",
+             HotkeyActionType::CombineTaskbarButtons},
+            {L"action_toggle_taskbar_alignment",
+             HotkeyActionType::ToggleTaskbarAlignment},
+            {L"action_open_start_menu", HotkeyActionType::OpenStartMenu},
+            {L"action_send_keypress", HotkeyActionType::SendKeypress},
+            {L"action_start_process", HotkeyActionType::StartProcess},
+            {L"action_media_play_pause", HotkeyActionType::MediaPlayPause},
+            {L"action_media_next", HotkeyActionType::MediaNext},
+            {L"action_media_prev", HotkeyActionType::MediaPrev},
+            {L"action_select_active_in_explorer",
+             HotkeyActionType::SelectActiveInExplorer},
+            {L"action_opacity_up_active", HotkeyActionType::OpacityUp},
+            {L"action_opacity_down_active", HotkeyActionType::OpacityDown},
+            {L"action_toggle_alwaysontop_active",
+             HotkeyActionType::ToggleAlwaysOnTop},
+        };
+
+    auto normalized = stringtools::toLower(stringtools::trim(raw));
+    auto it = actionMap.find(normalized);
+    if (it != actionMap.end()) {
+        return it->second;
+    }
+
+    Wh_Log(L"Unknown action: %s", raw.c_str());
+    return HotkeyActionType::Invalid;
+}
+
+const wchar_t* RegionNameToString(HotkeyRegionName region) {
+    if (region == HotkeyRegionName::TOP_LEFT) return L"TOP_LEFT";
+    if (region == HotkeyRegionName::TOP) return L"TOP";
+    if (region == HotkeyRegionName::TOP_RIGHT) return L"TOP_RIGHT";
+    if (region == HotkeyRegionName::LEFT) return L"LEFT";
+    if (region == HotkeyRegionName::Elsewhere) return L"Elsewhere";
+    if (region == HotkeyRegionName::RIGHT) return L"RIGHT";
+    if (region == HotkeyRegionName::BOTTOM_LEFT) return L"BOTTOM_LEFT";
+    if (region == HotkeyRegionName::BOTTOM) return L"BOTTOM";
+    if (region == HotkeyRegionName::BOTTOM_RIGHT) return L"BOTTOM_RIGHT";
     return L"Unknown";
 }
 
-bool TryBuildActionExecutor(HotkeyActionType actionType,
-                            const std::wstring& args,
-                            std::function<void()>& executorOut,
-                            std::wstring& errorOut) {
-    errorOut.clear();
+// Converts action enum to string for logging
+const wchar_t* ActionTypeToString(HotkeyActionType actionType) {
+    if (actionType == HotkeyActionType::Nothing) return L"Nothing";
+    if (actionType == HotkeyActionType::ShowDesktop) return L"ShowDesktop";
+    if (actionType == HotkeyActionType::AltTab) return L"AltTab";
+    if (actionType == HotkeyActionType::TaskManager) return L"TaskManager";
+    if (actionType == HotkeyActionType::Mute) return L"Mute";
+    if (actionType == HotkeyActionType::TaskbarAutohide) return L"TaskbarAutohide";
+    if (actionType == HotkeyActionType::WinTab) return L"WinTab";
+    if (actionType == HotkeyActionType::HideIcons) return L"HideIcons";
+    if (actionType == HotkeyActionType::CombineTaskbarButtons) return L"CombineTaskbarButtons";
+    if (actionType == HotkeyActionType::ToggleTaskbarAlignment) return L"ToggleTaskbarAlignment";
+    if (actionType == HotkeyActionType::OpenStartMenu) return L"OpenStartMenu";
+    if (actionType == HotkeyActionType::SendKeypress) return L"SendKeypress";
+    if (actionType == HotkeyActionType::StartProcess) return L"StartProcess";
+    if (actionType == HotkeyActionType::MediaPlayPause) return L"MediaPlayPause";
+    if (actionType == HotkeyActionType::MediaNext) return L"MediaNext";
+    if (actionType == HotkeyActionType::MediaPrev) return L"MediaPrev";
+    if (actionType == HotkeyActionType::SelectActiveInExplorer) return L"SelectActiveInExplorer";
+    if (actionType == HotkeyActionType::OpacityUp) return L"OpacityUp";
+    if (actionType == HotkeyActionType::OpacityDown) return L"OpacityDown";
+    if (actionType == HotkeyActionType::ToggleAlwaysOnTop) return L"ToggleAlwaysOnTop";
+    return L"Unknown";
+}
 
+// Creates action executor from action type and arguments
+std::function<void()> ParseActionSetting(HotkeyActionType actionType,
+                                         const std::wstring& args) {
     switch (actionType) {
         case HotkeyActionType::Nothing:
-            errorOut = L"Action is Nothing (row ignored)";
-            return false;
-
+            return []() {};
         case HotkeyActionType::ShowDesktop:
-            executorOut = []() { ShowDesktop(); };
-            return true;
-
+            return []() { ShowDesktop(); };
         case HotkeyActionType::AltTab:
-            executorOut = []() { SendCtrlAltTabKeypress(); };
-            return true;
-
+            return []() { SendCtrlAltTabKeypress(); };
         case HotkeyActionType::TaskManager:
-            executorOut = []() { OpenTaskManager(); };
-            return true;
-
+            return []() { OpenTaskManager(); };
         case HotkeyActionType::Mute:
-            executorOut = []() { ToggleVolMuted(); };
-            return true;
-
+            return []() { ToggleVolMuted(); };
         case HotkeyActionType::TaskbarAutohide:
-            executorOut = []() { ToggleTaskbarAutohide(); };
-            return true;
-
+            return []() { ToggleTaskbarAutohide(); };
         case HotkeyActionType::WinTab:
-            executorOut = []() { SendWinTabKeypress(); };
-            return true;
-
+            return []() { SendWinTabKeypress(); };
         case HotkeyActionType::HideIcons:
-            executorOut = []() { HideIcons(); };
-            return true;
-
+            return []() { HideIcons(); };
         case HotkeyActionType::CombineTaskbarButtons: {
             const auto [s1, s2, s3, s4] = ParseTaskBarButtonsState(args);
-            const bool primaryValid = (s1 != COMBINE_INVALID && s2 != COMBINE_INVALID);
-            const bool secondaryValid = (s3 != COMBINE_INVALID && s4 != COMBINE_INVALID);
-            if (!primaryValid && !secondaryValid) {
-                errorOut = L"Invalid CombineTaskbarButtons args (no valid state pairs)";
-                return false;
-            }
-            executorOut = [s1, s2, s3, s4]() { CombineTaskbarButtons(s1, s2, s3, s4); };
-            return true;
+            return [s1, s2, s3, s4]() { CombineTaskbarButtons(s1, s2, s3, s4); };
         }
-
         case HotkeyActionType::ToggleTaskbarAlignment:
-            executorOut = []() { ToggleTaskbarAlignment(); };
-            return true;
-
+            return []() { ToggleTaskbarAlignment(); };
         case HotkeyActionType::OpenStartMenu:
-            executorOut = []() { OpenStartMenu(); };
-            return true;
-
+            return []() { OpenStartMenu(); };
         case HotkeyActionType::SendKeypress: {
             const auto keyCodes = ParseVirtualKeypressSetting(args);
-            if (keyCodes.empty()) {
-                errorOut = L"Invalid SendKeypress args (parsed key list empty)";
-                return false;
-            }
-            executorOut = [keyCodes]() {
+            return [keyCodes]() {
                 Wh_Log(L"Sending %zu keypresses", keyCodes.size());
                 SendKeypress(keyCodes);
             };
-            return true;
         }
-
         case HotkeyActionType::StartProcess: {
             std::wstring cmd = stringtools::trim(args);
-            if (cmd.empty()) {
-                errorOut = L"Invalid StartProcess args (empty command)";
-                return false;
-            }
-            executorOut = [cmd]() { StartProcess(cmd); };
-            return true;
+            return [cmd]() { StartProcess(cmd); };
         }
-
+        case HotkeyActionType::SelectActiveInExplorer:
+            return []() { SelectActiveInExplorer(); };
+        case HotkeyActionType::OpacityUp: {
+            const auto [max, step] = ParseOpacityUpArgs(args);
+            return [max, step]() { OpacityUp(max, step); };
+        }
+        case HotkeyActionType::OpacityDown: {
+            const auto [min, step] = ParseOpacityDownArgs(args);
+            return [min, step]() { OpacityDown(min, step); };
+        }
+        case HotkeyActionType::ToggleAlwaysOnTop:
+            return []() { ToggleAlwaysOnTop(); };
         case HotkeyActionType::MediaPlayPause:
-            executorOut = []() { MediaPlayPause(); };
-            return true;
-
+            return []() { MediaPlayPause(); };
         case HotkeyActionType::MediaNext:
-            executorOut = []() { MediaNext(); };
-            return true;
-
+            return []() { MediaNext(); };
         case HotkeyActionType::MediaPrev:
-            executorOut = []() { MediaPrev(); };
-            return true;
-
-        case HotkeyActionType::ToggleAlwaysOnTopActive:
-            executorOut = []() { ToggleAlwaysOnTopActive(); };
-            return true;
-
-        case HotkeyActionType::OpacityUpActive: {
-            const OpacityConfig cfg = ParseOpacityArgs_NoEquals(args);
-            executorOut = [cfg]() { OpacityUpActive(cfg); };
-            return true;
-        }
-
-        case HotkeyActionType::OpacityDownActive: {
-            const OpacityConfig cfg = ParseOpacityArgs_NoEquals(args);
-            executorOut = [cfg]() { OpacityDownActive(cfg); };
-            return true;
-        }
+            return []() { MediaPrev(); };
+        default:
+            return []() {};
     }
-
-    errorOut = L"Unknown action type";
-    return false;
 }
 
 #pragma endregion  // actions
@@ -1797,74 +1860,82 @@ LRESULT CALLBACK TaskbarWindowSubclassProc(_In_ HWND hWnd,
                                            _In_ WPARAM wParam,
                                            _In_ LPARAM lParam,
                                            _In_ DWORD_PTR dwRefData) {
-    if (uMsg == g_uninitCOMMsg) {
-        g_audioCOM.Uninit();
-        return 0;
-    }
+    switch (uMsg) {
+        case WM_HOTKEY: {
+            int hotkeyId = static_cast<int>(wParam);
 
-    if (uMsg == WM_HOTKEY) {
-        const int hotkeyId = static_cast<int>(wParam);
-        const Zone zone = GetCursorZone(g_settings.gatePx);
+            auto tryFire = [&](HotkeyRegionName r) -> bool {
+                auto it = std::find_if(
+                    g_settings.hotkeyActions.begin(),
+                    g_settings.hotkeyActions.end(),
+                    [&](const HotkeyBinding& e) {
+                        return e.registered && e.hotkeyId == hotkeyId && e.region == r;
+                    });
+                if (it == g_settings.hotkeyActions.end()) return false;
+                Wh_Log(L"Hotkey '%s' fired in region %s, executing %s",
+                       it->hotkeyString.c_str(),
+                       RegionNameToString(r),
+                       ActionTypeToString(it->actionType));
+                it->actionExecutor();
+                return true;
+            };
 
-        auto& st = g_settings.statsByHotkeyId[hotkeyId];
-        st.hits_total++;
+            constexpr LONG kEdgeMargin = 12;
+            POINT cursorPos{};
+            GetCursorPos(&cursorPos);
+            HMONITOR hMonitor = MonitorFromPoint(cursorPos, MONITOR_DEFAULTTONEAREST);
+            MONITORINFO monitorInfo{};
+            monitorInfo.cbSize = sizeof(monitorInfo);
+            GetMonitorInfo(hMonitor, &monitorInfo);
+            const auto& r = monitorInfo.rcMonitor;
+            const bool atTop    = cursorPos.y - r.top    < kEdgeMargin;
+            const bool atBottom = r.bottom - cursorPos.y <= kEdgeMargin;
+            const bool atLeft   = cursorPos.x - r.left   < kEdgeMargin;
+            const bool atRight  = r.right - cursorPos.x  <= kEdgeMargin;
 
-        bool anyIdMatch = false;
-        bool executed = false;
-        for (const auto& action : g_settings.hotkeyActions) {
-            if (!action.registered) {
-                continue;
+            bool fired = false;
+            if (atTop && atLeft) {
+                fired = tryFire(HotkeyRegionName::TOP_LEFT)
+                     || tryFire(HotkeyRegionName::TOP)
+                     || tryFire(HotkeyRegionName::LEFT);
+            } else if (atTop && atRight) {
+                fired = tryFire(HotkeyRegionName::TOP_RIGHT)
+                     || tryFire(HotkeyRegionName::TOP)
+                     || tryFire(HotkeyRegionName::RIGHT);
+            } else if (atBottom && atLeft) {
+                fired = tryFire(HotkeyRegionName::BOTTOM_LEFT)
+                     || tryFire(HotkeyRegionName::BOTTOM)
+                     || tryFire(HotkeyRegionName::LEFT);
+            } else if (atBottom && atRight) {
+                fired = tryFire(HotkeyRegionName::BOTTOM_RIGHT)
+                     || tryFire(HotkeyRegionName::BOTTOM)
+                     || tryFire(HotkeyRegionName::RIGHT);
+            } else if (atTop)    { fired = tryFire(HotkeyRegionName::TOP); }
+            else if (atBottom)   { fired = tryFire(HotkeyRegionName::BOTTOM); }
+            else if (atLeft)     { fired = tryFire(HotkeyRegionName::LEFT); }
+            else if (atRight)    { fired = tryFire(HotkeyRegionName::RIGHT); }
+            if (!fired) tryFire(HotkeyRegionName::Elsewhere);
+            return 0;
+        }
+
+        default:
+            if (uMsg == g_hotkeyRegisteredMsg) {
+                switch (wParam) {
+                    case HOTKEY_REGISTER:
+                        RegisterHotkeys(hWnd);
+                        break;
+                    case HOTKEY_UNREGISTER:
+                        UnregisterHotkeys(hWnd);
+                        break;
+                }
+                return 0;
             }
-            if (action.hotkeyId != hotkeyId) {
-                continue;
-            }
-            anyIdMatch = true;
 
-            if (action.zone != zone) {
-                continue;
+            if (uMsg == g_uninitCOMMsg) {
+                g_audioCOM.Uninit();
+                return 0;
             }
-
-            if (action.actionExecutor) {
-                action.actionExecutor();
-            }
-            executed = true;
             break;
-        }
-
-        if (executed) {
-            st.hits_matched++;
-        } else {
-            st.hits_no_match++;
-
-            if (!anyIdMatch) {
-                if (g_settings.loggedUnknownId.insert(hotkeyId).second) {
-                    Wh_Log(L"WM_HOTKEY id=%d received but no registered mapping has this id (stale registration?)",
-                           hotkeyId);
-                }
-            } else {
-                const uint64_t k = (static_cast<uint64_t>(static_cast<uint32_t>(hotkeyId)) << 8) |
-                                   static_cast<uint64_t>(static_cast<uint8_t>(zone));
-                if (g_settings.loggedNoMatchByIdZone.insert(k).second) {
-                    Wh_Log(L"Hotkey id=%d pressed but no mapping for zone %s",
-                           hotkeyId, ZoneToString(zone));
-                }
-            }
-        }
-
-        // Always consume WM_HOTKEY.
-        return 0;
-    }
-
-    if (uMsg == g_hotkeyRegisteredMsg) {
-        switch (wParam) {
-            case HOTKEY_REGISTER:
-                RegisterHotkeys(hWnd);
-                break;
-            case HOTKEY_UNREGISTER:
-                UnregisterHotkeys(hWnd);
-                break;
-        }
-        return 0;
     }
 
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
@@ -1889,7 +1960,6 @@ void HandleIdentifiedTaskbarWindow(HWND hWnd) {
 
 using CreateWindowExW_t = decltype(&CreateWindowExW);
 CreateWindowExW_t CreateWindowExW_Original;
-
 HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle,
                                  LPCWSTR lpClassName,
                                  LPCWSTR lpWindowName,
@@ -1914,11 +1984,13 @@ HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle,
     if (bTextualClassName && _wcsicmp(lpClassName, L"Shell_TrayWnd") == 0) {
         Wh_Log(L"Shell_TrayWnd created: %p", hWnd);
         HandleIdentifiedTaskbarWindow(hWnd);
+        RegisterHotkeys(hWnd);
     }
 
     return hWnd;
 }
 
+// Finds main taskbar window in current process
 HWND FindCurrentProcessTaskbarWindow() {
     HWND hWnd = nullptr;
 
@@ -1953,234 +2025,107 @@ HWND FindCurrentProcessTaskbarWindow() {
 
 #pragma region settings
 
-// Put near the top of the "settings" region (or above LoadSettings).
-
-struct ConfigRow {
-    std::wstring hotkeyStr;
-    std::wstring zoneStr;
-    std::wstring actionStr;
-    std::wstring argsStr;
-    int rowIndex = -1;
-
-    void Normalize() {
-        hotkeyStr = stringtools::trim(hotkeyStr);
-        zoneStr   = stringtools::trim(zoneStr);
-        actionStr = stringtools::trim(actionStr);
-        argsStr   = stringtools::trim(argsStr);
-    }
-
-    bool ZoneEmptyOrNone() const {
-        return zoneStr.empty() || stringtools::toLower(zoneStr) == L"none";
-    }
-
-    bool ActionEmptyOrNothing() const {
-        return actionStr.empty() || stringtools::toLower(actionStr) == L"action_nothing";
-    }
-
-    bool IsTerminator() const {
-        return hotkeyStr.empty() && ZoneEmptyOrNone() && ActionEmptyOrNothing() && argsStr.empty();
-    }
-
-    bool IsPartialEmptyHotkey() const {
-        return hotkeyStr.empty() && (!ActionEmptyOrNothing() || !zoneStr.empty() || !argsStr.empty());
-    }
-};
-
-static ConfigRow ReadConfigRow(int i) {
-    using WindhawkUtils::StringSetting;
-    ConfigRow r;
-    r.rowIndex  = i;
-    r.hotkeyStr = std::wstring(StringSetting::make(L"HotkeyActions[%d].Hotkey", i).get());
-    r.zoneStr   = std::wstring(StringSetting::make(L"HotkeyActions[%d].Zone", i).get());
-    r.actionStr = std::wstring(StringSetting::make(L"HotkeyActions[%d].Action", i).get());
-    r.argsStr   = std::wstring(StringSetting::make(L"HotkeyActions[%d].AdditionalArgs", i).get());
-    r.Normalize();
-    return r;
-}
-
 void LoadSettings() {
-    g_settings.gatePx = static_cast<int>(Wh_GetIntSetting(L"GatePx"));
-    if (g_settings.gatePx < 0) {
-        g_settings.gatePx = 0;
-    }
+    using WindhawkUtils::StringSetting;
 
     g_settings.hotkeyActions.clear();
 
-    struct HotkeyZoneIdentity {
-        UINT modifiers;
-        UINT vk;
-        Zone zone;
-        bool operator==(const HotkeyZoneIdentity& o) const {
-            return modifiers == o.modifiers && vk == o.vk && zone == o.zone;
-        }
-    };
-    struct HotkeyZoneIdentityHasher {
-        size_t operator()(const HotkeyZoneIdentity& k) const {
-            size_t h1 = std::hash<UINT>{}(k.modifiers);
-            size_t h2 = std::hash<UINT>{}(k.vk);
-            size_t h3 = std::hash<uint8_t>{}(static_cast<uint8_t>(k.zone));
-            return h1 ^ (h2 << 1) ^ (h3 << 17);
-        }
-    };
-
-    std::unordered_set<HotkeyZoneIdentity, HotkeyZoneIdentityHasher> seen;
-    seen.reserve(64);
-
-    // Load diagnostics (counts).
-    int scanned = 0;
-    int loaded = 0;
-    int terminatedAt = -1;
-
-    int invalid_partial_empty = 0;
-    int invalid_unknown_action = 0;
-    int invalid_zone_parse = 0;
-    int invalid_hotkey_parse = 0;
-    int invalid_duplicate_hotkey_zone = 0;
-    int invalid_inert_executor = 0;
-
-    // Per-key diagnostics.
-    struct KeyDiag {
-        std::wstring sampleHotkey;
-        int mappingCount = 0;
-        std::unordered_set<uint8_t> zones;
-    };
-    std::unordered_map<uint64_t, KeyDiag> diagByKey;
-    diagByKey.reserve(64);
+    std::unordered_map<uint64_t, int> seenCombos;
 
     for (int i = 0; i < 50; i++) {
-        ConfigRow row = ReadConfigRow(i);
-        scanned++;
+        auto hotkeyStr = stringtools::trim(std::wstring(
+            StringSetting::make(L"HotkeyActions[%d].Hotkey", i).get()));
 
-        if (row.IsTerminator()) {
-            terminatedAt = i;
+        if (hotkeyStr.empty()) {
             break;
         }
 
-        if (row.IsPartialEmptyHotkey()) {
-            invalid_partial_empty++;
-            Wh_Log(L"Row %d invalid: Hotkey empty but other fields set (Zone='%s' Action='%s' Args='%s')",
-                   i, row.zoneStr.c_str(), row.actionStr.c_str(), row.argsStr.c_str());
+        UINT modifiers = 0, vk = 0;
+        if (!FromStringHotKey(hotkeyStr, &modifiers, &vk)) {
+            Wh_Log(L"Hotkey[%d] '%s': failed to parse, skipping group",
+                   i, hotkeyStr.c_str());
             continue;
         }
 
-        if (row.hotkeyStr.empty()) {
+        uint64_t comboKey = (static_cast<uint64_t>(modifiers) << 32) | vk;
+        auto existing = seenCombos.find(comboKey);
+        if (existing != seenCombos.end()) {
+            Wh_Log(L"Hotkey[%d] '%s': duplicate combo (first at group %d), skipping group",
+                   i, hotkeyStr.c_str(), existing->second);
             continue;
         }
+        seenCombos[comboKey] = i;
 
-        // If action empty => invalid (hotkey present).
-        if (row.actionStr.empty()) {
-            invalid_partial_empty++;
-            Wh_Log(L"Row %d invalid: Action empty but Hotkey set ('%s')", i, row.hotkeyStr.c_str());
-            continue;
-        }
+        size_t startIdx = g_settings.hotkeyActions.size();
 
-        // Parse action (no internal log; row log includes context).
-        auto actionOpt = TryParseActionType(row.actionStr);
-        if (!actionOpt.has_value()) {
-            invalid_unknown_action++;
-            Wh_Log(L"Row %d invalid: Unknown Action '%s' (Hotkey='%s' Zone='%s')",
-                   i, row.actionStr.c_str(), row.hotkeyStr.c_str(), row.zoneStr.c_str());
-            continue;
-        }
+        for (int j = 0; j < 10; j++) {
+            auto regionStr = stringtools::trim(std::wstring(
+                StringSetting::make(L"HotkeyActions[%d].Regions[%d].Region", i, j)
+                    .get()));
+            auto actionStr = stringtools::trim(std::wstring(
+                StringSetting::make(L"HotkeyActions[%d].Regions[%d].Action", i, j)
+                    .get()));
 
-        HotkeyActionType actionType = *actionOpt;
-
-        // Ignore ACTION_NOTHING rows intentionally, but do it explicitly.
-        if (actionType == HotkeyActionType::Nothing) {
-            // If user set additional fields with ACTION_NOTHING, log for clarity.
-            if (!row.zoneStr.empty() || !row.argsStr.empty()) {
-                Wh_Log(L"Row %d ignored: Action=ACTION_NOTHING (Hotkey='%s' Zone='%s' Args='%s')",
-                       i, row.hotkeyStr.c_str(), row.zoneStr.c_str(), row.argsStr.c_str());
+            if (regionStr.empty() && actionStr.empty()) {
+                break;
             }
+
+            auto regionName = TryParseRegionName(regionStr);
+            auto actionType = TryParseActionType(actionStr);
+
+            if (regionName == HotkeyRegionName::Invalid) {
+                Wh_Log(L"Hotkey[%d] Region[%d]: unknown region '%s', skipping row",
+                       i, j, regionStr.c_str());
+                continue;
+            }
+
+            if (actionType == HotkeyActionType::Invalid) {
+                Wh_Log(L"Hotkey[%d] Region[%d]: unknown action '%s', skipping row",
+                       i, j, actionStr.c_str());
+                continue;
+            }
+
+            if (actionType == HotkeyActionType::Nothing) {
+                continue;
+            }
+
+            auto argsStr = stringtools::trim(std::wstring(
+                StringSetting::make(
+                    L"HotkeyActions[%d].Regions[%d].AdditionalArgs", i, j)
+                    .get()));
+
+            HotkeyBinding entry;
+            entry.hotkeyString = hotkeyStr;
+            entry.region = regionName;
+            entry.actionType = actionType;
+            entry.additionalArgs = argsStr;
+            entry.actionExecutor = ParseActionSetting(actionType, argsStr);
+            entry.modifiers = modifiers;
+            entry.vk = vk;
+            entry.hotkeyId = 0;
+            entry.registered = false;
+
+            auto it = std::find_if(
+                g_settings.hotkeyActions.begin() + startIdx,
+                g_settings.hotkeyActions.end(),
+                [&](const HotkeyBinding& e) { return e.region == regionName; });
+
+              if (it != g_settings.hotkeyActions.end()) {
+                Wh_Log(L"Hotkey[%d]: duplicate region '%s', first row wins, skipping",
+                    i, RegionNameToString(regionName));
+                  } else {
+                    g_settings.hotkeyActions.push_back(std::move(entry));
+                 }
+            }
+      
+        if (g_settings.hotkeyActions.size() == startIdx) {
+            Wh_Log(L"Hotkey[%d] '%s': no non-Nothing region rows configured, skipping",
+                   i, hotkeyStr.c_str());
             continue;
         }
 
-        Zone zone = Zone::NONE;
-        if (!TryParseZone(row.zoneStr, &zone)) {
-            invalid_zone_parse++;
-            Wh_Log(L"Row %d invalid: Failed to parse Zone '%s' (Hotkey='%s')",
-                   i, row.zoneStr.c_str(), row.hotkeyStr.c_str());
-            continue;
-        }
-
-        UINT modifiers = 0;
-        UINT vk = 0;
-        if (!FromStringHotKey(row.hotkeyStr, &modifiers, &vk)) {
-            invalid_hotkey_parse++;
-            Wh_Log(L"Row %d invalid: Failed to parse Hotkey '%s' (Action='%s' Zone='%s')",
-                   i, row.hotkeyStr.c_str(), row.actionStr.c_str(), row.zoneStr.c_str());
-            continue;
-        }
-
-        HotkeyZoneIdentity id{modifiers, vk, zone};
-        if (!seen.insert(id).second) {
-            invalid_duplicate_hotkey_zone++;
-            Wh_Log(L"Row %d invalid: Duplicate (hotkey, zone) rejected (Hotkey='%s' Zone='%s')",
-                   i, row.hotkeyStr.c_str(), row.zoneStr.c_str());
-            continue;
-        }
-
-        std::function<void()> exec;
-        std::wstring execErr;
-        if (!TryBuildActionExecutor(actionType, row.argsStr, exec, execErr)) {
-            invalid_inert_executor++;
-            Wh_Log(L"Row %d invalid: %s (Hotkey='%s' Action='%s' Zone='%s' Args='%s')",
-                   i, execErr.c_str(), row.hotkeyStr.c_str(), row.actionStr.c_str(),
-                   row.zoneStr.c_str(), row.argsStr.c_str());
-            continue;
-        }
-
-        HotkeyAction action;
-        action.hotkeyString = row.hotkeyStr;
-        action.zone = zone;
-        action.actionType = actionType;
-        action.additionalArgs = row.argsStr;
-        action.actionExecutor = std::move(exec);
-        action.modifiers = modifiers;
-        action.vk = vk;
-        action.hotkeyId = 0;
-        action.registered = false;
-
-        g_settings.hotkeyActions.push_back(std::move(action));
-        loaded++;
-
-        // Per-key diagnostics.
-        const uint64_t key = MakeHotkeyKey(modifiers, vk);
-        auto& kd = diagByKey[key];
-        kd.mappingCount++;
-        if (kd.sampleHotkey.empty()) kd.sampleHotkey = row.hotkeyStr;
-        kd.zones.insert(static_cast<uint8_t>(zone));
-
-        Wh_Log(L"Loaded row %d: Hotkey='%s' Zone='%s' Action='%s'",
-               i, row.hotkeyStr.c_str(), ZoneToString(zone), ActionTypeToString(actionType));
-    }
-
-    // Key-level summary.
-    Wh_Log(L"Load summary: scanned=%d loaded=%d terminatedAt=%d",
-           scanned, loaded, terminatedAt);
-
-    Wh_Log(L"Invalid/ignored counts: partialEmpty=%d unknownAction=%d zoneParse=%d hotkeyParse=%d dupHotkeyZone=%d inertArgs=%d",
-           invalid_partial_empty, invalid_unknown_action, invalid_zone_parse,
-           invalid_hotkey_parse, invalid_duplicate_hotkey_zone, invalid_inert_executor);
-
-    // Per-unique-key diagnostic: zones and mapping count.
-    // Helps detect “I configured zones but only one zone is actually loaded”.
-    for (const auto& kv : diagByKey) {
-        const auto& kd = kv.second;
-
-        // Build zone list string.
-        std::wstring zlist;
-        bool first = true;
-        for (uint8_t z : kd.zones) {
-            if (!first) zlist += L",";
-            first = false;
-            zlist += ZoneToString(static_cast<Zone>(z));
-        }
-
-        const bool hasNone = (kd.zones.find(static_cast<uint8_t>(Zone::NONE)) != kd.zones.end());
-        Wh_Log(L"Key '%s': mappings=%d zones={%s} hasNONE=%s",
-               kd.sampleHotkey.c_str(), kd.mappingCount, zlist.c_str(),
-               hasNone ? L"yes" : L"no");
+        Wh_Log(L"Loaded hotkey[%d]: '%s' with %zu region(s)", i,
+               hotkeyStr.c_str(), g_settings.hotkeyActions.size() - startIdx);
     }
 }
 
@@ -2241,6 +2186,7 @@ void Wh_ModUninit() {
 void Wh_ModSettingsChanged() {
     Wh_Log(L">");
 
+    // Unregister old hotkeys before loading new settings
     if (g_hTaskbarWnd) {
         SendMessage(g_hTaskbarWnd, g_hotkeyRegisteredMsg, HOTKEY_UNREGISTER, 0);
     }
@@ -2251,4 +2197,5 @@ void Wh_ModSettingsChanged() {
         SendMessage(g_hTaskbarWnd, g_hotkeyRegisteredMsg, HOTKEY_REGISTER, 0);
     }
 }
-#pragma endregion // windhawk_exports
+
+#pragma endregion  // windhawk_exports

--- a/mods/hotcorner-hotkeys.wh.cpp
+++ b/mods/hotcorner-hotkeys.wh.cpp
@@ -2,7 +2,7 @@
 // @id                   hotcorner-hotkeys
 // @name                 HotCorner Hotkeys
 // @description          Assign up to 9 distinct actions per hotkey, dispatched based on which screen zone the cursor is in when pressed (4 corners, 4 edges, or elsewhere).
-// @version              3.1
+// @version              3.3
 // @author               webberlv
 // @github               https://github.com/webberLV
 // @license              GPL-3.0-only
@@ -57,6 +57,7 @@ When a hotkey fires, the mod determines which action to run using a
 17. **Opacity Up (active window)** — Increases the foreground window's opacity toward a configurable maximum.
 18. **Opacity Down (active window)** — Decreases the foreground window's opacity toward a configurable minimum.
 19. **Toggle Always On Top (active window)** — Toggles the foreground window's always-on-top state.
+20. **Force Kill Active Window** — Terminates the foreground window's process, except for the current `explorer.exe` host process.
 
 ## Hotkey format
 
@@ -221,6 +222,7 @@ To modifiy step you must include min first.
 - The mod runs inside `explorer.exe` and uses global hotkey registration.
 - Each unique key combination is registered with Windows exactly once.
 - Some windows may not respond to layered window attributes.
+- Force-killing elevated or protected processes may fail if `explorer.exe` lacks the required rights.
 
 ## Credits
 
@@ -281,6 +283,7 @@ by [m417z](https://github.com/m417z).
           - ACTION_OPACITY_UP_ACTIVE: Opacity Up (active window)
           - ACTION_OPACITY_DOWN_ACTIVE: Opacity Down (active window)
           - ACTION_TOGGLE_ALWAYSONTOP_ACTIVE: Toggle Always On Top (active window)
+          - ACTION_FORCE_KILL_ACTIVE: Force Kill Active Window
         - AdditionalArgs: ""
           $name: Additional Args
           $description: Optional arguments for this action (e.g., Ctrl+C, uac;cmd.exe, clip;google, 200;15). See Details tab.
@@ -363,6 +366,7 @@ enum class HotkeyActionType {
     OpacityUp,
     OpacityDown,
     ToggleAlwaysOnTop,
+    ForceKillActive,
     Invalid,
 };
 
@@ -1687,6 +1691,28 @@ void ToggleAlwaysOnTop() {
            topmost ? L"normal" : L"topmost");
 }
 
+void ForceKillActiveWindow() {
+    HWND hWnd = ForegroundWindow();
+    if (!hWnd) {
+        return;
+    }
+
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hWnd, &pid);
+    if (pid == 0 || pid == GetCurrentProcessId()) {
+        return;
+    }
+
+    HANDLE hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
+    if (hProcess) {
+        TerminateProcess(hProcess, 1);
+        CloseHandle(hProcess);
+        Wh_Log(L"ForceKill: terminated PID %lu", pid);
+    } else {
+        Wh_Log(L"ForceKill: OpenProcess failed for PID %lu (UAC?)", pid);
+    }
+}
+
 HotkeyRegionName TryParseRegionName(const std::wstring& raw) {
     static const std::unordered_map<std::wstring, HotkeyRegionName> regionMap = 
         {
@@ -1738,6 +1764,7 @@ HotkeyActionType TryParseActionType(const std::wstring& raw) {
             {L"action_opacity_down_active", HotkeyActionType::OpacityDown},
             {L"action_toggle_alwaysontop_active",
              HotkeyActionType::ToggleAlwaysOnTop},
+            {L"action_force_kill_active", HotkeyActionType::ForceKillActive},
         };
 
     auto normalized = stringtools::toLower(stringtools::trim(raw));
@@ -1819,6 +1846,8 @@ const wchar_t* ActionTypeToString(HotkeyActionType actionType) {
             return L"OpacityDown";
         case HotkeyActionType::ToggleAlwaysOnTop:
             return L"ToggleAlwaysOnTop";
+        case HotkeyActionType::ForceKillActive:
+            return L"ForceKillActive";
         case HotkeyActionType::Invalid:
             return L"Invalid";
     }
@@ -1877,6 +1906,8 @@ std::function<void()> ParseActionSetting(HotkeyActionType actionType,
         }
         case HotkeyActionType::ToggleAlwaysOnTop:
             return []() { ToggleAlwaysOnTop(); };
+        case HotkeyActionType::ForceKillActive:
+            return []() { ForceKillActiveWindow(); };
         case HotkeyActionType::MediaPlayPause:
             return []() { MediaPlayPause(); };
         case HotkeyActionType::MediaNext:

--- a/mods/hotcorner-hotkeys.wh.cpp
+++ b/mods/hotcorner-hotkeys.wh.cpp
@@ -2,7 +2,7 @@
 // @id                   hotcorner-hotkeys
 // @name                 HotCorner Hotkeys
 // @description          Assign up to 9 distinct actions per hotkey, dispatched based on which screen zone the cursor is in when pressed (4 corners, 4 edges, or elsewhere).
-// @version              3.5
+// @version              3..51
 // @author               webberlv
 // @github               https://github.com/webberLV
 // @license              GPL-3.0-only
@@ -36,7 +36,6 @@ When a hotkey fires, the mod determines which action to run using a
 | Right        | Right → Elsewhere                         |
 | Elsewhere    | Elsewhere                                 |
 
-Here’s your updated and renumbered list with the requested changes applied:
 
 ---
 

--- a/mods/hotcorner-hotkeys.wh.cpp
+++ b/mods/hotcorner-hotkeys.wh.cpp
@@ -2,7 +2,7 @@
 // @id                   hotcorner-hotkeys
 // @name                 HotCorner Hotkeys
 // @description          Assign up to 9 distinct actions per hotkey, dispatched based on which screen zone the cursor is in when pressed (4 corners, 4 edges, or elsewhere).
-// @version              3.3
+// @version              3.5
 // @author               webberlv
 // @github               https://github.com/webberLV
 // @license              GPL-3.0-only
@@ -36,6 +36,10 @@ When a hotkey fires, the mod determines which action to run using a
 | Right        | Right → Elsewhere                         |
 | Elsewhere    | Elsewhere                                 |
 
+Here’s your updated and renumbered list with the requested changes applied:
+
+---
+
 ## Supported actions
 
 1. **Show desktop** — Toggles the desktop view using the taskbar Show Desktop command.
@@ -50,14 +54,15 @@ When a hotkey fires, the mod determines which action to run using a
 10. **Open Start menu** — Simulates the Windows key to open Start.
 11. **Virtual key press** — Sends one or more virtual key presses or shortcuts using `SendInput`.
 12. **Open application, path or URL** — Launches an executable, opens a file/folder path, or opens a URL.
-13. **Media Play/Pause**
-14. **Media Next Track**
-15. **Media Previous Track**
-16. **Open parsed title path in explorer, with fallback to exe** — Selects the active file in an Explorer window, falling back to the foreground executable if no file path could be parsed from the title.
-17. **Opacity Up (active window)** — Increases the foreground window's opacity toward a configurable maximum.
-18. **Opacity Down (active window)** — Decreases the foreground window's opacity toward a configurable minimum.
-19. **Toggle Always On Top (active window)** — Toggles the foreground window's always-on-top state.
-20. **Force Kill Active Window** — Terminates the foreground window's process, except for the current `explorer.exe` host process.
+13. **Clipboard Run** — URL-encodes the clipboard contents and opens the result using a built-in alias or custom URL prefix provided as the additional argument.
+14. **Open parsed title path in explorer, with fallback to exe** — Selects the active file in an Explorer window, falling back to the foreground executable if no file path could be parsed from the title.
+15. **Opacity Up (active window)** — Increases the foreground window's opacity toward a configurable maximum.
+16. **Opacity Down (active window)** — Decreases the foreground window's opacity toward a configurable minimum.
+17. **Toggle Always On Top (active window)** — Toggles the foreground window's always-on-top state.
+18. **Force Kill Active Window** — Terminates the foreground window's process, except for the current `explorer.exe` host process.
+19. **Media Play/Pause**
+20. **Media Next Track**
+21. **Media Previous Track**
 
 ## Hotkey format
 
@@ -125,33 +130,8 @@ Prefix with `uac;` to request elevation:
 
 ```
 uac;cmd.exe
-uac;"C:\Tools\app.exe" --example
+uac;"C:\Tools\app.exe" args
 ```
-
-Prefix with `clip;` to URL-encode the clipboard contents and append them to the remainder of the argument. Built-in aliases are supported:
-
-```
-clip;gpt
-clip;yt
-clip;google
-clip;copilot
-clip;x
-clip;reddit
-clip;translate
-clip;https://www.bing.com/search?q=
-```
-
-The `uac;` and `clip;` prefixes can be combined (`uac;` must come first).
-
-| Alias       | Expands to                                    |
-|-------------|-----------------------------------------------|
-| `gpt`       | https://chatgpt.com/?q=                       |
-| `yt`        | https://www.youtube.com/results?search_query= |
-| `google`    | https://www.google.com/search?q=              |
-| `copilot`   | https://copilot.microsoft.com/?sendquery=1&q= |
-| `x`         | https://twitter.com/search?q=                 |
-| `reddit`    | https://www.reddit.com/search/?q=             |
-| `translate` | https://translate.google.com/?text=           |
 
 ---
 
@@ -189,6 +169,7 @@ Format: `max;step`
 Omitting both values uses all defaults.
 Providing only the first value sets min while keeping the default step.
 To modifiy step you must include max first. 
+Some windows may not respond to layered window attributes.
 
 **Example:**
 
@@ -210,19 +191,48 @@ Format: `min;step`
 Omitting both values uses all defaults.
 Providing only the first value sets min while keeping the default step.
 To modifiy step you must include min first. 
-
+Some windows may not respond to layered window attributes.
 **Example:**
 
 ```
 5;25
 ```
 
-## Notes
+---
 
-- The mod runs inside `explorer.exe` and uses global hotkey registration.
-- Each unique key combination is registered with Windows exactly once.
-- Some windows may not respond to layered window attributes.
-- Force-killing elevated or protected processes may fail if `explorer.exe` lacks the required rights.
+### Clipboard Run
+
+One or more semicolon-separated aliases or URL prefixes. The clipboard contents are URL-encoded once and appended to every token, opening each result as a separate target. Clipboard is read a single time per invocation regardless of how many targets are listed.
+
+**Single target:**
+
+```
+yt
+google
+https://www.bing.com/search?q=
+```
+
+**Multiple targets (opens all simultaneously):**
+
+```
+yt;google
+yt;google;reddit
+gpt;copilot
+```
+
+| Alias       | Expands to                                    |
+|-------------|-----------------------------------------------|
+| `gpt`       | https://chatgpt.com/?q=                       |
+| `yt`        | https://www.youtube.com/results?search_query= |
+| `google`    | https://www.google.com/search?q=              |
+| `copilot`   | https://copilot.microsoft.com/?sendquery=1&q= |
+| `x`         | https://twitter.com/search?q=                 |
+| `reddit`    | https://www.reddit.com/search/?q=             |
+| `translate` | https://translate.google.com/?text=           |
+
+---
+
+
 
 ## Credits
 
@@ -276,17 +286,18 @@ by [m417z](https://github.com/m417z).
           - ACTION_OPEN_START_MENU: Open Start menu
           - ACTION_SEND_KEYPRESS: Virtual key press
           - ACTION_START_PROCESS: Open application, path or URL
-          - ACTION_MEDIA_PLAY_PAUSE: Media Play/Pause
-          - ACTION_MEDIA_NEXT: Media Next Track
-          - ACTION_MEDIA_PREV: Media Previous Track
+          - ACTION_COPYRUN: Clipboard Run
           - ACTION_SELECT_ACTIVE_IN_EXPLORER: Open parsed title path in explorer, with fallback to exe.
           - ACTION_OPACITY_UP_ACTIVE: Opacity Up (active window)
           - ACTION_OPACITY_DOWN_ACTIVE: Opacity Down (active window)
           - ACTION_TOGGLE_ALWAYSONTOP_ACTIVE: Toggle Always On Top (active window)
           - ACTION_FORCE_KILL_ACTIVE: Force Kill Active Window
+          - ACTION_MEDIA_PLAY_PAUSE: Media Play/Pause
+          - ACTION_MEDIA_NEXT: Media Next Track
+          - ACTION_MEDIA_PREV: Media Previous Track
         - AdditionalArgs: ""
           $name: Additional Args
-          $description: Optional arguments for this action (e.g., Ctrl+C, uac;cmd.exe, clip;google, 200;15). See Details tab.
+          $description: Optional arguments for this action (e.g., Ctrl+C, uac;cmd.exe, google, 200;15). See Details tab.
   $name: Keyboard Shortcut Actions
 */
 // ==/WindhawkModSettings==
@@ -359,14 +370,15 @@ enum class HotkeyActionType {
     OpenStartMenu,
     SendKeypress,
     StartProcess,
+    CopyRun,
     MediaPlayPause,
     MediaNext,
     MediaPrev,
-    SelectActiveInExplorer,
     OpacityUp,
     OpacityDown,
     ToggleAlwaysOnTop,
     ForceKillActive,
+    SelectActiveInExplorer,
     Invalid,
 };
 
@@ -1401,8 +1413,43 @@ std::tuple<std::wstring, std::wstring> ParseExecutableAndParameters(
 }
 
 void StartProcess(std::wstring command) {
-    if (command.empty())
+    if (command.empty()) {
         return;
+    }
+
+    std::vector<std::wstring> uac_args = SplitArgs(command, L';');
+    std::wstring verb = L"open";
+    if (stringtools::toLower(uac_args[0]) == L"uac") {
+        verb = L"runas";
+        command = stringtools::ltrim(command.substr(uac_args[0].length() + 1));
+    }
+
+    const auto [executable, parameters] = ParseExecutableAndParameters(command);
+    Wh_Log(L"Starting: %s %s", executable.c_str(), parameters.c_str());
+
+    POINT cursorPos;
+    GetCursorPos(&cursorPos);
+    HMONITOR hMonitor = MonitorFromPoint(cursorPos, MONITOR_DEFAULTTONEAREST);
+
+    SHELLEXECUTEINFO sei = {sizeof(sei)};
+    sei.fMask = SEE_MASK_HMONITOR | SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI;
+    sei.lpVerb = verb.c_str();
+    sei.lpFile = executable.c_str();
+    sei.lpParameters = parameters.empty() ? NULL : parameters.c_str();
+    sei.nShow = SW_SHOWNORMAL;
+    sei.hMonitor = hMonitor;
+
+    if (!ShellExecuteEx(&sei)) {
+        DWORD error = GetLastError();
+        if (error != ERROR_CANCELLED) {
+            Wh_Log(L"ShellExecuteEx failed, error: %d", error);
+        }
+    }
+}
+
+
+std::wstring ParseCopyRunTarget(const std::wstring& token,
+                                const std::wstring& encodedClip) {
     static const std::unordered_map<std::wstring, std::wstring> kUrlAliases = {
         {L"gpt",       L"https://chatgpt.com/?q="},
         {L"yt",        L"https://www.youtube.com/results?search_query="},
@@ -1412,92 +1459,98 @@ void StartProcess(std::wstring command) {
         {L"reddit",    L"https://www.reddit.com/search/?q="},
         {L"translate", L"https://translate.google.com/?text="},
     };
-    auto toLowerCopy = [&](std::wstring s) {
-        return stringtools::toLower(std::move(s));
-    };
-    auto getClipboardText = [&]() -> std::wstring {
-        std::wstring result;
-        if (OpenClipboard(nullptr)) {
-            if (HANDLE hData = GetClipboardData(CF_UNICODETEXT)) {
-                if (const wchar_t* p = (const wchar_t*)GlobalLock(hData)) {
-                    result = p;
-                    GlobalUnlock(hData);
-                }
-            }
-            CloseClipboard();
-        }
-        return result;
-    };
-    auto percentEncode = [&](const std::wstring& input) {
-        std::wstring encoded;
-        encoded.reserve(input.size() * 3);
-        for (wchar_t wc : input) {
-            if ((wc >= L'A' && wc <= L'Z') ||
-                (wc >= L'a' && wc <= L'z') ||
-                (wc >= L'0' && wc <= L'9') ||
-                wc == L'-' || wc == L'_' || wc == L'.' || wc == L'~') {
-                encoded += wc;
-            } else if (wc <= 0x7F) {
-                wchar_t buf[4];
-                swprintf(buf, 4, L"%%%02X", (unsigned)wc);
-                encoded += buf;
-            } else {
-                char utf8[4];
-                int n = WideCharToMultiByte(CP_UTF8, 0, &wc, 1, utf8, 4, nullptr, nullptr);
-                for (int i = 0; i < n; i++) {
-                    wchar_t buf[4];
-                    swprintf(buf, 4, L"%%%02X", (unsigned char)utf8[i]);
-                    encoded += buf;
-                }
-            }
-        }
-        return encoded;
-    };
-    std::vector<std::wstring> args = SplitArgs(command);
-    std::wstring verb = L"open";
-    if (!args.empty() && toLowerCopy(args[0]) == L"uac") 
-        {
-            verb = L"runas";
-            command = stringtools::ltrim(command.substr(args[0].length() + 1));
-            args = SplitArgs(command);    
-        }
-    bool isClip = !args.empty() && toLowerCopy(args[0]) == L"clip";
-    std::wstring finalTarget;
-    if (isClip) {
-        command = stringtools::trim(
-            stringtools::ltrim(command.substr(args[0].length() + 1))
-        );
-        std::wstring key = command;
-        std::wstring urlPrefix;
-        auto it = kUrlAliases.find(toLowerCopy(key));
-        urlPrefix = (it != kUrlAliases.end()) ? it->second : key;
-        std::wstring clip = getClipboardText();
-        std::wstring encoded = percentEncode(clip);
-        finalTarget = urlPrefix + encoded;
-        Wh_Log(L"clip; resolved to: %s", finalTarget.c_str());
-    } else {
-        finalTarget = command;
+
+    std::wstring key = stringtools::trim(token);
+    if (key.empty()) {
+        return L"";
     }
-    const auto [exe, params] = ParseExecutableAndParameters(finalTarget);
-    POINT pt;
-    GetCursorPos(&pt);
-    HMONITOR mon = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
-    SHELLEXECUTEINFO sei = { sizeof(sei) };
-    sei.fMask = SEE_MASK_HMONITOR | SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI;
-    sei.lpVerb = verb.c_str();
-    sei.lpFile = exe.c_str();
-    sei.lpParameters = params.empty() ? nullptr : params.c_str();
-    sei.nShow = SW_SHOWNORMAL;
-    sei.hMonitor = mon;
-    if (!ShellExecuteEx(&sei)) {
-        DWORD err = GetLastError();
-        if (err != ERROR_CANCELLED) {
-            Wh_Log(L"ShellExecuteEx failed, error: %d", err);
+
+    std::wstring prefix;
+    auto it = kUrlAliases.find(stringtools::toLower(key));
+    if (it != kUrlAliases.end()) {
+        prefix = it->second;
+    } else if (stringtools::startsWith(key, L"http://") ||
+               stringtools::startsWith(key, L"https://")) {
+        prefix = key;
+    } else {
+        prefix = L"https://" + key;
+    }
+
+    return prefix + encodedClip;
+}
+
+
+void CopyRun(const std::wstring& args) {
+    if (args.empty()) {
+        return;
+    }
+    std::wstring clip;
+    if (OpenClipboard(nullptr)) {
+        if (HANDLE hData = GetClipboardData(CF_UNICODETEXT)) {
+            if (const wchar_t* p =
+                    static_cast<const wchar_t*>(GlobalLock(hData))) {
+                clip = p;
+                GlobalUnlock(hData);
+            }
+        }
+        CloseClipboard();
+    }
+
+    std::wstring encodedClip;
+    if (!clip.empty()) {
+        int size = WideCharToMultiByte(CP_UTF8, 0, clip.c_str(), -1,
+                                       nullptr, 0, nullptr, nullptr);
+        std::string utf8;
+        if (size > 1) {
+            utf8.resize(size);
+            WideCharToMultiByte(CP_UTF8, 0, clip.c_str(), -1,
+                                utf8.data(), size, nullptr, nullptr);
+            utf8.pop_back();  // drop null terminator
+        }
+        for (unsigned char c : utf8) {
+            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                (c >= '0' && c <= '9') ||
+                c == '-' || c == '_' || c == '.' || c == '~') {
+                encodedClip += static_cast<wchar_t>(c);
+            } else {
+                wchar_t buf[4];
+                swprintf(buf, 4, L"%%%02X", c);
+                encodedClip += buf;
+            }
+        }
+    }
+
+    // --- Split args on ';' and launch one URL per token ---
+    POINT cursorPos;
+    GetCursorPos(&cursorPos);
+    HMONITOR hMonitor = MonitorFromPoint(cursorPos, MONITOR_DEFAULTTONEAREST);
+
+    const std::vector<std::wstring> tokens = SplitArgs(args);
+    for (const std::wstring& token : tokens) {
+        std::wstring target = ParseCopyRunTarget(token, encodedClip);
+        if (target.empty()) {
+            continue;
+        }
+
+        Wh_Log(L"CopyRun: %s", target.c_str());
+
+        SHELLEXECUTEINFO sei = {sizeof(sei)};
+        sei.fMask = SEE_MASK_HMONITOR | SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI;
+        sei.lpVerb = L"open";
+        sei.lpFile = target.c_str();
+        sei.lpParameters = nullptr;
+        sei.nShow = SW_SHOWNORMAL;
+        sei.hMonitor = hMonitor;
+
+        if (!ShellExecuteEx(&sei)) {
+            DWORD err = GetLastError();
+            if (err != ERROR_CANCELLED) {
+                Wh_Log(L"CopyRun failed for '%s': %d", token.c_str(), err);
+            }
         }
     }
 }
 
-// Parses virtual key codes from settings string using FromStringHotKey
 std::vector<int> ParseVirtualKeypressSetting(const std::wstring& args) {
     std::vector<int> keys;
 
@@ -1765,6 +1818,7 @@ HotkeyActionType TryParseActionType(const std::wstring& raw) {
             {L"action_toggle_alwaysontop_active",
              HotkeyActionType::ToggleAlwaysOnTop},
             {L"action_force_kill_active", HotkeyActionType::ForceKillActive},
+            {L"action_copyrun", HotkeyActionType::CopyRun},
         };
 
     auto normalized = stringtools::toLower(stringtools::trim(raw));
@@ -1832,12 +1886,8 @@ const wchar_t* ActionTypeToString(HotkeyActionType actionType) {
             return L"SendKeypress";
         case HotkeyActionType::StartProcess:
             return L"StartProcess";
-        case HotkeyActionType::MediaPlayPause:
-            return L"MediaPlayPause";
-        case HotkeyActionType::MediaNext:
-            return L"MediaNext";
-        case HotkeyActionType::MediaPrev:
-            return L"MediaPrev";
+        case HotkeyActionType::CopyRun:
+            return L"CopyRun";
         case HotkeyActionType::SelectActiveInExplorer:
             return L"SelectActiveInExplorer";
         case HotkeyActionType::OpacityUp:
@@ -1848,6 +1898,12 @@ const wchar_t* ActionTypeToString(HotkeyActionType actionType) {
             return L"ToggleAlwaysOnTop";
         case HotkeyActionType::ForceKillActive:
             return L"ForceKillActive";
+        case HotkeyActionType::MediaPlayPause:
+            return L"MediaPlayPause";
+        case HotkeyActionType::MediaNext:
+            return L"MediaNext";
+        case HotkeyActionType::MediaPrev:
+            return L"MediaPrev";
         case HotkeyActionType::Invalid:
             return L"Invalid";
     }
@@ -1893,6 +1949,10 @@ std::function<void()> ParseActionSetting(HotkeyActionType actionType,
         case HotkeyActionType::StartProcess: {
             std::wstring cmd = stringtools::trim(args);
             return [cmd]() { StartProcess(cmd); };
+        }
+        case HotkeyActionType::CopyRun: {
+            std::wstring copyRunArgs = stringtools::trim(args);
+            return [copyRunArgs]() { CopyRun(copyRunArgs); };
         }
         case HotkeyActionType::SelectActiveInExplorer:
             return []() { SelectActiveInExplorer(); };

--- a/mods/hotcorner-hotkeys.wh.cpp
+++ b/mods/hotcorner-hotkeys.wh.cpp
@@ -2,7 +2,7 @@
 // @id                   hotcorner-hotkeys
 // @name                 HotCorner Hotkeys
 // @description          Assign up to 9 distinct actions per hotkey, dispatched based on which screen zone the cursor is in when pressed (4 corners, 4 edges, or elsewhere).
-// @version              3..51
+// @version              3.51
 // @author               webberlv
 // @github               https://github.com/webberLV
 // @license              GPL-3.0-only

--- a/mods/hotcorner-hotkeys.wh.cpp
+++ b/mods/hotcorner-hotkeys.wh.cpp
@@ -2,7 +2,7 @@
 // @id                   hotcorner-hotkeys
 // @name                 HotCorner Hotkeys
 // @description          Assign up to 9 distinct actions per hotkey, dispatched based on which screen zone the cursor is in when pressed (4 corners, 4 edges, or elsewhere).
-// @version              3
+// @version              3.1
 // @author               webberlv
 // @github               https://github.com/webberLV
 // @license              GPL-3.0-only


### PR DESCRIPTION
Update hotcorner-hotkeys.wh.cpp

hotcorner-hotkeys: tighten hotkey dispatch and refresh action docs

Bump the mod to v3.56 and clean up both the implementation and
user-facing documentation for hotkey dispatch, window actions, and
additional arguments.

Readme and settings updates:
- rewrite the Windhawk Details readme to better explain cursor zones,
  fallback order, supported actions, hotkey syntax, and action-specific
  arguments
- update the settings UI wording from "Additional Args" to
  "Additional Arguments" and add clearer examples for the actions that
  actually consume it
- clarify that cursor zones are based on physical monitor edges and use
  a 12 px margin, with explicit fallback chains for corners, edges, and
  elsewhere
- document virtual key press behavior more accurately, including the
  flat `SendInput` batch behavior and deferred send when modifier keys
  are still held
- document Clipboard Run, `ShellExecuteEx` launching, parsed-title
  Explorer selection, and combine-taskbar-button behavior to match the
  implementation

Hotkey registration and dispatch:
- rework hotkey registration so region rows that share the same hotkey
  also share a single registered hotkey ID instead of tracking duplicate
  registrations independently
- replace the old `registered` flag with `ownsRegistration` to make
  ownership of `RegisterHotKey`/`UnregisterHotKey` explicit
- reset hotkey IDs and ownership state before registration and after
  unregister
- improve logging for shared hotkeys and keep dispatch logic focused on
  the matched hotkey ID plus region fallback
- reject duplicate region rows per hotkey during settings load; the
  first matching row now wins with a clear log message

Window and action behavior:
- add `trimDecorated()` and improve foreground title parsing so Explorer
  selection can strip leading `*`, trim wrapping quotes, scan
  right-to-left across ` - ` title segments, and only accept absolute
  paths that resolve to regular files
- keep the parsed-title action falling back to the foreground process
  executable when no valid file path can be resolved
- launch Explorer selection on the monitor under the cursor via
  `SEE_MASK_HMONITOR`
- replace the old configurable opacity min/max/step handling with fixed
  opacity steps for up/down actions, including resetting to full opacity
  by removing `WS_EX_LAYERED` when stepping up past the top level
- tighten active-window validation for opacity, always-on-top, and
  force-kill actions so they ignore invalid, hidden, or taskbar windows

Internal cleanup:
- normalize `HotkeyRegionName` enum values to `TopLeft`, `Top`, `Right`,
  etc. while preserving the external region strings used in
  settings/logging
- update the base hotkey ID constant
- apply small code cleanups and reordering around helper functions and
  logging

<!-- ⚠️ Please don't remove the template below. Add your content above the template. -->

## Changelog

- Improved hotkey registration handling for shared hotkeys
- Replaced `registered` flag with `ownsRegistration` for correct ownership tracking
- Prevented duplicate region entries per hotkey during settings load
- Updated readme with clearer documentation and examples
- Improved foreground window title parsing and Explorer selection behavior
- Cleaned up internal helpers, logging, and function ordering

## Mod authorship

This mod was created by:

- [x] Manually by the submitter (with or without AI assistance)
- [ ] Claude Code
- [ ] ChatGPT
- [ ] Gemini
- [ ] Another AI (please specify): 
- [ ] Other (please specify):
