### PR TITLE
Add Explorer No Minimum Window Size mod

### DIFF
--- a/mods/explorer-no-min-size.wh.cpp
+++ b/mods/explorer-no-min-size.wh.cpp
@@ -20,85 +20,67 @@ width and height. With this mod you can resize Explorer windows to any size.
 
 */
 // ==/WindhawkModReadme==
-
 #include <windhawk_utils.h>
 #include <windows.h>
 
-static bool IsExplorerWindow(HWND hwnd)
-{
+static bool IsExplorerWindow(HWND hwnd) {
     if (!hwnd) return false;
-    wchar_t cls[256] = {};
-    if (!GetClassNameW(hwnd, cls, ARRAYSIZE(cls))) return false;
+    wchar_t cls[256];
+    if (!GetClassNameW(hwnd, cls, 256)) return false;
     return wcscmp(cls, L"CabinetWClass") == 0 || wcscmp(cls, L"ExploreWClass") == 0;
 }
 
-static LRESULT CALLBACK SubclassWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData)
-{
-    if (msg == WM_GETMINMAXINFO)
-    {
-        LRESULT result = DefSubclassProc(hwnd, msg, wParam, lParam);
-        MINMAXINFO* mmi = reinterpret_cast<MINMAXINFO*>(lParam);
-        mmi->ptMinTrackSize.x = 1;
-        mmi->ptMinTrackSize.y = 1;
-        return result;
+static LRESULT CALLBACK SubclassProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp, DWORD_PTR) {
+    if (msg == WM_GETMINMAXINFO) {
+        LRESULT r = DefSubclassProc(hwnd, msg, wp, lp);
+        MINMAXINFO* m = (MINMAXINFO*)lp;
+        m->ptMinTrackSize.x = 1;
+        m->ptMinTrackSize.y = 1;
+        return r;
     }
-    return DefSubclassProc(hwnd, msg, wParam, lParam);
+    return DefSubclassProc(hwnd, msg, wp, lp);
 }
 
-static void SubclassWindow(HWND hwnd)
-{
-    if (!IsExplorerWindow(hwnd)) return;
-    if (WindhawkUtils::SetWindowSubclassFromAnyThread(hwnd, SubclassWndProc, 0))
-        Wh_Log(L"Subclassed HWND %p", hwnd);
+static void Sub(HWND hwnd) {
+    if (IsExplorerWindow(hwnd))
+        WindhawkUtils::SetWindowSubclassFromAnyThread(hwnd, SubclassProc, 0);
 }
 
-static void UnsubclassWindow(HWND hwnd)
-{
-    WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwnd, SubclassWndProc);
+static void Unsub(HWND hwnd) {
+    WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwnd, SubclassProc);
 }
 
-static BOOL CALLBACK EnumSubclass(HWND hwnd, LPARAM)
-{
-    DWORD pid = 0;
+static BOOL CALLBACK EnumSub(HWND hwnd, LPARAM) {
+    DWORD pid;
     GetWindowThreadProcessId(hwnd, &pid);
-    if (pid == GetCurrentProcessId()) SubclassWindow(hwnd);
+    if (pid == GetCurrentProcessId()) Sub(hwnd);
     return TRUE;
 }
 
-static BOOL CALLBACK EnumUnsubclass(HWND hwnd, LPARAM)
-{
-    DWORD pid = 0;
+static BOOL CALLBACK EnumUnsub(HWND hwnd, LPARAM) {
+    DWORD pid;
     GetWindowThreadProcessId(hwnd, &pid);
-    if (pid == GetCurrentProcessId()) UnsubclassWindow(hwnd);
+    if (pid == GetCurrentProcessId()) Unsub(hwnd);
     return TRUE;
 }
 
-using CreateWindowExW_t = HWND(WINAPI*)(DWORD, LPCWSTR, LPCWSTR, DWORD, int, int, int, int, HWND, HMENU, HINSTANCE, LPVOID);
-CreateWindowExW_t originalCreateWindowExW = nullptr;
+typedef HWND(WINAPI* CWE_t)(DWORD, LPCWSTR, LPCWSTR, DWORD, int, int, int, int, HWND, HMENU, HINSTANCE, LPVOID);
+CWE_t oCWE;
 
-HWND WINAPI CreateWindowExWHook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
-{
-    HWND hwnd = originalCreateWindowExW(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
-    if (hwnd) SubclassWindow(hwnd);
+HWND WINAPI hCWE(DWORD a, LPCWSTR b, LPCWSTR c, DWORD d, int e, int f, int g, int h, HWND i, HMENU j, HINSTANCE k, LPVOID l) {
+    HWND hwnd = oCWE(a, b, c, d, e, f, g, h, i, j, k, l);
+    if (hwnd) Sub(hwnd);
     return hwnd;
 }
 
-BOOL Wh_ModInit()
-{
-    Wh_Log(L"init");
-    Wh_SetFunctionHook(
-        reinterpret_cast<void*>(CreateWindowExW),
-        reinterpret_cast<void*>(CreateWindowExWHook),
-        reinterpret_cast<void**>(&originalCreateWindowExW));
-    EnumWindows(EnumSubclass, 0);
+BOOL Wh_ModInit() {
+    Wh_SetFunctionHook((void*)CreateWindowExW, (void*)hCWE, (void**)&oCWE);
+    EnumWindows(EnumSub, 0);
     return TRUE;
 }
 
-void Wh_ModUninit()
-{
-    Wh_Log(L"uninit");
-    EnumWindows(EnumUnsubclass, 0);
+void Wh_ModUninit() {
+    EnumWindows(EnumUnsub, 0);
 }
 
-void Wh_ModSettingsChanged() {}ttingsChanged() {}
-}
+void Wh_ModSettingsChanged() {}

--- a/mods/explorer-no-min-size.wh.cpp
+++ b/mods/explorer-no-min-size.wh.cpp
@@ -26,18 +26,13 @@ width and height. With this mod you can resize Explorer windows to any size.
 
 static bool IsExplorerWindow(HWND hwnd)
 {
-    if (!hwnd)
-        return false;
+    if (!hwnd) return false;
     wchar_t cls[256] = {};
-    if (!GetClassNameW(hwnd, cls, ARRAYSIZE(cls)))
-        return false;
-    return wcscmp(cls, L"CabinetWClass") == 0 ||
-           wcscmp(cls, L"ExploreWClass") == 0;
+    if (!GetClassNameW(hwnd, cls, ARRAYSIZE(cls))) return false;
+    return wcscmp(cls, L"CabinetWClass") == 0 || wcscmp(cls, L"ExploreWClass") == 0;
 }
 
-static LRESULT CALLBACK SubclassWndProc(
-    HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
-    DWORD_PTR dwRefData)
+static LRESULT CALLBACK SubclassWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData)
 {
     if (msg == WM_GETMINMAXINFO)
     {
@@ -52,8 +47,7 @@ static LRESULT CALLBACK SubclassWndProc(
 
 static void SubclassWindow(HWND hwnd)
 {
-    if (!IsExplorerWindow(hwnd))
-        return;
+    if (!IsExplorerWindow(hwnd)) return;
     if (WindhawkUtils::SetWindowSubclassFromAnyThread(hwnd, SubclassWndProc, 0))
         Wh_Log(L"Subclassed HWND %p", hwnd);
 }
@@ -67,8 +61,7 @@ static BOOL CALLBACK EnumSubclass(HWND hwnd, LPARAM)
 {
     DWORD pid = 0;
     GetWindowThreadProcessId(hwnd, &pid);
-    if (pid == GetCurrentProcessId())
-        SubclassWindow(hwnd);
+    if (pid == GetCurrentProcessId()) SubclassWindow(hwnd);
     return TRUE;
 }
 
@@ -76,28 +69,17 @@ static BOOL CALLBACK EnumUnsubclass(HWND hwnd, LPARAM)
 {
     DWORD pid = 0;
     GetWindowThreadProcessId(hwnd, &pid);
-    if (pid == GetCurrentProcessId())
-        UnsubclassWindow(hwnd);
+    if (pid == GetCurrentProcessId()) UnsubclassWindow(hwnd);
     return TRUE;
 }
 
-using CreateWindowExW_t = HWND(WINAPI*)(
-    DWORD, LPCWSTR, LPCWSTR, DWORD,
-    int, int, int, int,
-    HWND, HMENU, HINSTANCE, LPVOID);
-
+using CreateWindowExW_t = HWND(WINAPI*)(DWORD, LPCWSTR, LPCWSTR, DWORD, int, int, int, int, HWND, HMENU, HINSTANCE, LPVOID);
 CreateWindowExW_t originalCreateWindowExW = nullptr;
 
-HWND WINAPI CreateWindowExWHook(
-    DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName,
-    DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
-    HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
+HWND WINAPI CreateWindowExWHook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
 {
-    HWND hwnd = originalCreateWindowExW(
-        dwExStyle, lpClassName, lpWindowName, dwStyle,
-        X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
-    if (hwnd)
-        SubclassWindow(hwnd);
+    HWND hwnd = originalCreateWindowExW(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+    if (hwnd) SubclassWindow(hwnd);
     return hwnd;
 }
 
@@ -118,5 +100,5 @@ void Wh_ModUninit()
     EnumWindows(EnumUnsubclass, 0);
 }
 
-void Wh_ModSettingsChanged() {}
+void Wh_ModSettingsChanged() {}ttingsChanged() {}
 }

--- a/mods/explorer-no-min-size.wh.cpp
+++ b/mods/explorer-no-min-size.wh.cpp
@@ -1,0 +1,181 @@
+// ==WindhawkMod==
+// @id              explorer-no-min-size
+// @name            Explorer No Minimum Window Size
+// @description     Removes the minimum window size restriction in File Explorer, allowing windows to be resized freely.
+// @version         1.0.0
+// @author          Anixx
+// @github          https://github.com/Anixx
+// @include         explorer.exe
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Explorer No Minimum Window Size
+
+Removes the minimum window size restriction in Windows File Explorer.
+By default, Explorer prevents windows from being resized below a certain
+width and height. With this mod you can resize Explorer windows to any size.
+
+![screenshot](https://i.imgur.com/eE0Hmr8.png)
+
+*/
+// ==/WindhawkModReadme==
+
+#include <windhawk_utils.h>
+#include <windows.h>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+static bool IsExplorerWindow(HWND hwnd)
+{
+    if (!hwnd)
+        return false;
+
+    wchar_t cls[256] = {};
+    if (!GetClassNameW(hwnd, cls, ARRAYSIZE(cls)))
+        return false;
+
+    return wcscmp(cls, L"CabinetWClass") == 0 ||
+           wcscmp(cls, L"ExploreWClass") == 0;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-window subclassing
+// ─────────────────────────────────────────────────────────────────────────────
+
+static const wchar_t* kPropName = L"WH_OrigWndProc";
+
+static LRESULT CALLBACK SubclassWndProc(HWND hwnd, UINT msg,
+                                         WPARAM wParam, LPARAM lParam)
+{
+    WNDPROC original = reinterpret_cast<WNDPROC>(
+        GetPropW(hwnd, kPropName));
+
+    if (msg == WM_GETMINMAXINFO)
+    {
+        LRESULT result = original
+            ? CallWindowProcW(original, hwnd, msg, wParam, lParam)
+            : DefWindowProcW(hwnd, msg, wParam, lParam);
+
+        MINMAXINFO* mmi = reinterpret_cast<MINMAXINFO*>(lParam);
+        mmi->ptMinTrackSize.x = 1;
+        mmi->ptMinTrackSize.y = 1;
+
+        return result;
+    }
+
+    if (msg == WM_NCDESTROY)
+    {
+        if (original)
+            SetWindowLongPtrW(hwnd, GWLP_WNDPROC,
+                              reinterpret_cast<LONG_PTR>(original));
+        RemovePropW(hwnd, kPropName);
+    }
+
+    return original
+        ? CallWindowProcW(original, hwnd, msg, wParam, lParam)
+        : DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+static void SubclassWindow(HWND hwnd)
+{
+    if (!IsExplorerWindow(hwnd))
+        return;
+    if (GetPropW(hwnd, kPropName))
+        return; // already subclassed
+
+    LONG_PTR original = SetWindowLongPtrW(
+        hwnd, GWLP_WNDPROC,
+        reinterpret_cast<LONG_PTR>(SubclassWndProc));
+
+    SetPropW(hwnd, kPropName, reinterpret_cast<HANDLE>(original));
+    Wh_Log(L"Subclassed HWND %p", hwnd);
+}
+
+static void UnsubclassWindow(HWND hwnd)
+{
+    WNDPROC original = reinterpret_cast<WNDPROC>(
+        GetPropW(hwnd, kPropName));
+    if (!original)
+        return;
+
+    SetWindowLongPtrW(hwnd, GWLP_WNDPROC,
+                      reinterpret_cast<LONG_PTR>(original));
+    RemovePropW(hwnd, kPropName);
+    Wh_Log(L"Unsubclassed HWND %p", hwnd);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// EnumWindows callbacks  (plain functions – no captures, convertible to WNDENUMPROC)
+// ─────────────────────────────────────────────────────────────────────────────
+
+static BOOL CALLBACK EnumSubclass(HWND hwnd, LPARAM /*lParam*/)
+{
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hwnd, &pid);
+    if (pid == GetCurrentProcessId())
+        SubclassWindow(hwnd);
+    return TRUE;
+}
+
+static BOOL CALLBACK EnumUnsubclass(HWND hwnd, LPARAM /*lParam*/)
+{
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hwnd, &pid);
+    if (pid == GetCurrentProcessId())
+        UnsubclassWindow(hwnd);
+    return TRUE;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CreateWindowExW hook – catch windows as they are created
+// ─────────────────────────────────────────────────────────────────────────────
+
+using CreateWindowExW_t = HWND(WINAPI *)(
+    DWORD, LPCWSTR, LPCWSTR, DWORD,
+    int, int, int, int,
+    HWND, HMENU, HINSTANCE, LPVOID);
+
+CreateWindowExW_t originalCreateWindowExW = nullptr;
+
+HWND WINAPI CreateWindowExWHook(
+    DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName,
+    DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
+    HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
+{
+    HWND hwnd = originalCreateWindowExW(
+        dwExStyle, lpClassName, lpWindowName, dwStyle,
+        X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+
+    if (hwnd)
+        SubclassWindow(hwnd);
+
+    return hwnd;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Windhawk entry points
+// ─────────────────────────────────────────────────────────────────────────────
+
+BOOL Wh_ModInit()
+{
+    Wh_Log(L"Explorer No Minimum Window Size – init");
+
+    Wh_SetFunctionHook(
+        reinterpret_cast<void*>(CreateWindowExW),
+        reinterpret_cast<void*>(CreateWindowExWHook),
+        reinterpret_cast<void**>(&originalCreateWindowExW));
+
+    // Subclass windows that are already open.
+    EnumWindows(EnumSubclass, 0);
+
+    return TRUE;
+}
+
+void Wh_ModUninit()
+{
+    Wh_Log(L"Explorer No Minimum Window Size – uninit");
+    EnumWindows(EnumUnsubclass, 0);
+}

--- a/mods/explorer-no-min-size.wh.cpp
+++ b/mods/explorer-no-min-size.wh.cpp
@@ -24,94 +24,46 @@ width and height. With this mod you can resize Explorer windows to any size.
 #include <windhawk_utils.h>
 #include <windows.h>
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Helpers
-// ─────────────────────────────────────────────────────────────────────────────
-
 static bool IsExplorerWindow(HWND hwnd)
 {
     if (!hwnd)
         return false;
-
     wchar_t cls[256] = {};
     if (!GetClassNameW(hwnd, cls, ARRAYSIZE(cls)))
         return false;
-
     return wcscmp(cls, L"CabinetWClass") == 0 ||
            wcscmp(cls, L"ExploreWClass") == 0;
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Per-window subclassing
-// ─────────────────────────────────────────────────────────────────────────────
-
-static const wchar_t* kPropName = L"WH_OrigWndProc";
-
-static LRESULT CALLBACK SubclassWndProc(HWND hwnd, UINT msg,
-                                         WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK SubclassWndProc(
+    HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
+    DWORD_PTR dwRefData)
 {
-    WNDPROC original = reinterpret_cast<WNDPROC>(
-        GetPropW(hwnd, kPropName));
-
     if (msg == WM_GETMINMAXINFO)
     {
-        LRESULT result = original
-            ? CallWindowProcW(original, hwnd, msg, wParam, lParam)
-            : DefWindowProcW(hwnd, msg, wParam, lParam);
-
+        LRESULT result = DefSubclassProc(hwnd, msg, wParam, lParam);
         MINMAXINFO* mmi = reinterpret_cast<MINMAXINFO*>(lParam);
         mmi->ptMinTrackSize.x = 1;
         mmi->ptMinTrackSize.y = 1;
-
         return result;
     }
-
-    if (msg == WM_NCDESTROY)
-    {
-        if (original)
-            SetWindowLongPtrW(hwnd, GWLP_WNDPROC,
-                              reinterpret_cast<LONG_PTR>(original));
-        RemovePropW(hwnd, kPropName);
-    }
-
-    return original
-        ? CallWindowProcW(original, hwnd, msg, wParam, lParam)
-        : DefWindowProcW(hwnd, msg, wParam, lParam);
+    return DefSubclassProc(hwnd, msg, wParam, lParam);
 }
 
 static void SubclassWindow(HWND hwnd)
 {
     if (!IsExplorerWindow(hwnd))
         return;
-    if (GetPropW(hwnd, kPropName))
-        return; // already subclassed
-
-    LONG_PTR original = SetWindowLongPtrW(
-        hwnd, GWLP_WNDPROC,
-        reinterpret_cast<LONG_PTR>(SubclassWndProc));
-
-    SetPropW(hwnd, kPropName, reinterpret_cast<HANDLE>(original));
-    Wh_Log(L"Subclassed HWND %p", hwnd);
+    if (WindhawkUtils::SetWindowSubclassFromAnyThread(hwnd, SubclassWndProc, 0))
+        Wh_Log(L"Subclassed HWND %p", hwnd);
 }
 
 static void UnsubclassWindow(HWND hwnd)
 {
-    WNDPROC original = reinterpret_cast<WNDPROC>(
-        GetPropW(hwnd, kPropName));
-    if (!original)
-        return;
-
-    SetWindowLongPtrW(hwnd, GWLP_WNDPROC,
-                      reinterpret_cast<LONG_PTR>(original));
-    RemovePropW(hwnd, kPropName);
-    Wh_Log(L"Unsubclassed HWND %p", hwnd);
+    WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwnd, SubclassWndProc);
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// EnumWindows callbacks  (plain functions – no captures, convertible to WNDENUMPROC)
-// ─────────────────────────────────────────────────────────────────────────────
-
-static BOOL CALLBACK EnumSubclass(HWND hwnd, LPARAM /*lParam*/)
+static BOOL CALLBACK EnumSubclass(HWND hwnd, LPARAM)
 {
     DWORD pid = 0;
     GetWindowThreadProcessId(hwnd, &pid);
@@ -120,7 +72,7 @@ static BOOL CALLBACK EnumSubclass(HWND hwnd, LPARAM /*lParam*/)
     return TRUE;
 }
 
-static BOOL CALLBACK EnumUnsubclass(HWND hwnd, LPARAM /*lParam*/)
+static BOOL CALLBACK EnumUnsubclass(HWND hwnd, LPARAM)
 {
     DWORD pid = 0;
     GetWindowThreadProcessId(hwnd, &pid);
@@ -129,11 +81,7 @@ static BOOL CALLBACK EnumUnsubclass(HWND hwnd, LPARAM /*lParam*/)
     return TRUE;
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// CreateWindowExW hook – catch windows as they are created
-// ─────────────────────────────────────────────────────────────────────────────
-
-using CreateWindowExW_t = HWND(WINAPI *)(
+using CreateWindowExW_t = HWND(WINAPI*)(
     DWORD, LPCWSTR, LPCWSTR, DWORD,
     int, int, int, int,
     HWND, HMENU, HINSTANCE, LPVOID);
@@ -148,34 +96,27 @@ HWND WINAPI CreateWindowExWHook(
     HWND hwnd = originalCreateWindowExW(
         dwExStyle, lpClassName, lpWindowName, dwStyle,
         X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
-
     if (hwnd)
         SubclassWindow(hwnd);
-
     return hwnd;
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Windhawk entry points
-// ─────────────────────────────────────────────────────────────────────────────
-
 BOOL Wh_ModInit()
 {
-    Wh_Log(L"Explorer No Minimum Window Size – init");
-
+    Wh_Log(L"init");
     Wh_SetFunctionHook(
         reinterpret_cast<void*>(CreateWindowExW),
         reinterpret_cast<void*>(CreateWindowExWHook),
         reinterpret_cast<void**>(&originalCreateWindowExW));
-
-    // Subclass windows that are already open.
     EnumWindows(EnumSubclass, 0);
-
     return TRUE;
 }
 
 void Wh_ModUninit()
 {
-    Wh_Log(L"Explorer No Minimum Window Size – uninit");
+    Wh_Log(L"uninit");
     EnumWindows(EnumUnsubclass, 0);
+}
+
+void Wh_ModSettingsChanged() {}
 }


### PR DESCRIPTION
This mod removes the minimum window size restriction in Windows File Explorer, allowing users to resize windows freely.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
