### PR TITLE
Bump version to 1.1.5 and add configurable taskbar volume tooltip text for translation purposes

### DIFF
--- a/mods/taskbar-volume-control-per-app.wh.cpp
+++ b/mods/taskbar-volume-control-per-app.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-volume-control-per-app
 // @name            Taskbar Volume Control Per-App
 // @description     Control the per-app volume by scrolling over taskbar buttons
-// @version         1.1.4
+// @version         1.1.5
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -83,6 +83,33 @@ Control mod takes precedence due to the way the mod works.
     By default, the app is muted once the volume reaches zero, and is unmuted
     on any change to a non-zero volume. Enabling this option turns off this
     functionality, such that the app mute status is not changed.
+- tooltipNoAudioSessionText: No audio session
+  $name: No audio session tooltip text
+  $description: >-
+    Text to show when the hovered app has no active audio session.
+- tooltipMutedText: Muted
+  $name: Muted tooltip text
+  $description: >-
+    Text to show when the hovered app is muted.
+- tooltipVolumeText: 'Volume: {volume}%'
+  $name: Volume tooltip text
+  $description: >-
+    Text to show for the hovered app volume. Use {volume} for the volume
+    percentage.
+- tooltipTerseNoAudioSessionText: '🔕'
+  $name: Terse no audio session tooltip text
+  $description: >-
+    Text to show when terse format is enabled and the hovered app has no active
+    audio session.
+- tooltipTerseMutedText: '🔇'
+  $name: Terse muted tooltip text
+  $description: >-
+    Text to show when terse format is enabled and the hovered app is muted.
+- tooltipTerseVolumeText: '🔊 {volume}%'
+  $name: Terse volume tooltip text
+  $description: >-
+    Text to show when terse format is enabled for the hovered app volume. Use
+    {volume} for the volume percentage.
 */
 // ==/WindhawkModSettings==
 
@@ -120,6 +147,12 @@ struct {
     bool ctrlScrollVolumeChange;
     bool terseFormat;
     bool noAutomaticMuteToggle;
+    std::wstring tooltipNoAudioSessionText;
+    std::wstring tooltipMutedText;
+    std::wstring tooltipVolumeText;
+    std::wstring tooltipTerseNoAudioSessionText;
+    std::wstring tooltipTerseMutedText;
+    std::wstring tooltipTerseVolumeText;
 } g_settings;
 
 std::atomic<bool> g_taskbarViewDllLoaded;
@@ -1044,6 +1077,37 @@ void HideVolumeTooltip() {
     g_volumeTooltipState.cursorX = 0.0;
 }
 
+std::wstring FormatVolumeText(std::wstring text, int volume) {
+    const std::wstring placeholder = L"{volume}";
+    const std::wstring volumeText = std::to_wstring(volume);
+
+    size_t pos = 0;
+    while ((pos = text.find(placeholder, pos)) != std::wstring::npos) {
+        text.replace(pos, placeholder.length(), volumeText);
+        pos += volumeText.length();
+    }
+
+    return text;
+}
+
+std::wstring FormatVolumeTooltipText(
+    std::optional<AppVolumeResult> volumeResult) {
+    if (!volumeResult) {
+        return g_settings.terseFormat ? g_settings.tooltipTerseNoAudioSessionText
+                                      : g_settings.tooltipNoAudioSessionText;
+    }
+
+    if (volumeResult->muted) {
+        return g_settings.terseFormat ? g_settings.tooltipTerseMutedText
+                                      : g_settings.tooltipMutedText;
+    }
+
+    const std::wstring& format = g_settings.terseFormat
+                                     ? g_settings.tooltipTerseVolumeText
+                                     : g_settings.tooltipVolumeText;
+    return FormatVolumeText(format, volumeResult->volume);
+}
+
 void ShowVolumeResultTooltip(UIElement element,
                              Input::PointerRoutedEventArgs args,
                              std::optional<AppVolumeResult> volumeResult) {
@@ -1061,19 +1125,9 @@ void ShowVolumeResultTooltip(UIElement element,
     double cursorX = rootPoint.X;
     double cursorY = rootPoint.Y;
 
-    WCHAR tooltipText[64];
-    if (!volumeResult) {
-        wcscpy_s(tooltipText,
-                 g_settings.terseFormat ? L"🔕" : L"No audio session");
-    } else if (volumeResult->muted) {
-        wcscpy_s(tooltipText, g_settings.terseFormat ? L"🔇" : L"Muted");
-    } else {
-        swprintf_s(tooltipText,
-                   g_settings.terseFormat ? L"🔊 %d%%" : L"Volume: %d%%",
-                   volumeResult->volume);
-    }
+    std::wstring tooltipText = FormatVolumeTooltipText(volumeResult);
     ShowVolumeTooltip(taskbarFrame, cursorX, cursorY, isOverflowPopup,
-                      tooltipText);
+                      tooltipText.c_str());
 }
 
 // Per-app volume wheel scroll handling.
