### PR TITLE
Salyts' Ultimate Custom Tray: Fixed the DWORD Value that the mod checks for the icon theme mode

### DIFF
--- a/mods/ultimate-custom-tray.wh.cpp
+++ b/mods/ultimate-custom-tray.wh.cpp
@@ -315,7 +315,7 @@ static bool IsSystemDarkMode() {
     DWORD size  = sizeof(value);
     RegGetValueW(HKEY_CURRENT_USER,
                  L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
-                 L"AppsUseLightTheme",
+                 L"SystemUsesLightTheme",
                  RRF_RT_DWORD, nullptr, &value, &size);
     return value == 0;
 }


### PR DESCRIPTION
The mod originally looked for the 'AppsUseLightTheme' DWORD Value, Which checks if apps such as Settings, Clock, File Explorer. are using Light/Dark mode. Which as a side-effect makes the tray icon look bad in environments where people used light mode on apps, while still maintaining the dark mode taskbar.

So corrected this so it looks for the 'SystemUsesLightTheme' DWORD, so the icon actually matches with the taskbar's theme mode, when the icon theme mode is set to 'Auto'

## Before:

<img width="799" height="591" alt="image" src="https://github.com/user-attachments/assets/5ba76564-a894-4f22-b8e5-87fdc512c6f3" />
<img width="713" height="463" alt="image" src="https://github.com/user-attachments/assets/5c317b97-956c-49a0-944d-c4e2de9ef23f" />


## After:

<img width="747" height="595" alt="image" src="https://github.com/user-attachments/assets/9d740f20-c594-46bd-98e4-7f8679387d8c" />
<img width="719" height="593" alt="image" src="https://github.com/user-attachments/assets/84bb0ce9-0a50-4d61-a49b-5f1697c2da80" />



<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changed the DWORD Value that the mod originally checked (AppsUseLightTheme) to (SystemUsesLightTheme) fixing the icon's theme mode in certain theme configurations

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
