### PR TITLE
Add Tray hover expand mod for hidden icons

### DIFF
--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -1,0 +1,303 @@
+// ==WindhawkMod==
+// @id              tray-hover-expand
+// @name            Tray hover expand
+// @description     Open the hidden tray icons flyout on hover instead of clicking the chevron; optionally collapse it when the cursor leaves
+// @version         1.0.0
+// @author          wygodad
+// @github          https://github.com/wygodad
+// @include         explorer.exe
+// @compilerOptions -lole32 -loleaut32 -luuid -luiautomationcore
+// @license         MIT
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Tray hover expand
+
+Opens the hidden tray icons flyout (the "Show Hidden Icons" chevron) when you
+hover the cursor over it, instead of having to click. Optionally collapses it
+again once the cursor leaves the opened icons.
+
+It works through UI Automation, so it does not hook internal shell functions —
+it is relatively safe and resilient across Windows builds.
+
+## Notes
+- If the chevron button is not detected, the matching is name-based. The default
+  keywords cover English and Polish; other languages may need the button's name
+  added to the `keywords` list in the source.
+- If auto-collapse does not work, the flyout window class name may differ on your
+  build. Change it in the "Flyout window class" setting.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- autoClose: true
+  $name: Collapse when the cursor leaves
+  $description: After the cursor leaves the opened icons (and the chevron), the flyout closes itself.
+- pollInterval: 50
+  $name: Polling interval (ms)
+  $description: How often to check the cursor position. Lower = smoother, more CPU.
+- grace: 200
+  $name: Collapse delay (ms)
+  $description: How long the cursor must stay outside the area before the flyout closes (prevents flicker).
+- pad: 4
+  $name: Hit area padding (pixels)
+  $description: Enlarges the hover area around the chevron button.
+- flyoutClass: TopLevelWindowForOverflowXamlIsland
+  $name: Flyout window class
+  $description: Window class name of the opened flyout (used to tell whether the cursor is over the icons). Change it if auto-collapse does not work.
+*/
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+#include <uiautomation.h>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+// GUID-y na wszelki wypadek (gdyby linker MinGW ich nie dostarczył).
+#ifndef __IUIAutomation_FWD_DEFINED__
+#error "Brak nagłówków UI Automation"
+#endif
+
+struct Settings {
+    bool autoClose = true;
+    int pollInterval = 50;
+    int grace = 200;
+    int pad = 4;
+    std::wstring flyoutClass = L"TopLevelWindowForOverflowXamlIsland";
+    std::vector<std::wstring> keywords = {
+        L"ukryte ikony", L"hidden icons", L"rozwiń", L"overflow"
+    };
+};
+
+static Settings g_settings;
+static volatile bool g_running = false;
+static HANDLE g_thread = nullptr;
+
+static std::wstring ToLower(const std::wstring& s) {
+    std::wstring r = s;
+    std::transform(r.begin(), r.end(), r.begin(), ::towlower);
+    return r;
+}
+
+static bool NameMatches(const std::wstring& name) {
+    std::wstring low = ToLower(name);
+    for (const auto& k : g_settings.keywords) {
+        if (!k.empty() && low.find(ToLower(k)) != std::wstring::npos) return true;
+    }
+    return false;
+}
+
+// ---- Pomocnicze: pobranie wzorców UIA ----
+
+static ExpandCollapseState GetState(IUIAutomationElement* e) {
+    IUIAutomationExpandCollapsePattern* p = nullptr;
+    if (SUCCEEDED(e->GetCurrentPatternAs(
+            UIA_ExpandCollapsePatternId,
+            __uuidof(IUIAutomationExpandCollapsePattern), (void**)&p)) && p) {
+        ExpandCollapseState s = ExpandCollapseState_Collapsed;
+        p->get_CurrentExpandCollapseState(&s);
+        p->Release();
+        return s;
+    }
+    // Fallback: stan po widoczności okna flyoutu.
+    HWND f = FindWindowW(g_settings.flyoutClass.c_str(), nullptr);
+    return (f && IsWindowVisible(f)) ? ExpandCollapseState_Expanded
+                                     : ExpandCollapseState_Collapsed;
+}
+
+static void DoExpand(IUIAutomationElement* e) {
+    IUIAutomationExpandCollapsePattern* p = nullptr;
+    if (SUCCEEDED(e->GetCurrentPatternAs(
+            UIA_ExpandCollapsePatternId,
+            __uuidof(IUIAutomationExpandCollapsePattern), (void**)&p)) && p) {
+        p->Expand();
+        p->Release();
+        return;
+    }
+    IUIAutomationInvokePattern* inv = nullptr;
+    if (SUCCEEDED(e->GetCurrentPatternAs(
+            UIA_InvokePatternId,
+            __uuidof(IUIAutomationInvokePattern), (void**)&inv)) && inv) {
+        inv->Invoke();
+        inv->Release();
+    }
+}
+
+static void DoCollapse(IUIAutomationElement* e) {
+    IUIAutomationExpandCollapsePattern* p = nullptr;
+    if (SUCCEEDED(e->GetCurrentPatternAs(
+            UIA_ExpandCollapsePatternId,
+            __uuidof(IUIAutomationExpandCollapsePattern), (void**)&p)) && p) {
+        p->Collapse();
+        p->Release();
+        return;
+    }
+    // Fallback przy braku ExpandCollapse: ponowne Invoke (toggle).
+    IUIAutomationInvokePattern* inv = nullptr;
+    if (SUCCEEDED(e->GetCurrentPatternAs(
+            UIA_InvokePatternId,
+            __uuidof(IUIAutomationInvokePattern), (void**)&inv)) && inv) {
+        inv->Invoke();
+        inv->Release();
+    }
+}
+
+// ---- Znajdowanie przycisku chevron ----
+
+static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto) {
+    HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
+    if (!hTaskbar) return nullptr;
+
+    IUIAutomationElement* pRoot = nullptr;
+    if (FAILED(pAuto->ElementFromHandle(hTaskbar, &pRoot)) || !pRoot) return nullptr;
+
+    IUIAutomationCondition* pCond = nullptr;
+    VARIANT v; VariantInit(&v);
+    v.vt = VT_I4; v.lVal = UIA_ButtonControlTypeId;
+    pAuto->CreatePropertyCondition(UIA_ControlTypePropertyId, v, &pCond);
+
+    IUIAutomationElement* result = nullptr;
+    IUIAutomationElementArray* pArr = nullptr;
+    if (pCond && SUCCEEDED(pRoot->FindAll(TreeScope_Subtree, pCond, &pArr)) && pArr) {
+        int n = 0; pArr->get_Length(&n);
+        for (int i = 0; i < n; i++) {
+            IUIAutomationElement* e = nullptr;
+            if (SUCCEEDED(pArr->GetElement(i, &e)) && e) {
+                BSTR name = nullptr;
+                e->get_CurrentName(&name);
+                if (name && NameMatches(name)) {
+                    SysFreeString(name);
+                    result = e;          // zachowujemy referencję
+                    break;
+                }
+                if (name) SysFreeString(name);
+                e->Release();
+            }
+        }
+        pArr->Release();
+    }
+    if (pCond) pCond->Release();
+    pRoot->Release();
+    return result;
+}
+
+static bool PtInRectPad(const RECT& r, POINT pt, int pad) {
+    return pt.x >= r.left - pad && pt.x <= r.right + pad &&
+           pt.y >= r.top - pad  && pt.y <= r.bottom + pad;
+}
+
+static bool CursorOverFlyout(POINT pt) {
+    HWND f = FindWindowW(g_settings.flyoutClass.c_str(), nullptr);
+    if (!f || !IsWindowVisible(f)) return false;
+    RECT r;
+    if (!GetWindowRect(f, &r)) return false;
+    return PtInRect(&r, pt);
+}
+
+// ---- Wątek roboczy ----
+
+static DWORD WINAPI WorkerThread(LPVOID) {
+    CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+
+    IUIAutomation* pAuto = nullptr;
+    if (FAILED(CoCreateInstance(__uuidof(CUIAutomation), nullptr,
+            CLSCTX_INPROC_SERVER, __uuidof(IUIAutomation), (void**)&pAuto)) || !pAuto) {
+        Wh_Log(L"Failed to create IUIAutomation");
+        CoUninitialize();
+        return 0;
+    }
+
+    IUIAutomationElement* pBtn = nullptr;
+    ULONGLONG leftAt = 0;
+    ULONGLONG nextRefind = 0;
+
+    while (g_running) {
+        ULONGLONG now = GetTickCount64();
+
+        if (!pBtn || now >= nextRefind) {
+            // Okresowo odśwież referencję (pasek mógł się przebudować).
+            if (pBtn) { pBtn->Release(); pBtn = nullptr; }
+            pBtn = FindOverflowButton(pAuto);
+            nextRefind = now + 3000;
+        }
+
+        if (pBtn) {
+            RECT r;
+            if (FAILED(pBtn->get_CurrentBoundingRectangle(&r))) {
+                pBtn->Release(); pBtn = nullptr;
+                Sleep(g_settings.pollInterval);
+                continue;
+            }
+
+            POINT pt; GetCursorPos(&pt);
+            bool overBtn = PtInRectPad(r, pt, g_settings.pad);
+            ExpandCollapseState st = GetState(pBtn);
+            bool expanded = (st == ExpandCollapseState_Expanded);
+
+            if (overBtn && !expanded) {
+                DoExpand(pBtn);
+                leftAt = 0;
+            }
+
+            if (g_settings.autoClose && expanded) {
+                bool overFlyout = CursorOverFlyout(pt);
+                if (overBtn || overFlyout) {
+                    leftAt = 0;
+                } else {
+                    if (leftAt == 0) {
+                        leftAt = now;
+                    } else if (now - leftAt >= (ULONGLONG)g_settings.grace) {
+                        DoCollapse(pBtn);
+                        leftAt = 0;
+                    }
+                }
+            } else {
+                leftAt = 0;
+            }
+        }
+
+        Sleep(g_settings.pollInterval);
+    }
+
+    if (pBtn) pBtn->Release();
+    if (pAuto) pAuto->Release();
+    CoUninitialize();
+    return 0;
+}
+
+// ---- Cykl życia moda ----
+
+static void LoadSettings() {
+    g_settings.autoClose = Wh_GetIntSetting(L"autoClose") != 0;
+    g_settings.pollInterval = (int)Wh_GetIntSetting(L"pollInterval");
+    g_settings.grace = (int)Wh_GetIntSetting(L"grace");
+    g_settings.pad = (int)Wh_GetIntSetting(L"pad");
+    if (g_settings.pollInterval < 10) g_settings.pollInterval = 10;
+    if (g_settings.grace < 0) g_settings.grace = 0;
+
+    PCWSTR fc = Wh_GetStringSetting(L"flyoutClass");
+    if (fc) { g_settings.flyoutClass = fc; Wh_FreeStringSetting(fc); }
+}
+
+BOOL Wh_ModInit() {
+    LoadSettings();
+    g_running = true;
+    g_thread = CreateThread(nullptr, 0, WorkerThread, nullptr, 0, nullptr);
+    return g_thread != nullptr;
+}
+
+void Wh_ModSettingsChanged() {
+    LoadSettings();
+}
+
+void Wh_ModUninit() {
+    g_running = false;
+    if (g_thread) {
+        WaitForSingleObject(g_thread, 3000);
+        CloseHandle(g_thread);
+        g_thread = nullptr;
+    }
+}

