### PR TITLE
Add Taskbar Restart Explorer mod

### DIFF
--- a/mods/taskbar-restart-explorer.wh.cpp
+++ b/mods/taskbar-restart-explorer.wh.cpp
@@ -1,0 +1,422 @@
+// ==WindhawkMod==
+// @id              taskbar-restart-explorer
+// @name            Taskbar Restart Explorer
+// @description     Adds a Restart Explorer shortcut to the native Windows 11 empty-taskbar context menu.
+// @version         1.0
+// @author          https://github.com/Mgrmjp
+// @github          https://github.com/Mgrmjp
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lversion
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+Adds a Restart Explorer shortcut to the native rounded Windows 11 empty-taskbar
+context menu.
+
+This version hooks the taskbar settings context-menu build path in the actually
+loaded Taskbar.View.dll/ExplorerExtensions.dll module. It doesn't replace the
+classic popup menu, install global mouse hooks, or show a separate flyout.
+
+Demo:
+![Taskbar Restart Explorer demo](https://i.imgur.com/JrLPgxo.gif)
+
+If the required symbols aren't available, the mod logs why and fails closed.
+*/
+// ==/WindhawkModReadme==
+
+#include <windhawk_utils.h>
+
+#include <windows.h>
+#include <winver.h>
+
+#undef GetCurrentTime
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Input.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/base.h>
+
+#include <atomic>
+#include <string_view>
+
+namespace wf = winrt::Windows::Foundation;
+namespace wux = winrt::Windows::UI::Xaml;
+namespace wuxc = winrt::Windows::UI::Xaml::Controls;
+namespace wuxi = winrt::Windows::UI::Xaml::Input;
+namespace wuxm = winrt::Windows::UI::Xaml::Media;
+
+static constexpr wchar_t kRestartExplorerText[] = L"Restart Explorer";
+static constexpr wchar_t kItemName[] = L"WindhawkRestartExplorerItem";
+static constexpr wchar_t kSeparatorName[] = L"WindhawkRestartExplorerSeparator";
+
+std::atomic<bool> g_taskbarViewModuleHooked = false;
+std::atomic<bool> g_restartStarted = false;
+
+thread_local int g_taskbarSettingsMenuDepth = 0;
+thread_local bool g_currentMenuInjected = false;
+
+bool HStringEquals(winrt::hstring const& value, const wchar_t* text) {
+    return std::wstring_view(value.c_str(), value.size()) == text;
+}
+
+bool IsNamedItem(wuxc::MenuFlyoutItemBase const& baseItem,
+                 const wchar_t* name) {
+    try {
+        if (auto frameworkElement = baseItem.try_as<wux::FrameworkElement>()) {
+            return HStringEquals(frameworkElement.Name(), name);
+        }
+    } catch (...) {
+    }
+
+    return false;
+}
+
+bool IsSeparator(wuxc::MenuFlyoutItemBase const& baseItem) {
+    try {
+        return !!baseItem.try_as<wuxc::MenuFlyoutSeparator>();
+    } catch (...) {
+    }
+
+    return false;
+}
+
+bool RunDetachedCommandLine(wchar_t* commandLine) {
+    STARTUPINFOW si = {};
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESHOWWINDOW;
+    si.wShowWindow = SW_HIDE;
+
+    PROCESS_INFORMATION pi = {};
+
+    if (!CreateProcessW(nullptr, commandLine, nullptr, nullptr, FALSE,
+                        CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP, nullptr,
+                        nullptr, &si, &pi)) {
+        Wh_Log(L"CreateProcessW restart command failed: %lu", GetLastError());
+        return false;
+    }
+
+    CloseHandle(pi.hThread);
+    CloseHandle(pi.hProcess);
+    return true;
+}
+
+void RestartExplorer() {
+    if (g_restartStarted.exchange(true)) {
+        Wh_Log(L"Restart Explorer skipped: restart already started");
+        return;
+    }
+
+    Wh_Log(L"Restart Explorer clicked");
+
+    wchar_t commandLine[] =
+        L"cmd.exe /d /c \"taskkill /f /im explorer.exe >nul 2>nul & start \"\" explorer.exe\"";
+
+    if (!RunDetachedCommandLine(commandLine)) {
+        g_restartStarted = false;
+    }
+}
+
+void OnRestartExplorerClick(wf::IInspectable const&,
+                            wux::RoutedEventArgs const&) {
+    RestartExplorer();
+}
+
+using MenuFlyoutItemBaseVector_Append_t =
+    void(__cdecl*)(void* pThis, wuxc::MenuFlyoutItemBase const& item);
+MenuFlyoutItemBaseVector_Append_t MenuFlyoutItemBaseVector_Append_Original;
+
+void AppendInjectedItems(void* vectorThis) {
+    wuxc::MenuFlyoutItem item;
+    item.Name(kItemName);
+    item.Tag(winrt::box_value(winrt::hstring{kItemName}));
+    item.Text(kRestartExplorerText);
+
+    wuxc::FontIcon icon;
+    icon.FontFamily(wuxm::FontFamily(L"Segoe Fluent Icons"));
+    icon.Glyph(L"\xE72C");
+    icon.FontSize(16);
+    item.Icon(icon);
+
+    item.Click(wux::RoutedEventHandler{&OnRestartExplorerClick});
+
+    wuxc::MenuFlyoutSeparator separator;
+    separator.Name(kSeparatorName);
+    separator.Tag(winrt::box_value(winrt::hstring{kSeparatorName}));
+
+    MenuFlyoutItemBaseVector_Append_Original(vectorThis, item);
+    MenuFlyoutItemBaseVector_Append_Original(vectorThis, separator);
+
+    g_currentMenuInjected = true;
+    Wh_Log(L"Injected Restart Explorer into taskbar context menu");
+}
+
+void __cdecl MenuFlyoutItemBaseVector_Append_Hook(
+    void* pThis,
+    wuxc::MenuFlyoutItemBase const& item) {
+    if (g_taskbarSettingsMenuDepth > 0 && !g_currentMenuInjected) {
+        try {
+            if (!IsSeparator(item) &&
+                !IsNamedItem(item, kItemName) &&
+                !IsNamedItem(item, kSeparatorName)) {
+                AppendInjectedItems(pThis);
+            }
+        } catch (...) {
+            Wh_Log(L"Taskbar menu append inspection failed; skipping injection");
+        }
+    }
+
+    MenuFlyoutItemBaseVector_Append_Original(pThis, item);
+}
+
+struct ScopedTaskbarSettingsMenuBuild {
+    bool outer = false;
+
+    ScopedTaskbarSettingsMenuBuild() {
+        outer = g_taskbarSettingsMenuDepth++ == 0;
+        if (outer) {
+            g_currentMenuInjected = false;
+        }
+    }
+
+    ~ScopedTaskbarSettingsMenuBuild() {
+        if (outer && !g_currentMenuInjected) {
+            Wh_Log(L"Skipping injection: no menu item append observed");
+        }
+
+        g_taskbarSettingsMenuDepth--;
+    }
+};
+
+using ContextMenus_ShowTaskbarSettingsContextMenu_t =
+    void(__cdecl*)(wux::FrameworkElement const& target,
+                   void* taskbarSettings,
+                   wuxi::ContextRequestedEventArgs const& args,
+                   unsigned long long options);
+ContextMenus_ShowTaskbarSettingsContextMenu_t
+    ContextMenus_ShowTaskbarSettingsContextMenu_Original;
+
+void __cdecl ContextMenus_ShowTaskbarSettingsContextMenu_Hook(
+    wux::FrameworkElement const& target,
+    void* taskbarSettings,
+    wuxi::ContextRequestedEventArgs const& args,
+    unsigned long long options) {
+    ScopedTaskbarSettingsMenuBuild scopedBuild;
+
+    ContextMenus_ShowTaskbarSettingsContextMenu_Original(
+        target, taskbarSettings, args, options);
+}
+
+using RtlGetVersion_t = LONG(WINAPI*)(OSVERSIONINFOW* versionInfo);
+
+DWORD GetWindowsBuild() {
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    auto rtlGetVersion = ntdll ? reinterpret_cast<RtlGetVersion_t>(
+                                     GetProcAddress(ntdll, "RtlGetVersion"))
+                               : nullptr;
+    if (!rtlGetVersion) {
+        return 0;
+    }
+
+    OSVERSIONINFOW versionInfo = {};
+    versionInfo.dwOSVersionInfoSize = sizeof(versionInfo);
+
+    if (rtlGetVersion(&versionInfo) != 0) {
+        return 0;
+    }
+
+    Wh_Log(L"Windows version: %lu.%lu.%lu", versionInfo.dwMajorVersion,
+           versionInfo.dwMinorVersion, versionInfo.dwBuildNumber);
+
+    return versionInfo.dwBuildNumber;
+}
+
+VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE module) {
+    void* fixedFileInfo = nullptr;
+    UINT len = 0;
+
+    HRSRC resource =
+        FindResourceW(module, MAKEINTRESOURCEW(VS_VERSION_INFO), RT_VERSION);
+    if (resource) {
+        HGLOBAL global = LoadResource(module, resource);
+        if (global) {
+            void* data = LockResource(global);
+            if (data) {
+                if (!VerQueryValueW(data, L"\\", &fixedFileInfo, &len) ||
+                    len == 0) {
+                    fixedFileInfo = nullptr;
+                }
+            }
+        }
+    }
+
+    return static_cast<VS_FIXEDFILEINFO*>(fixedFileInfo);
+}
+
+void LogModuleInfo(HMODULE module, const wchar_t* reason) {
+    wchar_t path[MAX_PATH] = {};
+    GetModuleFileNameW(module, path, ARRAYSIZE(path));
+
+    const wchar_t* moduleName = wcsrchr(path, L'\\');
+    moduleName = moduleName ? moduleName + 1 : path;
+
+    VS_FIXEDFILEINFO* versionInfo = GetModuleVersionInfo(module);
+    if (versionInfo) {
+        Wh_Log(L"%s module=%s path=%s version=%u.%u.%u.%u", reason,
+               moduleName, path, HIWORD(versionInfo->dwFileVersionMS),
+               LOWORD(versionInfo->dwFileVersionMS),
+               HIWORD(versionInfo->dwFileVersionLS),
+               LOWORD(versionInfo->dwFileVersionLS));
+    } else {
+        Wh_Log(L"%s module=%s path=%s version=<unavailable>", reason,
+               moduleName, path);
+    }
+}
+
+HMODULE GetTaskbarViewModuleHandle() {
+    HMODULE module = GetModuleHandleW(L"Taskbar.View.dll");
+    if (!module) {
+        module = GetModuleHandleW(L"ExplorerExtensions.dll");
+    }
+
+    return module;
+}
+
+bool HookTaskbarViewDllSymbols(HMODULE module) {
+    LogModuleInfo(module, L"Resolving taskbar symbols");
+
+    WindhawkUtils::SYMBOL_HOOK requiredHooks[] = {
+        {
+            {
+                LR"(void __cdecl winrt::Taskbar::implementation::ContextMenus::ShowTaskbarSettingsContextMenu(struct winrt::Windows::UI::Xaml::FrameworkElement const &,struct winrt::WindowsUdk::UI::Shell::TaskbarSettings const &,struct winrt::Windows::UI::Xaml::Input::ContextRequestedEventArgs const &,unsigned __int64))",
+                LR"(?ShowTaskbarSettingsContextMenu@ContextMenus@implementation@Taskbar@winrt@@YAXAEBUFrameworkElement@Xaml@UI@Windows@4@AEBUTaskbarSettings@Shell@7WindowsUdk@4@AEBUContextRequestedEventArgs@Input@6784@_K@Z)",
+            },
+            &ContextMenus_ShowTaskbarSettingsContextMenu_Original,
+            ContextMenus_ShowTaskbarSettingsContextMenu_Hook,
+        },
+        {
+            {
+                LR"(public: __cdecl winrt::impl::consume_Windows_Foundation_Collections_IVector<struct winrt::Windows::Foundation::Collections::IVector<struct winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase>,struct winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase>::Append(struct winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase const &)const )",
+                LR"(?Append@?$consume_Windows_Foundation_Collections_IVector@U?$IVector@UMenuFlyoutItemBase@Controls@Xaml@UI@Windows@winrt@@@Collections@Foundation@Windows@winrt@@UMenuFlyoutItemBase@Controls@Xaml@UI@45@@impl@winrt@@QEBA@AEBUMenuFlyoutItemBase@Controls@Xaml@UI@Windows@3@@Z)",
+            },
+            &MenuFlyoutItemBaseVector_Append_Original,
+            MenuFlyoutItemBaseVector_Append_Hook,
+        },
+    };
+
+    if (!HookSymbols(module, requiredHooks, ARRAYSIZE(requiredHooks))) {
+        Wh_Log(L"Skipping injection: missing symbols");
+        return false;
+    }
+
+    Wh_Log(L"Hook installed: ContextMenus::ShowTaskbarSettingsContextMenu");
+    Wh_Log(L"Hook installed: IVector<MenuFlyoutItemBase>::Append");
+
+    return true;
+}
+
+void HandleLoadedModuleIfTaskbarView(HMODULE module,
+                                     LPCWSTR loadedFileName,
+                                     bool applyHookOperations) {
+    if (!module || g_taskbarViewModuleHooked) {
+        return;
+    }
+
+    if (GetTaskbarViewModuleHandle() != module) {
+        return;
+    }
+
+    if (g_taskbarViewModuleHooked.exchange(true)) {
+        return;
+    }
+
+    Wh_Log(L"Taskbar module loaded via LoadLibraryExW: %s",
+           loadedFileName ? loadedFileName : L"<null>");
+
+    if (HookTaskbarViewDllSymbols(module)) {
+        if (applyHookOperations) {
+            Wh_ApplyHookOperations();
+        }
+    } else {
+        Wh_Log(L"Skipping injection: unsupported build or missing symbols");
+    }
+}
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t LoadLibraryExW_Original;
+
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
+                                   HANDLE hFile,
+                                   DWORD dwFlags) {
+    HMODULE module = LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
+
+    if (module) {
+        HandleLoadedModuleIfTaskbarView(module, lpLibFileName, true);
+    }
+
+    return module;
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"Init");
+
+    DWORD build = GetWindowsBuild();
+    if (build && build < 22000) {
+        Wh_Log(L"Skipping injection: unsupported build %lu", build);
+        return TRUE;
+    }
+
+    if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
+        g_taskbarViewModuleHooked = true;
+        if (!HookTaskbarViewDllSymbols(taskbarViewModule)) {
+            Wh_Log(L"Skipping injection: missing symbols");
+            return TRUE;
+        }
+    } else {
+        Wh_Log(L"Taskbar view module not loaded yet");
+    }
+
+    HMODULE kernelBase = GetModuleHandleW(L"kernelbase.dll");
+    auto loadLibraryExW = kernelBase ? reinterpret_cast<LoadLibraryExW_t>(
+                                          GetProcAddress(kernelBase,
+                                                         "LoadLibraryExW"))
+                                    : nullptr;
+    if (!loadLibraryExW) {
+        Wh_Log(L"LoadLibraryExW not found; hook not installed");
+        return TRUE;
+    }
+
+    if (WindhawkUtils::SetFunctionHook(loadLibraryExW, LoadLibraryExW_Hook,
+                                       &LoadLibraryExW_Original)) {
+        Wh_Log(L"Hook installed: LoadLibraryExW");
+    } else {
+        Wh_Log(L"LoadLibraryExW hook install failed");
+    }
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    Wh_Log(L"AfterInit");
+
+    if (!g_taskbarViewModuleHooked) {
+        if (HMODULE taskbarViewModule = GetTaskbarViewModuleHandle()) {
+            if (!g_taskbarViewModuleHooked.exchange(true)) {
+                Wh_Log(L"Taskbar view module found after init");
+
+                if (HookTaskbarViewDllSymbols(taskbarViewModule)) {
+                    Wh_ApplyHookOperations();
+                } else {
+                    Wh_Log(L"Skipping injection: missing symbols");
+                }
+            }
+        }
+    }
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"Uninit");
+}

