### PR TITLE
Add dynamic transparency for maximized windows and update default settings

### DIFF
--- a/mods/taskbar-background-helper.wh.cpp
+++ b/mods/taskbar-background-helper.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-background-helper
 // @name            Taskbar Background Helper
 // @description     Sets the taskbar background for the transparent parts, always or only when there's a maximized window, designed to be used with Windows 11 Taskbar Styler
-// @version         1.2
+// @version         1.3
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -121,6 +121,7 @@ a workaround.
 
 #include <winrt/Windows.UI.ViewManagement.h>
 
+#include <algorithm>
 #include <atomic>
 #include <mutex>
 #include <optional>
@@ -1256,7 +1257,7 @@ void LoadSettings() {
                                         (((DWORD)(BYTE)transparency) << 24));
     g_settings.style.accentColor = accentColor;
     g_settings.style.useMaximizedTransparency = Wh_GetIntSetting(L"color.useMaximizedTransparency");
-    g_settings.style.maximizedTransparency = Wh_GetIntSetting(L"color.maximizedTransparency");
+    g_settings.style.maximizedTransparency = std::clamp(Wh_GetIntSetting(L"color.maximizedTransparency"), 0, 255);
 
     g_settings.onlyWhenMaximized = Wh_GetIntSetting(L"onlyWhenMaximized");
 
@@ -1306,8 +1307,9 @@ void LoadSettings() {
                                  (((DWORD)(BYTE)blue) << 16) |
                                  (((DWORD)(BYTE)transparency) << 24));
 
+        style.accentColor = Wh_GetIntSetting(L"styleForDarkMode.color.accentColor");
         style.useMaximizedTransparency = Wh_GetIntSetting(L"styleForDarkMode.color.useMaximizedTransparency");
