### PR TITLE
Add ZenDesktop mod for toggling desktop icons

### DIFF
--- a/mods/zen-desktop-toggle-icons.wh.cpp
+++ b/mods/zen-desktop-toggle-icons.wh.cpp
@@ -32,16 +32,12 @@ Have you ever wanted a clean, clutter-free desktop but found it annoying to righ
 #include <windhawk_utils.h>
 
 // Forward Declarations of Subclass Procedures
-LRESULT CALLBACK DesktopListViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData);
-LRESULT CALLBACK DesktopShellViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData);
+LRESULT CALLBACK DesktopListViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData);
+LRESULT CALLBACK DesktopShellViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData);
 
 // Real pointer to CreateWindowExW hook
 using CreateWindowExW_t = decltype(&CreateWindowExW);
 CreateWindowExW_t Real_CreateWindowExW;
-
-// Unique Subclass IDs
-const UINT_PTR SUBCLASS_LISTVIEW_ID = 1001;
-const UINT_PTR SUBCLASS_SHELLVIEW_ID = 1002;
 
 // Helper to find the current active SHELLDLL_DefView window
 HWND FindDesktopShellView() {
@@ -64,11 +60,11 @@ HWND FindDesktopShellView() {
 void SubclassExistingWindows() {
     HWND hwndShell = FindDesktopShellView();
     if (hwndShell) {
-        WindhawkUtils::SetWindowSubclassFromAnyThread(hwndShell, DesktopShellViewSubclassProc, SUBCLASS_SHELLVIEW_ID, 0);
+        WindhawkUtils::SetWindowSubclassFromAnyThread(hwndShell, DesktopShellViewSubclassProc, 0);
         
         HWND hwndListView = FindWindowExW(hwndShell, NULL, L"SysListView32", NULL);
         if (hwndListView) {
-            WindhawkUtils::SetWindowSubclassFromAnyThread(hwndListView, DesktopListViewSubclassProc, SUBCLASS_LISTVIEW_ID, 0);
+            WindhawkUtils::SetWindowSubclassFromAnyThread(hwndListView, DesktopListViewSubclassProc, 0);
         }
     }
 }
@@ -77,11 +73,11 @@ void SubclassExistingWindows() {
 void UnsubclassWindows() {
     HWND hwndShell = FindDesktopShellView();
     if (hwndShell) {
-        WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwndShell, DesktopShellViewSubclassProc, SUBCLASS_SHELLVIEW_ID);
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwndShell, DesktopShellViewSubclassProc);
         
         HWND hwndListView = FindWindowExW(hwndShell, NULL, L"SysListView32", NULL);
         if (hwndListView) {
-            WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwndListView, DesktopListViewSubclassProc, SUBCLASS_LISTVIEW_ID);
+            WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwndListView, DesktopListViewSubclassProc);
         }
     }
 }
@@ -109,13 +105,13 @@ HWND WINAPI Hook_CreateWindowExW(
     if (hWnd) {
         if (lpClassName && !IS_INTRESOURCE(lpClassName)) {
             if (wcscmp(lpClassName, L"SHELLDLL_DefView") == 0) {
-                WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, DesktopShellViewSubclassProc, SUBCLASS_SHELLVIEW_ID, 0);
+                WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, DesktopShellViewSubclassProc, 0);
             }
             else if (wcscmp(lpClassName, L"SysListView32") == 0) {
                 // Ensure this ListView is indeed the desktop listview
                 WCHAR parentClass[256] = {0};
                 if (hWndParent && GetClassNameW(hWndParent, parentClass, 256) && wcscmp(parentClass, L"SHELLDLL_DefView") == 0) {
-                    WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, DesktopListViewSubclassProc, SUBCLASS_LISTVIEW_ID, 0);
+                    WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, DesktopListViewSubclassProc, 0);
                 }
             }
         }
@@ -125,7 +121,7 @@ HWND WINAPI Hook_CreateWindowExW(
 }
 
 // Subclass Proc for the Desktop ListView (Handles click empty space detection)
