### PR TITLE
Add taskbar-tray-on-all-monitors mod v1.0

### DIFF
--- a/mods/taskbar-tray-on-all-monitors.wh.cpp
+++ b/mods/taskbar-tray-on-all-monitors.wh.cpp
@@ -98,6 +98,7 @@ struct TrayMetrics {
     double notificationCenterButton = 0;
     double showDesktopStack = 0;
     double frameWidth = 0;
+    double stockWidth = 0;  // sum of known stock elements only (excludes injected mod elements)
     bool valid = false;
 };
 
@@ -219,16 +220,35 @@ static void UpdateTrayMetricsFromFrame(FrameworkElement frame,
         metrics.notificationCenterButton +
         metrics.showDesktopStack;
 
+    metrics.stockWidth = measuredWidth;
     metrics.valid = measuredWidth > 0 && metrics.frameWidth > 0;
     g_trayMetrics = metrics;
 
-    Wh_Log(L"[TrayMetrics:%s] frame=%.0f sum=%.0f show=%.0f notif=%.0f "
+    Wh_Log(L"[TrayMetrics:%s] frame=%.0f stock=%.0f show=%.0f notif=%.0f "
            L"cc=%.0f nonAct=%.0f main=%.0f nai=%.0f overflow=%.0f valid=%d",
            reason, metrics.frameWidth, measuredWidth,
            metrics.showDesktopStack, metrics.notificationCenterButton,
            metrics.controlCenterButton, metrics.nonActivatableStack,
            metrics.mainStack, metrics.notificationAreaIcons,
            metrics.notifyIconStack, metrics.valid);
+}
+
+// Returns the width that secondary trays should use. This is the sum of
+// stock tray elements only, excluding any elements injected by other mods
+// (e.g. Taskbar Fluent Media Player). Falls back to the full frame width
+// if metrics haven't been computed yet.
+static double GetStockTrayWidth() {
+    if (g_trayMetrics.valid && g_trayMetrics.stockWidth > 0) {
+        return g_trayMetrics.stockWidth;
+    }
+    // Fallback: use full frame width if we don't have metrics yet
+    if (g_primarySystemTrayFrame) {
+        try {
+            double w = g_primarySystemTrayFrame.ActualWidth();
+            if (w > 0) return w;
+        } catch (...) {}
+    }
+    return g_lastPrimaryFrameSize;
 }
 
 FrameworkElement EnumParentElements(
@@ -673,10 +693,17 @@ static bool TryCursorRescue(HWND hWnd, const RECT& requestedRect) {
 
 // ─── MonitorFrom* hooks — redirect to target monitor ────────────────────────
 
-static bool ShouldForceForPoint(POINT pt, HMONITOR targetMon) {
+static bool ShouldForceForPoint(POINT pt, HMONITOR targetMon, int flyoutKind) {
     if (!targetMon) return false;
-    // Ambiguous origin queries
-    if (pt.x == 0 && pt.y == 0) return true;
+    // For kTrayPopup, do NOT redirect ambiguous origin queries (0,0).
+    // The shell queries MonitorFromPoint(0,0) during tray notification
+    // dispatch to find the primary monitor. Redirecting this corrupts
+    // the icon rect calculation, breaking custom popups (e.g. Steam)
+    // at non-100% DPI.
+    if (pt.x == 0 && pt.y == 0) {
+        if (flyoutKind == kTrayPopup) return false;
+        return true;  // other flyout kinds: redirect ambiguous origin
+    }
     // Only redirect if the point resolves to the target monitor already,
     // or to primary (where the system would normally place the flyout)
     FlyoutRedirectionGuard guard;
@@ -693,11 +720,21 @@ static bool ShouldForceForPoint(POINT pt, HMONITOR targetMon) {
     return force;
 }
 
-static bool ShouldForceForRect(LPCRECT rect, HMONITOR targetMon) {
+static bool ShouldForceForRect(LPCRECT rect, HMONITOR targetMon, int flyoutKind) {
     if (!targetMon) return false;
-    if (!rect || (rect->left == 0 && rect->top == 0 &&
-                  rect->right == 0 && rect->bottom == 0))
-        return true;
+    // For kTrayPopup, do NOT redirect zero/degenerate rects. The shell
+    // uses these internally during tray notification dispatch to look up
+    // the primary monitor and compute icon screen rects. Redirecting them
+    // causes DPI-scaled coordinate corruption for custom popups (Steam).
+    bool isZeroRect = !rect || (rect->left == 0 && rect->top == 0 &&
+                                rect->right == 0 && rect->bottom == 0);
+    bool isDegenerateRect = rect &&
+        (rect->right - rect->left <= 1) && (rect->bottom - rect->top <= 1);
+    if (isZeroRect || isDegenerateRect) {
+        if (flyoutKind == kTrayPopup) return false;
+        if (isZeroRect) return true;  // other flyout kinds: redirect zero rects
+        // Degenerate (1x1 or 0x0 non-zero): check normally below
+    }
     FlyoutRedirectionGuard guard;
     HMONITOR actualMon = MonitorFromRect_Original
         ? MonitorFromRect_Original(rect, MONITOR_DEFAULTTONEAREST)
@@ -716,10 +753,17 @@ static bool ShouldForceForRect(LPCRECT rect, HMONITOR targetMon) {
 static HMONITOR WINAPI MonitorFromPoint_Hook(POINT pt, DWORD flags) {
     if (!g_flyoutRedirectionSuppressed && !g_unloading) {
         if (auto* ctx = GetActiveFlyoutContext()) {
-            if (ShouldForceForPoint(pt, ctx->targetMonitor)) {
-                Wh_Log(L"[MFP_Hook] Redirecting pt=(%d,%d) -> mon=%p kind=%d",
-                       pt.x, pt.y, ctx->targetMonitor, ctx->flyoutKind);
-                return ctx->targetMonitor;
+            // For kTrayPopup, skip MonitorFromPoint redirection entirely.
+            // The shell dispatches tray click notifications correctly via
+            // MonitorFromWindow (which we redirect for the taskbar window).
+            // Redirecting MonitorFromPoint during kTrayPopup interferes with
+            // the system's popup window positioning for custom popups (Steam).
+            if (ctx->flyoutKind != kTrayPopup) {
+                if (ShouldForceForPoint(pt, ctx->targetMonitor, ctx->flyoutKind)) {
+                    Wh_Log(L"[MFP_Hook] Redirecting pt=(%d,%d) -> mon=%p kind=%d",
+                           pt.x, pt.y, ctx->targetMonitor, ctx->flyoutKind);
+                    return ctx->targetMonitor;
+                }
             }
         }
     }
@@ -729,12 +773,19 @@ static HMONITOR WINAPI MonitorFromPoint_Hook(POINT pt, DWORD flags) {
 static HMONITOR WINAPI MonitorFromRect_Hook(LPCRECT rect, DWORD flags) {
     if (!g_flyoutRedirectionSuppressed && !g_unloading) {
         if (auto* ctx = GetActiveFlyoutContext()) {
-            if (ShouldForceForRect(rect, ctx->targetMonitor)) {
-                Wh_Log(L"[MFR_Hook] Redirecting rect=(%d,%d,%d,%d) -> mon=%p kind=%d",
-                       rect ? rect->left : 0, rect ? rect->top : 0,
-                       rect ? rect->right : 0, rect ? rect->bottom : 0,
-                       ctx->targetMonitor, ctx->flyoutKind);
-                return ctx->targetMonitor;
+            // For kTrayPopup, skip MonitorFromRect redirection entirely.
+            // Same rationale as MonitorFromPoint: the shell only needs
+            // MonitorFromWindow (taskbar window) to dispatch the tray click.
+            // Redirecting MonitorFromRect causes the system to misplace
+            // custom popup windows (e.g. Steam) that compute their own rects.
+            if (ctx->flyoutKind != kTrayPopup) {
+                if (ShouldForceForRect(rect, ctx->targetMonitor, ctx->flyoutKind)) {
+                    Wh_Log(L"[MFR_Hook] Redirecting rect=(%d,%d,%d,%d) -> mon=%p kind=%d",
+                           rect ? rect->left : 0, rect ? rect->top : 0,
+                           rect ? rect->right : 0, rect ? rect->bottom : 0,
+                           ctx->targetMonitor, ctx->flyoutKind);
+                    return ctx->targetMonitor;
+                }
             }
         }
     }
@@ -1543,6 +1594,77 @@ static const wchar_t* g_stackContainers[] = {
     L"ShowDesktopStack",
 };
 
+// Recursively sync Visibility of named elements from primary to secondary.
+// Walks the primary's XAML subtree and for each named child, finds the same-
+// named child in the secondary subtree and copies its Visibility. This ensures
+// individual system tray icons (clock, volume, network, battery, bell, overflow
+// chevron, etc.) match the primary's state on each secondary monitor.
+static void DeepSyncVisibility(FrameworkElement primary,
+                                FrameworkElement secondary,
+                                int depth = 0) {
+    if (depth > 12) return;  // safety limit
+
+    int pCount = Media::VisualTreeHelper::GetChildrenCount(primary);
+    int sCount = Media::VisualTreeHelper::GetChildrenCount(secondary);
+
+    for (int i = 0; i < pCount; i++) {
+        auto pChild = Media::VisualTreeHelper::GetChild(primary, i)
+                          .try_as<FrameworkElement>();
+        if (!pChild) continue;
+
+        // Match by index (same XAML template) — children at the same position
+        // in matching containers correspond to each other
+        FrameworkElement sChild{nullptr};
+        if (i < sCount) {
+            sChild = Media::VisualTreeHelper::GetChild(secondary, i)
+                         .try_as<FrameworkElement>();
+        }
+
+        // If index match failed, try matching by name
+        if (!sChild) {
+            auto name = pChild.Name();
+            if (!name.empty()) {
+                sChild = FindChildByName(secondary, name.c_str());
+            }
+        }
+
+        if (!sChild) continue;
+
+        // Sync visibility
+        auto pVis = pChild.Visibility();
+        auto sVis = sChild.Visibility();
+        if (pVis != sVis) {
+            try { sChild.Visibility(pVis); } catch (...) {}
+        }
+
+        // Sync Width if explicitly set (e.g. ShowDesktop button)
+        try {
+            auto pWidth = pChild.ReadLocalValue(FrameworkElement::WidthProperty());
+            if (pWidth) {
+                auto val = winrt::unbox_value_or<double>(pWidth, -1.0);
+                if (val >= 0) {
+                    sChild.Width(val);
+                }
+            }
+        } catch (...) {}
+
+        // Sync IsEnabled for controls
+        auto pCtrl = pChild.try_as<Controls::Control>();
+        auto sCtrl = sChild.try_as<Controls::Control>();
+        if (pCtrl && sCtrl) {
+            try {
+                bool pEnabled = pCtrl.IsEnabled();
+                if (pEnabled != sCtrl.IsEnabled()) {
+                    sCtrl.IsEnabled(pEnabled);
+                }
+            } catch (...) {}
+        }
+
+        // Recurse into children
+        DeepSyncVisibility(pChild, sChild, depth + 1);
+    }
+}
+
 static void SyncTrayState(SecondaryInfo& si) {
     auto primaryGrid = FindChildByName(g_primarySystemTrayFrame, L"SystemTrayFrameGrid");
     auto secondaryGrid = FindChildByName(si.frame, L"SystemTrayFrameGrid");
@@ -1562,6 +1684,9 @@ static void SyncTrayState(SecondaryInfo& si) {
             secondaryContainer.Visibility(Visibility::Collapsed);
             si.containersUncollapsed = true;
         }
+
+        // Deep-sync individual icon visibility within each container
+        DeepSyncVisibility(primaryContainer, secondaryContainer);
     }
 
     auto primaryNAI = FindChildByName(primaryGrid, L"NotificationAreaIcons");
@@ -1655,13 +1780,17 @@ void TryPopulateSecondaryTray() {
                     UpdateTrayMetricsFromFrame(g_primarySystemTrayFrame,
                                                L"primary-size");
 
+                    // Use stock-only width for secondaries to exclude
+                    // elements injected by other mods (e.g. media player)
+                    double stockWidth = GetStockTrayWidth();
+
                     for (auto& si : g_secondaries) {
                         if (!si.populated || !si.frame) continue;
                         SyncTrayState(si);
                         try {
                             double secWidth = si.frame.Width();
-                            if (secWidth != newWidth) {
-                                si.frame.Width(newWidth);
+                            if (secWidth != stockWidth) {
+                                si.frame.Width(stockWidth);
                                 si.frame.InvalidateMeasure();
                                 si.frame.InvalidateArrange();
                                 auto parent = Media::VisualTreeHelper::GetParent(
@@ -1703,18 +1832,21 @@ void TryPopulateOneSecondary(SecondaryInfo& si) {
 
     si.populated = true;
 
-    double primaryFrameWidth = g_primarySystemTrayFrame.ActualWidth();
+    // Use stock-only width to exclude injected mod elements (e.g. media player)
+    UpdateTrayMetricsFromFrame(g_primarySystemTrayFrame, L"primary-populate");
+    double targetWidth = GetStockTrayWidth();
     double secondaryFrameWidth = si.frame.ActualWidth();
-    Wh_Log(L"Frame widths - primary:%.0f secondary:%.0f",
-           primaryFrameWidth, secondaryFrameWidth);
+    Wh_Log(L"Frame widths - stock:%.0f secondary:%.0f primary-actual:%.0f",
+           targetWidth, secondaryFrameWidth,
+           g_primarySystemTrayFrame.ActualWidth());
 
     SyncTrayState(si);
 
-    // Step 4: Set the secondary frame width to match primary
-    if (primaryFrameWidth > secondaryFrameWidth) {
+    // Step 4: Set the secondary frame width to match stock tray elements
+    if (targetWidth > secondaryFrameWidth) {
         Wh_Log(L"Setting secondary frame Width: %.0f -> %.0f",
-               secondaryFrameWidth, primaryFrameWidth);
-        si.frame.Width(primaryFrameWidth);
+               secondaryFrameWidth, targetWidth);
+        si.frame.Width(targetWidth);
     }
 
     // Force the secondary controller to recalculate frame size
@@ -1953,16 +2085,10 @@ double WINAPI SystemTraySecondaryController_GetFrameSize_Hook(void* pThis, int e
     // Check if this controller's secondary has been populated
     for (auto& si : g_secondaries) {
         if (si.controller == pThis && si.populated) {
-            // Read live primary width to avoid returning stale DPI values
-            double primaryWidth = g_lastPrimaryFrameSize;
-            if (g_primarySystemTrayFrame) {
-                try {
-                    double live = g_primarySystemTrayFrame.ActualWidth();
-                    if (live > 0) primaryWidth = live;
-                } catch (...) {}
-            }
-            if (primaryWidth > originalSize) {
-                return primaryWidth;
+            // Use stock-only width to exclude injected mod elements
+            double stockWidth = GetStockTrayWidth();
+            if (stockWidth > originalSize) {
+                return stockWidth;
             }
         }
     }
@@ -2352,15 +2478,20 @@ static void RefreshSecondaryTrayImpl() {
     try {
         double primaryWidth = g_primarySystemTrayFrame.ActualWidth();
         if (primaryWidth <= 0) return;
-
-        Wh_Log(L"[Refresh] Syncing %zu secondaries to width %.0f",
-               g_secondaries.size(), primaryWidth);
         g_lastPrimaryFrameSize = primaryWidth;
+
+        // Recompute metrics and use stock-only width for secondaries
+        UpdateTrayMetricsFromFrame(g_primarySystemTrayFrame, L"refresh");
+        double stockWidth = GetStockTrayWidth();
+
+        Wh_Log(L"[Refresh] Syncing %zu secondaries to stock width %.0f "
+               L"(primary actual %.0f)",
+               g_secondaries.size(), stockWidth, primaryWidth);
 
         for (auto& si : g_secondaries) {
             if (!si.populated || !si.frame) continue;
             try {
-                si.frame.Width(primaryWidth);
+                si.frame.Width(stockWidth);
                 si.frame.InvalidateMeasure();
                 si.frame.InvalidateArrange();
 

--- a/mods/taskbar-tray-on-all-monitors.wh.cpp
+++ b/mods/taskbar-tray-on-all-monitors.wh.cpp
@@ -535,13 +535,25 @@ extern SystemTraySecondaryController_UpdateFrameSize_t SystemTraySecondaryContro
 static bool g_primaryFrameSearchDone = false;
 static bool g_secondaryFrameSearchDone = false;
 
+// Check if a pointer range is readable using VirtualQuery
+static bool IsReadableMemory(const void* ptr, size_t size) {
+    MEMORY_BASIC_INFORMATION mbi;
+    if (!VirtualQuery(ptr, &mbi, sizeof(mbi))) return false;
+    if (mbi.State != MEM_COMMIT) return false;
+    if (mbi.Protect & (PAGE_NOACCESS | PAGE_GUARD)) return false;
+    // Ensure the entire range fits within this region
+    uintptr_t regionEnd = (uintptr_t)mbi.BaseAddress + mbi.RegionSize;
+    uintptr_t rangeEnd = (uintptr_t)ptr + size;
+    return rangeEnd <= regionEnd;
+}
+
 FrameworkElement TryExtractFrameFromController(void* controller,
                                                 const wchar_t* label) {
     uintptr_t* slots = (uintptr_t*)controller;
 
     for (int i = 2; i < 48; i++) {
-        // Check slot is readable
-        if (IsBadReadPtr(&slots[i], sizeof(uintptr_t))) break;
+        // Check that the slot itself is readable
+        if (!IsReadableMemory(&slots[i], sizeof(uintptr_t))) break;
 
         uintptr_t value = slots[i];
 
@@ -549,16 +561,16 @@ FrameworkElement TryExtractFrameFromController(void* controller,
         if (value < 0x10000) continue;
         if ((value & 0x7) != 0) continue;  // must be 8-byte aligned
 
-        // Check pointed-to memory is readable (object header / vtable ptr)
-        if (IsBadReadPtr((void*)value, 2 * sizeof(void*))) continue;
-
-        // Check vtable pointer itself is readable
+        // Read vtable pointer safely
+        if (!IsReadableMemory((void*)value, sizeof(uintptr_t))) continue;
         uintptr_t vtablePtr = *(uintptr_t*)value;
-        if (vtablePtr < 0x10000) continue;
-        if (IsBadReadPtr((void*)vtablePtr, 3 * sizeof(void*))) continue;
 
-        // Check first vtable entry (QueryInterface) points to executable code
+        if (vtablePtr < 0x10000) continue;
+
+        // Check first vtable entry points to executable code
+        if (!IsReadableMemory((void*)vtablePtr, sizeof(uintptr_t))) continue;
         uintptr_t qiAddr = *(uintptr_t*)vtablePtr;
+
         MEMORY_BASIC_INFORMATION mbi;
         if (!VirtualQuery((void*)qiAddr, &mbi, sizeof(mbi))) continue;
         if (!(mbi.Protect & (PAGE_EXECUTE | PAGE_EXECUTE_READ |
@@ -566,7 +578,7 @@ FrameworkElement TryExtractFrameFromController(void* controller,
                              PAGE_EXECUTE_WRITECOPY)))
             continue;
 
-        // Looks like a valid COM vtable - try QI for FrameworkElement
+        // Try QI for FrameworkElement
         try {
             FrameworkElement fe{nullptr};
             HRESULT hr = ((IUnknown*)value)->QueryInterface(
@@ -591,6 +603,22 @@ FrameworkElement TryExtractFrameFromController(void* controller,
 
 void HandleExtractedFrame(FrameworkElement frame, bool isSecondary) {
     const wchar_t* label = isSecondary ? L"SECONDARY" : L"PRIMARY";
+
+    // Check if the XAML tree is actually built yet (has SystemTrayFrameGrid)
+    auto grid = FindChildByName(frame, L"SystemTrayFrameGrid");
+    if (!grid) {
+        Wh_Log(L"[%s] Frame found via controller scan but XAML tree not "
+               L"ready yet (no SystemTrayFrameGrid) — deferring to IconView",
+               label);
+        // Save the frame reference but don't mark tree as dumped,
+        // so IconView::Loaded can still capture properly
+        if (isSecondary) {
+            g_secondarySystemTrayFrame = frame;
+        } else {
+            g_primarySystemTrayFrame = frame;
+        }
+        return;
+    }
 
     if (isSecondary) {
         g_secondarySystemTrayFrame = frame;
@@ -680,10 +708,23 @@ static const wchar_t* g_stackContainers[] = {
     L"ShowDesktopStack",
 };
 
+void TryPopulateSecondaryTrayImpl();
+
 void TryPopulateSecondaryTray() {
     if (g_populationAttempted) return;
     g_populationAttempted = true;
 
+    try {
+        TryPopulateSecondaryTrayImpl();
+    } catch (winrt::hresult_error const& ex) {
+        Wh_Log(L"Population failed (hresult): 0x%08X %s",
+               (unsigned)ex.code(), ex.message().c_str());
+    } catch (...) {
+        Wh_Log(L"Population failed (unknown exception)");
+    }
+}
+
+void TryPopulateSecondaryTrayImpl() {
     Wh_Log(L"=== ATTEMPTING TO POPULATE SECONDARY TRAY ===");
 
     auto primaryGrid =
@@ -691,7 +732,8 @@ void TryPopulateSecondaryTray() {
     auto secondaryGrid =
         FindChildByName(g_secondarySystemTrayFrame, L"SystemTrayFrameGrid");
     if (!primaryGrid || !secondaryGrid) {
-        Wh_Log(L"Missing grid(s), aborting");
+        Wh_Log(L"Missing grid(s), aborting (will retry)");
+        g_populationAttempted = false;  // allow retry once grids are ready
         return;
     }
 
@@ -922,31 +964,33 @@ void TryPopulateSecondaryTray() {
            SizeChangedEventArgs const& args) {
             if (g_unloading || !g_secondarySystemTrayFrame) return;
 
-            double newWidth = args.NewSize().Width;
-            double oldWidth = args.PreviousSize().Width;
-            if (newWidth == oldWidth) return;
+            try {
+                double newWidth = args.NewSize().Width;
+                double oldWidth = args.PreviousSize().Width;
+                if (newWidth == oldWidth) return;
 
-            Wh_Log(L"[PrimarySizeChanged] %.0f -> %.0f", oldWidth, newWidth);
+                Wh_Log(L"[PrimarySizeChanged] %.0f -> %.0f", oldWidth, newWidth);
 
-            // Update the cached primary size
-            g_lastPrimaryFrameSize = newWidth;
+                g_lastPrimaryFrameSize = newWidth;
 
-            // Apply to secondary frame
-            double secWidth = g_secondarySystemTrayFrame.Width();
-            if (secWidth != newWidth) {
-                Wh_Log(L"[PrimarySizeChanged] Syncing secondary: %.0f -> %.0f",
-                       secWidth, newWidth);
-                g_secondarySystemTrayFrame.Width(newWidth);
-                g_secondarySystemTrayFrame.InvalidateMeasure();
-                g_secondarySystemTrayFrame.InvalidateArrange();
-                auto parent = Media::VisualTreeHelper::GetParent(
-                    g_secondarySystemTrayFrame).try_as<FrameworkElement>();
-                while (parent) {
-                    parent.InvalidateMeasure();
-                    parent.InvalidateArrange();
-                    parent = Media::VisualTreeHelper::GetParent(parent)
-                        .try_as<FrameworkElement>();
+                double secWidth = g_secondarySystemTrayFrame.Width();
+                if (secWidth != newWidth) {
+                    Wh_Log(L"[PrimarySizeChanged] Syncing secondary: %.0f -> %.0f",
+                           secWidth, newWidth);
+                    g_secondarySystemTrayFrame.Width(newWidth);
+                    g_secondarySystemTrayFrame.InvalidateMeasure();
+                    g_secondarySystemTrayFrame.InvalidateArrange();
+                    auto parent = Media::VisualTreeHelper::GetParent(
+                        g_secondarySystemTrayFrame).try_as<FrameworkElement>();
+                    while (parent) {
+                        parent.InvalidateMeasure();
+                        parent.InvalidateArrange();
+                        parent = Media::VisualTreeHelper::GetParent(parent)
+                            .try_as<FrameworkElement>();
+                    }
                 }
+            } catch (...) {
+                Wh_Log(L"[PrimarySizeChanged] Exception during sync");
             }
         });
     Wh_Log(L"[SizeChanged] Registered on primary frame");
@@ -994,11 +1038,48 @@ void HandleLoadedIconView(FrameworkElement iconView) {
 
 // ─── SystemTrayController hooks ─────────────────────────────────────────────
 
+// Reset all XAML state — called when a new controller is created (explorer restart)
+static void ResetXamlState() {
+    Wh_Log(L"Resetting XAML state (new controller detected)");
+
+    // Unregister SizeChanged before releasing the reference
+    if (g_primarySystemTrayFrame && g_primarySizeChangedToken.value) {
+        try {
+            g_primarySystemTrayFrame.SizeChanged(g_primarySizeChangedToken);
+        } catch (...) {}
+        g_primarySizeChangedToken = {};
+    }
+
+    UninstallFlyoutHook();
+    g_autoRevokerList.clear();
+
+    g_primarySystemTrayFrame = nullptr;
+    g_secondarySystemTrayFrame = nullptr;
+    g_primaryTreeDumped = false;
+    g_secondaryTreeDumped = false;
+    g_primaryFrameSearchDone = false;
+    g_secondaryFrameSearchDone = false;
+    g_populationAttempted = false;
+    g_secondaryContainersUncollapsed = false;
+    g_lastPrimaryFrameSize = 0;
+    g_primaryController = nullptr;
+    g_secondaryControllerCount = 0;
+    memset(g_secondaryControllers, 0, sizeof(g_secondaryControllers));
+}
+
 // Constructor: captures primary controller this pointer
 using SystemTrayController_ctor_t = void*(WINAPI*)(void* pThis, void* taskbarModel);
 SystemTrayController_ctor_t SystemTrayController_ctor_Original;
 void* WINAPI SystemTrayController_ctor_Hook(void* pThis, void* taskbarModel) {
-    Wh_Log(L">>> SystemTrayController::ctor this=%p", pThis);
+    Wh_Log(L">>> SystemTrayController::ctor this=%p (prev=%p)", pThis,
+           g_primaryController);
+
+    // Always reset if we already had a controller — explorer may reuse the
+    // same heap address after restart, so pointer comparison is unreliable
+    if (g_primaryController) {
+        ResetXamlState();
+    }
+
     g_primaryController = pThis;
     void* ret = SystemTrayController_ctor_Original(pThis, taskbarModel);
     Wh_Log(L">>> SystemTrayController::ctor done, ret=%p", ret);
@@ -1078,10 +1159,12 @@ void WINAPI SystemTraySecondaryController_UpdateFrameSize_Hook(void* pThis) {
     // Re-apply width override after the original sets it to native value
     if (g_populationAttempted && g_secondarySystemTrayFrame &&
         g_lastPrimaryFrameSize > 0 && !g_unloading) {
-        double currentWidth = g_secondarySystemTrayFrame.Width();
-        if (currentWidth != g_lastPrimaryFrameSize) {
-            g_secondarySystemTrayFrame.Width(g_lastPrimaryFrameSize);
-        }
+        try {
+            double currentWidth = g_secondarySystemTrayFrame.Width();
+            if (currentWidth != g_lastPrimaryFrameSize) {
+                g_secondarySystemTrayFrame.Width(g_lastPrimaryFrameSize);
+            }
+        } catch (...) {}
     }
 }
 
@@ -1115,40 +1198,43 @@ void* WINAPI IconView_IconView_Hook(void* pThis) {
 
     if (g_unloading) return ret;
 
-    // Get FrameworkElement from IconView WinRT object
-    // WinRT implementation objects have IInspectable at ((IUnknown**)pThis)[1]
-    FrameworkElement iconView = nullptr;
-    ((IUnknown**)pThis)[1]->QueryInterface(winrt::guid_of<FrameworkElement>(),
-                                           winrt::put_abi(iconView));
-    if (!iconView) {
-        return ret;
+    try {
+        // Get FrameworkElement from IconView WinRT object
+        FrameworkElement iconView = nullptr;
+        ((IUnknown**)pThis)[1]->QueryInterface(
+            winrt::guid_of<FrameworkElement>(), winrt::put_abi(iconView));
+        if (!iconView) {
+            return ret;
+        }
+
+        Wh_Log(L">>> IconView created: %p", pThis);
+
+        // Hook the Loaded event to explore the tree once in the visual tree
+        g_autoRevokerList.emplace_back();
+        auto autoRevokerIt = g_autoRevokerList.end();
+        --autoRevokerIt;
+
+        *autoRevokerIt = iconView.Loaded(
+            winrt::auto_revoke_t{},
+            [autoRevokerIt](
+                winrt::Windows::Foundation::IInspectable const& sender,
+                RoutedEventArgs const& e) {
+                g_autoRevokerList.erase(autoRevokerIt);
+
+                if (g_unloading) return;
+
+                try {
+                    auto iconView = sender.try_as<FrameworkElement>();
+                    if (!iconView) return;
+
+                    HandleLoadedIconView(iconView);
+                } catch (...) {
+                    Wh_Log(L"Exception in IconView Loaded handler");
+                }
+            });
+    } catch (...) {
+        Wh_Log(L"Exception in IconView_IconView_Hook");
     }
-
-    Wh_Log(L">>> IconView created: %p", pThis);
-
-    // Hook the Loaded event to explore the tree once the element is in the visual tree
-    g_autoRevokerList.emplace_back();
-    auto autoRevokerIt = g_autoRevokerList.end();
-    --autoRevokerIt;
-
-    *autoRevokerIt = iconView.Loaded(
-        winrt::auto_revoke_t{},
-        [autoRevokerIt](winrt::Windows::Foundation::IInspectable const& sender,
-                        RoutedEventArgs const& e) {
-            g_autoRevokerList.erase(autoRevokerIt);
-
-            if (g_unloading) return;
-
-            auto iconView = sender.try_as<FrameworkElement>();
-            if (!iconView) return;
-
-            auto className = winrt::get_class_name(iconView);
-            auto name = iconView.Name();
-            Wh_Log(L">>> IconView Loaded: class=%s name=%s",
-                   className.c_str(), name.c_str());
-
-            HandleLoadedIconView(iconView);
-        });
 
     return ret;
 }
@@ -1383,27 +1469,34 @@ void Wh_ModUninit() {
 static void RefreshSecondaryTray() {
     if (g_unloading) return;
 
-    if (g_primarySystemTrayFrame && g_secondarySystemTrayFrame) {
-        double primaryWidth = g_primarySystemTrayFrame.ActualWidth();
-        if (primaryWidth > 0) {
-            Wh_Log(L"[Refresh] Syncing secondary width to %.0f", primaryWidth);
-            g_lastPrimaryFrameSize = primaryWidth;
-            g_secondarySystemTrayFrame.Width(primaryWidth);
-            g_secondarySystemTrayFrame.InvalidateMeasure();
-            g_secondarySystemTrayFrame.InvalidateArrange();
+    try {
+        if (g_primarySystemTrayFrame && g_secondarySystemTrayFrame) {
+            double primaryWidth = g_primarySystemTrayFrame.ActualWidth();
+            if (primaryWidth > 0) {
+                Wh_Log(L"[Refresh] Syncing secondary width to %.0f", primaryWidth);
+                g_lastPrimaryFrameSize = primaryWidth;
+                g_secondarySystemTrayFrame.Width(primaryWidth);
+                g_secondarySystemTrayFrame.InvalidateMeasure();
+                g_secondarySystemTrayFrame.InvalidateArrange();
 
-            // Walk up the visual tree to force parent re-layout
-            auto parent = Media::VisualTreeHelper::GetParent(
-                g_secondarySystemTrayFrame).try_as<FrameworkElement>();
-            while (parent) {
-                parent.InvalidateMeasure();
-                parent.InvalidateArrange();
-                parent = Media::VisualTreeHelper::GetParent(parent)
-                    .try_as<FrameworkElement>();
+                // Walk up the visual tree to force parent re-layout
+                auto parent = Media::VisualTreeHelper::GetParent(
+                    g_secondarySystemTrayFrame).try_as<FrameworkElement>();
+                while (parent) {
+                    parent.InvalidateMeasure();
+                    parent.InvalidateArrange();
+                    parent = Media::VisualTreeHelper::GetParent(parent)
+                        .try_as<FrameworkElement>();
+                }
+
+                g_secondarySystemTrayFrame.UpdateLayout();
             }
-
-            g_secondarySystemTrayFrame.UpdateLayout();
         }
+    } catch (winrt::hresult_error const& ex) {
+        Wh_Log(L"[Refresh] Failed (hresult): 0x%08X %s",
+               (unsigned)ex.code(), ex.message().c_str());
+    } catch (...) {
+        Wh_Log(L"[Refresh] Failed (unknown exception)");
     }
 }
 

--- a/mods/taskbar-tray-on-all-monitors.wh.cpp
+++ b/mods/taskbar-tray-on-all-monitors.wh.cpp
@@ -23,13 +23,16 @@ Mirrors the system tray from the primary taskbar onto all secondary monitor
 taskbars — including the clock, volume, network, battery, notification area
 icons, input indicator, overflow chevron, and Show Desktop button.
 
+Supports any number of monitors (2, 3, 4, etc.).
+
 **Only Windows 11 (build 26200+) is supported.**
 
 ## Features
 
-- All system tray icons visible on secondary taskbars (click, hover,
+- All system tray icons visible on every secondary taskbar (click, hover,
   right-click context menus work natively)
-- Dynamic width syncing — secondary tray resizes automatically when icons
+- Multi-monitor support — works with 3+ displays, not just 2
+- Dynamic width syncing — all secondary trays resize automatically when icons
   are added or removed on the primary
 - Show Desktop button synced to match primary visibility
 - Flyout repositioning — Quick Settings, notification panels, and context
@@ -40,8 +43,8 @@ icons, input indicator, overflow chevron, and Show Desktop button.
 
 Hooks into `SystemTrayController` and `SystemTraySecondaryController` in
 `SystemTray.dll`, then shares XAML `ItemsSource` bindings from the primary
-tray containers to the secondary ones. A `SizeChanged` event on the primary
-frame keeps the secondary width in sync at runtime.
+tray containers to each secondary. A `SizeChanged` event on the primary
+frame keeps all secondary widths in sync at runtime.
 */
 // ==/WindhawkModReadme==
 
@@ -59,6 +62,7 @@ frame keeps the secondary width in sync at runtime.
 #include <atomic>
 #include <functional>
 #include <list>
+#include <vector>
 
 using namespace winrt::Windows::UI::Xaml;
 
@@ -66,21 +70,28 @@ using namespace winrt::Windows::UI::Xaml;
 
 static std::atomic<bool> g_unloading{false};
 
-// Captured controller pointers
+// Captured primary controller pointer
 static void* g_primaryController = nullptr;
-static void* g_secondaryControllers[8] = {};
-static int   g_secondaryControllerCount = 0;
 
-// Track whether we've dumped the XAML tree for primary/secondary
+// Track whether we've dumped the primary XAML tree
 static bool g_primaryTreeDumped = false;
-static bool g_secondaryTreeDumped = false;
 
-// Saved XAML tree references for primary/secondary SystemTrayFrame
+// Primary SystemTrayFrame reference
 static FrameworkElement g_primarySystemTrayFrame{nullptr};
-static FrameworkElement g_secondarySystemTrayFrame{nullptr};
-static bool g_populationAttempted = false;
 static double g_lastPrimaryFrameSize = 0;
 static winrt::event_token g_primarySizeChangedToken{};
+
+// Per-secondary-controller state
+struct SecondaryInfo {
+    void* controller = nullptr;
+    FrameworkElement frame{nullptr};
+    bool treeDumped = false;
+    bool frameSearchDone = false;
+    bool populated = false;
+    bool containersUncollapsed = false;
+};
+
+static std::vector<SecondaryInfo> g_secondaries;
 
 // Hidden window for display change notifications
 static HWND g_displayChangeWindow = nullptr;
@@ -244,7 +255,7 @@ static void TrackFlyout(HWND hwnd, HMONITOR target) {
 }
 
 static void UntrackFlyout(HWND hwnd) {
-    for (int i = 0; i < g_trackedCount; i++) {
+    for (int i = 0; i < g_trackedCount;  i++) {
         if (g_trackedFlyouts[i] == hwnd) {
             g_trackedFlyouts[i] = g_trackedFlyouts[--g_trackedCount];
             g_trackedTargets[i] = g_trackedTargets[g_trackedCount];
@@ -533,7 +544,6 @@ extern SystemTraySecondaryController_UpdateFrameSize_t SystemTraySecondaryContro
 // Used when mod is loaded after startup (no new IconViews being created).
 
 static bool g_primaryFrameSearchDone = false;
-static bool g_secondaryFrameSearchDone = false;
 
 // Check if a pointer range is readable using VirtualQuery
 static bool IsReadableMemory(const void* ptr, size_t size) {
@@ -601,7 +611,25 @@ FrameworkElement TryExtractFrameFromController(void* controller,
     return nullptr;
 }
 
-void HandleExtractedFrame(FrameworkElement frame, bool isSecondary) {
+// Find or create a SecondaryInfo for a given controller
+static SecondaryInfo* FindOrCreateSecondary(void* controller) {
+    for (auto& si : g_secondaries) {
+        if (si.controller == controller) return &si;
+    }
+    g_secondaries.push_back({controller});
+    return &g_secondaries.back();
+}
+
+// Find the SecondaryInfo that owns a given frame
+static SecondaryInfo* FindSecondaryByFrame(FrameworkElement frame) {
+    for (auto& si : g_secondaries) {
+        if (si.frame == frame) return &si;
+    }
+    return nullptr;
+}
+
+void HandleExtractedFrame(FrameworkElement frame, bool isSecondary,
+                          void* controller = nullptr) {
     const wchar_t* label = isSecondary ? L"SECONDARY" : L"PRIMARY";
 
     // Check if the XAML tree is actually built yet (has SystemTrayFrameGrid)
@@ -610,21 +638,29 @@ void HandleExtractedFrame(FrameworkElement frame, bool isSecondary) {
         Wh_Log(L"[%s] Frame found via controller scan but XAML tree not "
                L"ready yet (no SystemTrayFrameGrid) — deferring to IconView",
                label);
-        // Save the frame reference but don't mark tree as dumped,
-        // so IconView::Loaded can still capture properly
-        if (isSecondary) {
-            g_secondarySystemTrayFrame = frame;
-        } else {
+        if (isSecondary && controller) {
+            auto* si = FindOrCreateSecondary(controller);
+            si->frame = frame;
+        } else if (!isSecondary) {
             g_primarySystemTrayFrame = frame;
         }
         return;
     }
 
     if (isSecondary) {
-        g_secondarySystemTrayFrame = frame;
-        if (!g_secondaryTreeDumped) {
-            g_secondaryTreeDumped = true;
-            Wh_Log(L"=== SECONDARY TASKBAR XAML TREE (via controller scan) ===");
+        SecondaryInfo* si = controller ? FindOrCreateSecondary(controller)
+                                       : FindSecondaryByFrame(frame);
+        if (!si) {
+            // No controller association yet — create one with nullptr controller
+            // (will be associated later via UpdateFrameSize)
+            g_secondaries.push_back({nullptr, frame});
+            si = &g_secondaries.back();
+        }
+        si->frame = frame;
+        if (!si->treeDumped) {
+            si->treeDumped = true;
+            Wh_Log(L"=== SECONDARY TASKBAR XAML TREE (via controller scan) [%zu] ===",
+                   g_secondaries.size());
             DumpXamlTree(frame, 0, 8);
             ProbeContainerInterfaces(frame, label);
         }
@@ -638,7 +674,7 @@ void HandleExtractedFrame(FrameworkElement frame, bool isSecondary) {
         }
     }
 
-    if (g_primarySystemTrayFrame && g_secondarySystemTrayFrame) {
+    if (g_primarySystemTrayFrame) {
         TryPopulateSecondaryTray();
     }
 }
@@ -687,9 +723,6 @@ void ProbeContainerInterfaces(FrameworkElement systemTrayFrame,
 
 // ─── Try to populate secondary tray from primary ────────────────────────────
 
-// Track what we changed so we can undo on unload
-static bool g_secondaryContainersUncollapsed = false;
-
 // Containers whose visibility is synced between primary and secondary
 static const wchar_t* g_syncedContainers[] = {
     L"ControlCenterButton",
@@ -708,42 +741,95 @@ static const wchar_t* g_stackContainers[] = {
     L"ShowDesktopStack",
 };
 
-void TryPopulateSecondaryTrayImpl();
+void TryPopulateOneSecondary(SecondaryInfo& si);
 
 void TryPopulateSecondaryTray() {
-    if (g_populationAttempted) return;
-    g_populationAttempted = true;
+    if (!g_primarySystemTrayFrame) return;
 
-    try {
-        TryPopulateSecondaryTrayImpl();
-    } catch (winrt::hresult_error const& ex) {
-        Wh_Log(L"Population failed (hresult): 0x%08X %s",
-               (unsigned)ex.code(), ex.message().c_str());
-    } catch (...) {
-        Wh_Log(L"Population failed (unknown exception)");
+    bool anyPopulated = false;
+    for (auto& si : g_secondaries) {
+        if (si.populated || !si.frame) continue;
+
+        try {
+            TryPopulateOneSecondary(si);
+            if (si.populated) anyPopulated = true;
+        } catch (winrt::hresult_error const& ex) {
+            Wh_Log(L"Population failed (hresult): 0x%08X %s",
+                   (unsigned)ex.code(), ex.message().c_str());
+        } catch (...) {
+            Wh_Log(L"Population failed (unknown exception)");
+        }
+    }
+
+    // Register SizeChanged on primary (once) if any secondary got populated
+    if (anyPopulated && !g_primarySizeChangedToken.value) {
+        g_primarySizeChangedToken = g_primarySystemTrayFrame.SizeChanged(
+            [](winrt::Windows::Foundation::IInspectable const& sender,
+               SizeChangedEventArgs const& args) {
+                if (g_unloading) return;
+
+                try {
+                    double newWidth = args.NewSize().Width;
+                    double oldWidth = args.PreviousSize().Width;
+                    if (newWidth == oldWidth) return;
+
+                    Wh_Log(L"[PrimarySizeChanged] %.0f -> %.0f",
+                           oldWidth, newWidth);
+                    g_lastPrimaryFrameSize = newWidth;
+
+                    for (auto& si : g_secondaries) {
+                        if (!si.populated || !si.frame) continue;
+                        try {
+                            double secWidth = si.frame.Width();
+                            if (secWidth != newWidth) {
+                                si.frame.Width(newWidth);
+                                si.frame.InvalidateMeasure();
+                                si.frame.InvalidateArrange();
+                                auto parent = Media::VisualTreeHelper::GetParent(
+                                    si.frame).try_as<FrameworkElement>();
+                                while (parent) {
+                                    parent.InvalidateMeasure();
+                                    parent.InvalidateArrange();
+                                    parent = Media::VisualTreeHelper::GetParent(
+                                        parent).try_as<FrameworkElement>();
+                                }
+                            }
+                        } catch (...) {}
+                    }
+                } catch (...) {
+                    Wh_Log(L"[PrimarySizeChanged] Exception during sync");
+                }
+            });
+        Wh_Log(L"[SizeChanged] Registered on primary frame");
+    }
+
+    // Install flyout repositioning hook once any secondary is populated
+    if (anyPopulated) {
+        InstallFlyoutHook();
     }
 }
 
-void TryPopulateSecondaryTrayImpl() {
-    Wh_Log(L"=== ATTEMPTING TO POPULATE SECONDARY TRAY ===");
+void TryPopulateOneSecondary(SecondaryInfo& si) {
+    Wh_Log(L"=== ATTEMPTING TO POPULATE SECONDARY TRAY (controller=%p) ===",
+           si.controller);
 
     auto primaryGrid =
         FindChildByName(g_primarySystemTrayFrame, L"SystemTrayFrameGrid");
     auto secondaryGrid =
-        FindChildByName(g_secondarySystemTrayFrame, L"SystemTrayFrameGrid");
+        FindChildByName(si.frame, L"SystemTrayFrameGrid");
     if (!primaryGrid || !secondaryGrid) {
         Wh_Log(L"Missing grid(s), aborting (will retry)");
-        g_populationAttempted = false;  // allow retry once grids are ready
-        return;
+        return;  // si.populated stays false — will retry
     }
 
-    // Log primary frame dimensions for reference
+    si.populated = true;
+
     double primaryFrameWidth = g_primarySystemTrayFrame.ActualWidth();
-    double secondaryFrameWidth = g_secondarySystemTrayFrame.ActualWidth();
+    double secondaryFrameWidth = si.frame.ActualWidth();
     Wh_Log(L"Frame widths - primary:%.0f secondary:%.0f",
            primaryFrameWidth, secondaryFrameWidth);
 
-    // Step 1: Sync visibility of containers between primary and secondary
+    // Step 1: Sync visibility of containers
     for (auto containerName : g_syncedContainers) {
         auto primaryContainer = FindChildByName(primaryGrid, containerName);
         auto secondaryContainer = FindChildByName(secondaryGrid, containerName);
@@ -765,21 +851,18 @@ void TryPopulateSecondaryTrayImpl() {
                secondaryW, secondaryContainer.ActualHeight(),
                secondaryVis == Visibility::Collapsed ? L"COLLAPSED" : L"Visible");
 
-        // Sync visibility: match secondary to primary
         if (primaryVis == Visibility::Visible &&
             secondaryVis == Visibility::Collapsed) {
             Wh_Log(L"[%s] Uncollapsing secondary container", containerName);
             secondaryContainer.Visibility(Visibility::Visible);
-            g_secondaryContainersUncollapsed = true;
+            si.containersUncollapsed = true;
         } else if (primaryVis == Visibility::Collapsed &&
                    secondaryVis == Visibility::Visible) {
             Wh_Log(L"[%s] Collapsing secondary to match primary", containerName);
             secondaryContainer.Visibility(Visibility::Collapsed);
-            g_secondaryContainersUncollapsed = true;
+            si.containersUncollapsed = true;
         }
 
-        // If secondary is visible but very narrow (< 5px), it might be
-        // effectively hidden - log this for diagnosis
         if (secondaryVis == Visibility::Visible && secondaryW < 5 &&
             primaryW > 5) {
             Wh_Log(L"[%s] Secondary is visible but very narrow (%.0f vs %.0f)",
@@ -787,9 +870,7 @@ void TryPopulateSecondaryTrayImpl() {
         }
     }
 
-    // Step 2: Share NotificationAreaIcons ItemsSource for third-party tray icons
-    // NotificationAreaIcons is a DIRECT child of SystemTrayFrameGrid (sibling
-    // of NotifyIconStack, not inside it)
+    // Step 2: Share NotificationAreaIcons ItemsSource
     auto primaryNAI = FindChildByName(primaryGrid, L"NotificationAreaIcons");
     auto secondaryNAI = FindChildByName(secondaryGrid, L"NotificationAreaIcons");
 
@@ -819,7 +900,6 @@ void TryPopulateSecondaryTrayImpl() {
                 }
             }
 
-            // Uncollapse if needed
             if (secondaryNAI.Visibility() == Visibility::Collapsed &&
                 primaryNAI.Visibility() == Visibility::Visible) {
                 secondaryNAI.Visibility(Visibility::Visible);
@@ -832,8 +912,7 @@ void TryPopulateSecondaryTrayImpl() {
                secondaryNAI ? L"found" : L"MISSING");
     }
 
-    // Step 3: Share ItemsSource for ControlCenterButton and
-    //         NotificationCenterButton (in case secondary has 0 items)
+    // Step 3: Share ItemsSource for ControlCenterButton and NotificationCenterButton
     const wchar_t* icContainers[] = {
         L"ControlCenterButton",
         L"NotificationCenterButton",
@@ -864,14 +943,11 @@ void TryPopulateSecondaryTrayImpl() {
     }
 
     // Step 3b: Share StackListView ItemsSource for Stack containers
-    // SystemTray.Stack is NOT an ItemsControl, but it contains a child
-    // StackListView (via Content grid > IconStack) which IS an ItemsControl.
     for (auto stackName : g_stackContainers) {
         auto primaryStack = FindChildByName(primaryGrid, stackName);
         auto secondaryStack = FindChildByName(secondaryGrid, stackName);
         if (!primaryStack || !secondaryStack) continue;
 
-        // Drill down: Stack > Content (Grid) > IconStack (StackListView)
         auto primaryContent = FindChildByName(primaryStack, L"Content");
         auto secondaryContent = FindChildByName(secondaryStack, L"Content");
         if (!primaryContent || !secondaryContent) continue;
@@ -913,27 +989,25 @@ void TryPopulateSecondaryTrayImpl() {
     }
 
     // Step 4: Set the secondary frame width to match primary
-    // (GetFrameSize symbol may not exist, so set Width directly)
     if (primaryFrameWidth > secondaryFrameWidth) {
         Wh_Log(L"Setting secondary frame Width: %.0f -> %.0f",
                secondaryFrameWidth, primaryFrameWidth);
-        g_secondarySystemTrayFrame.Width(primaryFrameWidth);
+        si.frame.Width(primaryFrameWidth);
     }
 
     // Force the secondary controller to recalculate frame size
-    if (g_secondaryControllerCount > 0 &&
+    if (si.controller &&
         SystemTraySecondaryController_UpdateFrameSize_Original) {
-        Wh_Log(L"Forcing UpdateFrameSize on secondary controller");
-        SystemTraySecondaryController_UpdateFrameSize_Original(
-            g_secondaryControllers[0]);
+        Wh_Log(L"Forcing UpdateFrameSize on secondary controller %p",
+               si.controller);
+        SystemTraySecondaryController_UpdateFrameSize_Original(si.controller);
     }
 
-    // Also force layout update on secondary frame
-    g_secondarySystemTrayFrame.InvalidateMeasure();
-    g_secondarySystemTrayFrame.InvalidateArrange();
-    g_secondarySystemTrayFrame.UpdateLayout();
+    // Force layout update on secondary frame
+    si.frame.InvalidateMeasure();
+    si.frame.InvalidateArrange();
+    si.frame.UpdateLayout();
 
-    // Also invalidate the grid
     secondaryGrid.InvalidateMeasure();
     secondaryGrid.InvalidateArrange();
     secondaryGrid.UpdateLayout();
@@ -953,50 +1027,9 @@ void TryPopulateSecondaryTrayImpl() {
                child.Visibility() == Visibility::Collapsed ? L"COLLAPSED" : L"Visible");
     }
     Wh_Log(L"Secondary frame size now: %.0fx%.0f",
-           g_secondarySystemTrayFrame.ActualWidth(),
-           g_secondarySystemTrayFrame.ActualHeight());
+           si.frame.ActualWidth(), si.frame.ActualHeight());
 
     Wh_Log(L"=== POPULATION ATTEMPT COMPLETE ===");
-
-    // Step 6: Watch primary frame for size changes so we can sync to secondary
-    g_primarySizeChangedToken = g_primarySystemTrayFrame.SizeChanged(
-        [](winrt::Windows::Foundation::IInspectable const& sender,
-           SizeChangedEventArgs const& args) {
-            if (g_unloading || !g_secondarySystemTrayFrame) return;
-
-            try {
-                double newWidth = args.NewSize().Width;
-                double oldWidth = args.PreviousSize().Width;
-                if (newWidth == oldWidth) return;
-
-                Wh_Log(L"[PrimarySizeChanged] %.0f -> %.0f", oldWidth, newWidth);
-
-                g_lastPrimaryFrameSize = newWidth;
-
-                double secWidth = g_secondarySystemTrayFrame.Width();
-                if (secWidth != newWidth) {
-                    Wh_Log(L"[PrimarySizeChanged] Syncing secondary: %.0f -> %.0f",
-                           secWidth, newWidth);
-                    g_secondarySystemTrayFrame.Width(newWidth);
-                    g_secondarySystemTrayFrame.InvalidateMeasure();
-                    g_secondarySystemTrayFrame.InvalidateArrange();
-                    auto parent = Media::VisualTreeHelper::GetParent(
-                        g_secondarySystemTrayFrame).try_as<FrameworkElement>();
-                    while (parent) {
-                        parent.InvalidateMeasure();
-                        parent.InvalidateArrange();
-                        parent = Media::VisualTreeHelper::GetParent(parent)
-                            .try_as<FrameworkElement>();
-                    }
-                }
-            } catch (...) {
-                Wh_Log(L"[PrimarySizeChanged] Exception during sync");
-            }
-        });
-    Wh_Log(L"[SizeChanged] Registered on primary frame");
-
-    // Install flyout repositioning hook now that secondary tray is populated
-    InstallFlyoutHook();
 }
 
 // ─── Process a loaded IconView element ──────────────────────────────────────
@@ -1013,10 +1046,25 @@ void HandleLoadedIconView(FrameworkElement iconView) {
     bool isSecondary = IsSecondaryTaskbar(systemTrayFrame);
 
     if (isSecondary) {
-        if (!g_secondaryTreeDumped) {
-            g_secondaryTreeDumped = true;
-            g_secondarySystemTrayFrame = systemTrayFrame;
-            Wh_Log(L"=== SECONDARY TASKBAR XAML TREE ===");
+        // Find existing SecondaryInfo with this frame, or find one without
+        // a frame yet, or create a new one
+        SecondaryInfo* si = FindSecondaryByFrame(systemTrayFrame);
+        if (!si) {
+            // Try to find a secondary entry that has no frame yet
+            for (auto& s : g_secondaries) {
+                if (!s.frame) { si = &s; break; }
+            }
+            if (!si) {
+                g_secondaries.push_back({nullptr, systemTrayFrame});
+                si = &g_secondaries.back();
+            } else {
+                si->frame = systemTrayFrame;
+            }
+        }
+        if (!si->treeDumped) {
+            si->treeDumped = true;
+            Wh_Log(L"=== SECONDARY TASKBAR XAML TREE [%zu] ===",
+                   g_secondaries.size());
             DumpXamlTree(systemTrayFrame, 0, 8);
             ProbeContainerInterfaces(systemTrayFrame, L"SECONDARY");
         }
@@ -1030,8 +1078,7 @@ void HandleLoadedIconView(FrameworkElement iconView) {
         }
     }
 
-    // Once we have both, try to populate the secondary tray
-    if (g_primarySystemTrayFrame && g_secondarySystemTrayFrame) {
+    if (g_primarySystemTrayFrame) {
         TryPopulateSecondaryTray();
     }
 }
@@ -1054,17 +1101,16 @@ static void ResetXamlState() {
     g_autoRevokerList.clear();
 
     g_primarySystemTrayFrame = nullptr;
-    g_secondarySystemTrayFrame = nullptr;
     g_primaryTreeDumped = false;
-    g_secondaryTreeDumped = false;
     g_primaryFrameSearchDone = false;
-    g_secondaryFrameSearchDone = false;
-    g_populationAttempted = false;
-    g_secondaryContainersUncollapsed = false;
     g_lastPrimaryFrameSize = 0;
     g_primaryController = nullptr;
-    g_secondaryControllerCount = 0;
-    memset(g_secondaryControllers, 0, sizeof(g_secondaryControllers));
+
+    // Clear all secondary state
+    for (auto& si : g_secondaries) {
+        si.frame = nullptr;
+    }
+    g_secondaries.clear();
 }
 
 // Constructor: captures primary controller this pointer
@@ -1123,9 +1169,7 @@ SystemTraySecondaryController_ctor_t SystemTraySecondaryController_ctor_Original
 void* WINAPI SystemTraySecondaryController_ctor_Hook(void* pThis, void* taskbarModel) {
     Wh_Log(L">>> SystemTraySecondaryController::ctor this=%p", pThis);
 
-    if (g_secondaryControllerCount < 8) {
-        g_secondaryControllers[g_secondaryControllerCount++] = pThis;
-    }
+    FindOrCreateSecondary(pThis);
 
     void* ret = SystemTraySecondaryController_ctor_Original(pThis, taskbarModel);
     Wh_Log(L">>> SystemTraySecondaryController::ctor done, ret=%p", ret);
@@ -1136,33 +1180,34 @@ void* WINAPI SystemTraySecondaryController_ctor_Hook(void* pThis, void* taskbarM
 using SystemTraySecondaryController_UpdateFrameSize_t = void(WINAPI*)(void* pThis);
 SystemTraySecondaryController_UpdateFrameSize_t SystemTraySecondaryController_UpdateFrameSize_Original;
 void WINAPI SystemTraySecondaryController_UpdateFrameSize_Hook(void* pThis) {
-    // Track this secondary controller
-    bool found = false;
-    for (int i = 0; i < g_secondaryControllerCount; i++) {
-        if (g_secondaryControllers[i] == pThis) { found = true; break; }
-    }
-    if (!found && g_secondaryControllerCount < 8) {
-        g_secondaryControllers[g_secondaryControllerCount++] = pThis;
-        Wh_Log(L">>> Secondary controller captured via UpdateFrameSize: %p", pThis);
-    }
+    // Ensure this controller is tracked
+    auto* si = FindOrCreateSecondary(pThis);
+
     SystemTraySecondaryController_UpdateFrameSize_Original(pThis);
 
     // Fallback: extract frame from controller if not yet captured
-    if (!g_secondarySystemTrayFrame && !g_secondaryFrameSearchDone && !g_unloading) {
-        g_secondaryFrameSearchDone = true;
+    if (!si->frame && !si->frameSearchDone && !g_unloading) {
+        si->frameSearchDone = true;
         auto frame = TryExtractFrameFromController(pThis, L"SECONDARY");
         if (frame) {
-            HandleExtractedFrame(frame, true);
+            HandleExtractedFrame(frame, true, pThis);
         }
     }
 
-    // Re-apply width override after the original sets it to native value
-    if (g_populationAttempted && g_secondarySystemTrayFrame &&
-        g_lastPrimaryFrameSize > 0 && !g_unloading) {
+    // Re-apply width override after the original sets it to native value.
+    // Re-read the primary frame's actual width rather than using the cached
+    // g_lastPrimaryFrameSize, because during DPI changes the cache may be
+    // stale (still holding the old-DPI value).
+    if (si->populated && si->frame &&
+        g_primarySystemTrayFrame && !g_unloading) {
         try {
-            double currentWidth = g_secondarySystemTrayFrame.Width();
-            if (currentWidth != g_lastPrimaryFrameSize) {
-                g_secondarySystemTrayFrame.Width(g_lastPrimaryFrameSize);
+            double primaryWidth = g_primarySystemTrayFrame.ActualWidth();
+            if (primaryWidth > 0) {
+                g_lastPrimaryFrameSize = primaryWidth;
+                double currentWidth = si->frame.Width();
+                if (currentWidth != primaryWidth) {
+                    si->frame.Width(primaryWidth);
+                }
             }
         } catch (...) {}
     }
@@ -1182,8 +1227,12 @@ SystemTraySecondaryController_GetFrameSize_t SystemTraySecondaryController_GetFr
 double WINAPI SystemTraySecondaryController_GetFrameSize_Hook(void* pThis, int enumTaskbarSize) {
     double originalSize = SystemTraySecondaryController_GetFrameSize_Original(pThis, enumTaskbarSize);
 
-    if (g_populationAttempted && g_lastPrimaryFrameSize > originalSize) {
-        return g_lastPrimaryFrameSize;
+    // Check if this controller's secondary has been populated
+    for (auto& si : g_secondaries) {
+        if (si.controller == pThis && si.populated &&
+            g_lastPrimaryFrameSize > originalSize) {
+            return g_lastPrimaryFrameSize;
+        }
     }
 
     return originalSize;
@@ -1383,7 +1432,7 @@ BOOL Wh_ModInit() {
 void Wh_ModAfterInit() {
     Wh_Log(L">");
     Wh_Log(L"Primary controller: %p", g_primaryController);
-    Wh_Log(L"Secondary controllers: %d", g_secondaryControllerCount);
+    Wh_Log(L"Secondary controllers: %zu", g_secondaries.size());
 
     // If the mod was loaded after the taskbar is already running, we need to
     // force the taskbar to rebuild so our constructor and UpdateFrameSize
@@ -1419,24 +1468,19 @@ void Wh_ModBeforeUninit() {
     // Clear loaded event revokers
     g_autoRevokerList.clear();
 
-    // Restore secondary tray to original state
-    if (g_secondaryContainersUncollapsed && g_secondarySystemTrayFrame) {
+    // Restore all secondary trays to original state
+    for (auto& si : g_secondaries) {
+        if (!si.containersUncollapsed || !si.frame) continue;
         try {
-            auto grid = FindChildByName(g_secondarySystemTrayFrame,
-                                         L"SystemTrayFrameGrid");
+            auto grid = FindChildByName(si.frame, L"SystemTrayFrameGrid");
             if (grid) {
-                // Re-collapse containers that we modified
                 for (auto name : g_syncedContainers) {
                     auto child = FindChildByName(grid, name);
                     if (child && child.ActualWidth() > 0) {
-                        // Only re-collapse if it was originally collapsed
-                        // (we can't perfectly know, but narrow ones likely were)
                         child.Visibility(Visibility::Collapsed);
                     }
                 }
 
-                // Clear shared ItemsSource on NotificationAreaIcons
-                // (it's a direct child of SystemTrayFrameGrid)
                 auto nai = FindChildByName(grid, L"NotificationAreaIcons");
                 if (nai) {
                     auto ic = nai.try_as<Controls::ItemsControl>();
@@ -1445,20 +1489,22 @@ void Wh_ModBeforeUninit() {
                     }
                 }
 
-                // Restore frame width and force layout update
-                g_secondarySystemTrayFrame.ClearValue(
-                    FrameworkElement::WidthProperty());
-                g_secondarySystemTrayFrame.InvalidateMeasure();
-                g_secondarySystemTrayFrame.UpdateLayout();
+                si.frame.ClearValue(FrameworkElement::WidthProperty());
+                si.frame.InvalidateMeasure();
+                si.frame.UpdateLayout();
             }
         } catch (...) {
-            Wh_Log(L"Error during cleanup");
+            Wh_Log(L"Error during cleanup of secondary controller %p",
+                   si.controller);
         }
     }
 
     // Release XAML references
     g_primarySystemTrayFrame = nullptr;
-    g_secondarySystemTrayFrame = nullptr;
+    for (auto& si : g_secondaries) {
+        si.frame = nullptr;
+    }
+    g_secondaries.clear();
 }
 
 void Wh_ModUninit() {
@@ -1467,22 +1513,27 @@ void Wh_ModUninit() {
 
 // ─── refresh helper ─────────────────────────────────────────────────────────
 
-static void RefreshSecondaryTray() {
+static void RefreshSecondaryTrayImpl() {
     if (g_unloading) return;
+    if (!g_primarySystemTrayFrame) return;
 
     try {
-        if (g_primarySystemTrayFrame && g_secondarySystemTrayFrame) {
-            double primaryWidth = g_primarySystemTrayFrame.ActualWidth();
-            if (primaryWidth > 0) {
-                Wh_Log(L"[Refresh] Syncing secondary width to %.0f", primaryWidth);
-                g_lastPrimaryFrameSize = primaryWidth;
-                g_secondarySystemTrayFrame.Width(primaryWidth);
-                g_secondarySystemTrayFrame.InvalidateMeasure();
-                g_secondarySystemTrayFrame.InvalidateArrange();
+        double primaryWidth = g_primarySystemTrayFrame.ActualWidth();
+        if (primaryWidth <= 0) return;
 
-                // Walk up the visual tree to force parent re-layout
+        Wh_Log(L"[Refresh] Syncing %zu secondaries to width %.0f",
+               g_secondaries.size(), primaryWidth);
+        g_lastPrimaryFrameSize = primaryWidth;
+
+        for (auto& si : g_secondaries) {
+            if (!si.populated || !si.frame) continue;
+            try {
+                si.frame.Width(primaryWidth);
+                si.frame.InvalidateMeasure();
+                si.frame.InvalidateArrange();
+
                 auto parent = Media::VisualTreeHelper::GetParent(
-                    g_secondarySystemTrayFrame).try_as<FrameworkElement>();
+                    si.frame).try_as<FrameworkElement>();
                 while (parent) {
                     parent.InvalidateMeasure();
                     parent.InvalidateArrange();
@@ -1490,14 +1541,43 @@ static void RefreshSecondaryTray() {
                         .try_as<FrameworkElement>();
                 }
 
-                g_secondarySystemTrayFrame.UpdateLayout();
-            }
+                si.frame.UpdateLayout();
+            } catch (...) {}
         }
     } catch (winrt::hresult_error const& ex) {
         Wh_Log(L"[Refresh] Failed (hresult): 0x%08X %s",
                (unsigned)ex.code(), ex.message().c_str());
     } catch (...) {
         Wh_Log(L"[Refresh] Failed (unknown exception)");
+    }
+}
+
+// Timer ID for deferred refresh after DPI/display changes
+static UINT_PTR g_refreshTimerId = 0;
+
+static void CALLBACK RefreshTimerProc(HWND hwnd, UINT msg, UINT_PTR id,
+                                       DWORD time) {
+    KillTimer(hwnd, id);
+    g_refreshTimerId = 0;
+    Wh_Log(L"[Refresh] Deferred refresh firing");
+    RefreshSecondaryTrayImpl();
+}
+
+static void RefreshSecondaryTray() {
+    if (g_unloading) return;
+
+    // During DPI/display changes the primary frame hasn't re-laid-out yet
+    // when the notification arrives. Defer the refresh so ActualWidth()
+    // returns the new DPI-scaled value.
+    if (g_displayChangeWindow) {
+        if (g_refreshTimerId) {
+            KillTimer(g_displayChangeWindow, g_refreshTimerId);
+        }
+        g_refreshTimerId = SetTimer(g_displayChangeWindow, 1, 250,
+                                     RefreshTimerProc);
+        Wh_Log(L"[Refresh] Deferred refresh scheduled (250ms)");
+    } else {
+        RefreshSecondaryTrayImpl();
     }
 }
 
@@ -1560,6 +1640,10 @@ static void InstallDisplayChangeListener() {
 
 static void UninstallDisplayChangeListener() {
     if (g_displayChangeWindow) {
+        if (g_refreshTimerId) {
+            KillTimer(g_displayChangeWindow, g_refreshTimerId);
+            g_refreshTimerId = 0;
+        }
         DestroyWindow(g_displayChangeWindow);
         g_displayChangeWindow = nullptr;
     }

--- a/mods/taskbar-tray-on-all-monitors.wh.cpp
+++ b/mods/taskbar-tray-on-all-monitors.wh.cpp
@@ -52,7 +52,6 @@ frame keeps all secondary widths in sync at runtime.
 #include <windhawk_utils.h>
 
 #include <commctrl.h>
-#include <shellapi.h>
 #include <ShellScalingApi.h>
 #include <windowsx.h>
 #include <winrt/base.h>
@@ -440,17 +439,13 @@ static void ArmFlyoutContext(HWND taskbarWnd, int kind, POINT anchor) {
     MONITORINFOEX armMi = {};
     armMi.cbSize = sizeof(armMi);
     GetMonitorInfo(mon, &armMi);
-    APPBARDATA abd = {sizeof(abd)};
-    UINT abState = (UINT)SHAppBarMessage(ABM_GETSTATE, &abd);
     Wh_Log(L"[FlyoutCtx] Armed kind=%d mon=%p \"%s\" dpi=%u anchor=(%d,%d) "
-           L"duration=%u taskbar=(%d,%d,%d,%d) monWork=(%d,%d,%d,%d) "
-           L"autoHide=%s",
+           L"duration=%u taskbar=(%d,%d,%d,%d) monWork=(%d,%d,%d,%d)",
            kind, mon, armMi.szDevice, g_flyoutCtx.targetDpi,
            anchor.x, anchor.y, durationMs,
            tbRect.left, tbRect.top, tbRect.right, tbRect.bottom,
            armMi.rcWork.left, armMi.rcWork.top,
-           armMi.rcWork.right, armMi.rcWork.bottom,
-           (abState & ABS_AUTOHIDE) ? L"YES" : L"NO");
+           armMi.rcWork.right, armMi.rcWork.bottom);
 }
 
 static void ClearFlyoutContext() {
@@ -480,10 +475,16 @@ static void ShortenFlyoutContext(DWORD newDurationMs) {
     }
 }
 
+// Forward declarations used by flyout code below
+static bool IsKnownFlyoutWindow(HWND hWnd, wchar_t* outClass = nullptr,
+                                 int outClassSize = 0);
+static decltype(&MonitorFromRect) MonitorFromRect_Original = nullptr;
+static decltype(&SetWindowPos)    SetWindowPos_Original     = nullptr;
+
 // ─── Known flyout window identification ─────────────────────────────────────
 
-static bool IsKnownFlyoutWindow(HWND hWnd, wchar_t* outClass = nullptr,
-                                 int outClassSize = 0) {
+static bool IsKnownFlyoutWindow(HWND hWnd, wchar_t* outClass,
+                                 int outClassSize) {
     wchar_t className[128] = {};
     if (!GetClassName(hWnd, className, ARRAYSIZE(className)))
         return false;
@@ -495,15 +496,42 @@ static bool IsKnownFlyoutWindow(HWND hWnd, wchar_t* outClass = nullptr,
         return true;
     if (wcscmp(className, L"ControlCenterWindow") == 0)
         return true;
-    // Note: Xaml_WindowedPopupClass is excluded — it matches tooltips and
-    // small XAML popups that the system positions correctly. Real CC/overflow
-    // flyouts use ControlCenterWindow or TopLevelWindowForOverflowXamlIsland.
+    // Xaml_WindowedPopupClass is matched only when a CC/NC flyout context
+    // is active (i.e. we just forwarded a right-click to the primary).
+    // This avoids catching tooltips and other small XAML popups that the
+    // system positions correctly during normal operation.
+    if (wcscmp(className, L"Xaml_WindowedPopupClass") == 0) {
+        auto* ctx = GetActiveFlyoutContext();
+        return ctx && (ctx->flyoutKind == kControlCenter ||
+                       ctx->flyoutKind == kNotificationCenter);
+    }
     if (wcscmp(className, L"#32768") == 0)
         return true;
-    if (wcscmp(className, L"XamlExplorerHostIslandWindow") == 0)
+    // XamlExplorerHostIslandWindow and DesktopChildSiteBridge are used by
+    // both tray flyout popups AND Explorer file manager windows (toolbars,
+    // navigation bar, content area). Only treat them as flyout windows if
+    // they are NOT children of an Explorer file manager window (CabinetWClass)
+    // or a navigation window (ShellTabWindowClass).
+    if (wcscmp(className, L"XamlExplorerHostIslandWindow") == 0 ||
+        wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0) {
+        // Walk up the parent/owner chain to check for Explorer file manager
+        HWND ancestor = hWnd;
+        for (int i = 0; i < 10 && ancestor; i++) {
+            HWND parent = GetParent(ancestor);
+            if (!parent) parent = GetWindow(ancestor, GW_OWNER);
+            if (!parent) break;
+            wchar_t parentClass[128] = {};
+            if (GetClassName(parent, parentClass, ARRAYSIZE(parentClass))) {
+                if (wcscmp(parentClass, L"CabinetWClass") == 0 ||
+                    wcscmp(parentClass, L"ShellTabWindowClass") == 0 ||
+                    wcscmp(parentClass, L"ExploreWClass") == 0) {
+                    return false;  // Explorer file manager window, not a flyout
+                }
+            }
+            ancestor = parent;
+        }
         return true;
-    if (wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0)
-        return true;
+    }
     // Note: Windows.UI.Composition.DesktopWindowContentBridge is excluded —
     // it's the taskbar's own XAML bridge, not a flyout popup.
     return false;
@@ -525,9 +553,7 @@ static bool IsKnownFlyoutWindow(HWND hWnd, wchar_t* outClass = nullptr,
 
 // Original function pointers (set during hook installation)
 static decltype(&MonitorFromPoint)  MonitorFromPoint_Original  = nullptr;
-static decltype(&MonitorFromRect)   MonitorFromRect_Original   = nullptr;
 static decltype(&MonitorFromWindow) MonitorFromWindow_Original = nullptr;
-static decltype(&SetWindowPos)      SetWindowPos_Original      = nullptr;
 static decltype(&MoveWindow)        MoveWindow_Original        = nullptr;
 static decltype(&DeferWindowPos)    DeferWindowPos_Original    = nullptr;
 static decltype(&TrackPopupMenuEx)  TrackPopupMenuEx_Original  = nullptr;
@@ -568,20 +594,23 @@ static bool TranslateFlyoutRect(HWND hWnd, const RECT& requested,
         if (!sourceDpi) sourceDpi = 96;
     }
 
+    // Get class name for kind-specific placement and rescaling decisions
+    wchar_t className[128] = {};
+    GetClassName(hWnd, className, ARRAYSIZE(className));
+
     // Rescale dimensions if source and target monitors have different DPI.
-    // Only rescale for fixed-size flyouts (overflow tray, tray popups).
-    // Control Center and Notification Center fill the work area height and
-    // are already sized correctly by the system for the target monitor.
-    bool shouldRescale = (sourceDpi != targetDpi) &&
-        (ctx->flyoutKind == kOverflowTray || ctx->flyoutKind == kTrayPopup);
+    // Rescale for: fixed-size flyouts (overflow tray, tray popups) and
+    // Xaml_WindowedPopupClass (CC/NC context menus forwarded from secondary).
+    // Full-height panels (Control Center, Notification Center) fill the work
+    // area and are sized correctly by the system — no rescaling needed.
+    bool isSmallPopup = (ctx->flyoutKind == kOverflowTray ||
+                         ctx->flyoutKind == kTrayPopup ||
+                         wcscmp(className, L"Xaml_WindowedPopupClass") == 0);
+    bool shouldRescale = (sourceDpi != targetDpi) && isSmallPopup;
     if (shouldRescale) {
         width  = MulDiv(width, targetDpi, sourceDpi);
         height = MulDiv(height, targetDpi, sourceDpi);
     }
-
-    // Get class name for kind-specific placement
-    wchar_t className[128] = {};
-    GetClassName(hWnd, className, ARRAYSIZE(className));
 
     Wh_Log(L"[Translate] class=%s kind=%d anchor=(%d,%d) "
            L"targetMon=%p srcDpi=%u tgtDpi=%u "
@@ -649,7 +678,7 @@ static bool TranslateFlyoutRect(HWND hWnd, const RECT& requested,
 
 static bool TryCursorRescue(HWND hWnd, const RECT& requestedRect) {
     wchar_t className[128] = {};
-    if (!GetClassName(hWnd, className, ARRAYSIZE(className)))
+    if (!IsKnownFlyoutWindow(hWnd, className, ARRAYSIZE(className)))
         return false;
 
     int kind = kFlyoutNone;
@@ -896,6 +925,28 @@ static BOOL WINAPI SetWindowPos_Hook(HWND hWnd, HWND hWndInsertAfter,
                                       int X, int Y, int cx, int cy,
                                       UINT uFlags) {
     if (!g_unloading && !g_flyoutRedirectionSuppressed) {
+        // Unconditional logging for Xaml_WindowedPopupClass to diagnose
+        // right-click context menus (primary vs secondary comparison).
+        {
+            wchar_t debugCls[128] = {};
+            if (GetClassName(hWnd, debugCls, ARRAYSIZE(debugCls)) &&
+                wcscmp(debugCls, L"Xaml_WindowedPopupClass") == 0 &&
+                ShouldTranslatePlacement(uFlags)) {
+                RECT wr = {};
+                GetWindowRect(hWnd, &wr);
+                bool vis = IsWindowVisible(hWnd);
+                LONG style = GetWindowLong(hWnd, GWL_STYLE);
+                LONG exStyle = GetWindowLong(hWnd, GWL_EXSTYLE);
+                Wh_Log(L"[SWP_Debug] Xaml_WindowedPopupClass hwnd=%p "
+                       L"pos=(%d,%d) size=(%d,%d) flags=0x%X "
+                       L"curRect=(%d,%d,%d,%d) visible=%d "
+                       L"style=0x%X exStyle=0x%X",
+                       hWnd, X, Y, cx, cy, uFlags,
+                       wr.left, wr.top, wr.right, wr.bottom,
+                       vis, style, exStyle);
+            }
+        }
+
         bool isFlyout = IsKnownFlyoutWindow(hWnd);
 
         if (isFlyout && ShouldTranslatePlacement(uFlags)) {
@@ -1103,8 +1154,11 @@ static BOOL WINAPI TrackPopupMenuEx_Hook(HMENU hMenu, UINT uFlags,
                    ctx->flyoutKind);
 
             ShortenFlyoutContext(kAfterPlacementMs);
-            return TrackPopupMenuEx_Original(hMenu, uFlags, newX, newY,
-                                              hWnd, lptpm);
+
+            BOOL result = TrackPopupMenuEx_Original(hMenu, uFlags, newX, newY,
+                                                     hWnd, lptpm);
+
+            return result;
         }
     }
     return TrackPopupMenuEx_Original(hMenu, uFlags, x, y, hWnd, lptpm);
@@ -1257,6 +1311,222 @@ static bool GetFlyoutAnchorPoint(HWND hWnd, LPARAM lParam, int flyoutKind,
     return true;
 }
 
+// ─── Mouse hook — intercept right-clicks on CC/NC, relay to primary ──────────
+// The XAML island child window processes WM_RBUTTONDOWN directly, before
+// WM_PARENTNOTIFY reaches Shell_SecondaryTrayWnd. A WH_MOUSE hook fires
+// before the target window's WndProc, letting us swallow the message.
+//
+// Instead of just eating the click, we relay it to the primary taskbar's
+// XAML island at the equivalent position. The primary processes it normally
+// (no XamlRoot crash), opens the MenuFlyout, and our SetWindowPos/MoveWindow
+// hooks reposition the resulting Xaml_WindowedPopupClass to the secondary.
+
+static HHOOK g_mouseHook = nullptr;
+
+// Set when we're forwarding a right-click to the primary — prevents the
+// mouse hook from eating the forwarded message and the subclass from
+// re-arming the flyout context. Cleared by a deferred timer after
+// SendInput's async messages have been processed.
+static bool g_forwardingRightClick = false;
+
+// Timer callback: clears g_forwardingRightClick after SendInput's async
+// messages have been processed by the message loop.
+static VOID CALLBACK ForwardClickCleanupTimerProc(HWND, UINT, UINT_PTR id,
+                                                   DWORD) {
+    KillTimer(nullptr, id);
+    g_forwardingRightClick = false;
+    Wh_Log(L"[Forward] Cleanup timer fired, forwarding flag cleared");
+}
+
+// Find the Shell_SecondaryTrayWnd ancestor of a window, if any.
+static HWND FindSecondaryTaskbarAncestor(HWND hWnd) {
+    HWND root = GetAncestor(hWnd, GA_ROOT);
+    if (!root) return nullptr;
+    wchar_t cls[64] = {};
+    GetClassName(root, cls, ARRAYSIZE(cls));
+    if (wcscmp(cls, L"Shell_SecondaryTrayWnd") == 0)
+        return root;
+    return nullptr;
+}
+
+// Find the XAML island child window inside a taskbar (primary or secondary).
+// The XAML island is a child window of class
+// "Windows.UI.Composition.DesktopWindowContentBridge".
+static HWND FindXamlIslandChild(HWND taskbarWnd) {
+    struct FindCtx { HWND result; } ctx = {nullptr};
+    EnumChildWindows(taskbarWnd, [](HWND child, LPARAM lp) -> BOOL {
+        wchar_t cls[128] = {};
+        GetClassName(child, cls, ARRAYSIZE(cls));
+        if (wcscmp(cls, L"Windows.UI.Composition.DesktopWindowContentBridge") == 0) {
+            auto* c = reinterpret_cast<FindCtx*>(lp);
+            c->result = child;
+            return FALSE;  // found it
+        }
+        return TRUE;
+    }, reinterpret_cast<LPARAM>(&ctx));
+    return ctx.result;
+}
+
+// Translate a right-click from a secondary taskbar to the primary.
+// The click position is mapped by preserving the x-offset-from-right,
+// since both taskbars share the same tray layout (right-aligned).
+static void ForwardRightClickToPrimary(HWND secondaryTaskbar,
+                                        POINT screenPt, int kind) {
+    // Find primary taskbar
+    HWND primaryTaskbar = FindWindow(L"Shell_TrayWnd", nullptr);
+    if (!primaryTaskbar) {
+        Wh_Log(L"[Forward] Primary taskbar not found");
+        return;
+    }
+
+    // Find XAML island in primary
+    HWND primaryIsland = FindXamlIslandChild(primaryTaskbar);
+    if (!primaryIsland) {
+        Wh_Log(L"[Forward] Primary XAML island not found");
+        return;
+    }
+
+    // Compute x-from-right in the secondary taskbar (in client pixels)
+    RECT secClient = {};
+    GetClientRect(secondaryTaskbar, &secClient);
+    POINT secClientPt = screenPt;
+    ScreenToClient(secondaryTaskbar, &secClientPt);
+    int xFromRight = secClient.right - secClientPt.x;
+
+    // Map to primary taskbar client coordinates (same x-from-right)
+    RECT priClient = {};
+    GetClientRect(primaryTaskbar, &priClient);
+
+    // DPI-adjust: the x-from-right is in secondary pixels, convert to primary pixels
+    UINT secDpi = GetWindowDpi(secondaryTaskbar);
+    UINT priDpi = GetWindowDpi(primaryTaskbar);
+    int priXFromRight = MulDiv(xFromRight, priDpi, secDpi ? secDpi : 96);
+
+    int priClientX = priClient.right - priXFromRight;
+    if (priClientX < priClient.left) priClientX = priClient.left;
+
+    // The XAML island may not cover the full taskbar client area.
+    // Convert from taskbar client to island client coords.
+    POINT priScreenPt = {priClientX, (priClient.top + priClient.bottom) / 2};
+    ClientToScreen(primaryTaskbar, &priScreenPt);
+
+    POINT islandClientPt = priScreenPt;
+    ScreenToClient(primaryIsland, &islandClientPt);
+
+    // Arm flyout context targeting the secondary monitor BEFORE sending
+    // the click so our MonitorFrom*/SetWindowPos hooks redirect the menu.
+    POINT anchor = {};
+    LPARAM secLParam = MAKELPARAM(secClientPt.x, secClientPt.y);
+    GetFlyoutAnchorPoint(secondaryTaskbar, secLParam, kind, &anchor);
+    ArmFlyoutContext(secondaryTaskbar, kind, anchor);
+
+    Wh_Log(L"[Forward] Relaying right-click: secondary screen=(%d,%d) "
+           L"xFromRight=%d -> primary island client=(%d,%d) kind=%d "
+           L"anchor=(%d,%d)",
+           screenPt.x, screenPt.y, xFromRight,
+           islandClientPt.x, islandClientPt.y, kind,
+           anchor.x, anchor.y);
+
+    // Synthesize a real right-click at the primary island position using
+    // SendInput. SendMessage(WM_RBUTTONDOWN/UP) doesn't work because XAML's
+    // input processing requires messages to come through the real input
+    // pipeline with proper input state (GetAsyncKeyState, etc.).
+    //
+    // SendInput with MOUSEEVENTF_ABSOLUTE positions the click in normalized
+    // coordinates (0-65535 mapped to the virtual screen). The mouse hook's
+    // g_forwardingRightClick flag prevents our hook from eating the
+    // injected click on the primary.
+
+    // Convert primary screen point to normalized absolute coordinates.
+    // The virtual screen spans all monitors.
+    int vsX = GetSystemMetrics(SM_XVIRTUALSCREEN);
+    int vsY = GetSystemMetrics(SM_YVIRTUALSCREEN);
+    int vsW = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+    int vsH = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+    LONG absX = (LONG)(((double)(priScreenPt.x - vsX) / vsW) * 65535.0 + 0.5);
+    LONG absY = (LONG)(((double)(priScreenPt.y - vsY) / vsH) * 65535.0 + 0.5);
+
+    Wh_Log(L"[Forward] SendInput abs=(%d,%d) screen=(%d,%d) vs=(%d,%d,%d,%d)",
+           absX, absY, priScreenPt.x, priScreenPt.y, vsX, vsY, vsW, vsH);
+
+    INPUT inputs[3] = {};
+    // First move cursor to the primary position
+    inputs[0].type = INPUT_MOUSE;
+    inputs[0].mi.dx = absX;
+    inputs[0].mi.dy = absY;
+    inputs[0].mi.dwFlags = MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE |
+                            MOUSEEVENTF_VIRTUALDESK;
+    // Right button down
+    inputs[1].type = INPUT_MOUSE;
+    inputs[1].mi.dx = absX;
+    inputs[1].mi.dy = absY;
+    inputs[1].mi.dwFlags = MOUSEEVENTF_RIGHTDOWN | MOUSEEVENTF_ABSOLUTE |
+                            MOUSEEVENTF_VIRTUALDESK;
+    // Right button up
+    inputs[2].type = INPUT_MOUSE;
+    inputs[2].mi.dx = absX;
+    inputs[2].mi.dy = absY;
+    inputs[2].mi.dwFlags = MOUSEEVENTF_RIGHTUP | MOUSEEVENTF_ABSOLUTE |
+                            MOUSEEVENTF_VIRTUALDESK;
+
+    // Set flag BEFORE SendInput. SendInput is async — the injected messages
+    // arrive through the message queue AFTER SendInput returns. We use a
+    // timer callback to clear the flag and restore the cursor after XAML
+    // has had time to process the input and create the context menu.
+    g_forwardingRightClick = true;
+    SendInput(3, inputs, sizeof(INPUT));
+
+    // Defer cursor restore and flag reset via timer. 200ms gives XAML
+    // enough time to process the input and create the context menu.
+    SetTimer(nullptr, 0, 200, ForwardClickCleanupTimerProc);
+}
+
+static LRESULT CALLBACK MouseHookProc(int nCode, WPARAM wParam, LPARAM lParam) {
+    if (nCode >= 0 && !g_unloading && !g_forwardingRightClick) {
+        if (wParam == WM_RBUTTONDOWN || wParam == WM_RBUTTONUP ||
+            wParam == WM_CONTEXTMENU) {
+            auto* mhs = reinterpret_cast<MOUSEHOOKSTRUCT*>(lParam);
+            HWND taskbar = FindSecondaryTaskbarAncestor(mhs->hwnd);
+            if (taskbar) {
+                // Convert screen coords to taskbar client coords for hit test
+                POINT clientPt = mhs->pt;
+                ScreenToClient(taskbar, &clientPt);
+                LPARAM clientLParam = MAKELPARAM(clientPt.x, clientPt.y);
+                int kind = HitTestTrayClick(taskbar, clientLParam);
+                if (kind == kControlCenter || kind == kNotificationCenter) {
+                    if (wParam == WM_RBUTTONDOWN) {
+                        Wh_Log(L"[MouseHook] Intercepting right-click on "
+                               L"CC/NC (kind=%d) -> forwarding to primary",
+                               kind);
+                        ForwardRightClickToPrimary(taskbar, mhs->pt, kind);
+                    }
+                    return 1;  // eat the original message
+                }
+            }
+        }
+    }
+    return CallNextHookEx(g_mouseHook, nCode, wParam, lParam);
+}
+
+static void InstallMouseHook() {
+    if (g_mouseHook) return;
+    g_mouseHook = SetWindowsHookEx(WH_MOUSE, MouseHookProc, nullptr,
+                                    GetCurrentThreadId());
+    if (g_mouseHook) {
+        Wh_Log(L"[MouseHook] Installed on thread %u", GetCurrentThreadId());
+    } else {
+        Wh_Log(L"[MouseHook] Failed: error=%d", GetLastError());
+    }
+}
+
+static void RemoveMouseHook() {
+    if (g_mouseHook) {
+        UnhookWindowsHookEx(g_mouseHook);
+        g_mouseHook = nullptr;
+        Wh_Log(L"[MouseHook] Removed");
+    }
+}
+
 // ─── Taskbar subclass ───────────────────────────────────────────────────────
 
 static constexpr UINT_PTR kTaskbarSubclassId = 0x54524159; // 'TRAY'
@@ -1272,6 +1542,13 @@ static LRESULT CALLBACK TaskbarSubclassProc(HWND hWnd, UINT uMsg,
         if (uMsg == WM_NCDESTROY) {
             RemoveWindowSubclass(hWnd, TaskbarSubclassProc, kTaskbarSubclassId);
         }
+        return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+    }
+
+    // Skip arming during forwarded right-clicks — we already armed the
+    // context in ForwardRightClickToPrimary and don't want the subclass
+    // to override it with a different kind when WM_PARENTNOTIFY arrives.
+    if (g_forwardingRightClick) {
         return DefSubclassProc(hWnd, uMsg, wParam, lParam);
     }
 
@@ -1296,6 +1573,9 @@ static LRESULT CALLBACK TaskbarSubclassProc(HWND hWnd, UINT uMsg,
     if (isDown) {
         int kind = HitTestTrayClick(hWnd, lParam);
         if (kind != kFlyoutNone) {
+            // Note: right-click on CC/NC is eaten by the WH_MOUSE hook
+            // (MouseHookProc) before it reaches the XAML island. The
+            // subclass here only arms the flyout context for left-clicks.
             if (isRight && kind != kOverflowTray) {
                 kind = kTrayPopup;
             }
@@ -1366,6 +1646,10 @@ static void InstallFlyoutHooks() {
             InstallTaskbarSubclass(tbWnd);
         }
     }
+
+    // Install WH_MOUSE hook to eat right-clicks on CC/NC before XAML
+    // island processes them (prevents XamlRoot-lock crash).
+    InstallMouseHook();
 }
 
 // ─── Identify primary vs secondary from XAML tree ───────────────────────────
@@ -1702,22 +1986,43 @@ static void SyncTrayState(SecondaryInfo& si) {
         }
     }
 
-    const wchar_t* icContainers[] = {
-        L"ControlCenterButton",
-        L"NotificationCenterButton",
-    };
-    for (auto name : icContainers) {
-        auto primaryC = FindChildByName(primaryGrid, name);
-        auto secondaryC = FindChildByName(secondaryGrid, name);
-        if (!primaryC || !secondaryC) continue;
-        auto pIC = primaryC.try_as<Controls::ItemsControl>();
-        auto sIC = secondaryC.try_as<Controls::ItemsControl>();
+    // Share ItemsSource on ControlCenterButton so volume/network/battery
+    // glyphs render on secondaries. Right-clicks on secondary CC glyphs
+    // are intercepted by the WH_MOUSE hook (MouseHookProc), forwarded to
+    // the primary taskbar's XAML island (which has the correct XamlRoot),
+    // and the resulting context menu is repositioned to the secondary
+    // monitor by our SetWindowPos/MoveWindow hooks.
+    //
+    // NotificationCenterButton is NOT shared — Windows gives every taskbar
+    // its own clock/date items natively.
+    auto primaryCC = FindChildByName(primaryGrid, L"ControlCenterButton");
+    auto secondaryCC = FindChildByName(secondaryGrid, L"ControlCenterButton");
+    if (primaryCC && secondaryCC) {
+        auto pIC = primaryCC.try_as<Controls::ItemsControl>();
+        auto sIC = secondaryCC.try_as<Controls::ItemsControl>();
         if (pIC && sIC) {
             auto pSource = pIC.ItemsSource();
             if (pSource && sIC.ItemsSource() != pSource) {
                 try { sIC.ItemsSource(pSource); } catch (...) {}
             }
+            // Re-attach on primary to transfer menu ownership back.
+            // Setting ItemsSource on the secondary moves the per-glyph
+            // context menu ownership to the secondary's island. Without
+            // this re-attach, right-clicking CC glyphs on the PRIMARY
+            // would also crash. The detach/re-attach cycle moves
+            // ownership back to the primary's island.
+            if (pSource) {
+                try {
+                    pIC.ItemsSource(nullptr);
+                    pIC.ItemsSource(pSource);
+                } catch (...) {}
+            }
         }
+        // Note: right-click on secondary CC is intercepted by the
+        // WH_MOUSE hook and forwarded to the primary's XAML island.
+        // The re-attach above ensures the primary island owns the
+        // MenuFlyout, so the forwarded click opens the menu without
+        // crashing. Our placement hooks then reposition it.
     }
 
     for (auto stackName : g_stackContainers) {
@@ -1959,6 +2264,7 @@ static void ResetXamlState() {
     }
 
     RemoveAllTaskbarSubclasses();
+    RemoveMouseHook();
     ClearFlyoutContext();
     g_autoRevokerList.clear();
 
@@ -2291,6 +2597,7 @@ BOOL Wh_ModInit() {
                                            LoadLibraryExW_Hook,
                                            &LoadLibraryExW_Original);
         }
+
     }
 
     // Hook Win32 APIs for proactive flyout repositioning in ALL included processes (explorer.exe and ShellHost.exe).
@@ -2345,15 +2652,6 @@ BOOL Wh_ModInit() {
                MonitorFromWindow_Original, SetWindowPos_Original,
                MoveWindow_Original, DeferWindowPos_Original,
                TrackPopupMenuEx_Original);
-    }
-
-    // Log taskbar auto-hide state
-    {
-        APPBARDATA abd = {sizeof(abd)};
-        UINT state = (UINT)SHAppBarMessage(ABM_GETSTATE, &abd);
-        Wh_Log(L"[Taskbar] auto-hide=%s always-on-top=%s",
-               (state & ABS_AUTOHIDE) ? L"YES" : L"NO",
-               (state & ABS_ALWAYSONTOP) ? L"YES" : L"NO");
     }
 
     // Log all monitor geometries for diagnostics
@@ -2411,8 +2709,9 @@ void Wh_ModBeforeUninit() {
     // Remove display change listener
     UninstallDisplayChangeListener();
 
-    // Remove flyout subclasses and clear context
+    // Remove flyout subclasses, mouse hook, and clear context
     RemoveAllTaskbarSubclasses();
+    RemoveMouseHook();
     ClearFlyoutContext();
 
     // Remove SizeChanged listener from primary frame

--- a/mods/taskbar-tray-on-all-monitors.wh.cpp
+++ b/mods/taskbar-tray-on-all-monitors.wh.cpp
@@ -7,6 +7,7 @@
 // @github          https://github.com/RYJASM
 // @include         explorer.exe
 // @architecture    x86-64
+// @architecture    arm64
 // @compilerOptions -lole32 -loleaut32 -lruntimeobject -lversion -luuid
 // ==/WindhawkMod==
 
@@ -1030,6 +1031,11 @@ void TryPopulateOneSecondary(SecondaryInfo& si) {
            si.frame.ActualWidth(), si.frame.ActualHeight());
 
     Wh_Log(L"=== POPULATION ATTEMPT COMPLETE ===");
+
+    // Schedule a deferred refresh to re-sync width after layout settles.
+    // During monitor hot-plug or DPI changes, the primary frame's ActualWidth
+    // may not reflect the final value yet at population time.
+    RefreshSecondaryTray();
 }
 
 // ─── Process a loaded IconView element ──────────────────────────────────────

--- a/mods/taskbar-tray-on-all-monitors.wh.cpp
+++ b/mods/taskbar-tray-on-all-monitors.wh.cpp
@@ -1,0 +1,1474 @@
+// ==WindhawkMod==
+// @id              taskbar-tray-on-all-monitors
+// @name            Taskbar tray on all monitors
+// @description     Mirrors the system tray (clock, volume, network, battery, notification icons) from the primary taskbar onto all secondary monitor taskbars
+// @version         1.0
+// @author          RYJASM
+// @github          https://github.com/RYJASM
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lversion -luuid
+// ==/WindhawkMod==
+
+// Source code is published under The GNU General Public License v3.0.
+//
+// For bug reports and feature requests, please open an issue here:
+// https://github.com/ramensoftware/windhawk-mods/issues
+
+// ==WindhawkModReadme==
+/*
+# Taskbar Tray on All Monitors
+
+Mirrors the system tray from the primary taskbar onto all secondary monitor
+taskbars — including the clock, volume, network, battery, notification area
+icons, input indicator, overflow chevron, and Show Desktop button.
+
+**Only Windows 11 (build 26200+) is supported.**
+
+## Features
+
+- All system tray icons visible on secondary taskbars (click, hover,
+  right-click context menus work natively)
+- Dynamic width syncing — secondary tray resizes automatically when icons
+  are added or removed on the primary
+- Show Desktop button synced to match primary visibility
+- Flyout repositioning — Quick Settings, notification panels, and context
+  menus open on the correct monitor
+- Auto-refresh on display resolution, scale, or DPI changes
+
+## How it works
+
+Hooks into `SystemTrayController` and `SystemTraySecondaryController` in
+`SystemTray.dll`, then shares XAML `ItemsSource` bindings from the primary
+tray containers to the secondary ones. A `SizeChanged` event on the primary
+frame keeps the secondary width in sync at runtime.
+*/
+// ==/WindhawkModReadme==
+
+#include <windhawk_utils.h>
+
+#include <winrt/base.h>
+
+#undef GetCurrentTime
+
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.h>
+
+#include <atomic>
+#include <functional>
+#include <list>
+
+using namespace winrt::Windows::UI::Xaml;
+
+// ─── globals ────────────────────────────────────────────────────────────────
+
+static std::atomic<bool> g_unloading{false};
+
+// Captured controller pointers
+static void* g_primaryController = nullptr;
+static void* g_secondaryControllers[8] = {};
+static int   g_secondaryControllerCount = 0;
+
+// Track whether we've dumped the XAML tree for primary/secondary
+static bool g_primaryTreeDumped = false;
+static bool g_secondaryTreeDumped = false;
+
+// Saved XAML tree references for primary/secondary SystemTrayFrame
+static FrameworkElement g_primarySystemTrayFrame{nullptr};
+static FrameworkElement g_secondarySystemTrayFrame{nullptr};
+static bool g_populationAttempted = false;
+static double g_lastPrimaryFrameSize = 0;
+static winrt::event_token g_primarySizeChangedToken{};
+
+// Hidden window for display change notifications
+static HWND g_displayChangeWindow = nullptr;
+static const wchar_t* g_displayChangeClassName =
+    L"WindhawkTrayMod_DisplayChangeListener";
+
+// Forward declarations
+static void RefreshSecondaryTray();
+static void InstallDisplayChangeListener();
+static void UninstallDisplayChangeListener();
+
+// Loaded event revokers (prevent crash on unload)
+using FrameworkElementLoadedEventRevoker = winrt::impl::event_revoker<
+    IFrameworkElement,
+    &winrt::impl::abi<IFrameworkElement>::type::remove_Loaded>;
+
+std::list<FrameworkElementLoadedEventRevoker> g_autoRevokerList;
+
+// ─── helper: get module version ─────────────────────────────────────────────
+
+static VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT* puPtrLen) {
+    void* pFixedFileInfo = nullptr;
+    UINT uPtrLen = 0;
+
+    HRSRC hResource =
+        FindResource(hModule, MAKEINTRESOURCE(VS_VERSION_INFO), RT_VERSION);
+    if (hResource) {
+        HGLOBAL hGlobal = LoadResource(hModule, hResource);
+        if (hGlobal) {
+            void* pData = LockResource(hGlobal);
+            if (pData) {
+                VerQueryValue(pData, L"\\", &pFixedFileInfo, &uPtrLen);
+            }
+        }
+    }
+
+    if (puPtrLen)
+        *puPtrLen = uPtrLen;
+
+    return (VS_FIXEDFILEINFO*)pFixedFileInfo;
+}
+
+// ─── XAML tree utilities ────────────────────────────────────────────────────
+
+FrameworkElement EnumChildElements(
+    FrameworkElement element,
+    std::function<bool(FrameworkElement)> enumCallback) {
+    int childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
+
+    for (int i = 0; i < childrenCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i)
+                         .try_as<FrameworkElement>();
+        if (!child) {
+            continue;
+        }
+
+        if (enumCallback(child)) {
+            return child;
+        }
+    }
+
+    return nullptr;
+}
+
+FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name) {
+    return EnumChildElements(element, [name](FrameworkElement child) {
+        return child.Name() == name;
+    });
+}
+
+FrameworkElement EnumParentElements(
+    FrameworkElement element,
+    std::function<bool(FrameworkElement)> enumCallback) {
+    auto parent = element;
+    while (true) {
+        parent = Media::VisualTreeHelper::GetParent(parent)
+                     .try_as<FrameworkElement>();
+        if (!parent) {
+            return nullptr;
+        }
+
+        if (enumCallback(parent)) {
+            return parent;
+        }
+    }
+}
+
+FrameworkElement GetParentElementByClassName(FrameworkElement element,
+                                             PCWSTR className) {
+    return EnumParentElements(element, [className](FrameworkElement parent) {
+        return winrt::get_class_name(parent) == className;
+    });
+}
+
+// ─── XAML tree dump (recursive, depth-limited) ──────────────────────────────
+
+void DumpXamlTree(FrameworkElement element, int depth, int maxDepth) {
+    if (depth > maxDepth) return;
+
+    auto name = element.Name();
+    auto className = winrt::get_class_name(element);
+    auto width = element.ActualWidth();
+    auto height = element.ActualHeight();
+    auto visibility = element.Visibility();
+
+    wchar_t indent[64] = {};
+    for (int i = 0; i < depth && i < 30; i++) {
+        wcscat_s(indent, L"  ");
+    }
+
+    Wh_Log(L"%s[%s] name=\"%s\" %.0fx%.0f %s",
+           indent,
+           className.c_str(),
+           name.c_str(),
+           width, height,
+           visibility == Visibility::Collapsed ? L"COLLAPSED" : L"");
+
+    int childCount = Media::VisualTreeHelper::GetChildrenCount(element);
+    for (int i = 0; i < childCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i)
+                         .try_as<FrameworkElement>();
+        if (child) {
+            DumpXamlTree(child, depth + 1, maxDepth);
+        }
+    }
+}
+
+// ─── Flyout repositioning ──────────────────────────────────────────────────
+// Detects flyout windows that appear on the primary monitor when the cursor
+// is on a secondary monitor, and repositions them to the correct monitor.
+// Uses EVENT_OBJECT_LOCATIONCHANGE to persistently reposition windows that
+// the system moves back to primary (e.g. Quick Settings XAML island).
+
+static HWINEVENTHOOK g_winEventHook = nullptr;
+
+// Track repositioned flyouts so we can fight back on LOCATIONCHANGE
+static HWND g_trackedFlyouts[4] = {};
+static HMONITOR g_trackedTargets[4] = {};
+static DWORD g_trackedTimes[4] = {};
+static int g_trackedCount = 0;
+
+static bool IsPrimaryMonitor(HMONITOR hMon) {
+    MONITORINFO mi = {sizeof(mi)};
+    return GetMonitorInfo(hMon, &mi) && (mi.dwFlags & MONITORINFOF_PRIMARY);
+}
+
+static void TrackFlyout(HWND hwnd, HMONITOR target) {
+    for (int i = 0; i < g_trackedCount; i++) {
+        if (g_trackedFlyouts[i] == hwnd) {
+            g_trackedTargets[i] = target;
+            g_trackedTimes[i] = GetTickCount();
+            return;
+        }
+    }
+    if (g_trackedCount < 4) {
+        g_trackedFlyouts[g_trackedCount] = hwnd;
+        g_trackedTargets[g_trackedCount] = target;
+        g_trackedTimes[g_trackedCount] = GetTickCount();
+        g_trackedCount++;
+    }
+}
+
+static void UntrackFlyout(HWND hwnd) {
+    for (int i = 0; i < g_trackedCount; i++) {
+        if (g_trackedFlyouts[i] == hwnd) {
+            g_trackedFlyouts[i] = g_trackedFlyouts[--g_trackedCount];
+            g_trackedTargets[i] = g_trackedTargets[g_trackedCount];
+            g_trackedTimes[i] = g_trackedTimes[g_trackedCount];
+            return;
+        }
+    }
+}
+
+static bool IsTrayFlyoutClass(const wchar_t* className) {
+    if (wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0)
+        return true;
+    if (wcscmp(className, L"ControlCenterWindow") == 0)
+        return true;
+    if (wcscmp(className, L"#32768") == 0)
+        return true;
+    if (wcscmp(className, L"Shell_LightDismissOverlay") == 0)
+        return true;
+    if (wcscmp(className, L"XamlExplorerHostIslandWindow") == 0)
+        return true;
+    if (wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0)
+        return true;
+    if (wcscmp(className, L"Windows.UI.Composition.DesktopWindowContentBridge") == 0)
+        return true;
+    return false;
+}
+
+static void RepositionFlyoutToMonitor(HWND hwnd, HMONITOR fromMon,
+                                       HMONITOR toMon) {
+    RECT wr;
+    if (!GetWindowRect(hwnd, &wr)) return;
+
+    MONITORINFO fromMi = {sizeof(fromMi)};
+    MONITORINFO toMi = {sizeof(toMi)};
+    if (!GetMonitorInfo(fromMon, &fromMi)) return;
+    if (!GetMonitorInfo(toMon, &toMi)) return;
+
+    int ww = wr.right - wr.left;
+    int wh = wr.bottom - wr.top;
+    int fromMonW = fromMi.rcMonitor.right - fromMi.rcMonitor.left;
+    int fromMonH = fromMi.rcMonitor.bottom - fromMi.rcMonitor.top;
+
+    // Log extended style to understand rendering mode
+    LONG exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
+    Wh_Log(L"[Flyout] hwnd=%p style=0x%08X exStyle=0x%08X "
+           L"WS_EX_NOREDIRECTIONBITMAP=%s",
+           hwnd, GetWindowLong(hwnd, GWL_STYLE), exStyle,
+           (exStyle & 0x00200000 /*WS_EX_NOREDIRECTIONBITMAP*/) ? L"YES" : L"NO");
+
+    // Check if this is a full-screen overlay (e.g. Quick Settings XAML island)
+    if (ww >= fromMonW && wh >= fromMonH) {
+        // If the overlay already spans multiple monitors (e.g.
+        // Shell_LightDismissOverlay at (0,0,7680,7680)), it already covers
+        // the secondary monitor — don't resize/move it or we'll break the
+        // internal coordinate system of popups rendered within it.
+        int totalW = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+        int totalH = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+        if (ww > fromMonW || wh > fromMonH) {
+            Wh_Log(L"[Flyout] Multi-monitor overlay (%dx%d vs virtual %dx%d)"
+                   L" — skipping reposition",
+                   ww, wh, totalW, totalH);
+            return;
+        }
+
+        int toMonW = toMi.rcMonitor.right - toMi.rcMonitor.left;
+        int toMonH = toMi.rcMonitor.bottom - toMi.rcMonitor.top;
+
+        Wh_Log(L"[Flyout] Full-screen overlay: moving to (%d,%d %dx%d)",
+               toMi.rcMonitor.left, toMi.rcMonitor.top, toMonW, toMonH);
+
+        // Try hide-move-show to force re-render on new monitor
+        ShowWindow(hwnd, SW_HIDE);
+        BOOL ok = SetWindowPos(hwnd, nullptr,
+                               toMi.rcMonitor.left, toMi.rcMonitor.top,
+                               toMonW, toMonH,
+                               SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+        ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+
+        // Verify the move
+        RECT afterRect;
+        GetWindowRect(hwnd, &afterRect);
+        Wh_Log(L"[Flyout] SetWindowPos returned %d, error=%d, "
+               L"after rect=(%d,%d,%d,%d)",
+               ok, GetLastError(),
+               afterRect.left, afterRect.top,
+               afterRect.right, afterRect.bottom);
+        return;
+    }
+
+    // Normal flyout: position relative to taskbar
+    int offRight = fromMi.rcWork.right - wr.right;
+    int newX = toMi.rcWork.right - ww - offRight;
+
+    // Find the secondary taskbar to align above it (handles auto-hide)
+    int taskbarTop = toMi.rcWork.bottom;
+    HWND findHwnd = nullptr;
+    while ((findHwnd = FindWindowEx(nullptr, findHwnd,
+                                     L"Shell_SecondaryTrayWnd",
+                                     nullptr)) != nullptr) {
+        HMONITOR trayMon =
+            MonitorFromWindow(findHwnd, MONITOR_DEFAULTTONEAREST);
+        if (trayMon == toMon) {
+            RECT trayRect;
+            if (GetWindowRect(findHwnd, &trayRect)) {
+                taskbarTop = trayRect.top;
+            }
+            break;
+        }
+    }
+
+    int newY = taskbarTop - wh;
+
+    Wh_Log(L"[Flyout] Repositioning from (%d,%d) to (%d,%d)",
+           wr.left, wr.top, newX, newY);
+
+    SetWindowPos(hwnd, nullptr, newX, newY, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+}
+
+static void CALLBACK FlyoutWinEventProc(HWINEVENTHOOK hWinEventHook,
+                                         DWORD event, HWND hwnd,
+                                         LONG idObject, LONG idChild,
+                                         DWORD idEventThread,
+                                         DWORD dwmsEventTime) {
+    if (g_unloading) return;
+    if (!hwnd || idObject != 0 || idChild != 0) return;
+
+    // EVENT_OBJECT_HIDE: stop tracking
+    if (event == EVENT_OBJECT_HIDE) {
+        UntrackFlyout(hwnd);
+        return;
+    }
+
+    // EVENT_OBJECT_LOCATIONCHANGE: reposition tracked flyouts that moved
+    // back to primary (system fighting our SetWindowPos)
+    if (event == EVENT_OBJECT_LOCATIONCHANGE) {
+        for (int i = 0; i < g_trackedCount; i++) {
+            if (g_trackedFlyouts[i] != hwnd) continue;
+
+            // Expire tracking after 3 seconds
+            if (GetTickCount() - g_trackedTimes[i] > 3000) {
+                UntrackFlyout(hwnd);
+                return;
+            }
+
+            RECT wr;
+            if (!GetWindowRect(hwnd, &wr)) return;
+            HMONITOR windowMon =
+                MonitorFromRect(&wr, MONITOR_DEFAULTTONEAREST);
+            if (IsPrimaryMonitor(windowMon)) {
+                RepositionFlyoutToMonitor(
+                    hwnd, windowMon, g_trackedTargets[i]);
+            }
+            return;
+        }
+        return;
+    }
+
+    // EVENT_OBJECT_SHOW: detect new flyouts
+    if (event != EVENT_OBJECT_SHOW) return;
+    if (!IsWindowVisible(hwnd)) return;
+
+    LONG style = GetWindowLong(hwnd, GWL_STYLE);
+    if (style & WS_CHILD) return;
+
+    // Check cursor is on a secondary monitor
+    POINT cursorPos;
+    GetCursorPos(&cursorPos);
+    HMONITOR cursorMon =
+        MonitorFromPoint(cursorPos, MONITOR_DEFAULTTONEAREST);
+    if (IsPrimaryMonitor(cursorMon)) return;
+
+    // Check window is on the primary monitor
+    RECT wr;
+    if (!GetWindowRect(hwnd, &wr)) return;
+    HMONITOR windowMon = MonitorFromRect(&wr, MONITOR_DEFAULTTONEAREST);
+    if (!IsPrimaryMonitor(windowMon)) return;
+
+    // Mismatch: cursor on secondary, window on primary
+    wchar_t className[256] = {};
+    GetClassName(hwnd, className, ARRAYSIZE(className));
+
+    DWORD ownerPid = 0;
+    GetWindowThreadProcessId(hwnd, &ownerPid);
+    Wh_Log(L"[Flyout] Show on primary while cursor on secondary: "
+           L"class='%s' hwnd=%p pid=%u rect=(%d,%d,%d,%d)",
+           className, hwnd, ownerPid, wr.left, wr.top, wr.right, wr.bottom);
+
+    if (IsTrayFlyoutClass(className)) {
+        int ww = wr.right - wr.left;
+        int wh = wr.bottom - wr.top;
+
+        // Skip multi-monitor overlays — they already cover the secondary
+        // monitor and repositioning them breaks internal popup coordinates
+        MONITORINFO wmi = {sizeof(wmi)};
+        GetMonitorInfo(windowMon, &wmi);
+        int monW = wmi.rcMonitor.right - wmi.rcMonitor.left;
+        int monH = wmi.rcMonitor.bottom - wmi.rcMonitor.top;
+        if (ww > monW || wh > monH) {
+            Wh_Log(L"[Flyout] Multi-monitor overlay (%dx%d vs mon %dx%d)"
+                   L" — skipping",
+                   ww, wh, monW, monH);
+        } else if (ww > 0 && wh > 0) {
+            // Window has real dimensions — reposition now
+            RepositionFlyoutToMonitor(hwnd, windowMon, cursorMon);
+            TrackFlyout(hwnd, cursorMon);
+        } else {
+            // Zero-sized at SHOW time — will be positioned later,
+            // LOCATIONCHANGE will handle it
+            Wh_Log(L"[Flyout] Zero-sized at SHOW, deferring to LOCATIONCHANGE");
+            TrackFlyout(hwnd, cursorMon);
+        }
+    }
+
+    // Also scan for any XamlExplorerHostIslandWindow on primary that we
+    // might have missed (pre-existing windows that didn't fire SHOW)
+    HWND found = nullptr;
+    while ((found = FindWindowEx(nullptr, found,
+                                  L"XamlExplorerHostIslandWindow",
+                                  nullptr)) != nullptr) {
+        if (found == hwnd) continue;  // already handled above
+        RECT fr;
+        if (!GetWindowRect(found, &fr)) continue;
+        if (!IsWindowVisible(found)) continue;
+        HMONITOR fMon = MonitorFromRect(&fr, MONITOR_DEFAULTTONEAREST);
+        if (IsPrimaryMonitor(fMon)) {
+            Wh_Log(L"[Flyout] SCAN: found extra XamlExplorerHostIslandWindow "
+                   L"hwnd=%p rect=(%d,%d,%d,%d) on primary",
+                   found, fr.left, fr.top, fr.right, fr.bottom);
+        }
+    }
+}
+
+static void InstallFlyoutHook() {
+    if (g_winEventHook) return;
+
+    // Cover SHOW (0x8002) through LOCATIONCHANGE (0x800B) to also
+    // catch HIDE (0x8003) for cleanup and LOCATIONCHANGE for persistent
+    // repositioning of flyouts that the system moves back to primary.
+    g_winEventHook = SetWinEventHook(
+        EVENT_OBJECT_SHOW, EVENT_OBJECT_LOCATIONCHANGE,
+        nullptr, FlyoutWinEventProc,
+        0, 0, WINEVENT_OUTOFCONTEXT);
+
+    if (g_winEventHook) {
+        Wh_Log(L"[Flyout] WinEvent hook installed (SHOW+LOCATIONCHANGE)");
+    } else {
+        Wh_Log(L"[Flyout] Failed to install WinEvent hook: error %d",
+               GetLastError());
+    }
+}
+
+static void UninstallFlyoutHook() {
+    if (g_winEventHook) {
+        UnhookWinEvent(g_winEventHook);
+        g_winEventHook = nullptr;
+        g_trackedCount = 0;
+        Wh_Log(L"[Flyout] WinEvent hook removed");
+    }
+}
+
+// ─── Identify primary vs secondary from XAML tree ───────────────────────────
+// On secondary taskbars, ControlCenterButton exists but is empty (width < 5)
+
+bool IsSecondaryTaskbar(FrameworkElement systemTrayFrame) {
+    auto grid = FindChildByName(systemTrayFrame, L"SystemTrayFrameGrid");
+    if (!grid) return false;
+
+    auto ccButton = FindChildByName(grid, L"ControlCenterButton");
+    if (!ccButton) return false;
+
+    return ccButton.ActualWidth() < 5;
+}
+
+// Forward declarations
+void ProbeContainerInterfaces(FrameworkElement systemTrayFrame,
+                               const wchar_t* label);
+void TryPopulateSecondaryTray();
+
+// Forward-declared so TryPopulateSecondaryTray can call UpdateFrameSize
+using SystemTraySecondaryController_UpdateFrameSize_t = void(WINAPI*)(void* pThis);
+extern SystemTraySecondaryController_UpdateFrameSize_t SystemTraySecondaryController_UpdateFrameSize_Original;
+
+// ─── Fallback: extract SystemTrayFrame from controller object ────────────────
+// Scans the controller's member fields for a WinRT reference to the frame.
+// Used when mod is loaded after startup (no new IconViews being created).
+
+static bool g_primaryFrameSearchDone = false;
+static bool g_secondaryFrameSearchDone = false;
+
+FrameworkElement TryExtractFrameFromController(void* controller,
+                                                const wchar_t* label) {
+    uintptr_t* slots = (uintptr_t*)controller;
+
+    for (int i = 2; i < 48; i++) {
+        // Check slot is readable
+        if (IsBadReadPtr(&slots[i], sizeof(uintptr_t))) break;
+
+        uintptr_t value = slots[i];
+
+        // Basic pointer sanity checks
+        if (value < 0x10000) continue;
+        if ((value & 0x7) != 0) continue;  // must be 8-byte aligned
+
+        // Check pointed-to memory is readable (object header / vtable ptr)
+        if (IsBadReadPtr((void*)value, 2 * sizeof(void*))) continue;
+
+        // Check vtable pointer itself is readable
+        uintptr_t vtablePtr = *(uintptr_t*)value;
+        if (vtablePtr < 0x10000) continue;
+        if (IsBadReadPtr((void*)vtablePtr, 3 * sizeof(void*))) continue;
+
+        // Check first vtable entry (QueryInterface) points to executable code
+        uintptr_t qiAddr = *(uintptr_t*)vtablePtr;
+        MEMORY_BASIC_INFORMATION mbi;
+        if (!VirtualQuery((void*)qiAddr, &mbi, sizeof(mbi))) continue;
+        if (!(mbi.Protect & (PAGE_EXECUTE | PAGE_EXECUTE_READ |
+                             PAGE_EXECUTE_READWRITE |
+                             PAGE_EXECUTE_WRITECOPY)))
+            continue;
+
+        // Looks like a valid COM vtable - try QI for FrameworkElement
+        try {
+            FrameworkElement fe{nullptr};
+            HRESULT hr = ((IUnknown*)value)->QueryInterface(
+                winrt::guid_of<FrameworkElement>(), winrt::put_abi(fe));
+            if (SUCCEEDED(hr) && fe) {
+                auto className = winrt::get_class_name(fe);
+                if (className == L"SystemTray.SystemTrayFrame") {
+                    Wh_Log(L"[%s] Found SystemTrayFrame at controller "
+                           L"offset %d (0x%X)",
+                           label, i, i * 8);
+                    return fe;
+                }
+            }
+        } catch (...) {
+            continue;
+        }
+    }
+
+    Wh_Log(L"[%s] SystemTrayFrame not found in controller object", label);
+    return nullptr;
+}
+
+void HandleExtractedFrame(FrameworkElement frame, bool isSecondary) {
+    const wchar_t* label = isSecondary ? L"SECONDARY" : L"PRIMARY";
+
+    if (isSecondary) {
+        g_secondarySystemTrayFrame = frame;
+        if (!g_secondaryTreeDumped) {
+            g_secondaryTreeDumped = true;
+            Wh_Log(L"=== SECONDARY TASKBAR XAML TREE (via controller scan) ===");
+            DumpXamlTree(frame, 0, 8);
+            ProbeContainerInterfaces(frame, label);
+        }
+    } else {
+        g_primarySystemTrayFrame = frame;
+        if (!g_primaryTreeDumped) {
+            g_primaryTreeDumped = true;
+            Wh_Log(L"=== PRIMARY TASKBAR XAML TREE (via controller scan) ===");
+            DumpXamlTree(frame, 0, 8);
+            ProbeContainerInterfaces(frame, label);
+        }
+    }
+
+    if (g_primarySystemTrayFrame && g_secondarySystemTrayFrame) {
+        TryPopulateSecondaryTray();
+    }
+}
+
+// ─── Probe containers for WinRT interfaces ──────────────────────────────────
+
+void ProbeContainerInterfaces(FrameworkElement systemTrayFrame,
+                               const wchar_t* label) {
+    auto grid = FindChildByName(systemTrayFrame, L"SystemTrayFrameGrid");
+    if (!grid) {
+        Wh_Log(L"[%s] No SystemTrayFrameGrid found", label);
+        return;
+    }
+
+    int childCount = Media::VisualTreeHelper::GetChildrenCount(grid);
+    for (int i = 0; i < childCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(grid, i)
+                         .try_as<FrameworkElement>();
+        if (!child) continue;
+
+        auto name = child.Name();
+        auto className = winrt::get_class_name(child);
+
+        // Probe standard XAML interfaces
+        auto asItemsControl = child.try_as<Controls::ItemsControl>();
+        auto asContentControl = child.try_as<Controls::ContentControl>();
+        auto asPanel = child.try_as<Controls::Panel>();
+
+        int itemsCount = -1;
+        bool hasItemsSource = false;
+        if (asItemsControl) {
+            itemsCount = (int)asItemsControl.Items().Size();
+            hasItemsSource = (asItemsControl.ItemsSource() != nullptr);
+        }
+
+        Wh_Log(L"[%s] '%s' (%s) - ItemsControl:%s ContentControl:%s Panel:%s"
+               L" Items:%d ItemsSource:%s",
+               label, name.c_str(), className.c_str(),
+               asItemsControl ? L"YES" : L"NO",
+               asContentControl ? L"YES" : L"NO",
+               asPanel ? L"YES" : L"NO",
+               itemsCount,
+               hasItemsSource ? L"YES" : L"NO");
+    }
+}
+
+// ─── Try to populate secondary tray from primary ────────────────────────────
+
+// Track what we changed so we can undo on unload
+static bool g_secondaryContainersUncollapsed = false;
+
+// Containers whose visibility is synced between primary and secondary
+static const wchar_t* g_syncedContainers[] = {
+    L"ControlCenterButton",
+    L"NotificationCenterButton",
+    L"NotifyIconStack",
+    L"NonActivatableStack",
+    L"MainStack",
+    L"ShowDesktopStack",
+};
+
+// Stack containers that use Content > IconStack for ItemsSource sharing
+static const wchar_t* g_stackContainers[] = {
+    L"NotifyIconStack",
+    L"NonActivatableStack",
+    L"MainStack",
+    L"ShowDesktopStack",
+};
+
+void TryPopulateSecondaryTray() {
+    if (g_populationAttempted) return;
+    g_populationAttempted = true;
+
+    Wh_Log(L"=== ATTEMPTING TO POPULATE SECONDARY TRAY ===");
+
+    auto primaryGrid =
+        FindChildByName(g_primarySystemTrayFrame, L"SystemTrayFrameGrid");
+    auto secondaryGrid =
+        FindChildByName(g_secondarySystemTrayFrame, L"SystemTrayFrameGrid");
+    if (!primaryGrid || !secondaryGrid) {
+        Wh_Log(L"Missing grid(s), aborting");
+        return;
+    }
+
+    // Log primary frame dimensions for reference
+    double primaryFrameWidth = g_primarySystemTrayFrame.ActualWidth();
+    double secondaryFrameWidth = g_secondarySystemTrayFrame.ActualWidth();
+    Wh_Log(L"Frame widths - primary:%.0f secondary:%.0f",
+           primaryFrameWidth, secondaryFrameWidth);
+
+    // Step 1: Sync visibility of containers between primary and secondary
+    for (auto containerName : g_syncedContainers) {
+        auto primaryContainer = FindChildByName(primaryGrid, containerName);
+        auto secondaryContainer = FindChildByName(secondaryGrid, containerName);
+
+        if (!primaryContainer || !secondaryContainer) {
+            Wh_Log(L"[%s] Missing on one side", containerName);
+            continue;
+        }
+
+        auto primaryVis = primaryContainer.Visibility();
+        auto secondaryVis = secondaryContainer.Visibility();
+        double primaryW = primaryContainer.ActualWidth();
+        double secondaryW = secondaryContainer.ActualWidth();
+
+        Wh_Log(L"[%s] primary: %.0fx%.0f %s | secondary: %.0fx%.0f %s",
+               containerName,
+               primaryW, primaryContainer.ActualHeight(),
+               primaryVis == Visibility::Collapsed ? L"COLLAPSED" : L"Visible",
+               secondaryW, secondaryContainer.ActualHeight(),
+               secondaryVis == Visibility::Collapsed ? L"COLLAPSED" : L"Visible");
+
+        // Sync visibility: match secondary to primary
+        if (primaryVis == Visibility::Visible &&
+            secondaryVis == Visibility::Collapsed) {
+            Wh_Log(L"[%s] Uncollapsing secondary container", containerName);
+            secondaryContainer.Visibility(Visibility::Visible);
+            g_secondaryContainersUncollapsed = true;
+        } else if (primaryVis == Visibility::Collapsed &&
+                   secondaryVis == Visibility::Visible) {
+            Wh_Log(L"[%s] Collapsing secondary to match primary", containerName);
+            secondaryContainer.Visibility(Visibility::Collapsed);
+            g_secondaryContainersUncollapsed = true;
+        }
+
+        // If secondary is visible but very narrow (< 5px), it might be
+        // effectively hidden - log this for diagnosis
+        if (secondaryVis == Visibility::Visible && secondaryW < 5 &&
+            primaryW > 5) {
+            Wh_Log(L"[%s] Secondary is visible but very narrow (%.0f vs %.0f)",
+                   containerName, secondaryW, primaryW);
+        }
+    }
+
+    // Step 2: Share NotificationAreaIcons ItemsSource for third-party tray icons
+    // NotificationAreaIcons is a DIRECT child of SystemTrayFrameGrid (sibling
+    // of NotifyIconStack, not inside it)
+    auto primaryNAI = FindChildByName(primaryGrid, L"NotificationAreaIcons");
+    auto secondaryNAI = FindChildByName(secondaryGrid, L"NotificationAreaIcons");
+
+    if (primaryNAI && secondaryNAI) {
+        auto primaryIC = primaryNAI.try_as<Controls::ItemsControl>();
+        auto secondaryIC = secondaryNAI.try_as<Controls::ItemsControl>();
+
+        if (primaryIC && secondaryIC) {
+            int pCount = (int)primaryIC.Items().Size();
+            int sCount = (int)secondaryIC.Items().Size();
+            auto pSource = primaryIC.ItemsSource();
+
+            Wh_Log(L"[NotificationAreaIcons] primary:%d secondary:%d "
+                   L"primarySource:%s",
+                   pCount, sCount, pSource ? L"YES" : L"NO");
+
+            if (pSource && sCount == 0 && pCount > 0) {
+                try {
+                    secondaryIC.ItemsSource(pSource);
+                    int newCount = (int)secondaryIC.Items().Size();
+                    Wh_Log(L"[NotificationAreaIcons] ItemsSource shared! "
+                           L"Secondary now has %d items",
+                           newCount);
+                } catch (winrt::hresult_error const& ex) {
+                    Wh_Log(L"[NotificationAreaIcons] Share failed: 0x%08X %s",
+                           (unsigned)ex.code(), ex.message().c_str());
+                }
+            }
+
+            // Uncollapse if needed
+            if (secondaryNAI.Visibility() == Visibility::Collapsed &&
+                primaryNAI.Visibility() == Visibility::Visible) {
+                secondaryNAI.Visibility(Visibility::Visible);
+                Wh_Log(L"[NotificationAreaIcons] Uncollapsed secondary");
+            }
+        }
+    } else {
+        Wh_Log(L"[NotificationAreaIcons] Not found (primary:%s secondary:%s)",
+               primaryNAI ? L"found" : L"MISSING",
+               secondaryNAI ? L"found" : L"MISSING");
+    }
+
+    // Step 3: Share ItemsSource for ControlCenterButton and
+    //         NotificationCenterButton (in case secondary has 0 items)
+    const wchar_t* icContainers[] = {
+        L"ControlCenterButton",
+        L"NotificationCenterButton",
+    };
+    for (auto name : icContainers) {
+        auto primaryC = FindChildByName(primaryGrid, name);
+        auto secondaryC = FindChildByName(secondaryGrid, name);
+        if (!primaryC || !secondaryC) continue;
+
+        auto pIC = primaryC.try_as<Controls::ItemsControl>();
+        auto sIC = secondaryC.try_as<Controls::ItemsControl>();
+        if (!pIC || !sIC) continue;
+
+        int pCount = (int)pIC.Items().Size();
+        int sCount = (int)sIC.Items().Size();
+        auto pSource = pIC.ItemsSource();
+
+        if (pSource && sCount == 0 && pCount > 0) {
+            try {
+                sIC.ItemsSource(pSource);
+                Wh_Log(L"[%s] ItemsSource shared! Secondary now has %d items",
+                       name, (int)sIC.Items().Size());
+            } catch (winrt::hresult_error const& ex) {
+                Wh_Log(L"[%s] ItemsSource share failed: 0x%08X",
+                       name, (unsigned)ex.code());
+            }
+        }
+    }
+
+    // Step 3b: Share StackListView ItemsSource for Stack containers
+    // SystemTray.Stack is NOT an ItemsControl, but it contains a child
+    // StackListView (via Content grid > IconStack) which IS an ItemsControl.
+    for (auto stackName : g_stackContainers) {
+        auto primaryStack = FindChildByName(primaryGrid, stackName);
+        auto secondaryStack = FindChildByName(secondaryGrid, stackName);
+        if (!primaryStack || !secondaryStack) continue;
+
+        // Drill down: Stack > Content (Grid) > IconStack (StackListView)
+        auto primaryContent = FindChildByName(primaryStack, L"Content");
+        auto secondaryContent = FindChildByName(secondaryStack, L"Content");
+        if (!primaryContent || !secondaryContent) continue;
+
+        auto primaryIconStack = FindChildByName(primaryContent, L"IconStack");
+        auto secondaryIconStack = FindChildByName(secondaryContent, L"IconStack");
+        if (!primaryIconStack || !secondaryIconStack) continue;
+
+        auto pIC = primaryIconStack.try_as<Controls::ItemsControl>();
+        auto sIC = secondaryIconStack.try_as<Controls::ItemsControl>();
+
+        Wh_Log(L"[%s/IconStack] primary IC:%s secondary IC:%s",
+               stackName,
+               pIC ? L"YES" : L"NO",
+               sIC ? L"YES" : L"NO");
+
+        if (pIC && sIC) {
+            int pCount = (int)pIC.Items().Size();
+            int sCount = (int)sIC.Items().Size();
+            auto pSource = pIC.ItemsSource();
+
+            Wh_Log(L"[%s/IconStack] primary:%d secondary:%d source:%s",
+                   stackName, pCount, sCount, pSource ? L"YES" : L"NO");
+
+            if (pSource && sCount == 0 && pCount > 0) {
+                try {
+                    sIC.ItemsSource(pSource);
+                    int newCount = (int)sIC.Items().Size();
+                    Wh_Log(L"[%s/IconStack] ItemsSource shared! "
+                           L"Secondary now has %d items",
+                           stackName, newCount);
+                } catch (winrt::hresult_error const& ex) {
+                    Wh_Log(L"[%s/IconStack] Share failed: 0x%08X %s",
+                           stackName, (unsigned)ex.code(),
+                           ex.message().c_str());
+                }
+            }
+        }
+    }
+
+    // Step 4: Set the secondary frame width to match primary
+    // (GetFrameSize symbol may not exist, so set Width directly)
+    if (primaryFrameWidth > secondaryFrameWidth) {
+        Wh_Log(L"Setting secondary frame Width: %.0f -> %.0f",
+               secondaryFrameWidth, primaryFrameWidth);
+        g_secondarySystemTrayFrame.Width(primaryFrameWidth);
+    }
+
+    // Force the secondary controller to recalculate frame size
+    if (g_secondaryControllerCount > 0 &&
+        SystemTraySecondaryController_UpdateFrameSize_Original) {
+        Wh_Log(L"Forcing UpdateFrameSize on secondary controller");
+        SystemTraySecondaryController_UpdateFrameSize_Original(
+            g_secondaryControllers[0]);
+    }
+
+    // Also force layout update on secondary frame
+    g_secondarySystemTrayFrame.InvalidateMeasure();
+    g_secondarySystemTrayFrame.InvalidateArrange();
+    g_secondarySystemTrayFrame.UpdateLayout();
+
+    // Also invalidate the grid
+    secondaryGrid.InvalidateMeasure();
+    secondaryGrid.InvalidateArrange();
+    secondaryGrid.UpdateLayout();
+
+    // Step 5: Log final state
+    Wh_Log(L"=== POST-POPULATION STATE ===");
+    int gridChildCount = Media::VisualTreeHelper::GetChildrenCount(secondaryGrid);
+    for (int i = 0; i < gridChildCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(secondaryGrid, i)
+                         .try_as<FrameworkElement>();
+        if (!child) continue;
+        auto cname = child.Name();
+        auto cclass = winrt::get_class_name(child);
+        Wh_Log(L"  [%s] (%s) %.0fx%.0f %s",
+               cname.c_str(), cclass.c_str(),
+               child.ActualWidth(), child.ActualHeight(),
+               child.Visibility() == Visibility::Collapsed ? L"COLLAPSED" : L"Visible");
+    }
+    Wh_Log(L"Secondary frame size now: %.0fx%.0f",
+           g_secondarySystemTrayFrame.ActualWidth(),
+           g_secondarySystemTrayFrame.ActualHeight());
+
+    Wh_Log(L"=== POPULATION ATTEMPT COMPLETE ===");
+
+    // Step 6: Watch primary frame for size changes so we can sync to secondary
+    g_primarySizeChangedToken = g_primarySystemTrayFrame.SizeChanged(
+        [](winrt::Windows::Foundation::IInspectable const& sender,
+           SizeChangedEventArgs const& args) {
+            if (g_unloading || !g_secondarySystemTrayFrame) return;
+
+            double newWidth = args.NewSize().Width;
+            double oldWidth = args.PreviousSize().Width;
+            if (newWidth == oldWidth) return;
+
+            Wh_Log(L"[PrimarySizeChanged] %.0f -> %.0f", oldWidth, newWidth);
+
+            // Update the cached primary size
+            g_lastPrimaryFrameSize = newWidth;
+
+            // Apply to secondary frame
+            double secWidth = g_secondarySystemTrayFrame.Width();
+            if (secWidth != newWidth) {
+                Wh_Log(L"[PrimarySizeChanged] Syncing secondary: %.0f -> %.0f",
+                       secWidth, newWidth);
+                g_secondarySystemTrayFrame.Width(newWidth);
+                g_secondarySystemTrayFrame.InvalidateMeasure();
+                g_secondarySystemTrayFrame.InvalidateArrange();
+                auto parent = Media::VisualTreeHelper::GetParent(
+                    g_secondarySystemTrayFrame).try_as<FrameworkElement>();
+                while (parent) {
+                    parent.InvalidateMeasure();
+                    parent.InvalidateArrange();
+                    parent = Media::VisualTreeHelper::GetParent(parent)
+                        .try_as<FrameworkElement>();
+                }
+            }
+        });
+    Wh_Log(L"[SizeChanged] Registered on primary frame");
+
+    // Install flyout repositioning hook now that secondary tray is populated
+    InstallFlyoutHook();
+}
+
+// ─── Process a loaded IconView element ──────────────────────────────────────
+
+void HandleLoadedIconView(FrameworkElement iconView) {
+    // Navigate up to find SystemTray.SystemTrayFrame
+    auto systemTrayFrame = GetParentElementByClassName(
+        iconView, L"SystemTray.SystemTrayFrame");
+    if (!systemTrayFrame) {
+        Wh_Log(L"IconView loaded but no SystemTrayFrame parent found");
+        return;
+    }
+
+    bool isSecondary = IsSecondaryTaskbar(systemTrayFrame);
+
+    if (isSecondary) {
+        if (!g_secondaryTreeDumped) {
+            g_secondaryTreeDumped = true;
+            g_secondarySystemTrayFrame = systemTrayFrame;
+            Wh_Log(L"=== SECONDARY TASKBAR XAML TREE ===");
+            DumpXamlTree(systemTrayFrame, 0, 8);
+            ProbeContainerInterfaces(systemTrayFrame, L"SECONDARY");
+        }
+    } else {
+        if (!g_primaryTreeDumped) {
+            g_primaryTreeDumped = true;
+            g_primarySystemTrayFrame = systemTrayFrame;
+            Wh_Log(L"=== PRIMARY TASKBAR XAML TREE ===");
+            DumpXamlTree(systemTrayFrame, 0, 8);
+            ProbeContainerInterfaces(systemTrayFrame, L"PRIMARY");
+        }
+    }
+
+    // Once we have both, try to populate the secondary tray
+    if (g_primarySystemTrayFrame && g_secondarySystemTrayFrame) {
+        TryPopulateSecondaryTray();
+    }
+}
+
+// ─── SystemTrayController hooks ─────────────────────────────────────────────
+
+// Constructor: captures primary controller this pointer
+using SystemTrayController_ctor_t = void*(WINAPI*)(void* pThis, void* taskbarModel);
+SystemTrayController_ctor_t SystemTrayController_ctor_Original;
+void* WINAPI SystemTrayController_ctor_Hook(void* pThis, void* taskbarModel) {
+    Wh_Log(L">>> SystemTrayController::ctor this=%p", pThis);
+    g_primaryController = pThis;
+    void* ret = SystemTrayController_ctor_Original(pThis, taskbarModel);
+    Wh_Log(L">>> SystemTrayController::ctor done, ret=%p", ret);
+    return ret;
+}
+
+// InitializeMainStack
+using SystemTrayController_InitializeMainStack_t = void(WINAPI*)(void* pThis);
+SystemTrayController_InitializeMainStack_t SystemTrayController_InitializeMainStack_Original;
+void WINAPI SystemTrayController_InitializeMainStack_Hook(void* pThis) {
+    Wh_Log(L">>> SystemTrayController::InitializeMainStack this=%p", pThis);
+    g_primaryController = pThis;
+    SystemTrayController_InitializeMainStack_Original(pThis);
+}
+
+// UpdateFrameSize - captures controller after startup
+using SystemTrayController_UpdateFrameSize_t = void(WINAPI*)(void* pThis);
+SystemTrayController_UpdateFrameSize_t SystemTrayController_UpdateFrameSize_Original;
+void WINAPI SystemTrayController_UpdateFrameSize_Hook(void* pThis) {
+    if (!g_primaryController) {
+        g_primaryController = pThis;
+        Wh_Log(L">>> Primary controller captured via UpdateFrameSize: %p", pThis);
+    }
+    SystemTrayController_UpdateFrameSize_Original(pThis);
+
+    // Fallback: extract frame from controller if not yet captured
+    if (!g_primarySystemTrayFrame && !g_primaryFrameSearchDone && !g_unloading) {
+        g_primaryFrameSearchDone = true;
+        auto frame = TryExtractFrameFromController(pThis, L"PRIMARY");
+        if (frame) {
+            HandleExtractedFrame(frame, false);
+        }
+    }
+}
+
+// ─── SystemTraySecondaryController hooks ────────────────────────────────────
+
+// Constructor
+using SystemTraySecondaryController_ctor_t = void*(WINAPI*)(void* pThis, void* taskbarModel);
+SystemTraySecondaryController_ctor_t SystemTraySecondaryController_ctor_Original;
+void* WINAPI SystemTraySecondaryController_ctor_Hook(void* pThis, void* taskbarModel) {
+    Wh_Log(L">>> SystemTraySecondaryController::ctor this=%p", pThis);
+
+    if (g_secondaryControllerCount < 8) {
+        g_secondaryControllers[g_secondaryControllerCount++] = pThis;
+    }
+
+    void* ret = SystemTraySecondaryController_ctor_Original(pThis, taskbarModel);
+    Wh_Log(L">>> SystemTraySecondaryController::ctor done, ret=%p", ret);
+    return ret;
+}
+
+// UpdateFrameSize
+using SystemTraySecondaryController_UpdateFrameSize_t = void(WINAPI*)(void* pThis);
+SystemTraySecondaryController_UpdateFrameSize_t SystemTraySecondaryController_UpdateFrameSize_Original;
+void WINAPI SystemTraySecondaryController_UpdateFrameSize_Hook(void* pThis) {
+    // Track this secondary controller
+    bool found = false;
+    for (int i = 0; i < g_secondaryControllerCount; i++) {
+        if (g_secondaryControllers[i] == pThis) { found = true; break; }
+    }
+    if (!found && g_secondaryControllerCount < 8) {
+        g_secondaryControllers[g_secondaryControllerCount++] = pThis;
+        Wh_Log(L">>> Secondary controller captured via UpdateFrameSize: %p", pThis);
+    }
+    SystemTraySecondaryController_UpdateFrameSize_Original(pThis);
+
+    // Fallback: extract frame from controller if not yet captured
+    if (!g_secondarySystemTrayFrame && !g_secondaryFrameSearchDone && !g_unloading) {
+        g_secondaryFrameSearchDone = true;
+        auto frame = TryExtractFrameFromController(pThis, L"SECONDARY");
+        if (frame) {
+            HandleExtractedFrame(frame, true);
+        }
+    }
+
+    // Re-apply width override after the original sets it to native value
+    if (g_populationAttempted && g_secondarySystemTrayFrame &&
+        g_lastPrimaryFrameSize > 0 && !g_unloading) {
+        double currentWidth = g_secondarySystemTrayFrame.Width();
+        if (currentWidth != g_lastPrimaryFrameSize) {
+            g_secondarySystemTrayFrame.Width(g_lastPrimaryFrameSize);
+        }
+    }
+}
+
+// GetFrameSize - override to match primary tray width when populated
+using SystemTrayController_GetFrameSize_t = double(WINAPI*)(void* pThis, int enumTaskbarSize);
+SystemTrayController_GetFrameSize_t SystemTrayController_GetFrameSize_Original;
+double WINAPI SystemTrayController_GetFrameSize_Hook(void* pThis, int enumTaskbarSize) {
+    double size = SystemTrayController_GetFrameSize_Original(pThis, enumTaskbarSize);
+    g_lastPrimaryFrameSize = size;
+    return size;
+}
+
+using SystemTraySecondaryController_GetFrameSize_t = double(WINAPI*)(void* pThis, int enumTaskbarSize);
+SystemTraySecondaryController_GetFrameSize_t SystemTraySecondaryController_GetFrameSize_Original;
+double WINAPI SystemTraySecondaryController_GetFrameSize_Hook(void* pThis, int enumTaskbarSize) {
+    double originalSize = SystemTraySecondaryController_GetFrameSize_Original(pThis, enumTaskbarSize);
+
+    if (g_populationAttempted && g_lastPrimaryFrameSize > originalSize) {
+        return g_lastPrimaryFrameSize;
+    }
+
+    return originalSize;
+}
+
+// ─── IconView::IconView hook ────────────────────────────────────────────────
+
+using IconView_IconView_t = void*(WINAPI*)(void* pThis);
+IconView_IconView_t IconView_IconView_Original;
+void* WINAPI IconView_IconView_Hook(void* pThis) {
+    void* ret = IconView_IconView_Original(pThis);
+
+    if (g_unloading) return ret;
+
+    // Get FrameworkElement from IconView WinRT object
+    // WinRT implementation objects have IInspectable at ((IUnknown**)pThis)[1]
+    FrameworkElement iconView = nullptr;
+    ((IUnknown**)pThis)[1]->QueryInterface(winrt::guid_of<FrameworkElement>(),
+                                           winrt::put_abi(iconView));
+    if (!iconView) {
+        return ret;
+    }
+
+    Wh_Log(L">>> IconView created: %p", pThis);
+
+    // Hook the Loaded event to explore the tree once the element is in the visual tree
+    g_autoRevokerList.emplace_back();
+    auto autoRevokerIt = g_autoRevokerList.end();
+    --autoRevokerIt;
+
+    *autoRevokerIt = iconView.Loaded(
+        winrt::auto_revoke_t{},
+        [autoRevokerIt](winrt::Windows::Foundation::IInspectable const& sender,
+                        RoutedEventArgs const& e) {
+            g_autoRevokerList.erase(autoRevokerIt);
+
+            if (g_unloading) return;
+
+            auto iconView = sender.try_as<FrameworkElement>();
+            if (!iconView) return;
+
+            auto className = winrt::get_class_name(iconView);
+            auto name = iconView.Name();
+            Wh_Log(L">>> IconView Loaded: class=%s name=%s",
+                   className.c_str(), name.c_str());
+
+            HandleLoadedIconView(iconView);
+        });
+
+    return ret;
+}
+
+// ─── module hooking ─────────────────────────────────────────────────────────
+
+bool HookSystemTraySymbols(HMODULE module) {
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        // Primary controller
+        {
+            {LR"(public: __cdecl winrt::SystemTray::implementation::SystemTrayController::SystemTrayController(struct winrt::WindowsUdk::UI::Shell::TaskbarModel const &))"},
+            &SystemTrayController_ctor_Original,
+            SystemTrayController_ctor_Hook,
+            true,
+        },
+        {
+            {LR"(private: void __cdecl winrt::SystemTray::implementation::SystemTrayController::InitializeMainStack(void))"},
+            &SystemTrayController_InitializeMainStack_Original,
+            SystemTrayController_InitializeMainStack_Hook,
+            true,
+        },
+        {
+            {LR"(private: void __cdecl winrt::SystemTray::implementation::SystemTrayController::UpdateFrameSize(void))"},
+            &SystemTrayController_UpdateFrameSize_Original,
+            SystemTrayController_UpdateFrameSize_Hook,
+            true,
+        },
+        {
+            {LR"(private: double __cdecl winrt::SystemTray::implementation::SystemTrayController::GetFrameSize(enum winrt::WindowsUdk::UI::Shell::TaskbarSize))"},
+            &SystemTrayController_GetFrameSize_Original,
+            SystemTrayController_GetFrameSize_Hook,
+            true,
+        },
+        // Secondary controller
+        {
+            {LR"(public: __cdecl winrt::SystemTray::implementation::SystemTraySecondaryController::SystemTraySecondaryController(struct winrt::WindowsUdk::UI::Shell::TaskbarModel const &))"},
+            &SystemTraySecondaryController_ctor_Original,
+            SystemTraySecondaryController_ctor_Hook,
+            true,
+        },
+        {
+            {LR"(private: void __cdecl winrt::SystemTray::implementation::SystemTraySecondaryController::UpdateFrameSize(void))"},
+            &SystemTraySecondaryController_UpdateFrameSize_Original,
+            SystemTraySecondaryController_UpdateFrameSize_Hook,
+            true,
+        },
+        {
+            {LR"(private: double __cdecl winrt::SystemTray::implementation::SystemTraySecondaryController::GetFrameSize(enum winrt::WindowsUdk::UI::Shell::TaskbarSize))"},
+            &SystemTraySecondaryController_GetFrameSize_Original,
+            SystemTraySecondaryController_GetFrameSize_Hook,
+            true,
+        },
+        // IconView constructor - key hook for XAML tree access
+        {
+            {LR"(public: __cdecl winrt::SystemTray::implementation::IconView::IconView(void))"},
+            &IconView_IconView_Original,
+            IconView_IconView_Hook,
+            true,
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks))) {
+        Wh_Log(L"HookSymbols failed");
+        return false;
+    }
+
+    return true;
+}
+
+// ─── module discovery ───────────────────────────────────────────────────────
+
+static HMODULE GetSystemTrayModuleHandle() {
+    HMODULE module = GetModuleHandle(L"SystemTray.dll");
+    if (!module) {
+        module = GetModuleHandle(L"Taskbar.View.dll");
+        if (module) {
+            VS_FIXEDFILEINFO* fixedFileInfo =
+                GetModuleVersionInfo(module, nullptr);
+            WORD moduleMajor =
+                fixedFileInfo ? HIWORD(fixedFileInfo->dwFileVersionMS) : 0;
+            if (!moduleMajor || moduleMajor >= 2604) {
+                Wh_Log(L"Skipping Taskbar.View.dll version %d", moduleMajor);
+                module = nullptr;
+            }
+        }
+    }
+    return module;
+}
+
+static void HandleLoadedModuleIfSystemTray(HMODULE module,
+                                            LPCWSTR lpLibFileName) {
+    if (!lpLibFileName) return;
+
+    LPCWSTR fileName = wcsrchr(lpLibFileName, L'\\');
+    fileName = fileName ? fileName + 1 : lpLibFileName;
+
+    if (_wcsicmp(fileName, L"SystemTray.dll") == 0 ||
+        _wcsicmp(fileName, L"Taskbar.View.dll") == 0) {
+        Wh_Log(L"SystemTray module loaded: %s", fileName);
+        if (HookSystemTraySymbols(module)) {
+            Wh_ApplyHookOperations();
+        }
+    }
+}
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t LoadLibraryExW_Original;
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
+                                   HANDLE hFile,
+                                   DWORD dwFlags) {
+    HMODULE module = LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
+    if (module && !g_unloading) {
+        HandleLoadedModuleIfSystemTray(module, lpLibFileName);
+    }
+    return module;
+}
+
+// ─── Windhawk callbacks ─────────────────────────────────────────────────────
+
+BOOL Wh_ModInit() {
+    Wh_Log(L">");
+
+    HMODULE systemTrayModule = GetSystemTrayModuleHandle();
+    if (systemTrayModule) {
+        Wh_Log(L"SystemTray module already loaded");
+        if (!HookSystemTraySymbols(systemTrayModule)) {
+            Wh_Log(L"Failed to hook SystemTray symbols");
+            return FALSE;
+        }
+    } else {
+        Wh_Log(L"SystemTray module not loaded yet, hooking LoadLibraryExW");
+
+        HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
+        auto pKernelBaseLoadLibraryExW =
+            (decltype(&LoadLibraryExW))GetProcAddress(kernelBaseModule,
+                                                      "LoadLibraryExW");
+        WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
+                                       LoadLibraryExW_Hook,
+                                       &LoadLibraryExW_Original);
+    }
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    Wh_Log(L">");
+    Wh_Log(L"Primary controller: %p", g_primaryController);
+    Wh_Log(L"Secondary controllers: %d", g_secondaryControllerCount);
+
+    // If the mod was loaded after the taskbar is already running, we need to
+    // force the taskbar to rebuild so our constructor and UpdateFrameSize
+    // hooks fire. Broadcast WM_SETTINGCHANGE with "TraySettings" to trigger
+    // the taskbar to re-read its configuration and rebuild its XAML tree.
+    if (!g_primaryController && !g_unloading) {
+        Wh_Log(L"No controllers captured during init - broadcasting "
+               L"WM_SETTINGCHANGE to trigger taskbar rebuild");
+
+        SendNotifyMessage(HWND_BROADCAST, WM_SETTINGCHANGE,
+                          0, (LPARAM)L"TraySettings");
+    }
+
+    InstallDisplayChangeListener();
+}
+
+void Wh_ModBeforeUninit() {
+    Wh_Log(L">");
+    g_unloading = true;
+
+    // Remove display change listener
+    UninstallDisplayChangeListener();
+
+    // Remove flyout repositioning hook
+    UninstallFlyoutHook();
+
+    // Remove SizeChanged listener from primary frame
+    if (g_primarySystemTrayFrame && g_primarySizeChangedToken.value) {
+        g_primarySystemTrayFrame.SizeChanged(g_primarySizeChangedToken);
+        g_primarySizeChangedToken = {};
+    }
+
+    // Clear loaded event revokers
+    g_autoRevokerList.clear();
+
+    // Restore secondary tray to original state
+    if (g_secondaryContainersUncollapsed && g_secondarySystemTrayFrame) {
+        try {
+            auto grid = FindChildByName(g_secondarySystemTrayFrame,
+                                         L"SystemTrayFrameGrid");
+            if (grid) {
+                // Re-collapse containers that we modified
+                for (auto name : g_syncedContainers) {
+                    auto child = FindChildByName(grid, name);
+                    if (child && child.ActualWidth() > 0) {
+                        // Only re-collapse if it was originally collapsed
+                        // (we can't perfectly know, but narrow ones likely were)
+                        child.Visibility(Visibility::Collapsed);
+                    }
+                }
+
+                // Clear shared ItemsSource on NotificationAreaIcons
+                // (it's a direct child of SystemTrayFrameGrid)
+                auto nai = FindChildByName(grid, L"NotificationAreaIcons");
+                if (nai) {
+                    auto ic = nai.try_as<Controls::ItemsControl>();
+                    if (ic) {
+                        ic.ItemsSource(nullptr);
+                    }
+                }
+
+                // Restore frame width and force layout update
+                g_secondarySystemTrayFrame.ClearValue(
+                    FrameworkElement::WidthProperty());
+                g_secondarySystemTrayFrame.InvalidateMeasure();
+                g_secondarySystemTrayFrame.UpdateLayout();
+            }
+        } catch (...) {
+            Wh_Log(L"Error during cleanup");
+        }
+    }
+
+    // Release XAML references
+    g_primarySystemTrayFrame = nullptr;
+    g_secondarySystemTrayFrame = nullptr;
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L">");
+}
+
+// ─── refresh helper ─────────────────────────────────────────────────────────
+
+static void RefreshSecondaryTray() {
+    if (g_unloading) return;
+
+    if (g_primarySystemTrayFrame && g_secondarySystemTrayFrame) {
+        double primaryWidth = g_primarySystemTrayFrame.ActualWidth();
+        if (primaryWidth > 0) {
+            Wh_Log(L"[Refresh] Syncing secondary width to %.0f", primaryWidth);
+            g_lastPrimaryFrameSize = primaryWidth;
+            g_secondarySystemTrayFrame.Width(primaryWidth);
+            g_secondarySystemTrayFrame.InvalidateMeasure();
+            g_secondarySystemTrayFrame.InvalidateArrange();
+
+            // Walk up the visual tree to force parent re-layout
+            auto parent = Media::VisualTreeHelper::GetParent(
+                g_secondarySystemTrayFrame).try_as<FrameworkElement>();
+            while (parent) {
+                parent.InvalidateMeasure();
+                parent.InvalidateArrange();
+                parent = Media::VisualTreeHelper::GetParent(parent)
+                    .try_as<FrameworkElement>();
+            }
+
+            g_secondarySystemTrayFrame.UpdateLayout();
+        }
+    }
+}
+
+// ─── display change listener ────────────────────────────────────────────────
+
+static LRESULT CALLBACK DisplayChangeWndProc(HWND hwnd, UINT msg,
+                                              WPARAM wParam, LPARAM lParam) {
+    switch (msg) {
+        case WM_DISPLAYCHANGE:
+            Wh_Log(L"[DisplayChange] Resolution changed: %dx%d bpp=%d",
+                   LOWORD(lParam), HIWORD(lParam), (int)wParam);
+            RefreshSecondaryTray();
+            return 0;
+
+        case WM_DPICHANGED:
+            Wh_Log(L"[DisplayChange] DPI changed: X=%d Y=%d",
+                   LOWORD(wParam), HIWORD(wParam));
+            RefreshSecondaryTray();
+            return 0;
+
+        case WM_SETTINGCHANGE:
+            // Windows fires WM_SETTINGCHANGE on various display/DPI changes
+            if (lParam) {
+                auto param = reinterpret_cast<const wchar_t*>(lParam);
+                // "WindowMetrics" fires on DPI/scale changes
+                if (wcscmp(param, L"WindowMetrics") == 0) {
+                    Wh_Log(L"[DisplayChange] WM_SETTINGCHANGE: %s", param);
+                    RefreshSecondaryTray();
+                }
+            }
+            return 0;
+    }
+
+    return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+
+static void InstallDisplayChangeListener() {
+    if (g_displayChangeWindow) return;
+
+    WNDCLASS wc = {};
+    wc.lpfnWndProc = DisplayChangeWndProc;
+    wc.hInstance = GetModuleHandle(nullptr);
+    wc.lpszClassName = g_displayChangeClassName;
+
+    RegisterClass(&wc);
+
+    g_displayChangeWindow = CreateWindowEx(
+        0, g_displayChangeClassName, L"", 0,
+        0, 0, 0, 0,
+        HWND_MESSAGE,  // message-only window
+        nullptr, wc.hInstance, nullptr);
+
+    if (g_displayChangeWindow) {
+        Wh_Log(L"[DisplayChange] Listener window installed");
+    } else {
+        Wh_Log(L"[DisplayChange] Failed to create listener window: %d",
+               GetLastError());
+    }
+}
+
+static void UninstallDisplayChangeListener() {
+    if (g_displayChangeWindow) {
+        DestroyWindow(g_displayChangeWindow);
+        g_displayChangeWindow = nullptr;
+    }
+    UnregisterClass(g_displayChangeClassName, GetModuleHandle(nullptr));
+}
+

--- a/mods/taskbar-tray-on-all-monitors.wh.cpp
+++ b/mods/taskbar-tray-on-all-monitors.wh.cpp
@@ -2,13 +2,13 @@
 // @id              taskbar-tray-on-all-monitors
 // @name            Taskbar tray on all monitors
 // @description     Mirrors the system tray (clock, volume, network, battery, notification icons) from the primary taskbar onto all secondary monitor taskbars
-// @version         1.0
+// @version         1.1
 // @author          RYJASM
 // @github          https://github.com/RYJASM
 // @include         explorer.exe
+// @include         ShellHost.exe
 // @architecture    x86-64
-// @architecture    arm64
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lversion -luuid
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lversion -luuid -lshcore -lcomctl32
 // ==/WindhawkMod==
 
 // Source code is published under The GNU General Public License v3.0.
@@ -51,15 +51,21 @@ frame keeps all secondary widths in sync at runtime.
 
 #include <windhawk_utils.h>
 
+#include <commctrl.h>
+#include <shellapi.h>
+#include <ShellScalingApi.h>
+#include <windowsx.h>
 #include <winrt/base.h>
 
 #undef GetCurrentTime
 
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.h>
 
+#include <algorithm>
 #include <atomic>
 #include <functional>
 #include <list>
@@ -81,6 +87,21 @@ static bool g_primaryTreeDumped = false;
 static FrameworkElement g_primarySystemTrayFrame{nullptr};
 static double g_lastPrimaryFrameSize = 0;
 static winrt::event_token g_primarySizeChangedToken{};
+static winrt::Windows::UI::Core::CoreDispatcher g_xamlDispatcher{nullptr};
+
+struct TrayMetrics {
+    double notifyIconStack = 0;
+    double notificationAreaIcons = 0;
+    double mainStack = 0;
+    double nonActivatableStack = 0;
+    double controlCenterButton = 0;
+    double notificationCenterButton = 0;
+    double showDesktopStack = 0;
+    double frameWidth = 0;
+    bool valid = false;
+};
+
+static TrayMetrics g_trayMetrics{};
 
 // Per-secondary-controller state
 struct SecondaryInfo {
@@ -163,6 +184,53 @@ FrameworkElement FindChildByName(FrameworkElement element, PCWSTR name) {
     });
 }
 
+static double GetChildWidthByName(FrameworkElement parent, PCWSTR name) {
+    auto child = FindChildByName(parent, name);
+    return child ? child.ActualWidth() : 0;
+}
+
+static void UpdateTrayMetricsFromFrame(FrameworkElement frame,
+                                       const wchar_t* reason) {
+    if (!frame) return;
+
+    auto grid = FindChildByName(frame, L"SystemTrayFrameGrid");
+    if (!grid) return;
+
+    TrayMetrics metrics = {};
+    metrics.notifyIconStack = GetChildWidthByName(grid, L"NotifyIconStack");
+    metrics.notificationAreaIcons =
+        GetChildWidthByName(grid, L"NotificationAreaIcons");
+    metrics.mainStack = GetChildWidthByName(grid, L"MainStack");
+    metrics.nonActivatableStack =
+        GetChildWidthByName(grid, L"NonActivatableStack");
+    metrics.controlCenterButton =
+        GetChildWidthByName(grid, L"ControlCenterButton");
+    metrics.notificationCenterButton =
+        GetChildWidthByName(grid, L"NotificationCenterButton");
+    metrics.showDesktopStack = GetChildWidthByName(grid, L"ShowDesktopStack");
+    metrics.frameWidth = frame.ActualWidth();
+
+    double measuredWidth =
+        metrics.notifyIconStack +
+        metrics.notificationAreaIcons +
+        metrics.mainStack +
+        metrics.nonActivatableStack +
+        metrics.controlCenterButton +
+        metrics.notificationCenterButton +
+        metrics.showDesktopStack;
+
+    metrics.valid = measuredWidth > 0 && metrics.frameWidth > 0;
+    g_trayMetrics = metrics;
+
+    Wh_Log(L"[TrayMetrics:%s] frame=%.0f sum=%.0f show=%.0f notif=%.0f "
+           L"cc=%.0f nonAct=%.0f main=%.0f nai=%.0f overflow=%.0f valid=%d",
+           reason, metrics.frameWidth, measuredWidth,
+           metrics.showDesktopStack, metrics.notificationCenterButton,
+           metrics.controlCenterButton, metrics.nonActivatableStack,
+           metrics.mainStack, metrics.notificationAreaIcons,
+           metrics.notifyIconStack, metrics.valid);
+}
+
 FrameworkElement EnumParentElements(
     FrameworkElement element,
     std::function<bool(FrameworkElement)> enumCallback) {
@@ -220,301 +288,1032 @@ void DumpXamlTree(FrameworkElement element, int depth, int maxDepth) {
     }
 }
 
-// ─── Flyout repositioning ──────────────────────────────────────────────────
-// Detects flyout windows that appear on the primary monitor when the cursor
-// is on a secondary monitor, and repositions them to the correct monitor.
-// Uses EVENT_OBJECT_LOCATIONCHANGE to persistently reposition windows that
-// the system moves back to primary (e.g. Quick Settings XAML island).
+// ─── Flyout repositioning (proactive hook-based) ────────────────────────────
+//
+// ## Overview
+// When a user clicks a tray icon on a secondary monitor, the system normally
+// opens the corresponding flyout on the primary monitor. We intercept the
+// Win32 APIs that control flyout placement so they open on the correct monitor.
+//
+// ## Architecture
+// 1. A Win32 subclass on each Shell_SecondaryTrayWnd detects clicks and arms
+//    a short-lived FlyoutContext with the target monitor, anchor point, and
+//    flyout kind.
+// 2. MonitorFrom* hooks redirect monitor queries to the target monitor so
+//    the system's own layout code picks the right display.
+// 3. SetWindowPos/MoveWindow/DeferWindowPos hooks intercept the final window
+//    placement and call TranslateFlyoutRect to compute the correct position.
+// 4. TrackPopupMenuEx hook handles Win32 popup menus (#32768 class) which
+//    bypass SetWindowPos entirely — e.g. "Safely Remove Hardware".
+//
+// ## Flyout kinds and their positioning behavior
+// - kControlCenter / kNotificationCenter: Full-height panels (Quick Settings,
+//   Notification Center). The system sizes these to fill the work area height,
+//   and ShellHost.exe already computes dimensions at the target monitor's DPI
+//   thanks to our MonitorFrom* redirections. No DPI rescaling needed — only
+//   X/Y translation to the target monitor.
+// - kOverflowTray: Fixed-size popup (overflow tray chevron). The system
+//   computes the window size using the primary monitor's DPI. When the target
+//   monitor has a different DPI, dimensions must be rescaled.
+// - kTrayPopup: Context menus and other small popups from tray icons. Same
+//   rescaling behavior as kOverflowTray.
+//
+// ## Cross-DPI scaling
+// When primary and secondary monitors have different DPI (e.g. 200% vs 150%),
+// fixed-size flyouts (kOverflowTray, kTrayPopup) are computed at the primary
+// DPI but displayed on the secondary. We rescale: newDim = MulDiv(dim,
+// targetDpi, primaryDpi). Full-height panels (kControlCenter,
+// kNotificationCenter) don't need this because the system sizes them to the
+// work area after our MonitorFrom* hooks tell it the correct monitor.
+//
+// Note: We always look up the PRIMARY monitor's DPI as the source, not the
+// requested rect's monitor, because our MonitorFrom* hooks may have already
+// redirected the system to compute coordinates on the target monitor.
 
-static HWINEVENTHOOK g_winEventHook = nullptr;
-
-// Track repositioned flyouts so we can fight back on LOCATIONCHANGE
-static HWND g_trackedFlyouts[4] = {};
-static HMONITOR g_trackedTargets[4] = {};
-static DWORD g_trackedTimes[4] = {};
-static int g_trackedCount = 0;
+// Returns the DPI for a monitor, falling back to 96 on failure.
+static UINT GetMonitorDpi(HMONITOR hMon) {
+    UINT dpiX = 96, dpiY = 96;
+    GetDpiForMonitor(hMon, MDT_EFFECTIVE_DPI, &dpiX, &dpiY);
+    return dpiX;
+}
 
 static bool IsPrimaryMonitor(HMONITOR hMon) {
     MONITORINFO mi = {sizeof(mi)};
     return GetMonitorInfo(hMon, &mi) && (mi.dwFlags & MONITORINFOF_PRIMARY);
 }
 
-static void TrackFlyout(HWND hwnd, HMONITOR target) {
-    for (int i = 0; i < g_trackedCount; i++) {
-        if (g_trackedFlyouts[i] == hwnd) {
-            g_trackedTargets[i] = target;
-            g_trackedTimes[i] = GetTickCount();
-            return;
-        }
+// ─── Flyout context ─────────────────────────────────────────────────────────
+
+asm(".section .shared,\"dws\"\n");
+#define SHARED_SECTION __attribute__((section(".shared")))
+
+// Flyout kinds — determines positioning and DPI scaling behavior.
+// Full-height panels (kControlCenter, kNotificationCenter) are sized by the
+// system to fill the work area; no DPI rescaling needed, only X/Y translation.
+// Fixed-size popups (kOverflowTray, kTrayPopup) need DPI rescaling when the
+// target monitor has a different DPI than the primary.
+constexpr int kFlyoutNone          = 0;  // No flyout
+constexpr int kControlCenter       = 1;  // Quick Settings panel (full-height)
+constexpr int kOverflowTray        = 2;  // Overflow tray popup (fixed-size, needs DPI rescale)
+constexpr int kNotificationCenter  = 3;  // Notification Center panel (full-height)
+constexpr int kTrayPopup           = 4;  // Context menus, tray icon popups (fixed-size, needs DPI rescale)
+
+// Context durations (milliseconds)
+constexpr DWORD kControlCenterContextMs  = 1800;
+constexpr DWORD kOverflowTrayContextMs   = 800;
+constexpr DWORD kAfterPlacementMs        = 650;
+
+// Hit-test metrics (logical pixels at 96 DPI)
+constexpr int kShowDesktopWidth        = 2;
+constexpr int kNotificationCenterWidth = 78;
+constexpr int kControlCenterWidth      = 117;
+constexpr int kNotifyIconStackWidth    = 32;
+constexpr int kHitSlop                 = 8;
+
+struct FlyoutContext {
+    HMONITOR targetMonitor;
+    HWND     taskbarWnd;
+    POINT    anchorPoint;
+    RECT     taskbarRect;
+    UINT     targetDpi;
+    volatile DWORD expireTick;
+    int      flyoutKind;
+};
+
+FlyoutContext g_flyoutCtx SHARED_SECTION = {};
+
+// Suppression depth — incremented while our own hooks call Original functions
+// to prevent re-entrant redirection.
+static thread_local int g_flyoutRedirectionSuppressed = 0;
+
+struct FlyoutRedirectionGuard {
+    FlyoutRedirectionGuard() { g_flyoutRedirectionSuppressed++; }
+    ~FlyoutRedirectionGuard() { g_flyoutRedirectionSuppressed--; }
+};
+
+static void ArmFlyoutContext(HWND taskbarWnd, int kind, POINT anchor) {
+    // Clear first so MonitorFromRect below doesn't get redirected by stale context
+    g_flyoutCtx.expireTick = 0;
+
+    RECT tbRect = {};
+    GetWindowRect(taskbarWnd, &tbRect);
+    // Use suppression guard + plain API call. expireTick is already 0 so
+    // our hook would fall through anyway, but the guard is extra safety.
+    FlyoutRedirectionGuard guard;
+    HMONITOR mon = MonitorFromRect(&tbRect, MONITOR_DEFAULTTONEAREST);
+
+    DWORD durationMs = (kind == kControlCenter || kind == kNotificationCenter)
+                           ? kControlCenterContextMs
+                           : kOverflowTrayContextMs;
+
+    g_flyoutCtx.targetMonitor = mon;
+    g_flyoutCtx.taskbarWnd    = taskbarWnd;
+    g_flyoutCtx.anchorPoint   = anchor;
+    g_flyoutCtx.taskbarRect   = tbRect;
+    g_flyoutCtx.targetDpi     = GetMonitorDpi(mon);
+    g_flyoutCtx.flyoutKind    = kind;
+    // Write expireTick last with a store barrier so readers see
+    // all fields populated before expiry becomes valid.
+    MemoryBarrier();
+    g_flyoutCtx.expireTick    = GetTickCount() + durationMs;
+
+    MONITORINFOEX armMi = {};
+    armMi.cbSize = sizeof(armMi);
+    GetMonitorInfo(mon, &armMi);
+    APPBARDATA abd = {sizeof(abd)};
+    UINT abState = (UINT)SHAppBarMessage(ABM_GETSTATE, &abd);
+    Wh_Log(L"[FlyoutCtx] Armed kind=%d mon=%p \"%s\" dpi=%u anchor=(%d,%d) "
+           L"duration=%u taskbar=(%d,%d,%d,%d) monWork=(%d,%d,%d,%d) "
+           L"autoHide=%s",
+           kind, mon, armMi.szDevice, g_flyoutCtx.targetDpi,
+           anchor.x, anchor.y, durationMs,
+           tbRect.left, tbRect.top, tbRect.right, tbRect.bottom,
+           armMi.rcWork.left, armMi.rcWork.top,
+           armMi.rcWork.right, armMi.rcWork.bottom,
+           (abState & ABS_AUTOHIDE) ? L"YES" : L"NO");
+}
+
+static void ClearFlyoutContext() {
+    g_flyoutCtx.expireTick = 0;
+    g_flyoutCtx.flyoutKind = kFlyoutNone;
+    g_flyoutCtx.targetMonitor = nullptr;
+}
+
+static FlyoutContext* GetActiveFlyoutContext() {
+    DWORD expire = g_flyoutCtx.expireTick;
+    if (!expire) return nullptr;
+    if (GetTickCount() > expire) {
+        Wh_Log(L"[FlyoutCtx] Context EXPIRED kind=%d (tick=%u expire=%u)",
+               g_flyoutCtx.flyoutKind, GetTickCount(), expire);
+        g_flyoutCtx.expireTick = 0;
+        return nullptr;
     }
-    if (g_trackedCount < 4) {
-        g_trackedFlyouts[g_trackedCount] = hwnd;
-        g_trackedTargets[g_trackedCount] = target;
-        g_trackedTimes[g_trackedCount] = GetTickCount();
-        g_trackedCount++;
+    if (!g_flyoutCtx.targetMonitor) return nullptr;
+    return &g_flyoutCtx;
+}
+
+static void ShortenFlyoutContext(DWORD newDurationMs) {
+    DWORD newExpire = GetTickCount() + newDurationMs;
+    DWORD currentExpire = g_flyoutCtx.expireTick;
+    if (currentExpire && newExpire < currentExpire) {
+        g_flyoutCtx.expireTick = newExpire;
     }
 }
 
-static void UntrackFlyout(HWND hwnd) {
-    for (int i = 0; i < g_trackedCount;  i++) {
-        if (g_trackedFlyouts[i] == hwnd) {
-            g_trackedFlyouts[i] = g_trackedFlyouts[--g_trackedCount];
-            g_trackedTargets[i] = g_trackedTargets[g_trackedCount];
-            g_trackedTimes[i] = g_trackedTimes[g_trackedCount];
-            return;
-        }
-    }
-}
+// ─── Known flyout window identification ─────────────────────────────────────
 
-static bool IsTrayFlyoutClass(const wchar_t* className) {
+static bool IsKnownFlyoutWindow(HWND hWnd, wchar_t* outClass = nullptr,
+                                 int outClassSize = 0) {
+    wchar_t className[128] = {};
+    if (!GetClassName(hWnd, className, ARRAYSIZE(className)))
+        return false;
+
+    if (outClass && outClassSize > 0)
+        wcsncpy_s(outClass, outClassSize, className, _TRUNCATE);
+
     if (wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0)
         return true;
     if (wcscmp(className, L"ControlCenterWindow") == 0)
         return true;
+    // Note: Xaml_WindowedPopupClass is excluded — it matches tooltips and
+    // small XAML popups that the system positions correctly. Real CC/overflow
+    // flyouts use ControlCenterWindow or TopLevelWindowForOverflowXamlIsland.
     if (wcscmp(className, L"#32768") == 0)
-        return true;
-    if (wcscmp(className, L"Shell_LightDismissOverlay") == 0)
         return true;
     if (wcscmp(className, L"XamlExplorerHostIslandWindow") == 0)
         return true;
     if (wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0)
         return true;
-    if (wcscmp(className, L"Windows.UI.Composition.DesktopWindowContentBridge") == 0)
-        return true;
+    // Note: Windows.UI.Composition.DesktopWindowContentBridge is excluded —
+    // it's the taskbar's own XAML bridge, not a flyout popup.
     return false;
 }
 
-static void RepositionFlyoutToMonitor(HWND hwnd, HMONITOR fromMon,
-                                       HMONITOR toMon) {
-    RECT wr;
-    if (!GetWindowRect(hwnd, &wr)) return;
+// ─── TranslateFlyoutRect — core DPI-aware position translation ──────────────
+//
+// Translates a flyout window's requested rect from its system-computed
+// position (typically on/near the primary monitor) to the correct position
+// on the target secondary monitor.
+//
+// For fixed-size flyouts (overflow tray, tray popups), rescales the window
+// dimensions from primary DPI to target DPI. For full-height panels (Control
+// Center, Notification Center), preserves the system's dimensions since they
+// already span the work area correctly.
+//
+// Positioning strategy: center horizontally on the anchor point (where the
+// user clicked), pin the bottom edge flush against the taskbar top.
 
-    MONITORINFO fromMi = {sizeof(fromMi)};
-    MONITORINFO toMi = {sizeof(toMi)};
-    if (!GetMonitorInfo(fromMon, &fromMi)) return;
-    if (!GetMonitorInfo(toMon, &toMi)) return;
+// Original function pointers (set during hook installation)
+static decltype(&MonitorFromPoint)  MonitorFromPoint_Original  = nullptr;
+static decltype(&MonitorFromRect)   MonitorFromRect_Original   = nullptr;
+static decltype(&MonitorFromWindow) MonitorFromWindow_Original = nullptr;
+static decltype(&SetWindowPos)      SetWindowPos_Original      = nullptr;
+static decltype(&MoveWindow)        MoveWindow_Original        = nullptr;
+static decltype(&DeferWindowPos)    DeferWindowPos_Original    = nullptr;
+static decltype(&TrackPopupMenuEx)  TrackPopupMenuEx_Original  = nullptr;
 
-    int ww = wr.right - wr.left;
-    int wh = wr.bottom - wr.top;
-    int fromMonW = fromMi.rcMonitor.right - fromMi.rcMonitor.left;
-    int fromMonH = fromMi.rcMonitor.bottom - fromMi.rcMonitor.top;
+static bool TranslateFlyoutRect(HWND hWnd, const RECT& requested,
+                                 RECT* translated) {
+    auto* ctx = GetActiveFlyoutContext();
+    if (!ctx) return false;
 
-    // Log extended style to understand rendering mode
-    LONG exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
-    Wh_Log(L"[Flyout] hwnd=%p style=0x%08X exStyle=0x%08X "
-           L"WS_EX_NOREDIRECTIONBITMAP=%s",
-           hwnd, GetWindowLong(hwnd, GWL_STYLE), exStyle,
-           (exStyle & 0x00200000 /*WS_EX_NOREDIRECTIONBITMAP*/) ? L"YES" : L"NO");
+    HMONITOR targetMon = ctx->targetMonitor;
+    MONITORINFO targetMi = {sizeof(targetMi)};
+    if (!GetMonitorInfo(targetMon, &targetMi)) return false;
+    const RECT& targetWork = targetMi.rcWork;
 
-    // Check if this is a full-screen overlay (e.g. Quick Settings XAML island)
-    if (ww >= fromMonW && wh >= fromMonH) {
-        // If the overlay already spans multiple monitors (e.g.
-        // Shell_LightDismissOverlay at (0,0,7680,7680)), it already covers
-        // the secondary monitor — don't resize/move it or we'll break the
-        // internal coordinate system of popups rendered within it.
-        int totalW = GetSystemMetrics(SM_CXVIRTUALSCREEN);
-        int totalH = GetSystemMetrics(SM_CYVIRTUALSCREEN);
-        if (ww > fromMonW || wh > fromMonH) {
-            Wh_Log(L"[Flyout] Multi-monitor overlay (%dx%d vs virtual %dx%d)"
-                   L" — skipping reposition",
-                   ww, wh, totalW, totalH);
-            return;
-        }
+    LONG width  = requested.right - requested.left;
+    LONG height = requested.bottom - requested.top;
+    if (width <= 0 || height <= 0) return false;
 
-        int toMonW = toMi.rcMonitor.right - toMi.rcMonitor.left;
-        int toMonH = toMi.rcMonitor.bottom - toMi.rcMonitor.top;
+    UINT targetDpi = ctx->targetDpi;
+    if (!targetDpi) targetDpi = GetMonitorDpi(targetMon);
+    if (!targetDpi) targetDpi = 96;
 
-        Wh_Log(L"[Flyout] Full-screen overlay: moving to (%d,%d %dx%d)",
-               toMi.rcMonitor.left, toMi.rcMonitor.top, toMonW, toMonH);
-
-        // Try hide-move-show to force re-render on new monitor
-        ShowWindow(hwnd, SW_HIDE);
-        BOOL ok = SetWindowPos(hwnd, nullptr,
-                               toMi.rcMonitor.left, toMi.rcMonitor.top,
-                               toMonW, toMonH,
-                               SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
-        ShowWindow(hwnd, SW_SHOWNOACTIVATE);
-
-        // Verify the move
-        RECT afterRect;
-        GetWindowRect(hwnd, &afterRect);
-        Wh_Log(L"[Flyout] SetWindowPos returned %d, error=%d, "
-               L"after rect=(%d,%d,%d,%d)",
-               ok, GetLastError(),
-               afterRect.left, afterRect.top,
-               afterRect.right, afterRect.bottom);
-        return;
+    // The system computes flyout window size at the PRIMARY monitor's DPI,
+    // regardless of which monitor the flyout will appear on (because the
+    // XAML layout engine runs at the primary DPI). We need to find the
+    // primary monitor's DPI to rescale correctly.
+    // Note: we can't use the requested rect position to find the source
+    // monitor because our MonitorFrom* hooks may have already redirected
+    // the coordinates to the target monitor.
+    UINT sourceDpi = 96;
+    {
+        FlyoutRedirectionGuard guard;
+        POINT origin = {0, 0};
+        HMONITOR primaryMon = MonitorFromPoint_Original
+            ? MonitorFromPoint_Original(origin, MONITOR_DEFAULTTOPRIMARY)
+            : MonitorFromPoint(origin, MONITOR_DEFAULTTOPRIMARY);
+        sourceDpi = GetMonitorDpi(primaryMon);
+        if (!sourceDpi) sourceDpi = 96;
     }
 
-    // Normal flyout: position relative to taskbar
-    int offRight = fromMi.rcWork.right - wr.right;
-    int newX = toMi.rcWork.right - ww - offRight;
-
-    // Find the secondary taskbar to align above it (handles auto-hide)
-    int taskbarTop = toMi.rcWork.bottom;
-    HWND findHwnd = nullptr;
-    while ((findHwnd = FindWindowEx(nullptr, findHwnd,
-                                     L"Shell_SecondaryTrayWnd",
-                                     nullptr)) != nullptr) {
-        HMONITOR trayMon =
-            MonitorFromWindow(findHwnd, MONITOR_DEFAULTTONEAREST);
-        if (trayMon == toMon) {
-            RECT trayRect;
-            if (GetWindowRect(findHwnd, &trayRect)) {
-                taskbarTop = trayRect.top;
-            }
-            break;
-        }
+    // Rescale dimensions if source and target monitors have different DPI.
+    // Only rescale for fixed-size flyouts (overflow tray, tray popups).
+    // Control Center and Notification Center fill the work area height and
+    // are already sized correctly by the system for the target monitor.
+    bool shouldRescale = (sourceDpi != targetDpi) &&
+        (ctx->flyoutKind == kOverflowTray || ctx->flyoutKind == kTrayPopup);
+    if (shouldRescale) {
+        width  = MulDiv(width, targetDpi, sourceDpi);
+        height = MulDiv(height, targetDpi, sourceDpi);
     }
 
-    int newY = taskbarTop - wh;
+    // Get class name for kind-specific placement
+    wchar_t className[128] = {};
+    GetClassName(hWnd, className, ARRAYSIZE(className));
 
-    Wh_Log(L"[Flyout] Repositioning from (%d,%d) to (%d,%d)",
-           wr.left, wr.top, newX, newY);
+    Wh_Log(L"[Translate] class=%s kind=%d anchor=(%d,%d) "
+           L"targetMon=%p srcDpi=%u tgtDpi=%u "
+           L"taskbar=(%d,%d,%d,%d) targetWork=(%d,%d,%d,%d) "
+           L"requested=(%d,%d,%d,%d) scaledSize=(%d,%d)",
+           className, ctx->flyoutKind,
+           ctx->anchorPoint.x, ctx->anchorPoint.y,
+           targetMon, sourceDpi, targetDpi,
+           ctx->taskbarRect.left, ctx->taskbarRect.top,
+           ctx->taskbarRect.right, ctx->taskbarRect.bottom,
+           targetWork.left, targetWork.top,
+           targetWork.right, targetWork.bottom,
+           requested.left, requested.top,
+           requested.right, requested.bottom,
+           width, height);
 
-    SetWindowPos(hwnd, nullptr, newX, newY, 0, 0,
-                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+    // Position flyout: center horizontally on anchor, pin bottom to taskbar top.
+    // Width and height have already been rescaled to the target monitor's DPI,
+    // so this positions the correctly-sized flyout flush against the taskbar.
+    LONG newX = ctx->anchorPoint.x - width / 2;
+    LONG newY = ctx->taskbarRect.top - height;
+
+    Wh_Log(L"[Translate] Anchor: newX=%d newY=%d tbTop=%d w=%d h=%d srcDpi=%u tgtDpi=%u",
+           newX, newY, ctx->taskbarRect.top, width, height, sourceDpi, targetDpi);
+
+    // Clamp into target work area
+    if (newX + width > targetWork.right)
+        newX = targetWork.right - width;
+    if (newX < targetWork.left)
+        newX = targetWork.left;
+    if (newY + height > targetWork.bottom)
+        newY = targetWork.bottom - height;
+    if (newY < targetWork.top)
+        newY = targetWork.top;
+
+    translated->left   = newX;
+    translated->top    = newY;
+    translated->right  = newX + width;
+    translated->bottom = newY + height;
+
+    // Shorten context after successful placement
+    ShortenFlyoutContext(kAfterPlacementMs);
+
+    bool changed = (translated->left != requested.left ||
+                    translated->top != requested.top ||
+                    translated->right != requested.right ||
+                    translated->bottom != requested.bottom);
+
+    if (changed) {
+        Wh_Log(L"[Translate] %s: (%d,%d,%d,%d) -> (%d,%d,%d,%d) kind=%d",
+               className,
+               requested.left, requested.top,
+               requested.right, requested.bottom,
+               translated->left, translated->top,
+               translated->right, translated->bottom,
+               ctx->flyoutKind);
+    }
+
+    return changed;
 }
 
-static void CALLBACK FlyoutWinEventProc(HWINEVENTHOOK hWinEventHook,
-                                         DWORD event, HWND hwnd,
-                                         LONG idObject, LONG idChild,
-                                         DWORD idEventThread,
-                                         DWORD dwmsEventTime) {
-    if (g_unloading) return;
-    if (!hwnd || idObject != 0 || idChild != 0) return;
+// ─── Cursor rescue fallback ─────────────────────────────────────────────────
+// For cases where click detection missed (pen/touch, icon shifts), detect
+// that a flyout is about to open on the wrong monitor and arm a context.
 
-    // EVENT_OBJECT_HIDE: stop tracking
-    if (event == EVENT_OBJECT_HIDE) {
-        UntrackFlyout(hwnd);
-        return;
+static bool TryCursorRescue(HWND hWnd, const RECT& requestedRect) {
+    wchar_t className[128] = {};
+    if (!GetClassName(hWnd, className, ARRAYSIZE(className)))
+        return false;
+
+    int kind = kFlyoutNone;
+    if (wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0)
+        kind = kOverflowTray;
+    else if (wcscmp(className, L"ControlCenterWindow") == 0)
+        kind = kControlCenter;
+    else if (wcscmp(className, L"#32768") == 0 ||
+             wcscmp(className, L"XamlExplorerHostIslandWindow") == 0 ||
+             wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0)
+        kind = kTrayPopup;
+    else
+        return false;
+
+    POINT cursorPos = {};
+    if (!GetCursorPos(&cursorPos)) return false;
+
+    // Find the taskbar window under the cursor
+    FlyoutRedirectionGuard guard;
+    HWND cursorWnd = WindowFromPoint(cursorPos);
+    HWND rootWnd = cursorWnd ? GetAncestor(cursorWnd, GA_ROOT) : nullptr;
+    if (!rootWnd) return false;
+
+    // Must be a secondary taskbar
+    wchar_t rootClass[128] = {};
+    GetClassName(rootWnd, rootClass, ARRAYSIZE(rootClass));
+    if (wcscmp(rootClass, L"Shell_SecondaryTrayWnd") != 0) {
+        Wh_Log(L"[CursorRescue] Skip: root class=%s (not secondary taskbar) "
+               L"cursor=(%d,%d) class=%s",
+               rootClass, cursorPos.x, cursorPos.y, className);
+        return false;
     }
 
-    // EVENT_OBJECT_LOCATIONCHANGE: reposition tracked flyouts that moved
-    // back to primary (system fighting our SetWindowPos)
-    if (event == EVENT_OBJECT_LOCATIONCHANGE) {
-        for (int i = 0; i < g_trackedCount; i++) {
-            if (g_trackedFlyouts[i] != hwnd) continue;
+    Wh_Log(L"[CursorRescue] Arming for class=%s kind=%d taskbar=%p "
+           L"cursor=(%d,%d)",
+           className, kind, rootWnd, cursorPos.x, cursorPos.y);
 
-            // Expire tracking after 3 seconds
-            if (GetTickCount() - g_trackedTimes[i] > 3000) {
-                UntrackFlyout(hwnd);
-                return;
-            }
-
-            RECT wr;
-            if (!GetWindowRect(hwnd, &wr)) return;
-            HMONITOR windowMon =
-                MonitorFromRect(&wr, MONITOR_DEFAULTTONEAREST);
-            if (IsPrimaryMonitor(windowMon)) {
-                RepositionFlyoutToMonitor(
-                    hwnd, windowMon, g_trackedTargets[i]);
-            }
-            return;
-        }
-        return;
-    }
-
-    // EVENT_OBJECT_SHOW: detect new flyouts
-    if (event != EVENT_OBJECT_SHOW) return;
-    if (!IsWindowVisible(hwnd)) return;
-
-    LONG style = GetWindowLong(hwnd, GWL_STYLE);
-    if (style & WS_CHILD) return;
-
-    // Check cursor is on a secondary monitor
-    POINT cursorPos;
-    GetCursorPos(&cursorPos);
-    HMONITOR cursorMon =
-        MonitorFromPoint(cursorPos, MONITOR_DEFAULTTONEAREST);
-    if (IsPrimaryMonitor(cursorMon)) return;
-
-    // Check window is on the primary monitor
-    RECT wr;
-    if (!GetWindowRect(hwnd, &wr)) return;
-    HMONITOR windowMon = MonitorFromRect(&wr, MONITOR_DEFAULTTONEAREST);
-    if (!IsPrimaryMonitor(windowMon)) return;
-
-    // Mismatch: cursor on secondary, window on primary
-    wchar_t className[256] = {};
-    GetClassName(hwnd, className, ARRAYSIZE(className));
-
-    DWORD ownerPid = 0;
-    GetWindowThreadProcessId(hwnd, &ownerPid);
-    Wh_Log(L"[Flyout] Show on primary while cursor on secondary: "
-           L"class='%s' hwnd=%p pid=%u rect=(%d,%d,%d,%d)",
-           className, hwnd, ownerPid, wr.left, wr.top, wr.right, wr.bottom);
-
-    if (IsTrayFlyoutClass(className)) {
-        int ww = wr.right - wr.left;
-        int wh = wr.bottom - wr.top;
-
-        // Skip multi-monitor overlays — they already cover the secondary
-        // monitor and repositioning them breaks internal popup coordinates
-        MONITORINFO wmi = {sizeof(wmi)};
-        GetMonitorInfo(windowMon, &wmi);
-        int monW = wmi.rcMonitor.right - wmi.rcMonitor.left;
-        int monH = wmi.rcMonitor.bottom - wmi.rcMonitor.top;
-        if (ww > monW || wh > monH) {
-            Wh_Log(L"[Flyout] Multi-monitor overlay (%dx%d vs mon %dx%d)"
-                   L" — skipping",
-                   ww, wh, monW, monH);
-        } else if (ww > 0 && wh > 0) {
-            // Window has real dimensions — reposition now
-            RepositionFlyoutToMonitor(hwnd, windowMon, cursorMon);
-            TrackFlyout(hwnd, cursorMon);
-        } else {
-            // Zero-sized at SHOW time — will be positioned later,
-            // LOCATIONCHANGE will handle it
-            Wh_Log(L"[Flyout] Zero-sized at SHOW, deferring to LOCATIONCHANGE");
-            TrackFlyout(hwnd, cursorMon);
-        }
-    }
-
-    // Also scan for any XamlExplorerHostIslandWindow on primary that we
-    // might have missed (pre-existing windows that didn't fire SHOW)
-    HWND found = nullptr;
-    while ((found = FindWindowEx(nullptr, found,
-                                  L"XamlExplorerHostIslandWindow",
-                                  nullptr)) != nullptr) {
-        if (found == hwnd) continue;  // already handled above
-        RECT fr;
-        if (!GetWindowRect(found, &fr)) continue;
-        if (!IsWindowVisible(found)) continue;
-        HMONITOR fMon = MonitorFromRect(&fr, MONITOR_DEFAULTTONEAREST);
-        if (IsPrimaryMonitor(fMon)) {
-            Wh_Log(L"[Flyout] SCAN: found extra XamlExplorerHostIslandWindow "
-                   L"hwnd=%p rect=(%d,%d,%d,%d) on primary",
-                   found, fr.left, fr.top, fr.right, fr.bottom);
-        }
-    }
+    ArmFlyoutContext(rootWnd, kind, cursorPos);
+    return true;
 }
 
-static void InstallFlyoutHook() {
-    if (g_winEventHook) return;
+// ─── MonitorFrom* hooks — redirect to target monitor ────────────────────────
 
-    // Cover SHOW (0x8002) through LOCATIONCHANGE (0x800B) to also
-    // catch HIDE (0x8003) for cleanup and LOCATIONCHANGE for persistent
-    // repositioning of flyouts that the system moves back to primary.
-    g_winEventHook = SetWinEventHook(
-        EVENT_OBJECT_SHOW, EVENT_OBJECT_LOCATIONCHANGE,
-        nullptr, FlyoutWinEventProc,
-        0, 0, WINEVENT_OUTOFCONTEXT);
+static bool ShouldForceForPoint(POINT pt, HMONITOR targetMon) {
+    if (!targetMon) return false;
+    // Ambiguous origin queries
+    if (pt.x == 0 && pt.y == 0) return true;
+    // Only redirect if the point resolves to the target monitor already,
+    // or to primary (where the system would normally place the flyout)
+    FlyoutRedirectionGuard guard;
+    HMONITOR actualMon = MonitorFromPoint_Original
+        ? MonitorFromPoint_Original(pt, MONITOR_DEFAULTTONEAREST)
+        : MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+    if (!actualMon) return true;
+    bool force = (actualMon == targetMon || IsPrimaryMonitor(actualMon));
+    if (!force) {
+        Wh_Log(L"[ShouldForcePoint] REJECTED pt=(%d,%d) actualMon=%p "
+               L"targetMon=%p (not target or primary)",
+               pt.x, pt.y, actualMon, targetMon);
+    }
+    return force;
+}
 
-    if (g_winEventHook) {
-        Wh_Log(L"[Flyout] WinEvent hook installed (SHOW+LOCATIONCHANGE)");
+static bool ShouldForceForRect(LPCRECT rect, HMONITOR targetMon) {
+    if (!targetMon) return false;
+    if (!rect || (rect->left == 0 && rect->top == 0 &&
+                  rect->right == 0 && rect->bottom == 0))
+        return true;
+    FlyoutRedirectionGuard guard;
+    HMONITOR actualMon = MonitorFromRect_Original
+        ? MonitorFromRect_Original(rect, MONITOR_DEFAULTTONEAREST)
+        : MonitorFromRect(rect, MONITOR_DEFAULTTONEAREST);
+    if (!actualMon) return true;
+    bool force = (actualMon == targetMon || IsPrimaryMonitor(actualMon));
+    if (!force) {
+        Wh_Log(L"[ShouldForceRect] REJECTED rect=(%d,%d,%d,%d) actualMon=%p "
+               L"targetMon=%p (not target or primary)",
+               rect->left, rect->top, rect->right, rect->bottom,
+               actualMon, targetMon);
+    }
+    return force;
+}
+
+static HMONITOR WINAPI MonitorFromPoint_Hook(POINT pt, DWORD flags) {
+    if (!g_flyoutRedirectionSuppressed && !g_unloading) {
+        if (auto* ctx = GetActiveFlyoutContext()) {
+            if (ShouldForceForPoint(pt, ctx->targetMonitor)) {
+                Wh_Log(L"[MFP_Hook] Redirecting pt=(%d,%d) -> mon=%p kind=%d",
+                       pt.x, pt.y, ctx->targetMonitor, ctx->flyoutKind);
+                return ctx->targetMonitor;
+            }
+        }
+    }
+    return MonitorFromPoint_Original(pt, flags);
+}
+
+static HMONITOR WINAPI MonitorFromRect_Hook(LPCRECT rect, DWORD flags) {
+    if (!g_flyoutRedirectionSuppressed && !g_unloading) {
+        if (auto* ctx = GetActiveFlyoutContext()) {
+            if (ShouldForceForRect(rect, ctx->targetMonitor)) {
+                Wh_Log(L"[MFR_Hook] Redirecting rect=(%d,%d,%d,%d) -> mon=%p kind=%d",
+                       rect ? rect->left : 0, rect ? rect->top : 0,
+                       rect ? rect->right : 0, rect ? rect->bottom : 0,
+                       ctx->targetMonitor, ctx->flyoutKind);
+                return ctx->targetMonitor;
+            }
+        }
+    }
+    return MonitorFromRect_Original(rect, flags);
+}
+
+// Auto-arm: when a known flyout class queries its monitor and cursor is over
+// a secondary taskbar, arm the context. This replaces click-based arming since
+// XAML islands consume input before WM_LBUTTONDOWN reaches the Win32 parent.
+static bool TryAutoArmFromCursor(HWND flyoutWnd, const wchar_t* className) {
+    POINT cursorPos = {};
+    if (!GetCursorPos(&cursorPos)) return false;
+
+    FlyoutRedirectionGuard guard;
+    HWND cursorWnd = WindowFromPoint(cursorPos);
+    HWND rootWnd = cursorWnd ? GetAncestor(cursorWnd, GA_ROOT) : nullptr;
+    if (!rootWnd) return false;
+
+    wchar_t rootClass[128] = {};
+    GetClassName(rootWnd, rootClass, ARRAYSIZE(rootClass));
+    if (wcscmp(rootClass, L"Shell_SecondaryTrayWnd") != 0)
+        return false;
+
+    int kind = kFlyoutNone;
+    if (wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0)
+        kind = kOverflowTray;
+    else if (wcscmp(className, L"ControlCenterWindow") == 0)
+        kind = kControlCenter;
+    // Note: Xaml_WindowedPopupClass is NOT auto-armed here — it matches both
+    // real CC sub-popups and small tooltips. CC flow starts with
+    // ControlCenterWindow which sets context; sub-popups inherit it.
+    else if (wcscmp(className, L"#32768") == 0 ||
+             wcscmp(className, L"XamlExplorerHostIslandWindow") == 0 ||
+             wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0)
+        kind = kTrayPopup;
+    else
+        return false;
+
+    Wh_Log(L"[AutoArm] Arming from cursor for class=%s kind=%d "
+           L"taskbar=%p cursor=(%d,%d)",
+           className, kind, rootWnd, cursorPos.x, cursorPos.y);
+
+    ArmFlyoutContext(rootWnd, kind, cursorPos);
+    return true;
+}
+
+static HMONITOR WINAPI MonitorFromWindow_Hook(HWND hWnd, DWORD flags) {
+    if (!g_flyoutRedirectionSuppressed && !g_unloading) {
+        // Check for active context first
+        auto* ctx = GetActiveFlyoutContext();
+
+        // If no context, try auto-arming from cursor position when we see
+        // a known flyout class. This handles the case where XAML islands
+        // consume clicks before they reach the Win32 subclass.
+        if (!ctx && hWnd) {
+            wchar_t className[128] = {};
+            if (IsKnownFlyoutWindow(hWnd, className, ARRAYSIZE(className))) {
+                if (TryAutoArmFromCursor(hWnd, className)) {
+                    ctx = GetActiveFlyoutContext();
+                }
+            }
+        }
+
+        if (ctx) {
+            wchar_t className[128] = {};
+            bool isFlyoutPopup = false;
+            if (hWnd) {
+                isFlyoutPopup = IsKnownFlyoutWindow(hWnd, className, ARRAYSIZE(className));
+            }
+            bool isClickedTaskbar = (hWnd == ctx->taskbarWnd);
+
+            if (isFlyoutPopup || isClickedTaskbar) {
+                Wh_Log(L"[MFW_Hook] Redirecting class=%s hwnd=%p -> mon=%p "
+                       L"kind=%d (flyout=%d taskbar=%d)",
+                       className, hWnd, ctx->targetMonitor, ctx->flyoutKind,
+                       isFlyoutPopup, isClickedTaskbar);
+                // Shorten context when placement is clearly happening
+                if (wcscmp(className, L"ControlCenterWindow") == 0 ||
+                    wcscmp(className, L"TopLevelWindowForOverflowXamlIsland") == 0) {
+                    ShortenFlyoutContext(kAfterPlacementMs);
+                }
+                return ctx->targetMonitor;
+            } else if (className[0] != L'\0') {
+                // Log unmatched top-level popup windows to spot missing flyout types
+                LONG style = GetWindowLong(hWnd, GWL_STYLE);
+                HWND parent = GetParent(hWnd);
+                if (!parent && (style & WS_POPUP)) {
+                    Wh_Log(L"[MFW_Hook] SKIPPED popup class=%s hwnd=%p "
+                           L"style=0x%X kind=%d",
+                           className, hWnd, style, ctx->flyoutKind);
+                }
+            }
+        }
+    }
+    return MonitorFromWindow_Original(hWnd, flags);
+}
+
+// ─── Placement hooks — translate flyout coordinates ─────────────────────────
+
+static bool ShouldTranslatePlacement(UINT uFlags) {
+    // Skip pure z-order / activation changes
+    if ((uFlags & SWP_NOMOVE) && (uFlags & SWP_NOSIZE))
+        return false;
+    return true;
+}
+
+static BOOL WINAPI SetWindowPos_Hook(HWND hWnd, HWND hWndInsertAfter,
+                                      int X, int Y, int cx, int cy,
+                                      UINT uFlags) {
+    if (!g_unloading && !g_flyoutRedirectionSuppressed) {
+        bool isFlyout = IsKnownFlyoutWindow(hWnd);
+
+        if (isFlyout && ShouldTranslatePlacement(uFlags)) {
+            bool hasContext = (GetActiveFlyoutContext() != nullptr);
+            wchar_t cls[128] = {};
+            GetClassName(hWnd, cls, ARRAYSIZE(cls));
+            Wh_Log(L"[SWP_Hook] class=%s hwnd=%p pos=(%d,%d) size=(%d,%d) "
+                   L"flags=0x%X hasCtx=%d",
+                   cls, hWnd, X, Y, cx, cy, uFlags, hasContext);
+
+            RECT currentRect = {};
+            GetWindowRect(hWnd, &currentRect);
+
+            LONG width = (uFlags & SWP_NOSIZE) ? currentRect.right - currentRect.left : cx;
+            LONG height = (uFlags & SWP_NOSIZE) ? currentRect.bottom - currentRect.top : cy;
+            RECT requested = {
+                (uFlags & SWP_NOMOVE) ? currentRect.left : X,
+                (uFlags & SWP_NOMOVE) ? currentRect.top : Y,
+                ((uFlags & SWP_NOMOVE) ? currentRect.left : X) + width,
+                ((uFlags & SWP_NOMOVE) ? currentRect.top : Y) + height,
+            };
+
+            // If no context, try auto-arm then cursor rescue
+            if (!hasContext) {
+                TryAutoArmFromCursor(hWnd, cls);
+                hasContext = (GetActiveFlyoutContext() != nullptr);
+            }
+            if (!hasContext) {
+                TryCursorRescue(hWnd, requested);
+                hasContext = (GetActiveFlyoutContext() != nullptr);
+            }
+
+            if (hasContext) {
+                RECT translated = {};
+                if (TranslateFlyoutRect(hWnd, requested, &translated)) {
+                    Wh_Log(L"[SWP_Hook] TRANSLATED (%d,%d,%d,%d) -> (%d,%d,%d,%d)",
+                           requested.left, requested.top,
+                           requested.right, requested.bottom,
+                           translated.left, translated.top,
+                           translated.right, translated.bottom);
+                    uFlags &= ~(SWP_NOMOVE | SWP_NOSIZE);
+                    X  = translated.left;
+                    Y  = translated.top;
+                    cx = translated.right - translated.left;
+                    cy = translated.bottom - translated.top;
+                }
+            }
+        }
+    }
+    return SetWindowPos_Original(hWnd, hWndInsertAfter, X, Y, cx, cy, uFlags);
+}
+
+static BOOL WINAPI MoveWindow_Hook(HWND hWnd, int X, int Y,
+                                    int nWidth, int nHeight, BOOL bRepaint) {
+    if (!g_unloading && !g_flyoutRedirectionSuppressed) {
+        bool isFlyout = IsKnownFlyoutWindow(hWnd);
+
+        if (isFlyout) {
+            bool hasContext = (GetActiveFlyoutContext() != nullptr);
+            wchar_t cls[128] = {};
+            GetClassName(hWnd, cls, ARRAYSIZE(cls));
+            Wh_Log(L"[MW_Hook] class=%s hwnd=%p pos=(%d,%d) size=(%d,%d) "
+                   L"hasCtx=%d",
+                   cls, hWnd, X, Y, nWidth, nHeight, hasContext);
+
+            RECT requested = {X, Y, X + nWidth, Y + nHeight};
+
+            if (!hasContext) {
+                TryAutoArmFromCursor(hWnd, cls);
+                hasContext = (GetActiveFlyoutContext() != nullptr);
+            }
+            if (!hasContext) {
+                TryCursorRescue(hWnd, requested);
+                hasContext = (GetActiveFlyoutContext() != nullptr);
+            }
+
+            if (hasContext) {
+                RECT translated = {};
+                if (TranslateFlyoutRect(hWnd, requested, &translated)) {
+                    Wh_Log(L"[MW_Hook] TRANSLATED (%d,%d,%d,%d) -> (%d,%d,%d,%d)",
+                           requested.left, requested.top,
+                           requested.right, requested.bottom,
+                           translated.left, translated.top,
+                           translated.right, translated.bottom);
+                    X       = translated.left;
+                    Y       = translated.top;
+                    nWidth  = translated.right - translated.left;
+                    nHeight = translated.bottom - translated.top;
+                }
+            }
+        }
+    }
+    return MoveWindow_Original(hWnd, X, Y, nWidth, nHeight, bRepaint);
+}
+
+static HDWP WINAPI DeferWindowPos_Hook(HDWP hWinPosInfo, HWND hWnd,
+                                        HWND hWndInsertAfter,
+                                        int x, int y, int cx, int cy,
+                                        UINT uFlags) {
+    if (!g_unloading && !g_flyoutRedirectionSuppressed) {
+        bool isFlyout = IsKnownFlyoutWindow(hWnd);
+
+        if (isFlyout && ShouldTranslatePlacement(uFlags)) {
+            bool hasContext = (GetActiveFlyoutContext() != nullptr);
+            wchar_t cls[128] = {};
+            GetClassName(hWnd, cls, ARRAYSIZE(cls));
+            Wh_Log(L"[DWP_Hook] class=%s hwnd=%p pos=(%d,%d) size=(%d,%d) "
+                   L"flags=0x%X hasCtx=%d",
+                   cls, hWnd, x, y, cx, cy, uFlags, hasContext);
+
+            RECT currentRect = {};
+            GetWindowRect(hWnd, &currentRect);
+
+            LONG width = (uFlags & SWP_NOSIZE) ? currentRect.right - currentRect.left : cx;
+            LONG height = (uFlags & SWP_NOSIZE) ? currentRect.bottom - currentRect.top : cy;
+            RECT requested = {
+                (uFlags & SWP_NOMOVE) ? currentRect.left : x,
+                (uFlags & SWP_NOMOVE) ? currentRect.top : y,
+                ((uFlags & SWP_NOMOVE) ? currentRect.left : x) + width,
+                ((uFlags & SWP_NOMOVE) ? currentRect.top : y) + height,
+            };
+
+            if (!hasContext) {
+                TryAutoArmFromCursor(hWnd, cls);
+                hasContext = (GetActiveFlyoutContext() != nullptr);
+            }
+            if (!hasContext) {
+                TryCursorRescue(hWnd, requested);
+                hasContext = (GetActiveFlyoutContext() != nullptr);
+            }
+
+            if (hasContext) {
+                RECT translated = {};
+                if (TranslateFlyoutRect(hWnd, requested, &translated)) {
+                    Wh_Log(L"[DWP_Hook] TRANSLATED (%d,%d,%d,%d) -> (%d,%d,%d,%d)",
+                           requested.left, requested.top,
+                           requested.right, requested.bottom,
+                           translated.left, translated.top,
+                           translated.right, translated.bottom);
+                    uFlags &= ~(SWP_NOMOVE | SWP_NOSIZE);
+                    x  = translated.left;
+                    y  = translated.top;
+                    cx = translated.right - translated.left;
+                    cy = translated.bottom - translated.top;
+                }
+            }
+        }
+    }
+    return DeferWindowPos_Original(hWinPosInfo, hWnd, hWndInsertAfter,
+                                    x, y, cx, cy, uFlags);
+}
+
+// ─── TrackPopupMenuEx hook — intercept Win32 popup menu positioning ──────────
+// Win32 popup menus (window class #32768) — e.g. "Safely Remove Hardware" —
+// are positioned internally by TrackPopupMenuEx. Unlike XAML flyouts, these
+// never call SetWindowPos/MoveWindow, so our placement hooks don't see them.
+// This hook translates the (x, y) coordinates to the anchor point on the
+// target monitor. The menu auto-sizes itself, so no DPI rescaling is needed.
+
+static BOOL WINAPI TrackPopupMenuEx_Hook(HMENU hMenu, UINT uFlags,
+                                          int x, int y,
+                                          HWND hWnd, LPTPMPARAMS lptpm) {
+    if (!g_unloading && !g_flyoutRedirectionSuppressed) {
+        auto* ctx = GetActiveFlyoutContext();
+
+        // If no context, check if cursor is over a secondary taskbar
+        if (!ctx) {
+            POINT cursorPos = {};
+            if (GetCursorPos(&cursorPos)) {
+                FlyoutRedirectionGuard guard;
+                HWND cursorWnd = WindowFromPoint(cursorPos);
+                HWND rootWnd = cursorWnd ? GetAncestor(cursorWnd, GA_ROOT) : nullptr;
+                if (rootWnd) {
+                    wchar_t rootClass[128] = {};
+                    GetClassName(rootWnd, rootClass, ARRAYSIZE(rootClass));
+                    if (wcscmp(rootClass, L"Shell_SecondaryTrayWnd") == 0) {
+                        Wh_Log(L"[TPM_Hook] Auto-arming from cursor at (%d,%d) "
+                               L"taskbar=%p", cursorPos.x, cursorPos.y, rootWnd);
+                        ArmFlyoutContext(rootWnd, kTrayPopup, cursorPos);
+                        ctx = GetActiveFlyoutContext();
+                    }
+                }
+            }
+        }
+
+        if (ctx) {
+            // Translate popup menu to the anchor point on the target monitor.
+            // Keep the system's original alignment flags and Y coordinate
+            // strategy — just shift X to the anchor and Y to the same
+            // offset from the taskbar on the target monitor.
+            int newX = ctx->anchorPoint.x;
+            int newY = y;
+
+            // The system's Y is relative to the primary tray position.
+            // Translate: compute offset from primary taskbar top, apply to target.
+            // Primary taskbar top == targetWork.bottom for same-DPI monitors.
+            // Original y was in absolute coords near the primary taskbar.
+            // Use anchor Y (cursor position near taskbar) for a reliable Y.
+            newY = ctx->anchorPoint.y;
+
+            Wh_Log(L"[TPM_Hook] Translating popup menu: (%d,%d) -> (%d,%d) "
+                   L"flags=0x%X anchor=(%d,%d) kind=%d",
+                   x, y, newX, newY, uFlags,
+                   ctx->anchorPoint.x, ctx->anchorPoint.y,
+                   ctx->flyoutKind);
+
+            ShortenFlyoutContext(kAfterPlacementMs);
+            return TrackPopupMenuEx_Original(hMenu, uFlags, newX, newY,
+                                              hWnd, lptpm);
+        }
+    }
+    return TrackPopupMenuEx_Original(hMenu, uFlags, x, y, hWnd, lptpm);
+}
+
+// ─── Hit-test for secondary taskbar tray clicks ─────────────────────────────
+
+static int PhysicalPixelsToDips(UINT dpi, int pixels) {
+    return MulDiv(pixels, 96, dpi ? dpi : 96);
+}
+
+static int DipsToPhysicalPixels(UINT dpi, double dips) {
+    return MulDiv((int)(dips + 0.5), dpi ? dpi : 96, 96);
+}
+
+static UINT GetWindowDpi(HWND hWnd) {
+    // GetDpiForWindow requires Windows 10 1607+
+    UINT dpi = GetDpiForWindow(hWnd);
+    return dpi ? dpi : 96;
+}
+
+static int HitTestTrayClick(HWND hWnd, LPARAM lParam) {
+    RECT clientRect = {};
+    if (!GetClientRect(hWnd, &clientRect)) return kFlyoutNone;
+
+    int width  = clientRect.right - clientRect.left;
+    int height = clientRect.bottom - clientRect.top;
+
+    // Only handle horizontal taskbars
+    if (width <= height) return kFlyoutNone;
+
+    int x = GET_X_LPARAM(lParam);
+    UINT dpi = GetWindowDpi(hWnd);
+    int xFromRight = clientRect.right - x;
+    int xFromRightDip = PhysicalPixelsToDips(dpi, xFromRight);
+
+    int showDesktopEnd = 0;
+    int notifCenterEnd = 0;
+    int controlCenterEnd = 0;
+    int trayIconsStart = 0;
+    int trayIconsEnd = 0;
+    int overflowStart = 0;
+    int overflowEnd = 0;
+
+    if (g_trayMetrics.valid) {
+        showDesktopEnd = (int)(g_trayMetrics.showDesktopStack + 0.5);
+        notifCenterEnd = showDesktopEnd +
+            (int)(g_trayMetrics.notificationCenterButton + 0.5);
+        controlCenterEnd = notifCenterEnd +
+            (int)(g_trayMetrics.controlCenterButton + 0.5);
+        trayIconsStart = controlCenterEnd +
+            (int)(g_trayMetrics.nonActivatableStack + 0.5) +
+            (int)(g_trayMetrics.mainStack + 0.5);
+        trayIconsEnd = trayIconsStart +
+            (int)(g_trayMetrics.notificationAreaIcons + 0.5);
+        overflowStart = trayIconsEnd;
+        overflowEnd = overflowStart +
+            (int)(g_trayMetrics.notifyIconStack + 0.5);
     } else {
-        Wh_Log(L"[Flyout] Failed to install WinEvent hook: error %d",
-               GetLastError());
+        showDesktopEnd = kShowDesktopWidth;
+        notifCenterEnd = showDesktopEnd + kNotificationCenterWidth;
+        controlCenterEnd = notifCenterEnd + kControlCenterWidth;
+        trayIconsStart = controlCenterEnd;
+        trayIconsEnd = trayIconsStart + 100;
+        overflowStart = trayIconsEnd;
+        overflowEnd = overflowStart + kNotifyIconStackWidth;
+    }
+
+    int slop = kHitSlop;
+
+    // Overflow tray chevron
+    if (xFromRightDip >= overflowStart - slop &&
+        xFromRightDip < overflowEnd + slop) {
+        Wh_Log(L"[HitTest] -> kOverflowTray");
+        return kOverflowTray;
+    }
+
+    // Promoted tray icons
+    if (xFromRightDip >= trayIconsStart - slop &&
+        xFromRightDip < trayIconsEnd + slop) {
+        return kTrayPopup;
+    }
+
+    // Control center (volume/wifi/battery)
+    if (xFromRightDip >= notifCenterEnd - slop &&
+        xFromRightDip < controlCenterEnd + slop) {
+        Wh_Log(L"[HitTest] -> kControlCenter");
+        return kControlCenter;
+    }
+
+    // Notification center (clock/date)
+    if (xFromRightDip >= showDesktopEnd - slop &&
+        xFromRightDip < notifCenterEnd + slop) {
+        Wh_Log(L"[HitTest] -> kNotificationCenter");
+        return kNotificationCenter;
+    }
+
+    Wh_Log(L"[HitTest] -> kFlyoutNone (no zone matched)");
+    return kFlyoutNone;
+}
+
+static bool GetFlyoutAnchorPoint(HWND hWnd, LPARAM lParam, int flyoutKind,
+                                  POINT* anchor) {
+    RECT clientRect = {};
+    if (!GetClientRect(hWnd, &clientRect)) return false;
+
+    LONG clientX = GET_X_LPARAM(lParam);
+    LONG origClientX = clientX;
+    UINT dpi = GetWindowDpi(hWnd);
+
+    if (flyoutKind == kOverflowTray) {
+        // Compute chevron midpoint from metrics
+        double overflowStart = 0;
+        double overflowW = kNotifyIconStackWidth;
+        if (g_trayMetrics.valid) {
+            overflowStart =
+                g_trayMetrics.showDesktopStack +
+                g_trayMetrics.notificationCenterButton +
+                g_trayMetrics.controlCenterButton +
+                g_trayMetrics.nonActivatableStack +
+                g_trayMetrics.mainStack +
+                g_trayMetrics.notificationAreaIcons;
+            overflowW = g_trayMetrics.notifyIconStack;
+        } else {
+            overflowStart =
+                kShowDesktopWidth +
+                kNotificationCenterWidth +
+                kControlCenterWidth;
+        }
+        int overflowMidPx =
+            DipsToPhysicalPixels(dpi, overflowStart + overflowW / 2);
+        clientX = clientRect.right - overflowMidPx;
+        if (clientX < clientRect.left) clientX = clientRect.left;
+        if (clientX >= clientRect.right) clientX = clientRect.right - 1;
+        Wh_Log(L"[Anchor] Overflow chevron: origX=%d computedX=%d "
+               L"overflowStart=%.0f overflowW=%.0f midPx=%d "
+               L"clientRight=%d",
+               origClientX, clientX, overflowStart, overflowW,
+               overflowMidPx, clientRect.right);
+    }
+
+    POINT pt = {clientX, (clientRect.top + clientRect.bottom) / 2};
+    if (!ClientToScreen(hWnd, &pt)) return false;
+
+    Wh_Log(L"[Anchor] kind=%d client=(%d,%d) screen=(%d,%d)",
+           flyoutKind, clientX, (clientRect.top + clientRect.bottom) / 2,
+           pt.x, pt.y);
+
+    *anchor = pt;
+    return true;
+}
+
+// ─── Taskbar subclass ───────────────────────────────────────────────────────
+
+static constexpr UINT_PTR kTaskbarSubclassId = 0x54524159; // 'TRAY'
+
+// Track subclassed windows for cleanup
+static std::vector<HWND> g_subclassedTaskbars;
+
+static LRESULT CALLBACK TaskbarSubclassProc(HWND hWnd, UINT uMsg,
+                                             WPARAM wParam, LPARAM lParam,
+                                             UINT_PTR uIdSubclass,
+                                             DWORD_PTR dwRefData) {
+    if (g_unloading) {
+        if (uMsg == WM_NCDESTROY) {
+            RemoveWindowSubclass(hWnd, TaskbarSubclassProc, kTaskbarSubclassId);
+        }
+        return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+    }
+
+    bool isDown = false;
+    bool isRight = false;
+
+    if (uMsg == WM_LBUTTONDOWN) {
+        isDown = true;
+    } else if (uMsg == WM_RBUTTONDOWN) {
+        isDown = true;
+        isRight = true;
+    } else if (uMsg == WM_PARENTNOTIFY) {
+        WORD event = LOWORD(wParam);
+        if (event == WM_LBUTTONDOWN) {
+            isDown = true;
+        } else if (event == WM_RBUTTONDOWN) {
+            isDown = true;
+            isRight = true;
+        }
+    }
+
+    if (isDown) {
+        int kind = HitTestTrayClick(hWnd, lParam);
+        if (kind != kFlyoutNone) {
+            if (isRight && kind != kOverflowTray) {
+                kind = kTrayPopup;
+            }
+            POINT anchor = {};
+            GetFlyoutAnchorPoint(hWnd, lParam, kind, &anchor);
+            ArmFlyoutContext(hWnd, kind, anchor);
+        } else {
+            ClearFlyoutContext();
+        }
+    }
+
+    if (uMsg == WM_NCDESTROY) {
+        RemoveWindowSubclass(hWnd, TaskbarSubclassProc, kTaskbarSubclassId);
+        auto it = std::find(g_subclassedTaskbars.begin(),
+                            g_subclassedTaskbars.end(), hWnd);
+        if (it != g_subclassedTaskbars.end())
+            g_subclassedTaskbars.erase(it);
+    }
+
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+static void InstallTaskbarSubclass(HWND hWnd) {
+    if (SetWindowSubclass(hWnd, TaskbarSubclassProc, kTaskbarSubclassId, 0)) {
+        g_subclassedTaskbars.push_back(hWnd);
+        RECT winRect = {};
+        GetWindowRect(hWnd, &winRect);
+        RECT clientRect = {};
+        GetClientRect(hWnd, &clientRect);
+        UINT dpi = GetWindowDpi(hWnd);
+        HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+        Wh_Log(L"[Subclass] Installed on hwnd=%p mon=%p dpi=%u "
+               L"winRect=(%d,%d,%d,%d) clientSize=(%dx%d)",
+               hWnd, hMon, dpi,
+               winRect.left, winRect.top, winRect.right, winRect.bottom,
+               clientRect.right - clientRect.left,
+               clientRect.bottom - clientRect.top);
+    } else {
+        Wh_Log(L"[Subclass] Failed for hwnd=%p error=%d",
+               hWnd, GetLastError());
     }
 }
 
-static void UninstallFlyoutHook() {
-    if (g_winEventHook) {
-        UnhookWinEvent(g_winEventHook);
-        g_winEventHook = nullptr;
-        g_trackedCount = 0;
-        Wh_Log(L"[Flyout] WinEvent hook removed");
+static void RemoveAllTaskbarSubclasses() {
+    for (HWND hwnd : g_subclassedTaskbars) {
+        if (IsWindow(hwnd)) {
+            RemoveWindowSubclass(hwnd, TaskbarSubclassProc, kTaskbarSubclassId);
+        }
+    }
+    g_subclassedTaskbars.clear();
+}
+
+// Install subclasses on all Shell_SecondaryTrayWnd windows
+static void InstallFlyoutHooks() {
+    HWND tbWnd = nullptr;
+    while ((tbWnd = FindWindowEx(nullptr, tbWnd,
+                                  L"Shell_SecondaryTrayWnd",
+                                  nullptr)) != nullptr) {
+        // Check if already subclassed
+        bool alreadySubclassed = false;
+        for (HWND existing : g_subclassedTaskbars) {
+            if (existing == tbWnd) {
+                alreadySubclassed = true;
+                break;
+            }
+        }
+        if (!alreadySubclassed) {
+            InstallTaskbarSubclass(tbWnd);
+        }
     }
 }
 
@@ -667,6 +1466,8 @@ void HandleExtractedFrame(FrameworkElement frame, bool isSecondary,
         }
     } else {
         g_primarySystemTrayFrame = frame;
+        g_xamlDispatcher = frame.Dispatcher();
+        UpdateTrayMetricsFromFrame(frame, L"primary-extracted");
         if (!g_primaryTreeDumped) {
             g_primaryTreeDumped = true;
             Wh_Log(L"=== PRIMARY TASKBAR XAML TREE (via controller scan) ===");
@@ -742,6 +1543,80 @@ static const wchar_t* g_stackContainers[] = {
     L"ShowDesktopStack",
 };
 
+static void SyncTrayState(SecondaryInfo& si) {
+    auto primaryGrid = FindChildByName(g_primarySystemTrayFrame, L"SystemTrayFrameGrid");
+    auto secondaryGrid = FindChildByName(si.frame, L"SystemTrayFrameGrid");
+    if (!primaryGrid || !secondaryGrid) return;
+
+    for (auto containerName : g_syncedContainers) {
+        auto primaryContainer = FindChildByName(primaryGrid, containerName);
+        auto secondaryContainer = FindChildByName(secondaryGrid, containerName);
+        if (!primaryContainer || !secondaryContainer) continue;
+
+        auto primaryVis = primaryContainer.Visibility();
+        auto secondaryVis = secondaryContainer.Visibility();
+        if (primaryVis == Visibility::Visible && secondaryVis == Visibility::Collapsed) {
+            secondaryContainer.Visibility(Visibility::Visible);
+            si.containersUncollapsed = true;
+        } else if (primaryVis == Visibility::Collapsed && secondaryVis == Visibility::Visible) {
+            secondaryContainer.Visibility(Visibility::Collapsed);
+            si.containersUncollapsed = true;
+        }
+    }
+
+    auto primaryNAI = FindChildByName(primaryGrid, L"NotificationAreaIcons");
+    auto secondaryNAI = FindChildByName(secondaryGrid, L"NotificationAreaIcons");
+    if (primaryNAI && secondaryNAI) {
+        auto primaryIC = primaryNAI.try_as<Controls::ItemsControl>();
+        auto secondaryIC = secondaryNAI.try_as<Controls::ItemsControl>();
+        if (primaryIC && secondaryIC) {
+            auto pSource = primaryIC.ItemsSource();
+            if (pSource && secondaryIC.ItemsSource() != pSource) {
+                try { secondaryIC.ItemsSource(pSource); } catch (...) {}
+            }
+        }
+    }
+
+    const wchar_t* icContainers[] = {
+        L"ControlCenterButton",
+        L"NotificationCenterButton",
+    };
+    for (auto name : icContainers) {
+        auto primaryC = FindChildByName(primaryGrid, name);
+        auto secondaryC = FindChildByName(secondaryGrid, name);
+        if (!primaryC || !secondaryC) continue;
+        auto pIC = primaryC.try_as<Controls::ItemsControl>();
+        auto sIC = secondaryC.try_as<Controls::ItemsControl>();
+        if (pIC && sIC) {
+            auto pSource = pIC.ItemsSource();
+            if (pSource && sIC.ItemsSource() != pSource) {
+                try { sIC.ItemsSource(pSource); } catch (...) {}
+            }
+        }
+    }
+
+    for (auto stackName : g_stackContainers) {
+        auto primaryStack = FindChildByName(primaryGrid, stackName);
+        auto secondaryStack = FindChildByName(secondaryGrid, stackName);
+        if (!primaryStack || !secondaryStack) continue;
+        auto primaryContent = FindChildByName(primaryStack, L"Content");
+        auto secondaryContent = FindChildByName(secondaryStack, L"Content");
+        if (!primaryContent || !secondaryContent) continue;
+        auto primaryIconStack = FindChildByName(primaryContent, L"IconStack");
+        auto secondaryIconStack = FindChildByName(secondaryContent, L"IconStack");
+        if (!primaryIconStack || !secondaryIconStack) continue;
+
+        auto pIC = primaryIconStack.try_as<Controls::ItemsControl>();
+        auto sIC = secondaryIconStack.try_as<Controls::ItemsControl>();
+        if (pIC && sIC) {
+            auto pSource = pIC.ItemsSource();
+            if (pSource && sIC.ItemsSource() != pSource) {
+                try { sIC.ItemsSource(pSource); } catch (...) {}
+            }
+        }
+    }
+}
+
 void TryPopulateOneSecondary(SecondaryInfo& si);
 
 void TryPopulateSecondaryTray() {
@@ -777,9 +1652,12 @@ void TryPopulateSecondaryTray() {
                     Wh_Log(L"[PrimarySizeChanged] %.0f -> %.0f",
                            oldWidth, newWidth);
                     g_lastPrimaryFrameSize = newWidth;
+                    UpdateTrayMetricsFromFrame(g_primarySystemTrayFrame,
+                                               L"primary-size");
 
                     for (auto& si : g_secondaries) {
                         if (!si.populated || !si.frame) continue;
+                        SyncTrayState(si);
                         try {
                             double secWidth = si.frame.Width();
                             if (secWidth != newWidth) {
@@ -804,9 +1682,9 @@ void TryPopulateSecondaryTray() {
         Wh_Log(L"[SizeChanged] Registered on primary frame");
     }
 
-    // Install flyout repositioning hook once any secondary is populated
+    // Install taskbar subclasses for flyout redirection
     if (anyPopulated) {
-        InstallFlyoutHook();
+        InstallFlyoutHooks();
     }
 }
 
@@ -830,164 +1708,7 @@ void TryPopulateOneSecondary(SecondaryInfo& si) {
     Wh_Log(L"Frame widths - primary:%.0f secondary:%.0f",
            primaryFrameWidth, secondaryFrameWidth);
 
-    // Step 1: Sync visibility of containers
-    for (auto containerName : g_syncedContainers) {
-        auto primaryContainer = FindChildByName(primaryGrid, containerName);
-        auto secondaryContainer = FindChildByName(secondaryGrid, containerName);
-
-        if (!primaryContainer || !secondaryContainer) {
-            Wh_Log(L"[%s] Missing on one side", containerName);
-            continue;
-        }
-
-        auto primaryVis = primaryContainer.Visibility();
-        auto secondaryVis = secondaryContainer.Visibility();
-        double primaryW = primaryContainer.ActualWidth();
-        double secondaryW = secondaryContainer.ActualWidth();
-
-        Wh_Log(L"[%s] primary: %.0fx%.0f %s | secondary: %.0fx%.0f %s",
-               containerName,
-               primaryW, primaryContainer.ActualHeight(),
-               primaryVis == Visibility::Collapsed ? L"COLLAPSED" : L"Visible",
-               secondaryW, secondaryContainer.ActualHeight(),
-               secondaryVis == Visibility::Collapsed ? L"COLLAPSED" : L"Visible");
-
-        if (primaryVis == Visibility::Visible &&
-            secondaryVis == Visibility::Collapsed) {
-            Wh_Log(L"[%s] Uncollapsing secondary container", containerName);
-            secondaryContainer.Visibility(Visibility::Visible);
-            si.containersUncollapsed = true;
-        } else if (primaryVis == Visibility::Collapsed &&
-                   secondaryVis == Visibility::Visible) {
-            Wh_Log(L"[%s] Collapsing secondary to match primary", containerName);
-            secondaryContainer.Visibility(Visibility::Collapsed);
-            si.containersUncollapsed = true;
-        }
-
-        if (secondaryVis == Visibility::Visible && secondaryW < 5 &&
-            primaryW > 5) {
-            Wh_Log(L"[%s] Secondary is visible but very narrow (%.0f vs %.0f)",
-                   containerName, secondaryW, primaryW);
-        }
-    }
-
-    // Step 2: Share NotificationAreaIcons ItemsSource
-    auto primaryNAI = FindChildByName(primaryGrid, L"NotificationAreaIcons");
-    auto secondaryNAI = FindChildByName(secondaryGrid, L"NotificationAreaIcons");
-
-    if (primaryNAI && secondaryNAI) {
-        auto primaryIC = primaryNAI.try_as<Controls::ItemsControl>();
-        auto secondaryIC = secondaryNAI.try_as<Controls::ItemsControl>();
-
-        if (primaryIC && secondaryIC) {
-            int pCount = (int)primaryIC.Items().Size();
-            int sCount = (int)secondaryIC.Items().Size();
-            auto pSource = primaryIC.ItemsSource();
-
-            Wh_Log(L"[NotificationAreaIcons] primary:%d secondary:%d "
-                   L"primarySource:%s",
-                   pCount, sCount, pSource ? L"YES" : L"NO");
-
-            if (pSource && sCount == 0 && pCount > 0) {
-                try {
-                    secondaryIC.ItemsSource(pSource);
-                    int newCount = (int)secondaryIC.Items().Size();
-                    Wh_Log(L"[NotificationAreaIcons] ItemsSource shared! "
-                           L"Secondary now has %d items",
-                           newCount);
-                } catch (winrt::hresult_error const& ex) {
-                    Wh_Log(L"[NotificationAreaIcons] Share failed: 0x%08X %s",
-                           (unsigned)ex.code(), ex.message().c_str());
-                }
-            }
-
-            if (secondaryNAI.Visibility() == Visibility::Collapsed &&
-                primaryNAI.Visibility() == Visibility::Visible) {
-                secondaryNAI.Visibility(Visibility::Visible);
-                Wh_Log(L"[NotificationAreaIcons] Uncollapsed secondary");
-            }
-        }
-    } else {
-        Wh_Log(L"[NotificationAreaIcons] Not found (primary:%s secondary:%s)",
-               primaryNAI ? L"found" : L"MISSING",
-               secondaryNAI ? L"found" : L"MISSING");
-    }
-
-    // Step 3: Share ItemsSource for ControlCenterButton and NotificationCenterButton
-    const wchar_t* icContainers[] = {
-        L"ControlCenterButton",
-        L"NotificationCenterButton",
-    };
-    for (auto name : icContainers) {
-        auto primaryC = FindChildByName(primaryGrid, name);
-        auto secondaryC = FindChildByName(secondaryGrid, name);
-        if (!primaryC || !secondaryC) continue;
-
-        auto pIC = primaryC.try_as<Controls::ItemsControl>();
-        auto sIC = secondaryC.try_as<Controls::ItemsControl>();
-        if (!pIC || !sIC) continue;
-
-        int pCount = (int)pIC.Items().Size();
-        int sCount = (int)sIC.Items().Size();
-        auto pSource = pIC.ItemsSource();
-
-        if (pSource && sCount == 0 && pCount > 0) {
-            try {
-                sIC.ItemsSource(pSource);
-                Wh_Log(L"[%s] ItemsSource shared! Secondary now has %d items",
-                       name, (int)sIC.Items().Size());
-            } catch (winrt::hresult_error const& ex) {
-                Wh_Log(L"[%s] ItemsSource share failed: 0x%08X",
-                       name, (unsigned)ex.code());
-            }
-        }
-    }
-
-    // Step 3b: Share StackListView ItemsSource for Stack containers
-    for (auto stackName : g_stackContainers) {
-        auto primaryStack = FindChildByName(primaryGrid, stackName);
-        auto secondaryStack = FindChildByName(secondaryGrid, stackName);
-        if (!primaryStack || !secondaryStack) continue;
-
-        auto primaryContent = FindChildByName(primaryStack, L"Content");
-        auto secondaryContent = FindChildByName(secondaryStack, L"Content");
-        if (!primaryContent || !secondaryContent) continue;
-
-        auto primaryIconStack = FindChildByName(primaryContent, L"IconStack");
-        auto secondaryIconStack = FindChildByName(secondaryContent, L"IconStack");
-        if (!primaryIconStack || !secondaryIconStack) continue;
-
-        auto pIC = primaryIconStack.try_as<Controls::ItemsControl>();
-        auto sIC = secondaryIconStack.try_as<Controls::ItemsControl>();
-
-        Wh_Log(L"[%s/IconStack] primary IC:%s secondary IC:%s",
-               stackName,
-               pIC ? L"YES" : L"NO",
-               sIC ? L"YES" : L"NO");
-
-        if (pIC && sIC) {
-            int pCount = (int)pIC.Items().Size();
-            int sCount = (int)sIC.Items().Size();
-            auto pSource = pIC.ItemsSource();
-
-            Wh_Log(L"[%s/IconStack] primary:%d secondary:%d source:%s",
-                   stackName, pCount, sCount, pSource ? L"YES" : L"NO");
-
-            if (pSource && sCount == 0 && pCount > 0) {
-                try {
-                    sIC.ItemsSource(pSource);
-                    int newCount = (int)sIC.Items().Size();
-                    Wh_Log(L"[%s/IconStack] ItemsSource shared! "
-                           L"Secondary now has %d items",
-                           stackName, newCount);
-                } catch (winrt::hresult_error const& ex) {
-                    Wh_Log(L"[%s/IconStack] Share failed: 0x%08X %s",
-                           stackName, (unsigned)ex.code(),
-                           ex.message().c_str());
-                }
-            }
-        }
-    }
+    SyncTrayState(si);
 
     // Step 4: Set the secondary frame width to match primary
     if (primaryFrameWidth > secondaryFrameWidth) {
@@ -1078,6 +1799,8 @@ void HandleLoadedIconView(FrameworkElement iconView) {
         if (!g_primaryTreeDumped) {
             g_primaryTreeDumped = true;
             g_primarySystemTrayFrame = systemTrayFrame;
+            g_xamlDispatcher = systemTrayFrame.Dispatcher();
+            UpdateTrayMetricsFromFrame(systemTrayFrame, L"primary-loaded");
             Wh_Log(L"=== PRIMARY TASKBAR XAML TREE ===");
             DumpXamlTree(systemTrayFrame, 0, 8);
             ProbeContainerInterfaces(systemTrayFrame, L"PRIMARY");
@@ -1103,10 +1826,13 @@ static void ResetXamlState() {
         g_primarySizeChangedToken = {};
     }
 
-    UninstallFlyoutHook();
+    RemoveAllTaskbarSubclasses();
+    ClearFlyoutContext();
     g_autoRevokerList.clear();
 
     g_primarySystemTrayFrame = nullptr;
+    g_xamlDispatcher = nullptr;
+    g_trayMetrics = {};
     g_primaryTreeDumped = false;
     g_primaryFrameSearchDone = false;
     g_lastPrimaryFrameSize = 0;
@@ -1200,22 +1926,13 @@ void WINAPI SystemTraySecondaryController_UpdateFrameSize_Hook(void* pThis) {
         }
     }
 
-    // Re-apply width override after the original sets it to native value.
-    // Re-read the primary frame's actual width rather than using the cached
-    // g_lastPrimaryFrameSize, because during DPI changes the cache may be
-    // stale (still holding the old-DPI value).
+    // Schedule a deferred refresh rather than immediately re-applying width.
+    // During DPI changes, the primary frame hasn't re-laid-out yet when this
+    // hook fires, so ActualWidth() returns the old-DPI value. A deferred
+    // refresh lets layout settle before reading the correct width.
     if (si->populated && si->frame &&
         g_primarySystemTrayFrame && !g_unloading) {
-        try {
-            double primaryWidth = g_primarySystemTrayFrame.ActualWidth();
-            if (primaryWidth > 0) {
-                g_lastPrimaryFrameSize = primaryWidth;
-                double currentWidth = si->frame.Width();
-                if (currentWidth != primaryWidth) {
-                    si->frame.Width(primaryWidth);
-                }
-            }
-        } catch (...) {}
+        RefreshSecondaryTray();
     }
 }
 
@@ -1235,9 +1952,18 @@ double WINAPI SystemTraySecondaryController_GetFrameSize_Hook(void* pThis, int e
 
     // Check if this controller's secondary has been populated
     for (auto& si : g_secondaries) {
-        if (si.controller == pThis && si.populated &&
-            g_lastPrimaryFrameSize > originalSize) {
-            return g_lastPrimaryFrameSize;
+        if (si.controller == pThis && si.populated) {
+            // Read live primary width to avoid returning stale DPI values
+            double primaryWidth = g_lastPrimaryFrameSize;
+            if (g_primarySystemTrayFrame) {
+                try {
+                    double live = g_primarySystemTrayFrame.ActualWidth();
+                    if (live > 0) primaryWidth = live;
+                } catch (...) {}
+            }
+            if (primaryWidth > originalSize) {
+                return primaryWidth;
+            }
         }
     }
 
@@ -1413,24 +2139,121 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
 BOOL Wh_ModInit() {
     Wh_Log(L">");
 
-    HMODULE systemTrayModule = GetSystemTrayModuleHandle();
-    if (systemTrayModule) {
-        Wh_Log(L"SystemTray module already loaded");
-        if (!HookSystemTraySymbols(systemTrayModule)) {
-            Wh_Log(L"Failed to hook SystemTray symbols");
-            return FALSE;
-        }
-    } else {
-        Wh_Log(L"SystemTray module not loaded yet, hooking LoadLibraryExW");
+    wchar_t modulePath[MAX_PATH];
+    GetModuleFileName(nullptr, modulePath, ARRAYSIZE(modulePath));
+    PCWSTR fileName = wcsrchr(modulePath, L'\\');
+    fileName = fileName ? fileName + 1 : modulePath;
 
-        HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
-        auto pKernelBaseLoadLibraryExW =
-            (decltype(&LoadLibraryExW))GetProcAddress(kernelBaseModule,
-                                                      "LoadLibraryExW");
-        WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
-                                       LoadLibraryExW_Hook,
-                                       &LoadLibraryExW_Original);
+    bool isExplorer = _wcsicmp(fileName, L"explorer.exe") == 0;
+
+    if (isExplorer) {
+        HMODULE systemTrayModule = GetSystemTrayModuleHandle();
+        if (systemTrayModule) {
+            Wh_Log(L"SystemTray module already loaded");
+            if (!HookSystemTraySymbols(systemTrayModule)) {
+                Wh_Log(L"Failed to hook SystemTray symbols");
+                return FALSE;
+            }
+        } else {
+            Wh_Log(L"SystemTray module not loaded yet, hooking LoadLibraryExW");
+    
+            HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
+            auto pKernelBaseLoadLibraryExW =
+                (decltype(&LoadLibraryExW))GetProcAddress(kernelBaseModule,
+                                                          "LoadLibraryExW");
+            WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
+                                           LoadLibraryExW_Hook,
+                                           &LoadLibraryExW_Original);
+        }
     }
+
+    // Hook Win32 APIs for proactive flyout repositioning in ALL included processes (explorer.exe and ShellHost.exe).
+    HMODULE user32 = GetModuleHandle(L"user32.dll");
+    if (user32) {
+        auto pMonitorFromPoint = (decltype(&MonitorFromPoint))
+            GetProcAddress(user32, "MonitorFromPoint");
+        auto pMonitorFromRect = (decltype(&MonitorFromRect))
+            GetProcAddress(user32, "MonitorFromRect");
+        auto pMonitorFromWindow = (decltype(&MonitorFromWindow))
+            GetProcAddress(user32, "MonitorFromWindow");
+        auto pSetWindowPos = (decltype(&SetWindowPos))
+            GetProcAddress(user32, "SetWindowPos");
+        auto pMoveWindow = (decltype(&MoveWindow))
+            GetProcAddress(user32, "MoveWindow");
+        auto pDeferWindowPos = (decltype(&DeferWindowPos))
+            GetProcAddress(user32, "DeferWindowPos");
+        auto pTrackPopupMenuEx = (decltype(&TrackPopupMenuEx))
+            GetProcAddress(user32, "TrackPopupMenuEx");
+
+        if (pMonitorFromPoint)
+            WindhawkUtils::SetFunctionHook(pMonitorFromPoint,
+                                           MonitorFromPoint_Hook,
+                                           &MonitorFromPoint_Original);
+        if (pMonitorFromRect)
+            WindhawkUtils::SetFunctionHook(pMonitorFromRect,
+                                           MonitorFromRect_Hook,
+                                           &MonitorFromRect_Original);
+        if (pMonitorFromWindow)
+            WindhawkUtils::SetFunctionHook(pMonitorFromWindow,
+                                           MonitorFromWindow_Hook,
+                                           &MonitorFromWindow_Original);
+        if (pSetWindowPos)
+            WindhawkUtils::SetFunctionHook(pSetWindowPos,
+                                           SetWindowPos_Hook,
+                                           &SetWindowPos_Original);
+        if (pMoveWindow)
+            WindhawkUtils::SetFunctionHook(pMoveWindow,
+                                           MoveWindow_Hook,
+                                           &MoveWindow_Original);
+        if (pDeferWindowPos)
+            WindhawkUtils::SetFunctionHook(pDeferWindowPos,
+                                           DeferWindowPos_Hook,
+                                           &DeferWindowPos_Original);
+        if (pTrackPopupMenuEx)
+            WindhawkUtils::SetFunctionHook(pTrackPopupMenuEx,
+                                           TrackPopupMenuEx_Hook,
+                                           &TrackPopupMenuEx_Original);
+
+        Wh_Log(L"Win32 flyout hooks: MFP=%p MFR=%p MFW=%p SWP=%p MW=%p DWP=%p TPM=%p",
+               MonitorFromPoint_Original, MonitorFromRect_Original,
+               MonitorFromWindow_Original, SetWindowPos_Original,
+               MoveWindow_Original, DeferWindowPos_Original,
+               TrackPopupMenuEx_Original);
+    }
+
+    // Log taskbar auto-hide state
+    {
+        APPBARDATA abd = {sizeof(abd)};
+        UINT state = (UINT)SHAppBarMessage(ABM_GETSTATE, &abd);
+        Wh_Log(L"[Taskbar] auto-hide=%s always-on-top=%s",
+               (state & ABS_AUTOHIDE) ? L"YES" : L"NO",
+               (state & ABS_ALWAYSONTOP) ? L"YES" : L"NO");
+    }
+
+    // Log all monitor geometries for diagnostics
+    Wh_Log(L"[MonitorEnum] Enumerating all displays:");
+    EnumDisplayMonitors(nullptr, nullptr,
+        [](HMONITOR hMon, HDC, LPRECT, LPARAM) -> BOOL {
+            MONITORINFOEX mi = {};
+            mi.cbSize = sizeof(mi);
+            if (GetMonitorInfo(hMon, &mi)) {
+                UINT dpiX = 96, dpiY = 96;
+                GetDpiForMonitor(hMon, MDT_EFFECTIVE_DPI, &dpiX, &dpiY);
+                int scale = MulDiv(dpiX, 100, 96);
+                Wh_Log(L"[MonitorEnum] hMon=%p \"%s\"%s "
+                       L"full=(%d,%d,%d,%d) work=(%d,%d,%d,%d) "
+                       L"dpi=%u scale=%d%%",
+                       hMon, mi.szDevice,
+                       (mi.dwFlags & MONITORINFOF_PRIMARY)
+                           ? L" [PRIMARY]" : L"",
+                       mi.rcMonitor.left, mi.rcMonitor.top,
+                       mi.rcMonitor.right, mi.rcMonitor.bottom,
+                       mi.rcWork.left, mi.rcWork.top,
+                       mi.rcWork.right, mi.rcWork.bottom,
+                       dpiX, scale);
+            }
+            return TRUE;
+        }, 0);
 
     return TRUE;
 }
@@ -1462,8 +2285,9 @@ void Wh_ModBeforeUninit() {
     // Remove display change listener
     UninstallDisplayChangeListener();
 
-    // Remove flyout repositioning hook
-    UninstallFlyoutHook();
+    // Remove flyout subclasses and clear context
+    RemoveAllTaskbarSubclasses();
+    ClearFlyoutContext();
 
     // Remove SizeChanged listener from primary frame
     if (g_primarySystemTrayFrame && g_primarySizeChangedToken.value) {
@@ -1507,6 +2331,8 @@ void Wh_ModBeforeUninit() {
 
     // Release XAML references
     g_primarySystemTrayFrame = nullptr;
+    g_xamlDispatcher = nullptr;
+    g_trayMetrics = {};
     for (auto& si : g_secondaries) {
         si.frame = nullptr;
     }
@@ -1558,15 +2384,47 @@ static void RefreshSecondaryTrayImpl() {
     }
 }
 
-// Timer ID for deferred refresh after DPI/display changes
+static void RefreshSecondaryTrayOnXamlThread() {
+    if (g_unloading) return;
+
+    try {
+        if (g_xamlDispatcher) {
+            if (g_xamlDispatcher.HasThreadAccess()) {
+                RefreshSecondaryTrayImpl();
+            } else {
+                g_xamlDispatcher.TryRunAsync(
+                    winrt::Windows::UI::Core::CoreDispatcherPriority::Normal,
+                    winrt::Windows::UI::Core::DispatchedHandler([]() {
+                        RefreshSecondaryTrayImpl();
+                    }));
+            }
+            return;
+        }
+    } catch (winrt::hresult_error const& ex) {
+        Wh_Log(L"[Refresh] Dispatcher marshal failed: 0x%08X %s",
+               (unsigned)ex.code(), ex.message().c_str());
+    } catch (...) {
+        Wh_Log(L"[Refresh] Dispatcher marshal failed (unknown exception)");
+    }
+
+    RefreshSecondaryTrayImpl();
+}
+
+// Timer IDs for deferred refresh after DPI/display changes
 static UINT_PTR g_refreshTimerId = 0;
+static UINT_PTR g_refreshTimerId2 = 0;
 
 static void CALLBACK RefreshTimerProc(HWND hwnd, UINT msg, UINT_PTR id,
                                        DWORD time) {
     KillTimer(hwnd, id);
-    g_refreshTimerId = 0;
-    Wh_Log(L"[Refresh] Deferred refresh firing");
-    RefreshSecondaryTrayImpl();
+    if (id == 1) {
+        g_refreshTimerId = 0;
+        Wh_Log(L"[Refresh] Deferred refresh firing (pass 1)");
+    } else {
+        g_refreshTimerId2 = 0;
+        Wh_Log(L"[Refresh] Deferred refresh firing (pass 2)");
+    }
+    RefreshSecondaryTrayOnXamlThread();
 }
 
 static void RefreshSecondaryTray() {
@@ -1574,16 +2432,22 @@ static void RefreshSecondaryTray() {
 
     // During DPI/display changes the primary frame hasn't re-laid-out yet
     // when the notification arrives. Defer the refresh so ActualWidth()
-    // returns the new DPI-scaled value.
+    // returns the new DPI-scaled value. A second pass at 1000ms catches
+    // cases where layout settles late (e.g. complex DPI transitions).
     if (g_displayChangeWindow) {
         if (g_refreshTimerId) {
             KillTimer(g_displayChangeWindow, g_refreshTimerId);
         }
-        g_refreshTimerId = SetTimer(g_displayChangeWindow, 1, 250,
+        g_refreshTimerId = SetTimer(g_displayChangeWindow, 1, 350,
                                      RefreshTimerProc);
-        Wh_Log(L"[Refresh] Deferred refresh scheduled (250ms)");
+
+        if (g_refreshTimerId2) {
+            KillTimer(g_displayChangeWindow, g_refreshTimerId2);
+        }
+        g_refreshTimerId2 = SetTimer(g_displayChangeWindow, 2, 1000,
+                                      RefreshTimerProc);
     } else {
-        RefreshSecondaryTrayImpl();
+        RefreshSecondaryTrayOnXamlThread();
     }
 }
 
@@ -1650,9 +2514,12 @@ static void UninstallDisplayChangeListener() {
             KillTimer(g_displayChangeWindow, g_refreshTimerId);
             g_refreshTimerId = 0;
         }
+        if (g_refreshTimerId2) {
+            KillTimer(g_displayChangeWindow, g_refreshTimerId2);
+            g_refreshTimerId2 = 0;
+        }
         DestroyWindow(g_displayChangeWindow);
         g_displayChangeWindow = nullptr;
     }
     UnregisterClass(g_displayChangeClassName, GetModuleHandle(nullptr));
 }
-

--- a/mods/taskbar-tray-on-all-monitors.wh.cpp
+++ b/mods/taskbar-tray-on-all-monitors.wh.cpp
@@ -1242,6 +1242,7 @@ void* WINAPI IconView_IconView_Hook(void* pThis) {
 // ─── module hooking ─────────────────────────────────────────────────────────
 
 bool HookSystemTraySymbols(HMODULE module) {
+    // SystemTray.dll, Taskbar.View.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         // Primary controller
         {


### PR DESCRIPTION
Mirrors the system tray from the primary taskbar onto all secondary monitor taskbars on Windows 11 (build 26200+).

Features:
- All system tray icons on secondary taskbars (clock, volume, network, battery, notification area icons, input indicator, overflow chevron, Show Desktop button)
- Native click, hover, and right-click context menu behavior
- Dynamic width syncing when icons are added or removed
- Flyout repositioning to the correct monitor
- Auto-refresh on display resolution, scale, or DPI changes

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
