### PR TITLE
Add mod: Ctrl+Backspace Fix for Win32 Text Boxes

### DIFF
--- a/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
+++ b/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
@@ -155,7 +155,7 @@ bool IsEditControl(HWND hWnd)
 
         // Fallback for .NET WinForms wrapped Edit controls
         // Required for those within PropertyGrid controls that swallow the
-        // message query
+        // WM_GETDLGCODE query.
         if (_wcsnicmp(szClassName, L"WindowsForms10.EDIT.", 20) == 0)
         {
             return true;

--- a/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
+++ b/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
@@ -152,6 +152,14 @@ bool IsEditControl(HWND hWnd)
             }
             return true;
         }
+
+        // Fallback for .NET WinForms wrapped Edit controls
+        // Required for those within PropertyGrid controls that swallow the
+        // message query
+        if (_wcsnicmp(szClassName, L"WindowsForms10.EDIT.", 20) == 0)
+        {
+            return true;
+        }
     }
     return false;
 }

--- a/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
+++ b/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
@@ -275,6 +275,8 @@ BOOL WINAPI TranslateMessage_Hook(const MSG *lpMsg)
 // Mod initialization
 BOOL Wh_ModInit()
 {
+    Wh_Log(L"Init");
+
     WindhawkUtils::SetFunctionHook(
         DispatchMessageW,
         DispatchMessageW_Hook,

--- a/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
+++ b/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
@@ -22,11 +22,11 @@ It also supports wrapped `Edit` controls used in .NET WinForms and Delphi VCL
 applications.
 
 | Before |
-| ------ |
+| :----- |
 | ![](https://raw.githubusercontent.com/AromaKitsune/My-Windhawk-Mods/main/screenshots/ctrl-backspace-fix-for-win32-text-boxes_before.gif) |
 
 | After |
-| ----- |
+| :---- |
 | ![](https://raw.githubusercontent.com/AromaKitsune/My-Windhawk-Mods/main/screenshots/ctrl-backspace-fix-for-win32-text-boxes_after.gif) |
 
 ## Notes

--- a/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
+++ b/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
@@ -139,8 +139,8 @@ bool IsEditControl(HWND hWnd)
 
         // Query the UI framework to reveal a wrapped Edit control
         // Common class names for such controls:
-        // - WindowsForms10.EDIT.app.* | .NET WinForms
-        // - TEdit, TMemo, T*Edit      | Delphi VCL
+        // - WindowsForms10.EDIT.* | .NET WinForms
+        // - TEdit, TMemo, T*Edit  | Delphi VCL
         LRESULT lResult = SendMessageW(hWnd, WM_GETDLGCODE, 0, 0);
         if (lResult & DLGC_HASSETSEL)
         {

--- a/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
+++ b/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
@@ -2,7 +2,7 @@
 // @id              ctrl-backspace-fix-for-win32-text-boxes
 // @name            Ctrl+Backspace Fix for Win32 Text Boxes
 // @description     Makes Ctrl+Backspace delete the previous word in Win32 text boxes instead of inserting a control character
-// @version         0.1-beta37
+// @version         1.0
 // @author          Kitsune
 // @github          https://github.com/AromaKitsune
 // @include         *

--- a/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
+++ b/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
@@ -1,0 +1,301 @@
+// ==WindhawkMod==
+// @id              ctrl-backspace-fix-for-win32-text-boxes
+// @name            Ctrl+Backspace Fix for Win32 Text Boxes
+// @description     Makes Ctrl+Backspace delete the previous word in Win32 text boxes instead of inserting a control character
+// @version         0.1-beta37
+// @author          Kitsune
+// @github          https://github.com/AromaKitsune
+// @include         *
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Ctrl+Backspace Fix for Win32 Text Boxes
+Win32 text boxes often lack previous-word deletion functionality, resulting in
+the `Ctrl+Backspace` hotkey inserting the `Delete` control character instead of
+deleting the previous word.
+
+This mod resolves this behavior by adding previous-word deletion functionality
+to those `Edit` controls.
+
+It also supports wrapped `Edit` controls used in .NET WinForms and Delphi VCL
+applications.
+
+| Before |
+| ------ |
+| ![](https://raw.githubusercontent.com/AromaKitsune/My-Windhawk-Mods/main/screenshots/ctrl-backspace-fix-for-win32-text-boxes_before.gif) |
+
+| After |
+| ----- |
+| ![](https://raw.githubusercontent.com/AromaKitsune/My-Windhawk-Mods/main/screenshots/ctrl-backspace-fix-for-win32-text-boxes_after.gif) |
+
+## Notes
+* In hotkey text boxes, pressing `Ctrl+Backspace` deletes the text instead of
+  assigning the hotkey.
+* In masked text boxes, pressing `Ctrl+Backspace` deletes the placeholder
+  characters, breaking the input mask and preventing further input into those
+  missing slots.
+* Custom-drawn text boxes, such as those in Qt applications, are unaffected
+  because they do not utilize standard Win32 `Edit` controls. Most custom-drawn
+  UI frameworks already handle their own previous-word deletion functionality.
+*/
+// ==/WindhawkModReadme==
+
+#include <windhawk_utils.h>
+#include <windows.h>
+#include <cwctype>
+#include <string>
+
+enum class CharClass {
+    Whitespace,
+    Alphanumeric,
+    Punctuation
+};
+
+// Helper: Determine the character class to calculate word boundaries
+CharClass GetCharClass(WCHAR wch)
+{
+    // Whitespace
+    if (iswspace(wch)) return CharClass::Whitespace;
+
+    // VS Code's default word separators
+    constexpr const WCHAR* szWordSeparators =
+        L"`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?";
+    if (wcschr(szWordSeparators, wch) != nullptr)
+    {
+        return CharClass::Punctuation;
+    }
+
+    // Everything else is grouped as a word
+    return CharClass::Alphanumeric;
+}
+
+// Helper: Calculate the previous word boundary and delete the text block
+void DeletePreviousWord(HWND hWnd)
+{
+    // Retrieve the starting and ending positions of the current text selection
+    DWORD dwSelectionStart, dwSelectionEnd;
+    SendMessageW(hWnd, EM_GETSEL, reinterpret_cast<WPARAM>(&dwSelectionStart),
+        reinterpret_cast<LPARAM>(&dwSelectionEnd));
+
+    // Replace any active text selection with an empty string
+    if (dwSelectionStart != dwSelectionEnd)
+    {
+        SendMessageW(hWnd, EM_REPLACESEL, TRUE, reinterpret_cast<LPARAM>(L""));
+        return;
+    }
+
+    // Allocate a string buffer and retrieve the text to calculate the boundary
+    int cchTextLen = GetWindowTextLengthW(hWnd);
+    if (cchTextLen == 0 || dwSelectionStart == 0) return;
+
+    std::wstring windowText(cchTextLen, L'\0');
+    GetWindowTextW(hWnd, windowText.data(), cchTextLen + 1);
+    int iPos = dwSelectionStart - 1;
+
+    // Step back through all whitespace characters
+    while (iPos >= 0 && GetCharClass(windowText[iPos]) == CharClass::Whitespace)
+    {
+        iPos--;
+    }
+
+    if (iPos >= 0)
+    {
+        // Identify the character class to delete
+        CharClass targetCharClass = GetCharClass(windowText[iPos]);
+
+        // Step back through all characters of the same class
+        while (iPos >= 0 && GetCharClass(windowText[iPos]) == targetCharClass)
+        {
+            iPos--;
+        }
+    }
+
+    // Calculate the final text selection boundary
+    DWORD dwNewSelStart = iPos + 1;
+
+    // Pause re-drawing to hide the text selection flicker
+    SendMessageW(hWnd, WM_SETREDRAW, FALSE, 0);
+
+    // Select the calculated word bounds and replace with an empty string
+    SendMessageW(hWnd, EM_SETSEL, dwNewSelStart, dwSelectionEnd);
+    SendMessageW(hWnd, EM_REPLACESEL, TRUE, reinterpret_cast<LPARAM>(L""));
+
+    // Resume re-drawing and force a re-paint to display the updated text
+    SendMessageW(hWnd, WM_SETREDRAW, TRUE, 0);
+    InvalidateRect(hWnd, nullptr, TRUE);
+}
+
+// Helper: Identify the target Edit control
+bool IsEditControl(HWND hWnd)
+{
+    WCHAR szClassName[64];
+    if (GetClassNameW(hWnd, szClassName, ARRAYSIZE(szClassName)))
+    {
+        if (_wcsicmp(szClassName, L"Edit") == 0)
+        {
+            return true;
+        }
+
+        // Query the UI framework to reveal a wrapped Edit control
+        // Common class names for such controls:
+        // - WindowsForms10.EDIT.app.* | .NET WinForms
+        // - TEdit, TMemo, T*Edit      | Delphi VCL
+        LRESULT lResult = SendMessageW(hWnd, WM_GETDLGCODE, 0, 0);
+        if (lResult & DLGC_HASSETSEL)
+        {
+            // Exclude RichEdit controls
+            _wcsupr_s(szClassName, ARRAYSIZE(szClassName));
+            if (wcsstr(szClassName, L"RICHEDIT") != nullptr)
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
+// Helper: Validate the Ctrl+Backspace hotkey on a target Edit control
+bool IsCtrlBackspaceOnEditControl(HWND hWnd, UINT uMsg, WPARAM wParam)
+{
+    if (uMsg == WM_KEYDOWN && wParam == VK_BACK &&
+        (GetKeyState(VK_CONTROL) & 0x8000))
+    {
+        LONG_PTR lStyle = GetWindowLongPtrW(hWnd, GWL_STYLE);
+        if ((lStyle & WS_CHILD) == 0)
+        {
+            return false;
+        }
+
+        if (IsEditControl(hWnd))
+        {
+            // Ignore read-only Edit controls
+            if ((lStyle & ES_READONLY) == 0)
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// Hook for DispatchMessageW
+using DispatchMessageW_t = decltype(&DispatchMessageW);
+DispatchMessageW_t DispatchMessageW_Original;
+LRESULT WINAPI DispatchMessageW_Hook(const MSG *lpMsg)
+{
+    if (lpMsg)
+    {
+        if (IsCtrlBackspaceOnEditControl(lpMsg->hwnd, lpMsg->message,
+                lpMsg->wParam))
+        {
+            DeletePreviousWord(lpMsg->hwnd);
+            return 0;
+        }
+    }
+    return DispatchMessageW_Original(lpMsg);
+}
+
+// Hook for DispatchMessageA
+using DispatchMessageA_t = decltype(&DispatchMessageA);
+DispatchMessageA_t DispatchMessageA_Original;
+LRESULT WINAPI DispatchMessageA_Hook(const MSG *lpMsg)
+{
+    if (lpMsg)
+    {
+        if (IsCtrlBackspaceOnEditControl(lpMsg->hwnd, lpMsg->message,
+                lpMsg->wParam))
+        {
+            DeletePreviousWord(lpMsg->hwnd);
+            return 0;
+        }
+    }
+    return DispatchMessageA_Original(lpMsg);
+}
+
+// Hook for IsDialogMessageW
+using IsDialogMessageW_t = decltype(&IsDialogMessageW);
+IsDialogMessageW_t IsDialogMessageW_Original;
+BOOL WINAPI IsDialogMessageW_Hook(HWND hDlg, LPMSG lpMsg)
+{
+    if (lpMsg)
+    {
+        if (IsCtrlBackspaceOnEditControl(lpMsg->hwnd, lpMsg->message,
+                lpMsg->wParam))
+        {
+            DeletePreviousWord(lpMsg->hwnd);
+            return TRUE;
+        }
+    }
+    return IsDialogMessageW_Original(hDlg, lpMsg);
+}
+
+// Hook for IsDialogMessageA
+using IsDialogMessageA_t = decltype(&IsDialogMessageA);
+IsDialogMessageA_t IsDialogMessageA_Original;
+BOOL WINAPI IsDialogMessageA_Hook(HWND hDlg, LPMSG lpMsg)
+{
+    if (lpMsg)
+    {
+        if (IsCtrlBackspaceOnEditControl(lpMsg->hwnd, lpMsg->message,
+                lpMsg->wParam))
+        {
+            DeletePreviousWord(lpMsg->hwnd);
+            return TRUE;
+        }
+    }
+    return IsDialogMessageA_Original(hDlg, lpMsg);
+}
+
+// Hook for TranslateMessage
+using TranslateMessage_t = decltype(&TranslateMessage);
+TranslateMessage_t TranslateMessage_Original;
+BOOL WINAPI TranslateMessage_Hook(const MSG *lpMsg)
+{
+    if (lpMsg)
+    {
+        if (IsCtrlBackspaceOnEditControl(lpMsg->hwnd, lpMsg->message,
+                lpMsg->wParam))
+        {
+            return TRUE;
+        }
+    }
+    return TranslateMessage_Original(lpMsg);
+}
+
+// Mod initialization
+BOOL Wh_ModInit()
+{
+    WindhawkUtils::SetFunctionHook(
+        DispatchMessageW,
+        DispatchMessageW_Hook,
+        &DispatchMessageW_Original
+    );
+
+    WindhawkUtils::SetFunctionHook(
+        DispatchMessageA,
+        DispatchMessageA_Hook,
+        &DispatchMessageA_Original
+    );
+
+    WindhawkUtils::SetFunctionHook(
+        IsDialogMessageW,
+        IsDialogMessageW_Hook,
+        &IsDialogMessageW_Original
+    );
+
+    WindhawkUtils::SetFunctionHook(
+        IsDialogMessageA,
+        IsDialogMessageA_Hook,
+        &IsDialogMessageA_Original
+    );
+
+    WindhawkUtils::SetFunctionHook(
+        TranslateMessage,
+        TranslateMessage_Hook,
+        &TranslateMessage_Original
+    );
+
+    return TRUE;
+}

--- a/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
+++ b/mods/ctrl-backspace-fix-for-win32-text-boxes.wh.cpp
@@ -48,8 +48,8 @@ applications.
 
 enum class CharClass {
     Whitespace,
-    Alphanumeric,
-    Punctuation
+    Punctuation,
+    Alphanumeric
 };
 
 // Helper: Determine the character class to calculate word boundaries

--- a/mods/disk-usage-bar-in-drive-properties.wh.cpp
+++ b/mods/disk-usage-bar-in-drive-properties.wh.cpp
@@ -2,7 +2,7 @@
 // @id              disk-usage-bar-in-drive-properties
 // @name            Disk Usage Bar in Drive Properties
 // @description     Replaces the pie/donut chart in drive properties with a usage bar
-// @version         1.1
+// @version         1.2
 // @author          Kitsune
 // @github          https://github.com/AromaKitsune
 // @include         *
@@ -29,6 +29,12 @@ This mod provides the following options:
   usage exceeds 90%.
 * **Show decimal percentage**: Displays the disk usage percentage text with one
   decimal place (e.g., `64.1%`).
+* **Hide storage management button**: Hides the "Details" (Windows 11) or "Disk
+  Clean-up" (Windows 8.1/10) button.
+  * It is recommended to hide this button for localized systems to prevent a UI
+    collision with a long "Space used" string for the disk usage percentage
+    text.
+  * The `Alt+D` keyboard shortcut remains functional.
 
 ## Supported Windows versions
 * Windows 11
@@ -50,6 +56,9 @@ Based on the "[Disk Pie Chart](https://windhawk.net/mods/disk-pie-chart)" mod by
 - showDecimalPercentage: false
   $name: Show decimal percentage
   $description: Displays the disk usage percentage text with one decimal place (e.g., 64.1%)
+- hideStorageMgmtButton: true
+  $name: Hide storage management button
+  $description: Hides the "Details" (Windows 11) or "Disk Clean-up" (Windows 8.1/10) button
 */
 // ==/WindhawkModSettings==
 
@@ -69,6 +78,7 @@ Based on the "[Disk Pie Chart](https://windhawk.net/mods/disk-pie-chart)" mod by
 struct {
     bool showRedUsageBar;
     bool showDecimalPercentage;
+    bool hideStorageMgmtButton;
 } settings;
 
 // Helper: Restore the AutoRun icon
@@ -162,7 +172,7 @@ void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent,
     DWORD dwUsagePer1000, const RECT& rcChart)
 {
     // Define the unique control ID for the custom usage percentage label
-    const int IDC_USAGE_PERCENT_LABEL = 14999;
+    constexpr int IDC_USAGE_PERCENT_LABEL = 14999;
 
     // Find the static control with the SS_CENTER style
     // Expected text format: "Drive C:" or similar
@@ -276,7 +286,7 @@ void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent,
     {
         // Dynamically resize the label window to fit the text area exactly
         // The label window's default boundary is large, which causes it to draw
-        // over the adjacent horizontal separator and "Details" / "Disk
+        // over the adjacent horizontal separator and "Details" or "Disk
         // Clean-up" button when the text changes.
         HDC hTextDC = GetDC(hLabelWnd);
         HFONT hCurrentFont = reinterpret_cast<HFONT>(
@@ -367,49 +377,50 @@ void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent,
 void HideLegendsAndAlignLabels(HWND hPropPageWnd)
 {
     // Define control IDs for the standard drive storage properties page
-    const int IDC_SHELL32_LEGEND_USED     = 14403;
-    const int IDC_SHELL32_LEGEND_FREE     = 14404;
-    const int IDC_SHELL32_LABEL_USED      = 14416;
-    const int IDC_SHELL32_LABEL_FREE      = 14417;
-    const int IDC_SHELL32_LABEL_CAPACITY  = 14415;
+    constexpr int IDC_SHELL32_LEGEND_USED     = 14403;
+    constexpr int IDC_SHELL32_LEGEND_FREE     = 14404;
+    constexpr int IDC_SHELL32_LABEL_USED      = 14416;
+    constexpr int IDC_SHELL32_LABEL_FREE      = 14417;
+    constexpr int IDC_SHELL32_LABEL_CAPACITY  = 14415;
 
     // Define control IDs for the portable device storage properties page
-    const int IDC_WPDSHEXT_LEGEND_USED    = 834;
-    const int IDC_WPDSHEXT_LEGEND_FREE    = 838;
-    const int IDC_WPDSHEXT_LABEL_USED     = 835;
-    const int IDC_WPDSHEXT_LABEL_FREE     = 839;
-    const int IDC_WPDSHEXT_LABEL_CAPACITY = 843;
+    constexpr int IDC_WPDSHEXT_LEGEND_USED    = 834;
+    constexpr int IDC_WPDSHEXT_LEGEND_FREE    = 838;
+    constexpr int IDC_WPDSHEXT_LABEL_USED     = 835;
+    constexpr int IDC_WPDSHEXT_LABEL_FREE     = 839;
+    constexpr int IDC_WPDSHEXT_LABEL_CAPACITY = 843;
 
     // Handle the standard drive storage properties page
-    HWND hLegendWnd = GetDlgItem(hPropPageWnd, IDC_SHELL32_LEGEND_USED);
-    if (hLegendWnd)
+    HWND hLegendUsedWnd = GetDlgItem(hPropPageWnd, IDC_SHELL32_LEGEND_USED);
+    if (hLegendUsedWnd)
     {
         // Check if the layout has already been adjusted
-        if (IsWindowVisible(hLegendWnd))
+        if (IsWindowVisible(hLegendUsedWnd))
         {
             // Retrieve the X position of the legend window as the margin
-            RECT rcLegendWnd;
-            GetWindowRect(hLegendWnd, &rcLegendWnd);
+            RECT rcLegendUsedWnd;
+            GetWindowRect(hLegendUsedWnd, &rcLegendUsedWnd);
             MapWindowPoints(nullptr, hPropPageWnd,
-                reinterpret_cast<LPPOINT>(&rcLegendWnd), 2);
-            int xLeft = rcLegendWnd.left;
+                reinterpret_cast<LPPOINT>(&rcLegendUsedWnd), 2);
+            int xLeft = rcLegendUsedWnd.left;
 
             // Hide the legend windows
-            ShowWindow(hLegendWnd, SW_HIDE);
+            ShowWindow(hLegendUsedWnd, SW_HIDE);
             HWND hLegendFreeWnd = GetDlgItem(hPropPageWnd,
                 IDC_SHELL32_LEGEND_FREE);
             ShowWindow(hLegendFreeWnd, SW_HIDE);
 
-            // Move the label windows to the left margin
-            const int rgLabelIds[] = {
+            // List the control IDs for the labels
+            constexpr int rgLabelIds[] = {
                 IDC_SHELL32_LABEL_USED,
                 IDC_SHELL32_LABEL_FREE,
                 IDC_SHELL32_LABEL_CAPACITY
             };
 
-            for (int id : rgLabelIds)
+            // Move the label windows to the left margin
+            for (int ctrlId : rgLabelIds)
             {
-                HWND hLabelWnd = GetDlgItem(hPropPageWnd, id);
+                HWND hLabelWnd = GetDlgItem(hPropPageWnd, ctrlId);
                 if (hLabelWnd)
                 {
                     RECT rcLabelWnd;
@@ -425,35 +436,36 @@ void HideLegendsAndAlignLabels(HWND hPropPageWnd)
     }
 
     // Handle the portable device storage properties page
-    hLegendWnd = GetDlgItem(hPropPageWnd, IDC_WPDSHEXT_LEGEND_USED);
-    if (hLegendWnd)
+    hLegendUsedWnd = GetDlgItem(hPropPageWnd, IDC_WPDSHEXT_LEGEND_USED);
+    if (hLegendUsedWnd)
     {
         // Check if the layout has already been adjusted
-        if (IsWindowVisible(hLegendWnd))
+        if (IsWindowVisible(hLegendUsedWnd))
         {
             // Retrieve the X position of the legend window as the margin
-            RECT rcLegendWnd;
-            GetWindowRect(hLegendWnd, &rcLegendWnd);
+            RECT rcLegendUsedWnd;
+            GetWindowRect(hLegendUsedWnd, &rcLegendUsedWnd);
             MapWindowPoints(nullptr, hPropPageWnd,
-                reinterpret_cast<LPPOINT>(&rcLegendWnd), 2);
-            int xLeft = rcLegendWnd.left;
+                reinterpret_cast<LPPOINT>(&rcLegendUsedWnd), 2);
+            int xLeft = rcLegendUsedWnd.left;
 
             // Hide the legend windows
-            ShowWindow(hLegendWnd, SW_HIDE);
+            ShowWindow(hLegendUsedWnd, SW_HIDE);
             HWND hLegendFreeWnd = GetDlgItem(hPropPageWnd,
                 IDC_WPDSHEXT_LEGEND_FREE);
             ShowWindow(hLegendFreeWnd, SW_HIDE);
 
-            // Move the label windows to the left margin
-            const int rgLabelIds[] = {
+            // List the control IDs for the labels
+            constexpr int rgLabelIds[] = {
                 IDC_WPDSHEXT_LABEL_USED,
                 IDC_WPDSHEXT_LABEL_FREE,
                 IDC_WPDSHEXT_LABEL_CAPACITY
             };
 
-            for (int id : rgLabelIds)
+            // Move the label windows to the left margin
+            for (int ctrlId : rgLabelIds)
             {
-                HWND hLabelWnd = GetDlgItem(hPropPageWnd, id);
+                HWND hLabelWnd = GetDlgItem(hPropPageWnd, ctrlId);
                 if (hLabelWnd)
                 {
                     RECT rcLabelWnd;
@@ -466,6 +478,32 @@ void HideLegendsAndAlignLabels(HWND hPropPageWnd)
             }
         }
         return;
+    }
+}
+
+// Helper: Hide the storage management button
+void HideStorageManagementButton(HWND hPropPageWnd)
+{
+    if (!settings.hideStorageMgmtButton) return;
+
+    // List the control IDs for the storage management buttons
+    constexpr int rgStorageMgmtBtnIds[] = {
+        14430, // Details (Windows 11)
+        14428  // Disk Clean-up (Windows 8.1/10)
+    };
+
+    // Hide the storage management button
+    for (int ctrlId : rgStorageMgmtBtnIds)
+    {
+        HWND hStorageMgmtBtn = GetDlgItem(hPropPageWnd, ctrlId);
+        if (hStorageMgmtBtn)
+        {
+            if (IsWindowVisible(hStorageMgmtBtn))
+            {
+                ShowWindow(hStorageMgmtBtn, SW_HIDE);
+            }
+            break;
+        }
     }
 }
 
@@ -514,6 +552,9 @@ void DrawDiskUsageBar(HDC hChartDC, LPCRECT prcChart, DWORD dwUsagePer1000)
 
     // Hide legends and align labels to the left
     HideLegendsAndAlignLabels(hPropPageWnd);
+
+    // Hide the storage management button
+    HideStorageManagementButton(hPropPageWnd);
 
     // Define the usage bar height in Dialog Units
     RECT rcBarDlu = { 0, 0, 0, 14 };
@@ -575,9 +616,7 @@ void DrawDiskUsageBar(HDC hChartDC, LPCRECT prcChart, DWORD dwUsagePer1000)
         reinterpret_cast<LPPOINT>(&rcChartWnd), 2);
     if (!EqualRect(&rcBar, &rcChartWnd))
     {
-        SetWindowPos(hChartWnd, nullptr,
-            rcBar.left, rcBar.top,
-            rcBar.right - rcBar.left, rcBar.bottom - rcBar.top,
+        SetWindowPos(hChartWnd, nullptr, rcBar.left, rcBar.top, cxBar, cyBar,
             SWP_NOZORDER | SWP_NOACTIVATE);
     }
 
@@ -713,6 +752,7 @@ void LoadSettings()
 {
     settings.showRedUsageBar = Wh_GetIntSetting(L"showRedUsageBar");
     settings.showDecimalPercentage = Wh_GetIntSetting(L"showDecimalPercentage");
+    settings.hideStorageMgmtButton = Wh_GetIntSetting(L"hideStorageMgmtButton");
 }
 
 // Mod initialization

--- a/mods/disk-usage-bar-in-drive-properties.wh.cpp
+++ b/mods/disk-usage-bar-in-drive-properties.wh.cpp
@@ -2,11 +2,11 @@
 // @id              disk-usage-bar-in-drive-properties
 // @name            Disk Usage Bar in Drive Properties
 // @description     Replaces the pie/donut chart in drive properties with a usage bar
-// @version         1.0
+// @version         1.1
 // @author          Kitsune
 // @github          https://github.com/AromaKitsune
 // @include         *
-// @compilerOptions -luxtheme -lgdi32
+// @compilerOptions -lgdi32 -luxtheme
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -21,16 +21,19 @@ with a usage bar.
 ## Features
 * Replaces the pie/donut chart with a blue usage bar, like in "This PC".
 * Switches the bar color to red when the disk is almost full.
-* Displays the usage percentage text below the bar.
+* Displays the disk usage percentage text below the bar.
+
+## Configuration
+This mod provides the following options:
+* **Show red bar on low space**: Switches the usage bar color to red when disk
+  usage exceeds 90%.
+* **Show decimal percentage**: Displays the disk usage percentage text with one
+  decimal place (e.g., `64.1%`).
 
 ## Supported Windows versions
 * Windows 11
 * Windows 10
 * Windows 8.1
-
-## Configuration
-You can enable the option to switch the usage bar color to red when disk usage
-exceeds 90%.
 
 ---
 
@@ -42,15 +45,18 @@ Based on the "[Disk Pie Chart](https://windhawk.net/mods/disk-pie-chart)" mod by
 // ==WindhawkModSettings==
 /*
 - showRedUsageBar: false
-  $name: Switch to red bar when disk is almost full
-  $description: Switches the usage bar color to red when disk usage exceeds 90%.
+  $name: Show red bar on low space
+  $description: Switches the usage bar color to red when disk usage exceeds 90%
+- showDecimalPercentage: false
+  $name: Show decimal percentage
+  $description: Displays the disk usage percentage text with one decimal place (e.g., 64.1%)
 */
 // ==/WindhawkModSettings==
 
 #include <windhawk_utils.h>
+#include <shellapi.h>
 #include <uxtheme.h>
 #include <vssym32.h>
-#include <shellapi.h>
 
 #ifdef _WIN64
 #   define SHELL32_DRAWPIE L"DrawPie"
@@ -62,9 +68,10 @@ Based on the "[Disk Pie Chart](https://windhawk.net/mods/disk-pie-chart)" mod by
 
 struct {
     bool showRedUsageBar;
+    bool showDecimalPercentage;
 } settings;
 
-// Helper to restore the AutoRun icon
+// Helper: Restore the AutoRun icon
 // Since Windows 2000, the drive properties dialog never displays the AutoRun
 // icon on the General tab, leaving a blank space.
 // This function restores the AutoRun icon back where it belongs.
@@ -145,12 +152,14 @@ void RestoreCustomDriveIcon(HWND hPropPageWnd)
     if (SHGetFileInfoW(szDriveRoot, 0, &shFileInfo, sizeof(shFileInfo),
             SHGFI_ICON | SHGFI_LARGEICON))
     {
-        SendMessage(hIconWnd, STM_SETICON, (WPARAM)shFileInfo.hIcon, 0);
+        SendMessage(hIconWnd, STM_SETICON,
+            reinterpret_cast<WPARAM>(shFileInfo.hIcon), 0);
     }
 }
 
-// Helper to update the disk usage percentage label below the disk usage bar
-void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent, const RECT& rcChart)
+// Helper: Update the disk usage percentage label below the disk usage bar
+void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent,
+    DWORD dwUsagePer1000, const RECT& rcChart)
 {
     // Define the unique control ID for the custom usage percentage label
     const int IDC_USAGE_PERCENT_LABEL = 14999;
@@ -178,6 +187,7 @@ void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent, const 
     // Create a custom usage percentage label window for the portable device
     // storage properties page
     bool isUsagePercentLabel = false;
+
     if (!hLabelWnd)
     {
         // Check if the custom usage percentage label window has already been
@@ -189,20 +199,23 @@ void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent, const 
         if (!hLabelWnd)
         {
             hLabelWnd = CreateWindowExW(0, L"Static", L"",
-                WS_CHILD | WS_VISIBLE | SS_CENTER | SS_NOPREFIX,
-                0, 0, 0, 0, // Positioned dynamically
-                hPropPageWnd, (HMENU)IDC_USAGE_PERCENT_LABEL,
-                (HINSTANCE)GetWindowLongPtrW(hPropPageWnd, GWLP_HINSTANCE),
+                WS_CHILD | WS_VISIBLE | SS_CENTER | SS_NOPREFIX, 0, 0, 0, 0,
+                hPropPageWnd, reinterpret_cast<HMENU>(IDC_USAGE_PERCENT_LABEL),
+                reinterpret_cast<HINSTANCE>(
+                    GetWindowLongPtrW(hPropPageWnd, GWLP_HINSTANCE)),
                 nullptr);
 
             // Apply the property page's font to the custom usage percentage
             // label window
             if (hLabelWnd)
             {
-                HFONT hPropPageFont = (HFONT)SendMessage(hPropPageWnd, WM_GETFONT, 0, 0);
-                SendMessage(hLabelWnd, WM_SETFONT, (WPARAM)hPropPageFont, TRUE);
+                HFONT hPropPageFont = reinterpret_cast<HFONT>(
+                    SendMessage(hPropPageWnd, WM_GETFONT, 0, 0));
+                SendMessage(hLabelWnd, WM_SETFONT,
+                    reinterpret_cast<WPARAM>(hPropPageFont), TRUE);
             }
         }
+
         isUsagePercentLabel = true;
     }
 
@@ -215,7 +228,8 @@ void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent, const 
         LOAD_LIBRARY_AS_DATAFILE | LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (hPropSys)
     {
-        if (LoadStringW(hPropSys, 38652, szLabelTemplate, ARRAYSIZE(szLabelTemplate)))
+        if (LoadStringW(hPropSys, 38652, szLabelTemplate,
+                ARRAYSIZE(szLabelTemplate)))
         {
             isStringLoaded = true;
         }
@@ -233,9 +247,26 @@ void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent, const 
         lstrcpyW(szLabelTemplate, L"Space used");
     }
 
-    // Format the string: "Space used: 64%"
+    // Buffer for the disk usage percentage text
     WCHAR szUpdatedText[128];
-    wsprintfW(szUpdatedText, L"%s: %u%%", szLabelTemplate, dwUsagePercent);
+    if (settings.showDecimalPercentage)
+    {
+        // Get the system's localized decimal separator
+        WCHAR szDecimalSeparator[4] = L".";
+        GetLocaleInfoW(LOCALE_USER_DEFAULT, LOCALE_SDECIMAL, szDecimalSeparator,
+            ARRAYSIZE(szDecimalSeparator));
+
+        // Format the text with one decimal place
+        // Example: "Space used: 64.1%"
+        wsprintfW(szUpdatedText, L"%s: %u%s%u%%", szLabelTemplate,
+            dwUsagePer1000 / 10, szDecimalSeparator, dwUsagePer1000 % 10);
+    }
+    else
+    {
+        // Format the text as a whole number
+        // Example: "Space used: 64%"
+        wsprintfW(szUpdatedText, L"%s: %u%%", szLabelTemplate, dwUsagePercent);
+    }
 
     // Prevent infinite re-paint loops and flickering by updating only when
     // necessary
@@ -248,11 +279,12 @@ void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent, const 
         // over the adjacent horizontal separator and "Details" / "Disk
         // Clean-up" button when the text changes.
         HDC hTextDC = GetDC(hLabelWnd);
-        HFONT hCurrentFont = (HFONT)SendMessage(hLabelWnd, WM_GETFONT, 0, 0);
-        HFONT hOriginalFont = (HFONT)SelectObject(hTextDC,
+        HFONT hCurrentFont = reinterpret_cast<HFONT>(
+            SendMessage(hLabelWnd, WM_GETFONT, 0, 0));
+        HFONT hOriginalFont = reinterpret_cast<HFONT>(SelectObject(hTextDC,
             hCurrentFont
                 ? hCurrentFont
-                : GetStockObject(DEFAULT_GUI_FONT));
+                : GetStockObject(DEFAULT_GUI_FONT)));
 
         // Calculate the required dimensions of the text area
         RECT rcLabelText = { 0 };
@@ -266,7 +298,8 @@ void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent, const 
             // Retrieve the geometry of the label window
             RECT rcLabelWnd;
             GetWindowRect(hLabelWnd, &rcLabelWnd);
-            MapWindowPoints(nullptr, hPropPageWnd, reinterpret_cast<LPPOINT>(&rcLabelWnd), 2);
+            MapWindowPoints(nullptr, hPropPageWnd,
+                reinterpret_cast<LPPOINT>(&rcLabelWnd), 2);
 
             // Align with the horizontal separator window's geometry by finding
             // the static control with the SS_ETCHEDHORZ style
@@ -298,7 +331,8 @@ void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent, const 
             {
                 RECT rcSeparatorWnd;
                 GetWindowRect(hSeparatorWnd, &rcSeparatorWnd);
-                MapWindowPoints(nullptr, hPropPageWnd, reinterpret_cast<LPPOINT>(&rcSeparatorWnd), 2);
+                MapWindowPoints(nullptr, hPropPageWnd,
+                    reinterpret_cast<LPPOINT>(&rcSeparatorWnd), 2);
                 centerX = (rcSeparatorWnd.left + rcSeparatorWnd.right) / 2;
             }
 
@@ -329,7 +363,7 @@ void UpdateDiskUsagePercentLabel(HWND hPropPageWnd, DWORD dwUsagePercent, const 
     }
 }
 
-// Helper to hide legends and align labels to the left
+// Helper: Hide legends and align labels to the left
 void HideLegendsAndAlignLabels(HWND hPropPageWnd)
 {
     // Define control IDs for the standard drive storage properties page
@@ -356,12 +390,15 @@ void HideLegendsAndAlignLabels(HWND hPropPageWnd)
             // Retrieve the X position of the legend window as the margin
             RECT rcLegendWnd;
             GetWindowRect(hLegendWnd, &rcLegendWnd);
-            MapWindowPoints(nullptr, hPropPageWnd, reinterpret_cast<LPPOINT>(&rcLegendWnd), 2);
+            MapWindowPoints(nullptr, hPropPageWnd,
+                reinterpret_cast<LPPOINT>(&rcLegendWnd), 2);
             int xLeft = rcLegendWnd.left;
 
             // Hide the legend windows
             ShowWindow(hLegendWnd, SW_HIDE);
-            ShowWindow(GetDlgItem(hPropPageWnd, IDC_SHELL32_LEGEND_FREE), SW_HIDE);
+            HWND hLegendFreeWnd = GetDlgItem(hPropPageWnd,
+                IDC_SHELL32_LEGEND_FREE);
+            ShowWindow(hLegendFreeWnd, SW_HIDE);
 
             // Move the label windows to the left margin
             const int rgLabelIds[] = {
@@ -377,7 +414,8 @@ void HideLegendsAndAlignLabels(HWND hPropPageWnd)
                 {
                     RECT rcLabelWnd;
                     GetWindowRect(hLabelWnd, &rcLabelWnd);
-                    MapWindowPoints(nullptr, hPropPageWnd, reinterpret_cast<LPPOINT>(&rcLabelWnd), 2);
+                    MapWindowPoints(nullptr, hPropPageWnd,
+                        reinterpret_cast<LPPOINT>(&rcLabelWnd), 2);
                     SetWindowPos(hLabelWnd, nullptr, xLeft, rcLabelWnd.top,
                         0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
                 }
@@ -396,12 +434,15 @@ void HideLegendsAndAlignLabels(HWND hPropPageWnd)
             // Retrieve the X position of the legend window as the margin
             RECT rcLegendWnd;
             GetWindowRect(hLegendWnd, &rcLegendWnd);
-            MapWindowPoints(nullptr, hPropPageWnd, reinterpret_cast<LPPOINT>(&rcLegendWnd), 2);
+            MapWindowPoints(nullptr, hPropPageWnd,
+                reinterpret_cast<LPPOINT>(&rcLegendWnd), 2);
             int xLeft = rcLegendWnd.left;
 
             // Hide the legend windows
             ShowWindow(hLegendWnd, SW_HIDE);
-            ShowWindow(GetDlgItem(hPropPageWnd, IDC_WPDSHEXT_LEGEND_FREE), SW_HIDE);
+            HWND hLegendFreeWnd = GetDlgItem(hPropPageWnd,
+                IDC_WPDSHEXT_LEGEND_FREE);
+            ShowWindow(hLegendFreeWnd, SW_HIDE);
 
             // Move the label windows to the left margin
             const int rgLabelIds[] = {
@@ -417,7 +458,8 @@ void HideLegendsAndAlignLabels(HWND hPropPageWnd)
                 {
                     RECT rcLabelWnd;
                     GetWindowRect(hLabelWnd, &rcLabelWnd);
-                    MapWindowPoints(nullptr, hPropPageWnd, reinterpret_cast<LPPOINT>(&rcLabelWnd), 2);
+                    MapWindowPoints(nullptr, hPropPageWnd,
+                        reinterpret_cast<LPPOINT>(&rcLabelWnd), 2);
                     SetWindowPos(hLabelWnd, nullptr, xLeft, rcLabelWnd.top,
                         0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
                 }
@@ -427,7 +469,7 @@ void HideLegendsAndAlignLabels(HWND hPropPageWnd)
     }
 }
 
-// Helper to draw the disk usage bar
+// Helper: Draw the disk usage bar
 void DrawDiskUsageBar(HDC hChartDC, LPCRECT prcChart, DWORD dwUsagePer1000)
 {
     HWND hChartWnd = WindowFromDC(hChartDC);
@@ -443,18 +485,32 @@ void DrawDiskUsageBar(HDC hChartDC, LPCRECT prcChart, DWORD dwUsagePer1000)
     RestoreCustomDriveIcon(hPropPageWnd);
 
     // Convert the raw disk usage value (0-1000) to a rounded 0-100 integer for
-    // the disk usage percentage label and the disk usage bar fill color state
+    // the disk usage percentage text and the disk usage bar fill color state
     // Example: 635-644 → 64%
     //          645-654 → 65%
+    // Applies to the text when displayed as whole numbers.
     DWORD dwUsagePercent = (dwUsagePer1000 + 5) / 10;
-    if (dwUsagePercent > 100) dwUsagePercent = 100;
+
+    // Adjust disk usage percentage rounding to cap values between 99.5% and
+    // 99.9% at 99% when displayed as whole numbers, ensuring the disk usage
+    // percentage text displays "100%" only when the disk is completely full
+    if (dwUsagePercent == 100 && dwUsagePer1000 < 1000)
+    {
+        dwUsagePercent = 99;
+    }
+    else if (dwUsagePercent > 100)
+    {
+        dwUsagePercent = 100;
+    }
 
     // Retrieve the geometry of the original chart area
     RECT rcChart = *prcChart;
-    MapWindowPoints(hChartWnd, hPropPageWnd, reinterpret_cast<LPPOINT>(&rcChart), 2);
+    MapWindowPoints(hChartWnd, hPropPageWnd,
+        reinterpret_cast<LPPOINT>(&rcChart), 2);
 
     // Update the disk usage percentage label below the disk usage bar
-    UpdateDiskUsagePercentLabel(hPropPageWnd, dwUsagePercent, rcChart);
+    UpdateDiskUsagePercentLabel(hPropPageWnd, dwUsagePercent, dwUsagePer1000,
+        rcChart);
 
     // Hide legends and align labels to the left
     HideLegendsAndAlignLabels(hPropPageWnd);
@@ -497,7 +553,8 @@ void DrawDiskUsageBar(HDC hChartDC, LPCRECT prcChart, DWORD dwUsagePer1000)
     {
         RECT rcSeparatorWnd;
         GetWindowRect(hSeparatorWnd, &rcSeparatorWnd);
-        MapWindowPoints(nullptr, hPropPageWnd, reinterpret_cast<LPPOINT>(&rcSeparatorWnd), 2);
+        MapWindowPoints(nullptr, hPropPageWnd,
+            reinterpret_cast<LPPOINT>(&rcSeparatorWnd), 2);
         cxBar = rcSeparatorWnd.right - rcSeparatorWnd.left;
         centerX = (rcSeparatorWnd.left + rcSeparatorWnd.right) / 2;
     }
@@ -514,7 +571,8 @@ void DrawDiskUsageBar(HDC hChartDC, LPCRECT prcChart, DWORD dwUsagePer1000)
     // region covers the entire usage bar.
     RECT rcChartWnd;
     GetWindowRect(hChartWnd, &rcChartWnd);
-    MapWindowPoints(nullptr, hPropPageWnd, reinterpret_cast<LPPOINT>(&rcChartWnd), 2);
+    MapWindowPoints(nullptr, hPropPageWnd,
+        reinterpret_cast<LPPOINT>(&rcChartWnd), 2);
     if (!EqualRect(&rcBar, &rcChartWnd))
     {
         SetWindowPos(hChartWnd, nullptr,
@@ -557,15 +615,17 @@ void DrawDiskUsageBar(HDC hChartDC, LPCRECT prcChart, DWORD dwUsagePer1000)
 
             int cxFill = (cxBar * static_cast<int>(dwUsagePer1000)) / 1000;
             rcFill.right = rcFill.left + cxFill;
+
             if (cxFill > 0)
-                DrawThemeBackground(hTheme, hPropPageDC, PP_FILL, iFillState, &rcFill, nullptr);
+            {
+                DrawThemeBackground(hTheme, hPropPageDC, PP_FILL, iFillState,
+                    &rcFill, nullptr);
+            }
         }
 
         CloseThemeData(hTheme);
     }
-
-    // Fallback for Classic theme
-    else
+    else // Fallback for Classic theme
     {
         // Draw the track (background)
         FillRect(hPropPageDC, &rcBar, GetSysColorBrush(COLOR_BTNFACE));
@@ -574,7 +634,6 @@ void DrawDiskUsageBar(HDC hChartDC, LPCRECT prcChart, DWORD dwUsagePer1000)
         COLORREF crFill = (iFillState == PBFS_ERROR)
             ? RGB(196, 43, 28)              // Red (when disk is >90% full)
             : GetSysColor(COLOR_HIGHLIGHT); // System color: Highlight
-
         HBRUSH hFillBrush = CreateSolidBrush(crFill);
 
         // Draw the fill (foreground)
@@ -585,7 +644,9 @@ void DrawDiskUsageBar(HDC hChartDC, LPCRECT prcChart, DWORD dwUsagePer1000)
             // Cap usage at 100% to prevent the fill from overflowing
             if (dwUsagePer1000 > 1000) dwUsagePer1000 = 1000;
 
-            rcFill.right = rcFill.left + ((cxBar * static_cast<int>(dwUsagePer1000)) / 1000);
+            int cxFill = (cxBar * static_cast<int>(dwUsagePer1000)) / 1000;
+            rcFill.right = rcFill.left + cxFill;
+
             FillRect(hPropPageDC, &rcFill, hFillBrush);
         }
 
@@ -599,17 +660,18 @@ void DrawDiskUsageBar(HDC hChartDC, LPCRECT prcChart, DWORD dwUsagePer1000)
 }
 
 // Hook DrawPie (shell32.dll) for standard drive storage properties
-using Shell32_DrawPie_t = int (__fastcall *)(HDC, LPRECT, DWORD, DWORD, const DWORD *);
+using Shell32_DrawPie_t =
+    int (__fastcall *)(HDC, LPRECT, DWORD, DWORD, const DWORD *);
 Shell32_DrawPie_t Shell32_DrawPie_Original;
 int __fastcall Shell32_DrawPie_Hook(
-    HDC hdc,
+    HDC hChartDC,
     LPRECT prcChart,
     DWORD dwUsagePer1000,
     DWORD dwCachePer1000,
     const DWORD *lpColors
 )
 {
-    DrawDiskUsageBar(hdc, prcChart, dwUsagePer1000);
+    DrawDiskUsageBar(hChartDC, prcChart, dwUsagePer1000);
     return 0; // Suppress the original chart
 }
 
@@ -623,17 +685,18 @@ const WindhawkUtils::SYMBOL_HOOK shell32DllHooks[] = {
 };
 
 // Hook _DrawPie (wpdshext.dll) for portable device storage properties
-using WpdShExt_DrawPie_t = void (__fastcall *)(HDC, LPCRECT, DWORD, DWORD, const DWORD *);
+using WpdShExt_DrawPie_t =
+    void (__fastcall *)(HDC, LPCRECT, DWORD, DWORD, const DWORD *);
 WpdShExt_DrawPie_t WpdShExt_DrawPie_Original;
 void __fastcall WpdShExt_DrawPie_Hook(
-    HDC hdc,
+    HDC hChartDC,
     LPCRECT prcChart,
     DWORD dwUsagePer1000,
     DWORD dwCachePer1000,
     const DWORD *lpColors
 )
 {
-    DrawDiskUsageBar(hdc, prcChart, dwUsagePer1000);
+    DrawDiskUsageBar(hChartDC, prcChart, dwUsagePer1000);
 }
 
 const WindhawkUtils::SYMBOL_HOOK wpdshextDllHooks[] = {
@@ -649,6 +712,7 @@ const WindhawkUtils::SYMBOL_HOOK wpdshextDllHooks[] = {
 void LoadSettings()
 {
     settings.showRedUsageBar = Wh_GetIntSetting(L"showRedUsageBar");
+    settings.showDecimalPercentage = Wh_GetIntSetting(L"showDecimalPercentage");
 }
 
 // Mod initialization
@@ -662,11 +726,8 @@ BOOL Wh_ModInit()
         LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (hShell32)
     {
-        if (!WindhawkUtils::HookSymbols(
-            hShell32,
-            shell32DllHooks,
-            ARRAYSIZE(shell32DllHooks)
-        ))
+        if (!WindhawkUtils::HookSymbols(hShell32, shell32DllHooks,
+                ARRAYSIZE(shell32DllHooks)))
         {
             Wh_Log(L"Failed to hook DrawPie in shell32.dll");
         }
@@ -676,11 +737,8 @@ BOOL Wh_ModInit()
         LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (hWpdShExt)
     {
-        if (!WindhawkUtils::HookSymbols(
-            hWpdShExt,
-            wpdshextDllHooks,
-            ARRAYSIZE(wpdshextDllHooks)
-        ))
+        if (!WindhawkUtils::HookSymbols(hWpdShExt, wpdshextDllHooks,
+                ARRAYSIZE(wpdshextDllHooks)))
         {
             Wh_Log(L"Failed to hook _DrawPie in wpdshext.dll");
         }


### PR DESCRIPTION
Win32 text boxes often lack previous-word deletion functionality, resulting in the `Ctrl+Backspace` hotkey inserting the `Delete` control character instead of deleting the previous word.

This mod resolves this behavior by adding previous-word deletion functionality to those `Edit` controls.

| Before |
| :----- |
| ![](https://raw.githubusercontent.com/AromaKitsune/My-Windhawk-Mods/main/screenshots/ctrl-backspace-fix-for-win32-text-boxes_before.gif) |

| After |
| :---- |
| ![](https://raw.githubusercontent.com/AromaKitsune/My-Windhawk-Mods/main/screenshots/ctrl-backspace-fix-for-win32-text-boxes_after.gif) |

Resolves https://github.com/ramensoftware/windhawk-mods/issues/3768

<!-- ⚠️ Please don't remove the template below. Add your content above the template. -->

## Changelog

If the submission is an update to an existing mod, include the changelog below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If the submission is a new mod, please fill the form below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [x] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the appropriate option. Your selection will not affect acceptance criteria, but will help reviewers understand the context of the code and provide relevant feedback.
