### PR TITLE
Start button always on the left v1.3

### DIFF
--- a/mods/taskbar-start-button-position.wh.cpp
+++ b/mods/taskbar-start-button-position.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              taskbar-start-button-position
 // @name            Start button always on the left
-// @description     Forces the start button to be on the left of the taskbar, even when taskbar icons are centered (Windows 11 only)
-// @version         1.2.4
+// @description     Forces the Start button to be on the left of the taskbar, even when taskbar icons are centered, with an option to also move the search and task view buttons (Windows 11 only)
+// @version         1.3
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -25,12 +25,19 @@
 /*
 # Start button always on the left
 
-Forces the start button to be on the left of the taskbar, even when taskbar
+Forces the Start button to be on the left of the taskbar, even when taskbar
 icons are centered.
+
+There's also an option to move the search and task view buttons to the left,
+keeping only the app icons centered.
 
 Only Windows 11 is supported.
 
 ![Screenshot](https://i.imgur.com/MSKYKbE.png)
+_Start button on the left_
+
+![Screenshot](https://i.imgur.com/SOdWH1P.png)
+_Start button, search and task view buttons on the left_
 */
 // ==/WindhawkModReadme==
 
@@ -39,7 +46,12 @@ Only Windows 11 is supported.
 - startMenuOnTheLeft: true
   $name: Start menu on the left
   $description: >-
-    Make the start menu open on the left even if taskbar icons are centered
+    Make the start menu open on the left even if taskbar icons are centered.
+- otherSystemButtonsOnTheLeft: false
+  $name: Move other system buttons to the left
+  $description: >-
+    In addition to the start button, also move the search and task view buttons
+    to the left, keeping only the app icons centered.
 */
 // ==/WindhawkModSettings==
 
@@ -64,10 +76,17 @@ Only Windows 11 is supported.
 #include <winrt/Windows.UI.Xaml.h>
 #include <winrt/base.h>
 
+// The taskbar items live in a WinUI 2 (MUX) ItemsRepeater built on top of
+// system XAML. Pull in its projection to enumerate only the realized items
+// (ItemsSourceView / TryGetElement), excluding virtualized cache items.
+#define WH_WINRT_WINUI2
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+
 using namespace winrt::Windows::UI::Xaml;
 
 struct {
     bool startMenuOnTheLeft;
+    bool otherSystemButtonsOnTheLeft;
 } g_settings;
 
 enum class Target {
@@ -81,20 +100,10 @@ std::atomic<bool> g_taskbarViewDllLoaded;
 std::atomic<bool> g_unloading;
 
 thread_local bool g_TaskbarCollapsibleLayoutXamlTraits_ArrangeOverride;
+thread_local bool g_inShowStartButtonContextMenu;
 
 HWND g_searchMenuWnd;
 int g_searchMenuOriginalX;
-
-typedef enum MONITOR_DPI_TYPE {
-    MDT_EFFECTIVE_DPI = 0,
-    MDT_ANGULAR_DPI = 1,
-    MDT_RAW_DPI = 2,
-    MDT_DEFAULT = MDT_EFFECTIVE_DPI
-} MONITOR_DPI_TYPE;
-STDAPI GetDpiForMonitor(HMONITOR hmonitor,
-                        MONITOR_DPI_TYPE dpiType,
-                        UINT* dpiX,
-                        UINT* dpiY);
 
 HWND FindCurrentProcessTaskbarWnd() {
     HWND hTaskbarWnd = nullptr;
@@ -151,6 +160,261 @@ FrameworkElement FindChildByClassName(FrameworkElement element,
     });
 }
 
