### PR TITLE
Improve translucency support for classic Win32 dialogs

### DIFF
--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -616,7 +616,10 @@ BOOL IsWindowEligible(HWND hWnd)
     BOOL isFlyoutWindow = IsWindowClass(hWnd, TOOLTIPS_CLASS) || IsWindowClass(hWnd, L"DropDown") || IsWindowClass(hWnd, L"ViewControlClass");
     if (isFlyoutWindow && g_settings.FlyoutsEffects)
         return TRUE;   
-    
+
+	if (IsWindowClass(hWnd, L"#32770"))
+    	return TRUE;
+	
     LONG_PTR styleEx = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
     LONG_PTR style = GetWindowLongPtrW(hWnd, GWL_STYLE);
     
@@ -1495,9 +1498,7 @@ static COLORREF GetDefaultSysColor(INT nIndex)
 
 static COLORREF GetCustomSysColor(INT nIndex) 
 {
-    if (nIndex == COLOR_SCROLLBAR || nIndex == COLOR_BACKGROUND || nIndex == COLOR_MENU ||
-        nIndex == COLOR_WINDOW || nIndex == COLOR_INACTIVEBORDER || nIndex == COLOR_INFOBK ||
-        nIndex == COLOR_MENUBAR)
+    if (nIndex == COLOR_SCROLLBAR || nIndex == COLOR_BACKGROUND || nIndex == COLOR_MENU || nIndex == COLOR_WINDOW || nIndex == COLOR_INACTIVEBORDER || nIndex == COLOR_INFOBK || nIndex == COLOR_MENUBAR || nIndex == COLOR_BTNFACE)
         return RGB(0, 0, 0);
     else if (nIndex == COLOR_GRADIENTACTIVECAPTION || nIndex == COLOR_INACTIVECAPTION)
         return (g_settings.AccentColorize) ? g_settings.AccentColor : RGB(0, 0, 0);
@@ -1516,8 +1517,6 @@ static COLORREF GetCustomSysColor(INT nIndex)
         return RGB(8, 8, 8);
     else if (nIndex == COLOR_HIGHLIGHT || nIndex == COLOR_MENUHILIGHT)
         return (g_settings.AccentColorize) ? g_settings.AccentColor : RGB(0, 120, 215);
-    else if (nIndex == COLOR_BTNFACE)
-        return RGB(1, 1, 1);
     else if (nIndex == COLOR_GRAYTEXT)
         return RGB(128, 128, 128);
     else if (nIndex == COLOR_INACTIVECAPTIONTEXT)


### PR DESCRIPTION
Allow #32770 dialog windows to receive translucency effects.

This change improves compatibility with classic Win32 dialogs such as:

- System Properties
- Performance Options
- Programs and Features
- Internet Options
- File and Folder Properties
- And more

Classic Win32 dialogs (#32770) were not considered eligible windows, preventing translucency from being applied. Also, COLOR_BTNFACE was excluded from the custom system color set, preventing dialog client areas from fully participating in the translucency effect.

<img width="399" height="206" alt="image_2026-05-29_145817303" src="https://github.com/user-attachments/assets/a7fb319e-a3ea-4632-acca-98bb3b603f9c" />
<img width="412" height="468" alt="image" src="https://github.com/user-attachments/assets/46ac8d82-4f9a-430d-9eca-80d4c1681747" />


<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Allow classic Win32 dialog windows (#32770) to receive translucency effects
* Include COLOR_BTNFACE in the custom system color set used for translucency rendering

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