--- a/mods/taskbar-restart-explorer.wh.cpp
+++ b/mods/taskbar-restart-explorer.wh.cpp
@@ -3,7 +3,7 @@
 // @name            Taskbar Restart Explorer
 // @description     Adds a Restart Explorer shortcut to the native Windows 11 empty-taskbar context menu.
 // @version         1.0
-// @author          https://github.com/Mgrmjp
+// @author          Mgrmjp
 // @github          https://github.com/Mgrmjp
 // @include         explorer.exe
 // @architecture    x86-64
@@ -288,11 +288,11 @@ HMODULE GetTaskbarViewModuleHandle() {
 bool HookTaskbarViewDllSymbols(HMODULE module) {
     LogModuleInfo(module, L"Resolving taskbar symbols");
 
-    WindhawkUtils::SYMBOL_HOOK requiredHooks[] = {
+    // Taskbar.View.dll, ExplorerExtensions.dll
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {
                 LR"(void __cdecl winrt::Taskbar::implementation::ContextMenus::ShowTaskbarSettingsContextMenu(struct winrt::Windows::UI::Xaml::FrameworkElement const &,struct winrt::WindowsUdk::UI::Shell::TaskbarSettings const &,struct winrt::Windows::UI::Xaml::Input::ContextRequestedEventArgs const &,unsigned __int64))",
-                LR"(?ShowTaskbarSettingsContextMenu@ContextMenus@implementation@Taskbar@winrt@@YAXAEBUFrameworkElement@Xaml@UI@Windows@4@AEBUTaskbarSettings@Shell@7WindowsUdk@4@AEBUContextRequestedEventArgs@Input@6784@_K@Z)",
             },
             &ContextMenus_ShowTaskbarSettingsContextMenu_Original,
             ContextMenus_ShowTaskbarSettingsContextMenu_Hook,
@@ -300,14 +300,13 @@ bool HookTaskbarViewDllSymbols(HMODULE module) {
         {
             {
                 LR"(public: __cdecl winrt::impl::consume_Windows_Foundation_Collections_IVector<struct winrt::Windows::Foundation::Collections::IVector<struct winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase>,struct winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase>::Append(struct winrt::Windows::UI::Xaml::Controls::MenuFlyoutItemBase const &)const )",
-                LR"(?Append@?$consume_Windows_Foundation_Collections_IVector@U?$IVector@UMenuFlyoutItemBase@Controls@Xaml@UI@Windows@winrt@@@Collections@Foundation@Windows@winrt@@UMenuFlyoutItemBase@Controls@Xaml@UI@45@@impl@winrt@@QEBA@AEBUMenuFlyoutItemBase@Controls@Xaml@UI@Windows@3@@Z)",
             },
             &MenuFlyoutItemBaseVector_Append_Original,
             MenuFlyoutItemBaseVector_Append_Hook,
         },
     };
 
-    if (!HookSymbols(module, requiredHooks, ARRAYSIZE(requiredHooks))) {
+    if (!HookSymbols(module, symbolHooks, ARRAYSIZE(symbolHooks))) {
         Wh_Log(L"Skipping injection: missing symbols");
         return false;
     }


### PR DESCRIPTION
Adds a Windhawk mod that inserts a Restart Explorer item into the native Windows 11 empty-taskbar context menu by hooking the taskbar context-menu build path.

Validation:
- Windhawk clang syntax check passed.

## Changelog

New mod: Taskbar Restart Explorer.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [x] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.