### PR TITLE
Update UWP Assets Redirect to v1.1

### DIFF
--- a/mods/uwp-assets-redirect.wh.cpp
+++ b/mods/uwp-assets-redirect.wh.cpp
@@ -542,7 +542,8 @@ void RefreshIcons(bool check_should_refresh = false) {
     }
 
     g_refresh_icons_prompt_thread = CreateThread(
-        nullptr, 0,
+        nullptr,
+        0,
         [](LPVOID lpParameter) WINAPI -> DWORD {
 
             static decltype(&TaskDialogIndirect) pTaskDialogIndirect = []() {
@@ -553,9 +554,11 @@ void RefreshIcons(bool check_should_refresh = false) {
                 }
                 return (decltype(&TaskDialogIndirect)) GetProcAddress(hComctl32, "TaskDialogIndirect");
             }();
+
             if(!pTaskDialogIndirect) {
                 return 0;
             }
+
             TASKDIALOGCONFIG promptDialogConfig {
                 .cbSize = sizeof(promptDialogConfig),
                 .dwFlags = TDF_ALLOW_DIALOG_CANCELLATION | TDF_EXPAND_FOOTER_AREA,
@@ -578,6 +581,7 @@ void RefreshIcons(bool check_should_refresh = false) {
                     return S_OK;
                 },
             };
+
             int button;
             if (SUCCEEDED(pTaskDialogIndirect(&promptDialogConfig, &button, nullptr, nullptr)) && button == IDYES) {
                 WCHAR commandLine[ARRAYSIZE(g_clear_cache_command)];
@@ -587,13 +591,18 @@ void RefreshIcons(bool check_should_refresh = false) {
                 };
                 PROCESS_INFORMATION pi{};
                 if (CreateProcess(nullptr, commandLine, nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
+                    WaitForSingleObject(pi.hProcess, INFINITE);
                     CloseHandle(pi.hThread);
                     CloseHandle(pi.hProcess);
                 }
             }
+
             return 0;
+
         },
-        nullptr, 0, nullptr
+        nullptr,
+        0,
+        nullptr
     );
 
     // Let other processes some time to init/uninit.

--- a/mods/uwp-assets-redirect.wh.cpp
+++ b/mods/uwp-assets-redirect.wh.cpp
@@ -2,7 +2,7 @@
 // @id              uwp-assets-redirect
 // @name            UWP Assets Redirect
 // @description     Replace UWP app assets (such as icons) without worrying about updates or modifying system files permissions.
-// @version         1.0
+// @version         1.1
 // @author          ferrys
 // @github          https://github.com/atferrys
 // @license         GPL-3.0
@@ -13,7 +13,7 @@
 // @include         ShellHost.exe
 // @include         RuntimeBroker.exe
 // @include         Taskmgr.exe
-// @compilerOptions -lcomctl32 -lole32 -loleaut32
+// @compilerOptions -lcomctl32 -lole32 -loleaut32 -lgdiplus -lgdi32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -32,6 +32,20 @@ and their previews in the [theme repository](https://github.com/atferrys/uwp-ass
 
 _To contribute a new theme to the theme repository, follow the instructions
 [here](https://github.com/atferrys/uwp-assets-redirect/blob/main/themes/README.md#contributing-new-themes)._
+
+# Applying redirections
+You can apply redirections to _Windows Apps_, _System Apps_ and _Custom_ paths directly from
+the **Settings** tab.
+
+For each redirection you will need to specify the **Bundle name** and a **Redirection folder or .ico file**:
+You can find the application bundle by following [the guide below](#finding-the-application-bundle-and-assets),
+then you can specify a folder with the custom assets files or a single `.ico` file.
+
+If you provide a single `.ico` file, only the app icons shown throughout the generic parts of the system will be
+replaced _(e.g. File Explorer, Start Menu, etc...)_, and it may not always be able to generate the correct assets.
+
+**To fully replace assets**, it's recommended to use a Redirection folder with the correct assets. You can
+find out more about creating custom assets [down below](#creating-custom-assets).
 
 # Finding the Application bundle and assets
 You can quickly identify both the application bundle and its Assets folder using Task Manager.
@@ -77,7 +91,7 @@ For example, the `theme.ini` file may contain the following redirection rules:
 For apps found in "`C:\Program Files\WindowsApps`" and in "`C:\Windows\SystemApps`",
 you can use respectively the `[windows-apps]` and `[system-apps]` headers.
 
-Each rule should be provided in this format: "`<application bundle>`=`<redirection folder>`".
+Each rule should be provided in this format: "`<application bundle>`=`<redirection folder/.ico>`".
 The application bundle can be easily found by following [the guide above](#finding-the-application-bundle-and-assets).
 
 ### Example config
@@ -85,6 +99,7 @@ The application bundle can be easily found by following [the guide above](#findi
 [windows-apps]
 Microsoft.WindowsStore=.\Microsoft Store
 Microsoft.WindowsCalculator=.\Calculator
+Microsoft.WindowsTerminal=Terminal.ico
 ```
 
 Most of the time, Assets Redirect can automatically locate the bundle's Assets folder.
@@ -142,6 +157,7 @@ You can contribute to the mod development by opening a pull request [here](https
   $options:
   - "": None
   - "ferrys/aero": Aero (by @ferrys)
+  - "ferrys/luna": Luna (by @ferrys)
 - theme-paths: [""]
   $name: Theme paths
   $description: >-
@@ -159,8 +175,12 @@ You can contribute to the mod development by opening a pull request [here](https
         You can get easily get this via Task Manager, follow the guide in
         the details tab for more information.
     - redirect: ""
-      $name: Redirection folder
-      $description: The folder with the custom assets files.
+      $name: Redirection folder or .ico file
+      $description: >-
+        The folder with the custom assets files or a single .ico file.
+
+        Note: If you provide a single .ico file, only app icons will be replaced.
+        You can find more information in the details tab.
   $name: WindowsApps Redirections
   $description: >-
     Redirections for the apps found in "C:\Program Files\WindowsApps".
@@ -176,8 +196,12 @@ You can contribute to the mod development by opening a pull request [here](https
         You can get easily get this via Task Manager, follow the guide in
         the details tab for more information.
     - redirect: ""
-      $name: Redirection folder
-      $description: The folder with the custom assets files.
+      $name: Redirection folder or .ico file
+      $description: >-
+        The folder with the custom assets files or a single .ico file.
+
+        Note: If you provide a single .ico file, only app icons will be replaced.
+        You can find more information in the details tab.
   $name: SystemApps Redirections
   $description: >-
     Redirections for the apps found in "C:\Windows\SystemApps".
@@ -223,6 +247,7 @@ You can contribute to the mod development by opening a pull request [here](https
 #include <winrt/base.h>
 #include <comutil.h>
 #include <shldisp.h>
+#include <gdiplus.h>
 #include <format>
 #include <string>
 #include <unordered_map>
@@ -983,7 +1008,7 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
     auto add_bundle_redirection = [&redirections, normalize_path](std::wstring bundles_root, std::wstring bundle, std::wstring redirect, std::filesystem::path theme_folder = g_normalize_path_base_path) {
 
-        const auto deduct_bundle = [](std::wstring bundles_root, std::wstring bundle, std::wstring& bundle_id, std::wstring& assets_folder) {
+        const auto deduct_bundle = [](std::wstring bundles_root, std::wstring bundle, std::wstring& bundle_id, std::wstring& assets_folder, std::filesystem::path& assets_folder_path) {
 
             const auto get_assets_folder = [](const std::wstring& appx_manifest) -> std::wstring {
 
@@ -1102,9 +1127,13 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
                     Wh_Log(L"Invalid assets folder for \"%s\", falling back to default.", bundle_id.c_str());
                 }
 
-                if(find_bundle_folder(bundles_root, bundle_id).empty()) {
+                std::wstring bundle_folder = find_bundle_folder(bundles_root, bundle_id);
+
+                if(bundle_folder.empty()) {
                     assets_folder = L"";
                     Wh_Log(L"Failed to find bundle folder for \"%s\", skipping redirection.", bundle_id.c_str());
+                } else {
+                    assets_folder_path = std::filesystem::path(bundle_folder) / assets_folder;
                 }
 
                 return;
@@ -1127,21 +1156,337 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
                 return;
             }
 
+            assets_folder_path = std::filesystem::path(bundle_folder) / assets_folder;
+
             Wh_Log(L"Automatically found assets folder for \"%s\" in \"%s\".", bundle_id.c_str(), assets_folder.c_str());
+
+        };
+
+        const auto get_generated_assets_path = [](std::wstring bundle_id, std::wstring assets_folder, std::filesystem::path assets_folder_path, std::wstring ico_file) -> std::wstring {
+
+            WCHAR storage_path_buffer[MAX_PATH];
+            if (!Wh_GetModStoragePath(storage_path_buffer, ARRAYSIZE(storage_path_buffer))) {
+                Wh_Log(L"Failed to setup ICO redirection: Unable to get mod's storage path.");
+                return L"";
+            }
+
+            std::error_code error_code;
+            auto generated_assets_path = std::filesystem::path{storage_path_buffer} / "generated-assets" / bundle_id / assets_folder;
+
+            if(std::filesystem::is_directory(generated_assets_path, error_code)) {
+
+                WIN32_FILE_ATTRIBUTE_DATA ico_info;
+                if (!GetFileAttributesEx(ico_file.c_str(), GetFileExInfoStandard, &ico_info)) {
+                    Wh_Log(L"Failed to setup ICO redirection: Unable to get ICO file attributes for \"%s\".", ico_file.c_str());
+                    return L"";
+                }
+
+                FILETIME ico_last_modified_time = ico_info.ftLastWriteTime;
+
+                WIN32_FILE_ATTRIBUTE_DATA generated_assets_info;
+                if (!GetFileAttributesEx(generated_assets_path.c_str(), GetFileExInfoStandard, &generated_assets_info)) {
+                    Wh_Log(L"Failed to setup ICO redirection: Unable to get generated assets folder attributes for \"%s\".", bundle_id.c_str());
+                    return L"";
+                }
+
+                FILETIME generated_assets_creation_time = generated_assets_info.ftCreationTime;
+
+                if (CompareFileTime(&ico_last_modified_time, &generated_assets_creation_time) == 0) {
+                    Wh_Log(L"Assets for \"%s\" already generated and source icon didn't change.", bundle_id.c_str());
+                    return generated_assets_path;
+                }
+
+                for (int suffix = 0; suffix < 100; suffix++) {
+
+                    if (suffix > 0) {
+                        generated_assets_path = std::filesystem::path{storage_path_buffer} / "generated-assets" / std::format(L"{}_{}", bundle_id, suffix + 1) / assets_folder;
+                    }
+
+                    if (!std::filesystem::is_directory(generated_assets_path, error_code)) {
+                        // Generated assets folder doesn't exist, we can use it.
+                        break;
+                    }
+
+                    // Generated assets folder exists, try to remove it.
+                    Wh_Log(L"Generated assets folder already exists, trying to remove: %s", generated_assets_path.c_str());
+                    std::filesystem::remove_all(generated_assets_path, error_code);
+
+                    if (!std::filesystem::is_directory(generated_assets_path, error_code)) {
+                        // Successfully removed Generated assets folder.
+                        break;
+                    }
+
+                    Wh_Log(L"Failed to remove Generated assets folder, trying next usable name...");
+
+                }
+
+                if (std::filesystem::is_directory(generated_assets_path, error_code)) {
+                    Wh_Log(L"Failed to setup ICO redirection: Unable to find a usable Generated assets folder name.");
+                    return L"";
+                }
+
+                std::filesystem::create_directories(generated_assets_path, error_code);
+
+                HANDLE generated_assets_handle = CreateFile(
+                    generated_assets_path.c_str(),
+                    FILE_WRITE_ATTRIBUTES,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    nullptr,
+                    OPEN_EXISTING,
+                    FILE_FLAG_BACKUP_SEMANTICS,
+                    nullptr
+                );
+
+                if (generated_assets_handle != INVALID_HANDLE_VALUE) {
+                    SetFileTime(generated_assets_handle, &ico_last_modified_time, nullptr, nullptr);
+                    CloseHandle(generated_assets_handle);
+                }
+
+            }
+
+            Gdiplus::GdiplusStartupInput gdi_startup;
+            ULONG_PTR gdi_token;
+
+            if (GdiplusStartup(&gdi_token, &gdi_startup, nullptr) != Gdiplus::Ok) {
+                Wh_Log(L"Failed to setup ICO redirection: Unable to initialize GDI+.");
+                return L"";
+            }
+
+            const auto get_clsid_encoder = [](std::wstring mime_type, CLSID* clsid) -> int {
+
+                UINT encoders_count = 0;
+                UINT encoders_size = 0;
+
+                Gdiplus::GetImageEncodersSize(&encoders_count, &encoders_size);
+
+                if (encoders_size == 0) {
+                    return -1;
+                }
+
+                std::vector<Gdiplus::ImageCodecInfo> encoders(encoders_size / sizeof(Gdiplus::ImageCodecInfo));
+                Gdiplus::GetImageEncoders(encoders_count, encoders_size, encoders.data());
+
+                for (UINT i = 0; i < encoders_count; ++i) {
+                    if (wcscmp(encoders[i].MimeType, mime_type.c_str()) == 0) {
+                        *clsid = encoders[i].Clsid;
+                        return i;
+                    }
+                }
+
+                return -1;
+
+            };
+
+            CLSID png_encoder_clsid;
+
+            if (get_clsid_encoder(L"image/png", &png_encoder_clsid) == -1) {
+                Wh_Log(L"Failed to setup ICO redirection: Unable to get PNG encoder.");
+                return L"";
+            }
+
+            // Generate common tiles from an .ico file.
+            // Same concept as TileGen: https://github.com/atferrys/TileGen
+            // Partially taken and adapted from: https://stackoverflow.com/a/22885412
+
+            const auto generate_tile = [ico_file, png_encoder_clsid](int width, int height, std::wstring output_file) {
+
+                HICON icon = nullptr;
+
+                UINT result = PrivateExtractIconsW(
+                    ico_file.c_str(),
+                    0,
+                    width,
+                    height,
+                    &icon,
+                    nullptr,
+                    1,
+                    0
+                );
+
+                if (result == 0 || icon == nullptr) {
+                    Wh_Log(L"Failed to generate asset from ICO file: Unable to read icon.");
+                    return;
+                }
+
+                ICONINFO icon_info = {};
+
+                if (!GetIconInfo(icon, &icon_info)) {
+                    DestroyIcon(icon);
+                    Wh_Log(L"Failed to generate asset from ICO file: Unable to get icon info.");
+                    return;
+                }
+
+                BITMAP bitmap = {};
+                GetObject(icon_info.hbmColor, sizeof(BITMAP), &bitmap);
+
+                HDC hdc = GetDC(nullptr);
+
+                BITMAPINFO bitmap_info = {
+                    .bmiHeader = {
+                        .biSize = sizeof(BITMAPINFOHEADER),
+                        .biWidth = bitmap.bmWidth,
+                        .biHeight = -bitmap.bmHeight,
+                        .biPlanes = 1,
+                        .biBitCount = 32,
+                        .biCompression = BI_RGB
+                    }
+                };
+
+                int pixel_count = bitmap.bmWidth * bitmap.bmHeight;
+                std::vector<UINT32> pixels(pixel_count);
+
+                GetDIBits(
+                    hdc,
+                    icon_info.hbmColor,
+                    0,
+                    bitmap.bmHeight,
+                    pixels.data(),
+                    &bitmap_info,
+                    DIB_RGB_COLORS
+                );
+
+                bool has_alpha = false;
+
+                for (int pixel : pixels) {
+                    if ((pixel & 0xFF000000) != 0) {
+                        has_alpha = true;
+                        break;
+                    }
+                }
+
+                if (!has_alpha && icon_info.hbmMask) {
+
+                    std::vector<UINT32> mask(pixel_count);
+
+                    GetDIBits(
+                        hdc,
+                        icon_info.hbmMask,
+                        0,
+                        bitmap.bmHeight,
+                        mask.data(),
+                        &bitmap_info,
+                        DIB_RGB_COLORS
+                    );
+
+                    for (int i = 0; i < pixel_count; i++) {
+                        if (mask[i] == 0) {
+                            pixels[i] |= 0xFF000000;
+                        }
+                    }
+
+                }
+
+                Gdiplus::Bitmap output_bitmap(
+                    bitmap.bmWidth,
+                    bitmap.bmHeight,
+                    bitmap.bmWidth * 4,
+                    PixelFormat32bppARGB,
+                    (BYTE*) pixels.data()
+                );
+
+                if (output_bitmap.Save(output_file.c_str(), &png_encoder_clsid, nullptr) != Gdiplus::Ok) {
+                    Wh_Log(L"Failed to generate asset from ICO file: Unable to save output bitmap: %s", output_file.c_str());
+                    return;
+                }
+
+                ReleaseDC(nullptr, hdc);
+
+                if (icon_info.hbmColor) {
+                    DeleteObject(icon_info.hbmColor);
+                }
+
+                if (icon_info.hbmMask) {
+                    DeleteObject(icon_info.hbmMask);
+                }
+
+                DestroyIcon(icon);
+
+            };
+
+            for (const auto& entry : std::filesystem::recursive_directory_iterator(assets_folder_path)) {
+
+                if (!entry.is_regular_file()) {
+                    continue;
+                }
+
+                std::filesystem::path path = entry.path();
+                std::wstring filename = path.filename().wstring();
+
+                if (!filename.ends_with(L".png")) {
+                    continue;
+                }
+
+                if (filename.find(L"targetsize") == std::wstring::npos) {
+                    continue;
+                }
+
+                if (filename.find(L"contrast") != std::wstring::npos) {
+                    continue;
+                }
+
+                Gdiplus::Image tile_image = path.c_str();
+
+                if (tile_image.GetLastStatus() != Gdiplus::Ok) {
+                    Wh_Log(L"Failed to generate asset from ICO file: Unable to read Reference Tile: %s", path.c_str());
+                    continue;
+                }
+
+                UINT tile_width = tile_image.GetWidth();
+                UINT tile_height = tile_image.GetHeight();
+
+                if (tile_width != tile_height) {
+                    continue;
+                }
+
+                const auto generated_tile_path = generated_assets_path / path.lexically_relative(assets_folder_path);
+                std::filesystem::create_directories(generated_tile_path.parent_path());
+
+                generate_tile(tile_width, tile_height, generated_tile_path);
+
+            }
+
+            Gdiplus::GdiplusShutdown(gdi_token);
+
+            Wh_Log(L"Assets for \"%s\" generated from icon successfully.", bundle_id.c_str());
+
+            return generated_assets_path;
 
         };
 
         std::wstring bundle_id;
         std::wstring assets_folder;
+        std::filesystem::path assets_folder_path;
 
-        deduct_bundle(bundles_root, std::wstring(bundle), bundle_id, assets_folder);
+        deduct_bundle(bundles_root, std::wstring(bundle), bundle_id, assets_folder, assets_folder_path);
 
         if(bundle_id.empty() || assets_folder.empty()) {
             return;
         }
 
+        std::filesystem::path normalized_redirect = normalize_path(redirect, theme_folder);
+
+        if(!assets_folder_path.empty() &&
+            std::filesystem::exists(normalized_redirect) &&
+            std::filesystem::is_regular_file(normalized_redirect) &&
+            normalized_redirect.extension() == ".ico") {
+
+            std::wstring generated_assets_path = get_generated_assets_path(
+                bundle_id,
+                assets_folder,
+                assets_folder_path,
+                normalized_redirect
+            );
+
+            if(generated_assets_path.empty()) {
+                return;
+            }
+
+            normalized_redirect = generated_assets_path;
+
+        }
+
         auto path = std::format(L"\\??\\{}\\{}_*\\{}", bundles_root, bundle_id, assets_folder);
-        auto redirection = std::format(L"\\??\\{}", normalize_path(redirect, theme_folder));
+        auto redirection = std::format(L"\\??\\{}", normalized_redirect.wstring());
 
         redirections[path] = redirection;
 

--- a/mods/uwp-assets-redirect.wh.cpp
+++ b/mods/uwp-assets-redirect.wh.cpp
@@ -2087,10 +2087,12 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
                         pTaskDialogIndirect(&promptDialogConfig, nullptr, nullptr, nullptr);
 
+                        delete static_cast<std::wstring*>(lpParameter);
+
                         return 0;
 
                     },
-                    &icon_theme,
+                    new std::wstring(icon_theme),
                     0,
                     nullptr
                 );

--- a/mods/uwp-assets-redirect.wh.cpp
+++ b/mods/uwp-assets-redirect.wh.cpp
@@ -962,6 +962,18 @@ inline constexpr auto g_custom_redirections_blacklist = std::to_array<std::wstri
     LR"(C:\Windows\SystemApps)"
 });
 
+HANDLE g_downloading_theme_prompt_thread;
+std::atomic<HWND> g_downloading_theme_prompt;
+
+constexpr WCHAR g_downloading_theme_prompt_title[] = L"UWP Assets Redirect - Windhawk";
+constexpr WCHAR g_downloading_theme_prompt_header[] = L"Downloading Icon theme...";
+constexpr WCHAR g_downloading_theme_prompt_body[] = L"UWP Assets Redirect is downloading \"{}\", please wait...";
+
+std::atomic<HWND> g_failed_to_download_theme_prompt;
+
+constexpr WCHAR g_failed_to_download_theme_prompt_title[] = L"UWP Assets Redirect - Windhawk";
+constexpr WCHAR g_failed_to_download_theme_prompt_header[] = L"Failed to download Icon theme";
+
 constexpr auto g_normalize_path_base_path = L"C:\\Windows\\System32\\";
 
 void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirections) {
@@ -1990,6 +2002,116 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
                 };
 
+                if (g_downloading_theme_prompt_thread) {
+                    if (WaitForSingleObject(g_downloading_theme_prompt_thread, 0) != WAIT_OBJECT_0) {
+                        return false;
+                    }
+                    CloseHandle(g_downloading_theme_prompt_thread);
+                }
+
+                static decltype(&TaskDialogIndirect) pTaskDialogIndirect = []() {
+                    HMODULE hComctl32 = LoadLibraryEx(L"comctl32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+                    if (!hComctl32) {
+                        Wh_Log(L"Failed to load comctl32.dll");
+                            return (decltype(&TaskDialogIndirect)) nullptr;
+                        }
+                    return (decltype(&TaskDialogIndirect)) GetProcAddress(hComctl32, "TaskDialogIndirect");
+                }();
+
+                g_downloading_theme_prompt_thread = CreateThread(
+                    nullptr,
+                    0,
+                    [](LPVOID lpParameter) WINAPI -> DWORD {
+
+                        if(!pTaskDialogIndirect) {
+                            return 0;
+                        }
+
+                        const std::wstring icon_theme = *static_cast<std::wstring*>(lpParameter);
+                        const std::wstring message = std::format(g_downloading_theme_prompt_body, icon_theme.c_str());
+
+                        const TASKDIALOG_BUTTON buttons[] = {
+                            {IDCLOSE, L"Hide"}
+                        };
+
+                        TASKDIALOGCONFIG promptDialogConfig {
+                            .cbSize = sizeof(promptDialogConfig),
+                            .dwFlags = TDF_SHOW_MARQUEE_PROGRESS_BAR,
+                            .dwCommonButtons = 0,
+
+                            .pszWindowTitle = g_downloading_theme_prompt_title,
+                            .pszMainIcon = TD_INFORMATION_ICON,
+                            .pszMainInstruction = g_downloading_theme_prompt_header,
+                            .pszContent = message.c_str(),
+
+                            .cButtons = ARRAYSIZE(buttons),
+                            .pButtons = buttons,
+
+                            .pfCallback = [](HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, LONG_PTR lpRefData) WINAPI -> HRESULT {
+                                switch (msg) {
+                                    case TDN_CREATED:
+                                        g_downloading_theme_prompt = hwnd;
+                                        SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                                        SendMessage(hwnd, TDM_SET_PROGRESS_BAR_MARQUEE, TRUE, 0);
+                                        break;
+
+                                    case TDN_DESTROYED:
+                                        g_downloading_theme_prompt = nullptr;
+                                        break;
+                                }
+                                return S_OK;
+                            },
+                        };
+
+                        pTaskDialogIndirect(&promptDialogConfig, nullptr, nullptr, nullptr);
+
+                        return 0;
+
+                    },
+                    &icon_theme,
+                    0,
+                    nullptr
+                );
+
+                const auto show_error_message = [](std::wstring message) {
+
+                    if(g_downloading_theme_prompt) {
+                        SendMessage(g_downloading_theme_prompt, TDM_CLICK_BUTTON, TDCBF_CLOSE_BUTTON, 0);
+                    }
+
+                    if(!pTaskDialogIndirect) {
+                        return;
+                    }
+
+                    TASKDIALOGCONFIG promptDialogConfig {
+                        .cbSize = sizeof(promptDialogConfig),
+                        .dwFlags = TDF_ALLOW_DIALOG_CANCELLATION,
+                        .dwCommonButtons = TDCBF_CLOSE_BUTTON,
+
+                        .pszWindowTitle = g_failed_to_download_theme_prompt_title,
+                        .pszMainIcon = TD_ERROR_ICON,
+                        .pszMainInstruction = g_failed_to_download_theme_prompt_header,
+                        .pszContent = message.c_str(),
+
+                        .pfCallback = [](HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, LONG_PTR lpRefData) WINAPI -> HRESULT {
+                            switch (msg) {
+                                case TDN_CREATED:
+                                    g_failed_to_download_theme_prompt = hwnd;
+                                    SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                                    break;
+
+                                case TDN_DESTROYED:
+                                    g_failed_to_download_theme_prompt = nullptr;
+                                    break;
+                            }
+                            return S_OK;
+                        },
+                    };
+
+                    pTaskDialogIndirect(&promptDialogConfig, nullptr, nullptr, nullptr);
+
+                };
+
                 const std::wstring theme_url = std::format(
                     L"https://raw.githubusercontent.com/atferrys/uwp-assets-redirect/refs/heads/main/themes/{}.zip",
                     icon_theme
@@ -2004,12 +2126,14 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
                 if (!response) {
                     Wh_Log(L"Failed to download Icon theme: Wh_GetUrlContent returned NULL.");
+                    show_error_message(L"An unknown error occurred while downloading the Icon theme.");
                     return false;
                 }
 
                 if (response->statusCode != 200) {
                     Wh_Log(L"Failed to download Icon theme: Request failed with code %d.", response->statusCode);
                     Wh_FreeUrlContent(response);
+                    show_error_message(std::format(L"Icon theme download request failed with code {}.", response->statusCode));
                     return false;
                 }
 
@@ -2019,6 +2143,7 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
                 if(FAILED(result)) {
                     Wh_Log(L"Failed to download Icon theme: CoInitialize returned 0x%08X", result);
+                    show_error_message(std::format(L"COM initialization failed with code 0x{:08X}.", result));
                     return false;
                 }
 
@@ -2030,6 +2155,7 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
                 if (FAILED(result)) {
                     Wh_Log(L"Failed to download Icon theme: UnzipToFolder returned 0x%08X", result);
+                    show_error_message(std::format(L"Unzipping of downloaded theme file failed with code 0x{:08X}.", result));
                     return false;
                 }
 
@@ -2038,6 +2164,10 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
                 DeleteFile(temp_zip.c_str());
                 CoUninitialize();
+
+                if(g_downloading_theme_prompt) {
+                    SendMessage(g_downloading_theme_prompt, TDM_CLICK_BUTTON, TDCBF_CLOSE_BUTTON, 0);
+                }
 
                 return std::filesystem::is_directory(icon_theme_path, error_code);
 

--- a/mods/uwp-assets-redirect.wh.cpp
+++ b/mods/uwp-assets-redirect.wh.cpp
@@ -2304,7 +2304,7 @@ constexpr WCHAR g_ownership_prompt_body[] =
     L"\n"
     L"To continue, click on \"Allow\" and respond to the UAC prompt.";
 
-constexpr WCHAR g_ask_permission_command[] =
+constexpr WCHAR g_ownership_command[] =
     LR"(powershell -NoProfile -WindowStyle minimized Start-Process -Wait -FilePath cmd -Verb RunAs -ArgumentList ')"
 
     LR"(/c title "UWP Assets Redirect - Windhawk")"
@@ -2423,8 +2423,8 @@ void CheckWindowsAppsOwner() {
 
     int button;
     if (SUCCEEDED(pTaskDialogIndirect(&promptDialogConfig, &button, nullptr, nullptr)) && button == IDYES) {
-        WCHAR commandLine[ARRAYSIZE(g_ask_permission_command)];
-        memcpy(commandLine, g_ask_permission_command, sizeof(g_ask_permission_command));
+        WCHAR commandLine[ARRAYSIZE(g_ownership_command)];
+        memcpy(commandLine, g_ownership_command, sizeof(g_ownership_command));
         STARTUPINFO si = {
             .cb = sizeof(si),
         };

--- a/mods/uwp-assets-redirect.wh.cpp
+++ b/mods/uwp-assets-redirect.wh.cpp
@@ -2156,11 +2156,156 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
 }
 
+std::atomic<HWND> g_ownership_prompt;
+
+constexpr WCHAR g_ownership_prompt_title[] = L"UWP Assets Redirect - Windhawk";
+constexpr WCHAR g_ownership_prompt_header[] = L"Access required";
+constexpr WCHAR g_ownership_prompt_body[] =
+    L"To work properly, UWP Assets Redirect requires permission to access certain system-protected locations.\n"
+    L"\n"
+    L"To continue, click on \"Allow\" and respond to the UAC prompt.";
+
+constexpr WCHAR g_ask_permission_command[] =
+    LR"(powershell -NoProfile -WindowStyle minimized Start-Process -Wait -FilePath cmd -Verb RunAs -ArgumentList ')"
+
+    LR"(/c title "UWP Assets Redirect - Windhawk")"
+    LR"(& echo Updating permissions, please wait...)"
+    LR"(& takeown /F \"C:\Program Files\WindowsApps\" /A)"
+    LR"(& icacls \"C:\Program Files\WindowsApps\" /grant \"%COMPUTERNAME%\%USERNAME%:(R)\"')";
+
+void CheckWindowsAppsOwner() {
+
+    const auto is_owner_administrators = [](std::wstring folder_path) -> BOOL {
+
+        PSECURITY_DESCRIPTOR security_descriptor = nullptr;
+        PSID owner_sid = nullptr;
+
+        DWORD result = GetNamedSecurityInfoW(
+            folder_path.c_str(),
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION,
+            &owner_sid,
+            nullptr,
+            nullptr,
+            nullptr,
+            &security_descriptor
+        );
+
+        if (result != ERROR_SUCCESS) {
+            if(security_descriptor) {
+                LocalFree(security_descriptor);
+            }
+            return false;
+        }
+
+        SID_IDENTIFIER_AUTHORITY nt_authority_sid = SECURITY_NT_AUTHORITY;
+        PSID administrators_sid = nullptr;
+
+        WINBOOL allocation_result = AllocateAndInitializeSid(
+            &nt_authority_sid,
+            2,
+            SECURITY_BUILTIN_DOMAIN_RID,
+            DOMAIN_ALIAS_RID_ADMINS,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            &administrators_sid
+        );
+
+        if (!allocation_result) {
+            LocalFree(security_descriptor);
+            return false;
+        }
+
+        BOOL is_owner_adminstators = EqualSid(owner_sid, administrators_sid);
+
+        FreeSid(administrators_sid);
+        LocalFree(security_descriptor);
+
+        return is_owner_adminstators;
+
+    };
+
+    if(is_owner_administrators(L"C:\\Program Files\\WindowsApps")) {
+        return;
+    }
+
+    Wh_Log(L"WindowsApps folder not owned by Administrators group. This will prevent reads, asking permissions...");
+
+    static decltype(&TaskDialogIndirect) pTaskDialogIndirect = []() {
+        HMODULE hComctl32 = LoadLibraryEx(L"comctl32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+        if (!hComctl32) {
+            Wh_Log(L"Failed to load comctl32.dll");
+            return (decltype(&TaskDialogIndirect)) nullptr;
+        }
+        return (decltype(&TaskDialogIndirect)) GetProcAddress(hComctl32, "TaskDialogIndirect");
+    }();
+
+    if(!pTaskDialogIndirect) {
+        return;
+    }
+
+    TASKDIALOG_BUTTON buttons[] = {
+        {IDYES, L"Allow"},
+        {IDCANCEL, L"Cancel"}
+    };
+
+    TASKDIALOGCONFIG promptDialogConfig {
+        .cbSize = sizeof(promptDialogConfig),
+        .dwFlags = TDF_ALLOW_DIALOG_CANCELLATION,
+        .dwCommonButtons = 0,
+
+        .pszWindowTitle = g_ownership_prompt_title,
+        .pszMainIcon = TD_WARNING_ICON,
+        .pszMainInstruction = g_ownership_prompt_header,
+        .pszContent = g_ownership_prompt_body,
+
+        .cButtons = ARRAYSIZE(buttons),
+        .pButtons = buttons,
+
+        .pfCallback = [](HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, LONG_PTR lpRefData) WINAPI -> HRESULT {
+            switch (msg) {
+                case TDN_CREATED:
+                    g_ownership_prompt = hwnd;
+                    SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                    SendMessage(hwnd, TDM_SET_BUTTON_ELEVATION_REQUIRED_STATE, IDYES, TRUE);
+                    break;
+
+                case TDN_DESTROYED:
+                    g_ownership_prompt = nullptr;
+                    break;
+            }
+            return S_OK;
+        },
+    };
+
+    int button;
+    if (SUCCEEDED(pTaskDialogIndirect(&promptDialogConfig, &button, nullptr, nullptr)) && button == IDYES) {
+        WCHAR commandLine[ARRAYSIZE(g_ask_permission_command)];
+        memcpy(commandLine, g_ask_permission_command, sizeof(g_ask_permission_command));
+        STARTUPINFO si = {
+            .cb = sizeof(si),
+        };
+        PROCESS_INFORMATION pi{};
+        if (CreateProcess(nullptr, commandLine, nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
+            WaitForSingleObject(pi.hProcess, INFINITE);
+            CloseHandle(pi.hThread);
+            CloseHandle(pi.hProcess);
+        }
+    }
+
+}
+
 void LoadSettings() {
 
     std::unordered_map<std::wstring, std::wstring> redirections;
 
     if(DoesCurrentProcessOwnTaskbar()) {
+
+        CheckWindowsAppsOwner();
 
         ClearRedirectionsCache(false);
         LoadRedirections(redirections);

--- a/mods/uwp-assets-redirect.wh.cpp
+++ b/mods/uwp-assets-redirect.wh.cpp
@@ -1338,10 +1338,35 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
                     return;
                 }
 
-                BITMAP bitmap = {};
-                GetObject(icon_info.hbmColor, sizeof(BITMAP), &bitmap);
-
                 HDC hdc = GetDC(nullptr);
+
+                const auto cleanup = [&hdc, &icon_info, &icon]() {
+
+                    if (hdc) {
+                        ReleaseDC(nullptr, hdc);
+                    }
+
+                    if (icon_info.hbmColor) {
+                        DeleteObject(icon_info.hbmColor);
+                    }
+
+                    if (icon_info.hbmMask) {
+                        DeleteObject(icon_info.hbmMask);
+                    }
+
+                    if (icon) {
+                        DestroyIcon(icon);
+                    }
+
+                };
+
+                BITMAP bitmap = {};
+
+                if (!GetObject(icon_info.hbmColor, sizeof(BITMAP), &bitmap)) {
+                    Wh_Log(L"Failed to generate asset from ICO file: Unable to get bitmap info.");
+                    cleanup();
+                    return;
+                }
 
                 BITMAPINFO bitmap_info = {
                     .bmiHeader = {
@@ -1357,7 +1382,7 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
                 int pixel_count = bitmap.bmWidth * bitmap.bmHeight;
                 std::vector<UINT32> pixels(pixel_count);
 
-                GetDIBits(
+                if (!GetDIBits(
                     hdc,
                     icon_info.hbmColor,
                     0,
@@ -1365,7 +1390,11 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
                     pixels.data(),
                     &bitmap_info,
                     DIB_RGB_COLORS
-                );
+                )) {
+                    Wh_Log(L"Failed to generate asset from ICO file: Unable to read bitmap pixels.");
+                    cleanup();
+                    return;
+                }
 
                 bool has_alpha = false;
 
@@ -1380,7 +1409,7 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
                     std::vector<UINT32> mask(pixel_count);
 
-                    GetDIBits(
+                    if (!GetDIBits(
                         hdc,
                         icon_info.hbmMask,
                         0,
@@ -1388,7 +1417,11 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
                         mask.data(),
                         &bitmap_info,
                         DIB_RGB_COLORS
-                    );
+                    )) {
+                        Wh_Log(L"Failed to generate asset from ICO file: Unable to read bitmap alpha mask.");
+                        cleanup();
+                        return;
+                    }
 
                     for (int i = 0; i < pixel_count; i++) {
                         if (mask[i] == 0) {
@@ -1408,20 +1441,9 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
                 if (output_bitmap.Save(output_file.c_str(), &png_encoder_clsid, nullptr) != Gdiplus::Ok) {
                     Wh_Log(L"Failed to generate asset from ICO file: Unable to save output bitmap: %s", output_file.c_str());
-                    return;
                 }
 
-                ReleaseDC(nullptr, hdc);
-
-                if (icon_info.hbmColor) {
-                    DeleteObject(icon_info.hbmColor);
-                }
-
-                if (icon_info.hbmMask) {
-                    DeleteObject(icon_info.hbmMask);
-                }
-
-                DestroyIcon(icon);
+                cleanup();
 
             };
 

--- a/mods/uwp-assets-redirect.wh.cpp
+++ b/mods/uwp-assets-redirect.wh.cpp
@@ -38,20 +38,20 @@ You can apply redirections to _Windows Apps_, _System Apps_ and _Custom_ paths d
 the **Settings** tab.
 
 For each redirection you will need to specify the **Bundle name** and a **Redirection folder or .ico file**:
-You can find the application bundle by following [the guide below](#finding-the-application-bundle-and-assets),
-then you can specify a folder with the custom assets files or a single `.ico` file.
+You can find the application bundle by following [the guide below](#finding-the-application-bundle-and-assets), then you can specify a folder with the
+custom assets files or a single `.ico` file.
 
 If you provide a single `.ico` file, only the app icons shown throughout the generic parts of the system will be
 replaced _(e.g. File Explorer, Start Menu, etc...)_, and it may not always be able to generate the correct assets.
 
-**To fully replace assets**, it's recommended to use a Redirection folder with the correct assets. You can
-find out more about creating custom assets [down below](#creating-custom-assets).
+**To fully replace assets**, it's recommended to use a Redirection folder with the correct assets.
+You can find out more about creating custom assets [down below](#creating-custom-assets).
 
 # Finding the Application bundle and assets
 You can quickly identify both the application bundle and its Assets folder using Task Manager.
 
-1. Open the application you want to redirect assets for. Then open Task Manager,
-right-click the application process, and select "**Open file location**":
+1. Open the application you want to redirect assets for. Then open Task Manager, right-click the
+   application process, and select "**Open file location**":
 
     ![Task Manager right-click context menu on "Microsoft Store" with "Open file location" hovered](https://raw.githubusercontent.com/atferrys/uwp-assets-redirect/main/docs-assets/task-manager-open-location.png)
 
@@ -60,36 +60,35 @@ right-click the application process, and select "**Open file location**":
     ![Application folder highlighted in File Explorer with the bundle identifier shown](https://raw.githubusercontent.com/atferrys/uwp-assets-redirect/main/docs-assets/application-folder.png)
 
 3. The application bundle is the part of the folder name that comes before the first underscore,
-in this case "`Microsoft.WindowsStore`".
+   in this case "`Microsoft.WindowsStore`".
 
 If Assets Redirect can't automatically locate the Assets folder, you can browse the application directory to manually find it.
 In this example, although it was detected automatically, the assets were located in "`Assets\AppTiles`":
 
 ![The path to the assets folder](https://raw.githubusercontent.com/atferrys/uwp-assets-redirect/main/docs-assets/assets-folder.png)
 
-You can specify them in the application bundle using this format:
-"`<application bundle>`|`<assets folder>`", and in this case "`Microsoft.WindowsStore|Assets\AppTiles`".
+You can specify them in the application bundle using this format: "`<application bundle>`|`<assets folder>`",
+and in this case "`Microsoft.WindowsStore|Assets\AppTiles`".
 
 # Creating custom assets
 You can manually create replacement assets by copying the original Assets folder, removing any files you don't
 want to replace, and editing the remaining ones making sure to preserve the original file resolutions.
 
-A quicker and easier approach is to use something like [TileGen](https://tilegen.ferrys.it/assets-redirect), an open-source tool that
-generates the required assets from a single image or an `.ico` file.
-_Using an .ico file is recommended, as it already contains multiple resolutions._
+A quicker and easier approach is to use something like [TileGen](https://tilegen.ferrys.it/assets-redirect), an open-source tool that generates the required assets
+from a single image or an `.ico` file. _Using an .ico file is recommended, as it already contains multiple resolutions._
 
-_Keep in mind that even if File Explorer doesn't show the non-redirected assets after you've applied them,
-they're still present. This is only a visual issue caused by how File Explorer loads folder contents._
+_Keep in mind that even if File Explorer doesn't show the non-redirected assets after you've applied them, they're
+still present. This is only a visual issue caused by how File Explorer loads folder contents._
 
 # Theme paths
-Theme paths can be set in the settings.
-Each theme path can be a folder with custom assets files and a `theme.ini` file that contains redirection rules, or the `.ini` theme file itself.
+Theme paths can be set in the settings. Each theme path can be a folder with custom assets files and a `theme.ini` file
+that contains redirection rules, or the `.ini` theme file itself.
 
 For example, the `theme.ini` file may contain the following redirection rules:
 
 ## WindowsApps and SystemApps redirections
-For apps found in "`C:\Program Files\WindowsApps`" and in "`C:\Windows\SystemApps`",
-you can use respectively the `[windows-apps]` and `[system-apps]` headers.
+For apps found in "`C:\Program Files\WindowsApps`" and in "`C:\Windows\SystemApps`", you can use respectively
+the `[windows-apps]` and `[system-apps]` headers.
 
 Each rule should be provided in this format: "`<application bundle>`=`<redirection folder/.ico>`".
 The application bundle can be easily found by following [the guide above](#finding-the-application-bundle-and-assets).
@@ -102,11 +101,11 @@ Microsoft.WindowsCalculator=.\Calculator
 Microsoft.WindowsTerminal=Terminal.ico
 ```
 
-Most of the time, Assets Redirect can automatically locate the bundle's Assets folder.
-However, some applications use the same application bundle as other apps, which can prevent Assets Redirect
-from identifying the correct folder.
-In these cases, you can manually specify the Assets folder within the application bundle using the
-following format: "`<application bundle>`|`<assets folder>`" (an example is shown below in `[system-apps]`).
+Most of the time, Assets Redirect can automatically locate the bundle's Assets folder. However, some applications use
+the same application bundle as other apps, which can prevent Assets Redirect from identifying the correct folder.
+
+In these cases, you can manually specify the Assets folder within the application bundle using the following format:
+"`<application bundle>`|`<assets folder>`" (an example is shown below in `[system-apps]`).
 
 ### Example config
 ```
@@ -116,8 +115,8 @@ Microsoft.PPIProjection=.\Wireless Display
 ```
 
 ## Custom redirections
-For apps that aren't found in common folders like `WindowsApps` or `SystemApps`,
-like _Settings_, you can use the `[custom]` header.
+For apps that aren't found in common folders like `WindowsApps` or `SystemApps`, like _Settings_, you can use
+the `[custom]` header.
 
 Each rule should be provided in this format: "`<assets folder>`=`<redirection folder>`".
 
@@ -128,7 +127,7 @@ Each rule should be provided in this format: "`<assets folder>`=`<redirection fo
 ```
 
 # Injecting into other processes
-By default, Assets Redirect only targets the processes that most commonly use these assets, such as File Explorer and the Start Menu.
+By default, Assets Redirect only targets the processes that most commonly use these assets, such as File Explorer and Start Menu.
 As a result, UWP applications are not affected by asset redirection out of the box.
 
 You can change this behavior using the "Custom process inclusion list" in the Advanced tab and doing one of the following:
@@ -136,8 +135,8 @@ You can change this behavior using the "Custom process inclusion list" in the Ad
 - Include the entire applications directories: "`C:\Program Files\WindowsApps\*`" and "`C:\Windows\SystemApps\*`".
 - Or, if you're willing to risk system stability, include all processes using "`*`".
 
-Doing this applies your asset changes not only to the Windows shell,
-but also to the applications themselves, changing their look as well (like the splash screen).
+Doing this applies your asset changes not only to the Windows shell, but also to the applications themselves, changing
+their look as well (like the splash screen).
 
 # Contributions
 You can contribute to the mod development by opening a pull request [here](https://github.com/atferrys/uwp-assets-redirect/pulls).

--- a/mods/uwp-assets-redirect.wh.cpp
+++ b/mods/uwp-assets-redirect.wh.cpp
@@ -1013,7 +1013,7 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
                 std::wifstream file(appx_manifest.c_str());
 
-                if (!file.is_open()) {
+                if (!file.is_open() || file.fail()) {
                     Wh_Log(L"Failed to open manifest: %s", appx_manifest.c_str());
                     return L"";
                 }
@@ -1056,7 +1056,9 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
             const auto find_bundle_folder = [](const std::wstring& bundles_root, const std::wstring& app_bundle) -> std::wstring {
 
-                for (const auto& entry : std::filesystem::directory_iterator(bundles_root)) {
+                std::error_code error_code;
+
+                for (const auto& entry : std::filesystem::directory_iterator(bundles_root, error_code)) {
 
                     if (!entry.is_directory()) {
                         continue;
@@ -1079,7 +1081,7 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
                         continue;
                     }
 
-                    if (!std::filesystem::exists(std::filesystem::path(path) / "AppxManifest.xml")) {
+                    if (!std::filesystem::exists(std::filesystem::path(path) / "AppxManifest.xml", error_code)) {
                         continue;
                     }
 
@@ -1402,7 +1404,7 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
             };
 
-            for (const auto& entry : std::filesystem::recursive_directory_iterator(assets_folder_path)) {
+            for (const auto& entry : std::filesystem::recursive_directory_iterator(assets_folder_path, error_code)) {
 
                 if (!entry.is_regular_file()) {
                     continue;
@@ -1438,7 +1440,7 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
                 }
 
                 const auto generated_tile_path = generated_assets_path / path.lexically_relative(assets_folder_path);
-                std::filesystem::create_directories(generated_tile_path.parent_path());
+                std::filesystem::create_directories(generated_tile_path.parent_path(), error_code);
 
                 generate_tile(tile_width, tile_height, generated_tile_path);
 
@@ -1463,10 +1465,11 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
         }
 
         std::filesystem::path normalized_redirect = normalize_path(redirect, theme_folder);
+        std::error_code error_code;
 
         if(!assets_folder_path.empty() &&
-            std::filesystem::exists(normalized_redirect) &&
-            std::filesystem::is_regular_file(normalized_redirect) &&
+            std::filesystem::exists(normalized_redirect, error_code) &&
+            std::filesystem::is_regular_file(normalized_redirect, error_code) &&
             normalized_redirect.extension() == ".ico") {
 
             std::wstring generated_assets_path = get_generated_assets_path(
@@ -1562,14 +1565,16 @@ void LoadRedirections(std::unordered_map<std::wstring, std::wstring>& redirectio
 
     auto add_theme_redirections = [add_bundle_redirection, add_custom_redirection](std::filesystem::path theme_ini, std::filesystem::path theme_folder) {
 
-        if(!std::filesystem::exists(theme_ini)) {
+        std::error_code error_code;
+
+        if(!std::filesystem::exists(theme_ini, error_code)) {
             Wh_Log(L"Failed to read theme file, path doesn't exist: %s", theme_ini.c_str());
             return;
         }
 
-        const auto read_section = [theme_ini](std::wstring section_key, auto on_pair_read) {
+        const auto read_section = [theme_ini, &error_code](std::wstring section_key, auto on_pair_read) {
 
-            auto theme_ini_size = std::filesystem::file_size(theme_ini);
+            auto theme_ini_size = std::filesystem::file_size(theme_ini, error_code);
             std::wstring buffer(theme_ini_size + 2, L'\0');
 
             DWORD result = GetPrivateProfileSection(


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Added support for .ico redirections:
   * You can now provide the path to an .ico file, and assets will be automatically generated,
   * You can find more information in the mod's details tab under "Applying redirections".
* Fixed WindowsApps read permissions that caused the mod to hang on loading
* Added dialogs during Icon themes download or when an error occurs
* Added "Luna" theme

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
