### PR TITLE
Add Paste Clipboard Content to Explorer mod

### DIFF
--- a/mods/paste-clipboard-content-to-explorer.wh.cpp
+++ b/mods/paste-clipboard-content-to-explorer.wh.cpp
@@ -1,0 +1,778 @@
+// ==WindhawkMod==
+// @id              paste-clipboard-content-to-explorer
+// @name            Paste Clipboard Content to Explorer
+// @description     Paste text and images from clipboard as files in Explorer, on desktop and in file dialogs
+// @version         1.0
+// @author          Anixx
+// @github 			https://github.com/Anixx
+// @include         *
+// @compilerOptions -lole32 -loleaut32 -luuid -lgdiplus -lshlwapi -lshell32 -lcomctl32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Paste Clipboard Content to Explorer
+
+Allows pasting text and images from clipboard as files in Explorer,
+on the desktop and in open/save file dialogs.
+
+## Features
+- Paste text as .txt (UTF-16 LE with BOM)
+- Paste images as .png
+- Auto-naming with incrementing number on conflict
+- Works in Explorer folders, on the desktop, in file dialogs
+- Works with network folders (UNC paths)
+- Paste menu item is grayed out in virtual folders (This PC, Network, etc.)
+- Ctrl+V and context menu Paste both work
+*/
+// ==/WindhawkModReadme==
+
+#include <windows.h>
+#include <windowsx.h>
+#include <shlobj.h>
+#include <shobjidl.h>
+#include <shlwapi.h>
+#include <gdiplus.h>
+#include <string>
+
+using namespace Gdiplus;
+
+static ULONG_PTR g_gdiplusToken = 0;
+static HWND g_lastContextMenuShellView = nullptr;
+static bool PerformPaste(HWND sourceWindow);
+
+// ============================================================
+//  RAII COM init — инициализирует только если ещё не инициализировано
+//  или инициализировано с тем же режимом (apartment).
+//  Если поток уже использует MTA — не трогаем ничего.
+// ============================================================
+struct ScopedCoInit
+{
+    bool m_initialized = false;
+
+    ScopedCoInit()
+    {
+        HRESULT hr = CoInitializeEx(nullptr,
+                                    COINIT_APARTMENTTHREADED |
+                                    COINIT_DISABLE_OLE1DDE);
+        // S_OK или S_FALSE — COM инициализирован успешно (возможно повторно)
+        // RPC_E_CHANGED_MODE — поток уже использует другой режим, не трогаем
+        if (SUCCEEDED(hr))
+            m_initialized = true;
+    }
+
+    ~ScopedCoInit()
+    {
+        if (m_initialized)
+            CoUninitialize();
+    }
+};
+
+// ============================================================
+//  Default base name from explorerframe.dll string id 49922
+// ============================================================
+static std::wstring GetDefaultBaseName()
+{
+    std::wstring result;
+    HMODULE hMod = LoadLibraryExW(L"explorerframe.dll", nullptr,
+                                  LOAD_LIBRARY_AS_DATAFILE |
+                                  LOAD_LIBRARY_AS_IMAGE_RESOURCE);
+    if (hMod)
+    {
+        WCHAR buf[512] = {};
+        if (LoadStringW(hMod, 49922, buf, 512) > 0)
+            result = buf;
+        FreeLibrary(hMod);
+    }
+    if (result.empty())
+        result = L"Clipboard";
+    return result;
+}
+
+// ============================================================
+//  Unique file path
+// ============================================================
+static std::wstring GetUniquePath(const std::wstring& dir,
+                                  const std::wstring& baseName,
+                                  const std::wstring& ext)
+{
+    std::wstring p = dir + L'\\' + baseName + ext;
+    if (!PathFileExistsW(p.c_str()))
+        return p;
+    for (int n = 1; n < 100000; ++n)
+    {
+        p = dir + L'\\' + baseName + L" (" + std::to_wstring(n) + L")" + ext;
+        if (!PathFileExistsW(p.c_str()))
+            return p;
+    }
+    return dir + L'\\' + baseName + ext;
+}
+
+// ============================================================
+//  GDI+ encoder
+// ============================================================
+static bool GetPngClsid(CLSID* clsid)
+{
+    UINT num = 0, size = 0;
+    GetImageEncodersSize(&num, &size);
+    if (!size) return false;
+    ImageCodecInfo* info = (ImageCodecInfo*)malloc(size);
+    if (!info) return false;
+    GetImageEncoders(num, size, info);
+    bool found = false;
+    for (UINT i = 0; i < num; ++i)
+    {
+        if (!wcscmp(info[i].MimeType, L"image/png"))
+        {
+            *clsid = info[i].Clsid;
+            found = true;
+            break;
+        }
+    }
+    free(info);
+    return found;
+}
+
+// ============================================================
+//  Save image
+// ============================================================
+static bool SaveImageFromClipboard(const std::wstring& filePath)
+{
+    if (!OpenClipboard(nullptr)) return false;
+
+    CLSID pngClsid;
+    bool ok = false;
+
+    if (GetPngClsid(&pngClsid))
+    {
+        Bitmap* bmp = nullptr;
+
+        HANDLE hDibV5 = GetClipboardData(CF_DIBV5);
+        HANDLE hDib   = GetClipboardData(CF_DIB);
+        HBITMAP hBmp  = (HBITMAP)GetClipboardData(CF_BITMAP);
+
+        if (hDibV5)
+        {
+            BITMAPV5HEADER* p = (BITMAPV5HEADER*)GlobalLock(hDibV5);
+            if (p)
+            {
+                DWORD clrSz = 0;
+                if (p->bV5BitCount <= 8)
+                    clrSz = (p->bV5ClrUsed
+                                 ? p->bV5ClrUsed
+                                 : (1u << p->bV5BitCount)) * sizeof(RGBQUAD);
+                else if (p->bV5Compression == BI_BITFIELDS)
+                    clrSz = 3 * sizeof(DWORD);
+                void* bits = (BYTE*)p + p->bV5Size + clrSz;
+                bmp = new Bitmap((BITMAPINFO*)p, bits);
+                if (bmp->GetLastStatus() != Ok) { delete bmp; bmp = nullptr; }
+                GlobalUnlock(hDibV5);
+            }
+        }
+        if (!bmp && hDib)
+        {
+            BITMAPINFO* bi = (BITMAPINFO*)GlobalLock(hDib);
+            if (bi)
+            {
+                DWORD clrSz = 0;
+                if (bi->bmiHeader.biBitCount <= 8)
+                    clrSz = (bi->bmiHeader.biClrUsed
+                                 ? bi->bmiHeader.biClrUsed
+                                 : (1u << bi->bmiHeader.biBitCount)) * sizeof(RGBQUAD);
+                else if (bi->bmiHeader.biCompression == BI_BITFIELDS)
+                    clrSz = 3 * sizeof(DWORD);
+                void* bits = (BYTE*)bi + bi->bmiHeader.biSize + clrSz;
+                bmp = new Bitmap(bi, bits);
+                if (bmp->GetLastStatus() != Ok) { delete bmp; bmp = nullptr; }
+                GlobalUnlock(hDib);
+            }
+        }
+        if (!bmp && hBmp)
+        {
+            bmp = Bitmap::FromHBITMAP(hBmp, nullptr);
+            if (bmp && bmp->GetLastStatus() != Ok) { delete bmp; bmp = nullptr; }
+        }
+
+        if (bmp)
+        {
+            ok = (bmp->Save(filePath.c_str(), &pngClsid, nullptr) == Ok);
+            delete bmp;
+        }
+    }
+
+    CloseClipboard();
+    return ok;
+}
+
+// ============================================================
+//  Save text
+// ============================================================
+static bool SaveTextFromClipboard(const std::wstring& filePath)
+{
+    if (!OpenClipboard(nullptr)) return false;
+    bool ok = false;
+    HANDLE h = GetClipboardData(CF_UNICODETEXT);
+    if (h)
+    {
+        WCHAR* text = (WCHAR*)GlobalLock(h);
+        if (text)
+        {
+            HANDLE hFile = CreateFileW(filePath.c_str(), GENERIC_WRITE, 0,
+                                       nullptr, CREATE_ALWAYS,
+                                       FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (hFile != INVALID_HANDLE_VALUE)
+            {
+                DWORD written;
+                WORD bom = 0xFEFF;
+                WriteFile(hFile, &bom, sizeof(bom), &written, nullptr);
+                DWORD bytes = (DWORD)(wcslen(text) * sizeof(WCHAR));
+                WriteFile(hFile, text, bytes, &written, nullptr);
+                CloseHandle(hFile);
+                ok = true;
+            }
+            GlobalUnlock(h);
+        }
+    }
+    CloseClipboard();
+    return ok;
+}
+
+// ============================================================
+//  SHELLDLL_DefView detection
+// ============================================================
+static HWND FindShellDefViewInChain(HWND hwnd)
+{
+    HWND w = hwnd;
+    while (w)
+    {
+        WCHAR cls[256] = {};
+        GetClassNameW(w, cls, 256);
+        if (!wcscmp(cls, L"SHELLDLL_DefView"))
+            return w;
+        HWND par = GetParent(w);
+        if (!par) par = GetWindow(w, GW_OWNER);
+        w = par;
+    }
+    return nullptr;
+}
+
+static bool IsShellViewWindow(HWND hwnd)
+{
+    return FindShellDefViewInChain(hwnd) != nullptr;
+}
+
+// ============================================================
+//  Clipboard check
+// ============================================================
+static bool HasNonFileClipboardContent()
+{
+    if (IsClipboardFormatAvailable(CF_HDROP)) return false;
+    return IsClipboardFormatAvailable(CF_UNICODETEXT) ||
+           IsClipboardFormatAvailable(CF_BITMAP)      ||
+           IsClipboardFormatAvailable(CF_DIB)         ||
+           IsClipboardFormatAvailable(CF_DIBV5);
+}
+
+// ============================================================
+//  Get current folder path
+// ============================================================
+static bool IsDesktopShellWindow(HWND hwnd)
+{
+    HWND root = GetAncestor(hwnd, GA_ROOT);
+    WCHAR cls[64] = {};
+    GetClassNameW(root, cls, 64);
+    if (!wcscmp(cls, L"Progman") || !wcscmp(cls, L"WorkerW"))
+        return true;
+    HWND par = GetParent(root);
+    if (par)
+    {
+        GetClassNameW(par, cls, 64);
+        if (!wcscmp(cls, L"Progman") || !wcscmp(cls, L"WorkerW"))
+            return true;
+    }
+    return false;
+}
+
+static bool GetDesktopFolderPath(std::wstring& path)
+{
+    WCHAR buf[MAX_PATH] = {};
+    if (SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_DESKTOPDIRECTORY,
+                                   nullptr, 0, buf)))
+    {
+        path = buf;
+        return true;
+    }
+    return false;
+}
+
+static bool GetPathViaShellWindows(HWND topLevel, std::wstring& path)
+{
+    ScopedCoInit comInit; 
+
+    IShellWindows* pSW = nullptr;
+    if (FAILED(CoCreateInstance(CLSID_ShellWindows, nullptr, CLSCTX_ALL,
+                                IID_IShellWindows, (void**)&pSW)) || !pSW)
+        return false;
+
+    long count = 0;
+    pSW->get_Count(&count);
+    bool found = false;
+
+    for (long i = 0; i < count && !found; ++i)
+    {
+        VARIANT vi = {};
+        vi.vt  = VT_I4;
+        vi.lVal = i;
+        IDispatch* pDisp = nullptr;
+        if (FAILED(pSW->Item(vi, &pDisp)) || !pDisp) continue;
+
+        IWebBrowserApp* pWBA = nullptr;
+        if (SUCCEEDED(pDisp->QueryInterface(IID_IWebBrowserApp,
+                                            (void**)&pWBA)) && pWBA)
+        {
+            HWND hwndItem = nullptr;
+            pWBA->get_HWND((SHANDLE_PTR*)&hwndItem);
+            if (hwndItem == topLevel)
+            {
+                IServiceProvider* pSP = nullptr;
+                if (SUCCEEDED(pWBA->QueryInterface(IID_IServiceProvider,
+                                                   (void**)&pSP)) && pSP)
+                {
+                    IShellBrowser* pSB = nullptr;
+                    if (SUCCEEDED(pSP->QueryService(SID_STopLevelBrowser,
+                                                    IID_IShellBrowser,
+                                                    (void**)&pSB)) && pSB)
+                    {
+                        IShellView* pSV = nullptr;
+                        if (SUCCEEDED(pSB->QueryActiveShellView(&pSV)) && pSV)
+                        {
+                            IFolderView* pFV = nullptr;
+                            if (SUCCEEDED(pSV->QueryInterface(IID_IFolderView,
+                                                              (void**)&pFV)) && pFV)
+                            {
+                                IPersistFolder2* pPF = nullptr;
+                                if (SUCCEEDED(pFV->GetFolder(
+                                        IID_IPersistFolder2,
+                                        (void**)&pPF)) && pPF)
+                                {
+                                    LPITEMIDLIST pidl = nullptr;
+                                    if (SUCCEEDED(pPF->GetCurFolder(&pidl))
+                                        && pidl)
+                                    {
+                                        WCHAR szPath[MAX_PATH] = {};
+                                        SHGetPathFromIDListW(pidl, szPath);
+                                        path  = szPath;
+                                        found = true;
+                                        CoTaskMemFree(pidl);
+                                    }
+                                    pPF->Release();
+                                }
+                                pFV->Release();
+                            }
+                            pSV->Release();
+                        }
+                        pSB->Release();
+                    }
+                    pSP->Release();
+                }
+            }
+            pWBA->Release();
+        }
+        pDisp->Release();
+    }
+    pSW->Release();
+    return found;
+}
+
+static bool GetPathViaFileDialog(HWND topLevel, std::wstring& path)
+{
+    ScopedCoInit comInit; // безопасная локальная инициализация COM
+
+    IRunningObjectTable* pROT = nullptr;
+    if (FAILED(GetRunningObjectTable(0, &pROT)) || !pROT)
+        return false;
+
+    IEnumMoniker* pEnum = nullptr;
+    bool found = false;
+
+    if (SUCCEEDED(pROT->EnumRunning(&pEnum)) && pEnum)
+    {
+        IMoniker* pMk = nullptr;
+        while (!found && pEnum->Next(1, &pMk, nullptr) == S_OK)
+        {
+            IUnknown* pUnk = nullptr;
+            if (SUCCEEDED(pROT->GetObject(pMk, &pUnk)) && pUnk)
+            {
+                IFileDialog* pFD = nullptr;
+                if (SUCCEEDED(pUnk->QueryInterface(IID_IFileDialog,
+                                                   (void**)&pFD)) && pFD)
+                {
+                    IOleWindow* pOW = nullptr;
+                    if (SUCCEEDED(pFD->QueryInterface(IID_IOleWindow,
+                                                      (void**)&pOW)) && pOW)
+                    {
+                        HWND dlgHwnd = nullptr;
+                        pOW->GetWindow(&dlgHwnd);
+                        if (dlgHwnd == topLevel ||
+                            GetAncestor(dlgHwnd, GA_ROOT) == topLevel ||
+                            GetAncestor(topLevel, GA_ROOT) == dlgHwnd)
+                        {
+                            IShellItem* pFolder = nullptr;
+                            if (SUCCEEDED(pFD->GetFolder(&pFolder)) && pFolder)
+                            {
+                                PWSTR pszPath = nullptr;
+                                if (SUCCEEDED(pFolder->GetDisplayName(
+                                        SIGDN_FILESYSPATH,
+                                        &pszPath)) && pszPath)
+                                {
+                                    path = pszPath;
+                                    CoTaskMemFree(pszPath);
+                                }
+                                found = true;
+                                pFolder->Release();
+                            }
+                        }
+                        pOW->Release();
+                    }
+                    pFD->Release();
+                }
+                pUnk->Release();
+            }
+            pMk->Release();
+        }
+        pEnum->Release();
+    }
+    pROT->Release();
+    return found;
+}
+
+static bool GetPathViaDefViewChild(HWND topLevel, std::wstring& path)
+{
+    struct FindData { HWND defView; };
+    FindData fd = {};
+    struct CB {
+        static BOOL CALLBACK Enum(HWND hw, LPARAM lp) {
+            WCHAR cls[64] = {};
+            GetClassNameW(hw, cls, 64);
+            if (!wcscmp(cls, L"SHELLDLL_DefView"))
+            {
+                ((FindData*)lp)->defView = hw;
+                return FALSE;
+            }
+            return TRUE;
+        }
+    };
+    EnumChildWindows(topLevel, CB::Enum, (LPARAM)&fd);
+    if (!fd.defView) return false;
+
+    HWND defViewParent = GetParent(fd.defView);
+    if (!defViewParent) return false;
+
+    IShellBrowser* pSB = (IShellBrowser*)SendMessageW(defViewParent,
+                                                       WM_USER + 7, 0, 0);
+    if (!pSB) return false;
+
+    IShellView* pSV = nullptr;
+    if (FAILED(pSB->QueryActiveShellView(&pSV)) || !pSV) return false;
+
+    bool found = false;
+    IFolderView* pFV = nullptr;
+    if (SUCCEEDED(pSV->QueryInterface(IID_IFolderView, (void**)&pFV)) && pFV)
+    {
+        IPersistFolder2* pPF = nullptr;
+        if (SUCCEEDED(pFV->GetFolder(IID_IPersistFolder2,
+                                     (void**)&pPF)) && pPF)
+        {
+            LPITEMIDLIST pidl = nullptr;
+            if (SUCCEEDED(pPF->GetCurFolder(&pidl)) && pidl)
+            {
+                WCHAR szPath[MAX_PATH] = {};
+                SHGetPathFromIDListW(pidl, szPath);
+                path  = szPath;
+                found = true;
+                CoTaskMemFree(pidl);
+            }
+            pPF->Release();
+        }
+        pFV->Release();
+    }
+    pSV->Release();
+    return found;
+}
+
+static bool GetCurrentFolderFromWindow(HWND hwnd, std::wstring& path)
+{
+    if (IsDesktopShellWindow(hwnd))
+        return GetDesktopFolderPath(path);
+
+    HWND root = GetAncestor(hwnd, GA_ROOT);
+    if (!root) root = hwnd;
+
+    if (GetPathViaShellWindows(root, path))  return true;
+    if (GetPathViaFileDialog(root, path))    return true;
+    if (GetPathViaDefViewChild(root, path))  return true;
+
+    return false;
+}
+
+// ============================================================
+//  CanPasteInWindow
+// ============================================================
+static bool CanPasteInWindow(HWND hwnd)
+{
+    if (!hwnd)                         return false;
+    if (!IsShellViewWindow(hwnd))      return false;
+    if (!HasNonFileClipboardContent()) return false;
+
+    std::wstring path;
+    if (!GetCurrentFolderFromWindow(hwnd, path))
+        return false;
+
+    return !path.empty();
+}
+
+// ============================================================
+//  ShellView-окно по позиции курсора
+// ============================================================
+static HWND GetShellViewWindowAtCursor()
+{
+    DWORD pos = GetMessagePos();
+    POINT pt  = { GET_X_LPARAM(pos), GET_Y_LPARAM(pos) };
+    HWND hwnd = WindowFromPoint(pt);
+    while (hwnd)
+    {
+        if (IsShellViewWindow(hwnd))
+            return hwnd;
+        HWND par = GetParent(hwnd);
+        if (!par) break;
+        hwnd = par;
+    }
+    return nullptr;
+}
+
+// ============================================================
+//  Paste command ID check
+// ============================================================
+static bool IsPasteCmd(UINT id)
+{
+    return id == 26
+        || id == 30979
+        || (id >= 28690 && id <= 28720);
+}
+
+// ============================================================
+//  Hooks
+// ============================================================
+
+using EnableMenuItem_t = BOOL(WINAPI*)(HMENU, UINT, UINT);
+EnableMenuItem_t EnableMenuItem_Orig;
+BOOL WINAPI EnableMenuItem_Hook(HMENU hMenu, UINT uIDEnableItem, UINT uEnable)
+{
+    if (IsPasteCmd(uIDEnableItem) && (uEnable & (MF_GRAYED | MF_DISABLED)))
+    {
+        HWND hwnd = GetShellViewWindowAtCursor();
+        if (!hwnd) hwnd = g_lastContextMenuShellView;
+        if (hwnd && CanPasteInWindow(hwnd))
+            uEnable = (uEnable & ~(MF_GRAYED | MF_DISABLED)) | MF_ENABLED;
+    }
+    return EnableMenuItem_Orig(hMenu, uIDEnableItem, uEnable);
+}
+
+using GetMenuState_t = UINT(WINAPI*)(HMENU, UINT, UINT);
+GetMenuState_t GetMenuState_Orig;
+UINT WINAPI GetMenuState_Hook(HMENU hMenu, UINT uId, UINT uFlags)
+{
+    UINT result = GetMenuState_Orig(hMenu, uId, uFlags);
+    if (IsPasteCmd(uId))
+    {
+        HWND hwnd = GetShellViewWindowAtCursor();
+        if (!hwnd) hwnd = g_lastContextMenuShellView;
+        if (hwnd && CanPasteInWindow(hwnd))
+            result = (result & ~(MF_GRAYED | MF_DISABLED)) | MF_ENABLED;
+    }
+    return result;
+}
+
+using TrackPopupMenuEx_t = BOOL(WINAPI*)(HMENU, UINT, int, int, HWND, LPTPMPARAMS);
+TrackPopupMenuEx_t TrackPopupMenuEx_Orig;
+BOOL WINAPI TrackPopupMenuEx_Hook(HMENU hmenu, UINT fuFlags,
+                                   int x, int y, HWND hwnd, LPTPMPARAMS lptpm)
+{
+    bool canPaste = CanPasteInWindow(hwnd);
+    g_lastContextMenuShellView = canPaste ? hwnd : nullptr;
+
+    if (canPaste)
+    {
+        int n = GetMenuItemCount(hmenu);
+        for (int i = 0; i < n; ++i)
+        {
+            MENUITEMINFOW mii = {};
+            mii.cbSize = sizeof(mii);
+            mii.fMask  = MIIM_ID | MIIM_STATE;
+            if (GetMenuItemInfoW(hmenu, (UINT)i, TRUE, &mii) &&
+                IsPasteCmd(mii.wID))
+            {
+                mii.fMask  = MIIM_STATE;
+                mii.fState = MFS_ENABLED;
+                SetMenuItemInfoW(hmenu, (UINT)i, TRUE, &mii);
+            }
+        }
+    }
+
+    return TrackPopupMenuEx_Orig(hmenu, fuFlags, x, y, hwnd, lptpm);
+}
+
+using SendMessageW_t = LRESULT(WINAPI*)(HWND, UINT, WPARAM, LPARAM);
+SendMessageW_t SendMessageW_Orig;
+LRESULT WINAPI SendMessageW_Hook(HWND hWnd, UINT Msg,
+                                  WPARAM wParam, LPARAM lParam)
+{
+    if (Msg == WM_COMMAND && IsPasteCmd(LOWORD(wParam)) &&
+        HasNonFileClipboardContent())
+    {
+        HWND target =
+            IsShellViewWindow(hWnd) ? hWnd :
+            (g_lastContextMenuShellView &&
+             IsShellViewWindow(g_lastContextMenuShellView)
+                 ? g_lastContextMenuShellView : nullptr);
+        if (target && PerformPaste(target))
+            return 0;
+    }
+    return SendMessageW_Orig(hWnd, Msg, wParam, lParam);
+}
+
+using PostMessageW_t = BOOL(WINAPI*)(HWND, UINT, WPARAM, LPARAM);
+PostMessageW_t PostMessageW_Orig;
+BOOL WINAPI PostMessageW_Hook(HWND hWnd, UINT Msg,
+                               WPARAM wParam, LPARAM lParam)
+{
+    if (Msg == WM_COMMAND && IsPasteCmd(LOWORD(wParam)) &&
+        HasNonFileClipboardContent())
+    {
+        HWND target =
+            IsShellViewWindow(hWnd) ? hWnd :
+            (g_lastContextMenuShellView &&
+             IsShellViewWindow(g_lastContextMenuShellView)
+                 ? g_lastContextMenuShellView : nullptr);
+        if (target && PerformPaste(target))
+            return TRUE;
+    }
+    return PostMessageW_Orig(hWnd, Msg, wParam, lParam);
+}
+
+using TranslateAcceleratorW_t = int(WINAPI*)(HWND, HACCEL, LPMSG);
+TranslateAcceleratorW_t TranslateAcceleratorW_Orig;
+int WINAPI TranslateAcceleratorW_Hook(HWND hWnd, HACCEL hAccTable, LPMSG lpMsg)
+{
+    if (lpMsg                              &&
+        lpMsg->message == WM_KEYDOWN       &&
+        lpMsg->wParam  == 'V'              &&
+        (GetKeyState(VK_CONTROL) & 0x8000) &&
+        !(GetKeyState(VK_SHIFT)  & 0x8000) &&
+        !(GetKeyState(VK_MENU)   & 0x8000))
+    {
+        HWND target = nullptr;
+        if (IsShellViewWindow(hWnd))             target = hWnd;
+        else if (IsShellViewWindow(lpMsg->hwnd)) target = lpMsg->hwnd;
+
+        if (target && CanPasteInWindow(target))
+        {
+            Wh_Log(L"TranslateAcceleratorW_Hook: Ctrl+V hwnd=%p", target);
+            if (PerformPaste(target))
+                return 1;
+        }
+    }
+    return TranslateAcceleratorW_Orig(hWnd, hAccTable, lpMsg);
+}
+
+// ============================================================
+//  Perform paste
+// ============================================================
+static bool PerformPaste(HWND sourceWindow)
+{
+    if (!IsShellViewWindow(sourceWindow))  return false;
+    if (!HasNonFileClipboardContent())     return false;
+
+    std::wstring targetPath;
+    if (!GetCurrentFolderFromWindow(sourceWindow, targetPath))
+    {
+        Wh_Log(L"PerformPaste: window not recognized, hwnd=%p", sourceWindow);
+        return false;
+    }
+    if (targetPath.empty())
+    {
+        Wh_Log(L"PerformPaste: virtual folder, skipping");
+        return false;
+    }
+
+    Wh_Log(L"PerformPaste: target='%s'", targetPath.c_str());
+
+    std::wstring baseName = GetDefaultBaseName();
+    std::wstring filePath;
+    bool success = false;
+
+    bool hasImage = IsClipboardFormatAvailable(CF_BITMAP)  ||
+                    IsClipboardFormatAvailable(CF_DIB)     ||
+                    IsClipboardFormatAvailable(CF_DIBV5);
+    bool hasText  = IsClipboardFormatAvailable(CF_UNICODETEXT);
+
+    if (hasImage)
+    {
+        filePath = GetUniquePath(targetPath, baseName, L".png");
+        success  = SaveImageFromClipboard(filePath);
+    }
+    else if (hasText)
+    {
+        filePath = GetUniquePath(targetPath, baseName, L".txt");
+        success  = SaveTextFromClipboard(filePath);
+    }
+
+    if (success)
+    {
+        Wh_Log(L"PerformPaste: created '%s'", filePath.c_str());
+        SHChangeNotify(SHCNE_CREATE,    SHCNF_PATH | SHCNF_FLUSH,
+                       filePath.c_str(),   nullptr);
+        SHChangeNotify(SHCNE_UPDATEDIR, SHCNF_PATH | SHCNF_FLUSH,
+                       targetPath.c_str(), nullptr);
+    }
+    return success;
+}
+
+// ============================================================
+//  Init / Uninit
+// ============================================================
+BOOL Wh_ModInit()
+{
+    Wh_Log(L"PasteClipboardToExplorer: Init");
+
+    GdiplusStartupInput gsi = {};
+    GdiplusStartup(&g_gdiplusToken, &gsi, nullptr);
+
+    Wh_SetFunctionHook((void*)EnableMenuItem,
+                       (void*)EnableMenuItem_Hook,
+                       (void**)&EnableMenuItem_Orig);
+    Wh_SetFunctionHook((void*)GetMenuState,
+                       (void*)GetMenuState_Hook,
+                       (void**)&GetMenuState_Orig);
+    Wh_SetFunctionHook((void*)TrackPopupMenuEx,
+                       (void*)TrackPopupMenuEx_Hook,
+                       (void**)&TrackPopupMenuEx_Orig);
+    Wh_SetFunctionHook((void*)SendMessageW,
+                       (void*)SendMessageW_Hook,
+                       (void**)&SendMessageW_Orig);
+    Wh_SetFunctionHook((void*)PostMessageW,
+                       (void*)PostMessageW_Hook,
+                       (void**)&PostMessageW_Orig);
+    Wh_SetFunctionHook((void*)TranslateAcceleratorW,
+                       (void*)TranslateAcceleratorW_Hook,
+                       (void**)&TranslateAcceleratorW_Orig);
+
+    return TRUE;
+}
+
+void Wh_ModUninit()
+{
+    Wh_Log(L"PasteClipboardToExplorer: Uninit");
+    if (g_gdiplusToken)
+        GdiplusShutdown(g_gdiplusToken);
+}


### PR DESCRIPTION
This mod allows pasting text and images from the clipboard as files in Explorer, including on the desktop and in file dialogs. It supports auto-naming with incrementing numbers on conflict and works with network folders.

<!-- ⚠️ Please don't remove the template below. Add your content above the template. -->

## Changelog

If the submission is an update to an existing mod, include the changelog below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If the submission is a new mod, please fill the form below.

This mod was created by:

- - [x] Manually by the submitter (with or without AI assistance)
- - [x] Claude Code
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the appropriate option. Your selection will not affect acceptance criteria, but will help reviewers understand the context of the code and provide relevant feedback.
