### PR TITLE
Fix: Auto Custom Titlebar Colors - Prevent focus loss on window creation

### DIFF
--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -2,7 +2,7 @@
 // @id              auto-custom-titlebar-colors
 // @name            Auto Custom Titlebar Colors
 // @description     Auto-switches titlebar dark/light mode with the Windows theme, with separate custom colours for active/inactive windows in both modes
-// @version         1.1.0
+// @version         1.1.1
 // @author          Lone
 // @github          https://github.com/Louis047
 // @include         *

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -472,7 +472,7 @@ HWND WINAPI CreateWindowExW_hook(
         dwExStyle, lpClassName, lpWindowName, dwStyle,
         X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 
-    if (hWnd) ApplyTitleBar(hWnd, FALSE, TRUE);
+    if (hWnd) ApplyTitleBar(hWnd, FALSE, FALSE);
     return hWnd;
 }
 
@@ -488,7 +488,7 @@ HWND WINAPI CreateWindowExA_hook(
         dwExStyle, lpClassName, lpWindowName, dwStyle,
         X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 
-    if (hWnd) ApplyTitleBar(hWnd, FALSE, TRUE);
+    if (hWnd) ApplyTitleBar(hWnd, FALSE, FALSE);
     return hWnd;
 }
 


### PR DESCRIPTION
A quick fix for `auto-custom-titlebar-colors.wh.cpp` which went unnoticed. 

<!-- ⚠️ Please don't remove the template below. Add your content above the template. -->

## Changelog

Issue Fixed:

- Input focus loss for every new window. Root cause was `SetWindowPos` with `SWP_FRAMECHANGED` flag in `CreateWindowEx` hooks was stealing focus from newly created windows. 

## Mod authorship

This mod was created by:

- - [ ] Manually by the submitter (with or without AI assistance)
- - [ ] Claude Code
- - [ ] ChatGPT
  - - [ ] Gemini
- - [x] Another AI (please specify): OpenCode (Haiku 4.5)
- - [ ] Other (please specify): 