@@ -1277,6 +1331,16 @@ int WINAPI TaskListButton_OnPointerPressed_Hook(void* pThis, void* pArgs) {
     return 0;
 }
 
+std::wstring GetStringSettingWithFallback(PCWSTR valueName,
+                                          PCWSTR fallbackValue) {
+    PCWSTR value = Wh_GetStringSetting(valueName);
+    std::wstring result = value && *value ? value : fallbackValue;
+    if (value) {
+        Wh_FreeStringSetting(value);
+    }
+    return result;
+}
+
 void LoadSettings() {
     g_settings.volumeChangeStep = Wh_GetIntSetting(L"volumeChangeStep");
     g_settings.ctrlClickToMute = Wh_GetIntSetting(L"ctrlClickToMute");
@@ -1285,6 +1349,18 @@ void LoadSettings() {
     g_settings.terseFormat = Wh_GetIntSetting(L"terseFormat");
     g_settings.noAutomaticMuteToggle =
         Wh_GetIntSetting(L"noAutomaticMuteToggle");
+    g_settings.tooltipNoAudioSessionText = GetStringSettingWithFallback(
+        L"tooltipNoAudioSessionText", L"No audio session");
+    g_settings.tooltipMutedText =
+        GetStringSettingWithFallback(L"tooltipMutedText", L"Muted");
+    g_settings.tooltipVolumeText =
+        GetStringSettingWithFallback(L"tooltipVolumeText", L"Volume: {volume}%");
+    g_settings.tooltipTerseNoAudioSessionText = GetStringSettingWithFallback(
+        L"tooltipTerseNoAudioSessionText", L"🔕");
+    g_settings.tooltipTerseMutedText =
+        GetStringSettingWithFallback(L"tooltipTerseMutedText", L"🔇");
+    g_settings.tooltipTerseVolumeText = GetStringSettingWithFallback(
+        L"tooltipTerseVolumeText", L"🔊 {volume}%");
 }
 
 bool HookTaskbarViewDllSymbols(HMODULE module) {

--- a/mods/taskbar-volume-control-per-app.wh.cpp
+++ b/mods/taskbar-volume-control-per-app.wh.cpp
@@ -118,6 +118,7 @@ Control mod takes precedence due to the way the mod works.
 #include <atomic>
 #include <cmath>
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -141,7 +142,7 @@ Control mod takes precedence due to the way the mod works.
 
 using namespace winrt::Windows::UI::Xaml;
 
-struct {
+struct Settings {
     int volumeChangeStep;
     bool ctrlClickToMute;
     bool ctrlScrollVolumeChange;
@@ -153,7 +154,15 @@ struct {
     std::wstring tooltipTerseNoAudioSessionText;
     std::wstring tooltipTerseMutedText;
     std::wstring tooltipTerseVolumeText;
-} g_settings;
+};
+
+Settings g_settings;
+std::mutex g_settingsMutex;
+
+Settings GetSettings() {
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
+    return g_settings;
+}
 
 std::atomic<bool> g_taskbarViewDllLoaded;
 
@@ -462,6 +471,7 @@ struct AppVolumeResult {
 std::optional<AppVolumeResult> AdjustAppVolumeForPID(DWORD targetPID,
                                                      float fVolumeAdd) {
     std::optional<AppVolumeResult> result;
+    auto settings = GetSettings();
 
     ForEachAudioSession([&](DWORD pid, IAudioSessionControl2* sessionControl) {
         if (pid != targetPID) {
@@ -493,7 +503,7 @@ std::optional<AppVolumeResult> AdjustAppVolumeForPID(DWORD targetPID,
             r.volume = (int)(newVolume * 100.0f + 0.5f);
 
             // Handle mute state based on volume.
-            if (!g_settings.noAutomaticMuteToggle) {
+            if (!settings.noAutomaticMuteToggle) {
                 if (newVolume < 0.005f) {
                     vol->SetMute(TRUE, NULL);
                     r.muted = true;
@@ -1092,19 +1102,21 @@ std::wstring FormatVolumeText(std::wstring text, int volume) {
 
 std::wstring FormatVolumeTooltipText(
     std::optional<AppVolumeResult> volumeResult) {
+    auto settings = GetSettings();
+
     if (!volumeResult) {
-        return g_settings.terseFormat ? g_settings.tooltipTerseNoAudioSessionText
-                                      : g_settings.tooltipNoAudioSessionText;
+        return settings.terseFormat ? settings.tooltipTerseNoAudioSessionText
+                                    : settings.tooltipNoAudioSessionText;
     }
 
     if (volumeResult->muted) {
-        return g_settings.terseFormat ? g_settings.tooltipTerseMutedText
-                                      : g_settings.tooltipMutedText;
+        return settings.terseFormat ? settings.tooltipTerseMutedText
+                                    : settings.tooltipMutedText;
     }
 
-    const std::wstring& format = g_settings.terseFormat
-                                     ? g_settings.tooltipTerseVolumeText
-                                     : g_settings.tooltipVolumeText;
+    const std::wstring& format = settings.terseFormat
+                                     ? settings.tooltipTerseVolumeText
+                                     : settings.tooltipVolumeText;
     return FormatVolumeText(format, volumeResult->volume);
 }
 
@@ -1162,8 +1174,10 @@ int WINAPI TaskListButton_OnPointerWheelChanged_Hook(void* pThis, void* pArgs) {
         return original();
     }
 
+    auto settings = GetSettings();
+
     // If Ctrl + Scroll is required, skip if Ctrl is not pressed.
-    if (g_settings.ctrlScrollVolumeChange && GetKeyState(VK_CONTROL) >= 0) {
+    if (settings.ctrlScrollVolumeChange && GetKeyState(VK_CONTROL) >= 0) {
         return original();
     }
 
@@ -1182,7 +1196,7 @@ int WINAPI TaskListButton_OnPointerWheelChanged_Hook(void* pThis, void* pArgs) {
     Wh_Log(L"Per-app volume: PID=%u, delta=%f", processId, delta);
 
     // Calculate volume change.
-    int step = g_settings.volumeChangeStep;
+    int step = settings.volumeChangeStep;
     if (!step) {
         step = 2;
     }
@@ -1283,7 +1297,9 @@ int WINAPI TaskListButton_OnPointerPressed_Hook(void* pThis, void* pArgs) {
         return TaskListButton_OnPointerPressed_Original(pThis, pArgs);
     };
 
-    if (!g_settings.ctrlClickToMute) {
+    auto settings = GetSettings();
+
+    if (!settings.ctrlClickToMute) {
         return original();
     }
 
@@ -1342,25 +1358,30 @@ std::wstring GetStringSettingWithFallback(PCWSTR valueName,
 }
 
 void LoadSettings() {
-    g_settings.volumeChangeStep = Wh_GetIntSetting(L"volumeChangeStep");
-    g_settings.ctrlClickToMute = Wh_GetIntSetting(L"ctrlClickToMute");
-    g_settings.ctrlScrollVolumeChange =
+    Settings settings;
+
+    settings.volumeChangeStep = Wh_GetIntSetting(L"volumeChangeStep");
+    settings.ctrlClickToMute = Wh_GetIntSetting(L"ctrlClickToMute");
+    settings.ctrlScrollVolumeChange =
         Wh_GetIntSetting(L"ctrlScrollVolumeChange");
-    g_settings.terseFormat = Wh_GetIntSetting(L"terseFormat");
-    g_settings.noAutomaticMuteToggle =
+    settings.terseFormat = Wh_GetIntSetting(L"terseFormat");
+    settings.noAutomaticMuteToggle =
         Wh_GetIntSetting(L"noAutomaticMuteToggle");
-    g_settings.tooltipNoAudioSessionText = GetStringSettingWithFallback(
+    settings.tooltipNoAudioSessionText = GetStringSettingWithFallback(
         L"tooltipNoAudioSessionText", L"No audio session");
-    g_settings.tooltipMutedText =
+    settings.tooltipMutedText =
         GetStringSettingWithFallback(L"tooltipMutedText", L"Muted");
-    g_settings.tooltipVolumeText =
+    settings.tooltipVolumeText =
         GetStringSettingWithFallback(L"tooltipVolumeText", L"Volume: {volume}%");
-    g_settings.tooltipTerseNoAudioSessionText = GetStringSettingWithFallback(
+    settings.tooltipTerseNoAudioSessionText = GetStringSettingWithFallback(
         L"tooltipTerseNoAudioSessionText", L"🔕");
-    g_settings.tooltipTerseMutedText =
+    settings.tooltipTerseMutedText =
         GetStringSettingWithFallback(L"tooltipTerseMutedText", L"🔇");
-    g_settings.tooltipTerseVolumeText = GetStringSettingWithFallback(
+    settings.tooltipTerseVolumeText = GetStringSettingWithFallback(
         L"tooltipTerseVolumeText", L"🔊 {volume}%");
+
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
+    g_settings = settings;
 }
 
 bool HookTaskbarViewDllSymbols(HMODULE module) {


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

The volume text supports a {volume} placeholder, for example: Volume: {volume}%.
The default behavior and default tooltip text remain unchanged.
This adds settings for customizing the tooltip text shown by Taskbar Volume Control Per-App.

The new settings allow users to customize the text for:
* no active audio session
* muted state
* volume percentage
* terse format variants

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
