### PR TITLE
New Mod - Taskbar Fluent Media Player 1.0.1

### DIFF
--- a/mods/taskbar-fluent-media-player.wh.cpp
+++ b/mods/taskbar-fluent-media-player.wh.cpp
@@ -2083,7 +2083,6 @@ static void ExecuteMediaAction(const std::wstring& action) {
                 }
             }
 
-            // Try to find and focus window containing track title (ideal for browser playing YouTube/Spotify)
             if (!title.empty()) {
                 struct WindowSearch {
                     std::wstring targetTitle;
@@ -2102,7 +2101,6 @@ static void ExecuteMediaAction(const std::wstring& action) {
                     if (GetWindowTextW(hwnd, windowTitle, ARRAYSIZE(windowTitle)) > 0) {
                         auto* search = reinterpret_cast<WindowSearch*>(lParam);
                         std::wstring wTitle(windowTitle);
-                        // Case-insensitive check if window title contains currently playing media title
                         auto it = std::search(
                             wTitle.begin(), wTitle.end(),
                             search->targetTitle.begin(), search->targetTitle.end(),
@@ -2111,7 +2109,7 @@ static void ExecuteMediaAction(const std::wstring& action) {
 
                         if (it != wTitle.end()) {
                             search->foundHwnd = hwnd;
-                            return FALSE; // found, stop enumerating
+                            return FALSE;
                         }
                     }
                     return TRUE;
@@ -2126,7 +2124,6 @@ static void ExecuteMediaAction(const std::wstring& action) {
                 }
             }
 
-            // Fallback: Launch or focus via AppUserModelId
             if (!app.empty()) {
                 std::wstring shellPath = L"shell:AppsFolder\\" + app;
                 ShellExecuteW(nullptr, L"open", shellPath.c_str(), nullptr, nullptr, SW_SHOWNORMAL);

--- a/mods/taskbar-fluent-media-player.wh.cpp
+++ b/mods/taskbar-fluent-media-player.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-fluent-media-player
 // @name            Taskbar Fluent Media Player
 // @description     Taskbar Fluent Media Player — is a Windhawk mod that integrates a modern media player with Fluent Design directly into the Windows 11 taskbar. It allows you to control music and view track information seamlessly without interrupting your workflow.
-// @version         1.0.0
+// @version         1.0.1
 // @author          Salyts
 // @github          https://github.com/Salyts
 // @include         explorer.exe
@@ -12,7 +12,7 @@
 
 // ==WindhawkModReadme==
 /*
-# Taskbar Fluent Media Player 1.0.0
+# Taskbar Fluent Media Player 1.0.1
 
 **Taskbar Fluent Media Player —** is a Windhawk mod that integrates a modern media player with Fluent Design directly into the Windows 11 taskbar. It allows you to control music and view track information seamlessly without interrupting your workflow.
 
@@ -2068,97 +2068,69 @@ static void ExecuteMediaAction(const std::wstring& action) {
     } else if (action == L"open_app") {
         std::thread([]() {
             if (g_unloading) return;
+            std::wstring title;
             std::wstring app;
             {
                 std::lock_guard<std::mutex> lk(g_sessionMtx);
                 if (g_currentSession) {
                     try {
                         app = std::wstring(g_currentSession.SourceAppUserModelId());
+                        auto props = g_currentSession.TryGetMediaPropertiesAsync().get();
+                        if (props) {
+                            title = std::wstring(props.Title());
+                        }
                     } catch (...) {}
                 }
             }
-            if (!app.empty()) {
-                HWND foundWindow = nullptr;
 
-                struct FindData {
-                    const std::wstring* aumid;
-                    HWND hwnd;
+            // Try to find and focus window containing track title (ideal for browser playing YouTube/Spotify)
+            if (!title.empty()) {
+                struct WindowSearch {
+                    std::wstring targetTitle;
+                    HWND foundHwnd = nullptr;
                 };
-                FindData fd{&app, nullptr};
 
-                EnumWindows([](HWND hWnd, LPARAM lParam) -> BOOL {
-                    auto* fd2 = reinterpret_cast<FindData*>(lParam);
-                    if (!IsWindowVisible(hWnd)) return TRUE;
+                WindowSearch search;
+                search.targetTitle = title;
 
-                    wchar_t title[256] = {};
-                    GetWindowTextW(hWnd, title, 256);
-                    if (wcslen(title) == 0) return TRUE;
-
-                    DWORD pid = 0;
-                    GetWindowThreadProcessId(hWnd, &pid);
-                    if (!pid) return TRUE;
-
-                    wchar_t procPath[MAX_PATH] = {};
-                    HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-                    if (hProc) {
-                        DWORD sz = MAX_PATH;
-                        QueryFullProcessImageNameW(hProc, 0, procPath, &sz);
-                        CloseHandle(hProc);
+                EnumWindows([](HWND hwnd, LPARAM lParam) -> BOOL {
+                    if (!IsWindowVisible(hwnd)) {
+                        return TRUE;
                     }
 
-                    std::wstring procName = procPath;
-                    auto slash = procName.rfind(L'\\');
-                    if (slash != std::wstring::npos) procName = procName.substr(slash + 1);
+                    wchar_t windowTitle[512];
+                    if (GetWindowTextW(hwnd, windowTitle, ARRAYSIZE(windowTitle)) > 0) {
+                        auto* search = reinterpret_cast<WindowSearch*>(lParam);
+                        std::wstring wTitle(windowTitle);
+                        // Case-insensitive check if window title contains currently playing media title
+                        auto it = std::search(
+                            wTitle.begin(), wTitle.end(),
+                            search->targetTitle.begin(), search->targetTitle.end(),
+                            [](wchar_t ch1, wchar_t ch2) { return towlower(ch1) == towlower(ch2); }
+                        );
 
-                    auto dot = procName.rfind(L'.');
-                    if (dot != std::wstring::npos) procName = procName.substr(0, dot);
-
-                    const std::wstring& aumid = *fd2->aumid;
-                    std::wstring aumidLower = aumid;
-                    std::wstring procLower = procName;
-                    for (auto& c : aumidLower) c = towlower(c);
-                    for (auto& c : procLower) c = towlower(c);
-
-                    if (aumidLower.find(procLower) != std::wstring::npos ||
-                        procLower.find(aumidLower) != std::wstring::npos) {
-                        fd2->hwnd = hWnd;
-                        return FALSE;
+                        if (it != wTitle.end()) {
+                            search->foundHwnd = hwnd;
+                            return FALSE; // found, stop enumerating
+                        }
                     }
                     return TRUE;
-                }, reinterpret_cast<LPARAM>(&fd));
+                }, reinterpret_cast<LPARAM>(&search));
 
-                foundWindow = fd.hwnd;
-
-                if (foundWindow) {
-                    if (IsIconic(foundWindow)) {
-                        ShowWindow(foundWindow, SW_RESTORE);
+                if (search.foundHwnd) {
+                    if (IsIconic(search.foundHwnd)) {
+                        ShowWindow(search.foundHwnd, SW_RESTORE);
                     }
-
-                    DWORD currentThreadId = GetCurrentThreadId();
-                    DWORD windowThreadId = GetWindowThreadProcessId(foundWindow, nullptr);
-
-                    if (currentThreadId != windowThreadId) {
-                        AttachThreadInput(currentThreadId, windowThreadId, TRUE);
-                        BringWindowToTop(foundWindow);
-                        ShowWindow(foundWindow, SW_SHOW);
-                        AttachThreadInput(currentThreadId, windowThreadId, FALSE);
-                    }
-
-                    SetForegroundWindow(foundWindow);
-                    SetFocus(foundWindow);
-                } else {
-                    std::wstring appLower = app;
-                    for (auto& c : appLower) c = towlower(c);
-
-                    bool isUnsupported = (appLower.find(L"windows.") == 0 ||
-                                         appLower.find(L"microsoft.windows.") == 0 ||
-                                         appLower.find(L"systemsettings") != std::wstring::npos);
-
-                    if (!isUnsupported) {
-                        std::wstring shellPath = L"shell:AppsFolder\\" + app;
-                        ShellExecuteW(nullptr, L"open", shellPath.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
-                    }
+                    SetForegroundWindow(search.foundHwnd);
+                    return;
                 }
+            }
+
+            // Fallback: Launch or focus via AppUserModelId
+            if (!app.empty()) {
+                std::wstring shellPath = L"shell:AppsFolder\\" + app;
+                ShellExecuteW(nullptr, L"open", shellPath.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+                return;
             }
         }).detach();
     }
@@ -5834,7 +5806,10 @@ static void StartRetryThread() {
 
                 Sleep(200);
 
-                if (g_playerGrid) break;
+                if (g_playerGrid) {
+                    if (g_retryStopEvent) SetEvent(g_retryStopEvent);
+                    break;
+                }
             }
             ++attempt;
         }
@@ -5909,8 +5884,10 @@ void Wh_ModAfterInit() {
         Wh_Log(L"Wh_ModAfterInit: No taskbar window found");
     }
 
-    StartRetryThread();
-    Wh_Log(L"Wh_ModAfterInit: Retry thread started");
+    if (!g_playerGrid) {
+        StartRetryThread();
+        Wh_Log(L"Wh_ModAfterInit: Retry thread started");
+    }
 }
 
 void Wh_ModUninit() {

--- a/mods/taskbar-fluent-media-player.wh.cpp
+++ b/mods/taskbar-fluent-media-player.wh.cpp
@@ -36,7 +36,6 @@
 If you encounter any issues, bugs, or have suggestions for new features, please report them on the project's GitHub page:
 👉 **[Report an Issue on GitHub](https://github.com/Salyts/Taskbar-Fluent-Media-Player/issues)**
 
-![img](https://i.imgur.com/dTcEZ9G.png)
 */
 // ==/WindhawkModReadme==
 

--- a/mods/taskbar-fluent-media-player.wh.cpp
+++ b/mods/taskbar-fluent-media-player.wh.cpp
@@ -1,0 +1,6041 @@
+// ==WindhawkMod==
+// @id              taskbar-fluent-media-player
+// @name            Taskbar Fluent Media Player
+// @description     Taskbar Fluent Media Player — is a Windhawk mod that integrates a modern media player with Fluent Design directly into the Windows 11 taskbar. It allows you to control music and view track information seamlessly without interrupting your workflow.
+// @version         1.0.0
+// @author          Salyts
+// @github          https://github.com/Salyts
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lversion -luuid -luser32 -lwindowsapp -lshell32 -lgdi32 -lshlwapi -lwindowscodecs -ldwmapi
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Taskbar Fluent Media Player 1.0.0
+
+**Taskbar Fluent Media Player —** is a Windhawk mod that integrates a modern media player with Fluent Design directly into the Windows 11 taskbar. It allows you to control music and view track information seamlessly without interrupting your workflow.
+
+![img](https://i.imgur.com/S5vQyUa.png)
+
+### Key Features:
+* **Deep Integration —** Place the player in the tray area (left or right of the clock), next to system icons, or in the center of the taskbar.
+* **Fluent UI Effects —** Full support for native Windows 11 materials including **Acrylic**, **Mica**, and **Mica Alt**.
+* **Adaptive Design —** The player can automatically adapt its colors based on the album art or follow the system accent color.
+* **Full Media Control —** Buttons for Play/Pause, Skip, 5-second Seek, Shuffle, and Repeat modes.
+* **Smart Behavior —** Automatically hides the player when no media is playing, when entering full-screen mode, or after a period of inactivity (idle).
+
+### Advanced Customization:
+* **Visuals —** Customize fonts (Segoe UI, Aptos, etc.), text sizes, padding, and element transparency.
+* **Album Art —** Adjustable corner radius, source app icon overlay, and pause overlay effects.
+* **Mouse Interactions —** Assign custom actions (Volume control, Track seeking, Session switching) to the mouse wheel, single clicks, or double clicks on different parts of the player.
+
+---
+
+### Report a Bug
+If you encounter any issues, bugs, or have suggestions for new features, please report them on the project's GitHub page:
+👉 **[Report an Issue on GitHub](https://github.com/Salyts/Taskbar-Fluent-Media-Player/issues)**
+
+![img](https://i.imgur.com/dTcEZ9G.png)
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- MainSettings:
+  - PlayerSetting:
+    - position: "tray_left"
+      $name: Media player position •
+      $options:
+      - "tray_left": "Tray - Far edge - Left"
+      - "tray_right": "Tray - Far edge - Right"
+      - "tray_before_clock": "Tray - Clock - Left"
+      - "tray_after_clock": "Tray - Clock - Right"
+      - "tray_before_omni_left": "Tray - Network/volume - Left"
+      - "tray_before_omni_right": "Tray - Network/volume - Right"
+      - "tray_language_left": "Tray - Language button - Left"
+      - "tray_language_right": "Tray - Language button - Right"
+      - "tray_hidden_icons_left": "Tray - Hidden icons button - Left"
+      - "tray_hidden_icons_right": "Tray - Hidden icons button - Right"
+      - "tray_icons_left": "Tray - Icons - Left"
+      - "tray_icons_right": "Tray - Icons - Right"
+      - "tray_after_showdesktop_left": "Tray - Show Desktop - Left"
+      - "tray_after_showdesktop_right": "Tray - Show Desktop - Right"
+      - "taskbar_left_start": "Taskbar - Start button - Left"
+      - "taskbar_right_start": "Taskbar - Start button - Right"
+      - "taskbar_after_search_left": "Taskbar - Search button - Left"
+      - "taskbar_after_search_right": "Taskbar - Search button - Right"
+      - "taskbar_after_taskview_left": "Taskbar - Task View button - Left"
+      - "taskbar_after_taskview_right": "Taskbar - Task View button - Right"
+      - "taskbar_after_widgets_left": "Taskbar - Widgets button - Left"
+      - "taskbar_after_widgets_right": "Taskbar - Widgets button - Right"
+      - "taskbar_far_edge_left": "Taskbar - far edge - Left"
+      - "taskbar_left_edge": "Taskbar - far edge (Overlay) - Left"
+      - "taskbar_center_edge": "Taskbar - far edge (Overlay) - Center"
+      - "taskbar_right_edge": "Taskbar - far edge (Overlay) - Right"
+    - playerWidth: "0 0"
+      $name: Media player width ↔ (min max, px, 0 = no limit)
+    - playerHeight: "40 40"
+      $name: Media player height ↕ (min max, px, 0 = no limit)
+    - playerMargin: "4 4"
+      $name: Media player margin ↔ (left right, px)
+    - mirrorLayout: false
+      $name: Mirror layout (flip album art, text, and buttons to opposite sides)
+    $name: Media player Settings
+
+  - AlbumArtSetting:
+    - showAlbumArt: true
+      $name: Show album art
+    - albumArtWidth: "32 64"
+      $name: Album art width ↔ (min max, px)
+    - albumArtHeight: "32 32"
+      $name: Album art height ↕ (min max, px)
+    - albumArtMargin: "0 0"
+      $name: Album art margin ↔ (left right, px)
+    $name: Album Art Settings
+
+  - TextAreaSetting:
+    - showTrackTitle: true
+      $name: Show track title
+    - showTrackArtist: true
+      $name: Show artist name
+    - textAreaWidth: "0 120"
+      $name: Text area width ↔ (min max, px, 0 = no limit)
+    - textAreaHeight: "0 0"
+      $name: Text area height ↕ (min max, px, 0 = no limit)
+    - textAreaMargin: "5 5"
+      $name: Text area margin ↔ (left right, px)
+    - textSpacing: 1
+      $name: Spacing between title and artist (px)
+    $name: Text area Settings
+
+  - MediaButtonsSettings:
+    - showMediaButtons: true
+      $name: Show media buttons
+    - mediaButtons: [prev, play, next]
+      $name: Media buttons order
+      $description: Select which media control buttons to display and their order. Duplicates are ignored.
+      $options:
+      - prev: Previous
+      - play: Play/Pause
+      - next: Next
+      - rewind: Rewind 5s
+      - forward: Forward 5s
+      - shuffle: Shuffle
+      - repeat: Repeat
+    - mediaButtonsMargin: "2 2"
+      $name: Media buttons margin (left right, px)
+    - buttonSpacing: 0
+      $name: Spacing between media buttons (px)
+    - buttonSize: 28
+      $name: Button size (px)
+    - buttonIconSize: 12
+      $name: Button icon size (px)
+    - hideUnsupportedButtons: false
+      $name: Hide unsupported buttons
+      $description: When enabled, buttons not supported by the current media app are hidden instead of just disabled
+    $name: Media Buttons Settings
+  $name: Main Settings
+
+- AppearanceSettings:
+  - BackgroundStyle:
+    - backgroundType: "none"
+      $name: Background type
+      $options:
+      - "none":       "None (transparent)"
+      - "solid":      "Solid color"
+      - "gradient":   "Gradient"
+      - "acrylic":    "Acrylic"
+      - "mica":       "Mica"
+      - "mica_alt":   "Mica Alt"
+      - "album_art_blur": "Album art - Blur"
+    - solidColor: "32 32 32"
+      $name: Primary color (R G B 0-255)
+      $description: "Use '-1 -1 -1' for system contrast color, '-2 -2 -2' for album art color"
+    - solidColor2: "64 64 64"
+      $name: Secondary color for gradient (R G B 0-255)
+      $description: "Use '-1 -1 -1' for system contrast color, '-2 -2 -2' for album art color"
+    - solidOpacity: 100
+      $name: Solid color opacity (0-255)
+    - gradientAngle: 0
+      $name: Gradient rotation angle (0-360 degrees)
+    - gradientBalance: 50
+      $name: Gradient color balance (0-100)
+    - acrylicTintOpacity: 60
+      $name: Acrylic tint opacity (0-100)
+    - micaOpacity: 50
+      $name: Mica/Mica Alt opacity (0-255)
+    - blurOpacity: 70
+      $name: Album art blur opacity (0-100)
+    - blurRadius: 10
+      $name: Album art blur strength (1-50, higher = blurrier)
+    - cornerRadius: 4
+      $name: Panel corner radius (px)
+    - enablePlayerHoverEffect: true
+      $name: Enable button-style hover effect on player
+    - enableMediaButtonsHoverEffect: true
+      $name: Enable hover effect on media buttons
+    $name: Background Style
+
+  - MediaButtonsStyle:
+    - autoTheme: true
+      $name: Enable auto theme
+      $description: When enabled, text and button colors are determined automatically based on system theme. When disabled, uses custom Title color, Button icons color, and Artist color settings
+    - iconStyle: "fluent_filled"
+      $name: Icon style
+      $options:
+      - "fluent_outline": "Segoe Fluent Icons (Outline)"
+      - "fluent_filled": "Segoe Fluent Icons (Filled)"
+      - "mdl2_outline": "Segoe MDL2 Assets (Outline)"
+      - "mdl2_filled": "Segoe MDL2 Assets (Filled)"
+    - buttonCornerRadius: 4
+      $name: Button corner radius (px)
+    - buttonColor: "255 255 255"
+      $name: Button icons color (R G B 0-255)
+      $description: "Use '-1 -1 -1' for system contrast color, '-2 -2 -2' for album art color"
+    - buttonColorOpacity: 100
+      $name: Button icons opacity (0-100)
+    - disabledButtonOpacity: 30
+      $name: Disabled button opacity (0-100)
+      $description: Opacity of buttons that are not supported by the current media app
+    $name: Media Buttons Style
+
+  - TitleTextStyle:
+    - titleColor: "255 255 255"
+      $name: Title color (R G B 0-255)
+      $description: "Use '-1 -1 -1' for system contrast color, '-2 -2 -2' for album art color"
+    - titleColorOpacity: 100
+      $name: Title opacity (0-100)
+    - titleFont: segoe_ui_variable
+      $name: Title font
+      $options:
+        - segoe_ui_variable: Segoe UI Variable Display
+        - segoe_ui: Segoe UI
+        - segoe_ui_semibold: Segoe UI Semibold
+        - segoe_ui_bold: Segoe UI Bold
+        - segoe_ui_light: Segoe UI Light
+        - segoe_ui_semilight: Segoe UI Semilight
+        - aptos: Aptos
+        - calibri: Calibri
+        - cambria: Cambria
+        - candara: Candara
+        - consolas: Consolas
+        - corbel: Corbel
+        - arial: Arial
+        - trebuchet: Trebuchet MS
+        - verdana: Verdana
+        - tahoma: Tahoma
+        - georgia: Georgia
+        - times_new_roman: Times New Roman
+    - titleFontSize: 12
+      $name: Title font size (pt)
+    $name: Title Text Style
+
+  - ArtistTextStyle:
+    - artistColor: "255 255 255"
+      $name: Artist color (R G B 0-255)
+      $description: "Use '-1 -1 -1' for system contrast color, '-2 -2 -2' for album art color"
+    - artistColorOpacity: 70
+      $name: Artist opacity (0-100)
+    - artistFont: segoe_ui_variable
+      $name: Artist font
+      $options:
+        - segoe_ui_variable: Segoe UI Variable Display
+        - segoe_ui: Segoe UI
+        - segoe_ui_semibold: Segoe UI Semibold
+        - segoe_ui_bold: Segoe UI Bold
+        - segoe_ui_light: Segoe UI Light
+        - segoe_ui_semilight: Segoe UI Semilight
+        - aptos: Aptos
+        - calibri: Calibri
+        - cambria: Cambria
+        - candara: Candara
+        - consolas: Consolas
+        - corbel: Corbel
+        - arial: Arial
+        - trebuchet: Trebuchet MS
+        - verdana: Verdana
+        - tahoma: Tahoma
+        - georgia: Georgia
+        - times_new_roman: Times New Roman
+    - artistFontSize: 11
+      $name: Artist font size (pt)
+    $name: Artist Text Style
+
+  - AlbumArtDisplaySettings:
+    - albumArtEmptyBehavior: "show"
+      $name: Album art behavior when no cover available
+      $options:
+      - "show": "Show area (default)"
+      - "hide": "Hide area"
+      - "show_question": "Show area with question mark"
+      - "show_note": "Show area with music note"
+    - showPauseOverlay: false
+      $name: Show pause icon overlay on album art when paused
+    - pauseOverlayOpacity: 60
+      $name: Pause overlay background opacity (0-100)
+    - albumArtOpacity: 100
+      $name: Album art opacity (0-100)
+    - albumArtCornerRadius: 4
+      $name: Album art corner radius (px)
+    - showAppIcon: false
+      $name: Show media app icon overlay
+    - appIconCorner: "bottom_right"
+      $name: App icon corner
+      $options:
+      - "top_left":     "Top left"
+      - "top_right":    "Top right"
+      - "bottom_left":  "Bottom left"
+      - "bottom_right": "Bottom right"
+    - appIconSize: 12
+      $name: App icon size (px)
+    $name: Album Art Display
+  $name: Appearance Settings
+
+- BehaviorSettings:
+  - ClickActionSettings:
+      - - object: player
+          $name: Object
+          $options:
+          - none: Nothing
+          - player: Player area
+          - album_art: Album art area
+        - click: left_click
+          $name: Click type
+          $options:
+          - none: Nothing
+          - left_click: Left click
+          - left_double_click: Left double click
+          - right_click: Right click
+          - right_double_click: Right double click
+          - middle_click: Middle click
+          - middle_double_click: Middle double click
+        - action: play_pause
+          $name: Action
+          $options:
+          - none: Nothing
+          - switch_session: Switch active media session
+          - play_pause: Play/Pause
+          - next_track: Next track
+          - prev_track: Previous track
+          - stop: Stop playback
+          - rewind_5s: Rewind 5s
+          - forward_5s: Forward 5s
+          - toggle_shuffle: Toggle Shuffle
+          - toggle_repeat: Toggle Repeat
+          - open_app: Open media app
+      - - object: album_art
+          $name: Object
+          $options:
+          - none: Nothing
+          - player: Player area
+          - album_art: Album art area
+        - click: left_double_click
+          $name: Click type
+          $options:
+          - none: Nothing
+          - left_click: Left click
+          - left_double_click: Left double click
+          - right_click: Right click
+          - right_double_click: Right double click
+          - middle_click: Middle click
+          - middle_double_click: Middle double click
+        - action: open_app
+          $name: Action
+          $options:
+          - none: Nothing
+          - switch_session: Switch active media session
+          - play_pause: Play/Pause
+          - next_track: Next track
+          - prev_track: Previous track
+          - stop: Stop playback
+          - rewind_5s: Rewind 5s
+          - forward_5s: Forward 5s
+          - toggle_shuffle: Toggle Shuffle
+          - toggle_repeat: Toggle Repeat
+          - open_app: Open media app
+    $name: Click Actions
+  - MouseWheelActionSettings:
+      - - object: player
+          $name: Object
+          $options:
+          - none: Nothing
+          - player: Player area
+          - album_art: Album art area
+        - click: mouse_wheel
+          $name: Mouse type
+          $options:
+          - none: Nothing
+          - mouse_wheel: Mouse wheel
+          - mouse_wheel_up: Mouse wheel up
+          - mouse_wheel_down: Mouse wheel down
+        - action: switch_tracks
+          $name: Action
+          $options:
+            - none: Nothing
+            - "switch_tracks": "Switch tracks (up=prev, down=next)"
+            - "switch_sessions": "Switch sessions (up/down)"
+            - "system_sound": "Change system sound volume (up/down)"
+            - "app_sound": "Change app sound volume (up/down)"
+      - - object: album_art
+          $name: Object
+          $options:
+          - none: Nothing
+          - player: Player area
+          - album_art: Album art area
+        - click: mouse_wheel
+          $name: Mouse type
+          $options:
+          - none: Nothing
+          - mouse_wheel: Mouse wheel
+          - mouse_wheel_up: Mouse wheel up
+          - mouse_wheel_down: Mouse wheel down
+        - action: switch_sessions
+          $name: Action
+          $options:
+            - none: Nothing
+            - "switch_tracks": "Switch tracks (up=prev, down=next)"
+            - "switch_sessions": "Switch sessions (up/down)"
+            - "system_sound": "Change system sound volume (up/down)"
+            - "app_sound": "Change app sound volume (up/down)"
+    $name: Mouse wheel Actions
+  - hideWhenNoMedia: true
+    $name: Hide when no media is playing
+  - hideFullscreen: true
+    $name: Hide when a fullscreen app is running
+  - idleHideSeconds: 0
+    $name: Idle auto-hide timeout (seconds, 0 = disabled)
+  - showFullTitleOnHover: true
+    $name: Show full track title on hover (tooltip)
+  $name: Behavior Settings
+
+- AnimationSettings:
+  - enableSmoothPositionAnimation: true
+    $name: Enable smooth position animation (like taskbar icons)
+  $name: Animation Settings
+
+- NotificationSettings:
+  - showSuccessNotification: False
+    $name: Show notification on successful mod load
+    $description: Display a Windows notification when the mod is successfully loaded or reloaded
+  $name: Notification Settings
+
+- DebugSettings:
+  - ignoredProcesses: ""
+    $name: Ignore media from processes (separate with ;)
+  - enableTreeDump: false
+    $name: Dump XAML element names to log on inject
+  - showDebugBorders: false
+    $name: Show debug borders (hitboxes)
+  - showLayoutAnchors: false
+    $name: Show layout anchors and centers
+  $name: Debug Settings
+*/
+// ==/WindhawkModSettings==
+
+#undef GetCurrentTime
+
+#include <winrt/base.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.Core.h>
+#include <winrt/Windows.UI.Text.h>
+#include <winrt/Windows.UI.Input.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Media.Imaging.h>
+#include <winrt/Windows.UI.Xaml.Shapes.h>
+#include <winrt/Windows.UI.Xaml.Media.Animation.h>
+#include <winrt/Windows.UI.Xaml.Markup.h>
+#include <winrt/Windows.UI.Xaml.Input.h>
+#include <winrt/Windows.UI.Xaml.Automation.h>
+#include <winrt/Windows.UI.ViewManagement.h>
+#include <winrt/Windows.Media.Control.h>
+#include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Windows.Graphics.Imaging.h>
+#include <robuffer.h>
+
+#include <windows.h>
+#include <shellapi.h>
+#include <shlobj.h>
+#include <shlwapi.h>
+#include <shobjidl.h>
+#include <wincodec.h>
+#include <propsys.h>
+#include <dwmapi.h>
+#include <windhawk_utils.h>
+#include <audiopolicy.h>
+#include <mmdeviceapi.h>
+#include <endpointvolume.h>
+#include <tlhelp32.h>
+
+#include <atomic>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <vector>
+#include <set>
+#include <algorithm>
+#include <thread>
+#include <cmath>
+#include <chrono>
+
+using namespace winrt::Windows::UI::Xaml;
+using namespace winrt::Windows::UI::Xaml::Controls;
+using namespace winrt::Windows::UI::Xaml::Media;
+using namespace winrt::Windows::UI::Xaml::Media::Imaging;
+using namespace winrt::Windows::UI::Xaml::Media::Animation;
+using namespace winrt::Windows::UI::Xaml::Input;
+using namespace winrt::Windows::Media::Control;
+using namespace winrt::Windows::Storage::Streams;
+
+struct ModSettings {
+    std::wstring position             = L"none";
+    std::wstring albumArtLeftClick    = L"none";
+    std::wstring albumArtRightClick   = L"none";
+    std::wstring albumArtMiddleClick  = L"none";
+    std::wstring albumArtLeftDoubleClick  = L"none";
+    std::wstring albumArtRightDoubleClick = L"none";
+    std::wstring albumArtWheelAction  = L"none";
+    std::wstring playerLeftClick      = L"none";
+    std::wstring playerRightClick     = L"none";
+    std::wstring playerMiddleClick    = L"none";
+    std::wstring playerLeftDoubleClick  = L"none";
+    std::wstring playerRightDoubleClick = L"none";
+    std::wstring playerWheelAction    = L"none";
+    bool         mirrorLayout         = false;
+    bool         showMediaButtons     = true;
+    int          playerMinWidth       = 0;
+    int          playerMaxWidth       = 0;
+    int          playerMinHeight      = 40;
+    int          playerMaxHeight      = 40;
+    bool         showAlbumArt         = true;
+    std::wstring albumArtEmptyBehavior = L"show";
+    bool         showPauseOverlay     = false;
+    int          pauseOverlayOpacity  = 60;
+    int          albumArtMinWidth     = 32;
+    int          albumArtMaxWidth     = 64;
+    int          albumArtMinHeight    = 32;
+    int          albumArtMaxHeight    = 32;
+    int          albumArtOpacity      = 100;
+    int          albumArtLeftMargin   = 0;
+    int          albumArtRightMargin  = 0;
+    bool         showTrackTitle       = true;
+    bool         showFullTitleOnHover = true;
+    bool         showTrackArtist      = true;
+    std::wstring iconStyle            = L"fluent_filled";
+    bool         showAppIcon          = false;
+    std::wstring appIconCorner        = L"bottom_right";
+    int          appIconSize          = 12;
+    bool         hideWhenNoMedia      = true;
+    bool         enablePlayerHoverEffect   = true;
+    bool         enableMediaButtonsHoverEffect = true;
+    bool         enableSmoothPositionAnimation = true;
+    int          controlsMarginLeft   = 4;
+    int          controlsMarginRight  = 0;
+    int          playerMarginLeft     = 4;
+    int          playerMarginRight    = 4;
+    int          mediaButtonsLeftMargin  = 2;
+    int          mediaButtonsRightMargin = 2;
+    int          textAreaMinWidth     = 0;
+    int          textAreaMaxWidth     = 120;
+    int          textAreaMinHeight    = 0;
+    int          textAreaMaxHeight    = 0;
+    int          textAreaLeftMargin   = 5;
+    int          textAreaRightMargin  = 5;
+    bool         hideFullscreen       = true;
+    int          idleHideSeconds      = 0;
+    bool         autoTheme            = true;
+    std::wstring backgroundType       = L"none";
+    int          blurOpacity          = 100;
+    int          blurRadius           = 10;
+    int          cornerRadius         = 4;
+    int          albumArtCornerRadius = 4;
+    int          buttonSpacing        = 0;
+    int          buttonSize           = 28;
+    int          buttonIconSize       = 12;
+    bool         hideUnsupportedButtons = false;
+    int          buttonCornerRadius   = 4;
+    int          titleFontSize        = 12;
+    int          artistFontSize       = 11;
+    std::wstring titleFont            = L"segoe_ui_variable";
+    std::wstring artistFont           = L"segoe_ui_variable";
+    int          textSpacing          = 1;
+    std::wstring solidColor           = L"32 32 32";
+    std::wstring solidColor2          = L"64 64 64";
+    int          solidOpacity         = 204;
+    int          gradientAngle        = 0;
+    int          gradientBalance      = 50;
+    int          acrylicTintOpacity   = 60;
+    int          micaOpacity          = 51;
+    std::wstring buttonColor          = L"255 255 255";
+    int          buttonColorOpacity   = 100;
+    int          disabledButtonOpacity = 30;
+    std::wstring titleColor           = L"255 255 255";
+    int          titleColorOpacity    = 90;
+    std::wstring artistColor          = L"255 255 255";
+    int          artistColorOpacity   = 60;
+    std::wstring ignoredProcesses     = L"";
+    bool         enableTreeDump       = false;
+    bool         showDebugBorders     = false;
+    bool         showLayoutAnchors    = false;
+    bool         showSuccessNotification = false;
+};
+static ModSettings g_settings;
+
+enum class MediaButtonType {
+    Previous = 1,
+    PlayPause = 2,
+    Next = 3,
+    Rewind5s = 4,
+    Forward5s = 5,
+    Shuffle = 6,
+    Repeat = 7,
+};
+
+struct MediaButtonDefinition {
+    std::wstring keyword;
+    MediaButtonType type;
+    int cmd;
+};
+
+static const std::vector<MediaButtonDefinition> g_mediaButtonDefinitions = {
+    {L"prev", MediaButtonType::Previous, 1},
+    {L"play", MediaButtonType::PlayPause, 2},
+    {L"next", MediaButtonType::Next, 3},
+    {L"rewind", MediaButtonType::Rewind5s, 5},
+    {L"forward", MediaButtonType::Forward5s, 6},
+    {L"shuffle", MediaButtonType::Shuffle, 7},
+    {L"repeat", MediaButtonType::Repeat, 8},
+};
+
+struct MediaButtonConfig {
+    MediaButtonType type;
+    int cmd;
+};
+
+static std::vector<MediaButtonConfig> g_mediaButtons;
+static std::mutex g_mediaButtonsMutex;
+
+static std::wstring MapFontName(const std::wstring& key) {
+    if (key == L"segoe_ui_variable") return L"Segoe UI Variable Display";
+    if (key == L"segoe_ui") return L"Segoe UI";
+    if (key == L"segoe_ui_semibold") return L"Segoe UI Semibold";
+    if (key == L"segoe_ui_bold") return L"Segoe UI Bold";
+    if (key == L"segoe_ui_light") return L"Segoe UI Light";
+    if (key == L"segoe_ui_semilight") return L"Segoe UI Semilight";
+    if (key == L"aptos") return L"Aptos";
+    if (key == L"calibri") return L"Calibri";
+    if (key == L"cambria") return L"Cambria";
+    if (key == L"candara") return L"Candara";
+    if (key == L"consolas") return L"Consolas";
+    if (key == L"corbel") return L"Corbel";
+    if (key == L"arial") return L"Arial";
+    if (key == L"trebuchet") return L"Trebuchet MS";
+    if (key == L"verdana") return L"Verdana";
+    if (key == L"tahoma") return L"Tahoma";
+    if (key == L"georgia") return L"Georgia";
+    if (key == L"times_new_roman") return L"Times New Roman";
+    return L"Segoe UI Variable Display";
+}
+
+static void LoadSettings() {
+    auto Str = [](const wchar_t* key, const wchar_t* def) -> std::wstring {
+        PCWSTR p = Wh_GetStringSetting(key);
+        std::wstring r = p ? p : def;
+        Wh_FreeStringSetting(p);
+        return r;
+    };
+    auto Int = [](const wchar_t* key, int lo, int hi, int def) -> int {
+        int v = Wh_GetIntSetting(key);
+        if (v == 0 && def != 0) v = def;
+        return std::clamp(v, lo, hi);
+    };
+    auto ParseMargin = [&Str](const wchar_t* key, const wchar_t* def, int& left, int& right) {
+        std::wstring val = Str(key, def);
+        try {
+            size_t space = val.find(L' ');
+            if (space != std::wstring::npos) {
+                left  = std::stoi(val.substr(0, space));
+                right = std::stoi(val.substr(space + 1));
+            } else if (!val.empty()) {
+                left = right = std::stoi(val);
+            }
+        } catch (...) {
+            std::wstring d(def);
+            size_t space = d.find(L' ');
+            try {
+                if (space != std::wstring::npos) {
+                    left  = std::stoi(d.substr(0, space));
+                    right = std::stoi(d.substr(space + 1));
+                } else {
+                    left = right = std::stoi(d);
+                }
+            } catch (...) { left = right = 0; }
+        }
+    };
+
+    g_settings.position             = Str(L"MainSettings.PlayerSetting.position",    L"tray_right");
+
+    ParseMargin(L"MainSettings.PlayerSetting.playerMargin", L"0 0", g_settings.playerMarginLeft, g_settings.playerMarginRight);
+    ParseMargin(L"MainSettings.PlayerSetting.playerWidth", L"80 320", g_settings.playerMinWidth, g_settings.playerMaxWidth);
+    ParseMargin(L"MainSettings.PlayerSetting.playerHeight", L"40 40", g_settings.playerMinHeight, g_settings.playerMaxHeight);
+
+    ParseMargin(L"MainSettings.AlbumArtSetting.albumArtWidth", L"32 64", g_settings.albumArtMinWidth, g_settings.albumArtMaxWidth);
+    ParseMargin(L"MainSettings.AlbumArtSetting.albumArtHeight", L"32 32", g_settings.albumArtMinHeight, g_settings.albumArtMaxHeight);
+    ParseMargin(L"MainSettings.AlbumArtSetting.albumArtMargin", L"2 0", g_settings.albumArtLeftMargin, g_settings.albumArtRightMargin);
+
+    ParseMargin(L"MainSettings.TextAreaSetting.textAreaWidth", L"0 120", g_settings.textAreaMinWidth, g_settings.textAreaMaxWidth);
+    ParseMargin(L"MainSettings.TextAreaSetting.textAreaHeight", L"0 0", g_settings.textAreaMinHeight, g_settings.textAreaMaxHeight);
+    ParseMargin(L"MainSettings.TextAreaSetting.textAreaMargin", L"0 0", g_settings.textAreaLeftMargin, g_settings.textAreaRightMargin);
+
+    g_settings.mirrorLayout         = Wh_GetIntSetting(L"MainSettings.PlayerSetting.mirrorLayout") != 0;
+    g_settings.showMediaButtons     = Wh_GetIntSetting(L"MainSettings.MediaButtonsSettings.showMediaButtons") != 0;
+    ParseMargin(L"MainSettings.MediaButtonsSettings.mediaButtonsMargin", L"0 1", g_settings.mediaButtonsLeftMargin, g_settings.mediaButtonsRightMargin);
+    g_settings.showTrackTitle       = Wh_GetIntSetting(L"MainSettings.TextAreaSetting.showTrackTitle")    != 0;
+    g_settings.showFullTitleOnHover = Wh_GetIntSetting(L"BehaviorSettings.showFullTitleOnHover") != 0;
+    g_settings.showTrackArtist      = Wh_GetIntSetting(L"MainSettings.TextAreaSetting.showTrackArtist")   != 0;
+    g_settings.showAlbumArt         = Wh_GetIntSetting(L"MainSettings.AlbumArtSetting.showAlbumArt")      != 0;
+    g_settings.albumArtEmptyBehavior = Str(L"AppearanceSettings.AlbumArtDisplaySettings.albumArtEmptyBehavior", L"show");
+    g_settings.showPauseOverlay     = Wh_GetIntSetting(L"AppearanceSettings.AlbumArtDisplaySettings.showPauseOverlay")  != 0;
+    g_settings.pauseOverlayOpacity  = Int(L"AppearanceSettings.AlbumArtDisplaySettings.pauseOverlayOpacity",     0, 100,  60);
+    g_settings.iconStyle            = Str(L"AppearanceSettings.MediaButtonsStyle.iconStyle", L"fluent_outline");
+    g_settings.showAppIcon          = Wh_GetIntSetting(L"AppearanceSettings.AlbumArtDisplaySettings.showAppIcon")       != 0;
+    g_settings.appIconCorner        = Str(L"AppearanceSettings.AlbumArtDisplaySettings.appIconCorner",  L"bottom_right");
+    g_settings.appIconSize          = Int(L"AppearanceSettings.AlbumArtDisplaySettings.appIconSize",         8,  32,  12);
+
+    int autoThemeValue = Wh_GetIntSetting(L"AppearanceSettings.MediaButtonsStyle.autoTheme");
+    g_settings.autoTheme            = (autoThemeValue != 0);
+    g_settings.backgroundType       = Str(L"AppearanceSettings.BackgroundStyle.backgroundType", L"none");
+    g_settings.blurOpacity          = Int(L"AppearanceSettings.BackgroundStyle.blurOpacity",           0, 100, 100);
+    g_settings.blurRadius           = Int(L"AppearanceSettings.BackgroundStyle.blurRadius",            1,  50,  10);
+    g_settings.cornerRadius         = Int(L"AppearanceSettings.BackgroundStyle.cornerRadius",          0,  24,   5);
+    g_settings.albumArtOpacity      = Int(L"AppearanceSettings.AlbumArtDisplaySettings.albumArtOpacity",       0, 100, 100);
+    g_settings.albumArtCornerRadius = Int(L"AppearanceSettings.AlbumArtDisplaySettings.albumArtCornerRadius",  0,  24,   4);
+    ParseMargin(L"AppearanceSettings.LayoutSettings.controlsMargin", L"4 0", g_settings.controlsMarginLeft, g_settings.controlsMarginRight);
+    g_settings.buttonSpacing        = Wh_GetIntSetting(L"MainSettings.MediaButtonsSettings.buttonSpacing");
+    g_settings.buttonSize           = Int(L"MainSettings.MediaButtonsSettings.buttonSize",          16,  48,  28);
+    g_settings.buttonIconSize       = Int(L"MainSettings.MediaButtonsSettings.buttonIconSize",       8,  32,  16);
+    g_settings.hideUnsupportedButtons = Wh_GetIntSetting(L"MainSettings.MediaButtonsSettings.hideUnsupportedButtons") != 0;
+    g_settings.buttonCornerRadius   = Int(L"AppearanceSettings.MediaButtonsStyle.buttonCornerRadius",   0,  24,  14);
+    g_settings.titleFontSize        = Int(L"AppearanceSettings.TitleTextStyle.titleFontSize",         7,  24,  12);
+    g_settings.titleFont            = MapFontName(Str(L"AppearanceSettings.TitleTextStyle.titleFont", L"segoe_ui_variable"));
+    g_settings.artistFontSize       = Int(L"AppearanceSettings.ArtistTextStyle.artistFontSize",        7,  24,  10);
+    g_settings.artistFont           = MapFontName(Str(L"AppearanceSettings.ArtistTextStyle.artistFont", L"segoe_ui_semibold"));
+    g_settings.textSpacing          = Int(L"MainSettings.TextAreaSetting.textSpacing",           0,  20,   1);
+    g_settings.solidColor           = Str(L"AppearanceSettings.BackgroundStyle.solidColor", L"32 32 32");
+    g_settings.solidColor2          = Str(L"AppearanceSettings.BackgroundStyle.solidColor2", L"64 64 64");
+    g_settings.solidOpacity         = Int(L"AppearanceSettings.BackgroundStyle.solidOpacity", 0, 255, 204);
+    g_settings.gradientAngle        = Int(L"AppearanceSettings.BackgroundStyle.gradientAngle", 0, 360, 0);
+    g_settings.gradientBalance      = Int(L"AppearanceSettings.BackgroundStyle.gradientBalance", 0, 100, 50);
+    g_settings.acrylicTintOpacity   = Int(L"AppearanceSettings.BackgroundStyle.acrylicTintOpacity", 0, 100, 60);
+    g_settings.micaOpacity          = Int(L"AppearanceSettings.BackgroundStyle.micaOpacity", 0, 255, 51);
+    g_settings.buttonColor          = Str(L"AppearanceSettings.MediaButtonsStyle.buttonColor", L"255 255 255");
+    g_settings.buttonColorOpacity   = Int(L"AppearanceSettings.MediaButtonsStyle.buttonColorOpacity", 0, 100, 100);
+    g_settings.disabledButtonOpacity = Int(L"AppearanceSettings.MediaButtonsStyle.disabledButtonOpacity", 0, 100, 30);
+    g_settings.titleColor           = Str(L"AppearanceSettings.TitleTextStyle.titleColor", L"255 255 255");
+    g_settings.titleColorOpacity    = Int(L"AppearanceSettings.TitleTextStyle.titleColorOpacity", 0, 100, 90);
+    g_settings.artistColor          = Str(L"AppearanceSettings.ArtistTextStyle.artistColor", L"255 255 255");
+    g_settings.artistColorOpacity   = Int(L"AppearanceSettings.ArtistTextStyle.artistColorOpacity", 0, 100, 60);
+
+    for (int i = 0; i < 20; i++) {
+        PCWSTR objectStr = Wh_GetStringSetting(L"BehaviorSettings.ClickActionSettings[%d].object", i);
+        PCWSTR clickStr = Wh_GetStringSetting(L"BehaviorSettings.ClickActionSettings[%d].click", i);
+        PCWSTR actionStr = Wh_GetStringSetting(L"BehaviorSettings.ClickActionSettings[%d].action", i);
+
+        if (!objectStr || !clickStr || !actionStr) {
+            Wh_FreeStringSetting(objectStr);
+            Wh_FreeStringSetting(clickStr);
+            Wh_FreeStringSetting(actionStr);
+            break;
+        }
+
+        std::wstring object(objectStr);
+        std::wstring click(clickStr);
+        std::wstring action(actionStr);
+
+        Wh_FreeStringSetting(objectStr);
+        Wh_FreeStringSetting(clickStr);
+        Wh_FreeStringSetting(actionStr);
+
+        if (object.empty()) object = L"none";
+        if (click.empty()) click = L"none";
+        if (action.empty()) action = L"none";
+
+        if (object == L"none" || click == L"none") {
+            continue;
+        }
+
+        if (object == L"album_art") {
+            if (click == L"left_click") g_settings.albumArtLeftClick = action;
+            else if (click == L"right_click") g_settings.albumArtRightClick = action;
+            else if (click == L"middle_click") g_settings.albumArtMiddleClick = action;
+            else if (click == L"left_double_click") g_settings.albumArtLeftDoubleClick = action;
+            else if (click == L"right_double_click") g_settings.albumArtRightDoubleClick = action;
+        } else if (object == L"player") {
+            if (click == L"left_click") g_settings.playerLeftClick = action;
+            else if (click == L"right_click") g_settings.playerRightClick = action;
+            else if (click == L"middle_click") g_settings.playerMiddleClick = action;
+            else if (click == L"left_double_click") g_settings.playerLeftDoubleClick = action;
+            else if (click == L"right_double_click") g_settings.playerRightDoubleClick = action;
+        }
+    }
+
+    for (int i = 0; i < 20; i++) {
+        PCWSTR objectStr = Wh_GetStringSetting(L"BehaviorSettings.MouseWheelActionSettings[%d].object", i);
+        PCWSTR clickStr = Wh_GetStringSetting(L"BehaviorSettings.MouseWheelActionSettings[%d].click", i);
+        PCWSTR actionStr = Wh_GetStringSetting(L"BehaviorSettings.MouseWheelActionSettings[%d].action", i);
+
+        if (!objectStr || !clickStr || !actionStr) {
+            Wh_FreeStringSetting(objectStr);
+            Wh_FreeStringSetting(clickStr);
+            Wh_FreeStringSetting(actionStr);
+            break;
+        }
+
+        std::wstring object(objectStr);
+        std::wstring click(clickStr);
+        std::wstring action(actionStr);
+
+        Wh_FreeStringSetting(objectStr);
+        Wh_FreeStringSetting(clickStr);
+        Wh_FreeStringSetting(actionStr);
+
+        if (object.empty()) object = L"none";
+        if (click.empty()) click = L"none";
+        if (action.empty()) action = L"none";
+
+        if (object == L"none" || click == L"none") {
+            continue;
+        }
+
+        if (object == L"album_art" && click == L"mouse_wheel") {
+            g_settings.albumArtWheelAction = action;
+        } else if (object == L"player" && click == L"mouse_wheel") {
+            g_settings.playerWheelAction = action;
+        }
+    }
+    g_settings.hideWhenNoMedia      = Wh_GetIntSetting(L"BehaviorSettings.hideWhenNoMedia")   != 0;
+    g_settings.hideFullscreen       = Wh_GetIntSetting(L"BehaviorSettings.hideFullscreen")    != 0;
+    g_settings.idleHideSeconds      = std::max(Wh_GetIntSetting(L"BehaviorSettings.idleHideSeconds"), 0);
+    g_settings.enablePlayerHoverEffect   = Wh_GetIntSetting(L"AppearanceSettings.BackgroundStyle.enablePlayerHoverEffect") != 0;
+    g_settings.enableMediaButtonsHoverEffect = Wh_GetIntSetting(L"AppearanceSettings.BackgroundStyle.enableMediaButtonsHoverEffect") != 0;
+
+    g_settings.enableSmoothPositionAnimation = Wh_GetIntSetting(L"AnimationSettings.enableSmoothPositionAnimation") != 0;
+
+    g_settings.showSuccessNotification = Wh_GetIntSetting(L"NotificationSettings.showSuccessNotification") != 0;
+
+    g_settings.ignoredProcesses     = Str(L"DebugSettings.ignoredProcesses", L"");
+    g_settings.enableTreeDump       = Wh_GetIntSetting(L"DebugSettings.enableTreeDump")    != 0;
+    g_settings.showDebugBorders     = Wh_GetIntSetting(L"DebugSettings.showDebugBorders")  != 0;
+    g_settings.showLayoutAnchors    = Wh_GetIntSetting(L"DebugSettings.showLayoutAnchors") != 0;
+
+    {
+        std::lock_guard<std::mutex> lock(g_mediaButtonsMutex);
+        g_mediaButtons.clear();
+        std::set<MediaButtonType> seen;
+
+        for (int i = 0; i < 10; i++) {
+            PCWSTR itemStr = Wh_GetStringSetting(L"MainSettings.MediaButtonsSettings.mediaButtons[%d]", i);
+            if (!itemStr || !*itemStr) {
+                Wh_FreeStringSetting(itemStr);
+                break;
+            }
+
+            std::wstring keyword(itemStr);
+            Wh_FreeStringSetting(itemStr);
+
+            for (const auto& def : g_mediaButtonDefinitions) {
+                if (def.keyword == keyword && seen.insert(def.type).second) {
+                    g_mediaButtons.push_back({def.type, def.cmd});
+                    break;
+                }
+            }
+        }
+
+        if (g_mediaButtons.empty()) {
+            g_mediaButtons = {
+                {MediaButtonType::Previous, 1},
+                {MediaButtonType::PlayPause, 2},
+                {MediaButtonType::Next, 3}
+            };
+        }
+    }
+
+    if (g_settings.position == L"taskbar_left")
+        g_settings.position = L"taskbar_left_start";
+    else if (g_settings.position == L"taskbar_right")
+        g_settings.position = L"taskbar_right_start";
+    else if (g_settings.position == L"taskbar_after_start")
+        g_settings.position = L"taskbar_after_search_right";
+    else if (g_settings.position == L"taskbar_after_search")
+        g_settings.position = L"taskbar_after_search_right";
+    else if (g_settings.position == L"tray_before_omni")
+        g_settings.position = L"tray_before_omni_right";
+    else if (g_settings.position == L"tray_after_showdesktop")
+        g_settings.position = L"tray_after_showdesktop_right";
+}
+
+static HWND FindCurrentProcessTaskbarWnd();
+static void DispatchMediaUpdate();
+static void ApplySettings();
+static void StartRetryThread();
+static void StopRetryThread();
+
+static std::atomic<bool> g_unloading{false};
+static std::atomic<bool> g_applyingSettings{false};
+
+static IMMDeviceEnumerator* g_pDeviceEnumerator = nullptr;
+
+static const CLSID XIID_MMDeviceEnumerator = __uuidof(MMDeviceEnumerator);
+static const IID XIID_IMMDeviceEnumerator = __uuidof(IMMDeviceEnumerator);
+static const IID XIID_IAudioSessionManager2 = __uuidof(IAudioSessionManager2);
+
+static HWND             g_taskbarWnd      = nullptr;
+static Grid             g_playerGrid      = nullptr;
+static FrameworkElement g_injectionParent = nullptr;
+static int              g_playerColumn    = -1;
+static std::atomic<bool> g_needsUiUpdate{false};
+
+static void ShowSuccessNotification() {
+    if (!g_settings.showSuccessNotification) {
+        return;
+    }
+
+    MessageBoxW(
+        nullptr,
+        L"Media player successfully loaded and ready to use",
+        L"Taskbar Fluent Media Player",
+        MB_ICONINFORMATION | MB_OK | MB_TOPMOST | MB_SETFOREGROUND
+    );
+}
+
+static HWND  g_themeWatchWnd  = nullptr;
+static HANDLE g_themeWatchThread  = nullptr;
+static HANDLE g_themeWatchStop    = nullptr;
+
+static FrameworkElement g_trackedElement = nullptr;
+static Thickness g_trackedElementOriginalMargin{};
+static bool g_hasTrackedElementOriginalMargin = false;
+static std::wstring g_trackPosition = L"";
+static winrt::event_token g_layoutUpdateToken{};
+
+using CTaskBand_GetTaskbarHost_t  = void*(WINAPI*)(void*, void*);
+using TaskbarHost_FrameHeight_t   = int  (WINAPI*)(void*);
+using Std_Ref_Decref_t            = void (WINAPI*)(void*);
+
+static CTaskBand_GetTaskbarHost_t  CTaskBand_GetTaskbarHost_Original  = nullptr;
+static TaskbarHost_FrameHeight_t   TaskbarHost_FrameHeight_Original   = nullptr;
+static Std_Ref_Decref_t            Std_Ref_Decref_Original            = nullptr;
+static void* CTaskBand_ITaskListWndSite_vftable = nullptr;
+static bool                        g_taskbarViewDllLoaded             = false;
+
+using WindowThreadProc = void(*)(void*);
+
+static bool RunFromWindowThread(HWND hWnd, WindowThreadProc proc, void* param) {
+    static const UINT kMsg = RegisterWindowMessage(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
+
+    struct Payload { WindowThreadProc proc; void* param; };
+
+    DWORD tid = GetWindowThreadProcessId(hWnd, nullptr);
+    if (!tid) return false;
+
+    if (tid == GetCurrentThreadId()) {
+        proc(param);
+        return true;
+    }
+
+    HHOOK hook = SetWindowsHookExW(WH_CALLWNDPROC,
+        [](int code, WPARAM w, LPARAM l) -> LRESULT {
+            if (code == HC_ACTION) {
+                auto* cwp = reinterpret_cast<const CWPSTRUCT*>(l);
+                static const UINT kM = RegisterWindowMessage(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
+                if (cwp->message == kM) {
+                    auto* p = reinterpret_cast<Payload*>(cwp->lParam);
+                    p->proc(p->param);
+                }
+            }
+            return CallNextHookEx(nullptr, code, w, l);
+        }, nullptr, tid);
+
+    if (!hook) return false;
+
+    Payload pay{proc, param};
+    SendMessageW(hWnd, kMsg, 0, reinterpret_cast<LPARAM>(&pay));
+    UnhookWindowsHookEx(hook);
+    return true;
+}
+
+struct MediaState {
+    std::wstring      title;
+    std::wstring      artist;
+    std::wstring      appUserModelId;
+    bool              isPlaying     = false;
+    bool              hasMedia      = false;
+    std::vector<BYTE> thumbnailBytes;
+    uint64_t          thumbnailHash = 0;
+    std::vector<BYTE> appIconBytes;
+    std::wstring      appIconKey;
+};
+
+static MediaState g_media;
+static std::mutex g_mediaMtx;
+
+enum class RepeatMode {
+    Off = 0,
+    All = 1,
+    One = 2,
+};
+
+static std::atomic<bool> g_shuffleEnabled{false};
+static std::atomic<RepeatMode> g_repeatMode{RepeatMode::Off};
+
+static std::atomic<bool> g_capCanShuffle{false};
+static std::atomic<bool> g_capCanRepeat{false};
+static std::atomic<bool> g_capCanSkipPrev{false};
+static std::atomic<bool> g_capCanSkipNext{false};
+static std::atomic<bool> g_capCanSeek{false};
+
+static std::wstring g_cachedAlbumTitle;
+static std::wstring g_cachedAlbumArtist;
+static std::vector<BYTE> g_cachedThumbnailBytes;
+static int g_cachedAppIconSize = -1;
+
+struct BlurBgCache {
+    std::vector<BYTE>  blurredPixels;
+    int                width  = 0;
+    int                height = 0;
+    size_t             artHash = 0;
+
+    void Invalidate() {
+        blurredPixels.clear();
+        width = height = 0;
+        artHash = 0;
+    }
+} g_blurBgCache;
+
+struct AlbumPalette {
+    winrt::Windows::UI::Color primary;
+    winrt::Windows::UI::Color secondary;
+};
+
+static AlbumPalette g_cachedAlbumPalette = {
+    winrt::Windows::UI::Color{255, 18, 18, 18},
+    winrt::Windows::UI::Color{255, 45, 45, 45}
+};
+static size_t g_cachedPaletteHash = 0;
+
+static GlobalSystemMediaTransportControlsSessionManager g_sessionMgr     = nullptr;
+static GlobalSystemMediaTransportControlsSession        g_currentSession = nullptr;
+static std::mutex  g_sessionMtx;
+static bool g_userSwitchedSession = false;
+static std::atomic<bool> g_forceSessionRefresh{false};
+
+static winrt::event_token g_evSessionsChanged{};
+static winrt::event_token g_evCurrentChanged{};
+static winrt::event_token g_evMediaProps{};
+static winrt::event_token g_evPlayback{};
+
+static HANDLE g_mediaThread    = nullptr;
+static HANDLE g_mediaStopEvent = nullptr;
+
+static bool IsSystemLightTheme() {
+    DWORD v = 0, sz = sizeof(v);
+    if (RegGetValueW(HKEY_CURRENT_USER,
+        L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+        L"SystemUsesLightTheme", RRF_RT_DWORD, nullptr, &v, &sz) == ERROR_SUCCESS) {
+        return v != 0;
+    }
+    v = 0; sz = sizeof(v);
+    RegGetValueW(HKEY_CURRENT_USER,
+        L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+        L"AppsUseLightTheme", RRF_RT_DWORD, nullptr, &v, &sz);
+    return v != 0;
+}
+
+static bool IsLightTheme() {
+    return IsSystemLightTheme();
+}
+
+static winrt::Windows::UI::Color PanelBgColor() {
+    if (g_settings.backgroundType != L"solid" && g_settings.backgroundType != L"gradient") {
+        return winrt::Windows::UI::Color{0x00, 0x00, 0x00, 0x00};
+    }
+    if (IsLightTheme()) {
+        return winrt::Windows::UI::Color{0xCC, 0xF3, 0xF3, 0xF3};
+    } else {
+        return winrt::Windows::UI::Color{0xCC, 0x20, 0x20, 0x20};
+    }
+}
+
+static SolidColorBrush MakeBrush(winrt::Windows::UI::Color c) {
+    SolidColorBrush b; b.Color(c); return b;
+}
+
+static winrt::Windows::UI::Color GetSystemButtonHoverColor() {
+    if (IsLightTheme()) return winrt::Windows::UI::Color{0x25, 0x00, 0x00, 0x00};
+    else return winrt::Windows::UI::Color{0x10, 0xFF, 0xFF, 0xFF};
+}
+
+static winrt::Windows::UI::Color GetSystemButtonPressedColor() {
+    if (IsLightTheme()) return winrt::Windows::UI::Color{0x40, 0x00, 0x00, 0x00};
+    else return winrt::Windows::UI::Color{0x0A, 0xFF, 0xFF, 0xFF};
+}
+
+static winrt::Windows::UI::Color GetSystemButtonBorderColor() {
+    if (IsLightTheme()) return winrt::Windows::UI::Color{0x20, 0x00, 0x00, 0x00};
+    else return winrt::Windows::UI::Color{0x14, 0xFF, 0xFF, 0xFF};
+}
+
+static ObjectAnimationUsingKeyFrames MakeDiscreteObjectAnimation(
+    DependencyObject const& target,
+    const wchar_t* propertyPath,
+    winrt::Windows::Foundation::IInspectable const& value)
+{
+    ObjectAnimationUsingKeyFrames anim;
+    anim.EnableDependentAnimation(true);
+    DiscreteObjectKeyFrame kf;
+    kf.Value(value);
+    anim.KeyFrames().Append(kf);
+    Storyboard::SetTarget(anim, target);
+    Storyboard::SetTargetProperty(anim, winrt::hstring(propertyPath));
+    return anim;
+}
+
+static Storyboard MakeRootBorderStoryboard(
+    Border const& root,
+    Brush const& background,
+    Brush const& borderBrush)
+{
+    Storyboard sb;
+    sb.Children().Append(MakeDiscreteObjectAnimation(
+        root, L"Background", winrt::box_value(background)));
+    sb.Children().Append(MakeDiscreteObjectAnimation(
+        root, L"BorderBrush", winrt::box_value(borderBrush)));
+    return sb;
+}
+
+static VisualState FindVisualState(VisualStateGroup const& group, std::wstring_view name) {
+    for (auto const& state : group.States()) {
+        if (state.Name() == name) return state;
+    }
+    return nullptr;
+}
+
+static Border GetButtonTemplateRoot(Button const& btn) {
+    if (!btn) return nullptr;
+    try {
+        btn.ApplyTemplate();
+        if (auto named = btn.FindName(L"Root")) {
+            if (auto border = named.try_as<Border>()) return border;
+        }
+        if (VisualTreeHelper::GetChildrenCount(btn) > 0) {
+            return VisualTreeHelper::GetChild(btn, 0).try_as<Border>();
+        }
+    } catch (...) {}
+    return nullptr;
+}
+
+static VisualStateGroup FindCommonStatesGroup(Button const& btn) {
+    for (auto const& group : VisualStateManager::GetVisualStateGroups(btn)) {
+        if (group.Name() == L"CommonStates") return group;
+    }
+    if (auto root = GetButtonTemplateRoot(btn)) {
+        for (auto const& group : VisualStateManager::GetVisualStateGroups(root)) {
+            if (group.Name() == L"CommonStates") return group;
+        }
+    }
+    return nullptr;
+}
+
+static Style GetFluentMediaButtonStyle() {
+    static winrt::weak_ref<Style> cached;
+    if (auto existing = cached.get()) return existing;
+
+    static const wchar_t kStyleXaml[] = LR"(<Style TargetType="Button"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Setter Property="Background" Value="Transparent"/>
+  <Setter Property="BorderBrush" Value="Transparent"/>
+  <Setter Property="BorderThickness" Value="0"/>
+  <Setter Property="UseSystemFocusVisuals" Value="False"/>
+  <Setter Property="Template">
+    <Setter.Value>
+      <ControlTemplate TargetType="Button">
+        <Border x:Name="Root"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Padding="{TemplateBinding Padding}">
+          <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="CommonStates">
+              <VisualState x:Name="Normal"/>
+              <VisualState x:Name="PointerOver"/>
+              <VisualState x:Name="Pressed"/>
+              <VisualState x:Name="Disabled"/>
+            </VisualStateGroup>
+          </VisualStateManager.VisualStateGroups>
+          <ContentPresenter Content="{TemplateBinding Content}"
+                            ContentTransitions="{TemplateBinding ContentTransitions}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+        </Border>
+      </ControlTemplate>
+    </Setter.Value>
+  </Setter>
+</Style>)";
+
+    try {
+        auto style = winrt::Windows::UI::Xaml::Markup::XamlReader::Load(
+            winrt::hstring(kStyleXaml)).as<Style>();
+        cached = style;
+        return style;
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+static void ApplyFluentMediaButtonStyle(Button const& btn) {
+    if (auto style = GetFluentMediaButtonStyle()) {
+        btn.Style(style);
+    }
+}
+
+static void SetupCommonStates(
+    Button const& btn,
+    Brush const& normalBackground,
+    Brush const& pointerOverBackground,
+    Brush const& pressedBackground,
+    Brush const& disabledBackground,
+    Brush const& normalBorderBrush,
+    Brush const& pointerOverBorderBrush,
+    Brush const& pressedBorderBrush,
+    Brush const& disabledBorderBrush)
+{
+    auto root = GetButtonTemplateRoot(btn);
+    if (!root) return;
+
+    auto commonStates = FindCommonStatesGroup(btn);
+    if (!commonStates) return;
+
+    auto assignStoryboard = [&](std::wstring_view name, Brush const& bg, Brush const& border) {
+        if (auto state = FindVisualState(commonStates, name)) {
+            state.Storyboard(MakeRootBorderStoryboard(root, bg, border));
+        }
+    };
+
+    assignStoryboard(L"Normal", normalBackground, normalBorderBrush);
+    assignStoryboard(L"PointerOver", pointerOverBackground, pointerOverBorderBrush);
+    assignStoryboard(L"Pressed", pressedBackground, pressedBorderBrush);
+    assignStoryboard(L"Disabled", disabledBackground, disabledBorderBrush);
+}
+
+static void GoToCommonState(Button const& btn, bool effectEnabled, bool pressed, bool hovered) {
+    if (!btn) return;
+    winrt::hstring stateName = L"Normal";
+    if (effectEnabled) {
+        if (pressed) {
+            stateName = L"Pressed";
+        } else if (hovered) {
+            stateName = L"PointerOver";
+        }
+    }
+    try {
+        VisualStateManager::GoToState(btn, stateName, true);
+    } catch (...) {}
+}
+
+static void RunWhenButtonReady(Button const& btn, std::function<void()> const& action) {
+    if (!btn || !action) return;
+    auto run = std::make_shared<std::function<void()>>(action);
+    auto invoke = [btn, run]() {
+        try {
+            btn.ApplyTemplate();
+            (*run)();
+        } catch (...) {}
+    };
+    try {
+        if (btn.IsLoaded()) {
+            invoke();
+        } else {
+            btn.Loaded([invoke](auto const&, auto const&) { invoke(); });
+        }
+    } catch (...) {
+        invoke();
+    }
+}
+
+static void SetupMediaButtonCommonStates(Button const& btn) {
+    auto transparent = MakeBrush({0x00, 0, 0, 0});
+    SetupCommonStates(
+        btn,
+        transparent,
+        MakeBrush(GetSystemButtonHoverColor()),
+        MakeBrush(GetSystemButtonPressedColor()),
+        transparent,
+        transparent, transparent, transparent, transparent);
+}
+
+static void ApplyMediaButtonCapability(Button const& btn, bool capable) {
+    if (!btn) return;
+    try {
+        if (capable) {
+            btn.Visibility(Visibility::Visible);
+            btn.IsEnabled(true);
+            if (auto ct = btn.Content().try_as<TextBlock>()) {
+                ct.Opacity(1.0);
+            }
+        } else {
+            if (g_settings.hideUnsupportedButtons) {
+                btn.Visibility(Visibility::Collapsed);
+            } else {
+                btn.Visibility(Visibility::Visible);
+                if (auto ct = btn.Content().try_as<TextBlock>()) {
+                    ct.Opacity(g_settings.disabledButtonOpacity / 100.0);
+                }
+            }
+            btn.IsEnabled(false);
+        }
+    } catch (...) {}
+}
+
+static void SetupPlayerButtonCommonStates(Button const& btn, Brush const& normalBackground) {
+    auto transparent = MakeBrush({0x00, 0, 0, 0});
+    auto border = MakeBrush(GetSystemButtonBorderColor());
+    SetupCommonStates(
+        btn,
+        normalBackground,
+        MakeBrush(GetSystemButtonHoverColor()),
+        MakeBrush(GetSystemButtonPressedColor()),
+        transparent,
+        transparent,
+        border,
+        border,
+        transparent);
+}
+
+static bool DecodeImageToBGRA(const std::vector<BYTE>& imgBytes,
+                               std::vector<BYTE>& outPixels,
+                               int& outW, int& outH)
+{
+    if (imgBytes.empty()) return false;
+    IWICImagingFactory* pFactory = nullptr;
+    if (FAILED(CoCreateInstance(CLSID_WICImagingFactory, nullptr,
+                                CLSCTX_INPROC_SERVER,
+                                IID_PPV_ARGS(&pFactory))) || !pFactory)
+        return false;
+    IStream* pStream = SHCreateMemStream(imgBytes.data(), (UINT)imgBytes.size());
+    if (!pStream) { pFactory->Release(); return false; }
+    bool ok = false;
+    IWICBitmapDecoder* pDecoder = nullptr;
+    if (SUCCEEDED(pFactory->CreateDecoderFromStream(
+            pStream, nullptr, WICDecodeMetadataCacheOnDemand, &pDecoder))) {
+        IWICBitmapFrameDecode* pFrame = nullptr;
+        if (SUCCEEDED(pDecoder->GetFrame(0, &pFrame))) {
+            IWICFormatConverter* pConv = nullptr;
+            if (SUCCEEDED(pFactory->CreateFormatConverter(&pConv))) {
+                if (SUCCEEDED(pConv->Initialize(
+                        pFrame, GUID_WICPixelFormat32bppBGRA,
+                        WICBitmapDitherTypeNone, nullptr, 0.0,
+                        WICBitmapPaletteTypeMedianCut))) {
+                    UINT w = 0, h = 0;
+                    pConv->GetSize(&w, &h);
+                    if (w > 0 && h > 0) {
+                        outPixels.resize((size_t)w * h * 4);
+                        if (SUCCEEDED(pConv->CopyPixels(nullptr, w * 4,
+                                (UINT)outPixels.size(), outPixels.data()))) {
+                            outW = (int)w; outH = (int)h; ok = true;
+                        }
+                    }
+                }
+                pConv->Release();
+            }
+            pFrame->Release();
+        }
+        pDecoder->Release();
+    }
+    pStream->Release();
+    pFactory->Release();
+    return ok;
+}
+
+static void DownsampleBGRA(const std::vector<BYTE>& src, int srcW, int srcH,
+                            std::vector<BYTE>& dst, int dstW, int dstH)
+{
+    dst.resize((size_t)dstW * dstH * 4);
+    float xr = (float)srcW / dstW, yr = (float)srcH / dstH;
+    for (int dy = 0; dy < dstH; ++dy) {
+        for (int dx = 0; dx < dstW; ++dx) {
+            float sx = (dx + 0.5f) * xr - 0.5f;
+            float sy = (dy + 0.5f) * yr - 0.5f;
+            int x0 = (int)sx; if (x0 < 0) x0 = 0;
+            int y0 = (int)sy; if (y0 < 0) y0 = 0;
+            int x1 = x0 + 1; if (x1 >= srcW) x1 = srcW - 1;
+            int y1 = y0 + 1; if (y1 >= srcH) y1 = srcH - 1;
+            float fx = sx - (float)x0; if (fx < 0) fx = 0;
+            float fy = sy - (float)y0; if (fy < 0) fy = 0;
+            const BYTE* p00 = &src[((size_t)y0 * srcW + x0) * 4];
+            const BYTE* p10 = &src[((size_t)y0 * srcW + x1) * 4];
+            const BYTE* p01 = &src[((size_t)y1 * srcW + x0) * 4];
+            const BYTE* p11 = &src[((size_t)y1 * srcW + x1) * 4];
+            BYTE* d = &dst[((size_t)dy * dstW + dx) * 4];
+            for (int c = 0; c < 4; ++c) {
+                float v = p00[c]*(1-fx)*(1-fy) + p10[c]*fx*(1-fy)
+                        + p01[c]*(1-fx)*fy     + p11[c]*fx*fy;
+                d[c] = (BYTE)(v < 0 ? 0 : v > 255 ? 255 : (int)v);
+            }
+        }
+    }
+}
+
+static void ApplyBoxBlurBGRA(std::vector<BYTE>& pixels, int w, int h, int radius)
+{
+    if (radius < 1 || w < 1 || h < 1) return;
+    std::vector<BYTE> temp(pixels.size());
+
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+            int r = 0, g = 0, b = 0, a = 0, count = 0;
+            for (int dx = -radius; dx <= radius; ++dx) {
+                int sx = x + dx;
+                if (sx >= 0 && sx < w) {
+                    const BYTE* p = &pixels[((size_t)y * w + sx) * 4];
+                    b += p[0]; g += p[1]; r += p[2]; a += p[3];
+                    count++;
+                }
+            }
+            BYTE* d = &temp[((size_t)y * w + x) * 4];
+            d[0] = (BYTE)(b / count);
+            d[1] = (BYTE)(g / count);
+            d[2] = (BYTE)(r / count);
+            d[3] = (BYTE)(a / count);
+        }
+    }
+
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+            int r = 0, g = 0, b = 0, a = 0, count = 0;
+            for (int dy = -radius; dy <= radius; ++dy) {
+                int sy = y + dy;
+                if (sy >= 0 && sy < h) {
+                    const BYTE* p = &temp[((size_t)sy * w + x) * 4];
+                    b += p[0]; g += p[1]; r += p[2]; a += p[3];
+                    count++;
+                }
+            }
+            BYTE* d = &pixels[((size_t)y * w + x) * 4];
+            d[0] = (BYTE)(b / count);
+            d[1] = (BYTE)(g / count);
+            d[2] = (BYTE)(r / count);
+            d[3] = (BYTE)(a / count);
+        }
+    }
+}
+
+static bool UpdateAlbumBlurBgCache(const std::vector<BYTE>& thumbBytes,
+                                    int targetW, int targetH)
+{
+    if (thumbBytes.empty() || targetW <= 0 || targetH <= 0) {
+        g_blurBgCache.Invalidate(); return false;
+    }
+    size_t artHash = 0;
+    for (size_t i = 0; i < thumbBytes.size(); i += 512)
+        artHash = artHash * 31 + thumbBytes[i];
+    if (g_blurBgCache.artHash == artHash && g_blurBgCache.width == targetW &&
+        g_blurBgCache.height == targetH && !g_blurBgCache.blurredPixels.empty())
+        return true;
+
+    std::vector<BYTE> srcPixels; int srcW = 0, srcH = 0;
+    if (!DecodeImageToBGRA(thumbBytes, srcPixels, srcW, srcH)) return false;
+
+    int blurDiv = 8;
+    int smallW = srcW / blurDiv; if (smallW < 1) smallW = 1;
+    int smallH = srcH / blurDiv; if (smallH < 1) smallH = 1;
+
+    std::vector<BYTE> small;
+    DownsampleBGRA(srcPixels, srcW, srcH, small, smallW, smallH);
+
+    int blurRadius = std::clamp(g_settings.blurRadius, 1, 50);
+    for (int i = 0; i < 3; ++i) {
+        ApplyBoxBlurBGRA(small, smallW, smallH, blurRadius);
+    }
+
+    std::vector<BYTE> blurred;
+    DownsampleBGRA(small, smallW, smallH, blurred, targetW, targetH);
+
+    g_blurBgCache.blurredPixels = std::move(blurred);
+    g_blurBgCache.width   = targetW;
+    g_blurBgCache.height  = targetH;
+    g_blurBgCache.artHash = artHash;
+    return true;
+}
+
+static AlbumPalette ExtractAlbumPalette(const std::vector<BYTE>& thumbBytes) {
+    const winrt::Windows::UI::Color fallbackPrimary{255, 18, 18, 18};
+    const winrt::Windows::UI::Color fallbackSecondary{255, 45, 45, 45};
+
+    if (thumbBytes.empty())
+        return {fallbackPrimary, fallbackSecondary};
+
+    try {
+        auto stream = winrt::Windows::Storage::Streams::InMemoryRandomAccessStream();
+        auto writer = winrt::Windows::Storage::Streams::DataWriter(stream);
+        writer.WriteBytes(thumbBytes);
+        writer.StoreAsync().get();
+        writer.DetachStream();
+        stream.Seek(0);
+
+        auto decoder = winrt::Windows::Graphics::Imaging::BitmapDecoder::CreateAsync(stream).get();
+
+        auto transform = winrt::Windows::Graphics::Imaging::BitmapTransform();
+        auto pixelData = decoder.GetPixelDataAsync(
+            winrt::Windows::Graphics::Imaging::BitmapPixelFormat::Bgra8,
+            winrt::Windows::Graphics::Imaging::BitmapAlphaMode::Premultiplied,
+            transform,
+            winrt::Windows::Graphics::Imaging::ExifOrientationMode::RespectExifOrientation,
+            winrt::Windows::Graphics::Imaging::ColorManagementMode::DoNotColorManage
+        ).get();
+
+        auto pixels = pixelData.DetachPixelData();
+        uint32_t w = decoder.PixelWidth();
+        uint32_t h = decoder.PixelHeight();
+
+        if (w == 0 || h == 0 || pixels.size() < w * h * 4)
+            return {fallbackPrimary, fallbackSecondary};
+
+        struct Bucket { uint32_t r=0, g=0, b=0, n=0; };
+        Bucket buckets[16][16][16]{};
+
+        for (uint32_t y = 0; y < h; y += 4) {
+            for (uint32_t x = 0; x < w; x += 4) {
+                uint32_t idx = (y * w + x) * 4;
+                if (idx + 3 >= pixels.size()) continue;
+
+                BYTE pb = pixels[idx];
+                BYTE pg = pixels[idx + 1];
+                BYTE pr = pixels[idx + 2];
+
+                int luma = (pr * 299 + pg * 587 + pb * 114) / 1000;
+                if (luma < 24 || luma > 235) continue;
+
+                auto& bk = buckets[pr >> 4][pg >> 4][pb >> 4];
+                bk.r += pr; bk.g += pg; bk.b += pb; bk.n++;
+            }
+        }
+
+        struct Cand { float w; BYTE r, g, b; };
+        std::vector<Cand> cands;
+        cands.reserve(64);
+
+        for (int R = 0; R < 16; R++)
+            for (int G = 0; G < 16; G++)
+                for (int B = 0; B < 16; B++) {
+                    auto& bk = buckets[R][G][B];
+                    if (bk.n < 8) continue;
+                    float fr = bk.r / (float)bk.n / 255.f;
+                    float fg = bk.g / (float)bk.n / 255.f;
+                    float fb = bk.b / (float)bk.n / 255.f;
+                    float mx = std::max({fr, fg, fb});
+                    float mn = std::min({fr, fg, fb});
+                    float sat = mx > 0 ? (mx - mn) / mx : 0;
+                    cands.push_back({bk.n * (0.3f + sat),
+                                     (BYTE)(fr * 255), (BYTE)(fg * 255), (BYTE)(fb * 255)});
+                }
+
+        if (cands.empty())
+            return {fallbackPrimary, fallbackSecondary};
+
+        std::sort(cands.begin(), cands.end(),
+                  [](const Cand& a, const Cand& b){ return a.w > b.w; });
+
+        winrt::Windows::UI::Color primary{255, cands[0].r, cands[0].g, cands[0].b};
+        winrt::Windows::UI::Color secondary = primary;
+
+        for (auto& c : cands) {
+            int dr = (int)c.r - (int)cands[0].r;
+            int dg = (int)c.g - (int)cands[0].g;
+            int db = (int)c.b - (int)cands[0].b;
+            if (dr*dr + dg*dg + db*db > 3264) {
+                secondary = winrt::Windows::UI::Color{255, c.r, c.g, c.b};
+                break;
+            }
+        }
+
+        return {primary, secondary};
+    } catch (...) {
+        return {fallbackPrimary, fallbackSecondary};
+    }
+}
+
+static DWORD GetWindowsAccentColor() {
+    DWORD color = 0;
+    BOOL opaque = FALSE;
+    if (SUCCEEDED(DwmGetColorizationColor(&color, &opaque)))
+        return 0xFF000000 | (color & 0x00FFFFFF);
+    return 0xFF0078D4;
+}
+
+static winrt::Windows::UI::Color ParseColorWithSpecialValues(const std::wstring& colorStr, BYTE alpha = 255) {
+    int r = 255, g = 255, b = 255;
+    size_t pos1 = colorStr.find(L' ');
+    size_t pos2 = colorStr.find(L' ', pos1 + 1);
+
+    if (pos1 != std::wstring::npos && pos2 != std::wstring::npos) {
+        try {
+            r = std::stoi(colorStr.substr(0, pos1));
+            g = std::stoi(colorStr.substr(pos1 + 1, pos2 - pos1 - 1));
+            b = std::stoi(colorStr.substr(pos2 + 1));
+
+            if (r == -1 && g == -1 && b == -1) {
+                DWORD accentColor = GetWindowsAccentColor();
+                return winrt::Windows::UI::Color{alpha,
+                    (BYTE)((accentColor >> 16) & 0xFF),
+                    (BYTE)((accentColor >> 8) & 0xFF),
+                    (BYTE)(accentColor & 0xFF)};
+            }
+
+            if (r == -2 && g == -2 && b == -2) {
+                return winrt::Windows::UI::Color{alpha,
+                    g_cachedAlbumPalette.primary.R,
+                    g_cachedAlbumPalette.primary.G,
+                    g_cachedAlbumPalette.primary.B};
+            }
+
+            r = std::clamp(r, 0, 255);
+            g = std::clamp(g, 0, 255);
+            b = std::clamp(b, 0, 255);
+        } catch (...) {}
+    }
+
+    return winrt::Windows::UI::Color{alpha, (BYTE)r, (BYTE)g, (BYTE)b};
+}
+
+static winrt::Windows::UI::Color TextColor() {
+    if (g_settings.autoTheme) {
+        BYTE alpha = (BYTE)((g_settings.titleColorOpacity * 255) / 100);
+        return IsLightTheme() ? winrt::Windows::UI::Color{alpha, 0x00, 0x00, 0x00}
+                              : winrt::Windows::UI::Color{alpha, 0xFF, 0xFF, 0xFF};
+    }
+    BYTE alpha = (BYTE)((g_settings.titleColorOpacity * 255) / 100);
+    return ParseColorWithSpecialValues(g_settings.titleColor, alpha);
+}
+
+static winrt::Windows::UI::Color ArtistColor() {
+    if (g_settings.autoTheme) {
+        BYTE alpha = (BYTE)((g_settings.artistColorOpacity * 255) / 100);
+        return IsLightTheme() ? winrt::Windows::UI::Color{alpha, 0x33, 0x33, 0x33}
+                              : winrt::Windows::UI::Color{alpha, 0xFF, 0xFF, 0xFF};
+    }
+    BYTE alpha = (BYTE)((g_settings.artistColorOpacity * 255) / 100);
+    return ParseColorWithSpecialValues(g_settings.artistColor, alpha);
+}
+
+static winrt::Windows::UI::Color ButtonColor() {
+    if (g_settings.autoTheme) {
+        BYTE alpha = (BYTE)((g_settings.buttonColorOpacity * 255) / 100);
+        return IsLightTheme() ? winrt::Windows::UI::Color{alpha, 0x00, 0x00, 0x00}
+                              : winrt::Windows::UI::Color{alpha, 0xFF, 0xFF, 0xFF};
+    }
+    BYTE alpha = (BYTE)((g_settings.buttonColorOpacity * 255) / 100);
+    return ParseColorWithSpecialValues(g_settings.buttonColor, alpha);
+}
+
+static Brush MakeAlbumBlurBrush(const std::vector<BYTE>& thumbBytes,
+                                  int panelW, int panelH)
+{
+    if (!UpdateAlbumBlurBgCache(thumbBytes, panelW, panelH) ||
+        g_blurBgCache.blurredPixels.empty())
+        return MakeBrush({0x00, 0x00, 0x00, 0x00});
+    try {
+        size_t bytesNeeded = (size_t)panelW * panelH * 4;
+        WriteableBitmap wb(panelW, panelH);
+        auto buf = wb.PixelBuffer();
+        auto byteAccess = buf.as<Windows::Storage::Streams::IBufferByteAccess>();
+        BYTE* pixels = nullptr;
+        byteAccess->Buffer(&pixels);
+        if (pixels && g_blurBgCache.blurredPixels.size() >= bytesNeeded)
+            memcpy(pixels, g_blurBgCache.blurredPixels.data(), bytesNeeded);
+        buf.Length(static_cast<uint32_t>(bytesNeeded));
+        wb.Invalidate();
+        ImageBrush brush;
+        brush.ImageSource(wb);
+        brush.Stretch(Stretch::UniformToFill);
+        return brush;
+    } catch (...) {}
+    return MakeBrush({0x00, 0x00, 0x00, 0x00});
+}
+static Brush MakeBackgroundBrush() {
+    auto& t = g_settings.backgroundType;
+
+    auto color1 = ParseColorWithSpecialValues(g_settings.solidColor, (BYTE)g_settings.solidOpacity);
+    auto color2 = ParseColorWithSpecialValues(g_settings.solidColor2, (BYTE)g_settings.solidOpacity);
+
+    if (t == L"gradient") {
+        try {
+            winrt::Windows::UI::Xaml::Media::LinearGradientBrush brush;
+
+            double angleRad = (g_settings.gradientAngle % 360) * 3.14159265358979323846 / 180.0;
+            double startX = 0.5 - 0.5 * std::cos(angleRad);
+            double startY = 0.5 - 0.5 * std::sin(angleRad);
+            double endX = 0.5 + 0.5 * std::cos(angleRad);
+            double endY = 0.5 + 0.5 * std::sin(angleRad);
+
+            brush.StartPoint(winrt::Windows::Foundation::Point((float)startX, (float)startY));
+            brush.EndPoint(winrt::Windows::Foundation::Point((float)endX, (float)endY));
+
+            double balancePoint = std::clamp(g_settings.gradientBalance, 0, 100) / 100.0;
+
+            winrt::Windows::UI::Xaml::Media::GradientStop stop1;
+            stop1.Color(color1);
+            stop1.Offset(0.0);
+
+            winrt::Windows::UI::Xaml::Media::GradientStop stop2;
+            stop2.Color(color2);
+            stop2.Offset(balancePoint);
+
+            winrt::Windows::UI::Xaml::Media::GradientStop stop3;
+            stop3.Color(color2);
+            stop3.Offset(1.0);
+
+            brush.GradientStops().Append(stop1);
+            brush.GradientStops().Append(stop2);
+            brush.GradientStops().Append(stop3);
+
+            return brush;
+        } catch (...) {}
+    }
+
+    if (t == L"acrylic") {
+        try {
+            winrt::Windows::UI::Xaml::Media::AcrylicBrush brush;
+            brush.BackgroundSource(winrt::Windows::UI::Xaml::Media::AcrylicBackgroundSource::HostBackdrop);
+            auto col = winrt::Windows::UI::Color{0xFF, color1.R, color1.G, color1.B};
+            brush.TintColor(col);
+            brush.TintOpacity(g_settings.acrylicTintOpacity / 100.0);
+            brush.FallbackColor(winrt::Windows::UI::Color{0xCC, color1.R, color1.G, color1.B});
+            return brush;
+        } catch (...) {}
+    }
+
+    if (t == L"mica" || t == L"mica_alt") {
+        auto col = winrt::Windows::UI::Color{(BYTE)g_settings.micaOpacity, color1.R, color1.G, color1.B};
+        return MakeBrush(col);
+    }
+
+    if (t == L"solid") {
+        return MakeBrush(color1);
+    }
+
+    if (t == L"album_art_blur") {
+        return MakeBrush({0x00, 0x00, 0x00, 0x00});
+    }
+
+    return MakeBrush({0x00, 0x00, 0x00, 0x00});
+}
+
+static FrameworkElement FindChildByName(FrameworkElement const& root, std::wstring_view name, int depth = 32) {
+    if (!root || depth == 0) return nullptr;
+    int n = VisualTreeHelper::GetChildrenCount(root);
+    for (int i = 0; i < n; ++i) {
+        auto child = VisualTreeHelper::GetChild(root, i).try_as<FrameworkElement>();
+        if (!child) continue;
+        if (child.Name() == name) return child;
+        if (auto found = FindChildByName(child, name, depth - 1)) return found;
+    }
+    return nullptr;
+}
+
+static void DumpXamlTree(DependencyObject const& node, int depth, int maxDepth) {
+    if (!node || depth > maxDepth) return;
+    std::wstring indent(depth * 2, L' ');
+    auto fe = node.try_as<FrameworkElement>();
+    std::wstring name  = fe ? std::wstring(fe.Name()) : L"";
+    winrt::hstring typeHstr = winrt::get_class_name(node);
+    std::wstring type  = std::wstring(typeHstr);
+    auto dot = type.rfind(L'.');
+    if (dot != std::wstring::npos) type = type.substr(dot + 1);
+
+    int col = fe ? Grid::GetColumn(fe) : -1;
+    if (!name.empty()) Wh_Log(L"%ls[%ls] name='%ls' col=%d", indent.c_str(), type.c_str(), name.c_str(), col);
+    else Wh_Log(L"%ls[%ls]", indent.c_str(), type.c_str());
+
+    int n = VisualTreeHelper::GetChildrenCount(node);
+    for (int i = 0; i < n; ++i) {
+        auto child = VisualTreeHelper::GetChild(node, i);
+        if (child) DumpXamlTree(child, depth + 1, maxDepth);
+    }
+}
+
+static constexpr wchar_t kGridName[]        = L"FluentMediaBar";
+static constexpr wchar_t kArtImageName[]    = L"FluentMedia_Art";
+static constexpr wchar_t kAppIconImageName[]= L"FluentMedia_AppIcon";
+static constexpr wchar_t kAnchorOverlayName[]= L"FluentMedia_DebugAnchorTarget";
+static constexpr wchar_t kTextStackName[]   = L"FluentMedia_TextStack";
+static constexpr wchar_t kTitleBlockName[]  = L"FluentMedia_Title";
+static constexpr wchar_t kArtistBlockName[] = L"FluentMedia_Artist";
+static constexpr wchar_t kPlayBtnName[]     = L"FluentMedia_Play";
+static constexpr wchar_t kPrevBtnName[]     = L"FluentMedia_Prev";
+static constexpr wchar_t kNextBtnName[]     = L"FluentMedia_Next";
+static constexpr wchar_t kRewindBtnName[]   = L"FluentMedia_Rewind";
+static constexpr wchar_t kForwardBtnName[]  = L"FluentMedia_Forward";
+static constexpr wchar_t kShuffleBtnName[]  = L"FluentMedia_Shuffle";
+static constexpr wchar_t kRepeatBtnName[]   = L"FluentMedia_Repeat";
+
+static int  g_idleSeconds  = 0;
+static bool g_hiddenByIdle = false;
+static std::chrono::steady_clock::time_point g_lastMediaTime = std::chrono::steady_clock::now();
+
+static void SendMediaCommandAsync(int cmd) {
+    std::thread([cmd]() {
+        if (g_unloading) return;
+        winrt::init_apartment(winrt::apartment_type::multi_threaded);
+        try {
+            GlobalSystemMediaTransportControlsSession session{nullptr};
+            { std::lock_guard<std::mutex> lk(g_sessionMtx); session = g_currentSession; }
+            if (session) {
+                switch (cmd) {
+                    case 1: session.TrySkipPreviousAsync().get();    break;
+                    case 2: session.TryTogglePlayPauseAsync().get(); break;
+                    case 3: session.TrySkipNextAsync().get();        break;
+                    case 4:
+                        try {
+                            Wh_Log(L"SendMediaCommandAsync: Attempting to stop playback");
+
+                            auto result = session.TryStopAsync().get();
+                            Wh_Log(L"SendMediaCommandAsync: TryStopAsync returned %d", result);
+
+                            if (!result) {
+                                Wh_Log(L"SendMediaCommandAsync: Stop not supported, using pause + seek fallback");
+                                session.TryPauseAsync().get();
+                                session.TryChangePlaybackPositionAsync(0).get();
+                            }
+                        } catch (...) {
+                            Wh_Log(L"SendMediaCommandAsync: Stop failed, trying pause + seek fallback");
+
+                            try {
+                                session.TryPauseAsync().get();
+                                session.TryChangePlaybackPositionAsync(0).get();
+                            } catch (...) {
+                                Wh_Log(L"SendMediaCommandAsync: Fallback also failed");
+                            }
+                        }
+                        break;
+                    case 5:
+                        try {
+                            auto timeline = session.GetTimelineProperties();
+                            auto currentPos = timeline.Position();
+                            auto newPos = currentPos - std::chrono::seconds(5);
+                            if (newPos.count() < 0) newPos = std::chrono::seconds(0);
+                            session.TryChangePlaybackPositionAsync(newPos.count()).get();
+                        } catch (...) {}
+                        break;
+                    case 6:
+                        try {
+                            auto timeline = session.GetTimelineProperties();
+                            auto currentPos = timeline.Position();
+                            auto endTime = timeline.EndTime();
+                            auto newPos = currentPos + std::chrono::seconds(5);
+                            if (newPos > endTime) newPos = endTime;
+                            session.TryChangePlaybackPositionAsync(newPos.count()).get();
+                        } catch (...) {}
+                        break;
+                    case 7:
+                        try {
+                            bool currentShuffle = g_shuffleEnabled.load();
+                            session.TryChangeShuffleActiveAsync(!currentShuffle).get();
+                        } catch (...) {}
+                        break;
+                    case 8:
+                        try {
+                            RepeatMode current = g_repeatMode.load();
+                            winrt::Windows::Media::MediaPlaybackAutoRepeatMode mode;
+
+                            switch (current) {
+                                case RepeatMode::Off:
+                                    mode = winrt::Windows::Media::MediaPlaybackAutoRepeatMode::List;
+                                    break;
+                                case RepeatMode::All:
+                                    mode = winrt::Windows::Media::MediaPlaybackAutoRepeatMode::Track;
+                                    break;
+                                case RepeatMode::One:
+                                default:
+                                    mode = winrt::Windows::Media::MediaPlaybackAutoRepeatMode::None;
+                                    break;
+                            }
+
+                            session.TryChangeAutoRepeatModeAsync(mode).get();
+                        } catch (...) {}
+                        break;
+                }
+            }
+        } catch (...) {}
+        winrt::uninit_apartment();
+    }).detach();
+}
+
+static void FetchMediaPropertiesAsync();
+static void FetchPlaybackInfoAsync();
+static void OnSessionsChanged();
+static void AttachToSession(GlobalSystemMediaTransportControlsSession session);
+static bool IsIgnoredMediaApp(const std::wstring& appUserModelId);
+
+static void SwitchMediaSession() {
+    GlobalSystemMediaTransportControlsSession nextSession{nullptr};
+    {
+        std::lock_guard<std::mutex> lk(g_sessionMtx);
+        if (!g_sessionMgr) return;
+        g_userSwitchedSession = true;
+        try {
+            auto sessions = g_sessionMgr.GetSessions();
+            int count = (int)sessions.Size();
+            if (count <= 1) return;
+
+            std::vector<GlobalSystemMediaTransportControlsSession> validSessions;
+            for (int i = 0; i < count; ++i) {
+                auto session = sessions.GetAt(i);
+                try {
+                    std::wstring appId = session.SourceAppUserModelId().c_str();
+                    if (!IsIgnoredMediaApp(appId)) {
+                        validSessions.push_back(session);
+                    }
+                } catch (...) {
+                    validSessions.push_back(session);
+                }
+            }
+
+            if (validSessions.empty()) return;
+            if (validSessions.size() == 1) return;
+
+            int currentIndex = -1;
+            if (g_currentSession) {
+                auto curId = g_currentSession.SourceAppUserModelId();
+                for (int i = 0; i < (int)validSessions.size(); ++i) {
+                    try {
+                        if (validSessions[i].SourceAppUserModelId() == curId) {
+                            currentIndex = i;
+                            break;
+                        }
+                    } catch (...) {}
+                }
+            }
+            int nextIndex = (currentIndex + 1) % (int)validSessions.size();
+            nextSession = validSessions[nextIndex];
+        } catch (...) { return; }
+    }
+    if (nextSession) {
+        AttachToSession(nextSession);
+    }
+}
+
+static void InitAudioDeviceEnumerator() {
+    if (!g_pDeviceEnumerator) {
+        CoCreateInstance(
+            XIID_MMDeviceEnumerator, NULL, CLSCTX_INPROC_SERVER,
+            XIID_IMMDeviceEnumerator, (LPVOID*)&g_pDeviceEnumerator);
+    }
+}
+
+static void CleanupAudioDeviceEnumerator() {
+    if (g_pDeviceEnumerator) {
+        g_pDeviceEnumerator->Release();
+        g_pDeviceEnumerator = nullptr;
+    }
+}
+
+static bool AdjustAppVolumeByAUMID(const std::wstring& aumid, float volumeDelta) {
+    InitAudioDeviceEnumerator();
+    if (!g_pDeviceEnumerator) return false;
+
+    winrt::com_ptr<IMMDevice> defaultDevice;
+    HRESULT hr = g_pDeviceEnumerator->GetDefaultAudioEndpoint(eRender, eConsole, defaultDevice.put());
+    if (FAILED(hr)) return false;
+
+    winrt::com_ptr<IAudioSessionManager2> sessionManager;
+    hr = defaultDevice->Activate(XIID_IAudioSessionManager2, CLSCTX_ALL, NULL, sessionManager.put_void());
+    if (FAILED(hr)) return false;
+
+    winrt::com_ptr<IAudioSessionEnumerator> sessionEnumerator;
+    hr = sessionManager->GetSessionEnumerator(sessionEnumerator.put());
+    if (FAILED(hr)) return false;
+
+    int sessionCount = 0;
+    hr = sessionEnumerator->GetCount(&sessionCount);
+    if (FAILED(hr)) return false;
+
+    bool found = false;
+    for (int i = 0; i < sessionCount; i++) {
+        winrt::com_ptr<IAudioSessionControl> sessionControl;
+        hr = sessionEnumerator->GetSession(i, sessionControl.put());
+        if (FAILED(hr)) continue;
+
+        winrt::com_ptr<IAudioSessionControl2> sessionControl2;
+        hr = sessionControl->QueryInterface(__uuidof(IAudioSessionControl2), sessionControl2.put_void());
+        if (FAILED(hr)) continue;
+
+        LPWSTR sessionId = nullptr;
+        hr = sessionControl2->GetSessionIdentifier(&sessionId);
+        if (SUCCEEDED(hr) && sessionId) {
+            std::wstring sessionIdStr(sessionId);
+            CoTaskMemFree(sessionId);
+
+            if (sessionIdStr.find(aumid) != std::wstring::npos) {
+                winrt::com_ptr<ISimpleAudioVolume> vol;
+                if (SUCCEEDED(sessionControl->QueryInterface(__uuidof(ISimpleAudioVolume), vol.put_void()))) {
+                    float currentVolume = 0.0f;
+                    if (SUCCEEDED(vol->GetMasterVolume(&currentVolume))) {
+                        float newVolume = std::clamp(currentVolume + volumeDelta, 0.0f, 1.0f);
+                        vol->SetMasterVolume(newVolume, NULL);
+                        found = true;
+                    }
+                }
+            }
+        }
+    }
+
+    return found;
+}
+
+static void ChangeSystemVolume(bool increase) {
+    InitAudioDeviceEnumerator();
+    if (!g_pDeviceEnumerator) return;
+
+    winrt::com_ptr<IMMDevice> defaultDevice;
+    HRESULT hr = g_pDeviceEnumerator->GetDefaultAudioEndpoint(eRender, eConsole, defaultDevice.put());
+    if (FAILED(hr)) return;
+
+    winrt::com_ptr<IAudioEndpointVolume> endpointVolume;
+    hr = defaultDevice->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_ALL, NULL, endpointVolume.put_void());
+    if (FAILED(hr)) return;
+
+    float currentVolume = 0.0f;
+    if (SUCCEEDED(endpointVolume->GetMasterVolumeLevelScalar(&currentVolume))) {
+        float newVolume = currentVolume + (increase ? 0.005f : -0.005f);
+        newVolume = std::clamp(newVolume, 0.0f, 1.0f);
+        endpointVolume->SetMasterVolumeLevelScalar(newVolume, NULL);
+    }
+
+    HWND hShellTrayWnd = FindWindow(L"Shell_TrayWnd", nullptr);
+    if (hShellTrayWnd) {
+        SHORT appCommand = increase ? APPCOMMAND_VOLUME_UP : APPCOMMAND_VOLUME_DOWN;
+        PostMessage(hShellTrayWnd, WM_APPCOMMAND, (WPARAM)hShellTrayWnd,
+                    MAKELPARAM(0, appCommand));
+    }
+}
+
+static void ExecuteMediaAction(const std::wstring& action) {
+    if (action == L"none") {
+        return;
+    } else if (action == L"switch_session") {
+        SwitchMediaSession();
+    } else if (action == L"play_pause") {
+        SendMediaCommandAsync(2);
+        DispatchMediaUpdate();
+    } else if (action == L"next_track") {
+        SendMediaCommandAsync(3);
+        DispatchMediaUpdate();
+    } else if (action == L"prev_track") {
+        SendMediaCommandAsync(1);
+        DispatchMediaUpdate();
+    } else if (action == L"stop") {
+        g_forceSessionRefresh = true;
+        SendMediaCommandAsync(4);
+        DispatchMediaUpdate();
+        std::thread([]() {
+            for (DWORD delay : {300, 1200, 2500}) {
+                Sleep(delay);
+                if (g_unloading) return;
+                g_forceSessionRefresh = true;
+                OnSessionsChanged();
+                FetchPlaybackInfoAsync();
+                FetchMediaPropertiesAsync();
+            }
+        }).detach();
+    } else if (action == L"rewind_5s") {
+        SendMediaCommandAsync(5);
+        DispatchMediaUpdate();
+    } else if (action == L"forward_5s") {
+        SendMediaCommandAsync(6);
+        DispatchMediaUpdate();
+    } else if (action == L"toggle_shuffle") {
+        SendMediaCommandAsync(7);
+        DispatchMediaUpdate();
+    } else if (action == L"toggle_repeat") {
+        SendMediaCommandAsync(8);
+        DispatchMediaUpdate();
+    } else if (action == L"open_app") {
+        std::thread([]() {
+            if (g_unloading) return;
+            std::wstring app;
+            {
+                std::lock_guard<std::mutex> lk(g_sessionMtx);
+                if (g_currentSession) {
+                    try {
+                        app = std::wstring(g_currentSession.SourceAppUserModelId());
+                    } catch (...) {}
+                }
+            }
+            if (!app.empty()) {
+                HWND foundWindow = nullptr;
+
+                struct FindData {
+                    const std::wstring* aumid;
+                    HWND hwnd;
+                };
+                FindData fd{&app, nullptr};
+
+                EnumWindows([](HWND hWnd, LPARAM lParam) -> BOOL {
+                    auto* fd2 = reinterpret_cast<FindData*>(lParam);
+                    if (!IsWindowVisible(hWnd)) return TRUE;
+
+                    wchar_t title[256] = {};
+                    GetWindowTextW(hWnd, title, 256);
+                    if (wcslen(title) == 0) return TRUE;
+
+                    DWORD pid = 0;
+                    GetWindowThreadProcessId(hWnd, &pid);
+                    if (!pid) return TRUE;
+
+                    wchar_t procPath[MAX_PATH] = {};
+                    HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+                    if (hProc) {
+                        DWORD sz = MAX_PATH;
+                        QueryFullProcessImageNameW(hProc, 0, procPath, &sz);
+                        CloseHandle(hProc);
+                    }
+
+                    std::wstring procName = procPath;
+                    auto slash = procName.rfind(L'\\');
+                    if (slash != std::wstring::npos) procName = procName.substr(slash + 1);
+
+                    auto dot = procName.rfind(L'.');
+                    if (dot != std::wstring::npos) procName = procName.substr(0, dot);
+
+                    const std::wstring& aumid = *fd2->aumid;
+                    std::wstring aumidLower = aumid;
+                    std::wstring procLower = procName;
+                    for (auto& c : aumidLower) c = towlower(c);
+                    for (auto& c : procLower) c = towlower(c);
+
+                    if (aumidLower.find(procLower) != std::wstring::npos ||
+                        procLower.find(aumidLower) != std::wstring::npos) {
+                        fd2->hwnd = hWnd;
+                        return FALSE;
+                    }
+                    return TRUE;
+                }, reinterpret_cast<LPARAM>(&fd));
+
+                foundWindow = fd.hwnd;
+
+                if (foundWindow) {
+                    if (IsIconic(foundWindow)) {
+                        ShowWindow(foundWindow, SW_RESTORE);
+                    }
+
+                    DWORD currentThreadId = GetCurrentThreadId();
+                    DWORD windowThreadId = GetWindowThreadProcessId(foundWindow, nullptr);
+
+                    if (currentThreadId != windowThreadId) {
+                        AttachThreadInput(currentThreadId, windowThreadId, TRUE);
+                        BringWindowToTop(foundWindow);
+                        ShowWindow(foundWindow, SW_SHOW);
+                        AttachThreadInput(currentThreadId, windowThreadId, FALSE);
+                    }
+
+                    SetForegroundWindow(foundWindow);
+                    SetFocus(foundWindow);
+                } else {
+                    std::wstring appLower = app;
+                    for (auto& c : appLower) c = towlower(c);
+
+                    bool isUnsupported = (appLower.find(L"windows.") == 0 ||
+                                         appLower.find(L"microsoft.windows.") == 0 ||
+                                         appLower.find(L"systemsettings") != std::wstring::npos);
+
+                    if (!isUnsupported) {
+                        std::wstring shellPath = L"shell:AppsFolder\\" + app;
+                        ShellExecuteW(nullptr, L"open", shellPath.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+                    }
+                }
+            }
+        }).detach();
+    }
+}
+
+static std::wstring ToLowerCopy(std::wstring value) {
+    for (auto& c : value) c = towlower(c);
+    return value;
+}
+
+static std::wstring PathFileStem(std::wstring path) {
+    auto slash = path.find_last_of(L"\\/");
+    if (slash != std::wstring::npos) path = path.substr(slash + 1);
+    auto dot = path.rfind(L'.');
+    if (dot != std::wstring::npos) path = path.substr(0, dot);
+    return path;
+}
+
+static std::wstring TrimCopy(std::wstring value) {
+    const wchar_t* ws = L" \t\r\n";
+    size_t first = value.find_first_not_of(ws);
+    if (first == std::wstring::npos) return L"";
+    size_t last = value.find_last_not_of(ws);
+    return value.substr(first, last - first + 1);
+}
+
+static bool IsIgnoredMediaApp(const std::wstring& appUserModelId) {
+    if (g_settings.ignoredProcesses.empty() || appUserModelId.empty()) return false;
+
+    std::wstring appLower = ToLowerCopy(appUserModelId);
+    std::wstring appStemLower = ToLowerCopy(PathFileStem(appUserModelId));
+    size_t start = 0;
+    while (start <= g_settings.ignoredProcesses.size()) {
+        size_t end = g_settings.ignoredProcesses.find(L';', start);
+        std::wstring item = TrimCopy(g_settings.ignoredProcesses.substr(
+            start, end == std::wstring::npos ? std::wstring::npos : end - start));
+        if (!item.empty()) {
+            std::wstring itemLower = ToLowerCopy(item);
+            std::wstring itemStemLower = ToLowerCopy(PathFileStem(item));
+            if (appLower == itemLower ||
+                appStemLower == itemStemLower ||
+                appLower.find(itemLower) != std::wstring::npos ||
+                appLower.find(itemStemLower) != std::wstring::npos) {
+                return true;
+            }
+        }
+        if (end == std::wstring::npos) break;
+        start = end + 1;
+    }
+    return false;
+}
+
+static std::wstring GetWindowAppUserModelId(HWND hWnd) {
+    static const PROPERTYKEY kAppUserModelIdKey = {
+        {0x9F4C2855, 0x9F79, 0x4B39, {0xA8, 0xD0, 0xE1, 0xD4, 0x2D, 0xE1, 0xD5, 0xF3}},
+        5
+    };
+    std::wstring result;
+    IPropertyStore* store = nullptr;
+    if (SUCCEEDED(SHGetPropertyStoreForWindow(hWnd, IID_PPV_ARGS(&store))) && store) {
+        PROPVARIANT pv;
+        PropVariantInit(&pv);
+        if (SUCCEEDED(store->GetValue(kAppUserModelIdKey, &pv)) && pv.vt == VT_LPWSTR && pv.pwszVal) {
+            result = pv.pwszVal;
+        }
+        PropVariantClear(&pv);
+        store->Release();
+    }
+    return result;
+}
+
+static bool AppIdMatchesProcess(const std::wstring& appUserModelId, HWND hWnd, DWORD* outPid = nullptr, std::wstring* outProcPath = nullptr) {
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hWnd, &pid);
+    if (outPid) *outPid = pid;
+    if (!pid) return false;
+
+    std::wstring windowAumid = GetWindowAppUserModelId(hWnd);
+    std::wstring appLower = ToLowerCopy(appUserModelId);
+    std::wstring windowAumidLower = ToLowerCopy(windowAumid);
+
+    if (!windowAumidLower.empty() &&
+        (appLower == windowAumidLower ||
+         appLower.find(windowAumidLower) != std::wstring::npos ||
+         windowAumidLower.find(appLower) != std::wstring::npos)) {
+        return true;
+    }
+
+    wchar_t procPath[MAX_PATH] = {};
+    HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (hProc) {
+        DWORD sz = MAX_PATH;
+        QueryFullProcessImageNameW(hProc, 0, procPath, &sz);
+        CloseHandle(hProc);
+    }
+    if (outProcPath) *outProcPath = procPath;
+
+    std::wstring procLower = ToLowerCopy(PathFileStem(procPath));
+    if (procLower.empty()) return false;
+
+    std::wstring appStemLower = ToLowerCopy(PathFileStem(appUserModelId));
+    return appLower.find(procLower) != std::wstring::npos ||
+           procLower.find(appLower) != std::wstring::npos ||
+           appStemLower.find(procLower) != std::wstring::npos ||
+           procLower.find(appStemLower) != std::wstring::npos ||
+           (!windowAumidLower.empty() &&
+            (windowAumidLower.find(procLower) != std::wstring::npos ||
+             procLower.find(windowAumidLower) != std::wstring::npos));
+}
+
+static std::vector<BYTE> FetchAppIconBytes(const std::wstring& appUserModelId, int iconSize) {
+    std::vector<BYTE> result;
+    if (appUserModelId.empty()) return result;
+
+    HICON hIcon = nullptr;
+
+    struct FindData { const std::wstring* aumid; HICON icon; DWORD pid; std::wstring procPath; };
+    FindData fd{&appUserModelId, nullptr, 0, L""};
+
+    EnumWindows([](HWND hWnd, LPARAM lParam) -> BOOL {
+        auto* fd2 = reinterpret_cast<FindData*>(lParam);
+        if (!IsWindowVisible(hWnd)) return TRUE;
+
+        DWORD pid = 0;
+        std::wstring procPath;
+        if (!AppIdMatchesProcess(*fd2->aumid, hWnd, &pid, &procPath))
+            return TRUE;
+
+        if (!fd2->pid) {
+            fd2->pid = pid;
+            fd2->procPath = procPath;
+        }
+
+        HICON icon = (HICON)GetClassLongPtrW(hWnd, GCLP_HICONSM);
+        if (!icon) icon = (HICON)GetClassLongPtrW(hWnd, GCLP_HICON);
+        if (!icon) icon = (HICON)SendMessageW(hWnd, WM_GETICON, ICON_SMALL, 0);
+        if (!icon) icon = (HICON)SendMessageW(hWnd, WM_GETICON, ICON_BIG,   0);
+
+        if (icon) {
+            fd2->icon = icon;
+            fd2->pid  = pid;
+            fd2->procPath = procPath;
+            return FALSE;
+        }
+        return TRUE;
+    }, reinterpret_cast<LPARAM>(&fd));
+
+    hIcon = fd.icon;
+
+    if (!hIcon && fd.pid) {
+        if (fd.procPath.empty()) {
+            wchar_t procPath[MAX_PATH] = {};
+            HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, fd.pid);
+            if (hProc) {
+                DWORD sz = MAX_PATH;
+                QueryFullProcessImageNameW(hProc, 0, procPath, &sz);
+                CloseHandle(hProc);
+            }
+            fd.procPath = procPath;
+        }
+        if (!fd.procPath.empty()) {
+            SHFILEINFOW sfi{};
+            if (SHGetFileInfoW(fd.procPath.c_str(), 0, &sfi, sizeof(sfi), SHGFI_ICON | SHGFI_SMALLICON))
+                hIcon = sfi.hIcon;
+        }
+    }
+
+    if (!hIcon && appUserModelId.find(L".exe") != std::wstring::npos) {
+        std::wstring exePath = appUserModelId;
+        if (exePath.size() >= 2 && exePath.front() == L'"' && exePath.back() == L'"')
+            exePath = exePath.substr(1, exePath.size() - 2);
+        SHFILEINFOW sfi{};
+        if (SHGetFileInfoW(exePath.c_str(), 0, &sfi, sizeof(sfi), SHGFI_ICON | SHGFI_SMALLICON))
+            hIcon = sfi.hIcon;
+    }
+
+    if (!hIcon) return result;
+
+    ICONINFO ii{};
+    if (!GetIconInfo(hIcon, &ii)) return result;
+
+    BITMAP bm{};
+    GetObjectW(ii.hbmColor ? ii.hbmColor : ii.hbmMask, sizeof(bm), &bm);
+
+    int w = bm.bmWidth  ? bm.bmWidth  : iconSize;
+    int h = bm.bmHeight ? bm.bmHeight : iconSize;
+
+    HDC hdc = CreateCompatibleDC(nullptr);
+    BITMAPINFO bi{};
+    bi.bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
+    bi.bmiHeader.biWidth       = w;
+    bi.bmiHeader.biHeight      = -h;
+    bi.bmiHeader.biPlanes      = 1;
+    bi.bmiHeader.biBitCount    = 32;
+    bi.bmiHeader.biCompression = BI_RGB;
+
+    std::vector<BYTE> pixels(w * h * 4, 0);
+    HBITMAP hBmp = CreateCompatibleBitmap(GetDC(nullptr), w, h);
+    HBITMAP hOld = (HBITMAP)SelectObject(hdc, hBmp);
+    DrawIconEx(hdc, 0, 0, hIcon, w, h, 0, nullptr, DI_NORMAL);
+    GetDIBits(hdc, hBmp, 0, h, pixels.data(), &bi, DIB_RGB_COLORS);
+    SelectObject(hdc, hOld);
+    DeleteObject(hBmp);
+    DeleteDC(hdc);
+
+    if (ii.hbmColor) DeleteObject(ii.hbmColor);
+    if (ii.hbmMask)  DeleteObject(ii.hbmMask);
+
+    for (int i = 0; i + 3 < (int)pixels.size(); i += 4) {
+        std::swap(pixels[i], pixels[i + 2]);
+    }
+
+    if (w != iconSize || h != iconSize) {
+        std::vector<BYTE> scaled(iconSize * iconSize * 4, 0);
+        for (int dy = 0; dy < iconSize; ++dy) {
+            for (int dx = 0; dx < iconSize; ++dx) {
+                int sx = dx * w / iconSize;
+                int sy = dy * h / iconSize;
+                int si = (sy * w + sx) * 4;
+                int di = (dy * iconSize + dx) * 4;
+                scaled[di+0] = pixels[si+0];
+                scaled[di+1] = pixels[si+1];
+                scaled[di+2] = pixels[si+2];
+                scaled[di+3] = pixels[si+3];
+            }
+        }
+        result = std::move(scaled);
+    } else {
+        result = std::move(pixels);
+    }
+
+    return result;
+}
+
+static void FetchMediaPropertiesAsync() {
+    Wh_Log(L"FetchMediaPropertiesAsync: Called");
+    std::thread([]() {
+        if (g_unloading) return;
+        winrt::init_apartment(winrt::apartment_type::multi_threaded);
+        try {
+            GlobalSystemMediaTransportControlsSession session{nullptr};
+            std::wstring aumid;
+            {
+                std::lock_guard<std::mutex> lk(g_sessionMtx);
+                session = g_currentSession;
+                if (session) {
+                    try {
+                        aumid = std::wstring(session.SourceAppUserModelId());
+                    } catch (...) {
+                        winrt::uninit_apartment();
+                        return;
+                    }
+                }
+            }
+            if (!session) {
+                winrt::uninit_apartment();
+                return;
+            }
+
+            try {
+                auto props = session.TryGetMediaPropertiesAsync().get();
+                if (!props) {
+                    winrt::uninit_apartment();
+                    return;
+                }
+
+                std::vector<BYTE> thumbBytes;
+                uint64_t          thumbHash = 0;
+
+                if (auto thumbRef = props.Thumbnail()) {
+                    try {
+                        auto stream = thumbRef.OpenReadAsync().get();
+                        if (stream) {
+                            UINT64 sz = stream.Size();
+                            if (sz > 0 && sz < 4 * 1024 * 1024) {
+                                DataReader reader(stream);
+                                reader.LoadAsync((UINT32)sz).get();
+                                thumbBytes.resize((size_t)sz);
+                                reader.ReadBytes(winrt::array_view<BYTE>(thumbBytes));
+                                reader.DetachStream();
+                                for (size_t i = 0; i < thumbBytes.size(); i += 1024)
+                                    thumbHash = thumbHash * 31 + thumbBytes[i];
+                            }
+                        }
+                    } catch (...) { thumbBytes.clear(); }
+                }
+
+                std::vector<BYTE> appIconBytes;
+                std::wstring      appIconKey;
+                {
+                    std::lock_guard<std::mutex> lk(g_mediaMtx);
+                    appIconKey = g_media.appIconKey;
+                    appIconBytes = g_media.appIconBytes;
+                }
+                if (g_settings.showAppIcon && (aumid != appIconKey || appIconBytes.empty())) {
+                    try {
+                        appIconBytes = FetchAppIconBytes(aumid, g_settings.appIconSize);
+                        appIconKey   = aumid;
+                        g_cachedAppIconSize = g_settings.appIconSize;
+                    } catch (...) {
+
+                    }
+                }
+
+                {
+                    std::lock_guard<std::mutex> lk(g_mediaMtx);
+                    try {
+                        g_media.title          = std::wstring(props.Title());
+                        g_media.artist         = std::wstring(props.Artist());
+                        g_media.hasMedia       = !g_media.title.empty() || !g_media.artist.empty();
+                        g_media.thumbnailBytes = std::move(thumbBytes);
+                        g_media.thumbnailHash  = thumbHash;
+                        g_media.appUserModelId = aumid;
+                        if (g_settings.showAppIcon) {
+                            g_media.appIconBytes   = std::move(appIconBytes);
+                            g_media.appIconKey     = appIconKey;
+                        }
+                        Wh_Log(L"FetchMediaPropertiesAsync: Set hasMedia=%d (title='%s', artist='%s')",
+                               g_media.hasMedia, g_media.title.c_str(), g_media.artist.c_str());
+                    } catch (...) {
+
+                    }
+                }
+            } catch (...) {
+
+            }
+        } catch (...) {}
+        Wh_Log(L"FetchMediaPropertiesAsync: About to call DispatchMediaUpdate");
+        DispatchMediaUpdate();
+        winrt::uninit_apartment();
+    }).detach();
+}
+
+static void FetchPlaybackInfoAsync() {
+    Wh_Log(L"FetchPlaybackInfoAsync: Called");
+    std::thread([]() {
+        if (g_unloading) return;
+        winrt::init_apartment(winrt::apartment_type::multi_threaded);
+        try {
+            GlobalSystemMediaTransportControlsSession session{nullptr};
+            { std::lock_guard<std::mutex> lk(g_sessionMtx); session = g_currentSession; }
+            if (session) {
+                try {
+                    auto info = session.GetPlaybackInfo();
+                    if (!info) {
+                        winrt::uninit_apartment();
+                        return;
+                    }
+
+                    auto status = info.PlaybackStatus();
+                    bool playing = (status == GlobalSystemMediaTransportControlsSessionPlaybackStatus::Playing);
+                    bool wasPlaying = false;
+                    {
+                        std::lock_guard<std::mutex> lk(g_mediaMtx);
+                        wasPlaying = g_media.isPlaying;
+                        g_media.isPlaying = playing;
+                    }
+
+                    if (playing != wasPlaying) {
+                        Wh_Log(L"Playback state changed: %s -> %s",
+                            wasPlaying ? L"Playing" : L"Not Playing",
+                            playing ? L"Playing" : L"Not Playing");
+                    }
+
+                    try {
+                        auto shuffleRef = info.IsShuffleActive();
+                        if (shuffleRef) {
+                            g_shuffleEnabled = shuffleRef.Value();
+                        }
+                    } catch (...) {}
+
+                    try {
+                        auto repeatRef = info.AutoRepeatMode();
+                        if (repeatRef) {
+                            using RM = winrt::Windows::Media::MediaPlaybackAutoRepeatMode;
+                            auto v = repeatRef.Value();
+                            if (v == RM::Track) g_repeatMode = RepeatMode::One;
+                            else if (v == RM::List) g_repeatMode = RepeatMode::All;
+                            else g_repeatMode = RepeatMode::Off;
+                        }
+                    } catch (...) {}
+
+                    try {
+                        auto controls = info.Controls();
+                        g_capCanShuffle  = controls.IsShuffleEnabled();
+                        g_capCanRepeat   = controls.IsRepeatEnabled();
+                        g_capCanSkipPrev = controls.IsPreviousEnabled();
+                        g_capCanSkipNext = controls.IsNextEnabled();
+                        g_capCanSeek     = controls.IsPlaybackPositionEnabled();
+                    } catch (...) {
+                        g_capCanShuffle  = true;
+                        g_capCanRepeat   = true;
+                        g_capCanSkipPrev = true;
+                        g_capCanSkipNext = true;
+                        g_capCanSeek     = true;
+                    }
+                } catch (...) {
+
+                }
+            }
+        } catch (...) {}
+        Wh_Log(L"FetchPlaybackInfoAsync: About to call DispatchMediaUpdate");
+        DispatchMediaUpdate();
+        winrt::uninit_apartment();
+    }).detach();
+}
+
+static void DetachCurrentSession() {
+    std::lock_guard<std::mutex> lk(g_sessionMtx);
+    if (!g_currentSession) return;
+    try {
+        if (g_evMediaProps.value) {
+            g_currentSession.MediaPropertiesChanged(g_evMediaProps);
+            g_evMediaProps = {};
+        }
+    } catch (...) {
+        Wh_Log(L"DetachCurrentSession: Failed to unregister MediaPropertiesChanged");
+    }
+    try {
+        if (g_evPlayback.value) {
+            g_currentSession.PlaybackInfoChanged(g_evPlayback);
+            g_evPlayback = {};
+        }
+    } catch (...) {
+        Wh_Log(L"DetachCurrentSession: Failed to unregister PlaybackInfoChanged");
+    }
+    try {
+        g_currentSession = nullptr;
+    } catch (...) {
+        Wh_Log(L"DetachCurrentSession: Exception clearing current session");
+    }
+}
+
+static GlobalSystemMediaTransportControlsSession PickBestSession() {
+    if (!g_sessionMgr) return nullptr;
+    try {
+        auto sessions = g_sessionMgr.GetSessions();
+        int sessionCount = sessions.Size();
+        Wh_Log(L"PickBestSession: Found %d media sessions", sessionCount);
+
+        GlobalSystemMediaTransportControlsSession best{nullptr};
+        int index = 0;
+        for (auto const& s : sessions) {
+            try {
+                std::wstring appId = s.SourceAppUserModelId().c_str();
+                if (IsIgnoredMediaApp(appId)) {
+                    Wh_Log(L"PickBestSession: Session %d (%s) is ignored", index, appId.c_str());
+                    index++;
+                    continue;
+                }
+
+                auto pb = s.GetPlaybackInfo();
+                if (!pb) {
+                    Wh_Log(L"PickBestSession: Session %d (%s) has no playback info", index, appId.c_str());
+                    index++;
+                    continue;
+                }
+
+                auto status = pb.PlaybackStatus();
+                const wchar_t* statusStr = L"Unknown";
+                if (status == GlobalSystemMediaTransportControlsSessionPlaybackStatus::Playing) statusStr = L"Playing";
+                else if (status == GlobalSystemMediaTransportControlsSessionPlaybackStatus::Paused) statusStr = L"Paused";
+                else if (status == GlobalSystemMediaTransportControlsSessionPlaybackStatus::Stopped) statusStr = L"Stopped";
+
+                Wh_Log(L"PickBestSession: Session %d (%s) status: %s", index, appId.c_str(), statusStr);
+
+                if (status == GlobalSystemMediaTransportControlsSessionPlaybackStatus::Playing) {
+                    Wh_Log(L"PickBestSession: Selected playing session %d (%s)", index, appId.c_str());
+                    return s;
+                }
+                if (!best) best = s;
+            } catch (...) {
+                Wh_Log(L"PickBestSession: Exception processing session %d", index);
+            }
+            index++;
+        }
+
+        if (best) {
+            try {
+                std::wstring appId = best.SourceAppUserModelId().c_str();
+                Wh_Log(L"PickBestSession: No playing session, selected first available (%s)", appId.c_str());
+            } catch (...) {
+                Wh_Log(L"PickBestSession: No playing session, selected first available (app ID unavailable)");
+            }
+        } else {
+            Wh_Log(L"PickBestSession: No suitable session found");
+        }
+
+        return best;
+    } catch (...) {
+        Wh_Log(L"PickBestSession: Exception occurred");
+        return nullptr;
+    }
+}
+
+static void AttachToSession(GlobalSystemMediaTransportControlsSession session) {
+    if (!session) {
+        Wh_Log(L"AttachToSession: No session provided, detaching current session");
+        DetachCurrentSession();
+        {
+            std::lock_guard<std::mutex> lk(g_mediaMtx);
+            g_media = MediaState{};
+            Wh_Log(L"AttachToSession: Cleared media state (hasMedia=false)");
+        }
+        g_capCanShuffle  = false;
+        g_capCanRepeat   = false;
+        g_capCanSkipPrev = false;
+        g_capCanSkipNext = false;
+        g_capCanSeek     = false;
+        DispatchMediaUpdate();
+        return;
+    }
+
+    bool needsReattach = false;
+    {
+        std::lock_guard<std::mutex> lk(g_sessionMtx);
+        if (g_currentSession == session) {
+            if (!g_evMediaProps.value || !g_evPlayback.value) {
+                Wh_Log(L"AttachToSession: Same session but events not attached, reattaching");
+                needsReattach = true;
+            } else {
+                Wh_Log(L"AttachToSession: Same session already attached, fetching data");
+                goto fetch;
+            }
+        }
+    }
+
+    try {
+        std::wstring appId = session.SourceAppUserModelId().c_str();
+        Wh_Log(L"AttachToSession: Attaching to new session from app: %s", appId.c_str());
+    } catch (...) {
+        Wh_Log(L"AttachToSession: Attaching to new session (app ID unavailable)");
+    }
+
+    if (needsReattach) {
+        DetachCurrentSession();
+    } else {
+        DetachCurrentSession();
+    }
+
+    {
+        std::lock_guard<std::mutex> lk(g_sessionMtx);
+        g_currentSession = session;
+        try {
+            g_evMediaProps = g_currentSession.MediaPropertiesChanged([](auto const&, auto const&) {
+                Wh_Log(L"MediaPropertiesChanged event fired");
+                if (!g_unloading) FetchMediaPropertiesAsync();
+            });
+            g_evPlayback = g_currentSession.PlaybackInfoChanged([](auto const&, auto const&) {
+                Wh_Log(L"PlaybackInfoChanged event fired");
+                if (!g_unloading) FetchPlaybackInfoAsync();
+            });
+            Wh_Log(L"AttachToSession: Event handlers attached successfully");
+        } catch (...) {
+            Wh_Log(L"AttachToSession: Failed to attach event handlers");
+            g_currentSession = nullptr;
+            return;
+        }
+    }
+fetch:
+    FetchMediaPropertiesAsync();
+    FetchPlaybackInfoAsync();
+}
+
+static void OnSessionsChanged() {
+    if (g_unloading) return;
+    bool userSwitched = false;
+    bool forceRefresh = g_forceSessionRefresh.exchange(false);
+    {
+        std::lock_guard<std::mutex> lk(g_sessionMtx);
+        userSwitched = g_userSwitchedSession;
+    }
+
+    Wh_Log(L"OnSessionsChanged: userSwitched=%d, forceRefresh=%d", userSwitched, forceRefresh);
+
+    if (forceRefresh || !userSwitched) {
+        try {
+            auto newSession = PickBestSession();
+            if (newSession) {
+                try {
+                    auto pb = newSession.GetPlaybackInfo();
+                    if (pb && pb.PlaybackStatus() == GlobalSystemMediaTransportControlsSessionPlaybackStatus::Playing) {
+                        Wh_Log(L"OnSessionsChanged: Found actively playing session, resetting user switch flag");
+                        std::lock_guard<std::mutex> lk(g_sessionMtx);
+                        g_userSwitchedSession = false;
+                    }
+                } catch (...) {}
+            } else {
+                Wh_Log(L"OnSessionsChanged: No session found, resetting user switch flag");
+                std::lock_guard<std::mutex> lk(g_sessionMtx);
+                g_userSwitchedSession = false;
+            }
+            AttachToSession(newSession);
+        } catch (...) {
+            Wh_Log(L"OnSessionsChanged: Exception occurred");
+        }
+    } else {
+        Wh_Log(L"OnSessionsChanged: Skipping due to user switch - checking if current session still exists");
+        try {
+            bool currentSessionExists = false;
+            GlobalSystemMediaTransportControlsSession currentSession{nullptr};
+            {
+                std::lock_guard<std::mutex> lk(g_sessionMtx);
+                currentSession = g_currentSession;
+            }
+
+            if (currentSession) {
+                auto sessions = g_sessionMgr.GetSessions();
+                for (auto const& s : sessions) {
+                    if (s == currentSession) {
+                        currentSessionExists = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!currentSessionExists) {
+                Wh_Log(L"OnSessionsChanged: Current session no longer exists, resetting user switch flag and picking new session");
+                {
+                    std::lock_guard<std::mutex> lk(g_sessionMtx);
+                    g_userSwitchedSession = false;
+                }
+                auto newSession = PickBestSession();
+                AttachToSession(newSession);
+            } else {
+                Wh_Log(L"OnSessionsChanged: Current session still exists, keeping it");
+            }
+        } catch (...) {
+            Wh_Log(L"OnSessionsChanged: Exception checking current session validity");
+        }
+    }
+}
+
+static DWORD WINAPI MediaThreadProc(void*) {
+    Wh_Log(L"MediaThreadProc: Starting media thread");
+    try {
+        winrt::init_apartment(winrt::apartment_type::multi_threaded);
+        Wh_Log(L"MediaThreadProc: Requesting session manager");
+        auto op = GlobalSystemMediaTransportControlsSessionManager::RequestAsync();
+        while (op.Status() == winrt::Windows::Foundation::AsyncStatus::Started) {
+            if (WaitForSingleObject(g_mediaStopEvent, 50) == WAIT_OBJECT_0) goto done;
+        }
+        g_sessionMgr = op.GetResults();
+        Wh_Log(L"MediaThreadProc: Session manager obtained");
+
+        g_evSessionsChanged = g_sessionMgr.SessionsChanged([](auto const&, auto const&) {
+            Wh_Log(L"MediaThreadProc: SessionsChanged event fired");
+            OnSessionsChanged();
+        });
+        g_evCurrentChanged  = g_sessionMgr.CurrentSessionChanged([](auto const&, auto const&) {
+            Wh_Log(L"MediaThreadProc: CurrentSessionChanged event fired");
+            OnSessionsChanged();
+        });
+
+        Wh_Log(L"MediaThreadProc: Initial session check");
+        OnSessionsChanged();
+
+        Wh_Log(L"MediaThreadProc: Waiting 2 seconds before retry check");
+        if (WaitForSingleObject(g_mediaStopEvent, 2000) == WAIT_TIMEOUT) {
+            if (!g_unloading) {
+                Wh_Log(L"MediaThreadProc: Performing retry session check");
+                g_forceSessionRefresh = true;
+                OnSessionsChanged();
+            }
+        }
+
+        Wh_Log(L"MediaThreadProc: Entering wait loop");
+        WaitForSingleObject(g_mediaStopEvent, INFINITE);
+
+        Wh_Log(L"MediaThreadProc: Shutting down");
+        try {
+            if (g_evSessionsChanged.value) {
+                g_sessionMgr.SessionsChanged(g_evSessionsChanged);
+                g_evSessionsChanged = {};
+            }
+        } catch (...) {
+            Wh_Log(L"MediaThreadProc: Failed to unregister SessionsChanged event");
+        }
+        try {
+            if (g_evCurrentChanged.value) {
+                g_sessionMgr.CurrentSessionChanged(g_evCurrentChanged);
+                g_evCurrentChanged = {};
+            }
+        } catch (...) {
+            Wh_Log(L"MediaThreadProc: Failed to unregister CurrentSessionChanged event");
+        }
+        DetachCurrentSession();
+        try {
+            g_sessionMgr = nullptr;
+        } catch (...) {
+            Wh_Log(L"MediaThreadProc: Exception clearing session manager");
+        }
+    done:
+        try {
+            winrt::uninit_apartment();
+        } catch (...) {
+            Wh_Log(L"MediaThreadProc: Exception uninitializing apartment");
+        }
+        Wh_Log(L"MediaThreadProc: Media thread ended");
+    } catch (...) {
+        Wh_Log(L"MediaThreadProc: Exception in media thread");
+    }
+    return 0;
+}
+
+static void StartMediaThread() {
+    if (g_mediaThread) return;
+    g_mediaStopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (!g_mediaStopEvent) return;
+    g_mediaThread = CreateThread(nullptr, 0, MediaThreadProc, nullptr, 0, nullptr);
+    if (!g_mediaThread) { CloseHandle(g_mediaStopEvent); g_mediaStopEvent = nullptr; }
+}
+static void StopMediaThread() {
+    Wh_Log(L"StopMediaThread: Starting");
+    if (g_mediaStopEvent) {
+        SetEvent(g_mediaStopEvent);
+        Wh_Log(L"StopMediaThread: Stop event signaled");
+    }
+    if (g_mediaThread) {
+        Wh_Log(L"StopMediaThread: Waiting for media thread to exit");
+        DWORD waitResult = WaitForSingleObject(g_mediaThread, 5000);
+        if (waitResult == WAIT_TIMEOUT) {
+            Wh_Log(L"StopMediaThread: Timeout waiting for media thread, terminating");
+            TerminateThread(g_mediaThread, 1);
+        } else {
+            Wh_Log(L"StopMediaThread: Media thread exited normally");
+        }
+        CloseHandle(g_mediaThread);
+        g_mediaThread = nullptr;
+    }
+    if (g_mediaStopEvent) {
+        CloseHandle(g_mediaStopEvent);
+        g_mediaStopEvent = nullptr;
+    }
+    Wh_Log(L"StopMediaThread: Complete");
+}
+
+static HANDLE g_timerThread    = nullptr;
+static HANDLE g_timerStopEvent = nullptr;
+static HANDLE g_timerUpdateEvent = nullptr;
+
+static void DispatchMediaUpdate() {
+    bool unloading = g_unloading;
+    bool applyingSettings = g_applyingSettings;
+    bool hasPlayerGrid = (g_playerGrid != nullptr);
+
+    if (unloading || applyingSettings || !g_playerGrid) {
+        Wh_Log(L"DispatchMediaUpdate: Skipped (unloading=%d, applyingSettings=%d, playerGrid=%d)",
+               unloading, applyingSettings, hasPlayerGrid);
+        return;
+    }
+
+    Wh_Log(L"DispatchMediaUpdate: Called");
+
+    try {
+        auto dispatcher = g_playerGrid.Dispatcher();
+        if (!dispatcher) {
+            Wh_Log(L"DispatchMediaUpdate: No dispatcher");
+            g_playerGrid = nullptr;
+            g_injectionParent = nullptr;
+            if (g_taskbarWnd) {
+                StopRetryThread();
+                StartRetryThread();
+            }
+            return;
+        }
+    } catch (...) {
+        Wh_Log(L"DispatchMediaUpdate: Exception getting dispatcher");
+        g_playerGrid = nullptr;
+        g_injectionParent = nullptr;
+        if (g_taskbarWnd) {
+            StopRetryThread();
+            StartRetryThread();
+        }
+        return;
+    }
+
+    g_needsUiUpdate = true;
+    if (g_timerUpdateEvent) {
+        SetEvent(g_timerUpdateEvent);
+        Wh_Log(L"DispatchMediaUpdate: Signaled timer update event");
+    }
+}
+
+static void RefreshPlayerContents();
+static void UpdateVisibility();
+
+static DWORD WINAPI TimerThreadProc(void*) {
+    static bool lastThemeWasLight = IsSystemLightTheme();
+
+    HKEY hKey = nullptr;
+    HANDLE hEvent = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", 0, KEY_NOTIFY, &hKey) == ERROR_SUCCESS) {
+        RegNotifyChangeKeyValue(hKey, FALSE, REG_NOTIFY_CHANGE_LAST_SET, hEvent, TRUE);
+    }
+
+    while (!g_unloading) {
+        HANDLE handles[] = {g_timerStopEvent, hEvent, g_timerUpdateEvent};
+        DWORD wait = WaitForMultipleObjects(3, handles, FALSE, 500);
+
+        if (wait == WAIT_OBJECT_0) break;
+        if (g_applyingSettings) continue;
+
+        HWND hWnd = g_taskbarWnd;
+        if (!hWnd || !IsWindow(hWnd)) {
+            hWnd = FindCurrentProcessTaskbarWnd();
+            g_taskbarWnd = hWnd;
+            if (!hWnd) continue;
+        }
+
+        if (wait == WAIT_OBJECT_0 + 1) {
+            if (g_settings.autoTheme) {
+                bool currentThemeIsLight = IsSystemLightTheme();
+                if (currentThemeIsLight != lastThemeWasLight) {
+                    lastThemeWasLight = currentThemeIsLight;
+                    g_needsUiUpdate = true;
+                }
+            }
+            if (hKey) {
+                RegNotifyChangeKeyValue(hKey, FALSE, REG_NOTIFY_CHANGE_LAST_SET, hEvent, TRUE);
+            }
+        }
+
+        bool needsUpdate = g_needsUiUpdate.exchange(false);
+        if (needsUpdate) {
+            RunFromWindowThread(hWnd, [](void*) {
+                if (!g_unloading && !g_applyingSettings && g_playerGrid) {
+                    RefreshPlayerContents();
+                    UpdateVisibility();
+                }
+            }, nullptr);
+        }
+    }
+
+    if (hKey) RegCloseKey(hKey);
+    if (hEvent) CloseHandle(hEvent);
+    return 0;
+}
+
+static void StartTimerThread() {
+    if (g_timerThread) return;
+    g_timerStopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    g_timerUpdateEvent = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+    g_timerThread    = CreateThread(nullptr, 0, TimerThreadProc, nullptr, 0, nullptr);
+    if (!g_timerThread) {
+        CloseHandle(g_timerStopEvent);
+        g_timerStopEvent = nullptr;
+        CloseHandle(g_timerUpdateEvent);
+        g_timerUpdateEvent = nullptr;
+    }
+}
+static void StopTimerThread() {
+    if (g_timerStopEvent) SetEvent(g_timerStopEvent);
+    if (g_timerThread) { WaitForSingleObject(g_timerThread, 2000); CloseHandle(g_timerThread); g_timerThread = nullptr; }
+    if (g_timerStopEvent) { CloseHandle(g_timerStopEvent); g_timerStopEvent = nullptr; }
+    if (g_timerUpdateEvent) { CloseHandle(g_timerUpdateEvent); g_timerUpdateEvent = nullptr; }
+}
+
+static HANDLE g_idleThread    = nullptr;
+static HANDLE g_idleStopEvent = nullptr;
+
+static DWORD WINAPI IdleThreadProc(void*) {
+    while (!g_unloading) {
+        if (WaitForSingleObject(g_idleStopEvent, 1000) == WAIT_OBJECT_0) break;
+        if (g_taskbarWnd) PostMessageW(g_taskbarWnd, WM_APP + 44, 0, 0);
+    }
+    return 0;
+}
+
+static void StartIdleTimer() {
+    if (g_idleThread) return;
+    g_idleStopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    g_idleThread    = CreateThread(nullptr, 0, IdleThreadProc, nullptr, 0, nullptr);
+}
+
+static void StopIdleTimer() {
+    if (g_idleStopEvent) SetEvent(g_idleStopEvent);
+    if (g_idleThread) { WaitForSingleObject(g_idleThread, 2000); CloseHandle(g_idleThread); g_idleThread = nullptr; }
+    if (g_idleStopEvent) { CloseHandle(g_idleStopEvent); g_idleStopEvent = nullptr; }
+}
+
+static void RefreshThemeColors();
+
+static LRESULT CALLBACK ThemeWatchWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    if (msg == WM_SETTINGCHANGE) {
+        const wchar_t* section = reinterpret_cast<const wchar_t*>(lParam);
+        if (section && wcscmp(section, L"ImmersiveColorSet") == 0) {
+            if (g_taskbarWnd) {
+                RunFromWindowThread(g_taskbarWnd, [](void*) {
+                    if (!g_unloading && !g_applyingSettings && g_playerGrid)
+                        RefreshThemeColors();
+                }, nullptr);
+            }
+        }
+    }
+    return DefWindowProcW(hWnd, msg, wParam, lParam);
+}
+
+static DWORD WINAPI ThemeWatchThreadProc(void*) {
+    WNDCLASSEXW wc{};
+    wc.cbSize        = sizeof(wc);
+    wc.lpfnWndProc   = ThemeWatchWndProc;
+    wc.hInstance     = GetModuleHandleW(nullptr);
+    wc.lpszClassName = L"Windhawk_FMP_ThemeWatch";
+    RegisterClassExW(&wc);
+
+    g_themeWatchWnd = CreateWindowExW(0, L"Windhawk_FMP_ThemeWatch", nullptr, 0,
+        0, 0, 0, 0, HWND_MESSAGE, nullptr, GetModuleHandleW(nullptr), nullptr);
+    if (!g_themeWatchWnd) return 1;
+
+    MSG msg{};
+    while (!g_unloading) {
+        if (WaitForSingleObject(g_themeWatchStop, 0) == WAIT_OBJECT_0) break;
+        while (PeekMessageW(&msg, g_themeWatchWnd, 0, 0, PM_REMOVE)) {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+        Sleep(50);
+    }
+
+    DestroyWindow(g_themeWatchWnd);
+    g_themeWatchWnd = nullptr;
+    UnregisterClassW(L"Windhawk_FMP_ThemeWatch", GetModuleHandleW(nullptr));
+    return 0;
+}
+
+static void StartThemeWatcher() {
+    if (g_themeWatchThread) return;
+    g_themeWatchStop   = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    g_themeWatchThread = CreateThread(nullptr, 0, ThemeWatchThreadProc, nullptr, 0, nullptr);
+}
+
+static void StopThemeWatcher() {
+    if (g_themeWatchStop) SetEvent(g_themeWatchStop);
+    if (g_themeWatchThread) {
+        WaitForSingleObject(g_themeWatchThread, 3000);
+        CloseHandle(g_themeWatchThread);
+        g_themeWatchThread = nullptr;
+    }
+    if (g_themeWatchStop) { CloseHandle(g_themeWatchStop); g_themeWatchStop = nullptr; }
+}
+
+static void RefreshThemeColors() {
+    if (!g_playerGrid || g_unloading || g_applyingSettings) return;
+    try {
+        auto textClr = TextColor();
+        auto artistClr = ArtistColor();
+        auto buttonClr = ButtonColor();
+
+        if (auto bgFe = FindChildByName(g_playerGrid, L"FluentMedia_Background")) {
+            if (auto bgBorder = bgFe.try_as<Border>()) {
+                auto& bgType = g_settings.backgroundType;
+
+                if (bgType == L"album_art_blur") {
+                    if (!g_cachedThumbnailBytes.empty()) {
+                        int w = (int)bgBorder.ActualWidth();
+                        int h = (int)bgBorder.ActualHeight();
+                        if (w > 0 && h > 0) {
+                            bgBorder.Background(MakeAlbumBlurBrush(g_cachedThumbnailBytes, w, h));
+                        }
+                    } else {
+                        auto fallbackCol = IsLightTheme()
+                            ? winrt::Windows::UI::Color{0xCC, 0xF3, 0xF3, 0xF3}
+                            : winrt::Windows::UI::Color{0xCC, 0x20, 0x20, 0x20};
+                        bgBorder.Background(MakeBrush(fallbackCol));
+                    }
+                    bgBorder.Visibility(Visibility::Visible);
+                    bgBorder.Opacity(g_settings.blurOpacity / 100.0);
+                } else if (bgType == L"solid" || bgType == L"gradient" || bgType == L"acrylic" || bgType == L"mica" || bgType == L"mica_alt") {
+                    bgBorder.Background(MakeBackgroundBrush());
+                    bgBorder.Visibility(Visibility::Visible);
+                    bgBorder.Opacity(1.0);
+                } else {
+                    bgBorder.Background(nullptr);
+                    bgBorder.Visibility(Visibility::Collapsed);
+                }
+            }
+        }
+
+        if (auto fe = FindChildByName(g_playerGrid, L"FluentMedia_OuterBorder")) {
+            if (auto btn = fe.try_as<Button>()) {
+                ApplyFluentMediaButtonStyle(btn);
+                auto transparentBg = MakeBrush({0x00, 0, 0, 0});
+                SetupPlayerButtonCommonStates(btn, transparentBg);
+                GoToCommonState(btn, g_settings.enablePlayerHoverEffect, false, false);
+            }
+        }
+
+        if (auto fe = FindChildByName(g_playerGrid, kTitleBlockName))
+            if (auto tb = fe.try_as<TextBlock>()) tb.Foreground(MakeBrush(textClr));
+
+        if (auto fe = FindChildByName(g_playerGrid, kArtistBlockName))
+            if (auto ab = fe.try_as<TextBlock>()) ab.Foreground(MakeBrush(artistClr));
+
+        for (const wchar_t* name : {kPrevBtnName, kPlayBtnName, kNextBtnName, kRewindBtnName, kForwardBtnName, kShuffleBtnName, kRepeatBtnName}) {
+            if (auto fe = FindChildByName(g_playerGrid, name)) {
+                if (auto btn = fe.try_as<Button>()) {
+                    ApplyFluentMediaButtonStyle(btn);
+                    SetupMediaButtonCommonStates(btn);
+                    GoToCommonState(btn, g_settings.enableMediaButtonsHoverEffect, false, false);
+                    if (auto ct = btn.Content().try_as<TextBlock>()) ct.Foreground(MakeBrush(buttonClr));
+                }
+            }
+        }
+    } catch (...) {}
+}
+
+static HWND FindCurrentProcessTaskbarWnd() {
+    HWND result = nullptr;
+    EnumWindows([](HWND hWnd, LPARAM lp) -> BOOL {
+        DWORD pid = 0; wchar_t cls[32] = {};
+        if (GetWindowThreadProcessId(hWnd, &pid) && pid == GetCurrentProcessId() &&
+            GetClassNameW(hWnd, cls, ARRAYSIZE(cls)) &&
+            _wcsicmp(cls, L"Shell_TrayWnd") == 0)
+        {
+            *reinterpret_cast<HWND*>(lp) = hWnd;
+            return FALSE;
+        }
+        return TRUE;
+    }, reinterpret_cast<LPARAM>(&result));
+    return result;
+}
+
+static XamlRoot GetTaskbarXamlRoot(HWND hTaskbarWnd) {
+    try {
+        HWND hTaskSwWnd = (HWND)GetProp(hTaskbarWnd, L"TaskbandHWND");
+        if (!hTaskSwWnd) return nullptr;
+
+        void* taskBand = (void*)GetWindowLongPtrW(hTaskSwWnd, 0);
+        if (!taskBand) return nullptr;
+
+        if (!CTaskBand_ITaskListWndSite_vftable) return nullptr;
+
+        void* tbfs = taskBand;
+        for (int i = 0; *(void**)tbfs != CTaskBand_ITaskListWndSite_vftable; ++i) {
+            if (i == 20) return nullptr;
+            tbfs = (void**)tbfs + 1;
+        }
+
+        void* tbhsp[2]{};
+        if (!CTaskBand_GetTaskbarHost_Original) return nullptr;
+        CTaskBand_GetTaskbarHost_Original(tbfs, tbhsp);
+        if (!tbhsp[0] && !tbhsp[1]) return nullptr;
+
+        size_t offset = 0x48;
+        if (TaskbarHost_FrameHeight_Original) {
+            const BYTE* b = (const BYTE*)TaskbarHost_FrameHeight_Original;
+#if defined(_WIN64) && defined(_M_X64)
+            if (b[0] == 0x48 && b[1] == 0x83 && b[2] == 0xEC && b[4] == 0x48 &&
+                b[5] == 0x83 && b[6] == 0xC1 && b[7] <= 0x7F)
+                offset = b[7];
+#elif defined(_WIN64) && defined(_M_ARM64)
+            if (b[0] == 0xFF && b[1] == 0x23 && b[2] == 0x03 && b[3] == 0xD5) {
+                b += 4;
+            }
+            if ((b[0] & 0x1F) == 0 && b[1] == 0 && (b[2] & 0xC0) == 0 &&
+                b[3] == 0x91) {
+                offset = ((b[2] & 0x3F) << 2) | (b[1] >> 6);
+            }
+#elif !defined(_WIN64)
+            if (b[0] == 0x8B && b[1] == 0x81)
+                offset = *(DWORD*)(b + 2);
+#endif
+        }
+
+        auto* iunk = *(IUnknown**)((BYTE*)tbhsp[0] + offset);
+        if (!iunk) {
+            if (tbhsp[1] && Std_Ref_Decref_Original) Std_Ref_Decref_Original(tbhsp[1]);
+            return nullptr;
+        }
+
+        FrameworkElement taskbarElem{nullptr};
+        iunk->QueryInterface(winrt::guid_of<FrameworkElement>(), winrt::put_abi(taskbarElem));
+        auto result = taskbarElem ? taskbarElem.XamlRoot() : nullptr;
+
+        if (tbhsp[1] && Std_Ref_Decref_Original) Std_Ref_Decref_Original(tbhsp[1]);
+        return result;
+    } catch (...) {
+        Wh_Log(L"GetTaskbarXamlRoot: Exception occurred");
+        return nullptr;
+    }
+}
+
+static const wchar_t* GetGlyph(int cmd, bool isPlaying = false) {
+    bool isFluent = (g_settings.iconStyle == L"fluent_outline" || g_settings.iconStyle == L"fluent_filled");
+    bool isFilled = (g_settings.iconStyle == L"fluent_filled" || g_settings.iconStyle == L"mdl2_filled");
+
+    switch (cmd) {
+        case 1:
+            if (isFilled) return L"";
+            return L"";
+        case 2:
+            if (isPlaying) {
+                if (isFluent && isFilled) return L"";
+                if (!isFluent && isFilled) return L"";
+                return L"";
+            } else {
+                if (isFilled) return L"";
+                return L"";
+            }
+        case 3:
+            if (isFilled) return L"";
+            return L"";
+        case 5:
+            if (isFilled) return L"";
+            return L"";
+        case 6:
+            if (isFilled) return L"";
+            return L"";
+        case 7:
+            return L"";
+        case 8: {
+            RepeatMode mode = g_repeatMode.load();
+            switch (mode) {
+                case RepeatMode::Off: return L"";
+                case RepeatMode::All: return L"";
+                case RepeatMode::One: return L"";
+            }
+        }
+    }
+    return L"";
+}
+
+static TextBlock MakeIconText(const wchar_t* glyph, double sz, winrt::Windows::UI::Color c) {
+    TextBlock t;
+    t.Text(glyph);
+    t.FontSize(sz);
+    t.Foreground(MakeBrush(c));
+    t.VerticalAlignment(VerticalAlignment::Center);
+    t.HorizontalAlignment(HorizontalAlignment::Center);
+
+    bool useFluent = (g_settings.iconStyle == L"fluent_outline" || g_settings.iconStyle == L"fluent_filled");
+
+    try {
+        if (useFluent) {
+            t.FontFamily(FontFamily(L"Segoe Fluent Icons"));
+        } else {
+            t.FontFamily(FontFamily(L"Segoe MDL2 Assets"));
+        }
+    } catch (...) {
+        try {
+            t.FontFamily(FontFamily(L"Segoe MDL2 Assets"));
+        } catch (...) {
+            try {
+                t.FontFamily(FontFamily(L"Segoe UI Symbol"));
+            } catch (...) {}
+        }
+    }
+    return t;
+}
+
+static Button MakeControlButton(int cmd, bool isPlaying, winrt::Windows::UI::Color iconColor) {
+    Button btn;
+    try {
+        btn.Width((double)g_settings.buttonSize);
+        btn.Height((double)g_settings.buttonSize);
+        btn.Padding({1,1,1,1});
+        double cr = (double)g_settings.buttonCornerRadius;
+        btn.CornerRadius({cr,cr,cr,cr});
+        btn.BorderThickness({0,0,0,0});
+        btn.VerticalAlignment(VerticalAlignment::Center);
+        btn.HorizontalAlignment(HorizontalAlignment::Center);
+
+        const wchar_t* glyph = L"";
+
+        double opacity = 1.0;
+        if (cmd == 7 && !g_shuffleEnabled.load()) {
+            opacity = 0.4;
+        }
+
+        auto iconText = MakeIconText(glyph, (double)g_settings.buttonIconSize, iconColor);
+        iconText.Opacity(opacity);
+        btn.Content(winrt::box_value(iconText));
+
+        btn.Click([cmd](auto const&, auto const&) {
+            if (!g_unloading) {
+                SendMediaCommandAsync(cmd);
+                DispatchMediaUpdate();
+            }
+        });
+
+        ApplyFluentMediaButtonStyle(btn);
+
+        auto isPressed = std::make_shared<bool>(false);
+        auto isHovered = std::make_shared<bool>(false);
+
+        auto updateBtnVisualState = [btn, isPressed, isHovered]() {
+            GoToCommonState(btn, g_settings.enableMediaButtonsHoverEffect, *isPressed, *isHovered);
+        };
+
+        RunWhenButtonReady(btn, [btn, updateBtnVisualState]() {
+            SetupMediaButtonCommonStates(btn);
+            updateBtnVisualState();
+        });
+
+        btn.PointerEntered([isHovered, updateBtnVisualState](auto const&, auto const&) {
+            *isHovered = true;
+            updateBtnVisualState();
+        });
+
+        btn.PointerExited([isHovered, updateBtnVisualState](auto const&, auto const&) {
+            *isHovered = false;
+            updateBtnVisualState();
+        });
+
+        btn.PointerPressed([isPressed, updateBtnVisualState](auto const& sender, winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e) {
+            if (auto elem = sender.template try_as<UIElement>()) {
+                elem.CapturePointer(e.Pointer());
+            }
+            *isPressed = true;
+            updateBtnVisualState();
+        });
+
+        btn.PointerReleased([isPressed, isHovered, updateBtnVisualState, cmd](auto const& sender, winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e) {
+            bool actuallyHovered = false;
+            auto prop = e.GetCurrentPoint(nullptr).Properties();
+            auto kind = prop.PointerUpdateKind();
+
+            if (auto elem = sender.template try_as<UIElement>()) {
+                elem.ReleasePointerCapture(e.Pointer());
+                try {
+                    auto bounds = elem.RenderSize();
+                    auto pos = e.GetCurrentPoint(elem).Position();
+                    actuallyHovered = (pos.X >= 0 && pos.X <= bounds.Width && pos.Y >= 0 && pos.Y <= bounds.Height);
+                } catch (...) {}
+            }
+            *isPressed = false;
+            *isHovered = actuallyHovered;
+            updateBtnVisualState();
+
+            if (!g_unloading && actuallyHovered) {
+                if (kind == winrt::Windows::UI::Input::PointerUpdateKind::LeftButtonReleased) {
+                    SendMediaCommandAsync(cmd);
+                    DispatchMediaUpdate();
+                }
+            }
+            e.Handled(true);
+        });
+
+        btn.PointerCanceled([isPressed, isHovered, updateBtnVisualState](auto const&, auto const&) {
+            *isPressed = false;
+            *isHovered = false;
+            updateBtnVisualState();
+        });
+
+        btn.PointerCaptureLost([isPressed, isHovered, updateBtnVisualState](auto const& sender, winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e) {
+            *isPressed = false;
+            if (auto elem = sender.template try_as<UIElement>()) {
+                try {
+                    auto bounds = elem.RenderSize();
+                    auto pos = e.GetCurrentPoint(elem).Position();
+                    *isHovered = (pos.X >= 0 && pos.X <= bounds.Width && pos.Y >= 0 && pos.Y <= bounds.Height);
+                } catch (...) { *isHovered = false; }
+            }
+            updateBtnVisualState();
+        });
+
+    } catch (...) {}
+    return btn;
+}
+
+static void AddLayoutAnchorOverlay(Grid const& target, const wchar_t* name, winrt::Windows::UI::Color color) {
+    if (!target || !g_settings.showLayoutAnchors) return;
+    try {
+        Grid overlay;
+        overlay.Name(name);
+        overlay.IsHitTestVisible(false);
+        overlay.HorizontalAlignment(HorizontalAlignment::Stretch);
+        overlay.VerticalAlignment(VerticalAlignment::Stretch);
+
+        winrt::Windows::UI::Xaml::Shapes::Rectangle vLine;
+        vLine.Width(1);
+        vLine.Fill(MakeBrush(color));
+        vLine.HorizontalAlignment(HorizontalAlignment::Center);
+        vLine.VerticalAlignment(VerticalAlignment::Stretch);
+
+        winrt::Windows::UI::Xaml::Shapes::Rectangle hLine;
+        hLine.Height(1);
+        hLine.Fill(MakeBrush(color));
+        hLine.HorizontalAlignment(HorizontalAlignment::Stretch);
+        hLine.VerticalAlignment(VerticalAlignment::Center);
+
+        Border outline;
+        outline.BorderBrush(MakeBrush(color));
+        outline.BorderThickness({1,1,1,1});
+        outline.HorizontalAlignment(HorizontalAlignment::Stretch);
+        outline.VerticalAlignment(VerticalAlignment::Stretch);
+
+        overlay.Children().Append(outline);
+        overlay.Children().Append(vLine);
+        overlay.Children().Append(hLine);
+        Canvas::SetZIndex(overlay, 5000);
+        target.Children().Append(overlay);
+    } catch (...) {}
+}
+
+static Grid BuildPlayerGrid() {
+    try {
+        auto textClr = TextColor();
+        auto artistClr = ArtistColor();
+        auto buttonClr = ButtonColor();
+        auto bgBrush = MakeBackgroundBrush();
+        double cr    = (double)g_settings.cornerRadius;
+        double phMin = (double)g_settings.playerMinHeight;
+        double phMax = (double)g_settings.playerMaxHeight;
+
+        bool hasTextOrButtons = g_settings.showTrackTitle || g_settings.showTrackArtist || (g_settings.showMediaButtons && !g_mediaButtons.empty());
+
+        Border backgroundBorder;
+        backgroundBorder.Name(L"FluentMedia_Background");
+        if (cr > 0) {
+            backgroundBorder.CornerRadius({cr, cr, cr, cr});
+        }
+        backgroundBorder.HorizontalAlignment(HorizontalAlignment::Stretch);
+        backgroundBorder.VerticalAlignment(VerticalAlignment::Stretch);
+        backgroundBorder.IsHitTestVisible(false);
+        backgroundBorder.Visibility(Visibility::Collapsed);
+
+        Button playerButton;
+        playerButton.Name(L"FluentMedia_OuterBorder");
+        if (cr > 0) {
+            playerButton.CornerRadius({cr, cr, cr, cr});
+        } else {
+            playerButton.CornerRadius({0, 0, 0, 0});
+        }
+        playerButton.BorderThickness({0, 0, 0, 0});
+        playerButton.UseSystemFocusVisuals(false);
+        playerButton.IsHitTestVisible(false);
+        playerButton.HorizontalAlignment(HorizontalAlignment::Stretch);
+        playerButton.VerticalAlignment(VerticalAlignment::Stretch);
+        if (phMin > 0) {
+            playerButton.MinHeight(phMin);
+        }
+        if (phMax > 0) {
+            playerButton.MaxHeight(phMax);
+        }
+
+        Grid chromeFill;
+        if (phMin > 0) {
+            chromeFill.MinHeight(phMin);
+        }
+        if (phMax > 0) {
+            chromeFill.MaxHeight(phMax);
+        }
+        chromeFill.IsHitTestVisible(false);
+        playerButton.Content(chromeFill);
+
+        if (g_settings.showDebugBorders) {
+            playerButton.BorderBrush(MakeBrush({0xFF, 0xFF, 0x00, 0x00}));
+            playerButton.BorderThickness({2, 2, 2, 2});
+        }
+
+        Grid panel;
+        panel.VerticalAlignment(VerticalAlignment::Center);
+        panel.HorizontalAlignment(HorizontalAlignment::Stretch);
+        if (hasTextOrButtons) {
+            panel.Margin({4, 2, 4, 2});
+        }
+        AddLayoutAnchorOverlay(panel, L"FluentMedia_DebugPanelAnchors", {0xD0, 0x00, 0xFF, 0x00});
+
+        if (g_settings.showDebugBorders) {
+            Border panelDebugBorder;
+            panelDebugBorder.BorderBrush(MakeBrush({0xFF, 0x00, 0xFF, 0x00}));
+            panelDebugBorder.BorderThickness({1,1,1,1});
+            panel.Children().Append(panelDebugBorder);
+        }
+
+        bool buttonsLeft = g_settings.mirrorLayout;
+        bool albumArtLeft = !g_settings.mirrorLayout;
+        bool hasText = g_settings.showTrackTitle || g_settings.showTrackArtist;
+
+        ColumnDefinition colFirst, colText, colSpacer, colLast;
+        colFirst.Width({1.0, GridUnitType::Auto});
+
+        if (hasText) {
+            colText.Width({1.0, GridUnitType::Star});
+        } else {
+            colText.Width({0.0, GridUnitType::Pixel});
+        }
+
+        colSpacer.Width({0.0, GridUnitType::Pixel});
+
+        colLast.Width({1.0, GridUnitType::Auto});
+        panel.ColumnDefinitions().Append(colFirst);
+        panel.ColumnDefinitions().Append(colText);
+        panel.ColumnDefinitions().Append(colSpacer);
+        panel.ColumnDefinitions().Append(colLast);
+
+        Grid artContainer{nullptr};
+
+        if (g_settings.showAlbumArt) {
+            double acr = (double)g_settings.albumArtCornerRadius;
+            int iconSz = g_settings.appIconSize;
+
+            artContainer = Grid();
+            artContainer.VerticalAlignment(VerticalAlignment::Center);
+            artContainer.HorizontalAlignment(HorizontalAlignment::Center);
+
+            if (g_settings.albumArtMinWidth > 0) {
+                artContainer.MinWidth((double)g_settings.albumArtMinWidth);
+            }
+            if (g_settings.albumArtMaxWidth > 0) {
+                artContainer.MaxWidth((double)g_settings.albumArtMaxWidth);
+            }
+            if (g_settings.albumArtMinHeight > 0) {
+                artContainer.MinHeight((double)g_settings.albumArtMinHeight);
+            }
+            if (g_settings.albumArtMaxHeight > 0) {
+                artContainer.MaxHeight((double)g_settings.albumArtMaxHeight);
+            }
+
+            double artLeftMargin = (double)g_settings.albumArtLeftMargin;
+            double artRightMargin = (double)g_settings.albumArtRightMargin;
+            artContainer.Margin({artLeftMargin, 0, artRightMargin, 0});
+
+            artContainer.Opacity(g_settings.albumArtOpacity / 100.0);
+            artContainer.Background(MakeBrush({0x00,0x00,0x00,0x00}));
+            AddLayoutAnchorOverlay(artContainer, L"FluentMedia_DebugArtAnchors", {0xD0, 0xFF, 0xFF, 0x00});
+
+            if (g_settings.showDebugBorders) {
+                Border artDebugBorder;
+                artDebugBorder.BorderBrush(MakeBrush({0xFF, 0xFF, 0xFF, 0x00}));
+                artDebugBorder.BorderThickness({2,2,2,2});
+                artContainer.Children().Append(artDebugBorder);
+            }
+
+            winrt::Windows::UI::Xaml::Shapes::Rectangle placeholder;
+            placeholder.Fill(MakeBrush({0x40,0x80,0x80,0x80}));
+            placeholder.RadiusX(acr); placeholder.RadiusY(acr);
+            placeholder.HorizontalAlignment(HorizontalAlignment::Stretch);
+            placeholder.VerticalAlignment(VerticalAlignment::Stretch);
+            artContainer.Children().Append(placeholder);
+
+            Border artBorder;
+            artBorder.CornerRadius({acr,acr,acr,acr});
+            artBorder.HorizontalAlignment(HorizontalAlignment::Stretch);
+            artBorder.VerticalAlignment(VerticalAlignment::Stretch);
+
+            Controls::Image artImage;
+            artImage.Name(kArtImageName);
+
+            bool isSquare = (g_settings.albumArtMinWidth == g_settings.albumArtMinHeight) &&
+                           (g_settings.albumArtMaxWidth == g_settings.albumArtMaxHeight);
+            artImage.Stretch(isSquare ? Stretch::UniformToFill : Stretch::Uniform);
+
+            artImage.HorizontalAlignment(HorizontalAlignment::Center);
+            artImage.VerticalAlignment(VerticalAlignment::Center);
+            artBorder.Child(artImage);
+            artContainer.Children().Append(artBorder);
+
+            Border artRing;
+            artRing.CornerRadius({acr,acr,acr,acr});
+            artRing.BorderThickness({1,1,1,1});
+            artRing.BorderBrush(MakeBrush({0x25,0x80,0x80,0x80}));
+            artContainer.Children().Append(artRing);
+
+            if (g_settings.showAppIcon) {
+                Grid iconOverlay;
+                iconOverlay.VerticalAlignment(VerticalAlignment::Stretch);
+                iconOverlay.HorizontalAlignment(HorizontalAlignment::Stretch);
+
+                Controls::Image appIconImage;
+                appIconImage.Name(kAppIconImageName);
+                appIconImage.Width(iconSz);
+                appIconImage.Height(iconSz);
+                appIconImage.Stretch(Stretch::UniformToFill);
+                appIconImage.Visibility(Visibility::Collapsed);
+
+                const auto& corner = g_settings.appIconCorner;
+                double margin_right  = 0, margin_bottom = 0;
+                double margin_left   = 0, margin_top    = 0;
+                HorizontalAlignment ha = HorizontalAlignment::Right;
+                VerticalAlignment   va = VerticalAlignment::Bottom;
+
+                if (corner == L"top_left") {
+                    ha = HorizontalAlignment::Left;
+                    va = VerticalAlignment::Top;
+                } else if (corner == L"top_right") {
+                    ha = HorizontalAlignment::Right;
+                    va = VerticalAlignment::Top;
+                } else if (corner == L"bottom_left") {
+                    ha = HorizontalAlignment::Left;
+                    va = VerticalAlignment::Bottom;
+                } else {
+                    ha = HorizontalAlignment::Right;
+                    va = VerticalAlignment::Bottom;
+                }
+
+                appIconImage.HorizontalAlignment(ha);
+                appIconImage.VerticalAlignment(va);
+                appIconImage.Margin({margin_left, margin_top, margin_right, margin_bottom});
+
+                iconOverlay.Children().Append(appIconImage);
+                Canvas::SetZIndex(iconOverlay, 15);
+                artContainer.Children().Append(iconOverlay);
+            }
+
+            if (g_settings.showPauseOverlay) {
+                Border pauseBorder;
+                pauseBorder.Name(L"PauseIconOverlay");
+                pauseBorder.HorizontalAlignment(HorizontalAlignment::Stretch);
+                pauseBorder.VerticalAlignment(VerticalAlignment::Stretch);
+                pauseBorder.CornerRadius({acr + 1, acr + 1, acr + 1, acr + 1});
+                BYTE opacity = (BYTE)((g_settings.pauseOverlayOpacity * 255) / 100);
+                pauseBorder.Background(MakeBrush({opacity, 0x00, 0x00, 0x00}));
+                pauseBorder.Visibility(Visibility::Collapsed);
+                Canvas::SetZIndex(pauseBorder, 8);
+
+                TextBlock pauseIcon;
+                pauseIcon.Text(L"");
+                pauseIcon.FontFamily(Media::FontFamily(L"Segoe MDL2 Assets"));
+                pauseIcon.FontSize(16);
+                pauseIcon.Foreground(MakeBrush({0xFF, 0xFF, 0xFF, 0xFF}));
+                pauseIcon.HorizontalAlignment(HorizontalAlignment::Center);
+                pauseIcon.VerticalAlignment(VerticalAlignment::Center);
+
+                pauseBorder.Child(pauseIcon);
+                artContainer.Children().Append(pauseBorder);
+            }
+
+            artContainer.PointerPressed([](auto const& sender, winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e) mutable {
+                if (auto elem = sender.template try_as<UIElement>()) {
+                    elem.CapturePointer(e.Pointer());
+                }
+                e.Handled(true);
+            });
+
+            artContainer.PointerReleased([](auto const& sender, winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e) mutable {
+                bool actuallyHovered = false;
+                if (auto elem = sender.template try_as<UIElement>()) {
+                    elem.ReleasePointerCapture(e.Pointer());
+                    try {
+                        auto pointerPoint = e.GetCurrentPoint(elem);
+                        auto bounds = elem.RenderSize();
+                        auto pos = pointerPoint.Position();
+                        actuallyHovered = (pos.X >= 0 && pos.X <= bounds.Width && pos.Y >= 0 && pos.Y <= bounds.Height);
+                    } catch (...) { actuallyHovered = false; }
+                }
+
+                if (g_unloading) return;
+
+                if (actuallyHovered) {
+                    auto kind = e.GetCurrentPoint(nullptr).Properties().PointerUpdateKind();
+                    if (kind == winrt::Windows::UI::Input::PointerUpdateKind::LeftButtonReleased) {
+                        ExecuteMediaAction(g_settings.albumArtLeftClick);
+                    } else if (kind == winrt::Windows::UI::Input::PointerUpdateKind::RightButtonReleased) {
+                        ExecuteMediaAction(g_settings.albumArtRightClick);
+                    } else if (kind == winrt::Windows::UI::Input::PointerUpdateKind::MiddleButtonReleased) {
+                        ExecuteMediaAction(g_settings.albumArtMiddleClick);
+                    }
+                }
+                e.Handled(true);
+            });
+
+            artContainer.DoubleTapped([](auto const&, winrt::Windows::UI::Xaml::Input::DoubleTappedRoutedEventArgs const& e) mutable {
+                if (g_unloading) return;
+                ExecuteMediaAction(g_settings.albumArtLeftDoubleClick);
+                e.Handled(true);
+            });
+
+            artContainer.PointerWheelChanged([](winrt::Windows::Foundation::IInspectable const&, winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e) {
+                if (g_unloading) return;
+                auto action = g_settings.albumArtWheelAction;
+                if (action == L"none") return;
+
+                auto props = e.GetCurrentPoint(nullptr).Properties();
+                int delta = props.MouseWheelDelta();
+
+                if (action == L"switch_tracks") {
+                    if (delta > 0) SendMediaCommandAsync(1);
+                    else if (delta < 0) SendMediaCommandAsync(3);
+                    DispatchMediaUpdate();
+                } else if (action == L"switch_sessions") {
+                    if (delta != 0) SwitchMediaSession();
+                } else if (action == L"system_sound") {
+                    ChangeSystemVolume(delta > 0);
+                } else if (action == L"app_sound") {
+                    std::thread([delta]() {
+                        std::wstring aumid;
+                        {
+                            std::lock_guard<std::mutex> lk(g_sessionMtx);
+                            if (g_currentSession) {
+                                try {
+                                    aumid = std::wstring(g_currentSession.SourceAppUserModelId());
+                                } catch (...) {}
+                            }
+                        }
+                        if (!aumid.empty()) {
+                            float volumeDelta = (delta > 0) ? 0.02f : -0.02f;
+                            AdjustAppVolumeByAUMID(aumid, volumeDelta);
+                        }
+                    }).detach();
+                }
+                e.Handled(true);
+            });
+
+            artContainer.Tag(winrt::box_value(winrt::hstring(L"FluentMediaArtContainer")));
+
+            if (albumArtLeft) {
+                Grid::SetColumn(artContainer, 0);
+            } else {
+                Grid::SetColumn(artContainer, 3);
+            }
+            panel.Children().Append(artContainer);
+        }
+
+        if (g_settings.showTrackTitle || g_settings.showTrackArtist) {
+            Border textContainer;
+            textContainer.VerticalAlignment(VerticalAlignment::Center);
+
+            if (albumArtLeft) {
+                textContainer.HorizontalAlignment(HorizontalAlignment::Left);
+            } else {
+                textContainer.HorizontalAlignment(HorizontalAlignment::Right);
+            }
+
+            if (g_settings.textAreaMinWidth > 0) {
+                textContainer.MinWidth((double)g_settings.textAreaMinWidth);
+            }
+            if (g_settings.textAreaMaxWidth > 0) {
+                textContainer.MaxWidth((double)g_settings.textAreaMaxWidth);
+            }
+            if (g_settings.textAreaMinHeight > 0) {
+                textContainer.MinHeight((double)g_settings.textAreaMinHeight);
+            }
+            if (g_settings.textAreaMaxHeight > 0) {
+                textContainer.MaxHeight((double)g_settings.textAreaMaxHeight);
+            }
+
+            double leftMargin = (double)g_settings.textAreaLeftMargin;
+            double rightMargin = (double)g_settings.textAreaRightMargin;
+            textContainer.Margin({leftMargin, 0, rightMargin, 0});
+
+            if (g_settings.showDebugBorders) {
+                textContainer.BorderBrush(MakeBrush({0xFF, 0x00, 0xFF, 0xFF}));
+                textContainer.BorderThickness({1,1,1,1});
+            }
+
+            StackPanel textStack;
+            textStack.Name(kTextStackName);
+            textStack.Orientation(Orientation::Vertical);
+            textStack.VerticalAlignment(VerticalAlignment::Center);
+            textStack.HorizontalAlignment(g_settings.mirrorLayout ? HorizontalAlignment::Right : HorizontalAlignment::Left);
+            textStack.Spacing((double)g_settings.textSpacing);
+
+            if (g_settings.showTrackTitle) {
+                TextBlock titleBlock;
+                titleBlock.Name(kTitleBlockName);
+                titleBlock.FontSize((double)g_settings.titleFontSize);
+                titleBlock.FontFamily(Media::FontFamily(g_settings.titleFont));
+                titleBlock.Foreground(MakeBrush(textClr));
+                titleBlock.TextWrapping(TextWrapping::NoWrap);
+                titleBlock.TextTrimming(TextTrimming::CharacterEllipsis);
+                titleBlock.TextAlignment(g_settings.mirrorLayout ? TextAlignment::Right : TextAlignment::Left);
+                textStack.Children().Append(titleBlock);
+            }
+
+            if (g_settings.showTrackArtist) {
+                TextBlock artistBlock;
+                artistBlock.Name(kArtistBlockName);
+                artistBlock.FontSize((double)g_settings.artistFontSize);
+                artistBlock.FontFamily(Media::FontFamily(g_settings.artistFont));
+                artistBlock.Foreground(MakeBrush(artistClr));
+                artistBlock.TextWrapping(TextWrapping::NoWrap);
+                artistBlock.TextTrimming(TextTrimming::CharacterEllipsis);
+                artistBlock.TextAlignment(g_settings.mirrorLayout ? TextAlignment::Right : TextAlignment::Left);
+                textStack.Children().Append(artistBlock);
+            }
+
+            textContainer.Child(textStack);
+
+            Grid::SetColumn(textContainer, 1);
+            panel.Children().Append(textContainer);
+        }
+
+        if (g_settings.showMediaButtons) {
+            StackPanel ctrlPanel;
+            ctrlPanel.Orientation(Orientation::Horizontal);
+            ctrlPanel.Spacing((double)g_settings.buttonSpacing);
+            ctrlPanel.VerticalAlignment(VerticalAlignment::Center);
+            ctrlPanel.HorizontalAlignment(buttonsLeft ? HorizontalAlignment::Left : HorizontalAlignment::Right);
+
+            std::vector<MediaButtonConfig> currentButtons;
+            {
+                std::lock_guard<std::mutex> lock(g_mediaButtonsMutex);
+                currentButtons = g_mediaButtons;
+            }
+
+            bool hasButtons = !currentButtons.empty();
+            if (hasButtons) {
+                ctrlPanel.Margin({(double)g_settings.mediaButtonsLeftMargin, 0, (double)g_settings.mediaButtonsRightMargin, 0});
+            }
+
+            if (g_settings.showDebugBorders) {
+                Border ctrlDebugBorder;
+                ctrlDebugBorder.BorderBrush(MakeBrush({0xFF, 0xFF, 0x00, 0xFF}));
+                ctrlDebugBorder.BorderThickness({1,1,1,1});
+                Grid::SetColumn(ctrlDebugBorder, buttonsLeft ? 0 : 3);
+                panel.Children().Append(ctrlDebugBorder);
+            }
+
+            for (const auto& btnCfg : currentButtons) {
+                auto btn = MakeControlButton(btnCfg.cmd, false, buttonClr);
+
+                switch (btnCfg.type) {
+                    case MediaButtonType::Previous:
+                        btn.Name(kPrevBtnName);
+                        break;
+                    case MediaButtonType::PlayPause:
+                        btn.Name(kPlayBtnName);
+                        break;
+                    case MediaButtonType::Next:
+                        btn.Name(kNextBtnName);
+                        break;
+                    case MediaButtonType::Rewind5s:
+                        btn.Name(kRewindBtnName);
+                        break;
+                    case MediaButtonType::Forward5s:
+                        btn.Name(kForwardBtnName);
+                        break;
+                    case MediaButtonType::Shuffle:
+                        btn.Name(kShuffleBtnName);
+                        break;
+                    case MediaButtonType::Repeat:
+                        btn.Name(kRepeatBtnName);
+                        break;
+                }
+
+                ctrlPanel.Children().Append(btn);
+            }
+
+            if (buttonsLeft) {
+                Grid::SetColumn(ctrlPanel, 0);
+            } else {
+                Grid::SetColumn(ctrlPanel, 3);
+            }
+
+            if (hasButtons) {
+                panel.Children().Append(ctrlPanel);
+            }
+        }
+
+        Grid wrapper;
+        wrapper.Name(kGridName);
+        wrapper.VerticalAlignment(VerticalAlignment::Stretch);
+        wrapper.HorizontalAlignment(HorizontalAlignment::Left);
+        AddLayoutAnchorOverlay(wrapper, L"FluentMedia_DebugPlayerAnchors", {0xD0, 0xFF, 0x50, 0x50});
+
+        try {
+            if (g_settings.enableSmoothPositionAnimation) {
+                TransitionCollection transitions;
+                RepositionThemeTransition marginTransition;
+                transitions.Append(marginTransition);
+                wrapper.Transitions(transitions);
+            }
+        } catch (...) {}
+
+        if (hasTextOrButtons && g_settings.playerMinWidth > 0) {
+            wrapper.MinWidth((double)g_settings.playerMinWidth);
+        }
+
+        if (g_settings.playerMaxWidth > 0) {
+            wrapper.MaxWidth((double)g_settings.playerMaxWidth);
+        }
+
+        if (g_settings.playerMinHeight > 0) {
+            wrapper.MinHeight((double)g_settings.playerMinHeight);
+        }
+
+        if (g_settings.playerMaxHeight > 0) {
+            wrapper.MaxHeight((double)g_settings.playerMaxHeight);
+        }
+
+        wrapper.Background(MakeBrush({0x00, 0, 0, 0}));
+
+        Canvas::SetZIndex(backgroundBorder, 0);
+        Canvas::SetZIndex(playerButton, 1);    
+        Canvas::SetZIndex(panel, 2);           
+
+        wrapper.Children().Append(backgroundBorder);
+        wrapper.Children().Append(playerButton);
+        wrapper.Children().Append(panel);
+
+        ApplyFluentMediaButtonStyle(playerButton);
+        if (!g_settings.showDebugBorders) {
+            playerButton.BorderThickness({1, 1, 1, 1});
+        }
+
+        auto isPressed = std::make_shared<bool>(false);
+        auto isHovered = std::make_shared<bool>(false);
+
+        auto playerNormalBg = MakeBackgroundBrush();
+
+        auto updatePlayerVisualState = [playerButton, isPressed, isHovered]() {
+            GoToCommonState(playerButton, g_settings.enablePlayerHoverEffect, *isPressed, *isHovered);
+        };
+
+        RunWhenButtonReady(playerButton, [playerButton, playerNormalBg, updatePlayerVisualState]() {
+            SetupPlayerButtonCommonStates(playerButton, playerNormalBg);
+            updatePlayerVisualState();
+        });
+
+        wrapper.Loaded([playerButton, playerNormalBg, updatePlayerVisualState](auto const&, auto const&) {
+            try {
+                SetupPlayerButtonCommonStates(playerButton, playerNormalBg);
+                updatePlayerVisualState();
+            } catch (...) {}
+        });
+
+        panel.PointerEntered([isHovered, updatePlayerVisualState](auto const&, auto const&) {
+            *isHovered = true;
+            updatePlayerVisualState();
+        });
+
+        panel.PointerExited([wrapper, isHovered, updatePlayerVisualState](auto const&, PointerRoutedEventArgs const& e) {
+            bool stillInside = false;
+            try {
+                auto pos = e.GetCurrentPoint(wrapper).Position();
+                auto bounds = wrapper.RenderSize();
+                stillInside = pos.X >= 0 && pos.X <= bounds.Width && pos.Y >= 0 && pos.Y <= bounds.Height;
+            } catch (...) {}
+            if (!stillInside) {
+                *isHovered = false;
+                updatePlayerVisualState();
+            }
+        });
+
+        wrapper.PointerEntered([isHovered, updatePlayerVisualState](auto const&, auto const&) mutable {
+            *isHovered = true;
+            updatePlayerVisualState();
+        });
+
+        wrapper.PointerExited([isHovered, updatePlayerVisualState](auto const&, auto const&) mutable {
+            *isHovered = false;
+            updatePlayerVisualState();
+        });
+
+        wrapper.PointerPressed([isPressed, updatePlayerVisualState](auto const& sender, winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e) mutable {
+            if (auto elem = sender.template try_as<UIElement>()) {
+                elem.CapturePointer(e.Pointer());
+            }
+            *isPressed = true;
+            updatePlayerVisualState();
+        });
+
+        wrapper.PointerReleased([isPressed, isHovered, updatePlayerVisualState](auto const& sender, winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e) mutable {
+            *isPressed = false;
+            bool actuallyHovered = false;
+            if (auto elem = sender.template try_as<UIElement>()) {
+                elem.ReleasePointerCapture(e.Pointer());
+                try {
+                    auto pointerPoint = e.GetCurrentPoint(elem);
+                    auto bounds = elem.RenderSize();
+                    auto pos = pointerPoint.Position();
+                    actuallyHovered = (pos.X >= 0 && pos.X <= bounds.Width && pos.Y >= 0 && pos.Y <= bounds.Height);
+                } catch (...) { actuallyHovered = false; }
+            }
+            *isHovered = actuallyHovered;
+            updatePlayerVisualState();
+
+            if (g_unloading || e.Handled()) return;
+
+            if (actuallyHovered) {
+                auto kind = e.GetCurrentPoint(nullptr).Properties().PointerUpdateKind();
+                if (kind == winrt::Windows::UI::Input::PointerUpdateKind::LeftButtonReleased) {
+                    ExecuteMediaAction(g_settings.playerLeftClick);
+                } else if (kind == winrt::Windows::UI::Input::PointerUpdateKind::RightButtonReleased) {
+                    ExecuteMediaAction(g_settings.playerRightClick);
+                } else if (kind == winrt::Windows::UI::Input::PointerUpdateKind::MiddleButtonReleased) {
+                    ExecuteMediaAction(g_settings.playerMiddleClick);
+                }
+            }
+        });
+
+        wrapper.PointerCanceled([isPressed, isHovered, updatePlayerVisualState](auto const&, auto const&) mutable {
+            *isPressed = false;
+            *isHovered = false;
+            updatePlayerVisualState();
+        });
+
+        wrapper.PointerCaptureLost([isPressed, isHovered, updatePlayerVisualState](auto const& sender, winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e) mutable {
+            *isPressed = false;
+            if (auto elem = sender.template try_as<UIElement>()) {
+                try {
+                    auto pointerPoint = e.GetCurrentPoint(elem);
+                    auto bounds = elem.RenderSize();
+                    auto pos = pointerPoint.Position();
+                    *isHovered = (pos.X >= 0 && pos.X <= bounds.Width && pos.Y >= 0 && pos.Y <= bounds.Height);
+                } catch (...) { *isHovered = false; }
+            }
+            updatePlayerVisualState();
+        });
+
+        wrapper.DoubleTapped([isPressed, updatePlayerVisualState](auto const&, winrt::Windows::UI::Xaml::Input::DoubleTappedRoutedEventArgs const& e) mutable {
+            *isPressed = false;
+            updatePlayerVisualState();
+            if (g_unloading) return;
+            ExecuteMediaAction(g_settings.playerLeftDoubleClick);
+            e.Handled(true);
+        });
+
+        wrapper.Tag(winrt::box_value(winrt::hstring(L"FluentMediaBarWrapper")));
+
+        wrapper.PointerWheelChanged([](auto const&, winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e) {
+            if (g_unloading) return;
+            auto action = g_settings.playerWheelAction;
+            if (action == L"none") return;
+
+            auto props = e.GetCurrentPoint(nullptr).Properties();
+            int delta = props.MouseWheelDelta();
+
+            if (action == L"switch_tracks") {
+                if (delta > 0) SendMediaCommandAsync(1);
+                else if (delta < 0) SendMediaCommandAsync(3);
+                DispatchMediaUpdate();
+            } else if (action == L"switch_sessions") {
+                if (delta != 0) SwitchMediaSession();
+            } else if (action == L"system_sound") {
+                ChangeSystemVolume(delta > 0);
+            } else if (action == L"app_sound") {
+                std::thread([delta]() {
+                    std::wstring aumid;
+                    {
+                        std::lock_guard<std::mutex> lk(g_sessionMtx);
+                        if (g_currentSession) {
+                            try {
+                                aumid = std::wstring(g_currentSession.SourceAppUserModelId());
+                            } catch (...) {}
+                        }
+                    }
+                    if (!aumid.empty()) {
+                        float volumeDelta = (delta > 0) ? 0.02f : -0.02f;
+                        AdjustAppVolumeByAUMID(aumid, volumeDelta);
+                    }
+                }).detach();
+            }
+            e.Handled(true);
+        });
+
+        try {
+            winrt::Windows::UI::Xaml::Interop::TypeName gridType;
+            gridType.Name = L"Windows.UI.Xaml.Controls.Grid";
+            gridType.Kind = winrt::Windows::UI::Xaml::Interop::TypeKind::Metadata;
+
+            winrt::Windows::UI::Xaml::Style wrapperStyle(gridType);
+            wrapper.Style(wrapperStyle);
+        } catch (...) {}
+
+        return wrapper;
+    } catch (...) {
+        Wh_Log(L"BuildPlayerGrid: Exception occurred");
+        return nullptr;
+    }
+}
+
+struct InjectionTarget {
+    Grid grid;
+    int  insertCol = 0;
+};
+
+static int RemovePlayerGridChildren(Grid const& targetGrid) {
+    if (!targetGrid) return -1;
+
+    int firstCol = -1;
+    for (int i = (int)targetGrid.Children().Size() - 1; i >= 0; --i) {
+        auto fe = targetGrid.Children().GetAt(i).try_as<FrameworkElement>();
+        if (fe && fe.Name() == kGridName) {
+            if (firstCol < 0) firstCol = Grid::GetColumn(fe);
+            try { targetGrid.Children().RemoveAt(i); } catch (...) {}
+        }
+    }
+    return firstCol;
+}
+
+static void RemoveAnchorDebugOverlays(Grid const& targetGrid) {
+    if (!targetGrid) return;
+    for (int i = (int)targetGrid.Children().Size() - 1; i >= 0; --i) {
+        auto fe = targetGrid.Children().GetAt(i).try_as<FrameworkElement>();
+        if (fe && fe.Name() == kAnchorOverlayName) {
+            try { targetGrid.Children().RemoveAt(i); } catch (...) {}
+        }
+    }
+}
+
+static void UpdateAnchorDebugOverlay(Grid const& targetGrid, FrameworkElement const& targetElem) {
+    if (!targetGrid) return;
+
+    if (!g_settings.showLayoutAnchors || !targetElem) {
+        RemoveAnchorDebugOverlays(targetGrid);
+        return;
+    }
+
+    try {
+        Border overlay{nullptr};
+        for (uint32_t i = 0; i < targetGrid.Children().Size(); ++i) {
+            auto fe = targetGrid.Children().GetAt(i).try_as<FrameworkElement>();
+            if (fe && fe.Name() == kAnchorOverlayName) {
+                overlay = fe.try_as<Border>();
+                break;
+            }
+        }
+
+        if (!overlay) {
+            overlay = Border();
+            overlay.Name(kAnchorOverlayName);
+            overlay.IsHitTestVisible(false);
+            overlay.BorderBrush(MakeBrush({0xE0, 0x00, 0xA2, 0xFF}));
+            overlay.BorderThickness({2,2,2,2});
+            overlay.Background(MakeBrush({0x20, 0x00, 0xA2, 0xFF}));
+            overlay.HorizontalAlignment(HorizontalAlignment::Left);
+            overlay.VerticalAlignment(VerticalAlignment::Top);
+            Canvas::SetZIndex(overlay, 5001);
+            targetGrid.Children().Append(overlay);
+        }
+
+        auto transform = targetElem.TransformToVisual(targetGrid);
+        auto point = transform.TransformPoint({0, 0});
+        overlay.Width(std::max(1.0, targetElem.ActualWidth()));
+        overlay.Height(std::max(1.0, targetElem.ActualHeight()));
+        overlay.Margin({point.X, point.Y, 0, 0});
+        overlay.Visibility(Visibility::Visible);
+    } catch (...) {
+        RemoveAnchorDebugOverlays(targetGrid);
+    }
+}
+
+static const wchar_t* const kStartButtonNames[] = {
+    L"StartButton",
+    L"StartMenuButton",
+    L"StartMenuLaunchButton", 
+    L"LaunchListButton",
+};
+
+static const wchar_t* const kSearchButtonNames[] = {
+    L"SearchBoxButton",
+    L"SearchButton",
+    L"TaskbarSearchBox",
+    L"SearchBoxControl",
+};
+
+static const wchar_t* const kAppIconsNames[] = {
+    L"TaskListView",
+    L"RunningAppsListView",
+    L"TaskListGrid",
+    L"IconContainer",
+    L"OverflowFlyoutList",
+    L"TaskListLargeView",
+};
+
+static Grid FindParentGrid(FrameworkElement const& elem, bool immediate = true) {
+    if (!elem) return nullptr;
+    DependencyObject cur = elem;
+    while (cur) {
+        auto par = VisualTreeHelper::GetParent(cur);
+        if (!par) break;
+        if (auto g = par.try_as<Grid>()) {
+            if (immediate) return g;
+        }
+        cur = par;
+    }
+    return nullptr;
+}
+
+static Grid FindRootGrid(FrameworkElement const& elem) {
+    if (!elem) return nullptr;
+    Grid last{nullptr};
+    DependencyObject cur = elem;
+    while (cur) {
+        auto par = VisualTreeHelper::GetParent(cur);
+        if (!par) break;
+        if (auto g = par.try_as<Grid>()) last = g;
+        cur = par;
+    }
+    return last;
+}
+
+static Grid FindTaskbarRootGrid(FrameworkElement const& root) {
+    FrameworkElement taskbarFrame = nullptr;
+    int count = VisualTreeHelper::GetChildrenCount(root);
+
+    for (int i = 0; i < count; i++) {
+        auto c = VisualTreeHelper::GetChild(root, i).try_as<FrameworkElement>();
+        if (c) {
+            auto className = winrt::get_class_name(c);
+            if (className == L"Taskbar.TaskbarFrame") {
+                taskbarFrame = c;
+                break;
+            }
+        }
+    }
+
+    if (!taskbarFrame) {
+        return nullptr;
+    }
+
+    auto rootGrid = FindChildByName(taskbarFrame, L"RootGrid");
+
+    return rootGrid ? rootGrid.try_as<Grid>() : nullptr;
+}
+
+static FrameworkElement FindElementInRepeater(FrameworkElement const& repeater, const wchar_t* const* names, int nameCount) {
+    if (!repeater) return nullptr;
+
+    int childCount = VisualTreeHelper::GetChildrenCount(repeater);
+    for (int i = 0; i < childCount; i++) {
+        auto child = VisualTreeHelper::GetChild(repeater, i).try_as<FrameworkElement>();
+        if (!child) continue;
+
+        for (int j = 0; j < nameCount; j++) {
+            if (child.Name() == names[j]) return child;
+        }
+    }
+
+    for (int i = 0; i < childCount; i++) {
+        auto child = VisualTreeHelper::GetChild(repeater, i).try_as<FrameworkElement>();
+        if (!child) continue;
+
+        int subChildCount = VisualTreeHelper::GetChildrenCount(child);
+        for (int k = 0; k < subChildCount; k++) {
+            auto subChild = VisualTreeHelper::GetChild(child, k).try_as<FrameworkElement>();
+            if (!subChild) continue;
+
+            for (int j = 0; j < nameCount; j++) {
+                if (subChild.Name() == names[j]) return subChild;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+static FrameworkElement FindElementByClassName(FrameworkElement const& parent, const wchar_t* className) {
+    if (!parent) return nullptr;
+
+    int childCount = VisualTreeHelper::GetChildrenCount(parent);
+    for (int i = 0; i < childCount; i++) {
+        auto child = VisualTreeHelper::GetChild(parent, i).try_as<FrameworkElement>();
+        if (!child) continue;
+
+        auto childClassName = winrt::get_class_name(child);
+        if (childClassName == className) return child;
+    }
+
+    return nullptr;
+}
+
+static FrameworkElement FindNthElementByClassName(FrameworkElement const& parent, const wchar_t* className, int index) {
+    if (!parent) return nullptr;
+
+    int foundCount = 0;
+    int childCount = VisualTreeHelper::GetChildrenCount(parent);
+
+    for (int i = 0; i < childCount; i++) {
+        auto child = VisualTreeHelper::GetChild(parent, i).try_as<FrameworkElement>();
+        if (!child) continue;
+
+        auto childClassName = winrt::get_class_name(child);
+        if (childClassName == className) {
+            if (foundCount == index) return child;
+            foundCount++;
+        }
+    }
+
+    return nullptr;
+}
+
+static FrameworkElement FindFirstElementByClassName(FrameworkElement const& parent, const wchar_t* className) {
+    if (!parent) return nullptr;
+
+    int childCount = VisualTreeHelper::GetChildrenCount(parent);
+
+    for (int i = 0; i < childCount; i++) {
+        auto child = VisualTreeHelper::GetChild(parent, i).try_as<FrameworkElement>();
+        if (!child) continue;
+
+        auto childClassName = winrt::get_class_name(child);
+
+        if (childClassName == className) {
+            return child;
+        }
+    }
+
+    return nullptr;
+}
+
+static FrameworkElement FindLastElementByClassName(FrameworkElement const& parent, const wchar_t* className) {
+    if (!parent) return nullptr;
+
+    FrameworkElement lastFound = nullptr;
+    int childCount = VisualTreeHelper::GetChildrenCount(parent);
+
+    for (int i = 0; i < childCount; i++) {
+        auto child = VisualTreeHelper::GetChild(parent, i).try_as<FrameworkElement>();
+        if (!child) continue;
+
+        auto childClassName = winrt::get_class_name(child);
+
+        if (childClassName == className) {
+            lastFound = child;
+        }
+    }
+
+    return lastFound;
+}
+
+static FrameworkElement FindChildByClassName(FrameworkElement const& parent, const wchar_t* className, int depth = 32) {
+    if (!parent || depth <= 0) return nullptr;
+
+    int childCount = VisualTreeHelper::GetChildrenCount(parent);
+    for (int i = 0; i < childCount; i++) {
+        auto child = VisualTreeHelper::GetChild(parent, i).try_as<FrameworkElement>();
+        if (!child) continue;
+
+        if (winrt::get_class_name(child) == className) return child;
+        if (auto found = FindChildByClassName(child, className, depth - 1)) return found;
+    }
+
+    return nullptr;
+}
+
+static double FindLeftmostVisibleChildX(FrameworkElement const& parent, UIElement const& relativeTo, int depth = 3) {
+    if (!parent || !relativeTo || depth < 0) return -1.0;
+
+    double leftmost = -1.0;
+    int childCount = VisualTreeHelper::GetChildrenCount(parent);
+    for (int i = 0; i < childCount; i++) {
+        auto child = VisualTreeHelper::GetChild(parent, i).try_as<FrameworkElement>();
+        if (!child) continue;
+
+        try {
+            if (child.Visibility() == Visibility::Visible && child.ActualWidth() > 1.0) {
+                auto transform = child.TransformToVisual(relativeTo);
+                auto point = transform.TransformPoint({0, 0});
+                if (point.X >= 0.0 && (leftmost < 0.0 || point.X < leftmost))
+                    leftmost = point.X;
+            }
+        } catch (...) {}
+
+        double nested = FindLeftmostVisibleChildX(child, relativeTo, depth - 1);
+        if (nested >= 0.0 && (leftmost < 0.0 || nested < leftmost))
+            leftmost = nested;
+    }
+
+    return leftmost;
+}
+
+static FrameworkElement FindTrayElement(FrameworkElement const& trayGrid, FrameworkElement const& root, const wchar_t* name) {
+    auto elem = FindChildByName(trayGrid, name);
+    if (!elem) elem = FindChildByName(root, name);
+    return elem;
+}
+
+static bool IsStartButtonModActive(FrameworkElement const& root) {
+    try {
+        auto rootGrid = FindTaskbarRootGrid(root);
+        if (!rootGrid) return false;
+
+        auto repeater = FindChildByName(rootGrid, L"TaskbarFrameRepeater");
+        if (!repeater) return false;
+
+        static const wchar_t* kStartNames[] = {L"StartButton"};
+        auto startButton = FindElementInRepeater(repeater, kStartNames, 1);
+        if (!startButton) return false;
+
+        auto margin = startButton.Margin();
+        return margin.Right < -10.0;
+    } catch (...) {
+        return false;
+    }
+}
+
+static double GetStartButtonAdjustment(FrameworkElement const& root) {
+    try {
+        auto rootGrid = FindTaskbarRootGrid(root);
+        if (!rootGrid) return 0.0;
+
+        auto repeater = FindChildByName(rootGrid, L"TaskbarFrameRepeater");
+        if (!repeater) return 0.0;
+
+        static const wchar_t* kStartNames[] = {L"StartButton"};
+        auto startButton = FindElementInRepeater(repeater, kStartNames, 1);
+        if (!startButton) return 0.0;
+
+        return startButton.ActualWidth();
+    } catch (...) {
+        return 0.0;
+    }
+}
+
+static InjectionTarget ResolveInjectionTarget(
+    FrameworkElement const& root,
+    std::wstring_view position)
+{
+    auto trayFrame = FindChildByName(root, L"SystemTrayFrameGrid");
+    if (auto trayGrid = trayFrame ? trayFrame.try_as<Grid>() : nullptr) {
+
+        int col = -1;
+        if      (position == L"tray_right")
+            col = (int)trayGrid.ColumnDefinitions().Size();
+        else if (position == L"tray_left")
+            col = 0;
+        else if (position == L"tray_before_clock") {
+            auto clockBtn = FindChildByName(trayGrid, L"NotificationCenterButton");
+            if (!clockBtn) clockBtn = FindChildByName(root, L"NotificationCenterButton");
+            col = clockBtn ? Grid::GetColumn(clockBtn) : -1;
+        }
+        else if (position == L"tray_after_clock") {
+            auto showDesktop = FindChildByName(trayGrid, L"ShowDesktopStack");
+            if (!showDesktop) showDesktop = FindChildByName(root, L"ShowDesktopStack");
+            col = showDesktop ? Grid::GetColumn(showDesktop) : -1;
+        }
+        else if (position == L"tray_before_omni_left") {
+            auto omniBtn = FindChildByName(trayGrid, L"ControlCenterButton");
+            if (!omniBtn) omniBtn = FindChildByName(root, L"ControlCenterButton");
+            col = omniBtn ? Grid::GetColumn(omniBtn) : -1;
+        }
+        else if (position == L"tray_before_omni_right") {
+            auto omniBtn = FindChildByName(trayGrid, L"ControlCenterButton");
+            if (!omniBtn) omniBtn = FindChildByName(root, L"ControlCenterButton");
+            if (omniBtn) col = Grid::GetColumn(omniBtn) + 1;
+            else col = -1;
+        }
+        else if (position == L"tray_language_left") {
+            auto languageBtn = FindTrayElement(trayGrid, root, L"NonActivatableStack");
+            col = languageBtn ? Grid::GetColumn(languageBtn) : -1;
+        }
+        else if (position == L"tray_language_right") {
+            auto languageBtn = FindTrayElement(trayGrid, root, L"NonActivatableStack");
+            col = languageBtn ? Grid::GetColumn(languageBtn) + 1 : -1;
+        }
+        else if (position == L"tray_hidden_icons_left") {
+            auto hiddenIconsBtn = FindTrayElement(trayGrid, root, L"NotifyIconStack");
+            col = hiddenIconsBtn ? Grid::GetColumn(hiddenIconsBtn) : -1;
+        }
+        else if (position == L"tray_hidden_icons_right") {
+            auto hiddenIconsBtn = FindTrayElement(trayGrid, root, L"NotifyIconStack");
+            col = hiddenIconsBtn ? Grid::GetColumn(hiddenIconsBtn) + 1 : -1;
+        }
+        else if (position == L"tray_icons_left") {
+            auto trayIcons = FindTrayElement(trayGrid, root, L"NotificationAreaIcons");
+            col = trayIcons ? Grid::GetColumn(trayIcons) : -1;
+        }
+        else if (position == L"tray_icons_right") {
+            auto trayIcons = FindTrayElement(trayGrid, root, L"NotificationAreaIcons");
+            col = trayIcons ? Grid::GetColumn(trayIcons) + 1 : -1;
+        }
+        else if (position == L"tray_after_showdesktop_left") {
+            auto showDesktop = FindChildByName(trayGrid, L"ShowDesktopStack");
+            if (!showDesktop) showDesktop = FindChildByName(root, L"ShowDesktopStack");
+            col = showDesktop ? Grid::GetColumn(showDesktop) : -1;
+        }
+        else if (position == L"tray_after_showdesktop_right") {
+            auto showDesktop = FindChildByName(trayGrid, L"ShowDesktopStack");
+            if (!showDesktop) showDesktop = FindChildByName(root, L"ShowDesktopStack");
+            if (showDesktop) col = Grid::GetColumn(showDesktop) + 1;
+            else col = (int)trayGrid.ColumnDefinitions().Size();
+        }
+
+        if (col >= 0) {
+            return {trayGrid, col};
+        }
+    }
+
+    if (position == L"taskbar_left_start"  ||
+        position == L"taskbar_right_start" ||
+        position == L"taskbar_after_search_left"||
+        position == L"taskbar_after_search_right"||
+        position == L"taskbar_after_taskview_left"||
+        position == L"taskbar_after_taskview_right"||
+        position == L"taskbar_after_widgets_left"||
+        position == L"taskbar_after_widgets_right"||
+        position == L"taskbar_far_edge_left" ||
+        position == L"taskbar_left_edge"   ||
+        position == L"taskbar_center_edge" ||
+        position == L"taskbar_right_edge")
+    {
+        auto rootGrid = FindTaskbarRootGrid(root);
+        if (!rootGrid) {
+            auto tf2 = FindChildByName(root, L"SystemTrayFrameGrid");
+            if (auto tg2 = tf2 ? tf2.try_as<Grid>() : nullptr)
+                return {tg2, (int)tg2.ColumnDefinitions().Size()};
+            return {};
+        }
+
+        return {rootGrid, -1};
+    }
+
+    return {};
+}
+
+static bool InjectPlayerGrid() {
+    Wh_Log(L"InjectPlayerGrid: Starting");
+    HWND hWnd = g_taskbarWnd ? g_taskbarWnd : FindCurrentProcessTaskbarWnd();
+    if (!hWnd) {
+        Wh_Log(L"InjectPlayerGrid: No taskbar window found");
+        return false;
+    }
+    g_taskbarWnd = hWnd;
+
+    try {
+        auto xamlRoot = GetTaskbarXamlRoot(hWnd);
+        if (!xamlRoot) {
+            Wh_Log(L"InjectPlayerGrid: Failed to get XAML root");
+            return false;
+        }
+
+        auto root = xamlRoot.Content().try_as<FrameworkElement>();
+        if (!root) {
+            Wh_Log(L"InjectPlayerGrid: Failed to get root FrameworkElement");
+            return false;
+        }
+
+        Wh_Log(L"InjectPlayerGrid: Got XAML root and framework element");
+
+        if (g_settings.enableTreeDump) {
+            DumpXamlTree(root, 0, 5);
+            auto rootGrid = FindTaskbarRootGrid(root);
+            if (rootGrid) {
+                auto repeater = FindChildByName(rootGrid, L"TaskbarFrameRepeater");
+                if (repeater) {
+                    DumpXamlTree(repeater, 0, 3);
+                }
+            }
+        }
+
+        auto [targetGrid, insertCol] = ResolveInjectionTarget(root, g_settings.position);
+
+        if (!targetGrid) {
+            if (g_settings.enableTreeDump) {
+                DumpXamlTree(root, 0, 8);
+            }
+            return false;
+        }
+
+        Grid playerGrid = BuildPlayerGrid();
+        if (!playerGrid) return false;
+
+        bool startButtonModActive = IsStartButtonModActive(root);
+        (void)startButtonModActive;
+
+        bool isTrayGrid = (targetGrid.Name() == L"SystemTrayFrameGrid");
+        RemovePlayerGridChildren(targetGrid);
+        RemoveAnchorDebugOverlays(targetGrid);
+
+        if (isTrayGrid) {
+            ColumnDefinition newCol;
+            newCol.Width({1.0, GridUnitType::Auto});
+
+            if (insertCol >= (int)targetGrid.ColumnDefinitions().Size()) {
+                targetGrid.ColumnDefinitions().Append(newCol);
+            } else {
+                targetGrid.ColumnDefinitions().InsertAt(insertCol, newCol);
+                for (uint32_t i = 0; i < targetGrid.Children().Size(); ++i) {
+                    auto child = targetGrid.Children().GetAt(i).try_as<FrameworkElement>();
+                    if (child) {
+                        int childCol = Grid::GetColumn(child);
+                        if (childCol >= insertCol)
+                            Grid::SetColumn(child, childCol + 1);
+                    }
+                }
+            }
+
+            playerGrid.Margin({(double)g_settings.playerMarginLeft, 0,
+                              (double)g_settings.playerMarginRight, 0});
+            Grid::SetColumn(playerGrid, insertCol);
+            targetGrid.Children().Append(playerGrid);
+            g_playerColumn = insertCol;
+
+        }
+        else {
+            auto repeater  = FindChildByName(targetGrid, L"TaskbarFrameRepeater");
+            auto trayFrame = FindChildByName(targetGrid, L"SystemTrayFrameGrid");
+
+            bool isEdgePosition = (g_settings.position == L"taskbar_left_edge" ||
+                                   g_settings.position == L"taskbar_center_edge" ||
+                                   g_settings.position == L"taskbar_right_edge");
+
+            bool isTrackingPosition = (g_settings.position == L"taskbar_left_start" ||
+                                       g_settings.position == L"taskbar_right_start" ||
+                                       g_settings.position == L"taskbar_after_search_left" ||
+                                       g_settings.position == L"taskbar_after_search_right" ||
+                                       g_settings.position == L"taskbar_after_taskview_left" ||
+                                       g_settings.position == L"taskbar_after_taskview_right" ||
+                                       g_settings.position == L"taskbar_after_widgets_left" ||
+                                       g_settings.position == L"taskbar_after_widgets_right" ||
+                                       g_settings.position == L"taskbar_far_edge_left");
+
+            if (isEdgePosition || isTrackingPosition) {
+                double leftMargin  = (double)g_settings.playerMarginLeft;
+                double rightMargin = (double)g_settings.playerMarginRight;
+
+                playerGrid.HorizontalAlignment(HorizontalAlignment::Left);
+
+                if (isEdgePosition) {
+                    if (g_settings.position == L"taskbar_left_edge") {
+                        playerGrid.Margin({leftMargin, 0, rightMargin, 0});
+                    }
+                    else if (g_settings.position == L"taskbar_center_edge") {
+                        playerGrid.HorizontalAlignment(HorizontalAlignment::Center);
+                        playerGrid.Margin({leftMargin, 0, rightMargin, 0});
+                    }
+                    else if (g_settings.position == L"taskbar_right_edge") {
+                        playerGrid.HorizontalAlignment(HorizontalAlignment::Right);
+                        if (trayFrame) rightMargin += trayFrame.ActualWidth() + 4;
+                        playerGrid.Margin({leftMargin, 0, rightMargin, 0});
+                    }
+                } else if (isTrackingPosition) {
+                    FrameworkElement targetElem = nullptr;
+                    std::wstring trackSide = L"right";
+
+                    if (repeater) {
+                        if (g_settings.position == L"taskbar_far_edge_left") {
+                            targetElem = repeater.try_as<FrameworkElement>();
+                            trackSide = L"far_left";
+                        } else if (g_settings.position == L"taskbar_left_start") {
+                            targetElem = FindElementInRepeater(repeater, kStartButtonNames, ARRAYSIZE(kStartButtonNames));
+                            trackSide = L"left";
+                        } else if (g_settings.position == L"taskbar_right_start") {
+                            targetElem = FindElementInRepeater(repeater, kStartButtonNames, ARRAYSIZE(kStartButtonNames));
+                            trackSide = L"right";
+                        } else if (g_settings.position == L"taskbar_after_search_left") {
+                            targetElem = FindElementByClassName(repeater, L"Taskbar.TaskbarExtensionElement");
+                            trackSide = L"left";
+                        } else if (g_settings.position == L"taskbar_after_search_right") {
+                            targetElem = FindElementByClassName(repeater, L"Taskbar.TaskbarExtensionElement");
+                            trackSide = L"right";
+                        } else if (g_settings.position == L"taskbar_after_taskview_left") {
+                            targetElem = FindNthElementByClassName(repeater, L"Taskbar.ExperienceToggleButton", 1);
+                            trackSide = L"left";
+                        } else if (g_settings.position == L"taskbar_after_taskview_right") {
+                            targetElem = FindNthElementByClassName(repeater, L"Taskbar.ExperienceToggleButton", 1);
+                            trackSide = L"right";
+                        } else if (g_settings.position == L"taskbar_after_widgets_left") {
+                            targetElem = FindChildByName(repeater, L"AugmentedEntryPointButton");
+                            if (!targetElem) targetElem = FindChildByClassName(repeater, L"Taskbar.AugmentedEntryPointButton");
+                            trackSide = L"left";
+                        } else if (g_settings.position == L"taskbar_after_widgets_right") {
+                            targetElem = FindChildByName(repeater, L"AugmentedEntryPointButton");
+                            if (!targetElem) targetElem = FindChildByClassName(repeater, L"Taskbar.AugmentedEntryPointButton");
+                            trackSide = L"right";
+                        }
+                    }
+
+                    if (targetElem) {
+                        g_trackedElement = targetElem;
+                        g_trackedElementOriginalMargin = targetElem.Margin();
+                        g_hasTrackedElementOriginalMargin = true;
+                        g_trackPosition = trackSide;
+
+                        bool startButtonModActiveMod = IsStartButtonModActive(root);
+                        double startButtonOffset = 0.0;
+
+                        if (startButtonModActiveMod &&
+                            (g_settings.position == L"taskbar_left_start" ||
+                             g_settings.position == L"taskbar_right_start" ||
+                             g_settings.position == L"taskbar_after_taskview_left" ||
+                             g_settings.position == L"taskbar_after_taskview_right")) {
+                            startButtonOffset = GetStartButtonAdjustment(root);
+                        }
+
+                        g_layoutUpdateToken = targetGrid.LayoutUpdated(
+                            [targetGrid, startButtonModActiveMod, startButtonOffset](winrt::Windows::Foundation::IInspectable const&, winrt::Windows::Foundation::IInspectable const&) {
+                                if (!g_playerGrid || !g_trackedElement || g_unloading) return;
+                                UpdateAnchorDebugOverlay(targetGrid, g_trackedElement);
+
+                                bool isVisible = (g_playerGrid.Visibility() == Visibility::Visible);
+                                double w = isVisible ? g_playerGrid.ActualWidth() : 0.0;
+
+                                double desiredGap = isVisible ? (w + g_settings.playerMarginLeft + g_settings.playerMarginRight) : 0.0;
+                                auto m = g_hasTrackedElementOriginalMargin ? g_trackedElementOriginalMargin : g_trackedElement.Margin();
+                                auto currentMargin = g_trackedElement.Margin();
+                                bool changedMargin = false;
+
+                                if (g_trackPosition == L"far_left") {
+                                    try {
+                                        double originalLeft = g_hasTrackedElementOriginalMargin ? g_trackedElementOriginalMargin.Left : 0.0;
+                                        double currentLeftmost = FindLeftmostVisibleChildX(g_trackedElement, targetGrid, 4);
+                                        double naturalLeft = currentLeftmost >= 0.0
+                                            ? currentLeftmost - (currentMargin.Left - originalLeft)
+                                            : desiredGap;
+                                        double requiredExtra = std::max(0.0, desiredGap - naturalLeft);
+                                        double targetLeft = originalLeft + requiredExtra;
+
+                                        if (std::abs(currentMargin.Left - targetLeft) > 1.0 ||
+                                            std::abs(currentMargin.Right - m.Right) > 1.0) {
+                                            m.Left = targetLeft;
+                                            changedMargin = true;
+                                        }
+                                    } catch (...) {
+                                        if (g_hasTrackedElementOriginalMargin &&
+                                            (std::abs(currentMargin.Left - m.Left) > 1.0 ||
+                                             std::abs(currentMargin.Right - m.Right) > 1.0)) {
+                                            changedMargin = true;
+                                        }
+                                    }
+                                } else if (g_trackPosition == L"left") {
+                                    if (std::abs(currentMargin.Left - desiredGap) > 1.0) { m.Left = desiredGap; changedMargin = true; }
+                                } else {
+                                    if (std::abs(currentMargin.Right - desiredGap) > 1.0) { m.Right = desiredGap; changedMargin = true; }
+                                }
+
+                                if (changedMargin) g_trackedElement.Margin(m);
+
+                                if (isVisible) {
+                                    try {
+                                        auto transform = g_trackedElement.TransformToVisual(targetGrid);
+                                        auto point = transform.TransformPoint({0, 0});
+                                        double leftPos = point.X;
+
+                                        if (g_trackPosition == L"far_left") {
+                                            leftPos = g_settings.playerMarginLeft;
+                                        } else if (g_trackPosition == L"left") {
+                                            leftPos = point.X - desiredGap + g_settings.playerMarginLeft;
+                                            if (startButtonModActiveMod && startButtonOffset > 0) {
+                                                leftPos += startButtonOffset;
+                                            }
+                                        } else {
+                                            leftPos = point.X + g_trackedElement.ActualWidth() + g_settings.playerMarginLeft;
+                                        }
+
+                                        auto pm = g_playerGrid.Margin();
+                                        if (std::abs(pm.Left - leftPos) > 1.0) {
+                                            g_playerGrid.Margin({leftPos, 0, 0, 0});
+                                        }
+                                    } catch (...) {}
+                                }
+                            }
+                        );
+                    } else {
+                        playerGrid.Margin({leftMargin, 0, rightMargin, 0});
+                    }
+                }
+
+                Grid::SetColumn(playerGrid, 0);
+                Canvas::SetZIndex(playerGrid, 1000);
+                targetGrid.Children().Append(playerGrid);
+                g_playerColumn = -1;
+                Wh_Log(L"InjectPlayerGrid: Added player to targetGrid.Children (edge/tracking position), column=0, zindex=1000");
+            }
+            else {
+                ColumnDefinition newCol;
+                newCol.Width({1.0, GridUnitType::Auto});
+
+                if (insertCol >= (int)targetGrid.ColumnDefinitions().Size()) {
+                    targetGrid.ColumnDefinitions().Append(newCol);
+                } else {
+                    targetGrid.ColumnDefinitions().InsertAt(insertCol, newCol);
+                    for (uint32_t i = 0; i < targetGrid.Children().Size(); ++i) {
+                        auto child = targetGrid.Children().GetAt(i).try_as<FrameworkElement>();
+                        if (child) {
+                            int childCol = Grid::GetColumn(child);
+                            if (childCol >= insertCol)
+                                Grid::SetColumn(child, childCol + 1);
+                        }
+                    }
+                }
+
+                playerGrid.Margin({(double)g_settings.playerMarginLeft, 0,
+                                  (double)g_settings.playerMarginRight, 0});
+                Grid::SetColumn(playerGrid, insertCol);
+                targetGrid.Children().Append(playerGrid);
+                g_playerColumn = insertCol;
+            }
+        }
+
+        g_playerGrid      = playerGrid;
+        g_injectionParent = targetGrid;
+
+        RefreshPlayerContents();
+
+        g_playerGrid.Visibility(Visibility::Visible);
+        Wh_Log(L"InjectPlayerGrid: Set g_playerGrid.Visibility to Visible");
+        g_playerGrid.UpdateLayout();
+
+        Wh_Log(L"InjectPlayerGrid: Player size - ActualWidth=%f, ActualHeight=%f, Width=%f, Height=%f",
+               g_playerGrid.ActualWidth(), g_playerGrid.ActualHeight(),
+               g_playerGrid.Width(), g_playerGrid.Height());
+        auto margin = g_playerGrid.Margin();
+        Wh_Log(L"InjectPlayerGrid: Player margin - Left=%f, Top=%f, Right=%f, Bottom=%f",
+               margin.Left, margin.Top, margin.Right, margin.Bottom);
+
+        if (g_injectionParent) {
+            g_injectionParent.UpdateLayout();
+            Wh_Log(L"InjectPlayerGrid: Called UpdateLayout on injectionParent");
+            Wh_Log(L"InjectPlayerGrid: UpdateLayout completed successfully");
+        }
+
+        RefreshThemeColors();
+
+        auto dispatcher = g_playerGrid.Dispatcher();
+        if (dispatcher) {
+            std::thread([dispatcher]() {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                try {
+                    dispatcher.RunAsync(winrt::Windows::UI::Core::CoreDispatcherPriority::Normal, [=]() {
+                        RefreshThemeColors();
+                    });
+                } catch (...) {}
+            }).detach();
+        }
+
+        Canvas::SetZIndex(g_playerGrid, 1000);
+        bool needsExtraUpdates = (g_settings.position == L"taskbar_left_start" ||
+                                  g_settings.position == L"taskbar_right_start" ||
+                                  g_settings.position == L"taskbar_after_search_left" ||
+                                  g_settings.position == L"taskbar_after_search_right" ||
+                                  g_settings.position == L"taskbar_after_taskview_left" ||
+                                  g_settings.position == L"taskbar_after_taskview_right" ||
+                                  g_settings.position == L"taskbar_after_widgets_left" ||
+                                  g_settings.position == L"taskbar_after_widgets_right" ||
+                                  g_settings.position == L"taskbar_far_edge_left");
+
+        std::thread([playerGrid, targetGrid, needsExtraUpdates]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            if (g_unloading) return;
+            try {
+                RunFromWindowThread(g_taskbarWnd, [](void* param) {
+                    if (g_unloading) return;
+                    try {
+                        if (g_playerGrid && g_injectionParent) {
+                            g_playerGrid.UpdateLayout();
+                            g_injectionParent.UpdateLayout();
+                            g_playerGrid.InvalidateArrange();
+                            g_injectionParent.InvalidateArrange();
+                        }
+                    } catch (...) {}
+                }, nullptr);
+            } catch (...) {}
+
+            if (needsExtraUpdates) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                if (g_unloading) return;
+                try {
+                    RunFromWindowThread(g_taskbarWnd, [](void* param) {
+                        if (g_unloading) return;
+                        try {
+                            if (g_playerGrid && g_injectionParent) {
+                                g_playerGrid.UpdateLayout();
+                                g_injectionParent.UpdateLayout();
+                                g_playerGrid.InvalidateArrange();
+                                g_injectionParent.InvalidateArrange();
+                            }
+                        } catch (...) {}
+                    }, nullptr);
+                } catch (...) {}
+
+                std::this_thread::sleep_for(std::chrono::milliseconds(300));
+                if (g_unloading) return;
+                try {
+                    RunFromWindowThread(g_taskbarWnd, [](void* param) {
+                        if (g_unloading) return;
+                        try {
+                            if (g_playerGrid && g_injectionParent) {
+                                g_playerGrid.UpdateLayout();
+                                g_injectionParent.UpdateLayout();
+                                g_playerGrid.InvalidateArrange();
+                                g_injectionParent.InvalidateArrange();
+                            }
+                        } catch (...) {}
+                    }, nullptr);
+                } catch (...) {}
+            }
+        }).detach();
+
+        OnSessionsChanged();
+        g_needsUiUpdate = true;
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+static void RemovePlayerGrid() {
+    static std::atomic<bool> s_removing{false};
+
+    if (s_removing.exchange(true)) {
+        Wh_Log(L"RemovePlayerGrid: Already removing, skipping");
+        return;
+    }
+
+    struct Guard {
+        ~Guard() { s_removing = false; }
+    } guard;
+
+    if (!g_injectionParent) {
+        Wh_Log(L"RemovePlayerGrid: No injection parent");
+        return;
+    }
+
+    Wh_Log(L"RemovePlayerGrid: Starting cleanup");
+
+    try {
+        if (g_layoutUpdateToken.value) {
+            auto targetGrid = g_injectionParent.try_as<Grid>();
+            if (targetGrid) {
+                try { targetGrid.LayoutUpdated(g_layoutUpdateToken); } catch (...) {}
+            }
+            g_layoutUpdateToken = {};
+        }
+
+        if (g_trackedElement) {
+            try {
+                if (g_hasTrackedElementOriginalMargin) {
+                    g_trackedElement.Margin(g_trackedElementOriginalMargin);
+                } else {
+                    auto m = g_trackedElement.Margin();
+                    if (g_trackPosition == L"left" || g_trackPosition == L"far_left") m.Left = 0;
+                    if (g_trackPosition == L"right") m.Right = 0;
+                    g_trackedElement.Margin(m);
+                }
+            } catch (...) {}
+            g_trackedElement = nullptr;
+        }
+        g_hasTrackedElementOriginalMargin = false;
+        g_trackPosition = L"";
+
+        auto targetGrid = g_injectionParent.try_as<Grid>();
+        int playerCol = -1;
+
+        RemoveAnchorDebugOverlays(targetGrid);
+        playerCol = RemovePlayerGridChildren(targetGrid);
+
+        bool isTrackingPosition = (g_settings.position == L"taskbar_left_edge" ||
+                                  g_settings.position == L"taskbar_center_edge" ||
+                                  g_settings.position == L"taskbar_right_edge" ||
+                                  g_settings.position == L"taskbar_left_start" ||
+                                  g_settings.position == L"taskbar_right_start" ||
+                                  g_settings.position == L"taskbar_after_search_left" ||
+                                  g_settings.position == L"taskbar_after_search_right" ||
+                                  g_settings.position == L"taskbar_after_taskview_left" ||
+                                  g_settings.position == L"taskbar_after_taskview_right" ||
+                                  g_settings.position == L"taskbar_after_widgets_left" ||
+                                  g_settings.position == L"taskbar_after_widgets_right" ||
+                                  g_settings.position == L"taskbar_far_edge_left");
+
+        if (!isTrackingPosition && playerCol >= 0 && playerCol < (int)targetGrid.ColumnDefinitions().Size()) {
+            for (uint32_t i = 0; i < targetGrid.Children().Size(); ++i) {
+                auto child = targetGrid.Children().GetAt(i).try_as<FrameworkElement>();
+                if (child) {
+                    int childCol = Grid::GetColumn(child);
+                    if (childCol > playerCol)
+                        Grid::SetColumn(child, childCol - 1);
+
+                }
+            }
+            targetGrid.ColumnDefinitions().RemoveAt(playerCol);
+        }
+
+        g_playerGrid      = nullptr;
+        g_injectionParent = nullptr;
+        g_playerColumn    = -1;
+
+        g_cachedAlbumTitle.clear();
+        g_cachedAlbumArtist.clear();
+        g_cachedThumbnailBytes.clear();
+        g_blurBgCache.Invalidate();
+        g_cachedAppIconSize = -1;
+
+        Wh_Log(L"RemovePlayerGrid: Cleanup completed successfully");
+    } catch (...) {
+        Wh_Log(L"RemovePlayerGrid: Exception during cleanup");
+        g_playerGrid      = nullptr;
+        g_injectionParent = nullptr;
+        g_playerColumn    = -1;
+
+        g_cachedAlbumTitle.clear();
+        g_cachedAlbumArtist.clear();
+        g_cachedThumbnailBytes.clear();
+        g_blurBgCache.Invalidate();
+        g_cachedAppIconSize = -1;
+    }
+}
+
+static thread_local bool g_inRefreshPlayerContents = false;
+
+static void RefreshPlayerContents() {
+    if (!g_playerGrid || g_unloading || g_applyingSettings) return;
+    if (g_inRefreshPlayerContents) return;
+    g_inRefreshPlayerContents = true;
+    struct Guard { ~Guard() { g_inRefreshPlayerContents = false; } } guard;
+
+    Wh_Log(L"RefreshPlayerContents: Starting");
+
+    try {
+        auto dispatcher = g_playerGrid.Dispatcher();
+        if (!dispatcher) {
+            Wh_Log(L"RefreshPlayerContents: No dispatcher");
+            g_playerGrid = nullptr;
+            g_injectionParent = nullptr;
+            if (g_taskbarWnd) {
+                StopRetryThread();
+                StartRetryThread();
+            }
+            return;
+        }
+    } catch (...) {
+        Wh_Log(L"RefreshPlayerContents: Exception getting dispatcher");
+        g_playerGrid = nullptr;
+        g_injectionParent = nullptr;
+        if (g_taskbarWnd) {
+            StopRetryThread();
+            StartRetryThread();
+        }
+        return;
+    }
+
+    std::wstring      title, artist;
+    bool              isPlaying = false, hasMedia = false;
+    std::vector<BYTE> thumbBytes;
+    std::vector<BYTE> appIconBytes;
+    {
+        std::lock_guard<std::mutex> lk(g_mediaMtx);
+        title        = g_media.title;
+        artist       = g_media.artist;
+        isPlaying    = g_media.isPlaying;
+        hasMedia     = g_media.hasMedia;
+        thumbBytes   = g_media.thumbnailBytes;
+        appIconBytes = g_media.appIconBytes;
+    }
+    Wh_Log(L"RefreshPlayerContents: title='%s', artist='%s', isPlaying=%d, hasMedia=%d",
+           title.c_str(), artist.c_str(), isPlaying, hasMedia);
+    (void)hasMedia;
+    bool hasSession = false;
+    { std::lock_guard<std::mutex> lk(g_sessionMtx); hasSession = (g_currentSession != nullptr); }
+
+    if (auto fe = FindChildByName(g_playerGrid, kTitleBlockName))
+        if (auto tb = fe.try_as<TextBlock>())
+            try {
+                tb.Text(winrt::hstring(title));
+                tb.Foreground(MakeBrush(TextColor()));
+                bool visible = g_settings.showTrackTitle && (!title.empty() || hasSession);
+                tb.Visibility(visible ? Visibility::Visible : Visibility::Collapsed);
+
+                if (g_settings.showFullTitleOnHover && !title.empty()) {
+                    ToolTipService::SetToolTip(tb, winrt::box_value(winrt::hstring(title)));
+                    ToolTipService::SetPlacement(tb, Controls::Primitives::PlacementMode::Top);
+                } else {
+                    ToolTipService::SetToolTip(tb, nullptr);
+                }
+            } catch (...) {}
+
+    if (auto fe = FindChildByName(g_playerGrid, kArtistBlockName))
+        if (auto ab = fe.try_as<TextBlock>())
+            try {
+                ab.Text(winrt::hstring(artist));
+                bool visible = g_settings.showTrackArtist && !artist.empty();
+                ab.Visibility(visible ? Visibility::Visible : Visibility::Collapsed);
+                ab.Foreground(MakeBrush(ArtistColor()));
+
+                if (g_settings.showFullTitleOnHover && !artist.empty()) {
+                    ToolTipService::SetToolTip(ab, winrt::box_value(winrt::hstring(artist)));
+                    ToolTipService::SetPlacement(ab, Controls::Primitives::PlacementMode::Top);
+                } else {
+                    ToolTipService::SetToolTip(ab, nullptr);
+                }
+            } catch (...) {}
+
+    if (auto fe = FindChildByName(g_playerGrid, kPlayBtnName))
+        if (auto btn = fe.try_as<Button>())
+            try {
+                if (auto ct = btn.Content().try_as<TextBlock>()) {
+                    const wchar_t* glyph = GetGlyph(2, isPlaying);
+                    ct.Text(winrt::hstring(glyph));
+                    ct.Foreground(MakeBrush(ButtonColor()));
+                }
+            } catch (...) {}
+
+    if (auto fe = FindChildByName(g_playerGrid, kPrevBtnName))
+        if (auto btn = fe.try_as<Button>())
+            try {
+                if (auto ct = btn.Content().try_as<TextBlock>()) {
+                    const wchar_t* glyph = GetGlyph(1);
+                    ct.Text(winrt::hstring(glyph));
+                    ct.Foreground(MakeBrush(ButtonColor()));
+                }
+                ApplyMediaButtonCapability(btn, g_capCanSkipPrev.load());
+            } catch (...) {}
+
+    if (auto fe = FindChildByName(g_playerGrid, kNextBtnName))
+        if (auto btn = fe.try_as<Button>())
+            try {
+                if (auto ct = btn.Content().try_as<TextBlock>()) {
+                    const wchar_t* glyph = GetGlyph(3);
+                    ct.Text(winrt::hstring(glyph));
+                    ct.Foreground(MakeBrush(ButtonColor()));
+                }
+                ApplyMediaButtonCapability(btn, g_capCanSkipNext.load());
+            } catch (...) {}
+
+    if (auto fe = FindChildByName(g_playerGrid, kRewindBtnName))
+        if (auto btn = fe.try_as<Button>())
+            try {
+                if (auto ct = btn.Content().try_as<TextBlock>()) {
+                    const wchar_t* glyph = GetGlyph(5);
+                    ct.Text(winrt::hstring(glyph));
+                    ct.Foreground(MakeBrush(ButtonColor()));
+                }
+                ApplyMediaButtonCapability(btn, g_capCanSeek.load());
+            } catch (...) {}
+
+    if (auto fe = FindChildByName(g_playerGrid, kForwardBtnName))
+        if (auto btn = fe.try_as<Button>())
+            try {
+                if (auto ct = btn.Content().try_as<TextBlock>()) {
+                    const wchar_t* glyph = GetGlyph(6);
+                    ct.Text(winrt::hstring(glyph));
+                    ct.Foreground(MakeBrush(ButtonColor()));
+                }
+                ApplyMediaButtonCapability(btn, g_capCanSeek.load());
+            } catch (...) {}
+
+    if (auto fe = FindChildByName(g_playerGrid, kShuffleBtnName))
+        if (auto btn = fe.try_as<Button>())
+            try {
+                bool canShuffle = g_capCanShuffle.load();
+                if (auto ct = btn.Content().try_as<TextBlock>()) {
+                    bool isEnabled = g_shuffleEnabled.load();
+                    const wchar_t* glyph = L"";
+                    ct.Text(winrt::hstring(glyph));
+                    ct.Foreground(MakeBrush(ButtonColor()));
+                    ct.Opacity(isEnabled ? 1.0 : 0.4);
+                }
+                ApplyMediaButtonCapability(btn, canShuffle);
+            } catch (...) {}
+
+    if (auto fe = FindChildByName(g_playerGrid, kRepeatBtnName))
+        if (auto btn = fe.try_as<Button>())
+            try {
+                bool canRepeat = g_capCanRepeat.load();
+                if (auto ct = btn.Content().try_as<TextBlock>()) {
+                    RepeatMode mode = g_repeatMode.load();
+                    const wchar_t* glyph;
+                    switch (mode) {
+                        case RepeatMode::Off:
+                            glyph = L"";
+                            break;
+                        case RepeatMode::All:
+                            glyph = L"";
+                            break;
+                        case RepeatMode::One:
+                            glyph = L"";
+                            break;
+                    }
+                    ct.Text(winrt::hstring(glyph));
+                    ct.Foreground(MakeBrush(ButtonColor()));
+                    ct.Opacity(1.0);
+                }
+                ApplyMediaButtonCapability(btn, canRepeat);
+            } catch (...) {}
+
+    if (g_settings.showPauseOverlay && g_settings.showAlbumArt) {
+        if (auto fe = FindChildByName(g_playerGrid, L"PauseIconOverlay"))
+            if (auto overlay = fe.try_as<Border>()) {
+                try {
+                    bool showPause = !isPlaying;
+                    overlay.Visibility(showPause ? Visibility::Visible : Visibility::Collapsed);
+
+                    if (auto pauseIcon = overlay.Child().try_as<TextBlock>()) {
+                        pauseIcon.Text(GetGlyph(2, true));
+                        bool useFluent = (g_settings.iconStyle == L"fluent_outline" || g_settings.iconStyle == L"fluent_filled");
+                        pauseIcon.FontFamily(Media::FontFamily(useFluent ? L"Segoe Fluent Icons" : L"Segoe MDL2 Assets"));
+                    }
+
+                    if (showPause) {
+                        if (auto artImg = FindChildByName(g_playerGrid, kArtImageName)) {
+                            if (auto parent = VisualTreeHelper::GetParent(artImg)) {
+                                if (auto container = parent.try_as<FrameworkElement>()) {
+                                    if (auto grandParent = VisualTreeHelper::GetParent(container)) {
+                                        if (auto artContainer = grandParent.try_as<Grid>()) {
+                                            for (uint32_t i = 0; i < artContainer.Children().Size(); ++i) {
+                                                auto child = artContainer.Children().GetAt(i);
+                                                if (auto border = child.try_as<Border>()) {
+                                                    if (border.Name() == L"EmptyIconBorder") {
+                                                        border.Visibility(Visibility::Collapsed);
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } catch (...) {}
+            }
+    }
+
+    bool paletteChanged = false;
+
+    if (auto fe = FindChildByName(g_playerGrid, kArtImageName))
+        if (auto img = fe.try_as<Controls::Image>()) {
+            if (!thumbBytes.empty() && g_settings.showAlbumArt) {
+                bool isSameAlbum = (!g_cachedThumbnailBytes.empty() &&
+                                   title == g_cachedAlbumTitle &&
+                                   artist == g_cachedAlbumArtist &&
+                                   thumbBytes == g_cachedThumbnailBytes);
+
+                size_t newHash = 0;
+                for (const auto& byte : thumbBytes) {
+                    newHash = newHash * 31 + byte;
+                }
+                if (newHash != g_cachedPaletteHash && newHash != 0) {
+                    g_cachedAlbumPalette = ExtractAlbumPalette(thumbBytes);
+                    g_cachedPaletteHash = newHash;
+                    paletteChanged = true;
+                }
+
+                if (!isSameAlbum) {
+                    try {
+                        auto stream = winrt::Windows::Storage::Streams::InMemoryRandomAccessStream();
+                        DataWriter writer(stream);
+                        writer.WriteBytes(winrt::array_view<const BYTE>(thumbBytes));
+                        auto storeOp = writer.StoreAsync();
+                        if (storeOp.wait_for(std::chrono::milliseconds(100)) == winrt::Windows::Foundation::AsyncStatus::Completed) {
+                            writer.DetachStream();
+                            stream.Seek(0);
+                            BitmapImage bmp;
+                            if (g_settings.albumArtMaxHeight > 0) {
+                                bmp.DecodePixelHeight(g_settings.albumArtMaxHeight);
+                            }
+                            bmp.SetSourceAsync(stream);
+                            img.Source(bmp);
+                            img.Visibility(Visibility::Visible);
+
+                            g_cachedAlbumTitle = title;
+                            g_cachedAlbumArtist = artist;
+                            g_cachedThumbnailBytes = thumbBytes;
+
+                            if (auto parent = VisualTreeHelper::GetParent(img)) {
+                                if (auto container = parent.try_as<FrameworkElement>()) {
+                                    if (auto grandParent = VisualTreeHelper::GetParent(container)) {
+                                        if (auto artContainer = grandParent.try_as<Grid>()) {
+                                            artContainer.Visibility(Visibility::Visible);
+                                            for (uint32_t i = 0; i < artContainer.Children().Size(); ++i) {
+                                                auto child = artContainer.Children().GetAt(i);
+                                                if (auto border = child.try_as<Border>()) {
+                                                    if (border.Name() == L"EmptyIconBorder") {
+                                                        border.Visibility(Visibility::Collapsed);
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } catch (...) { try { img.Source(nullptr); } catch (...) {} }
+                } else {
+                    img.Visibility(Visibility::Visible);
+                    if (auto parent = VisualTreeHelper::GetParent(img)) {
+                        if (auto container = parent.try_as<FrameworkElement>()) {
+                            if (auto grandParent = VisualTreeHelper::GetParent(container)) {
+                                if (auto artContainer = grandParent.try_as<Grid>()) {
+                                    artContainer.Visibility(Visibility::Visible);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (auto bgFe = FindChildByName(g_playerGrid, L"FluentMedia_Background")) {
+                    if (auto bgBorder = bgFe.try_as<Border>()) {
+                        auto& bgType = g_settings.backgroundType;
+
+                        if (bgType == L"album_art_blur") {
+                            try {
+                                g_blurBgCache.Invalidate();
+                                auto applyBlur = [bgBorder, thumbBytesSnap = thumbBytes]() {
+                                    try {
+                                        int w = (int)bgBorder.ActualWidth();
+                                        int h = (int)bgBorder.ActualHeight();
+                                        if (w <= 0 || h <= 0) return;
+                                        g_blurBgCache.Invalidate();
+                                        bgBorder.Background(MakeAlbumBlurBrush(thumbBytesSnap, w, h));
+                                        bgBorder.Opacity(g_settings.blurOpacity / 100.0);
+                                        bgBorder.Visibility(Visibility::Visible);
+                                    } catch (...) {}
+                                };
+                                if (bgBorder.ActualWidth() > 0 && bgBorder.ActualHeight() > 0) {
+                                    applyBlur();
+                                } else {
+                                    auto tokenHolder = std::make_shared<winrt::event_token>();
+                                    *tokenHolder = bgBorder.SizeChanged(
+                                        [applyBlur, bgBorder, tokenHolder](auto const&, auto const&) mutable {
+                                            applyBlur();
+                                            try { bgBorder.SizeChanged(*tokenHolder); } catch (...) {}
+                                        });
+                                }
+                            } catch (...) {}
+                        } else if (bgType == L"solid" || bgType == L"gradient" || bgType == L"acrylic" || bgType == L"mica" || bgType == L"mica_alt") {
+                            try {
+                                bgBorder.Background(MakeBackgroundBrush());
+                                bgBorder.Visibility(Visibility::Visible);
+                                bgBorder.Opacity(1.0);
+                            } catch (...) {}
+                        }
+                    }
+                }
+            } else {
+                g_cachedAlbumTitle.clear();
+                g_cachedAlbumArtist.clear();
+                g_cachedThumbnailBytes.clear();
+                g_blurBgCache.Invalidate();
+
+                if (auto bgFe = FindChildByName(g_playerGrid, L"FluentMedia_Background")) {
+                    if (auto bgBorder = bgFe.try_as<Border>()) {
+                        try {
+                            bgBorder.Background(nullptr);
+                            bgBorder.Visibility(Visibility::Collapsed);
+                        } catch (...) {}
+                    }
+                }
+
+                try {
+                    img.Source(nullptr);
+                    img.Visibility(Visibility::Collapsed);
+
+                    if (g_settings.albumArtEmptyBehavior == L"hide" && thumbBytes.empty()) {
+                        if (auto parent = VisualTreeHelper::GetParent(img)) {
+                            if (auto container = parent.try_as<FrameworkElement>()) {
+                                if (auto grandParent = VisualTreeHelper::GetParent(container)) {
+                                    if (auto artContainer = grandParent.try_as<FrameworkElement>()) {
+                                        artContainer.Visibility(Visibility::Collapsed);
+                                    }
+                                }
+                            }
+                        }
+                    } else if ((g_settings.albumArtEmptyBehavior == L"show_question" ||
+                                g_settings.albumArtEmptyBehavior == L"show_note") && thumbBytes.empty()) {
+                        if (auto parent = VisualTreeHelper::GetParent(img)) {
+                            if (auto container = parent.try_as<FrameworkElement>()) {
+                                if (auto grandParent = VisualTreeHelper::GetParent(container)) {
+                                    if (auto artContainer = grandParent.try_as<Grid>()) {
+                                        artContainer.Visibility(Visibility::Visible);
+
+                                        Border iconBorder = nullptr;
+                                        for (uint32_t i = 0; i < artContainer.Children().Size(); ++i) {
+                                            auto child = artContainer.Children().GetAt(i);
+                                            if (auto border = child.try_as<Border>()) {
+                                                if (border.Name() == L"EmptyIconBorder") {
+                                                    iconBorder = border;
+                                                    break;
+                                                }
+                                            }
+                                        }
+
+                                        if (!iconBorder) {
+                                            double acr = (double)g_settings.albumArtCornerRadius;
+                                            iconBorder = Border();
+                                            iconBorder.Name(L"EmptyIconBorder");
+                                            iconBorder.Background(MakeBrush({0x40, 0x80, 0x80, 0x80}));
+                                            iconBorder.CornerRadius({acr, acr, acr, acr});
+                                            iconBorder.HorizontalAlignment(HorizontalAlignment::Stretch);
+                                            iconBorder.VerticalAlignment(VerticalAlignment::Stretch);
+                                            Canvas::SetZIndex(iconBorder, 5);
+
+                                            TextBlock iconText = TextBlock();
+                                            iconText.Name(L"EmptyIconText");
+                                            bool useFluent = (g_settings.iconStyle == L"fluent_outline" || g_settings.iconStyle == L"fluent_filled");
+                                            iconText.FontFamily(Media::FontFamily(useFluent ? L"Segoe Fluent Icons" : L"Segoe MDL2 Assets"));
+                                            iconText.FontSize(16);
+                                            iconText.Foreground(MakeBrush({0xFF, 0xFF, 0xFF, 0xFF}));
+                                            iconText.HorizontalAlignment(HorizontalAlignment::Center);
+                                            iconText.VerticalAlignment(VerticalAlignment::Center);
+
+                                            iconBorder.Child(iconText);
+                                            artContainer.Children().Append(iconBorder);
+                                        }
+
+                                        if (auto textBlock = iconBorder.Child().try_as<TextBlock>()) {
+                                            if (g_settings.albumArtEmptyBehavior == L"show_question") {
+                                                textBlock.Text(L"?");
+                                                textBlock.FontFamily(Media::FontFamily(L"Segoe UI"));
+                                            } else {
+                                                textBlock.Text(L"");
+                                                textBlock.FontFamily(Media::FontFamily(L"Segoe MDL2 Assets"));
+                                            }
+                                        }
+
+                                        iconBorder.Visibility(Visibility::Visible);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } catch (...) {}
+            }
+        }
+
+    if (paletteChanged) {
+        try {
+            if (g_settings.backgroundType == L"gradient" ||
+                g_settings.backgroundType == L"solid" ||
+                g_settings.backgroundType == L"acrylic" ||
+                g_settings.backgroundType == L"mica" ||
+                g_settings.backgroundType == L"mica_alt") {
+                if (auto bgFe = FindChildByName(g_playerGrid, L"FluentMedia_Background")) {
+                    if (auto bgBorder = bgFe.try_as<Border>()) {
+                        bgBorder.Background(MakeBackgroundBrush());
+                    }
+                }
+            }
+
+            auto textClr = TextColor();
+            auto artistClr = ArtistColor();
+
+            if (auto titleFe = FindChildByName(g_playerGrid, kTitleBlockName)) {
+                if (auto titleBlock = titleFe.try_as<TextBlock>()) {
+                    titleBlock.Foreground(SolidColorBrush(textClr));
+                }
+            }
+
+            if (auto artistFe = FindChildByName(g_playerGrid, kArtistBlockName)) {
+                if (auto artistBlock = artistFe.try_as<TextBlock>()) {
+                    artistBlock.Foreground(SolidColorBrush(artistClr));
+                }
+            }
+
+            auto buttonClr = ButtonColor();
+            for (const auto& btnName : {kPlayBtnName, kPrevBtnName, kNextBtnName,
+                                        kRewindBtnName, kForwardBtnName, kShuffleBtnName, kRepeatBtnName}) {
+                if (auto btnFe = FindChildByName(g_playerGrid, btnName)) {
+                    if (auto btn = btnFe.try_as<Button>()) {
+                        if (auto content = btn.Content()) {
+                            if (auto icon = content.try_as<TextBlock>()) {
+                                icon.Foreground(SolidColorBrush(buttonClr));
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (...) {}
+    }
+
+    if (g_settings.showAppIcon) {
+        if (auto fe = FindChildByName(g_playerGrid, kAppIconImageName))
+            if (auto img = fe.try_as<Controls::Image>()) {
+                bool sizeChanged = (g_cachedAppIconSize != g_settings.appIconSize);
+                if (sizeChanged && !appIconBytes.empty()) {
+                    std::wstring aumid;
+                    {
+                        std::lock_guard<std::mutex> lk(g_mediaMtx);
+                        aumid = g_media.appUserModelId;
+                    }
+                    if (!aumid.empty()) {
+                        appIconBytes = FetchAppIconBytes(aumid, g_settings.appIconSize);
+                        {
+                            std::lock_guard<std::mutex> lk(g_mediaMtx);
+                            g_media.appIconBytes = appIconBytes;
+                        }
+                    }
+                    g_cachedAppIconSize = g_settings.appIconSize;
+                }
+
+                if (!appIconBytes.empty()) {
+                    try {
+                        int iconSz = g_settings.appIconSize;
+                        size_t expectedBytes = (size_t)iconSz * iconSz * 4;
+                        if (appIconBytes.size() != expectedBytes) {
+                            int computed = (int)std::sqrt((double)appIconBytes.size() / 4.0);
+                            if (computed > 0 && (size_t)computed * computed * 4 == appIconBytes.size())
+                                iconSz = computed;
+                        }
+
+                        img.Width(iconSz);
+                        img.Height(iconSz);
+
+                        size_t bytesNeeded = (size_t)iconSz * iconSz * 4;
+                        winrt::Windows::UI::Xaml::Media::Imaging::WriteableBitmap wb(iconSz, iconSz);
+                        auto buf = wb.PixelBuffer();
+
+                        auto bufferByteAccess = buf.as<Windows::Storage::Streams::IBufferByteAccess>();
+                        BYTE* pixels = nullptr;
+                        bufferByteAccess->Buffer(&pixels);
+
+                        if (appIconBytes.size() >= bytesNeeded && pixels) {
+                            for (size_t i = 0; i + 3 < bytesNeeded; i += 4) {
+                                pixels[i+0] = appIconBytes[i+2];
+                                pixels[i+1] = appIconBytes[i+1];
+                                pixels[i+2] = appIconBytes[i+0];
+                                pixels[i+3] = appIconBytes[i+3];
+                            }
+                        }
+                        buf.Length(static_cast<uint32_t>(bytesNeeded));
+                        wb.Invalidate();
+                        img.Source(wb);
+                        img.Visibility(Visibility::Visible);
+                    } catch (...) {
+                        try { img.Source(nullptr); img.Visibility(Visibility::Collapsed); } catch (...) {}
+                    }
+                } else {
+                    try { img.Source(nullptr); img.Visibility(Visibility::Collapsed); } catch (...) {}
+                }
+            }
+    }
+}
+
+static bool IsFullscreenActive() {
+    using Fn = HRESULT(WINAPI*)(int*);
+    static Fn pfn = nullptr; static bool tried = false;
+    if (!tried) {
+        tried = true;
+        HMODULE h = GetModuleHandleW(L"shell32.dll");
+        if (!h) h = LoadLibraryW(L"shell32.dll");
+        if (h) pfn = (Fn)GetProcAddress(h, (LPCSTR)2573);
+    }
+    if (!pfn) return false;
+    int s = 0;
+    return SUCCEEDED(pfn(&s)) && (s == 2 || s == 3 || s == 4);
+}
+
+static void UpdateVisibility() {
+    if (!g_playerGrid || g_unloading || g_applyingSettings) return;
+
+    bool hide = false;
+    if (g_settings.hideFullscreen && IsFullscreenActive()) hide = true;
+
+    if (!hide && g_settings.idleHideSeconds > 0) {
+        bool playing = false;
+        { std::lock_guard<std::mutex> lk(g_mediaMtx); playing = g_media.isPlaying; }
+        if (playing) { g_idleSeconds = 0; g_hiddenByIdle = false; }
+        else if (++g_idleSeconds >= g_settings.idleHideSeconds) g_hiddenByIdle = true;
+        if (g_hiddenByIdle) hide = true;
+    }
+
+    if (!hide) {
+        bool hasMedia = false, hasSession = false;
+        { std::lock_guard<std::mutex> lk(g_mediaMtx); hasMedia = g_media.hasMedia; }
+        { std::lock_guard<std::mutex> lk(g_sessionMtx); hasSession = (g_currentSession != nullptr); }
+        Wh_Log(L"UpdateVisibility: hasMedia=%d, hasSession=%d, hideWhenNoMedia=%d", hasMedia, hasSession, g_settings.hideWhenNoMedia);
+
+        if (hasMedia || hasSession) {
+            g_lastMediaTime = std::chrono::steady_clock::now();
+        }
+
+        if (g_settings.hideWhenNoMedia) {
+
+            if (!hasSession) {
+                hide = true;
+            }
+
+            else if (!hasMedia) {
+                auto now = std::chrono::steady_clock::now();
+                auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - g_lastMediaTime).count();
+
+                if (elapsed > 1000) {
+                    hide = true;
+                }
+            }
+        }
+    }
+
+    Wh_Log(L"UpdateVisibility: Final decision - hide=%d", hide);
+
+    try {
+        Wh_Log(L"UpdateVisibility: g_playerColumn=%d", g_playerColumn);
+        if (g_playerColumn == -1) {
+            if (hide) {
+                g_playerGrid.Visibility(Visibility::Collapsed);
+                Wh_Log(L"UpdateVisibility: Set Visibility to Collapsed (playerColumn=-1)");
+            } else {
+                g_playerGrid.Visibility(Visibility::Visible);
+                Wh_Log(L"UpdateVisibility: Set Visibility to Visible (playerColumn=-1)");
+            }
+        } else {
+            bool isTrackingPosition = (g_settings.position == L"taskbar_left_start" ||
+                                      g_settings.position == L"taskbar_right_start" ||
+                                      g_settings.position == L"taskbar_after_search_left" ||
+                                      g_settings.position == L"taskbar_after_search_right" ||
+                                      g_settings.position == L"taskbar_after_taskview_left" ||
+                                      g_settings.position == L"taskbar_after_taskview_right" ||
+                                      g_settings.position == L"taskbar_after_widgets_left" ||
+                                      g_settings.position == L"taskbar_after_widgets_right" ||
+                                      g_settings.position == L"taskbar_far_edge_left");
+
+            if (hide && isTrackingPosition && g_settings.enableSmoothPositionAnimation) {
+                g_playerGrid.Opacity(0.0);
+
+                std::thread([]() {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                    if (g_unloading) return;
+                    try {
+                        RunFromWindowThread(g_taskbarWnd, [](void* param) {
+                            if (g_unloading) return;
+                            try {
+                                if (g_playerGrid) {
+                                    g_playerGrid.Visibility(Visibility::Collapsed);
+
+                                    if (g_injectionParent) {
+                                        if (auto targetGrid = g_injectionParent.try_as<Grid>()) {
+                                            if (g_playerColumn < (int)targetGrid.ColumnDefinitions().Size()) {
+                                                auto colDef = targetGrid.ColumnDefinitions().GetAt(g_playerColumn);
+                                                colDef.Width({0.0, GridUnitType::Pixel});
+                                            }
+                                        }
+                                    }
+
+                                    g_playerGrid.MinWidth(0);
+                                    g_playerGrid.MaxWidth(0);
+                                    g_playerGrid.Width(0);
+                                }
+                            } catch (...) {}
+                        }, nullptr);
+                    } catch (...) {}
+                }).detach();
+            } else {
+                g_playerGrid.Visibility(hide ? Visibility::Collapsed : Visibility::Visible);
+                g_playerGrid.Opacity(hide ? 0.0 : 1.0);
+                Wh_Log(L"UpdateVisibility: Set Visibility=%d, Opacity=%f", hide ? 0 : 1, hide ? 0.0 : 1.0);
+
+                if (g_injectionParent) {
+                    if (auto targetGrid = g_injectionParent.try_as<Grid>()) {
+                        if (g_playerColumn < (int)targetGrid.ColumnDefinitions().Size()) {
+                            auto colDef = targetGrid.ColumnDefinitions().GetAt(g_playerColumn);
+                            if (hide) {
+                                colDef.Width({0.0, GridUnitType::Pixel});
+                                Wh_Log(L"UpdateVisibility: Set column width to 0");
+                            } else {
+                                colDef.Width({1.0, GridUnitType::Auto});
+                                Wh_Log(L"UpdateVisibility: Set column width to Auto");
+                            }
+                        }
+                    }
+                } else {
+                    Wh_Log(L"UpdateVisibility: g_injectionParent is NULL");
+                }
+
+                if (hide) {
+                    g_playerGrid.MinWidth(0);
+                    g_playerGrid.MaxWidth(0);
+                    g_playerGrid.Width(0);
+                } else {
+                    bool hasTextOrButtons = g_settings.showTrackTitle || g_settings.showTrackArtist || (g_settings.showMediaButtons && !g_mediaButtons.empty());
+                    if (hasTextOrButtons && g_settings.playerMinWidth > 0) {
+                        g_playerGrid.MinWidth((double)g_settings.playerMinWidth);
+                    } else {
+                        g_playerGrid.MinWidth(0);
+                    }
+                    if (g_settings.playerMaxWidth > 0) {
+                        g_playerGrid.MaxWidth((double)g_settings.playerMaxWidth);
+                    } else {
+                        g_playerGrid.ClearValue(FrameworkElement::MaxWidthProperty());
+                    }
+                    g_playerGrid.ClearValue(FrameworkElement::WidthProperty());
+                }
+            }
+        }
+        
+    } catch (...) {}
+}
+
+static void ApplySettings() {
+    Wh_Log(L"ApplySettings: Called");
+    try { RemovePlayerGrid(); } catch (...) { Wh_Log(L"ApplySettings: Exception in RemovePlayerGrid"); }
+    if (!g_unloading) {
+        Wh_Log(L"ApplySettings: Calling InjectPlayerGrid");
+        try { InjectPlayerGrid(); } catch (...) { Wh_Log(L"ApplySettings: Exception in InjectPlayerGrid"); }
+    }
+    Wh_Log(L"ApplySettings: Finished, g_playerGrid exists = %d", g_playerGrid ? 1 : 0);
+}
+
+using IconView_IconView_t = void*(WINAPI*)(void*);
+static IconView_IconView_t IconView_IconView_Original = nullptr;
+
+static void StartRetryThread();
+static void StopRetryThread();
+
+static void* WINAPI IconView_IconView_Hook(void* pThis) {
+    auto r = IconView_IconView_Original(pThis);
+    if (!g_unloading && !g_playerGrid) {
+        HWND hWnd = FindCurrentProcessTaskbarWnd();
+        if (hWnd) {
+            g_taskbarWnd = hWnd;
+            ApplySettings();
+        }
+    }
+    return r;
+}
+
+using LoadLibraryExW_t = HMODULE(WINAPI*)(LPCWSTR, HANDLE, DWORD);
+static LoadLibraryExW_t LoadLibraryExW_Original = nullptr;
+
+static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR path, HANDLE file, DWORD flags) {
+    HMODULE h = LoadLibraryExW_Original(path, file, flags);
+    if (h && path && !g_taskbarViewDllLoaded) {
+        const wchar_t* base = wcsrchr(path, L'\\');
+        base = base ? base + 1 : path;
+        if (_wcsicmp(base, L"Taskbar.View.dll") == 0 ||
+            _wcsicmp(base, L"SystemTray.dll") == 0 ||
+            _wcsicmp(base, L"ExplorerExtensions.dll") == 0) {
+            WindhawkUtils::SYMBOL_HOOK hooks[] = {{
+                {LR"(public: __cdecl winrt::SystemTray::implementation::IconView::IconView(void))"},
+                &IconView_IconView_Original,
+                IconView_IconView_Hook,
+            }};
+            if (WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks))) {
+                g_taskbarViewDllLoaded = true;
+                Wh_ApplyHookOperations();
+            }
+        }
+    }
+    return h;
+}
+
+static bool HookTaskbarDllSymbols() {
+    HMODULE h = LoadLibraryExW(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!h) { return false; }
+
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+        {{LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})"},
+         &CTaskBand_ITaskListWndSite_vftable},
+        {{LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )"},
+         &CTaskBand_GetTaskbarHost_Original},
+        {{LR"(public: int __cdecl TaskbarHost::FrameHeight(void)const )"},
+         &TaskbarHost_FrameHeight_Original},
+        {{LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))"},
+         &Std_Ref_Decref_Original},
+    };
+    bool ok = WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks));
+    return ok;
+}
+
+static bool HookTaskbarViewDllSymbols(HMODULE h) {
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {{
+        {LR"(public: __cdecl winrt::SystemTray::implementation::IconView::IconView(void))"},
+        &IconView_IconView_Original,
+        IconView_IconView_Hook,
+    }};
+    if (!WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks))) {
+        return false;
+    }
+    g_taskbarViewDllLoaded = true;
+    return true;
+}
+
+static HMODULE GetTaskbarViewModule() {
+    for (auto* n : {L"SystemTray.dll", L"Taskbar.View.dll", 
+                    L"taskbar.view.dll", L"ExplorerExtensions.dll",
+                    L"twinui.pcshell.dll"})
+        if (HMODULE h = GetModuleHandleW(n)) return h;
+    return nullptr;
+}
+
+static HANDLE g_retryThread    = nullptr;
+static HANDLE g_retryStopEvent = nullptr;
+
+static void StartRetryThread() {
+    if (g_retryThread) return;
+    g_retryStopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    g_retryThread = CreateThread(nullptr, 0, [](void*) -> DWORD {
+        const DWORD delays[] = {500, 1000, 1500, 2000, 3000, 4000, 5000, 8000, 10000};
+        int attempt = 0;
+        while (!g_unloading) {
+            DWORD delay = (attempt < 9) ? delays[attempt] : 15000;
+            if (WaitForSingleObject(g_retryStopEvent, delay) != WAIT_TIMEOUT) break;
+            if (g_playerGrid || g_unloading) break;
+
+            HWND hWnd = FindCurrentProcessTaskbarWnd();
+            if (hWnd) {
+                g_taskbarWnd = hWnd;
+                RunFromWindowThread(hWnd, [](void*) {
+                    if (!g_playerGrid && !g_unloading) {
+                        ApplySettings();
+                        if (g_playerGrid) {
+                            ShowSuccessNotification();
+                        }
+                    }
+                }, nullptr);
+
+                Sleep(200);
+
+                if (g_playerGrid) break;
+            }
+            ++attempt;
+        }
+        return 0;
+    }, nullptr, 0, nullptr);
+}
+
+static void StopRetryThread() {
+    if (g_retryStopEvent) SetEvent(g_retryStopEvent);
+    if (g_retryThread) { WaitForSingleObject(g_retryThread, 3000); CloseHandle(g_retryThread); g_retryThread = nullptr; }
+    if (g_retryStopEvent) { CloseHandle(g_retryStopEvent); g_retryStopEvent = nullptr; }
+}
+
+BOOL Wh_ModInit() {
+    LoadSettings();
+
+    if (!HookTaskbarDllSymbols()) {
+    }
+
+    if (HMODULE h = GetTaskbarViewModule()) {
+        HookTaskbarViewDllSymbols(h);
+    } else {
+        HMODULE kb = GetModuleHandleW(L"kernelbase.dll");
+        auto pLLEW = kb ? (LoadLibraryExW_t)GetProcAddress(kb, "LoadLibraryExW") : nullptr;
+        if (pLLEW)
+            Wh_SetFunctionHook((void*)pLLEW, (void*)LoadLibraryExW_Hook,
+                               (void**)&LoadLibraryExW_Original);
+    }
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+
+    Wh_Log(L"Wh_ModAfterInit: Starting initialization");
+
+    if (!g_taskbarViewDllLoaded)
+        if (HMODULE h = GetTaskbarViewModule())
+            HookTaskbarViewDllSymbols(h);
+
+    g_taskbarWnd = FindCurrentProcessTaskbarWnd();
+    Wh_Log(L"Wh_ModAfterInit: Taskbar window = %p", g_taskbarWnd);
+
+    StartMediaThread();
+    Wh_Log(L"Wh_ModAfterInit: Media thread started");
+
+    StartTimerThread();
+    Wh_Log(L"Wh_ModAfterInit: Timer thread started");
+
+    StartIdleTimer();
+    StartThemeWatcher();
+
+    if (g_taskbarWnd) {
+        RunFromWindowThread(g_taskbarWnd, [](void*) {
+            Wh_Log(L"Wh_ModAfterInit: Inside window thread callback");
+            ApplySettings();
+            if (g_playerGrid) {
+                Wh_Log(L"Wh_ModAfterInit: Player grid exists, refreshing UI");
+                ShowSuccessNotification();
+                RefreshPlayerContents();
+                UpdateVisibility();
+                g_needsUiUpdate = true;
+                if (g_timerUpdateEvent) {
+                    SetEvent(g_timerUpdateEvent);
+                    Wh_Log(L"Wh_ModAfterInit: Signaled timer update event");
+                }
+            } else {
+                Wh_Log(L"Wh_ModAfterInit: Player grid is NULL after ApplySettings");
+            }
+        }, nullptr);
+    } else {
+        Wh_Log(L"Wh_ModAfterInit: No taskbar window found");
+    }
+
+    StartRetryThread();
+    Wh_Log(L"Wh_ModAfterInit: Retry thread started");
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"Wh_ModUninit: Starting cleanup");
+    g_unloading = true;
+
+    StopRetryThread();
+    Wh_Log(L"Wh_ModUninit: Retry thread stopped");
+
+    StopTimerThread();
+    Wh_Log(L"Wh_ModUninit: Timer thread stopped");
+
+    StopIdleTimer();
+    Wh_Log(L"Wh_ModUninit: Idle timer stopped");
+
+    StopMediaThread();
+    Wh_Log(L"Wh_ModUninit: Media thread stopped");
+
+    StopThemeWatcher();
+    Wh_Log(L"Wh_ModUninit: Theme watcher stopped");
+
+    if (g_taskbarWnd && IsWindow(g_taskbarWnd)) {
+        Wh_Log(L"Wh_ModUninit: Removing player grid");
+        HANDLE hDoneEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        if (hDoneEvent) {
+            struct CleanupData { HANDLE hEvent; };
+            CleanupData* pData = new CleanupData{hDoneEvent};
+
+            bool posted = RunFromWindowThread(g_taskbarWnd, [](void* param) {
+                CleanupData* pData = (CleanupData*)param;
+                try {
+                    RemovePlayerGrid();
+                    Wh_Log(L"Wh_ModUninit: Player grid removed");
+                } catch (...) {
+                    Wh_Log(L"Wh_ModUninit: Exception removing player grid");
+                }
+                SetEvent(pData->hEvent);
+                delete pData;
+            }, pData);
+
+            if (posted) {
+                DWORD waitResult = WaitForSingleObject(hDoneEvent, 3000);
+                if (waitResult == WAIT_TIMEOUT) {
+                    Wh_Log(L"Wh_ModUninit: Timeout waiting for player grid removal");
+                    delete pData;
+                }
+            } else {
+                Wh_Log(L"Wh_ModUninit: Failed to post cleanup to window thread");
+                delete pData;
+            }
+            CloseHandle(hDoneEvent);
+        }
+    }
+
+    g_playerGrid = nullptr;
+    g_injectionParent = nullptr;
+    g_taskbarWnd = nullptr;
+
+    CleanupAudioDeviceEnumerator();
+    Wh_Log(L"Wh_ModUninit: Audio device enumerator cleaned up");
+
+    Wh_Log(L"Wh_ModUninit: Cleanup complete");
+}
+
+void Wh_ModSettingsChanged() {
+    g_applyingSettings = true;
+
+    StopRetryThread();
+    StopTimerThread();
+    StopIdleTimer();
+
+    LoadSettings();
+
+    g_forceSessionRefresh = true;
+    OnSessionsChanged();
+
+    HWND hWnd = g_taskbarWnd ? g_taskbarWnd : FindCurrentProcessTaskbarWnd();
+    if (!hWnd) {
+        g_applyingSettings = false;
+        StartTimerThread();
+        StartIdleTimer();
+        StartRetryThread();
+        return;
+    }
+    g_taskbarWnd = hWnd;
+
+    DWORD threadId = GetWindowThreadProcessId(hWnd, nullptr);
+    if (threadId && threadId != GetCurrentThreadId()) {
+        struct WorkData { HWND hWnd; };
+        WorkData* data = new WorkData{hWnd};
+
+        HANDLE hThread = CreateThread(nullptr, 0, [](LPVOID param) -> DWORD {
+            WorkData* data2 = (WorkData*)param;
+            RunFromWindowThread(data2->hWnd, [](void*) {
+                try {
+                    RemovePlayerGrid();
+                    if (!g_unloading) InjectPlayerGrid();
+                } catch (...) {
+                    g_playerGrid = nullptr;
+                    g_injectionParent = nullptr;
+                }
+            }, nullptr);
+            delete data2;
+            return 0;
+        }, data, 0, nullptr);
+
+        if (hThread) {
+            WaitForSingleObject(hThread, 2000);
+            CloseHandle(hThread);
+        } else {
+            delete data;
+        }
+    } else {
+        try {
+            RemovePlayerGrid();
+            if (!g_unloading) InjectPlayerGrid();
+        } catch (...) {
+            g_playerGrid = nullptr;
+            g_injectionParent = nullptr;
+        }
+    }
+
+    g_applyingSettings = false;
+    g_needsUiUpdate = true;
+
+    StartTimerThread();
+    StartIdleTimer();
+    StartRetryThread();
+}

--- a/mods/taskbar-fluent-media-player.wh.cpp
+++ b/mods/taskbar-fluent-media-player.wh.cpp
@@ -5752,12 +5752,12 @@ static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR path, HANDLE file, DWORD flags
         if (_wcsicmp(base, L"Taskbar.View.dll") == 0 ||
             _wcsicmp(base, L"SystemTray.dll") == 0 ||
             _wcsicmp(base, L"ExplorerExtensions.dll") == 0) {
-            WindhawkUtils::SYMBOL_HOOK hooks[] = {{
+            WindhawkUtils::SYMBOL_HOOK taskbarViewHooks[] = {{
                 {LR"(public: __cdecl winrt::SystemTray::implementation::IconView::IconView(void))"},
                 &IconView_IconView_Original,
                 IconView_IconView_Hook,
             }};
-            if (WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks))) {
+            if (WindhawkUtils::HookSymbols(h, taskbarViewHooks, ARRAYSIZE(taskbarViewHooks))) {
                 g_taskbarViewDllLoaded = true;
                 Wh_ApplyHookOperations();
             }
@@ -5770,7 +5770,7 @@ static bool HookTaskbarDllSymbols() {
     HMODULE h = LoadLibraryExW(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (!h) { return false; }
 
-    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+    WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
         {{LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})"},
          &CTaskBand_ITaskListWndSite_vftable},
         {{LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )"},
@@ -5780,17 +5780,17 @@ static bool HookTaskbarDllSymbols() {
         {{LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))"},
          &Std_Ref_Decref_Original},
     };
-    bool ok = WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks));
+    bool ok = WindhawkUtils::HookSymbols(h, taskbarDllHooks, ARRAYSIZE(taskbarDllHooks));
     return ok;
 }
 
 static bool HookTaskbarViewDllSymbols(HMODULE h) {
-    WindhawkUtils::SYMBOL_HOOK hooks[] = {{
+    WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {{
         {LR"(public: __cdecl winrt::SystemTray::implementation::IconView::IconView(void))"},
         &IconView_IconView_Original,
         IconView_IconView_Hook,
     }};
-    if (!WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks))) {
+    if (!WindhawkUtils::HookSymbols(h, taskbarViewDllHooks, ARRAYSIZE(taskbarViewDllHooks))) {
         return false;
     }
     g_taskbarViewDllLoaded = true;

--- a/mods/taskbar-fluent-media-player.wh.cpp
+++ b/mods/taskbar-fluent-media-player.wh.cpp
@@ -5752,12 +5752,13 @@ static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR path, HANDLE file, DWORD flags
         if (_wcsicmp(base, L"Taskbar.View.dll") == 0 ||
             _wcsicmp(base, L"SystemTray.dll") == 0 ||
             _wcsicmp(base, L"ExplorerExtensions.dll") == 0) {
-            WindhawkUtils::SYMBOL_HOOK taskbarViewHooks[] = {{
+            // Taskbar.View.dll, SystemTray.dll, ExplorerExtensions.dll
+            WindhawkUtils::SYMBOL_HOOK hooks[] = {{
                 {LR"(public: __cdecl winrt::SystemTray::implementation::IconView::IconView(void))"},
                 &IconView_IconView_Original,
                 IconView_IconView_Hook,
             }};
-            if (WindhawkUtils::HookSymbols(h, taskbarViewHooks, ARRAYSIZE(taskbarViewHooks))) {
+            if (WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks))) {
                 g_taskbarViewDllLoaded = true;
                 Wh_ApplyHookOperations();
             }
@@ -5785,12 +5786,13 @@ static bool HookTaskbarDllSymbols() {
 }
 
 static bool HookTaskbarViewDllSymbols(HMODULE h) {
-    WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {{
+    // Taskbar.View.dll, SystemTray.dll, ExplorerExtensions.dll
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {{
         {LR"(public: __cdecl winrt::SystemTray::implementation::IconView::IconView(void))"},
         &IconView_IconView_Original,
         IconView_IconView_Hook,
     }};
-    if (!WindhawkUtils::HookSymbols(h, taskbarViewDllHooks, ARRAYSIZE(taskbarViewDllHooks))) {
+    if (!WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks))) {
         return false;
     }
     g_taskbarViewDllLoaded = true;


### PR DESCRIPTION
**Taskbar Fluent Media Player —** is a Windhawk mod that integrates a modern media player with Fluent Design directly into the Windows 11 taskbar. It allows you to control music and view track information seamlessly without interrupting your workflow.

![img](https://i.imgur.com/S5vQyUa.png)

### Key Features:
* **Deep Integration —** Place the player in the tray area (left or right of the clock), next to system icons, or in the center of the taskbar.
* **Fluent UI Effects —** Full support for native Windows 11 materials including **Acrylic**, **Mica**, and **Mica Alt**.
* **Adaptive Design —** The player can automatically adapt its colors based on the album art or follow the system accent color.
* **Full Media Control —** Buttons for Play/Pause, Skip, 5-second Seek, Shuffle, and Repeat modes.
* **Smart Behavior —** Automatically hides the player when no media is playing, when entering full-screen mode, or after a period of inactivity (idle).

### Advanced Customization:
* **Visuals —** Customize fonts (Segoe UI, Aptos, etc.), text sizes, padding, and element transparency.
* **Album Art —** Adjustable corner radius, source app icon overlay, and pause overlay effects.
* **Mouse Interactions —** Assign custom actions (Volume control, Track seeking, Session switching) to the mouse wheel, single clicks, or double clicks on different parts of the player.

If this pull request introduces a new mod, please complete the section below.

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 