--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -2,11 +2,11 @@
 // @id              tray-hover-expand
 // @name            Tray hover expand
 // @description     Open the hidden tray icons flyout on hover instead of clicking the chevron; optionally collapse it when the cursor leaves
-// @version         1.3.0
+// @version         1.4.0
 // @author          wygodad
 // @github          https://github.com/wygodad
-// @include         explorer.exe
-// @compilerOptions -lole32 -loleaut32 -luuid -luiautomationcore
+// @include         windhawk.exe
+// @compilerOptions -lole32 -loleaut32 -luuid -luiautomationcore -lshell32
 // @license         MIT
 // ==/WindhawkMod==
 
@@ -14,26 +14,73 @@
 /*
 # Tray hover expand
 
+![Demo](https://i.imgur.com/qsNUNpj.png)
+
 Opens the hidden tray icons flyout (the "Show Hidden Icons" chevron) when you
 hover the cursor over it, instead of having to click. Optionally collapses it
 again once the cursor leaves the opened icons.
 
 It works through UI Automation, so it does not hook internal shell functions —
-it is relatively safe and resilient across Windows builds.
+it is relatively safe and resilient across Windows builds. It runs as a tool
+mod in a dedicated process and does not inject into the shell.
+
+## How it differs from similar mods
+- *Taskbar tray icons hide on hover* auto-hides the whole tray area and reveals
+  it on hover.
+- *Show all taskbar notification icons* forces all hidden icons to always show.
+- This mod keeps the standard Windows overflow flyout and simply opens it on
+  hover (and optionally closes it when you move away).
 
 ## How the chevron is detected
 The "Show Hidden Icons" chevron has no language-independent unique identifier on
 Windows 11 (it shares AutomationId `SystemTrayIcon` with the clock, volume,
 battery, etc., and exposes no ExpandCollapse pattern). So detection is a hybrid:
-1. Match the button by name (keywords cover English and Polish by default).
+1. Match the button by name (the keyword list covers English and Polish by
+   default and can be extended in the settings).
 2. If no name matches (other languages), fall back to the leftmost tray button
    with the configured AutomationId, which is normally the chevron.
 
 ## Notes
-- For unsupported languages, either add the button's name to the `keywords` list
-  in the source, or rely on the leftmost-tray-icon fallback.
+- For unsupported languages, add your locale's chevron name to the "Chevron name
+  keywords" setting, or rely on the leftmost-tray-icon fallback.
 - If auto-collapse does not work, the flyout window class name may differ on your
   build. Change it in the "Flyout window class" setting.
+
+---
+
+## Opis po polsku
+
+Otwiera schowek ukrytych ikon zasobnika (strzałkę „Pokaż ukryte ikony") po
+najechaniu kursorem, bez konieczności klikania. Opcjonalnie zwija go z powrotem,
+gdy kursor opuści otwarte ikony.
+
+Mod działa przez UI Automation, więc nie hookuje wewnętrznych funkcji powłoki —
+jest stosunkowo bezpieczny i odporny na zmiany między kompilacjami Windows.
+Działa jako „tool mod" w osobnym procesie i nie wstrzykuje się do powłoki.
+
+### Czym różni się od podobnych modów
+- *Taskbar tray icons hide on hover* automatycznie ukrywa cały obszar zasobnika
+  i odsłania go po najechaniu.
+- *Show all taskbar notification icons* wymusza stałe wyświetlanie wszystkich
+  ukrytych ikon.
+- Ten mod zachowuje standardowy schowek Windows i po prostu otwiera go po
+  najechaniu (a opcjonalnie zamyka po odjechaniu kursorem).
+
+### Jak wykrywana jest strzałka
+Strzałka „Pokaż ukryte ikony" nie ma w Windows 11 unikalnego, niezależnego od
+języka identyfikatora (dzieli AutomationId `SystemTrayIcon` z zegarem,
+głośnością, baterią itd. i nie udostępnia wzorca ExpandCollapse). Wykrywanie
+jest więc hybrydowe:
+1. Dopasowanie przycisku po nazwie (domyślna lista słów kluczowych obejmuje
+   angielski i polski; można ją rozszerzyć w ustawieniach).
+2. Gdy nazwa nie pasuje (inne języki) — pierwszy od lewej przycisk zasobnika ze
+   skonfigurowanym AutomationId, którym zwykle jest strzałka.
+
+### Uwagi
+- Dla nieobsługiwanych języków dodaj nazwę strzałki w swoim języku do ustawienia
+  „Słowa kluczowe nazwy strzałki" albo polegaj na powyższym mechanizmie zapasowym.
+- Jeśli auto-zwijanie nie działa, nazwa klasy okna schowka może się różnić na
+  Twojej kompilacji systemu. Zmień ją w ustawieniu „Klasa okna schowka".
 */
 // ==/WindhawkModReadme==
 
