### PR TITLE
Add Edge Snap Throw mod

### DIFF
--- a/edge-snap-throw.wh.cpp
+++ b/edge-snap-throw.wh.cpp
@@ -1,0 +1,374 @@
+// ==WindhawkMod==
+// @id              edge-snap-throw
+// @name            Edge Snap Throw
+// @description     Slide a window into a screen edge and it snaps like native Windows snap
+// @version         1.6.0
+// @author          getrektbynoob20
+// @github          https://github.com/getrektbynoob20
+// @include         *
+// @compilerOptions -lcomctl32 -ldwmapi
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Edge Snap Throw
+
+![Demo](https://raw.githubusercontent.com/getrektbynoob20/Edge-snap/refs/heads/main/edge-snap.gif)
+
+Works with the Slick Window Arrangement mod. When the sliding animation
+moves a window into a screen edge fast enough, it snaps using native
+Windows snap.
+
+Snap zones:
+- Left or right edge: 50 percent snap
+- Top edge: maximize
+- Corners: 25 percent snap
+
+Corner detection uses both position (corner zone) and throw direction.
+
+## All settings explained
+
+- Velocity Threshold: how fast (px/sec) the window must be moving to trigger any snap. Lower = easier to snap. Default 500.
+- Corner Zone: how many pixels from a screen corner the window center must land to trigger a corner snap. Default 120.
+- Diagonal Angle: how close to a perfect 45 degree angle your throw must be to count as diagonal. Lower = stricter. Default 20.
+- Diagonal Min Speed: minimum speed on each axis (px/sec) for a throw to be considered diagonal. Prevents slow drifts from counting. Default 100.
+- Diagonal Axis Ratio: horizontal speed must be at least this percent of vertical (and vice versa) for diagonal detection. 40 means neither axis can be less than 40 percent of the other. Default 40.
+- Direction Threshold: minimum px/sec on an axis before it counts as intentional direction. Default 30.
+- Snap Settle Delay: ms to wait after sending snap keys before re-enabling Snap Assist. Increase if Snap Assist still shows. Default 300.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- VelocityThreshold: 500
+  $name: Velocity Threshold px per second (default 500)
+- CornerZone: 120
+  $name: Corner Zone Size in pixels (default 120)
+- DiagonalAngle: 20
+  $name: Diagonal Angle tolerance degrees (default 20)
+- DiagonalMinSpeed: 100
+  $name: Diagonal Min Speed per axis px per second (default 100)
+- DiagonalAxisRatio: 40
+  $name: Diagonal Axis Ratio percent (default 40)
+- DirectionThreshold: 30
+  $name: Direction Threshold px per second (default 30)
+- SnapSettleDelay: 300
+  $name: Snap Settle Delay milliseconds (default 300)
+*/
+// ==/WindhawkModSettings==
+
+#include <dwmapi.h>
+#include <windowsx.h>
+#include <winreg.h>
+
+#include <atomic>
+#include <cmath>
+#include <mutex>
+#include <unordered_map>
+
+struct Settings {
+    int velocityThreshold;
+    int cornerZone;
+    int diagonalAngle;
+    int diagonalMinSpeed;
+    int diagonalAxisRatio;
+    int directionThreshold;
+    int snapSettleDelay;
+} g_settings;
+
+enum class SnapZone {
+    None, Maximize, Left, Right,
+    TopLeft, TopRight, BottomLeft, BottomRight,
+};
+
+// ── Velocity tracker ──────────────────────────────────────────────────────────
+struct PosSnapshot { DWORD tick; int x, y; };
+
+struct WinTrack {
+    PosSnapshot history[6]{};
+    int  head   = 0;
+    int  count  = 0;
+    bool active = false;
+
+    void Reset() { count = 0; active = false; }
+
+    void Push(int x, int y) {
+        DWORD now = GetTickCount();
+        if (count > 0 && now - history[(head + count - 1) % 6].tick > 400)
+            count = 0;
+        int idx = (head + count) % 6;
+        history[idx] = { now, x, y };
+        if (count < 6) count++;
+        else           head = (head + 1) % 6;
+        active = true;
+    }
+
+    bool Velocity(double* vx, double* vy) const {
+        if (count < 2) return false;
+        auto& last = history[(head + count - 1) % 6];
+        int prevIdx = head;
+        for (int i = 0; i < count - 1; i++) {
+            int idx = (head + i) % 6;
+            if ((int)(last.tick - history[idx].tick) <= 80) break;
+            prevIdx = idx;
+        }
+        auto& prev = history[prevIdx];
+        int dt = (int)(last.tick - prev.tick);
+        if (dt <= 0) return false;
+        *vx = 1000.0 * (last.x - prev.x) / dt;
+        *vy = 1000.0 * (last.y - prev.y) / dt;
+        return true;
+    }
+};
+
+std::mutex g_trackMutex;
+std::unordered_map<HWND, WinTrack> g_tracks;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+static RECT GetWorkArea(HWND hWnd) {
+    HMONITOR mon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO mi = { sizeof(mi) };
+    GetMonitorInfo(mon, &mi);
+    return mi.rcWork;
+}
+
+static RECT GetFrameRect(HWND hWnd) {
+    RECT rc{};
+    if (FAILED(DwmGetWindowAttribute(hWnd, DWMWA_EXTENDED_FRAME_BOUNDS, &rc, sizeof(rc))))
+        GetWindowRect(hWnd, &rc);
+    return rc;
+}
+
+static bool IsDiagonal(double vx, double vy) {
+    double ax = fabs(vx), ay = fabs(vy);
+    double minSpeed = (double)g_settings.diagonalMinSpeed;
+    double ratio    = g_settings.diagonalAxisRatio / 100.0;
+
+    if (ax < minSpeed || ay < minSpeed) return false;
+    if (ax < ay * ratio || ay < ax * ratio) return false;
+
+    constexpr double PI = 3.14159265358979323846;
+    double angle = fabs(atan2(ay, ax) * 180.0 / PI);
+    return fabs(angle - 45.0) <= (double)g_settings.diagonalAngle;
+}
+
+static SnapZone ClassifyCollision(HWND hWnd, double vx, double vy) {
+    double speed = sqrt(vx * vx + vy * vy);
+    if (speed < g_settings.velocityThreshold)
+        return SnapZone::None;
+
+    RECT frame = GetFrameRect(hWnd);
+    RECT wa    = GetWorkArea(hWnd);
+    int  cz    = g_settings.cornerZone;
+    int  dt    = g_settings.directionThreshold;
+
+    bool hitLeft   = frame.left   <= wa.left;
+    bool hitRight  = frame.right  >= wa.right;
+    bool hitTop    = frame.top    <= wa.top;
+    bool hitBottom = frame.bottom >= wa.bottom;
+
+    if (!hitLeft && !hitRight && !hitTop && !hitBottom)
+        return SnapZone::None;
+
+    int cx = (frame.left + frame.right)  / 2;
+    int cy = (frame.top  + frame.bottom) / 2;
+
+    bool nearLeft   = (cx - wa.left)  < cz;
+    bool nearRight  = (wa.right - cx) < cz;
+    bool nearTop    = (cy - wa.top)   < cz;
+    bool nearBottom = (wa.bottom - cy)< cz;
+
+    bool throwLeft  = vx < -(double)dt;
+    bool throwRight = vx >  (double)dt;
+    bool throwUp    = vy < -(double)dt;
+    bool throwDown  = vy >  (double)dt;
+
+    bool diagonal = IsDiagonal(vx, vy);
+
+    // Two-edge hits
+    if (hitLeft  && hitTop)    return SnapZone::TopLeft;
+    if (hitRight && hitTop)    return SnapZone::TopRight;
+    if (hitLeft  && hitBottom) return SnapZone::BottomLeft;
+    if (hitRight && hitBottom) return SnapZone::BottomRight;
+
+    // One-edge hit + in corner zone
+    if (hitTop    && nearLeft)   return SnapZone::TopLeft;
+    if (hitTop    && nearRight)  return SnapZone::TopRight;
+    if (hitBottom && nearLeft)   return SnapZone::BottomLeft;
+    if (hitBottom && nearRight)  return SnapZone::BottomRight;
+    if (hitLeft   && nearTop)    return SnapZone::TopLeft;
+    if (hitLeft   && nearBottom) return SnapZone::BottomLeft;
+    if (hitRight  && nearTop)    return SnapZone::TopRight;
+    if (hitRight  && nearBottom) return SnapZone::BottomRight;
+
+    // Diagonal throw direction
+    if (diagonal) {
+        if (hitLeft  && throwUp)    return SnapZone::TopLeft;
+        if (hitLeft  && throwDown)  return SnapZone::BottomLeft;
+        if (hitRight && throwUp)    return SnapZone::TopRight;
+        if (hitRight && throwDown)  return SnapZone::BottomRight;
+        if (hitTop   && throwLeft)  return SnapZone::TopLeft;
+        if (hitTop   && throwRight) return SnapZone::TopRight;
+        if (hitBottom&& throwLeft)  return SnapZone::BottomLeft;
+        if (hitBottom&& throwRight) return SnapZone::BottomRight;
+    }
+
+    // Plain edges
+    if (hitTop)    return SnapZone::Maximize;
+    if (hitLeft)   return SnapZone::Left;
+    if (hitRight)  return SnapZone::Right;
+
+    return SnapZone::None;
+}
+
+// ── Apply snap ────────────────────────────────────────────────────────────────
+static void PressWinKey(BYTE vk) {
+    INPUT inputs[4] = {};
+    inputs[0].type = INPUT_KEYBOARD; inputs[0].ki.wVk = VK_LWIN;
+    inputs[1].type = INPUT_KEYBOARD; inputs[1].ki.wVk = vk;
+    inputs[2].type = INPUT_KEYBOARD; inputs[2].ki.wVk = vk;    inputs[2].ki.dwFlags = KEYEVENTF_KEYUP;
+    inputs[3].type = INPUT_KEYBOARD; inputs[3].ki.wVk = VK_LWIN; inputs[3].ki.dwFlags = KEYEVENTF_KEYUP;
+    SendInput(4, inputs, sizeof(INPUT));
+}
+
+static void SetSnapAssist(bool enabled) {
+    DWORD val = enabled ? 1 : 0;
+    RegSetKeyValueW(HKEY_CURRENT_USER,
+        L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced",
+        L"SnapAssist", REG_DWORD, &val, sizeof(val));
+    SendNotifyMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0,
+        (LPARAM)L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced");
+}
+
+static void SnapToQuarter(HWND hWnd, SnapZone zone) {
+    HMONITOR mon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO mi = { sizeof(mi) };
+    GetMonitorInfo(mon, &mi);
+    RECT wa = mi.rcWork;
+
+    int halfW = (wa.right  - wa.left) / 2;
+    int halfH = (wa.bottom - wa.top)  / 2;
+
+    int x = wa.left, y = wa.top;
+    switch (zone) {
+    case SnapZone::TopLeft:     x = wa.left;        y = wa.top;         break;
+    case SnapZone::TopRight:    x = wa.left + halfW; y = wa.top;         break;
+    case SnapZone::BottomLeft:  x = wa.left;        y = wa.top + halfH; break;
+    case SnapZone::BottomRight: x = wa.left + halfW; y = wa.top + halfH; break;
+    default: return;
+    }
+
+    ShowWindow(hWnd, SW_RESTORE);
+    Sleep(30);
+    SetWindowPos(hWnd, nullptr, x, y, halfW, halfH,
+        SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+}
+
+static void ApplySnap(HWND hWnd, SnapZone zone) {
+    SetForegroundWindow(hWnd);
+    Sleep(20);
+
+    // Corners: direct SetWindowPos — no snap engine, no Snap Assist popup
+    if (zone == SnapZone::TopLeft    || zone == SnapZone::TopRight ||
+        zone == SnapZone::BottomLeft || zone == SnapZone::BottomRight) {
+        SnapToQuarter(hWnd, zone);
+        return;
+    }
+
+    // Halves + maximize: suppress Snap Assist around the key send
+    SetSnapAssist(false);
+    switch (zone) {
+    case SnapZone::Maximize: ShowWindow(hWnd, SW_MAXIMIZE); break;
+    case SnapZone::Left:     PressWinKey(VK_LEFT);          break;
+    case SnapZone::Right:    PressWinKey(VK_RIGHT);         break;
+    default: break;
+    }
+    Sleep(g_settings.snapSettleDelay);
+    SetSnapAssist(true);
+}
+
+struct SnapThreadParam { HWND hWnd; SnapZone zone; };
+static DWORD WINAPI SnapThreadProc(LPVOID p) {
+    auto* sp = reinterpret_cast<SnapThreadParam*>(p);
+    ApplySnap(sp->hWnd, sp->zone);
+    { std::lock_guard<std::mutex> lock(g_trackMutex); g_tracks.erase(sp->hWnd); }
+    delete sp;
+    return 0;
+}
+
+// ── Hook SetWindowPos ─────────────────────────────────────────────────────────
+using SetWindowPos_t = decltype(&SetWindowPos);
+SetWindowPos_t pOrigSetWindowPos;
+
+BOOL WINAPI SetWindowPosHook(HWND hWnd, HWND hWndInsertAfter,
+    int X, int Y, int cx, int cy, UINT uFlags)
+{
+    const UINT slideFlags = SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOOWNERZORDER;
+
+    if ((uFlags & slideFlags) == slideFlags && !(uFlags & SWP_NOMOVE)) {
+        LONG exStyle = GetWindowLong(hWnd, GWL_EXSTYLE);
+        if (!(exStyle & WS_EX_TOOLWINDOW) && IsWindowVisible(hWnd)) {
+            std::lock_guard<std::mutex> lock(g_trackMutex);
+            auto& track = g_tracks[hWnd];
+
+            if (track.count > 0) {
+                track.Push(X, Y);
+                double vx = 0, vy = 0;
+                if (track.Velocity(&vx, &vy)) {
+                    SnapZone zone = ClassifyCollision(hWnd, vx, vy);
+                    if (zone != SnapZone::None) {
+                        track.Reset();
+                        auto* param = new SnapThreadParam{ hWnd, zone };
+                        CreateThread(nullptr, 0, SnapThreadProc, param, 0, nullptr);
+                        return TRUE;
+                    }
+                }
+            } else {
+                track.Push(X, Y);
+            }
+        }
+    } else {
+        std::lock_guard<std::mutex> lock(g_trackMutex);
+        auto it = g_tracks.find(hWnd);
+        if (it != g_tracks.end()) it->second.Reset();
+    }
+
+    return pOrigSetWindowPos(hWnd, hWndInsertAfter, X, Y, cx, cy, uFlags);
+}
+
+// ── Windhawk lifecycle ────────────────────────────────────────────────────────
+void LoadSettings() {
+    g_settings.velocityThreshold  = Wh_GetIntSetting(L"VelocityThreshold");
+    g_settings.cornerZone         = Wh_GetIntSetting(L"CornerZone");
+    g_settings.diagonalAngle      = Wh_GetIntSetting(L"DiagonalAngle");
+    g_settings.diagonalMinSpeed   = Wh_GetIntSetting(L"DiagonalMinSpeed");
+    g_settings.diagonalAxisRatio  = Wh_GetIntSetting(L"DiagonalAxisRatio");
+    g_settings.directionThreshold = Wh_GetIntSetting(L"DirectionThreshold");
+    g_settings.snapSettleDelay    = Wh_GetIntSetting(L"SnapSettleDelay");
+
+    if (g_settings.velocityThreshold  < 1)   g_settings.velocityThreshold  = 500;
+    if (g_settings.cornerZone         < 0)   g_settings.cornerZone         = 120;
+    if (g_settings.diagonalAngle      < 1)   g_settings.diagonalAngle      = 20;
+    if (g_settings.diagonalAngle      > 44)  g_settings.diagonalAngle      = 44;
+    if (g_settings.diagonalMinSpeed   < 0)   g_settings.diagonalMinSpeed   = 100;
+    if (g_settings.diagonalAxisRatio  < 0)   g_settings.diagonalAxisRatio  = 40;
+    if (g_settings.diagonalAxisRatio  > 99)  g_settings.diagonalAxisRatio  = 99;
+    if (g_settings.directionThreshold < 0)   g_settings.directionThreshold = 30;
+    if (g_settings.snapSettleDelay    < 0)   g_settings.snapSettleDelay    = 300;
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"Edge Snap Throw: Init");
+    LoadSettings();
+    Wh_SetFunctionHook((void*)SetWindowPos, (void*)SetWindowPosHook, (void**)&pOrigSetWindowPos);
+    return TRUE;
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"Edge Snap Throw: Uninit");
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L"Edge Snap Throw: Settings changed");
+    LoadSettings();
+}

