### PR TITLE
Update Word PDF Lossless Export

### DIFF
--- a/mods/word-pdf-lossless-export.wh.cpp
+++ b/mods/word-pdf-lossless-export.wh.cpp
@@ -4,7 +4,7 @@
 // @name:zh-CN    Word 图像无损导出 PDF
 // @description   Forces Word to export PDFs with lossless image quality
 // @description:zh-CN   强制 Word 导出 PDF 时使用 100% 无损图像质量
-// @version       1.1.1
+// @version       1.2.0
 // @author        Joe Ye
 // @github        https://github.com/JoeYe-233
 // @include       winword.exe
@@ -21,46 +21,71 @@ Microsoft Word has a notorious, long-standing issue when exporting documents to 
 
 This mod performs a deep, memory-level intervention on Word's internal graphics rendering pipeline to bypass these limitations. It intercepts the core image resolution calculator (`DOCEXIMAGE::HrComputeSize`) to prevent dimensional downscaling, and hooks the output validator (`DOCEXIMAGE::HrCheckForLosslessOutput`) to force the engine to use a lossless FLATE (Zlib) stream instead of the default JPEG encoder.
 
-**Key Improvements:**
+### ✨ Key Improvements
 
   * **Pixel-Perfect Pictures:** Solid PNG images, JPEGs and BMPs, etc. are exported with absolute 100% pixel accuracy. No quality loss, no artifacts. PNGs with transparency are guaranteed > 98% pixel accuracy (this is due to limits of GDI+, which does not handle alpha channel perfectly, but it's still a huge improvement over what we currently have. For detailed information, see Test Results below).
   * **True Lossless Quality:** Bypasses Word's forced secondary JPEG compression entirely, preserving the exact quality of your original high-resolution inserts.
   * **Overrides Broken Settings:** Bypasses the hardcoded internal DPI limits that Word's built-in *so called* "High fidelity" setting fails to disable.
   * **Cross-Architecture Support:** Dynamically adapts to both 64-bit and 32-bit versions of Office using precise memory offsets and calling conventions.
 
-*Note: this mod needs pdb symbol of `mso.dll` to work. The symbol file is expected to be quite large (~90MB in size). Windhawk will download it automatically when launching Word first time after you installed the mod (the popup at right bottom corner of your screen, please make sure that it shows percentage like "Loading symbols... 0% (mso.dll)", wait until it reaches 100% and the pop up disappears, otherwise please switch your network and try again) please wait patiently and **relaunch Word AS ADMINISTRATOR** first time after it finishes,this is to write symbols being used to SymbolCache, which speeds up word launching later on.*
+---
 
+### ⚙️ Hook Method & Symbol Download Instructions
 
-**Attention**: this mod utilizes functions and data structures in `DOCEXIMAGE` class, which is undocumented and is subject to change without notice. If the mod causes crash when exporting PDFs, please **open an issue** at my [GitHub repository](https://github.com/JoeYe-233/windhawk-mods/issues) and provide your version of `mso.dll` (usually located in `C:\Program Files\Microsoft Office\root\vfs\ProgramFilesCommon[X64, X86]\Microsoft Shared\OFFICE16\MSO.DLL` where `[X64, X86]` varies based on your Microsoft Office architecture. For 64-bit Office, usually both X86 and X64 are available, use the X64 one; for 32-bit Office, use the X86 one).
+This mod now features a **Hook Method** option in the settings, meaning the large PDB symbol file is no longer strictly mandatory. Both methods prioritize a local cache for optimal speed and will automatically fall back to the other if one fails:
 
-**Test Results and Verifications:**
+* **Pattern First (Faster):** Prioritizes AOB pattern scanning. It does not require downloading PDBs, though it may be more susceptible to breaking with Office updates.
+* **PDB First (More Robust):** Prioritizes symbol-based hooking. If you select this (or if the mod uses it as a fallback), Windhawk needs the `mso.dll` PDB symbol (~90MB) and will download it automatically when you first launch Word.
+  * *If downloading PDB:* Please watch the popup in the bottom right corner of your screen (it will show progress like "Loading symbols... 0% (mso.dll)"). Wait patiently until it reaches 100% and disappears. If it fails, please switch your network and try again.
+
+**⚠️ IMPORTANT:** Whenever you modify the Hook Method option, or after the PDB finishes downloading for the first time, please **relaunch Word AS ADMINISTRATOR**. This writes the target functions to the local cache, which drastically speeds up Word's launch times later on.
+
+---
+
+### 🖼️ Recommended Word Settings for Lossless Images
+
+To ensure Word does not degrade your picture quality, please configure the following built-in settings:
+
+1. Navigate to **File** > **Options** > **Advanced**.
+2. Scroll down to the **Image size and quality** section.
+3. *Recommended: In the combobox right next to "Image size and quality", select **All New Documents** to apply these settings to all future documents created on your PC.
+4. Tick the box for **"Do not compress images in file"**.
+5. Select **High fidelity** as the default resolution.
+
+**Note:** If your document was saved *before* this option was applied, its existing images may have already been compressed. You may need to replace and re-insert all pictures, then re-save the document to ensure the images stored within the Word document itself (and not just the exported PDF) are truly lossless.
+
+---
+
+### 🧪 Test Results and Verifications
 
 * **Lossless performance guaranteed for JPEGs, BMPs, and other non-transparent formats**: 100% lossless pixel-perfect accuracy. No downscaling, no compression artifacts or quality loss.
 
 * **Lossless performance guaranteed for PNGs**:
-  * 100% lossless for pngs that **do not contain** transparent regions. (same as above, no downscaling, no compression artifacts or quality loss).
-  * > 98.4% (absolute visually lossless) for PNGs that **contain** transparent regions. (No downscaling, no compression artifacts, and negligible quality loss). This is because of how GDI+ handles transparent images (Pre-multiplied Alpha and Float to Integer rounding error). Combined, these may cause up to ±4 drift out of 255 (±1.6%) on each of 3 RGB channels. Also, RGB values for pixels on complete transparent regions (i.e., alpha strictly equals 0) are discarded by GDI+ for better performance. (which is actually a good thing as it increases redundancy, thus decreasing size of end product).
+  * 100% lossless for PNGs that **do not contain** transparent regions. (same as above, no downscaling, no compression artifacts or quality loss).
+  * > 98.4% lossless for PNGs that **contain** transparent regions. (No downscaling, no compression artifacts, and negligible quality loss). This is because of how GDI+ handles transparent images (Pre-multiplied Alpha and Float to Integer rounding error). Combined, these may cause up to ±4 drift out of 255 (±1.6%) on each of 3 RGB channels. Also, RGB values for pixels on complete transparent regions (i.e., alpha strictly equals 0) are discarded by GDI+ for better performance. (which is actually a good thing as it increases redundancy, thus decreasing size of end product).
 
 * Also, pictures embedded in SVGs are lossless too, because the mod hooks the core image processing pipeline, which applies to all images regardless of their source.
 
 Lossless picture extractor of PDF files are also provided to help you verify the output PDF files. You can get the Python script [here](https://raw.githubusercontent.com/JoeYe-233/images/refs/heads/main/PDF_Image_Extractor_Lossless.py).
 
-### Before (input vs output)
+### ❌ Before (Input vs Output)
 
 ![Before](https://raw.githubusercontent.com/JoeYe-233/images/refs/heads/main/word-pdf-lossless-export-before.png)
 
 (Image courtesy of [Nicky ❤️🌿🐞🌿❤️](https://pixabay.com/photos/winter-nature-trees-snow-cold-6762640/) from Pixabay)
-### After (input vs output)
+
+### ✅ After (Input vs Output)
 
 ![After](https://raw.githubusercontent.com/JoeYe-233/images/refs/heads/main/word-pdf-lossless-export-after.png)
 
-### Before vs After at 800% Zoom
+### 🔎 Before vs After at 800% Zoom
 
-![Before vs After](https://raw.githubusercontent.com/JoeYe-233/images/refs/heads/main/word-pdf-lossless-export-before-vs-after.png)
+![Before vs After](https://raw.githubusercontent.com/JoeYe-233/images/refs/heads/main/word-pdf-lossless-export-before-vs-after-new.png)
 
 (Notice the severe downscaling and compression artifacts in the "Before" image, which are completely gone in the "After" image.)
 
-### PNG with Transparency Test
+### 🖼️ PNG with Transparency Test
+
 (Image courtesy of [Sunriseforever](https://pixabay.com/illustrations/fruit-nutrition-organic-healthy-6925630/) from Pixabay)
 
 Before (input vs output):
@@ -75,6 +100,34 @@ After (input vs output):
 
 */
 // ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- hook_method: pdb
+  $name: Hook Method
+  $name:zh-CN: Hook 方式
+  $description: |
+    Determines the primary method for locating target functions in mso.dll.
+    * The "PDB First" option prioritizes symbol-based hooking using PDB files, which is more robust against Office updates but relies on successful PDB retrieval.
+    * The "Pattern First" option prioritizes AOB pattern scanning, which is faster and does not require PDBs but may be more susceptible to breaking with Office updates. 
+    Both methods will fall back to the other if the primary method fails, and both will always attempt to use the local cache first for optimal performance.
+    
+    Note: After changing this setting, please restart Word AS ADMINISTRATOR to ensure the cache is updated correctly.
+  $description:zh-CN: |
+    选择首选的函数定位方式:
+    * “PDB 优先”选项优先使用 PDB 符号文件进行符号定位，具有更强的抗 Office 更新能力，但依赖于成功获取 PDB。
+    * “特征码优先”选项优先使用 AOB 特征码扫描进行函数定位，速度更快且不依赖 PDB，但可能更容易受到 Office 更新的影响。
+    两者互为备用，且均会优先读取之前保存的本地极速缓存
+    
+    注意：修改选项后，需要重新【以管理员身份】启动 Word 以写入缓存
+  $options:
+    - pdb: PDB First (Pattern as Fallback)
+    - pattern: Pattern First (PDB as Fallback)
+  $options:zh-CN:
+    - pdb: PDB 优先 (特征码作为备用)
+    - pattern: 特征码优先 (PDB 作为备用)
+*/
+// ==/WindhawkModSettings==
 
 #include <windhawk_utils.h>
 #include <windows.h>
@@ -179,11 +232,106 @@ int CC_CALL Hook_HrCheckForLosslessOutput(void* pThis, int a1) {
 }
 
 // =============================================================
-// Core Symbol Hook logic
+// Unified Cache & Core Routing
 // =============================================================
-void ScanAndHookMso() {
-    HMODULE hMso = GetModuleHandleW(L"mso.dll");
-    if (!hMso || g_bMsoHooked.exchange(true)) return;
+
+// Updated the cache key to avoid loading older cache data with the wrong format.
+#define CACHE_KEY_MSO_HOOKS L"WordLossless_MsoHooksCache"
+
+#pragma pack(push, 1)
+struct HookStateCache {
+    DWORD pdbFailCount;             // Number of consecutive PDB hook failures.
+    DWORD offset_HrComputeSize;
+    BYTE  prefix_HrComputeSize[8];
+    DWORD offset_HrCheckForLosslessOutput;
+    BYTE  prefix_HrCheckForLosslessOutput[8];
+    DWORD lastHookMethod;           // Records the strategy used when this cache was generated (0=PDB, 1=Pattern)
+};
+#pragma pack(pop)
+
+HookStateCache g_cache = {0};
+bool g_cacheLoaded = false;
+
+void LoadCache() {
+    size_t bytesRead = Wh_GetBinaryValue(CACHE_KEY_MSO_HOOKS, &g_cache, sizeof(g_cache));
+    if (bytesRead == sizeof(g_cache)) {
+        g_cacheLoaded = true;
+        Wh_Log(L"[Cache] Loaded successfully. PDB Fail Count: %lu", g_cache.pdbFailCount);
+    } else {
+        Wh_Log(L"[Cache] No valid cache found (Read %zu bytes). Initializing new.", bytesRead);
+        memset(&g_cache, 0, sizeof(g_cache));
+    }
+}
+
+void SaveCache() {
+    Wh_SetBinaryValue(CACHE_KEY_MSO_HOOKS, &g_cache, sizeof(g_cache));
+}
+
+bool CheckPattern(const BYTE* pData, const BYTE* bMask, const char* szMask) {
+    for (; *szMask; ++szMask, ++pData, ++bMask)
+        if (*szMask == 'x' && *pData != *bMask)
+            return false;
+    return (*szMask) == '\0';
+}
+
+BYTE* FindPatternInTextSection(HMODULE hMod, const BYTE* bMask, const char* szMask) {
+    PIMAGE_DOS_HEADER dosHeader = (PIMAGE_DOS_HEADER)hMod;
+    PIMAGE_NT_HEADERS ntHeaders = (PIMAGE_NT_HEADERS)((BYTE*)hMod + dosHeader->e_lfanew);
+    PIMAGE_SECTION_HEADER section = IMAGE_FIRST_SECTION(ntHeaders);
+
+    for (WORD i = 0; i < ntHeaders->FileHeader.NumberOfSections; i++) {
+        if (memcmp(section[i].Name, ".text", 5) == 0) {
+            BYTE* start = (BYTE*)hMod + section[i].VirtualAddress;
+            DWORD size = section[i].SizeOfRawData;
+
+            for (DWORD j = 0; j < size; j++) {
+                if (CheckPattern(start + j, bMask, szMask)) {
+                    return start + j;
+                }
+            }
+        }
+    }
+    return nullptr;
+}
+
+bool TryFastPathHooks(HMODULE hMso) {
+    if (!g_cacheLoaded || g_cache.offset_HrComputeSize == 0 || g_cache.offset_HrCheckForLosslessOutput == 0) {
+        return false;
+    }
+
+    BYTE* pComputeSize = (BYTE*)hMso + g_cache.offset_HrComputeSize;
+    BYTE* pCheckLossless = (BYTE*)hMso + g_cache.offset_HrCheckForLosslessOutput;
+
+    // Strict validation: Verify the first 8 bytes haven't changed due to Office updates
+    if (memcmp(pComputeSize, g_cache.prefix_HrComputeSize, 8) != 0 ||
+        memcmp(pCheckLossless, g_cache.prefix_HrCheckForLosslessOutput, 8) != 0) {
+        Wh_Log(L"[Cache] Opcode prefix mismatch. Office updated? Forcing full scan/PDB.");
+        
+        // Office has updated, so reset the PDB failure counter and give PDB another chance.
+        g_cache.pdbFailCount = 0;
+        SaveCache();
+        return false;
+    }
+
+    // Validation passed, apply hooks
+    Wh_SetFunctionHook((void*)pComputeSize, (void*)Hook_HrComputeSize, (void**)&pOrig_HrComputeSize);
+    Wh_SetFunctionHook((void*)pCheckLossless, (void*)Hook_HrCheckForLosslessOutput, (void**)&pOrig_HrCheckForLosslessOutput);
+    
+    // Important: commit the hook operations to memory.
+    Wh_ApplyHookOperations();
+
+    Wh_Log(L"[FastPath] Fast path successful! Hooks applied via cached offsets.");
+    return true;
+}
+
+// -------------------------------------------------------------
+// Route 1: PDB Hooking
+// -------------------------------------------------------------
+bool RunPdbRoute(HMODULE hMso) {
+    if (g_cache.pdbFailCount >= 2) {
+        Wh_Log(L"[PDB Route] PDB failed %lu times previously. Skipping PDB.", g_cache.pdbFailCount);
+        return false;
+    }
 
     WindhawkUtils::SYMBOL_HOOK msoDllHook[] = {
         {
@@ -210,17 +358,144 @@ void ScanAndHookMso() {
     options.noUndecoratedSymbols = TRUE;
     options.onlineCacheUrl = L""; // Gracefully stops it from trying to get online symbols. We will rely entirely on local symbol cache, which is populated when you launch Word as administrator after installing the mod and waiting for symbol download to complete.
 
+    Wh_Log(L"[PDB Route] Attempting to hook mso.dll via PDB symbols...");
     if (WindhawkUtils::HookSymbols(hMso, msoDllHook, ARRAYSIZE(msoDllHook), &options)) {
-
-        // Don't forget to apply the hooks after setting them up, otherwise they won't take effect!
         Wh_ApplyHookOperations();
-
-        Wh_Log(L"[Success] Hooks applied successfully to mso.dll! HrComputeSize and HrCheckForLosslessOutput are now hooked.");
+        Wh_Log(L"[Success] Hooks applied successfully via PDB!");
+        
+        // Clear the failure counter on success.
+        if (g_cache.pdbFailCount != 0) {
+            g_cache.pdbFailCount = 0;
+            SaveCache();
+        }
+        return true;
     } else {
-        Wh_Log(L"[Error] Failed to hook symbols in mso.dll. HrComputeSize and HrCheckForLosslessOutput are not hooked, and the mod will not work. Please make sure your Office version is supported and the symbol files are properly downloaded.");
+        g_cache.pdbFailCount++;
+        Wh_Log(L"[Warning] PDB symbol hook failed. Fail Count: %lu", g_cache.pdbFailCount);
+        SaveCache();
+        return false;
     }
 }
 
+// -------------------------------------------------------------
+// Route 2: Pattern Scanning
+// -------------------------------------------------------------
+bool RunPatternRoute(HMODULE hMso) {
+    Wh_Log(L"[Pattern Route] Starting full AOB pattern scan in mso.dll...");
+
+#ifdef _WIN64
+    const BYTE sig_ComputeSize[] = {0x48, 0x8B, 0xC4, 0x48, 0x89, 0x58, 0x10, 0x48, 0x89, 0x70, 0x18, 0x55, 0x57, 0x41, 0x54, 0x41, 0x55, 0x41, 0x56, 0x48, 0x8B, 0xEC};
+    const char mask_ComputeSize[] = "xxxxxxxxxxxxxxxxxxxxxx";
+
+    const BYTE sig_CheckLossless[] = {0x48, 0x89, 0x5C, 0x24, 0x10, 0x55, 0x56, 0x57, 0x48, 0x83, 0xEC, 0x30, 0x33, 0xED, 0x8B, 0xF2, 0x48, 0x8B, 0xD9, 0x39, 0xA9};
+    const char mask_CheckLossless[] = "xxxxxxxxxxxxxxxxxxxxx";
+#else
+    const BYTE sig_ComputeSize[] = {
+        0x55, 0x8B, 0xEC, 0x83, 0xE4, 0xF8, 0x83, 0xEC, 0x00, 0x53, 0x56, 0x8B, 
+        0xF1, 0xC7, 0x44, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x33, 0xDB, 0x43, 0x57
+    };
+    const char mask_ComputeSize[] = "xxxxxxxx?xxxxxxx?xxxxxxxx";
+
+    const BYTE sig_CheckLossless[] = {
+        0x55, 0x8B, 0xEC, 0x51, 0x56, 0x8B, 0xF1, 0x83, 0xBE, 0xA4, 0x00, 0x00, 
+        0x00, 0x00, 0x0F, 0x85, 0x00, 0x00, 0x00, 0x00, 0x53, 0x57, 0x6A, 0x00
+    };
+    const char mask_CheckLossless[] = "xxxxxxxxxxxxxxxx????xxxx";
+#endif
+
+    BYTE* pComputeSize = FindPatternInTextSection(hMso, sig_ComputeSize, mask_ComputeSize);
+    BYTE* pCheckLossless = FindPatternInTextSection(hMso, sig_CheckLossless, mask_CheckLossless);
+
+    if (pComputeSize && pCheckLossless) {
+        Wh_Log(L"[Pattern Route] Patterns found! ComputeSize at %p, CheckLossless at %p", pComputeSize, pCheckLossless);
+
+        // Update cache data
+        g_cache.offset_HrComputeSize = (DWORD)(pComputeSize - (BYTE*)hMso);
+        memcpy(g_cache.prefix_HrComputeSize, pComputeSize, 8);
+        
+        g_cache.offset_HrCheckForLosslessOutput = (DWORD)(pCheckLossless - (BYTE*)hMso);
+        memcpy(g_cache.prefix_HrCheckForLosslessOutput, pCheckLossless, 8);
+
+        SaveCache();
+        Wh_Log(L"[Success] Offsets and 8-byte prefixes saved to local cache via Pattern Route.");
+        
+        Wh_SetFunctionHook((void*)pComputeSize, (void*)Hook_HrComputeSize, (void**)&pOrig_HrComputeSize);
+        Wh_SetFunctionHook((void*)pCheckLossless, (void*)Hook_HrCheckForLosslessOutput, (void**)&pOrig_HrCheckForLosslessOutput);
+
+        // Important: commit the hook operations to memory.
+        Wh_ApplyHookOperations();
+        
+        return true;
+    }
+
+    Wh_Log(L"[Error] Pattern scan failed to locate functions.");
+    return false;
+}
+
+// =============================================================
+// Core Loader
+// =============================================================
+void ScanAndHookMso() {
+    HMODULE hMso = GetModuleHandleW(L"mso.dll");
+    if (!hMso || g_bMsoHooked.exchange(true)) return;
+
+    // 1. Initialize and load the global cache.
+    LoadCache();
+
+    // 2. Read the user's preferred setting (string value).
+    LPCWSTR pszHookMethod = Wh_GetStringSetting(L"hook_method");
+    bool isPdbFirst = (wcscmp(pszHookMethod, L"pdb") == 0);
+    Wh_FreeStringSetting(pszHookMethod); // Free the allocated string.
+    
+    DWORD currentMethodEnum = isPdbFirst ? 0 : 1;
+
+    // 3. [Core Fix]: Check if settings were modified while Word was closed
+    // If the current settings are different from the last settings recorded in the cache, it means the user changed preferences while offline
+    if (g_cacheLoaded && g_cache.lastHookMethod != currentMethodEnum) {
+        Wh_Log(L"[Init] Setting changed while Word was closed. Wiping cache to force re-evaluation.");
+        memset(&g_cache, 0, sizeof(g_cache)); // Clear the cache completely
+        g_cache.lastHookMethod = currentMethodEnum; // Record the new settings
+        SaveCache();
+        // Since the cache has been cleared, subsequent TryFastPathHooks will naturally become invalid
+    } else {
+        // Synchronize as well to ensure the newly generated cache can correctly record the current state
+        g_cache.lastHookMethod = currentMethodEnum;
+    }
+
+    // 2. Ignore user settings; the fast cache path always has highest priority.
+    if (TryFastPathHooks(hMso)) {
+        return;
+    }
+
+
+
+    bool success = false;
+
+    if (isPdbFirst) {
+        Wh_Log(L"[Init] Mode: PDB First");
+        success = RunPdbRoute(hMso);
+        if (!success) {
+            Wh_Log(L"[Init] PDB Route failed, falling back to Pattern Route...");
+            success = RunPatternRoute(hMso);
+        }
+    } else {
+        Wh_Log(L"[Init] Mode: Pattern First");
+        success = RunPatternRoute(hMso);
+        if (!success) {
+            Wh_Log(L"[Init] Pattern Route failed, falling back to PDB Route...");
+            success = RunPdbRoute(hMso);
+        }
+    }
+
+    // 4. Final validation.
+    if (!success) {
+        Wh_Log(L"[Fatal] Both PDB and Pattern hooking failed. Mod will not function.");
+        // If everything fails, reset state to avoid getting stuck in the failure branch next time.
+        g_cache.pdbFailCount = 0;
+        SaveCache();
+        g_bMsoHooked = false; 
+    }
+}
 // =============================================================
 // Intercept LoadLibraryExW to elegantly monitor mso.dll loading
 // =============================================================
@@ -246,7 +521,7 @@ BOOL Wh_ModInit() {
     Wh_Log(L"Word PDF Lossless Export Ultimate Loaded");
 
     if (GetModuleHandleW(L"mso.dll")) {
-        // If already loaded, start thread directly
+        // If already loaded, hook immediately.
         ScanAndHookMso();
     } else {
         // Not loaded yet, hook LoadLibrary to stand guard
@@ -257,3 +532,17 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModUninit() {}
+
+// Listen for setting change callbacks so that switching preferences takes effect immediately
+BOOL Wh_ModSettingsChanged(BOOL* bReload) {
+    Wh_Log(L"[Settings] Preference switched. Wiping cache to force re-evaluation...");
+
+    // Completely clear the entire cache structure (including failure counts and saved offset addresses)
+    memset(&g_cache, 0, sizeof(g_cache));
+
+    // Overwrite local files, equivalent to "formatting" the cache
+    SaveCache();
+
+    *bReload = TRUE; // Tell Windhawk to reload Mod
+    return TRUE;
+}


### PR DESCRIPTION
This pull request significantly enhances the "Word PDF Lossless Export" Windhawk mod by introducing a flexible, robust, and user-configurable hooking mechanism for Microsoft Word's PDF export process. The update provides a new settings interface, improves reliability across Office updates, and offers detailed documentation and guidance for users.

**Major improvements and new features:**

### User Experience & Documentation

- Expanded and reorganized the mod's documentation, including new sections for recommended Word settings, clearer instructions for symbol downloading, and improved visual examples to help users achieve and verify lossless PDF exports.

### Configuration & Settings

- Added a new "Hook Method" option in the mod's settings (`hook_method`), allowing users to choose between "PDB First" (symbol-based, more robust) and "Pattern First" (faster, no PDB required) strategies for function hooking. The mod now automatically falls back to the alternate method if the preferred one fails, and always uses a local cache for performance.

### Reliability & Robustness

- Implemented a unified cache system (`HookStateCache`) to store hook offsets and validation data, ensuring fast and reliable operation even after Office updates. The cache is validated using opcode prefixes and is wiped automatically if settings are changed or if validation fails. [[1]](diffhunk://#diff-1784e67cc8065b2565fdf8007bcdb542709752601879fec3ddae4e7924f19b60L182-R334) [[2]](diffhunk://#diff-1784e67cc8065b2565fdf8007bcdb542709752601879fec3ddae4e7924f19b60R361-R498)

- The mod now listens for settings changes and immediately wipes the cache and reloads itself, ensuring that user preference changes take effect without manual intervention.

### Technical Enhancements

- Refactored the core hooking logic to support both PDB symbol-based and pattern scanning approaches, with robust error handling, logging, and fallback mechanisms. This makes the mod more resilient to Office updates and user environment changes. [[1]](diffhunk://#diff-1784e67cc8065b2565fdf8007bcdb542709752601879fec3ddae4e7924f19b60L182-R334) [[2]](diffhunk://#diff-1784e67cc8065b2565fdf8007bcdb542709752601879fec3ddae4e7924f19b60R361-R498) [[3]](diffhunk://#diff-1784e67cc8065b2565fdf8007bcdb542709752601879fec3ddae4e7924f19b60L249-R524)

**Version bump:**

- Incremented the mod version from 1.1.1 to 1.2.0 to reflect these substantial improvements.
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Added an option to use pattern scanning for hooking. This provides an alternative for specific Office versions where Microsoft has not released PDB symbols.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [x] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
