### PR TITLE
Taskbar Thumbnail Reorder v1.1.4

### DIFF
--- a/mods/taskbar-thumbnail-reorder.wh.cpp
+++ b/mods/taskbar-thumbnail-reorder.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-thumbnail-reorder
 // @name            Taskbar Thumbnail Reorder
 // @description     Reorder taskbar thumbnails with the left mouse button
-// @version         1.1.3
+// @version         1.1.4
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -28,17 +28,6 @@ Reorder taskbar thumbnails with the left mouse button.
 
 Only Windows 10 64-bit and Windows 11 are supported. For older Windows versions
 check out [7+ Taskbar Tweaker](https://tweaker.ramensoftware.com/).
-
-**Note:** To customize the old taskbar on Windows 11 (if using ExplorerPatcher
-or a similar tool), enable the relevant option in the mod's settings.
-
-## Known limitations
-
-* When the new thumbnail previews implementation in Windows 11 is used, and when
-  labels are shown, each reordering operation causes the thumbnail previews to
-  be closed. This seems to be a bug in Windows 11, it also happens when closing
-  items with the x button or via middle click. I couldn't find a workaround,
-  hopefully it will be fixed by Microsoft in one of the next updates.
 
 ![demonstration](https://i.imgur.com/wGGe2RS.gif)
 */
@@ -612,6 +601,39 @@ void* WINAPI TaskItemThumbnail_TaskItemThumbnail_Hook(void* param1,
     return result;
 }
 
+using TaskItemThumbnail_TaskItemThumbnail_2_t = void*(WINAPI*)(void* param1,
+                                                               void* param2,
+                                                               void* taskGroup,
+                                                               void* taskItem,
+                                                               void* taskListUi,
+                                                               void* param6,
+                                                               bool param7);
+TaskItemThumbnail_TaskItemThumbnail_2_t
+    TaskItemThumbnail_TaskItemThumbnail_2_Original;
+void* WINAPI TaskItemThumbnail_TaskItemThumbnail_2_Hook(void* param1,
+                                                        void* param2,
+                                                        void* taskGroup,
+                                                        void* taskItem,
+                                                        void* taskListUi,
+                                                        void* param6,
+                                                        bool param7) {
+    Wh_Log(L">");
+
+    void* result = TaskItemThumbnail_TaskItemThumbnail_2_Original(
+        param1, param2, taskGroup, taskItem, taskListUi, param6, param7);
+
+    winrt::Windows::Foundation::IInspectable obj = nullptr;
+    ((IUnknown*)result + 2)
+        ->QueryInterface(
+            winrt::guid_of<winrt::Windows::Foundation::IInspectable>(),
+            winrt::put_abi(obj));
+
+    g_thumbnailTaskItemMapping.push_back(
+        ThumbnailTaskItemMapping{obj, taskGroup, taskItem});
+
+    return result;
+}
+
 using TaskGroup_Thumbnails_t = void*(WINAPI*)(void* pThis, void* param1);
 TaskGroup_Thumbnails_t TaskGroup_Thumbnails_Original;
 void* WINAPI TaskGroup_Thumbnails_Hook(void* pThis, void* param1) {
@@ -900,6 +922,23 @@ int WINAPI TaskItemThumbnailList_OnPointerMoved_Hook(void* pThis, void* pArgs) {
     return original();
 }
 
+using FlyoutFrame_UpdateFlyoutPosition_t = void(WINAPI*)(void* pThis);
+FlyoutFrame_UpdateFlyoutPosition_t FlyoutFrame_UpdateFlyoutPosition_Original;
+void WINAPI FlyoutFrame_UpdateFlyoutPosition_Hook(void* pThis) {
+    // Skip the call entirely until the reorder completes. Otherwise, if labels
+    // are shown, the thumbnail flyout moves off-screen and disappears. That
+    // seems to be a Windows bug, happens with middle-click too.
+    if (g_reorderingXamlThumbnails) {
+        if (GetCapture()) {
+            return;
+        }
+
+        g_reorderingXamlThumbnails = false;
+    }
+
+    FlyoutFrame_UpdateFlyoutPosition_Original(pThis);
+}
+
 using DPA_GetPtr_t = decltype(&DPA_GetPtr);
 DPA_GetPtr_t DPA_GetPtr_Original;
 PVOID WINAPI DPA_GetPtr_Hook(HDPA hdpa, INT_PTR i) {
@@ -983,9 +1022,17 @@ bool HookTaskbarSymbols() {
                 CTaskListThumbnailWnd_v_WndProc_Hook,
             },
             {
+                // An older variant, see the newer variant below.
                 {LR"(public: __cdecl winrt::WindowsUdk::UI::Shell::implementation::TaskItemThumbnail::TaskItemThumbnail(struct winrt::WindowsUdk::UI::Shell::TaskItem const &,struct ITaskGroup *,struct ITaskItem *,struct ITaskListUI *,struct IWICImagingFactory *,struct ITaskListAcc *,bool))"},
                 &TaskItemThumbnail_TaskItemThumbnail_Original,
                 TaskItemThumbnail_TaskItemThumbnail_Hook,
+                true,  // New XAML thumbnails, enabled in late Windows 11 24H2.
+            },
+            {
+                // A newer variant seen in Windows 11 version 10.0.26100.8328.
+                {LR"(public: __cdecl winrt::WindowsUdk::UI::Shell::implementation::TaskItemThumbnail::TaskItemThumbnail(struct winrt::WindowsUdk::UI::Shell::TaskItem const &,struct ITaskGroup *,struct ITaskItem *,struct ITaskListUI *,struct IWICImagingFactory *,bool))"},
+                &TaskItemThumbnail_TaskItemThumbnail_2_Original,
+                TaskItemThumbnail_TaskItemThumbnail_2_Hook,
                 true,  // New XAML thumbnails, enabled in late Windows 11 24H2.
             },
             {
@@ -1035,6 +1082,12 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
             {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskItemThumbnailList,struct winrt::Windows::UI::Xaml::Controls::IControlOverrides>::OnPointerMoved(void *))"},
             &TaskItemThumbnailList_OnPointerMoved_Original,
             TaskItemThumbnailList_OnPointerMoved_Hook,
+            true,  // New XAML thumbnails, enabled in late Windows 11 24H2.
+        },
+        {
+            {LR"(private: void __cdecl winrt::Taskbar::implementation::FlyoutFrame::UpdateFlyoutPosition(void))"},
+            &FlyoutFrame_UpdateFlyoutPosition_Original,
+            FlyoutFrame_UpdateFlyoutPosition_Hook,
             true,  // New XAML thumbnails, enabled in late Windows 11 24H2.
         },
     };


### PR DESCRIPTION
* Fixed: If labels are shown, each reordering operation caused the thumbnail previews to be closed.
* Fixed compatibility with update KB5083631 for Windows 11 version 25H2.