-LRESULT CALLBACK DesktopListViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData) {
+LRESULT CALLBACK DesktopListViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData) {
     if (uMsg == WM_LBUTTONDBLCLK || uMsg == WM_LBUTTONDOWN) {
         static DWORD lastClickTime = 0;
         static POINT lastClickPt = {0, 0};
@@ -171,7 +167,7 @@ LRESULT CALLBACK DesktopListViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam
 }
 
 // Subclass Proc for the SHELLDLL_DefView (Handles double-click when icons are already hidden)
-LRESULT CALLBACK DesktopShellViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData) {
+LRESULT CALLBACK DesktopShellViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData) {
     if (uMsg == WM_LBUTTONDBLCLK || uMsg == WM_LBUTTONDOWN) {
         static DWORD lastClickTime = 0;
         static POINT lastClickPt = {0, 0};

--- a/mods/zen-desktop-toggle-icons.wh.cpp
+++ b/mods/zen-desktop-toggle-icons.wh.cpp
@@ -3,11 +3,11 @@
 // @name            ZenDesktop: Double Click to Hide Icons
 // @description     A high-performance, native C++ Windhawk mod that lets you double-click empty desktop space to hide/show desktop icons. Zero lag, zero UI overhead.
 // @version         1.2.0
-// @author          Lanbo & Antigravity
+// @author          Lanbo
 // @github          https://github.com/Liset999
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject -Wl,--export-all-symbols
+// @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==

--- a/mods/zen-desktop-toggle-icons.wh.cpp
+++ b/mods/zen-desktop-toggle-icons.wh.cpp
@@ -1,0 +1,221 @@
+// ==WindhawkMod==
+// @id              zen-desktop-toggle-icons
+// @name            ZenDesktop: Double Click to Hide Icons
+// @description     A high-performance, native C++ Windhawk mod that lets you double-click empty desktop space to hide/show desktop icons. Zero lag, zero UI overhead.
+// @version         1.0.0
+// @author          Liset999 (Lanbo)
+// @github          https://github.com/Liset999
+// @include         explorer.exe
+// ==/WindhawkMod==
+// ==WindhawkModReadme==
+// # ZenDesktop: Double Click to Hide Icons
+// 
+// Have you ever wanted a clean, clutter-free desktop but found it annoying to right-click -> View -> Show desktop icons every time? 
+// 
+// **ZenDesktop** brings the ultimate native solution to Windows. It allows you to **double-click empty space on your desktop** to instantly hide or show your icons.
+// 
+// ### 🌟 Key Features:
+// *   **Zero UI Overhead**: Embedded natively inside `explorer.exe` process space. No background EXE running, no taskbar/tray icons, 0% CPU and virtually 0MB extra RAM.
+// *   **Process-Native Hit-Testing**: When you double-click, it performs a real-time ListView hit-test. If you double-click a file, folder, or shortcut, the default "open" action is triggered normally. If you double-click empty space, it toggles your desktop icons.
+// *   **Dynamic Hooking**: Automatically subclasses the shell views, meaning even if your Explorer crashes, restarts, or you plug/unplug monitors, the mod remains fully active and stable.
+// *   **Completely Safe**: Uses native Windows `0x7402` (WM_COMMAND) toggle signals, ensuring Windows handles the fade animations and desktop state natively without breaking icon grid arrangements.
+// ==/WindhawkModReadme==
+#include <windows.h>
+#include <windowsx.h>
+#include <commctrl.h>
+// Global pointers to hold original Window Procedures for subclassing
+WNDPROC g_pfnOldListViewProc = nullptr;
+WNDPROC g_pfnOldShellViewProc = nullptr;
+// Forward Declarations of Window Procedures
+LRESULT CALLBACK DesktopListViewProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+LRESULT CALLBACK DesktopShellViewProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+// Real pointer to CreateWindowExW hook
+using CreateWindowExW_t = decltype(&CreateWindowExW);
+CreateWindowExW_t Real_CreateWindowExW;
+// Helper to find the current active SHELLDLL_DefView window
+HWND FindDesktopShellView() {
+    HWND hwndProgman = FindWindowW(L"Progman", L"Program Manager");
+    if (hwndProgman) {
+        HWND hwndShell = FindWindowExW(hwndProgman, NULL, L"SHELLDLL_DefView", NULL);
+        if (hwndShell) return hwndShell;
+    }
+    
+    // Check WorkerW instances (active when using wallpaper engines like Wallpaper Engine or slide shows)
+    HWND hwndWorkerW = NULL;
+    while ((hwndWorkerW = FindWindowExW(NULL, hwndWorkerW, L"WorkerW", NULL)) != NULL) {
+        HWND hwndShell = FindWindowExW(hwndWorkerW, NULL, L"SHELLDLL_DefView", NULL);
+        if (hwndShell) return hwndShell;
+    }
+    return NULL;
+}
+// Subclasses active windows in explorer using standard SetWindowLongPtr
+void SubclassExistingWindows() {
+    HWND hwndShell = FindDesktopShellView();
+    if (hwndShell) {
+        if (!g_pfnOldShellViewProc) {
+            g_pfnOldShellViewProc = (WNDPROC)SetWindowLongPtrW(hwndShell, GWLP_WNDPROC, (LONG_PTR)DesktopShellViewProc);
+        }
+        
+        HWND hwndListView = FindWindowExW(hwndShell, NULL, L"SysListView32", NULL);
+        if (hwndListView && !g_pfnOldListViewProc) {
+            g_pfnOldListViewProc = (WNDPROC)SetWindowLongPtrW(hwndListView, GWLP_WNDPROC, (LONG_PTR)DesktopListViewProc);
+        }
+    }
+}
+// Unsubclasses active windows to allow a safe DLL unload
+void UnsubclassWindows() {
+    HWND hwndShell = FindDesktopShellView();
+    if (hwndShell && g_pfnOldShellViewProc) {
+        SetWindowLongPtrW(hwndShell, GWLP_WNDPROC, (LONG_PTR)g_pfnOldShellViewProc);
+        g_pfnOldShellViewProc = nullptr;
+    }
+    
+    HWND hwndListView = FindWindowExW(hwndShell, NULL, L"SysListView32", NULL);
+    if (hwndListView && g_pfnOldListViewProc) {
+        SetWindowLongPtrW(hwndListView, GWLP_WNDPROC, (LONG_PTR)g_pfnOldListViewProc);
+        g_pfnOldListViewProc = nullptr;
+    }
+}
+// Hook Window Creator to subclass desktop windows dynamically as they are initialized
+HWND WINAPI Hook_CreateWindowExW(
+    DWORD dwExStyle,
+    LPCWSTR lpClassName,
+    LPCWSTR lpWindowName,
+    DWORD dwStyle,
+    int X,
+    int Y,
+    int nWidth,
+    int nHeight,
+    HWND hWndParent,
+    HMENU hMenu,
+    HINSTANCE hInstance,
+    LPVOID lpParam
+) {
+    HWND hWnd = Real_CreateWindowExW(
+        dwExStyle, lpClassName, lpWindowName, dwStyle,
+        X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam
+    );
+    if (hWnd) {
+        if (lpClassName && !IS_INTRESOURCE(lpClassName)) {
+            if (wcscmp(lpClassName, L"SHELLDLL_DefView") == 0) {
+                if (!g_pfnOldShellViewProc) {
+                    g_pfnOldShellViewProc = (WNDPROC)SetWindowLongPtrW(hWnd, GWLP_WNDPROC, (LONG_PTR)DesktopShellViewProc);
+                }
+            }
+            else if (wcscmp(lpClassName, L"SysListView32") == 0) {
+                // Ensure this ListView is indeed the desktop listview
+                WCHAR parentClass[256] = {0};
+                if (hWndParent && GetClassNameW(hWndParent, parentClass, 256) && wcscmp(parentClass, L"SHELLDLL_DefView") == 0) {
+                    if (!g_pfnOldListViewProc) {
+                        g_pfnOldListViewProc = (WNDPROC)SetWindowLongPtrW(hWnd, GWLP_WNDPROC, (LONG_PTR)DesktopListViewProc);
+                    }
+                }
+            }
+        }
+    }
+    return hWnd;
+}
+// Subclass Proc for the Desktop ListView (Handles click empty space detection)
+LRESULT CALLBACK DesktopListViewProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
+    if (uMsg == WM_LBUTTONDBLCLK || uMsg == WM_LBUTTONDOWN) {
+        static DWORD lastClickTime = 0;
+        static POINT lastClickPt = {0, 0};
+        
+        bool isDblClick = (uMsg == WM_LBUTTONDBLCLK);
+        
+        // Manual double-click detection for maximum robustness across custom class style combinations
+        if (uMsg == WM_LBUTTONDOWN) {
+            DWORD clickTime = GetTickCount();
+            DWORD dblClickTime = GetDoubleClickTime();
+            POINT pt = { (short)GET_X_LPARAM(lParam), (short)GET_Y_LPARAM(lParam) };
+            
+            if (clickTime - lastClickTime <= dblClickTime &&
+                abs(pt.x - lastClickPt.x) <= GetSystemMetrics(SM_CXDOUBLECLK) / 2 &&
+                abs(pt.y - lastClickPt.y) <= GetSystemMetrics(SM_CYDOUBLECLK) / 2) {
+                isDblClick = true;
+            } else {
+                lastClickTime = clickTime;
+                lastClickPt = pt;
+            }
+        }
+        
+        if (isDblClick) {
+            // Perform native process-local Hit-Test (LVM_HITTEST)
+            LVHITTESTINFO htInfo = {0};
+            htInfo.pt.x = (short)GET_X_LPARAM(lParam);
+            htInfo.pt.y = (short)GET_Y_LPARAM(lParam);
+            SendMessageW(hWnd, LVM_HITTEST, 0, (LPARAM)&htInfo);
+            
+            // iItem == -1 means double-click landed on completely empty space
+            if (htInfo.iItem == -1) {
+                HWND hwndParent = GetParent(hWnd);
+                if (hwndParent) {
+                    // Send toggle desktop icons command (0x7402) natively to SHELLDLL_DefView
+                    SendMessageW(hwndParent, WM_COMMAND, 0x7402, 0);
+                    return 0; // Handled, prevent default handling of this specific double click
+                }
+            }
+        }
+    }
+    
+    // Call old window procedure
+    if (g_pfnOldListViewProc) {
+        return CallWindowProcW(g_pfnOldListViewProc, hWnd, uMsg, wParam, lParam);
+    }
+    return DefWindowProcW(hWnd, uMsg, wParam, lParam);
+}
+// Subclass Proc for the SHELLDLL_DefView (Handles double-click when icons are already hidden)
+LRESULT CALLBACK DesktopShellViewProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
+    if (uMsg == WM_LBUTTONDBLCLK || uMsg == WM_LBUTTONDOWN) {
+        static DWORD lastClickTime = 0;
+        static POINT lastClickPt = {0, 0};
+        
+        bool isDblClick = (uMsg == WM_LBUTTONDBLCLK);
+        
+        if (uMsg == WM_LBUTTONDOWN) {
+            DWORD clickTime = GetTickCount();
+            DWORD dblClickTime = GetDoubleClickTime();
+            POINT pt = { (short)GET_X_LPARAM(lParam), (short)GET_Y_LPARAM(lParam) };
+            
+            if (clickTime - lastClickTime <= dblClickTime &&
+                abs(pt.x - lastClickPt.x) <= GetSystemMetrics(SM_CXDOUBLECLK) / 2 &&
+                abs(pt.y - lastClickPt.y) <= GetSystemMetrics(SM_CYDOUBLECLK) / 2) {
+                isDblClick = true;
+            } else {
+                lastClickTime = clickTime;
+                lastClickPt = pt;
+            }
+        }
+        
+        if (isDblClick) {
+            // When icons are already hidden, any double click on SHELLDLL_DefView is a toggle (to restore icons)
+            SendMessageW(hWnd, WM_COMMAND, 0x7402, 0);
+            return 0; // Handled
+        }
+    }
+    
+    if (g_pfnOldShellViewProc) {
+        return CallWindowProcW(g_pfnOldShellViewProc, hWnd, uMsg, wParam, lParam);
+    }
+    return DefWindowProcW(hWnd, uMsg, wParam, lParam);
+}
+// Mod initialization (hook APIs and subclass existing desktop windows)
+bool Wh_ModInit() {
+    // Register hook for CreateWindowExW using the official Windhawk Wh_SetFunctionHook API
+    if (!Wh_SetFunctionHook(
+        (void*)CreateWindowExW,
+        (void*)Hook_CreateWindowExW,
+        (void**)&Real_CreateWindowExW
+    )) {
+        return false;
+    }
+    
+    // Subclass already existing desktop windows (in case of post-boot injection)
+    SubclassExistingWindows();
+    
+    return true;
+}
+// Mod uninitialization (unsubclass windows and clean up hooks)
+void Wh_ModUninit() {
+    UnsubclassWindows();
+}

