### PR TITLE
Update Monitor Sleep Button to v1.1.0

### DIFF
--- a/mods/monitor-sleep-button.wh.cpp
+++ b/mods/monitor-sleep-button.wh.cpp
@@ -2,9 +2,10 @@
 // @id              monitor-sleep-button
 // @name            Monitor Sleep Button
 // @description     Tray icon to turn off the monitor after a configurable countdown.
-// @version         1.0.0
+// @version         1.1.0
 // @author          SilverAmd
 // @github          https://github.com/SilverAmd
+// @twitter         https://twitter.com/SilverAmd
 // @homepage        https://github.com/SilverAmd
 // @include         windhawk.exe
 // @compilerOptions -luser32 -lshell32 -lgdi32
@@ -16,20 +17,60 @@
 /*
 # Monitor Sleep Button
 
-Adds a small tray icon for turning off the monitor.
+Adds a small tray icon for quickly turning off the monitor after a configurable countdown.
+
+## Features
+
+- Tray icon for quick monitor power-off
+- Left-click the tray icon to start the countdown
+- Right-click the tray icon to open a context menu
+- Configurable countdown duration
+- Optional black screen mode for instant blackout without monitor standby
+- Black screen mode can be closed with Esc or mouse click
+- Optional configurable global hotkey
+- Supports `Ctrl`, `Alt`, `Shift` and Windows key modifiers
+- Default hotkey: `Ctrl + M`
+- Hotkey can be enabled or disabled in the mod settings
+- Tray menu can temporarily enable or disable the hotkey for the current session
+- Countdown overlay before the monitor turns off
+- Countdown can be cancelled from the tray menu
+- Countdown can be cancelled with `Esc`
+- Automatically restores the tray icon after taskbar/explorer restart
+- Mouse wheel over the tray icon changes the countdown duration
+- Tray icon displays the currently selected countdown duration
+- Tray menu shortcut to open Windhawk
 
 ## Usage
 
-- Left-click the tray icon.
-- A countdown appears on the screen.
-- After the countdown, the monitor turns off.
+- Left-click the tray icon to start the monitor sleep countdown.
+- Right-click the tray icon to open the tray menu.
+- Press the configured hotkey to start the countdown. The default is `Ctrl + M`.
+- Press `Esc` while the countdown is running to cancel it.
 - Move the mouse or press any key to wake the monitor again.
+- Scroll the mouse wheel over the tray icon to temporarily change the countdown duration.
+
+## Tray Menu
+
+The tray icon context menu provides quick access to:
+
+- Turn monitor off
+- Cancel countdown
+- Enable or disable the configured hotkey for the current session
+- Open Windhawk
+
+The countdown can also be cancelled by pressing `Esc` while it is running.
+
+The tray menu hotkey toggle is temporary.  
+To change the default hotkey behavior permanently, use the Windhawk mod settings.
 
 ## Settings
+
+### Countdown
 
 The countdown duration can be configured in the mod settings.
 
 Available values:
+
 - 1 second
 - 2 seconds
 - 3 seconds
@@ -38,13 +79,68 @@ Available values:
 - 15 seconds
 - 30 seconds
 
+### Action mode
+
+The mod supports two action modes:
+
+- Turn monitor off: Sends the Windows monitor power-off command.
+- Show black screen: Shows a fullscreen black overlay while keeping the monitor active. Black screen mode is ideal when you want an instant blackout and instant wake-up without waiting for the monitor to leave standby. 
+
+
+
+### Hotkey
+
+The global hotkey can be enabled or disabled in the mod settings.
+
+Default:
+
+- `Ctrl + M`
+
+`M` stands for monitor.
+
+The `Esc` key can be used to cancel a running countdown.
+
+### Hotkey conflicts
+
+The hotkey supports `Ctrl`, `Alt`, `Shift` and the Windows key as modifiers.
+
+Examples:
+
+- `Ctrl + M`
+- `Alt + M`
+- `Ctrl + Shift + S`
+- `Ctrl + Alt + S`
+- `Ctrl + Win + J`
+
+Some hotkey combinations may already be used by Windows or other applications, for example `Win + S` for Windows Search.
+
+If a selected hotkey does not work, choose another key combination.
+
+NirSoft HotKeysList can help you check which global hotkeys are already registered on your system:
+
+https://www.nirsoft.net/utils/hot_keys_list.html
+
+## Credits
+
+Based on and inspired by an old PowerShell script:
+
+```batch
+@echo off
+powershell -windowstyle hidden (Add-Type '[DllImport(\"user32.dll\")]^public static extern int PostMessage(int hWnd, int hMsg, int wParam, int lParam);' -Name a -Pas)::PostMessage(-1,0x0112,0xF170,2)
+```
+
+Additional development help and debugging guidance: ChatGPT by OpenAI.
+
 ## Notes
 
-This mod does not shut down, suspend, or lock the computer. It only sends the Windows monitor power-off command.
+This mod does not shut down, suspend, hibernate, or lock the computer.  
+It only sends the Windows monitor power-off command.
 
-Useful as a quick replacement for desktop shortcuts or batch files.
+Useful as a quick replacement for desktop shortcuts, batch files, or context menu entries.
 
-This is useful when long-running downloads, renders, AI model installs, or other background tasks are running and the monitor should be turned off without putting the PC to sleep.
+This is helpful when long-running downloads, renders, AI model installs, backups, or other background tasks are running and the monitor should be turned off without putting the PC to sleep.
+
+Black screen mode does not save as much power as turning the monitor off, because the display remains active.
 */
 // ==/WindhawkModReadme==
 
@@ -53,7 +149,7 @@ This is useful when long-running downloads, renders, AI model installs, or other
 /*
 - countdownSeconds: "3"
   $name: "Countdown seconds"
-  $description: "Number of seconds to show before turning off the monitor."
+  $description: "Number of seconds to show before turning off the monitor. Mouse wheel changes over the tray icon are temporary for the current session. The default countdown duration is still controlled by the Windhawk mod settings."
   $options:
     - "1": "1 second"
     - "2": "2 seconds"
@@ -62,6 +158,33 @@ This is useful when long-running downloads, renders, AI model installs, or other
     - "10": "10 seconds"
     - "15": "15 seconds"
     - "30": "30 seconds"
+
+- actionMode: "monitor_off"
+  $name: Action mode
+  $description: "Choose what happens after the countdown."
+  $options:
+    - "monitor_off": "Turn monitor off"
+    - "black_screen": "Show black screen"
+
+- hotkeyEnabled: true
+  $name: Enable hotkey
+  $description: "Enable global hotkey for starting the monitor sleep countdown. Default is true"
+
+- hotkeyCtrl: true
+  $name: Hotkey Ctrl
+
+- hotkeyAlt: false
+  $name: Hotkey Alt
+
+- hotkeyShift: false
+  $name: Hotkey Shift
+
+- hotkeyWin: false
+  $name: Hotkey Windows key
+
+- hotkeyKey: "M"
+  $name: Hotkey key
+  $description: "Single key used for the hotkey. Default is M"
 */
 // ==/WindhawkModSettings==
 
