### PR TITLE
Add Redirect Settings to Control Panel mod

### DIFF
--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -2,14 +2,14 @@
 // @id             settings-to-control-panel
 // @name           Redirect Settings to Control Panel
 // @description    Forces classic Control Panel to open instead of Windows 10/11 Settings app using native components. Primarily designed for Windows 10; Windows 11 support is limited due to Microsoft's shell architecture changes.
-// @version        9.8.7
+// @version        9.8.8
 // @author         babamohammed
 // @github         https://github.com/babamohammed2022
 // @include        explorer.exe
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
-# Redirect Settings → Control Panel (v9.8.7)
+# Redirect Settings → Control Panel (v9.8.8)
 
 This Windhawk mod intercepts modern `ms-settings:` URIs and redirects them to
 their corresponding classic Control Panel applets, relying exclusively on native
@@ -470,18 +470,8 @@ static void InitMappings() {
             L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         {L"ms-settings:network-ethernet",
             L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-vpn",
-            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-airplanemode",
-            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-mobilehotspot",
-            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-cellular",
-            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:datausage",
-            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         {L"ms-settings:network-proxy",                       L"inetcpl.cpl,,4"},
-        {L"settings:network-status", 
+        {L"ms-settings:network-status", 
             L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
         {L"ms-settings:network-status",
             L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
@@ -520,9 +510,14 @@ static void InitMappings() {
         {L"ms-settings:regionformatting",                    L"intl.cpl"},
         {L"ms-settings:language",                            L"intl.cpl"},
 
-        // ── Ease of Access ────────────────────────────────────────────────────
-        {L"ms-settings:easeofaccess",
-            L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        // ── Ease of Access ────────────────────────────────────────────────────,
+        // Ease Of Access entries
+        {L"ms-settings:easeofaccess", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-narrator", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}\\pageNoVisual"},
+        {L"ms-settings:easeofaccess-magnifier", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}\\pageEasierToSee"},
+        {L"ms-settings:easeofaccess-speech", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A"},
+        {L"ms-settings:easeofaccess-colorfilter", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}\\pageEasierToSee"},
+        {L"ms-settings:easeofaccess-display", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}\\pageEasierToSee"},
 
         // ── Recovery / Backup ─────────────────────────────────────────────────
         {L"ms-settings:backup",
@@ -753,8 +748,13 @@ static bool IsPersonalizationWindow(HWND hwnd) {
             return false;
         }
         if (c == L"cabinetwclass") {
-            Wh_Log(L"HWND: CabinetWClass -> inside Personalization");
-            return true;
+            if (t.find(L"personaliz") != std::wstring::npos) {
+                Wh_Log(L"HWND: CabinetWClass personalization confirmed");
+                return true;
+        }
+
+            Wh_Log(L"HWND: CabinetWClass but not personalization");
+            return false;
         }
         if (t.find(L"personaliz") != std::wstring::npos) {
             Wh_Log(L"HWND: title match 'personaliz' -> Personalization window");
@@ -802,6 +802,18 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
         return {t, true};
     }
 
+    // ─── EDIT FOR EASE OF ACCESS IN PERSONALIZATION ───
+
+    if (g_settings.smartPersonalizationDetect && IsPersonalizationWindow(hwnd)) {
+        if (uri.find(L"ms-settings:easeofaccess") == 0) {
+            Wh_Log(L"SmartPersonalization: Accesso da finestra Personalizzazione, forzo radice Centro Accessibilità");
+            std::wstring t = ApplyWin11Filter(L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}");
+            BounceGuardRecord(uri);
+            return {t, true};
+        }
+    }
+    // ─────────────────────────────────────────────────────────────────
+
     auto it = g_mappings.find(uri);
     if (it != g_mappings.end()) {
         if (BounceGuardIsBounce(uri)) {
@@ -839,7 +851,6 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
     Wh_Log(L"Unmapped, passing through: %s", uri.c_str());
     return {L"", false};
 }
-
 // ── Precise control system detection ─────────────────────────────────────────
 
 static std::wstring BaseNameLower(const std::wstring& path) {
@@ -1064,7 +1075,7 @@ BOOL WINAPI CreateProcessW_hook(
 // ── Windhawk entry points ─────────────────────────────────────────────────────
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"Redirect Settings to Control Panel v9.8.7 init");
+    Wh_Log(L"Redirect Settings to Control Panel v9.8.8 init");
 
     DetectWindowsVersion();
     LoadSettings();

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -2,7 +2,7 @@
 // @id             settings-to-control-panel
 // @name           Redirect Settings to Control Panel
 // @description    Forces classic Control Panel to open instead of Windows 10/11 Settings app using native components. Primarily designed for Windows 10; Windows 11 support is limited due to Microsoft's shell architecture changes.
-// @version        10.0.2
+// @version        10.0.1
 // @author         babamohammed
 // @github         https://github.com/babamohammed2022
 // @include        explorer.exe
@@ -26,7 +26,6 @@ corresponding classic Control Panel applets using only native Windows components
 ## Features
 
 - Redirects numerous `ms-settings:` URIs to classic Control Panel
-- Smart personalization detection (desktop vs in-window)
 - Anti-loop protection
 - Configurable fallback modes
 
@@ -67,7 +66,7 @@ Control Panel target instead of the modern Settings app.
 
 - m417z – Code reviews and feedback
 - Anixx – Testing on Windows 11 23H2
-- dbilanoski – CLSID documentation  
+- dbilanoski – CLSID documentation
 */
 // ==/WindhawkModReadme==
 // ==WindhawkModSettings==
@@ -104,8 +103,6 @@ Control Panel target instead of the modern Settings app.
 #include <vector>
 #include <mutex>   
 #include <initguid.h>  
-#include <chrono>
-#include <thread>
 
 // Dynamic COM handling - no linking required
 typedef HRESULT (WINAPI *CoCreateInstance_t)(const GUID* rclsid, IUnknown* pUnkOuter, DWORD dwClsContext, const GUID* riid, void** ppv);
@@ -136,10 +133,6 @@ using ShellExecuteW_t = HINSTANCE(WINAPI*)(HWND, LPCWSTR, LPCWSTR, LPCWSTR, LPCW
 using ShellExecuteExW_t = BOOL(WINAPI*)(SHELLEXECUTEINFOW*);
 static ShellExecuteExW_t ShellExecuteExW_orig = nullptr;
 static ShellExecuteW_t ShellExecuteW_orig = nullptr;
-
-// Pending redirects guard per evitare chiamate duplicate
-static std::unordered_set<std::wstring> g_pendingRedirects;
-static std::mutex g_pendingMtx;
 
 // Core resolve logic struct - MUST be defined before use
 struct ResolveResult {
@@ -331,6 +324,13 @@ static const std::unordered_set<std::wstring> g_win11LoopClsids = {
     L"shell:::{9fe63afd-59cf-4419-9775-abcc3849f861}",
 };
 
+static const std::unordered_set<std::wstring> g_win11NoForceRedirect = {
+    L"ms-settings:defaultapps",
+    L"ms-settings:appsfeatures",
+    L"ms-settings:network",
+    L"ms-settings:bluetooth",
+    L"ms-settings:printers",
+};
 
 static bool IsClsidSafeOnWin11(const std::wstring& lowerTarget) {
     return g_win11SafeClsids.count(lowerTarget) > 0;
@@ -651,7 +651,7 @@ static bool HandleFallback(const std::wstring& uri) {
     }
 }
 
-// LaunchTarget - VERSIONE CORRETTA CON PULIZIA PENDING REDIRECTS
+// LaunchTarget - VERSIONE CORRETTA
 static void LaunchTarget(const std::wstring& command) {
     Wh_Log(L"Launching: %s", command.c_str());
 
@@ -756,8 +756,11 @@ static void LaunchTarget(const std::wstring& command) {
         CloseHandle(pi.hThread);
     }
 }
-
 // Personalization detection
+
+
+
+
 
 // Helper function to open sound panel
 static bool OpenSoundPanel() {
@@ -811,17 +814,7 @@ static std::wstring ResolvePersonalizationBackground(HWND hwnd) {
     Wh_Log(L"personalization-background -> Personalization root");
     return PERS_ROOT;
 }
-
 static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
-    // Controlla se questo URI è già in elaborazione
-    {
-        std::lock_guard<std::mutex> lk(g_pendingMtx);
-        if (g_pendingRedirects.find(uri) != g_pendingRedirects.end()) {
-            Wh_Log(L"URI already being processed, blocking duplicate: %s", uri.c_str());
-            return {L"", true}; // Blocca completamente
-        }
-    }
-    
     if (uri == L"ms-settings:personalization-background") {
         if (BounceGuardIsBounce(uri)) {
             Wh_Log(L"Bounce-back on personalization-background - suppressing duplicate, target is opening");
@@ -829,12 +822,6 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
         }
         std::wstring t = ApplyWin11Filter(ResolvePersonalizationBackground(hwnd));
         BounceGuardRecord(uri);
-        
-        // Marca come pendente
-        {
-            std::lock_guard<std::mutex> lk(g_pendingMtx);
-            g_pendingRedirects.insert(uri);
-        }
         return {t, true};
     }
 
@@ -856,12 +843,6 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
 
         Wh_Log(L"Mapped: %s -> %s", uri.c_str(), t.c_str());
         BounceGuardRecord(uri);
-        
-        // Marca come pendente
-        {
-            std::lock_guard<std::mutex> lk(g_pendingMtx);
-            g_pendingRedirects.insert(uri);
-        }
         return {t, true};
     }
 
@@ -874,12 +855,6 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
         if (g_isWin11 && IsClsidLoopOnWin11(uri)) {
             std::wstring t = ApplyWin11Filter(uri);
             Wh_Log(L"Win11 loop-CLSID intercepted: %s -> %s", uri.c_str(), t.c_str());
-            
-            // Marca come pendente
-            {
-                std::lock_guard<std::mutex> lk(g_pendingMtx);
-                g_pendingRedirects.insert(uri);
-            }
             return {t, true};
         }
     }
@@ -887,7 +862,6 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
     Wh_Log(L"Unmapped, passing through: %s", uri.c_str());
     return {L"", false};
 }
-
 // Control system detection helpers
 static std::wstring BaseNameLower(const std::wstring& path) {
     size_t pos = path.rfind(L'\\');
@@ -928,14 +902,6 @@ static bool IsControlSystemCommand(const std::wstring& cmdLine) {
 
     std::wstring arg = ToLower(tokens[1]);
     return (arg == L"system" || arg == L"microsoft.system");
-}
-
-// Funzione per pulire i pending redirects dopo un delay
-static void CleanupPendingRedirect(const std::wstring& uri, DWORD delayMs) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
-    std::lock_guard<std::mutex> lk(g_pendingMtx);
-    g_pendingRedirects.erase(uri);
-    Wh_Log(L"Cleaned up pending redirect for: %s", uri.c_str());
 }
 
 // Hook: ShellExecuteExW
@@ -983,28 +949,9 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
     }
 
     if (!uri.empty()) {
-        // Controllo extra per bloccare chiamate duplicate
-        {
-            std::lock_guard<std::mutex> lk(g_pendingMtx);
-            if (g_pendingRedirects.find(uri) != g_pendingRedirects.end()) {
-                Wh_Log(L"ShellExecuteExW: BLOCKED duplicate call for: %s", uri.c_str());
-                if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
-                return TRUE;
-            }
-        }
-        
         auto result = ResolveUri(uri, pei->hwnd);
         if (result.intercept) {
-            if (!result.target.empty()) {
-                LaunchTarget(result.target);
-                // Pulisci il pending redirect dopo 200ms
-                std::thread cleanupThread(CleanupPendingRedirect, uri, 200);
-                cleanupThread.detach();
-            } else {
-                // Pulisci subito se non c'è target
-                std::lock_guard<std::mutex> lk(g_pendingMtx);
-                g_pendingRedirects.erase(uri);
-            }
+            if (!result.target.empty()) LaunchTarget(result.target);
             if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
             return TRUE;
         }
@@ -1057,27 +1004,9 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file, LPCWSTR
     }
 
     if (!uri.empty()) {
-        // Controllo per bloccare chiamate duplicate
-        {
-            std::lock_guard<std::mutex> lk(g_pendingMtx);
-            if (g_pendingRedirects.find(uri) != g_pendingRedirects.end()) {
-                Wh_Log(L"ShellExecuteW: BLOCKED duplicate call for: %s", uri.c_str());
-                return SHELL_EXECUTE_SUCCESS;
-            }
-        }
-        
         auto result = ResolveUri(uri, hwnd);
         if (result.intercept) {
-            if (!result.target.empty()) {
-                LaunchTarget(result.target);
-                // Pulisci il pending redirect dopo 200ms
-                std::thread cleanupThread(CleanupPendingRedirect, uri, 200);
-                cleanupThread.detach();
-            } else {
-                // Pulisci subito se non c'è target
-                std::lock_guard<std::mutex> lk(g_pendingMtx);
-                g_pendingRedirects.erase(uri);
-            }
+            if (!result.target.empty()) LaunchTarget(result.target);
             return SHELL_EXECUTE_SUCCESS;
         }
     }
@@ -1150,14 +1079,7 @@ HRESULT WINAPI IShellDispatch2_ShellExecute_hook(
         uri = ToLower(fileStr);
 
     if (!uri.empty()) {
-        // Controllo per bloccare chiamate duplicate
-        {
-            std::lock_guard<std::mutex> lk(g_pendingMtx);
-            if (g_pendingRedirects.find(uri) != g_pendingRedirects.end()) {
-                Wh_Log(L"IShellDispatch2: BLOCKED duplicate call for: %s", uri.c_str());
-                return S_OK;
-            }
-        }
+        
         
         // Audio URI handling in COM hook
         if (uri.find(L"ms-settings:sound") == 0 ||
@@ -1167,16 +1089,7 @@ HRESULT WINAPI IShellDispatch2_ShellExecute_hook(
         
         auto result = ResolveUri(uri, nullptr);
         if (result.intercept) {
-            if (!result.target.empty()) {
-                LaunchTarget(result.target);
-                // Pulisci il pending redirect dopo 200ms
-                std::thread cleanupThread(CleanupPendingRedirect, uri, 200);
-                cleanupThread.detach();
-            } else {
-                // Pulisci subito se non c'è target
-                std::lock_guard<std::mutex> lk(g_pendingMtx);
-                g_pendingRedirects.erase(uri);
-            }
+            if (!result.target.empty()) LaunchTarget(result.target);
             return S_OK;
         }
     }
@@ -1190,7 +1103,7 @@ HRESULT WINAPI IShellDispatch2_ShellExecute_hook(
 
 // Windhawk entry points
 BOOL Wh_ModInit() {
-    Wh_Log(L"Redirect Settings to Control Panel v10.0.2");
+    Wh_Log(L"Redirect Settings to Control Panel v10.0.1");
     
     // Load COM dynamically for IShellDispatch2 hook
     g_hOle32 = LoadLibraryW(L"ole32.dll");
@@ -1256,7 +1169,7 @@ void Wh_ModUninit() {
         FreeLibrary(g_hOle32);
         g_hOle32 = nullptr;
     }
-    Wh_Log(L"Redirect Settings to Control Panel v10.0.2 unloaded.");
+    Wh_Log(L"Redirect Settings to Control Panel v10.0.1 unloaded.");
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -28,7 +28,6 @@ right-click menus) using XAML/UWP technology. The modern taskbar uses
 `ShellExecute`, which means:
 
 - **Control Panel navigation** works on both OSes (with Windows 10 being more compatible)
-- **System tray redirection works on Windows 10 only** (or Windows 11 with the classic Win32 taskbar restored via ExplorerPatcher)
 - Some Control Panel components have been **deprecated or removed** by Microsoft on Windows 11
 - Some CLSIDs still exist in the registry but open **empty panels**
 - **Desktop right-click → Personalize** uses a different code path on Win11 (Could be fixed in future)
@@ -50,7 +49,6 @@ configuration (see Settings section).
 - Troubleshooting → MSDT on Win11 (`msdt.exe`)
 
 ### 🟡 Redirected on Windows 10 only
-- System tray icon clicks (audio, network) — uses Win32 taskbar
 - Desktop right-click → Personalize
 - Taskbar notification area settings
 
@@ -58,10 +56,9 @@ configuration (see Settings section).
 - Modern Windows 11 taskbar tray (uses `DelegateExecute` COM activation)
 - Start Menu search results (excluded to avoid breaking search)
 - Internal Settings app navigation
-
-**Note for Windows 11 users:** To get full tray icon redirection, use a tool
-like **ExplorerPatcher** to restore the classic Win32 taskbar, which uses
-`explorer.exe` and `ms-settings:` URIs like Windows 10.
+**Note:** System tray icon clicks (audio, network) are NOT redirected on either OS.
+The tray uses DCOM activation which bypasses ShellExecute hooks. This is an
+architectural limitation documented above. (Could be fixed soon)
 
 ---
 
@@ -83,22 +80,6 @@ transparently redirected to the equivalent classic Control Panel interface.
 - Safe fallback handling for unmapped settings
 - Anti-loop protection (cross-process, in-process, bounce-back detection)
 - Lightweight implementation using native Windows APIs only
-
----
-
-## Testing
-
-### On Windows 10
-1. **Right-click speaker icon** → "Sounds" → should open `mmsys.cpl`
-2. **Right-click network icon** → "Network settings" → should open Network Connections
-3. **Right-click desktop** → "Personalize" → should open classic Personalization
-4. **Control Panel** → System → should stay in classic Control Panel
-
-### On Windows 11
-1. **Win+R** → `ms-settings:about` → should open System Properties (`sysdm.cpl`)
-2. **Win+R** → `explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}` → classic Personalization
-3. **Control Panel** → System → should stay in classic Control Panel
-4. **Control Panel** → Troubleshooting → should open MSDT
 
 ---
 

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -2,48 +2,105 @@
 // @id             settings-to-control-panel
 // @name           Redirect Settings to Control Panel
 // @description    Forces classic Control Panel to open instead of Windows 10/11 Settings app using native components
-// @version        9.7.1
+// @version        9.8.4
 // @author         babamohammed
 // @github         https://github.com/babamohammed2022
 // @license        MIT
 // @include        explorer.exe
 // ==/WindhawkMod==
-
 // ==WindhawkModReadme==
 /*
-# Redirect Settings → Control Panel (v9.7.1)
+# Redirect Settings → Control Panel (v9.8.4)
 
-This mod intercepts modern `ms-settings:` URI protocols and forces Windows to open their classic
-Control Panel equivalents when possible. It relies entirely on native Windows components and
-legacy CLSIDs without requiring any third-party external programs.
+This Windhawk mod intercepts modern `ms-settings:` URIs and redirects them to
+their corresponding classic Control Panel applets, relying exclusively on native
+Windows components (no external binaries or dependencies).
 
-**Scope:** This mod only intercepts calls made from within Explorer (explorer.exe).
-`ms-settings:` links opened from Start Menu, Search (StartMenuExperienceHost, SearchHost),
-or other applications will not be redirected.
+---
 
-### Compatibility & Limitations:
-- **Windows 10:** Effective for the mapped entries since most legacy control panels from the Windows 7/8/8.1 era are still intact
-  and accessible via standard shell hooks.
-- **Windows 11:** Limited. Microsoft has deprecated or hardcoded many legacy CLSIDs.
-  However, key elements like network properties (`ncpa.cpl`) and specific dialog mappings
-  still function. Unmapped pages pass through to the Settings app by default
-  (configurable via FallbackMode).
+## Overview
 
-### Key Features:
-- **Smart Desktop Personalization Hook:** Right-clicking the desktop opens the Personalization
-  window; clicking "Desktop Background" from inside it opens the wallpaper page.
-- **Precise command interception:** Only intercepts `control.exe system` (exact lone argument),
-  avoiding false positives from paths containing "System32".
+This mod restores access to the legacy Control Panel experience from older
+versions of Windows. When a system setting link is opened (typically triggering
+the modern Settings app), it is transparently redirected to the equivalent
+classic Control Panel interface whenever possible.
 
-### Settings (v9.7.1):
-- **EnableRedirects** — Turns the mod on or off completely.
-- **UIOnlyRedirects** — Safer mode: only intercepts ShellExecute calls, not CreateProcessW.
-- **SmartPersonalizationDetection** — Contextual awareness for the desktop right-click.
-- **FallbackMode** — What happens for unmapped `ms-settings:` URIs.
-- **Win11CompatibilityMode** — Skips CLSIDs known to be broken on Win11.
+This is particularly useful for users who prefer the Windows 7-style Control
+Panel workflow or want a faster, more direct navigation model compared to the
+modern Settings application.
+
+---
+
+## Scope of Interception
+
+Redirection is applied **only to ShellExecute calls originating from File Explorer**.
+This design choice minimizes side effects and avoids interfering with:
+
+- Start Menu behavior  
+- Windows Search results  
+- Third-party applications  
+
+All other invocation contexts remain unaffected.
+
+---
+
+## Compatibility
+
+### Windows 10
+Fully functional in most scenarios. The majority of Control Panel applets are
+still present and correctly mapped. Some legacy applets removed by Microsoft
+(e.g. Taskbar-related settings or legacy Display configuration pages) cannot be
+resolved and will fall back to the configured behavior.
+
+### Windows 11
+Partially supported due to the removal or migration of several Control Panel
+components into the Settings app.
+
+When no valid classic equivalent exists, behavior is controlled via fallback
+configuration (see Settings section). Options include:
+
+- Opening the root Control Panel
+- Allowing the modern Settings app to launch
+- Suppressing the action entirely
+
+Ongoing compatibility improvements target newer Windows 11 builds.
+
+---
+
+## Features
+
+- Over 90 URI-to-applet mappings covering:
+  System, Network, Personalization, Sound, Devices, Accounts, Fonts, and more
+- Enhanced desktop context handling:
+  - Right-click Desktop → opens classic Personalization
+  - Nested navigation support for wallpaper selection workflows
+- Safe fallback handling for unmapped settings
+- Anti-loop protection for recursive redirections on Windows 11
+- Lightweight implementation using native Windows APIs only
+
+---
+
+## Configuration Options
+
+- **EnableRedirects**  
+  Master switch enabling or disabling all redirections.
+
+- **UIOnlyRedirects**  
+  Restricts interception to ShellExecute/UI-level calls only, avoiding script-level execution paths for improved safety.
+
+- **SmartPersonalizationDetection**  
+  Differentiates between desktop context actions and in-window personalization navigation.
+
+- **FallbackMode**  
+  Defines behavior when no classic Control Panel equivalent exists.
+
+- **Win11CompatibilityMode**  
+  Enables additional safeguards for Windows 11, including blocking unverified CLSID targets.
+
+- **MaxLaunchesPerUri**  
+  Limits repeated redirection chains to prevent infinite loops or runaway execution.
 */
 // ==/WindhawkModReadme==
-
 // ==WindhawkModSettings==
 /*
 - EnableRedirects: true
@@ -64,7 +121,10 @@ or other applications will not be redirected.
   - "2": Pass through to the modern Settings application (ms-settings.exe)
 - Win11CompatibilityMode: false
   $name: Windows 11 Compatibility Mode
-  $description: "On Windows 11, replaces CLSIDs known to be broken with a plain Control Panel open."
+  $description: "On Windows 11, also replaces CLSIDs not confirmed safe (beyond the always-blocked known-loop CLSIDs)."
+- MaxLaunchesPerUri: 3
+  $name: Loop Guard — max launches per URI (per 5 s)
+  $description: "Safety valve: if the same redirect target fires more than this many times in 5 seconds the mod stops launching it. Set to 0 to disable."
 */
 // ==/WindhawkModSettings==
 
@@ -76,17 +136,27 @@ or other applications will not be redirected.
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <mutex>
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-// ShellExecuteW: any value > 32 signals success to the caller
 static const HINSTANCE SHELL_EXECUTE_SUCCESS = (HINSTANCE)33;
 
 #define SYSTEM_PROPS_CLSID  L"shell:::{BB06C0E4-D293-4f75-8A90-CB05B6477EEE}"
 #define NOTIF_AREA_CLSID    L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"
-#define PERS_ROOT_CLSID     L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"
-#define PERS_WALLPAPER      PERS_ROOT_CLSID L"\\pageWallpaper"
-#define PERS_COLORS         PERS_ROOT_CLSID L"\\pageColorization"
+
+// Classic Personalization CPL opened via "explorer shell:::{ED834ED6} [-page]"
+// syntax. Explorer resolves the CLSID namespace directly, bypassing the
+// ShellExecuteEx/DelegateExecute path that redirects to ms-settings on Win11.
+// The "-Microsoft.Personalization\pageX" suffix navigates to a sub-page.
+// All four values are full command lines handled by LaunchTarget.
+#define PERS_ED_CLSID   L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"
+#define PERS_ROOT       L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"
+#define PERS_WALLPAPER  L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921} -Microsoft.Personalization\\pageWallpaper"
+#define PERS_COLORS     L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921} -Microsoft.Personalization\\pageColorization"
+
+// Sentinel: URI has no working CP equivalent on Win11; route straight to fallback.
+#define WIN11_PASSTHROUGH L"__PASSTHROUGH__"
 
 // ── Forward declarations ──────────────────────────────────────────────────────
 
@@ -98,6 +168,51 @@ static CreateProcessW_t CreateProcessW_orig = nullptr;
 using ShellExecuteW_t = HINSTANCE(WINAPI*)(HWND, LPCWSTR, LPCWSTR, LPCWSTR, LPCWSTR, INT);
 static ShellExecuteW_t ShellExecuteW_orig = nullptr;
 
+// ── In-process reentry guard ──────────────────────────────────────────────────
+//
+// Prevents hooks from re-intercepting calls made by code that our mod itself
+// triggered (e.g. Control Panel subpages, Explorer internal navigation).
+// This is per-thread so concurrent Explorer threads don't block each other.
+//
+// Usage: create a HookGuard at the top of each hook function, then call
+// IsReentrant() to decide whether to pass through.
+
+static thread_local int g_hookDepth = 0;
+
+struct HookGuard {
+    HookGuard()  { ++g_hookDepth; }
+    ~HookGuard() { --g_hookDepth; }
+    bool IsReentrant() const { return g_hookDepth > 1; }
+};
+
+// ── Cross-process reentry guard ───────────────────────────────────────────────
+//
+// Child processes spawned by LaunchTarget receive WH_STC_NOREDIRECT=1 in their
+// environment. Hooks in the child check this flag and pass through without
+// re-intercepting, preventing cross-process redirect loops.
+
+static std::wstring g_childEnvBlock;
+
+static void BuildChildEnvironment() {
+    LPWCH curEnv = GetEnvironmentStringsW();
+    if (curEnv) {
+        LPWCH p = curEnv;
+        while (*p) {
+            std::wstring entry(p);
+            if (entry.find(L"WH_STC_NOREDIRECT=") != 0) {
+                g_childEnvBlock += entry + L'\0';
+            }
+            p += entry.length() + 1;
+        }
+        FreeEnvironmentStringsW(curEnv);
+    }
+    g_childEnvBlock += L"WH_STC_NOREDIRECT=1\0\0";
+}
+
+static bool IsChildProcess() {
+    return GetEnvironmentVariableW(L"WH_STC_NOREDIRECT", nullptr, 0) > 0;
+}
+
 // ── Settings ──────────────────────────────────────────────────────────────────
 
 struct ModSettings {
@@ -106,6 +221,7 @@ struct ModSettings {
     bool smartPersonalizationDetect = true;
     int  fallbackMode               = 2;
     bool win11CompatibilityMode     = false;
+    int  maxLaunchesPerUri          = 3;
 };
 
 static ModSettings g_settings;
@@ -116,12 +232,9 @@ static void LoadSettings() {
     g_settings.smartPersonalizationDetect = Wh_GetIntSetting(L"SmartPersonalizationDetection") != 0;
 
     PCWSTR fallbackStr = Wh_GetStringSetting(L"FallbackMode");
-    if (fallbackStr && fallbackStr[0] != L'\0') {
+    if (fallbackStr[0] != L'\0') {
         int mode = _wtoi(fallbackStr);
-        if (mode >= 0 && mode <= 2)
-            g_settings.fallbackMode = mode;
-        else
-            g_settings.fallbackMode = 2;
+        g_settings.fallbackMode = (mode >= 0 && mode <= 2) ? mode : 2;
     } else {
         g_settings.fallbackMode = 2;
     }
@@ -129,12 +242,16 @@ static void LoadSettings() {
 
     g_settings.win11CompatibilityMode = Wh_GetIntSetting(L"Win11CompatibilityMode") != 0;
 
-    Wh_Log(L"EnableRedirects=%d  UIOnly=%d  SmartPers=%d  Fallback=%d  Win11Compat=%d",
+    int ml = Wh_GetIntSetting(L"MaxLaunchesPerUri");
+    g_settings.maxLaunchesPerUri = (ml >= 0 && ml <= 20) ? ml : 3;
+
+    Wh_Log(L"EnableRedirects=%d  UIOnly=%d  SmartPers=%d  Fallback=%d  Win11Compat=%d  MaxLaunches=%d",
         (int)g_settings.enableRedirects,
         (int)g_settings.uiOnlyRedirects,
         (int)g_settings.smartPersonalizationDetect,
         g_settings.fallbackMode,
-        (int)g_settings.win11CompatibilityMode);
+        (int)g_settings.win11CompatibilityMode,
+        g_settings.maxLaunchesPerUri);
 }
 
 // ── Win11 detection ───────────────────────────────────────────────────────────
@@ -156,20 +273,126 @@ static void DetectWindowsVersion() {
     Wh_Log(L"Build %lu  IsWin11=%d", osvi.dwBuildNumber, (int)g_isWin11);
 }
 
+// ── Loop guard + Bounce-back detection ───────────────────────────────────────
+//
+// Two distinct protections:
+//
+// 1. LOOP GUARD (existing): caps total launches of a given *target* within 5 s.
+//
+// 2. BOUNCE-BACK DETECTOR (new): detects when a CP panel/CPL that we launched
+//    no longer exists on Win11 and silently re-fires the original ms-settings URI.
+//    Pattern: same URI seen again within BOUNCE_WINDOW_MS of a prior redirect.
+//    On detection the second call is routed to fallback instead of retrying.
+//    This is separate from the loop guard so it works even with MaxLaunches > 1.
+
+struct LaunchRecord {
+    int   count     = 0;
+    DWORD firstTick = 0;
+};
+
+// Bounce-back: records the tick at which we last redirected a given URI.
+struct BounceRecord {
+    DWORD lastRedirectTick = 0;
+};
+
+static std::mutex                                      g_loopGuardMtx;
+static std::unordered_map<std::wstring, LaunchRecord>  g_loopGuard;
+static std::unordered_map<std::wstring, BounceRecord>  g_bounceGuard;
+
+static constexpr DWORD LOOP_WINDOW_MS   = 5000;
+static constexpr DWORD BOUNCE_WINDOW_MS = 600;
+
+// Call this when we are about to redirect a URI (before LaunchTarget).
+// Records the redirect time for bounce-back detection.
+static void BounceGuardRecord(const std::wstring& uri) {
+    std::lock_guard<std::mutex> lk(g_loopGuardMtx);
+    g_bounceGuard[uri].lastRedirectTick = GetTickCount();
+}
+
+// Call this when a URI fires again. Returns true if it looks like a bounce-back
+// (the same URI came back too quickly after we redirected it → the target is dead).
+static bool BounceGuardIsBounce(const std::wstring& uri) {
+    std::lock_guard<std::mutex> lk(g_loopGuardMtx);
+    auto it = g_bounceGuard.find(uri);
+    if (it == g_bounceGuard.end()) return false;
+    DWORD elapsed = GetTickCount() - it->second.lastRedirectTick;
+    if (elapsed < BOUNCE_WINDOW_MS) {
+        Wh_Log(L"BOUNCE-BACK: '%s' returned %lu ms after redirect — target is dead, routing to fallback",
+               uri.c_str(), elapsed);
+        // Reset so the user can try again after the window expires
+        it->second.lastRedirectTick = 0;
+        return true;
+    }
+    return false;
+}
+
+static bool LoopGuardAllow(const std::wstring& target) {
+    if (g_settings.maxLaunchesPerUri <= 0) return true;
+
+    std::lock_guard<std::mutex> lk(g_loopGuardMtx);
+    DWORD now = GetTickCount();
+    auto& rec = g_loopGuard[target];
+
+    if (rec.count == 0 || (now - rec.firstTick) >= LOOP_WINDOW_MS) {
+        rec.count     = 1;
+        rec.firstTick = now;
+        return true;
+    }
+
+    if (rec.count < g_settings.maxLaunchesPerUri) {
+        rec.count++;
+        return true;
+    }
+
+    Wh_Log(L"LOOP GUARD: suppressing launch of '%s' (fired %d times in %lu ms)",
+           target.c_str(), rec.count, (now - rec.firstTick));
+    return false;
+}
+
+// ── CLSID classification ──────────────────────────────────────────────────────
+
 static const std::unordered_set<std::wstring> g_win11SafeClsids = {
     L"shell:::{8e908fc9-becc-40f6-915b-f4ca0e70d03d}",
     L"shell:::{7007acc7-3202-11d1-aad2-00805fc1270e}",
-    L"shell:::{a8a91a66-3a7d-4424-8d24-04e180695C7A}",
+    L"shell:::{a8a91a66-3a7d-4424-8d24-04e180695c7a}",
     L"shell:::{4026492f-2f69-46b8-b9bf-5654fc07e423}",
     L"shell:::{20d04fe0-3aea-1069-a2d8-08002b30309d}",
     L"shell:::{60632754-c523-4b62-b45c-4172da012619}",
     L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}",
+    L"shell:::{2227a280-3aea-1069-a2de-08002b30309d}",
+    L"shell:::{59031a47-3f72-44a7-89c5-5595fe6b30ee}",
+    L"shell:::{9c60de1e-e5fc-40f4-a487-460851a8d915}",
+    L"shell:::{b98a2bea-7d42-4558-8bd1-832f41bac6fd}",
+    L"shell:::{bd84b380-8ca2-1069-ab1d-08000948f534}",
+    L"shell:::{d555645e-d4f8-4c29-a827-d93c859c4f2a}",
+    L"shell:::{d9ef8727-cac2-4e60-809e-86f80a666c91}",
 };
 
-static bool IsClsidSafeOnWin11(const std::wstring& target) {
-    std::wstring lower = target;
-    std::transform(lower.begin(), lower.end(), lower.begin(), ::towlower);
-    return g_win11SafeClsids.count(lower) > 0;
+// CLSIDs that on Win11 trigger a redirect back to ms-settings when opened
+// via ShellExecuteEx (DelegateExecute path). ApplyWin11Filter intercepts these
+// and routes them to working alternatives before they are passed to Explorer.
+// Note: {ED834ED6} is handled specially -> PERS_ROOT / PERS_WALLPAPER.
+//       {BB06C0E4} is handled specially -> sysdm.cpl.
+//       The rest fall back to control.exe.
+static const std::unordered_set<std::wstring> g_win11LoopClsids = {
+    L"shell:::{bb06c0e4-d293-4f75-8a90-cb05b6477eee}",  // System Properties
+    L"shell:::{ed834ed6-4b5a-4bfe-8f11-a626dcb6a921}",  // Personalization CPL
+    L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}",  // Default Programs
+    L"shell:::{80f3f1d5-feca-45f3-bc32-752c152e456e}",  // Pen and Touch
+    L"shell:::{9fe63afd-59cf-4419-9775-abcc3849f861}",  // Recovery
+    L"shell:::{c58c4893-3be0-4b45-abb5-a63e4b8c8651}",  // Troubleshooting
+};
+
+static bool IsClsidSafeOnWin11(const std::wstring& lowerTarget) {
+    return g_win11SafeClsids.count(lowerTarget) > 0;
+}
+
+static bool IsClsidLoopOnWin11(const std::wstring& lowerTarget) {
+    std::wstring base = lowerTarget;
+    size_t brace = base.rfind(L'}');
+    if (brace != std::wstring::npos && brace + 1 < base.size())
+        base = base.substr(0, brace + 1);
+    return g_win11LoopClsids.count(base) > 0;
 }
 
 // ── String utilities ──────────────────────────────────────────────────────────
@@ -184,76 +407,86 @@ static std::wstring ToLower(std::wstring s) {
 static std::unordered_map<std::wstring, std::wstring> g_mappings;
 
 static void InitMappings() {
+    const bool w11 = g_isWin11;
+
     g_mappings = {
 
         // ── Personalization ──────────────────────────────────────────────────
-        {L"ms-settings:personalization",                    PERS_ROOT_CLSID},
-        {L"ms-settings:personalization-colors",             PERS_COLORS},
-        {L"ms-settings:colors",                             PERS_COLORS},
-        {L"ms-settings:themes",                             PERS_ROOT_CLSID},
-        {L"ms-settings:lockscreen",                         PERS_ROOT_CLSID},
-        {L"ms-settings:personalization-start",              PERS_ROOT_CLSID},
-        {L"ms-settings:personalization-start-places",       PERS_ROOT_CLSID},
-        {L"ms-settings:background",                         PERS_WALLPAPER},
-        {L"ms-settings:personalization-background-wallpaper",PERS_WALLPAPER},
-        {L"ms-settings:personalization-background-slideshow",PERS_WALLPAPER},
+        // PERS_ROOT and PERS_WALLPAPER use the "explorer shell:::{ED834ED6} [-page]"
+        // syntax, which works on both Win10 and Win11. Explorer opens the CLSID
+        // namespace directly without triggering the DelegateExecute redirect.
+        {L"ms-settings:personalization",             PERS_ROOT},
+        {L"ms-settings:personalization-colors",      PERS_COLORS},
+        {L"ms-settings:colors",                      PERS_COLORS},
+        {L"ms-settings:themes",                      PERS_ROOT},
+        {L"ms-settings:lockscreen",                  PERS_ROOT},
+        {L"ms-settings:personalization-start",       PERS_ROOT},
+        {L"ms-settings:personalization-start-places",PERS_ROOT},
+        {L"ms-settings:background",                  PERS_WALLPAPER},
+        {L"ms-settings:personalization-background-wallpaper",  PERS_WALLPAPER},
+        {L"ms-settings:personalization-background-slideshow",  PERS_WALLPAPER},
+
         {L"ms-settings:fonts",
             L"shell:::{BD84B380-8CA2-1069-AB1D-08000948F534}"},
 
         // ── Color Management ─────────────────────────────────────────────────
-        {L"ms-settings:display-advanced-color",             L"colorcpl.exe"},
-        {L"ms-settings:colorcpl",                           L"colorcpl.exe"},
+        {L"ms-settings:display-advanced-color",              L"colorcpl.exe"},
+        {L"ms-settings:colorcpl",                            L"colorcpl.exe"},
 
         // ── System / About ───────────────────────────────────────────────────
-        {L"ms-settings:about",                              SYSTEM_PROPS_CLSID},
-        {L"ms-settings:system",                             SYSTEM_PROPS_CLSID},
-        {L"ms-settings:sysinfo",                            SYSTEM_PROPS_CLSID},
-        {L"ms-settings:system-about",                       SYSTEM_PROPS_CLSID},
-        {L"ms-settings:system-protection",                  L"sysdm.cpl,,4"},
-        {L"ms-settings:system-remotedesktop",               L"sysdm.cpl,,5"},
-        {L"ms-settings:remotedesktop",                      L"sysdm.cpl,,5"},
-        {L"ms-settings:devicemanager",                      L"devmgmt.msc"},
-        {L"ms-settings:system-devicemanager",               L"devmgmt.msc"},
-        {L"ms-settings:computermanagement",                 L"compmgmt.msc"},
-        {L"ms-settings:activation",                         L"slui.exe"},
-        {L"ms-settings:appsfeatures",                       L"appwiz.cpl"},
-        {L"ms-settings:appsforwebsites",                    L"appwiz.cpl"},
-        {L"ms-settings:optionalfeatures",                   L"OptionalFeatures.exe"},
+        {L"ms-settings:about",
+            w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
+        {L"ms-settings:system",
+            w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
+        {L"ms-settings:sysinfo",
+            w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
+        {L"ms-settings:system-about",
+            w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
+        {L"ms-settings:system-protection",                   L"sysdm.cpl,,4"},
+        {L"ms-settings:system-remotedesktop",                L"sysdm.cpl,,5"},
+        {L"ms-settings:remotedesktop",                       L"sysdm.cpl,,5"},
+        {L"ms-settings:devicemanager",                       L"devmgmt.msc"},
+        {L"ms-settings:system-devicemanager",                L"devmgmt.msc"},
+        {L"ms-settings:computermanagement",                  L"compmgmt.msc"},
+        {L"ms-settings:activation",                          L"slui.exe"},
+        {L"ms-settings:appsfeatures",                        L"appwiz.cpl"},
+        {L"ms-settings:appsforwebsites",                     L"appwiz.cpl"},
+        {L"ms-settings:optionalfeatures",                    L"OptionalFeatures.exe"},
 
         // ── Power ────────────────────────────────────────────────────────────
-        {L"ms-settings:powersleep",                         L"powercfg.cpl"},
-        {L"ms-settings:battery",                            L"powercfg.cpl"},
-        {L"ms-settings:batterysaver",                       L"powercfg.cpl"},
-        {L"ms-settings:batterysaver-settings",              L"powercfg.cpl"},
-        {L"ms-settings:batterysaver-usagedetails",          L"powercfg.cpl"},
+        {L"ms-settings:powersleep",                          L"powercfg.cpl"},
+        {L"ms-settings:battery",                             L"powercfg.cpl"},
+        {L"ms-settings:batterysaver",                        L"powercfg.cpl"},
+        {L"ms-settings:batterysaver-settings",               L"powercfg.cpl"},
+        {L"ms-settings:batterysaver-usagedetails",           L"powercfg.cpl"},
 
         // ── Sound ────────────────────────────────────────────────────────────
-        {L"ms-settings:sound",                              L"mmsys.cpl"},
-        {L"ms-settings:sound-devices",                      L"mmsys.cpl"},
-        {L"ms-settings:audio",                              L"mmsys.cpl"},
-        {L"ms-settings:apps-volume",                        L"sndvol.exe"},
+        {L"ms-settings:sound",                               L"mmsys.cpl"},
+        {L"ms-settings:sound-devices",                       L"mmsys.cpl"},
+        {L"ms-settings:audio",                               L"mmsys.cpl"},
+        {L"ms-settings:apps-volume",                         L"sndvol.exe"},
 
         // ── Notifications / Taskbar ──────────────────────────────────────────
-        {L"ms-settings:notifications",                      NOTIF_AREA_CLSID},
-        {L"ms-settings:taskbar-notifications",              NOTIF_AREA_CLSID},
-        {L"ms-settings:taskbar-systemtray",                 NOTIF_AREA_CLSID},
-        {L"ms-settings:notifications-systemtray",           NOTIF_AREA_CLSID},
-        {L"ms-settings:systemtray",                         NOTIF_AREA_CLSID},
-        {L"ms-settings:notificationiconpreferences",        NOTIF_AREA_CLSID},
+        {L"ms-settings:notifications",                       NOTIF_AREA_CLSID},
+        {L"ms-settings:taskbar-notifications",               NOTIF_AREA_CLSID},
+        {L"ms-settings:taskbar-systemtray",                  NOTIF_AREA_CLSID},
+        {L"ms-settings:notifications-systemtray",            NOTIF_AREA_CLSID},
+        {L"ms-settings:systemtray",                          NOTIF_AREA_CLSID},
+        {L"ms-settings:notificationiconpreferences",         NOTIF_AREA_CLSID},
 
         // ── Input devices ────────────────────────────────────────────────────
-        {L"ms-settings:mousetouchpad",                      L"main.cpl"},
-        {L"ms-settings:devices-touchpad",                   L"main.cpl"},
-        {L"ms-settings:keyboard",                           L"main.cpl,,1"},
-        {L"ms-settings:typing",                             L"main.cpl,,1"},
+        {L"ms-settings:mousetouchpad",                       L"main.cpl"},
+        {L"ms-settings:devices-touchpad",                    L"main.cpl"},
+        {L"ms-settings:keyboard",                            L"main.cpl,,1"},
+        {L"ms-settings:typing",                              L"main.cpl,,1"},
         {L"ms-settings:pen",
-            L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+            w11 ? L"control.exe" : L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
         {L"ms-settings:pen-windowsink",
-            L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+            w11 ? L"control.exe" : L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
         {L"ms-settings:pen-windowsinksettings",
-            L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+            w11 ? L"control.exe" : L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
         {L"ms-settings:devices-touch",
-            L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+            w11 ? L"control.exe" : L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
         {L"ms-settings:autoplay",
             L"shell:::{9C60DE1E-E5FC-40f4-A487-460851A8D915}"},
 
@@ -292,7 +525,7 @@ static void InitMappings() {
             L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         {L"ms-settings:datausage",
             L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-proxy",                      L"inetcpl.cpl,,4"},
+        {L"ms-settings:network-proxy",                       L"inetcpl.cpl,,4"},
         {L"ms-settings:network-status",
             L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
         {L"ms-settings:network-dialup",
@@ -315,31 +548,35 @@ static void InitMappings() {
             L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
         {L"ms-settings:accounts",
             L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:startupapps",                        L"msconfig.exe"},
-
-        // ── Time & Language ───────────────────────────────────────────────────
-        {L"ms-settings:dateandtime",                        L"timedate.cpl"},
-        {L"ms-settings:dateandtime-region",                 L"timedate.cpl"},
-        {L"ms-settings:dateandtime-addclocks",              L"timedate.cpl,,1"},
-        {L"ms-settings:regionlanguage",                     L"intl.cpl"},
-        {L"ms-settings:regionformatting",                   L"intl.cpl"},
-        {L"ms-settings:language",                           L"intl.cpl"},
-
-        // ── Ease of Access (root only) ───────────────────────────────────────
-        {L"ms-settings:easeofaccess",
-            L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:startupapps",                         L"msconfig.exe"},
 
         // ── Default Apps ──────────────────────────────────────────────────────
+        // Microsoft.DefaultPrograms panel was removed on Win11 24H2.
+        // The CPL would open briefly and re-fire ms-settings:defaultapps,
+        // causing a bounce-back loop. Route to passthrough (FallbackMode) instead.
         {L"ms-settings:defaultapps",
-            L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
+            w11 ? WIN11_PASSTHROUGH
+                : L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
+
+        // ── Time & Language ───────────────────────────────────────────────────
+        {L"ms-settings:dateandtime",                         L"timedate.cpl"},
+        {L"ms-settings:dateandtime-region",                  L"timedate.cpl"},
+        {L"ms-settings:dateandtime-addclocks",               L"timedate.cpl,,1"},
+        {L"ms-settings:regionlanguage",                      L"intl.cpl"},
+        {L"ms-settings:regionformatting",                    L"intl.cpl"},
+        {L"ms-settings:language",                            L"intl.cpl"},
+
+        // ── Ease of Access ────────────────────────────────────────────────────
+        {L"ms-settings:easeofaccess",
+            L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
 
         // ── Recovery / Backup ─────────────────────────────────────────────────
         {L"ms-settings:backup",
             L"shell:::{B98A2BEA-7D42-4558-8BD1-832F41BAC6FD}"},
         {L"ms-settings:recovery",
-            L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
+            w11 ? L"control.exe" : L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
         {L"ms-settings:troubleshoot",
-            L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
+            w11 ? L"control.exe" : L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
         {L"ms-settings:deviceencryption",
             L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
     };
@@ -374,16 +611,41 @@ static bool IsShellClsid(const wchar_t* s) {
     return ToLower(s).find(L"shell:::") != std::wstring::npos;
 }
 
-// ── Win11 compat filter ───────────────────────────────────────────────────────
+// ── Win11 CLSID filter ────────────────────────────────────────────────────────
 
-static std::wstring ApplyWin11Compat(const std::wstring& target) {
-    if (!g_settings.win11CompatibilityMode || !g_isWin11) return target;
+static std::wstring ApplyWin11Filter(const std::wstring& target) {
+    if (!g_isWin11) return target;
 
     std::wstring lower = ToLower(target);
-    if (lower.find(L"shell:::") == 0 && !IsClsidSafeOnWin11(lower)) {
-        Wh_Log(L"Win11 compat: replacing unsafe CLSID '%s' with control.exe", target.c_str());
+
+    if (lower.find(L"shell:::") != 0) return target;
+
+    if (IsClsidLoopOnWin11(lower)) {
+        if (lower.find(L"ed834ed6") != std::wstring::npos) {
+            // Use the unified "explorer shell:::{ED834ED6} [-page]" syntax.
+            // This bypasses DelegateExecute and works on both Win10 and Win11.
+            if (lower.find(L"pagewallpaper") != std::wstring::npos) {
+                Wh_Log(L"Win11 loop-guard: {ED834ED6}\\pageWallpaper -> PERS_WALLPAPER");
+                return PERS_WALLPAPER;
+            }
+            Wh_Log(L"Win11 loop-guard: {ED834ED6} -> PERS_ROOT");
+            return PERS_ROOT;
+        }
+        if (lower.find(L"bb06c0e4") != std::wstring::npos) {
+            Wh_Log(L"Win11 loop-guard: {BB06C0E4} -> sysdm.cpl");
+            return L"sysdm.cpl";
+        }
+        Wh_Log(L"Win11 loop-guard: replacing loop CLSID '%s' with control.exe",
+               target.c_str());
         return L"control.exe";
     }
+
+    if (g_settings.win11CompatibilityMode && !IsClsidSafeOnWin11(lower)) {
+        Wh_Log(L"Win11 compat: replacing unconfirmed CLSID '%s' with control.exe",
+               target.c_str());
+        return L"control.exe";
+    }
+
     return target;
 }
 
@@ -421,21 +683,55 @@ static bool HandleFallback(const std::wstring& uri) {
 static void LaunchTarget(const std::wstring& command) {
     Wh_Log(L"Launching: %s", command.c_str());
 
-    // Use ShellExecuteW_orig for targets that need elevation / UAC
-    if (command == L"devmgmt.msc" ||
-    command == L"compmgmt.msc" ||
-    command == L"slui.exe" ||
-    command == L"C:\\Windows\\System32\\devmgmt.msc" ||
-    command == L"C:\\Windows\\System32\\compmgmt.msc" ||
-    command == L"C:\\Windows\\System32\\slui.exe" ||
-    command == L"OptionalFeatures.exe" ||
-    command == L"C:\\Windows\\System32\\OptionalFeatures.exe") {
-    ShellExecuteW_orig(nullptr, L"open", command.c_str(),
-                       nullptr, nullptr, SW_SHOWNORMAL);
-    return;
-}
+    if (!LoopGuardAllow(command)) {
+        Wh_Log(L"Launch suppressed by loop guard: %s", command.c_str());
+        return;
+    }
 
+    // Full command lines (exe + arguments)
+    {
+        std::wstring lower = ToLower(command);
+        bool isFullCmdLine =
+            (lower.find(L"rundll32.exe ")    != std::wstring::npos) ||
+            (lower.find(L"explorer.exe ")    != std::wstring::npos) ||
+            // "explorer shell:::{...}" — no .exe, but still a full command line
+            (lower.find(L"explorer shell:::") != std::wstring::npos) ||
+            (lower.find(L"control.exe /")    != std::wstring::npos);
 
+        if (isFullCmdLine) {
+            STARTUPINFOW si = {}; si.cb = sizeof(si);
+            si.dwFlags = STARTF_USESHOWWINDOW; si.wShowWindow = SW_SHOWNORMAL;
+            PROCESS_INFORMATION pi = {};
+            std::wstring mutable_cmd = command;
+            if (!CreateProcessW_orig(nullptr, mutable_cmd.data(), nullptr, nullptr,
+                                     FALSE, CREATE_UNICODE_ENVIRONMENT,
+                                     (LPVOID)g_childEnvBlock.c_str(),
+                                     nullptr, &si, &pi)) {
+                Wh_Log(L"CreateProcess failed for '%s' (%lu)",
+                       command.c_str(), GetLastError());
+            } else {
+                CloseHandle(pi.hProcess);
+                CloseHandle(pi.hThread);
+            }
+            return;
+        }
+    }
+
+    // ShellExecute passthrough for UAC targets
+    if (command == L"devmgmt.msc"                          ||
+        command == L"compmgmt.msc"                         ||
+        command == L"slui.exe"                             ||
+        command == L"OptionalFeatures.exe"                 ||
+        command == L"C:\\Windows\\System32\\devmgmt.msc"   ||
+        command == L"C:\\Windows\\System32\\compmgmt.msc"  ||
+        command == L"C:\\Windows\\System32\\slui.exe"      ||
+        command == L"C:\\Windows\\System32\\OptionalFeatures.exe") {
+        ShellExecuteW_orig(nullptr, L"open", command.c_str(),
+                           nullptr, nullptr, SW_SHOWNORMAL);
+        return;
+    }
+
+    // Generic router
     STARTUPINFOW si = {};
     si.cb = sizeof(si);
     si.dwFlags = STARTF_USESHOWWINDOW;
@@ -445,12 +741,10 @@ static void LaunchTarget(const std::wstring& command) {
 
     if (command.find(L".msc") != std::wstring::npos) {
         cmdLine = L"mmc.exe \"" + command + L"\"";
-    } else if (command.find(L".exe") != std::wstring::npos ||
-               command.find(L".cpl") != std::wstring::npos) {
-        if (command.find(L".cpl") != std::wstring::npos)
-            cmdLine = L"control.exe " + command;
-        else
-            cmdLine = command;
+    } else if (command.find(L".cpl") != std::wstring::npos) {
+        cmdLine = L"control.exe " + command;
+    } else if (command.find(L".exe") != std::wstring::npos) {
+        cmdLine = command;
     } else if (command.find(L"shell:::") == 0) {
         cmdLine = L"explorer.exe " + command;
     } else if (command.empty()) {
@@ -461,7 +755,9 @@ static void LaunchTarget(const std::wstring& command) {
 
     std::wstring mutableCmd = cmdLine;
     if (!CreateProcessW_orig(nullptr, mutableCmd.data(), nullptr, nullptr,
-                             FALSE, 0, nullptr, nullptr, &si, &pi)) {
+                             FALSE, CREATE_UNICODE_ENVIRONMENT,
+                             (LPVOID)g_childEnvBlock.c_str(),
+                             nullptr, &si, &pi)) {
         Wh_Log(L"CreateProcess failed for '%s' (error %lu)",
                cmdLine.c_str(), GetLastError());
         return;
@@ -513,14 +809,14 @@ static bool IsPersonalizationWindow(HWND hwnd) {
 static std::wstring ResolvePersonalizationBackground(HWND hwnd) {
     if (!g_settings.smartPersonalizationDetect) {
         Wh_Log(L"SmartPersonalizationDetection OFF -> Personalization root");
-        return PERS_ROOT_CLSID;
+        return PERS_ROOT;
     }
     if (IsPersonalizationWindow(hwnd)) {
         Wh_Log(L"personalization-background -> wallpaper page");
         return PERS_WALLPAPER;
     }
     Wh_Log(L"personalization-background -> Personalization root");
-    return PERS_ROOT_CLSID;
+    return PERS_ROOT;
 }
 
 // ── Core resolve logic ────────────────────────────────────────────────────────
@@ -532,14 +828,39 @@ struct ResolveResult {
 
 static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
     if (uri == L"ms-settings:personalization-background") {
-        std::wstring t = ApplyWin11Compat(ResolvePersonalizationBackground(hwnd));
+        // Bounce-back check: if this URI is returning quickly after our redirect,
+        // the target is dead — go straight to fallback.
+        if (BounceGuardIsBounce(uri)) {
+            Wh_Log(L"Bounce-back on personalization-background, routing to fallback");
+            bool handled = HandleFallback(uri);
+            return {L"", handled};
+        }
+        std::wstring t = ApplyWin11Filter(ResolvePersonalizationBackground(hwnd));
+        BounceGuardRecord(uri);
         return {t, true};
     }
 
     auto it = g_mappings.find(uri);
     if (it != g_mappings.end()) {
-        std::wstring t = ApplyWin11Compat(it->second);
+        // Bounce-back check before attempting the mapped target
+        if (BounceGuardIsBounce(uri)) {
+            Wh_Log(L"Bounce-back on '%s', routing to fallback", uri.c_str());
+            bool handled = HandleFallback(uri);
+            return {L"", handled};
+        }
+
+        std::wstring t = ApplyWin11Filter(it->second);
+
+        // PASSTHROUGH sentinel: this URI has no working CP equivalent on this OS.
+        // Route directly to fallback without spawning anything.
+        if (t == WIN11_PASSTHROUGH) {
+            Wh_Log(L"Passthrough sentinel for '%s', routing to fallback", uri.c_str());
+            bool handled = HandleFallback(uri);
+            return {L"", handled};
+        }
+
         Wh_Log(L"Mapped: %s -> %s", uri.c_str(), t.c_str());
+        BounceGuardRecord(uri);
         return {t, true};
     }
 
@@ -548,7 +869,19 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
         return {L"", handled};
     }
 
-    Wh_Log(L"Unmapped shell target, passing through: %s", uri.c_str());
+    // For direct shell::: CLSIDs: on Win11 only intercept known loop CLSIDs.
+    // On Win10, pass through — they were already explicitly passed by the caller
+    // as a CLSID, so no translation needed.
+    if (uri.find(L"shell:::") == 0) {
+        if (g_isWin11 && IsClsidLoopOnWin11(uri)) {
+            std::wstring t = ApplyWin11Filter(uri);
+            Wh_Log(L"Win11 loop-CLSID intercepted: %s -> %s", uri.c_str(), t.c_str());
+            return {t, true};
+        }
+        // Not a loop CLSID or not Win11: do not intercept
+    }
+
+    Wh_Log(L"Unmapped, passing through: %s", uri.c_str());
     return {L"", false};
 }
 
@@ -557,6 +890,14 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
 static std::wstring BaseNameLower(const std::wstring& path) {
     size_t pos = path.rfind(L'\\');
     return ToLower((pos != std::wstring::npos) ? path.substr(pos + 1) : path);
+}
+
+static bool IsControlSystemParams(const wchar_t* file, const wchar_t* params) {
+    if (!file || !params) return false;
+    std::wstring exe = BaseNameLower(file);
+    if (exe != L"control.exe" && exe != L"control") return false;
+    std::wstring arg = ToLower(params);
+    return (arg == L"system" || arg == L"microsoft.system");
 }
 
 static bool IsControlSystemCommand(const std::wstring& cmdLine) {
@@ -596,6 +937,15 @@ using ShellExecuteExW_t = BOOL(WINAPI*)(SHELLEXECUTEINFOW*);
 ShellExecuteExW_t ShellExecuteExW_orig;
 
 BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
+    if (IsChildProcess())
+        return ShellExecuteExW_orig(pei);
+
+    HookGuard guard;
+    if (guard.IsReentrant()) {
+        Wh_Log(L"ShellExecuteExW: reentrant call, passing through");
+        return ShellExecuteExW_orig(pei);
+    }
+
     if (!g_settings.enableRedirects || !pei)
         return ShellExecuteExW_orig(pei);
 
@@ -604,15 +954,29 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
            pei->lpFile       ? pei->lpFile       : L"(null)",
            pei->lpParameters ? pei->lpParameters : L"(null)");
 
+    if (IsControlSystemParams(pei->lpFile, pei->lpParameters)) {
+        Wh_Log(L"ShellExecuteExW: intercepted control system");
+        LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
+        if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
+        return TRUE;
+    }
+
     std::wstring uri;
     if (IsMsSettings(pei->lpFile))
         uri = NormalizeUri(pei->lpFile);
     else if (IsMsSettings(pei->lpParameters))
         uri = NormalizeUri(pei->lpParameters);
-    else if (IsShellClsid(pei->lpFile))
-        uri = ToLower(pei->lpFile);
-    else if (IsShellClsid(pei->lpParameters))
-        uri = ToLower(pei->lpParameters);
+    else if (IsShellClsid(pei->lpFile)) {
+        std::wstring lower = ToLower(pei->lpFile);
+        // Only intercept shell::: CLSIDs that are known loop-causers on Win11
+        if (g_isWin11 && IsClsidLoopOnWin11(lower))
+            uri = lower;
+    }
+    else if (IsShellClsid(pei->lpParameters)) {
+        std::wstring lower = ToLower(pei->lpParameters);
+        if (g_isWin11 && IsClsidLoopOnWin11(lower))
+            uri = lower;
+    }
 
     if (!uri.empty()) {
         auto result = ResolveUri(uri, pei->hwnd);
@@ -631,6 +995,15 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
 
 HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
                                      LPCWSTR params, LPCWSTR dir, INT show) {
+    if (IsChildProcess())
+        return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
+
+    HookGuard guard;
+    if (guard.IsReentrant()) {
+        Wh_Log(L"ShellExecuteW: reentrant call, passing through");
+        return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
+    }
+
     if (!g_settings.enableRedirects)
         return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
 
@@ -639,15 +1012,27 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
            file   ? file   : L"(null)",
            params ? params : L"(null)");
 
+    if (IsControlSystemParams(file, params)) {
+        Wh_Log(L"ShellExecuteW: intercepted control system");
+        LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
+        return SHELL_EXECUTE_SUCCESS;
+    }
+
     std::wstring uri;
     if (IsMsSettings(file))
         uri = NormalizeUri(file);
     else if (IsMsSettings(params))
         uri = NormalizeUri(params);
-    else if (IsShellClsid(file))
-        uri = ToLower(file);
-    else if (IsShellClsid(params))
-        uri = ToLower(params);
+    else if (IsShellClsid(file)) {
+        std::wstring lower = ToLower(file);
+        if (g_isWin11 && IsClsidLoopOnWin11(lower))
+            uri = lower;
+    }
+    else if (IsShellClsid(params)) {
+        std::wstring lower = ToLower(params);
+        if (g_isWin11 && IsClsidLoopOnWin11(lower))
+            uri = lower;
+    }
 
     if (!uri.empty()) {
         auto result = ResolveUri(uri, hwnd);
@@ -674,6 +1059,25 @@ BOOL WINAPI CreateProcessW_hook(
     LPSTARTUPINFOW       lpStartupInfo,
     LPPROCESS_INFORMATION lpProcessInformation)
 {
+    if (IsChildProcess()) {
+        return CreateProcessW_orig(
+            lpApplicationName, lpCommandLine,
+            lpProcessAttributes, lpThreadAttributes,
+            bInheritHandles, dwCreationFlags,
+            lpEnvironment, lpCurrentDirectory,
+            lpStartupInfo, lpProcessInformation);
+    }
+
+    HookGuard guard;
+    if (guard.IsReentrant()) {
+        return CreateProcessW_orig(
+            lpApplicationName, lpCommandLine,
+            lpProcessAttributes, lpThreadAttributes,
+            bInheritHandles, dwCreationFlags,
+            lpEnvironment, lpCurrentDirectory,
+            lpStartupInfo, lpProcessInformation);
+    }
+
     if (!g_settings.enableRedirects || g_settings.uiOnlyRedirects) {
         return CreateProcessW_orig(
             lpApplicationName, lpCommandLine,
@@ -687,7 +1091,7 @@ BOOL WINAPI CreateProcessW_hook(
 
     if (IsControlSystemCommand(cmdLine)) {
         Wh_Log(L"CreateProcessW: intercepted 'control system': %s", lpCommandLine);
-        LaunchTarget(SYSTEM_PROPS_CLSID);
+        LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
 
         if (lpProcessInformation)
             ZeroMemory(lpProcessInformation, sizeof(PROCESS_INFORMATION));
@@ -707,10 +1111,11 @@ BOOL WINAPI CreateProcessW_hook(
 // ── Windhawk entry points ─────────────────────────────────────────────────────
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"Redirect Settings to Control Panel v9.7.1 init");
+    Wh_Log(L"Redirect Settings to Control Panel v9.8.4 init");
 
     DetectWindowsVersion();
     LoadSettings();
+    BuildChildEnvironment();
     InitMappings();
     Wh_Log(L"%zu URI mappings loaded", g_mappings.size());
 
@@ -750,12 +1155,13 @@ BOOL Wh_ModInit() {
         }
     }
 
-    Wh_Log(L"Ready (EnableRedirects=%d UIOnly=%d SmartPers=%d Fallback=%d Win11Compat=%d)",
+    Wh_Log(L"Ready — EnableRedirects=%d UIOnly=%d SmartPers=%d Fallback=%d Win11Compat=%d MaxLaunches=%d",
         (int)g_settings.enableRedirects,
         (int)g_settings.uiOnlyRedirects,
         (int)g_settings.smartPersonalizationDetect,
         g_settings.fallbackMode,
-        (int)g_settings.win11CompatibilityMode);
+        (int)g_settings.win11CompatibilityMode,
+        g_settings.maxLaunchesPerUri);
     return TRUE;
 }
 
@@ -766,4 +1172,5 @@ void Wh_ModUninit() {
 void Wh_ModSettingsChanged() {
     Wh_Log(L"Settings changed, reloading");
     LoadSettings();
+    InitMappings();
 }

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -54,7 +54,7 @@ This mod intercepts modern `ms-settings:` URI protocols and forces Windows to op
   - "2": Pass through to ms-settings
 - Win11CompatibilityMode: false
   $name: Windows 11 Compatibility Mode
-  $description: "On Windows 11, replaces legacy shortcuts that no longer work with a plain Control Panel open instead."
+  $description: "On Windows 11, replaces legacy shortcuts that no longer work with a plain Control Panel open instead when possible."
 */
 // ==/WindhawkModSettings==
 

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -2,19 +2,20 @@
 // @id             settings-to-control-panel
 // @name           Redirect Settings to Control Panel
 // @description    Forces classic Control Panel to open instead of Windows 10/11 Settings app using native components
-// @version        9.6.0
+// @version        9.6.1
 // @author         babamohammed
 // @github         https://github.com/babamohammed2022
 // @license        MIT                                        
 // @include        explorer.exe
-// @compilerOptions -lshell32 -lkernel32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
 /*
-# Redirect Settings → Control Panel (v9.6.0)
+# Redirect Settings → Control Panel (v9.6.1)
 
 This mod intercepts modern `ms-settings:` URI protocols and forces Windows to open their classic Control Panel equivalents when possible. It relies entirely on native Windows components and legacy CLSIDs without requiring any third-party external programs.
+
+**Scope:** This mod only intercepts clicks from within Explorer (explorer.exe). ms-settings: links opened from Start Menu, Search, or other applications will not be redirected.
 
 ### Compatibility & Limitations:
 - **Windows 10:** Highly effective (~70% redirection success rate), as most legacy control panels are fully intact and accessible via standard shell hooks.
@@ -22,9 +23,9 @@ This mod intercepts modern `ms-settings:` URI protocols and forces Windows to op
 
 ### Key Features:
 - **Smart Desktop Personalization Hook:** Contextual awareness based on `hwnd` detection. Clicking "Personalize" from the desktop right-click menu correctly targets the main classic Personalization window, while clicking "Desktop Background" inside an existing shell folder still brings up the wallpaper page.
-- **CreateProcess Interception:** Intercepts modern overrides on commands like `control system` to dynamically fall back onto legacy System Properties (`sysdm.cpl`).
+- **Precise Command Interception:** Only intercepts exact `control system` commands, avoiding conflicts with other Control Panel applets.
 
-### Settings (v9.6.0):
+### Settings (v9.6.1):
 - **EnableRedirects** — Turns the mod on or off completely.
 - **UIOnlyRedirects** — Safer mode: only intercepts clicks from Explorer. Leaves scripts and installers alone.
 - **SmartPersonalizationDetection** — When ON, right-clicking the desktop opens Personalization; clicking "Desktop Background" from inside it opens the wallpaper picker. When OFF, both always open Personalization.
@@ -36,7 +37,7 @@ This mod intercepts modern `ms-settings:` URI protocols and forces Windows to op
 // ==WindhawkModSettings==
 /*
 - EnableRedirects: true
-  $name: Enable Redirects (Kill Switch)
+  $name: Enable Redirects 
   $description: "Turns the mod on or off. When off, all Settings calls open normally without any redirect."
 - UIOnlyRedirects: false
   $name: Non-Invasive UI Mode
@@ -44,13 +45,13 @@ This mod intercepts modern `ms-settings:` URI protocols and forces Windows to op
 - SmartPersonalizationDetection: true
   $name: Smart Personalization Detection
   $description: "When ON, right-clicking the desktop opens Personalization, while clicking Desktop Background from inside it opens the wallpaper picker. When OFF, both always open Personalization."
-- FallbackMode: 1
+- FallbackMode: "1"
   $name: Fallback Mode (unmapped URIs)
   $description: "What to do when a Settings page has no classic equivalent. Ignore it silently, open Control Panel as a fallback, or let the original Settings app open."
   $options:
-  - 0: Ignore (silent fail)
-  - 1: Open control.exe
-  - 2: Pass through to ms-settings
+  - "0": Ignore (silent fail)
+  - "1": Open control.exe
+  - "2": Pass through to ms-settings
 - Win11CompatibilityMode: false
   $name: Windows 11 Compatibility Mode
   $description: "On Windows 11, replaces legacy shortcuts that no longer work with a plain Control Panel open instead."
@@ -64,9 +65,12 @@ This mod intercepts modern `ms-settings:` URI protocols and forces Windows to op
 #include <algorithm>
 #include <unordered_map>
 #include <unordered_set>
-
+#include <vector>
 #define SYSTEM_PROPERTIES_FALLBACK L"shell:::{BB06C0E4-D293-4f75-8A90-CB05B6477EEE}"
 #define NOTIF_AREA_CLSID L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"
+
+// ShellExecuteW success value (any value > 32 means success)
+static const HINSTANCE SHELL_EXECUTE_SUCCESS = (HINSTANCE)33;
 
 // ── Settings ─────────────────────────────────────────────────────────────────
 
@@ -84,10 +88,14 @@ static void LoadSettings() {
     g_settings.enableRedirects            = Wh_GetIntSetting(L"EnableRedirects")            != 0;
     g_settings.uiOnlyRedirects            = Wh_GetIntSetting(L"UIOnlyRedirects")            != 0;
     g_settings.smartPersonalizationDetect = Wh_GetIntSetting(L"SmartPersonalizationDetection") != 0;
-    g_settings.fallbackMode               = (int)Wh_GetIntSetting(L"FallbackMode");
+    
+    PCWSTR fallbackStr = Wh_GetStringSetting(L"FallbackMode");
+    g_settings.fallbackMode = fallbackStr ? _wtoi(fallbackStr) : 1;
+    Wh_FreeStringSetting(fallbackStr);
+    
     g_settings.win11CompatibilityMode     = Wh_GetIntSetting(L"Win11CompatibilityMode")     != 0;
 
-    Wh_Log(L"[SETTINGS] EnableRedirects=%d  UIOnly=%d  SmartPers=%d  Fallback=%d  Win11Compat=%d",
+    Wh_Log(L"EnableRedirects=%d  UIOnly=%d  SmartPers=%d  Fallback=%d  Win11Compat=%d",
         (int)g_settings.enableRedirects,
         (int)g_settings.uiOnlyRedirects,
         (int)g_settings.smartPersonalizationDetect,
@@ -102,27 +110,25 @@ static bool g_isWin11 = false;
 static void DetectWindowsVersion() {
     OSVERSIONINFOEXW osvi = {};
     osvi.dwOSVersionInfoSize = sizeof(osvi);
-    // Use RtlGetVersion to bypass compat shims
     using RtlGetVersion_t = NTSTATUS(WINAPI*)(OSVERSIONINFOEXW*);
     HMODULE hNtdll = GetModuleHandleW(L"ntdll.dll");
     if (hNtdll) {
         auto fn = (RtlGetVersion_t)GetProcAddress(hNtdll, "RtlGetVersion");
         if (fn) fn(&osvi);
     }
-    // Windows 11 is 10.0.22000+
     g_isWin11 = (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber >= 22000);
-    Wh_Log(L"[VERSION] Build %lu  IsWin11=%d", osvi.dwBuildNumber, (int)g_isWin11);
+    Wh_Log(L"Build %lu  IsWin11=%d", osvi.dwBuildNumber, (int)g_isWin11);
 }
 
 // CLSIDs considered safe on Win11 (well-tested, not deprecated)
 static const std::unordered_set<std::wstring> g_win11SafeClsids = {
-    L"shell:::{8e908fc9-becc-40f6-915b-f4ca0e70d03d}", // Network and Sharing
-    L"shell:::{7007acc7-3202-11d1-aad2-00805fc1270e}", // Network Connections
-    L"shell:::{a8a91a66-3a7d-4424-8d24-04e180695c7a}", // Devices and Printers
-    L"shell:::{4026492f-2f69-46b8-b9bf-5654fc07e423}", // Windows Firewall
-    L"shell:::{20d04fe0-3aea-1069-a2d8-08002b30309d}", // This PC / Computer
-    L"shell:::{60632754-c523-4b62-b45c-4172da012619}", // User Accounts
-    L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}", // Notification Area Icons
+    L"shell:::{8e908fc9-becc-40f6-915b-f4ca0e70d03d}",
+    L"shell:::{7007acc7-3202-11d1-aad2-00805fc1270e}",
+    L"shell:::{a8a91a66-3a7d-4424-8d24-04e180695c7a}",
+    L"shell:::{4026492f-2f69-46b8-b9bf-5654fc07e423}",
+    L"shell:::{20d04fe0-3aea-1069-a2d8-08002b30309d}",
+    L"shell:::{60632754-c523-4b62-b45c-4172da012619}",
+    L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}",
 };
 
 static bool IsClsidSafeOnWin11(const std::wstring& target) {
@@ -134,7 +140,6 @@ static bool IsClsidSafeOnWin11(const std::wstring& target) {
 // ── Mappings ─────────────────────────────────────────────────────────────────
 
 static std::unordered_map<std::wstring, std::wstring> g_mappings;
-static std::unordered_map<std::wstring, std::wstring> g_controlNameMappings;
 
 static std::wstring ToLower(std::wstring s) {
     std::transform(s.begin(), s.end(), s.begin(), ::towlower);
@@ -147,12 +152,13 @@ static void InitMappings() {
 
     g_mappings = {
         // NOTE: ms-settings:personalization-background is handled specially via hwnd
-        // detection in the hook — it is intentionally absent from this table.
         {L"shell:::{52205fd8-5dfb-447d-801a-d0b52f2e83e1}", L"explorer.exe shell:UsersLibrariesFolder"},
         {L"shell:::{bb06c0e4-d293-4f75-8a90-cb05b6477eee}", SYSTEM_PROPERTIES_FALLBACK},
         {L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}", L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"},
         {L"explorer.exe", L"explorer.exe"},
         {L"explorer", L"explorer"},
+        
+        // Personalization
         {L"ms-settings:personalization-background-wallpaper", kWall},
         {L"ms-settings:personalization-background-slideshow", kWall},
         {L"ms-settings:background", kWall},
@@ -161,69 +167,100 @@ static void InitMappings() {
         {L"ms-settings:colors", kPers + L"\\pageColorization"},
         {L"ms-settings:themes", kPers},
         {L"ms-settings:lockscreen", kPers},
-        {L"ms-settings:regionlanguage", L"intl.cpl"},
-        {L"ms-settings:regionformatting", L"intl.cpl"},
-        {L"ms-settings:language", L"intl.cpl"},
-        {L"ms-settings:typing", L"main.cpl,,1"},
+        {L"ms-settings:personalization-start", kPers},
+        {L"ms-settings:personalization-start-places", kPers},
+        {L"ms-settings:personalization-touchkeyboard", kPers},
+        {L"ms-settings:deviceusage", kPers},
+        {L"ms-settings:fonts", L"shell:::{BD84B380-8CA2-1069-AB1D-08000948F534}"},
+        
+        // System
         {L"ms-settings:system", SYSTEM_PROPERTIES_FALLBACK},
         {L"ms-settings:about", SYSTEM_PROPERTIES_FALLBACK},
         {L"ms-settings:sysinfo", SYSTEM_PROPERTIES_FALLBACK},
+        {L"ms-settings:system-about", SYSTEM_PROPERTIES_FALLBACK},
+        {L"ms-settings:system-advanced", SYSTEM_PROPERTIES_FALLBACK},
+        {L"ms-settings:system-remotedesktop", L"sysdm.cpl,,5"},
+        {L"ms-settings:system-protection", L"sysdm.cpl,,4"},
+        {L"ms-settings:remotedesktop", L"sysdm.cpl,,5"},
         {L"ms-settings:display", L"desk.cpl"},
         {L"ms-settings:display-advanced", L"desk.cpl"},
-        {L"ms-settings:notifications", NOTIF_AREA_CLSID},
-        {L"ms-settings:backup", L"shell:::{B98A2BEA-7D42-4558-8BD1-832F41BAC6FD}"},
-        {L"ms-settings:optionalfeatures", L"OptionalFeatures.exe"},
-        {L"ms-settings:devicemanager", L"devmgmt.msc"},
+        {L"ms-settings:display-advancedgraphics", L"desk.cpl"},
+        {L"ms-settings:nightlight", L"desk.cpl"},
         {L"ms-settings:display-advanced-color", L"colorcpl.exe"},
         {L"ms-settings:colorcpl", L"colorcpl.exe"},
+        {L"ms-settings:powersleep", L"powercfg.cpl"},
+        {L"ms-settings:battery", L"powercfg.cpl"},
+        {L"ms-settings:batterysaver", L"powercfg.cpl"},
+        {L"ms-settings:batterysaver-settings", L"powercfg.cpl"},
+        {L"ms-settings:batterysaver-usagedetails", L"powercfg.cpl"},
         {L"ms-settings:sound", L"mmsys.cpl"},
+        {L"ms-settings:sound-devices", L"mmsys.cpl"},
+        {L"ms-settings:audio", L"mmsys.cpl"},
+        {L"ms-settings:apps-volume", L"sndvol.exe"},
+        {L"ms-settings:notifications", NOTIF_AREA_CLSID},
+        {L"ms-settings:typing", L"main.cpl,,1"},
+        {L"ms-settings:mousetouchpad", L"main.cpl"},
+        {L"ms-settings:devices-touchpad", L"main.cpl"},
+        {L"ms-settings:keyboard", L"main.cpl"},
+        {L"ms-settings:storagesense", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:storagepolicies", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:disksandvolumes", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:savelocations", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:optionalfeatures", L"OptionalFeatures.exe"},
+        {L"ms-settings:devicemanager", L"devmgmt.msc"},
+        {L"ms-settings:system-devicemanager", L"devmgmt.msc"},
+        {L"ms-settings:computerManagement", L"compmgmt.msc"},
+        {L"ms-settings:activation", L"slui.exe"},
+        {L"ms-settings:appsfeatures", L"appwiz.cpl"},
+        {L"ms-settings:appsforwebsites", L"appwiz.cpl"},
+        
+        // Network
         {L"ms-settings:network", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         {L"ms-settings:network-wifi", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         {L"ms-settings:network-ethernet", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         {L"ms-settings:network-vpn", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-airplanemode", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-mobilehotspot", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-cellular", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:datausage", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         {L"ms-settings:network-proxy", L"inetcpl.cpl,,4"},
         {L"ms-settings:network-status", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
-        {L"ms-settings:datausage", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-dialup", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
+        {L"ms-settings:network-advancedsettings", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
+        {L"ms-settings:firewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
+        {L"ms-settings:network-firewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
+        
+        // Accounts
         {L"ms-settings:yourinfo", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
         {L"ms-settings:emailandaccounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
         {L"ms-settings:signinoptions", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
         {L"ms-settings:otherusers", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
         {L"ms-settings:workplace", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
         {L"ms-settings:family", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:accounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:accounts-signinoptions", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:accounts-otherusers", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:signinoptions-face", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:signinoptions-fingerprint", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:signinoptions-dynamiclock", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:signinoptions-launchfaceenrollment", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:signinoptions-launchfingerprintenrollment", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:signinoptions-launchsecuritykeyenrollment", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:startupapps", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        // other personalization mapping
+        {L"control desktop", kPers}, 
+        // Time & Language
+        {L"ms-settings:regionlanguage", L"intl.cpl"},
+        {L"ms-settings:regionformatting", L"intl.cpl"},
+        {L"ms-settings:language", L"intl.cpl"},
         {L"ms-settings:dateandtime", L"timedate.cpl"},
+        {L"ms-settings:dateandtime-region", L"timedate.cpl"},
+        {L"ms-settings:dateandtime-addclocks", L"timedate.cpl,,1"},
+        
+        // Ease of Access
         {L"ms-settings:easeofaccess", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
         {L"ms-settings:easeofaccess-highcontrast", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
         {L"ms-settings:easeofaccess-closedcaptioning", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:printers", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:printers-scanners", L"shell:::{2227A280-3AEA-1069-A2DE-08002B30309D}"},
-        {L"ms-settings:mousetouchpad", L"main.cpl"},
-        {L"ms-settings:devices-touchpad", L"main.cpl"},
-        {L"ms-settings:keyboard", L"main.cpl"},
-        {L"ms-settings:bluetooth", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:usb", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:autoplay", L"shell:::{9C60DE1E-E5FC-40f4-A487-460851A8D915}"},
-        {L"ms-settings:powersleep", L"powercfg.cpl"},
-        {L"ms-settings:pen", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
-        {L"ms-settings:appsfeatures", L"appwiz.cpl"},
-        {L"ms-settings:defaultapps", L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
-        {L"ms-settings:firewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
-        {L"ms-settings:network-firewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
-        {L"ms-settings:home", L"shell:::{59031a47-3f72-44a7-89c5-5595fe6b30ee}"},
-        {L"ms-settings:yourinfo-profile", L"shell:::{59031a47-3f72-44a7-89c5-5595fe6b30ee}"},
-        {L"ms-settings:storagesense", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:storagepolicies", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:disksandvolumes", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:computerManagement", L"compmgmt.msc"},
-        {L"ms-settings:taskbar", NOTIF_AREA_CLSID},
-        {L"ms-settings:taskbar-notifications", NOTIF_AREA_CLSID},
-        {L"ms-settings:notifications-systemtray", NOTIF_AREA_CLSID},
-        {L"ms-settings:systemtray", NOTIF_AREA_CLSID},
-        {L"ms-settings:taskbar-systemtray", NOTIF_AREA_CLSID},
-        {L"ms-settings:notificationiconpreferences", NOTIF_AREA_CLSID},
-        {L"explorer shell:::{ed834ed6-4b5a-4bfe-8f11-a626dcb6a921}", L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"},
-        {L"shell:::{f20df4e5-ea01-41a2-b02a-dcbd92d4696e}", L"__display__"},
-        {L"shell:::{20d04fe0-3aea-1069-a2d8-08002b30309d}", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\0\\::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}", L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\0\\::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"},
         {L"ms-settings:easeofaccess-narrator", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
         {L"ms-settings:easeofaccess-magnifier", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
         {L"ms-settings:easeofaccess-cursor", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
@@ -233,125 +270,80 @@ static void InitMappings() {
         {L"ms-settings:easeofaccess-colorfilter", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
         {L"ms-settings:easeofaccess-audio", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
         {L"ms-settings:easeofaccess-speechrecognition", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:audio", L"mmsys.cpl"},
-        {L"ms-settings:system-advanced", SYSTEM_PROPERTIES_FALLBACK},
-        {L"ms-settings:system-remotedesktop", L"sysdm.cpl,,5"},
-        {L"ms-settings:system-about", SYSTEM_PROPERTIES_FALLBACK},
-        {L"ms-settings:system-protection", L"sysdm.cpl,,4"},
-        {L"ms-settings:system-devicemanager", L"devmgmt.msc"},
-        {L"ms-settings:privacy", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:privacy-webcam", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:privacy-microphone", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:privacy-location", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:accounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:accounts-signinoptions", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:accounts-otherusers", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:gaming", L"control.exe"},
-        {L"ms-settings:gaming-gamebar", L"control.exe"},
-        {L"ms-settings:gaming-gamemode", L"control.exe"},
-        {L"ms-settings:gaming-gameDVR", L"control.exe"},
-        {L"ms-settings:gaming-broadcasting", L"control.exe"},
-        {L"ms-settings:appsforwebsites", L"appwiz.cpl"},
-        {L"ms-settings:startupapps", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:videoplayback", L"control.exe"},
-        {L"ms-settings:defaultapps-maps", L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
-        {L"ms-settings:cortana", L"control.exe"},
-        {L"ms-settings:search", L"control.exe"},
-        {L"ms-settings:cortana-permissions", L"control.exe"},
-        {L"ms-settings:dateandtime-region", L"timedate.cpl"},
-        {L"ms-settings:dateandtime-addclocks", L"timedate.cpl,,1"},
-        {L"ms-settings:speech", L"control.exe"},
-        {L"ms-settings:phone", L"control.exe"},
-        {L"ms-settings:phone-defaultapps", L"control.exe"},
-        {L"ms-settings:multitasking", L"control.exe"},
-        {L"ms-settings:multitasking-snap", L"control.exe"},
-        {L"ms-settings:project", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:pen-windowsink", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
-        {L"ms-settings:pen-windowsinksettings", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
-        {L"ms-settings:network-airplanemode", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-mobilehotspot", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-dialup", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
-        {L"ms-settings:network-advancedsettings", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
-        {L"ms-settings:battery", L"powercfg.cpl"},
-        {L"ms-settings:batterysaver", L"powercfg.cpl"},
-        {L"ms-settings:batterysaver-settings", L"powercfg.cpl"},
-        {L"ms-settings:batterysaver-usagedetails", L"powercfg.cpl"},
-        {L"ms-settings:storagepolicies-other", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:recovery", L"control.exe"},
-        {L"ms-settings:recovery-reset", L"control.exe"},
-        {L"ms-settings:tabletmode", L"control.exe"},
-        {L"ms-settings:connecteddevices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:signinoptions-face", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:signinoptions-fingerprint", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:signinoptions-dynamiclock", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
         {L"ms-settings:easeofaccess-cursorandpointersize", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
         {L"ms-settings:easeofaccess-visualeffects", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
         {L"ms-settings:easeofaccess-display", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:nearbysharing", L"control.exe"},
-        {L"ms-settings:crossdevice", L"control.exe"},
-        {L"ms-settings:clipboard", L"control.exe"},
-        {L"ms-settings:messaging", L"control.exe"},
-        {L"ms-settings:remotedesktop", L"sysdm.cpl,,5"},
+        {L"ms-settings:easeofaccess-mousepointer", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        
+        // Devices
+        {L"ms-settings:printers", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:printers-scanners", L"shell:::{2227A280-3AEA-1069-A2DE-08002B30309D}"},
+        {L"ms-settings:bluetooth", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:usb", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:connecteddevices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:camera", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:mobile-devices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:privacy-customdevices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:autoplay", L"shell:::{9C60DE1E-E5FC-40f4-A487-460851A8D915}"},
+        {L"ms-settings:pen", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:pen-windowsink", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:pen-windowsinksettings", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:devices-touch", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        
+        // Default Programs
+        {L"ms-settings:defaultapps", L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
+        {L"ms-settings:defaultapps-maps", L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
+        
+        // Taskbar / Notification Area (verified mappings)
+        {L"ms-settings:taskbar-notifications", NOTIF_AREA_CLSID},
+        {L"ms-settings:taskbar-systemtray", NOTIF_AREA_CLSID},
+        {L"ms-settings:notifications-systemtray", NOTIF_AREA_CLSID},
+        {L"ms-settings:systemtray", NOTIF_AREA_CLSID},
+        {L"ms-settings:notificationiconpreferences", NOTIF_AREA_CLSID},
+        {L"ms-settings:privacy-notifications", L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"},
+        
+        // Recovery / Backup
+        {L"ms-settings:backup", L"shell:::{B98A2BEA-7D42-4558-8BD1-832F41BAC6FD}"},
+        {L"ms-settings:recovery", L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
+        {L"ms-settings:troubleshoot", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
+        {L"ms-settings:findmydevice", L"shell:::{F942C606-0914-47AB-BE56-1321B8035096}"},
+        {L"ms-settings:deviceencryption", L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
+        
+        // Security & Maintenance
+        {L"shell:microsoft.actioncenter", L"wscui.cpl"},
         {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\1\\::{0df44eaa-ff21-4412-828e-260a8728e7f1}", L"wscui.cpl"},
         {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\2\\::{025a5937-a6be-4686-a844-36fe4bec8b6d}", L"powercfg.cpl"},
         {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\3\\::{c555438b-3c23-4769-a71f-b6d3d9b6053a}", L"__display__"},
-        {L"shell:microsoft.actioncenter", L"wscui.cpl"},
-        {L"ms-settings:recovery", L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
-        {L"ms-settings:troubleshoot", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
-        {L"ms-settings:activation", L"slui.exe"},
-        {L"ms-settings:savelocations", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\0\\::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}", L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\0\\::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"},
+        
+        // Quiethours / Focus Assist
         {L"ms-settings:quiethours", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
         {L"ms-settings:quietmomentsscheduled", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
         {L"ms-settings:quietmomentspresentation", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
         {L"ms-settings:quietmomentsgame", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:sound-devices", L"mmsys.cpl"},
-        {L"ms-settings:apps-volume", L"sndvol.exe"},
-        {L"ms-settings:personalization-start", L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"},
-        {L"ms-settings:personalization-start-places", L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"},
-        {L"ms-settings:personalization-touchkeyboard", L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"},
-        {L"ms-settings:deviceusage", L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"},
-        {L"ms-settings:fonts", L"shell:::{BD84B380-8CA2-1069-AB1D-08000948F534}"},
-        {L"ms-settings:nightlight", L"desk.cpl"},
-        {L"ms-settings:display-advancedgraphics", L"desk.cpl"},
-        {L"ms-settings:easeofaccess-mousepointer", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:network-cellular", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:privacy-speech", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
         {L"ms-settings:privacy-feedback", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
         {L"ms-settings:privacy-activityhistory", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:privacy-accountinfo", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:privacy-contacts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:privacy-calendar", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:privacy-phonecalls", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:privacy-callhistory", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:privacy-email", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:privacy-tasks", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:privacy-messaging", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:privacy-notifications", L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"},
-        {L"ms-settings:privacy-voiceactivation", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
-        {L"ms-settings:privacy-radios", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:privacy-customdevices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
         {L"ms-settings:privacy-appdiagnostics", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:privacy-automaticfiledownloads", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:privacy-documents", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:privacy-downloadsfolder", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:privacy-musiclibrary", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:privacy-pictures", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:privacy-broadfilesystemaccess", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:windowsdefender", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
+        {L"ms-settings:privacy-feedback-telemetryviewergroup", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
+        
+        // Speech
+        {L"ms-settings:privacy-speech", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
+        {L"ms-settings:privacy-voiceactivation", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
         {L"ms-settings:privacy-speechtyping", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
+        
+        // Search
         {L"ms-settings:search-permissions", L"shell:::{04731B67-D933-450a-90E6-4ACD2E9408FE}"},
         {L"ms-settings:cortana-windowssearch", L"shell:::{04731B67-D933-450a-90E6-4ACD2E9408FE}"},
-        {L"ms-settings:windowsdefender", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:findmydevice", L"shell:::{F942C606-0914-47AB-BE56-1321B8035096}"},
-        {L"ms-settings:deviceencryption", L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
-        {L"ms-settings:developers", L"control.exe"},
-        {L"ms-settings:windowsinsider", L"control.exe"},
-        {L"ms-settings:privacy-feedback-telemetryviewergroup", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:signinoptions-launchfaceenrollment", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:signinoptions-launchfingerprintenrollment", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:signinoptions-launchsecuritykeyenrollment", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:camera", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:devices-touch", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
-        {L"ms-settings:mobile-devices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        
+        // Home / Profile
+        {L"ms-settings:home", L"shell:::{59031a47-3f72-44a7-89c5-5595fe6b30ee}"},
+        {L"ms-settings:yourinfo-profile", L"shell:::{59031a47-3f72-44a7-89c5-5595fe6b30ee}"},
+        
+        // Shell CLSID mappings
+        {L"shell:::{f20df4e5-ea01-41a2-b02a-dcbd92d4696e}", L"__display__"},
+        {L"shell:::{20d04fe0-3aea-1069-a2d8-08002b30309d}", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"explorer shell:::{ed834ed6-4b5a-4bfe-8f11-a626dcb6a921}", L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"},
         {L"shell:::{1206f5f1-0569-412c-8fec-3204630dfb70}", L"shell:::{1206F5F1-0569-412C-8FEC-3204630DFB70}"},
         {L"shell:::{d9ef8727-cac2-4e60-809e-86f80a666c91}", L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
         {L"shell:::{9fe63afd-59cf-4419-9775-abcc3849f861}", L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
@@ -362,29 +354,7 @@ static void InitMappings() {
         {L"shell:::{d20ea4e1-3957-11d2-a40b-0c5020524153}", L"shell:::{D20EA4E1-3957-11d2-A40B-0C5020524153}"},
         {L"shell:::{bb64f8a7-bee7-4e1a-ab8d-7d8273f7fdb6}", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
         {L"shell:::{58e3c745-d971-4081-9034-86e34b30836a}", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
-        {L"shell:::{04731b67-d933-450a-90e6-4acd2e9408fe}", L"shell:::{04731B67-D933-450a-90E6-4ACD2E9408FE}"}
-    };
-
-    // control.exe /name mappings
-    g_controlNameMappings = {
-        {L"microsoft.personalization", kPers},
-        {L"microsoft.personalization/page pagewallpaper", kWall},
-        {L"microsoft.color", kPers + L"\\pageColorization"},
-        {L"microsoft.sound", L"mmsys.cpl"},
-        {L"microsoft.system", SYSTEM_PROPERTIES_FALLBACK},
-        {L"microsoft.programsandfeatures", L"appwiz.cpl"},
-        {L"microsoft.devicesandprinters", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"microsoft.networkandsharingcenter", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"microsoft.windowsfirewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
-        {L"microsoft.poweroptions", L"powercfg.cpl"},
-        {L"microsoft.mouse", L"main.cpl"},
-        {L"microsoft.keyboard", L"main.cpl,,1"},
-        {L"microsoft.useraccounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"microsoft.easeofaccesscenter", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"microsoft.dateandtime", L"timedate.cpl"},
-        {L"microsoft.region", L"intl.cpl"},
-        {L"microsoft.defaultprograms", L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
-        {L"microsoft.notificationareaicons", NOTIF_AREA_CLSID}
+        {L"shell:::{04731b67-d933-450a-90e6-4acd2e9408fe}", L"shell:::{04731B67-D933-450a-90E6-4ACD2E9408FE}"},
     };
 }
 
@@ -395,7 +365,7 @@ static std::wstring NormalizeUri(const std::wstring& uri) {
 
     size_t pos = result.find(L"ms-settings://");
     if (pos != std::wstring::npos)
-        result = L"ms-settings:" + result.substr(pos + 15);
+        result = L"ms-settings:" + result.substr(pos + 14);  // Fixed: 14, not 15
 
     pos = result.find(L'?');
     if (pos != std::wstring::npos)
@@ -419,17 +389,13 @@ static bool IsShellClsid(const wchar_t* s) {
 
 // ── Win11 compat filter ───────────────────────────────────────────────────────
 
-// Applies Win11CompatibilityMode: if the resolved target is a shell CLSID that is
-// not in the known-safe list, substitute control.exe.
 static std::wstring ApplyWin11Compat(const std::wstring& target) {
     if (!g_settings.win11CompatibilityMode || !g_isWin11) return target;
 
-    // Only shell CLSID targets are at risk of being broken on Win11.
-    // Executable targets (.exe, .cpl, .msc) are left as-is.
     std::wstring lower = ToLower(target);
     if (lower.find(L"shell:::") == 0) {
         if (!IsClsidSafeOnWin11(lower)) {
-            Wh_Log(L"[WIN11-COMPAT] Replacing unsafe CLSID '%s' with control.exe", target.c_str());
+            Wh_Log(L"Win11 compat: replacing unsafe CLSID '%s' with control.exe", target.c_str());
             return L"control.exe";
         }
     }
@@ -438,17 +404,13 @@ static std::wstring ApplyWin11Compat(const std::wstring& target) {
 
 // ── Fallback handling ─────────────────────────────────────────────────────────
 
-// Returns false if the caller should fall through to the original function (passthrough mode).
-// Returns true if the caller should return early (ignore or control.exe modes were handled).
 static bool HandleFallback(const std::wstring& uri) {
     switch (g_settings.fallbackMode) {
         case 0: // ignore
-            Wh_Log(L"[FALLBACK] Ignoring unmapped URI: %s", uri.c_str());
+            Wh_Log(L"Fallback: ignoring unmapped URI: %s", uri.c_str());
             return true;
         case 1: // control.exe
-            Wh_Log(L"[FALLBACK] Opening control.exe for unmapped URI: %s", uri.c_str());
-            // LaunchTarget is defined below; we call it inline here via a forward path.
-            // We use CreateProcessW directly to avoid circular call with LaunchTarget.
+            Wh_Log(L"Fallback: opening control.exe for unmapped URI: %s", uri.c_str());
             {
                 std::wstring cmd = L"control.exe";
                 STARTUPINFOW si = {}; si.cb = sizeof(si);
@@ -461,7 +423,7 @@ static bool HandleFallback(const std::wstring& uri) {
             return true;
         case 2: // passthrough
         default:
-            Wh_Log(L"[FALLBACK] Passing through unmapped URI to original: %s", uri.c_str());
+            Wh_Log(L"Fallback: passing through unmapped URI to original: %s", uri.c_str());
             return false;
     }
 }
@@ -469,7 +431,7 @@ static bool HandleFallback(const std::wstring& uri) {
 // ── LaunchTarget ──────────────────────────────────────────────────────────────
 
 static void LaunchTarget(const std::wstring& command) {
-    Wh_Log(L"[EXEC] %s", command.c_str());
+    Wh_Log(L"Exec: %s", command.c_str());
 
     STARTUPINFOW si = {};
     si.cb = sizeof(si);
@@ -478,7 +440,10 @@ static void LaunchTarget(const std::wstring& command) {
     PROCESS_INFORMATION pi = {};
 
     std::wstring cmdLine;
-    if (command.find(L".exe") != std::wstring::npos || command.find(L".msc") != std::wstring::npos) {
+    if (command.find(L".msc") != std::wstring::npos) {
+        // Launch .msc files via mmc.exe
+        cmdLine = L"mmc.exe " + command;
+    } else if (command.find(L".exe") != std::wstring::npos) {
         cmdLine = command;
     } else if (command.find(L"shell:::") == 0) {
         cmdLine = L"explorer.exe " + command;
@@ -494,7 +459,7 @@ static void LaunchTarget(const std::wstring& command) {
         if (pi.hProcess) CloseHandle(pi.hProcess);
         if (pi.hThread)  CloseHandle(pi.hThread);
     } else {
-        Wh_Log(L"[ERROR] CreateProcess failed for: %s (error: %lu)", cmdLine.c_str(), GetLastError());
+        Wh_Log(L"ERROR: CreateProcess failed for: %s (error: %lu)", cmdLine.c_str(), GetLastError());
     }
 }
 
@@ -502,7 +467,7 @@ static void LaunchTarget(const std::wstring& command) {
 
 static bool IsPersonalizationWindow(HWND hwnd) {
     if (!hwnd) {
-        Wh_Log(L"[HWND] hwnd is NULL -> context menu, not Personalization window");
+        Wh_Log(L"HWND: hwnd is NULL -> context menu");
         return false;
     }
 
@@ -513,23 +478,23 @@ static bool IsPersonalizationWindow(HWND hwnd) {
         GetClassNameW(h, cls, 256);
         GetWindowTextW(h, title, 512);
 
-        Wh_Log(L"[HWND] %p  class='%s'  title='%s'", h, cls, title);
+        Wh_Log(L"HWND: %p  class='%s'  title='%s'", h, cls, title);
 
         std::wstring c = ToLower(cls);
         std::wstring t = ToLower(title);
 
         if (c == L"progman" || c == L"workerw" || c == L"shelldll_defview") {
-            Wh_Log(L"[HWND] Desktop window class -> context menu");
+            Wh_Log(L"HWND: Desktop window class -> context menu");
             return false;
         }
 
         if (c == L"cabinetwclass") {
-            Wh_Log(L"[HWND] CabinetWClass with title='%s' -> Personalization window", title);
+            Wh_Log(L"HWND: CabinetWClass -> Personalization window");
             return true;
         }
 
         if (t.find(L"personaliz") != std::wstring::npos) {
-            Wh_Log(L"[HWND] Title match -> Personalization window: %s", title);
+            Wh_Log(L"HWND: Title match -> Personalization window");
             return true;
         }
 
@@ -538,7 +503,7 @@ static bool IsPersonalizationWindow(HWND hwnd) {
         h = parent;
     }
 
-    Wh_Log(L"[HWND] No Personalization window found in chain -> context menu");
+    Wh_Log(L"HWND: No Personalization window found -> context menu");
     return false;
 }
 
@@ -546,24 +511,21 @@ static std::wstring ResolvePersonalizationBackground(HWND hwnd) {
     const std::wstring kPers = L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}";
     const std::wstring kWall = kPers + L"\\pageWallpaper";
 
-    // If SmartPersonalizationDetection is OFF, always go to the root.
     if (!g_settings.smartPersonalizationDetect) {
-        Wh_Log(L"[RESOLVE] SmartPersonalizationDetection=OFF -> Personalization root");
+        Wh_Log(L"Resolve: SmartPersonalizationDetection=OFF -> Personalization root");
         return kPers;
     }
 
     if (IsPersonalizationWindow(hwnd)) {
-        Wh_Log(L"[RESOLVE] personalization-background -> wallpaper (called from inside Personalization)");
+        Wh_Log(L"Resolve: personalization-background -> wallpaper");
         return kWall;
     } else {
-        Wh_Log(L"[RESOLVE] personalization-background -> Personalization (called from context menu)");
+        Wh_Log(L"Resolve: personalization-background -> Personalization");
         return kPers;
     }
 }
 
 // ── Shared hook logic ─────────────────────────────────────────────────────────
-// Returns {resolved_target, should_intercept}.
-// should_intercept=false means the caller must fall through to the original.
 
 struct ResolveResult {
     std::wstring target;
@@ -580,15 +542,62 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
     auto it = g_mappings.find(uri);
     if (it != g_mappings.end()) {
         std::wstring t = ApplyWin11Compat(it->second);
-        Wh_Log(L"[MAP] %s -> %s", uri.c_str(), t.c_str());
+        Wh_Log(L"Map: %s -> %s", uri.c_str(), t.c_str());
         return {t, true};
     }
 
-    // Not in map: apply fallback policy.
-    bool handled = HandleFallback(uri);
-    // handled=true  → ignore or control.exe already launched, intercept=true so caller exits.
-    // handled=false → passthrough requested, intercept=false so caller calls original.
-    return {L"", handled};
+    // Only apply fallback for ms-settings: URIs
+    if (uri.find(L"ms-settings:") == 0) {
+        bool handled = HandleFallback(uri);
+        return {L"", handled};
+    }
+    
+    // Unmapped shell::: targets pass through to original
+    Wh_Log(L"Unmapped shell target, passing through: %s", uri.c_str());
+    return {L"", false};
+}
+
+// ── Command line parsing helper ────────────────────────────────────────────────
+
+static bool IsControlSystemCommand(const std::wstring& cmdLine) {
+    // Parse command line into tokens
+    std::vector<std::wstring> tokens;
+    std::wstring current;
+    bool inQuotes = false;
+    
+    for (wchar_t c : cmdLine) {
+        if (c == L'"') {
+            inQuotes = !inQuotes;
+        } else if (c == L' ' && !inQuotes) {
+            if (!current.empty()) {
+                tokens.push_back(ToLower(current));
+                current.clear();
+            }
+        } else {
+            current += c;
+        }
+    }
+    if (!current.empty()) {
+        tokens.push_back(ToLower(current));
+    }
+    
+    if (tokens.empty()) return false;
+    
+    // Check if first token is control.exe (or ends with control.exe)
+    std::wstring exe = tokens[0];
+    if (exe == L"control.exe" || 
+        exe.find(L"\\control.exe") != std::wstring::npos ||
+        exe == L"control") {
+        
+        // Check for exact "system" argument
+        for (size_t i = 1; i < tokens.size(); i++) {
+            if (tokens[i] == L"system" || tokens[i] == L"microsoft.system") {
+                return true;
+            }
+        }
+    }
+    
+    return false;
 }
 
 // ── Hook: ShellExecuteExW ─────────────────────────────────────────────────────
@@ -600,7 +609,7 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
     if (!g_settings.enableRedirects) return ShellExecuteExW_orig(pei);
 
     if (pei) {
-        Wh_Log(L"[DEBUG] hwnd=%p  lpFile=%s  lpParameters=%s",
+        Wh_Log(L"ShellExecuteExW: hwnd=%p  lpFile=%s  lpParameters=%s",
                pei->hwnd,
                pei->lpFile       ? pei->lpFile       : L"(null)",
                pei->lpParameters ? pei->lpParameters : L"(null)");
@@ -618,7 +627,7 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
         }
 
         if (!uri.empty()) {
-            Wh_Log(L"[HOOK] %s", uri.c_str());
+            Wh_Log(L"ShellExecuteExW hook: %s", uri.c_str());
             auto result = ResolveUri(uri, pei->hwnd);
 
             if (result.intercept) {
@@ -626,7 +635,6 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
                 if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
                 return TRUE;
             }
-            // fallthrough for passthrough mode
         }
     }
     return ShellExecuteExW_orig(pei);
@@ -641,7 +649,7 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
                                      LPCWSTR params, LPCWSTR dir, INT show) {
     if (!g_settings.enableRedirects) return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
 
-    Wh_Log(L"[DEBUG-W] hwnd=%p  file=%s  params=%s",
+    Wh_Log(L"ShellExecuteW: hwnd=%p  file=%s  params=%s",
            hwnd,
            file   ? file   : L"(null)",
            params ? params : L"(null)");
@@ -657,14 +665,13 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
     }
 
     if (!uri.empty()) {
-        Wh_Log(L"[HOOK-W] %s", uri.c_str());
+        Wh_Log(L"ShellExecuteW hook: %s", uri.c_str());
         auto result = ResolveUri(uri, hwnd);
 
         if (result.intercept) {
             if (!result.target.empty()) LaunchTarget(result.target);
-            return (HINSTANCE)42;
+            return SHELL_EXECUTE_SUCCESS;
         }
-        // fallthrough for passthrough mode
     }
     return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
 }
@@ -689,7 +696,6 @@ BOOL WINAPI CreateProcessW_hook(
     LPSTARTUPINFOW lpStartupInfo,
     LPPROCESS_INFORMATION lpProcessInformation)
 {
-    // Respect global kill switch and UI-only mode.
     if (!g_settings.enableRedirects || g_settings.uiOnlyRedirects) {
         return CreateProcessW_orig(
             lpApplicationName, lpCommandLine,
@@ -699,25 +705,18 @@ BOOL WINAPI CreateProcessW_hook(
             lpStartupInfo, lpProcessInformation);
     }
 
-    std::wstring cmdLine = lpCommandLine ? ToLower(std::wstring(lpCommandLine)) : L"";
+    std::wstring cmdLine = lpCommandLine ? std::wstring(lpCommandLine) : L"";
     
-    if (cmdLine.find(L"control") != std::wstring::npos && 
-        cmdLine.find(L"system") != std::wstring::npos &&
-        cmdLine.find(L"mmsys.cpl") == std::wstring::npos &&
-        cmdLine.find(L"timedate.cpl") == std::wstring::npos &&
-        cmdLine.find(L"main.cpl") == std::wstring::npos &&
-        cmdLine.find(L"ncpa.cpl") == std::wstring::npos &&
-        cmdLine.find(L"inetcpl.cpl") == std::wstring::npos &&
-        cmdLine.find(L"desk.cpl") == std::wstring::npos &&
-        cmdLine.find(L"telephon.cpl") == std::wstring::npos &&
-        cmdLine.find(L"control.exe srchadmin.dll") == std::wstring::npos &&
-        cmdLine.find(L"intl.cpl") == std::wstring::npos &&
-        cmdLine.find(L"mmsys.cpl") == std::wstring::npos &&
-        cmdLine.find(L"microsoft.sound") == std::wstring::npos &&
-        cmdLine.find(L"sndvol") == std::wstring::npos) {
-
-        Wh_Log(L"[HOOK-CPW] Intercepted control system command: %s", lpCommandLine);
+    if (IsControlSystemCommand(cmdLine)) {
+        Wh_Log(L"CreateProcessW: intercepted control system command: %s", lpCommandLine);
+        
+        // Launch System Properties via ShellExecute instead
         LaunchTarget(L"shell:::{BB06C0E4-D293-4f75-8A90-CB05B6477EEE}");
+        
+        // Zero out PROCESS_INFORMATION to avoid garbage handles
+        if (lpProcessInformation) {
+            ZeroMemory(lpProcessInformation, sizeof(PROCESS_INFORMATION));
+        }
         SetLastError(ERROR_SUCCESS);
         return TRUE;
     }
@@ -734,17 +733,17 @@ BOOL WINAPI CreateProcessW_hook(
 // ── Windhawk Entry Points ─────────────────────────────────────────────────────
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"[v9.6.0] Redirect Settings to Control Panel - Initializing...");
+    Wh_Log(L"Redirect Settings to Control Panel v9.6.1 - Initializing...");
 
     DetectWindowsVersion();
     LoadSettings();
     InitMappings();
-    Wh_Log(L"[v9.6.0] %zu URI mappings loaded", g_mappings.size());
+    Wh_Log(L"%zu URI mappings loaded", g_mappings.size());
 
     HMODULE hShell32 = GetModuleHandleW(L"shell32.dll");
     if (!hShell32) hShell32 = LoadLibraryW(L"shell32.dll");
     if (!hShell32) {
-        Wh_Log(L"[v9.6.0] ERROR: Could not load shell32.dll");
+        Wh_Log(L"ERROR: Could not load shell32.dll");
         return FALSE;
     }
 
@@ -752,34 +751,31 @@ BOOL Wh_ModInit() {
     auto pW   = (void*)GetProcAddress(hShell32, "ShellExecuteW");
 
     if (!pExW || !pW) {
-        Wh_Log(L"[v9.6.0] ERROR: Required functions not found in shell32.dll");
+        Wh_Log(L"ERROR: Required functions not found in shell32.dll");
         return FALSE;
     }
 
     bool ok1 = Wh_SetFunctionHook(pExW, (void*)ShellExecuteExW_hook, (void**)&ShellExecuteExW_orig);
     bool ok2 = Wh_SetFunctionHook(pW,   (void*)ShellExecuteW_hook,   (void**)&ShellExecuteW_orig);
 
-    Wh_Log(L"[v9.6.0] Hook results: ShellExecuteExW=%d  ShellExecuteW=%d", ok1, ok2);
+    Wh_Log(L"Hook results: ShellExecuteExW=%d  ShellExecuteW=%d", ok1, ok2);
 
-    // CreateProcessW hook: only install if UIOnlyRedirects is OFF.
-    // We always install but the hook itself checks g_settings.uiOnlyRedirects at runtime,
-    // which allows settings changes without a full reinit.
     HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
     if (!hKernel32) hKernel32 = LoadLibraryW(L"kernel32.dll");
     if (hKernel32) {
         auto pCPW = (void*)GetProcAddress(hKernel32, "CreateProcessW");
         if (pCPW) {
             bool ok3 = Wh_SetFunctionHook(pCPW, (void*)CreateProcessW_hook, (void**)&CreateProcessW_orig);
-            Wh_Log(L"[v9.6.0] CreateProcessW hook: %d", ok3);
+            Wh_Log(L"CreateProcessW hook: %d", ok3);
         }
     }
 
     if (!ok1 && !ok2) {
-        Wh_Log(L"[v9.6.0] ERROR: Failed to install any hooks");
+        Wh_Log(L"ERROR: Failed to install any hooks");
         return FALSE;
     }
 
-    Wh_Log(L"[v9.6.0] Ready! (EnableRedirects=%d, UIOnly=%d, SmartPers=%d, Fallback=%d, Win11Compat=%d)",
+    Wh_Log(L"Ready! (EnableRedirects=%d, UIOnly=%d, SmartPers=%d, Fallback=%d, Win11Compat=%d)",
         (int)g_settings.enableRedirects,
         (int)g_settings.uiOnlyRedirects,
         (int)g_settings.smartPersonalizationDetect,
@@ -789,10 +785,10 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModUninit() {
-    Wh_Log(L"[v9.6.0] Unloaded.");
+    Wh_Log(L"Unloaded.");
 }
 
 void Wh_ModSettingsChanged() {
-    Wh_Log(L"[v9.6.0] Settings changed, reloading...");
+    Wh_Log(L"Settings changed, reloading...");
     LoadSettings();
 }

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -2,59 +2,69 @@
 // @id             settings-to-control-panel
 // @name           Redirect Settings to Control Panel
 // @description    Forces classic Control Panel to open instead of Windows 10/11 Settings app using native components
-// @version        9.6.1
+// @version        9.7.1
 // @author         babamohammed
 // @github         https://github.com/babamohammed2022
-// @license        MIT                                        
+// @license        MIT
 // @include        explorer.exe
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
 /*
-# Redirect Settings → Control Panel (v9.6.1)
+# Redirect Settings → Control Panel (v9.7.1)
 
-This mod intercepts modern `ms-settings:` URI protocols and forces Windows to open their classic Control Panel equivalents when possible. It relies entirely on native Windows components and legacy CLSIDs without requiring any third-party external programs.
+This mod intercepts modern `ms-settings:` URI protocols and forces Windows to open their classic
+Control Panel equivalents when possible. It relies entirely on native Windows components and
+legacy CLSIDs without requiring any third-party external programs.
 
-**Scope:** This mod only intercepts clicks from within Explorer (explorer.exe). ms-settings: links opened from Start Menu, Search, or other applications will not be redirected.
+**Scope:** This mod only intercepts calls made from within Explorer (explorer.exe).
+`ms-settings:` links opened from Start Menu, Search (StartMenuExperienceHost, SearchHost),
+or other applications will not be redirected.
 
 ### Compatibility & Limitations:
-- **Windows 10:** Highly effective (~70% redirection success rate), as most legacy control panels are fully intact and accessible via standard shell hooks.
-- **Windows 11:** Limited effectiveness (acts as a ~5% baseline restoration). Microsoft has deeply hardcoded or deprecated many legacy CLSIDs, bypassing classic shell activation methods. However, key elements like native network properties (`ncpa.cpl`) and specific dialog mappings still function.
+- **Windows 10:** Effective for the mapped entries since most legacy control panels from the Windows 7/8/8.1 era are still intact
+  and accessible via standard shell hooks.
+- **Windows 11:** Limited. Microsoft has deprecated or hardcoded many legacy CLSIDs.
+  However, key elements like network properties (`ncpa.cpl`) and specific dialog mappings
+  still function. Unmapped pages pass through to the Settings app by default
+  (configurable via FallbackMode).
 
 ### Key Features:
-- **Smart Desktop Personalization Hook:** Contextual awareness based on `hwnd` detection. Clicking "Personalize" from the desktop right-click menu correctly targets the main classic Personalization window, while clicking "Desktop Background" inside an existing shell folder still brings up the wallpaper page.
-- **Precise Command Interception:** Only intercepts exact `control system` commands, avoiding conflicts with other Control Panel applets.
+- **Smart Desktop Personalization Hook:** Right-clicking the desktop opens the Personalization
+  window; clicking "Desktop Background" from inside it opens the wallpaper page.
+- **Precise command interception:** Only intercepts `control.exe system` (exact lone argument),
+  avoiding false positives from paths containing "System32".
 
-### Settings (v9.6.1):
+### Settings (v9.7.1):
 - **EnableRedirects** — Turns the mod on or off completely.
-- **UIOnlyRedirects** — Safer mode: only intercepts clicks from Explorer. Leaves scripts and installers alone.
-- **SmartPersonalizationDetection** — When ON, right-clicking the desktop opens Personalization; clicking "Desktop Background" from inside it opens the wallpaper picker. When OFF, both always open Personalization.
-- **FallbackMode** — What happens when a Settings page has no classic equivalent: do nothing, open Control Panel, or let the original Settings app open.
-- **Win11CompatibilityMode** — On Windows 11, skips legacy shortcuts that no longer work and opens Control Panel instead.
+- **UIOnlyRedirects** — Safer mode: only intercepts ShellExecute calls, not CreateProcessW.
+- **SmartPersonalizationDetection** — Contextual awareness for the desktop right-click.
+- **FallbackMode** — What happens for unmapped `ms-settings:` URIs.
+- **Win11CompatibilityMode** — Skips CLSIDs known to be broken on Win11.
 */
 // ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
 /*
 - EnableRedirects: true
-  $name: Enable Redirects 
-  $description: "Turns the mod on or off. When off, all Settings calls open normally without any redirect."
+  $name: Enable Redirects
+  $description: "Turns the mod on or off. When off, all Settings calls open normally."
 - UIOnlyRedirects: false
   $name: Non-Invasive UI Mode
-  $description: "Only intercepts clicks from Explorer. Safer option if you use scripts, installers, or older apps that might be affected."
+  $description: "Only intercepts ShellExecute* calls. Leaves CreateProcessW alone."
 - SmartPersonalizationDetection: true
   $name: Smart Personalization Detection
-  $description: "When ON, right-clicking the desktop opens Personalization, while clicking Desktop Background from inside it opens the wallpaper picker. When OFF, both always open Personalization."
-- FallbackMode: "1"
+  $description: "Right-clicking the desktop opens Personalization; clicking Desktop Background from inside it opens the wallpaper picker."
+- FallbackMode: "2"
   $name: Fallback Mode (unmapped URIs)
-  $description: "What to do when a Settings page has no classic equivalent. Ignore it silently, open Control Panel as a fallback, or let the original Settings app open."
+  $description: "What to do when a Settings page has no classic equivalent."
   $options:
   - "0": Ignore (silent fail)
-  - "1": Open control.exe
-  - "2": Pass through to ms-settings
+  - "1": Open the Control Panel (control.exe)
+  - "2": Pass through to the modern Settings application (ms-settings.exe)
 - Win11CompatibilityMode: false
   $name: Windows 11 Compatibility Mode
-  $description: "On Windows 11, replaces legacy shortcuts that no longer work with a plain Control Panel open instead when possible."
+  $description: "On Windows 11, replaces CLSIDs known to be broken with a plain Control Panel open."
 */
 // ==/WindhawkModSettings==
 
@@ -66,34 +76,58 @@ This mod intercepts modern `ms-settings:` URI protocols and forces Windows to op
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#define SYSTEM_PROPERTIES_FALLBACK L"shell:::{BB06C0E4-D293-4f75-8A90-CB05B6477EEE}"
-#define NOTIF_AREA_CLSID L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"
 
-// ShellExecuteW success value (any value > 32 means success)
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+// ShellExecuteW: any value > 32 signals success to the caller
 static const HINSTANCE SHELL_EXECUTE_SUCCESS = (HINSTANCE)33;
 
-// ── Settings ─────────────────────────────────────────────────────────────────
+#define SYSTEM_PROPS_CLSID  L"shell:::{BB06C0E4-D293-4f75-8A90-CB05B6477EEE}"
+#define NOTIF_AREA_CLSID    L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"
+#define PERS_ROOT_CLSID     L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"
+#define PERS_WALLPAPER      PERS_ROOT_CLSID L"\\pageWallpaper"
+#define PERS_COLORS         PERS_ROOT_CLSID L"\\pageColorization"
+
+// ── Forward declarations ──────────────────────────────────────────────────────
+
+using CreateProcessW_t = BOOL(WINAPI*)(
+    LPCWSTR, LPWSTR, LPSECURITY_ATTRIBUTES, LPSECURITY_ATTRIBUTES,
+    BOOL, DWORD, LPVOID, LPCWSTR, LPSTARTUPINFOW, LPPROCESS_INFORMATION);
+static CreateProcessW_t CreateProcessW_orig = nullptr;
+
+using ShellExecuteW_t = HINSTANCE(WINAPI*)(HWND, LPCWSTR, LPCWSTR, LPCWSTR, LPCWSTR, INT);
+static ShellExecuteW_t ShellExecuteW_orig = nullptr;
+
+// ── Settings ──────────────────────────────────────────────────────────────────
 
 struct ModSettings {
     bool enableRedirects            = true;
     bool uiOnlyRedirects            = false;
     bool smartPersonalizationDetect = true;
-    int  fallbackMode               = 1;   // 0=ignore, 1=control.exe, 2=passthrough
+    int  fallbackMode               = 2;
     bool win11CompatibilityMode     = false;
 };
 
 static ModSettings g_settings;
 
 static void LoadSettings() {
-    g_settings.enableRedirects            = Wh_GetIntSetting(L"EnableRedirects")            != 0;
-    g_settings.uiOnlyRedirects            = Wh_GetIntSetting(L"UIOnlyRedirects")            != 0;
+    g_settings.enableRedirects            = Wh_GetIntSetting(L"EnableRedirects") != 0;
+    g_settings.uiOnlyRedirects            = Wh_GetIntSetting(L"UIOnlyRedirects") != 0;
     g_settings.smartPersonalizationDetect = Wh_GetIntSetting(L"SmartPersonalizationDetection") != 0;
-    
+
     PCWSTR fallbackStr = Wh_GetStringSetting(L"FallbackMode");
-    g_settings.fallbackMode = fallbackStr ? _wtoi(fallbackStr) : 1;
+    if (fallbackStr && fallbackStr[0] != L'\0') {
+        int mode = _wtoi(fallbackStr);
+        if (mode >= 0 && mode <= 2)
+            g_settings.fallbackMode = mode;
+        else
+            g_settings.fallbackMode = 2;
+    } else {
+        g_settings.fallbackMode = 2;
+    }
     Wh_FreeStringSetting(fallbackStr);
-    
-    g_settings.win11CompatibilityMode     = Wh_GetIntSetting(L"Win11CompatibilityMode")     != 0;
+
+    g_settings.win11CompatibilityMode = Wh_GetIntSetting(L"Win11CompatibilityMode") != 0;
 
     Wh_Log(L"EnableRedirects=%d  UIOnly=%d  SmartPers=%d  Fallback=%d  Win11Compat=%d",
         (int)g_settings.enableRedirects,
@@ -103,7 +137,7 @@ static void LoadSettings() {
         (int)g_settings.win11CompatibilityMode);
 }
 
-// ── Win11 detection (cached) ─────────────────────────────────────────────────
+// ── Win11 detection ───────────────────────────────────────────────────────────
 
 static bool g_isWin11 = false;
 
@@ -116,15 +150,16 @@ static void DetectWindowsVersion() {
         auto fn = (RtlGetVersion_t)GetProcAddress(hNtdll, "RtlGetVersion");
         if (fn) fn(&osvi);
     }
-    g_isWin11 = (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber >= 22000);
+    g_isWin11 = (osvi.dwMajorVersion == 10 &&
+                 osvi.dwMinorVersion == 0   &&
+                 osvi.dwBuildNumber >= 22000);
     Wh_Log(L"Build %lu  IsWin11=%d", osvi.dwBuildNumber, (int)g_isWin11);
 }
 
-// CLSIDs considered safe on Win11 (well-tested, not deprecated)
 static const std::unordered_set<std::wstring> g_win11SafeClsids = {
     L"shell:::{8e908fc9-becc-40f6-915b-f4ca0e70d03d}",
     L"shell:::{7007acc7-3202-11d1-aad2-00805fc1270e}",
-    L"shell:::{a8a91a66-3a7d-4424-8d24-04e180695c7a}",
+    L"shell:::{a8a91a66-3a7d-4424-8d24-04e180695C7A}",
     L"shell:::{4026492f-2f69-46b8-b9bf-5654fc07e423}",
     L"shell:::{20d04fe0-3aea-1069-a2d8-08002b30309d}",
     L"shell:::{60632754-c523-4b62-b45c-4172da012619}",
@@ -137,235 +172,187 @@ static bool IsClsidSafeOnWin11(const std::wstring& target) {
     return g_win11SafeClsids.count(lower) > 0;
 }
 
-// ── Mappings ─────────────────────────────────────────────────────────────────
-
-static std::unordered_map<std::wstring, std::wstring> g_mappings;
+// ── String utilities ──────────────────────────────────────────────────────────
 
 static std::wstring ToLower(std::wstring s) {
     std::transform(s.begin(), s.end(), s.begin(), ::towlower);
     return s;
 }
 
-static void InitMappings() {
-    const std::wstring kPers = L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}";
-    const std::wstring kWall = kPers + L"\\pageWallpaper";
+// ── Mappings ──────────────────────────────────────────────────────────────────
 
+static std::unordered_map<std::wstring, std::wstring> g_mappings;
+
+static void InitMappings() {
     g_mappings = {
-        // NOTE: ms-settings:personalization-background is handled specially via hwnd
-        {L"shell:::{52205fd8-5dfb-447d-801a-d0b52f2e83e1}", L"explorer.exe shell:UsersLibrariesFolder"},
-        {L"shell:::{bb06c0e4-d293-4f75-8a90-cb05b6477eee}", SYSTEM_PROPERTIES_FALLBACK},
-        {L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}", L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"},
-        {L"explorer.exe", L"explorer.exe"},
-        {L"explorer", L"explorer"},
-        
-        // Personalization
-        {L"ms-settings:personalization-background-wallpaper", kWall},
-        {L"ms-settings:personalization-background-slideshow", kWall},
-        {L"ms-settings:background", kWall},
-        {L"ms-settings:personalization", kPers},
-        {L"ms-settings:personalization-colors", kPers + L"\\pageColorization"},
-        {L"ms-settings:colors", kPers + L"\\pageColorization"},
-        {L"ms-settings:themes", kPers},
-        {L"ms-settings:lockscreen", kPers},
-        {L"ms-settings:personalization-start", kPers},
-        {L"ms-settings:personalization-start-places", kPers},
-        {L"ms-settings:personalization-touchkeyboard", kPers},
-        {L"ms-settings:deviceusage", kPers},
-        {L"ms-settings:fonts", L"shell:::{BD84B380-8CA2-1069-AB1D-08000948F534}"},
-        
-        // System
-        {L"ms-settings:system", SYSTEM_PROPERTIES_FALLBACK},
-        {L"ms-settings:about", SYSTEM_PROPERTIES_FALLBACK},
-        {L"ms-settings:sysinfo", SYSTEM_PROPERTIES_FALLBACK},
-        {L"ms-settings:system-about", SYSTEM_PROPERTIES_FALLBACK},
-        {L"ms-settings:system-advanced", SYSTEM_PROPERTIES_FALLBACK},
-        {L"ms-settings:system-remotedesktop", L"sysdm.cpl,,5"},
-        {L"ms-settings:system-protection", L"sysdm.cpl,,4"},
-        {L"ms-settings:remotedesktop", L"sysdm.cpl,,5"},
-        {L"ms-settings:display", L"desk.cpl"},
-        {L"ms-settings:display-advanced", L"desk.cpl"},
-        {L"ms-settings:display-advancedgraphics", L"desk.cpl"},
-        {L"ms-settings:nightlight", L"desk.cpl"},
-        {L"ms-settings:display-advanced-color", L"colorcpl.exe"},
-        {L"ms-settings:colorcpl", L"colorcpl.exe"},
-        {L"ms-settings:powersleep", L"powercfg.cpl"},
-        {L"ms-settings:battery", L"powercfg.cpl"},
-        {L"ms-settings:batterysaver", L"powercfg.cpl"},
-        {L"ms-settings:batterysaver-settings", L"powercfg.cpl"},
-        {L"ms-settings:batterysaver-usagedetails", L"powercfg.cpl"},
-        {L"ms-settings:sound", L"mmsys.cpl"},
-        {L"ms-settings:sound-devices", L"mmsys.cpl"},
-        {L"ms-settings:audio", L"mmsys.cpl"},
-        {L"ms-settings:apps-volume", L"sndvol.exe"},
-        {L"ms-settings:notifications", NOTIF_AREA_CLSID},
-        {L"ms-settings:typing", L"main.cpl,,1"},
-        {L"ms-settings:mousetouchpad", L"main.cpl"},
-        {L"ms-settings:devices-touchpad", L"main.cpl"},
-        {L"ms-settings:keyboard", L"main.cpl"},
-        {L"ms-settings:storagesense", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:storagepolicies", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:disksandvolumes", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:savelocations", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"ms-settings:optionalfeatures", L"OptionalFeatures.exe"},
-        {L"ms-settings:devicemanager", L"devmgmt.msc"},
-        {L"ms-settings:system-devicemanager", L"devmgmt.msc"},
-        {L"ms-settings:computerManagement", L"compmgmt.msc"},
-        {L"ms-settings:activation", L"slui.exe"},
-        {L"ms-settings:appsfeatures", L"appwiz.cpl"},
-        {L"ms-settings:appsforwebsites", L"appwiz.cpl"},
-        
-        // Network
-        {L"ms-settings:network", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-wifi", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-ethernet", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-vpn", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-airplanemode", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-mobilehotspot", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-cellular", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:datausage", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-proxy", L"inetcpl.cpl,,4"},
-        {L"ms-settings:network-status", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
-        {L"ms-settings:network-dialup", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
-        {L"ms-settings:network-advancedsettings", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
-        {L"ms-settings:firewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
-        {L"ms-settings:network-firewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
-        
-        // Accounts
-        {L"ms-settings:yourinfo", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:emailandaccounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:signinoptions", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:otherusers", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:workplace", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:family", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:accounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:accounts-signinoptions", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:accounts-otherusers", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:signinoptions-face", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:signinoptions-fingerprint", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:signinoptions-dynamiclock", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:signinoptions-launchfaceenrollment", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:signinoptions-launchfingerprintenrollment", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:signinoptions-launchsecuritykeyenrollment", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:startupapps", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        // other personalization mapping
-        {L"control desktop", kPers}, 
-        // Time & Language
-        {L"ms-settings:regionlanguage", L"intl.cpl"},
-        {L"ms-settings:regionformatting", L"intl.cpl"},
-        {L"ms-settings:language", L"intl.cpl"},
-        {L"ms-settings:dateandtime", L"timedate.cpl"},
-        {L"ms-settings:dateandtime-region", L"timedate.cpl"},
-        {L"ms-settings:dateandtime-addclocks", L"timedate.cpl,,1"},
-        
-        // Ease of Access
-        {L"ms-settings:easeofaccess", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-highcontrast", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-closedcaptioning", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-narrator", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-magnifier", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-cursor", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-keyboard", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-mouse", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-eyecontrol", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-colorfilter", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-audio", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-speechrecognition", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-cursorandpointersize", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-visualeffects", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-display", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-mousepointer", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        
-        // Devices
-        {L"ms-settings:printers", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:printers-scanners", L"shell:::{2227A280-3AEA-1069-A2DE-08002B30309D}"},
-        {L"ms-settings:bluetooth", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:usb", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:connecteddevices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:camera", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:mobile-devices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:privacy-customdevices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:autoplay", L"shell:::{9C60DE1E-E5FC-40f4-A487-460851A8D915}"},
-        {L"ms-settings:pen", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
-        {L"ms-settings:pen-windowsink", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
-        {L"ms-settings:pen-windowsinksettings", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
-        {L"ms-settings:devices-touch", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
-        
-        // Default Programs
-        {L"ms-settings:defaultapps", L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
-        {L"ms-settings:defaultapps-maps", L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
-        
-        // Taskbar / Notification Area (verified mappings)
-        {L"ms-settings:taskbar-notifications", NOTIF_AREA_CLSID},
-        {L"ms-settings:taskbar-systemtray", NOTIF_AREA_CLSID},
-        {L"ms-settings:notifications-systemtray", NOTIF_AREA_CLSID},
-        {L"ms-settings:systemtray", NOTIF_AREA_CLSID},
-        {L"ms-settings:notificationiconpreferences", NOTIF_AREA_CLSID},
-        {L"ms-settings:privacy-notifications", L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"},
-        
-        // Recovery / Backup
-        {L"ms-settings:backup", L"shell:::{B98A2BEA-7D42-4558-8BD1-832F41BAC6FD}"},
-        {L"ms-settings:recovery", L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
-        {L"ms-settings:troubleshoot", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
-        {L"ms-settings:findmydevice", L"shell:::{F942C606-0914-47AB-BE56-1321B8035096}"},
-        {L"ms-settings:deviceencryption", L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
-        
-        // Security & Maintenance
-        {L"shell:microsoft.actioncenter", L"wscui.cpl"},
-        {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\1\\::{0df44eaa-ff21-4412-828e-260a8728e7f1}", L"wscui.cpl"},
-        {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\2\\::{025a5937-a6be-4686-a844-36fe4bec8b6d}", L"powercfg.cpl"},
-        {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\3\\::{c555438b-3c23-4769-a71f-b6d3d9b6053a}", L"__display__"},
-        {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\0\\::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}", L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\0\\::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"},
-        
-        // Quiethours / Focus Assist
-        {L"ms-settings:quiethours", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:quietmomentsscheduled", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:quietmomentspresentation", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:quietmomentsgame", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:privacy-feedback", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:privacy-activityhistory", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:privacy-appdiagnostics", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:windowsdefender", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"ms-settings:privacy-feedback-telemetryviewergroup", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        
-        // Speech
-        {L"ms-settings:privacy-speech", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
-        {L"ms-settings:privacy-voiceactivation", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
-        {L"ms-settings:privacy-speechtyping", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
-        
-        // Search
-        {L"ms-settings:search-permissions", L"shell:::{04731B67-D933-450a-90E6-4ACD2E9408FE}"},
-        {L"ms-settings:cortana-windowssearch", L"shell:::{04731B67-D933-450a-90E6-4ACD2E9408FE}"},
-        
-        // Home / Profile
-        {L"ms-settings:home", L"shell:::{59031a47-3f72-44a7-89c5-5595fe6b30ee}"},
-        {L"ms-settings:yourinfo-profile", L"shell:::{59031a47-3f72-44a7-89c5-5595fe6b30ee}"},
-        
-        // Shell CLSID mappings
-        {L"shell:::{f20df4e5-ea01-41a2-b02a-dcbd92d4696e}", L"__display__"},
-        {L"shell:::{20d04fe0-3aea-1069-a2d8-08002b30309d}", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
-        {L"explorer shell:::{ed834ed6-4b5a-4bfe-8f11-a626dcb6a921}", L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"},
-        {L"shell:::{1206f5f1-0569-412c-8fec-3204630dfb70}", L"shell:::{1206F5F1-0569-412C-8FEC-3204630DFB70}"},
-        {L"shell:::{d9ef8727-cac2-4e60-809e-86f80a666c91}", L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
-        {L"shell:::{9fe63afd-59cf-4419-9775-abcc3849f861}", L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
-        {L"shell:::{c58c4893-3be0-4b45-abb5-a63e4b8c8651}", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
-        {L"shell:::{f942c606-0914-47ab-be56-1321b8035096}", L"shell:::{F942C606-0914-47AB-BE56-1321B8035096}"},
-        {L"shell:::{241d7c96-f8bf-4f85-b01f-e2b043341a4b}", L"shell:::{241D7C96-F8BF-4F85-B01F-E2B043341A4B}"},
-        {L"shell:::{bd7a2e7b-21cb-41b2-a086-b309680c6b7e}", L"shell:::{BD7A2E7B-21CB-41b2-A086-B309680C6B7E}"},
-        {L"shell:::{d20ea4e1-3957-11d2-a40b-0c5020524153}", L"shell:::{D20EA4E1-3957-11d2-A40B-0C5020524153}"},
-        {L"shell:::{bb64f8a7-bee7-4e1a-ab8d-7d8273f7fdb6}", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
-        {L"shell:::{58e3c745-d971-4081-9034-86e34b30836a}", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
-        {L"shell:::{04731b67-d933-450a-90e6-4acd2e9408fe}", L"shell:::{04731B67-D933-450a-90E6-4ACD2E9408FE}"},
+
+        // ── Personalization ──────────────────────────────────────────────────
+        {L"ms-settings:personalization",                    PERS_ROOT_CLSID},
+        {L"ms-settings:personalization-colors",             PERS_COLORS},
+        {L"ms-settings:colors",                             PERS_COLORS},
+        {L"ms-settings:themes",                             PERS_ROOT_CLSID},
+        {L"ms-settings:lockscreen",                         PERS_ROOT_CLSID},
+        {L"ms-settings:personalization-start",              PERS_ROOT_CLSID},
+        {L"ms-settings:personalization-start-places",       PERS_ROOT_CLSID},
+        {L"ms-settings:background",                         PERS_WALLPAPER},
+        {L"ms-settings:personalization-background-wallpaper",PERS_WALLPAPER},
+        {L"ms-settings:personalization-background-slideshow",PERS_WALLPAPER},
+        {L"ms-settings:fonts",
+            L"shell:::{BD84B380-8CA2-1069-AB1D-08000948F534}"},
+
+        // ── Color Management ─────────────────────────────────────────────────
+        {L"ms-settings:display-advanced-color",             L"colorcpl.exe"},
+        {L"ms-settings:colorcpl",                           L"colorcpl.exe"},
+
+        // ── System / About ───────────────────────────────────────────────────
+        {L"ms-settings:about",                              SYSTEM_PROPS_CLSID},
+        {L"ms-settings:system",                             SYSTEM_PROPS_CLSID},
+        {L"ms-settings:sysinfo",                            SYSTEM_PROPS_CLSID},
+        {L"ms-settings:system-about",                       SYSTEM_PROPS_CLSID},
+        {L"ms-settings:system-protection",                  L"sysdm.cpl,,4"},
+        {L"ms-settings:system-remotedesktop",               L"sysdm.cpl,,5"},
+        {L"ms-settings:remotedesktop",                      L"sysdm.cpl,,5"},
+        {L"ms-settings:devicemanager",                      L"devmgmt.msc"},
+        {L"ms-settings:system-devicemanager",               L"devmgmt.msc"},
+        {L"ms-settings:computermanagement",                 L"compmgmt.msc"},
+        {L"ms-settings:activation",                         L"slui.exe"},
+        {L"ms-settings:appsfeatures",                       L"appwiz.cpl"},
+        {L"ms-settings:appsforwebsites",                    L"appwiz.cpl"},
+        {L"ms-settings:optionalfeatures",                   L"OptionalFeatures.exe"},
+
+        // ── Power ────────────────────────────────────────────────────────────
+        {L"ms-settings:powersleep",                         L"powercfg.cpl"},
+        {L"ms-settings:battery",                            L"powercfg.cpl"},
+        {L"ms-settings:batterysaver",                       L"powercfg.cpl"},
+        {L"ms-settings:batterysaver-settings",              L"powercfg.cpl"},
+        {L"ms-settings:batterysaver-usagedetails",          L"powercfg.cpl"},
+
+        // ── Sound ────────────────────────────────────────────────────────────
+        {L"ms-settings:sound",                              L"mmsys.cpl"},
+        {L"ms-settings:sound-devices",                      L"mmsys.cpl"},
+        {L"ms-settings:audio",                              L"mmsys.cpl"},
+        {L"ms-settings:apps-volume",                        L"sndvol.exe"},
+
+        // ── Notifications / Taskbar ──────────────────────────────────────────
+        {L"ms-settings:notifications",                      NOTIF_AREA_CLSID},
+        {L"ms-settings:taskbar-notifications",              NOTIF_AREA_CLSID},
+        {L"ms-settings:taskbar-systemtray",                 NOTIF_AREA_CLSID},
+        {L"ms-settings:notifications-systemtray",           NOTIF_AREA_CLSID},
+        {L"ms-settings:systemtray",                         NOTIF_AREA_CLSID},
+        {L"ms-settings:notificationiconpreferences",        NOTIF_AREA_CLSID},
+
+        // ── Input devices ────────────────────────────────────────────────────
+        {L"ms-settings:mousetouchpad",                      L"main.cpl"},
+        {L"ms-settings:devices-touchpad",                   L"main.cpl"},
+        {L"ms-settings:keyboard",                           L"main.cpl,,1"},
+        {L"ms-settings:typing",                             L"main.cpl,,1"},
+        {L"ms-settings:pen",
+            L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:pen-windowsink",
+            L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:pen-windowsinksettings",
+            L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:devices-touch",
+            L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:autoplay",
+            L"shell:::{9C60DE1E-E5FC-40f4-A487-460851A8D915}"},
+
+        // ── Devices / Printers ───────────────────────────────────────────────
+        {L"ms-settings:printers",
+            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:printers-scanners",
+            L"shell:::{2227A280-3AEA-1069-A2DE-08002B30309D}"},
+        {L"ms-settings:bluetooth",
+            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:usb",
+            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:connecteddevices",
+            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:mobile-devices",
+            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:camera",
+            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:privacy-customdevices",
+            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+
+        // ── Network ──────────────────────────────────────────────────────────
+        {L"ms-settings:network",
+            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-wifi",
+            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-ethernet",
+            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-vpn",
+            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-airplanemode",
+            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-mobilehotspot",
+            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-cellular",
+            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:datausage",
+            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-proxy",                      L"inetcpl.cpl,,4"},
+        {L"ms-settings:network-status",
+            L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
+        {L"ms-settings:network-dialup",
+            L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
+        {L"ms-settings:network-advancedsettings",
+            L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
+        {L"ms-settings:firewall",
+            L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
+        {L"ms-settings:network-firewall",
+            L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
+        {L"ms-settings:windowsdefender",
+            L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
+
+        // ── Accounts ─────────────────────────────────────────────────────────
+        {L"ms-settings:yourinfo",
+            L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:yourinfo-profile",
+            L"shell:::{59031a47-3f72-44a7-89c5-5595fe6b30ee}"},
+        {L"ms-settings:emailandaccounts",
+            L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:accounts",
+            L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:startupapps",                        L"msconfig.exe"},
+
+        // ── Time & Language ───────────────────────────────────────────────────
+        {L"ms-settings:dateandtime",                        L"timedate.cpl"},
+        {L"ms-settings:dateandtime-region",                 L"timedate.cpl"},
+        {L"ms-settings:dateandtime-addclocks",              L"timedate.cpl,,1"},
+        {L"ms-settings:regionlanguage",                     L"intl.cpl"},
+        {L"ms-settings:regionformatting",                   L"intl.cpl"},
+        {L"ms-settings:language",                           L"intl.cpl"},
+
+        // ── Ease of Access (root only) ───────────────────────────────────────
+        {L"ms-settings:easeofaccess",
+            L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+
+        // ── Default Apps ──────────────────────────────────────────────────────
+        {L"ms-settings:defaultapps",
+            L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
+
+        // ── Recovery / Backup ─────────────────────────────────────────────────
+        {L"ms-settings:backup",
+            L"shell:::{B98A2BEA-7D42-4558-8BD1-832F41BAC6FD}"},
+        {L"ms-settings:recovery",
+            L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
+        {L"ms-settings:troubleshoot",
+            L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
+        {L"ms-settings:deviceencryption",
+            L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
     };
 }
 
-// ── URI utilities ─────────────────────────────────────────────────────────────
+// ── URI normalization ─────────────────────────────────────────────────────────
 
 static std::wstring NormalizeUri(const std::wstring& uri) {
     std::wstring result = ToLower(uri);
 
     size_t pos = result.find(L"ms-settings://");
     if (pos != std::wstring::npos)
-        result = L"ms-settings:" + result.substr(pos + 14);  // Fixed: 14, not 15
+        result = L"ms-settings:" + result.substr(pos + 14);
 
     pos = result.find(L'?');
     if (pos != std::wstring::npos)
@@ -393,11 +380,9 @@ static std::wstring ApplyWin11Compat(const std::wstring& target) {
     if (!g_settings.win11CompatibilityMode || !g_isWin11) return target;
 
     std::wstring lower = ToLower(target);
-    if (lower.find(L"shell:::") == 0) {
-        if (!IsClsidSafeOnWin11(lower)) {
-            Wh_Log(L"Win11 compat: replacing unsafe CLSID '%s' with control.exe", target.c_str());
-            return L"control.exe";
-        }
+    if (lower.find(L"shell:::") == 0 && !IsClsidSafeOnWin11(lower)) {
+        Wh_Log(L"Win11 compat: replacing unsafe CLSID '%s' with control.exe", target.c_str());
+        return L"control.exe";
     }
     return target;
 }
@@ -406,24 +391,27 @@ static std::wstring ApplyWin11Compat(const std::wstring& target) {
 
 static bool HandleFallback(const std::wstring& uri) {
     switch (g_settings.fallbackMode) {
-        case 0: // ignore
+        case 0:
             Wh_Log(L"Fallback: ignoring unmapped URI: %s", uri.c_str());
             return true;
-        case 1: // control.exe
+
+        case 1: {
             Wh_Log(L"Fallback: opening control.exe for unmapped URI: %s", uri.c_str());
-            {
-                std::wstring cmd = L"control.exe";
-                STARTUPINFOW si = {}; si.cb = sizeof(si);
-                si.dwFlags = STARTF_USESHOWWINDOW; si.wShowWindow = SW_SHOWNORMAL;
-                PROCESS_INFORMATION pi = {};
-                CreateProcessW(nullptr, cmd.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi);
-                if (pi.hProcess) CloseHandle(pi.hProcess);
-                if (pi.hThread)  CloseHandle(pi.hThread);
+            std::wstring cmd = L"control.exe";
+            STARTUPINFOW si = {}; si.cb = sizeof(si);
+            si.dwFlags = STARTF_USESHOWWINDOW; si.wShowWindow = SW_SHOWNORMAL;
+            PROCESS_INFORMATION pi = {};
+            if (CreateProcessW_orig(nullptr, cmd.data(), nullptr, nullptr,
+                                    FALSE, 0, nullptr, nullptr, &si, &pi)) {
+                CloseHandle(pi.hProcess);
+                CloseHandle(pi.hThread);
             }
             return true;
-        case 2: // passthrough
+        }
+
+        case 2:
         default:
-            Wh_Log(L"Fallback: passing through unmapped URI to original: %s", uri.c_str());
+            Wh_Log(L"Fallback: passing through unmapped URI: %s", uri.c_str());
             return false;
     }
 }
@@ -431,20 +419,38 @@ static bool HandleFallback(const std::wstring& uri) {
 // ── LaunchTarget ──────────────────────────────────────────────────────────────
 
 static void LaunchTarget(const std::wstring& command) {
-    Wh_Log(L"Exec: %s", command.c_str());
+    Wh_Log(L"Launching: %s", command.c_str());
+
+    // Use ShellExecuteW_orig for targets that need elevation / UAC
+    if (command == L"devmgmt.msc" ||
+    command == L"compmgmt.msc" ||
+    command == L"slui.exe" ||
+    command == L"C:\\Windows\\System32\\devmgmt.msc" ||
+    command == L"C:\\Windows\\System32\\compmgmt.msc" ||
+    command == L"C:\\Windows\\System32\\slui.exe" ||
+    command == L"OptionalFeatures.exe" ||
+    command == L"C:\\Windows\\System32\\OptionalFeatures.exe") {
+    ShellExecuteW_orig(nullptr, L"open", command.c_str(),
+                       nullptr, nullptr, SW_SHOWNORMAL);
+    return;
+}
+
 
     STARTUPINFOW si = {};
     si.cb = sizeof(si);
     si.dwFlags = STARTF_USESHOWWINDOW;
     si.wShowWindow = SW_SHOWNORMAL;
     PROCESS_INFORMATION pi = {};
-
     std::wstring cmdLine;
+
     if (command.find(L".msc") != std::wstring::npos) {
-        // Launch .msc files via mmc.exe
-        cmdLine = L"mmc.exe " + command;
-    } else if (command.find(L".exe") != std::wstring::npos) {
-        cmdLine = command;
+        cmdLine = L"mmc.exe \"" + command + L"\"";
+    } else if (command.find(L".exe") != std::wstring::npos ||
+               command.find(L".cpl") != std::wstring::npos) {
+        if (command.find(L".cpl") != std::wstring::npos)
+            cmdLine = L"control.exe " + command;
+        else
+            cmdLine = command;
     } else if (command.find(L"shell:::") == 0) {
         cmdLine = L"explorer.exe " + command;
     } else if (command.empty()) {
@@ -454,20 +460,21 @@ static void LaunchTarget(const std::wstring& command) {
     }
 
     std::wstring mutableCmd = cmdLine;
-    if (CreateProcessW(nullptr, mutableCmd.data(), nullptr, nullptr, FALSE,
-                       0, nullptr, nullptr, &si, &pi)) {
-        if (pi.hProcess) CloseHandle(pi.hProcess);
-        if (pi.hThread)  CloseHandle(pi.hThread);
-    } else {
-        Wh_Log(L"ERROR: CreateProcess failed for: %s (error: %lu)", cmdLine.c_str(), GetLastError());
+    if (!CreateProcessW_orig(nullptr, mutableCmd.data(), nullptr, nullptr,
+                             FALSE, 0, nullptr, nullptr, &si, &pi)) {
+        Wh_Log(L"CreateProcess failed for '%s' (error %lu)",
+               cmdLine.c_str(), GetLastError());
+        return;
     }
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
 }
 
 // ── Personalization hwnd detection ───────────────────────────────────────────
 
 static bool IsPersonalizationWindow(HWND hwnd) {
     if (!hwnd) {
-        Wh_Log(L"HWND: hwnd is NULL -> context menu");
+        Wh_Log(L"HWND null -> desktop context menu path");
         return false;
     }
 
@@ -478,23 +485,19 @@ static bool IsPersonalizationWindow(HWND hwnd) {
         GetClassNameW(h, cls, 256);
         GetWindowTextW(h, title, 512);
 
-        Wh_Log(L"HWND: %p  class='%s'  title='%s'", h, cls, title);
-
         std::wstring c = ToLower(cls);
         std::wstring t = ToLower(title);
 
         if (c == L"progman" || c == L"workerw" || c == L"shelldll_defview") {
-            Wh_Log(L"HWND: Desktop window class -> context menu");
+            Wh_Log(L"HWND: desktop class '%s' -> context menu", cls);
             return false;
         }
-
         if (c == L"cabinetwclass") {
-            Wh_Log(L"HWND: CabinetWClass -> Personalization window");
+            Wh_Log(L"HWND: CabinetWClass -> inside Personalization");
             return true;
         }
-
         if (t.find(L"personaliz") != std::wstring::npos) {
-            Wh_Log(L"HWND: Title match -> Personalization window");
+            Wh_Log(L"HWND: title match 'personaliz' -> Personalization window");
             return true;
         }
 
@@ -503,29 +506,24 @@ static bool IsPersonalizationWindow(HWND hwnd) {
         h = parent;
     }
 
-    Wh_Log(L"HWND: No Personalization window found -> context menu");
+    Wh_Log(L"HWND: no personalization window found -> context menu");
     return false;
 }
 
 static std::wstring ResolvePersonalizationBackground(HWND hwnd) {
-    const std::wstring kPers = L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}";
-    const std::wstring kWall = kPers + L"\\pageWallpaper";
-
     if (!g_settings.smartPersonalizationDetect) {
-        Wh_Log(L"Resolve: SmartPersonalizationDetection=OFF -> Personalization root");
-        return kPers;
+        Wh_Log(L"SmartPersonalizationDetection OFF -> Personalization root");
+        return PERS_ROOT_CLSID;
     }
-
     if (IsPersonalizationWindow(hwnd)) {
-        Wh_Log(L"Resolve: personalization-background -> wallpaper");
-        return kWall;
-    } else {
-        Wh_Log(L"Resolve: personalization-background -> Personalization");
-        return kPers;
+        Wh_Log(L"personalization-background -> wallpaper page");
+        return PERS_WALLPAPER;
     }
+    Wh_Log(L"personalization-background -> Personalization root");
+    return PERS_ROOT_CLSID;
 }
 
-// ── Shared hook logic ─────────────────────────────────────────────────────────
+// ── Core resolve logic ────────────────────────────────────────────────────────
 
 struct ResolveResult {
     std::wstring target;
@@ -534,70 +532,62 @@ struct ResolveResult {
 
 static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
     if (uri == L"ms-settings:personalization-background") {
-        std::wstring t = ResolvePersonalizationBackground(hwnd);
-        t = ApplyWin11Compat(t);
+        std::wstring t = ApplyWin11Compat(ResolvePersonalizationBackground(hwnd));
         return {t, true};
     }
 
     auto it = g_mappings.find(uri);
     if (it != g_mappings.end()) {
         std::wstring t = ApplyWin11Compat(it->second);
-        Wh_Log(L"Map: %s -> %s", uri.c_str(), t.c_str());
+        Wh_Log(L"Mapped: %s -> %s", uri.c_str(), t.c_str());
         return {t, true};
     }
 
-    // Only apply fallback for ms-settings: URIs
     if (uri.find(L"ms-settings:") == 0) {
         bool handled = HandleFallback(uri);
         return {L"", handled};
     }
-    
-    // Unmapped shell::: targets pass through to original
+
     Wh_Log(L"Unmapped shell target, passing through: %s", uri.c_str());
     return {L"", false};
 }
 
-// ── Command line parsing helper ────────────────────────────────────────────────
+// ── Precise control system detection ─────────────────────────────────────────
+
+static std::wstring BaseNameLower(const std::wstring& path) {
+    size_t pos = path.rfind(L'\\');
+    return ToLower((pos != std::wstring::npos) ? path.substr(pos + 1) : path);
+}
 
 static bool IsControlSystemCommand(const std::wstring& cmdLine) {
-    // Parse command line into tokens
     std::vector<std::wstring> tokens;
     std::wstring current;
     bool inQuotes = false;
-    
+
     for (wchar_t c : cmdLine) {
         if (c == L'"') {
             inQuotes = !inQuotes;
         } else if (c == L' ' && !inQuotes) {
             if (!current.empty()) {
-                tokens.push_back(ToLower(current));
+                tokens.push_back(current);
                 current.clear();
             }
         } else {
             current += c;
         }
     }
-    if (!current.empty()) {
-        tokens.push_back(ToLower(current));
-    }
-    
-    if (tokens.empty()) return false;
-    
-    // Check if first token is control.exe (or ends with control.exe)
-    std::wstring exe = tokens[0];
-    if (exe == L"control.exe" || 
-        exe.find(L"\\control.exe") != std::wstring::npos ||
-        exe == L"control") {
-        
-        // Check for exact "system" argument
-        for (size_t i = 1; i < tokens.size(); i++) {
-            if (tokens[i] == L"system" || tokens[i] == L"microsoft.system") {
-                return true;
-            }
-        }
-    }
-    
-    return false;
+    if (!current.empty())
+        tokens.push_back(current);
+
+    if (tokens.size() != 2)
+        return false;
+
+    std::wstring exe = BaseNameLower(tokens[0]);
+    if (exe != L"control.exe" && exe != L"control")
+        return false;
+
+    std::wstring arg = ToLower(tokens[1]);
+    return (arg == L"system" || arg == L"microsoft.system");
 }
 
 // ── Hook: ShellExecuteExW ─────────────────────────────────────────────────────
@@ -606,35 +596,32 @@ using ShellExecuteExW_t = BOOL(WINAPI*)(SHELLEXECUTEINFOW*);
 ShellExecuteExW_t ShellExecuteExW_orig;
 
 BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
-    if (!g_settings.enableRedirects) return ShellExecuteExW_orig(pei);
+    if (!g_settings.enableRedirects || !pei)
+        return ShellExecuteExW_orig(pei);
 
-    if (pei) {
-        Wh_Log(L"ShellExecuteExW: hwnd=%p  lpFile=%s  lpParameters=%s",
-               pei->hwnd,
-               pei->lpFile       ? pei->lpFile       : L"(null)",
-               pei->lpParameters ? pei->lpParameters : L"(null)");
+    Wh_Log(L"ShellExecuteExW: hwnd=%p  file=%s  params=%s",
+           pei->hwnd,
+           pei->lpFile       ? pei->lpFile       : L"(null)",
+           pei->lpParameters ? pei->lpParameters : L"(null)");
 
-        const wchar_t* file   = pei->lpFile;
-        const wchar_t* params = pei->lpParameters;
-        std::wstring uri;
+    std::wstring uri;
+    if (IsMsSettings(pei->lpFile))
+        uri = NormalizeUri(pei->lpFile);
+    else if (IsMsSettings(pei->lpParameters))
+        uri = NormalizeUri(pei->lpParameters);
+    else if (IsShellClsid(pei->lpFile))
+        uri = ToLower(pei->lpFile);
+    else if (IsShellClsid(pei->lpParameters))
+        uri = ToLower(pei->lpParameters);
 
-        if (IsMsSettings(file) || IsMsSettings(params)) {
-            const wchar_t* raw = IsMsSettings(file) ? file : params;
-            uri = NormalizeUri(raw);
-        } else if (IsShellClsid(file) || IsShellClsid(params)) {
-            const wchar_t* raw = IsShellClsid(file) ? file : params;
-            uri = ToLower(raw);
-        }
-
-        if (!uri.empty()) {
-            Wh_Log(L"ShellExecuteExW hook: %s", uri.c_str());
-            auto result = ResolveUri(uri, pei->hwnd);
-
-            if (result.intercept) {
-                if (!result.target.empty()) LaunchTarget(result.target);
-                if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
-                return TRUE;
-            }
+    if (!uri.empty()) {
+        auto result = ResolveUri(uri, pei->hwnd);
+        if (result.intercept) {
+            if (!result.target.empty())
+                LaunchTarget(result.target);
+            if (pei->fMask & SEE_MASK_NOCLOSEPROCESS)
+                pei->hProcess = nullptr;
+            return TRUE;
         }
     }
     return ShellExecuteExW_orig(pei);
@@ -642,12 +629,10 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
 
 // ── Hook: ShellExecuteW ───────────────────────────────────────────────────────
 
-using ShellExecuteW_t = HINSTANCE(WINAPI*)(HWND, LPCWSTR, LPCWSTR, LPCWSTR, LPCWSTR, INT);
-ShellExecuteW_t ShellExecuteW_orig;
-
 HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
                                      LPCWSTR params, LPCWSTR dir, INT show) {
-    if (!g_settings.enableRedirects) return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
+    if (!g_settings.enableRedirects)
+        return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
 
     Wh_Log(L"ShellExecuteW: hwnd=%p  file=%s  params=%s",
            hwnd,
@@ -655,21 +640,20 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
            params ? params : L"(null)");
 
     std::wstring uri;
-
-    if (IsMsSettings(file) || IsMsSettings(params)) {
-        const wchar_t* raw = IsMsSettings(file) ? file : params;
-        uri = NormalizeUri(raw);
-    } else if (IsShellClsid(file) || IsShellClsid(params)) {
-        const wchar_t* raw = IsShellClsid(file) ? file : params;
-        uri = ToLower(raw);
-    }
+    if (IsMsSettings(file))
+        uri = NormalizeUri(file);
+    else if (IsMsSettings(params))
+        uri = NormalizeUri(params);
+    else if (IsShellClsid(file))
+        uri = ToLower(file);
+    else if (IsShellClsid(params))
+        uri = ToLower(params);
 
     if (!uri.empty()) {
-        Wh_Log(L"ShellExecuteW hook: %s", uri.c_str());
         auto result = ResolveUri(uri, hwnd);
-
         if (result.intercept) {
-            if (!result.target.empty()) LaunchTarget(result.target);
+            if (!result.target.empty())
+                LaunchTarget(result.target);
             return SHELL_EXECUTE_SUCCESS;
         }
     }
@@ -678,22 +662,16 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
 
 // ── Hook: CreateProcessW ──────────────────────────────────────────────────────
 
-using CreateProcessW_t = BOOL(WINAPI*)(
-    LPCWSTR, LPWSTR, LPSECURITY_ATTRIBUTES, LPSECURITY_ATTRIBUTES,
-    BOOL, DWORD, LPVOID, LPCWSTR, LPSTARTUPINFOW, LPPROCESS_INFORMATION
-);
-CreateProcessW_t CreateProcessW_orig = nullptr;
-
 BOOL WINAPI CreateProcessW_hook(
     LPCWSTR lpApplicationName,
-    LPWSTR lpCommandLine,
+    LPWSTR  lpCommandLine,
     LPSECURITY_ATTRIBUTES lpProcessAttributes,
     LPSECURITY_ATTRIBUTES lpThreadAttributes,
-    BOOL bInheritHandles,
-    DWORD dwCreationFlags,
-    LPVOID lpEnvironment,
+    BOOL    bInheritHandles,
+    DWORD   dwCreationFlags,
+    LPVOID  lpEnvironment,
     LPCWSTR lpCurrentDirectory,
-    LPSTARTUPINFOW lpStartupInfo,
+    LPSTARTUPINFOW       lpStartupInfo,
     LPPROCESS_INFORMATION lpProcessInformation)
 {
     if (!g_settings.enableRedirects || g_settings.uiOnlyRedirects) {
@@ -706,34 +684,30 @@ BOOL WINAPI CreateProcessW_hook(
     }
 
     std::wstring cmdLine = lpCommandLine ? std::wstring(lpCommandLine) : L"";
-    
+
     if (IsControlSystemCommand(cmdLine)) {
-        Wh_Log(L"CreateProcessW: intercepted control system command: %s", lpCommandLine);
-        
-        // Launch System Properties via ShellExecute instead
-        LaunchTarget(L"shell:::{BB06C0E4-D293-4f75-8A90-CB05B6477EEE}");
-        
-        // Zero out PROCESS_INFORMATION to avoid garbage handles
-        if (lpProcessInformation) {
+        Wh_Log(L"CreateProcessW: intercepted 'control system': %s", lpCommandLine);
+        LaunchTarget(SYSTEM_PROPS_CLSID);
+
+        if (lpProcessInformation)
             ZeroMemory(lpProcessInformation, sizeof(PROCESS_INFORMATION));
-        }
+
         SetLastError(ERROR_SUCCESS);
         return TRUE;
     }
-    
+
     return CreateProcessW_orig(
         lpApplicationName, lpCommandLine,
         lpProcessAttributes, lpThreadAttributes,
         bInheritHandles, dwCreationFlags,
         lpEnvironment, lpCurrentDirectory,
-        lpStartupInfo, lpProcessInformation
-    );
+        lpStartupInfo, lpProcessInformation);
 }
 
-// ── Windhawk Entry Points ─────────────────────────────────────────────────────
+// ── Windhawk entry points ─────────────────────────────────────────────────────
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"Redirect Settings to Control Panel v9.6.1 - Initializing...");
+    Wh_Log(L"Redirect Settings to Control Panel v9.7.1 init");
 
     DetectWindowsVersion();
     LoadSettings();
@@ -743,39 +717,40 @@ BOOL Wh_ModInit() {
     HMODULE hShell32 = GetModuleHandleW(L"shell32.dll");
     if (!hShell32) hShell32 = LoadLibraryW(L"shell32.dll");
     if (!hShell32) {
-        Wh_Log(L"ERROR: Could not load shell32.dll");
+        Wh_Log(L"ERROR: could not load shell32.dll");
         return FALSE;
     }
 
     auto pExW = (void*)GetProcAddress(hShell32, "ShellExecuteExW");
     auto pW   = (void*)GetProcAddress(hShell32, "ShellExecuteW");
-
     if (!pExW || !pW) {
-        Wh_Log(L"ERROR: Required functions not found in shell32.dll");
+        Wh_Log(L"ERROR: required exports not found in shell32.dll");
         return FALSE;
     }
 
-    bool ok1 = Wh_SetFunctionHook(pExW, (void*)ShellExecuteExW_hook, (void**)&ShellExecuteExW_orig);
-    bool ok2 = Wh_SetFunctionHook(pW,   (void*)ShellExecuteW_hook,   (void**)&ShellExecuteW_orig);
+    bool ok1 = Wh_SetFunctionHook(pExW, (void*)ShellExecuteExW_hook,
+                                   (void**)&ShellExecuteExW_orig);
+    bool ok2 = Wh_SetFunctionHook(pW,   (void*)ShellExecuteW_hook,
+                                   (void**)&ShellExecuteW_orig);
+    Wh_Log(L"ShellExecuteExW hook=%d  ShellExecuteW hook=%d", ok1, ok2);
 
-    Wh_Log(L"Hook results: ShellExecuteExW=%d  ShellExecuteW=%d", ok1, ok2);
+    if (!ok1 && !ok2) {
+        Wh_Log(L"ERROR: failed to install any hooks");
+        return FALSE;
+    }
 
     HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
     if (!hKernel32) hKernel32 = LoadLibraryW(L"kernel32.dll");
     if (hKernel32) {
         auto pCPW = (void*)GetProcAddress(hKernel32, "CreateProcessW");
         if (pCPW) {
-            bool ok3 = Wh_SetFunctionHook(pCPW, (void*)CreateProcessW_hook, (void**)&CreateProcessW_orig);
-            Wh_Log(L"CreateProcessW hook: %d", ok3);
+            bool ok3 = Wh_SetFunctionHook(pCPW, (void*)CreateProcessW_hook,
+                                           (void**)&CreateProcessW_orig);
+            Wh_Log(L"CreateProcessW hook=%d", ok3);
         }
     }
 
-    if (!ok1 && !ok2) {
-        Wh_Log(L"ERROR: Failed to install any hooks");
-        return FALSE;
-    }
-
-    Wh_Log(L"Ready! (EnableRedirects=%d, UIOnly=%d, SmartPers=%d, Fallback=%d, Win11Compat=%d)",
+    Wh_Log(L"Ready (EnableRedirects=%d UIOnly=%d SmartPers=%d Fallback=%d Win11Compat=%d)",
         (int)g_settings.enableRedirects,
         (int)g_settings.uiOnlyRedirects,
         (int)g_settings.smartPersonalizationDetect,
@@ -789,6 +764,6 @@ void Wh_ModUninit() {
 }
 
 void Wh_ModSettingsChanged() {
-    Wh_Log(L"Settings changed, reloading...");
+    Wh_Log(L"Settings changed, reloading");
     LoadSettings();
 }

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -2,7 +2,7 @@
 // @id             settings-to-control-panel
 // @name           Redirect Settings to Control Panel
 // @description    Forces classic Control Panel to open instead of Windows 10/11 Settings app using native components. Primarily designed for Windows 10; Windows 11 support is limited due to Microsoft's shell architecture changes.
-// @version        10.0.1
+// @version        10.0.2
 // @author         babamohammed
 // @github         https://github.com/babamohammed2022
 // @include        explorer.exe
@@ -67,7 +67,7 @@ Control Panel target instead of the modern Settings app.
 
 - m417z – Code reviews and feedback
 - Anixx – Testing on Windows 11 23H2
-- dbilanoski – CLSID documentation
+- dbilanoski – CLSID documentation  
 */
 // ==/WindhawkModReadme==
 // ==WindhawkModSettings==
@@ -104,6 +104,8 @@ Control Panel target instead of the modern Settings app.
 #include <vector>
 #include <mutex>   
 #include <initguid.h>  
+#include <chrono>
+#include <thread>
 
 // Dynamic COM handling - no linking required
 typedef HRESULT (WINAPI *CoCreateInstance_t)(const GUID* rclsid, IUnknown* pUnkOuter, DWORD dwClsContext, const GUID* riid, void** ppv);
@@ -134,6 +136,10 @@ using ShellExecuteW_t = HINSTANCE(WINAPI*)(HWND, LPCWSTR, LPCWSTR, LPCWSTR, LPCW
 using ShellExecuteExW_t = BOOL(WINAPI*)(SHELLEXECUTEINFOW*);
 static ShellExecuteExW_t ShellExecuteExW_orig = nullptr;
 static ShellExecuteW_t ShellExecuteW_orig = nullptr;
+
+// Pending redirects guard per evitare chiamate duplicate
+static std::unordered_set<std::wstring> g_pendingRedirects;
+static std::mutex g_pendingMtx;
 
 // Core resolve logic struct - MUST be defined before use
 struct ResolveResult {
@@ -325,13 +331,6 @@ static const std::unordered_set<std::wstring> g_win11LoopClsids = {
     L"shell:::{9fe63afd-59cf-4419-9775-abcc3849f861}",
 };
 
-static const std::unordered_set<std::wstring> g_win11NoForceRedirect = {
-    L"ms-settings:defaultapps",
-    L"ms-settings:appsfeatures",
-    L"ms-settings:network",
-    L"ms-settings:bluetooth",
-    L"ms-settings:printers",
-};
 
 static bool IsClsidSafeOnWin11(const std::wstring& lowerTarget) {
     return g_win11SafeClsids.count(lowerTarget) > 0;
@@ -652,7 +651,7 @@ static bool HandleFallback(const std::wstring& uri) {
     }
 }
 
-// LaunchTarget - VERSIONE CORRETTA
+// LaunchTarget - VERSIONE CORRETTA CON PULIZIA PENDING REDIRECTS
 static void LaunchTarget(const std::wstring& command) {
     Wh_Log(L"Launching: %s", command.c_str());
 
@@ -757,11 +756,8 @@ static void LaunchTarget(const std::wstring& command) {
         CloseHandle(pi.hThread);
     }
 }
+
 // Personalization detection
-
-
-
-
 
 // Helper function to open sound panel
 static bool OpenSoundPanel() {
@@ -815,7 +811,17 @@ static std::wstring ResolvePersonalizationBackground(HWND hwnd) {
     Wh_Log(L"personalization-background -> Personalization root");
     return PERS_ROOT;
 }
+
 static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
+    // Controlla se questo URI è già in elaborazione
+    {
+        std::lock_guard<std::mutex> lk(g_pendingMtx);
+        if (g_pendingRedirects.find(uri) != g_pendingRedirects.end()) {
+            Wh_Log(L"URI already being processed, blocking duplicate: %s", uri.c_str());
+            return {L"", true}; // Blocca completamente
+        }
+    }
+    
     if (uri == L"ms-settings:personalization-background") {
         if (BounceGuardIsBounce(uri)) {
             Wh_Log(L"Bounce-back on personalization-background - suppressing duplicate, target is opening");
@@ -823,6 +829,12 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
         }
         std::wstring t = ApplyWin11Filter(ResolvePersonalizationBackground(hwnd));
         BounceGuardRecord(uri);
+        
+        // Marca come pendente
+        {
+            std::lock_guard<std::mutex> lk(g_pendingMtx);
+            g_pendingRedirects.insert(uri);
+        }
         return {t, true};
     }
 
@@ -844,6 +856,12 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
 
         Wh_Log(L"Mapped: %s -> %s", uri.c_str(), t.c_str());
         BounceGuardRecord(uri);
+        
+        // Marca come pendente
+        {
+            std::lock_guard<std::mutex> lk(g_pendingMtx);
+            g_pendingRedirects.insert(uri);
+        }
         return {t, true};
     }
 
@@ -856,6 +874,12 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
         if (g_isWin11 && IsClsidLoopOnWin11(uri)) {
             std::wstring t = ApplyWin11Filter(uri);
             Wh_Log(L"Win11 loop-CLSID intercepted: %s -> %s", uri.c_str(), t.c_str());
+            
+            // Marca come pendente
+            {
+                std::lock_guard<std::mutex> lk(g_pendingMtx);
+                g_pendingRedirects.insert(uri);
+            }
             return {t, true};
         }
     }
@@ -863,6 +887,7 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
     Wh_Log(L"Unmapped, passing through: %s", uri.c_str());
     return {L"", false};
 }
+
 // Control system detection helpers
 static std::wstring BaseNameLower(const std::wstring& path) {
     size_t pos = path.rfind(L'\\');
@@ -903,6 +928,14 @@ static bool IsControlSystemCommand(const std::wstring& cmdLine) {
 
     std::wstring arg = ToLower(tokens[1]);
     return (arg == L"system" || arg == L"microsoft.system");
+}
+
+// Funzione per pulire i pending redirects dopo un delay
+static void CleanupPendingRedirect(const std::wstring& uri, DWORD delayMs) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+    std::lock_guard<std::mutex> lk(g_pendingMtx);
+    g_pendingRedirects.erase(uri);
+    Wh_Log(L"Cleaned up pending redirect for: %s", uri.c_str());
 }
 
 // Hook: ShellExecuteExW
@@ -950,9 +983,28 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
     }
 
     if (!uri.empty()) {
+        // Controllo extra per bloccare chiamate duplicate
+        {
+            std::lock_guard<std::mutex> lk(g_pendingMtx);
+            if (g_pendingRedirects.find(uri) != g_pendingRedirects.end()) {
+                Wh_Log(L"ShellExecuteExW: BLOCKED duplicate call for: %s", uri.c_str());
+                if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
+                return TRUE;
+            }
+        }
+        
         auto result = ResolveUri(uri, pei->hwnd);
         if (result.intercept) {
-            if (!result.target.empty()) LaunchTarget(result.target);
+            if (!result.target.empty()) {
+                LaunchTarget(result.target);
+                // Pulisci il pending redirect dopo 200ms
+                std::thread cleanupThread(CleanupPendingRedirect, uri, 200);
+                cleanupThread.detach();
+            } else {
+                // Pulisci subito se non c'è target
+                std::lock_guard<std::mutex> lk(g_pendingMtx);
+                g_pendingRedirects.erase(uri);
+            }
             if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
             return TRUE;
         }
@@ -1005,9 +1057,27 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file, LPCWSTR
     }
 
     if (!uri.empty()) {
+        // Controllo per bloccare chiamate duplicate
+        {
+            std::lock_guard<std::mutex> lk(g_pendingMtx);
+            if (g_pendingRedirects.find(uri) != g_pendingRedirects.end()) {
+                Wh_Log(L"ShellExecuteW: BLOCKED duplicate call for: %s", uri.c_str());
+                return SHELL_EXECUTE_SUCCESS;
+            }
+        }
+        
         auto result = ResolveUri(uri, hwnd);
         if (result.intercept) {
-            if (!result.target.empty()) LaunchTarget(result.target);
+            if (!result.target.empty()) {
+                LaunchTarget(result.target);
+                // Pulisci il pending redirect dopo 200ms
+                std::thread cleanupThread(CleanupPendingRedirect, uri, 200);
+                cleanupThread.detach();
+            } else {
+                // Pulisci subito se non c'è target
+                std::lock_guard<std::mutex> lk(g_pendingMtx);
+                g_pendingRedirects.erase(uri);
+            }
             return SHELL_EXECUTE_SUCCESS;
         }
     }
@@ -1080,7 +1150,14 @@ HRESULT WINAPI IShellDispatch2_ShellExecute_hook(
         uri = ToLower(fileStr);
 
     if (!uri.empty()) {
-        
+        // Controllo per bloccare chiamate duplicate
+        {
+            std::lock_guard<std::mutex> lk(g_pendingMtx);
+            if (g_pendingRedirects.find(uri) != g_pendingRedirects.end()) {
+                Wh_Log(L"IShellDispatch2: BLOCKED duplicate call for: %s", uri.c_str());
+                return S_OK;
+            }
+        }
         
         // Audio URI handling in COM hook
         if (uri.find(L"ms-settings:sound") == 0 ||
@@ -1090,7 +1167,16 @@ HRESULT WINAPI IShellDispatch2_ShellExecute_hook(
         
         auto result = ResolveUri(uri, nullptr);
         if (result.intercept) {
-            if (!result.target.empty()) LaunchTarget(result.target);
+            if (!result.target.empty()) {
+                LaunchTarget(result.target);
+                // Pulisci il pending redirect dopo 200ms
+                std::thread cleanupThread(CleanupPendingRedirect, uri, 200);
+                cleanupThread.detach();
+            } else {
+                // Pulisci subito se non c'è target
+                std::lock_guard<std::mutex> lk(g_pendingMtx);
+                g_pendingRedirects.erase(uri);
+            }
             return S_OK;
         }
     }
@@ -1104,7 +1190,7 @@ HRESULT WINAPI IShellDispatch2_ShellExecute_hook(
 
 // Windhawk entry points
 BOOL Wh_ModInit() {
-    Wh_Log(L"Redirect Settings to Control Panel v10.0.1");
+    Wh_Log(L"Redirect Settings to Control Panel v10.0.2");
     
     // Load COM dynamically for IShellDispatch2 hook
     g_hOle32 = LoadLibraryW(L"ole32.dll");
@@ -1170,7 +1256,7 @@ void Wh_ModUninit() {
         FreeLibrary(g_hOle32);
         g_hOle32 = nullptr;
     }
-    Wh_Log(L"Redirect Settings to Control Panel v10.0.1 unloaded.");
+    Wh_Log(L"Redirect Settings to Control Panel v10.0.2 unloaded.");
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -1,16 +1,15 @@
 // ==WindhawkMod==
 // @id             settings-to-control-panel
 // @name           Redirect Settings to Control Panel
-// @description    Forces classic Control Panel to open instead of Windows 10/11 Settings app using native components
-// @version        9.8.4
+// @description    Forces classic Control Panel to open instead of Windows 10/11 Settings app using native components. Primarily designed for Windows 10; Windows 11 support is limited due to Microsoft's shell architecture changes.
+// @version        9.8.7
 // @author         babamohammed
 // @github         https://github.com/babamohammed2022
-// @license        MIT
 // @include        explorer.exe
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
-# Redirect Settings → Control Panel (v9.8.4)
+# Redirect Settings → Control Panel (v9.8.7)
 
 This Windhawk mod intercepts modern `ms-settings:` URIs and redirects them to
 their corresponding classic Control Panel applets, relying exclusively on native
@@ -18,52 +17,59 @@ Windows components (no external binaries or dependencies).
 
 ---
 
-## Overview
+## Important: Windows 10 vs Windows 11
 
-This mod restores access to the legacy Control Panel experience from older
-versions of Windows. When a system setting link is opened (typically triggering
-the modern Settings app), it is transparently redirected to the equivalent
-classic Control Panel interface whenever possible.
+**This mod is primarily designed for Windows 10**, where the classic Control Panel
+infrastructure is fully intact and most user interactions go through `explorer.exe`.
 
-This is particularly useful for users who prefer the Windows 7-style Control
-Panel workflow or want a faster, more direct navigation model compared to the
-modern Settings application.
+**On Windows 11**, Microsoft rewrote the shell (taskbar, system tray, desktop
+right-click menus) using XAML/UWP technology. The modern taskbar uses
+`DelegateExecute` COM activation and `ms-contact-support://` protocol instead of
+`ShellExecute`, which means:
 
----
-
-## Scope of Interception
-
-Redirection is applied **only to ShellExecute calls originating from File Explorer**.
-This design choice minimizes side effects and avoids interfering with:
-
-- Start Menu behavior  
-- Windows Search results  
-- Third-party applications  
-
-All other invocation contexts remain unaffected.
-
----
-
-## Compatibility
-
-### Windows 10
-Fully functional in most scenarios. The majority of Control Panel applets are
-still present and correctly mapped. Some legacy applets removed by Microsoft
-(e.g. Taskbar-related settings or legacy Display configuration pages) cannot be
-resolved and will fall back to the configured behavior.
-
-### Windows 11
-Partially supported due to the removal or migration of several Control Panel
-components into the Settings app.
+- **Control Panel navigation** works on both OSes (with Windows 10 being more compatible)
+- **System tray redirection works on Windows 10 only** (or Windows 11 with the classic Win32 taskbar restored via ExplorerPatcher)
+- Some Control Panel components have been **deprecated or removed** by Microsoft on Windows 11
+- Some CLSIDs still exist in the registry but open **empty panels**
+- **Desktop right-click → Personalize** uses a different code path on Win11 (Could be fixed in future)
+- **Start Menu search results** are not intercepted (to avoid breaking search)
 
 When no valid classic equivalent exists, behavior is controlled via fallback
-configuration (see Settings section). Options include:
+configuration (see Settings section).
 
-- Opening the root Control Panel
-- Allowing the modern Settings app to launch
-- Suppressing the action entirely
+---
 
-Ongoing compatibility improvements target newer Windows 11 builds.
+## What This Mod Does (and Doesn't Do)
+
+### ✅ Redirected (both Windows 10 and 11)
+- Control Panel navigation (System, Network, Sound, Accounts, Devices, etc.)
+- `Win+R` → `ms-settings:*` commands
+- `explorer shell:::*` protocol
+- Classic Personalization CPL — including Colors and Background sub-pages
+- Right-click "This PC" → Properties
+- Troubleshooting → MSDT on Win11 (`msdt.exe`)
+
+### 🟡 Redirected on Windows 10 only
+- System tray icon clicks (audio, network) — uses Win32 taskbar
+- Desktop right-click → Personalize
+- Taskbar notification area settings
+
+### 🔴 Not Redirected (architectural limitation)
+- Modern Windows 11 taskbar tray (uses `DelegateExecute` COM activation)
+- Start Menu search results (excluded to avoid breaking search)
+- Internal Settings app navigation
+
+**Note for Windows 11 users:** To get full tray icon redirection, use a tool
+like **ExplorerPatcher** to restore the classic Win32 taskbar, which uses
+`explorer.exe` and `ms-settings:` URIs like Windows 10.
+
+---
+
+## Overview
+
+This mod restores access to the legacy Control Panel experience. When a system
+setting link is opened (typically triggering the modern Settings app), it is
+transparently redirected to the equivalent classic Control Panel interface.
 
 ---
 
@@ -71,34 +77,42 @@ Ongoing compatibility improvements target newer Windows 11 builds.
 
 - Over 90 URI-to-applet mappings covering:
   System, Network, Personalization, Sound, Devices, Accounts, Fonts, and more
-- Enhanced desktop context handling:
-  - Right-click Desktop → opens classic Personalization
-  - Nested navigation support for wallpaper selection workflows
+- Smart Personalization detection (desktop right-click vs in-window navigation)
+- Classic Personalization CPL with working Colors and Background sub-pages
+- MSDT troubleshooting on Windows 11
 - Safe fallback handling for unmapped settings
-- Anti-loop protection for recursive redirections on Windows 11
+- Anti-loop protection (cross-process, in-process, bounce-back detection)
 - Lightweight implementation using native Windows APIs only
+
+---
+
+## Testing
+
+### On Windows 10
+1. **Right-click speaker icon** → "Sounds" → should open `mmsys.cpl`
+2. **Right-click network icon** → "Network settings" → should open Network Connections
+3. **Right-click desktop** → "Personalize" → should open classic Personalization
+4. **Control Panel** → System → should stay in classic Control Panel
+
+### On Windows 11
+1. **Win+R** → `ms-settings:about` → should open System Properties (`sysdm.cpl`)
+2. **Win+R** → `explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}` → classic Personalization
+3. **Control Panel** → System → should stay in classic Control Panel
+4. **Control Panel** → Troubleshooting → should open MSDT
 
 ---
 
 ## Configuration Options
 
-- **EnableRedirects**  
-  Master switch enabling or disabling all redirections.
-
-- **UIOnlyRedirects**  
-  Restricts interception to ShellExecute/UI-level calls only, avoiding script-level execution paths for improved safety.
-
-- **SmartPersonalizationDetection**  
-  Differentiates between desktop context actions and in-window personalization navigation.
-
-- **FallbackMode**  
-  Defines behavior when no classic Control Panel equivalent exists.
-
-- **Win11CompatibilityMode**  
-  Enables additional safeguards for Windows 11, including blocking unverified CLSID targets.
-
-- **MaxLaunchesPerUri**  
-  Limits repeated redirection chains to prevent infinite loops or runaway execution.
+- **EnableRedirects**: Master switch — turn the mod on or off
+- **UIOnlyRedirects**: Only intercept ShellExecute* calls (leaves CreateProcessW alone)
+- **SmartPersonalizationDetection**: Differentiate desktop vs in-window personalization
+- **FallbackMode**: Behavior when no classic equivalent exists
+  - `0` — Ignore (silent fail)
+  - `1` — Open Control Panel root (`control.exe`)
+  - `2` — Pass through to modern Settings app (default)
+- **Win11CompatibilityMode**: Additional Win11 safeguards for unverified CLSIDs
+- **MaxLaunchesPerUri**: Anti-loop safety valve (max launches per URI in 5 seconds)
 */
 // ==/WindhawkModReadme==
 // ==WindhawkModSettings==
@@ -145,17 +159,11 @@ static const HINSTANCE SHELL_EXECUTE_SUCCESS = (HINSTANCE)33;
 #define SYSTEM_PROPS_CLSID  L"shell:::{BB06C0E4-D293-4f75-8A90-CB05B6477EEE}"
 #define NOTIF_AREA_CLSID    L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"
 
-// Classic Personalization CPL opened via "explorer shell:::{ED834ED6} [-page]"
-// syntax. Explorer resolves the CLSID namespace directly, bypassing the
-// ShellExecuteEx/DelegateExecute path that redirects to ms-settings on Win11.
-// The "-Microsoft.Personalization\pageX" suffix navigates to a sub-page.
-// All four values are full command lines handled by LaunchTarget.
 #define PERS_ED_CLSID   L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"
 #define PERS_ROOT       L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"
 #define PERS_WALLPAPER  L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921} -Microsoft.Personalization\\pageWallpaper"
 #define PERS_COLORS     L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921} -Microsoft.Personalization\\pageColorization"
 
-// Sentinel: URI has no working CP equivalent on Win11; route straight to fallback.
 #define WIN11_PASSTHROUGH L"__PASSTHROUGH__"
 
 // ── Forward declarations ──────────────────────────────────────────────────────
@@ -166,16 +174,11 @@ using CreateProcessW_t = BOOL(WINAPI*)(
 static CreateProcessW_t CreateProcessW_orig = nullptr;
 
 using ShellExecuteW_t = HINSTANCE(WINAPI*)(HWND, LPCWSTR, LPCWSTR, LPCWSTR, LPCWSTR, INT);
+using ShellExecuteExW_t = BOOL(WINAPI*)(SHELLEXECUTEINFOW*);
+static ShellExecuteExW_t ShellExecuteExW_orig = nullptr;
 static ShellExecuteW_t ShellExecuteW_orig = nullptr;
 
 // ── In-process reentry guard ──────────────────────────────────────────────────
-//
-// Prevents hooks from re-intercepting calls made by code that our mod itself
-// triggered (e.g. Control Panel subpages, Explorer internal navigation).
-// This is per-thread so concurrent Explorer threads don't block each other.
-//
-// Usage: create a HookGuard at the top of each hook function, then call
-// IsReentrant() to decide whether to pass through.
 
 static thread_local int g_hookDepth = 0;
 
@@ -186,10 +189,6 @@ struct HookGuard {
 };
 
 // ── Cross-process reentry guard ───────────────────────────────────────────────
-//
-// Child processes spawned by LaunchTarget receive WH_STC_NOREDIRECT=1 in their
-// environment. Hooks in the child check this flag and pass through without
-// re-intercepting, preventing cross-process redirect loops.
 
 static std::wstring g_childEnvBlock;
 
@@ -274,23 +273,12 @@ static void DetectWindowsVersion() {
 }
 
 // ── Loop guard + Bounce-back detection ───────────────────────────────────────
-//
-// Two distinct protections:
-//
-// 1. LOOP GUARD (existing): caps total launches of a given *target* within 5 s.
-//
-// 2. BOUNCE-BACK DETECTOR (new): detects when a CP panel/CPL that we launched
-//    no longer exists on Win11 and silently re-fires the original ms-settings URI.
-//    Pattern: same URI seen again within BOUNCE_WINDOW_MS of a prior redirect.
-//    On detection the second call is routed to fallback instead of retrying.
-//    This is separate from the loop guard so it works even with MaxLaunches > 1.
 
 struct LaunchRecord {
     int   count     = 0;
     DWORD firstTick = 0;
 };
 
-// Bounce-back: records the tick at which we last redirected a given URI.
 struct BounceRecord {
     DWORD lastRedirectTick = 0;
 };
@@ -302,15 +290,11 @@ static std::unordered_map<std::wstring, BounceRecord>  g_bounceGuard;
 static constexpr DWORD LOOP_WINDOW_MS   = 5000;
 static constexpr DWORD BOUNCE_WINDOW_MS = 600;
 
-// Call this when we are about to redirect a URI (before LaunchTarget).
-// Records the redirect time for bounce-back detection.
 static void BounceGuardRecord(const std::wstring& uri) {
     std::lock_guard<std::mutex> lk(g_loopGuardMtx);
     g_bounceGuard[uri].lastRedirectTick = GetTickCount();
 }
 
-// Call this when a URI fires again. Returns true if it looks like a bounce-back
-// (the same URI came back too quickly after we redirected it → the target is dead).
 static bool BounceGuardIsBounce(const std::wstring& uri) {
     std::lock_guard<std::mutex> lk(g_loopGuardMtx);
     auto it = g_bounceGuard.find(uri);
@@ -319,7 +303,6 @@ static bool BounceGuardIsBounce(const std::wstring& uri) {
     if (elapsed < BOUNCE_WINDOW_MS) {
         Wh_Log(L"BOUNCE-BACK: '%s' returned %lu ms after redirect — target is dead, routing to fallback",
                uri.c_str(), elapsed);
-        // Reset so the user can try again after the window expires
         it->second.lastRedirectTick = 0;
         return true;
     }
@@ -366,21 +349,15 @@ static const std::unordered_set<std::wstring> g_win11SafeClsids = {
     L"shell:::{bd84b380-8ca2-1069-ab1d-08000948f534}",
     L"shell:::{d555645e-d4f8-4c29-a827-d93c859c4f2a}",
     L"shell:::{d9ef8727-cac2-4e60-809e-86f80a666c91}",
+    L"shell:::{c58c4893-3be0-4b45-abb5-a63e4b8c8651}",
 };
 
-// CLSIDs that on Win11 trigger a redirect back to ms-settings when opened
-// via ShellExecuteEx (DelegateExecute path). ApplyWin11Filter intercepts these
-// and routes them to working alternatives before they are passed to Explorer.
-// Note: {ED834ED6} is handled specially -> PERS_ROOT / PERS_WALLPAPER.
-//       {BB06C0E4} is handled specially -> sysdm.cpl.
-//       The rest fall back to control.exe.
 static const std::unordered_set<std::wstring> g_win11LoopClsids = {
-    L"shell:::{bb06c0e4-d293-4f75-8a90-cb05b6477eee}",  // System Properties
-    L"shell:::{ed834ed6-4b5a-4bfe-8f11-a626dcb6a921}",  // Personalization CPL
-    L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}",  // Default Programs
-    L"shell:::{80f3f1d5-feca-45f3-bc32-752c152e456e}",  // Pen and Touch
-    L"shell:::{9fe63afd-59cf-4419-9775-abcc3849f861}",  // Recovery
-    L"shell:::{c58c4893-3be0-4b45-abb5-a63e4b8c8651}",  // Troubleshooting
+    L"shell:::{bb06c0e4-d293-4f75-8a90-cb05b6477eee}",
+    L"shell:::{ed834ed6-4b5a-4bfe-8f11-a626dcb6a921}",
+    L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}",
+    L"shell:::{80f3f1d5-feca-45f3-bc32-752c152e456e}",
+    L"shell:::{9fe63afd-59cf-4419-9775-abcc3849f861}",
 };
 
 static bool IsClsidSafeOnWin11(const std::wstring& lowerTarget) {
@@ -412,9 +389,6 @@ static void InitMappings() {
     g_mappings = {
 
         // ── Personalization ──────────────────────────────────────────────────
-        // PERS_ROOT and PERS_WALLPAPER use the "explorer shell:::{ED834ED6} [-page]"
-        // syntax, which works on both Win10 and Win11. Explorer opens the CLSID
-        // namespace directly without triggering the DelegateExecute redirect.
         {L"ms-settings:personalization",             PERS_ROOT},
         {L"ms-settings:personalization-colors",      PERS_COLORS},
         {L"ms-settings:colors",                      PERS_COLORS},
@@ -526,6 +500,8 @@ static void InitMappings() {
         {L"ms-settings:datausage",
             L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         {L"ms-settings:network-proxy",                       L"inetcpl.cpl,,4"},
+        {L"settings:network-status", 
+            L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
         {L"ms-settings:network-status",
             L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
         {L"ms-settings:network-dialup",
@@ -551,9 +527,6 @@ static void InitMappings() {
         {L"ms-settings:startupapps",                         L"msconfig.exe"},
 
         // ── Default Apps ──────────────────────────────────────────────────────
-        // Microsoft.DefaultPrograms panel was removed on Win11 24H2.
-        // The CPL would open briefly and re-fire ms-settings:defaultapps,
-        // causing a bounce-back loop. Route to passthrough (FallbackMode) instead.
         {L"ms-settings:defaultapps",
             w11 ? WIN11_PASSTHROUGH
                 : L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
@@ -575,8 +548,12 @@ static void InitMappings() {
             L"shell:::{B98A2BEA-7D42-4558-8BD1-832F41BAC6FD}"},
         {L"ms-settings:recovery",
             w11 ? L"control.exe" : L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
+
+        // ── Troubleshooting ───────────────────────────────────────────────────
+        // added a legacy redirect in windows 11
         {L"ms-settings:troubleshoot",
-            w11 ? L"control.exe" : L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
+                w11 ? L"msdt.exe -id DeviceDiagnostic" : L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
+
         {L"ms-settings:deviceencryption",
             L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
     };
@@ -587,9 +564,10 @@ static void InitMappings() {
 static std::wstring NormalizeUri(const std::wstring& uri) {
     std::wstring result = ToLower(uri);
 
-    size_t pos = result.find(L"ms-settings://");
+    const std::wstring PROTOCOL = L"ms-settings://";
+    size_t pos = result.find(PROTOCOL);
     if (pos != std::wstring::npos)
-        result = L"ms-settings:" + result.substr(pos + 14);
+    { result = L"ms-settings:" + result.substr(pos + PROTOCOL.length()); }
 
     pos = result.find(L'?');
     if (pos != std::wstring::npos)
@@ -622,8 +600,6 @@ static std::wstring ApplyWin11Filter(const std::wstring& target) {
 
     if (IsClsidLoopOnWin11(lower)) {
         if (lower.find(L"ed834ed6") != std::wstring::npos) {
-            // Use the unified "explorer shell:::{ED834ED6} [-page]" syntax.
-            // This bypasses DelegateExecute and works on both Win10 and Win11.
             if (lower.find(L"pagewallpaper") != std::wstring::npos) {
                 Wh_Log(L"Win11 loop-guard: {ED834ED6}\\pageWallpaper -> PERS_WALLPAPER");
                 return PERS_WALLPAPER;
@@ -688,14 +664,26 @@ static void LaunchTarget(const std::wstring& command) {
         return;
     }
 
-    // Full command lines (exe + arguments)
     {
         std::wstring lower = ToLower(command);
+        
+        // Gestisci "explorer shell:::" separatamente
+        if (lower.find(L"explorer shell:::") != std::wstring::npos) {
+            std::wstring clsid = command.substr(command.find(L"shell:::"));
+            SHELLEXECUTEINFOW sei = {};
+            sei.cbSize = sizeof(sei);
+            sei.fMask = SEE_MASK_FLAG_NO_UI;
+            sei.lpVerb = L"open";
+            sei.lpFile = clsid.c_str();
+            sei.nShow = SW_SHOWNORMAL;
+            ShellExecuteExW_orig(&sei);
+            return;
+        }
+        
         bool isFullCmdLine =
             (lower.find(L"rundll32.exe ")    != std::wstring::npos) ||
             (lower.find(L"explorer.exe ")    != std::wstring::npos) ||
-            // "explorer shell:::{...}" — no .exe, but still a full command line
-            (lower.find(L"explorer shell:::") != std::wstring::npos) ||
+            (lower.find(L"msdt.exe ")        != std::wstring::npos) ||
             (lower.find(L"control.exe /")    != std::wstring::npos);
 
         if (isFullCmdLine) {
@@ -717,19 +705,6 @@ static void LaunchTarget(const std::wstring& command) {
         }
     }
 
-    // ShellExecute passthrough for UAC targets
-    if (command == L"devmgmt.msc"                          ||
-        command == L"compmgmt.msc"                         ||
-        command == L"slui.exe"                             ||
-        command == L"OptionalFeatures.exe"                 ||
-        command == L"C:\\Windows\\System32\\devmgmt.msc"   ||
-        command == L"C:\\Windows\\System32\\compmgmt.msc"  ||
-        command == L"C:\\Windows\\System32\\slui.exe"      ||
-        command == L"C:\\Windows\\System32\\OptionalFeatures.exe") {
-        ShellExecuteW_orig(nullptr, L"open", command.c_str(),
-                           nullptr, nullptr, SW_SHOWNORMAL);
-        return;
-    }
 
     // Generic router
     STARTUPINFOW si = {};
@@ -746,7 +721,15 @@ static void LaunchTarget(const std::wstring& command) {
     } else if (command.find(L".exe") != std::wstring::npos) {
         cmdLine = command;
     } else if (command.find(L"shell:::") == 0) {
-        cmdLine = L"explorer.exe " + command;
+        // Apri CLSID direttamente
+        SHELLEXECUTEINFOW sei = {};
+        sei.cbSize = sizeof(sei);
+        sei.fMask = SEE_MASK_FLAG_NO_UI;
+        sei.lpVerb = L"open";
+        sei.lpFile = command.c_str();
+        sei.nShow = SW_SHOWNORMAL;
+        ShellExecuteExW_orig(&sei);
+        return;
     } else if (command.empty()) {
         cmdLine = L"control.exe";
     } else {
@@ -828,8 +811,6 @@ struct ResolveResult {
 
 static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
     if (uri == L"ms-settings:personalization-background") {
-        // Bounce-back check: if this URI is returning quickly after our redirect,
-        // the target is dead — go straight to fallback.
         if (BounceGuardIsBounce(uri)) {
             Wh_Log(L"Bounce-back on personalization-background, routing to fallback");
             bool handled = HandleFallback(uri);
@@ -842,7 +823,6 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
 
     auto it = g_mappings.find(uri);
     if (it != g_mappings.end()) {
-        // Bounce-back check before attempting the mapped target
         if (BounceGuardIsBounce(uri)) {
             Wh_Log(L"Bounce-back on '%s', routing to fallback", uri.c_str());
             bool handled = HandleFallback(uri);
@@ -851,8 +831,6 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
 
         std::wstring t = ApplyWin11Filter(it->second);
 
-        // PASSTHROUGH sentinel: this URI has no working CP equivalent on this OS.
-        // Route directly to fallback without spawning anything.
         if (t == WIN11_PASSTHROUGH) {
             Wh_Log(L"Passthrough sentinel for '%s', routing to fallback", uri.c_str());
             bool handled = HandleFallback(uri);
@@ -869,16 +847,12 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
         return {L"", handled};
     }
 
-    // For direct shell::: CLSIDs: on Win11 only intercept known loop CLSIDs.
-    // On Win10, pass through — they were already explicitly passed by the caller
-    // as a CLSID, so no translation needed.
     if (uri.find(L"shell:::") == 0) {
         if (g_isWin11 && IsClsidLoopOnWin11(uri)) {
             std::wstring t = ApplyWin11Filter(uri);
             Wh_Log(L"Win11 loop-CLSID intercepted: %s -> %s", uri.c_str(), t.c_str());
             return {t, true};
         }
-        // Not a loop CLSID or not Win11: do not intercept
     }
 
     Wh_Log(L"Unmapped, passing through: %s", uri.c_str());
@@ -933,8 +907,7 @@ static bool IsControlSystemCommand(const std::wstring& cmdLine) {
 
 // ── Hook: ShellExecuteExW ─────────────────────────────────────────────────────
 
-using ShellExecuteExW_t = BOOL(WINAPI*)(SHELLEXECUTEINFOW*);
-ShellExecuteExW_t ShellExecuteExW_orig;
+
 
 BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
     if (IsChildProcess())
@@ -968,7 +941,6 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
         uri = NormalizeUri(pei->lpParameters);
     else if (IsShellClsid(pei->lpFile)) {
         std::wstring lower = ToLower(pei->lpFile);
-        // Only intercept shell::: CLSIDs that are known loop-causers on Win11
         if (g_isWin11 && IsClsidLoopOnWin11(lower))
             uri = lower;
     }
@@ -1111,7 +1083,7 @@ BOOL WINAPI CreateProcessW_hook(
 // ── Windhawk entry points ─────────────────────────────────────────────────────
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"Redirect Settings to Control Panel v9.8.4 init");
+    Wh_Log(L"Redirect Settings to Control Panel v9.8.7 init");
 
     DetectWindowsVersion();
     LoadSettings();
@@ -1154,7 +1126,6 @@ BOOL Wh_ModInit() {
             Wh_Log(L"CreateProcessW hook=%d", ok3);
         }
     }
-
     Wh_Log(L"Ready — EnableRedirects=%d UIOnly=%d SmartPers=%d Fallback=%d Win11Compat=%d MaxLaunches=%d",
         (int)g_settings.enableRedirects,
         (int)g_settings.uiOnlyRedirects,

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -1,0 +1,798 @@
+// ==WindhawkMod==
+// @id             settings-to-control-panel
+// @name           Redirect Settings to Control Panel
+// @description    Forces classic Control Panel to open instead of Windows 10/11 Settings app using native components
+// @version        9.6.0
+// @author         babamohammed
+// @github         https://github.com/babamohammed2022
+// @license        MIT                                        
+// @include        explorer.exe
+// @compilerOptions -lshell32 -lkernel32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Redirect Settings → Control Panel (v9.6.0)
+
+This mod intercepts modern `ms-settings:` URI protocols and forces Windows to open their classic Control Panel equivalents when possible. It relies entirely on native Windows components and legacy CLSIDs without requiring any third-party external programs.
+
+### Compatibility & Limitations:
+- **Windows 10:** Highly effective (~70% redirection success rate), as most legacy control panels are fully intact and accessible via standard shell hooks.
+- **Windows 11:** Limited effectiveness (acts as a ~5% baseline restoration). Microsoft has deeply hardcoded or deprecated many legacy CLSIDs, bypassing classic shell activation methods. However, key elements like native network properties (`ncpa.cpl`) and specific dialog mappings still function.
+
+### Key Features:
+- **Smart Desktop Personalization Hook:** Contextual awareness based on `hwnd` detection. Clicking "Personalize" from the desktop right-click menu correctly targets the main classic Personalization window, while clicking "Desktop Background" inside an existing shell folder still brings up the wallpaper page.
+- **CreateProcess Interception:** Intercepts modern overrides on commands like `control system` to dynamically fall back onto legacy System Properties (`sysdm.cpl`).
+
+### Settings (v9.6.0):
+- **EnableRedirects** — Turns the mod on or off completely.
+- **UIOnlyRedirects** — Safer mode: only intercepts clicks from Explorer. Leaves scripts and installers alone.
+- **SmartPersonalizationDetection** — When ON, right-clicking the desktop opens Personalization; clicking "Desktop Background" from inside it opens the wallpaper picker. When OFF, both always open Personalization.
+- **FallbackMode** — What happens when a Settings page has no classic equivalent: do nothing, open Control Panel, or let the original Settings app open.
+- **Win11CompatibilityMode** — On Windows 11, skips legacy shortcuts that no longer work and opens Control Panel instead.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- EnableRedirects: true
+  $name: Enable Redirects (Kill Switch)
+  $description: "Turns the mod on or off. When off, all Settings calls open normally without any redirect."
+- UIOnlyRedirects: false
+  $name: Non-Invasive UI Mode
+  $description: "Only intercepts clicks from Explorer. Safer option if you use scripts, installers, or older apps that might be affected."
+- SmartPersonalizationDetection: true
+  $name: Smart Personalization Detection
+  $description: "When ON, right-clicking the desktop opens Personalization, while clicking Desktop Background from inside it opens the wallpaper picker. When OFF, both always open Personalization."
+- FallbackMode: 1
+  $name: Fallback Mode (unmapped URIs)
+  $description: "What to do when a Settings page has no classic equivalent. Ignore it silently, open Control Panel as a fallback, or let the original Settings app open."
+  $options:
+  - 0: Ignore (silent fail)
+  - 1: Open control.exe
+  - 2: Pass through to ms-settings
+- Win11CompatibilityMode: false
+  $name: Windows 11 Compatibility Mode
+  $description: "On Windows 11, replaces legacy shortcuts that no longer work with a plain Control Panel open instead."
+*/
+// ==/WindhawkModSettings==
+
+#include <windhawk_api.h>
+#include <windows.h>
+#include <shellapi.h>
+#include <string>
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+
+#define SYSTEM_PROPERTIES_FALLBACK L"shell:::{BB06C0E4-D293-4f75-8A90-CB05B6477EEE}"
+#define NOTIF_AREA_CLSID L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"
+
+// ── Settings ─────────────────────────────────────────────────────────────────
+
+struct ModSettings {
+    bool enableRedirects            = true;
+    bool uiOnlyRedirects            = false;
+    bool smartPersonalizationDetect = true;
+    int  fallbackMode               = 1;   // 0=ignore, 1=control.exe, 2=passthrough
+    bool win11CompatibilityMode     = false;
+};
+
+static ModSettings g_settings;
+
+static void LoadSettings() {
+    g_settings.enableRedirects            = Wh_GetIntSetting(L"EnableRedirects")            != 0;
+    g_settings.uiOnlyRedirects            = Wh_GetIntSetting(L"UIOnlyRedirects")            != 0;
+    g_settings.smartPersonalizationDetect = Wh_GetIntSetting(L"SmartPersonalizationDetection") != 0;
+    g_settings.fallbackMode               = (int)Wh_GetIntSetting(L"FallbackMode");
+    g_settings.win11CompatibilityMode     = Wh_GetIntSetting(L"Win11CompatibilityMode")     != 0;
+
+    Wh_Log(L"[SETTINGS] EnableRedirects=%d  UIOnly=%d  SmartPers=%d  Fallback=%d  Win11Compat=%d",
+        (int)g_settings.enableRedirects,
+        (int)g_settings.uiOnlyRedirects,
+        (int)g_settings.smartPersonalizationDetect,
+        g_settings.fallbackMode,
+        (int)g_settings.win11CompatibilityMode);
+}
+
+// ── Win11 detection (cached) ─────────────────────────────────────────────────
+
+static bool g_isWin11 = false;
+
+static void DetectWindowsVersion() {
+    OSVERSIONINFOEXW osvi = {};
+    osvi.dwOSVersionInfoSize = sizeof(osvi);
+    // Use RtlGetVersion to bypass compat shims
+    using RtlGetVersion_t = NTSTATUS(WINAPI*)(OSVERSIONINFOEXW*);
+    HMODULE hNtdll = GetModuleHandleW(L"ntdll.dll");
+    if (hNtdll) {
+        auto fn = (RtlGetVersion_t)GetProcAddress(hNtdll, "RtlGetVersion");
+        if (fn) fn(&osvi);
+    }
+    // Windows 11 is 10.0.22000+
+    g_isWin11 = (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber >= 22000);
+    Wh_Log(L"[VERSION] Build %lu  IsWin11=%d", osvi.dwBuildNumber, (int)g_isWin11);
+}
+
+// CLSIDs considered safe on Win11 (well-tested, not deprecated)
+static const std::unordered_set<std::wstring> g_win11SafeClsids = {
+    L"shell:::{8e908fc9-becc-40f6-915b-f4ca0e70d03d}", // Network and Sharing
+    L"shell:::{7007acc7-3202-11d1-aad2-00805fc1270e}", // Network Connections
+    L"shell:::{a8a91a66-3a7d-4424-8d24-04e180695c7a}", // Devices and Printers
+    L"shell:::{4026492f-2f69-46b8-b9bf-5654fc07e423}", // Windows Firewall
+    L"shell:::{20d04fe0-3aea-1069-a2d8-08002b30309d}", // This PC / Computer
+    L"shell:::{60632754-c523-4b62-b45c-4172da012619}", // User Accounts
+    L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}", // Notification Area Icons
+};
+
+static bool IsClsidSafeOnWin11(const std::wstring& target) {
+    std::wstring lower = target;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::towlower);
+    return g_win11SafeClsids.count(lower) > 0;
+}
+
+// ── Mappings ─────────────────────────────────────────────────────────────────
+
+static std::unordered_map<std::wstring, std::wstring> g_mappings;
+static std::unordered_map<std::wstring, std::wstring> g_controlNameMappings;
+
+static std::wstring ToLower(std::wstring s) {
+    std::transform(s.begin(), s.end(), s.begin(), ::towlower);
+    return s;
+}
+
+static void InitMappings() {
+    const std::wstring kPers = L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}";
+    const std::wstring kWall = kPers + L"\\pageWallpaper";
+
+    g_mappings = {
+        // NOTE: ms-settings:personalization-background is handled specially via hwnd
+        // detection in the hook — it is intentionally absent from this table.
+        {L"shell:::{52205fd8-5dfb-447d-801a-d0b52f2e83e1}", L"explorer.exe shell:UsersLibrariesFolder"},
+        {L"shell:::{bb06c0e4-d293-4f75-8a90-cb05b6477eee}", SYSTEM_PROPERTIES_FALLBACK},
+        {L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}", L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"},
+        {L"explorer.exe", L"explorer.exe"},
+        {L"explorer", L"explorer"},
+        {L"ms-settings:personalization-background-wallpaper", kWall},
+        {L"ms-settings:personalization-background-slideshow", kWall},
+        {L"ms-settings:background", kWall},
+        {L"ms-settings:personalization", kPers},
+        {L"ms-settings:personalization-colors", kPers + L"\\pageColorization"},
+        {L"ms-settings:colors", kPers + L"\\pageColorization"},
+        {L"ms-settings:themes", kPers},
+        {L"ms-settings:lockscreen", kPers},
+        {L"ms-settings:regionlanguage", L"intl.cpl"},
+        {L"ms-settings:regionformatting", L"intl.cpl"},
+        {L"ms-settings:language", L"intl.cpl"},
+        {L"ms-settings:typing", L"main.cpl,,1"},
+        {L"ms-settings:system", SYSTEM_PROPERTIES_FALLBACK},
+        {L"ms-settings:about", SYSTEM_PROPERTIES_FALLBACK},
+        {L"ms-settings:sysinfo", SYSTEM_PROPERTIES_FALLBACK},
+        {L"ms-settings:display", L"desk.cpl"},
+        {L"ms-settings:display-advanced", L"desk.cpl"},
+        {L"ms-settings:notifications", NOTIF_AREA_CLSID},
+        {L"ms-settings:backup", L"shell:::{B98A2BEA-7D42-4558-8BD1-832F41BAC6FD}"},
+        {L"ms-settings:optionalfeatures", L"OptionalFeatures.exe"},
+        {L"ms-settings:devicemanager", L"devmgmt.msc"},
+        {L"ms-settings:display-advanced-color", L"colorcpl.exe"},
+        {L"ms-settings:colorcpl", L"colorcpl.exe"},
+        {L"ms-settings:sound", L"mmsys.cpl"},
+        {L"ms-settings:network", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-wifi", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-ethernet", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-vpn", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-proxy", L"inetcpl.cpl,,4"},
+        {L"ms-settings:network-status", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
+        {L"ms-settings:datausage", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:yourinfo", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:emailandaccounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:signinoptions", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:otherusers", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:workplace", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:family", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:dateandtime", L"timedate.cpl"},
+        {L"ms-settings:easeofaccess", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-highcontrast", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-closedcaptioning", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:printers", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:printers-scanners", L"shell:::{2227A280-3AEA-1069-A2DE-08002B30309D}"},
+        {L"ms-settings:mousetouchpad", L"main.cpl"},
+        {L"ms-settings:devices-touchpad", L"main.cpl"},
+        {L"ms-settings:keyboard", L"main.cpl"},
+        {L"ms-settings:bluetooth", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:usb", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:autoplay", L"shell:::{9C60DE1E-E5FC-40f4-A487-460851A8D915}"},
+        {L"ms-settings:powersleep", L"powercfg.cpl"},
+        {L"ms-settings:pen", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:appsfeatures", L"appwiz.cpl"},
+        {L"ms-settings:defaultapps", L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
+        {L"ms-settings:firewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
+        {L"ms-settings:network-firewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
+        {L"ms-settings:home", L"shell:::{59031a47-3f72-44a7-89c5-5595fe6b30ee}"},
+        {L"ms-settings:yourinfo-profile", L"shell:::{59031a47-3f72-44a7-89c5-5595fe6b30ee}"},
+        {L"ms-settings:storagesense", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:storagepolicies", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:disksandvolumes", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:computerManagement", L"compmgmt.msc"},
+        {L"ms-settings:taskbar", NOTIF_AREA_CLSID},
+        {L"ms-settings:taskbar-notifications", NOTIF_AREA_CLSID},
+        {L"ms-settings:notifications-systemtray", NOTIF_AREA_CLSID},
+        {L"ms-settings:systemtray", NOTIF_AREA_CLSID},
+        {L"ms-settings:taskbar-systemtray", NOTIF_AREA_CLSID},
+        {L"ms-settings:notificationiconpreferences", NOTIF_AREA_CLSID},
+        {L"explorer shell:::{ed834ed6-4b5a-4bfe-8f11-a626dcb6a921}", L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"},
+        {L"shell:::{f20df4e5-ea01-41a2-b02a-dcbd92d4696e}", L"__display__"},
+        {L"shell:::{20d04fe0-3aea-1069-a2d8-08002b30309d}", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\0\\::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}", L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\0\\::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"},
+        {L"ms-settings:easeofaccess-narrator", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-magnifier", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-cursor", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-keyboard", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-mouse", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-eyecontrol", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-colorfilter", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-audio", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-speechrecognition", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:audio", L"mmsys.cpl"},
+        {L"ms-settings:system-advanced", SYSTEM_PROPERTIES_FALLBACK},
+        {L"ms-settings:system-remotedesktop", L"sysdm.cpl,,5"},
+        {L"ms-settings:system-about", SYSTEM_PROPERTIES_FALLBACK},
+        {L"ms-settings:system-protection", L"sysdm.cpl,,4"},
+        {L"ms-settings:system-devicemanager", L"devmgmt.msc"},
+        {L"ms-settings:privacy", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:privacy-webcam", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:privacy-microphone", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:privacy-location", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:accounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:accounts-signinoptions", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:accounts-otherusers", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:gaming", L"control.exe"},
+        {L"ms-settings:gaming-gamebar", L"control.exe"},
+        {L"ms-settings:gaming-gamemode", L"control.exe"},
+        {L"ms-settings:gaming-gameDVR", L"control.exe"},
+        {L"ms-settings:gaming-broadcasting", L"control.exe"},
+        {L"ms-settings:appsforwebsites", L"appwiz.cpl"},
+        {L"ms-settings:startupapps", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:videoplayback", L"control.exe"},
+        {L"ms-settings:defaultapps-maps", L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
+        {L"ms-settings:cortana", L"control.exe"},
+        {L"ms-settings:search", L"control.exe"},
+        {L"ms-settings:cortana-permissions", L"control.exe"},
+        {L"ms-settings:dateandtime-region", L"timedate.cpl"},
+        {L"ms-settings:dateandtime-addclocks", L"timedate.cpl,,1"},
+        {L"ms-settings:speech", L"control.exe"},
+        {L"ms-settings:phone", L"control.exe"},
+        {L"ms-settings:phone-defaultapps", L"control.exe"},
+        {L"ms-settings:multitasking", L"control.exe"},
+        {L"ms-settings:multitasking-snap", L"control.exe"},
+        {L"ms-settings:project", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:pen-windowsink", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:pen-windowsinksettings", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:network-airplanemode", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-mobilehotspot", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-dialup", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
+        {L"ms-settings:network-advancedsettings", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
+        {L"ms-settings:battery", L"powercfg.cpl"},
+        {L"ms-settings:batterysaver", L"powercfg.cpl"},
+        {L"ms-settings:batterysaver-settings", L"powercfg.cpl"},
+        {L"ms-settings:batterysaver-usagedetails", L"powercfg.cpl"},
+        {L"ms-settings:storagepolicies-other", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:recovery", L"control.exe"},
+        {L"ms-settings:recovery-reset", L"control.exe"},
+        {L"ms-settings:tabletmode", L"control.exe"},
+        {L"ms-settings:connecteddevices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:signinoptions-face", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:signinoptions-fingerprint", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:signinoptions-dynamiclock", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:easeofaccess-cursorandpointersize", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-visualeffects", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:easeofaccess-display", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:nearbysharing", L"control.exe"},
+        {L"ms-settings:crossdevice", L"control.exe"},
+        {L"ms-settings:clipboard", L"control.exe"},
+        {L"ms-settings:messaging", L"control.exe"},
+        {L"ms-settings:remotedesktop", L"sysdm.cpl,,5"},
+        {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\1\\::{0df44eaa-ff21-4412-828e-260a8728e7f1}", L"wscui.cpl"},
+        {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\2\\::{025a5937-a6be-4686-a844-36fe4bec8b6d}", L"powercfg.cpl"},
+        {L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}\\3\\::{c555438b-3c23-4769-a71f-b6d3d9b6053a}", L"__display__"},
+        {L"shell:microsoft.actioncenter", L"wscui.cpl"},
+        {L"ms-settings:recovery", L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
+        {L"ms-settings:troubleshoot", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
+        {L"ms-settings:activation", L"slui.exe"},
+        {L"ms-settings:savelocations", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:quiethours", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
+        {L"ms-settings:quietmomentsscheduled", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
+        {L"ms-settings:quietmomentspresentation", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
+        {L"ms-settings:quietmomentsgame", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
+        {L"ms-settings:sound-devices", L"mmsys.cpl"},
+        {L"ms-settings:apps-volume", L"sndvol.exe"},
+        {L"ms-settings:personalization-start", L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"},
+        {L"ms-settings:personalization-start-places", L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"},
+        {L"ms-settings:personalization-touchkeyboard", L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"},
+        {L"ms-settings:deviceusage", L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"},
+        {L"ms-settings:fonts", L"shell:::{BD84B380-8CA2-1069-AB1D-08000948F534}"},
+        {L"ms-settings:nightlight", L"desk.cpl"},
+        {L"ms-settings:display-advancedgraphics", L"desk.cpl"},
+        {L"ms-settings:easeofaccess-mousepointer", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"ms-settings:network-cellular", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:privacy-speech", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
+        {L"ms-settings:privacy-feedback", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
+        {L"ms-settings:privacy-activityhistory", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
+        {L"ms-settings:privacy-accountinfo", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:privacy-contacts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:privacy-calendar", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:privacy-phonecalls", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:privacy-callhistory", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:privacy-email", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:privacy-tasks", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:privacy-messaging", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:privacy-notifications", L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"},
+        {L"ms-settings:privacy-voiceactivation", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
+        {L"ms-settings:privacy-radios", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:privacy-customdevices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:privacy-appdiagnostics", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
+        {L"ms-settings:privacy-automaticfiledownloads", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:privacy-documents", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:privacy-downloadsfolder", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:privacy-musiclibrary", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:privacy-pictures", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:privacy-broadfilesystemaccess", L"shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}"},
+        {L"ms-settings:privacy-speechtyping", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
+        {L"ms-settings:search-permissions", L"shell:::{04731B67-D933-450a-90E6-4ACD2E9408FE}"},
+        {L"ms-settings:cortana-windowssearch", L"shell:::{04731B67-D933-450a-90E6-4ACD2E9408FE}"},
+        {L"ms-settings:windowsdefender", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
+        {L"ms-settings:findmydevice", L"shell:::{F942C606-0914-47AB-BE56-1321B8035096}"},
+        {L"ms-settings:deviceencryption", L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
+        {L"ms-settings:developers", L"control.exe"},
+        {L"ms-settings:windowsinsider", L"control.exe"},
+        {L"ms-settings:privacy-feedback-telemetryviewergroup", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
+        {L"ms-settings:signinoptions-launchfaceenrollment", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:signinoptions-launchfingerprintenrollment", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:signinoptions-launchsecuritykeyenrollment", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:camera", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:devices-touch", L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:mobile-devices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"shell:::{1206f5f1-0569-412c-8fec-3204630dfb70}", L"shell:::{1206F5F1-0569-412C-8FEC-3204630DFB70}"},
+        {L"shell:::{d9ef8727-cac2-4e60-809e-86f80a666c91}", L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
+        {L"shell:::{9fe63afd-59cf-4419-9775-abcc3849f861}", L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
+        {L"shell:::{c58c4893-3be0-4b45-abb5-a63e4b8c8651}", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
+        {L"shell:::{f942c606-0914-47ab-be56-1321b8035096}", L"shell:::{F942C606-0914-47AB-BE56-1321B8035096}"},
+        {L"shell:::{241d7c96-f8bf-4f85-b01f-e2b043341a4b}", L"shell:::{241D7C96-F8BF-4F85-B01F-E2B043341A4B}"},
+        {L"shell:::{bd7a2e7b-21cb-41b2-a086-b309680c6b7e}", L"shell:::{BD7A2E7B-21CB-41b2-A086-B309680C6B7E}"},
+        {L"shell:::{d20ea4e1-3957-11d2-a40b-0c5020524153}", L"shell:::{D20EA4E1-3957-11d2-A40B-0C5020524153}"},
+        {L"shell:::{bb64f8a7-bee7-4e1a-ab8d-7d8273f7fdb6}", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}"},
+        {L"shell:::{58e3c745-d971-4081-9034-86e34b30836a}", L"shell:::{58E3C745-D971-4081-9034-86E34B30836A}"},
+        {L"shell:::{04731b67-d933-450a-90e6-4acd2e9408fe}", L"shell:::{04731B67-D933-450a-90E6-4ACD2E9408FE}"}
+    };
+
+    // control.exe /name mappings
+    g_controlNameMappings = {
+        {L"microsoft.personalization", kPers},
+        {L"microsoft.personalization/page pagewallpaper", kWall},
+        {L"microsoft.color", kPers + L"\\pageColorization"},
+        {L"microsoft.sound", L"mmsys.cpl"},
+        {L"microsoft.system", SYSTEM_PROPERTIES_FALLBACK},
+        {L"microsoft.programsandfeatures", L"appwiz.cpl"},
+        {L"microsoft.devicesandprinters", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"microsoft.networkandsharingcenter", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"microsoft.windowsfirewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
+        {L"microsoft.poweroptions", L"powercfg.cpl"},
+        {L"microsoft.mouse", L"main.cpl"},
+        {L"microsoft.keyboard", L"main.cpl,,1"},
+        {L"microsoft.useraccounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"microsoft.easeofaccesscenter", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
+        {L"microsoft.dateandtime", L"timedate.cpl"},
+        {L"microsoft.region", L"intl.cpl"},
+        {L"microsoft.defaultprograms", L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
+        {L"microsoft.notificationareaicons", NOTIF_AREA_CLSID}
+    };
+}
+
+// ── URI utilities ─────────────────────────────────────────────────────────────
+
+static std::wstring NormalizeUri(const std::wstring& uri) {
+    std::wstring result = ToLower(uri);
+
+    size_t pos = result.find(L"ms-settings://");
+    if (pos != std::wstring::npos)
+        result = L"ms-settings:" + result.substr(pos + 15);
+
+    pos = result.find(L'?');
+    if (pos != std::wstring::npos)
+        result = result.substr(0, pos);
+
+    while (!result.empty() && result.back() == L'/')
+        result.pop_back();
+
+    return result;
+}
+
+static bool IsMsSettings(const wchar_t* s) {
+    if (!s) return false;
+    return ToLower(s).find(L"ms-settings:") != std::wstring::npos;
+}
+
+static bool IsShellClsid(const wchar_t* s) {
+    if (!s) return false;
+    return ToLower(s).find(L"shell:::") != std::wstring::npos;
+}
+
+// ── Win11 compat filter ───────────────────────────────────────────────────────
+
+// Applies Win11CompatibilityMode: if the resolved target is a shell CLSID that is
+// not in the known-safe list, substitute control.exe.
+static std::wstring ApplyWin11Compat(const std::wstring& target) {
+    if (!g_settings.win11CompatibilityMode || !g_isWin11) return target;
+
+    // Only shell CLSID targets are at risk of being broken on Win11.
+    // Executable targets (.exe, .cpl, .msc) are left as-is.
+    std::wstring lower = ToLower(target);
+    if (lower.find(L"shell:::") == 0) {
+        if (!IsClsidSafeOnWin11(lower)) {
+            Wh_Log(L"[WIN11-COMPAT] Replacing unsafe CLSID '%s' with control.exe", target.c_str());
+            return L"control.exe";
+        }
+    }
+    return target;
+}
+
+// ── Fallback handling ─────────────────────────────────────────────────────────
+
+// Returns false if the caller should fall through to the original function (passthrough mode).
+// Returns true if the caller should return early (ignore or control.exe modes were handled).
+static bool HandleFallback(const std::wstring& uri) {
+    switch (g_settings.fallbackMode) {
+        case 0: // ignore
+            Wh_Log(L"[FALLBACK] Ignoring unmapped URI: %s", uri.c_str());
+            return true;
+        case 1: // control.exe
+            Wh_Log(L"[FALLBACK] Opening control.exe for unmapped URI: %s", uri.c_str());
+            // LaunchTarget is defined below; we call it inline here via a forward path.
+            // We use CreateProcessW directly to avoid circular call with LaunchTarget.
+            {
+                std::wstring cmd = L"control.exe";
+                STARTUPINFOW si = {}; si.cb = sizeof(si);
+                si.dwFlags = STARTF_USESHOWWINDOW; si.wShowWindow = SW_SHOWNORMAL;
+                PROCESS_INFORMATION pi = {};
+                CreateProcessW(nullptr, cmd.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi);
+                if (pi.hProcess) CloseHandle(pi.hProcess);
+                if (pi.hThread)  CloseHandle(pi.hThread);
+            }
+            return true;
+        case 2: // passthrough
+        default:
+            Wh_Log(L"[FALLBACK] Passing through unmapped URI to original: %s", uri.c_str());
+            return false;
+    }
+}
+
+// ── LaunchTarget ──────────────────────────────────────────────────────────────
+
+static void LaunchTarget(const std::wstring& command) {
+    Wh_Log(L"[EXEC] %s", command.c_str());
+
+    STARTUPINFOW si = {};
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESHOWWINDOW;
+    si.wShowWindow = SW_SHOWNORMAL;
+    PROCESS_INFORMATION pi = {};
+
+    std::wstring cmdLine;
+    if (command.find(L".exe") != std::wstring::npos || command.find(L".msc") != std::wstring::npos) {
+        cmdLine = command;
+    } else if (command.find(L"shell:::") == 0) {
+        cmdLine = L"explorer.exe " + command;
+    } else if (command.empty()) {
+        cmdLine = L"control.exe";
+    } else {
+        cmdLine = L"control.exe " + command;
+    }
+
+    std::wstring mutableCmd = cmdLine;
+    if (CreateProcessW(nullptr, mutableCmd.data(), nullptr, nullptr, FALSE,
+                       0, nullptr, nullptr, &si, &pi)) {
+        if (pi.hProcess) CloseHandle(pi.hProcess);
+        if (pi.hThread)  CloseHandle(pi.hThread);
+    } else {
+        Wh_Log(L"[ERROR] CreateProcess failed for: %s (error: %lu)", cmdLine.c_str(), GetLastError());
+    }
+}
+
+// ── Personalization hwnd detection ───────────────────────────────────────────
+
+static bool IsPersonalizationWindow(HWND hwnd) {
+    if (!hwnd) {
+        Wh_Log(L"[HWND] hwnd is NULL -> context menu, not Personalization window");
+        return false;
+    }
+
+    HWND h = hwnd;
+    while (h) {
+        wchar_t cls[256]   = {};
+        wchar_t title[512] = {};
+        GetClassNameW(h, cls, 256);
+        GetWindowTextW(h, title, 512);
+
+        Wh_Log(L"[HWND] %p  class='%s'  title='%s'", h, cls, title);
+
+        std::wstring c = ToLower(cls);
+        std::wstring t = ToLower(title);
+
+        if (c == L"progman" || c == L"workerw" || c == L"shelldll_defview") {
+            Wh_Log(L"[HWND] Desktop window class -> context menu");
+            return false;
+        }
+
+        if (c == L"cabinetwclass") {
+            Wh_Log(L"[HWND] CabinetWClass with title='%s' -> Personalization window", title);
+            return true;
+        }
+
+        if (t.find(L"personaliz") != std::wstring::npos) {
+            Wh_Log(L"[HWND] Title match -> Personalization window: %s", title);
+            return true;
+        }
+
+        HWND parent = GetParent(h);
+        if (!parent || parent == h) break;
+        h = parent;
+    }
+
+    Wh_Log(L"[HWND] No Personalization window found in chain -> context menu");
+    return false;
+}
+
+static std::wstring ResolvePersonalizationBackground(HWND hwnd) {
+    const std::wstring kPers = L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}";
+    const std::wstring kWall = kPers + L"\\pageWallpaper";
+
+    // If SmartPersonalizationDetection is OFF, always go to the root.
+    if (!g_settings.smartPersonalizationDetect) {
+        Wh_Log(L"[RESOLVE] SmartPersonalizationDetection=OFF -> Personalization root");
+        return kPers;
+    }
+
+    if (IsPersonalizationWindow(hwnd)) {
+        Wh_Log(L"[RESOLVE] personalization-background -> wallpaper (called from inside Personalization)");
+        return kWall;
+    } else {
+        Wh_Log(L"[RESOLVE] personalization-background -> Personalization (called from context menu)");
+        return kPers;
+    }
+}
+
+// ── Shared hook logic ─────────────────────────────────────────────────────────
+// Returns {resolved_target, should_intercept}.
+// should_intercept=false means the caller must fall through to the original.
+
+struct ResolveResult {
+    std::wstring target;
+    bool         intercept;
+};
+
+static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
+    if (uri == L"ms-settings:personalization-background") {
+        std::wstring t = ResolvePersonalizationBackground(hwnd);
+        t = ApplyWin11Compat(t);
+        return {t, true};
+    }
+
+    auto it = g_mappings.find(uri);
+    if (it != g_mappings.end()) {
+        std::wstring t = ApplyWin11Compat(it->second);
+        Wh_Log(L"[MAP] %s -> %s", uri.c_str(), t.c_str());
+        return {t, true};
+    }
+
+    // Not in map: apply fallback policy.
+    bool handled = HandleFallback(uri);
+    // handled=true  → ignore or control.exe already launched, intercept=true so caller exits.
+    // handled=false → passthrough requested, intercept=false so caller calls original.
+    return {L"", handled};
+}
+
+// ── Hook: ShellExecuteExW ─────────────────────────────────────────────────────
+
+using ShellExecuteExW_t = BOOL(WINAPI*)(SHELLEXECUTEINFOW*);
+ShellExecuteExW_t ShellExecuteExW_orig;
+
+BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
+    if (!g_settings.enableRedirects) return ShellExecuteExW_orig(pei);
+
+    if (pei) {
+        Wh_Log(L"[DEBUG] hwnd=%p  lpFile=%s  lpParameters=%s",
+               pei->hwnd,
+               pei->lpFile       ? pei->lpFile       : L"(null)",
+               pei->lpParameters ? pei->lpParameters : L"(null)");
+
+        const wchar_t* file   = pei->lpFile;
+        const wchar_t* params = pei->lpParameters;
+        std::wstring uri;
+
+        if (IsMsSettings(file) || IsMsSettings(params)) {
+            const wchar_t* raw = IsMsSettings(file) ? file : params;
+            uri = NormalizeUri(raw);
+        } else if (IsShellClsid(file) || IsShellClsid(params)) {
+            const wchar_t* raw = IsShellClsid(file) ? file : params;
+            uri = ToLower(raw);
+        }
+
+        if (!uri.empty()) {
+            Wh_Log(L"[HOOK] %s", uri.c_str());
+            auto result = ResolveUri(uri, pei->hwnd);
+
+            if (result.intercept) {
+                if (!result.target.empty()) LaunchTarget(result.target);
+                if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
+                return TRUE;
+            }
+            // fallthrough for passthrough mode
+        }
+    }
+    return ShellExecuteExW_orig(pei);
+}
+
+// ── Hook: ShellExecuteW ───────────────────────────────────────────────────────
+
+using ShellExecuteW_t = HINSTANCE(WINAPI*)(HWND, LPCWSTR, LPCWSTR, LPCWSTR, LPCWSTR, INT);
+ShellExecuteW_t ShellExecuteW_orig;
+
+HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
+                                     LPCWSTR params, LPCWSTR dir, INT show) {
+    if (!g_settings.enableRedirects) return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
+
+    Wh_Log(L"[DEBUG-W] hwnd=%p  file=%s  params=%s",
+           hwnd,
+           file   ? file   : L"(null)",
+           params ? params : L"(null)");
+
+    std::wstring uri;
+
+    if (IsMsSettings(file) || IsMsSettings(params)) {
+        const wchar_t* raw = IsMsSettings(file) ? file : params;
+        uri = NormalizeUri(raw);
+    } else if (IsShellClsid(file) || IsShellClsid(params)) {
+        const wchar_t* raw = IsShellClsid(file) ? file : params;
+        uri = ToLower(raw);
+    }
+
+    if (!uri.empty()) {
+        Wh_Log(L"[HOOK-W] %s", uri.c_str());
+        auto result = ResolveUri(uri, hwnd);
+
+        if (result.intercept) {
+            if (!result.target.empty()) LaunchTarget(result.target);
+            return (HINSTANCE)42;
+        }
+        // fallthrough for passthrough mode
+    }
+    return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
+}
+
+// ── Hook: CreateProcessW ──────────────────────────────────────────────────────
+
+using CreateProcessW_t = BOOL(WINAPI*)(
+    LPCWSTR, LPWSTR, LPSECURITY_ATTRIBUTES, LPSECURITY_ATTRIBUTES,
+    BOOL, DWORD, LPVOID, LPCWSTR, LPSTARTUPINFOW, LPPROCESS_INFORMATION
+);
+CreateProcessW_t CreateProcessW_orig = nullptr;
+
+BOOL WINAPI CreateProcessW_hook(
+    LPCWSTR lpApplicationName,
+    LPWSTR lpCommandLine,
+    LPSECURITY_ATTRIBUTES lpProcessAttributes,
+    LPSECURITY_ATTRIBUTES lpThreadAttributes,
+    BOOL bInheritHandles,
+    DWORD dwCreationFlags,
+    LPVOID lpEnvironment,
+    LPCWSTR lpCurrentDirectory,
+    LPSTARTUPINFOW lpStartupInfo,
+    LPPROCESS_INFORMATION lpProcessInformation)
+{
+    // Respect global kill switch and UI-only mode.
+    if (!g_settings.enableRedirects || g_settings.uiOnlyRedirects) {
+        return CreateProcessW_orig(
+            lpApplicationName, lpCommandLine,
+            lpProcessAttributes, lpThreadAttributes,
+            bInheritHandles, dwCreationFlags,
+            lpEnvironment, lpCurrentDirectory,
+            lpStartupInfo, lpProcessInformation);
+    }
+
+    std::wstring cmdLine = lpCommandLine ? ToLower(std::wstring(lpCommandLine)) : L"";
+    
+    if (cmdLine.find(L"control") != std::wstring::npos && 
+        cmdLine.find(L"system") != std::wstring::npos &&
+        cmdLine.find(L"mmsys.cpl") == std::wstring::npos &&
+        cmdLine.find(L"timedate.cpl") == std::wstring::npos &&
+        cmdLine.find(L"main.cpl") == std::wstring::npos &&
+        cmdLine.find(L"ncpa.cpl") == std::wstring::npos &&
+        cmdLine.find(L"inetcpl.cpl") == std::wstring::npos &&
+        cmdLine.find(L"desk.cpl") == std::wstring::npos &&
+        cmdLine.find(L"telephon.cpl") == std::wstring::npos &&
+        cmdLine.find(L"control.exe srchadmin.dll") == std::wstring::npos &&
+        cmdLine.find(L"intl.cpl") == std::wstring::npos &&
+        cmdLine.find(L"mmsys.cpl") == std::wstring::npos &&
+        cmdLine.find(L"microsoft.sound") == std::wstring::npos &&
+        cmdLine.find(L"sndvol") == std::wstring::npos) {
+
+        Wh_Log(L"[HOOK-CPW] Intercepted control system command: %s", lpCommandLine);
+        LaunchTarget(L"shell:::{BB06C0E4-D293-4f75-8A90-CB05B6477EEE}");
+        SetLastError(ERROR_SUCCESS);
+        return TRUE;
+    }
+    
+    return CreateProcessW_orig(
+        lpApplicationName, lpCommandLine,
+        lpProcessAttributes, lpThreadAttributes,
+        bInheritHandles, dwCreationFlags,
+        lpEnvironment, lpCurrentDirectory,
+        lpStartupInfo, lpProcessInformation
+    );
+}
+
+// ── Windhawk Entry Points ─────────────────────────────────────────────────────
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"[v9.6.0] Redirect Settings to Control Panel - Initializing...");
+
+    DetectWindowsVersion();
+    LoadSettings();
+    InitMappings();
+    Wh_Log(L"[v9.6.0] %zu URI mappings loaded", g_mappings.size());
+
+    HMODULE hShell32 = GetModuleHandleW(L"shell32.dll");
+    if (!hShell32) hShell32 = LoadLibraryW(L"shell32.dll");
+    if (!hShell32) {
+        Wh_Log(L"[v9.6.0] ERROR: Could not load shell32.dll");
+        return FALSE;
+    }
+
+    auto pExW = (void*)GetProcAddress(hShell32, "ShellExecuteExW");
+    auto pW   = (void*)GetProcAddress(hShell32, "ShellExecuteW");
+
+    if (!pExW || !pW) {
+        Wh_Log(L"[v9.6.0] ERROR: Required functions not found in shell32.dll");
+        return FALSE;
+    }
+
+    bool ok1 = Wh_SetFunctionHook(pExW, (void*)ShellExecuteExW_hook, (void**)&ShellExecuteExW_orig);
+    bool ok2 = Wh_SetFunctionHook(pW,   (void*)ShellExecuteW_hook,   (void**)&ShellExecuteW_orig);
+
+    Wh_Log(L"[v9.6.0] Hook results: ShellExecuteExW=%d  ShellExecuteW=%d", ok1, ok2);
+
+    // CreateProcessW hook: only install if UIOnlyRedirects is OFF.
+    // We always install but the hook itself checks g_settings.uiOnlyRedirects at runtime,
+    // which allows settings changes without a full reinit.
+    HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
+    if (!hKernel32) hKernel32 = LoadLibraryW(L"kernel32.dll");
+    if (hKernel32) {
+        auto pCPW = (void*)GetProcAddress(hKernel32, "CreateProcessW");
+        if (pCPW) {
+            bool ok3 = Wh_SetFunctionHook(pCPW, (void*)CreateProcessW_hook, (void**)&CreateProcessW_orig);
+            Wh_Log(L"[v9.6.0] CreateProcessW hook: %d", ok3);
+        }
+    }
+
+    if (!ok1 && !ok2) {
+        Wh_Log(L"[v9.6.0] ERROR: Failed to install any hooks");
+        return FALSE;
+    }
+
+    Wh_Log(L"[v9.6.0] Ready! (EnableRedirects=%d, UIOnly=%d, SmartPers=%d, Fallback=%d, Win11Compat=%d)",
+        (int)g_settings.enableRedirects,
+        (int)g_settings.uiOnlyRedirects,
+        (int)g_settings.smartPersonalizationDetect,
+        g_settings.fallbackMode,
+        (int)g_settings.win11CompatibilityMode);
+    return TRUE;
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"[v9.6.0] Unloaded.");
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L"[v9.6.0] Settings changed, reloading...");
+    LoadSettings();
+}

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -2,94 +2,18 @@
 // @id             settings-to-control-panel
 // @name           Redirect Settings to Control Panel
 // @description    Forces classic Control Panel to open instead of Windows 10/11 Settings app using native components. Primarily designed for Windows 10; Windows 11 support is limited due to Microsoft's shell architecture changes.
-// @version        9.8.8
+// @version        9.9.6
 // @author         babamohammed
 // @github         https://github.com/babamohammed2022
 // @include        explorer.exe
+// @include        SystemSettings.exe
+// @include        StartMenuExperienceHost.exe
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
-# Redirect Settings → Control Panel (v9.8.8)
+# Redirect Settings → Control Panel (v9.9.6)
 
-This Windhawk mod intercepts modern `ms-settings:` URIs and redirects them to
-their corresponding classic Control Panel applets, relying exclusively on native
-Windows components (no external binaries or dependencies).
-
----
-
-## Important: Windows 10 vs Windows 11
-
-**This mod is primarily designed for Windows 10**, where the classic Control Panel
-infrastructure is fully intact and most user interactions go through `explorer.exe`.
-
-**On Windows 11**, Microsoft rewrote the shell using XAML/UWP technology. The
-modern taskbar and some UI elements use COM activation that bypasses standard
-ShellExecute hooks. This means:
-
-- **Windows 10**: Full support — all redirects work as expected ✅
-- **Windows 11**: Partial support — most redirects work, but some specific cases
-  (like clicking "Ease of Access" or "Display" links inside the classic
-  Personalization window) may not be interceptable via API hooks alone.
-  A WinEventHook workaround attempts to catch and redirect these cases.
-
-### Known Windows 11 Limitations
-- **Desktop right-click → Personalize**: May open modern Settings on some builds
-- **Ease of Access / Display links inside Personalization window**: Uses internal
-  COM/XAML activation that cannot be hooked directly. The mod uses a WinEventHook
-  to detect and close the modern window, then launch the classic panel.
-  Effectiveness may vary by build.
-- **Start Menu search results**: Not intercepted (to avoid breaking search)
-- **System tray icon clicks**: Use DCOM activation, cannot be hooked
-
-**In short**: On Windows 10 this mod works fully. On Windows 11 it works in most
-cases but some edge cases depend on your specific build and configuration.
-
-Credits to Anixx and m417z for the reviews and testing to enhance the mod.
-
----
-
-## What This Mod Does (and Doesn't Do)
-
-### ✅ Redirected (both Windows 10 and 11)
-- Control Panel navigation (System, Network, Sound, Accounts, Devices, etc.)
-- `Win+R` → `ms-settings:*` commands
-- `explorer shell:::*` protocol
-- Classic Personalization CPL — Colors and Background sub-pages
-- Right-click "This PC" → Properties
-- Troubleshooting → MSDT on Win11 (`msdt.exe`)
-- Display settings → `desk.cpl`
-- Ease of Access → `access.cpl`
-
-### 🟡 Partially Redirected (works on Win10, Win11 depends on build)
-- Desktop right-click → Personalize
-- Ease of Access / Display links from inside Personalization window
-
-### 🔴 Not Redirected (architectural limitation)
-- Modern Windows 11 taskbar tray (uses DCOM activation)
-- Start Menu search results (excluded to avoid breaking search)
-- Internal Settings app navigation
-
----
-
-## Features
-
-- Over 90 URI-to-applet mappings
-- Smart Personalization detection (desktop vs in-window navigation)
-- WinEventHook workaround for Windows 11 modern windows
-- Safe fallback handling for unmapped settings
-- Anti-loop protection (cross-process, in-process, bounce-back detection)
-- No external dependencies — uses only native Windows APIs
-
----
-
-## Configuration Options
-
-- **EnableRedirects**: Master switch
-- **UIOnlyRedirects**: Only intercept ShellExecute* calls
-- **SmartPersonalizationDetection**: Desktop right-click vs in-window navigation
-- **FallbackMode**: Behavior when no classic equivalent exists (0=Ignore, 1=Control Panel root, 2=Pass through)
-- **Win11CompatibilityMode**: Additional Win11 safeguards for unverified CLSIDs
-- **MaxLaunchesPerUri**: Anti-loop safety valve (max launches per URI in 5 seconds)
+Debug version - logging all ShellExecuteW calls to diagnose audio tray issues.
 */
 // ==/WindhawkModReadme==
 // ==WindhawkModSettings==
@@ -109,7 +33,7 @@ Credits to Anixx and m417z for the reviews and testing to enhance the mod.
   $options:
   - "0": Ignore (silent fail)
   - "1": Open the Control Panel (control.exe)
-  - "2": Pass through to the modern Settings application (ms-settings.exe)
+  - "2": Pass through to the modern Settings application (ms-settings.exe)"
 - Win11CompatibilityMode: false
   $name: Windows 11 Compatibility Mode
   $description: "On Windows 11, also replaces CLSIDs not confirmed safe (beyond the always-blocked known-loop CLSIDs)."
@@ -121,33 +45,42 @@ Credits to Anixx and m417z for the reviews and testing to enhance the mod.
 
 #include <windhawk_api.h>
 #include <windows.h>
-#include <shellapi.h>
+#include <objbase.h>
 #include <string>
 #include <algorithm>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 #include <mutex>
+#include <shobjidl.h>     
+#include <initguid.h>  
 
-// ── Constants ─────────────────────────────────────────────────────────────────
+// Dynamic COM handling - no linking required
+typedef HRESULT (WINAPI *CoCreateInstance_t)(const GUID* rclsid, IUnknown* pUnkOuter, DWORD dwClsContext, const GUID* riid, void** ppv);
+static CoCreateInstance_t dyn_CoCreateInstance = nullptr;
+static HMODULE g_hOle32 = nullptr;
 
+// IShellDispatch2 vtable hook
+using IShellDispatch2_ShellExecute_t = HRESULT(WINAPI*)(void* pThis, BSTR File, void* vArgs, void* vDir, void* vOperation, void* vShow);
+static IShellDispatch2_ShellExecute_t IShellDispatch2_ShellExecute_orig = nullptr;
+
+// CLSID_Shell / IID_IShellDispatch2
+static const GUID CLSID_Shell_ = {0x13709620,0xC279,0x11CE,{0xA4,0x9E,0x44,0x45,0x53,0x54,0x00,0x00}};
+static const GUID IID_IShellDispatch2_ = {0xA4C6892C,0x3BA9,0x11D2,{0x9D,0xEA,0x00,0xC0,0x4F,0xB9,0x60,0x3F}};
+
+// Constants
 static const HINSTANCE SHELL_EXECUTE_SUCCESS = (HINSTANCE)33;
 
 #define SYSTEM_PROPS_CLSID  L"shell:::{BB06C0E4-D293-4f75-8A90-CB05B6477EEE}"
 #define NOTIF_AREA_CLSID    L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"
-
-#define PERS_ED_CLSID   L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"
 #define PERS_ROOT       L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"
 #define PERS_WALLPAPER  L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921} -Microsoft.Personalization\\pageWallpaper"
 #define PERS_COLORS     L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921} -Microsoft.Personalization\\pageColorization"
-
 #define WIN11_PASSTHROUGH L"__PASSTHROUGH__"
+#define EASE_OF_ACCESS  L"control.exe /name Microsoft.EaseOfAccessCenter"
 
-// ── Forward declarations ──────────────────────────────────────────────────────
-
-using CreateProcessW_t = BOOL(WINAPI*)(
-    LPCWSTR, LPWSTR, LPSECURITY_ATTRIBUTES, LPSECURITY_ATTRIBUTES,
-    BOOL, DWORD, LPVOID, LPCWSTR, LPSTARTUPINFOW, LPPROCESS_INFORMATION);
+// Forward declarations
+using CreateProcessW_t = BOOL(WINAPI*)(LPCWSTR, LPWSTR, LPSECURITY_ATTRIBUTES, LPSECURITY_ATTRIBUTES, BOOL, DWORD, LPVOID, LPCWSTR, LPSTARTUPINFOW, LPPROCESS_INFORMATION);
 static CreateProcessW_t CreateProcessW_orig = nullptr;
 
 using ShellExecuteW_t = HINSTANCE(WINAPI*)(HWND, LPCWSTR, LPCWSTR, LPCWSTR, LPCWSTR, INT);
@@ -155,18 +88,16 @@ using ShellExecuteExW_t = BOOL(WINAPI*)(SHELLEXECUTEINFOW*);
 static ShellExecuteExW_t ShellExecuteExW_orig = nullptr;
 static ShellExecuteW_t ShellExecuteW_orig = nullptr;
 
-// ── In-process reentry guard ──────────────────────────────────────────────────
-
+// Reentry guards
 static thread_local int g_hookDepth = 0;
 
 struct HookGuard {
-    HookGuard()  { ++g_hookDepth; }
+    HookGuard() { ++g_hookDepth; }
     ~HookGuard() { --g_hookDepth; }
     bool IsReentrant() const { return g_hookDepth > 1; }
 };
 
-// ── Cross-process reentry guard ───────────────────────────────────────────────
-
+// Cross-process reentry guard
 static std::wstring g_childEnvBlock;
 
 static void BuildChildEnvironment() {
@@ -189,22 +120,21 @@ static bool IsChildProcess() {
     return GetEnvironmentVariableW(L"WH_STC_NOREDIRECT", nullptr, 0) > 0;
 }
 
-// ── Settings ──────────────────────────────────────────────────────────────────
-
+// Settings
 struct ModSettings {
-    bool enableRedirects            = true;
-    bool uiOnlyRedirects            = false;
+    bool enableRedirects = true;
+    bool uiOnlyRedirects = false;
     bool smartPersonalizationDetect = true;
-    int  fallbackMode               = 2;
-    bool win11CompatibilityMode     = false;
-    int  maxLaunchesPerUri          = 3;
+    int fallbackMode = 2;
+    bool win11CompatibilityMode = false;
+    int maxLaunchesPerUri = 3;
 };
 
 static ModSettings g_settings;
 
 static void LoadSettings() {
-    g_settings.enableRedirects            = Wh_GetIntSetting(L"EnableRedirects") != 0;
-    g_settings.uiOnlyRedirects            = Wh_GetIntSetting(L"UIOnlyRedirects") != 0;
+    g_settings.enableRedirects = Wh_GetIntSetting(L"EnableRedirects") != 0;
+    g_settings.uiOnlyRedirects = Wh_GetIntSetting(L"UIOnlyRedirects") != 0;
     g_settings.smartPersonalizationDetect = Wh_GetIntSetting(L"SmartPersonalizationDetection") != 0;
 
     PCWSTR fallbackStr = Wh_GetStringSetting(L"FallbackMode");
@@ -221,17 +151,13 @@ static void LoadSettings() {
     int ml = Wh_GetIntSetting(L"MaxLaunchesPerUri");
     g_settings.maxLaunchesPerUri = (ml >= 0 && ml <= 20) ? ml : 3;
 
-    Wh_Log(L"EnableRedirects=%d  UIOnly=%d  SmartPers=%d  Fallback=%d  Win11Compat=%d  MaxLaunches=%d",
-        (int)g_settings.enableRedirects,
-        (int)g_settings.uiOnlyRedirects,
-        (int)g_settings.smartPersonalizationDetect,
-        g_settings.fallbackMode,
-        (int)g_settings.win11CompatibilityMode,
-        g_settings.maxLaunchesPerUri);
+    Wh_Log(L"EnableRedirects=%d UIOnly=%d SmartPers=%d Fallback=%d Win11Compat=%d MaxLaunches=%d",
+        (int)g_settings.enableRedirects, (int)g_settings.uiOnlyRedirects,
+        (int)g_settings.smartPersonalizationDetect, g_settings.fallbackMode,
+        (int)g_settings.win11CompatibilityMode, g_settings.maxLaunchesPerUri);
 }
 
-// ── Win11 detection ───────────────────────────────────────────────────────────
-
+// Win11 detection
 static bool g_isWin11 = false;
 
 static void DetectWindowsVersion() {
@@ -243,48 +169,20 @@ static void DetectWindowsVersion() {
         auto fn = (RtlGetVersion_t)GetProcAddress(hNtdll, "RtlGetVersion");
         if (fn) fn(&osvi);
     }
-    g_isWin11 = (osvi.dwMajorVersion == 10 &&
-                 osvi.dwMinorVersion == 0   &&
-                 osvi.dwBuildNumber >= 22000);
-    Wh_Log(L"Build %lu  IsWin11=%d", osvi.dwBuildNumber, (int)g_isWin11);
+    g_isWin11 = (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber >= 22000);
+    Wh_Log(L"Build %lu IsWin11=%d", osvi.dwBuildNumber, (int)g_isWin11);
 }
 
-// ── Loop guard + Bounce-back detection ───────────────────────────────────────
-
+// Loop guard
 struct LaunchRecord {
-    int   count     = 0;
+    int count = 0;
     DWORD firstTick = 0;
 };
 
-struct BounceRecord {
-    DWORD lastRedirectTick = 0;
-};
+static std::mutex g_loopGuardMtx;
+static std::unordered_map<std::wstring, LaunchRecord> g_loopGuard;
 
-static std::mutex                                      g_loopGuardMtx;
-static std::unordered_map<std::wstring, LaunchRecord>  g_loopGuard;
-static std::unordered_map<std::wstring, BounceRecord>  g_bounceGuard;
-
-static constexpr DWORD LOOP_WINDOW_MS   = 5000;
-static constexpr DWORD BOUNCE_WINDOW_MS = 600;
-
-static void BounceGuardRecord(const std::wstring& uri) {
-    std::lock_guard<std::mutex> lk(g_loopGuardMtx);
-    g_bounceGuard[uri].lastRedirectTick = GetTickCount();
-}
-
-static bool BounceGuardIsBounce(const std::wstring& uri) {
-    std::lock_guard<std::mutex> lk(g_loopGuardMtx);
-    auto it = g_bounceGuard.find(uri);
-    if (it == g_bounceGuard.end()) return false;
-    DWORD elapsed = GetTickCount() - it->second.lastRedirectTick;
-    if (elapsed < BOUNCE_WINDOW_MS) {
-        Wh_Log(L"BOUNCE-BACK: '%s' returned %lu ms after redirect — target is dead, routing to fallback",
-               uri.c_str(), elapsed);
-        it->second.lastRedirectTick = 0;
-        return true;
-    }
-    return false;
-}
+static constexpr DWORD LOOP_WINDOW_MS = 3000;
 
 static bool LoopGuardAllow(const std::wstring& target) {
     if (g_settings.maxLaunchesPerUri <= 0) return true;
@@ -294,7 +192,7 @@ static bool LoopGuardAllow(const std::wstring& target) {
     auto& rec = g_loopGuard[target];
 
     if (rec.count == 0 || (now - rec.firstTick) >= LOOP_WINDOW_MS) {
-        rec.count     = 1;
+        rec.count = 1;
         rec.firstTick = now;
         return true;
     }
@@ -304,13 +202,11 @@ static bool LoopGuardAllow(const std::wstring& target) {
         return true;
     }
 
-    Wh_Log(L"LOOP GUARD: suppressing launch of '%s' (fired %d times in %lu ms)",
-           target.c_str(), rec.count, (now - rec.firstTick));
+    Wh_Log(L"LOOP GUARD: suppressing launch of '%s' (%d times in %lu ms)", target.c_str(), rec.count, (now - rec.firstTick));
     return false;
 }
 
-// ── CLSID classification ──────────────────────────────────────────────────────
-
+// CLSID classification
 static const std::unordered_set<std::wstring> g_win11SafeClsids = {
     L"shell:::{8e908fc9-becc-40f6-915b-f4ca0e70d03d}",
     L"shell:::{7007acc7-3202-11d1-aad2-00805fc1270e}",
@@ -324,7 +220,6 @@ static const std::unordered_set<std::wstring> g_win11SafeClsids = {
     L"shell:::{9c60de1e-e5fc-40f4-a487-460851a8d915}",
     L"shell:::{b98a2bea-7d42-4558-8bd1-832f41bac6fd}",
     L"shell:::{bd84b380-8ca2-1069-ab1d-08000948f534}",
-    L"shell:::{d555645e-d4f8-4c29-a827-d93c859c4f2a}",
     L"shell:::{d9ef8727-cac2-4e60-809e-86f80a666c91}",
     L"shell:::{c58c4893-3be0-4b45-abb5-a63e4b8c8651}",
 };
@@ -335,6 +230,14 @@ static const std::unordered_set<std::wstring> g_win11LoopClsids = {
     L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}",
     L"shell:::{80f3f1d5-feca-45f3-bc32-752c152e456e}",
     L"shell:::{9fe63afd-59cf-4419-9775-abcc3849f861}",
+};
+
+static const std::unordered_set<std::wstring> g_win11NoForceRedirect = {
+    L"ms-settings:defaultapps",
+    L"ms-settings:appsfeatures",
+    L"ms-settings:network",
+    L"ms-settings:bluetooth",
+    L"ms-settings:printers",
 };
 
 static bool IsClsidSafeOnWin11(const std::wstring& lowerTarget) {
@@ -349,212 +252,188 @@ static bool IsClsidLoopOnWin11(const std::wstring& lowerTarget) {
     return g_win11LoopClsids.count(base) > 0;
 }
 
-// ── String utilities ──────────────────────────────────────────────────────────
-
+// String utilities
 static std::wstring ToLower(std::wstring s) {
     std::transform(s.begin(), s.end(), s.begin(), ::towlower);
     return s;
 }
 
-// ── Mappings ──────────────────────────────────────────────────────────────────
-
+// Mappings
 static std::unordered_map<std::wstring, std::wstring> g_mappings;
 
 static void InitMappings() {
     const bool w11 = g_isWin11;
 
     g_mappings = {
-
-        // ── Personalization ──────────────────────────────────────────────────
-        {L"ms-settings:personalization",             PERS_ROOT},
-        {L"ms-settings:personalization-colors",      PERS_COLORS},
-        {L"ms-settings:colors",                      PERS_COLORS},
-        {L"ms-settings:themes",                      PERS_ROOT},
-        {L"ms-settings:lockscreen",                  PERS_ROOT},
-        {L"ms-settings:personalization-start",       PERS_ROOT},
-        {L"ms-settings:personalization-start-places",PERS_ROOT},
-        {L"ms-settings:background",                  PERS_WALLPAPER},
-        {L"ms-settings:personalization-background-wallpaper",  PERS_WALLPAPER},
-        {L"ms-settings:personalization-background-slideshow",  PERS_WALLPAPER},
-
-        {L"ms-settings:fonts",
-            L"shell:::{BD84B380-8CA2-1069-AB1D-08000948F534}"},
-
-        // ── Color Management ─────────────────────────────────────────────────
-        {L"ms-settings:display-advanced-color",              L"colorcpl.exe"},
-        {L"ms-settings:colorcpl",                            L"colorcpl.exe"},
-        {L"ms-settings:display",                             L"desk.cpl"},
-        {L"ms-settings:display-advanced",                    L"desk.cpl"},
-        {L"ms-settings:display-resolution",                  L"desk.cpl"},
-        {L"ms-settings:screenrotation",                      L"desk.cpl"},
-        // ── Graphics Adapter Properties ──────────────────── suggested by Anixx
-        {L"ms-settings:display-advanced-graphics",           L"rundll32.exe display.dll,ShowAdapterSettings 0"},
-        {L"ms-settings:graphics-settings",                   L"rundll32.exe display.dll,ShowAdapterSettings 0"},
-        {L"ms-settings:display-adapter-properties",          L"rundll32.exe display.dll,ShowAdapterSettings 0"},
-        // ── System / About ───────────────────────────────────────────────────
-        {L"ms-settings:about",
-            w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
-        {L"ms-settings:system",
-            w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
-        {L"ms-settings:sysinfo",
-            w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
-        {L"ms-settings:system-about",
-            w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
-        {L"ms-settings:system-protection",                   L"sysdm.cpl,,4"},
-        {L"ms-settings:system-remotedesktop",                L"sysdm.cpl,,5"},
-        {L"ms-settings:remotedesktop",                       L"sysdm.cpl,,5"},
-        {L"ms-settings:devicemanager",                       L"devmgmt.msc"},
-        {L"ms-settings:system-devicemanager",                L"devmgmt.msc"},
-        {L"ms-settings:computermanagement",                  L"compmgmt.msc"},
-        {L"ms-settings:activation",                          L"slui.exe"},
-        {L"ms-settings:appsfeatures",                        L"appwiz.cpl"},
-        {L"ms-settings:appsforwebsites",                     L"appwiz.cpl"},
-        {L"ms-settings:optionalfeatures",                    L"OptionalFeatures.exe"},
-
-        // ── Power ────────────────────────────────────────────────────────────
-        {L"ms-settings:powersleep",                          L"powercfg.cpl"},
-        {L"ms-settings:battery",                             L"powercfg.cpl"},
-        {L"ms-settings:batterysaver",                        L"powercfg.cpl"},
-        {L"ms-settings:batterysaver-settings",               L"powercfg.cpl"},
-        {L"ms-settings:batterysaver-usagedetails",           L"powercfg.cpl"},
-
-        // ── Sound ────────────────────────────────────────────────────────────
-        {L"ms-settings:sound",                               L"mmsys.cpl"},
-        {L"ms-settings:sound-devices",                       L"mmsys.cpl"},
-        {L"ms-settings:audio",                               L"mmsys.cpl"},
-        {L"ms-settings:apps-volume",                         L"sndvol.exe"},
-
-        // ── Notifications / Taskbar ──────────────────────────────────────────
-        {L"ms-settings:notifications",                       NOTIF_AREA_CLSID},
-        {L"ms-settings:taskbar-notifications",               NOTIF_AREA_CLSID},
-        {L"ms-settings:taskbar-systemtray",                  NOTIF_AREA_CLSID},
-        {L"ms-settings:notifications-systemtray",            NOTIF_AREA_CLSID},
-        {L"ms-settings:systemtray",                          NOTIF_AREA_CLSID},
-        {L"ms-settings:notificationiconpreferences",         NOTIF_AREA_CLSID},
-
-        // ── Input devices ────────────────────────────────────────────────────
-        {L"ms-settings:mousetouchpad",                       L"main.cpl"},
-        {L"ms-settings:devices-touchpad",                    L"main.cpl"},
-        {L"ms-settings:keyboard",                            L"main.cpl,,1"},
-        {L"ms-settings:typing",                              L"main.cpl,,1"},
-        {L"ms-settings:pen",
-            w11 ? L"control.exe" : L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
-        {L"ms-settings:pen-windowsink",
-            w11 ? L"control.exe" : L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
-        {L"ms-settings:pen-windowsinksettings",
-            w11 ? L"control.exe" : L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
-        {L"ms-settings:devices-touch",
-            w11 ? L"control.exe" : L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
-        {L"ms-settings:autoplay",
-            L"shell:::{9C60DE1E-E5FC-40f4-A487-460851A8D915}"},
-
-        // ── Devices / Printers ───────────────────────────────────────────────
-        {L"ms-settings:printers",
-            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:printers-scanners",
-            L"shell:::{2227A280-3AEA-1069-A2DE-08002B30309D}"},
-        {L"ms-settings:bluetooth",
-            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:usb",
-            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:connecteddevices",
-            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:mobile-devices",
-            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:camera",
-            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-        {L"ms-settings:privacy-customdevices",
-            L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
-
-        // ── Network ──────────────────────────────────────────────────────────
-        {L"ms-settings:network",
-            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-wifi",
-            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-ethernet",
-            L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
-        {L"ms-settings:network-proxy",                       L"inetcpl.cpl,,4"},
-        {L"ms-settings:network-status", 
-            L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
-        {L"ms-settings:network-status",
-            L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
-        {L"ms-settings:network-dialup",
-            L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
-        {L"ms-settings:network-advancedsettings",
-            L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
-        {L"ms-settings:firewall",
-            L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
-        {L"ms-settings:network-firewall",
-            L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
-        {L"ms-settings:windowsdefender",
-            L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
-
-        // ── Accounts ─────────────────────────────────────────────────────────
-        {L"ms-settings:yourinfo",
-            L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:yourinfo-profile",
-            L"shell:::{59031a47-3f72-44a7-89c5-5595fe6b30ee}"},
-        {L"ms-settings:emailandaccounts",
-            L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:accounts",
-            L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
-        {L"ms-settings:startupapps",                         L"msconfig.exe"},
-
-        // ── Default Apps ──────────────────────────────────────────────────────
-        {L"ms-settings:defaultapps",
-            w11 ? WIN11_PASSTHROUGH
-                : L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
-
-        // ── Time & Language ───────────────────────────────────────────────────
-        {L"ms-settings:dateandtime",                         L"timedate.cpl"},
-        {L"ms-settings:dateandtime-region",                  L"timedate.cpl"},
-        {L"ms-settings:dateandtime-addclocks",               L"timedate.cpl,,1"},
-        {L"ms-settings:regionlanguage",                      L"intl.cpl"},
-        {L"ms-settings:regionformatting",                    L"intl.cpl"},
-        {L"ms-settings:language",                            L"intl.cpl"},
-
-        // ── Ease of Access ────────────────────────────────────────────────────,
-        // Ease Of Access entries
-        {L"ms-settings:easeofaccess", L"access.cpl"},
-        {L"ms-settings:easeofaccess-narrator", L"access.cpl"},
-        {L"ms-settings:easeofaccess-magnifier", L"access.cpl"},
-        {L"ms-settings:easeofaccess-speech", L"access.cpl"},
-        {L"ms-settings:easeofaccess-colorfilter", L"access.cpl"},
-        {L"ms-settings:easeofaccess-display", L"access.cpl"},
-
-        // ── Recovery / Backup ─────────────────────────────────────────────────
-        {L"ms-settings:backup",
-            L"shell:::{B98A2BEA-7D42-4558-8BD1-832F41BAC6FD}"},
-        {L"ms-settings:recovery",
-            w11 ? L"control.exe" : L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
-
-        // ── Troubleshooting ───────────────────────────────────────────────────
-        // added a legacy redirect in windows 11
-        {L"ms-settings:troubleshoot",
-                w11 ? L"msdt.exe -id DeviceDiagnostic" : L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
-
-        {L"ms-settings:deviceencryption",
-            L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
+        // Personalization
+        {L"ms-settings:personalization", PERS_ROOT},
+        {L"ms-settings:personalization-colors", PERS_COLORS},
+        {L"ms-settings:colors", PERS_COLORS},
+        {L"ms-settings:themes", PERS_ROOT},
+        {L"ms-settings:lockscreen", PERS_ROOT},
+        {L"ms-settings:personalization-start", PERS_ROOT},
+        {L"ms-settings:personalization-start-places", PERS_ROOT},
+        {L"ms-settings:background", PERS_WALLPAPER},
+        {L"ms-settings:personalization-background-wallpaper", PERS_WALLPAPER},
+        {L"ms-settings:personalization-background-slideshow", PERS_WALLPAPER},
+        
+        // Fonts & Color
+        {L"ms-settings:fonts", L"shell:::{BD84B380-8CA2-1069-AB1D-08000948F534}"},
+        {L"ms-settings:display-advanced-color", L"colorcpl.exe"},
+        {L"ms-settings:colorcpl", L"colorcpl.exe"},
+        
+        // Display (using rundll32 for advanced properties)
+        {L"ms-settings:display", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
+        {L"ms-settings:display-advanced", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
+        {L"ms-settings:display-advanced-graphics", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
+        {L"ms-settings:graphics-settings", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
+        {L"ms-settings:display-adapter-properties", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
+        
+        // System
+        {L"ms-settings:about", w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
+        {L"ms-settings:system", w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
+        {L"ms-settings:sysinfo", w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
+        {L"ms-settings:system-about", w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
+        {L"ms-settings:system-protection", L"sysdm.cpl,,4"},
+        {L"ms-settings:system-remotedesktop", L"sysdm.cpl,,5"},
+        {L"ms-settings:remotedesktop", L"sysdm.cpl,,5"},
+        {L"ms-settings:devicemanager", L"devmgmt.msc"},
+        {L"ms-settings:system-devicemanager", L"devmgmt.msc"},
+        {L"ms-settings:computermanagement", L"compmgmt.msc"},
+        {L"ms-settings:activation", L"slui.exe"},
+        {L"ms-settings:appsfeatures", L"appwiz.cpl"},
+        {L"ms-settings:appsforwebsites", L"appwiz.cpl"},
+        {L"ms-settings:optionalfeatures", L"OptionalFeatures.exe"},
+        
+        // Power
+        {L"ms-settings:powersleep", L"powercfg.cpl"},
+        {L"ms-settings:battery", L"powercfg.cpl"},
+        {L"ms-settings:batterysaver", L"powercfg.cpl"},
+        {L"ms-settings:batterysaver-settings", L"powercfg.cpl"},
+        {L"ms-settings:batterysaver-usagedetails", L"powercfg.cpl"},
+        
+        // Sound
+        {L"ms-settings:audio", L"mmsys.cpl"},
+        {L"ms-settings:sound-control-panel", L"control.exe /name Microsoft.Sound"},
+        {L"ms-settings:sound-playback", L"control.exe mmsys.cpl,,0"},
+        {L"ms-settings:sound-recording", L"control.exe mmsys.cpl,,1"},
+        {L"ms-settings:sound-sounds", L"control.exe mmsys.cpl,,2"},
+        {L"ms-settings:sound-volume-flyout", L"sndvol.exe -f"},
+        {L"ms-settings:sound-devices", L"control.exe mmsys.cpl,,0"},
+        {L"ms-settings:sound-output", L"control.exe mmsys.cpl,,0"},
+        {L"ms-settings:sound-input", L"control.exe mmsys.cpl,,1"},
+        {L"ms-settings:apps-volume", L"control.exe mmsys.cpl,,0"},
+        {L"ms-settings:sound", L"control.exe mmsys.cpl,,0"},
+        
+        // Notifications / Taskbar
+        {L"ms-settings:notifications", NOTIF_AREA_CLSID},
+        {L"ms-settings:taskbar-notifications", NOTIF_AREA_CLSID},
+        {L"ms-settings:taskbar-systemtray", NOTIF_AREA_CLSID},
+        {L"ms-settings:notifications-systemtray", NOTIF_AREA_CLSID},
+        {L"ms-settings:systemtray", NOTIF_AREA_CLSID},
+        {L"ms-settings:notificationiconpreferences", NOTIF_AREA_CLSID},
+        
+        // Input devices
+        {L"ms-settings:mousetouchpad", L"main.cpl"},
+        {L"ms-settings:devices-touchpad", L"main.cpl"},
+        {L"ms-settings:keyboard", L"main.cpl,,1"},
+        {L"ms-settings:typing", L"main.cpl,,1"},
+        {L"ms-settings:pen", w11 ? L"control.exe" : L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:pen-windowsink", w11 ? L"control.exe" : L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:pen-windowsinksettings", w11 ? L"control.exe" : L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:devices-touch", w11 ? L"control.exe" : L"shell:::{80F3F1D5-FECA-45F3-BC32-752C152E456E}"},
+        {L"ms-settings:autoplay", L"shell:::{9C60DE1E-E5FC-40f4-A487-460851A8D915}"},
+        
+        // Devices / Printers
+        {L"ms-settings:printers", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:printers-scanners", L"shell:::{2227A280-3AEA-1069-A2DE-08002B30309D}"},
+        {L"ms-settings:bluetooth", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:usb", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:connecteddevices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:mobile-devices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:camera", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        {L"ms-settings:privacy-customdevices", L"shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"},
+        
+        // Network
+        {L"ms-settings:network", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-wifi", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-ethernet", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-proxy", L"inetcpl.cpl,,4"},
+        {L"ms-settings:network-status", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
+        {L"ms-settings:network-dialup", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
+        {L"ms-settings:network-advancedsettings", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
+        {L"ms-settings:firewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
+        {L"ms-settings:network-firewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
+        {L"ms-settings:windowsdefender", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
+        
+        // Accounts
+        {L"ms-settings:yourinfo", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:yourinfo-profile", L"shell:::{59031a47-3f72-44a7-89c5-5595fe6b30ee}"},
+        {L"ms-settings:emailandaccounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:accounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
+        {L"ms-settings:startupapps", L"msconfig.exe"},
+        
+        // Default Apps
+        {L"ms-settings:defaultapps", w11 ? WIN11_PASSTHROUGH : L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
+        
+        // Time & Language
+        {L"ms-settings:dateandtime", L"timedate.cpl"},
+        {L"ms-settings:dateandtime-region", L"timedate.cpl"},
+        {L"ms-settings:dateandtime-addclocks", L"timedate.cpl,,1"},
+        {L"ms-settings:regionlanguage", L"intl.cpl"},
+        {L"ms-settings:regionformatting", L"intl.cpl"},
+        {L"ms-settings:language", L"intl.cpl"},
+        
+        // Ease of Access
+        {L"ms-settings:easeofaccess", EASE_OF_ACCESS},
+        {L"ms-settings:easeofaccess-narrator", EASE_OF_ACCESS},
+        {L"ms-settings:easeofaccess-magnifier", EASE_OF_ACCESS},
+        {L"ms-settings:easeofaccess-speech", EASE_OF_ACCESS},
+        {L"ms-settings:easeofaccess-colorfilter", EASE_OF_ACCESS},
+        {L"ms-settings:easeofaccess-display", EASE_OF_ACCESS},
+        {L"ms-settings:easeofaccess-uiaccess", EASE_OF_ACCESS},
+        {L"ms-settings:easeofaccess-highcontrast", EASE_OF_ACCESS},
+        {L"ms-settings:easeofaccess-closedcaptioning", EASE_OF_ACCESS},
+        {L"ms-settings:easeofaccess-audio", EASE_OF_ACCESS},
+        {L"ms-settings:easeofaccess-mouse", EASE_OF_ACCESS},
+        {L"ms-settings:easeofaccess-keyboard", EASE_OF_ACCESS},
+        
+        // Recovery / Backup / Troubleshooting
+        {L"ms-settings:backup", L"shell:::{B98A2BEA-7D42-4558-8BD1-832F41BAC6FD}"},
+        {L"ms-settings:recovery", w11 ? L"control.exe" : L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
+        {L"ms-settings:troubleshoot", w11 ? L"msdt.exe -id DeviceDiagnostic" : L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
+        {L"ms-settings:deviceencryption", L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
     };
+    
+    // Additional Windows 11 24H2 specific mappings
+    if (g_isWin11) {
+        g_mappings[L"ms-settings:power"] = L"powercfg.cpl";
+        g_mappings[L"ms-settings:display-hdr"] = L"colorcpl.exe";
+        g_mappings[L"ms-settings:taskbar"] = NOTIF_AREA_CLSID;
+        g_mappings[L"ms-settings:personalization-taskbar"] = NOTIF_AREA_CLSID;
+        g_mappings[L"ms-settings:multitasking"] = L"control.exe";
+        g_mappings[L"ms-settings:storage"] = L"control.exe";
+        g_mappings[L"ms-settings:storagesense"] = L"control.exe";
+        g_mappings[L"ms-settings:backup"] = L"control.exe /name Microsoft.BackupAndRestore";
+        g_mappings[L"ms-settings:windowsupdate"] = L"control.exe /name Microsoft.WindowsUpdate";
+    }
 }
 
-// ── URI normalization ─────────────────────────────────────────────────────────
-
+// URI normalization
 static std::wstring NormalizeUri(const std::wstring& uri) {
     std::wstring result = ToLower(uri);
-
     const std::wstring PROTOCOL = L"ms-settings://";
     size_t pos = result.find(PROTOCOL);
-    if (pos != std::wstring::npos)
-    { result = L"ms-settings:" + result.substr(pos + PROTOCOL.length()); }
-
+    if (pos != std::wstring::npos) {
+        result = L"ms-settings:" + result.substr(pos + PROTOCOL.length());
+    }
     pos = result.find(L'?');
-    if (pos != std::wstring::npos)
+    if (pos != std::wstring::npos) {
         result = result.substr(0, pos);
-
-    while (!result.empty() && result.back() == L'/')
+    }
+    while (!result.empty() && result.back() == L'/') {
         result.pop_back();
-
+    }
     return result;
 }
 
@@ -568,13 +447,11 @@ static bool IsShellClsid(const wchar_t* s) {
     return ToLower(s).find(L"shell:::") != std::wstring::npos;
 }
 
-// ── Win11 CLSID filter ────────────────────────────────────────────────────────
-
+// Win11 CLSID filter
 static std::wstring ApplyWin11Filter(const std::wstring& target) {
     if (!g_isWin11) return target;
 
     std::wstring lower = ToLower(target);
-
     if (lower.find(L"shell:::") != 0) return target;
 
     if (IsClsidLoopOnWin11(lower)) {
@@ -590,51 +467,45 @@ static std::wstring ApplyWin11Filter(const std::wstring& target) {
             Wh_Log(L"Win11 loop-guard: {BB06C0E4} -> sysdm.cpl");
             return L"sysdm.cpl";
         }
-        Wh_Log(L"Win11 loop-guard: replacing loop CLSID '%s' with control.exe",
-               target.c_str());
+        Wh_Log(L"Win11 loop-guard: replacing loop CLSID '%s' with control.exe", target.c_str());
         return L"control.exe";
     }
 
     if (g_settings.win11CompatibilityMode && !IsClsidSafeOnWin11(lower)) {
-        Wh_Log(L"Win11 compat: replacing unconfirmed CLSID '%s' with control.exe",
-               target.c_str());
+        Wh_Log(L"Win11 compat: replacing unconfirmed CLSID '%s' with control.exe", target.c_str());
         return L"control.exe";
     }
 
     return target;
 }
 
-// ── Fallback handling ─────────────────────────────────────────────────────────
-
+// Fallback handling
 static bool HandleFallback(const std::wstring& uri) {
     switch (g_settings.fallbackMode) {
         case 0:
             Wh_Log(L"Fallback: ignoring unmapped URI: %s", uri.c_str());
             return true;
-
         case 1: {
             Wh_Log(L"Fallback: opening control.exe for unmapped URI: %s", uri.c_str());
             std::wstring cmd = L"control.exe";
-            STARTUPINFOW si = {}; si.cb = sizeof(si);
-            si.dwFlags = STARTF_USESHOWWINDOW; si.wShowWindow = SW_SHOWNORMAL;
+            STARTUPINFOW si = {};
+            si.cb = sizeof(si);
+            si.dwFlags = STARTF_USESHOWWINDOW;
+            si.wShowWindow = SW_SHOWNORMAL;
             PROCESS_INFORMATION pi = {};
-            if (CreateProcessW_orig(nullptr, cmd.data(), nullptr, nullptr,
-                                    FALSE, 0, nullptr, nullptr, &si, &pi)) {
+            if (CreateProcessW_orig(nullptr, cmd.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
                 CloseHandle(pi.hProcess);
                 CloseHandle(pi.hThread);
             }
             return true;
         }
-
-        case 2:
         default:
             Wh_Log(L"Fallback: passing through unmapped URI: %s", uri.c_str());
             return false;
     }
 }
 
-// ── LaunchTarget ──────────────────────────────────────────────────────────────
-
+// LaunchTarget
 static void LaunchTarget(const std::wstring& command) {
     Wh_Log(L"Launching: %s", command.c_str());
 
@@ -643,61 +514,58 @@ static void LaunchTarget(const std::wstring& command) {
         return;
     }
 
-    {
-        std::wstring lower = ToLower(command);
-            // rundll32.exe needs special handling (commas in arguments)
+    std::wstring lower = ToLower(command);
+
+    // Handle rundll32.exe specially (needs comma in arguments)
     if (command.find(L"rundll32.exe") != std::wstring::npos) {
         std::wstring mutable_cmd = command;
-        STARTUPINFOW si = {}; si.cb = sizeof(si);
+        STARTUPINFOW si = {};
+        si.cb = sizeof(si);
         PROCESS_INFORMATION pi = {};
-        if (!CreateProcessW_orig(nullptr, mutable_cmd.data(), nullptr, nullptr,
-                                 FALSE, 0, nullptr, nullptr, &si, &pi)) {
-            Wh_Log(L"rundll32 CreateProcess failed for '%s' (%lu)",
-                   command.c_str(), GetLastError());
+        if (!CreateProcessW_orig(nullptr, mutable_cmd.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
+            Wh_Log(L"rundll32 CreateProcess failed for '%s' (%lu)", command.c_str(), GetLastError());
         } else {
             CloseHandle(pi.hProcess);
             CloseHandle(pi.hThread);
         }
         return;
     }
-        // Gestisci "explorer shell:::" separatamente
-        if (lower.find(L"explorer shell:::") != std::wstring::npos) {
-            std::wstring clsid = command.substr(command.find(L"shell:::"));
-            SHELLEXECUTEINFOW sei = {};
-            sei.cbSize = sizeof(sei);
-            sei.fMask = SEE_MASK_FLAG_NO_UI;
-            sei.lpVerb = L"open";
-            sei.lpFile = clsid.c_str();
-            sei.nShow = SW_SHOWNORMAL;
-            ShellExecuteExW_orig(&sei);
-            return;
-        }
-        
-        bool isFullCmdLine =
-            (lower.find(L"rundll32.exe ")    != std::wstring::npos) ||
-            (lower.find(L"explorer.exe ")    != std::wstring::npos) ||
-            (lower.find(L"msdt.exe ")        != std::wstring::npos) ||
-            (lower.find(L"control.exe /")    != std::wstring::npos);
 
-        if (isFullCmdLine) {
-            STARTUPINFOW si = {}; si.cb = sizeof(si);
-            si.dwFlags = STARTF_USESHOWWINDOW; si.wShowWindow = SW_SHOWNORMAL;
-            PROCESS_INFORMATION pi = {};
-            std::wstring mutable_cmd = command;
-            if (!CreateProcessW_orig(nullptr, mutable_cmd.data(), nullptr, nullptr,
-                                     FALSE, CREATE_UNICODE_ENVIRONMENT,
-                                     (LPVOID)g_childEnvBlock.c_str(),
-                                     nullptr, &si, &pi)) {
-                Wh_Log(L"CreateProcess failed for '%s' (%lu)",
-                       command.c_str(), GetLastError());
-            } else {
-                CloseHandle(pi.hProcess);
-                CloseHandle(pi.hThread);
-            }
-            return;
-        }
+    // Handle "explorer shell:::" directly
+    if (lower.find(L"explorer shell:::") != std::wstring::npos) {
+        std::wstring clsid = command.substr(command.find(L"shell:::"));
+        SHELLEXECUTEINFOW sei = {};
+        sei.cbSize = sizeof(sei);
+        sei.fMask = SEE_MASK_FLAG_NO_UI;
+        sei.lpVerb = L"open";
+        sei.lpFile = clsid.c_str();
+        sei.nShow = SW_SHOWNORMAL;
+        ShellExecuteExW_orig(&sei);
+        return;
     }
 
+    // Full command line detection
+    bool isFullCmdLine = (lower.find(L"rundll32.exe ") != std::wstring::npos) ||
+                         (lower.find(L"explorer.exe ") != std::wstring::npos) ||
+                         (lower.find(L"msdt.exe ") != std::wstring::npos) ||
+                         (lower.find(L"control.exe /") != std::wstring::npos);
+
+    if (isFullCmdLine) {
+        STARTUPINFOW si = {};
+        si.cb = sizeof(si);
+        si.dwFlags = STARTF_USESHOWWINDOW;
+        si.wShowWindow = SW_SHOWNORMAL;
+        PROCESS_INFORMATION pi = {};
+        std::wstring mutable_cmd = command;
+        if (!CreateProcessW_orig(nullptr, mutable_cmd.data(), nullptr, nullptr, FALSE, CREATE_UNICODE_ENVIRONMENT,
+                                 (LPVOID)g_childEnvBlock.c_str(), nullptr, &si, &pi)) {
+            Wh_Log(L"CreateProcess failed for '%s' (%lu)", command.c_str(), GetLastError());
+        } else {
+            CloseHandle(pi.hProcess);
+            CloseHandle(pi.hThread);
+        }
+        return;
+    }
 
     // Generic router
     STARTUPINFOW si = {};
@@ -714,7 +582,6 @@ static void LaunchTarget(const std::wstring& command) {
     } else if (command.find(L".exe") != std::wstring::npos) {
         cmdLine = command;
     } else if (command.find(L"shell:::") == 0) {
-        // Apri CLSID direttamente
         SHELLEXECUTEINFOW sei = {};
         sei.cbSize = sizeof(sei);
         sei.fMask = SEE_MASK_FLAG_NO_UI;
@@ -730,66 +597,39 @@ static void LaunchTarget(const std::wstring& command) {
     }
 
     std::wstring mutableCmd = cmdLine;
-    if (!CreateProcessW_orig(nullptr, mutableCmd.data(), nullptr, nullptr,
-                             FALSE, CREATE_UNICODE_ENVIRONMENT,
-                             (LPVOID)g_childEnvBlock.c_str(),
-                             nullptr, &si, &pi)) {
-        Wh_Log(L"CreateProcess failed for '%s' (error %lu)",
-               cmdLine.c_str(), GetLastError());
+    if (!CreateProcessW_orig(nullptr, mutableCmd.data(), nullptr, nullptr, FALSE, CREATE_UNICODE_ENVIRONMENT,
+                             (LPVOID)g_childEnvBlock.c_str(), nullptr, &si, &pi)) {
+        Wh_Log(L"CreateProcess failed for '%s' (error %lu)", cmdLine.c_str(), GetLastError());
         return;
     }
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
 }
 
-// ── Personalization hwnd detection ───────────────────────────────────────────
-
+// Personalization detection
 static bool IsPersonalizationWindow(HWND hwnd) {
-    // Se HWND è NULL, prova con la finestra in primo piano
     if (!hwnd) {
         hwnd = GetForegroundWindow();
-        Wh_Log(L"IsPersonalizationWindow: HWND null, trying GetForegroundWindow=%p", hwnd);
-        if (!hwnd) {
-            Wh_Log(L"IsPersonalizationWindow: GetForegroundWindow returned null -> false");
-            return false;
-        }
+        if (!hwnd) return false;
     }
 
     HWND h = hwnd;
     while (h) {
-        wchar_t cls[256]   = {};
+        wchar_t cls[256] = {};
         wchar_t title[512] = {};
         GetClassNameW(h, cls, 256);
         GetWindowTextW(h, title, 512);
-
         std::wstring c = ToLower(cls);
         std::wstring t = ToLower(title);
 
-        Wh_Log(L"IsPersonalizationWindow: hwnd=%p class='%s' title='%s'", h, cls, title);
-
-        if (c == L"progman" || c == L"workerw" || c == L"shelldll_defview") {
-            Wh_Log(L"IsPersonalizationWindow: desktop class -> false");
-            return false;
-        }
-        if (c == L"cabinetwclass") {
-            if (t.find(L"personaliz") != std::wstring::npos) {
-                Wh_Log(L"IsPersonalizationWindow: CabinetWClass personalization -> true");
-                return true;
-            }
-            Wh_Log(L"IsPersonalizationWindow: CabinetWClass but not personalization -> false");
-            return false;
-        }
-        if (t.find(L"personaliz") != std::wstring::npos) {
-            Wh_Log(L"IsPersonalizationWindow: title match -> true");
-            return true;
-        }
+        if (c == L"progman" || c == L"workerw" || c == L"shelldll_defview") return false;
+        if (c == L"cabinetwclass" && t.find(L"personaliz") != std::wstring::npos) return true;
+        if (t.find(L"personaliz") != std::wstring::npos) return true;
 
         HWND parent = GetParent(h);
         if (!parent || parent == h) break;
         h = parent;
     }
-
-    Wh_Log(L"IsPersonalizationWindow: no match found -> false");
     return false;
 }
 
@@ -806,94 +646,181 @@ static std::wstring ResolvePersonalizationBackground(HWND hwnd) {
     return PERS_ROOT;
 }
 
-// ── Core resolve logic ────────────────────────────────────────────────────────
+// Audio window closing (workaround for modern windows)
+static bool g_isClosingAudioWindow = false;
 
+static void CloseModernAudioWindow() {
+    if (g_isClosingAudioWindow) {
+        Wh_Log(L"CloseModernAudioWindow: already running, skipping");
+        return;
+    }
+    g_isClosingAudioWindow = true;
+    
+    Wh_Log(L"CloseModernAudioWindow: searching for modern audio windows");
+    
+    HWND hwnd = FindWindowW(L"ApplicationFrameWindow", nullptr);
+    bool found = false;
+    
+    while (hwnd && !found) {
+        if (IsWindowVisible(hwnd)) {
+            DWORD processId = 0;
+            GetWindowThreadProcessId(hwnd, &processId);
+            
+            HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, processId);
+            if (hProcess) {
+                wchar_t processPath[MAX_PATH] = {0};
+                DWORD size = MAX_PATH;
+                if (QueryFullProcessImageNameW(hProcess, 0, processPath, &size)) {
+                    std::wstring processName = ToLower(processPath);
+                    
+                    if (processName.find(L"systemsettings.exe") != std::wstring::npos ||
+                        processName.find(L"settings.exe") != std::wstring::npos ||
+                        processName.find(L"windows.immersivecontrolpanel") != std::wstring::npos) {
+                        
+                        HWND childHwnd = FindWindowExW(hwnd, nullptr, L"Windows.UI.Core.CoreWindow", nullptr);
+                        if (childHwnd) {
+                            wchar_t className[256] = {0};
+                            GetClassNameW(childHwnd, className, 256);
+                            std::wstring classNameStr = ToLower(className);
+                            
+                            if (classNameStr.find(L"audio") != std::wstring::npos ||
+                                classNameStr.find(L"sound") != std::wstring::npos) {
+                                
+                                Wh_Log(L"CloseModernAudioWindow: found audio window (process: %s, class: %s)", 
+                                       processPath, className);
+                                PostMessageW(hwnd, WM_CLOSE, 0, 0);
+                                found = true;
+                            }
+                        }
+                        
+                        if (!found) {
+                            wchar_t windowTitle[256] = {0};
+                            GetWindowTextW(hwnd, windowTitle, 256);
+                            std::wstring title = ToLower(windowTitle);
+                            
+                            if (title.find(L"audio") != std::wstring::npos ||
+                                title.find(L"sound") != std::wstring::npos ||
+                                title.find(L"suono") != std::wstring::npos) {
+                                
+                                Wh_Log(L"CloseModernAudioWindow: found audio window by title (process: %s, title: %s)", 
+                                       processPath, windowTitle);
+                                PostMessageW(hwnd, WM_CLOSE, 0, 0);
+                                found = true;
+                            }
+                        }
+                    }
+                }
+                CloseHandle(hProcess);
+            }
+        }
+        
+        if (!found) {
+            hwnd = FindWindowExW(nullptr, hwnd, L"ApplicationFrameWindow", nullptr);
+        } else {
+            break;
+        }
+    }
+    
+    if (!found) {
+        Wh_Log(L"CloseModernAudioWindow: no modern audio window found");
+    }
+    
+    g_isClosingAudioWindow = false;
+}
+
+// Helper function to open sound panel
+static bool OpenSoundPanel() {
+    Wh_Log(L"Opening sound panel via LaunchTarget");
+    LaunchTarget(L"control.exe mmsys.cpl,,0");
+    return true;
+}
+
+// Core resolve logic
 struct ResolveResult {
     std::wstring target;
-    bool         intercept;
+    bool intercept;
 };
 
 static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
+    // Win11: some URIs should not be forced
+    if (g_isWin11 && g_win11NoForceRedirect.count(uri) > 0) {
+        Wh_Log(L"Win11 whitelist: skipping redirect for %s (pass-through)", uri.c_str());
+        return {L"", false};
+    }
+    
+    // Audio URI detection with window closing
+    if (uri.find(L"ms-settings:sound") == 0 ||
+        uri.find(L"ms-settings:audio") == 0 ||
+        uri.find(L"ms-settings:apps-volume") == 0 ||
+        uri.find(L"ms-settings:sound-devices") == 0 ||
+        uri.find(L"ms-settings:sound-output") == 0 ||
+        uri.find(L"ms-settings:sound-input") == 0) {
+        Wh_Log(L"Audio URI detected, closing modern windows");
+        CloseModernAudioWindow();
+    }
+    
+    // Personalization Background (smart detection)
     if (uri == L"ms-settings:personalization-background") {
-        if (BounceGuardIsBounce(uri)) {
-            Wh_Log(L"Bounce-back on personalization-background, routing to fallback");
-            bool handled = HandleFallback(uri);
-            return {L"", handled};
-        }
         std::wstring t = ApplyWin11Filter(ResolvePersonalizationBackground(hwnd));
-        BounceGuardRecord(uri);
+        Wh_Log(L"personalization-background -> %s", t.c_str());
         return {t, true};
     }
 
-    if (uri.find(L"shell:::{d555645e-d4f8-4c29-a827-d93c859c4f2a}") == 0) {
-        Wh_Log(L"Win11 hardcode: forcing classic ease of access target for shell CLSID '%s'", uri.c_str());
-        return {L"access.cpl", true};
+    // Display settings (use rundll32 for advanced properties)
+    if (uri == L"ms-settings:display" ||
+        uri == L"ms-settings:display-advanced" ||
+        uri == L"ms-settings:display-advanced-graphics" ||
+        uri == L"ms-settings:graphics-settings" ||
+        uri == L"ms-settings:display-adapter-properties" ||
+        uri == L"ms-settings:display-resolution" ||
+        uri == L"ms-settings:screenrotation") {
+        std::wstring t = L"rundll32.exe display.dll,ShowAdapterSettings 0";
+        Wh_Log(L"Display redirect: %s -> %s", uri.c_str(), t.c_str());
+        return {t, true};
     }
 
+    // Ease of Access (use control.exe /name to avoid CLSID loops)
+    if (uri == L"ms-settings:easeofaccess" ||
+        uri.find(L"ms-settings:easeofaccess-") == 0) {
+        std::wstring t = EASE_OF_ACCESS;
+        Wh_Log(L"EaseOfAccess redirect: %s -> %s", uri.c_str(), t.c_str());
+        return {t, true};
+    }
+
+    // Personalization CLSID handling (from inside classic CPL)
     if (uri.find(L"shell:::{ed834ed6-4b5a-4bfe-8f11-a626dcb6a921}") == 0) {
         if (uri.find(L"pagewallpaper") != std::wstring::npos) {
-            Wh_Log(L"Win11 hardcode: forcing classic personalization wallpaper target for '%s'", uri.c_str());
+            Wh_Log(L"Personalization CLSID: forcing wallpaper for '%s'", uri.c_str());
             return {PERS_WALLPAPER, true};
         }
         if (uri.find(L"pagecolorization") != std::wstring::npos) {
-            Wh_Log(L"Win11 hardcode: forcing classic personalization colors target for '%s'", uri.c_str());
+            Wh_Log(L"Personalization CLSID: forcing colors for '%s'", uri.c_str());
             return {PERS_COLORS, true};
         }
-        Wh_Log(L"Win11 hardcode: forcing classic personalization root for '%s'", uri.c_str());
+        Wh_Log(L"Personalization CLSID: forcing root for '%s'", uri.c_str());
         return {PERS_ROOT, true};
     }
 
-    // ─── Win11 hardcoded classic target overrides ───
-    // Force Win11 to open the classic display and ease of access panels instead
-    // of letting modern Settings choose a different or unsupported path.
-    if (g_isWin11) {
-        if (uri == L"ms-settings:display" ||
-            uri == L"ms-settings:display-advanced" ||
-            uri == L"ms-settings:display-resolution" ||
-            uri == L"ms-settings:screenrotation")
-        {
-            Wh_Log(L"Win11 hardcode: forcing classic display target for '%s'", uri.c_str());
-            return {L"desk.cpl", true};
-        }
-
-        if (uri == L"ms-settings:easeofaccess" ||
-            uri == L"ms-settings:easeofaccess-narrator" ||
-            uri == L"ms-settings:easeofaccess-magnifier" ||
-            uri == L"ms-settings:easeofaccess-speech" ||
-            uri == L"ms-settings:easeofaccess-colorfilter" ||
-            uri == L"ms-settings:easeofaccess-display")
-        {
-            Wh_Log(L"Win11 hardcode: forcing classic ease of access target for '%s'", uri.c_str());
-            return {L"access.cpl", true};
-        }
-    }
-
+    // Check mappings table
     auto it = g_mappings.find(uri);
     if (it != g_mappings.end()) {
-        if (BounceGuardIsBounce(uri)) {
-            Wh_Log(L"Bounce-back on '%s', routing to fallback", uri.c_str());
-            bool handled = HandleFallback(uri);
-            return {L"", handled};
-        }
-
         std::wstring t = ApplyWin11Filter(it->second);
-
         if (t == WIN11_PASSTHROUGH) {
-            Wh_Log(L"Passthrough sentinel for '%s', routing to fallback", uri.c_str());
+            Wh_Log(L"Passthrough sentinel for '%s'", uri.c_str());
             bool handled = HandleFallback(uri);
             return {L"", handled};
         }
-
         Wh_Log(L"Mapped: %s -> %s", uri.c_str(), t.c_str());
-        BounceGuardRecord(uri);
         return {t, true};
     }
 
+    // Unmapped ms-settings: URI
     if (uri.find(L"ms-settings:") == 0) {
         bool handled = HandleFallback(uri);
         return {L"", handled};
     }
 
+    // Unmapped shell::: CLSID (only intercept known loop CLSIDs on Win11)
     if (uri.find(L"shell:::") == 0) {
         if (g_isWin11 && IsClsidLoopOnWin11(uri)) {
             std::wstring t = ApplyWin11Filter(uri);
@@ -905,8 +832,8 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
     Wh_Log(L"Unmapped, passing through: %s", uri.c_str());
     return {L"", false};
 }
-// ── Precise control system detection ─────────────────────────────────────────
 
+// Control system detection helpers
 static std::wstring BaseNameLower(const std::wstring& path) {
     size_t pos = path.rfind(L'\\');
     return ToLower((pos != std::wstring::npos) ? path.substr(pos + 1) : path);
@@ -937,27 +864,20 @@ static bool IsControlSystemCommand(const std::wstring& cmdLine) {
             current += c;
         }
     }
-    if (!current.empty())
-        tokens.push_back(current);
+    if (!current.empty()) tokens.push_back(current);
 
-    if (tokens.size() != 2)
-        return false;
+    if (tokens.size() != 2) return false;
 
     std::wstring exe = BaseNameLower(tokens[0]);
-    if (exe != L"control.exe" && exe != L"control")
-        return false;
+    if (exe != L"control.exe" && exe != L"control") return false;
 
     std::wstring arg = ToLower(tokens[1]);
     return (arg == L"system" || arg == L"microsoft.system");
 }
 
-// ── Hook: ShellExecuteExW ─────────────────────────────────────────────────────
-
-
-
+// Hook: ShellExecuteExW
 BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
-    if (IsChildProcess())
-        return ShellExecuteExW_orig(pei);
+    if (IsChildProcess()) return ShellExecuteExW_orig(pei);
 
     HookGuard guard;
     if (guard.IsReentrant()) {
@@ -965,13 +885,7 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
         return ShellExecuteExW_orig(pei);
     }
 
-    if (!g_settings.enableRedirects || !pei)
-        return ShellExecuteExW_orig(pei);
-
-    Wh_Log(L"ShellExecuteExW: hwnd=%p  file=%s  params=%s",
-           pei->hwnd,
-           pei->lpFile       ? pei->lpFile       : L"(null)",
-           pei->lpParameters ? pei->lpParameters : L"(null)");
+    if (!g_settings.enableRedirects || !pei) return ShellExecuteExW_orig(pei);
 
     if (IsControlSystemParams(pei->lpFile, pei->lpParameters)) {
         Wh_Log(L"ShellExecuteExW: intercepted control system");
@@ -985,32 +899,42 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
         uri = NormalizeUri(pei->lpFile);
     else if (IsMsSettings(pei->lpParameters))
         uri = NormalizeUri(pei->lpParameters);
-    else if (IsShellClsid(pei->lpFile)) {
+    else if (IsShellClsid(pei->lpFile))
         uri = ToLower(pei->lpFile);
-    }
-    else if (IsShellClsid(pei->lpParameters)) {
+    else if (IsShellClsid(pei->lpParameters))
         uri = ToLower(pei->lpParameters);
+
+    // Audio URI handling with debug log
+    if (!uri.empty() && (uri.find(L"ms-settings:sound") == 0 ||
+        uri.find(L"ms-settings:audio") == 0 ||
+        uri.find(L"ms-settings:apps-volume") == 0 ||
+        uri.find(L"ms-settings:sound-devices") == 0 ||
+        uri.find(L"ms-settings:sound-output") == 0 ||
+        uri.find(L"ms-settings:sound-input") == 0)) {
+        
+        Wh_Log(L"Audio URI detected in ShellExecuteExW: %s", uri.c_str());
+        CloseModernAudioWindow();
+        
+        if (OpenSoundPanel()) {
+            if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
+            return TRUE;
+        }
     }
 
     if (!uri.empty()) {
         auto result = ResolveUri(uri, pei->hwnd);
         if (result.intercept) {
-            if (!result.target.empty())
-                LaunchTarget(result.target);
-            if (pei->fMask & SEE_MASK_NOCLOSEPROCESS)
-                pei->hProcess = nullptr;
+            if (!result.target.empty()) LaunchTarget(result.target);
+            if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
             return TRUE;
         }
     }
     return ShellExecuteExW_orig(pei);
 }
 
-// ── Hook: ShellExecuteW ───────────────────────────────────────────────────────
-
-HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
-                                     LPCWSTR params, LPCWSTR dir, INT show) {
-    if (IsChildProcess())
-        return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
+// Hook: ShellExecuteW with DEBUG logging
+HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file, LPCWSTR params, LPCWSTR dir, INT show) {
+    if (IsChildProcess()) return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
 
     HookGuard guard;
     if (guard.IsReentrant()) {
@@ -1018,19 +942,15 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
         return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
     }
 
-    if (!g_settings.enableRedirects)
-        return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
+    if (!g_settings.enableRedirects) return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
 
-    // LOG TEMPORANEO - CATTURA TUTTO
-    Wh_Log(L"ShellExecuteW: hwnd=%p file='%s' params='%s' op='%s'",
-           hwnd,
-           file ? file : L"NULL",
-           params ? params : L"NULL",
-           op ? op : L"NULL");
-    
-    if (IsPersonalizationWindow(hwnd)) {
-        Wh_Log(L"^^^ CHIAMATA DA PERSONALIZZAZIONE! ^^^");
-    }
+    // DEBUG: Log everything that passes through ShellExecuteW
+    Wh_Log(L"DEBUG ShellExecuteW: hwnd=%p, op='%s', file='%s', params='%s', dir='%s'", 
+           hwnd, 
+           op ? op : L"(null)", 
+           file ? file : L"(null)", 
+           params ? params : L"(null)", 
+           dir ? dir : L"(null)");
 
     if (IsControlSystemParams(file, params)) {
         Wh_Log(L"ShellExecuteW: intercepted control system");
@@ -1043,115 +963,66 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
         uri = NormalizeUri(file);
     else if (IsMsSettings(params))
         uri = NormalizeUri(params);
-    else if (IsShellClsid(file)) {
+    else if (IsShellClsid(file))
         uri = ToLower(file);
-    }
-    else if (IsShellClsid(params)) {
+    else if (IsShellClsid(params))
         uri = ToLower(params);
+
+    // DEBUG: Log specifically for audio-related calls
+    if (file && (wcsstr(file, L"sound") || wcsstr(file, L"audio") || wcsstr(file, L"mmsys"))) {
+        Wh_Log(L"AUDIO DEBUG: file='%s', params='%s', uri='%s'", 
+               file, params ? params : L"(null)", uri.c_str());
+    }
+
+    // Audio URI handling
+    if (!uri.empty() && (uri.find(L"ms-settings:sound") == 0 ||
+        uri.find(L"ms-settings:audio") == 0 ||
+        uri.find(L"ms-settings:apps-volume") == 0 ||
+        uri.find(L"ms-settings:sound-devices") == 0 ||
+        uri.find(L"ms-settings:sound-output") == 0 ||
+        uri.find(L"ms-settings:sound-input") == 0)) {
+        
+        Wh_Log(L"Audio URI detected in ShellExecuteW: %s", uri.c_str());
+        CloseModernAudioWindow();
+        
+        if (OpenSoundPanel()) {
+            return SHELL_EXECUTE_SUCCESS;
+        }
     }
 
     if (!uri.empty()) {
         auto result = ResolveUri(uri, hwnd);
         if (result.intercept) {
-            if (!result.target.empty())
-                LaunchTarget(result.target);
+            if (!result.target.empty()) LaunchTarget(result.target);
             return SHELL_EXECUTE_SUCCESS;
         }
     }
     return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
 }
-// ── WinEventHook for Modern Settings Windows (Win11 workaround) ──────────────
 
-static HWINEVENTHOOK g_hModernWindowHook = nullptr;
-
-// Intercetta quando si apre una nuova finestra (Display, Ease of Access moderna)
-static void CALLBACK ModernWindowEventHook(
-    HWINEVENTHOOK hWinEventHook,
-    DWORD event,
-    HWND hwnd,
-    LONG idObject,
-    LONG idChild,
-    DWORD dwEventThread,
-    DWORD dwmsEventTime)
-{
-    if (event != EVENT_OBJECT_CREATE && event != EVENT_OBJECT_SHOW)
-        return;
-    if (!g_isWin11) return;
-    if (!hwnd || idObject != OBJID_WINDOW) return;
-    if (!IsWindow(hwnd)) return;
-
-    wchar_t cls[256] = {};
-    wchar_t title[512] = {};
-    GetClassNameW(hwnd, cls, ARRAYSIZE(cls));
-    GetWindowTextW(hwnd, title, ARRAYSIZE(title));
-    std::wstring classLower = ToLower(cls);
-    std::wstring titleLower = ToLower(title);
-
-    Wh_Log(L"ModernWindowEventHook: event=%u hwnd=%p class='%s' title='%s'", event, hwnd, cls, title);
-
-    // Controlli su qualsiasi finestra che contiene display, settings, o access nel titolo
-    if ((titleLower.find(L"display") != std::wstring::npos ||
-         titleLower.find(L"scheda") != std::wstring::npos) &&
-        classLower.find(L"applicationframewindow") != std::wstring::npos) {
-        Wh_Log(L"ModernWindowEventHook: Display-related window detected, closing and launching classic");
-        PostMessageW(hwnd, WM_CLOSE, 0, 0);
-        Sleep(100);  // Breve pausa per assicurare la chiusura
-        LaunchTarget(L"desk.cpl");
-        return;
-    }
-
-    if ((titleLower.find(L"ease") != std::wstring::npos ||
-         titleLower.find(L"access") != std::wstring::npos ||
-         titleLower.find(L"accessib") != std::wstring::npos) &&
-        classLower.find(L"applicationframewindow") != std::wstring::npos) {
-        Wh_Log(L"ModernWindowEventHook: Ease of Access window detected, closing and launching classic");
-        PostMessageW(hwnd, WM_CLOSE, 0, 0);
-        Sleep(100);
-        LaunchTarget(L"access.cpl");
-        return;
-    }
-}
-
-// ── Hook: CreateProcessW ──────────────────────────────────────────────────────
-
-BOOL WINAPI CreateProcessW_hook(
-    LPCWSTR lpApplicationName,
-    LPWSTR  lpCommandLine,
-    LPSECURITY_ATTRIBUTES lpProcessAttributes,
-    LPSECURITY_ATTRIBUTES lpThreadAttributes,
-    BOOL    bInheritHandles,
-    DWORD   dwCreationFlags,
-    LPVOID  lpEnvironment,
-    LPCWSTR lpCurrentDirectory,
-    LPSTARTUPINFOW       lpStartupInfo,
-    LPPROCESS_INFORMATION lpProcessInformation)
-{
+// Hook: CreateProcessW
+BOOL WINAPI CreateProcessW_hook(LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+                                 LPSECURITY_ATTRIBUTES lpProcessAttributes, LPSECURITY_ATTRIBUTES lpThreadAttributes,
+                                 BOOL bInheritHandles, DWORD dwCreationFlags, LPVOID lpEnvironment,
+                                 LPCWSTR lpCurrentDirectory, LPSTARTUPINFOW lpStartupInfo,
+                                 LPPROCESS_INFORMATION lpProcessInformation) {
     if (IsChildProcess()) {
-        return CreateProcessW_orig(
-            lpApplicationName, lpCommandLine,
-            lpProcessAttributes, lpThreadAttributes,
-            bInheritHandles, dwCreationFlags,
-            lpEnvironment, lpCurrentDirectory,
-            lpStartupInfo, lpProcessInformation);
+        return CreateProcessW_orig(lpApplicationName, lpCommandLine, lpProcessAttributes, lpThreadAttributes,
+                                   bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory,
+                                   lpStartupInfo, lpProcessInformation);
     }
 
     HookGuard guard;
     if (guard.IsReentrant()) {
-        return CreateProcessW_orig(
-            lpApplicationName, lpCommandLine,
-            lpProcessAttributes, lpThreadAttributes,
-            bInheritHandles, dwCreationFlags,
-            lpEnvironment, lpCurrentDirectory,
-            lpStartupInfo, lpProcessInformation);
+        return CreateProcessW_orig(lpApplicationName, lpCommandLine, lpProcessAttributes, lpThreadAttributes,
+                                   bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory,
+                                   lpStartupInfo, lpProcessInformation);
     }
 
     if (!g_settings.enableRedirects || g_settings.uiOnlyRedirects) {
-        return CreateProcessW_orig(
-            lpApplicationName, lpCommandLine,
-            lpProcessAttributes, lpThreadAttributes,
-            bInheritHandles, dwCreationFlags,
-            lpEnvironment, lpCurrentDirectory,
-            lpStartupInfo, lpProcessInformation);
+        return CreateProcessW_orig(lpApplicationName, lpCommandLine, lpProcessAttributes, lpThreadAttributes,
+                                   bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory,
+                                   lpStartupInfo, lpProcessInformation);
     }
 
     std::wstring cmdLine = lpCommandLine ? std::wstring(lpCommandLine) : L"";
@@ -1159,26 +1030,102 @@ BOOL WINAPI CreateProcessW_hook(
     if (IsControlSystemCommand(cmdLine)) {
         Wh_Log(L"CreateProcessW: intercepted 'control system': %s", lpCommandLine);
         LaunchTarget(g_isWin11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID);
-
-        if (lpProcessInformation)
-            ZeroMemory(lpProcessInformation, sizeof(PROCESS_INFORMATION));
-
+        if (lpProcessInformation) ZeroMemory(lpProcessInformation, sizeof(PROCESS_INFORMATION));
         SetLastError(ERROR_SUCCESS);
         return TRUE;
     }
 
-    return CreateProcessW_orig(
-        lpApplicationName, lpCommandLine,
-        lpProcessAttributes, lpThreadAttributes,
-        bInheritHandles, dwCreationFlags,
-        lpEnvironment, lpCurrentDirectory,
-        lpStartupInfo, lpProcessInformation);
+    return CreateProcessW_orig(lpApplicationName, lpCommandLine, lpProcessAttributes, lpThreadAttributes,
+                               bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory,
+                               lpStartupInfo, lpProcessInformation);
 }
 
-// ── Windhawk entry points ─────────────────────────────────────────────────────
+// Hook: IShellDispatch2::ShellExecute (for COM-based invocations)
+HRESULT WINAPI IShellDispatch2_ShellExecute_hook(
+    void* pThis, BSTR File, void* vArgs, void* vDir, void* vOperation, void* vShow)
+{
+    if (IsChildProcess()) {
+        return IShellDispatch2_ShellExecute_orig(pThis, File, vArgs, vDir, vOperation, vShow);
+    }
 
+    HookGuard guard;
+    if (guard.IsReentrant()) {
+        return IShellDispatch2_ShellExecute_orig(pThis, File, vArgs, vDir, vOperation, vShow);
+    }
+
+    if (!g_settings.enableRedirects || !File) {
+        return IShellDispatch2_ShellExecute_orig(pThis, File, vArgs, vDir, vOperation, vShow);
+    }
+
+    std::wstring fileStr(File);
+    std::wstring uri;
+
+    if (IsMsSettings(fileStr.c_str()))
+        uri = NormalizeUri(fileStr);
+    else if (IsShellClsid(fileStr.c_str()))
+        uri = ToLower(fileStr);
+
+    if (!uri.empty()) {
+        Wh_Log(L"IShellDispatch2::ShellExecute intercepted: %s", uri.c_str());
+        auto result = ResolveUri(uri, nullptr);
+        if (result.intercept) {
+            if (!result.target.empty()) LaunchTarget(result.target);
+            return S_OK;
+        }
+    }
+
+    return IShellDispatch2_ShellExecute_orig(pThis, File, vArgs, vDir, vOperation, vShow);
+}
+
+static const GUID IID_IUnknown_Manual = {0x00000000,0x0000,0x0000,{0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46}};
+#define IID_IUnknown IID_IUnknown_Manual
+
+// Install IShellDispatch2 COM hook (runs inside explorer.exe)
+static void InstallIShellDispatch2Hook() {
+    if (!dyn_CoCreateInstance) {
+        Wh_Log(L"IShellDispatch2 hook: COM not available");
+        return;
+    }
+    
+    IUnknown* pUnk = nullptr;
+    HRESULT hr = dyn_CoCreateInstance(&CLSID_Shell_, nullptr, 1, &IID_IUnknown, (void**)&pUnk);
+    if (FAILED(hr) || !pUnk) {
+        Wh_Log(L"IShellDispatch2 hook: CoCreateInstance failed hr=0x%08lX", hr);
+        return;
+    }
+
+    void* pDisp = nullptr;
+    hr = pUnk->QueryInterface(IID_IShellDispatch2_, &pDisp);
+    pUnk->Release();
+
+    if (FAILED(hr) || !pDisp) {
+        Wh_Log(L"IShellDispatch2 hook: QI failed hr=0x%08lX", hr);
+        return;
+    }
+
+    void** vtable = *reinterpret_cast<void***>(pDisp);
+    void* pShellExecute = vtable[37];
+
+    ((IUnknown*)pDisp)->Release();
+
+    bool ok = Wh_SetFunctionHook(pShellExecute,
+                                  (void*)IShellDispatch2_ShellExecute_hook,
+                                  (void**)&IShellDispatch2_ShellExecute_orig);
+    Wh_Log(L"IShellDispatch2::ShellExecute hook=%d addr=%p", ok, pShellExecute);
+}
+
+// Windhawk entry points
 BOOL Wh_ModInit() {
-    Wh_Log(L"Redirect Settings to Control Panel v9.8.8 init");
+    Wh_Log(L"Redirect Settings to Control Panel v9.9.6");
+    
+    // Load COM dynamically for IShellDispatch2 hook
+    g_hOle32 = LoadLibraryW(L"ole32.dll");
+    if (g_hOle32) {
+        dyn_CoCreateInstance = (CoCreateInstance_t)GetProcAddress(g_hOle32, "CoCreateInstance");
+        if (!dyn_CoCreateInstance) {
+            Wh_Log(L"Warning: CoCreateInstance not found");
+        }
+    }
 
     DetectWindowsVersion();
     LoadSettings();
@@ -1186,6 +1133,7 @@ BOOL Wh_ModInit() {
     InitMappings();
     Wh_Log(L"%zu URI mappings loaded", g_mappings.size());
 
+    // Install ShellExecute hooks
     HMODULE hShell32 = GetModuleHandleW(L"shell32.dll");
     if (!hShell32) hShell32 = LoadLibraryW(L"shell32.dll");
     if (!hShell32) {
@@ -1193,71 +1141,49 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
-    auto pExW = (void*)GetProcAddress(hShell32, "ShellExecuteExW");
-    auto pW   = (void*)GetProcAddress(hShell32, "ShellExecuteW");
+    FARPROC pExW = GetProcAddress(hShell32, "ShellExecuteExW");
+    FARPROC pW = GetProcAddress(hShell32, "ShellExecuteW");
     if (!pExW || !pW) {
         Wh_Log(L"ERROR: required exports not found in shell32.dll");
         return FALSE;
     }
 
-    bool ok1 = Wh_SetFunctionHook(pExW, (void*)ShellExecuteExW_hook,
-                                   (void**)&ShellExecuteExW_orig);
-    bool ok2 = Wh_SetFunctionHook(pW,   (void*)ShellExecuteW_hook,
-                                   (void**)&ShellExecuteW_orig);
-    Wh_Log(L"ShellExecuteExW hook=%d  ShellExecuteW hook=%d", ok1, ok2);
+    bool ok1 = Wh_SetFunctionHook((void*)pExW, (void*)ShellExecuteExW_hook, (void**)&ShellExecuteExW_orig);
+    bool ok2 = Wh_SetFunctionHook((void*)pW, (void*)ShellExecuteW_hook, (void**)&ShellExecuteW_orig);
+    Wh_Log(L"ShellExecuteExW hook=%d ShellExecuteW hook=%d", ok1, ok2);
 
     if (!ok1 && !ok2) {
         Wh_Log(L"ERROR: failed to install any hooks");
         return FALSE;
     }
 
+    // Install CreateProcessW hook
     HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
     if (!hKernel32) hKernel32 = LoadLibraryW(L"kernel32.dll");
     if (hKernel32) {
-        auto pCPW = (void*)GetProcAddress(hKernel32, "CreateProcessW");
+        FARPROC pCPW = GetProcAddress(hKernel32, "CreateProcessW");
         if (pCPW) {
-            bool ok3 = Wh_SetFunctionHook(pCPW, (void*)CreateProcessW_hook,
-                                           (void**)&CreateProcessW_orig);
+            bool ok3 = Wh_SetFunctionHook((void*)pCPW, (void*)CreateProcessW_hook, (void**)&CreateProcessW_orig);
             Wh_Log(L"CreateProcessW hook=%d", ok3);
         }
     }
 
-    // Install WinEventHook for modern window creation on Windows 11
-    // This intercepts when Display Settings or Ease of Access windows open from Personalizzazione
-    if (g_isWin11) {
-        g_hModernWindowHook = SetWinEventHook(
-            EVENT_OBJECT_CREATE,
-            EVENT_OBJECT_SHOW,
-            nullptr,
-            ModernWindowEventHook,
-            0,      // dwProcessId = 0 means all processes
-            0,      // dwThreadId = 0 means all threads
-            WINEVENT_OUTOFCONTEXT
-        );
-        if (g_hModernWindowHook) {
-            Wh_Log(L"ModernWindowEventHook installed for Win11");
-        } else {
-            Wh_Log(L"Failed to install ModernWindowEventHook");
-        }
-    }
+    // Install COM hook for IShellDispatch2 (for deeper interception)
+    InstallIShellDispatch2Hook();
 
     Wh_Log(L"Ready — EnableRedirects=%d UIOnly=%d SmartPers=%d Fallback=%d Win11Compat=%d MaxLaunches=%d",
-        (int)g_settings.enableRedirects,
-        (int)g_settings.uiOnlyRedirects,
-        (int)g_settings.smartPersonalizationDetect,
-        g_settings.fallbackMode,
-        (int)g_settings.win11CompatibilityMode,
-        g_settings.maxLaunchesPerUri);
+        (int)g_settings.enableRedirects, (int)g_settings.uiOnlyRedirects, (int)g_settings.smartPersonalizationDetect,
+        g_settings.fallbackMode, (int)g_settings.win11CompatibilityMode, g_settings.maxLaunchesPerUri);
+
     return TRUE;
 }
 
 void Wh_ModUninit() {
-    if (g_hModernWindowHook) {
-        UnhookWinEvent(g_hModernWindowHook);
-        g_hModernWindowHook = nullptr;
-        Wh_Log(L"ModernWindowEventHook uninstalled");
+    if (g_hOle32) {
+        FreeLibrary(g_hOle32);
+        g_hOle32 = nullptr;
     }
-    Wh_Log(L"Unloaded.");
+    Wh_Log(L"Redirect Settings to Control Panel v9.9.6 unloaded.");
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -2,18 +2,72 @@
 // @id             settings-to-control-panel
 // @name           Redirect Settings to Control Panel
 // @description    Forces classic Control Panel to open instead of Windows 10/11 Settings app using native components. Primarily designed for Windows 10; Windows 11 support is limited due to Microsoft's shell architecture changes.
-// @version        10.0.0
+// @version        10.0.1
 // @author         babamohammed
 // @github         https://github.com/babamohammed2022
 // @include        explorer.exe
-// @include        SystemSettings.exe
-// @include        StartMenuExperienceHost.exe
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
-# Redirect Settings → Control Panel (v10.0.0)
+# Redirect Settings → Control Panel
 
-Debug version - logging all ShellExecuteW calls to diagnose audio tray issues.
+This mod intercepts modern `ms-settings:` URIs and redirects them to their
+corresponding classic Control Panel applets using only native Windows components.
+
+---
+
+## Compatibility
+
+- **Windows 10** – Mostly complete support
+- **Windows 11** – Partial support (some redirects may vary by build)
+
+---
+
+## Features
+
+- Redirects numerous `ms-settings:` URIs to classic Control Panel
+- Smart personalization detection (desktop vs in-window)
+- Anti-loop protection
+- Configurable fallback modes
+
+---
+
+## Configuration
+
+- **EnableRedirects** – Turn the mod on or off
+- **UIOnlyRedirects** – Only redirect clicks (safer, may miss some)
+- **FallbackMode** – What to do when no classic page exists:
+  - `0` = ignore (do nothing)
+  - `1` = open Control Panel
+  - `2` = open modern Settings (default)
+- **Win11CompatibilityMode** – Extra safety for Windows 11
+- **MaxLaunchesPerUri** – Prevents infinite loops (default: 3 launches per 5 seconds)
+
+---
+## Limitations
+
+- System tray icons (audio/network) use DCOM activation and cannot be intercepted (This could change in future)
+- Windows 11 support is limited due to Microsoft's architectural changes and some redirects might change based on versions.
+
+---
+
+## How It Works
+
+The mod hooks:
+- `ShellExecuteExW` / `ShellExecuteW`
+- `CreateProcessW`
+- `IShellDispatch2::ShellExecute`
+
+When a `ms-settings:` URI is detected, it launches the corresponding classic
+Control Panel target instead of the modern Settings app.
+
+---
+
+## Credits
+
+- m417z – Code reviews and feedback
+- Anixx – Testing on Windows 11 23H2
+- dbilanoski – CLSID documentation
 */
 // ==/WindhawkModReadme==
 // ==WindhawkModSettings==
@@ -48,8 +102,7 @@ Debug version - logging all ShellExecuteW calls to diagnose audio tray issues.
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <mutex>
-#include <shobjidl.h>     
+#include <mutex>   
 #include <initguid.h>  
 
 // Dynamic COM handling - no linking required
@@ -61,18 +114,15 @@ static HMODULE g_hOle32 = nullptr;
 using IShellDispatch2_ShellExecute_t = HRESULT(WINAPI*)(void* pThis, BSTR File, void* vArgs, void* vDir, void* vOperation, void* vShow);
 static IShellDispatch2_ShellExecute_t IShellDispatch2_ShellExecute_orig = nullptr;
 
-// CLSID_Shell / IID_IShellDispatch2
-static const GUID CLSID_Shell_ = {0x13709620,0xC279,0x11CE,{0xA4,0x9E,0x44,0x45,0x53,0x54,0x00,0x00}};
-static const GUID IID_IShellDispatch2_ = {0xA4C6892C,0x3BA9,0x11D2,{0x9D,0xEA,0x00,0xC0,0x4F,0xB9,0x60,0x3F}};
-
 // Constants
 static const HINSTANCE SHELL_EXECUTE_SUCCESS = (HINSTANCE)33;
-
-#define SYSTEM_PROPS_CLSID  L"shell:::{BB06C0E4-D293-4f75-8A90-CB05B6477EEE}"
-#define NOTIF_AREA_CLSID    L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"
+#define PERS_ED_CLSID   L"shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"
 #define PERS_ROOT       L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921}"
 #define PERS_WALLPAPER  L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921} -Microsoft.Personalization\\pageWallpaper"
 #define PERS_COLORS     L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921} -Microsoft.Personalization\\pageColorization"
+
+#define SYSTEM_PROPS_CLSID  L"shell:::{BB06C0E4-D293-4f75-8A90-CB05B6477EEE}"
+#define NOTIF_AREA_CLSID    L"shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}"
 #define WIN11_PASSTHROUGH L"__PASSTHROUGH__"
 #define EASE_OF_ACCESS  L"explorer shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"
 
@@ -84,6 +134,12 @@ using ShellExecuteW_t = HINSTANCE(WINAPI*)(HWND, LPCWSTR, LPCWSTR, LPCWSTR, LPCW
 using ShellExecuteExW_t = BOOL(WINAPI*)(SHELLEXECUTEINFOW*);
 static ShellExecuteExW_t ShellExecuteExW_orig = nullptr;
 static ShellExecuteW_t ShellExecuteW_orig = nullptr;
+
+// Core resolve logic struct - MUST be defined before use
+struct ResolveResult {
+    std::wstring target;
+    bool intercept;
+};
 
 // Reentry guards
 static thread_local int g_hookDepth = 0;
@@ -121,7 +177,6 @@ static bool IsChildProcess() {
 struct ModSettings {
     bool enableRedirects = true;
     bool uiOnlyRedirects = false;
-    // SmartPersonalizationDetection è sempre attivo (rimosso dalle impostazioni utente)
     int fallbackMode = 2;
     bool win11CompatibilityMode = false;
     int maxLaunchesPerUri = 3;
@@ -132,7 +187,6 @@ static ModSettings g_settings;
 static void LoadSettings() {
     g_settings.enableRedirects = Wh_GetIntSetting(L"EnableRedirects") != 0;
     g_settings.uiOnlyRedirects = Wh_GetIntSetting(L"UIOnlyRedirects") != 0;
-    // SmartPersonalizationDetection è sempre attivo, non viene più letto dalle impostazioni
 
     PCWSTR fallbackStr = Wh_GetStringSetting(L"FallbackMode");
     if (fallbackStr[0] != L'\0') {
@@ -170,6 +224,35 @@ static void DetectWindowsVersion() {
     Wh_Log(L"Build %lu IsWin11=%d", osvi.dwBuildNumber, (int)g_isWin11);
 }
 
+// Bounce-back guard
+struct BounceRecord {
+    DWORD lastRedirectTick = 0;
+};
+
+static std::mutex g_bounceGuardMtx;
+static std::unordered_map<std::wstring, BounceRecord> g_bounceGuard;
+
+static constexpr DWORD BOUNCE_WINDOW_MS = 3000;
+
+static void BounceGuardRecord(const std::wstring& uri) {
+    std::lock_guard<std::mutex> lk(g_bounceGuardMtx);
+    g_bounceGuard[uri].lastRedirectTick = GetTickCount();
+}
+
+static bool BounceGuardIsBounce(const std::wstring& uri) {
+    std::lock_guard<std::mutex> lk(g_bounceGuardMtx);
+    auto it = g_bounceGuard.find(uri);
+    if (it == g_bounceGuard.end()) return false;
+    DWORD elapsed = GetTickCount() - it->second.lastRedirectTick;
+    if (elapsed < BOUNCE_WINDOW_MS) {
+        Wh_Log(L"BOUNCE-BACK: '%s' returned %lu ms after redirect — target is dead, routing to fallback",
+               uri.c_str(), elapsed);
+        it->second.lastRedirectTick = 0;
+        return true;
+    }
+    return false;
+}
+
 // Loop guard
 struct LaunchRecord {
     int count = 0;
@@ -179,7 +262,7 @@ struct LaunchRecord {
 static std::mutex g_loopGuardMtx;
 static std::unordered_map<std::wstring, LaunchRecord> g_loopGuard;
 
-static constexpr DWORD LOOP_WINDOW_MS = 3000;
+static constexpr DWORD LOOP_WINDOW_MS = 5000;
 
 static bool LoopGuardAllow(const std::wstring& target) {
     if (g_settings.maxLaunchesPerUri <= 0) return true;
@@ -219,6 +302,19 @@ static const std::unordered_set<std::wstring> g_win11SafeClsids = {
     L"shell:::{bd84b380-8ca2-1069-ab1d-08000948f534}",
     L"shell:::{d9ef8727-cac2-4e60-809e-86f80a666c91}",
     L"shell:::{c58c4893-3be0-4b45-abb5-a63e4b8c8651}",
+    L"shell:::{6dfd7c5c-2451-11d3-a299-00c04f8ef6af}",
+    L"shell:::{15eae92e-f17a-4431-9f28-805e482dafd4}",
+    L"shell:::{d450a8a1-9568-45c7-9c0e-b4f9fb4537bd}",
+    L"shell:::{26ee0668-a00a-44d7-9371-beb064c98683}",
+    L"shell:::{725be8f7-668e-4c7b-8f90-46bdb0936430}",
+    L"shell:::{f02c1a0d-be21-4350-88b0-7367fc96ef3c}",
+    L"shell:::{bb64f8a7-bee7-4e1a-ab8d-7d8273f7fdb6}",
+    L"shell:::{025a5937-a6be-4686-a844-36fe4bec8b6d}",
+    L"shell:::{d17d1d6d-cc3f-4815-8fe3-607e7d5d10b3}",
+    L"shell:::{7a9d77bd-5403-11d2-8785-2e0420524153}",
+    L"shell:::{ecd0924-4208-451e-8ee0-373c0956de16}",
+    L"shell:::{ed7ba470-8e54-465e-825c-99712043e01c}",
+    L"shell:::{d555645e-d4f8-4c29-a827-d93c859c4f2a}",
 };
 
 static const std::unordered_set<std::wstring> g_win11LoopClsids = {
@@ -279,12 +375,14 @@ static void InitMappings() {
         {L"ms-settings:display-advanced-color", L"colorcpl.exe"},
         {L"ms-settings:colorcpl", L"colorcpl.exe"},
         
-        // Display (using rundll32 for advanced properties)
+        // Display
         {L"ms-settings:display", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         {L"ms-settings:display-advanced", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         {L"ms-settings:display-advanced-graphics", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         {L"ms-settings:graphics-settings", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         {L"ms-settings:display-adapter-properties", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
+        {L"ms-settings:display-resolution", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
+        {L"ms-settings:screenrotation", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         
         // System
         {L"ms-settings:about", w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
@@ -301,6 +399,7 @@ static void InitMappings() {
         {L"ms-settings:appsfeatures", L"appwiz.cpl"},
         {L"ms-settings:appsforwebsites", L"appwiz.cpl"},
         {L"ms-settings:optionalfeatures", L"OptionalFeatures.exe"},
+        {L"ms-settings:system-settings", L"shell:::{025A5937-A6BE-4686-A844-36FE4BEC8B6D}\\pageGlobalSettings"},
         
         // Power
         {L"ms-settings:powersleep", L"powercfg.cpl"},
@@ -355,13 +454,19 @@ static void InitMappings() {
         {L"ms-settings:network", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         {L"ms-settings:network-wifi", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         {L"ms-settings:network-ethernet", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-vpn", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-airplanemode", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-mobilehotspot", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:network-cellular", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        {L"ms-settings:datausage", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         {L"ms-settings:network-proxy", L"inetcpl.cpl,,4"},
         {L"ms-settings:network-status", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
         {L"ms-settings:network-dialup", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
-        {L"ms-settings:network-advancedsettings", L"shell:::{7007ACC7-3202-11D1-AAD2-00805FC1270E}"},
+        {L"ms-settings:network-advancedsettings", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         {L"ms-settings:firewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
         {L"ms-settings:network-firewall", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
         {L"ms-settings:windowsdefender", L"shell:::{4026492F-2F69-46B8-B9BF-5654FC07E423}"},
+        {L"ms-settings:network-places", L"shell:::{F02C1A0D-BE21-4350-88B0-7367FC96EF3C}"},
         
         // Accounts
         {L"ms-settings:yourinfo", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
@@ -369,6 +474,8 @@ static void InitMappings() {
         {L"ms-settings:emailandaccounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
         {L"ms-settings:accounts", L"shell:::{60632754-c523-4b62-b45c-4172da012619}"},
         {L"ms-settings:startupapps", L"msconfig.exe"},
+        {L"ms-settings:netplwiz", L"shell:::{7A9D77BD-5403-11d2-8785-2E0420524153}"},
+        {L"ms-settings:workplace", L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{ECDB0924-4208-451E-8EE0-373C0956DE16}"},
         
         // Default Apps
         {L"ms-settings:defaultapps", w11 ? WIN11_PASSTHROUGH : L"shell:::{17cd9488-1228-4b2f-88ce-4298e93e0966}"},
@@ -400,7 +507,6 @@ static void InitMappings() {
         {L"ms-settings:recovery", w11 ? L"control.exe" : L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
         {L"ms-settings:troubleshoot", w11 ? L"msdt.exe -id DeviceDiagnostic" : L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
         {L"ms-settings:deviceencryption", L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
-        // --- Redirections to classic panels (verified) --- source: https://gist.github.com/dbilanoski/3670be6d81b48cde29d40e48e41e0a48
         
         // Gaming
         {L"ms-settings:gaming-gamebar", L"joy.cpl"},
@@ -409,28 +515,19 @@ static void InitMappings() {
         {L"ms-settings:folders", L"shell:::{6DFD7C5C-2451-11d3-A299-00C04F8EF6AF}"},
         
         // Get Programs (modern: Apps & Features)
-        {L"ms-settings:appsfeatures", L"shell:::{15eae92e-f17a-4431-9f28-805e482dafd4}"},
+        {L"ms-settings:appsfeatures-app", L"shell:::{15eae92e-f17a-4431-9f28-805e482dafd4}"},
         
         // Installed Updates
         {L"ms-settings:windowsupdate-history", L"shell:::{d450a8a1-9568-45c7-9c0e-b4f9fb4537bd}"},
         
         // History (Troubleshooting)
-        {L"ms-settings:troubleshoot", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}\\historyPage"},
+        {L"ms-settings:troubleshoot-history", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}\\historyPage"},
         
         // Keyboard
-        {L"ms-settings:keyboard", L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{725BE8F7-668E-4C7B-8F90-46BDB0936430}"},
+        {L"ms-settings:keyboard-advanced", L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{725BE8F7-668E-4C7B-8F90-46BDB0936430}"},
         
         // Keyboard Properties
         {L"ms-settings:keyboard-properties", L"shell:::{725BE8F7-668E-4C7B-8F90-46BDB0936430}"},
-        
-        // Network (Places)
-        {L"ms-settings:network-places", L"shell:::{F02C1A0D-BE21-4350-88B0-7367FC96EF3C}"},
-        
-        // Network and Internet
-        {L"ms-settings:network", L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\3"},
-        
-        // Network and Sharing Centre (already in mappings, kept for clarity)
-        {L"ms-settings:network-advancedsettings", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
         
         // Problem Details / Reports
         {L"ms-settings:privacy-feedback", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}\\pageReportDetails"},
@@ -441,26 +538,14 @@ static void InitMappings() {
         // Problem Reports (list)
         {L"ms-settings:problem-reports", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}\\pageProblems"},
         
-        // Recovery (already in mappings, kept for clarity)
-        {L"ms-settings:recovery", w11 ? L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{9FE63AFD-59CF-4419-9775-ABCC3849F861}" : L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
-        
         // Reliability Monitor
         {L"ms-settings:reliability", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}\\pageReliabilityView"},
-        
-        // System Settings
-        {L"ms-settings:system-settings", L"shell:::{025A5937-A6BE-4686-A844-36FE4BEC8B6D}\\pageGlobalSettings"},
         
         // Speech Properties
         {L"ms-settings:speech", L"shell:::{D17D1D6D-CC3F-4815-8FE3-607E7D5D10B3}"},
         
         // Search Troubleshooting
         {L"ms-settings:search-diagnostics", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}\\searchPage"},
-        
-        // User Accounts (netplwiz)
-        {L"ms-settings:netplwiz", L"shell:::{7A9D77BD-5403-11d2-8785-2E0420524153}"},
-        
-        // Work Folders
-        {L"ms-settings:workplace", L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{ECDB0924-4208-451E-8EE0-373C0956DE16}"},
         
         // Control Panel All Tasks
         {L"ms-settings:controlpanel", L"shell:::{ED7BA470-8E54-465E-825C-99712043E01C}"},
@@ -476,6 +561,8 @@ static void InitMappings() {
         g_mappings[L"ms-settings:storage"] = L"control.exe";
         g_mappings[L"ms-settings:storagesense"] = L"control.exe";
         g_mappings[L"ms-settings:backup"] = L"control.exe /name Microsoft.BackupAndRestore";
+        g_mappings[L"ms-settings:network-advancedsettings"] = L"control.exe /name Microsoft.NetworkAndSharingCenter";
+        g_mappings[L"ms-settings:recovery"] = L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{9FE63AFD-59CF-4419-9775-ABCC3849F861}";
     }
 }
 
@@ -565,7 +652,7 @@ static bool HandleFallback(const std::wstring& uri) {
     }
 }
 
-// LaunchTarget
+// LaunchTarget - VERSIONE CORRETTA
 static void LaunchTarget(const std::wstring& command) {
     Wh_Log(L"Launching: %s", command.c_str());
 
@@ -575,40 +662,27 @@ static void LaunchTarget(const std::wstring& command) {
     }
 
     std::wstring lower = ToLower(command);
-
-    // Handle rundll32.exe specially (needs comma in arguments)
-    if (command.find(L"rundll32.exe") != std::wstring::npos) {
-        std::wstring mutable_cmd = command;
-        STARTUPINFOW si = {};
-        si.cb = sizeof(si);
-        PROCESS_INFORMATION pi = {};
-        if (!CreateProcessW_orig(nullptr, mutable_cmd.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
-            Wh_Log(L"rundll32 CreateProcess failed for '%s' (%lu)", command.c_str(), GetLastError());
-        } else {
-            CloseHandle(pi.hProcess);
-            CloseHandle(pi.hThread);
-        }
-        return;
-    }
-
-    // Handle "explorer shell:::" directly
+    
+    // PER I COMANDI "explorer shell:::" USA ShellExecuteExW
     if (lower.find(L"explorer shell:::") != std::wstring::npos) {
-        std::wstring clsid = command.substr(command.find(L"shell:::"));
         SHELLEXECUTEINFOW sei = {};
         sei.cbSize = sizeof(sei);
         sei.fMask = SEE_MASK_FLAG_NO_UI;
         sei.lpVerb = L"open";
-        sei.lpFile = clsid.c_str();
+        sei.lpFile = L"explorer.exe";
+        sei.lpParameters = command.c_str() + 9; // Salta "explorer " (9 caratteri)
         sei.nShow = SW_SHOWNORMAL;
+        
+        Wh_Log(L"Using ShellExecuteExW: explorer.exe params='%s'", sei.lpParameters);
         ShellExecuteExW_orig(&sei);
         return;
     }
-
-    // Full command line detection
-    bool isFullCmdLine = (lower.find(L"rundll32.exe ") != std::wstring::npos) ||
-                         (lower.find(L"explorer.exe ") != std::wstring::npos) ||
-                         (lower.find(L"msdt.exe ") != std::wstring::npos) ||
-                         (lower.find(L"control.exe /") != std::wstring::npos);
+    
+    // Comandi completi con percorso eseguibile
+    bool isFullCmdLine =
+        (lower.find(L"rundll32.exe ") != std::wstring::npos) ||
+        (lower.find(L"explorer.exe ") != std::wstring::npos) ||
+        (lower.find(L"control.exe /") != std::wstring::npos);
 
     if (isFullCmdLine) {
         STARTUPINFOW si = {};
@@ -617,13 +691,24 @@ static void LaunchTarget(const std::wstring& command) {
         si.wShowWindow = SW_SHOWNORMAL;
         PROCESS_INFORMATION pi = {};
         std::wstring mutable_cmd = command;
-        if (!CreateProcessW_orig(nullptr, mutable_cmd.data(), nullptr, nullptr, FALSE, CREATE_UNICODE_ENVIRONMENT,
-                                 (LPVOID)g_childEnvBlock.c_str(), nullptr, &si, &pi)) {
-            Wh_Log(L"CreateProcess failed for '%s' (%lu)", command.c_str(), GetLastError());
+        if (!CreateProcessW_orig(nullptr, mutable_cmd.data(), nullptr, nullptr,
+                                 FALSE, CREATE_UNICODE_ENVIRONMENT,
+                                 (LPVOID)g_childEnvBlock.c_str(),
+                                 nullptr, &si, &pi)) {
+            Wh_Log(L"CreateProcess failed for '%s' (%lu)",
+                   command.c_str(), GetLastError());
         } else {
             CloseHandle(pi.hProcess);
             CloseHandle(pi.hThread);
         }
+        return;
+    }
+
+    // UAC targets
+    if (command == L"devmgmt.msc" || command == L"compmgmt.msc" ||
+        command == L"slui.exe" || command == L"OptionalFeatures.exe") {
+        ShellExecuteW_orig(nullptr, L"open", command.c_str(),
+                           nullptr, nullptr, SW_SHOWNORMAL);
         return;
     }
 
@@ -634,37 +719,21 @@ static void LaunchTarget(const std::wstring& command) {
     si.wShowWindow = SW_SHOWNORMAL;
     PROCESS_INFORMATION pi = {};
     std::wstring cmdLine;
-    // Special handling for control.exe with /name parameter
-if (command.find(L"control.exe /name") != std::wstring::npos) {
-    std::wstring mutable_cmd = command;
-    STARTUPINFOW si = {};
-    si.cb = sizeof(si);
-    si.dwFlags = STARTF_USESHOWWINDOW;
-    si.wShowWindow = SW_SHOWNORMAL;
-    PROCESS_INFORMATION pi = {};
-    if (CreateProcessW_orig(nullptr, mutable_cmd.data(), nullptr, nullptr, FALSE, 
-                            CREATE_UNICODE_ENVIRONMENT, (LPVOID)g_childEnvBlock.c_str(), 
-                            nullptr, &si, &pi)) {
-        CloseHandle(pi.hProcess);
-        CloseHandle(pi.hThread);
-    } else {
-        Wh_Log(L"CreateProcess failed for '%s' (%lu)", command.c_str(), GetLastError());
-    }
-    return;
-}
+
     if (command.find(L".msc") != std::wstring::npos) {
         cmdLine = L"mmc.exe \"" + command + L"\"";
     } else if (command.find(L".cpl") != std::wstring::npos) {
         cmdLine = L"control.exe " + command;
-        
     } else if (command.find(L".exe") != std::wstring::npos) {
         cmdLine = command;
     } else if (command.find(L"shell:::") == 0) {
+        // CLSID puro - usa explorer.exe
         SHELLEXECUTEINFOW sei = {};
         sei.cbSize = sizeof(sei);
         sei.fMask = SEE_MASK_FLAG_NO_UI;
         sei.lpVerb = L"open";
-        sei.lpFile = command.c_str();
+        sei.lpFile = L"explorer.exe";
+        sei.lpParameters = command.c_str();
         sei.nShow = SW_SHOWNORMAL;
         ShellExecuteExW_orig(&sei);
         return;
@@ -674,134 +743,25 @@ if (command.find(L"control.exe /name") != std::wstring::npos) {
         cmdLine = L"control.exe " + command;
     }
 
-    std::wstring mutableCmd = cmdLine;
-    if (!CreateProcessW_orig(nullptr, mutableCmd.data(), nullptr, nullptr, FALSE, CREATE_UNICODE_ENVIRONMENT,
-                             (LPVOID)g_childEnvBlock.c_str(), nullptr, &si, &pi)) {
-        Wh_Log(L"CreateProcess failed for '%s' (error %lu)", cmdLine.c_str(), GetLastError());
-        return;
-    }
-    CloseHandle(pi.hProcess);
-    CloseHandle(pi.hThread);
-}
-
-// Personalization detection - sempre attiva
-static bool IsPersonalizationWindow(HWND hwnd) {
-    if (!hwnd) {
-        hwnd = GetForegroundWindow();
-        if (!hwnd) return false;
-    }
-
-    HWND h = hwnd;
-    while (h) {
-        wchar_t cls[256] = {};
-        wchar_t title[512] = {};
-        GetClassNameW(h, cls, 256);
-        GetWindowTextW(h, title, 512);
-        std::wstring c = ToLower(cls);
-        std::wstring t = ToLower(title);
-
-        if (c == L"progman" || c == L"workerw" || c == L"shelldll_defview") return false;
-        if (c == L"cabinetwclass" && t.find(L"personaliz") != std::wstring::npos) return true;
-        if (t.find(L"personaliz") != std::wstring::npos) return true;
-
-        HWND parent = GetParent(h);
-        if (!parent || parent == h) break;
-        h = parent;
-    }
-    return false;
-}
-
-static std::wstring ResolvePersonalizationBackground(HWND hwnd) {
-    // SmartPersonalizationDetection è sempre attivo
-    if (IsPersonalizationWindow(hwnd)) {
-        Wh_Log(L"personalization-background -> wallpaper page (smart detection always active)");
-        return PERS_WALLPAPER;
-    }
-    Wh_Log(L"personalization-background -> Personalization root (smart detection always active)");
-    return PERS_ROOT;
-}
-
-// Audio window closing (workaround for modern windows)
-static bool g_isClosingAudioWindow = false;
-
-static void CloseModernAudioWindow() {
-    if (g_isClosingAudioWindow) {
-        Wh_Log(L"CloseModernAudioWindow: already running, skipping");
-        return;
-    }
-    g_isClosingAudioWindow = true;
-    
-    Wh_Log(L"CloseModernAudioWindow: searching for modern audio windows");
-    
-    HWND hwnd = FindWindowW(L"ApplicationFrameWindow", nullptr);
-    bool found = false;
-    
-    while (hwnd && !found) {
-        if (IsWindowVisible(hwnd)) {
-            DWORD processId = 0;
-            GetWindowThreadProcessId(hwnd, &processId);
-            
-            HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, processId);
-            if (hProcess) {
-                wchar_t processPath[MAX_PATH] = {0};
-                DWORD size = MAX_PATH;
-                if (QueryFullProcessImageNameW(hProcess, 0, processPath, &size)) {
-                    std::wstring processName = ToLower(processPath);
-                    
-                    if (processName.find(L"systemsettings.exe") != std::wstring::npos ||
-                        processName.find(L"settings.exe") != std::wstring::npos ||
-                        processName.find(L"windows.immersivecontrolpanel") != std::wstring::npos) {
-                        
-                        HWND childHwnd = FindWindowExW(hwnd, nullptr, L"Windows.UI.Core.CoreWindow", nullptr);
-                        if (childHwnd) {
-                            wchar_t className[256] = {0};
-                            GetClassNameW(childHwnd, className, 256);
-                            std::wstring classNameStr = ToLower(className);
-                            
-                            if (classNameStr.find(L"audio") != std::wstring::npos ||
-                                classNameStr.find(L"sound") != std::wstring::npos) {
-                                
-                                Wh_Log(L"CloseModernAudioWindow: found audio window (process: %s, class: %s)", 
-                                       processPath, className);
-                                PostMessageW(hwnd, WM_CLOSE, 0, 0);
-                                found = true;
-                            }
-                        }
-                        
-                        if (!found) {
-                            wchar_t windowTitle[256] = {0};
-                            GetWindowTextW(hwnd, windowTitle, 256);
-                            std::wstring title = ToLower(windowTitle);
-                            
-                            if (title.find(L"audio") != std::wstring::npos ||
-                                title.find(L"sound") != std::wstring::npos ||
-                                title.find(L"suono") != std::wstring::npos) {
-                                
-                                Wh_Log(L"CloseModernAudioWindow: found audio window by title (process: %s, title: %s)", 
-                                       processPath, windowTitle);
-                                PostMessageW(hwnd, WM_CLOSE, 0, 0);
-                                found = true;
-                            }
-                        }
-                    }
-                }
-                CloseHandle(hProcess);
-            }
+    if (!cmdLine.empty()) {
+        std::wstring mutableCmd = cmdLine;
+        if (!CreateProcessW_orig(nullptr, mutableCmd.data(), nullptr, nullptr,
+                                 FALSE, CREATE_UNICODE_ENVIRONMENT,
+                                 (LPVOID)g_childEnvBlock.c_str(),
+                                 nullptr, &si, &pi)) {
+            Wh_Log(L"CreateProcess failed for '%s' (error %lu)",
+                   cmdLine.c_str(), GetLastError());
+            return;
         }
-        
-        if (!found) {
-            hwnd = FindWindowExW(nullptr, hwnd, L"ApplicationFrameWindow", nullptr);
-        } else {
-            break;
-        }
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
     }
-    
-    if (!found) {
-        Wh_Log(L"CloseModernAudioWindow: no modern audio window found");
-    }
-    
-    g_isClosingAudioWindow = false;
 }
+// Personalization detection
+
+
+
+
 
 // Helper function to open sound panel
 static bool OpenSoundPanel() {
@@ -810,92 +770,88 @@ static bool OpenSoundPanel() {
     return true;
 }
 
-// Core resolve logic
-struct ResolveResult {
-    std::wstring target;
-    bool intercept;
-};
+static bool IsPersonalizationWindow(HWND hwnd) {
+    if (!hwnd) {
+        Wh_Log(L"HWND null -> desktop context menu path");
+        return false;
+    }
 
+    HWND h = hwnd;
+    while (h) {
+        wchar_t cls[256]   = {};
+        wchar_t title[512] = {};
+        GetClassNameW(h, cls, 256);
+        GetWindowTextW(h, title, 512);
+
+        std::wstring c = ToLower(cls);
+        std::wstring t = ToLower(title);
+
+        if (c == L"progman" || c == L"workerw" || c == L"shelldll_defview") {
+            Wh_Log(L"HWND: desktop class '%s' -> context menu", cls);
+            return false;
+        }
+        if (c == L"cabinetwclass") {
+            return true;
+        }
+        if (t.find(L"personaliz") != std::wstring::npos) {
+            Wh_Log(L"HWND: title match 'personaliz' -> Personalization window");
+            return true;
+        }
+
+        HWND parent = GetParent(h);
+        if (!parent || parent == h) break;
+        h = parent;
+    }
+
+    Wh_Log(L"HWND: no personalization window found -> context menu");
+    return false;
+}
+
+static std::wstring ResolvePersonalizationBackground(HWND hwnd) {
+    if (IsPersonalizationWindow(hwnd)) {
+        Wh_Log(L"personalization-background -> wallpaper page");
+        return PERS_WALLPAPER;
+    }
+    Wh_Log(L"personalization-background -> Personalization root");
+    return PERS_ROOT;
+}
 static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
-    // Win11: some URIs should not be forced
-    if (g_isWin11 && g_win11NoForceRedirect.count(uri) > 0) {
-        Wh_Log(L"Win11 whitelist: skipping redirect for %s (pass-through)", uri.c_str());
-        return {L"", false};
-    }
-    
-    // Audio URI detection with window closing
-    if (uri.find(L"ms-settings:sound") == 0 ||
-        uri.find(L"ms-settings:audio") == 0 ||
-        uri.find(L"ms-settings:apps-volume") == 0 ||
-        uri.find(L"ms-settings:sound-devices") == 0 ||
-        uri.find(L"ms-settings:sound-output") == 0 ||
-        uri.find(L"ms-settings:sound-input") == 0) {
-        Wh_Log(L"Audio URI detected, closing modern windows");
-        CloseModernAudioWindow();
-    }
-    
-    // Personalization Background (smart detection sempre attiva)
     if (uri == L"ms-settings:personalization-background") {
+        if (BounceGuardIsBounce(uri)) {
+            Wh_Log(L"Bounce-back on personalization-background - suppressing duplicate, target is opening");
+            return {L"", true};
+        }
         std::wstring t = ApplyWin11Filter(ResolvePersonalizationBackground(hwnd));
-        Wh_Log(L"personalization-background -> %s", t.c_str());
+        BounceGuardRecord(uri);
         return {t, true};
     }
 
-    // Display settings (use rundll32 for advanced properties)
-    if (uri == L"ms-settings:display" ||
-        uri == L"ms-settings:display-advanced" ||
-        uri == L"ms-settings:display-advanced-graphics" ||
-        uri == L"ms-settings:graphics-settings" ||
-        uri == L"ms-settings:display-adapter-properties" ||
-        uri == L"ms-settings:display-resolution" ||
-        uri == L"ms-settings:screenrotation") {
-        std::wstring t = L"rundll32.exe display.dll,ShowAdapterSettings 0";
-        Wh_Log(L"Display redirect: %s -> %s", uri.c_str(), t.c_str());
-        return {t, true};
-    }
-
-    // Ease of Access (use control.exe /name to avoid CLSID loops)
-    if (uri == L"ms-settings:easeofaccess" ||
-        uri.find(L"ms-settings:easeofaccess-") == 0) {
-        std::wstring t = EASE_OF_ACCESS;
-        Wh_Log(L"EaseOfAccess redirect: %s -> %s", uri.c_str(), t.c_str());
-        return {t, true};
-    }
-
-    // Personalization CLSID handling (from inside classic CPL)
-    if (uri.find(L"shell:::{ed834ed6-4b5a-4bfe-8f11-a626dcb6a921}") == 0) {
-        if (uri.find(L"pagewallpaper") != std::wstring::npos) {
-            Wh_Log(L"Personalization CLSID: forcing wallpaper for '%s'", uri.c_str());
-            return {PERS_WALLPAPER, true};
-        }
-        if (uri.find(L"pagecolorization") != std::wstring::npos) {
-            Wh_Log(L"Personalization CLSID: forcing colors for '%s'", uri.c_str());
-            return {PERS_COLORS, true};
-        }
-        Wh_Log(L"Personalization CLSID: forcing root for '%s'", uri.c_str());
-        return {PERS_ROOT, true};
-    }
-
-    // Check mappings table
     auto it = g_mappings.find(uri);
     if (it != g_mappings.end()) {
-        std::wstring t = ApplyWin11Filter(it->second);
-        if (t == WIN11_PASSTHROUGH) {
-            Wh_Log(L"Passthrough sentinel for '%s'", uri.c_str());
+        if (BounceGuardIsBounce(uri)) {
+            Wh_Log(L"Bounce-back on '%s', routing to fallback", uri.c_str());
             bool handled = HandleFallback(uri);
             return {L"", handled};
         }
+
+        std::wstring t = ApplyWin11Filter(it->second);
+
+        if (t == WIN11_PASSTHROUGH) {
+            Wh_Log(L"Passthrough sentinel for '%s', routing to fallback", uri.c_str());
+            bool handled = HandleFallback(uri);
+            return {L"", handled};
+        }
+
         Wh_Log(L"Mapped: %s -> %s", uri.c_str(), t.c_str());
+        BounceGuardRecord(uri);
         return {t, true};
     }
 
-    // Unmapped ms-settings: URI
     if (uri.find(L"ms-settings:") == 0) {
         bool handled = HandleFallback(uri);
         return {L"", handled};
     }
 
-    // Unmapped shell::: CLSID (only intercept known loop CLSIDs on Win11)
     if (uri.find(L"shell:::") == 0) {
         if (g_isWin11 && IsClsidLoopOnWin11(uri)) {
             std::wstring t = ApplyWin11Filter(uri);
@@ -907,7 +863,6 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
     Wh_Log(L"Unmapped, passing through: %s", uri.c_str());
     return {L"", false};
 }
-
 // Control system detection helpers
 static std::wstring BaseNameLower(const std::wstring& path) {
     size_t pos = path.rfind(L'\\');
@@ -986,9 +941,7 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
         uri.find(L"ms-settings:sound-devices") == 0 ||
         uri.find(L"ms-settings:sound-output") == 0 ||
         uri.find(L"ms-settings:sound-input") == 0)) {
-        
-        Wh_Log(L"Audio URI detected in ShellExecuteExW: %s", uri.c_str());
-        CloseModernAudioWindow();
+
         
         if (OpenSoundPanel()) {
             if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
@@ -1019,13 +972,6 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file, LPCWSTR
 
     if (!g_settings.enableRedirects) return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
 
-    // DEBUG: Log everything that passes through ShellExecuteW
-    Wh_Log(L"DEBUG ShellExecuteW: hwnd=%p, op='%s', file='%s', params='%s', dir='%s'", 
-           hwnd, 
-           op ? op : L"(null)", 
-           file ? file : L"(null)", 
-           params ? params : L"(null)", 
-           dir ? dir : L"(null)");
 
     if (IsControlSystemParams(file, params)) {
         Wh_Log(L"ShellExecuteW: intercepted control system");
@@ -1043,11 +989,6 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file, LPCWSTR
     else if (IsShellClsid(params))
         uri = ToLower(params);
 
-    // DEBUG: Log specifically for audio-related calls
-    if (file && (wcsstr(file, L"sound") || wcsstr(file, L"audio") || wcsstr(file, L"mmsys"))) {
-        Wh_Log(L"AUDIO DEBUG: file='%s', params='%s', uri='%s'", 
-               file, params ? params : L"(null)", uri.c_str());
-    }
 
     // Audio URI handling
     if (!uri.empty() && (uri.find(L"ms-settings:sound") == 0 ||
@@ -1057,9 +998,7 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file, LPCWSTR
         uri.find(L"ms-settings:sound-output") == 0 ||
         uri.find(L"ms-settings:sound-input") == 0)) {
         
-        Wh_Log(L"Audio URI detected in ShellExecuteW: %s", uri.c_str());
-        CloseModernAudioWindow();
-        
+
         if (OpenSoundPanel()) {
             return SHELL_EXECUTE_SUCCESS;
         }
@@ -1115,7 +1054,7 @@ BOOL WINAPI CreateProcessW_hook(LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
                                lpStartupInfo, lpProcessInformation);
 }
 
-// Hook: IShellDispatch2::ShellExecute (for COM-based invocations)
+// Hook: IShellDispatch2::ShellExecute
 HRESULT WINAPI IShellDispatch2_ShellExecute_hook(
     void* pThis, BSTR File, void* vArgs, void* vDir, void* vOperation, void* vShow)
 {
@@ -1141,7 +1080,14 @@ HRESULT WINAPI IShellDispatch2_ShellExecute_hook(
         uri = ToLower(fileStr);
 
     if (!uri.empty()) {
-        Wh_Log(L"IShellDispatch2::ShellExecute intercepted: %s", uri.c_str());
+        
+        
+        // Audio URI handling in COM hook
+        if (uri.find(L"ms-settings:sound") == 0 ||
+            uri.find(L"ms-settings:audio") == 0 ||
+            uri.find(L"ms-settings:apps-volume") == 0) {
+        }
+        
         auto result = ResolveUri(uri, nullptr);
         if (result.intercept) {
             if (!result.target.empty()) LaunchTarget(result.target);
@@ -1152,46 +1098,13 @@ HRESULT WINAPI IShellDispatch2_ShellExecute_hook(
     return IShellDispatch2_ShellExecute_orig(pThis, File, vArgs, vDir, vOperation, vShow);
 }
 
-static const GUID IID_IUnknown_Manual = {0x00000000,0x0000,0x0000,{0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46}};
-#define IID_IUnknown IID_IUnknown_Manual
 
-// Install IShellDispatch2 COM hook (runs inside explorer.exe)
-static void InstallIShellDispatch2Hook() {
-    if (!dyn_CoCreateInstance) {
-        Wh_Log(L"IShellDispatch2 hook: COM not available");
-        return;
-    }
-    
-    IUnknown* pUnk = nullptr;
-    HRESULT hr = dyn_CoCreateInstance(&CLSID_Shell_, nullptr, 1, &IID_IUnknown, (void**)&pUnk);
-    if (FAILED(hr) || !pUnk) {
-        Wh_Log(L"IShellDispatch2 hook: CoCreateInstance failed hr=0x%08lX", hr);
-        return;
-    }
+// Install IShellDispatch2 COM hook
 
-    void* pDisp = nullptr;
-    hr = pUnk->QueryInterface(IID_IShellDispatch2_, &pDisp);
-    pUnk->Release();
-
-    if (FAILED(hr) || !pDisp) {
-        Wh_Log(L"IShellDispatch2 hook: QI failed hr=0x%08lX", hr);
-        return;
-    }
-
-    void** vtable = *reinterpret_cast<void***>(pDisp);
-    void* pShellExecute = vtable[37];
-
-    ((IUnknown*)pDisp)->Release();
-
-    bool ok = Wh_SetFunctionHook(pShellExecute,
-                                  (void*)IShellDispatch2_ShellExecute_hook,
-                                  (void**)&IShellDispatch2_ShellExecute_orig);
-    Wh_Log(L"IShellDispatch2::ShellExecute hook=%d addr=%p", ok, pShellExecute);
-}
 
 // Windhawk entry points
 BOOL Wh_ModInit() {
-    Wh_Log(L"Redirect Settings to Control Panel v10.0.0");
+    Wh_Log(L"Redirect Settings to Control Panel v10.0.1");
     
     // Load COM dynamically for IShellDispatch2 hook
     g_hOle32 = LoadLibraryW(L"ole32.dll");
@@ -1243,8 +1156,7 @@ BOOL Wh_ModInit() {
         }
     }
 
-    // Install COM hook for IShellDispatch2 (for deeper interception)
-    InstallIShellDispatch2Hook();
+
 
     Wh_Log(L"Ready — EnableRedirects=%d UIOnly=%d SmartPers=always_active Fallback=%d Win11Compat=%d MaxLaunches=%d",
         (int)g_settings.enableRedirects, (int)g_settings.uiOnlyRedirects,
@@ -1258,7 +1170,7 @@ void Wh_ModUninit() {
         FreeLibrary(g_hOle32);
         g_hOle32 = nullptr;
     }
-    Wh_Log(L"Redirect Settings to Control Panel v10.0.0 unloaded.");
+    Wh_Log(L"Redirect Settings to Control Panel v10.0.1 unloaded.");
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -2,7 +2,7 @@
 // @id             settings-to-control-panel
 // @name           Redirect Settings to Control Panel
 // @description    Forces classic Control Panel to open instead of Windows 10/11 Settings app using native components. Primarily designed for Windows 10; Windows 11 support is limited due to Microsoft's shell architecture changes.
-// @version        9.9.6
+// @version        10.0.0
 // @author         babamohammed
 // @github         https://github.com/babamohammed2022
 // @include        explorer.exe
@@ -11,7 +11,7 @@
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
-# Redirect Settings → Control Panel (v9.9.6)
+# Redirect Settings → Control Panel (v10.0.0)
 
 Debug version - logging all ShellExecuteW calls to diagnose audio tray issues.
 */
@@ -24,9 +24,6 @@ Debug version - logging all ShellExecuteW calls to diagnose audio tray issues.
 - UIOnlyRedirects: false
   $name: Non-Invasive UI Mode
   $description: "Only intercepts ShellExecute* calls. Leaves CreateProcessW alone."
-- SmartPersonalizationDetection: true
-  $name: Smart Personalization Detection
-  $description: "Right-clicking the desktop opens Personalization; clicking Desktop Background from inside it opens the wallpaper picker."
 - FallbackMode: "2"
   $name: Fallback Mode (unmapped URIs)
   $description: "What to do when a Settings page has no classic equivalent."
@@ -77,7 +74,7 @@ static const HINSTANCE SHELL_EXECUTE_SUCCESS = (HINSTANCE)33;
 #define PERS_WALLPAPER  L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921} -Microsoft.Personalization\\pageWallpaper"
 #define PERS_COLORS     L"explorer shell:::{ED834ED6-4B5A-4bfe-8F11-A626DCB6A921} -Microsoft.Personalization\\pageColorization"
 #define WIN11_PASSTHROUGH L"__PASSTHROUGH__"
-#define EASE_OF_ACCESS  L"control.exe /name Microsoft.EaseOfAccessCenter"
+#define EASE_OF_ACCESS  L"explorer shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"
 
 // Forward declarations
 using CreateProcessW_t = BOOL(WINAPI*)(LPCWSTR, LPWSTR, LPSECURITY_ATTRIBUTES, LPSECURITY_ATTRIBUTES, BOOL, DWORD, LPVOID, LPCWSTR, LPSTARTUPINFOW, LPPROCESS_INFORMATION);
@@ -124,7 +121,7 @@ static bool IsChildProcess() {
 struct ModSettings {
     bool enableRedirects = true;
     bool uiOnlyRedirects = false;
-    bool smartPersonalizationDetect = true;
+    // SmartPersonalizationDetection è sempre attivo (rimosso dalle impostazioni utente)
     int fallbackMode = 2;
     bool win11CompatibilityMode = false;
     int maxLaunchesPerUri = 3;
@@ -135,7 +132,7 @@ static ModSettings g_settings;
 static void LoadSettings() {
     g_settings.enableRedirects = Wh_GetIntSetting(L"EnableRedirects") != 0;
     g_settings.uiOnlyRedirects = Wh_GetIntSetting(L"UIOnlyRedirects") != 0;
-    g_settings.smartPersonalizationDetect = Wh_GetIntSetting(L"SmartPersonalizationDetection") != 0;
+    // SmartPersonalizationDetection è sempre attivo, non viene più letto dalle impostazioni
 
     PCWSTR fallbackStr = Wh_GetStringSetting(L"FallbackMode");
     if (fallbackStr[0] != L'\0') {
@@ -151,9 +148,9 @@ static void LoadSettings() {
     int ml = Wh_GetIntSetting(L"MaxLaunchesPerUri");
     g_settings.maxLaunchesPerUri = (ml >= 0 && ml <= 20) ? ml : 3;
 
-    Wh_Log(L"EnableRedirects=%d UIOnly=%d SmartPers=%d Fallback=%d Win11Compat=%d MaxLaunches=%d",
+    Wh_Log(L"EnableRedirects=%d UIOnly=%d SmartPers=always_on Fallback=%d Win11Compat=%d MaxLaunches=%d",
         (int)g_settings.enableRedirects, (int)g_settings.uiOnlyRedirects,
-        (int)g_settings.smartPersonalizationDetect, g_settings.fallbackMode,
+        g_settings.fallbackMode,
         (int)g_settings.win11CompatibilityMode, g_settings.maxLaunchesPerUri);
 }
 
@@ -403,6 +400,70 @@ static void InitMappings() {
         {L"ms-settings:recovery", w11 ? L"control.exe" : L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
         {L"ms-settings:troubleshoot", w11 ? L"msdt.exe -id DeviceDiagnostic" : L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}"},
         {L"ms-settings:deviceencryption", L"shell:::{D9EF8727-CAC2-4e60-809E-86F80A666C91}"},
+        // --- Redirections to classic panels (verified) --- source: https://gist.github.com/dbilanoski/3670be6d81b48cde29d40e48e41e0a48
+        
+        // Gaming
+        {L"ms-settings:gaming-gamebar", L"joy.cpl"},
+        
+        // File Explorer Options
+        {L"ms-settings:folders", L"shell:::{6DFD7C5C-2451-11d3-A299-00C04F8EF6AF}"},
+        
+        // Get Programs (modern: Apps & Features)
+        {L"ms-settings:appsfeatures", L"shell:::{15eae92e-f17a-4431-9f28-805e482dafd4}"},
+        
+        // Installed Updates
+        {L"ms-settings:windowsupdate-history", L"shell:::{d450a8a1-9568-45c7-9c0e-b4f9fb4537bd}"},
+        
+        // History (Troubleshooting)
+        {L"ms-settings:troubleshoot", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}\\historyPage"},
+        
+        // Keyboard
+        {L"ms-settings:keyboard", L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{725BE8F7-668E-4C7B-8F90-46BDB0936430}"},
+        
+        // Keyboard Properties
+        {L"ms-settings:keyboard-properties", L"shell:::{725BE8F7-668E-4C7B-8F90-46BDB0936430}"},
+        
+        // Network (Places)
+        {L"ms-settings:network-places", L"shell:::{F02C1A0D-BE21-4350-88B0-7367FC96EF3C}"},
+        
+        // Network and Internet
+        {L"ms-settings:network", L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\3"},
+        
+        // Network and Sharing Centre (already in mappings, kept for clarity)
+        {L"ms-settings:network-advancedsettings", L"shell:::{8E908FC9-BECC-40f6-915B-F4CA0E70D03D}"},
+        
+        // Problem Details / Reports
+        {L"ms-settings:privacy-feedback", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}\\pageReportDetails"},
+        
+        // Problem Reporting Settings
+        {L"ms-settings:problem-reporting-settings", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}\\pageSettings"},
+        
+        // Problem Reports (list)
+        {L"ms-settings:problem-reports", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}\\pageProblems"},
+        
+        // Recovery (already in mappings, kept for clarity)
+        {L"ms-settings:recovery", w11 ? L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{9FE63AFD-59CF-4419-9775-ABCC3849F861}" : L"shell:::{9FE63AFD-59CF-4419-9775-ABCC3849F861}"},
+        
+        // Reliability Monitor
+        {L"ms-settings:reliability", L"shell:::{BB64F8A7-BEE7-4E1A-AB8D-7D8273F7FDB6}\\pageReliabilityView"},
+        
+        // System Settings
+        {L"ms-settings:system-settings", L"shell:::{025A5937-A6BE-4686-A844-36FE4BEC8B6D}\\pageGlobalSettings"},
+        
+        // Speech Properties
+        {L"ms-settings:speech", L"shell:::{D17D1D6D-CC3F-4815-8FE3-607E7D5D10B3}"},
+        
+        // Search Troubleshooting
+        {L"ms-settings:search-diagnostics", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}\\searchPage"},
+        
+        // User Accounts (netplwiz)
+        {L"ms-settings:netplwiz", L"shell:::{7A9D77BD-5403-11d2-8785-2E0420524153}"},
+        
+        // Work Folders
+        {L"ms-settings:workplace", L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{ECDB0924-4208-451E-8EE0-373C0956DE16}"},
+        
+        // Control Panel All Tasks
+        {L"ms-settings:controlpanel", L"shell:::{ED7BA470-8E54-465E-825C-99712043E01C}"},
     };
     
     // Additional Windows 11 24H2 specific mappings
@@ -415,7 +476,6 @@ static void InitMappings() {
         g_mappings[L"ms-settings:storage"] = L"control.exe";
         g_mappings[L"ms-settings:storagesense"] = L"control.exe";
         g_mappings[L"ms-settings:backup"] = L"control.exe /name Microsoft.BackupAndRestore";
-        g_mappings[L"ms-settings:windowsupdate"] = L"control.exe /name Microsoft.WindowsUpdate";
     }
 }
 
@@ -574,11 +634,29 @@ static void LaunchTarget(const std::wstring& command) {
     si.wShowWindow = SW_SHOWNORMAL;
     PROCESS_INFORMATION pi = {};
     std::wstring cmdLine;
-
+    // Special handling for control.exe with /name parameter
+if (command.find(L"control.exe /name") != std::wstring::npos) {
+    std::wstring mutable_cmd = command;
+    STARTUPINFOW si = {};
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESHOWWINDOW;
+    si.wShowWindow = SW_SHOWNORMAL;
+    PROCESS_INFORMATION pi = {};
+    if (CreateProcessW_orig(nullptr, mutable_cmd.data(), nullptr, nullptr, FALSE, 
+                            CREATE_UNICODE_ENVIRONMENT, (LPVOID)g_childEnvBlock.c_str(), 
+                            nullptr, &si, &pi)) {
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+    } else {
+        Wh_Log(L"CreateProcess failed for '%s' (%lu)", command.c_str(), GetLastError());
+    }
+    return;
+}
     if (command.find(L".msc") != std::wstring::npos) {
         cmdLine = L"mmc.exe \"" + command + L"\"";
     } else if (command.find(L".cpl") != std::wstring::npos) {
         cmdLine = L"control.exe " + command;
+        
     } else if (command.find(L".exe") != std::wstring::npos) {
         cmdLine = command;
     } else if (command.find(L"shell:::") == 0) {
@@ -606,7 +684,7 @@ static void LaunchTarget(const std::wstring& command) {
     CloseHandle(pi.hThread);
 }
 
-// Personalization detection
+// Personalization detection - sempre attiva
 static bool IsPersonalizationWindow(HWND hwnd) {
     if (!hwnd) {
         hwnd = GetForegroundWindow();
@@ -634,15 +712,12 @@ static bool IsPersonalizationWindow(HWND hwnd) {
 }
 
 static std::wstring ResolvePersonalizationBackground(HWND hwnd) {
-    if (!g_settings.smartPersonalizationDetect) {
-        Wh_Log(L"SmartPersonalizationDetection OFF -> Personalization root");
-        return PERS_ROOT;
-    }
+    // SmartPersonalizationDetection è sempre attivo
     if (IsPersonalizationWindow(hwnd)) {
-        Wh_Log(L"personalization-background -> wallpaper page");
+        Wh_Log(L"personalization-background -> wallpaper page (smart detection always active)");
         return PERS_WALLPAPER;
     }
-    Wh_Log(L"personalization-background -> Personalization root");
+    Wh_Log(L"personalization-background -> Personalization root (smart detection always active)");
     return PERS_ROOT;
 }
 
@@ -759,7 +834,7 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
         CloseModernAudioWindow();
     }
     
-    // Personalization Background (smart detection)
+    // Personalization Background (smart detection sempre attiva)
     if (uri == L"ms-settings:personalization-background") {
         std::wstring t = ApplyWin11Filter(ResolvePersonalizationBackground(hwnd));
         Wh_Log(L"personalization-background -> %s", t.c_str());
@@ -1116,7 +1191,7 @@ static void InstallIShellDispatch2Hook() {
 
 // Windhawk entry points
 BOOL Wh_ModInit() {
-    Wh_Log(L"Redirect Settings to Control Panel v9.9.6");
+    Wh_Log(L"Redirect Settings to Control Panel v10.0.0");
     
     // Load COM dynamically for IShellDispatch2 hook
     g_hOle32 = LoadLibraryW(L"ole32.dll");
@@ -1171,8 +1246,8 @@ BOOL Wh_ModInit() {
     // Install COM hook for IShellDispatch2 (for deeper interception)
     InstallIShellDispatch2Hook();
 
-    Wh_Log(L"Ready — EnableRedirects=%d UIOnly=%d SmartPers=%d Fallback=%d Win11Compat=%d MaxLaunches=%d",
-        (int)g_settings.enableRedirects, (int)g_settings.uiOnlyRedirects, (int)g_settings.smartPersonalizationDetect,
+    Wh_Log(L"Ready — EnableRedirects=%d UIOnly=%d SmartPers=always_active Fallback=%d Win11Compat=%d MaxLaunches=%d",
+        (int)g_settings.enableRedirects, (int)g_settings.uiOnlyRedirects,
         g_settings.fallbackMode, (int)g_settings.win11CompatibilityMode, g_settings.maxLaunchesPerUri);
 
     return TRUE;
@@ -1183,7 +1258,7 @@ void Wh_ModUninit() {
         FreeLibrary(g_hOle32);
         g_hOle32 = nullptr;
     }
-    Wh_Log(L"Redirect Settings to Control Panel v9.9.6 unloaded.");
+    Wh_Log(L"Redirect Settings to Control Panel v10.0.0 unloaded.");
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -22,19 +22,29 @@ Windows components (no external binaries or dependencies).
 **This mod is primarily designed for Windows 10**, where the classic Control Panel
 infrastructure is fully intact and most user interactions go through `explorer.exe`.
 
-**On Windows 11**, Microsoft rewrote the shell (taskbar, system tray, desktop
-right-click menus) using XAML/UWP technology. The modern taskbar uses
-`DelegateExecute` COM activation and `ms-contact-support://` protocol instead of
-`ShellExecute`, which means:
+**On Windows 11**, Microsoft rewrote the shell using XAML/UWP technology. The
+modern taskbar and some UI elements use COM activation that bypasses standard
+ShellExecute hooks. This means:
 
-- **Control Panel navigation** works on both OSes (with Windows 10 being more compatible)
-- Some Control Panel components have been **deprecated or removed** by Microsoft on Windows 11
-- Some CLSIDs still exist in the registry but open **empty panels**
-- **Desktop right-click → Personalize** uses a different code path on Win11 (Could be fixed in future)
-- **Start Menu search results** are not intercepted (to avoid breaking search)
+- **Windows 10**: Full support — all redirects work as expected ✅
+- **Windows 11**: Partial support — most redirects work, but some specific cases
+  (like clicking "Ease of Access" or "Display" links inside the classic
+  Personalization window) may not be interceptable via API hooks alone.
+  A WinEventHook workaround attempts to catch and redirect these cases.
 
-When no valid classic equivalent exists, behavior is controlled via fallback
-configuration (see Settings section).
+### Known Windows 11 Limitations
+- **Desktop right-click → Personalize**: May open modern Settings on some builds
+- **Ease of Access / Display links inside Personalization window**: Uses internal
+  COM/XAML activation that cannot be hooked directly. The mod uses a WinEventHook
+  to detect and close the modern window, then launch the classic panel.
+  Effectiveness may vary by build.
+- **Start Menu search results**: Not intercepted (to avoid breaking search)
+- **System tray icon clicks**: Use DCOM activation, cannot be hooked
+
+**In short**: On Windows 10 this mod works fully. On Windows 11 it works in most
+cases but some edge cases depend on your specific build and configuration.
+
+Credits to Anixx and m417z for the reviews and testing to enhance the mod.
 
 ---
 
@@ -44,54 +54,40 @@ configuration (see Settings section).
 - Control Panel navigation (System, Network, Sound, Accounts, Devices, etc.)
 - `Win+R` → `ms-settings:*` commands
 - `explorer shell:::*` protocol
-- Classic Personalization CPL — including Colors and Background sub-pages
+- Classic Personalization CPL — Colors and Background sub-pages
 - Right-click "This PC" → Properties
 - Troubleshooting → MSDT on Win11 (`msdt.exe`)
+- Display settings → `desk.cpl`
+- Ease of Access → `access.cpl`
 
-### 🟡 Redirected on Windows 10 only
+### 🟡 Partially Redirected (works on Win10, Win11 depends on build)
 - Desktop right-click → Personalize
-- Taskbar notification area settings
+- Ease of Access / Display links from inside Personalization window
 
 ### 🔴 Not Redirected (architectural limitation)
-- Modern Windows 11 taskbar tray (uses `DelegateExecute` COM activation)
+- Modern Windows 11 taskbar tray (uses DCOM activation)
 - Start Menu search results (excluded to avoid breaking search)
 - Internal Settings app navigation
-**Note:** System tray icon clicks (audio, network) are NOT redirected on either OS.
-The tray uses DCOM activation which bypasses ShellExecute hooks. This is an
-architectural limitation documented above. (Could be fixed soon)
-
----
-
-## Overview
-
-This mod restores access to the legacy Control Panel experience. When a system
-setting link is opened (typically triggering the modern Settings app), it is
-transparently redirected to the equivalent classic Control Panel interface.
 
 ---
 
 ## Features
 
-- Over 90 URI-to-applet mappings covering:
-  System, Network, Personalization, Sound, Devices, Accounts, Fonts, and more
-- Smart Personalization detection (desktop right-click vs in-window navigation)
-- Classic Personalization CPL with working Colors and Background sub-pages
-- MSDT troubleshooting on Windows 11
+- Over 90 URI-to-applet mappings
+- Smart Personalization detection (desktop vs in-window navigation)
+- WinEventHook workaround for Windows 11 modern windows
 - Safe fallback handling for unmapped settings
 - Anti-loop protection (cross-process, in-process, bounce-back detection)
-- Lightweight implementation using native Windows APIs only
+- No external dependencies — uses only native Windows APIs
 
 ---
 
 ## Configuration Options
 
-- **EnableRedirects**: Master switch — turn the mod on or off
-- **UIOnlyRedirects**: Only intercept ShellExecute* calls (leaves CreateProcessW alone)
-- **SmartPersonalizationDetection**: Differentiate desktop vs in-window personalization
-- **FallbackMode**: Behavior when no classic equivalent exists
-  - `0` — Ignore (silent fail)
-  - `1` — Open Control Panel root (`control.exe`)
-  - `2` — Pass through to modern Settings app (default)
+- **EnableRedirects**: Master switch
+- **UIOnlyRedirects**: Only intercept ShellExecute* calls
+- **SmartPersonalizationDetection**: Desktop right-click vs in-window navigation
+- **FallbackMode**: Behavior when no classic equivalent exists (0=Ignore, 1=Control Panel root, 2=Pass through)
 - **Win11CompatibilityMode**: Additional Win11 safeguards for unverified CLSIDs
 - **MaxLaunchesPerUri**: Anti-loop safety valve (max launches per URI in 5 seconds)
 */
@@ -387,7 +383,14 @@ static void InitMappings() {
         // ── Color Management ─────────────────────────────────────────────────
         {L"ms-settings:display-advanced-color",              L"colorcpl.exe"},
         {L"ms-settings:colorcpl",                            L"colorcpl.exe"},
-
+        {L"ms-settings:display",                             L"desk.cpl"},
+        {L"ms-settings:display-advanced",                    L"desk.cpl"},
+        {L"ms-settings:display-resolution",                  L"desk.cpl"},
+        {L"ms-settings:screenrotation",                      L"desk.cpl"},
+        // ── Graphics Adapter Properties ──────────────────── suggested by Anixx
+        {L"ms-settings:display-advanced-graphics",           L"rundll32.exe display.dll,ShowAdapterSettings 0"},
+        {L"ms-settings:graphics-settings",                   L"rundll32.exe display.dll,ShowAdapterSettings 0"},
+        {L"ms-settings:display-adapter-properties",          L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         // ── System / About ───────────────────────────────────────────────────
         {L"ms-settings:about",
             w11 ? L"sysdm.cpl" : SYSTEM_PROPS_CLSID},
@@ -512,12 +515,12 @@ static void InitMappings() {
 
         // ── Ease of Access ────────────────────────────────────────────────────,
         // Ease Of Access entries
-        {L"ms-settings:easeofaccess", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}"},
-        {L"ms-settings:easeofaccess-narrator", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}\\pageNoVisual"},
-        {L"ms-settings:easeofaccess-magnifier", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}\\pageEasierToSee"},
-        {L"ms-settings:easeofaccess-speech", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A"},
-        {L"ms-settings:easeofaccess-colorfilter", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}\\pageEasierToSee"},
-        {L"ms-settings:easeofaccess-display", L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}\\pageEasierToSee"},
+        {L"ms-settings:easeofaccess", L"access.cpl"},
+        {L"ms-settings:easeofaccess-narrator", L"access.cpl"},
+        {L"ms-settings:easeofaccess-magnifier", L"access.cpl"},
+        {L"ms-settings:easeofaccess-speech", L"access.cpl"},
+        {L"ms-settings:easeofaccess-colorfilter", L"access.cpl"},
+        {L"ms-settings:easeofaccess-display", L"access.cpl"},
 
         // ── Recovery / Backup ─────────────────────────────────────────────────
         {L"ms-settings:backup",
@@ -642,7 +645,21 @@ static void LaunchTarget(const std::wstring& command) {
 
     {
         std::wstring lower = ToLower(command);
-        
+            // rundll32.exe needs special handling (commas in arguments)
+    if (command.find(L"rundll32.exe") != std::wstring::npos) {
+        std::wstring mutable_cmd = command;
+        STARTUPINFOW si = {}; si.cb = sizeof(si);
+        PROCESS_INFORMATION pi = {};
+        if (!CreateProcessW_orig(nullptr, mutable_cmd.data(), nullptr, nullptr,
+                                 FALSE, 0, nullptr, nullptr, &si, &pi)) {
+            Wh_Log(L"rundll32 CreateProcess failed for '%s' (%lu)",
+                   command.c_str(), GetLastError());
+        } else {
+            CloseHandle(pi.hProcess);
+            CloseHandle(pi.hThread);
+        }
+        return;
+    }
         // Gestisci "explorer shell:::" separatamente
         if (lower.find(L"explorer shell:::") != std::wstring::npos) {
             std::wstring clsid = command.substr(command.find(L"shell:::"));
@@ -728,9 +745,14 @@ static void LaunchTarget(const std::wstring& command) {
 // ── Personalization hwnd detection ───────────────────────────────────────────
 
 static bool IsPersonalizationWindow(HWND hwnd) {
+    // Se HWND è NULL, prova con la finestra in primo piano
     if (!hwnd) {
-        Wh_Log(L"HWND null -> desktop context menu path");
-        return false;
+        hwnd = GetForegroundWindow();
+        Wh_Log(L"IsPersonalizationWindow: HWND null, trying GetForegroundWindow=%p", hwnd);
+        if (!hwnd) {
+            Wh_Log(L"IsPersonalizationWindow: GetForegroundWindow returned null -> false");
+            return false;
+        }
     }
 
     HWND h = hwnd;
@@ -743,21 +765,22 @@ static bool IsPersonalizationWindow(HWND hwnd) {
         std::wstring c = ToLower(cls);
         std::wstring t = ToLower(title);
 
+        Wh_Log(L"IsPersonalizationWindow: hwnd=%p class='%s' title='%s'", h, cls, title);
+
         if (c == L"progman" || c == L"workerw" || c == L"shelldll_defview") {
-            Wh_Log(L"HWND: desktop class '%s' -> context menu", cls);
+            Wh_Log(L"IsPersonalizationWindow: desktop class -> false");
             return false;
         }
         if (c == L"cabinetwclass") {
             if (t.find(L"personaliz") != std::wstring::npos) {
-                Wh_Log(L"HWND: CabinetWClass personalization confirmed");
+                Wh_Log(L"IsPersonalizationWindow: CabinetWClass personalization -> true");
                 return true;
-        }
-
-            Wh_Log(L"HWND: CabinetWClass but not personalization");
+            }
+            Wh_Log(L"IsPersonalizationWindow: CabinetWClass but not personalization -> false");
             return false;
         }
         if (t.find(L"personaliz") != std::wstring::npos) {
-            Wh_Log(L"HWND: title match 'personaliz' -> Personalization window");
+            Wh_Log(L"IsPersonalizationWindow: title match -> true");
             return true;
         }
 
@@ -766,7 +789,7 @@ static bool IsPersonalizationWindow(HWND hwnd) {
         h = parent;
     }
 
-    Wh_Log(L"HWND: no personalization window found -> context menu");
+    Wh_Log(L"IsPersonalizationWindow: no match found -> false");
     return false;
 }
 
@@ -802,17 +825,48 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
         return {t, true};
     }
 
-    // ─── EDIT FOR EASE OF ACCESS IN PERSONALIZATION ───
+    if (uri.find(L"shell:::{d555645e-d4f8-4c29-a827-d93c859c4f2a}") == 0) {
+        Wh_Log(L"Win11 hardcode: forcing classic ease of access target for shell CLSID '%s'", uri.c_str());
+        return {L"access.cpl", true};
+    }
 
-    if (g_settings.smartPersonalizationDetect && IsPersonalizationWindow(hwnd)) {
-        if (uri.find(L"ms-settings:easeofaccess") == 0) {
-            Wh_Log(L"SmartPersonalization: Accesso da finestra Personalizzazione, forzo radice Centro Accessibilità");
-            std::wstring t = ApplyWin11Filter(L"shell:::{D555645E-D4F8-4c29-A827-D93C859C4F2A}");
-            BounceGuardRecord(uri);
-            return {t, true};
+    if (uri.find(L"shell:::{ed834ed6-4b5a-4bfe-8f11-a626dcb6a921}") == 0) {
+        if (uri.find(L"pagewallpaper") != std::wstring::npos) {
+            Wh_Log(L"Win11 hardcode: forcing classic personalization wallpaper target for '%s'", uri.c_str());
+            return {PERS_WALLPAPER, true};
+        }
+        if (uri.find(L"pagecolorization") != std::wstring::npos) {
+            Wh_Log(L"Win11 hardcode: forcing classic personalization colors target for '%s'", uri.c_str());
+            return {PERS_COLORS, true};
+        }
+        Wh_Log(L"Win11 hardcode: forcing classic personalization root for '%s'", uri.c_str());
+        return {PERS_ROOT, true};
+    }
+
+    // ─── Win11 hardcoded classic target overrides ───
+    // Force Win11 to open the classic display and ease of access panels instead
+    // of letting modern Settings choose a different or unsupported path.
+    if (g_isWin11) {
+        if (uri == L"ms-settings:display" ||
+            uri == L"ms-settings:display-advanced" ||
+            uri == L"ms-settings:display-resolution" ||
+            uri == L"ms-settings:screenrotation")
+        {
+            Wh_Log(L"Win11 hardcode: forcing classic display target for '%s'", uri.c_str());
+            return {L"desk.cpl", true};
+        }
+
+        if (uri == L"ms-settings:easeofaccess" ||
+            uri == L"ms-settings:easeofaccess-narrator" ||
+            uri == L"ms-settings:easeofaccess-magnifier" ||
+            uri == L"ms-settings:easeofaccess-speech" ||
+            uri == L"ms-settings:easeofaccess-colorfilter" ||
+            uri == L"ms-settings:easeofaccess-display")
+        {
+            Wh_Log(L"Win11 hardcode: forcing classic ease of access target for '%s'", uri.c_str());
+            return {L"access.cpl", true};
         }
     }
-    // ─────────────────────────────────────────────────────────────────
 
     auto it = g_mappings.find(uri);
     if (it != g_mappings.end()) {
@@ -932,14 +986,10 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
     else if (IsMsSettings(pei->lpParameters))
         uri = NormalizeUri(pei->lpParameters);
     else if (IsShellClsid(pei->lpFile)) {
-        std::wstring lower = ToLower(pei->lpFile);
-        if (g_isWin11 && IsClsidLoopOnWin11(lower))
-            uri = lower;
+        uri = ToLower(pei->lpFile);
     }
     else if (IsShellClsid(pei->lpParameters)) {
-        std::wstring lower = ToLower(pei->lpParameters);
-        if (g_isWin11 && IsClsidLoopOnWin11(lower))
-            uri = lower;
+        uri = ToLower(pei->lpParameters);
     }
 
     if (!uri.empty()) {
@@ -971,10 +1021,16 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
     if (!g_settings.enableRedirects)
         return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
 
-    Wh_Log(L"ShellExecuteW: hwnd=%p  file=%s  params=%s",
+    // LOG TEMPORANEO - CATTURA TUTTO
+    Wh_Log(L"ShellExecuteW: hwnd=%p file='%s' params='%s' op='%s'",
            hwnd,
-           file   ? file   : L"(null)",
-           params ? params : L"(null)");
+           file ? file : L"NULL",
+           params ? params : L"NULL",
+           op ? op : L"NULL");
+    
+    if (IsPersonalizationWindow(hwnd)) {
+        Wh_Log(L"^^^ CHIAMATA DA PERSONALIZZAZIONE! ^^^");
+    }
 
     if (IsControlSystemParams(file, params)) {
         Wh_Log(L"ShellExecuteW: intercepted control system");
@@ -988,14 +1044,10 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
     else if (IsMsSettings(params))
         uri = NormalizeUri(params);
     else if (IsShellClsid(file)) {
-        std::wstring lower = ToLower(file);
-        if (g_isWin11 && IsClsidLoopOnWin11(lower))
-            uri = lower;
+        uri = ToLower(file);
     }
     else if (IsShellClsid(params)) {
-        std::wstring lower = ToLower(params);
-        if (g_isWin11 && IsClsidLoopOnWin11(lower))
-            uri = lower;
+        uri = ToLower(params);
     }
 
     if (!uri.empty()) {
@@ -1007,6 +1059,57 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
         }
     }
     return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
+}
+// ── WinEventHook for Modern Settings Windows (Win11 workaround) ──────────────
+
+static HWINEVENTHOOK g_hModernWindowHook = nullptr;
+
+// Intercetta quando si apre una nuova finestra (Display, Ease of Access moderna)
+static void CALLBACK ModernWindowEventHook(
+    HWINEVENTHOOK hWinEventHook,
+    DWORD event,
+    HWND hwnd,
+    LONG idObject,
+    LONG idChild,
+    DWORD dwEventThread,
+    DWORD dwmsEventTime)
+{
+    if (event != EVENT_OBJECT_CREATE && event != EVENT_OBJECT_SHOW)
+        return;
+    if (!g_isWin11) return;
+    if (!hwnd || idObject != OBJID_WINDOW) return;
+    if (!IsWindow(hwnd)) return;
+
+    wchar_t cls[256] = {};
+    wchar_t title[512] = {};
+    GetClassNameW(hwnd, cls, ARRAYSIZE(cls));
+    GetWindowTextW(hwnd, title, ARRAYSIZE(title));
+    std::wstring classLower = ToLower(cls);
+    std::wstring titleLower = ToLower(title);
+
+    Wh_Log(L"ModernWindowEventHook: event=%u hwnd=%p class='%s' title='%s'", event, hwnd, cls, title);
+
+    // Controlli su qualsiasi finestra che contiene display, settings, o access nel titolo
+    if ((titleLower.find(L"display") != std::wstring::npos ||
+         titleLower.find(L"scheda") != std::wstring::npos) &&
+        classLower.find(L"applicationframewindow") != std::wstring::npos) {
+        Wh_Log(L"ModernWindowEventHook: Display-related window detected, closing and launching classic");
+        PostMessageW(hwnd, WM_CLOSE, 0, 0);
+        Sleep(100);  // Breve pausa per assicurare la chiusura
+        LaunchTarget(L"desk.cpl");
+        return;
+    }
+
+    if ((titleLower.find(L"ease") != std::wstring::npos ||
+         titleLower.find(L"access") != std::wstring::npos ||
+         titleLower.find(L"accessib") != std::wstring::npos) &&
+        classLower.find(L"applicationframewindow") != std::wstring::npos) {
+        Wh_Log(L"ModernWindowEventHook: Ease of Access window detected, closing and launching classic");
+        PostMessageW(hwnd, WM_CLOSE, 0, 0);
+        Sleep(100);
+        LaunchTarget(L"access.cpl");
+        return;
+    }
 }
 
 // ── Hook: CreateProcessW ──────────────────────────────────────────────────────
@@ -1118,6 +1221,26 @@ BOOL Wh_ModInit() {
             Wh_Log(L"CreateProcessW hook=%d", ok3);
         }
     }
+
+    // Install WinEventHook for modern window creation on Windows 11
+    // This intercepts when Display Settings or Ease of Access windows open from Personalizzazione
+    if (g_isWin11) {
+        g_hModernWindowHook = SetWinEventHook(
+            EVENT_OBJECT_CREATE,
+            EVENT_OBJECT_SHOW,
+            nullptr,
+            ModernWindowEventHook,
+            0,      // dwProcessId = 0 means all processes
+            0,      // dwThreadId = 0 means all threads
+            WINEVENT_OUTOFCONTEXT
+        );
+        if (g_hModernWindowHook) {
+            Wh_Log(L"ModernWindowEventHook installed for Win11");
+        } else {
+            Wh_Log(L"Failed to install ModernWindowEventHook");
+        }
+    }
+
     Wh_Log(L"Ready — EnableRedirects=%d UIOnly=%d SmartPers=%d Fallback=%d Win11Compat=%d MaxLaunches=%d",
         (int)g_settings.enableRedirects,
         (int)g_settings.uiOnlyRedirects,
@@ -1129,6 +1252,11 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModUninit() {
+    if (g_hModernWindowHook) {
+        UnhookWinEvent(g_hModernWindowHook);
+        g_hModernWindowHook = nullptr;
+        Wh_Log(L"ModernWindowEventHook uninstalled");
+    }
     Wh_Log(L"Unloaded.");
 }
 

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -374,7 +374,7 @@ static void InitMappings() {
         {L"ms-settings:display-advanced-color", L"colorcpl.exe"},
         {L"ms-settings:colorcpl", L"colorcpl.exe"},
         
-        // Display
+        // Display - reindirizzamento a Impostazioni schermo classiche (rundll32)
         {L"ms-settings:display", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         {L"ms-settings:display-advanced", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
         {L"ms-settings:display-advanced-graphics", L"rundll32.exe display.dll,ShowAdapterSettings 0"},
@@ -651,7 +651,9 @@ static bool HandleFallback(const std::wstring& uri) {
     }
 }
 
-// LaunchTarget - VERSIONE CORRETTA
+
+
+// LaunchTarget - CORRETTA per rundll32
 static void LaunchTarget(const std::wstring& command) {
     Wh_Log(L"Launching: %s", command.c_str());
 
@@ -677,9 +679,44 @@ static void LaunchTarget(const std::wstring& command) {
         return;
     }
     
-    // Comandi completi con percorso eseguibile
+    // Gestione speciale per rundll32.exe e comandi con parametri
+    if (lower.find(L"rundll32.exe ") == 0 || 
+        (lower.find(L"rundll32.exe") == 0 && lower.length() > 12)) {
+        Wh_Log(L"Detected rundll32 command: %s", command.c_str());
+        
+        // Estrai il percorso completo di rundll32.exe
+        std::wstring rundll32Path;
+        wchar_t sysDir[MAX_PATH];
+        if (GetSystemDirectoryW(sysDir, MAX_PATH)) {
+            rundll32Path = std::wstring(sysDir) + L"\\rundll32.exe";
+        } else {
+            rundll32Path = L"rundll32.exe";
+        }
+        
+        // Estrai i parametri (tutto dopo "rundll32.exe ")
+        std::wstring params;
+        if (lower.find(L"rundll32.exe ") != std::wstring::npos) {
+            params = command.substr(13); // lunghezza di "rundll32.exe "
+        } else {
+            params = command.substr(12); // lunghezza di "rundll32.exe"
+        }
+        
+        // Usa ShellExecuteExW per eseguire rundll32 con i parametri
+        SHELLEXECUTEINFOW sei = {};
+        sei.cbSize = sizeof(sei);
+        sei.fMask = SEE_MASK_FLAG_NO_UI;
+        sei.lpVerb = L"open";
+        sei.lpFile = rundll32Path.c_str();
+        sei.lpParameters = params.c_str();
+        sei.nShow = SW_SHOWNORMAL;
+        
+        Wh_Log(L"Using ShellExecuteExW: %s params='%s'", rundll32Path.c_str(), params.c_str());
+        ShellExecuteExW_orig(&sei);
+        return;
+    }
+    
+    // Comandi completi con percorso eseguibile (esploratore, control.exe, ecc.)
     bool isFullCmdLine =
-        (lower.find(L"rundll32.exe ") != std::wstring::npos) ||
         (lower.find(L"explorer.exe ") != std::wstring::npos) ||
         (lower.find(L"control.exe /") != std::wstring::npos);
 
@@ -756,19 +793,8 @@ static void LaunchTarget(const std::wstring& command) {
         CloseHandle(pi.hThread);
     }
 }
+
 // Personalization detection
-
-
-
-
-
-// Helper function to open sound panel
-static bool OpenSoundPanel() {
-    Wh_Log(L"Opening sound panel via LaunchTarget");
-    LaunchTarget(L"control.exe mmsys.cpl,,0");
-    return true;
-}
-
 static bool IsPersonalizationWindow(HWND hwnd) {
     if (!hwnd) {
         Wh_Log(L"HWND null -> desktop context menu path");
@@ -814,6 +840,7 @@ static std::wstring ResolvePersonalizationBackground(HWND hwnd) {
     Wh_Log(L"personalization-background -> Personalization root");
     return PERS_ROOT;
 }
+
 static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
     if (uri == L"ms-settings:personalization-background") {
         if (BounceGuardIsBounce(uri)) {
@@ -862,6 +889,7 @@ static ResolveResult ResolveUri(const std::wstring& uri, HWND hwnd) {
     Wh_Log(L"Unmapped, passing through: %s", uri.c_str());
     return {L"", false};
 }
+
 // Control system detection helpers
 static std::wstring BaseNameLower(const std::wstring& path) {
     size_t pos = path.rfind(L'\\');
@@ -904,6 +932,13 @@ static bool IsControlSystemCommand(const std::wstring& cmdLine) {
     return (arg == L"system" || arg == L"microsoft.system");
 }
 
+// Helper function to open sound panel
+static bool OpenSoundPanel() {
+    Wh_Log(L"Opening sound panel via LaunchTarget");
+    LaunchTarget(L"control.exe mmsys.cpl,,0");
+    return true;
+}
+
 // Hook: ShellExecuteExW
 BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
     if (IsChildProcess()) return ShellExecuteExW_orig(pei);
@@ -933,19 +968,28 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
     else if (IsShellClsid(pei->lpParameters))
         uri = ToLower(pei->lpParameters);
 
-    // Audio URI handling with debug log
+    // Audio URI handling
     if (!uri.empty() && (uri.find(L"ms-settings:sound") == 0 ||
         uri.find(L"ms-settings:audio") == 0 ||
         uri.find(L"ms-settings:apps-volume") == 0 ||
         uri.find(L"ms-settings:sound-devices") == 0 ||
         uri.find(L"ms-settings:sound-output") == 0 ||
         uri.find(L"ms-settings:sound-input") == 0)) {
-
         
         if (OpenSoundPanel()) {
             if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
             return TRUE;
         }
+    }
+
+    // Display URI handling - questo intercetta anche i clic dal menu contestuale del desktop
+    if (!uri.empty() && (uri.find(L"ms-settings:display") == 0 ||
+        uri.find(L"ms-settings:screenrotation") == 0 ||
+        uri.find(L"ms-settings:graphics-settings") == 0)) {
+        Wh_Log(L"ShellExecuteExW: intercepted display settings, launching classic Display Properties");
+        LaunchTarget(L"rundll32.exe display.dll,ShowAdapterSettings 0");
+        if (pei->fMask & SEE_MASK_NOCLOSEPROCESS) pei->hProcess = nullptr;
+        return TRUE;
     }
 
     if (!uri.empty()) {
@@ -959,7 +1003,7 @@ BOOL WINAPI ShellExecuteExW_hook(SHELLEXECUTEINFOW* pei) {
     return ShellExecuteExW_orig(pei);
 }
 
-// Hook: ShellExecuteW with DEBUG logging
+// Hook: ShellExecuteW
 HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file, LPCWSTR params, LPCWSTR dir, INT show) {
     if (IsChildProcess()) return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
 
@@ -970,7 +1014,6 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file, LPCWSTR
     }
 
     if (!g_settings.enableRedirects) return ShellExecuteW_orig(hwnd, op, file, params, dir, show);
-
 
     if (IsControlSystemParams(file, params)) {
         Wh_Log(L"ShellExecuteW: intercepted control system");
@@ -988,7 +1031,6 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file, LPCWSTR
     else if (IsShellClsid(params))
         uri = ToLower(params);
 
-
     // Audio URI handling
     if (!uri.empty() && (uri.find(L"ms-settings:sound") == 0 ||
         uri.find(L"ms-settings:audio") == 0 ||
@@ -997,10 +1039,18 @@ HINSTANCE WINAPI ShellExecuteW_hook(HWND hwnd, LPCWSTR op, LPCWSTR file, LPCWSTR
         uri.find(L"ms-settings:sound-output") == 0 ||
         uri.find(L"ms-settings:sound-input") == 0)) {
         
-
         if (OpenSoundPanel()) {
             return SHELL_EXECUTE_SUCCESS;
         }
+    }
+
+    // Display URI handling - questo intercetta anche i clic dal menu contestuale del desktop
+    if (!uri.empty() && (uri.find(L"ms-settings:display") == 0 ||
+        uri.find(L"ms-settings:screenrotation") == 0 ||
+        uri.find(L"ms-settings:graphics-settings") == 0)) {
+        Wh_Log(L"ShellExecuteW: intercepted display settings, launching classic Display Properties");
+        LaunchTarget(L"rundll32.exe display.dll,ShowAdapterSettings 0");
+        return SHELL_EXECUTE_SUCCESS;
     }
 
     if (!uri.empty()) {
@@ -1079,14 +1129,6 @@ HRESULT WINAPI IShellDispatch2_ShellExecute_hook(
         uri = ToLower(fileStr);
 
     if (!uri.empty()) {
-        
-        
-        // Audio URI handling in COM hook
-        if (uri.find(L"ms-settings:sound") == 0 ||
-            uri.find(L"ms-settings:audio") == 0 ||
-            uri.find(L"ms-settings:apps-volume") == 0) {
-        }
-        
         auto result = ResolveUri(uri, nullptr);
         if (result.intercept) {
             if (!result.target.empty()) LaunchTarget(result.target);
@@ -1096,10 +1138,6 @@ HRESULT WINAPI IShellDispatch2_ShellExecute_hook(
 
     return IShellDispatch2_ShellExecute_orig(pThis, File, vArgs, vDir, vOperation, vShow);
 }
-
-
-// Install IShellDispatch2 COM hook
-
 
 // Windhawk entry points
 BOOL Wh_ModInit() {
@@ -1154,8 +1192,6 @@ BOOL Wh_ModInit() {
             Wh_Log(L"CreateProcessW hook=%d", ok3);
         }
     }
-
-
 
     Wh_Log(L"Ready — EnableRedirects=%d UIOnly=%d SmartPers=always_active Fallback=%d Win11Compat=%d MaxLaunches=%d",
         (int)g_settings.enableRedirects, (int)g_settings.uiOnlyRedirects,

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -652,8 +652,6 @@ static bool HandleFallback(const std::wstring& uri) {
 }
 
 
-
-// LaunchTarget - CORRETTA per rundll32
 static void LaunchTarget(const std::wstring& command) {
     Wh_Log(L"Launching: %s", command.c_str());
 
@@ -684,7 +682,6 @@ static void LaunchTarget(const std::wstring& command) {
         (lower.find(L"rundll32.exe") == 0 && lower.length() > 12)) {
         Wh_Log(L"Detected rundll32 command: %s", command.c_str());
         
-        // Estrai il percorso completo di rundll32.exe
         std::wstring rundll32Path;
         wchar_t sysDir[MAX_PATH];
         if (GetSystemDirectoryW(sysDir, MAX_PATH)) {
@@ -693,15 +690,13 @@ static void LaunchTarget(const std::wstring& command) {
             rundll32Path = L"rundll32.exe";
         }
         
-        // Estrai i parametri (tutto dopo "rundll32.exe ")
         std::wstring params;
         if (lower.find(L"rundll32.exe ") != std::wstring::npos) {
-            params = command.substr(13); // lunghezza di "rundll32.exe "
+            params = command.substr(13);
         } else {
-            params = command.substr(12); // lunghezza di "rundll32.exe"
+            params = command.substr(12);
         }
         
-        // Usa ShellExecuteExW per eseguire rundll32 con i parametri
         SHELLEXECUTEINFOW sei = {};
         sei.cbSize = sizeof(sei);
         sei.fMask = SEE_MASK_FLAG_NO_UI;
@@ -715,7 +710,7 @@ static void LaunchTarget(const std::wstring& command) {
         return;
     }
     
-    // Comandi completi con percorso eseguibile (esploratore, control.exe, ecc.)
+    // Comandi completi con percorso eseguibile
     bool isFullCmdLine =
         (lower.find(L"explorer.exe ") != std::wstring::npos) ||
         (lower.find(L"control.exe /") != std::wstring::npos);
@@ -759,11 +754,13 @@ static void LaunchTarget(const std::wstring& command) {
     if (command.find(L".msc") != std::wstring::npos) {
         cmdLine = L"mmc.exe \"" + command + L"\"";
     } else if (command.find(L".cpl") != std::wstring::npos) {
-        cmdLine = L"control.exe " + command;
+        // Usa ShellExecuteW per i .cpl - molto più affidabile
+        Wh_Log(L"Using ShellExecuteW for .cpl: control.exe %s", command.c_str());
+        ShellExecuteW_orig(nullptr, L"open", L"control.exe", command.c_str(), nullptr, SW_SHOWNORMAL);
+        return;
     } else if (command.find(L".exe") != std::wstring::npos) {
         cmdLine = command;
     } else if (command.find(L"shell:::") == 0) {
-        // CLSID puro - usa explorer.exe
         SHELLEXECUTEINFOW sei = {};
         sei.cbSize = sizeof(sei);
         sei.fMask = SEE_MASK_FLAG_NO_UI;

--- a/mods/settings-to-control-panel.wh.cpp
+++ b/mods/settings-to-control-panel.wh.cpp
@@ -519,8 +519,8 @@ static void InitMappings() {
         // Installed Updates
         {L"ms-settings:windowsupdate-history", L"shell:::{d450a8a1-9568-45c7-9c0e-b4f9fb4537bd}"},
         
-        // History (Troubleshooting)
-        {L"ms-settings:troubleshoot-history", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}\\historyPage"},
+        // History - doubled like as how it was in 10.0.0
+        {L"ms-settings:troubleshoot", L"shell:::{C58C4893-3BE0-4B45-ABB5-A63E4B8C8651}\\historyPage"},
         
         // Keyboard
         {L"ms-settings:keyboard-advanced", L"shell:::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{725BE8F7-668E-4C7B-8F90-46BDB0936430}"},


### PR DESCRIPTION
# Redirect Settings to Control Panel

This mod intercepts modern `ms-settings:` URI protocols and forces Windows to open their classic Control Panel equivalents using native Windows components and legacy CLSIDs.

## Features
- Intercepts ShellExecuteExW, ShellExecuteW, and CreateProcessW calls
- Smart Personalization Detection via hwnd context awareness
- 200+ URI mappings to Control Panel applets
- Configurable fallback modes (ignore, control.exe, passthrough)
- Windows 11 compatibility mode for deprecated CLSIDs

## Compatibility
- Windows 10 21H2 (IoT Enterprise LTSC 2021) ✅
- Windows 10 22H2 ✅
- Windows 11 24H2 ✅ (but more limited compared to Windows 10)

## Limitations
- Windows 10: ~70% redirection success rate
- Windows 11: ~5% baseline restoration (many CLSIDs deprecated by Microsoft)

---

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Initial release - Redirect Settings to Control Panel v9.6.0
* 200+ ms-settings: URI mappings to classic Control Panel
* Smart Personalization detection with hwnd context awareness
* Windows 11 compatibility mode

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [X] The submitter, with AI assistance
- - [X] Claude
- - [X] ChatGPT
- - [X] Gemini
- - [X] Another AI (please specify): Deepseek
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.