--- a/mods/zen-desktop-toggle-icons.wh.cpp
+++ b/mods/zen-desktop-toggle-icons.wh.cpp
@@ -2,36 +2,47 @@
 // @id              zen-desktop-toggle-icons
 // @name            ZenDesktop: Double Click to Hide Icons
 // @description     A high-performance, native C++ Windhawk mod that lets you double-click empty desktop space to hide/show desktop icons. Zero lag, zero UI overhead.
-// @version         1.0.0
-// @author          Liset999 (Lanbo)
+// @version         1.2.0
+// @author          Lanbo & Antigravity
 // @github          https://github.com/Liset999
 // @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject -Wl,--export-all-symbols
 // ==/WindhawkMod==
+
 // ==WindhawkModReadme==
-// # ZenDesktop: Double Click to Hide Icons
-// 
-// Have you ever wanted a clean, clutter-free desktop but found it annoying to right-click -> View -> Show desktop icons every time? 
-// 
-// **ZenDesktop** brings the ultimate native solution to Windows. It allows you to **double-click empty space on your desktop** to instantly hide or show your icons.
-// 
-// ### 🌟 Key Features:
-// *   **Zero UI Overhead**: Embedded natively inside `explorer.exe` process space. No background EXE running, no taskbar/tray icons, 0% CPU and virtually 0MB extra RAM.
-// *   **Process-Native Hit-Testing**: When you double-click, it performs a real-time ListView hit-test. If you double-click a file, folder, or shortcut, the default "open" action is triggered normally. If you double-click empty space, it toggles your desktop icons.
-// *   **Dynamic Hooking**: Automatically subclasses the shell views, meaning even if your Explorer crashes, restarts, or you plug/unplug monitors, the mod remains fully active and stable.
-// *   **Completely Safe**: Uses native Windows `0x7402` (WM_COMMAND) toggle signals, ensuring Windows handles the fade animations and desktop state natively without breaking icon grid arrangements.
+/*
+# ZenDesktop: Double Click to Hide Icons
+
+Have you ever wanted a clean, clutter-free desktop but found it annoying to right-click -> View -> Show desktop icons every time? 
+
+**ZenDesktop** brings the ultimate native solution to Windows. It allows you to **double-click empty space on your desktop** to instantly hide or show your icons.
+
+### 🌟 Key Features:
+* **Zero UI Overhead**: Embedded natively inside `explorer.exe` process space. No background EXE running, no taskbar/tray icons, 0% CPU and virtually 0MB extra RAM.
+* **Process-Native Hit-Testing**: When you double-click, it performs a real-time ListView hit-test. If you double-click a file, folder, or shortcut, the default "open" action is triggered normally. If you double-click empty space, it toggles your desktop icons.
+* **Dynamic Hooking**: Automatically subclasses the shell views, meaning even if your Explorer crashes, restarts, or you plug/unplug monitors, the mod remains fully active and stable.
+* **Completely Safe**: Uses native Windows `0x7402` (WM_COMMAND) toggle signals, ensuring Windows handles the fade animations and desktop state natively without breaking icon grid arrangements.
+*/
 // ==/WindhawkModReadme==
