### PR TITLE
Update Simple Window Switcher Mod

### DIFF
--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -1297,10 +1297,11 @@ static void ComputeLayout(HMONITOR hMon) {
                 curY = initialTop + masterPad;
                 curX = curX + curColMaxW + rightInc;
                 curColMaxW = 0;
-                if (curX + width + rightInc - initialLeft > maxW - masterPad) {
-                    truncateRemaining(idx);
-                    break;
-                }
+            }
+
+            if (curX + width + rightInc - initialLeft > maxW - masterPad && idx > 0) {
+                truncateRemaining(idx);
+                break;
             }
 
             w.rcCell.left   = curX - initialLeft + elemPadLeft;

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -209,7 +209,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
     - switcherDisplayBehavior: cursorMonitor
       $name: Switcher Display Behavior
       $options:
-      - primaryOnly: Show Switcher in Primary Monitor only
+      - primaryOnly: Primary Monitor Only
       - allMonitors: All Monitors
       - cursorMonitor: Monitor Based On Cursor Location
     - perMonitorWindows: false
@@ -223,7 +223,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
           - exe: Executable Name
         - Value: ""
           $name: Pattern
-          $description: "The pattern to exclude (regex supported). Separate multiple entries with a comma. Example: chrome\\.exe, msedge\\.exe"
+          $description: "The pattern to exclude (wildcards supported: * matches any characters, ? matches one). Separate multiple entries with a comma. Example: *chrome*, msedge.exe"
       $name: Excluded Windows
       $description: Exclude specific windows from appearing in the switcher.
     - virtualDesktopBehavior: currentOnly
@@ -240,7 +240,6 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 #include <windows.h>
 #include <dwmapi.h>
 #include <uxtheme.h>
-#include <vssym32.h>
 #include <shellapi.h>
 #include <shlobj.h>
 #include <shlwapi.h>
@@ -256,7 +255,6 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 #include <string>
 #include <algorithm>
 #include <gdiplus.h>
-#include <regex>
 
 #define SWS_CLASSNAME       L"WindhawkSWS_Switcher"
 #define SWS_ICON_SIZE       16
@@ -274,7 +272,6 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 #define SWS_ROW_TITLE_HEIGHT    30  // Height of icon+title row
 #define SWS_MAX_TILE_ASPECT     2.0 // Max thumbnail width = thumbH * this
 #define SWS_CONTOUR_SIZE        2
-#define SWS_HIGHLIGHT_SIZE      2
 #define SWS_HOTKEY_ALTTAB           1
 #define SWS_HOTKEY_ALTSHIFTTAB      2
 #define SWS_HOTKEY_ALTCTRLTAB       3
@@ -300,8 +297,8 @@ struct WINDOWCOMPOSITIONATTRIBDATA { DWORD dwAttrib; PVOID pvData; SIZE_T cbData
 typedef BOOL(WINAPI *SetWindowCompositionAttribute_t)(HWND, WINDOWCOMPOSITIONATTRIBDATA*);
 
 struct WindowEntry {
-    HWND hWnd; HICON hIcon; WCHAR title[256]; HTHUMBNAIL hThumb;
-    RECT rcCell; RECT rcThumb; RECT rcThumbActual; RECT rcThumbSlot;
+    HWND hWnd; HICON hIcon; WCHAR title[256]; std::map<HWND, HTHUMBNAIL> hThumbs;
+    RECT rcCell; RECT rcThumbActual; RECT rcThumbSlot;
     SIZE sourceSize;           // Raw DWM surface size
     RECT rcSourceCrop;         // Source crop rect for DWM_TNP_RECTSOURCE
     SIZE effectiveSourceSize;  // Source size after cropping invisible frame
@@ -326,8 +323,8 @@ struct Settings {
     bool centerTaskContent;
 };
 
-static std::vector<std::wregex> g_excludeTitleRegexes;
-static std::vector<std::wregex> g_excludeExeRegexes;
+static std::vector<std::wstring> g_excludeTitlePatterns;
+static std::vector<std::wstring> g_excludeExePatterns;
 static std::vector<HWND> g_hMirrorSwitchers;
 
 static HWND g_hSwitcher = NULL;
@@ -337,6 +334,7 @@ static bool g_showAllMonitors = false;
 static HHOOK g_hMouseHook = NULL;
 static std::vector<WindowEntry> g_windows;
 static int g_selectedIndex = 0, g_hoverIndex = -1;
+static HWND g_hoverWnd = NULL;
 static int g_layoutStartIndex = 0; // EP-style: first window index visible in the layout
 static bool g_isVisible = false, g_isSticky = false, g_isDarkMode = false;
 static HFONT g_hFont = NULL;
@@ -609,7 +607,8 @@ static BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) {
             } else return TRUE;
         } else return TRUE;
     }
-    if (g_settings.perMonitorWindows && !g_showAllMonitors && g_hCurrentMonitor) {
+    bool isPrimaryOnly = (wcscmp(g_settings.switcherDisplayBehavior, L"primaryOnly") == 0);
+    if (g_settings.perMonitorWindows && !g_showAllMonitors && g_hCurrentMonitor && !isPrimaryOnly) {
         if (MonitorFromWindow(hWnd, MONITOR_DEFAULTTONULL) != g_hCurrentMonitor) return TRUE;
     }
     WindowEntry e = {};
@@ -618,10 +617,10 @@ static BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) {
     if (!e.title[0]) GetWindowTextW(hWnd, e.title, 256);
     
     bool excluded = false;
-    for (const auto& rx : g_excludeTitleRegexes) {
-        if (std::regex_search(e.title, rx)) { excluded = true; break; }
+    for (const auto& pat : g_excludeTitlePatterns) {
+        if (PathMatchSpecW(e.title, pat.c_str())) { excluded = true; break; }
     }
-    if (!excluded && !g_excludeExeRegexes.empty()) {
+    if (!excluded && !g_excludeExePatterns.empty()) {
         DWORD pid = 0;
         GetWindowThreadProcessId(hWnd, &pid);
         if (pid) {
@@ -631,8 +630,8 @@ static BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) {
                 DWORD size = MAX_PATH;
                 if (QueryFullProcessImageNameW(hProc, 0, exePath, &size)) {
                     WCHAR* filename = PathFindFileNameW(exePath);
-                    for (const auto& rx : g_excludeExeRegexes) {
-                        if (std::regex_search(filename, rx)) { excluded = true; break; }
+                    for (const auto& pat : g_excludeExePatterns) {
+                        if (PathMatchSpecW(filename, pat.c_str())) { excluded = true; break; }
                     }
                 }
                 CloseHandle(hProc);
@@ -750,17 +749,7 @@ static HICON ResolveIconFromAumid(const WCHAR* aumid, int desiredSizePx) {
             }
         }
     }
-    // Additional fallback for Windows 10: try resolving from process executable
-    if (!hIcon) {
-        Wh_Log(L"ResolveIconFromAumid: Falling back to process exe icon");
-        // Attempt to parse AUMID for package family or exe; if not, try to find process owning the app
-        // A caller should pass a window handle context; as a best-effort here we try to locate any process
-        // associated with the AUMID by enumerating package family is complex; instead this fallback
-        // will be used by callers that have a HWND and can call TryGetUwpIconFromExplorer first. Here
-        // provide a helper-like attempt using shell APIs if possible.
-        // No-op in this function since we don't have HWND; real fallback is implemented where callers
-        // have HWND context (see TryGetUwpIconFromExplorer usage).
-    }
+
     return hIcon;
 }
 
@@ -967,9 +956,15 @@ static HICON TryGetUwpIconFromExplorer(HWND hWnd, int desiredSizePx) {
 }
 
 static void BuildWindowList() {
-    for (auto& w : g_windows) if (w.hThumb) { DwmUnregisterThumbnail(w.hThumb); w.hThumb = NULL; }
+    for (auto& w : g_windows) {
+        for (const auto& kv : w.hThumbs) { if (kv.second) DwmUnregisterThumbnail(kv.second); }
+        w.hThumbs.clear();
+    }
     g_windows.clear();
     EnumWindows(EnumWindowsProc, (LPARAM)&g_windows);
+    std::stable_sort(g_windows.begin(), g_windows.end(), [](const WindowEntry& a, const WindowEntry& b) {
+        return IsIconic(a.hWnd) < IsIconic(b.hWnd);
+    });
 }
 
 // Layout + Thumbnails
@@ -1008,43 +1003,56 @@ static HFONT CreateScaledFont(int dpiY) {
 static void RegisterThumbnailsEarly() {
     if (!g_settings.showThumbnails || !g_hSwitcher) return;
     for (auto& w : g_windows) {
-        if (!w.hThumb) {
-            if (SUCCEEDED(DwmRegisterThumbnail(g_hSwitcher, w.hWnd, &w.hThumb))) {
-                SIZE src = {0}; DwmQueryThumbnailSourceSize(w.hThumb, &src);
+        if (!w.hThumbs.count(g_hSwitcher)) {
+            HTHUMBNAIL hT = NULL;
+            if (SUCCEEDED(DwmRegisterThumbnail(g_hSwitcher, w.hWnd, &hT))) {
+                w.hThumbs[g_hSwitcher] = hT;
+                SIZE src = {0}; DwmQueryThumbnailSourceSize(hT, &src);
                 w.sourceSize = src;
+            }
+        }
+        for (HWND m : g_hMirrorSwitchers) {
+            if (!w.hThumbs.count(m)) {
+                HTHUMBNAIL hT = NULL;
+                if (SUCCEEDED(DwmRegisterThumbnail(m, w.hWnd, &hT))) w.hThumbs[m] = hT;
+            }
+        }
+        SIZE src = w.sourceSize;
 
-                // Compute invisible frame crop using DWMWA_EXTENDED_FRAME_BOUNDS
-                // This fixes thumbnail displacement for maximized windows where
-                // the window extends beyond screen edges to hide the frame.
-                // Skip for minimized windows: GetWindowRect/DWMWA_EXTENDED_FRAME_BOUNDS
-                // return garbage coords (-32000) for iconic windows, causing zoom.
-                // ONLY apply manual crop for maximized windows (IsZoomed). Non-maximized 
-                // windows are natively handled by DWM (preserves rounded corners perfectly).
-                if (!IsIconic(w.hWnd) && IsZoomed(w.hWnd)) {
-                    RECT wr = {0}, efb = {0};
-                    GetWindowRect(w.hWnd, &wr);
-                    if (SUCCEEDED(DwmGetWindowAttribute(w.hWnd, DWMWA_EXTENDED_FRAME_BOUNDS, &efb, sizeof(efb)))) {
-                        int wrW = wr.right - wr.left, wrH = wr.bottom - wr.top;
-                        if (wrW > 0 && wrH > 0 && src.cx > 0 && src.cy > 0) {
-                            double sx = (double)src.cx / wrW;
-                            double sy = (double)src.cy / wrH;
-                            int ml = (int)((efb.left - wr.left) * sx);
-                            int mt = (int)((efb.top - wr.top) * sy);
-                            int mr = (int)((wr.right - efb.right) * sx);
-                            int mb = (int)((wr.bottom - efb.bottom) * sy);
-                            if (ml < 0) ml = 0; if (mt < 0) mt = 0;
-                            if (mr < 0) mr = 0; if (mb < 0) mb = 0;
-                            w.rcSourceCrop = { ml, mt, src.cx - mr, src.cy - mb };
-                            w.effectiveSourceSize = { src.cx - ml - mr, src.cy - mt - mb };
-                            if (w.effectiveSourceSize.cx <= 0 || w.effectiveSourceSize.cy <= 0) {
-                                w.effectiveSourceSize = src;
-                                w.rcSourceCrop = { 0, 0, src.cx, src.cy };
-                            }
-                        } else {
-                            w.effectiveSourceSize = src;
-                            w.rcSourceCrop = { 0, 0, src.cx, src.cy };
-                        }
-                    } else {
+        // Compute invisible frame crop using DWMWA_EXTENDED_FRAME_BOUNDS.
+        // This fixes thumbnail displacement for maximized windows where
+        // the window extends beyond screen edges to hide the frame.
+        // Only apply for actively maximized windows (not minimized).
+        // Minimized windows use DWM's low-res cached thumbnail where
+        // frame borders are negligible; cropping them causes aspect ratio
+        // distortion that makes the thumbnail overflow its destination.
+        // Non-maximized windows are natively handled by DWM.
+        if (IsZoomed(w.hWnd) && !IsIconic(w.hWnd)) {
+            RECT wr = {0}, efb = {0};
+            GetWindowRect(w.hWnd, &wr);
+            if (SUCCEEDED(DwmGetWindowAttribute(w.hWnd, DWMWA_EXTENDED_FRAME_BOUNDS, &efb, sizeof(efb)))) {
+                int wrW = wr.right - wr.left, wrH = wr.bottom - wr.top;
+                int efbW = efb.right - efb.left, efbH = efb.bottom - efb.top;
+                if (wrW > 0 && wrH > 0 && efbW > 0 && efbH > 0 && src.cx > 0 && src.cy > 0) {
+                    int ml = 0, mt = 0, mr = 0, mb = 0;
+                    double diffEfb = ((double)src.cx / efbW) - ((double)src.cy / efbH);
+                    if (diffEfb < 0) diffEfb = -diffEfb;
+                    double diffWr = ((double)src.cx / wrW) - ((double)src.cy / wrH);
+                    if (diffWr < 0) diffWr = -diffWr;
+                    
+                    if (diffEfb >= diffWr) {
+                        double sx = (double)src.cx / wrW;
+                        double sy = (double)src.cy / wrH;
+                        ml = (int)((efb.left - wr.left) * sx);
+                        mt = (int)((efb.top - wr.top) * sy);
+                        mr = (int)((wr.right - efb.right) * sx);
+                        mb = (int)((wr.bottom - efb.bottom) * sy);
+                    }
+                    if (ml < 0) ml = 0; if (mt < 0) mt = 0;
+                    if (mr < 0) mr = 0; if (mb < 0) mb = 0;
+                    w.rcSourceCrop = { ml, mt, src.cx - mr, src.cy - mb };
+                    w.effectiveSourceSize = { src.cx - ml - mr, src.cy - mt - mb };
+                    if (w.effectiveSourceSize.cx <= 0 || w.effectiveSourceSize.cy <= 0) {
                         w.effectiveSourceSize = src;
                         w.rcSourceCrop = { 0, 0, src.cx, src.cy };
                     }
@@ -1053,10 +1061,12 @@ static void RegisterThumbnailsEarly() {
                     w.rcSourceCrop = { 0, 0, src.cx, src.cy };
                 }
             } else {
-                w.sourceSize = {0, 0};
-                w.effectiveSourceSize = {0, 0};
-                w.rcSourceCrop = {0, 0, 0, 0};
+                w.effectiveSourceSize = src;
+                w.rcSourceCrop = { 0, 0, src.cx, src.cy };
             }
+        } else {
+            w.effectiveSourceSize = src;
+            w.rcSourceCrop = { 0, 0, src.cx, src.cy };
         }
     }
 }
@@ -1151,12 +1161,11 @@ static void ComputeLayout(HMONITOR hMon) {
             g_windows[ji].sourceSize = {0, 0};
             g_windows[ji].rcCell = {0, 0, 0, 0};
             g_windows[ji].rcThumbActual = {0, 0, 0, 0};
-            g_windows[ji].rcThumb = {0, 0, 0, 0};
             g_windows[ji].rcThumbSlot = {0, 0, 0, 0};
-            if (g_windows[ji].hThumb) {
-                DwmUnregisterThumbnail(g_windows[ji].hThumb);
-                g_windows[ji].hThumb = NULL;
+            for (const auto& kv : g_windows[ji].hThumbs) {
+                if (kv.second) DwmUnregisterThumbnail(kv.second);
             }
+            g_windows[ji].hThumbs.clear();
         }
         placedCount = startIdx;
     };
@@ -1296,7 +1305,6 @@ static void ComputeLayout(HMONITOR hMon) {
                     thumbX += (width - thumbWidth) / 2;
                 }
                 w.rcThumbActual = { thumbX, thumbY, thumbX + thumbWidth, thumbY + actualThumbH };
-                w.rcThumb = w.rcThumbActual;
                 w.rcThumbSlot = { slotX, thumbY, slotX + slotW, thumbY + actualThumbH };
             }
 
@@ -1327,8 +1335,6 @@ static void ComputeLayout(HMONITOR hMon) {
                     g_windows[j].rcCell.right += diff;
                     g_windows[j].rcThumbActual.left += diff;
                     g_windows[j].rcThumbActual.right += diff;
-                    g_windows[j].rcThumb.left += diff;
-                    g_windows[j].rcThumb.right += diff;
                     g_windows[j].rcThumbSlot.left += diff;
                     g_windows[j].rcThumbSlot.right += diff;
                 }
@@ -1468,7 +1474,6 @@ static void ComputeLayout(HMONITOR hMon) {
                     thumbX += (width - thumbWidth) / 2;
                 }
                 w.rcThumbActual = { thumbX, thumbY, thumbX + thumbWidth, thumbY + actualThumbH };
-                w.rcThumb = w.rcThumbActual;
                 w.rcThumbSlot = { slotX, thumbY, slotX + slotW, thumbY + actualThumbH };
             }
 
@@ -1505,8 +1510,6 @@ static void ComputeLayout(HMONITOR hMon) {
                     g_windows[j].rcCell.bottom += diff;
                     g_windows[j].rcThumbActual.top += diff;
                     g_windows[j].rcThumbActual.bottom += diff;
-                    g_windows[j].rcThumb.top += diff;
-                    g_windows[j].rcThumb.bottom += diff;
                     g_windows[j].rcThumbSlot.top += diff;
                     g_windows[j].rcThumbSlot.bottom += diff;
                 }
@@ -1520,13 +1523,24 @@ static void ComputeLayout(HMONITOR hMon) {
 static void RegisterThumbnails() {
     if (!g_settings.showThumbnails || !g_hSwitcher) return;
     for (auto& w : g_windows) {
-        if (!w.hThumb) {
-            if (SUCCEEDED(DwmRegisterThumbnail(g_hSwitcher, w.hWnd, &w.hThumb))) {
-                SIZE src = {0}; DwmQueryThumbnailSourceSize(w.hThumb, &src);
+        if (!w.hThumbs.count(g_hSwitcher)) {
+            HTHUMBNAIL hT = NULL;
+            if (SUCCEEDED(DwmRegisterThumbnail(g_hSwitcher, w.hWnd, &hT))) {
+                w.hThumbs[g_hSwitcher] = hT;
+                SIZE src = {0}; DwmQueryThumbnailSourceSize(hT, &src);
                 w.sourceSize = src;
             }
         }
-        if (w.hThumb) {
+        for (HWND m : g_hMirrorSwitchers) {
+            if (!w.hThumbs.count(m)) {
+                HTHUMBNAIL hT = NULL;
+                if (SUCCEEDED(DwmRegisterThumbnail(m, w.hWnd, &hT))) w.hThumbs[m] = hT;
+            }
+        }
+        
+        for (const auto& kv : w.hThumbs) {
+            HTHUMBNAIL hThumb = kv.second;
+            if (!hThumb) continue;
             // Skip truncated windows with zero destination rect
             if (w.rcThumbActual.left == 0 && w.rcThumbActual.right == 0 &&
                 w.rcThumbActual.top == 0 && w.rcThumbActual.bottom == 0) continue;
@@ -1544,12 +1558,17 @@ static void RegisterThumbnails() {
                 p.dwFlags |= DWM_TNP_RECTSOURCE;
                 p.rcSource = w.rcSourceCrop;
             }
-            DwmUpdateThumbnailProperties(w.hThumb, &p);
+            DwmUpdateThumbnailProperties(hThumb, &p);
         }
     }
 }
 static void UnregisterThumbnails() {
-    for (auto& w : g_windows) if (w.hThumb) { DwmUnregisterThumbnail(w.hThumb); w.hThumb = NULL; }
+    for (auto& w : g_windows) {
+        for (const auto& kv : w.hThumbs) {
+            if (kv.second) DwmUnregisterThumbnail(kv.second);
+        }
+        w.hThumbs.clear();
+    }
 }
 
 
@@ -1627,18 +1646,12 @@ static void MaskRectCorners(HDC hdc, const RECT& rc, int radiusPx) {
     graphics.FillPath(&brush, &cutBl);
 }
 
-// Draw a sharp rectangular contour using StretchDIBits (EP's _DrawContour approach)
+// Draw a rectangular contour around a rect.
 // direction: 1 = inner (shrinks inward), -1 = outer (grows outward)
+// Uses GDI+ rounded path for inner contours when cornerRadius > 0, FrameRect otherwise.
 static void DrawContour(HDC hdc, RECT rc, int contourSize, int direction) {
     COLORREF c = GetContourColor();
     BYTE r = GetRValue(c), g = GetGValue(c), b = GetBValue(c);
-    BITMAPINFO bi = {};
-    bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-    bi.bmiHeader.biWidth = 1; bi.bmiHeader.biHeight = 1;
-    bi.bmiHeader.biPlanes = 1; bi.bmiHeader.biBitCount = 32; bi.bmiHeader.biCompression = BI_RGB;
-    RGBQUAD px = { b, g, r, 0xFF };
-
-    int t = direction * (contourSize * g_dpiX / 96);
 
     int cornerRadius = GetTaskUiCornerRadiusPx();
     if (cornerRadius > 0 && direction > 0) {
@@ -1674,19 +1687,25 @@ static void DrawContour(HDC hdc, RECT rc, int contourSize, int direction) {
         return;
     }
 
+    HBRUSH hBrush = CreateSolidBrush(RGB(r, g, b));
     if (direction < 0) {
-        // Outer contour (EP: SWS_CONTOUR_OUTER)
-        StretchDIBits(hdc, rc.left + t, rc.top, -t, rc.bottom - rc.top, 0, 0, 1, 1, &px, &bi, DIB_RGB_COLORS, SRCCOPY);
-        StretchDIBits(hdc, rc.right, rc.top, -t, rc.bottom - rc.top, 0, 0, 1, 1, &px, &bi, DIB_RGB_COLORS, SRCCOPY);
-        StretchDIBits(hdc, rc.left + t, rc.top + t, (rc.right - rc.left) - t * 2, -t, 0, 0, 1, 1, &px, &bi, DIB_RGB_COLORS, SRCCOPY);
-        StretchDIBits(hdc, rc.left + t, rc.bottom, (rc.right - rc.left) - t * 2, -t, 0, 0, 1, 1, &px, &bi, DIB_RGB_COLORS, SRCCOPY);
+        // Outer contour: DWM composites thumbnails on top of GDI and renders
+        // inclusively at rcDestination's right/bottom edges. Inflate by i+2
+        // so FrameRect's border pixels land 1px beyond DWM's last column/row.
+        for (int i = 0; i < contourSize; i++) {
+            RECT r_rect = rc;
+            InflateRect(&r_rect, i + 2, i + 2);
+            FrameRect(hdc, &r_rect, hBrush);
+        }
     } else {
-        // Inner contour (EP: SWS_CONTOUR_INNER)
-        StretchDIBits(hdc, rc.left, rc.top, t, rc.bottom - rc.top, 0, 0, 1, 1, &px, &bi, DIB_RGB_COLORS, SRCCOPY);
-        StretchDIBits(hdc, rc.right - t, rc.top, t, rc.bottom - rc.top, 0, 0, 1, 1, &px, &bi, DIB_RGB_COLORS, SRCCOPY);
-        StretchDIBits(hdc, rc.left, rc.top, rc.right - rc.left, t, 0, 0, 1, 1, &px, &bi, DIB_RGB_COLORS, SRCCOPY);
-        StretchDIBits(hdc, rc.left, rc.bottom - t, rc.right - rc.left, t, 0, 0, 1, 1, &px, &bi, DIB_RGB_COLORS, SRCCOPY);
+        // Inner contour
+        for (int i = 0; i < contourSize; i++) {
+            RECT r_rect = rc;
+            InflateRect(&r_rect, -i, -i);
+            FrameRect(hdc, &r_rect, hBrush);
+        }
     }
+    DeleteObject(hBrush);
 }
 
 static void DrawSelectionFill(HDC hdc, RECT rc) {
@@ -1793,7 +1812,7 @@ static int GetHeaderTopForEntry(const WindowEntry& e) {
 }
 
 // Shared drawing routine for both layered and buffered paint paths
-static void DrawSwitcherContent(HDC hdc, bool fillBg) {
+static void DrawSwitcherContent(HDC hdc, bool fillBg, HWND hWnd) {
     RECT rcClient; GetClientRect(g_hSwitcher, &rcClient);
     int w = rcClient.right, h = rcClient.bottom;
 
@@ -1836,7 +1855,7 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
         }
 
         // Hover thumbnail border: outer contour on rcThumbActual (EP draws both independently)
-        if (i == g_hoverIndex && g_settings.showThumbnails) {
+        if (i == g_hoverIndex && g_hoverWnd == hWnd && g_settings.showThumbnails) {
             DrawContour(hdc, e.rcThumbActual, 1, -1);
         }
 
@@ -1854,7 +1873,7 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
         bool isIconOnly = !g_settings.showThumbnails && !g_settings.showTitle && g_settings.showIcon;
         if (!HeaderIsVertical()) {
             if (!isIconOnly && !(g_settings.showThumbnails && ThumbnailIsSide())) {
-                btnReserve = ((g_settings.centerTaskContent) || i == g_hoverIndex)
+                btnReserve = ((g_settings.centerTaskContent) || (i == g_hoverIndex && g_hoverWnd == hWnd))
                          ? closeBtnReserve
                          : 0;
             }
@@ -1941,7 +1960,7 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
 
 static bool IsWindowTruncated(int idx);
 
-static void DrawSwitcherOverlay(HDC hdc) {
+static void DrawSwitcherOverlay(HDC hdc, HWND hWnd) {
     if (g_windows.empty()) return;
 
     int rowTitleH = GetHeaderRowHeightPx();
@@ -1952,7 +1971,7 @@ static void DrawSwitcherOverlay(HDC hdc) {
         if (IsWindowTruncated(i)) continue;
 
         // Close button (positioned at top-right of the cell, in title area)
-        if (i == g_hoverIndex) {
+        if (i == g_hoverIndex && g_hoverWnd == hWnd) {
             int btnSz = DpiScale(24, g_dpiX);
             int bx, by;
             if (rowTitleH == 0 || (g_settings.showThumbnails && ThumbnailIsSide())) {
@@ -2044,7 +2063,7 @@ static void PaintSwitcherOverlay() {
     HBITMAP hBmp = CreateDIBSection(hdcMem, &bmi, DIB_RGB_COLORS, &bits, NULL, 0);
     HBITMAP hOld = (HBITMAP)SelectObject(hdcMem, hBmp);
 
-    DrawSwitcherOverlay(hdcMem);
+    DrawSwitcherOverlay(hdcMem, g_hSwitcher);
 
     POINT ptSrc = {0,0}; SIZE sz = {w, h};
     BLENDFUNCTION bf = {AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
@@ -2068,12 +2087,13 @@ static void PaintSwitcher() {
         void* bits = NULL;
         HBITMAP hBmp = CreateDIBSection(hdcMem, &bmi, DIB_RGB_COLORS, &bits, NULL, 0);
         HBITMAP hOld = (HBITMAP)SelectObject(hdcMem, hBmp);
-        DrawSwitcherContent(hdcMem, true);
+        DrawSwitcherContent(hdcMem, true, g_hSwitcher);
         POINT ptSrc = {0,0}; SIZE sz = {w, h};
         BLENDFUNCTION bf = {AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
         UpdateLayeredWindow(g_hSwitcher, hdcScreen, NULL, &sz, hdcMem, &ptSrc, 0, &bf, ULW_ALPHA);
         for (HWND hMirror : g_hMirrorSwitchers) {
             if (IsWindow(hMirror)) {
+                DrawSwitcherContent(hdcMem, true, hMirror);
                 HDC hdcMirrorScreen = GetDC(hMirror);
                 UpdateLayeredWindow(hMirror, hdcMirrorScreen, NULL, &sz, hdcMem, &ptSrc, 0, &bf, ULW_ALPHA);
                 ReleaseDC(hMirror, hdcMirrorScreen);
@@ -2192,14 +2212,28 @@ static void ApplyThemeToWindow(HWND hWnd) {
         BOOL dark = g_isDarkMode;
         DwmSetWindowAttribute(hWnd, 20, &dark, sizeof(dark));
         if (ThemeIs(L"mica")) {
-            int micaVal = 2; // DWMSBT_MAINWINDOW
-            HRESULT hr = DwmSetWindowAttribute(hWnd, 38, &micaVal, sizeof(micaVal));
-            if (FAILED(hr) && ThemeIs(L"mica")) {
-                int oldMicaVal = 1;
-                hr = DwmSetWindowAttribute(hWnd, 1029, &oldMicaVal, sizeof(oldMicaVal));
-            }
-            if (FAILED(hr)) {
-                SetWindowLongPtrW(hWnd, GWL_EXSTYLE, GetWindowLongPtrW(hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
+            if (hWnd == g_hSwitcher) {
+                // Native Mica for the primary active window
+                int micaVal = 2; // DWMSBT_MAINWINDOW
+                HRESULT hr = DwmSetWindowAttribute(hWnd, 38, &micaVal, sizeof(micaVal));
+                if (FAILED(hr)) {
+                    int oldMicaVal = 1;
+                    hr = DwmSetWindowAttribute(hWnd, 1029, &oldMicaVal, sizeof(oldMicaVal));
+                }
+                if (FAILED(hr)) {
+                    SetWindowLongPtrW(hWnd, GWL_EXSTYLE, GetWindowLongPtrW(hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
+                }
+            } else if (g_SetWindowCompositionAttribute) {
+                // Unfocused mirror windows drop to solid grey with native Mica.
+                // We use SetWindowCompositionAttribute (Acrylic Blur) to force a translucent effect.
+                DWORD blur = 200; // Fixed opacity (~78%) to closely simulate Mica blur
+                COLORREF bg = g_isDarkMode ? SWS_BG_DARK : SWS_BG_LIGHT;
+                ACCENT_POLICY accent = {};
+                accent.AccentState = 4 /* ACCENT_ENABLE_ACRYLICBLURBEHIND */;
+                accent.AccentFlags = 0;
+                accent.GradientColor = (blur << 24) | (bg & 0x00FFFFFF);
+                WINDOWCOMPOSITIONATTRIBDATA data = {19, &accent, sizeof(accent)};
+                g_SetWindowCompositionAttribute(hWnd, &data);
             }
         }
         if (ThemeIs(L"backdrop") && g_SetWindowCompositionAttribute) {
@@ -2224,7 +2258,7 @@ static BOOL WINAPI MirrorEnumProc(HMONITOR hM, HDC, LPRECT, LPARAM) {
         GetMonitorInfoW(hM, &mInfo);
         int mx = (mInfo.rcWork.left + mInfo.rcWork.right - g_winW) / 2;
         int my = (mInfo.rcWork.top + mInfo.rcWork.bottom - g_winH) / 2;
-        HWND hMirror = CreateWindowExW(WS_EX_TOOLWINDOW | WS_EX_TOPMOST, SWS_CLASSNAME, L"", WS_POPUP, mx, my, g_winW, g_winH, NULL, NULL, GetModuleHandle(NULL), NULL);
+        HWND hMirror = CreateWindowExW(WS_EX_TOOLWINDOW | WS_EX_TOPMOST, SWS_CLASSNAME, L"", WS_POPUP | WS_THICKFRAME | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, mx, my, g_winW, g_winH, g_hSwitcher, NULL, GetModuleHandle(NULL), NULL);
         if (hMirror) {
             ApplyThemeToWindow(hMirror);
             g_hMirrorSwitchers.push_back(hMirror);
@@ -2250,6 +2284,7 @@ static void ShowSwitcher(bool sticky) {
     g_layoutStartIndex = 0; // Always start from the first window on initial show
     g_selectedIndex = (g_windows.size() > 1) ? 1 : 0;
     g_hoverIndex = -1;
+    g_hoverWnd = NULL;
     g_isCloseHovered = false;
 
     RegisterThumbnailsEarly();
@@ -2578,7 +2613,7 @@ static int HitTest(int x, int y) {
 static int HitTestThumb(int x, int y) {
     if (!g_settings.showThumbnails) return -1;
     for (int i = 0; i < (int)g_windows.size(); i++) {
-        RECT r = g_windows[i].rcThumb;
+        RECT r = g_windows[i].rcThumbActual;
         if (x >= r.left && x < r.right && y >= r.top && y < r.bottom) return i;
     }
     return -1;
@@ -2592,6 +2627,10 @@ static void SWS_RegisterHotkeys();
 static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
     if (uMsg == WM_NCCALCSIZE && wParam == TRUE) {
         return 0; // Remove standard frame for WS_OVERLAPPED
+    }
+    if (uMsg == WM_NCACTIVATE) {
+        // Force DWM to keep the active visual state (Mica/Backdrop) even when unfocused
+        return DefWindowProcW(hWnd, uMsg, TRUE, lParam);
     }
 
     if (uMsg == WM_TIMER) {
@@ -2683,7 +2722,7 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
         HDC hdcBuf = NULL;
         HPAINTBUFFER hBP = BeginBufferedPaint(hdc, &rc, BPBF_TOPDOWNDIB, &params, &hdcBuf);
         if (hBP) {
-            DrawSwitcherContent(hdcBuf, false);
+            DrawSwitcherContent(hdcBuf, false, hWnd);
             // Do NOT call BufferedPaintSetAlpha here — it would force all pixels
             // to opaque (alpha=255), blocking the acrylic blur from showing through.
             // BPPF_ERASE already cleared the buffer to RGBA(0,0,0,0) = transparent.
@@ -2840,6 +2879,7 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
         
         if (idx != g_hoverIndex || closeHovered != g_isCloseHovered) {
             g_hoverIndex = idx;
+            g_hoverWnd = hWnd;
             g_isCloseHovered = closeHovered;
             PaintSwitcher();
         }
@@ -2868,6 +2908,7 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
                     }
                     RegisterThumbnails();
                     g_hoverIndex = -1;
+                    g_hoverWnd = NULL;
                     g_isCloseHovered = false;
                     PaintSwitcher();
                 }
@@ -3077,8 +3118,8 @@ static void LoadSettings() {
     v = Wh_GetStringSetting(L"Miscellaneous.switcherDisplayBehavior");
     wcscpy_s(g_settings.switcherDisplayBehavior, v ? v : L"cursorMonitor"); Wh_FreeStringSetting(v);
 
-    g_excludeTitleRegexes.clear();
-    g_excludeExeRegexes.clear();
+    g_excludeTitlePatterns.clear();
+    g_excludeExePatterns.clear();
     for (int i = 0; ; i++) {
         PCWSTR method = Wh_GetStringSetting(L"Miscellaneous.ExcludedWindows[%d].Method", i);
         bool done = !method || !*method;
@@ -3104,9 +3145,9 @@ static void LoadSettings() {
                     token = token.substr(0, last + 1);
                     
                     if (wcscmp(method, L"title") == 0) {
-                        try { g_excludeTitleRegexes.push_back(std::wregex(token)); } catch (...) {}
+                        g_excludeTitlePatterns.push_back(token);
                     } else if (wcscmp(method, L"exe") == 0) {
-                        try { g_excludeExeRegexes.push_back(std::wregex(token)); } catch (...) {}
+                        g_excludeExePatterns.push_back(token);
                     }
                 }
                 start = end + 1;
@@ -3161,9 +3202,9 @@ static DWORD WINAPI SwitcherThread(LPVOID lpParam) {
     wc.style = CS_DBLCLKS;
     RegisterClassExW(&wc);
 
-    // Use WS_OVERLAPPED instead of WS_POPUP. Windows 11 DWM (Mica/Acrylic) has
-    // much better support for standard top-level windows. We remove the frame via WM_NCCALCSIZE.
-    DWORD dwStyle = WS_OVERLAPPED | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
+    // Use WS_POPUP | WS_THICKFRAME to get DWM rounded corners and shadows, 
+    // without the system caption buttons. We remove the frame via WM_NCCALCSIZE.
+    DWORD dwStyle = WS_POPUP | WS_THICKFRAME | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
     DWORD exStyle = WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_LAYERED;
     g_hSwitcher = CreateWindowExW(exStyle, SWS_CLASSNAME, L"",
         dwStyle, 0, 0, 0, 0, NULL, NULL, GetModuleHandleW(NULL), NULL);

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -2533,10 +2533,9 @@ static void DrawSwitcherOverlay(HDC hdc, HWND hWnd) {
             }
 
             // Draw X with GDI+ for smooth diagonal lines only.
-            // Always white, regardless of the (custom/accent) border color.
             Gdiplus::Graphics graphics(hdc);
             graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-            COLORREF xc = RGB(255, 255, 255);
+            COLORREF xc = (g_isCloseHovered || g_isDarkMode) ? RGB(255, 255, 255) : RGB(0, 0, 0);
             Gdiplus::Pen xPen(Gdiplus::Color(255, GetRValue(xc), GetGValue(xc), GetBValue(xc)), 1.5f * g_dpiX / 96.0f);
             int p = (btnSz == DpiScale(16, g_dpiX)) ? DpiScale(4, g_dpiX) : DpiScale(7, g_dpiX);
             graphics.DrawLine(&xPen, bx + p, by + p, bx + btnSz - p, by + btnSz - p);
@@ -2547,10 +2546,11 @@ static void DrawSwitcherOverlay(HDC hdc, HWND hWnd) {
 
 static void PaintSwitcherOverlay() {
     if (!g_hCloseBtnWnd || !g_isVisible) return;
-    RECT rc; GetClientRect(g_hSwitcher, &rc);
+    HWND targetWnd = g_hoverWnd ? g_hoverWnd : g_hSwitcher;
+    RECT rc; GetClientRect(targetWnd, &rc);
     int w = rc.right, h = rc.bottom;
     if (w <= 0 || h <= 0) return;
-    HDC hdcScreen = GetDC(g_hCloseBtnWnd);
+    HDC hdcScreen = GetDC(NULL);
     HDC hdcMem = CreateCompatibleDC(hdcScreen);
     BITMAPINFO bmi = {}; bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
     bmi.bmiHeader.biWidth = w; bmi.bmiHeader.biHeight = -h;
@@ -2569,15 +2569,27 @@ static void PaintSwitcherOverlay() {
         HRGN hClip = CreateRoundRectRgn(0, 0, w + 1, h + 1, radius * 2, radius * 2);
         SelectClipRgn(hdcMem, hClip);
         DeleteObject(hClip);
+    } else if (cp == 2) {
+        int radius = MulDiv(8, g_dpiX, 96);
+        HRGN hClip = CreateRoundRectRgn(0, 0, w + 1, h + 1, radius * 2, radius * 2);
+        SelectClipRgn(hdcMem, hClip);
+        DeleteObject(hClip);
+    } else if (cp == 3) {
+        int radius = MulDiv(4, g_dpiX, 96);
+        HRGN hClip = CreateRoundRectRgn(0, 0, w + 1, h + 1, radius * 2, radius * 2);
+        SelectClipRgn(hdcMem, hClip);
+        DeleteObject(hClip);
     }
 
-    DrawSwitcherOverlay(hdcMem, g_hSwitcher);
+    DrawSwitcherOverlay(hdcMem, targetWnd);
 
     POINT ptSrc = {0,0}; SIZE sz = {w, h};
+    RECT wr; GetWindowRect(targetWnd, &wr);
+    POINT ptDst = { wr.left, wr.top };
     BLENDFUNCTION bf = {AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
-    UpdateLayeredWindow(g_hCloseBtnWnd, hdcScreen, NULL, &sz, hdcMem, &ptSrc, 0, &bf, ULW_ALPHA);
+    UpdateLayeredWindow(g_hCloseBtnWnd, hdcScreen, &ptDst, &sz, hdcMem, &ptSrc, 0, &bf, ULW_ALPHA);
     SelectObject(hdcMem, hOld); DeleteObject(hBmp); DeleteDC(hdcMem);
-    ReleaseDC(g_hCloseBtnWnd, hdcScreen);
+    ReleaseDC(NULL, hdcScreen);
 }
 
 static void PaintSwitcher() {
@@ -2720,29 +2732,17 @@ static void ApplyThemeToWindow(HWND hWnd) {
         BOOL dark = g_isDarkMode;
         DwmSetWindowAttribute(hWnd, 20, &dark, sizeof(dark));
         if (ThemeIs(L"mica")) {
-            if (hWnd == g_hSwitcher) {
-                // Native Mica for the primary active window
-                int micaVal = 2; // DWMSBT_MAINWINDOW
-                HRESULT hr = DwmSetWindowAttribute(hWnd, 38, &micaVal, sizeof(micaVal));
-                if (FAILED(hr)) {
-                    int oldMicaVal = 1;
-                    hr = DwmSetWindowAttribute(hWnd, 1029, &oldMicaVal, sizeof(oldMicaVal));
-                }
-                if (FAILED(hr)) {
-                    SetWindowLongPtrW(hWnd, GWL_EXSTYLE, GetWindowLongPtrW(hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
-                }
-            } else if (g_SetWindowCompositionAttribute) {
-                // Unfocused mirror windows drop to solid grey with native Mica.
-                // We use SetWindowCompositionAttribute (Acrylic Blur) to force a translucent effect.
-                DWORD blur = 200; // Fixed opacity (~78%) to closely simulate Mica blur
-                COLORREF bg = GetBgColor();
-                ACCENT_POLICY accent = {};
-                accent.AccentState = 4 /* ACCENT_ENABLE_ACRYLICBLURBEHIND */;
-                accent.AccentFlags = 0;
-                accent.GradientColor = (blur << 24) | (bg & 0x00FFFFFF);
-                WINDOWCOMPOSITIONATTRIBDATA data = {19, &accent, sizeof(accent)};
-                g_SetWindowCompositionAttribute(hWnd, &data);
+            int micaVal = 2; // DWMSBT_MAINWINDOW
+            HRESULT hr = DwmSetWindowAttribute(hWnd, 38, &micaVal, sizeof(micaVal));
+            if (FAILED(hr)) {
+                int oldMicaVal = 1;
+                hr = DwmSetWindowAttribute(hWnd, 1029, &oldMicaVal, sizeof(oldMicaVal));
             }
+            if (FAILED(hr)) {
+                SetWindowLongPtrW(hWnd, GWL_EXSTYLE, GetWindowLongPtrW(hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
+            }
+            // Force the window to evaluate its NCACTIVATE state so Mica stays active
+            SendMessage(hWnd, WM_NCACTIVATE, TRUE, 0);
         }
         if (ThemeIs(L"backdrop") && g_SetWindowCompositionAttribute) {
             DWORD blur = (DWORD)((g_settings.opacity / 100.0) * 255);
@@ -2786,6 +2786,7 @@ static BOOL WINAPI MirrorEnumProc(HMONITOR hM, HDC, LPRECT, LPARAM) {
             g_hMirrorSwitchers.push_back(hMirror);
             SetWindowPos(hMirror, HWND_TOPMOST, mx, my, g_winW, g_winH, SWP_NOACTIVATE);
             ShowWindow(hMirror, SW_SHOWNA);
+            SetActiveWindow(hMirror);
         }
     }
     return TRUE;
@@ -2865,15 +2866,16 @@ static void ShowSwitcher(bool sticky) {
 
     SetWindowPos(g_hSwitcher, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
     ShowWindow(g_hSwitcher, SW_SHOWNA);
-    SetForegroundWindow(g_hSwitcher);
+    if (wcscmp(g_settings.switcherDisplayBehavior, L"allMonitors") == 0 || g_showAllMonitors) {
+        EnumDisplayMonitors(NULL, NULL, MirrorEnumProc, 0);
+    }
+    
     if (g_hCloseBtnWnd) {
         SetWindowPos(g_hCloseBtnWnd, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
         ShowWindow(g_hCloseBtnWnd, SW_SHOWNA);
     }
 
-    if (wcscmp(g_settings.switcherDisplayBehavior, L"allMonitors") == 0 || g_showAllMonitors) {
-        EnumDisplayMonitors(NULL, NULL, MirrorEnumProc, 0);
-    }
+    SetForegroundWindow(g_hSwitcher);
 
     RegisterThumbnails();
     PaintSwitcher();
@@ -3259,6 +3261,15 @@ static void CloseSwitcherEntry(int idx) {
     PaintSwitcher();
 }
 
+static bool IsSwitcherWindow(HWND hWnd) {
+    if (!hWnd) return false;
+    if (hWnd == g_hSwitcher) return true;
+    for (HWND h : g_hMirrorSwitchers) {
+        if (hWnd == h) return true;
+    }
+    return false;
+}
+
 static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
     if (uMsg == WM_NCCALCSIZE && wParam == TRUE) {
         return 0; // Remove standard frame for WS_OVERLAPPED
@@ -3532,7 +3543,7 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
             }
         }
         
-        if (idx != g_hoverIndex || closeHovered != g_isCloseHovered) {
+        if (idx != g_hoverIndex || closeHovered != g_isCloseHovered || g_hoverWnd != hWnd) {
             g_hoverIndex = idx;
             g_hoverWnd = hWnd;
             g_isCloseHovered = closeHovered;
@@ -3564,10 +3575,22 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
         return 0;
     }
     case WM_ACTIVATE:
-        if (wParam == WA_INACTIVE && g_isVisible) { HideSwitcher(); return 0; }
+        if (wParam == WA_INACTIVE && g_isVisible) {
+            HWND hNewActive = (HWND)lParam;
+            if (!IsSwitcherWindow(hNewActive)) {
+                HideSwitcher();
+            }
+            return 0;
+        }
         break;
     case WM_KILLFOCUS:
-        if (g_isVisible) { HideSwitcher(); return 0; }
+        if (g_isVisible) {
+            HWND hNewFocus = (HWND)wParam;
+            if (!IsSwitcherWindow(hNewFocus)) {
+                HideSwitcher();
+            }
+            return 0;
+        }
         break;
     case WM_ERASEBKGND: return 1;
     case WM_DESTROY: UnregisterThumbnails(); return 0;

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -589,6 +589,17 @@ static HICON ResolveIconFromAumid(const WCHAR* aumid, int desiredSizePx) {
             }
         }
     }
+    // Additional fallback for Windows 10: try resolving from process executable
+    if (!hIcon) {
+        Wh_Log(L"ResolveIconFromAumid: Falling back to process exe icon");
+        // Attempt to parse AUMID for package family or exe; if not, try to find process owning the app
+        // A caller should pass a window handle context; as a best-effort here we try to locate any process
+        // associated with the AUMID by enumerating package family is complex; instead this fallback
+        // will be used by callers that have a HWND and can call TryGetUwpIconFromExplorer first. Here
+        // provide a helper-like attempt using shell APIs if possible.
+        // No-op in this function since we don't have HWND; real fallback is implemented where callers
+        // have HWND context (see TryGetUwpIconFromExplorer usage).
+    }
     return hIcon;
 }
 
@@ -642,6 +653,47 @@ LRESULT CALLBACK ExplorerIpcWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM 
                     CloseHandle(hProc);
                 } else {
                     Wh_Log(L"Explorer IPC: OpenProcess failed, err=%u", GetLastError());
+                }
+            }
+            // If still no AUMID (common on Win10), try to get the process executable and return its icon
+            if (aumid.empty() && pid) {
+                // First try window/class icons via WM_GETICON / GetClassLongPtr — sometimes available on Win10
+                HICON hWinIcon = NULL;
+                HICON hTmp = (HICON)SendMessageW(hCore, WM_GETICON, ICON_BIG, 0);
+                if (!hTmp) hTmp = (HICON)SendMessageW(hCore, WM_GETICON, ICON_SMALL, 0);
+                if (!hTmp) hTmp = (HICON)SendMessageW(hCore, WM_GETICON, ICON_SMALL2, 0);
+                if (hTmp) hWinIcon = hTmp;
+                if (!hWinIcon) {
+                    HICON hClassIcon = (HICON)GetClassLongPtrW(hCore, GCLP_HICON);
+                    if (!hClassIcon) hClassIcon = (HICON)GetClassLongPtrW(hCore, GCLP_HICONSM);
+                    if (hClassIcon) hWinIcon = hClassIcon;
+                }
+                if (hWinIcon) {
+                    Wh_Log(L"Explorer IPC: Returning WM_GETICON/GetClassLongPtr icon %p as Win10 fallback", hWinIcon);
+                    g_uwpIconCache[L"wm_icon_" + std::to_wstring((uintptr_t)hWinIcon) + L"_" + std::to_wstring(desiredSizePx)] = hWinIcon;
+                    return (LRESULT)hWinIcon;
+                }
+
+                WCHAR exePath[MAX_PATH] = {0};
+                HANDLE hProc2 = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ, FALSE, pid);
+                if (hProc2) {
+                    DWORD size = MAX_PATH;
+                    if (QueryFullProcessImageNameW(hProc2, 0, exePath, &size)) {
+                        Wh_Log(L"Explorer IPC: Fallback exe path = %s", exePath);
+                        SHFILEINFOW sfi = {};
+                        UINT flags = SHGFI_ICON | SHGFI_USEFILEATTRIBUTES | (desiredSizePx > 24 ? SHGFI_LARGEICON : SHGFI_SMALLICON);
+                        if (SHGetFileInfoW(exePath, FILE_ATTRIBUTE_NORMAL, &sfi, sizeof(sfi), flags)) {
+                            if (sfi.hIcon) {
+                                Wh_Log(L"Explorer IPC: Returning exe icon %p as Win10 fallback", sfi.hIcon);
+                                g_uwpIconCache[std::wstring(exePath) + L"_" + std::to_wstring(desiredSizePx)] = sfi.hIcon;
+                                CloseHandle(hProc2);
+                                return (LRESULT)sfi.hIcon;
+                            }
+                        }
+                    } else {
+                        Wh_Log(L"Explorer IPC: QueryFullProcessImageNameW failed, err=%u", GetLastError());
+                    }
+                    CloseHandle(hProc2);
                 }
             }
         }
@@ -702,7 +754,51 @@ static HICON TryGetUwpIconFromExplorer(HWND hWnd, int desiredSizePx) {
         DWORD_PTR res = 0;
         LRESULT sendRes = SendMessageTimeoutW(hIpc, g_WM_SWS_GET_UWP_ICON, (WPARAM)hWnd, desiredSizePx, SMTO_ABORTIFHUNG | SMTO_BLOCK, 1000, &res);
         Wh_Log(L"TryGetUwpIconFromExplorer: SendMessageTimeoutW to %p returned %ld, res = %p", hIpc, sendRes, res);
-        return (HICON)res;
+        if (res) {
+            // On Windows 11 explorer returns usable icon handles via IPC in our environment.
+            // Avoid attempting local AUMID->icon resolution on Win11 to preserve that behavior.
+            auto IsWindows11OrGreater = []() -> bool {
+                DWORD build = 0; DWORD sz = sizeof(build);
+                if (RegGetValueW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", L"CurrentBuildNumber", RRF_RT_REG_SZ, NULL, NULL, &sz) == ERROR_SUCCESS) {
+                    // Read as string
+                    std::wstring buf; buf.resize(sz/2);
+                    if (RegGetValueW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", L"CurrentBuildNumber", RRF_RT_REG_SZ, NULL, &buf[0], &sz) == ERROR_SUCCESS) {
+                        int buildNum = _wtoi(buf.c_str());
+                        return buildNum >= 22000;
+                    }
+                }
+                return false;
+            };
+            if (IsWindows11OrGreater()) {
+                return (HICON)res;
+            }
+            // We got an icon handle from Explorer, but HICON handles are process-local —
+            // prefer resolving the AUMID locally and creating an icon in this process.
+            // Try to get the AUMID locally using SHGetPropertyStoreForWindow; if available,
+            // create a local icon via ResolveIconFromAumid and return it.
+            std::wstring aumidLocal;
+            IPropertyStore* ps = NULL;
+            if (SUCCEEDED(SHGetPropertyStoreForWindow(hWnd, IID_PPV_ARGS(&ps))) && ps) {
+                PROPVARIANT pv; PropVariantInit(&pv);
+                if (SUCCEEDED(ps->GetValue(PKEY_AppUserModel_ID, &pv)) && pv.vt == VT_LPWSTR && pv.pwszVal && pv.pwszVal[0]) {
+                    aumidLocal = pv.pwszVal;
+                    Wh_Log(L"TryGetUwpIconFromExplorer: Got AUMID locally = %s", aumidLocal.c_str());
+                }
+                PropVariantClear(&pv);
+                ps->Release();
+            }
+            if (!aumidLocal.empty()) {
+                HICON hLocal = ResolveIconFromAumid(aumidLocal.c_str(), desiredSizePx);
+                if (hLocal) {
+                    Wh_Log(L"TryGetUwpIconFromExplorer: Resolved local icon %p from AUMID", hLocal);
+                    return hLocal;
+                }
+                Wh_Log(L"TryGetUwpIconFromExplorer: Local ResolveIconFromAumid failed for %s", aumidLocal.c_str());
+            }
+            // As a last resort, return the handle from explorer (may not be valid across processes)
+            return (HICON)res;
+        }
+        return NULL;
     } else {
         Wh_Log(L"TryGetUwpIconFromExplorer: WindhawkSWS_IpcWindow not found");
     }

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -74,17 +74,17 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       - system: Follow system setting
       - light: Light
       - dark: Dark
+    - highlightStyle: border
+      $name: Task Highlight Style
+      $description: Style used for the selected task row/tile. Applies to both light and dark themes.
+      $options:
+      - border: Border only
+      - fillAndBorder: Background fill and border
+      - fillOnly: Background fill only
+    - opacity: 100
+      $name: Background Opacity
+      $description: Background opacity percentage (0-100), applies to None and Acrylic themes for both light and dark themes. Set value to '80' for Acrylic to see the effect.
     - DarkMode:
-        - highlightStyle: border
-          $name: Task Highlight Style
-          $description: Style used for the selected task row/tile.
-          $options:
-          - border: Border only
-          - fillAndBorder: Background fill and border
-          - fillOnly: Background fill only
-        - opacity: 100
-          $name: Background Opacity
-          $description: Background opacity percentage (0-100), applies to None and Acrylic themes. Set value to '80' for Acrylic to see the effect.
         - borderColorMode: default
           $name: Border Color
           $description: Color source for the selected/hovered task border in dark mode.
@@ -117,16 +117,6 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
           $description: HEX color value, used when Switcher Background Color is set to Custom.
       $name: Dark Mode
     - LightMode:
-        - highlightStyle: border
-          $name: Task Highlight Style
-          $description: Style used for the selected task row/tile.
-          $options:
-          - border: Border only
-          - fillAndBorder: Background fill and border
-          - fillOnly: Background fill only
-        - opacity: 100
-          $name: Background Opacity
-          $description: Background opacity percentage (0-100), applies to None and Acrylic themes. Set value to '80' for Acrylic to see the effect.
         - borderColorMode: default
           $name: Border Color
           $description: Color source for the selected/hovered task border in light mode.
@@ -280,6 +270,9 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
     - stretchThumbnailsToTaskWidth: true
       $name: Stretch Thumbnails to Task Width
       $description: When enabled, custom row width also changes thumbnail width. Disable to keep thumbnail aspect sizing while row width controls only task tile width.
+    - autoFitTasks: false
+      $name: Shrink Tasks to Fit
+      $description: Automatically shrink task tiles (thumbnails and icons) in discrete steps as the number of visible windows grows, so more tasks stay visible without being pushed off-screen. Your Row Height and Icon Size act as the maximum size.
   $name: Dimensions
 - Grouping:
     - showApplications: false
@@ -339,6 +332,15 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       $description: "Executable name patterns to exclude, separated by ';' (wildcards supported: * matches any characters, ? matches one). Example: notepad.exe;chrome.exe"
   $name: Excluded Windows
   $description: Exclude specific windows from appearing in the switcher.
+- customIcons:
+  - - process: ""
+      $name: Process Name
+      $description: "Executable name to match (wildcards supported: * matches any characters, ? matches one). Example: chrome.exe or *code.exe"
+    - iconPath: ""
+      $name: Icon Path
+      $description: "Full path to an icon source (.ico, .exe or .dll); the first icon in the file is used. Example: C:\\Icons\\myapp.ico"
+  $name: Custom Icons
+  $description: Assign custom icons to tasks based on their executable name. The first matching rule wins.
 
 */
 // ==/WindhawkModSettings==
@@ -365,6 +367,9 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 
 #define SWS_CLASSNAME       L"WindhawkSWS_Switcher"
 #define SWS_ICON_SIZE       16
+// Lower bound (pre-DPI px) for the auto-fit "Shrink tasks to fit" row height so
+// thumbnails never collapse to an unusable size.
+#define SWS_AUTOFIT_MIN_ROWHEIGHT 90
 // EP-style nested padding layers (before DPI scaling)
 #define SWS_MASTER_PADDING      20  // Outer margin of the entire switcher window
 #define SWS_ELEMENT_PAD_TOP     5   // Vertical margin between cell border and content
@@ -414,12 +419,12 @@ struct WindowEntry {
 struct Settings {
     WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32]; WCHAR thumbnailPosition[32]; WCHAR thumbnailAlignment[32]; WCHAR switcherDisplayBehavior[32];
     WCHAR virtualDesktopBehavior[32];
+    // Global theme settings (apply to both light and dark)
+    WCHAR highlightStyle[32]; int opacity;
     // Dark Mode color settings
-    WCHAR highlightStyleDark[32]; int opacityDark;
     WCHAR borderColorModeDark[16]; WCHAR highlightFillColorModeDark[16]; WCHAR bgColorModeDark[16];
     WCHAR customBorderColorDark[16]; WCHAR customHighlightFillColorDark[16]; WCHAR customBgColorDark[16];
     // Light Mode color settings
-    WCHAR highlightStyleLight[32]; int opacityLight;
     WCHAR borderColorModeLight[16]; WCHAR highlightFillColorModeLight[16]; WCHAR bgColorModeLight[16];
     WCHAR customBorderColorLight[16]; WCHAR customHighlightFillColorLight[16]; WCHAR customBgColorLight[16];
     WCHAR fontFamily[64]; WCHAR fontStyle[32];
@@ -431,6 +436,7 @@ struct Settings {
     bool showTitle;
     bool showIcon;
     int maxWidthPercent;
+    bool autoFitTasks;
     int maxHeightPercent; int showDelay;
     bool perMonitorWindows; bool taskRoundedCorners; bool reverseScrollDirection;
     bool centerTaskContent;
@@ -468,6 +474,10 @@ static HFONT g_hFont = NULL;
 static HTHEME g_hTheme = NULL;
 static UINT g_shellHookMsg = 0;
 static int g_dpiX = 96, g_dpiY = 96;
+// Auto-fit ("Shrink tasks to fit") scale percentage applied to row/thumbnail
+// height and icon size. 100 = no shrink. Recomputed in ComputeLayout from the
+// visible task count when the setting is enabled.
+static int g_autoFitScalePct = 100;
 static int g_winW = 0, g_winH = 0;
 static bool g_hotkeysRegistered = false;
 static HMONITOR g_hCurrentMonitor = NULL;
@@ -498,7 +508,7 @@ static bool IconSizeIs(const WCHAR* v) { return wcscmp(g_settings.iconSize, v) =
 static bool BackwardShortcutIs(const WCHAR* v) { return wcscmp(g_settings.backwardShortcut, v) == 0; }
 static bool ThumbnailPositionIs(const WCHAR* v) { return wcscmp(g_settings.thumbnailPosition, v) == 0; }
 static bool HighlightStyleIs(const WCHAR* v) {
-    return wcscmp(g_isDarkMode ? g_settings.highlightStyleDark : g_settings.highlightStyleLight, v) == 0;
+    return wcscmp(g_settings.highlightStyle, v) == 0;
 }
 static bool UseAltShiftTabBackward() { return BackwardShortcutIs(L"altShiftTab"); }
 static bool UseAltShiftBackward() { return BackwardShortcutIs(L"altShift"); }
@@ -529,8 +539,28 @@ static int GetHeaderIconSizeBase() {
     if (IconSizeIs(L"medium")) return 32;
     return SWS_ICON_SIZE;
 }
+// Discrete shrink steps for the "Shrink tasks to fit" option, keyed off the
+// number of visible tasks. Coarse but predictable; tune thresholds freely.
+static int ComputeAutoFitScalePct(int taskCount) {
+    if (!g_settings.autoFitTasks) return 100;
+    if (taskCount <= 8)  return 100;
+    if (taskCount <= 14) return 80;
+    if (taskCount <= 22) return 65;
+    if (taskCount <= 32) return 50;
+    return 40;
+}
+// Apply the current auto-fit scale to a pixel value (no-op when not shrinking).
+static int ScaleAutoFit(int px) {
+    return g_autoFitScalePct == 100 ? px : px * g_autoFitScalePct / 100;
+}
 static int GetHeaderIconSizePx() {
-    return MulDiv(GetHeaderIconSizeBase(), g_dpiX, 96);
+    int px = MulDiv(GetHeaderIconSizeBase(), g_dpiX, 96);
+    if (g_autoFitScalePct != 100) {
+        px = ScaleAutoFit(px);
+        int floorPx = MulDiv(SWS_ICON_SIZE, g_dpiX, 96);
+        if (px < floorPx) px = floorPx;
+    }
+    return px;
 }
 static int GetHeaderTitleHeightPx() {
     return MulDiv(18, g_dpiY, 96);
@@ -786,8 +816,58 @@ static HICON TryGetCrispExeIcon(HWND hWnd, int desiredSizePx) {
     return NULL;
 }
 
-static HICON LoadWindowIcon(HWND hWnd) {
+// === Custom per-process icons ===
+
+struct CustomIconRule {
+    std::wstring pattern;   // executable name pattern; wildcards * and ? supported
+    std::wstring iconPath;  // .ico / .exe / .dll to extract the icon from
+};
+static std::vector<CustomIconRule> g_customIcons;
+// Owned cache of icons loaded from custom paths; keyed by "<path>_<sizePx>".
+static std::map<std::wstring, HICON> g_customIconCache;
+
+static HICON LoadCustomIconFromPath(const std::wstring& path, int sizePx) {
+    if (path.empty() || sizePx <= 0) return NULL;
+    std::wstring key = path + L"_" + std::to_wstring(sizePx);
+    auto it = g_customIconCache.find(key);
+    if (it != g_customIconCache.end()) return it->second;
     HICON hIcon = NULL;
+    if (PrivateExtractIconsW(path.c_str(), 0, sizePx, sizePx,
+                             &hIcon, NULL, 1, 0) == 1 && hIcon) {
+        g_customIconCache[key] = hIcon;
+        return hIcon;
+    }
+    return NULL;
+}
+
+// If the window's executable name matches a user-defined rule, return its
+// custom icon. The first matching rule wins; this overrides all other sources.
+static HICON TryGetCustomIcon(HWND hWnd, int sizePx) {
+    if (g_customIcons.empty()) return NULL;
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hWnd, &pid);
+    if (!pid) return NULL;
+    HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (!hProc) return NULL;
+    WCHAR exePath[MAX_PATH] = {0};
+    DWORD size = MAX_PATH;
+    BOOL ok = QueryFullProcessImageNameW(hProc, 0, exePath, &size);
+    CloseHandle(hProc);
+    if (!ok || !exePath[0]) return NULL;
+    WCHAR* fileName = PathFindFileNameW(exePath);
+    for (const auto& rule : g_customIcons) {
+        if (PathMatchSpecW(fileName, rule.pattern.c_str())) {
+            HICON h = LoadCustomIconFromPath(rule.iconPath, sizePx);
+            if (h) return h;
+        }
+    }
+    return NULL;
+}
+
+static HICON LoadWindowIcon(HWND hWnd) {
+    // User-assigned custom icon takes priority over everything else.
+    HICON hIcon = TryGetCustomIcon(hWnd, GetHeaderIconSizePx());
+    if (hIcon) return hIcon;
     if (g_IsShellFrameWindow && g_IsShellFrameWindow(hWnd)) {
         hIcon = TryGetUwpIconFromExplorer(hWnd, GetHeaderIconSizePx());
     }
@@ -1400,6 +1480,11 @@ static void ComputeLayout(HMONITOR hMon) {
     int n = (int)g_windows.size();
     if (n == 0) { g_winW = 0; g_winH = 0; return; }
 
+    // "Shrink tasks to fit": pick a discrete scale from the task count. Must be
+    // set before any GetHeaderIconSizePx()/GetHeaderRowHeightPx() call below so
+    // icon and row sizes pick it up.
+    g_autoFitScalePct = ComputeAutoFitScalePct(n);
+
     // DPI-scale all EP padding constants
     int masterPad    = DpiScale(SWS_MASTER_PADDING, dpiX);
     int elemPadTop   = DpiScale(SWS_ELEMENT_PAD_TOP, dpiY);
@@ -1416,6 +1501,11 @@ static void ComputeLayout(HMONITOR hMon) {
     // EP: cbThumbnailAvailableHeight = cbRowHeight - cbRowTitleHeight - cbTopPadding - 2 * cbBottomPadding
     // All values are DPI-scaled at this point (matching EP lines 826-844)
     int scaledRowH = DpiScale(g_settings.rowHeight, dpiY);
+    if (g_autoFitScalePct != 100) {
+        scaledRowH = ScaleAutoFit(scaledRowH);
+        int floorH = DpiScale(SWS_AUTOFIT_MIN_ROWHEIGHT, dpiY);
+        if (scaledRowH < floorH) scaledRowH = floorH;
+    }
     bool sidePlacement = ThumbnailIsSide() && g_settings.showThumbnails;
     int thumbH = 0;
     if (g_settings.showThumbnails) {
@@ -1423,7 +1513,7 @@ static void ComputeLayout(HMONITOR hMon) {
         if (thumbH < 0) thumbH = 0;
     }
     // EP: cbMaxTileWidth = cbRowHeight * MAX_TILE_WIDTH (computed before DPI, then scaled)
-    int maxTileW = DpiScale((int)(g_settings.rowHeight * SWS_MAX_TILE_ASPECT), dpiX);
+    int maxTileW = ScaleAutoFit(DpiScale((int)(g_settings.rowHeight * SWS_MAX_TILE_ASPECT), dpiX));
 
     // EP helper equivalents:
     // initialLeft  = elemPadLeft + padLeft
@@ -1522,7 +1612,7 @@ static void ComputeLayout(HMONITOR hMon) {
 
                 width = thumbWidth;
                 if (g_settings.rowWidth > 0) {
-                    width = DpiScale(g_settings.rowWidth, dpiX);
+                    width = ScaleAutoFit(DpiScale(g_settings.rowWidth, dpiX));
                     if (StretchThumbsToTaskWidth() && !sidePlacement) {
                         thumbWidth = sidePlacement ? std::max(0, width - ((rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0)) : width;
                         if (thumbWidth <= 0) thumbWidth = DpiScale(16, dpiX);
@@ -1560,7 +1650,7 @@ static void ComputeLayout(HMONITOR hMon) {
             }
 
             if (!g_settings.showThumbnails && g_settings.rowWidth > 0) {
-                width = DpiScale(g_settings.rowWidth, dpiX);
+                width = ScaleAutoFit(DpiScale(g_settings.rowWidth, dpiX));
                 thumbWidth = width;
             }
 
@@ -1695,7 +1785,7 @@ static void ComputeLayout(HMONITOR hMon) {
 
                 width = thumbWidth;
                 if (g_settings.rowWidth > 0) {
-                    width = DpiScale(g_settings.rowWidth, dpiX);
+                    width = ScaleAutoFit(DpiScale(g_settings.rowWidth, dpiX));
                     if (StretchThumbsToTaskWidth() && !sidePlacement) {
                         thumbWidth = sidePlacement ? std::max(0, width - ((rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0)) : width;
                         if (thumbWidth <= 0) thumbWidth = DpiScale(16, dpiX);
@@ -1730,7 +1820,7 @@ static void ComputeLayout(HMONITOR hMon) {
             }
 
             if (!g_settings.showThumbnails && g_settings.rowWidth > 0) {
-                width = DpiScale(g_settings.rowWidth, dpiX);
+                width = ScaleAutoFit(DpiScale(g_settings.rowWidth, dpiX));
                 thumbWidth = width;
             }
 
@@ -2172,7 +2262,7 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg, HWND hWnd) {
     int w = rcClient.right, h = rcClient.bottom;
 
     if (fillBg) {
-        BYTE bgA = (BYTE)((g_isDarkMode ? g_settings.opacityDark : g_settings.opacityLight) * 255 / 100);
+        BYTE bgA = (BYTE)(g_settings.opacity * 255 / 100);
         if (bgA == 0) bgA = 1; // Prevent full transparency click-through
         COLORREF bgC = GetBgColor();
         BYTE bgR = GetRValue(bgC), bgG = GetGValue(bgC), bgB = GetBValue(bgC);
@@ -2408,10 +2498,11 @@ static void DrawSwitcherOverlay(HDC hdc, HWND hWnd) {
                 }
             }
 
-            // Draw X with GDI+ for smooth diagonal lines only
+            // Draw X with GDI+ for smooth diagonal lines only.
+            // Always white, regardless of the (custom/accent) border color.
             Gdiplus::Graphics graphics(hdc);
             graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
-            COLORREF xc = g_isCloseHovered ? RGB(255, 255, 255) : GetContourColor();
+            COLORREF xc = RGB(255, 255, 255);
             Gdiplus::Pen xPen(Gdiplus::Color(255, GetRValue(xc), GetGValue(xc), GetBValue(xc)), 1.5f * g_dpiX / 96.0f);
             int p = (btnSz == DpiScale(16, g_dpiX)) ? DpiScale(4, g_dpiX) : DpiScale(7, g_dpiX);
             graphics.DrawLine(&xPen, bx + p, by + p, bx + btnSz - p, by + btnSz - p);
@@ -2620,7 +2711,7 @@ static void ApplyThemeToWindow(HWND hWnd) {
             }
         }
         if (ThemeIs(L"backdrop") && g_SetWindowCompositionAttribute) {
-            DWORD blur = (DWORD)(((g_isDarkMode ? g_settings.opacityDark : g_settings.opacityLight) / 100.0) * 255);
+            DWORD blur = (DWORD)((g_settings.opacity / 100.0) * 255);
             COLORREF bg = GetBgColor();
             ACCENT_POLICY accent = {};
             accent.AccentState = 4 /* ACCENT_ENABLE_ACRYLICBLURBEHIND */;
@@ -3107,6 +3198,33 @@ static int HitTestThumb(int x, int y) {
 
 static void SWS_RegisterHotkeys();
 
+// Close the window for the entry at idx (graceful WM_CLOSE, same as the close
+// button), remove it from the list and relayout. Shared by the close button,
+// middle-click and the Q key.
+static void CloseSwitcherEntry(int idx) {
+    if (idx < 0 || idx >= (int)g_windows.size()) return;
+    PostMessage(g_windows[idx].hWnd, WM_CLOSE, 0, 0);
+    g_windows.erase(g_windows.begin() + idx);
+    if (g_windows.empty()) { HideSwitcher(); return; }
+    if (g_selectedIndex >= (int)g_windows.size()) g_selectedIndex = (int)g_windows.size() - 1;
+    UnregisterThumbnails();
+    RegisterThumbnailsEarly();
+    ComputeLayout(g_hCurrentMonitor);
+    // Resize and re-center the window to match new layout
+    MONITORINFO rmi = { sizeof(rmi) }; GetMonitorInfoW(g_hCurrentMonitor, &rmi);
+    int cx, cy;
+    GetSwitcherPosition(rmi.rcWork, &cx, &cy);
+    SetWindowPos(g_hSwitcher, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
+    if (g_hCloseBtnWnd) {
+        SetWindowPos(g_hCloseBtnWnd, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
+    }
+    RegisterThumbnails();
+    g_hoverIndex = -1;
+    g_hoverWnd = NULL;
+    g_isCloseHovered = false;
+    PaintSwitcher();
+}
+
 static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
     if (uMsg == WM_NCCALCSIZE && wParam == TRUE) {
         return 0; // Remove standard frame for WS_OVERLAPPED
@@ -3302,6 +3420,11 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
                 return 0;
             }
             if (wParam == VK_RETURN || wParam == VK_SPACE) { SwitchToSelected(); return 0; }
+            if (wParam == 'Q') {
+                bool isRepeat = (lParam & 0x40000000) != 0;
+                if (!isRepeat) CloseSwitcherEntry(g_selectedIndex);
+                return 0;
+            }
         }
         break;
     // (Removed duplicate combined case for WM_SYSKEYUP and WM_KEYUP)
@@ -3388,32 +3511,21 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
         int idx = HitTest(x, y);
         if (idx >= 0) {
             if (g_isCloseHovered && idx == g_hoverIndex) {
-                PostMessage(g_windows[idx].hWnd, WM_CLOSE, 0, 0);
-                g_windows.erase(g_windows.begin() + idx);
-                if (g_windows.empty()) { HideSwitcher(); }
-                else {
-                    if (g_selectedIndex >= (int)g_windows.size()) g_selectedIndex = (int)g_windows.size() - 1;
-                    UnregisterThumbnails();
-                    RegisterThumbnailsEarly();
-                    ComputeLayout(g_hCurrentMonitor);
-                    // Resize and re-center the window to match new layout
-                    MONITORINFO rmi = { sizeof(rmi) }; GetMonitorInfoW(g_hCurrentMonitor, &rmi);
-                    int cx, cy;
-                    GetSwitcherPosition(rmi.rcWork, &cx, &cy);
-                    SetWindowPos(g_hSwitcher, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
-                    if (g_hCloseBtnWnd) {
-                        SetWindowPos(g_hCloseBtnWnd, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
-                    }
-                    RegisterThumbnails();
-                    g_hoverIndex = -1;
-                    g_hoverWnd = NULL;
-                    g_isCloseHovered = false;
-                    PaintSwitcher();
-                }
+                CloseSwitcherEntry(idx);
             } else {
-                g_selectedIndex = idx; 
+                g_selectedIndex = idx;
                 SwitchToSelected();
             }
+        }
+        return 0;
+    }
+    case WM_MBUTTONUP: {
+        // Middle-click ends (closes) the task under the cursor.
+        if (g_isVisible) {
+            int x = GET_X_LPARAM(lParam), y = GET_Y_LPARAM(lParam);
+            int idx = g_settings.showThumbnails ? HitTestThumb(x, y) : HitTest(x, y);
+            if (idx < 0) idx = HitTest(x, y);
+            if (idx >= 0) CloseSwitcherEntry(idx);
         }
         return 0;
     }
@@ -3582,6 +3694,7 @@ static void LoadSettings() {
     g_settings.rowWidth = Wh_GetIntSetting(L"Dimensions.rowWidth");
     if (g_settings.rowWidth < 0) g_settings.rowWidth = 0;
     g_settings.stretchThumbnailsToTaskWidth = Wh_GetIntSetting(L"Dimensions.stretchThumbnailsToTaskWidth");
+    g_settings.autoFitTasks = Wh_GetIntSetting(L"Dimensions.autoFitTasks");
     g_settings.showThumbnails = Wh_GetIntSetting(L"Appearance.Thumbnails.showThumbnails");
     g_settings.showHoverBorder = Wh_GetIntSetting(L"Appearance.Thumbnails.showHoverBorder");
     g_settings.showTitle = Wh_GetIntSetting(L"Appearance.HeaderContent.showTitle");
@@ -3610,18 +3723,19 @@ static void LoadSettings() {
     g_settings.centerTaskContent = Wh_GetIntSetting(L"Appearance.HeaderContent.centerTaskContent");
 
 
-    // Dark Mode color settings
-    v = Wh_GetStringSetting(L"Style.DarkMode.highlightStyle");
-    wcscpy_s(g_settings.highlightStyleDark, v ? v : L"border"); Wh_FreeStringSetting(v);
-    if (wcscmp(g_settings.highlightStyleDark, L"border") != 0 &&
-        wcscmp(g_settings.highlightStyleDark, L"fillAndBorder") != 0 &&
-        wcscmp(g_settings.highlightStyleDark, L"fillOnly") != 0) {
-        wcscpy_s(g_settings.highlightStyleDark, L"border");
+    // Global theme settings (apply to both light and dark)
+    v = Wh_GetStringSetting(L"Style.highlightStyle");
+    wcscpy_s(g_settings.highlightStyle, v ? v : L"border"); Wh_FreeStringSetting(v);
+    if (wcscmp(g_settings.highlightStyle, L"border") != 0 &&
+        wcscmp(g_settings.highlightStyle, L"fillAndBorder") != 0 &&
+        wcscmp(g_settings.highlightStyle, L"fillOnly") != 0) {
+        wcscpy_s(g_settings.highlightStyle, L"border");
     }
-    g_settings.opacityDark = Wh_GetIntSetting(L"Style.DarkMode.opacity");
-    if (g_settings.opacityDark < 0) g_settings.opacityDark = 0;
-    if (g_settings.opacityDark > 100) g_settings.opacityDark = 100;
+    g_settings.opacity = Wh_GetIntSetting(L"Style.opacity");
+    if (g_settings.opacity < 0) g_settings.opacity = 0;
+    if (g_settings.opacity > 100) g_settings.opacity = 100;
 
+    // Dark Mode color settings
     v = Wh_GetStringSetting(L"Style.DarkMode.borderColorMode");
     wcscpy_s(g_settings.borderColorModeDark, v ? v : L"default"); Wh_FreeStringSetting(v);
     v = Wh_GetStringSetting(L"Style.DarkMode.highlightFillColorMode");
@@ -3636,17 +3750,6 @@ static void LoadSettings() {
     wcscpy_s(g_settings.customBgColorDark, v ? v : L"#202020"); Wh_FreeStringSetting(v);
 
     // Light Mode color settings
-    v = Wh_GetStringSetting(L"Style.LightMode.highlightStyle");
-    wcscpy_s(g_settings.highlightStyleLight, v ? v : L"border"); Wh_FreeStringSetting(v);
-    if (wcscmp(g_settings.highlightStyleLight, L"border") != 0 &&
-        wcscmp(g_settings.highlightStyleLight, L"fillAndBorder") != 0 &&
-        wcscmp(g_settings.highlightStyleLight, L"fillOnly") != 0) {
-        wcscpy_s(g_settings.highlightStyleLight, L"border");
-    }
-    g_settings.opacityLight = Wh_GetIntSetting(L"Style.LightMode.opacity");
-    if (g_settings.opacityLight < 0) g_settings.opacityLight = 0;
-    if (g_settings.opacityLight > 100) g_settings.opacityLight = 100;
-
     v = Wh_GetStringSetting(L"Style.LightMode.borderColorMode");
     wcscpy_s(g_settings.borderColorModeLight, v ? v : L"default"); Wh_FreeStringSetting(v);
     v = Wh_GetStringSetting(L"Style.LightMode.highlightFillColorMode");
@@ -3715,6 +3818,30 @@ static void LoadSettings() {
         }
     }
     if (v) Wh_FreeStringSetting(v);
+
+    // Custom per-process icons (array of { process, iconPath }).
+    g_customIcons.clear();
+    auto trimWs = [](std::wstring s) -> std::wstring {
+        size_t a = s.find_first_not_of(L" \t\r\n");
+        if (a == std::wstring::npos) return L"";
+        size_t b = s.find_last_not_of(L" \t\r\n");
+        return s.substr(a, b - a + 1);
+    };
+    for (int i = 0; ; i++) {
+        PCWSTR proc = Wh_GetStringSetting(L"customIcons[%d].process", i);
+        PCWSTR icon = Wh_GetStringSetting(L"customIcons[%d].iconPath", i);
+        bool hasProc = proc && *proc;
+        bool hasIcon = icon && *icon;
+        if (hasProc && hasIcon) {
+            std::wstring p = trimWs(proc);
+            std::wstring ip = trimWs(icon);
+            if (!p.empty() && !ip.empty()) g_customIcons.push_back({p, ip});
+        }
+        bool endOfArray = !hasProc && !hasIcon;
+        if (proc) Wh_FreeStringSetting(proc);
+        if (icon) Wh_FreeStringSetting(icon);
+        if (endOfArray) break;
+    }
 }
 
 
@@ -4107,6 +4234,10 @@ void Wh_ModUninit() {
             if (pair.second) DestroyIcon(pair.second);
         }
         g_exeIconCache.clear();
+        for (auto& pair : g_customIconCache) {
+            if (pair.second) DestroyIcon(pair.second);
+        }
+        g_customIconCache.clear();
 
         if (g_isExplorer && IsMainExplorer()) {
             if (!GetSystemMetrics(SM_SHUTTINGDOWN)) {

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -161,13 +161,17 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
   $name: Theme
 - Appearance:
     - Corners:
-        - cornerPreference: none
+        - cornerPreference: round
           $name: Corner Preference
-          $description: Corner radius for the switcher window only.
+          $description: Corner radius for the switcher window and its elements.
           $options:
           - none: Squared
           - round: Rounded
           - roundSmall: Rounded small
+          - custom: Custom
+        - customCornerRadius: 8
+          $name: Custom Corner Radius (px)
+          $description: Corner radius in pixels, used when Corner Preference is set to Custom. Applies to task borders, close buttons, and thumbnails.
         - taskRoundedCorners: false
           $name: Round Task Borders and Close Button
           $description: Apply small rounded corners to the selected task border and close button.
@@ -191,6 +195,9 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
         - showThumbnails: true
           $name: Show Thumbnails
           $description: Show DWM live thumbnail previews of windows.
+        - showHoverBorder: true
+          $name: Show Hover Border
+          $description: Show a colored border around the thumbnail when hovered.
       $name: Thumbnails
     - HeaderContent:
         - iconSize: small
@@ -223,6 +230,24 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
           - horizontal: Horizontal
           - vertical: Vertical
       $name: Orientation
+    - Position:
+        - switcherPosition: center
+          $name: Switcher Position
+          $description: Where the switcher should appear on the screen.
+          $options:
+          - topLeft: Top Left
+          - topCenter: Top Center
+          - topRight: Top Right
+          - centerLeft: Center Left
+          - center: Center
+          - centerRight: Center Right
+          - bottomLeft: Bottom Left
+          - bottomCenter: Bottom Center
+          - bottomRight: Bottom Right
+        - switcherPositionMargin: 0
+          $name: Switcher Position Margin (px)
+          $description: Offset from the screen edges when using non-centered positions.
+      $name: Position
     - Font:
         - fontFamily: Segoe UI
           $name: Font Family
@@ -412,6 +437,10 @@ struct Settings {
     bool showApplications;
     WCHAR showTitles[32];
     bool restoreAllWindows;
+    int customCornerRadius;
+    WCHAR switcherPosition[32];
+    int switcherPositionMargin;
+    bool showHoverBorder;
 };
 
 static std::vector<std::wstring> g_excludeTitlePatterns;
@@ -526,6 +555,7 @@ static int GetHeaderRowHeightPx() {
 static INT GetCornerPref() {
     if (wcscmp(g_settings.cornerPreference, L"none") == 0) return 1;
     if (wcscmp(g_settings.cornerPreference, L"roundSmall") == 0) return 3;
+    if (wcscmp(g_settings.cornerPreference, L"custom") == 0) return 1; // Don't let DWM round, we'll try to manual mask
     return 2; // Default to round
 }
 
@@ -537,7 +567,35 @@ static int GetTaskUiCornerRadiusPx() {
     if (!UseTaskRoundedCorners()) {
         return 0;
     }
+    if (wcscmp(g_settings.cornerPreference, L"custom") == 0) {
+        return MulDiv(g_settings.customCornerRadius, g_dpiX, 96);
+    }
     return MulDiv(4, g_dpiX, 96);
+}
+
+static void GetSwitcherPosition(const RECT& workArea, int* outX, int* outY) {
+    int w = workArea.right - workArea.left;
+    int h = workArea.bottom - workArea.top;
+    int m = MulDiv(g_settings.switcherPositionMargin, g_dpiX, 96);
+    if (wcscmp(g_settings.switcherPosition, L"topLeft") == 0) {
+        *outX = workArea.left + m; *outY = workArea.top + m;
+    } else if (wcscmp(g_settings.switcherPosition, L"topCenter") == 0) {
+        *outX = workArea.left + (w - g_winW) / 2; *outY = workArea.top + m;
+    } else if (wcscmp(g_settings.switcherPosition, L"topRight") == 0) {
+        *outX = workArea.right - g_winW - m; *outY = workArea.top + m;
+    } else if (wcscmp(g_settings.switcherPosition, L"centerLeft") == 0) {
+        *outX = workArea.left + m; *outY = workArea.top + (h - g_winH) / 2;
+    } else if (wcscmp(g_settings.switcherPosition, L"centerRight") == 0) {
+        *outX = workArea.right - g_winW - m; *outY = workArea.top + (h - g_winH) / 2;
+    } else if (wcscmp(g_settings.switcherPosition, L"bottomLeft") == 0) {
+        *outX = workArea.left + m; *outY = workArea.bottom - g_winH - m;
+    } else if (wcscmp(g_settings.switcherPosition, L"bottomCenter") == 0) {
+        *outX = workArea.left + (w - g_winW) / 2; *outY = workArea.bottom - g_winH - m;
+    } else if (wcscmp(g_settings.switcherPosition, L"bottomRight") == 0) {
+        *outX = workArea.right - g_winW - m; *outY = workArea.bottom - g_winH - m;
+    } else { // center
+        *outX = workArea.left + (w - g_winW) / 2; *outY = workArea.top + (h - g_winH) / 2;
+    }
 }
 
 static int GetCloseButtonCornerRadiusPx() {
@@ -1871,7 +1929,7 @@ static COLORREF GetBgColor() {
                         SWS_BG_LIGHT);
 }
 
-static void MaskRectCorners(HDC hdc, const RECT& rc, int radiusPx) {
+static void MaskRectCorners(HDC hdc, const RECT& rc, int radiusPx, bool forceOpaque = false, COLORREF overrideBg = CLR_INVALID) {
     if (radiusPx <= 0) {
         return;
     }
@@ -1889,38 +1947,42 @@ static void MaskRectCorners(HDC hdc, const RECT& rc, int radiusPx) {
         return;
     }
 
-    COLORREF bg = GetBgColor();
+    COLORREF bg = (overrideBg != CLR_INVALID) ? overrideBg : GetBgColor();
     // In layered mode, punch fully transparent corners to force thumbnail clipping.
-    BYTE alpha = ThemeIs(L"none") ? 0 : 255;
+    BYTE alpha = (ThemeIs(L"none") && !forceOpaque) ? 0 : 255;
 
     Gdiplus::Graphics graphics(hdc);
+    if (alpha == 0) {
+        graphics.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
+    }
     graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
     Gdiplus::SolidBrush brush(Gdiplus::Color(alpha, GetRValue(bg), GetGValue(bg), GetBValue(bg)));
 
     int d = r * 2;
     Gdiplus::GraphicsPath cutTl, cutTr, cutBr, cutBl;
+    Gdiplus::REAL ext = (alpha != 0) ? 1.0f : 0.0f; // Extend outward to cover anti-aliased edge
 
     cutTl.StartFigure();
-    cutTl.AddLine((Gdiplus::REAL)rc.left, (Gdiplus::REAL)rc.top + r, (Gdiplus::REAL)rc.left, (Gdiplus::REAL)rc.top);
-    cutTl.AddLine((Gdiplus::REAL)rc.left, (Gdiplus::REAL)rc.top, (Gdiplus::REAL)rc.left + r, (Gdiplus::REAL)rc.top);
+    cutTl.AddLine((Gdiplus::REAL)rc.left - ext, (Gdiplus::REAL)rc.top + r, (Gdiplus::REAL)rc.left - ext, (Gdiplus::REAL)rc.top - ext);
+    cutTl.AddLine((Gdiplus::REAL)rc.left - ext, (Gdiplus::REAL)rc.top - ext, (Gdiplus::REAL)rc.left + r, (Gdiplus::REAL)rc.top - ext);
     cutTl.AddArc((Gdiplus::REAL)rc.left, (Gdiplus::REAL)rc.top, (Gdiplus::REAL)d, (Gdiplus::REAL)d, 270, -90);
     cutTl.CloseFigure();
 
     cutTr.StartFigure();
-    cutTr.AddLine((Gdiplus::REAL)rc.right - r, (Gdiplus::REAL)rc.top, (Gdiplus::REAL)rc.right, (Gdiplus::REAL)rc.top);
-    cutTr.AddLine((Gdiplus::REAL)rc.right, (Gdiplus::REAL)rc.top, (Gdiplus::REAL)rc.right, (Gdiplus::REAL)rc.top + r);
+    cutTr.AddLine((Gdiplus::REAL)rc.right - r, (Gdiplus::REAL)rc.top - ext, (Gdiplus::REAL)rc.right + ext, (Gdiplus::REAL)rc.top - ext);
+    cutTr.AddLine((Gdiplus::REAL)rc.right + ext, (Gdiplus::REAL)rc.top - ext, (Gdiplus::REAL)rc.right + ext, (Gdiplus::REAL)rc.top + r);
     cutTr.AddArc((Gdiplus::REAL)rc.right - d, (Gdiplus::REAL)rc.top, (Gdiplus::REAL)d, (Gdiplus::REAL)d, 0, -90);
     cutTr.CloseFigure();
 
     cutBr.StartFigure();
-    cutBr.AddLine((Gdiplus::REAL)rc.right, (Gdiplus::REAL)rc.bottom - r, (Gdiplus::REAL)rc.right, (Gdiplus::REAL)rc.bottom);
-    cutBr.AddLine((Gdiplus::REAL)rc.right, (Gdiplus::REAL)rc.bottom, (Gdiplus::REAL)rc.right - r, (Gdiplus::REAL)rc.bottom);
+    cutBr.AddLine((Gdiplus::REAL)rc.right + ext, (Gdiplus::REAL)rc.bottom - r, (Gdiplus::REAL)rc.right + ext, (Gdiplus::REAL)rc.bottom + ext);
+    cutBr.AddLine((Gdiplus::REAL)rc.right + ext, (Gdiplus::REAL)rc.bottom + ext, (Gdiplus::REAL)rc.right - r, (Gdiplus::REAL)rc.bottom + ext);
     cutBr.AddArc((Gdiplus::REAL)rc.right - d, (Gdiplus::REAL)rc.bottom - d, (Gdiplus::REAL)d, (Gdiplus::REAL)d, 90, -90);
     cutBr.CloseFigure();
 
     cutBl.StartFigure();
-    cutBl.AddLine((Gdiplus::REAL)rc.left + r, (Gdiplus::REAL)rc.bottom, (Gdiplus::REAL)rc.left, (Gdiplus::REAL)rc.bottom);
-    cutBl.AddLine((Gdiplus::REAL)rc.left, (Gdiplus::REAL)rc.bottom, (Gdiplus::REAL)rc.left, (Gdiplus::REAL)rc.bottom - r);
+    cutBl.AddLine((Gdiplus::REAL)rc.left + r, (Gdiplus::REAL)rc.bottom + ext, (Gdiplus::REAL)rc.left - ext, (Gdiplus::REAL)rc.bottom + ext);
+    cutBl.AddLine((Gdiplus::REAL)rc.left - ext, (Gdiplus::REAL)rc.bottom + ext, (Gdiplus::REAL)rc.left - ext, (Gdiplus::REAL)rc.bottom - r);
     cutBl.AddArc((Gdiplus::REAL)rc.left, (Gdiplus::REAL)rc.bottom - d, (Gdiplus::REAL)d, (Gdiplus::REAL)d, 180, -90);
     cutBl.CloseFigure();
 
@@ -1932,17 +1994,22 @@ static void MaskRectCorners(HDC hdc, const RECT& rc, int radiusPx) {
 
 // Draw a rectangular contour around a rect.
 // direction: 1 = inner (shrinks inward), -1 = outer (grows outward)
-// Uses GDI+ rounded path for inner contours when cornerRadius > 0, FrameRect otherwise.
-static void DrawContour(HDC hdc, RECT rc, int contourSize, int direction) {
+// Uses GDI+ rounded path for contours when cornerRadius > 0.
+static void DrawContour(HDC hdc, RECT rc, int contourSize, int direction, int overrideCornerRadius = -1) {
     COLORREF c = GetContourColor();
     BYTE r = GetRValue(c), g = GetGValue(c), b = GetBValue(c);
 
-    int cornerRadius = GetTaskUiCornerRadiusPx();
-    if (cornerRadius > 0 && direction > 0) {
+    int cornerRadius = (overrideCornerRadius != -1) ? overrideCornerRadius : GetTaskUiCornerRadiusPx();
+    if (cornerRadius > 0) {
         int penWidth = contourSize * g_dpiX / 96;
         if (penWidth < 1) penWidth = 1;
 
         RECT drawRc = rc;
+        if (direction < 0) {
+            InflateRect(&drawRc, 2, 2);
+            cornerRadius += 2 + penWidth / 2;
+        }
+
         int width = drawRc.right - drawRc.left - penWidth;
         int height = drawRc.bottom - drawRc.top - penWidth;
         if (width <= 0 || height <= 0) {
@@ -1976,9 +2043,6 @@ static void DrawContour(HDC hdc, RECT rc, int contourSize, int direction) {
     Gdiplus::SolidBrush solidBrush(Gdiplus::Color(255, r, g, b));
 
     if (direction < 0) {
-        // Outer contour: DWM composites thumbnails on top of GDI and renders
-        // inclusively at rcDestination's right/bottom edges. Inflate by i+2
-        // so border pixels land 1px beyond DWM's last column/row.
         for (int i = 0; i < contourSize; i++) {
             RECT r_rect = rc;
             InflateRect(&r_rect, i + 2, i + 2);
@@ -1988,7 +2052,6 @@ static void DrawContour(HDC hdc, RECT rc, int contourSize, int direction) {
             graphics.FillRectangle(&solidBrush, r_rect.right - 1, r_rect.top + 1, 1, (r_rect.bottom - r_rect.top) - 2);
         }
     } else {
-        // Inner contour
         for (int i = 0; i < contourSize; i++) {
             RECT r_rect = rc;
             InflateRect(&r_rect, -i, -i);
@@ -2146,12 +2209,9 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg, HWND hWnd) {
             }
         }
 
-        // Hover thumbnail border: outer contour on rcThumbActual (EP draws both independently)
-        if (i == g_hoverIndex && g_hoverWnd == hWnd && g_settings.showThumbnails) {
-            DrawContour(hdc, e.rcThumbActual, 1, -1);
-        }
+        // Hover thumbnail border is now drawn in DrawSwitcherOverlay so it sits above the thumbnail mask
 
-        if (g_settings.showThumbnails && cornerRadius > 0) {
+        if (g_settings.showThumbnails && cornerRadius > 0 && ThemeIs(L"none")) {
             MaskRectCorners(hdc, e.rcThumbActual, cornerRadius);
             RECT inset = e.rcThumbActual;
             InflateRect(&inset, -1, -1);
@@ -2256,11 +2316,30 @@ static void DrawSwitcherOverlay(HDC hdc, HWND hWnd) {
     if (g_windows.empty()) return;
 
     int rowTitleH = GetHeaderRowHeightPx();
+    int cornerRadius = GetTaskUiCornerRadiusPx();
 
     for (int idx = 0; idx < (int)g_windows.size(); idx++) {
         int i = (g_layoutStartIndex + idx) % g_windows.size();
         auto& e = g_windows[i];
         if (IsWindowTruncated(i)) continue;
+
+        // ALWAYS draw opaque mask on the overlay window to cover the DWM thumbnail's square corners.
+        // Even for the transparent theme, DWM on Windows 11 does not clip the thumbnail to the layered window's alpha channel.
+        if (g_settings.showThumbnails && cornerRadius > 0) {
+            COLORREF maskColor = GetBgColor();
+            if (i == g_selectedIndex && HighlightHasFill()) {
+                maskColor = GetHighlightFillColor();
+            }
+            MaskRectCorners(hdc, e.rcThumbActual, cornerRadius, true, maskColor);
+            RECT inset = e.rcThumbActual;
+            InflateRect(&inset, -1, -1);
+            MaskRectCorners(hdc, inset, cornerRadius, true, maskColor);
+        }
+
+        // Hover thumbnail border: outer contour on rcThumbActual (drawn here to overlay the mask)
+        if (i == g_hoverIndex && g_hoverWnd == hWnd && g_settings.showThumbnails && g_settings.showHoverBorder) {
+            DrawContour(hdc, e.rcThumbActual, 1, -1, cornerRadius);
+        }
 
         // Close button (positioned at top-right of the cell, in title area)
         if (i == g_hoverIndex && g_hoverWnd == hWnd) {
@@ -2354,6 +2433,18 @@ static void PaintSwitcherOverlay() {
     void* bits = NULL;
     HBITMAP hBmp = CreateDIBSection(hdcMem, &bmi, DIB_RGB_COLORS, &bits, NULL, 0);
     HBITMAP hOld = (HBITMAP)SelectObject(hdcMem, hBmp);
+
+    // Clip the overlay DC to the same rounded rect as the main window.
+    // SetWindowRgn is ignored for layered windows using UpdateLayeredWindow,
+    // so we must clip manually to prevent corner masks from bleeding outside
+    // the main window's rounded boundary.
+    INT cp = GetCornerPref();
+    if (cp == 1 && wcscmp(g_settings.cornerPreference, L"custom") == 0) {
+        int radius = MulDiv(g_settings.customCornerRadius, g_dpiX, 96);
+        HRGN hClip = CreateRoundRectRgn(0, 0, w + 1, h + 1, radius * 2, radius * 2);
+        SelectClipRgn(hdcMem, hClip);
+        DeleteObject(hClip);
+    }
 
     DrawSwitcherOverlay(hdcMem, g_hSwitcher);
 
@@ -2541,15 +2632,29 @@ static void ApplyThemeToWindow(HWND hWnd) {
         SetClassLongPtrW(hWnd, GCLP_HBRBACKGROUND, (LONG_PTR)GetStockObject(BLACK_BRUSH));
     }
     INT cp = GetCornerPref();
-    DwmSetWindowAttribute(hWnd, 33, &cp, sizeof(cp));
+    if (cp == 1 && wcscmp(g_settings.cornerPreference, L"custom") == 0) {
+        COLORREF none = 0xFFFFFFFE; // DWMWA_COLOR_NONE
+        DwmSetWindowAttribute(hWnd, 34 /* DWMWA_BORDER_COLOR */, &none, sizeof(none));
+        
+        // Always use DONOTROUND for custom corners. SetWindowRgn defines the
+        // window shape; DWM's own rounding (ROUND/ROUNDSMALL) uses a fixed
+        // radius that conflicts with our custom radius, creating visible
+        // glass artifacts at the corners.
+        INT shadowCp = 1; // DWMWCP_DONOTROUND
+        DwmSetWindowAttribute(hWnd, 33, &shadowCp, sizeof(shadowCp));
+    } else {
+        DwmSetWindowAttribute(hWnd, 33, &cp, sizeof(cp));
+        COLORREF defaultColor = 0xFFFFFFFF; // DWMWA_COLOR_DEFAULT
+        DwmSetWindowAttribute(hWnd, 34, &defaultColor, sizeof(defaultColor));
+    }
 }
 
 static BOOL WINAPI MirrorEnumProc(HMONITOR hM, HDC, LPRECT, LPARAM) {
     if (hM != g_hCurrentMonitor) {
         MONITORINFO mInfo = { sizeof(mInfo) };
         GetMonitorInfoW(hM, &mInfo);
-        int mx = (mInfo.rcWork.left + mInfo.rcWork.right - g_winW) / 2;
-        int my = (mInfo.rcWork.top + mInfo.rcWork.bottom - g_winH) / 2;
+        int mx, my;
+        GetSwitcherPosition(mInfo.rcWork, &mx, &my);
         HWND hMirror = CreateWindowExW(WS_EX_TOOLWINDOW | WS_EX_TOPMOST, SWS_CLASSNAME, L"", WS_POPUP | WS_THICKFRAME | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, mx, my, g_winW, g_winH, g_hSwitcher, NULL, GetModuleHandle(NULL), NULL);
         if (hMirror) {
             ApplyThemeToWindow(hMirror);
@@ -2591,10 +2696,22 @@ static void ShowSwitcher(bool sticky) {
     g_hFont = CreateScaledFont(g_dpiY);
 
     MONITORINFO mi = { sizeof(mi) }; GetMonitorInfoW(hMon, &mi);
-    int cx = (mi.rcWork.left + mi.rcWork.right - g_winW) / 2;
-    int cy = (mi.rcWork.top + mi.rcWork.bottom - g_winH) / 2;
+    int cx, cy;
+    GetSwitcherPosition(mi.rcWork, &cx, &cy);
 
     ApplyThemeToWindow(g_hSwitcher);
+
+    INT cp = GetCornerPref();
+    if (cp == 1 && wcscmp(g_settings.cornerPreference, L"custom") == 0) {
+        int radius = MulDiv(g_settings.customCornerRadius, g_dpiX, 96);
+        HRGN hRgn1 = CreateRoundRectRgn(0, 0, g_winW + 1, g_winH + 1, radius * 2, radius * 2);
+        SetWindowRgn(g_hSwitcher, hRgn1, TRUE);
+        // NOTE: Do NOT call SetWindowRgn on g_hCloseBtnWnd — it is a layered
+        // window using UpdateLayeredWindow, which ignores SetWindowRgn.
+        // Instead, the overlay DC is clipped in PaintSwitcherOverlay.
+    } else {
+        SetWindowRgn(g_hSwitcher, NULL, TRUE);
+    }
 
     g_pendingSwitcherRect = {
         cx,
@@ -2705,8 +2822,8 @@ static void RecomputeAndReposition() {
     ComputeLayout(hMon);
     MONITORINFO mi = { sizeof(mi) };
     GetMonitorInfoW(hMon, &mi);
-    int cx = mi.rcWork.left + (mi.rcWork.right - mi.rcWork.left - g_winW) / 2;
-    int cy = mi.rcWork.top + (mi.rcWork.bottom - mi.rcWork.top - g_winH) / 2;
+    int cx, cy;
+    GetSwitcherPosition(mi.rcWork, &cx, &cy);
 
     g_pendingSwitcherRect = {
         cx,
@@ -3281,8 +3398,8 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
                     ComputeLayout(g_hCurrentMonitor);
                     // Resize and re-center the window to match new layout
                     MONITORINFO rmi = { sizeof(rmi) }; GetMonitorInfoW(g_hCurrentMonitor, &rmi);
-                    int cx = (rmi.rcWork.left + rmi.rcWork.right - g_winW) / 2;
-                    int cy = (rmi.rcWork.top + rmi.rcWork.bottom - g_winH) / 2;
+                    int cx, cy;
+                    GetSwitcherPosition(rmi.rcWork, &cx, &cy);
                     SetWindowPos(g_hSwitcher, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
                     if (g_hCloseBtnWnd) {
                         SetWindowPos(g_hCloseBtnWnd, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
@@ -3384,6 +3501,9 @@ static void LoadSettings() {
     wcscpy_s(g_settings.colorScheme, v ? v : L"system"); Wh_FreeStringSetting(v);
     v = Wh_GetStringSetting(L"Appearance.Corners.cornerPreference");
     wcscpy_s(g_settings.cornerPreference, v ? v : L"round"); Wh_FreeStringSetting(v);
+    g_settings.customCornerRadius = Wh_GetIntSetting(L"Appearance.Corners.customCornerRadius");
+    if (g_settings.customCornerRadius < 0) g_settings.customCornerRadius = 0;
+    if (g_settings.customCornerRadius > 32) g_settings.customCornerRadius = 32;
     g_settings.taskRoundedCorners = Wh_GetIntSetting(L"Appearance.Corners.taskRoundedCorners");
     v = Wh_GetStringSetting(L"Accessibility.scrollWheelBehavior");
     wcscpy_s(g_settings.scrollWheelBehavior, v ? v : L"never"); Wh_FreeStringSetting(v);
@@ -3395,6 +3515,22 @@ static void LoadSettings() {
         wcscmp(g_settings.headerContentOrientation, L"vertical") != 0) {
         wcscpy_s(g_settings.headerContentOrientation, L"horizontal");
     }
+    
+    v = Wh_GetStringSetting(L"Appearance.Position.switcherPosition");
+    wcscpy_s(g_settings.switcherPosition, v ? v : L"center"); Wh_FreeStringSetting(v);
+    if (wcscmp(g_settings.switcherPosition, L"topLeft") != 0 &&
+        wcscmp(g_settings.switcherPosition, L"topCenter") != 0 &&
+        wcscmp(g_settings.switcherPosition, L"topRight") != 0 &&
+        wcscmp(g_settings.switcherPosition, L"centerLeft") != 0 &&
+        wcscmp(g_settings.switcherPosition, L"center") != 0 &&
+        wcscmp(g_settings.switcherPosition, L"centerRight") != 0 &&
+        wcscmp(g_settings.switcherPosition, L"bottomLeft") != 0 &&
+        wcscmp(g_settings.switcherPosition, L"bottomCenter") != 0 &&
+        wcscmp(g_settings.switcherPosition, L"bottomRight") != 0) {
+        wcscpy_s(g_settings.switcherPosition, L"center");
+    }
+    g_settings.switcherPositionMargin = Wh_GetIntSetting(L"Appearance.Position.switcherPositionMargin");
+    if (g_settings.switcherPositionMargin < 0) g_settings.switcherPositionMargin = 0;
     v = Wh_GetStringSetting(L"Appearance.HeaderContent.iconSize");
     wcscpy_s(g_settings.iconSize, v ? v : L"small"); Wh_FreeStringSetting(v);
     if (wcscmp(g_settings.iconSize, L"small") != 0 &&
@@ -3447,6 +3583,7 @@ static void LoadSettings() {
     if (g_settings.rowWidth < 0) g_settings.rowWidth = 0;
     g_settings.stretchThumbnailsToTaskWidth = Wh_GetIntSetting(L"Dimensions.stretchThumbnailsToTaskWidth");
     g_settings.showThumbnails = Wh_GetIntSetting(L"Appearance.Thumbnails.showThumbnails");
+    g_settings.showHoverBorder = Wh_GetIntSetting(L"Appearance.Thumbnails.showHoverBorder");
     g_settings.showTitle = Wh_GetIntSetting(L"Appearance.HeaderContent.showTitle");
     g_settings.showIcon = Wh_GetIntSetting(L"Appearance.HeaderContent.showIcon");
     if (!g_settings.showThumbnails && !g_settings.showTitle && !g_settings.showIcon) {

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -91,6 +91,14 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 - showThumbnails: true
   $name: Show Thumbnails
   $description: Show DWM live thumbnail previews of windows.
+- thumbnailPosition: bottom
+  $name: Thumbnail Position
+  $description: Place the thumbnail below or above the header row.
+  $options:
+  - bottom: Bottom (below header)
+  - top: Top (above header)
+  - left: Left (before header)
+  - right: Right (after header)
 - showTitle: true
   $name: Show Title Label
 - showIcon: true
@@ -119,11 +127,13 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 - rowWidth: 0
   $name: Row Width
   $description: Width of each thumbnail tile in pixels (before DPI scaling). Set to 0 for automatic width based on window aspect ratio.
+- stretchThumbnailsToTaskWidth: true
+  $name: Stretch Thumbnails To Task Width
+  $description: When enabled, custom row width also changes thumbnail width. Disable to keep thumbnail aspect sizing while row width controls only task tile width.
 - maxWidthPercent: 80
   $name: Maximum Width (percentage of screen width)
 - maxHeightPercent: 80
   $name: Maximum Height (percentage of screen height)
-
 - showDelay: 0
   $name: Show Delay (ms)
   $description: Delay in milliseconds before showing the switcher (0 = instant).
@@ -147,8 +157,15 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
   $name: Border Color (Light Mode)
   $description: Border color in HEX format for light mode.
 - useAccentColor: false
-  $name: Use Accent Color for Borders
+  $name: Accent Color for Borders and Background Fill
   $description: Use Windows accent color for selection and hover borders.
+- highlightStyle: border
+  $name: Selected Task Highlight Style
+  $description: Style used for the selected task row/tile.
+  $options:
+  - border: Border only
+  - fillAndBorder: Background fill and border
+  - fillOnly: Background fill only
 - centerTaskContent: false
   $name: Center Task Icon and Title
   $description: Center the icon and title together in each task row.
@@ -177,6 +194,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 #include <atomic>
 #include <map>
 #include <string>
+#include <algorithm>
 #include <gdiplus.h>
 
 #define SWS_CLASSNAME       L"WindhawkSWS_Switcher"
@@ -225,12 +243,14 @@ struct WindowEntry {
     SIZE effectiveSourceSize;  // Source size after cropping invisible frame
 };
 struct Settings {
-    WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32];
+    WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32]; WCHAR thumbnailPosition[32];
+    WCHAR highlightStyle[32];
     WCHAR borderColorDark[16];
     WCHAR borderColorLight[16];
     int opacity;
     int rowHeight;
     int rowWidth;
+    bool stretchThumbnailsToTaskWidth;
     bool showThumbnails;
     bool showTitle;
     bool showIcon;
@@ -278,9 +298,25 @@ static bool LayoutIsVertical() { return wcscmp(g_settings.taskListOrientation, L
 static bool HeaderOrientationIs(const WCHAR* v) { return wcscmp(g_settings.headerContentOrientation, v) == 0; }
 static bool IconSizeIs(const WCHAR* v) { return wcscmp(g_settings.iconSize, v) == 0; }
 static bool BackwardShortcutIs(const WCHAR* v) { return wcscmp(g_settings.backwardShortcut, v) == 0; }
+static bool ThumbnailPositionIs(const WCHAR* v) { return wcscmp(g_settings.thumbnailPosition, v) == 0; }
+static bool HighlightStyleIs(const WCHAR* v) { return wcscmp(g_settings.highlightStyle, v) == 0; }
 static bool UseAltShiftTabBackward() { return BackwardShortcutIs(L"altShiftTab"); }
 static bool UseAltShiftBackward() { return BackwardShortcutIs(L"altShift"); }
 static bool UseAltBacktickBackward() { return BackwardShortcutIs(L"altBacktick"); }
+static bool ThumbnailIsBottom() { return ThumbnailPositionIs(L"bottom"); }
+static bool ThumbnailIsTop() { return ThumbnailPositionIs(L"top"); }
+static bool ThumbnailIsLeft() { return ThumbnailPositionIs(L"left"); }
+static bool ThumbnailIsRight() { return ThumbnailPositionIs(L"right"); }
+static bool ThumbnailIsSide() { return ThumbnailIsLeft() || ThumbnailIsRight(); }
+static bool HighlightHasFill() {
+    return HighlightStyleIs(L"fillAndBorder") || HighlightStyleIs(L"fillOnly");
+}
+static bool HighlightHasBorder() {
+    return HighlightStyleIs(L"border") || HighlightStyleIs(L"fillAndBorder");
+}
+static bool StretchThumbsToTaskWidth() {
+    return g_settings.stretchThumbnailsToTaskWidth;
+}
 static bool HeaderIsVertical() {
     return HeaderOrientationIs(L"vertical");
 }
@@ -918,9 +954,10 @@ static void ComputeLayout(HMONITOR hMon) {
     // EP: cbThumbnailAvailableHeight = cbRowHeight - cbRowTitleHeight - cbTopPadding - 2 * cbBottomPadding
     // All values are DPI-scaled at this point (matching EP lines 826-844)
     int scaledRowH = DpiScale(g_settings.rowHeight, dpiY);
+    bool sidePlacement = ThumbnailIsSide() && g_settings.showThumbnails;
     int thumbH = 0;
     if (g_settings.showThumbnails) {
-        thumbH = scaledRowH - rowTitleH - padTop - 2 * padBot;
+        thumbH = scaledRowH - (sidePlacement ? 0 : rowTitleH) - padTop - 2 * padBot;
         if (thumbH < 0) thumbH = 0;
     }
     // EP: cbMaxTileWidth = cbRowHeight * MAX_TILE_WIDTH (computed before DPI, then scaled)
@@ -933,9 +970,18 @@ static void ComputeLayout(HMONITOR hMon) {
     // bottomInc    = (thumbH + padBot) + elemPadBot + initialTop
     int initialLeft = elemPadLeft + padLeft;
     int rightInc    = (padRight + elemPadRight) + initialLeft;
-    int activePadDivider = (g_settings.showThumbnails && rowTitleH > 0) ? padDivider : 0;
-    int initialTop  = elemPadTop + (padTop + rowTitleH + activePadDivider);
-    int bottomInc   = (thumbH + padBot) + elemPadBot + initialTop;
+    bool showThumbs = g_settings.showThumbnails;
+    bool thumbBottom = showThumbs ? ThumbnailIsBottom() : true;
+    bool thumbTop = showThumbs ? ThumbnailIsTop() : false;
+    bool thumbSide = showThumbs ? ThumbnailIsSide() : false;
+    
+    int activePadDivider = (showThumbs && rowTitleH > 0) ? padDivider : 0;
+    int headerAndDividerH = rowTitleH + activePadDivider;
+    int thumbTopOffset = padTop + (thumbBottom ? headerAndDividerH : 0);
+    int initialTop  = elemPadTop + thumbTopOffset;
+    int baseContentH = thumbSide ? std::max(thumbH, rowTitleH) : thumbH;
+    int bottomInc   = (baseContentH + padBot) + elemPadBot + initialTop + (thumbTop ? headerAndDividerH : 0);
+    int sideHeaderWidth = DpiScale(HeaderIsVertical() ? 96 : 150, dpiX);
 
     int maxW = monW * g_settings.maxWidthPercent / 100;
     int maxH = monH * g_settings.maxHeightPercent / 100;
@@ -979,18 +1025,47 @@ static void ComputeLayout(HMONITOR hMon) {
             }
 
             int width = 0;
-            int original_width = 0;
+            int thumbWidth = 0;
+            int actualThumbH = thumbH;
 
             if (g_settings.showThumbnails && thumbH > 0) {
                 if (w.effectiveSourceSize.cx > 0 && w.effectiveSourceSize.cy > 0) {
-                    width = (int)((double)w.effectiveSourceSize.cx * thumbH / w.effectiveSourceSize.cy);
+                    thumbWidth = (int)((double)w.effectiveSourceSize.cx * thumbH / w.effectiveSourceSize.cy);
                 } else {
-                    width = thumbH;
+                    thumbWidth = thumbH;
                 }
-                if (width > maxTileW || width > w.effectiveSourceSize.cx) {
-                    original_width = width;
-                    if (width > maxTileW) width = maxTileW;
-                    if (w.effectiveSourceSize.cx > 0 && width > w.effectiveSourceSize.cx) width = w.effectiveSourceSize.cx;
+
+                int naturalThumbWidth = thumbWidth;
+                if (thumbWidth > maxTileW) thumbWidth = maxTileW;
+                if (w.effectiveSourceSize.cx > 0 && thumbWidth > w.effectiveSourceSize.cx) thumbWidth = w.effectiveSourceSize.cx;
+                if (naturalThumbWidth > 0 && thumbWidth != naturalThumbWidth) {
+                    actualThumbH = (int)((double)thumbWidth * thumbH / naturalThumbWidth);
+                }
+
+                width = thumbWidth;
+                if (g_settings.rowWidth > 0) {
+                    width = DpiScale(g_settings.rowWidth, dpiX);
+                    if (StretchThumbsToTaskWidth()) {
+                        thumbWidth = sidePlacement ? std::max(0, width - ((rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0)) : width;
+                        if (thumbWidth <= 0) thumbWidth = DpiScale(16, dpiX);
+                        actualThumbH = thumbH;
+                    } else if (thumbWidth > width && width > 0) {
+                        actualThumbH = (int)((double)width * actualThumbH / thumbWidth);
+                        thumbWidth = width;
+                    }
+                }
+
+                if (sidePlacement) {
+                    int headerExtra = (rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0;
+                    if (g_settings.rowWidth > 0) {
+                        int maxThumbW = width - headerExtra;
+                        if (maxThumbW > 0 && thumbWidth > maxThumbW) {
+                            actualThumbH = (int)((double)maxThumbW * actualThumbH / thumbWidth);
+                            thumbWidth = maxThumbW;
+                        }
+                    } else {
+                        width = thumbWidth + headerExtra;
+                    }
                 }
             } else {
                 if (!g_settings.showTitle && g_settings.showIcon) {
@@ -1002,10 +1077,13 @@ static void ComputeLayout(HMONITOR hMon) {
                 } else {
                     width = DpiScale(160, dpiX);
                 }
+                thumbWidth = width;
+                actualThumbH = 0;
             }
 
-            if (g_settings.rowWidth > 0) {
+            if (!g_settings.showThumbnails && g_settings.rowWidth > 0) {
                 width = DpiScale(g_settings.rowWidth, dpiX);
+                thumbWidth = width;
             }
 
             if (curX + width + rightInc - initialLeft > maxW - masterPad && curX > initialLeft + masterPad) {
@@ -1020,21 +1098,35 @@ static void ComputeLayout(HMONITOR hMon) {
                 curY = curY + bottomInc;
             }
 
-            int actualThumbH = thumbH;
-            if (original_width > 0 && thumbH > 0) {
-                actualThumbH = (int)((double)width * thumbH / original_width);
-            }
-
             w.rcCell.left   = curX - initialLeft + elemPadLeft;
             w.rcCell.top    = curY - initialTop + elemPadTop;
             w.rcCell.right  = curX + width + rightInc - initialLeft - elemPadRight;
             w.rcCell.bottom = curY + bottomInc - initialTop - elemPadBot;
-            if (original_width > 0) {
-                w.rcCell.bottom -= (thumbH - actualThumbH);
+            if (g_settings.showThumbnails) {
+                if (sidePlacement) {
+                    int contentH = std::max(actualThumbH, rowTitleH);
+                    int baseH = std::max(thumbH, rowTitleH);
+                    if (contentH < baseH) {
+                        w.rcCell.bottom -= (baseH - contentH);
+                    }
+                } else if (actualThumbH < thumbH) {
+                    w.rcCell.bottom -= (thumbH - actualThumbH);
+                }
             }
 
             if (g_settings.showThumbnails) {
-                w.rcThumbActual = { curX, curY, curX + width, curY + actualThumbH };
+                int thumbX = curX;
+                int thumbY = curY;
+                if (sidePlacement) {
+                    int contentH = std::max(actualThumbH, rowTitleH);
+                    thumbY = curY + (contentH - actualThumbH) / 2;
+                    if (ThumbnailIsRight()) {
+                        thumbX = curX + width - thumbWidth;
+                    }
+                } else if (!StretchThumbsToTaskWidth() && width > thumbWidth) {
+                    thumbX += (width - thumbWidth) / 2;
+                }
+                w.rcThumbActual = { thumbX, thumbY, thumbX + thumbWidth, thumbY + actualThumbH };
                 w.rcThumb = w.rcThumbActual;
             }
 
@@ -1093,18 +1185,47 @@ static void ComputeLayout(HMONITOR hMon) {
             }
 
             int width = 0;
-            int original_width = 0;
+            int thumbWidth = 0;
+            int actualThumbH = thumbH;
 
             if (g_settings.showThumbnails && thumbH > 0) {
                 if (w.effectiveSourceSize.cx > 0 && w.effectiveSourceSize.cy > 0) {
-                    width = (int)((double)w.effectiveSourceSize.cx * thumbH / w.effectiveSourceSize.cy);
+                    thumbWidth = (int)((double)w.effectiveSourceSize.cx * thumbH / w.effectiveSourceSize.cy);
                 } else {
-                    width = thumbH;
+                    thumbWidth = thumbH;
                 }
-                if (width > maxTileW || width > w.effectiveSourceSize.cx) {
-                    original_width = width;
-                    if (width > maxTileW) width = maxTileW;
-                    if (w.effectiveSourceSize.cx > 0 && width > w.effectiveSourceSize.cx) width = w.effectiveSourceSize.cx;
+
+                int naturalThumbWidth = thumbWidth;
+                if (thumbWidth > maxTileW) thumbWidth = maxTileW;
+                if (w.effectiveSourceSize.cx > 0 && thumbWidth > w.effectiveSourceSize.cx) thumbWidth = w.effectiveSourceSize.cx;
+                if (naturalThumbWidth > 0 && thumbWidth != naturalThumbWidth) {
+                    actualThumbH = (int)((double)thumbWidth * thumbH / naturalThumbWidth);
+                }
+
+                width = thumbWidth;
+                if (g_settings.rowWidth > 0) {
+                    width = DpiScale(g_settings.rowWidth, dpiX);
+                    if (StretchThumbsToTaskWidth()) {
+                        thumbWidth = sidePlacement ? std::max(0, width - ((rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0)) : width;
+                        if (thumbWidth <= 0) thumbWidth = DpiScale(16, dpiX);
+                        actualThumbH = thumbH;
+                    } else if (thumbWidth > width && width > 0) {
+                        actualThumbH = (int)((double)width * actualThumbH / thumbWidth);
+                        thumbWidth = width;
+                    }
+                }
+
+                if (sidePlacement) {
+                    int headerExtra = (rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0;
+                    if (g_settings.rowWidth > 0) {
+                        int maxThumbW = width - headerExtra;
+                        if (maxThumbW > 0 && thumbWidth > maxThumbW) {
+                            actualThumbH = (int)((double)maxThumbW * actualThumbH / thumbWidth);
+                            thumbWidth = maxThumbW;
+                        }
+                    } else {
+                        width = thumbWidth + headerExtra;
+                    }
                 }
             } else {
                 if (!g_settings.showTitle && g_settings.showIcon) {
@@ -1116,10 +1237,13 @@ static void ComputeLayout(HMONITOR hMon) {
                 } else {
                     width = DpiScale(160, dpiX);
                 }
+                thumbWidth = width;
+                actualThumbH = 0;
             }
 
-            if (g_settings.rowWidth > 0) {
+            if (!g_settings.showThumbnails && g_settings.rowWidth > 0) {
                 width = DpiScale(g_settings.rowWidth, dpiX);
+                thumbWidth = width;
             }
 
             if (curY + bottomInc - initialTop > maxH - masterPad && curY > initialTop + masterPad) {
@@ -1132,21 +1256,35 @@ static void ComputeLayout(HMONITOR hMon) {
                 }
             }
 
-            int actualThumbH = thumbH;
-            if (original_width > 0 && thumbH > 0) {
-                actualThumbH = (int)((double)width * thumbH / original_width);
-            }
-
             w.rcCell.left   = curX - initialLeft + elemPadLeft;
             w.rcCell.top    = curY - initialTop + elemPadTop;
             w.rcCell.right  = curX + width + rightInc - initialLeft - elemPadRight;
             w.rcCell.bottom = curY + bottomInc - initialTop - elemPadBot;
-            if (original_width > 0) {
-                w.rcCell.bottom -= (thumbH - actualThumbH);
+            if (g_settings.showThumbnails) {
+                if (sidePlacement) {
+                    int contentH = std::max(actualThumbH, rowTitleH);
+                    int baseH = std::max(thumbH, rowTitleH);
+                    if (contentH < baseH) {
+                        w.rcCell.bottom -= (baseH - contentH);
+                    }
+                } else if (actualThumbH < thumbH) {
+                    w.rcCell.bottom -= (thumbH - actualThumbH);
+                }
             }
 
             if (g_settings.showThumbnails) {
-                w.rcThumbActual = { curX, curY, curX + width, curY + actualThumbH };
+                int thumbX = curX;
+                int thumbY = curY;
+                if (sidePlacement) {
+                    int contentH = std::max(actualThumbH, rowTitleH);
+                    thumbY = curY + (contentH - actualThumbH) / 2;
+                    if (ThumbnailIsRight()) {
+                        thumbX = curX + width - thumbWidth;
+                    }
+                } else if (!StretchThumbsToTaskWidth() && width > thumbWidth) {
+                    thumbX += (width - thumbWidth) / 2;
+                }
+                w.rcThumbActual = { thumbX, thumbY, thumbX + thumbWidth, thumbY + actualThumbH };
                 w.rcThumb = w.rcThumbActual;
             }
 
@@ -1365,6 +1503,104 @@ static void DrawContour(HDC hdc, RECT rc, int contourSize, int direction) {
     }
 }
 
+static void DrawSelectionFill(HDC hdc, RECT rc) {
+    RECT fillRc = rc;
+    InflateRect(&fillRc, -1, -1);
+    int width = fillRc.right - fillRc.left;
+    int height = fillRc.bottom - fillRc.top;
+    if (width <= 0 || height <= 0) {
+        return;
+    }
+
+    COLORREF c = GetContourColor();
+    BYTE r = GetRValue(c);
+    BYTE g = GetGValue(c);
+    BYTE b = GetBValue(c);
+
+    int cornerRadius = GetTaskUiCornerRadiusPx();
+    if (cornerRadius > 0) {
+        int maxRadius = std::min(width, height) / 2;
+        if (cornerRadius > maxRadius) cornerRadius = maxRadius;
+    }
+
+    Gdiplus::Graphics graphics(hdc);
+    graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+    Gdiplus::SolidBrush brush(Gdiplus::Color(64, r, g, b));
+
+    if (cornerRadius > 0) {
+        Gdiplus::REAL left = (Gdiplus::REAL)fillRc.left;
+        Gdiplus::REAL top = (Gdiplus::REAL)fillRc.top;
+        Gdiplus::REAL w = (Gdiplus::REAL)(fillRc.right - fillRc.left);
+        Gdiplus::REAL h = (Gdiplus::REAL)(fillRc.bottom - fillRc.top);
+        Gdiplus::REAL d = (Gdiplus::REAL)(cornerRadius * 2);
+
+        Gdiplus::GraphicsPath path;
+        path.AddArc(left, top, d, d, 180, 90);
+        path.AddArc(left + w - d, top, d, d, 270, 90);
+        path.AddArc(left + w - d, top + h - d, d, d, 0, 90);
+        path.AddArc(left, top + h - d, d, d, 90, 90);
+        path.CloseFigure();
+        graphics.FillPath(&brush, &path);
+        return;
+    }
+
+    graphics.FillRectangle(&brush,
+                           (Gdiplus::REAL)fillRc.left,
+                           (Gdiplus::REAL)fillRc.top,
+                           (Gdiplus::REAL)width,
+                           (Gdiplus::REAL)height);
+}
+
+static RECT GetHeaderContentRectForEntry(const WindowEntry& e) {
+    int padLeft = DpiScale(SWS_PAD_LEFT, g_dpiX);
+    int padTop = DpiScale(SWS_PAD_TOP, g_dpiY);
+    int padBottom = DpiScale(SWS_PAD_BOTTOM, g_dpiY);
+    RECT rc = {
+        e.rcCell.left + padLeft,
+        e.rcCell.top + padTop,
+        e.rcCell.right - padLeft,
+        e.rcCell.bottom - padBottom,
+    };
+
+    if (!g_settings.showThumbnails) {
+        return rc;
+    }
+
+    if (ThumbnailIsTop()) {
+        int divider = DpiScale(SWS_PAD_DIVIDER, g_dpiY);
+        rc.top = e.rcThumbActual.bottom + divider;
+    } else if (ThumbnailIsBottom()) {
+        int divider = DpiScale(SWS_PAD_DIVIDER, g_dpiY);
+        rc.bottom = e.rcThumbActual.top - divider;
+    } else if (ThumbnailIsSide()) {
+        int divider = DpiScale(SWS_PAD_DIVIDER, g_dpiX);
+        if (ThumbnailIsLeft()) {
+            rc.left = e.rcThumbActual.right + divider;
+        } else {
+            rc.right = e.rcThumbActual.left - divider;
+        }
+    }
+
+    if (rc.right < rc.left) rc.right = rc.left;
+    if (rc.bottom < rc.top) rc.bottom = rc.top;
+    return rc;
+}
+
+static int GetHeaderTopForEntry(const WindowEntry& e) {
+    RECT rcHeader = GetHeaderContentRectForEntry(e);
+    int rowTitleH = GetHeaderRowHeightPx();
+    if (rowTitleH <= 0) {
+        return rcHeader.top;
+    }
+
+    int available = rcHeader.bottom - rcHeader.top;
+    if (available <= rowTitleH) {
+        return rcHeader.top;
+    }
+
+    return rcHeader.top + (available - rowTitleH) / 2;
+}
+
 // Shared drawing routine for both layered and buffered paint paths
 static void DrawSwitcherContent(HDC hdc, bool fillBg) {
     RECT rcClient; GetClientRect(g_hSwitcher, &rcClient);
@@ -1387,7 +1623,6 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
 
     // DPI-scale layout constants for drawing
     int padLeft    = DpiScale(SWS_PAD_LEFT, g_dpiX);
-    int padTop     = DpiScale(SWS_PAD_TOP, g_dpiY);
     int rowTitleH  = GetHeaderRowHeightPx();
     int iconSz     = GetHeaderIconSizePx();
     int cornerRadius = GetTaskUiCornerRadiusPx();
@@ -1399,9 +1634,14 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
         if (e.rcCell.left == 0 && e.rcCell.right == 0 &&
             e.rcCell.top == 0 && e.rcCell.bottom == 0) continue;
 
-        // Selection border: inner contour on rcCell
+        // Selection highlight: configurable border/fill combinations on rcCell.
         if (i == g_selectedIndex) {
-            DrawContour(hdc, e.rcCell, SWS_CONTOUR_SIZE, 1);
+            if (HighlightHasFill()) {
+                DrawSelectionFill(hdc, e.rcCell);
+            }
+            if (HighlightHasBorder()) {
+                DrawContour(hdc, e.rcCell, SWS_CONTOUR_SIZE, 1);
+            }
         }
 
         // Hover thumbnail border: outer contour on rcThumbActual (EP draws both independently)
@@ -1417,25 +1657,29 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
         }
 
         int closeBtnReserve = DpiScale(24, g_dpiX) + padLeft;
+        // Keep centered header content stable: reserve close-button space consistently.
+        // In vertical mode, never reserve space - close button overlays without displacement.
         int btnReserve = 0;
         bool isIconOnly = !g_settings.showThumbnails && !g_settings.showTitle && g_settings.showIcon;
         if (!HeaderIsVertical()) {
-            if (!isIconOnly) {
+            if (!isIconOnly && !(g_settings.showThumbnails && ThumbnailIsSide())) {
                 btnReserve = ((g_settings.centerTaskContent) || i == g_hoverIndex)
                          ? closeBtnReserve
                          : 0;
             }
         }
-        int contentLeft = e.rcCell.left + padLeft;
-        int contentRight = e.rcCell.right - padLeft - btnReserve;
+        RECT rcHeaderContent = GetHeaderContentRectForEntry(e);
+        int contentLeft = rcHeaderContent.left;
+        int contentRight = rcHeaderContent.right - btnReserve;
         if (contentRight < contentLeft) contentRight = contentLeft;
 
+        int headerTop = GetHeaderTopForEntry(e);
         int iconX = contentLeft;
-        int iconY = e.rcCell.top + padTop + (rowTitleH - iconSz) / 2;
+        int iconY = headerTop + (rowTitleH - iconSz) / 2;
         int textLeft = contentLeft;
         if (g_settings.showIcon) textLeft += iconSz + padLeft;
         int textRight = contentRight;
-        int textTop = e.rcCell.top + padTop;
+        int textTop = headerTop;
         int textBottom = textTop + rowTitleH;
 
         if (HeaderIsVertical() && !isIconOnly) {
@@ -1443,7 +1687,7 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
             if (availableW < 0) availableW = 0;
 
             iconX = contentLeft + ((availableW > iconSz) ? (availableW - iconSz) / 2 : 0);
-            iconY = e.rcCell.top + padTop;
+            iconY = headerTop;
 
             int headerGap = DpiScale(4, g_dpiY);
             int textH = GetHeaderTitleHeightPx();
@@ -1509,8 +1753,6 @@ static bool IsWindowTruncated(int idx);
 static void DrawSwitcherOverlay(HDC hdc) {
     if (g_windows.empty()) return;
 
-    int padTop = DpiScale(SWS_PAD_TOP, g_dpiY);
-    int padLeft = DpiScale(SWS_PAD_LEFT, g_dpiX);
     int rowTitleH = GetHeaderRowHeightPx();
 
     for (int idx = 0; idx < (int)g_windows.size(); idx++) {
@@ -1522,11 +1764,13 @@ static void DrawSwitcherOverlay(HDC hdc) {
         if (i == g_hoverIndex) {
             int btnSz = DpiScale(24, g_dpiX);
             int bx, by;
-            if (rowTitleH == 0) {
+            if (rowTitleH == 0 || (g_settings.showThumbnails && ThumbnailIsSide())) {
                 int btnPadding = DpiScale(4, g_dpiX);
                 bx = e.rcThumbActual.right - btnSz - btnPadding;
                 by = e.rcThumbActual.top + btnPadding;
             } else if (!g_settings.showThumbnails && !g_settings.showTitle && g_settings.showIcon) {
+                int padLeft = DpiScale(SWS_PAD_LEFT, g_dpiX);
+                int padTop = DpiScale(SWS_PAD_TOP, g_dpiY);
                 int contentLeft = e.rcCell.left + padLeft;
                 int contentRight = e.rcCell.right - padLeft;
                 int iconSz = GetHeaderIconSizePx();
@@ -1554,9 +1798,11 @@ static void DrawSwitcherOverlay(HDC hdc) {
                     by = iconY;
                 }
             } else {
-                bx = e.rcCell.right - padLeft - btnSz;
-                by = HeaderIsVertical() ? (e.rcCell.top + padTop)
-                                        : (e.rcCell.top + padTop + (rowTitleH - btnSz) / 2);
+                RECT rcHeaderContent = GetHeaderContentRectForEntry(e);
+                int headerTop = GetHeaderTopForEntry(e);
+                bx = rcHeaderContent.right - btnSz;
+                by = HeaderIsVertical() ? headerTop
+                                        : (headerTop + (rowTitleH - btnSz) / 2);
             }
 
             if (g_isCloseHovered) {
@@ -2250,16 +2496,16 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
         bool closeHovered = false;
         if (idx >= 0) {
             auto& e = g_windows[idx];
-            int padL = DpiScale(SWS_PAD_LEFT, g_dpiX);
-            int padT = DpiScale(SWS_PAD_TOP, g_dpiY);
             int titleH = GetHeaderRowHeightPx();
             int btnSz = DpiScale(24, g_dpiX);
             int bx, by;
-            if (titleH == 0) {
+            if (titleH == 0 || (g_settings.showThumbnails && ThumbnailIsSide())) {
                 int btnPadding = DpiScale(4, g_dpiX);
                 bx = e.rcThumbActual.right - btnSz - btnPadding;
                 by = e.rcThumbActual.top + btnPadding;
             } else if (!g_settings.showThumbnails && !g_settings.showTitle && g_settings.showIcon) {
+                int padL = DpiScale(SWS_PAD_LEFT, g_dpiX);
+                int padT = DpiScale(SWS_PAD_TOP, g_dpiY);
                 int contentLeft = e.rcCell.left + padL;
                 int contentRight = e.rcCell.right - padL;
                 int iconSz = GetHeaderIconSizePx();
@@ -2287,9 +2533,11 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
                     by = iconY;
                 }
             } else {
-                bx = e.rcCell.right - padL - btnSz;
-                by = HeaderIsVertical() ? (e.rcCell.top + padT)
-                                        : (e.rcCell.top + padT + (titleH - btnSz) / 2);
+                RECT rcHeaderContent = GetHeaderContentRectForEntry(e);
+                int headerTop = GetHeaderTopForEntry(e);
+                bx = rcHeaderContent.right - btnSz;
+                by = HeaderIsVertical() ? headerTop
+                                        : (headerTop + (titleH - btnSz) / 2);
             }
             if (x >= bx && x <= bx + btnSz && y >= by && y <= by + btnSz) {
                 closeHovered = true;
@@ -2431,6 +2679,14 @@ static void LoadSettings() {
         wcscmp(g_settings.iconSize, L"large") != 0) {
         wcscpy_s(g_settings.iconSize, L"small");
     }
+    v = Wh_GetStringSetting(L"thumbnailPosition");
+    wcscpy_s(g_settings.thumbnailPosition, v ? v : L"bottom"); Wh_FreeStringSetting(v);
+    if (wcscmp(g_settings.thumbnailPosition, L"bottom") != 0 &&
+        wcscmp(g_settings.thumbnailPosition, L"top") != 0 &&
+        wcscmp(g_settings.thumbnailPosition, L"left") != 0 &&
+        wcscmp(g_settings.thumbnailPosition, L"right") != 0) {
+        wcscpy_s(g_settings.thumbnailPosition, L"bottom");
+    }
     v = Wh_GetStringSetting(L"backwardShortcut");
     if (v) {
         wcscpy_s(g_settings.backwardShortcut, v);
@@ -2446,6 +2702,15 @@ static void LoadSettings() {
         wcscpy_s(g_settings.backwardShortcut, L"altShiftTab");
     }
 
+    v = Wh_GetStringSetting(L"highlightStyle");
+    wcscpy_s(g_settings.highlightStyle, v ? v : L"border");
+    Wh_FreeStringSetting(v);
+    if (wcscmp(g_settings.highlightStyle, L"border") != 0 &&
+        wcscmp(g_settings.highlightStyle, L"fillAndBorder") != 0 &&
+        wcscmp(g_settings.highlightStyle, L"fillOnly") != 0) {
+        wcscpy_s(g_settings.highlightStyle, L"border");
+    }
+
     g_settings.opacity = Wh_GetIntSetting(L"opacity");
     if (g_settings.opacity < 0) g_settings.opacity = 0;
     if (g_settings.opacity > 100) g_settings.opacity = 100;
@@ -2453,6 +2718,7 @@ static void LoadSettings() {
     if (g_settings.rowHeight <= 0) g_settings.rowHeight = 230;
     g_settings.rowWidth = Wh_GetIntSetting(L"rowWidth");
     if (g_settings.rowWidth < 0) g_settings.rowWidth = 0;
+    g_settings.stretchThumbnailsToTaskWidth = Wh_GetIntSetting(L"stretchThumbnailsToTaskWidth");
     g_settings.showThumbnails = Wh_GetIntSetting(L"showThumbnails");
     g_settings.showTitle = Wh_GetIntSetting(L"showTitle");
     g_settings.showIcon = Wh_GetIntSetting(L"showIcon");

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -2,7 +2,7 @@
 // @id              simple-window-switcher
 // @name            Simple Window Switcher
 // @description     Replaces the default Alt+Tab with a lightweight window switcher inspired by ExplorerPatcher's Simple Window Switcher
-// @version         1.1
+// @version         1.2
 // @author          Lone
 // @github          https://github.com/Louis047
 // @include         windhawk.exe
@@ -13,22 +13,24 @@
 // ==WindhawkModReadme==
 /*
 # Simple Window Switcher
-A lightweight Alt+Tab replacement for Windows, ported from the
-[Simple Window Switcher](https://github.com/valinet/sws) project.
+A lightweight Alt+Tab replacement for Windows, ported from the [Simple Window Switcher](https://github.com/valinet/sws) project.
 Additional improvements made by [Asteski](https://github.com/Asteski).
 
 ## Features
 - Grid layout with live DWM thumbnail previews
 - Different Task List and Header Content layouts
+- Center align task list content and titles (horizontal and vertical options)
 - Keyboard navigation (Tab/Shift+Tab/Shift/Backtick, Arrow keys, Enter, Esc)
 - Mouse click to select, scroll wheel to cycle
 - Alt+Ctrl+Tab sticky mode
-- Theme support (None/Backdrop Acrylic)
+- Theme support (None/Backdrop Acrylic) with fully customizable background opacity
 - Works with elevated/admin applications
 - Dark/light mode auto-detection
 - Custom border colors with optional Windows accent color
 - DPI-aware, multi-monitor aware
 - Rounded corners for switcher and task thumbnails (optional)
+- Dynamic UI adjustments (e.g., intelligent close button placement over thumbnails)
+- Highly reliable Explorer restart prompt handling without infinite loops
 
 ## Screenshots
 
@@ -89,6 +91,10 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 - showThumbnails: true
   $name: Show Thumbnails
   $description: Show DWM live thumbnail previews of windows.
+- showTitle: true
+  $name: Show Title Label
+- showIcon: true
+  $name: Show Icon
 - taskListOrientation: horizontal
   $name: Task List Orientation
   $description: Arrange tasks left-to-right or top-to-bottom.
@@ -222,13 +228,20 @@ struct Settings {
     WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32];
     WCHAR borderColorDark[16];
     WCHAR borderColorLight[16];
-    int opacity; int rowHeight; int rowWidth;
-    int maxWidthPercent; int maxHeightPercent; int showDelay;
-    bool showThumbnails; bool useAccentColor; bool primaryMonitorOnly; bool perMonitorWindows; bool taskRoundedCorners;
+    int opacity;
+    int rowHeight;
+    int rowWidth;
+    bool showThumbnails;
+    bool showTitle;
+    bool showIcon;
+    int maxWidthPercent;
+    int maxHeightPercent; int showDelay;
+    bool useAccentColor; bool primaryMonitorOnly; bool perMonitorWindows; bool taskRoundedCorners;
     bool centerTaskContent;
 };
 
 static HWND g_hSwitcher = NULL;
+static HWND g_hCloseBtnWnd = NULL;
 static std::vector<WindowEntry> g_windows;
 static int g_selectedIndex = 0, g_hoverIndex = -1;
 static int g_layoutStartIndex = 0; // EP-style: first window index visible in the layout
@@ -281,12 +294,19 @@ static int GetHeaderTitleHeightPx() {
     return MulDiv(18, g_dpiY, 96);
 }
 static int GetHeaderRowHeightPx() {
+    if (!g_settings.showTitle && !g_settings.showIcon) {
+        return 0;
+    }
+
     if (!HeaderIsVertical()) {
         return MulDiv(SWS_ROW_TITLE_HEIGHT, g_dpiY, 96);
     }
 
     int gap = MulDiv(4, g_dpiY, 96);
-    return GetHeaderIconSizePx() + gap + GetHeaderTitleHeightPx();
+    int h = 0;
+    if (g_settings.showIcon) h += GetHeaderIconSizePx();
+    if (g_settings.showTitle) h += (h > 0 ? gap : 0) + GetHeaderTitleHeightPx();
+    return h;
 }
 static INT GetCornerPref() {
     if (wcscmp(g_settings.cornerPreference, L"none") == 0) return 1;
@@ -815,7 +835,8 @@ static void ComputeLayout(HMONITOR hMon) {
     // bottomInc    = (thumbH + padBot) + elemPadBot + initialTop
     int initialLeft = elemPadLeft + padLeft;
     int rightInc    = (padRight + elemPadRight) + initialLeft;
-    int initialTop  = elemPadTop + (padTop + rowTitleH + padDivider);
+    int activePadDivider = (g_settings.showThumbnails && rowTitleH > 0) ? padDivider : 0;
+    int initialTop  = elemPadTop + (padTop + rowTitleH + activePadDivider);
     int bottomInc   = (thumbH + padBot) + elemPadBot + initialTop;
 
     int maxW = monW * g_settings.maxWidthPercent / 100;
@@ -1237,6 +1258,7 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
 
     if (fillBg) {
         BYTE bgA = (BYTE)(g_settings.opacity * 255 / 100);
+        if (bgA == 0) bgA = 1; // Prevent full transparency click-through
         COLORREF bgC = g_isDarkMode ? SWS_BG_DARK : SWS_BG_LIGHT;
         BYTE bgR = GetRValue(bgC), bgG = GetGValue(bgC), bgB = GetBValue(bgC);
         RGBQUAD bgPx = { (BYTE)(bgB*bgA/255), (BYTE)(bgG*bgA/255), (BYTE)(bgR*bgA/255), bgA };
@@ -1280,12 +1302,120 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
             MaskRectCorners(hdc, inset, cornerRadius);
         }
 
+        int closeBtnReserve = DpiScale(24, g_dpiX) + padLeft;
+        // Keep centered header content stable: reserve close-button space consistently.
+        // In vertical mode, never reserve space - close button overlays without displacement.
+        int btnReserve = 0;
+        if (!HeaderIsVertical()) {
+            btnReserve = ((g_settings.centerTaskContent) || i == g_hoverIndex)
+                     ? closeBtnReserve
+                     : 0;
+        }
+        int contentLeft = e.rcCell.left + padLeft;
+        int contentRight = e.rcCell.right - padLeft - btnReserve;
+        if (contentRight < contentLeft) contentRight = contentLeft;
+
+        int iconX = contentLeft;
+        int iconY = e.rcCell.top + padTop + (rowTitleH - iconSz) / 2;
+        int textLeft = contentLeft;
+        if (g_settings.showIcon) textLeft += iconSz + padLeft;
+        int textRight = contentRight;
+        int textTop = e.rcCell.top + padTop;
+        int textBottom = textTop + rowTitleH;
+
+        if (HeaderIsVertical()) {
+            int availableW = contentRight - contentLeft;
+            if (availableW < 0) availableW = 0;
+
+            iconX = contentLeft + fmax(0, (availableW - iconSz) / 2);
+            iconY = e.rcCell.top + padTop;
+
+            int headerGap = DpiScale(4, g_dpiY);
+            int textH = GetHeaderTitleHeightPx();
+            textTop = g_settings.showIcon ? (iconY + iconSz + headerGap) : iconY;
+            textBottom = textTop + textH;
+            textLeft = contentLeft;
+            textRight = contentRight;
+        } else if (g_settings.centerTaskContent) {
+            int availableW = contentRight - contentLeft;
+            if (availableW < 0) availableW = 0;
+
+            int gap = padLeft;
+            int textMaxW = availableW - (g_settings.showIcon ? iconSz + gap : 0);
+            if (textMaxW < 0) textMaxW = 0;
+
+            int textW = 0;
+            if (g_settings.showTitle && textMaxW > 0 && e.title[0]) {
+                RECT rcMeasure = { 0, 0, textMaxW, rowTitleH };
+                DrawTextW(hdc, e.title, -1, &rcMeasure,
+                          DT_SINGLELINE | DT_VCENTER | DT_END_ELLIPSIS | DT_NOPREFIX | DT_CALCRECT);
+                textW = rcMeasure.right - rcMeasure.left;
+                if (textW < 0) textW = 0;
+                if (textW > textMaxW) textW = textMaxW;
+            }
+
+            int blockW = (g_settings.showIcon ? iconSz : 0) + ((g_settings.showIcon && textW > 0) ? gap : 0) + textW;
+            if (blockW < availableW) {
+                iconX = contentLeft + (availableW - blockW) / 2;
+            }
+
+            textLeft = iconX + (g_settings.showIcon ? iconSz + ((textW > 0) ? gap : 0) : 0);
+            textRight = textLeft + textW;
+        }
+
+        // Icon
+        if (g_settings.showIcon && e.hIcon) DrawIconEx(hdc, iconX, iconY, e.hIcon, iconSz, iconSz, 0, NULL, DI_NORMAL);
+
+        // Title text
+        if (g_settings.showTitle) {
+            RECT rcText = { textLeft, textTop, textRight, textBottom };
+            if (rcText.right < rcText.left) rcText.right = rcText.left;
+            if (g_hTheme) {
+                DTTOPTS opts = { sizeof(DTTOPTS) };
+                opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
+                opts.crText = g_isDarkMode ? SWS_TEXT_DARK : SWS_TEXT_LIGHT;
+                DrawThemeTextEx(g_hTheme, hdc, 0, 0, e.title, -1,
+                    DT_SINGLELINE | (HeaderIsVertical() ? DT_CENTER : DT_VCENTER) | DT_END_ELLIPSIS | DT_NOPREFIX, &rcText, &opts);
+            } else {
+                SetTextColor(hdc, g_isDarkMode ? SWS_TEXT_DARK : SWS_TEXT_LIGHT);
+                DrawTextW(hdc, e.title, -1, &rcText,
+                          DT_SINGLELINE | (HeaderIsVertical() ? DT_CENTER : DT_VCENTER) | DT_END_ELLIPSIS | DT_NOPREFIX);
+            }
+        }
+    }
+    SelectObject(hdc, hOldFont);
+}
+
+
+// Rendering
+
+static bool IsWindowTruncated(int idx);
+
+static void DrawSwitcherOverlay(HDC hdc) {
+    if (g_windows.empty()) return;
+
+    int padTop = DpiScale(SWS_PAD_TOP, g_dpiY);
+    int padLeft = DpiScale(SWS_PAD_LEFT, g_dpiX);
+    int rowTitleH = GetHeaderRowHeightPx();
+
+    for (int idx = 0; idx < (int)g_windows.size(); idx++) {
+        int i = (g_layoutStartIndex + idx) % g_windows.size();
+        auto& e = g_windows[i];
+        if (IsWindowTruncated(i)) continue;
+
         // Close button (positioned at top-right of the cell, in title area)
         if (i == g_hoverIndex) {
             int btnSz = DpiScale(24, g_dpiX);
-            int bx = e.rcCell.right - padLeft - btnSz;
-            int by = HeaderIsVertical() ? (e.rcCell.top + padTop)
+            int bx, by;
+            if (rowTitleH == 0) {
+                int btnPadding = DpiScale(4, g_dpiX);
+                bx = e.rcThumbActual.right - btnSz - btnPadding;
+                by = e.rcThumbActual.top + btnPadding;
+            } else {
+                bx = e.rcCell.right - padLeft - btnSz;
+                by = HeaderIsVertical() ? (e.rcCell.top + padTop)
                                         : (e.rcCell.top + padTop + (rowTitleH - btnSz) / 2);
+            }
 
             if (g_isCloseHovered) {
                 // Red rounded background for close button
@@ -1318,90 +1448,31 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
             graphics.DrawLine(&xPen, bx + p, by + p, bx + btnSz - p, by + btnSz - p);
             graphics.DrawLine(&xPen, bx + btnSz - p, by + p, bx + p, by + btnSz - p);
         }
-
-        int closeBtnReserve = DpiScale(24, g_dpiX) + padLeft;
-        // Keep centered header content stable: reserve close-button space consistently.
-        // In vertical mode, never reserve space - close button overlays without displacement.
-        int btnReserve = 0;
-        if (!HeaderIsVertical()) {
-            btnReserve = ((g_settings.centerTaskContent) || i == g_hoverIndex)
-                     ? closeBtnReserve
-                     : 0;
-        }
-        int contentLeft = e.rcCell.left + padLeft;
-        int contentRight = e.rcCell.right - padLeft - btnReserve;
-        if (contentRight < contentLeft) contentRight = contentLeft;
-
-        int iconX = contentLeft;
-        int iconY = e.rcCell.top + padTop + (rowTitleH - iconSz) / 2;
-        int textLeft = iconX + iconSz + padLeft;
-        int textRight = contentRight;
-        int textTop = e.rcCell.top + padTop;
-        int textBottom = textTop + rowTitleH;
-
-        if (HeaderIsVertical()) {
-            int availableW = contentRight - contentLeft;
-            if (availableW < 0) availableW = 0;
-
-            iconX = contentLeft + fmax(0, (availableW - iconSz) / 2);
-            iconY = e.rcCell.top + padTop;
-
-            int headerGap = DpiScale(4, g_dpiY);
-            int textH = GetHeaderTitleHeightPx();
-            textTop = iconY + iconSz + headerGap;
-            textBottom = textTop + textH;
-            textLeft = contentLeft;
-            textRight = contentRight;
-        } else if (g_settings.centerTaskContent) {
-            int availableW = contentRight - contentLeft;
-            if (availableW < 0) availableW = 0;
-
-            int gap = padLeft;
-            int textMaxW = availableW - iconSz - gap;
-            if (textMaxW < 0) textMaxW = 0;
-
-            int textW = 0;
-            if (textMaxW > 0 && e.title[0]) {
-                RECT rcMeasure = { 0, 0, textMaxW, rowTitleH };
-                DrawTextW(hdc, e.title, -1, &rcMeasure,
-                          DT_SINGLELINE | DT_VCENTER | DT_END_ELLIPSIS | DT_NOPREFIX | DT_CALCRECT);
-                textW = rcMeasure.right - rcMeasure.left;
-                if (textW < 0) textW = 0;
-                if (textW > textMaxW) textW = textMaxW;
-            }
-
-            int blockW = iconSz + ((textW > 0) ? gap : 0) + textW;
-            if (blockW < availableW) {
-                iconX = contentLeft + (availableW - blockW) / 2;
-            }
-
-            textLeft = iconX + iconSz + ((textW > 0) ? gap : 0);
-            textRight = textLeft + textW;
-        }
-
-        // Icon
-        if (e.hIcon) DrawIconEx(hdc, iconX, iconY, e.hIcon, iconSz, iconSz, 0, NULL, DI_NORMAL);
-
-        // Title text
-        RECT rcText = { textLeft, textTop, textRight, textBottom };
-        if (rcText.right < rcText.left) rcText.right = rcText.left;
-        if (g_hTheme) {
-            DTTOPTS opts = { sizeof(DTTOPTS) };
-            opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
-            opts.crText = g_isDarkMode ? SWS_TEXT_DARK : SWS_TEXT_LIGHT;
-            DrawThemeTextEx(g_hTheme, hdc, 0, 0, e.title, -1,
-                DT_SINGLELINE | (HeaderIsVertical() ? DT_CENTER : DT_VCENTER) | DT_END_ELLIPSIS | DT_NOPREFIX, &rcText, &opts);
-        } else {
-            SetTextColor(hdc, g_isDarkMode ? SWS_TEXT_DARK : SWS_TEXT_LIGHT);
-            DrawTextW(hdc, e.title, -1, &rcText,
-                      DT_SINGLELINE | (HeaderIsVertical() ? DT_CENTER : DT_VCENTER) | DT_END_ELLIPSIS | DT_NOPREFIX);
-        }
     }
-    SelectObject(hdc, hOldFont);
 }
 
+static void PaintSwitcherOverlay() {
+    if (!g_hCloseBtnWnd || !g_isVisible) return;
+    RECT rc; GetClientRect(g_hSwitcher, &rc);
+    int w = rc.right, h = rc.bottom;
+    if (w <= 0 || h <= 0) return;
+    HDC hdcScreen = GetDC(g_hCloseBtnWnd);
+    HDC hdcMem = CreateCompatibleDC(hdcScreen);
+    BITMAPINFO bmi = {}; bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth = w; bmi.bmiHeader.biHeight = -h;
+    bmi.bmiHeader.biPlanes = 1; bmi.bmiHeader.biBitCount = 32; bmi.bmiHeader.biCompression = BI_RGB;
+    void* bits = NULL;
+    HBITMAP hBmp = CreateDIBSection(hdcMem, &bmi, DIB_RGB_COLORS, &bits, NULL, 0);
+    HBITMAP hOld = (HBITMAP)SelectObject(hdcMem, hBmp);
 
-// Rendering
+    DrawSwitcherOverlay(hdcMem);
+
+    POINT ptSrc = {0,0}; SIZE sz = {w, h};
+    BLENDFUNCTION bf = {AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
+    UpdateLayeredWindow(g_hCloseBtnWnd, hdcScreen, NULL, &sz, hdcMem, &ptSrc, 0, &bf, ULW_ALPHA);
+    SelectObject(hdcMem, hOld); DeleteObject(hBmp); DeleteDC(hdcMem);
+    ReleaseDC(g_hCloseBtnWnd, hdcScreen);
+}
 
 static void PaintSwitcher() {
     if (!g_hSwitcher || !g_isVisible) return;
@@ -1424,10 +1495,12 @@ static void PaintSwitcher() {
         UpdateLayeredWindow(g_hSwitcher, hdcScreen, NULL, &sz, hdcMem, &ptSrc, 0, &bf, ULW_ALPHA);
         SelectObject(hdcMem, hOld); DeleteObject(hBmp); DeleteDC(hdcMem);
         ReleaseDC(g_hSwitcher, hdcScreen);
+        PaintSwitcherOverlay();
     } else {
         // Acrylic: trigger WM_PAINT via InvalidateRect
         InvalidateRect(g_hSwitcher, NULL, TRUE);
         UpdateWindow(g_hSwitcher);
+        PaintSwitcherOverlay();
     }
 }
 
@@ -1487,6 +1560,10 @@ static void RevealPendingSwitcher() {
     int h = g_pendingSwitcherRect.bottom - g_pendingSwitcherRect.top;
 
     SetWindowPos(g_hSwitcher, HWND_TOPMOST, x, y, w, h, SWP_NOACTIVATE);
+    if (g_hCloseBtnWnd) {
+        SetWindowPos(g_hCloseBtnWnd, HWND_TOPMOST, x, y, w, h, SWP_NOACTIVATE);
+        ShowWindow(g_hCloseBtnWnd, SW_SHOWNA);
+    }
 
     RegisterThumbnails();
     PaintSwitcher();
@@ -1582,6 +1659,10 @@ static void ShowSwitcher(bool sticky) {
     SetWindowPos(g_hSwitcher, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
     ShowWindow(g_hSwitcher, SW_SHOWNA);
     SetForegroundWindow(g_hSwitcher);
+    if (g_hCloseBtnWnd) {
+        SetWindowPos(g_hCloseBtnWnd, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
+        ShowWindow(g_hCloseBtnWnd, SW_SHOWNA);
+    }
 
     RegisterThumbnails();
     PaintSwitcher();
@@ -1593,6 +1674,9 @@ static void HideSwitcher() {
     UnregisterThumbnails();
     if (g_hSwitcher) {
         ShowWindow(g_hSwitcher, SW_HIDE);
+    }
+    if (g_hCloseBtnWnd) {
+        ShowWindow(g_hCloseBtnWnd, SW_HIDE);
     }
 
     g_isVisible = false;
@@ -1646,6 +1730,9 @@ static void RecomputeAndReposition() {
     }
 
     SetWindowPos(g_hSwitcher, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
+    if (g_hCloseBtnWnd && g_isVisible && !g_isPendingShow) {
+        SetWindowPos(g_hCloseBtnWnd, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
+    }
     RegisterThumbnails();
 }
 
@@ -2025,9 +2112,16 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
             int padT = DpiScale(SWS_PAD_TOP, g_dpiY);
             int titleH = GetHeaderRowHeightPx();
             int btnSz = DpiScale(24, g_dpiX);
-            int bx = e.rcCell.right - padL - btnSz;
-            int by = HeaderIsVertical() ? (e.rcCell.top + padT)
+            int bx, by;
+            if (titleH == 0) {
+                int btnPadding = DpiScale(4, g_dpiX);
+                bx = e.rcThumbActual.right - btnSz - btnPadding;
+                by = e.rcThumbActual.top + btnPadding;
+            } else {
+                bx = e.rcCell.right - padL - btnSz;
+                by = HeaderIsVertical() ? (e.rcCell.top + padT)
                                         : (e.rcCell.top + padT + (titleH - btnSz) / 2);
+            }
             if (x >= bx && x <= bx + btnSz && y >= by && y <= by + btnSz) {
                 closeHovered = true;
             }
@@ -2058,6 +2152,9 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
                     int cx = (rmi.rcWork.left + rmi.rcWork.right - g_winW) / 2;
                     int cy = (rmi.rcWork.top + rmi.rcWork.bottom - g_winH) / 2;
                     SetWindowPos(g_hSwitcher, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
+                    if (g_hCloseBtnWnd) {
+                        SetWindowPos(g_hCloseBtnWnd, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
+                    }
                     RegisterThumbnails();
                     g_hoverIndex = -1;
                     g_isCloseHovered = false;
@@ -2094,6 +2191,8 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
 
 // Hotkey Helpers
 
+static HANDLE g_hHotkeyMutex = NULL;
+
 static void SWS_RegisterHotkeys() {
     if (g_hotkeysRegistered || !g_hSwitcher) return;
     BOOL r1 = RegisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTTAB, MOD_ALT, VK_TAB);
@@ -2103,6 +2202,9 @@ static void SWS_RegisterHotkeys() {
     BOOL r5 = RegisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTBACKTICK, MOD_ALT, VK_OEM_3);
     if (r1 && r2 && r3 && r4 && r5) {
         g_hotkeysRegistered = true;
+        if (!g_hHotkeyMutex) {
+            g_hHotkeyMutex = CreateMutexW(NULL, TRUE, L"Windhawk_SWS_HotkeyMutex");
+        }
         KillTimer(g_hSwitcher, SWS_HOTKEY_RETRY_TIMER_ID);
         Wh_Log(L"All hotkeys registered successfully");
     } else {
@@ -2124,6 +2226,11 @@ static void SWS_UnregisterHotkeys() {
     UnregisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTSHIFTCTRLTAB);
     UnregisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTBACKTICK);
     g_hotkeysRegistered = false;
+    if (g_hHotkeyMutex) {
+        ReleaseMutex(g_hHotkeyMutex);
+        CloseHandle(g_hHotkeyMutex);
+        g_hHotkeyMutex = NULL;
+    }
     Wh_Log(L"Hotkeys unregistered");
 }
 
@@ -2171,12 +2278,18 @@ static void LoadSettings() {
     }
 
     g_settings.opacity = Wh_GetIntSetting(L"opacity");
-    if (g_settings.opacity <= 0 || g_settings.opacity > 100) g_settings.opacity = 90;
+    if (g_settings.opacity < 0) g_settings.opacity = 0;
+    if (g_settings.opacity > 100) g_settings.opacity = 100;
     g_settings.rowHeight = Wh_GetIntSetting(L"rowHeight");
     if (g_settings.rowHeight <= 0) g_settings.rowHeight = 230;
     g_settings.rowWidth = Wh_GetIntSetting(L"rowWidth");
     if (g_settings.rowWidth < 0) g_settings.rowWidth = 0;
     g_settings.showThumbnails = Wh_GetIntSetting(L"showThumbnails");
+    g_settings.showTitle = Wh_GetIntSetting(L"showTitle");
+    g_settings.showIcon = Wh_GetIntSetting(L"showIcon");
+    if (!g_settings.showThumbnails && !g_settings.showTitle && !g_settings.showIcon) {
+        g_settings.showTitle = true;
+    }
     g_settings.maxWidthPercent = Wh_GetIntSetting(L"maxWidthPercent");
     if (g_settings.maxWidthPercent <= 0 || g_settings.maxWidthPercent > 100) g_settings.maxWidthPercent = 80;
     g_settings.maxHeightPercent = Wh_GetIntSetting(L"maxHeightPercent");
@@ -2252,6 +2365,11 @@ static DWORD WINAPI SwitcherThread(LPVOID lpParam) {
         WS_POPUP, 0, 0, 0, 0, NULL, NULL, GetModuleHandleW(NULL), NULL);
     if (!g_hSwitcher) { Wh_Log(L"Failed to create switcher window"); return 1; }
 
+    g_hCloseBtnWnd = CreateWindowExW(
+        WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_LAYERED | WS_EX_TRANSPARENT,
+        SWS_CLASSNAME, L"",
+        WS_POPUP, 0, 0, 0, 0, g_hSwitcher, NULL, GetModuleHandleW(NULL), NULL);
+
     BOOL bExclude = TRUE;
     DwmSetWindowAttribute(g_hSwitcher, DWMWA_EXCLUDED_FROM_PEEK, &bExclude, sizeof(bExclude));
 
@@ -2275,6 +2393,7 @@ static DWORD WINAPI SwitcherThread(LPVOID lpParam) {
     if (g_isVisible) HideSwitcher();
     UnregisterThumbnails();
     g_windows.clear();
+    if (g_hCloseBtnWnd) { DestroyWindow(g_hCloseBtnWnd); g_hCloseBtnWnd = NULL; }
     if (g_hSwitcher) { DeregisterShellHookWindow(g_hSwitcher); DestroyWindow(g_hSwitcher); g_hSwitcher = NULL; }
     UnregisterClassW(SWS_CLASSNAME, GetModuleHandleW(NULL));
     if (g_hFont) { DeleteObject(g_hFont); g_hFont = NULL; }
@@ -2347,26 +2466,7 @@ static bool IsMainExplorer() {
     return true;
 }
 
-static bool IsExplorerUptimeLarge() {
-    FILETIME creationTime, exitTime, kernelTime, userTime;
-    if (GetProcessTimes(GetCurrentProcess(), &creationTime, &exitTime, &kernelTime, &userTime)) {
-        ULARGE_INTEGER creation;
-        creation.LowPart = creationTime.dwLowDateTime;
-        creation.HighPart = creationTime.dwHighDateTime;
-        
-        FILETIME systemTime;
-        GetSystemTimeAsFileTime(&systemTime);
-        ULARGE_INTEGER current;
-        current.LowPart = systemTime.dwLowDateTime;
-        current.HighPart = systemTime.dwHighDateTime;
-        
-        // 30 seconds = 300,000,000 intervals of 100ns
-        if (current.QuadPart > creation.QuadPart && (current.QuadPart - creation.QuadPart) > 300000000ULL) {
-            return true;
-        }
-    }
-    return false;
-}
+
 
 BOOL Wh_ModInit() {
     WCHAR exePath[MAX_PATH];
@@ -2395,19 +2495,33 @@ BOOL Wh_ModInit() {
 
         // Check if Explorer has already registered standard hotkeys.
         // We use Alt+Tab as a probe. If it fails, Explorer is mid-session and already owns it.
-        // We only do this for the main Explorer process, and only if it's been running for a while (>30s),
-        // to avoid false prompts on system startup or when secondary Explorers are launched.
-        if (!GetSystemMetrics(SM_SHUTTINGDOWN) && IsMainExplorer() && IsExplorerUptimeLarge()) {
+        // We only do this for the main Explorer process to avoid false prompts in secondary Explorers.
+        if (!GetSystemMetrics(SM_SHUTTINGDOWN) && IsMainExplorer()) {
             Wh_Log(L"SWS: Checking if Explorer is mid-session -> probing Alt+Tab");
             if (!RegisterHotKey(NULL, 0x1337, MOD_ALT, VK_TAB)) {
-                Wh_Log(L"SWS: Alt+Tab failed -> Explorer is mid-session, prompting");
-                PromptForExplorerRestart();
+                HANDLE hMutex = OpenMutexW(MUTEX_ALL_ACCESS, FALSE, L"Windhawk_SWS_HotkeyMutex");
+                bool isToolModHolding = false;
+                if (hMutex) {
+                    if (WaitForSingleObject(hMutex, 0) == WAIT_TIMEOUT) {
+                        isToolModHolding = true;
+                    } else {
+                        ReleaseMutex(hMutex);
+                    }
+                    CloseHandle(hMutex);
+                }
+
+                if (isToolModHolding) {
+                    Wh_Log(L"SWS: Alt+Tab failed, but tool mod holds mutex -> skipping prompt");
+                } else {
+                    Wh_Log(L"SWS: Alt+Tab failed, tool mod does NOT hold mutex -> Explorer is mid-session, prompting");
+                    PromptForExplorerRestart();
+                }
             } else {
                 Wh_Log(L"SWS: Alt+Tab succeeded -> Explorer hasn't registered it, skipping prompt");
                 UnregisterHotKey(NULL, 0x1337);
             }
         } else {
-            Wh_Log(L"SWS: System shutting down or early startup/secondary explorer, skipping prompt");
+            Wh_Log(L"SWS: System shutting down or secondary explorer, skipping prompt");
         }
 
         return TRUE;

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -545,6 +545,9 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 #define SWS_TEXT_LIGHT        RGB(0, 0, 0)
 #define SWS_SHOW_DELAY_TIMER_ID 101
 #define SWS_ALT_POLL_TIMER_ID   102
+// Posted by the low-level mouse hook so the heavy CycleLinear work runs in the
+// wndproc instead of on the synchronous raw-input path. WPARAM is the direction.
+#define WM_SWS_SCROLL           (WM_APP + 1)
 
 typedef BOOL (WINAPI *IsShellWindow_t)(HWND);
 typedef HWND (WINAPI *GhostWindowFromHungWindow_t)(HWND);
@@ -3374,8 +3377,6 @@ static void ShowPendingOffscreenWindow() {
     SetForegroundWindow(g_hSwitcher);
 }
 
-static void CycleLinear(int delta);
-
 static LRESULT CALLBACK LowLevelMouseProc(int nCode, WPARAM wParam, LPARAM lParam) {
     if (nCode == HC_ACTION && g_isVisible && wParam == WM_MOUSEWHEEL) {
         MSLLHOOKSTRUCT* pMouseStruct = (MSLLHOOKSTRUCT*)lParam;
@@ -3383,7 +3384,10 @@ static LRESULT CALLBACK LowLevelMouseProc(int nCode, WPARAM wParam, LPARAM lPara
         if (ok) {
             int dir = (short)HIWORD(pMouseStruct->mouseData) > 0 ? -1 : 1;
             if (g_settings.reverseScrollDirection) dir = -dir;
-            CycleLinear(dir);
+            // Defer the heavy CycleLinear work to the wndproc; low-level hook
+            // callbacks run synchronously on the raw-input path and must stay
+            // trivial or Windows will silently drop the hook.
+            PostMessage(g_hSwitcher, WM_SWS_SCROLL, (WPARAM)dir, 0);
             return 1;
         }
     }
@@ -4239,17 +4243,11 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
         }
         break;
     // (Removed duplicate combined case for WM_SYSKEYUP and WM_KEYUP)
-    case WM_MOUSEWHEEL:
+    case WM_SWS_SCROLL:
         if (g_isVisible) {
-            bool ok = ScrollIs(L"always") || (ScrollIs(L"stickyOnly") && g_isSticky);
-            if (ok) {
-                int dir = GET_WHEEL_DELTA_WPARAM(wParam) > 0 ? -1 : 1;
-                if (g_settings.reverseScrollDirection) dir = -dir;
-                CycleLinear(dir); 
-                return 0; 
-            }
+            CycleLinear((int)wParam);
         }
-        break;
+        return 0;
     case WM_SETCURSOR:
         SetCursor(LoadCursor(NULL, IDC_ARROW));
         return TRUE;
@@ -4783,6 +4781,11 @@ static BOOL WINAPI RegisterHotKey_Hook(HWND hWnd, int id, UINT fsModifiers, UINT
 static DWORD WINAPI SwitcherThread(LPVOID lpParam) {
     Wh_Log(L"SwitcherThread starting");
     CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+    // Create the virtual desktop manager on this thread so it lives in the same
+    // apartment that uses it (EnumWindowsProc runs here). An STA interface
+    // pointer is only valid in the apartment that created it.
+    CoCreateInstance(CLSID_VirtualDesktopManager, nullptr, CLSCTX_INPROC_SERVER,
+                     IID_IVirtualDesktopManager, (void**)&g_pVirtualDesktopManager);
     ResolveAPIs();
     LoadSettings();
     g_isDarkMode = ShouldUseDarkMode();
@@ -4847,6 +4850,10 @@ static DWORD WINAPI SwitcherThread(LPVOID lpParam) {
         g_gdiplusToken = 0;
     }
 
+    if (g_pVirtualDesktopManager) {
+        g_pVirtualDesktopManager->Release();
+        g_pVirtualDesktopManager = NULL;
+    }
     CoUninitialize();
     Wh_Log(L"SwitcherThread exiting");
     return 0;
@@ -5029,9 +5036,6 @@ BOOL Wh_ModInit() {
             ExitProcess(1);
         }
 
-        CoInitialize(NULL);
-        CoCreateInstance(CLSID_VirtualDesktopManager, nullptr, CLSCTX_INPROC_SERVER, IID_IVirtualDesktopManager, (void**)&g_pVirtualDesktopManager);
-
         IMAGE_DOS_HEADER* dosHeader =
             (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
         IMAGE_NT_HEADERS* ntHeaders =
@@ -5170,10 +5174,9 @@ void Wh_ModUninit() {
         return;
     }
 
-    if (g_pVirtualDesktopManager) {
-        g_pVirtualDesktopManager->Release();
-        g_pVirtualDesktopManager = NULL;
-    }
+    // g_pVirtualDesktopManager is created, used, and released on the switcher
+    // thread (see SwitcherThread); WhTool_ModUninit joins that thread, which
+    // releases it before CoUninitialize.
     WhTool_ModUninit();
     ExitProcess(0);
 }

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -239,6 +239,8 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 #define SWS_HOTKEY_ALTCTRLTAB       3
 #define SWS_HOTKEY_ALTSHIFTCTRLTAB  4
 #define SWS_HOTKEY_ALTBACKTICK      5
+#define SWS_HOTKEY_WINALTTAB        6
+#define SWS_HOTKEY_WINALTSHIFTTAB   7
 #define SWS_HOTKEY_RETRY_TIMER_ID   100
 #define SWS_HOTKEY_RETRY_INTERVAL   2000
 #define SWS_BG_DARK          RGB(32, 32, 32)
@@ -2413,9 +2415,17 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
         switch (id) {
         case SWS_HOTKEY_ALTTAB:
             break;
+        case SWS_HOTKEY_WINALTTAB:
+            g_showAllMonitors = true;
+            break;
         case SWS_HOTKEY_ALTSHIFTTAB:
             if (!UseAltShiftTabBackward()) return 0;
             isBackward = true;
+            break;
+        case SWS_HOTKEY_WINALTSHIFTTAB:
+            if (!UseAltShiftTabBackward()) return 0;
+            isBackward = true;
+            g_showAllMonitors = true;
             break;
         case SWS_HOTKEY_ALTCTRLTAB:
             isCtrl = true;
@@ -2434,9 +2444,6 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
         }
 
         if (!g_isVisible && !g_isPendingShow) {
-            if (GetAsyncKeyState(VK_LWIN) < 0 || GetAsyncKeyState(VK_RWIN) < 0) {
-                g_showAllMonitors = true;
-            }
             ShowSwitcher(isCtrl);
 
             if (isBackward && g_windows.size() > 1) {
@@ -2698,7 +2705,9 @@ static void SWS_RegisterHotkeys() {
     BOOL r3 = RegisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTCTRLTAB, MOD_ALT | MOD_CONTROL, VK_TAB);
     BOOL r4 = RegisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTSHIFTCTRLTAB, MOD_ALT | MOD_SHIFT | MOD_CONTROL, VK_TAB);
     BOOL r5 = RegisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTBACKTICK, MOD_ALT, VK_OEM_3);
-    if (r1 && r2 && r3 && r4 && r5) {
+    BOOL r6 = RegisterHotKey(g_hSwitcher, SWS_HOTKEY_WINALTTAB, MOD_ALT | MOD_WIN, VK_TAB);
+    BOOL r7 = RegisterHotKey(g_hSwitcher, SWS_HOTKEY_WINALTSHIFTTAB, MOD_ALT | MOD_SHIFT | MOD_WIN, VK_TAB);
+    if (r1 && r2 && r3 && r4 && r5 && r6 && r7) {
         g_hotkeysRegistered = true;
         if (!g_hHotkeyMutex) {
             g_hHotkeyMutex = CreateMutexW(NULL, TRUE, L"Windhawk_SWS_HotkeyMutex");
@@ -2711,6 +2720,8 @@ static void SWS_RegisterHotkeys() {
         if (r3) UnregisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTCTRLTAB);
         if (r4) UnregisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTSHIFTCTRLTAB);
         if (r5) UnregisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTBACKTICK);
+        if (r6) UnregisterHotKey(g_hSwitcher, SWS_HOTKEY_WINALTTAB);
+        if (r7) UnregisterHotKey(g_hSwitcher, SWS_HOTKEY_WINALTSHIFTTAB);
         SetTimer(g_hSwitcher, SWS_HOTKEY_RETRY_TIMER_ID, SWS_HOTKEY_RETRY_INTERVAL, NULL);
         Wh_Log(L"Hotkey registration incomplete, retrying in %dms", SWS_HOTKEY_RETRY_INTERVAL);
     }
@@ -2723,6 +2734,8 @@ static void SWS_UnregisterHotkeys() {
     UnregisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTCTRLTAB);
     UnregisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTSHIFTCTRLTAB);
     UnregisterHotKey(g_hSwitcher, SWS_HOTKEY_ALTBACKTICK);
+    UnregisterHotKey(g_hSwitcher, SWS_HOTKEY_WINALTTAB);
+    UnregisterHotKey(g_hSwitcher, SWS_HOTKEY_WINALTSHIFTTAB);
     g_hotkeysRegistered = false;
     if (g_hHotkeyMutex) {
         ReleaseMutex(g_hHotkeyMutex);

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -115,6 +115,42 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
         - customBgColor: "#202020"
           $name: Custom Switcher Background Color
           $description: HEX color value, used when Switcher Background Color is set to Custom.
+        - iconBgColorMode: default
+          $name: Badge Icon Background Color
+          $description: Color source for the badge icon background pill in dark mode.
+          $options:
+          - default: Default
+          - custom: Custom
+          - accent: Accent
+        - customIconBgColor: "#000000"
+          $name: Custom Badge Icon Background Color
+          $description: HEX color value, used when Badge Icon Background Color is set to Custom.
+        - iconBgOpacity: 55
+          $name: Badge Icon Background Opacity
+          $description: Opacity percentage (0-100) for the badge icon background in dark mode.
+        - indicatorBgColorMode: default
+          $name: Group Indicator Background Color
+          $description: Color source for the group indicator background pill in dark mode.
+          $options:
+          - default: Default
+          - custom: Custom
+          - accent: Accent
+        - customIndicatorBgColor: "#333333"
+          $name: Custom Group Indicator Background Color
+          $description: HEX color value, used when Group Indicator Background Color is set to Custom.
+        - indicatorBgOpacity: 85
+          $name: Group Indicator Background Opacity
+          $description: Opacity percentage (0-100) for the group indicator background in dark mode.
+        - indicatorTextColorMode: default
+          $name: Group Indicator Text Color
+          $description: Color source for the group indicator text in dark mode.
+          $options:
+          - default: Default
+          - custom: Custom
+          - accent: Accent
+        - customIndicatorTextColor: "#FFFFFF"
+          $name: Custom Group Indicator Text Color
+          $description: HEX color value, used when Group Indicator Text Color is set to Custom.
       $name: Dark Mode
     - LightMode:
         - borderColorMode: default
@@ -147,6 +183,42 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
         - customBgColor: "#F3F3F3"
           $name: Custom Switcher Background Color
           $description: HEX color value, used when Switcher Background Color is set to Custom.
+        - iconBgColorMode: default
+          $name: Badge Icon Background Color
+          $description: Color source for the badge icon background pill in light mode.
+          $options:
+          - default: Default
+          - custom: Custom
+          - accent: Accent
+        - customIconBgColor: "#FFFFFF"
+          $name: Custom Badge Icon Background Color
+          $description: HEX color value, used when Badge Icon Background Color is set to Custom.
+        - iconBgOpacity: 55
+          $name: Badge Icon Background Opacity
+          $description: Opacity percentage (0-100) for the badge icon background in light mode.
+        - indicatorBgColorMode: default
+          $name: Group Indicator Background Color
+          $description: Color source for the group indicator background pill in light mode.
+          $options:
+          - default: Default
+          - custom: Custom
+          - accent: Accent
+        - customIndicatorBgColor: "#EAEAEA"
+          $name: Custom Group Indicator Background Color
+          $description: HEX color value, used when Group Indicator Background Color is set to Custom.
+        - indicatorBgOpacity: 85
+          $name: Group Indicator Background Opacity
+          $description: Opacity percentage (0-100) for the group indicator background in light mode.
+        - indicatorTextColorMode: default
+          $name: Group Indicator Text Color
+          $description: Color source for the group indicator text in light mode.
+          $options:
+          - default: Default
+          - custom: Custom
+          - accent: Accent
+        - customIndicatorTextColor: "#000000"
+          $name: Custom Group Indicator Text Color
+          $description: HEX color value, used when Group Indicator Text Color is set to Custom.
       $name: Light Mode
   $name: Theme
 - Appearance:
@@ -168,6 +240,12 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
         - roundThumbnailCorners: false
           $name: Round Thumbnail Corners
           $description: Round the corners of window thumbnails. Uses the radius from Corner Preference.
+        - roundGroupIndicator: false
+          $name: Round Group Indicator
+          $description: Round the corners of the group indicator. Uses the radius from Corner Preference.
+        - roundBadgeIconBackground: false
+          $name: Round Icon Background (only for badge-layout)
+          $description: Round the corners of the badge icon background pill. Uses the radius from Corner Preference.
       $name: Corners
     - Thumbnails:
         - thumbnailPosition: bottom
@@ -241,6 +319,45 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
           $name: Switcher Position Margin (px)
           $description: Offset from the screen edges when using non-centered positions.
       $name: Position
+    - BadgeLayout:
+        - enableBadgeLayout: false
+          $name: Enable Badge Layout (macOS-style)
+          $description: Overlay the icon on top of the thumbnail and place the title outside. Overrides normal header positioning when enabled. Requires Show Thumbnails to be on.
+        - badgeIconPosition: bottomCenter
+          $name: Badge Icon Position
+          $description: Where to place the icon overlay on the thumbnail.
+          $options:
+          - topLeft: Top Left
+          - topCenter: Top Center
+          - topRight: Top Right
+          - centerLeft: Center Left
+          - center: Center
+          - centerRight: Center Right
+          - bottomLeft: Bottom Left
+          - bottomCenter: Bottom Center
+          - bottomRight: Bottom Right
+        - badgeTitlePosition: bottom
+          $name: Badge Title Position
+          $description: Where to place the title label relative to the thumbnail.
+          $options:
+          - top: Above Thumbnail
+          - bottom: Below Thumbnail
+        - showBadgeIconBackground: true
+          $name: Show Badge Icon Background
+          $description: Draw a backdrop shape behind the badge icon. If off, a drop shadow is drawn instead.
+        - showBadgeIconBackgroundShadow: false
+          $name: Show Badge Icon Background Shadow
+          $description: Draw a soft drop shadow under the badge icon background pill.
+        - badgeIconPadding: 4
+          $name: Badge Icon Padding (px)
+          $description: Extra space between the icon and the edge of its background.
+        - badgeIconOffsetX: 0
+          $name: Badge Icon Offset X (px)
+          $description: Nudge the icon horizontally from its default position.
+        - badgeIconOffsetY: 0
+          $name: Badge Icon Offset Y (px)
+          $description: Nudge the icon vertically from its default position.
+      $name: Badge Layout
     - Font:
         - fontFamily: Segoe UI
           $name: Font Family
@@ -257,6 +374,9 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
           - bold: Bold
           - italic: Italic
           - boldItalic: Bold Italic
+        - applyToGroupIndicator: false
+          $name: Apply to Group Indicator
+          $description: Use these custom font settings for the grouped window count indicator badge.
       $name: Font
   $name: Appearance
 - Dimensions:
@@ -291,6 +411,18 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
     - restoreAllWindows: false
       $name: Restore All Windows
       $description: When switching to an application, restore all of its minimized windows to their previous state. Only applies when "Group Windows by Application" is enabled. Tip - to act on a single window instead, tap Ctrl while the application is selected to show all of its windows and pick one.
+    - showGroupIndicator: true
+      $name: Show Group Indicator
+      $description: Show a count badge on grouped application entries indicating how many windows are in the group. Only visible when Group Windows by Application is enabled.
+    - showGroupIndicatorShadow: false
+      $name: Show Group Indicator Shadow
+      $description: Show a soft drop shadow behind the group indicator badge.
+    - groupCloseBehavior: closeRecent
+      $name: Group Close Button Behavior
+      $description: Action when closing a grouped application entry.
+      $options:
+      - closeRecent: Close Most Recent Window
+      - closeAll: Close All Windows
   $name: Grouping
 - Accessibility:
     - showDelay: 0
@@ -421,6 +553,9 @@ struct WindowEntry {
     RECT rcSourceCrop;         // Source crop rect for DWM_TNP_RECTSOURCE
     SIZE effectiveSourceSize;  // Source size after cropping invisible frame
     std::vector<HWND> groupWindows;  // All app windows when grouping by application
+    int drawnIconX;            // X coordinate where the icon is drawn
+    int drawnIconY;            // Y coordinate where the icon is drawn
+    int drawnIconSz;           // Size of the drawn icon
 };
 struct Settings {
     WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32]; WCHAR thumbnailPosition[32]; WCHAR thumbnailAlignment[32]; WCHAR switcherDisplayBehavior[32];
@@ -428,13 +563,20 @@ struct Settings {
     // Global theme settings (apply to both light and dark)
     WCHAR highlightStyle[32]; int opacity;
     // Dark Mode color settings
-    WCHAR borderColorModeDark[16]; WCHAR highlightFillColorModeDark[16]; WCHAR bgColorModeDark[16];
-    WCHAR customBorderColorDark[16]; WCHAR customHighlightFillColorDark[16]; WCHAR customBgColorDark[16];
+    WCHAR borderColorModeDark[16]; WCHAR highlightFillColorModeDark[16]; WCHAR bgColorModeDark[16]; WCHAR iconBgColorModeDark[16];
+    WCHAR customBorderColorDark[16]; WCHAR customHighlightFillColorDark[16]; WCHAR customBgColorDark[16]; WCHAR customIconBgColorDark[16];
+    int iconBgOpacityDark;
+    WCHAR indicatorBgColorModeDark[16]; WCHAR customIndicatorBgColorDark[16]; int indicatorBgOpacityDark;
+    WCHAR indicatorTextColorModeDark[16]; WCHAR customIndicatorTextColorDark[16];
     // Light Mode color settings
-    WCHAR borderColorModeLight[16]; WCHAR highlightFillColorModeLight[16]; WCHAR bgColorModeLight[16];
-    WCHAR customBorderColorLight[16]; WCHAR customHighlightFillColorLight[16]; WCHAR customBgColorLight[16];
+    WCHAR borderColorModeLight[16]; WCHAR highlightFillColorModeLight[16]; WCHAR bgColorModeLight[16]; WCHAR iconBgColorModeLight[16];
+    WCHAR customBorderColorLight[16]; WCHAR customHighlightFillColorLight[16]; WCHAR customBgColorLight[16]; WCHAR customIconBgColorLight[16];
+    int iconBgOpacityLight;
+    WCHAR indicatorBgColorModeLight[16]; WCHAR customIndicatorBgColorLight[16]; int indicatorBgOpacityLight;
+    WCHAR indicatorTextColorModeLight[16]; WCHAR customIndicatorTextColorLight[16];
     WCHAR fontFamily[64]; WCHAR fontStyle[32];
     int fontSize;
+    bool applyToGroupIndicator;
     int rowHeight;
     int rowWidth;
     bool stretchThumbnailsToTaskWidth;
@@ -444,7 +586,7 @@ struct Settings {
     int maxWidthPercent;
     bool autoFitTasks;
     int maxHeightPercent; int showDelay;
-    bool perMonitorWindows; bool taskRoundedCorners; bool roundThumbnailCorners; bool reverseScrollDirection;
+    bool perMonitorWindows; bool taskRoundedCorners; bool roundThumbnailCorners; bool roundGroupIndicator; bool roundBadgeIconBackground; bool reverseScrollDirection;
     bool centerTaskContent;
     bool showApplications;
     WCHAR showTitles[32];
@@ -454,6 +596,18 @@ struct Settings {
     WCHAR switcherPosition[32];
     int switcherPositionMargin;
     bool showHoverBorder;
+    // Badge layout (macOS-style)
+    bool enableBadgeLayout;
+    WCHAR badgeIconPosition[32];
+    WCHAR badgeTitlePosition[16];
+    bool showBadgeIconBackground; bool showBadgeIconBackgroundShadow;
+    int badgeIconPadding;
+    int badgeIconOffsetX;
+    int badgeIconOffsetY;
+    // Grouped indicator
+    bool showGroupIndicator;
+    bool showGroupIndicatorShadow;
+    WCHAR groupCloseBehavior[16];
 };
 
 static std::vector<std::wstring> g_excludeTitlePatterns;
@@ -486,6 +640,7 @@ static int g_dpiX = 96, g_dpiY = 96;
 // visible task count when the setting is enabled.
 static int g_autoFitScalePct = 100;
 static int g_winW = 0, g_winH = 0;
+static int g_activePadDivider = 0;
 static bool g_hotkeysRegistered = false;
 static HMONITOR g_hCurrentMonitor = NULL;
 static Settings g_settings;
@@ -540,6 +695,11 @@ static bool StretchThumbsToTaskWidth() {
 static bool HeaderIsVertical() {
     return HeaderOrientationIs(L"vertical");
 }
+static bool BadgeLayoutActive() {
+    return g_settings.enableBadgeLayout && g_settings.showThumbnails;
+}
+static bool BadgeIconPositionIs(const WCHAR* v) { return wcscmp(g_settings.badgeIconPosition, v) == 0; }
+static bool BadgeTitleIsTop() { return wcscmp(g_settings.badgeTitlePosition, L"top") == 0; }
 static int GetHeaderIconSizeBase() {
     if (IconSizeIs(L"xlarge")) return 64;
     if (IconSizeIs(L"large")) return 48;
@@ -620,6 +780,32 @@ static int GetThumbnailCornerRadiusPx() {
         return MulDiv(g_settings.customCornerRadius, g_dpiX, 96);
     }
     return MulDiv(4, g_dpiX, 96);
+}
+
+static int GetGroupIndicatorCornerRadiusPx(int maxRadius) {
+    if (!g_settings.roundGroupIndicator) {
+        return 0;
+    }
+    int radius = 0;
+    if (wcscmp(g_settings.cornerPreference, L"custom") == 0) {
+        radius = MulDiv(g_settings.customCornerRadius, g_dpiX, 96);
+    } else {
+        radius = MulDiv(4, g_dpiX, 96);
+    }
+    return (radius > maxRadius) ? maxRadius : radius;
+}
+
+static int GetBadgeIconBackgroundCornerRadiusPx(int maxRadius) {
+    if (!g_settings.roundBadgeIconBackground) {
+        return 0;
+    }
+    int radius = 0;
+    if (wcscmp(g_settings.cornerPreference, L"custom") == 0) {
+        radius = MulDiv(g_settings.customCornerRadius, g_dpiX, 96);
+    } else {
+        radius = MulDiv(4, g_dpiX, 96);
+    }
+    return (radius > maxRadius) ? maxRadius : radius;
 }
 
 static void GetSwitcherPosition(const RECT& workArea, int* outX, int* outY) {
@@ -1532,6 +1718,13 @@ static void ComputeLayout(HMONITOR hMon) {
     int padDivider   = DpiScale(SWS_PAD_DIVIDER, dpiY);
     int rowTitleH    = GetHeaderRowHeightPx();
 
+    // Badge layout override: the icon overlays the thumbnail, so the header
+    // row only needs to account for the title text, not the icon.  Also force
+    // the thumbnail position so the title band sits above or below.
+    if (BadgeLayoutActive()) {
+        rowTitleH = g_settings.showTitle ? GetHeaderTitleHeightPx() : 0;
+    }
+
     // EP: cbThumbnailAvailableHeight = cbRowHeight - cbRowTitleHeight - cbTopPadding - 2 * cbBottomPadding
     // All values are DPI-scaled at this point (matching EP lines 826-844)
     int scaledRowH = DpiScale(g_settings.rowHeight, dpiY);
@@ -1541,6 +1734,7 @@ static void ComputeLayout(HMONITOR hMon) {
         if (scaledRowH < floorH) scaledRowH = floorH;
     }
     bool sidePlacement = ThumbnailIsSide() && g_settings.showThumbnails;
+    if (BadgeLayoutActive()) sidePlacement = false;  // badge mode never uses side placement
     int thumbH = 0;
     if (g_settings.showThumbnails) {
         thumbH = scaledRowH - (sidePlacement ? 0 : rowTitleH) - padTop - 2 * padBot;
@@ -1560,8 +1754,63 @@ static void ComputeLayout(HMONITOR hMon) {
     bool thumbBottom = showThumbs ? ThumbnailIsBottom() : true;
     bool thumbTop = showThumbs ? ThumbnailIsTop() : false;
     bool thumbSide = showThumbs ? ThumbnailIsSide() : false;
-    
+
+    // Badge layout: override thumbnail position semantics.
+    // "title on top" → title band above, thumbnail below → thumbBottom = true
+    // "title on bottom" → title band below, thumbnail above → thumbTop = true
     int activePadDivider = (showThumbs && rowTitleH > 0) ? padDivider : 0;
+    
+    if (BadgeLayoutActive()) {
+        thumbSide = false;
+        thumbBottom = BadgeTitleIsTop();
+        thumbTop = !BadgeTitleIsTop();
+
+        // Calculate icon overlap due to offsets to dynamically resize borders & push title away
+        bool isTop = BadgeIconPositionIs(L"topLeft") || BadgeIconPositionIs(L"topCenter") || BadgeIconPositionIs(L"topRight");
+        bool isBottom = BadgeIconPositionIs(L"bottomLeft") || BadgeIconPositionIs(L"bottomCenter") || BadgeIconPositionIs(L"bottomRight");
+        bool isLeft = BadgeIconPositionIs(L"topLeft") || BadgeIconPositionIs(L"centerLeft") || BadgeIconPositionIs(L"bottomLeft");
+        bool isRight = BadgeIconPositionIs(L"topRight") || BadgeIconPositionIs(L"centerRight") || BadgeIconPositionIs(L"bottomRight");
+
+        int shadowPad = g_settings.showBadgeIconBackgroundShadow ? DpiScale(6, dpiY) : 0;
+        int shadowPadX = g_settings.showBadgeIconBackgroundShadow ? DpiScale(6, dpiX) : 0;
+
+        int bIconOffY = DpiScale(g_settings.badgeIconOffsetY, dpiY) + shadowPad;
+        int bIconOffX = DpiScale(g_settings.badgeIconOffsetX, dpiX) + shadowPadX;
+        
+        int bIconOffYNeg = DpiScale(g_settings.badgeIconOffsetY, dpiY) - shadowPad;
+        int bIconOffXNeg = DpiScale(g_settings.badgeIconOffsetX, dpiX) - shadowPadX;
+        
+        int minGapY = DpiScale(8, dpiY);
+        int minGapX = DpiScale(8, dpiX);
+        
+        if (bIconOffY > 0 && isBottom && thumbTop) {
+            int extra = bIconOffY + minGapY - activePadDivider;
+            if (extra > 0) activePadDivider += extra;
+        } else if (bIconOffY > 0 && isBottom && !thumbTop) {
+            int extra = bIconOffY + minGapY - padBot;
+            if (extra > 0) padBot += extra;
+        }
+        
+        if (bIconOffYNeg < 0 && isTop && thumbBottom) {
+            int extra = abs(bIconOffYNeg) + minGapY - activePadDivider;
+            if (extra > 0) activePadDivider += extra;
+        } else if (bIconOffYNeg < 0 && isTop && !thumbBottom) {
+            int extra = abs(bIconOffYNeg) + minGapY - padTop;
+            if (extra > 0) padTop += extra;
+        }
+
+        if (bIconOffX > 0 && isRight) {
+            int extra = bIconOffX + minGapX - padRight;
+            if (extra > 0) padRight += extra;
+        }
+        if (bIconOffXNeg < 0 && isLeft) {
+            int extra = abs(bIconOffXNeg) + minGapX - padLeft;
+            if (extra > 0) padLeft += extra;
+        }
+    }
+    
+    g_activePadDivider = activePadDivider;
+    
     int headerAndDividerH = rowTitleH + activePadDivider;
     int thumbTopOffset = padTop + (thumbBottom ? headerAndDividerH : 0);
     int initialTop  = elemPadTop + thumbTopOffset;
@@ -2053,6 +2302,115 @@ static COLORREF GetBgColor() {
                         SWS_BG_LIGHT);
 }
 
+static COLORREF GetIconBackgroundColor() {
+    if (g_isDarkMode) {
+        return ResolveColor(g_settings.iconBgColorModeDark,
+                            g_settings.customIconBgColorDark,
+                            RGB(0, 0, 0));
+    }
+    return ResolveColor(g_settings.iconBgColorModeLight,
+                        g_settings.customIconBgColorLight,
+                        RGB(255, 255, 255));
+}
+
+static COLORREF GetIndicatorBackgroundColor() {
+    if (g_isDarkMode) {
+        return ResolveColor(g_settings.indicatorBgColorModeDark,
+                            g_settings.customIndicatorBgColorDark,
+                            RGB(51, 51, 51)); // #333333
+    }
+    return ResolveColor(g_settings.indicatorBgColorModeLight,
+                        g_settings.customIndicatorBgColorLight,
+                        RGB(234, 234, 234)); // #EAEAEA
+}
+
+static COLORREF GetIndicatorTextColor() {
+    if (g_isDarkMode) {
+        return ResolveColor(g_settings.indicatorTextColorModeDark,
+                            g_settings.customIndicatorTextColorDark,
+                            RGB(255, 255, 255)); // #FFFFFF
+    }
+    return ResolveColor(g_settings.indicatorTextColorModeLight,
+                        g_settings.customIndicatorTextColorLight,
+                        RGB(0, 0, 0)); // #000000
+}
+
+static Gdiplus::Bitmap* CreateIconShadowBitmap(HICON hIcon, int width, int height, float shadowAlphaMult) {
+    BITMAPINFO bmi = {};
+    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth = width;
+    bmi.bmiHeader.biHeight = -height;
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+    
+    void* pBlackBits = nullptr;
+    void* pWhiteBits = nullptr;
+    HDC hdc = GetDC(NULL);
+    HBITMAP hBmpBlack = CreateDIBSection(hdc, &bmi, DIB_RGB_COLORS, &pBlackBits, NULL, 0);
+    HBITMAP hBmpWhite = CreateDIBSection(hdc, &bmi, DIB_RGB_COLORS, &pWhiteBits, NULL, 0);
+    
+    if (!hBmpBlack || !hBmpWhite) {
+        if (hBmpBlack) DeleteObject(hBmpBlack);
+        if (hBmpWhite) DeleteObject(hBmpWhite);
+        ReleaseDC(NULL, hdc);
+        return nullptr;
+    }
+    
+    HDC hdcMem = CreateCompatibleDC(hdc);
+    
+    // Draw on black
+    HBITMAP hOld = (HBITMAP)SelectObject(hdcMem, hBmpBlack);
+    RECT rc = {0, 0, width, height};
+    HBRUSH blackBrush = CreateSolidBrush(RGB(0, 0, 0));
+    FillRect(hdcMem, &rc, blackBrush);
+    DrawIconEx(hdcMem, 0, 0, hIcon, width, height, 0, NULL, DI_NORMAL);
+    DeleteObject(blackBrush);
+    
+    // Draw on white
+    SelectObject(hdcMem, hBmpWhite);
+    HBRUSH whiteBrush = CreateSolidBrush(RGB(255, 255, 255));
+    FillRect(hdcMem, &rc, whiteBrush);
+    DrawIconEx(hdcMem, 0, 0, hIcon, width, height, 0, NULL, DI_NORMAL);
+    DeleteObject(whiteBrush);
+    
+    SelectObject(hdcMem, hOld);
+    DeleteDC(hdcMem);
+    ReleaseDC(NULL, hdc);
+    
+    // Compute alpha and create shadow bitmap
+    BYTE* shadowBits = new BYTE[width * height * 4];
+    BYTE* blackPtr = (BYTE*)pBlackBits;
+    BYTE* whitePtr = (BYTE*)pWhiteBits;
+    
+    for (int i = 0; i < width * height; ++i) {
+        int idx = i * 4;
+        int whiteB = whitePtr[idx];
+        int blackB = blackPtr[idx];
+        
+        int a = 255 - (whiteB - blackB);
+        if (a < 0) a = 0;
+        if (a > 255) a = 255;
+        
+        int finalAlpha = (int)(a * shadowAlphaMult);
+        if (finalAlpha > 255) finalAlpha = 255;
+        
+        shadowBits[idx] = 0;     // B
+        shadowBits[idx+1] = 0;   // G
+        shadowBits[idx+2] = 0;   // R
+        shadowBits[idx+3] = (BYTE)finalAlpha; // A
+    }
+    
+    Gdiplus::Bitmap* shadowBmp = new Gdiplus::Bitmap(width, height, width * 4, PixelFormat32bppARGB, shadowBits);
+    Gdiplus::Bitmap* shadowBmpCopy = shadowBmp->Clone(0, 0, width, height, PixelFormat32bppARGB);
+    delete shadowBmp;
+    delete[] shadowBits;
+    DeleteObject(hBmpBlack);
+    DeleteObject(hBmpWhite);
+    
+    return shadowBmpCopy;
+}
+
 static void MaskRectCorners(HDC hdc, const RECT& rc, int radiusPx, bool forceOpaque = false, COLORREF overrideBg = CLR_INVALID) {
     if (radiusPx <= 0) {
         return;
@@ -2255,13 +2613,18 @@ static RECT GetHeaderContentRectForEntry(const WindowEntry& e) {
                                     ? e.rcThumbSlot
                                     : e.rcThumbActual;
 
-    if (ThumbnailIsTop()) {
-        int divider = DpiScale(SWS_PAD_DIVIDER, g_dpiY);
-        rc.top = rcHeaderSplit.bottom + divider;
-    } else if (ThumbnailIsBottom()) {
-        int divider = DpiScale(SWS_PAD_DIVIDER, g_dpiY);
-        rc.bottom = rcHeaderSplit.top - divider;
-    } else if (ThumbnailIsSide()) {
+    // In badge mode the title position is controlled by badgeTitlePosition, not thumbnailPosition.
+    // "title on top" → thumb on bottom → header rect is above the thumb (ThumbnailIsBottom semantics)
+    // "title on bottom" → thumb on top → header rect is below the thumb (ThumbnailIsTop semantics)
+    bool effectiveThumbTop = BadgeLayoutActive() ? !BadgeTitleIsTop() : ThumbnailIsTop();
+    bool effectiveThumbBottom = BadgeLayoutActive() ? BadgeTitleIsTop() : ThumbnailIsBottom();
+    bool effectiveThumbSide = BadgeLayoutActive() ? false : ThumbnailIsSide();
+
+    if (effectiveThumbTop) {
+        rc.top = rcHeaderSplit.bottom + g_activePadDivider;
+    } else if (effectiveThumbBottom) {
+        rc.bottom = rcHeaderSplit.top - g_activePadDivider;
+    } else if (effectiveThumbSide) {
         int divider = DpiScale(SWS_PAD_DIVIDER, g_dpiX);
         if (ThumbnailIsLeft()) {
             rc.left = rcHeaderSplit.right + divider;
@@ -2278,6 +2641,9 @@ static RECT GetHeaderContentRectForEntry(const WindowEntry& e) {
 static int GetHeaderTopForEntry(const WindowEntry& e) {
     RECT rcHeader = GetHeaderContentRectForEntry(e);
     int rowTitleH = GetHeaderRowHeightPx();
+    if (BadgeLayoutActive()) {
+        rowTitleH = g_settings.showTitle ? GetHeaderTitleHeightPx() : 0;
+    }
     if (rowTitleH <= 0) {
         return rcHeader.top;
     }
@@ -2343,6 +2709,34 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg, HWND hWnd) {
         }
 
         int closeBtnReserve = DpiScale(24, g_dpiX) + padLeft;
+
+        // ---- Badge layout rendering path ----
+        if (BadgeLayoutActive()) {
+            // Badge title: draw centered in the header content rect
+            if (g_settings.showTitle && e.title[0]) {
+                RECT rcHeaderContent = GetHeaderContentRectForEntry(e);
+                int titleH = GetHeaderTitleHeightPx();
+                int headerTop = GetHeaderTopForEntry(e);
+                RECT rcText = { rcHeaderContent.left, headerTop, rcHeaderContent.right, headerTop + titleH };
+                if (g_hTheme) {
+                    DTTOPTS opts = { sizeof(DTTOPTS) };
+                    opts.dwFlags = DTT_COMPOSITED | DTT_TEXTCOLOR;
+                    opts.crText = g_isDarkMode ? SWS_TEXT_DARK : SWS_TEXT_LIGHT;
+                    DrawThemeTextEx(g_hTheme, hdc, 0, 0, e.title, -1,
+                        DT_SINGLELINE | DT_CENTER | DT_VCENTER | DT_END_ELLIPSIS | DT_NOPREFIX, &rcText, &opts);
+                } else {
+                    SetTextColor(hdc, g_isDarkMode ? SWS_TEXT_DARK : SWS_TEXT_LIGHT);
+                    DrawTextW(hdc, e.title, -1, &rcText,
+                              DT_SINGLELINE | DT_CENTER | DT_VCENTER | DT_END_ELLIPSIS | DT_NOPREFIX);
+                }
+            }
+
+            // Badge icon is drawn in DrawSwitcherOverlay so it appears
+            // above the DWM thumbnail (which composites on top of window content).
+            continue;  // Skip normal header content rendering
+        }
+
+        // ---- Normal (non-badge) header content rendering ----
         // Keep centered header content stable: reserve close-button space consistently.
         // In vertical mode, never reserve space - close button overlays without displacement.
         int btnReserve = 0;
@@ -2409,8 +2803,16 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg, HWND hWnd) {
         }
 
         // Icon
-        if (g_settings.showIcon && e.hIcon) DrawIconEx(hdc, iconX, iconY, e.hIcon, iconSz, iconSz, 0, NULL, DI_NORMAL);
-
+        if (g_settings.showIcon && e.hIcon) {
+            e.drawnIconX = iconX;
+            e.drawnIconY = iconY;
+            e.drawnIconSz = iconSz;
+            DrawIconEx(hdc, iconX, iconY, e.hIcon, iconSz, iconSz, 0, NULL, DI_NORMAL);
+        } else {
+            e.drawnIconX = contentLeft;
+            e.drawnIconY = headerTop;
+            e.drawnIconSz = 0;
+        }
         // Title text
         if (g_settings.showTitle) {
             RECT rcText = { textLeft, textTop, textRight, textBottom };
@@ -2465,11 +2867,115 @@ static void DrawSwitcherOverlay(HDC hdc, HWND hWnd) {
             DrawContour(hdc, e.rcThumbActual, 1, -1, cornerRadius);
         }
 
+        // Badge layout: draw icon overlay on thumbnail (must be in overlay layer
+        // because DWM thumbnails composite on top of window content)
+        if (BadgeLayoutActive() && g_settings.showIcon && e.hIcon) {
+            int iconSz = GetHeaderIconSizePx();
+            int thumbW = e.rcThumbActual.right - e.rcThumbActual.left;
+            int thumbHt = e.rcThumbActual.bottom - e.rcThumbActual.top;
+            if (thumbW > 0 && thumbHt > 0) {
+                int badgePad = DpiScale(g_settings.badgeIconPadding, g_dpiX);
+                int bIconX = 0, bIconY = 0;
+
+                // Horizontal positioning
+                if (BadgeIconPositionIs(L"topLeft") || BadgeIconPositionIs(L"centerLeft") || BadgeIconPositionIs(L"bottomLeft")) {
+                    bIconX = e.rcThumbActual.left + badgePad;
+                } else if (BadgeIconPositionIs(L"topRight") || BadgeIconPositionIs(L"centerRight") || BadgeIconPositionIs(L"bottomRight")) {
+                    bIconX = e.rcThumbActual.right - iconSz - badgePad;
+                } else {
+                    bIconX = e.rcThumbActual.left + (thumbW - iconSz) / 2;
+                }
+                // Vertical positioning
+                if (BadgeIconPositionIs(L"topLeft") || BadgeIconPositionIs(L"topCenter") || BadgeIconPositionIs(L"topRight")) {
+                    bIconY = e.rcThumbActual.top + badgePad;
+                } else if (BadgeIconPositionIs(L"bottomLeft") || BadgeIconPositionIs(L"bottomCenter") || BadgeIconPositionIs(L"bottomRight")) {
+                    bIconY = e.rcThumbActual.bottom - iconSz - badgePad;
+                } else {
+                    bIconY = e.rcThumbActual.top + (thumbHt - iconSz) / 2;
+                }
+
+                bIconX += DpiScale(g_settings.badgeIconOffsetX, g_dpiX);
+                bIconY += DpiScale(g_settings.badgeIconOffsetY, g_dpiY);
+
+                e.drawnIconX = bIconX;
+                e.drawnIconY = bIconY;
+                e.drawnIconSz = iconSz;
+
+                Gdiplus::Graphics gfx(hdc);
+                gfx.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+
+                if (g_settings.showBadgeIconBackground) {
+                    int bgSize = iconSz + badgePad * 2;
+                    int bgX = bIconX - badgePad;
+                    int bgY = bIconY - badgePad;
+                    
+                    COLORREF bgC = GetIconBackgroundColor();
+                    int op = g_isDarkMode ? g_settings.iconBgOpacityDark : g_settings.iconBgOpacityLight;
+                    int alpha = (op * 255) / 100;
+                    Gdiplus::SolidBrush bgBrush(Gdiplus::Color(alpha, GetRValue(bgC), GetGValue(bgC), GetBValue(bgC)));
+                    
+                    Gdiplus::REAL r = (Gdiplus::REAL)GetBadgeIconBackgroundCornerRadiusPx(bgSize / 2);
+                    
+                    if (g_settings.showBadgeIconBackgroundShadow) {
+                        for (int pass = 5; pass > 0; --pass) {
+                            int shadowAlpha = 15 - (pass * 2);
+                            if (shadowAlpha < 1) shadowAlpha = 1;
+                            Gdiplus::SolidBrush shadowBrush(Gdiplus::Color(shadowAlpha, 0, 0, 0));
+                            int sp = pass;
+                            if (r > 0) {
+                                Gdiplus::GraphicsPath sPath;
+                                Gdiplus::REAL sw = (Gdiplus::REAL)(bgSize + sp * 2), sh = sw;
+                                Gdiplus::REAL sx = (Gdiplus::REAL)(bgX - sp), sy = (Gdiplus::REAL)(bgY - sp + 1);
+                                Gdiplus::REAL sd = r * 2 + sp * 2;
+                                if (sd > sw) sd = sw; if (sd > sh) sd = sh;
+                                sPath.AddArc(sx, sy, sd, sd, 180, 90);
+                                sPath.AddArc(sx + sw - sd, sy, sd, sd, 270, 90);
+                                sPath.AddArc(sx + sw - sd, sy + sh - sd, sd, sd, 0, 90);
+                                sPath.AddArc(sx, sy + sh - sd, sd, sd, 90, 90);
+                                sPath.CloseFigure();
+                                gfx.FillPath(&shadowBrush, &sPath);
+                            } else {
+                                gfx.FillRectangle(&shadowBrush, bgX - sp, bgY - sp + 1, bgSize + sp * 2, bgSize + sp * 2);
+                            }
+                        }
+                    }
+
+                    if (r > 0) {
+                        Gdiplus::GraphicsPath path;
+                        Gdiplus::REAL w = (Gdiplus::REAL)bgSize, h = (Gdiplus::REAL)bgSize;
+                        Gdiplus::REAL x = (Gdiplus::REAL)bgX, y = (Gdiplus::REAL)bgY;
+                        Gdiplus::REAL d = r * 2;
+                        if (d > w) d = w; if (d > h) d = h;
+                        path.AddArc(x, y, d, d, 180, 90);
+                        path.AddArc(x + w - d, y, d, d, 270, 90);
+                        path.AddArc(x + w - d, y + h - d, d, d, 0, 90);
+                        path.AddArc(x, y + h - d, d, d, 90, 90);
+                        path.CloseFigure();
+                        gfx.FillPath(&bgBrush, &path);
+                    } else {
+                        gfx.FillRectangle(&bgBrush, bgX, bgY, bgSize, bgSize);
+                    }
+                    DrawIconEx(hdc, bIconX, bIconY, e.hIcon, iconSz, iconSz, 0, NULL, DI_NORMAL);
+                } else {
+                    Gdiplus::Bitmap* pBmp = CreateIconShadowBitmap(e.hIcon, iconSz, iconSz, 0.08f);
+                    if (pBmp) {
+                        int dx[] = { 0, 1, 0, -1, 1 };
+                        int dy[] = { 1, 0, -1, 0, 1 };
+                        for (int p = 0; p < 5; ++p) {
+                            gfx.DrawImage(pBmp, bIconX + DpiScale(dx[p], g_dpiX), bIconY + DpiScale(dy[p] + 2, g_dpiY), iconSz, iconSz);
+                        }
+                        delete pBmp;
+                    }
+                    DrawIconEx(hdc, bIconX, bIconY, e.hIcon, iconSz, iconSz, 0, NULL, DI_NORMAL);
+                }
+            }
+        }
+
         // Close button (positioned at top-right of the cell, in title area)
         if (i == g_hoverIndex && g_hoverWnd == hWnd) {
             int btnSz = DpiScale(24, g_dpiX);
             int bx, by;
-            if (rowTitleH == 0 || (g_settings.showThumbnails && ThumbnailIsSide())) {
+            if (rowTitleH == 0 || (g_settings.showThumbnails && ThumbnailIsSide()) || BadgeLayoutActive()) {
                 int btnPadding = DpiScale(4, g_dpiX);
                 bx = e.rcThumbActual.right - btnSz - btnPadding;
                 by = e.rcThumbActual.top + btnPadding;
@@ -2540,6 +3046,114 @@ static void DrawSwitcherOverlay(HDC hdc, HWND hWnd) {
             int p = (btnSz == DpiScale(16, g_dpiX)) ? DpiScale(4, g_dpiX) : DpiScale(7, g_dpiX);
             graphics.DrawLine(&xPen, bx + p, by + p, bx + btnSz - p, by + btnSz - p);
             graphics.DrawLine(&xPen, bx + btnSz - p, by + p, bx + p, by + btnSz - p);
+        }
+
+        // Grouped window count badge
+        if (g_settings.showGroupIndicator && g_settings.showApplications &&
+            e.groupWindows.size() > 1) {
+            Gdiplus::Graphics gfx(hdc);
+            gfx.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+            gfx.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAlias);
+
+            // Badge text
+            WCHAR countText[8];
+            _snwprintf_s(countText, ARRAYSIZE(countText), _TRUNCATE, L"%d", (int)e.groupWindows.size());
+
+            // Badge font
+            int badgeFontSz = DpiScale(10, g_dpiX);
+            int fontStyle = Gdiplus::FontStyleBold;
+            LPCWSTR family = L"Segoe UI";
+            if (g_settings.applyToGroupIndicator && g_settings.fontFamily[0]) {
+                family = g_settings.fontFamily;
+                badgeFontSz = MulDiv(g_settings.fontSize, g_dpiY, 72);
+                if (wcscmp(g_settings.fontStyle, L"regular") == 0 || wcscmp(g_settings.fontStyle, L"light") == 0) fontStyle = Gdiplus::FontStyleRegular;
+                else if (wcscmp(g_settings.fontStyle, L"semibold") == 0 || wcscmp(g_settings.fontStyle, L"bold") == 0) fontStyle = Gdiplus::FontStyleBold;
+                else if (wcscmp(g_settings.fontStyle, L"italic") == 0) fontStyle = Gdiplus::FontStyleItalic;
+                else if (wcscmp(g_settings.fontStyle, L"boldItalic") == 0) fontStyle = Gdiplus::FontStyleBoldItalic;
+            }
+            Gdiplus::Font badgeFont(family, (Gdiplus::REAL)badgeFontSz, fontStyle, Gdiplus::UnitPixel);
+
+            // Measure text
+            Gdiplus::StringFormat sf;
+            sf.SetAlignment(Gdiplus::StringAlignmentCenter);
+            sf.SetLineAlignment(Gdiplus::StringAlignmentCenter);
+            Gdiplus::RectF measureRect(0, 0, 100, 100);
+            Gdiplus::RectF textBounds;
+            gfx.MeasureString(countText, -1, &badgeFont, measureRect, &sf, &textBounds);
+
+            int badgePadX = DpiScale(4, g_dpiX);
+            int badgePadY = DpiScale(2, g_dpiY);
+            int badgeW = (int)(textBounds.Width + badgePadX * 2);
+            int badgeH = (int)(textBounds.Height + badgePadY * 2);
+            int minW = badgeH;  // pill shape: at least as wide as tall
+            if (badgeW < minW) badgeW = minW;
+
+            // Position: top-right area of the icon
+            int badgeX, badgeY;
+            if (e.drawnIconSz > 0) {
+                badgeX = e.drawnIconX + e.drawnIconSz - (badgeW / 2);
+                badgeY = e.drawnIconY - (badgeH / 2);
+            } else {
+                int cellPad = DpiScale(4, g_dpiX);
+                badgeX = e.rcCell.right - badgeW - cellPad;
+                badgeY = e.rcCell.top + cellPad;
+            }
+
+            // Background pill
+            COLORREF bgC = GetIndicatorBackgroundColor();
+            int op = g_isDarkMode ? g_settings.indicatorBgOpacityDark : g_settings.indicatorBgOpacityLight;
+            int alpha = (op * 255) / 100;
+            Gdiplus::SolidBrush pillBrush(Gdiplus::Color(alpha, GetRValue(bgC), GetGValue(bgC), GetBValue(bgC)));
+            Gdiplus::REAL pillRadius = (Gdiplus::REAL)GetGroupIndicatorCornerRadiusPx(badgeH / 2);
+            
+            if (g_settings.showGroupIndicatorShadow) {
+                for (int pass = 5; pass > 0; --pass) {
+                    int shadowAlpha = 15 - (pass * 2);
+                    if (shadowAlpha < 1) shadowAlpha = 1;
+                    Gdiplus::SolidBrush shadowBrush(Gdiplus::Color(shadowAlpha, 0, 0, 0));
+                    int sp = pass;
+                    Gdiplus::REAL sx = (Gdiplus::REAL)(badgeX - sp);
+                    Gdiplus::REAL sy = (Gdiplus::REAL)(badgeY - sp + 1);
+                    Gdiplus::REAL sw = (Gdiplus::REAL)(badgeW + sp * 2);
+                    Gdiplus::REAL sh = (Gdiplus::REAL)(badgeH + sp * 2);
+                    Gdiplus::REAL sd = pillRadius * 2.0f + sp * 2.0f;
+                    if (sd > sw) sd = sw; if (sd > sh) sd = sh;
+                    
+                    if (pillRadius > 0) {
+                        Gdiplus::GraphicsPath sPath;
+                        sPath.AddArc(sx, sy, sd, sd, 180, 90);
+                        sPath.AddArc(sx + sw - sd, sy, sd, sd, 270, 90);
+                        sPath.AddArc(sx + sw - sd, sy + sh - sd, sd, sd, 0, 90);
+                        sPath.AddArc(sx, sy + sh - sd, sd, sd, 90, 90);
+                        sPath.CloseFigure();
+                        gfx.FillPath(&shadowBrush, &sPath);
+                    } else {
+                        gfx.FillRectangle(&shadowBrush, sx, sy, sw, sh);
+                    }
+                }
+            }
+
+            if (pillRadius > 0) {
+                Gdiplus::GraphicsPath pillPath;
+                Gdiplus::REAL d = pillRadius * 2.0f;
+                Gdiplus::REAL px = (Gdiplus::REAL)badgeX, py = (Gdiplus::REAL)badgeY;
+                Gdiplus::REAL pw = (Gdiplus::REAL)badgeW, ph = (Gdiplus::REAL)badgeH;
+                pillPath.AddArc(px, py, d, d, 180, 90);
+                pillPath.AddArc(px + pw - d, py, d, d, 270, 90);
+                pillPath.AddArc(px + pw - d, py + ph - d, d, d, 0, 90);
+                pillPath.AddArc(px, py + ph - d, d, d, 90, 90);
+                pillPath.CloseFigure();
+                gfx.FillPath(&pillBrush, &pillPath);
+            } else {
+                gfx.FillRectangle(&pillBrush, badgeX, badgeY, badgeW, badgeH);
+            }
+
+            // Badge text
+            COLORREF txtC = GetIndicatorTextColor();
+            Gdiplus::SolidBrush textBrush(Gdiplus::Color(255, GetRValue(txtC), GetGValue(txtC), GetBValue(txtC)));
+            Gdiplus::RectF pillRect((Gdiplus::REAL)badgeX, (Gdiplus::REAL)badgeY,
+                                    (Gdiplus::REAL)badgeW, (Gdiplus::REAL)badgeH);
+            gfx.DrawString(countText, -1, &badgeFont, pillRect, &sf, &textBrush);
         }
     }
 }
@@ -3234,13 +3848,72 @@ static int HitTestThumb(int x, int y) {
 
 static void SWS_RegisterHotkeys();
 
+static void UpdateEntryForWindow(WindowEntry& e) {
+    InternalGetWindowText(e.hWnd, e.title, 256);
+    if (!e.title[0]) GetWindowTextW(e.hWnd, e.title, 256);
+    e.hIcon = LoadWindowIcon(e.hWnd);
+
+    if (g_settings.showApplications && wcscmp(g_settings.showTitles, L"windowTitle") != 0) {
+        WCHAR appName[256] = {0};
+        GetAppName(e.hWnd, appName, ARRAYSIZE(appName));
+        if (appName[0]) {
+            if (_wcsicmp(appName, L"Application Frame Host") == 0 && e.title[0]) {
+                wcscpy_s(appName, e.title);
+            }
+            if (wcscmp(g_settings.showTitles, L"appName") == 0) {
+                wcscpy_s(e.title, appName);
+            } else {  // appNameWindowTitle
+                if (e.title[0]) {
+                    WCHAR combined[256];
+                    _snwprintf_s(combined, ARRAYSIZE(combined), _TRUNCATE,
+                                 L"%s - %s", appName, e.title);
+                    wcscpy_s(e.title, combined);
+                } else {
+                    wcscpy_s(e.title, appName);
+                }
+            }
+        }
+    }
+}
+
 // Close the window for the entry at idx (graceful WM_CLOSE, same as the close
 // button), remove it from the list and relayout. Shared by the close button,
 // middle-click and the Q key.
 static void CloseSwitcherEntry(int idx) {
     if (idx < 0 || idx >= (int)g_windows.size()) return;
-    PostMessage(g_windows[idx].hWnd, WM_CLOSE, 0, 0);
-    g_windows.erase(g_windows.begin() + idx);
+    
+    bool eraseEntry = true;
+    if (g_settings.showApplications && g_windows[idx].groupWindows.size() > 1) {
+        if (wcscmp(g_settings.groupCloseBehavior, L"closeAll") == 0) {
+            for (HWND hw : g_windows[idx].groupWindows) {
+                PostMessage(hw, WM_CLOSE, 0, 0);
+            }
+        } else {
+            // closeRecent (Default)
+            HWND closedHwnd = g_windows[idx].hWnd;
+            PostMessage(closedHwnd, WM_CLOSE, 0, 0);
+            
+            auto& group = g_windows[idx].groupWindows;
+            group.erase(std::remove(group.begin(), group.end(), closedHwnd), group.end());
+            
+            if (!group.empty()) {
+                eraseEntry = false;
+                g_windows[idx].hWnd = group[0];
+                UpdateEntryForWindow(g_windows[idx]);
+                for (const auto& kv : g_windows[idx].hThumbs) {
+                    if (kv.second) DwmUnregisterThumbnail(kv.second);
+                }
+                g_windows[idx].hThumbs.clear();
+            }
+        }
+    } else {
+        PostMessage(g_windows[idx].hWnd, WM_CLOSE, 0, 0);
+    }
+
+    if (eraseEntry) {
+        g_windows.erase(g_windows.begin() + idx);
+    }
+
     if (g_windows.empty()) { HideSwitcher(); return; }
     if (g_selectedIndex >= (int)g_windows.size()) g_selectedIndex = (int)g_windows.size() - 1;
     UnregisterThumbnails();
@@ -3498,7 +4171,7 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
             int titleH = GetHeaderRowHeightPx();
             int btnSz = DpiScale(24, g_dpiX);
             int bx, by;
-            if (titleH == 0 || (g_settings.showThumbnails && ThumbnailIsSide())) {
+            if (titleH == 0 || (g_settings.showThumbnails && ThumbnailIsSide()) || BadgeLayoutActive()) {
                 int btnPadding = DpiScale(4, g_dpiX);
                 bx = e.rcThumbActual.right - btnSz - btnPadding;
                 by = e.rcThumbActual.top + btnPadding;
@@ -3675,6 +4348,8 @@ static void LoadSettings() {
     if (g_settings.customCornerRadius > 32) g_settings.customCornerRadius = 32;
     g_settings.taskRoundedCorners = Wh_GetIntSetting(L"Appearance.Corners.taskRoundedCorners");
     g_settings.roundThumbnailCorners = Wh_GetIntSetting(L"Appearance.Corners.roundThumbnailCorners");
+    g_settings.roundGroupIndicator = Wh_GetIntSetting(L"Appearance.Corners.roundGroupIndicator");
+    g_settings.roundBadgeIconBackground = Wh_GetIntSetting(L"Appearance.Corners.roundBadgeIconBackground");
     v = Wh_GetStringSetting(L"Accessibility.scrollWheelBehavior");
     wcscpy_s(g_settings.scrollWheelBehavior, v ? v : L"never"); Wh_FreeStringSetting(v);
     v = Wh_GetStringSetting(L"Appearance.Orientation.taskListOrientation");
@@ -3781,6 +4456,42 @@ static void LoadSettings() {
     }
     g_settings.centerTaskContent = Wh_GetIntSetting(L"Appearance.HeaderContent.centerTaskContent");
 
+    // Badge layout settings
+    g_settings.enableBadgeLayout = Wh_GetIntSetting(L"Appearance.BadgeLayout.enableBadgeLayout");
+    v = Wh_GetStringSetting(L"Appearance.BadgeLayout.badgeIconPosition");
+    wcscpy_s(g_settings.badgeIconPosition, v ? v : L"bottomCenter"); Wh_FreeStringSetting(v);
+    if (wcscmp(g_settings.badgeIconPosition, L"topLeft") != 0 &&
+        wcscmp(g_settings.badgeIconPosition, L"topCenter") != 0 &&
+        wcscmp(g_settings.badgeIconPosition, L"topRight") != 0 &&
+        wcscmp(g_settings.badgeIconPosition, L"centerLeft") != 0 &&
+        wcscmp(g_settings.badgeIconPosition, L"center") != 0 &&
+        wcscmp(g_settings.badgeIconPosition, L"centerRight") != 0 &&
+        wcscmp(g_settings.badgeIconPosition, L"bottomLeft") != 0 &&
+        wcscmp(g_settings.badgeIconPosition, L"bottomCenter") != 0 &&
+        wcscmp(g_settings.badgeIconPosition, L"bottomRight") != 0) {
+        wcscpy_s(g_settings.badgeIconPosition, L"bottomCenter");
+    }
+    v = Wh_GetStringSetting(L"Appearance.BadgeLayout.badgeTitlePosition");
+    wcscpy_s(g_settings.badgeTitlePosition, v ? v : L"bottom"); Wh_FreeStringSetting(v);
+    if (wcscmp(g_settings.badgeTitlePosition, L"top") != 0 &&
+        wcscmp(g_settings.badgeTitlePosition, L"bottom") != 0) {
+        wcscpy_s(g_settings.badgeTitlePosition, L"bottom");
+    }
+    g_settings.showBadgeIconBackground = Wh_GetIntSetting(L"Appearance.BadgeLayout.showBadgeIconBackground");
+    g_settings.showBadgeIconBackgroundShadow = Wh_GetIntSetting(L"Appearance.BadgeLayout.showBadgeIconBackgroundShadow");
+    g_settings.badgeIconPadding = Wh_GetIntSetting(L"Appearance.BadgeLayout.badgeIconPadding");
+    g_settings.badgeIconOffsetX = Wh_GetIntSetting(L"Appearance.BadgeLayout.badgeIconOffsetX");
+    g_settings.badgeIconOffsetY = Wh_GetIntSetting(L"Appearance.BadgeLayout.badgeIconOffsetY");
+
+    // Grouped indicator
+    g_settings.showGroupIndicator = Wh_GetIntSetting(L"Grouping.showGroupIndicator");
+    g_settings.showGroupIndicatorShadow = Wh_GetIntSetting(L"Grouping.showGroupIndicatorShadow");
+    v = Wh_GetStringSetting(L"Grouping.groupCloseBehavior");
+    wcscpy_s(g_settings.groupCloseBehavior, v ? v : L"closeRecent"); Wh_FreeStringSetting(v);
+    if (wcscmp(g_settings.groupCloseBehavior, L"closeAll") != 0 &&
+        wcscmp(g_settings.groupCloseBehavior, L"closeRecent") != 0) {
+        wcscpy_s(g_settings.groupCloseBehavior, L"closeRecent");
+    }
 
     // Global theme settings (apply to both light and dark)
     v = Wh_GetStringSetting(L"Style.highlightStyle");
@@ -3807,6 +4518,27 @@ static void LoadSettings() {
     wcscpy_s(g_settings.customHighlightFillColorDark, v ? v : L"#FFFFFF"); Wh_FreeStringSetting(v);
     v = Wh_GetStringSetting(L"Style.DarkMode.customBgColor");
     wcscpy_s(g_settings.customBgColorDark, v ? v : L"#202020"); Wh_FreeStringSetting(v);
+    
+    v = Wh_GetStringSetting(L"Style.DarkMode.iconBgColorMode");
+    wcscpy_s(g_settings.iconBgColorModeDark, v ? v : L"default"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.DarkMode.customIconBgColor");
+    wcscpy_s(g_settings.customIconBgColorDark, v ? v : L"#000000"); Wh_FreeStringSetting(v);
+    g_settings.iconBgOpacityDark = Wh_GetIntSetting(L"Style.DarkMode.iconBgOpacity");
+    if (g_settings.iconBgOpacityDark < 0) g_settings.iconBgOpacityDark = 0;
+    if (g_settings.iconBgOpacityDark > 100) g_settings.iconBgOpacityDark = 100;
+
+    v = Wh_GetStringSetting(L"Style.DarkMode.indicatorBgColorMode");
+    wcscpy_s(g_settings.indicatorBgColorModeDark, v ? v : L"default"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.DarkMode.customIndicatorBgColor");
+    wcscpy_s(g_settings.customIndicatorBgColorDark, v ? v : L"#333333"); Wh_FreeStringSetting(v);
+    g_settings.indicatorBgOpacityDark = Wh_GetIntSetting(L"Style.DarkMode.indicatorBgOpacity");
+    if (g_settings.indicatorBgOpacityDark < 0) g_settings.indicatorBgOpacityDark = 0;
+    if (g_settings.indicatorBgOpacityDark > 100) g_settings.indicatorBgOpacityDark = 100;
+    
+    v = Wh_GetStringSetting(L"Style.DarkMode.indicatorTextColorMode");
+    wcscpy_s(g_settings.indicatorTextColorModeDark, v ? v : L"default"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.DarkMode.customIndicatorTextColor");
+    wcscpy_s(g_settings.customIndicatorTextColorDark, v ? v : L"#FFFFFF"); Wh_FreeStringSetting(v);
 
     // Light Mode color settings
     v = Wh_GetStringSetting(L"Style.LightMode.borderColorMode");
@@ -3822,6 +4554,27 @@ static void LoadSettings() {
     v = Wh_GetStringSetting(L"Style.LightMode.customBgColor");
     wcscpy_s(g_settings.customBgColorLight, v ? v : L"#F3F3F3"); Wh_FreeStringSetting(v);
 
+    v = Wh_GetStringSetting(L"Style.LightMode.iconBgColorMode");
+    wcscpy_s(g_settings.iconBgColorModeLight, v ? v : L"default"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.LightMode.customIconBgColor");
+    wcscpy_s(g_settings.customIconBgColorLight, v ? v : L"#FFFFFF"); Wh_FreeStringSetting(v);
+    g_settings.iconBgOpacityLight = Wh_GetIntSetting(L"Style.LightMode.iconBgOpacity");
+    if (g_settings.iconBgOpacityLight < 0) g_settings.iconBgOpacityLight = 0;
+    if (g_settings.iconBgOpacityLight > 100) g_settings.iconBgOpacityLight = 100;
+
+    v = Wh_GetStringSetting(L"Style.LightMode.indicatorBgColorMode");
+    wcscpy_s(g_settings.indicatorBgColorModeLight, v ? v : L"default"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.LightMode.customIndicatorBgColor");
+    wcscpy_s(g_settings.customIndicatorBgColorLight, v ? v : L"#EAEAEA"); Wh_FreeStringSetting(v);
+    g_settings.indicatorBgOpacityLight = Wh_GetIntSetting(L"Style.LightMode.indicatorBgOpacity");
+    if (g_settings.indicatorBgOpacityLight < 0) g_settings.indicatorBgOpacityLight = 0;
+    if (g_settings.indicatorBgOpacityLight > 100) g_settings.indicatorBgOpacityLight = 100;
+    
+    v = Wh_GetStringSetting(L"Style.LightMode.indicatorTextColorMode");
+    wcscpy_s(g_settings.indicatorTextColorModeLight, v ? v : L"default"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.LightMode.customIndicatorTextColor");
+    wcscpy_s(g_settings.customIndicatorTextColorLight, v ? v : L"#000000"); Wh_FreeStringSetting(v);
+
     v = Wh_GetStringSetting(L"Appearance.Font.fontFamily");
     wcscpy_s(g_settings.fontFamily, v ? v : L"Segoe UI"); Wh_FreeStringSetting(v);
     
@@ -3830,6 +4583,8 @@ static void LoadSettings() {
 
     v = Wh_GetStringSetting(L"Appearance.Font.fontStyle");
     wcscpy_s(g_settings.fontStyle, v ? v : L"regular"); Wh_FreeStringSetting(v);
+
+    g_settings.applyToGroupIndicator = Wh_GetIntSetting(L"Appearance.Font.applyToGroupIndicator");
 
     v = Wh_GetStringSetting(L"Accessibility.switcherDisplayBehavior");
     wcscpy_s(g_settings.switcherDisplayBehavior, v ? v : L"cursorMonitor"); Wh_FreeStringSetting(v);

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -197,6 +197,8 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       - never: Never
       - always: Always
       - stickyOnly: Only in sticky mode
+    - reverseScrollDirection: false
+      $name: Reverse Scroll Direction
     - backwardShortcut: altShiftTab
       $name: Backward Shortcut
       $description: Shortcut used to move backward in the switcher.
@@ -204,19 +206,12 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       - altShiftTab: Alt+Shift+Tab (default)
       - altShift: Alt+Shift
       - altBacktick: Alt+Backtick
-<<<<<<< HEAD
-    - reverseScrollDirection: false
-      $name: Reverse Scroll Direction
-    - primaryMonitorOnly: false
-      $name: Always Display Switcher on Primary Monitor
-=======
     - switcherDisplayBehavior: cursorMonitor
       $name: Switcher Display Behavior
       $options:
       - primaryOnly: Show Switcher in Primary Monitor only
       - allMonitors: All Monitors
       - cursorMonitor: Monitor Based On Cursor Location
->>>>>>> 0fc3be76 (Refactor Simple Window Switcher UI, apply upstream layout fixes, add multi-monitor mirror support, and implement structured array schemas for excluded windows)
     - perMonitorWindows: false
       $name: Display Windows Only From the Monitor Containing the Cursor
     - ExcludedWindows:
@@ -312,11 +307,7 @@ struct WindowEntry {
     SIZE effectiveSourceSize;  // Source size after cropping invisible frame
 };
 struct Settings {
-<<<<<<< HEAD
-    WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32]; WCHAR thumbnailPosition[32]; WCHAR thumbnailAlignment[32];
-=======
     WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32]; WCHAR thumbnailPosition[32]; WCHAR thumbnailAlignment[32]; WCHAR switcherDisplayBehavior[32];
->>>>>>> 0fc3be76 (Refactor Simple Window Switcher UI, apply upstream layout fixes, add multi-monitor mirror support, and implement structured array schemas for excluded windows)
     WCHAR highlightStyle[32]; WCHAR virtualDesktopBehavior[32];
     WCHAR borderColorDark[16];
     WCHAR borderColorLight[16];
@@ -381,7 +372,6 @@ static bool HeaderOrientationIs(const WCHAR* v) { return wcscmp(g_settings.heade
 static bool IconSizeIs(const WCHAR* v) { return wcscmp(g_settings.iconSize, v) == 0; }
 static bool BackwardShortcutIs(const WCHAR* v) { return wcscmp(g_settings.backwardShortcut, v) == 0; }
 static bool ThumbnailPositionIs(const WCHAR* v) { return wcscmp(g_settings.thumbnailPosition, v) == 0; }
-static bool ThumbnailAlignmentIs(const WCHAR* v) { return wcscmp(g_settings.thumbnailAlignment, v) == 0; }
 static bool HighlightStyleIs(const WCHAR* v) { return wcscmp(g_settings.highlightStyle, v) == 0; }
 static bool UseAltShiftTabBackward() { return BackwardShortcutIs(L"altShiftTab"); }
 static bool UseAltShiftBackward() { return BackwardShortcutIs(L"altShift"); }
@@ -391,11 +381,7 @@ static bool ThumbnailIsTop() { return ThumbnailPositionIs(L"top"); }
 static bool ThumbnailIsLeft() { return ThumbnailPositionIs(L"left"); }
 static bool ThumbnailIsRight() { return ThumbnailPositionIs(L"right"); }
 static bool ThumbnailIsSide() { return ThumbnailIsLeft() || ThumbnailIsRight(); }
-<<<<<<< HEAD
-static bool ThumbnailAlignLeft() { return ThumbnailAlignmentIs(L"left"); }
-=======
 static bool ThumbnailAlignmentIs(const WCHAR* v) { return wcscmp(g_settings.thumbnailAlignment, v) == 0; }
->>>>>>> 0fc3be76 (Refactor Simple Window Switcher UI, apply upstream layout fixes, add multi-monitor mirror support, and implement structured array schemas for excluded windows)
 static bool ThumbnailAlignCentered() { return ThumbnailAlignmentIs(L"centered"); }
 static bool ThumbnailAlignRight() { return ThumbnailAlignmentIs(L"right"); }
 static bool HighlightHasFill() {
@@ -1228,10 +1214,13 @@ static void ComputeLayout(HMONITOR hMon) {
                 if (sidePlacement) {
                     int headerExtra = (rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0;
                     if (g_settings.rowWidth > 0) {
-                        int minWidth = sideThumbSlotW + headerExtra;
-                        if (width < minWidth) width = minWidth;
+                        int maxThumbW = width - headerExtra;
+                        if (maxThumbW > 0 && thumbWidth > maxThumbW) {
+                            actualThumbH = (int)((double)maxThumbW * actualThumbH / thumbWidth);
+                            thumbWidth = maxThumbW;
+                        }
                     } else {
-                        width = sideThumbSlotW + headerExtra;
+                        width = thumbWidth + headerExtra;
                     }
                 }
             } else {

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -269,6 +269,9 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
         - showHoverBorder: true
           $name: Show Hover Border
           $description: Show a colored border around the thumbnail when hovered.
+        - showThumbnailShadow: false
+          $name: Show Thumbnail Shadow
+          $description: Draw a soft drop shadow behind each window thumbnail.
       $name: Thumbnails
     - HeaderContent:
         - iconSize: small
@@ -470,15 +473,18 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       $description: "Executable name patterns to exclude, separated by ';' (wildcards supported: * matches any characters, ? matches one). Example: notepad.exe;chrome.exe"
   $name: Excluded Windows
   $description: Exclude specific windows from appearing in the switcher.
-- customIcons:
+- customHeader:
   - - process: ""
       $name: Process Name
       $description: "Executable name to match (wildcards supported: * matches any characters, ? matches one). Example: chrome.exe or *code.exe"
     - iconPath: ""
       $name: Icon Path
-      $description: "Full path to an icon source (.ico, .exe or .dll); the first icon in the file is used. Example: C:\\Icons\\myapp.ico"
-  $name: Custom Icons
-  $description: Assign custom icons to tasks based on their executable name. The first matching rule wins.
+      $description: "Full path to an icon source (.ico, .exe or .dll); the first icon in the file is used. Leave empty to keep the default icon. Example: C:\\Icons\\myapp.ico"
+    - appName: ""
+      $name: Application Name
+      $description: "Custom name to display for matching tasks, replacing the detected application name. Leave empty to keep the default. Shown in the 'App name' and 'App name + Window title' title modes."
+  $name: Custom Header
+  $description: Assign a custom icon and/or application name to tasks based on their executable name. The first matching rule wins.
 
 */
 // ==/WindhawkModSettings==
@@ -596,6 +602,7 @@ struct Settings {
     WCHAR switcherPosition[32];
     int switcherPositionMargin;
     bool showHoverBorder;
+    bool showThumbnailShadow;
     // Badge layout (macOS-style)
     bool enableBadgeLayout;
     WCHAR badgeIconPosition[32];
@@ -1021,13 +1028,14 @@ static HICON TryGetCrispExeIcon(HWND hWnd, int desiredSizePx) {
     return NULL;
 }
 
-// === Custom per-process icons ===
+// === Custom per-process header (icon and/or application name) ===
 
-struct CustomIconRule {
+struct CustomHeaderRule {
     std::wstring pattern;   // executable name pattern; wildcards * and ? supported
-    std::wstring iconPath;  // .ico / .exe / .dll to extract the icon from
+    std::wstring iconPath;  // .ico / .exe / .dll to extract the icon from (optional)
+    std::wstring appName;   // custom display name overriding the detected one (optional)
 };
-static std::vector<CustomIconRule> g_customIcons;
+static std::vector<CustomHeaderRule> g_customHeaderRules;
 // Owned cache of icons loaded from custom paths; keyed by "<path>_<sizePx>".
 static std::map<std::wstring, HICON> g_customIconCache;
 
@@ -1048,7 +1056,7 @@ static HICON LoadCustomIconFromPath(const std::wstring& path, int sizePx) {
 // If the window's executable name matches a user-defined rule, return its
 // custom icon. The first matching rule wins; this overrides all other sources.
 static HICON TryGetCustomIcon(HWND hWnd, int sizePx) {
-    if (g_customIcons.empty()) return NULL;
+    if (g_customHeaderRules.empty()) return NULL;
     DWORD pid = 0;
     GetWindowThreadProcessId(hWnd, &pid);
     if (!pid) return NULL;
@@ -1060,13 +1068,38 @@ static HICON TryGetCustomIcon(HWND hWnd, int sizePx) {
     CloseHandle(hProc);
     if (!ok || !exePath[0]) return NULL;
     WCHAR* fileName = PathFindFileNameW(exePath);
-    for (const auto& rule : g_customIcons) {
+    for (const auto& rule : g_customHeaderRules) {
         if (PathMatchSpecW(fileName, rule.pattern.c_str())) {
             HICON h = LoadCustomIconFromPath(rule.iconPath, sizePx);
             if (h) return h;
         }
     }
     return NULL;
+}
+
+// If the window's executable name matches a user-defined rule with a custom
+// application name, copy it into `out` and return true. The first matching rule
+// with a non-empty name wins.
+static bool TryGetCustomAppName(HWND hWnd, WCHAR* out, size_t cch) {
+    if (g_customHeaderRules.empty()) return false;
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hWnd, &pid);
+    if (!pid) return false;
+    HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (!hProc) return false;
+    WCHAR exePath[MAX_PATH] = {0};
+    DWORD size = MAX_PATH;
+    BOOL ok = QueryFullProcessImageNameW(hProc, 0, exePath, &size);
+    CloseHandle(hProc);
+    if (!ok || !exePath[0]) return false;
+    WCHAR* fileName = PathFindFileNameW(exePath);
+    for (const auto& rule : g_customHeaderRules) {
+        if (!rule.appName.empty() && PathMatchSpecW(fileName, rule.pattern.c_str())) {
+            wcsncpy_s(out, cch, rule.appName.c_str(), _TRUNCATE);
+            return true;
+        }
+    }
+    return false;
 }
 
 static HICON LoadWindowIcon(HWND hWnd) {
@@ -1076,9 +1109,11 @@ static HICON LoadWindowIcon(HWND hWnd) {
     if (g_IsShellFrameWindow && g_IsShellFrameWindow(hWnd)) {
         hIcon = TryGetUwpIconFromExplorer(hWnd, GetHeaderIconSizePx());
     }
-    // For the larger sizes, a crisp full-resolution exe icon beats the
-    // upscaled WM_GETICON result.
-    if (!hIcon && GetHeaderIconSizeBase() > 32) {
+    // A crisp exe icon extracted at the exact target size beats the WM_GETICON
+    // result, which is a fixed ~32px frame: blurry when upscaled to 48/64 and
+    // pixelated when downscaled to 16 (GDI does no smoothing in DrawIconEx).
+    // PrivateExtractIconsW picks the best-matching frame at the requested size.
+    if (!hIcon) {
         hIcon = TryGetCrispExeIcon(hWnd, GetHeaderIconSizePx());
     }
     if (!hIcon) SendMessageTimeoutW(hWnd, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK, 100, (DWORD_PTR*)&hIcon);
@@ -1466,6 +1501,7 @@ static void GetWindowGroupKey(HWND hWnd, WCHAR* out, size_t cch) {
 // the executable file name without extension.
 static void GetAppName(HWND hWnd, WCHAR* out, size_t cch) {
     out[0] = 0;
+    if (TryGetCustomAppName(hWnd, out, cch)) return;
     DWORD pid = 0;
     GetWindowThreadProcessId(hWnd, &pid);
     if (!pid) return;
@@ -2656,6 +2692,47 @@ static int GetHeaderTopForEntry(const WindowEntry& e) {
     return rcHeader.top + (available - rowTitleH) / 2;
 }
 
+// Soft drop shadow behind a thumbnail. Drawn in the content layer, which sits
+// below the DWM thumbnail, so only the expanded/offset border peeks out around
+// the thumbnail edges, producing a drop-shadow halo.
+static void DrawThumbnailShadow(HDC hdc, const RECT& rc, int cornerRadius) {
+    int rcw = rc.right - rc.left;
+    int rch = rc.bottom - rc.top;
+    if (rcw <= 0 || rch <= 0) return;
+
+    Gdiplus::Graphics gfx(hdc);
+    gfx.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+
+    int maxPass = DpiScale(6, g_dpiX);
+    if (maxPass < 1) maxPass = 1;
+    int yOff = DpiScale(2, g_dpiY);  // nudge down for a "drop" feel
+
+    for (int pass = maxPass; pass > 0; --pass) {
+        int shadowAlpha = 16 - (pass * 2);
+        if (shadowAlpha < 1) shadowAlpha = 1;
+        Gdiplus::SolidBrush shadowBrush(Gdiplus::Color(shadowAlpha, 0, 0, 0));
+        int sp = pass;
+        Gdiplus::REAL sx = (Gdiplus::REAL)(rc.left - sp);
+        Gdiplus::REAL sy = (Gdiplus::REAL)(rc.top - sp + yOff);
+        Gdiplus::REAL sw = (Gdiplus::REAL)(rcw + sp * 2);
+        Gdiplus::REAL sh = (Gdiplus::REAL)(rch + sp * 2);
+        if (cornerRadius > 0) {
+            Gdiplus::REAL sd = cornerRadius * 2.0f + sp * 2.0f;
+            if (sd > sw) sd = sw;
+            if (sd > sh) sd = sh;
+            Gdiplus::GraphicsPath sPath;
+            sPath.AddArc(sx, sy, sd, sd, 180, 90);
+            sPath.AddArc(sx + sw - sd, sy, sd, sd, 270, 90);
+            sPath.AddArc(sx + sw - sd, sy + sh - sd, sd, sd, 0, 90);
+            sPath.AddArc(sx, sy + sh - sd, sd, sd, 90, 90);
+            sPath.CloseFigure();
+            gfx.FillPath(&shadowBrush, &sPath);
+        } else {
+            gfx.FillRectangle(&shadowBrush, sx, sy, sw, sh);
+        }
+    }
+}
+
 // Shared drawing routine for both layered and buffered paint paths
 static void DrawSwitcherContent(HDC hdc, bool fillBg, HWND hWnd) {
     RECT rcClient; GetClientRect(g_hSwitcher, &rcClient);
@@ -2700,6 +2777,13 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg, HWND hWnd) {
         }
 
         // Hover thumbnail border is now drawn in DrawSwitcherOverlay so it sits above the thumbnail mask
+
+        // Drop shadow behind the thumbnail (below the DWM thumbnail layer).
+        if (g_settings.showThumbnails && g_settings.showThumbnailShadow &&
+            !(e.rcThumbActual.left == 0 && e.rcThumbActual.right == 0 &&
+              e.rcThumbActual.top == 0 && e.rcThumbActual.bottom == 0)) {
+            DrawThumbnailShadow(hdc, e.rcThumbActual, cornerRadius);
+        }
 
         if (g_settings.showThumbnails && cornerRadius > 0 && ThemeIs(L"none")) {
             MaskRectCorners(hdc, e.rcThumbActual, cornerRadius);
@@ -4439,6 +4523,7 @@ static void LoadSettings() {
     g_settings.autoFitTasks = Wh_GetIntSetting(L"Dimensions.autoFitTasks");
     g_settings.showThumbnails = Wh_GetIntSetting(L"Appearance.Thumbnails.showThumbnails");
     g_settings.showHoverBorder = Wh_GetIntSetting(L"Appearance.Thumbnails.showHoverBorder");
+    g_settings.showThumbnailShadow = Wh_GetIntSetting(L"Appearance.Thumbnails.showThumbnailShadow");
     g_settings.showTitle = Wh_GetIntSetting(L"Appearance.HeaderContent.showTitle");
     g_settings.showIcon = Wh_GetIntSetting(L"Appearance.HeaderContent.showIcon");
     if (!g_settings.showThumbnails && !g_settings.showTitle && !g_settings.showIcon) {
@@ -4642,8 +4727,8 @@ static void LoadSettings() {
     }
     if (v) Wh_FreeStringSetting(v);
 
-    // Custom per-process icons (array of { process, iconPath }).
-    g_customIcons.clear();
+    // Custom per-process header (array of { process, iconPath, appName }).
+    g_customHeaderRules.clear();
     auto trimWs = [](std::wstring s) -> std::wstring {
         size_t a = s.find_first_not_of(L" \t\r\n");
         if (a == std::wstring::npos) return L"";
@@ -4651,18 +4736,23 @@ static void LoadSettings() {
         return s.substr(a, b - a + 1);
     };
     for (int i = 0; ; i++) {
-        PCWSTR proc = Wh_GetStringSetting(L"customIcons[%d].process", i);
-        PCWSTR icon = Wh_GetStringSetting(L"customIcons[%d].iconPath", i);
+        PCWSTR proc = Wh_GetStringSetting(L"customHeader[%d].process", i);
+        PCWSTR icon = Wh_GetStringSetting(L"customHeader[%d].iconPath", i);
+        PCWSTR name = Wh_GetStringSetting(L"customHeader[%d].appName", i);
         bool hasProc = proc && *proc;
         bool hasIcon = icon && *icon;
-        if (hasProc && hasIcon) {
+        bool hasName = name && *name;
+        if (hasProc && (hasIcon || hasName)) {
             std::wstring p = trimWs(proc);
-            std::wstring ip = trimWs(icon);
-            if (!p.empty() && !ip.empty()) g_customIcons.push_back({p, ip});
+            std::wstring ip = hasIcon ? trimWs(icon) : L"";
+            std::wstring an = hasName ? trimWs(name) : L"";
+            if (!p.empty() && (!ip.empty() || !an.empty()))
+                g_customHeaderRules.push_back({p, ip, an});
         }
-        bool endOfArray = !hasProc && !hasIcon;
+        bool endOfArray = !hasProc && !hasIcon && !hasName;
         if (proc) Wh_FreeStringSetting(proc);
         if (icon) Wh_FreeStringSetting(icon);
+        if (name) Wh_FreeStringSetting(name);
         if (endOfArray) break;
     }
 }

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -63,116 +63,132 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 
 // ==WindhawkModSettings==
 /*
-- theme: none
-  $name: Theme
-  $description: Visual theme for the switcher background.
-  $options:
-  - none: None (transparent)
-  - backdrop: Backdrop (Acrylic)
-- opacity: 100
-  $name: Background Opacity
-  $description: Background opacity percentage (0-100), applies to None theme.
-- colorScheme: system
-  $name: Color Scheme
-  $options:
-  - system: Follow system setting
-  - light: Light
-  - dark: Dark
-- cornerPreference: none
-  $name: Corner Preference
-  $description: Corner radius for the switcher window only.
-  $options:
-  - none: Do not round
-  - round: Round
-  - roundSmall: Round small
-- taskRoundedCorners: false
-  $name: Round Task Borders and Close Button
-  $description: Apply small rounded corners to the selected task border and close button.
-- showThumbnails: true
-  $name: Show Thumbnails
-  $description: Show DWM live thumbnail previews of windows.
-- thumbnailPosition: bottom
-  $name: Thumbnail Position
-  $description: Place the thumbnail below or above the header row.
-  $options:
-  - bottom: Bottom (below header)
-  - top: Top (above header)
-  - left: Left (before header)
-  - right: Right (after header)
-- showTitle: true
-  $name: Show Title Label
-- showIcon: true
-  $name: Show Icon
-- taskListOrientation: horizontal
-  $name: Task List Orientation
-  $description: Arrange tasks left-to-right or top-to-bottom.
-  $options:
-  - horizontal: Horizontal
-  - vertical: Vertical
-- headerContentOrientation: horizontal
-  $name: Header Content Orientation
-  $description: Orientation of the task header icon and title.
-  $options:
-  - horizontal: Horizontal
-  - vertical: Vertical
-- iconSize: small
-  $name: Icon Size
-  $description: Size of the header icon.
-  $options:
-  - small: Small
-  - large: Large
-- rowHeight: 230
-  $name: Row Height
-  $description: Total height of each thumbnail row in pixels (before DPI scaling). Default 230 matches ExplorerPatcher.
-- rowWidth: 0
-  $name: Row Width
-  $description: Width of each thumbnail tile in pixels (before DPI scaling). Set to 0 for automatic width based on window aspect ratio.
-- stretchThumbnailsToTaskWidth: true
-  $name: Stretch Thumbnails To Task Width
-  $description: When enabled, custom row width also changes thumbnail width. Disable to keep thumbnail aspect sizing while row width controls only task tile width.
-- maxWidthPercent: 80
-  $name: Maximum Width (percentage of screen width)
-- maxHeightPercent: 80
-  $name: Maximum Height (percentage of screen height)
-- showDelay: 0
-  $name: Show Delay (ms)
-  $description: Delay in milliseconds before showing the switcher (0 = instant).
-- scrollWheelBehavior: never
-  $name: Scroll Wheel to Change Selection
-  $options:
-  - never: Never
-  - always: Always
-  - stickyOnly: Only in sticky mode
-- backwardShortcut: altShiftTab
-  $name: Backward Shortcut
-  $description: Shortcut used to move backward in the switcher.
-  $options:
-  - altShiftTab: Alt+Shift+Tab (default)
-  - altShift: Alt+Shift
-  - altBacktick: Alt+Backtick
-- borderColorDark: "#FFFFFF"
-  $name: Border Color (Dark Mode)
-  $description: Border color in HEX format for dark mode.
-- borderColorLight: "#000000"
-  $name: Border Color (Light Mode)
-  $description: Border color in HEX format for light mode.
-- useAccentColor: false
-  $name: Accent Color for Borders and Background Fill
-  $description: Use Windows accent color for selection and hover borders.
-- highlightStyle: border
-  $name: Selected Task Highlight Style
-  $description: Style used for the selected task row/tile.
-  $options:
-  - border: Border only
-  - fillAndBorder: Background fill and border
-  - fillOnly: Background fill only
-- centerTaskContent: false
-  $name: Center Task Icon and Title
-  $description: Center the icon and title together in each task row.
-- primaryMonitorOnly: false
-  $name: Always Display Switcher on Primary Monitor
-- perMonitorWindows: false
-  $name: Display Windows Only From the Monitor Containing the Cursor
+- Style:
+    - theme: none
+      $name: Theme
+      $description: Visual theme for the switcher background.
+      $options:
+      - none: None (transparent)
+      - backdrop: Backdrop (Acrylic)
+    - opacity: 100
+      $name: Background Opacity
+      $description: Background opacity percentage (0-100), applies to None theme.
+    - colorScheme: system
+      $name: Color Scheme
+      $options:
+      - system: Follow system setting
+      - light: Light
+      - dark: Dark
+    - highlightStyle: border
+      $name: Selected Task Highlight Style
+      $description: Style used for the selected task row/tile.
+      $options:
+      - border: Border only
+      - fillAndBorder: Background fill and border
+      - fillOnly: Background fill only
+    - borderColorDark: "#FFFFFF"
+      $name: Border Color (Dark Mode)
+      $description: Border color in HEX format for dark mode.
+    - borderColorLight: "#000000"
+      $name: Border Color (Light Mode)
+      $description: Border color in HEX format for light mode.
+    - useAccentColor: false
+      $name: Accent Color for Borders and Background Fill
+      $description: Use Windows accent color for selection and hover borders.
+  $name: Theme Style
+- Appearance:
+    - Corners:
+        - cornerPreference: none
+          $name: Corner Preference
+          $description: Corner radius for the switcher window only.
+          $options:
+          - none: Do not round
+          - round: Round
+          - roundSmall: Round small
+        - taskRoundedCorners: false
+          $name: Round Task Borders and Close Button
+          $description: Apply small rounded corners to the selected task border and close button.
+      $name: Corners
+    - Thumbnails:
+        - thumbnailPosition: bottom
+          $name: Thumbnail Position
+          $description: Place the thumbnail below or above the header row.
+          $options:
+          - bottom: Bottom (below header)
+          - top: Top (above header)
+          - left: Left (before header)
+          - right: Right (after header)
+        - showThumbnails: true
+          $name: Show Thumbnails
+          $description: Show DWM live thumbnail previews of windows.
+      $name: Thumbnails
+    - HeaderContent:
+        - iconSize: small
+          $name: Icon Size
+          $description: Size of the header icon.
+          $options:
+          - small: Small
+          - large: Large
+        - showTitle: true
+          $name: Show Title Label
+        - showIcon: true
+          $name: Show Icon
+        - centerTaskContent: false
+          $name: Center Task Icon and Title
+          $description: Center the icon and title together in each task row.
+      $name: Header Content
+    - Orientation:
+        - taskListOrientation: horizontal
+          $name: Task List Orientation
+          $description: Arrange tasks left-to-right or top-to-bottom.
+          $options:
+          - horizontal: Horizontal
+          - vertical: Vertical
+        - headerContentOrientation: horizontal
+          $name: Header Content Orientation
+          $description: Orientation of the task header icon and title.
+          $options:
+          - horizontal: Horizontal
+          - vertical: Vertical
+      $name: Orientation
+  $name: Appearance
+- Dimensions:
+    - rowHeight: 230
+      $name: Row Height
+      $description: Total height of each thumbnail row in pixels (before DPI scaling). Default 230 matches ExplorerPatcher.
+    - rowWidth: 0
+      $name: Row Width
+      $description: Width of each thumbnail tile in pixels (before DPI scaling). Set to 0 for automatic width based on window aspect ratio.
+    - maxWidthPercent: 80
+      $name: Maximum Width (percentage of screen width)
+    - maxHeightPercent: 80
+      $name: Maximum Height (percentage of screen height)
+    - stretchThumbnailsToTaskWidth: true
+      $name: Stretch Thumbnails To Task Width
+      $description: When enabled, custom row width also changes thumbnail width. Disable to keep thumbnail aspect sizing while row width controls only task tile width.
+  $name: Dimensions
+- Miscellaneous:
+    - showDelay: 0
+      $name: Show Delay (ms)
+      $description: Delay in milliseconds before showing the switcher (0 = instant).
+    - scrollWheelBehavior: never
+      $name: Scroll Wheel to Change Selection
+      $options:
+      - never: Never
+      - always: Always
+      - stickyOnly: Only in sticky mode
+    - backwardShortcut: altShiftTab
+      $name: Backward Shortcut
+      $description: Shortcut used to move backward in the switcher.
+      $options:
+      - altShiftTab: Alt+Shift+Tab (default)
+      - altShift: Alt+Shift
+      - altBacktick: Alt+Backtick
+    - primaryMonitorOnly: false
+      $name: Always Display Switcher on Primary Monitor
+    - perMonitorWindows: false
+      $name: Display Windows Only From the Monitor Containing the Cursor
+  $name: Miscellaneous
 */
 // ==/WindhawkModSettings==
 
@@ -2656,30 +2672,30 @@ static void SWS_UnregisterHotkeys() {
 
 static void LoadSettings() {
     LPCWSTR v;
-    v = Wh_GetStringSetting(L"theme");
+    v = Wh_GetStringSetting(L"Style.theme");
     wcscpy_s(g_settings.theme, v ? v : L"none"); Wh_FreeStringSetting(v);
-    v = Wh_GetStringSetting(L"colorScheme");
+    v = Wh_GetStringSetting(L"Style.colorScheme");
     wcscpy_s(g_settings.colorScheme, v ? v : L"system"); Wh_FreeStringSetting(v);
-    v = Wh_GetStringSetting(L"cornerPreference");
+    v = Wh_GetStringSetting(L"Appearance.Corners.cornerPreference");
     wcscpy_s(g_settings.cornerPreference, v ? v : L"round"); Wh_FreeStringSetting(v);
-    g_settings.taskRoundedCorners = Wh_GetIntSetting(L"taskRoundedCorners");
-    v = Wh_GetStringSetting(L"scrollWheelBehavior");
+    g_settings.taskRoundedCorners = Wh_GetIntSetting(L"Appearance.Corners.taskRoundedCorners");
+    v = Wh_GetStringSetting(L"Miscellaneous.scrollWheelBehavior");
     wcscpy_s(g_settings.scrollWheelBehavior, v ? v : L"never"); Wh_FreeStringSetting(v);
-    v = Wh_GetStringSetting(L"taskListOrientation");
+    v = Wh_GetStringSetting(L"Appearance.Orientation.taskListOrientation");
     wcscpy_s(g_settings.taskListOrientation, v ? v : L"horizontal"); Wh_FreeStringSetting(v);
-    v = Wh_GetStringSetting(L"headerContentOrientation");
+    v = Wh_GetStringSetting(L"Appearance.Orientation.headerContentOrientation");
     wcscpy_s(g_settings.headerContentOrientation, v ? v : L"horizontal"); Wh_FreeStringSetting(v);
     if (wcscmp(g_settings.headerContentOrientation, L"horizontal") != 0 &&
         wcscmp(g_settings.headerContentOrientation, L"vertical") != 0) {
         wcscpy_s(g_settings.headerContentOrientation, L"horizontal");
     }
-    v = Wh_GetStringSetting(L"iconSize");
+    v = Wh_GetStringSetting(L"Appearance.HeaderContent.iconSize");
     wcscpy_s(g_settings.iconSize, v ? v : L"small"); Wh_FreeStringSetting(v);
     if (wcscmp(g_settings.iconSize, L"small") != 0 &&
         wcscmp(g_settings.iconSize, L"large") != 0) {
         wcscpy_s(g_settings.iconSize, L"small");
     }
-    v = Wh_GetStringSetting(L"thumbnailPosition");
+    v = Wh_GetStringSetting(L"Appearance.Thumbnails.thumbnailPosition");
     wcscpy_s(g_settings.thumbnailPosition, v ? v : L"bottom"); Wh_FreeStringSetting(v);
     if (wcscmp(g_settings.thumbnailPosition, L"bottom") != 0 &&
         wcscmp(g_settings.thumbnailPosition, L"top") != 0 &&
@@ -2687,7 +2703,7 @@ static void LoadSettings() {
         wcscmp(g_settings.thumbnailPosition, L"right") != 0) {
         wcscpy_s(g_settings.thumbnailPosition, L"bottom");
     }
-    v = Wh_GetStringSetting(L"backwardShortcut");
+    v = Wh_GetStringSetting(L"Miscellaneous.backwardShortcut");
     if (v) {
         wcscpy_s(g_settings.backwardShortcut, v);
         Wh_FreeStringSetting(v);
@@ -2702,7 +2718,7 @@ static void LoadSettings() {
         wcscpy_s(g_settings.backwardShortcut, L"altShiftTab");
     }
 
-    v = Wh_GetStringSetting(L"highlightStyle");
+    v = Wh_GetStringSetting(L"Style.highlightStyle");
     wcscpy_s(g_settings.highlightStyle, v ? v : L"border");
     Wh_FreeStringSetting(v);
     if (wcscmp(g_settings.highlightStyle, L"border") != 0 &&
@@ -2711,40 +2727,40 @@ static void LoadSettings() {
         wcscpy_s(g_settings.highlightStyle, L"border");
     }
 
-    g_settings.opacity = Wh_GetIntSetting(L"opacity");
+    g_settings.opacity = Wh_GetIntSetting(L"Style.opacity");
     if (g_settings.opacity < 0) g_settings.opacity = 0;
     if (g_settings.opacity > 100) g_settings.opacity = 100;
-    g_settings.rowHeight = Wh_GetIntSetting(L"rowHeight");
+    g_settings.rowHeight = Wh_GetIntSetting(L"Dimensions.rowHeight");
     if (g_settings.rowHeight <= 0) g_settings.rowHeight = 230;
-    g_settings.rowWidth = Wh_GetIntSetting(L"rowWidth");
+    g_settings.rowWidth = Wh_GetIntSetting(L"Dimensions.rowWidth");
     if (g_settings.rowWidth < 0) g_settings.rowWidth = 0;
-    g_settings.stretchThumbnailsToTaskWidth = Wh_GetIntSetting(L"stretchThumbnailsToTaskWidth");
-    g_settings.showThumbnails = Wh_GetIntSetting(L"showThumbnails");
-    g_settings.showTitle = Wh_GetIntSetting(L"showTitle");
-    g_settings.showIcon = Wh_GetIntSetting(L"showIcon");
+    g_settings.stretchThumbnailsToTaskWidth = Wh_GetIntSetting(L"Dimensions.stretchThumbnailsToTaskWidth");
+    g_settings.showThumbnails = Wh_GetIntSetting(L"Appearance.Thumbnails.showThumbnails");
+    g_settings.showTitle = Wh_GetIntSetting(L"Appearance.HeaderContent.showTitle");
+    g_settings.showIcon = Wh_GetIntSetting(L"Appearance.HeaderContent.showIcon");
     if (!g_settings.showThumbnails && !g_settings.showTitle && !g_settings.showIcon) {
         g_settings.showTitle = true;
     }
-    g_settings.maxWidthPercent = Wh_GetIntSetting(L"maxWidthPercent");
+    g_settings.maxWidthPercent = Wh_GetIntSetting(L"Dimensions.maxWidthPercent");
     if (g_settings.maxWidthPercent <= 0 || g_settings.maxWidthPercent > 100) g_settings.maxWidthPercent = 80;
-    g_settings.maxHeightPercent = Wh_GetIntSetting(L"maxHeightPercent");
+    g_settings.maxHeightPercent = Wh_GetIntSetting(L"Dimensions.maxHeightPercent");
     if (g_settings.maxHeightPercent <= 0 || g_settings.maxHeightPercent > 100) g_settings.maxHeightPercent = 80;
 
-    g_settings.showDelay = Wh_GetIntSetting(L"showDelay");
+    g_settings.showDelay = Wh_GetIntSetting(L"Miscellaneous.showDelay");
     if (g_settings.showDelay < 0) g_settings.showDelay = 0;
-    g_settings.useAccentColor = Wh_GetIntSetting(L"useAccentColor");
-    g_settings.primaryMonitorOnly = Wh_GetIntSetting(L"primaryMonitorOnly");
-    g_settings.perMonitorWindows = Wh_GetIntSetting(L"perMonitorWindows");
-    g_settings.centerTaskContent = Wh_GetIntSetting(L"centerTaskContent");
+    g_settings.useAccentColor = Wh_GetIntSetting(L"Style.useAccentColor");
+    g_settings.primaryMonitorOnly = Wh_GetIntSetting(L"Miscellaneous.primaryMonitorOnly");
+    g_settings.perMonitorWindows = Wh_GetIntSetting(L"Miscellaneous.perMonitorWindows");
+    g_settings.centerTaskContent = Wh_GetIntSetting(L"Appearance.HeaderContent.centerTaskContent");
 
 
-    v = Wh_GetStringSetting(L"borderColorDark");
+    v = Wh_GetStringSetting(L"Style.borderColorDark");
     wcscpy_s(g_settings.borderColorDark, v ? v : L"#FFFFFF"); Wh_FreeStringSetting(v);
     if (!ParseHexColor(g_settings.borderColorDark, nullptr)) {
         wcscpy_s(g_settings.borderColorDark, L"#FFFFFF");
     }
 
-    v = Wh_GetStringSetting(L"borderColorLight");
+    v = Wh_GetStringSetting(L"Style.borderColorLight");
     wcscpy_s(g_settings.borderColorLight, v ? v : L"#000000"); Wh_FreeStringSetting(v);
     if (!ParseHexColor(g_settings.borderColorLight, nullptr)) {
         wcscpy_s(g_settings.borderColorLight, L"#000000");

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -65,7 +65,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       $options:
       - none: None (transparent)
       - backdrop: Acrylic (Windows 10+)
-      - mica: Mica (Windows 11 Only)
+      - mica: Mica Blur (Windows 11 only)
     - opacity: 100
       $name: Background Opacity
       $description: Background opacity percentage (0-100), applies to None theme.
@@ -98,9 +98,9 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
           $name: Corner Preference
           $description: Corner radius for the switcher window only.
           $options:
-          - none: Do not round
-          - round: Round
-          - roundSmall: Round small
+          - none: Squared
+          - round: Rounded
+          - roundSmall: Rounded small
         - taskRoundedCorners: false
           $name: Round Task Borders and Close Button
           $description: Apply small rounded corners to the selected task border and close button.
@@ -110,10 +110,17 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
           $name: Thumbnail Position
           $description: Place the thumbnail below or above the header row.
           $options:
-          - bottom: Bottom (below header)
-          - top: Top (above header)
-          - left: Left (before header)
-          - right: Right (after header)
+          - bottom: Bottom
+          - top: Top
+          - left: Left
+          - right: Right
+        - thumbnailAlignment: left
+          $name: Thumbnail Alignment
+          $description: Align thumbnail content inside the available thumbnail area.
+          $options:
+          - left: Left
+          - centered: Center
+          - right: Right
         - showThumbnails: true
           $name: Show Thumbnails
           $description: Show DWM live thumbnail previews of windows.
@@ -160,7 +167,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
     - maxHeightPercent: 80
       $name: Maximum Height (percentage of screen height)
     - stretchThumbnailsToTaskWidth: true
-      $name: Stretch Thumbnails To Task Width
+      $name: Stretch Thumbnails to Task Width
       $description: When enabled, custom row width also changes thumbnail width. Disable to keep thumbnail aspect sizing while row width controls only task tile width.
   $name: Dimensions
 - Miscellaneous:
@@ -173,8 +180,6 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       - never: Never
       - always: Always
       - stickyOnly: Only in sticky mode
-    - reverseScrollDirection: false
-      $name: Reverse Scroll Direction
     - backwardShortcut: altShiftTab
       $name: Backward Shortcut
       $description: Shortcut used to move backward in the switcher.
@@ -182,6 +187,8 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       - altShiftTab: Alt+Shift+Tab (default)
       - altShift: Alt+Shift
       - altBacktick: Alt+Backtick
+    - reverseScrollDirection: false
+      $name: Reverse Scroll Direction
     - primaryMonitorOnly: false
       $name: Always Display Switcher on Primary Monitor
     - perMonitorWindows: false
@@ -259,13 +266,13 @@ typedef BOOL(WINAPI *SetWindowCompositionAttribute_t)(HWND, WINDOWCOMPOSITIONATT
 
 struct WindowEntry {
     HWND hWnd; HICON hIcon; WCHAR title[256]; HTHUMBNAIL hThumb;
-    RECT rcCell; RECT rcThumb; RECT rcThumbActual;
+    RECT rcCell; RECT rcThumb; RECT rcThumbActual; RECT rcThumbSlot;
     SIZE sourceSize;           // Raw DWM surface size
     RECT rcSourceCrop;         // Source crop rect for DWM_TNP_RECTSOURCE
     SIZE effectiveSourceSize;  // Source size after cropping invisible frame
 };
 struct Settings {
-    WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32]; WCHAR thumbnailPosition[32];
+    WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32]; WCHAR thumbnailPosition[32]; WCHAR thumbnailAlignment[32];
     WCHAR highlightStyle[32]; WCHAR virtualDesktopBehavior[32];
     WCHAR borderColorDark[16];
     WCHAR borderColorLight[16];
@@ -324,6 +331,7 @@ static bool HeaderOrientationIs(const WCHAR* v) { return wcscmp(g_settings.heade
 static bool IconSizeIs(const WCHAR* v) { return wcscmp(g_settings.iconSize, v) == 0; }
 static bool BackwardShortcutIs(const WCHAR* v) { return wcscmp(g_settings.backwardShortcut, v) == 0; }
 static bool ThumbnailPositionIs(const WCHAR* v) { return wcscmp(g_settings.thumbnailPosition, v) == 0; }
+static bool ThumbnailAlignmentIs(const WCHAR* v) { return wcscmp(g_settings.thumbnailAlignment, v) == 0; }
 static bool HighlightStyleIs(const WCHAR* v) { return wcscmp(g_settings.highlightStyle, v) == 0; }
 static bool UseAltShiftTabBackward() { return BackwardShortcutIs(L"altShiftTab"); }
 static bool UseAltShiftBackward() { return BackwardShortcutIs(L"altShift"); }
@@ -333,6 +341,9 @@ static bool ThumbnailIsTop() { return ThumbnailPositionIs(L"top"); }
 static bool ThumbnailIsLeft() { return ThumbnailPositionIs(L"left"); }
 static bool ThumbnailIsRight() { return ThumbnailPositionIs(L"right"); }
 static bool ThumbnailIsSide() { return ThumbnailIsLeft() || ThumbnailIsRight(); }
+static bool ThumbnailAlignLeft() { return ThumbnailAlignmentIs(L"left"); }
+static bool ThumbnailAlignCentered() { return ThumbnailAlignmentIs(L"centered"); }
+static bool ThumbnailAlignRight() { return ThumbnailAlignmentIs(L"right"); }
 static bool HighlightHasFill() {
     return HighlightStyleIs(L"fillAndBorder") || HighlightStyleIs(L"fillOnly");
 }
@@ -935,14 +946,7 @@ static void RegisterThumbnailsEarly() {
                     GetWindowRect(w.hWnd, &wr);
                     if (SUCCEEDED(DwmGetWindowAttribute(w.hWnd, DWMWA_EXTENDED_FRAME_BOUNDS, &efb, sizeof(efb)))) {
                         int wrW = wr.right - wr.left, wrH = wr.bottom - wr.top;
-                        int efbW = efb.right - efb.left;
-                        
-                        // DWM in Windows 11 natively crops off-screen borders for maximized windows.
-                        // If the thumbnail source size is already closer to the visible bounds (efb) 
-                        // than the physical bounds (wr), we skip manual cropping to avoid double-cropping.
-                        bool dwmNativelyCropped = (abs(src.cx - efbW) < abs(src.cx - wrW));
-                        
-                        if (!dwmNativelyCropped && wrW > 0 && wrH > 0 && src.cx > 0 && src.cy > 0) {
+                        if (wrW > 0 && wrH > 0 && src.cx > 0 && src.cy > 0) {
                             double sx = (double)src.cx / wrW;
                             double sy = (double)src.cy / wrH;
                             int ml = (int)((efb.left - wr.left) * sx);
@@ -1042,6 +1046,22 @@ static void ComputeLayout(HMONITOR hMon) {
     int maxW = monW * g_settings.maxWidthPercent / 100;
     int maxH = monH * g_settings.maxHeightPercent / 100;
 
+    int sideThumbSlotW = 0;
+    if (g_settings.showThumbnails && sidePlacement && thumbH > 0) {
+        for (const auto& w : g_windows) {
+            int slotW = thumbH;
+            if (w.effectiveSourceSize.cx > 0 && w.effectiveSourceSize.cy > 0) {
+                slotW = (int)((double)w.effectiveSourceSize.cx * thumbH / w.effectiveSourceSize.cy);
+            }
+            if (slotW > maxTileW) slotW = maxTileW;
+            if (w.effectiveSourceSize.cx > 0 && slotW > w.effectiveSourceSize.cx) slotW = w.effectiveSourceSize.cx;
+            if (slotW > sideThumbSlotW) sideThumbSlotW = slotW;
+        }
+        if (sideThumbSlotW <= 0) {
+            sideThumbSlotW = DpiScale(16, dpiX);
+        }
+    }
+
     int curX = initialLeft + masterPad;
     int curY = initialTop + masterPad;
     int placedCount = n; // Track how many windows were actually placed
@@ -1053,6 +1073,7 @@ static void ComputeLayout(HMONITOR hMon) {
             g_windows[ji].rcCell = {0, 0, 0, 0};
             g_windows[ji].rcThumbActual = {0, 0, 0, 0};
             g_windows[ji].rcThumb = {0, 0, 0, 0};
+            g_windows[ji].rcThumbSlot = {0, 0, 0, 0};
             if (g_windows[ji].hThumb) {
                 DwmUnregisterThumbnail(g_windows[ji].hThumb);
                 g_windows[ji].hThumb = NULL;
@@ -1101,7 +1122,7 @@ static void ComputeLayout(HMONITOR hMon) {
                 width = thumbWidth;
                 if (g_settings.rowWidth > 0) {
                     width = DpiScale(g_settings.rowWidth, dpiX);
-                    if (StretchThumbsToTaskWidth()) {
+                    if (StretchThumbsToTaskWidth() && !sidePlacement) {
                         thumbWidth = sidePlacement ? std::max(0, width - ((rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0)) : width;
                         if (thumbWidth <= 0) thumbWidth = DpiScale(16, dpiX);
                         actualThumbH = thumbH;
@@ -1114,13 +1135,10 @@ static void ComputeLayout(HMONITOR hMon) {
                 if (sidePlacement) {
                     int headerExtra = (rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0;
                     if (g_settings.rowWidth > 0) {
-                        int maxThumbW = width - headerExtra;
-                        if (maxThumbW > 0 && thumbWidth > maxThumbW) {
-                            actualThumbH = (int)((double)maxThumbW * actualThumbH / thumbWidth);
-                            thumbWidth = maxThumbW;
-                        }
+                        int minWidth = sideThumbSlotW + headerExtra;
+                        if (width < minWidth) width = minWidth;
                     } else {
-                        width = thumbWidth + headerExtra;
+                        width = sideThumbSlotW + headerExtra;
                     }
                 }
             } else {
@@ -1173,17 +1191,31 @@ static void ComputeLayout(HMONITOR hMon) {
             if (g_settings.showThumbnails) {
                 int thumbX = curX;
                 int thumbY = curY;
+                int slotX = curX;
+                int slotW = width;
                 if (sidePlacement) {
                     int contentH = std::max(actualThumbH, rowTitleH);
+                    int headerExtra = (rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0;
+                    int thumbAreaW = (g_settings.rowWidth > 0) ? sideThumbSlotW : std::max(0, width - headerExtra);
+                    int thumbAreaStart = ThumbnailIsRight()
+                        ? (curX + std::max(0, width - thumbAreaW))
+                        : curX;
+                    slotX = thumbAreaStart;
+                    slotW = thumbAreaW;
                     thumbY = curY + (contentH - actualThumbH) / 2;
-                    if (ThumbnailIsRight()) {
-                        thumbX = curX + width - thumbWidth;
+                    if (ThumbnailAlignRight()) {
+                        thumbX = thumbAreaStart + std::max(0, thumbAreaW - thumbWidth);
+                    } else if (ThumbnailAlignCentered()) {
+                        thumbX = thumbAreaStart + std::max(0, (thumbAreaW - thumbWidth) / 2);
+                    } else {
+                        thumbX = thumbAreaStart;
                     }
                 } else if (!StretchThumbsToTaskWidth() && width > thumbWidth) {
                     thumbX += (width - thumbWidth) / 2;
                 }
                 w.rcThumbActual = { thumbX, thumbY, thumbX + thumbWidth, thumbY + actualThumbH };
                 w.rcThumb = w.rcThumbActual;
+                w.rcThumbSlot = { slotX, thumbY, slotX + slotW, thumbY + actualThumbH };
             }
 
             curX = curX + width + rightInc;
@@ -1215,6 +1247,8 @@ static void ComputeLayout(HMONITOR hMon) {
                     g_windows[j].rcThumbActual.right += diff;
                     g_windows[j].rcThumb.left += diff;
                     g_windows[j].rcThumb.right += diff;
+                    g_windows[j].rcThumbSlot.left += diff;
+                    g_windows[j].rcThumbSlot.right += diff;
                 }
             }
             while (idx + 1 < placedCount && g_windows[(g_layoutStartIndex + idx + 1) % n].rcCell.top == rowTop) idx++;
@@ -1261,7 +1295,7 @@ static void ComputeLayout(HMONITOR hMon) {
                 width = thumbWidth;
                 if (g_settings.rowWidth > 0) {
                     width = DpiScale(g_settings.rowWidth, dpiX);
-                    if (StretchThumbsToTaskWidth()) {
+                    if (StretchThumbsToTaskWidth() && !sidePlacement) {
                         thumbWidth = sidePlacement ? std::max(0, width - ((rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0)) : width;
                         if (thumbWidth <= 0) thumbWidth = DpiScale(16, dpiX);
                         actualThumbH = thumbH;
@@ -1274,13 +1308,10 @@ static void ComputeLayout(HMONITOR hMon) {
                 if (sidePlacement) {
                     int headerExtra = (rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0;
                     if (g_settings.rowWidth > 0) {
-                        int maxThumbW = width - headerExtra;
-                        if (maxThumbW > 0 && thumbWidth > maxThumbW) {
-                            actualThumbH = (int)((double)maxThumbW * actualThumbH / thumbWidth);
-                            thumbWidth = maxThumbW;
-                        }
+                        int minWidth = sideThumbSlotW + headerExtra;
+                        if (width < minWidth) width = minWidth;
                     } else {
-                        width = thumbWidth + headerExtra;
+                        width = sideThumbSlotW + headerExtra;
                     }
                 }
             } else {
@@ -1332,17 +1363,31 @@ static void ComputeLayout(HMONITOR hMon) {
             if (g_settings.showThumbnails) {
                 int thumbX = curX;
                 int thumbY = curY;
+                int slotX = curX;
+                int slotW = width;
                 if (sidePlacement) {
                     int contentH = std::max(actualThumbH, rowTitleH);
+                    int headerExtra = (rowTitleH > 0) ? (sideHeaderWidth + padDivider) : 0;
+                    int thumbAreaW = (g_settings.rowWidth > 0) ? sideThumbSlotW : std::max(0, width - headerExtra);
+                    int thumbAreaStart = ThumbnailIsRight()
+                        ? (curX + std::max(0, width - thumbAreaW))
+                        : curX;
+                    slotX = thumbAreaStart;
+                    slotW = thumbAreaW;
                     thumbY = curY + (contentH - actualThumbH) / 2;
-                    if (ThumbnailIsRight()) {
-                        thumbX = curX + width - thumbWidth;
+                    if (ThumbnailAlignRight()) {
+                        thumbX = thumbAreaStart + std::max(0, thumbAreaW - thumbWidth);
+                    } else if (ThumbnailAlignCentered()) {
+                        thumbX = thumbAreaStart + std::max(0, (thumbAreaW - thumbWidth) / 2);
+                    } else {
+                        thumbX = thumbAreaStart;
                     }
                 } else if (!StretchThumbsToTaskWidth() && width > thumbWidth) {
                     thumbX += (width - thumbWidth) / 2;
                 }
                 w.rcThumbActual = { thumbX, thumbY, thumbX + thumbWidth, thumbY + actualThumbH };
                 w.rcThumb = w.rcThumbActual;
+                w.rcThumbSlot = { slotX, thumbY, slotX + slotW, thumbY + actualThumbH };
             }
 
             if (width > curColMaxW) curColMaxW = width;
@@ -1380,6 +1425,8 @@ static void ComputeLayout(HMONITOR hMon) {
                     g_windows[j].rcThumbActual.bottom += diff;
                     g_windows[j].rcThumb.top += diff;
                     g_windows[j].rcThumb.bottom += diff;
+                    g_windows[j].rcThumbSlot.top += diff;
+                    g_windows[j].rcThumbSlot.bottom += diff;
                 }
             }
 
@@ -1623,18 +1670,23 @@ static RECT GetHeaderContentRectForEntry(const WindowEntry& e) {
         return rc;
     }
 
+    const RECT& rcHeaderSplit = ((e.rcThumbSlot.left != 0 || e.rcThumbSlot.top != 0 ||
+                                  e.rcThumbSlot.right != 0 || e.rcThumbSlot.bottom != 0))
+                                    ? e.rcThumbSlot
+                                    : e.rcThumbActual;
+
     if (ThumbnailIsTop()) {
         int divider = DpiScale(SWS_PAD_DIVIDER, g_dpiY);
-        rc.top = e.rcThumbActual.bottom + divider;
+        rc.top = rcHeaderSplit.bottom + divider;
     } else if (ThumbnailIsBottom()) {
         int divider = DpiScale(SWS_PAD_DIVIDER, g_dpiY);
-        rc.bottom = e.rcThumbActual.top - divider;
+        rc.bottom = rcHeaderSplit.top - divider;
     } else if (ThumbnailIsSide()) {
         int divider = DpiScale(SWS_PAD_DIVIDER, g_dpiX);
         if (ThumbnailIsLeft()) {
-            rc.left = e.rcThumbActual.right + divider;
+            rc.left = rcHeaderSplit.right + divider;
         } else {
-            rc.right = e.rcThumbActual.left - divider;
+            rc.right = rcHeaderSplit.left - divider;
         }
     }
 
@@ -2804,6 +2856,13 @@ static void LoadSettings() {
         wcscmp(g_settings.thumbnailPosition, L"left") != 0 &&
         wcscmp(g_settings.thumbnailPosition, L"right") != 0) {
         wcscpy_s(g_settings.thumbnailPosition, L"bottom");
+    }
+    v = Wh_GetStringSetting(L"Appearance.Thumbnails.thumbnailAlignment");
+    wcscpy_s(g_settings.thumbnailAlignment, v ? v : L"left"); Wh_FreeStringSetting(v);
+    if (wcscmp(g_settings.thumbnailAlignment, L"left") != 0 &&
+        wcscmp(g_settings.thumbnailAlignment, L"centered") != 0 &&
+        wcscmp(g_settings.thumbnailAlignment, L"right") != 0) {
+        wcscpy_s(g_settings.thumbnailAlignment, L"left");
     }
     v = Wh_GetStringSetting(L"Miscellaneous.backwardShortcut");
     if (v) {

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -68,31 +68,96 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       - none: None (Transparent)
       - backdrop: Acrylic (Windows 10+)
       - mica: Mica Blur (Windows 11 only)
-    - opacity: 100
-      $name: Background Opacity
-      $description: Background opacity percentage (0-100), applies to None and Acrylic themes. Set value to '80' for Acrylic to see the effect.
     - colorScheme: system
       $name: Color Scheme
       $options:
       - system: Follow system setting
       - light: Light
       - dark: Dark
-    - highlightStyle: border
-      $name: Selected Task Highlight Style
-      $description: Style used for the selected task row/tile.
-      $options:
-      - border: Border only
-      - fillAndBorder: Background fill and border
-      - fillOnly: Background fill only
-    - borderColorDark: "#FFFFFF"
-      $name: Dark Mode Border Color
-      $description: Border color in HEX format for dark mode.
-    - borderColorLight: "#000000"
-      $name: Light Mode Border Color
-      $description: Border color in HEX format for light mode.
-    - useAccentColor: false
-      $name: Use Accent Color for Borders and Background Fill
-      $description: Use Windows accent color for selection and hover borders. 
+    - DarkMode:
+        - highlightStyle: border
+          $name: Task Highlight Style
+          $description: Style used for the selected task row/tile.
+          $options:
+          - border: Border only
+          - fillAndBorder: Background fill and border
+          - fillOnly: Background fill only
+        - opacity: 100
+          $name: Background Opacity
+          $description: Background opacity percentage (0-100), applies to None and Acrylic themes. Set value to '80' for Acrylic to see the effect.
+        - borderColorMode: default
+          $name: Border Color
+          $description: Color source for the selected/hovered task border in dark mode.
+          $options:
+          - default: Default
+          - custom: Custom
+          - accent: Accent
+        - highlightFillColorMode: default
+          $name: Task Highlight Background Fill Color
+          $description: Color source for the selected task background fill in dark mode.
+          $options:
+          - default: Default
+          - custom: Custom
+          - accent: Accent
+        - bgColorMode: default
+          $name: Switcher Background Color
+          $description: Color source for the switcher window background in dark mode. Applies to None and Acrylic themes.
+          $options:
+          - default: Default
+          - custom: Custom
+          - accent: Accent
+        - customBorderColor: "#FFFFFF"
+          $name: Custom Border Color
+          $description: HEX color value, used when Border Color is set to Custom.
+        - customHighlightFillColor: "#FFFFFF"
+          $name: Custom Task Highlight Background Fill Color
+          $description: HEX color value, used when Task Highlight Background Fill Color is set to Custom.
+        - customBgColor: "#202020"
+          $name: Custom Switcher Background Color
+          $description: HEX color value, used when Switcher Background Color is set to Custom.
+      $name: Dark Mode
+    - LightMode:
+        - highlightStyle: border
+          $name: Task Highlight Style
+          $description: Style used for the selected task row/tile.
+          $options:
+          - border: Border only
+          - fillAndBorder: Background fill and border
+          - fillOnly: Background fill only
+        - opacity: 100
+          $name: Background Opacity
+          $description: Background opacity percentage (0-100), applies to None and Acrylic themes. Set value to '80' for Acrylic to see the effect.
+        - borderColorMode: default
+          $name: Border Color
+          $description: Color source for the selected/hovered task border in light mode.
+          $options:
+          - default: Default
+          - custom: Custom
+          - accent: Accent
+        - highlightFillColorMode: default
+          $name: Task Highlight Background Fill Color
+          $description: Color source for the selected task background fill in light mode.
+          $options:
+          - default: Default
+          - custom: Custom
+          - accent: Accent
+        - bgColorMode: default
+          $name: Switcher Background Color
+          $description: Color source for the switcher window background in light mode. Applies to None and Acrylic themes.
+          $options:
+          - default: Default
+          - custom: Custom
+          - accent: Accent
+        - customBorderColor: "#000000"
+          $name: Custom Border Color
+          $description: HEX color value, used when Border Color is set to Custom.
+        - customHighlightFillColor: "#000000"
+          $name: Custom Task Highlight Background Fill Color
+          $description: HEX color value, used when Task Highlight Background Fill Color is set to Custom.
+        - customBgColor: "#F3F3F3"
+          $name: Custom Switcher Background Color
+          $description: HEX color value, used when Switcher Background Color is set to Custom.
+      $name: Light Mode
   $name: Theme
 - Appearance:
     - Corners:
@@ -241,15 +306,12 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       - allDesktops: Show windows from all virtual desktops
   $name: Accessibility
 - ExcludedWindows:
-  - - Method: title
-      $name: Exclusion Method
-      $description: Exclude by window title or executable name
-      $options:
-      - title: Window Title
-      - exe: Executable Name
-    - Value: ""
-      $name: Pattern
-      $description: "The pattern to exclude (wildcards supported: * matches any characters, ? matches one). Separate multiple entries with a comma. Example: *chrome*, msedge.exe"
+    - excludeByTitle: ""
+      $name: Exclude by Window Title
+      $description: "Window title patterns to exclude, separated by ';' (wildcards supported: * matches any characters, ? matches one). Example: *Notepad*;*Chrome*"
+    - excludeByExe: ""
+      $name: Exclude by Executable Name
+      $description: "Executable name patterns to exclude, separated by ';' (wildcards supported: * matches any characters, ? matches one). Example: notepad.exe;chrome.exe"
   $name: Excluded Windows
   $description: Exclude specific windows from appearing in the switcher.
 
@@ -326,12 +388,17 @@ struct WindowEntry {
 };
 struct Settings {
     WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32]; WCHAR thumbnailPosition[32]; WCHAR thumbnailAlignment[32]; WCHAR switcherDisplayBehavior[32];
-    WCHAR highlightStyle[32]; WCHAR virtualDesktopBehavior[32];
-    WCHAR borderColorDark[16];
-    WCHAR borderColorLight[16];
+    WCHAR virtualDesktopBehavior[32];
+    // Dark Mode color settings
+    WCHAR highlightStyleDark[32]; int opacityDark;
+    WCHAR borderColorModeDark[16]; WCHAR highlightFillColorModeDark[16]; WCHAR bgColorModeDark[16];
+    WCHAR customBorderColorDark[16]; WCHAR customHighlightFillColorDark[16]; WCHAR customBgColorDark[16];
+    // Light Mode color settings
+    WCHAR highlightStyleLight[32]; int opacityLight;
+    WCHAR borderColorModeLight[16]; WCHAR highlightFillColorModeLight[16]; WCHAR bgColorModeLight[16];
+    WCHAR customBorderColorLight[16]; WCHAR customHighlightFillColorLight[16]; WCHAR customBgColorLight[16];
     WCHAR fontFamily[64]; WCHAR fontStyle[32];
     int fontSize;
-    int opacity;
     int rowHeight;
     int rowWidth;
     bool stretchThumbnailsToTaskWidth;
@@ -340,7 +407,7 @@ struct Settings {
     bool showIcon;
     int maxWidthPercent;
     int maxHeightPercent; int showDelay;
-    bool useAccentColor; bool perMonitorWindows; bool taskRoundedCorners; bool reverseScrollDirection;
+    bool perMonitorWindows; bool taskRoundedCorners; bool reverseScrollDirection;
     bool centerTaskContent;
     bool showApplications;
     WCHAR showTitles[32];
@@ -401,7 +468,9 @@ static bool HeaderOrientationIs(const WCHAR* v) { return wcscmp(g_settings.heade
 static bool IconSizeIs(const WCHAR* v) { return wcscmp(g_settings.iconSize, v) == 0; }
 static bool BackwardShortcutIs(const WCHAR* v) { return wcscmp(g_settings.backwardShortcut, v) == 0; }
 static bool ThumbnailPositionIs(const WCHAR* v) { return wcscmp(g_settings.thumbnailPosition, v) == 0; }
-static bool HighlightStyleIs(const WCHAR* v) { return wcscmp(g_settings.highlightStyle, v) == 0; }
+static bool HighlightStyleIs(const WCHAR* v) {
+    return wcscmp(g_isDarkMode ? g_settings.highlightStyleDark : g_settings.highlightStyleLight, v) == 0;
+}
 static bool UseAltShiftTabBackward() { return BackwardShortcutIs(L"altShiftTab"); }
 static bool UseAltShiftBackward() { return BackwardShortcutIs(L"altShift"); }
 static bool UseAltBacktickBackward() { return BackwardShortcutIs(L"altBacktick"); }
@@ -1760,17 +1829,46 @@ static void UnregisterThumbnails() {
 
 // Drawing Helpers
 
-static COLORREF GetContourColor() {
-    if (g_settings.useAccentColor) return GetAccentColor();
-
-    COLORREF parsed;
-    if (g_isDarkMode) {
-        if (ParseHexColor(g_settings.borderColorDark, &parsed)) return parsed;
-    } else {
-        if (ParseHexColor(g_settings.borderColorLight, &parsed)) return parsed;
+static COLORREF ResolveColor(const WCHAR* mode, const WCHAR* customHex, COLORREF defaultColor) {
+    if (wcscmp(mode, L"accent") == 0) return GetAccentColor();
+    if (wcscmp(mode, L"custom") == 0) {
+        COLORREF parsed;
+        if (ParseHexColor(customHex, &parsed)) return parsed;
     }
+    return defaultColor;
+}
 
-    return g_isDarkMode ? SWS_CONTOUR_DARK : SWS_CONTOUR_LIGHT;
+static COLORREF GetContourColor() {
+    if (g_isDarkMode) {
+        return ResolveColor(g_settings.borderColorModeDark,
+                            g_settings.customBorderColorDark,
+                            SWS_CONTOUR_DARK);
+    }
+    return ResolveColor(g_settings.borderColorModeLight,
+                        g_settings.customBorderColorLight,
+                        SWS_CONTOUR_LIGHT);
+}
+
+static COLORREF GetHighlightFillColor() {
+    if (g_isDarkMode) {
+        return ResolveColor(g_settings.highlightFillColorModeDark,
+                            g_settings.customHighlightFillColorDark,
+                            SWS_CONTOUR_DARK);
+    }
+    return ResolveColor(g_settings.highlightFillColorModeLight,
+                        g_settings.customHighlightFillColorLight,
+                        SWS_CONTOUR_LIGHT);
+}
+
+static COLORREF GetBgColor() {
+    if (g_isDarkMode) {
+        return ResolveColor(g_settings.bgColorModeDark,
+                            g_settings.customBgColorDark,
+                            SWS_BG_DARK);
+    }
+    return ResolveColor(g_settings.bgColorModeLight,
+                        g_settings.customBgColorLight,
+                        SWS_BG_LIGHT);
 }
 
 static void MaskRectCorners(HDC hdc, const RECT& rc, int radiusPx) {
@@ -1791,7 +1889,7 @@ static void MaskRectCorners(HDC hdc, const RECT& rc, int radiusPx) {
         return;
     }
 
-    COLORREF bg = g_isDarkMode ? SWS_BG_DARK : SWS_BG_LIGHT;
+    COLORREF bg = GetBgColor();
     // In layered mode, punch fully transparent corners to force thumbnail clipping.
     BYTE alpha = ThemeIs(L"none") ? 0 : 255;
 
@@ -1873,25 +1971,33 @@ static void DrawContour(HDC hdc, RECT rc, int contourSize, int direction) {
         return;
     }
 
-    HBRUSH hBrush = CreateSolidBrush(RGB(r, g, b));
+    Gdiplus::Graphics graphics(hdc);
+    graphics.SetSmoothingMode(Gdiplus::SmoothingModeNone);
+    Gdiplus::SolidBrush solidBrush(Gdiplus::Color(255, r, g, b));
+
     if (direction < 0) {
         // Outer contour: DWM composites thumbnails on top of GDI and renders
         // inclusively at rcDestination's right/bottom edges. Inflate by i+2
-        // so FrameRect's border pixels land 1px beyond DWM's last column/row.
+        // so border pixels land 1px beyond DWM's last column/row.
         for (int i = 0; i < contourSize; i++) {
             RECT r_rect = rc;
             InflateRect(&r_rect, i + 2, i + 2);
-            FrameRect(hdc, &r_rect, hBrush);
+            graphics.FillRectangle(&solidBrush, r_rect.left, r_rect.top, (r_rect.right - r_rect.left), 1);
+            graphics.FillRectangle(&solidBrush, r_rect.left, r_rect.bottom - 1, (r_rect.right - r_rect.left), 1);
+            graphics.FillRectangle(&solidBrush, r_rect.left, r_rect.top + 1, 1, (r_rect.bottom - r_rect.top) - 2);
+            graphics.FillRectangle(&solidBrush, r_rect.right - 1, r_rect.top + 1, 1, (r_rect.bottom - r_rect.top) - 2);
         }
     } else {
         // Inner contour
         for (int i = 0; i < contourSize; i++) {
             RECT r_rect = rc;
             InflateRect(&r_rect, -i, -i);
-            FrameRect(hdc, &r_rect, hBrush);
+            graphics.FillRectangle(&solidBrush, r_rect.left, r_rect.top, (r_rect.right - r_rect.left), 1);
+            graphics.FillRectangle(&solidBrush, r_rect.left, r_rect.bottom - 1, (r_rect.right - r_rect.left), 1);
+            graphics.FillRectangle(&solidBrush, r_rect.left, r_rect.top + 1, 1, (r_rect.bottom - r_rect.top) - 2);
+            graphics.FillRectangle(&solidBrush, r_rect.right - 1, r_rect.top + 1, 1, (r_rect.bottom - r_rect.top) - 2);
         }
     }
-    DeleteObject(hBrush);
 }
 
 static void DrawSelectionFill(HDC hdc, RECT rc) {
@@ -1903,7 +2009,7 @@ static void DrawSelectionFill(HDC hdc, RECT rc) {
         return;
     }
 
-    COLORREF c = GetContourColor();
+    COLORREF c = GetHighlightFillColor();
     BYTE r = GetRValue(c);
     BYTE g = GetGValue(c);
     BYTE b = GetBValue(c);
@@ -2003,9 +2109,9 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg, HWND hWnd) {
     int w = rcClient.right, h = rcClient.bottom;
 
     if (fillBg) {
-        BYTE bgA = (BYTE)(g_settings.opacity * 255 / 100);
+        BYTE bgA = (BYTE)((g_isDarkMode ? g_settings.opacityDark : g_settings.opacityLight) * 255 / 100);
         if (bgA == 0) bgA = 1; // Prevent full transparency click-through
-        COLORREF bgC = g_isDarkMode ? SWS_BG_DARK : SWS_BG_LIGHT;
+        COLORREF bgC = GetBgColor();
         BYTE bgR = GetRValue(bgC), bgG = GetGValue(bgC), bgB = GetBValue(bgC);
         RGBQUAD bgPx = { (BYTE)(bgB*bgA/255), (BYTE)(bgG*bgA/255), (BYTE)(bgR*bgA/255), bgA };
         BITMAPINFO bgBi = {}; bgBi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
@@ -2413,7 +2519,7 @@ static void ApplyThemeToWindow(HWND hWnd) {
                 // Unfocused mirror windows drop to solid grey with native Mica.
                 // We use SetWindowCompositionAttribute (Acrylic Blur) to force a translucent effect.
                 DWORD blur = 200; // Fixed opacity (~78%) to closely simulate Mica blur
-                COLORREF bg = g_isDarkMode ? SWS_BG_DARK : SWS_BG_LIGHT;
+                COLORREF bg = GetBgColor();
                 ACCENT_POLICY accent = {};
                 accent.AccentState = 4 /* ACCENT_ENABLE_ACRYLICBLURBEHIND */;
                 accent.AccentFlags = 0;
@@ -2423,8 +2529,8 @@ static void ApplyThemeToWindow(HWND hWnd) {
             }
         }
         if (ThemeIs(L"backdrop") && g_SetWindowCompositionAttribute) {
-            DWORD blur = (DWORD)((g_settings.opacity / 100.0) * 255);
-            COLORREF bg = g_isDarkMode ? SWS_BG_DARK : SWS_BG_LIGHT;
+            DWORD blur = (DWORD)(((g_isDarkMode ? g_settings.opacityDark : g_settings.opacityLight) / 100.0) * 255);
+            COLORREF bg = GetBgColor();
             ACCENT_POLICY accent = {};
             accent.AccentState = 4 /* ACCENT_ENABLE_ACRYLICBLURBEHIND */;
             accent.AccentFlags = 0;
@@ -3327,15 +3433,6 @@ static void LoadSettings() {
         wcscpy_s(g_settings.backwardShortcut, L"altShiftTab");
     }
 
-    v = Wh_GetStringSetting(L"Style.highlightStyle");
-    wcscpy_s(g_settings.highlightStyle, v ? v : L"border");
-    Wh_FreeStringSetting(v);
-    if (wcscmp(g_settings.highlightStyle, L"border") != 0 &&
-        wcscmp(g_settings.highlightStyle, L"fillAndBorder") != 0 &&
-        wcscmp(g_settings.highlightStyle, L"fillOnly") != 0) {
-        wcscpy_s(g_settings.highlightStyle, L"border");
-    }
-
     v = Wh_GetStringSetting(L"Accessibility.virtualDesktopBehavior");
     wcscpy_s(g_settings.virtualDesktopBehavior, v ? v : L"currentOnly");
     Wh_FreeStringSetting(v);
@@ -3344,9 +3441,6 @@ static void LoadSettings() {
         wcscpy_s(g_settings.virtualDesktopBehavior, L"currentOnly");
     }
 
-    g_settings.opacity = Wh_GetIntSetting(L"Style.opacity");
-    if (g_settings.opacity < 0) g_settings.opacity = 0;
-    if (g_settings.opacity > 100) g_settings.opacity = 100;
     g_settings.rowHeight = Wh_GetIntSetting(L"Dimensions.rowHeight");
     if (g_settings.rowHeight <= 0) g_settings.rowHeight = 230;
     g_settings.rowWidth = Wh_GetIntSetting(L"Dimensions.rowWidth");
@@ -3365,7 +3459,6 @@ static void LoadSettings() {
 
     g_settings.showDelay = Wh_GetIntSetting(L"Accessibility.showDelay");
     if (g_settings.showDelay < 0) g_settings.showDelay = 0;
-    g_settings.useAccentColor = Wh_GetIntSetting(L"Style.useAccentColor");
     g_settings.perMonitorWindows = Wh_GetIntSetting(L"Accessibility.perMonitorWindows");
     g_settings.reverseScrollDirection = Wh_GetIntSetting(L"Accessibility.reverseScrollDirection");
     g_settings.showApplications = Wh_GetIntSetting(L"Grouping.showApplications");
@@ -3380,17 +3473,55 @@ static void LoadSettings() {
     g_settings.centerTaskContent = Wh_GetIntSetting(L"Appearance.HeaderContent.centerTaskContent");
 
 
-    v = Wh_GetStringSetting(L"Style.borderColorDark");
-    wcscpy_s(g_settings.borderColorDark, v ? v : L"#FFFFFF"); Wh_FreeStringSetting(v);
-    if (!ParseHexColor(g_settings.borderColorDark, nullptr)) {
-        wcscpy_s(g_settings.borderColorDark, L"#FFFFFF");
+    // Dark Mode color settings
+    v = Wh_GetStringSetting(L"Style.DarkMode.highlightStyle");
+    wcscpy_s(g_settings.highlightStyleDark, v ? v : L"border"); Wh_FreeStringSetting(v);
+    if (wcscmp(g_settings.highlightStyleDark, L"border") != 0 &&
+        wcscmp(g_settings.highlightStyleDark, L"fillAndBorder") != 0 &&
+        wcscmp(g_settings.highlightStyleDark, L"fillOnly") != 0) {
+        wcscpy_s(g_settings.highlightStyleDark, L"border");
     }
+    g_settings.opacityDark = Wh_GetIntSetting(L"Style.DarkMode.opacity");
+    if (g_settings.opacityDark < 0) g_settings.opacityDark = 0;
+    if (g_settings.opacityDark > 100) g_settings.opacityDark = 100;
 
-    v = Wh_GetStringSetting(L"Style.borderColorLight");
-    wcscpy_s(g_settings.borderColorLight, v ? v : L"#000000"); Wh_FreeStringSetting(v);
-    if (!ParseHexColor(g_settings.borderColorLight, nullptr)) {
-        wcscpy_s(g_settings.borderColorLight, L"#000000");
+    v = Wh_GetStringSetting(L"Style.DarkMode.borderColorMode");
+    wcscpy_s(g_settings.borderColorModeDark, v ? v : L"default"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.DarkMode.highlightFillColorMode");
+    wcscpy_s(g_settings.highlightFillColorModeDark, v ? v : L"default"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.DarkMode.bgColorMode");
+    wcscpy_s(g_settings.bgColorModeDark, v ? v : L"default"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.DarkMode.customBorderColor");
+    wcscpy_s(g_settings.customBorderColorDark, v ? v : L"#FFFFFF"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.DarkMode.customHighlightFillColor");
+    wcscpy_s(g_settings.customHighlightFillColorDark, v ? v : L"#FFFFFF"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.DarkMode.customBgColor");
+    wcscpy_s(g_settings.customBgColorDark, v ? v : L"#202020"); Wh_FreeStringSetting(v);
+
+    // Light Mode color settings
+    v = Wh_GetStringSetting(L"Style.LightMode.highlightStyle");
+    wcscpy_s(g_settings.highlightStyleLight, v ? v : L"border"); Wh_FreeStringSetting(v);
+    if (wcscmp(g_settings.highlightStyleLight, L"border") != 0 &&
+        wcscmp(g_settings.highlightStyleLight, L"fillAndBorder") != 0 &&
+        wcscmp(g_settings.highlightStyleLight, L"fillOnly") != 0) {
+        wcscpy_s(g_settings.highlightStyleLight, L"border");
     }
+    g_settings.opacityLight = Wh_GetIntSetting(L"Style.LightMode.opacity");
+    if (g_settings.opacityLight < 0) g_settings.opacityLight = 0;
+    if (g_settings.opacityLight > 100) g_settings.opacityLight = 100;
+
+    v = Wh_GetStringSetting(L"Style.LightMode.borderColorMode");
+    wcscpy_s(g_settings.borderColorModeLight, v ? v : L"default"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.LightMode.highlightFillColorMode");
+    wcscpy_s(g_settings.highlightFillColorModeLight, v ? v : L"default"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.LightMode.bgColorMode");
+    wcscpy_s(g_settings.bgColorModeLight, v ? v : L"default"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.LightMode.customBorderColor");
+    wcscpy_s(g_settings.customBorderColorLight, v ? v : L"#000000"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.LightMode.customHighlightFillColor");
+    wcscpy_s(g_settings.customHighlightFillColorLight, v ? v : L"#000000"); Wh_FreeStringSetting(v);
+    v = Wh_GetStringSetting(L"Style.LightMode.customBgColor");
+    wcscpy_s(g_settings.customBgColorLight, v ? v : L"#F3F3F3"); Wh_FreeStringSetting(v);
 
     v = Wh_GetStringSetting(L"Appearance.Font.fontFamily");
     wcscpy_s(g_settings.fontFamily, v ? v : L"Segoe UI"); Wh_FreeStringSetting(v);
@@ -3404,45 +3535,49 @@ static void LoadSettings() {
     v = Wh_GetStringSetting(L"Accessibility.switcherDisplayBehavior");
     wcscpy_s(g_settings.switcherDisplayBehavior, v ? v : L"cursorMonitor"); Wh_FreeStringSetting(v);
 
+    // Exclusion patterns (newline-delimited text fields)
     g_excludeTitlePatterns.clear();
     g_excludeExePatterns.clear();
-    for (int i = 0; ; i++) {
-        PCWSTR method = Wh_GetStringSetting(L"ExcludedWindows[%d].Method", i);
-        bool done = !method || !*method;
-        
-        if (done) {
-            if (method) Wh_FreeStringSetting(method);
-            break;
-        }
-        
-        PCWSTR value = Wh_GetStringSetting(L"ExcludedWindows[%d].Value", i);
-        if (value && *value) {
-            std::wstring valStr(value);
-            size_t start = 0;
-            while (start < valStr.length()) {
-                size_t end = valStr.find(L',', start);
-                if (end == std::wstring::npos) end = valStr.length();
-                
-                std::wstring token = valStr.substr(start, end - start);
-                size_t first = token.find_first_not_of(L" \t");
-                if (first != std::wstring::npos) {
-                    token = token.substr(first);
-                    size_t last = token.find_last_not_of(L" \t");
-                    token = token.substr(0, last + 1);
-                    
-                    if (wcscmp(method, L"title") == 0) {
-                        g_excludeTitlePatterns.push_back(token);
-                    } else if (wcscmp(method, L"exe") == 0) {
-                        g_excludeExePatterns.push_back(token);
-                    }
-                }
-                start = end + 1;
+
+    v = Wh_GetStringSetting(L"ExcludedWindows.excludeByTitle");
+    if (v && *v) {
+        std::wstring valStr(v);
+        size_t start = 0;
+        while (start < valStr.length()) {
+            size_t end = valStr.find(L';', start);
+            if (end == std::wstring::npos) end = valStr.length();
+            std::wstring token = valStr.substr(start, end - start);
+            size_t first = token.find_first_not_of(L" \t\r\n");
+            if (first != std::wstring::npos) {
+                token = token.substr(first);
+                size_t last = token.find_last_not_of(L" \t\r\n");
+                token = token.substr(0, last + 1);
+                if (!token.empty()) g_excludeTitlePatterns.push_back(token);
             }
+            start = end + 1;
         }
-        
-        Wh_FreeStringSetting(method);
-        if (value) Wh_FreeStringSetting(value);
     }
+    if (v) Wh_FreeStringSetting(v);
+
+    v = Wh_GetStringSetting(L"ExcludedWindows.excludeByExe");
+    if (v && *v) {
+        std::wstring valStr(v);
+        size_t start = 0;
+        while (start < valStr.length()) {
+            size_t end = valStr.find(L';', start);
+            if (end == std::wstring::npos) end = valStr.length();
+            std::wstring token = valStr.substr(start, end - start);
+            size_t first = token.find_first_not_of(L" \t\r\n");
+            if (first != std::wstring::npos) {
+                token = token.substr(first);
+                size_t last = token.find_last_not_of(L" \t\r\n");
+                token = token.substr(0, last + 1);
+                if (!token.empty()) g_excludeExePatterns.push_back(token);
+            }
+            start = end + 1;
+        }
+    }
+    if (v) Wh_FreeStringSetting(v);
 }
 
 

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -18,7 +18,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 
 ## Features
 - Grid layout with live DWM thumbnail previews
-- Different Task List and Header Content layouts
+- Different Task List, Header Content and Thumbnails layouts
 - Center align task list content and titles (horizontal and vertical options)
 - Keyboard navigation (Tab/Shift+Tab/Shift/Backtick, Arrow keys, Enter, Esc)
 - Mouse click to select, scroll wheel to cycle
@@ -27,6 +27,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 - Works with elevated/admin applications
 - Dark/light mode auto-detection
 - Custom border colors with optional Windows accent color
+- Different item highlight options
 - DPI-aware, multi-monitor aware
 - Rounded corners for switcher and task thumbnails (optional)
 - Dynamic UI adjustments (e.g., intelligent close button placement over thumbnails)
@@ -50,13 +51,17 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 
 ![Vertical large](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/2.png)
 
-*Vertical rounded with centered task icons and titles*
+*Horizontal rounded with centered task icons and titles*
 
-![Vertical centered](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/6.png)
+![Horizontal centered](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/6.png)
 
-*Vertical squared with thumbnails*
+*Horizontal squared with thumbnails on top*
 
-![Vertical squared with thumbnails](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/5.png)
+![Horizontal squared with thumbnails on top](https://github.com/Asteski/Windhawk-Mods/blob/cc72179d1ff603f3d3cf94fd41230ebea774bc8b/img/simple-window-switcher/7.png)
+
+*Horizontal rounded with thumbnails and no icons*
+
+![Horizontal rounded with thumbnails and no icons]https://github.com/Asteski/Windhawk-Mods/blob/cc72179d1ff603f3d3cf94fd41230ebea774bc8b/img/simple-window-switcher/8.png)
 
 */
 // ==/WindhawkModReadme==

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -994,7 +994,11 @@ static void ComputeLayout(HMONITOR hMon) {
                 }
             } else {
                 if (!g_settings.showTitle && g_settings.showIcon) {
-                    width = GetHeaderIconSizePx() + DpiScale(16, dpiX); // Base padding
+                    if (g_settings.centerTaskContent) {
+                        width = GetHeaderIconSizePx() + DpiScale(16, dpiX); // Base padding
+                    } else {
+                        width = GetHeaderIconSizePx() + DpiScale(20, dpiX); // Icon + btnSz(16) + gap(4)
+                    }
                 } else {
                     width = DpiScale(160, dpiX);
                 }
@@ -1103,7 +1107,15 @@ static void ComputeLayout(HMONITOR hMon) {
                     if (w.effectiveSourceSize.cx > 0 && width > w.effectiveSourceSize.cx) width = w.effectiveSourceSize.cx;
                 }
             } else {
-                width = DpiScale(160, dpiX);
+                if (!g_settings.showTitle && g_settings.showIcon) {
+                    if (g_settings.centerTaskContent) {
+                        width = GetHeaderIconSizePx() + DpiScale(16, dpiX); // Base padding
+                    } else {
+                        width = GetHeaderIconSizePx() + DpiScale(20, dpiX); // Icon + btnSz(16) + gap(4)
+                    }
+                } else {
+                    width = DpiScale(160, dpiX);
+                }
             }
 
             if (g_settings.rowWidth > 0) {
@@ -1406,8 +1418,8 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
 
         int closeBtnReserve = DpiScale(24, g_dpiX) + padLeft;
         int btnReserve = 0;
+        bool isIconOnly = !g_settings.showThumbnails && !g_settings.showTitle && g_settings.showIcon;
         if (!HeaderIsVertical()) {
-            bool isIconOnly = !g_settings.showThumbnails && !g_settings.showTitle && g_settings.showIcon;
             if (!isIconOnly) {
                 btnReserve = ((g_settings.centerTaskContent) || i == g_hoverIndex)
                          ? closeBtnReserve
@@ -1426,7 +1438,7 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
         int textTop = e.rcCell.top + padTop;
         int textBottom = textTop + rowTitleH;
 
-        if (HeaderIsVertical()) {
+        if (HeaderIsVertical() && !isIconOnly) {
             int availableW = contentRight - contentLeft;
             if (availableW < 0) availableW = 0;
 
@@ -1524,10 +1536,7 @@ static void DrawSwitcherOverlay(HDC hdc) {
                 int iconX = contentLeft;
                 int iconY = e.rcCell.top + padTop + (rowTitleH - iconSz) / 2;
                 
-                if (HeaderIsVertical()) {
-                    iconX = contentLeft + ((availableW > iconSz) ? (availableW - iconSz) / 2 : 0);
-                    iconY = e.rcCell.top + padTop;
-                } else if (g_settings.centerTaskContent) {
+                if (g_settings.centerTaskContent) {
                     if (iconSz < availableW) {
                         iconX = contentLeft + (availableW - iconSz) / 2;
                     }
@@ -1535,8 +1544,15 @@ static void DrawSwitcherOverlay(HDC hdc) {
 
                 int btnPadding = DpiScale(2, g_dpiX);
                 btnSz = DpiScale(16, g_dpiX);
-                bx = iconX + iconSz - btnSz + btnPadding;
-                by = iconY - btnPadding;
+                
+                if (g_settings.centerTaskContent) {
+                    bx = iconX + iconSz - btnSz + btnPadding;
+                    by = iconY - btnPadding;
+                } else {
+                    int gap = DpiScale(4, g_dpiX);
+                    bx = iconX + iconSz + gap;
+                    by = iconY;
+                }
             } else {
                 bx = e.rcCell.right - padLeft - btnSz;
                 by = HeaderIsVertical() ? (e.rcCell.top + padTop)
@@ -2253,10 +2269,7 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
                 int iconX = contentLeft;
                 int iconY = e.rcCell.top + padT + (titleH - iconSz) / 2;
                 
-                if (HeaderIsVertical()) {
-                    iconX = contentLeft + ((availableW > iconSz) ? (availableW - iconSz) / 2 : 0);
-                    iconY = e.rcCell.top + padT;
-                } else if (g_settings.centerTaskContent) {
+                if (g_settings.centerTaskContent) {
                     if (iconSz < availableW) {
                         iconX = contentLeft + (availableW - iconSz) / 2;
                     }
@@ -2264,8 +2277,15 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
 
                 int btnPadding = DpiScale(2, g_dpiX);
                 btnSz = DpiScale(16, g_dpiX);
-                bx = iconX + iconSz - btnSz + btnPadding;
-                by = iconY - btnPadding;
+                
+                if (g_settings.centerTaskContent) {
+                    bx = iconX + iconSz - btnSz + btnPadding;
+                    by = iconY - btnPadding;
+                } else {
+                    int gap = DpiScale(4, g_dpiX);
+                    bx = iconX + iconSz + gap;
+                    by = iconY;
+                }
             } else {
                 bx = e.rcCell.right - padL - btnSz;
                 by = HeaderIsVertical() ? (e.rcCell.top + padT)

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -2,7 +2,7 @@
 // @id              simple-window-switcher
 // @name            Simple Window Switcher
 // @description     Replaces the default Alt+Tab with a lightweight window switcher inspired by ExplorerPatcher's Simple Window Switcher
-// @version         1.2
+// @version         2.0
 // @author          Lone
 // @github          https://github.com/Louis047
 // @include         windhawk.exe
@@ -21,7 +21,9 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 - Different Task List, Header Content and Thumbnails layouts
 - Center align task list content and titles (horizontal and vertical options)
 - Keyboard navigation (Tab/Shift+Tab/Shift/Backtick, Arrow keys, Enter, Esc)
-- Mouse click to select, scroll wheel to cycle
+- Mouse click to select, scroll wheel to cycle from anywhere
+- Virtual Desktop Support (Show windows across multiple virtual desktops)
+- Win+Alt+Tab override to display windows from all monitors when using Per-Monitor mode
 - Alt+Ctrl+Tab sticky mode
 - Theme support (None/Backdrop Acrylic) with fully customizable background opacity
 - Works with elevated/admin applications
@@ -62,7 +64,8 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       $description: Visual theme for the switcher background.
       $options:
       - none: None (transparent)
-      - backdrop: Backdrop (Acrylic)
+      - backdrop: Acrylic (Windows 10+)
+      - mica: Mica (Windows 11 Only)
     - opacity: 100
       $name: Background Opacity
       $description: Background opacity percentage (0-100), applies to None theme.
@@ -170,6 +173,8 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       - never: Never
       - always: Always
       - stickyOnly: Only in sticky mode
+    - reverseScrollDirection: false
+      $name: Reverse Scroll Direction
     - backwardShortcut: altShiftTab
       $name: Backward Shortcut
       $description: Shortcut used to move backward in the switcher.
@@ -181,6 +186,12 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       $name: Always Display Switcher on Primary Monitor
     - perMonitorWindows: false
       $name: Display Windows Only From the Monitor Containing the Cursor
+    - virtualDesktopBehavior: currentOnly
+      $name: Virtual Desktop Behavior
+      $description: Choose which virtual desktops to show windows from.
+      $options:
+      - currentOnly: Show windows from current virtual desktop only
+      - allDesktops: Show windows from all virtual desktops
   $name: Miscellaneous
 */
 // ==/WindhawkModSettings==
@@ -253,7 +264,7 @@ struct WindowEntry {
 };
 struct Settings {
     WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32]; WCHAR thumbnailPosition[32];
-    WCHAR highlightStyle[32];
+    WCHAR highlightStyle[32]; WCHAR virtualDesktopBehavior[32];
     WCHAR borderColorDark[16];
     WCHAR borderColorLight[16];
     int opacity;
@@ -265,12 +276,15 @@ struct Settings {
     bool showIcon;
     int maxWidthPercent;
     int maxHeightPercent; int showDelay;
-    bool useAccentColor; bool primaryMonitorOnly; bool perMonitorWindows; bool taskRoundedCorners;
+    bool useAccentColor; bool primaryMonitorOnly; bool perMonitorWindows; bool taskRoundedCorners; bool reverseScrollDirection;
     bool centerTaskContent;
 };
 
 static HWND g_hSwitcher = NULL;
 static HWND g_hCloseBtnWnd = NULL;
+static IVirtualDesktopManager* g_pVirtualDesktopManager = NULL;
+static bool g_showAllMonitors = false;
+static HHOOK g_hMouseHook = NULL;
 static std::vector<WindowEntry> g_windows;
 static int g_selectedIndex = 0, g_hoverIndex = -1;
 static int g_layoutStartIndex = 0; // EP-style: first window index visible in the layout
@@ -519,8 +533,15 @@ static BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) {
     if (!IsAltTabWindow(hWnd)) return TRUE;
     BOOL cloaked = FALSE;
     DwmGetWindowAttribute(hWnd, DWMWA_CLOAKED, &cloaked, sizeof(cloaked));
-    if (cloaked) return TRUE;
-    if (g_settings.perMonitorWindows && g_hCurrentMonitor) {
+    if (cloaked) {
+        if (wcscmp(g_settings.virtualDesktopBehavior, L"allDesktops") == 0 && g_pVirtualDesktopManager) {
+            BOOL onCurrent = FALSE;
+            if (SUCCEEDED(g_pVirtualDesktopManager->IsWindowOnCurrentVirtualDesktop(hWnd, &onCurrent)) && !onCurrent) {
+                // allow cloaked window since it's just on another virtual desktop
+            } else return TRUE;
+        } else return TRUE;
+    }
+    if (g_settings.perMonitorWindows && !g_showAllMonitors && g_hCurrentMonitor) {
         if (MonitorFromWindow(hWnd, MONITOR_DEFAULTTONULL) != g_hCurrentMonitor) return TRUE;
     }
     WindowEntry e = {};
@@ -1941,6 +1962,22 @@ static void ShowPendingOffscreenWindow() {
     SetForegroundWindow(g_hSwitcher);
 }
 
+static void CycleLinear(int delta);
+
+static LRESULT CALLBACK LowLevelMouseProc(int nCode, WPARAM wParam, LPARAM lParam) {
+    if (nCode == HC_ACTION && g_isVisible && wParam == WM_MOUSEWHEEL) {
+        MSLLHOOKSTRUCT* pMouseStruct = (MSLLHOOKSTRUCT*)lParam;
+        bool ok = ScrollIs(L"always") || (ScrollIs(L"stickyOnly") && g_isSticky);
+        if (ok) {
+            int dir = (short)HIWORD(pMouseStruct->mouseData) > 0 ? -1 : 1;
+            if (g_settings.reverseScrollDirection) dir = -dir;
+            CycleLinear(dir);
+            return 1;
+        }
+    }
+    return CallNextHookEx(g_hMouseHook, nCode, wParam, lParam);
+}
+
 static void RevealPendingSwitcher() {
     if (!g_isPendingShow || !g_hSwitcher) {
         return;
@@ -1950,6 +1987,9 @@ static void RevealPendingSwitcher() {
 
     g_isPendingShow = false;
     g_isVisible = true;
+    if (!g_hMouseHook) {
+        g_hMouseHook = SetWindowsHookEx(WH_MOUSE_LL, LowLevelMouseProc, GetModuleHandle(NULL), 0);
+    }
 
     int x = g_pendingSwitcherRect.left;
     int y = g_pendingSwitcherRect.top;
@@ -1975,7 +2015,7 @@ static void ShowSwitcher(bool sticky) {
         MonitorFromPoint({0,0}, MONITOR_DEFAULTTOPRIMARY) :
         MonitorFromPoint(pt, MONITOR_DEFAULTTOPRIMARY);
     g_hCurrentMonitor = hMon;
-    if (g_settings.perMonitorWindows) {
+    if (g_settings.perMonitorWindows && !g_showAllMonitors) {
         UnregisterThumbnails(); BuildWindowList();
         if (g_windows.empty()) return;
     }
@@ -1996,7 +2036,7 @@ static void ShowSwitcher(bool sticky) {
 
     // Apply theme (EP: sws_WindowSwitcher.c lines 510-570)
     // Step 1: Reset DWM frame and blur state (EP lines 510-524)
-    MARGINS marGlassInset = { 0, 0, 0, 0 };
+    MARGINS marGlassInset = ThemeIs(L"mica") ? MARGINS{-1, -1, -1, -1} : MARGINS{0, 0, 0, 0};
     DwmExtendFrameIntoClientArea(g_hSwitcher, &marGlassInset);
 
     LONG_PTR exs = GetWindowLongPtrW(g_hSwitcher, GWL_EXSTYLE);
@@ -2006,20 +2046,29 @@ static void ShowSwitcher(bool sticky) {
         SetWindowLongPtrW(g_hSwitcher, GWL_EXSTYLE, exs & ~WS_EX_LAYERED);
         BOOL dark = g_isDarkMode;
         DwmSetWindowAttribute(g_hSwitcher, 20, &dark, sizeof(dark));
+        if (ThemeIs(L"mica")) {
+            int micaVal = 2; // DWMSBT_MAINWINDOW
+            HRESULT hr = DwmSetWindowAttribute(g_hSwitcher, 38, &micaVal, sizeof(micaVal));
+            if (FAILED(hr) && ThemeIs(L"mica")) {
+                // Try old undocumented DWMWA_MICA_EFFECT (1029)
+                int oldMicaVal = 1;
+                hr = DwmSetWindowAttribute(g_hSwitcher, 1029, &oldMicaVal, sizeof(oldMicaVal));
+            }
+            if (FAILED(hr)) {
+                // Fallback to none
+                SetWindowLongPtrW(g_hSwitcher, GWL_EXSTYLE, GetWindowLongPtrW(g_hSwitcher, GWL_EXSTYLE) | WS_EX_LAYERED);
+            }
+        }
         if (ThemeIs(L"backdrop") && g_SetWindowCompositionAttribute) {
-            // EP: blur = (dwOpacity / 100.0) * 255
             DWORD blur = (DWORD)((g_settings.opacity / 100.0) * 255);
             COLORREF bg = g_isDarkMode ? SWS_BG_DARK : SWS_BG_LIGHT;
-            // EP: nColor = (Opacity << 24) | (Color & 0xFFFFFF)
-            // COLORREF is 0x00BBGGRR, so this works directly
             ACCENT_POLICY accent = {};
-            accent.AccentState = 4; // ACCENT_ENABLE_ACRYLICBLURBEHIND
+            accent.AccentState = 4 /* ACCENT_ENABLE_ACRYLICBLURBEHIND */;
             accent.AccentFlags = 0;
             accent.GradientColor = (blur << 24) | (bg & 0x00FFFFFF);
             WINDOWCOMPOSITIONATTRIBDATA data = {19, &accent, sizeof(accent)};
             g_SetWindowCompositionAttribute(g_hSwitcher, &data);
         }
-        // EP: Set black background brush for DWM compositing (line 566)
         SetClassLongPtrW(g_hSwitcher, GCLP_HBRBACKGROUND, (LONG_PTR)GetStockObject(BLACK_BRUSH));
     }
 
@@ -2052,6 +2101,9 @@ static void ShowSwitcher(bool sticky) {
 
     g_isPendingShow = false;
     g_isVisible = true;
+    if (!g_hMouseHook) {
+        g_hMouseHook = SetWindowsHookEx(WH_MOUSE_LL, LowLevelMouseProc, GetModuleHandle(NULL), 0);
+    }
 
     SetWindowPos(g_hSwitcher, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
     ShowWindow(g_hSwitcher, SW_SHOWNA);
@@ -2066,6 +2118,7 @@ static void ShowSwitcher(bool sticky) {
 }
 
 static void HideSwitcher() {
+    g_showAllMonitors = false;
     CancelPendingShow();
 
     UnregisterThumbnails();
@@ -2078,6 +2131,10 @@ static void HideSwitcher() {
 
     g_isVisible = false;
     g_isPendingShow = false;
+    if (g_hMouseHook) {
+        UnhookWindowsHookEx(g_hMouseHook);
+        g_hMouseHook = NULL;
+    }
     g_isSticky = false;
 }
 
@@ -2333,6 +2390,10 @@ static int HitTestThumb(int x, int y) {
 static void SWS_RegisterHotkeys();
 
 static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
+    if (uMsg == WM_NCCALCSIZE && wParam == TRUE) {
+        return 0; // Remove standard frame for WS_OVERLAPPED
+    }
+
     if (uMsg == WM_TIMER) {
         if (wParam == SWS_HOTKEY_RETRY_TIMER_ID) {
             SWS_RegisterHotkeys();
@@ -2373,6 +2434,9 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
         }
 
         if (!g_isVisible && !g_isPendingShow) {
+            if (GetAsyncKeyState(VK_LWIN) < 0 || GetAsyncKeyState(VK_RWIN) < 0) {
+                g_showAllMonitors = true;
+            }
             ShowSwitcher(isCtrl);
 
             if (isBackward && g_windows.size() > 1) {
@@ -2494,9 +2558,17 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
     case WM_MOUSEWHEEL:
         if (g_isVisible) {
             bool ok = ScrollIs(L"always") || (ScrollIs(L"stickyOnly") && g_isSticky);
-            if (ok) { CycleLinear(GET_WHEEL_DELTA_WPARAM(wParam) > 0 ? -1 : 1); return 0; }
+            if (ok) {
+                int dir = GET_WHEEL_DELTA_WPARAM(wParam) > 0 ? -1 : 1;
+                if (g_settings.reverseScrollDirection) dir = -dir;
+                CycleLinear(dir); 
+                return 0; 
+            }
         }
         break;
+    case WM_SETCURSOR:
+        SetCursor(LoadCursor(NULL, IDC_ARROW));
+        return TRUE;
     case WM_MOUSEMOVE: {
         int x = GET_X_LPARAM(lParam), y = GET_Y_LPARAM(lParam);
         int idx = g_settings.showThumbnails ? HitTestThumb(x, y) : HitTest(x, y);
@@ -2720,6 +2792,14 @@ static void LoadSettings() {
         wcscpy_s(g_settings.highlightStyle, L"border");
     }
 
+    v = Wh_GetStringSetting(L"Miscellaneous.virtualDesktopBehavior");
+    wcscpy_s(g_settings.virtualDesktopBehavior, v ? v : L"currentOnly");
+    Wh_FreeStringSetting(v);
+    if (wcscmp(g_settings.virtualDesktopBehavior, L"currentOnly") != 0 &&
+        wcscmp(g_settings.virtualDesktopBehavior, L"allDesktops") != 0) {
+        wcscpy_s(g_settings.virtualDesktopBehavior, L"currentOnly");
+    }
+
     g_settings.opacity = Wh_GetIntSetting(L"Style.opacity");
     if (g_settings.opacity < 0) g_settings.opacity = 0;
     if (g_settings.opacity > 100) g_settings.opacity = 100;
@@ -2744,6 +2824,7 @@ static void LoadSettings() {
     g_settings.useAccentColor = Wh_GetIntSetting(L"Style.useAccentColor");
     g_settings.primaryMonitorOnly = Wh_GetIntSetting(L"Miscellaneous.primaryMonitorOnly");
     g_settings.perMonitorWindows = Wh_GetIntSetting(L"Miscellaneous.perMonitorWindows");
+    g_settings.reverseScrollDirection = Wh_GetIntSetting(L"Miscellaneous.reverseScrollDirection");
     g_settings.centerTaskContent = Wh_GetIntSetting(L"Appearance.HeaderContent.centerTaskContent");
 
 
@@ -2804,9 +2885,12 @@ static DWORD WINAPI SwitcherThread(LPVOID lpParam) {
     wc.style = CS_DBLCLKS;
     RegisterClassExW(&wc);
 
+    // Use WS_OVERLAPPED instead of WS_POPUP. Windows 11 DWM (Mica/Acrylic) has
+    // much better support for standard top-level windows. We remove the frame via WM_NCCALCSIZE.
+    DWORD dwStyle = WS_OVERLAPPED | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
     DWORD exStyle = WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_LAYERED;
     g_hSwitcher = CreateWindowExW(exStyle, SWS_CLASSNAME, L"",
-        WS_POPUP, 0, 0, 0, 0, NULL, NULL, GetModuleHandleW(NULL), NULL);
+        dwStyle, 0, 0, 0, 0, NULL, NULL, GetModuleHandleW(NULL), NULL);
     if (!g_hSwitcher) { Wh_Log(L"Failed to create switcher window"); return 1; }
 
     g_hCloseBtnWnd = CreateWindowExW(
@@ -3030,6 +3114,9 @@ BOOL Wh_ModInit() {
             ExitProcess(1);
         }
 
+        CoInitialize(NULL);
+        CoCreateInstance(CLSID_VirtualDesktopManager, nullptr, CLSCTX_INPROC_SERVER, IID_IVirtualDesktopManager, (void**)&g_pVirtualDesktopManager);
+
         IMAGE_DOS_HEADER* dosHeader =
             (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
         IMAGE_NT_HEADERS* ntHeaders =
@@ -3160,6 +3247,10 @@ void Wh_ModUninit() {
         return;
     }
 
+    if (g_pVirtualDesktopManager) {
+        g_pVirtualDesktopManager->Release();
+        g_pVirtualDesktopManager = NULL;
+    }
     WhTool_ModUninit();
     ExitProcess(0);
 }

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -35,33 +35,21 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 
 ## Screenshots
 
-*Horizontal squared (default)*
+| Horizontal squared (default) | Horizontal squared without thumbnails |
+| :---: | :---: |
+| ![Horizontal default](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/4.png) | ![Horizontal without thumbnails](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/3.png) |
 
-![Horizontal default](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/4.png)
+| Vertical small rounded | Vertical large rounded |
+| :---: | :---: |
+| ![Vertical small](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/58449dc268347949193f2c67b0b042d287c20bd5/img/simple-window-switcher/1.png) | ![Vertical large](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/2.png) |
 
-*Horizontal squared without thumbnails*
+| Horizontal rounded with centered task icons and titles | Horizontal squared with thumbnails on top |
+| :---: | :---: |
+| ![Horizontal centered](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/6.png) | ![Horizontal squared with thumbnails on top](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/7.png) |
 
-![Horizontal without thumbnails](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/3.png)
-
-*Vertical small rounded*
-
-![Vertical small](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/58449dc268347949193f2c67b0b042d287c20bd5/img/simple-window-switcher/1.png)
-
-*Vertical large rounded*
-
-![Vertical large](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/2.png)
-
-*Horizontal rounded with centered task icons and titles*
-
-![Horizontal centered](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/6.png)
-
-*Horizontal squared with thumbnails on top*
-
-![Horizontal squared with thumbnails on top](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/7.png)
-
-*Horizontal rounded with thumbnails and no icons*
-
-![Horizontal rounded with thumbnails and no icons](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/8.png)
+| Horizontal rounded with thumbnails and no icons |
+| :---: |
+| ![Horizontal rounded with thumbnails and no icons](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/8.png) |
 
 */
 // ==/WindhawkModReadme==

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -2756,6 +2756,15 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg, HWND hWnd) {
         int headerTop = GetHeaderTopForEntry(e);
         int iconX = contentLeft;
         int iconY = headerTop + (rowTitleH - iconSz) / 2;
+
+        if (!HeaderIsVertical() && g_settings.showTitle && g_settings.showIcon) {
+            // Font rendering and icon boundaries scale slightly differently at higher DPIs.
+            // At 100% (96 DPI), mathematical centering is visually perfect (shift = 0).
+            // At >100% (e.g. 144 DPI), a small nudge downwards perfectly aligns their visual centers.
+            int shift = (g_dpiY - 96) / 24;
+            if (shift > 0) iconY += shift;
+        }
+
         int textLeft = contentLeft;
         if (g_settings.showIcon) textLeft += iconSz + padLeft;
         int textRight = contentRight;

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -928,7 +928,9 @@ static void RegisterThumbnailsEarly() {
                 // the window extends beyond screen edges to hide the frame.
                 // Skip for minimized windows: GetWindowRect/DWMWA_EXTENDED_FRAME_BOUNDS
                 // return garbage coords (-32000) for iconic windows, causing zoom.
-                if (!IsIconic(w.hWnd)) {
+                // ONLY apply manual crop for maximized windows (IsZoomed). Non-maximized 
+                // windows are natively handled by DWM (preserves rounded corners perfectly).
+                if (!IsIconic(w.hWnd) && IsZoomed(w.hWnd)) {
                     RECT wr = {0}, efb = {0};
                     GetWindowRect(w.hWnd, &wr);
                     if (SUCCEEDED(DwmGetWindowAttribute(w.hWnd, DWMWA_EXTENDED_FRAME_BOUNDS, &efb, sizeof(efb)))) {

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -57,7 +57,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 
 *Horizontal squared with thumbnails on top*
 
-![Horizontal squared with thumbnails on top](https://github.com/Asteski/Windhawk-Mods/blob/cc72179d1ff603f3d3cf94fd41230ebea774bc8b/img/simple-window-switcher/7.png)
+![Horizontal squared with thumbnails on top](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/7.png)
 
 *Horizontal rounded with thumbnails and no icons*
 

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -60,10 +60,10 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 /*
 - Style:
     - theme: none
-      $name: Theme
-      $description: Visual theme for the switcher background.
+      $name: Style
+      $description: Visual theme style for the switcher background.
       $options:
-      - none: None (transparent)
+      - none: None (Transparent)
       - backdrop: Acrylic (Windows 10+)
       - mica: Mica Blur (Windows 11 only)
     - opacity: 100
@@ -83,15 +83,15 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       - fillAndBorder: Background fill and border
       - fillOnly: Background fill only
     - borderColorDark: "#FFFFFF"
-      $name: Border Color (Dark Mode)
+      $name: Dark Mode Border Color
       $description: Border color in HEX format for dark mode.
     - borderColorLight: "#000000"
-      $name: Border Color (Light Mode)
+      $name: Light Mode Border Color
       $description: Border color in HEX format for light mode.
     - useAccentColor: false
-      $name: Accent Color for Borders and Background Fill
-      $description: Use Windows accent color for selection and hover borders.
-  $name: Theme Style
+      $name: Use Accent Color for Borders and Background Fill
+      $description: Use Windows accent color for selection and hover borders. 
+  $name: Theme
 - Appearance:
     - Corners:
         - cornerPreference: none
@@ -108,7 +108,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
     - Thumbnails:
         - thumbnailPosition: bottom
           $name: Thumbnail Position
-          $description: Place the thumbnail below or above the header row.
+          $description: Change the thumbnail position.
           $options:
           - bottom: Bottom
           - top: Top
@@ -187,7 +187,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       $name: Stretch Thumbnails to Task Width
       $description: When enabled, custom row width also changes thumbnail width. Disable to keep thumbnail aspect sizing while row width controls only task tile width.
   $name: Dimensions
-- Miscellaneous:
+- Accessibility:
     - showDelay: 0
       $name: Show Delay (ms)
       $description: Delay in milliseconds before showing the switcher (0 = instant).
@@ -211,28 +211,29 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       $options:
       - primaryOnly: Primary Monitor Only
       - allMonitors: All Monitors
-      - cursorMonitor: Monitor Based On Cursor Location
+      - cursorMonitor: Monitor Based on Cursor Location
     - perMonitorWindows: false
-      $name: Display Windows Only From the Monitor Containing the Cursor
-    - ExcludedWindows:
-      - - Method: title
-          $name: Exclusion Method
-          $description: Exclude by window title or executable name
-          $options:
-          - title: Window Title
-          - exe: Executable Name
-        - Value: ""
-          $name: Pattern
-          $description: "The pattern to exclude (wildcards supported: * matches any characters, ? matches one). Separate multiple entries with a comma. Example: *chrome*, msedge.exe"
-      $name: Excluded Windows
-      $description: Exclude specific windows from appearing in the switcher.
+      $name: Display Windows Only from the Monitor Containing the Cursor
     - virtualDesktopBehavior: currentOnly
       $name: Virtual Desktop Behavior
       $description: Choose which virtual desktops to show windows from.
       $options:
       - currentOnly: Show windows from current virtual desktop only
       - allDesktops: Show windows from all virtual desktops
-  $name: Miscellaneous
+  $name: Accessibility
+- ExcludedWindows:
+  - - Method: title
+      $name: Exclusion Method
+      $description: Exclude by window title or executable name
+      $options:
+      - title: Window Title
+      - exe: Executable Name
+    - Value: ""
+      $name: Pattern
+      $description: "The pattern to exclude (wildcards supported: * matches any characters, ? matches one). Separate multiple entries with a comma. Example: *chrome*, msedge.exe"
+  $name: Excluded Windows
+  $description: Exclude specific windows from appearing in the switcher.
+
 */
 // ==/WindhawkModSettings==
 

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -68,7 +68,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       - mica: Mica Blur (Windows 11 only)
     - opacity: 100
       $name: Background Opacity
-      $description: Background opacity percentage (0-100), applies to None theme.
+      $description: Background opacity percentage (0-100), applies to None and Acrylic themes. Set value to '80' for Acrylic to see the effect.
     - colorScheme: system
       $name: Color Scheme
       $options:
@@ -154,6 +154,23 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
           - horizontal: Horizontal
           - vertical: Vertical
       $name: Orientation
+    - Font:
+        - fontFamily: Segoe UI
+          $name: Font Family
+          $description: Font used for window titles (e.g., Segoe UI, Tahoma).
+        - fontSize: 9
+          $name: Font Size
+          $description: Size of the font in points.
+        - fontStyle: regular
+          $name: Font Style
+          $options:
+          - light: Light
+          - regular: Regular
+          - semibold: Semi-Bold
+          - bold: Bold
+          - italic: Italic
+          - boldItalic: Bold Italic
+      $name: Font
   $name: Appearance
 - Dimensions:
     - rowHeight: 230
@@ -187,12 +204,33 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       - altShiftTab: Alt+Shift+Tab (default)
       - altShift: Alt+Shift
       - altBacktick: Alt+Backtick
+<<<<<<< HEAD
     - reverseScrollDirection: false
       $name: Reverse Scroll Direction
     - primaryMonitorOnly: false
       $name: Always Display Switcher on Primary Monitor
+=======
+    - switcherDisplayBehavior: cursorMonitor
+      $name: Switcher Display Behavior
+      $options:
+      - primaryOnly: Show Switcher in Primary Monitor only
+      - allMonitors: All Monitors
+      - cursorMonitor: Monitor Based On Cursor Location
+>>>>>>> 0fc3be76 (Refactor Simple Window Switcher UI, apply upstream layout fixes, add multi-monitor mirror support, and implement structured array schemas for excluded windows)
     - perMonitorWindows: false
       $name: Display Windows Only From the Monitor Containing the Cursor
+    - ExcludedWindows:
+      - - Method: title
+          $name: Exclusion Method
+          $description: Exclude by window title or executable name
+          $options:
+          - title: Window Title
+          - exe: Executable Name
+        - Value: ""
+          $name: Pattern
+          $description: "The pattern to exclude (regex supported). Separate multiple entries with a comma. Example: chrome\\.exe, msedge\\.exe"
+      $name: Excluded Windows
+      $description: Exclude specific windows from appearing in the switcher.
     - virtualDesktopBehavior: currentOnly
       $name: Virtual Desktop Behavior
       $description: Choose which virtual desktops to show windows from.
@@ -223,6 +261,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 #include <string>
 #include <algorithm>
 #include <gdiplus.h>
+#include <regex>
 
 #define SWS_CLASSNAME       L"WindhawkSWS_Switcher"
 #define SWS_ICON_SIZE       16
@@ -257,6 +296,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 #define SWS_TEXT_DARK         RGB(255, 255, 255)
 #define SWS_TEXT_LIGHT        RGB(0, 0, 0)
 #define SWS_SHOW_DELAY_TIMER_ID 101
+#define SWS_ALT_POLL_TIMER_ID   102
 
 typedef BOOL (WINAPI *IsShellWindow_t)(HWND);
 typedef HWND (WINAPI *GhostWindowFromHungWindow_t)(HWND);
@@ -272,10 +312,16 @@ struct WindowEntry {
     SIZE effectiveSourceSize;  // Source size after cropping invisible frame
 };
 struct Settings {
+<<<<<<< HEAD
     WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32]; WCHAR thumbnailPosition[32]; WCHAR thumbnailAlignment[32];
+=======
+    WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32]; WCHAR thumbnailPosition[32]; WCHAR thumbnailAlignment[32]; WCHAR switcherDisplayBehavior[32];
+>>>>>>> 0fc3be76 (Refactor Simple Window Switcher UI, apply upstream layout fixes, add multi-monitor mirror support, and implement structured array schemas for excluded windows)
     WCHAR highlightStyle[32]; WCHAR virtualDesktopBehavior[32];
     WCHAR borderColorDark[16];
     WCHAR borderColorLight[16];
+    WCHAR fontFamily[64]; WCHAR fontStyle[32];
+    int fontSize;
     int opacity;
     int rowHeight;
     int rowWidth;
@@ -285,9 +331,13 @@ struct Settings {
     bool showIcon;
     int maxWidthPercent;
     int maxHeightPercent; int showDelay;
-    bool useAccentColor; bool primaryMonitorOnly; bool perMonitorWindows; bool taskRoundedCorners; bool reverseScrollDirection;
+    bool useAccentColor; bool perMonitorWindows; bool taskRoundedCorners; bool reverseScrollDirection;
     bool centerTaskContent;
 };
+
+static std::vector<std::wregex> g_excludeTitleRegexes;
+static std::vector<std::wregex> g_excludeExeRegexes;
+static std::vector<HWND> g_hMirrorSwitchers;
 
 static HWND g_hSwitcher = NULL;
 static HWND g_hCloseBtnWnd = NULL;
@@ -341,7 +391,11 @@ static bool ThumbnailIsTop() { return ThumbnailPositionIs(L"top"); }
 static bool ThumbnailIsLeft() { return ThumbnailPositionIs(L"left"); }
 static bool ThumbnailIsRight() { return ThumbnailPositionIs(L"right"); }
 static bool ThumbnailIsSide() { return ThumbnailIsLeft() || ThumbnailIsRight(); }
+<<<<<<< HEAD
 static bool ThumbnailAlignLeft() { return ThumbnailAlignmentIs(L"left"); }
+=======
+static bool ThumbnailAlignmentIs(const WCHAR* v) { return wcscmp(g_settings.thumbnailAlignment, v) == 0; }
+>>>>>>> 0fc3be76 (Refactor Simple Window Switcher UI, apply upstream layout fixes, add multi-monitor mirror support, and implement structured array schemas for excluded windows)
 static bool ThumbnailAlignCentered() { return ThumbnailAlignmentIs(L"centered"); }
 static bool ThumbnailAlignRight() { return ThumbnailAlignmentIs(L"right"); }
 static bool HighlightHasFill() {
@@ -576,6 +630,31 @@ static BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) {
     e.hWnd = hWnd;
     InternalGetWindowText(hWnd, e.title, 256);
     if (!e.title[0]) GetWindowTextW(hWnd, e.title, 256);
+    
+    bool excluded = false;
+    for (const auto& rx : g_excludeTitleRegexes) {
+        if (std::regex_search(e.title, rx)) { excluded = true; break; }
+    }
+    if (!excluded && !g_excludeExeRegexes.empty()) {
+        DWORD pid = 0;
+        GetWindowThreadProcessId(hWnd, &pid);
+        if (pid) {
+            HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+            if (hProc) {
+                WCHAR exePath[MAX_PATH] = {0};
+                DWORD size = MAX_PATH;
+                if (QueryFullProcessImageNameW(hProc, 0, exePath, &size)) {
+                    WCHAR* filename = PathFindFileNameW(exePath);
+                    for (const auto& rx : g_excludeExeRegexes) {
+                        if (std::regex_search(filename, rx)) { excluded = true; break; }
+                    }
+                }
+                CloseHandle(hProc);
+            }
+        }
+    }
+    if (excluded) return TRUE;
+
     e.hIcon = NULL;
     
     bool isUwp = false;
@@ -922,7 +1001,21 @@ static HFONT CreateScaledFont(int dpiY) {
         SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncm), &ncm, 0);
     }
     LOGFONTW lf = ncm.lfMessageFont;
-    lf.lfWeight = FW_NORMAL;
+    if (g_settings.fontFamily[0] != L'\0') {
+        wcsncpy_s(lf.lfFaceName, g_settings.fontFamily, _TRUNCATE);
+    }
+    lf.lfHeight = -MulDiv(g_settings.fontSize, dpiY, 72);
+    if (wcscmp(g_settings.fontStyle, L"light") == 0) {
+        lf.lfWeight = FW_LIGHT;
+    } else if (wcscmp(g_settings.fontStyle, L"semibold") == 0) {
+        lf.lfWeight = FW_SEMIBOLD;
+    } else if (wcscmp(g_settings.fontStyle, L"bold") == 0 || wcscmp(g_settings.fontStyle, L"boldItalic") == 0) {
+        lf.lfWeight = FW_BOLD;
+    } else {
+        lf.lfWeight = FW_NORMAL;
+    }
+    lf.lfItalic = (wcscmp(g_settings.fontStyle, L"italic") == 0 || wcscmp(g_settings.fontStyle, L"boldItalic") == 0) ? TRUE : FALSE;
+    lf.lfQuality = CLEARTYPE_QUALITY;
     return CreateFontIndirectW(&lf);
 }
 
@@ -1990,6 +2083,13 @@ static void PaintSwitcher() {
         POINT ptSrc = {0,0}; SIZE sz = {w, h};
         BLENDFUNCTION bf = {AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
         UpdateLayeredWindow(g_hSwitcher, hdcScreen, NULL, &sz, hdcMem, &ptSrc, 0, &bf, ULW_ALPHA);
+        for (HWND hMirror : g_hMirrorSwitchers) {
+            if (IsWindow(hMirror)) {
+                HDC hdcMirrorScreen = GetDC(hMirror);
+                UpdateLayeredWindow(hMirror, hdcMirrorScreen, NULL, &sz, hdcMem, &ptSrc, 0, &bf, ULW_ALPHA);
+                ReleaseDC(hMirror, hdcMirrorScreen);
+            }
+        }
         SelectObject(hdcMem, hOld); DeleteObject(hBmp); DeleteDC(hdcMem);
         ReleaseDC(g_hSwitcher, hdcScreen);
         PaintSwitcherOverlay();
@@ -1997,20 +2097,17 @@ static void PaintSwitcher() {
         // Acrylic: trigger WM_PAINT via InvalidateRect
         InvalidateRect(g_hSwitcher, NULL, TRUE);
         UpdateWindow(g_hSwitcher);
+        for (HWND hMirror : g_hMirrorSwitchers) {
+            if (IsWindow(hMirror)) {
+                InvalidateRect(hMirror, NULL, TRUE);
+                UpdateWindow(hMirror);
+            }
+        }
         PaintSwitcherOverlay();
     }
 }
 
 // Switcher Show / Hide / Switch
-
-static void ResetDwmAttributes() {
-    // Reset acrylic
-    if (g_SetWindowCompositionAttribute) {
-        ACCENT_POLICY a = {}; a.AccentState = 0;
-        WINDOWCOMPOSITIONATTRIBDATA d = {19, &a, sizeof(a)};
-        g_SetWindowCompositionAttribute(g_hSwitcher, &d);
-    }
-}
 
 static void GetOffscreenDelayPosition(int* x, int* y) {
     // Put the 1x1 window just outside the virtual screen bounds.
@@ -2083,13 +2180,77 @@ static void RevealPendingSwitcher() {
 
     RegisterThumbnails();
     PaintSwitcher();
+
+    if (!g_isSticky) {
+        SetTimer(g_hSwitcher, SWS_ALT_POLL_TIMER_ID, 50, NULL);
+    }
+}
+
+static void ApplyThemeToWindow(HWND hWnd) {
+    if (g_SetWindowCompositionAttribute) {
+        ACCENT_POLICY a = {}; a.AccentState = 0;
+        WINDOWCOMPOSITIONATTRIBDATA d = {19, &a, sizeof(a)};
+        g_SetWindowCompositionAttribute(hWnd, &d);
+    }
+    MARGINS marGlassInset = ThemeIs(L"mica") ? MARGINS{-1, -1, -1, -1} : MARGINS{0, 0, 0, 0};
+    DwmExtendFrameIntoClientArea(hWnd, &marGlassInset);
+
+    LONG_PTR exs = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
+    if (ThemeIs(L"none")) {
+        SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exs | WS_EX_LAYERED);
+    } else {
+        SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exs & ~WS_EX_LAYERED);
+        BOOL dark = g_isDarkMode;
+        DwmSetWindowAttribute(hWnd, 20, &dark, sizeof(dark));
+        if (ThemeIs(L"mica")) {
+            int micaVal = 2; // DWMSBT_MAINWINDOW
+            HRESULT hr = DwmSetWindowAttribute(hWnd, 38, &micaVal, sizeof(micaVal));
+            if (FAILED(hr) && ThemeIs(L"mica")) {
+                int oldMicaVal = 1;
+                hr = DwmSetWindowAttribute(hWnd, 1029, &oldMicaVal, sizeof(oldMicaVal));
+            }
+            if (FAILED(hr)) {
+                SetWindowLongPtrW(hWnd, GWL_EXSTYLE, GetWindowLongPtrW(hWnd, GWL_EXSTYLE) | WS_EX_LAYERED);
+            }
+        }
+        if (ThemeIs(L"backdrop") && g_SetWindowCompositionAttribute) {
+            DWORD blur = (DWORD)((g_settings.opacity / 100.0) * 255);
+            COLORREF bg = g_isDarkMode ? SWS_BG_DARK : SWS_BG_LIGHT;
+            ACCENT_POLICY accent = {};
+            accent.AccentState = 4 /* ACCENT_ENABLE_ACRYLICBLURBEHIND */;
+            accent.AccentFlags = 0;
+            accent.GradientColor = (blur << 24) | (bg & 0x00FFFFFF);
+            WINDOWCOMPOSITIONATTRIBDATA data = {19, &accent, sizeof(accent)};
+            g_SetWindowCompositionAttribute(hWnd, &data);
+        }
+        SetClassLongPtrW(hWnd, GCLP_HBRBACKGROUND, (LONG_PTR)GetStockObject(BLACK_BRUSH));
+    }
+    INT cp = GetCornerPref();
+    DwmSetWindowAttribute(hWnd, 33, &cp, sizeof(cp));
+}
+
+static BOOL WINAPI MirrorEnumProc(HMONITOR hM, HDC, LPRECT, LPARAM) {
+    if (hM != g_hCurrentMonitor) {
+        MONITORINFO mInfo = { sizeof(mInfo) };
+        GetMonitorInfoW(hM, &mInfo);
+        int mx = (mInfo.rcWork.left + mInfo.rcWork.right - g_winW) / 2;
+        int my = (mInfo.rcWork.top + mInfo.rcWork.bottom - g_winH) / 2;
+        HWND hMirror = CreateWindowExW(WS_EX_TOOLWINDOW | WS_EX_TOPMOST, SWS_CLASSNAME, L"", WS_POPUP, mx, my, g_winW, g_winH, NULL, NULL, GetModuleHandle(NULL), NULL);
+        if (hMirror) {
+            ApplyThemeToWindow(hMirror);
+            g_hMirrorSwitchers.push_back(hMirror);
+            SetWindowPos(hMirror, HWND_TOPMOST, mx, my, g_winW, g_winH, SWP_NOACTIVATE);
+            ShowWindow(hMirror, SW_SHOWNA);
+        }
+    }
+    return TRUE;
 }
 
 static void ShowSwitcher(bool sticky) {
     POINT pt; GetCursorPos(&pt);
-    HMONITOR hMon = g_settings.primaryMonitorOnly ?
-        MonitorFromPoint({0,0}, MONITOR_DEFAULTTOPRIMARY) :
-        MonitorFromPoint(pt, MONITOR_DEFAULTTOPRIMARY);
+    HMONITOR hMon = (wcscmp(g_settings.switcherDisplayBehavior, L"primaryOnly") == 0) ?
+                    MonitorFromWindow(GetDesktopWindow(), MONITOR_DEFAULTTOPRIMARY) :
+                    MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
 
     g_hCurrentMonitor = hMon;
     UnregisterThumbnails(); BuildWindowList();
@@ -2114,49 +2275,7 @@ static void ShowSwitcher(bool sticky) {
     int cx = (mi.rcWork.left + mi.rcWork.right - g_winW) / 2;
     int cy = (mi.rcWork.top + mi.rcWork.bottom - g_winH) / 2;
 
-    // Always reset DWM attributes first to avoid leftovers
-    ResetDwmAttributes();
-
-    // Apply theme (EP: sws_WindowSwitcher.c lines 510-570)
-    // Step 1: Reset DWM frame and blur state (EP lines 510-524)
-    MARGINS marGlassInset = ThemeIs(L"mica") ? MARGINS{-1, -1, -1, -1} : MARGINS{0, 0, 0, 0};
-    DwmExtendFrameIntoClientArea(g_hSwitcher, &marGlassInset);
-
-    LONG_PTR exs = GetWindowLongPtrW(g_hSwitcher, GWL_EXSTYLE);
-    if (ThemeIs(L"none")) {
-        SetWindowLongPtrW(g_hSwitcher, GWL_EXSTYLE, exs | WS_EX_LAYERED);
-    } else {
-        SetWindowLongPtrW(g_hSwitcher, GWL_EXSTYLE, exs & ~WS_EX_LAYERED);
-        BOOL dark = g_isDarkMode;
-        DwmSetWindowAttribute(g_hSwitcher, 20, &dark, sizeof(dark));
-        if (ThemeIs(L"mica")) {
-            int micaVal = 2; // DWMSBT_MAINWINDOW
-            HRESULT hr = DwmSetWindowAttribute(g_hSwitcher, 38, &micaVal, sizeof(micaVal));
-            if (FAILED(hr) && ThemeIs(L"mica")) {
-                // Try old undocumented DWMWA_MICA_EFFECT (1029)
-                int oldMicaVal = 1;
-                hr = DwmSetWindowAttribute(g_hSwitcher, 1029, &oldMicaVal, sizeof(oldMicaVal));
-            }
-            if (FAILED(hr)) {
-                // Fallback to none
-                SetWindowLongPtrW(g_hSwitcher, GWL_EXSTYLE, GetWindowLongPtrW(g_hSwitcher, GWL_EXSTYLE) | WS_EX_LAYERED);
-            }
-        }
-        if (ThemeIs(L"backdrop") && g_SetWindowCompositionAttribute) {
-            DWORD blur = (DWORD)((g_settings.opacity / 100.0) * 255);
-            COLORREF bg = g_isDarkMode ? SWS_BG_DARK : SWS_BG_LIGHT;
-            ACCENT_POLICY accent = {};
-            accent.AccentState = 4 /* ACCENT_ENABLE_ACRYLICBLURBEHIND */;
-            accent.AccentFlags = 0;
-            accent.GradientColor = (blur << 24) | (bg & 0x00FFFFFF);
-            WINDOWCOMPOSITIONATTRIBDATA data = {19, &accent, sizeof(accent)};
-            g_SetWindowCompositionAttribute(g_hSwitcher, &data);
-        }
-        SetClassLongPtrW(g_hSwitcher, GCLP_HBRBACKGROUND, (LONG_PTR)GetStockObject(BLACK_BRUSH));
-    }
-
-    INT cp = GetCornerPref();
-    DwmSetWindowAttribute(g_hSwitcher, 33, &cp, sizeof(cp));
+    ApplyThemeToWindow(g_hSwitcher);
 
     g_pendingSwitcherRect = {
         cx,
@@ -2191,13 +2310,27 @@ static void ShowSwitcher(bool sticky) {
         ShowWindow(g_hCloseBtnWnd, SW_SHOWNA);
     }
 
+    if (wcscmp(g_settings.switcherDisplayBehavior, L"allMonitors") == 0 || g_showAllMonitors) {
+        EnumDisplayMonitors(NULL, NULL, MirrorEnumProc, 0);
+    }
+
     RegisterThumbnails();
     PaintSwitcher();
+
+    if (!sticky) {
+        SetTimer(g_hSwitcher, SWS_ALT_POLL_TIMER_ID, 50, NULL);
+    }
 }
 
 static void HideSwitcher() {
     g_showAllMonitors = false;
     CancelPendingShow();
+    if (g_hSwitcher) KillTimer(g_hSwitcher, SWS_ALT_POLL_TIMER_ID);
+
+    for (HWND hMirror : g_hMirrorSwitchers) {
+        if (IsWindow(hMirror)) DestroyWindow(hMirror);
+    }
+    g_hMirrorSwitchers.clear();
 
     UnregisterThumbnails();
     if (g_hSwitcher) {
@@ -2480,6 +2613,14 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
 
         if (wParam == SWS_SHOW_DELAY_TIMER_ID) {
             RevealPendingSwitcher();
+            return 0;
+        }
+
+        if (wParam == SWS_ALT_POLL_TIMER_ID) {
+            if (!g_isSticky && (GetAsyncKeyState(VK_MENU) & 0x8000) == 0) {
+                KillTimer(hWnd, SWS_ALT_POLL_TIMER_ID);
+                SwitchToSelected();
+            }
             return 0;
         }
     }
@@ -2918,7 +3059,6 @@ static void LoadSettings() {
     g_settings.showDelay = Wh_GetIntSetting(L"Miscellaneous.showDelay");
     if (g_settings.showDelay < 0) g_settings.showDelay = 0;
     g_settings.useAccentColor = Wh_GetIntSetting(L"Style.useAccentColor");
-    g_settings.primaryMonitorOnly = Wh_GetIntSetting(L"Miscellaneous.primaryMonitorOnly");
     g_settings.perMonitorWindows = Wh_GetIntSetting(L"Miscellaneous.perMonitorWindows");
     g_settings.reverseScrollDirection = Wh_GetIntSetting(L"Miscellaneous.reverseScrollDirection");
     g_settings.centerTaskContent = Wh_GetIntSetting(L"Appearance.HeaderContent.centerTaskContent");
@@ -2936,6 +3076,57 @@ static void LoadSettings() {
         wcscpy_s(g_settings.borderColorLight, L"#000000");
     }
 
+    v = Wh_GetStringSetting(L"Appearance.Font.fontFamily");
+    wcscpy_s(g_settings.fontFamily, v ? v : L"Segoe UI"); Wh_FreeStringSetting(v);
+    
+    g_settings.fontSize = Wh_GetIntSetting(L"Appearance.Font.fontSize");
+    if (g_settings.fontSize <= 0) g_settings.fontSize = 9;
+
+    v = Wh_GetStringSetting(L"Appearance.Font.fontStyle");
+    wcscpy_s(g_settings.fontStyle, v ? v : L"regular"); Wh_FreeStringSetting(v);
+
+    v = Wh_GetStringSetting(L"Miscellaneous.switcherDisplayBehavior");
+    wcscpy_s(g_settings.switcherDisplayBehavior, v ? v : L"cursorMonitor"); Wh_FreeStringSetting(v);
+
+    g_excludeTitleRegexes.clear();
+    g_excludeExeRegexes.clear();
+    for (int i = 0; ; i++) {
+        PCWSTR method = Wh_GetStringSetting(L"Miscellaneous.ExcludedWindows[%d].Method", i);
+        bool done = !method || !*method;
+        
+        if (done) {
+            if (method) Wh_FreeStringSetting(method);
+            break;
+        }
+        
+        PCWSTR value = Wh_GetStringSetting(L"Miscellaneous.ExcludedWindows[%d].Value", i);
+        if (value && *value) {
+            std::wstring valStr(value);
+            size_t start = 0;
+            while (start < valStr.length()) {
+                size_t end = valStr.find(L',', start);
+                if (end == std::wstring::npos) end = valStr.length();
+                
+                std::wstring token = valStr.substr(start, end - start);
+                size_t first = token.find_first_not_of(L" \t");
+                if (first != std::wstring::npos) {
+                    token = token.substr(first);
+                    size_t last = token.find_last_not_of(L" \t");
+                    token = token.substr(0, last + 1);
+                    
+                    if (wcscmp(method, L"title") == 0) {
+                        try { g_excludeTitleRegexes.push_back(std::wregex(token)); } catch (...) {}
+                    } else if (wcscmp(method, L"exe") == 0) {
+                        try { g_excludeExeRegexes.push_back(std::wregex(token)); } catch (...) {}
+                    }
+                }
+                start = end + 1;
+            }
+        }
+        
+        Wh_FreeStringSetting(method);
+        if (value) Wh_FreeStringSetting(value);
+    }
 }
 
 

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -509,12 +509,27 @@ static bool IsReallyVisible(HWND h) { RECT r; GetWindowRect(h, &r); return IsWin
 static bool IsGhosted(HWND h) { return g_GhostWindowFromHungWindow && g_GhostWindowFromHungWindow(h) != NULL; }
 static bool ShouldListInAltTab(HWND hwnd) {
     if (!IsWindow(hwnd)) return false;
+    if (!IsReallyVisible(hwnd)) return false;
+    if (IsGhosted(hwnd)) return false;
+
     DWORD ex = (DWORD)GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+
+    // WS_EX_TOOLWINDOW always excludes from alt-tab, regardless of other flags
+    if (ex & WS_EX_TOOLWINDOW) return false;
+
+    // WS_EX_NOACTIVATE excludes unless WS_EX_APPWINDOW is also set
+    if ((ex & WS_EX_NOACTIVATE) && !(ex & WS_EX_APPWINDOW)) return false;
+
+    // Owner chain: if window has a visible, enabled owner, exclude it
+    // unless WS_EX_APPWINDOW forces inclusion
     HWND own = GetWindow(hwnd, GW_OWNER);
     bool ownVis = IsWindow(own) && IsWindowEnabled(own) && IsReallyVisible(own);
-    bool noAct = (ex & WS_EX_NOACTIVATE) || (ex & WS_EX_TOOLWINDOW);
-    if (ex & WS_EX_APPWINDOW) noAct = false;
-    return IsReallyVisible(hwnd) && !noAct && ((ex & WS_EX_APPWINDOW) || (!ownVis && !IsOwnerToolWindow(hwnd))) && !IsGhosted(hwnd);
+    if (ownVis && !(ex & WS_EX_APPWINDOW)) return false;
+
+    // Check if an ancestor in the owner chain is a tool window
+    if (IsOwnerToolWindow(hwnd)) return false;
+
+    return true;
 }
 static bool IsAltTabWindow(HWND h) {
     if (!IsWindow(h)) return false;

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -299,7 +299,9 @@ static int GetHeaderRowHeightPx() {
     }
 
     if (!HeaderIsVertical()) {
-        return MulDiv(SWS_ROW_TITLE_HEIGHT, g_dpiY, 96);
+        int h = MulDiv(SWS_ROW_TITLE_HEIGHT, g_dpiY, 96);
+        if (g_settings.showIcon && GetHeaderIconSizePx() > h) h = GetHeaderIconSizePx();
+        return h;
     }
 
     int gap = MulDiv(4, g_dpiY, 96);
@@ -991,7 +993,11 @@ static void ComputeLayout(HMONITOR hMon) {
                     if (w.effectiveSourceSize.cx > 0 && width > w.effectiveSourceSize.cx) width = w.effectiveSourceSize.cx;
                 }
             } else {
-                width = DpiScale(160, dpiX);
+                if (!g_settings.showTitle && g_settings.showIcon) {
+                    width = GetHeaderIconSizePx() + DpiScale(16, dpiX); // Base padding
+                } else {
+                    width = DpiScale(160, dpiX);
+                }
             }
 
             if (g_settings.rowWidth > 0) {
@@ -1399,13 +1405,14 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
         }
 
         int closeBtnReserve = DpiScale(24, g_dpiX) + padLeft;
-        // Keep centered header content stable: reserve close-button space consistently.
-        // In vertical mode, never reserve space - close button overlays without displacement.
         int btnReserve = 0;
         if (!HeaderIsVertical()) {
-            btnReserve = ((g_settings.centerTaskContent) || i == g_hoverIndex)
-                     ? closeBtnReserve
-                     : 0;
+            bool isIconOnly = !g_settings.showThumbnails && !g_settings.showTitle && g_settings.showIcon;
+            if (!isIconOnly) {
+                btnReserve = ((g_settings.centerTaskContent) || i == g_hoverIndex)
+                         ? closeBtnReserve
+                         : 0;
+            }
         }
         int contentLeft = e.rcCell.left + padLeft;
         int contentRight = e.rcCell.right - padLeft - btnReserve;
@@ -1423,7 +1430,7 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg) {
             int availableW = contentRight - contentLeft;
             if (availableW < 0) availableW = 0;
 
-            iconX = contentLeft + fmax(0, (availableW - iconSz) / 2);
+            iconX = contentLeft + ((availableW > iconSz) ? (availableW - iconSz) / 2 : 0);
             iconY = e.rcCell.top + padTop;
 
             int headerGap = DpiScale(4, g_dpiY);
@@ -1507,6 +1514,29 @@ static void DrawSwitcherOverlay(HDC hdc) {
                 int btnPadding = DpiScale(4, g_dpiX);
                 bx = e.rcThumbActual.right - btnSz - btnPadding;
                 by = e.rcThumbActual.top + btnPadding;
+            } else if (!g_settings.showThumbnails && !g_settings.showTitle && g_settings.showIcon) {
+                int contentLeft = e.rcCell.left + padLeft;
+                int contentRight = e.rcCell.right - padLeft;
+                int iconSz = GetHeaderIconSizePx();
+                int availableW = contentRight - contentLeft;
+                if (availableW < 0) availableW = 0;
+                
+                int iconX = contentLeft;
+                int iconY = e.rcCell.top + padTop + (rowTitleH - iconSz) / 2;
+                
+                if (HeaderIsVertical()) {
+                    iconX = contentLeft + ((availableW > iconSz) ? (availableW - iconSz) / 2 : 0);
+                    iconY = e.rcCell.top + padTop;
+                } else if (g_settings.centerTaskContent) {
+                    if (iconSz < availableW) {
+                        iconX = contentLeft + (availableW - iconSz) / 2;
+                    }
+                }
+
+                int btnPadding = DpiScale(2, g_dpiX);
+                btnSz = DpiScale(16, g_dpiX);
+                bx = iconX + iconSz - btnSz + btnPadding;
+                by = iconY - btnPadding;
             } else {
                 bx = e.rcCell.right - padLeft - btnSz;
                 by = HeaderIsVertical() ? (e.rcCell.top + padTop)
@@ -1540,7 +1570,7 @@ static void DrawSwitcherOverlay(HDC hdc) {
             graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
             COLORREF xc = g_isCloseHovered ? RGB(255, 255, 255) : GetContourColor();
             Gdiplus::Pen xPen(Gdiplus::Color(255, GetRValue(xc), GetGValue(xc), GetBValue(xc)), 1.5f * g_dpiX / 96.0f);
-            int p = DpiScale(7, g_dpiX);
+            int p = (btnSz == DpiScale(16, g_dpiX)) ? DpiScale(4, g_dpiX) : DpiScale(7, g_dpiX);
             graphics.DrawLine(&xPen, bx + p, by + p, bx + btnSz - p, by + btnSz - p);
             graphics.DrawLine(&xPen, bx + btnSz - p, by + p, bx + p, by + btnSz - p);
         }
@@ -2213,6 +2243,29 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
                 int btnPadding = DpiScale(4, g_dpiX);
                 bx = e.rcThumbActual.right - btnSz - btnPadding;
                 by = e.rcThumbActual.top + btnPadding;
+            } else if (!g_settings.showThumbnails && !g_settings.showTitle && g_settings.showIcon) {
+                int contentLeft = e.rcCell.left + padL;
+                int contentRight = e.rcCell.right - padL;
+                int iconSz = GetHeaderIconSizePx();
+                int availableW = contentRight - contentLeft;
+                if (availableW < 0) availableW = 0;
+                
+                int iconX = contentLeft;
+                int iconY = e.rcCell.top + padT + (titleH - iconSz) / 2;
+                
+                if (HeaderIsVertical()) {
+                    iconX = contentLeft + ((availableW > iconSz) ? (availableW - iconSz) / 2 : 0);
+                    iconY = e.rcCell.top + padT;
+                } else if (g_settings.centerTaskContent) {
+                    if (iconSz < availableW) {
+                        iconX = contentLeft + (availableW - iconSz) / 2;
+                    }
+                }
+
+                int btnPadding = DpiScale(2, g_dpiX);
+                btnSz = DpiScale(16, g_dpiX);
+                bx = iconX + iconSz - btnSz + btnPadding;
+                by = iconY - btnPadding;
             } else {
                 bx = e.rcCell.right - padL - btnSz;
                 by = HeaderIsVertical() ? (e.rcCell.top + padT)

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -61,7 +61,7 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 
 *Horizontal rounded with thumbnails and no icons*
 
-![Horizontal rounded with thumbnails and no icons]https://github.com/Asteski/Windhawk-Mods/blob/cc72179d1ff603f3d3cf94fd41230ebea774bc8b/img/simple-window-switcher/8.png)
+![Horizontal rounded with thumbnails and no icons](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/simple-window-switcher/8.png)
 
 */
 // ==/WindhawkModReadme==

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -164,7 +164,10 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
           $description: Corner radius in pixels, used when Corner Preference is set to Custom. Applies to task borders, close buttons, and thumbnails.
         - taskRoundedCorners: false
           $name: Round Task Borders and Close Button
-          $description: Apply small rounded corners to the selected task border and close button.
+          $description: Apply rounded corners to the selected task border and close button.
+        - roundThumbnailCorners: false
+          $name: Round Thumbnail Corners
+          $description: Round the corners of window thumbnails. Uses the radius from Corner Preference.
       $name: Corners
     - Thumbnails:
         - thumbnailPosition: bottom
@@ -322,6 +325,9 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       $options:
       - currentOnly: Show windows from current virtual desktop only
       - allDesktops: Show windows from all virtual desktops
+    - hideMinimizedWindows: false
+      $name: Hide Minimized Windows
+      $description: Hide minimized windows from the switcher. When "Group Windows by Application" is enabled, an application is only hidden if all of its windows are minimized.
   $name: Accessibility
 - ExcludedWindows:
     - excludeByTitle: ""
@@ -438,11 +444,12 @@ struct Settings {
     int maxWidthPercent;
     bool autoFitTasks;
     int maxHeightPercent; int showDelay;
-    bool perMonitorWindows; bool taskRoundedCorners; bool reverseScrollDirection;
+    bool perMonitorWindows; bool taskRoundedCorners; bool roundThumbnailCorners; bool reverseScrollDirection;
     bool centerTaskContent;
     bool showApplications;
     WCHAR showTitles[32];
     bool restoreAllWindows;
+    bool hideMinimizedWindows;
     int customCornerRadius;
     WCHAR switcherPosition[32];
     int switcherPositionMargin;
@@ -595,6 +602,18 @@ static bool UseTaskRoundedCorners() {
 
 static int GetTaskUiCornerRadiusPx() {
     if (!UseTaskRoundedCorners()) {
+        return 0;
+    }
+    if (wcscmp(g_settings.cornerPreference, L"custom") == 0) {
+        return MulDiv(g_settings.customCornerRadius, g_dpiX, 96);
+    }
+    return MulDiv(4, g_dpiX, 96);
+}
+
+// Thumbnail corner rounding is controlled independently from the task border /
+// close button rounding, but shares the same radius from Corner Preference.
+static int GetThumbnailCornerRadiusPx() {
+    if (!g_settings.roundThumbnailCorners) {
         return 0;
     }
     if (wcscmp(g_settings.cornerPreference, L"custom") == 0) {
@@ -1354,6 +1373,21 @@ static void BuildWindowList() {
             }
         }
         g_windows = std::move(grouped);
+    }
+    // Optionally hide minimized windows. When grouping by application, an app
+    // entry is only hidden if every one of its windows is minimized; apps with
+    // at least one non-minimized window are kept.
+    if (g_settings.hideMinimizedWindows) {
+        g_windows.erase(std::remove_if(g_windows.begin(), g_windows.end(),
+            [](const WindowEntry& w) {
+                if (g_settings.showApplications) {
+                    for (HWND hw : w.groupWindows) {
+                        if (!IsIconic(hw)) return false;  // keep: has a visible window
+                    }
+                    return true;  // all windows minimized: hide
+                }
+                return IsIconic(w.hWnd) != FALSE;  // hide if minimized
+            }), g_windows.end());
     }
     std::stable_sort(g_windows.begin(), g_windows.end(), [](const WindowEntry& a, const WindowEntry& b) {
         return IsIconic(a.hWnd) < IsIconic(b.hWnd);
@@ -2280,7 +2314,7 @@ static void DrawSwitcherContent(HDC hdc, bool fillBg, HWND hWnd) {
     int padLeft    = DpiScale(SWS_PAD_LEFT, g_dpiX);
     int rowTitleH  = GetHeaderRowHeightPx();
     int iconSz     = GetHeaderIconSizePx();
-    int cornerRadius = GetTaskUiCornerRadiusPx();
+    int cornerRadius = GetThumbnailCornerRadiusPx();
 
     for (int i = 0; i < (int)g_windows.size(); i++) {
         auto& e = g_windows[i];
@@ -2406,7 +2440,7 @@ static void DrawSwitcherOverlay(HDC hdc, HWND hWnd) {
     if (g_windows.empty()) return;
 
     int rowTitleH = GetHeaderRowHeightPx();
-    int cornerRadius = GetTaskUiCornerRadiusPx();
+    int cornerRadius = GetThumbnailCornerRadiusPx();
 
     for (int idx = 0; idx < (int)g_windows.size(); idx++) {
         int i = (g_layoutStartIndex + idx) % g_windows.size();
@@ -3617,6 +3651,7 @@ static void LoadSettings() {
     if (g_settings.customCornerRadius < 0) g_settings.customCornerRadius = 0;
     if (g_settings.customCornerRadius > 32) g_settings.customCornerRadius = 32;
     g_settings.taskRoundedCorners = Wh_GetIntSetting(L"Appearance.Corners.taskRoundedCorners");
+    g_settings.roundThumbnailCorners = Wh_GetIntSetting(L"Appearance.Corners.roundThumbnailCorners");
     v = Wh_GetStringSetting(L"Accessibility.scrollWheelBehavior");
     wcscpy_s(g_settings.scrollWheelBehavior, v ? v : L"never"); Wh_FreeStringSetting(v);
     v = Wh_GetStringSetting(L"Appearance.Orientation.taskListOrientation");
@@ -3713,6 +3748,7 @@ static void LoadSettings() {
     g_settings.reverseScrollDirection = Wh_GetIntSetting(L"Accessibility.reverseScrollDirection");
     g_settings.showApplications = Wh_GetIntSetting(L"Grouping.showApplications");
     g_settings.restoreAllWindows = Wh_GetIntSetting(L"Grouping.restoreAllWindows");
+    g_settings.hideMinimizedWindows = Wh_GetIntSetting(L"Accessibility.hideMinimizedWindows");
     v = Wh_GetStringSetting(L"Grouping.showTitles");
     wcscpy_s(g_settings.showTitles, v ? v : L"windowTitle"); Wh_FreeStringSetting(v);
     if (wcscmp(g_settings.showTitles, L"windowTitle") != 0 &&

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/Louis047
 // @include         windhawk.exe
 // @include         explorer.exe
-// @compilerOptions -ldwmapi -luxtheme -lgdi32 -lshlwapi -loleaut32 -lole32 -lcomctl32 -lgdiplus
+// @compilerOptions -ldwmapi -luxtheme -lgdi32 -lshlwapi -loleaut32 -lole32 -lcomctl32 -lgdiplus -lversion
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -23,6 +23,8 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
 - Keyboard navigation (Tab/Shift+Tab/Shift/Backtick, Arrow keys, Enter, Esc)
 - Mouse click to select, scroll wheel to cycle from anywhere
 - Virtual Desktop Support (Show windows across multiple virtual desktops)
+- Group windows by application (macOS Cmd+Tab style, one entry per app)
+- Drill into an app's windows with a Ctrl tap to pick a specific window (Esc backs out)
 - Win+Alt+Tab override to display windows from all monitors when using Per-Monitor mode
 - Alt+Ctrl+Tab sticky mode
 - Theme support (None/Backdrop Acrylic) with fully customizable background opacity
@@ -130,8 +132,10 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
           $name: Icon Size
           $description: Size of the header icon.
           $options:
-          - small: Small
-          - large: Large
+          - small: Small (16x16)
+          - medium: Medium (32x32)
+          - large: Large (48x48)
+          - xlarge: Extra Large (64x64)
         - showTitle: true
           $name: Show Title Label
         - showIcon: true
@@ -187,6 +191,21 @@ Additional improvements made by [Asteski](https://github.com/Asteski).
       $name: Stretch Thumbnails to Task Width
       $description: When enabled, custom row width also changes thumbnail width. Disable to keep thumbnail aspect sizing while row width controls only task tile width.
   $name: Dimensions
+- Grouping:
+    - showApplications: false
+      $name: Group Windows by Application
+      $description: Show one entry per application instead of one per window, similar to macOS Cmd+Tab. Selecting an application switches to its most recently used window. Tap Ctrl while an application is selected to expand it and show all of its windows as thumbnails.
+    - showTitles: windowTitle
+      $name: Show Titles
+      $description: Which title text to display for each entry. Only applies when "Group Windows by Application" is enabled.
+      $options:
+      - windowTitle: Window Title
+      - appName: Application Name
+      - appNameWindowTitle: Application Name - Window Title
+    - restoreAllWindows: false
+      $name: Restore All Windows
+      $description: When switching to an application, restore all of its minimized windows to their previous state. Only applies when "Group Windows by Application" is enabled. Tip - to act on a single window instead, tap Ctrl while the application is selected to show all of its windows and pick one.
+  $name: Grouping
 - Accessibility:
     - showDelay: 0
       $name: Show Delay (ms)
@@ -303,6 +322,7 @@ struct WindowEntry {
     SIZE sourceSize;           // Raw DWM surface size
     RECT rcSourceCrop;         // Source crop rect for DWM_TNP_RECTSOURCE
     SIZE effectiveSourceSize;  // Source size after cropping invisible frame
+    std::vector<HWND> groupWindows;  // All app windows when grouping by application
 };
 struct Settings {
     WCHAR theme[32]; WCHAR colorScheme[32]; WCHAR cornerPreference[32]; WCHAR scrollWheelBehavior[32]; WCHAR taskListOrientation[32]; WCHAR headerContentOrientation[32]; WCHAR iconSize[32]; WCHAR backwardShortcut[32]; WCHAR thumbnailPosition[32]; WCHAR thumbnailAlignment[32]; WCHAR switcherDisplayBehavior[32];
@@ -322,6 +342,9 @@ struct Settings {
     int maxHeightPercent; int showDelay;
     bool useAccentColor; bool perMonitorWindows; bool taskRoundedCorners; bool reverseScrollDirection;
     bool centerTaskContent;
+    bool showApplications;
+    WCHAR showTitles[32];
+    bool restoreAllWindows;
 };
 
 static std::vector<std::wstring> g_excludeTitlePatterns;
@@ -337,6 +360,13 @@ static std::vector<WindowEntry> g_windows;
 static int g_selectedIndex = 0, g_hoverIndex = -1;
 static HWND g_hoverWnd = NULL;
 static int g_layoutStartIndex = 0; // EP-style: first window index visible in the layout
+// App drill-in: when grouping by application, Ctrl drills into the selected app's
+// windows. The grouped app list is stashed here so it can be restored on exit.
+static bool g_drilledIn = false;
+static std::vector<WindowEntry> g_savedAppList;
+static int g_savedSelectedIndex = 0;
+static int g_savedLayoutStartIndex = 0;
+static bool g_consumeEscUp = false;
 static bool g_isVisible = false, g_isSticky = false, g_isDarkMode = false;
 static HFONT g_hFont = NULL;
 static HTHEME g_hTheme = NULL;
@@ -395,11 +425,14 @@ static bool StretchThumbsToTaskWidth() {
 static bool HeaderIsVertical() {
     return HeaderOrientationIs(L"vertical");
 }
+static int GetHeaderIconSizeBase() {
+    if (IconSizeIs(L"xlarge")) return 64;
+    if (IconSizeIs(L"large")) return 48;
+    if (IconSizeIs(L"medium")) return 32;
+    return SWS_ICON_SIZE;
+}
 static int GetHeaderIconSizePx() {
-    if (IconSizeIs(L"large")) {
-        return MulDiv(32, g_dpiX, 96);
-    }
-    return MulDiv(SWS_ICON_SIZE, g_dpiX, 96);
+    return MulDiv(GetHeaderIconSizeBase(), g_dpiX, 96);
 }
 static int GetHeaderTitleHeightPx() {
     return MulDiv(18, g_dpiY, 96);
@@ -594,6 +627,57 @@ static bool IsAltTabWindow(HWND h) {
 
 static HICON TryGetUwpIconFromExplorer(HWND hWnd, int desiredSizePx);
 
+// Cache of crisp icons extracted from exe files at a specific pixel size.
+// Owned here (DestroyIcon at unload); keyed by "<exePath>_<sizePx>".
+static std::map<std::wstring, HICON> g_exeIconCache;
+
+// WM_GETICON returns a fixed (usually 32px) icon that looks blurry when scaled
+// up to 48/64. PrivateExtractIconsW pulls the best-matching frame from the
+// exe's icon resource at the exact requested size for a crisp result.
+static HICON TryGetCrispExeIcon(HWND hWnd, int desiredSizePx) {
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hWnd, &pid);
+    if (!pid) return NULL;
+    HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (!hProc) return NULL;
+    WCHAR exePath[MAX_PATH] = {0};
+    DWORD size = MAX_PATH;
+    BOOL ok = QueryFullProcessImageNameW(hProc, 0, exePath, &size);
+    CloseHandle(hProc);
+    if (!ok || !exePath[0]) return NULL;
+
+    std::wstring key = std::wstring(exePath) + L"_" + std::to_wstring(desiredSizePx);
+    auto it = g_exeIconCache.find(key);
+    if (it != g_exeIconCache.end()) return it->second;
+
+    HICON hIcon = NULL;
+    if (PrivateExtractIconsW(exePath, 0, desiredSizePx, desiredSizePx,
+                             &hIcon, NULL, 1, 0) == 1 && hIcon) {
+        g_exeIconCache[key] = hIcon;
+        return hIcon;
+    }
+    return NULL;
+}
+
+static HICON LoadWindowIcon(HWND hWnd) {
+    HICON hIcon = NULL;
+    if (g_IsShellFrameWindow && g_IsShellFrameWindow(hWnd)) {
+        hIcon = TryGetUwpIconFromExplorer(hWnd, GetHeaderIconSizePx());
+    }
+    // For the larger sizes, a crisp full-resolution exe icon beats the
+    // upscaled WM_GETICON result.
+    if (!hIcon && GetHeaderIconSizeBase() > 32) {
+        hIcon = TryGetCrispExeIcon(hWnd, GetHeaderIconSizePx());
+    }
+    if (!hIcon) SendMessageTimeoutW(hWnd, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK, 100, (DWORD_PTR*)&hIcon);
+    if (!hIcon) SendMessageTimeoutW(hWnd, WM_GETICON, ICON_SMALL2, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK, 100, (DWORD_PTR*)&hIcon);
+    if (!hIcon) SendMessageTimeoutW(hWnd, WM_GETICON, ICON_SMALL, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK, 100, (DWORD_PTR*)&hIcon);
+    if (!hIcon) hIcon = (HICON)GetClassLongPtrW(hWnd, GCLP_HICON);
+    if (!hIcon) hIcon = (HICON)GetClassLongPtrW(hWnd, GCLP_HICONSM);
+    if (!hIcon) hIcon = LoadIconW(NULL, IDI_APPLICATION);
+    return hIcon;
+}
+
 static BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) {
     auto* list = reinterpret_cast<std::vector<WindowEntry>*>(lParam);
     if (hWnd == g_hSwitcher) return TRUE;
@@ -641,23 +725,7 @@ static BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) {
     }
     if (excluded) return TRUE;
 
-    e.hIcon = NULL;
-    
-    bool isUwp = false;
-    if (g_IsShellFrameWindow && g_IsShellFrameWindow(hWnd)) {
-        isUwp = true;
-    }
-    
-    if (isUwp) {
-        e.hIcon = TryGetUwpIconFromExplorer(hWnd, GetHeaderIconSizePx());
-    }
-    
-    if (!e.hIcon) SendMessageTimeoutW(hWnd, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK, 100, (DWORD_PTR*)&e.hIcon);
-    if (!e.hIcon) SendMessageTimeoutW(hWnd, WM_GETICON, ICON_SMALL2, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK, 100, (DWORD_PTR*)&e.hIcon);
-    if (!e.hIcon) SendMessageTimeoutW(hWnd, WM_GETICON, ICON_SMALL, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK, 100, (DWORD_PTR*)&e.hIcon);
-    if (!e.hIcon) e.hIcon = (HICON)GetClassLongPtrW(hWnd, GCLP_HICON);
-    if (!e.hIcon) e.hIcon = (HICON)GetClassLongPtrW(hWnd, GCLP_HICONSM);
-    if (!e.hIcon) e.hIcon = LoadIconW(NULL, IDI_APPLICATION);
+    e.hIcon = LoadWindowIcon(hWnd);
     list->push_back(e);
     return TRUE;
 }
@@ -956,6 +1024,76 @@ static HICON TryGetUwpIconFromExplorer(HWND hWnd, int desiredSizePx) {
     return NULL;
 }
 
+// Identity key used to group windows by application. UWP/app-frame-host windows
+// all share a single host process, so keying them by executable would merge
+// unrelated apps; those are keyed per-window to avoid over-grouping.
+static void GetWindowGroupKey(HWND hWnd, WCHAR* out, size_t cch) {
+    out[0] = 0;
+    if (g_IsShellFrameWindow && g_IsShellFrameWindow(hWnd)) {
+        swprintf_s(out, cch, L"hwnd:%p", (void*)hWnd);
+        return;
+    }
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hWnd, &pid);
+    if (pid) {
+        HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+        if (hProc) {
+            WCHAR exePath[MAX_PATH] = {0};
+            DWORD size = MAX_PATH;
+            if (QueryFullProcessImageNameW(hProc, 0, exePath, &size)) {
+                wcsncpy_s(out, cch, exePath, _TRUNCATE);
+            }
+            CloseHandle(hProc);
+        }
+    }
+    if (!out[0]) swprintf_s(out, cch, L"hwnd:%p", (void*)hWnd);
+}
+
+// Human-readable application name for a window, taken from the executable's
+// FileDescription version-info field (e.g. "Google Chrome"), falling back to
+// the executable file name without extension.
+static void GetAppName(HWND hWnd, WCHAR* out, size_t cch) {
+    out[0] = 0;
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hWnd, &pid);
+    if (!pid) return;
+    HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (!hProc) return;
+    WCHAR exePath[MAX_PATH] = {0};
+    DWORD size = MAX_PATH;
+    bool gotPath = QueryFullProcessImageNameW(hProc, 0, exePath, &size);
+    CloseHandle(hProc);
+    if (!gotPath) return;
+
+    DWORD handle = 0;
+    DWORD verSize = GetFileVersionInfoSizeW(exePath, &handle);
+    if (verSize) {
+        std::vector<BYTE> buf(verSize);
+        if (GetFileVersionInfoW(exePath, handle, verSize, buf.data())) {
+            struct LangAndCodePage { WORD wLanguage; WORD wCodePage; } *translate = nullptr;
+            UINT cbTranslate = 0;
+            if (VerQueryValueW(buf.data(), L"\\VarFileInfo\\Translation",
+                               (LPVOID*)&translate, &cbTranslate) &&
+                cbTranslate >= sizeof(LangAndCodePage)) {
+                WCHAR subBlock[64];
+                swprintf_s(subBlock, ARRAYSIZE(subBlock),
+                           L"\\StringFileInfo\\%04x%04x\\FileDescription",
+                           translate[0].wLanguage, translate[0].wCodePage);
+                LPWSTR desc = nullptr;
+                UINT descLen = 0;
+                if (VerQueryValueW(buf.data(), subBlock, (LPVOID*)&desc, &descLen) &&
+                    desc && desc[0]) {
+                    wcsncpy_s(out, cch, desc, _TRUNCATE);
+                }
+            }
+        }
+    }
+    if (!out[0]) {
+        wcsncpy_s(out, cch, PathFindFileNameW(exePath), _TRUNCATE);
+        PathRemoveExtensionW(out);
+    }
+}
+
 static void BuildWindowList() {
     for (auto& w : g_windows) {
         for (const auto& kv : w.hThumbs) { if (kv.second) DwmUnregisterThumbnail(kv.second); }
@@ -963,6 +1101,53 @@ static void BuildWindowList() {
     }
     g_windows.clear();
     EnumWindows(EnumWindowsProc, (LPARAM)&g_windows);
+    // App grouping: keep one entry per application. EnumWindows yields windows in
+    // Z-order (top to bottom), so the first window seen for each app is its most
+    // recently used one, which becomes the representative entry.
+    if (g_settings.showApplications) {
+        std::vector<WindowEntry> grouped;
+        grouped.reserve(g_windows.size());
+        std::vector<std::wstring> seenKeys;  // parallel to grouped
+        for (auto& w : g_windows) {
+            WCHAR key[MAX_PATH];
+            GetWindowGroupKey(w.hWnd, key, ARRAYSIZE(key));
+            int found = -1;
+            for (size_t i = 0; i < seenKeys.size(); i++) {
+                if (seenKeys[i] == key) { found = (int)i; break; }
+            }
+            if (found >= 0) {
+                grouped[found].groupWindows.push_back(w.hWnd);
+                continue;
+            }
+            seenKeys.emplace_back(key);
+            w.groupWindows.assign(1, w.hWnd);
+            grouped.push_back(std::move(w));
+        }
+        for (auto& e : grouped) {
+            if (wcscmp(g_settings.showTitles, L"windowTitle") == 0) continue;
+            WCHAR appName[256] = {0};
+            GetAppName(e.hWnd, appName, ARRAYSIZE(appName));
+            if (!appName[0]) continue;
+            // UWP apps share the "Application Frame Host" executable, whose
+            // FileDescription is useless as an app name; use the window title instead.
+            if (_wcsicmp(appName, L"Application Frame Host") == 0 && e.title[0]) {
+                wcscpy_s(appName, e.title);
+            }
+            if (wcscmp(g_settings.showTitles, L"appName") == 0) {
+                wcscpy_s(e.title, appName);
+            } else {  // appNameWindowTitle
+                if (e.title[0]) {
+                    WCHAR combined[256];
+                    _snwprintf_s(combined, ARRAYSIZE(combined), _TRUNCATE,
+                                 L"%s - %s", appName, e.title);
+                    wcscpy_s(e.title, combined);
+                } else {
+                    wcscpy_s(e.title, appName);
+                }
+            }
+        }
+        g_windows = std::move(grouped);
+    }
     std::stable_sort(g_windows.begin(), g_windows.end(), [](const WindowEntry& a, const WindowEntry& b) {
         return IsIconic(a.hWnd) < IsIconic(b.hWnd);
     });
@@ -2283,6 +2468,9 @@ static void ShowSwitcher(bool sticky) {
     g_isDarkMode = ShouldUseDarkMode(); g_isSticky = sticky;
 
     g_layoutStartIndex = 0; // Always start from the first window on initial show
+    g_drilledIn = false;
+    g_savedAppList.clear();
+    g_consumeEscUp = false;
     g_selectedIndex = (g_windows.size() > 1) ? 1 : 0;
     g_hoverIndex = -1;
     g_hoverWnd = NULL;
@@ -2372,12 +2560,22 @@ static void HideSwitcher() {
         g_hMouseHook = NULL;
     }
     g_isSticky = false;
+    g_drilledIn = false;
+    g_savedAppList.clear();
+    g_consumeEscUp = false;
 }
 
 static void SwitchToSelected() {
     if (g_selectedIndex < 0 || g_selectedIndex >= (int)g_windows.size()) { HideSwitcher(); return; }
     HWND hT = g_windows[g_selectedIndex].hWnd;
+    std::vector<HWND> groupWindows;
+    if (g_settings.showApplications && g_settings.restoreAllWindows) {
+        groupWindows = g_windows[g_selectedIndex].groupWindows;
+    }
     HideSwitcher();
+    for (HWND hw : groupWindows) {
+        if (IsWindow(hw) && hw != hT && IsIconic(hw)) ShowWindow(hw, SW_RESTORE);
+    }
     if (IsWindow(hT)) {
         HWND hP = GetLastActivePopup(hT);
         HWND hF = IsWindowVisible(hP) ? hP : hT;
@@ -2424,6 +2622,67 @@ static void RecomputeAndReposition() {
         SetWindowPos(g_hCloseBtnWnd, HWND_TOPMOST, cx, cy, g_winW, g_winH, SWP_NOACTIVATE);
     }
     RegisterThumbnails();
+}
+
+// Drill into the selected application's windows: stash the grouped app list and
+// replace g_windows with one entry per window of that app.
+static void EnterAppGroup() {
+    if (!g_settings.showApplications || g_drilledIn) return;
+    if (g_selectedIndex < 0 || g_selectedIndex >= (int)g_windows.size()) return;
+    std::vector<HWND> members = g_windows[g_selectedIndex].groupWindows;
+    if (members.size() <= 1) return;  // nothing to expand
+
+    UnregisterThumbnails();  // release app-list thumbnails before stashing
+    g_savedAppList = std::move(g_windows);
+    g_savedSelectedIndex = g_selectedIndex;
+    g_savedLayoutStartIndex = g_layoutStartIndex;
+
+    g_windows.clear();
+    for (HWND hw : members) {
+        if (!IsWindow(hw)) continue;
+        WindowEntry e = {};
+        e.hWnd = hw;
+        InternalGetWindowText(hw, e.title, 256);
+        if (!e.title[0]) GetWindowTextW(hw, e.title, 256);
+        e.hIcon = LoadWindowIcon(hw);
+        g_windows.push_back(std::move(e));
+    }
+    if (g_windows.empty()) {  // every window closed in the meantime; abort
+        g_windows = std::move(g_savedAppList);
+        RecomputeAndReposition();
+        return;
+    }
+    g_drilledIn = true;
+    g_selectedIndex = 0;
+    g_layoutStartIndex = 0;
+    g_hoverIndex = -1;
+    g_hoverWnd = NULL;
+    g_isCloseHovered = false;
+    RecomputeAndReposition();
+    PaintSwitcher();
+}
+
+// Leave the drilled-in window view and restore the grouped application list.
+static void ExitAppGroup() {
+    if (!g_drilledIn) return;
+    UnregisterThumbnails();  // release drilled-window thumbnails
+    g_windows = std::move(g_savedAppList);
+    g_savedAppList.clear();
+    g_selectedIndex = g_savedSelectedIndex;
+    g_layoutStartIndex = g_savedLayoutStartIndex;
+    if (g_selectedIndex >= (int)g_windows.size()) g_selectedIndex = (int)g_windows.size() - 1;
+    if (g_selectedIndex < 0) g_selectedIndex = 0;
+    g_drilledIn = false;
+    g_hoverIndex = -1;
+    g_hoverWnd = NULL;
+    g_isCloseHovered = false;
+    RecomputeAndReposition();
+    PaintSwitcher();
+}
+
+static void ToggleAppDrill() {
+    if (g_drilledIn) ExitAppGroup();
+    else EnterAppGroup();
 }
 
 // Linear navigation: Tab, Shift+Tab, Left, Right, Hotkeys, Scroll
@@ -2748,7 +3007,11 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
             SwitchToSelected();
             return 0;
         }
-        if (wParam == VK_ESCAPE && g_isVisible) { HideSwitcher(); return 0; }
+        if (wParam == VK_ESCAPE && g_isVisible) {
+            if (g_consumeEscUp) { g_consumeEscUp = false; return 0; }
+            HideSwitcher();
+            return 0;
+        }
         if (wParam == VK_RETURN && g_isVisible) { SwitchToSelected(); return 0; }
         break;
     case WM_SYSKEYUP:
@@ -2767,6 +3030,13 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
         break;
     case WM_SYSKEYDOWN: case WM_KEYDOWN:
         if (g_isVisible) {
+            // Ctrl tap: drill into / out of the selected application's windows.
+            if ((wParam == VK_CONTROL || wParam == VK_LCONTROL || wParam == VK_RCONTROL)
+                && g_settings.showApplications) {
+                bool isRepeat = (lParam & 0x40000000) != 0;
+                if (!isRepeat) ToggleAppDrill();
+                return 0;
+            }
             // Block Alt+Shift+Tab from reaching the system if setting is enabled
             if (UseAltShiftBackward() && wParam == VK_TAB) {
                 bool altDown = (GetKeyState(VK_MENU) & 0x8000) != 0;
@@ -2803,7 +3073,11 @@ static LRESULT CALLBACK SwitcherWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
                 if (wParam == VK_LEFT) { CycleDirectional(-1); return 0; }
                 if (wParam == VK_RIGHT) { CycleDirectional(1); return 0; }
             }
-            if (wParam == VK_ESCAPE) { HideSwitcher(); return 0; }
+            if (wParam == VK_ESCAPE) {
+                if (g_drilledIn) { ExitAppGroup(); g_consumeEscUp = true; }
+                else HideSwitcher();
+                return 0;
+            }
             if (wParam == VK_RETURN || wParam == VK_SPACE) { SwitchToSelected(); return 0; }
         }
         break;
@@ -3005,7 +3279,7 @@ static void LoadSettings() {
     v = Wh_GetStringSetting(L"Appearance.Corners.cornerPreference");
     wcscpy_s(g_settings.cornerPreference, v ? v : L"round"); Wh_FreeStringSetting(v);
     g_settings.taskRoundedCorners = Wh_GetIntSetting(L"Appearance.Corners.taskRoundedCorners");
-    v = Wh_GetStringSetting(L"Miscellaneous.scrollWheelBehavior");
+    v = Wh_GetStringSetting(L"Accessibility.scrollWheelBehavior");
     wcscpy_s(g_settings.scrollWheelBehavior, v ? v : L"never"); Wh_FreeStringSetting(v);
     v = Wh_GetStringSetting(L"Appearance.Orientation.taskListOrientation");
     wcscpy_s(g_settings.taskListOrientation, v ? v : L"horizontal"); Wh_FreeStringSetting(v);
@@ -3018,7 +3292,9 @@ static void LoadSettings() {
     v = Wh_GetStringSetting(L"Appearance.HeaderContent.iconSize");
     wcscpy_s(g_settings.iconSize, v ? v : L"small"); Wh_FreeStringSetting(v);
     if (wcscmp(g_settings.iconSize, L"small") != 0 &&
-        wcscmp(g_settings.iconSize, L"large") != 0) {
+        wcscmp(g_settings.iconSize, L"medium") != 0 &&
+        wcscmp(g_settings.iconSize, L"large") != 0 &&
+        wcscmp(g_settings.iconSize, L"xlarge") != 0) {
         wcscpy_s(g_settings.iconSize, L"small");
     }
     v = Wh_GetStringSetting(L"Appearance.Thumbnails.thumbnailPosition");
@@ -3036,7 +3312,7 @@ static void LoadSettings() {
         wcscmp(g_settings.thumbnailAlignment, L"right") != 0) {
         wcscpy_s(g_settings.thumbnailAlignment, L"left");
     }
-    v = Wh_GetStringSetting(L"Miscellaneous.backwardShortcut");
+    v = Wh_GetStringSetting(L"Accessibility.backwardShortcut");
     if (v) {
         wcscpy_s(g_settings.backwardShortcut, v);
         Wh_FreeStringSetting(v);
@@ -3060,7 +3336,7 @@ static void LoadSettings() {
         wcscpy_s(g_settings.highlightStyle, L"border");
     }
 
-    v = Wh_GetStringSetting(L"Miscellaneous.virtualDesktopBehavior");
+    v = Wh_GetStringSetting(L"Accessibility.virtualDesktopBehavior");
     wcscpy_s(g_settings.virtualDesktopBehavior, v ? v : L"currentOnly");
     Wh_FreeStringSetting(v);
     if (wcscmp(g_settings.virtualDesktopBehavior, L"currentOnly") != 0 &&
@@ -3087,11 +3363,20 @@ static void LoadSettings() {
     g_settings.maxHeightPercent = Wh_GetIntSetting(L"Dimensions.maxHeightPercent");
     if (g_settings.maxHeightPercent <= 0 || g_settings.maxHeightPercent > 100) g_settings.maxHeightPercent = 80;
 
-    g_settings.showDelay = Wh_GetIntSetting(L"Miscellaneous.showDelay");
+    g_settings.showDelay = Wh_GetIntSetting(L"Accessibility.showDelay");
     if (g_settings.showDelay < 0) g_settings.showDelay = 0;
     g_settings.useAccentColor = Wh_GetIntSetting(L"Style.useAccentColor");
-    g_settings.perMonitorWindows = Wh_GetIntSetting(L"Miscellaneous.perMonitorWindows");
-    g_settings.reverseScrollDirection = Wh_GetIntSetting(L"Miscellaneous.reverseScrollDirection");
+    g_settings.perMonitorWindows = Wh_GetIntSetting(L"Accessibility.perMonitorWindows");
+    g_settings.reverseScrollDirection = Wh_GetIntSetting(L"Accessibility.reverseScrollDirection");
+    g_settings.showApplications = Wh_GetIntSetting(L"Grouping.showApplications");
+    g_settings.restoreAllWindows = Wh_GetIntSetting(L"Grouping.restoreAllWindows");
+    v = Wh_GetStringSetting(L"Grouping.showTitles");
+    wcscpy_s(g_settings.showTitles, v ? v : L"windowTitle"); Wh_FreeStringSetting(v);
+    if (wcscmp(g_settings.showTitles, L"windowTitle") != 0 &&
+        wcscmp(g_settings.showTitles, L"appName") != 0 &&
+        wcscmp(g_settings.showTitles, L"appNameWindowTitle") != 0) {
+        wcscpy_s(g_settings.showTitles, L"windowTitle");
+    }
     g_settings.centerTaskContent = Wh_GetIntSetting(L"Appearance.HeaderContent.centerTaskContent");
 
 
@@ -3116,13 +3401,13 @@ static void LoadSettings() {
     v = Wh_GetStringSetting(L"Appearance.Font.fontStyle");
     wcscpy_s(g_settings.fontStyle, v ? v : L"regular"); Wh_FreeStringSetting(v);
 
-    v = Wh_GetStringSetting(L"Miscellaneous.switcherDisplayBehavior");
+    v = Wh_GetStringSetting(L"Accessibility.switcherDisplayBehavior");
     wcscpy_s(g_settings.switcherDisplayBehavior, v ? v : L"cursorMonitor"); Wh_FreeStringSetting(v);
 
     g_excludeTitlePatterns.clear();
     g_excludeExePatterns.clear();
     for (int i = 0; ; i++) {
-        PCWSTR method = Wh_GetStringSetting(L"Miscellaneous.ExcludedWindows[%d].Method", i);
+        PCWSTR method = Wh_GetStringSetting(L"ExcludedWindows[%d].Method", i);
         bool done = !method || !*method;
         
         if (done) {
@@ -3130,7 +3415,7 @@ static void LoadSettings() {
             break;
         }
         
-        PCWSTR value = Wh_GetStringSetting(L"Miscellaneous.ExcludedWindows[%d].Value", i);
+        PCWSTR value = Wh_GetStringSetting(L"ExcludedWindows[%d].Value", i);
         if (value && *value) {
             std::wstring valStr(value);
             size_t start = 0;
@@ -3546,6 +3831,10 @@ void Wh_ModUninit() {
             if (pair.second) DestroyIcon(pair.second);
         }
         g_uwpIconCache.clear();
+        for (auto& pair : g_exeIconCache) {
+            if (pair.second) DestroyIcon(pair.second);
+        }
+        g_exeIconCache.clear();
 
         if (g_isExplorer && IsMainExplorer()) {
             if (!GetSystemMetrics(SM_SHUTTINGDOWN)) {

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -935,7 +935,14 @@ static void RegisterThumbnailsEarly() {
                     GetWindowRect(w.hWnd, &wr);
                     if (SUCCEEDED(DwmGetWindowAttribute(w.hWnd, DWMWA_EXTENDED_FRAME_BOUNDS, &efb, sizeof(efb)))) {
                         int wrW = wr.right - wr.left, wrH = wr.bottom - wr.top;
-                        if (wrW > 0 && wrH > 0 && src.cx > 0 && src.cy > 0) {
+                        int efbW = efb.right - efb.left;
+                        
+                        // DWM in Windows 11 natively crops off-screen borders for maximized windows.
+                        // If the thumbnail source size is already closer to the visible bounds (efb) 
+                        // than the physical bounds (wr), we skip manual cropping to avoid double-cropping.
+                        bool dwmNativelyCropped = (abs(src.cx - efbW) < abs(src.cx - wrW));
+                        
+                        if (!dwmNativelyCropped && wrW > 0 && wrH > 0 && src.cx > 0 && src.cy > 0) {
                             double sx = (double)src.cx / wrW;
                             double sy = (double)src.cy / wrH;
                             int ml = (int)((efb.left - wr.left) * sx);

--- a/mods/simple-window-switcher.wh.cpp
+++ b/mods/simple-window-switcher.wh.cpp
@@ -2024,18 +2024,22 @@ static void RevealPendingSwitcher() {
 }
 
 static void ShowSwitcher(bool sticky) {
-    UnregisterThumbnails(); BuildWindowList();
-    if (g_windows.empty()) return;
-    g_isDarkMode = ShouldUseDarkMode(); g_isSticky = sticky;
     POINT pt; GetCursorPos(&pt);
     HMONITOR hMon = g_settings.primaryMonitorOnly ?
         MonitorFromPoint({0,0}, MONITOR_DEFAULTTOPRIMARY) :
         MonitorFromPoint(pt, MONITOR_DEFAULTTOPRIMARY);
+
     g_hCurrentMonitor = hMon;
-    if (g_settings.perMonitorWindows && !g_showAllMonitors) {
-        UnregisterThumbnails(); BuildWindowList();
-        if (g_windows.empty()) return;
-    }
+    UnregisterThumbnails(); BuildWindowList();
+    if (g_windows.empty()) return;
+
+    g_isDarkMode = ShouldUseDarkMode(); g_isSticky = sticky;
+
+    g_layoutStartIndex = 0; // Always start from the first window on initial show
+    g_selectedIndex = (g_windows.size() > 1) ? 1 : 0;
+    g_hoverIndex = -1;
+    g_isCloseHovered = false;
+
     RegisterThumbnailsEarly();
     ComputeLayout(hMon);
     if (g_winW <= 0 || g_winH <= 0) return;
@@ -2098,11 +2102,6 @@ static void ShowSwitcher(bool sticky) {
         cx + g_winW,
         cy + g_winH
     };
-
-    g_layoutStartIndex = 0; // Always start from the first window on initial show
-    g_selectedIndex = (g_windows.size() > 1) ? 1 : 0;
-    g_hoverIndex = -1;
-    g_isCloseHovered = false;
 
     CancelPendingShow();
 


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

### Fixes
- Fixed centering for elements. Now elements like Title and Label are correctly centered when DWM Thumbnails is disabled
- Fixed UWP Icons display for Windows 10 and older builds (Credits to @Asteski)
- Fixed Background Opacity fallback issue where setting it to 0 or above 100 falls back to 90. Now they follow the range correctly
- Fixed layout issues for icon-only setup
- Fixed scroll navigation issue where it doesn't navigate when the cursor is out of the alt tab menu
- Fixed an issue where special apps that uses overlays like Raycast, WindowSill etc were caught in the alt tab menu. 
- Fixed an issue with vertical alignment configuration where wide thumbnails "cut-through" the space. 
- Fixed an edge case with `Display Windows Only From the Monitor Containing the Cursor` option (Credits to @zhilemann)
- Fixed minor thumbnail issues. Now it correctly follows the DWM state for the windows
- Fixed row width to correctly follow the layout (Credits to @Asteski)
- Fixed Mica theme multi-monitor bug

### Updates
- Updated Explorer Restart Prompt logic using a new mutex check
- Updated Settings Layout to be more structured
- Updated Switcher Display options into a drop-down menu
- Updated Icons Size configuration, has four options: (Credits to @Asteski)
  - Small
  - Medium
  - Large
  - Extra Large
- Update Theme Mode Settings to allow a modular configuration separate for both light and dark modes
- Updated close button glyph to stay in static color (Credits to @Asteski)

### Additions
- Added new options: 
  - Show Title 
  - Show Label 
  - Reverse Scroll Direction
  - Switcher Background Color
- Added Virtual Desktop Support
- Added Font Customizations
- Added four new features (Credits to @Asteski) 
  - Thumbnail Position
  - Thumbnail Alignment
  - Task Highlight Style
  - Thumbnails to Task Width
  - Grouping Applications
- Added a new theme: Mica (Only Supported for Windows 11)
- Added Exclude Windows support
- Added Custom Border Radius support
- Added Switcher Positioning support
- Added Automatic Icon Size depending on the switcher dimensions (Credits to @Asteski)
- Added middle-mouse button task close (Credits to @Asteski)
- Added a new layout: Bagde, inspired from macOS with a set of customization options
- Added Grouper Window Indicator to show the number of windows of the related process
- Added Thumbnail Shadow Support (Credits to @Asteski)

### Issue References:
- #4190 
- #4165 
- #4213
- #4214 
- #4215 
- #4216 
- #4217 
- #4218 
- #4219
- #4232 (Didn't implement animations, moved to the next update)

