### PR TITLE
Update Perform Speed Test Redirect to v1.3.0

### DIFF
--- a/mods/perform-speedtest-redirect.wh.cpp
+++ b/mods/perform-speedtest-redirect.wh.cpp
@@ -5,6 +5,8 @@
 // @version         1.3.0
 // @author          mynameistito
 // @github          https://github.com/mynameistito
+// @twitter         https://x.com/mynameistito
+// @homepage        https://mynameistito.com
 // @license         MIT
 // @include         explorer.exe
 // @include         ShellExperienceHost.exe
@@ -18,7 +20,7 @@
 /*
 # Perform Speed Test Redirect
 
-![PSR Image](https://raw.githubusercontent.com/mynameistito/windhawk-perform-speedtest/refs/heads/main/psr.png)
+![PSR Image](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/perform-speedtest-redirect/psr.png)
 
 When you right-click the network icon in the Windows taskbar and click
 **"Perform speed test"**, Windows normally launches the browser to:

--- a/mods/perform-speedtest-redirect.wh.cpp
+++ b/mods/perform-speedtest-redirect.wh.cpp
@@ -20,7 +20,7 @@
 /*
 # Perform Speed Test Redirect
 
-![PSR Image](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/perform-speedtest-redirect/psr.png)
+![PSR Image](https://raw.githubusercontent.com/mynameistito/windhawk-perform-speedtest/refs/heads/main/psr.png)
 
 When you right-click the network icon in the Windows taskbar and click
 **"Perform speed test"**, Windows normally launches the browser to:

--- a/mods/perform-speedtest-redirect.wh.cpp
+++ b/mods/perform-speedtest-redirect.wh.cpp
@@ -5,6 +5,8 @@
 // @version         1.3.0
 // @author          mynameistito
 // @github          https://github.com/mynameistito
+// @twitter         https://x.com/mynameistito
+// @homepage        https://mynameistito.com
 // @license         MIT
 // @include         explorer.exe
 // @include         ShellExperienceHost.exe

--- a/mods/perform-speedtest-redirect.wh.cpp
+++ b/mods/perform-speedtest-redirect.wh.cpp
@@ -5,8 +5,6 @@
 // @version         1.3.0
 // @author          mynameistito
 // @github          https://github.com/mynameistito
-// @twitter         https://x.com/mynameistito
-// @homepage        https://mynameistito.com
 // @license         MIT
 // @include         explorer.exe
 // @include         ShellExperienceHost.exe
@@ -20,7 +18,7 @@
 /*
 # Perform Speed Test Redirect
 
-![PSR Image](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/perform-speedtest-redirect/psr.png)
+![PSR Image](https://raw.githubusercontent.com/mynameistito/windhawk-perform-speedtest/refs/heads/main/psr.png)
 
 When you right-click the network icon in the Windows taskbar and click
 **"Perform speed test"**, Windows normally launches the browser to:

--- a/mods/perform-speedtest-redirect.wh.cpp
+++ b/mods/perform-speedtest-redirect.wh.cpp
@@ -2,12 +2,13 @@
 // @id              perform-speedtest-redirect
 // @name            Perform Speed Test Redirect
 // @description     Redirects the "Perform speed test" link in the taskbar network right-click menu from the default Microsoft page to a custom URL (defaults to speedtest.net).
-// @version         1.2.2
+// @version         1.3.0
 // @author          mynameistito
 // @github          https://github.com/mynameistito
 // @license         MIT
 // @include         explorer.exe
 // @include         ShellExperienceHost.exe
+// @include         ShellHost.exe
 // @include         RuntimeBroker.exe
 // @architecture    x86-64
 // @compilerOptions -lshell32 -lkernel32
@@ -17,58 +18,127 @@
 /*
 # Perform Speed Test Redirect
 
+![PSR Image](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/perform-speedtest-redirect/psr.png)
+
 When you right-click the network icon in the Windows taskbar and click
-**"Perform speed test"**, Windows normally opens:
+**"Perform speed test"**, Windows normally launches the browser to:
 
 ```
 https://go.microsoft.com/fwlink/?linkid=2324916
 ```
 
-This mod intercepts that URL and replaces it with a URL of your choice.
-By default it redirects to **https://www.speedtest.net** (or any URL you set).
+This mod can either:
+1. Replace that URL, or
+2. Let you execute a command of your choice instead.
+
+By default, it redirects the URL to **https://www.speedtest.net**.
 
 ## Settings
 
-- **Redirect URL** – the URL to open instead of the default Microsoft speed
+### Command execution mode
+
+Controls what the mod does after detecting the speed-test launch.
+
+- **Disabled**: URL replacement mode.
+- **Enabled**: command execution mode.
+
+### Action text
+
+- **URL Replacement Mode** – the URL to open instead of the default Microsoft speed
   test link. Change this to any speed test site you prefer, e.g.
   `https://fast.com` or `https://cloudflare.com/speed`.
 
+- **Command execution mode** - the full command line or URL to run. Examples:
+
+    ```https://www.speedtest.net/```
+
+    ```explorer.exe shell:AppsFolder\Ookla.SpeedtestbyOokla_43tkc6nmykmb6!App```
+
+### Target substrings
+
+A list of substrings to detect inside the launched command line. Default entries:
+
+`linkid=2324916`
+
+`linkid=2325015`
+
+Feel free to add more entries here if Microsoft ever changes them.
+
 ## How it works
 
-Hooks `ShellExecuteW`, `ShellExecuteExW`, and `CreateProcessW` across
-`explorer.exe`, `ShellExperienceHost.exe`, and `RuntimeBroker.exe` —
-covering every known code path Windows uses to open the speed test URL.
+The mod hooks `CreateProcessW` in shell-related processes such as:
+
+- `explorer.exe`
+- `ShellExperienceHost.exe`
+- `ShellHost.exe`
+- `RuntimeBroker.exe`
+
+When a process launch attempt contains one of the configured target substrings, the mod partially / fully redirects that launch.
+
+The original launch is left untouched when none of the configured substrings match.
 */
 // ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
 /*
-- redirectUrl: "https://www.speedtest.net/"
-  $name: Redirect URL
-  $description: The URL to open instead of the default Microsoft speed test link.
+- commandMode: false
+  $name: Command execution mode
+  $description: If disabled, replace the URL. If enabled, execute Action text as a command line.
+
+- actionText: "https://www.speedtest.net/"
+  $name: Action text
+  $description: In URL mode, this is the redirected URL. In command mode, this is the full command to execute.
+
+- targetSubstrings:
+  - linkid=2324916
+  - linkid=2325015
+  $name: Target substrings
+  $description: Extra substrings to detect in the Microsoft URL. E.g. "...microsoft.com/fwlink/?linkid=2325015".  Add URL fragments here if they are changed.
 */
 // ==/WindhawkModSettings==
 
 #include <windows.h>
 #include <shellapi.h>
