### PR TITLE
fix: desynced Y position on context menu

### DIFF
--- a/mods/taskbar-on-top.wh.cpp
+++ b/mods/taskbar-on-top.wh.cpp
@@ -1488,8 +1488,11 @@ BOOL WINAPI SetWindowPos_Hook(HWND hWnd,
         }
 
         if (!adjusted) {
-            if (Y < workAreaRect.top) {
-                Y = workAreaRect.top;
+			MONITORINFO monitorInfo{.cbSize = sizeof(MONITORINFO)};
+			GetMonitorInfo(monitor, &monitorInfo);
+			
+            if (Y < monitorInfo.rcMonitor.top) {
+                Y = monitorInfo.rcMonitor.top;
             } else if (Y > workAreaRect.bottom - cy) {
                 Y = workAreaRect.bottom - cy;
             }


### PR DESCRIPTION
## Changelog

If this pull request updates an existing mod, describe the changes below:

this patch addresses a bug with taskbar-on-top where the taskbar menu (the one which has "task manager" & "taskbar settings") would be desynced vertically, causing the mouse to sometimes completely miss the menu or reach it too early. the menu now visually lines up with where the buttons actually are

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
