### PR TITLE
Add VS Code dark non-client frame mod

### DIFF
--- a/mods/vscode-dark-nonclient-frame.wh.cpp
+++ b/mods/vscode-dark-nonclient-frame.wh.cpp
@@ -20,13 +20,15 @@ This fixes the 2px light gray bottom edge that can appear when VS Code is maximi
 
 Before:
 
-![Before](https://i.imgur.com/ldT3xJt.png)
+![Before](https://i.imgur.com/DVrOPag.png)
 
 After:
 
-![After](https://i.imgur.com/DVrOPag.png)
+![After](https://i.imgur.com/ldT3xJt.png)
 
-The mod targets only `Code.exe`.
+The mod targets only `Code.exe` by default. Users of VS Code Insiders, VSCodium, or renamed/portable builds can add the relevant executable name to the mod's custom include list.
+
+When the mod is disabled, it stops overriding VS Code's frame mode. Already affected windows may keep their current frame mode until VS Code applies a new value, for example after a theme or window state change.
 */
 // ==/WindhawkModReadme==
 
@@ -36,9 +38,6 @@ The mod targets only `Code.exe`.
 using DwmSetWindowAttribute_t = decltype(&DwmSetWindowAttribute);
 DwmSetWindowAttribute_t DwmSetWindowAttribute_orig;
 
-HWINEVENTHOOK g_objectCreateHook = nullptr;
-HWINEVENTHOOK g_objectShowHook = nullptr;
-
 BOOL IsCurrentProcessWindow(HWND hWnd) {
     DWORD windowPid = 0;
     GetWindowThreadProcessId(hWnd, &windowPid);
@@ -47,14 +46,14 @@ BOOL IsCurrentProcessWindow(HWND hWnd) {
 }
 
 BOOL IsValidWindow(HWND hWnd) {
-    LONG_PTR dwStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+    LONG_PTR style = GetWindowLongPtr(hWnd, GWL_STYLE);
 
-    return (dwStyle & WS_THICKFRAME) == WS_THICKFRAME ||
-           (dwStyle & WS_CAPTION) == WS_CAPTION;
+    return (style & WS_THICKFRAME) == WS_THICKFRAME ||
+           (style & WS_CAPTION) == WS_CAPTION;
 }
 
 void ApplyDarkFrame(HWND hWnd) {
-    if (!IsCurrentProcessWindow(hWnd) || !IsValidWindow(hWnd)) {
+    if (!IsValidWindow(hWnd)) {
         return;
     }
 
@@ -96,32 +95,16 @@ HRESULT WINAPI DwmSetWindowAttribute_hook(
 }
 
 BOOL CALLBACK EnableEnumWindowsCallback(HWND hWnd, LPARAM lParam) {
-    DWORD pid = lParam;
+    DWORD targetPid = static_cast<DWORD>(lParam);
 
     DWORD windowPid = 0;
     GetWindowThreadProcessId(hWnd, &windowPid);
 
-    if (pid == windowPid) {
+    if (targetPid == windowPid) {
         ApplyDarkFrame(hWnd);
     }
 
     return TRUE;
-}
-
-void CALLBACK WinEventProc(
-    HWINEVENTHOOK,
-    DWORD,
-    HWND hWnd,
-    LONG idObject,
-    LONG idChild,
-    DWORD,
-    DWORD
-) {
-    if (idObject != OBJID_WINDOW || idChild != CHILDID_SELF) {
-        return;
-    }
-
-    ApplyDarkFrame(hWnd);
 }
 
 BOOL Wh_ModInit() {
@@ -132,36 +115,6 @@ BOOL Wh_ModInit() {
         (void*)DwmSetWindowAttribute_hook,
         (void**)&DwmSetWindowAttribute_orig
     );
-
-    DWORD currentPid = GetCurrentProcessId();
-
-    g_objectCreateHook = SetWinEventHook(
-        EVENT_OBJECT_CREATE,
-        EVENT_OBJECT_CREATE,
-        nullptr,
-        WinEventProc,
-        currentPid,
-        0,
-        WINEVENT_OUTOFCONTEXT
-    );
-
-    if (!g_objectCreateHook) {
-        Wh_Log(L"Failed to create EVENT_OBJECT_CREATE hook");
-    }
-
-    g_objectShowHook = SetWinEventHook(
-        EVENT_OBJECT_SHOW,
-        EVENT_OBJECT_SHOW,
-        nullptr,
-        WinEventProc,
-        currentPid,
-        0,
-        WINEVENT_OUTOFCONTEXT
-    );
-
-    if (!g_objectShowHook) {
-        Wh_Log(L"Failed to create EVENT_OBJECT_SHOW hook");
-    }
 
     return TRUE;
 }
@@ -174,16 +127,6 @@ void Wh_ModAfterInit() {
 
 void Wh_ModBeforeUninit() {
     Wh_Log(L"BeforeUninit");
-
-    if (g_objectCreateHook) {
-        UnhookWinEvent(g_objectCreateHook);
-        g_objectCreateHook = nullptr;
-    }
-
-    if (g_objectShowHook) {
-        UnhookWinEvent(g_objectShowHook);
-        g_objectShowHook = nullptr;
-    }
 
     // Do not force DWMWA_USE_IMMERSIVE_DARK_MODE to FALSE here.
     // Disabling the mod should stop overriding VS Code's own value instead of

--- a/mods/vscode-dark-nonclient-frame.wh.cpp
+++ b/mods/vscode-dark-nonclient-frame.wh.cpp
@@ -1,0 +1,134 @@
+// ==WindhawkMod==
+// @id              vscode-dark-nonclient-frame
+// @name            VS Code Dark Non-client Frame
+// @description     Forces VS Code's non-client frame into dark mode to remove the light 2px bottom edge in Windows light mode.
+// @version         1.0
+// @author          v1b3s
+// @github          https://github.com/v1b3s0
+// @license         MIT
+// @include         Code.exe
+// @compilerOptions -ldwmapi
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# VS Code Dark Non-client Frame
+
+Forces VS Code's Windows non-client frame into immersive dark mode.
+
+This fixes the 2px light gray/white bottom edge that can appear when VS Code is maximized with the custom title bar, especially when using a hidden or transparent taskbar in Windows light mode.
+
+The mod targets only `Code.exe`.
+*/
+// ==/WindhawkModReadme==
+
+#include <windows.h>
+#include <dwmapi.h>
+
+static HANDLE g_stopEvent = nullptr;
+static HANDLE g_workerThread = nullptr;
+
+constexpr DWORD REAPPLY_INTERVAL_MS = 1000;
+
+// Official modern value.
+// On current Windows 10/11 builds, this is the dark non-client-frame switch.
+constexpr DWORD DWMWA_USE_IMMERSIVE_DARK_MODE_VALUE = 20;
+
+BOOL ApplyDarkFrameToWindow(HWND hwnd, BOOL enabled) {
+    BOOL value = enabled;
+
+    HRESULT hr = DwmSetWindowAttribute(
+        hwnd,
+        DWMWA_USE_IMMERSIVE_DARK_MODE_VALUE,
+        &value,
+        sizeof(value)
+    );
+
+    return SUCCEEDED(hr);
+}
+
+BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
+    DWORD targetPid = GetCurrentProcessId();
+
+    DWORD windowPid = 0;
+    GetWindowThreadProcessId(hwnd, &windowPid);
+
+    if (windowPid != targetPid) {
+        return TRUE;
+    }
+
+    if (!IsWindowVisible(hwnd)) {
+        return TRUE;
+    }
+
+    BOOL enabled = static_cast<BOOL>(lParam);
+    ApplyDarkFrameToWindow(hwnd, enabled);
+
+    return TRUE;
+}
+
+void ApplyDarkFrameToCurrentProcessWindows(BOOL enabled) {
+    EnumWindows(EnumWindowsProc, static_cast<LPARAM>(enabled));
+}
+
+DWORD WINAPI WorkerThreadProc(LPVOID) {
+    while (WaitForSingleObject(g_stopEvent, REAPPLY_INTERVAL_MS) == WAIT_TIMEOUT) {
+        ApplyDarkFrameToCurrentProcessWindows(TRUE);
+    }
+
+    return 0;
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"VS Code dark non-client frame mod initialized");
+
+    g_stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (!g_stopEvent) {
+        Wh_Log(L"Failed to create stop event");
+        return FALSE;
+    }
+
+    // Apply immediately in case VS Code already has a visible window.
+    ApplyDarkFrameToCurrentProcessWindows(TRUE);
+
+    // Keep reapplying so new/reloaded/remaximized VS Code windows get fixed too.
+    g_workerThread = CreateThread(
+        nullptr,
+        0,
+        WorkerThreadProc,
+        nullptr,
+        0,
+        nullptr
+    );
+
+    if (!g_workerThread) {
+        Wh_Log(L"Failed to create worker thread");
+        CloseHandle(g_stopEvent);
+        g_stopEvent = nullptr;
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+void Wh_ModBeforeUninit() {
+    Wh_Log(L"VS Code dark non-client frame mod unloading");
+
+    if (g_stopEvent) {
+        SetEvent(g_stopEvent);
+    }
+
+    if (g_workerThread) {
+        WaitForSingleObject(g_workerThread, 3000);
+        CloseHandle(g_workerThread);
+        g_workerThread = nullptr;
+    }
+
+    // Restore default behavior when the mod is disabled/unloaded.
+    ApplyDarkFrameToCurrentProcessWindows(FALSE);
+
+    if (g_stopEvent) {
+        CloseHandle(g_stopEvent);
+        g_stopEvent = nullptr;
+    }
+}

--- a/mods/vscode-dark-nonclient-frame.wh.cpp
+++ b/mods/vscode-dark-nonclient-frame.wh.cpp
@@ -3,132 +3,189 @@
 // @name            VS Code Dark Non-client Frame
 // @description     Forces VS Code's non-client frame into dark mode to remove the light 2px bottom edge in Windows light mode.
 // @version         1.0
-// @author          v1b3s
+// @author          v1b3s0
 // @github          https://github.com/v1b3s0
 // @license         MIT
 // @include         Code.exe
-// @compilerOptions -ldwmapi
+// @compilerOptions -ldwmapi -luser32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
 /*
 # VS Code Dark Non-client Frame
 
-Forces VS Code's Windows non-client frame into immersive dark mode.
+Forces Visual Studio Code's Windows non-client frame into immersive dark mode.
 
-This fixes the 2px light gray/white bottom edge that can appear when VS Code is maximized with the custom title bar, especially when using a hidden or transparent taskbar in Windows light mode.
+This fixes the 2px light gray bottom edge that can appear when VS Code is maximized with the custom title bar in Windows light mode, especially with a hidden or transparent taskbar.
+
+Before:
+
+![Before](https://i.imgur.com/ldT3xJt.png)
+
+After:
+
+![After](https://i.imgur.com/DVrOPag.png)
 
 The mod targets only `Code.exe`.
 */
 // ==/WindhawkModReadme==
 
-#include <windows.h>
 #include <dwmapi.h>
+#include <windhawk_api.h>
 
-static HANDLE g_stopEvent = nullptr;
-static HANDLE g_workerThread = nullptr;
+using DwmSetWindowAttribute_t = decltype(&DwmSetWindowAttribute);
+DwmSetWindowAttribute_t DwmSetWindowAttribute_orig;
 
-constexpr DWORD REAPPLY_INTERVAL_MS = 1000;
+HWINEVENTHOOK g_objectCreateHook = nullptr;
+HWINEVENTHOOK g_objectShowHook = nullptr;
 
-// Official modern value.
-// On current Windows 10/11 builds, this is the dark non-client-frame switch.
-constexpr DWORD DWMWA_USE_IMMERSIVE_DARK_MODE_VALUE = 20;
+BOOL IsCurrentProcessWindow(HWND hWnd) {
+    DWORD windowPid = 0;
+    GetWindowThreadProcessId(hWnd, &windowPid);
 
-BOOL ApplyDarkFrameToWindow(HWND hwnd, BOOL enabled) {
-    BOOL value = enabled;
-
-    HRESULT hr = DwmSetWindowAttribute(
-        hwnd,
-        DWMWA_USE_IMMERSIVE_DARK_MODE_VALUE,
-        &value,
-        sizeof(value)
-    );
-
-    return SUCCEEDED(hr);
+    return windowPid == GetCurrentProcessId();
 }
 
-BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
-    DWORD targetPid = GetCurrentProcessId();
+BOOL IsValidWindow(HWND hWnd) {
+    LONG_PTR dwStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+
+    return (dwStyle & WS_THICKFRAME) == WS_THICKFRAME ||
+           (dwStyle & WS_CAPTION) == WS_CAPTION;
+}
+
+void ApplyDarkFrame(HWND hWnd) {
+    if (!IsCurrentProcessWindow(hWnd) || !IsValidWindow(hWnd)) {
+        return;
+    }
+
+    BOOL enabled = TRUE;
+
+    DwmSetWindowAttribute_orig(
+        hWnd,
+        DWMWA_USE_IMMERSIVE_DARK_MODE,
+        &enabled,
+        sizeof(enabled)
+    );
+}
+
+HRESULT WINAPI DwmSetWindowAttribute_hook(
+    HWND hWnd,
+    DWORD dwAttribute,
+    LPCVOID pvAttribute,
+    DWORD cbAttribute
+) {
+    if (dwAttribute == DWMWA_USE_IMMERSIVE_DARK_MODE &&
+        IsCurrentProcessWindow(hWnd) &&
+        IsValidWindow(hWnd)) {
+        BOOL enabled = TRUE;
+
+        return DwmSetWindowAttribute_orig(
+            hWnd,
+            dwAttribute,
+            &enabled,
+            sizeof(enabled)
+        );
+    }
+
+    return DwmSetWindowAttribute_orig(
+        hWnd,
+        dwAttribute,
+        pvAttribute,
+        cbAttribute
+    );
+}
+
+BOOL CALLBACK EnableEnumWindowsCallback(HWND hWnd, LPARAM lParam) {
+    DWORD pid = lParam;
 
     DWORD windowPid = 0;
-    GetWindowThreadProcessId(hwnd, &windowPid);
+    GetWindowThreadProcessId(hWnd, &windowPid);
 
-    if (windowPid != targetPid) {
-        return TRUE;
+    if (pid == windowPid) {
+        ApplyDarkFrame(hWnd);
     }
-
-    if (!IsWindowVisible(hwnd)) {
-        return TRUE;
-    }
-
-    BOOL enabled = static_cast<BOOL>(lParam);
-    ApplyDarkFrameToWindow(hwnd, enabled);
 
     return TRUE;
 }
 
-void ApplyDarkFrameToCurrentProcessWindows(BOOL enabled) {
-    EnumWindows(EnumWindowsProc, static_cast<LPARAM>(enabled));
-}
-
-DWORD WINAPI WorkerThreadProc(LPVOID) {
-    while (WaitForSingleObject(g_stopEvent, REAPPLY_INTERVAL_MS) == WAIT_TIMEOUT) {
-        ApplyDarkFrameToCurrentProcessWindows(TRUE);
+void CALLBACK WinEventProc(
+    HWINEVENTHOOK,
+    DWORD,
+    HWND hWnd,
+    LONG idObject,
+    LONG idChild,
+    DWORD,
+    DWORD
+) {
+    if (idObject != OBJID_WINDOW || idChild != CHILDID_SELF) {
+        return;
     }
 
-    return 0;
+    ApplyDarkFrame(hWnd);
 }
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"VS Code dark non-client frame mod initialized");
+    Wh_Log(L"Init");
 
-    g_stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    if (!g_stopEvent) {
-        Wh_Log(L"Failed to create stop event");
-        return FALSE;
-    }
-
-    // Apply immediately in case VS Code already has a visible window.
-    ApplyDarkFrameToCurrentProcessWindows(TRUE);
-
-    // Keep reapplying so new/reloaded/remaximized VS Code windows get fixed too.
-    g_workerThread = CreateThread(
-        nullptr,
-        0,
-        WorkerThreadProc,
-        nullptr,
-        0,
-        nullptr
+    Wh_SetFunctionHook(
+        (void*)DwmSetWindowAttribute,
+        (void*)DwmSetWindowAttribute_hook,
+        (void**)&DwmSetWindowAttribute_orig
     );
 
-    if (!g_workerThread) {
-        Wh_Log(L"Failed to create worker thread");
-        CloseHandle(g_stopEvent);
-        g_stopEvent = nullptr;
-        return FALSE;
+    DWORD currentPid = GetCurrentProcessId();
+
+    g_objectCreateHook = SetWinEventHook(
+        EVENT_OBJECT_CREATE,
+        EVENT_OBJECT_CREATE,
+        nullptr,
+        WinEventProc,
+        currentPid,
+        0,
+        WINEVENT_OUTOFCONTEXT
+    );
+
+    if (!g_objectCreateHook) {
+        Wh_Log(L"Failed to create EVENT_OBJECT_CREATE hook");
+    }
+
+    g_objectShowHook = SetWinEventHook(
+        EVENT_OBJECT_SHOW,
+        EVENT_OBJECT_SHOW,
+        nullptr,
+        WinEventProc,
+        currentPid,
+        0,
+        WINEVENT_OUTOFCONTEXT
+    );
+
+    if (!g_objectShowHook) {
+        Wh_Log(L"Failed to create EVENT_OBJECT_SHOW hook");
     }
 
     return TRUE;
 }
 
+void Wh_ModAfterInit() {
+    Wh_Log(L"AfterInit");
+
+    EnumWindows(EnableEnumWindowsCallback, GetCurrentProcessId());
+}
+
 void Wh_ModBeforeUninit() {
-    Wh_Log(L"VS Code dark non-client frame mod unloading");
+    Wh_Log(L"BeforeUninit");
 
-    if (g_stopEvent) {
-        SetEvent(g_stopEvent);
+    if (g_objectCreateHook) {
+        UnhookWinEvent(g_objectCreateHook);
+        g_objectCreateHook = nullptr;
     }
 
-    if (g_workerThread) {
-        WaitForSingleObject(g_workerThread, 3000);
-        CloseHandle(g_workerThread);
-        g_workerThread = nullptr;
+    if (g_objectShowHook) {
+        UnhookWinEvent(g_objectShowHook);
+        g_objectShowHook = nullptr;
     }
 
-    // Restore default behavior when the mod is disabled/unloaded.
-    ApplyDarkFrameToCurrentProcessWindows(FALSE);
-
-    if (g_stopEvent) {
-        CloseHandle(g_stopEvent);
-        g_stopEvent = nullptr;
-    }
+    // Do not force DWMWA_USE_IMMERSIVE_DARK_MODE to FALSE here.
+    // Disabling the mod should stop overriding VS Code's own value instead of
+    // forcing a light non-client frame.
 }


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

Adds a new mod: VS Code Dark Non-client Frame.

This mod forces Visual Studio Code’s Windows non-client frame into immersive dark mode. It fixes a visible 2px white bottom edge that can appear when VS Code is maximized with the custom title bar in Windows light mode, especially with a hidden or transparent taskbar.

## Changelog

If this pull request updates an existing mod, describe the changes below:

* N/A - this pull request introduces a new mod.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [x] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.