### PR TITLE
Support SystemTray.dll for taskbar desktop indicator

### DIFF
--- a/mods/taskbar-desktop-indicator.wh.cpp
+++ b/mods/taskbar-desktop-indicator.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-desktop-indicator
 // @name            Taskbar Desktop Indicator
 // @description     Displays the current virtual desktop as a number or marker in the Windows 11 taskbar clock area
-// @version         1.2.1
+// @version         1.2.2
 // @author          Simon Benedict
 // @github          https://github.com/simon-ami
 // @include         explorer.exe
@@ -244,7 +244,7 @@ struct VirtualDesktopNotificationObject {
 WinVersion g_winVersion = WinVersion::Unsupported;
 WORD g_explorerBuildNumber = 0;
 WORD g_explorerRevisionNumber = 0;
-std::atomic<bool> g_taskbarViewDllLoaded = false;
+std::atomic<bool> g_systemTrayModuleHooked = false;
 std::atomic<bool> g_unloading = false;
 std::atomic<int> g_currentDesktopNumber = 1;
 std::atomic<int> g_pollIntervalMs = 0;
@@ -2043,8 +2043,24 @@ HRESULT WINAPI BadgeIconContent_get_ViewModel_Hook(LPVOID pThis, LPVOID pArgs) {
     return hr;
 }
 
-HMODULE GetTaskbarViewModuleHandle() {
-    HMODULE module = GetModuleHandleW(L"Taskbar.View.dll");
+HMODULE GetSystemTrayModuleHandle() {
+    HMODULE module = GetModuleHandleW(L"SystemTray.dll");
+
+    if (!module) {
+        module = GetModuleHandleW(L"Taskbar.View.dll");
+        // First known Taskbar.View.dll version without SystemTray symbols:
+        // 2604.8002.200.6000.
+        if (module) {
+            VS_FIXEDFILEINFO* fixedFileInfo = GetModuleVersionInfo(module, nullptr);
+            WORD moduleMajor =
+                fixedFileInfo ? HIWORD(fixedFileInfo->dwFileVersionMS) : 0;
+
+            if (!moduleMajor || moduleMajor >= 2604) {
+                Wh_Log(L"Skipping Taskbar.View.dll version %d", moduleMajor);
+                module = nullptr;
+            }
+        }
+    }
     if (!module) {
         module = GetModuleHandleW(L"ExplorerExtensions.dll");
     }
@@ -2052,9 +2068,9 @@ HMODULE GetTaskbarViewModuleHandle() {
     return module;
 }
 
-bool HookTaskbarViewDllSymbols(HMODULE module) {
-    // Taskbar.View.dll, ExplorerExtensions.dll
-    WindhawkUtils::SYMBOL_HOOK taskbarViewHooks[] = {
+bool HookSystemTraySymbols(HMODULE module) {
+    // SystemTray.dll, Taskbar.View.dll, ExplorerExtensions.dll
+    WindhawkUtils::SYMBOL_HOOK systemTrayHooks[] = {
         {
             {LR"(private: void __cdecl winrt::SystemTray::implementation::ClockSystemTrayIconDataModel::RefreshIcon(class SystemTrayTelemetry::ClockUpdate &))"},
             &ClockSystemTrayIconDataModel_RefreshIcon_Original,
@@ -2080,8 +2096,21 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
         },
     };
 
-    if (!HookSymbols(module, taskbarViewHooks, ARRAYSIZE(taskbarViewHooks))) {
+    if (!HookSymbols(module, systemTrayHooks, ARRAYSIZE(systemTrayHooks))) {
         Wh_Log(L"HookSymbols failed");
+        return false;
+    }
+
+    return true;
+}
+
+bool TryHookSystemTrayModule(HMODULE module) {
+    if (!module || g_systemTrayModuleHooked.exchange(true)) {
+        return false;
+    }
+
+    if (!HookSystemTraySymbols(module)) {
+        g_systemTrayModuleHooked = false;
         return false;
     }
 
@@ -2212,15 +2241,20 @@ void RefreshLiveTaskbarClock() {
         reinterpret_cast<LPARAM>(&enumWindowsProc));
 }
 
-void HandleLoadedModuleIfTaskbarView(HMODULE module, LPCWSTR moduleName) {
-    if (g_winVersion >= WinVersion::Win11 && !g_taskbarViewDllLoaded &&
-        GetTaskbarViewModuleHandle() == module &&
-        !g_taskbarViewDllLoaded.exchange(true)) {
-        Wh_Log(L"Loaded %s", moduleName);
-        if (HookTaskbarViewDllSymbols(module)) {
-            Wh_ApplyHookOperations();
-            RefreshLiveTaskbarClock();
-        }
+void HandleLoadedModuleIfSystemTray(HMODULE module, LPCWSTR moduleName) {
+    if (g_winVersion < WinVersion::Win11 || g_systemTrayModuleHooked) {
+        return;
+    }
+
+    if (GetSystemTrayModuleHandle() != module) {
+        return;
+    }
+
+    Wh_Log(L"Loaded %s", moduleName);
+
+    if (TryHookSystemTrayModule(module)) {
+        Wh_ApplyHookOperations();
+        RefreshLiveTaskbarClock();
     }
 }
 
@@ -2232,7 +2266,7 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR libFileName,
                                    DWORD flags) {
     HMODULE module = LoadLibraryExW_Original(libFileName, file, flags);
     if (module) {
-        HandleLoadedModuleIfTaskbarView(module, libFileName);
+        HandleLoadedModuleIfSystemTray(module, libFileName);
     }
 
     return module;
@@ -2318,11 +2352,12 @@ BOOL Wh_ModInit() {
 
     HookExplorerExeSymbols();
 
-    if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
-        g_taskbarViewDllLoaded = true;
-        if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
-            return FALSE;
+    if (HMODULE systemTrayModule = GetSystemTrayModuleHandle()) {
+        if (!TryHookSystemTrayModule(systemTrayModule)) {
+            Wh_Log(L"System tray symbols not found in initial module");
         }
+    } else {
+        Wh_Log(L"System tray module not loaded yet");
     }
 
     HMODULE kernelBaseModule = GetModuleHandleW(L"kernelbase.dll");
@@ -2348,10 +2383,9 @@ void Wh_ModSettingsChanged() {
 }
 
 void Wh_ModAfterInit() {
-    if (g_winVersion >= WinVersion::Win11 && !g_taskbarViewDllLoaded) {
-        if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
-            if (!g_taskbarViewDllLoaded.exchange(true) &&
-                HookTaskbarViewDllSymbols(taskbarViewModule)) {
+    if (g_winVersion >= WinVersion::Win11 && !g_systemTrayModuleHooked) {
+        if (HMODULE systemTrayModule = GetSystemTrayModuleHandle()) {
+            if (TryHookSystemTrayModule(systemTrayModule)) {
                 Wh_ApplyHookOperations();
             }
         }

--- a/mods/taskbar-desktop-indicator.wh.cpp
+++ b/mods/taskbar-desktop-indicator.wh.cpp
@@ -2069,9 +2069,8 @@ HMODULE GetSystemTrayModuleHandle() {
 }
 
 bool HookSystemTraySymbols(HMODULE module) {
-    // Hooks SystemTray.dll when available; falls back to the modules below.
-    // Taskbar.View.dll, ExplorerExtensions.dll
-    WindhawkUtils::SYMBOL_HOOK trayHooks[] = {
+    // SystemTray.dll, Taskbar.View.dll, ExplorerExtensions.dll
+    WindhawkUtils::SYMBOL_HOOK systemTrayHooks[] = {
         {
             {LR"(private: void __cdecl winrt::SystemTray::implementation::ClockSystemTrayIconDataModel::RefreshIcon(class SystemTrayTelemetry::ClockUpdate &))"},
             &ClockSystemTrayIconDataModel_RefreshIcon_Original,
@@ -2097,7 +2096,7 @@ bool HookSystemTraySymbols(HMODULE module) {
         },
     };
 
-    if (!HookSymbols(module, trayHooks, ARRAYSIZE(trayHooks))) {
+    if (!HookSymbols(module, systemTrayHooks, ARRAYSIZE(systemTrayHooks))) {
         Wh_Log(L"HookSymbols failed");
         return false;
     }
@@ -2255,7 +2254,6 @@ void HandleLoadedModuleIfSystemTray(HMODULE module, LPCWSTR moduleName) {
 
     if (TryHookSystemTrayModule(module)) {
         Wh_ApplyHookOperations();
-        RefreshLiveTaskbarClock();
     }
 }
 
@@ -2356,6 +2354,7 @@ BOOL Wh_ModInit() {
     if (HMODULE systemTrayModule = GetSystemTrayModuleHandle()) {
         if (!TryHookSystemTrayModule(systemTrayModule)) {
             Wh_Log(L"System tray symbols not found in initial module");
+            return FALSE;
         }
     } else {
         Wh_Log(L"System tray module not loaded yet");

--- a/mods/taskbar-desktop-indicator.wh.cpp
+++ b/mods/taskbar-desktop-indicator.wh.cpp
@@ -2069,8 +2069,9 @@ HMODULE GetSystemTrayModuleHandle() {
 }
 
 bool HookSystemTraySymbols(HMODULE module) {
-    // SystemTray.dll, Taskbar.View.dll, ExplorerExtensions.dll
-    WindhawkUtils::SYMBOL_HOOK systemTrayHooks[] = {
+    // Hooks SystemTray.dll when available; falls back to the modules below.
+    // Taskbar.View.dll, ExplorerExtensions.dll
+    WindhawkUtils::SYMBOL_HOOK trayHooks[] = {
         {
             {LR"(private: void __cdecl winrt::SystemTray::implementation::ClockSystemTrayIconDataModel::RefreshIcon(class SystemTrayTelemetry::ClockUpdate &))"},
             &ClockSystemTrayIconDataModel_RefreshIcon_Original,
@@ -2096,7 +2097,7 @@ bool HookSystemTraySymbols(HMODULE module) {
         },
     };
 
-    if (!HookSymbols(module, systemTrayHooks, ARRAYSIZE(systemTrayHooks))) {
+    if (!HookSymbols(module, trayHooks, ARRAYSIZE(trayHooks))) {
         Wh_Log(L"HookSymbols failed");
         return false;
     }


### PR DESCRIPTION
Adds compatibility for newer Windows 11 builds where the taskbar SystemTray symbols moved to SystemTray.dll.

The mod now tries SystemTray.dll first, then falls back to Taskbar.View.dll and ExplorerExtensions.dll for older builds. It also keeps the existing post-init refresh/update path intact and guards the hook attempt so it won't install the same hooks twice.

Tested on my older Taskbar.View.dll path without regressions. @Meteony tested the SystemTray.dll path on a newer build and confirmed it works.

Fixes #3926

<!-- ⚠️ Please don't remove the template below. Add your content above the template. -->

## Changelog

If the submission is an update to an existing mod, include the changelog below:

* Added support for newer Windows 11 builds where taskbar SystemTray symbols are in SystemTray.dll.
* Kept fallback support for older Taskbar.View.dll and ExplorerExtensions.dll builds.

## Mod authorship

If the submission is a new mod, please fill the form below.

This mod was created by:

- - [ ] Manually by the submitter (with or without AI assistance)
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the appropriate option. Your selection will not affect acceptance criteria, but will help reviewers understand the context of the code and provide relevant feedback.