### PR TITLE
Update taskbar-clock-customization.wh.cpp - Extend 'Remove brackets from info' to media_title and media_artist - Issue #4378

### DIFF
--- a/mods/taskbar-clock-customization.wh.cpp
+++ b/mods/taskbar-clock-customization.wh.cpp
@@ -2563,20 +2563,22 @@ void RefreshMediaData() {
         auto artist = mediaProperties.Artist();
         auto album = mediaProperties.AlbumTitle();
 
+        // Create processed title and artist with bracket removal for individual and combined display
+        std::wstring processedArtist = RemoveBracketsFromString(artist);
+        std::wstring processedTitle = RemoveBracketsFromString(title);
+
         StringCopyTruncatedWithEllipsis(g_mediaTitleFormatted.buffer,
                                         ARRAYSIZE(g_mediaTitleFormatted.buffer),
-                                        title.c_str());
-        StringCopyTruncatedWithEllipsis(
-            g_mediaArtistFormatted.buffer,
-            ARRAYSIZE(g_mediaArtistFormatted.buffer), artist.c_str());
+                                        processedTitle.c_str());
+        StringCopyTruncatedWithEllipsis(g_mediaArtistFormatted.buffer,
+                                        ARRAYSIZE(g_mediaArtistFormatted.buffer),
+                                        processedArtist.c_str());
         StringCopyTruncatedWithEllipsis(g_mediaAlbumFormatted.buffer,
                                         ARRAYSIZE(g_mediaAlbumFormatted.buffer),
                                         album.c_str());
 
         // Create combined info with bracket removal
-        std::wstring processedArtist = RemoveBracketsFromString(artist);
-        std::wstring processedTitle = RemoveBracketsFromString(title);
-
+        
         std::wstring combinedInfo;
         if (!processedArtist.empty() && !processedTitle.empty()) {
             combinedInfo = processedArtist + L" - " + processedTitle;


### PR DESCRIPTION
* Mod enhancement for taskbar-clock-customization
* Solves issue #4378 (raised by me)

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog


* Extends the functionality of "Remove brackets from info" from %media_info% to %media_title% and %media_artist%

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [x] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
