### PR TITLE
Files 2 Folders v1.3

### DIFF
--- a/mods/files-2-folders.wh.cpp
+++ b/mods/files-2-folders.wh.cpp
@@ -2,7 +2,7 @@
 // @id              files-2-folders
 // @name            Files 2 Folders
 // @description     Move one or more selected files in Explorer into a subfolder (named, by extension, by name, or by date), with a workaround hotkey for other file managers
-// @version         1.2
+// @version         1.3
 // @author          tria
 // @github          https://github.com/triatomic
 // @include         explorer.exe
@@ -840,7 +840,18 @@ static INT_PTR CALLBACK DlgProc(HWND hDlg, UINT msg, WPARAM wp, LPARAM lp) {
         return TRUE;
     }
     case WM_COMMAND: {
-        WORD id = LOWORD(wp);
+        WORD id   = LOWORD(wp);
+        WORD code = HIWORD(wp);
+
+        // Clicking or tabbing into an edit box selects its companion radio,
+        // so the mode the user is editing is the mode that runs on OK.
+        if (code == EN_SETFOCUS) {
+            if (id == IDC_ED_FIXED)
+                CheckRadioButton(hDlg, IDC_RB_FIXED, IDC_RB_DATE, IDC_RB_FIXED);
+            else if (id == IDC_ED_DATE)
+                CheckRadioButton(hDlg, IDC_RB_FIXED, IDC_RB_DATE, IDC_RB_DATE);
+            return TRUE;
+        }
         if (id == IDOK) {
             if (IsDlgButtonChecked(hDlg, IDC_RB_FIXED) == BST_CHECKED)        s->mode = MODE_FIXED_NAME;
             else if (IsDlgButtonChecked(hDlg, IDC_RB_PERNAME) == BST_CHECKED) s->mode = MODE_PER_FILE_NAME;


### PR DESCRIPTION
## Changelog

* Auto-select a mode's radio button when its companion edit box receives focus (by mouse click or Tab). Focusing the subfolder-name box now selects the fixed-name mode; focusing the date box selects the date-named mode. Previously you could type a name into a box without its radio being checked, so the move would run under whichever mode happened to be selected. This makes the mode you're editing the mode that runs on OK.
tl;dr: Clicking on subfolder name box or date will choose that mod now.
## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 