### PR TITLE
Windows 7 File Open/Save Toggle Bar Icon

### DIFF
--- a/mods/win7-file-open-save-toggle-bar-icon.wh.cpp
+++ b/mods/win7-file-open-save-toggle-bar-icon.wh.cpp
@@ -7,8 +7,8 @@
 // @github          https://github.com/Leymonaide
 // @twitter         https://twitter.com/Leym0naide
 // @homepage        https://leymonaide.github.io/
-// @include         notepad.exe
-// @compilerOptions -lcomdlg32 -lgdi32 -lntdll
+// @include         *
+// @compilerOptions -lgdi32
 // @license         MIT
 // ==/WindhawkMod==
 
@@ -89,6 +89,14 @@ void SHLogicalToPhysicalDPI(int *px, int *py)
 thread_local void *g_pCurrentToggleBar = nullptr;
 thread_local HWND g_hwndCurrentToggleBar = nullptr;
 
+// Worth keeping in mind:
+// "Capture relies on the toggle bar being created via CreateWindowExW. If a
+// future build (or a differently-behaving app, once the scope broadens) creates
+// the toolbar through a path your hook doesn't see, the handle stays null and
+// ScaleAndSet… quietly logs 'hwndToggleBar is null' and does nothing — graceful,
+// but the feature silently won't apply. The analogous mod hooks CreateToolbarEx
+// for the same purpose; worth keeping in mind if you broaden @include."
+// https://github.com/ramensoftware/windhawk-mods/pull/4447#issuecomment-4765563181
 using CreateWindowExW_t = decltype(&CreateWindowExW);
 CreateWindowExW_t CreateWindowExW_orig;
 HWND WINAPI CreateWindowExW_hook(DWORD dwExStyle,
@@ -216,12 +224,8 @@ BOOL Wh_ModInit()
 
     LoadSettings();
 
-    RTL_OSVERSIONINFOW osvi;
-    RtlGetVersion(&osvi);
-
-    HMODULE hUser32 = LoadLibraryExW(L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-    pfnGetDpiForWindow = (decltype(pfnGetDpiForWindow))GetProcAddress(hUser32, "GetDpiForWindow");
-    FreeLibrary(hUser32);
+    pfnGetDpiForWindow = (decltype(pfnGetDpiForWindow))GetProcAddress(
+        GetModuleHandleW(L"user32.dll"), "GetDpiForWindow");
 
     if (!Wh_SetFunctionHook(
         (void *)CreateWindowExW,
@@ -256,6 +260,18 @@ BOOL Wh_ModInit()
     g_hbmArrowUp = LoadBitmapW(g_hmodComdlg32_7, (LPCWSTR)0x242);
     Wh_Log(L"hbmArrow up: %p", g_hbmArrowUp);
 
+    if (!g_hbmArrowDown || !g_hbmArrowUp)
+    {
+        Wh_Log(
+            L"Failed to load one or more bitmaps from the module \"%s\". "
+            L"Please ensure that bitmap resources 577 (0x241) and 578 (0x242) "
+            L"exist in the target binary. An unmodified binary from Windows 7 "
+            L"will feature these resources.",
+            g_spszComdlg32Path.c_str()
+        );
+        return FALSE;
+    }
+
     return TRUE;
 }
 
@@ -263,6 +279,12 @@ BOOL Wh_ModInit()
 void Wh_ModUninit()
 {
     Wh_Log(L"Uninit");
+
+    if (g_hbmArrowDown)
+        DeleteObject(g_hbmArrowDown);
+
+    if (g_hbmArrowUp)
+        DeleteObject(g_hbmArrowUp);
 
     if (g_hmodComdlg32_7)
         FreeLibrary(g_hmodComdlg32_7);

--- a/mods/win7-file-open-save-toggle-bar-icon.wh.cpp
+++ b/mods/win7-file-open-save-toggle-bar-icon.wh.cpp
@@ -1,0 +1,221 @@
+// ==WindhawkMod==
+// @id              win7-file-open-save-toggle-bar-icon
+// @name            Windows 7 File Open/Save Toggle Bar Icon
+// @description     Restores the bitmap arrow glyph on the "Toggle Folders" button in open/save dialogs.
+// @version         1.0
+// @author          Leymonaide
+// @github          https://github.com/Leymonaide
+// @twitter         https://twitter.com/Lem0naide
+// @homepage        https://leymonaide.github.io/
+// @include         *
+// @compilerOptions -lcomdlg32 -lgdi32
+// @license         MIT
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Windows 7 File Open/Save Toggle Bar Icon
+
+Restores the bitmap arrow glyph on the "Toggle Folders" button in open/save dialogs.
+
+This glyph was changed to an icon in later versions of Windows. The icon scaling differs, so it wasn't possible to just
+make the icon look like the Windows 7 glyph.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- win7_comdlg32_path: C:\path\to\win7\comdlg32.dll
+  $name: Path to Windows 7 comdlg32.dll
+  $description: The bitmap will be loaded from this DLL.
+
+- use_per_window_dpi: true
+  $name: Use per-window DPI
+  $description: >
+    Windows 7 only supported per-process DPI. If you want perfect accuracy to
+    Windows 7, then disable this option.
+*/
+// ==/WindhawkModSettings==
+
+#include <string>
+#include <windhawk_utils.h>
+
+HMODULE g_hmodComdlg32_7 = nullptr;
+std::wstring g_spszComdlg32Path;
+bool g_usePerWindowDpi = false;
+
+bool g_fHighDPIAware = false;
+bool g_fHighDPI = false;
+int g_iLPX = -1;
+int g_iLPY = -1;
+
+HBITMAP g_hbmArrowDown = nullptr;
+HBITMAP g_hbmArrowUp = nullptr;
+
+UINT (*pfnGetDpiForWindow)(HWND hwnd) = nullptr;
+
+void InitDPI()
+{
+    bool isProcessDpiAware = IsProcessDPIAware();
+    if (g_iLPX == -1 || g_fHighDPIAware != isProcessDpiAware)
+    {
+        g_fHighDPIAware = isProcessDpiAware;
+
+        // Get the pixel density of the display:
+        HDC hdc = GetDC(NULL);
+        if (hdc)
+        {
+            g_iLPX = GetDeviceCaps(hdc, LOGPIXELSX);
+            g_iLPY = GetDeviceCaps(hdc, LOGPIXELSY);
+            g_fHighDPI = g_iLPX != 96;
+            ReleaseDC(NULL, hdc);
+        }
+    }
+}
+
+void SHLogicalToPhysicalDPI(int *px, int *py)
+{
+    InitDPI();
+    if (px)
+        *px = MulDiv(*px, g_iLPX, 96);
+    if (py)
+        *py = MulDiv(*py, g_iLPY, 96);
+}
+
+void (__thiscall *CFileOpenSave__ScaleAndSetToggleBarImageListIfNeeded_orig)(class CFileOpenSave *pThis);
+
+class CFileOpenSave
+{
+public:
+    // The current offsets are applicable for 19041.1806
+    HWND get_hwndToggleBar()
+    {
+#ifdef _WIN64
+        return *(HWND *)((size_t)this + (70 * 8));
+#else
+        return *(HWND *)((size_t)this + (79 * 4));
+#endif
+    }
+
+    // Entirely replaces original implementation.
+    void ScaleAndSetToggleBarImageListIfNeeded()
+    {
+        HWND hwndToggleBar = get_hwndToggleBar();
+
+        if (!hwndToggleBar)
+        {
+            Wh_Log(L"hwndToggleBar is null");
+            return;
+        }
+
+        int buttonHeight = 21;
+        if (g_usePerWindowDpi && pfnGetDpiForWindow)
+        {
+            UINT uDpi = pfnGetDpiForWindow(hwndToggleBar);
+            buttonHeight = MulDiv(buttonHeight, uDpi, 96);
+        }
+        else
+        {
+            SHLogicalToPhysicalDPI(&buttonHeight, nullptr);
+        }
+
+        // Windows 7 does not have variants of the bitmap for larger DPI scales,
+        // so it will appear at a low scale on such devices.
+        SendMessageW(hwndToggleBar, TB_SETBUTTONSIZE, 0, MAKELPARAM(150, buttonHeight));
+        SendMessageW(hwndToggleBar, TB_SETPADDING, 0, MAKELPARAM(0, buttonHeight - 21));
+        SendMessageW(hwndToggleBar, TB_SETBITMAPSIZE, 0, MAKELPARAM(18, 21));
+        {   
+            TBADDBITMAP tbab {
+                .hInst = nullptr,
+                .nID = (UINT_PTR)g_hbmArrowDown,
+            };
+            SendMessageW(hwndToggleBar, TB_ADDBITMAP, 1, (LPARAM)&tbab);
+        }
+        {
+            TBADDBITMAP tbab {
+                .hInst = nullptr,
+                .nID = (UINT_PTR)g_hbmArrowUp,
+            };
+            SendMessageW(hwndToggleBar, TB_ADDBITMAP, 1, (LPARAM)&tbab);
+        }
+    }
+};
+
+void __thiscall CFileOpenSave__ScaleAndSetToggleBarImageListIfNeeded_hook(class CFileOpenSave *pThis)
+{
+    return pThis->ScaleAndSetToggleBarImageListIfNeeded();
+}
+
+// comdlg32.dll
+const WindhawkUtils::SYMBOL_HOOK kComdlg32Hooks[] = {
+    {
+        {
+#ifdef _WIN64
+            L"protected: void __cdecl CFileOpenSave::ScaleAndSetToggleBarImageListIfNeeded(void)",
+#else
+            L"protected: void __thiscall CFileOpenSave::ScaleAndSetToggleBarImageListIfNeeded(void)",
+#endif
+        },
+        &CFileOpenSave__ScaleAndSetToggleBarImageListIfNeeded_orig,
+        CFileOpenSave__ScaleAndSetToggleBarImageListIfNeeded_hook,
+    },
+};
+
+void LoadSettings()
+{
+    g_spszComdlg32Path = WindhawkUtils::StringSetting::make(L"win7_comdlg32_path");
+    g_usePerWindowDpi = Wh_GetIntSetting(L"use_per_window_dpi");
+}
+
+// The mod is being initialized, load settings, hook functions, and do other
+// initialization stuff if required.
+BOOL Wh_ModInit()
+{
+    Wh_Log(L"Init");
+
+    LoadSettings();
+
+    HMODULE hUser32 = LoadLibraryExW(L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    pfnGetDpiForWindow = (decltype(pfnGetDpiForWindow))GetProcAddress(hUser32, "GetDpiForWindow");
+    FreeLibrary(hUser32);
+
+    g_hmodComdlg32_7 = LoadLibraryExW(g_spszComdlg32Path.c_str(), nullptr,
+        LOAD_LIBRARY_AS_DATAFILE);
+
+    if (!g_hmodComdlg32_7)
+    {
+        Wh_Log(L"Path to 7 comdlg32 not specified or the module is invalid.");
+        return FALSE;
+    }
+
+    HMODULE hmodComdlg32_10 = LoadLibraryExW(L"comdlg32.dll", nullptr,
+        LOAD_LIBRARY_SEARCH_SYSTEM32);
+
+    if (!WindhawkUtils::HookSymbols(hmodComdlg32_10, kComdlg32Hooks, ARRAYSIZE(kComdlg32Hooks)))
+    {
+        Wh_Log(L"Failed to hook symbols in comdlg32.dll.");
+    }
+
+    g_hbmArrowDown = LoadBitmapW(g_hmodComdlg32_7, (LPCWSTR)0x241);
+    Wh_Log(L"hbmArrow down: %p", g_hbmArrowDown);
+    g_hbmArrowUp = LoadBitmapW(g_hmodComdlg32_7, (LPCWSTR)0x242);
+    Wh_Log(L"hbmArrow up: %p", g_hbmArrowUp);
+
+    return TRUE;
+}
+
+// The mod is being unloaded, free all allocated resources.
+void Wh_ModUninit()
+{
+    Wh_Log(L"Uninit");
+
+    if (g_hmodComdlg32_7)
+        FreeLibrary(g_hmodComdlg32_7);
+}
+
+// The mod setting were changed, reload them.
+void Wh_ModSettingsChanged(BOOL *pbReload)
+{
+    Wh_Log(L"SettingsChanged");
+    *pbReload = TRUE;
+}

--- a/mods/win7-file-open-save-toggle-bar-icon.wh.cpp
+++ b/mods/win7-file-open-save-toggle-bar-icon.wh.cpp
@@ -20,6 +20,8 @@ Restores the bitmap arrow glyph on the "Toggle Folders" button in open/save dial
 
 This glyph was changed to an icon in later versions of Windows. The icon scaling differs, so it wasn't possible to just
 make the icon look like the Windows 7 glyph.
+
+![Preview image](https://raw.githubusercontent.com/Leymonaide/images/refs/heads/main/win7-file-open-save-toggle-bar-icon.png)
 */
 // ==/WindhawkModReadme==
 

--- a/mods/win7-file-open-save-toggle-bar-icon.wh.cpp
+++ b/mods/win7-file-open-save-toggle-bar-icon.wh.cpp
@@ -5,7 +5,7 @@
 // @version         1.0
 // @author          Leymonaide
 // @github          https://github.com/Leymonaide
-// @twitter         https://twitter.com/Lem0naide
+// @twitter         https://twitter.com/Leym0naide
 // @homepage        https://leymonaide.github.io/
 // @include         *
 // @compilerOptions -lcomdlg32 -lgdi32
@@ -20,6 +20,9 @@ Restores the bitmap arrow glyph on the "Toggle Folders" button in open/save dial
 
 This glyph was changed to an icon in later versions of Windows. The icon scaling differs, so it wasn't possible to just
 make the icon look like the Windows 7 glyph.
+
+This mod is currently tested and known to work on Windows 10 builds 19041 through 19045.. It is not tested on other
+versions.
 
 ![Preview image](https://raw.githubusercontent.com/Leymonaide/images/refs/heads/main/win7-file-open-save-toggle-bar-icon.png)
 */
@@ -89,7 +92,8 @@ void (__thiscall *CFileOpenSave__ScaleAndSetToggleBarImageListIfNeeded_orig)(cla
 class CFileOpenSave
 {
 public:
-    // The current offsets are applicable for 19041.1806
+    // The current offsets are applicable for 19041.1806, and reportedly works
+    // on other 19041 variants. Support for other builds will be added later.
     HWND get_hwndToggleBar()
     {
 #ifdef _WIN64
@@ -149,7 +153,7 @@ void __thiscall CFileOpenSave__ScaleAndSetToggleBarImageListIfNeeded_hook(class 
 }
 
 // comdlg32.dll
-const WindhawkUtils::SYMBOL_HOOK kComdlg32Hooks[] = {
+const WindhawkUtils::SYMBOL_HOOK c_rghkComdlg32[] = {
     {
         {
 #ifdef _WIN64
@@ -193,7 +197,7 @@ BOOL Wh_ModInit()
     HMODULE hmodComdlg32_10 = LoadLibraryExW(L"comdlg32.dll", nullptr,
         LOAD_LIBRARY_SEARCH_SYSTEM32);
 
-    if (!WindhawkUtils::HookSymbols(hmodComdlg32_10, kComdlg32Hooks, ARRAYSIZE(kComdlg32Hooks)))
+    if (!WindhawkUtils::HookSymbols(hmodComdlg32_10, c_rghkComdlg32, ARRAYSIZE(c_rghkComdlg32)))
     {
         Wh_Log(L"Failed to hook symbols in comdlg32.dll.");
     }
@@ -216,8 +220,9 @@ void Wh_ModUninit()
 }
 
 // The mod setting were changed, reload them.
-void Wh_ModSettingsChanged(BOOL *pbReload)
+BOOL Wh_ModSettingsChanged(BOOL *pbReload)
 {
     Wh_Log(L"SettingsChanged");
     *pbReload = TRUE;
+    return TRUE;
 }

--- a/mods/win7-file-open-save-toggle-bar-icon.wh.cpp
+++ b/mods/win7-file-open-save-toggle-bar-icon.wh.cpp
@@ -8,7 +8,7 @@
 // @twitter         https://twitter.com/Leym0naide
 // @homepage        https://leymonaide.github.io/
 // @include         *
-// @compilerOptions -lcomdlg32 -lgdi32
+// @compilerOptions -lcomdlg32 -lgdi32 -lntdll
 // @license         MIT
 // ==/WindhawkMod==
 
@@ -21,8 +21,9 @@ Restores the bitmap arrow glyph on the "Toggle Folders" button in open/save dial
 This glyph was changed to an icon in later versions of Windows. The icon scaling differs, so it wasn't possible to just
 make the icon look like the Windows 7 glyph.
 
-This mod is currently tested and known to work on Windows 10 builds 19041 through 19045.. It is not tested on other
-versions.
+This mod is currently tested and known to work on Windows 10 builds 19041 through 19045. It is not tested on other
+versions. Since the mod injects into all processes to function, the mod will silently refuse to load on unsupported
+versions of Windows.
 
 ![Preview image](https://raw.githubusercontent.com/Leymonaide/images/refs/heads/main/win7-file-open-save-toggle-bar-icon.png)
 */
@@ -44,6 +45,8 @@ versions.
 
 #include <string>
 #include <windhawk_utils.h>
+
+EXTERN_C NTSYSAPI NTSTATUS NTAPI RtlGetVersion(PRTL_OSVERSIONINFOW lpVersionInformation);
 
 HMODULE g_hmodComdlg32_7 = nullptr;
 std::wstring g_spszComdlg32Path;
@@ -180,6 +183,15 @@ BOOL Wh_ModInit()
     Wh_Log(L"Init");
 
     LoadSettings();
+
+    RTL_OSVERSIONINFOW osvi;
+    RtlGetVersion(&osvi);
+
+
+    if (osvi.dwBuildNumber < 19041 || osvi.dwBuildNumber > 19045)
+    {
+        return FALSE;
+    }
 
     HMODULE hUser32 = LoadLibraryExW(L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     pfnGetDpiForWindow = (decltype(pfnGetDpiForWindow))GetProcAddress(hUser32, "GetDpiForWindow");

--- a/mods/win7-file-open-save-toggle-bar-icon.wh.cpp
+++ b/mods/win7-file-open-save-toggle-bar-icon.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/Leymonaide
 // @twitter         https://twitter.com/Leym0naide
 // @homepage        https://leymonaide.github.io/
-// @include         *
+// @include         notepad.exe
 // @compilerOptions -lcomdlg32 -lgdi32 -lntdll
 // @license         MIT
 // ==/WindhawkMod==
@@ -20,10 +20,6 @@ Restores the bitmap arrow glyph on the "Toggle Folders" button in open/save dial
 
 This glyph was changed to an icon in later versions of Windows. The icon scaling differs, so it wasn't possible to just
 make the icon look like the Windows 7 glyph.
-
-This mod is currently tested and known to work on Windows 10 builds 19041 through 19045. It is not tested on other
-versions. Since the mod injects into all processes to function, the mod will silently refuse to load on unsupported
-versions of Windows.
 
 ![Preview image](https://raw.githubusercontent.com/Leymonaide/images/refs/heads/main/win7-file-open-save-toggle-bar-icon.png)
 */
@@ -60,7 +56,7 @@ int g_iLPY = -1;
 HBITMAP g_hbmArrowDown = nullptr;
 HBITMAP g_hbmArrowUp = nullptr;
 
-UINT (*pfnGetDpiForWindow)(HWND hwnd) = nullptr;
+UINT (WINAPI *pfnGetDpiForWindow)(HWND hwnd) = nullptr;
 
 void InitDPI()
 {
@@ -90,26 +86,44 @@ void SHLogicalToPhysicalDPI(int *px, int *py)
         *py = MulDiv(*py, g_iLPY, 96);
 }
 
+thread_local void *g_pCurrentToggleBar = nullptr;
+thread_local HWND g_hwndCurrentToggleBar = nullptr;
+
+using CreateWindowExW_t = decltype(&CreateWindowExW);
+CreateWindowExW_t CreateWindowExW_orig;
+HWND WINAPI CreateWindowExW_hook(DWORD dwExStyle,
+                     LPCWSTR lpClassName,
+                     LPCWSTR lpWindowName,
+                     DWORD dwStyle,
+                     int X,
+                     int Y,
+                     int nWidth,
+                     int nHeight,
+                     HWND hWndParent,
+                     HMENU hMenu,
+                     HINSTANCE hInstance,
+                     LPVOID lpParam)
+{
+    HWND hwnd = CreateWindowExW_orig(dwExStyle, lpClassName, lpWindowName, 
+        dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+
+    if (hwnd && g_pCurrentToggleBar && !IS_INTRESOURCE(lpClassName) &&
+        0 == _wcsicmp(lpClassName, L"ToolbarWindow32"))
+        g_hwndCurrentToggleBar = hwnd;
+
+    return hwnd;
+}
+
 void (__thiscall *CFileOpenSave__ScaleAndSetToggleBarImageListIfNeeded_orig)(class CFileOpenSave *pThis);
+void (__thiscall *CFileOpenSave___SetToggleBar_orig)(class CFileOpenSave *pThis);
 
 class CFileOpenSave
 {
 public:
-    // The current offsets are applicable for 19041.1806, and reportedly works
-    // on other 19041 variants. Support for other builds will be added later.
-    HWND get_hwndToggleBar()
-    {
-#ifdef _WIN64
-        return *(HWND *)((size_t)this + (70 * 8));
-#else
-        return *(HWND *)((size_t)this + (79 * 4));
-#endif
-    }
-
     // Entirely replaces original implementation.
     void ScaleAndSetToggleBarImageListIfNeeded()
     {
-        HWND hwndToggleBar = get_hwndToggleBar();
+        HWND hwndToggleBar = g_hwndCurrentToggleBar;
 
         if (!hwndToggleBar)
         {
@@ -155,6 +169,13 @@ void __thiscall CFileOpenSave__ScaleAndSetToggleBarImageListIfNeeded_hook(class 
     return pThis->ScaleAndSetToggleBarImageListIfNeeded();
 }
 
+void __thiscall CFileOpenSave___SetToggleBar_hook(class CFileOpenSave *pThis)
+{
+    g_pCurrentToggleBar = pThis;
+    CFileOpenSave___SetToggleBar_orig(pThis);
+    g_pCurrentToggleBar = nullptr;
+}
+
 // comdlg32.dll
 const WindhawkUtils::SYMBOL_HOOK c_rghkComdlg32[] = {
     {
@@ -167,6 +188,17 @@ const WindhawkUtils::SYMBOL_HOOK c_rghkComdlg32[] = {
         },
         &CFileOpenSave__ScaleAndSetToggleBarImageListIfNeeded_orig,
         CFileOpenSave__ScaleAndSetToggleBarImageListIfNeeded_hook,
+    },
+    {
+        {
+#ifdef _WIN64
+            L"protected: void __cdecl CFileOpenSave::_SetToggleBar(void)",
+#else
+            L"protected: void __thiscall CFileOpenSave::_SetToggleBar(void)",
+#endif
+        },
+        &CFileOpenSave___SetToggleBar_orig,
+        CFileOpenSave___SetToggleBar_hook,
     },
 };
 
@@ -187,15 +219,19 @@ BOOL Wh_ModInit()
     RTL_OSVERSIONINFOW osvi;
     RtlGetVersion(&osvi);
 
-
-    if (osvi.dwBuildNumber < 19041 || osvi.dwBuildNumber > 19045)
-    {
-        return FALSE;
-    }
-
     HMODULE hUser32 = LoadLibraryExW(L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     pfnGetDpiForWindow = (decltype(pfnGetDpiForWindow))GetProcAddress(hUser32, "GetDpiForWindow");
     FreeLibrary(hUser32);
+
+    if (!Wh_SetFunctionHook(
+        (void *)CreateWindowExW,
+        (void *)CreateWindowExW_hook,
+        (void **)&CreateWindowExW_orig
+    ))
+    {
+        Wh_Log(L"Failed to hook CreateWindowExW.");
+        return FALSE;
+    }
 
     g_hmodComdlg32_7 = LoadLibraryExW(g_spszComdlg32Path.c_str(), nullptr,
         LOAD_LIBRARY_AS_DATAFILE);
@@ -212,6 +248,7 @@ BOOL Wh_ModInit()
     if (!WindhawkUtils::HookSymbols(hmodComdlg32_10, c_rghkComdlg32, ARRAYSIZE(c_rghkComdlg32)))
     {
         Wh_Log(L"Failed to hook symbols in comdlg32.dll.");
+        return FALSE;
     }
 
     g_hbmArrowDown = LoadBitmapW(g_hmodComdlg32_7, (LPCWSTR)0x241);


### PR DESCRIPTION
Restores the bitmap arrow glyph on the "Toggle Folders" button in open/save dialogs.

This glyph was changed to an icon in later versions of Windows. The icon scaling differs, so it wasn't possible to just
make the icon look like the Windows 7 glyph.

![Preview image](https://raw.githubusercontent.com/Leymonaide/images/refs/heads/main/win7-file-open-save-toggle-bar-icon.png)

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* This pull request introduces a new mod.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [x] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
