### PR TITLE
Feature/hide fullscreen

### DIFF
--- a/mods/taskbar-music-lounge.wh.cpp
+++ b/mods/taskbar-music-lounge.wh.cpp
@@ -539,6 +539,31 @@ void DrawMediaPanel(HDC hdc, int width, int height) {
     }
 }
 
+bool IsFullscreenAppRunning()
+{
+    HWND fg = GetForegroundWindow();
+    if (!fg)
+        return false;
+
+    RECT rcWindow;
+    GetWindowRect(fg, &rcWindow);
+
+    HMONITOR hMon = MonitorFromWindow(fg, MONITOR_DEFAULTTOPRIMARY);
+
+    MONITORINFO mi{};
+    mi.cbSize = sizeof(mi);
+
+    if (!GetMonitorInfo(hMon, &mi))
+        return false;
+
+    RECT rcMonitor = mi.rcMonitor;
+
+    return rcWindow.left <= rcMonitor.left &&
+           rcWindow.top <= rcMonitor.top &&
+           rcWindow.right >= rcMonitor.right &&
+           rcWindow.bottom >= rcMonitor.bottom;
+}
+
 // --- Event Hook ---
 bool IsTaskbarWindow(HWND hwnd) {
     WCHAR cls[64];
@@ -623,15 +648,11 @@ LRESULT CALLBACK MediaWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
                 bool shouldHide = false;
 
                 // 1. Check Fullscreen
-                if (g_Settings.hideFullscreen) {
-                    QUERY_USER_NOTIFICATION_STATE state;
-                    if (SUCCEEDED(SHQueryUserNotificationState(&state))) {
-                        if (state == QUNS_BUSY || state == QUNS_RUNNING_D3D_FULL_SCREEN || state == QUNS_PRESENTATION_MODE) {
-                            shouldHide = true;
-                        }
-                    }
+                if (g_Settings.hideFullscreen)
+                {
+                    shouldHide = IsFullscreenAppRunning();
                 }
-
+                
                 // 2. Check Idle Timeout
                 bool isPlaying = false;
                 {
@@ -701,11 +722,9 @@ LRESULT CALLBACK MediaWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             if (!g_IsHiddenByIdle && !IsWindowVisible(hwnd)) {
                 // Double check fullscreen mode isn't forcing hide
                 bool gameModeHide = false;
-                if (g_Settings.hideFullscreen) {
-                     QUERY_USER_NOTIFICATION_STATE state;
-                     if (SUCCEEDED(SHQueryUserNotificationState(&state))) {
-                        if (state == QUNS_BUSY || state == QUNS_RUNNING_D3D_FULL_SCREEN || state == QUNS_PRESENTATION_MODE) gameModeHide = true;
-                     }
+                if (g_Settings.hideFullscreen)
+                {
+                    gameModeHide = IsFullscreenAppRunning();
                 }
                 if (!gameModeHide) ShowWindow(hwnd, SW_SHOWNOACTIVATE);
             }
@@ -724,7 +743,7 @@ LRESULT CALLBACK MediaWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
                 (myRc.bottom - myRc.top) != g_Settings.height) {
                     SetWindowPos(
                         hwnd,
-                        HWND_TOPMOST,
+                        HWND_NOTOPMOST,
                         x, y,
                         g_Settings.width,
                         g_Settings.height,
@@ -832,12 +851,12 @@ void MediaThread() {
 
     if (CreateWindowInBand) {
         g_hMediaWindow = CreateWindowInBand(
-            WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_TOPMOST,
+            WS_EX_LAYERED | WS_EX_TOOLWINDOW,
             wc.lpszClassName, TEXT("MusicLounge"),
             WS_POPUP | WS_VISIBLE,
             0, 0, g_Settings.width, g_Settings.height,
             NULL, NULL, wc.hInstance, NULL,
-            ZBID_IMMERSIVE_NOTIFICATION
+            ZBID_DESKTOP
         );
         if (g_hMediaWindow) {
             Wh_Log(L"Created window in ZBID_IMMERSIVE_NOTIFICATION band");
@@ -847,7 +866,7 @@ void MediaThread() {
     if (!g_hMediaWindow) {
         Wh_Log(L"Falling back to CreateWindowEx");
         g_hMediaWindow = CreateWindowEx(
-            WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_TOPMOST,
+            WS_EX_LAYERED | WS_EX_TOOLWINDOW,
             wc.lpszClassName, TEXT("MusicLounge"),
             WS_POPUP | WS_VISIBLE,
             0, 0, g_Settings.width, g_Settings.height,

--- a/mods/taskbar-music-lounge.wh.cpp
+++ b/mods/taskbar-music-lounge.wh.cpp
@@ -1,6 +1,6 @@
 // ==WindhawkMod==
-// @id              taskbar-music-lounge
-// @name            Taskbar Music Lounge
+// @id              taskbar-music-lounge-fork
+// @name            Taskbar Music Lounge - Fork
 // @description     A native-style music ticker with media controls.
 // @version         4.0.2
 // @author          Hashah2311
@@ -255,55 +255,117 @@ void UpdateMediaInfo() {
         if (!g_SessionManager) {
             g_SessionManager = GlobalSystemMediaTransportControlsSessionManager::RequestAsync().get();
         }
-        if (!g_SessionManager) return;
 
-        // Iterate ALL sessions to find one that is actively PLAYING.
+        if (!g_SessionManager)
+            return;
+
         GlobalSystemMediaTransportControlsSession session = nullptr;
-        bool foundActive = false;
-
         auto sessionsList = g_SessionManager.GetSessions();
+
+        // ======================================================
+        // PRIORIDADE 1: SPOTIFY
+        // ======================================================
         for (auto const& s : sessionsList) {
+            auto source = s.SourceAppUserModelId();
             auto pb = s.GetPlaybackInfo();
-            if (pb && pb.PlaybackStatus() == GlobalSystemMediaTransportControlsSessionPlaybackStatus::Playing) {
-                session = s;
-                foundActive = true;
-                break;
+
+            if (pb &&
+                pb.PlaybackStatus() ==
+                    GlobalSystemMediaTransportControlsSessionPlaybackStatus::Playing)
+            {
+                std::wstring sourceStr = source.c_str();
+
+                if (sourceStr.find(L"Spotify") != std::wstring::npos ||
+                    sourceStr.find(L"spotify") != std::wstring::npos)
+                {
+                    session = s;
+                    break;
+                }
             }
         }
 
-        if (!foundActive) {
+        // ======================================================
+        // PRIORIDADE 2: QUALQUER MÍDIA TOCANDO
+        // ======================================================
+        if (!session) {
+            for (auto const& s : sessionsList) {
+                auto pb = s.GetPlaybackInfo();
+
+                if (pb &&
+                    pb.PlaybackStatus() ==
+                        GlobalSystemMediaTransportControlsSessionPlaybackStatus::Playing)
+                {
+                    session = s;
+                    break;
+                }
+            }
+        }
+
+        // ======================================================
+        // PRIORIDADE 3: CURRENT SESSION
+        // ======================================================
+        if (!session) {
             session = g_SessionManager.GetCurrentSession();
         }
 
+        // ======================================================
+        // ATUALIZA DADOS
+        // ======================================================
         if (session) {
             auto props = session.TryGetMediaPropertiesAsync().get();
             auto info = session.GetPlaybackInfo();
 
             lock_guard<mutex> guard(g_MediaState.lock);
-            
+
             wstring newTitle = props.Title().c_str();
-            if (newTitle != g_MediaState.title || g_MediaState.albumArt == nullptr) {
-                if (g_MediaState.albumArt) { delete g_MediaState.albumArt; g_MediaState.albumArt = nullptr; }
+
+            if (newTitle != g_MediaState.title || g_MediaState.albumArt == nullptr)
+            {
+                if (g_MediaState.albumArt) {
+                    delete g_MediaState.albumArt;
+                    g_MediaState.albumArt = nullptr;
+                }
+
                 auto thumbRef = props.Thumbnail();
+
                 if (thumbRef) {
                     auto stream = thumbRef.OpenReadAsync().get();
                     g_MediaState.albumArt = StreamToBitmap(stream);
                 }
             }
+
             g_MediaState.title = newTitle;
             g_MediaState.artist = props.Artist().c_str();
-            g_MediaState.isPlaying = (info.PlaybackStatus() == GlobalSystemMediaTransportControlsSessionPlaybackStatus::Playing);
+            g_MediaState.isPlaying =
+                (info.PlaybackStatus() ==
+                 GlobalSystemMediaTransportControlsSessionPlaybackStatus::Playing);
+
             g_MediaState.hasMedia = true;
-        } else {
+        }
+        else {
             lock_guard<mutex> guard(g_MediaState.lock);
+
             g_MediaState.hasMedia = false;
             g_MediaState.title = L"No Media";
             g_MediaState.artist = L"";
-            if (g_MediaState.albumArt) { delete g_MediaState.albumArt; g_MediaState.albumArt = nullptr; }
+
+            if (g_MediaState.albumArt) {
+                delete g_MediaState.albumArt;
+                g_MediaState.albumArt = nullptr;
+            }
         }
-    } catch (...) {
+    }
+    catch (...) {
         lock_guard<mutex> guard(g_MediaState.lock);
+
         g_MediaState.hasMedia = false;
+        g_MediaState.title = L"No Media";
+        g_MediaState.artist = L"";
+
+        if (g_MediaState.albumArt) {
+            delete g_MediaState.albumArt;
+            g_MediaState.albumArt = nullptr;
+        }
     }
 }
 


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

This PR improves fullscreen behavior for Taskbar Music Lounge.

Previously, the widget could remain visible above fullscreen applications and videos because it was created as a topmost window in the ZBID_IMMERSIVE_NOTIFICATION band.

### Changes made:

* Added explicit fullscreen detection based on the foreground window size.
* Replaced QUERY_USER_NOTIFICATION_STATE checks with the new fullscreen detection.
* Removed WS_EX_TOPMOST.
* Replaced HWND_TOPMOST with HWND_NOTOPMOST.
*  Changed the window band from ZBID_IMMERSIVE_NOTIFICATION to ZBID_DEFAULT.

As a result, the widget now automatically hides when applications enter fullscreen mode (games, YouTube, Netflix, etc.) and reappears when returning to normal desktop usage.

# Changelog
Improve fullscreen detection and hiding behavior.
Remove topmost window behavior to prevent overlaying fullscreen applications.
Use the default Z-band to better integrate with desktop and taskbar visibility.

* Improve fullscreen detection and hiding behavior.
* Remove topmost window behavior to prevent overlaying fullscreen applications.
* Use the default Z-band to better integrate with desktop and taskbar visibility.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [x] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