--- a/mods/edge-snap-throw.wh.cpp
+++ b/mods/edge-snap-throw.wh.cpp
@@ -2,7 +2,7 @@
 // @id              edge-snap-throw
 // @name            Edge Snap Throw
 // @description     Slide a window into a screen edge and it snaps like native Windows snap
-// @version         1.6.0
+// @version         1.9.0
 // @author          getrektbynoob20
 // @github          https://github.com/getrektbynoob20
 // @include         *
@@ -13,28 +13,28 @@
 /*
 # Edge Snap Throw
 
-![Demo](https://raw.githubusercontent.com/getrektbynoob20/Edge-snap/refs/heads/main/edge-snap.gif)
+![Demo](https://raw.githubusercontent.com/getrektbynoob20/Edge-snap/refs/heads/main/edge-snap2.0.gif)
 
-Works with the Slick Window Arrangement mod. When the sliding animation
-moves a window into a screen edge fast enough, it snaps using native
-Windows snap.
+Works best with **[Slick Window Arrangement](https://windhawk.net/mods/slick-window-arrangement)** by m417z.
+Install that mod first. It adds sliding momentum when you release a dragged window.
+This mod detects when that sliding window hits a screen edge fast enough and snaps it.
 
 Snap zones:
 - Left or right edge: 50 percent snap
 - Top edge: maximize
 - Corners: 25 percent snap
 
-Corner detection uses both position (corner zone) and throw direction.
+When you drag a snapped window back out, it restores to its original size (toggle in settings).
 
-## All settings explained
+## Settings
 
-- Velocity Threshold: how fast (px/sec) the window must be moving to trigger any snap. Lower = easier to snap. Default 500.
-- Corner Zone: how many pixels from a screen corner the window center must land to trigger a corner snap. Default 120.
-- Diagonal Angle: how close to a perfect 45 degree angle your throw must be to count as diagonal. Lower = stricter. Default 20.
-- Diagonal Min Speed: minimum speed on each axis (px/sec) for a throw to be considered diagonal. Prevents slow drifts from counting. Default 100.
-- Diagonal Axis Ratio: horizontal speed must be at least this percent of vertical (and vice versa) for diagonal detection. 40 means neither axis can be less than 40 percent of the other. Default 40.
-- Direction Threshold: minimum px/sec on an axis before it counts as intentional direction. Default 30.
-- Snap Settle Delay: ms to wait after sending snap keys before re-enabling Snap Assist. Increase if Snap Assist still shows. Default 300.
+- Velocity Threshold: how fast the window must be moving to trigger a snap. Default 500.
+- Corner Zone: pixels from a corner that count as a corner hit. Default 120.
+- Diagonal Angle: how close to 45 degrees a throw must be to count as diagonal. Default 20.
+- Diagonal Min Speed: minimum speed per axis for diagonal detection. Default 100.
+- Diagonal Axis Ratio: how balanced both axes must be for diagonal detection. Default 40.
+- Direction Threshold: minimum speed before a direction counts as intentional. Default 30.
+- Restore On Drag: when on, dragging a snapped window restores its original size. Default on.
 */
 // ==/WindhawkModReadme==
 