@@ -41,34 +88,52 @@ battery, etc., and exposes no ExpandCollapse pattern). So detection is a hybrid:
 /*
 - autoClose: true
   $name: Collapse when the cursor leaves
+  $name:pl-PL: Zwijaj po odjechaniu kursorem
   $description: After the cursor leaves the opened icons (and the chevron), the flyout closes itself.
+  $description:pl-PL: Gdy kursor opuści otwarte ikony (i strzałkę), schowek sam się zamyka.
 - pollInterval: 50
   $name: Polling interval (ms)
+  $name:pl-PL: Częstotliwość sprawdzania (ms)
   $description: How often to check the cursor position. Lower = smoother, more CPU.
+  $description:pl-PL: Co ile sprawdzać pozycję kursora. Mniej = płynniej, większe użycie CPU.
 - grace: 200
   $name: Collapse delay (ms)
+  $name:pl-PL: Opóźnienie zwijania (ms)
   $description: How long the cursor must stay outside the area before the flyout closes (prevents flicker).
+  $description:pl-PL: Jak długo kursor musi pozostawać poza obszarem, zanim schowek się zamknie (zapobiega miganiu).
 - pad: 4
   $name: Hit area padding (pixels)
+  $name:pl-PL: Margines obszaru najechania (piksele)
   $description: Enlarges the hover area around the chevron button.
+  $description:pl-PL: Powiększa obszar najechania wokół przycisku strzałki.
+- keywords: ["ukryte ikony", "hidden icons", "rozwiń", "overflow"]
+  $name: Chevron name keywords
+  $name:pl-PL: Słowa kluczowe nazwy strzałki
+  $description: Case-insensitive substrings used to match the chevron button name. Add your locale's name for "Show Hidden Icons" here.
+  $description:pl-PL: Fragmenty nazwy przycisku strzałki (wielkość liter bez znaczenia). Dodaj tu nazwę „Pokaż ukryte ikony" w swoim języku.
 - flyoutClass: TopLevelWindowForOverflowXamlIsland
   $name: Flyout window class
+  $name:pl-PL: Klasa okna schowka
   $description: Window class name of the opened flyout (used to tell whether the cursor is over the icons). Change it if auto-collapse does not work.
+  $description:pl-PL: Nazwa klasy okna otwartego schowka (służy do sprawdzania, czy kursor jest nad ikonami). Zmień ją, jeśli auto-zwijanie nie działa.
 - trayIconAutomationId: SystemTrayIcon
   $name: Tray icon AutomationId (fallback)
-  $description: Used only when the chevron is not matched by name (non-English/Polish systems). The leftmost tray button with this AutomationId is then assumed to be the chevron.
+  $name:pl-PL: AutomationId ikony zasobnika (mechanizm zapasowy)
+  $description: Used only when the chevron is not matched by name. The leftmost tray button with this AutomationId is then assumed to be the chevron.
+  $description:pl-PL: Używane tylko, gdy strzałki nie uda się dopasować po nazwie. Za strzałkę uznawany jest wtedy pierwszy od lewej przycisk zasobnika o tym AutomationId.
 */
 // ==/WindhawkModSettings==
 
 #include <windows.h>
+#include <shellapi.h>
 #include <uiautomation.h>
+#include <atomic>
 #include <string>
 #include <vector>
 #include <algorithm>
 
-// GUID-y na wszelki wypadek (gdyby linker MinGW ich nie dostarczył).
 #ifndef __IUIAutomation_FWD_DEFINED__
-#error "Brak nagłówków UI Automation"
+#error "UI Automation headers are missing"
 #endif
 
 struct Settings {
@@ -83,9 +148,23 @@ struct Settings {
     };
 };
 
+// g_settings is guarded by g_settingsLock; the worker thread keeps a private
+// snapshot and refreshes it when g_settingsGeneration changes, so it never
+// reads the strings while the settings thread reassigns them.
 static Settings g_settings;
-static volatile bool g_running = false;
+static SRWLOCK g_settingsLock = SRWLOCK_INIT;
+static std::atomic<int> g_settingsGeneration{0};
+
+static std::atomic<bool> g_running{false};
 static HANDLE g_thread = nullptr;