@@ -69,30 +192,68 @@ This is useful when long-running downloads, renders, AI model installs, or other
 #include <shellapi.h>
 #include <stdlib.h>
 
+#ifndef NIF_SHOWTIP
+#define NIF_SHOWTIP 0x00000080
+#endif
+
 #define WM_TRAYICON (WM_USER + 1)
+
 #define ID_TRAYICON 1001
+#define ID_HOTKEY_MONITOR_OFF 1002
+#define ID_HOTKEY_CANCEL_COUNTDOWN 1003
+#define ID_HOTKEY_CLOSE_BLACK_SCREEN 1004
+
+#define ID_MENU_TURN_OFF 3001
+#define ID_MENU_CANCEL_COUNTDOWN 3002
+#define ID_MENU_TOGGLE_HOTKEY 3003
+#define ID_MENU_OPEN_WINDHAWK 3004
 
 #define TIMER_COUNTDOWN 2001
 #define COUNTDOWN_INTERVAL_MS 1000
 
 #define WM_APP_EXIT (WM_APP + 1)
+#define WM_APP_SETTINGS_CHANGED (WM_APP + 2)
+#define WM_TRAY_SCROLL (WM_APP + 3)
+
+#define HIDDEN_WINDOW_CLASS L"MonitorSleepButtonHiddenWindow"
 
 #define COUNTDOWN_TRANSPARENT_COLOR RGB(1, 2, 3)
 
 
 static HWND g_hwnd = nullptr;
 static HWND g_countdownHwnd = nullptr;
+static HWND g_blackScreenHwnd = nullptr;
+static bool g_blackScreenActive = false;
 
 static HICON g_hIcon = nullptr;
 static NOTIFYICONDATAW g_nid = {};
 static UINT g_taskbarCreatedMessage = 0;
 
+static HHOOK g_mouseHook = nullptr;
+static RECT g_trayIconRect = {};
+static DWORD g_lastScrollTime = 0;
+
 static bool g_countdownActive = false;
 static int g_countdownSeconds = 3;
 static int g_countdownValue = 3;
+static const int g_countdownOptions[] = {1, 2, 3, 5, 10, 15, 30};
+static const int g_countdownOptionCount = ARRAYSIZE(g_countdownOptions);
+static bool g_hotkeyEnabled = true;
+static bool g_hotkeyRegistered = false;
+static UINT g_hotkeyModifiers = MOD_CONTROL;
+static UINT g_hotkeyVk = 'M';
+static WCHAR g_hotkeyName[64] = L"Ctrl+M";
+
+enum ActionMode {
+    ACTION_MONITOR_OFF,
+    ACTION_BLACK_SCREEN,
+};
+
+static ActionMode g_actionMode = ACTION_MONITOR_OFF;
 
 static HANDLE g_uiThread = nullptr;
 static DWORD g_uiThreadId = 0;
+static WCHAR g_windhawkPath[MAX_PATH] = {};
 
 // ------------------------------------------------------------
 // Monitor ausschalten
@@ -106,27 +267,256 @@ void TurnMonitorOff() {
     PostMessageW(HWND_BROADCAST, WM_SYSCOMMAND, SC_MONITORPOWER, 2);
 }
 