@@ -52,30 +52,31 @@ Corner detection uses both position (corner zone) and throw direction.
   $name: Diagonal Axis Ratio percent (default 40)
 - DirectionThreshold: 30
   $name: Direction Threshold px per second (default 30)
-- SnapSettleDelay: 300
-  $name: Snap Settle Delay milliseconds (default 300)
+- RestoreOnDrag: true
+  $name: Restore original size when dragging out of snap (default on)
 */
 // ==/WindhawkModSettings==
 
 #include <dwmapi.h>
 #include <windowsx.h>
-#include <winreg.h>
 
 #include <atomic>
 #include <cmath>
 #include <mutex>
 #include <unordered_map>
 
+// ── Settings ──────────────────────────────────────────────────────────────────
 struct Settings {
-    int velocityThreshold;
-    int cornerZone;
-    int diagonalAngle;
-    int diagonalMinSpeed;
-    int diagonalAxisRatio;
-    int directionThreshold;
-    int snapSettleDelay;
+    int  velocityThreshold;
+    int  cornerZone;
+    int  diagonalAngle;
+    int  diagonalMinSpeed;
+    int  diagonalAxisRatio;
+    int  directionThreshold;
+    bool restoreOnDrag;
 } g_settings;
 
+// ── Snap zone ─────────────────────────────────────────────────────────────────
 enum class SnapZone {
     None, Maximize, Left, Right,
     TopLeft, TopRight, BottomLeft, BottomRight,
@@ -86,11 +87,10 @@ struct PosSnapshot { DWORD tick; int x, y; };
 
 struct WinTrack {
     PosSnapshot history[6]{};
-    int  head   = 0;
-    int  count  = 0;
-    bool active = false;
+    int  head  = 0;
+    int  count = 0;
 
-    void Reset() { count = 0; active = false; }
+    void Reset() { count = 0; }
 
     void Push(int x, int y) {
         DWORD now = GetTickCount();
@@ -100,7 +100,6 @@ struct WinTrack {
         history[idx] = { now, x, y };
         if (count < 6) count++;
         else           head = (head + 1) % 6;
-        active = true;
     }
 
     bool Velocity(double* vx, double* vy) const {
@@ -124,6 +123,71 @@ struct WinTrack {
 std::mutex g_trackMutex;
 std::unordered_map<HWND, WinTrack> g_tracks;
 
+// ── Restore-on-drag state ─────────────────────────────────────────────────────
+struct SnapRestore {
+    RECT originalRect; // size before snap — only w/h matter
+    bool restored;     // true once we have done the restore
+};
+
+std::mutex g_restoreMutex;
+std::unordered_map<HWND, SnapRestore> g_restoreMap;
+
+// ── SetWindowPos hook (forward declared so RestoreSubclassProc can use it) ───
+using SetWindowPos_t = decltype(&SetWindowPos);
+SetWindowPos_t pOrigSetWindowPos;
+
+// ── Restore subclass proc ─────────────────────────────────────────────────────
+// Installed on the window's OWN thread (from SetWindowPosHook which runs there).
+// Intercepts WM_MOVING to resize the window back to its original size on the
+// first drag frame, exactly like native Windows snap restore does.
+LRESULT CALLBACK RestoreSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
+                                     UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
+{
+    if (uMsg == WM_MOVING) {
+        std::lock_guard<std::mutex> lock(g_restoreMutex);
+        auto it = g_restoreMap.find(hWnd);
+        if (it != g_restoreMap.end() && !it->second.restored) {
+            it->second.restored = true;
+
+            RECT& orig = it->second.originalRect;
+            int w = orig.right  - orig.left;
+            int h = orig.bottom - orig.top;
+
+            POINT cursor;
+            GetCursorPos(&cursor);
+
+            // Write into the rect Windows is using for drag positioning
+            RECT* r = (RECT*)lParam;
+            r->left   = cursor.x - w / 2;
+            r->top    = cursor.y - 10;
+            r->right  = r->left + w;
+            r->bottom = r->top  + h;
+
+            // Actually resize the window — WM_MOVING lParam only sets position
+            pOrigSetWindowPos(hWnd, nullptr, r->left, r->top, w, h,
+                SWP_NOZORDER | SWP_NOACTIVATE);
+
+            return TRUE;
+        }
+    }
+    else if (uMsg == WM_EXITSIZEMOVE) {
+        {
+            std::lock_guard<std::mutex> lock(g_restoreMutex);
+            g_restoreMap.erase(hWnd);
+        }
+        RemoveWindowSubclass(hWnd, RestoreSubclassProc, 0);
+    }
+    else if (uMsg == WM_NCDESTROY) {
+        {
+            std::lock_guard<std::mutex> lock(g_restoreMutex);
+            g_restoreMap.erase(hWnd);
+        }
+        RemoveWindowSubclass(hWnd, RestoreSubclassProc, 0);
+    }
+
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 static RECT GetWorkArea(HWND hWnd) {
     HMONITOR mon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
@@ -143,10 +207,8 @@ static bool IsDiagonal(double vx, double vy) {
     double ax = fabs(vx), ay = fabs(vy);
     double minSpeed = (double)g_settings.diagonalMinSpeed;
     double ratio    = g_settings.diagonalAxisRatio / 100.0;
-
     if (ax < minSpeed || ay < minSpeed) return false;
     if (ax < ay * ratio || ay < ax * ratio) return false;
-
     constexpr double PI = 3.14159265358979323846;
     double angle = fabs(atan2(ay, ax) * 180.0 / PI);
     return fabs(angle - 45.0) <= (double)g_settings.diagonalAngle;
@@ -154,8 +216,7 @@ static bool IsDiagonal(double vx, double vy) {
 
 static SnapZone ClassifyCollision(HWND hWnd, double vx, double vy) {
     double speed = sqrt(vx * vx + vy * vy);
-    if (speed < g_settings.velocityThreshold)
-        return SnapZone::None;
+    if (speed < g_settings.velocityThreshold) return SnapZone::None;
 
     RECT frame = GetFrameRect(hWnd);
     RECT wa    = GetWorkArea(hWnd);
@@ -167,8 +228,7 @@ static SnapZone ClassifyCollision(HWND hWnd, double vx, double vy) {
     bool hitTop    = frame.top    <= wa.top;
     bool hitBottom = frame.bottom >= wa.bottom;
 
-    if (!hitLeft && !hitRight && !hitTop && !hitBottom)
-        return SnapZone::None;
+    if (!hitLeft && !hitRight && !hitTop && !hitBottom) return SnapZone::None;
 
     int cx = (frame.left + frame.right)  / 2;
     int cy = (frame.top  + frame.bottom) / 2;
@@ -182,8 +242,7 @@ static SnapZone ClassifyCollision(HWND hWnd, double vx, double vy) {
     bool throwRight = vx >  (double)dt;
     bool throwUp    = vy < -(double)dt;
     bool throwDown  = vy >  (double)dt;
-
-    bool diagonal = IsDiagonal(vx, vy);
+    bool diagonal   = IsDiagonal(vx, vy);
 
     // Two-edge hits
     if (hitLeft  && hitTop)    return SnapZone::TopLeft;
@@ -191,7 +250,7 @@ static SnapZone ClassifyCollision(HWND hWnd, double vx, double vy) {
     if (hitLeft  && hitBottom) return SnapZone::BottomLeft;
     if (hitRight && hitBottom) return SnapZone::BottomRight;
 
-    // One-edge hit + in corner zone
+    // One edge + corner zone
     if (hitTop    && nearLeft)   return SnapZone::TopLeft;
     if (hitTop    && nearRight)  return SnapZone::TopRight;
     if (hitBottom && nearLeft)   return SnapZone::BottomLeft;
@@ -203,43 +262,25 @@ static SnapZone ClassifyCollision(HWND hWnd, double vx, double vy) {
 
     // Diagonal throw direction
     if (diagonal) {
-        if (hitLeft  && throwUp)    return SnapZone::TopLeft;
-        if (hitLeft  && throwDown)  return SnapZone::BottomLeft;
-        if (hitRight && throwUp)    return SnapZone::TopRight;
-        if (hitRight && throwDown)  return SnapZone::BottomRight;
-        if (hitTop   && throwLeft)  return SnapZone::TopLeft;
-        if (hitTop   && throwRight) return SnapZone::TopRight;
-        if (hitBottom&& throwLeft)  return SnapZone::BottomLeft;
-        if (hitBottom&& throwRight) return SnapZone::BottomRight;
+        if (hitLeft   && throwUp)    return SnapZone::TopLeft;
+        if (hitLeft   && throwDown)  return SnapZone::BottomLeft;
+        if (hitRight  && throwUp)    return SnapZone::TopRight;
+        if (hitRight  && throwDown)  return SnapZone::BottomRight;
+        if (hitTop    && throwLeft)  return SnapZone::TopLeft;
+        if (hitTop    && throwRight) return SnapZone::TopRight;
+        if (hitBottom && throwLeft)  return SnapZone::BottomLeft;
+        if (hitBottom && throwRight) return SnapZone::BottomRight;
     }
 
     // Plain edges
-    if (hitTop)    return SnapZone::Maximize;
-    if (hitLeft)   return SnapZone::Left;
-    if (hitRight)  return SnapZone::Right;
+    if (hitTop)   return SnapZone::Maximize;
+    if (hitLeft)  return SnapZone::Left;
+    if (hitRight) return SnapZone::Right;
 
     return SnapZone::None;
 }
 
 // ── Apply snap ────────────────────────────────────────────────────────────────
-static void PressWinKey(BYTE vk) {
-    INPUT inputs[4] = {};
-    inputs[0].type = INPUT_KEYBOARD; inputs[0].ki.wVk = VK_LWIN;
-    inputs[1].type = INPUT_KEYBOARD; inputs[1].ki.wVk = vk;
-    inputs[2].type = INPUT_KEYBOARD; inputs[2].ki.wVk = vk;    inputs[2].ki.dwFlags = KEYEVENTF_KEYUP;
-    inputs[3].type = INPUT_KEYBOARD; inputs[3].ki.wVk = VK_LWIN; inputs[3].ki.dwFlags = KEYEVENTF_KEYUP;
-    SendInput(4, inputs, sizeof(INPUT));
-}
-
-static void SetSnapAssist(bool enabled) {
-    DWORD val = enabled ? 1 : 0;
-    RegSetKeyValueW(HKEY_CURRENT_USER,
-        L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced",
-        L"SnapAssist", REG_DWORD, &val, sizeof(val));
-    SendNotifyMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0,
-        (LPARAM)L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced");
-}
-
 static void SnapToQuarter(HWND hWnd, SnapZone zone) {
     HMONITOR mon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
     MONITORINFO mi = { sizeof(mi) };
@@ -248,58 +289,66 @@ static void SnapToQuarter(HWND hWnd, SnapZone zone) {
 
     int halfW = (wa.right  - wa.left) / 2;
     int halfH = (wa.bottom - wa.top)  / 2;
-
     int x = wa.left, y = wa.top;
+
     switch (zone) {
-    case SnapZone::TopLeft:     x = wa.left;        y = wa.top;         break;
-    case SnapZone::TopRight:    x = wa.left + halfW; y = wa.top;         break;
-    case SnapZone::BottomLeft:  x = wa.left;        y = wa.top + halfH; break;
-    case SnapZone::BottomRight: x = wa.left + halfW; y = wa.top + halfH; break;
+    case SnapZone::TopLeft:     x = wa.left;         y = wa.top;         break;
+    case SnapZone::TopRight:    x = wa.left + halfW;  y = wa.top;         break;
+    case SnapZone::BottomLeft:  x = wa.left;         y = wa.top + halfH; break;
+    case SnapZone::BottomRight: x = wa.left + halfW;  y = wa.top + halfH; break;
     default: return;
     }
 
     ShowWindow(hWnd, SW_RESTORE);
     Sleep(30);
-    SetWindowPos(hWnd, nullptr, x, y, halfW, halfH,
+    pOrigSetWindowPos(hWnd, nullptr, x, y, halfW, halfH,
+        SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+}
+
+static void SnapToHalf(HWND hWnd, SnapZone zone) {
+    HMONITOR mon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO mi = { sizeof(mi) };
+    GetMonitorInfo(mon, &mi);
+    RECT wa = mi.rcWork;
+
+    int halfW = (wa.right - wa.left) / 2;
+    int fullH =  wa.bottom - wa.top;
+    int x = (zone == SnapZone::Left) ? wa.left : wa.left + halfW;
+
+    ShowWindow(hWnd, SW_RESTORE);
+    Sleep(30);
+    pOrigSetWindowPos(hWnd, nullptr, x, wa.top, halfW, fullH,
         SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
 }
 
 static void ApplySnap(HWND hWnd, SnapZone zone) {
     SetForegroundWindow(hWnd);
     Sleep(20);
-
-    // Corners: direct SetWindowPos — no snap engine, no Snap Assist popup
-    if (zone == SnapZone::TopLeft    || zone == SnapZone::TopRight ||
-        zone == SnapZone::BottomLeft || zone == SnapZone::BottomRight) {
-        SnapToQuarter(hWnd, zone);
-        return;
-    }
-
-    // Halves + maximize: suppress Snap Assist around the key send
-    SetSnapAssist(false);
     switch (zone) {
-    case SnapZone::Maximize: ShowWindow(hWnd, SW_MAXIMIZE); break;
-    case SnapZone::Left:     PressWinKey(VK_LEFT);          break;
-    case SnapZone::Right:    PressWinKey(VK_RIGHT);         break;
+    case SnapZone::Maximize:                                  ShowWindow(hWnd, SW_MAXIMIZE); break;
+    case SnapZone::Left:    case SnapZone::Right:             SnapToHalf(hWnd, zone);        break;
+    case SnapZone::TopLeft: case SnapZone::TopRight:
+    case SnapZone::BottomLeft: case SnapZone::BottomRight:    SnapToQuarter(hWnd, zone);     break;
     default: break;
     }
-    Sleep(g_settings.snapSettleDelay);
-    SetSnapAssist(true);
 }
 
 struct SnapThreadParam { HWND hWnd; SnapZone zone; };
 static DWORD WINAPI SnapThreadProc(LPVOID p) {
     auto* sp = reinterpret_cast<SnapThreadParam*>(p);
     ApplySnap(sp->hWnd, sp->zone);
-    { std::lock_guard<std::mutex> lock(g_trackMutex); g_tracks.erase(sp->hWnd); }
+    {
+        std::lock_guard<std::mutex> lock(g_trackMutex);
+        g_tracks.erase(sp->hWnd);
+    }
     delete sp;
     return 0;
 }
 
 // ── Hook SetWindowPos ─────────────────────────────────────────────────────────
-using SetWindowPos_t = decltype(&SetWindowPos);
-SetWindowPos_t pOrigSetWindowPos;
-
+// This hook runs on the window's UI thread (Slick Window Arrangement's slide
+// timer is a thread timer processed by the UI thread's message loop).
+// That means SetWindowSubclass can safely be called here.
 BOOL WINAPI SetWindowPosHook(HWND hWnd, HWND hWndInsertAfter,
     int X, int Y, int cx, int cy, UINT uFlags)
 {
@@ -318,9 +367,28 @@ BOOL WINAPI SetWindowPosHook(HWND hWnd, HWND hWndInsertAfter,
                     SnapZone zone = ClassifyCollision(hWnd, vx, vy);
                     if (zone != SnapZone::None) {
                         track.Reset();
+
+                        // ── Restore-on-drag setup ─────────────────────────
+                        // We're on the window's UI thread here, so
+                        // SetWindowSubclass is safe to call.
+                        // Save rect NOW before the snap changes the size.
+                        // The slide only moves (SWP_NOSIZE) so the current
+                        // size IS the original pre-snap size.
+                        if (g_settings.restoreOnDrag && zone != SnapZone::Maximize) {
+                            RECT rc{};
+                            GetWindowRect(hWnd, &rc);
+                            {
+                                std::lock_guard<std::mutex> rlock(g_restoreMutex);
+                                g_restoreMap[hWnd] = { rc, false };
+                            }
+                            SetWindowSubclass(hWnd, RestoreSubclassProc, 0, 0);
+                        }
+
+                        // Stop the slide and snap on a worker thread so we
+                        // don't block the UI thread with Sleep() calls
                         auto* param = new SnapThreadParam{ hWnd, zone };
                         CreateThread(nullptr, 0, SnapThreadProc, param, 0, nullptr);
-                        return TRUE;
+                        return TRUE; // block this SetWindowPos — slide stops here
                     }
                 }
             } else {
@@ -344,17 +412,16 @@ void LoadSettings() {
     g_settings.diagonalMinSpeed   = Wh_GetIntSetting(L"DiagonalMinSpeed");
     g_settings.diagonalAxisRatio  = Wh_GetIntSetting(L"DiagonalAxisRatio");
     g_settings.directionThreshold = Wh_GetIntSetting(L"DirectionThreshold");
-    g_settings.snapSettleDelay    = Wh_GetIntSetting(L"SnapSettleDelay");
+    g_settings.restoreOnDrag      = Wh_GetIntSetting(L"RestoreOnDrag") != 0;
 
-    if (g_settings.velocityThreshold  < 1)   g_settings.velocityThreshold  = 500;
-    if (g_settings.cornerZone         < 0)   g_settings.cornerZone         = 120;
-    if (g_settings.diagonalAngle      < 1)   g_settings.diagonalAngle      = 20;
-    if (g_settings.diagonalAngle      > 44)  g_settings.diagonalAngle      = 44;
-    if (g_settings.diagonalMinSpeed   < 0)   g_settings.diagonalMinSpeed   = 100;
-    if (g_settings.diagonalAxisRatio  < 0)   g_settings.diagonalAxisRatio  = 40;
-    if (g_settings.diagonalAxisRatio  > 99)  g_settings.diagonalAxisRatio  = 99;
-    if (g_settings.directionThreshold < 0)   g_settings.directionThreshold = 30;
-    if (g_settings.snapSettleDelay    < 0)   g_settings.snapSettleDelay    = 300;
+    if (g_settings.velocityThreshold  < 1)  g_settings.velocityThreshold  = 500;
+    if (g_settings.cornerZone         < 0)  g_settings.cornerZone         = 120;
+    if (g_settings.diagonalAngle      < 1)  g_settings.diagonalAngle      = 20;
+    if (g_settings.diagonalAngle      > 44) g_settings.diagonalAngle      = 44;
+    if (g_settings.diagonalMinSpeed   < 0)  g_settings.diagonalMinSpeed   = 100;
+    if (g_settings.diagonalAxisRatio  < 0)  g_settings.diagonalAxisRatio  = 40;
+    if (g_settings.diagonalAxisRatio  > 99) g_settings.diagonalAxisRatio  = 99;
+    if (g_settings.directionThreshold < 0)  g_settings.directionThreshold = 30;
 }
 
 BOOL Wh_ModInit() {

--- a/mods/edge-snap-throw.wh.cpp
+++ b/mods/edge-snap-throw.wh.cpp
@@ -2,7 +2,7 @@
 // @id              edge-snap-throw
 // @name            Edge Snap Throw
 // @description     Slide a window into a screen edge and it snaps like native Windows snap
-// @version         1.9.0
+// @version         2.0.0
 // @author          getrektbynoob20
 // @github          https://github.com/getrektbynoob20
 // @include         *
@@ -60,10 +60,10 @@ When you drag a snapped window back out, it restores to its original size (toggl
 #include <dwmapi.h>
 #include <windowsx.h>
 
-#include <atomic>
 #include <cmath>
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 
 // ── Settings ──────────────────────────────────────────────────────────────────
 struct Settings {
@@ -82,13 +82,13 @@ enum class SnapZone {
     TopLeft, TopRight, BottomLeft, BottomRight,
 };
 
-// ── Velocity tracker ──────────────────────────────────────────────────────────
+// ── Velocity tracker (thread_local — no mutex needed) ─────────────────────────
 struct PosSnapshot { DWORD tick; int x, y; };
 
 struct WinTrack {
     PosSnapshot history[6]{};
-    int  head  = 0;
-    int  count = 0;
+    int head  = 0;
+    int count = 0;
 
     void Reset() { count = 0; }
 
@@ -120,69 +120,86 @@ struct WinTrack {
     }
 };
 
-std::mutex g_trackMutex;
-std::unordered_map<HWND, WinTrack> g_tracks;
+// thread_local: each UI thread has its own map, no mutex needed
+thread_local std::unordered_map<HWND, WinTrack> g_tracks;
 
-// ── Restore-on-drag state ─────────────────────────────────────────────────────
+// Timer-based snap: maps timer ID -> {hWnd, zone}, also thread_local
+thread_local std::unordered_map<UINT_PTR, std::pair<HWND, SnapZone>> g_pendingSnaps;
+
+// ── SetWindowPos hook (forward declared for RestoreSubclassProc) ──────────────
+using SetWindowPos_t = decltype(&SetWindowPos);
+SetWindowPos_t pOrigSetWindowPos;
+
+// ── Restore-on-drag ───────────────────────────────────────────────────────────
 struct SnapRestore {
-    RECT originalRect; // size before snap — only w/h matter
-    bool restored;     // true once we have done the restore
+    RECT originalRect;
+    bool restored;
 };
 
 std::mutex g_restoreMutex;
 std::unordered_map<HWND, SnapRestore> g_restoreMap;
 
-// ── SetWindowPos hook (forward declared so RestoreSubclassProc can use it) ───
-using SetWindowPos_t = decltype(&SetWindowPos);
-SetWindowPos_t pOrigSetWindowPos;
+// Track subclassed windows so we can clean them up on unload
+std::mutex g_subclassedMutex;
+std::unordered_set<HWND> g_subclassedWindows;
 
-// ── Restore subclass proc ─────────────────────────────────────────────────────
-// Installed on the window's OWN thread (from SetWindowPosHook which runs there).
-// Intercepts WM_MOVING to resize the window back to its original size on the
-// first drag frame, exactly like native Windows snap restore does.
+UINT g_unsubclassMsg = RegisterWindowMessage(L"Windhawk_Unsubclass_restore_edge-snap-throw");
+
 LRESULT CALLBACK RestoreSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
                                      UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
+    auto cleanup = [&]() {
+        RemoveWindowSubclass(hWnd, RestoreSubclassProc, 0);
+        {
+            std::lock_guard<std::mutex> lock(g_subclassedMutex);
+            g_subclassedWindows.erase(hWnd);
+        }
+        {
+            std::lock_guard<std::mutex> lock(g_restoreMutex);
+            g_restoreMap.erase(hWnd);
+        }
+    };
+
     if (uMsg == WM_MOVING) {
-        std::lock_guard<std::mutex> lock(g_restoreMutex);
-        auto it = g_restoreMap.find(hWnd);
-        if (it != g_restoreMap.end() && !it->second.restored) {
-            it->second.restored = true;
+        bool didRestore = false;
+        {
+            std::lock_guard<std::mutex> lock(g_restoreMutex);
+            auto it = g_restoreMap.find(hWnd);
+            if (it != g_restoreMap.end() && !it->second.restored) {
+                it->second.restored = true;
 
-            RECT& orig = it->second.originalRect;
-            int w = orig.right  - orig.left;
-            int h = orig.bottom - orig.top;
+                RECT& orig = it->second.originalRect;
+                int w = orig.right  - orig.left;
+                int h = orig.bottom - orig.top;
 
-            POINT cursor;
-            GetCursorPos(&cursor);
+                POINT cursor;
+                GetCursorPos(&cursor);
 
-            // Write into the rect Windows is using for drag positioning
-            RECT* r = (RECT*)lParam;
-            r->left   = cursor.x - w / 2;
-            r->top    = cursor.y - 10;
-            r->right  = r->left + w;
-            r->bottom = r->top  + h;
+                RECT* r = (RECT*)lParam;
+                r->left   = cursor.x - w / 2;
+                r->top    = cursor.y - 10;
+                r->right  = r->left + w;
+                r->bottom = r->top  + h;
 
-            // Actually resize the window — WM_MOVING lParam only sets position
-            pOrigSetWindowPos(hWnd, nullptr, r->left, r->top, w, h,
-                SWP_NOZORDER | SWP_NOACTIVATE);
+                pOrigSetWindowPos(hWnd, nullptr, r->left, r->top, w, h,
+                    SWP_NOZORDER | SWP_NOACTIVATE);
 
+                didRestore = true;
+            }
+        }
+        if (didRestore) {
+            // Remove subclass immediately — job is done
+            cleanup();
             return TRUE;
         }
     }
-    else if (uMsg == WM_EXITSIZEMOVE) {
-        {
-            std::lock_guard<std::mutex> lock(g_restoreMutex);
-            g_restoreMap.erase(hWnd);
-        }
-        RemoveWindowSubclass(hWnd, RestoreSubclassProc, 0);
-    }
     else if (uMsg == WM_NCDESTROY) {
-        {
-            std::lock_guard<std::mutex> lock(g_restoreMutex);
-            g_restoreMap.erase(hWnd);
-        }
-        RemoveWindowSubclass(hWnd, RestoreSubclassProc, 0);
+        cleanup();
+    }
+    else if (uMsg == g_unsubclassMsg) {
+        // Sent by Wh_ModUninit to cleanly remove subclass on unload
+        cleanup();
+        return 0;
     }
 
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
@@ -244,13 +261,11 @@ static SnapZone ClassifyCollision(HWND hWnd, double vx, double vy) {
     bool throwDown  = vy >  (double)dt;
     bool diagonal   = IsDiagonal(vx, vy);
 
-    // Two-edge hits
     if (hitLeft  && hitTop)    return SnapZone::TopLeft;
     if (hitRight && hitTop)    return SnapZone::TopRight;
     if (hitLeft  && hitBottom) return SnapZone::BottomLeft;
     if (hitRight && hitBottom) return SnapZone::BottomRight;
 
-    // One edge + corner zone
     if (hitTop    && nearLeft)   return SnapZone::TopLeft;
     if (hitTop    && nearRight)  return SnapZone::TopRight;
     if (hitBottom && nearLeft)   return SnapZone::BottomLeft;
@@ -260,7 +275,6 @@ static SnapZone ClassifyCollision(HWND hWnd, double vx, double vy) {
     if (hitRight  && nearTop)    return SnapZone::TopRight;
     if (hitRight  && nearBottom) return SnapZone::BottomRight;
 
-    // Diagonal throw direction
     if (diagonal) {
         if (hitLeft   && throwUp)    return SnapZone::TopLeft;
         if (hitLeft   && throwDown)  return SnapZone::BottomLeft;
@@ -272,7 +286,6 @@ static SnapZone ClassifyCollision(HWND hWnd, double vx, double vy) {
         if (hitBottom && throwRight) return SnapZone::BottomRight;
     }
 
-    // Plain edges
     if (hitTop)   return SnapZone::Maximize;
     if (hitLeft)  return SnapZone::Left;
     if (hitRight) return SnapZone::Right;
@@ -281,83 +294,81 @@ static SnapZone ClassifyCollision(HWND hWnd, double vx, double vy) {
 }
 
 // ── Apply snap ────────────────────────────────────────────────────────────────
-static void SnapToQuarter(HWND hWnd, SnapZone zone) {
+static void SnapWindow(HWND hWnd, SnapZone zone) {
     HMONITOR mon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
     MONITORINFO mi = { sizeof(mi) };
     GetMonitorInfo(mon, &mi);
     RECT wa = mi.rcWork;
 
-    int halfW = (wa.right  - wa.left) / 2;
-    int halfH = (wa.bottom - wa.top)  / 2;
-    int x = wa.left, y = wa.top;
+    int fullW = wa.right  - wa.left;
+    int fullH = wa.bottom - wa.top;
+    int halfW = fullW / 2;
+    int halfH = fullH / 2;
+
+    int x = wa.left, y = wa.top, w = fullW, h = fullH;
 
     switch (zone) {
-    case SnapZone::TopLeft:     x = wa.left;         y = wa.top;         break;
-    case SnapZone::TopRight:    x = wa.left + halfW;  y = wa.top;         break;
-    case SnapZone::BottomLeft:  x = wa.left;         y = wa.top + halfH; break;
-    case SnapZone::BottomRight: x = wa.left + halfW;  y = wa.top + halfH; break;
+    case SnapZone::Maximize:
+        ShowWindow(hWnd, SW_MAXIMIZE);
+        return;
+    case SnapZone::Left:        x = wa.left;        y = wa.top;         w = halfW; h = fullH; break;
+    case SnapZone::Right:       x = wa.left + halfW; y = wa.top;         w = halfW; h = fullH; break;
+    case SnapZone::TopLeft:     x = wa.left;        y = wa.top;         w = halfW; h = halfH; break;
+    case SnapZone::TopRight:    x = wa.left + halfW; y = wa.top;         w = halfW; h = halfH; break;
+    case SnapZone::BottomLeft:  x = wa.left;        y = wa.top + halfH; w = halfW; h = halfH; break;
+    case SnapZone::BottomRight: x = wa.left + halfW; y = wa.top + halfH; w = halfW; h = halfH; break;
     default: return;
     }
 
     ShowWindow(hWnd, SW_RESTORE);
-    Sleep(30);
-    pOrigSetWindowPos(hWnd, nullptr, x, y, halfW, halfH,
+    pOrigSetWindowPos(hWnd, nullptr, x, y, w, h,
         SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
 }
 
-static void SnapToHalf(HWND hWnd, SnapZone zone) {
-    HMONITOR mon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
-    MONITORINFO mi = { sizeof(mi) };
-    GetMonitorInfo(mon, &mi);
-    RECT wa = mi.rcWork;
+// ── Timer-based snap (runs on UI thread — no CreateThread needed) ─────────────
+void CALLBACK SnapTimerProc(HWND, UINT, UINT_PTR idTimer, DWORD) {
+    KillTimer(nullptr, idTimer);
 
-    int halfW = (wa.right - wa.left) / 2;
-    int fullH =  wa.bottom - wa.top;
-    int x = (zone == SnapZone::Left) ? wa.left : wa.left + halfW;
+    auto it = g_pendingSnaps.find(idTimer);
+    if (it == g_pendingSnaps.end()) return;
 
-    ShowWindow(hWnd, SW_RESTORE);
-    Sleep(30);
-    pOrigSetWindowPos(hWnd, nullptr, x, wa.top, halfW, fullH,
-        SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
-}
+    HWND     hWnd = it->second.first;
+    SnapZone zone = it->second.second;
+    g_pendingSnaps.erase(it);
 
-static void ApplySnap(HWND hWnd, SnapZone zone) {
-    SetForegroundWindow(hWnd);
-    Sleep(20);
-    switch (zone) {
-    case SnapZone::Maximize:                                  ShowWindow(hWnd, SW_MAXIMIZE); break;
-    case SnapZone::Left:    case SnapZone::Right:             SnapToHalf(hWnd, zone);        break;
-    case SnapZone::TopLeft: case SnapZone::TopRight:
-    case SnapZone::BottomLeft: case SnapZone::BottomRight:    SnapToQuarter(hWnd, zone);     break;
-    default: break;
-    }
-}
-
-struct SnapThreadParam { HWND hWnd; SnapZone zone; };
-static DWORD WINAPI SnapThreadProc(LPVOID p) {
-    auto* sp = reinterpret_cast<SnapThreadParam*>(p);
-    ApplySnap(sp->hWnd, sp->zone);
-    {
-        std::lock_guard<std::mutex> lock(g_trackMutex);
-        g_tracks.erase(sp->hWnd);
-    }
-    delete sp;
-    return 0;
+    SnapWindow(hWnd, zone);
 }
 
 // ── Hook SetWindowPos ─────────────────────────────────────────────────────────
-// This hook runs on the window's UI thread (Slick Window Arrangement's slide
-// timer is a thread timer processed by the UI thread's message loop).
-// That means SetWindowSubclass can safely be called here.
 BOOL WINAPI SetWindowPosHook(HWND hWnd, HWND hWndInsertAfter,
     int X, int Y, int cx, int cy, UINT uFlags)
 {
+    // Verify the caller is slick-window-arrangement by checking which module
+    // the return address belongs to. _ReturnAddress() must be called directly
+    // in the hook function — it reads the actual stack return address.
+    void* callerAddr = __builtin_return_address(0);
+    {
+        HMODULE callerMod = nullptr;
+        if (GetModuleHandleExW(
+                GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                (LPCWSTR)callerAddr, &callerMod) && callerMod) {
+            WCHAR modPath[MAX_PATH];
+            if (GetModuleFileNameW(callerMod, modPath, MAX_PATH)) {
+                if (!wcsstr(modPath, L"slick-window-arrangement")) {
+                    return pOrigSetWindowPos(hWnd, hWndInsertAfter, X, Y, cx, cy, uFlags);
+                }
+            }
+        } else {
+            return pOrigSetWindowPos(hWnd, hWndInsertAfter, X, Y, cx, cy, uFlags);
+        }
+    }
+
     const UINT slideFlags = SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOOWNERZORDER;
 
     if ((uFlags & slideFlags) == slideFlags && !(uFlags & SWP_NOMOVE)) {
         LONG exStyle = GetWindowLong(hWnd, GWL_EXSTYLE);
         if (!(exStyle & WS_EX_TOOLWINDOW) && IsWindowVisible(hWnd)) {
-            std::lock_guard<std::mutex> lock(g_trackMutex);
             auto& track = g_tracks[hWnd];
 
             if (track.count > 0) {
@@ -368,27 +379,28 @@ BOOL WINAPI SetWindowPosHook(HWND hWnd, HWND hWndInsertAfter,
                     if (zone != SnapZone::None) {
                         track.Reset();
 
-                        // ── Restore-on-drag setup ─────────────────────────
-                        // We're on the window's UI thread here, so
-                        // SetWindowSubclass is safe to call.
-                        // Save rect NOW before the snap changes the size.
-                        // The slide only moves (SWP_NOSIZE) so the current
-                        // size IS the original pre-snap size.
+                        // Save original size and subclass for restore-on-drag.
+                        // Safe to call SetWindowSubclass here — we are on the
+                        // window's own UI thread (slide timer runs there).
                         if (g_settings.restoreOnDrag && zone != SnapZone::Maximize) {
                             RECT rc{};
                             GetWindowRect(hWnd, &rc);
                             {
-                                std::lock_guard<std::mutex> rlock(g_restoreMutex);
+                                std::lock_guard<std::mutex> lock(g_restoreMutex);
                                 g_restoreMap[hWnd] = { rc, false };
                             }
-                            SetWindowSubclass(hWnd, RestoreSubclassProc, 0, 0);
+                            if (SetWindowSubclass(hWnd, RestoreSubclassProc, 0, 0)) {
+                                std::lock_guard<std::mutex> lock(g_subclassedMutex);
+                                g_subclassedWindows.insert(hWnd);
+                            }
                         }
 
-                        // Stop the slide and snap on a worker thread so we
-                        // don't block the UI thread with Sleep() calls
-                        auto* param = new SnapThreadParam{ hWnd, zone };
-                        CreateThread(nullptr, 0, SnapThreadProc, param, 0, nullptr);
-                        return TRUE; // block this SetWindowPos — slide stops here
+                        // Use SetTimer instead of CreateThread so snap runs on
+                        // the UI thread and g_tracks stays thread_local.
+                        UINT_PTR timerId = SetTimer(nullptr, 0, 1, SnapTimerProc);
+                        g_pendingSnaps[timerId] = { hWnd, zone };
+
+                        return TRUE; // stop the slide
                     }
                 }
             } else {
@@ -396,7 +408,6 @@ BOOL WINAPI SetWindowPosHook(HWND hWnd, HWND hWndInsertAfter,
             }
         }
     } else {
-        std::lock_guard<std::mutex> lock(g_trackMutex);
         auto it = g_tracks.find(hWnd);
         if (it != g_tracks.end()) it->second.Reset();
     }
@@ -433,6 +444,16 @@ BOOL Wh_ModInit() {
 
 void Wh_ModUninit() {
     Wh_Log(L"Edge Snap Throw: Uninit");
+
+    // Remove all restore subclasses so the mod unloads cleanly without crashes
+    std::unordered_set<HWND> windows;
+    {
+        std::lock_guard<std::mutex> lock(g_subclassedMutex);
+        windows = g_subclassedWindows;
+    }
+    for (HWND hWnd : windows) {
+        SendMessage(hWnd, g_unsubclassMsg, 0, 0);
+    }
 }
 
 void Wh_ModSettingsChanged() {


### PR DESCRIPTION
This file implements the Edge Snap Throw functionality, allowing windows to snap to screen edges with customizable settings.

## Mod authorship

This mod was created by:

- [x] Manually by the submitter (with help of AI assistance)

## Notes

Requires the **Slick Window Arrangement** mod to work. This mod hooks into
the sliding animation that Slick Window Arrangement produces, and triggers
native Windows snapping when the window hits a screen edge with enough velocity.

Snap zones:
- Left / right edge: 50% snap
- Top edge: maximize
- Corners: 25% quarter snap (no Snap Assist popup)