### PR TITLE
Add Explorer No Minimum Window Size mod

### DIFF
--- a/mods/explorer-no-min-size.wh.cpp
+++ b/mods/explorer-no-min-size.wh.cpp
@@ -9,6 +9,16 @@
 // @compilerOptions -lcomctl32
 // ==/WindhawkMod==
 
+// ==WindhawkModReadme==
+/*
+# Explorer No Minimum Window Size
+
+Removes the minimum window size restriction in Windows File Explorer.
+By default, Explorer prevents windows from being resized below a certain
+width and height. With this mod you can resize Explorer windows to any size.
+*/
+// ==/WindhawkModReadme==
+
 #include <windhawk_utils.h>
 #include <windows.h>
 

--- a/mods/explorer-no-min-size.wh.cpp
+++ b/mods/explorer-no-min-size.wh.cpp
@@ -1,0 +1,91 @@
+// ==WindhawkMod==
+// @id              explorer-no-min-size
+// @name            Explorer No Minimum Window Size
+// @description     Removes the minimum window size restriction in File Explorer
+// @version         1.0.0
+// @author          Anixx
+// @github          https://github.com/Anixx
+// @include         explorer.exe
+// @compilerOptions -lcomctl32
+// ==/WindhawkMod==
+
+#include <windhawk_utils.h>
+#include <windows.h>
+
+static bool IsExplorerWindow(HWND hwnd)
+{
+    if (!hwnd) return false;
+    wchar_t cls[256] = {};
+    if (!GetClassNameW(hwnd, cls, ARRAYSIZE(cls))) return false;
+    return wcscmp(cls, L"CabinetWClass") == 0 || wcscmp(cls, L"ExploreWClass") == 0;
+}
+
+static LRESULT CALLBACK SubclassWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData)
+{
+    if (msg == WM_GETMINMAXINFO)
+    {
+        LRESULT result = DefSubclassProc(hwnd, msg, wParam, lParam);
+        MINMAXINFO* mmi = reinterpret_cast<MINMAXINFO*>(lParam);
+        mmi->ptMinTrackSize.x = 1;
+        mmi->ptMinTrackSize.y = 1;
+        return result;
+    }
+    return DefSubclassProc(hwnd, msg, wParam, lParam);
+}
+
+static void SubclassWindow(HWND hwnd)
+{
+    if (!IsExplorerWindow(hwnd)) return;
+    if (WindhawkUtils::SetWindowSubclassFromAnyThread(hwnd, SubclassWndProc, 0))
+        Wh_Log(L"Subclassed HWND %p", hwnd);
+}
+
+static void UnsubclassWindow(HWND hwnd)
+{
+    WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwnd, SubclassWndProc);
+}
+
+static BOOL CALLBACK EnumSubclass(HWND hwnd, LPARAM)
+{
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hwnd, &pid);
+    if (pid == GetCurrentProcessId()) SubclassWindow(hwnd);
+    return TRUE;
+}
+
+static BOOL CALLBACK EnumUnsubclass(HWND hwnd, LPARAM)
+{
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hwnd, &pid);
+    if (pid == GetCurrentProcessId()) UnsubclassWindow(hwnd);
+    return TRUE;
+}
+
+using CreateWindowExW_t = HWND(WINAPI*)(DWORD, LPCWSTR, LPCWSTR, DWORD, int, int, int, int, HWND, HMENU, HINSTANCE, LPVOID);
+CreateWindowExW_t originalCreateWindowExW = nullptr;
+
+HWND WINAPI CreateWindowExWHook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
+{
+    HWND hwnd = originalCreateWindowExW(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+    if (hwnd) SubclassWindow(hwnd);
+    return hwnd;
+}
+
+BOOL Wh_ModInit()
+{
+    Wh_Log(L"init");
+    Wh_SetFunctionHook(
+        reinterpret_cast<void*>(CreateWindowExW),
+        reinterpret_cast<void*>(CreateWindowExWHook),
+        reinterpret_cast<void**>(&originalCreateWindowExW));
+    EnumWindows(EnumSubclass, 0);
+    return TRUE;
+}
+
+void Wh_ModUninit()
+{
+    Wh_Log(L"uninit");
+    EnumWindows(EnumUnsubclass, 0);
+}
+
+void Wh_ModSettingsChanged() {}

--- a/mods/explorer-no-min-size.wh.cpp
+++ b/mods/explorer-no-min-size.wh.cpp
@@ -16,6 +16,9 @@
 Removes the minimum window size restriction in Windows File Explorer.
 By default, Explorer prevents windows from being resized below a certain
 width and height. With this mod you can resize Explorer windows to any size.
+
+![screenshot](https://i.imgur.com/eE0Hmr8.png)
+
 */
 // ==/WindhawkModReadme==
 


### PR DESCRIPTION
This mod removes the minimum window size restriction in File Explorer by subclassing the window procedure.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
