### PR TITLE
Fix VS Code dark frame screenshot order

### DIFF
--- a/mods/vscode-dark-nonclient-frame.wh.cpp
+++ b/mods/vscode-dark-nonclient-frame.wh.cpp
@@ -2,7 +2,7 @@
 // @id              vscode-dark-nonclient-frame
 // @name            VS Code Dark Non-client Frame
 // @description     Forces VS Code's non-client frame into dark mode to remove the light 2px bottom edge in Windows light mode.
-// @version         1.0
+// @version         1.1
 // @author          v1b3s0
 // @github          https://github.com/v1b3s0
 // @license         MIT

--- a/mods/vscode-dark-nonclient-frame.wh.cpp
+++ b/mods/vscode-dark-nonclient-frame.wh.cpp
@@ -20,11 +20,11 @@ This fixes the 2px light gray bottom edge that can appear when VS Code is maximi
 
 Before:
 
-![Before](https://i.imgur.com/DVrOPag.png)
+![Before](https://i.imgur.com/ldT3xJt.png)
 
 After:
 
-![After](https://i.imgur.com/ldT3xJt.png)
+![After](https://i.imgur.com/DVrOPag.png)
 
 The mod targets only `Code.exe` by default. Users of VS Code Insiders, VSCodium, or renamed/portable builds can add the relevant executable name to the mod's custom include list.
 


### PR DESCRIPTION
## Changelog

If this pull request updates an existing mod, describe the changes below:

* Swaps the before/after screenshot links in the README for `vscode-dark-nonclient-frame`.

* The images were accidentally reversed in the merged version. No code changes.