### PR TITLE
Fix Monitor Sleep Button tray icon scroll hit testing

### DIFF
--- a/mods/monitor-sleep-button.wh.cpp
+++ b/mods/monitor-sleep-button.wh.cpp
@@ -781,7 +781,6 @@ LRESULT CALLBACK LowLevelMouseProc(int nCode, WPARAM wParam, LPARAM lParam) {
         short delta = static_cast<short>(HIWORD(ms->mouseData));
         int direction = (delta > 0) ? 1 : -1;
 
-        RefreshTrayIconRect();
         BOOL inside = IsPointNearTrayIcon(ms->pt);
 
         if (inside && g_hwnd) {

--- a/mods/monitor-sleep-button.wh.cpp
+++ b/mods/monitor-sleep-button.wh.cpp
@@ -18,6 +18,12 @@
 
 Adds a small tray icon for quickly turning off the monitor after a configurable countdown.
 
+## Preview
+
+![Monitor Sleep Button preview 1](https://i.imgur.com/sztL2TK.png)
+
+![Monitor Sleep Button preview 2](https://i.imgur.com/euxiJiQ.png)
+
 ## Features
 
 - Tray icon for quick monitor power-off
@@ -667,9 +673,9 @@ void RefreshTrayIconRect();
 bool IsPointNearTrayIcon(POINT pt) {
     RECT rect = g_trayIconRect;
 
-    // Tray icon rect can be slightly off because of DPI/taskbar scaling.
-    // Expand it a bit so mouse wheel over the visible icon is still detected.
-    InflateRect(&rect, 32, 48);
+    if (IsRectEmpty(&rect)) {
+        return false;
+    }
 
     return PtInRect(&rect, pt) != FALSE;
 }
@@ -775,6 +781,7 @@ LRESULT CALLBACK LowLevelMouseProc(int nCode, WPARAM wParam, LPARAM lParam) {
         short delta = static_cast<short>(HIWORD(ms->mouseData));
         int direction = (delta > 0) ? 1 : -1;
 
+        RefreshTrayIconRect();
         BOOL inside = IsPointNearTrayIcon(ms->pt);
 
         if (inside && g_hwnd) {

--- a/mods/monitor-sleep-button.wh.cpp
+++ b/mods/monitor-sleep-button.wh.cpp
@@ -2,7 +2,7 @@
 // @id              monitor-sleep-button
 // @name            Monitor Sleep Button
 // @description     Tray icon to turn off the monitor after a configurable countdown.
-// @version         1.1.0
+// @version         1.1.1
 // @author          SilverAmd
 // @github          https://github.com/SilverAmd
 // @homepage        https://github.com/SilverAmd


### PR DESCRIPTION
Fixes #4148.

Monitor Sleep Button now uses the actual Shell_NotifyIconGetRect rectangle for mouse wheel hit testing instead of expanding the tray icon rectangle. The rectangle is refreshed before handling mouse wheel events.

Tested with an adjacent tray icon. Monitor Sleep Button now only changes the countdown when scrolling over its own tray icon.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x ] The submitter, with AI assistance
- - [ ] Claude
- - [x ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
