### PR TITLE
Add mod: Never Auto-Expand Explorer Tree Items

### DIFF
--- a/mods/crystaldiskinfo-smart-auto-refresh.wh.cpp
+++ b/mods/crystaldiskinfo-smart-auto-refresh.wh.cpp
@@ -1,0 +1,177 @@
+// ==WindhawkMod==
+// @id              crystaldiskinfo-smart-auto-refresh
+// @name            CrystalDiskInfo Smart Auto-Refresh
+// @description     Temporarily pauses the Auto-Refresh function whenever the application's main window is visible
+// @version         1.0
+// @author          Kitsune
+// @github          https://github.com/AromaKitsune
+// @include         DiskInfo*.exe
+// @compilerOptions -lcomctl32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# CrystalDiskInfo Smart Auto-Refresh
+CrystalDiskInfo includes an optional Auto-Refresh feature that updates disk
+information at specified intervals, which is useful for background monitoring
+while the application is minimized to the system tray. However, when the
+application's main window is visible, automatic refreshes can interfere with the
+analysis of current disk status, as shifting attribute values make tracking
+specific metrics more difficult.
+
+This mod temporarily pauses the Auto-Refresh function by blocking its disk
+polling cycle whenever the application's main window is visible, allowing for an
+uninterrupted analysis of current disk status.
+
+The Auto-Refresh function resumes once the application is minimized to the
+taskbar or system tray.
+
+**Note:** If CrystalDiskInfo is already running when the mod is loaded, pick one
+of the following options to activate it:
+* Restart the application completely.
+* Select an interval in **Function** → **Auto Refresh**, including the one
+  currently set.
+*/
+// ==/WindhawkModReadme==
+
+#include <windhawk_utils.h>
+#include <windows.h>
+#include <commctrl.h>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+std::mutex g_timerMutex;
+std::unordered_map<HWND, std::unordered_set<UINT_PTR>> g_timerMap;
+
+// Subclass procedure
+LRESULT CALLBACK AutoRefreshSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam,
+    LPARAM lParam, DWORD_PTR dwRefData)
+{
+    if (uMsg == WM_TIMER)
+    {
+        bool isAutoRefreshTimer = false;
+        {
+            std::lock_guard<std::mutex> lock(g_timerMutex);
+            auto it = g_timerMap.find(hWnd);
+            if (it != g_timerMap.end() && it->second.count(wParam))
+            {
+                isAutoRefreshTimer = true;
+            }
+        }
+
+        if (isAutoRefreshTimer)
+        {
+            HWND hRootWnd = GetAncestor(hWnd, GA_ROOT);
+            if (!hRootWnd)
+            {
+                hRootWnd = hWnd;
+            }
+
+            if (IsWindowVisible(hRootWnd) && !IsIconic(hRootWnd))
+            {
+                return 0;
+            }
+        }
+    }
+    else if (uMsg == WM_NCDESTROY)
+    {
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(hWnd,
+            AutoRefreshSubclassProc);
+        std::lock_guard<std::mutex> lock(g_timerMutex);
+        g_timerMap.erase(hWnd);
+    }
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+// Hook for SetTimer
+using SetTimer_t = decltype(&SetTimer);
+SetTimer_t SetTimer_Original;
+UINT_PTR WINAPI SetTimer_Hook(HWND hWnd, UINT_PTR nIDEvent, UINT uElapse,
+    TIMERPROC lpTimerFunc)
+{
+    // CrystalDiskInfo's minimum Auto-Refresh interval is 1 minute
+    // This threshold avoids interfering with unrelated functions by filtering
+    // out high-frequency timers, ensuring only the application's disk polling
+    // cycle is targeted.
+    if (hWnd && uElapse >= 60000)
+    {
+        bool isSubclassRequired = false;
+        {
+            std::lock_guard<std::mutex> lock(g_timerMutex);
+            auto [it, inserted] = g_timerMap.try_emplace(hWnd);
+            if (inserted)
+            {
+                isSubclassRequired = true;
+            }
+            it->second.insert(nIDEvent);
+        }
+
+        if (isSubclassRequired)
+        {
+            WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd,
+                AutoRefreshSubclassProc, 0);
+        }
+    }
+    return SetTimer_Original(hWnd, nIDEvent, uElapse, lpTimerFunc);
+}
+
+// Hook for KillTimer
+using KillTimer_t = decltype(&KillTimer);
+KillTimer_t KillTimer_Original;
+BOOL WINAPI KillTimer_Hook(HWND hWnd, UINT_PTR nIDEvent)
+{
+    if (hWnd)
+    {
+        std::lock_guard<std::mutex> lock(g_timerMutex);
+        auto it = g_timerMap.find(hWnd);
+        if (it != g_timerMap.end())
+        {
+            it->second.erase(nIDEvent);
+        }
+    }
+    return KillTimer_Original(hWnd, nIDEvent);
+}
+
+// Mod initialization
+BOOL Wh_ModInit()
+{
+    Wh_Log(L"Init");
+
+    WindhawkUtils::SetFunctionHook(
+        SetTimer,
+        SetTimer_Hook,
+        &SetTimer_Original
+    );
+
+    WindhawkUtils::SetFunctionHook(
+        KillTimer,
+        KillTimer_Hook,
+        &KillTimer_Original
+    );
+
+    return TRUE;
+}
+
+// Mod uninitialization
+void Wh_ModUninit()
+{
+    Wh_Log(L"Uninit");
+
+    std::vector<HWND> windowsToDetach;
+    {
+        std::lock_guard<std::mutex> lock(g_timerMutex);
+        for (const auto& timerEntry : g_timerMap)
+        {
+            windowsToDetach.push_back(timerEntry.first);
+        }
+        g_timerMap.clear();
+    }
+
+    for (HWND hWnd : windowsToDetach)
+    {
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(hWnd,
+            AutoRefreshSubclassProc);
+    }
+}

