### PR TITLE
Add explorer-status-metadata v1.3.0

### DIFF
--- a/mods/explorer-status-metadata.wh.cpp
+++ b/mods/explorer-status-metadata.wh.cpp
@@ -4,7 +4,7 @@
 // @description     Appends rich metadata (dimensions, date, type, duration, bitrate, fps) to Explorer's status bar. Zero polling — purely reactive, path-keyed cache.
 // @version         1.3.0
 // @author          VitalS
-// @github          VitalSkib
+// @github          https://github.com/VitalSkib
 // @include         explorer.exe
 // @compilerOptions -lgdi32 -luser32 -lole32 -loleaut32 -luuid -lpropsys
 // ==/WindhawkMod==

--- a/mods/explorer-status-metadata.wh.cpp
+++ b/mods/explorer-status-metadata.wh.cpp
@@ -1,0 +1,839 @@
+// ==WindhawkMod==
+// @id              explorer-status-metadata
+// @name            Explorer Status Bar Metadata
+// @description     Appends rich metadata (dimensions, date, type, duration, bitrate, fps) to Explorer's status bar. Zero polling — purely reactive, path-keyed cache.
+// @version         1.3.0
+// @author          VitalS
+// @github          VitalSkib
+// @include         explorer.exe
+// @compilerOptions -lgdi32 -luser32 -lole32 -loleaut32 -luuid -lpropsys
+// ==/WindhawkMod==
+
+// ==WindhawkModSettings==
+/*
+- allowNetworkDrives: false
+  $name: Enable metadata on network drives (UNC paths)
+  $description: >
+    WARNING: May cause Explorer to freeze for several seconds if the network
+    is slow or unavailable. The metadata lookup is synchronous on the UI thread.
+    Only enable this if you are on a fast, reliable local network.
+
+- allowRemovableDrives: true
+  $name: Enable metadata on removable drives (USB, SD cards)
+  $description: >
+    Metadata lookup on slow removable media (e.g. old USB drives) may cause
+    a brief UI stutter. Fast USB 3.x drives are generally fine.
+
+- cacheEvictCount: 10
+  $name: Cache eviction count
+  $description: >
+    When the cache reaches 1000 entries, this many of the oldest entries
+    are removed. Range: 1-50. Lower values preserve more history;
+    higher values free more memory at once.
+*/
+// ==/WindhawkModSettings==
+
+// ==WindhawkModReadme==
+/*
+# Explorer Status Bar Metadata — v1.3.0
+
+Appends file metadata to the Windows Explorer status bar when a single file
+is selected: dimensions, modification date, file type, duration, bitrate, fps.
+
+## How it works
+- No timers, no polling. Metadata is computed only when the selected file changes.
+- Path-keyed LRU-style cache (1000 entries). Same file = instant return, zero COM calls.
+- Hooks `DrawTextW` and `GetTextExtentPoint32W` in the Explorer UI thread.
+- Custom binary parsers for formats the Windows Property System does not index:
+  SVG, HDR, EXR, TIFF/TX (LE+BE), TGA, WebM/MKV (EBML).
+
+## Settings
+- **Network drives** — disabled by default. Can freeze Explorer on slow networks.
+- **Removable drives** — enabled by default. Disable if you use slow USB media.
+- **Cache evict count** — how many old entries to drop when the 1000-entry limit is hit.
+
+## Changelog
+### v1.3.0
+- Initial release
+*/
+// ==/WindhawkModReadme==
+
+#include <initguid.h>
+#include <windows.h>
+#include <shlobj.h>
+#include <shlguid.h>
+#include <propkey.h>
+#include <propsys.h>
+#include <string>
+#include <algorithm>
+#include <unordered_map>
+#include <vector>
+
+// ─── Undocumented message to obtain IShellBrowser from a window ──────────────
+#define CWM_GETISHELLBROWSER (WM_USER + 7)
+
+// ─── Hook function pointer types ────────────────────────────────────────────
+typedef int  (WINAPI *DrawTextW_t)            (HDC, LPCWSTR, int, LPRECT, UINT);
+typedef BOOL (WINAPI *GetTextExtentPoint32W_t)(HDC, LPCWSTR, int, LPSIZE);
+
+DrawTextW_t             g_origDTW  = nullptr;
+GetTextExtentPoint32W_t g_origGTEP = nullptr;
+
+// ─── Settings (read once at init, immutable afterwards) ──────────────────────
+static bool   g_allowNetworkDrives   = false;
+static bool   g_allowRemovableDrives = true;
+static size_t g_cacheEvictCount      = 10;
+
+// ─── Metadata cache ──────────────────────────────────────────────────────────
+// unordered_map for O(1) lookup + vector to track insertion order for eviction.
+static CRITICAL_SECTION g_cs;
+static std::unordered_map<std::wstring, std::wstring> g_metaCache;
+static std::vector<std::wstring>                      g_cacheOrder; // insertion order
+static const size_t MAX_CACHE_SIZE = 1000;
+
+// ─── Binary structures for TIFF/TX parser ────────────────────────────────────
+#pragma pack(push, 1)
+struct TiffHeader { WORD magic; WORD version; DWORD ifdOffset; };
+struct TiffTag    { WORD tagId; WORD tagType; DWORD count; DWORD valueOffset; };
+#pragma pack(pop)
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// BLOCK 1: Custom format header parsers
+//   Covers formats the Windows Property System does not index natively:
+//   WebM/MKV (EBML), TIFF/TX (LE+BE), SVG, HDR, EXR, TGA.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+struct CustomMeta {
+    int    width  = 0;
+    int    height = 0;
+    double fps    = 0.0;
+};
+
+static CustomMeta ParseCustomFormatMetadata(const std::wstring& filePath, const std::wstring& ext)
+{
+    CustomMeta meta;
+
+    HANDLE hFile = CreateFileW(
+        filePath.c_str(), GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+
+    if (hFile == INVALID_HANDLE_VALUE) {
+        Wh_Log(L"[Parser] Cannot open file: %ls (GLE=%u)", filePath.c_str(), GetLastError());
+        return meta;
+    }
+
+    DWORD bytesRead = 0;
+
+    // ── WebM / MKV (EBML/Matroska) ───────────────────────────────────────────
+    // Flat streaming parse: containers (Segment, Info, Tracks, TrackEntry, Video)
+    // are entered by letting the loop continue into their bodies without skipping.
+    // Leaf elements (PixelWidth, PixelHeight, DefaultDuration) are read directly.
+    if (ext == L"webm" || ext == L"mkv") {
+        unsigned char buf[16384];
+        if (ReadFile(hFile, buf, sizeof(buf), &bytesRead, nullptr) && bytesRead > 16) {
+            const unsigned char* p   = buf;
+            const unsigned char* end = buf + bytesRead;
+
+            // Reads a variable-length EBML ID (1–4 bytes, leading 1-bit signals length)
+            auto readID = [&]() -> uint32_t {
+                if (p >= end) return 0;
+                uint8_t first = *p;
+                if (first == 0) return 0;
+                int     len  = 1;
+                uint8_t mask = 0x80;
+                while (!(first & mask) && len <= 4) { mask >>= 1; len++; }
+                if (p + len > end) return 0;
+                uint32_t val = 0;
+                for (int i = 0; i < len; ++i) val = (val << 8) | *p++;
+                return val;
+            };
+
+            // Reads a variable-length EBML data size (1–8 bytes).
+            // Returns (uint64_t)-1 for "unknown size" (all data bits set).
+            auto readSize = [&]() -> uint64_t {
+                if (p >= end) return 0;
+                uint8_t first = *p;
+                if (first == 0) return 0;
+                int     len  = 1;
+                uint8_t mask = 0x80;
+                while (!(first & mask) && len <= 8) { mask >>= 1; len++; }
+                if (p + len > end) return 0;
+                uint64_t val         = (*p++) & ~mask;
+                for (int i = 1; i < len; ++i) val = (val << 8) | *p++;
+                uint64_t unknownSize = (1ULL << (7 * len)) - 1;
+                if (val == unknownSize) return (uint64_t)-1;
+                return val;
+            };
+
+            // Reads an unsigned integer from the next `size` bytes (big-endian)
+            auto readUint = [&](uint64_t size) -> uint64_t {
+                if (size > 8 || p + size > end) return 0;
+                uint64_t val = 0;
+                for (uint64_t i = 0; i < size; ++i) val = (val << 8) | *p++;
+                return val;
+            };
+
+            while (p < end) {
+                uint32_t id   = readID();
+                if (id == 0) break;
+                uint64_t size = readSize();
+
+                // Handle unknown-size and truncated-in-buffer containers
+                if (size == (uint64_t)-1) {
+                    if (id == 0x18538067 /*Segment*/) size = (uint64_t)(end - p);
+                    else break;
+                } else if (p + size > end) {
+                    // Container body extends past our read buffer — clamp and enter anyway
+                    if (id == 0x18538067 /*Segment*/  || id == 0x1549A966 /*Info*/    ||
+                        id == 0x1654AE6B /*Tracks*/   || id == 0xAE /*TrackEntry*/    ||
+                        id == 0xE0       /*Video*/)
+                        size = (uint64_t)(end - p);
+                    else
+                        break;
+                }
+
+                if (id == 0x18538067 || id == 0x1549A966 || id == 0x1654AE6B ||
+                    id == 0xAE        || id == 0xE0) {
+                    // Container: do not skip, let the loop parse the body directly
+                    continue;
+                } else if (id == 0xB0) {           // PixelWidth
+                    meta.width  = (int)readUint(size);
+                } else if (id == 0xBA) {           // PixelHeight
+                    meta.height = (int)readUint(size);
+                } else if (id == 0x23E383) {       // DefaultDuration (nanoseconds)
+                    uint64_t defDur = readUint(size);
+                    if (defDur > 0) meta.fps = 1000000000.0 / (double)defDur;
+                } else {
+                    // Guard: size == 0 means empty element body.
+                    // Without this break, p would not advance → infinite loop.
+                    if (size == 0) break;
+                    p += size;
+                }
+
+                if (meta.width > 0 && meta.height > 0 && meta.fps > 0.0) break;
+            }
+        }
+    }
+    // ── TIFF / TX ─────────────────────────────────────────────────────────────
+    // Supports both Little-Endian (II, magic=42) and Big-Endian (MM, magic=42 BE).
+    else if (ext == L"tx" || ext == L"tif" || ext == L"tiff") {
+        TiffHeader head;
+        if (ReadFile(hFile, &head, sizeof(head), &bytesRead, nullptr)
+            && bytesRead == sizeof(head))
+        {
+            bool isLE = (head.magic == 0x4949 && head.version == 42);
+            bool isBE = (head.magic == 0x4D4D && head.version == 0x2A00);
+
+            if (isLE || isBE) {
+                DWORD ifdOffset = isLE ? head.ifdOffset : _byteswap_ulong(head.ifdOffset);
+                if (SetFilePointer(hFile, ifdOffset, nullptr, FILE_BEGIN)
+                    != INVALID_SET_FILE_POINTER)
+                {
+                    WORD numTagsRaw = 0;
+                    ReadFile(hFile, &numTagsRaw, sizeof(numTagsRaw), &bytesRead, nullptr);
+                    WORD numTags = isLE ? numTagsRaw : _byteswap_ushort(numTagsRaw);
+
+                    int width = 0, height = 0;
+                    for (WORD i = 0; i < numTags && !(width && height); ++i) {
+                        TiffTag tag;
+                        if (!ReadFile(hFile, &tag, sizeof(tag), &bytesRead, nullptr)) break;
+
+                        WORD  tagId   = isLE ? tag.tagId       : _byteswap_ushort(tag.tagId);
+                        WORD  tagType = isLE ? tag.tagType     : _byteswap_ushort(tag.tagType);
+                        DWORD valOff  = isLE ? tag.valueOffset : _byteswap_ulong(tag.valueOffset);
+
+                        if      (tagId == 0x0100) width  = (tagType == 3) ? (int)(valOff & 0xFFFF) : (int)valOff;
+                        else if (tagId == 0x0101) height = (tagType == 3) ? (int)(valOff & 0xFFFF) : (int)valOff;
+                    }
+                    if (width > 0 && height > 0) { meta.width = width; meta.height = height; }
+                }
+            }
+        }
+    }
+    // ── SVG ───────────────────────────────────────────────────────────────────
+    // Priority: viewBox (logical canvas size). Fallback: explicit width=/height=.
+    // Search is scoped to start at the <svg tag to avoid false matches on nested
+    // elements that appear earlier in the file (e.g. <symbol width=...>).
+    else if (ext == L"svg") {
+        char buf[2048] = {0};
+        if (ReadFile(hFile, buf, sizeof(buf) - 1, &bytesRead, nullptr) && bytesRead > 0) {
+            std::string content(buf, bytesRead);
+            size_t svgTagPos = content.find("<svg");
+            if (svgTagPos == std::string::npos) svgTagPos = 0;
+
+            size_t vbPos = content.find("viewBox=", svgTagPos);
+            if (vbPos != std::string::npos) {
+                size_t q1 = content.find('"', vbPos);
+                if (q1 != std::string::npos) {
+                    size_t q2 = content.find('"', q1 + 1);
+                    if (q2 != std::string::npos) {
+                        float x, y, w, h;
+                        if (sscanf_s(content.substr(q1 + 1, q2 - q1 - 1).c_str(),
+                                     "%f %f %f %f", &x, &y, &w, &h) == 4) {
+                            meta.width  = (int)w;
+                            meta.height = (int)h;
+                        }
+                    }
+                }
+            }
+            if (meta.width == 0) {
+                size_t wPos = content.find("width=",  svgTagPos);
+                size_t hPos = content.find("height=", svgTagPos);
+                if (wPos != std::string::npos && hPos != std::string::npos) {
+                    int w = 0, h = 0;
+                    if (sscanf_s(content.c_str() + wPos,  "width=\"%d",  &w) == 1 &&
+                        sscanf_s(content.c_str() + hPos, "height=\"%d", &h) == 1) {
+                        meta.width = w; meta.height = h;
+                    }
+                }
+            }
+        }
+    }
+    // ── HDR (Radiance RGBE) ───────────────────────────────────────────────────
+    // Resolution line format: "-Y <height> +X <width>"
+    else if (ext == L"hdr") {
+        char buf[1024] = {0};
+        if (ReadFile(hFile, buf, sizeof(buf) - 1, &bytesRead, nullptr) && bytesRead > 0) {
+            std::string content(buf, bytesRead);
+            size_t marker = content.find("-Y");
+            if (marker != std::string::npos) {
+                size_t lineEnd = content.find('\n', marker);
+                if (lineEnd != std::string::npos) {
+                    int w = 0, h = 0;
+                    if (sscanf_s(content.substr(marker, lineEnd - marker).c_str(),
+                                 "-Y %d +X %d", &h, &w) == 2) {
+                        meta.width = w; meta.height = h;
+                    }
+                }
+            }
+        }
+    }
+    // ── EXR (OpenEXR) ─────────────────────────────────────────────────────────
+    // Scans attribute list for "dataWindow" (type box2i: xMin,yMin,xMax,yMax).
+    // Width  = xMax - xMin + 1
+    // Height = yMax - yMin + 1
+    // Uses memcpy to avoid undefined behaviour from unaligned int* cast.
+    else if (ext == L"exr") {
+        unsigned char head[512] = {0};
+        if (ReadFile(hFile, head, sizeof(head), &bytesRead, nullptr) && bytesRead >= 4
+            && head[0] == 0x76 && head[1] == 0x2f && head[2] == 0x31 && head[3] == 0x01)
+        {
+            for (DWORD i = 4; i + 32 < bytesRead; ++i) {
+                if (memcmp(head + i, "dataWindow", 10) == 0) {
+                    size_t off = i + 11; // skip "dataWindow\0"
+                    // Layout: type "box2i\0" (6) + size DWORD (4) + xMin,yMin,xMax,yMax (16)
+                    // Need: off + 26 bytes within the buffer
+                    if (off + 26 <= (size_t)bytesRead
+                        && memcmp(head + off, "box2i", 5) == 0)
+                    {
+                        int box[4];
+                        memcpy(box, head + off + 10, sizeof(box)); // safe unaligned read
+                        int w = box[2] - box[0] + 1;
+                        int h = box[3] - box[1] + 1;
+                        if (w > 0 && h > 0 && w < 65535 && h < 65535) {
+                            meta.width = w; meta.height = h;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    // ── TGA (Truevision TARGA) ────────────────────────────────────────────────
+    // Fixed 18-byte header. Width/height at bytes 12–15 (little-endian WORD each).
+    // Supported image types: 1=CM, 2=RGB, 3=BW (raw) and 9,10,11 (RLE variants).
+    else if (ext == L"tga") {
+        unsigned char hdr[18] = {0};
+        if (ReadFile(hFile, hdr, sizeof(hdr), &bytesRead, nullptr)
+            && bytesRead == sizeof(hdr))
+        {
+            BYTE imgType = hdr[2];
+            if (imgType == 1 || imgType == 2  || imgType == 3  ||
+                imgType == 9 || imgType == 10 || imgType == 11)
+            {
+                int w = (int)(hdr[12] | (hdr[13] << 8));
+                int h = (int)(hdr[14] | (hdr[15] << 8));
+                if (w > 0 && h > 0 && w < 65535 && h < 65535) {
+                    meta.width = w; meta.height = h;
+                }
+            }
+        }
+    }
+
+    CloseHandle(hFile);
+    return meta;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// BLOCK 2: Utility functions
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Returns true if the file at `path` is safe to parse synchronously on the
+// Explorer UI thread (i.e. the read will complete in < ~5 ms).
+// Controlled by Windhawk settings for network and removable drives.
+// Reparse points (junctions, symlinks) are always skipped — they may point
+// to slow or unavailable targets.
+static bool IsSafeToParse(const std::wstring& path)
+{
+    if (path.empty() || path.length() < 3) return false;
+
+    // UNC network paths (\\server\share\...)
+    if (path.size() >= 2 && path[0] == L'\\' && path[1] == L'\\') {
+        if (!g_allowNetworkDrives) {
+            Wh_Log(L"[Safety] Skipping network path: %ls", path.c_str());
+            return false;
+        }
+        // Network paths pass the drive-type and attribute checks below
+        // only if the setting is enabled.
+        goto check_attributes;
+    }
+
+    {
+        wchar_t root[4] = { path[0], L':', L'\\', L'\0' };
+        UINT driveType  = GetDriveTypeW(root);
+
+        if (driveType == DRIVE_REMOVABLE && !g_allowRemovableDrives) {
+            Wh_Log(L"[Safety] Skipping removable drive path: %ls", path.c_str());
+            return false;
+        }
+        if (driveType != DRIVE_FIXED    &&
+            driveType != DRIVE_REMOVABLE &&
+            driveType != DRIVE_REMOTE)   // DRIVE_REMOTE handled above via UNC check
+        {
+            Wh_Log(L"[Safety] Skipping unsupported drive type %u: %ls", driveType, path.c_str());
+            return false;
+        }
+    }
+
+check_attributes:
+    DWORD attr = GetFileAttributesW(path.c_str());
+    if (attr == INVALID_FILE_ATTRIBUTES) return false;
+    if (attr & FILE_ATTRIBUTE_OFFLINE) {
+        Wh_Log(L"[Safety] Skipping offline file: %ls", path.c_str());
+        return false;
+    }
+    if (attr & FILE_ATTRIBUTE_REPARSE_POINT) {
+        // Reparse points (symlinks, junctions) may point anywhere — always skip.
+        return false;
+    }
+
+    return true;
+}
+
+// Detects the Explorer status-bar "N item(s) selected" string without
+// allocating heap memory. Called on every DrawTextW / GetTextExtentPoint32W
+// invocation, so must be as cheap as possible.
+static bool IsSelectionStatus(const wchar_t* s, UINT len)
+{
+    if (!s || len < 2) return false;
+    UINT checkLen = (len < 512u) ? len : 512u;
+
+    for (UINT i = 0; i + 7 < checkLen; ++i) {
+        wchar_t c = s[i];
+        // English: "selected" / "Selected"
+        if ((c == L's' || c == L'S') && wcsncmp(s + i + 1, L"elected", 7) == 0)
+            return true;
+        // Russian: "выбр" (U+0432 U+044B U+0431 U+0440) / "Выбр" (U+0412 ...)
+        if ((c == L'\u0432' || c == L'\u0412') && i + 3 < checkLen &&
+            s[i+1] == L'\u044b' && s[i+2] == L'\u0431' && s[i+3] == L'\u0440')
+            return true;
+    }
+    return false;
+}
+
+// Strips Unicode LTR/RTL directional marks (U+200E, U+200F) that Windows
+// appends to formatted date strings.
+static std::wstring CleanPropString(LPCWSTR src)
+{
+    if (!src) return L"";
+    std::wstring s(src);
+    s.erase(std::remove(s.begin(), s.end(), L'\x200e'), s.end());
+    s.erase(std::remove(s.begin(), s.end(), L'\x200f'), s.end());
+    return s;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// BLOCK 3: Selection path discovery via CWM_GETISHELLBROWSER
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Extracts the filesystem path of the single selected item from a shell browser.
+// Returns empty string if no item or multiple items are selected.
+// GetSelection(FALSE, ...) — FALSE prevents the folder itself from being
+// returned as a "selection" when nothing is actually selected.
+static std::wstring ExtractPathFromBrowser(IShellBrowser* pSB)
+{
+    if (!pSB) return L"";
+    IShellView* pSV = nullptr;
+    if (FAILED(pSB->QueryActiveShellView(&pSV)) || !pSV) return L"";
+
+    std::wstring path;
+    IFolderView2* pFV2 = nullptr;
+    if (SUCCEEDED(pSV->QueryInterface(IID_IFolderView2, (void**)&pFV2)) && pFV2) {
+        IShellItemArray* pIA = nullptr;
+        if (SUCCEEDED(pFV2->GetSelection(FALSE, &pIA)) && pIA) {
+            DWORD cnt = 0;
+            pIA->GetCount(&cnt);
+            if (cnt == 1) {
+                IShellItem* pItem = nullptr;
+                if (SUCCEEDED(pIA->GetItemAt(0, &pItem)) && pItem) {
+                    LPWSTR ps = nullptr;
+                    if (SUCCEEDED(pItem->GetDisplayName(SIGDN_FILESYSPATH, &ps)) && ps) {
+                        path = ps;
+                        CoTaskMemFree(ps);
+                    }
+                    pItem->Release();
+                }
+            }
+            pIA->Release();
+        }
+        pFV2->Release();
+    }
+    pSV->Release();
+    return path;
+}
+
+// Finds the path of the currently selected file in the active Explorer window.
+// Strategy 1: Walk the focus window hierarchy upward, asking each window for
+//             its IShellBrowser via the undocumented CWM_GETISHELLBROWSER message.
+//             SendMessageW to own windows on the same thread dispatches directly
+//             to the window procedure — no queue, no blocking.
+// Strategy 2: Fallback — enumerate ShellTabWindowClass children of the root
+//             window when the focus has moved outside the file list.
+static std::wstring GetSelectionPath(HDC /*hdc*/, HWND& outExplorerRoot)
+{
+    outExplorerRoot = NULL;
+    HWND hFocus = NULL;
+    GUITHREADINFO gti = { sizeof(GUITHREADINFO) };
+    if (GetGUIThreadInfo(GetCurrentThreadId(), &gti))
+        hFocus = gti.hwndFocus ? gti.hwndFocus : gti.hwndActive;
+    if (!hFocus) hFocus = GetForegroundWindow();
+
+    for (HWND h = hFocus; h; h = GetParent(h)) {
+        auto* pSB = (IShellBrowser*)SendMessageW(h, CWM_GETISHELLBROWSER, 0, 0);
+        if (pSB) {
+            std::wstring path = ExtractPathFromBrowser(pSB);
+            if (!path.empty()) {
+                outExplorerRoot = GetAncestor(h, GA_ROOT);
+                return path;
+            }
+        }
+    }
+
+    HWND hRoot = hFocus ? GetAncestor(hFocus, GA_ROOT) : NULL;
+    if (hRoot) {
+        HWND hTab = NULL;
+        while ((hTab = FindWindowExW(hRoot, hTab, L"ShellTabWindowClass", NULL)) != NULL) {
+            auto* pSB = (IShellBrowser*)SendMessageW(hTab, CWM_GETISHELLBROWSER, 0, 0);
+            if (pSB) {
+                std::wstring path = ExtractPathFromBrowser(pSB);
+                if (!path.empty()) {
+                    outExplorerRoot = hRoot;
+                    return path;
+                }
+            }
+        }
+    }
+    return L"";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// BLOCK 4: Metadata suffix builder
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Builds the status-bar suffix string for `filePath`.
+// Called at most once per unique path (results are cached).
+// Metadata priority for dimensions:
+//   1. PKEY_Image_Dimensions  (Windows indexer — covers JPEG, PNG, BMP, …)
+//   2. PKEY_Video_FrameWidth/Height (Windows indexer — covers MP4, AVI, …)
+//   3. Custom binary parser   (SVG, HDR, EXR, TIFF/TX, TGA, WebM/MKV)
+// Date: PSFormatForDisplayAlloc — correctly applies system timezone and DST,
+//       avoiding the ±1 hour error from manual FileTimeToLocalFileTime chains.
+// Bitrate: video property → audio property → file-size / duration estimate.
+// FPS: PKEY_Video_FrameRate → EBML DefaultDuration fallback.
+static std::wstring BuildMetadataSuffix(const std::wstring& filePath)
+{
+    IShellItem2* pItem2 = nullptr;
+    if (FAILED(SHCreateItemFromParsingName(
+            filePath.c_str(), nullptr, IID_PPV_ARGS(&pItem2))) || !pItem2)
+    {
+        Wh_Log(L"[Build] SHCreateItemFromParsingName failed for: %ls", filePath.c_str());
+        return L"";
+    }
+
+    // Determine extension for custom parser dispatch
+    std::wstring ext;
+    size_t dot = filePath.find_last_of(L'.');
+    if (dot != std::wstring::npos) {
+        ext = filePath.substr(dot + 1);
+        std::transform(ext.begin(), ext.end(), ext.begin(), ::towlower);
+    }
+
+    // Run custom parser for formats not covered by the Windows Property System
+    CustomMeta customMeta;
+    if (ext == L"webm" || ext == L"mkv"  ||
+        ext == L"tx"   || ext == L"tif"  || ext == L"tiff" ||
+        ext == L"svg"  || ext == L"hdr"  || ext == L"exr"  || ext == L"tga")
+    {
+        customMeta = ParseCustomFormatMetadata(filePath, ext);
+    }
+
+    std::wstring dimStr, dateStr, typeStr;
+
+    // 1. Dimensions
+    LPWSTR pszDim = nullptr;
+    if (SUCCEEDED(pItem2->GetString(PKEY_Image_Dimensions, &pszDim)) && pszDim) {
+        dimStr = CleanPropString(pszDim);
+        CoTaskMemFree(pszDim);
+    }
+    if (dimStr.empty()) {
+        ULONG fw = 0, fh = 0;
+        if (SUCCEEDED(pItem2->GetUInt32(PKEY_Video_FrameWidth,  &fw)) && fw > 0 &&
+            SUCCEEDED(pItem2->GetUInt32(PKEY_Video_FrameHeight, &fh)) && fh > 0) {
+            wchar_t buf[64];
+            swprintf_s(buf, L"%u x %u", fw, fh);
+            dimStr = buf;
+        }
+    }
+    if (dimStr.empty() && customMeta.width > 0 && customMeta.height > 0) {
+        wchar_t buf[64];
+        swprintf_s(buf, L"%d x %d", customMeta.width, customMeta.height);
+        dimStr = buf;
+    }
+
+    // 2. Modification date
+    // PSFormatForDisplayAlloc handles timezone and DST conversion correctly.
+    PROPVARIANT propVar;
+    PropVariantInit(&propVar);
+    if (SUCCEEDED(pItem2->GetProperty(PKEY_DateModified, &propVar))) {
+        LPWSTR pszDate = nullptr;
+        if (SUCCEEDED(PSFormatForDisplayAlloc(
+                PKEY_DateModified, propVar, PDFF_DEFAULT, &pszDate)) && pszDate) {
+            dateStr = CleanPropString(pszDate);
+            CoTaskMemFree(pszDate);
+        }
+        PropVariantClear(&propVar);
+    }
+
+    // 3. File type description
+    LPWSTR pszType = nullptr;
+    if (SUCCEEDED(pItem2->GetString(PKEY_ItemTypeText, &pszType)) && pszType) {
+        typeStr = CleanPropString(pszType);
+        CoTaskMemFree(pszType);
+    }
+
+    // 4. Duration and derived media properties
+    ULONGLONG duration100ns = 0;
+    bool hasDuration = SUCCEEDED(pItem2->GetUInt64(PKEY_Media_Duration, &duration100ns))
+                       && duration100ns > 0;
+
+    std::wstring sfx;
+    if (!dimStr.empty())  sfx += L"  \u2502  " + dimStr;
+    if (!dateStr.empty()) sfx += L"  \u2502  " + dateStr;
+    if (!typeStr.empty()) sfx += L"  \u2502  " + typeStr;
+
+    if (hasDuration) {
+        ULONG totalSec = (ULONG)(duration100ns / 10000000ULL);
+        ULONG hh = totalSec / 3600;
+        ULONG mm = (totalSec % 3600) / 60;
+        ULONG ss = totalSec % 60;
+        wchar_t durBuf[64];
+        if (hh > 0) swprintf_s(durBuf, L"%02u:%02u:%02u", hh, mm, ss);
+        else        swprintf_s(durBuf, L"%02u:%02u", mm, ss);
+        sfx += L"  \u2502  " + std::wstring(durBuf);
+
+        // Bitrate: video property → audio property → estimate from file size
+        ULONG bitrateBps = 0;
+        if (FAILED(pItem2->GetUInt32(PKEY_Video_TotalBitrate, &bitrateBps)) || !bitrateBps)
+            pItem2->GetUInt32(PKEY_Audio_EncodingBitrate, &bitrateBps);
+        if (bitrateBps == 0) {
+            ULONGLONG fileSize = 0;
+            if (SUCCEEDED(pItem2->GetUInt64(PKEY_Size, &fileSize)) && fileSize > 0) {
+                double durationSec = (double)duration100ns / 10000000.0;
+                if (durationSec > 0)
+                    bitrateBps = (ULONG)((fileSize * 8.0) / durationSec);
+            }
+        }
+        if (bitrateBps > 0) {
+            wchar_t bitBuf[64];
+            if (bitrateBps >= 1000000)
+                swprintf_s(bitBuf, L"%.1f Mbps", (double)bitrateBps / 1000000.0);
+            else
+                swprintf_s(bitBuf, L"%u kbps", bitrateBps / 1000);
+            sfx += L"  \u2502  " + std::wstring(bitBuf);
+        }
+
+        // FPS: Windows property system → EBML DefaultDuration fallback
+        ULONG fps1000 = 0;
+        if (!SUCCEEDED(pItem2->GetUInt32(PKEY_Video_FrameRate, &fps1000)) || !fps1000) {
+            if (customMeta.fps > 0.0)
+                fps1000 = (ULONG)(customMeta.fps * 1000.0 + 0.5);
+        }
+        if (fps1000 > 0) {
+            wchar_t fpsBuf[64];
+            if (fps1000 % 1000 == 0) swprintf_s(fpsBuf, L"%u fps", fps1000 / 1000);
+            else                     swprintf_s(fpsBuf, L"%.2f fps", (double)fps1000 / 1000.0);
+            sfx += L"  \u2502  " + std::wstring(fpsBuf);
+        }
+    }
+
+    pItem2->Release();
+    return sfx;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// BLOCK 5: Path-keyed cache with LRU-style eviction
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Removes the N oldest cache entries (by insertion order).
+// Must be called with g_cs held.
+static void EvictOldestEntries(size_t n)
+{
+    n = std::min(n, g_cacheOrder.size());
+    for (size_t i = 0; i < n; ++i)
+        g_metaCache.erase(g_cacheOrder[i]);
+    g_cacheOrder.erase(g_cacheOrder.begin(), g_cacheOrder.begin() + (ptrdiff_t)n);
+    Wh_Log(L"[Cache] Evicted %zu entries, remaining: %zu", n, g_metaCache.size());
+}
+
+// Main entry point called from both GDI hooks.
+// Cache hit  → returns immediately with zero COM calls.
+// Cache miss → calls BuildMetadataSuffix, stores result, returns.
+// g_insideMetadataBuild guards against re-entrancy in the unlikely event that
+// BuildMetadataSuffix or something it calls triggers a DrawTextW/GTEP redraw.
+static std::wstring GetSuffixForStatusBar(HDC hdc)
+{
+    HWND hwndExplorerRoot = NULL;
+    std::wstring path = GetSelectionPath(hdc, hwndExplorerRoot);
+    if (path.empty()) return L"";
+
+    thread_local bool g_insideMetadataBuild = false;
+    if (g_insideMetadataBuild) return L"";
+
+    if (!IsSafeToParse(path)) return L"";
+
+    EnterCriticalSection(&g_cs);
+    auto it = g_metaCache.find(path);
+    if (it != g_metaCache.end()) {
+        std::wstring result = it->second;
+        LeaveCriticalSection(&g_cs);
+        return result;
+    }
+
+    // Cache miss — evict if full before computing new entry
+    if (g_metaCache.size() >= MAX_CACHE_SIZE)
+        EvictOldestEntries(g_cacheEvictCount);
+
+    LeaveCriticalSection(&g_cs);
+
+    Wh_Log(L"[Cache] Miss — computing metadata for: %ls", path.c_str());
+
+    g_insideMetadataBuild = true;
+    std::wstring suffix = BuildMetadataSuffix(path);
+    g_insideMetadataBuild = false;
+
+    EnterCriticalSection(&g_cs);
+    g_metaCache[path]  = suffix;
+    g_cacheOrder.push_back(path);
+    LeaveCriticalSection(&g_cs);
+
+    return suffix;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// BLOCK 6: GDI hooks
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Both hooks follow the same pattern:
+//  1. Detect "N items selected" status-bar text via IsSelectionStatus.
+//  2. Retrieve (or compute) the metadata suffix.
+//  3. Concatenate and forward to the original GDI function.
+// thread_local string buffers avoid per-call heap allocations.
+
+int WINAPI Hook_DTW(HDC hdc, LPCWSTR s, int cch, LPRECT rc, UINT fmt)
+{
+    UINT len = (cch < 0) ? (s ? (UINT)wcslen(s) : 0u) : (UINT)cch;
+    if (!IsSelectionStatus(s, len))
+        return g_origDTW(hdc, s, cch, rc, fmt);
+
+    std::wstring sfx = GetSuffixForStatusBar(hdc);
+    if (!sfx.empty()) {
+        thread_local std::wstring t_full;
+        t_full.assign(s, len);
+        t_full.append(sfx);
+        return g_origDTW(hdc, t_full.c_str(), (int)t_full.size(), rc, fmt);
+    }
+    return g_origDTW(hdc, s, cch, rc, fmt);
+}
+
+BOOL WINAPI Hook_GTEP(HDC hdc, LPCWSTR s, int cch, LPSIZE sz)
+{
+    UINT len = (cch < 0) ? (s ? (UINT)wcslen(s) : 0u) : (UINT)cch;
+    if (!IsSelectionStatus(s, len))
+        return g_origGTEP(hdc, s, cch, sz);
+
+    std::wstring sfx = GetSuffixForStatusBar(hdc);
+    if (!sfx.empty()) {
+        thread_local std::wstring t_full;
+        t_full.assign(s, len);
+        t_full.append(sfx);
+        return g_origGTEP(hdc, t_full.c_str(), (int)t_full.size(), sz);
+    }
+    return g_origGTEP(hdc, s, cch, sz);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// BLOCK 7: Mod init / uninit
+// ═══════════════════════════════════════════════════════════════════════════════
+
+BOOL Wh_ModInit()
+{
+    Wh_Log(L"[Init] Explorer Status Bar Metadata v1.3.0 starting");
+
+    // Read settings (Windhawk guarantees these are available during Wh_ModInit)
+    g_allowNetworkDrives   = Wh_GetIntSetting(L"allowNetworkDrives")   != 0;
+    g_allowRemovableDrives = Wh_GetIntSetting(L"allowRemovableDrives") != 0;
+    int evictRaw           = Wh_GetIntSetting(L"cacheEvictCount");
+    g_cacheEvictCount      = (evictRaw >= 1 && evictRaw <= 50) ? (size_t)evictRaw : 10;
+
+    Wh_Log(L"[Init] Settings: networkDrives=%d removableDrives=%d evictCount=%zu",
+           (int)g_allowNetworkDrives, (int)g_allowRemovableDrives, g_cacheEvictCount);
+
+    InitializeCriticalSection(&g_cs);
+
+    HMODULE u32 = GetModuleHandleW(L"user32.dll");
+    HMODULE gdi = GetModuleHandleW(L"gdi32.dll");
+
+    if (!u32 || !gdi) {
+        Wh_Log(L"[Init] FATAL: user32.dll or gdi32.dll not found");
+        return FALSE;
+    }
+
+    void* pfnDTW  = reinterpret_cast<void*>(GetProcAddress(u32, "DrawTextW"));
+    void* pfnGTEP = reinterpret_cast<void*>(GetProcAddress(gdi, "GetTextExtentPoint32W"));
+
+    if (!pfnDTW || !pfnGTEP) {
+        Wh_Log(L"[Init] FATAL: could not resolve DrawTextW or GetTextExtentPoint32W");
+        return FALSE;
+    }
+
+    Wh_SetFunctionHook(pfnDTW,  (void*)Hook_DTW,  (void**)&g_origDTW);
+    Wh_SetFunctionHook(pfnGTEP, (void*)Hook_GTEP, (void**)&g_origGTEP);
+
+    Wh_Log(L"[Init] Hooks installed. DTW=%p GTEP=%p", pfnDTW, pfnGTEP);
+    return TRUE;
+}
+
+void Wh_ModUninit()
+{
+    Wh_Log(L"[Uninit] Clearing cache (%zu entries) and shutting down",
+           g_metaCache.size());
+
+    EnterCriticalSection(&g_cs);
+    g_metaCache.clear();
+    g_cacheOrder.clear();
+    LeaveCriticalSection(&g_cs);
+
+    DeleteCriticalSection(&g_cs);
+    Wh_Log(L"[Uninit] Done");
+}

--- a/mods/explorer-status-metadata.wh.cpp
+++ b/mods/explorer-status-metadata.wh.cpp
@@ -2,11 +2,11 @@
 // @id              explorer-status-metadata
 // @name            Explorer Status Bar Metadata
 // @description     Appends rich metadata (dimensions, date, type, duration, bitrate, fps) to Explorer's status bar. Zero polling — purely reactive, path-keyed cache.
-// @version         1.3.0
+// @version         1.4.0
 // @author          VitalS
 // @github          https://github.com/VitalSkib
 // @include         explorer.exe
-// @compilerOptions -lgdi32 -luser32 -lole32 -loleaut32 -luuid -lpropsys
+// @compilerOptions -lole32 -loleaut32 -lpropsys -luuid
 // ==/WindhawkMod==
 
 // ==WindhawkModSettings==
@@ -35,7 +35,7 @@
 
 // ==WindhawkModReadme==
 /*
-# Explorer Status Bar Metadata — v1.3.0
+# Explorer Status Bar Metadata — v1.4.0
 
 Appends file metadata to the Windows Explorer status bar when a single file
 is selected: dimensions, modification date, file type, duration, bitrate, fps.
@@ -43,9 +43,14 @@ is selected: dimensions, modification date, file type, duration, bitrate, fps.
 ## How it works
 - No timers, no polling. Metadata is computed only when the selected file changes.
 - Path-keyed LRU-style cache (1000 entries). Same file = instant return, zero COM calls.
-- Hooks `DrawTextW` and `GetTextExtentPoint32W` in the Explorer UI thread.
+- Hooks `PSFormatForDisplayAlloc` in propsys.dll — the exact function Explorer calls
+  to format the file size for the status bar. Language-independent, no text matching.
+- Filter: `key == System.Size` AND `SHELL32.dll` appears in the first 5 call stack
+  frames (status bar path), but NOT `explorerframe.dll` (Details column — skipped).
+- Compatible with "Better file sizes in Explorer details" — multi-frame stack scan
+  handles chained hooks transparently.
 - Custom binary parsers for formats the Windows Property System does not index:
-  SVG, HDR, EXR, TIFF/TX (LE+BE), TGA, WebM/MKV (EBML).
+  SVG, HDR, EXR, TIFF/TX (LE+BE), TGA, PSD/PSB, WebM/MKV (EBML).
 
 ## Settings
 - **Network drives** — disabled by default. Can freeze Explorer on slow networks.
@@ -53,17 +58,38 @@ is selected: dimensions, modification date, file type, duration, bitrate, fps.
 - **Cache evict count** — how many old entries to drop when the 1000-entry limit is hit.
 
 ## Changelog
+### v1.4.0
+- Replaced DrawTextW/GetTextExtentPoint32W hooks with PSFormatForDisplayAlloc hook
+  (language-independent, no text matching, no "selected"-string false positives)
+- SHELL32.dll stack filter (5 frames) precisely identifies the status bar call
+- Selection path discovery uses IFolderView2::GetSelection — same-thread, no
+  CWM_GETISHELLBROWSER broadcast to arbitrary windows
+- CWM_GETISHELLBROWSER is now sent only to windows of known safe classes:
+  CabinetWClass and ShellTabWindowClass
+- Added Wh_ModSettingsChanged so settings take effect without restarting Explorer
+- Cache upgraded from FIFO to true LRU: cache hits now move the entry to the
+  back of the eviction queue, keeping frequently-accessed files safe from eviction
+- SVG parser rewritten with ExtractAttribute helper: tolerant of whitespace
+  around '=' and both quote styles (viewBox = "...", width='100px', etc.)
+- Added PSD/PSB binary parser (width/height from fixed 26-byte header)
+- File type moved to last position (right edge) for all file types
+- CleanTypeString strips spurious ".<digits>" suffix from type names (Windows
+  shell quirk: "Adobe Photoshop Image.27" → "Adobe Photoshop Image")
+- PSD/PSB type label overridden to "Adobe Photoshop File" for consistency
+- Removed cross-window fallback (Strategy 3): GetSelectedFilePath is strictly
+  scoped to the root window identified by GetGUIThreadInfo / GetForegroundWindow
+  — no risk of reading a selection from a different Explorer window
+
 ### v1.3.0
 - Initial release
 */
 // ==/WindhawkModReadme==
 
-#include <initguid.h>
 #include <windows.h>
+#include <propsys.h>
 #include <shlobj.h>
 #include <shlguid.h>
 #include <propkey.h>
-#include <propsys.h>
 #include <string>
 #include <algorithm>
 #include <unordered_map>
@@ -72,14 +98,20 @@ is selected: dimensions, modification date, file type, duration, bitrate, fps.
 // ─── Undocumented message to obtain IShellBrowser from a window ──────────────
 #define CWM_GETISHELLBROWSER (WM_USER + 7)
 
-// ─── Hook function pointer types ────────────────────────────────────────────
-typedef int  (WINAPI *DrawTextW_t)            (HDC, LPCWSTR, int, LPRECT, UINT);
-typedef BOOL (WINAPI *GetTextExtentPoint32W_t)(HDC, LPCWSTR, int, LPSIZE);
+// ─── PSFormatForDisplayAlloc hook ────────────────────────────────────────────
+typedef HRESULT (WINAPI *PSFormatForDisplayAlloc_t)(
+    REFPROPERTYKEY, REFPROPVARIANT, PROPDESC_FORMAT_FLAGS, PWSTR*);
+static PSFormatForDisplayAlloc_t g_origPSF = nullptr;
 
-DrawTextW_t             g_origDTW  = nullptr;
-GetTextExtentPoint32W_t g_origGTEP = nullptr;
+// ─── System.Size PKEY ────────────────────────────────────────────────────────
+static const PROPERTYKEY kPKEY_Size = {
+    { 0xB725F130,0x47EF,0x101A,{0xA5,0xF1,0x02,0x60,0x8C,0x9E,0xEB,0xAC} }, 12 };
 
-// ─── Settings (read once at init, immutable afterwards) ──────────────────────
+static bool IsSystemSize(REFPROPERTYKEY k) {
+    return k.pid == kPKEY_Size.pid && IsEqualGUID(k.fmtid, kPKEY_Size.fmtid);
+}
+
+// ─── Settings ────────────────────────────────────────────────────────────────
 static bool   g_allowNetworkDrives   = false;
 static bool   g_allowRemovableDrives = true;
 static size_t g_cacheEvictCount      = 10;
@@ -88,7 +120,7 @@ static size_t g_cacheEvictCount      = 10;
 // unordered_map for O(1) lookup + vector to track insertion order for eviction.
 static CRITICAL_SECTION g_cs;
 static std::unordered_map<std::wstring, std::wstring> g_metaCache;
-static std::vector<std::wstring>                      g_cacheOrder; // insertion order
+static std::vector<std::wstring>                      g_cacheOrder;
 static const size_t MAX_CACHE_SIZE = 1000;
 
 // ─── Binary structures for TIFF/TX parser ────────────────────────────────────
@@ -98,9 +130,9 @@ struct TiffTag    { WORD tagId; WORD tagType; DWORD count; DWORD valueOffset; };
 #pragma pack(pop)
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// BLOCK 1: Custom format header parsers
+// BLOCK 1: Custom format binary parsers
 //   Covers formats the Windows Property System does not index natively:
-//   WebM/MKV (EBML), TIFF/TX (LE+BE), SVG, HDR, EXR, TGA.
+//   WebM/MKV (EBML), TIFF/TX (LE+BE), SVG, HDR, EXR, TGA, PSD/PSB, AI.
 // ═══════════════════════════════════════════════════════════════════════════════
 
 struct CustomMeta {
@@ -118,10 +150,8 @@ static CustomMeta ParseCustomFormatMetadata(const std::wstring& filePath, const 
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
         nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
 
-    if (hFile == INVALID_HANDLE_VALUE) {
-        Wh_Log(L"[Parser] Cannot open file: %ls (GLE=%u)", filePath.c_str(), GetLastError());
+    if (hFile == INVALID_HANDLE_VALUE)
         return meta;
-    }
 
     DWORD bytesRead = 0;
 
@@ -252,40 +282,69 @@ static CustomMeta ParseCustomFormatMetadata(const std::wstring& filePath, const 
         }
     }
     // ── SVG ───────────────────────────────────────────────────────────────────
-    // Priority: viewBox (logical canvas size). Fallback: explicit width=/height=.
-    // Search is scoped to start at the <svg tag to avoid false matches on nested
-    // elements that appear earlier in the file (e.g. <symbol width=...>).
+    // Priority: viewBox (logical canvas size). Fallback: explicit width/height
+    // on the root <svg> tag only.
+    //
+    // ExtractAttribute handles whitespace around '=' and both quote styles,
+    // so `viewBox = "..."`, `width='100px'`, etc. all parse correctly.
+    // Search is anchored inside the opening <svg ... > tag to avoid false
+    // matches on nested elements such as <symbol width=...>.
     else if (ext == L"svg") {
         char buf[2048] = {0};
         if (ReadFile(hFile, buf, sizeof(buf) - 1, &bytesRead, nullptr) && bytesRead > 0) {
             std::string content(buf, bytesRead);
+
+            // Locate the root <svg tag and its closing '>'
             size_t svgTagPos = content.find("<svg");
             if (svgTagPos == std::string::npos) svgTagPos = 0;
+            size_t svgTagEnd = content.find('>', svgTagPos);
+            if (svgTagEnd == std::string::npos) svgTagEnd = content.size();
 
-            size_t vbPos = content.find("viewBox=", svgTagPos);
-            if (vbPos != std::string::npos) {
-                size_t q1 = content.find('"', vbPos);
-                if (q1 != std::string::npos) {
-                    size_t q2 = content.find('"', q1 + 1);
-                    if (q2 != std::string::npos) {
-                        float x, y, w, h;
-                        if (sscanf_s(content.substr(q1 + 1, q2 - q1 - 1).c_str(),
-                                     "%f %f %f %f", &x, &y, &w, &h) == 4) {
-                            meta.width  = (int)w;
-                            meta.height = (int)h;
-                        }
-                    }
+            // Helper: find attribute NAME inside [svgTagPos, svgTagEnd),
+            // return its value string regardless of whitespace or quote style.
+            // Returns empty string if not found.
+            auto ExtractAttribute = [&](const std::string& attrName) -> std::string {
+                size_t pos = svgTagPos;
+                while (pos < svgTagEnd) {
+                    size_t found = content.find(attrName, pos);
+                    if (found == std::string::npos || found >= svgTagEnd) break;
+                    // Skip whitespace after attribute name
+                    size_t eq = found + attrName.size();
+                    while (eq < svgTagEnd && content[eq] == ' ') ++eq;
+                    if (eq >= svgTagEnd || content[eq] != '=') { pos = found + 1; continue; }
+                    ++eq; // skip '='
+                    while (eq < svgTagEnd && content[eq] == ' ') ++eq;
+                    if (eq >= svgTagEnd) break;
+                    char q = content[eq];
+                    if (q != '"' && q != '\'') { pos = found + 1; continue; }
+                    ++eq; // skip opening quote
+                    size_t qEnd = content.find(q, eq);
+                    if (qEnd == std::string::npos) break;
+                    return content.substr(eq, qEnd - eq);
+                }
+                return "";
+            };
+
+            // 1. viewBox="minX minY width height"
+            std::string vb = ExtractAttribute("viewBox");
+            if (!vb.empty()) {
+                float x, y, w, h;
+                if (sscanf_s(vb.c_str(), "%f %f %f %f", &x, &y, &w, &h) == 4
+                    && w > 0 && h > 0) {
+                    meta.width  = (int)w;
+                    meta.height = (int)h;
                 }
             }
+            // 2. Fallback: explicit width / height (ignore unit suffixes: px, pt, %)
             if (meta.width == 0) {
-                size_t wPos = content.find("width=",  svgTagPos);
-                size_t hPos = content.find("height=", svgTagPos);
-                if (wPos != std::string::npos && hPos != std::string::npos) {
-                    int w = 0, h = 0;
-                    if (sscanf_s(content.c_str() + wPos,  "width=\"%d",  &w) == 1 &&
-                        sscanf_s(content.c_str() + hPos, "height=\"%d", &h) == 1) {
-                        meta.width = w; meta.height = h;
-                    }
+                std::string ws = ExtractAttribute("width");
+                std::string hs = ExtractAttribute("height");
+                float w = 0, h = 0;
+                if (!ws.empty()) sscanf_s(ws.c_str(), "%f", &w);
+                if (!hs.empty()) sscanf_s(hs.c_str(), "%f", &h);
+                if (w > 0 && h > 0) {
+                    meta.width  = (int)w;
+                    meta.height = (int)h;
                 }
             }
         }
@@ -323,7 +382,6 @@ static CustomMeta ParseCustomFormatMetadata(const std::wstring& filePath, const 
                 if (memcmp(head + i, "dataWindow", 10) == 0) {
                     size_t off = i + 11; // skip "dataWindow\0"
                     // Layout: type "box2i\0" (6) + size DWORD (4) + xMin,yMin,xMax,yMax (16)
-                    // Need: off + 26 bytes within the buffer
                     if (off + 26 <= (size_t)bytesRead
                         && memcmp(head + off, "box2i", 5) == 0)
                     {
@@ -360,32 +418,51 @@ static CustomMeta ParseCustomFormatMetadata(const std::wstring& filePath, const 
             }
         }
     }
+    // ── PSD (Adobe Photoshop) ─────────────────────────────────────────────────
+    // Fixed 26-byte header:
+    //   Bytes 0–3:  signature "8BPS"
+    //   Bytes 4–5:  version (1 = PSD, 2 = PSB)
+    //   Bytes 6–11: reserved (must be zero)
+    //   Bytes 12–13: channels (1–56)
+    //   Bytes 14–17: height (rows), big-endian DWORD
+    //   Bytes 18–21: width (columns), big-endian DWORD
+    else if (ext == L"psd" || ext == L"psb") {
+        unsigned char hdr[26] = {0};
+        if (ReadFile(hFile, hdr, sizeof(hdr), &bytesRead, nullptr)
+            && bytesRead == sizeof(hdr)
+            && hdr[0] == '8' && hdr[1] == 'B' && hdr[2] == 'P' && hdr[3] == 'S'
+            && (hdr[4] == 0 && (hdr[5] == 1 || hdr[5] == 2))) // version 1=PSD, 2=PSB
+        {
+            DWORD h = ((DWORD)hdr[14] << 24) | ((DWORD)hdr[15] << 16)
+                    | ((DWORD)hdr[16] <<  8) |  (DWORD)hdr[17];
+            DWORD w = ((DWORD)hdr[18] << 24) | ((DWORD)hdr[19] << 16)
+                    | ((DWORD)hdr[20] <<  8) |  (DWORD)hdr[21];
+            if (w > 0 && h > 0 && w <= 300000 && h <= 300000) {
+                meta.width  = (int)w;
+                meta.height = (int)h;
+            }
+        }
+    }
 
     CloseHandle(hFile);
     return meta;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// BLOCK 2: Utility functions
+// BLOCK 2: Utility helpers
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// Returns true if the file at `path` is safe to parse synchronously on the
-// Explorer UI thread (i.e. the read will complete in < ~5 ms).
-// Controlled by Windhawk settings for network and removable drives.
-// Reparse points (junctions, symlinks) are always skipped — they may point
-// to slow or unavailable targets.
+// Returns true if the file at `path` is safe to read synchronously on the
+// Explorer UI thread (< ~5 ms). Controlled by settings.
+// Offline files and reparse points (symlinks/junctions) are always skipped.
 static bool IsSafeToParse(const std::wstring& path)
 {
     if (path.empty() || path.length() < 3) return false;
 
     // UNC network paths (\\server\share\...)
-    if (path.size() >= 2 && path[0] == L'\\' && path[1] == L'\\') {
-        if (!g_allowNetworkDrives) {
-            Wh_Log(L"[Safety] Skipping network path: %ls", path.c_str());
+    if (path[0] == L'\\' && path[1] == L'\\') {
+        if (!g_allowNetworkDrives)
             return false;
-        }
-        // Network paths pass the drive-type and attribute checks below
-        // only if the setting is enabled.
         goto check_attributes;
     }
 
@@ -393,53 +470,20 @@ static bool IsSafeToParse(const std::wstring& path)
         wchar_t root[4] = { path[0], L':', L'\\', L'\0' };
         UINT driveType  = GetDriveTypeW(root);
 
-        if (driveType == DRIVE_REMOVABLE && !g_allowRemovableDrives) {
-            Wh_Log(L"[Safety] Skipping removable drive path: %ls", path.c_str());
+        if (driveType == DRIVE_REMOVABLE && !g_allowRemovableDrives)
             return false;
-        }
-        if (driveType != DRIVE_FIXED    &&
+        if (driveType != DRIVE_FIXED     &&
             driveType != DRIVE_REMOVABLE &&
-            driveType != DRIVE_REMOTE)   // DRIVE_REMOTE handled above via UNC check
-        {
-            Wh_Log(L"[Safety] Skipping unsupported drive type %u: %ls", driveType, path.c_str());
+            driveType != DRIVE_REMOTE)
             return false;
-        }
     }
 
 check_attributes:
     DWORD attr = GetFileAttributesW(path.c_str());
-    if (attr == INVALID_FILE_ATTRIBUTES) return false;
-    if (attr & FILE_ATTRIBUTE_OFFLINE) {
-        Wh_Log(L"[Safety] Skipping offline file: %ls", path.c_str());
-        return false;
-    }
-    if (attr & FILE_ATTRIBUTE_REPARSE_POINT) {
-        // Reparse points (symlinks, junctions) may point anywhere — always skip.
-        return false;
-    }
-
+    if (attr == INVALID_FILE_ATTRIBUTES)          return false;
+    if (attr & FILE_ATTRIBUTE_OFFLINE)            return false;
+    if (attr & FILE_ATTRIBUTE_REPARSE_POINT)      return false; // symlinks/junctions
     return true;
-}
-
-// Detects the Explorer status-bar "N item(s) selected" string without
-// allocating heap memory. Called on every DrawTextW / GetTextExtentPoint32W
-// invocation, so must be as cheap as possible.
-static bool IsSelectionStatus(const wchar_t* s, UINT len)
-{
-    if (!s || len < 2) return false;
-    UINT checkLen = (len < 512u) ? len : 512u;
-
-    for (UINT i = 0; i + 7 < checkLen; ++i) {
-        wchar_t c = s[i];
-        // English: "selected" / "Selected"
-        if ((c == L's' || c == L'S') && wcsncmp(s + i + 1, L"elected", 7) == 0)
-            return true;
-        // Russian: "выбр" (U+0432 U+044B U+0431 U+0440) / "Выбр" (U+0412 ...)
-        if ((c == L'\u0432' || c == L'\u0412') && i + 3 < checkLen &&
-            s[i+1] == L'\u044b' && s[i+2] == L'\u0431' && s[i+3] == L'\u0440')
-            return true;
-    }
-    return false;
 }
 
 // Strips Unicode LTR/RTL directional marks (U+200E, U+200F) that Windows
@@ -453,14 +497,34 @@ static std::wstring CleanPropString(LPCWSTR src)
     return s;
 }
 
+// Cleans a file-type description string.
+// Applies CleanPropString, then strips any trailing " .<digits>" suffix that
+// Windows appends to some type names (e.g. "Adobe Photoshop Image.27" → 
+// "Adobe Photoshop Image"). This is a known Windows shell quirk for PSD files.
+static std::wstring CleanTypeString(LPCWSTR src)
+{
+    std::wstring s = CleanPropString(src);
+    // Strip trailing ".<one or more digits>"
+    size_t dot = s.rfind(L'.');
+    if (dot != std::wstring::npos && dot + 1 < s.size()) {
+        bool allDigits = true;
+        for (size_t i = dot + 1; i < s.size(); ++i) {
+            if (!iswdigit(s[i])) { allDigits = false; break; }
+        }
+        if (allDigits) s.resize(dot);
+    }
+    return s;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
-// BLOCK 3: Selection path discovery via CWM_GETISHELLBROWSER
+// BLOCK 3: Selection path discovery
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// Extracts the filesystem path of the single selected item from a shell browser.
-// Returns empty string if no item or multiple items are selected.
-// GetSelection(FALSE, ...) — FALSE prevents the folder itself from being
-// returned as a "selection" when nothing is actually selected.
+// Extracts the filesystem path of the single selected item from an IShellBrowser.
+// Uses IFolderView2::GetSelection — avoids IDataObject round-trip.
+// GetSelection(FALSE) prevents the folder itself from being returned when
+// nothing is selected.
+// Returns empty string if zero or more than one item is selected.
 static std::wstring ExtractPathFromBrowser(IShellBrowser* pSB)
 {
     if (!pSB) return L"";
@@ -479,7 +543,10 @@ static std::wstring ExtractPathFromBrowser(IShellBrowser* pSB)
                 if (SUCCEEDED(pIA->GetItemAt(0, &pItem)) && pItem) {
                     LPWSTR ps = nullptr;
                     if (SUCCEEDED(pItem->GetDisplayName(SIGDN_FILESYSPATH, &ps)) && ps) {
-                        path = ps;
+                        // Skip directories — status bar uses a different path for them
+                        DWORD attr = GetFileAttributesW(ps);
+                        if (attr != INVALID_FILE_ATTRIBUTES && !(attr & FILE_ATTRIBUTE_DIRECTORY))
+                            path = ps;
                         CoTaskMemFree(ps);
                     }
                     pItem->Release();
@@ -493,75 +560,123 @@ static std::wstring ExtractPathFromBrowser(IShellBrowser* pSB)
     return path;
 }
 
-// Finds the path of the currently selected file in the active Explorer window.
-// Strategy 1: Walk the focus window hierarchy upward, asking each window for
-//             its IShellBrowser via the undocumented CWM_GETISHELLBROWSER message.
-//             SendMessageW to own windows on the same thread dispatches directly
-//             to the window procedure — no queue, no blocking.
-// Strategy 2: Fallback — enumerate ShellTabWindowClass children of the root
-//             window when the focus has moved outside the file list.
-static std::wstring GetSelectionPath(HDC /*hdc*/, HWND& outExplorerRoot)
+// Attempts to send CWM_GETISHELLBROWSER to a window of a known-safe class.
+// Guards:
+//   1. Thread ID — only windows belonging to the current thread; prevents
+//      cross-process or cross-window-station SendMessage to a foreign Explorer.
+//   2. Class name — only CabinetWClass / ShellTabWindowClass; these are the
+//      only classes known to handle WM_USER+7 correctly.
+static IShellBrowser* SafeGetShellBrowser(HWND h)
 {
-    outExplorerRoot = NULL;
+    if (!h) return nullptr;
+    // Guard 1: must belong to the current thread (same Explorer instance)
+    if (GetWindowThreadProcessId(h, nullptr) != GetCurrentThreadId())
+        return nullptr;
+    // Guard 2: must be a known-safe class
+    wchar_t cls[64] = {};
+    GetClassNameW(h, cls, 64);
+    if (_wcsicmp(cls, L"CabinetWClass")      != 0 &&
+        _wcsicmp(cls, L"ShellTabWindowClass") != 0)
+        return nullptr;
+    return (IShellBrowser*)SendMessageW(h, CWM_GETISHELLBROWSER, 0, 0);
+}
+
+// Finds the path of the currently selected file in the Explorer window that
+// triggered the current PSFormatForDisplayAlloc call.
+//
+// PSFormatForDisplayAlloc may fire on a shell worker thread (not the GUI thread
+// that owns the Explorer window), so GetGUIThreadInfo may return no window.
+// GetForegroundWindow() is the reliable cross-thread fallback: it returns the
+// single window the user is actively interacting with, which is the Explorer
+// window whose status bar is being updated.
+//
+// We deliberately do NOT enumerate all CabinetWClass windows: that would risk
+// reading a selection from a different Explorer window, which is worse than
+// showing nothing.
+//
+// Strategy 1: Walk up the focus-window hierarchy (safe classes only).
+//             GetGUIThreadInfo is tried first; GetForegroundWindow as fallback.
+// Strategy 2: ShellTabWindowClass children of the same root window.
+//             Covers address bar / search box focus with a tab selection.
+// No cross-window fallback. If neither strategy finds a selection, we return
+// empty and the status bar shows only the file size (normal Explorer behaviour).
+static std::wstring GetSelectedFilePath()
+{
+    // Prefer the focused window of the current thread (works when called on the
+    // UI thread). Fall back to the system foreground window (works from any thread).
     HWND hFocus = NULL;
     GUITHREADINFO gti = { sizeof(GUITHREADINFO) };
     if (GetGUIThreadInfo(GetCurrentThreadId(), &gti))
         hFocus = gti.hwndFocus ? gti.hwndFocus : gti.hwndActive;
-    if (!hFocus) hFocus = GetForegroundWindow();
+    if (!hFocus) {
+        hFocus = GetForegroundWindow();
+    }
+    if (!hFocus) return L"";
 
+    // Strategy 1: walk up the focus chain, safe-class only
     for (HWND h = hFocus; h; h = GetParent(h)) {
-        auto* pSB = (IShellBrowser*)SendMessageW(h, CWM_GETISHELLBROWSER, 0, 0);
+        IShellBrowser* pSB = SafeGetShellBrowser(h);
         if (pSB) {
-            std::wstring path = ExtractPathFromBrowser(pSB);
-            if (!path.empty()) {
-                outExplorerRoot = GetAncestor(h, GA_ROOT);
-                return path;
-            }
+            std::wstring p = ExtractPathFromBrowser(pSB);
+            if (!p.empty()) return p;
         }
     }
 
-    HWND hRoot = hFocus ? GetAncestor(hFocus, GA_ROOT) : NULL;
+    // Strategy 2: ShellTabWindowClass children of the same root window
+    HWND hRoot = GetAncestor(hFocus, GA_ROOT);
     if (hRoot) {
         HWND hTab = NULL;
         while ((hTab = FindWindowExW(hRoot, hTab, L"ShellTabWindowClass", NULL)) != NULL) {
-            auto* pSB = (IShellBrowser*)SendMessageW(hTab, CWM_GETISHELLBROWSER, 0, 0);
+            IShellBrowser* pSB = SafeGetShellBrowser(hTab);
             if (pSB) {
-                std::wstring path = ExtractPathFromBrowser(pSB);
-                if (!path.empty()) {
-                    outExplorerRoot = hRoot;
-                    return path;
-                }
+                std::wstring p = ExtractPathFromBrowser(pSB);
+                if (!p.empty()) return p;
             }
         }
     }
+
     return L"";
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// BLOCK 4: Metadata suffix builder
+// BLOCK 4: Cache helpers
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// Builds the status-bar suffix string for `filePath`.
-// Called at most once per unique path (results are cached).
-// Metadata priority for dimensions:
-//   1. PKEY_Image_Dimensions  (Windows indexer — covers JPEG, PNG, BMP, …)
-//   2. PKEY_Video_FrameWidth/Height (Windows indexer — covers MP4, AVI, …)
-//   3. Custom binary parser   (SVG, HDR, EXR, TIFF/TX, TGA, WebM/MKV)
-// Date: PSFormatForDisplayAlloc — correctly applies system timezone and DST,
-//       avoiding the ±1 hour error from manual FileTimeToLocalFileTime chains.
-// Bitrate: video property → audio property → file-size / duration estimate.
-// FPS: PKEY_Video_FrameRate → EBML DefaultDuration fallback.
+// Removes the N oldest cache entries (by insertion order).
+// Must be called with g_cs held.
+static void EvictOldestEntries(size_t n)
+{
+    n = std::min(n, g_cacheOrder.size());
+    for (size_t i = 0; i < n; ++i)
+        g_metaCache.erase(g_cacheOrder[i]);
+    g_cacheOrder.erase(g_cacheOrder.begin(), g_cacheOrder.begin() + (ptrdiff_t)n);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// BLOCK 5: Metadata suffix builder
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Builds the status-bar suffix for `filePath`. Called at most once per unique
+// path (results are cached by the caller).
+//
+// Metadata order: Dimensions | Date Modified | Duration | Bitrate | FPS | Type
+//
+// Dimensions priority:
+//   1. PKEY_Image_Dimensions  (Windows indexer — JPEG, PNG, BMP, …)
+//   2. PKEY_Video_FrameWidth/Height (Windows indexer — MP4, AVI, …)
+//   3. Custom binary parser   (SVG, HDR, EXR, TIFF/TX, TGA, PSD, WebM/MKV) as fallback
+//
+// Note: g_origPSF (the real PSFormatForDisplayAlloc) is called here for keys
+// other than System.Size — this does NOT re-enter our hook because we only
+// intercept System.Size calls from SHELL32.dll.
 static std::wstring BuildMetadataSuffix(const std::wstring& filePath)
 {
     IShellItem2* pItem2 = nullptr;
     if (FAILED(SHCreateItemFromParsingName(
             filePath.c_str(), nullptr, IID_PPV_ARGS(&pItem2))) || !pItem2)
-    {
-        Wh_Log(L"[Build] SHCreateItemFromParsingName failed for: %ls", filePath.c_str());
         return L"";
-    }
 
-    // Determine extension for custom parser dispatch
+    // Extension for custom parser dispatch
     std::wstring ext;
     size_t dot = filePath.find_last_of(L'.');
     if (dot != std::wstring::npos) {
@@ -573,64 +688,61 @@ static std::wstring BuildMetadataSuffix(const std::wstring& filePath)
     CustomMeta customMeta;
     if (ext == L"webm" || ext == L"mkv"  ||
         ext == L"tx"   || ext == L"tif"  || ext == L"tiff" ||
-        ext == L"svg"  || ext == L"hdr"  || ext == L"exr"  || ext == L"tga")
+        ext == L"svg"  || ext == L"hdr"  || ext == L"exr"  ||
+        ext == L"tga"  || ext == L"psd"  || ext == L"psb")
     {
         customMeta = ParseCustomFormatMetadata(filePath, ext);
     }
 
-    std::wstring dimStr, dateStr, typeStr;
+    std::wstring sfx;
 
-    // 1. Dimensions
-    LPWSTR pszDim = nullptr;
-    if (SUCCEEDED(pItem2->GetString(PKEY_Image_Dimensions, &pszDim)) && pszDim) {
-        dimStr = CleanPropString(pszDim);
-        CoTaskMemFree(pszDim);
-    }
-    if (dimStr.empty()) {
-        ULONG fw = 0, fh = 0;
-        if (SUCCEEDED(pItem2->GetUInt32(PKEY_Video_FrameWidth,  &fw)) && fw > 0 &&
-            SUCCEEDED(pItem2->GetUInt32(PKEY_Video_FrameHeight, &fh)) && fh > 0) {
+    // ── 1. Dimensions ────────────────────────────────────────────────────────
+    {
+        LPWSTR pszDim = nullptr;
+        std::wstring dimStr;
+
+        if (SUCCEEDED(pItem2->GetString(PKEY_Image_Dimensions, &pszDim)) && pszDim) {
+            dimStr = CleanPropString(pszDim);
+            CoTaskMemFree(pszDim);
+        }
+        if (dimStr.empty()) {
+            ULONG fw = 0, fh = 0;
+            if (SUCCEEDED(pItem2->GetUInt32(PKEY_Video_FrameWidth,  &fw)) && fw > 0 &&
+                SUCCEEDED(pItem2->GetUInt32(PKEY_Video_FrameHeight, &fh)) && fh > 0) {
+                wchar_t buf[64];
+                swprintf_s(buf, L"%u \u00D7 %u", fw, fh);
+                dimStr = buf;
+            }
+        }
+        if (dimStr.empty() && customMeta.width > 0 && customMeta.height > 0) {
             wchar_t buf[64];
-            swprintf_s(buf, L"%u x %u", fw, fh);
+            swprintf_s(buf, L"%d \u00D7 %d", customMeta.width, customMeta.height);
             dimStr = buf;
         }
-    }
-    if (dimStr.empty() && customMeta.width > 0 && customMeta.height > 0) {
-        wchar_t buf[64];
-        swprintf_s(buf, L"%d x %d", customMeta.width, customMeta.height);
-        dimStr = buf;
+        if (!dimStr.empty()) sfx += L" \u2502 " + dimStr;
     }
 
-    // 2. Modification date
-    // PSFormatForDisplayAlloc handles timezone and DST conversion correctly.
-    PROPVARIANT propVar;
-    PropVariantInit(&propVar);
-    if (SUCCEEDED(pItem2->GetProperty(PKEY_DateModified, &propVar))) {
-        LPWSTR pszDate = nullptr;
-        if (SUCCEEDED(PSFormatForDisplayAlloc(
-                PKEY_DateModified, propVar, PDFF_DEFAULT, &pszDate)) && pszDate) {
-            dateStr = CleanPropString(pszDate);
-            CoTaskMemFree(pszDate);
+    // ── 2. Date Modified ─────────────────────────────────────────────────────
+    // PSFormatForDisplayAlloc handles timezone and DST conversion correctly,
+    // avoiding the ±1 h error from manual FileTimeToLocalFileTime chains.
+    {
+        PROPVARIANT pv; PropVariantInit(&pv);
+        if (SUCCEEDED(pItem2->GetProperty(PKEY_DateModified, &pv))) {
+            LPWSTR pszDate = nullptr;
+            if (SUCCEEDED(g_origPSF(PKEY_DateModified, pv, PDFF_DEFAULT, &pszDate))
+                && pszDate) {
+                std::wstring s = CleanPropString(pszDate);
+                if (!s.empty()) sfx += L" \u2502 " + s;
+                CoTaskMemFree(pszDate);
+            }
+            PropVariantClear(&pv);
         }
-        PropVariantClear(&propVar);
     }
 
-    // 3. File type description
-    LPWSTR pszType = nullptr;
-    if (SUCCEEDED(pItem2->GetString(PKEY_ItemTypeText, &pszType)) && pszType) {
-        typeStr = CleanPropString(pszType);
-        CoTaskMemFree(pszType);
-    }
-
-    // 4. Duration and derived media properties
+    // ── 3. Duration ──────────────────────────────────────────────────────────
     ULONGLONG duration100ns = 0;
     bool hasDuration = SUCCEEDED(pItem2->GetUInt64(PKEY_Media_Duration, &duration100ns))
                        && duration100ns > 0;
-
-    std::wstring sfx;
-    if (!dimStr.empty())  sfx += L"  \u2502  " + dimStr;
-    if (!dateStr.empty()) sfx += L"  \u2502  " + dateStr;
-    if (!typeStr.empty()) sfx += L"  \u2502  " + typeStr;
 
     if (hasDuration) {
         ULONG totalSec = (ULONG)(duration100ns / 10000000ULL);
@@ -640,9 +752,12 @@ static std::wstring BuildMetadataSuffix(const std::wstring& filePath)
         wchar_t durBuf[64];
         if (hh > 0) swprintf_s(durBuf, L"%02u:%02u:%02u", hh, mm, ss);
         else        swprintf_s(durBuf, L"%02u:%02u", mm, ss);
-        sfx += L"  \u2502  " + std::wstring(durBuf);
+        sfx += L" \u2502 " + std::wstring(durBuf);
+    }
 
-        // Bitrate: video property → audio property → estimate from file size
+    // ── 4. Bitrate ───────────────────────────────────────────────────────────
+    // Priority: video total bitrate → audio encoding bitrate → file-size estimate
+    if (hasDuration) {
         ULONG bitrateBps = 0;
         if (FAILED(pItem2->GetUInt32(PKEY_Video_TotalBitrate, &bitrateBps)) || !bitrateBps)
             pItem2->GetUInt32(PKEY_Audio_EncodingBitrate, &bitrateBps);
@@ -660,10 +775,14 @@ static std::wstring BuildMetadataSuffix(const std::wstring& filePath)
                 swprintf_s(bitBuf, L"%.1f Mbps", (double)bitrateBps / 1000000.0);
             else
                 swprintf_s(bitBuf, L"%u kbps", bitrateBps / 1000);
-            sfx += L"  \u2502  " + std::wstring(bitBuf);
+            sfx += L" \u2502 " + std::wstring(bitBuf);
         }
+    }
 
-        // FPS: Windows property system → EBML DefaultDuration fallback
+    // ── 5. FPS ───────────────────────────────────────────────────────────────
+    // Property System stores fps * 1000 as VT_UI4 (e.g. 29970 → 29.97 fps).
+    // Fallback: EBML DefaultDuration from the custom WebM/MKV parser.
+    {
         ULONG fps1000 = 0;
         if (!SUCCEEDED(pItem2->GetUInt32(PKEY_Video_FrameRate, &fps1000)) || !fps1000) {
             if (customMeta.fps > 0.0)
@@ -673,8 +792,40 @@ static std::wstring BuildMetadataSuffix(const std::wstring& filePath)
             wchar_t fpsBuf[64];
             if (fps1000 % 1000 == 0) swprintf_s(fpsBuf, L"%u fps", fps1000 / 1000);
             else                     swprintf_s(fpsBuf, L"%.2f fps", (double)fps1000 / 1000.0);
-            sfx += L"  \u2502  " + std::wstring(fpsBuf);
+            sfx += L" \u2502 " + std::wstring(fpsBuf);
         }
+    }
+
+    // ── 6. File type description ──────────────────────────────────────────────
+    // Placed last so it appears at the right edge for all file types.
+    // IShellItem2::GetString(PKEY_ItemTypeText) works correctly on the UI thread.
+    // SHGetFileInfoW(SHGFI_USEFILEATTRIBUTES) is used as fallback — never hits
+    // disk and is safe on any thread.
+    // CleanTypeString strips the spurious ".<digits>" suffix Windows appends to
+    // some registered types (e.g. "Adobe Photoshop Image.27" → "Adobe Photoshop Image").
+    // For PSD/PSB we override the system string entirely: Windows reports
+    // "Adobe Photoshop Image" while the consistent convention is "...File".
+    {
+        std::wstring typeStr;
+
+        // Hard override for known problematic types
+        if (ext == L"psd" || ext == L"psb")
+            typeStr = L"Adobe Photoshop File";
+
+        if (typeStr.empty()) {
+            LPWSTR pszType = nullptr;
+            if (SUCCEEDED(pItem2->GetString(PKEY_ItemTypeText, &pszType)) && pszType) {
+                typeStr = CleanTypeString(pszType);
+                CoTaskMemFree(pszType);
+            }
+        }
+        if (typeStr.empty()) {
+            SHFILEINFOW sfi = {};
+            if (SHGetFileInfoW(filePath.c_str(), FILE_ATTRIBUTE_NORMAL, &sfi, sizeof(sfi),
+                               SHGFI_USEFILEATTRIBUTES | SHGFI_TYPENAME) && sfi.szTypeName[0])
+                typeStr = CleanTypeString(sfi.szTypeName);
+        }
+        if (!typeStr.empty()) sfx += L" \u2502 " + typeStr;
     }
 
     pItem2->Release();
@@ -682,158 +833,143 @@ static std::wstring BuildMetadataSuffix(const std::wstring& filePath)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// BLOCK 5: Path-keyed cache with LRU-style eviction
+// BLOCK 6: PSFormatForDisplayAlloc hook
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// Removes the N oldest cache entries (by insertion order).
-// Must be called with g_cs held.
-static void EvictOldestEntries(size_t n)
+HRESULT WINAPI Hook_PSF(REFPROPERTYKEY key, REFPROPVARIANT propvar,
+                        PROPDESC_FORMAT_FLAGS pdff, PWSTR* ppszDisplay)
 {
-    n = std::min(n, g_cacheOrder.size());
-    for (size_t i = 0; i < n; ++i)
-        g_metaCache.erase(g_cacheOrder[i]);
-    g_cacheOrder.erase(g_cacheOrder.begin(), g_cacheOrder.begin() + (ptrdiff_t)n);
-    Wh_Log(L"[Cache] Evicted %zu entries, remaining: %zu", n, g_metaCache.size());
-}
+    HRESULT hr = g_origPSF(key, propvar, pdff, ppszDisplay);
 
-// Main entry point called from both GDI hooks.
-// Cache hit  → returns immediately with zero COM calls.
-// Cache miss → calls BuildMetadataSuffix, stores result, returns.
-// g_insideMetadataBuild guards against re-entrancy in the unlikely event that
-// BuildMetadataSuffix or something it calls triggers a DrawTextW/GTEP redraw.
-static std::wstring GetSuffixForStatusBar(HDC hdc)
-{
-    HWND hwndExplorerRoot = NULL;
-    std::wstring path = GetSelectionPath(hdc, hwndExplorerRoot);
-    if (path.empty()) return L"";
+    // Only intercept System.Size
+    if (!IsSystemSize(key)) return hr;
+    if (FAILED(hr) || !ppszDisplay || !*ppszDisplay) return hr;
 
-    thread_local bool g_insideMetadataBuild = false;
-    if (g_insideMetadataBuild) return L"";
+    // ── Stack filter: identify the status bar call ────────────────────────────
+    // The status bar path goes through SHELL32.dll.
+    // The Details column path goes through explorerframe.dll — skip it.
+    // When other mods chain-hook PSFormatForDisplayAlloc (e.g. "Better file sizes"),
+    // Windhawk inserts their thunk between SHELL32 and us, so we scan 5 frames.
+    {
+        void* frames[5] = {};
+        CaptureStackBackTrace(1, 5, frames, nullptr);
+        bool isStatusBar = false;
+        for (int i = 0; i < 5 && frames[i]; ++i) {
+            HMODULE hMod = nullptr;
+            GetModuleHandleExW(
+                GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                (LPCWSTR)frames[i], &hMod);
+            wchar_t modPath[MAX_PATH] = {};
+            GetModuleFileNameW(hMod, modPath, MAX_PATH);
+            const wchar_t* name = wcsrchr(modPath, L'\\');
+            name = name ? name + 1 : modPath;
+            if (_wcsicmp(name, L"explorerframe.dll") == 0) return hr; // Details column
+            if (_wcsicmp(name, L"SHELL32.dll")       == 0) { isStatusBar = true; break; }
+        }
+        if (!isStatusBar) return hr;
+    }
 
-    if (!IsSafeToParse(path)) return L"";
+    // ── Get selected file path ────────────────────────────────────────────────
+    std::wstring path = GetSelectedFilePath();
+    if (path.empty()) return hr;
 
+    // ── Drive / offline / reparse safety check ───────────────────────────────
+    if (!IsSafeToParse(path)) return hr;
+
+    // ── Cache lookup ─────────────────────────────────────────────────────────
     EnterCriticalSection(&g_cs);
     auto it = g_metaCache.find(path);
     if (it != g_metaCache.end()) {
-        std::wstring result = it->second;
+        std::wstring cached = it->second;
+        // LRU: move this entry to the back so it is evicted last
+        auto oit = std::find(g_cacheOrder.begin(), g_cacheOrder.end(), path);
+        if (oit != g_cacheOrder.end()) {
+            g_cacheOrder.erase(oit);
+            g_cacheOrder.push_back(path);
+        }
         LeaveCriticalSection(&g_cs);
-        return result;
+        if (cached.empty()) return hr;
+        std::wstring full = std::wstring(*ppszDisplay) + cached;
+        if (auto* s = (PWSTR)CoTaskMemAlloc((full.size() + 1) * sizeof(WCHAR))) {
+            wcscpy_s(s, full.size() + 1, full.c_str());
+            CoTaskMemFree(*ppszDisplay);
+            *ppszDisplay = s;
+        }
+        return hr;
     }
 
-    // Cache miss — evict if full before computing new entry
+    // Cache miss — evict if full, then compute
     if (g_metaCache.size() >= MAX_CACHE_SIZE)
         EvictOldestEntries(g_cacheEvictCount);
-
     LeaveCriticalSection(&g_cs);
 
-    Wh_Log(L"[Cache] Miss — computing metadata for: %ls", path.c_str());
-
-    g_insideMetadataBuild = true;
     std::wstring suffix = BuildMetadataSuffix(path);
-    g_insideMetadataBuild = false;
 
     EnterCriticalSection(&g_cs);
-    g_metaCache[path]  = suffix;
-    g_cacheOrder.push_back(path);
+    // Double-check: another call may have inserted the entry while we computed
+    if (g_metaCache.find(path) == g_metaCache.end()) {
+        g_metaCache[path] = suffix;
+        g_cacheOrder.push_back(path);
+    }
     LeaveCriticalSection(&g_cs);
 
-    return suffix;
-}
+    if (suffix.empty()) return hr;
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// BLOCK 6: GDI hooks
-// ═══════════════════════════════════════════════════════════════════════════════
-
-// Both hooks follow the same pattern:
-//  1. Detect "N items selected" status-bar text via IsSelectionStatus.
-//  2. Retrieve (or compute) the metadata suffix.
-//  3. Concatenate and forward to the original GDI function.
-// thread_local string buffers avoid per-call heap allocations.
-
-int WINAPI Hook_DTW(HDC hdc, LPCWSTR s, int cch, LPRECT rc, UINT fmt)
-{
-    UINT len = (cch < 0) ? (s ? (UINT)wcslen(s) : 0u) : (UINT)cch;
-    if (!IsSelectionStatus(s, len))
-        return g_origDTW(hdc, s, cch, rc, fmt);
-
-    std::wstring sfx = GetSuffixForStatusBar(hdc);
-    if (!sfx.empty()) {
-        thread_local std::wstring t_full;
-        t_full.assign(s, len);
-        t_full.append(sfx);
-        return g_origDTW(hdc, t_full.c_str(), (int)t_full.size(), rc, fmt);
+    std::wstring full = std::wstring(*ppszDisplay) + suffix;
+    if (auto* s = (PWSTR)CoTaskMemAlloc((full.size() + 1) * sizeof(WCHAR))) {
+        wcscpy_s(s, full.size() + 1, full.c_str());
+        CoTaskMemFree(*ppszDisplay);
+        *ppszDisplay = s;
     }
-    return g_origDTW(hdc, s, cch, rc, fmt);
-}
-
-BOOL WINAPI Hook_GTEP(HDC hdc, LPCWSTR s, int cch, LPSIZE sz)
-{
-    UINT len = (cch < 0) ? (s ? (UINT)wcslen(s) : 0u) : (UINT)cch;
-    if (!IsSelectionStatus(s, len))
-        return g_origGTEP(hdc, s, cch, sz);
-
-    std::wstring sfx = GetSuffixForStatusBar(hdc);
-    if (!sfx.empty()) {
-        thread_local std::wstring t_full;
-        t_full.assign(s, len);
-        t_full.append(sfx);
-        return g_origGTEP(hdc, t_full.c_str(), (int)t_full.size(), sz);
-    }
-    return g_origGTEP(hdc, s, cch, sz);
+    return hr;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// BLOCK 7: Mod init / uninit
+// BLOCK 7: Mod lifecycle
 // ═══════════════════════════════════════════════════════════════════════════════
 
-BOOL Wh_ModInit()
+static void LoadSettings()
 {
-    Wh_Log(L"[Init] Explorer Status Bar Metadata v1.3.0 starting");
-
-    // Read settings (Windhawk guarantees these are available during Wh_ModInit)
     g_allowNetworkDrives   = Wh_GetIntSetting(L"allowNetworkDrives")   != 0;
     g_allowRemovableDrives = Wh_GetIntSetting(L"allowRemovableDrives") != 0;
     int evictRaw           = Wh_GetIntSetting(L"cacheEvictCount");
     g_cacheEvictCount      = (evictRaw >= 1 && evictRaw <= 50) ? (size_t)evictRaw : 10;
+}
 
-    Wh_Log(L"[Init] Settings: networkDrives=%d removableDrives=%d evictCount=%zu",
-           (int)g_allowNetworkDrives, (int)g_allowRemovableDrives, g_cacheEvictCount);
+BOOL Wh_ModInit()
+{
+    LoadSettings();
 
     InitializeCriticalSection(&g_cs);
 
-    HMODULE u32 = GetModuleHandleW(L"user32.dll");
-    HMODULE gdi = GetModuleHandleW(L"gdi32.dll");
+    HMODULE hPS = GetModuleHandleW(L"propsys.dll");
+    if (!hPS) hPS = LoadLibraryW(L"propsys.dll");
+    if (!hPS) return FALSE;
 
-    if (!u32 || !gdi) {
-        Wh_Log(L"[Init] FATAL: user32.dll or gdi32.dll not found");
-        return FALSE;
-    }
+    void* pfn = (void*)GetProcAddress(hPS, "PSFormatForDisplayAlloc");
+    if (!pfn) return FALSE;
 
-    void* pfnDTW  = reinterpret_cast<void*>(GetProcAddress(u32, "DrawTextW"));
-    void* pfnGTEP = reinterpret_cast<void*>(GetProcAddress(gdi, "GetTextExtentPoint32W"));
-
-    if (!pfnDTW || !pfnGTEP) {
-        Wh_Log(L"[Init] FATAL: could not resolve DrawTextW or GetTextExtentPoint32W");
-        return FALSE;
-    }
-
-    Wh_SetFunctionHook(pfnDTW,  (void*)Hook_DTW,  (void**)&g_origDTW);
-    Wh_SetFunctionHook(pfnGTEP, (void*)Hook_GTEP, (void**)&g_origGTEP);
-
-    Wh_Log(L"[Init] Hooks installed. DTW=%p GTEP=%p", pfnDTW, pfnGTEP);
+    Wh_SetFunctionHook(pfn, (void*)Hook_PSF, (void**)&g_origPSF);
     return TRUE;
 }
 
-void Wh_ModUninit()
+void Wh_ModSettingsChanged()
 {
-    Wh_Log(L"[Uninit] Clearing cache (%zu entries) and shutting down",
-           g_metaCache.size());
-
+    LoadSettings();
+    // Clear the cache so settings changes (network/removable drives) take
+    // effect immediately without requiring an Explorer restart.
     EnterCriticalSection(&g_cs);
     g_metaCache.clear();
     g_cacheOrder.clear();
     LeaveCriticalSection(&g_cs);
+}
 
+void Wh_ModUninit()
+{
+    EnterCriticalSection(&g_cs);
+    g_metaCache.clear();
+    g_cacheOrder.clear();
+    LeaveCriticalSection(&g_cs);
     DeleteCriticalSection(&g_cs);
-    Wh_Log(L"[Uninit] Done");
 }

--- a/mods/explorer-status-metadata.wh.cpp
+++ b/mods/explorer-status-metadata.wh.cpp
@@ -66,6 +66,11 @@ is selected: dimensions, modification date, file type, duration, bitrate, fps.
   CWM_GETISHELLBROWSER broadcast to arbitrary windows
 - CWM_GETISHELLBROWSER is now sent only to windows of known safe classes:
   CabinetWClass and ShellTabWindowClass
+- SafeGetShellBrowser: thread-ID guard replaced with process-ID guard.
+  PSFormatForDisplayAlloc fires on a shell worker thread (not the GUI thread),
+  so the thread-ID check always failed and GetSelectedFilePath always returned
+  empty. Process-ID check is sufficient and works correctly from any thread.
+- Added Wh_Log to Wh_ModInit/Wh_ModUninit for basic injection diagnostics
 - Added Wh_ModSettingsChanged so settings take effect without restarting Explorer
 - Cache upgraded from FIFO to true LRU: cache hits now move the entry to the
   back of the eviction queue, keeping frequently-accessed files safe from eviction
@@ -569,8 +574,13 @@ static std::wstring ExtractPathFromBrowser(IShellBrowser* pSB)
 static IShellBrowser* SafeGetShellBrowser(HWND h)
 {
     if (!h) return nullptr;
-    // Guard 1: must belong to the current thread (same Explorer instance)
-    if (GetWindowThreadProcessId(h, nullptr) != GetCurrentThreadId())
+    // Guard 1: must belong to the current process.
+    // PSFormatForDisplayAlloc fires on a shell worker thread, not the GUI thread,
+    // so GetCurrentThreadId() never matches the window's thread. Process-ID check
+    // is sufficient to prevent sending CWM_GETISHELLBROWSER to other processes.
+    DWORD pid = 0;
+    GetWindowThreadProcessId(h, &pid);
+    if (pid != GetCurrentProcessId())
         return nullptr;
     // Guard 2: must be a known-safe class
     wchar_t cls[64] = {};
@@ -939,18 +949,20 @@ static void LoadSettings()
 
 BOOL Wh_ModInit()
 {
+    Wh_Log(L"Wh_ModInit: starting");
     LoadSettings();
 
     InitializeCriticalSection(&g_cs);
 
     HMODULE hPS = GetModuleHandleW(L"propsys.dll");
     if (!hPS) hPS = LoadLibraryW(L"propsys.dll");
-    if (!hPS) return FALSE;
+    if (!hPS) { Wh_Log(L"Wh_ModInit: FAILED — propsys.dll not found"); return FALSE; }
 
     void* pfn = (void*)GetProcAddress(hPS, "PSFormatForDisplayAlloc");
-    if (!pfn) return FALSE;
+    if (!pfn) { Wh_Log(L"Wh_ModInit: FAILED — PSFormatForDisplayAlloc not found"); return FALSE; }
 
     Wh_SetFunctionHook(pfn, (void*)Hook_PSF, (void**)&g_origPSF);
+    Wh_Log(L"Wh_ModInit: hook set — OK");
     return TRUE;
 }
 
@@ -967,6 +979,7 @@ void Wh_ModSettingsChanged()
 
 void Wh_ModUninit()
 {
+    Wh_Log(L"Wh_ModUninit: unloading");
     EnterCriticalSection(&g_cs);
     g_metaCache.clear();
     g_cacheOrder.clear();


### PR DESCRIPTION
Add explorer-status-metadata v1.3.0

Appends rich file metadata (dimensions, date modified, file type,
duration, bitrate, fps) to the Windows Explorer status bar when
a single file is selected. Zero polling — purely reactive,
path-keyed cache with LRU eviction.

## Changelog
Initial release.

## Mod authorship

This mod was created by:
- [x] The submitter, with AI assistance
- [x] Claude