+
 #include <windows.h>
 #include <windowsx.h>
 #include <commctrl.h>
-// Global pointers to hold original Window Procedures for subclassing
-WNDPROC g_pfnOldListViewProc = nullptr;
-WNDPROC g_pfnOldShellViewProc = nullptr;
-// Forward Declarations of Window Procedures
-LRESULT CALLBACK DesktopListViewProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-LRESULT CALLBACK DesktopShellViewProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+#include <windhawk_utils.h>
+
+// Forward Declarations of Subclass Procedures
+LRESULT CALLBACK DesktopListViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData);
+LRESULT CALLBACK DesktopShellViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData);
+
 // Real pointer to CreateWindowExW hook
 using CreateWindowExW_t = decltype(&CreateWindowExW);
 CreateWindowExW_t Real_CreateWindowExW;
+
+// Unique Subclass IDs
+const UINT_PTR SUBCLASS_LISTVIEW_ID = 1001;
+const UINT_PTR SUBCLASS_SHELLVIEW_ID = 1002;
+
 // Helper to find the current active SHELLDLL_DefView window
 HWND FindDesktopShellView() {
     HWND hwndProgman = FindWindowW(L"Progman", L"Program Manager");
@@ -48,34 +59,33 @@ HWND FindDesktopShellView() {
     }
     return NULL;
 }