+// Enumerates the realized children of an ItemsRepeater by index. Unlike walking
+// the visual tree (EnumChildElements), this excludes virtualized cache items,
+// which aren't part of the live layout. Returns the first child for which the
+// callback returns true, or nullptr.
+FrameworkElement EnumRepeaterChildElements(
+    FrameworkElement repeaterElement,
+    std::function<bool(FrameworkElement)> enumCallback) {
+    auto repeater =
+        repeaterElement
+            .try_as<winrt::Microsoft::UI::Xaml::Controls::ItemsRepeater>();
+    if (!repeater) {
+        Wh_Log(L"Not an ItemsRepeater");
+        return nullptr;
+    }
+
+    auto itemsSourceView = repeater.ItemsSourceView();
+    int count = itemsSourceView ? itemsSourceView.Count() : 0;
+
+    for (int index = 0; index < count; index++) {
+        auto element = repeater.TryGetElement(index);
+        if (!element) {
+            // Not realized (virtualized away).
+            continue;
+        }
+
+        auto child = element.try_as<FrameworkElement>();
+        if (!child) {
+            continue;
+        }
+
+        if (enumCallback(child)) {
+            return child;
+        }
+    }
+
+    return nullptr;
+}
+
+// The taskbar system buttons that the mod can pin to the left.
+enum class SystemButton {
+    None,
+    Start,
+    Widgets,
+    Search,
+    TaskView,
+};
+
+// Number of SystemButton values, for sizing arrays indexed by SystemButton.
+constexpr size_t kSystemButtonCount =
+    static_cast<size_t>(SystemButton::TaskView) + 1;
+
+// The left-to-right order of the pinned cluster: start, search, task view,
+// widgets. Returns -1 for items that aren't part of the cluster.
+int SystemButtonClusterRank(SystemButton button) {
+    switch (button) {
+        case SystemButton::None:
+            return -1;
+        case SystemButton::Start:
+            return 0;
+        case SystemButton::Search:
+            return 1;
+        case SystemButton::TaskView:
+            return 2;
+        case SystemButton::Widgets:
+            return 3;
+    }
+}
+
+SystemButton IdentifySystemButton(FrameworkElement element) {
+    auto className = winrt::get_class_name(element);
+
+    if (className == L"Taskbar.ExperienceToggleButton") {
+        auto automationId =
+            Automation::AutomationProperties::GetAutomationId(element);
+        if (automationId == L"StartButton") {
+            return SystemButton::Start;
+        }
+        if (automationId == L"TaskViewButton") {
+            return SystemButton::TaskView;
+        }
+    } else if (className == L"Taskbar.AugmentedEntryPointButton") {
+        if (element.Name() == L"AugmentedEntryPointButton") {
+            return SystemButton::Widgets;
+        }
+    } else if (className == L"Taskbar.TaskbarExtensionElement") {
+        return SystemButton::Search;
+    }
+
+    return SystemButton::None;
+}
+
+// Whether the given button belongs to the left-pinned cluster: the start button
+// always, plus the search and task view buttons when the option is on. The
+// widgets button is pinned separately and isn't part of this set.
+bool IsPinnedClusterButton(SystemButton button) {
+    if (button == SystemButton::Start) {
+        return true;
+    }
+
+    return g_settings.otherSystemButtonsOnTheLeft &&
+           (button == SystemButton::Search || button == SystemButton::TaskView);
+}
+
+// The width of a cluster button. The search button's own ActualWidth is
+// unreliable while collapsed (the negative right margin reinforces its old
+// width), so use its content child's DesiredSize. Start and task view are
+// fixed-width, so ActualWidth is fine.
+double GetClusterButtonWidth(FrameworkElement element) {
+    if (IdentifySystemButton(element) == SystemButton::Search &&
+        Media::VisualTreeHelper::GetChildrenCount(element) > 0) {
+        auto child = Media::VisualTreeHelper::GetChild(element, 0)
+                         .try_as<FrameworkElement>();
+        if (child) {
+            return child.DesiredSize().Width;
+        }
+    }
+
+    return element.ActualWidth();
+}
+
+// The X at which a pinned cluster button goes: the summed widths of the buttons
+// before it in cluster order (start at 0, then search, task view, widgets), so
+// it's independent of the order the layout arranges its children in.
+double ComputePinnedSystemButtonX(FrameworkElement taskbarFrameRepeater,
+                                  SystemButton target) {
+    int targetRank = SystemButtonClusterRank(target);
+    if (targetRank <= 0) {
+        return 0;
+    }
+
+    double x = 0;
+    EnumRepeaterChildElements(
+        taskbarFrameRepeater, [&x, targetRank](FrameworkElement child) {
+            int childRank =
+                SystemButtonClusterRank(IdentifySystemButton(child));
+            if (childRank >= 0 && childRank < targetRank) {
+                x += GetClusterButtonWidth(child);
+            }
+            return false;
+        });
+
+    return x;
+}
+
+// Last GetTickCount64() at which each pinned button was collapsed, to throttle
+// collapses (see UpdatePinnedSystemButtonMargin). Indexed by SystemButton.
+ULONGLONG g_lastButtonCollapseTick[kSystemButtonCount];
+
+// Keeps the pinned cluster (start, plus search and task view when the option is
+// on) from overlapping the centered group: a button collapses out of the layout
+// when there's room and expands to reserve its width when crowded. Expansions
+// are throttled (see below) to avoid oscillation. Runs on the taskbar thread.
+void UpdatePinnedSystemButtonMargin(FrameworkElement element) {
+    SystemButton self = IdentifySystemButton(element);
+    if (g_unloading || !IsPinnedClusterButton(self)) {
+        // Unloading, or the option was turned off after this was scheduled;
+        // ApplyStyle restores the margins.
+        return;
+    }
+
+    auto taskbarFrameRepeater =
+        Media::VisualTreeHelper::GetParent(element).as<FrameworkElement>();
+    if (!taskbarFrameRepeater) {
+        return;
+    }
+
+    // Measure the pinned set's total width and the nearest centered item.
+    double pinnedWidth = 0;
+    double centeredLeftX = std::numeric_limits<double>::infinity();
+    EnumRepeaterChildElements(
+        taskbarFrameRepeater, [&](FrameworkElement child) {
+            SystemButton button = IdentifySystemButton(child);
+            if (IsPinnedClusterButton(button)) {
+                pinnedWidth += GetClusterButtonWidth(child);
+            } else if (button != SystemButton::Widgets) {
+                auto offset = child.ActualOffset();
+                if (offset.x >= 0 && offset.x < centeredLeftX) {
+                    centeredLeftX = offset.x;
+                }
+            }
+            return false;
+        });
+
+    Thickness margin = element.Margin();
+
+    double newRight;
+    if (centeredLeftX < pinnedWidth) {
+        newRight = 0;  // expand: reserve this button's width
+    } else if (margin.Right != 0 || centeredLeftX > pinnedWidth + 44) {
+        newRight =
+            -GetClusterButtonWidth(element);  // collapse out of the group
+    } else {
+        return;  // already collapsed and not crowded
+    }
+
+    if (margin.Right == newRight) {
+        return;
+    }
+
+    if (newRight < margin.Right) {
+        // Collapsing gives up this button's reserved width and shifts the
+        // centered group back, which can immediately make expanding look right
+        // again. Throttle collapses to at most once a second per button so it
+        // settles in the expanded (non-overlapping) state instead of
+        // oscillating.
+        ULONGLONG now = GetTickCount64();
+        ULONGLONG* lastCollapse =
+            &g_lastButtonCollapseTick[static_cast<int>(self)];
+        if (now - *lastCollapse < 1000) {
+            return;
+        }
+        *lastCollapse = now;
+    }
+
+    margin.Right = newRight;
+    element.Margin(margin);
+}
+
+// Pins the widgets button to the right of the start button (or the whole
+// cluster, when the option is on) via its left margin. Windows left-pins it at
+// the far left where the start button goes, so it always needs nudging right.
+// Runs on the taskbar thread.
+void UpdateWidgetLeftMargin(FrameworkElement element) {
+    if (g_unloading) {
+        // ApplyStyle restores the margin on unload; don't fight it.
+        return;
+    }
+
+    auto taskbarFrameRepeater =
+        Media::VisualTreeHelper::GetParent(element).as<FrameworkElement>();
+    if (!taskbarFrameRepeater) {
+        return;
+    }
+
+    double left = g_settings.otherSystemButtonsOnTheLeft
+                      ? ComputePinnedSystemButtonX(taskbarFrameRepeater,
+                                                   SystemButton::Widgets)
+                      : 44;
+
+    Thickness margin = element.Margin();
+    if (margin.Left != left) {
+        margin.Left = left;
+        element.Margin(margin);
+    }
+}
+
+// Runs one of the margin updaters on the taskbar thread, deferred off the
+// current layout pass (changing margins during arrange would re-enter layout).
+void ScheduleOnTaskbarThread(FrameworkElement element,
+                             void (*func)(FrameworkElement)) {
+    element.Dispatcher().TryRunAsync(
+        winrt::Windows::UI::Core::CoreDispatcherPriority::High,
+        [element, func]() { func(element); });
+}
+
 bool ApplyStyle(XamlRoot xamlRoot) {
     FrameworkElement xamlRootContent =
         xamlRoot.Content().try_as<FrameworkElement>();
@@ -169,27 +433,8 @@ bool ApplyStyle(XamlRoot xamlRoot) {
         return false;
     }
 
-    auto startButton =
-        EnumChildElements(taskbarFrameRepeater, [](FrameworkElement child) {
-            auto childClassName = winrt::get_class_name(child);
-            if (childClassName != L"Taskbar.ExperienceToggleButton") {
-                return false;
-            }
-
-            auto automationId =
-                Automation::AutomationProperties::GetAutomationId(child);
-            return automationId == L"StartButton";
-        });
-    if (startButton) {
-        double startButtonWidth = startButton.ActualWidth();
-
-        Thickness startButtonMargin = startButton.Margin();
-        startButtonMargin.Right = g_unloading ? 0 : -startButtonWidth;
-        startButton.Margin(startButtonMargin);
-    }
-
-    auto widgetElement =
-        EnumChildElements(taskbarFrameRepeater, [](FrameworkElement child) {
+    auto widgetElement = EnumRepeaterChildElements(
+        taskbarFrameRepeater, [](FrameworkElement child) {
             auto childClassName = winrt::get_class_name(child);
             if (childClassName != L"Taskbar.AugmentedEntryPointButton") {
                 return false;
@@ -210,9 +455,53 @@ bool ApplyStyle(XamlRoot xamlRoot) {
         });
     if (widgetElement) {
         auto margin = widgetElement.Margin();
-        margin.Left = g_unloading ? 0 : 44;
+        if (g_unloading) {
+            margin.Left = 0;
+        } else if (g_settings.otherSystemButtonsOnTheLeft) {
+            // Pin the widgets button at the end of the cluster, after the task
+            // view button, instead of right after the start button.
+            margin.Left = ComputePinnedSystemButtonX(taskbarFrameRepeater,
+                                                     SystemButton::Widgets);
+        } else {
+            margin.Left = 44;
+        }
         widgetElement.Margin(margin);
     }
+
+    // Collapse the pinned cluster buttons - the start button always, plus the
+    // search and task view buttons when the option is on - so they're excluded
+    // from the centered group; their left positioning happens in
+    // IUIElement_Arrange_Hook. Buttons that aren't pinned, and everything while
+    // unloading, are restored to the centered group.
+    EnumRepeaterChildElements(taskbarFrameRepeater, [](FrameworkElement child) {
+        SystemButton systemButton = IdentifySystemButton(child);
+        switch (systemButton) {
+            case SystemButton::Start:
+            case SystemButton::Search:
+            case SystemButton::TaskView: {
+                Thickness margin = child.Margin();
+                double width = GetClusterButtonWidth(child);
+                if (IsPinnedClusterButton(systemButton) && !g_unloading) {
+                    margin.Right = -width;
+                } else if (margin.Right < 0) {
+                    // Restore only the collapse applied by the mod.
+                    margin.Right = 0;
+                } else {
+                    break;
+                }
+                Wh_Log(
+                    L"Collapsing system button %d: width=%.1f, "
+                    L"margin.Right=%.1f",
+                    (int)systemButton, width, margin.Right);
+                child.Margin(margin);
+                break;
+            }
+            default:
+                break;
+        }
+
+        return false;
+    });
 
     return true;
 }
@@ -238,7 +527,7 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void* taskbarHostSharedPtr[2]) {
         return nullptr;
     }
 
-    size_t taskbarElementIUnknownOffset = 0x48;
+    size_t taskbarElementIUnknownOffset = 0x10;
 
 #if defined(_M_X64)
     {
@@ -253,7 +542,19 @@ XamlRoot XamlRootFromTaskbarHostSharedPtr(void* taskbarHostSharedPtr[2]) {
         }
     }
 #elif defined(_M_ARM64)
-    // Just use the default offset which will hopefully work in most cases.
+    {
+        // 7f2303d5 pacibsp
+        // fd7bbfa9 stp     fp, lr, [sp, #-0x10]!
+        // fd030091 mov     fp, sp
+        // 080c41f8 ldr     x8, [x0, #0x10]!
+        const DWORD* p = (const DWORD*)TaskbarHost_FrameHeight_Original;
+        if (p[0] == 0xD503237F && (p[1] & 0xFFC07FFF) == 0xA9807BFD &&
+            p[2] == 0x910003FD && (p[3] & 0xFFF00FE0) == 0xF8400C00) {
+            taskbarElementIUnknownOffset = (p[3] >> 12) & 0xFF;
+        } else {
+            Wh_Log(L"Unsupported TaskbarHost::FrameHeight");
+        }
+    }
 #else
 #error "Unsupported architecture"
 #endif
@@ -402,7 +703,7 @@ void ApplySettingsFromTaskbarThread() {
             }
 
             if (!ApplyStyle(xamlRoot)) {
-                Wh_Log(L"ApplyStyles failed");
+                Wh_Log(L"ApplyStyle failed");
                 return TRUE;
             }
 
@@ -437,79 +738,53 @@ HRESULT WINAPI IUIElement_Arrange_Hook(void* pThis,
         return original();
     }
 
-    auto className = winrt::get_class_name(element);
-    if (className != L"Taskbar.ExperienceToggleButton") {
+    SystemButton systemButton = IdentifySystemButton(element);
+
+    // The widgets button needs repositioning whether or not the option is on,
+    // so handle it before the pinned-cluster check below.
+    if (systemButton == SystemButton::Widgets) {
+        ScheduleOnTaskbarThread(element, UpdateWidgetLeftMargin);
         return original();
     }
 
-    auto automationId =
-        Automation::AutomationProperties::GetAutomationId(element);
-    if (automationId != L"StartButton") {
+    // The pinned cluster (the start button, plus search and task view when the
+    // option is on) is moved to the left below. Everything else (the app
+    // buttons) is left alone.
+    if (!IsPinnedClusterButton(systemButton)) {
         return original();
     }
 
     auto taskbarFrameRepeater =
         Media::VisualTreeHelper::GetParent(element).as<FrameworkElement>();
-    auto widgetElement =
-        EnumChildElements(taskbarFrameRepeater, [](FrameworkElement child) {
-            auto childClassName = winrt::get_class_name(child);
-            if (childClassName != L"Taskbar.AugmentedEntryPointButton") {
-                return false;
-            }
 
-            if (child.Name() != L"AugmentedEntryPointButton") {
+    // Find the widgets button at its left-pinned position (offset matches its
+    // margin). When present, it sits right of the start button (or cluster) and
+    // anchors it against the centered group.
+    auto widgetElement = EnumRepeaterChildElements(
+        taskbarFrameRepeater, [](FrameworkElement child) {
+            if (IdentifySystemButton(child) != SystemButton::Widgets) {
                 return false;
             }
 
             auto margin = child.Margin();
-
             auto offset = child.ActualOffset();
-            if (offset.x != margin.Left || offset.y != 0) {
-                return false;
-            }
-
-            return true;
+            return offset.x == margin.Left && offset.y == 0;
         });
 
+    // Without that anchor, adjust the margin so the start button (or cluster)
+    // doesn't overlap the centered group.
     if (!widgetElement) {
-        element.Dispatcher().TryRunAsync(
-            winrt::Windows::UI::Core::CoreDispatcherPriority::High,
-            [element]() {
-                double width = element.ActualWidth();
-
-                double minX = std::numeric_limits<double>::infinity();
-                auto taskbarFrameRepeater =
-                    Media::VisualTreeHelper::GetParent(element)
-                        .as<FrameworkElement>();
-                EnumChildElements(taskbarFrameRepeater,
-                                  [&element, &minX](FrameworkElement child) {
-                                      if (child == element) {
-                                          return false;
-                                      }
-
-                                      auto offset = child.ActualOffset();
-                                      if (offset.x >= 0 && offset.x < minX) {
-                                          minX = offset.x;
-                                      }
-
-                                      return false;
-                                  });
-
-                if (minX < width) {
-                    Thickness margin = element.Margin();
-                    margin.Right = 0;
-                    element.Margin(margin);
-                } else if (minX > width * 2) {
-                    Thickness margin = element.Margin();
-                    margin.Right = -width;
-                    element.Margin(margin);
-                }
-            });
+        ScheduleOnTaskbarThread(element, UpdatePinnedSystemButtonMargin);
     }
 
-    // Force the start button to have X = 0.
+    // Pin it to the left in cluster order: the start button gets
+    // X = 0, then search, then task view.
+    double x = ComputePinnedSystemButtonX(taskbarFrameRepeater, systemButton);
+
+    Wh_Log(L"Pinning system button %d to x=%.1f", (int)systemButton, x);
+
     winrt::Windows::Foundation::Rect newRect = rect;
-    newRect.X = 0;
+    newRect.X = x;
     return IUIElement_Arrange_Original(pThis, newRect);
 }
 
@@ -603,37 +878,37 @@ void WINAPI ExperienceToggleButton_UpdateButtonPadding_Hook(void* pThis) {
     }
 }
 
-using AugmentedEntryPointButton_UpdateButtonPadding_t =
-    void(WINAPI*)(void* pThis);
-AugmentedEntryPointButton_UpdateButtonPadding_t
-    AugmentedEntryPointButton_UpdateButtonPadding_Original;
-void WINAPI AugmentedEntryPointButton_UpdateButtonPadding_Hook(void* pThis) {
+// The start button context menu is centered over the start button or aligned
+// to its leading edge depending on the taskbar alignment (TaskbarFrame's
+// Alignment, where Left=0 and Center=1). Both the placement mode and the anchor
+// position are derived from it. With the start button forced to the left, the
+// menu should align to the button's leading edge, so report left alignment
+// while the menu is being shown, letting the taskbar's own left-alignment code
+// position the menu.
+using TaskbarFrame_Alignment_t = int(WINAPI*)(void* pThis);
+TaskbarFrame_Alignment_t TaskbarFrame_Alignment_Original;
+int WINAPI TaskbarFrame_Alignment_Hook(void* pThis) {
+    if (!g_unloading && g_settings.startMenuOnTheLeft &&
+        g_inShowStartButtonContextMenu) {
+        return 0;  // TaskbarAlignment::Left
+    }
+
+    return TaskbarFrame_Alignment_Original(pThis);
+}
+
+// The alignment above is read while the context menu coroutine resumes (after
+// the menu items are fetched asynchronously), not during the initial call, so
+// bracket the override around the whole resume.
+using ShowStartButtonContextMenuResumeCoro_t = void(WINAPI*)(void* coroFrame);
+ShowStartButtonContextMenuResumeCoro_t
+    ShowStartButtonContextMenuResumeCoro_Original;
+void WINAPI ShowStartButtonContextMenuResumeCoro_Hook(void* coroFrame) {
     Wh_Log(L">");
 
-    AugmentedEntryPointButton_UpdateButtonPadding_Original(pThis);
-
-    if (g_unloading) {
-        return;
-    }
-
-    FrameworkElement button = nullptr;
-    ((IUnknown**)pThis)[1]->QueryInterface(winrt::guid_of<FrameworkElement>(),
-                                           winrt::put_abi(button));
-    if (!button) {
-        return;
-    }
-
-    button.Dispatcher().TryRunAsync(
-        winrt::Windows::UI::Core::CoreDispatcherPriority::High, [button]() {
-            auto offset = button.ActualOffset();
-            if (offset.x != 0 || offset.y != 0) {
-                return;
-            }
-
-            auto margin = button.Margin();
-            margin.Left = 44;
-            button.Margin(margin);
-        });
+    bool prev = g_inShowStartButtonContextMenu;
+    g_inShowStartButtonContextMenu = true;
+    ShowStartButtonContextMenuResumeCoro_Original(coroFrame);
+    g_inShowStartButtonContextMenu = prev;
 }
 
 bool HookTaskbarDllSymbols() {
@@ -688,9 +963,14 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
             ExperienceToggleButton_UpdateButtonPadding_Hook,
         },
         {
-            {LR"(protected: virtual void __cdecl winrt::Taskbar::implementation::AugmentedEntryPointButton::UpdateButtonPadding(void))"},
-            &AugmentedEntryPointButton_UpdateButtonPadding_Original,
-            AugmentedEntryPointButton_UpdateButtonPadding_Hook,
+            {LR"(public: enum winrt::WindowsUdk::UI::Shell::TaskbarAlignment __cdecl winrt::Taskbar::implementation::TaskbarFrame::Alignment(void)const )"},
+            &TaskbarFrame_Alignment_Original,
+            TaskbarFrame_Alignment_Hook,
+        },
+        {
+            {LR"(static  winrt::Taskbar::implementation::ContextMenus::ShowStartButtonContextMenuAsync$_ResumeCoro$1())"},
+            &ShowStartButtonContextMenuResumeCoro_Original,
+            ShowStartButtonContextMenuResumeCoro_Hook,
         },
     };
 
@@ -747,13 +1027,50 @@ std::wstring GetProcessFileName(DWORD dwProcessId) {
 
     CloseHandle(hProcess);
 
-    PCWSTR processFileNameUpper = wcsrchr(processPath, L'\\');
-    if (!processFileNameUpper) {
+    PCWSTR processFileName = wcsrchr(processPath, L'\\');
+    if (!processFileName) {
         return std::wstring{};
     }
 
-    processFileNameUpper++;
-    return processFileNameUpper;
+    processFileName++;
+    return processFileName;
+}
+
+bool IsStartMenuOpen() {
+    bool open = false;
+    EnumWindows(
+        [](HWND hWnd, LPARAM lParam) -> BOOL {
+            WCHAR szClassName[32];
+            if (GetClassName(hWnd, szClassName, ARRAYSIZE(szClassName)) == 0 ||
+                _wcsicmp(szClassName, L"Windows.UI.Core.CoreWindow") != 0) {
+                return TRUE;
+            }
+
+            DWORD dwProcessId = 0;
+            if (!GetWindowThreadProcessId(hWnd, &dwProcessId)) {
+                return TRUE;
+            }
+
+            std::wstring processFileName = GetProcessFileName(dwProcessId);
+            if (_wcsicmp(processFileName.c_str(),
+                         L"StartMenuExperienceHost.exe") != 0) {
+                return TRUE;
+            }
+
+            // The start menu window stays cloaked while hidden and is uncloaked
+            // while shown.
+            BOOL cloaked = FALSE;
+            if (SUCCEEDED(DwmGetWindowAttribute(hWnd, DWMWA_CLOAKED, &cloaked,
+                                                sizeof(cloaked))) &&
+                !cloaked) {
+                *(bool*)lParam = true;
+            }
+
+            return FALSE;
+        },
+        (LPARAM)&open);
+
+    return open;
 }
 
 using DwmSetWindowAttribute_t = decltype(&DwmSetWindowAttribute);
@@ -798,10 +1115,6 @@ HRESULT WINAPI DwmSetWindowAttribute_Hook(HWND hwnd,
 
     HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
 
-    UINT monitorDpiX = 96;
-    UINT monitorDpiY = 96;
-    GetDpiForMonitor(monitor, MDT_DEFAULT, &monitorDpiX, &monitorDpiY);
-
     MONITORINFO monitorInfo{
         .cbSize = sizeof(MONITORINFO),
     };
@@ -818,6 +1131,15 @@ HRESULT WINAPI DwmSetWindowAttribute_Hook(HWND hwnd,
     int cy = targetRect.bottom - targetRect.top;
 
     if (target == DwmTarget::SearchHost) {
+        if (!IsStartMenuOpen()) {
+            // Win+S or the search bar on the taskbar cause the search menu to
+            // be repositioned. Don't customize it and restore the original
+            // position.
+            g_searchMenuWnd = nullptr;
+            g_searchMenuOriginalX = 0;
+            return original();
+        }
+
         // Only change x.
         int xNew;
 
@@ -854,14 +1176,14 @@ HRESULT WINAPI DwmSetWindowAttribute_Hook(HWND hwnd,
 
 namespace StartMenuUI {
 
-bool g_applyStylePending;
 bool g_inApplyStyle;
 std::optional<double> g_previousCanvasLeft;
 winrt::weak_ref<DependencyObject> g_startSizingFrameWeakRef;
 int64_t g_canvasTopPropertyChangedToken;
 int64_t g_canvasLeftPropertyChangedToken;
 std::optional<HorizontalAlignment> g_previousHorizontalAlignment;
-winrt::event_token g_layoutUpdatedToken;
+winrt::weak_ref<DependencyObject> g_frameRootWeakRef;
+int64_t g_horizontalAlignmentPropertyChangedToken;
 winrt::event_token g_visibilityChangedToken;
 
 HWND GetCoreWnd() {
@@ -984,6 +1306,25 @@ void ApplyStyleRedesignedStartMenu(FrameworkElement content) {
         }
 
         frameRoot.HorizontalAlignment(HorizontalAlignment::Left);
+
+        if (!g_frameRootWeakRef.get()) {
+            auto frameRootDo = frameRoot.as<DependencyObject>();
+
+            g_frameRootWeakRef = frameRootDo;
+
+            g_horizontalAlignmentPropertyChangedToken =
+                frameRootDo.RegisterPropertyChangedCallback(
+                    FrameworkElement::HorizontalAlignmentProperty(),
+                    [](DependencyObject sender, DependencyProperty property) {
+                        auto alignment =
+                            sender.as<FrameworkElement>().HorizontalAlignment();
+                        Wh_Log(L"FrameRoot HorizontalAlignment changed to %d",
+                               static_cast<int>(alignment));
+                        if (!g_inApplyStyle) {
+                            ApplyStyle();
+                        }
+                    });
+        }
     }
 }
 
@@ -1013,7 +1354,7 @@ void ApplyStyle() {
 }
 
 void Init() {
-    if (g_layoutUpdatedToken) {
+    if (g_visibilityChangedToken) {
         return;
     }
 
@@ -1022,29 +1363,11 @@ void Init() {
         return;
     }
 
-    if (!g_visibilityChangedToken) {
-        g_visibilityChangedToken = window.VisibilityChanged(
-            [](winrt::Windows::Foundation::IInspectable const& sender,
-               winrt::Windows::UI::Core::VisibilityChangedEventArgs const&
-                   args) {
-                Wh_Log(L"Window visibility changed: %d", args.Visible());
-                if (args.Visible()) {
-                    g_applyStylePending = true;
-                }
-            });
-    }
-
-    auto contentUI = window.Content();
-    if (!contentUI) {
-        return;
-    }
-
-    auto content = contentUI.as<FrameworkElement>();
-    g_layoutUpdatedToken = content.LayoutUpdated(
-        [](winrt::Windows::Foundation::IInspectable const&,
-           winrt::Windows::Foundation::IInspectable const&) {
-            if (g_applyStylePending) {
-                g_applyStylePending = false;
+    g_visibilityChangedToken = window.VisibilityChanged(
+        [](winrt::Windows::Foundation::IInspectable const& sender,
+           winrt::Windows::UI::Core::VisibilityChangedEventArgs const& args) {
+            Wh_Log(L"Window visibility changed: %d", args.Visible());
+            if (args.Visible()) {
                 ApplyStyle();
             }
         });
@@ -1053,7 +1376,7 @@ void Init() {
 }
 
 void Uninit() {
-    if (!g_layoutUpdatedToken) {
+    if (!g_visibilityChangedToken) {
         return;
     }
 
@@ -1062,19 +1385,8 @@ void Uninit() {
         return;
     }
 
-    if (g_visibilityChangedToken) {
-        window.VisibilityChanged(g_visibilityChangedToken);
-        g_visibilityChangedToken = {};
-    }
-
-    auto contentUI = window.Content();
-    if (!contentUI) {
-        return;
-    }
-
-    auto content = contentUI.as<FrameworkElement>();
-    content.LayoutUpdated(g_layoutUpdatedToken);
-    g_layoutUpdatedToken = {};
+    window.VisibilityChanged(g_visibilityChangedToken);
+    g_visibilityChangedToken = {};
 
     auto startSizingFrameDo = g_startSizingFrameWeakRef.get();
     if (startSizingFrameDo) {
@@ -1094,6 +1406,18 @@ void Uninit() {
     }
 
     g_startSizingFrameWeakRef = nullptr;
+
+    auto frameRootDo = g_frameRootWeakRef.get();
+    if (frameRootDo) {
+        if (g_horizontalAlignmentPropertyChangedToken) {
+            frameRootDo.UnregisterPropertyChangedCallback(
+                FrameworkElement::HorizontalAlignmentProperty(),
+                g_horizontalAlignmentPropertyChangedToken);
+            g_horizontalAlignmentPropertyChangedToken = 0;
+        }
+    }
+
+    g_frameRootWeakRef = nullptr;
 
     ApplyStyle();
 }
@@ -1159,6 +1483,8 @@ void RestoreMenuPositions() {
 
 void LoadSettings() {
     g_settings.startMenuOnTheLeft = Wh_GetIntSetting(L"startMenuOnTheLeft");
+    g_settings.otherSystemButtonsOnTheLeft =
+        Wh_GetIntSetting(L"otherSystemButtonsOnTheLeft");
 }
 
 BOOL Wh_ModInit() {
@@ -1174,7 +1500,7 @@ BOOL Wh_ModInit() {
         case 0:
         case ARRAYSIZE(moduleFilePath):
             Wh_Log(L"GetModuleFileName failed");
-            break;
+            return FALSE;
 
         default:
             if (PCWSTR moduleFileName = wcsrchr(moduleFilePath, L'\\')) {
@@ -1185,6 +1511,7 @@ BOOL Wh_ModInit() {
                 }
             } else {
                 Wh_Log(L"GetModuleFileName returned an unsupported path");
+                return FALSE;
             }
             break;
     }
@@ -1310,7 +1637,12 @@ BOOL Wh_ModSettingsChanged(BOOL* bReload) {
 
     LoadSettings();
 
-    if (g_target == Target::StartMenuExperienceHost) {
+    if (g_target == Target::Explorer) {
+        HWND hTaskbarWnd = FindCurrentProcessTaskbarWnd();
+        if (hTaskbarWnd) {
+            ApplySettings(hTaskbarWnd);
+        }
+    } else if (g_target == Target::StartMenuExperienceHost) {
         if (!g_settings.startMenuOnTheLeft) {
             return FALSE;
         }


### PR DESCRIPTION
* Added an option to move the search and task view buttons to the left.
* Various improvements for multiple monitors and other scenarios.