### PR TITLE
Common Controls Hook v1.0.1

### DIFF
--- a/mods/common-controls-hook.wh.cpp
+++ b/mods/common-controls-hook.wh.cpp
@@ -2,7 +2,7 @@
 // @id              common-controls-hook
 // @name            Common Controls Hook
 // @description     Force-enable Common Controls v6 visual styles for legacy Win32 applications
-// @version         1.0
+// @version         1.0.1
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -58,12 +58,16 @@ bool InitActCtx() {
 }
 
 class ActCtxGuard {
-    ULONG_PTR cookie;
-    BOOL activated;
+    ULONG_PTR cookie = 0;
+    BOOL activated = FALSE;
+
+    ActCtxGuard(const ActCtxGuard&) = delete;
+    ActCtxGuard& operator=(const ActCtxGuard&) = delete;
+    ActCtxGuard(ActCtxGuard&&) = delete;
+    ActCtxGuard& operator=(ActCtxGuard&&) = delete;
 
    public:
     ActCtxGuard() {
-        activated = FALSE;
         if (g_hActCtx != INVALID_HANDLE_VALUE) {
             activated = ActivateActCtx(g_hActCtx, &cookie);
         }
@@ -85,12 +89,32 @@ class ActCtxGuard {
 
 // clang-format off
 
-DEFINE_HOOK(HWND, CreateWindowExW, 
-    (DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam),
-    (dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam))
-DEFINE_HOOK(HWND, CreateWindowExA, 
-    (DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam),
-    (dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam))
+// CreateWindowEx is not defined through DEFINE_HOOK because the activation
+// context is only applied to top-level windows. Child windows inherit their
+// parent's activation context, so activating ours for them is unnecessary, and
+// it also avoids churning the activation stack for the many child controls a
+// window creates.
+typedef HWND(WINAPI* CreateWindowExW_t)(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam);
+CreateWindowExW_t CreateWindowExW_orig;
+HWND WINAPI CreateWindowExW_hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam) {
+    if (dwStyle & WS_CHILD) {
+        return CreateWindowExW_orig(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+    }
+
+    ActCtxGuard guard;
+    return CreateWindowExW_orig(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+}
+
+typedef HWND(WINAPI* CreateWindowExA_t)(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam);
+CreateWindowExA_t CreateWindowExA_orig;
+HWND WINAPI CreateWindowExA_hook(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam) {
+    if (dwStyle & WS_CHILD) {
+        return CreateWindowExA_orig(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+    }
+
+    ActCtxGuard guard;
+    return CreateWindowExA_orig(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+}
 
 DEFINE_HOOK(INT_PTR, DialogBoxParamW, 
     (HINSTANCE hInstance, LPCWSTR lpTemplateName, HWND hWndParent, DLGPROC lpDialogFunc, LPARAM dwInitParam),
@@ -159,12 +183,15 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
-#define INSTALL_HOOK(name)                                                   \
-    do {                                                                     \
-        auto addr = (name##_t)GetProcAddress(hUser32, #name);                \
-        if (addr) {                                                          \
-            WindhawkUtils::SetFunctionHook(addr, name##_hook, &name##_orig); \
-        }                                                                    \
+#define INSTALL_HOOK(name)                                         \
+    do {                                                           \
+        auto addr = (name##_t)GetProcAddress(hUser32, #name);      \
+        if (addr) {                                                \
+            if (!WindhawkUtils::SetFunctionHook(addr, name##_hook, \
+                                                &name##_orig)) {   \
+                Wh_Log(L"Failed to set hook for " TEXT(#name));    \
+            }                                                      \
+        }                                                          \
     } while (0)
 
     INSTALL_HOOK(CreateWindowExW);
@@ -185,6 +212,8 @@ BOOL Wh_ModInit() {
     INSTALL_HOOK(MessageBoxIndirectA);
     INSTALL_HOOK(MessageBoxTimeoutW);
     INSTALL_HOOK(MessageBoxTimeoutA);
+
+#undef INSTALL_HOOK
 
     return TRUE;
 }


### PR DESCRIPTION
* Only apply the common controls to windows, not to controls such as buttons. Improves stability, and fixes a crash in Device Manager.