### PR TITLE
Toggle Hidden Files

### DIFF
--- a/mods/toggle-hidden-files.wh.cpp
+++ b/mods/toggle-hidden-files.wh.cpp
@@ -5,7 +5,7 @@
 // @version      1.0.0
 // @author       Asteski
 // @github       https://github.com/Asteski
-// @include      windhawk.exe
+// @include      explorer.exe
 // @compilerOptions -std=c++20
 // ==/WindhawkMod==
 
@@ -272,7 +272,7 @@ LRESULT CALLBACK KeyboardHookProc(int nCode, WPARAM wParam, LPARAM lParam) {
 }
 
 // Mod initialization
-BOOL WhTool_ModInit() {
+BOOL Wh_ModInit() {
     // Load settings
     LoadSettings();
     
@@ -288,12 +288,12 @@ BOOL WhTool_ModInit() {
 }
 
 // Settings changed callback
-void WhTool_ModSettingsChanged() {
+void Wh_ModSettingsChanged() {
     LoadSettings();
 }
 
 // Mod cleanup
-void WhTool_ModUninit() {
+void Wh_ModUninit() {
     g_modEnabled = false;
     
     // Remove keyboard hook
@@ -301,175 +301,4 @@ void WhTool_ModUninit() {
         UnhookWindowsHookEx(g_hKeyboardHook);
         g_hKeyboardHook = nullptr;
     }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Windhawk tool mod implementation for mods which don't need to inject to other
-// processes or hook other functions. Context:
-// https://github.com/ramensoftware/windhawk-mods/pull/1916
-//
-// The mod will load and run in a dedicated windhawk.exe process.
-//
-// Paste the code below as part of the mod code, and use these callbacks:
-// * WhTool_ModInit
-// * WhTool_ModSettingsChanged
-// * WhTool_ModUninit
-//
-// Currently, other callbacks are not supported.
-
-bool g_isToolModProcessLauncher;
-HANDLE g_toolModProcessMutex;
-
-void WINAPI EntryPoint_Hook() {
-    Wh_Log(L">");
-    ExitThread(0);
-}
-
-BOOL WhTool_ModInit() {
-    bool isService = false;
-    bool isToolModProcess = false;
-    bool isCurrentToolModProcess = false;
-    int argc;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
-    if (!argv) {
-        Wh_Log(L"CommandLineToArgvW failed");
-        return FALSE;
-    }
-
-    for (int i = 1; i < argc; i++) {
-        if (wcscmp(argv[i], L"-service") == 0) {
-            isService = true;
-            break;
-        }
-    }
-
-    for (int i = 1; i < argc - 1; i++) {
-        if (wcscmp(argv[i], L"-tool-mod") == 0) {
-            isToolModProcess = true;
-            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
-                isCurrentToolModProcess = true;
-            }
-            break;
-        }
-    }
-
-    LocalFree(argv);
-
-    if (isService) {
-        return FALSE;
-    }
-
-    if (isCurrentToolModProcess) {
-        g_toolModProcessMutex =
-            CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
-        if (!g_toolModProcessMutex) {
-            Wh_Log(L"CreateMutex failed");
-            ExitProcess(1);
-        }
-
-        if (GetLastError() == ERROR_ALREADY_EXISTS) {
-            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
-            ExitProcess(1);
-        }
-
-        if (!WhTool_ModInit()) {
-            ExitProcess(1);
-        }
-
-        IMAGE_DOS_HEADER* dosHeader =
-            (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
-        IMAGE_NT_HEADERS* ntHeaders =
-            (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
-
-        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
-        void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
-
-        Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
-        return TRUE;
-    }
-
-    if (isToolModProcess) {
-        return FALSE;
-    }
-
-    g_isToolModProcessLauncher = true;
-    return TRUE;
-}
-
-void Wh_ModAfterInit() {
-    if (!g_isToolModProcessLauncher) {
-        return;
-    }
-
-    WCHAR currentProcessPath[MAX_PATH];
-    switch (GetModuleFileName(nullptr, currentProcessPath,
-                              ARRAYSIZE(currentProcessPath))) {
-        case 0:
-        case ARRAYSIZE(currentProcessPath):
-            Wh_Log(L"GetModuleFileName failed");
-            return;
-    }
-
-    WCHAR
-    commandLine[MAX_PATH + 2 +
-                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
-    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
-               WH_MOD_ID);
-
-    HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
-    if (!kernelModule) {
-        kernelModule = GetModuleHandle(L"kernel32.dll");
-        if (!kernelModule) {
-            Wh_Log(L"No kernelbase.dll/kernel32.dll");
-            return;
-        }
-    }
-
-    using CreateProcessInternalW_t = BOOL(WINAPI*)(
-        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
-        LPSECURITY_ATTRIBUTES lpProcessAttributes,
-        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
-        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
-        LPSTARTUPINFOW lpStartupInfo,
-        LPPROCESS_INFORMATION lpProcessInformation,
-        PHANDLE hRestrictedUserToken);
-    CreateProcessInternalW_t pCreateProcessInternalW =
-        (CreateProcessInternalW_t)GetProcAddress(kernelModule,
-                                                 "CreateProcessInternalW");
-    if (!pCreateProcessInternalW) {
-        Wh_Log(L"No CreateProcessInternalW");
-        return;
-    }
-
-    STARTUPINFO si{
-        .cb = sizeof(STARTUPINFO),
-        .dwFlags = STARTF_FORCEOFFFEEDBACK,
-    };
-    PROCESS_INFORMATION pi;
-    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
-                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
-                                 nullptr, nullptr, &si, &pi, nullptr)) {
-        Wh_Log(L"CreateProcess failed");
-        return;
-    }
-
-    CloseHandle(pi.hProcess);
-    CloseHandle(pi.hThread);
-}
-
-void WhTool_ModSettingsChanged() {
-    if (g_isToolModProcessLauncher) {
-        return;
-    }
-
-    WhTool_ModSettingsChanged();
-}
-
-void WhTool_ModUninit() {
-    if (g_isToolModProcessLauncher) {
-        return;
-    }
-
-    WhTool_ModUninit();
-    ExitProcess(0);
 }

--- a/mods/toggle-hidden-files.wh.cpp
+++ b/mods/toggle-hidden-files.wh.cpp
@@ -6,7 +6,6 @@
 // @author       Asteski
 // @github       https://github.com/Asteski
 // @include      explorer.exe
-// @compilerOptions -std=c++20
 // ==/WindhawkMod==
 
 // ==WindhawkModSettings==

--- a/mods/toggle-hidden-files.wh.cpp
+++ b/mods/toggle-hidden-files.wh.cpp
@@ -49,6 +49,7 @@ This mod allows you to toggle the visibility of hidden files in Windows Explorer
 #include <windows.h>
 #include <shlobj.h>
 #include <shellapi.h>
+#include <stdio.h>
 
 // Settings structure
 struct {

--- a/mods/toggle-hidden-files.wh.cpp
+++ b/mods/toggle-hidden-files.wh.cpp
@@ -5,7 +5,7 @@
 // @version      1.0.0
 // @author       Asteski
 // @github       https://github.com/Asteski
-// @include      explorer.exe
+// @include      windhawk.exe
 // ==/WindhawkMod==
 
 // ==WindhawkModSettings==
@@ -271,7 +271,7 @@ LRESULT CALLBACK KeyboardHookProc(int nCode, WPARAM wParam, LPARAM lParam) {
 }
 
 // Mod initialization
-BOOL Wh_ModInit() {
+BOOL WhTool_ModInit() {
     // Load settings
     LoadSettings();
     
@@ -287,17 +287,196 @@ BOOL Wh_ModInit() {
 }
 
 // Settings changed callback
-void Wh_ModSettingsChanged() {
+void WhTool_ModSettingsChanged() {
     LoadSettings();
 }
 
 // Mod cleanup
-void Wh_ModUninit() {
+void WhTool_ModUninit() {
     g_modEnabled = false;
-    
+
     // Remove keyboard hook
     if (g_hKeyboardHook) {
         UnhookWindowsHookEx(g_hKeyboardHook);
         g_hKeyboardHook = nullptr;
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Windhawk tool mod implementation for mods which don't need to inject to other
+// processes or hook other functions. Context:
+// https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
+//
+// The mod will load and run in a dedicated windhawk.exe process.
+//
+// Paste the code below as part of the mod code, and use these callbacks:
+// * WhTool_ModInit
+// * WhTool_ModSettingsChanged
+// * WhTool_ModUninit
+//
+// Currently, other callbacks are not supported.
+
+bool g_isToolModProcessLauncher;
+HANDLE g_toolModProcessMutex;
+
+void WINAPI EntryPoint_Hook() {
+    Wh_Log(L">");
+    ExitThread(0);
+}
+
+BOOL Wh_ModInit() {
+    DWORD sessionId;
+    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
+        sessionId == 0) {
+        return FALSE;
+    }
+
+    bool isExcluded = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+    int argc;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
+    if (!argv) {
+        Wh_Log(L"CommandLineToArgvW failed");
+        return FALSE;
+    }
+
+    for (int i = 1; i < argc; i++) {
+        if (wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0) {
+            isExcluded = true;
+            break;
+        }
+    }
+
+    for (int i = 1; i < argc - 1; i++) {
+        if (wcscmp(argv[i], L"-tool-mod") == 0) {
+            isToolModProcess = true;
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
+                isCurrentToolModProcess = true;
+            }
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isExcluded) {
+        return FALSE;
+    }
+
+    if (isCurrentToolModProcess) {
+        g_toolModProcessMutex =
+            CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
+        if (!g_toolModProcessMutex) {
+            Wh_Log(L"CreateMutex failed");
+            ExitProcess(1);
+        }
+
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
+            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
+            ExitProcess(1);
+        }
+
+        if (!WhTool_ModInit()) {
+            ExitProcess(1);
+        }
+
+        IMAGE_DOS_HEADER* dosHeader =
+            (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
+        IMAGE_NT_HEADERS* ntHeaders =
+            (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
+
+        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
+        void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
+
+        Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
+        return TRUE;
+    }
+
+    if (isToolModProcess) {
+        return FALSE;
+    }
+
+    g_isToolModProcessLauncher = true;
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (!g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WCHAR currentProcessPath[MAX_PATH];
+    switch (GetModuleFileName(nullptr, currentProcessPath,
+                              ARRAYSIZE(currentProcessPath))) {
+        case 0:
+        case ARRAYSIZE(currentProcessPath):
+            Wh_Log(L"GetModuleFileName failed");
+            return;
+    }
+
+    WCHAR
+    commandLine[MAX_PATH + 2 +
+                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
+    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
+               WH_MOD_ID);
+
+    HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
+    if (!kernelModule) {
+        kernelModule = GetModuleHandle(L"kernel32.dll");
+        if (!kernelModule) {
+            Wh_Log(L"No kernelbase.dll/kernel32.dll");
+            return;
+        }
+    }
+
+    using CreateProcessInternalW_t = BOOL(WINAPI*)(
+        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+        LPSECURITY_ATTRIBUTES lpProcessAttributes,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
+        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
+        LPSTARTUPINFOW lpStartupInfo,
+        LPPROCESS_INFORMATION lpProcessInformation,
+        PHANDLE hRestrictedUserToken);
+    CreateProcessInternalW_t pCreateProcessInternalW =
+        (CreateProcessInternalW_t)GetProcAddress(kernelModule,
+                                                 "CreateProcessInternalW");
+    if (!pCreateProcessInternalW) {
+        Wh_Log(L"No CreateProcessInternalW");
+        return;
+    }
+
+    STARTUPINFO si{
+        .cb = sizeof(STARTUPINFO),
+        .dwFlags = STARTF_FORCEOFFFEEDBACK,
+    };
+    PROCESS_INFORMATION pi;
+    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
+                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
+                                 nullptr, nullptr, &si, &pi, nullptr)) {
+        Wh_Log(L"CreateProcess failed");
+        return;
+    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+}
+
+void Wh_ModSettingsChanged() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModSettingsChanged();
+}
+
+void Wh_ModUninit() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModUninit();
+    ExitProcess(0);
 }

--- a/mods/toggle-hidden-files.wh.cpp
+++ b/mods/toggle-hidden-files.wh.cpp
@@ -1,0 +1,475 @@
+// ==WindhawkMod==
+// @id           toggle-hidden-files
+// @name         Toggle Hidden Files
+// @description  Toggle the visibility of hidden files in Windows Explorer using Ctrl+H
+// @version      1.0.0
+// @author       Asteski
+// @github       https://github.com/Asteski
+// @include      windhawk.exe
+// @compilerOptions -std=c++20
+// ==/WindhawkMod==
+
+// ==WindhawkModSettings==
+/*
+- toggleProtectedFiles: true
+  $name: Also toggle protected OS files
+  $description: When enabled, Ctrl+H will also toggle the visibility of protected operating system files
+*/
+// ==/WindhawkModSettings==
+
+// ==WindhawkModReadme==
+/*
+# Toggle Hidden Files
+
+This mod allows you to toggle the visibility of hidden files in Windows Explorer using the Ctrl+H keyboard shortcut.
+
+## Features
+- Ctrl+H hotkey that works only when Explorer windows are focused
+- Toggles the "Show hidden files" setting
+- Optional: Also toggle protected OS files
+- Automatically refreshes Explorer windows
+- Works with all Windows Explorer windows
+
+## Usage
+1. **Focus an Explorer window** - Click on or open any File Explorer window
+2. **Press Ctrl+H** - Use the keyboard shortcut to toggle hidden files visibility
+3. **The setting will be applied immediately** to all Explorer windows
+
+## Settings
+- **Also toggle protected OS files**: When enabled, Ctrl+H will also show/hide protected operating system files
+
+## Technical Details
+- Only activates when Windows Explorer windows are in focus
+- Modifies the standard registry settings for showing hidden files
+- Sends refresh messages to all Explorer windows
+- Handles proper cleanup when the mod is unloaded
+- Explorer process must be restarted for changes to take effect
+*/
+// ==/WindhawkModReadme==
+
+#include <windows.h>
+#include <shlobj.h>
+#include <shellapi.h>
+
+// Settings structure
+struct {
+    bool toggleProtectedFiles;
+} g_settings;
+
+// Global variables
+HHOOK g_hKeyboardHook = nullptr;
+bool g_modEnabled = false;
+
+// Registry keys and values for hidden files settings
+const wchar_t* EXPLORER_ADVANCED_KEY = L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced";
+const wchar_t* HIDDEN_FILES_VALUE = L"Hidden";
+const wchar_t* SUPER_HIDDEN_VALUE = L"ShowSuperHidden";
+
+const DWORD SHOW_HIDDEN = 1;
+const DWORD HIDE_HIDDEN = 2;
+const DWORD SHOW_SUPER_HIDDEN = 1;
+const DWORD HIDE_SUPER_HIDDEN = 0;
+
+// Window context enumeration
+enum WindowContext {
+    CONTEXT_UNKNOWN = 0,
+    CONTEXT_EXPLORER = 1,
+    CONTEXT_DESKTOP = 2
+};
+
+// Function declarations
+LRESULT CALLBACK KeyboardHookProc(int nCode, WPARAM wParam, LPARAM lParam);
+bool ToggleHiddenFiles();
+bool ToggleProtectedFiles();
+void RefreshAllExplorerWindows();
+bool IsCtrlHPressed(WPARAM wParam, LPARAM lParam);
+void LoadSettings();
+WindowContext GetCurrentWindowContext();
+DWORD GetHiddenFilesSetting();
+bool SetHiddenFilesSetting(DWORD dwValue);
+DWORD GetProtectedFilesSetting();
+bool SetProtectedFilesSetting(DWORD dwValue);
+
+// Get current window context based on focused window
+WindowContext GetCurrentWindowContext() {
+    HWND hForeground = GetForegroundWindow();
+    if (!hForeground) {
+        return CONTEXT_UNKNOWN;
+    }
+    
+    wchar_t className[256];
+    if (GetClassNameW(hForeground, className, sizeof(className) / sizeof(wchar_t)) == 0) {
+        return CONTEXT_UNKNOWN;
+    }
+    
+    // Check for Explorer windows
+    if (wcscmp(className, L"CabinetWClass") == 0 || 
+        wcscmp(className, L"ExploreWClass") == 0) {
+        return CONTEXT_EXPLORER;
+    }
+    
+    // Check for Desktop
+    if (wcscmp(className, L"Progman") == 0 || 
+        wcscmp(className, L"WorkerW") == 0) {
+        return CONTEXT_DESKTOP;
+    }
+    
+    // Also check if it's a desktop child window
+    HWND hDesktop = GetShellWindow();
+    if (hDesktop && (hForeground == hDesktop || IsChild(hDesktop, hForeground))) {
+        return CONTEXT_DESKTOP;
+    }
+    
+    return CONTEXT_UNKNOWN;
+}
+
+// Get current hidden files setting from registry
+DWORD GetHiddenFilesSetting() {
+    HKEY hKey;
+    DWORD dwValue = HIDE_HIDDEN; // Default to hidden
+    DWORD dwSize = sizeof(DWORD);
+    
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, EXPLORER_ADVANCED_KEY, 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
+        RegQueryValueExW(hKey, HIDDEN_FILES_VALUE, nullptr, nullptr, (LPBYTE)&dwValue, &dwSize);
+        RegCloseKey(hKey);
+    }
+    
+    return dwValue;
+}
+
+// Set hidden files setting in registry
+bool SetHiddenFilesSetting(DWORD dwValue) {
+    HKEY hKey;
+    bool success = false;
+    
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, EXPLORER_ADVANCED_KEY, 0, KEY_WRITE, &hKey) == ERROR_SUCCESS) {
+        if (RegSetValueExW(hKey, HIDDEN_FILES_VALUE, 0, REG_DWORD, (LPBYTE)&dwValue, sizeof(DWORD)) == ERROR_SUCCESS) {
+            success = true;
+        }
+        RegCloseKey(hKey);
+    }
+    
+    return success;
+}
+
+// Get current protected files setting from registry
+DWORD GetProtectedFilesSetting() {
+    HKEY hKey;
+    DWORD dwValue = HIDE_SUPER_HIDDEN; // Default to hidden
+    DWORD dwSize = sizeof(DWORD);
+    
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, EXPLORER_ADVANCED_KEY, 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
+        RegQueryValueExW(hKey, SUPER_HIDDEN_VALUE, nullptr, nullptr, (LPBYTE)&dwValue, &dwSize);
+        RegCloseKey(hKey);
+    }
+    
+    return dwValue;
+}
+
+// Set protected files setting in registry
+bool SetProtectedFilesSetting(DWORD dwValue) {
+    HKEY hKey;
+    bool success = false;
+    
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, EXPLORER_ADVANCED_KEY, 0, KEY_WRITE, &hKey) == ERROR_SUCCESS) {
+        if (RegSetValueExW(hKey, SUPER_HIDDEN_VALUE, 0, REG_DWORD, (LPBYTE)&dwValue, sizeof(DWORD)) == ERROR_SUCCESS) {
+            success = true;
+        }
+        RegCloseKey(hKey);
+    }
+    
+    return success;
+}
+
+// Toggle hidden files setting
+bool ToggleHiddenFiles() {
+    DWORD currentSetting = GetHiddenFilesSetting();
+    DWORD newSetting = (currentSetting == SHOW_HIDDEN) ? HIDE_HIDDEN : SHOW_HIDDEN;
+    
+    return SetHiddenFilesSetting(newSetting);
+}
+
+// Toggle protected files setting
+bool ToggleProtectedFiles() {
+    DWORD currentSetting = GetProtectedFilesSetting();
+    DWORD newSetting = (currentSetting == SHOW_SUPER_HIDDEN) ? HIDE_SUPER_HIDDEN : SHOW_SUPER_HIDDEN;
+    
+    return SetProtectedFilesSetting(newSetting);
+}
+
+// Load settings from Windhawk configuration
+void LoadSettings() {
+    // Default values
+    g_settings.toggleProtectedFiles = true;
+}
+
+// Refresh all Explorer windows
+void RefreshAllExplorerWindows() {
+    // Send a message to all windows to refresh their view
+    SendNotifyMessageW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)L"ShellState");
+    
+    // Also try to refresh specifically Explorer windows
+    HWND hWnd = nullptr;
+    while ((hWnd = FindWindowExW(nullptr, hWnd, L"CabinetWClass", nullptr)) != nullptr) {
+        SendNotifyMessageW(hWnd, WM_COMMAND, 41504, 0); // Refresh command
+    }
+    
+    // Also check ExploreWClass windows
+    hWnd = nullptr;
+    while ((hWnd = FindWindowExW(nullptr, hWnd, L"ExploreWClass", nullptr)) != nullptr) {
+        SendNotifyMessageW(hWnd, WM_COMMAND, 41504, 0);
+    }
+    
+    // Refresh desktop as well
+    HWND hDesktop = GetShellWindow();
+    if (hDesktop) {
+        SendNotifyMessageW(hDesktop, WM_COMMAND, 41504, 0);
+    }
+}
+
+// Check if Ctrl+H is pressed
+bool IsCtrlHPressed(WPARAM wParam, LPARAM lParam) {
+    if (wParam != WM_KEYDOWN) {
+        return false;
+    }
+    
+    KBDLLHOOKSTRUCT* pKeyboard = (KBDLLHOOKSTRUCT*)lParam;
+    
+    // Check if 'H' key is pressed
+    if (pKeyboard->vkCode != 'H') {
+        return false;
+    }
+    
+    // Check if Ctrl is pressed
+    return (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
+}
+
+// Keyboard hook procedure
+LRESULT CALLBACK KeyboardHookProc(int nCode, WPARAM wParam, LPARAM lParam) {
+    if (nCode >= 0 && g_modEnabled) {
+        WindowContext context = GetCurrentWindowContext();
+        
+        // Only process if we're in Explorer windows
+        if (context == CONTEXT_EXPLORER && IsCtrlHPressed(wParam, lParam)) {
+            // Toggle hidden files
+            bool success = ToggleHiddenFiles();
+            
+            // Also toggle protected files if setting is enabled
+            if (g_settings.toggleProtectedFiles) {
+                success = ToggleProtectedFiles() && success;
+            }
+            
+            if (success) {
+                RefreshAllExplorerWindows();
+            }
+            
+            // Consume the key press
+            return 1;
+        }
+    }
+    
+    return CallNextHookEx(g_hKeyboardHook, nCode, wParam, lParam);
+}
+
+// Mod initialization
+BOOL WhTool_ModInit() {
+    // Load settings
+    LoadSettings();
+    
+    // Install keyboard hook
+    g_hKeyboardHook = SetWindowsHookExW(WH_KEYBOARD_LL, KeyboardHookProc, GetModuleHandle(nullptr), 0);
+    
+    if (!g_hKeyboardHook) {
+        return FALSE;
+    }
+    
+    g_modEnabled = true;
+    return TRUE;
+}
+
+// Settings changed callback
+void WhTool_ModSettingsChanged() {
+    LoadSettings();
+}
+
+// Mod cleanup
+void WhTool_ModUninit() {
+    g_modEnabled = false;
+    
+    // Remove keyboard hook
+    if (g_hKeyboardHook) {
+        UnhookWindowsHookEx(g_hKeyboardHook);
+        g_hKeyboardHook = nullptr;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Windhawk tool mod implementation for mods which don't need to inject to other
+// processes or hook other functions. Context:
+// https://github.com/ramensoftware/windhawk-mods/pull/1916
+//
+// The mod will load and run in a dedicated windhawk.exe process.
+//
+// Paste the code below as part of the mod code, and use these callbacks:
+// * WhTool_ModInit
+// * WhTool_ModSettingsChanged
+// * WhTool_ModUninit
+//
+// Currently, other callbacks are not supported.
+
+bool g_isToolModProcessLauncher;
+HANDLE g_toolModProcessMutex;
+
+void WINAPI EntryPoint_Hook() {
+    Wh_Log(L">");
+    ExitThread(0);
+}
+
+BOOL WhTool_ModInit() {
+    bool isService = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+    int argc;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
+    if (!argv) {
+        Wh_Log(L"CommandLineToArgvW failed");
+        return FALSE;
+    }
+
+    for (int i = 1; i < argc; i++) {
+        if (wcscmp(argv[i], L"-service") == 0) {
+            isService = true;
+            break;
+        }
+    }
+
+    for (int i = 1; i < argc - 1; i++) {
+        if (wcscmp(argv[i], L"-tool-mod") == 0) {
+            isToolModProcess = true;
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
+                isCurrentToolModProcess = true;
+            }
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isService) {
+        return FALSE;
+    }
+
+    if (isCurrentToolModProcess) {
+        g_toolModProcessMutex =
+            CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
+        if (!g_toolModProcessMutex) {
+            Wh_Log(L"CreateMutex failed");
+            ExitProcess(1);
+        }
+
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
+            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
+            ExitProcess(1);
+        }
+
+        if (!WhTool_ModInit()) {
+            ExitProcess(1);
+        }
+
+        IMAGE_DOS_HEADER* dosHeader =
+            (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
+        IMAGE_NT_HEADERS* ntHeaders =
+            (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
+
+        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
+        void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
+
+        Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
+        return TRUE;
+    }
+
+    if (isToolModProcess) {
+        return FALSE;
+    }
+
+    g_isToolModProcessLauncher = true;
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (!g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WCHAR currentProcessPath[MAX_PATH];
+    switch (GetModuleFileName(nullptr, currentProcessPath,
+                              ARRAYSIZE(currentProcessPath))) {
+        case 0:
+        case ARRAYSIZE(currentProcessPath):
+            Wh_Log(L"GetModuleFileName failed");
+            return;
+    }
+
+    WCHAR
+    commandLine[MAX_PATH + 2 +
+                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
+    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
+               WH_MOD_ID);
+
+    HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
+    if (!kernelModule) {
+        kernelModule = GetModuleHandle(L"kernel32.dll");
+        if (!kernelModule) {
+            Wh_Log(L"No kernelbase.dll/kernel32.dll");
+            return;
+        }
+    }
+
+    using CreateProcessInternalW_t = BOOL(WINAPI*)(
+        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+        LPSECURITY_ATTRIBUTES lpProcessAttributes,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
+        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
+        LPSTARTUPINFOW lpStartupInfo,
+        LPPROCESS_INFORMATION lpProcessInformation,
+        PHANDLE hRestrictedUserToken);
+    CreateProcessInternalW_t pCreateProcessInternalW =
+        (CreateProcessInternalW_t)GetProcAddress(kernelModule,
+                                                 "CreateProcessInternalW");
+    if (!pCreateProcessInternalW) {
+        Wh_Log(L"No CreateProcessInternalW");
+        return;
+    }
+
+    STARTUPINFO si{
+        .cb = sizeof(STARTUPINFO),
+        .dwFlags = STARTF_FORCEOFFFEEDBACK,
+    };
+    PROCESS_INFORMATION pi;
+    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
+                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
+                                 nullptr, nullptr, &si, &pi, nullptr)) {
+        Wh_Log(L"CreateProcess failed");
+        return;
+    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+}
+
+void WhTool_ModSettingsChanged() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModSettingsChanged();
+}
+
+void WhTool_ModUninit() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModUninit();
+    ExitProcess(0);
+}

--- a/mods/toggle-hidden-files.wh.cpp
+++ b/mods/toggle-hidden-files.wh.cpp
@@ -59,6 +59,8 @@ struct {
 // Global variables
 HHOOK g_hKeyboardHook = nullptr;
 bool g_modEnabled = false;
+HANDLE g_hHookThread = nullptr;
+DWORD g_hookThreadId = 0;
 
 // Registry keys and values for hidden files settings
 const wchar_t* EXPLORER_ADVANCED_KEY = L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced";
@@ -271,19 +273,43 @@ LRESULT CALLBACK KeyboardHookProc(int nCode, WPARAM wParam, LPARAM lParam) {
     return CallNextHookEx(g_hKeyboardHook, nCode, wParam, lParam);
 }
 
+// Low-level keyboard hooks only deliver callbacks to a thread that runs a
+// message loop. In the dedicated windhawk.exe tool process the main thread
+// exits after init, so the hook is installed on this dedicated thread which
+// owns the message pump for its lifetime.
+DWORD WINAPI HookThreadProc(LPVOID lpParameter) {
+    g_hKeyboardHook = SetWindowsHookExW(WH_KEYBOARD_LL, KeyboardHookProc,
+                                        GetModuleHandle(nullptr), 0);
+    if (!g_hKeyboardHook) {
+        return 1;
+    }
+
+    MSG msg;
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    UnhookWindowsHookEx(g_hKeyboardHook);
+    g_hKeyboardHook = nullptr;
+    return 0;
+}
+
 // Mod initialization
 BOOL WhTool_ModInit() {
     // Load settings
     LoadSettings();
-    
-    // Install keyboard hook
-    g_hKeyboardHook = SetWindowsHookExW(WH_KEYBOARD_LL, KeyboardHookProc, GetModuleHandle(nullptr), 0);
-    
-    if (!g_hKeyboardHook) {
+
+    g_modEnabled = true;
+
+    // Install the keyboard hook on a dedicated thread with a message loop.
+    g_hHookThread =
+        CreateThread(nullptr, 0, HookThreadProc, nullptr, 0, &g_hookThreadId);
+    if (!g_hHookThread) {
+        g_modEnabled = false;
         return FALSE;
     }
-    
-    g_modEnabled = true;
+
     return TRUE;
 }
 
@@ -296,10 +322,14 @@ void WhTool_ModSettingsChanged() {
 void WhTool_ModUninit() {
     g_modEnabled = false;
 
-    // Remove keyboard hook
-    if (g_hKeyboardHook) {
-        UnhookWindowsHookEx(g_hKeyboardHook);
-        g_hKeyboardHook = nullptr;
+    // Signal the hook thread to exit its message loop, then wait for it to
+    // unhook and finish.
+    if (g_hHookThread) {
+        PostThreadMessageW(g_hookThreadId, WM_QUIT, 0, 0);
+        WaitForSingleObject(g_hHookThread, INFINITE);
+        CloseHandle(g_hHookThread);
+        g_hHookThread = nullptr;
+        g_hookThreadId = 0;
     }
 }
 

--- a/mods/toggle-hidden-files.wh.cpp
+++ b/mods/toggle-hidden-files.wh.cpp
@@ -26,7 +26,7 @@ This mod allows you to toggle the visibility of hidden files in Windows Explorer
 - Ctrl+H hotkey that works only when Explorer windows are focused
 - Toggles the "Show hidden files" setting
 - Optional: Also toggle protected OS files
-- Automatically refreshes Explorer windows
+- Applies changes immediately to Explorer windows
 - Works with all Windows Explorer windows
 
 ## Usage
@@ -39,10 +39,10 @@ This mod allows you to toggle the visibility of hidden files in Windows Explorer
 
 ## Technical Details
 - Only activates when Windows Explorer windows are in focus
-- Modifies the standard registry settings for showing hidden files
-- Sends refresh messages to all Explorer windows
+- Queues toggle work to a worker thread to keep input handling responsive
+- Uses Windows shell APIs to update hidden-file visibility live
+- Notifies the shell to refresh views after toggling
 - Handles proper cleanup when the mod is unloaded
-- Explorer process must be restarted for changes to take effect
 */
 // ==/WindhawkModReadme==
 
@@ -58,37 +58,27 @@ struct {
 
 // Global variables
 HHOOK g_hKeyboardHook = nullptr;
-bool g_modEnabled = false;
+HANDLE g_hookThread = nullptr;
+DWORD g_hookThreadId = 0;
+HANDLE g_hookThreadReadyEvent = nullptr;
+bool g_hookInstallSucceeded = false;
 
-// Registry keys and values for hidden files settings
-const wchar_t* EXPLORER_ADVANCED_KEY = L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced";
-const wchar_t* HIDDEN_FILES_VALUE = L"Hidden";
-const wchar_t* SUPER_HIDDEN_VALUE = L"ShowSuperHidden";
+constexpr UINT WM_APP_TOGGLE_HIDDEN_FILES = WM_APP + 1;
 
-const DWORD SHOW_HIDDEN = 1;
-const DWORD HIDE_HIDDEN = 2;
-const DWORD SHOW_SUPER_HIDDEN = 1;
-const DWORD HIDE_SUPER_HIDDEN = 0;
 
 // Window context enumeration
 enum WindowContext {
     CONTEXT_UNKNOWN = 0,
-    CONTEXT_EXPLORER = 1,
-    CONTEXT_DESKTOP = 2
+    CONTEXT_EXPLORER = 1
 };
 
 // Function declarations
 LRESULT CALLBACK KeyboardHookProc(int nCode, WPARAM wParam, LPARAM lParam);
-bool ToggleHiddenFiles();
-bool ToggleProtectedFiles();
-void RefreshAllExplorerWindows();
+DWORD WINAPI HookThreadProc(LPVOID lpParameter);
+bool ToggleHiddenFilesInShellState();
 bool IsCtrlHPressed(WPARAM wParam, LPARAM lParam);
 void LoadSettings();
 WindowContext GetCurrentWindowContext();
-DWORD GetHiddenFilesSetting();
-bool SetHiddenFilesSetting(DWORD dwValue);
-DWORD GetProtectedFilesSetting();
-bool SetProtectedFilesSetting(DWORD dwValue);
 
 // Get current window context based on focused window
 WindowContext GetCurrentWindowContext() {
@@ -108,123 +98,33 @@ WindowContext GetCurrentWindowContext() {
         return CONTEXT_EXPLORER;
     }
     
-    // Check for Desktop
-    if (wcscmp(className, L"Progman") == 0 || 
-        wcscmp(className, L"WorkerW") == 0) {
-        return CONTEXT_DESKTOP;
-    }
-    
-    // Also check if it's a desktop child window
-    HWND hDesktop = GetShellWindow();
-    if (hDesktop && (hForeground == hDesktop || IsChild(hDesktop, hForeground))) {
-        return CONTEXT_DESKTOP;
-    }
-    
     return CONTEXT_UNKNOWN;
 }
 
-// Get current hidden files setting from registry
-DWORD GetHiddenFilesSetting() {
-    HKEY hKey;
-    DWORD dwValue = HIDE_HIDDEN; // Default to hidden
-    DWORD dwSize = sizeof(DWORD);
-    
-    if (RegOpenKeyExW(HKEY_CURRENT_USER, EXPLORER_ADVANCED_KEY, 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-        RegQueryValueExW(hKey, HIDDEN_FILES_VALUE, nullptr, nullptr, (LPBYTE)&dwValue, &dwSize);
-        RegCloseKey(hKey);
+// Toggle hidden files visibility using the shell state API.
+bool ToggleHiddenFilesInShellState() {
+    SHELLSTATE shellState{};
+    constexpr DWORD kReadMask = SSF_SHOWALLOBJECTS | SSF_SHOWSUPERHIDDEN;
+
+    SHGetSetSettings(&shellState, kReadMask, FALSE);
+
+    shellState.fShowAllObjects = !shellState.fShowAllObjects;
+
+    DWORD writeMask = SSF_SHOWALLOBJECTS;
+    if (g_settings.toggleProtectedFiles) {
+        shellState.fShowSuperHidden = !shellState.fShowSuperHidden;
+        writeMask |= SSF_SHOWSUPERHIDDEN;
     }
-    
-    return dwValue;
-}
 
-// Set hidden files setting in registry
-bool SetHiddenFilesSetting(DWORD dwValue) {
-    HKEY hKey;
-    bool success = false;
-    
-    if (RegOpenKeyExW(HKEY_CURRENT_USER, EXPLORER_ADVANCED_KEY, 0, KEY_WRITE, &hKey) == ERROR_SUCCESS) {
-        if (RegSetValueExW(hKey, HIDDEN_FILES_VALUE, 0, REG_DWORD, (LPBYTE)&dwValue, sizeof(DWORD)) == ERROR_SUCCESS) {
-            success = true;
-        }
-        RegCloseKey(hKey);
-    }
-    
-    return success;
-}
-
-// Get current protected files setting from registry
-DWORD GetProtectedFilesSetting() {
-    HKEY hKey;
-    DWORD dwValue = HIDE_SUPER_HIDDEN; // Default to hidden
-    DWORD dwSize = sizeof(DWORD);
-    
-    if (RegOpenKeyExW(HKEY_CURRENT_USER, EXPLORER_ADVANCED_KEY, 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
-        RegQueryValueExW(hKey, SUPER_HIDDEN_VALUE, nullptr, nullptr, (LPBYTE)&dwValue, &dwSize);
-        RegCloseKey(hKey);
-    }
-    
-    return dwValue;
-}
-
-// Set protected files setting in registry
-bool SetProtectedFilesSetting(DWORD dwValue) {
-    HKEY hKey;
-    bool success = false;
-    
-    if (RegOpenKeyExW(HKEY_CURRENT_USER, EXPLORER_ADVANCED_KEY, 0, KEY_WRITE, &hKey) == ERROR_SUCCESS) {
-        if (RegSetValueExW(hKey, SUPER_HIDDEN_VALUE, 0, REG_DWORD, (LPBYTE)&dwValue, sizeof(DWORD)) == ERROR_SUCCESS) {
-            success = true;
-        }
-        RegCloseKey(hKey);
-    }
-    
-    return success;
-}
-
-// Toggle hidden files setting
-bool ToggleHiddenFiles() {
-    DWORD currentSetting = GetHiddenFilesSetting();
-    DWORD newSetting = (currentSetting == SHOW_HIDDEN) ? HIDE_HIDDEN : SHOW_HIDDEN;
-    
-    return SetHiddenFilesSetting(newSetting);
-}
-
-// Toggle protected files setting
-bool ToggleProtectedFiles() {
-    DWORD currentSetting = GetProtectedFilesSetting();
-    DWORD newSetting = (currentSetting == SHOW_SUPER_HIDDEN) ? HIDE_SUPER_HIDDEN : SHOW_SUPER_HIDDEN;
-    
-    return SetProtectedFilesSetting(newSetting);
+    SHGetSetSettings(&shellState, writeMask, TRUE);
+    SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
+    return true;
 }
 
 // Load settings from Windhawk configuration
 void LoadSettings() {
-    // Default values
-    g_settings.toggleProtectedFiles = true;
-}
-
-// Refresh all Explorer windows
-void RefreshAllExplorerWindows() {
-    // Send a message to all windows to refresh their view
-    SendNotifyMessageW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)L"ShellState");
-    
-    // Also try to refresh specifically Explorer windows
-    HWND hWnd = nullptr;
-    while ((hWnd = FindWindowExW(nullptr, hWnd, L"CabinetWClass", nullptr)) != nullptr) {
-        SendNotifyMessageW(hWnd, WM_COMMAND, 41504, 0); // Refresh command
-    }
-    
-    // Also check ExploreWClass windows
-    hWnd = nullptr;
-    while ((hWnd = FindWindowExW(nullptr, hWnd, L"ExploreWClass", nullptr)) != nullptr) {
-        SendNotifyMessageW(hWnd, WM_COMMAND, 41504, 0);
-    }
-    
-    // Refresh desktop as well
-    HWND hDesktop = GetShellWindow();
-    if (hDesktop) {
-        SendNotifyMessageW(hDesktop, WM_COMMAND, 41504, 0);
-    }
+    g_settings.toggleProtectedFiles =
+        Wh_GetIntSetting(L"toggleProtectedFiles") != 0;
 }
 
 // Check if Ctrl+H is pressed
@@ -240,27 +140,56 @@ bool IsCtrlHPressed(WPARAM wParam, LPARAM lParam) {
         return false;
     }
     
-    // Check if Ctrl is pressed
-    return (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
+    const bool ctrlPressed = (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
+    const bool shiftPressed = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
+    const bool altPressed = (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
+    const bool winPressed = (GetAsyncKeyState(VK_LWIN) & 0x8000) != 0 ||
+                            (GetAsyncKeyState(VK_RWIN) & 0x8000) != 0;
+
+    // Require Ctrl-only to avoid clobbering combinations like Ctrl+Shift+H.
+    return ctrlPressed && !shiftPressed && !altPressed && !winPressed;
+}
+
+DWORD WINAPI HookThreadProc(LPVOID) {
+    MSG msg;
+
+    // Ensure the message queue exists before hooks/messages are used.
+    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+
+    g_hKeyboardHook = SetWindowsHookExW(WH_KEYBOARD_LL, KeyboardHookProc,
+                                        nullptr, 0);
+    g_hookInstallSucceeded = g_hKeyboardHook != nullptr;
+
+    if (g_hookThreadReadyEvent) {
+        SetEvent(g_hookThreadReadyEvent);
+    }
+
+    if (!g_hookInstallSucceeded) {
+        return 0;
+    }
+
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        if (msg.message == WM_APP_TOGGLE_HIDDEN_FILES) {
+            ToggleHiddenFilesInShellState();
+        }
+    }
+
+    UnhookWindowsHookEx(g_hKeyboardHook);
+    g_hKeyboardHook = nullptr;
+
+    return 0;
 }
 
 // Keyboard hook procedure
 LRESULT CALLBACK KeyboardHookProc(int nCode, WPARAM wParam, LPARAM lParam) {
-    if (nCode >= 0 && g_modEnabled) {
+    if (nCode >= 0) {
         WindowContext context = GetCurrentWindowContext();
         
         // Only process if we're in Explorer windows
         if (context == CONTEXT_EXPLORER && IsCtrlHPressed(wParam, lParam)) {
-            // Toggle hidden files
-            bool success = ToggleHiddenFiles();
-            
-            // Also toggle protected files if setting is enabled
-            if (g_settings.toggleProtectedFiles) {
-                success = ToggleProtectedFiles() && success;
-            }
-            
-            if (success) {
-                RefreshAllExplorerWindows();
+            if (g_hookThreadId != 0) {
+                PostThreadMessageW(g_hookThreadId, WM_APP_TOGGLE_HIDDEN_FILES,
+                                   0, 0);
             }
             
             // Consume the key press
@@ -275,15 +204,39 @@ LRESULT CALLBACK KeyboardHookProc(int nCode, WPARAM wParam, LPARAM lParam) {
 BOOL WhTool_ModInit() {
     // Load settings
     LoadSettings();
-    
-    // Install keyboard hook
-    g_hKeyboardHook = SetWindowsHookExW(WH_KEYBOARD_LL, KeyboardHookProc, GetModuleHandle(nullptr), 0);
-    
-    if (!g_hKeyboardHook) {
+
+    g_hookThreadReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (!g_hookThreadReadyEvent) {
         return FALSE;
     }
-    
-    g_modEnabled = true;
+
+    g_hookInstallSucceeded = false;
+    g_hookThread = CreateThread(nullptr, 0, HookThreadProc, nullptr, 0,
+                                &g_hookThreadId);
+    if (!g_hookThread) {
+        CloseHandle(g_hookThreadReadyEvent);
+        g_hookThreadReadyEvent = nullptr;
+        g_hookThreadId = 0;
+        return FALSE;
+    }
+
+    if (WaitForSingleObject(g_hookThreadReadyEvent, 5000) != WAIT_OBJECT_0 ||
+        !g_hookInstallSucceeded) {
+        if (g_hookThreadId != 0) {
+            PostThreadMessageW(g_hookThreadId, WM_QUIT, 0, 0);
+        }
+        WaitForSingleObject(g_hookThread, 5000);
+        CloseHandle(g_hookThread);
+        g_hookThread = nullptr;
+        g_hookThreadId = 0;
+        CloseHandle(g_hookThreadReadyEvent);
+        g_hookThreadReadyEvent = nullptr;
+        return FALSE;
+    }
+
+    CloseHandle(g_hookThreadReadyEvent);
+    g_hookThreadReadyEvent = nullptr;
+
     return TRUE;
 }
 
@@ -294,12 +247,21 @@ void WhTool_ModSettingsChanged() {
 
 // Mod cleanup
 void WhTool_ModUninit() {
-    g_modEnabled = false;
+    if (g_hookThreadId != 0) {
+        PostThreadMessageW(g_hookThreadId, WM_QUIT, 0, 0);
+    }
 
-    // Remove keyboard hook
-    if (g_hKeyboardHook) {
-        UnhookWindowsHookEx(g_hKeyboardHook);
-        g_hKeyboardHook = nullptr;
+    if (g_hookThread) {
+        WaitForSingleObject(g_hookThread, 5000);
+        CloseHandle(g_hookThread);
+        g_hookThread = nullptr;
+    }
+
+    g_hookThreadId = 0;
+
+    if (g_hookThreadReadyEvent) {
+        CloseHandle(g_hookThreadReadyEvent);
+        g_hookThreadReadyEvent = nullptr;
     }
 }
 
@@ -436,7 +398,7 @@ void Wh_ModAfterInit() {
     using CreateProcessInternalW_t = BOOL(WINAPI*)(
         HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
         LPSECURITY_ATTRIBUTES lpProcessAttributes,
-        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, BOOL bInheritHandles,
         DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
         LPSTARTUPINFOW lpStartupInfo,
         LPPROCESS_INFORMATION lpProcessInformation,

--- a/mods/toggle-hidden-files.wh.cpp
+++ b/mods/toggle-hidden-files.wh.cpp
@@ -22,6 +22,8 @@
 
 This mod allows you to toggle the visibility of hidden files in Windows Explorer using the Ctrl+H keyboard shortcut.
 
+![toggle-hidden-files-gif](https://raw.githubusercontent.com/Asteski/Windhawk-Mods/refs/heads/main/img/toggle-hidden-files/toggle-hidden-files.gif)
+
 ## Features
 - Ctrl+H hotkey that works only when Explorer windows are focused
 - Toggles the "Show hidden files" setting


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

### Toggle Hidden Files

This mod allows you to toggle the visibility of hidden files in Windows Explorer using the Ctrl+H keyboard shortcut.

## Features
- Ctrl+H hotkey that works only when Explorer windows are focused
- Toggles the "Show hidden files" setting
- Optional: Also toggle protected OS files
- Automatically refreshes Explorer windows
- Works with all Windows Explorer windows

## Usage
1. **Focus an Explorer window** - Click on or open any File Explorer window
2. **Press Ctrl+H** - Use the keyboard shortcut to toggle hidden files visibility
3. **The setting will be applied immediately** to all Explorer windows

## Settings
- **Also toggle protected OS files**: When enabled, Ctrl+H will also show/hide protected operating system files

## Technical Details
- Only activates when Windows Explorer windows are in focus
- Modifies the standard registry settings for showing hidden files
- Sends refresh messages to all Explorer windows
- Handles proper cleanup when the mod is unloaded
- Explorer process must be restarted for changes to take effect

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [x] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