-        style.maximizedTransparency = Wh_GetIntSetting(L"styleForDarkMode.color.maximizedTransparency");
+        style.maximizedTransparency = std::clamp(Wh_GetIntSetting(L"styleForDarkMode.color.maximizedTransparency"), 0, 255);
 
         g_settings.darkModeStyle = std::move(style);
     } else {

--- a/mods/taskbar-background-helper.wh.cpp
+++ b/mods/taskbar-background-helper.wh.cpp
@@ -46,20 +46,26 @@ a workaround.
   - acrylicBlur: Acrylic blur
   - color: Color
 - color:
-  - red: 255
+  - red: 0
     $name: Red
-  - green: 127
+  - green: 0
     $name: Green
-  - blue: 39
+  - blue: 0
     $name: Blue
   - accentColor: false
     $name: Current theme accent color
     $description: If enabled, the color values above are ignored
-  - transparency: 128
+  - transparency: 0
     $name: Transparency
+  - useMaximizedTransparency: false
+    $name: Use different transparency when maximized
+    $description: If enabled, a different transparency value is used when there's a maximized window
+  - maximizedTransparency: 150
+    $name: Transparency when maximized
+    $description: Transparency value (0-255) to use when a window is maximized
   $name: Custom color
   $description: Values are between 0 and 255
-- onlyWhenMaximized: true
+- onlyWhenMaximized: false
   $name: Only when maximized
   $description: >-
     Only apply the style when there's a maximized window on the monitor
@@ -86,17 +92,23 @@ a workaround.
     - acrylicBlur: Acrylic blur
     - color: Color
   - color:
-    - red: 255
+    - red: 0
       $name: Red
-    - green: 127
+    - green: 0
       $name: Green
-    - blue: 39
+    - blue: 0
       $name: Blue
     - accentColor: false
       $name: Current theme accent color
       $description: If enabled, the color values above are ignored
-    - transparency: 128
+    - transparency: 0
       $name: Transparency
+    - useMaximizedTransparency: false
+      $name: Use different transparency when maximized
+      $description: If enabled, a different transparency value is used when there's a maximized window
+    - maximizedTransparency: 150
+      $name: Transparency when maximized
+      $description: Transparency value (0-255) to use when a window is maximized
     $name: Custom color
     $description: Values are between 0 and 255
   $name: Dark mode
@@ -127,6 +139,8 @@ struct TaskbarStyle {
     BackgroundStyle backgroundStyle;
     COLORREF color;
     bool accentColor;
+    bool useMaximizedTransparency;
+    int maximizedTransparency;
 };
 
 struct {
@@ -427,7 +441,7 @@ class SpecialViewModeState {
 
 SpecialViewModeState g_specialViewMode;
 
-BOOL SetTaskbarStyle(HWND hWnd) {
+BOOL SetTaskbarStyle(HWND hWnd, bool hasMaximized = true) {
     Wh_Log(L">");
 
     TaskbarStyle& style =
@@ -453,6 +467,9 @@ BOOL SetTaskbarStyle(HWND hWnd) {
     }
 
     COLORREF color = style.color;
+    if (style.useMaximizedTransparency && hasMaximized) {
+        color = (color & 0x00FFFFFF) | (((DWORD)(BYTE)style.maximizedTransparency) << 24);
+    }
     if (style.accentColor) {
         try {
             const winrt::Windows::UI::ViewManagement::UISettings uiSettings;
@@ -608,25 +625,30 @@ void UpdateTaskbarStyleForMonitor(HMONITOR monitor, bool hasMaximized) {
         return;
     }
 
-    if (hasMaximized) {
-        SetTaskbarStyle(hMMTaskbarWnd);
+    if (g_settings.onlyWhenMaximized) {
+        if (hasMaximized) {
+            SetTaskbarStyle(hMMTaskbarWnd, true);
+        } else {
+            ResetTaskbarStyle(hMMTaskbarWnd);
+        }
     } else {
-        ResetTaskbarStyle(hMMTaskbarWnd);
+        SetTaskbarStyle(hMMTaskbarWnd, hasMaximized);
     }
 }
 
 BOOL ApplyTaskbarStyleForWindow(HWND hWnd) {
-    if (!g_settings.onlyWhenMaximized) {
-        return SetTaskbarStyle(hWnd);
-    }
-
     HMONITOR monitor = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
-    if (g_specialViewMode.IsActive() ||
-        !g_monitorState.HasMaximizedWindow(monitor)) {
-        return ResetTaskbarStyle(hWnd);
+    bool hasMaximized = !g_specialViewMode.IsActive() &&
+                        g_monitorState.HasMaximizedWindow(monitor);
+
+    if (g_settings.onlyWhenMaximized) {
+        if (!hasMaximized) {
+            return ResetTaskbarStyle(hWnd);
+        }
+        return SetTaskbarStyle(hWnd, true);
     }
 
-    return SetTaskbarStyle(hWnd);
+    return SetTaskbarStyle(hWnd, hasMaximized);
 }
 
 void EnsureMonitoringThreadStarted();
@@ -1164,8 +1186,19 @@ void PopulateMonitorState() {
         reinterpret_cast<LPARAM>(&enumWindowsProc));
 }
 
+bool NeedsMonitoringThread() {
+    if (g_settings.onlyWhenMaximized) {
+        return true;
+    }
+    TaskbarStyle& style =
+        (g_settings.darkModeStyle && IsWindowsDarkModeEnabled())
+            ? *g_settings.darkModeStyle
+            : g_settings.style;
+    return style.useMaximizedTransparency;
+}
+
 void EnsureMonitoringThreadStarted() {
-    if (!g_settings.onlyWhenMaximized || g_winEventHookThread) {
+    if (!NeedsMonitoringThread() || g_winEventHookThread) {
         return;
     }
 
@@ -1222,6 +1255,8 @@ void LoadSettings() {
                                         (((DWORD)(BYTE)blue) << 16) |
                                         (((DWORD)(BYTE)transparency) << 24));
     g_settings.style.accentColor = accentColor;
+    g_settings.style.useMaximizedTransparency = Wh_GetIntSetting(L"color.useMaximizedTransparency");
+    g_settings.style.maximizedTransparency = Wh_GetIntSetting(L"color.maximizedTransparency");
 
     g_settings.onlyWhenMaximized = Wh_GetIntSetting(L"onlyWhenMaximized");
 
@@ -1270,6 +1305,9 @@ void LoadSettings() {
         style.color = (COLORREF)((BYTE)red | ((WORD)((BYTE)green) << 8) |
                                  (((DWORD)(BYTE)blue) << 16) |
                                  (((DWORD)(BYTE)transparency) << 24));
+
+        style.useMaximizedTransparency = Wh_GetIntSetting(L"styleForDarkMode.color.useMaximizedTransparency");
+        style.maximizedTransparency = Wh_GetIntSetting(L"styleForDarkMode.color.maximizedTransparency");
 
         g_settings.darkModeStyle = std::move(style);
     } else {


### PR DESCRIPTION
This PR adds support for using a different transparency value when a maximized window is present on the monitor. This is useful for users who want a fully transparent taskbar normally, but a tinted/opaque taskbar when a window is maximized — without relying on the existing `onlyWhenMaximized` toggle that completely removes/applies the style.

---

### Policy and authorship note:

This PR is submitted as a technical proposal for the original mod author.

I understand that, per repository policy for mod updates, the official update should be published by the original author (matching the mod metadata github value). This PR is not intended to replace authorship, but to provide a complete and reviewable implementation that the original author can replicate, adapt, or cherry-pick for a future official update.

To keep review simple and policy-friendly, the changes are scoped to a single mod file only.

---

### New settings added (both in general and dark mode sections):

- **`useMaximizedTransparency`** (bool, default: `false`) — Enables the dynamic transparency feature.
- **`maximizedTransparency`** (0–255, default: `150`) — The transparency value to use when a maximized window is detected.

### Behavior:

- If `useMaximizedTransparency` is **disabled**, behavior is identical to the current version (full backward compatibility).
- If `useMaximizedTransparency` is **enabled**:
  - When `onlyWhenMaximized = true`: The existing apply/reset logic is preserved; `maximizedTransparency` overrides the alpha when applying.
  - When `onlyWhenMaximized = false`: The style is always applied, but the alpha channel dynamically switches between the normal `transparency` and `maximizedTransparency` based on whether a maximized window exists.
- Special view modes (Peek, Multitasking View / Win+Tab) are respected — they temporarily force the non-maximized transparency.
- The monitoring thread is now also started when `useMaximizedTransparency` is enabled (previously only started for `onlyWhenMaximized`).

### Default value changes:

- `onlyWhenMaximized`: `true` → `false`
- `color` (red, green, blue): `255/127/39` → `0/0/0`
- `transparency`: `128` → `0`

These defaults apply to both the general and dark mode color sections.

### Compatibility by background style:

- **Blur** — 🚫 (Transparency levels are not supported by the base Blur style implementation)
- **Acrylic Blur** — ✅
- **Color** — ✅

> **Note on Blur style:** The "Blur" background style does not natively support adjustable transparency levels in this mod's base implementation. While the new dynamic logic is applied, the visual transparency level will remain constant for this specific style. However, the feature works perfectly for both **Acrylic Blur** and **Color** modes.
---

### Mod authorship
If the submission is a new mod, please fill the form below.

This mod was created by:

- [x] Manually by the submitter (with or without AI assistance)
- [ ] Claude Code
- [ ] ChatGPT
- [ ] Gemini
- [ ] Another AI (please specify):
- [ ] Other (please specify):

Please select the appropriate option. Your selection will not affect acceptance criteria, but will help reviewers understand the context of the code and provide relevant feedback.

---

### Demos:
- [Background Style: Acrylic Blur](https://youtu.be/EA5ZfJRsxA8)
- [Background Style: Color](https://youtu.be/6SLkXqcDy14)