### PR TITLE
Add mod to disable inactive menubar greying

### DIFF
--- a/mods/disable-inactive-menubar-greying.wh.cpp
+++ b/mods/disable-inactive-menubar-greying.wh.cpp
@@ -19,6 +19,8 @@ the way it was in Windows 95, before Windows 98.
 
 ![screenshot](https://i.imgur.com/FCEXTyt.png)
 
+![screenshot](https://i.imgur.com/XBVNN0v.png)
+
 */
 // ==/WindhawkModReadme==
 

--- a/mods/disable-inactive-menubar-greying.wh.cpp
+++ b/mods/disable-inactive-menubar-greying.wh.cpp
@@ -1,0 +1,55 @@
+// ==WindhawkMod==
+// @id              disable-inactive-menubar-greying
+// @name            Disable Inactive Menubar Greying
+// @description     Prevents menubar text from being greyed out in inactive folder windows in Classic theme
+// @version         1.0
+// @author          Anixx
+// @github          https://github.com/Anixx
+// @include         explorer.exe
+// @compilerOptions -lgdi32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Disable Inactive Menubar Greying
+
+This mod prevents the classic menubar text (File, Edit, View, etc.) in folder windows
+under the Classic theme from appearing greyed out when the window loses focus, 
+the way it was in Windows 95, before Windows 98.
+
+*/
+// ==/WindhawkModReadme==
+
+typedef COLORREF (WINAPI *SetTextColor_t)(HDC hdc, COLORREF color);
+SetTextColor_t SetTextColor_Original;
+
+bool IsGreyColor(COLORREF color, COLORREF menuTextColor)
+{
+    BYTE r = GetRValue(color);
+    BYTE g = GetGValue(color);
+    BYTE b = GetBValue(color);
+    
+    return ((r == g && g == b) && (r > 0) && (r < 255)&&!(color == menuTextColor));
+}
+
+COLORREF WINAPI SetTextColor_Hook(HDC hdc, COLORREF color)
+{
+    COLORREF menuTextColor = GetSysColor(COLOR_MENUTEXT);
+    
+    if (IsGreyColor(color, menuTextColor))
+    {
+        return SetTextColor_Original(hdc, menuTextColor);
+    }
+    
+    return SetTextColor_Original(hdc, color);
+}
+
+
+BOOL Wh_ModInit()
+{
+    Wh_SetFunctionHook((void*)GetProcAddress(GetModuleHandle(L"gdi32.dll"), "SetTextColor"),
+                       (void*)SetTextColor_Hook,
+                       (void**)&SetTextColor_Original);
+
+    return TRUE;
+}

--- a/mods/disable-inactive-menubar-greying.wh.cpp
+++ b/mods/disable-inactive-menubar-greying.wh.cpp
@@ -38,12 +38,9 @@ COLORREF WINAPI SetTextColor_Hook(HDC hdc, COLORREF color)
 {
     COLORREF menuTextColor = GetSysColor(COLOR_MENUTEXT);
 
-    if (IsGreyColor(color, menuTextColor))
+    if (IsGreyColor(color, menuTextColor) && !WindowFromDC(hdc))
     {
-        if (!WindowFromDC(hdc))
-        {
-            return SetTextColor_Original(hdc, menuTextColor);
-        }
+        return SetTextColor_Original(hdc, menuTextColor);
     }
 
     return SetTextColor_Original(hdc, color);

--- a/mods/disable-inactive-menubar-greying.wh.cpp
+++ b/mods/disable-inactive-menubar-greying.wh.cpp
@@ -17,6 +17,8 @@ This mod prevents the classic menubar text (File, Edit, View, etc.) in folder wi
 under the Classic theme from appearing greyed out when the window loses focus, 
 the way it was in Windows 95, before Windows 98.
 
+![screenshot](https://i.imgur.com/FCEXTyt.png)
+
 */
 // ==/WindhawkModReadme==
 

--- a/mods/disable-inactive-menubar-greying.wh.cpp
+++ b/mods/disable-inactive-menubar-greying.wh.cpp
@@ -30,28 +30,31 @@ bool IsGreyColor(COLORREF color, COLORREF menuTextColor)
     BYTE r = GetRValue(color);
     BYTE g = GetGValue(color);
     BYTE b = GetBValue(color);
-    
-    return ((r == g && g == b) && (r > 0) && (r < 255)&&!(color == menuTextColor));
+
+    return (r == g && g == b && r > 0 && r < 255 && color != menuTextColor);
 }
 
 COLORREF WINAPI SetTextColor_Hook(HDC hdc, COLORREF color)
 {
     COLORREF menuTextColor = GetSysColor(COLOR_MENUTEXT);
-    
+
     if (IsGreyColor(color, menuTextColor))
     {
-        return SetTextColor_Original(hdc, menuTextColor);
+        if (!WindowFromDC(hdc))
+        {
+            return SetTextColor_Original(hdc, menuTextColor);
+        }
     }
-    
+
     return SetTextColor_Original(hdc, color);
 }
 
-
 BOOL Wh_ModInit()
 {
-    Wh_SetFunctionHook((void*)GetProcAddress(GetModuleHandle(L"gdi32.dll"), "SetTextColor"),
-                       (void*)SetTextColor_Hook,
-                       (void**)&SetTextColor_Original);
+    Wh_SetFunctionHook(
+        (void*)GetProcAddress(GetModuleHandle(L"gdi32.dll"), "SetTextColor"),
+        (void*)SetTextColor_Hook,
+        (void**)&SetTextColor_Original);
 
     return TRUE;
 }


### PR DESCRIPTION
This mod prevents the classic menubar text in folder windows under the Classic theme from appearing greyed out when the window loses focus.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