-void LoadSettings() {
+void OpenWindhawk() {
+    if (!g_windhawkPath[0]) {
+        Wh_Log(L"Windhawk path is empty.");
+        return;
+    }
+
+    SHELLEXECUTEINFOW sei = {};
+    sei.cbSize = sizeof(sei);
+    sei.lpFile = g_windhawkPath;
+    sei.nShow = SW_SHOWNORMAL;
+
+    if (!ShellExecuteExW(&sei)) {
+        Wh_Log(L"Failed to open Windhawk. Error: %u", GetLastError());
+    }
+}
+
+int ReadCountdownSecondsSetting() {
     PCWSTR countdownSecondsW = Wh_GetStringSetting(L"countdownSeconds");
 
-    g_countdownSeconds = _wtoi(countdownSecondsW);
+    int countdownSeconds = _wtoi(countdownSecondsW);
 
     Wh_FreeStringSetting(countdownSecondsW);
 
-    if (g_countdownSeconds < 1) {
-        g_countdownSeconds = 1;
+    if (countdownSeconds < 1) {
+        countdownSeconds = 1;
     }
 
-    if (g_countdownSeconds > 30) {
-        g_countdownSeconds = 30;
+    if (countdownSeconds > 30) {
+        countdownSeconds = 30;
     }
+
+    return countdownSeconds;
+}
+
+ActionMode ReadActionModeSetting() {
+    PCWSTR actionMode = Wh_GetStringSetting(L"actionMode");
+
+    ActionMode mode = ACTION_MONITOR_OFF;
+
+    if (actionMode && wcscmp(actionMode, L"black_screen") == 0) {
+        mode = ACTION_BLACK_SCREEN;
+    }
+
+    Wh_FreeStringSetting(actionMode);
+
+    return mode;
+}
+
+int GetCountdownOptionIndex(int seconds) {
+    for (int i = 0; i < g_countdownOptionCount; i++) {
+        if (g_countdownOptions[i] == seconds) {
+            return i;
+        }
+    }
+
+    // Fallback to 3 seconds.
+    for (int i = 0; i < g_countdownOptionCount; i++) {
+        if (g_countdownOptions[i] == 3) {
+            return i;
+        }
+    }
+
+    return 0;
+}
+
+bool ReadHotkeyEnabledSetting() {
+    return Wh_GetIntSetting(L"hotkeyEnabled") != 0;
+}
+
+UINT ReadHotkeyModifiersSetting() {
+    UINT modifiers = 0;
+
+    if (Wh_GetIntSetting(L"hotkeyCtrl")) {
+        modifiers |= MOD_CONTROL;
+    }
+
+    if (Wh_GetIntSetting(L"hotkeyAlt")) {
+        modifiers |= MOD_ALT;
+    }
+
+    if (Wh_GetIntSetting(L"hotkeyShift")) {
+        modifiers |= MOD_SHIFT;
+    }
+
+    if (Wh_GetIntSetting(L"hotkeyWin")) {
+        modifiers |= MOD_WIN;
+    }
+
+    // Safety fallback: don't allow a modifier-less global hotkey.
+    if (modifiers == 0) {
+        modifiers = MOD_CONTROL;
+    }
+
+    return modifiers;
+}
+
+UINT ReadHotkeyKeySetting() {
+    PCWSTR hotkeyKey = Wh_GetStringSetting(L"hotkeyKey");
+
+    UINT vk = 'M';
+
+    if (hotkeyKey && hotkeyKey[0]) {
+        WCHAR c = hotkeyKey[0];
+
+        if (c >= L'a' && c <= L'z') {
+            c = c - L'a' + L'A';
+        }
+
+        if ((c >= L'A' && c <= L'Z') || (c >= L'0' && c <= L'9')) {
+            vk = (UINT)c;
+        }
+    }
+
+    Wh_FreeStringSetting(hotkeyKey);
+
+    return vk;
+}
+
+void UpdateHotkeyName() {
+    g_hotkeyName[0] = L'\0';
+
+    if (g_hotkeyModifiers & MOD_CONTROL) {
+        wcscat_s(g_hotkeyName, L"Ctrl+");
+    }
+
+    if (g_hotkeyModifiers & MOD_ALT) {
+        wcscat_s(g_hotkeyName, L"Alt+");
+    }
+
+    if (g_hotkeyModifiers & MOD_SHIFT) {
+        wcscat_s(g_hotkeyName, L"Shift+");
+    }
+
+    if (g_hotkeyModifiers & MOD_WIN) {
+        wcscat_s(g_hotkeyName, L"Win+");
+    }
+
+    WCHAR keyText[8] = {};
+    keyText[0] = (WCHAR)g_hotkeyVk;
+    keyText[1] = L'\0';
+
+    wcscat_s(g_hotkeyName, keyText);
+}
+
+void UpdateTrayTooltip(bool countdownRunning) {
+    if (countdownRunning) {
+        wsprintfW(
+            g_nid.szTip,
+            L"Monitor Sleep Button - %ds countdown running, RMB: Menu, Esc cancels",
+            g_countdownSeconds
+        );
+    } else {
+    PCWSTR actionText =
+        g_actionMode == ACTION_BLACK_SCREEN
+            ? L"LMB: Black screen"
+            : L"LMB: Off";
+
+        wsprintfW(
+            g_nid.szTip,
+            L"Monitor Sleep Button - %ds, %s, RMB: Menu, %s",
+            g_countdownSeconds,
+            actionText,
+            g_hotkeyName
+        );
+    }
+
+    g_nid.uFlags = NIF_TIP | NIF_SHOWTIP; 
+    Shell_NotifyIconW(NIM_MODIFY, &g_nid);
+}
+
+void LoadSettings() {
+    g_countdownSeconds = ReadCountdownSecondsSetting();
+    g_actionMode = ReadActionModeSetting();
+    g_hotkeyEnabled = ReadHotkeyEnabledSetting();
+    g_hotkeyModifiers = ReadHotkeyModifiersSetting();
+    g_hotkeyVk = ReadHotkeyKeySetting();
+    UpdateHotkeyName();
+}
+
+bool RegisterMonitorHotkey() {
+    if (!g_hwnd || !g_hotkeyEnabled) {
+        return false;
+    }
+
+    if (g_hotkeyRegistered) {
+        UnregisterHotKey(g_hwnd, ID_HOTKEY_MONITOR_OFF);
+        g_hotkeyRegistered = false;
+    }
+
+    if (!RegisterHotKey(g_hwnd,
+                        ID_HOTKEY_MONITOR_OFF,
+                        g_hotkeyModifiers,
+                        g_hotkeyVk)) {
+        Wh_Log(L"Failed to register hotkey %s. Error: %u",
+               g_hotkeyName,
+               GetLastError());
+        return false;
+    }
+
+    g_hotkeyRegistered = true;
+    Wh_Log(L"Registered hotkey %s.", g_hotkeyName);
+    return true;
+}
+
+void UnregisterMonitorHotkey() {
+    if (g_hwnd && g_hotkeyRegistered) {
+        UnregisterHotKey(g_hwnd, ID_HOTKEY_MONITOR_OFF);
+        g_hotkeyRegistered = false;
+        Wh_Log(L"Unregistered hotkey %s.", g_hotkeyName);
+    }
+}
+
+void UpdateTrayIcon();
+
+void ApplyRuntimeSettings(int countdownSeconds,
+                          ActionMode actionMode,
+                          bool hotkeyEnabled,
+                          UINT hotkeyModifiers,
+                          UINT hotkeyVk) {
+    UnregisterMonitorHotkey();
+
+    g_countdownSeconds = countdownSeconds;
+    g_actionMode = actionMode;
+    g_hotkeyEnabled = hotkeyEnabled;
+    g_hotkeyModifiers = hotkeyModifiers;
+    g_hotkeyVk = hotkeyVk;
+    UpdateHotkeyName();
+
+    if (g_hwnd) {
+        UpdateTrayIcon();
+        UpdateTrayTooltip(g_countdownActive);
+    }
+
+    if (g_hotkeyEnabled) {
+        RegisterMonitorHotkey();
+    } else {
+        Wh_Log(L"Hotkey disabled.");
+    }
+
+    Wh_Log(L"Runtime settings applied. Countdown seconds: %d, hotkey enabled: %d, hotkey: %s",
+           g_countdownSeconds,
+           g_hotkeyEnabled,
+           g_hotkeyName);
 }
 
 // ------------------------------------------------------------
 // Einfaches eigenes Tray-Icon erzeugen
 // ------------------------------------------------------------
 
-HICON CreateSimpleTrayIcon() {
+HICON CreateSimpleTrayIcon(int countdownSeconds) {
     const int size = 32;
 
     BITMAPINFO bi = {};
@@ -154,38 +544,96 @@ HICON CreateSimpleTrayIcon() {
         return LoadIconW(nullptr, IDI_APPLICATION);
     }
 
-    // Transparenter Hintergrund
     for (int i = 0; i < size * size; i++) {
         pixels[i] = 0x00000000;
     }
 
-    // Kleines Monitor-Symbol malen
-    // Farbe: hellblau
-    DWORD blue = 0xFF00A6FF;
-    DWORD dark = 0xFF202020;
-
-    // Bildschirmrahmen
-    for (int y = 7; y <= 21; y++) {
-        for (int x = 5; x <= 26; x++) {
-            bool border =
-                y == 7 || y == 21 ||
-                x == 5 || x == 26;
-
-            pixels[y * size + x] = border ? blue : dark;
-        }
+    HDC iconHdc = CreateCompatibleDC(nullptr);
+    if (!iconHdc) {
+        DeleteObject(hbmColor);
+        return LoadIconW(nullptr, IDI_APPLICATION);
     }
 
-    // Standfuß
-    for (int y = 22; y <= 24; y++) {
-        for (int x = 14; x <= 17; x++) {
-            pixels[y * size + x] = blue;
-        }
+    HBITMAP oldBitmap = (HBITMAP)SelectObject(iconHdc, hbmColor);
+
+    // Bigger, simpler tray icon:
+    // dark monitor-like background + blue border + large countdown number.
+    HBRUSH bgBrush = CreateSolidBrush(RGB(20, 24, 28));
+    HBRUSH oldBrush = (HBRUSH)SelectObject(iconHdc, bgBrush);
+
+    HPEN borderPen = CreatePen(PS_SOLID, 2, RGB(0, 166, 255));
+    HPEN oldPen = (HPEN)SelectObject(iconHdc, borderPen);
+
+    RoundRect(iconHdc, 0, 1, 32, 31, 5, 5);
+
+    SelectObject(iconHdc, oldPen);
+    DeleteObject(borderPen);
+
+    SelectObject(iconHdc, oldBrush);
+    DeleteObject(bgBrush);
+
+    SetBkMode(iconHdc, TRANSPARENT);
+
+    int fontSize = 28;
+    if (countdownSeconds >= 10) {
+        fontSize = 22;
     }
 
-    // Fuß unten
-    for (int y = 25; y <= 26; y++) {
-        for (int x = 10; x <= 21; x++) {
-            pixels[y * size + x] = blue;
+    HFONT hFont = CreateFontW(
+        fontSize,
+        0,
+        0,
+        0,
+        FW_HEAVY,
+        FALSE,
+        FALSE,
+        FALSE,
+        DEFAULT_CHARSET,
+        OUT_DEFAULT_PRECIS,
+        CLIP_DEFAULT_PRECIS,
+        CLEARTYPE_QUALITY,
+        DEFAULT_PITCH | FF_SWISS,
+        L"Segoe UI"
+    );
+
+    HFONT oldFont = (HFONT)SelectObject(iconHdc, hFont);
+
+    WCHAR text[8];
+    wsprintfW(text, L"%d", countdownSeconds);
+
+    RECT textRect = {-1, 0, 33, 31};
+
+    // Strong shadow for readability.
+    RECT shadowRect = textRect;
+    OffsetRect(&shadowRect, 1, 1);
+    SetTextColor(iconHdc, RGB(0, 0, 0));
+    DrawTextW(
+        iconHdc,
+        text,
+        -1,
+        &shadowRect,
+        DT_CENTER | DT_VCENTER | DT_SINGLELINE
+    );
+
+    SetTextColor(iconHdc, RGB(255, 255, 255));
+    DrawTextW(
+        iconHdc,
+        text,
+        -1,
+        &textRect,
+        DT_CENTER | DT_VCENTER | DT_SINGLELINE
+    );
+
+    SelectObject(iconHdc, oldFont);
+    DeleteObject(hFont);
+
+    SelectObject(iconHdc, oldBitmap);
+    DeleteDC(iconHdc);
+
+    // Fix alpha after GDI drawing.
+    for (int i = 0; i < size * size; i++) {
+        if ((pixels[i] & 0x00FFFFFF) != 0) {
+            pixels[i] |= 0xFF000000;
         }
     }
 
@@ -216,6 +664,18 @@ HICON CreateSimpleTrayIcon() {
 // ------------------------------------------------------------
 // Tray-Icon hinzufügen / entfernen
 // ------------------------------------------------------------
+void RefreshTrayIconRect();
+bool IsPointNearTrayIcon(POINT pt) {
+    RECT rect = g_trayIconRect;
+
+    // Tray icon rect can be slightly off because of DPI/taskbar scaling.
+    // Expand it a bit so mouse wheel over the visible icon is still detected.
+    InflateRect(&rect, 32, 48);
+
+    return PtInRect(&rect, pt) != FALSE;
+}
+bool InstallMouseWheelHook();
+void UninstallMouseWheelHook();
 
 bool AddTrayIcon() {
     if (!g_hwnd) {
@@ -223,7 +683,7 @@ bool AddTrayIcon() {
     }
 
     if (!g_hIcon) {
-        g_hIcon = CreateSimpleTrayIcon();
+        g_hIcon = CreateSimpleTrayIcon(g_countdownSeconds);
     }
 
     ZeroMemory(&g_nid, sizeof(g_nid));
@@ -231,16 +691,35 @@ bool AddTrayIcon() {
     g_nid.cbSize = sizeof(g_nid);
     g_nid.hWnd = g_hwnd;
     g_nid.uID = ID_TRAYICON;
-    g_nid.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
+    g_nid.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP | NIF_SHOWTIP;
     g_nid.uCallbackMessage = WM_TRAYICON;
     g_nid.hIcon = g_hIcon;
 
-    wcscpy_s(g_nid.szTip, L"Monitor Sleep Button - Left-click: Monitor off");
+    PCWSTR actionText =
+    g_actionMode == ACTION_BLACK_SCREEN
+        ? L"LMB: Black screen"
+        : L"LMB: Off";
+
+    wsprintfW(
+        g_nid.szTip,
+        L"Monitor Sleep Button - %ds, %s, RMB: Menu, %s",
+        g_countdownSeconds,
+        actionText,
+        g_hotkeyName
+    );
 
     BOOL result = Shell_NotifyIconW(NIM_ADD, &g_nid);
 
     if (result) {
+        NOTIFYICONDATAW nidVer = {};
+        nidVer.cbSize = sizeof(nidVer);
+        nidVer.hWnd = g_hwnd;
+        nidVer.uID = ID_TRAYICON;
+        nidVer.uVersion = NOTIFYICON_VERSION_4;
+        Shell_NotifyIconW(NIM_SETVERSION, &nidVer);
+
         Wh_Log(L"Tray icon added.");
+        RefreshTrayIconRect();
     } else {
         Wh_Log(L"Failed to add tray icon. Error: %u", GetLastError());
     }
@@ -248,6 +727,128 @@ bool AddTrayIcon() {
     return result != FALSE;
 }
 
+void UpdateTrayIcon() {
+    if (!g_hwnd) {
+        return;
+    }
+
+    HICON newIcon = CreateSimpleTrayIcon(g_countdownSeconds);
+    if (!newIcon) {
+        return;
+    }
+
+    HICON oldIcon = g_hIcon;
+    g_hIcon = newIcon;
+
+    g_nid.uFlags = NIF_ICON;
+    g_nid.hIcon = g_hIcon;
+    Shell_NotifyIconW(NIM_MODIFY, &g_nid);
+    RefreshTrayIconRect();
+
+    if (oldIcon) {
+        DestroyIcon(oldIcon);
+    }
+}
+
+void RefreshTrayIconRect() {
+    if (!g_hwnd) {
+        return;
+    }
+
+    NOTIFYICONIDENTIFIER nii = {};
+    nii.cbSize = sizeof(nii);
+    nii.hWnd = g_hwnd;
+    nii.uID = ID_TRAYICON;
+
+    HRESULT hr = Shell_NotifyIconGetRect(&nii, &g_trayIconRect);
+    if (FAILED(hr)) {
+        SetRectEmpty(&g_trayIconRect);
+        Wh_Log(L"Shell_NotifyIconGetRect failed. HRESULT: 0x%08X", hr);
+        return;
+    }
+}
+
+LRESULT CALLBACK LowLevelMouseProc(int nCode, WPARAM wParam, LPARAM lParam) {
+    if (nCode == HC_ACTION && wParam == WM_MOUSEWHEEL) {
+        const MSLLHOOKSTRUCT* ms =
+            reinterpret_cast<const MSLLHOOKSTRUCT*>(lParam);
+
+        short delta = static_cast<short>(HIWORD(ms->mouseData));
+        int direction = (delta > 0) ? 1 : -1;
+
+        BOOL inside = IsPointNearTrayIcon(ms->pt);
+
+        if (inside && g_hwnd) {
+            PostMessageW(
+                g_hwnd,
+                WM_TRAY_SCROLL,
+                static_cast<WPARAM>(direction),
+                0
+            );
+
+            return 1;
+        }
+    }
+
+    return CallNextHookEx(g_mouseHook, nCode, wParam, lParam);
+}
+
+bool InstallMouseWheelHook() {
+    if (g_mouseHook) {
+        return true;
+    }
+
+    g_mouseHook = SetWindowsHookExW(
+        WH_MOUSE_LL,
+        LowLevelMouseProc,
+        GetModuleHandleW(nullptr),
+        0
+    );
+
+    if (!g_mouseHook) {
+        Wh_Log(L"Failed to register mouse wheel hook. Error: %u", GetLastError());
+        return false;
+    }
+
+    Wh_Log(L"Mouse wheel hook registered.");
+    return true;
+}
+
+void UninstallMouseWheelHook() {
+    if (g_mouseHook) {
+        UnhookWindowsHookEx(g_mouseHook);
+        g_mouseHook = nullptr;
+        Wh_Log(L"Mouse wheel hook unregistered.");
+    }
+}
+
+void ChangeCountdownDurationByWheel(int direction) {
+    if (g_countdownActive) {
+        return;
+    }
+
+    int index = GetCountdownOptionIndex(g_countdownSeconds);
+
+    if (direction > 0) {
+        index++;
+        if (index >= g_countdownOptionCount) {
+            index = 0;
+        }
+    } else {
+        index--;
+        if (index < 0) {
+            index = g_countdownOptionCount - 1;
+        }
+    }
+
+    g_countdownSeconds = g_countdownOptions[index];
+
+    UpdateTrayIcon();
+    UpdateTrayTooltip(false);
+
+    Wh_Log(L"Countdown duration changed by mouse wheel: %d seconds",
+           g_countdownSeconds);
+}
 
 void RemoveTrayIcon() {
     if (g_hwnd) {
@@ -267,6 +868,116 @@ void DestroyCountdownWindow() {
     }
 }
 
+LRESULT CALLBACK BlackScreenWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    switch (msg) {
+        case WM_SETCURSOR:
+            SetCursor(nullptr);
+            return TRUE;
+
+        case WM_MOUSEMOVE:
+            SetCursor(nullptr);
+            return 0;
+
+        case WM_PAINT: {
+            PAINTSTRUCT ps;
+            HDC hdc = BeginPaint(hwnd, &ps);
+
+            RECT rect;
+            GetClientRect(hwnd, &rect);
+
+            HBRUSH brush = CreateSolidBrush(RGB(0, 0, 0));
+            FillRect(hdc, &rect, brush);
+            DeleteObject(brush);
+
+            EndPaint(hwnd, &ps);
+            return 0;
+        }
+
+        case WM_KEYDOWN:
+            if (wParam == VK_ESCAPE) {
+                PostMessageW(g_hwnd, WM_HOTKEY, ID_HOTKEY_CLOSE_BLACK_SCREEN, 0);
+                return 0;
+            }
+            break;
+
+        case WM_LBUTTONDOWN:
+        case WM_RBUTTONDOWN:
+        case WM_MBUTTONDOWN:
+            PostMessageW(g_hwnd, WM_HOTKEY, ID_HOTKEY_CLOSE_BLACK_SCREEN, 0);
+            return 0;
+
+        case WM_ERASEBKGND:
+            return 1;
+    }
+
+    return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+bool CreateBlackScreenWindow() {
+    if (g_blackScreenHwnd) {
+        return true;
+    }
+
+    HINSTANCE hInstance = GetModuleHandleW(nullptr);
+
+    const wchar_t CLASS_NAME[] = L"MonitorSleepBlackScreenWindow";
+
+    WNDCLASSW wc = {};
+    wc.lpfnWndProc = BlackScreenWindowProc;
+    wc.hInstance = hInstance;
+    wc.lpszClassName = CLASS_NAME;
+    wc.hCursor = nullptr;
+
+    RegisterClassW(&wc);
+
+    int x = GetSystemMetrics(SM_XVIRTUALSCREEN);
+    int y = GetSystemMetrics(SM_YVIRTUALSCREEN);
+    int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+    int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+
+    g_blackScreenHwnd = CreateWindowExW(
+        WS_EX_TOPMOST | WS_EX_TOOLWINDOW,
+        CLASS_NAME,
+        L"Monitor Sleep Black Screen",
+        WS_POPUP,
+        x,
+        y,
+        width,
+        height,
+        nullptr,
+        nullptr,
+        hInstance,
+        nullptr
+    );
+
+    if (!g_blackScreenHwnd) {
+        Wh_Log(L"Failed to create black screen window. Error: %u", GetLastError());
+        return false;
+    }
+
+    ShowWindow(g_blackScreenHwnd, SW_SHOW);
+    SetForegroundWindow(g_blackScreenHwnd);
+    SetFocus(g_blackScreenHwnd);
+    UpdateWindow(g_blackScreenHwnd);
+
+    g_blackScreenActive = true;
+
+    RegisterHotKey(g_hwnd, ID_HOTKEY_CLOSE_BLACK_SCREEN, 0, VK_ESCAPE);
+
+    Wh_Log(L"Black screen shown.");
+    return true;
+}
+
+void DestroyBlackScreenWindow() {
+    if (g_blackScreenHwnd) {
+        UnregisterHotKey(g_hwnd, ID_HOTKEY_CLOSE_BLACK_SCREEN);
+        DestroyWindow(g_blackScreenHwnd);
+        g_blackScreenHwnd = nullptr;
+    }
+
+    g_blackScreenActive = false;
+    Wh_Log(L"Black screen closed.");
+}
 
 LRESULT CALLBACK CountdownWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     switch (msg) {
@@ -288,7 +999,7 @@ LRESULT CALLBACK CountdownWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM 
                 0,
                 0,
                 0,
-                FW_BOLD,
+                FW_HEAVY,
                 FALSE,
                 FALSE,
                 FALSE,
@@ -394,6 +1105,11 @@ bool CreateCountdownWindow() {
 
 
 void StartCountdown(HWND hwnd) {
+    if (g_blackScreenActive) {
+        DestroyBlackScreenWindow();
+        return;
+    }
+
     if (g_countdownActive) {
         return;
     }
@@ -405,39 +1121,120 @@ void StartCountdown(HWND hwnd) {
 
     CreateCountdownWindow();
 
-    lstrcpynW(
-        g_nid.szTip,
-        L"Monitor Sleep Button - Countdown running...",
-        ARRAYSIZE(g_nid.szTip)
-    );
-    g_nid.uFlags = NIF_TIP;
-    Shell_NotifyIconW(NIM_MODIFY, &g_nid);
+    UpdateTrayTooltip(true);
 
     SetTimer(hwnd, TIMER_COUNTDOWN, COUNTDOWN_INTERVAL_MS, nullptr);
+
+    if (!RegisterHotKey(hwnd, ID_HOTKEY_CANCEL_COUNTDOWN, 0, VK_ESCAPE)) {
+        Wh_Log(L"Failed to register ESC cancel hotkey. Error: %u", GetLastError());
+    } else {
+        Wh_Log(L"Registered ESC cancel hotkey.");
+    }
 }
 
+void CancelCountdown(HWND hwnd) {
+    if (!g_countdownActive) {
+        return;
+    }
 
-void FinishCountdown(HWND hwnd) {
     KillTimer(hwnd, TIMER_COUNTDOWN);
+    UnregisterHotKey(hwnd, ID_HOTKEY_CANCEL_COUNTDOWN);
 
     g_countdownActive = false;
 
     DestroyCountdownWindow();
 
-    lstrcpynW(
-        g_nid.szTip,
-        L"Monitor Sleep Button - Left-click: Monitor off",
-        ARRAYSIZE(g_nid.szTip)
-    );
-    g_nid.uFlags = NIF_TIP;
-    Shell_NotifyIconW(NIM_MODIFY, &g_nid);
+    UpdateTrayTooltip(false);
 
-    TurnMonitorOff();
+    Wh_Log(L"Countdown cancelled.");
+}
+
+void ShowTrayContextMenu(HWND hwnd) {
+    HMENU menu = CreatePopupMenu();
+    if (!menu) {
+        return;
+    }
+
+    AppendMenuW(
+        menu,
+        MF_STRING,
+        ID_MENU_TURN_OFF,
+        g_actionMode == ACTION_BLACK_SCREEN
+            ? L"Start countdown: Show black screen"
+            : L"Start countdown: Turn monitor off"
+    );
+
+    if (g_countdownActive) {
+        AppendMenuW(menu, MF_STRING, ID_MENU_CANCEL_COUNTDOWN, L"Cancel countdown    Esc");
+    } else {
+        AppendMenuW(menu, MF_STRING | MF_GRAYED, ID_MENU_CANCEL_COUNTDOWN, L"Cancel countdown    Esc");
+    }
+
+    AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
+
+    WCHAR hotkeyMenuText[128];
+
+    wsprintfW(
+        hotkeyMenuText,
+        g_hotkeyEnabled ? L"Disable %s for this session" : L"Enable %s for this session",
+        g_hotkeyName
+    );
+
+    AppendMenuW(
+        menu,
+        MF_STRING,
+        ID_MENU_TOGGLE_HOTKEY,
+        hotkeyMenuText
+    );
+
+    AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
+    AppendMenuW(menu, MF_STRING, ID_MENU_OPEN_WINDHAWK, L"Open Windhawk");
+
+    POINT pt;
+    GetCursorPos(&pt);
+
+    SetForegroundWindow(hwnd);
+
+    TrackPopupMenu(
+        menu,
+        TPM_RIGHTBUTTON | TPM_BOTTOMALIGN | TPM_LEFTALIGN,
+        pt.x,
+        pt.y,
+        0,
+        hwnd,
+        nullptr
+    );
+
+    PostMessageW(hwnd, WM_NULL, 0, 0);
+
+    DestroyMenu(menu);
+}
+
+void FinishCountdown(HWND hwnd) {
+    KillTimer(hwnd, TIMER_COUNTDOWN);
+    UnregisterHotKey(hwnd, ID_HOTKEY_CANCEL_COUNTDOWN);
+
+    g_countdownActive = false;
+
+    DestroyCountdownWindow();
+
+    UpdateTrayTooltip(false);
+
+    if (g_actionMode == ACTION_BLACK_SCREEN) {
+        CreateBlackScreenWindow();
+    } else {
+        TurnMonitorOff();
+    }
 }
 
 void WhTool_ModSettingsChanged() {
-    LoadSettings();
-    Wh_Log(L"Settings changed. Countdown seconds: %d", g_countdownSeconds);
+    ApplyRuntimeSettings(
+        ReadCountdownSecondsSetting(),
+        ReadActionModeSetting(),
+        ReadHotkeyEnabledSetting(),
+        ReadHotkeyModifiersSetting(),
+        ReadHotkeyKeySetting()
+    );
 }
 
 // ------------------------------------------------------------
@@ -445,6 +1242,7 @@ void WhTool_ModSettingsChanged() {
 // ------------------------------------------------------------
 
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+
     if (msg == WM_APP_EXIT) {
         Wh_Log(L"Exit message received.");
 
@@ -453,7 +1251,11 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         g_countdownActive = false;
 
         DestroyCountdownWindow();
+        DestroyBlackScreenWindow();
         RemoveTrayIcon();
+
+        UnregisterMonitorHotkey();
+        UninstallMouseWheelHook();
 
         DestroyWindow(hwnd);
         g_hwnd = nullptr;
@@ -462,15 +1264,111 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         return 0;
     }
 
+    if (msg == WM_APP_SETTINGS_CHANGED) {
+        DWORD packedSettings = (DWORD)wParam;
+        int newCountdownSeconds = packedSettings & 0xFFFF;
+        ActionMode newActionMode =
+            (ActionMode)((packedSettings >> 16) & 0xFFFF);
+
+        DWORD packedHotkey = (DWORD)lParam;
+        bool newHotkeyEnabled = (packedHotkey & 0x01) != 0;
+        UINT newHotkeyModifiers = (packedHotkey >> 8) & 0xFF;
+        UINT newHotkeyVk = (packedHotkey >> 16) & 0xFFFF;
+
+        Wh_Log(L"Settings changed message received. Countdown seconds: %d, hotkey enabled: %d",
+            newCountdownSeconds,
+            newHotkeyEnabled);
+
+        ApplyRuntimeSettings(
+            newCountdownSeconds,
+            newActionMode,
+            newHotkeyEnabled,
+            newHotkeyModifiers,
+            newHotkeyVk
+        );
+        return 0;
+    }
+
     if (msg == WM_DESTROY) {
         PostQuitMessage(0);
         return 0;
     }
 
+    if (msg == WM_HOTKEY) {
+        if (wParam == ID_HOTKEY_MONITOR_OFF) {
+            StartCountdown(hwnd);
+            return 0;
+        }
+
+        if (wParam == ID_HOTKEY_CANCEL_COUNTDOWN) {
+            CancelCountdown(hwnd);
+            return 0;
+        }
+
+        if (wParam == ID_HOTKEY_CLOSE_BLACK_SCREEN) {
+            DestroyBlackScreenWindow();
+            return 0;
+        }
+
+        return 0;
+    }
+
+    if (msg == WM_COMMAND) {
+        switch (LOWORD(wParam)) {
+            case ID_MENU_TURN_OFF:
+                StartCountdown(hwnd);
+                return 0;
+
+            case ID_MENU_CANCEL_COUNTDOWN:
+                CancelCountdown(hwnd);
+                return 0;
+
+            case ID_MENU_TOGGLE_HOTKEY:
+                ApplyRuntimeSettings(
+                    g_countdownSeconds,
+                    g_actionMode,
+                    !g_hotkeyEnabled,
+                    g_hotkeyModifiers,
+                    g_hotkeyVk
+                );
+                return 0;
+
+            case ID_MENU_OPEN_WINDHAWK:
+                OpenWindhawk();
+                return 0;
+                }
+
+        return 0;
+    }
+
+    if (msg == WM_TRAY_SCROLL) {
+        DWORD now = GetTickCount();
+
+        if (now - g_lastScrollTime > 150) {
+            g_lastScrollTime = now;
+
+            int direction = static_cast<int>(wParam);
+            ChangeCountdownDurationByWheel(direction);
+        }
+
+        return 0;
+    }
+
     if (msg == WM_TRAYICON) {
-        switch (lParam) {
+        UINT event = LOWORD(lParam);
+
+        switch (event) {
+            case WM_MOUSEMOVE:
+                RefreshTrayIconRect();
+                return 0;
+
             case WM_LBUTTONUP:
                 StartCountdown(hwnd);
+                return 0;
+
+            case WM_RBUTTONUP:
+            case WM_CONTEXTMENU:
+                ShowTrayContextMenu(hwnd);
                 return 0;
         }
 
@@ -512,18 +1410,16 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 bool CreateHiddenWindow() {
     HINSTANCE hInstance = GetModuleHandleW(nullptr);
 
-    const wchar_t CLASS_NAME[] = L"MonitorSleepButtonHiddenWindow";
-
     WNDCLASSW wc = {};
     wc.lpfnWndProc = WindowProc;
     wc.hInstance = hInstance;
-    wc.lpszClassName = CLASS_NAME;
+    wc.lpszClassName = HIDDEN_WINDOW_CLASS;
 
     RegisterClassW(&wc);
 
     g_hwnd = CreateWindowExW(
         0,
-        CLASS_NAME,
+        HIDDEN_WINDOW_CLASS,
         L"Monitor Sleep Button",
         WS_OVERLAPPED,
         0, 0, 0, 0,
@@ -539,6 +1435,8 @@ bool CreateHiddenWindow() {
     }
 
     g_taskbarCreatedMessage = RegisterWindowMessageW(L"TaskbarCreated");
+
+    RegisterMonitorHotkey();
 
     return true;
 }
@@ -557,6 +1455,8 @@ DWORD WINAPI UiThreadProc(LPVOID) {
     }
 
     AddTrayIcon();
+    RefreshTrayIconRect();
+    InstallMouseWheelHook();
 
     MSG msg;
     while (GetMessageW(&msg, nullptr, 0, 0)) {
@@ -570,6 +1470,8 @@ DWORD WINAPI UiThreadProc(LPVOID) {
 
 BOOL WhTool_ModInit() {
     Wh_Log(L"Initializing Monitor Sleep Button...");
+
+    GetModuleFileNameW(nullptr, g_windhawkPath, ARRAYSIZE(g_windhawkPath));
 
     LoadSettings();
 
@@ -809,11 +1711,41 @@ void Wh_ModAfterInit() {
 }
 
 void Wh_ModSettingsChanged() {
-    if (g_isToolModProcessLauncher) {
+    if (!g_isToolModProcessLauncher) {
         return;
     }
 
-    WhTool_ModSettingsChanged();
+    HWND hwnd = FindWindowW(HIDDEN_WINDOW_CLASS, L"Monitor Sleep Button");
+
+    int newCountdownSeconds = ReadCountdownSecondsSetting();
+    ActionMode newActionMode = ReadActionModeSetting();
+    bool newHotkeyEnabled = ReadHotkeyEnabledSetting();
+    UINT newHotkeyModifiers = ReadHotkeyModifiersSetting();
+    UINT newHotkeyVk = ReadHotkeyKeySetting();
+
+    DWORD packedSettings =
+        (newCountdownSeconds & 0xFFFF) |
+        (((DWORD)newActionMode & 0xFFFF) << 16);
+
+    DWORD packedHotkey =
+        (newHotkeyEnabled ? 0x01 : 0x00) |
+        ((newHotkeyModifiers & 0xFF) << 8) |
+        ((newHotkeyVk & 0xFFFF) << 16);
+
+    if (hwnd) {
+        PostMessageW(
+            hwnd,
+            WM_APP_SETTINGS_CHANGED,
+            (WPARAM)packedSettings,
+            (LPARAM)packedHotkey
+        );
+
+        Wh_Log(L"Posted settings changed message to tool window. Countdown seconds: %d, hotkey enabled: %d",
+               newCountdownSeconds,
+               newHotkeyEnabled);
+    } else {
+        Wh_Log(L"Tool window not found for settings update.");
+    }
 }
 
 void Wh_ModUninit() {

--- a/mods/monitor-sleep-button.wh.cpp
+++ b/mods/monitor-sleep-button.wh.cpp
@@ -5,6 +5,7 @@
 // @version         1.1.0
 // @author          SilverAmd
 // @github          https://github.com/SilverAmd
+// @twitter         https://twitter.com/SilverAmd
 // @homepage        https://github.com/SilverAmd
 // @include         windhawk.exe
 // @compilerOptions -luser32 -lshell32 -lgdi32
@@ -211,8 +212,7 @@ Black screen mode does not save as much power as turning the monitor off, becaus
 #define COUNTDOWN_INTERVAL_MS 1000
 
 #define WM_APP_EXIT (WM_APP + 1)
-#define WM_APP_SETTINGS_CHANGED (WM_APP + 2)
-#define WM_TRAY_SCROLL (WM_APP + 3)
+#define WM_TRAY_SCROLL (WM_APP + 2)
 
 #define HIDDEN_WINDOW_CLASS L"MonitorSleepButtonHiddenWindow"
 
@@ -1164,9 +1164,9 @@ void ShowTrayContextMenu(HWND hwnd) {
     );
 
     if (g_countdownActive) {
-        AppendMenuW(menu, MF_STRING, ID_MENU_CANCEL_COUNTDOWN, L"Cancel countdown    Esc");
+        AppendMenuW(menu, MF_STRING, ID_MENU_CANCEL_COUNTDOWN, L"Cancel countdown\tEsc");
     } else {
-        AppendMenuW(menu, MF_STRING | MF_GRAYED, ID_MENU_CANCEL_COUNTDOWN, L"Cancel countdown    Esc");
+        AppendMenuW(menu, MF_STRING | MF_GRAYED, ID_MENU_CANCEL_COUNTDOWN, L"Cancel countdown\tEsc");
     }
 
     AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
@@ -1263,32 +1263,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         return 0;
     }
 
-    if (msg == WM_APP_SETTINGS_CHANGED) {
-        DWORD packedSettings = (DWORD)wParam;
-        int newCountdownSeconds = packedSettings & 0xFFFF;
-        ActionMode newActionMode =
-            (ActionMode)((packedSettings >> 16) & 0xFFFF);
-
-        DWORD packedHotkey = (DWORD)lParam;
-        bool newHotkeyEnabled = (packedHotkey & 0x01) != 0;
-        UINT newHotkeyModifiers = (packedHotkey >> 8) & 0xFF;
-        UINT newHotkeyVk = (packedHotkey >> 16) & 0xFFFF;
-
-        Wh_Log(L"Settings changed message received. Countdown seconds: %d, hotkey enabled: %d",
-            newCountdownSeconds,
-            newHotkeyEnabled);
-
-        ApplyRuntimeSettings(
-            newCountdownSeconds,
-            newActionMode,
-            newHotkeyEnabled,
-            newHotkeyModifiers,
-            newHotkeyVk
-        );
-        return 0;
-    }
-
-    if (msg == WM_DESTROY) {
+        if (msg == WM_DESTROY) {
         PostQuitMessage(0);
         return 0;
     }
@@ -1710,41 +1685,11 @@ void Wh_ModAfterInit() {
 }
 
 void Wh_ModSettingsChanged() {
-    if (!g_isToolModProcessLauncher) {
+    if (g_isToolModProcessLauncher) {
         return;
     }
 
-    HWND hwnd = FindWindowW(HIDDEN_WINDOW_CLASS, L"Monitor Sleep Button");
-
-    int newCountdownSeconds = ReadCountdownSecondsSetting();
-    ActionMode newActionMode = ReadActionModeSetting();
-    bool newHotkeyEnabled = ReadHotkeyEnabledSetting();
-    UINT newHotkeyModifiers = ReadHotkeyModifiersSetting();
-    UINT newHotkeyVk = ReadHotkeyKeySetting();
-
-    DWORD packedSettings =
-        (newCountdownSeconds & 0xFFFF) |
-        (((DWORD)newActionMode & 0xFFFF) << 16);
-
-    DWORD packedHotkey =
-        (newHotkeyEnabled ? 0x01 : 0x00) |
-        ((newHotkeyModifiers & 0xFF) << 8) |
-        ((newHotkeyVk & 0xFFFF) << 16);
-
-    if (hwnd) {
-        PostMessageW(
-            hwnd,
-            WM_APP_SETTINGS_CHANGED,
-            (WPARAM)packedSettings,
-            (LPARAM)packedHotkey
-        );
-
-        Wh_Log(L"Posted settings changed message to tool window. Countdown seconds: %d, hotkey enabled: %d",
-               newCountdownSeconds,
-               newHotkeyEnabled);
-    } else {
-        Wh_Log(L"Tool window not found for settings update.");
-    }
+    WhTool_ModSettingsChanged();
 }
 
 void Wh_ModUninit() {

--- a/mods/monitor-sleep-button.wh.cpp
+++ b/mods/monitor-sleep-button.wh.cpp
@@ -211,7 +211,8 @@ Black screen mode does not save as much power as turning the monitor off, becaus
 #define COUNTDOWN_INTERVAL_MS 1000
 
 #define WM_APP_EXIT (WM_APP + 1)
-#define WM_TRAY_SCROLL (WM_APP + 2)
+#define WM_APP_SETTINGS_CHANGED (WM_APP + 2)
+#define WM_TRAY_SCROLL (WM_APP + 3)
 
 #define HIDDEN_WINDOW_CLASS L"MonitorSleepButtonHiddenWindow"
 
@@ -1226,13 +1227,9 @@ void FinishCountdown(HWND hwnd) {
 }
 
 void WhTool_ModSettingsChanged() {
-    ApplyRuntimeSettings(
-        ReadCountdownSecondsSetting(),
-        ReadActionModeSetting(),
-        ReadHotkeyEnabledSetting(),
-        ReadHotkeyModifiersSetting(),
-        ReadHotkeyKeySetting()
-    );
+    if (g_hwnd) {
+        PostMessageW(g_hwnd, WM_APP_SETTINGS_CHANGED, 0, 0);
+    }
 }
 
 // ------------------------------------------------------------
@@ -1262,7 +1259,21 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         return 0;
     }
 
-        if (msg == WM_DESTROY) {
+    if (msg == WM_APP_SETTINGS_CHANGED) {
+        Wh_Log(L"Settings changed message received.");
+
+        ApplyRuntimeSettings(
+            ReadCountdownSecondsSetting(),
+            ReadActionModeSetting(),
+            ReadHotkeyEnabledSetting(),
+            ReadHotkeyModifiersSetting(),
+            ReadHotkeyKeySetting()
+        );
+
+        return 0;
+    }
+
+    if (msg == WM_DESTROY) {
         PostQuitMessage(0);
         return 0;
     }

--- a/mods/monitor-sleep-button.wh.cpp
+++ b/mods/monitor-sleep-button.wh.cpp
@@ -5,7 +5,6 @@
 // @version         1.1.0
 // @author          SilverAmd
 // @github          https://github.com/SilverAmd
-// @twitter         https://twitter.com/SilverAmd
 // @homepage        https://github.com/SilverAmd
 // @include         windhawk.exe
 // @compilerOptions -luser32 -lshell32 -lgdi32


### PR DESCRIPTION
Adds black screen action mode, dynamic tooltip/menu text, mouse wheel countdown changes, Open Windhawk shortcut, and improved hotkey handling.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

Updates Monitor Sleep Button to v1.1.0.

Changes:

- Configurable global hotkey
- Ctrl / Alt / Shift / Win modifier support
- Right-click tray menu
- Esc cancels the countdown
- Mouse wheel over the tray icon changes countdown duration
- Tray icon displays the selected countdown duration
- Dynamic tray tooltip and menu text
- Open Windhawk shortcut
- New action mode:
  - Turn monitor off
  - Show black screen
- Black screen mode can be closed instantly with Esc, a mouse click, or by pressing the tray hotkey / tray icon again

The black screen mode keeps the monitor active, so it is much faster to dismiss than waking the monitor from standby.

Tested locally on Windows 11.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x ] The submitter, with AI assistance
- - [ ] Claude
- - [x ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
