### PR TITLE
Add ExplorerPatcher Taskbar Button Width mod

### DIFF
--- a/mods/ep-taskbar-button-width.wh.cpp
+++ b/mods/ep-taskbar-button-width.wh.cpp
@@ -159,7 +159,7 @@ BOOL Wh_ModInit() {
     HMODULE hMods[1024];
     DWORD cbNeeded;
     if (EnumProcessModules(GetCurrentProcess(), hMods, sizeof(hMods), &cbNeeded)) {
-        size_t count = min(cbNeeded, (DWORD)sizeof(hMods)) / sizeof(HMODULE);
+        size_t count = (cbNeeded < sizeof(hMods) ? cbNeeded : sizeof(hMods)) / sizeof(HMODULE);
         for (size_t i = 0; i < count; i++) {
             if (IsExplorerPatcherModule(hMods[i])) {
                 HookExplorerPatcher(hMods[i], true);

--- a/mods/ep-taskbar-button-width.wh.cpp
+++ b/mods/ep-taskbar-button-width.wh.cpp
@@ -1,0 +1,179 @@
+// ==WindhawkMod==
+// @id              ep-taskbar-button-width
+// @name            ExplorerPatcher Taskbar Button Width
+// @description     Customize the minimum width of taskbar buttons when using ExplorerPatcher's Windows 10 taskbar
+// @version         1.0.0
+// @author          Rod Boev
+// @github          https://github.com/rodboev
+// @include         explorer.exe
+// @architecture    x86-64
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# ExplorerPatcher Taskbar Button Width
+
+The standard MinWidth registry hack doesn't work with ExplorerPatcher's
+Windows 10 taskbar. This mod lets you adjust button width as a percentage
+(default 150%).
+
+Requires ExplorerPatcher with Windows 10 taskbar enabled.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- buttonWidthPercent: 150
+  $name: Button width (% of default)
+  $description: >-
+    Percentage to scale button width. 100% = no change, 150% = 50% wider.
+    Range: 50-300.
+*/
+// ==/WindhawkModSettings==
+
+#include <psapi.h>
+#include <atomic>
+
+struct {
+    int buttonWidthPercent;
+} g_settings;
+
+std::atomic<bool> g_hooked{false};
+
+using ComputeSingleButtonWidth_t = int(WINAPI*)(void* pThis, int groupType, void* pTaskBtnGroup, int* pWidth);
+ComputeSingleButtonWidth_t ComputeSingleButtonWidth_Original;
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t LoadLibraryExW_Original;
+
+int WINAPI ComputeSingleButtonWidth_Hook(void* pThis, int groupType, void* pTaskBtnGroup, int* pWidth) {
+    int result = ComputeSingleButtonWidth_Original(pThis, groupType, pTaskBtnGroup, pWidth);
+
+    if (g_settings.buttonWidthPercent != 100) {
+        result = (result * g_settings.buttonWidthPercent) / 100;
+        if (pWidth) {
+            *pWidth = (*pWidth * g_settings.buttonWidthPercent) / 100;
+        }
+    }
+
+    return result;
+}
+
+void RefreshTaskbar() {
+    // Primary taskbar: Shell_TrayWnd -> ReBarWindow32 -> MSTaskSwWClass
+    HWND taskbar = FindWindow(L"Shell_TrayWnd", nullptr);
+    if (taskbar) {
+        HWND hReBarWindow32 = FindWindowEx(taskbar, nullptr, L"ReBarWindow32", nullptr);
+        if (hReBarWindow32) {
+            HWND hMSTaskSwWClass = FindWindowEx(hReBarWindow32, nullptr, L"MSTaskSwWClass", nullptr);
+            if (hMSTaskSwWClass) {
+                SendMessage(hMSTaskSwWClass, 0x452, 3, 0);
+            }
+        }
+    }
+
+    // Secondary taskbars: Shell_SecondaryTrayWnd -> WorkerW -> MSTaskSwWClass
+    HWND secondaryTaskbar = nullptr;
+    while ((secondaryTaskbar = FindWindowEx(nullptr, secondaryTaskbar, L"Shell_SecondaryTrayWnd", nullptr)) != nullptr) {
+        HWND hWorkerW = FindWindowEx(secondaryTaskbar, nullptr, L"WorkerW", nullptr);
+        if (hWorkerW) {
+            HWND hMSTaskSwWClass = FindWindowEx(hWorkerW, nullptr, L"MSTaskSwWClass", nullptr);
+            if (hMSTaskSwWClass) {
+                SendMessage(hMSTaskSwWClass, 0x452, 3, 0);
+            }
+        }
+    }
+}
+
+bool IsExplorerPatcherModule(HMODULE module) {
+    WCHAR path[MAX_PATH];
+    if (!GetModuleFileName(module, path, ARRAYSIZE(path))) {
+        return false;
+    }
+    PCWSTR name = wcsrchr(path, L'\\');
+    if (!name) return false;
+    name++;
+    return _wcsnicmp(L"ep_taskbar.", name, 11) == 0;
+}
+
+bool HookExplorerPatcher(HMODULE module, bool calledFromInit) {
+    if (g_hooked.exchange(true)) {
+        return true;
+    }
+
+    void* ptr = (void*)GetProcAddress(module,
+        "?_ComputeSingleButtonWidth@CTaskListWnd@@IEAAHW4eTBGROUPTYPE@@PEAUITaskBtnGroup@@PEAH@Z");
+
+    if (!ptr) {
+        Wh_Log(L"ERROR: _ComputeSingleButtonWidth not found");
+        g_hooked = false;
+        return false;
+    }
+
+    Wh_SetFunctionHook(ptr, (void*)ComputeSingleButtonWidth_Hook, (void**)&ComputeSingleButtonWidth_Original);
+
+    if (!calledFromInit) {
+        Wh_ApplyHookOperations();
+        RefreshTaskbar();
+    }
+
+    Wh_Log(L"Hooked at %p (scale: %d%%)", ptr, g_settings.buttonWidthPercent);
+    return true;
+}
+
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags) {
+    HMODULE module = LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
+    if (module && !g_hooked && IsExplorerPatcherModule(module)) {
+        Wh_Log(L"ExplorerPatcher loaded: %s", lpLibFileName);
+        HookExplorerPatcher(module, false);
+    }
+    return module;
+}
+
+void LoadSettings() {
+    g_settings.buttonWidthPercent = Wh_GetIntSetting(L"buttonWidthPercent");
+    if (g_settings.buttonWidthPercent < 50) g_settings.buttonWidthPercent = 50;
+    if (g_settings.buttonWidthPercent > 300) g_settings.buttonWidthPercent = 300;
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"=== EP Taskbar Button Width v1.3.0 ===");
+    LoadSettings();
+
+    HMODULE hMods[1024];
+    DWORD cbNeeded;
+    if (EnumProcessModules(GetCurrentProcess(), hMods, sizeof(hMods), &cbNeeded)) {
+        for (size_t i = 0; i < cbNeeded / sizeof(HMODULE); i++) {
+            if (IsExplorerPatcherModule(hMods[i])) {
+                HookExplorerPatcher(hMods[i], true);
+                break;
+            }
+        }
+    }
+
+    HMODULE kb = GetModuleHandle(L"kernelbase.dll");
+    if (kb) {
+        auto pLoadLib = (LoadLibraryExW_t)GetProcAddress(kb, "LoadLibraryExW");
+        if (pLoadLib) {
+            Wh_SetFunctionHook((void*)pLoadLib, (void*)LoadLibraryExW_Hook, (void**)&LoadLibraryExW_Original);
+        }
+    }
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (g_hooked) {
+        RefreshTaskbar();
+    }
+}
+
+void Wh_ModUninit() {
+    g_settings.buttonWidthPercent = 100;
+    RefreshTaskbar();
+}
+
+void Wh_ModSettingsChanged() {
+    LoadSettings();
+    RefreshTaskbar();
+}

--- a/mods/ep-taskbar-button-width.wh.cpp
+++ b/mods/ep-taskbar-button-width.wh.cpp
@@ -44,9 +44,7 @@ ExplorerPatcher.)
 #include <psapi.h>
 #include <atomic>
 
-struct {
-    int percent;
-} g_settings;
+std::atomic<int> g_settingsPercent{120};
 
 std::atomic<bool> g_hooked{false};
 
@@ -59,10 +57,11 @@ LoadLibraryExW_t LoadLibraryExW_Original;
 int WINAPI ComputeSingleButtonWidth_Hook(void* pThis, int groupType, void* pTaskBtnGroup, int* pWidth) {
     int result = ComputeSingleButtonWidth_Original(pThis, groupType, pTaskBtnGroup, pWidth);
 
-    if (g_settings.percent != 100) {
-        result = (result * g_settings.percent) / 100;
+    int percent = g_settingsPercent.load();
+    if (percent != 100) {
+        result = (result * percent) / 100;
         if (pWidth) {
-            *pWidth = (*pWidth * g_settings.percent) / 100;
+            *pWidth = (*pWidth * percent) / 100;
         }
     }
 
@@ -107,7 +106,8 @@ bool IsExplorerPatcherModule(HMODULE module) {
 }
 
 bool HookExplorerPatcher(HMODULE module, bool calledFromInit) {
-    if (g_hooked.exchange(true)) {
+    bool expected = false;
+    if (!g_hooked.compare_exchange_strong(expected, true)) {
         return true;
     }
 
@@ -120,14 +120,18 @@ bool HookExplorerPatcher(HMODULE module, bool calledFromInit) {
         return false;
     }
 
-    Wh_SetFunctionHook(ptr, (void*)ComputeSingleButtonWidth_Hook, (void**)&ComputeSingleButtonWidth_Original);
+    if (!Wh_SetFunctionHook(ptr, (void*)ComputeSingleButtonWidth_Hook, (void**)&ComputeSingleButtonWidth_Original)) {
+        Wh_Log(L"ERROR: Wh_SetFunctionHook failed");
+        g_hooked = false;
+        return false;
+    }
 
     if (!calledFromInit) {
         Wh_ApplyHookOperations();
         RefreshTaskbar();
     }
 
-    Wh_Log(L"Hooked at %p (%d%%)", ptr, g_settings.percent);
+    Wh_Log(L"Hooked at %p (%d%%)", ptr, g_settingsPercent.load());
     return true;
 }
 
@@ -141,10 +145,11 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dw
 }
 
 void LoadSettings() {
-    g_settings.percent = Wh_GetIntSetting(L"buttonWidthPercent");
-    if (g_settings.percent <= 0) g_settings.percent = 120;
-    else if (g_settings.percent < 50) g_settings.percent = 50;
-    else if (g_settings.percent > 300) g_settings.percent = 300;
+    int percent = Wh_GetIntSetting(L"buttonWidthPercent");
+    if (percent <= 0) percent = 120;
+    else if (percent < 50) percent = 50;
+    else if (percent > 300) percent = 300;
+    g_settingsPercent.store(percent);
 }
 
 BOOL Wh_ModInit() {
@@ -154,7 +159,8 @@ BOOL Wh_ModInit() {
     HMODULE hMods[1024];
     DWORD cbNeeded;
     if (EnumProcessModules(GetCurrentProcess(), hMods, sizeof(hMods), &cbNeeded)) {
-        for (size_t i = 0; i < cbNeeded / sizeof(HMODULE); i++) {
+        size_t count = min(cbNeeded, (DWORD)sizeof(hMods)) / sizeof(HMODULE);
+        for (size_t i = 0; i < count; i++) {
             if (IsExplorerPatcherModule(hMods[i])) {
                 HookExplorerPatcher(hMods[i], true);
                 break;
@@ -180,7 +186,7 @@ void Wh_ModAfterInit() {
 }
 
 void Wh_ModUninit() {
-    g_settings.percent = 100;
+    g_settingsPercent.store(100);
     RefreshTaskbar();
 }
 

--- a/mods/ep-taskbar-button-width.wh.cpp
+++ b/mods/ep-taskbar-button-width.wh.cpp
@@ -13,21 +13,31 @@
 /*
 # ExplorerPatcher Taskbar Button Width
 
-The standard MinWidth registry hack doesn't work with ExplorerPatcher's
-Windows 10 taskbar. This mod lets you adjust button width as a percentage
-(default 150%).
+This mod lets you change the width of taskbar items when using ExplorerPatcher's Windows 10 taskbar on Windows 11.
 
-Requires ExplorerPatcher with Windows 10 taskbar enabled.
+Before:
+
+![Before](https://i.imgur.com/r82ISo3.png)
+
+After (120%):
+
+![After](https://i.imgur.com/qHaRdVt.png)
+
+The item scales as a percentage from a pre-computed base value not exposed by EP.
+
+(The registry hack at
+`HKCU\Control Panel\Desktop\WindowMetrics\MinWidth` doesn't work with
+ExplorerPatcher.)
+
+**Requirements:** Windows 11 with ExplorerPatcher, using the Windows 10 taskbar.
 */
 // ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
 /*
-- buttonWidthPercent: 150
-  $name: Button width (% of default)
-  $description: >-
-    Percentage to scale button width. 100% = no change, 150% = 50% wider.
-    Range: 50-300.
+- buttonWidthPercent: 120
+  $name: Button width (%)
+  $description: "Recommended: 75-150%"
 */
 // ==/WindhawkModSettings==
 
@@ -35,7 +45,7 @@ Requires ExplorerPatcher with Windows 10 taskbar enabled.
 #include <atomic>
 
 struct {
-    int buttonWidthPercent;
+    int percent;
 } g_settings;
 
 std::atomic<bool> g_hooked{false};
@@ -49,10 +59,10 @@ LoadLibraryExW_t LoadLibraryExW_Original;
 int WINAPI ComputeSingleButtonWidth_Hook(void* pThis, int groupType, void* pTaskBtnGroup, int* pWidth) {
     int result = ComputeSingleButtonWidth_Original(pThis, groupType, pTaskBtnGroup, pWidth);
 
-    if (g_settings.buttonWidthPercent != 100) {
-        result = (result * g_settings.buttonWidthPercent) / 100;
+    if (g_settings.percent != 100) {
+        result = (result * g_settings.percent) / 100;
         if (pWidth) {
-            *pWidth = (*pWidth * g_settings.buttonWidthPercent) / 100;
+            *pWidth = (*pWidth * g_settings.percent) / 100;
         }
     }
 
@@ -117,7 +127,7 @@ bool HookExplorerPatcher(HMODULE module, bool calledFromInit) {
         RefreshTaskbar();
     }
 
-    Wh_Log(L"Hooked at %p (scale: %d%%)", ptr, g_settings.buttonWidthPercent);
+    Wh_Log(L"Hooked at %p (%d%%)", ptr, g_settings.percent);
     return true;
 }
 
@@ -131,13 +141,14 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dw
 }
 
 void LoadSettings() {
-    g_settings.buttonWidthPercent = Wh_GetIntSetting(L"buttonWidthPercent");
-    if (g_settings.buttonWidthPercent < 50) g_settings.buttonWidthPercent = 50;
-    if (g_settings.buttonWidthPercent > 300) g_settings.buttonWidthPercent = 300;
+    g_settings.percent = Wh_GetIntSetting(L"buttonWidthPercent");
+    if (g_settings.percent <= 0) g_settings.percent = 120;
+    else if (g_settings.percent < 50) g_settings.percent = 50;
+    else if (g_settings.percent > 300) g_settings.percent = 300;
 }
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"=== EP Taskbar Button Width v1.3.0 ===");
+    Wh_Log(L"=== EP Taskbar Button Width v1.0.0 ===");
     LoadSettings();
 
     HMODULE hMods[1024];
@@ -169,7 +180,7 @@ void Wh_ModAfterInit() {
 }
 
 void Wh_ModUninit() {
-    g_settings.buttonWidthPercent = 100;
+    g_settings.percent = 100;
     RefreshTaskbar();
 }
 


### PR DESCRIPTION
## Summary

New mod to customize taskbar button width when using ExplorerPatcher's Windows 10 taskbar on Windows 11.

Before:

![Before](https://i.imgur.com/r82ISo3.png)

After (120%):

![After](https://i.imgur.com/qHaRdVt.png)

The standard registry hack (`HKCU\Control Panel\Desktop\WindowMetrics\MinWidth`) doesn't work with ExplorerPatcher's reimplemented taskbar. This mod hooks `_ComputeSingleButtonWidth` to scale button width as a percentage.

## Requirements

- Windows 11 with ExplorerPatcher installed
- ExplorerPatcher configured to use the Windows 10 taskbar