### PR TITLE
Dynamic Island for Window

### DIFF
--- a/mods/dynamic-island-for-windows.wh.cpp
+++ b/mods/dynamic-island-for-windows.wh.cpp
@@ -2,11 +2,10 @@
 // @id              dynamic-island-for-windows
 // @name            Dynamic Island for Windows
 // @description     A living, breathing pill overlay inspired by iPhone's Dynamic Island. Reacts to media, downloads, clipboard, battery, and more.
-// @version         1.0.0
+// @version         1.0.1
 // @author          Himanshu
 // @github          https://github.com/devcode90
 // @include         windhawk.exe
-// @architecture    x86-64
 // @compilerOptions -lole32 -loleaut32 -lshcore -ld2d1 -ldwrite -ldwmapi -lgdi32 -luser32 -lshell32 -lruntimeobject -lwindowscodecs -lavrt -lsetupapi
 // @license         MIT
 // ==/WindhawkMod==
@@ -3793,8 +3792,18 @@ void WhTool_ModUninit() {
 }
 
 //////////////////////////////////////////////////////////////////////////////////
-// Tool-mod launcher: runs mod logic in a dedicated windhawk.exe process.
+// Windhawk tool mod implementation for mods which don't need to inject to other
+// processes or hook other functions. Context:
 // https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
+//
+// The mod will load and run in a dedicated windhawk.exe process.
+//
+// Paste the code below as part of the mod code, and use these callbacks:
+// * WhTool_ModInit
+// * WhTool_ModSettingsChanged
+// * WhTool_ModUninit
+//
+// Currently, other callbacks are not supported.
 
 bool g_isToolModProcessLauncher;
 HANDLE g_toolModProcessMutex;


### PR DESCRIPTION
Follow-up fix to #4115.

The mod was not loading for public catalog users after installation. The root cause was that `windhawk.exe` is excluded from injection by default (to prevent recursion), so the tool-mod launcher was never executed and the Dynamic Island UI never appeared.

### Changes

- **`@include explorer.exe`** — `explorer.exe` always runs in the active user session (Session 1) and is always injected by default. This guarantees the launcher executes on startup for every user without any manual configuration.
- **Removed `sessionId == 0` check in `Wh_ModInit`** — not needed anymore since `explorer.exe` never runs in Session 0.
- **Dynamic settings launcher (Case 9)** — instead of passing a hardcoded `local@` URL, it now reads Windhawk's installation path from the registry (`SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Windhawk` → `DisplayIcon`) and opens it with `windhawk://mods/<WH_MOD_ID>`. This works correctly for both local drafts and the public catalog release.

### Mod Authorship ✍️
- [x] The submitter, without AI assistance
- [ ] The submitter, with AI assistance
- [ ] Claude
- [ ] ChatGPT
- [ ] Gemini (Antigravity)
- [ ] Another AI (please specify):
- [ ] Other (please specify):