+static HANDLE g_stopEvent = nullptr;
+
+static Settings GetSettingsSnapshot() {
+    AcquireSRWLockShared(&g_settingsLock);
+    Settings s = g_settings;
+    ReleaseSRWLockShared(&g_settingsLock);
+    return s;
+}
 
 static std::wstring ToLower(const std::wstring& s) {
     std::wstring r = s;
@@ -93,15 +172,15 @@ static std::wstring ToLower(const std::wstring& s) {
     return r;
 }
 
-static bool NameMatches(const std::wstring& name) {
+static bool NameMatches(const std::wstring& name, const Settings& s) {
     std::wstring low = ToLower(name);
-    for (const auto& k : g_settings.keywords) {
+    for (const auto& k : s.keywords) {
         if (!k.empty() && low.find(ToLower(k)) != std::wstring::npos) return true;
     }
     return false;
 }
 
-// ---- Pomocnicze: pobranie wzorców UIA ----
+// ---- UIA pattern helpers ----
 
 static void DoExpand(IUIAutomationElement* e) {
     IUIAutomationExpandCollapsePattern* p = nullptr;
@@ -130,7 +209,7 @@ static void DoCollapse(IUIAutomationElement* e) {
         p->Release();
         return;
     }
-    // Fallback przy braku ExpandCollapse: ponowne Invoke (toggle).
+    // No ExpandCollapse support: a second Invoke toggles the flyout closed.
     IUIAutomationInvokePattern* inv = nullptr;
     if (SUCCEEDED(e->GetCurrentPatternAs(
             UIA_InvokePatternId,
@@ -140,9 +219,10 @@ static void DoCollapse(IUIAutomationElement* e) {
     }
 }
 
-// ---- Znajdowanie przycisku chevron ----
+// ---- Locating the chevron button ----
 
-static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto) {
+static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto,
+                                                const Settings& s) {
     HWND hTaskbar = FindWindowW(L"Shell_TrayWnd", nullptr);
     if (!hTaskbar) return nullptr;
 
@@ -154,10 +234,10 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto) {
     v.vt = VT_I4; v.lVal = UIA_ButtonControlTypeId;
     pAuto->CreatePropertyCondition(UIA_ControlTypePropertyId, v, &pCond);
 
-    // Strategia hybrydowa:
-    //  1) dopasowanie po nazwie (pewne dla znanych języków),
-    //  2) fallback: najlewszy przycisk o danym AutomationId (językowo-niezależny,
-    //     ale heurystyczny) — używany tylko, gdy nazwa nie pasuje.
+    // Hybrid strategy:
+    //  1) match by name (reliable for configured languages),
+    //  2) fallback: the leftmost button with the configured AutomationId
+    //     (language-independent but heuristic) — used only when no name matches.
     IUIAutomationElement* nameMatch = nullptr;
     IUIAutomationElement* leftmost = nullptr;
     LONG leftmostX = 0;
@@ -171,17 +251,17 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto) {
 
             BSTR name = nullptr;
             e->get_CurrentName(&name);
-            bool matched = (name && NameMatches(name));
+            bool matched = (name && NameMatches(name, s));
             if (name) SysFreeString(name);
             if (matched) {
-                nameMatch = e;           // zachowujemy referencję; nazwa wygrywa
+                nameMatch = e;           // keep the reference; a name match wins
                 break;
             }
 
-            // Kandydat do fallbacku: przycisk zasobnika o danym AutomationId.
+            // Fallback candidate: a tray button with the configured AutomationId.
             BSTR aid = nullptr;
             e->get_CurrentAutomationId(&aid);
-            bool isTrayIcon = (aid && g_settings.trayIconAutomationId == aid);
+            bool isTrayIcon = (aid && s.trayIconAutomationId == aid);
             if (aid) SysFreeString(aid);
 
             if (isTrayIcon) {
@@ -189,7 +269,7 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto) {
                 if (SUCCEEDED(e->get_CurrentBoundingRectangle(&r)) &&
                     (!leftmost || r.left < leftmostX)) {
                     if (leftmost) leftmost->Release();
-                    leftmost = e;        // zachowujemy nowego najlewszego
+                    leftmost = e;        // keep the new leftmost candidate
                     leftmostX = r.left;
                     e = nullptr;
                 }
@@ -205,7 +285,7 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto) {
         if (leftmost) leftmost->Release();
         return nameMatch;
     }
-    return leftmost;   // nullptr, jeśli nic nie pasuje
+    return leftmost;   // nullptr if nothing matched
 }
 
 static bool PtInRectPad(const RECT& r, POINT pt, int pad) {
@@ -214,24 +294,27 @@ static bool PtInRectPad(const RECT& r, POINT pt, int pad) {
 }
 
 static const ULONGLONG ACTION_COOLDOWN_MS = 300;
+static const ULONGLONG REFIND_INTERVAL_MS = 3000;
+static const ULONGLONG RECT_REFRESH_MS = 750;
+static const ULONGLONG IDLE_STATE_CHECK_MS = 500;
 
-// Tani (czysto Win32) test, czy schowek jest otwarty — bez zapytań UIA.
-// Chevron i tak nie wspiera ExpandCollapse, więc widoczność okna flyoutu
-// jest tym samym sygnałem, którego używał fallback w GetState().
-static bool IsFlyoutOpen() {
-    HWND f = FindWindowW(g_settings.flyoutClass.c_str(), nullptr);
+// Cheap (pure Win32) check whether the flyout is open — no UIA calls.
+// The chevron does not support the ExpandCollapse pattern anyway, so the
+// flyout window's visibility is the only reliable state signal.
+static bool IsFlyoutOpen(const Settings& s) {
+    HWND f = FindWindowW(s.flyoutClass.c_str(), nullptr);
     return f && IsWindowVisible(f);
 }
 
-static bool CursorOverFlyout(POINT pt) {
-    HWND f = FindWindowW(g_settings.flyoutClass.c_str(), nullptr);
+static bool CursorOverFlyout(POINT pt, const Settings& s) {
+    HWND f = FindWindowW(s.flyoutClass.c_str(), nullptr);
     if (!f || !IsWindowVisible(f)) return false;
     RECT r;
     if (!GetWindowRect(f, &r)) return false;
     return PtInRect(&r, pt);
 }
 
-// ---- Wątek roboczy ----
+// ---- Worker thread ----
 
 static DWORD WINAPI WorkerThread(LPVOID) {
     CoInitializeEx(nullptr, COINIT_MULTITHREADED);
@@ -244,29 +327,41 @@ static DWORD WINAPI WorkerThread(LPVOID) {
         return 0;
     }
 
+    Settings s = GetSettingsSnapshot();
+    int settingsGen = g_settingsGeneration;
+
     IUIAutomationElement* pBtn = nullptr;
     RECT cachedRect = {};
     bool haveRect = false;
+    bool flyoutBelievedOpen = false;
     ULONGLONG leftAt = 0;
     ULONGLONG nextRefind = 0;
     ULONGLONG nextRectRefresh = 0;
+    ULONGLONG nextIdleStateCheck = 0;
     ULONGLONG lastOpenAt = 0;
     bool overBtnPrev = false;
 
     while (g_running) {
         ULONGLONG now = GetTickCount64();
 
-        // Drogo i RZADKO: odśwież referencję przycisku (pasek mógł się przebudować).
+        if (g_settingsGeneration != settingsGen) {
+            s = GetSettingsSnapshot();
+            settingsGen = g_settingsGeneration;
+            nextRefind = 0;             // settings may change how we detect things
+        }
+
+        // Expensive and RARE: refresh the button reference (the taskbar may
+        // have been rebuilt).
         if (!pBtn || now >= nextRefind) {
             if (pBtn) { pBtn->Release(); pBtn = nullptr; }
-            pBtn = FindOverflowButton(pAuto);
-            nextRefind = now + 3000;
-            nextRectRefresh = 0;          // wymuś świeży prostokąt poniżej
+            pBtn = FindOverflowButton(pAuto, s);
+            nextRefind = now + REFIND_INTERVAL_MS;
+            nextRectRefresh = 0;        // force a fresh rectangle below
         }
 
         if (pBtn) {
-            // Drogo i RZADKO: pobierz prostokąt przycisku przez UIA tylko co ~750 ms,
-            // a nie co tick. Chevron prawie nigdy nie zmienia pozycji.
+            // Expensive and RARE: query the button rectangle through UIA only
+            // periodically, not every tick. The chevron rarely moves.
             if (now >= nextRectRefresh) {
                 RECT r;
                 if (SUCCEEDED(pBtn->get_CurrentBoundingRectangle(&r))) {
@@ -274,45 +369,57 @@ static DWORD WINAPI WorkerThread(LPVOID) {
                     haveRect = true;
                 } else {
                     pBtn->Release(); pBtn = nullptr; haveRect = false;
-                    Sleep(g_settings.pollInterval);
+                    WaitForSingleObject(g_stopEvent, s.pollInterval);
                     continue;
                 }
-                nextRectRefresh = now + 750;
+                nextRectRefresh = now + RECT_REFRESH_MS;
             }
         }
 
         if (haveRect) {
-            // TANIO i CO TICK: tylko lokalne wywołania Win32.
+            // Cheap and EVERY TICK: only local Win32 calls.
             POINT pt; GetCursorPos(&pt);
-            bool overBtn = PtInRectPad(cachedRect, pt, g_settings.pad);
+            bool overBtn = PtInRectPad(cachedRect, pt, s.pad);
             bool cooling = (now - lastOpenAt < ACTION_COOLDOWN_MS);
+            bool enterEdge = overBtn && !overBtnPrev && !cooling;
 
-            // Stan schowka sprawdzamy tanio (widoczność okna flyoutu) i tylko
-            // gdy jest potrzebny: na zboczu wejścia albo przy auto-zwijaniu.
-            bool needState = (overBtn && !overBtnPrev && !cooling) || g_settings.autoClose;
-            bool flyoutVisible = needState ? IsFlyoutOpen() : false;
+            // The flyout state is only needed on the cursor-enter edge (to
+            // avoid toggling an open flyout closed) and while auto-collapse is
+            // watching an open flyout. When idle, throttle the check so a
+            // manually opened flyout is still noticed without paying a
+            // FindWindowW call on every tick.
+            bool flyoutVisible = false;
+            if (enterEdge || (s.autoClose && flyoutBelievedOpen)) {
+                flyoutVisible = IsFlyoutOpen(s);
+            } else if (s.autoClose && now >= nextIdleStateCheck) {
+                flyoutVisible = IsFlyoutOpen(s);
+                nextIdleStateCheck = now + IDLE_STATE_CHECK_MS;
+            }
+            flyoutBelievedOpen = flyoutVisible || cooling;
 
-            // Otwórz tylko na zboczu wejścia kursora na przycisk i tylko gdy
-            // schowek nie jest otwarty. Chevron działa jak przełącznik, więc
-            // każde nadmiarowe Invoke by go zamknęło.
-            if (overBtn && !overBtnPrev && !cooling && !flyoutVisible) {
+            // Open only on the cursor-enter edge and only when the flyout is
+            // not already open. The chevron acts as a toggle, so any redundant
+            // Invoke would close it again.
+            if (enterEdge && !flyoutVisible) {
                 DoExpand(pBtn);
                 lastOpenAt = now;
+                flyoutBelievedOpen = true;
                 leftAt = 0;
                 Wh_Log(L"OPEN");
             }
             overBtnPrev = overBtn;
 
-            // Auto-zwijanie po wyjściu kursora poza przycisk i okno schowka.
-            if (g_settings.autoClose && flyoutVisible && !cooling) {
-                bool overFlyout = CursorOverFlyout(pt);
+            // Auto-collapse once the cursor left both the button and the flyout.
+            if (s.autoClose && flyoutVisible && !cooling) {
+                bool overFlyout = CursorOverFlyout(pt, s);
                 if (overBtn || overFlyout) {
                     leftAt = 0;
                 } else if (leftAt == 0) {
                     leftAt = now;
-                } else if (now - leftAt >= (ULONGLONG)g_settings.grace) {
+                } else if (now - leftAt >= (ULONGLONG)s.grace) {
                     DoCollapse(pBtn);
                     leftAt = 0;
+                    flyoutBelievedOpen = false;
                     Wh_Log(L"CLOSE after grace");
                 }
             } else {
@@ -320,7 +427,9 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             }
         }
 
-        Sleep(g_settings.pollInterval);
+        // Interruptible sleep: WhTool_ModUninit signals g_stopEvent so the
+        // thread wakes immediately regardless of the polling interval.
+        WaitForSingleObject(g_stopEvent, s.pollInterval);
     }
 
     if (pBtn) pBtn->Release();
@@ -329,39 +438,239 @@ static DWORD WINAPI WorkerThread(LPVOID) {
     return 0;
 }
 
-// ---- Cykl życia moda ----
+// ---- Mod lifecycle (tool mod) ----
 
 static void LoadSettings() {
-    g_settings.autoClose = Wh_GetIntSetting(L"autoClose") != 0;
-    g_settings.pollInterval = (int)Wh_GetIntSetting(L"pollInterval");
-    g_settings.grace = (int)Wh_GetIntSetting(L"grace");
-    g_settings.pad = (int)Wh_GetIntSetting(L"pad");
-    if (g_settings.pollInterval < 10) g_settings.pollInterval = 10;
-    if (g_settings.grace < 0) g_settings.grace = 0;
+    Settings s;
 
+    s.autoClose = Wh_GetIntSetting(L"autoClose") != 0;
+    s.pollInterval = (int)Wh_GetIntSetting(L"pollInterval");
+    s.grace = (int)Wh_GetIntSetting(L"grace");
+    s.pad = (int)Wh_GetIntSetting(L"pad");
+    if (s.pollInterval < 10) s.pollInterval = 10;
+    if (s.grace < 0) s.grace = 0;
+
+    // Wh_GetStringSetting never returns NULL (it returns L"" on unset/error),
+    // so only override the defaults with non-empty values.
     PCWSTR fc = Wh_GetStringSetting(L"flyoutClass");
-    if (fc) { g_settings.flyoutClass = fc; Wh_FreeStringSetting(fc); }
+    if (*fc) s.flyoutClass = fc;
+    Wh_FreeStringSetting(fc);
 
     PCWSTR aid = Wh_GetStringSetting(L"trayIconAutomationId");
-    if (aid) { g_settings.trayIconAutomationId = aid; Wh_FreeStringSetting(aid); }
+    if (*aid) s.trayIconAutomationId = aid;
+    Wh_FreeStringSetting(aid);
+
+    std::vector<std::wstring> keywords;
+    for (int i = 0;; i++) {
+        PCWSTR k = Wh_GetStringSetting(L"keywords[%d]", i);
+        bool empty = !*k;
+        if (!empty) keywords.push_back(k);
+        Wh_FreeStringSetting(k);
+        if (empty) break;
+    }
+    if (!keywords.empty()) s.keywords = std::move(keywords);
+
+    AcquireSRWLockExclusive(&g_settingsLock);
+    g_settings = std::move(s);
+    ReleaseSRWLockExclusive(&g_settingsLock);
+    g_settingsGeneration++;
 }
 
-BOOL Wh_ModInit() {
+BOOL WhTool_ModInit() {
     LoadSettings();
+
+    g_stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (!g_stopEvent) {
+        Wh_Log(L"CreateEvent failed");
+        return FALSE;
+    }
+
     g_running = true;
     g_thread = CreateThread(nullptr, 0, WorkerThread, nullptr, 0, nullptr);
-    return g_thread != nullptr;
+    if (!g_thread) {
+        g_running = false;
+        CloseHandle(g_stopEvent);
+        g_stopEvent = nullptr;
+        return FALSE;
+    }
+    return TRUE;
 }
 
-void Wh_ModSettingsChanged() {
+void WhTool_ModSettingsChanged() {
     LoadSettings();
 }
 
-void Wh_ModUninit() {
+void WhTool_ModUninit() {
     g_running = false;
+    if (g_stopEvent) {
+        SetEvent(g_stopEvent);
+    }
     if (g_thread) {
-        WaitForSingleObject(g_thread, 3000);
+        // Safe to wait without a timeout: the worker only blocks in the
+        // interruptible wait above, so it exits promptly once signaled.
+        WaitForSingleObject(g_thread, INFINITE);
         CloseHandle(g_thread);
         g_thread = nullptr;
     }
+    if (g_stopEvent) {
+        CloseHandle(g_stopEvent);
+        g_stopEvent = nullptr;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Tool mod boilerplate
+
+bool g_isToolModProcessLauncher;
+HANDLE g_toolModProcessMutex;
+
+void WINAPI EntryPoint_Hook() {
+    Wh_Log(L">");
+    ExitThread(0);
+}
+
+BOOL Wh_ModInit() {
+    bool isExcluded = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+    int argc;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
+    if (!argv) {
+        Wh_Log(L"CommandLineToArgvW failed");
+        return FALSE;
+    }
+
+    for (int i = 1; i < argc; i++) {
+        if (wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0) {
+            isExcluded = true;
+            break;
+        }
+    }
+
+    for (int i = 1; i < argc - 1; i++) {
+        if (wcscmp(argv[i], L"-tool-mod") == 0) {
+            isToolModProcess = true;
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
+                isCurrentToolModProcess = true;
+            }
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isExcluded) {
+        return FALSE;
+    }
+
+    if (isCurrentToolModProcess) {
+        g_toolModProcessMutex =
+            CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
+        if (!g_toolModProcessMutex) {
+            Wh_Log(L"CreateMutex failed");
+            ExitProcess(1);
+        }
+
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
+            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
+            ExitProcess(1);
+        }
+
+        if (!WhTool_ModInit()) {
+            ExitProcess(1);
+        }
+
+        IMAGE_DOS_HEADER* dosHeader =
+            (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
+        IMAGE_NT_HEADERS* ntHeaders =
+            (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
+
+        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
+        void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
+
+        Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
+        return TRUE;
+    }
+
+    if (isToolModProcess) {
+        return FALSE;
+    }
+
+    g_isToolModProcessLauncher = true;
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (!g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WCHAR currentProcessPath[MAX_PATH];
+    switch (GetModuleFileName(nullptr, currentProcessPath,
+                              ARRAYSIZE(currentProcessPath))) {
+        case 0:
+        case ARRAYSIZE(currentProcessPath):
+            Wh_Log(L"GetModuleFileName failed");
+            return;
+    }
+
+    WCHAR commandLine[MAX_PATH + 2 +
+                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
+    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
+               WH_MOD_ID);
+
+    HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
+    if (!kernelModule) {
+        kernelModule = GetModuleHandle(L"kernel32.dll");
+        if (!kernelModule) {
+            Wh_Log(L"No kernelbase.dll/kernel32.dll");
+            return;
+        }
+    }
+
+    using CreateProcessInternalW_t = BOOL(WINAPI*)(
+        HANDLE, LPCWSTR, LPWSTR, LPSECURITY_ATTRIBUTES,
+        LPSECURITY_ATTRIBUTES, WINBOOL, DWORD, LPVOID, LPCWSTR,
+        LPSTARTUPINFOW, LPPROCESS_INFORMATION, PHANDLE);
+    CreateProcessInternalW_t pCreateProcessInternalW =
+        (CreateProcessInternalW_t)GetProcAddress(kernelModule,
+                                                 "CreateProcessInternalW");
+    if (!pCreateProcessInternalW) {
+        Wh_Log(L"No CreateProcessInternalW");
+        return;
+    }
+
+    STARTUPINFO si{
+        .cb = sizeof(STARTUPINFO),
+        .dwFlags = STARTF_FORCEOFFFEEDBACK,
+    };
+    PROCESS_INFORMATION pi;
+    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
+                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
+                                 nullptr, nullptr, &si, &pi, nullptr)) {
+        Wh_Log(L"CreateProcess failed");
+        return;
+    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+}
+
+void Wh_ModSettingsChanged() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModSettingsChanged();
+}
+
+void Wh_ModUninit() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModUninit();
+    ExitProcess(0);
 }

--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -2,7 +2,7 @@
 // @id              tray-hover-expand
 // @name            Tray hover expand
 // @description     Open the hidden tray icons flyout on hover instead of clicking the chevron; optionally collapse it when the cursor leaves
-// @version         1.0.0
+// @version         1.3.0
 // @author          wygodad
 // @github          https://github.com/wygodad
 // @include         explorer.exe
@@ -21,10 +21,17 @@ again once the cursor leaves the opened icons.
 It works through UI Automation, so it does not hook internal shell functions —
 it is relatively safe and resilient across Windows builds.
 
+## How the chevron is detected
+The "Show Hidden Icons" chevron has no language-independent unique identifier on
+Windows 11 (it shares AutomationId `SystemTrayIcon` with the clock, volume,
+battery, etc., and exposes no ExpandCollapse pattern). So detection is a hybrid:
+1. Match the button by name (keywords cover English and Polish by default).
+2. If no name matches (other languages), fall back to the leftmost tray button
+   with the configured AutomationId, which is normally the chevron.
+
 ## Notes
-- If the chevron button is not detected, the matching is name-based. The default
-  keywords cover English and Polish; other languages may need the button's name
-  added to the `keywords` list in the source.
+- For unsupported languages, either add the button's name to the `keywords` list
+  in the source, or rely on the leftmost-tray-icon fallback.
 - If auto-collapse does not work, the flyout window class name may differ on your
   build. Change it in the "Flyout window class" setting.
 */
@@ -47,6 +54,9 @@ it is relatively safe and resilient across Windows builds.
 - flyoutClass: TopLevelWindowForOverflowXamlIsland
   $name: Flyout window class
   $description: Window class name of the opened flyout (used to tell whether the cursor is over the icons). Change it if auto-collapse does not work.
+- trayIconAutomationId: SystemTrayIcon
+  $name: Tray icon AutomationId (fallback)
+  $description: Used only when the chevron is not matched by name (non-English/Polish systems). The leftmost tray button with this AutomationId is then assumed to be the chevron.
 */
 // ==/WindhawkModSettings==
 
@@ -67,6 +77,7 @@ struct Settings {
     int grace = 200;
     int pad = 4;
     std::wstring flyoutClass = L"TopLevelWindowForOverflowXamlIsland";
+    std::wstring trayIconAutomationId = L"SystemTrayIcon";
     std::vector<std::wstring> keywords = {
         L"ukryte ikony", L"hidden icons", L"rozwiń", L"overflow"
     };
@@ -91,22 +102,6 @@ static bool NameMatches(const std::wstring& name) {
 }
 
 // ---- Pomocnicze: pobranie wzorców UIA ----
-
-static ExpandCollapseState GetState(IUIAutomationElement* e) {
-    IUIAutomationExpandCollapsePattern* p = nullptr;
-    if (SUCCEEDED(e->GetCurrentPatternAs(
-            UIA_ExpandCollapsePatternId,
-            __uuidof(IUIAutomationExpandCollapsePattern), (void**)&p)) && p) {
-        ExpandCollapseState s = ExpandCollapseState_Collapsed;
-        p->get_CurrentExpandCollapseState(&s);
-        p->Release();
-        return s;
-    }
-    // Fallback: stan po widoczności okna flyoutu.
-    HWND f = FindWindowW(g_settings.flyoutClass.c_str(), nullptr);
-    return (f && IsWindowVisible(f)) ? ExpandCollapseState_Expanded
-                                     : ExpandCollapseState_Collapsed;
-}
 
 static void DoExpand(IUIAutomationElement* e) {
     IUIAutomationExpandCollapsePattern* p = nullptr;
@@ -159,34 +154,73 @@ static IUIAutomationElement* FindOverflowButton(IUIAutomation* pAuto) {
     v.vt = VT_I4; v.lVal = UIA_ButtonControlTypeId;
     pAuto->CreatePropertyCondition(UIA_ControlTypePropertyId, v, &pCond);
 
-    IUIAutomationElement* result = nullptr;
+    // Strategia hybrydowa:
+    //  1) dopasowanie po nazwie (pewne dla znanych języków),
+    //  2) fallback: najlewszy przycisk o danym AutomationId (językowo-niezależny,
+    //     ale heurystyczny) — używany tylko, gdy nazwa nie pasuje.
+    IUIAutomationElement* nameMatch = nullptr;
+    IUIAutomationElement* leftmost = nullptr;
+    LONG leftmostX = 0;
+
     IUIAutomationElementArray* pArr = nullptr;
     if (pCond && SUCCEEDED(pRoot->FindAll(TreeScope_Subtree, pCond, &pArr)) && pArr) {
         int n = 0; pArr->get_Length(&n);
         for (int i = 0; i < n; i++) {
             IUIAutomationElement* e = nullptr;
-            if (SUCCEEDED(pArr->GetElement(i, &e)) && e) {
-                BSTR name = nullptr;
-                e->get_CurrentName(&name);
-                if (name && NameMatches(name)) {
-                    SysFreeString(name);
-                    result = e;          // zachowujemy referencję
-                    break;
-                }
-                if (name) SysFreeString(name);
-                e->Release();
+            if (FAILED(pArr->GetElement(i, &e)) || !e) continue;
+
+            BSTR name = nullptr;
+            e->get_CurrentName(&name);
+            bool matched = (name && NameMatches(name));
+            if (name) SysFreeString(name);
+            if (matched) {
+                nameMatch = e;           // zachowujemy referencję; nazwa wygrywa
+                break;
             }
+
+            // Kandydat do fallbacku: przycisk zasobnika o danym AutomationId.
+            BSTR aid = nullptr;
+            e->get_CurrentAutomationId(&aid);
+            bool isTrayIcon = (aid && g_settings.trayIconAutomationId == aid);
+            if (aid) SysFreeString(aid);
+
+            if (isTrayIcon) {
+                RECT r;
+                if (SUCCEEDED(e->get_CurrentBoundingRectangle(&r)) &&
+                    (!leftmost || r.left < leftmostX)) {
+                    if (leftmost) leftmost->Release();
+                    leftmost = e;        // zachowujemy nowego najlewszego
+                    leftmostX = r.left;
+                    e = nullptr;
+                }
+            }
+            if (e) e->Release();
         }
         pArr->Release();
     }
     if (pCond) pCond->Release();
     pRoot->Release();
-    return result;
+
+    if (nameMatch) {
+        if (leftmost) leftmost->Release();
+        return nameMatch;
+    }
+    return leftmost;   // nullptr, jeśli nic nie pasuje
 }
 
 static bool PtInRectPad(const RECT& r, POINT pt, int pad) {
     return pt.x >= r.left - pad && pt.x <= r.right + pad &&
            pt.y >= r.top - pad  && pt.y <= r.bottom + pad;
+}
+
+static const ULONGLONG ACTION_COOLDOWN_MS = 300;
+
+// Tani (czysto Win32) test, czy schowek jest otwarty — bez zapytań UIA.
+// Chevron i tak nie wspiera ExpandCollapse, więc widoczność okna flyoutu
+// jest tym samym sygnałem, którego używał fallback w GetState().
+static bool IsFlyoutOpen() {
+    HWND f = FindWindowW(g_settings.flyoutClass.c_str(), nullptr);
+    return f && IsWindowVisible(f);
 }
 
 static bool CursorOverFlyout(POINT pt) {
@@ -211,48 +245,75 @@ static DWORD WINAPI WorkerThread(LPVOID) {
     }
 
     IUIAutomationElement* pBtn = nullptr;
+    RECT cachedRect = {};
+    bool haveRect = false;
     ULONGLONG leftAt = 0;
     ULONGLONG nextRefind = 0;
+    ULONGLONG nextRectRefresh = 0;
+    ULONGLONG lastOpenAt = 0;
+    bool overBtnPrev = false;
 
     while (g_running) {
         ULONGLONG now = GetTickCount64();
 
+        // Drogo i RZADKO: odśwież referencję przycisku (pasek mógł się przebudować).
         if (!pBtn || now >= nextRefind) {
-            // Okresowo odśwież referencję (pasek mógł się przebudować).
             if (pBtn) { pBtn->Release(); pBtn = nullptr; }
             pBtn = FindOverflowButton(pAuto);
             nextRefind = now + 3000;
+            nextRectRefresh = 0;          // wymuś świeży prostokąt poniżej
         }
 
         if (pBtn) {
-            RECT r;
-            if (FAILED(pBtn->get_CurrentBoundingRectangle(&r))) {
-                pBtn->Release(); pBtn = nullptr;
-                Sleep(g_settings.pollInterval);
-                continue;
+            // Drogo i RZADKO: pobierz prostokąt przycisku przez UIA tylko co ~750 ms,
+            // a nie co tick. Chevron prawie nigdy nie zmienia pozycji.
+            if (now >= nextRectRefresh) {
+                RECT r;
+                if (SUCCEEDED(pBtn->get_CurrentBoundingRectangle(&r))) {
+                    cachedRect = r;
+                    haveRect = true;
+                } else {
+                    pBtn->Release(); pBtn = nullptr; haveRect = false;
+                    Sleep(g_settings.pollInterval);
+                    continue;
+                }
+                nextRectRefresh = now + 750;
             }
+        }
 
+        if (haveRect) {
+            // TANIO i CO TICK: tylko lokalne wywołania Win32.
             POINT pt; GetCursorPos(&pt);
-            bool overBtn = PtInRectPad(r, pt, g_settings.pad);
-            ExpandCollapseState st = GetState(pBtn);
-            bool expanded = (st == ExpandCollapseState_Expanded);
+            bool overBtn = PtInRectPad(cachedRect, pt, g_settings.pad);
+            bool cooling = (now - lastOpenAt < ACTION_COOLDOWN_MS);
 
-            if (overBtn && !expanded) {
+            // Stan schowka sprawdzamy tanio (widoczność okna flyoutu) i tylko
+            // gdy jest potrzebny: na zboczu wejścia albo przy auto-zwijaniu.
+            bool needState = (overBtn && !overBtnPrev && !cooling) || g_settings.autoClose;
+            bool flyoutVisible = needState ? IsFlyoutOpen() : false;
+
+            // Otwórz tylko na zboczu wejścia kursora na przycisk i tylko gdy
+            // schowek nie jest otwarty. Chevron działa jak przełącznik, więc
+            // każde nadmiarowe Invoke by go zamknęło.
+            if (overBtn && !overBtnPrev && !cooling && !flyoutVisible) {
                 DoExpand(pBtn);
+                lastOpenAt = now;
                 leftAt = 0;
+                Wh_Log(L"OPEN");
             }
+            overBtnPrev = overBtn;
 
-            if (g_settings.autoClose && expanded) {
+            // Auto-zwijanie po wyjściu kursora poza przycisk i okno schowka.
+            if (g_settings.autoClose && flyoutVisible && !cooling) {
                 bool overFlyout = CursorOverFlyout(pt);
                 if (overBtn || overFlyout) {
                     leftAt = 0;
-                } else {
-                    if (leftAt == 0) {
-                        leftAt = now;
-                    } else if (now - leftAt >= (ULONGLONG)g_settings.grace) {
-                        DoCollapse(pBtn);
-                        leftAt = 0;
-                    }
+                } else if (leftAt == 0) {
+                    leftAt = now;
+                } else if (now - leftAt >= (ULONGLONG)g_settings.grace) {
+                    DoCollapse(pBtn);
+                    leftAt = 0;
+                    Wh_Log(L"CLOSE after grace");
                 }
             } else {
                 leftAt = 0;
@@ -280,6 +341,9 @@ static void LoadSettings() {
 
     PCWSTR fc = Wh_GetStringSetting(L"flyoutClass");
     if (fc) { g_settings.flyoutClass = fc; Wh_FreeStringSetting(fc); }
+
+    PCWSTR aid = Wh_GetStringSetting(L"trayIconAutomationId");
+    if (aid) { g_settings.trayIconAutomationId = aid; Wh_FreeStringSetting(aid); }
 }
 
 BOOL Wh_ModInit() {

--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -2,7 +2,7 @@
 // @id              tray-hover-expand
 // @name            Tray hover expand
 // @description     Open the hidden tray icons flyout on hover instead of clicking the chevron; optionally collapse it when the cursor leaves
-// @version         1.4.0
+// @version         1.4.1
 // @author          wygodad
 // @github          https://github.com/wygodad
 // @include         windhawk.exe
@@ -340,6 +340,8 @@ static DWORD WINAPI WorkerThread(LPVOID) {
     ULONGLONG nextIdleStateCheck = 0;
     ULONGLONG lastOpenAt = 0;
     bool overBtnPrev = false;
+    bool clickedInFlyout = false;
+    bool anyBtnDownPrev = false;
 
     while (g_running) {
         ULONGLONG now = GetTickCount64();
@@ -409,8 +411,26 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             }
             overBtnPrev = overBtn;
 
+            // Detect a click inside the flyout: the user is interacting with
+            // an icon (e.g. its popup window just opened and took focus).
+            // Suspend auto-collapse until the flyout closes on its own —
+            // collapsing via Invoke would steal focus and dismiss the popup
+            // the user just opened.
+            bool anyBtnDown = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) ||
+                              (GetAsyncKeyState(VK_RBUTTON) & 0x8000) ||
+                              (GetAsyncKeyState(VK_MBUTTON) & 0x8000);
+            if (anyBtnDown && !anyBtnDownPrev && flyoutVisible &&
+                CursorOverFlyout(pt, s)) {
+                clickedInFlyout = true;
+                Wh_Log(L"Click inside flyout: auto-collapse suspended");
+            }
+            anyBtnDownPrev = anyBtnDown;
+            if (!flyoutVisible && !cooling) {
+                clickedInFlyout = false;
+            }
+
             // Auto-collapse once the cursor left both the button and the flyout.
-            if (s.autoClose && flyoutVisible && !cooling) {
+            if (s.autoClose && flyoutVisible && !cooling && !clickedInFlyout) {
                 bool overFlyout = CursorOverFlyout(pt, s);
                 if (overBtn || overFlyout) {
                     leftAt = 0;

--- a/mods/tray-hover-expand.wh.cpp
+++ b/mods/tray-hover-expand.wh.cpp
@@ -2,11 +2,11 @@
 // @id              tray-hover-expand
 // @name            Tray hover expand
 // @description     Open the hidden tray icons flyout on hover instead of clicking the chevron; optionally collapse it when the cursor leaves
-// @version         1.4.1
+// @version         1.4.2
 // @author          wygodad
 // @github          https://github.com/wygodad
 // @include         windhawk.exe
-// @compilerOptions -lole32 -loleaut32 -luuid -luiautomationcore -lshell32
+// @compilerOptions -lole32 -loleaut32 -lshell32
 // @license         MIT
 // ==/WindhawkMod==
 
@@ -298,19 +298,20 @@ static const ULONGLONG REFIND_INTERVAL_MS = 3000;
 static const ULONGLONG RECT_REFRESH_MS = 750;
 static const ULONGLONG IDLE_STATE_CHECK_MS = 500;
 
-// Cheap (pure Win32) check whether the flyout is open — no UIA calls.
-// The chevron does not support the ExpandCollapse pattern anyway, so the
-// flyout window's visibility is the only reliable state signal.
-static bool IsFlyoutOpen(const Settings& s) {
+// Cheap (pure Win32) resolution of the flyout window — no UIA calls. The
+// chevron does not support the ExpandCollapse pattern anyway, so the flyout
+// window's visibility is the only reliable state signal. Returns the window
+// handle if the flyout is open, or nullptr otherwise. Resolving the handle
+// once per tick lets callers reuse it instead of each calling FindWindowW.
+static HWND GetVisibleFlyout(const Settings& s) {
     HWND f = FindWindowW(s.flyoutClass.c_str(), nullptr);
-    return f && IsWindowVisible(f);
+    return (f && IsWindowVisible(f)) ? f : nullptr;
 }
 
-static bool CursorOverFlyout(POINT pt, const Settings& s) {
-    HWND f = FindWindowW(s.flyoutClass.c_str(), nullptr);
-    if (!f || !IsWindowVisible(f)) return false;
+static bool PtOverWindow(HWND hwnd, POINT pt) {
+    if (!hwnd) return false;
     RECT r;
-    if (!GetWindowRect(f, &r)) return false;
+    if (!GetWindowRect(hwnd, &r)) return false;
     return PtInRect(&r, pt);
 }
 
@@ -349,13 +350,20 @@ static DWORD WINAPI WorkerThread(LPVOID) {
         if (g_settingsGeneration != settingsGen) {
             s = GetSettingsSnapshot();
             settingsGen = g_settingsGeneration;
-            nextRefind = 0;             // settings may change how we detect things
+            // Settings may change how the chevron is detected, so drop the
+            // cached element and re-detect promptly with the new settings.
+            if (pBtn) { pBtn->Release(); pBtn = nullptr; }
+            haveRect = false;
+            nextRefind = 0;
         }
 
-        // Expensive and RARE: refresh the button reference (the taskbar may
-        // have been rebuilt).
-        if (!pBtn || now >= nextRefind) {
-            if (pBtn) { pBtn->Release(); pBtn = nullptr; }
+        // Lazily (re-)find the button only when we don't have a valid one. A
+        // destroyed or stale element makes the rectangle query below fail,
+        // which clears pBtn and triggers a prompt re-find — so there is no need
+        // for a periodic cross-process subtree walk while the element is valid.
+        // When the chevron is absent (e.g. no hidden icons), throttle retries
+        // to REFIND_INTERVAL_MS instead of walking the tree every tick.
+        if (!pBtn && now >= nextRefind) {
             pBtn = FindOverflowButton(pAuto, s);
             nextRefind = now + REFIND_INTERVAL_MS;
             nextRectRefresh = 0;        // force a fresh rectangle below
@@ -370,7 +378,10 @@ static DWORD WINAPI WorkerThread(LPVOID) {
                     cachedRect = r;
                     haveRect = true;
                 } else {
+                    // The element is stale/destroyed (taskbar rebuilt). Drop it
+                    // and re-find promptly on the next tick.
                     pBtn->Release(); pBtn = nullptr; haveRect = false;
+                    nextRefind = 0;
                     WaitForSingleObject(g_stopEvent, s.pollInterval);
                     continue;
                 }
@@ -390,13 +401,14 @@ static DWORD WINAPI WorkerThread(LPVOID) {
             // watching an open flyout. When idle, throttle the check so a
             // manually opened flyout is still noticed without paying a
             // FindWindowW call on every tick.
-            bool flyoutVisible = false;
+            HWND flyoutHwnd = nullptr;
             if (enterEdge || (s.autoClose && flyoutBelievedOpen)) {
-                flyoutVisible = IsFlyoutOpen(s);
+                flyoutHwnd = GetVisibleFlyout(s);
             } else if (s.autoClose && now >= nextIdleStateCheck) {
-                flyoutVisible = IsFlyoutOpen(s);
+                flyoutHwnd = GetVisibleFlyout(s);
                 nextIdleStateCheck = now + IDLE_STATE_CHECK_MS;
             }
+            bool flyoutVisible = (flyoutHwnd != nullptr);
             flyoutBelievedOpen = flyoutVisible || cooling;
 
             // Open only on the cursor-enter edge and only when the flyout is
@@ -420,7 +432,7 @@ static DWORD WINAPI WorkerThread(LPVOID) {
                               (GetAsyncKeyState(VK_RBUTTON) & 0x8000) ||
                               (GetAsyncKeyState(VK_MBUTTON) & 0x8000);
             if (anyBtnDown && !anyBtnDownPrev && flyoutVisible &&
-                CursorOverFlyout(pt, s)) {
+                PtOverWindow(flyoutHwnd, pt)) {
                 clickedInFlyout = true;
                 Wh_Log(L"Click inside flyout: auto-collapse suspended");
             }
@@ -431,7 +443,7 @@ static DWORD WINAPI WorkerThread(LPVOID) {
 
             // Auto-collapse once the cursor left both the button and the flyout.
             if (s.autoClose && flyoutVisible && !cooling && !clickedInFlyout) {
-                bool overFlyout = CursorOverFlyout(pt, s);
+                bool overFlyout = PtOverWindow(flyoutHwnd, pt);
                 if (overBtn || overFlyout) {
                     leftAt = 0;
                 } else if (leftAt == 0) {
@@ -539,7 +551,18 @@ void WhTool_ModUninit() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Tool mod boilerplate
+// Windhawk tool mod implementation for mods which don't need to inject to other
+// processes or hook other functions. Context:
+// https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
+//
+// The mod will load and run in a dedicated windhawk.exe process.
+//
+// Paste the code below as part of the mod code, and use these callbacks:
+// * WhTool_ModInit
+// * WhTool_ModSettingsChanged
+// * WhTool_ModUninit
+//
+// Currently, other callbacks are not supported.
 
 bool g_isToolModProcessLauncher;
 HANDLE g_toolModProcessMutex;
@@ -550,6 +573,12 @@ void WINAPI EntryPoint_Hook() {
 }
 
 BOOL Wh_ModInit() {
+    DWORD sessionId;
+    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
+        sessionId == 0) {
+        return FALSE;
+    }
+
     bool isExcluded = false;
     bool isToolModProcess = false;
     bool isCurrentToolModProcess = false;


### PR DESCRIPTION
This mod allows the hidden tray icons flyout to open on hover instead of requiring a click. It includes settings for auto-closing, polling interval, collapse delay, and hit area padding.
It works through UI Automation (no shell function hooks), so it is relatively safe and resilient across Windows builds.
Known limitation: auto-collapse relies on detecting the flyout window class (TopLevelWindowForOverflowXamlIsland by default), which is exposed as a configurable setting in case it differs across Windows builds.
Tested on: Windows 11 25H2 (build 26200.8524)

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:
N/A — this pull request introduces a new mod.
 
## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
