### PR TITLE
Add Desktop root and expandable This PC to nav top

### DIFF
--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.17
+// @version         1.1.18
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -236,6 +236,7 @@ struct TreeState {
     HTREEITEM boundaryItem = nullptr;
     HTREEITEM belowQAItem = nullptr;
     uint8_t pendingWork = 0;   // bitmask of PendingWork flags
+    int sepRetries = 0;
     bool ownsNscRef = false;
     bool triedHomeSpacer = false;
     HIMAGELIST savedStateImageList = nullptr;
@@ -632,7 +633,7 @@ static void DrawChevron(HDC hdc, const RECT *r, int partId, int stateId)
 static thread_local bool g_inTreePaint = false;
 static thread_local int g_inSubclassProc = 0;
 static thread_local int g_lastSepY = -1;
-static thread_local int g_sepRetries = 0;
+static thread_local int g_firstSepY = -1;
 
 static bool AreWeMutating()
 {
@@ -953,6 +954,7 @@ static void RestoreTree(HWND hTree)
     void *pNscRaw = ts->pNscTree;
     unsigned long enumFlags = ts->enumFlags;
     IShellItemFilter *pFilterRaw = ts->pFilter;
+    ts->pFilter = nullptr;
     if (pFilterRaw)
         pFilterRaw->AddRef();
     HIMAGELIST savedImgList = ts->savedStateImageList;
@@ -1001,11 +1003,6 @@ static void RestoreTree(HWND hTree)
         if (ownsRef)
             ts->ownsNscRef = false;
         ts->pNscTree = nullptr;
-        if (ts->pFilter)
-        {
-            ts->pFilter->Release();
-            ts->pFilter = nullptr;
-        }
     }
 
     if (ownsRef)
@@ -1023,6 +1020,12 @@ static void FullRebuildTree(HWND hTree)
     ComRef<INameSpaceTreeControl> pNsc((INameSpaceTreeControl *)ts->pNscTree);
     void *pNscRaw = ts->pNscTree;
     unsigned long enumFlags = ts->enumFlags;
+
+    if (ts->pFilter)
+    {
+        ts->pFilter->Release();
+        ts->pFilter = nullptr;
+    }
 
     // Remove HomeSpacer before roots — it's a separate namespace item.
     RemoveHomeSpacer(*ts, pNsc.get());
@@ -1112,10 +1115,8 @@ static void InsertHomeSpacer(HWND hTree)
     HTREEITEM hSpacer = nullptr;
     WCHAR spacerNames[1][64] = {};
     wcsncpy_s(spacerNames[0], 64, g_navItems[spacerId].label, _TRUNCATE);
-    ForEachLabeledSibling(hTree,
-        [&](HTREEITEM h) { return h == ts->hItems[NAV_DESKTOP] || h == ts->hItems[NAV_THISPC]; },
-        spacerNames, 1,
-        [&](HTREEITEM h, int) -> bool { hSpacer = h; return false; });
+    ForEachLabeledSibling(hTree, [&](HTREEITEM h) { return h == ts->hItems[NAV_DESKTOP] || h == ts->hItems[NAV_THISPC]; },
+        spacerNames, 1, [&](HTREEITEM h, int) -> bool { hSpacer = h; return false; });
 
     if (hSpacer)
     {
@@ -1235,6 +1236,8 @@ static void DrawSeparatorLine(HDC hdc, HWND hTree, int sepY)
     {
         FillRect(hdc, &sepRect, brush);
         DeleteObject(brush);
+        if (g_firstSepY == -1)
+            g_firstSepY = sepY;
         g_lastSepY = sepY;
     }
 }
@@ -1481,15 +1484,11 @@ static bool CleanupDups(HWND hTree, TreeState& ts)
     int childlessCount = 0;
     int sectionCount = 0;
 
-    ForEachLabeledSibling(hTree,
-        [&](HTREEITEM h) { return IsOurSection(ts, h); },
-        matchNames, expectedCount,
+    ForEachLabeledSibling(hTree, [&](HTREEITEM h) { return IsOurSection(ts, h); }, matchNames, expectedCount,
         [&](HTREEITEM h, int) -> bool {
             HTREEITEM hChild = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_CHILD, (LPARAM)h);
-            if (!hChild)
-            { if (childlessCount < 8) toDeleteChildless[childlessCount++] = h; }
-            else
-            { if (sectionCount < 4) toDeleteSections[sectionCount++] = h; }
+            if (!hChild) { if (childlessCount < 8) toDeleteChildless[childlessCount++] = h; }
+            else { if (sectionCount < 4) toDeleteSections[sectionCount++] = h; }
             return true;
         });
 
@@ -1558,12 +1557,8 @@ static bool RemoveInherited(HWND hTree, TreeState& ts)
     for (int i = 0; i < targetCount; i++)
         wcsncpy_s(targetNames[i], 64, targets[i].name, _TRUNCATE);
 
-    ForEachLabeledSibling(hTree,
-        [&](HTREEITEM h) {
-            return IsOurSection(ts, h) || h == ts.hiddenDuplicate || h == ts.homeSpacerItem;
-        },
-        targetNames, targetCount,
-        [&](HTREEITEM h, int j) -> bool {
+    ForEachLabeledSibling(hTree, [&](HTREEITEM h) { return IsOurSection(ts, h) || h == ts.hiddenDuplicate || h == ts.homeSpacerItem; },
+        targetNames, targetCount, [&](HTREEITEM h, int j) -> bool {
             toDelete[delCount++] = { h, targets[j].id };
             return delCount < targetCount;
         });
@@ -1916,6 +1911,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             SetWindowSubclass(hWnd, TreeInteractionProc, 0xAF01, 0);
 
         g_lastSepY = -1;
+        g_firstSepY = -1;
         g_inTreePaint = true;
 
         LRESULT result = SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData);
@@ -1923,7 +1919,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         g_inTreePaint = false;
 
         ts = GetTree(hWnd);
-        if (g_lastSepY >= 0 && g_sepColor != CLR_INVALID && g_sepRetries < 3)
+        if (g_lastSepY >= 0 && g_sepColor != CLR_INVALID && ts && ts->sepRetries < 3)
         {
             HDC hdc = GetDC(hWnd);
             if (hdc)
@@ -1931,28 +1927,37 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 RECT client;
                 GetClientRect(hWnd, &client);
                 int sampleX = client.right / 2;
-                COLORREF pixel = GetPixel(hdc, sampleX, g_lastSepY);
-                ReleaseDC(hWnd, hdc);
-                if (pixel != CLR_INVALID && pixel != g_sepColor)
+                bool mismatch = false;
+                int failY = g_lastSepY;
+                int checkYs[] = { g_firstSepY, g_lastSepY };
+                for (int y : checkYs)
                 {
-                    g_sepRetries++;
+                    if (y < 0) continue;
+                    COLORREF pixel = GetPixel(hdc, sampleX, y);
+                    if (pixel != CLR_INVALID && pixel != g_sepColor)
+                        { mismatch = true; failY = y; break; }
+                }
+                ReleaseDC(hWnd, hdc);
+                if (mismatch)
+                {
+                    ts->sepRetries++;
                     Wh_Log(L"[SEP-VERIFY] tree=%04X at (%d,%d): "
-                           L"expected=0x%06X got=0x%06X, retry %d",
-                           PTR4(hWnd), sampleX, g_lastSepY, g_sepColor, pixel, g_sepRetries);
-                    InvalidateRect(hWnd, nullptr, FALSE);
+                           L"expected=0x%06X, retry %d",
+                           PTR4(hWnd), sampleX, failY, g_sepColor, ts->sepRetries);
+                    RedrawWindow(hWnd, nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
                 }
                 else
-                    g_sepRetries = 0;
+                    ts->sepRetries = 0;
             }
         }
-        else if (g_lastSepY == -1 && g_sepColor != CLR_INVALID && g_sepRetries < 3
-                 && ts && !ts->pendingWork && HasOurItemsInTree(*ts) && ts->boundaryItem
-                 && !g_settings.removeSepBelowNav && !GetHiddenItem(*ts))
+        else if (g_lastSepY == -1 && g_sepColor != CLR_INVALID
+                 && ts && ts->sepRetries < 3 && !ts->pendingWork && HasOurItemsInTree(*ts)
+                 && ts->boundaryItem && !g_settings.removeSepBelowNav && !GetHiddenItem(*ts))
         {
-            g_sepRetries++;
+            ts->sepRetries++;
             Wh_Log(L"[SEP-VERIFY] tree=%04X boundary=%04X: expected separator but none drawn, retry %d",
-                   PTR4(hWnd), PTR4(ts->boundaryItem), g_sepRetries);
-            InvalidateRect(hWnd, nullptr, FALSE);
+                   PTR4(hWnd), PTR4(ts->boundaryItem), ts->sepRetries);
+            RedrawWindow(hWnd, nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
         }
 
         return result;
@@ -2374,80 +2379,91 @@ ChangeTier ClassifySettingsChange(const Settings& prev, const Settings& cur)
 
 void Wh_ModSettingsChanged()
 {
-    auto prev = g_settings;
-    LoadSettings();
+    static bool inProgress = false, rerunNeeded = false;
+    if (inProgress) { rerunNeeded = true; return; }
+    inProgress = true;
 
-    ChangeTier tier = ClassifySettingsChange(prev, g_settings);
-    if (tier == TIER_NONE)
-        return;
+    do {
+        rerunNeeded = false;
 
-    g_sepRetries = 0;
+        auto prev = g_settings;
+        LoadSettings();
 
-    // Snapshot HWNDs: FullRebuildTree pumps messages, which can rehash g_trees mid-iteration.
-    std::vector<HWND> treeList;
-    treeList.reserve(g_trees.size());
-    for (auto& [hTree, ts] : g_trees)
-        treeList.push_back(hTree);
-    int treeCount = (int)treeList.size();
+        ChangeTier tier = ClassifySettingsChange(prev, g_settings);
+        if (tier == TIER_NONE)
+            break;
 
-    bool sepChanged = (prev.removeSepBelowNav != g_settings.removeSepBelowNav ||
-                       prev.removeSepBelowQA  != g_settings.removeSepBelowQA);
-    if (sepChanged)
-        ResetSepColor();
-
-    for (int i = 0; i < treeCount; i++)
-    {
-        HWND hTree = treeList[i];
-        TreeState* ts = GetTree(hTree);
-        if (!ts || !IsWindow(hTree) || !ts->pNscTree)
-            continue;
-
-        if (tier == TIER_REBUILD)
+        // Snapshot HWNDs: FullRebuildTree pumps messages, which can rehash g_trees mid-iteration.
+        std::vector<HWND> treeList;
+        treeList.reserve(g_trees.size());
+        for (auto& [hTree, ts] : g_trees)
         {
-            g_deferredOpInProgress = true;
-            g_mutatingTree = hTree;
-            FullRebuildTree(hTree);
-            DrainPendingRebuilds();
+            ts.sepRetries = 0;
+            treeList.push_back(hTree);
         }
-        else if (tier == TIER_REFRESH)
-        {
-            ts->boundaryItem = nullptr;
-            ts->belowQAItem = nullptr;
-            ts->pendingWork |= WORK_QA_CLEANUP;
-            RefreshNavPane(hTree);
-        }
-        else // TIER_REPAINT
-        {
-            bool homeGalleryChanged = (prev.items[NAV_HOME].hide    != g_settings.items[NAV_HOME].hide ||
-                                       prev.items[NAV_GALLERY].hide != g_settings.items[NAV_GALLERY].hide);
-            bool dedupChanged = false;
-            for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
-                if (g_settings.items[i].showAtTop && prev.items[i].hideFromQA != g_settings.items[i].hideFromQA)
-                    dedupChanged = true;
+        int treeCount = (int)treeList.size();
 
-            if (homeGalleryChanged)
+        bool sepChanged = (prev.removeSepBelowNav != g_settings.removeSepBelowNav ||
+                           prev.removeSepBelowQA  != g_settings.removeSepBelowQA);
+        if (sepChanged)
+            ResetSepColor();
+
+        for (int i = 0; i < treeCount; i++)
+        {
+            HWND hTree = treeList[i];
+            TreeState* ts = GetTree(hTree);
+            if (!ts || !IsWindow(hTree) || !ts->pNscTree)
+                continue;
+
+            if (tier == TIER_REBUILD)
             {
-                for (int j = NAV_HOME; j < NAV_COUNT; j++)
-                    if (g_settings.items[j].hide)
-                        ts->hItems[j] = nullptr;
-                ts->pendingWork |= WORK_HG_CLEANUP;
+                g_deferredOpInProgress = true;
+                g_mutatingTree = hTree;
+                FullRebuildTree(hTree);
+                DrainPendingRebuilds();
             }
-            if (dedupChanged)
-            {
-                ts->pendingWork |= WORK_QA_CLEANUP;
-            }
-            if (sepChanged || dedupChanged)
+            else if (tier == TIER_REFRESH)
             {
                 ts->boundaryItem = nullptr;
                 ts->belowQAItem = nullptr;
+                ts->pendingWork |= WORK_QA_CLEANUP;
+                RefreshNavPane(hTree);
             }
+            else // TIER_REPAINT
+            {
+                bool homeGalleryChanged = (prev.items[NAV_HOME].hide    != g_settings.items[NAV_HOME].hide ||
+                                           prev.items[NAV_GALLERY].hide != g_settings.items[NAV_GALLERY].hide);
+                bool dedupChanged = false;
+                for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
+                    if (g_settings.items[i].showAtTop && prev.items[i].hideFromQA != g_settings.items[i].hideFromQA)
+                        dedupChanged = true;
 
-            InvalidateRect(hTree, nullptr, TRUE);
+                if (homeGalleryChanged)
+                {
+                    for (int j = NAV_HOME; j < NAV_COUNT; j++)
+                        if (g_settings.items[j].hide)
+                            ts->hItems[j] = nullptr;
+                    ts->pendingWork |= WORK_HG_CLEANUP;
+                }
+                if (dedupChanged)
+                {
+                    ts->pendingWork |= WORK_QA_CLEANUP;
+                }
+                if (sepChanged || dedupChanged)
+                {
+                    ts->boundaryItem = nullptr;
+                    ts->belowQAItem = nullptr;
+                }
+
+                InvalidateRect(hTree, nullptr, TRUE);
+            }
         }
-    }
 
-    if (!prev.hasItemsAtTop && g_settings.hasItemsAtTop)
-        Wh_ModAfterInit();
+        if (!prev.hasItemsAtTop && g_settings.hasItemsAtTop)
+            Wh_ModAfterInit();
+    } while (rerunNeeded);
+
+    inProgress = false;
 }
 
 void Wh_ModUninit()

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -595,6 +595,8 @@ static void DrawChevron(HDC hdc, const RECT *r, int partId, int stateId)
 
 static thread_local bool g_inTreePaint = false;
 static thread_local int g_inSubclassProc = 0;
+static thread_local int g_lastSepY = -1;
+static thread_local int g_sepRetries = 0;
 
 static bool AreWeMutating()
 {
@@ -1187,6 +1189,7 @@ static void DrawSeparatorLine(HDC hdc, HWND hTree, int sepY)
     {
         FillRect(hdc, &sepRect, brush);
         DeleteObject(brush);
+        g_lastSepY = sepY;
     }
 }
 
@@ -1903,11 +1906,35 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         if (ts && GetHiddenItem(*ts))
             SetWindowSubclass(hWnd, TreeInteractionProc, 0xAF01, 0);
 
+        g_lastSepY = -1;
         g_inTreePaint = true;
 
         LRESULT result = SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData);
 
         g_inTreePaint = false;
+
+        if (g_lastSepY >= 0 && g_sepColor != CLR_INVALID && g_sepRetries < 3)
+        {
+            HDC hdc = GetDC(hWnd);
+            if (hdc)
+            {
+                RECT client;
+                GetClientRect(hWnd, &client);
+                int sampleX = client.right / 2;
+                COLORREF pixel = GetPixel(hdc, sampleX, g_lastSepY);
+                ReleaseDC(hWnd, hdc);
+                if (pixel != CLR_INVALID && pixel != g_sepColor)
+                {
+                    g_sepRetries++;
+                    Wh_Log(L"[SEP-VERIFY] separator redrawn at (%d,%d): "
+                           L"expected=0x%06X got=0x%06X, retry %d",
+                           sampleX, g_lastSepY, g_sepColor, pixel, g_sepRetries);
+                    InvalidateRect(hWnd, nullptr, FALSE);
+                }
+                else
+                    g_sepRetries = 0;
+            }
+        }
 
         return result;
     }
@@ -2325,6 +2352,8 @@ void Wh_ModSettingsChanged()
     ChangeTier tier = ClassifySettingsChange(prev, g_settings);
     if (tier == TIER_NONE)
         return;
+
+    g_sepRetries = 0;
 
     // Snapshot HWNDs: FullRebuildTree pumps messages, which can rehash g_trees mid-iteration.
     std::vector<HWND> treeList;

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.5
+// @version         1.1.6
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -1417,12 +1417,11 @@ static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
         InvalidateRect(hTree, nullptr, TRUE);
     }
 
-    int totalFound = childlessCount + sectionCount;
-    bool complete = (totalFound >= expectedCount);
-    if (needDelete && (complete || ts.hiddenDuplicate != prevDup))
-        Wh_Log(L"[QA-HIDE] tree=%p childless=%d sections=%d expected=%d", hTree, childlessCount, sectionCount, expectedCount);
+    if (needDelete || ts.hiddenDuplicate != prevDup)
+        Wh_Log(L"[QA-HIDE] tree=%p childless=%d sections=%d expected=%d",
+               hTree, childlessCount, sectionCount, expectedCount);
 
-    return complete;
+    return true;
 }
 
 static bool RemoveHiddenInheritedItems(HWND hTree, TreeState& ts)
@@ -1587,7 +1586,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                     for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
                         if (ts->hItems[i]) { hasOurItems = true; break; }
 
-                    if (hasOurItems)
+                    if (hasOurItems && !g_deferredOpInProgress && !g_inTreePaint)
                     {
                         ts->pendingWork |= WORK_FULL_REBUILD;
                         PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
@@ -1837,8 +1836,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         if (ts && ts->hiddenDuplicate)
             SetWindowSubclass(hWnd, TreeInteractionProc, 0xAF01, 0);
 
-        if (g_settings.fixChevronDrawing)
-            g_inTreePaint = true;
+        g_inTreePaint = true;
 
         LRESULT result = SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData);
 
@@ -1886,7 +1884,7 @@ HRESULT WINAPI DrawThemeBackground_hook(HTHEME hTheme, HDC hdc, int iPartId, int
             Wh_Log(L"[CHEVRON] DTB hook active, inPaint=%d fixEnabled=%d",
                 (int)g_inTreePaint, (int)g_settings.fixChevronDrawing);
         }
-        if (g_inTreePaint)
+        if (g_inTreePaint && g_settings.fixChevronDrawing)
         {
             RECT drawRect;
             CalcGlyphRect(pRect, &drawRect);

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
-// @description     Adds This PC and Desktop to the top of Explorer's navigation pane
-// @version         1.1.1
+// @description     Adds This PC and Desktop to the top of Explorer's nav
+// @version         1.1.2
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -15,35 +15,21 @@
 /*
 # Add This PC and Desktop to Nav Top
 
-This mod adds two virtual folders to the top of File Explorer's
-navigation pane and fixes the chevron rendering.
+This mod adds two virtual folders to the top of File Explorer's navigation pane and fixes the chevron rendering.
 
-- **Show This PC at top:** Adds an expandable This PC entry
-with drives. (Expandable This PC can't be pinned to the top
-without this mod.)
+- **Show This PC at top:** Adds an expandable This PC entry with drives. (Expandable This PC can't be pinned to the top without this mod.)
 
-- **Show Desktop at top:** Adds a Desktop entry for the root
-namespace object. This includes Recycle Bin, Control Panel, etc.
-instead of just the items on the desktop. (This target can't be
-pinned without this mod.)
+- **Show Desktop at top:** Adds a Desktop entry for the root namespace object. This includes Recycle Bin, Control Panel, etc. instead of just the items on the desktop. (This target can't be pinned without this mod.)
 
-Both virtual folders have a toggle for whether they are expandable
-or not. Their position can be swapped. Duplicate entries of Desktop
-or This PC can be removed from other parts of the nav. Also:
+Both virtual folders have a toggle for whether they are expandable or not. Their position can be swapped. Duplicate entries of Desktop or This PC can be removed from other parts of the nav. Also:
 
-- **Hide Home/Gallery:** Optional, default-enabled toggles to
-hide the native Explorer entries. They don't affect Quick Access.
+- **Hide Home/Gallery:** Optional, default-enabled toggles to hide the native Explorer entries. They don't affect Quick Access.
 
 - **Remove separators:** Optionally remove each separator individually.
 
-- **Fix chevron drawing:** Replaces the pixelated and clipped
-chevron with a smooth anti-aliased versions. The size (which
-matches other UI elements by default) is configurable.
+- **Fix chevron drawing:** Replaces the pixelated and clipped chevron with a smooth anti-aliased versions. The size (which matches other UI elements by default) is configurable.
 
-This mod injects only in processes that have ExplorerFrame.dll,
-so the include is set to `*` but it will not touch most processes.
-You can set it to `explorer.exe` only, if you don't want the nav in
-Open/Save dialogs changed (only modern dialogs are affected.)
+This mod injects only in processes that have ExplorerFrame.dll, so the include is set to `*` but it will not touch most processes. You can set it to `explorer.exe` only, if you don't want the nav in Open/Save dialogs changed (only modern dialogs are affected.)
 
 Before:
 
@@ -53,8 +39,7 @@ After:
 
 ![After](https://i.imgur.com/JQQ5ZTN.jpeg)
 
-The screenshots show the normal Desktop pinned to Quick Access in
-the before, and the mod with defaults set in the after.
+The screenshots show the normal Desktop pinned to Quick Access in the before, and the mod with defaults set in the after.
 */
 // ==/WindhawkModReadme==
 
@@ -63,7 +48,7 @@ the before, and the mod with defaults set in the after.
 - ThisPC:
   - showThisPCAtTop: true
     $name: Add to top
-    $description: Add an expandable entry for This PC to the top of the navigation pane.
+    $description: Add an expandable entry for This PC to the top of the nav.
   - thisPCExpandable: true
     $name: Make expandable
     $description: Shows drives underneath This PC when expanded.
@@ -135,53 +120,115 @@ the before, and the mod with defaults set in the after.
 #define THISCALL __thiscall
 #endif
 
-struct {
-    bool showThisPCAtTop;
-    bool thisPCExpandable;
-    bool thisPCStartExpanded;
-    bool hideThisPCFromQuickAccess;
-    bool showDesktopAtTop;
+template<typename T>
+struct ComRef {
+    T* p;
+    ComRef() : p(nullptr) {}
+    explicit ComRef(T* raw, bool addRef = true) : p(raw) {
+        if (p && addRef) p->AddRef();
+    }
+    ~ComRef() { if (p) p->Release(); }
+    ComRef(const ComRef&) = delete;
+    ComRef& operator=(const ComRef&) = delete;
+    ComRef(ComRef&& other) noexcept : p(other.p) { other.p = nullptr; }
+    ComRef& operator=(ComRef&& other) noexcept {
+        if (this != &other) { if (p) p->Release(); p = other.p; other.p = nullptr; }
+        return *this;
+    }
+    T* operator->() { return p; }
+    T* get() const { return p; }
+    explicit operator bool() const { return p != nullptr; }
+};
+
+enum NavItemId {
+    NAV_THISPC  = 0,
+    NAV_DESKTOP = 1,
+    NAV_HOME    = 2,
+    NAV_GALLERY = 3,
+    NAV_COUNT   = 4
+};
+
+struct NavItemDef {
+    PIDLIST_ABSOLUTE pidl;
+    WCHAR label[64];
+};
+
+static NavItemDef g_navItems[NAV_COUNT] = {};
+
+struct NavItemSettings {
+    bool showAtTop;
+    bool expandable;
+    bool startExpanded;
+    bool hideFromQA;
+    bool hide;
+};
+
+struct Settings {
+    NavItemSettings items[NAV_COUNT];
     bool desktopAboveThisPC;
-    bool desktopExpandable;
-    bool hideDesktopFromQuickAccess;
-    bool hideHome;
-    bool hideGallery;
     bool fixChevronDrawing;
     int chevronScale;
     bool hidePinButtons;
     bool removeSepBelowNav;
     bool removeSepBelowQA;
-} g_settings;
+    bool hasItemsAtTop;  // precomputed: any items[i].showAtTop is true
+};
+static Settings g_settings;
 
-static PIDLIST_ABSOLUTE g_pidlThisPC = nullptr;
-static PIDLIST_ABSOLUTE g_pidlDesktop = nullptr;
-static PIDLIST_ABSOLUTE g_pidlHome = nullptr;
-static PIDLIST_ABSOLUTE g_pidlGallery = nullptr;
+struct RootShellItems {
+    ComRef<IShellItem> items[NAV_COUNT];
+
+    bool Create() {
+        for (int i = 0; i < NAV_COUNT; i++) {
+            if (!g_navItems[i].pidl) continue;
+            IShellItem *raw = nullptr;
+            if (SUCCEEDED(SHCreateItemFromIDList(
+                    g_navItems[i].pidl, IID_IShellItem, (void**)&raw)))
+                items[i] = ComRef<IShellItem>(raw, false);
+        }
+        return (bool)items[NAV_DESKTOP];
+    }
+
+    void RemoveInsertableRoots(INameSpaceTreeControl *pNsc) {
+        if (items[NAV_THISPC])
+            while (SUCCEEDED(pNsc->RemoveRoot(items[NAV_THISPC].get())));
+        if (items[NAV_DESKTOP])
+            while (SUCCEEDED(pNsc->RemoveRoot(items[NAV_DESKTOP].get())));
+    }
+};
+
+enum ChangeTier { TIER_NONE, TIER_REPAINT, TIER_REFRESH, TIER_REBUILD };
+
 static ULONG_PTR g_gdipToken = 0;
 static std::set<HWND> g_subclassedParents;
 static COLORREF g_sepColor = CLR_INVALID;
 static bool g_sepColorPendingVerify = false;
 static bool g_logSepDraw = true;
 
+static void ResetSepColor() {
+    g_sepColor = CLR_INVALID;
+    g_logSepDraw = true;
+}
+
+enum PendingWork : uint8_t {
+    WORK_FULL_REBUILD = 0x01,
+    WORK_HOT_INSERT   = 0x02,
+    WORK_QA_CLEANUP   = 0x04,
+    WORK_HG_CLEANUP   = 0x08,
+    WORK_DUP_COLLAPSE = 0x10,
+};
+
 // Per-tree state: one entry per SysTreeView32 that we've injected items into.
 struct TreeState {
     void *pNscTree = nullptr;
     unsigned long enumFlags = 0;
     IShellItemFilter *pFilter = nullptr;
-    HTREEITEM hThisPC = nullptr;
-    HTREEITEM hDesktop = nullptr;
-    HTREEITEM hHome = nullptr;
-    HTREEITEM hGallery = nullptr;
+    HTREEITEM hItems[NAV_COUNT] = {};
     HTREEITEM hiddenDuplicate = nullptr;
-    bool dupAtBoundary = false;
     HTREEITEM boundaryItem = nullptr;
     HTREEITEM belowQAItem = nullptr;
-    bool qaCleanupDone = false;
+    uint8_t pendingWork = 0;   // bitmask of PendingWork flags
     bool qaEverCleaned = false;
-    bool dupCollapsesDone = false;
-    bool homeGalleryCleanupDone = false;
-    bool needHotInsert = false;
-    bool needFullRebuild = false;
     bool ownsNscRef = false;
     HIMAGELIST savedStateImageList = nullptr;
 };
@@ -194,7 +241,8 @@ static TreeState* GetTree(HWND hWnd) {
 
 static bool IsNavPaneHost(HWND hTree)
 {
-    for (HWND h = GetAncestor(hTree, GA_ROOT); h; h = nullptr)
+    HWND h = GetAncestor(hTree, GA_ROOT);
+    if (h)
     {
         WCHAR cls[64];
         if (GetClassNameW(h, cls, ARRAYSIZE(cls)))
@@ -210,27 +258,45 @@ static bool IsNavPaneHost(HWND hTree)
 
 static bool IsOurSection(const TreeState& ts, HTREEITEM h)
 {
-    return h == ts.hThisPC || h == ts.hDesktop ||
-           (ts.hHome && h == ts.hHome) ||
-           (ts.hGallery && h == ts.hGallery);
+    for (int i = 0; i < NAV_COUNT; i++)
+        if (ts.hItems[i] && h == ts.hItems[i])
+            return true;
+    return false;
+}
+
+static bool IsInsertableItem(int id)
+{
+    return id == NAV_THISPC || id == NAV_DESKTOP;
+}
+
+static void GetPidlDisplayName(PIDLIST_ABSOLUTE pidl, WCHAR *buf, int len)
+{
+    IShellItem *psi = nullptr;
+    if (SUCCEEDED(SHCreateItemFromIDList(pidl, IID_IShellItem, (void **)&psi)) && psi)
+    {
+        LPWSTR name = nullptr;
+        if (SUCCEEDED(psi->GetDisplayName(SIGDN_NORMALDISPLAY, &name)) && name)
+        {
+            wcsncpy_s(buf, len, name, _TRUNCATE);
+            CoTaskMemFree(name);
+        }
+        psi->Release();
+    }
 }
 
 static void ResetTreeCleanup(TreeState& ts)
 {
     ts.hiddenDuplicate = nullptr;
-    ts.dupAtBoundary = false;
     ts.boundaryItem = nullptr;
     ts.belowQAItem = nullptr;
-    ts.qaCleanupDone = false;
+    ts.pendingWork = WORK_QA_CLEANUP | WORK_HG_CLEANUP | WORK_DUP_COLLAPSE;
     ts.qaEverCleaned = false;
-    ts.dupCollapsesDone = false;
-    ts.homeGalleryCleanupDone = false;
 }
 
-// 0=not ours, 1=This PC, 2=Desktop — set during AppendOneItem
+// -1=not ours, 0..3=NavItemId — set during AppendOneItem
 // so the TVM_INSERTITEM handler knows which item is being inserted
 // without comparing localized display text.
-static int g_insertingItem = 0;
+static int g_insertingItem = -1;
 
 // Temporary globals bridging AppendRoot_hook to TVM_INSERTITEM handler.
 // Copied into TreeState once the tree HWND is known.
@@ -263,29 +329,59 @@ static void DrainPendingRebuilds()
             PostMessage(hNext, WM_DEFERRED_REBUILD, 0, 0);
     }
 }
-static void RefreshNavPane(HWND hTree);
-static void HotEnableInsert(HWND hWnd);
-static void FullRebuildTree(HWND hTree);
+
+static TreeState* RunDeferredWork(HWND hWnd, TreeState* ts,
+                                  uint8_t flag, void(*op)(HWND),
+                                  bool checkGuard = false)
+{
+    if (!ts || !(ts->pendingWork & flag))
+        return ts;
+    if (checkGuard && g_deferredOpInProgress)
+        return ts;
+    g_deferredOpInProgress = true;
+    ts->pendingWork &= ~flag;
+    op(hWnd);
+    ts = GetTree(hWnd);
+    DrainPendingRebuilds();
+    return ts;
+}
+
+static bool g_inCustomAppend = false;
+
+struct InsertionScope {
+    ComRef<INameSpaceTreeControl> pNsc;
+    ComRef<IShellItemFilter> pFilter;
+    void *pNscRaw;
+
+    InsertionScope(TreeState& ts, HWND hTree)
+        : pNsc((INameSpaceTreeControl *)ts.pNscTree)
+        , pFilter(ts.pFilter)
+        , pNscRaw(ts.pNscTree)
+    {
+        g_pNscTree = ts.pNscTree;
+        g_lastEnumFlags = ts.enumFlags;
+        g_insertingForTree = hTree;
+        g_inCustomAppend = true;
+    }
+
+    ~InsertionScope() {
+        g_insertingForTree = nullptr;
+        g_inCustomAppend = false;
+    }
+};
 
 static bool ShouldRemoveInternalSep()
 {
-    return g_settings.showThisPCAtTop && g_settings.showDesktopAtTop;
+    return g_settings.items[NAV_THISPC].showAtTop && g_settings.items[NAV_DESKTOP].showAtTop;
 }
 
 // --- AppendRoot hook ---
 
-using AppendRoot_t = HRESULT (THISCALL *)(
-    void *pThis, IShellItem *psiRoot, unsigned long grfEnumFlags,
-    unsigned long grfRootStyle, IShellItemFilter *pFilter);
+using AppendRoot_t = HRESULT (THISCALL *)(void *pThis, IShellItem *psiRoot, unsigned long grfEnumFlags, unsigned long grfRootStyle, IShellItemFilter *pFilter);
 
 AppendRoot_t AppendRoot_orig;
 
-static bool g_inCustomAppend = false;
-
-static void AppendOneItem(
-    void *pThis, PIDLIST_ABSOLUTE pidl, bool expandable,
-    unsigned long grfEnumFlags, IShellItemFilter *pOrigFilter,
-    unsigned long rootStyle = 0)
+static void AppendOneItem(void *pThis, PIDLIST_ABSOLUTE pidl, bool expandable, unsigned long grfEnumFlags, IShellItemFilter *pOrigFilter, unsigned long rootStyle = 0)
 {
     if (!pidl)
         return;
@@ -294,10 +390,7 @@ static void AppendOneItem(
     if (FAILED(SHCreateItemFromIDList(pidl, IID_IShellItem, (void **)&pItem)))
         return;
 
-    AppendRoot_orig(pThis, pItem,
-        expandable ? grfEnumFlags : 0,
-        rootStyle,
-        pOrigFilter);
+    AppendRoot_orig(pThis, pItem, expandable ? grfEnumFlags : 0, rootStyle, pOrigFilter);
 
     pItem->Release();
 }
@@ -312,88 +405,89 @@ struct NavItem {
 
 static void BuildItemOrder(NavItem items[2])
 {
-    unsigned long thisPCStyle = g_settings.thisPCStartExpanded ? 0x2 : 0;
+    int first = g_settings.desktopAboveThisPC ? NAV_DESKTOP : NAV_THISPC;
+    int second = g_settings.desktopAboveThisPC ? NAV_THISPC : NAV_DESKTOP;
 
-    if (g_settings.desktopAboveThisPC)
-    {
-        items[0] = { g_pidlDesktop, g_settings.desktopExpandable,
-                     g_settings.showDesktopAtTop, 2, 0 };
-        items[1] = { g_pidlThisPC, g_settings.thisPCExpandable,
-                     g_settings.showThisPCAtTop, 1, thisPCStyle };
-    }
-    else
-    {
-        items[0] = { g_pidlThisPC, g_settings.thisPCExpandable,
-                     g_settings.showThisPCAtTop, 1, thisPCStyle };
-        items[1] = { g_pidlDesktop, g_settings.desktopExpandable,
-                     g_settings.showDesktopAtTop, 2, 0 };
-    }
+    auto fill = [&](NavItem& out, int id) {
+        out.pidl = g_navItems[id].pidl;
+        out.expandable = g_settings.items[id].expandable;
+        out.enabled = g_settings.items[id].showAtTop;
+        out.id = id;
+        out.style = g_settings.items[id].startExpanded ? 0x2 : 0UL;
+    };
+
+    fill(items[0], first);
+    fill(items[1], second);
 }
 
-static void InsertItems(void *pNsc, const NavItem items[2],
-                        unsigned long enumFlags, IShellItemFilter *filter)
+template<typename Pred>
+static int BuildMatchList(WCHAR out[][64], int maxOut, Pred&& pred)
+{
+    int count = 0;
+    for (int i = 0; i < NAV_COUNT && count < maxOut; i++)
+        if (g_navItems[i].label[0] && pred(i, g_settings.items[i]))
+        {
+            wcsncpy_s(out[count], 64, g_navItems[i].label, _TRUNCATE);
+            count++;
+        }
+    return count;
+}
+
+static void InsertItems(void *pNsc, const NavItem items[2], unsigned long enumFlags, IShellItemFilter *filter)
 {
     for (int i = 1; i >= 0; i--)
     {
         if (items[i].enabled)
         {
             g_insertingItem = items[i].id;
-            AppendOneItem(pNsc, items[i].pidl, items[i].expandable,
-                          enumFlags, filter, items[i].style);
-            g_insertingItem = 0;
+            AppendOneItem(pNsc, items[i].pidl, items[i].expandable, enumFlags, filter, items[i].style);
+            g_insertingItem = -1;
         }
     }
 }
 
-HRESULT THISCALL AppendRoot_hook(
-    void *pThis, IShellItem *psiRoot, unsigned long grfEnumFlags,
-    unsigned long grfRootStyle, IShellItemFilter *pFilter)
+HRESULT THISCALL AppendRoot_hook(void *pThis, IShellItem *psiRoot, unsigned long grfEnumFlags, unsigned long grfRootStyle, IShellItemFilter *pFilter)
 {
     // Intercept Home/Gallery root items by PIDL comparison.
     // Must happen BEFORE g_inCustomAppend check: during FullRebuildTree,
     // AppendRoot_orig for the hidden root can trigger Explorer to add
     // Home/Gallery internally while g_inCustomAppend is true. Without
-    // this, ts.hHome/ts.hGallery would never be cached.
-    if (g_pidlHome || g_pidlGallery)
+    // this, ts.hItems[NAV_HOME]/ts.hItems[NAV_GALLERY] would never be cached.
     {
         PIDLIST_ABSOLUTE pidlRoot = nullptr;
         if (SUCCEEDED(SHGetIDListFromObject(psiRoot, &pidlRoot)))
         {
-            bool isHome = g_pidlHome && ILIsEqual(pidlRoot, g_pidlHome);
-            bool isGallery = g_pidlGallery && ILIsEqual(pidlRoot, g_pidlGallery);
+            int matchId = -1;
+            for (int i = NAV_HOME; i < NAV_COUNT; i++)
+            {
+                if (g_navItems[i].pidl && ILIsEqual(pidlRoot, g_navItems[i].pidl))
+                { matchId = i; break; }
+            }
             CoTaskMemFree(pidlRoot);
 
-            if (isHome || isGallery)
+            if (matchId >= 0)
             {
-                bool hide = isHome ? g_settings.hideHome : g_settings.hideGallery;
+                bool hide = g_settings.items[matchId].hide;
                 if (hide)
                 {
-                    LPWSTR supName = nullptr;
-                    psiRoot->GetDisplayName(SIGDN_NORMALDISPLAY, &supName);
-                    Wh_Log(L"[HOOK] Suppressing '%s' root",
-                           supName ? supName : L"?");
-                    if (supName) CoTaskMemFree(supName);
+                    Wh_Log(L"[HOOK] Suppressing '%s' root", g_navItems[matchId].label);
                     return S_OK;
                 }
-                g_insertingItem = isHome ? 3 : 4;
-                HRESULT hr = AppendRoot_orig(pThis, psiRoot, grfEnumFlags,
-                                             grfRootStyle, pFilter);
-                g_insertingItem = 0;
+                g_insertingItem = matchId;
+                HRESULT hr = AppendRoot_orig(pThis, psiRoot, grfEnumFlags, grfRootStyle, pFilter);
+                g_insertingItem = -1;
                 return hr;
             }
         }
     }
 
     if (g_inCustomAppend)
-        return AppendRoot_orig(pThis, psiRoot, grfEnumFlags,
-                               grfRootStyle, pFilter);
+        return AppendRoot_orig(pThis, psiRoot, grfEnumFlags, grfRootStyle, pFilter);
 
     bool isHiddenRoot = (grfRootStyle & 0x1) != 0;
-    bool wantItems = isHiddenRoot &&
-        (g_settings.showThisPCAtTop || g_settings.showDesktopAtTop);
+    bool wantItems = isHiddenRoot && g_settings.hasItemsAtTop;
 
-    HRESULT hr = AppendRoot_orig(pThis, psiRoot, grfEnumFlags,
-                                 grfRootStyle, pFilter);
+    HRESULT hr = AppendRoot_orig(pThis, psiRoot, grfEnumFlags, grfRootStyle, pFilter);
 
     if (wantItems)
     {
@@ -491,22 +585,31 @@ static thread_local bool g_inTreePaint = false;
 
 static bool IsDepth1Item(HWND hTree, HTREEITEM h)
 {
-    HTREEITEM parent = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                                TVGN_PARENT, (LPARAM)h);
+    HTREEITEM parent = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_PARENT, (LPARAM)h);
     if (!parent)
         return false;
-    HTREEITEM gp = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                            TVGN_PARENT, (LPARAM)parent);
+    HTREEITEM gp = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_PARENT, (LPARAM)parent);
     return (gp == nullptr);
 }
 
 static HTREEITEM GetFirstDepth1Child(HWND hTree)
 {
-    HTREEITEM hRoot = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                              TVGN_ROOT, 0);
-    return hRoot ? (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                            TVGN_CHILD, (LPARAM)hRoot)
-                 : nullptr;
+    HTREEITEM hRoot = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_ROOT, 0);
+    return hRoot ? (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_CHILD, (LPARAM)hRoot) : nullptr;
+}
+
+template<typename F>
+static void ForEachDepth1Item(HWND hTree, F&& visitor)
+{
+    HTREEITEM h = GetFirstDepth1Child(hTree);
+    while (h)
+    {
+        HTREEITEM hNext = (HTREEITEM)SendMessageW(
+            hTree, TVM_GETNEXTITEM, TVGN_NEXT, (LPARAM)h);
+        if (!visitor(h))
+            break;
+        h = hNext;
+    }
 }
 
 static bool CollapseItemIntegral(HWND hTree, HTREEITEM h)
@@ -524,11 +627,19 @@ static bool CollapseItemIntegral(HWND hTree, HTREEITEM h)
     return false;
 }
 
+static void SetItemIntegral(HWND hTree, HTREEITEM h, int value)
+{
+    TVITEMEXW tvi = {};
+    tvi.mask = TVIF_HANDLE | TVIF_INTEGRAL;
+    tvi.hItem = h;
+    tvi.iIntegral = value;
+    SendMessageW(hTree, TVM_SETITEMW, 0, (LPARAM)&tvi);
+}
+
 static int GetBaseItemHeight(HWND hTree)
 {
     int baseHeight = 0;
-    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                          TVGN_FIRSTVISIBLE, 0);
+    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_FIRSTVISIBLE, 0);
     while (h)
     {
         RECT rc = {};
@@ -539,10 +650,345 @@ static int GetBaseItemHeight(HWND hTree)
             if (ih > 0 && (baseHeight == 0 || ih < baseHeight))
                 baseHeight = ih;
         }
-        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                    TVGN_NEXTVISIBLE, (LPARAM)h);
+        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_NEXTVISIBLE, (LPARAM)h);
     }
     return baseHeight;
+}
+
+static void GetItemText(HWND hTree, HTREEITEM h, WCHAR *buf, int len)
+{
+    TVITEMEXW tvi = {};
+    tvi.mask = TVIF_HANDLE | TVIF_TEXT;
+    tvi.hItem = h;
+    tvi.pszText = buf;
+    tvi.cchTextMax = len;
+    SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
+}
+
+static void CollapseMatchingItems(HWND hTree, const TreeState *ts,
+                                  const WCHAR names[][64], int count)
+{
+    ForEachDepth1Item(hTree, [&](HTREEITEM h) -> bool {
+        if (!ts || !IsOurSection(*ts, h))
+        {
+            WCHAR text[64] = {};
+            TVITEMEXW tvi = {};
+            tvi.mask = TVIF_HANDLE | TVIF_TEXT | TVIF_STATE;
+            tvi.stateMask = TVIS_EXPANDED;
+            tvi.hItem = h;
+            tvi.pszText = text;
+            tvi.cchTextMax = 64;
+            SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
+            if ((tvi.state & TVIS_EXPANDED) && text[0])
+            {
+                for (int j = 0; j < count; j++)
+                {
+                    if (wcscmp(text, names[j]) == 0)
+                    {
+                        SendMessageW(hTree, TVM_EXPAND, TVE_COLLAPSE, (LPARAM)h);
+                        break;
+                    }
+                }
+            }
+        }
+        return true;
+    });
+}
+
+static void RefreshNavPane(HWND hTree)
+{
+    TreeState* ts = GetTree(hTree);
+    if (!ts || !hTree || !IsWindow(hTree) || !ts->pNscTree)
+        return;
+
+    for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
+    {
+        if (ts->hItems[i])
+        {
+            SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)ts->hItems[i]);
+            ts->hItems[i] = nullptr;
+        }
+    }
+
+    // Clear managed items — CleanupQuickAccessDuplicates will
+    // re-evaluate on the next paint.
+    ResetTreeCleanup(*ts);
+
+    {
+        InsertionScope scope(*ts, hTree);
+        NavItem items[2];
+        BuildItemOrder(items);
+        g_deferredOpInProgress = true;
+        InsertItems(scope.pNscRaw, items, ts->enumFlags, scope.pFilter.get());
+    }
+    DrainPendingRebuilds();
+
+    RedrawWindow(hTree, nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+}
+
+static void HotEnableInsert(HWND hWnd)
+{
+    TreeState* ts = GetTree(hWnd);
+    if (!ts || !ts->pNscTree || !IsWindow(hWnd))
+        return;
+
+    HTREEITEM hFirstChild = GetFirstDepth1Child(hWnd);
+    if (!hFirstChild)
+    {
+        ts->pendingWork |= WORK_HOT_INSERT;
+        return;
+    }
+
+    ts->hItems[NAV_THISPC] = nullptr;
+    ts->hItems[NAV_DESKTOP] = nullptr;
+    // Don't clear inherited items (Home/Gallery): they may have been
+    // cached during FullRebuildTree's AppendRoot_orig and are still valid.
+    ResetTreeCleanup(*ts);
+    ResetSepColor();
+
+    {
+        InsertionScope scope(*ts, hWnd);
+        NavItem items[2];
+        BuildItemOrder(items);
+        InsertItems(scope.pNscRaw, items, ts->enumFlags, scope.pFilter.get());
+    }
+
+    ts = GetTree(hWnd);
+    Wh_Log(L"[HOTINSERT] Items inserted, ThisPC=%p Desktop=%p Home=%p Gallery=%p",
+           ts ? ts->hItems[NAV_THISPC] : nullptr, ts ? ts->hItems[NAV_DESKTOP] : nullptr,
+           ts ? ts->hItems[NAV_HOME] : nullptr, ts ? ts->hItems[NAV_GALLERY] : nullptr);
+
+    // Invalidate for dedup and separator setup on the next paint
+    // (not RDW_UPDATENOW since we're already inside WM_PAINT)
+    InvalidateRect(hWnd, nullptr, TRUE);
+}
+
+static LRESULT CALLBACK TreeInteractionProc(
+    HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
+    UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
+{
+    TreeState* ts = GetTree(hWnd);
+    HTREEITEM hiddenDup = ts ? ts->hiddenDuplicate : nullptr;
+
+    if (hiddenDup &&
+        (uMsg == WM_RBUTTONDOWN || uMsg == WM_RBUTTONUP ||
+         uMsg == WM_MOUSEMOVE))
+    {
+        POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+        TVHITTESTINFO ht = {};
+        ht.pt = pt;
+        HTREEITEM hHit = (HTREEITEM)SendMessageW(
+            hWnd, TVM_HITTEST, 0, (LPARAM)&ht);
+        if (hHit == hiddenDup)
+            return 0;
+    }
+
+    if (uMsg == WM_NCDESTROY)
+        RemoveWindowSubclass(hWnd, TreeInteractionProc, uIdSubclass);
+
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+static void RestoreTree(HWND hTree)
+{
+    TreeState* ts = GetTree(hTree);
+    if (!ts || !IsWindow(hTree) || !ts->pNscTree)
+        return;
+
+    ComRef<INameSpaceTreeControl> pNsc((INameSpaceTreeControl *)ts->pNscTree);
+    void *pNscRaw = ts->pNscTree;
+    unsigned long enumFlags = ts->enumFlags;
+    ComRef<IShellItemFilter> pFilter(ts->pFilter);
+    HIMAGELIST savedImgList = ts->savedStateImageList;
+    bool ownsRef = ts->ownsNscRef;
+
+    // Remove our roots
+    RootShellItems roots;
+    if (!roots.Create()) return;
+    roots.RemoveInsertableRoots(pNsc.get());
+
+    // Re-add hidden root with current (zeroed) settings — hook passes through
+    if (roots.items[NAV_DESKTOP] && pNscRaw)
+    {
+        g_inCustomAppend = true;
+        AppendRoot_orig(pNscRaw, roots.items[NAV_DESKTOP].get(), enumFlags, 0x1, pFilter.get());
+        g_inCustomAppend = false;
+
+        // Collapse expanded items matching our items' names
+        WCHAR collapseNames[NAV_COUNT][64] = {};
+        int collapseCount = BuildMatchList(collapseNames, NAV_COUNT,
+            [](int id, const NavItemSettings&) {
+                return IsInsertableItem(id) && g_navItems[id].label[0];
+            });
+        if (collapseCount > 0)
+            CollapseMatchingItems(hTree, nullptr, collapseNames, collapseCount);
+    }
+
+    RemoveWindowSubclass(hTree, TreeInteractionProc, 0xAF01);
+
+    // Restore pin icons
+    if (savedImgList)
+    {
+        SendMessageW(hTree, TVM_SETIMAGELIST, TVSIL_STATE, (LPARAM)savedImgList);
+        Wh_Log(L"[DISABLE] Restored state image list %p for tree=%p", savedImgList, hTree);
+    }
+
+    // Re-fetch ts: AppendRoot_orig pumps messages
+    ts = GetTree(hTree);
+    if (ts)
+    {
+        if (ownsRef)
+            ts->ownsNscRef = false;
+        ts->pNscTree = nullptr;
+        ts->pFilter = nullptr;
+    }
+
+    // Release TreeState's ownership ref (separate from our ComRef AddRef)
+    if (ownsRef)
+        pNsc.p->Release();
+
+    Wh_Log(L"[DISABLE] Cleaned up tree=%p", hTree);
+    // ComRef destructors release our local AddRefs (pFilter, pNsc, pDesktop, pThisPC)
+}
+
+static void FullRebuildTree(HWND hTree)
+{
+    TreeState* ts = GetTree(hTree);
+    if (!ts || !ts->pNscTree || !IsWindow(hTree))
+        return;
+
+    ComRef<INameSpaceTreeControl> pNsc((INameSpaceTreeControl *)ts->pNscTree);
+    void *pNscRaw = ts->pNscTree;
+    unsigned long enumFlags = ts->enumFlags;
+
+    RootShellItems roots;
+    if (!roots.Create()) return;
+    roots.RemoveInsertableRoots(pNsc.get());
+
+    if (roots.items[NAV_HOME] && g_settings.items[NAV_HOME].hide)
+        pNsc->RemoveRoot(roots.items[NAV_HOME].get());
+    if (roots.items[NAV_GALLERY] && g_settings.items[NAV_GALLERY].hide)
+        pNsc->RemoveRoot(roots.items[NAV_GALLERY].get());
+
+    if (roots.items[NAV_DESKTOP])
+    {
+        // Clear ALL item handles: RemoveRoot(pDesktop) destroys the
+        // hidden root and all its children (Home, Gallery, QA items).
+        // All old handles are now invalid.
+        ts = GetTree(hTree);
+        if (ts)
+        {
+            for (int i = 0; i < NAV_COUNT; i++)
+                ts->hItems[i] = nullptr;
+            ResetTreeCleanup(*ts);
+        }
+
+        g_pNscTree = pNscRaw;
+        g_lastEnumFlags = enumFlags;
+
+        g_inCustomAppend = true;
+        AppendRoot_orig(pNscRaw, roots.items[NAV_DESKTOP].get(), enumFlags, 0x1, nullptr);
+        g_inCustomAppend = false;
+
+        // Re-fetch ts: AppendRoot_orig pumps messages, which can
+        // trigger TVM_INSERTITEM and rehash g_trees.
+        ts = GetTree(hTree);
+        if (ts)
+        {
+            ts->pendingWork |= WORK_HOT_INSERT;
+        }
+        ResetSepColor();
+
+        InvalidateRect(hTree, nullptr, TRUE);
+        Wh_Log(L"[REBUILD] Deferred insertion for tree=%p hHome=%p hGallery=%p",
+               hTree, ts ? ts->hItems[NAV_HOME] : nullptr, ts ? ts->hItems[NAV_GALLERY] : nullptr);
+    }
+}
+
+struct SectionLayout {
+    HTREEITEM boundary;       // first non-section item after our items
+    HTREEITEM belowQA;        // first tall non-section item after boundary
+};
+
+static SectionLayout FindSectionLayout(HWND hTree, TreeState& ts)
+{
+    SectionLayout layout = {};
+
+    // Pre-resolve display names for inherited items with null handles
+    // so we can identify them by text during the walk.
+    WCHAR inheritedNames[NAV_COUNT][64] = {};
+    bool inheritedHidden[NAV_COUNT] = {};
+    for (int i = NAV_HOME; i < NAV_COUNT; i++)
+    {
+        inheritedHidden[i] = g_settings.items[i].hide;
+        if (!ts.hItems[i])
+            wcsncpy_s(inheritedNames[i], 64, g_navItems[i].label, _TRUNCATE);
+    }
+
+    int baseHeight = GetBaseItemHeight(hTree);
+    int tallThreshold = baseHeight + baseHeight / 2;
+
+    bool passedOurs = false;
+    ForEachDepth1Item(hTree, [&](HTREEITEM h) -> bool {
+        bool isSection = IsOurSection(ts, h);
+
+        // Text fallback for inherited items with null handles
+        if (!isSection)
+        {
+            WCHAR text[64] = {};
+            bool textFetched = false;
+            for (int i = NAV_HOME; i < NAV_COUNT; i++)
+            {
+                if (inheritedNames[i][0])
+                {
+                    if (!textFetched)
+                    {
+                        GetItemText(hTree, h, text, ARRAYSIZE(text));
+                        textFetched = true;
+                    }
+                    if (text[0] && wcscmp(text, inheritedNames[i]) == 0)
+                    {
+                        if (!inheritedHidden[i])
+                        {
+                            ts.hItems[i] = h;
+                            Wh_Log(L"[CACHE] %s item=%p tree=%p (walk)", g_navItems[i].label, h, hTree);
+                        }
+                        isSection = true;
+                        inheritedNames[i][0] = L'\0';
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (isSection)
+        {
+            passedOurs = true;
+        }
+        else if (passedOurs && h != ts.hiddenDuplicate)
+        {
+            if (!layout.boundary)
+            {
+                layout.boundary = h;
+            }
+            else if (baseHeight > 0)
+            {
+                RECT rc = {};
+                *(HTREEITEM*)&rc = h;
+                if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rc))
+                {
+                    int ih = rc.bottom - rc.top;
+                    if (ih >= tallThreshold)
+                    {
+                        layout.belowQA = h;
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    });
+    return layout;
 }
 
 static void DrawSeparatorLine(HDC hdc, HWND hTree, int sepY)
@@ -581,8 +1027,7 @@ static COLORREF SampleSeparatorColor(HWND hTree, HDC hdc)
     int tallThreshold = baseHeight + baseHeight / 2;
 
     // Find the first tall depth-1 item — its separator is at rc.top + baseHeight/2
-    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                          TVGN_FIRSTVISIBLE, 0);
+    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_FIRSTVISIBLE, 0);
     while (h)
     {
         if (IsDepth1Item(hTree, h))
@@ -598,8 +1043,7 @@ static COLORREF SampleSeparatorColor(HWND hTree, HDC hdc)
                     int sampleX = client.right / 2;
 
                     // Sample background color nearby for validation
-                    COLORREF bg = GetPixel(hdc, sampleX,
-                                           rc.top + baseHeight + baseHeight / 4);
+                    COLORREF bg = GetPixel(hdc, sampleX, rc.top + baseHeight + baseHeight / 4);
 
                     auto isPlausible = [&](COLORREF c) -> bool {
                         if (c == CLR_INVALID || c == 0x000000)
@@ -625,8 +1069,7 @@ static COLORREF SampleSeparatorColor(HWND hTree, HDC hdc)
                 }
             }
         }
-        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                    TVGN_NEXTVISIBLE, (LPARAM)h);
+        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_NEXTVISIBLE, (LPARAM)h);
     }
 
     return CLR_INVALID;
@@ -651,20 +1094,18 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
 
     int tallThreshold = baseHeight + baseHeight / 2;
 
-    bool passedOurSection = false;
     bool foundBoundary = false;
     bool foundBelowQA = false;
     int sepCount = 0;
 
     // Diagnostic: build a walk summary for logging
     // Each depth-1 item gets a tag: O=ours, H=home, G=gallery,
-    // D=dup(at boundary), d=dup(not at boundary), B=boundary(tall),
-    // b=boundary(short), Q=belowQA, S=sep-drawn, .=other
+    // B=boundary(tall), b=boundary(short), Q=belowQA(skipped),
+    // S=sep-drawn, .=other
     WCHAR walkLog[64] = {};
     int walkIdx = 0;
 
-    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                          TVGN_FIRSTVISIBLE, 0);
+    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_FIRSTVISIBLE, 0);
     while (h)
     {
         if (IsDepth1Item(hTree, h))
@@ -677,18 +1118,18 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
 
             if (IsOurSection(ts, h))
             {
-                passedOurSection = true;
                 if (g_logSepDraw && walkIdx < 60)
                 {
-                    if (h == ts.hThisPC || h == ts.hDesktop) walkLog[walkIdx++] = L'O';
-                    else if (ts.hHome && h == ts.hHome) walkLog[walkIdx++] = L'H';
-                    else walkLog[walkIdx++] = L'G';
+                    WCHAR tag = L'O';
+                    if (ts.hItems[NAV_HOME] && h == ts.hItems[NAV_HOME]) tag = L'H';
+                    else if (ts.hItems[NAV_GALLERY] && h == ts.hItems[NAV_GALLERY]) tag = L'G';
+                    walkLog[walkIdx++] = tag;
                 }
             }
-            else if (h == ts.hiddenDuplicate)
+            else if (ts.hiddenDuplicate && h == ts.hiddenDuplicate)
             {
                 if (g_logSepDraw && walkIdx < 60)
-                    walkLog[walkIdx++] = ts.dupAtBoundary ? L'D' : L'd';
+                    walkLog[walkIdx++] = L'D';
             }
             else
             {
@@ -697,31 +1138,26 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
                 int sepY = 0;
                 WCHAR tag = L'.';
 
-                if (passedOurSection && !foundBoundary)
+                if (ts.boundaryItem && h == ts.boundaryItem)
                 {
                     foundBoundary = true;
                     tag = isTall ? L'B' : L'b';
-                    if (!g_settings.removeSepBelowNav &&
-                        !ts.dupAtBoundary)
+                    if (!g_settings.removeSepBelowNav && !ts.hiddenDuplicate)
                     {
                         drawSep = true;
-                        sepY = isTall ? rc.top + baseHeight / 2
-                                      : rc.top;
+                        sepY = isTall ? rc.top + baseHeight / 2 : rc.top;
                     }
                 }
-                else if (foundBoundary && isTall)
+                else if (ts.belowQAItem && h == ts.belowQAItem)
                 {
-                    if (g_settings.removeSepBelowQA && !foundBelowQA)
-                    {
-                        foundBelowQA = true;
-                        tag = L'Q';
-                    }
-                    else
-                    {
-                        drawSep = true;
-                        sepY = rc.top + baseHeight / 2;
-                        tag = L'S';
-                    }
+                    foundBelowQA = true;
+                    tag = L'Q';
+                }
+                else if (foundBoundary && isTall && !foundBelowQA)
+                {
+                    drawSep = true;
+                    sepY = rc.top + baseHeight / 2;
+                    tag = L'S';
                 }
 
                 if (drawSep)
@@ -735,14 +1171,12 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
             }
         }
 
-        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                    TVGN_NEXTVISIBLE, (LPARAM)h);
+        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_NEXTVISIBLE, (LPARAM)h);
     }
     walkLog[walkIdx] = 0;
     if (g_logSepDraw)
     {
-        Wh_Log(L"[SEP-DRAW] tree=%p walk=[%s] drew=%d hHome=%p hGallery=%p hDup=%p",
-               hTree, walkLog, sepCount, ts.hHome, ts.hGallery, ts.hiddenDuplicate);
+        Wh_Log(L"[SEP-DRAW] tree=%p walk=[%s] drew=%d hHome=%p hGallery=%p", hTree, walkLog, sepCount, ts.hItems[NAV_HOME], ts.hItems[NAV_GALLERY]);
     }
 }
 
@@ -750,9 +1184,7 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
 // Returning CDRF_NOTIFYPOSTPAINT at CDDS_PREPAINT without calling
 // DefSubclassProc hides ALL separator lines
 // At CDDS_POSTPAINT we redraw the separators we want to keep.
-static LRESULT CALLBACK SepParentSubclassProc(
-    HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
-    DWORD_PTR dwRefData)
+static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData)
 {
     HWND hTree = (HWND)dwRefData;
 
@@ -765,19 +1197,10 @@ static LRESULT CALLBACK SepParentSubclassProc(
             {
                 LPNMTVCUSTOMDRAW cd = (LPNMTVCUSTOMDRAW)lParam;
                 DWORD stage = cd->nmcd.dwDrawStage;
-                bool hasItemsAtTop = g_settings.showThisPCAtTop ||
-                                     g_settings.showDesktopAtTop;
                 TreeState* ts = GetTree(hTree);
-                bool hasDupHide = (ts && ts->hiddenDuplicate != nullptr);
-
-                if (stage == CDDS_PREPAINT &&
-                    (hasItemsAtTop || hasDupHide))
+                if (stage == CDDS_PREPAINT && g_settings.hasItemsAtTop)
                 {
-                    // Skipping DefSubclassProc suppresses ALL native separator
-                    // lines but also prevents per-item custom draw
-                    // (CDDS_ITEMPREPAINT) for other subclasses on this tree.
-                    if (hasItemsAtTop && g_sepColor != CLR_INVALID &&
-                        !g_sepColorPendingVerify)
+                    if (g_sepColor != CLR_INVALID && !g_sepColorPendingVerify)
                         return CDRF_NOTIFYPOSTPAINT;
                     LRESULT r = DefSubclassProc(hWnd, uMsg, wParam, lParam);
                     return r | CDRF_NOTIFYPOSTPAINT;
@@ -790,46 +1213,36 @@ static LRESULT CALLBACK SepParentSubclassProc(
                     // through so we can re-sample. If the color
                     // changed, update and repaint; if same, just
                     // repaint to re-suppress native separators.
-                    if (g_sepColorPendingVerify &&
-                        g_sepColor != CLR_INVALID &&
-                        (hasItemsAtTop || hasDupHide))
+                    if (g_sepColorPendingVerify && g_sepColor != CLR_INVALID && g_settings.hasItemsAtTop)
                     {
                         g_sepColorPendingVerify = false;
                         COLORREF c = SampleSeparatorColor(hTree, cd->nmcd.hdc);
                         if (c != CLR_INVALID && c != g_sepColor)
                         {
-                            Wh_Log(L"[SEP] color changed 0x%06X -> 0x%06X tree=%p",
-                                   g_sepColor, c, hTree);
+                            Wh_Log(L"[SEP] color changed 0x%06X -> 0x%06X tree=%p", g_sepColor, c, hTree);
                             g_sepColor = c;
                             g_logSepDraw = true;
                         }
                         InvalidateRect(hTree, NULL, TRUE);
                     }
 
-                    if (g_sepColor == CLR_INVALID &&
-                        (hasItemsAtTop || hasDupHide))
+                    if (g_sepColor == CLR_INVALID && g_settings.hasItemsAtTop)
                     {
                         COLORREF c = SampleSeparatorColor(hTree, cd->nmcd.hdc);
                         if (c != CLR_INVALID)
                         {
                             g_sepColor = c;
                             g_logSepDraw = true;
-                            Wh_Log(L"[SEP] color=0x%06X tree=%p",
-                                   c, hTree);
+                            Wh_Log(L"[SEP] color=0x%06X tree=%p", c, hTree);
                             InvalidateRect(hTree, NULL, TRUE);
                         }
                     }
 
-                    if (hasItemsAtTop &&
-                        g_sepColor != CLR_INVALID && ts)
+                    if (g_settings.hasItemsAtTop && g_sepColor != CLR_INVALID && ts)
                         RedrawOtherSeparators(hTree, cd->nmcd.hdc, *ts);
 
-                    // Re-fetch ts: SendMessageW calls in RedrawOtherSeparators
-                    // could have modified g_trees
                     ts = GetTree(hTree);
-                    hasDupHide = (ts && ts->hiddenDuplicate != nullptr);
-
-                    if (hasDupHide)
+                    if (ts && ts->hiddenDuplicate)
                     {
                         RECT rcHide = {};
                         *(HTREEITEM*)&rcHide = ts->hiddenDuplicate;
@@ -838,48 +1251,23 @@ static LRESULT CALLBACK SepParentSubclassProc(
                             HDC hdc = cd->nmcd.hdc;
                             RECT client;
                             GetClientRect(hTree, &client);
-                            COLORREF bg = GetPixel(hdc, client.right / 2, rcHide.top + 2);
-                            if (bg == CLR_INVALID || bg == 0x000000)
-                                bg = GetPixel(hdc, client.right - 2, rcHide.top + 2);
-                            if (bg == CLR_INVALID || bg == 0x000000)
-                                bg = GetPixel(hdc, 1, rcHide.top + 2);
+                            COLORREF bg = GetPixel(hdc, 1, rcHide.top + 2);
                             if (bg == CLR_INVALID)
-                                bg = (COLORREF)SendMessageW(hTree, TVM_GETBKCOLOR, 0, 0);
-                            if (bg == CLR_INVALID || bg == (COLORREF)-1)
                                 bg = GetSysColor(COLOR_WINDOW);
-                            if (bg != CLR_INVALID)
+                            HBRUSH bgBrush = CreateSolidBrush(bg);
+                            if (bgBrush)
                             {
-                                HBRUSH bgBrush = CreateSolidBrush(bg);
-                                if (bgBrush)
-                                {
-                                    FillRect(hdc, &rcHide, bgBrush);
-                                    DeleteObject(bgBrush);
-                                }
+                                FillRect(hdc, &rcHide, bgBrush);
+                                DeleteObject(bgBrush);
                             }
-
-                            // Only draw separator line through the dup
-                            // if it's at the boundary (right after our
-                            // section). Otherwise just paint over.
                             if (g_sepColor != CLR_INVALID)
                             {
-                                HTREEITEM hPrev = (HTREEITEM)SendMessageW(
-                                    hTree, TVM_GETNEXTITEM, TVGN_PREVIOUS,
-                                    (LPARAM)ts->hiddenDuplicate);
-                                bool atBoundary = hPrev && IsOurSection(*ts, hPrev);
-
-                                if (atBoundary)
+                                HTREEITEM hPrev = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_PREVIOUS, (LPARAM)ts->hiddenDuplicate);
+                                if (hPrev && IsOurSection(*ts, hPrev))
                                 {
                                     int h = rcHide.bottom - rcHide.top;
-                                    int sepY = rcHide.top + h / 2;
-                                    DrawSeparatorLine(hdc, hTree, sepY);
+                                    DrawSeparatorLine(hdc, hTree, rcHide.top + h / 2);
                                 }
-                            }
-                            if (g_logSepDraw)
-                            {
-                                Wh_Log(L"[SEP-HIDE] dup=%p bg=0x%06X sepColor=0x%06X y=%d-%d",
-                                       ts->hiddenDuplicate, bg,
-                                       g_sepColor != CLR_INVALID ? g_sepColor : 0,
-                                       rcHide.top, rcHide.bottom);
                             }
                         }
                     }
@@ -897,31 +1285,11 @@ static LRESULT CALLBACK SepParentSubclassProc(
                 g_logSepDraw = true;
                 TreeState* tsExp = GetTree(hTree);
                 if (tsExp)
-                    tsExp->dupCollapsesDone = false;
+                    tsExp->pendingWork |= WORK_DUP_COLLAPSE;
                 InvalidateRect(hTree, NULL, TRUE);
                 return r;
             }
 
-            if (hdr->code == (UINT)TVN_SELCHANGEDW ||
-                hdr->code == (UINT)TVN_SELCHANGEDA)
-            {
-                LPNMTREEVIEWW nm = (LPNMTREEVIEWW)lParam;
-                TreeState* tsSel = GetTree(hTree);
-                if (tsSel && tsSel->hiddenDuplicate &&
-                    nm->itemNew.hItem == tsSel->hiddenDuplicate)
-                {
-                    HTREEITEM hAlt = (HTREEITEM)SendMessageW(
-                        hTree, TVM_GETNEXTITEM, TVGN_NEXTVISIBLE,
-                        (LPARAM)tsSel->hiddenDuplicate);
-                    if (!hAlt)
-                        hAlt = (HTREEITEM)SendMessageW(
-                            hTree, TVM_GETNEXTITEM, TVGN_PREVIOUSVISIBLE,
-                            (LPARAM)tsSel->hiddenDuplicate);
-                    if (hAlt)
-                        SendMessageW(hTree, TVM_SELECTITEM,
-                                     TVGN_CARET, (LPARAM)hAlt);
-                }
-            }
         }
     }
 
@@ -943,8 +1311,7 @@ static void EnsureParentSubclass(HWND hTree)
         return;
     if (g_subclassedParents.count(parent))
         return;
-    bool ok = WindhawkUtils::SetWindowSubclassFromAnyThread(
-        parent, SepParentSubclassProc, (DWORD_PTR)hTree);
+    bool ok = WindhawkUtils::SetWindowSubclassFromAnyThread(parent, SepParentSubclassProc, (DWORD_PTR)hTree);
     Wh_Log(L"[SEP-PARENT] subclass on parent=%p for tree=%p ok=%d", parent, hTree, ok);
     if (ok)
         g_subclassedParents.insert(parent);
@@ -962,143 +1329,49 @@ HRESULT THISCALL SetStateImageList_hook(void *pThis, HIMAGELIST himl)
     return SetStateImageList_orig(pThis, himl);
 }
 
-static void GetPidlDisplayName(PIDLIST_ABSOLUTE pidl, WCHAR *buf, int len)
-{
-    IShellItem *psi = nullptr;
-    if (SUCCEEDED(SHCreateItemFromIDList(pidl, IID_IShellItem,
-                                         (void **)&psi)) && psi)
-    {
-        LPWSTR name = nullptr;
-        if (SUCCEEDED(psi->GetDisplayName(SIGDN_NORMALDISPLAY, &name))
-            && name)
-        {
-            wcsncpy_s(buf, len, name, _TRUNCATE);
-            CoTaskMemFree(name);
-        }
-        psi->Release();
-    }
-}
-
-static void GetItemText(HWND hTree, HTREEITEM h, WCHAR *buf, int len)
-{
-    TVITEMEXW tvi = {};
-    tvi.mask = TVIF_HANDLE | TVIF_TEXT;
-    tvi.hItem = h;
-    tvi.pszText = buf;
-    tvi.cchTextMax = len;
-    SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
-}
-
-static void ResolveHomeGalleryNames(WCHAR *homeName, int homeLen,
-                                     WCHAR *galleryName, int galleryLen)
-{
-    if (g_pidlHome) GetPidlDisplayName(g_pidlHome, homeName, homeLen);
-    if (g_pidlGallery) GetPidlDisplayName(g_pidlGallery, galleryName, galleryLen);
-}
-
 // --- Quick Access item hiding ---
 // Walk depth-1 children of the hidden root and delete items matching
-// our items' display text. Handles two kinds of duplicates:
-// - Childless QA pins: kept as hiddenDuplicate (separator mechanism)
-//   when removeSepBelowNav is off, otherwise deleted.
-// - Native sections with children (e.g. the native "This PC" below
-//   Quick Access): always deleted — our top-level items replace them.
+// our items' display text. Both childless QA pins and native sections
+// with children are deleted — our top-level items replace them.
 //
 // Returns true when all expected childless duplicates were found.
 // Returns false if some are still missing (async population race).
 static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
 {
-    if (!ts.hThisPC && !ts.hDesktop)
+    if (!ts.hItems[NAV_THISPC] && !ts.hItems[NAV_DESKTOP])
         return true;
 
-    WCHAR thisPCText[64] = {};
-    WCHAR desktopText[64] = {};
-    int expectedCount = 0;
-
-    if (g_settings.showThisPCAtTop &&
-        g_settings.hideThisPCFromQuickAccess && ts.hThisPC)
-    {
-        GetItemText(hTree, ts.hThisPC, thisPCText, ARRAYSIZE(thisPCText));
-        if (thisPCText[0]) expectedCount++;
-    }
-
-    if (g_settings.showDesktopAtTop &&
-        g_settings.hideDesktopFromQuickAccess && ts.hDesktop)
-    {
-        GetItemText(hTree, ts.hDesktop, desktopText, ARRAYSIZE(desktopText));
-        if (desktopText[0]) expectedCount++;
-    }
+    WCHAR matchNames[2][64] = {};
+    int expectedCount = BuildMatchList(matchNames, 2,
+        [&](int id, const NavItemSettings& s) {
+            return IsInsertableItem(id) && s.showAtTop && s.hideFromQA &&
+                   ts.hItems[id] != nullptr;
+        });
 
     if (!expectedCount)
         return true;
 
-    HTREEITEM h = GetFirstDepth1Child(hTree);
-    if (!h) return false;
+    if (!GetFirstDepth1Child(hTree)) return false;
 
     HTREEITEM toDeleteChildless[8] = {};
     HTREEITEM toDeleteSections[4] = {};
     int childlessCount = 0;
     int sectionCount = 0;
 
-    // Find the boundary position: first non-our/non-HG depth-1 child
-    // after our section. A dup can only be kept as hiddenDuplicate if
-    // it occupies this exact position.
-    //
-    // ts.hHome/hGallery may be null at this point (COM vtable bypass),
-    // so resolve Home/Gallery display names from PIDLs to identify them.
-    WCHAR homeName[64] = {};
-    WCHAR galleryName[64] = {};
-    ResolveHomeGalleryNames(homeName, ARRAYSIZE(homeName),
-                            galleryName, ARRAYSIZE(galleryName));
-
-    HTREEITEM hBoundaryPos = nullptr;
-    {
-        bool passedOurs = false;
-        HTREEITEM hWalk = h;
-        while (hWalk)
-        {
-            bool isOursOrHG = IsOurSection(ts, hWalk);
-
-            if (!isOursOrHG && (homeName[0] || galleryName[0]))
-            {
-                WCHAR text[64] = {};
-                GetItemText(hTree, hWalk, text, ARRAYSIZE(text));
-                if ((homeName[0] && wcscmp(text, homeName) == 0) ||
-                    (galleryName[0] && wcscmp(text, galleryName) == 0))
-                    isOursOrHG = true;
-            }
-
-            if (isOursOrHG)
-                passedOurs = true;
-            else if (passedOurs)
-            {
-                hBoundaryPos = hWalk;
-                break;
-            }
-            hWalk = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                             TVGN_NEXT, (LPARAM)hWalk);
-        }
-    }
-
-    while (h)
-    {
-        HTREEITEM hNext = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                                   TVGN_NEXT, (LPARAM)h);
-        if (h != ts.hThisPC && h != ts.hDesktop)
+    ForEachDepth1Item(hTree, [&](HTREEITEM h) -> bool {
+        if (!IsOurSection(ts, h))
         {
             WCHAR text[64] = {};
             GetItemText(hTree, h, text, ARRAYSIZE(text));
 
             bool match = false;
-            if (thisPCText[0] && wcscmp(text, thisPCText) == 0)
-                match = true;
-            if (desktopText[0] && wcscmp(text, desktopText) == 0)
-                match = true;
+            for (int i = 0; i < expectedCount; i++)
+                if (matchNames[i][0] && wcscmp(text, matchNames[i]) == 0)
+                    { match = true; break; }
 
             if (match)
             {
-                HTREEITEM hChild = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                                            TVGN_CHILD, (LPARAM)h);
+                HTREEITEM hChild = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_CHILD, (LPARAM)h);
                 if (!hChild)
                 {
                     if (childlessCount < 8)
@@ -1111,20 +1384,13 @@ static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
                 }
             }
         }
-        h = hNext;
-    }
+        return true;
+    });
 
     // Freeze redraw during deletions to prevent Explorer from
     // re-inserting items synchronously (which would reset cleanup
     // flags via the TVM_INSERTITEM handler and cause a loop).
-    bool needDelete = (sectionCount > 0);
-    for (int i = 0; i < childlessCount && !needDelete; i++)
-    {
-        bool wouldKeep = (!g_settings.removeSepBelowNav &&
-                          toDeleteChildless[i] == hBoundaryPos);
-        if (!wouldKeep)
-            needDelete = true;
-    }
+    bool needDelete = (sectionCount > 0 || childlessCount > 0);
     if (needDelete)
         SendMessageW(hTree, WM_SETREDRAW, FALSE, 0);
 
@@ -1135,32 +1401,22 @@ static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
         SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDeleteSections[i]);
     }
 
-    // Only keep a childless match as hiddenDuplicate if it IS the
-    // boundary item (first non-our item after our section). A dup in
-    // the middle of QA would be painted over but leave a blank gap
-    // with no separator, since RedrawOtherSeparators skips the boundary
-    // when hiddenDuplicate exists.
     HTREEITEM prevDup = ts.hiddenDuplicate;
     ts.hiddenDuplicate = nullptr;
-    ts.dupAtBoundary = false;
+
+    SectionLayout layout = FindSectionLayout(hTree, ts);
+    HTREEITEM hBoundaryPos = layout.boundary;
     for (int i = 0; i < childlessCount; i++)
     {
-        if (!g_settings.removeSepBelowNav && !ts.hiddenDuplicate &&
-            toDeleteChildless[i] == hBoundaryPos)
+        if (!g_settings.removeSepBelowNav && !ts.hiddenDuplicate && toDeleteChildless[i] == hBoundaryPos)
         {
             ts.hiddenDuplicate = toDeleteChildless[i];
-            TVITEMEXW fix = {};
-            fix.mask = TVIF_HANDLE | TVIF_INTEGRAL;
-            fix.hItem = toDeleteChildless[i];
-            fix.iIntegral = 1;
-            SendMessageW(hTree, TVM_SETITEMW, 0, (LPARAM)&fix);
+            SetItemIntegral(hTree, toDeleteChildless[i], 1);
             if (ts.hiddenDuplicate != prevDup)
-                Wh_Log(L"[QA-HIDE] keeping dup=%p at boundary (iIntegral=1)",
-                       toDeleteChildless[i]);
+                Wh_Log(L"[QA-HIDE] keeping dup=%p at boundary", toDeleteChildless[i]);
             continue;
         }
-        Wh_Log(L"[QA-HIDE] deleting duplicate item=%p (boundary=%p)",
-               toDeleteChildless[i], hBoundaryPos);
+        Wh_Log(L"[QA-HIDE] deleting duplicate item=%p", toDeleteChildless[i]);
         SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDeleteChildless[i]);
     }
 
@@ -1170,270 +1426,147 @@ static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
         InvalidateRect(hTree, nullptr, TRUE);
     }
 
-    if (ts.hiddenDuplicate != prevDup || sectionCount > 0)
-        Wh_Log(L"[QA-HIDE] tree=%p childless=%d sections=%d expected=%d dup=%p",
-               hTree, childlessCount, sectionCount, expectedCount,
-               ts.hiddenDuplicate);
+    bool complete = (childlessCount >= expectedCount);
+    if (needDelete && (complete || ts.hiddenDuplicate != prevDup))
+        Wh_Log(L"[QA-HIDE] tree=%p childless=%d sections=%d expected=%d", hTree, childlessCount, sectionCount, expectedCount);
 
-    return (childlessCount >= expectedCount);
+    return complete;
 }
 
-// Walk depth-1 children and cache Home/Gallery handles by matching
-// PIDL-derived display names. Called when handles are unknown (e.g.,
-// after FullRebuildTree where items existed before our hooks).
-static void CacheHomeGalleryHandles(HWND hTree, TreeState& ts)
+static bool RemoveHiddenInheritedItems(HWND hTree, TreeState& ts)
 {
-    if (ts.hHome && ts.hGallery)
-        return;
+    if (!IsWindow(hTree)) return true;
 
-    bool needHome = !ts.hHome && g_pidlHome && !g_settings.hideHome;
-    bool needGallery = !ts.hGallery && g_pidlGallery && !g_settings.hideGallery;
-    if (!needHome && !needGallery)
-        return;
+    struct Target { int id; WCHAR name[64]; };
+    Target targets[NAV_COUNT - NAV_HOME] = {};
+    int targetCount = 0;
 
-    WCHAR homeName[64] = {};
-    WCHAR galleryName[64] = {};
-    ResolveHomeGalleryNames(homeName, ARRAYSIZE(homeName),
-                            galleryName, ARRAYSIZE(galleryName));
-
-    HTREEITEM h = GetFirstDepth1Child(hTree);
-    if (!h) return;
-
-    while (h)
+    for (int i = NAV_HOME; i < NAV_COUNT; i++)
     {
-        if (h != ts.hThisPC && h != ts.hDesktop)
-        {
-            WCHAR text[64] = {};
-            GetItemText(hTree, h, text, ARRAYSIZE(text));
-
-            if (needHome && homeName[0] && wcscmp(text, homeName) == 0)
-            {
-                ts.hHome = h;
-                needHome = false;
-                Wh_Log(L"[CACHE] Home item=%p tree=%p (walk)", h, hTree);
-            }
-            else if (needGallery && galleryName[0] &&
-                     wcscmp(text, galleryName) == 0)
-            {
-                ts.hGallery = h;
-                needGallery = false;
-                Wh_Log(L"[CACHE] Gallery item=%p tree=%p (walk)", h, hTree);
-            }
-
-            if (!needHome && !needGallery)
-                break;
-        }
-        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                    TVGN_NEXT, (LPARAM)h);
+        if (!g_settings.items[i].hide || !g_navItems[i].label[0]) continue;
+        targets[targetCount].id = i;
+        wcsncpy_s(targets[targetCount].name, 64, g_navItems[i].label, _TRUNCATE);
+        if (targets[targetCount].name[0]) targetCount++;
     }
-}
+    if (!targetCount) return true;
 
-// Walk depth-1 items and delete Home/Gallery by matching their
-// display names derived from PIDLs (localization-agnostic).
-// Returns true when all expected items have been found and removed.
-static bool RemoveHomeGalleryItems(HWND hTree, TreeState& ts)
-{
-    if (!IsWindow(hTree))
-        return true;
+    if (!GetFirstDepth1Child(hTree)) return false;
 
-    bool wantHome = g_settings.hideHome && g_pidlHome;
-    bool wantGallery = g_settings.hideGallery && g_pidlGallery;
-    if (!wantHome && !wantGallery)
-        return true;
-
-    WCHAR homeName[64] = {};
-    WCHAR galleryName[64] = {};
-    ResolveHomeGalleryNames(homeName, ARRAYSIZE(homeName),
-                            galleryName, ARRAYSIZE(galleryName));
-
-    int expectedCount = 0;
-    if (wantHome && homeName[0]) expectedCount++;
-    if (wantGallery && galleryName[0]) expectedCount++;
-    if (!expectedCount) return true;
-
-    HTREEITEM h = GetFirstDepth1Child(hTree);
-    if (!h) return false;
-    struct { HTREEITEM h; bool isHome; } toDelete[2] = {};
+    struct { HTREEITEM h; int id; } toDelete[NAV_COUNT] = {};
     int delCount = 0;
 
-    while (h && delCount < 2)
-    {
-        HTREEITEM hNext = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                                   TVGN_NEXT, (LPARAM)h);
-        if (h != ts.hThisPC && h != ts.hDesktop &&
-            h != ts.hiddenDuplicate)
+    ForEachDepth1Item(hTree, [&](HTREEITEM h) -> bool {
+        if (delCount >= targetCount)
+            return false;
+        if (!IsOurSection(ts, h) && h != ts.hiddenDuplicate)
         {
             WCHAR text[64] = {};
             GetItemText(hTree, h, text, ARRAYSIZE(text));
-
-            if (text[0])
+            for (int j = 0; j < targetCount; j++)
             {
-                bool isHome = wantHome && homeName[0] &&
-                              wcscmp(text, homeName) == 0;
-                bool isGallery = wantGallery && galleryName[0] &&
-                                 wcscmp(text, galleryName) == 0;
-                if (isHome || isGallery)
-                    toDelete[delCount++] = { h, isHome };
+                if (wcscmp(text, targets[j].name) == 0)
+                { toDelete[delCount++] = { h, targets[j].id }; break; }
             }
         }
-        h = hNext;
-    }
+        return true;
+    });
 
     if (delCount > 0)
         SendMessageW(hTree, WM_SETREDRAW, FALSE, 0);
-
     for (int i = 0; i < delCount; i++)
     {
         Wh_Log(L"[HIDE] Deleting '%s' item=%p",
-               toDelete[i].isHome ? homeName : galleryName, toDelete[i].h);
+               g_navItems[toDelete[i].id].label, toDelete[i].h);
         SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDelete[i].h);
-        if (toDelete[i].isHome)
-            ts.hHome = nullptr;
-        else
-            ts.hGallery = nullptr;
+        ts.hItems[toDelete[i].id] = nullptr;
     }
-
     if (delCount > 0)
     {
         SendMessageW(hTree, WM_SETREDRAW, TRUE, 0);
         InvalidateRect(hTree, nullptr, TRUE);
     }
-
-    return (delCount >= expectedCount);
-}
-
-// Tree subclass installed via SetWindowSubclass — runs BEFORE
-// Explorer's other subclasses (LIFO order), blocking right-click
-// on the hidden duplicate.
-// TODO: instead of blocking, redirect to empty space and reposition
-// the resulting background context menu to the click point.
-static LRESULT CALLBACK TreeInteractionProc(
-    HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
-    UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
-{
-    TreeState* ts = GetTree(hWnd);
-    HTREEITEM hiddenDup = ts ? ts->hiddenDuplicate : nullptr;
-
-    if (hiddenDup &&
-        (uMsg == WM_RBUTTONDOWN || uMsg == WM_RBUTTONUP ||
-         uMsg == WM_MOUSEMOVE))
-    {
-        POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
-        TVHITTESTINFO ht = {};
-        ht.pt = pt;
-        HTREEITEM hHit = (HTREEITEM)SendMessageW(
-            hWnd, TVM_HITTEST, 0, (LPARAM)&ht);
-        if (hHit == hiddenDup)
-            return 0;
-    }
-
-    if (uMsg == WM_NCDESTROY)
-        RemoveWindowSubclass(hWnd, TreeInteractionProc, uIdSubclass);
-
-    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+    return (delCount >= targetCount);
 }
 
 // --- SubClassTreeWndProc ---
 
-using SubClassTreeWndProc_t = LRESULT (CALLBACK *)(
-    HWND, UINT, WPARAM, LPARAM, UINT_PTR, DWORD_PTR);
+using SubClassTreeWndProc_t = LRESULT (CALLBACK *)(HWND, UINT, WPARAM, LPARAM, UINT_PTR, DWORD_PTR);
 
 SubClassTreeWndProc_t SubClassTreeWndProc_orig;
 
-LRESULT CALLBACK SubClassTreeWndProc_hook(
-    HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
-    UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
+LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
     if (uMsg == TVM_INSERTITEMW || uMsg == TVM_INSERTITEMA)
     {
-        bool isOurInsert = (g_insertingItem >= 1 && g_insertingItem <= 4) &&
+        bool isOurInsert = (g_insertingItem >= 0 && g_insertingItem < NAV_COUNT) &&
                            (!g_insertingForTree || hWnd == g_insertingForTree);
 
-        if (isOurInsert && (g_insertingItem == 1 || g_insertingItem == 2) && lParam)
+        if (isOurInsert && IsInsertableItem(g_insertingItem) && lParam)
         {
             TVINSERTSTRUCTW *pInsert = (TVINSERTSTRUCTW *)lParam;
             pInsert->hInsertAfter = TVI_FIRST;
         }
 
-        LRESULT result = SubClassTreeWndProc_orig(hWnd, uMsg, wParam,
-                            lParam, uIdSubclass, dwRefData);
+        LRESULT result = SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData);
         HTREEITEM hNew = (HTREEITEM)result;
         if (hNew)
         {
-            if (isOurInsert && (g_insertingItem == 1 || g_insertingItem == 2))
+            if (isOurInsert)
             {
-                bool isThisPC = (g_insertingItem == 1);
-                g_insertingItem = 0;
+                int id = g_insertingItem;
+                g_insertingItem = -1;
                 if (!GetTree(hWnd) && !IsNavPaneHost(hWnd))
                     return result;
                 auto [it, _] = g_trees.try_emplace(hWnd);
                 TreeState& ts = it->second;
-                (isThisPC ? ts.hThisPC : ts.hDesktop) = hNew;
-                ts.qaCleanupDone = false;
-                ts.hiddenDuplicate = nullptr;
-                ts.dupAtBoundary = false;
-                if (!ts.pNscTree)
+                ts.hItems[id] = hNew;
+
+                if (IsInsertableItem(id))
                 {
-                    ts.pNscTree = g_pNscTree;
-                    ts.enumFlags = g_lastEnumFlags;
-                    if (g_pLastFilter && !ts.pFilter)
+                    ts.pendingWork |= WORK_QA_CLEANUP;
+                    if (!ts.pNscTree)
                     {
-                        g_pLastFilter->AddRef();
-                        ts.pFilter = g_pLastFilter;
+                        ts.pNscTree = g_pNscTree;
+                        ts.enumFlags = g_lastEnumFlags;
+                        if (g_pLastFilter && !ts.pFilter)
+                        {
+                            g_pLastFilter->AddRef();
+                            ts.pFilter = g_pLastFilter;
+                        }
                     }
+                    SetPropW(hWnd, L"WH_NscTree", (HANDLE)ts.pNscTree);
+                    SetPropW(hWnd, L"WH_EnumFlags", (HANDLE)(ULONG_PTR)ts.enumFlags);
                 }
-                SetPropW(hWnd, L"WH_NscTree", (HANDLE)ts.pNscTree);
-                SetPropW(hWnd, L"WH_EnumFlags", (HANDLE)(ULONG_PTR)ts.enumFlags);
-                Wh_Log(L"[CACHE] %s item=%p tree=%p",
-                       isThisPC ? L"This PC" : L"Desktop", hNew, hWnd);
-            }
-            else if (isOurInsert && (g_insertingItem == 3 || g_insertingItem == 4))
-            {
-                bool isHome = (g_insertingItem == 3);
-                g_insertingItem = 0;
-                if (!GetTree(hWnd) && !IsNavPaneHost(hWnd))
-                    return result;
-                auto [it, _] = g_trees.try_emplace(hWnd);
-                TreeState& ts = it->second;
-                (isHome ? ts.hHome : ts.hGallery) = hNew;
-                WCHAR itemText[64] = {};
-                GetItemText(hWnd, hNew, itemText, ARRAYSIZE(itemText));
-                Wh_Log(L"[CACHE] '%s' item=%p tree=%p", itemText, hNew, hWnd);
-                bool hidden = isHome ? g_settings.hideHome : g_settings.hideGallery;
-                if (!hidden &&
-                    (g_settings.showThisPCAtTop || g_settings.showDesktopAtTop))
+                else
                 {
-                    TVITEMEXW fix = {};
-                    fix.mask = TVIF_HANDLE | TVIF_INTEGRAL;
-                    fix.hItem = hNew;
-                    fix.iIntegral = 1;
-                    SendMessageW(hWnd, TVM_SETITEMW, 0, (LPARAM)&fix);
+                    bool hidden = g_settings.items[id].hide;
+                    if (!hidden && g_settings.hasItemsAtTop)
+                        SetItemIntegral(hWnd, hNew, 1);
                 }
+                Wh_Log(L"[CACHE] %s item=%p tree=%p", g_navItems[id].label, hNew, hWnd);
             }
             else
             {
                 TreeState* ts = GetTree(hWnd);
                 if (ts && IsDepth1Item(hWnd, hNew))
                 {
-                    if (g_settings.hideHome || g_settings.hideGallery)
+                    if (g_settings.items[NAV_HOME].hide || g_settings.items[NAV_GALLERY].hide)
                     {
-                        WCHAR homeName[64] = {}, galleryName[64] = {};
-                        ResolveHomeGalleryNames(homeName, ARRAYSIZE(homeName),
-                                                galleryName, ARRAYSIZE(galleryName));
                         WCHAR itemText[64] = {};
                         GetItemText(hWnd, hNew, itemText, ARRAYSIZE(itemText));
-                        bool isHome = g_settings.hideHome && homeName[0] &&
-                                      wcscmp(itemText, homeName) == 0;
-                        bool isGallery = g_settings.hideGallery && galleryName[0] &&
-                                         wcscmp(itemText, galleryName) == 0;
+                        bool isHome = g_settings.items[NAV_HOME].hide &&
+                                      g_navItems[NAV_HOME].label[0] &&
+                                      wcscmp(itemText, g_navItems[NAV_HOME].label) == 0;
+                        bool isGallery = g_settings.items[NAV_GALLERY].hide &&
+                                         g_navItems[NAV_GALLERY].label[0] &&
+                                         wcscmp(itemText, g_navItems[NAV_GALLERY].label) == 0;
                         if (isHome || isGallery)
                         {
                             bool nearOurSection = false;
                             HTREEITEM hPrev = hNew;
                             for (int walk = 0; walk < 6 && hPrev; walk++)
                             {
-                                hPrev = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM,
-                                    TVGN_PREVIOUS, (LPARAM)hPrev);
+                                hPrev = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM, TVGN_PREVIOUS, (LPARAM)hPrev);
                                 if (hPrev && IsOurSection(*ts, hPrev))
                                 {
                                     nearOurSection = true;
@@ -1442,22 +1575,87 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
                             }
                             if (nearOurSection)
                             {
-                                ts->homeGalleryCleanupDone = false;
+                                ts->pendingWork |= WORK_HG_CLEANUP;
                                 Wh_Log(L"[INSERT] '%s' item=%p tree=%p",
                                        itemText, hNew, hWnd);
                             }
                         }
                     }
-                    if (!ts->qaEverCleaned && ts->qaCleanupDone)
+                    bool hasOurItems = false;
+                    for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
+                        if (ts->hItems[i]) { hasOurItems = true; break; }
+
+                    if (hasOurItems)
                     {
-                        ts->qaCleanupDone = false;
-                        ts->hiddenDuplicate = nullptr;
-                        ts->dupAtBoundary = false;
+                        ts->pendingWork |= WORK_FULL_REBUILD;
+                        PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
+                        Wh_Log(L"[INSERT] New depth-1 item=%p, rebuilding tree=%p", hNew, hWnd);
+                    }
+                    else
+                    {
+                        ts->pendingWork |= WORK_QA_CLEANUP;
                     }
                 }
             }
         }
         return result;
+    }
+
+    if (uMsg == TVM_SETITEMW || uMsg == TVM_SETITEMA)
+    {
+        TVITEMEXW* tvi = (TVITEMEXW*)lParam;
+        if (tvi && (tvi->mask & TVIF_INTEGRAL))
+        {
+            TreeState* ts = GetTree(hWnd);
+            HTREEITEM hiddenDup = ts ? ts->hiddenDuplicate : nullptr;
+            HTREEITEM boundaryIt = ts ? ts->boundaryItem : nullptr;
+            HTREEITEM belowQAIt = ts ? ts->belowQAItem : nullptr;
+
+            struct ClampRule { HTREEITEM h; bool cond; bool anyNonOne; };
+            ClampRule rules[] = {
+                { hiddenDup,  true, true },
+                { boundaryIt, g_settings.removeSepBelowNav || hiddenDup != nullptr, false },
+                { belowQAIt,  true, false },
+            };
+            for (auto& r : rules)
+                if (r.h && tvi->hItem == r.h && r.cond &&
+                    (r.anyNonOne ? tvi->iIntegral != 1 : tvi->iIntegral >= 2))
+                    { tvi->iIntegral = 1; break; }
+
+            if (ts && tvi->iIntegral >= 2 && g_settings.hasItemsAtTop)
+            {
+                for (int i = NAV_HOME; i < NAV_COUNT; i++)
+                {
+                    if (ts->hItems[i] && tvi->hItem == ts->hItems[i])
+                    {
+                        if (!g_settings.items[i].hide) tvi->iIntegral = 1;
+                        break;
+                    }
+                }
+            }
+
+            // Collapse the boundary between Desktop and This PC.
+            if (ShouldRemoveInternalSep() && tvi->iIntegral >= 2 && ts)
+            {
+                HTREEITEM hA = ts->hItems[NAV_THISPC];
+                HTREEITEM hB = ts->hItems[NAV_DESKTOP];
+                if (hA && hB)
+                {
+                    RECT rcA = {}, rcB = {};
+                    *(HTREEITEM*)&rcA = hA;
+                    *(HTREEITEM*)&rcB = hB;
+                    bool gotA = SendMessageW(hWnd, TVM_GETITEMRECT, FALSE, (LPARAM)&rcA);
+                    bool gotB = SendMessageW(hWnd, TVM_GETITEMRECT, FALSE, (LPARAM)&rcB);
+
+                    if (gotA && gotB)
+                    {
+                        HTREEITEM hLower = (rcA.top > rcB.top) ? hA : hB;
+                        if (tvi->hItem == hLower)
+                            tvi->iIntegral = 1;
+                    }
+                }
+            }
+        }
     }
 
     // Block all interaction with hidden duplicate
@@ -1526,73 +1724,6 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
         }
     }
 
-    if (uMsg == TVM_SETITEMW || uMsg == TVM_SETITEMA)
-    {
-        TVITEMEXW* tvi = (TVITEMEXW*)lParam;
-        if (tvi && (tvi->mask & TVIF_INTEGRAL))
-        {
-            TreeState* ts = GetTree(hWnd);
-            HTREEITEM hiddenDup = ts ? ts->hiddenDuplicate : nullptr;
-            HTREEITEM boundaryIt = ts ? ts->boundaryItem : nullptr;
-            HTREEITEM belowQAIt = ts ? ts->belowQAItem : nullptr;
-
-            // Keep hidden duplicate at iIntegral=1 so it occupies
-            // exactly one row of space for the painted-over separator.
-            if (hiddenDup && tvi->hItem == hiddenDup &&
-                tvi->iIntegral != 1)
-            {
-                tvi->iIntegral = 1;
-            }
-
-            if (boundaryIt && tvi->hItem == boundaryIt &&
-                tvi->iIntegral >= 2 &&
-                (g_settings.removeSepBelowNav ||
-                 ts->dupAtBoundary))
-            {
-                tvi->iIntegral = 1;
-            }
-
-            if (belowQAIt && tvi->hItem == belowQAIt &&
-                tvi->iIntegral >= 2)
-            {
-                tvi->iIntegral = 1;
-            }
-
-            if (ts && tvi->iIntegral >= 2 &&
-                (g_settings.showThisPCAtTop || g_settings.showDesktopAtTop))
-            {
-                bool isVisibleHome = ts->hHome && tvi->hItem == ts->hHome &&
-                                     !g_settings.hideHome;
-                bool isVisibleGallery = ts->hGallery && tvi->hItem == ts->hGallery &&
-                                        !g_settings.hideGallery;
-                if (isVisibleHome || isVisibleGallery)
-                    tvi->iIntegral = 1;
-            }
-
-            // Collapse the boundary between Desktop and This PC.
-            if (ShouldRemoveInternalSep() && tvi->iIntegral >= 2 && ts)
-            {
-                HTREEITEM hA = ts->hThisPC;
-                HTREEITEM hB = ts->hDesktop;
-                if (hA && hB)
-                {
-                    RECT rcA = {}, rcB = {};
-                    *(HTREEITEM*)&rcA = hA;
-                    *(HTREEITEM*)&rcB = hB;
-                    bool gotA = SendMessageW(hWnd, TVM_GETITEMRECT, FALSE, (LPARAM)&rcA);
-                    bool gotB = SendMessageW(hWnd, TVM_GETITEMRECT, FALSE, (LPARAM)&rcB);
-
-                    if (gotA && gotB)
-                    {
-                        HTREEITEM hLower = (rcA.top > rcB.top) ? hA : hB;
-                        if (tvi->hItem == hLower)
-                            tvi->iIntegral = 1;
-                    }
-                }
-            }
-        }
-    }
-
     if (uMsg == WM_DEFERRED_REBUILD)
     {
         if (g_deferredOpInProgress)
@@ -1602,21 +1733,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
         }
 
         TreeState* ts = GetTree(hWnd);
-        if (ts && ts->needFullRebuild)
-        {
-            g_deferredOpInProgress = true;
-            ts->needFullRebuild = false;
-            FullRebuildTree(hWnd);
-            ts = GetTree(hWnd);
-            DrainPendingRebuilds();
-        }
-        if (ts && ts->needHotInsert)
-        {
-            g_deferredOpInProgress = true;
-            ts->needHotInsert = false;
-            HotEnableInsert(hWnd);
-            DrainPendingRebuilds();
-        }
+        ts = RunDeferredWork(hWnd, ts, WORK_FULL_REBUILD, FullRebuildTree);
+        ts = RunDeferredWork(hWnd, ts, WORK_HOT_INSERT, HotEnableInsert);
         return 0;
     }
 
@@ -1624,43 +1742,22 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
     {
         TreeState* ts = GetTree(hWnd);
 
-        // Full rebuild deferred from settings change or missed message.
-        // Guarded to prevent re-entrancy (AppendRoot_orig pumps messages).
-        if (ts && ts->needFullRebuild && !g_deferredOpInProgress)
-        {
-            g_deferredOpInProgress = true;
-            ts->needFullRebuild = false;
-            FullRebuildTree(hWnd);
-            ts = GetTree(hWnd);
-            DrainPendingRebuilds();
-        }
+        // Full rebuild and hot-insert deferred from settings change or
+        // missed message. Guarded to prevent re-entrancy (AppendRoot_orig
+        // pumps messages). checkGuard=true so another tree's in-progress
+        // op blocks us.
+        ts = RunDeferredWork(hWnd, ts, WORK_FULL_REBUILD, FullRebuildTree, true);
+        ts = RunDeferredWork(hWnd, ts, WORK_HOT_INSERT, HotEnableInsert, true);
 
-        // Hot-enable deferred insertion: items are inserted on the UI
-        // thread so TVM_INSERTITEM fires through the subclass (TVI_FIRST
-        // + caching work). Items land as children of the hidden root.
-        // Guarded: same re-entrancy risk as FullRebuildTree.
-        if (ts && ts->needHotInsert && !g_deferredOpInProgress)
+        if (ts && (ts->pendingWork & WORK_QA_CLEANUP) &&
+            ((g_settings.items[NAV_THISPC].showAtTop && g_settings.items[NAV_THISPC].hideFromQA) ||
+             (g_settings.items[NAV_DESKTOP].showAtTop && g_settings.items[NAV_DESKTOP].hideFromQA)))
         {
-            g_deferredOpInProgress = true;
-            ts->needHotInsert = false;
-            HotEnableInsert(hWnd);
-            ts = GetTree(hWnd);
-            DrainPendingRebuilds();
-        }
-
-        // Cache Home/Gallery handles if unknown (items exist in tree
-        // but were added before our hooks, e.g., after FullRebuildTree).
-        if (ts && ((g_pidlHome && !ts->hHome && !g_settings.hideHome) ||
-                   (g_pidlGallery && !ts->hGallery && !g_settings.hideGallery)))
-            CacheHomeGalleryHandles(hWnd, *ts);
-
-        if (ts && !ts->qaCleanupDone &&
-            ((g_settings.showThisPCAtTop && g_settings.hideThisPCFromQuickAccess) ||
-             (g_settings.showDesktopAtTop && g_settings.hideDesktopFromQuickAccess)))
-        {
-            ts->qaCleanupDone = CleanupQuickAccessDuplicates(hWnd, *ts);
-            if (ts->qaCleanupDone)
+            if (CleanupQuickAccessDuplicates(hWnd, *ts))
+            {
+                ts->pendingWork &= ~WORK_QA_CLEANUP;
                 ts->qaEverCleaned = true;
+            }
         }
 
         // Collapse visible duplicates of our items so they don't
@@ -1668,149 +1765,55 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
         // a dup is visible: parent off (dup never hidden) or parent
         // on but not hiding from nav. Uses PIDL fallback for names
         // when our item handle doesn't exist.
-        if (ts)
+        if (ts && (ts->pendingWork & WORK_DUP_COLLAPSE))
         {
-            WCHAR collapseText[2][64] = {};
-            int collapseCount = 0;
+            WCHAR collapseText[NAV_COUNT][64] = {};
+            int collapseCount = BuildMatchList(collapseText, NAV_COUNT,
+                [](int id, const NavItemSettings& s) {
+                    return IsInsertableItem(id) && !(s.showAtTop && s.hideFromQA);
+                });
 
-            auto getTextFromItem = [&](HTREEITEM h) {
-                if (!h || collapseCount >= 2) return;
-                GetItemText(hWnd, h, collapseText[collapseCount], 64);
-                if (collapseText[collapseCount][0]) collapseCount++;
-            };
-
-            if (!g_settings.showThisPCAtTop ||
-                !g_settings.hideThisPCFromQuickAccess)
-            {
-                if (ts->hThisPC)
-                    getTextFromItem(ts->hThisPC);
-                else if (g_pidlThisPC && collapseCount < 2)
-                {
-                    GetPidlDisplayName(g_pidlThisPC,
-                                       collapseText[collapseCount], 64);
-                    if (collapseText[collapseCount][0]) collapseCount++;
-                }
-            }
-            if (!g_settings.showDesktopAtTop ||
-                !g_settings.hideDesktopFromQuickAccess)
-            {
-                if (ts->hDesktop)
-                    getTextFromItem(ts->hDesktop);
-                else if (g_pidlDesktop && collapseCount < 2)
-                {
-                    GetPidlDisplayName(g_pidlDesktop,
-                                       collapseText[collapseCount], 64);
-                    if (collapseText[collapseCount][0]) collapseCount++;
-                }
-            }
-
-            if (collapseCount > 0 && !ts->dupCollapsesDone)
-            {
-                ts->dupCollapsesDone = true;
-                HTREEITEM h = GetFirstDepth1Child(hWnd);
-                while (h)
-                {
-                    if (h != ts->hThisPC && h != ts->hDesktop)
-                    {
-                        WCHAR text[64] = {};
-                        TVITEMEXW tvi = {};
-                        tvi.mask = TVIF_HANDLE | TVIF_TEXT | TVIF_STATE;
-                        tvi.stateMask = TVIS_EXPANDED;
-                        tvi.hItem = h;
-                        tvi.pszText = text;
-                        tvi.cchTextMax = 64;
-                        SendMessageW(hWnd, TVM_GETITEMW, 0, (LPARAM)&tvi);
-
-                        if ((tvi.state & TVIS_EXPANDED) && text[0])
-                        {
-                            for (int j = 0; j < collapseCount; j++)
-                            {
-                                if (wcscmp(text, collapseText[j]) == 0)
-                                {
-                                    SendMessageW(hWnd, TVM_EXPAND, TVE_COLLAPSE, (LPARAM)h);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    h = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM, TVGN_NEXT, (LPARAM)h);
-                }
-            }
+            ts->pendingWork &= ~WORK_DUP_COLLAPSE;
+            if (collapseCount > 0)
+                CollapseMatchingItems(hWnd, ts, collapseText, collapseCount);
         }
 
-        // Remove Home/Gallery items by PIDL (children of hidden root)
-        if (ts && !ts->homeGalleryCleanupDone &&
-            ts->pNscTree && (g_pidlHome || g_pidlGallery) &&
-            (g_settings.hideHome || g_settings.hideGallery))
+        // Remove hidden inherited items (Home/Gallery) by PIDL
+        if (ts && (ts->pendingWork & WORK_HG_CLEANUP) && ts->pNscTree &&
+            (g_navItems[NAV_HOME].pidl || g_navItems[NAV_GALLERY].pidl) &&
+            (g_settings.items[NAV_HOME].hide || g_settings.items[NAV_GALLERY].hide))
         {
-            ts->homeGalleryCleanupDone = RemoveHomeGalleryItems(hWnd, *ts);
+            if (RemoveHiddenInheritedItems(hWnd, *ts))
+                ts->pendingWork &= ~WORK_HG_CLEANUP;
         }
 
-        // Collapse iIntegral on visible Home/Gallery so there's no
-        // space between our items and them.
-        if (ts && (g_settings.showThisPCAtTop || g_settings.showDesktopAtTop))
+        // Collapse iIntegral on visible inherited items so there's no
+        // separator space between our items and them.
+        if (ts && g_settings.hasItemsAtTop)
         {
-            if (ts->hHome && !g_settings.hideHome)
-                CollapseItemIntegral(hWnd, ts->hHome);
-            if (ts->hGallery && !g_settings.hideGallery)
-                CollapseItemIntegral(hWnd, ts->hGallery);
+            for (int i = NAV_HOME; i < NAV_COUNT; i++)
+            {
+                if (!ts->hItems[i]) continue;
+                if (!g_settings.items[i].hide)
+                    CollapseItemIntegral(hWnd, ts->hItems[i]);
+            }
         }
 
         // Find and optionally collapse separator boundary items.
-        // Always runs when we have items at top (to track boundaryItem
-        // for RedrawOtherSeparators). Only COLLAPSES iIntegral when the
-        // user wants to remove the separator:
-        // - boundary: collapse when removeSepBelowNav (otherwise its
-        //   iIntegral=2 provides space for the separator we draw)
-        // - below-QA: collapse when removeSepBelowQA
         // Deferred until g_sepColor is captured so tall items remain
         // for the sampling pass on the first paint cycle.
-        if ((g_settings.showThisPCAtTop || g_settings.showDesktopAtTop) &&
-            g_sepColor != CLR_INVALID && ts)
+        if (g_settings.hasItemsAtTop && g_sepColor != CLR_INVALID && ts)
         {
-            HTREEITEM hChild = GetFirstDepth1Child(hWnd);
-            if (hChild)
-            {
-                bool passedOurs = false;
-                bool foundBoundary = false;
-                while (hChild)
-                {
-                    bool isOursOrHG = IsOurSection(*ts, hChild);
+            SectionLayout layout = FindSectionLayout(hWnd, *ts);
+            ts->boundaryItem = layout.boundary;
+            ts->belowQAItem = nullptr;
 
-                    if (isOursOrHG)
-                    {
-                        passedOurs = true;
-                    }
-                    else if (passedOurs && hChild != ts->hiddenDuplicate)
-                    {
-                        if (!foundBoundary)
-                        {
-                            ts->boundaryItem = hChild;
-                            if (ts->hiddenDuplicate)
-                            {
-                                HTREEITEM hPrev = (HTREEITEM)SendMessageW(
-                                    hWnd, TVM_GETNEXTITEM, TVGN_PREVIOUS,
-                                    (LPARAM)hChild);
-                                ts->dupAtBoundary = (hPrev == ts->hiddenDuplicate);
-                            }
-                            if (g_settings.removeSepBelowNav ||
-                                ts->dupAtBoundary)
-                            {
-                                CollapseItemIntegral(hWnd, hChild);
-                            }
-                            foundBoundary = true;
-                            if (!g_settings.removeSepBelowQA)
-                                break;
-                        }
-                        else if (CollapseItemIntegral(hWnd, hChild))
-                        {
-                            ts->belowQAItem = hChild;
-                            break;
-                        }
-                    }
-                    hChild = (HTREEITEM)SendMessageW(
-                        hWnd, TVM_GETNEXTITEM, TVGN_NEXT, (LPARAM)hChild);
-                }
+            if (layout.boundary && (g_settings.removeSepBelowNav || ts->hiddenDuplicate))
+                CollapseItemIntegral(hWnd, layout.boundary);
+            if (g_settings.removeSepBelowQA && layout.belowQA)
+            {
+                CollapseItemIntegral(hWnd, layout.belowQA);
+                ts->belowQAItem = layout.belowQA;
             }
         }
 
@@ -1825,18 +1828,16 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
             }
         }
 
-        if (g_settings.showThisPCAtTop || g_settings.showDesktopAtTop)
+        if (g_settings.hasItemsAtTop)
             EnsureParentSubclass(hWnd);
 
-        // Install tree subclass for right-click blocking on hidden dup
         if (ts && ts->hiddenDuplicate)
             SetWindowSubclass(hWnd, TreeInteractionProc, 0xAF01, 0);
 
         if (g_settings.fixChevronDrawing)
             g_inTreePaint = true;
 
-        LRESULT result = SubClassTreeWndProc_orig(hWnd, uMsg, wParam,
-                            lParam, uIdSubclass, dwRefData);
+        LRESULT result = SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData);
 
         g_inTreePaint = false;
 
@@ -1845,10 +1846,10 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
 
     if (uMsg == WM_NCDESTROY)
     {
+        RemoveWindowSubclass(hWnd, TreeInteractionProc, 0xAF01);
         auto it = g_trees.find(hWnd);
         if (it != g_trees.end())
         {
-            RemoveWindowSubclass(hWnd, TreeInteractionProc, 0xAF01);
             IShellItemFilter *pf = it->second.pFilter;
             it->second.pFilter = nullptr;
             INameSpaceTreeControl *pNsc = nullptr;
@@ -1863,18 +1864,14 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
         }
     }
 
-    return SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam,
-                                    uIdSubclass, dwRefData);
+    return SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData);
 }
 
-using DrawThemeBackground_t = HRESULT (WINAPI *)(
-    HTHEME, HDC, int, int, LPCRECT, LPCRECT);
+using DrawThemeBackground_t = HRESULT (WINAPI *)(HTHEME, HDC, int, int, LPCRECT, LPCRECT);
 
 DrawThemeBackground_t DrawThemeBackground_orig;
 
-HRESULT WINAPI DrawThemeBackground_hook(
-    HTHEME hTheme, HDC hdc, int iPartId, int iStateId,
-    LPCRECT pRect, LPCRECT pClipRect)
+HRESULT WINAPI DrawThemeBackground_hook(HTHEME hTheme, HDC hdc, int iPartId, int iStateId, LPCRECT pRect, LPCRECT pClipRect)
 {
     if (g_inTreePaint && (iPartId == TVP_GLYPH || iPartId == TVP_HOTGLYPH))
     {
@@ -1883,47 +1880,76 @@ HRESULT WINAPI DrawThemeBackground_hook(
         DrawChevron(hdc, &drawRect, iPartId, iStateId);
         return S_OK;
     }
-    return DrawThemeBackground_orig(hTheme, hdc, iPartId, iStateId,
-                                    pRect, pClipRect);
+    return DrawThemeBackground_orig(hTheme, hdc, iPartId, iStateId, pRect, pClipRect);
 }
 
 // --- Settings ---
 
 void LoadSettings()
 {
-    g_settings.showThisPCAtTop = Wh_GetIntSetting(L"ThisPC.showThisPCAtTop");
-    g_settings.thisPCExpandable = Wh_GetIntSetting(L"ThisPC.thisPCExpandable");
-    g_settings.thisPCStartExpanded = Wh_GetIntSetting(L"ThisPC.thisPCStartExpanded");
-    g_settings.hideThisPCFromQuickAccess = Wh_GetIntSetting(L"ThisPC.hideThisPCFromQuickAccess");
-    g_settings.showDesktopAtTop = Wh_GetIntSetting(L"Desktop.showDesktopAtTop");
+    g_settings = {};  // zero everything first
+
+    // Per-item settings with explicit YAML paths
+    struct ItemSettingDef {
+        const wchar_t *showAtTop;
+        const wchar_t *expandable;
+        const wchar_t *startExpanded;
+        const wchar_t *hideFromQA;
+        const wchar_t *hide;
+    };
+    static const ItemSettingDef kItemKeys[NAV_COUNT] = {
+        // NAV_THISPC
+        { L"ThisPC.showThisPCAtTop", L"ThisPC.thisPCExpandable",
+          L"ThisPC.thisPCStartExpanded", L"ThisPC.hideThisPCFromQuickAccess", nullptr },
+        // NAV_DESKTOP
+        { L"Desktop.showDesktopAtTop", L"Desktop.desktopExpandable",
+          nullptr, L"Desktop.hideDesktopFromQuickAccess", nullptr },
+        // NAV_HOME
+        { nullptr, nullptr, nullptr, nullptr, L"HomeGallery.hideHome" },
+        // NAV_GALLERY
+        { nullptr, nullptr, nullptr, nullptr, L"HomeGallery.hideGallery" },
+    };
+
+    for (int i = 0; i < NAV_COUNT; i++)
+    {
+        auto& k = kItemKeys[i];
+        auto& s = g_settings.items[i];
+        if (k.showAtTop)     s.showAtTop     = Wh_GetIntSetting(k.showAtTop);
+        if (k.expandable)    s.expandable    = Wh_GetIntSetting(k.expandable);
+        if (k.startExpanded) s.startExpanded = Wh_GetIntSetting(k.startExpanded);
+        if (k.hideFromQA)    s.hideFromQA    = Wh_GetIntSetting(k.hideFromQA);
+        if (k.hide)          s.hide          = Wh_GetIntSetting(k.hide);
+    }
+
     g_settings.desktopAboveThisPC = Wh_GetIntSetting(L"Desktop.desktopAboveThisPC");
-    g_settings.desktopExpandable = Wh_GetIntSetting(L"Desktop.desktopExpandable");
-    g_settings.hideDesktopFromQuickAccess = Wh_GetIntSetting(L"Desktop.hideDesktopFromQuickAccess");
-    g_settings.hideHome = Wh_GetIntSetting(L"HomeGallery.hideHome");
-    g_settings.hideGallery = Wh_GetIntSetting(L"HomeGallery.hideGallery");
-    g_settings.fixChevronDrawing = Wh_GetIntSetting(L"Resources.fixChevronDrawing");
-    g_settings.chevronScale = Wh_GetIntSetting(L"Resources.chevronScale");
-    g_settings.hidePinButtons = Wh_GetIntSetting(L"Resources.hidePinButtons");
-    g_settings.removeSepBelowNav = Wh_GetIntSetting(L"Separators.removeSepBelowNav");
-    g_settings.removeSepBelowQA = Wh_GetIntSetting(L"Separators.removeSepBelowQA");
+    g_settings.fixChevronDrawing  = Wh_GetIntSetting(L"Resources.fixChevronDrawing");
+    g_settings.chevronScale       = Wh_GetIntSetting(L"Resources.chevronScale");
+    g_settings.hidePinButtons     = Wh_GetIntSetting(L"Resources.hidePinButtons");
+    g_settings.removeSepBelowNav  = Wh_GetIntSetting(L"Separators.removeSepBelowNav");
+    g_settings.removeSepBelowQA   = Wh_GetIntSetting(L"Separators.removeSepBelowQA");
+
+    // Precompute composite guard
+    g_settings.hasItemsAtTop = false;
+    for (int i = 0; i < NAV_COUNT; i++)
+        if (g_settings.items[i].showAtTop) { g_settings.hasItemsAtTop = true; break; }
 
     Wh_Log(L"Settings: thisPCAtTop=%d (expand=%d, startExp=%d, hideQA=%d) "
             L"desktopAtTop=%d (above=%d, expand=%d, hideQA=%d) "
-            L"hideHome=%d hideGallery=%d "
-            L"fixChevron=%d chevronScale=%d hidePins=%d "
-            L"rmSepNav=%d rmSepQA=%d",
-            g_settings.showThisPCAtTop,
-            g_settings.thisPCExpandable, g_settings.thisPCStartExpanded,
-            g_settings.hideThisPCFromQuickAccess,
-            g_settings.showDesktopAtTop, g_settings.desktopAboveThisPC,
-            g_settings.desktopExpandable,
-            g_settings.hideDesktopFromQuickAccess,
-            g_settings.hideHome, g_settings.hideGallery,
-            g_settings.fixChevronDrawing,
-            g_settings.chevronScale,
+            L"hideHome=%d hideGallery=%d fixChevron=%d chevronScale=%d "
+            L"hidePins=%d rmSepNav=%d rmSepQA=%d",
+            g_settings.items[NAV_THISPC].showAtTop,
+            g_settings.items[NAV_THISPC].expandable,
+            g_settings.items[NAV_THISPC].startExpanded,
+            g_settings.items[NAV_THISPC].hideFromQA,
+            g_settings.items[NAV_DESKTOP].showAtTop,
+            g_settings.desktopAboveThisPC,
+            g_settings.items[NAV_DESKTOP].expandable,
+            g_settings.items[NAV_DESKTOP].hideFromQA,
+            g_settings.items[NAV_HOME].hide,
+            g_settings.items[NAV_GALLERY].hide,
+            g_settings.fixChevronDrawing, g_settings.chevronScale,
             g_settings.hidePinButtons,
-            g_settings.removeSepBelowNav,
-            g_settings.removeSepBelowQA);
+            g_settings.removeSepBelowNav, g_settings.removeSepBelowQA);
 }
 
 BOOL Wh_ModInit()
@@ -1936,32 +1962,37 @@ BOOL Wh_ModInit()
 
     auto cleanupOnFail = []() {
         if (g_gdipToken) { Gdiplus::GdiplusShutdown(g_gdipToken); g_gdipToken = 0; }
-        if (g_pidlThisPC) { CoTaskMemFree(g_pidlThisPC); g_pidlThisPC = nullptr; }
-        if (g_pidlDesktop) { CoTaskMemFree(g_pidlDesktop); g_pidlDesktop = nullptr; }
-        if (g_pidlHome) { CoTaskMemFree(g_pidlHome); g_pidlHome = nullptr; }
-        if (g_pidlGallery) { CoTaskMemFree(g_pidlGallery); g_pidlGallery = nullptr; }
+        for (int i = 0; i < NAV_COUNT; i++)
+            if (g_navItems[i].pidl) { CoTaskMemFree(g_navItems[i].pidl); g_navItems[i].pidl = nullptr; }
     };
+
+    for (int i = 0; i < NAV_COUNT; i++)
+        g_navItems[i] = {};
 
     Gdiplus::GdiplusStartupInput gdipIn;
     Gdiplus::GdiplusStartup(&g_gdipToken, &gdipIn, NULL);
 
-    SHGetSpecialFolderLocation(nullptr, CSIDL_DRIVES, &g_pidlThisPC);
-    if (!g_pidlThisPC)
+    SHGetSpecialFolderLocation(nullptr, CSIDL_DRIVES, &g_navItems[NAV_THISPC].pidl);
+    if (!g_navItems[NAV_THISPC].pidl)
     {
         Wh_Log(L"Failed to get This PC PIDL");
         cleanupOnFail();
         return FALSE;
     }
 
-    SHGetSpecialFolderLocation(nullptr, CSIDL_DESKTOP, &g_pidlDesktop);
-    if (!g_pidlDesktop)
+    SHGetSpecialFolderLocation(nullptr, CSIDL_DESKTOP, &g_navItems[NAV_DESKTOP].pidl);
+    if (!g_navItems[NAV_DESKTOP].pidl)
         Wh_Log(L"Warning: failed to get Desktop PIDL");
 
     SHParseDisplayName(L"::{f874310e-b6b7-47dc-bc84-b9e6b38f5903}",
-                       nullptr, &g_pidlHome, 0, nullptr);
+                       nullptr, &g_navItems[NAV_HOME].pidl, 0, nullptr);
     SHParseDisplayName(L"::{e88865ea-0e1c-4e20-9aa6-edcd0212c87c}",
-                       nullptr, &g_pidlGallery, 0, nullptr);
-    Wh_Log(L"PIDLs: Home=%p Gallery=%p", g_pidlHome, g_pidlGallery);
+                       nullptr, &g_navItems[NAV_GALLERY].pidl, 0, nullptr);
+    Wh_Log(L"PIDLs: Home=%p Gallery=%p", g_navItems[NAV_HOME].pidl, g_navItems[NAV_GALLERY].pidl);
+
+    for (int i = 0; i < NAV_COUNT; i++)
+        if (g_navItems[i].pidl)
+            GetPidlDisplayName(g_navItems[i].pidl, g_navItems[i].label, ARRAYSIZE(g_navItems[i].label));
 
     WindhawkUtils::SYMBOL_HOOK explorerFrameDllHooks[] = {
         {
@@ -2016,9 +2047,7 @@ BOOL Wh_ModInit()
     {
         FARPROC pDTB = GetProcAddress(hUxTheme, "DrawThemeBackground");
         if (pDTB)
-            Wh_SetFunctionHook((void *)pDTB,
-                               (void *)DrawThemeBackground_hook,
-                               (void **)&DrawThemeBackground_orig);
+            Wh_SetFunctionHook((void *)pDTB, (void *)DrawThemeBackground_hook, (void **)&DrawThemeBackground_orig);
     }
 
     Wh_Log(L"Mod initialized successfully");
@@ -2062,9 +2091,7 @@ void Wh_ModAfterInit()
             return TRUE;
 
         INameSpaceTreeControl *pNsc = nullptr;
-        HRESULT hr = pSP->QueryService(IID_INameSpaceTreeControl,
-                                         IID_INameSpaceTreeControl,
-                                         (void **)&pNsc);
+        HRESULT hr = pSP->QueryService(IID_INameSpaceTreeControl, IID_INameSpaceTreeControl, (void **)&pNsc);
         pSP->Release();
         if (FAILED(hr))
             return TRUE;
@@ -2099,7 +2126,7 @@ void Wh_ModAfterInit()
         TreeState& ts = g_trees[d.hTree];
         ts.pNscTree = (void *)d.pNsc;
         ts.enumFlags = d.enumFlags;
-        ts.needFullRebuild = true;
+        ts.pendingWork |= WORK_FULL_REBUILD;
         ts.ownsNscRef = true;
 
         SetPropW(d.hTree, L"WH_NscTree", (HANDLE)ts.pNscTree);
@@ -2110,264 +2137,73 @@ void Wh_ModAfterInit()
     }
 }
 
-static void RefreshNavPane(HWND hTree)
+ChangeTier ClassifySettingsChange(const Settings& prev, const Settings& cur)
 {
-    TreeState* ts = GetTree(hTree);
-    if (!ts || !hTree || !IsWindow(hTree) || !ts->pNscTree)
-        return;
+    ChangeTier tier = TIER_NONE;
 
-    if (ts->hThisPC)
+    // Per-item transitions
+    for (int i = 0; i < NAV_COUNT; i++)
     {
-        SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)ts->hThisPC);
-        ts->hThisPC = nullptr;
-    }
-    if (ts->hDesktop)
-    {
-        SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)ts->hDesktop);
-        ts->hDesktop = nullptr;
-    }
+        auto& p = prev.items[i];
+        auto& c = cur.items[i];
 
-    // Clear managed items. Don't restore hiddenDuplicate's iIntegral —
-    // CleanupQuickAccessDuplicates will re-evaluate on the next paint.
-    // Restoring to 2 is wrong when the item won't be re-deduped (e.g.,
-    // Desktop disabled) and creates visible extra spacing.
-    ResetTreeCleanup(*ts);
+        // hide: hidden->visible needs rebuild (children of hidden root)
+        if (p.hide && !c.hide)
+            tier = std::max(tier, TIER_REBUILD);
+        // hide: visible->hidden is repaint (WM_PAINT handles removal)
+        if (!p.hide && c.hide)
+            tier = std::max(tier, TIER_REPAINT);
 
-    INameSpaceTreeControl *pNsc = (INameSpaceTreeControl *)ts->pNscTree;
-    pNsc->AddRef();
-    unsigned long enumFlags = ts->enumFlags;
-    IShellItemFilter *pFilter = ts->pFilter;
-    if (pFilter)
-        pFilter->AddRef();
+        // hideFromQA toggle in either direction when parent enabled
+        if (c.showAtTop && p.hideFromQA != c.hideFromQA)
+            tier = std::max(tier, TIER_REBUILD);
 
-    g_pNscTree = ts->pNscTree;
-    g_lastEnumFlags = enumFlags;
-    g_insertingForTree = hTree;
-    g_inCustomAppend = true;
+        // Parent going off while hideFromQA was on: dups were deleted
+        if (p.showAtTop && !c.showAtTop && p.hideFromQA)
+            tier = std::max(tier, TIER_REBUILD);
 
-    NavItem items[2];
-    BuildItemOrder(items);
+        // Item enable/disable
+        if (p.showAtTop != c.showAtTop)
+            tier = std::max(tier, TIER_REFRESH);
 
-    g_deferredOpInProgress = true;
-    InsertItems(ts->pNscTree, items, enumFlags, pFilter);
-    g_insertingForTree = nullptr;
-    g_inCustomAppend = false;
-    DrainPendingRebuilds();
-
-    if (pFilter)
-        pFilter->Release();
-    pNsc->Release();
-
-    RedrawWindow(hTree, nullptr, nullptr,
-                 RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
-}
-
-static void HotEnableInsert(HWND hWnd)
-{
-    TreeState* ts = GetTree(hWnd);
-    if (!ts || !ts->pNscTree || !IsWindow(hWnd))
-        return;
-
-    HTREEITEM hFirstChild = GetFirstDepth1Child(hWnd);
-    if (!hFirstChild)
-    {
-        ts->needHotInsert = true;
-        return;
-    }
-
-    ts->hThisPC = nullptr;
-    ts->hDesktop = nullptr;
-    // Don't clear hHome/hGallery: they may have been cached during
-    // FullRebuildTree's AppendRoot_orig and are still valid.
-    ResetTreeCleanup(*ts);
-    g_sepColor = CLR_INVALID;
-    g_logSepDraw = true;
-
-    INameSpaceTreeControl *pNsc = (INameSpaceTreeControl *)ts->pNscTree;
-    pNsc->AddRef();
-    unsigned long enumFlags = ts->enumFlags;
-    IShellItemFilter *pFilter = ts->pFilter;
-    if (pFilter)
-        pFilter->AddRef();
-
-    g_pNscTree = ts->pNscTree;
-    g_lastEnumFlags = enumFlags;
-    g_insertingForTree = hWnd;
-    g_inCustomAppend = true;
-
-    NavItem items[2];
-    BuildItemOrder(items);
-
-    InsertItems(ts->pNscTree, items, enumFlags, pFilter);
-    g_insertingForTree = nullptr;
-    g_inCustomAppend = false;
-
-    if (pFilter)
-        pFilter->Release();
-    pNsc->Release();
-
-    ts = GetTree(hWnd);
-    Wh_Log(L"[HOTINSERT] Items inserted, ThisPC=%p Desktop=%p Home=%p Gallery=%p",
-           ts ? ts->hThisPC : nullptr, ts ? ts->hDesktop : nullptr,
-           ts ? ts->hHome : nullptr, ts ? ts->hGallery : nullptr);
-
-    // Invalidate for dedup and separator setup on the next paint
-    // (not RDW_UPDATENOW since we're already inside WM_PAINT)
-    InvalidateRect(hWnd, nullptr, TRUE);
-}
-
-static void FullRebuildTree(HWND hTree)
-{
-    TreeState* ts = GetTree(hTree);
-    if (!ts || !ts->pNscTree || !IsWindow(hTree))
-        return;
-
-    INameSpaceTreeControl *pNsc = (INameSpaceTreeControl *)ts->pNscTree;
-    pNsc->AddRef();
-    void *pNscRaw = ts->pNscTree;
-    unsigned long enumFlags = ts->enumFlags;
-
-    IShellItem *pDesktop = nullptr;
-    IShellItem *pThisPC = nullptr;
-    SHCreateItemFromIDList(g_pidlDesktop, IID_IShellItem, (void **)&pDesktop);
-    if (g_pidlThisPC)
-        SHCreateItemFromIDList(g_pidlThisPC, IID_IShellItem, (void **)&pThisPC);
-
-    if (pThisPC) { while (SUCCEEDED(pNsc->RemoveRoot(pThisPC))); }
-    if (pDesktop) { while (SUCCEEDED(pNsc->RemoveRoot(pDesktop))); }
-
-    IShellItem *pHome = nullptr, *pGallery = nullptr;
-    if (g_pidlHome)
-        SHCreateItemFromIDList(g_pidlHome, IID_IShellItem, (void **)&pHome);
-    if (g_pidlGallery)
-        SHCreateItemFromIDList(g_pidlGallery, IID_IShellItem, (void **)&pGallery);
-
-    if (pHome && g_settings.hideHome)
-        pNsc->RemoveRoot(pHome);
-    if (pGallery && g_settings.hideGallery)
-        pNsc->RemoveRoot(pGallery);
-    if (pHome) pHome->Release();
-    if (pGallery) pGallery->Release();
-
-    if (pDesktop)
-    {
-        // Clear ALL item handles: RemoveRoot(pDesktop) destroys the
-        // hidden root and all its children (Home, Gallery, QA items).
-        // All old handles are now invalid.
-        ts = GetTree(hTree);
-        if (ts)
+        // Sub-settings only matter when item is/was at top
+        if (c.showAtTop || p.showAtTop)
         {
-            ts->hThisPC = nullptr;
-            ts->hDesktop = nullptr;
-            ts->hHome = nullptr;
-            ts->hGallery = nullptr;
-            ResetTreeCleanup(*ts);
+            if (p.expandable != c.expandable || p.startExpanded != c.startExpanded)
+                tier = std::max(tier, TIER_REFRESH);
         }
-
-        g_pNscTree = pNscRaw;
-        g_lastEnumFlags = enumFlags;
-
-        g_inCustomAppend = true;
-        AppendRoot_orig(pNscRaw, pDesktop, enumFlags, 0x1, nullptr);
-        g_inCustomAppend = false;
-
-        // Re-fetch ts: AppendRoot_orig pumps messages, which can
-        // trigger TVM_INSERTITEM and rehash g_trees.
-        ts = GetTree(hTree);
-        if (ts)
-        {
-            ts->needHotInsert = true;
-        }
-        g_sepColor = CLR_INVALID;
-        g_logSepDraw = true;
-
-        InvalidateRect(hTree, nullptr, TRUE);
-        Wh_Log(L"[REBUILD] Deferred insertion for tree=%p hHome=%p hGallery=%p",
-               hTree, ts ? ts->hHome : nullptr, ts ? ts->hGallery : nullptr);
     }
 
-    pNsc->Release();
+    // Cross-item: order only matters when both are at top
+    if (cur.items[NAV_THISPC].showAtTop && cur.items[NAV_DESKTOP].showAtTop)
+    {
+        if (prev.desktopAboveThisPC != cur.desktopAboveThisPC)
+            tier = std::max(tier, TIER_REFRESH);
+    }
 
-    if (pDesktop) pDesktop->Release();
-    if (pThisPC) pThisPC->Release();
+    // Non-item settings
+    if (prev.removeSepBelowNav != cur.removeSepBelowNav)
+        tier = std::max(tier, TIER_REBUILD);
+    if (prev.removeSepBelowQA && !cur.removeSepBelowQA)
+        tier = std::max(tier, TIER_REBUILD);
+    if (!prev.removeSepBelowQA && cur.removeSepBelowQA)
+        tier = std::max(tier, TIER_REPAINT);
+
+    if (prev.fixChevronDrawing != cur.fixChevronDrawing ||
+        prev.chevronScale != cur.chevronScale ||
+        prev.hidePinButtons != cur.hidePinButtons)
+        tier = std::max(tier, TIER_REPAINT);
+
+    return tier;
 }
 
 void Wh_ModSettingsChanged()
 {
-    // Snapshot ALL settings that affect behavior
     auto prev = g_settings;
-
     LoadSettings();
 
-    // Classify what changed. Sub-settings only matter when their
-    // parent item is enabled — toggling them while disabled is a no-op.
-    bool itemsChanged =
-        prev.showThisPCAtTop != g_settings.showThisPCAtTop ||
-        prev.showDesktopAtTop != g_settings.showDesktopAtTop;
-
-    // This PC sub-settings only matter when This PC is or was at top
-    if (g_settings.showThisPCAtTop || prev.showThisPCAtTop)
-        itemsChanged = itemsChanged ||
-            prev.thisPCExpandable != g_settings.thisPCExpandable ||
-            prev.thisPCStartExpanded != g_settings.thisPCStartExpanded;
-
-    // Desktop sub-settings only matter when Desktop is or was at top
-    if (g_settings.showDesktopAtTop || prev.showDesktopAtTop)
-        itemsChanged = itemsChanged ||
-            prev.desktopExpandable != g_settings.desktopExpandable;
-
-    // Order only matters when both items are at top
-    if (g_settings.showThisPCAtTop && g_settings.showDesktopAtTop)
-        itemsChanged = itemsChanged ||
-            prev.desktopAboveThisPC != g_settings.desktopAboveThisPC;
-
-    bool homeGalleryChanged =
-        prev.hideHome != g_settings.hideHome ||
-        prev.hideGallery != g_settings.hideGallery;
-
-    // Dedup sub-settings only matter when their item is at top
-    bool dedupChanged =
-        (g_settings.showThisPCAtTop &&
-         prev.hideThisPCFromQuickAccess != g_settings.hideThisPCFromQuickAccess) ||
-        (g_settings.showDesktopAtTop &&
-         prev.hideDesktopFromQuickAccess != g_settings.hideDesktopFromQuickAccess);
-
-    bool sepChanged =
-        prev.removeSepBelowNav != g_settings.removeSepBelowNav ||
-        prev.removeSepBelowQA != g_settings.removeSepBelowQA;
-
-    bool visualOnly =
-        prev.fixChevronDrawing != g_settings.fixChevronDrawing ||
-        prev.chevronScale != g_settings.chevronScale ||
-        prev.hidePinButtons != g_settings.hidePinButtons;
-
-    // Full rebuild for transitions where RefreshNavPane can't restore
-    // deleted/modified items: hidden root children (Home/Gallery),
-    // deleted QA duplicates, collapsed iIntegral items.
-    bool needRebuild =
-        (prev.hideHome && !g_settings.hideHome) ||
-        (prev.hideGallery && !g_settings.hideGallery) ||
-        (prev.removeSepBelowNav != g_settings.removeSepBelowNav) ||
-        (prev.removeSepBelowQA && !g_settings.removeSepBelowQA) ||
-        // Dedup toggles in either direction need rebuild when parent is
-        // enabled: on→off deletes dups that can't be restored; off→on
-        // needs dups discovered and potentially kept as hiddenDuplicate.
-        (g_settings.showThisPCAtTop &&
-         prev.hideThisPCFromQuickAccess != g_settings.hideThisPCFromQuickAccess) ||
-        (g_settings.showDesktopAtTop &&
-         prev.hideDesktopFromQuickAccess != g_settings.hideDesktopFromQuickAccess) ||
-        // Parent going off while hideFromQA was on: QA dups were deleted
-        // and can't be restored without rebuild.
-        (prev.showThisPCAtTop && !g_settings.showThisPCAtTop &&
-         prev.hideThisPCFromQuickAccess) ||
-        (prev.showDesktopAtTop && !g_settings.showDesktopAtTop &&
-         prev.hideDesktopFromQuickAccess);
-
-    // Nothing that affects the tree changed — just repaint
-    bool needRefresh = itemsChanged || needRebuild;
-    bool needRepaint = homeGalleryChanged || dedupChanged || sepChanged || visualOnly;
-
-    if (!needRefresh && !needRepaint)
+    ChangeTier tier = ClassifySettingsChange(prev, g_settings);
+    if (tier == TIER_NONE)
         return;
 
     // Snapshot HWNDs: FullRebuildTree pumps messages, which can trigger
@@ -2379,11 +2215,10 @@ void Wh_ModSettingsChanged()
         treeList.push_back(hTree);
     int treeCount = (int)treeList.size();
 
+    bool sepChanged = (prev.removeSepBelowNav != g_settings.removeSepBelowNav ||
+                       prev.removeSepBelowQA  != g_settings.removeSepBelowQA);
     if (sepChanged)
-    {
-        g_sepColor = CLR_INVALID;
-        g_logSepDraw = true;
-    }
+        ResetSepColor();
 
     for (int i = 0; i < treeCount; i++)
     {
@@ -2392,28 +2227,38 @@ void Wh_ModSettingsChanged()
         if (!ts || !IsWindow(hTree) || !ts->pNscTree)
             continue;
 
-        if (needRebuild)
+        if (tier == TIER_REBUILD)
         {
             g_deferredOpInProgress = true;
             FullRebuildTree(hTree);
             DrainPendingRebuilds();
         }
-        else if (itemsChanged)
+        else if (tier == TIER_REFRESH)
         {
             ts->boundaryItem = nullptr;
             ts->belowQAItem = nullptr;
-            ts->qaCleanupDone = false;
+            ts->pendingWork |= WORK_QA_CLEANUP;
             RefreshNavPane(hTree);
         }
-        else
+        else // TIER_REPAINT
         {
+            bool homeGalleryChanged = (prev.items[NAV_HOME].hide    != g_settings.items[NAV_HOME].hide ||
+                                       prev.items[NAV_GALLERY].hide != g_settings.items[NAV_GALLERY].hide);
+            bool dedupChanged = false;
+            for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
+                if (g_settings.items[i].showAtTop && prev.items[i].hideFromQA != g_settings.items[i].hideFromQA)
+                    dedupChanged = true;
+
             if (homeGalleryChanged)
             {
-                ts->homeGalleryCleanupDone = false;
+                for (int j = NAV_HOME; j < NAV_COUNT; j++)
+                    if (g_settings.items[j].hide)
+                        ts->hItems[j] = nullptr;
+                ts->pendingWork |= WORK_HG_CLEANUP;
             }
             if (dedupChanged)
             {
-                ts->qaCleanupDone = false;
+                ts->pendingWork |= WORK_QA_CLEANUP;
                 ts->qaEverCleaned = false;
             }
             if (sepChanged || dedupChanged)
@@ -2431,7 +2276,7 @@ void Wh_ModUninit()
 {
     // Clear state so hooks become no-ops
     g_settings = {};
-    g_sepColor = CLR_INVALID;
+    ResetSepColor();
 
     // Snapshot HWNDs: AppendRoot_orig pumps messages, which could
     // trigger TVM_INSERTITEM and modify g_trees during iteration.
@@ -2443,115 +2288,10 @@ void Wh_ModUninit()
     for (int i = 0; i < (int)uninitList.size(); i++)
     {
         HWND hTree = uninitList[i];
-        TreeState* ts = GetTree(hTree);
-        if (!ts || !IsWindow(hTree))
-            continue;
-
-        if (!ts->pNscTree)
-            continue;
-
-        INameSpaceTreeControl *pNsc = (INameSpaceTreeControl *)ts->pNscTree;
-        pNsc->AddRef();
-        void *pNscRaw = ts->pNscTree;
-        unsigned long enumFlags = ts->enumFlags;
-        IShellItemFilter *pFilter = ts->pFilter;
-        if (pFilter)
-            pFilter->AddRef();
-        HIMAGELIST savedImgList = ts->savedStateImageList;
-        bool ownsRef = ts->ownsNscRef;
-
-        IShellItem *pDesktop = nullptr;
-        IShellItem *pThisPC = nullptr;
-        SHCreateItemFromIDList(g_pidlDesktop, IID_IShellItem, (void **)&pDesktop);
-        if (g_pidlThisPC)
-            SHCreateItemFromIDList(g_pidlThisPC, IID_IShellItem, (void **)&pThisPC);
-
-        if (pThisPC) { while (SUCCEEDED(pNsc->RemoveRoot(pThisPC))); }
-        if (pDesktop) { while (SUCCEEDED(pNsc->RemoveRoot(pDesktop))); }
-
-        if (pDesktop && pNscRaw)
-        {
-            g_inCustomAppend = true;
-            AppendRoot_orig(pNscRaw, pDesktop, enumFlags, 0x1, pFilter);
-            g_inCustomAppend = false;
-
-            // Collapse any expanded items matching our items so they
-            // don't stay expanded in the restored native nav pane.
-            WCHAR collapseNames[2][64] = {};
-            int collapseCount = 0;
-            if (g_pidlThisPC)
-            {
-                GetPidlDisplayName(g_pidlThisPC, collapseNames[collapseCount], 64);
-                if (collapseNames[collapseCount][0]) collapseCount++;
-            }
-            if (g_pidlDesktop && collapseCount < 2)
-            {
-                GetPidlDisplayName(g_pidlDesktop, collapseNames[collapseCount], 64);
-                if (collapseNames[collapseCount][0]) collapseCount++;
-            }
-            if (collapseCount > 0)
-            {
-                HTREEITEM h = GetFirstDepth1Child(hTree);
-                while (h)
-                {
-                    WCHAR text[64] = {};
-                    TVITEMEXW tvi = {};
-                    tvi.mask = TVIF_HANDLE | TVIF_TEXT | TVIF_STATE;
-                    tvi.stateMask = TVIS_EXPANDED;
-                    tvi.hItem = h;
-                    tvi.pszText = text;
-                    tvi.cchTextMax = 64;
-                    SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
-                    if ((tvi.state & TVIS_EXPANDED) && text[0])
-                    {
-                        for (int j = 0; j < collapseCount; j++)
-                        {
-                            if (wcscmp(text, collapseNames[j]) == 0)
-                            {
-                                SendMessageW(hTree, TVM_EXPAND, TVE_COLLAPSE, (LPARAM)h);
-                                Wh_Log(L"[DISABLE] Collapsed '%s' in tree=%p", text, hTree);
-                                break;
-                            }
-                        }
-                    }
-                    h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_NEXT, (LPARAM)h);
-                }
-            }
-        }
-
-        if (pDesktop) pDesktop->Release();
-        if (pThisPC) pThisPC->Release();
-
-        RemoveWindowSubclass(hTree, TreeInteractionProc, 0xAF01);
-
-        if (savedImgList)
-        {
-            SendMessageW(hTree, TVM_SETIMAGELIST, TVSIL_STATE, (LPARAM)savedImgList);
-            Wh_Log(L"[DISABLE] Restored state image list %p for tree=%p", savedImgList, hTree);
-        }
-
-        // Re-fetch ts after message pumping
-        ts = GetTree(hTree);
-        if (ts)
-        {
-            if (ownsRef)
-                ts->ownsNscRef = false;
-            ts->pNscTree = nullptr;
-            ts->pFilter = nullptr;
-        }
-
-        // Release local refs (safe even if WM_NCDESTROY already released
-        // the TreeState's refs — our AddRef keeps the objects alive)
-        if (pFilter)
-            pFilter->Release();
-        if (ownsRef)
-            pNsc->Release();
-        pNsc->Release();
-
-        RedrawWindow(hTree, nullptr, nullptr,
-                     RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
-
-        Wh_Log(L"[DISABLE] Cleaned up tree=%p", hTree);
+        RestoreTree(hTree);
+        if (IsWindow(hTree))
+            RedrawWindow(hTree, nullptr, nullptr,
+                         RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
     }
 
     // Remove all parent subclasses
@@ -2561,8 +2301,8 @@ void Wh_ModUninit()
             WindhawkUtils::RemoveWindowSubclassFromAnyThread(parent, SepParentSubclassProc);
     }
     g_subclassedParents.clear();
-    // WM_NCDESTROY and the per-tree loop above null pFilter/pNscTree,
-    // but trees that were never processed (e.g., !IsWindow) may remain.
+
+    // Release straggler filters from trees never processed
     for (auto& [h, ts] : g_trees)
     {
         if (ts.pFilter)
@@ -2574,12 +2314,9 @@ void Wh_ModUninit()
     g_trees.clear();
     g_pendingRebuildTrees.clear();
 
-    // Clean up global resources
     if (g_gdipToken) { Gdiplus::GdiplusShutdown(g_gdipToken); g_gdipToken = 0; }
-    if (g_pidlThisPC) { CoTaskMemFree(g_pidlThisPC); g_pidlThisPC = nullptr; }
-    if (g_pidlDesktop) { CoTaskMemFree(g_pidlDesktop); g_pidlDesktop = nullptr; }
-    if (g_pidlHome) { CoTaskMemFree(g_pidlHome); g_pidlHome = nullptr; }
-    if (g_pidlGallery) { CoTaskMemFree(g_pidlGallery); g_pidlGallery = nullptr; }
+    for (int i = 0; i < NAV_COUNT; i++)
+        if (g_navItems[i].pidl) { CoTaskMemFree(g_navItems[i].pidl); g_navItems[i].pidl = nullptr; }
     g_pNscTree = nullptr;
     g_lastEnumFlags = 0;
     if (g_pLastFilter) { g_pLastFilter->Release(); g_pLastFilter = nullptr; }

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.12
+// @version         1.1.13
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -29,17 +29,11 @@ Both virtual folders have a toggle for whether they are expandable or not. Their
 
 - **Fix chevron drawing:** Replaces the pixelated and clipped chevron with a smooth anti-aliased versions. The size (which matches other UI elements by default) is configurable.
 
-This mod injects only in processes that have ExplorerFrame.dll, so the include is set to `*` but it will not touch most processes. You can set it to `explorer.exe` only, if you don't want the nav in Open/Save dialogs changed (only modern dialogs are affected.)
+This mod injects only in processes that use `ExplorerFrame.dll`, so the include is set to `*` but it will not touch most processes. You can set it to `explorer.exe` only, if you don't want the nav in Open/Save dialogs changed. Only "modern" dialogs are affected.
 
-Before:
+Before/after:
 
-![Before](https://i.imgur.com/eWSQRJb.png)
-
-After:
-
-![After](https://i.imgur.com/6IaHifm.png)
-
-The screenshots show the normal Desktop pinned to Quick Access in the before, and the mod with defaults set in the after.
+![](https://i.imgur.com/LZuqzMx.png)
 */
 // ==/WindhawkModReadme==
 
@@ -912,24 +906,22 @@ static void RestoreTree(HWND hTree)
 
     // Remove our roots
     RootShellItems roots;
-    if (roots.Create())
+    if (!roots.Create()) return;
+    roots.RemoveInsertableRoots(pNsc.get());
+
+    if (roots.items[NAV_DESKTOP] && pNscRaw)
     {
-        roots.RemoveInsertableRoots(pNsc.get());
+        g_inCustomAppend = true;
+        AppendRoot_orig(pNscRaw, roots.items[NAV_DESKTOP].get(), enumFlags, 0x1, pFilter.get());
+        g_inCustomAppend = false;
 
-        if (roots.items[NAV_DESKTOP] && pNscRaw)
-        {
-            g_inCustomAppend = true;
-            AppendRoot_orig(pNscRaw, roots.items[NAV_DESKTOP].get(), enumFlags, 0x1, pFilter.get());
-            g_inCustomAppend = false;
-
-            WCHAR collapseNames[NAV_COUNT][64] = {};
-            int collapseCount = BuildMatchList(collapseNames, NAV_COUNT,
-                [](int id, const NavItemSettings&) {
-                    return IsInsertableItem(id) && g_navItems[id].label[0];
-                });
-            if (collapseCount > 0)
-                CollapseMatchingItems(hTree, nullptr, collapseNames, collapseCount);
-        }
+        WCHAR collapseNames[NAV_COUNT][64] = {};
+        int collapseCount = BuildMatchList(collapseNames, NAV_COUNT,
+            [](int id, const NavItemSettings&) {
+                return IsInsertableItem(id) && g_navItems[id].label[0];
+            });
+        if (collapseCount > 0)
+            CollapseMatchingItems(hTree, nullptr, collapseNames, collapseCount);
     }
 
     RemoveWindowSubclass(hTree, TreeInteractionProc, 0xAF01);

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's navigation pane
-// @version         1.1
+// @version         1.1.1
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -160,6 +160,7 @@ static PIDLIST_ABSOLUTE g_pidlGallery = nullptr;
 static ULONG_PTR g_gdipToken = 0;
 static std::set<HWND> g_subclassedParents;
 static COLORREF g_sepColor = CLR_INVALID;
+static bool g_sepColorPendingVerify = false;
 static bool g_logSepDraw = true;
 
 // Per-tree state: one entry per SysTreeView32 that we've injected items into.
@@ -176,6 +177,8 @@ struct TreeState {
     HTREEITEM boundaryItem = nullptr;
     HTREEITEM belowQAItem = nullptr;
     bool qaCleanupDone = false;
+    bool qaEverCleaned = false;
+    bool dupCollapsesDone = false;
     bool homeGalleryCleanupDone = false;
     bool needHotInsert = false;
     bool needFullRebuild = false;
@@ -187,6 +190,22 @@ static std::unordered_map<HWND, TreeState> g_trees;
 static TreeState* GetTree(HWND hWnd) {
     auto it = g_trees.find(hWnd);
     return (it != g_trees.end()) ? &it->second : nullptr;
+}
+
+static bool IsNavPaneHost(HWND hTree)
+{
+    for (HWND h = GetAncestor(hTree, GA_ROOT); h; h = nullptr)
+    {
+        WCHAR cls[64];
+        if (GetClassNameW(h, cls, ARRAYSIZE(cls)))
+        {
+            if (wcscmp(cls, L"CabinetWClass") == 0)
+                return true;
+            if (wcscmp(cls, L"#32770") == 0)
+                return true;
+        }
+    }
+    return false;
 }
 
 static bool IsOurSection(const TreeState& ts, HTREEITEM h)
@@ -203,6 +222,8 @@ static void ResetTreeCleanup(TreeState& ts)
     ts.boundaryItem = nullptr;
     ts.belowQAItem = nullptr;
     ts.qaCleanupDone = false;
+    ts.qaEverCleaned = false;
+    ts.dupCollapsesDone = false;
     ts.homeGalleryCleanupDone = false;
 }
 
@@ -347,8 +368,11 @@ HRESULT THISCALL AppendRoot_hook(
                 bool hide = isHome ? g_settings.hideHome : g_settings.hideGallery;
                 if (hide)
                 {
-                    Wh_Log(L"[HOOK] Suppressing %s root",
-                           isHome ? L"Home" : L"Gallery");
+                    LPWSTR supName = nullptr;
+                    psiRoot->GetDisplayName(SIGDN_NORMALDISPLAY, &supName);
+                    Wh_Log(L"[HOOK] Suppressing '%s' root",
+                           supName ? supName : L"?");
+                    if (supName) CoTaskMemFree(supName);
                     return S_OK;
                 }
                 g_insertingItem = isHome ? 3 : 4;
@@ -651,24 +675,27 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
             if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rc))
                 ih = rc.bottom - rc.top;
 
-            WCHAR tag = L'.';
-
             if (IsOurSection(ts, h))
             {
                 passedOurSection = true;
-                if (h == ts.hThisPC || h == ts.hDesktop) tag = L'O';
-                else if (ts.hHome && h == ts.hHome) tag = L'H';
-                else tag = L'G';
+                if (g_logSepDraw && walkIdx < 60)
+                {
+                    if (h == ts.hThisPC || h == ts.hDesktop) walkLog[walkIdx++] = L'O';
+                    else if (ts.hHome && h == ts.hHome) walkLog[walkIdx++] = L'H';
+                    else walkLog[walkIdx++] = L'G';
+                }
             }
             else if (h == ts.hiddenDuplicate)
             {
-                tag = ts.dupAtBoundary ? L'D' : L'd';
+                if (g_logSepDraw && walkIdx < 60)
+                    walkLog[walkIdx++] = ts.dupAtBoundary ? L'D' : L'd';
             }
             else
             {
                 bool isTall = (ih >= tallThreshold);
                 bool drawSep = false;
                 int sepY = 0;
+                WCHAR tag = L'.';
 
                 if (passedOurSection && !foundBoundary)
                 {
@@ -702,10 +729,10 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
                     sepCount++;
                     DrawSeparatorLine(hdc, hTree, sepY);
                 }
-            }
 
-            if (walkIdx < 60)
-                walkLog[walkIdx++] = tag;
+                if (g_logSepDraw && walkIdx < 60)
+                    walkLog[walkIdx++] = tag;
+            }
         }
 
         h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
@@ -749,7 +776,8 @@ static LRESULT CALLBACK SepParentSubclassProc(
                     // Skipping DefSubclassProc suppresses ALL native separator
                     // lines but also prevents per-item custom draw
                     // (CDDS_ITEMPREPAINT) for other subclasses on this tree.
-                    if (hasItemsAtTop && g_sepColor != CLR_INVALID)
+                    if (hasItemsAtTop && g_sepColor != CLR_INVALID &&
+                        !g_sepColorPendingVerify)
                         return CDRF_NOTIFYPOSTPAINT;
                     LRESULT r = DefSubclassProc(hWnd, uMsg, wParam, lParam);
                     return r | CDRF_NOTIFYPOSTPAINT;
@@ -757,6 +785,27 @@ static LRESULT CALLBACK SepParentSubclassProc(
 
                 if (stage == CDDS_POSTPAINT)
                 {
+                    // Re-verify separator color after theme/syscolor
+                    // change. CDDS_PREPAINT let native separators
+                    // through so we can re-sample. If the color
+                    // changed, update and repaint; if same, just
+                    // repaint to re-suppress native separators.
+                    if (g_sepColorPendingVerify &&
+                        g_sepColor != CLR_INVALID &&
+                        (hasItemsAtTop || hasDupHide))
+                    {
+                        g_sepColorPendingVerify = false;
+                        COLORREF c = SampleSeparatorColor(hTree, cd->nmcd.hdc);
+                        if (c != CLR_INVALID && c != g_sepColor)
+                        {
+                            Wh_Log(L"[SEP] color changed 0x%06X -> 0x%06X tree=%p",
+                                   g_sepColor, c, hTree);
+                            g_sepColor = c;
+                            g_logSepDraw = true;
+                        }
+                        InvalidateRect(hTree, NULL, TRUE);
+                    }
+
                     if (g_sepColor == CLR_INVALID &&
                         (hasItemsAtTop || hasDupHide))
                     {
@@ -846,6 +895,9 @@ static LRESULT CALLBACK SepParentSubclassProc(
             {
                 LRESULT r = DefSubclassProc(hWnd, uMsg, wParam, lParam);
                 g_logSepDraw = true;
+                TreeState* tsExp = GetTree(hTree);
+                if (tsExp)
+                    tsExp->dupCollapsesDone = false;
                 InvalidateRect(hTree, NULL, TRUE);
                 return r;
             }
@@ -875,8 +927,7 @@ static LRESULT CALLBACK SepParentSubclassProc(
 
     if (uMsg == WM_THEMECHANGED || uMsg == WM_SYSCOLORCHANGE)
     {
-        g_sepColor = CLR_INVALID;
-        g_logSepDraw = true;
+        g_sepColorPendingVerify = true;
     }
 
     if (uMsg == WM_NCDESTROY)
@@ -1063,6 +1114,20 @@ static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
         h = hNext;
     }
 
+    // Freeze redraw during deletions to prevent Explorer from
+    // re-inserting items synchronously (which would reset cleanup
+    // flags via the TVM_INSERTITEM handler and cause a loop).
+    bool needDelete = (sectionCount > 0);
+    for (int i = 0; i < childlessCount && !needDelete; i++)
+    {
+        bool wouldKeep = (!g_settings.removeSepBelowNav &&
+                          toDeleteChildless[i] == hBoundaryPos);
+        if (!wouldKeep)
+            needDelete = true;
+    }
+    if (needDelete)
+        SendMessageW(hTree, WM_SETREDRAW, FALSE, 0);
+
     // Native sections with children: always delete (our items replace them)
     for (int i = 0; i < sectionCount; i++)
     {
@@ -1097,6 +1162,12 @@ static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
         Wh_Log(L"[QA-HIDE] deleting duplicate item=%p (boundary=%p)",
                toDeleteChildless[i], hBoundaryPos);
         SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDeleteChildless[i]);
+    }
+
+    if (needDelete)
+    {
+        SendMessageW(hTree, WM_SETREDRAW, TRUE, 0);
+        InvalidateRect(hTree, nullptr, TRUE);
     }
 
     if (ts.hiddenDuplicate != prevDup || sectionCount > 0)
@@ -1208,15 +1279,24 @@ static bool RemoveHomeGalleryItems(HWND hTree, TreeState& ts)
         h = hNext;
     }
 
+    if (delCount > 0)
+        SendMessageW(hTree, WM_SETREDRAW, FALSE, 0);
+
     for (int i = 0; i < delCount; i++)
     {
-        Wh_Log(L"[HIDE-%s] Deleting item=%p",
-               toDelete[i].isHome ? L"HOME" : L"GALLERY", toDelete[i].h);
+        Wh_Log(L"[HIDE] Deleting '%s' item=%p",
+               toDelete[i].isHome ? homeName : galleryName, toDelete[i].h);
         SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDelete[i].h);
         if (toDelete[i].isHome)
             ts.hHome = nullptr;
         else
             ts.hGallery = nullptr;
+    }
+
+    if (delCount > 0)
+    {
+        SendMessageW(hTree, WM_SETREDRAW, TRUE, 0);
+        InvalidateRect(hTree, nullptr, TRUE);
     }
 
     return (delCount >= expectedCount);
@@ -1284,6 +1364,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
             {
                 bool isThisPC = (g_insertingItem == 1);
                 g_insertingItem = 0;
+                if (!GetTree(hWnd) && !IsNavPaneHost(hWnd))
+                    return result;
                 auto [it, _] = g_trees.try_emplace(hWnd);
                 TreeState& ts = it->second;
                 (isThisPC ? ts.hThisPC : ts.hDesktop) = hNew;
@@ -1309,11 +1391,14 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
             {
                 bool isHome = (g_insertingItem == 3);
                 g_insertingItem = 0;
+                if (!GetTree(hWnd) && !IsNavPaneHost(hWnd))
+                    return result;
                 auto [it, _] = g_trees.try_emplace(hWnd);
                 TreeState& ts = it->second;
                 (isHome ? ts.hHome : ts.hGallery) = hNew;
-                Wh_Log(L"[CACHE] %s item=%p tree=%p",
-                       isHome ? L"Home" : L"Gallery", hNew, hWnd);
+                WCHAR itemText[64] = {};
+                GetItemText(hWnd, hNew, itemText, ARRAYSIZE(itemText));
+                Wh_Log(L"[CACHE] '%s' item=%p tree=%p", itemText, hNew, hWnd);
                 bool hidden = isHome ? g_settings.hideHome : g_settings.hideGallery;
                 if (!hidden &&
                     (g_settings.showThisPCAtTop || g_settings.showDesktopAtTop))
@@ -1330,8 +1415,40 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
                 TreeState* ts = GetTree(hWnd);
                 if (ts && IsDepth1Item(hWnd, hNew))
                 {
-                    ts->homeGalleryCleanupDone = false;
-                    if (ts->qaCleanupDone)
+                    if (g_settings.hideHome || g_settings.hideGallery)
+                    {
+                        WCHAR homeName[64] = {}, galleryName[64] = {};
+                        ResolveHomeGalleryNames(homeName, ARRAYSIZE(homeName),
+                                                galleryName, ARRAYSIZE(galleryName));
+                        WCHAR itemText[64] = {};
+                        GetItemText(hWnd, hNew, itemText, ARRAYSIZE(itemText));
+                        bool isHome = g_settings.hideHome && homeName[0] &&
+                                      wcscmp(itemText, homeName) == 0;
+                        bool isGallery = g_settings.hideGallery && galleryName[0] &&
+                                         wcscmp(itemText, galleryName) == 0;
+                        if (isHome || isGallery)
+                        {
+                            bool nearOurSection = false;
+                            HTREEITEM hPrev = hNew;
+                            for (int walk = 0; walk < 6 && hPrev; walk++)
+                            {
+                                hPrev = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM,
+                                    TVGN_PREVIOUS, (LPARAM)hPrev);
+                                if (hPrev && IsOurSection(*ts, hPrev))
+                                {
+                                    nearOurSection = true;
+                                    break;
+                                }
+                            }
+                            if (nearOurSection)
+                            {
+                                ts->homeGalleryCleanupDone = false;
+                                Wh_Log(L"[INSERT] '%s' item=%p tree=%p",
+                                       itemText, hNew, hWnd);
+                            }
+                        }
+                    }
+                    if (!ts->qaEverCleaned && ts->qaCleanupDone)
                     {
                         ts->qaCleanupDone = false;
                         ts->hiddenDuplicate = nullptr;
@@ -1542,6 +1659,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
              (g_settings.showDesktopAtTop && g_settings.hideDesktopFromQuickAccess)))
         {
             ts->qaCleanupDone = CleanupQuickAccessDuplicates(hWnd, *ts);
+            if (ts->qaCleanupDone)
+                ts->qaEverCleaned = true;
         }
 
         // Collapse visible duplicates of our items so they don't
@@ -1585,8 +1704,9 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
                 }
             }
 
-            if (collapseCount > 0)
+            if (collapseCount > 0 && !ts->dupCollapsesDone)
             {
+                ts->dupCollapsesDone = true;
                 HTREEITEM h = GetFirstDepth1Child(hWnd);
                 while (h)
                 {
@@ -1916,7 +2036,6 @@ void Wh_ModAfterInit()
 {
     std::vector<DiscoveredTree> discovered;
 
-    DWORD pid = GetCurrentProcessId();
     EnumWindows([](HWND hTop, LPARAM lParam) -> BOOL {
         auto& out = *reinterpret_cast<std::vector<DiscoveredTree>*>(lParam);
 
@@ -2039,7 +2158,6 @@ static void RefreshNavPane(HWND hTree)
         pFilter->Release();
     pNsc->Release();
 
-    g_logSepDraw = true;
     RedrawWindow(hTree, nullptr, nullptr,
                  RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
 }
@@ -2290,9 +2408,14 @@ void Wh_ModSettingsChanged()
         else
         {
             if (homeGalleryChanged)
+            {
                 ts->homeGalleryCleanupDone = false;
+            }
             if (dedupChanged)
+            {
                 ts->qaCleanupDone = false;
+                ts->qaEverCleaned = false;
+            }
             if (sepChanged || dedupChanged)
             {
                 ts->boundaryItem = nullptr;

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.20
+// @version         1.1.21
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -335,9 +335,10 @@ using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 LoadLibraryExW_t LoadLibraryExW_orig;
 static std::atomic<bool> g_explorerFrameLoaded{false};
 
-static std::atomic<bool> g_deferredOpInProgress{false};
-static std::atomic<HWND> g_mutatingTree{nullptr};
-static std::unordered_set<HWND> g_pendingRebuildTrees;
+static thread_local bool g_deferredOpInProgress = false;
+static thread_local HWND g_mutatingTree = nullptr;
+static std::atomic<bool> g_uninitInProgress{false};
+static thread_local std::unordered_set<HWND> g_pendingRebuildTrees;
 
 #define WM_DEFERRED_REBUILD  (WM_APP + 0x101)
 
@@ -1407,7 +1408,7 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
         if (hdr && hdr->hwndFrom == hTree)
         {
             if ((hdr->code == TVN_SELCHANGEDW || hdr->code == TVN_SELCHANGEDA) &&
-                hTree == g_mutatingTree)
+                (hTree == g_mutatingTree || g_uninitInProgress.load(std::memory_order_relaxed)))
                 return 0;
 
             if (hdr->code == (UINT)NM_CUSTOMDRAW && hTree != g_mutatingTree)
@@ -2588,15 +2589,15 @@ void Wh_ModUninit()
             uninitList.push_back(hTree);
     }
 
+    g_uninitInProgress.store(true, std::memory_order_release);
     for (HWND hTree : uninitList)
     {
-        g_mutatingTree = hTree;
         RestoreTree(hTree);
-        g_mutatingTree = nullptr;
         if (IsWindow(hTree))
             RedrawWindow(hTree, nullptr, nullptr,
                          RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
     }
+    g_uninitInProgress.store(false, std::memory_order_release);
 
     for (HWND parent : g_subclassedParents)
     {
@@ -2622,7 +2623,6 @@ void Wh_ModUninit()
             }
         }
         g_trees.clear();
-        g_pendingRebuildTrees.clear();
     }
 
     if (g_gdipToken) { Gdiplus::GdiplusShutdown(g_gdipToken); g_gdipToken = 0; }

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.2
+// @version         1.1.3
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -840,7 +840,11 @@ static void RestoreTree(HWND hTree)
         if (ownsRef)
             ts->ownsNscRef = false;
         ts->pNscTree = nullptr;
-        ts->pFilter = nullptr;
+        if (ts->pFilter)
+        {
+            ts->pFilter->Release();
+            ts->pFilter = nullptr;
+        }
     }
 
     // Release TreeState's ownership ref (separate from our ComRef AddRef)
@@ -848,7 +852,7 @@ static void RestoreTree(HWND hTree)
         pNsc.p->Release();
 
     Wh_Log(L"[DISABLE] Cleaned up tree=%p", hTree);
-    // ComRef destructors release our local AddRefs (pFilter, pNsc, pDesktop, pThisPC)
+    // ComRef destructors release our local AddRefs (pFilter, pNsc)
 }
 
 static void FullRebuildTree(HWND hTree)
@@ -1523,6 +1527,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
 
                 if (IsInsertableItem(id))
                 {
+                    ts.hiddenDuplicate = nullptr;
                     ts.pendingWork |= WORK_QA_CLEANUP;
                     if (!ts.pNscTree)
                     {
@@ -1735,6 +1740,26 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         TreeState* ts = GetTree(hWnd);
         ts = RunDeferredWork(hWnd, ts, WORK_FULL_REBUILD, FullRebuildTree);
         ts = RunDeferredWork(hWnd, ts, WORK_HOT_INSERT, HotEnableInsert);
+
+        if (ts && (ts->pendingWork & WORK_QA_CLEANUP) &&
+            ((g_settings.items[NAV_THISPC].showAtTop && g_settings.items[NAV_THISPC].hideFromQA) ||
+             (g_settings.items[NAV_DESKTOP].showAtTop && g_settings.items[NAV_DESKTOP].hideFromQA)))
+        {
+            if (CleanupQuickAccessDuplicates(hWnd, *ts))
+            {
+                ts->pendingWork &= ~WORK_QA_CLEANUP;
+                ts->qaEverCleaned = true;
+            }
+            ts = GetTree(hWnd);
+        }
+
+        if (ts && (ts->pendingWork & WORK_HG_CLEANUP) && ts->pNscTree &&
+            (g_navItems[NAV_HOME].pidl || g_navItems[NAV_GALLERY].pidl) &&
+            (g_settings.items[NAV_HOME].hide || g_settings.items[NAV_GALLERY].hide))
+        {
+            if (RemoveHiddenInheritedItems(hWnd, *ts))
+                ts->pendingWork &= ~WORK_HG_CLEANUP;
+        }
         return 0;
     }
 
@@ -1749,42 +1774,21 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         ts = RunDeferredWork(hWnd, ts, WORK_FULL_REBUILD, FullRebuildTree, true);
         ts = RunDeferredWork(hWnd, ts, WORK_HOT_INSERT, HotEnableInsert, true);
 
-        if (ts && (ts->pendingWork & WORK_QA_CLEANUP) &&
-            ((g_settings.items[NAV_THISPC].showAtTop && g_settings.items[NAV_THISPC].hideFromQA) ||
-             (g_settings.items[NAV_DESKTOP].showAtTop && g_settings.items[NAV_DESKTOP].hideFromQA)))
-        {
-            if (CleanupQuickAccessDuplicates(hWnd, *ts))
-            {
-                ts->pendingWork &= ~WORK_QA_CLEANUP;
-                ts->qaEverCleaned = true;
-            }
-        }
+        // TVM_DELETEITEM during paint crashes (TV_SelectItem re-entrancy)
+        if (ts && (ts->pendingWork & (WORK_QA_CLEANUP | WORK_HG_CLEANUP)))
+            PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
 
-        // Collapse visible duplicates of our items so they don't
-        // mirror the expanded state of our top copies. Runs whenever
-        // a dup is visible: parent off (dup never hidden) or parent
-        // on but not hiding from nav. Uses PIDL fallback for names
-        // when our item handle doesn't exist.
         if (ts && (ts->pendingWork & WORK_DUP_COLLAPSE))
         {
             WCHAR collapseText[NAV_COUNT][64] = {};
             int collapseCount = BuildMatchList(collapseText, NAV_COUNT,
                 [](int id, const NavItemSettings& s) {
-                    return IsInsertableItem(id) && !(s.showAtTop && s.hideFromQA);
+                    return IsInsertableItem(id) && s.showAtTop && !s.hideFromQA;
                 });
 
             ts->pendingWork &= ~WORK_DUP_COLLAPSE;
             if (collapseCount > 0)
                 CollapseMatchingItems(hWnd, ts, collapseText, collapseCount);
-        }
-
-        // Remove hidden inherited items (Home/Gallery) by PIDL
-        if (ts && (ts->pendingWork & WORK_HG_CLEANUP) && ts->pNscTree &&
-            (g_navItems[NAV_HOME].pidl || g_navItems[NAV_GALLERY].pidl) &&
-            (g_settings.items[NAV_HOME].hide || g_settings.items[NAV_GALLERY].hide))
-        {
-            if (RemoveHiddenInheritedItems(hWnd, *ts))
-                ts->pendingWork &= ~WORK_HG_CLEANUP;
         }
 
         // Collapse iIntegral on visible inherited items so there's no
@@ -2074,7 +2078,10 @@ void Wh_ModAfterInit()
             return TRUE;
         WCHAR cls[64];
         GetClassNameW(hTop, cls, ARRAYSIZE(cls));
-        if (wcscmp(cls, L"CabinetWClass") != 0)
+
+        bool isCabinet = (wcscmp(cls, L"CabinetWClass") == 0);
+        bool isDialog = (wcscmp(cls, L"#32770") == 0);
+        if (!isCabinet && !isDialog)
             return TRUE;
 
         HWND hShellTab = FindWindowExW(hTop, nullptr, L"ShellTabWindowClass", nullptr);
@@ -2084,17 +2091,26 @@ void Wh_ModAfterInit()
         if (!pSB)
             pSB = (IShellBrowser *)SendMessageW(hTop, WM_USER + 7, 0, 0);
         if (!pSB)
+        {
+            Wh_Log(L"[DISCOVER] %s hwnd=%p — no IShellBrowser", cls, hTop);
             return TRUE;
+        }
 
         IServiceProvider *pSP = nullptr;
         if (FAILED(pSB->QueryInterface(IID_IServiceProvider, (void **)&pSP)))
+        {
+            Wh_Log(L"[DISCOVER] %s hwnd=%p — no IServiceProvider", cls, hTop);
             return TRUE;
+        }
 
         INameSpaceTreeControl *pNsc = nullptr;
         HRESULT hr = pSP->QueryService(IID_INameSpaceTreeControl, IID_INameSpaceTreeControl, (void **)&pNsc);
         pSP->Release();
         if (FAILED(hr))
+        {
+            Wh_Log(L"[DISCOVER] %s hwnd=%p — no INameSpaceTreeControl (hr=0x%08X)", cls, hTop, hr);
             return TRUE;
+        }
 
         HWND hTree = nullptr;
         IOleWindow *pOleWin = nullptr;
@@ -2108,6 +2124,7 @@ void Wh_ModAfterInit()
 
         if (!hTree)
         {
+            Wh_Log(L"[DISCOVER] %s hwnd=%p — no SysTreeView32", cls, hTop);
             pNsc->Release();
             return TRUE;
         }
@@ -2117,6 +2134,7 @@ void Wh_ModAfterInit()
         if (!enumFlags)
             enumFlags = SHCONTF_FOLDERS;
 
+        Wh_Log(L"[DISCOVER] %s hwnd=%p tree=%p pNsc=%p — accepted", cls, hTop, hTree, pNsc);
         out.push_back({ hTop, hTree, pNsc, enumFlags });
         return TRUE;
     }, (LPARAM)&discovered);

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.19
+// @version         1.1.20
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -104,6 +104,7 @@ Before/after:
 #include <uxtheme.h>
 #include <gdiplus.h>
 #include <atomic>
+#include <mutex>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -243,8 +244,10 @@ struct TreeState {
     HIMAGELIST savedStateImageList = nullptr;
 };
 static std::unordered_map<HWND, TreeState> g_trees;
+static std::recursive_mutex g_treesMutex;
 
 static TreeState* GetTree(HWND hWnd) {
+    std::lock_guard<std::recursive_mutex> lock(g_treesMutex);
     auto it = g_trees.find(hWnd);
     return (it != g_trees.end()) ? &it->second : nullptr;
 }
@@ -332,12 +335,20 @@ using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 LoadLibraryExW_t LoadLibraryExW_orig;
 static std::atomic<bool> g_explorerFrameLoaded{false};
 
-// Guards are static (not thread_local) because Wh_ModInit runs on the loader thread but hooks fire on the UI thread.
-static bool g_deferredOpInProgress = false;
-static HWND g_mutatingTree = nullptr;
+static std::atomic<bool> g_deferredOpInProgress{false};
+static std::atomic<HWND> g_mutatingTree{nullptr};
 static std::unordered_set<HWND> g_pendingRebuildTrees;
 
 #define WM_DEFERRED_REBUILD  (WM_APP + 0x101)
+
+#define WM_SETTINGS_CHANGED  (WM_APP + 0x102)
+#define WM_RESTORE_TREE      (WM_APP + 0x103)
+
+struct SettingsChangeInfo {
+    ChangeTier tier;
+    Settings prev;
+    bool sepChanged;
+};
 
 static void DrainPendingRebuilds()
 {
@@ -540,10 +551,16 @@ HRESULT THISCALL AppendRoot_hook(void *pThis, IShellItem *psiRoot, unsigned long
     }
 
     if (g_inCustomAppend)
+    {
+        Wh_Log(L"[APPEND] passthrough (g_inCustomAppend) tree=%04X style=%lX thread=%u",
+               PTR4(hForTree), grfRootStyle, GetCurrentThreadId());
         return AppendRoot_orig(pThis, psiRoot, grfEnumFlags, grfRootStyle, pFilter);
+    }
 
     bool isHiddenRoot = (grfRootStyle & 0x1) != 0;
     bool wantItems = isHiddenRoot && g_settings.hasItemsAtTop;
+    Wh_Log(L"[APPEND] tree=%04X hidden=%d wantItems=%d style=%lX thread=%u",
+           PTR4(hForTree), (int)isHiddenRoot, (int)wantItems, grfRootStyle, GetCurrentThreadId());
 
     HRESULT hr = AppendRoot_orig(pThis, psiRoot, grfEnumFlags, grfRootStyle, pFilter);
 
@@ -947,11 +964,30 @@ static void RemoveHomeSpacer(TreeState& ts, INameSpaceTreeControl* pNsc)
     ts.homeSpacerItem = nullptr;
 }
 
+static LRESULT CALLBACK SepParentSubclassProc(HWND, UINT, WPARAM, LPARAM, DWORD_PTR);
+
+static void EnsureParentSubclass(HWND hTree)
+{
+    HWND parent = GetParent(hTree);
+    if (!parent)
+        return;
+    if (g_subclassedParents.count(parent))
+        return;
+    bool ok = WindhawkUtils::SetWindowSubclassFromAnyThread(parent, SepParentSubclassProc, (DWORD_PTR)hTree);
+    Wh_Log(L"[SEP-PARENT] parent=%04X tree=%04X ok=%d", PTR4(parent), PTR4(hTree), ok);
+    if (ok)
+        g_subclassedParents.insert(parent);
+}
+
 static void RestoreTree(HWND hTree)
 {
+    Wh_Log(L"[RESTORE] tree=%04X thread=%u", PTR4(hTree), GetCurrentThreadId());
     TreeState* ts = GetTree(hTree);
     if (!ts || !IsWindow(hTree) || !ts->pNscTree)
+    {
+        Wh_Log(L"[RESTORE] bail: ts=%p isWindow=%d pNsc=%p", ts, IsWindow(hTree), ts ? ts->pNscTree : nullptr);
         return;
+    }
 
     void *pNscRaw = ts->pNscTree;
     unsigned long enumFlags = ts->enumFlags;
@@ -1022,6 +1058,11 @@ static void FullRebuildTree(HWND hTree)
     if (!ts || !ts->pNscTree || !IsWindow(hTree))
         return;
 
+    EnsureParentSubclass(hTree);
+
+    HTREEITEM hSelBefore = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_CARET, 0);
+    Wh_Log(L"[REBUILD-START] tree=%04X sel=%04X thread=%u", PTR4(hTree), PTR4(hSelBefore), GetCurrentThreadId());
+
     ComRef<INameSpaceTreeControl> pNsc((INameSpaceTreeControl *)ts->pNscTree);
     void *pNscRaw = ts->pNscTree;
     unsigned long enumFlags = ts->enumFlags;
@@ -1075,9 +1116,11 @@ static void FullRebuildTree(HWND hTree)
         }
         ResetSepColor();
 
+        HTREEITEM hSelAfter = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_CARET, 0);
         InvalidateRect(hTree, nullptr, TRUE);
-        Wh_Log(L"[REBUILD] tree=%04X hHome=%04X hGallery=%04X",
-               PTR4(hTree), PTR4(ts ? ts->hItems[NAV_HOME] : nullptr), PTR4(ts ? ts->hItems[NAV_GALLERY] : nullptr));
+        Wh_Log(L"[REBUILD-END] tree=%04X sel=%04X→%04X hHome=%04X hGallery=%04X",
+               PTR4(hTree), PTR4(hSelBefore), PTR4(hSelAfter),
+               PTR4(ts ? ts->hItems[NAV_HOME] : nullptr), PTR4(ts ? ts->hItems[NAV_GALLERY] : nullptr));
     }
 }
 
@@ -1363,6 +1406,10 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
         LPNMHDR hdr = (LPNMHDR)lParam;
         if (hdr && hdr->hwndFrom == hTree)
         {
+            if ((hdr->code == TVN_SELCHANGEDW || hdr->code == TVN_SELCHANGEDA) &&
+                hTree == g_mutatingTree)
+                return 0;
+
             if (hdr->code == (UINT)NM_CUSTOMDRAW && hTree != g_mutatingTree)
             {
                 LPNMTVCUSTOMDRAW cd = (LPNMTVCUSTOMDRAW)lParam;
@@ -1451,19 +1498,6 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
         g_subclassedParents.erase(hWnd);
 
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
-}
-
-static void EnsureParentSubclass(HWND hTree)
-{
-    HWND parent = GetParent(hTree);
-    if (!parent)
-        return;
-    if (g_subclassedParents.count(parent))
-        return;
-    bool ok = WindhawkUtils::SetWindowSubclassFromAnyThread(parent, SepParentSubclassProc, (DWORD_PTR)hTree);
-    Wh_Log(L"[SEP-PARENT] parent=%04X tree=%04X ok=%d", PTR4(parent), PTR4(hTree), ok);
-    if (ok)
-        g_subclassedParents.insert(parent);
 }
 
 // Returns false if expected dups are missing (async population race).
@@ -1640,6 +1674,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             {
                 int id = g_ins.item;
                 g_ins.item = -1;
+                std::lock_guard<std::recursive_mutex> lock(g_treesMutex);
                 if (!GetTree(hWnd) && !IsNavPaneHost(hWnd))
                     return result;
                 auto [it, _] = g_trees.try_emplace(hWnd);
@@ -1839,6 +1874,73 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         return 0;
     }
 
+    if (uMsg == WM_SETTINGS_CHANGED)
+    {
+        auto* info = reinterpret_cast<SettingsChangeInfo*>(lParam);
+        HTREEITEM hSel = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM, TVGN_CARET, 0);
+        Wh_Log(L"[SETTINGS-MSG] tree=%04X tier=%d sel=%04X thread=%u",
+               PTR4(hWnd), (int)info->tier, PTR4(hSel), GetCurrentThreadId());
+        TreeState* ts = GetTree(hWnd);
+        if (!ts || !IsWindow(hWnd) || !ts->pNscTree)
+            return 0;
+
+        ts->sepRetries = 0;
+
+        if (info->tier == TIER_REBUILD)
+        {
+            g_deferredOpInProgress = true;
+            g_mutatingTree = hWnd;
+            FullRebuildTree(hWnd);
+            DrainPendingRebuilds();
+        }
+        else if (info->tier == TIER_REFRESH)
+        {
+            ts->boundaryItem = nullptr;
+            ts->belowQAItem = nullptr;
+            ts->pendingWork |= WORK_QA_CLEANUP;
+            RefreshNavPane(hWnd);
+        }
+        else // TIER_REPAINT
+        {
+            bool homeGalleryChanged = (info->prev.items[NAV_HOME].hide    != g_settings.items[NAV_HOME].hide ||
+                                       info->prev.items[NAV_GALLERY].hide != g_settings.items[NAV_GALLERY].hide);
+            bool dedupChanged = false;
+            for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
+                if (g_settings.items[i].showAtTop && info->prev.items[i].hideFromQA != g_settings.items[i].hideFromQA)
+                    dedupChanged = true;
+
+            if (homeGalleryChanged)
+            {
+                for (int j = NAV_HOME; j < NAV_COUNT; j++)
+                    if (g_settings.items[j].hide)
+                        ts->hItems[j] = nullptr;
+                ts->pendingWork |= WORK_HG_CLEANUP;
+            }
+            if (dedupChanged)
+                ts->pendingWork |= WORK_QA_CLEANUP;
+            if (info->sepChanged || dedupChanged)
+            {
+                ts->boundaryItem = nullptr;
+                ts->belowQAItem = nullptr;
+            }
+
+            InvalidateRect(hWnd, nullptr, TRUE);
+        }
+        return 0;
+    }
+
+    if (uMsg == WM_RESTORE_TREE)
+    {
+        Wh_Log(L"[RESTORE-MSG] tree=%04X thread=%u", PTR4(hWnd), GetCurrentThreadId());
+        g_mutatingTree = hWnd;
+        RestoreTree(hWnd);
+        g_mutatingTree = nullptr;
+        if (IsWindow(hWnd))
+            RedrawWindow(hWnd, nullptr, nullptr,
+                         RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+        return 0;
+    }
+
     if (uMsg == WM_PAINT)
     {
         TreeState* ts = GetTree(hWnd);
@@ -1972,16 +2074,23 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
     {
         RemovePropW(hWnd, L"WH_NscTree");
         RemovePropW(hWnd, L"WH_EnumFlags");
-        auto it = g_trees.find(hWnd);
-        if (it != g_trees.end())
+        IShellItemFilter *pf = nullptr;
+        INameSpaceTreeControl *pNsc = nullptr;
         {
-            IShellItemFilter *pf = it->second.pFilter;
-            it->second.pFilter = nullptr;
-            INameSpaceTreeControl *pNsc = nullptr;
-            if (it->second.ownsNscRef && it->second.pNscTree)
-                pNsc = (INameSpaceTreeControl *)it->second.pNscTree;
-            it->second.pNscTree = nullptr;
-            g_trees.erase(it);
+            std::lock_guard<std::recursive_mutex> lock(g_treesMutex);
+            auto it = g_trees.find(hWnd);
+            if (it != g_trees.end())
+            {
+                pf = it->second.pFilter;
+                it->second.pFilter = nullptr;
+                if (it->second.ownsNscRef && it->second.pNscTree)
+                    pNsc = (INameSpaceTreeControl *)it->second.pNscTree;
+                it->second.pNscTree = nullptr;
+                g_trees.erase(it);
+            }
+        }
+        if (pf || pNsc)
+        {
             if (pf)
                 pf->Release();
             if (pNsc)
@@ -2330,19 +2439,22 @@ void Wh_ModAfterInit()
 
     for (auto& d : discovered)
     {
-        // Release the ref we took; nothing else will.
         if (!IsWindow(d.hTree))
         {
             d.pNsc->Release();
             continue;
         }
-        TreeState& ts = g_trees[d.hTree];
-        ts.pNscTree = (void *)d.pNsc;
-        ts.enumFlags = d.enumFlags;
-        ts.pendingWork |= WORK_FULL_REBUILD;
-        ts.ownsNscRef = true;
 
-        SetPropW(d.hTree, L"WH_NscTree", (HANDLE)ts.pNscTree);
+        {
+            std::lock_guard<std::recursive_mutex> lock(g_treesMutex);
+            TreeState& ts = g_trees[d.hTree];
+            ts.pNscTree = (void *)d.pNsc;
+            ts.enumFlags = d.enumFlags;
+            ts.pendingWork |= WORK_FULL_REBUILD;
+            ts.ownsNscRef = true;
+        }
+
+        SetPropW(d.hTree, L"WH_NscTree", (HANDLE)d.pNsc);
         SetPropW(d.hTree, L"WH_EnumFlags", (HANDLE)(ULONG_PTR)d.enumFlags);
 
         PostMessage(d.hTree, WM_DEFERRED_REBUILD, 0, 0);
@@ -2435,70 +2547,25 @@ void Wh_ModSettingsChanged()
         if (tier == TIER_NONE)
             break;
 
-        // Snapshot HWNDs: FullRebuildTree pumps messages, which can rehash g_trees mid-iteration.
-        std::vector<HWND> treeList;
-        treeList.reserve(g_trees.size());
-        for (auto& [hTree, ts] : g_trees)
-        {
-            ts.sepRetries = 0;
-            treeList.push_back(hTree);
-        }
-        int treeCount = (int)treeList.size();
-
         bool sepChanged = (prev.removeSepBelowNav != g_settings.removeSepBelowNav ||
                            prev.removeSepBelowQA  != g_settings.removeSepBelowQA);
         if (sepChanged)
             ResetSepColor();
 
-        for (int i = 0; i < treeCount; i++)
+        SettingsChangeInfo info = { tier, prev, sepChanged };
+
+        std::vector<HWND> treeList;
         {
-            HWND hTree = treeList[i];
-            TreeState* ts = GetTree(hTree);
-            if (!ts || !IsWindow(hTree) || !ts->pNscTree)
-                continue;
+            std::lock_guard<std::recursive_mutex> lock(g_treesMutex);
+            treeList.reserve(g_trees.size());
+            for (auto& [hTree, ts] : g_trees)
+                treeList.push_back(hTree);
+        }
 
-            if (tier == TIER_REBUILD)
-            {
-                g_deferredOpInProgress = true;
-                g_mutatingTree = hTree;
-                FullRebuildTree(hTree);
-                DrainPendingRebuilds();
-            }
-            else if (tier == TIER_REFRESH)
-            {
-                ts->boundaryItem = nullptr;
-                ts->belowQAItem = nullptr;
-                ts->pendingWork |= WORK_QA_CLEANUP;
-                RefreshNavPane(hTree);
-            }
-            else // TIER_REPAINT
-            {
-                bool homeGalleryChanged = (prev.items[NAV_HOME].hide    != g_settings.items[NAV_HOME].hide ||
-                                           prev.items[NAV_GALLERY].hide != g_settings.items[NAV_GALLERY].hide);
-                bool dedupChanged = false;
-                for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
-                    if (g_settings.items[i].showAtTop && prev.items[i].hideFromQA != g_settings.items[i].hideFromQA)
-                        dedupChanged = true;
-
-                if (homeGalleryChanged)
-                {
-                    for (int j = NAV_HOME; j < NAV_COUNT; j++)
-                        if (g_settings.items[j].hide)
-                            ts->hItems[j] = nullptr;
-                    ts->pendingWork |= WORK_HG_CLEANUP;
-                }
-                if (dedupChanged)
-                {
-                    ts->pendingWork |= WORK_QA_CLEANUP;
-                }
-                if (sepChanged || dedupChanged)
-                {
-                    ts->boundaryItem = nullptr;
-                    ts->belowQAItem = nullptr;
-                }
-
-                InvalidateRect(hTree, nullptr, TRUE);
-            }
+        for (HWND hTree : treeList)
+        {
+            if (IsWindow(hTree))
+                SendMessage(hTree, WM_SETTINGS_CHANGED, 0, (LPARAM)&info);
         }
 
         if (!prev.hasItemsAtTop && g_settings.hasItemsAtTop)
@@ -2510,26 +2577,27 @@ void Wh_ModSettingsChanged()
 
 void Wh_ModUninit()
 {
-    // Clear state so hooks become no-ops
     g_settings = {};
     ResetSepColor();
 
-    // Snapshot HWNDs: AppendRoot_orig pumps messages, which can rehash g_trees mid-iteration.
     std::vector<HWND> uninitList;
-    uninitList.reserve(g_trees.size());
-    for (auto& [hTree, ts] : g_trees)
-        uninitList.push_back(hTree);
-
-    for (int i = 0; i < (int)uninitList.size(); i++)
     {
-        HWND hTree = uninitList[i];
+        std::lock_guard<std::recursive_mutex> lock(g_treesMutex);
+        uninitList.reserve(g_trees.size());
+        for (auto& [hTree, ts] : g_trees)
+            uninitList.push_back(hTree);
+    }
+
+    for (HWND hTree : uninitList)
+    {
+        g_mutatingTree = hTree;
         RestoreTree(hTree);
+        g_mutatingTree = nullptr;
         if (IsWindow(hTree))
             RedrawWindow(hTree, nullptr, nullptr,
                          RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
     }
 
-    // Remove all parent subclasses
     for (HWND parent : g_subclassedParents)
     {
         if (IsWindow(parent))
@@ -2537,23 +2605,25 @@ void Wh_ModUninit()
     }
     g_subclassedParents.clear();
 
-    // Release straggler refs from trees that RestoreTree didn't fully process
-    for (auto& [h, ts] : g_trees)
     {
-        if (ts.pFilter)
+        std::lock_guard<std::recursive_mutex> lock(g_treesMutex);
+        for (auto& [h, ts] : g_trees)
         {
-            ts.pFilter->Release();
-            ts.pFilter = nullptr;
+            if (ts.pFilter)
+            {
+                ts.pFilter->Release();
+                ts.pFilter = nullptr;
+            }
+            if (ts.ownsNscRef && ts.pNscTree)
+            {
+                ((INameSpaceTreeControl *)ts.pNscTree)->Release();
+                ts.pNscTree = nullptr;
+                ts.ownsNscRef = false;
+            }
         }
-        if (ts.ownsNscRef && ts.pNscTree)
-        {
-            ((INameSpaceTreeControl *)ts.pNscTree)->Release();
-            ts.pNscTree = nullptr;
-            ts.ownsNscRef = false;
-        }
+        g_trees.clear();
+        g_pendingRebuildTrees.clear();
     }
-    g_trees.clear();
-    g_pendingRebuildTrees.clear();
 
     if (g_gdipToken) { Gdiplus::GdiplusShutdown(g_gdipToken); g_gdipToken = 0; }
     for (int i = 0; i < NAV_COUNT; i++)
@@ -2561,5 +2631,6 @@ void Wh_ModUninit()
     g_ins.pNsc = nullptr;
     g_ins.enumFlags = 0;
     if (g_ins.filter) { g_ins.filter->Release(); g_ins.filter = nullptr; }
-    Wh_Log(L"Mod uninitialized");
+    if (g_explorerFrameLoaded.load(std::memory_order_relaxed))
+        Wh_Log(L"Mod uninitialized");
 }

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.15
+// @version         1.1.16
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -197,6 +197,7 @@ static ULONG_PTR g_gdipToken = 0;
 static std::set<HWND> g_subclassedParents;
 static COLORREF g_sepColor = CLR_INVALID;
 static bool g_logSepDraw = true;
+#define PTR4(p) ((unsigned)(uintptr_t)(p) & 0xFFFF)
 
 static void ResetSepColor() {
     g_sepColor = CLR_INVALID;
@@ -656,7 +657,7 @@ static bool CollapseItemIntegral(HWND hTree, HTREEITEM h)
     SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
     if (tvi.iIntegral >= 2)
     {
-        Wh_Log(L"[COLLAPSE] tree=%p item=%p int=%d->1", hTree, h, tvi.iIntegral);
+        Wh_Log(L"[COLLAPSE] tree=%04X item=%04X int=%d->1", PTR4(hTree), PTR4(h), tvi.iIntegral);
         tvi.iIntegral = 1;
         SendMessageW(hTree, TVM_SETITEMW, 0, (LPARAM)&tvi);
         return true;
@@ -852,9 +853,9 @@ static void InsertOurItems(HWND hTree, unsigned flags)
         RedrawWindow(hTree, nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
     else
     {
-        Wh_Log(L"[HOTINSERT] Items inserted, ThisPC=%p Desktop=%p Home=%p Gallery=%p",
-               ts ? ts->hItems[NAV_THISPC] : nullptr, ts ? ts->hItems[NAV_DESKTOP] : nullptr,
-               ts ? ts->hItems[NAV_HOME] : nullptr, ts ? ts->hItems[NAV_GALLERY] : nullptr);
+        Wh_Log(L"[HOTINSERT] ThisPC=%04X Desktop=%04X Home=%04X Gallery=%04X",
+               PTR4(ts ? ts->hItems[NAV_THISPC] : nullptr), PTR4(ts ? ts->hItems[NAV_DESKTOP] : nullptr),
+               PTR4(ts ? ts->hItems[NAV_HOME] : nullptr), PTR4(ts ? ts->hItems[NAV_GALLERY] : nullptr));
         InvalidateRect(hTree, nullptr, TRUE); // not RDW_UPDATENOW: inside WM_PAINT
     }
 }
@@ -959,7 +960,6 @@ static void RestoreTree(HWND hTree)
     if (savedImgList)
     {
         SendMessageW(hTree, TVM_SETIMAGELIST, TVSIL_STATE, (LPARAM)savedImgList);
-        Wh_Log(L"[DISABLE] Restored state image list %p for tree=%p", savedImgList, hTree);
     }
 
     ts = GetTree(hTree);
@@ -978,7 +978,7 @@ static void RestoreTree(HWND hTree)
     if (ownsRef)
         ((INameSpaceTreeControl *)pNscRaw)->Release();
 
-    Wh_Log(L"[DISABLE] Cleaned up tree=%p", hTree);
+    Wh_Log(L"[DISABLE] tree=%04X imglist=%04X", PTR4(hTree), PTR4(savedImgList));
 }
 
 static void FullRebuildTree(HWND hTree)
@@ -1050,8 +1050,8 @@ static void FullRebuildTree(HWND hTree)
         ResetSepColor();
 
         InvalidateRect(hTree, nullptr, TRUE);
-        Wh_Log(L"[REBUILD] Deferred insertion for tree=%p hHome=%p hGallery=%p",
-               hTree, ts ? ts->hItems[NAV_HOME] : nullptr, ts ? ts->hItems[NAV_GALLERY] : nullptr);
+        Wh_Log(L"[REBUILD] tree=%04X hHome=%04X hGallery=%04X",
+               PTR4(hTree), PTR4(ts ? ts->hItems[NAV_HOME] : nullptr), PTR4(ts ? ts->hItems[NAV_GALLERY] : nullptr));
     }
 }
 
@@ -1111,8 +1111,8 @@ static void InsertHomeSpacer(HWND hTree)
         SetItemIntegral(hTree, hSpacer, 1);
     }
 
-    Wh_Log(L"[HOME-SPACER] tree=%p %s spacer=%p afterDesktop=%p",
-           hTree, spacerLabel, hSpacer, ts->hItems[NAV_DESKTOP]);
+    Wh_Log(L"[SPACER] tree=%04X %s h=%04X after=%04X",
+           PTR4(hTree), spacerLabel, PTR4(hSpacer), PTR4(ts->hItems[NAV_DESKTOP]));
 
     InvalidateRect(hTree, nullptr, TRUE);
 }
@@ -1166,7 +1166,7 @@ static SectionLayout FindSectionLayout(HWND hTree, TreeState& ts)
                             ts.hItems[i] = h;
                             if (i == NAV_HOME) layout.homePresent = true;
                             else if (i == NAV_GALLERY) layout.galleryPresent = true;
-                            Wh_Log(L"[CACHE] %s item=%p tree=%p (walk)", g_navItems[i].label, h, hTree);
+                            Wh_Log(L"[CACHE] %s=%04X tree=%04X (walk)", g_navItems[i].label, PTR4(h), PTR4(hTree));
                         }
                         isSection = true;
                         inheritedNames[i][0] = L'\0';
@@ -1234,7 +1234,7 @@ static bool HasOurItemsInTree(const TreeState& ts)
     return ts.hItems[NAV_THISPC] || ts.hItems[NAV_DESKTOP];
 }
 
-static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
+static void RedrawSeps(HWND hTree, HDC hdc, TreeState& ts)
 {
     if (!hdc || !IsWindow(hTree) || !HasOurItemsInTree(ts))
         return;
@@ -1329,7 +1329,7 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
     walkLog[walkIdx] = 0;
     if (g_logSepDraw)
     {
-        Wh_Log(L"[SEP-DRAW] tree=%p walk=[%s] drew=%d hHome=%p hGallery=%p", hTree, walkLog, sepCount, ts.hItems[NAV_HOME], ts.hItems[NAV_GALLERY]);
+        Wh_Log(L"[SEP-DRAW] tree=%04X walk=[%s] drew=%d hHome=%04X hGallery=%04X", PTR4(hTree), walkLog, sepCount, PTR4(ts.hItems[NAV_HOME]), PTR4(ts.hItems[NAV_GALLERY]));
     }
 }
 
@@ -1363,11 +1363,11 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
                     {
                         g_sepColor = DeriveSepColor(hTree);
                         g_logSepDraw = true;
-                        Wh_Log(L"[SEP] color=0x%06X tree=%p (derived)", g_sepColor, hTree);
+                        Wh_Log(L"[SEP] 0x%06X tree=%04X", g_sepColor, PTR4(hTree));
                     }
 
                     if (g_settings.hasItemsAtTop && g_sepColor != CLR_INVALID && ts)
-                        RedrawOtherSeparators(hTree, cd->nmcd.hdc, *ts);
+                        RedrawSeps(hTree, cd->nmcd.hdc, *ts);
 
                     ts = GetTree(hTree);
                     HTREEITEM hHidden = (ts && HasOurItemsInTree(*ts)) ? GetHiddenItem(*ts) : nullptr;
@@ -1441,13 +1441,13 @@ static void EnsureParentSubclass(HWND hTree)
     if (g_subclassedParents.count(parent))
         return;
     bool ok = WindhawkUtils::SetWindowSubclassFromAnyThread(parent, SepParentSubclassProc, (DWORD_PTR)hTree);
-    Wh_Log(L"[SEP-PARENT] subclass on parent=%p for tree=%p ok=%d", parent, hTree, ok);
+    Wh_Log(L"[SEP-PARENT] parent=%04X tree=%04X ok=%d", PTR4(parent), PTR4(hTree), ok);
     if (ok)
         g_subclassedParents.insert(parent);
 }
 
 // Returns false if expected dups are missing (async population race).
-static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
+static bool CleanupDups(HWND hTree, TreeState& ts)
 {
     if (!ts.hItems[NAV_THISPC] && !ts.hItems[NAV_DESKTOP])
         return true;
@@ -1507,7 +1507,7 @@ static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
 
         for (int i = 0; i < sectionCount; i++)
         {
-            Wh_Log(L"[QA-HIDE] deleting native section=%p", toDeleteSections[i]);
+            Wh_Log(L"[DUP] del section=%04X", PTR4(toDeleteSections[i]));
             SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDeleteSections[i]);
         }
 
@@ -1522,22 +1522,22 @@ static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
                 ts.hiddenDuplicate = toDeleteChildless[i];
                 SetItemIntegral(hTree, toDeleteChildless[i], 1);
                 if (ts.hiddenDuplicate != prevDup)
-                    Wh_Log(L"[QA-HIDE] keeping dup=%p at boundary", toDeleteChildless[i]);
+                    Wh_Log(L"[DUP] hide dup=%04X", PTR4(toDeleteChildless[i]));
                 continue;
             }
-            Wh_Log(L"[QA-HIDE] deleting duplicate item=%p", toDeleteChildless[i]);
+            Wh_Log(L"[DUP] del dup=%04X", PTR4(toDeleteChildless[i]));
             SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDeleteChildless[i]);
         }
     }
 
     if (needDelete || ts.hiddenDuplicate != prevDup)
-        Wh_Log(L"[QA-HIDE] tree=%p childless=%d sections=%d expected=%d",
-               hTree, childlessCount, sectionCount, expectedCount);
+        Wh_Log(L"[DUP] tree=%04X n=%d exp=%d",
+               PTR4(hTree), childlessCount + sectionCount, expectedCount);
 
     return true;
 }
 
-static bool RemoveHiddenInheritedItems(HWND hTree, TreeState& ts)
+static bool RemoveInherited(HWND hTree, TreeState& ts)
 {
     if (!IsWindow(hTree)) return true;
 
@@ -1580,8 +1580,8 @@ static bool RemoveHiddenInheritedItems(HWND hTree, TreeState& ts)
         RedrawFreeze freeze(hTree);
         for (int i = 0; i < delCount; i++)
         {
-            Wh_Log(L"[HIDE] Deleting '%s' item=%p",
-                   g_navItems[toDelete[i].id].label, toDelete[i].h);
+            Wh_Log(L"[HIDE] del '%s'=%04X",
+                   g_navItems[toDelete[i].id].label, PTR4(toDelete[i].h));
             SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDelete[i].h);
             ts.hItems[toDelete[i].id] = nullptr;
         }
@@ -1657,7 +1657,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 {
                     SetItemIntegral(hWnd, hNew, 1);
                 }
-                Wh_Log(L"[CACHE] %s item=%p tree=%p", g_navItems[id].label, hNew, hWnd);
+                Wh_Log(L"[CACHE] %s=%04X tree=%04X", g_navItems[id].label, PTR4(hNew), PTR4(hWnd));
             }
             else
             {
@@ -1690,8 +1690,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                             if (nearOurSection)
                             {
                                 ts->pendingWork |= WORK_HG_CLEANUP;
-                                Wh_Log(L"[INSERT] '%s' item=%p tree=%p",
-                                       itemText, hNew, hWnd);
+                                Wh_Log(L"[INSERT] '%s' item=%04X tree=%04X",
+                                       itemText, PTR4(hNew), PTR4(hWnd));
                             }
                         }
                     }
@@ -1704,7 +1704,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                     {
                         ts->pendingWork |= WORK_FULL_REBUILD;
                         PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
-                        Wh_Log(L"[INSERT] New depth-1 item=%p, rebuilding tree=%p", hNew, hWnd);
+                        Wh_Log(L"[INSERT] depth1=%04X tree=%04X", PTR4(hNew), PTR4(hWnd));
                     }
                     else
                     {
@@ -1816,7 +1816,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             ((g_settings.items[NAV_THISPC].showAtTop && g_settings.items[NAV_THISPC].hideFromQA) ||
              (g_settings.items[NAV_DESKTOP].showAtTop && g_settings.items[NAV_DESKTOP].hideFromQA)))
         {
-            if (CleanupQuickAccessDuplicates(hWnd, *ts))
+            if (CleanupDups(hWnd, *ts))
             {
                 ts->pendingWork &= ~WORK_QA_CLEANUP;
             }
@@ -1827,7 +1827,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             (g_navItems[NAV_HOME].pidl || g_navItems[NAV_GALLERY].pidl) &&
             (g_settings.items[NAV_HOME].hide || g_settings.items[NAV_GALLERY].hide))
         {
-            if (RemoveHiddenInheritedItems(hWnd, *ts))
+            if (RemoveInherited(hWnd, *ts))
                 ts->pendingWork &= ~WORK_HG_CLEANUP;
         }
 
@@ -1908,11 +1908,11 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             }
 
             if (g_logSepDraw)
-                Wh_Log(L"[SEP-GAP] tree=%p boundary=%p int=%d home=%d gallery=%d rmNav=%d hidDup=%p spacer=%p tried=%d",
-                       hWnd, layout.boundary,
+                Wh_Log(L"[SEP-GAP] tree=%04X boundary=%04X int=%d home=%d gallery=%d rmNav=%d hidDup=%04X spacer=%04X tried=%d",
+                       PTR4(hWnd), PTR4(layout.boundary),
                        layout.boundary ? GetItemIntegral(hWnd, layout.boundary) : -1,
                        layout.homePresent, layout.galleryPresent,
-                       (int)g_settings.removeSepBelowNav, ts->hiddenDuplicate, ts->homeSpacerItem,
+                       (int)g_settings.removeSepBelowNav, PTR4(ts->hiddenDuplicate), PTR4(ts->homeSpacerItem),
                        (int)ts->triedHomeSpacer);
         }
 
@@ -1965,9 +1965,9 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 if (pixel != CLR_INVALID && pixel != g_sepColor)
                 {
                     g_sepRetries++;
-                    Wh_Log(L"[SEP-VERIFY] tree=%p at (%d,%d): "
+                    Wh_Log(L"[SEP-VERIFY] tree=%04X at (%d,%d): "
                            L"expected=0x%06X got=0x%06X, retry %d",
-                           hWnd, sampleX, g_lastSepY, g_sepColor, pixel, g_sepRetries);
+                           PTR4(hWnd), sampleX, g_lastSepY, g_sepColor, pixel, g_sepRetries);
                     InvalidateRect(hWnd, nullptr, FALSE);
                 }
                 else
@@ -1979,8 +1979,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                  && !g_settings.removeSepBelowNav && !GetHiddenItem(*ts))
         {
             g_sepRetries++;
-            Wh_Log(L"[SEP-VERIFY] tree=%p boundary=%p: expected separator but none drawn, retry %d",
-                   hWnd, ts->boundaryItem, g_sepRetries);
+            Wh_Log(L"[SEP-VERIFY] tree=%04X boundary=%04X: expected separator but none drawn, retry %d",
+                   PTR4(hWnd), PTR4(ts->boundaryItem), g_sepRetries);
             InvalidateRect(hWnd, nullptr, FALSE);
         }
 
@@ -2142,7 +2142,7 @@ BOOL Wh_ModInit()
                        nullptr, &g_navItems[NAV_HOME].pidl, 0, nullptr);
     SHParseDisplayName(L"::{e88865ea-0e1c-4e20-9aa6-edcd0212c87c}",
                        nullptr, &g_navItems[NAV_GALLERY].pidl, 0, nullptr);
-    Wh_Log(L"PIDLs: Home=%p Gallery=%p", g_navItems[NAV_HOME].pidl, g_navItems[NAV_GALLERY].pidl);
+    Wh_Log(L"PIDLs: Home=%04X Gallery=%04X", PTR4(g_navItems[NAV_HOME].pidl), PTR4(g_navItems[NAV_GALLERY].pidl));
 
     for (int i = 0; i < NAV_COUNT; i++)
         if (g_navItems[i].pidl)
@@ -2193,7 +2193,7 @@ BOOL Wh_ModInit()
         if (pDTB)
         {
             Wh_SetFunctionHook((void *)pDTB, (void *)DrawThemeBackground_hook, (void **)&DrawThemeBackground_orig);
-            Wh_Log(L"[CHEVRON] DTB hook installed at %p, orig=%p", pDTB, DrawThemeBackground_orig);
+            Wh_Log(L"[CHEVRON] at=%04X orig=%04X", PTR4(pDTB), PTR4(DrawThemeBackground_orig));
         }
         else
             Wh_Log(L"[CHEVRON] GetProcAddress(DrawThemeBackground) failed");
@@ -2219,7 +2219,7 @@ static void DiscoverTreeFromBrowser(HWND hTop, const WCHAR *cls,
     IServiceProvider *pSP = nullptr;
     if (FAILED(pSB->QueryInterface(IID_IServiceProvider, (void **)&pSP)))
     {
-        Wh_Log(L"[DISCOVER] %s hwnd=%p — no IServiceProvider", cls, hTop);
+        Wh_Log(L"[TREE] %s hwnd=%04X no IServiceProvider", cls, PTR4(hTop));
         return;
     }
 
@@ -2228,7 +2228,7 @@ static void DiscoverTreeFromBrowser(HWND hTop, const WCHAR *cls,
     pSP->Release();
     if (FAILED(hr))
     {
-        Wh_Log(L"[DISCOVER] %s hwnd=%p — no INameSpaceTreeControl (hr=0x%08X)", cls, hTop, hr);
+        Wh_Log(L"[TREE] %s hwnd=%04X no INameSpaceTreeControl hr=%08X", cls, PTR4(hTop), hr);
         return;
     }
 
@@ -2244,7 +2244,7 @@ static void DiscoverTreeFromBrowser(HWND hTop, const WCHAR *cls,
 
     if (!hTree)
     {
-        Wh_Log(L"[DISCOVER] %s hwnd=%p — no SysTreeView32", cls, hTop);
+        Wh_Log(L"[TREE] %s hwnd=%04X no SysTreeView32", cls, PTR4(hTop));
         pNsc->Release();
         return;
     }
@@ -2263,7 +2263,7 @@ static void DiscoverTreeFromBrowser(HWND hTop, const WCHAR *cls,
     if (!enumFlags)
         enumFlags = SHCONTF_FOLDERS;
 
-    Wh_Log(L"[DISCOVER] %s hwnd=%p tree=%p pNsc=%p — accepted", cls, hTop, hTree, pNsc);
+    Wh_Log(L"[TREE] %s hwnd=%04X tree=%04X nsc=%04X", cls, PTR4(hTop), PTR4(hTree), PTR4(pNsc));
     out.push_back({ hTop, hTree, pNsc, enumFlags });
 }
 
@@ -2305,7 +2305,7 @@ void Wh_ModAfterInit()
             if (pSB)
                 DiscoverTreeFromBrowser(hTop, cls, pSB, out);
             else
-                Wh_Log(L"[DISCOVER] %s hwnd=%p — no IShellBrowser", cls, hTop);
+                Wh_Log(L"[TREE] %s hwnd=%04X no IShellBrowser", cls, PTR4(hTop));
         }
         return TRUE;
     }, (LPARAM)&discovered);
@@ -2328,7 +2328,7 @@ void Wh_ModAfterInit()
         SetPropW(d.hTree, L"WH_EnumFlags", (HANDLE)(ULONG_PTR)d.enumFlags);
 
         PostMessage(d.hTree, WM_DEFERRED_REBUILD, 0, 0);
-        Wh_Log(L"[ENABLE] window=%p tree=%p pNsc=%p", d.hTop, d.hTree, d.pNsc);
+        Wh_Log(L"[ENABLE] window=%04X tree=%04X nsc=%04X", PTR4(d.hTop), PTR4(d.hTree), PTR4(d.pNsc));
     }
 }
 

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -1,0 +1,1135 @@
+// ==WindhawkMod==
+// @id              add-virtual-folders-to-nav-top
+// @name            Add This PC and Desktop to Nav Top
+// @description     Adds This PC and Desktop to the top of Explorer's navigation pane
+// @version         1.0
+// @author          Rod Boev
+// @github          https://github.com/rodboev
+// @include         *
+// @architecture    x86-64
+// @compilerOptions -lole32 -lshell32 -luuid -luxtheme -lgdi32 -lgdiplus -lcomctl32
+// @license         MIT
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Add This PC and Desktop to Nav Top
+
+This mod adds two virtual folders to the top of File Explorer's
+navigation pane and fixes the chevron rendering.
+
+- **Show This PC at top:** Adds an expandable This PC entry
+with drives. (Expandable This PC can't be pinned to the top
+without this mod.)
+
+- **Show Desktop at top:** Adds a Desktop entry for the root
+namespace object. This includes Recycle Bin, Control Panel, etc.
+instead of just the items on the desktop. (This target can't be
+pinned without this mod.)
+
+- **Fix chevron drawing:** Replaces the pixelated and clipped
+chevron with a smooth anti-aliased versions. The size can be
+tweaked to any percentage or pixel dimensions.
+
+Both virtual folders have a toggle for whether they are expandable
+or not. Their position can be swapped. Duplicate entries of Desktop
+or This PC can be removed from other parts of the nav.
+
+This mod injects only in processes that have ExplorerFrame.dll,
+so the include is set to `*` but it will not touch most processes.
+You can set it to `explorer.exe` only, if you don't want the nav in
+Open/Save dialogs changed (only modern dialogs are affected.)
+
+Before:
+
+![Before](https://i.imgur.com/aahBZPG.png)
+
+After:
+
+![After](https://i.imgur.com/e2fEDwb.png)
+
+The screenshots show the mod with the normal Desktop pinned to
+Quick Access in before, compared to adding it using the mod.
+
+Home and Gallery are already hidden using [standard](https://www.elevenforum.com/t/add-show-home-on-navigation-pane-to-folder-options-in-windows-11.27300/) [methods](https://www.elevenforum.com/t/add-show-gallery-on-navigation-pane-to-folder-options-in-windows-11.27301/).
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- ThisPC:
+  - showThisPCAtTop: true
+    $name: Add to top
+    $description: Add an expandable entry for This PC to the top of the navigation pane.
+  - thisPCExpandable: true
+    $name: Make expandable
+    $description: Shows drives underneath This PC when expanded.
+  - thisPCStartExpanded: true
+    $name: Start expanded
+    $description: Auto-expand This PC when window opens.
+  - hideThisPCFromQuickAccess: true
+    $name: Hide duplicates
+    $description: Hide This PC elsewhere in nav. Disable if there are issues with separators.
+  $name: This PC
+- Desktop:
+  - showDesktopAtTop: false
+    $name: Add to top
+    $description: Adds the namespace root to the top of the navigation pane.
+  - desktopExpandable: false
+    $name: Make expandable
+    $description: Shows namespace children when expanded.
+  - desktopAboveThisPC: true
+    $name: Place above This PC
+    $description: Disable if there are issues with separator lines.
+  - hideDesktopFromQuickAccess: true
+    $name: Hide duplicates
+    $description: Hide Desktop elsewhere in nav. Disable if there are issues with separators.
+  $name: Desktop
+- Resources:
+  - fixChevronDrawing: true
+    $name: Fix chevron drawing
+    $description: >-
+      Replaces theme-drawn expand/collapse chevrons with custom
+      anti-aliased ones (fixes clipping at non-standard DPI like 225%)
+  - chevronScale: 0
+    $name: Chevron scale (%)
+    $description: >-
+      Size of expand/collapse chevrons. 0 or 100 = default size,
+      125 = 25% larger. Only applies when Fix chevron drawing is enabled.
+  - hidePinButtons: true
+    $name: Hide "pin" icons
+    $description: Hide gray pin icons to the right of Quick Access items.
+  $name: Resources
+*/
+// ==/WindhawkModSettings==
+
+#include <windhawk_api.h>
+#include <windhawk_utils.h>
+#include <shlobj.h>
+#include <commctrl.h>
+#include <windowsx.h>
+#include <uxtheme.h>
+#include <gdiplus.h>
+#include <set>
+
+#ifdef _WIN64
+#define THISCALL __cdecl
+#else
+#define THISCALL __thiscall
+#endif
+
+struct {
+    bool showThisPCAtTop;
+    bool thisPCExpandable;
+    bool thisPCStartExpanded;
+    bool hideThisPCFromQuickAccess;
+    bool showDesktopAtTop;
+    bool desktopAboveThisPC;
+    bool desktopExpandable;
+    bool hideDesktopFromQuickAccess;
+    bool fixChevronDrawing;
+    int chevronScale;
+    bool hidePinButtons;
+} g_settings;
+
+static PIDLIST_ABSOLUTE g_pidlThisPC = nullptr;
+static PIDLIST_ABSOLUTE g_pidlDesktop = nullptr;
+static ULONG_PTR g_gdipToken = 0;
+static std::set<HWND> g_subclassedParents;
+static COLORREF g_sepColor = CLR_INVALID;
+static HTREEITEM g_hCachedThisPC = nullptr;
+static HTREEITEM g_hCachedDesktop = nullptr;
+static HWND g_hCachedTree = nullptr;
+
+// 0=not ours, 1=This PC, 2=Desktop — set during AppendOneItem
+// so the TVM_INSERTITEM handler knows which item is being inserted
+// without comparing localized display text.
+static thread_local int g_insertingItem = 0;
+
+static bool ShouldRemoveSeparators()
+{
+    return g_settings.showThisPCAtTop && g_settings.showDesktopAtTop &&
+           g_settings.desktopAboveThisPC;
+}
+
+// --- AppendRoot hook ---
+
+using AppendRoot_t = HRESULT (THISCALL *)(
+    void *pThis, IShellItem *psiRoot, unsigned long grfEnumFlags,
+    unsigned long grfRootStyle, IShellItemFilter *pFilter);
+
+AppendRoot_t AppendRoot_orig;
+
+static thread_local bool g_inCustomAppend = false;
+
+static void AppendOneItem(
+    void *pThis, PIDLIST_ABSOLUTE pidl, bool expandable,
+    unsigned long grfEnumFlags, IShellItemFilter *pOrigFilter,
+    const WCHAR *label, unsigned long rootStyle = 0)
+{
+    if (!pidl)
+        return;
+
+    IShellItem *pItem = nullptr;
+    if (FAILED(SHCreateItemFromIDList(pidl, IID_IShellItem, (void **)&pItem)))
+        return;
+
+    HRESULT hr = AppendRoot_orig(pThis, pItem,
+        expandable ? grfEnumFlags : 0,
+        rootStyle,
+        pOrigFilter);
+
+    Wh_Log(L"AppendRoot: %s (%s) rootStyle=0x%lx result=0x%lx",
+            label, expandable ? L"expandable" : L"leaf", rootStyle, hr);
+
+    pItem->Release();
+}
+
+HRESULT THISCALL AppendRoot_hook(
+    void *pThis, IShellItem *psiRoot, unsigned long grfEnumFlags,
+    unsigned long grfRootStyle, IShellItemFilter *pFilter)
+{
+    if (g_inCustomAppend)
+        return AppendRoot_orig(pThis, psiRoot, grfEnumFlags,
+                               grfRootStyle, pFilter);
+
+    bool isHiddenRoot = (grfRootStyle & 0x1) != 0;
+    bool wantItems = isHiddenRoot &&
+        (g_settings.showThisPCAtTop || g_settings.showDesktopAtTop);
+
+    HRESULT hr = AppendRoot_orig(pThis, psiRoot, grfEnumFlags,
+                                 grfRootStyle, pFilter);
+
+    if (wantItems)
+    {
+        g_inCustomAppend = true;
+
+        unsigned long thisPCStyle = g_settings.thisPCStartExpanded ? 0x2 : 0;
+
+        struct { PIDLIST_ABSOLUTE pidl; bool expandable; bool enabled;
+                 int id; const WCHAR *label; unsigned long style; } items[2];
+
+        if (g_settings.desktopAboveThisPC)
+        {
+            items[0] = { g_pidlDesktop, g_settings.desktopExpandable,
+                         g_settings.showDesktopAtTop, 2, L"Desktop", 0 };
+            items[1] = { g_pidlThisPC, g_settings.thisPCExpandable,
+                         g_settings.showThisPCAtTop, 1, L"This PC", thisPCStyle };
+        }
+        else
+        {
+            items[0] = { g_pidlThisPC, g_settings.thisPCExpandable,
+                         g_settings.showThisPCAtTop, 1, L"This PC", thisPCStyle };
+            items[1] = { g_pidlDesktop, g_settings.desktopExpandable,
+                         g_settings.showDesktopAtTop, 2, L"Desktop", 0 };
+        }
+
+        for (int i = 0; i < 2; i++)
+        {
+            if (items[i].enabled)
+            {
+                g_insertingItem = items[i].id;
+                AppendOneItem(pThis, items[i].pidl, items[i].expandable,
+                              grfEnumFlags, pFilter, items[i].label,
+                              items[i].style);
+            }
+        }
+        g_insertingItem = 0;
+
+        g_inCustomAppend = false;
+    }
+
+    return hr;
+}
+
+// --- Chevron fix: anti-aliased custom drawing via GDI+ ---
+
+#define TVP_GLYPH        2
+#define TVP_HOTGLYPH     4
+
+static void CalcGlyphRect(LPCRECT src, RECT *dst)
+{
+    int w = src->right - src->left;
+    int h = src->bottom - src->top;
+    int s = g_settings.chevronScale;
+    if (s <= 0) s = 100;
+    int nw = MulDiv(w, s, 100);
+    int nh = MulDiv(h, s, 100);
+    dst->right  = src->right;
+    dst->left   = src->right - nw;
+    dst->top    = src->top + (h - nh) / 2;
+    dst->bottom = dst->top + nh;
+}
+
+static void DrawChevron(HDC hdc, const RECT *r, int partId, int stateId)
+{
+    int w  = r->right  - r->left;
+    int h  = r->bottom - r->top;
+    int sz = (w < h) ? w : h;
+
+    float armLong  = sz * 0.375f;
+    float armShort = armLong * 0.55f;
+
+    float pw = sz / 14.0f;
+    if (pw < 1.2f) pw = 1.2f;
+
+    float cy = r->top + h * 0.5f;
+
+    bool hot = (partId == TVP_HOTGLYPH);
+    Gdiplus::Color col(hot ? 255 : 160, hot ? 255 : 160, hot ? 255 : 160);
+
+    Gdiplus::Graphics gfx(hdc);
+    gfx.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+
+    Gdiplus::Pen pen(col, pw);
+    pen.SetStartCap(Gdiplus::LineCapRound);
+    pen.SetEndCap(Gdiplus::LineCapRound);
+    pen.SetLineJoin(Gdiplus::LineJoinRound);
+
+    Gdiplus::PointF pts[3];
+    if (stateId == 2)   // expanded  ∨
+    {
+        float cx = (float)r->right - armLong - pw;
+        pts[0] = { cx - armLong,  cy - armShort };
+        pts[1] = { cx,            cy + armShort };
+        pts[2] = { cx + armLong,  cy - armShort };
+    }
+    else                // collapsed >
+    {
+        float cx = (float)r->right - armShort - pw;
+        pts[0] = { cx - armShort, cy - armLong };
+        pts[1] = { cx + armShort, cy           };
+        pts[2] = { cx - armShort, cy + armLong };
+    }
+
+    gfx.DrawLines(&pen, pts, 3);
+}
+
+static thread_local bool g_inTreePaint = false;
+
+// --- Separator removal ---
+// Strategy: swallowing NM_CUSTOMDRAW CDDS_PREPAINT (by returning
+// CDRF_NOTIFYPOSTPAINT without calling DefSubclassProc) hides ALL
+// separator lines. At CDDS_POSTPAINT we redraw the ones we want to
+// keep — all section boundaries EXCEPT the one between our custom items.
+
+// Sample the separator line color from the DC. Called on the first
+// paint cycle when CDDS_PREPAINT was NOT swallowed (separators visible).
+static COLORREF SampleSeparatorColor(HWND hTree, HDC hdc)
+{
+    if (!hdc || !IsWindow(hTree))
+        return CLR_INVALID;
+
+    RECT client;
+    GetClientRect(hTree, &client);
+    if (client.right <= 0)
+        return CLR_INVALID;
+
+    int baseHeight = 0;
+    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                          TVGN_FIRSTVISIBLE, 0);
+    while (h)
+    {
+        RECT rc = {};
+        *(HTREEITEM*)&rc = h;
+        if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rc))
+        {
+            int ih = rc.bottom - rc.top;
+            if (ih > 0 && (baseHeight == 0 || ih < baseHeight))
+                baseHeight = ih;
+        }
+        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                    TVGN_NEXTVISIBLE, (LPARAM)h);
+    }
+    if (baseHeight <= 0)
+        return CLR_INVALID;
+
+    int tallThreshold = baseHeight + baseHeight / 2;
+
+    // Find the first tall depth-1 item — its separator is at rc.top + baseHeight/2
+    h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                TVGN_FIRSTVISIBLE, 0);
+    while (h)
+    {
+        HTREEITEM parent = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                                    TVGN_PARENT, (LPARAM)h);
+        HTREEITEM gp = parent ?
+            (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                    TVGN_PARENT, (LPARAM)parent) : nullptr;
+        if (parent && !gp)
+        {
+            RECT rc = {};
+            *(HTREEITEM*)&rc = h;
+            if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rc))
+            {
+                int ih = rc.bottom - rc.top;
+                if (ih >= tallThreshold)
+                {
+                    int sepY = rc.top + baseHeight / 2;
+                    int sampleX = client.right / 2;
+                    COLORREF c = GetPixel(hdc, sampleX, sepY);
+                    Wh_Log(L"[SEP-COLOR] sampled at (%d,%d) = 0x%06X",
+                           sampleX, sepY, c);
+                    if (c != CLR_INVALID && c != 0x000000)
+                        return c;
+                    // Try a few pixels around it
+                    for (int dy = -2; dy <= 2; dy++)
+                    {
+                        c = GetPixel(hdc, sampleX, sepY + dy);
+                        if (c != CLR_INVALID && c != 0x000000)
+                        {
+                            Wh_Log(L"[SEP-COLOR] sampled at (%d,%d) = 0x%06X",
+                                   sampleX, sepY + dy, c);
+                            return c;
+                        }
+                    }
+                }
+            }
+        }
+        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                    TVGN_NEXTVISIBLE, (LPARAM)h);
+    }
+
+    return CLR_INVALID;
+}
+
+// At CDDS_POSTPAINT, all separators have been hidden by CDDS_PREPAINT
+// swallowing. Redraw separators for section boundaries we want to keep.
+// Tracks last-drawn positions to only log when something changes.
+static int g_lastSepPositions[8] = {};
+static int g_lastSepCount = 0;
+static bool g_qaCleanupDone = false;
+static HTREEITEM g_hiddenDuplicate = nullptr;
+
+static void RedrawOtherSeparators(HWND hTree, HDC hdc)
+{
+    if (!hdc || !IsWindow(hTree))
+        return;
+
+    RECT client;
+    GetClientRect(hTree, &client);
+    if (client.right <= 0 || client.bottom <= 0)
+        return;
+
+    HTREEITEM hThisPC = (g_hCachedTree == hTree) ? g_hCachedThisPC : nullptr;
+    HTREEITEM hDesktop = (g_hCachedTree == hTree) ? g_hCachedDesktop : nullptr;
+
+    int baseHeight = 0;
+    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                          TVGN_FIRSTVISIBLE, 0);
+    while (h)
+    {
+        RECT rc = {};
+        *(HTREEITEM*)&rc = h;
+        if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rc))
+        {
+            int ih = rc.bottom - rc.top;
+            if (ih > 0 && (baseHeight == 0 || ih < baseHeight))
+                baseHeight = ih;
+        }
+        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                    TVGN_NEXTVISIBLE, (LPARAM)h);
+    }
+    if (baseHeight <= 0)
+        baseHeight = 48;
+
+    int tallThreshold = baseHeight + baseHeight / 2;
+    int restored = 0;
+    int positions[8] = {};
+
+    h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                TVGN_FIRSTVISIBLE, 0);
+    while (h)
+    {
+        HTREEITEM parent = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                                    TVGN_PARENT, (LPARAM)h);
+        HTREEITEM grandparent = parent ?
+            (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                    TVGN_PARENT, (LPARAM)parent) : nullptr;
+        bool isDepth1 = (parent != nullptr && grandparent == nullptr);
+
+        if (isDepth1)
+        {
+            RECT rc = {};
+            *(HTREEITEM*)&rc = h;
+            if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rc))
+            {
+                int ih = rc.bottom - rc.top;
+                bool isTall = (ih >= tallThreshold);
+                bool isOurs = (h == hThisPC || h == hDesktop);
+
+                if (isTall && !isOurs)
+                {
+                    int sepY = rc.top + baseHeight / 2;
+                    int sepH = 2;
+
+                    int padLeft = 18;
+                    int padRight = 18;
+                    int sepLeft = (client.right >= padLeft * 2 + 8) ? padLeft : 0;
+                    int sepRight = (client.right >= padRight * 2 + 8) ? client.right - padRight : client.right;
+
+                    RECT sepRect = { sepLeft, sepY, sepRight, sepY + sepH };
+
+                    COLORREF sepColor = (g_sepColor != CLR_INVALID)
+                        ? g_sepColor : RGB(255, 0, 0);
+
+                    HBRUSH brush = CreateSolidBrush(sepColor);
+                    if (brush)
+                    {
+                        FillRect(hdc, &sepRect, brush);
+                        DeleteObject(brush);
+                    }
+
+                    if (restored < 8)
+                        positions[restored] = sepY;
+                    restored++;
+                }
+            }
+        }
+
+        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                    TVGN_NEXTVISIBLE, (LPARAM)h);
+    }
+
+
+    // Only log when positions change
+    bool changed = (restored != g_lastSepCount);
+    if (!changed)
+    {
+        for (int i = 0; i < restored && i < 8; i++)
+            if (positions[i] != g_lastSepPositions[i])
+                { changed = true; break; }
+    }
+    if (changed)
+    {
+        g_lastSepCount = restored;
+        for (int i = 0; i < 8; i++)
+            g_lastSepPositions[i] = positions[i];
+
+        if (restored == 0)
+            Wh_Log(L"[SEP-RESTORE] no separators to restore (baseH=%d)", baseHeight);
+        else if (restored == 1)
+            Wh_Log(L"[SEP-RESTORE] 1 separator at y=%d (baseH=%d pad=18)",
+                   positions[0], baseHeight);
+        else
+            Wh_Log(L"[SEP-RESTORE] %d separators at y=%d,%d (baseH=%d pad=18)",
+                   restored, positions[0], positions[1], baseHeight);
+    }
+}
+
+// Parent subclass — intercepts NM_CUSTOMDRAW.
+// Returning CDRF_NOTIFYPOSTPAINT at CDDS_PREPAINT without calling
+// DefSubclassProc hides ALL separator lines
+// At CDDS_POSTPAINT we redraw the separators we want to keep.
+static LRESULT CALLBACK SepParentSubclassProc(
+    HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
+    DWORD_PTR dwRefData)
+{
+    HWND hTree = (HWND)dwRefData;
+
+    if (uMsg == WM_NOTIFY && hTree && IsWindow(hTree))
+    {
+        LPNMHDR hdr = (LPNMHDR)lParam;
+        if (hdr && hdr->hwndFrom == hTree)
+        {
+            if (hdr->code == (UINT)NM_CUSTOMDRAW)
+            {
+                LPNMTVCUSTOMDRAW cd = (LPNMTVCUSTOMDRAW)lParam;
+                DWORD stage = cd->nmcd.dwDrawStage;
+                bool removeSep = ShouldRemoveSeparators();
+                bool hasDupHide = (g_hiddenDuplicate != nullptr);
+
+                if (stage == CDDS_PREPAINT && (removeSep || hasDupHide))
+                {
+                    if (removeSep)
+                    {
+                        if (g_sepColor == CLR_INVALID)
+                        {
+                            LRESULT r = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+                            return r | CDRF_NOTIFYPOSTPAINT;
+                        }
+                        return CDRF_NOTIFYPOSTPAINT;
+                    }
+                    else
+                    {
+                        LRESULT r = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+                        return r | CDRF_NOTIFYPOSTPAINT;
+                    }
+                }
+
+                if (stage == CDDS_POSTPAINT)
+                {
+                    if (g_sepColor == CLR_INVALID && (removeSep || hasDupHide))
+                    {
+                        COLORREF c = SampleSeparatorColor(hTree, cd->nmcd.hdc);
+                        if (c != CLR_INVALID)
+                        {
+                            g_sepColor = c;
+                            Wh_Log(L"[SEP-COLOR] captured separator color: 0x%06X", c);
+                            if (removeSep)
+                                InvalidateRect(hTree, NULL, TRUE);
+                        }
+                    }
+
+                    if (removeSep && g_sepColor != CLR_INVALID)
+                        RedrawOtherSeparators(hTree, cd->nmcd.hdc);
+
+                    if (hasDupHide)
+                    {
+                        RECT rcHide = {};
+                        *(HTREEITEM*)&rcHide = g_hiddenDuplicate;
+                        if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rcHide))
+                        {
+                            HDC hdc = cd->nmcd.hdc;
+                            COLORREF bg = GetPixel(hdc, 1, rcHide.top + 2);
+                            if (bg == CLR_INVALID || bg == 0)
+                            {
+                                RECT client;
+                                GetClientRect(hTree, &client);
+                                bg = GetPixel(hdc, client.right - 2, rcHide.top + 2);
+                            }
+                            if (bg != CLR_INVALID)
+                            {
+                                HBRUSH bgBrush = CreateSolidBrush(bg);
+                                if (bgBrush)
+                                {
+                                    FillRect(hdc, &rcHide, bgBrush);
+                                    DeleteObject(bgBrush);
+                                }
+                            }
+
+                            if (g_sepColor != CLR_INVALID)
+                            {
+                                int h = rcHide.bottom - rcHide.top;
+                                int sepY = rcHide.top + h / 2;
+                                RECT client;
+                                GetClientRect(hTree, &client);
+                                int padL = 18, padR = 18;
+                                int sepLeft = (client.right >= padL * 2 + 8) ? padL : 0;
+                                int sepRight = (client.right >= padR * 2 + 8)
+                                    ? client.right - padR : client.right;
+                                RECT sepRect = { sepLeft, sepY, sepRight, sepY + 2 };
+
+                                HBRUSH sepBrush = CreateSolidBrush(g_sepColor);
+                                if (sepBrush)
+                                {
+                                    FillRect(hdc, &sepRect, sepBrush);
+                                    DeleteObject(sepBrush);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // After expand/collapse, force full repaint so stale
+            // separator lines at old positions get overwritten.
+            if (hdr->code == TVN_ITEMEXPANDEDW ||
+                hdr->code == TVN_ITEMEXPANDEDA)
+            {
+                LRESULT r = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+                InvalidateRect(hTree, NULL, TRUE);
+                Wh_Log(L"[SEP-EXPAND] tree=%p expanded/collapsed, full repaint scheduled", hTree);
+                return r;
+            }
+        }
+    }
+
+    if (uMsg == WM_THEMECHANGED || uMsg == WM_SYSCOLORCHANGE)
+    {
+        g_sepColor = CLR_INVALID;
+        Wh_Log(L"[SEP-COLOR] theme/colors changed, will resample");
+    }
+
+    if (uMsg == WM_NCDESTROY)
+    {
+        g_subclassedParents.erase(hWnd);
+        Wh_Log(L"[SEP-PARENT] parent=%p destroyed, removed from tracking", hWnd);
+    }
+
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+static void EnsureParentSubclass(HWND hTree)
+{
+    HWND parent = GetParent(hTree);
+    if (!parent)
+        return;
+    if (g_subclassedParents.count(parent))
+        return;
+    bool ok = WindhawkUtils::SetWindowSubclassFromAnyThread(
+        parent, SepParentSubclassProc, (DWORD_PTR)hTree);
+    Wh_Log(L"[SEP-PARENT] subclass on parent=%p for tree=%p ok=%d", parent, hTree, ok);
+    if (ok)
+        g_subclassedParents.insert(parent);
+}
+
+// --- Pin button hiding ---
+
+using SetStateImageList_t = HRESULT (THISCALL *)(void *, HIMAGELIST);
+SetStateImageList_t SetStateImageList_orig;
+
+HRESULT THISCALL SetStateImageList_hook(void *pThis, HIMAGELIST himl)
+{
+    if (g_settings.hidePinButtons)
+        return S_OK;
+    return SetStateImageList_orig(pThis, himl);
+}
+
+// --- Quick Access item hiding ---
+// Quick Access pinned items bypass all CNscTree insertion predicates
+// (_ShouldInsertChild, _InsertChild) so we can't filter them at
+// insertion time. Instead, on the first WM_PAINT after our items
+// are cached, walk depth-1 items and delete any matching childless
+// duplicates (QA pins have no children; nav pane sections do).
+
+static void CleanupQuickAccessDuplicates(HWND hTree)
+{
+    if (!g_hCachedThisPC && !g_hCachedDesktop)
+        return;
+
+    WCHAR thisPCText[64] = {};
+    WCHAR desktopText[64] = {};
+
+    if (g_settings.showThisPCAtTop &&
+        g_settings.hideThisPCFromQuickAccess && g_hCachedThisPC)
+    {
+        TVITEMEXW tvi = {};
+        tvi.mask = TVIF_HANDLE | TVIF_TEXT;
+        tvi.hItem = g_hCachedThisPC;
+        tvi.pszText = thisPCText;
+        tvi.cchTextMax = ARRAYSIZE(thisPCText);
+        SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
+    }
+
+    if (g_settings.showDesktopAtTop &&
+        g_settings.hideDesktopFromQuickAccess && g_hCachedDesktop)
+    {
+        TVITEMEXW tvi = {};
+        tvi.mask = TVIF_HANDLE | TVIF_TEXT;
+        tvi.hItem = g_hCachedDesktop;
+        tvi.pszText = desktopText;
+        tvi.cchTextMax = ARRAYSIZE(desktopText);
+        SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
+    }
+
+    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                          TVGN_ROOT, 0);
+    if (!h) return;
+
+    // Walk depth-1 items (children of root)
+    h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                TVGN_CHILD, (LPARAM)h);
+
+    HTREEITEM toDelete[8] = {};
+    int delCount = 0;
+
+    while (h)
+    {
+        HTREEITEM hNext = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                                   TVGN_NEXT, (LPARAM)h);
+        if (h != g_hCachedThisPC && h != g_hCachedDesktop)
+        {
+            HTREEITEM hChild = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                                        TVGN_CHILD, (LPARAM)h);
+            if (!hChild)
+            {
+                WCHAR text[64] = {};
+                TVITEMEXW tvi = {};
+                tvi.mask = TVIF_HANDLE | TVIF_TEXT;
+                tvi.hItem = h;
+                tvi.pszText = text;
+                tvi.cchTextMax = ARRAYSIZE(text);
+                SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
+
+                bool match = false;
+                if (thisPCText[0] && wcscmp(text, thisPCText) == 0)
+                    match = true;
+                if (desktopText[0] && wcscmp(text, desktopText) == 0)
+                    match = true;
+
+                if (match && delCount < 8)
+                    toDelete[delCount++] = h;
+            }
+        }
+        h = hNext;
+    }
+
+    // Only keep a duplicate hidden (paint-over) if it's a section
+    // boundary item (iIntegral>=2) — removing it would destroy the
+    // gap where the separator line goes. All others are safe to delete.
+    g_hiddenDuplicate = nullptr;
+    for (int i = 0; i < delCount; i++)
+    {
+        if (!g_hiddenDuplicate)
+        {
+            TVITEMEXW check = {};
+            check.mask = TVIF_HANDLE | TVIF_INTEGRAL;
+            check.hItem = toDelete[i];
+            SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&check);
+
+            if (check.iIntegral >= 2)
+            {
+                g_hiddenDuplicate = toDelete[i];
+                TVITEMEXW forceSmall = {};
+                forceSmall.mask = TVIF_HANDLE | TVIF_INTEGRAL;
+                forceSmall.hItem = toDelete[i];
+                forceSmall.iIntegral = 1;
+                SendMessageW(hTree, TVM_SETITEMW, 0, (LPARAM)&forceSmall);
+                Wh_Log(L"[QA-HIDE] keeping boundary item=%p invisible (was iIntegral=%d)",
+                       toDelete[i], check.iIntegral);
+                continue;
+            }
+        }
+
+        Wh_Log(L"[QA-HIDE] deleting duplicate item=%p", toDelete[i]);
+        SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDelete[i]);
+    }
+}
+
+// --- SubClassTreeWndProc ---
+
+using SubClassTreeWndProc_t = LRESULT (CALLBACK *)(
+    HWND, UINT, WPARAM, LPARAM, UINT_PTR, DWORD_PTR);
+
+SubClassTreeWndProc_t SubClassTreeWndProc_orig;
+
+LRESULT CALLBACK SubClassTreeWndProc_hook(
+    HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
+    UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
+{
+    if (uMsg == TVM_INSERTITEMW || uMsg == TVM_INSERTITEMA)
+    {
+        LRESULT result = SubClassTreeWndProc_orig(hWnd, uMsg, wParam,
+                            lParam, uIdSubclass, dwRefData);
+        HTREEITEM hNew = (HTREEITEM)result;
+        if (hNew)
+        {
+            if (g_insertingItem == 1)
+            {
+                g_hCachedThisPC = hNew;
+                g_hCachedTree = hWnd;
+                g_qaCleanupDone = false;
+                g_hiddenDuplicate = nullptr;
+                Wh_Log(L"[CACHE] This PC item=%p tree=%p", hNew, hWnd);
+            }
+            else if (g_insertingItem == 2)
+            {
+                g_hCachedDesktop = hNew;
+                g_hCachedTree = hWnd;
+                g_qaCleanupDone = false;
+                g_hiddenDuplicate = nullptr;
+                Wh_Log(L"[CACHE] Desktop item=%p tree=%p", hNew, hWnd);
+            }
+            else if (g_qaCleanupDone && g_hCachedTree == hWnd)
+            {
+                HTREEITEM hPar = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM,
+                                                          TVGN_PARENT, (LPARAM)hNew);
+                if (hPar)
+                {
+                    HTREEITEM hGP = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM,
+                                                              TVGN_PARENT, (LPARAM)hPar);
+                    if (!hGP)
+                    {
+                        g_qaCleanupDone = false;
+                        g_hiddenDuplicate = nullptr;
+                        Wh_Log(L"[QA-HIDE] depth-1 item inserted, scheduling re-cleanup");
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    // Block clicks and cursor changes on hidden duplicate
+    if (g_hiddenDuplicate &&
+        (uMsg == WM_LBUTTONDOWN || uMsg == WM_SETCURSOR))
+    {
+        POINT pt;
+        if (uMsg == WM_LBUTTONDOWN)
+        {
+            pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+        }
+        else
+        {
+            GetCursorPos(&pt);
+            ScreenToClient(hWnd, &pt);
+        }
+        TVHITTESTINFO ht = {};
+        ht.pt = pt;
+        HTREEITEM hHit = (HTREEITEM)SendMessageW(hWnd, TVM_HITTEST, 0, (LPARAM)&ht);
+        if (hHit == g_hiddenDuplicate)
+        {
+            if (uMsg == WM_LBUTTONDOWN)
+                return 0;
+            SetCursor(LoadCursorW(nullptr, IDC_ARROW));
+            return TRUE;
+        }
+    }
+
+    // Skip hidden duplicate on keyboard navigation
+    if (uMsg == WM_KEYDOWN && g_hiddenDuplicate &&
+        (wParam == VK_UP || wParam == VK_DOWN))
+    {
+        LRESULT r = SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam,
+                                              uIdSubclass, dwRefData);
+        HTREEITEM hSel = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM,
+                                                   TVGN_CARET, 0);
+        if (hSel == g_hiddenDuplicate)
+        {
+            UINT dir = (wParam == VK_DOWN) ? TVGN_NEXTVISIBLE : TVGN_PREVIOUSVISIBLE;
+            HTREEITEM hNext = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM,
+                                                        dir, (LPARAM)hSel);
+            if (hNext)
+                SendMessageW(hWnd, TVM_SELECTITEM, TVGN_CARET, (LPARAM)hNext);
+        }
+        return r;
+    }
+
+    if (uMsg == TVM_SETITEMW || uMsg == TVM_SETITEMA)
+    {
+        TVITEMEXW* tvi = (TVITEMEXW*)lParam;
+        if (tvi && (tvi->mask & TVIF_INTEGRAL))
+        {
+            // Keep hidden duplicate at iIntegral=1 so it occupies
+            // exactly one row of space for the painted-over separator.
+            if (g_hiddenDuplicate && tvi->hItem == g_hiddenDuplicate &&
+                tvi->iIntegral != 1)
+            {
+                tvi->iIntegral = 1;
+            }
+
+            // Collapse the boundary between Desktop and This PC.
+            if (ShouldRemoveSeparators() && tvi->iIntegral >= 2)
+            {
+                HTREEITEM hA = (g_hCachedTree == hWnd) ? g_hCachedThisPC : nullptr;
+                HTREEITEM hB = (g_hCachedTree == hWnd) ? g_hCachedDesktop : nullptr;
+                if (hA && hB)
+                {
+                    RECT rcA = {}, rcB = {};
+                    *(HTREEITEM*)&rcA = hA;
+                    *(HTREEITEM*)&rcB = hB;
+                    bool gotA = SendMessageW(hWnd, TVM_GETITEMRECT, FALSE, (LPARAM)&rcA);
+                    bool gotB = SendMessageW(hWnd, TVM_GETITEMRECT, FALSE, (LPARAM)&rcB);
+
+                    if (gotA && gotB)
+                    {
+                        HTREEITEM hLower = (rcA.top > rcB.top) ? hA : hB;
+                        if (tvi->hItem == hLower)
+                        {
+                            Wh_Log(L"[SEP-COLLAPSE] TVM_SETITEMW: iIntegral %d->1 on item=%p",
+                                   tvi->iIntegral, tvi->hItem);
+                            tvi->iIntegral = 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (uMsg == WM_PAINT)
+    {
+        if (!g_qaCleanupDone && g_hCachedTree == hWnd &&
+            ((g_settings.showThisPCAtTop && g_settings.hideThisPCFromQuickAccess) ||
+             (g_settings.showDesktopAtTop && g_settings.hideDesktopFromQuickAccess)))
+        {
+            g_qaCleanupDone = true;
+            CleanupQuickAccessDuplicates(hWnd);
+        }
+
+        if (g_settings.hidePinButtons)
+        {
+            HIMAGELIST hState = (HIMAGELIST)SendMessageW(
+                hWnd, TVM_GETIMAGELIST, TVSIL_STATE, 0);
+            if (hState)
+                SendMessageW(hWnd, TVM_SETIMAGELIST, TVSIL_STATE, 0);
+        }
+
+        if (ShouldRemoveSeparators() || g_hiddenDuplicate)
+            EnsureParentSubclass(hWnd);
+
+        if (g_settings.fixChevronDrawing)
+            g_inTreePaint = true;
+
+        LRESULT result = SubClassTreeWndProc_orig(hWnd, uMsg, wParam,
+                            lParam, uIdSubclass, dwRefData);
+
+        g_inTreePaint = false;
+
+        return result;
+    }
+
+    return SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam,
+                                    uIdSubclass, dwRefData);
+}
+
+using DrawThemeBackground_t = HRESULT (WINAPI *)(
+    HTHEME, HDC, int, int, LPCRECT, LPCRECT);
+
+DrawThemeBackground_t DrawThemeBackground_orig;
+
+HRESULT WINAPI DrawThemeBackground_hook(
+    HTHEME hTheme, HDC hdc, int iPartId, int iStateId,
+    LPCRECT pRect, LPCRECT pClipRect)
+{
+    if (g_inTreePaint && (iPartId == TVP_GLYPH || iPartId == TVP_HOTGLYPH))
+    {
+        RECT drawRect;
+        CalcGlyphRect(pRect, &drawRect);
+        DrawChevron(hdc, &drawRect, iPartId, iStateId);
+        return S_OK;
+    }
+    return DrawThemeBackground_orig(hTheme, hdc, iPartId, iStateId,
+                                    pRect, pClipRect);
+}
+
+// --- Settings ---
+
+void LoadSettings()
+{
+    g_settings.showThisPCAtTop = Wh_GetIntSetting(L"ThisPC.showThisPCAtTop");
+    g_settings.thisPCExpandable = Wh_GetIntSetting(L"ThisPC.thisPCExpandable");
+    g_settings.thisPCStartExpanded = Wh_GetIntSetting(L"ThisPC.thisPCStartExpanded");
+    g_settings.hideThisPCFromQuickAccess = Wh_GetIntSetting(L"ThisPC.hideThisPCFromQuickAccess");
+    g_settings.showDesktopAtTop = Wh_GetIntSetting(L"Desktop.showDesktopAtTop");
+    g_settings.desktopAboveThisPC = Wh_GetIntSetting(L"Desktop.desktopAboveThisPC");
+    g_settings.desktopExpandable = Wh_GetIntSetting(L"Desktop.desktopExpandable");
+    g_settings.hideDesktopFromQuickAccess = Wh_GetIntSetting(L"Desktop.hideDesktopFromQuickAccess");
+    g_settings.fixChevronDrawing = Wh_GetIntSetting(L"Resources.fixChevronDrawing");
+    g_settings.chevronScale = Wh_GetIntSetting(L"Resources.chevronScale");
+    g_settings.hidePinButtons = Wh_GetIntSetting(L"Resources.hidePinButtons");
+
+    g_sepColor = CLR_INVALID;
+
+    Wh_Log(L"Settings: thisPCAtTop=%d (expand=%d, startExp=%d, hideQA=%d) "
+            L"desktopAtTop=%d (above=%d, expand=%d, hideQA=%d) "
+            L"sepRemoval=%d fixChevron=%d chevronScale=%d hidePins=%d",
+            g_settings.showThisPCAtTop,
+            g_settings.thisPCExpandable, g_settings.thisPCStartExpanded,
+            g_settings.hideThisPCFromQuickAccess,
+            g_settings.showDesktopAtTop, g_settings.desktopAboveThisPC,
+            g_settings.desktopExpandable,
+            g_settings.hideDesktopFromQuickAccess,
+            ShouldRemoveSeparators(),
+            g_settings.fixChevronDrawing,
+            g_settings.chevronScale,
+            g_settings.hidePinButtons);
+}
+
+BOOL Wh_ModInit()
+{
+    HMODULE hExplorerFrame = GetModuleHandleW(L"ExplorerFrame.dll");
+    if (!hExplorerFrame)
+        return FALSE;
+
+    LoadSettings();
+
+    Gdiplus::GdiplusStartupInput gdipIn;
+    Gdiplus::GdiplusStartup(&g_gdipToken, &gdipIn, NULL);
+
+    SHGetSpecialFolderLocation(nullptr, CSIDL_DRIVES, &g_pidlThisPC);
+    if (!g_pidlThisPC)
+    {
+        Wh_Log(L"Failed to get This PC PIDL");
+        return FALSE;
+    }
+
+    SHGetSpecialFolderLocation(nullptr, CSIDL_DESKTOP, &g_pidlDesktop);
+    if (!g_pidlDesktop)
+        Wh_Log(L"Warning: failed to get Desktop PIDL");
+
+    WindhawkUtils::SYMBOL_HOOK explorerFrameDllHooks[] = {
+        {
+            {
+                L"public: virtual long __cdecl"
+                L" CNscTree::AppendRoot("
+                L"struct IShellItem *,"
+                L"unsigned long,"
+                L"unsigned long,"
+                L"struct IShellItemFilter *)"
+            },
+            &AppendRoot_orig,
+            AppendRoot_hook,
+            false
+        },
+        {
+            {
+                L"private: static __int64 __cdecl"
+                L" CNscTree::s_SubClassTreeWndProc("
+                L"struct HWND__ *,"
+                L"unsigned int,"
+                L"unsigned __int64,"
+                L"__int64,"
+                L"unsigned __int64,"
+                L"unsigned __int64)"
+            },
+            &SubClassTreeWndProc_orig,
+            SubClassTreeWndProc_hook,
+            false
+        },
+        {
+            {
+                L"public: virtual long __cdecl"
+                L" CNscTree::SetStateImageList("
+                L"struct _IMAGELIST *)"
+            },
+            &SetStateImageList_orig,
+            SetStateImageList_hook,
+            false
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(hExplorerFrame, explorerFrameDllHooks, ARRAYSIZE(explorerFrameDllHooks)))
+    {
+        Wh_Log(L"Failed to hook symbols");
+        return FALSE;
+    }
+
+    HMODULE hUxTheme = GetModuleHandleW(L"uxtheme.dll");
+    if (hUxTheme)
+    {
+        FARPROC pDTB = GetProcAddress(hUxTheme, "DrawThemeBackground");
+        if (pDTB)
+            Wh_SetFunctionHook((void *)pDTB,
+                               (void *)DrawThemeBackground_hook,
+                               (void **)&DrawThemeBackground_orig);
+    }
+
+    Wh_Log(L"Mod initialized successfully");
+    return TRUE;
+}
+
+void Wh_ModSettingsChanged()
+{
+    LoadSettings();
+}
+
+void Wh_ModUninit()
+{
+    if (g_gdipToken)
+    {
+        Gdiplus::GdiplusShutdown(g_gdipToken);
+        g_gdipToken = 0;
+    }
+    if (g_pidlThisPC)
+    {
+        CoTaskMemFree(g_pidlThisPC);
+        g_pidlThisPC = nullptr;
+    }
+    if (g_pidlDesktop)
+    {
+        CoTaskMemFree(g_pidlDesktop);
+        g_pidlDesktop = nullptr;
+    }
+    for (HWND parent : g_subclassedParents)
+    {
+        if (IsWindow(parent))
+            WindhawkUtils::RemoveWindowSubclassFromAnyThread(parent, SepParentSubclassProc);
+    }
+    g_subclassedParents.clear();
+    g_hCachedThisPC = nullptr;
+    g_hCachedDesktop = nullptr;
+    g_hCachedTree = nullptr;
+    g_hiddenDuplicate = nullptr;
+    Wh_Log(L"Mod uninitialized");
+}

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.10
+// @version         1.1.11
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -215,7 +215,7 @@ static COLORREF DeriveSepColor(HWND hTree)
     if (bg == CLR_INVALID || (int)bg == -1)
         bg = GetSysColor(COLOR_WINDOW);
     int sum = GetRValue(bg) + GetGValue(bg) + GetBValue(bg);
-    int d = (sum < 384) ? 24 : -28;
+    int d = (sum < 384) ? 56 : -41;
     auto cl = [](int v) { return (BYTE)(v < 0 ? 0 : (v > 255 ? 255 : v)); };
     return RGB(cl(GetRValue(bg) + d), cl(GetGValue(bg) + d), cl(GetBValue(bg) + d));
 }
@@ -241,7 +241,6 @@ struct TreeState {
     HTREEITEM boundaryItem = nullptr;
     HTREEITEM belowQAItem = nullptr;
     uint8_t pendingWork = 0;   // bitmask of PendingWork flags
-    bool qaEverCleaned = false;
     bool ownsNscRef = false;
     bool triedHomeSpacer = false;
     HIMAGELIST savedStateImageList = nullptr;
@@ -313,7 +312,6 @@ static void ResetTreeCleanup(TreeState& ts)
     ts.belowQAItem = nullptr;
     ts.triedHomeSpacer = false;
     ts.pendingWork = WORK_QA_CLEANUP | WORK_HG_CLEANUP | WORK_DUP_COLLAPSE;
-    ts.qaEverCleaned = false;
 }
 
 // Globals bridging AppendRoot_hook to TVM_INSERTITEM handler.
@@ -326,7 +324,7 @@ struct InsertionCtx {
 };
 static InsertionCtx g_ins;
 
-// AppendRoot_orig pumps messages, so a second tree's deferred op could corrupt g_ins.
+// Guards are static (not thread_local) because Wh_ModInit runs on the loader thread but hooks fire on the UI thread.
 static bool g_deferredOpInProgress = false;
 static HWND g_mutatingTree = nullptr;
 static std::unordered_set<HWND> g_pendingRebuildTrees;
@@ -604,11 +602,10 @@ static void DrawChevron(HDC hdc, const RECT *r, int partId, int stateId)
 static thread_local bool g_inTreePaint = false;
 static thread_local int g_inSubclassProc = 0;
 
-// --- Separator removal ---
-// Strategy: swallowing NM_CUSTOMDRAW CDDS_PREPAINT (by returning
-// CDRF_NOTIFYPOSTPAINT without calling DefSubclassProc) hides ALL
-// separator lines. At CDDS_POSTPAINT we redraw the ones we want to
-// keep — all section boundaries EXCEPT the one between our custom items.
+static bool AreWeMutating()
+{
+    return g_deferredOpInProgress || g_inSubclassProc > 0 || g_inCustomAppend;
+}
 
 static bool IsDepth1Item(HWND hTree, HTREEITEM h)
 {
@@ -719,6 +716,8 @@ static bool ShouldBeUnitHeight(const TreeState& ts, HWND hTree, HTREEITEM h)
 
     return false;
 }
+
+// --- Separator removal: CDDS_PREPAINT swallows all native separators; CDDS_POSTPAINT redraws wanted ones. ---
 
 static int GetBaseItemHeight(HWND hTree)
 {
@@ -969,6 +968,24 @@ static void FullRebuildTree(HWND hTree)
     void *pNscRaw = ts->pNscTree;
     unsigned long enumFlags = ts->enumFlags;
 
+    // Remove HomeSpacer before roots — it's a separate namespace item.
+    if (ts->homeSpacerItem)
+    {
+        int spacerId = g_navItems[NAV_HOME].pidl ? NAV_HOME
+                     : (g_navItems[NAV_GALLERY].pidl ? NAV_GALLERY : -1);
+        if (spacerId >= 0)
+        {
+            IShellItem* raw = nullptr;
+            if (SUCCEEDED(SHCreateItemFromIDList(g_navItems[spacerId].pidl,
+                                                  IID_IShellItem, (void**)&raw)) && raw)
+            {
+                pNsc->RemoveRoot(raw);
+                raw->Release();
+            }
+        }
+        ts->homeSpacerItem = nullptr;
+    }
+
     RootShellItems roots;
     if (!roots.Create()) return;
     roots.RemoveInsertableRoots(pNsc.get());
@@ -1014,8 +1031,10 @@ static void InsertHomeSpacer(HWND hTree)
     TreeState* ts = GetTree(hTree);
     if (!ts) return;
     ts->triedHomeSpacer = true;
-    // WORK_HOME_SPACER may fire before This PC is cached; re-check desktopOnly.
-    if (!ts->pNscTree || !ts->hItems[NAV_DESKTOP] || ts->hItems[NAV_THISPC]) return;
+    // Re-check: Desktop must be bottom of our section (alone or below This PC).
+    bool desktopAtBottom = ts->hItems[NAV_DESKTOP] &&
+        (!ts->hItems[NAV_THISPC] || !g_settings.desktopAboveThisPC);
+    if (!ts->pNscTree || !desktopAtBottom) return;
 
     int spacerId = g_navItems[NAV_HOME].pidl ? NAV_HOME
                  : (g_navItems[NAV_GALLERY].pidl ? NAV_GALLERY : -1);
@@ -1031,9 +1050,11 @@ static void InsertHomeSpacer(HWND hTree)
     unsigned long enumFlags = ts->enumFlags;
 
     g_spacerInsertAfter = ts->hItems[NAV_DESKTOP];
+    g_ins.forTree = hTree;
     g_inCustomAppend = true;
     AppendRoot_orig(pNsc, spacer.get(), enumFlags, 0, nullptr);
     g_inCustomAppend = false;
+    g_ins.forTree = nullptr;
     g_spacerInsertAfter = nullptr;
 
     ts = GetTree(hTree);
@@ -1076,8 +1097,7 @@ static SectionLayout FindSectionLayout(HWND hTree, TreeState& ts)
 {
     SectionLayout layout = {};
 
-    // Pre-resolve display names for inherited items with null handles
-    // so we can identify them by text during the walk.
+    // Text fallback for inherited items whose handles haven't been cached yet.
     WCHAR inheritedNames[NAV_COUNT][64] = {};
     bool inheritedHidden[NAV_COUNT] = {};
     for (int i = NAV_HOME; i < NAV_COUNT; i++)
@@ -1175,8 +1195,7 @@ static void DrawSeparatorLine(HDC hdc, HWND hTree, int sepY)
     }
 }
 
-// At CDDS_POSTPAINT, all separators have been hidden by CDDS_PREPAINT
-// swallowing. Redraw separators for section boundaries we want to keep.
+// Redraws wanted separators at CDDS_POSTPAINT after CDDS_PREPAINT hid all native ones.
 
 static bool HasOurItemsInTree(const TreeState& ts)
 {
@@ -1203,10 +1222,7 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
     bool foundBelowQA = false;
     int sepCount = 0;
 
-    // Diagnostic: build a walk summary for logging
-    // Each depth-1 item gets a tag: O=ours, H=home, G=gallery,
-    // B=boundary(tall), b=boundary(short), Q=belowQA(skipped),
-    // S=sep-drawn, .=other
+    // Walk log tags: O=ours, H=home, G=gallery, B/b=boundary, Q=belowQA, S=sep, .=other
     WCHAR walkLog[64] = {};
     int walkIdx = 0;
 
@@ -1284,10 +1300,7 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
     }
 }
 
-// Parent subclass — intercepts NM_CUSTOMDRAW.
-// Returning CDRF_NOTIFYPOSTPAINT at CDDS_PREPAINT without calling
-// DefSubclassProc hides ALL separator lines
-// At CDDS_POSTPAINT we redraw the separators we want to keep.
+// Parent subclass: CDDS_PREPAINT suppresses native separators, CDDS_POSTPAINT redraws wanted ones.
 static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData)
 {
     HWND hTree = (HWND)dwRefData;
@@ -1303,7 +1316,13 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
                 DWORD stage = cd->nmcd.dwDrawStage;
                 TreeState* ts = GetTree(hTree);
                 if (stage == CDDS_PREPAINT && g_settings.hasItemsAtTop)
-                    return CDRF_NOTIFYPOSTPAINT;
+                {
+                    // Only suppress native separators once our items are in this tree.
+                    if (ts && HasOurItemsInTree(*ts))
+                        return CDRF_NOTIFYPOSTPAINT;
+                    LRESULT r = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+                    return r | CDRF_NOTIFYPOSTPAINT;
+                }
 
                 if (stage == CDDS_POSTPAINT)
                 {
@@ -1545,8 +1564,7 @@ SubClassTreeWndProc_t SubClassTreeWndProc_orig;
 
 LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
-    // Pass through re-entered messages to avoid deadlocks via other
-    // mods' global CallWndProc hooks during our SendMessageW calls.
+    // Re-entered messages pass through to avoid deadlocks from other mods' global CallWndProc hooks.
     if (g_inSubclassProc > 0 &&
         uMsg != TVM_INSERTITEMW && uMsg != TVM_INSERTITEMA &&
         uMsg != WM_NCDESTROY)
@@ -1564,7 +1582,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             TVINSERTSTRUCTW *pInsert = (TVINSERTSTRUCTW *)lParam;
             pInsert->hInsertAfter = TVI_FIRST;
         }
-        else if (g_spacerInsertAfter && lParam)
+        else if (g_spacerInsertAfter && lParam && (!g_ins.forTree || hWnd == g_ins.forTree))
         {
             TVINSERTSTRUCTW *pInsert = (TVINSERTSTRUCTW *)lParam;
             pInsert->hInsertAfter = g_spacerInsertAfter;
@@ -1648,8 +1666,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                     for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
                         if (ts->hItems[i]) { hasOurItems = true; break; }
 
-                    if (hasOurItems && !g_deferredOpInProgress && !g_inTreePaint &&
-                        g_inSubclassProc == 0)
+                    if (hasOurItems && !AreWeMutating() && !g_inTreePaint)
                     {
                         ts->pendingWork |= WORK_FULL_REBUILD;
                         PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
@@ -1768,7 +1785,6 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             if (CleanupQuickAccessDuplicates(hWnd, *ts))
             {
                 ts->pendingWork &= ~WORK_QA_CLEANUP;
-                ts->qaEverCleaned = true;
             }
             ts = GetTree(hWnd);
         }
@@ -1819,6 +1835,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         if (ts && (ts->pendingWork & DEFER_MASK))
             PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
 
+        // Paint-time mutations must be idempotent (no-op when already in target state) to avoid relayout loops.
         if (ts && g_settings.hasItemsAtTop)
         {
             for (int i = NAV_HOME; i < NAV_COUNT; i++)
@@ -1826,6 +1843,17 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 if (!ts->hItems[i]) continue;
                 if (!g_settings.items[i].hide)
                     CollapseItemIntegral(hWnd, ts->hItems[i]);
+            }
+            // TVM_SETITEMW's rect check can fail before layout; catch it here.
+            if (ShouldRemoveInternalSep() && ts->hItems[NAV_THISPC] && ts->hItems[NAV_DESKTOP])
+            {
+                RECT rcA = {}, rcB = {};
+                if (GetItemRect(hWnd, ts->hItems[NAV_THISPC], &rcA) &&
+                    GetItemRect(hWnd, ts->hItems[NAV_DESKTOP], &rcB))
+                {
+                    HTREEITEM hLower = (rcA.top > rcB.top) ? ts->hItems[NAV_THISPC] : ts->hItems[NAV_DESKTOP];
+                    CollapseItemIntegral(hWnd, hLower);
+                }
             }
         }
 
@@ -1835,8 +1863,10 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             ts->boundaryItem = layout.boundary;
             ts->belowQAItem = nullptr;
 
-            bool desktopOnly = ts->hItems[NAV_DESKTOP] && !ts->hItems[NAV_THISPC];
-            if (!ts->triedHomeSpacer && layout.boundary && desktopOnly
+            // Desktop is the bottom item of our section when alone or below This PC.
+            bool desktopAtBottom = ts->hItems[NAV_DESKTOP] &&
+                (!ts->hItems[NAV_THISPC] || !g_settings.desktopAboveThisPC);
+            if (!ts->triedHomeSpacer && layout.boundary && desktopAtBottom
                 && !g_settings.removeSepBelowNav && !GetHiddenItem(*ts)
                 && !layout.homePresent && !layout.galleryPresent)
             {
@@ -2301,9 +2331,7 @@ void Wh_ModSettingsChanged()
     if (tier == TIER_NONE)
         return;
 
-    // Snapshot HWNDs: FullRebuildTree pumps messages, which can trigger
-    // TVM_INSERTITEM on other trees, calling g_trees[hWnd] (operator[])
-    // and invalidating iterators if we're mid-range-for.
+    // Snapshot HWNDs: FullRebuildTree pumps messages, which can rehash g_trees mid-iteration.
     std::vector<HWND> treeList;
     treeList.reserve(g_trees.size());
     for (auto& [hTree, ts] : g_trees)
@@ -2355,7 +2383,6 @@ void Wh_ModSettingsChanged()
             if (dedupChanged)
             {
                 ts->pendingWork |= WORK_QA_CLEANUP;
-                ts->qaEverCleaned = false;
             }
             if (sepChanged || dedupChanged)
             {
@@ -2374,8 +2401,7 @@ void Wh_ModUninit()
     g_settings = {};
     ResetSepColor();
 
-    // Snapshot HWNDs: AppendRoot_orig pumps messages, which could
-    // trigger TVM_INSERTITEM and modify g_trees during iteration.
+    // Snapshot HWNDs: AppendRoot_orig pumps messages, which can rehash g_trees mid-iteration.
     std::vector<HWND> uninitList;
     uninitList.reserve(g_trees.size());
     for (auto& [hTree, ts] : g_trees)

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.16
+// @version         1.1.17
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -284,6 +284,13 @@ static bool IsInsertableItem(int id)
     return id == NAV_THISPC || id == NAV_DESKTOP;
 }
 
+// Settings determine visual order; no rect measurement needed.
+static HTREEITEM LowerInsertableItem(const TreeState& ts)
+{
+    int lower = g_settings.desktopAboveThisPC ? NAV_THISPC : NAV_DESKTOP;
+    return ts.hItems[lower];
+}
+
 static void GetPidlDisplayName(PIDLIST_ABSOLUTE pidl, WCHAR *buf, int len)
 {
     IShellItem *psi = nullptr;
@@ -346,6 +353,18 @@ static TreeState* RunDeferredWork(HWND hWnd, TreeState* ts, uint8_t flag, void(*
     ts->pendingWork &= ~flag;
     op(hWnd);
     ts = GetTree(hWnd);
+    return ts;
+}
+
+static TreeState* RunDeferredWorkIf(HWND hWnd, TreeState* ts, uint8_t flag,
+                                    bool pre, bool(*op)(HWND, TreeState&))
+{
+    if (!ts || !(ts->pendingWork & flag) || !pre)
+        return ts;
+    bool done = op(hWnd, *ts);
+    ts = GetTree(hWnd);
+    if (done && ts)
+        ts->pendingWork &= ~flag;
     return ts;
 }
 
@@ -649,6 +668,31 @@ static void ForEachDepth1Item(HWND hTree, F&& visitor)
     }
 }
 
+static void GetItemText(HWND hTree, HTREEITEM h, WCHAR *buf, int len)
+{
+    TVITEMEXW tvi = {};
+    tvi.mask = TVIF_HANDLE | TVIF_TEXT;
+    tvi.hItem = h;
+    tvi.pszText = buf;
+    tvi.cchTextMax = len;
+    SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
+}
+
+template<typename Skip, typename OnMatch>
+static void ForEachLabeledSibling(HWND hTree, Skip&& skip,
+                                  const WCHAR names[][64], int count, OnMatch&& onMatch)
+{
+    ForEachDepth1Item(hTree, [&](HTREEITEM h) -> bool {
+        if (skip(h)) return true;
+        WCHAR text[64] = {};
+        GetItemText(hTree, h, text, ARRAYSIZE(text));
+        for (int j = 0; j < count; j++)
+            if (names[j][0] && wcscmp(text, names[j]) == 0)
+                return onMatch(h, j);
+        return true;
+    });
+}
+
 static bool CollapseItemIntegral(HWND hTree, HTREEITEM h)
 {
     TVITEMEXW tvi = {};
@@ -720,13 +764,9 @@ static bool ShouldBeUnitHeight(const TreeState& ts, HWND hTree, HTREEITEM h)
         HTREEITEM hB = ts.hItems[NAV_DESKTOP];
         if (hA && hB && (h == hA || h == hB))
         {
-            RECT rcA = {}, rcB = {};
-            if (GetItemRect(hTree, hA, &rcA) && GetItemRect(hTree, hB, &rcB))
-            {
-                HTREEITEM hLower = (rcA.top > rcB.top) ? hA : hB;
-                if (h == hLower)
-                    return true;
-            }
+            HTREEITEM hLower = LowerInsertableItem(ts);
+            if (h == hLower)
+                return true;
         }
     }
 
@@ -751,16 +791,6 @@ static int GetBaseItemHeight(HWND hTree)
         h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_NEXTVISIBLE, (LPARAM)h);
     }
     return baseHeight;
-}
-
-static void GetItemText(HWND hTree, HTREEITEM h, WCHAR *buf, int len)
-{
-    TVITEMEXW tvi = {};
-    tvi.mask = TVIF_HANDLE | TVIF_TEXT;
-    tvi.hItem = h;
-    tvi.pszText = buf;
-    tvi.cchTextMax = len;
-    SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
 }
 
 static void CollapseMatchingItems(HWND hTree, const TreeState *ts,
@@ -896,6 +926,24 @@ static LRESULT CALLBACK TreeInteractionProc(
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
 
+static void RemoveHomeSpacer(TreeState& ts, INameSpaceTreeControl* pNsc)
+{
+    if (!ts.homeSpacerItem) return;
+    int spacerId = g_navItems[NAV_HOME].pidl ? NAV_HOME
+                 : (g_navItems[NAV_GALLERY].pidl ? NAV_GALLERY : -1);
+    if (spacerId >= 0)
+    {
+        IShellItem* raw = nullptr;
+        if (SUCCEEDED(SHCreateItemFromIDList(g_navItems[spacerId].pidl,
+                                              IID_IShellItem, (void**)&raw)) && raw)
+        {
+            pNsc->RemoveRoot(raw);
+            raw->Release();
+        }
+    }
+    ts.homeSpacerItem = nullptr;
+}
+
 static void RestoreTree(HWND hTree)
 {
     TreeState* ts = GetTree(hTree);
@@ -910,22 +958,7 @@ static void RestoreTree(HWND hTree)
     HIMAGELIST savedImgList = ts->savedStateImageList;
     bool ownsRef = ts->ownsNscRef;
 
-    if (ts->homeSpacerItem)
-    {
-        int spacerId = g_navItems[NAV_HOME].pidl ? NAV_HOME
-                     : (g_navItems[NAV_GALLERY].pidl ? NAV_GALLERY : -1);
-        if (spacerId >= 0)
-        {
-            IShellItem* raw = nullptr;
-            if (SUCCEEDED(SHCreateItemFromIDList(g_navItems[spacerId].pidl,
-                                                  IID_IShellItem, (void**)&raw)) && raw)
-            {
-                ((INameSpaceTreeControl *)pNscRaw)->RemoveRoot(raw);
-                raw->Release();
-            }
-        }
-        ts->homeSpacerItem = nullptr;
-    }
+    RemoveHomeSpacer(*ts, (INameSpaceTreeControl *)pNscRaw);
 
     // Remove our roots
     RootShellItems roots;
@@ -992,22 +1025,7 @@ static void FullRebuildTree(HWND hTree)
     unsigned long enumFlags = ts->enumFlags;
 
     // Remove HomeSpacer before roots — it's a separate namespace item.
-    if (ts->homeSpacerItem)
-    {
-        int spacerId = g_navItems[NAV_HOME].pidl ? NAV_HOME
-                     : (g_navItems[NAV_GALLERY].pidl ? NAV_GALLERY : -1);
-        if (spacerId >= 0)
-        {
-            IShellItem* raw = nullptr;
-            if (SUCCEEDED(SHCreateItemFromIDList(g_navItems[spacerId].pidl,
-                                                  IID_IShellItem, (void**)&raw)) && raw)
-            {
-                pNsc->RemoveRoot(raw);
-                raw->Release();
-            }
-        }
-        ts->homeSpacerItem = nullptr;
-    }
+    RemoveHomeSpacer(*ts, pNsc.get());
 
     RootShellItems roots;
     if (!roots.Create()) return;
@@ -1092,18 +1110,12 @@ static void InsertHomeSpacer(HWND hTree)
     if (!ts) return;
 
     HTREEITEM hSpacer = nullptr;
-    const WCHAR* spacerLabel = g_navItems[spacerId].label;
-    ForEachDepth1Item(hTree, [&](HTREEITEM h) -> bool {
-        if (h == ts->hItems[NAV_DESKTOP] || h == ts->hItems[NAV_THISPC])
-            return true;
-        WCHAR buf[256];
-        GetItemText(hTree, h, buf, 256);
-        if (wcscmp(buf, spacerLabel) == 0) {
-            hSpacer = h;
-            return false;
-        }
-        return true;
-    });
+    WCHAR spacerNames[1][64] = {};
+    wcsncpy_s(spacerNames[0], 64, g_navItems[spacerId].label, _TRUNCATE);
+    ForEachLabeledSibling(hTree,
+        [&](HTREEITEM h) { return h == ts->hItems[NAV_DESKTOP] || h == ts->hItems[NAV_THISPC]; },
+        spacerNames, 1,
+        [&](HTREEITEM h, int) -> bool { hSpacer = h; return false; });
 
     if (hSpacer)
     {
@@ -1112,7 +1124,7 @@ static void InsertHomeSpacer(HWND hTree)
     }
 
     Wh_Log(L"[SPACER] tree=%04X %s h=%04X after=%04X",
-           PTR4(hTree), spacerLabel, PTR4(hSpacer), PTR4(ts->hItems[NAV_DESKTOP]));
+           PTR4(hTree), g_navItems[spacerId].label, PTR4(hSpacer), PTR4(ts->hItems[NAV_DESKTOP]));
 
     InvalidateRect(hTree, nullptr, TRUE);
 }
@@ -1469,34 +1481,17 @@ static bool CleanupDups(HWND hTree, TreeState& ts)
     int childlessCount = 0;
     int sectionCount = 0;
 
-    ForEachDepth1Item(hTree, [&](HTREEITEM h) -> bool {
-        if (!IsOurSection(ts, h))
-        {
-            WCHAR text[64] = {};
-            GetItemText(hTree, h, text, ARRAYSIZE(text));
-
-            bool match = false;
-            for (int i = 0; i < expectedCount; i++)
-                if (matchNames[i][0] && wcscmp(text, matchNames[i]) == 0)
-                    { match = true; break; }
-
-            if (match)
-            {
-                HTREEITEM hChild = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_CHILD, (LPARAM)h);
-                if (!hChild)
-                {
-                    if (childlessCount < 8)
-                        toDeleteChildless[childlessCount++] = h;
-                }
-                else
-                {
-                    if (sectionCount < 4)
-                        toDeleteSections[sectionCount++] = h;
-                }
-            }
-        }
-        return true;
-    });
+    ForEachLabeledSibling(hTree,
+        [&](HTREEITEM h) { return IsOurSection(ts, h); },
+        matchNames, expectedCount,
+        [&](HTREEITEM h, int) -> bool {
+            HTREEITEM hChild = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_CHILD, (LPARAM)h);
+            if (!hChild)
+            { if (childlessCount < 8) toDeleteChildless[childlessCount++] = h; }
+            else
+            { if (sectionCount < 4) toDeleteSections[sectionCount++] = h; }
+            return true;
+        });
 
     // Redraw freeze prevents Explorer from synchronously re-inserting during deletion.
     bool needDelete = (sectionCount > 0 || childlessCount > 0);
@@ -1559,21 +1554,19 @@ static bool RemoveInherited(HWND hTree, TreeState& ts)
     struct { HTREEITEM h; int id; } toDelete[NAV_COUNT] = {};
     int delCount = 0;
 
-    ForEachDepth1Item(hTree, [&](HTREEITEM h) -> bool {
-        if (delCount >= targetCount)
-            return false;
-        if (!IsOurSection(ts, h) && h != ts.hiddenDuplicate && h != ts.homeSpacerItem)
-        {
-            WCHAR text[64] = {};
-            GetItemText(hTree, h, text, ARRAYSIZE(text));
-            for (int j = 0; j < targetCount; j++)
-            {
-                if (wcscmp(text, targets[j].name) == 0)
-                { toDelete[delCount++] = { h, targets[j].id }; break; }
-            }
-        }
-        return true;
-    });
+    WCHAR targetNames[NAV_COUNT][64] = {};
+    for (int i = 0; i < targetCount; i++)
+        wcsncpy_s(targetNames[i], 64, targets[i].name, _TRUNCATE);
+
+    ForEachLabeledSibling(hTree,
+        [&](HTREEITEM h) {
+            return IsOurSection(ts, h) || h == ts.hiddenDuplicate || h == ts.homeSpacerItem;
+        },
+        targetNames, targetCount,
+        [&](HTREEITEM h, int j) -> bool {
+            toDelete[delCount++] = { h, targets[j].id };
+            return delCount < targetCount;
+        });
 
     if (delCount > 0)
     {
@@ -1587,6 +1580,23 @@ static bool RemoveInherited(HWND hTree, TreeState& ts)
         }
     }
     return true;
+}
+
+static bool QaCleanupStep(HWND h, TreeState& ts) { return CleanupDups(h, ts); }
+static bool HgCleanupStep(HWND h, TreeState& ts) { return RemoveInherited(h, ts); }
+
+// Pre-clear: TVE_COLLAPSE re-sets WORK_DUP_COLLAPSE, so clearing before lets that survive.
+static void DupCollapse(HWND h)
+{
+    TreeState* ts = GetTree(h);
+    if (!ts) return;
+    WCHAR collapseText[NAV_COUNT][64] = {};
+    int collapseCount = BuildMatchList(collapseText, NAV_COUNT,
+        [](int id, const NavItemSettings& s) {
+            return IsInsertableItem(id) && s.showAtTop && !s.hideFromQA;
+        });
+    if (collapseCount > 0)
+        CollapseMatchingItems(h, ts, collapseText, collapseCount);
 }
 
 // --- SubClassTreeWndProc ---
@@ -1810,49 +1820,18 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
 
         TreeState* ts = GetTree(hWnd);
         ts = RunDeferredWork(hWnd, ts, WORK_FULL_REBUILD, FullRebuildTree);
-        ts = RunDeferredWork(hWnd, ts, WORK_HOT_INSERT, HotEnableInsert);
-
-        if (ts && (ts->pendingWork & WORK_QA_CLEANUP) &&
-            ((g_settings.items[NAV_THISPC].showAtTop && g_settings.items[NAV_THISPC].hideFromQA) ||
-             (g_settings.items[NAV_DESKTOP].showAtTop && g_settings.items[NAV_DESKTOP].hideFromQA)))
-        {
-            if (CleanupDups(hWnd, *ts))
-            {
-                ts->pendingWork &= ~WORK_QA_CLEANUP;
-            }
-            ts = GetTree(hWnd);
-        }
-
-        if (ts && (ts->pendingWork & WORK_HG_CLEANUP) && ts->pNscTree &&
+        ts = RunDeferredWork(hWnd, ts, WORK_HOT_INSERT,   HotEnableInsert);
+        ts = RunDeferredWorkIf(hWnd, ts, WORK_QA_CLEANUP,
+            (g_settings.items[NAV_THISPC].showAtTop && g_settings.items[NAV_THISPC].hideFromQA) ||
+            (g_settings.items[NAV_DESKTOP].showAtTop && g_settings.items[NAV_DESKTOP].hideFromQA),
+            QaCleanupStep);
+        ts = RunDeferredWorkIf(hWnd, ts, WORK_HG_CLEANUP,
+            ts && ts->pNscTree &&
             (g_navItems[NAV_HOME].pidl || g_navItems[NAV_GALLERY].pidl) &&
-            (g_settings.items[NAV_HOME].hide || g_settings.items[NAV_GALLERY].hide))
-        {
-            if (RemoveInherited(hWnd, *ts))
-                ts->pendingWork &= ~WORK_HG_CLEANUP;
-        }
-
-        ts = GetTree(hWnd);
-        if (ts && (ts->pendingWork & WORK_DUP_COLLAPSE))
-        {
-            WCHAR collapseText[NAV_COUNT][64] = {};
-            int collapseCount = BuildMatchList(collapseText, NAV_COUNT,
-                [](int id, const NavItemSettings& s) {
-                    return IsInsertableItem(id) && s.showAtTop && !s.hideFromQA;
-                });
-
-            ts->pendingWork &= ~WORK_DUP_COLLAPSE;
-            if (collapseCount > 0)
-                CollapseMatchingItems(hWnd, ts, collapseText, collapseCount);
-        }
-
-        ts = GetTree(hWnd);
-        if (ts && (ts->pendingWork & WORK_EXPAND))
-        {
-            ts->pendingWork &= ~WORK_EXPAND;
-            ExpandStartExpandedItems(hWnd);
-        }
-
-        ts = GetTree(hWnd);
+            (g_settings.items[NAV_HOME].hide || g_settings.items[NAV_GALLERY].hide),
+            HgCleanupStep);
+        ts = RunDeferredWork(hWnd, ts, WORK_DUP_COLLAPSE, DupCollapse);
+        ts = RunDeferredWork(hWnd, ts, WORK_EXPAND, ExpandStartExpandedItems);
         ts = RunDeferredWork(hWnd, ts, WORK_HOME_SPACER, InsertHomeSpacer);
 
         g_inSubclassProc--;
@@ -1879,15 +1858,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                     CollapseItemIntegral(hWnd, ts->hItems[i]);
             }
             if (ShouldRemoveInternalSep() && ts->hItems[NAV_THISPC] && ts->hItems[NAV_DESKTOP])
-            {
-                RECT rcA = {}, rcB = {};
-                if (GetItemRect(hWnd, ts->hItems[NAV_THISPC], &rcA) &&
-                    GetItemRect(hWnd, ts->hItems[NAV_DESKTOP], &rcB))
-                {
-                    HTREEITEM hLower = (rcA.top > rcB.top) ? ts->hItems[NAV_THISPC] : ts->hItems[NAV_DESKTOP];
-                    CollapseItemIntegral(hWnd, hLower);
-                }
-            }
+                CollapseItemIntegral(hWnd, LowerInsertableItem(*ts));
         }
 
         SectionLayout layout = {};

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.4
+// @version         1.1.5
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -33,11 +33,11 @@ This mod injects only in processes that have ExplorerFrame.dll, so the include i
 
 Before:
 
-![Before](https://i.imgur.com/nC9T5A7.jpeg)
+![Before](https://i.imgur.com/eWSQRJb.png)
 
 After:
 
-![After](https://i.imgur.com/JQQ5ZTN.jpeg)
+![After](https://i.imgur.com/6IaHifm.png)
 
 The screenshots show the normal Desktop pinned to Quick Access in the before, and the mod with defaults set in the after.
 */
@@ -331,13 +331,9 @@ static void DrainPendingRebuilds()
     }
 }
 
-static TreeState* RunDeferredWork(HWND hWnd, TreeState* ts,
-                                  uint8_t flag, void(*op)(HWND),
-                                  bool checkGuard = false)
+static TreeState* RunDeferredWork(HWND hWnd, TreeState* ts, uint8_t flag, void(*op)(HWND))
 {
     if (!ts || !(ts->pendingWork & flag))
-        return ts;
-    if (checkGuard && g_deferredOpInProgress)
         return ts;
     g_deferredOpInProgress = true;
     ts->pendingWork &= ~flag;
@@ -470,11 +466,7 @@ static void ExpandStartExpandedItems(HWND hTree)
 
 HRESULT THISCALL AppendRoot_hook(void *pThis, IShellItem *psiRoot, unsigned long grfEnumFlags, unsigned long grfRootStyle, IShellItemFilter *pFilter)
 {
-    // Intercept Home/Gallery root items by PIDL comparison.
-    // Must happen BEFORE g_inCustomAppend check: during FullRebuildTree,
-    // AppendRoot_orig for the hidden root can trigger Explorer to add
-    // Home/Gallery internally while g_inCustomAppend is true. Without
-    // this, ts.hItems[NAV_HOME]/ts.hItems[NAV_GALLERY] would never be cached.
+    // Must run before g_inCustomAppend check so Home/Gallery get cached.
     {
         PIDLIST_ABSOLUTE pidlRoot = nullptr;
         if (SUCCEEDED(SHGetIDListFromObject(psiRoot, &pidlRoot)))
@@ -733,8 +725,6 @@ static void RefreshNavPane(HWND hTree)
         }
     }
 
-    // Clear managed items — CleanupQuickAccessDuplicates will
-    // re-evaluate on the next paint.
     ResetTreeCleanup(*ts);
 
     {
@@ -764,8 +754,7 @@ static void HotEnableInsert(HWND hWnd)
 
     ts->hItems[NAV_THISPC] = nullptr;
     ts->hItems[NAV_DESKTOP] = nullptr;
-    // Don't clear inherited items (Home/Gallery): they may have been
-    // cached during FullRebuildTree's AppendRoot_orig and are still valid.
+    // Home/Gallery handles may still be valid from FullRebuildTree.
     ResetTreeCleanup(*ts);
     ResetSepColor();
 
@@ -781,9 +770,7 @@ static void HotEnableInsert(HWND hWnd)
            ts ? ts->hItems[NAV_THISPC] : nullptr, ts ? ts->hItems[NAV_DESKTOP] : nullptr,
            ts ? ts->hItems[NAV_HOME] : nullptr, ts ? ts->hItems[NAV_GALLERY] : nullptr);
 
-    // Invalidate for dedup and separator setup on the next paint
-    // (not RDW_UPDATENOW since we're already inside WM_PAINT)
-    InvalidateRect(hWnd, nullptr, TRUE);
+    InvalidateRect(hWnd, nullptr, TRUE); // not RDW_UPDATENOW: inside WM_PAINT
 }
 
 static LRESULT CALLBACK TreeInteractionProc(
@@ -830,14 +817,12 @@ static void RestoreTree(HWND hTree)
     if (!roots.Create()) return;
     roots.RemoveInsertableRoots(pNsc.get());
 
-    // Re-add hidden root with current (zeroed) settings — hook passes through
     if (roots.items[NAV_DESKTOP] && pNscRaw)
     {
         g_inCustomAppend = true;
         AppendRoot_orig(pNscRaw, roots.items[NAV_DESKTOP].get(), enumFlags, 0x1, pFilter.get());
         g_inCustomAppend = false;
 
-        // Collapse expanded items matching our items' names
         WCHAR collapseNames[NAV_COUNT][64] = {};
         int collapseCount = BuildMatchList(collapseNames, NAV_COUNT,
             [](int id, const NavItemSettings&) {
@@ -856,7 +841,6 @@ static void RestoreTree(HWND hTree)
         Wh_Log(L"[DISABLE] Restored state image list %p for tree=%p", savedImgList, hTree);
     }
 
-    // Re-fetch ts: AppendRoot_orig pumps messages
     ts = GetTree(hTree);
     if (ts)
     {
@@ -870,12 +854,10 @@ static void RestoreTree(HWND hTree)
         }
     }
 
-    // Release TreeState's ownership ref (separate from our ComRef AddRef)
     if (ownsRef)
         pNsc.p->Release();
 
     Wh_Log(L"[DISABLE] Cleaned up tree=%p", hTree);
-    // ComRef destructors release our local AddRefs (pFilter, pNsc)
 }
 
 static void FullRebuildTree(HWND hTree)
@@ -899,9 +881,6 @@ static void FullRebuildTree(HWND hTree)
 
     if (roots.items[NAV_DESKTOP])
     {
-        // Clear ALL item handles: RemoveRoot(pDesktop) destroys the
-        // hidden root and all its children (Home, Gallery, QA items).
-        // All old handles are now invalid.
         ts = GetTree(hTree);
         if (ts)
         {
@@ -917,8 +896,6 @@ static void FullRebuildTree(HWND hTree)
         AppendRoot_orig(pNscRaw, roots.items[NAV_DESKTOP].get(), enumFlags, 0x1, nullptr);
         g_inCustomAppend = false;
 
-        // Re-fetch ts: AppendRoot_orig pumps messages, which can
-        // trigger TVM_INSERTITEM and rehash g_trees.
         ts = GetTree(hTree);
         if (ts)
         {
@@ -1236,11 +1213,6 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
 
                 if (stage == CDDS_POSTPAINT)
                 {
-                    // Re-verify separator color after theme/syscolor
-                    // change. CDDS_PREPAINT let native separators
-                    // through so we can re-sample. If the color
-                    // changed, update and repaint; if same, just
-                    // repaint to re-suppress native separators.
                     if (g_sepColorPendingVerify && g_sepColor != CLR_INVALID && g_settings.hasItemsAtTop)
                     {
                         g_sepColorPendingVerify = false;
@@ -1304,8 +1276,6 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
                 }
             }
 
-            // After expand/collapse, force full repaint so stale
-            // separator lines at old positions get overwritten.
             if (hdr->code == TVN_ITEMEXPANDEDW ||
                 hdr->code == TVN_ITEMEXPANDEDA)
             {
@@ -1357,13 +1327,7 @@ HRESULT THISCALL SetStateImageList_hook(void *pThis, HIMAGELIST himl)
     return SetStateImageList_orig(pThis, himl);
 }
 
-// --- Quick Access item hiding ---
-// Walk depth-1 children of the hidden root and delete items matching
-// our items' display text. Both childless QA pins and native sections
-// with children are deleted — our top-level items replace them.
-//
-// Returns true when all expected childless duplicates were found.
-// Returns false if some are still missing (async population race).
+// Returns false if expected dups are missing (async population race).
 static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
 {
     if (!ts.hItems[NAV_THISPC] && !ts.hItems[NAV_DESKTOP])
@@ -1422,7 +1386,6 @@ static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
     if (needDelete)
         SendMessageW(hTree, WM_SETREDRAW, FALSE, 0);
 
-    // Native sections with children: always delete (our items replace them)
     for (int i = 0; i < sectionCount; i++)
     {
         Wh_Log(L"[QA-HIDE] deleting native section=%p", toDeleteSections[i]);
@@ -1454,7 +1417,8 @@ static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
         InvalidateRect(hTree, nullptr, TRUE);
     }
 
-    bool complete = (childlessCount >= expectedCount);
+    int totalFound = childlessCount + sectionCount;
+    bool complete = (totalFound >= expectedCount);
     if (needDelete && (complete || ts.hiddenDuplicate != prevDup))
         Wh_Log(L"[QA-HIDE] tree=%p childless=%d sections=%d expected=%d", hTree, childlessCount, sectionCount, expectedCount);
 
@@ -1524,12 +1488,8 @@ SubClassTreeWndProc_t SubClassTreeWndProc_orig;
 
 LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
-    // Re-entrancy guard: if we're already on the stack (g_inSubclassProc > 0)
-    // from WM_PAINT or WM_DEFERRED_REBUILD, any SendMessageW from our code
-    // can deadlock via global CallWndProc hooks (translucent-windows,
-    // AquaSnap) that make cross-process kernel transitions. Pass through
-    // for re-entered messages. Safe exceptions: TVM_INSERTITEM (caches
-    // handles, sends nothing out), WM_NCDESTROY (cleanup, no sends).
+    // Pass through re-entered messages to avoid deadlocks via other
+    // mods' global CallWndProc hooks during our SendMessageW calls.
     if (g_inSubclassProc > 0 &&
         uMsg != TVM_INSERTITEMW && uMsg != TVM_INSERTITEMA &&
         uMsg != WM_NCDESTROY)
@@ -1829,15 +1789,11 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
     {
         TreeState* ts = GetTree(hWnd);
 
-        // Tree-mutating deferred work (rebuild, insert, delete, collapse)
-        // must NOT run during WM_PAINT. Defer to WM_DEFERRED_REBUILD.
         constexpr uint8_t DEFER_MASK = WORK_FULL_REBUILD | WORK_HOT_INSERT |
             WORK_QA_CLEANUP | WORK_HG_CLEANUP | WORK_DUP_COLLAPSE;
         if (ts && (ts->pendingWork & DEFER_MASK))
             PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
 
-        // Collapse iIntegral on visible inherited items so there's no
-        // separator space between our items and them.
         if (ts && g_settings.hasItemsAtTop)
         {
             for (int i = NAV_HOME; i < NAV_COUNT; i++)
@@ -1848,9 +1804,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             }
         }
 
-        // Find and optionally collapse separator boundary items.
-        // Deferred until g_sepColor is captured so tall items remain
-        // for the sampling pass on the first paint cycle.
+        // Tall items remain until g_sepColor is captured for sampling.
         if (g_settings.hasItemsAtTop && g_sepColor != CLR_INVALID && ts)
         {
             SectionLayout layout = FindSectionLayout(hWnd, *ts);

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,11 +2,10 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.22
+// @version         1.2.0
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
-// @architecture    x86-64
 // @compilerOptions -lole32 -lshell32 -luuid -luxtheme -lgdi32 -lgdiplus -lcomctl32
 // @license         MIT
 // ==/WindhawkMod==
@@ -113,7 +112,7 @@ Before/after:
 #ifdef _WIN64
 #define THISCALL __cdecl
 #else
-#define THISCALL __thiscall
+#define THISCALL __stdcall
 #endif
 
 template<typename T>
@@ -299,7 +298,8 @@ static HTREEITEM LowerInsertableItem(const TreeState& ts)
 static void GetPidlDisplayName(PIDLIST_ABSOLUTE pidl, WCHAR *buf, int len)
 {
     IShellItem *psi = nullptr;
-    if (SUCCEEDED(SHCreateItemFromIDList(pidl, IID_IShellItem, (void **)&psi)) && psi)
+    HRESULT hr = SHCreateItemFromIDList(pidl, IID_IShellItem, (void **)&psi);
+    if (SUCCEEDED(hr) && psi)
     {
         LPWSTR name = nullptr;
         if (SUCCEEDED(psi->GetDisplayName(SIGDN_NORMALDISPLAY, &name)) && name)
@@ -308,6 +308,27 @@ static void GetPidlDisplayName(PIDLIST_ABSOLUTE pidl, WCHAR *buf, int len)
             CoTaskMemFree(name);
         }
         psi->Release();
+    }
+    if (!buf[0])
+    {
+        IShellFolder *pDesktop = nullptr;
+        if (SUCCEEDED(SHGetDesktopFolder(&pDesktop)) && pDesktop)
+        {
+            STRRET str = {};
+            if (SUCCEEDED(pDesktop->GetDisplayNameOf((PCUITEMID_CHILD)pidl, SHGDN_NORMAL, &str)))
+            {
+                if (str.uType == STRRET_WSTR && str.pOleStr)
+                {
+                    wcsncpy_s(buf, len, str.pOleStr, _TRUNCATE);
+                    CoTaskMemFree(str.pOleStr);
+                }
+                else if (str.uType == STRRET_CSTR)
+                {
+                    MultiByteToWideChar(CP_ACP, 0, str.cStr, -1, buf, len);
+                }
+            }
+            pDesktop->Release();
+        }
     }
 }
 
@@ -1058,6 +1079,27 @@ static void RestoreTree(HWND hTree)
     Wh_Log(L"[DISABLE] tree=%04X imglist=%04X", PTR4(hTree), PTR4(savedImgList));
 }
 
+static LRESULT CALLBACK RestoreSubclassProc(
+    HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData)
+{
+    if (uMsg == WM_RESTORE_TREE)
+    {
+        Wh_Log(L"[RESTORE-SC] tree=%04X thread=%u", PTR4(hWnd), GetCurrentThreadId());
+        g_mutatingTree = hWnd;
+        RestoreTree(hWnd);
+        g_mutatingTree = nullptr;
+        if (g_ins.filter) { g_ins.filter->Release(); g_ins.filter = nullptr; }
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(hWnd, RestoreSubclassProc);
+        if (IsWindow(hWnd))
+            RedrawWindow(hWnd, nullptr, nullptr,
+                         RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+        return 0x5748;
+    }
+    if (uMsg == WM_NCDESTROY)
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(hWnd, RestoreSubclassProc);
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
 static void FullRebuildTree(HWND hTree)
 {
     TreeState* ts = GetTree(hTree);
@@ -1189,6 +1231,7 @@ struct SectionLayout {
     HTREEITEM belowQA;        // first tall non-section item after boundary
     bool homePresent;         // a visible Home item exists among depth-1 siblings
     bool galleryPresent;      // a visible Gallery item exists among depth-1 siblings
+    bool needsHgCleanup;      // hidden inherited items found that need removal
 };
 
 static SectionLayout FindSectionLayout(HWND hTree, TreeState& ts)
@@ -1234,6 +1277,10 @@ static SectionLayout FindSectionLayout(HWND hTree, TreeState& ts)
                             if (i == NAV_HOME) layout.homePresent = true;
                             else if (i == NAV_GALLERY) layout.galleryPresent = true;
                             Wh_Log(L"[CACHE] %s=%04X tree=%04X (walk)", g_navItems[i].label, PTR4(h), PTR4(hTree));
+                        }
+                        else
+                        {
+                            layout.needsHgCleanup = true;
                         }
                         isSection = true;
                         inheritedNames[i][0] = L'\0';
@@ -1323,6 +1370,13 @@ static void RedrawSeps(HWND hTree, HDC hdc, TreeState& ts)
     bool foundBelowQA = false;
     int sepCount = 0;
 
+    if (ts.boundaryItem)
+    {
+        RECT rcBoundary = {};
+        if (GetItemRect(hTree, ts.boundaryItem, &rcBoundary) && rcBoundary.bottom <= 0)
+            foundBoundary = true;
+    }
+
     // Walk log tags: O=ours, H=home, G=gallery, P=spacer, B/b=boundary, Q=belowQA, S=sep, .=other
     WCHAR walkLog[64] = {};
     int walkIdx = 0;
@@ -1350,6 +1404,8 @@ static void RedrawSeps(HWND hTree, HDC hdc, TreeState& ts)
             }
             else if (GetHiddenItem(ts) && h == GetHiddenItem(ts))
             {
+                if (ts.boundaryItem && h == ts.boundaryItem)
+                    foundBoundary = true;
                 if (g_logSepDraw && walkIdx < 60)
                     walkLog[walkIdx++] = L'D';
             }
@@ -1439,8 +1495,13 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
                         Wh_Log(L"[SEP] 0x%06X tree=%04X", g_sepColor, PTR4(hTree));
                     }
 
+                    HDC hdc = cd->nmcd.hdc;
+                    HRGN hOldClip = CreateRectRgn(0, 0, 0, 0);
+                    int clipState = GetClipRgn(hdc, hOldClip);
+                    SelectClipRgn(hdc, nullptr);
+
                     if (g_settings.hasItemsAtTop && g_sepColor != CLR_INVALID && ts)
-                        RedrawSeps(hTree, cd->nmcd.hdc, *ts);
+                        RedrawSeps(hTree, hdc, *ts);
 
                     ts = GetTree(hTree);
                     HTREEITEM hHidden = (ts && HasOurItemsInTree(*ts)) ? GetHiddenItem(*ts) : nullptr;
@@ -1477,6 +1538,9 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
                             }
                         }
                     }
+
+                    SelectClipRgn(hdc, clipState == 1 ? hOldClip : nullptr);
+                    DeleteObject(hOldClip);
 
                     g_logSepDraw = false;
                 }
@@ -1706,6 +1770,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                     }
                     SetPropW(hWnd, L"WH_NscTree", (HANDLE)ts.pNscTree);
                     SetPropW(hWnd, L"WH_EnumFlags", (HANDLE)(ULONG_PTR)ts.enumFlags);
+                    WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, RestoreSubclassProc, 0);
                 }
                 else if (g_settings.hasItemsAtTop && !g_settings.items[id].hide)
                 {
@@ -1938,19 +2003,6 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         return 0;
     }
 
-    if (uMsg == WM_RESTORE_TREE)
-    {
-        Wh_Log(L"[RESTORE-MSG] tree=%04X thread=%u", PTR4(hWnd), GetCurrentThreadId());
-        g_mutatingTree = hWnd;
-        RestoreTree(hWnd);
-        g_mutatingTree = nullptr;
-        if (g_ins.filter) { g_ins.filter->Release(); g_ins.filter = nullptr; }
-        if (IsWindow(hWnd))
-            RedrawWindow(hWnd, nullptr, nullptr,
-                         RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
-        return 0;
-    }
-
     if (uMsg == WM_PAINT)
     {
         TreeState* ts = GetTree(hWnd);
@@ -1987,6 +2039,12 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 && !layout.homePresent && !layout.galleryPresent)
             {
                 ts->pendingWork |= WORK_HOME_SPACER;
+                PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
+            }
+
+            if (layout.needsHgCleanup && !(ts->pendingWork & WORK_HG_CLEANUP))
+            {
+                ts->pendingWork |= WORK_HG_CLEANUP;
                 PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
             }
 
@@ -2188,23 +2246,6 @@ void LoadSettings()
     for (int i = 0; i < NAV_COUNT; i++)
         if (g_settings.items[i].showAtTop) { g_settings.hasItemsAtTop = true; break; }
 
-    Wh_Log(L"Settings: thisPCAtTop=%d (expand=%d, startExp=%d, hideQA=%d) "
-            L"desktopAtTop=%d (above=%d, expand=%d, hideQA=%d) "
-            L"hideHome=%d hideGallery=%d fixChevron=%d chevronScale=%d "
-            L"hidePins=%d rmSepNav=%d rmSepQA=%d",
-            g_settings.items[NAV_THISPC].showAtTop,
-            g_settings.items[NAV_THISPC].expandable,
-            g_settings.items[NAV_THISPC].startExpanded,
-            g_settings.items[NAV_THISPC].hideFromQA,
-            g_settings.items[NAV_DESKTOP].showAtTop,
-            g_settings.desktopAboveThisPC,
-            g_settings.items[NAV_DESKTOP].expandable,
-            g_settings.items[NAV_DESKTOP].hideFromQA,
-            g_settings.items[NAV_HOME].hide,
-            g_settings.items[NAV_GALLERY].hide,
-            g_settings.fixChevronDrawing, g_settings.chevronScale,
-            g_settings.hidePinButtons,
-            g_settings.removeSepBelowNav, g_settings.removeSepBelowQA);
 }
 
 static bool InitializeModCore(HMODULE hExplorerFrame)
@@ -2239,8 +2280,6 @@ static bool InitializeModCore(HMODULE hExplorerFrame)
                        nullptr, &g_navItems[NAV_HOME].pidl, 0, nullptr);
     SHParseDisplayName(L"::{e88865ea-0e1c-4e20-9aa6-edcd0212c87c}",
                        nullptr, &g_navItems[NAV_GALLERY].pidl, 0, nullptr);
-    Wh_Log(L"PIDLs: Home=%04X Gallery=%04X", PTR4(g_navItems[NAV_HOME].pidl), PTR4(g_navItems[NAV_GALLERY].pidl));
-
     for (int i = 0; i < NAV_COUNT; i++)
         if (g_navItems[i].pidl)
             GetPidlDisplayName(g_navItems[i].pidl, g_navItems[i].label, ARRAYSIZE(g_navItems[i].label));
@@ -2248,12 +2287,21 @@ static bool InitializeModCore(HMODULE hExplorerFrame)
     WindhawkUtils::SYMBOL_HOOK explorerFrameDllHooks[] = {
         {
             {
+#ifdef _WIN64
                 L"public: virtual long __cdecl"
                 L" CNscTree::AppendRoot("
                 L"struct IShellItem *,"
                 L"unsigned long,"
                 L"unsigned long,"
                 L"struct IShellItemFilter *)"
+#else
+                L"public: virtual long __stdcall"
+                L" CNscTree::AppendRoot("
+                L"struct IShellItem *,"
+                L"unsigned long,"
+                L"unsigned long,"
+                L"struct IShellItemFilter *)"
+#endif
             },
             &AppendRoot_orig,
             AppendRoot_hook,
@@ -2261,6 +2309,7 @@ static bool InitializeModCore(HMODULE hExplorerFrame)
         },
         {
             {
+#ifdef _WIN64
                 L"private: static __int64 __cdecl"
                 L" CNscTree::s_SubClassTreeWndProc("
                 L"struct HWND__ *,"
@@ -2269,6 +2318,16 @@ static bool InitializeModCore(HMODULE hExplorerFrame)
                 L"__int64,"
                 L"unsigned __int64,"
                 L"unsigned __int64)"
+#else
+                L"private: static long __stdcall"
+                L" CNscTree::s_SubClassTreeWndProc("
+                L"struct HWND__ *,"
+                L"unsigned int,"
+                L"unsigned int,"
+                L"long,"
+                L"unsigned int,"
+                L"unsigned long)"
+#endif
             },
             &SubClassTreeWndProc_orig,
             SubClassTreeWndProc_hook,
@@ -2290,7 +2349,6 @@ static bool InitializeModCore(HMODULE hExplorerFrame)
         if (pDTB)
         {
             WindhawkUtils::SetFunctionHook(pDTB, DrawThemeBackground_hook, &DrawThemeBackground_orig);
-            Wh_Log(L"[CHEVRON] at=%04X orig=%04X", PTR4(pDTB), PTR4(DrawThemeBackground_orig));
         }
         else
             Wh_Log(L"[CHEVRON] GetProcAddress(DrawThemeBackground) failed");
@@ -2298,43 +2356,48 @@ static bool InitializeModCore(HMODULE hExplorerFrame)
     else
         Wh_Log(L"[CHEVRON] uxtheme.dll not loaded");
 
-    Wh_Log(L"Mod initialized, hasItemsAtTop=%d", (int)g_settings.hasItemsAtTop);
     return true;
 }
 
 void Wh_ModAfterInit();
+
+static void CheckLateLoadExplorerFrame(LPCWSTR lpLibFileName, HMODULE hModule)
+{
+    if (!hModule || !lpLibFileName ||
+        g_explorerFrameLoaded.load(std::memory_order_relaxed))
+        return;
+    LPCWSTR name = wcsrchr(lpLibFileName, L'\\');
+    name = name ? name + 1 : lpLibFileName;
+    if (_wcsicmp(name, L"ExplorerFrame.dll") != 0 ||
+        g_explorerFrameLoaded.exchange(true, std::memory_order_acq_rel))
+        return;
+    Wh_Log(L"ExplorerFrame.dll loaded late, installing hooks");
+    if (!InitializeModCore(hModule))
+    {
+        Wh_Log(L"Late-load InitializeModCore failed");
+        g_explorerFrameLoaded.store(false, std::memory_order_release);
+        return;
+    }
+    Wh_ApplyHookOperations();
+    Wh_Log(L"Late-load hooks installed, running discovery");
+    Wh_ModAfterInit();
+}
 
 static HMODULE WINAPI LoadLibraryExW_hook(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
 {
     HMODULE hModule = LoadLibraryExW_orig(lpLibFileName, hFile, dwFlags);
     constexpr DWORD DATA_ONLY = LOAD_LIBRARY_AS_DATAFILE |
         LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE | LOAD_LIBRARY_AS_IMAGE_RESOURCE;
-    if (hModule && lpLibFileName && !(dwFlags & DATA_ONLY) &&
-        !g_explorerFrameLoaded.load(std::memory_order_relaxed))
-    {
-        LPCWSTR name = wcsrchr(lpLibFileName, L'\\');
-        name = name ? name + 1 : lpLibFileName;
-        if (_wcsicmp(name, L"ExplorerFrame.dll") == 0 &&
-            !g_explorerFrameLoaded.exchange(true, std::memory_order_acq_rel))
-        {
-            Wh_Log(L"ExplorerFrame.dll loaded late, installing hooks");
-            if (!InitializeModCore(hModule))
-            {
-                Wh_Log(L"Late-load InitializeModCore failed");
-                g_explorerFrameLoaded.store(false, std::memory_order_release);
-                return hModule;
-            }
-            Wh_ApplyHookOperations();
-            Wh_Log(L"Late-load hooks installed, running discovery");
-            Wh_ModAfterInit();
-        }
-    }
+    if (!(dwFlags & DATA_ONLY))
+        CheckLateLoadExplorerFrame(lpLibFileName, hModule);
     return hModule;
 }
 
 BOOL Wh_ModInit()
 {
     HMODULE hExplorerFrame = GetModuleHandleW(L"ExplorerFrame.dll");
+    if (!hExplorerFrame)
+        hExplorerFrame = LoadLibraryExW(L"ExplorerFrame.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (!hExplorerFrame)
     {
         WindhawkUtils::SetFunctionHook(LoadLibraryExW, LoadLibraryExW_hook, &LoadLibraryExW_orig);
@@ -2406,6 +2469,46 @@ static void DiscoverTreeFromBrowser(HWND hTop, const WCHAR *cls,
     out.push_back({ hTop, hTree, pNsc, enumFlags });
 }
 
+static BOOL CALLBACK EnumWindowsForTrees(HWND hTop, LPARAM lParam)
+{
+    auto& out = *reinterpret_cast<std::vector<DiscoveredTree>*>(lParam);
+
+    DWORD wndPid = 0;
+    GetWindowThreadProcessId(hTop, &wndPid);
+    if (wndPid != GetCurrentProcessId())
+        return TRUE;
+    WCHAR cls[64];
+    GetClassNameW(hTop, cls, ARRAYSIZE(cls));
+
+    bool isCabinet = (wcscmp(cls, L"CabinetWClass") == 0);
+    bool isDialog = (wcscmp(cls, L"#32770") == 0);
+    if (!isCabinet && !isDialog)
+        return TRUE;
+
+    int found = 0;
+    HWND hShellTab = nullptr;
+    while ((hShellTab = FindWindowExW(hTop, hShellTab, L"ShellTabWindowClass", nullptr)) != nullptr)
+    {
+        IShellBrowser *pSB = (IShellBrowser *)SendMessageW(hShellTab, WM_USER + 7, 0, 0);
+        if (pSB)
+        {
+            size_t before = out.size();
+            DiscoverTreeFromBrowser(hTop, cls, pSB, out);
+            found += (int)(out.size() - before);
+        }
+    }
+
+    if (found == 0)
+    {
+        IShellBrowser *pSB = (IShellBrowser *)SendMessageW(hTop, WM_USER + 7, 0, 0);
+        if (pSB)
+            DiscoverTreeFromBrowser(hTop, cls, pSB, out);
+        else
+            Wh_Log(L"[TREE] %s hwnd=%04X no IShellBrowser", cls, PTR4(hTop));
+    }
+    return TRUE;
+}
+
 void Wh_ModAfterInit()
 {
 #ifdef _WIN64
@@ -2420,44 +2523,7 @@ void Wh_ModAfterInit()
 
     std::vector<DiscoveredTree> discovered;
 
-    EnumWindows([](HWND hTop, LPARAM lParam) -> BOOL {
-        auto& out = *reinterpret_cast<std::vector<DiscoveredTree>*>(lParam);
-
-        DWORD wndPid = 0;
-        GetWindowThreadProcessId(hTop, &wndPid);
-        if (wndPid != GetCurrentProcessId())
-            return TRUE;
-        WCHAR cls[64];
-        GetClassNameW(hTop, cls, ARRAYSIZE(cls));
-
-        bool isCabinet = (wcscmp(cls, L"CabinetWClass") == 0);
-        bool isDialog = (wcscmp(cls, L"#32770") == 0);
-        if (!isCabinet && !isDialog)
-            return TRUE;
-
-        int found = 0;
-        HWND hShellTab = nullptr;
-        while ((hShellTab = FindWindowExW(hTop, hShellTab, L"ShellTabWindowClass", nullptr)) != nullptr)
-        {
-            IShellBrowser *pSB = (IShellBrowser *)SendMessageW(hShellTab, WM_USER + 7, 0, 0);
-            if (pSB)
-            {
-                size_t before = out.size();
-                DiscoverTreeFromBrowser(hTop, cls, pSB, out);
-                found += (int)(out.size() - before);
-            }
-        }
-
-        if (found == 0)
-        {
-            IShellBrowser *pSB = (IShellBrowser *)SendMessageW(hTop, WM_USER + 7, 0, 0);
-            if (pSB)
-                DiscoverTreeFromBrowser(hTop, cls, pSB, out);
-            else
-                Wh_Log(L"[TREE] %s hwnd=%04X no IShellBrowser", cls, PTR4(hTop));
-        }
-        return TRUE;
-    }, (LPARAM)&discovered);
+    EnumWindows(EnumWindowsForTrees, (LPARAM)&discovered);
 
     for (auto& d : discovered)
     {
@@ -2478,6 +2544,7 @@ void Wh_ModAfterInit()
 
         SetPropW(d.hTree, L"WH_NscTree", (HANDLE)d.pNsc);
         SetPropW(d.hTree, L"WH_EnumFlags", (HANDLE)(ULONG_PTR)d.enumFlags);
+        WindhawkUtils::SetWindowSubclassFromAnyThread(d.hTree, RestoreSubclassProc, 0);
 
         PostMessage(d.hTree, WM_DEFERRED_REBUILD, 0, 0);
         Wh_Log(L"[ENABLE] window=%04X tree=%04X nsc=%04X", PTR4(d.hTop), PTR4(d.hTree), PTR4(d.pNsc));
@@ -2612,8 +2679,28 @@ void Wh_ModUninit()
 
     for (HWND hTree : uninitList)
     {
-        if (IsWindow(hTree))
-            SendMessage(hTree, WM_RESTORE_TREE, 0, 0);
+        if (!IsWindow(hTree))
+            continue;
+
+        DWORD treeThread = GetWindowThreadProcessId(hTree, nullptr);
+        if (treeThread != GetCurrentThreadId())
+        {
+            LRESULT lr = SendMessage(hTree, WM_RESTORE_TREE, 0, 0);
+            if (lr != 0x5748)
+            {
+                Wh_Log(L"[UNINIT] tree=%04X restore subclass missing, direct fallback", PTR4(hTree));
+                g_mutatingTree = hTree;
+                RestoreTree(hTree);
+                g_mutatingTree = nullptr;
+            }
+        }
+        else
+        {
+            g_mutatingTree = hTree;
+            RestoreTree(hTree);
+            g_mutatingTree = nullptr;
+            WindhawkUtils::RemoveWindowSubclassFromAnyThread(hTree, RestoreSubclassProc);
+        }
     }
 
     std::vector<HWND> parents;
@@ -2644,6 +2731,7 @@ void Wh_ModUninit()
                 ts.ownsNscRef = false;
             }
         }
+        g_trees.clear();
     }
 
     if (g_gdipToken) { Gdiplus::GdiplusShutdown(g_gdipToken); g_gdipToken = 0; }

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's navigation pane
-// @version         1.0
+// @version         1.1
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -27,13 +27,18 @@ namespace object. This includes Recycle Bin, Control Panel, etc.
 instead of just the items on the desktop. (This target can't be
 pinned without this mod.)
 
-- **Fix chevron drawing:** Replaces the pixelated and clipped
-chevron with a smooth anti-aliased versions. The size can be
-tweaked to any percentage or pixel dimensions.
-
 Both virtual folders have a toggle for whether they are expandable
 or not. Their position can be swapped. Duplicate entries of Desktop
-or This PC can be removed from other parts of the nav.
+or This PC can be removed from other parts of the nav. Also:
+
+- **Hide Home/Gallery:** Optional, default-enabled toggles to
+hide the native Explorer entries. They don't affect Quick Access.
+
+- **Remove separators:** Optionally remove each separator individually.
+
+- **Fix chevron drawing:** Replaces the pixelated and clipped
+chevron with a smooth anti-aliased versions. The size (which
+matches other UI elements by default) is configurable.
 
 This mod injects only in processes that have ExplorerFrame.dll,
 so the include is set to `*` but it will not touch most processes.
@@ -42,16 +47,14 @@ Open/Save dialogs changed (only modern dialogs are affected.)
 
 Before:
 
-![Before](https://i.imgur.com/aahBZPG.png)
+![Before](https://i.imgur.com/nC9T5A7.jpeg)
 
 After:
 
-![After](https://i.imgur.com/e2fEDwb.png)
+![After](https://i.imgur.com/JQQ5ZTN.jpeg)
 
-The screenshots show the mod with the normal Desktop pinned to
-Quick Access in before, compared to adding it using the mod.
-
-Home and Gallery are already hidden using [standard](https://www.elevenforum.com/t/add-show-home-on-navigation-pane-to-folder-options-in-windows-11.27300/) [methods](https://www.elevenforum.com/t/add-show-gallery-on-navigation-pane-to-folder-options-in-windows-11.27301/).
+The screenshots show the normal Desktop pinned to Quick Access in
+the before, and the mod with defaults set in the after.
 */
 // ==/WindhawkModReadme==
 
@@ -69,22 +72,33 @@ Home and Gallery are already hidden using [standard](https://www.elevenforum.com
     $description: Auto-expand This PC when window opens.
   - hideThisPCFromQuickAccess: true
     $name: Hide duplicates
-    $description: Hide This PC elsewhere in nav. Disable if there are issues with separators.
+    $description: Hide This PC elsewhere in the nav.
   $name: This PC
 - Desktop:
   - showDesktopAtTop: false
     $name: Add to top
-    $description: Adds the namespace root to the top of the navigation pane.
+    $description: Adds the namespace root to the top of the nav.
   - desktopExpandable: false
     $name: Make expandable
     $description: Shows namespace children when expanded.
   - desktopAboveThisPC: true
     $name: Place above This PC
-    $description: Disable if there are issues with separator lines.
   - hideDesktopFromQuickAccess: true
     $name: Hide duplicates
-    $description: Hide Desktop elsewhere in nav. Disable if there are issues with separators.
+    $description: Hide Desktop entries elsewhere in the nav.
   $name: Desktop
+- HomeGallery:
+  - hideHome: true
+    $name: Hide Home
+  - hideGallery: true
+    $name: Hide Gallery
+  $name: Hide Home/Gallery (does not affect Quick Access)
+- Separators:
+  - removeSepBelowNav: false
+    $name: Remove separator below top nav
+  - removeSepBelowQA: false
+    $name: Remove separator below Quick Access
+  $name: Separators
 - Resources:
   - fixChevronDrawing: true
     $name: Fix chevron drawing
@@ -111,6 +125,9 @@ Home and Gallery are already hidden using [standard](https://www.elevenforum.com
 #include <uxtheme.h>
 #include <gdiplus.h>
 #include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #ifdef _WIN64
 #define THISCALL __cdecl
@@ -127,29 +144,111 @@ struct {
     bool desktopAboveThisPC;
     bool desktopExpandable;
     bool hideDesktopFromQuickAccess;
+    bool hideHome;
+    bool hideGallery;
     bool fixChevronDrawing;
     int chevronScale;
     bool hidePinButtons;
+    bool removeSepBelowNav;
+    bool removeSepBelowQA;
 } g_settings;
 
 static PIDLIST_ABSOLUTE g_pidlThisPC = nullptr;
 static PIDLIST_ABSOLUTE g_pidlDesktop = nullptr;
+static PIDLIST_ABSOLUTE g_pidlHome = nullptr;
+static PIDLIST_ABSOLUTE g_pidlGallery = nullptr;
 static ULONG_PTR g_gdipToken = 0;
 static std::set<HWND> g_subclassedParents;
 static COLORREF g_sepColor = CLR_INVALID;
-static HTREEITEM g_hCachedThisPC = nullptr;
-static HTREEITEM g_hCachedDesktop = nullptr;
-static HWND g_hCachedTree = nullptr;
+static bool g_logSepDraw = true;
+
+// Per-tree state: one entry per SysTreeView32 that we've injected items into.
+struct TreeState {
+    void *pNscTree = nullptr;
+    unsigned long enumFlags = 0;
+    IShellItemFilter *pFilter = nullptr;
+    HTREEITEM hThisPC = nullptr;
+    HTREEITEM hDesktop = nullptr;
+    HTREEITEM hHome = nullptr;
+    HTREEITEM hGallery = nullptr;
+    HTREEITEM hiddenDuplicate = nullptr;
+    bool dupAtBoundary = false;
+    HTREEITEM boundaryItem = nullptr;
+    HTREEITEM belowQAItem = nullptr;
+    bool qaCleanupDone = false;
+    bool homeGalleryCleanupDone = false;
+    bool needHotInsert = false;
+    bool needFullRebuild = false;
+    bool ownsNscRef = false;
+    HIMAGELIST savedStateImageList = nullptr;
+};
+static std::unordered_map<HWND, TreeState> g_trees;
+
+static TreeState* GetTree(HWND hWnd) {
+    auto it = g_trees.find(hWnd);
+    return (it != g_trees.end()) ? &it->second : nullptr;
+}
+
+static bool IsOurSection(const TreeState& ts, HTREEITEM h)
+{
+    return h == ts.hThisPC || h == ts.hDesktop ||
+           (ts.hHome && h == ts.hHome) ||
+           (ts.hGallery && h == ts.hGallery);
+}
+
+static void ResetTreeCleanup(TreeState& ts)
+{
+    ts.hiddenDuplicate = nullptr;
+    ts.dupAtBoundary = false;
+    ts.boundaryItem = nullptr;
+    ts.belowQAItem = nullptr;
+    ts.qaCleanupDone = false;
+    ts.homeGalleryCleanupDone = false;
+}
 
 // 0=not ours, 1=This PC, 2=Desktop — set during AppendOneItem
 // so the TVM_INSERTITEM handler knows which item is being inserted
 // without comparing localized display text.
-static thread_local int g_insertingItem = 0;
+static int g_insertingItem = 0;
 
-static bool ShouldRemoveSeparators()
+// Temporary globals bridging AppendRoot_hook to TVM_INSERTITEM handler.
+// Copied into TreeState once the tree HWND is known.
+static void *g_pNscTree = nullptr;
+static unsigned long g_lastEnumFlags = 0;
+static IShellItemFilter *g_pLastFilter = nullptr;
+
+// Scopes g_insertingItem to a specific tree: TVM_INSERTITEM from other
+// trees during message pumping is ignored. Null = accept any tree
+// (used by AppendRoot_hook for fresh windows where HWND is unknown).
+static HWND g_insertingForTree = nullptr;
+
+// Re-entrancy guard: FullRebuildTree and HotEnableInsert set global
+// state (g_insertingItem, g_inCustomAppend, g_pNscTree) that would be
+// corrupted if a second tree's deferred op runs while the first is
+// in progress (AppendRoot_orig pumps messages internally).
+static bool g_deferredOpInProgress = false;
+static std::unordered_set<HWND> g_pendingRebuildTrees;
+
+#define WM_DEFERRED_REBUILD  (WM_APP + 0x101)
+
+static void DrainPendingRebuilds()
 {
-    return g_settings.showThisPCAtTop && g_settings.showDesktopAtTop &&
-           g_settings.desktopAboveThisPC;
+    g_deferredOpInProgress = false;
+    while (!g_pendingRebuildTrees.empty())
+    {
+        HWND hNext = *g_pendingRebuildTrees.begin();
+        g_pendingRebuildTrees.erase(g_pendingRebuildTrees.begin());
+        if (IsWindow(hNext) && GetTree(hNext))
+            PostMessage(hNext, WM_DEFERRED_REBUILD, 0, 0);
+    }
+}
+static void RefreshNavPane(HWND hTree);
+static void HotEnableInsert(HWND hWnd);
+static void FullRebuildTree(HWND hTree);
+
+static bool ShouldRemoveInternalSep()
+{
+    return g_settings.showThisPCAtTop && g_settings.showDesktopAtTop;
 }
 
 // --- AppendRoot hook ---
@@ -160,12 +259,12 @@ using AppendRoot_t = HRESULT (THISCALL *)(
 
 AppendRoot_t AppendRoot_orig;
 
-static thread_local bool g_inCustomAppend = false;
+static bool g_inCustomAppend = false;
 
 static void AppendOneItem(
     void *pThis, PIDLIST_ABSOLUTE pidl, bool expandable,
     unsigned long grfEnumFlags, IShellItemFilter *pOrigFilter,
-    const WCHAR *label, unsigned long rootStyle = 0)
+    unsigned long rootStyle = 0)
 {
     if (!pidl)
         return;
@@ -174,21 +273,93 @@ static void AppendOneItem(
     if (FAILED(SHCreateItemFromIDList(pidl, IID_IShellItem, (void **)&pItem)))
         return;
 
-    HRESULT hr = AppendRoot_orig(pThis, pItem,
+    AppendRoot_orig(pThis, pItem,
         expandable ? grfEnumFlags : 0,
         rootStyle,
         pOrigFilter);
 
-    Wh_Log(L"AppendRoot: %s (%s) rootStyle=0x%lx result=0x%lx",
-            label, expandable ? L"expandable" : L"leaf", rootStyle, hr);
-
     pItem->Release();
+}
+
+struct NavItem {
+    PIDLIST_ABSOLUTE pidl;
+    bool expandable;
+    bool enabled;
+    int id;
+    unsigned long style;
+};
+
+static void BuildItemOrder(NavItem items[2])
+{
+    unsigned long thisPCStyle = g_settings.thisPCStartExpanded ? 0x2 : 0;
+
+    if (g_settings.desktopAboveThisPC)
+    {
+        items[0] = { g_pidlDesktop, g_settings.desktopExpandable,
+                     g_settings.showDesktopAtTop, 2, 0 };
+        items[1] = { g_pidlThisPC, g_settings.thisPCExpandable,
+                     g_settings.showThisPCAtTop, 1, thisPCStyle };
+    }
+    else
+    {
+        items[0] = { g_pidlThisPC, g_settings.thisPCExpandable,
+                     g_settings.showThisPCAtTop, 1, thisPCStyle };
+        items[1] = { g_pidlDesktop, g_settings.desktopExpandable,
+                     g_settings.showDesktopAtTop, 2, 0 };
+    }
+}
+
+static void InsertItems(void *pNsc, const NavItem items[2],
+                        unsigned long enumFlags, IShellItemFilter *filter)
+{
+    for (int i = 1; i >= 0; i--)
+    {
+        if (items[i].enabled)
+        {
+            g_insertingItem = items[i].id;
+            AppendOneItem(pNsc, items[i].pidl, items[i].expandable,
+                          enumFlags, filter, items[i].style);
+            g_insertingItem = 0;
+        }
+    }
 }
 
 HRESULT THISCALL AppendRoot_hook(
     void *pThis, IShellItem *psiRoot, unsigned long grfEnumFlags,
     unsigned long grfRootStyle, IShellItemFilter *pFilter)
 {
+    // Intercept Home/Gallery root items by PIDL comparison.
+    // Must happen BEFORE g_inCustomAppend check: during FullRebuildTree,
+    // AppendRoot_orig for the hidden root can trigger Explorer to add
+    // Home/Gallery internally while g_inCustomAppend is true. Without
+    // this, ts.hHome/ts.hGallery would never be cached.
+    if (g_pidlHome || g_pidlGallery)
+    {
+        PIDLIST_ABSOLUTE pidlRoot = nullptr;
+        if (SUCCEEDED(SHGetIDListFromObject(psiRoot, &pidlRoot)))
+        {
+            bool isHome = g_pidlHome && ILIsEqual(pidlRoot, g_pidlHome);
+            bool isGallery = g_pidlGallery && ILIsEqual(pidlRoot, g_pidlGallery);
+            CoTaskMemFree(pidlRoot);
+
+            if (isHome || isGallery)
+            {
+                bool hide = isHome ? g_settings.hideHome : g_settings.hideGallery;
+                if (hide)
+                {
+                    Wh_Log(L"[HOOK] Suppressing %s root",
+                           isHome ? L"Home" : L"Gallery");
+                    return S_OK;
+                }
+                g_insertingItem = isHome ? 3 : 4;
+                HRESULT hr = AppendRoot_orig(pThis, psiRoot, grfEnumFlags,
+                                             grfRootStyle, pFilter);
+                g_insertingItem = 0;
+                return hr;
+            }
+        }
+    }
+
     if (g_inCustomAppend)
         return AppendRoot_orig(pThis, psiRoot, grfEnumFlags,
                                grfRootStyle, pFilter);
@@ -202,39 +373,20 @@ HRESULT THISCALL AppendRoot_hook(
 
     if (wantItems)
     {
+        g_pNscTree = pThis;
+        g_lastEnumFlags = grfEnumFlags;
+        if (g_pLastFilter != pFilter)
+        {
+            if (g_pLastFilter) g_pLastFilter->Release();
+            g_pLastFilter = pFilter;
+            if (g_pLastFilter) g_pLastFilter->AddRef();
+        }
+
         g_inCustomAppend = true;
 
-        unsigned long thisPCStyle = g_settings.thisPCStartExpanded ? 0x2 : 0;
-
-        struct { PIDLIST_ABSOLUTE pidl; bool expandable; bool enabled;
-                 int id; const WCHAR *label; unsigned long style; } items[2];
-
-        if (g_settings.desktopAboveThisPC)
-        {
-            items[0] = { g_pidlDesktop, g_settings.desktopExpandable,
-                         g_settings.showDesktopAtTop, 2, L"Desktop", 0 };
-            items[1] = { g_pidlThisPC, g_settings.thisPCExpandable,
-                         g_settings.showThisPCAtTop, 1, L"This PC", thisPCStyle };
-        }
-        else
-        {
-            items[0] = { g_pidlThisPC, g_settings.thisPCExpandable,
-                         g_settings.showThisPCAtTop, 1, L"This PC", thisPCStyle };
-            items[1] = { g_pidlDesktop, g_settings.desktopExpandable,
-                         g_settings.showDesktopAtTop, 2, L"Desktop", 0 };
-        }
-
-        for (int i = 0; i < 2; i++)
-        {
-            if (items[i].enabled)
-            {
-                g_insertingItem = items[i].id;
-                AppendOneItem(pThis, items[i].pidl, items[i].expandable,
-                              grfEnumFlags, pFilter, items[i].label,
-                              items[i].style);
-            }
-        }
-        g_insertingItem = 0;
+        NavItem items[2];
+        BuildItemOrder(items);
+        InsertItems(pThis, items, grfEnumFlags, pFilter);
 
         g_inCustomAppend = false;
     }
@@ -313,18 +465,43 @@ static thread_local bool g_inTreePaint = false;
 // separator lines. At CDDS_POSTPAINT we redraw the ones we want to
 // keep — all section boundaries EXCEPT the one between our custom items.
 
-// Sample the separator line color from the DC. Called on the first
-// paint cycle when CDDS_PREPAINT was NOT swallowed (separators visible).
-static COLORREF SampleSeparatorColor(HWND hTree, HDC hdc)
+static bool IsDepth1Item(HWND hTree, HTREEITEM h)
 {
-    if (!hdc || !IsWindow(hTree))
-        return CLR_INVALID;
+    HTREEITEM parent = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                                TVGN_PARENT, (LPARAM)h);
+    if (!parent)
+        return false;
+    HTREEITEM gp = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                            TVGN_PARENT, (LPARAM)parent);
+    return (gp == nullptr);
+}
 
-    RECT client;
-    GetClientRect(hTree, &client);
-    if (client.right <= 0)
-        return CLR_INVALID;
+static HTREEITEM GetFirstDepth1Child(HWND hTree)
+{
+    HTREEITEM hRoot = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                              TVGN_ROOT, 0);
+    return hRoot ? (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                            TVGN_CHILD, (LPARAM)hRoot)
+                 : nullptr;
+}
 
+static bool CollapseItemIntegral(HWND hTree, HTREEITEM h)
+{
+    TVITEMEXW tvi = {};
+    tvi.mask = TVIF_HANDLE | TVIF_INTEGRAL;
+    tvi.hItem = h;
+    SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
+    if (tvi.iIntegral >= 2)
+    {
+        tvi.iIntegral = 1;
+        SendMessageW(hTree, TVM_SETITEMW, 0, (LPARAM)&tvi);
+        return true;
+    }
+    return false;
+}
+
+static int GetBaseItemHeight(HWND hTree)
+{
     int baseHeight = 0;
     HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
                                           TVGN_FIRSTVISIBLE, 0);
@@ -341,22 +518,50 @@ static COLORREF SampleSeparatorColor(HWND hTree, HDC hdc)
         h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
                                     TVGN_NEXTVISIBLE, (LPARAM)h);
     }
+    return baseHeight;
+}
+
+static void DrawSeparatorLine(HDC hdc, HWND hTree, int sepY)
+{
+    RECT client;
+    GetClientRect(hTree, &client);
+    int pad = 18;
+    int sepLeft = (client.right >= pad * 2 + 8) ? pad : 0;
+    int sepRight = (client.right >= pad * 2 + 8) ? client.right - pad : client.right;
+    RECT sepRect = { sepLeft, sepY, sepRight, sepY + 2 };
+
+    HBRUSH brush = CreateSolidBrush(g_sepColor);
+    if (brush)
+    {
+        FillRect(hdc, &sepRect, brush);
+        DeleteObject(brush);
+    }
+}
+
+// Sample the separator line color from the DC. Called on the first
+// paint cycle when CDDS_PREPAINT was NOT swallowed (separators visible).
+static COLORREF SampleSeparatorColor(HWND hTree, HDC hdc)
+{
+    if (!hdc || !IsWindow(hTree))
+        return CLR_INVALID;
+
+    RECT client;
+    GetClientRect(hTree, &client);
+    if (client.right <= 0)
+        return CLR_INVALID;
+
+    int baseHeight = GetBaseItemHeight(hTree);
     if (baseHeight <= 0)
         return CLR_INVALID;
 
     int tallThreshold = baseHeight + baseHeight / 2;
 
     // Find the first tall depth-1 item — its separator is at rc.top + baseHeight/2
-    h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                TVGN_FIRSTVISIBLE, 0);
+    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                          TVGN_FIRSTVISIBLE, 0);
     while (h)
     {
-        HTREEITEM parent = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                                    TVGN_PARENT, (LPARAM)h);
-        HTREEITEM gp = parent ?
-            (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                    TVGN_PARENT, (LPARAM)parent) : nullptr;
-        if (parent && !gp)
+        if (IsDepth1Item(hTree, h))
         {
             RECT rc = {};
             *(HTREEITEM*)&rc = h;
@@ -367,21 +572,31 @@ static COLORREF SampleSeparatorColor(HWND hTree, HDC hdc)
                 {
                     int sepY = rc.top + baseHeight / 2;
                     int sampleX = client.right / 2;
+
+                    // Sample background color nearby for validation
+                    COLORREF bg = GetPixel(hdc, sampleX,
+                                           rc.top + baseHeight + baseHeight / 4);
+
+                    auto isPlausible = [&](COLORREF c) -> bool {
+                        if (c == CLR_INVALID || c == 0x000000)
+                            return false;
+                        if (bg == CLR_INVALID)
+                            return true;
+                        // Reject if separator color is too far from background
+                        int dr = abs((int)GetRValue(c) - (int)GetRValue(bg));
+                        int dg = abs((int)GetGValue(c) - (int)GetGValue(bg));
+                        int db = abs((int)GetBValue(c) - (int)GetBValue(bg));
+                        return (dr + dg + db) < 200;
+                    };
+
                     COLORREF c = GetPixel(hdc, sampleX, sepY);
-                    Wh_Log(L"[SEP-COLOR] sampled at (%d,%d) = 0x%06X",
-                           sampleX, sepY, c);
-                    if (c != CLR_INVALID && c != 0x000000)
+                    if (isPlausible(c))
                         return c;
-                    // Try a few pixels around it
                     for (int dy = -2; dy <= 2; dy++)
                     {
                         c = GetPixel(hdc, sampleX, sepY + dy);
-                        if (c != CLR_INVALID && c != 0x000000)
-                        {
-                            Wh_Log(L"[SEP-COLOR] sampled at (%d,%d) = 0x%06X",
-                                   sampleX, sepY + dy, c);
+                        if (isPlausible(c))
                             return c;
-                        }
                     }
                 }
             }
@@ -395,13 +610,8 @@ static COLORREF SampleSeparatorColor(HWND hTree, HDC hdc)
 
 // At CDDS_POSTPAINT, all separators have been hidden by CDDS_PREPAINT
 // swallowing. Redraw separators for section boundaries we want to keep.
-// Tracks last-drawn positions to only log when something changes.
-static int g_lastSepPositions[8] = {};
-static int g_lastSepCount = 0;
-static bool g_qaCleanupDone = false;
-static HTREEITEM g_hiddenDuplicate = nullptr;
 
-static void RedrawOtherSeparators(HWND hTree, HDC hdc)
+static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
 {
     if (!hdc || !IsWindow(hTree))
         return;
@@ -411,109 +621,101 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc)
     if (client.right <= 0 || client.bottom <= 0)
         return;
 
-    HTREEITEM hThisPC = (g_hCachedTree == hTree) ? g_hCachedThisPC : nullptr;
-    HTREEITEM hDesktop = (g_hCachedTree == hTree) ? g_hCachedDesktop : nullptr;
-
-    int baseHeight = 0;
-    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                          TVGN_FIRSTVISIBLE, 0);
-    while (h)
-    {
-        RECT rc = {};
-        *(HTREEITEM*)&rc = h;
-        if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rc))
-        {
-            int ih = rc.bottom - rc.top;
-            if (ih > 0 && (baseHeight == 0 || ih < baseHeight))
-                baseHeight = ih;
-        }
-        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                    TVGN_NEXTVISIBLE, (LPARAM)h);
-    }
+    int baseHeight = GetBaseItemHeight(hTree);
     if (baseHeight <= 0)
         baseHeight = 48;
 
     int tallThreshold = baseHeight + baseHeight / 2;
-    int restored = 0;
-    int positions[8] = {};
 
-    h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                TVGN_FIRSTVISIBLE, 0);
+    bool passedOurSection = false;
+    bool foundBoundary = false;
+    bool foundBelowQA = false;
+    int sepCount = 0;
+
+    // Diagnostic: build a walk summary for logging
+    // Each depth-1 item gets a tag: O=ours, H=home, G=gallery,
+    // D=dup(at boundary), d=dup(not at boundary), B=boundary(tall),
+    // b=boundary(short), Q=belowQA, S=sep-drawn, .=other
+    WCHAR walkLog[64] = {};
+    int walkIdx = 0;
+
+    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                          TVGN_FIRSTVISIBLE, 0);
     while (h)
     {
-        HTREEITEM parent = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                                    TVGN_PARENT, (LPARAM)h);
-        HTREEITEM grandparent = parent ?
-            (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                    TVGN_PARENT, (LPARAM)parent) : nullptr;
-        bool isDepth1 = (parent != nullptr && grandparent == nullptr);
-
-        if (isDepth1)
+        if (IsDepth1Item(hTree, h))
         {
             RECT rc = {};
             *(HTREEITEM*)&rc = h;
+            int ih = 0;
             if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rc))
+                ih = rc.bottom - rc.top;
+
+            WCHAR tag = L'.';
+
+            if (IsOurSection(ts, h))
             {
-                int ih = rc.bottom - rc.top;
+                passedOurSection = true;
+                if (h == ts.hThisPC || h == ts.hDesktop) tag = L'O';
+                else if (ts.hHome && h == ts.hHome) tag = L'H';
+                else tag = L'G';
+            }
+            else if (h == ts.hiddenDuplicate)
+            {
+                tag = ts.dupAtBoundary ? L'D' : L'd';
+            }
+            else
+            {
                 bool isTall = (ih >= tallThreshold);
-                bool isOurs = (h == hThisPC || h == hDesktop);
+                bool drawSep = false;
+                int sepY = 0;
 
-                if (isTall && !isOurs)
+                if (passedOurSection && !foundBoundary)
                 {
-                    int sepY = rc.top + baseHeight / 2;
-                    int sepH = 2;
-
-                    int padLeft = 18;
-                    int padRight = 18;
-                    int sepLeft = (client.right >= padLeft * 2 + 8) ? padLeft : 0;
-                    int sepRight = (client.right >= padRight * 2 + 8) ? client.right - padRight : client.right;
-
-                    RECT sepRect = { sepLeft, sepY, sepRight, sepY + sepH };
-
-                    COLORREF sepColor = (g_sepColor != CLR_INVALID)
-                        ? g_sepColor : RGB(255, 0, 0);
-
-                    HBRUSH brush = CreateSolidBrush(sepColor);
-                    if (brush)
+                    foundBoundary = true;
+                    tag = isTall ? L'B' : L'b';
+                    if (!g_settings.removeSepBelowNav &&
+                        !ts.dupAtBoundary)
                     {
-                        FillRect(hdc, &sepRect, brush);
-                        DeleteObject(brush);
+                        drawSep = true;
+                        sepY = isTall ? rc.top + baseHeight / 2
+                                      : rc.top;
                     }
+                }
+                else if (foundBoundary && isTall)
+                {
+                    if (g_settings.removeSepBelowQA && !foundBelowQA)
+                    {
+                        foundBelowQA = true;
+                        tag = L'Q';
+                    }
+                    else
+                    {
+                        drawSep = true;
+                        sepY = rc.top + baseHeight / 2;
+                        tag = L'S';
+                    }
+                }
 
-                    if (restored < 8)
-                        positions[restored] = sepY;
-                    restored++;
+                if (drawSep)
+                {
+                    sepCount++;
+                    DrawSeparatorLine(hdc, hTree, sepY);
                 }
             }
+
+            if (walkIdx < 60)
+                walkLog[walkIdx++] = tag;
         }
 
         h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
                                     TVGN_NEXTVISIBLE, (LPARAM)h);
     }
-
-
-    // Only log when positions change
-    bool changed = (restored != g_lastSepCount);
-    if (!changed)
+    walkLog[walkIdx] = 0;
+    if (g_logSepDraw)
     {
-        for (int i = 0; i < restored && i < 8; i++)
-            if (positions[i] != g_lastSepPositions[i])
-                { changed = true; break; }
-    }
-    if (changed)
-    {
-        g_lastSepCount = restored;
-        for (int i = 0; i < 8; i++)
-            g_lastSepPositions[i] = positions[i];
-
-        if (restored == 0)
-            Wh_Log(L"[SEP-RESTORE] no separators to restore (baseH=%d)", baseHeight);
-        else if (restored == 1)
-            Wh_Log(L"[SEP-RESTORE] 1 separator at y=%d (baseH=%d pad=18)",
-                   positions[0], baseHeight);
-        else
-            Wh_Log(L"[SEP-RESTORE] %d separators at y=%d,%d (baseH=%d pad=18)",
-                   restored, positions[0], positions[1], baseHeight);
+        Wh_Log(L"[SEP-DRAW] tree=%p walk=[%s] drew=%d hHome=%p hGallery=%p hDup=%p",
+               hTree, walkLog, sepCount, ts.hHome, ts.hGallery, ts.hiddenDuplicate);
     }
 }
 
@@ -532,62 +734,70 @@ static LRESULT CALLBACK SepParentSubclassProc(
         LPNMHDR hdr = (LPNMHDR)lParam;
         if (hdr && hdr->hwndFrom == hTree)
         {
-            if (hdr->code == (UINT)NM_CUSTOMDRAW)
+            if (hdr->code == (UINT)NM_CUSTOMDRAW && !g_deferredOpInProgress)
             {
                 LPNMTVCUSTOMDRAW cd = (LPNMTVCUSTOMDRAW)lParam;
                 DWORD stage = cd->nmcd.dwDrawStage;
-                bool removeSep = ShouldRemoveSeparators();
-                bool hasDupHide = (g_hiddenDuplicate != nullptr);
+                bool hasItemsAtTop = g_settings.showThisPCAtTop ||
+                                     g_settings.showDesktopAtTop;
+                TreeState* ts = GetTree(hTree);
+                bool hasDupHide = (ts && ts->hiddenDuplicate != nullptr);
 
-                if (stage == CDDS_PREPAINT && (removeSep || hasDupHide))
+                if (stage == CDDS_PREPAINT &&
+                    (hasItemsAtTop || hasDupHide))
                 {
-                    if (removeSep)
-                    {
-                        if (g_sepColor == CLR_INVALID)
-                        {
-                            LRESULT r = DefSubclassProc(hWnd, uMsg, wParam, lParam);
-                            return r | CDRF_NOTIFYPOSTPAINT;
-                        }
+                    // Skipping DefSubclassProc suppresses ALL native separator
+                    // lines but also prevents per-item custom draw
+                    // (CDDS_ITEMPREPAINT) for other subclasses on this tree.
+                    if (hasItemsAtTop && g_sepColor != CLR_INVALID)
                         return CDRF_NOTIFYPOSTPAINT;
-                    }
-                    else
-                    {
-                        LRESULT r = DefSubclassProc(hWnd, uMsg, wParam, lParam);
-                        return r | CDRF_NOTIFYPOSTPAINT;
-                    }
+                    LRESULT r = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+                    return r | CDRF_NOTIFYPOSTPAINT;
                 }
 
                 if (stage == CDDS_POSTPAINT)
                 {
-                    if (g_sepColor == CLR_INVALID && (removeSep || hasDupHide))
+                    if (g_sepColor == CLR_INVALID &&
+                        (hasItemsAtTop || hasDupHide))
                     {
                         COLORREF c = SampleSeparatorColor(hTree, cd->nmcd.hdc);
                         if (c != CLR_INVALID)
                         {
                             g_sepColor = c;
-                            Wh_Log(L"[SEP-COLOR] captured separator color: 0x%06X", c);
-                            if (removeSep)
-                                InvalidateRect(hTree, NULL, TRUE);
+                            g_logSepDraw = true;
+                            Wh_Log(L"[SEP] color=0x%06X tree=%p",
+                                   c, hTree);
+                            InvalidateRect(hTree, NULL, TRUE);
                         }
                     }
 
-                    if (removeSep && g_sepColor != CLR_INVALID)
-                        RedrawOtherSeparators(hTree, cd->nmcd.hdc);
+                    if (hasItemsAtTop &&
+                        g_sepColor != CLR_INVALID && ts)
+                        RedrawOtherSeparators(hTree, cd->nmcd.hdc, *ts);
+
+                    // Re-fetch ts: SendMessageW calls in RedrawOtherSeparators
+                    // could have modified g_trees
+                    ts = GetTree(hTree);
+                    hasDupHide = (ts && ts->hiddenDuplicate != nullptr);
 
                     if (hasDupHide)
                     {
                         RECT rcHide = {};
-                        *(HTREEITEM*)&rcHide = g_hiddenDuplicate;
+                        *(HTREEITEM*)&rcHide = ts->hiddenDuplicate;
                         if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rcHide))
                         {
                             HDC hdc = cd->nmcd.hdc;
-                            COLORREF bg = GetPixel(hdc, 1, rcHide.top + 2);
-                            if (bg == CLR_INVALID || bg == 0)
-                            {
-                                RECT client;
-                                GetClientRect(hTree, &client);
+                            RECT client;
+                            GetClientRect(hTree, &client);
+                            COLORREF bg = GetPixel(hdc, client.right / 2, rcHide.top + 2);
+                            if (bg == CLR_INVALID || bg == 0x000000)
                                 bg = GetPixel(hdc, client.right - 2, rcHide.top + 2);
-                            }
+                            if (bg == CLR_INVALID || bg == 0x000000)
+                                bg = GetPixel(hdc, 1, rcHide.top + 2);
+                            if (bg == CLR_INVALID)
+                                bg = (COLORREF)SendMessageW(hTree, TVM_GETBKCOLOR, 0, 0);
+                            if (bg == CLR_INVALID || bg == (COLORREF)-1)
+                                bg = GetSysColor(COLOR_WINDOW);
                             if (bg != CLR_INVALID)
                             {
                                 HBRUSH bgBrush = CreateSolidBrush(bg);
@@ -598,27 +808,34 @@ static LRESULT CALLBACK SepParentSubclassProc(
                                 }
                             }
 
+                            // Only draw separator line through the dup
+                            // if it's at the boundary (right after our
+                            // section). Otherwise just paint over.
                             if (g_sepColor != CLR_INVALID)
                             {
-                                int h = rcHide.bottom - rcHide.top;
-                                int sepY = rcHide.top + h / 2;
-                                RECT client;
-                                GetClientRect(hTree, &client);
-                                int padL = 18, padR = 18;
-                                int sepLeft = (client.right >= padL * 2 + 8) ? padL : 0;
-                                int sepRight = (client.right >= padR * 2 + 8)
-                                    ? client.right - padR : client.right;
-                                RECT sepRect = { sepLeft, sepY, sepRight, sepY + 2 };
+                                HTREEITEM hPrev = (HTREEITEM)SendMessageW(
+                                    hTree, TVM_GETNEXTITEM, TVGN_PREVIOUS,
+                                    (LPARAM)ts->hiddenDuplicate);
+                                bool atBoundary = hPrev && IsOurSection(*ts, hPrev);
 
-                                HBRUSH sepBrush = CreateSolidBrush(g_sepColor);
-                                if (sepBrush)
+                                if (atBoundary)
                                 {
-                                    FillRect(hdc, &sepRect, sepBrush);
-                                    DeleteObject(sepBrush);
+                                    int h = rcHide.bottom - rcHide.top;
+                                    int sepY = rcHide.top + h / 2;
+                                    DrawSeparatorLine(hdc, hTree, sepY);
                                 }
+                            }
+                            if (g_logSepDraw)
+                            {
+                                Wh_Log(L"[SEP-HIDE] dup=%p bg=0x%06X sepColor=0x%06X y=%d-%d",
+                                       ts->hiddenDuplicate, bg,
+                                       g_sepColor != CLR_INVALID ? g_sepColor : 0,
+                                       rcHide.top, rcHide.bottom);
                             }
                         }
                     }
+
+                    g_logSepDraw = false;
                 }
             }
 
@@ -628,9 +845,30 @@ static LRESULT CALLBACK SepParentSubclassProc(
                 hdr->code == TVN_ITEMEXPANDEDA)
             {
                 LRESULT r = DefSubclassProc(hWnd, uMsg, wParam, lParam);
+                g_logSepDraw = true;
                 InvalidateRect(hTree, NULL, TRUE);
-                Wh_Log(L"[SEP-EXPAND] tree=%p expanded/collapsed, full repaint scheduled", hTree);
                 return r;
+            }
+
+            if (hdr->code == (UINT)TVN_SELCHANGEDW ||
+                hdr->code == (UINT)TVN_SELCHANGEDA)
+            {
+                LPNMTREEVIEWW nm = (LPNMTREEVIEWW)lParam;
+                TreeState* tsSel = GetTree(hTree);
+                if (tsSel && tsSel->hiddenDuplicate &&
+                    nm->itemNew.hItem == tsSel->hiddenDuplicate)
+                {
+                    HTREEITEM hAlt = (HTREEITEM)SendMessageW(
+                        hTree, TVM_GETNEXTITEM, TVGN_NEXTVISIBLE,
+                        (LPARAM)tsSel->hiddenDuplicate);
+                    if (!hAlt)
+                        hAlt = (HTREEITEM)SendMessageW(
+                            hTree, TVM_GETNEXTITEM, TVGN_PREVIOUSVISIBLE,
+                            (LPARAM)tsSel->hiddenDuplicate);
+                    if (hAlt)
+                        SendMessageW(hTree, TVM_SELECTITEM,
+                                     TVGN_CARET, (LPARAM)hAlt);
+                }
             }
         }
     }
@@ -638,14 +876,11 @@ static LRESULT CALLBACK SepParentSubclassProc(
     if (uMsg == WM_THEMECHANGED || uMsg == WM_SYSCOLORCHANGE)
     {
         g_sepColor = CLR_INVALID;
-        Wh_Log(L"[SEP-COLOR] theme/colors changed, will resample");
+        g_logSepDraw = true;
     }
 
     if (uMsg == WM_NCDESTROY)
-    {
         g_subclassedParents.erase(hWnd);
-        Wh_Log(L"[SEP-PARENT] parent=%p destroyed, removed from tracking", hWnd);
-    }
 
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
@@ -671,120 +906,351 @@ SetStateImageList_t SetStateImageList_orig;
 
 HRESULT THISCALL SetStateImageList_hook(void *pThis, HIMAGELIST himl)
 {
-    if (g_settings.hidePinButtons)
-        return S_OK;
+    // Always let CNscTree accept the image list so it remains alive and
+    // can be cached by WM_PAINT (which hides it before the tree draws).
     return SetStateImageList_orig(pThis, himl);
 }
 
-// --- Quick Access item hiding ---
-// Quick Access pinned items bypass all CNscTree insertion predicates
-// (_ShouldInsertChild, _InsertChild) so we can't filter them at
-// insertion time. Instead, on the first WM_PAINT after our items
-// are cached, walk depth-1 items and delete any matching childless
-// duplicates (QA pins have no children; nav pane sections do).
-
-static void CleanupQuickAccessDuplicates(HWND hTree)
+static void GetPidlDisplayName(PIDLIST_ABSOLUTE pidl, WCHAR *buf, int len)
 {
-    if (!g_hCachedThisPC && !g_hCachedDesktop)
-        return;
+    IShellItem *psi = nullptr;
+    if (SUCCEEDED(SHCreateItemFromIDList(pidl, IID_IShellItem,
+                                         (void **)&psi)) && psi)
+    {
+        LPWSTR name = nullptr;
+        if (SUCCEEDED(psi->GetDisplayName(SIGDN_NORMALDISPLAY, &name))
+            && name)
+        {
+            wcsncpy_s(buf, len, name, _TRUNCATE);
+            CoTaskMemFree(name);
+        }
+        psi->Release();
+    }
+}
+
+static void GetItemText(HWND hTree, HTREEITEM h, WCHAR *buf, int len)
+{
+    TVITEMEXW tvi = {};
+    tvi.mask = TVIF_HANDLE | TVIF_TEXT;
+    tvi.hItem = h;
+    tvi.pszText = buf;
+    tvi.cchTextMax = len;
+    SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
+}
+
+static void ResolveHomeGalleryNames(WCHAR *homeName, int homeLen,
+                                     WCHAR *galleryName, int galleryLen)
+{
+    if (g_pidlHome) GetPidlDisplayName(g_pidlHome, homeName, homeLen);
+    if (g_pidlGallery) GetPidlDisplayName(g_pidlGallery, galleryName, galleryLen);
+}
+
+// --- Quick Access item hiding ---
+// Walk depth-1 children of the hidden root and delete items matching
+// our items' display text. Handles two kinds of duplicates:
+// - Childless QA pins: kept as hiddenDuplicate (separator mechanism)
+//   when removeSepBelowNav is off, otherwise deleted.
+// - Native sections with children (e.g. the native "This PC" below
+//   Quick Access): always deleted — our top-level items replace them.
+//
+// Returns true when all expected childless duplicates were found.
+// Returns false if some are still missing (async population race).
+static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
+{
+    if (!ts.hThisPC && !ts.hDesktop)
+        return true;
 
     WCHAR thisPCText[64] = {};
     WCHAR desktopText[64] = {};
+    int expectedCount = 0;
 
     if (g_settings.showThisPCAtTop &&
-        g_settings.hideThisPCFromQuickAccess && g_hCachedThisPC)
+        g_settings.hideThisPCFromQuickAccess && ts.hThisPC)
     {
-        TVITEMEXW tvi = {};
-        tvi.mask = TVIF_HANDLE | TVIF_TEXT;
-        tvi.hItem = g_hCachedThisPC;
-        tvi.pszText = thisPCText;
-        tvi.cchTextMax = ARRAYSIZE(thisPCText);
-        SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
+        GetItemText(hTree, ts.hThisPC, thisPCText, ARRAYSIZE(thisPCText));
+        if (thisPCText[0]) expectedCount++;
     }
 
     if (g_settings.showDesktopAtTop &&
-        g_settings.hideDesktopFromQuickAccess && g_hCachedDesktop)
+        g_settings.hideDesktopFromQuickAccess && ts.hDesktop)
     {
-        TVITEMEXW tvi = {};
-        tvi.mask = TVIF_HANDLE | TVIF_TEXT;
-        tvi.hItem = g_hCachedDesktop;
-        tvi.pszText = desktopText;
-        tvi.cchTextMax = ARRAYSIZE(desktopText);
-        SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
+        GetItemText(hTree, ts.hDesktop, desktopText, ARRAYSIZE(desktopText));
+        if (desktopText[0]) expectedCount++;
     }
 
-    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                          TVGN_ROOT, 0);
-    if (!h) return;
+    if (!expectedCount)
+        return true;
 
-    // Walk depth-1 items (children of root)
-    h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                TVGN_CHILD, (LPARAM)h);
+    HTREEITEM h = GetFirstDepth1Child(hTree);
+    if (!h) return false;
 
-    HTREEITEM toDelete[8] = {};
-    int delCount = 0;
+    HTREEITEM toDeleteChildless[8] = {};
+    HTREEITEM toDeleteSections[4] = {};
+    int childlessCount = 0;
+    int sectionCount = 0;
+
+    // Find the boundary position: first non-our/non-HG depth-1 child
+    // after our section. A dup can only be kept as hiddenDuplicate if
+    // it occupies this exact position.
+    //
+    // ts.hHome/hGallery may be null at this point (COM vtable bypass),
+    // so resolve Home/Gallery display names from PIDLs to identify them.
+    WCHAR homeName[64] = {};
+    WCHAR galleryName[64] = {};
+    ResolveHomeGalleryNames(homeName, ARRAYSIZE(homeName),
+                            galleryName, ARRAYSIZE(galleryName));
+
+    HTREEITEM hBoundaryPos = nullptr;
+    {
+        bool passedOurs = false;
+        HTREEITEM hWalk = h;
+        while (hWalk)
+        {
+            bool isOursOrHG = IsOurSection(ts, hWalk);
+
+            if (!isOursOrHG && (homeName[0] || galleryName[0]))
+            {
+                WCHAR text[64] = {};
+                GetItemText(hTree, hWalk, text, ARRAYSIZE(text));
+                if ((homeName[0] && wcscmp(text, homeName) == 0) ||
+                    (galleryName[0] && wcscmp(text, galleryName) == 0))
+                    isOursOrHG = true;
+            }
+
+            if (isOursOrHG)
+                passedOurs = true;
+            else if (passedOurs)
+            {
+                hBoundaryPos = hWalk;
+                break;
+            }
+            hWalk = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                             TVGN_NEXT, (LPARAM)hWalk);
+        }
+    }
 
     while (h)
     {
         HTREEITEM hNext = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
                                                    TVGN_NEXT, (LPARAM)h);
-        if (h != g_hCachedThisPC && h != g_hCachedDesktop)
+        if (h != ts.hThisPC && h != ts.hDesktop)
         {
-            HTREEITEM hChild = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
-                                                        TVGN_CHILD, (LPARAM)h);
-            if (!hChild)
+            WCHAR text[64] = {};
+            GetItemText(hTree, h, text, ARRAYSIZE(text));
+
+            bool match = false;
+            if (thisPCText[0] && wcscmp(text, thisPCText) == 0)
+                match = true;
+            if (desktopText[0] && wcscmp(text, desktopText) == 0)
+                match = true;
+
+            if (match)
             {
-                WCHAR text[64] = {};
-                TVITEMEXW tvi = {};
-                tvi.mask = TVIF_HANDLE | TVIF_TEXT;
-                tvi.hItem = h;
-                tvi.pszText = text;
-                tvi.cchTextMax = ARRAYSIZE(text);
-                SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
-
-                bool match = false;
-                if (thisPCText[0] && wcscmp(text, thisPCText) == 0)
-                    match = true;
-                if (desktopText[0] && wcscmp(text, desktopText) == 0)
-                    match = true;
-
-                if (match && delCount < 8)
-                    toDelete[delCount++] = h;
+                HTREEITEM hChild = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                                            TVGN_CHILD, (LPARAM)h);
+                if (!hChild)
+                {
+                    if (childlessCount < 8)
+                        toDeleteChildless[childlessCount++] = h;
+                }
+                else
+                {
+                    if (sectionCount < 4)
+                        toDeleteSections[sectionCount++] = h;
+                }
             }
         }
         h = hNext;
     }
 
-    // Only keep a duplicate hidden (paint-over) if it's a section
-    // boundary item (iIntegral>=2) — removing it would destroy the
-    // gap where the separator line goes. All others are safe to delete.
-    g_hiddenDuplicate = nullptr;
-    for (int i = 0; i < delCount; i++)
+    // Native sections with children: always delete (our items replace them)
+    for (int i = 0; i < sectionCount; i++)
     {
-        if (!g_hiddenDuplicate)
-        {
-            TVITEMEXW check = {};
-            check.mask = TVIF_HANDLE | TVIF_INTEGRAL;
-            check.hItem = toDelete[i];
-            SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&check);
+        Wh_Log(L"[QA-HIDE] deleting native section=%p", toDeleteSections[i]);
+        SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDeleteSections[i]);
+    }
 
-            if (check.iIntegral >= 2)
+    // Only keep a childless match as hiddenDuplicate if it IS the
+    // boundary item (first non-our item after our section). A dup in
+    // the middle of QA would be painted over but leave a blank gap
+    // with no separator, since RedrawOtherSeparators skips the boundary
+    // when hiddenDuplicate exists.
+    HTREEITEM prevDup = ts.hiddenDuplicate;
+    ts.hiddenDuplicate = nullptr;
+    ts.dupAtBoundary = false;
+    for (int i = 0; i < childlessCount; i++)
+    {
+        if (!g_settings.removeSepBelowNav && !ts.hiddenDuplicate &&
+            toDeleteChildless[i] == hBoundaryPos)
+        {
+            ts.hiddenDuplicate = toDeleteChildless[i];
+            TVITEMEXW fix = {};
+            fix.mask = TVIF_HANDLE | TVIF_INTEGRAL;
+            fix.hItem = toDeleteChildless[i];
+            fix.iIntegral = 1;
+            SendMessageW(hTree, TVM_SETITEMW, 0, (LPARAM)&fix);
+            if (ts.hiddenDuplicate != prevDup)
+                Wh_Log(L"[QA-HIDE] keeping dup=%p at boundary (iIntegral=1)",
+                       toDeleteChildless[i]);
+            continue;
+        }
+        Wh_Log(L"[QA-HIDE] deleting duplicate item=%p (boundary=%p)",
+               toDeleteChildless[i], hBoundaryPos);
+        SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDeleteChildless[i]);
+    }
+
+    if (ts.hiddenDuplicate != prevDup || sectionCount > 0)
+        Wh_Log(L"[QA-HIDE] tree=%p childless=%d sections=%d expected=%d dup=%p",
+               hTree, childlessCount, sectionCount, expectedCount,
+               ts.hiddenDuplicate);
+
+    return (childlessCount >= expectedCount);
+}
+
+// Walk depth-1 children and cache Home/Gallery handles by matching
+// PIDL-derived display names. Called when handles are unknown (e.g.,
+// after FullRebuildTree where items existed before our hooks).
+static void CacheHomeGalleryHandles(HWND hTree, TreeState& ts)
+{
+    if (ts.hHome && ts.hGallery)
+        return;
+
+    bool needHome = !ts.hHome && g_pidlHome && !g_settings.hideHome;
+    bool needGallery = !ts.hGallery && g_pidlGallery && !g_settings.hideGallery;
+    if (!needHome && !needGallery)
+        return;
+
+    WCHAR homeName[64] = {};
+    WCHAR galleryName[64] = {};
+    ResolveHomeGalleryNames(homeName, ARRAYSIZE(homeName),
+                            galleryName, ARRAYSIZE(galleryName));
+
+    HTREEITEM h = GetFirstDepth1Child(hTree);
+    if (!h) return;
+
+    while (h)
+    {
+        if (h != ts.hThisPC && h != ts.hDesktop)
+        {
+            WCHAR text[64] = {};
+            GetItemText(hTree, h, text, ARRAYSIZE(text));
+
+            if (needHome && homeName[0] && wcscmp(text, homeName) == 0)
             {
-                g_hiddenDuplicate = toDelete[i];
-                TVITEMEXW forceSmall = {};
-                forceSmall.mask = TVIF_HANDLE | TVIF_INTEGRAL;
-                forceSmall.hItem = toDelete[i];
-                forceSmall.iIntegral = 1;
-                SendMessageW(hTree, TVM_SETITEMW, 0, (LPARAM)&forceSmall);
-                Wh_Log(L"[QA-HIDE] keeping boundary item=%p invisible (was iIntegral=%d)",
-                       toDelete[i], check.iIntegral);
-                continue;
+                ts.hHome = h;
+                needHome = false;
+                Wh_Log(L"[CACHE] Home item=%p tree=%p (walk)", h, hTree);
+            }
+            else if (needGallery && galleryName[0] &&
+                     wcscmp(text, galleryName) == 0)
+            {
+                ts.hGallery = h;
+                needGallery = false;
+                Wh_Log(L"[CACHE] Gallery item=%p tree=%p (walk)", h, hTree);
+            }
+
+            if (!needHome && !needGallery)
+                break;
+        }
+        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                    TVGN_NEXT, (LPARAM)h);
+    }
+}
+
+// Walk depth-1 items and delete Home/Gallery by matching their
+// display names derived from PIDLs (localization-agnostic).
+// Returns true when all expected items have been found and removed.
+static bool RemoveHomeGalleryItems(HWND hTree, TreeState& ts)
+{
+    if (!IsWindow(hTree))
+        return true;
+
+    bool wantHome = g_settings.hideHome && g_pidlHome;
+    bool wantGallery = g_settings.hideGallery && g_pidlGallery;
+    if (!wantHome && !wantGallery)
+        return true;
+
+    WCHAR homeName[64] = {};
+    WCHAR galleryName[64] = {};
+    ResolveHomeGalleryNames(homeName, ARRAYSIZE(homeName),
+                            galleryName, ARRAYSIZE(galleryName));
+
+    int expectedCount = 0;
+    if (wantHome && homeName[0]) expectedCount++;
+    if (wantGallery && galleryName[0]) expectedCount++;
+    if (!expectedCount) return true;
+
+    HTREEITEM h = GetFirstDepth1Child(hTree);
+    if (!h) return false;
+    struct { HTREEITEM h; bool isHome; } toDelete[2] = {};
+    int delCount = 0;
+
+    while (h && delCount < 2)
+    {
+        HTREEITEM hNext = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM,
+                                                   TVGN_NEXT, (LPARAM)h);
+        if (h != ts.hThisPC && h != ts.hDesktop &&
+            h != ts.hiddenDuplicate)
+        {
+            WCHAR text[64] = {};
+            GetItemText(hTree, h, text, ARRAYSIZE(text));
+
+            if (text[0])
+            {
+                bool isHome = wantHome && homeName[0] &&
+                              wcscmp(text, homeName) == 0;
+                bool isGallery = wantGallery && galleryName[0] &&
+                                 wcscmp(text, galleryName) == 0;
+                if (isHome || isGallery)
+                    toDelete[delCount++] = { h, isHome };
             }
         }
-
-        Wh_Log(L"[QA-HIDE] deleting duplicate item=%p", toDelete[i]);
-        SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDelete[i]);
+        h = hNext;
     }
+
+    for (int i = 0; i < delCount; i++)
+    {
+        Wh_Log(L"[HIDE-%s] Deleting item=%p",
+               toDelete[i].isHome ? L"HOME" : L"GALLERY", toDelete[i].h);
+        SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDelete[i].h);
+        if (toDelete[i].isHome)
+            ts.hHome = nullptr;
+        else
+            ts.hGallery = nullptr;
+    }
+
+    return (delCount >= expectedCount);
+}
+
+// Tree subclass installed via SetWindowSubclass — runs BEFORE
+// Explorer's other subclasses (LIFO order), blocking right-click
+// on the hidden duplicate.
+// TODO: instead of blocking, redirect to empty space and reposition
+// the resulting background context menu to the click point.
+static LRESULT CALLBACK TreeInteractionProc(
+    HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
+    UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
+{
+    TreeState* ts = GetTree(hWnd);
+    HTREEITEM hiddenDup = ts ? ts->hiddenDuplicate : nullptr;
+
+    if (hiddenDup &&
+        (uMsg == WM_RBUTTONDOWN || uMsg == WM_RBUTTONUP ||
+         uMsg == WM_MOUSEMOVE))
+    {
+        POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+        TVHITTESTINFO ht = {};
+        ht.pt = pt;
+        HTREEITEM hHit = (HTREEITEM)SendMessageW(
+            hWnd, TVM_HITTEST, 0, (LPARAM)&ht);
+        if (hHit == hiddenDup)
+            return 0;
+    }
+
+    if (uMsg == WM_NCDESTROY)
+        RemoveWindowSubclass(hWnd, TreeInteractionProc, uIdSubclass);
+
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
 
 // --- SubClassTreeWndProc ---
@@ -800,40 +1266,76 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
 {
     if (uMsg == TVM_INSERTITEMW || uMsg == TVM_INSERTITEMA)
     {
+        bool isOurInsert = (g_insertingItem >= 1 && g_insertingItem <= 4) &&
+                           (!g_insertingForTree || hWnd == g_insertingForTree);
+
+        if (isOurInsert && (g_insertingItem == 1 || g_insertingItem == 2) && lParam)
+        {
+            TVINSERTSTRUCTW *pInsert = (TVINSERTSTRUCTW *)lParam;
+            pInsert->hInsertAfter = TVI_FIRST;
+        }
+
         LRESULT result = SubClassTreeWndProc_orig(hWnd, uMsg, wParam,
                             lParam, uIdSubclass, dwRefData);
         HTREEITEM hNew = (HTREEITEM)result;
         if (hNew)
         {
-            if (g_insertingItem == 1)
+            if (isOurInsert && (g_insertingItem == 1 || g_insertingItem == 2))
             {
-                g_hCachedThisPC = hNew;
-                g_hCachedTree = hWnd;
-                g_qaCleanupDone = false;
-                g_hiddenDuplicate = nullptr;
-                Wh_Log(L"[CACHE] This PC item=%p tree=%p", hNew, hWnd);
-            }
-            else if (g_insertingItem == 2)
-            {
-                g_hCachedDesktop = hNew;
-                g_hCachedTree = hWnd;
-                g_qaCleanupDone = false;
-                g_hiddenDuplicate = nullptr;
-                Wh_Log(L"[CACHE] Desktop item=%p tree=%p", hNew, hWnd);
-            }
-            else if (g_qaCleanupDone && g_hCachedTree == hWnd)
-            {
-                HTREEITEM hPar = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM,
-                                                          TVGN_PARENT, (LPARAM)hNew);
-                if (hPar)
+                bool isThisPC = (g_insertingItem == 1);
+                g_insertingItem = 0;
+                auto [it, _] = g_trees.try_emplace(hWnd);
+                TreeState& ts = it->second;
+                (isThisPC ? ts.hThisPC : ts.hDesktop) = hNew;
+                ts.qaCleanupDone = false;
+                ts.hiddenDuplicate = nullptr;
+                ts.dupAtBoundary = false;
+                if (!ts.pNscTree)
                 {
-                    HTREEITEM hGP = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM,
-                                                              TVGN_PARENT, (LPARAM)hPar);
-                    if (!hGP)
+                    ts.pNscTree = g_pNscTree;
+                    ts.enumFlags = g_lastEnumFlags;
+                    if (g_pLastFilter && !ts.pFilter)
                     {
-                        g_qaCleanupDone = false;
-                        g_hiddenDuplicate = nullptr;
-                        Wh_Log(L"[QA-HIDE] depth-1 item inserted, scheduling re-cleanup");
+                        g_pLastFilter->AddRef();
+                        ts.pFilter = g_pLastFilter;
+                    }
+                }
+                SetPropW(hWnd, L"WH_NscTree", (HANDLE)ts.pNscTree);
+                SetPropW(hWnd, L"WH_EnumFlags", (HANDLE)(ULONG_PTR)ts.enumFlags);
+                Wh_Log(L"[CACHE] %s item=%p tree=%p",
+                       isThisPC ? L"This PC" : L"Desktop", hNew, hWnd);
+            }
+            else if (isOurInsert && (g_insertingItem == 3 || g_insertingItem == 4))
+            {
+                bool isHome = (g_insertingItem == 3);
+                g_insertingItem = 0;
+                auto [it, _] = g_trees.try_emplace(hWnd);
+                TreeState& ts = it->second;
+                (isHome ? ts.hHome : ts.hGallery) = hNew;
+                Wh_Log(L"[CACHE] %s item=%p tree=%p",
+                       isHome ? L"Home" : L"Gallery", hNew, hWnd);
+                bool hidden = isHome ? g_settings.hideHome : g_settings.hideGallery;
+                if (!hidden &&
+                    (g_settings.showThisPCAtTop || g_settings.showDesktopAtTop))
+                {
+                    TVITEMEXW fix = {};
+                    fix.mask = TVIF_HANDLE | TVIF_INTEGRAL;
+                    fix.hItem = hNew;
+                    fix.iIntegral = 1;
+                    SendMessageW(hWnd, TVM_SETITEMW, 0, (LPARAM)&fix);
+                }
+            }
+            else
+            {
+                TreeState* ts = GetTree(hWnd);
+                if (ts && IsDepth1Item(hWnd, hNew))
+                {
+                    ts->homeGalleryCleanupDone = false;
+                    if (ts->qaCleanupDone)
+                    {
+                        ts->qaCleanupDone = false;
+                        ts->hiddenDuplicate = nullptr;
+                        ts->dupAtBoundary = false;
                     }
                 }
             }
@@ -841,49 +1343,70 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
         return result;
     }
 
-    // Block clicks and cursor changes on hidden duplicate
-    if (g_hiddenDuplicate &&
-        (uMsg == WM_LBUTTONDOWN || uMsg == WM_SETCURSOR))
+    // Block all interaction with hidden duplicate
     {
-        POINT pt;
-        if (uMsg == WM_LBUTTONDOWN)
-        {
-            pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
-        }
-        else
-        {
-            GetCursorPos(&pt);
-            ScreenToClient(hWnd, &pt);
-        }
-        TVHITTESTINFO ht = {};
-        ht.pt = pt;
-        HTREEITEM hHit = (HTREEITEM)SendMessageW(hWnd, TVM_HITTEST, 0, (LPARAM)&ht);
-        if (hHit == g_hiddenDuplicate)
-        {
-            if (uMsg == WM_LBUTTONDOWN)
-                return 0;
-            SetCursor(LoadCursorW(nullptr, IDC_ARROW));
-            return TRUE;
-        }
-    }
+        TreeState* ts = GetTree(hWnd);
+        HTREEITEM hiddenDup = ts ? ts->hiddenDuplicate : nullptr;
 
-    // Skip hidden duplicate on keyboard navigation
-    if (uMsg == WM_KEYDOWN && g_hiddenDuplicate &&
-        (wParam == VK_UP || wParam == VK_DOWN))
-    {
-        LRESULT r = SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam,
-                                              uIdSubclass, dwRefData);
-        HTREEITEM hSel = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM,
-                                                   TVGN_CARET, 0);
-        if (hSel == g_hiddenDuplicate)
+        if (hiddenDup &&
+            (uMsg == WM_LBUTTONDOWN || uMsg == WM_RBUTTONDOWN ||
+             uMsg == WM_RBUTTONUP || uMsg == WM_CONTEXTMENU ||
+             uMsg == WM_SETCURSOR))
         {
-            UINT dir = (wParam == VK_DOWN) ? TVGN_NEXTVISIBLE : TVGN_PREVIOUSVISIBLE;
-            HTREEITEM hNext = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM,
-                                                        dir, (LPARAM)hSel);
-            if (hNext)
-                SendMessageW(hWnd, TVM_SELECTITEM, TVGN_CARET, (LPARAM)hNext);
+            POINT pt = {};
+            bool checkHit = true;
+            if (uMsg == WM_CONTEXTMENU)
+            {
+                pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+                if (pt.x == -1 && pt.y == -1)
+                    checkHit = false;
+                else
+                    ScreenToClient(hWnd, &pt);
+            }
+            else if (uMsg == WM_SETCURSOR)
+            {
+                GetCursorPos(&pt);
+                ScreenToClient(hWnd, &pt);
+            }
+            else
+            {
+                pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+            }
+            if (checkHit)
+            {
+                TVHITTESTINFO ht = {};
+                ht.pt = pt;
+                HTREEITEM hHit = (HTREEITEM)SendMessageW(hWnd, TVM_HITTEST, 0, (LPARAM)&ht);
+                if (hHit == hiddenDup)
+                {
+                    if (uMsg == WM_SETCURSOR)
+                    {
+                        SetCursor(LoadCursorW(nullptr, IDC_ARROW));
+                        return TRUE;
+                    }
+                    return 0;
+                }
+            }
         }
-        return r;
+
+        // Skip hidden duplicate on keyboard navigation
+        if (uMsg == WM_KEYDOWN && hiddenDup &&
+            (wParam == VK_UP || wParam == VK_DOWN))
+        {
+            LRESULT r = SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam,
+                                                  uIdSubclass, dwRefData);
+            HTREEITEM hSel = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM,
+                                                       TVGN_CARET, 0);
+            if (hSel == hiddenDup)
+            {
+                UINT dir = (wParam == VK_DOWN) ? TVGN_NEXTVISIBLE : TVGN_PREVIOUSVISIBLE;
+                HTREEITEM hNext = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM,
+                                                            dir, (LPARAM)hSel);
+                if (hNext)
+                    SendMessageW(hWnd, TVM_SELECTITEM, TVGN_CARET, (LPARAM)hNext);
+            }
+            return r;
+        }
     }
 
     if (uMsg == TVM_SETITEMW || uMsg == TVM_SETITEMA)
@@ -891,19 +1414,49 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
         TVITEMEXW* tvi = (TVITEMEXW*)lParam;
         if (tvi && (tvi->mask & TVIF_INTEGRAL))
         {
+            TreeState* ts = GetTree(hWnd);
+            HTREEITEM hiddenDup = ts ? ts->hiddenDuplicate : nullptr;
+            HTREEITEM boundaryIt = ts ? ts->boundaryItem : nullptr;
+            HTREEITEM belowQAIt = ts ? ts->belowQAItem : nullptr;
+
             // Keep hidden duplicate at iIntegral=1 so it occupies
             // exactly one row of space for the painted-over separator.
-            if (g_hiddenDuplicate && tvi->hItem == g_hiddenDuplicate &&
+            if (hiddenDup && tvi->hItem == hiddenDup &&
                 tvi->iIntegral != 1)
             {
                 tvi->iIntegral = 1;
             }
 
-            // Collapse the boundary between Desktop and This PC.
-            if (ShouldRemoveSeparators() && tvi->iIntegral >= 2)
+            if (boundaryIt && tvi->hItem == boundaryIt &&
+                tvi->iIntegral >= 2 &&
+                (g_settings.removeSepBelowNav ||
+                 ts->dupAtBoundary))
             {
-                HTREEITEM hA = (g_hCachedTree == hWnd) ? g_hCachedThisPC : nullptr;
-                HTREEITEM hB = (g_hCachedTree == hWnd) ? g_hCachedDesktop : nullptr;
+                tvi->iIntegral = 1;
+            }
+
+            if (belowQAIt && tvi->hItem == belowQAIt &&
+                tvi->iIntegral >= 2)
+            {
+                tvi->iIntegral = 1;
+            }
+
+            if (ts && tvi->iIntegral >= 2 &&
+                (g_settings.showThisPCAtTop || g_settings.showDesktopAtTop))
+            {
+                bool isVisibleHome = ts->hHome && tvi->hItem == ts->hHome &&
+                                     !g_settings.hideHome;
+                bool isVisibleGallery = ts->hGallery && tvi->hItem == ts->hGallery &&
+                                        !g_settings.hideGallery;
+                if (isVisibleHome || isVisibleGallery)
+                    tvi->iIntegral = 1;
+            }
+
+            // Collapse the boundary between Desktop and This PC.
+            if (ShouldRemoveInternalSep() && tvi->iIntegral >= 2 && ts)
+            {
+                HTREEITEM hA = ts->hThisPC;
+                HTREEITEM hB = ts->hDesktop;
                 if (hA && hB)
                 {
                     RECT rcA = {}, rcB = {};
@@ -916,37 +1469,248 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
                     {
                         HTREEITEM hLower = (rcA.top > rcB.top) ? hA : hB;
                         if (tvi->hItem == hLower)
-                        {
-                            Wh_Log(L"[SEP-COLLAPSE] TVM_SETITEMW: iIntegral %d->1 on item=%p",
-                                   tvi->iIntegral, tvi->hItem);
                             tvi->iIntegral = 1;
-                        }
                     }
                 }
             }
         }
     }
 
+    if (uMsg == WM_DEFERRED_REBUILD)
+    {
+        if (g_deferredOpInProgress)
+        {
+            g_pendingRebuildTrees.insert(hWnd);
+            return 0;
+        }
+
+        TreeState* ts = GetTree(hWnd);
+        if (ts && ts->needFullRebuild)
+        {
+            g_deferredOpInProgress = true;
+            ts->needFullRebuild = false;
+            FullRebuildTree(hWnd);
+            ts = GetTree(hWnd);
+            DrainPendingRebuilds();
+        }
+        if (ts && ts->needHotInsert)
+        {
+            g_deferredOpInProgress = true;
+            ts->needHotInsert = false;
+            HotEnableInsert(hWnd);
+            DrainPendingRebuilds();
+        }
+        return 0;
+    }
+
     if (uMsg == WM_PAINT)
     {
-        if (!g_qaCleanupDone && g_hCachedTree == hWnd &&
+        TreeState* ts = GetTree(hWnd);
+
+        // Full rebuild deferred from settings change or missed message.
+        // Guarded to prevent re-entrancy (AppendRoot_orig pumps messages).
+        if (ts && ts->needFullRebuild && !g_deferredOpInProgress)
+        {
+            g_deferredOpInProgress = true;
+            ts->needFullRebuild = false;
+            FullRebuildTree(hWnd);
+            ts = GetTree(hWnd);
+            DrainPendingRebuilds();
+        }
+
+        // Hot-enable deferred insertion: items are inserted on the UI
+        // thread so TVM_INSERTITEM fires through the subclass (TVI_FIRST
+        // + caching work). Items land as children of the hidden root.
+        // Guarded: same re-entrancy risk as FullRebuildTree.
+        if (ts && ts->needHotInsert && !g_deferredOpInProgress)
+        {
+            g_deferredOpInProgress = true;
+            ts->needHotInsert = false;
+            HotEnableInsert(hWnd);
+            ts = GetTree(hWnd);
+            DrainPendingRebuilds();
+        }
+
+        // Cache Home/Gallery handles if unknown (items exist in tree
+        // but were added before our hooks, e.g., after FullRebuildTree).
+        if (ts && ((g_pidlHome && !ts->hHome && !g_settings.hideHome) ||
+                   (g_pidlGallery && !ts->hGallery && !g_settings.hideGallery)))
+            CacheHomeGalleryHandles(hWnd, *ts);
+
+        if (ts && !ts->qaCleanupDone &&
             ((g_settings.showThisPCAtTop && g_settings.hideThisPCFromQuickAccess) ||
              (g_settings.showDesktopAtTop && g_settings.hideDesktopFromQuickAccess)))
         {
-            g_qaCleanupDone = true;
-            CleanupQuickAccessDuplicates(hWnd);
+            ts->qaCleanupDone = CleanupQuickAccessDuplicates(hWnd, *ts);
         }
 
-        if (g_settings.hidePinButtons)
+        // Collapse visible duplicates of our items so they don't
+        // mirror the expanded state of our top copies. Runs whenever
+        // a dup is visible: parent off (dup never hidden) or parent
+        // on but not hiding from nav. Uses PIDL fallback for names
+        // when our item handle doesn't exist.
+        if (ts)
+        {
+            WCHAR collapseText[2][64] = {};
+            int collapseCount = 0;
+
+            auto getTextFromItem = [&](HTREEITEM h) {
+                if (!h || collapseCount >= 2) return;
+                GetItemText(hWnd, h, collapseText[collapseCount], 64);
+                if (collapseText[collapseCount][0]) collapseCount++;
+            };
+
+            if (!g_settings.showThisPCAtTop ||
+                !g_settings.hideThisPCFromQuickAccess)
+            {
+                if (ts->hThisPC)
+                    getTextFromItem(ts->hThisPC);
+                else if (g_pidlThisPC && collapseCount < 2)
+                {
+                    GetPidlDisplayName(g_pidlThisPC,
+                                       collapseText[collapseCount], 64);
+                    if (collapseText[collapseCount][0]) collapseCount++;
+                }
+            }
+            if (!g_settings.showDesktopAtTop ||
+                !g_settings.hideDesktopFromQuickAccess)
+            {
+                if (ts->hDesktop)
+                    getTextFromItem(ts->hDesktop);
+                else if (g_pidlDesktop && collapseCount < 2)
+                {
+                    GetPidlDisplayName(g_pidlDesktop,
+                                       collapseText[collapseCount], 64);
+                    if (collapseText[collapseCount][0]) collapseCount++;
+                }
+            }
+
+            if (collapseCount > 0)
+            {
+                HTREEITEM h = GetFirstDepth1Child(hWnd);
+                while (h)
+                {
+                    if (h != ts->hThisPC && h != ts->hDesktop)
+                    {
+                        WCHAR text[64] = {};
+                        TVITEMEXW tvi = {};
+                        tvi.mask = TVIF_HANDLE | TVIF_TEXT | TVIF_STATE;
+                        tvi.stateMask = TVIS_EXPANDED;
+                        tvi.hItem = h;
+                        tvi.pszText = text;
+                        tvi.cchTextMax = 64;
+                        SendMessageW(hWnd, TVM_GETITEMW, 0, (LPARAM)&tvi);
+
+                        if ((tvi.state & TVIS_EXPANDED) && text[0])
+                        {
+                            for (int j = 0; j < collapseCount; j++)
+                            {
+                                if (wcscmp(text, collapseText[j]) == 0)
+                                {
+                                    SendMessageW(hWnd, TVM_EXPAND, TVE_COLLAPSE, (LPARAM)h);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    h = (HTREEITEM)SendMessageW(hWnd, TVM_GETNEXTITEM, TVGN_NEXT, (LPARAM)h);
+                }
+            }
+        }
+
+        // Remove Home/Gallery items by PIDL (children of hidden root)
+        if (ts && !ts->homeGalleryCleanupDone &&
+            ts->pNscTree && (g_pidlHome || g_pidlGallery) &&
+            (g_settings.hideHome || g_settings.hideGallery))
+        {
+            ts->homeGalleryCleanupDone = RemoveHomeGalleryItems(hWnd, *ts);
+        }
+
+        // Collapse iIntegral on visible Home/Gallery so there's no
+        // space between our items and them.
+        if (ts && (g_settings.showThisPCAtTop || g_settings.showDesktopAtTop))
+        {
+            if (ts->hHome && !g_settings.hideHome)
+                CollapseItemIntegral(hWnd, ts->hHome);
+            if (ts->hGallery && !g_settings.hideGallery)
+                CollapseItemIntegral(hWnd, ts->hGallery);
+        }
+
+        // Find and optionally collapse separator boundary items.
+        // Always runs when we have items at top (to track boundaryItem
+        // for RedrawOtherSeparators). Only COLLAPSES iIntegral when the
+        // user wants to remove the separator:
+        // - boundary: collapse when removeSepBelowNav (otherwise its
+        //   iIntegral=2 provides space for the separator we draw)
+        // - below-QA: collapse when removeSepBelowQA
+        // Deferred until g_sepColor is captured so tall items remain
+        // for the sampling pass on the first paint cycle.
+        if ((g_settings.showThisPCAtTop || g_settings.showDesktopAtTop) &&
+            g_sepColor != CLR_INVALID && ts)
+        {
+            HTREEITEM hChild = GetFirstDepth1Child(hWnd);
+            if (hChild)
+            {
+                bool passedOurs = false;
+                bool foundBoundary = false;
+                while (hChild)
+                {
+                    bool isOursOrHG = IsOurSection(*ts, hChild);
+
+                    if (isOursOrHG)
+                    {
+                        passedOurs = true;
+                    }
+                    else if (passedOurs && hChild != ts->hiddenDuplicate)
+                    {
+                        if (!foundBoundary)
+                        {
+                            ts->boundaryItem = hChild;
+                            if (ts->hiddenDuplicate)
+                            {
+                                HTREEITEM hPrev = (HTREEITEM)SendMessageW(
+                                    hWnd, TVM_GETNEXTITEM, TVGN_PREVIOUS,
+                                    (LPARAM)hChild);
+                                ts->dupAtBoundary = (hPrev == ts->hiddenDuplicate);
+                            }
+                            if (g_settings.removeSepBelowNav ||
+                                ts->dupAtBoundary)
+                            {
+                                CollapseItemIntegral(hWnd, hChild);
+                            }
+                            foundBoundary = true;
+                            if (!g_settings.removeSepBelowQA)
+                                break;
+                        }
+                        else if (CollapseItemIntegral(hWnd, hChild))
+                        {
+                            ts->belowQAItem = hChild;
+                            break;
+                        }
+                    }
+                    hChild = (HTREEITEM)SendMessageW(
+                        hWnd, TVM_GETNEXTITEM, TVGN_NEXT, (LPARAM)hChild);
+                }
+            }
+        }
+
+        if (g_settings.hidePinButtons && ts)
         {
             HIMAGELIST hState = (HIMAGELIST)SendMessageW(
                 hWnd, TVM_GETIMAGELIST, TVSIL_STATE, 0);
             if (hState)
+            {
+                ts->savedStateImageList = hState;
                 SendMessageW(hWnd, TVM_SETIMAGELIST, TVSIL_STATE, 0);
+            }
         }
 
-        if (ShouldRemoveSeparators() || g_hiddenDuplicate)
+        if (g_settings.showThisPCAtTop || g_settings.showDesktopAtTop)
             EnsureParentSubclass(hWnd);
+
+        // Install tree subclass for right-click blocking on hidden dup
+        if (ts && ts->hiddenDuplicate)
+            SetWindowSubclass(hWnd, TreeInteractionProc, 0xAF01, 0);
 
         if (g_settings.fixChevronDrawing)
             g_inTreePaint = true;
@@ -957,6 +1721,26 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(
         g_inTreePaint = false;
 
         return result;
+    }
+
+    if (uMsg == WM_NCDESTROY)
+    {
+        auto it = g_trees.find(hWnd);
+        if (it != g_trees.end())
+        {
+            RemoveWindowSubclass(hWnd, TreeInteractionProc, 0xAF01);
+            IShellItemFilter *pf = it->second.pFilter;
+            it->second.pFilter = nullptr;
+            INameSpaceTreeControl *pNsc = nullptr;
+            if (it->second.ownsNscRef && it->second.pNscTree)
+                pNsc = (INameSpaceTreeControl *)it->second.pNscTree;
+            it->second.pNscTree = nullptr;
+            g_trees.erase(it);
+            if (pf)
+                pf->Release();
+            if (pNsc)
+                pNsc->Release();
+        }
     }
 
     return SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam,
@@ -995,25 +1779,31 @@ void LoadSettings()
     g_settings.desktopAboveThisPC = Wh_GetIntSetting(L"Desktop.desktopAboveThisPC");
     g_settings.desktopExpandable = Wh_GetIntSetting(L"Desktop.desktopExpandable");
     g_settings.hideDesktopFromQuickAccess = Wh_GetIntSetting(L"Desktop.hideDesktopFromQuickAccess");
+    g_settings.hideHome = Wh_GetIntSetting(L"HomeGallery.hideHome");
+    g_settings.hideGallery = Wh_GetIntSetting(L"HomeGallery.hideGallery");
     g_settings.fixChevronDrawing = Wh_GetIntSetting(L"Resources.fixChevronDrawing");
     g_settings.chevronScale = Wh_GetIntSetting(L"Resources.chevronScale");
     g_settings.hidePinButtons = Wh_GetIntSetting(L"Resources.hidePinButtons");
-
-    g_sepColor = CLR_INVALID;
+    g_settings.removeSepBelowNav = Wh_GetIntSetting(L"Separators.removeSepBelowNav");
+    g_settings.removeSepBelowQA = Wh_GetIntSetting(L"Separators.removeSepBelowQA");
 
     Wh_Log(L"Settings: thisPCAtTop=%d (expand=%d, startExp=%d, hideQA=%d) "
             L"desktopAtTop=%d (above=%d, expand=%d, hideQA=%d) "
-            L"sepRemoval=%d fixChevron=%d chevronScale=%d hidePins=%d",
+            L"hideHome=%d hideGallery=%d "
+            L"fixChevron=%d chevronScale=%d hidePins=%d "
+            L"rmSepNav=%d rmSepQA=%d",
             g_settings.showThisPCAtTop,
             g_settings.thisPCExpandable, g_settings.thisPCStartExpanded,
             g_settings.hideThisPCFromQuickAccess,
             g_settings.showDesktopAtTop, g_settings.desktopAboveThisPC,
             g_settings.desktopExpandable,
             g_settings.hideDesktopFromQuickAccess,
-            ShouldRemoveSeparators(),
+            g_settings.hideHome, g_settings.hideGallery,
             g_settings.fixChevronDrawing,
             g_settings.chevronScale,
-            g_settings.hidePinButtons);
+            g_settings.hidePinButtons,
+            g_settings.removeSepBelowNav,
+            g_settings.removeSepBelowQA);
 }
 
 BOOL Wh_ModInit()
@@ -1024,6 +1814,14 @@ BOOL Wh_ModInit()
 
     LoadSettings();
 
+    auto cleanupOnFail = []() {
+        if (g_gdipToken) { Gdiplus::GdiplusShutdown(g_gdipToken); g_gdipToken = 0; }
+        if (g_pidlThisPC) { CoTaskMemFree(g_pidlThisPC); g_pidlThisPC = nullptr; }
+        if (g_pidlDesktop) { CoTaskMemFree(g_pidlDesktop); g_pidlDesktop = nullptr; }
+        if (g_pidlHome) { CoTaskMemFree(g_pidlHome); g_pidlHome = nullptr; }
+        if (g_pidlGallery) { CoTaskMemFree(g_pidlGallery); g_pidlGallery = nullptr; }
+    };
+
     Gdiplus::GdiplusStartupInput gdipIn;
     Gdiplus::GdiplusStartup(&g_gdipToken, &gdipIn, NULL);
 
@@ -1031,12 +1829,19 @@ BOOL Wh_ModInit()
     if (!g_pidlThisPC)
     {
         Wh_Log(L"Failed to get This PC PIDL");
+        cleanupOnFail();
         return FALSE;
     }
 
     SHGetSpecialFolderLocation(nullptr, CSIDL_DESKTOP, &g_pidlDesktop);
     if (!g_pidlDesktop)
         Wh_Log(L"Warning: failed to get Desktop PIDL");
+
+    SHParseDisplayName(L"::{f874310e-b6b7-47dc-bc84-b9e6b38f5903}",
+                       nullptr, &g_pidlHome, 0, nullptr);
+    SHParseDisplayName(L"::{e88865ea-0e1c-4e20-9aa6-edcd0212c87c}",
+                       nullptr, &g_pidlGallery, 0, nullptr);
+    Wh_Log(L"PIDLs: Home=%p Gallery=%p", g_pidlHome, g_pidlGallery);
 
     WindhawkUtils::SYMBOL_HOOK explorerFrameDllHooks[] = {
         {
@@ -1082,6 +1887,7 @@ BOOL Wh_ModInit()
     if (!WindhawkUtils::HookSymbols(hExplorerFrame, explorerFrameDllHooks, ARRAYSIZE(explorerFrameDllHooks)))
     {
         Wh_Log(L"Failed to hook symbols");
+        cleanupOnFail();
         return FALSE;
     }
 
@@ -1099,37 +1905,560 @@ BOOL Wh_ModInit()
     return TRUE;
 }
 
+struct DiscoveredTree {
+    HWND hTop;
+    HWND hTree;
+    INameSpaceTreeControl *pNsc;
+    unsigned long enumFlags;
+};
+
+void Wh_ModAfterInit()
+{
+    std::vector<DiscoveredTree> discovered;
+
+    DWORD pid = GetCurrentProcessId();
+    EnumWindows([](HWND hTop, LPARAM lParam) -> BOOL {
+        auto& out = *reinterpret_cast<std::vector<DiscoveredTree>*>(lParam);
+
+        DWORD wndPid = 0;
+        GetWindowThreadProcessId(hTop, &wndPid);
+        if (wndPid != GetCurrentProcessId())
+            return TRUE;
+        WCHAR cls[64];
+        GetClassNameW(hTop, cls, ARRAYSIZE(cls));
+        if (wcscmp(cls, L"CabinetWClass") != 0)
+            return TRUE;
+
+        HWND hShellTab = FindWindowExW(hTop, nullptr, L"ShellTabWindowClass", nullptr);
+        IShellBrowser *pSB = nullptr;
+        if (hShellTab)
+            pSB = (IShellBrowser *)SendMessageW(hShellTab, WM_USER + 7, 0, 0);
+        if (!pSB)
+            pSB = (IShellBrowser *)SendMessageW(hTop, WM_USER + 7, 0, 0);
+        if (!pSB)
+            return TRUE;
+
+        IServiceProvider *pSP = nullptr;
+        if (FAILED(pSB->QueryInterface(IID_IServiceProvider, (void **)&pSP)))
+            return TRUE;
+
+        INameSpaceTreeControl *pNsc = nullptr;
+        HRESULT hr = pSP->QueryService(IID_INameSpaceTreeControl,
+                                         IID_INameSpaceTreeControl,
+                                         (void **)&pNsc);
+        pSP->Release();
+        if (FAILED(hr))
+            return TRUE;
+
+        HWND hTree = nullptr;
+        IOleWindow *pOleWin = nullptr;
+        if (SUCCEEDED(pNsc->QueryInterface(IID_IOleWindow, (void **)&pOleWin)))
+        {
+            HWND hNscWnd = nullptr;
+            if (SUCCEEDED(pOleWin->GetWindow(&hNscWnd)) && hNscWnd)
+                hTree = FindWindowExW(hNscWnd, nullptr, L"SysTreeView32", nullptr);
+            pOleWin->Release();
+        }
+
+        if (!hTree)
+        {
+            pNsc->Release();
+            return TRUE;
+        }
+
+        unsigned long enumFlags = 0;
+        enumFlags = (unsigned long)(ULONG_PTR)GetPropW(hTree, L"WH_EnumFlags");
+        if (!enumFlags)
+            enumFlags = SHCONTF_FOLDERS;
+
+        out.push_back({ hTop, hTree, pNsc, enumFlags });
+        return TRUE;
+    }, (LPARAM)&discovered);
+
+    for (auto& d : discovered)
+    {
+        TreeState& ts = g_trees[d.hTree];
+        ts.pNscTree = (void *)d.pNsc;
+        ts.enumFlags = d.enumFlags;
+        ts.needFullRebuild = true;
+        ts.ownsNscRef = true;
+
+        SetPropW(d.hTree, L"WH_NscTree", (HANDLE)ts.pNscTree);
+        SetPropW(d.hTree, L"WH_EnumFlags", (HANDLE)(ULONG_PTR)d.enumFlags);
+
+        PostMessage(d.hTree, WM_DEFERRED_REBUILD, 0, 0);
+        Wh_Log(L"[ENABLE] window=%p tree=%p pNsc=%p", d.hTop, d.hTree, d.pNsc);
+    }
+}
+
+static void RefreshNavPane(HWND hTree)
+{
+    TreeState* ts = GetTree(hTree);
+    if (!ts || !hTree || !IsWindow(hTree) || !ts->pNscTree)
+        return;
+
+    if (ts->hThisPC)
+    {
+        SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)ts->hThisPC);
+        ts->hThisPC = nullptr;
+    }
+    if (ts->hDesktop)
+    {
+        SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)ts->hDesktop);
+        ts->hDesktop = nullptr;
+    }
+
+    // Clear managed items. Don't restore hiddenDuplicate's iIntegral —
+    // CleanupQuickAccessDuplicates will re-evaluate on the next paint.
+    // Restoring to 2 is wrong when the item won't be re-deduped (e.g.,
+    // Desktop disabled) and creates visible extra spacing.
+    ResetTreeCleanup(*ts);
+
+    INameSpaceTreeControl *pNsc = (INameSpaceTreeControl *)ts->pNscTree;
+    pNsc->AddRef();
+    unsigned long enumFlags = ts->enumFlags;
+    IShellItemFilter *pFilter = ts->pFilter;
+    if (pFilter)
+        pFilter->AddRef();
+
+    g_pNscTree = ts->pNscTree;
+    g_lastEnumFlags = enumFlags;
+    g_insertingForTree = hTree;
+    g_inCustomAppend = true;
+
+    NavItem items[2];
+    BuildItemOrder(items);
+
+    g_deferredOpInProgress = true;
+    InsertItems(ts->pNscTree, items, enumFlags, pFilter);
+    g_insertingForTree = nullptr;
+    g_inCustomAppend = false;
+    DrainPendingRebuilds();
+
+    if (pFilter)
+        pFilter->Release();
+    pNsc->Release();
+
+    g_logSepDraw = true;
+    RedrawWindow(hTree, nullptr, nullptr,
+                 RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+}
+
+static void HotEnableInsert(HWND hWnd)
+{
+    TreeState* ts = GetTree(hWnd);
+    if (!ts || !ts->pNscTree || !IsWindow(hWnd))
+        return;
+
+    HTREEITEM hFirstChild = GetFirstDepth1Child(hWnd);
+    if (!hFirstChild)
+    {
+        ts->needHotInsert = true;
+        return;
+    }
+
+    ts->hThisPC = nullptr;
+    ts->hDesktop = nullptr;
+    // Don't clear hHome/hGallery: they may have been cached during
+    // FullRebuildTree's AppendRoot_orig and are still valid.
+    ResetTreeCleanup(*ts);
+    g_sepColor = CLR_INVALID;
+    g_logSepDraw = true;
+
+    INameSpaceTreeControl *pNsc = (INameSpaceTreeControl *)ts->pNscTree;
+    pNsc->AddRef();
+    unsigned long enumFlags = ts->enumFlags;
+    IShellItemFilter *pFilter = ts->pFilter;
+    if (pFilter)
+        pFilter->AddRef();
+
+    g_pNscTree = ts->pNscTree;
+    g_lastEnumFlags = enumFlags;
+    g_insertingForTree = hWnd;
+    g_inCustomAppend = true;
+
+    NavItem items[2];
+    BuildItemOrder(items);
+
+    InsertItems(ts->pNscTree, items, enumFlags, pFilter);
+    g_insertingForTree = nullptr;
+    g_inCustomAppend = false;
+
+    if (pFilter)
+        pFilter->Release();
+    pNsc->Release();
+
+    ts = GetTree(hWnd);
+    Wh_Log(L"[HOTINSERT] Items inserted, ThisPC=%p Desktop=%p Home=%p Gallery=%p",
+           ts ? ts->hThisPC : nullptr, ts ? ts->hDesktop : nullptr,
+           ts ? ts->hHome : nullptr, ts ? ts->hGallery : nullptr);
+
+    // Invalidate for dedup and separator setup on the next paint
+    // (not RDW_UPDATENOW since we're already inside WM_PAINT)
+    InvalidateRect(hWnd, nullptr, TRUE);
+}
+
+static void FullRebuildTree(HWND hTree)
+{
+    TreeState* ts = GetTree(hTree);
+    if (!ts || !ts->pNscTree || !IsWindow(hTree))
+        return;
+
+    INameSpaceTreeControl *pNsc = (INameSpaceTreeControl *)ts->pNscTree;
+    pNsc->AddRef();
+    void *pNscRaw = ts->pNscTree;
+    unsigned long enumFlags = ts->enumFlags;
+
+    IShellItem *pDesktop = nullptr;
+    IShellItem *pThisPC = nullptr;
+    SHCreateItemFromIDList(g_pidlDesktop, IID_IShellItem, (void **)&pDesktop);
+    if (g_pidlThisPC)
+        SHCreateItemFromIDList(g_pidlThisPC, IID_IShellItem, (void **)&pThisPC);
+
+    if (pThisPC) { while (SUCCEEDED(pNsc->RemoveRoot(pThisPC))); }
+    if (pDesktop) { while (SUCCEEDED(pNsc->RemoveRoot(pDesktop))); }
+
+    IShellItem *pHome = nullptr, *pGallery = nullptr;
+    if (g_pidlHome)
+        SHCreateItemFromIDList(g_pidlHome, IID_IShellItem, (void **)&pHome);
+    if (g_pidlGallery)
+        SHCreateItemFromIDList(g_pidlGallery, IID_IShellItem, (void **)&pGallery);
+
+    if (pHome && g_settings.hideHome)
+        pNsc->RemoveRoot(pHome);
+    if (pGallery && g_settings.hideGallery)
+        pNsc->RemoveRoot(pGallery);
+    if (pHome) pHome->Release();
+    if (pGallery) pGallery->Release();
+
+    if (pDesktop)
+    {
+        // Clear ALL item handles: RemoveRoot(pDesktop) destroys the
+        // hidden root and all its children (Home, Gallery, QA items).
+        // All old handles are now invalid.
+        ts = GetTree(hTree);
+        if (ts)
+        {
+            ts->hThisPC = nullptr;
+            ts->hDesktop = nullptr;
+            ts->hHome = nullptr;
+            ts->hGallery = nullptr;
+            ResetTreeCleanup(*ts);
+        }
+
+        g_pNscTree = pNscRaw;
+        g_lastEnumFlags = enumFlags;
+
+        g_inCustomAppend = true;
+        AppendRoot_orig(pNscRaw, pDesktop, enumFlags, 0x1, nullptr);
+        g_inCustomAppend = false;
+
+        // Re-fetch ts: AppendRoot_orig pumps messages, which can
+        // trigger TVM_INSERTITEM and rehash g_trees.
+        ts = GetTree(hTree);
+        if (ts)
+        {
+            ts->needHotInsert = true;
+        }
+        g_sepColor = CLR_INVALID;
+        g_logSepDraw = true;
+
+        InvalidateRect(hTree, nullptr, TRUE);
+        Wh_Log(L"[REBUILD] Deferred insertion for tree=%p hHome=%p hGallery=%p",
+               hTree, ts ? ts->hHome : nullptr, ts ? ts->hGallery : nullptr);
+    }
+
+    pNsc->Release();
+
+    if (pDesktop) pDesktop->Release();
+    if (pThisPC) pThisPC->Release();
+}
+
 void Wh_ModSettingsChanged()
 {
+    // Snapshot ALL settings that affect behavior
+    auto prev = g_settings;
+
     LoadSettings();
+
+    // Classify what changed. Sub-settings only matter when their
+    // parent item is enabled — toggling them while disabled is a no-op.
+    bool itemsChanged =
+        prev.showThisPCAtTop != g_settings.showThisPCAtTop ||
+        prev.showDesktopAtTop != g_settings.showDesktopAtTop;
+
+    // This PC sub-settings only matter when This PC is or was at top
+    if (g_settings.showThisPCAtTop || prev.showThisPCAtTop)
+        itemsChanged = itemsChanged ||
+            prev.thisPCExpandable != g_settings.thisPCExpandable ||
+            prev.thisPCStartExpanded != g_settings.thisPCStartExpanded;
+
+    // Desktop sub-settings only matter when Desktop is or was at top
+    if (g_settings.showDesktopAtTop || prev.showDesktopAtTop)
+        itemsChanged = itemsChanged ||
+            prev.desktopExpandable != g_settings.desktopExpandable;
+
+    // Order only matters when both items are at top
+    if (g_settings.showThisPCAtTop && g_settings.showDesktopAtTop)
+        itemsChanged = itemsChanged ||
+            prev.desktopAboveThisPC != g_settings.desktopAboveThisPC;
+
+    bool homeGalleryChanged =
+        prev.hideHome != g_settings.hideHome ||
+        prev.hideGallery != g_settings.hideGallery;
+
+    // Dedup sub-settings only matter when their item is at top
+    bool dedupChanged =
+        (g_settings.showThisPCAtTop &&
+         prev.hideThisPCFromQuickAccess != g_settings.hideThisPCFromQuickAccess) ||
+        (g_settings.showDesktopAtTop &&
+         prev.hideDesktopFromQuickAccess != g_settings.hideDesktopFromQuickAccess);
+
+    bool sepChanged =
+        prev.removeSepBelowNav != g_settings.removeSepBelowNav ||
+        prev.removeSepBelowQA != g_settings.removeSepBelowQA;
+
+    bool visualOnly =
+        prev.fixChevronDrawing != g_settings.fixChevronDrawing ||
+        prev.chevronScale != g_settings.chevronScale ||
+        prev.hidePinButtons != g_settings.hidePinButtons;
+
+    // Full rebuild for transitions where RefreshNavPane can't restore
+    // deleted/modified items: hidden root children (Home/Gallery),
+    // deleted QA duplicates, collapsed iIntegral items.
+    bool needRebuild =
+        (prev.hideHome && !g_settings.hideHome) ||
+        (prev.hideGallery && !g_settings.hideGallery) ||
+        (prev.removeSepBelowNav != g_settings.removeSepBelowNav) ||
+        (prev.removeSepBelowQA && !g_settings.removeSepBelowQA) ||
+        // Dedup toggles in either direction need rebuild when parent is
+        // enabled: on→off deletes dups that can't be restored; off→on
+        // needs dups discovered and potentially kept as hiddenDuplicate.
+        (g_settings.showThisPCAtTop &&
+         prev.hideThisPCFromQuickAccess != g_settings.hideThisPCFromQuickAccess) ||
+        (g_settings.showDesktopAtTop &&
+         prev.hideDesktopFromQuickAccess != g_settings.hideDesktopFromQuickAccess) ||
+        // Parent going off while hideFromQA was on: QA dups were deleted
+        // and can't be restored without rebuild.
+        (prev.showThisPCAtTop && !g_settings.showThisPCAtTop &&
+         prev.hideThisPCFromQuickAccess) ||
+        (prev.showDesktopAtTop && !g_settings.showDesktopAtTop &&
+         prev.hideDesktopFromQuickAccess);
+
+    // Nothing that affects the tree changed — just repaint
+    bool needRefresh = itemsChanged || needRebuild;
+    bool needRepaint = homeGalleryChanged || dedupChanged || sepChanged || visualOnly;
+
+    if (!needRefresh && !needRepaint)
+        return;
+
+    // Snapshot HWNDs: FullRebuildTree pumps messages, which can trigger
+    // TVM_INSERTITEM on other trees, calling g_trees[hWnd] (operator[])
+    // and invalidating iterators if we're mid-range-for.
+    std::vector<HWND> treeList;
+    treeList.reserve(g_trees.size());
+    for (auto& [hTree, ts] : g_trees)
+        treeList.push_back(hTree);
+    int treeCount = (int)treeList.size();
+
+    if (sepChanged)
+    {
+        g_sepColor = CLR_INVALID;
+        g_logSepDraw = true;
+    }
+
+    for (int i = 0; i < treeCount; i++)
+    {
+        HWND hTree = treeList[i];
+        TreeState* ts = GetTree(hTree);
+        if (!ts || !IsWindow(hTree) || !ts->pNscTree)
+            continue;
+
+        if (needRebuild)
+        {
+            g_deferredOpInProgress = true;
+            FullRebuildTree(hTree);
+            DrainPendingRebuilds();
+        }
+        else if (itemsChanged)
+        {
+            ts->boundaryItem = nullptr;
+            ts->belowQAItem = nullptr;
+            ts->qaCleanupDone = false;
+            RefreshNavPane(hTree);
+        }
+        else
+        {
+            if (homeGalleryChanged)
+                ts->homeGalleryCleanupDone = false;
+            if (dedupChanged)
+                ts->qaCleanupDone = false;
+            if (sepChanged || dedupChanged)
+            {
+                ts->boundaryItem = nullptr;
+                ts->belowQAItem = nullptr;
+            }
+
+            InvalidateRect(hTree, nullptr, TRUE);
+        }
+    }
 }
 
 void Wh_ModUninit()
 {
-    if (g_gdipToken)
+    // Clear state so hooks become no-ops
+    g_settings = {};
+    g_sepColor = CLR_INVALID;
+
+    // Snapshot HWNDs: AppendRoot_orig pumps messages, which could
+    // trigger TVM_INSERTITEM and modify g_trees during iteration.
+    std::vector<HWND> uninitList;
+    uninitList.reserve(g_trees.size());
+    for (auto& [hTree, ts] : g_trees)
+        uninitList.push_back(hTree);
+
+    for (int i = 0; i < (int)uninitList.size(); i++)
     {
-        Gdiplus::GdiplusShutdown(g_gdipToken);
-        g_gdipToken = 0;
+        HWND hTree = uninitList[i];
+        TreeState* ts = GetTree(hTree);
+        if (!ts || !IsWindow(hTree))
+            continue;
+
+        if (!ts->pNscTree)
+            continue;
+
+        INameSpaceTreeControl *pNsc = (INameSpaceTreeControl *)ts->pNscTree;
+        pNsc->AddRef();
+        void *pNscRaw = ts->pNscTree;
+        unsigned long enumFlags = ts->enumFlags;
+        IShellItemFilter *pFilter = ts->pFilter;
+        if (pFilter)
+            pFilter->AddRef();
+        HIMAGELIST savedImgList = ts->savedStateImageList;
+        bool ownsRef = ts->ownsNscRef;
+
+        IShellItem *pDesktop = nullptr;
+        IShellItem *pThisPC = nullptr;
+        SHCreateItemFromIDList(g_pidlDesktop, IID_IShellItem, (void **)&pDesktop);
+        if (g_pidlThisPC)
+            SHCreateItemFromIDList(g_pidlThisPC, IID_IShellItem, (void **)&pThisPC);
+
+        if (pThisPC) { while (SUCCEEDED(pNsc->RemoveRoot(pThisPC))); }
+        if (pDesktop) { while (SUCCEEDED(pNsc->RemoveRoot(pDesktop))); }
+
+        if (pDesktop && pNscRaw)
+        {
+            g_inCustomAppend = true;
+            AppendRoot_orig(pNscRaw, pDesktop, enumFlags, 0x1, pFilter);
+            g_inCustomAppend = false;
+
+            // Collapse any expanded items matching our items so they
+            // don't stay expanded in the restored native nav pane.
+            WCHAR collapseNames[2][64] = {};
+            int collapseCount = 0;
+            if (g_pidlThisPC)
+            {
+                GetPidlDisplayName(g_pidlThisPC, collapseNames[collapseCount], 64);
+                if (collapseNames[collapseCount][0]) collapseCount++;
+            }
+            if (g_pidlDesktop && collapseCount < 2)
+            {
+                GetPidlDisplayName(g_pidlDesktop, collapseNames[collapseCount], 64);
+                if (collapseNames[collapseCount][0]) collapseCount++;
+            }
+            if (collapseCount > 0)
+            {
+                HTREEITEM h = GetFirstDepth1Child(hTree);
+                while (h)
+                {
+                    WCHAR text[64] = {};
+                    TVITEMEXW tvi = {};
+                    tvi.mask = TVIF_HANDLE | TVIF_TEXT | TVIF_STATE;
+                    tvi.stateMask = TVIS_EXPANDED;
+                    tvi.hItem = h;
+                    tvi.pszText = text;
+                    tvi.cchTextMax = 64;
+                    SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
+                    if ((tvi.state & TVIS_EXPANDED) && text[0])
+                    {
+                        for (int j = 0; j < collapseCount; j++)
+                        {
+                            if (wcscmp(text, collapseNames[j]) == 0)
+                            {
+                                SendMessageW(hTree, TVM_EXPAND, TVE_COLLAPSE, (LPARAM)h);
+                                Wh_Log(L"[DISABLE] Collapsed '%s' in tree=%p", text, hTree);
+                                break;
+                            }
+                        }
+                    }
+                    h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_NEXT, (LPARAM)h);
+                }
+            }
+        }
+
+        if (pDesktop) pDesktop->Release();
+        if (pThisPC) pThisPC->Release();
+
+        RemoveWindowSubclass(hTree, TreeInteractionProc, 0xAF01);
+
+        if (savedImgList)
+        {
+            SendMessageW(hTree, TVM_SETIMAGELIST, TVSIL_STATE, (LPARAM)savedImgList);
+            Wh_Log(L"[DISABLE] Restored state image list %p for tree=%p", savedImgList, hTree);
+        }
+
+        // Re-fetch ts after message pumping
+        ts = GetTree(hTree);
+        if (ts)
+        {
+            if (ownsRef)
+                ts->ownsNscRef = false;
+            ts->pNscTree = nullptr;
+            ts->pFilter = nullptr;
+        }
+
+        // Release local refs (safe even if WM_NCDESTROY already released
+        // the TreeState's refs — our AddRef keeps the objects alive)
+        if (pFilter)
+            pFilter->Release();
+        if (ownsRef)
+            pNsc->Release();
+        pNsc->Release();
+
+        RedrawWindow(hTree, nullptr, nullptr,
+                     RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+
+        Wh_Log(L"[DISABLE] Cleaned up tree=%p", hTree);
     }
-    if (g_pidlThisPC)
-    {
-        CoTaskMemFree(g_pidlThisPC);
-        g_pidlThisPC = nullptr;
-    }
-    if (g_pidlDesktop)
-    {
-        CoTaskMemFree(g_pidlDesktop);
-        g_pidlDesktop = nullptr;
-    }
+
+    // Remove all parent subclasses
     for (HWND parent : g_subclassedParents)
     {
         if (IsWindow(parent))
             WindhawkUtils::RemoveWindowSubclassFromAnyThread(parent, SepParentSubclassProc);
     }
     g_subclassedParents.clear();
-    g_hCachedThisPC = nullptr;
-    g_hCachedDesktop = nullptr;
-    g_hCachedTree = nullptr;
-    g_hiddenDuplicate = nullptr;
+    // WM_NCDESTROY and the per-tree loop above null pFilter/pNscTree,
+    // but trees that were never processed (e.g., !IsWindow) may remain.
+    for (auto& [h, ts] : g_trees)
+    {
+        if (ts.pFilter)
+        {
+            ts.pFilter->Release();
+            ts.pFilter = nullptr;
+        }
+    }
+    g_trees.clear();
+    g_pendingRebuildTrees.clear();
+
+    // Clean up global resources
+    if (g_gdipToken) { Gdiplus::GdiplusShutdown(g_gdipToken); g_gdipToken = 0; }
+    if (g_pidlThisPC) { CoTaskMemFree(g_pidlThisPC); g_pidlThisPC = nullptr; }
+    if (g_pidlDesktop) { CoTaskMemFree(g_pidlDesktop); g_pidlDesktop = nullptr; }
+    if (g_pidlHome) { CoTaskMemFree(g_pidlHome); g_pidlHome = nullptr; }
+    if (g_pidlGallery) { CoTaskMemFree(g_pidlGallery); g_pidlGallery = nullptr; }
+    g_pNscTree = nullptr;
+    g_lastEnumFlags = 0;
+    if (g_pLastFilter) { g_pLastFilter->Release(); g_pLastFilter = nullptr; }
     Wh_Log(L"Mod uninitialized");
 }

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.6
+// @version         1.1.7
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -2080,6 +2080,61 @@ struct DiscoveredTree {
     unsigned long enumFlags;
 };
 
+static void DiscoverTreeFromBrowser(HWND hTop, const WCHAR *cls,
+                                    IShellBrowser *pSB,
+                                    std::vector<DiscoveredTree> &out)
+{
+    IServiceProvider *pSP = nullptr;
+    if (FAILED(pSB->QueryInterface(IID_IServiceProvider, (void **)&pSP)))
+    {
+        Wh_Log(L"[DISCOVER] %s hwnd=%p — no IServiceProvider", cls, hTop);
+        return;
+    }
+
+    INameSpaceTreeControl *pNsc = nullptr;
+    HRESULT hr = pSP->QueryService(IID_INameSpaceTreeControl, IID_INameSpaceTreeControl, (void **)&pNsc);
+    pSP->Release();
+    if (FAILED(hr))
+    {
+        Wh_Log(L"[DISCOVER] %s hwnd=%p — no INameSpaceTreeControl (hr=0x%08X)", cls, hTop, hr);
+        return;
+    }
+
+    HWND hTree = nullptr;
+    IOleWindow *pOleWin = nullptr;
+    if (SUCCEEDED(pNsc->QueryInterface(IID_IOleWindow, (void **)&pOleWin)))
+    {
+        HWND hNscWnd = nullptr;
+        if (SUCCEEDED(pOleWin->GetWindow(&hNscWnd)) && hNscWnd)
+            hTree = FindWindowExW(hNscWnd, nullptr, L"SysTreeView32", nullptr);
+        pOleWin->Release();
+    }
+
+    if (!hTree)
+    {
+        Wh_Log(L"[DISCOVER] %s hwnd=%p — no SysTreeView32", cls, hTop);
+        pNsc->Release();
+        return;
+    }
+
+    // The active tab can resolve through more than one host; don't seed twice.
+    for (auto &d : out)
+    {
+        if (d.hTree == hTree)
+        {
+            pNsc->Release();
+            return;
+        }
+    }
+
+    unsigned long enumFlags = (unsigned long)(ULONG_PTR)GetPropW(hTree, L"WH_EnumFlags");
+    if (!enumFlags)
+        enumFlags = SHCONTF_FOLDERS;
+
+    Wh_Log(L"[DISCOVER] %s hwnd=%p tree=%p pNsc=%p — accepted", cls, hTop, hTree, pNsc);
+    out.push_back({ hTop, hTree, pNsc, enumFlags });
+}
+
 void Wh_ModAfterInit()
 {
     std::vector<DiscoveredTree> discovered;
@@ -2099,63 +2154,38 @@ void Wh_ModAfterInit()
         if (!isCabinet && !isDialog)
             return TRUE;
 
-        HWND hShellTab = FindWindowExW(hTop, nullptr, L"ShellTabWindowClass", nullptr);
-        IShellBrowser *pSB = nullptr;
-        if (hShellTab)
-            pSB = (IShellBrowser *)SendMessageW(hShellTab, WM_USER + 7, 0, 0);
-        if (!pSB)
-            pSB = (IShellBrowser *)SendMessageW(hTop, WM_USER + 7, 0, 0);
-        if (!pSB)
+        int found = 0;
+        HWND hShellTab = nullptr;
+        while ((hShellTab = FindWindowExW(hTop, hShellTab, L"ShellTabWindowClass", nullptr)) != nullptr)
         {
-            Wh_Log(L"[DISCOVER] %s hwnd=%p — no IShellBrowser", cls, hTop);
-            return TRUE;
+            IShellBrowser *pSB = (IShellBrowser *)SendMessageW(hShellTab, WM_USER + 7, 0, 0);
+            if (pSB)
+            {
+                size_t before = out.size();
+                DiscoverTreeFromBrowser(hTop, cls, pSB, out);
+                found += (int)(out.size() - before);
+            }
         }
 
-        IServiceProvider *pSP = nullptr;
-        if (FAILED(pSB->QueryInterface(IID_IServiceProvider, (void **)&pSP)))
+        if (found == 0)
         {
-            Wh_Log(L"[DISCOVER] %s hwnd=%p — no IServiceProvider", cls, hTop);
-            return TRUE;
+            IShellBrowser *pSB = (IShellBrowser *)SendMessageW(hTop, WM_USER + 7, 0, 0);
+            if (pSB)
+                DiscoverTreeFromBrowser(hTop, cls, pSB, out);
+            else
+                Wh_Log(L"[DISCOVER] %s hwnd=%p — no IShellBrowser", cls, hTop);
         }
-
-        INameSpaceTreeControl *pNsc = nullptr;
-        HRESULT hr = pSP->QueryService(IID_INameSpaceTreeControl, IID_INameSpaceTreeControl, (void **)&pNsc);
-        pSP->Release();
-        if (FAILED(hr))
-        {
-            Wh_Log(L"[DISCOVER] %s hwnd=%p — no INameSpaceTreeControl (hr=0x%08X)", cls, hTop, hr);
-            return TRUE;
-        }
-
-        HWND hTree = nullptr;
-        IOleWindow *pOleWin = nullptr;
-        if (SUCCEEDED(pNsc->QueryInterface(IID_IOleWindow, (void **)&pOleWin)))
-        {
-            HWND hNscWnd = nullptr;
-            if (SUCCEEDED(pOleWin->GetWindow(&hNscWnd)) && hNscWnd)
-                hTree = FindWindowExW(hNscWnd, nullptr, L"SysTreeView32", nullptr);
-            pOleWin->Release();
-        }
-
-        if (!hTree)
-        {
-            Wh_Log(L"[DISCOVER] %s hwnd=%p — no SysTreeView32", cls, hTop);
-            pNsc->Release();
-            return TRUE;
-        }
-
-        unsigned long enumFlags = 0;
-        enumFlags = (unsigned long)(ULONG_PTR)GetPropW(hTree, L"WH_EnumFlags");
-        if (!enumFlags)
-            enumFlags = SHCONTF_FOLDERS;
-
-        Wh_Log(L"[DISCOVER] %s hwnd=%p tree=%p pNsc=%p — accepted", cls, hTop, hTree, pNsc);
-        out.push_back({ hTop, hTree, pNsc, enumFlags });
         return TRUE;
     }, (LPARAM)&discovered);
 
     for (auto& d : discovered)
     {
+        // Release the ref we took; nothing else will.
+        if (!IsWindow(d.hTree))
+        {
+            d.pNsc->Release();
+            continue;
+        }
         TreeState& ts = g_trees[d.hTree];
         ts.pNscTree = (void *)d.pNsc;
         ts.enumFlags = d.enumFlags;

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.3
+// @version         1.1.4
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -216,6 +216,7 @@ enum PendingWork : uint8_t {
     WORK_QA_CLEANUP   = 0x04,
     WORK_HG_CLEANUP   = 0x08,
     WORK_DUP_COLLAPSE = 0x10,
+    WORK_EXPAND       = 0x20,
 };
 
 // Per-tree state: one entry per SysTreeView32 that we've injected items into.
@@ -413,7 +414,7 @@ static void BuildItemOrder(NavItem items[2])
         out.expandable = g_settings.items[id].expandable;
         out.enabled = g_settings.items[id].showAtTop;
         out.id = id;
-        out.style = g_settings.items[id].startExpanded ? 0x2 : 0UL;
+        out.style = 0;
     };
 
     fill(items[0], first);
@@ -444,6 +445,27 @@ static void InsertItems(void *pNsc, const NavItem items[2], unsigned long enumFl
             g_insertingItem = -1;
         }
     }
+}
+
+static void ExpandStartExpandedItems(HWND hTree)
+{
+    TreeState* ts = GetTree(hTree);
+    if (!ts || !ts->pNscTree) return;
+    g_deferredOpInProgress = true;
+    INameSpaceTreeControl *pNsc = (INameSpaceTreeControl *)ts->pNscTree;
+    for (int i = 0; i < NAV_COUNT; i++)
+    {
+        if (!IsInsertableItem(i) || !g_settings.items[i].showAtTop ||
+            !g_settings.items[i].startExpanded || !g_navItems[i].pidl)
+            continue;
+        IShellItem *psi = nullptr;
+        if (SUCCEEDED(SHCreateItemFromIDList(g_navItems[i].pidl, IID_IShellItem, (void **)&psi)) && psi)
+        {
+            pNsc->SetItemState(psi, NSTCIS_EXPANDED, NSTCIS_EXPANDED);
+            psi->Release();
+        }
+    }
+    DrainPendingRebuilds();
 }
 
 HRESULT THISCALL AppendRoot_hook(void *pThis, IShellItem *psiRoot, unsigned long grfEnumFlags, unsigned long grfRootStyle, IShellItemFilter *pFilter)
@@ -576,6 +598,7 @@ static void DrawChevron(HDC hdc, const RECT *r, int partId, int stateId)
 }
 
 static thread_local bool g_inTreePaint = false;
+static thread_local int g_inSubclassProc = 0;
 
 // --- Separator removal ---
 // Strategy: swallowing NM_CUSTOMDRAW CDDS_PREPAINT (by returning
@@ -1197,7 +1220,8 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
         LPNMHDR hdr = (LPNMHDR)lParam;
         if (hdr && hdr->hwndFrom == hTree)
         {
-            if (hdr->code == (UINT)NM_CUSTOMDRAW && !g_deferredOpInProgress)
+            if (hdr->code == (UINT)NM_CUSTOMDRAW && !g_deferredOpInProgress &&
+                g_inSubclassProc == 0)
             {
                 LPNMTVCUSTOMDRAW cd = (LPNMTVCUSTOMDRAW)lParam;
                 DWORD stage = cd->nmcd.dwDrawStage;
@@ -1500,6 +1524,19 @@ SubClassTreeWndProc_t SubClassTreeWndProc_orig;
 
 LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
+    // Re-entrancy guard: if we're already on the stack (g_inSubclassProc > 0)
+    // from WM_PAINT or WM_DEFERRED_REBUILD, any SendMessageW from our code
+    // can deadlock via global CallWndProc hooks (translucent-windows,
+    // AquaSnap) that make cross-process kernel transitions. Pass through
+    // for re-entered messages. Safe exceptions: TVM_INSERTITEM (caches
+    // handles, sends nothing out), WM_NCDESTROY (cleanup, no sends).
+    if (g_inSubclassProc > 0 &&
+        uMsg != TVM_INSERTITEMW && uMsg != TVM_INSERTITEMA &&
+        uMsg != WM_NCDESTROY)
+    {
+        return SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData);
+    }
+
     if (uMsg == TVM_INSERTITEMW || uMsg == TVM_INSERTITEMA)
     {
         bool isOurInsert = (g_insertingItem >= 0 && g_insertingItem < NAV_COUNT) &&
@@ -1528,7 +1565,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 if (IsInsertableItem(id))
                 {
                     ts.hiddenDuplicate = nullptr;
-                    ts.pendingWork |= WORK_QA_CLEANUP;
+                    ts.pendingWork |= WORK_QA_CLEANUP | WORK_EXPAND;
                     if (!ts.pNscTree)
                     {
                         ts.pNscTree = g_pNscTree;
@@ -1737,6 +1774,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             return 0;
         }
 
+        g_inSubclassProc++;
+
         TreeState* ts = GetTree(hWnd);
         ts = RunDeferredWork(hWnd, ts, WORK_FULL_REBUILD, FullRebuildTree);
         ts = RunDeferredWork(hWnd, ts, WORK_HOT_INSERT, HotEnableInsert);
@@ -1760,24 +1799,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             if (RemoveHiddenInheritedItems(hWnd, *ts))
                 ts->pendingWork &= ~WORK_HG_CLEANUP;
         }
-        return 0;
-    }
 
-    if (uMsg == WM_PAINT)
-    {
-        TreeState* ts = GetTree(hWnd);
-
-        // Full rebuild and hot-insert deferred from settings change or
-        // missed message. Guarded to prevent re-entrancy (AppendRoot_orig
-        // pumps messages). checkGuard=true so another tree's in-progress
-        // op blocks us.
-        ts = RunDeferredWork(hWnd, ts, WORK_FULL_REBUILD, FullRebuildTree, true);
-        ts = RunDeferredWork(hWnd, ts, WORK_HOT_INSERT, HotEnableInsert, true);
-
-        // TVM_DELETEITEM during paint crashes (TV_SelectItem re-entrancy)
-        if (ts && (ts->pendingWork & (WORK_QA_CLEANUP | WORK_HG_CLEANUP)))
-            PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
-
+        ts = GetTree(hWnd);
         if (ts && (ts->pendingWork & WORK_DUP_COLLAPSE))
         {
             WCHAR collapseText[NAV_COUNT][64] = {};
@@ -1790,6 +1813,28 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             if (collapseCount > 0)
                 CollapseMatchingItems(hWnd, ts, collapseText, collapseCount);
         }
+
+        ts = GetTree(hWnd);
+        if (ts && (ts->pendingWork & WORK_EXPAND))
+        {
+            ts->pendingWork &= ~WORK_EXPAND;
+            ExpandStartExpandedItems(hWnd);
+        }
+
+        g_inSubclassProc--;
+        return 0;
+    }
+
+    if (uMsg == WM_PAINT)
+    {
+        TreeState* ts = GetTree(hWnd);
+
+        // Tree-mutating deferred work (rebuild, insert, delete, collapse)
+        // must NOT run during WM_PAINT. Defer to WM_DEFERRED_REBUILD.
+        constexpr uint8_t DEFER_MASK = WORK_FULL_REBUILD | WORK_HOT_INSERT |
+            WORK_QA_CLEANUP | WORK_HG_CLEANUP | WORK_DUP_COLLAPSE;
+        if (ts && (ts->pendingWork & DEFER_MASK))
+            PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
 
         // Collapse iIntegral on visible inherited items so there's no
         // separator space between our items and them.
@@ -1875,14 +1920,25 @@ using DrawThemeBackground_t = HRESULT (WINAPI *)(HTHEME, HDC, int, int, LPCRECT,
 
 DrawThemeBackground_t DrawThemeBackground_orig;
 
+static thread_local bool g_chevronLogged = false;
+
 HRESULT WINAPI DrawThemeBackground_hook(HTHEME hTheme, HDC hdc, int iPartId, int iStateId, LPCRECT pRect, LPCRECT pClipRect)
 {
-    if (g_inTreePaint && (iPartId == TVP_GLYPH || iPartId == TVP_HOTGLYPH))
+    if (iPartId == TVP_GLYPH || iPartId == TVP_HOTGLYPH)
     {
-        RECT drawRect;
-        CalcGlyphRect(pRect, &drawRect);
-        DrawChevron(hdc, &drawRect, iPartId, iStateId);
-        return S_OK;
+        if (!g_chevronLogged)
+        {
+            g_chevronLogged = true;
+            Wh_Log(L"[CHEVRON] DTB hook active, inPaint=%d fixEnabled=%d",
+                (int)g_inTreePaint, (int)g_settings.fixChevronDrawing);
+        }
+        if (g_inTreePaint)
+        {
+            RECT drawRect;
+            CalcGlyphRect(pRect, &drawRect);
+            DrawChevron(hdc, &drawRect, iPartId, iStateId);
+            return S_OK;
+        }
     }
     return DrawThemeBackground_orig(hTheme, hdc, iPartId, iStateId, pRect, pClipRect);
 }
@@ -2051,8 +2107,15 @@ BOOL Wh_ModInit()
     {
         FARPROC pDTB = GetProcAddress(hUxTheme, "DrawThemeBackground");
         if (pDTB)
+        {
             Wh_SetFunctionHook((void *)pDTB, (void *)DrawThemeBackground_hook, (void **)&DrawThemeBackground_orig);
+            Wh_Log(L"[CHEVRON] DTB hook installed at %p, orig=%p", pDTB, DrawThemeBackground_orig);
+        }
+        else
+            Wh_Log(L"[CHEVRON] GetProcAddress(DrawThemeBackground) failed");
     }
+    else
+        Wh_Log(L"[CHEVRON] uxtheme.dll not loaded");
 
     Wh_Log(L"Mod initialized successfully");
     return TRUE;

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.18
+// @version         1.1.19
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -103,6 +103,7 @@ Before/after:
 #include <windowsx.h>
 #include <uxtheme.h>
 #include <gdiplus.h>
+#include <atomic>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -326,6 +327,10 @@ struct InsertionCtx {
     HWND forTree = nullptr; // scopes item to a specific tree; null = any
 };
 static InsertionCtx g_ins;
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t LoadLibraryExW_orig;
+static std::atomic<bool> g_explorerFrameLoaded{false};
 
 // Guards are static (not thread_local) because Wh_ModInit runs on the loader thread but hooks fire on the UI thread.
 static bool g_deferredOpInProgress = false;
@@ -903,7 +908,7 @@ static void HotEnableInsert(HWND hWnd)
 
 static LRESULT CALLBACK TreeInteractionProc(
     HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
-    UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
+    DWORD_PTR dwRefData)
 {
     TreeState* ts = GetTree(hWnd);
     HTREEITEM hiddenDup = ts ? GetHiddenItem(*ts) : nullptr;
@@ -920,9 +925,6 @@ static LRESULT CALLBACK TreeInteractionProc(
         if (hHit == hiddenDup)
             return 0;
     }
-
-    if (uMsg == WM_NCDESTROY)
-        RemoveWindowSubclass(hWnd, TreeInteractionProc, uIdSubclass);
 
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
@@ -989,7 +991,7 @@ static void RestoreTree(HWND hTree)
     if (pFilterRaw)
         pFilterRaw->Release();
 
-    RemoveWindowSubclass(hTree, TreeInteractionProc, 0xAF01);
+    WindhawkUtils::RemoveWindowSubclassFromAnyThread(hTree, TreeInteractionProc);
 
     // Restore pin icons
     if (savedImgList)
@@ -1004,6 +1006,9 @@ static void RestoreTree(HWND hTree)
             ts->ownsNscRef = false;
         ts->pNscTree = nullptr;
     }
+
+    RemovePropW(hTree, L"WH_NscTree");
+    RemovePropW(hTree, L"WH_EnumFlags");
 
     if (ownsRef)
         ((INameSpaceTreeControl *)pNscRaw)->Release();
@@ -1908,7 +1913,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             EnsureParentSubclass(hWnd);
 
         if (ts && GetHiddenItem(*ts))
-            SetWindowSubclass(hWnd, TreeInteractionProc, 0xAF01, 0);
+            WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, TreeInteractionProc, 0);
 
         g_lastSepY = -1;
         g_firstSepY = -1;
@@ -1965,7 +1970,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
 
     if (uMsg == WM_NCDESTROY)
     {
-        RemoveWindowSubclass(hWnd, TreeInteractionProc, 0xAF01);
+        RemovePropW(hWnd, L"WH_NscTree");
+        RemovePropW(hWnd, L"WH_EnumFlags");
         auto it = g_trees.find(hWnd);
         if (it != g_trees.end())
         {
@@ -2082,12 +2088,8 @@ void LoadSettings()
             g_settings.removeSepBelowNav, g_settings.removeSepBelowQA);
 }
 
-BOOL Wh_ModInit()
+static bool InitializeModCore(HMODULE hExplorerFrame)
 {
-    HMODULE hExplorerFrame = GetModuleHandleW(L"ExplorerFrame.dll");
-    if (!hExplorerFrame)
-        return FALSE;
-
     LoadSettings();
 
     auto cleanupOnFail = []() {
@@ -2107,7 +2109,7 @@ BOOL Wh_ModInit()
     {
         Wh_Log(L"Failed to get This PC PIDL");
         cleanupOnFail();
-        return FALSE;
+        return false;
     }
 
     SHGetSpecialFolderLocation(nullptr, CSIDL_DESKTOP, &g_navItems[NAV_DESKTOP].pidl);
@@ -2159,16 +2161,16 @@ BOOL Wh_ModInit()
     {
         Wh_Log(L"Failed to hook symbols");
         cleanupOnFail();
-        return FALSE;
+        return false;
     }
 
     HMODULE hUxTheme = GetModuleHandleW(L"uxtheme.dll");
     if (hUxTheme)
     {
-        FARPROC pDTB = GetProcAddress(hUxTheme, "DrawThemeBackground");
+        auto pDTB = (DrawThemeBackground_t)GetProcAddress(hUxTheme, "DrawThemeBackground");
         if (pDTB)
         {
-            Wh_SetFunctionHook((void *)pDTB, (void *)DrawThemeBackground_hook, (void **)&DrawThemeBackground_orig);
+            WindhawkUtils::SetFunctionHook(pDTB, DrawThemeBackground_hook, &DrawThemeBackground_orig);
             Wh_Log(L"[CHEVRON] at=%04X orig=%04X", PTR4(pDTB), PTR4(DrawThemeBackground_orig));
         }
         else
@@ -2178,7 +2180,47 @@ BOOL Wh_ModInit()
         Wh_Log(L"[CHEVRON] uxtheme.dll not loaded");
 
     Wh_Log(L"Mod initialized, hasItemsAtTop=%d", (int)g_settings.hasItemsAtTop);
-    return TRUE;
+    return true;
+}
+
+void Wh_ModAfterInit();
+
+static HMODULE WINAPI LoadLibraryExW_hook(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
+{
+    HMODULE hModule = LoadLibraryExW_orig(lpLibFileName, hFile, dwFlags);
+    if (hModule && lpLibFileName && !(dwFlags & LOAD_LIBRARY_AS_DATAFILE) &&
+        !g_explorerFrameLoaded.load(std::memory_order_relaxed))
+    {
+        LPCWSTR name = wcsrchr(lpLibFileName, L'\\');
+        name = name ? name + 1 : lpLibFileName;
+        if (_wcsicmp(name, L"ExplorerFrame.dll") == 0 &&
+            !g_explorerFrameLoaded.exchange(true, std::memory_order_acq_rel))
+        {
+            Wh_Log(L"ExplorerFrame.dll loaded late, installing hooks");
+            if (!InitializeModCore(hModule))
+            {
+                Wh_Log(L"Late-load InitializeModCore failed");
+                g_explorerFrameLoaded.store(false, std::memory_order_release);
+                return hModule;
+            }
+            Wh_Log(L"Late-load hooks installed, running discovery");
+            Wh_ModAfterInit();
+        }
+    }
+    return hModule;
+}
+
+BOOL Wh_ModInit()
+{
+    HMODULE hExplorerFrame = GetModuleHandleW(L"ExplorerFrame.dll");
+    if (!hExplorerFrame)
+    {
+        // Wh_Log(L"ExplorerFrame.dll not loaded, hooking LoadLibraryExW for late detection");
+        Wh_SetFunctionHook((void *)LoadLibraryExW, (void *)LoadLibraryExW_hook, (void **)&LoadLibraryExW_orig);
+        return TRUE;
+    }
+    g_explorerFrameLoaded.store(true, std::memory_order_relaxed);
+    return InitializeModCore(hExplorerFrame) ? TRUE : FALSE;
 }
 
 struct DiscoveredTree {
@@ -2495,13 +2537,19 @@ void Wh_ModUninit()
     }
     g_subclassedParents.clear();
 
-    // Release straggler filters from trees never processed
+    // Release straggler refs from trees that RestoreTree didn't fully process
     for (auto& [h, ts] : g_trees)
     {
         if (ts.pFilter)
         {
             ts.pFilter->Release();
             ts.pFilter = nullptr;
+        }
+        if (ts.ownsNscRef && ts.pNscTree)
+        {
+            ((INameSpaceTreeControl *)ts.pNscTree)->Release();
+            ts.pNscTree = nullptr;
+            ts.ownsNscRef = false;
         }
     }
     g_trees.clear();

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.14
+// @version         1.1.15
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -470,6 +470,18 @@ static void ExpandStartExpandedItems(HWND hTree)
 
 HRESULT THISCALL AppendRoot_hook(void *pThis, IShellItem *psiRoot, unsigned long grfEnumFlags, unsigned long grfRootStyle, IShellItemFilter *pFilter)
 {
+    HWND hForTree = nullptr;
+    {
+        IOleWindow* pOle = nullptr;
+        if (SUCCEEDED(((INameSpaceTreeControl*)pThis)->QueryInterface(IID_IOleWindow, (void**)&pOle)))
+        {
+            HWND hNsc = nullptr;
+            if (SUCCEEDED(pOle->GetWindow(&hNsc)) && hNsc)
+                hForTree = FindWindowExW(hNsc, nullptr, L"SysTreeView32", nullptr);
+            pOle->Release();
+        }
+    }
+
     // Must run before g_inCustomAppend check so Home/Gallery get cached.
     {
         PIDLIST_ABSOLUTE pidlRoot = nullptr;
@@ -491,9 +503,11 @@ HRESULT THISCALL AppendRoot_hook(void *pThis, IShellItem *psiRoot, unsigned long
                     Wh_Log(L"[HOOK] Suppressing '%s' root", g_navItems[matchId].label);
                     return S_OK;
                 }
+                g_ins.forTree = hForTree;
                 g_ins.item = matchId;
                 HRESULT hr = AppendRoot_orig(pThis, psiRoot, grfEnumFlags, grfRootStyle, pFilter);
                 g_ins.item = -1;
+                g_ins.forTree = nullptr;
                 return hr;
             }
         }
@@ -518,6 +532,7 @@ HRESULT THISCALL AppendRoot_hook(void *pThis, IShellItem *psiRoot, unsigned long
             if (g_ins.filter) g_ins.filter->AddRef();
         }
 
+        g_ins.forTree = hForTree;
         g_inCustomAppend = true;
 
         NavItem items[2];
@@ -525,6 +540,7 @@ HRESULT THISCALL AppendRoot_hook(void *pThis, IShellItem *psiRoot, unsigned long
         InsertItems(pThis, items, grfEnumFlags, pFilter);
 
         g_inCustomAppend = false;
+        g_ins.forTree = nullptr;
     }
 
     return hr;
@@ -640,6 +656,7 @@ static bool CollapseItemIntegral(HWND hTree, HTREEITEM h)
     SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
     if (tvi.iIntegral >= 2)
     {
+        Wh_Log(L"[COLLAPSE] tree=%p item=%p int=%d->1", hTree, h, tvi.iIntegral);
         tvi.iIntegral = 1;
         SendMessageW(hTree, TVM_SETITEMW, 0, (LPARAM)&tvi);
         return true;
@@ -996,9 +1013,9 @@ static void FullRebuildTree(HWND hTree)
     if (!roots.Create()) return;
     roots.RemoveInsertableRoots(pNsc.get());
 
-    if (roots.items[NAV_HOME] && g_settings.items[NAV_HOME].hide)
+    if (roots.items[NAV_HOME])
         pNsc->RemoveRoot(roots.items[NAV_HOME].get());
-    if (roots.items[NAV_GALLERY] && g_settings.items[NAV_GALLERY].hide)
+    if (roots.items[NAV_GALLERY])
         pNsc->RemoveRoot(roots.items[NAV_GALLERY].get());
 
     if (roots.items[NAV_DESKTOP])
@@ -1237,7 +1254,7 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
     bool foundBelowQA = false;
     int sepCount = 0;
 
-    // Walk log tags: O=ours, H=home, G=gallery, B/b=boundary, Q=belowQA, S=sep, .=other
+    // Walk log tags: O=ours, H=home, G=gallery, P=spacer, B/b=boundary, Q=belowQA, S=sep, .=other
     WCHAR walkLog[64] = {};
     int walkIdx = 0;
 
@@ -1256,7 +1273,8 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
                 if (g_logSepDraw && walkIdx < 60)
                 {
                     WCHAR tag = L'O';
-                    if (ts.hItems[NAV_HOME] && h == ts.hItems[NAV_HOME]) tag = L'H';
+                    if (ts.homeSpacerItem && h == ts.homeSpacerItem) tag = L'P';
+                    else if (ts.hItems[NAV_HOME] && h == ts.hItems[NAV_HOME]) tag = L'H';
                     else if (ts.hItems[NAV_GALLERY] && h == ts.hItems[NAV_GALLERY]) tag = L'G';
                     walkLog[walkIdx++] = tag;
                 }
@@ -1681,7 +1699,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                     for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
                         if (ts->hItems[i]) { hasOurItems = true; break; }
 
-                    if (hasOurItems && !AreWeMutating() && !g_inTreePaint)
+                    if (hasOurItems && !AreWeMutating() && !g_inTreePaint &&
+                        !(ts->pendingWork & WORK_FULL_REBUILD))
                     {
                         ts->pendingWork |= WORK_FULL_REBUILD;
                         PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
@@ -1850,11 +1869,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         if (ts && (ts->pendingWork & DEFER_MASK))
             PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
 
-        // Skip paint-time mutations when another tree is being rebuilt; items may be stale from cross-tree side effects.
-        bool safeForMutations = !(g_deferredOpInProgress && hWnd != g_mutatingTree);
-
         // Paint-time mutations must be idempotent (no-op when already in target state) to avoid relayout loops.
-        if (safeForMutations && ts && g_settings.hasItemsAtTop)
+        if (ts && g_settings.hasItemsAtTop)
         {
             for (int i = NAV_HOME; i < NAV_COUNT; i++)
             {
@@ -1862,7 +1878,6 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 if (!g_settings.items[i].hide)
                     CollapseItemIntegral(hWnd, ts->hItems[i]);
             }
-            // TVM_SETITEMW's rect check can fail before layout; catch it here.
             if (ShouldRemoveInternalSep() && ts->hItems[NAV_THISPC] && ts->hItems[NAV_DESKTOP])
             {
                 RECT rcA = {}, rcB = {};
@@ -1875,13 +1890,13 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             }
         }
 
-        if (safeForMutations && g_settings.hasItemsAtTop && g_sepColor != CLR_INVALID && ts)
+        SectionLayout layout = {};
+        if (g_settings.hasItemsAtTop && ts)
         {
-            SectionLayout layout = FindSectionLayout(hWnd, *ts);
+            layout = FindSectionLayout(hWnd, *ts);
             ts->boundaryItem = layout.boundary;
             ts->belowQAItem = nullptr;
 
-            // Desktop is the bottom item of our section when alone or below This PC.
             bool desktopAtBottom = ts->hItems[NAV_DESKTOP] &&
                 (!ts->hItems[NAV_THISPC] || !g_settings.desktopAboveThisPC);
             if (!ts->triedHomeSpacer && layout.boundary && desktopAtBottom
@@ -1892,14 +1907,6 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
             }
 
-            if (layout.boundary && (g_settings.removeSepBelowNav || GetHiddenItem(*ts)))
-                CollapseItemIntegral(hWnd, layout.boundary);
-            if (g_settings.removeSepBelowQA && layout.belowQA)
-            {
-                CollapseItemIntegral(hWnd, layout.belowQA);
-                ts->belowQAItem = layout.belowQA;
-            }
-
             if (g_logSepDraw)
                 Wh_Log(L"[SEP-GAP] tree=%p boundary=%p int=%d home=%d gallery=%d rmNav=%d hidDup=%p spacer=%p tried=%d",
                        hWnd, layout.boundary,
@@ -1907,6 +1914,17 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                        layout.homePresent, layout.galleryPresent,
                        (int)g_settings.removeSepBelowNav, ts->hiddenDuplicate, ts->homeSpacerItem,
                        (int)ts->triedHomeSpacer);
+        }
+
+        if (g_settings.hasItemsAtTop && g_sepColor != CLR_INVALID && ts)
+        {
+            if (layout.boundary && (g_settings.removeSepBelowNav || GetHiddenItem(*ts)))
+                CollapseItemIntegral(hWnd, layout.boundary);
+            if (g_settings.removeSepBelowQA && layout.belowQA)
+            {
+                CollapseItemIntegral(hWnd, layout.belowQA);
+                ts->belowQAItem = layout.belowQA;
+            }
         }
 
         if (g_settings.hidePinButtons && ts)
@@ -1933,6 +1951,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
 
         g_inTreePaint = false;
 
+        ts = GetTree(hWnd);
         if (g_lastSepY >= 0 && g_sepColor != CLR_INVALID && g_sepRetries < 3)
         {
             HDC hdc = GetDC(hWnd);
@@ -1946,14 +1965,23 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 if (pixel != CLR_INVALID && pixel != g_sepColor)
                 {
                     g_sepRetries++;
-                    Wh_Log(L"[SEP-VERIFY] separator redrawn at (%d,%d): "
+                    Wh_Log(L"[SEP-VERIFY] tree=%p at (%d,%d): "
                            L"expected=0x%06X got=0x%06X, retry %d",
-                           sampleX, g_lastSepY, g_sepColor, pixel, g_sepRetries);
+                           hWnd, sampleX, g_lastSepY, g_sepColor, pixel, g_sepRetries);
                     InvalidateRect(hWnd, nullptr, FALSE);
                 }
                 else
                     g_sepRetries = 0;
             }
+        }
+        else if (g_lastSepY == -1 && g_sepColor != CLR_INVALID && g_sepRetries < 3
+                 && ts && !ts->pendingWork && HasOurItemsInTree(*ts) && ts->boundaryItem
+                 && !g_settings.removeSepBelowNav && !GetHiddenItem(*ts))
+        {
+            g_sepRetries++;
+            Wh_Log(L"[SEP-VERIFY] tree=%p boundary=%p: expected separator but none drawn, retry %d",
+                   hWnd, ts->boundaryItem, g_sepRetries);
+            InvalidateRect(hWnd, nullptr, FALSE);
         }
 
         return result;
@@ -1992,11 +2020,11 @@ HRESULT WINAPI DrawThemeBackground_hook(HTHEME hTheme, HDC hdc, int iPartId, int
 {
     if (iPartId == TVP_GLYPH || iPartId == TVP_HOTGLYPH)
     {
-        if (!g_chevronLogged)
+        if (!g_chevronLogged && g_inTreePaint)
         {
             g_chevronLogged = true;
-            Wh_Log(L"[CHEVRON] DTB hook active, inPaint=%d fixEnabled=%d",
-                (int)g_inTreePaint, (int)g_settings.fixChevronDrawing);
+            Wh_Log(L"[CHEVRON] DTB hook active, fixEnabled=%d",
+                (int)g_settings.fixChevronDrawing);
         }
         if (g_inTreePaint && g_settings.fixChevronDrawing)
         {
@@ -2173,7 +2201,7 @@ BOOL Wh_ModInit()
     else
         Wh_Log(L"[CHEVRON] uxtheme.dll not loaded");
 
-    Wh_Log(L"Mod initialized successfully");
+    Wh_Log(L"Mod initialized, hasItemsAtTop=%d", (int)g_settings.hasItemsAtTop);
     return TRUE;
 }
 
@@ -2314,10 +2342,8 @@ ChangeTier ClassifySettingsChange(const Settings& prev, const Settings& cur)
         auto& p = prev.items[i];
         auto& c = cur.items[i];
 
-        // hide: hidden->visible needs rebuild (children of hidden root)
         if (p.hide && !c.hide)
             tier = std::max(tier, TIER_REBUILD);
-        // hide: visible->hidden is repaint (WM_PAINT handles removal)
         if (!p.hide && c.hide)
             tier = std::max(tier, TIER_REPAINT);
 
@@ -2347,6 +2373,17 @@ ChangeTier ClassifySettingsChange(const Settings& prev, const Settings& cur)
         if (prev.desktopAboveThisPC != cur.desktopAboveThisPC)
             tier = std::max(tier, TIER_REFRESH);
     }
+
+    // Spacer lifecycle: rebuild when desktopAtBottom changes (spacer collapsed boundary iIntegral)
+    bool prevBottom = prev.items[NAV_DESKTOP].showAtTop &&
+        (!prev.items[NAV_THISPC].showAtTop || !prev.desktopAboveThisPC);
+    bool curBottom = cur.items[NAV_DESKTOP].showAtTop &&
+        (!cur.items[NAV_THISPC].showAtTop || !cur.desktopAboveThisPC);
+    if (prevBottom != curBottom)
+        tier = std::max(tier, TIER_REBUILD);
+
+    if (prev.hasItemsAtTop && !cur.hasItemsAtTop)
+        tier = std::max(tier, TIER_REBUILD);
 
     // Non-item settings
     if (prev.removeSepBelowNav != cur.removeSepBelowNav)
@@ -2437,6 +2474,9 @@ void Wh_ModSettingsChanged()
             InvalidateRect(hTree, nullptr, TRUE);
         }
     }
+
+    if (!prev.hasItemsAtTop && g_settings.hasItemsAtTop)
+        Wh_ModAfterInit();
 }
 
 void Wh_ModUninit()

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.7
+// @version         1.1.8
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -217,6 +217,7 @@ enum PendingWork : uint8_t {
     WORK_HG_CLEANUP   = 0x08,
     WORK_DUP_COLLAPSE = 0x10,
     WORK_EXPAND       = 0x20,
+    WORK_HOME_SPACER  = 0x40,
 };
 
 // Per-tree state: one entry per SysTreeView32 that we've injected items into.
@@ -226,11 +227,13 @@ struct TreeState {
     IShellItemFilter *pFilter = nullptr;
     HTREEITEM hItems[NAV_COUNT] = {};
     HTREEITEM hiddenDuplicate = nullptr;
+    HTREEITEM homeSpacerItem = nullptr;
     HTREEITEM boundaryItem = nullptr;
     HTREEITEM belowQAItem = nullptr;
     uint8_t pendingWork = 0;   // bitmask of PendingWork flags
     bool qaEverCleaned = false;
     bool ownsNscRef = false;
+    bool triedHomeSpacer = false;
     HIMAGELIST savedStateImageList = nullptr;
 };
 static std::unordered_map<HWND, TreeState> g_trees;
@@ -257,8 +260,15 @@ static bool IsNavPaneHost(HWND hTree)
     return false;
 }
 
+static HTREEITEM GetHiddenItem(const TreeState& ts)
+{
+    return ts.hiddenDuplicate ? ts.hiddenDuplicate : ts.homeSpacerItem;
+}
+
 static bool IsOurSection(const TreeState& ts, HTREEITEM h)
 {
+    if (ts.homeSpacerItem && h == ts.homeSpacerItem)
+        return true;
     for (int i = 0; i < NAV_COUNT; i++)
         if (ts.hItems[i] && h == ts.hItems[i])
             return true;
@@ -288,8 +298,10 @@ static void GetPidlDisplayName(PIDLIST_ABSOLUTE pidl, WCHAR *buf, int len)
 static void ResetTreeCleanup(TreeState& ts)
 {
     ts.hiddenDuplicate = nullptr;
+    ts.homeSpacerItem = nullptr;
     ts.boundaryItem = nullptr;
     ts.belowQAItem = nullptr;
+    ts.triedHomeSpacer = false;
     ts.pendingWork = WORK_QA_CLEANUP | WORK_HG_CLEANUP | WORK_DUP_COLLAPSE;
     ts.qaEverCleaned = false;
 }
@@ -315,6 +327,7 @@ static HWND g_insertingForTree = nullptr;
 // corrupted if a second tree's deferred op runs while the first is
 // in progress (AppendRoot_orig pumps messages internally).
 static bool g_deferredOpInProgress = false;
+static HWND g_mutatingTree = nullptr;
 static std::unordered_set<HWND> g_pendingRebuildTrees;
 
 #define WM_DEFERRED_REBUILD  (WM_APP + 0x101)
@@ -322,6 +335,7 @@ static std::unordered_set<HWND> g_pendingRebuildTrees;
 static void DrainPendingRebuilds()
 {
     g_deferredOpInProgress = false;
+    g_mutatingTree = nullptr;
     while (!g_pendingRebuildTrees.empty())
     {
         HWND hNext = *g_pendingRebuildTrees.begin();
@@ -335,15 +349,14 @@ static TreeState* RunDeferredWork(HWND hWnd, TreeState* ts, uint8_t flag, void(*
 {
     if (!ts || !(ts->pendingWork & flag))
         return ts;
-    g_deferredOpInProgress = true;
     ts->pendingWork &= ~flag;
     op(hWnd);
     ts = GetTree(hWnd);
-    DrainPendingRebuilds();
     return ts;
 }
 
 static bool g_inCustomAppend = false;
+static HTREEITEM g_spacerInsertAfter = nullptr;
 
 struct InsertionScope {
     ComRef<INameSpaceTreeControl> pNsc;
@@ -447,7 +460,6 @@ static void ExpandStartExpandedItems(HWND hTree)
 {
     TreeState* ts = GetTree(hTree);
     if (!ts || !ts->pNscTree) return;
-    g_deferredOpInProgress = true;
     INameSpaceTreeControl *pNsc = (INameSpaceTreeControl *)ts->pNscTree;
     for (int i = 0; i < NAV_COUNT; i++)
     {
@@ -461,7 +473,6 @@ static void ExpandStartExpandedItems(HWND hTree)
             psi->Release();
         }
     }
-    DrainPendingRebuilds();
 }
 
 HRESULT THISCALL AppendRoot_hook(void *pThis, IShellItem *psiRoot, unsigned long grfEnumFlags, unsigned long grfRootStyle, IShellItemFilter *pFilter)
@@ -651,6 +662,15 @@ static void SetItemIntegral(HWND hTree, HTREEITEM h, int value)
     SendMessageW(hTree, TVM_SETITEMW, 0, (LPARAM)&tvi);
 }
 
+static int GetItemIntegral(HWND hTree, HTREEITEM h)
+{
+    TVITEMEXW tvi = {};
+    tvi.mask = TVIF_HANDLE | TVIF_INTEGRAL;
+    tvi.hItem = h;
+    SendMessageW(hTree, TVM_GETITEMW, 0, (LPARAM)&tvi);
+    return tvi.iIntegral;
+}
+
 static int GetBaseItemHeight(HWND hTree)
 {
     int baseHeight = 0;
@@ -732,6 +752,7 @@ static void RefreshNavPane(HWND hTree)
         NavItem items[2];
         BuildItemOrder(items);
         g_deferredOpInProgress = true;
+        g_mutatingTree = hTree;
         InsertItems(scope.pNscRaw, items, ts->enumFlags, scope.pFilter.get());
     }
     DrainPendingRebuilds();
@@ -778,7 +799,7 @@ static LRESULT CALLBACK TreeInteractionProc(
     UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
 {
     TreeState* ts = GetTree(hWnd);
-    HTREEITEM hiddenDup = ts ? ts->hiddenDuplicate : nullptr;
+    HTREEITEM hiddenDup = ts ? GetHiddenItem(*ts) : nullptr;
 
     if (hiddenDup &&
         (uMsg == WM_RBUTTONDOWN || uMsg == WM_RBUTTONUP ||
@@ -811,6 +832,23 @@ static void RestoreTree(HWND hTree)
     ComRef<IShellItemFilter> pFilter(ts->pFilter);
     HIMAGELIST savedImgList = ts->savedStateImageList;
     bool ownsRef = ts->ownsNscRef;
+
+    if (ts->homeSpacerItem)
+    {
+        int spacerId = g_navItems[NAV_HOME].pidl ? NAV_HOME
+                     : (g_navItems[NAV_GALLERY].pidl ? NAV_GALLERY : -1);
+        if (spacerId >= 0)
+        {
+            IShellItem* raw = nullptr;
+            if (SUCCEEDED(SHCreateItemFromIDList(g_navItems[spacerId].pidl,
+                                                  IID_IShellItem, (void**)&raw)) && raw)
+            {
+                pNsc->RemoveRoot(raw);
+                raw->Release();
+            }
+        }
+        ts->homeSpacerItem = nullptr;
+    }
 
     // Remove our roots
     RootShellItems roots;
@@ -909,9 +947,67 @@ static void FullRebuildTree(HWND hTree)
     }
 }
 
+// Must use AppendRoot_orig (not raw TVM_INSERTITEM) so the item has namespace backing for Explorer's paint path.
+static void InsertHomeSpacer(HWND hTree)
+{
+    TreeState* ts = GetTree(hTree);
+    if (!ts) return;
+    ts->triedHomeSpacer = true;
+    if (!ts->pNscTree || !ts->hItems[NAV_DESKTOP]) return;
+
+    int spacerId = g_navItems[NAV_HOME].pidl ? NAV_HOME
+                 : (g_navItems[NAV_GALLERY].pidl ? NAV_GALLERY : -1);
+    if (spacerId < 0) return;
+
+    IShellItem* raw = nullptr;
+    if (FAILED(SHCreateItemFromIDList(g_navItems[spacerId].pidl,
+                                      IID_IShellItem, (void**)&raw)) || !raw)
+        return;
+    ComRef<IShellItem> spacer(raw, false);
+
+    void *pNsc = ts->pNscTree;
+    unsigned long enumFlags = ts->enumFlags;
+
+    g_spacerInsertAfter = ts->hItems[NAV_DESKTOP];
+    g_inCustomAppend = true;
+    AppendRoot_orig(pNsc, spacer.get(), enumFlags, 0, nullptr);
+    g_inCustomAppend = false;
+    g_spacerInsertAfter = nullptr;
+
+    ts = GetTree(hTree);
+    if (!ts) return;
+
+    HTREEITEM hSpacer = nullptr;
+    const WCHAR* spacerLabel = g_navItems[spacerId].label;
+    ForEachDepth1Item(hTree, [&](HTREEITEM h) -> bool {
+        if (h == ts->hItems[NAV_DESKTOP] || h == ts->hItems[NAV_THISPC])
+            return true;
+        WCHAR buf[256];
+        GetItemText(hTree, h, buf, 256);
+        if (wcscmp(buf, spacerLabel) == 0) {
+            hSpacer = h;
+            return false;
+        }
+        return true;
+    });
+
+    if (hSpacer)
+    {
+        ts->homeSpacerItem = hSpacer;
+        SetItemIntegral(hTree, hSpacer, 1);
+    }
+
+    Wh_Log(L"[HOME-SPACER] tree=%p %s spacer=%p afterDesktop=%p",
+           hTree, spacerLabel, hSpacer, ts->hItems[NAV_DESKTOP]);
+
+    InvalidateRect(hTree, nullptr, TRUE);
+}
+
 struct SectionLayout {
     HTREEITEM boundary;       // first non-section item after our items
     HTREEITEM belowQA;        // first tall non-section item after boundary
+    bool homePresent;         // a visible Home item exists among depth-1 siblings
+    bool galleryPresent;      // a visible Gallery item exists among depth-1 siblings
 };
 
 static SectionLayout FindSectionLayout(HWND hTree, TreeState& ts)
@@ -955,6 +1051,8 @@ static SectionLayout FindSectionLayout(HWND hTree, TreeState& ts)
                         if (!inheritedHidden[i])
                         {
                             ts.hItems[i] = h;
+                            if (i == NAV_HOME) layout.homePresent = true;
+                            else if (i == NAV_GALLERY) layout.galleryPresent = true;
                             Wh_Log(L"[CACHE] %s item=%p tree=%p (walk)", g_navItems[i].label, h, hTree);
                         }
                         isSection = true;
@@ -967,9 +1065,13 @@ static SectionLayout FindSectionLayout(HWND hTree, TreeState& ts)
 
         if (isSection)
         {
+            if (ts.hItems[NAV_HOME] && h == ts.hItems[NAV_HOME])
+                layout.homePresent = true;
+            else if (ts.hItems[NAV_GALLERY] && h == ts.hItems[NAV_GALLERY])
+                layout.galleryPresent = true;
             passedOurs = true;
         }
-        else if (passedOurs && h != ts.hiddenDuplicate)
+        else if (passedOurs && h != GetHiddenItem(ts))
         {
             if (!layout.boundary)
             {
@@ -1082,9 +1184,14 @@ static COLORREF SampleSeparatorColor(HWND hTree, HDC hdc)
 // At CDDS_POSTPAINT, all separators have been hidden by CDDS_PREPAINT
 // swallowing. Redraw separators for section boundaries we want to keep.
 
+static bool HasOurItemsInTree(const TreeState& ts)
+{
+    return ts.hItems[NAV_THISPC] || ts.hItems[NAV_DESKTOP];
+}
+
 static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
 {
-    if (!hdc || !IsWindow(hTree))
+    if (!hdc || !IsWindow(hTree) || !HasOurItemsInTree(ts))
         return;
 
     RECT client;
@@ -1130,7 +1237,7 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
                     walkLog[walkIdx++] = tag;
                 }
             }
-            else if (ts.hiddenDuplicate && h == ts.hiddenDuplicate)
+            else if (GetHiddenItem(ts) && h == GetHiddenItem(ts))
             {
                 if (g_logSepDraw && walkIdx < 60)
                     walkLog[walkIdx++] = L'D';
@@ -1146,7 +1253,7 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
                 {
                     foundBoundary = true;
                     tag = isTall ? L'B' : L'b';
-                    if (!g_settings.removeSepBelowNav && !ts.hiddenDuplicate)
+                    if (!g_settings.removeSepBelowNav && !GetHiddenItem(ts))
                     {
                         drawSep = true;
                         sepY = isTall ? rc.top + baseHeight / 2 : rc.top;
@@ -1197,8 +1304,7 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
         LPNMHDR hdr = (LPNMHDR)lParam;
         if (hdr && hdr->hwndFrom == hTree)
         {
-            if (hdr->code == (UINT)NM_CUSTOMDRAW && !g_deferredOpInProgress &&
-                g_inSubclassProc == 0)
+            if (hdr->code == (UINT)NM_CUSTOMDRAW && hTree != g_mutatingTree)
             {
                 LPNMTVCUSTOMDRAW cd = (LPNMTVCUSTOMDRAW)lParam;
                 DWORD stage = cd->nmcd.dwDrawStage;
@@ -1242,10 +1348,11 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
                         RedrawOtherSeparators(hTree, cd->nmcd.hdc, *ts);
 
                     ts = GetTree(hTree);
-                    if (ts && ts->hiddenDuplicate)
+                    HTREEITEM hHidden = (ts && HasOurItemsInTree(*ts)) ? GetHiddenItem(*ts) : nullptr;
+                    if (hHidden)
                     {
                         RECT rcHide = {};
-                        *(HTREEITEM*)&rcHide = ts->hiddenDuplicate;
+                        *(HTREEITEM*)&rcHide = hHidden;
                         if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rcHide))
                         {
                             HDC hdc = cd->nmcd.hdc;
@@ -1262,8 +1369,13 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
                             }
                             if (g_sepColor != CLR_INVALID)
                             {
-                                HTREEITEM hPrev = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_PREVIOUS, (LPARAM)ts->hiddenDuplicate);
-                                if (hPrev && IsOurSection(*ts, hPrev))
+                                bool drawSep = (hHidden == ts->homeSpacerItem);
+                                if (!drawSep)
+                                {
+                                    HTREEITEM hPrev = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_PREVIOUS, (LPARAM)hHidden);
+                                    drawSep = hPrev && IsOurSection(*ts, hPrev);
+                                }
+                                if (drawSep)
                                 {
                                     int h = rcHide.bottom - rcHide.top;
                                     DrawSeparatorLine(hdc, hTree, rcHide.top + h / 2);
@@ -1449,7 +1561,7 @@ static bool RemoveHiddenInheritedItems(HWND hTree, TreeState& ts)
     ForEachDepth1Item(hTree, [&](HTREEITEM h) -> bool {
         if (delCount >= targetCount)
             return false;
-        if (!IsOurSection(ts, h) && h != ts.hiddenDuplicate)
+        if (!IsOurSection(ts, h) && h != ts.hiddenDuplicate && h != ts.homeSpacerItem)
         {
             WCHAR text[64] = {};
             GetItemText(hTree, h, text, ARRAYSIZE(text));
@@ -1505,6 +1617,12 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         {
             TVINSERTSTRUCTW *pInsert = (TVINSERTSTRUCTW *)lParam;
             pInsert->hInsertAfter = TVI_FIRST;
+        }
+        else if (g_spacerInsertAfter && lParam)
+        {
+            TVINSERTSTRUCTW *pInsert = (TVINSERTSTRUCTW *)lParam;
+            pInsert->hInsertAfter = g_spacerInsertAfter;
+            g_spacerInsertAfter = nullptr;
         }
 
         LRESULT result = SubClassTreeWndProc_orig(hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData);
@@ -1608,7 +1726,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         if (tvi && (tvi->mask & TVIF_INTEGRAL))
         {
             TreeState* ts = GetTree(hWnd);
-            HTREEITEM hiddenDup = ts ? ts->hiddenDuplicate : nullptr;
+            HTREEITEM hiddenDup = ts ? GetHiddenItem(*ts) : nullptr;
             HTREEITEM boundaryIt = ts ? ts->boundaryItem : nullptr;
             HTREEITEM belowQAIt = ts ? ts->belowQAItem : nullptr;
 
@@ -1659,10 +1777,9 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         }
     }
 
-    // Block all interaction with hidden duplicate
     {
         TreeState* ts = GetTree(hWnd);
-        HTREEITEM hiddenDup = ts ? ts->hiddenDuplicate : nullptr;
+        HTREEITEM hiddenDup = ts ? GetHiddenItem(*ts) : nullptr;
 
         if (hiddenDup &&
             (uMsg == WM_LBUTTONDOWN || uMsg == WM_RBUTTONDOWN ||
@@ -1734,6 +1851,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         }
 
         g_inSubclassProc++;
+        g_deferredOpInProgress = true;
+        g_mutatingTree = hWnd;
 
         TreeState* ts = GetTree(hWnd);
         ts = RunDeferredWork(hWnd, ts, WORK_FULL_REBUILD, FullRebuildTree);
@@ -1780,7 +1899,11 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             ExpandStartExpandedItems(hWnd);
         }
 
+        ts = GetTree(hWnd);
+        ts = RunDeferredWork(hWnd, ts, WORK_HOME_SPACER, InsertHomeSpacer);
+
         g_inSubclassProc--;
+        DrainPendingRebuilds();
         return 0;
     }
 
@@ -1789,7 +1912,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         TreeState* ts = GetTree(hWnd);
 
         constexpr uint8_t DEFER_MASK = WORK_FULL_REBUILD | WORK_HOT_INSERT |
-            WORK_QA_CLEANUP | WORK_HG_CLEANUP | WORK_DUP_COLLAPSE;
+            WORK_QA_CLEANUP | WORK_HG_CLEANUP | WORK_DUP_COLLAPSE | WORK_HOME_SPACER;
         if (ts && (ts->pendingWork & DEFER_MASK))
             PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
 
@@ -1810,13 +1933,30 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             ts->boundaryItem = layout.boundary;
             ts->belowQAItem = nullptr;
 
-            if (layout.boundary && (g_settings.removeSepBelowNav || ts->hiddenDuplicate))
+            bool desktopOnly = ts->hItems[NAV_DESKTOP] && !ts->hItems[NAV_THISPC];
+            if (!ts->triedHomeSpacer && layout.boundary && desktopOnly
+                && !g_settings.removeSepBelowNav && !GetHiddenItem(*ts)
+                && !layout.homePresent && !layout.galleryPresent)
+            {
+                ts->pendingWork |= WORK_HOME_SPACER;
+                PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
+            }
+
+            if (layout.boundary && (g_settings.removeSepBelowNav || GetHiddenItem(*ts)))
                 CollapseItemIntegral(hWnd, layout.boundary);
             if (g_settings.removeSepBelowQA && layout.belowQA)
             {
                 CollapseItemIntegral(hWnd, layout.belowQA);
                 ts->belowQAItem = layout.belowQA;
             }
+
+            if (g_logSepDraw)
+                Wh_Log(L"[SEP-GAP] tree=%p boundary=%p int=%d home=%d gallery=%d rmNav=%d hidDup=%p spacer=%p tried=%d",
+                       hWnd, layout.boundary,
+                       layout.boundary ? GetItemIntegral(hWnd, layout.boundary) : -1,
+                       layout.homePresent, layout.galleryPresent,
+                       (int)g_settings.removeSepBelowNav, ts->hiddenDuplicate, ts->homeSpacerItem,
+                       (int)ts->triedHomeSpacer);
         }
 
         if (g_settings.hidePinButtons && ts)
@@ -1833,7 +1973,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         if (g_settings.hasItemsAtTop)
             EnsureParentSubclass(hWnd);
 
-        if (ts && ts->hiddenDuplicate)
+        if (ts && GetHiddenItem(*ts))
             SetWindowSubclass(hWnd, TreeInteractionProc, 0xAF01, 0);
 
         g_inTreePaint = true;
@@ -2293,6 +2433,7 @@ void Wh_ModSettingsChanged()
         if (tier == TIER_REBUILD)
         {
             g_deferredOpInProgress = true;
+            g_mutatingTree = hTree;
             FullRebuildTree(hTree);
             DrainPendingRebuilds();
         }

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.21
+// @version         1.1.22
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -337,7 +337,6 @@ static std::atomic<bool> g_explorerFrameLoaded{false};
 
 static thread_local bool g_deferredOpInProgress = false;
 static thread_local HWND g_mutatingTree = nullptr;
-static std::atomic<bool> g_uninitInProgress{false};
 static thread_local std::unordered_set<HWND> g_pendingRebuildTrees;
 
 #define WM_DEFERRED_REBUILD  (WM_APP + 0x101)
@@ -972,12 +971,18 @@ static void EnsureParentSubclass(HWND hTree)
     HWND parent = GetParent(hTree);
     if (!parent)
         return;
-    if (g_subclassedParents.count(parent))
-        return;
+    {
+        std::lock_guard<std::recursive_mutex> lock(g_treesMutex);
+        if (g_subclassedParents.count(parent))
+            return;
+    }
     bool ok = WindhawkUtils::SetWindowSubclassFromAnyThread(parent, SepParentSubclassProc, (DWORD_PTR)hTree);
     Wh_Log(L"[SEP-PARENT] parent=%04X tree=%04X ok=%d", PTR4(parent), PTR4(hTree), ok);
     if (ok)
+    {
+        std::lock_guard<std::recursive_mutex> lock(g_treesMutex);
         g_subclassedParents.insert(parent);
+    }
 }
 
 static void RestoreTree(HWND hTree)
@@ -1408,7 +1413,7 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
         if (hdr && hdr->hwndFrom == hTree)
         {
             if ((hdr->code == TVN_SELCHANGEDW || hdr->code == TVN_SELCHANGEDA) &&
-                (hTree == g_mutatingTree || g_uninitInProgress.load(std::memory_order_relaxed)))
+                hTree == g_mutatingTree)
                 return 0;
 
             if (hdr->code == (UINT)NM_CUSTOMDRAW && hTree != g_mutatingTree)
@@ -1496,7 +1501,10 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
         ResetSepColor();
 
     if (uMsg == WM_NCDESTROY)
+    {
+        std::lock_guard<std::recursive_mutex> lock(g_treesMutex);
         g_subclassedParents.erase(hWnd);
+    }
 
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
@@ -2298,7 +2306,9 @@ void Wh_ModAfterInit();
 static HMODULE WINAPI LoadLibraryExW_hook(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
 {
     HMODULE hModule = LoadLibraryExW_orig(lpLibFileName, hFile, dwFlags);
-    if (hModule && lpLibFileName && !(dwFlags & LOAD_LIBRARY_AS_DATAFILE) &&
+    constexpr DWORD DATA_ONLY = LOAD_LIBRARY_AS_DATAFILE |
+        LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE | LOAD_LIBRARY_AS_IMAGE_RESOURCE;
+    if (hModule && lpLibFileName && !(dwFlags & DATA_ONLY) &&
         !g_explorerFrameLoaded.load(std::memory_order_relaxed))
     {
         LPCWSTR name = wcsrchr(lpLibFileName, L'\\');
@@ -2313,6 +2323,7 @@ static HMODULE WINAPI LoadLibraryExW_hook(LPCWSTR lpLibFileName, HANDLE hFile, D
                 g_explorerFrameLoaded.store(false, std::memory_order_release);
                 return hModule;
             }
+            Wh_ApplyHookOperations();
             Wh_Log(L"Late-load hooks installed, running discovery");
             Wh_ModAfterInit();
         }
@@ -2325,8 +2336,7 @@ BOOL Wh_ModInit()
     HMODULE hExplorerFrame = GetModuleHandleW(L"ExplorerFrame.dll");
     if (!hExplorerFrame)
     {
-        // Wh_Log(L"ExplorerFrame.dll not loaded, hooking LoadLibraryExW for late detection");
-        Wh_SetFunctionHook((void *)LoadLibraryExW, (void *)LoadLibraryExW_hook, (void **)&LoadLibraryExW_orig);
+        WindhawkUtils::SetFunctionHook(LoadLibraryExW, LoadLibraryExW_hook, &LoadLibraryExW_orig);
         return TRUE;
     }
     g_explorerFrameLoaded.store(true, std::memory_order_relaxed);
@@ -2589,22 +2599,23 @@ void Wh_ModUninit()
             uninitList.push_back(hTree);
     }
 
-    g_uninitInProgress.store(true, std::memory_order_release);
     for (HWND hTree : uninitList)
     {
-        RestoreTree(hTree);
         if (IsWindow(hTree))
-            RedrawWindow(hTree, nullptr, nullptr,
-                         RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+            SendMessage(hTree, WM_RESTORE_TREE, 0, 0);
     }
-    g_uninitInProgress.store(false, std::memory_order_release);
 
-    for (HWND parent : g_subclassedParents)
+    std::vector<HWND> parents;
+    {
+        std::lock_guard<std::recursive_mutex> lock(g_treesMutex);
+        parents.assign(g_subclassedParents.begin(), g_subclassedParents.end());
+        g_subclassedParents.clear();
+    }
+    for (HWND parent : parents)
     {
         if (IsWindow(parent))
             WindhawkUtils::RemoveWindowSubclassFromAnyThread(parent, SepParentSubclassProc);
     }
-    g_subclassedParents.clear();
 
     {
         std::lock_guard<std::recursive_mutex> lock(g_treesMutex);

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.8
+// @version         1.1.10
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -202,12 +202,22 @@ enum ChangeTier { TIER_NONE, TIER_REPAINT, TIER_REFRESH, TIER_REBUILD };
 static ULONG_PTR g_gdipToken = 0;
 static std::set<HWND> g_subclassedParents;
 static COLORREF g_sepColor = CLR_INVALID;
-static bool g_sepColorPendingVerify = false;
 static bool g_logSepDraw = true;
 
 static void ResetSepColor() {
     g_sepColor = CLR_INVALID;
     g_logSepDraw = true;
+}
+
+static COLORREF DeriveSepColor(HWND hTree)
+{
+    COLORREF bg = (COLORREF)SendMessageW(hTree, TVM_GETBKCOLOR, 0, 0);
+    if (bg == CLR_INVALID || (int)bg == -1)
+        bg = GetSysColor(COLOR_WINDOW);
+    int sum = GetRValue(bg) + GetGValue(bg) + GetBValue(bg);
+    int d = (sum < 384) ? 24 : -28;
+    auto cl = [](int v) { return (BYTE)(v < 0 ? 0 : (v > 255 ? 255 : v)); };
+    return RGB(cl(GetRValue(bg) + d), cl(GetGValue(bg) + d), cl(GetBValue(bg) + d));
 }
 
 enum PendingWork : uint8_t {
@@ -306,26 +316,17 @@ static void ResetTreeCleanup(TreeState& ts)
     ts.qaEverCleaned = false;
 }
 
-// -1=not ours, 0..3=NavItemId — set during AppendOneItem
-// so the TVM_INSERTITEM handler knows which item is being inserted
-// without comparing localized display text.
-static int g_insertingItem = -1;
+// Globals bridging AppendRoot_hook to TVM_INSERTITEM handler.
+struct InsertionCtx {
+    int item = -1;          // -1=not ours, 0..3=NavItemId
+    void *pNsc = nullptr;
+    unsigned long enumFlags = 0;
+    IShellItemFilter *filter = nullptr;
+    HWND forTree = nullptr; // scopes item to a specific tree; null = any
+};
+static InsertionCtx g_ins;
 
-// Temporary globals bridging AppendRoot_hook to TVM_INSERTITEM handler.
-// Copied into TreeState once the tree HWND is known.
-static void *g_pNscTree = nullptr;
-static unsigned long g_lastEnumFlags = 0;
-static IShellItemFilter *g_pLastFilter = nullptr;
-
-// Scopes g_insertingItem to a specific tree: TVM_INSERTITEM from other
-// trees during message pumping is ignored. Null = accept any tree
-// (used by AppendRoot_hook for fresh windows where HWND is unknown).
-static HWND g_insertingForTree = nullptr;
-
-// Re-entrancy guard: FullRebuildTree and HotEnableInsert set global
-// state (g_insertingItem, g_inCustomAppend, g_pNscTree) that would be
-// corrupted if a second tree's deferred op runs while the first is
-// in progress (AppendRoot_orig pumps messages internally).
+// AppendRoot_orig pumps messages, so a second tree's deferred op could corrupt g_ins.
 static bool g_deferredOpInProgress = false;
 static HWND g_mutatingTree = nullptr;
 static std::unordered_set<HWND> g_pendingRebuildTrees;
@@ -368,14 +369,14 @@ struct InsertionScope {
         , pFilter(ts.pFilter)
         , pNscRaw(ts.pNscTree)
     {
-        g_pNscTree = ts.pNscTree;
-        g_lastEnumFlags = ts.enumFlags;
-        g_insertingForTree = hTree;
+        g_ins.pNsc = ts.pNscTree;
+        g_ins.enumFlags = ts.enumFlags;
+        g_ins.forTree = hTree;
         g_inCustomAppend = true;
     }
 
     ~InsertionScope() {
-        g_insertingForTree = nullptr;
+        g_ins.forTree = nullptr;
         g_inCustomAppend = false;
     }
 };
@@ -449,9 +450,9 @@ static void InsertItems(void *pNsc, const NavItem items[2], unsigned long enumFl
     {
         if (items[i].enabled)
         {
-            g_insertingItem = items[i].id;
+            g_ins.item = items[i].id;
             AppendOneItem(pNsc, items[i].pidl, items[i].expandable, enumFlags, filter, items[i].style);
-            g_insertingItem = -1;
+            g_ins.item = -1;
         }
     }
 }
@@ -498,9 +499,9 @@ HRESULT THISCALL AppendRoot_hook(void *pThis, IShellItem *psiRoot, unsigned long
                     Wh_Log(L"[HOOK] Suppressing '%s' root", g_navItems[matchId].label);
                     return S_OK;
                 }
-                g_insertingItem = matchId;
+                g_ins.item = matchId;
                 HRESULT hr = AppendRoot_orig(pThis, psiRoot, grfEnumFlags, grfRootStyle, pFilter);
-                g_insertingItem = -1;
+                g_ins.item = -1;
                 return hr;
             }
         }
@@ -516,13 +517,13 @@ HRESULT THISCALL AppendRoot_hook(void *pThis, IShellItem *psiRoot, unsigned long
 
     if (wantItems)
     {
-        g_pNscTree = pThis;
-        g_lastEnumFlags = grfEnumFlags;
-        if (g_pLastFilter != pFilter)
+        g_ins.pNsc = pThis;
+        g_ins.enumFlags = grfEnumFlags;
+        if (g_ins.filter != pFilter)
         {
-            if (g_pLastFilter) g_pLastFilter->Release();
-            g_pLastFilter = pFilter;
-            if (g_pLastFilter) g_pLastFilter->AddRef();
+            if (g_ins.filter) g_ins.filter->Release();
+            g_ins.filter = pFilter;
+            if (g_ins.filter) g_ins.filter->AddRef();
         }
 
         g_inCustomAppend = true;
@@ -671,6 +672,54 @@ static int GetItemIntegral(HWND hTree, HTREEITEM h)
     return tvi.iIntegral;
 }
 
+static bool GetItemRect(HWND hTree, HTREEITEM h, RECT *rc)
+{
+    *(HTREEITEM *)rc = h;
+    return SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)rc) != 0;
+}
+
+struct RedrawFreeze {
+    HWND h;
+    RedrawFreeze(HWND h) : h(h) { SendMessageW(h, WM_SETREDRAW, FALSE, 0); }
+    ~RedrawFreeze() { SendMessageW(h, WM_SETREDRAW, TRUE, 0); InvalidateRect(h, nullptr, TRUE); }
+};
+
+static bool ShouldBeUnitHeight(const TreeState& ts, HWND hTree, HTREEITEM h)
+{
+    if (ts.boundaryItem && h == ts.boundaryItem &&
+        (g_settings.removeSepBelowNav || GetHiddenItem(ts)))
+        return true;
+
+    if (ts.belowQAItem && h == ts.belowQAItem && g_settings.removeSepBelowQA)
+        return true;
+
+    if (g_settings.hasItemsAtTop)
+    {
+        for (int i = NAV_HOME; i < NAV_COUNT; i++)
+            if (ts.hItems[i] && h == ts.hItems[i] && !g_settings.items[i].hide)
+                return true;
+    }
+
+    // Collapse the lower of Desktop/This PC when they're adjacent (no internal sep).
+    if (ShouldRemoveInternalSep())
+    {
+        HTREEITEM hA = ts.hItems[NAV_THISPC];
+        HTREEITEM hB = ts.hItems[NAV_DESKTOP];
+        if (hA && hB && (h == hA || h == hB))
+        {
+            RECT rcA = {}, rcB = {};
+            if (GetItemRect(hTree, hA, &rcA) && GetItemRect(hTree, hB, &rcB))
+            {
+                HTREEITEM hLower = (rcA.top > rcB.top) ? hA : hB;
+                if (h == hLower)
+                    return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 static int GetBaseItemHeight(HWND hTree)
 {
     int baseHeight = 0;
@@ -678,8 +727,7 @@ static int GetBaseItemHeight(HWND hTree)
     while (h)
     {
         RECT rc = {};
-        *(HTREEITEM*)&rc = h;
-        if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rc))
+        if (GetItemRect(hTree, h, &rc))
         {
             int ih = rc.bottom - rc.top;
             if (ih > 0 && (baseHeight == 0 || ih < baseHeight))
@@ -730,68 +778,81 @@ static void CollapseMatchingItems(HWND hTree, const TreeState *ts,
     });
 }
 
-static void RefreshNavPane(HWND hTree)
+enum InsertFlags {
+    INS_DELETE_FIRST   = 1,  // delete existing items before re-inserting
+    INS_DEFER_IF_EMPTY = 2,  // bail via WORK_HOT_INSERT if tree is empty
+    INS_RESET_SEPCOLOR = 4,  // reset separator color
+    INS_UPDATE_NOW     = 8,  // RedrawWindow with RDW_UPDATENOW
+    INS_DEFERRED_GUARD = 16, // set g_deferredOpInProgress + drain
+};
+
+static void InsertOurItems(HWND hTree, unsigned flags)
 {
     TreeState* ts = GetTree(hTree);
-    if (!ts || !hTree || !IsWindow(hTree) || !ts->pNscTree)
+    if (!ts || !ts->pNscTree || !IsWindow(hTree))
         return;
 
-    for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
-    {
-        if (ts->hItems[i])
-        {
-            SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)ts->hItems[i]);
-            ts->hItems[i] = nullptr;
-        }
-    }
-
-    ResetTreeCleanup(*ts);
-
-    {
-        InsertionScope scope(*ts, hTree);
-        NavItem items[2];
-        BuildItemOrder(items);
-        g_deferredOpInProgress = true;
-        g_mutatingTree = hTree;
-        InsertItems(scope.pNscRaw, items, ts->enumFlags, scope.pFilter.get());
-    }
-    DrainPendingRebuilds();
-
-    RedrawWindow(hTree, nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
-}
-
-static void HotEnableInsert(HWND hWnd)
-{
-    TreeState* ts = GetTree(hWnd);
-    if (!ts || !ts->pNscTree || !IsWindow(hWnd))
-        return;
-
-    HTREEITEM hFirstChild = GetFirstDepth1Child(hWnd);
-    if (!hFirstChild)
+    if ((flags & INS_DEFER_IF_EMPTY) && !GetFirstDepth1Child(hTree))
     {
         ts->pendingWork |= WORK_HOT_INSERT;
         return;
     }
 
-    ts->hItems[NAV_THISPC] = nullptr;
-    ts->hItems[NAV_DESKTOP] = nullptr;
-    // Home/Gallery handles may still be valid from FullRebuildTree.
-    ResetTreeCleanup(*ts);
-    ResetSepColor();
-
+    if (flags & INS_DELETE_FIRST)
     {
-        InsertionScope scope(*ts, hWnd);
-        NavItem items[2];
-        BuildItemOrder(items);
-        InsertItems(scope.pNscRaw, items, ts->enumFlags, scope.pFilter.get());
+        for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
+        {
+            if (ts->hItems[i])
+            {
+                SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)ts->hItems[i]);
+                ts->hItems[i] = nullptr;
+            }
+        }
+    }
+    else
+    {
+        ts->hItems[NAV_THISPC] = nullptr;
+        ts->hItems[NAV_DESKTOP] = nullptr;
     }
 
-    ts = GetTree(hWnd);
-    Wh_Log(L"[HOTINSERT] Items inserted, ThisPC=%p Desktop=%p Home=%p Gallery=%p",
-           ts ? ts->hItems[NAV_THISPC] : nullptr, ts ? ts->hItems[NAV_DESKTOP] : nullptr,
-           ts ? ts->hItems[NAV_HOME] : nullptr, ts ? ts->hItems[NAV_GALLERY] : nullptr);
+    ResetTreeCleanup(*ts);
+    if (flags & INS_RESET_SEPCOLOR)
+        ResetSepColor();
 
-    InvalidateRect(hWnd, nullptr, TRUE); // not RDW_UPDATENOW: inside WM_PAINT
+    {
+        InsertionScope scope(*ts, hTree);
+        NavItem items[2];
+        BuildItemOrder(items);
+        if (flags & INS_DEFERRED_GUARD)
+        {
+            g_deferredOpInProgress = true;
+            g_mutatingTree = hTree;
+        }
+        InsertItems(scope.pNscRaw, items, ts->enumFlags, scope.pFilter.get());
+    }
+    if (flags & INS_DEFERRED_GUARD)
+        DrainPendingRebuilds();
+
+    ts = GetTree(hTree);
+    if (flags & INS_UPDATE_NOW)
+        RedrawWindow(hTree, nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+    else
+    {
+        Wh_Log(L"[HOTINSERT] Items inserted, ThisPC=%p Desktop=%p Home=%p Gallery=%p",
+               ts ? ts->hItems[NAV_THISPC] : nullptr, ts ? ts->hItems[NAV_DESKTOP] : nullptr,
+               ts ? ts->hItems[NAV_HOME] : nullptr, ts ? ts->hItems[NAV_GALLERY] : nullptr);
+        InvalidateRect(hTree, nullptr, TRUE); // not RDW_UPDATENOW: inside WM_PAINT
+    }
+}
+
+static void RefreshNavPane(HWND hTree)
+{
+    InsertOurItems(hTree, INS_DELETE_FIRST | INS_DEFERRED_GUARD | INS_UPDATE_NOW);
+}
+
+static void HotEnableInsert(HWND hWnd)
+{
+    InsertOurItems(hWnd, INS_DEFER_IF_EMPTY | INS_RESET_SEPCOLOR);
 }
 
 static LRESULT CALLBACK TreeInteractionProc(
@@ -927,8 +988,8 @@ static void FullRebuildTree(HWND hTree)
             ResetTreeCleanup(*ts);
         }
 
-        g_pNscTree = pNscRaw;
-        g_lastEnumFlags = enumFlags;
+        g_ins.pNsc = pNscRaw;
+        g_ins.enumFlags = enumFlags;
 
         g_inCustomAppend = true;
         AppendRoot_orig(pNscRaw, roots.items[NAV_DESKTOP].get(), enumFlags, 0x1, nullptr);
@@ -953,7 +1014,8 @@ static void InsertHomeSpacer(HWND hTree)
     TreeState* ts = GetTree(hTree);
     if (!ts) return;
     ts->triedHomeSpacer = true;
-    if (!ts->pNscTree || !ts->hItems[NAV_DESKTOP]) return;
+    // WORK_HOME_SPACER may fire before This PC is cached; re-check desktopOnly.
+    if (!ts->pNscTree || !ts->hItems[NAV_DESKTOP] || ts->hItems[NAV_THISPC]) return;
 
     int spacerId = g_navItems[NAV_HOME].pidl ? NAV_HOME
                  : (g_navItems[NAV_GALLERY].pidl ? NAV_GALLERY : -1);
@@ -1080,8 +1142,7 @@ static SectionLayout FindSectionLayout(HWND hTree, TreeState& ts)
             else if (baseHeight > 0)
             {
                 RECT rc = {};
-                *(HTREEITEM*)&rc = h;
-                if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rc))
+                if (GetItemRect(hTree, h, &rc))
                 {
                     int ih = rc.bottom - rc.top;
                     if (ih >= tallThreshold)
@@ -1112,73 +1173,6 @@ static void DrawSeparatorLine(HDC hdc, HWND hTree, int sepY)
         FillRect(hdc, &sepRect, brush);
         DeleteObject(brush);
     }
-}
-
-// Sample the separator line color from the DC. Called on the first
-// paint cycle when CDDS_PREPAINT was NOT swallowed (separators visible).
-static COLORREF SampleSeparatorColor(HWND hTree, HDC hdc)
-{
-    if (!hdc || !IsWindow(hTree))
-        return CLR_INVALID;
-
-    RECT client;
-    GetClientRect(hTree, &client);
-    if (client.right <= 0)
-        return CLR_INVALID;
-
-    int baseHeight = GetBaseItemHeight(hTree);
-    if (baseHeight <= 0)
-        return CLR_INVALID;
-
-    int tallThreshold = baseHeight + baseHeight / 2;
-
-    // Find the first tall depth-1 item — its separator is at rc.top + baseHeight/2
-    HTREEITEM h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_FIRSTVISIBLE, 0);
-    while (h)
-    {
-        if (IsDepth1Item(hTree, h))
-        {
-            RECT rc = {};
-            *(HTREEITEM*)&rc = h;
-            if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rc))
-            {
-                int ih = rc.bottom - rc.top;
-                if (ih >= tallThreshold)
-                {
-                    int sepY = rc.top + baseHeight / 2;
-                    int sampleX = client.right / 2;
-
-                    // Sample background color nearby for validation
-                    COLORREF bg = GetPixel(hdc, sampleX, rc.top + baseHeight + baseHeight / 4);
-
-                    auto isPlausible = [&](COLORREF c) -> bool {
-                        if (c == CLR_INVALID || c == 0x000000)
-                            return false;
-                        if (bg == CLR_INVALID)
-                            return true;
-                        // Reject if separator color is too far from background
-                        int dr = abs((int)GetRValue(c) - (int)GetRValue(bg));
-                        int dg = abs((int)GetGValue(c) - (int)GetGValue(bg));
-                        int db = abs((int)GetBValue(c) - (int)GetBValue(bg));
-                        return (dr + dg + db) < 200;
-                    };
-
-                    COLORREF c = GetPixel(hdc, sampleX, sepY);
-                    if (isPlausible(c))
-                        return c;
-                    for (int dy = -2; dy <= 2; dy++)
-                    {
-                        c = GetPixel(hdc, sampleX, sepY + dy);
-                        if (isPlausible(c))
-                            return c;
-                    }
-                }
-            }
-        }
-        h = (HTREEITEM)SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_NEXTVISIBLE, (LPARAM)h);
-    }
-
-    return CLR_INVALID;
 }
 
 // At CDDS_POSTPAINT, all separators have been hidden by CDDS_PREPAINT
@@ -1222,9 +1216,8 @@ static void RedrawOtherSeparators(HWND hTree, HDC hdc, TreeState& ts)
         if (IsDepth1Item(hTree, h))
         {
             RECT rc = {};
-            *(HTREEITEM*)&rc = h;
             int ih = 0;
-            if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rc))
+            if (GetItemRect(hTree, h, &rc))
                 ih = rc.bottom - rc.top;
 
             if (IsOurSection(ts, h))
@@ -1310,38 +1303,15 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
                 DWORD stage = cd->nmcd.dwDrawStage;
                 TreeState* ts = GetTree(hTree);
                 if (stage == CDDS_PREPAINT && g_settings.hasItemsAtTop)
-                {
-                    if (g_sepColor != CLR_INVALID && !g_sepColorPendingVerify)
-                        return CDRF_NOTIFYPOSTPAINT;
-                    LRESULT r = DefSubclassProc(hWnd, uMsg, wParam, lParam);
-                    return r | CDRF_NOTIFYPOSTPAINT;
-                }
+                    return CDRF_NOTIFYPOSTPAINT;
 
                 if (stage == CDDS_POSTPAINT)
                 {
-                    if (g_sepColorPendingVerify && g_sepColor != CLR_INVALID && g_settings.hasItemsAtTop)
-                    {
-                        g_sepColorPendingVerify = false;
-                        COLORREF c = SampleSeparatorColor(hTree, cd->nmcd.hdc);
-                        if (c != CLR_INVALID && c != g_sepColor)
-                        {
-                            Wh_Log(L"[SEP] color changed 0x%06X -> 0x%06X tree=%p", g_sepColor, c, hTree);
-                            g_sepColor = c;
-                            g_logSepDraw = true;
-                        }
-                        InvalidateRect(hTree, NULL, TRUE);
-                    }
-
                     if (g_sepColor == CLR_INVALID && g_settings.hasItemsAtTop)
                     {
-                        COLORREF c = SampleSeparatorColor(hTree, cd->nmcd.hdc);
-                        if (c != CLR_INVALID)
-                        {
-                            g_sepColor = c;
-                            g_logSepDraw = true;
-                            Wh_Log(L"[SEP] color=0x%06X tree=%p", c, hTree);
-                            InvalidateRect(hTree, NULL, TRUE);
-                        }
+                        g_sepColor = DeriveSepColor(hTree);
+                        g_logSepDraw = true;
+                        Wh_Log(L"[SEP] color=0x%06X tree=%p (derived)", g_sepColor, hTree);
                     }
 
                     if (g_settings.hasItemsAtTop && g_sepColor != CLR_INVALID && ts)
@@ -1352,8 +1322,7 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
                     if (hHidden)
                     {
                         RECT rcHide = {};
-                        *(HTREEITEM*)&rcHide = hHidden;
-                        if (SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)&rcHide))
+                        if (GetItemRect(hTree, hHidden, &rcHide))
                         {
                             HDC hdc = cd->nmcd.hdc;
                             RECT client;
@@ -1404,9 +1373,7 @@ static LRESULT CALLBACK SepParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wPara
     }
 
     if (uMsg == WM_THEMECHANGED || uMsg == WM_SYSCOLORCHANGE)
-    {
-        g_sepColorPendingVerify = true;
-    }
+        ResetSepColor();
 
     if (uMsg == WM_NCDESTROY)
         g_subclassedParents.erase(hWnd);
@@ -1425,18 +1392,6 @@ static void EnsureParentSubclass(HWND hTree)
     Wh_Log(L"[SEP-PARENT] subclass on parent=%p for tree=%p ok=%d", parent, hTree, ok);
     if (ok)
         g_subclassedParents.insert(parent);
-}
-
-// --- Pin button hiding ---
-
-using SetStateImageList_t = HRESULT (THISCALL *)(void *, HIMAGELIST);
-SetStateImageList_t SetStateImageList_orig;
-
-HRESULT THISCALL SetStateImageList_hook(void *pThis, HIMAGELIST himl)
-{
-    // Always let CNscTree accept the image list so it remains alive and
-    // can be cached by WM_PAINT (which hides it before the tree draws).
-    return SetStateImageList_orig(pThis, himl);
 }
 
 // Returns false if expected dups are missing (async population race).
@@ -1491,42 +1446,36 @@ static bool CleanupQuickAccessDuplicates(HWND hTree, TreeState& ts)
         return true;
     });
 
-    // Freeze redraw during deletions to prevent Explorer from
-    // re-inserting items synchronously (which would reset cleanup
-    // flags via the TVM_INSERTITEM handler and cause a loop).
+    // Redraw freeze prevents Explorer from synchronously re-inserting during deletion.
     bool needDelete = (sectionCount > 0 || childlessCount > 0);
-    if (needDelete)
-        SendMessageW(hTree, WM_SETREDRAW, FALSE, 0);
-
-    for (int i = 0; i < sectionCount; i++)
-    {
-        Wh_Log(L"[QA-HIDE] deleting native section=%p", toDeleteSections[i]);
-        SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDeleteSections[i]);
-    }
-
     HTREEITEM prevDup = ts.hiddenDuplicate;
-    ts.hiddenDuplicate = nullptr;
-
-    SectionLayout layout = FindSectionLayout(hTree, ts);
-    HTREEITEM hBoundaryPos = layout.boundary;
-    for (int i = 0; i < childlessCount; i++)
-    {
-        if (!g_settings.removeSepBelowNav && !ts.hiddenDuplicate && toDeleteChildless[i] == hBoundaryPos)
-        {
-            ts.hiddenDuplicate = toDeleteChildless[i];
-            SetItemIntegral(hTree, toDeleteChildless[i], 1);
-            if (ts.hiddenDuplicate != prevDup)
-                Wh_Log(L"[QA-HIDE] keeping dup=%p at boundary", toDeleteChildless[i]);
-            continue;
-        }
-        Wh_Log(L"[QA-HIDE] deleting duplicate item=%p", toDeleteChildless[i]);
-        SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDeleteChildless[i]);
-    }
-
     if (needDelete)
     {
-        SendMessageW(hTree, WM_SETREDRAW, TRUE, 0);
-        InvalidateRect(hTree, nullptr, TRUE);
+        RedrawFreeze freeze(hTree);
+
+        for (int i = 0; i < sectionCount; i++)
+        {
+            Wh_Log(L"[QA-HIDE] deleting native section=%p", toDeleteSections[i]);
+            SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDeleteSections[i]);
+        }
+
+        ts.hiddenDuplicate = nullptr;
+
+        SectionLayout layout = FindSectionLayout(hTree, ts);
+        HTREEITEM hBoundaryPos = layout.boundary;
+        for (int i = 0; i < childlessCount; i++)
+        {
+            if (!g_settings.removeSepBelowNav && !ts.hiddenDuplicate && toDeleteChildless[i] == hBoundaryPos)
+            {
+                ts.hiddenDuplicate = toDeleteChildless[i];
+                SetItemIntegral(hTree, toDeleteChildless[i], 1);
+                if (ts.hiddenDuplicate != prevDup)
+                    Wh_Log(L"[QA-HIDE] keeping dup=%p at boundary", toDeleteChildless[i]);
+                continue;
+            }
+            Wh_Log(L"[QA-HIDE] deleting duplicate item=%p", toDeleteChildless[i]);
+            SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDeleteChildless[i]);
+        }
     }
 
     if (needDelete || ts.hiddenDuplicate != prevDup)
@@ -1575,20 +1524,17 @@ static bool RemoveHiddenInheritedItems(HWND hTree, TreeState& ts)
     });
 
     if (delCount > 0)
-        SendMessageW(hTree, WM_SETREDRAW, FALSE, 0);
-    for (int i = 0; i < delCount; i++)
     {
-        Wh_Log(L"[HIDE] Deleting '%s' item=%p",
-               g_navItems[toDelete[i].id].label, toDelete[i].h);
-        SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDelete[i].h);
-        ts.hItems[toDelete[i].id] = nullptr;
+        RedrawFreeze freeze(hTree);
+        for (int i = 0; i < delCount; i++)
+        {
+            Wh_Log(L"[HIDE] Deleting '%s' item=%p",
+                   g_navItems[toDelete[i].id].label, toDelete[i].h);
+            SendMessageW(hTree, TVM_DELETEITEM, 0, (LPARAM)toDelete[i].h);
+            ts.hItems[toDelete[i].id] = nullptr;
+        }
     }
-    if (delCount > 0)
-    {
-        SendMessageW(hTree, WM_SETREDRAW, TRUE, 0);
-        InvalidateRect(hTree, nullptr, TRUE);
-    }
-    return (delCount >= targetCount);
+    return true;
 }
 
 // --- SubClassTreeWndProc ---
@@ -1610,10 +1556,10 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
 
     if (uMsg == TVM_INSERTITEMW || uMsg == TVM_INSERTITEMA)
     {
-        bool isOurInsert = (g_insertingItem >= 0 && g_insertingItem < NAV_COUNT) &&
-                           (!g_insertingForTree || hWnd == g_insertingForTree);
+        bool isOurInsert = (g_ins.item >= 0 && g_ins.item < NAV_COUNT) &&
+                           (!g_ins.forTree || hWnd == g_ins.forTree);
 
-        if (isOurInsert && IsInsertableItem(g_insertingItem) && lParam)
+        if (isOurInsert && IsInsertableItem(g_ins.item) && lParam)
         {
             TVINSERTSTRUCTW *pInsert = (TVINSERTSTRUCTW *)lParam;
             pInsert->hInsertAfter = TVI_FIRST;
@@ -1631,8 +1577,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         {
             if (isOurInsert)
             {
-                int id = g_insertingItem;
-                g_insertingItem = -1;
+                int id = g_ins.item;
+                g_ins.item = -1;
                 if (!GetTree(hWnd) && !IsNavPaneHost(hWnd))
                     return result;
                 auto [it, _] = g_trees.try_emplace(hWnd);
@@ -1645,22 +1591,20 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                     ts.pendingWork |= WORK_QA_CLEANUP | WORK_EXPAND;
                     if (!ts.pNscTree)
                     {
-                        ts.pNscTree = g_pNscTree;
-                        ts.enumFlags = g_lastEnumFlags;
-                        if (g_pLastFilter && !ts.pFilter)
+                        ts.pNscTree = g_ins.pNsc;
+                        ts.enumFlags = g_ins.enumFlags;
+                        if (g_ins.filter && !ts.pFilter)
                         {
-                            g_pLastFilter->AddRef();
-                            ts.pFilter = g_pLastFilter;
+                            g_ins.filter->AddRef();
+                            ts.pFilter = g_ins.filter;
                         }
                     }
                     SetPropW(hWnd, L"WH_NscTree", (HANDLE)ts.pNscTree);
                     SetPropW(hWnd, L"WH_EnumFlags", (HANDLE)(ULONG_PTR)ts.enumFlags);
                 }
-                else
+                else if (g_settings.hasItemsAtTop && !g_settings.items[id].hide)
                 {
-                    bool hidden = g_settings.items[id].hide;
-                    if (!hidden && g_settings.hasItemsAtTop)
-                        SetItemIntegral(hWnd, hNew, 1);
+                    SetItemIntegral(hWnd, hNew, 1);
                 }
                 Wh_Log(L"[CACHE] %s item=%p tree=%p", g_navItems[id].label, hNew, hWnd);
             }
@@ -1704,7 +1648,8 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
                     for (int i = NAV_THISPC; i <= NAV_DESKTOP; i++)
                         if (ts->hItems[i]) { hasOurItems = true; break; }
 
-                    if (hasOurItems && !g_deferredOpInProgress && !g_inTreePaint)
+                    if (hasOurItems && !g_deferredOpInProgress && !g_inTreePaint &&
+                        g_inSubclassProc == 0)
                     {
                         ts->pendingWork |= WORK_FULL_REBUILD;
                         PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
@@ -1727,53 +1672,11 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         {
             TreeState* ts = GetTree(hWnd);
             HTREEITEM hiddenDup = ts ? GetHiddenItem(*ts) : nullptr;
-            HTREEITEM boundaryIt = ts ? ts->boundaryItem : nullptr;
-            HTREEITEM belowQAIt = ts ? ts->belowQAItem : nullptr;
-
-            struct ClampRule { HTREEITEM h; bool cond; bool anyNonOne; };
-            ClampRule rules[] = {
-                { hiddenDup,  true, true },
-                { boundaryIt, g_settings.removeSepBelowNav || hiddenDup != nullptr, false },
-                { belowQAIt,  true, false },
-            };
-            for (auto& r : rules)
-                if (r.h && tvi->hItem == r.h && r.cond &&
-                    (r.anyNonOne ? tvi->iIntegral != 1 : tvi->iIntegral >= 2))
-                    { tvi->iIntegral = 1; break; }
-
-            if (ts && tvi->iIntegral >= 2 && g_settings.hasItemsAtTop)
-            {
-                for (int i = NAV_HOME; i < NAV_COUNT; i++)
-                {
-                    if (ts->hItems[i] && tvi->hItem == ts->hItems[i])
-                    {
-                        if (!g_settings.items[i].hide) tvi->iIntegral = 1;
-                        break;
-                    }
-                }
-            }
-
-            // Collapse the boundary between Desktop and This PC.
-            if (ShouldRemoveInternalSep() && tvi->iIntegral >= 2 && ts)
-            {
-                HTREEITEM hA = ts->hItems[NAV_THISPC];
-                HTREEITEM hB = ts->hItems[NAV_DESKTOP];
-                if (hA && hB)
-                {
-                    RECT rcA = {}, rcB = {};
-                    *(HTREEITEM*)&rcA = hA;
-                    *(HTREEITEM*)&rcB = hB;
-                    bool gotA = SendMessageW(hWnd, TVM_GETITEMRECT, FALSE, (LPARAM)&rcA);
-                    bool gotB = SendMessageW(hWnd, TVM_GETITEMRECT, FALSE, (LPARAM)&rcB);
-
-                    if (gotA && gotB)
-                    {
-                        HTREEITEM hLower = (rcA.top > rcB.top) ? hA : hB;
-                        if (tvi->hItem == hLower)
-                            tvi->iIntegral = 1;
-                    }
-                }
-            }
+            // Hidden dup: clamp any non-1 value (not just >= 2).
+            if (hiddenDup && tvi->hItem == hiddenDup && tvi->iIntegral != 1)
+                tvi->iIntegral = 1;
+            else if (ts && tvi->iIntegral >= 2 && ShouldBeUnitHeight(*ts, hWnd, tvi->hItem))
+                tvi->iIntegral = 1;
         }
     }
 
@@ -1926,7 +1829,6 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             }
         }
 
-        // Tall items remain until g_sepColor is captured for sampling.
         if (g_settings.hasItemsAtTop && g_sepColor != CLR_INVALID && ts)
         {
             SectionLayout layout = FindSectionLayout(hWnd, *ts);
@@ -2173,16 +2075,6 @@ BOOL Wh_ModInit()
             },
             &SubClassTreeWndProc_orig,
             SubClassTreeWndProc_hook,
-            false
-        },
-        {
-            {
-                L"public: virtual long __cdecl"
-                L" CNscTree::SetStateImageList("
-                L"struct _IMAGELIST *)"
-            },
-            &SetStateImageList_orig,
-            SetStateImageList_hook,
             false
         },
     };
@@ -2521,8 +2413,8 @@ void Wh_ModUninit()
     if (g_gdipToken) { Gdiplus::GdiplusShutdown(g_gdipToken); g_gdipToken = 0; }
     for (int i = 0; i < NAV_COUNT; i++)
         if (g_navItems[i].pidl) { CoTaskMemFree(g_navItems[i].pidl); g_navItems[i].pidl = nullptr; }
-    g_pNscTree = nullptr;
-    g_lastEnumFlags = 0;
-    if (g_pLastFilter) { g_pLastFilter->Release(); g_pLastFilter = nullptr; }
+    g_ins.pNsc = nullptr;
+    g_ins.enumFlags = 0;
+    if (g_ins.filter) { g_ins.filter->Release(); g_ins.filter = nullptr; }
     Wh_Log(L"Mod uninitialized");
 }

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -1944,6 +1944,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         g_mutatingTree = hWnd;
         RestoreTree(hWnd);
         g_mutatingTree = nullptr;
+        if (g_ins.filter) { g_ins.filter->Release(); g_ins.filter = nullptr; }
         if (IsWindow(hWnd))
             RedrawWindow(hWnd, nullptr, nullptr,
                          RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
@@ -2407,6 +2408,16 @@ static void DiscoverTreeFromBrowser(HWND hTop, const WCHAR *cls,
 
 void Wh_ModAfterInit()
 {
+#ifdef _WIN64
+    const size_t OFFSET_SAME_TEB_FLAGS = 0x17EE;
+#else
+    const size_t OFFSET_SAME_TEB_FLAGS = 0x0FCA;
+#endif
+    bool isInitialThread = *(USHORT *)((BYTE *)NtCurrentTeb() +
+        OFFSET_SAME_TEB_FLAGS) & 0x0400;
+    if (isInitialThread)
+        return;
+
     std::vector<DiscoveredTree> discovered;
 
     EnumWindows([](HWND hTop, LPARAM lParam) -> BOOL {
@@ -2633,7 +2644,6 @@ void Wh_ModUninit()
                 ts.ownsNscRef = false;
             }
         }
-        g_trees.clear();
     }
 
     if (g_gdipToken) { Gdiplus::GdiplusShutdown(g_gdipToken); g_gdipToken = 0; }

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -329,7 +329,7 @@ struct InsertionCtx {
     IShellItemFilter *filter = nullptr;
     HWND forTree = nullptr; // scopes item to a specific tree; null = any
 };
-static InsertionCtx g_ins;
+static thread_local InsertionCtx g_ins;
 
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 LoadLibraryExW_t LoadLibraryExW_orig;
@@ -385,8 +385,8 @@ static TreeState* RunDeferredWorkIf(HWND hWnd, TreeState* ts, uint8_t flag,
     return ts;
 }
 
-static bool g_inCustomAppend = false;
-static HTREEITEM g_spacerInsertAfter = nullptr;
+static thread_local bool g_inCustomAppend = false;
+static thread_local HTREEITEM g_spacerInsertAfter = nullptr;
 
 struct InsertionScope {
     ComRef<INameSpaceTreeControl> pNsc;
@@ -2628,9 +2628,6 @@ void Wh_ModUninit()
     if (g_gdipToken) { Gdiplus::GdiplusShutdown(g_gdipToken); g_gdipToken = 0; }
     for (int i = 0; i < NAV_COUNT; i++)
         if (g_navItems[i].pidl) { CoTaskMemFree(g_navItems[i].pidl); g_navItems[i].pidl = nullptr; }
-    g_ins.pNsc = nullptr;
-    g_ins.enumFlags = 0;
-    if (g_ins.filter) { g_ins.filter->Release(); g_ins.filter = nullptr; }
     if (g_explorerFrameLoaded.load(std::memory_order_relaxed))
         Wh_Log(L"Mod uninitialized");
 }

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.13
+// @version         1.1.14
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -667,6 +667,8 @@ static int GetItemIntegral(HWND hTree, HTREEITEM h)
 
 static bool GetItemRect(HWND hTree, HTREEITEM h, RECT *rc)
 {
+    if (!SendMessageW(hTree, TVM_GETNEXTITEM, TVGN_FIRSTVISIBLE, 0))
+        return false;
     *(HTREEITEM *)rc = h;
     return SendMessageW(hTree, TVM_GETITEMRECT, FALSE, (LPARAM)rc) != 0;
 }
@@ -882,10 +884,11 @@ static void RestoreTree(HWND hTree)
     if (!ts || !IsWindow(hTree) || !ts->pNscTree)
         return;
 
-    ComRef<INameSpaceTreeControl> pNsc((INameSpaceTreeControl *)ts->pNscTree);
     void *pNscRaw = ts->pNscTree;
     unsigned long enumFlags = ts->enumFlags;
-    ComRef<IShellItemFilter> pFilter(ts->pFilter);
+    IShellItemFilter *pFilterRaw = ts->pFilter;
+    if (pFilterRaw)
+        pFilterRaw->AddRef();
     HIMAGELIST savedImgList = ts->savedStateImageList;
     bool ownsRef = ts->ownsNscRef;
 
@@ -899,7 +902,7 @@ static void RestoreTree(HWND hTree)
             if (SUCCEEDED(SHCreateItemFromIDList(g_navItems[spacerId].pidl,
                                                   IID_IShellItem, (void**)&raw)) && raw)
             {
-                pNsc->RemoveRoot(raw);
+                ((INameSpaceTreeControl *)pNscRaw)->RemoveRoot(raw);
                 raw->Release();
             }
         }
@@ -909,13 +912,17 @@ static void RestoreTree(HWND hTree)
     // Remove our roots
     RootShellItems roots;
     if (!roots.Create()) return;
-    roots.RemoveInsertableRoots(pNsc.get());
+    roots.RemoveInsertableRoots((INameSpaceTreeControl *)pNscRaw);
 
     if (roots.items[NAV_DESKTOP] && pNscRaw)
     {
+        roots.items[NAV_THISPC] = {};
+
+        g_ins.forTree = hTree;
         g_inCustomAppend = true;
-        AppendRoot_orig(pNscRaw, roots.items[NAV_DESKTOP].get(), enumFlags, 0x1, pFilter.get());
+        AppendRoot_orig(pNscRaw, roots.items[NAV_DESKTOP].get(), enumFlags, 0x1, pFilterRaw);
         g_inCustomAppend = false;
+        g_ins.forTree = nullptr;
 
         WCHAR collapseNames[NAV_COUNT][64] = {};
         int collapseCount = BuildMatchList(collapseNames, NAV_COUNT,
@@ -925,6 +932,9 @@ static void RestoreTree(HWND hTree)
         if (collapseCount > 0)
             CollapseMatchingItems(hTree, nullptr, collapseNames, collapseCount);
     }
+
+    if (pFilterRaw)
+        pFilterRaw->Release();
 
     RemoveWindowSubclass(hTree, TreeInteractionProc, 0xAF01);
 
@@ -949,7 +959,7 @@ static void RestoreTree(HWND hTree)
     }
 
     if (ownsRef)
-        pNsc.p->Release();
+        ((INameSpaceTreeControl *)pNscRaw)->Release();
 
     Wh_Log(L"[DISABLE] Cleaned up tree=%p", hTree);
 }
@@ -993,6 +1003,11 @@ static void FullRebuildTree(HWND hTree)
 
     if (roots.items[NAV_DESKTOP])
     {
+        roots.items[NAV_THISPC] = {};
+        roots.items[NAV_HOME] = {};
+        roots.items[NAV_GALLERY] = {};
+        pNsc = {};
+
         ts = GetTree(hTree);
         if (ts)
         {
@@ -1004,9 +1019,11 @@ static void FullRebuildTree(HWND hTree)
         g_ins.pNsc = pNscRaw;
         g_ins.enumFlags = enumFlags;
 
+        g_ins.forTree = hTree;
         g_inCustomAppend = true;
         AppendRoot_orig(pNscRaw, roots.items[NAV_DESKTOP].get(), enumFlags, 0x1, nullptr);
         g_inCustomAppend = false;
+        g_ins.forTree = nullptr;
 
         ts = GetTree(hTree);
         if (ts)
@@ -1833,8 +1850,11 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
         if (ts && (ts->pendingWork & DEFER_MASK))
             PostMessage(hWnd, WM_DEFERRED_REBUILD, 0, 0);
 
+        // Skip paint-time mutations when another tree is being rebuilt; items may be stale from cross-tree side effects.
+        bool safeForMutations = !(g_deferredOpInProgress && hWnd != g_mutatingTree);
+
         // Paint-time mutations must be idempotent (no-op when already in target state) to avoid relayout loops.
-        if (ts && g_settings.hasItemsAtTop)
+        if (safeForMutations && ts && g_settings.hasItemsAtTop)
         {
             for (int i = NAV_HOME; i < NAV_COUNT; i++)
             {
@@ -1855,7 +1875,7 @@ LRESULT CALLBACK SubClassTreeWndProc_hook(HWND hWnd, UINT uMsg, WPARAM wParam, L
             }
         }
 
-        if (g_settings.hasItemsAtTop && g_sepColor != CLR_INVALID && ts)
+        if (safeForMutations && g_settings.hasItemsAtTop && g_sepColor != CLR_INVALID && ts)
         {
             SectionLayout layout = FindSectionLayout(hWnd, *ts);
             ts->boundaryItem = layout.boundary;

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.2.0
+// @version         1.2.1
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -2245,7 +2245,27 @@ void LoadSettings()
     g_settings.hasItemsAtTop = false;
     for (int i = 0; i < NAV_COUNT; i++)
         if (g_settings.items[i].showAtTop) { g_settings.hasItemsAtTop = true; break; }
+}
 
+static void LogSettings()
+{
+    Wh_Log(L"Settings: thisPCAtTop=%d (expand=%d, startExp=%d, hideQA=%d) "
+            L"desktopAtTop=%d (above=%d, expand=%d, hideQA=%d) "
+            L"hideHome=%d hideGallery=%d fixChevron=%d chevronScale=%d "
+            L"hidePins=%d rmSepNav=%d rmSepQA=%d",
+            g_settings.items[NAV_THISPC].showAtTop,
+            g_settings.items[NAV_THISPC].expandable,
+            g_settings.items[NAV_THISPC].startExpanded,
+            g_settings.items[NAV_THISPC].hideFromQA,
+            g_settings.items[NAV_DESKTOP].showAtTop,
+            g_settings.desktopAboveThisPC,
+            g_settings.items[NAV_DESKTOP].expandable,
+            g_settings.items[NAV_DESKTOP].hideFromQA,
+            g_settings.items[NAV_HOME].hide,
+            g_settings.items[NAV_GALLERY].hide,
+            g_settings.fixChevronDrawing, g_settings.chevronScale,
+            g_settings.hidePinButtons,
+            g_settings.removeSepBelowNav, g_settings.removeSepBelowQA);
 }
 
 static bool InitializeModCore(HMODULE hExplorerFrame)
@@ -2273,8 +2293,6 @@ static bool InitializeModCore(HMODULE hExplorerFrame)
     }
 
     SHGetSpecialFolderLocation(nullptr, CSIDL_DESKTOP, &g_navItems[NAV_DESKTOP].pidl);
-    if (!g_navItems[NAV_DESKTOP].pidl)
-        Wh_Log(L"Warning: failed to get Desktop PIDL");
 
     SHParseDisplayName(L"::{f874310e-b6b7-47dc-bc84-b9e6b38f5903}",
                        nullptr, &g_navItems[NAV_HOME].pidl, 0, nullptr);
@@ -2503,8 +2521,6 @@ static BOOL CALLBACK EnumWindowsForTrees(HWND hTop, LPARAM lParam)
         IShellBrowser *pSB = (IShellBrowser *)SendMessageW(hTop, WM_USER + 7, 0, 0);
         if (pSB)
             DiscoverTreeFromBrowser(hTop, cls, pSB, out);
-        else
-            Wh_Log(L"[TREE] %s hwnd=%04X no IShellBrowser", cls, PTR4(hTop));
     }
     return TRUE;
 }
@@ -2549,6 +2565,9 @@ void Wh_ModAfterInit()
         PostMessage(d.hTree, WM_DEFERRED_REBUILD, 0, 0);
         Wh_Log(L"[ENABLE] window=%04X tree=%04X nsc=%04X", PTR4(d.hTop), PTR4(d.hTree), PTR4(d.pNsc));
     }
+
+    if (!discovered.empty())
+        LogSettings();
 }
 
 ChangeTier ClassifySettingsChange(const Settings& prev, const Settings& cur)
@@ -2631,6 +2650,7 @@ void Wh_ModSettingsChanged()
 
         auto prev = g_settings;
         LoadSettings();
+        LogSettings();
 
         ChangeTier tier = ClassifySettingsChange(prev, g_settings);
         if (tier == TIER_NONE)
@@ -2737,6 +2757,4 @@ void Wh_ModUninit()
     if (g_gdipToken) { Gdiplus::GdiplusShutdown(g_gdipToken); g_gdipToken = 0; }
     for (int i = 0; i < NAV_COUNT; i++)
         if (g_navItems[i].pidl) { CoTaskMemFree(g_navItems[i].pidl); g_navItems[i].pidl = nullptr; }
-    if (g_explorerFrameLoaded.load(std::memory_order_relaxed))
-        Wh_Log(L"Mod uninitialized");
 }

--- a/mods/add-virtual-folders-to-nav-top.wh.cpp
+++ b/mods/add-virtual-folders-to-nav-top.wh.cpp
@@ -2,7 +2,7 @@
 // @id              add-virtual-folders-to-nav-top
 // @name            Add This PC and Desktop to Nav Top
 // @description     Adds This PC and Desktop to the top of Explorer's nav
-// @version         1.1.11
+// @version         1.1.12
 // @author          Rod Boev
 // @github          https://github.com/rodboev
 // @include         *
@@ -912,22 +912,24 @@ static void RestoreTree(HWND hTree)
 
     // Remove our roots
     RootShellItems roots;
-    if (!roots.Create()) return;
-    roots.RemoveInsertableRoots(pNsc.get());
-
-    if (roots.items[NAV_DESKTOP] && pNscRaw)
+    if (roots.Create())
     {
-        g_inCustomAppend = true;
-        AppendRoot_orig(pNscRaw, roots.items[NAV_DESKTOP].get(), enumFlags, 0x1, pFilter.get());
-        g_inCustomAppend = false;
+        roots.RemoveInsertableRoots(pNsc.get());
 
-        WCHAR collapseNames[NAV_COUNT][64] = {};
-        int collapseCount = BuildMatchList(collapseNames, NAV_COUNT,
-            [](int id, const NavItemSettings&) {
-                return IsInsertableItem(id) && g_navItems[id].label[0];
-            });
-        if (collapseCount > 0)
-            CollapseMatchingItems(hTree, nullptr, collapseNames, collapseCount);
+        if (roots.items[NAV_DESKTOP] && pNscRaw)
+        {
+            g_inCustomAppend = true;
+            AppendRoot_orig(pNscRaw, roots.items[NAV_DESKTOP].get(), enumFlags, 0x1, pFilter.get());
+            g_inCustomAppend = false;
+
+            WCHAR collapseNames[NAV_COUNT][64] = {};
+            int collapseCount = BuildMatchList(collapseNames, NAV_COUNT,
+                [](int id, const NavItemSettings&) {
+                    return IsInsertableItem(id) && g_navItems[id].label[0];
+                });
+            if (collapseCount > 0)
+                CollapseMatchingItems(hTree, nullptr, collapseNames, collapseCount);
+        }
     }
 
     RemoveWindowSubclass(hTree, TreeInteractionProc, 0xAF01);
@@ -1035,6 +1037,7 @@ static void InsertHomeSpacer(HWND hTree)
     bool desktopAtBottom = ts->hItems[NAV_DESKTOP] &&
         (!ts->hItems[NAV_THISPC] || !g_settings.desktopAboveThisPC);
     if (!ts->pNscTree || !desktopAtBottom) return;
+    if (GetHiddenItem(*ts)) return;
 
     int spacerId = g_navItems[NAV_HOME].pidl ? NAV_HOME
                  : (g_navItems[NAV_GALLERY].pidl ? NAV_GALLERY : -1);


### PR DESCRIPTION
## Summary

This mod adds the Desktop namespace root and an expandable This PC entry to the top of Explorer's left nav.

Windows lets you pin folders to Quick Access, but the Desktop root (which contains Recycle Bin, Control Panel, etc.) can't be pinned. There is also no way to move the expandable This PC up; if it's pinned to Quick Access, it isn't expandable.

This mod adds one or both of these virtual folders in the top part of the nav, above Quick Access and before Home/Gallery.

## Options

- Whether each entry is expandable (This PC shows drives, for example)
- Whether This PC starts expanded when a window opens
- Ordering (Desktop above or below This PC)
- Hiding duplicate This PC/Desktop entries elsewhere in the nav pane
- Hiding native Home/Gallery entries (does not affect Quick Access)
- Removing separators individually
- Fixing clipped/pixelated chevrons

## Before/after

![](https://i.imgur.com/LZuqzMx.png)