### PR TITLE
Never Auto-Expand Explorer Tree Items v1.0.1

### DIFF
--- a/mods/never-auto-expand-explorer-tree-items.wh.cpp
+++ b/mods/never-auto-expand-explorer-tree-items.wh.cpp
@@ -2,7 +2,7 @@
 // @id              never-auto-expand-explorer-tree-items
 // @name            Never Auto-Expand Explorer Tree Items
 // @description     Stops the unwanted auto-expansion of navigation pane items even if the "Expand to current folder" option is off
-// @version         1.0
+// @version         1.0.1
 // @author          Kitsune
 // @github          https://github.com/AromaKitsune
 // @include         *
@@ -15,10 +15,14 @@
 File Explorer automatically expands navigation pane items (such as "This PC")
 even if the "Expand to current folder" option is off, specifically when:
 * Opening any folder inside an external drive in a new tab or window.
-* Navigating to any drive after manually expanding and collapsing "This PC".
+* Navigating to any drive after manually expanding and collapsing the "This PC"
+  item.
 
 This mod prevents this unwanted auto-expansion behavior, keeping the navigation
 pane tidy.
+
+**Note:** The top-level "Desktop" item can still auto-expand when the
+"Show all folders" option is on, keeping the navigation pane populated.
 
 | Before | After |
 | :----: | :---: |
@@ -94,6 +98,23 @@ bool IsUserInteractingWithTreeView(HWND hTreeView)
     return false;
 }
 
+// Helper: Check if the tree item is the only root node in the navigation pane
+// This ensures the "Desktop" node can still auto-expand when the "Show all
+// folders" option is on.
+bool IsSingleRootNode(HWND hTreeView, HTREEITEM hTreeItem)
+{
+    auto hFirstRootItem = reinterpret_cast<HTREEITEM>(
+        SendMessageW(hTreeView, TVM_GETNEXTITEM, TVGN_ROOT, 0));
+    if (hFirstRootItem != nullptr && hTreeItem == hFirstRootItem)
+    {
+        auto hNextSibling = reinterpret_cast<HTREEITEM>(
+            SendMessageW(hTreeView, TVM_GETNEXTITEM, TVGN_NEXT,
+                reinterpret_cast<LPARAM>(hFirstRootItem)));
+        return hNextSibling == nullptr;
+    }
+    return false;
+}
+
 // Hook for SendMessageW
 using SendMessageW_t = decltype(&SendMessageW);
 SendMessageW_t SendMessageW_Original;
@@ -112,7 +133,8 @@ LRESULT WINAPI SendMessageW_Hook(HWND hWnd, UINT uMsg, WPARAM wParam,
             _wcsicmp(szClassName, L"SysTreeView32") == 0)
         {
             if (IsExplorerNavigationPane(hWnd) &&
-                !IsUserInteractingWithTreeView(hWnd))
+                !IsUserInteractingWithTreeView(hWnd) &&
+                !IsSingleRootNode(hWnd, reinterpret_cast<HTREEITEM>(lParam)))
             {
                 return 0;
             }
@@ -128,7 +150,9 @@ LRESULT WINAPI SendMessageW_Hook(HWND hWnd, UINT uMsg, WPARAM wParam,
             if (pTreeViewNotify->action == TVE_EXPAND)
             {
                 if (IsExplorerNavigationPane(pNotifyHeader->hwndFrom) &&
-                    !IsUserInteractingWithTreeView(pNotifyHeader->hwndFrom))
+                    !IsUserInteractingWithTreeView(pNotifyHeader->hwndFrom) &&
+                    !IsSingleRootNode(pNotifyHeader->hwndFrom,
+                        pTreeViewNotify->itemNew.hItem))
                 {
                     return TRUE;
                 }

--- a/mods/never-auto-expand-explorer-tree-items.wh.cpp
+++ b/mods/never-auto-expand-explorer-tree-items.wh.cpp
@@ -99,18 +99,14 @@ bool IsUserInteractingWithTreeView(HWND hTreeView)
 }
 
 // Helper: Check if the tree item is the only root node in the navigation pane
-// This ensures the "Desktop" node can still auto-expand when the "Show all
-// folders" option is on.
+// This ensures the top-level "Desktop" item can still auto-expand when the
+// "Show all folders" option is on.
 bool IsSingleRootNode(HWND hTreeView, HTREEITEM hTreeItem)
 {
-    auto hFirstRootItem = reinterpret_cast<HTREEITEM>(
-        SendMessageW(hTreeView, TVM_GETNEXTITEM, TVGN_ROOT, 0));
-    if (hFirstRootItem != nullptr && hTreeItem == hFirstRootItem)
+    auto hFirstRootItem = TreeView_GetRoot(hTreeView);
+    if (hTreeItem == hFirstRootItem)
     {
-        auto hNextSibling = reinterpret_cast<HTREEITEM>(
-            SendMessageW(hTreeView, TVM_GETNEXTITEM, TVGN_NEXT,
-                reinterpret_cast<LPARAM>(hFirstRootItem)));
-        return hNextSibling == nullptr;
+        return TreeView_GetNextSibling(hTreeView, hFirstRootItem) == nullptr;
     }
     return false;
 }


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

Added an exception for the top-level "Desktop" item so it can still auto-expand when the "Show all folders" option is on, keeping the navigation pane populated.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
