### PR TITLE
Update zen-desktop-toggle-icons to v3.4.0

### DIFF
--- a/mods/zen-desktop-toggle-icons.wh.cpp
+++ b/mods/zen-desktop-toggle-icons.wh.cpp
@@ -2,7 +2,7 @@
 // @id              zen-desktop-toggle-icons
 // @name            ZenDesktop: Double Click to Hide Icons
 // @description     Native C++ Windhawk mod to hide/show desktop icons by double-clicking. Auto-hides on system-wide inactivity and restores on any user input.
-// @version         3.0.0
+// @version         3.2.0
 // @author          Lanbo
 // @github          https://github.com/Liset999
 // @include         explorer.exe
@@ -499,7 +499,7 @@ LRESULT CALLBACK DesktopShellViewSubclassProc(
 // ─────────────────────────────────────────────────────────────────────────────
 BOOL Wh_ModInit()
 {
-    Wh_Log(L"[ZenDesktop] === Wh_ModInit v3.0.0 ===");
+    Wh_Log(L"[ZenDesktop] === Wh_ModInit v3.2.0 ===");
     LoadSettings();
 
     if (!Wh_SetFunctionHook(

--- a/mods/zen-desktop-toggle-icons.wh.cpp
+++ b/mods/zen-desktop-toggle-icons.wh.cpp
@@ -1,18 +1,18 @@
 // ==WindhawkMod==
 // @id              zen-desktop-toggle-icons
-// @name            ZenDesktop: Double Click to Hide Icons
-// @description     Native C++ Windhawk mod to hide/show desktop icons by double-clicking. Auto-hides on system-wide inactivity and restores on any user input.
-// @version         3.2.0
+// @name            ZenDesktop: Desktop Icon Toggle and Auto-Hide
+// @description     Native C++ Windhawk mod to hide/show desktop icons by double-clicking, with optional inactivity-based auto-hide and restore.
+// @version         3.4.0
 // @author          Lanbo
 // @github          https://github.com/Liset999
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject
+// @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject -lshell32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
 /*
-# ZenDesktop: Double Click to Hide Icons
+# ZenDesktop: Desktop Icon Toggle and Auto-Hide
 
 Have you ever wanted a clean, clutter-free desktop but found it annoying to right-click -> View -> Show desktop icons every time? 
 
@@ -25,33 +25,45 @@ Have you ever wanted a clean, clutter-free desktop but found it annoying to righ
 * **Smart Auto-Restore**: When icons are auto-hidden, any user input (mouse or keyboard anywhere) instantly restores them. Manually hidden icons are never auto-restored.
 * **Dynamic Hooking**: Automatically subclasses the shell views, meaning even if your Explorer crashes, restarts, or you plug/unplug monitors, the mod remains fully active and stable.
 * **Completely Safe**: Uses native Windows `0x7402` (WM_COMMAND) toggle signals, ensuring Windows handles the fade animations and desktop state natively without breaking icon grid arrangements.
+
+This mod focuses on desktop icons. If you want a similar inactivity effect for the taskbar, see the Taskbar Fade mod.
 */
 // ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
 /*
 - enableAutoHide: true
-  $name: "Auto-Hide Icons on Inactivity (自动隐藏)"
+  $name: Auto-Hide Icons on Inactivity
+  $name:zh-CN: 自动隐藏空闲桌面图标
   $description: "Automatically hides desktop icons after the system has been idle for the specified duration."
+  $description:zh-CN: "系统空闲达到指定时长后自动隐藏桌面图标。"
 - autoHideDelay: 5
-  $name: "Auto-Hide Delay in Seconds (延迟秒数)"
+  $name: Auto-Hide Delay in Seconds
+  $name:zh-CN: 自动隐藏延迟秒数
   $description: "Seconds of system-wide inactivity before icons are hidden. Range: 3–60 seconds."
+  $description:zh-CN: "桌面图标自动隐藏前的全局空闲秒数，范围为 3 到 60 秒。"
 - showIconsOnAnyInput: true
-  $name: "Restore Icons on Any Input (任意输入恢复)"
+  $name: Restore Icons on Any Input
+  $name:zh-CN: 任意输入时恢复图标
   $description: "When icons were auto-hidden, any mouse or keyboard input instantly restores them. Does NOT affect manually hidden icons."
+  $description:zh-CN: "图标由自动隐藏触发时，任意鼠标或键盘输入都会恢复图标；不影响手动隐藏的图标。"
 */
 // ==/WindhawkModSettings==
 
 #include <windows.h>
 #include <windowsx.h>
 #include <commctrl.h>
+#include <shellapi.h>
 #include <windhawk_utils.h>
 
-#define TIMER_AUTOHIDE   1001
-#define WM_REFRESH_TIMER (WM_USER + 5001)
-#define WM_MANUAL_TOGGLE (WM_USER + 5002)
-#define WM_AUTO_HIDE     (WM_USER + 5003)
-#define WM_AUTO_RESTORE  (WM_USER + 5004)
+#define TIMER_AUTOHIDE             1001
+#define TIMER_RESTORE_POLL_MS       500
+#define TIMER_FULLSCREEN_RECHECK_MS 1000
+
+static UINT g_msgRefreshTimer = 0;
+static UINT g_msgManualToggle = 0;
+static UINT g_msgAutoHide = 0;
+static UINT g_msgAutoRestore = 0;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Forward declarations
@@ -88,13 +100,71 @@ static void LoadSettings()
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Timer management — post WM_REFRESH_TIMER to SHELLDLL_DefView so the timer
+// Timer management — post a registered refresh message to SHELLDLL_DefView so the timer
 // is always created/destroyed on the window-owning thread.
 // ─────────────────────────────────────────────────────────────────────────────
+static void ClearAutoHideTimer(HWND hwndShell)
+{
+    KillTimer(hwndShell, TIMER_AUTOHIDE);
+    RemovePropW(hwndShell, L"ZenTimerInit");
+}
+
+static bool SetAutoHideTimer(HWND hwndShell, UINT intervalMs)
+{
+    if (intervalMs == 0)
+        intervalMs = 1;
+
+    if (SetTimer(hwndShell, TIMER_AUTOHIDE, intervalMs, NULL)) {
+        SetPropW(hwndShell, L"ZenTimerInit", UlongToHandle(1));
+        return true;
+    }
+
+    ClearAutoHideTimer(hwndShell);
+    return false;
+}
+
+static void ScheduleAutoHideTimer(HWND hwndShell)
+{
+    if (!hwndShell || !g_settings.enableAutoHide) {
+        if (hwndShell)
+            ClearAutoHideTimer(hwndShell);
+        return;
+    }
+
+    HWND hwndListView = FindWindowExW(hwndShell, NULL, L"SysListView32", NULL);
+    if (!hwndListView) {
+        ClearAutoHideTimer(hwndShell);
+        return;
+    }
+
+    bool isVisible = IsWindowVisible(hwndListView) != 0;
+    if (isVisible) {
+        LASTINPUTINFO lii = { sizeof(LASTINPUTINFO) };
+        if (!GetLastInputInfo(&lii)) {
+            SetAutoHideTimer(hwndShell, TIMER_FULLSCREEN_RECHECK_MS);
+            return;
+        }
+
+        DWORD now = GetTickCount();
+        DWORD idleMs = now - lii.dwTime;
+        DWORD thresholdMs = (DWORD)g_settings.autoHideDelay * 1000;
+        DWORD intervalMs = idleMs >= thresholdMs ? 1 : thresholdMs - idleMs;
+        SetAutoHideTimer(hwndShell, intervalMs);
+        return;
+    }
+
+    DWORD autoHiddenAt = HandleToUlong(GetPropW(hwndShell, L"ZenAutoHiddenAt"));
+    if (autoHiddenAt != 0 && g_settings.showIconsOnAnyInput) {
+        SetAutoHideTimer(hwndShell, TIMER_RESTORE_POLL_MS);
+    } else {
+        ClearAutoHideTimer(hwndShell);
+    }
+}
+
 static void UpdateTimerState(HWND hwndShell)
 {
-    if (hwndShell)
-        PostMessageW(hwndShell, WM_REFRESH_TIMER, 0, 0);
+    if (hwndShell && g_msgRefreshTimer)
+        PostMessageW(hwndShell, g_msgRefreshTimer, 0, 0);
 }
 
 static void UpdateAllTimers()
@@ -116,23 +186,18 @@ static void UpdateAllTimers()
 // ─────────────────────────────────────────────────────────────────────────────
 static bool IsFullscreenWindowActive()
 {
-    HWND hwndForeground = GetForegroundWindow();
-    if (hwndForeground && hwndForeground != GetDesktopWindow()) {
-        WCHAR className[256] = {};
-        if (GetClassNameW(hwndForeground, className, 256)) {
-            // Exclude desktop manager windows
-            if (wcscmp(className, L"Progman") != 0 && wcscmp(className, L"WorkerW") != 0) {
-                RECT rect;
-                if (GetWindowRect(hwndForeground, &rect)) {
-                    int screenWidth = GetSystemMetrics(SM_CXSCREEN);
-                    int screenHeight = GetSystemMetrics(SM_CYSCREEN);
-                    if (rect.left <= 0 && rect.top <= 0 && rect.right >= screenWidth && rect.bottom >= screenHeight) {
-                        return true;
-                    }
-                }
-            }
-        }
+    QUERY_USER_NOTIFICATION_STATE state;
+    if (FAILED(SHQueryUserNotificationState(&state))) {
+        return false;
     }
+
+    switch (state) {
+        case QUNS_NOT_PRESENT:
+        case QUNS_BUSY:
+        case QUNS_RUNNING_D3D_FULL_SCREEN:
+            return true;
+    }
+
     return false;
 }
 
@@ -162,6 +227,7 @@ static void ManualToggleIcons(HWND hwndShellView)
     RemovePropW(hwndShellView, L"ZenAutoHiddenAt");
     RemovePropW(hwndShellView, L"ZenMouseX");
     RemovePropW(hwndShellView, L"ZenMouseY");
+    ScheduleAutoHideTimer(hwndShellView);
 }
 
 static void AutoHideIcons(HWND hwndShellView)
@@ -182,6 +248,7 @@ static void AutoHideIcons(HWND hwndShellView)
 
         Wh_Log(L"[ZenDesktop] AutoHide: icons hidden at tick=%u, mouse=(%d,%d)", now, pt.x, pt.y);
     }
+    ScheduleAutoHideTimer(hwndShellView);
 }
 
 static void AutoRestoreIcons(HWND hwndShellView)
@@ -194,6 +261,7 @@ static void AutoRestoreIcons(HWND hwndShellView)
     RemovePropW(hwndShellView, L"ZenAutoHiddenAt");
     RemovePropW(hwndShellView, L"ZenMouseX");
     RemovePropW(hwndShellView, L"ZenMouseY");
+    ScheduleAutoHideTimer(hwndShellView);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -334,7 +402,7 @@ LRESULT CALLBACK DesktopListViewSubclassProc(
                 // Empty space — post manual toggle command asynchronously
                 HWND hwndParent = GetParent(hWnd);
                 if (hwndParent) {
-                    PostMessageW(hwndParent, WM_MANUAL_TOGGLE, 0, 0);
+                    PostMessageW(hwndParent, g_msgManualToggle, 0, 0);
                 }
                 return 0; // suppress default double-click action
             }
@@ -348,7 +416,7 @@ LRESULT CALLBACK DesktopListViewSubclassProc(
 // Subclass Proc: SHELLDLL_DefView
 //   Receives events when icons are HIDDEN (ListView hidden → DefView is hit).
 //   Responsibilities:
-//     • Run the 500 ms auto-hide/restore polling timer.
+//     • Run the dynamically scheduled auto-hide/restore timer.
 //     • Immediate restore on mouse move over desktop (when icons are auto-hidden).
 //     • Immediate restore on click on desktop (when icons are auto-hidden).
 //     • Double-click restore (always works, including manually hidden icons).
@@ -359,52 +427,50 @@ LRESULT CALLBACK DesktopShellViewSubclassProc(
     // ── One-time timer bootstrap ─────────────────────────────────────────────
     bool timerInitialized = GetPropW(hWnd, L"ZenTimerInit") != NULL;
     if (!timerInitialized && g_settings.enableAutoHide) {
-        if (SetTimer(hWnd, TIMER_AUTOHIDE, 500, NULL)) {
-            SetPropW(hWnd, L"ZenTimerInit", (HANDLE)1);
-            Wh_Log(L"[ZenDesktop] Timer bootstrapped for ShellView=%p", hWnd);
-        }
+        ScheduleAutoHideTimer(hWnd);
     }
 
     // ── Cross-thread timer refresh (settings change / new window subclassed) ──
-    if (uMsg == WM_REFRESH_TIMER) {
-        if (g_settings.enableAutoHide) {
-            if (SetTimer(hWnd, TIMER_AUTOHIDE, 500, NULL)) {
-                SetPropW(hWnd, L"ZenTimerInit", (HANDLE)1);
-                Wh_Log(L"[ZenDesktop] Timer refreshed (ON) for ShellView=%p", hWnd);
-            }
-        } else {
-            KillTimer(hWnd, TIMER_AUTOHIDE);
-            RemovePropW(hWnd, L"ZenTimerInit");
-            Wh_Log(L"[ZenDesktop] Timer killed (OFF) for ShellView=%p", hWnd);
-        }
+    if (uMsg == g_msgRefreshTimer) {
+        ScheduleAutoHideTimer(hWnd);
+        Wh_Log(L"[ZenDesktop] Timer refreshed for ShellView=%p", hWnd);
         return 0;
     }
 
     // ── Async Operations execution ───────────────────────────────────────────
-    if (uMsg == WM_MANUAL_TOGGLE) {
+    if (uMsg == g_msgManualToggle) {
         ManualToggleIcons(hWnd);
         return 0;
     }
-    if (uMsg == WM_AUTO_HIDE) {
+    if (uMsg == g_msgAutoHide) {
         AutoHideIcons(hWnd);
         return 0;
     }
-    if (uMsg == WM_AUTO_RESTORE) {
+    if (uMsg == g_msgAutoRestore) {
         AutoRestoreIcons(hWnd);
         return 0;
     }
 
-    // ── Auto-hide / auto-restore timer tick (every 500 ms) ───────────────────
+    // ── Auto-hide / auto-restore timer tick ──────────────────────────────────
     if (uMsg == WM_TIMER && wParam == TIMER_AUTOHIDE) {
-        if (!g_settings.enableAutoHide) return 0;
+        if (!g_settings.enableAutoHide) {
+            ScheduleAutoHideTimer(hWnd);
+            return 0;
+        }
 
         HWND hwndListView = FindWindowExW(hWnd, NULL, L"SysListView32", NULL);
-        if (!hwndListView) return 0;
+        if (!hwndListView) {
+            ScheduleAutoHideTimer(hWnd);
+            return 0;
+        }
 
         bool isVis = IsWindowVisible(hwndListView) != 0;
 
         LASTINPUTINFO lii = { sizeof(LASTINPUTINFO) };
-        if (!GetLastInputInfo(&lii)) return 0;
+        if (!GetLastInputInfo(&lii)) {
+            ScheduleAutoHideTimer(hWnd);
+            return 0;
+        }
         DWORD now = GetTickCount();
 
         DWORD autoHiddenAt = HandleToUlong(GetPropW(hWnd, L"ZenAutoHiddenAt"));
@@ -412,23 +478,27 @@ LRESULT CALLBACK DesktopShellViewSubclassProc(
         if (isVis) {
             // Check full screen guard
             if (IsFullscreenWindowActive()) {
+                SetAutoHideTimer(hWnd, TIMER_FULLSCREEN_RECHECK_MS);
                 return 0; // Skip auto-hide if a full-screen window is active (video/game/PPT)
             }
             DWORD idleMs = now - lii.dwTime;
             if (idleMs >= (DWORD)g_settings.autoHideDelay * 1000) {
                 Wh_Log(L"[ZenDesktop] Timer: idle %ums >= %us threshold -> AutoHide",
                        idleMs, g_settings.autoHideDelay);
-                PostMessageW(hWnd, WM_AUTO_HIDE, 0, 0);
+                PostMessageW(hWnd, g_msgAutoHide, 0, 0);
+                return 0;
             }
         }
         else if (autoHiddenAt != 0 && g_settings.showIconsOnAnyInput) {
             // Check system-wide physical input
             if (lii.dwTime > autoHiddenAt) {
                 Wh_Log(L"[ZenDesktop] Timer: new system-wide input detected -> AutoRestore");
-                PostMessageW(hWnd, WM_AUTO_RESTORE, 0, 0);
+                PostMessageW(hWnd, g_msgAutoRestore, 0, 0);
+                return 0;
             }
         }
 
+        ScheduleAutoHideTimer(hWnd);
         return 0;
     }
 
@@ -439,7 +509,7 @@ LRESULT CALLBACK DesktopShellViewSubclassProc(
         if (autoHiddenAt != 0 && g_settings.showIconsOnAnyInput) {
             if (uMsg == WM_LBUTTONDOWN || uMsg == WM_RBUTTONDOWN) {
                 Wh_Log(L"[ZenDesktop] Immediate click restore on DefView (uMsg=%u)", uMsg);
-                PostMessageW(hWnd, WM_AUTO_RESTORE, 0, 0);
+                PostMessageW(hWnd, g_msgAutoRestore, 0, 0);
             }
             else if (uMsg == WM_MOUSEMOVE) {
                 POINT ptCurrent = {};
@@ -450,7 +520,7 @@ LRESULT CALLBACK DesktopShellViewSubclassProc(
                 if (ptCurrent.x != (int)savedX || ptCurrent.y != (int)savedY) {
                     Wh_Log(L"[ZenDesktop] Physical mouse move detected: (%d,%d) vs (%d,%d) -> AutoRestore",
                            ptCurrent.x, ptCurrent.y, (int)savedX, (int)savedY);
-                    PostMessageW(hWnd, WM_AUTO_RESTORE, 0, 0);
+                    PostMessageW(hWnd, g_msgAutoRestore, 0, 0);
                 }
             }
         }
@@ -486,7 +556,7 @@ LRESULT CALLBACK DesktopShellViewSubclassProc(
         }
 
         if (isDblClick) {
-            PostMessageW(hWnd, WM_MANUAL_TOGGLE, 0, 0);
+            PostMessageW(hWnd, g_msgManualToggle, 0, 0);
             return 0;
         }
     }
@@ -499,7 +569,16 @@ LRESULT CALLBACK DesktopShellViewSubclassProc(
 // ─────────────────────────────────────────────────────────────────────────────
 BOOL Wh_ModInit()
 {
-    Wh_Log(L"[ZenDesktop] === Wh_ModInit v3.2.0 ===");
+    Wh_Log(L"[ZenDesktop] === Wh_ModInit v3.4.0 ===");
+    g_msgRefreshTimer = RegisterWindowMessageW(L"Windhawk.ZenDesktop.DesktopIconToggle.RefreshTimer");
+    g_msgManualToggle = RegisterWindowMessageW(L"Windhawk.ZenDesktop.DesktopIconToggle.ManualToggle");
+    g_msgAutoHide = RegisterWindowMessageW(L"Windhawk.ZenDesktop.DesktopIconToggle.AutoHide");
+    g_msgAutoRestore = RegisterWindowMessageW(L"Windhawk.ZenDesktop.DesktopIconToggle.AutoRestore");
+    if (!g_msgRefreshTimer || !g_msgManualToggle || !g_msgAutoHide || !g_msgAutoRestore) {
+        Wh_Log(L"[ZenDesktop] FAILED to register private window messages");
+        return FALSE;
+    }
+
     LoadSettings();
 
     if (!Wh_SetFunctionHook(

--- a/mods/zen-desktop-toggle-icons.wh.cpp
+++ b/mods/zen-desktop-toggle-icons.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              zen-desktop-toggle-icons
 // @name            ZenDesktop: Double Click to Hide Icons
-// @description     A high-performance, native C++ Windhawk mod that lets you double-click empty desktop space to hide/show desktop icons. Zero lag, zero UI overhead.
-// @version         1.2.0
+// @description     Native C++ Windhawk mod to hide/show desktop icons by double-clicking. Auto-hides on system-wide inactivity and restores on any user input.
+// @version         3.0.0
 // @author          Lanbo
 // @github          https://github.com/Liset999
 // @include         explorer.exe
@@ -16,207 +16,514 @@
 
 Have you ever wanted a clean, clutter-free desktop but found it annoying to right-click -> View -> Show desktop icons every time? 
 
-**ZenDesktop** brings the ultimate native solution to Windows. It allows you to **double-click empty space on your desktop** to instantly hide or show your icons.
+**ZenDesktop** brings the ultimate native solution to Windows. It allows you to **double-click empty space on your desktop** to instantly hide or show your icons, and optionally **automatically hide icons** after a configurable period of system inactivity.
 
 ### 🌟 Key Features:
 * **Zero UI Overhead**: Embedded natively inside `explorer.exe` process space. No background EXE running, no taskbar/tray icons, 0% CPU and virtually 0MB extra RAM.
 * **Process-Native Hit-Testing**: When you double-click, it performs a real-time ListView hit-test. If you double-click a file, folder, or shortcut, the default "open" action is triggered normally. If you double-click empty space, it toggles your desktop icons.
+* **System-Wide Inactivity Detection**: Uses `GetLastInputInfo()` to track ALL user input (keyboard, mouse anywhere on screen) — icons only auto-hide when you are truly idle, not just away from the desktop.
+* **Smart Auto-Restore**: When icons are auto-hidden, any user input (mouse or keyboard anywhere) instantly restores them. Manually hidden icons are never auto-restored.
 * **Dynamic Hooking**: Automatically subclasses the shell views, meaning even if your Explorer crashes, restarts, or you plug/unplug monitors, the mod remains fully active and stable.
 * **Completely Safe**: Uses native Windows `0x7402` (WM_COMMAND) toggle signals, ensuring Windows handles the fade animations and desktop state natively without breaking icon grid arrangements.
 */
 // ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- enableAutoHide: true
+  $name: "Auto-Hide Icons on Inactivity (自动隐藏)"
+  $description: "Automatically hides desktop icons after the system has been idle for the specified duration."
+- autoHideDelay: 5
+  $name: "Auto-Hide Delay in Seconds (延迟秒数)"
+  $description: "Seconds of system-wide inactivity before icons are hidden. Range: 3–60 seconds."
+- showIconsOnAnyInput: true
+  $name: "Restore Icons on Any Input (任意输入恢复)"
+  $description: "When icons were auto-hidden, any mouse or keyboard input instantly restores them. Does NOT affect manually hidden icons."
+*/
+// ==/WindhawkModSettings==
 
 #include <windows.h>
 #include <windowsx.h>
 #include <commctrl.h>
 #include <windhawk_utils.h>
 
-// Forward Declarations of Subclass Procedures
-LRESULT CALLBACK DesktopListViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData);
-LRESULT CALLBACK DesktopShellViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData);
+#define TIMER_AUTOHIDE   1001
+#define WM_REFRESH_TIMER (WM_USER + 5001)
+#define WM_MANUAL_TOGGLE (WM_USER + 5002)
+#define WM_AUTO_HIDE     (WM_USER + 5003)
+#define WM_AUTO_RESTORE  (WM_USER + 5004)
 
-// Real pointer to CreateWindowExW hook
+// ─────────────────────────────────────────────────────────────────────────────
+// Forward declarations
+// ─────────────────────────────────────────────────────────────────────────────
+LRESULT CALLBACK DesktopListViewSubclassProc(HWND, UINT, WPARAM, LPARAM, DWORD_PTR);
+LRESULT CALLBACK DesktopShellViewSubclassProc(HWND, UINT, WPARAM, LPARAM, DWORD_PTR);
+BOOL    CALLBACK EnumWindowsProc(HWND, LPARAM);
+
 using CreateWindowExW_t = decltype(&CreateWindowExW);
 CreateWindowExW_t Real_CreateWindowExW;
 
-// Helper to find the current active SHELLDLL_DefView window
-HWND FindDesktopShellView() {
+// ─────────────────────────────────────────────────────────────────────────────
+// Global settings
+// ─────────────────────────────────────────────────────────────────────────────
+struct Settings {
+    bool enableAutoHide;
+    int  autoHideDelay;       // seconds, clamped 3–60
+    bool showIconsOnAnyInput; // restore on any input after auto-hide
+} g_settings;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Settings
+// ─────────────────────────────────────────────────────────────────────────────
+static void LoadSettings()
+{
+    g_settings.enableAutoHide      = Wh_GetIntSetting(L"enableAutoHide") != 0;
+    g_settings.autoHideDelay       = Wh_GetIntSetting(L"autoHideDelay");
+    if (g_settings.autoHideDelay < 3)  g_settings.autoHideDelay = 3;
+    if (g_settings.autoHideDelay > 60) g_settings.autoHideDelay = 60;
+    g_settings.showIconsOnAnyInput = Wh_GetIntSetting(L"showIconsOnAnyInput") != 0;
+
+    Wh_Log(L"[ZenDesktop] Settings loaded: enableAutoHide=%d, autoHideDelay=%d, showIconsOnAnyInput=%d",
+           (int)g_settings.enableAutoHide, g_settings.autoHideDelay, (int)g_settings.showIconsOnAnyInput);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Timer management — post WM_REFRESH_TIMER to SHELLDLL_DefView so the timer
+// is always created/destroyed on the window-owning thread.
+// ─────────────────────────────────────────────────────────────────────────────
+static void UpdateTimerState(HWND hwndShell)
+{
+    if (hwndShell)
+        PostMessageW(hwndShell, WM_REFRESH_TIMER, 0, 0);
+}
+
+static void UpdateAllTimers()
+{
     HWND hwndProgman = FindWindowW(L"Progman", L"Program Manager");
     if (hwndProgman) {
         HWND hwndShell = FindWindowExW(hwndProgman, NULL, L"SHELLDLL_DefView", NULL);
-        if (hwndShell) return hwndShell;
+        if (hwndShell) UpdateTimerState(hwndShell);
     }
-    
-    // Check WorkerW instances (active when using wallpaper engines like Wallpaper Engine or slide shows)
     HWND hwndWorkerW = NULL;
     while ((hwndWorkerW = FindWindowExW(NULL, hwndWorkerW, L"WorkerW", NULL)) != NULL) {
         HWND hwndShell = FindWindowExW(hwndWorkerW, NULL, L"SHELLDLL_DefView", NULL);
-        if (hwndShell) return hwndShell;
-    }
-    return NULL;
-}
-
-// Subclasses active windows in explorer using SetWindowSubclassFromAnyThread
-void SubclassExistingWindows() {
-    HWND hwndShell = FindDesktopShellView();
-    if (hwndShell) {
-        WindhawkUtils::SetWindowSubclassFromAnyThread(hwndShell, DesktopShellViewSubclassProc, 0);
-        
-        HWND hwndListView = FindWindowExW(hwndShell, NULL, L"SysListView32", NULL);
-        if (hwndListView) {
-            WindhawkUtils::SetWindowSubclassFromAnyThread(hwndListView, DesktopListViewSubclassProc, 0);
-        }
+        if (hwndShell) UpdateTimerState(hwndShell);
     }
 }
 
-// Unsubclasses active windows to allow a safe DLL unload
-void UnsubclassWindows() {
-    HWND hwndShell = FindDesktopShellView();
-    if (hwndShell) {
-        WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwndShell, DesktopShellViewSubclassProc);
-        
-        HWND hwndListView = FindWindowExW(hwndShell, NULL, L"SysListView32", NULL);
-        if (hwndListView) {
-            WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwndListView, DesktopListViewSubclassProc);
-        }
-    }
-}
-
-// Hook Window Creator to subclass desktop windows dynamically as they are initialized
-HWND WINAPI Hook_CreateWindowExW(
-    DWORD dwExStyle,
-    LPCWSTR lpClassName,
-    LPCWSTR lpWindowName,
-    DWORD dwStyle,
-    int X,
-    int Y,
-    int nWidth,
-    int nHeight,
-    HWND hWndParent,
-    HMENU hMenu,
-    HINSTANCE hInstance,
-    LPVOID lpParam
-) {
-    HWND hWnd = Real_CreateWindowExW(
-        dwExStyle, lpClassName, lpWindowName, dwStyle,
-        X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam
-    );
-
-    if (hWnd) {
-        if (lpClassName && !IS_INTRESOURCE(lpClassName)) {
-            if (wcscmp(lpClassName, L"SHELLDLL_DefView") == 0) {
-                WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, DesktopShellViewSubclassProc, 0);
-            }
-            else if (wcscmp(lpClassName, L"SysListView32") == 0) {
-                // Ensure this ListView is indeed the desktop listview
-                WCHAR parentClass[256] = {0};
-                if (hWndParent && GetClassNameW(hWndParent, parentClass, 256) && wcscmp(parentClass, L"SHELLDLL_DefView") == 0) {
-                    WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, DesktopListViewSubclassProc, 0);
+// ─────────────────────────────────────────────────────────────────────────────
+// Full-Screen Application Guard
+// ─────────────────────────────────────────────────────────────────────────────
+static bool IsFullscreenWindowActive()
+{
+    HWND hwndForeground = GetForegroundWindow();
+    if (hwndForeground && hwndForeground != GetDesktopWindow()) {
+        WCHAR className[256] = {};
+        if (GetClassNameW(hwndForeground, className, 256)) {
+            // Exclude desktop manager windows
+            if (wcscmp(className, L"Progman") != 0 && wcscmp(className, L"WorkerW") != 0) {
+                RECT rect;
+                if (GetWindowRect(hwndForeground, &rect)) {
+                    int screenWidth = GetSystemMetrics(SM_CXSCREEN);
+                    int screenHeight = GetSystemMetrics(SM_CYSCREEN);
+                    if (rect.left <= 0 && rect.top <= 0 && rect.right >= screenWidth && rect.bottom >= screenHeight) {
+                        return true;
+                    }
                 }
             }
         }
     }
+    return false;
+}
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Icon visibility helpers
+//
+// ManualToggleIcons  — user double-clicked: toggle and clear auto-hide marker.
+// AutoHideIcons      — timer fired: hide only if visible, set auto-hide marker.
+// AutoRestoreIcons   — input detected: restore only auto-hidden icons.
+//
+// "ZenAutoHiddenAt" window property (stores GetTickCount) distinguishes
+// auto-hidden from manually-hidden state.
+// ─────────────────────────────────────────────────────────────────────────────
+static void ManualToggleIcons(HWND hwndShellView)
+{
+    HWND hwndListView = FindWindowExW(hwndShellView, NULL, L"SysListView32", NULL);
+    if (hwndListView) {
+        bool isVisible = IsWindowVisible(hwndListView) != 0;
+        ShowWindow(hwndListView, isVisible ? SW_HIDE : SW_SHOW);
+        Wh_Log(L"[ZenDesktop] ManualToggle: %s", isVisible ? L"HIDE" : L"SHOW");
+    } else {
+        // Fallback: use the native shell toggle if ListView handle is missing
+        PostMessageW(hwndShellView, WM_COMMAND, 0x7402, 0);
+        Wh_Log(L"[ZenDesktop] ManualToggle: fallback WM_COMMAND 0x7402");
+    }
+    // Clear auto-hide marker — this was a deliberate user action
+    RemovePropW(hwndShellView, L"ZenAutoHiddenAt");
+    RemovePropW(hwndShellView, L"ZenMouseX");
+    RemovePropW(hwndShellView, L"ZenMouseY");
+}
+
+static void AutoHideIcons(HWND hwndShellView)
+{
+    HWND hwndListView = FindWindowExW(hwndShellView, NULL, L"SysListView32", NULL);
+    if (hwndListView && IsWindowVisible(hwndListView)) {
+        ShowWindow(hwndListView, SW_HIDE);
+        DWORD now = GetTickCount();
+        // Avoid storing 0 (which means "not set"); extremely unlikely but be safe
+        if (now == 0) now = 1;
+        SetPropW(hwndShellView, L"ZenAutoHiddenAt", UlongToHandle(now));
+        
+        // Store current physical mouse coordinates for zero-latency coordinate guard
+        POINT pt = {};
+        GetCursorPos(&pt);
+        SetPropW(hwndShellView, L"ZenMouseX", UlongToHandle((DWORD)pt.x));
+        SetPropW(hwndShellView, L"ZenMouseY", UlongToHandle((DWORD)pt.y));
+
+        Wh_Log(L"[ZenDesktop] AutoHide: icons hidden at tick=%u, mouse=(%d,%d)", now, pt.x, pt.y);
+    }
+}
+
+static void AutoRestoreIcons(HWND hwndShellView)
+{
+    HWND hwndListView = FindWindowExW(hwndShellView, NULL, L"SysListView32", NULL);
+    if (hwndListView && !IsWindowVisible(hwndListView)) {
+        ShowWindow(hwndListView, SW_SHOW);
+        Wh_Log(L"[ZenDesktop] AutoRestore: icons restored");
+    }
+    RemovePropW(hwndShellView, L"ZenAutoHiddenAt");
+    RemovePropW(hwndShellView, L"ZenMouseX");
+    RemovePropW(hwndShellView, L"ZenMouseY");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Window enumeration / subclassing
+// ─────────────────────────────────────────────────────────────────────────────
+BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM)
+{
+    WCHAR className[256] = {};
+    if (!GetClassNameW(hWnd, className, 256)) return TRUE;
+
+    if (wcscmp(className, L"WorkerW") == 0 || wcscmp(className, L"Progman") == 0) {
+        HWND hwndShell = FindWindowExW(hWnd, NULL, L"SHELLDLL_DefView", NULL);
+        if (hwndShell) {
+            Wh_Log(L"[ZenDesktop] Subclassing ShellView=%p (parent=%s)", hwndShell, className);
+            WindhawkUtils::SetWindowSubclassFromAnyThread(hwndShell, DesktopShellViewSubclassProc, 0);
+            UpdateTimerState(hwndShell);
+
+            HWND hwndListView = FindWindowExW(hwndShell, NULL, L"SysListView32", NULL);
+            if (hwndListView) {
+                Wh_Log(L"[ZenDesktop] Subclassing ListView=%p", hwndListView);
+                WindhawkUtils::SetWindowSubclassFromAnyThread(hwndListView, DesktopListViewSubclassProc, 0);
+            }
+        }
+    }
+    return TRUE;
+}
+
+static void SubclassExistingWindows() { EnumWindows(EnumWindowsProc, 0); }
+
+static void UnsubclassWindows()
+{
+    auto Cleanup = [](HWND hwndShell) {
+        if (!hwndShell) return;
+        KillTimer(hwndShell, TIMER_AUTOHIDE);
+        RemovePropW(hwndShell, L"ZenTimerInit");
+        RemovePropW(hwndShell, L"ZenAutoHiddenAt");
+        RemovePropW(hwndShell, L"ZenMouseX");
+        RemovePropW(hwndShell, L"ZenMouseY");
+        
+        HWND lv = FindWindowExW(hwndShell, NULL, L"SysListView32", NULL);
+        if (lv) {
+            DWORD pid = 0;
+            // Verify window validity and process ownership before restoring visibility
+            if (IsWindow(lv) && GetWindowThreadProcessId(lv, &pid) && pid == GetCurrentProcessId()) {
+                if (!IsWindowVisible(lv)) {
+                    ShowWindow(lv, SW_SHOW);
+                    Wh_Log(L"[ZenDesktop] Cleanup: restored SysListView32 visibility");
+                }
+            }
+            WindhawkUtils::RemoveWindowSubclassFromAnyThread(lv, DesktopListViewSubclassProc);
+        }
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwndShell, DesktopShellViewSubclassProc);
+    };
+
+    HWND hwndProgman = FindWindowW(L"Progman", L"Program Manager");
+    if (hwndProgman)
+        Cleanup(FindWindowExW(hwndProgman, NULL, L"SHELLDLL_DefView", NULL));
+
+    HWND hwndWorkerW = NULL;
+    while ((hwndWorkerW = FindWindowExW(NULL, hwndWorkerW, L"WorkerW", NULL)) != NULL)
+        Cleanup(FindWindowExW(hwndWorkerW, NULL, L"SHELLDLL_DefView", NULL));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CreateWindowExW hook — dynamically subclass new desktop windows
+// ─────────────────────────────────────────────────────────────────────────────
+HWND WINAPI Hook_CreateWindowExW(
+    DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName,
+    DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
+    HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
+{
+    HWND hWnd = Real_CreateWindowExW(dwExStyle, lpClassName, lpWindowName,
+        dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+
+    if (hWnd && lpClassName && !IS_INTRESOURCE(lpClassName)) {
+        if (wcscmp(lpClassName, L"SHELLDLL_DefView") == 0) {
+            Wh_Log(L"[ZenDesktop] Hook: new SHELLDLL_DefView=%p created", hWnd);
+            WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, DesktopShellViewSubclassProc, 0);
+            UpdateTimerState(hWnd);
+        }
+        else if (wcscmp(lpClassName, L"SysListView32") == 0) {
+            WCHAR parentClass[256] = {};
+            if (hWndParent &&
+                GetClassNameW(hWndParent, parentClass, 256) &&
+                wcscmp(parentClass, L"SHELLDLL_DefView") == 0)
+            {
+                Wh_Log(L"[ZenDesktop] Hook: new desktop ListView=%p created", hWnd);
+                WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, DesktopListViewSubclassProc, 0);
+            }
+        }
+    }
     return hWnd;
 }
 
-// Subclass Proc for the Desktop ListView (Handles click empty space detection)
-LRESULT CALLBACK DesktopListViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData) {
+// ─────────────────────────────────────────────────────────────────────────────
+// Subclass Proc: SysListView32 (Desktop icon ListView)
+//   Receives events only when icons are VISIBLE (ListView is the hit target).
+//   Responsibility: detect double-click on empty desktop space → manual toggle.
+// ─────────────────────────────────────────────────────────────────────────────
+LRESULT CALLBACK DesktopListViewSubclassProc(
+    HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR)
+{
     if (uMsg == WM_LBUTTONDBLCLK || uMsg == WM_LBUTTONDOWN) {
-        static DWORD lastClickTime = 0;
-        static POINT lastClickPt = {0, 0};
-        
-        bool isDblClick = (uMsg == WM_LBUTTONDBLCLK);
-        
-        // Manual double-click detection for maximum robustness across custom class style combinations
-        if (uMsg == WM_LBUTTONDOWN) {
-            DWORD clickTime = GetTickCount();
-            DWORD dblClickTime = GetDoubleClickTime();
-            POINT pt = { (short)GET_X_LPARAM(lParam), (short)GET_Y_LPARAM(lParam) };
-            
-            if (clickTime - lastClickTime <= dblClickTime &&
-                abs(pt.x - lastClickPt.x) <= GetSystemMetrics(SM_CXDOUBLECLK) / 2 &&
-                abs(pt.y - lastClickPt.y) <= GetSystemMetrics(SM_CYDOUBLECLK) / 2) {
+        bool hasDblClkStyle = (GetClassLongPtrW(hWnd, GCL_STYLE) & CS_DBLCLKS) != 0;
+        bool isDblClick = false;
+
+        if (hasDblClkStyle) {
+            isDblClick = (uMsg == WM_LBUTTONDBLCLK);
+        } else {
+            if (uMsg == WM_LBUTTONDBLCLK) {
                 isDblClick = true;
-            } else {
-                lastClickTime = clickTime;
-                lastClickPt = pt;
+            } else if (uMsg == WM_LBUTTONDOWN) {
+                static DWORD lastClickTime = 0;
+                static POINT lastClickPt   = {};
+                DWORD now          = GetTickCount();
+                DWORD dblClickTime = GetDoubleClickTime();
+                POINT pt = { (short)GET_X_LPARAM(lParam), (short)GET_Y_LPARAM(lParam) };
+
+                if (now - lastClickTime <= dblClickTime &&
+                    abs(pt.x - lastClickPt.x) <= GetSystemMetrics(SM_CXDOUBLECLK) / 2 &&
+                    abs(pt.y - lastClickPt.y) <= GetSystemMetrics(SM_CYDOUBLECLK) / 2)
+                {
+                    isDblClick = true;
+                } else {
+                    lastClickTime = now;
+                    lastClickPt   = pt;
+                }
             }
         }
-        
+
         if (isDblClick) {
-            // Perform native process-local Hit-Test (LVM_HITTEST)
-            LVHITTESTINFO htInfo = {0};
-            htInfo.pt.x = (short)GET_X_LPARAM(lParam);
-            htInfo.pt.y = (short)GET_Y_LPARAM(lParam);
-            SendMessageW(hWnd, LVM_HITTEST, 0, (LPARAM)&htInfo);
-            
-            // iItem == -1 means double-click landed on completely empty space
-            if (htInfo.iItem == -1) {
+            // Native LVM_HITTEST to check if click landed on empty space.
+            LVHITTESTINFO ht = {};
+            ht.pt = { (short)GET_X_LPARAM(lParam), (short)GET_Y_LPARAM(lParam) };
+            SendMessageW(hWnd, LVM_HITTEST, 0, (LPARAM)&ht);
+
+            if (ht.iItem == -1) {
+                // Empty space — post manual toggle command asynchronously
                 HWND hwndParent = GetParent(hWnd);
                 if (hwndParent) {
-                    // Send toggle desktop icons command (0x7402) natively to SHELLDLL_DefView
-                    SendMessageW(hwndParent, WM_COMMAND, 0x7402, 0);
-                    return 0; // Handled, prevent default handling of this specific double click
+                    PostMessageW(hwndParent, WM_MANUAL_TOGGLE, 0, 0);
+                }
+                return 0; // suppress default double-click action
+            }
+        }
+    }
+
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Subclass Proc: SHELLDLL_DefView
+//   Receives events when icons are HIDDEN (ListView hidden → DefView is hit).
+//   Responsibilities:
+//     • Run the 500 ms auto-hide/restore polling timer.
+//     • Immediate restore on mouse move over desktop (when icons are auto-hidden).
+//     • Immediate restore on click on desktop (when icons are auto-hidden).
+//     • Double-click restore (always works, including manually hidden icons).
+// ─────────────────────────────────────────────────────────────────────────────
+LRESULT CALLBACK DesktopShellViewSubclassProc(
+    HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR)
+{
+    // ── One-time timer bootstrap ─────────────────────────────────────────────
+    bool timerInitialized = GetPropW(hWnd, L"ZenTimerInit") != NULL;
+    if (!timerInitialized && g_settings.enableAutoHide) {
+        if (SetTimer(hWnd, TIMER_AUTOHIDE, 500, NULL)) {
+            SetPropW(hWnd, L"ZenTimerInit", (HANDLE)1);
+            Wh_Log(L"[ZenDesktop] Timer bootstrapped for ShellView=%p", hWnd);
+        }
+    }
+
+    // ── Cross-thread timer refresh (settings change / new window subclassed) ──
+    if (uMsg == WM_REFRESH_TIMER) {
+        if (g_settings.enableAutoHide) {
+            if (SetTimer(hWnd, TIMER_AUTOHIDE, 500, NULL)) {
+                SetPropW(hWnd, L"ZenTimerInit", (HANDLE)1);
+                Wh_Log(L"[ZenDesktop] Timer refreshed (ON) for ShellView=%p", hWnd);
+            }
+        } else {
+            KillTimer(hWnd, TIMER_AUTOHIDE);
+            RemovePropW(hWnd, L"ZenTimerInit");
+            Wh_Log(L"[ZenDesktop] Timer killed (OFF) for ShellView=%p", hWnd);
+        }
+        return 0;
+    }
+
+    // ── Async Operations execution ───────────────────────────────────────────
+    if (uMsg == WM_MANUAL_TOGGLE) {
+        ManualToggleIcons(hWnd);
+        return 0;
+    }
+    if (uMsg == WM_AUTO_HIDE) {
+        AutoHideIcons(hWnd);
+        return 0;
+    }
+    if (uMsg == WM_AUTO_RESTORE) {
+        AutoRestoreIcons(hWnd);
+        return 0;
+    }
+
+    // ── Auto-hide / auto-restore timer tick (every 500 ms) ───────────────────
+    if (uMsg == WM_TIMER && wParam == TIMER_AUTOHIDE) {
+        if (!g_settings.enableAutoHide) return 0;
+
+        HWND hwndListView = FindWindowExW(hWnd, NULL, L"SysListView32", NULL);
+        if (!hwndListView) return 0;
+
+        bool isVis = IsWindowVisible(hwndListView) != 0;
+
+        LASTINPUTINFO lii = { sizeof(LASTINPUTINFO) };
+        if (!GetLastInputInfo(&lii)) return 0;
+        DWORD now = GetTickCount();
+
+        DWORD autoHiddenAt = HandleToUlong(GetPropW(hWnd, L"ZenAutoHiddenAt"));
+
+        if (isVis) {
+            // Check full screen guard
+            if (IsFullscreenWindowActive()) {
+                return 0; // Skip auto-hide if a full-screen window is active (video/game/PPT)
+            }
+            DWORD idleMs = now - lii.dwTime;
+            if (idleMs >= (DWORD)g_settings.autoHideDelay * 1000) {
+                Wh_Log(L"[ZenDesktop] Timer: idle %ums >= %us threshold -> AutoHide",
+                       idleMs, g_settings.autoHideDelay);
+                PostMessageW(hWnd, WM_AUTO_HIDE, 0, 0);
+            }
+        }
+        else if (autoHiddenAt != 0 && g_settings.showIconsOnAnyInput) {
+            // Check system-wide physical input
+            if (lii.dwTime > autoHiddenAt) {
+                Wh_Log(L"[ZenDesktop] Timer: new system-wide input detected -> AutoRestore");
+                PostMessageW(hWnd, WM_AUTO_RESTORE, 0, 0);
+            }
+        }
+
+        return 0;
+    }
+
+    // ── Immediate mouse/click restore (only when auto-hidden + restore-on-input enabled) ──
+    // Zero-latency coordinate-based physical mouse movement detection
+    {
+        DWORD autoHiddenAt = HandleToUlong(GetPropW(hWnd, L"ZenAutoHiddenAt"));
+        if (autoHiddenAt != 0 && g_settings.showIconsOnAnyInput) {
+            if (uMsg == WM_LBUTTONDOWN || uMsg == WM_RBUTTONDOWN) {
+                Wh_Log(L"[ZenDesktop] Immediate click restore on DefView (uMsg=%u)", uMsg);
+                PostMessageW(hWnd, WM_AUTO_RESTORE, 0, 0);
+            }
+            else if (uMsg == WM_MOUSEMOVE) {
+                POINT ptCurrent = {};
+                GetCursorPos(&ptCurrent);
+                DWORD savedX = HandleToUlong(GetPropW(hWnd, L"ZenMouseX"));
+                DWORD savedY = HandleToUlong(GetPropW(hWnd, L"ZenMouseY"));
+
+                if (ptCurrent.x != (int)savedX || ptCurrent.y != (int)savedY) {
+                    Wh_Log(L"[ZenDesktop] Physical mouse move detected: (%d,%d) vs (%d,%d) -> AutoRestore",
+                           ptCurrent.x, ptCurrent.y, (int)savedX, (int)savedY);
+                    PostMessageW(hWnd, WM_AUTO_RESTORE, 0, 0);
                 }
             }
         }
     }
-    
-    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
-}
 
-// Subclass Proc for the SHELLDLL_DefView (Handles double-click when icons are already hidden)
-LRESULT CALLBACK DesktopShellViewSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, DWORD_PTR dwRefData) {
+    // ── Double-click restore (works for both auto-hidden AND manually hidden) ──
     if (uMsg == WM_LBUTTONDBLCLK || uMsg == WM_LBUTTONDOWN) {
-        static DWORD lastClickTime = 0;
-        static POINT lastClickPt = {0, 0};
-        
-        bool isDblClick = (uMsg == WM_LBUTTONDBLCLK);
-        
-        if (uMsg == WM_LBUTTONDOWN) {
-            DWORD clickTime = GetTickCount();
-            DWORD dblClickTime = GetDoubleClickTime();
-            POINT pt = { (short)GET_X_LPARAM(lParam), (short)GET_Y_LPARAM(lParam) };
-            
-            if (clickTime - lastClickTime <= dblClickTime &&
-                abs(pt.x - lastClickPt.x) <= GetSystemMetrics(SM_CXDOUBLECLK) / 2 &&
-                abs(pt.y - lastClickPt.y) <= GetSystemMetrics(SM_CYDOUBLECLK) / 2) {
+        bool hasDblClkStyle = (GetClassLongPtrW(hWnd, GCL_STYLE) & CS_DBLCLKS) != 0;
+        bool isDblClick = false;
+
+        if (hasDblClkStyle) {
+            isDblClick = (uMsg == WM_LBUTTONDBLCLK);
+        } else {
+            if (uMsg == WM_LBUTTONDBLCLK) {
                 isDblClick = true;
-            } else {
-                lastClickTime = clickTime;
-                lastClickPt = pt;
+            } else if (uMsg == WM_LBUTTONDOWN) {
+                static DWORD lastClickTime = 0;
+                static POINT lastClickPt   = {};
+                DWORD now          = GetTickCount();
+                DWORD dblClickTime = GetDoubleClickTime();
+                POINT pt = { (short)GET_X_LPARAM(lParam), (short)GET_Y_LPARAM(lParam) };
+
+                if (now - lastClickTime <= dblClickTime &&
+                    abs(pt.x - lastClickPt.x) <= GetSystemMetrics(SM_CXDOUBLECLK) / 2 &&
+                    abs(pt.y - lastClickPt.y) <= GetSystemMetrics(SM_CYDOUBLECLK) / 2)
+                {
+                    isDblClick = true;
+                } else {
+                    lastClickTime = now;
+                    lastClickPt   = pt;
+                }
             }
         }
-        
+
         if (isDblClick) {
-            // When icons are already hidden, any double click on SHELLDLL_DefView is a toggle (to restore icons)
-            SendMessageW(hWnd, WM_COMMAND, 0x7402, 0);
-            return 0; // Handled
+            PostMessageW(hWnd, WM_MANUAL_TOGGLE, 0, 0);
+            return 0;
         }
     }
-    
+
     return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
 
-// Mod initialization (hook APIs and subclass existing desktop windows)
-bool Wh_ModInit() {
-    // Register hook for CreateWindowExW using the official Windhawk Wh_SetFunctionHook API
+// ─────────────────────────────────────────────────────────────────────────────
+// Windhawk lifecycle
+// ─────────────────────────────────────────────────────────────────────────────
+BOOL Wh_ModInit()
+{
+    Wh_Log(L"[ZenDesktop] === Wh_ModInit v3.0.0 ===");
+    LoadSettings();
+
     if (!Wh_SetFunctionHook(
-        (void*)CreateWindowExW,
-        (void*)Hook_CreateWindowExW,
-        (void**)&Real_CreateWindowExW
-    )) {
-        return false;
+            (void*)CreateWindowExW,
+            (void*)Hook_CreateWindowExW,
+            (void**)&Real_CreateWindowExW)) {
+        Wh_Log(L"[ZenDesktop] FAILED to hook CreateWindowExW");
+        return FALSE;
     }
-    
-    // Subclass already existing desktop windows (in case of post-boot injection)
+
     SubclassExistingWindows();
-    
-    return true;
+    Wh_Log(L"[ZenDesktop] Init complete");
+    return TRUE;
 }
 
-// Mod uninitialization (unsubclass windows and clean up hooks)
-void Wh_ModUninit() {
+void Wh_ModUninit()
+{
+    Wh_Log(L"[ZenDesktop] === Wh_ModUninit ===");
     UnsubclassWindows();
+}
+
+void Wh_ModSettingsChanged()
+{
+    Wh_Log(L"[ZenDesktop] === Settings changed ===");
+    LoadSettings();
+    UpdateAllTimers();
 }


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* **Asynchronous Execution Pipeline (`PostMessageW`)**: Replaced all synchronous `ShowWindow` calls in subclass procedures with asynchronous custom messages to avoid message queue deadlocks and Explorer crashes.
* **Full-Screen Application Guard**: Added automatic active window monitoring. Prevents auto-hiding icons when a full-screen application (video playback, PPT slide presentation, or game) is active.
* **Zero-Latency Physical Coordinate Guard**: Replaced the laggy 100ms timer guard with a precise, zero-latency mouse coordinate comparison to filter out synthetic window-layout movements immediately while enabling absolute 0ms physical mouse-move restore.
* **Dynamic `CS_DBLCLKS` Support**: Queries GCL_STYLE dynamically to support both native double-click inputs and manual interval-distance tracking fallback for windows lacking double-click style (like `SHELLDLL_DefView`).
* **Type Safety & Process Check**: Standardized custom properties using `UlongToHandle` / `HandleToUlong` to prevent 64-bit truncation, and added PID checks before modifying window states on subclass cleanup.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- [ ] The submitter, without AI assistance
- [x] The submitter, with AI assistance
  - [ ] Claude
  - [ ] ChatGPT
  - [x] Gemini (Pair programmed with Gemini 3.5 Flash)
  - [ ] Another AI (please specify):
  - [ ] Other (please specify):

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.