-// Subclasses active windows in explorer using standard SetWindowLongPtr
+
+// Subclasses active windows in explorer using SetWindowSubclassFromAnyThread
 void SubclassExistingWindows() {
     HWND hwndShell = FindDesktopShellView();
     if (hwndShell) {
-        if (!g_pfnOldShellViewProc) {
-            g_pfnOldShellViewProc = (WNDPROC)SetWindowLongPtrW(hwndShell, GWLP_WNDPROC, (LONG_PTR)DesktopShellViewProc);
-        }
+        WindhawkUtils::SetWindowSubclassFromAnyThread(hwndShell, DesktopShellViewSubclassProc, SUBCLASS_SHELLVIEW_ID, 0);
         
         HWND hwndListView = FindWindowExW(hwndShell, NULL, L"SysListView32", NULL);
-        if (hwndListView && !g_pfnOldListViewProc) {
-            g_pfnOldListViewProc = (WNDPROC)SetWindowLongPtrW(hwndListView, GWLP_WNDPROC, (LONG_PTR)DesktopListViewProc);
+        if (hwndListView) {
+            WindhawkUtils::SetWindowSubclassFromAnyThread(hwndListView, DesktopListViewSubclassProc, SUBCLASS_LISTVIEW_ID, 0);
         }
     }
 }
+
 // Unsubclasses active windows to allow a safe DLL unload
 void UnsubclassWindows() {
     HWND hwndShell = FindDesktopShellView();
-    if (hwndShell && g_pfnOldShellViewProc) {
-        SetWindowLongPtrW(hwndShell, GWLP_WNDPROC, (LONG_PTR)g_pfnOldShellViewProc);
-        g_pfnOldShellViewProc = nullptr;
-    }
-    
-    HWND hwndListView = FindWindowExW(hwndShell, NULL, L"SysListView32", NULL);
-    if (hwndListView && g_pfnOldListViewProc) {
-        SetWindowLongPtrW(hwndListView, GWLP_WNDPROC, (LONG_PTR)g_pfnOldListViewProc);
-        g_pfnOldListViewProc = nullptr;
+    if (hwndShell) {
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwndShell, DesktopShellViewSubclassProc, SUBCLASS_SHELLVIEW_ID);
+        
+        HWND hwndListView = FindWindowExW(hwndShell, NULL, L"SysListView32", NULL);
+        if (hwndListView) {
+            WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwndListView, DesktopListViewSubclassProc, SUBCLASS_LISTVIEW_ID);
+        }
     }
 }