--- a/mods/crystaldiskinfo-smart-auto-refresh.wh.cpp
+++ b/mods/crystaldiskinfo-smart-auto-refresh.wh.cpp
@@ -5,7 +5,18 @@
 // @version         1.0
 // @author          Kitsune
 // @github          https://github.com/AromaKitsune
-// @include         DiskInfo*.exe
+// @include         DiskInfo32.exe
+// @include         DiskInfo64.exe
+// @include         DiskInfoA64.exe
+// @include         DiskInfo32A.exe
+// @include         DiskInfo64A.exe
+// @include         DiskInfoA64A.exe
+// @include         DiskInfo32K.exe
+// @include         DiskInfo64K.exe
+// @include         DiskInfoA64K.exe
+// @include         DiskInfo32S.exe
+// @include         DiskInfo64S.exe
+// @include         DiskInfoA64S.exe
 // @compilerOptions -lcomctl32
 // ==/WindhawkMod==
 

--- a/mods/never-auto-expand-explorer-tree-items.wh.cpp
+++ b/mods/never-auto-expand-explorer-tree-items.wh.cpp
@@ -1,0 +1,154 @@
+// ==WindhawkMod==
+// @id              never-auto-expand-explorer-tree-items
+// @name            Never Auto-Expand Explorer Tree Items
+// @description     Stops the unwanted auto-expansion of navigation pane items even if the "Expand to current folder" option is off
+// @version         1.0
+// @author          Kitsune
+// @github          https://github.com/AromaKitsune
+// @include         *
+// @compilerOptions -lcomctl32 -luser32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Never Auto-Expand Explorer Tree Items
+File Explorer automatically expands navigation pane items such as "This PC"
+even if the "Expand to current folder" option is off, specifically when:
+* Opening any folder inside an external drive in a new tab or window.
+* Navigating to any drive after manually expanding and collapsing "This PC".
+
+This mod prevents this unwanted auto-expansion behavior, keeping the navigation
+pane tidy.
+
+| Before | After |
+| :----: | :---: |
+| ![](https://raw.githubusercontent.com/AromaKitsune/My-Windhawk-Mods/main/screenshots/never-auto-expand-explorer-tree-items_before.png) | ![](https://raw.githubusercontent.com/AromaKitsune/My-Windhawk-Mods/main/screenshots/never-auto-expand-explorer-tree-items_after.png) |
+*/
+// ==/WindhawkModReadme==
+
+#include <windhawk_utils.h>
+#include <windows.h>
+#include <commctrl.h>
+
+// Helper: Verify if the tree view belongs to the File Explorer navigation pane
+bool IsExplorerNavigationPane(HWND hTreeView)
+{
+    HWND hParentWnd = GetParent(hTreeView);
+    if (!hParentWnd)
+    {
+        return false;
+    }
+
+    WCHAR szClassName[32];
+    if (GetClassNameW(hParentWnd, szClassName, ARRAYSIZE(szClassName)) &&
+        _wcsicmp(szClassName, L"NamespaceTreeControl") == 0)
+    {
+        // Retrieve the root window to confirm it's a File Explorer window or
+        // file picker dialog
+        HWND hRootWnd = GetAncestor(hTreeView, GA_ROOT);
+        if (!hRootWnd)
+        {
+            return false;
+        }
+
+        if (GetClassNameW(hRootWnd, szClassName, ARRAYSIZE(szClassName)))
+        {
+            if (_wcsicmp(szClassName, L"CabinetWClass") == 0 ||
+                _wcsicmp(szClassName, L"#32770") == 0)
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+// Helper: Verify if the tree view is receiving keyboard or mouse input
+// This allows manual expansion of navigation pane items.
+bool IsUserInteractingWithTreeView(HWND hTreeView)
+{
+    // Verify keyboard interactions
+    HWND hFocusWnd = GetFocus();
+    if (hFocusWnd == hTreeView || IsChild(hTreeView, hFocusWnd))
+    {
+        return true;
+    }
+
+    // Verify mouse interactions
+    if ((GetAsyncKeyState(VK_LBUTTON) & 0x8000) ||
+        (GetAsyncKeyState(VK_RBUTTON) & 0x8000) ||
+        (GetAsyncKeyState(VK_MBUTTON) & 0x8000))
+    {
+        POINT cursorPos;
+        if (GetCursorPos(&cursorPos))
+        {
+            HWND hHoverWnd = WindowFromPoint(cursorPos);
+            if (hHoverWnd == hTreeView || IsChild(hTreeView, hHoverWnd))
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+// Hook for SendMessageW
+using SendMessageW_t = decltype(&SendMessageW);
+SendMessageW_t SendMessageW_Original;
+LRESULT WINAPI SendMessageW_Hook(HWND hWnd, UINT uMsg, WPARAM wParam,
+    LPARAM lParam)
+{
+    if (uMsg != TVM_EXPAND && uMsg != WM_NOTIFY)
+    {
+        return SendMessageW_Original(hWnd, uMsg, wParam, lParam);
+    }
+
+    if (uMsg == TVM_EXPAND && (wParam & TVE_EXPAND))
+    {
+        WCHAR szClassName[16];
+        if (GetClassNameW(hWnd, szClassName, ARRAYSIZE(szClassName)) &&
+            _wcsicmp(szClassName, L"SysTreeView32") == 0)
+        {
+            if (IsExplorerNavigationPane(hWnd) &&
+                !IsUserInteractingWithTreeView(hWnd))
+            {
+                return 0;
+            }
+        }
+    }
+    else if (uMsg == WM_NOTIFY)
+    {
+        auto* pNotifyHeader = reinterpret_cast<LPNMHDR>(lParam);
+        if (pNotifyHeader != nullptr &&
+            pNotifyHeader->code == TVN_ITEMEXPANDINGW)
+        {
+            auto* pTreeViewNotify = reinterpret_cast<LPNMTREEVIEWW>(lParam);
+            if (pTreeViewNotify->action == TVE_EXPAND)
+            {
+                if (IsExplorerNavigationPane(pNotifyHeader->hwndFrom) &&
+                    !IsUserInteractingWithTreeView(pNotifyHeader->hwndFrom))
+                {
+                    return TRUE;
+                }
+            }
+        }
+    }
+
+    return SendMessageW_Original(hWnd, uMsg, wParam, lParam);
+}
+
+// Mod initialization
+BOOL Wh_ModInit()
+{
+    Wh_Log(L"Init");
+
+    WindhawkUtils::SetFunctionHook(
+        SendMessageW,
+        SendMessageW_Hook,
+        &SendMessageW_Original
+    );
+
+    return TRUE;
+}

--- a/mods/never-auto-expand-explorer-tree-items.wh.cpp
+++ b/mods/never-auto-expand-explorer-tree-items.wh.cpp
@@ -12,7 +12,7 @@
 // ==WindhawkModReadme==
 /*
 # Never Auto-Expand Explorer Tree Items
-File Explorer automatically expands navigation pane items such as "This PC"
+File Explorer automatically expands navigation pane items (such as "This PC")
 even if the "Expand to current folder" option is off, specifically when:
 * Opening any folder inside an external drive in a new tab or window.
 * Navigating to any drive after manually expanding and collapsing "This PC".


### PR DESCRIPTION
File Explorer automatically expands navigation pane items (such as "This PC") even if the "Expand to current folder" option is off, specifically when:
* Opening any folder inside an external drive in a new tab or window.
* Navigating to any drive after manually expanding and collapsing "This PC".

This mod prevents this unwanted auto-expansion behavior, keeping the navigation pane tidy.

| Before | After |
| :----: | :---: |
| ![](https://raw.githubusercontent.com/AromaKitsune/My-Windhawk-Mods/main/screenshots/never-auto-expand-explorer-tree-items_before.png) | ![](https://raw.githubusercontent.com/AromaKitsune/My-Windhawk-Mods/main/screenshots/never-auto-expand-explorer-tree-items_after.png) |

Resolves https://github.com/ramensoftware/windhawk-mods/issues/3789

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [x] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