+#include <cwctype>
 #include <string>
+#include <vector>
 
-#define LINK_ID L"linkid=2324916"
 #define LOG(fmt, ...) Wh_Log(L"[speedtest] " fmt, ##__VA_ARGS__)
+
+static bool g_commandMode = false;
+static std::wstring g_actionText;
+static std::vector<std::wstring> g_targetSubstrings;
+static SRWLOCK g_settingsLock = SRWLOCK_INIT;
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-static bool HasLinkId(LPCWSTR s) {
-    return s && wcsstr(s, LINK_ID);
+static bool HasLinkId(LPCWSTR s, const std::vector<std::wstring>& targetSubstrings) {
+    if (!s) return false;
+
+    for (const auto & sstr : targetSubstrings){
+        if (wcsstr(s, sstr.c_str())) return true;
+    }
+    return false;
 }
 
-// Replace the full URL that contains LINK_ID with redirectUrl.
-// Returns the modified string, or empty if LINK_ID not found.
-static std::wstring ReplaceUrl(LPCWSTR src) {
+// Replace the full URL that contains a configured target substring with actionText.
+// Returns the modified string, or empty if no target substring is found.
+static std::wstring ReplaceUrl(
+    LPCWSTR src,
+    const std::wstring& actionText,
+    const std::vector<std::wstring>& targetSubstrings
+) {
     if (!src) return {};
+
+    if (actionText.empty()) return {};
+
     std::wstring s(src);
 
-    const wchar_t* hit = wcsstr(src, LINK_ID);
+    const wchar_t* hit = nullptr;
+    for (const auto & link : targetSubstrings){
+        hit = wcsstr(src, link.c_str());
+        if (hit) break;
+    }
     if (!hit) return {};
 
     size_t pos      = hit - src;
@@ -77,60 +147,28 @@ static std::wstring ReplaceUrl(LPCWSTR src) {
     size_t urlEnd   = s.find_first_of(L" \t\r\n\"'", pos);
     if (urlEnd   == std::wstring::npos) urlEnd   = s.size();
 
-    PCWSTR url = Wh_GetStringSetting(L"redirectUrl");
-    s.replace(urlStart, urlEnd - urlStart, url);
-    Wh_FreeStringSetting(url);
+    s.replace(urlStart, urlEnd - urlStart, actionText);
     return s;
 }
 
-// ── ShellExecuteExW hook ─────────────────────────────────────────────────────
 
-using ShellExecuteExW_t = decltype(&ShellExecuteExW);
-ShellExecuteExW_t ShellExecuteExW_Original;
-
-BOOL WINAPI ShellExecuteExW_Hook(SHELLEXECUTEINFOW* pei) {
-    if (!pei) return ShellExecuteExW_Original(pei);
-
-    if (HasLinkId(pei->lpFile) || HasLinkId(pei->lpParameters)) {
-        std::wstring newFile, newParams;
-        SHELLEXECUTEINFOW mod = *pei;
-
-        if (HasLinkId(pei->lpFile)) {
-            newFile = ReplaceUrl(pei->lpFile);
-            mod.lpFile       = newFile.c_str();
-            mod.lpParameters = nullptr;
-        } else {
-            newParams = ReplaceUrl(pei->lpParameters);
-            mod.lpParameters = newParams.c_str();
-        }
-
-        LOG(L"ShellExecuteExW → %s", mod.lpFile ? mod.lpFile : mod.lpParameters);
-        return ShellExecuteExW_Original(&mod);
-    }
-
-    return ShellExecuteExW_Original(pei);
+static PCWSTR SafeStr(PCWSTR s) {
+    return s ? s : L"(null)";
 }
 
-// ── ShellExecuteW hook ───────────────────────────────────────────────────────
-
-using ShellExecuteW_t = decltype(&ShellExecuteW);
-ShellExecuteW_t ShellExecuteW_Original;
-
-HINSTANCE WINAPI ShellExecuteW_Hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
-                                    LPCWSTR params, LPCWSTR dir, INT show) {
-    if (HasLinkId(file)) {
-        std::wstring newFile = ReplaceUrl(file);
-        LOG(L"ShellExecuteW → %s", newFile.c_str());
-        return ShellExecuteW_Original(hwnd, op, newFile.c_str(), nullptr, dir, show);
-    }
-    if (HasLinkId(params)) {
-        std::wstring newParams = ReplaceUrl(params);
-        LOG(L"ShellExecuteW params → %s", newParams.c_str());
-        return ShellExecuteW_Original(hwnd, op, file, newParams.c_str(), dir, show);
+static PCWSTR SkipLeadingWhitespace(PCWSTR s) {
+    while (s && iswspace(*s)) {
+        ++s;
     }
 
-    return ShellExecuteW_Original(hwnd, op, file, params, dir, show);
+    return s;
 }
+
+static bool IsUrl(PCWSTR s) {
+    s = SkipLeadingWhitespace(s);
+    return s && (_wcsnicmp(s, L"http://", 7) == 0 || _wcsnicmp(s, L"https://", 8) == 0);
+}
+
 
 // ── CreateProcessW hook ──────────────────────────────────────────────────────
 // Last-resort: catches the browser being spawned with the URL in its
@@ -139,60 +177,186 @@ HINSTANCE WINAPI ShellExecuteW_Hook(HWND hwnd, LPCWSTR op, LPCWSTR file,
 using CreateProcessW_t = decltype(&CreateProcessW);
 CreateProcessW_t CreateProcessW_Original;
 
-BOOL WINAPI CreateProcessW_Hook(LPCWSTR app, LPWSTR cmd,
-                                LPSECURITY_ATTRIBUTES psa, LPSECURITY_ATTRIBUTES tsa,
-                                BOOL inherit, DWORD flags, LPVOID env,
-                                LPCWSTR dir, LPSTARTUPINFOW si, LPPROCESS_INFORMATION pi) {
-    if (HasLinkId(cmd)) {
-        std::wstring newCmd = ReplaceUrl(cmd);
-        LOG(L"CreateProcessW → %s", newCmd.c_str());
-        return CreateProcessW_Original(app, newCmd.data(), psa, tsa,
-                                       inherit, flags, env, dir, si, pi);
+BOOL WINAPI CreateProcessW_Hook(
+    LPCWSTR app,
+    LPWSTR cmd,
+    LPSECURITY_ATTRIBUTES psa,
+    LPSECURITY_ATTRIBUTES tsa,
+    BOOL inherit,
+    DWORD flags,
+    LPVOID env,
+    LPCWSTR dir,
+    LPSTARTUPINFOW si,
+    LPPROCESS_INFORMATION pi
+) {
+    AcquireSRWLockShared(&g_settingsLock);
+    bool commandMode = g_commandMode;
+    std::wstring actionText = g_actionText;
+    std::vector<std::wstring> targetSubstrings = g_targetSubstrings;
+    ReleaseSRWLockShared(&g_settingsLock);
+
+    if (!HasLinkId(cmd, targetSubstrings)) {
+        return CreateProcessW_Original(
+            app, cmd, psa, tsa, inherit, flags, env, dir, si, pi
+        );
     }
 
-    return CreateProcessW_Original(app, cmd, psa, tsa, inherit, flags, env, dir, si, pi);
+    LOG(L"Intercepted speed-test CreateProcessW(app=\"%ls\", flags=0x%08lX, dir=\"%ls\")",
+        SafeStr(app),
+        flags,
+        SafeStr(dir));
+
+    BOOL ret = FALSE;
+
+    if (commandMode) {
+        if (actionText.empty()) {
+            LOG(L"Command mode enabled, but actionText is empty");
+            SetLastError(ERROR_INVALID_PARAMETER);
+            ret = FALSE;
+        } else {
+            std::wstring newCmd = actionText;
+
+            if (IsUrl(newCmd.c_str())) {
+                LOG(L"Command mode: opening configured URL");
+                newCmd = L"explorer.exe \"" + std::wstring(SkipLeadingWhitespace(newCmd.c_str())) + L"\"";
+            } else {
+                LOG(L"Command mode: executing configured command");
+            }
+
+            ret = CreateProcessW_Original(
+                nullptr,
+                &newCmd[0],
+                psa,
+                tsa,
+                inherit,
+                flags,
+                env,
+                dir,
+                si,
+                pi
+            );
+
+            LOG(L"Command mode result: ret=%d err=%lu",
+                ret,
+                ret ? 0 : GetLastError());
+        }
+    } else {
+        std::wstring newCmd = ReplaceUrl(cmd, actionText, targetSubstrings);
+
+        if (newCmd.empty()) {
+            LOG(L"URL mode: ReplaceUrl returned empty, falling back to original command");
+
+            ret = CreateProcessW_Original(
+                app, cmd, psa, tsa, inherit, flags, env, dir, si, pi
+            );
+        } else {
+            LOG(L"URL mode: replacing matched speed-test URL");
+
+            ret = CreateProcessW_Original(
+                app,
+                &newCmd[0],
+                psa,
+                tsa,
+                inherit,
+                flags,
+                env,
+                dir,
+                si,
+                pi
+            );
+
+            LOG(L"URL mode result: ret=%d err=%lu",
+                ret,
+                ret ? 0 : GetLastError());
+        }
+    }
+
+    return ret;
 }
 
 // ── Init ─────────────────────────────────────────────────────────────────────
 
-static bool HookFn(void* target, void* hook, void** orig, const wchar_t* name) {
-    if (!target) {
-        LOG(L"Could not resolve %s", name);
+static bool HookFn(void* target, void* hook, void** orig, const wchar_t* name){
+    if (!target){
+        LOG(L"Could not resolve %ls", name);
         return false;
     }
-    if (!Wh_SetFunctionHook(target, hook, orig)) {
-        LOG(L"Hook failed for %s", name);
+
+    if (!Wh_SetFunctionHook(target, hook, orig)){
+        LOG(L"Hook failed for %ls", name);
         return false;
     }
-    LOG(L"Hooked %s", name);
+
+    LOG(L"Hooked %ls", name);
     return true;
 }
 
-BOOL Wh_ModInit() {
-    LOG(L"Init in %s", GetCommandLineW());
+static void LoadSettings() {
+    bool commandMode = Wh_GetIntSetting(L"commandMode") != 0;
 
-    HMODULE hShell32  = GetModuleHandleW(L"shell32.dll");
+    PCWSTR actionText = Wh_GetStringSetting(L"actionText");
+    std::wstring actionTextValue = actionText ? actionText : L"";
+    Wh_FreeStringSetting(actionText);
+
+    std::vector<std::wstring> targetSubstrings;
+
+    for (int i = 0;; i++) {
+        PCWSTR substring = Wh_GetStringSetting(L"targetSubstrings[%d]", i);
+
+        if (!substring || !*substring) {
+            Wh_FreeStringSetting(substring);
+            break;
+        }
+
+        targetSubstrings.emplace_back(substring);
+        LOG(L"Loaded targetSubstrings[%d]", i);
+
+        Wh_FreeStringSetting(substring);
+    }
+
+    if (targetSubstrings.empty()) {
+        targetSubstrings.emplace_back(L"linkid=2324916");
+        targetSubstrings.emplace_back(L"linkid=2325015");
+    }
+
+    AcquireSRWLockExclusive(&g_settingsLock);
+    g_commandMode = commandMode;
+    g_actionText = actionTextValue;
+    g_targetSubstrings = targetSubstrings;
+    ReleaseSRWLockExclusive(&g_settingsLock);
+
+    LOG(L"Settings loaded: commandMode=%d, actionTextLength=%zu, substringCount=%zu",
+        commandMode,
+        actionTextValue.size(),
+        targetSubstrings.size());
+}
+
+BOOL Wh_ModInit() {
+    LOG(L"Init in %ls", GetCommandLineW());
+
+    LoadSettings();
+
     HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
 
     bool ok = true;
 
-    ok &= HookFn(hShell32  ? (void*)GetProcAddress(hShell32,  "ShellExecuteExW") : nullptr,
-                 (void*)ShellExecuteExW_Hook, (void**)&ShellExecuteExW_Original,
-                 L"ShellExecuteExW");
-
-    ok &= HookFn(hShell32  ? (void*)GetProcAddress(hShell32,  "ShellExecuteW")   : nullptr,
-                 (void*)ShellExecuteW_Hook,   (void**)&ShellExecuteW_Original,
-                 L"ShellExecuteW");
-
-    ok &= HookFn(hKernel32 ? (void*)GetProcAddress(hKernel32, "CreateProcessW")  : nullptr,
-                 (void*)CreateProcessW_Hook,  (void**)&CreateProcessW_Original,
-                 L"CreateProcessW");
+    ok &= HookFn(
+        hKernel32 ? (void*)GetProcAddress(hKernel32, "CreateProcessW") : nullptr,
+        (void*)CreateProcessW_Hook,
+        (void**)&CreateProcessW_Original,
+        L"CreateProcessW"
+    );
 
     if (!ok) {
-        LOG(L"One or more hooks failed — aborting");
+        LOG(L"One or more hooks failed, aborting");
         return FALSE;
     }
 
     LOG(L"All hooks installed");
     return TRUE;
+}
+
+void Wh_ModSettingsChanged() {
+    LOG(L"Settings changed");
+    LoadSettings();
 }


### PR DESCRIPTION
## Changelog

If this pull request updates an existing mod, describe the changes below:

* Update Perform Speed Test Redirect to v1.3.0.
* Add Action Center support via `ShellHost.exe` and the `linkid=2325015` target substring.
* Add command execution mode through the new `Action text` setting, while keeping URL replacement as the default.
* Add configurable target substrings and runtime settings reload.
* Remove stale `ShellExecuteW` and `ShellExecuteExW` hooks, using `CreateProcessW` interception only.
* Fix bare URL handling in command mode and avoid logging full command lines or configured actions.

Fixes https://github.com/ramensoftware/windhawk-mods/issues/3733

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [x] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify):
- - [x] Other (please specify): v1.3.0 feature work by @Meteony, co-authored in the commit.

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