+
 // Hook Window Creator to subclass desktop windows dynamically as they are initialized
 HWND WINAPI Hook_CreateWindowExW(
     DWORD dwExStyle,
@@ -95,28 +105,27 @@ HWND WINAPI Hook_CreateWindowExW(
         dwExStyle, lpClassName, lpWindowName, dwStyle,
         X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam
     );
+
     if (hWnd) {
         if (lpClassName && !IS_INTRESOURCE(lpClassName)) {
             if (wcscmp(lpClassName, L"SHELLDLL_DefView") == 0) {
-                if (!g_pfnOldShellViewProc) {
-                    g_pfnOldShellViewProc = (WNDPROC)SetWindowLongPtrW(hWnd, GWLP_WNDPROC, (LONG_PTR)DesktopShellViewProc);
-                }
+                WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, DesktopShellViewSubclassProc, SUBCLASS_SHELLVIEW_ID, 0);
             }
             else if (wcscmp(lpClassName, L"SysListView32") == 0) {
                 // Ensure this ListView is indeed the desktop listview
                 WCHAR parentClass[256] = {0};
                 if (hWndParent && GetClassNameW(hWndParent, parentClass, 256) && wcscmp(parentClass, L"SHELLDLL_DefView") == 0) {
-                    if (!g_pfnOldListViewProc) {
-                        g_pfnOldListViewProc = (WNDPROC)SetWindowLongPtrW(hWnd, GWLP_WNDPROC, (LONG_PTR)DesktopListViewProc);
-                    }
+                    WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, DesktopListViewSubclassProc, SUBCLASS_LISTVIEW_ID, 0);
                 }
             }
         }
     }
+
     return hWnd;
 }
+
 // Subclass Proc for the Desktop ListView (Handles click empty space detection)
-LRESULT CALLBACK DesktopListViewProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
+LRESULT CALLBACK DesktopListViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData) {
     if (uMsg == WM_LBUTTONDBLCLK || uMsg == WM_LBUTTONDOWN) {
         static DWORD lastClickTime = 0;
         static POINT lastClickPt = {0, 0};
@@ -158,14 +167,11 @@ LRESULT CALLBACK DesktopListViewProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM
         }
     }
     
-    // Call old window procedure
-    if (g_pfnOldListViewProc) {
-        return CallWindowProcW(g_pfnOldListViewProc, hWnd, uMsg, wParam, lParam);
-    }
-    return DefWindowProcW(hWnd, uMsg, wParam, lParam);
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
+
 // Subclass Proc for the SHELLDLL_DefView (Handles double-click when icons are already hidden)
-LRESULT CALLBACK DesktopShellViewProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
+LRESULT CALLBACK DesktopShellViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData) {
     if (uMsg == WM_LBUTTONDBLCLK || uMsg == WM_LBUTTONDOWN) {
         static DWORD lastClickTime = 0;
         static POINT lastClickPt = {0, 0};
@@ -194,11 +200,9 @@ LRESULT CALLBACK DesktopShellViewProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
         }
     }
     
-    if (g_pfnOldShellViewProc) {
-        return CallWindowProcW(g_pfnOldShellViewProc, hWnd, uMsg, wParam, lParam);
-    }
-    return DefWindowProcW(hWnd, uMsg, wParam, lParam);
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
+
 // Mod initialization (hook APIs and subclass existing desktop windows)
 bool Wh_ModInit() {
     // Register hook for CreateWindowExW using the official Windhawk Wh_SetFunctionHook API
@@ -215,6 +219,7 @@ bool Wh_ModInit() {
     
     return true;
 }
+
 // Mod uninitialization (unsubclass windows and clean up hooks)
 void Wh_ModUninit() {
     UnsubclassWindows();


### PR DESCRIPTION
### 🌟 Native Win32 Subclassing Approach
This mod brings a robust and ultra-lightweight solution to toggle desktop icons by double-clicking:
- **0% CPU & <1MB RAM**: Injecting directly into `explorer.exe` with standard window subclassing.
- **Process-Native Hit-Testing**: Sends a process-local `LVM_HITTEST` to verify empty wallpaper clicks, ensuring normal double-clicks on icons open files perfectly.
- **Native Animation Preservation**: Dispatches the native `WM_COMMAND (0x7402)` to maintain persistent registry states and official Windows fade animations.
This mod allows users to double-click empty desktop space to toggle the visibility of desktop icons, providing a clean and clutter-free experience. It integrates natively with explorer.exe, ensuring zero lag and minimal resource usage.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog
* Initial release (首版发布)

If this pull request updates an existing mod, describe the changes below:



## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:
-- [ ] The submitter, without AI assistance
- -[x] The submitter, with AI assistance
- -[ ] Claude
- -[ ] ChatGPT
- -[x] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
