### PR TITLE
Update Island Media Controls to 0.9.146

### DIFF
--- a/mods/island-media-controls.wh.cpp
+++ b/mods/island-media-controls.wh.cpp
@@ -2,7 +2,7 @@
 // @id              island-media-controls
 // @name            Island Media Controls
 // @description     Dynamic island-like media controls for the Windows 11 taskbar.
-// @version         0.9.27
+// @version         0.9.39
 // @author          usho
 // @github          https://github.com/usho-lear
 // @license         MIT
@@ -63,6 +63,8 @@ it fits naturally alongside your taskbar and system tray items.
     - "taskbar_right_edge": "Taskbar - right overlay"
   - CompactWidth: 168
     $name: Compact width
+  - AutoSizeToTaskbar: true
+    $name: Auto size to taskbar
   - ExpandedWidth: 360
     $name: Expanded overlay width
   - ExpandedHeight: 500
@@ -202,6 +204,7 @@ namespace {
 struct Settings {
     std::wstring position = L"tray_left";
     int compactWidth = 168;
+    bool autoSizeToTaskbar = true;
     int expandedWidth = 360;
     int expandedHeight = 430;
     int popupSpacing = 8;
@@ -220,6 +223,25 @@ struct Settings {
     std::wstring material = L"mica_like";
 };
 
+struct RuntimeLayout {
+    double taskbarHeightDip = 40.0;
+    double compactHeight = 40.0;
+    double compactWidth = 168.0;
+    double artSize = 28.0;
+    double artImageSize = 30.0;
+    double artCornerRadius = 8.0;
+    double cornerRadius = 20.0;
+    double contentMarginX = 10.0;
+    double contentMarginY = 4.0;
+    double artColumnWidth = 30.0;
+    double textMarginX = 8.0;
+    double titleFontSize = 12.0;
+    double artistFontSize = 10.0;
+    double progressWidth = 74.0;
+    double progressHeight = 4.0;
+    double progressMarginLeft = 8.0;
+};
+
 struct MediaState {
     std::wstring title = L"Not Playing";
     std::wstring artist;
@@ -229,6 +251,7 @@ struct MediaState {
     int64_t timelineStartTicks = 0;
     int64_t positionTicks = 0;
     int64_t durationTicks = 0;
+    std::wstring sourceAppUserModelId;
     std::vector<uint8_t> thumbnailBytes;
 };
 
@@ -241,6 +264,7 @@ using MediaCommand =
     std::function<void(gsm::GlobalSystemMediaTransportControlsSession const&)>;
 
 Settings g_settings;
+RuntimeLayout g_layout;
 std::mutex g_pendingSettingsMutex;
 std::optional<Settings> g_pendingSettings;
 std::mutex g_mediaMutex;
@@ -337,7 +361,7 @@ mediax::RectangleGeometry g_popupXamlProgressGlowClip = nullptr;
 std::vector<Border> g_popupXamlProgressGlowLayers;
 std::vector<Border> g_popupXamlProgressCoreBlurLayers;
 Border g_popupXamlProgressGlowCore = nullptr;
-StackPanel g_popupXamlControls = nullptr;
+controls::Canvas g_popupXamlControls = nullptr;
 ScaleTransform g_popupXamlControlsScale = nullptr;
 uint64_t g_popupXamlThumbnailHash = UINT64_MAX;
 bool g_popupXamlBackdropCoverEnabled = false;
@@ -401,6 +425,11 @@ winrt::event_token g_compactTextRenderingToken{};
 bool g_compactTextRenderingHooked = false;
 double g_compactTextProgress = 1.0;
 std::chrono::steady_clock::time_point g_lastCompactTextFrameTime{};
+winrt::event_token g_taskbarLayoutRenderingToken{};
+bool g_taskbarLayoutRenderingHooked = false;
+std::chrono::steady_clock::time_point g_lastTaskbarLayoutCheckTime{};
+FrameworkElement g_taskbarLayoutWatchRoot = nullptr;
+FrameworkElement g_taskbarLayoutWatchTarget = nullptr;
 bool g_compactTextInitialized = false;
 std::wstring g_compactLastTitle;
 std::wstring g_compactLastArtist;
@@ -542,7 +571,6 @@ bool TrySeekAppleMusicWithUiAutomation(double ratio) {
 SolidColorBrush Brush(winrt::Windows::UI::Color color) {
     return SolidColorBrush(color);
 }
-
 
 void AttachGpuFriendlyTransform(FrameworkElement const& element,
                                 ScaleTransform& scale,
@@ -712,6 +740,7 @@ Settings ReadSettings() {
     Settings settings;
     settings.position = GetStringSetting(L"Main.Position", L"tray_left");
     settings.compactWidth = Clamp(Wh_GetIntSetting(L"Main.CompactWidth"), 96, 320);
+    settings.autoSizeToTaskbar = Wh_GetIntSetting(L"Main.AutoSizeToTaskbar") != 0;
     settings.expandedWidth = Clamp(Wh_GetIntSetting(L"Main.ExpandedWidth"), 240, 640);
     settings.expandedHeight = Clamp(Wh_GetIntSetting(L"Main.ExpandedHeight"), 430, 760);
     settings.popupSpacing = Clamp(Wh_GetIntSetting(L"Main.PopupSpacing"), 2, 24);
@@ -974,12 +1003,38 @@ uint64_t MediaThumbFingerprint(std::vector<uint8_t> const& bytes) {
     return hash;
 }
 
+std::wstring MediaIdentityKey(MediaState const& state) {
+    if (!state.hasSession) {
+        return L"";
+    }
+
+    // Deliberately excludes artwork bytes. Browsers can emit metadata before a
+    // live-room/video thumbnail is available, and some providers temporarily
+    // repeat the previous thumbnail. This key represents the actual media item
+    // for deciding whether old artwork can be reused safely.
+    return state.sourceAppUserModelId + L"\n" +
+           state.title + L"\n" +
+           state.artist + L"\n" +
+           std::to_wstring(state.durationTicks);
+}
+
+bool LooksLikeBrowserMediaSource(std::wstring const& source) {
+    return source.find(L"Chrome") != std::wstring::npos ||
+           source.find(L"MSEdge") != std::wstring::npos ||
+           source.find(L"MicrosoftEdge") != std::wstring::npos ||
+           source.find(L"Firefox") != std::wstring::npos ||
+           source.find(L"Brave") != std::wstring::npos ||
+           source.find(L"Opera") != std::wstring::npos ||
+           source.find(L"Vivaldi") != std::wstring::npos ||
+           source.find(L"Arc") != std::wstring::npos ||
+           source.find(L"Browser") != std::wstring::npos;
+}
+
 std::wstring MediaContentKey(MediaState const& state) {
     if (!state.hasSession) {
         return L"";
     }
-    return state.title + L"\n" + state.artist + L"\n" +
-           std::to_wstring(state.durationTicks) + L"\n" +
+    return MediaIdentityKey(state) + L"\n" +
            std::to_wstring(MediaThumbFingerprint(state.thumbnailBytes));
 }
 
@@ -1135,6 +1190,11 @@ void RefreshMediaState(
         auto session = CurrentSessionFromManager(manager);
         if (session) {
             state.hasSession = true;
+            try {
+                state.sourceAppUserModelId = std::wstring(session.SourceAppUserModelId());
+            } catch (...) {
+                state.sourceAppUserModelId.clear();
+            }
             auto playback = session.GetPlaybackInfo();
             state.isPlaying =
                 playback.PlaybackStatus() ==
@@ -1314,7 +1374,6 @@ HBITMAP DecodeAlbumBitmap(std::vector<uint8_t> const& bytes, UINT size) {
     if (stream) stream->Release();
     return bitmap;
 }
-
 
 std::vector<uint8_t> CreateLowDetailAlbumCoverBytes(std::vector<uint8_t> const& bytes, bool bottomFadeToMiddle = false) {
     std::vector<uint8_t> output;
@@ -1507,7 +1566,6 @@ winrt::Windows::UI::Color DefaultPopupAccentColor() {
     return Color(0xFF, 0x4F, 0x7D, 0xE8);
 }
 
-
 std::vector<uint8_t> EncodePbgraPngBytes(UINT width, UINT height, std::vector<BYTE> const& pixels) {
     std::vector<uint8_t> output;
     if (width == 0 || height == 0 || pixels.size() < static_cast<size_t>(width) * height * 4) {
@@ -1681,8 +1739,6 @@ bool ShouldUseAbstractArtworkForDisplay(std::vector<uint8_t> const& bytes) {
     // covers stay untouched.
     return videoLikeAspect || lowResolution;
 }
-
-
 
 winrt::Windows::UI::Color BoostArtworkColor(winrt::Windows::UI::Color color,
                                             double saturationScale,
@@ -2296,7 +2352,6 @@ std::vector<uint8_t> CreateDisplayAlbumCoverBytes(std::vector<uint8_t> const& by
     return abstractBytes.empty() ? bytes : abstractBytes;
 }
 
-
 winrt::Windows::UI::Color ExtractAlbumAccentColor(std::vector<uint8_t> const& bytes) {
     if (bytes.empty()) {
         return DefaultPopupAccentColor();
@@ -2848,7 +2903,6 @@ int PopupFinalHeightFromArtSize(int artSize) {
            PopupSurfaceGap() * 2 + kPopupHostShadowMargin * 2;
 }
 
-
 mediax::Brush PopupControlCardBrush() {
     bool dark = IsDarkModeApprox();
     // Keep light and dark tint strengths independent. Light mode keeps the
@@ -2963,23 +3017,14 @@ RECT UnionPopupRects(RECT const& a, RECT const& b) {
 }
 
 RECT CurrentPopupSurfaceScreenRect() {
-    RECT targetArt{};
-    RECT targetCard{};
-    RECT targetTitle{};
-    RECT targetArtist{};
-    RECT targetProgress{};
-    RECT targetElapsed{};
-    RECT targetDuration{};
-    RECT targetControls{};
-    CalculatePopupFinalLayout(g_popupFinalRect, targetArt, targetCard,
-                              targetTitle, targetArtist, targetProgress,
-                              targetElapsed, targetDuration, targetControls);
-    RECT targetBackdrop = PopupBackdropRectFromParts(targetArt, targetCard);
+    // Used only for outside-click hit testing. Keep this in physical screen
+    // pixels and use the full animated host bounds; the precise XAML surface is
+    // calculated in DIP coordinates in UpdatePopupXamlVisuals().
     double progress = PopupProgress();
-    return {LerpInt(g_popupSourceRect.left, targetBackdrop.left, progress),
-            LerpInt(g_popupSourceRect.top, targetBackdrop.top, progress),
-            LerpInt(g_popupSourceRect.right, targetBackdrop.right, progress),
-            LerpInt(g_popupSourceRect.bottom, targetBackdrop.bottom, progress)};
+    return {LerpInt(g_popupSourceRect.left, g_popupFinalRect.left, progress),
+            LerpInt(g_popupSourceRect.top, g_popupFinalRect.top, progress),
+            LerpInt(g_popupSourceRect.right, g_popupFinalRect.right, progress),
+            LerpInt(g_popupSourceRect.bottom, g_popupFinalRect.bottom, progress)};
 }
 
 bool PopupShouldExpandRight(MONITORINFO const& monitorInfo) {
@@ -3232,7 +3277,6 @@ void PaintExpandedPopup(HWND hwnd, HDC dc) {
     DeleteObject(titleFont);
 }
 
-
 bool PopupButtonStyleIs(std::wstring_view style) {
     return std::wstring_view(g_settings.popupButtonStyle) == style;
 }
@@ -3258,13 +3302,35 @@ winrt::hstring PopupTransportGlyph(Border const& surface, bool playing) {
 }
 
 void UpdatePopupTransportButtonGlyph(Border const& surface, bool playing) {
-    if (auto icon = surface.Child().try_as<TextBlock>()) {
-        icon.Text(PopupTransportGlyph(surface, playing));
+    if (auto icon = surface.Child().try_as<controls::FontIcon>()) {
+        icon.Glyph(PopupTransportGlyph(surface, playing));
+    } else if (auto text = surface.Child().try_as<TextBlock>()) {
+        text.Text(PopupTransportGlyph(surface, playing));
     }
 }
 
 double PopupControlsWidth() {
     return 126.0;
+}
+
+double PopupControlsHeight() {
+    return 38.0;
+}
+
+double PopupButtonWidth() {
+    return 38.0;
+}
+
+double PopupButtonHeight() {
+    return 38.0;
+}
+
+double PopupButtonTop() {
+    return (PopupControlsHeight() - PopupButtonHeight()) * 0.5;
+}
+
+double PopupButtonLeft(int index) {
+    return 2.0 + 42.0 * static_cast<double>(index);
 }
 
 mediax::Brush PopupButtonHoverBrush(bool dark) {
@@ -3278,49 +3344,70 @@ void ApplyPopupButtonVisual(Border const& surface, bool hovered = false) {
     auto primaryText = dark ? Color(0xFF, 0xFF, 0xFF, 0xFF)
                             : Color(0xFF, 0x00, 0x00, 0x00);
 
-    double width = 36.0;
-    double height = 34.0;
-    double corner = 17.0;
-    double fontSize = primary ? 22.0 : 21.0;
+    double width = PopupButtonWidth();
+    double height = PopupButtonHeight();
+    double corner = height * 0.5;
+    double fontSize = primary ? 21.0 : 20.0;
     mediax::Brush background = hovered ? PopupButtonHoverBrush(dark)
                                        : Brush(Color(0x00, 0x00, 0x00, 0x00));
     mediax::Brush foreground = Brush(primaryText);
 
     if (PopupButtonStyleIs(L"fluent_bold")) {
-        fontSize = primary ? 26.0 : 24.0;
+        fontSize = primary ? 23.0 : 22.0;
     }
 
     surface.Width(width);
     surface.Height(height);
+    surface.Visibility(Visibility::Visible);
     surface.CornerRadius({corner, corner, corner, corner});
     surface.Background(background);
     surface.BorderThickness({0, 0, 0, 0});
     surface.BorderBrush(Brush(Color(0x00, 0x00, 0x00, 0x00)));
 
-    if (auto icon = surface.Child().try_as<TextBlock>()) {
-        bool playing = SnapshotMedia().isPlaying;
-        icon.Text(PopupTransportGlyph(surface, playing));
+    bool playing = SnapshotMedia().isPlaying;
+    if (auto icon = surface.Child().try_as<controls::FontIcon>()) {
+        icon.Visibility(Visibility::Visible);
+        icon.Opacity(1.0);
+        icon.Width(width);
+        icon.Height(height);
+        icon.Margin({0, 0, 0, 0});
+        icon.HorizontalAlignment(HorizontalAlignment::Center);
+        icon.VerticalAlignment(VerticalAlignment::Center);
+        icon.Glyph(PopupTransportGlyph(surface, playing));
         icon.Foreground(foreground);
         icon.FontFamily(mediax::FontFamily(L"Segoe Fluent Icons"));
         icon.FontSize(fontSize);
-        icon.FontWeight(winrt::Windows::UI::Text::FontWeights::Bold());
+        icon.FontWeight(winrt::Windows::UI::Text::FontWeights::SemiBold());
+    } else if (auto text = surface.Child().try_as<TextBlock>()) {
+        text.Visibility(Visibility::Visible);
+        text.Opacity(1.0);
+        text.Width(width);
+        text.Height(height);
+        text.Margin({0, 0, 0, 0});
+        text.HorizontalAlignment(HorizontalAlignment::Stretch);
+        text.VerticalAlignment(VerticalAlignment::Center);
+        text.TextAlignment(xaml::TextAlignment::Center);
+        text.Text(PopupTransportGlyph(surface, playing));
+        text.Foreground(foreground);
+        text.FontFamily(mediax::FontFamily(L"Segoe Fluent Icons"));
+        text.FontSize(fontSize);
+        text.FontWeight(winrt::Windows::UI::Text::FontWeights::SemiBold());
     }
 }
 
 Border MakePopupXamlButton(const wchar_t* name, void (*onClick)(), bool primary = false) {
     Border surface;
     surface.Name(name);
-    surface.Margin({3, 0, 3, 0});
+    surface.Margin({0, 0, 0, 0});
     surface.Padding({0, 0, 0, 0});
     surface.Tag(winrt::box_value(winrt::hstring(primary ? L"primary" : L"secondary")));
     surface.IsHitTestVisible(true);
 
-    TextBlock icon;
+    controls::FontIcon icon;
     icon.FontFamily(mediax::FontFamily(L"Segoe Fluent Icons"));
-    icon.Text(L"\uE768");
+    icon.Glyph(L"\uE768");
     icon.HorizontalAlignment(HorizontalAlignment::Center);
     icon.VerticalAlignment(VerticalAlignment::Center);
-    icon.TextAlignment(xaml::TextAlignment::Center);
     surface.Child(icon);
     ApplyPopupButtonVisual(surface, false);
 
@@ -3469,7 +3556,6 @@ void ApplyPopupXamlTheme(bool force = false) {
     }
     ApplyPopupDynamicAccentVisuals();
 }
-
 
 void ApplyPopupDynamicAccentVisuals() {
     auto accent = PopupAccentColor();
@@ -3638,7 +3724,6 @@ void TickPopupMediaTransition(double dt) {
         ApplyPopupMediaTransitionVisuals();
     }
 }
-
 
 void InitializePopupCompositionShadow() {
     // UWP XAML Border in Windhawk does not expose GetAlphaMask(), so an
@@ -3947,31 +4032,39 @@ bool InitializePopupXamlHost(HWND hwnd) {
         progressHitTarget.Background(Brush(Color(0x01, 0x00, 0x00, 0x00)));
         canvas.Children().Append(progressHitTarget);
 
-        StackPanel controlsPanel;
-        controlsPanel.Orientation(controls::Orientation::Horizontal);
-        controlsPanel.RenderTransformOrigin({0.5, 0.5});
-        ScaleTransform controlsScale;
-        controlsScale.ScaleX(0.82);
-        controlsScale.ScaleY(0.82);
-        controlsPanel.RenderTransform(controlsScale);
-        controlsPanel.Children().Append(MakePopupXamlButton(
+        controls::Canvas controlsPanel;
+        controlsPanel.Width(PopupControlsWidth());
+        controlsPanel.Height(PopupControlsHeight());
+
+        Border prevButton = MakePopupXamlButton(
             L"Popup_Prev", [] {
                 RunMediaCommand([](gsm::GlobalSystemMediaTransportControlsSession const& s) {
                     s.TrySkipPreviousAsync().get();
                 });
-            }));
-        controlsPanel.Children().Append(MakePopupXamlButton(
+            });
+        Border playButton = MakePopupXamlButton(
             L"Popup_Play", [] {
                 RunMediaCommand([](gsm::GlobalSystemMediaTransportControlsSession const& s) {
                     s.TryTogglePlayPauseAsync().get();
                 });
-            }, true));
-        controlsPanel.Children().Append(MakePopupXamlButton(
+            }, true);
+        Border nextButton = MakePopupXamlButton(
             L"Popup_Next", [] {
                 RunMediaCommand([](gsm::GlobalSystemMediaTransportControlsSession const& s) {
                     s.TrySkipNextAsync().get();
                 });
-            }));
+            });
+
+        controls::Canvas::SetLeft(prevButton, PopupButtonLeft(0));
+        controls::Canvas::SetTop(prevButton, PopupButtonTop());
+        controls::Canvas::SetLeft(playButton, PopupButtonLeft(1));
+        controls::Canvas::SetTop(playButton, PopupButtonTop());
+        controls::Canvas::SetLeft(nextButton, PopupButtonLeft(2));
+        controls::Canvas::SetTop(nextButton, PopupButtonTop());
+
+        controlsPanel.Children().Append(prevButton);
+        controlsPanel.Children().Append(playButton);
+        controlsPanel.Children().Append(nextButton);
         canvas.Children().Append(controlsPanel);
 
         progressHitTarget.PointerPressed([](auto const& sender,
@@ -4114,7 +4207,7 @@ bool InitializePopupXamlHost(HWND hwnd) {
         g_popupXamlProgressCoreBlurLayers = progressCoreBlurLayers;
         g_popupXamlProgressGlowCore = progressGlowCore;
         g_popupXamlControls = controlsPanel;
-        g_popupXamlControlsScale = controlsScale;
+        g_popupXamlControlsScale = nullptr;
         g_popupXamlThumbnailHash = UINT64_MAX;
         InitializePopupCompositionShadow();
         ApplyPopupXamlTheme(true);
@@ -4133,20 +4226,38 @@ bool InitializePopupXamlHost(HWND hwnd) {
     }
 }
 
+double PopupDpiScale(HWND hwnd);
+int PopupDipToPx(double value, HWND hwnd);
+int PopupPxToDip(double value, HWND hwnd);
+RECT PopupScreenRectToLocalDip(RECT const& rect,
+                               RECT const& popupScreenPx,
+                               double scale);
+
 void UpdatePopupXamlVisuals() {
     if (!g_popupXamlRoot || !g_expandedPopup) {
         return;
     }
 
-    RECT popupScreen{};
-    GetWindowRect(g_expandedPopup, &popupScreen);
-    int width = popupScreen.right - popupScreen.left;
-    int height = popupScreen.bottom - popupScreen.top;
-    if (width <= 0 || height <= 0) {
+    RECT popupScreenPx{};
+    GetWindowRect(g_expandedPopup, &popupScreenPx);
+    int widthPx = popupScreenPx.right - popupScreenPx.left;
+    int heightPx = popupScreenPx.bottom - popupScreenPx.top;
+    if (widthPx <= 0 || heightPx <= 0) {
         return;
     }
+
+    double dpiScale = PopupDpiScale(g_expandedPopup);
+    int width = std::max(1, static_cast<int>(std::lround(widthPx / dpiScale)));
+    int height = std::max(1, static_cast<int>(std::lround(heightPx / dpiScale)));
+    RECT popupScreen{0, 0, static_cast<LONG>(width), static_cast<LONG>(height)};
+    RECT sourceRect = PopupScreenRectToLocalDip(g_popupSourceRect, popupScreenPx, dpiScale);
+    RECT sourceArtRect = PopupScreenRectToLocalDip(g_popupSourceArtRect, popupScreenPx, dpiScale);
+    RECT sourceTitleRect = PopupScreenRectToLocalDip(g_popupSourceTitleRect, popupScreenPx, dpiScale);
+    RECT sourceArtistRect = PopupScreenRectToLocalDip(g_popupSourceArtistRect, popupScreenPx, dpiScale);
+    RECT finalRect = PopupScreenRectToLocalDip(g_popupFinalRect, popupScreenPx, dpiScale);
+
     double progress = PopupProgress();
-    RECT currentRect{popupScreen.left, popupScreen.top, popupScreen.right, popupScreen.bottom};
+    RECT currentRect{0, 0, static_cast<LONG>(width), static_cast<LONG>(height)};
     // Always update the animated XAML geometry while the popup is moving.
     // The previous small-delta skip optimization made the album-art morph
     // freeze for one or more frames when the HWND rect rounded to the same
@@ -4182,16 +4293,16 @@ void UpdatePopupXamlVisuals() {
     RECT targetElapsed{};
     RECT targetDuration{};
     RECT targetControls{};
-    CalculatePopupFinalLayout(g_popupFinalRect, targetArtScreen, targetCard,
+    CalculatePopupFinalLayout(finalRect, targetArtScreen, targetCard,
                               targetTitle, targetArtist,
                               targetProgress, targetElapsed, targetDuration,
                               targetControls);
     RECT targetBackdrop = PopupBackdropRectFromParts(targetArtScreen, targetCard);
     RECT backdropScreen{
-        LerpInt(g_popupSourceRect.left, targetBackdrop.left, progress),
-        LerpInt(g_popupSourceRect.top, targetBackdrop.top, progress),
-        LerpInt(g_popupSourceRect.right, targetBackdrop.right, progress),
-        LerpInt(g_popupSourceRect.bottom, targetBackdrop.bottom, progress),
+        LerpInt(sourceRect.left, targetBackdrop.left, progress),
+        LerpInt(sourceRect.top, targetBackdrop.top, progress),
+        LerpInt(sourceRect.right, targetBackdrop.right, progress),
+        LerpInt(sourceRect.bottom, targetBackdrop.bottom, progress),
     };
     double backdropWidth = std::max(1L, targetBackdrop.right - targetBackdrop.left);
     double backdropHeight = std::max(1L, targetBackdrop.bottom - targetBackdrop.top);
@@ -4234,10 +4345,10 @@ void UpdatePopupXamlVisuals() {
                             popupScreen);
     }
     RECT artScreen{
-        LerpInt(g_popupSourceArtRect.left, targetArtScreen.left, progress),
-        LerpInt(g_popupSourceArtRect.top, targetArtScreen.top, progress),
-        LerpInt(g_popupSourceArtRect.right, targetArtScreen.right, progress),
-        LerpInt(g_popupSourceArtRect.bottom, targetArtScreen.bottom, progress),
+        LerpInt(sourceArtRect.left, targetArtScreen.left, progress),
+        LerpInt(sourceArtRect.top, targetArtScreen.top, progress),
+        LerpInt(sourceArtRect.right, targetArtScreen.right, progress),
+        LerpInt(sourceArtRect.bottom, targetArtScreen.bottom, progress),
     };
     double artRadius = kPopupUnifiedCornerRadius;
     g_popupXamlArtFrame.CornerRadius({artRadius, artRadius, artRadius, artRadius});
@@ -4249,10 +4360,10 @@ void UpdatePopupXamlVisuals() {
                         popupScreen);
 
     RECT cardScreen{
-        LerpInt(g_popupSourceRect.left, targetCard.left, progress),
-        LerpInt(g_popupSourceRect.top, targetCard.top, progress),
-        LerpInt(g_popupSourceRect.right, targetCard.right, progress),
-        LerpInt(g_popupSourceRect.bottom, targetCard.bottom, progress),
+        LerpInt(sourceRect.left, targetCard.left, progress),
+        LerpInt(sourceRect.top, targetCard.top, progress),
+        LerpInt(sourceRect.right, targetCard.right, progress),
+        LerpInt(sourceRect.bottom, targetCard.bottom, progress),
     };
     double panelRadius = kPopupUnifiedCornerRadius;
     double cardOpacity = Clamp((progress - 0.12) / 0.28, 0.0, 1.0);
@@ -4293,10 +4404,10 @@ void UpdatePopupXamlVisuals() {
         controls::Canvas::SetLeft(text, screen.left - popupScreen.left);
         controls::Canvas::SetTop(text, screen.top - popupScreen.top);
     };
-    placeText(g_popupXamlOutgoingTitle, g_popupSourceTitleRect, targetTitle, 12, 16);
-    placeText(g_popupXamlOutgoingArtist, g_popupSourceArtistRect, targetArtist, 10, 13);
-    placeText(g_popupXamlTitle, g_popupSourceTitleRect, targetTitle, 12, 16);
-    placeText(g_popupXamlArtist, g_popupSourceArtistRect, targetArtist, 10, 13);
+    placeText(g_popupXamlOutgoingTitle, sourceTitleRect, targetTitle, 12, 16);
+    placeText(g_popupXamlOutgoingArtist, sourceArtistRect, targetArtist, 10, 13);
+    placeText(g_popupXamlTitle, sourceTitleRect, targetTitle, 12, 16);
+    placeText(g_popupXamlArtist, sourceArtistRect, targetArtist, 10, 13);
 
     double textOpacity = SmoothStep(Clamp(progress, 0.0, 1.0));
     g_popupTextBaseOpacity = textOpacity;
@@ -4327,15 +4438,15 @@ void UpdatePopupXamlVisuals() {
                     LerpInt(source.bottom, target.bottom, amount)};
     };
 
-    int sourceWidth = std::max(1, static_cast<int>(g_popupSourceRect.right - g_popupSourceRect.left));
-    int sourceCenterX = (g_popupSourceRect.left + g_popupSourceRect.right) / 2;
-    int sourceCenterY = (g_popupSourceRect.top + g_popupSourceRect.bottom) / 2;
+    int sourceWidth = std::max(1, static_cast<int>(sourceRect.right - sourceRect.left));
+    int sourceCenterX = (sourceRect.left + sourceRect.right) / 2;
+    int sourceCenterY = (sourceRect.top + sourceRect.bottom) / 2;
     int sourceInset = Clamp(sourceWidth / 8, 8, 18);
 
-    RECT progressSource{g_popupSourceRect.left + sourceInset,
-                        g_popupSourceRect.bottom - 8,
-                        g_popupSourceRect.right - sourceInset,
-                        g_popupSourceRect.bottom - 4};
+    RECT progressSource{sourceRect.left + sourceInset,
+                        sourceRect.bottom - 8,
+                        sourceRect.right - sourceInset,
+                        sourceRect.bottom - 4};
     RECT progressScreen = lerpRect(progressSource, targetProgress, controlsProgress);
     double progressRatio = 0.0;
     if (g_popupXamlProgress && g_popupXamlProgress.Maximum() > 0.0) {
@@ -4433,17 +4544,18 @@ void UpdatePopupXamlVisuals() {
     };
 
     RECT elapsedSource{sourceCenterX - 44,
-                       g_popupSourceRect.bottom - 7,
+                       sourceRect.bottom - 7,
                        sourceCenterX - 6,
-                       g_popupSourceRect.bottom + 9};
+                       sourceRect.bottom + 9};
     RECT durationSource{sourceCenterX + 6,
-                        g_popupSourceRect.bottom - 7,
+                        sourceRect.bottom - 7,
                         sourceCenterX + 44,
-                        g_popupSourceRect.bottom + 9};
+                        sourceRect.bottom + 9};
     placeTimeText(g_popupXamlElapsed, elapsedSource, targetElapsed, false);
     placeTimeText(g_popupXamlDuration, durationSource, targetDuration, true);
 
     double controlsWidth = PopupControlsWidth();
+    double controlsHeight = PopupControlsHeight();
     int controlsSourceHalfWidth = static_cast<int>(std::lround(controlsWidth * 0.38));
     RECT controlsSource{sourceCenterX - controlsSourceHalfWidth,
                         sourceCenterY - 14,
@@ -4454,16 +4566,48 @@ void UpdatePopupXamlVisuals() {
         g_popupXamlControls.Visibility(showControls ? Visibility::Visible : Visibility::Collapsed);
         g_popupXamlControls.Opacity(controlsOpacity);
         g_popupXamlControls.Width(controlsWidth);
-        if (g_popupXamlControlsScale) {
-            g_popupXamlControlsScale.ScaleX(controlsScale);
-            g_popupXamlControlsScale.ScaleY(controlsScale);
+        g_popupXamlControls.Height(controlsHeight);
+
+        double screenWidth = std::max(1L, controlsScreen.right - controlsScreen.left);
+        double screenHeight = std::max(1L, controlsScreen.bottom - controlsScreen.top);
+        double left = controlsScreen.left - popupScreen.left +
+                      (screenWidth - controlsWidth) * 0.5;
+        double top = controlsScreen.top - popupScreen.top +
+                     (screenHeight - controlsHeight) * 0.5;
+
+        controls::Canvas::SetLeft(g_popupXamlControls, left);
+        controls::Canvas::SetTop(g_popupXamlControls, top);
+
+        // Keep child button slots fixed in the local Canvas coordinates instead
+        // of scaling the whole StackPanel. The previous group RenderTransform
+        // could diverge from hit testing under high DPI, making the hover
+        // highlight and glyph appear offset from each other.
+        int index = 0;
+        for (auto const& child : g_popupXamlControls.Children()) {
+            if (auto buttonSurface = child.try_as<Border>()) {
+                controls::Canvas::SetLeft(buttonSurface, PopupButtonLeft(index));
+                controls::Canvas::SetTop(buttonSurface, PopupButtonTop());
+                buttonSurface.Width(PopupButtonWidth());
+                buttonSurface.Height(PopupButtonHeight());
+                buttonSurface.Visibility(Visibility::Visible);
+                if (auto icon = buttonSurface.Child().try_as<controls::FontIcon>()) {
+                    icon.Visibility(Visibility::Visible);
+                    icon.Opacity(1.0);
+                    icon.Width(PopupButtonWidth());
+                    icon.Height(PopupButtonHeight());
+                    icon.Margin({0, 0, 0, 0});
+                    icon.HorizontalAlignment(HorizontalAlignment::Center);
+                    icon.VerticalAlignment(VerticalAlignment::Center);
+                } else if (auto text = buttonSurface.Child().try_as<TextBlock>()) {
+                    text.Visibility(Visibility::Visible);
+                    text.Opacity(1.0);
+                    text.Width(PopupButtonWidth());
+                    text.Height(PopupButtonHeight());
+                    text.Margin({0, 0, 0, 0});
+                }
+                ++index;
+            }
         }
-        controls::Canvas::SetLeft(g_popupXamlControls,
-                                  controlsScreen.left - popupScreen.left +
-                                      ((controlsScreen.right - controlsScreen.left) - controlsWidth) / 2.0);
-        controls::Canvas::SetTop(g_popupXamlControls,
-                                 controlsScreen.top - popupScreen.top +
-                                     ((controlsScreen.bottom - controlsScreen.top) - 34.0) / 2.0);
     }
 
     ApplyPopupMediaTransitionVisuals();
@@ -4622,50 +4766,86 @@ bool GetElementScreenRect(FrameworkElement const& element, RECT& result) {
     }
 }
 
+double PopupDpiScale(HWND hwnd) {
+    HWND source = hwnd ? hwnd : (g_expandedPopup ? g_expandedPopup : g_taskbarWnd);
+    UINT dpi = source ? GetDpiForWindow(source) : 96;
+    if (dpi == 0) {
+        dpi = 96;
+    }
+    return std::max(0.01, static_cast<double>(dpi) / 96.0);
+}
+
+int PopupDipToPx(double value, HWND hwnd) {
+    return static_cast<int>(std::lround(value * PopupDpiScale(hwnd)));
+}
+
+int PopupPxToDip(double value, HWND hwnd) {
+    return static_cast<int>(std::lround(value / PopupDpiScale(hwnd)));
+}
+
+RECT PopupScreenRectToLocalDip(RECT const& rect,
+                               RECT const& popupScreenPx,
+                               double scale) {
+    return {
+        static_cast<LONG>(std::lround((rect.left - popupScreenPx.left) / scale)),
+        static_cast<LONG>(std::lround((rect.top - popupScreenPx.top) / scale)),
+        static_cast<LONG>(std::lround((rect.right - popupScreenPx.left) / scale)),
+        static_cast<LONG>(std::lround((rect.bottom - popupScreenPx.top) / scale))};
+}
+
 void CapturePopupSourceGeometry() {
     if (!GetElementScreenRect(g_playerGrid, g_popupSourceRect)) {
         RECT taskbar{};
         GetWindowRect(g_taskbarWnd, &taskbar);
-        g_popupSourceRect = {taskbar.left, taskbar.top,
-                             taskbar.left + g_settings.compactWidth,
-                             taskbar.top + g_settings.height};
+        g_popupSourceRect = {
+            taskbar.left,
+            taskbar.top,
+            taskbar.left + static_cast<LONG>(PopupDipToPx(g_layout.compactWidth, g_taskbarWnd)),
+            taskbar.top + static_cast<LONG>(PopupDipToPx(g_layout.compactHeight, g_taskbarWnd))};
     }
     auto art = FindChildByName(g_playerGrid, L"Island_ArtFallback");
     if (!GetElementScreenRect(art, g_popupSourceArtRect)) {
-        g_popupSourceArtRect = {g_popupSourceRect.left + 10,
-                                g_popupSourceRect.top + 6,
-                                g_popupSourceRect.left + 38,
-                                g_popupSourceRect.top + 34};
+        g_popupSourceArtRect = {
+            g_popupSourceRect.left + PopupDipToPx(10.0, g_taskbarWnd),
+            g_popupSourceRect.top + PopupDipToPx(6.0, g_taskbarWnd),
+            g_popupSourceRect.left + PopupDipToPx(38.0, g_taskbarWnd),
+            g_popupSourceRect.top + PopupDipToPx(34.0, g_taskbarWnd)};
     }
     auto title = FindChildByName(g_playerGrid, L"Island_Title");
     if (!GetElementScreenRect(title, g_popupSourceTitleRect)) {
-        g_popupSourceTitleRect = {g_popupSourceRect.left + 48,
-                                  g_popupSourceRect.top + 5,
-                                  g_popupSourceRect.right - 10,
-                                  g_popupSourceRect.top + 22};
+        g_popupSourceTitleRect = {
+            g_popupSourceRect.left + PopupDipToPx(48.0, g_taskbarWnd),
+            g_popupSourceRect.top + PopupDipToPx(5.0, g_taskbarWnd),
+            g_popupSourceRect.right - PopupDipToPx(10.0, g_taskbarWnd),
+            g_popupSourceRect.top + PopupDipToPx(22.0, g_taskbarWnd)};
     }
     auto artist = FindChildByName(g_playerGrid, L"Island_CompactArtist");
     if (!GetElementScreenRect(artist, g_popupSourceArtistRect)) {
-        g_popupSourceArtistRect = {g_popupSourceRect.left + 48,
-                                   g_popupSourceRect.top + 21,
-                                   g_popupSourceRect.right - 10,
-                                   g_popupSourceRect.bottom - 4};
+        g_popupSourceArtistRect = {
+            g_popupSourceRect.left + PopupDipToPx(48.0, g_taskbarWnd),
+            g_popupSourceRect.top + PopupDipToPx(21.0, g_taskbarWnd),
+            g_popupSourceRect.right - PopupDipToPx(10.0, g_taskbarWnd),
+            g_popupSourceRect.bottom - PopupDipToPx(4.0, g_taskbarWnd)};
     }
 
     HMONITOR monitor = MonitorFromRect(&g_popupSourceRect, MONITOR_DEFAULTTONEAREST);
     MONITORINFO monitorInfo{sizeof(monitorInfo)};
     if (GetMonitorInfoW(monitor, &monitorInfo)) {
-        int monitorWidth = monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left;
+        double dpiScale = PopupDpiScale(g_taskbarWnd);
+        int monitorWidthPx = monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left;
+        int monitorWidthDip = std::max(1, static_cast<int>(std::floor(monitorWidthPx / dpiScale)));
         RECT taskbar{};
         GetWindowRect(g_taskbarWnd, &taskbar);
-        int finalBottom = taskbar.top - 8;
-        int availableHeight = finalBottom - monitorInfo.rcMonitor.top - 12;
+        int finalBottom = taskbar.top - PopupDipToPx(8.0, g_taskbarWnd);
+        int availableHeightPx = finalBottom - monitorInfo.rcMonitor.top -
+                                PopupDipToPx(12.0, g_taskbarWnd);
+        int availableHeightDip = std::max(1, static_cast<int>(std::floor(availableHeightPx / dpiScale)));
 
         int maxArtBySetting = std::max(96, g_settings.expandedWidth -
             (PopupSurfaceGap() * 2 + kPopupHostShadowMargin * 2));
-        int maxArtByMonitorWidth = std::max(96, monitorWidth - 24 -
+        int maxArtByMonitorWidth = std::max(96, monitorWidthDip - 24 -
             (PopupSurfaceGap() * 2 + kPopupHostShadowMargin * 2));
-        int maxArtByHeight = std::max(96, availableHeight -
+        int maxArtByHeight = std::max(96, availableHeightDip -
             (kPopupCardHeight + PopupArtCardGap() +
              PopupSurfaceGap() * 2 + kPopupHostShadowMargin * 2));
         int targetArt = Clamp(std::min({maxArtBySetting,
@@ -4677,8 +4857,10 @@ void CapturePopupSourceGeometry() {
             targetArt = kPopupMinimumArtSize;
         }
 
-        int finalWidth = PopupFinalWidthFromArtSize(targetArt);
-        int finalHeight = PopupFinalHeightFromArtSize(targetArt);
+        int finalWidthDip = PopupFinalWidthFromArtSize(targetArt);
+        int finalHeightDip = PopupFinalHeightFromArtSize(targetArt);
+        int finalWidth = PopupDipToPx(finalWidthDip, g_taskbarWnd);
+        int finalHeight = PopupDipToPx(finalHeightDip, g_taskbarWnd);
         g_popupExpandedWidth = static_cast<double>(finalWidth);
         g_popupExpandedHeight = static_cast<double>(finalHeight);
 
@@ -4694,22 +4876,26 @@ void CapturePopupSourceGeometry() {
         int finalLeft = g_popupExpandsRight
                             ? g_popupSourceRect.left
                             : g_popupSourceRect.right - finalWidth;
+        int edgePad = PopupDipToPx(12.0, g_taskbarWnd);
         finalLeft = Clamp(finalLeft,
-                          static_cast<int>(monitorInfo.rcMonitor.left) + 12,
-                          static_cast<int>(monitorInfo.rcMonitor.right) - finalWidth - 12);
+                          static_cast<int>(monitorInfo.rcMonitor.left) + edgePad,
+                          static_cast<int>(monitorInfo.rcMonitor.right) - finalWidth - edgePad);
         g_popupFinalRect = {finalLeft, finalBottom - finalHeight,
                             finalLeft + finalWidth, finalBottom};
     } else {
         int targetArt = Clamp(g_settings.expandedWidth -
                                   (PopupSurfaceGap() * 2 + kPopupHostShadowMargin * 2),
                               96, kPopupMaximumArtSize);
-        g_popupExpandedWidth = static_cast<double>(PopupFinalWidthFromArtSize(targetArt));
-        g_popupExpandedHeight = static_cast<double>(PopupFinalHeightFromArtSize(targetArt));
+        int finalWidth = PopupDipToPx(PopupFinalWidthFromArtSize(targetArt), g_taskbarWnd);
+        int finalHeight = PopupDipToPx(PopupFinalHeightFromArtSize(targetArt), g_taskbarWnd);
+        int popupGap = PopupDipToPx(8.0, g_taskbarWnd);
+        g_popupExpandedWidth = static_cast<double>(finalWidth);
+        g_popupExpandedHeight = static_cast<double>(finalHeight);
         g_popupExpandsRight = true;
         g_popupFinalRect = {g_popupSourceRect.left,
-                            g_popupSourceRect.top - static_cast<int>(g_popupExpandedHeight) - 8,
-                            g_popupSourceRect.left + static_cast<int>(g_popupExpandedWidth),
-                            g_popupSourceRect.top - 8};
+                            g_popupSourceRect.top - finalHeight - popupGap,
+                            g_popupSourceRect.left + finalWidth,
+                            g_popupSourceRect.top - popupGap};
     }
 }
 
@@ -4893,6 +5079,50 @@ void ResetCompactTextAnimationVisuals() {
     }
 }
 
+double CompactTextClipWidthFallback() {
+    double width = g_layout.compactWidth -
+                   (g_layout.contentMarginX * 2.0 +
+                    g_layout.artColumnWidth +
+                    g_layout.textMarginX * 2.0 + 4.0);
+    return std::max(1.0, width);
+}
+
+double CompactTextClipHeightFallback() {
+    double height = g_layout.compactHeight - g_layout.contentMarginY * 2.0;
+    return std::max(1.0, height);
+}
+
+void RefreshCompactTextHostClip(bool forceLayout = false) {
+    if (!g_compactTextHost) {
+        return;
+    }
+
+    try {
+        if (forceLayout && g_playerGrid) {
+            g_playerGrid.UpdateLayout();
+        }
+
+        double fallbackWidth = CompactTextClipWidthFallback();
+        double fallbackHeight = CompactTextClipHeightFallback();
+        double clipWidth = g_compactTextHost.ActualWidth();
+        double clipHeight = g_compactTextHost.ActualHeight();
+
+        // Right after a settings/theme change, XAML may report the previous
+        // measured width for one frame. A too-small clip causes the compact
+        // title/artist to look cropped until the next expand/collapse. Prefer a
+        // geometry-derived fallback whenever ActualWidth is clearly stale.
+        if (clipWidth <= 1.0 || clipWidth < fallbackWidth * 0.65) {
+            clipWidth = fallbackWidth;
+        }
+        if (clipHeight <= 1.0 || clipHeight < fallbackHeight * 0.55) {
+            clipHeight = fallbackHeight;
+        }
+
+        ApplyElementClip(g_compactTextHost, clipWidth, clipHeight);
+    } catch (...) {
+    }
+}
+
 void StopCompactTextRenderLoop() {
     if (!g_compactTextRenderingHooked) {
         return;
@@ -4930,17 +5160,7 @@ void OnCompactTextRendering(winrt::Windows::Foundation::IInspectable const&,
         // more visible. SmootherStep keeps both ends of the motion soft.
         g_compactTextProgress = Clamp(g_compactTextProgress + dtSec * 2.45, 0.0, 1.0);
         constexpr double kTextSlideOffset = 22.0;
-        if (g_compactTextHost) {
-            double clipWidth = g_compactTextHost.ActualWidth();
-            double clipHeight = g_compactTextHost.ActualHeight();
-            if (clipWidth <= 0.0) {
-                clipWidth = std::max(1, g_settings.compactWidth - 122);
-            }
-            if (clipHeight <= 0.0) {
-                clipHeight = std::max(1, g_settings.height - 8);
-            }
-            ApplyElementClip(g_compactTextHost, clipWidth, clipHeight);
-        }
+        RefreshCompactTextHostClip(false);
 
         double titleIn = SmootherStep(Clamp((g_compactTextProgress - 0.04) / 0.86, 0.0, 1.0));
         double artistIn = SmootherStep(Clamp((g_compactTextProgress - 0.34) / 0.62, 0.0, 1.0));
@@ -5597,7 +5817,9 @@ bool EnsureExpandedPopup() {
     g_expandedPopup = CreateWindowExW(
         WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
         kPopupClassName, L"",
-        WS_POPUP, 0, 0, g_settings.compactWidth, g_settings.height,
+        WS_POPUP, 0, 0,
+        static_cast<int>(std::lround(g_layout.compactWidth)),
+        static_cast<int>(std::lround(g_layout.compactHeight)),
         g_taskbarWnd, nullptr, ModInstance(), nullptr);
     if (!g_expandedPopup) {
         return false;
@@ -5818,11 +6040,26 @@ void ApplyExpandedState() {
         return;
     }
 
-    g_playerGrid.Width(g_settings.compactWidth);
+    g_playerGrid.Width(g_layout.compactWidth);
+    g_playerGrid.Height(g_layout.compactHeight);
+    g_playerGrid.MinHeight(g_layout.compactHeight);
 
     if (auto backgroundFe = FindChildByName(g_playerGrid, L"Island_Background")) {
         if (auto background = backgroundFe.try_as<Border>()) {
-            background.CornerRadius({20, 20, 20, 20});
+            background.CornerRadius({g_layout.cornerRadius, g_layout.cornerRadius,
+                                     g_layout.cornerRadius, g_layout.cornerRadius});
+            background.BorderBrush(IslandBorderBrush());
+        }
+    }
+
+    if (auto contentFe = FindChildByName(g_playerGrid, L"Island_Content")) {
+        contentFe.Margin({g_layout.contentMarginX, g_layout.contentMarginY,
+                          g_layout.contentMarginX, g_layout.contentMarginY});
+        if (auto content = contentFe.try_as<Grid>()) {
+            if (content.ColumnDefinitions().Size() > 0) {
+                content.ColumnDefinitions().GetAt(0).Width(
+                    {g_layout.artColumnWidth, GridUnitType::Pixel});
+            }
         }
     }
 
@@ -5834,34 +6071,69 @@ void ApplyExpandedState() {
         compactArtist.Visibility(Visibility::Visible);
         compactArtist.Opacity(1.0);
     }
+
+    if (auto textHost = FindChildByName(g_playerGrid, L"Island_TextHost")) {
+        textHost.Margin({g_layout.textMarginX, 0, g_layout.textMarginX, 0});
+    }
+    RefreshCompactTextHostClip(false);
+
+    auto updateTextBlockSize = [](wchar_t const* name, double fontSize) {
+        if (auto fe = FindChildByName(g_playerGrid, name)) {
+            if (auto text = fe.try_as<TextBlock>()) {
+                text.FontSize(fontSize);
+            }
+        }
+    };
+    updateTextBlockSize(L"Island_Title", g_layout.titleFontSize);
+    updateTextBlockSize(L"Island_OutgoingTitle", g_layout.titleFontSize);
+    updateTextBlockSize(L"Island_CompactArtist", g_layout.artistFontSize);
+    updateTextBlockSize(L"Island_OutgoingCompactArtist", g_layout.artistFontSize);
+
     if (auto artFe = FindChildByName(g_playerGrid, L"Island_ArtFallback")) {
-        artFe.Width(28.0);
-        artFe.Height(28.0);
+        artFe.Width(g_layout.artSize);
+        artFe.Height(g_layout.artSize);
         if (auto art = artFe.try_as<Border>()) {
-            art.CornerRadius({8, 8, 8, 8});
+            art.CornerRadius({g_layout.artCornerRadius, g_layout.artCornerRadius,
+                              g_layout.artCornerRadius, g_layout.artCornerRadius});
+        }
+    }
+    if (auto artHostFe = FindChildByName(g_playerGrid, L"Island_ArtHost")) {
+        artHostFe.Width(g_layout.artSize);
+        artHostFe.Height(g_layout.artSize);
+        ApplyElementClip(artHostFe, g_layout.artSize, g_layout.artSize);
+    }
+    if (auto placeholderFe = FindChildByName(g_playerGrid, L"Island_ArtPlaceholder")) {
+        placeholderFe.Width(g_layout.artSize);
+        placeholderFe.Height(g_layout.artSize);
+        if (auto placeholder = placeholderFe.try_as<Border>()) {
+            placeholder.CornerRadius({g_layout.artCornerRadius, g_layout.artCornerRadius,
+                                      g_layout.artCornerRadius, g_layout.artCornerRadius});
         }
     }
     if (auto imageFe = FindChildByName(g_playerGrid, L"Island_AlbumArt")) {
-        imageFe.Width(30.0);
-        imageFe.Height(30.0);
+        imageFe.Width(g_layout.artImageSize);
+        imageFe.Height(g_layout.artImageSize);
         imageFe.Margin({-1, -1, -1, -1});
     }
     if (auto fadeFe = FindChildByName(g_playerGrid, L"Island_AlbumArtFade")) {
-        fadeFe.Width(30.0);
-        fadeFe.Height(30.0);
+        fadeFe.Width(g_layout.artImageSize);
+        fadeFe.Height(g_layout.artImageSize);
         fadeFe.Margin({-1, -1, -1, -1});
     }
     if (auto strokeFe = FindChildByName(g_playerGrid, L"Island_ArtStroke")) {
+        strokeFe.Width(g_layout.artSize);
+        strokeFe.Height(g_layout.artSize);
         if (auto stroke = strokeFe.try_as<Border>()) {
+            stroke.CornerRadius({g_layout.artCornerRadius, g_layout.artCornerRadius,
+                                 g_layout.artCornerRadius, g_layout.artCornerRadius});
             stroke.BorderBrush(IslandBorderBrush());
         }
     }
-    if (auto contentFe = FindChildByName(g_playerGrid, L"Island_Content")) {
-        if (auto content = contentFe.try_as<Grid>()) {
-            if (content.ColumnDefinitions().Size() > 0) {
-                content.ColumnDefinitions().GetAt(0).Width({30.0, GridUnitType::Pixel});
-            }
-        }
+
+    if (g_compactProgress) {
+        g_compactProgress.Width(g_layout.progressWidth);
+        g_compactProgress.Height(g_layout.progressHeight);
+        g_compactProgress.Margin({g_layout.progressMarginLeft, 0, 0, 0});
     }
 }
 
@@ -5877,6 +6149,7 @@ void StartExpandRenderLoop(bool expanded) {
         }
         if (g_playerGrid) {
             g_playerGrid.UpdateLayout();
+            RefreshCompactTextHostClip(false);
         }
         ShowExpandedPopup();
     } else {
@@ -6199,13 +6472,140 @@ void UpdateThemeVisuals() {
     UpdateButtonTheme(L"Island_Next");
 }
 
+double EffectiveElementVisualHeightDip(FrameworkElement const& element,
+                                       double referenceHeight) {
+    if (!element) {
+        return 0.0;
+    }
+
+    try {
+        double height = element.ActualHeight();
+        if (height <= 1.0) {
+            return 0.0;
+        }
+
+        // Taskbar Styler themes often compress the *visual* taskbar by adding
+        // positive top/bottom margins to high-level taskbar grids while the
+        // outer layout slot keeps the normal taskbar height. If ActualHeight
+        // still looks like the reference/root height, subtract those positive
+        // margins to estimate the real visual content height. If XAML already
+        // reduced ActualHeight because of the margin, do not subtract again.
+        Thickness margin = element.Margin();
+        double positiveVerticalMargin =
+            std::max(0.0, margin.Top) + std::max(0.0, margin.Bottom);
+        if (referenceHeight > 1.0 && positiveVerticalMargin > 0.0 &&
+            height > referenceHeight - positiveVerticalMargin * 0.5) {
+            height = std::max(1.0, height - positiveVerticalMargin);
+        }
+
+        return height;
+    } catch (...) {
+        return 0.0;
+    }
+}
+
+double DetectTaskbarHeightDip(HWND hwnd,
+                              FrameworkElement const& root,
+                              FrameworkElement const& targetElement) {
+    double rootHeight = 0.0;
+    try {
+        if (root) {
+            rootHeight = root.ActualHeight();
+        }
+    } catch (...) {
+        rootHeight = 0.0;
+    }
+
+    double bestVisualHeight = 0.0;
+    auto consider = [&](FrameworkElement const& element) {
+        double height = EffectiveElementVisualHeightDip(
+            element, rootHeight > 1.0 ? rootHeight : 0.0);
+        if (height >= 24.0) {
+            bestVisualHeight =
+                bestVisualHeight > 1.0 ? std::min(bestVisualHeight, height)
+                                        : height;
+        }
+    };
+
+    // The injection target can be a full-height layout grid. Use it, but also
+    // sample the tray grid because themes such as Matter/BottomDensy often put
+    // their visual compression there.
+    consider(targetElement);
+    if (root) {
+        consider(FindChildByName(root, L"SystemTrayFrameGrid"));
+        consider(FindChildByName(root, L"TaskbarFrame"));
+    }
+
+    double height = bestVisualHeight;
+    if (height <= 1.0 && rootHeight > 1.0) {
+        height = rootHeight;
+    }
+
+    if (height <= 1.0 && hwnd) {
+        RECT rc{};
+        if (GetWindowRect(hwnd, &rc)) {
+            UINT dpi = GetDpiForWindow(hwnd);
+            double scale = dpi > 0 ? static_cast<double>(dpi) / 96.0 : 1.0;
+            height = static_cast<double>(rc.bottom - rc.top) /
+                     std::max(0.01, scale);
+        }
+    }
+
+    return Clamp(height, 28.0, 96.0);
+}
+
+void UpdateRuntimeLayout(HWND hwnd,
+                         FrameworkElement const& root,
+                         FrameworkElement const& targetElement) {
+    double taskbarHeight = DetectTaskbarHeightDip(hwnd, root, targetElement);
+    g_layout.taskbarHeightDip = taskbarHeight;
+
+    double compactHeight = static_cast<double>(g_settings.height);
+    double compactWidth = static_cast<double>(g_settings.compactWidth);
+    if (g_settings.autoSizeToTaskbar) {
+        // Use the detected *visual* height, not the outer Shell_TrayWnd height.
+        // For smaller themed taskbars, never enlarge beyond the user's configured
+        // Height/CompactWidth; for genuinely tall taskbars, allow moderate growth.
+        double autoHeight = Clamp(taskbarHeight - 8.0, 28.0, 46.0);
+        double autoScale = autoHeight / 40.0;
+        double autoWidth = Clamp(168.0 * autoScale, 112.0, 220.0);
+
+        if (taskbarHeight <= 50.0) {
+            compactHeight = std::min(static_cast<double>(g_settings.height),
+                                     autoHeight);
+            compactWidth = std::min(static_cast<double>(g_settings.compactWidth),
+                                    autoWidth);
+        } else {
+            compactHeight = autoHeight;
+            compactWidth = autoWidth;
+        }
+    }
+
+    double scale = Clamp(compactHeight / 40.0, 0.68, 1.20);
+    g_layout.compactHeight = compactHeight;
+    g_layout.compactWidth = compactWidth;
+    g_layout.artSize = Clamp(compactHeight - 12.0, 18.0, 34.0);
+    g_layout.artImageSize = g_layout.artSize + 2.0;
+    g_layout.artCornerRadius = Clamp(g_layout.artSize * 0.29, 5.0, 10.0);
+    g_layout.cornerRadius = Clamp(compactHeight * 0.50, 12.0, 23.0);
+    g_layout.contentMarginX = Clamp(10.0 * scale, 6.0, 12.0);
+    g_layout.contentMarginY = Clamp(4.0 * scale, 2.0, 5.0);
+    g_layout.artColumnWidth = g_layout.artImageSize;
+    g_layout.textMarginX = Clamp(8.0 * scale, 4.0, 10.0);
+    g_layout.titleFontSize = Clamp(12.0 * scale, 10.0, 13.5);
+    g_layout.artistFontSize = Clamp(10.0 * scale, 8.5, 11.5);
+    g_layout.progressWidth = Clamp(74.0 * scale, 42.0, 92.0);
+    g_layout.progressHeight = Clamp(4.0 * scale, 2.5, 5.0);
+    g_layout.progressMarginLeft = Clamp(8.0 * scale, 4.0, 10.0);
+}
+
 Grid BuildIslandGrid() {
     Grid wrapper;
     wrapper.Name(L"IslandMedia_Wrapper");
     wrapper.Tag(winrt::box_value(winrt::hstring(L"IslandMediaControls")));
-    wrapper.Width(g_settings.compactWidth);
-    wrapper.Height(g_settings.height);
-    wrapper.MinHeight(g_settings.height);
+    wrapper.Width(g_layout.compactWidth);
+    wrapper.Height(g_layout.compactHeight);
+    wrapper.MinHeight(g_layout.compactHeight);
     wrapper.VerticalAlignment(VerticalAlignment::Center);
     wrapper.HorizontalAlignment(HorizontalAlignment::Left);
     wrapper.Margin({static_cast<double>(g_settings.marginLeft), 0,
@@ -6223,7 +6623,7 @@ Grid BuildIslandGrid() {
 
     Border background;
     background.Name(L"Island_Background");
-    background.CornerRadius({20, 20, 20, 20});
+    background.CornerRadius({g_layout.cornerRadius, g_layout.cornerRadius, g_layout.cornerRadius, g_layout.cornerRadius});
     background.Background(IslandBackgroundBrush());
     background.BorderBrush(IslandBorderBrush());
     background.BorderThickness({1, 1, 1, 1});
@@ -6231,11 +6631,11 @@ Grid BuildIslandGrid() {
 
     Grid content;
     content.Name(L"Island_Content");
-    content.Margin({10, 4, 10, 4});
+    content.Margin({g_layout.contentMarginX, g_layout.contentMarginY, g_layout.contentMarginX, g_layout.contentMarginY});
     controls::Canvas::SetZIndex(content, 1);
 
     ColumnDefinition artCol;
-    artCol.Width({30, GridUnitType::Pixel});
+    artCol.Width({g_layout.artColumnWidth, GridUnitType::Pixel});
     ColumnDefinition textCol;
     textCol.Width({1, GridUnitType::Star});
     ColumnDefinition controlsCol;
@@ -6246,9 +6646,9 @@ Grid BuildIslandGrid() {
 
     Border art;
     art.Name(L"Island_ArtFallback");
-    art.Width(28);
-    art.Height(28);
-    art.CornerRadius({8, 8, 8, 8});
+    art.Width(g_layout.artSize);
+    art.Height(g_layout.artSize);
+    art.CornerRadius({g_layout.artCornerRadius, g_layout.artCornerRadius, g_layout.artCornerRadius, g_layout.artCornerRadius});
     // Keep the parent transparent. The old blue fallback could show through as a
     // 1px strip on the right/bottom when the generated cover was rounded/scaled.
     art.Background(Brush(Color(0x00, 0x00, 0x00, 0x00)));
@@ -6257,15 +6657,16 @@ Grid BuildIslandGrid() {
     art.VerticalAlignment(VerticalAlignment::Center);
 
     Grid artHost;
-    artHost.Width(28);
-    artHost.Height(28);
-    ApplyElementClip(artHost, 28.0, 28.0);
+    artHost.Name(L"Island_ArtHost");
+    artHost.Width(g_layout.artSize);
+    artHost.Height(g_layout.artSize);
+    ApplyElementClip(artHost, g_layout.artSize, g_layout.artSize);
 
     Border artPlaceholder;
     artPlaceholder.Name(L"Island_ArtPlaceholder");
-    artPlaceholder.Width(28);
-    artPlaceholder.Height(28);
-    artPlaceholder.CornerRadius({8, 8, 8, 8});
+    artPlaceholder.Width(g_layout.artSize);
+    artPlaceholder.Height(g_layout.artSize);
+    artPlaceholder.CornerRadius({g_layout.artCornerRadius, g_layout.artCornerRadius, g_layout.artCornerRadius, g_layout.artCornerRadius});
     artPlaceholder.Background(Brush(Color(0xFF, 0x4F, 0x7D, 0xE8)));
     artPlaceholder.BorderThickness({0, 0, 0, 0});
     artPlaceholder.IsHitTestVisible(false);
@@ -6273,8 +6674,8 @@ Grid BuildIslandGrid() {
 
     Image artFade;
     artFade.Name(L"Island_AlbumArtFade");
-    artFade.Width(30);
-    artFade.Height(30);
+    artFade.Width(g_layout.artImageSize);
+    artFade.Height(g_layout.artImageSize);
     artFade.Margin({-1, -1, -1, -1});
     artFade.Stretch(mediax::Stretch::UniformToFill);
     artFade.Opacity(0.0);
@@ -6282,8 +6683,8 @@ Grid BuildIslandGrid() {
 
     Image artImage;
     artImage.Name(L"Island_AlbumArt");
-    artImage.Width(30);
-    artImage.Height(30);
+    artImage.Width(g_layout.artImageSize);
+    artImage.Height(g_layout.artImageSize);
     artImage.Margin({-1, -1, -1, -1});
     artImage.Stretch(mediax::Stretch::UniformToFill);
     artImage.Opacity(1.0);
@@ -6291,9 +6692,9 @@ Grid BuildIslandGrid() {
 
     Border artStroke;
     artStroke.Name(L"Island_ArtStroke");
-    artStroke.Width(28);
-    artStroke.Height(28);
-    artStroke.CornerRadius({8, 8, 8, 8});
+    artStroke.Width(g_layout.artSize);
+    artStroke.Height(g_layout.artSize);
+    artStroke.CornerRadius({g_layout.artCornerRadius, g_layout.artCornerRadius, g_layout.artCornerRadius, g_layout.artCornerRadius});
     artStroke.Background(Brush(Color(0x00, 0x00, 0x00, 0x00)));
     artStroke.BorderThickness({1, 1, 1, 1});
     artStroke.BorderBrush(IslandBorderBrush());
@@ -6310,7 +6711,7 @@ Grid BuildIslandGrid() {
     Grid textHost;
     textHost.Name(L"Island_TextHost");
     textHost.VerticalAlignment(VerticalAlignment::Center);
-    textHost.Margin({8, 0, 8, 0});
+    textHost.Margin({g_layout.textMarginX, 0, g_layout.textMarginX, 0});
     controls::Grid::SetColumn(textHost, 1);
 
     StackPanel outgoingTextStack;
@@ -6318,14 +6719,14 @@ Grid BuildIslandGrid() {
     outgoingTextStack.VerticalAlignment(VerticalAlignment::Center);
     outgoingTextStack.Opacity(1.0);
 
-    auto outgoingTitle = MakeTextBlock(L"Island_OutgoingTitle", 12, true);
+    auto outgoingTitle = MakeTextBlock(L"Island_OutgoingTitle", g_layout.titleFontSize, true);
     outgoingTitle.FontWeight(winrt::Windows::UI::Text::FontWeights::Bold());
     outgoingTitle.Opacity(0.0);
     TranslateTransform outgoingTitleTranslate;
     outgoingTitleTranslate.X(0.0);
     outgoingTitle.RenderTransform(outgoingTitleTranslate);
 
-    auto outgoingArtist = MakeTextBlock(L"Island_OutgoingCompactArtist", 10, false);
+    auto outgoingArtist = MakeTextBlock(L"Island_OutgoingCompactArtist", g_layout.artistFontSize, false);
     outgoingArtist.Foreground(Brush(IsDarkModeApprox() ? Color(0xB8, 0xFF, 0xFF, 0xFF)
                                                        : Color(0xB8, 0x1C, 0x1C, 0x20)));
     outgoingArtist.Opacity(0.0);
@@ -6341,12 +6742,12 @@ Grid BuildIslandGrid() {
     textStack.Orientation(controls::Orientation::Vertical);
     textStack.VerticalAlignment(VerticalAlignment::Center);
 
-    auto title = MakeTextBlock(L"Island_Title", 12, true);
+    auto title = MakeTextBlock(L"Island_Title", g_layout.titleFontSize, true);
     title.FontWeight(winrt::Windows::UI::Text::FontWeights::Bold());
     TranslateTransform titleTranslate;
     titleTranslate.X(0.0);
     title.RenderTransform(titleTranslate);
-    auto artist = MakeTextBlock(L"Island_CompactArtist", 10, false);
+    auto artist = MakeTextBlock(L"Island_CompactArtist", g_layout.artistFontSize, false);
     artist.Foreground(Brush(IsDarkModeApprox() ? Color(0xB8, 0xFF, 0xFF, 0xFF)
                                                : Color(0xB8, 0x1C, 0x1C, 0x20)));
     TranslateTransform artistTranslate;
@@ -6402,9 +6803,9 @@ Grid BuildIslandGrid() {
 
     ProgressBar progress;
     progress.Name(L"Island_Progress");
-    progress.Width(74);
-    progress.Height(4);
-    progress.Margin({8, 0, 0, 0});
+    progress.Width(g_layout.progressWidth);
+    progress.Height(g_layout.progressHeight);
+    progress.Margin({g_layout.progressMarginLeft, 0, 0, 0});
     progress.Minimum(0);
     progress.Maximum(1000);
     progress.Value(0);
@@ -6435,6 +6836,88 @@ Grid BuildIslandGrid() {
     return wrapper;
 }
 
+void StopTaskbarLayoutMonitor() {
+    if (g_taskbarLayoutRenderingHooked) {
+        try {
+            mediax::CompositionTarget::Rendering(g_taskbarLayoutRenderingToken);
+        } catch (...) {
+        }
+        g_taskbarLayoutRenderingHooked = false;
+    }
+    g_lastTaskbarLayoutCheckTime = {};
+    g_taskbarLayoutWatchRoot = nullptr;
+    g_taskbarLayoutWatchTarget = nullptr;
+}
+
+void OnTaskbarLayoutRendering(winrt::Windows::Foundation::IInspectable const&,
+                              winrt::Windows::Foundation::IInspectable const&) {
+    try {
+        if (g_unloading || !g_playerGrid || !g_taskbarLayoutWatchRoot ||
+            !g_taskbarLayoutWatchTarget) {
+            StopTaskbarLayoutMonitor();
+            return;
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        if (g_lastTaskbarLayoutCheckTime.time_since_epoch().count() != 0 &&
+            now - g_lastTaskbarLayoutCheckTime < std::chrono::milliseconds(600)) {
+            return;
+        }
+        g_lastTaskbarLayoutCheckTime = now;
+
+        double oldHeight = g_layout.compactHeight;
+        double oldWidth = g_layout.compactWidth;
+        double oldTaskbarHeight = g_layout.taskbarHeightDip;
+
+        HWND hwnd = g_taskbarWnd && IsWindow(g_taskbarWnd)
+                        ? g_taskbarWnd
+                        : FindCurrentProcessTaskbarWnd();
+        if (!hwnd) {
+            return;
+        }
+        g_taskbarWnd = hwnd;
+
+        UpdateRuntimeLayout(hwnd, g_taskbarLayoutWatchRoot,
+                            g_taskbarLayoutWatchTarget);
+
+        bool layoutChanged =
+            std::abs(g_layout.compactHeight - oldHeight) > 0.5 ||
+            std::abs(g_layout.compactWidth - oldWidth) > 0.5 ||
+            std::abs(g_layout.taskbarHeightDip - oldTaskbarHeight) > 0.75;
+
+        if (layoutChanged) {
+            ApplyExpandedState();
+            try {
+                g_playerGrid.UpdateLayout();
+            } catch (...) {
+            }
+            RefreshCompactTextHostClip(false);
+            if (!g_expanded) {
+                CapturePopupSourceGeometry();
+            }
+        }
+    } catch (...) {
+        StopTaskbarLayoutMonitor();
+    }
+}
+
+void StartTaskbarLayoutMonitor(FrameworkElement const& root,
+                               FrameworkElement const& targetElement) {
+    if (g_unloading || !root || !targetElement) {
+        return;
+    }
+
+    g_taskbarLayoutWatchRoot = root;
+    g_taskbarLayoutWatchTarget = targetElement;
+    g_lastTaskbarLayoutCheckTime = {};
+
+    if (!g_taskbarLayoutRenderingHooked) {
+        g_taskbarLayoutRenderingToken =
+            mediax::CompositionTarget::Rendering(OnTaskbarLayoutRendering);
+        g_taskbarLayoutRenderingHooked = true;
+    }
+}
+
 void UpdatePlayerContents() {
     if (!g_playerGrid || g_unloading) {
         return;
@@ -6443,16 +6926,82 @@ void UpdatePlayerContents() {
     try {
     MediaState state = SnapshotMedia();
 
-    // Some media sessions briefly report a new title before the new thumbnail is
-    // available. Keep the previous real artwork during that transient empty
-    // thumbnail state to avoid a placeholder-cover flash on every track change.
+    // Some providers briefly report metadata before the matching thumbnail is
+    // available. Reuse old artwork only when the *same media item* temporarily
+    // has an empty thumbnail. Do not carry a previous song/video cover into a
+    // new browser live room, where GSMTC often reports no thumbnail or repeats
+    // the previous thumbnail while the page is still updating.
+    auto artworkNow = std::chrono::steady_clock::now();
+    std::wstring artworkIdentityKey = MediaIdentityKey(state);
+    uint64_t rawThumbnailHash = ThumbnailHash(state.thumbnailBytes);
+
     static std::vector<uint8_t> s_lastNonEmptyThumbnailBytes;
+    static std::wstring s_lastNonEmptyThumbnailIdentityKey;
+    static uint64_t s_lastNonEmptyThumbnailHash = 0;
+    static std::chrono::steady_clock::time_point s_lastNonEmptyThumbnailTime{};
+    static std::wstring s_suspectRepeatedThumbnailIdentityKey;
+    static uint64_t s_suspectRepeatedThumbnailHash = 0;
+    static std::chrono::steady_clock::time_point s_suspectRepeatedThumbnailSince{};
+
     std::vector<uint8_t> visualThumbnailBytes = state.thumbnailBytes;
-    if (!state.thumbnailBytes.empty()) {
-        s_lastNonEmptyThumbnailBytes = state.thumbnailBytes;
-    } else if (state.hasSession && !s_lastNonEmptyThumbnailBytes.empty()) {
-        visualThumbnailBytes = s_lastNonEmptyThumbnailBytes;
-    } else if (!state.hasSession) {
+    if (!state.hasSession) {
+        visualThumbnailBytes.clear();
+        s_suspectRepeatedThumbnailIdentityKey.clear();
+        s_suspectRepeatedThumbnailHash = 0;
+    } else if (!state.thumbnailBytes.empty()) {
+        bool differentMedia =
+            !s_lastNonEmptyThumbnailIdentityKey.empty() &&
+            artworkIdentityKey != s_lastNonEmptyThumbnailIdentityKey;
+        bool repeatedPreviousArtwork =
+            differentMedia &&
+            rawThumbnailHash != 0 &&
+            rawThumbnailHash == s_lastNonEmptyThumbnailHash;
+        bool browserLiveLike =
+            LooksLikeBrowserMediaSource(state.sourceAppUserModelId) &&
+            state.durationTicks <= 0;
+
+        if (repeatedPreviousArtwork && browserLiveLike) {
+            if (s_suspectRepeatedThumbnailIdentityKey != artworkIdentityKey ||
+                s_suspectRepeatedThumbnailHash != rawThumbnailHash) {
+                s_suspectRepeatedThumbnailIdentityKey = artworkIdentityKey;
+                s_suspectRepeatedThumbnailHash = rawThumbnailHash;
+                s_suspectRepeatedThumbnailSince = artworkNow;
+            }
+
+            // Give browser/GSMTC a short chance to replace a stale thumbnail.
+            // During that window show the placeholder instead of the previous
+            // video's cover. If it never changes, accept it later so the UI
+            // doesn't stay placeholder forever.
+            auto suspectAge =
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    artworkNow - s_suspectRepeatedThumbnailSince)
+                    .count();
+            if (suspectAge < 3500) {
+                visualThumbnailBytes.clear();
+            }
+        } else {
+            s_suspectRepeatedThumbnailIdentityKey.clear();
+            s_suspectRepeatedThumbnailHash = 0;
+        }
+
+        if (!visualThumbnailBytes.empty()) {
+            s_lastNonEmptyThumbnailBytes = state.thumbnailBytes;
+            s_lastNonEmptyThumbnailIdentityKey = artworkIdentityKey;
+            s_lastNonEmptyThumbnailHash = rawThumbnailHash;
+            s_lastNonEmptyThumbnailTime = artworkNow;
+        }
+    } else if (!s_lastNonEmptyThumbnailBytes.empty() &&
+               artworkIdentityKey == s_lastNonEmptyThumbnailIdentityKey) {
+        auto age =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                artworkNow - s_lastNonEmptyThumbnailTime)
+                .count();
+        if (age <= 2500) {
+            visualThumbnailBytes = s_lastNonEmptyThumbnailBytes;
+        } else {
+            visualThumbnailBytes.clear();
+        }
+    } else {
         visualThumbnailBytes.clear();
     }
 
@@ -6815,6 +7364,7 @@ void UpdatePlayerContents() {
 }
 
 void RemoveIslandGrid() {
+    StopTaskbarLayoutMonitor();
     StopHoverRenderLoop();
     StopCompactTextRenderLoop();
     StopCompactProgressRenderLoop();
@@ -6941,6 +7491,7 @@ bool InjectIslandGrid() {
             return false;
         }
 
+        UpdateRuntimeLayout(hwnd, root, target.grid);
         Grid island = BuildIslandGrid();
 
         if (target.overlay) {
@@ -6981,9 +7532,11 @@ bool InjectIslandGrid() {
 
         g_playerGrid = island;
         g_injectionParent = target.grid;
+        StartTaskbarLayoutMonitor(root, target.grid);
         ApplyExpandedState();
         UpdatePlayerContents();
         target.grid.UpdateLayout();
+        RefreshCompactTextHostClip(false);
         Wh_Log(L"Island: injected successfully");
         return true;
     } catch (...) {

--- a/mods/island-media-controls.wh.cpp
+++ b/mods/island-media-controls.wh.cpp
@@ -2,7 +2,7 @@
 // @id              island-media-controls
 // @name            Island Media Controls
 // @description     Dynamic island-like media controls for the Windows 11 taskbar.
-// @version         0.9.137
+// @version         0.9.146
 // @author          usho
 // @github          https://github.com/usho-lear
 // @license         MIT
@@ -15,10 +15,31 @@
 /*
 # Island Media Controls
 
+## What's new
+
+- **Liquid Glass material:** Adds GPU-accelerated edge and corner refraction,
+  a softer interior blur, and theme-aware highlights and tint.
+- **Refined media transitions:** Track text now moves with smoother directional
+  animation and fades naturally beneath the artwork or popup edges.
+- **More reliable media sessions:** Improves browser media detection and makes
+  recompiling, unloading, and restarting the mod more robust.
+- **Acrylic by default:** New installs use Acrylic, while the settings migration
+  moves existing Mica-like users to the new default once.
+- **Recording-friendly previews:** An optional static blurred backdrop keeps the
+  expanded player and its blur visible to screen recorders without self-capture.
+
 Bring the current media session directly into the Windows 11 taskbar with a
 compact, theme-aware island built from native XAML. Unlike a floating Win32
 overlay, the island is inserted into the taskbar layout as a real XAML Grid, so
 it fits naturally alongside your taskbar and system tray items.
+
+## Material previews
+
+| Material | Dark mode | Light mode |
+| :--- | :---: | :---: |
+| **Mica-like** | ![Mica-like material in dark mode](https://raw.githubusercontent.com/usho-lear/island-media-controls/main/previews/materials/mica-dark.png) | ![Mica-like material in light mode](https://raw.githubusercontent.com/usho-lear/island-media-controls/main/previews/materials/mica-light.png) |
+| **Acrylic** | ![Acrylic material in dark mode](https://raw.githubusercontent.com/usho-lear/island-media-controls/main/previews/materials/acrylic-dark.png) | ![Acrylic material in light mode](https://raw.githubusercontent.com/usho-lear/island-media-controls/main/previews/materials/acrylic-light.png) |
+| **Liquid Glass** | ![Liquid Glass material in dark mode](https://raw.githubusercontent.com/usho-lear/island-media-controls/main/previews/materials/liquid-glass-dark.png) | ![Liquid Glass material in light mode](https://raw.githubusercontent.com/usho-lear/island-media-controls/main/previews/materials/liquid-glass-light.png) |
 
 ## Preview
 
@@ -133,7 +154,7 @@ it fits naturally alongside your taskbar and system tray items.
     $description: Gaussian blur standard deviation for live WGC blur.
   - AllowScreenCapture: false
     $name: Allow screen capture of expanded popup
-    $description: Makes the expanded popup visible to screen recorders. This is useful for recording Liquid glass, but may let the live backdrop capture the popup itself on some systems.
+    $description: Uses a capturable static blurred backdrop for Acrylic and Liquid glass, avoiding self-capture feedback.
 */
 // ==/WindhawkModSettings==
 
@@ -146,7 +167,7 @@ it fits naturally alongside your taskbar and system tray items.
 #include <wincodec.h>
 #include <windows.ui.xaml.hosting.desktopwindowxamlsource.h>
 
-#define IMC_WGC_OVERLAY_AVAILABLE 1
+
 #include <inspectable.h>
 #include <d3d11.h>
 #include <dxgi1_2.h>
@@ -205,7 +226,7 @@ extern "C" HRESULT __stdcall CreateDirect3D11DeviceFromDXGIDevice(
 #include <winrt/Windows.Foundation.Numerics.h>
 #include <winrt/Windows.Media.Control.h>
 #include <winrt/Windows.Storage.Streams.h>
-#include <winrt/Windows.Foundation.h>
+
 #include <winrt/Windows.UI.h>
 #include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Input.h>
@@ -253,11 +274,11 @@ namespace imaging = winrt::Windows::UI::Xaml::Media::Imaging;
 namespace hosting = winrt::Windows::UI::Xaml::Hosting;
 namespace streams = winrt::Windows::Storage::Streams;
 namespace gsm = winrt::Windows::Media::Control;
-#if IMC_WGC_OVERLAY_AVAILABLE
+
 namespace capture = winrt::Windows::Graphics::Capture;
 namespace directx = winrt::Windows::Graphics::DirectX;
 namespace direct3d11 = winrt::Windows::Graphics::DirectX::Direct3D11;
-#endif
+
 
 using xaml::FrameworkElement;
 using xaml::GridLength;
@@ -497,6 +518,11 @@ int g_popupBackdropOverlayFallbackWidth = 0;
 int g_popupBackdropOverlayFallbackHeight = 0;
 int g_popupBackdropOverlayFallbackRadius = 0;
 bool g_popupBackdropOverlayFallbackPixelsValid = false;
+std::vector<BYTE> g_popupBackdropOverlayCleanPixels;
+RECT g_popupBackdropOverlayCleanRect{};
+int g_popupBackdropOverlayCleanWidth = 0;
+int g_popupBackdropOverlayCleanHeight = 0;
+bool g_popupBackdropOverlayCleanPixelsValid = false;
 
 void ClearPopupBackdropOverlayHandoffCache() {
     std::lock_guard cacheLock(g_popupBackdropOverlayHandoffMutex);
@@ -506,12 +532,17 @@ void ClearPopupBackdropOverlayHandoffCache() {
     g_popupBackdropOverlayFallbackHeight = 0;
     g_popupBackdropOverlayFallbackRadius = 0;
     g_popupBackdropOverlayFallbackPixelsValid = false;
+    g_popupBackdropOverlayCleanPixels.clear();
+    g_popupBackdropOverlayCleanRect = {};
+    g_popupBackdropOverlayCleanWidth = 0;
+    g_popupBackdropOverlayCleanHeight = 0;
+    g_popupBackdropOverlayCleanPixelsValid = false;
     g_popupOverlayWgcHandoffStartTime = {};
     g_popupOverlayWgcFinalReadyTime = {};
 }
 
 
-#if IMC_WGC_OVERLAY_AVAILABLE
+
 std::mutex g_popupOverlayWgcMutex;
 bool g_popupOverlayWgcRunning = false;
 bool g_popupOverlayWgcFrameCallbackHooked = false;
@@ -542,7 +573,14 @@ capture::GraphicsCaptureSession g_popupOverlayWgcSession{nullptr};
 winrt::event_token g_popupOverlayWgcFrameArrivedToken{};
 bool g_popupOverlayWgcHadFrame = false;
 std::chrono::steady_clock::time_point g_popupOverlayWgcDiagnosticStartTime{};
-#endif
+std::mutex g_popupOverlayWgcPresentMutex;
+std::vector<BYTE> g_popupOverlayWgcPendingPixels;
+RECT g_popupOverlayWgcPendingRect{};
+int g_popupOverlayWgcPendingWidth = 0;
+int g_popupOverlayWgcPendingHeight = 0;
+bool g_popupOverlayWgcPendingFrame = false;
+
+
 hosting::DesktopWindowXamlSource g_popupXamlSource = nullptr;
 HWND g_popupXamlChild = nullptr;
 Grid g_popupXamlRoot = nullptr;
@@ -674,9 +712,7 @@ bool g_compactTextRenderingHooked = false;
 double g_compactTextProgress = 1.0;
 std::chrono::steady_clock::time_point g_lastCompactTextFrameTime{};
 bool g_compactTextEdgeFadeActive = false;
-winrt::event_token g_taskbarLayoutRenderingToken{};
-bool g_taskbarLayoutRenderingHooked = false;
-std::chrono::steady_clock::time_point g_lastTaskbarLayoutCheckTime{};
+HWND g_taskbarLayoutTimerWindow = nullptr;
 FrameworkElement g_taskbarLayoutWatchRoot = nullptr;
 FrameworkElement g_taskbarLayoutWatchTarget = nullptr;
 bool g_compactTextInitialized = false;
@@ -3421,6 +3457,9 @@ constexpr wchar_t kPopupClassName[] = L"WindhawkIslandMediaPopup";
 constexpr wchar_t kPopupBackdropOverlayClassName[] = L"WindhawkIslandMediaBackdropOverlay";
 constexpr UINT_PTR kPopupTimerId = 0x494D;
 constexpr UINT_PTR kPopupBackdropOverlayTimerId = 0x494E;
+constexpr UINT kPopupBackdropOverlayPresentMessage = WM_APP + 0x149;
+constexpr UINT_PTR kTaskbarLayoutMonitorTimerId = 0x494D4C54;
+constexpr UINT kTaskbarLayoutMonitorIntervalMs = 600;
 constexpr int kPopupBackdropOverlayRefreshMs = 90;
 constexpr int kPopupBackdropOverlayMaxCaptureSize = 320;
 
@@ -3871,6 +3910,13 @@ void SetPopupTextEdgeFadeOpacity(double opacity) {
 
 mediax::Brush PopupBackdropCardTintBrush() {
     bool dark = IsDarkModeApprox();
+    if (g_settings.material == L"mica_like") {
+        // Mica-like already carries its theme tint in IslandBackgroundColor().
+        // A second light-mode white veil makes the expanded surface nearly
+        // opaque white and breaks compact-to-expanded material continuity.
+        return Brush(Color(0x00, 0x00, 0x00, 0x00));
+    }
+
     if (UseOverlayPopupBackdropMaterial()) {
         if (IsLiquidGlassMaterial()) {
             return Brush(dark ? Color(0x04, 0xFF, 0xFF, 0xFF)
@@ -5472,7 +5518,7 @@ void UpdatePopupXamlVisuals() {
             g_popupXamlBackdropRimHighlight.BorderThickness(
                 IsLiquidGlassMaterial() ? Thickness{1.0, 1.0, 1.0, 1.0}
                                         : Thickness{0.0, 0.0, 0.0, 0.0});
-            g_popupXamlBackdropRimHighlight.Opacity(liquidHighlightOpacity * 0.72);
+            g_popupXamlBackdropRimHighlight.Opacity(liquidHighlightOpacity);
         }
         ApplyCompositorRect(g_popupXamlBackdrop,
                             g_popupXamlBackdropScale,
@@ -6077,6 +6123,10 @@ void ReleasePopupOverlayWgcDeviceResources();
 bool StartPopupOverlayWgcBackdrop(RECT const& captureRect, int widthPx, int heightPx);
 void UpdatePopupOverlayWgcCaptureRect(RECT const& captureRect);
 void SetPopupWindowCaptureExclusion(HWND hwnd, bool exclude);
+void QueuePopupOverlayWgcFrame(std::vector<BYTE>&& pixels,
+                               RECT const& screenRect,
+                               int width,
+                               int height);
 void ClearPopupBackdropOverlayHandoffCache();
 bool ClearPopupBackdropOverlayLayeredSurface(HWND hwnd);
 
@@ -6973,6 +7023,24 @@ LRESULT CALLBACK ExpandedPopupWndProc(HWND hwnd, UINT message, WPARAM wParam, LP
             RenderExpandedPopupLayer();
             return 0;
         }
+        case WM_DPICHANGED: {
+            auto suggestedRect = reinterpret_cast<RECT const*>(lParam);
+            if (suggestedRect) {
+                SetWindowPos(hwnd,
+                             nullptr,
+                             suggestedRect->left,
+                             suggestedRect->top,
+                             suggestedRect->right - suggestedRect->left,
+                             suggestedRect->bottom - suggestedRect->top,
+                             SWP_NOACTIVATE | SWP_NOOWNERZORDER |
+                                 SWP_NOZORDER);
+            }
+            if (g_expandedPopup == hwnd) {
+                PositionExpandedPopup();
+                RenderExpandedPopupLayer();
+            }
+            return 0;
+        }
         case WM_SETTINGCHANGE:
         case WM_THEMECHANGED:
             g_popupXamlThemeValid = false;
@@ -7185,7 +7253,7 @@ bool UpdatePopupBackdropOverlayLayeredDiagnostic(HWND hwnd,
 }
 
 BYTE PopupRoundedRectAlpha(int x, int y, int width, int height, int radius);
-#if IMC_WGC_OVERLAY_AVAILABLE
+
 bool CreatePopupOverlayWgcCaptureItemForMonitor(HMONITOR monitor,
                                                 capture::GraphicsCaptureItem& item) {
     item = nullptr;
@@ -7283,6 +7351,7 @@ bool EnsurePopupOverlayWgcLensDisplacementMap(int width, int height, int radius)
     std::vector<BYTE> pixels(static_cast<size_t>(width) * height * 4);
     double widthD = static_cast<double>(width);
     double heightD = static_cast<double>(height);
+    double minD = std::min(widthD, heightD);
     double radiusD = static_cast<double>(radius);
     double halfWidth = widthD * 0.5;
     double halfHeight = heightD * 0.5;
@@ -7291,75 +7360,97 @@ bool EnsurePopupOverlayWgcLensDisplacementMap(int width, int height, int radius)
     double centerX = widthD * 0.5;
     double centerY = heightD * 0.5;
 
-    double edgeWidth = Clamp(std::min(width, height) * 0.14, 10.0, 30.0);
-    double outerWidth = Clamp(std::min(width, height) * 0.035, 2.2, 5.5);
+    // A smooth graded lens profile:
+    // - rimWidth: very narrow high-index strip close to the boundary;
+    // - shoulderWidth: visible edge-to-body transition;
+    // - bodyWidth: broad, low-index interior falloff.
+    double rimWidth = Clamp(minD * 0.030, 2.4, 5.8);
+    double shoulderWidth = Clamp(minD * 0.130, 11.0, 32.0);
+    double bodyWidth = Clamp(minD * 0.360, 30.0, 104.0);
 
     auto smootherStep = [](double value) {
         value = Clamp(value, 0.0, 1.0);
         return value * value * value *
                (value * (value * 6.0 - 15.0) + 10.0);
     };
+    auto smoothMax = [](double a, double b, double smoothness) {
+        double h = Clamp(0.5 + 0.5 * (a - b) / smoothness, 0.0, 1.0);
+        return a * h + b * (1.0 - h) + smoothness * h * (1.0 - h);
+    };
 
-    auto signedDistanceAndNormal = [&](double px,
-                                       double py,
-                                       double& distanceInside,
-                                       double& inwardX,
-                                       double& inwardY) {
+    auto signedDistanceAt = [&](double px, double py) {
         double localX = px - centerX;
         double localY = py - centerY;
-        double signX = localX < 0.0 ? -1.0 : 1.0;
-        double signY = localY < 0.0 ? -1.0 : 1.0;
         double qx = std::abs(localX) - innerHalfWidth;
         double qy = std::abs(localY) - innerHalfHeight;
         double outsideX = std::max(qx, 0.0);
         double outsideY = std::max(qy, 0.0);
         double outsideLength = std::sqrt(outsideX * outsideX +
                                          outsideY * outsideY);
-        double signedDistance =
-            outsideLength + std::min(std::max(qx, qy), 0.0) - radiusD;
-        distanceInside = -signedDistance;
-        if (distanceInside < 0.0) {
-            return false;
+
+        // The exact rounded-rect SDF uses max(qx, qy) in the interior. Once
+        // the low-index body field is nonzero, that hard max exposes a
+        // diagonal medial-axis seam. Smooth it slightly; outside/corner
+        // distances remain effectively unchanged, but the interior normal
+        // becomes continuous.
+        double hardMax = std::max(qx, qy);
+        double smoothness = Clamp(minD * 0.020, 3.0, 8.0);
+        double innerTerm =
+            hardMax < 0.0 ? smoothMax(qx, qy, smoothness) : hardMax;
+
+        return outsideLength + std::min(innerTerm, 0.0) - radiusD;
+    };
+
+    auto profileAtDistance = [&](double distance) {
+        if (distance < 0.0) {
+            return 0.0;
         }
 
-        double outwardX = 0.0;
-        double outwardY = 0.0;
-        if (outsideLength > 0.001) {
-            outwardX = signX * outsideX / outsideLength;
-            outwardY = signY * outsideY / outsideLength;
-        } else if (qx > qy) {
-            outwardX = signX;
-        } else {
-            outwardY = signY;
-        }
+        // Strong high-index rim, with a smooth shoulder so there is no
+        // contour line between the highlight band and the body lens.
+        double rim =
+            std::pow(1.0 - smootherStep(distance / std::max(1.0, rimWidth)),
+                     0.88);
+        double shoulder =
+            std::pow(1.0 -
+                         smootherStep(distance /
+                                      std::max(1.0, shoulderWidth)),
+                     0.84);
+        double body =
+            std::pow(1.0 -
+                         smootherStep(distance /
+                                      std::max(1.0, bodyWidth)),
+                     1.95);
 
-        inwardX = -outwardX;
-        inwardY = -outwardY;
-        return true;
+        return Clamp(rim * 0.70 + shoulder * 0.24 + body * 0.06,
+                     0.0,
+                     1.0);
     };
 
     for (int y = 0; y < height; ++y) {
         double fy = static_cast<double>(y) + 0.5;
         for (int x = 0; x < width; ++x) {
             double fx = static_cast<double>(x) + 0.5;
-            double distance = 0.0;
-            double inwardX = 0.0;
-            double inwardY = 0.0;
+            double signedDistance = signedDistanceAt(fx, fy);
+            double distance = -signedDistance;
             double offsetX = 0.0;
             double offsetY = 0.0;
 
-            if (signedDistanceAndNormal(fx, fy, distance, inwardX, inwardY) &&
-                distance <= edgeWidth) {
-                double transition =
-                    1.0 - smootherStep(distance / std::max(1.0, edgeWidth));
-                double peak =
-                    1.0 - smootherStep(distance / std::max(1.0, outerWidth));
-                double amount =
-                    Clamp(std::sqrt(transition) * 0.78 + peak * 0.22,
-                          0.0,
-                          1.0);
-                offsetX = inwardX * amount;
-                offsetY = inwardY * amount;
+            if (distance >= 0.0) {
+                constexpr double kGradientStep = 0.75;
+                double gradX = signedDistanceAt(fx + kGradientStep, fy) -
+                               signedDistanceAt(fx - kGradientStep, fy);
+                double gradY = signedDistanceAt(fx, fy + kGradientStep) -
+                               signedDistanceAt(fx, fy - kGradientStep);
+                double gradLength = std::sqrt(gradX * gradX + gradY * gradY);
+                if (gradLength > 0.0001) {
+                    double inwardX = -gradX / gradLength;
+                    double inwardY = -gradY / gradLength;
+
+                    double amount = profileAtDistance(distance);
+                    offsetX = inwardX * amount;
+                    offsetY = inwardY * amount;
+                }
             }
 
             size_t index = (static_cast<size_t>(y) * width + x) * 4;
@@ -7512,11 +7603,15 @@ bool DrawLiquidGlassGpuLensWarp(ID2D1DeviceContext* context,
         width <= 2 || height <= 2) {
         return false;
     }
+    if (!refractBitmap) {
+        refractBitmap = blurredBitmap;
+    }
 
     float widthF = static_cast<float>(width);
     float heightF = static_cast<float>(height);
     D2D1_POINT_2F imageTargetOffset{0.0f, 0.0f};
 
+    // Base glass: stable blur across the entire surface.
     context->DrawBitmap(blurredBitmap,
                         D2D1::RectF(0.0f, 0.0f, widthF, heightF),
                         1.0f,
@@ -7539,11 +7634,11 @@ bool DrawLiquidGlassGpuLensWarp(ID2D1DeviceContext* context,
         return true;
     }
 
-    displacementEffect->SetInput(0, blurredBitmap);
+    displacementEffect->SetInput(0, refractBitmap);
     displacementEffect->SetInput(1, g_popupOverlayWgcLensDisplacementMap.get());
 
     float scale =
-        static_cast<float>(Clamp(std::min(width, height) * 0.55, 18.0, 58.0));
+        static_cast<float>(Clamp(std::min(width, height) * 1.04, 30.0, 90.0));
     hr = displacementEffect->SetValue(D2D1_DISPLACEMENTMAP_PROP_SCALE, scale);
     if (FAILED(hr)) {
         return true;
@@ -7561,14 +7656,27 @@ bool DrawLiquidGlassGpuLensWarp(ID2D1DeviceContext* context,
         return true;
     }
 
-    // Draw the displaced image over the already-rendered base. The map is
-    // neutral in the interior, so this is effectively a smooth edge/corner
-    // refraction without per-tile pixel boundaries.
+    // Do not clip the displaced image into four rectangular edge bands. The
+    // creates a visibly different "center rectangle" where only the base blur
+    // is present. Instead, blend the full-field displacement over the base
+    // glass. The displacement map is neutral in the interior, so the whole
+    // surface shares one continuous lens field while the rim still pulls from
+    // the lower-blur refractive source.
+    D2D1_LAYER_PARAMETERS1 layerParams = D2D1::LayerParameters1(
+        D2D1::InfiniteRect(),
+        nullptr,
+        D2D1_ANTIALIAS_MODE_PER_PRIMITIVE,
+        D2D1::IdentityMatrix(),
+        0.58f,
+        nullptr,
+        D2D1_LAYER_OPTIONS1_NONE);
+    context->PushLayer(layerParams, nullptr);
     context->DrawImage(displacementEffect.get(),
                        &imageTargetOffset,
                        nullptr,
                        D2D1_INTERPOLATION_MODE_LINEAR,
                        D2D1_COMPOSITE_MODE_SOURCE_OVER);
+    context->PopLayer();
     return true;
 }
 
@@ -7709,7 +7817,7 @@ bool EnsurePopupOverlayWgcDeviceResources(HWND hwnd, int widthPx, int heightPx) 
     g_popupOverlayWgcDxgiDevice = g_popupOverlayWgcD3dDevice.as<IDXGIDevice>();
 
     D2D1_FACTORY_OPTIONS factoryOptions{};
-    hr = D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED,
+    hr = D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED,
                            __uuidof(ID2D1Factory1),
                            &factoryOptions,
                            reinterpret_cast<void**>(g_popupOverlayWgcD2dFactory.put()));
@@ -7789,6 +7897,20 @@ void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
         return;
     }
 
+    std::vector<BYTE> recordingCleanPixels;
+    bool useRecordingCleanBackdrop = false;
+    if (g_settings.allowScreenCapture && IsLiquidGlassMaterial()) {
+        std::lock_guard cacheLock(g_popupBackdropOverlayHandoffMutex);
+        if (g_popupBackdropOverlayCleanPixelsValid &&
+            g_popupBackdropOverlayCleanWidth == targetWidth &&
+            g_popupBackdropOverlayCleanHeight == targetHeight &&
+            g_popupBackdropOverlayCleanPixels.size() ==
+                static_cast<size_t>(targetWidth) * targetHeight * 4) {
+            recordingCleanPixels = g_popupBackdropOverlayCleanPixels;
+            useRecordingCleanBackdrop = true;
+        }
+    }
+
     try {
         auto surface = frame.Surface();
         winrt::com_ptr<IDirect3DDxgiInterfaceAccess> access;
@@ -7836,6 +7958,30 @@ void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
             static_cast<float>(targetWidth),
             static_cast<float>(targetHeight));
 
+        int cornerRadiusPx = g_popupBackdropOverlayLastRadius > 0
+                                  ? g_popupBackdropOverlayLastRadius
+                                  : static_cast<int>(std::lround(kPopupUnifiedCornerRadius *
+                                                                 PopupDpiScale(g_expandedPopup)));
+
+        winrt::com_ptr<ID2D1Bitmap1> recordingCleanBitmap;
+        winrt::com_ptr<ID2D1RoundedRectangleGeometry> recordingCleanMaskGeometry;
+        if (useRecordingCleanBackdrop) {
+            winrt::check_hresult(g_popupOverlayWgcD2dContext->CreateBitmap(
+                D2D1::SizeU(static_cast<UINT32>(targetWidth),
+                            static_cast<UINT32>(targetHeight)),
+                recordingCleanPixels.data(),
+                static_cast<UINT32>(targetWidth * 4),
+                &sourceProps,
+                recordingCleanBitmap.put()));
+
+            D2D1_ROUNDED_RECT cleanMaskRect = D2D1::RoundedRect(
+                targetRect,
+                static_cast<float>(cornerRadiusPx),
+                static_cast<float>(cornerRadiusPx));
+            winrt::check_hresult(g_popupOverlayWgcD2dFactory->CreateRoundedRectangleGeometry(
+                &cleanMaskRect,
+                recordingCleanMaskGeometry.put()));
+        }
         D2D1_BITMAP_PROPERTIES1 intermediateProps = D2D1::BitmapProperties1(
             D2D1_BITMAP_OPTIONS_TARGET,
             D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM,
@@ -7861,6 +8007,23 @@ void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
             1.0f,
             D2D1_INTERPOLATION_MODE_LINEAR,
             sourceRect);
+        if (recordingCleanBitmap && recordingCleanMaskGeometry) {
+            D2D1_LAYER_PARAMETERS1 cleanLayerParams = D2D1::LayerParameters1(
+                targetRect,
+                recordingCleanMaskGeometry.get(),
+                D2D1_ANTIALIAS_MODE_PER_PRIMITIVE,
+                D2D1::IdentityMatrix(),
+                1.0f,
+                nullptr,
+                D2D1_LAYER_OPTIONS1_NONE);
+            g_popupOverlayWgcD2dContext->PushLayer(cleanLayerParams, nullptr);
+            g_popupOverlayWgcD2dContext->DrawBitmap(
+                recordingCleanBitmap.get(),
+                targetRect,
+                1.0f,
+                D2D1_INTERPOLATION_MODE_LINEAR);
+            g_popupOverlayWgcD2dContext->PopLayer();
+        }
         HRESULT hr = g_popupOverlayWgcD2dContext->EndDraw();
         if (FAILED(hr)) {
             g_popupOverlayWgcLastHr = hr;
@@ -7873,11 +8036,6 @@ void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
                    static_cast<unsigned long long>(g_popupOverlayWgcRenderFailCount));
             return;
         }
-
-        int cornerRadiusPx = g_popupBackdropOverlayLastRadius > 0
-                                  ? g_popupBackdropOverlayLastRadius
-                                  : static_cast<int>(std::lround(kPopupUnifiedCornerRadius *
-                                                                 PopupDpiScale(g_expandedPopup)));
 
         winrt::com_ptr<ID2D1Effect> blurEffect;
         winrt::check_hresult(g_popupOverlayWgcD2dContext->CreateEffect(
@@ -8008,6 +8166,8 @@ void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
             g_popupOverlayWgcStagingTexture.get(),
             g_popupOverlayWgcRenderTexture.get());
 
+        std::vector<BYTE> layeredPixels(static_cast<size_t>(targetWidth) *
+                                        targetHeight * 4);
         D3D11_MAPPED_SUBRESOURCE mapped{};
         hr = g_popupOverlayWgcD3dContext->Map(
             g_popupOverlayWgcStagingTexture.get(),
@@ -8027,8 +8187,8 @@ void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
             return;
         }
 
-        std::vector<BYTE> layeredPixels(static_cast<size_t>(targetWidth) *
-                                        targetHeight * 4);
+
+
         bool dark = IsDarkModeApprox();
         double dim = dark ? 0.94 : 1.0;
         BYTE maxAlpha = PopupBackdropOverlayMaxAlpha();
@@ -8089,75 +8249,10 @@ void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
 
         g_popupOverlayWgcD3dContext->Unmap(g_popupOverlayWgcStagingTexture.get(), 0);
 
-        HDC screenDc = GetDC(nullptr);
-        if (!screenDc) {
-            return;
-        }
-        HDC memDc = CreateCompatibleDC(screenDc);
-        if (!memDc) {
-            ReleaseDC(nullptr, screenDc);
-            return;
-        }
-
-        BITMAPINFO info{};
-        info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-        info.bmiHeader.biWidth = targetWidth;
-        info.bmiHeader.biHeight = -targetHeight;
-        info.bmiHeader.biPlanes = 1;
-        info.bmiHeader.biBitCount = 32;
-        info.bmiHeader.biCompression = BI_RGB;
-
-        void* bits = nullptr;
-        HBITMAP bitmap = CreateDIBSection(screenDc, &info, DIB_RGB_COLORS,
-                                          &bits, nullptr, 0);
-        if (!bitmap || !bits) {
-            if (bitmap) DeleteObject(bitmap);
-            DeleteDC(memDc);
-            ReleaseDC(nullptr, screenDc);
-            return;
-        }
-        std::memcpy(bits, layeredPixels.data(), layeredPixels.size());
-
-        HGDIOBJ oldBitmap = SelectObject(memDc, bitmap);
-        POINT srcPoint{0, 0};
-        SIZE size{targetWidth, targetHeight};
-        POINT dstPoint{captureRect.left, captureRect.top};
-        BLENDFUNCTION blend{AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
-
-        BOOL updateOk = UpdateLayeredWindow(g_popupBackdropOverlay,
-                                            screenDc,
-                                            &dstPoint,
-                                            &size,
-                                            memDc,
-                                            &srcPoint,
-                                            0,
-                                            &blend,
-                                            ULW_ALPHA);
-        if (updateOk) {
-            static bool loggedFirstVisibleFrame = false;
-            if (!loggedFirstVisibleFrame) {
-                Wh_Log(L"Island: overlay WGC state first visible frame frames=%llu",
-                       static_cast<unsigned long long>(g_popupOverlayWgcFrameCount));
-                loggedFirstVisibleFrame = true;
-            }
-            SetPopupWindowCaptureExclusion(g_popupBackdropOverlay, true);
-            ShowWindow(g_popupBackdropOverlay, SW_SHOWNOACTIVATE);
-            g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::VisibleFrame;
-            g_popupOverlayWgcReadbackHadVisibleFrame = true;
-            g_popupOverlayWgcFallbackPainted = true;
-        } else {
-            g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::UpdateFailed;
-            ++g_popupOverlayWgcRenderFailCount;
-            Wh_Log(L"Island: overlay WGC state UpdateLayeredWindow failed err=%lu frames=%llu fails=%llu",
-                   GetLastError(),
-                   static_cast<unsigned long long>(g_popupOverlayWgcFrameCount),
-                   static_cast<unsigned long long>(g_popupOverlayWgcRenderFailCount));
-        }
-
-        SelectObject(memDc, oldBitmap);
-        DeleteObject(bitmap);
-        DeleteDC(memDc);
-        ReleaseDC(nullptr, screenDc);
+        QueuePopupOverlayWgcFrame(std::move(layeredPixels),
+                                  captureRect,
+                                  targetWidth,
+                                  targetHeight);
     } catch (winrt::hresult_error const& error) {
         g_popupOverlayWgcLastHr = error.code().value;
         g_popupOverlayWgcDiagnosticHr = error.code().value;
@@ -8173,6 +8268,147 @@ void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
         g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::RenderFailed;
         ++g_popupOverlayWgcRenderFailCount;
         Wh_Log(L"Island: overlay WGC state unknown failure frames=%llu fails=%llu",
+               static_cast<unsigned long long>(g_popupOverlayWgcFrameCount),
+               static_cast<unsigned long long>(g_popupOverlayWgcRenderFailCount));
+    }
+}
+
+void ClearPendingPopupOverlayWgcFrame() {
+    std::lock_guard presentLock(g_popupOverlayWgcPresentMutex);
+    g_popupOverlayWgcPendingPixels.clear();
+    g_popupOverlayWgcPendingRect = {};
+    g_popupOverlayWgcPendingWidth = 0;
+    g_popupOverlayWgcPendingHeight = 0;
+    g_popupOverlayWgcPendingFrame = false;
+}
+
+void QueuePopupOverlayWgcFrame(std::vector<BYTE>&& pixels,
+                               RECT const& screenRect,
+                               int width,
+                               int height) {
+    HWND overlay = g_popupBackdropOverlay;
+    if (!overlay || pixels.empty() || width <= 0 || height <= 0) {
+        return;
+    }
+
+    {
+        std::lock_guard presentLock(g_popupOverlayWgcPresentMutex);
+        g_popupOverlayWgcPendingPixels = std::move(pixels);
+        g_popupOverlayWgcPendingRect = screenRect;
+        g_popupOverlayWgcPendingWidth = width;
+        g_popupOverlayWgcPendingHeight = height;
+        g_popupOverlayWgcPendingFrame = true;
+    }
+
+    if (!PostMessageW(overlay, kPopupBackdropOverlayPresentMessage, 0, 0)) {
+        ClearPendingPopupOverlayWgcFrame();
+    }
+}
+
+void PresentPopupOverlayWgcFrame(HWND hwnd) {
+    std::vector<BYTE> pixels;
+    RECT screenRect{};
+    int width = 0;
+    int height = 0;
+    {
+        std::lock_guard presentLock(g_popupOverlayWgcPresentMutex);
+        if (!g_popupOverlayWgcPendingFrame) {
+            return;
+        }
+        pixels.swap(g_popupOverlayWgcPendingPixels);
+        screenRect = g_popupOverlayWgcPendingRect;
+        width = g_popupOverlayWgcPendingWidth;
+        height = g_popupOverlayWgcPendingHeight;
+        g_popupOverlayWgcPendingRect = {};
+        g_popupOverlayWgcPendingWidth = 0;
+        g_popupOverlayWgcPendingHeight = 0;
+        g_popupOverlayWgcPendingFrame = false;
+    }
+
+    if (hwnd != g_popupBackdropOverlay || width <= 0 || height <= 0 ||
+        pixels.size() != static_cast<size_t>(width) * height * 4) {
+        return;
+    }
+
+    HDC screenDc = GetDC(nullptr);
+    if (!screenDc) {
+        return;
+    }
+    HDC memDc = CreateCompatibleDC(screenDc);
+    if (!memDc) {
+        ReleaseDC(nullptr, screenDc);
+        return;
+    }
+
+    BITMAPINFO info{};
+    info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    info.bmiHeader.biWidth = width;
+    info.bmiHeader.biHeight = -height;
+    info.bmiHeader.biPlanes = 1;
+    info.bmiHeader.biBitCount = 32;
+    info.bmiHeader.biCompression = BI_RGB;
+
+    void* bits = nullptr;
+    HBITMAP bitmap = CreateDIBSection(screenDc, &info, DIB_RGB_COLORS,
+                                      &bits, nullptr, 0);
+    if (!bitmap || !bits) {
+        if (bitmap) {
+            DeleteObject(bitmap);
+        }
+        DeleteDC(memDc);
+        ReleaseDC(nullptr, screenDc);
+        return;
+    }
+    std::memcpy(bits, pixels.data(), pixels.size());
+
+    HGDIOBJ oldBitmap = SelectObject(memDc, bitmap);
+    POINT srcPoint{0, 0};
+    SIZE size{width, height};
+    POINT dstPoint{screenRect.left, screenRect.top};
+    BLENDFUNCTION blend{AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
+    BOOL updateOk = UpdateLayeredWindow(hwnd,
+                                        screenDc,
+                                        &dstPoint,
+                                        &size,
+                                        memDc,
+                                        &srcPoint,
+                                        0,
+                                        &blend,
+                                        ULW_ALPHA);
+    DWORD updateError =
+        updateOk ? ERROR_SUCCESS : GetLastError();
+
+    SelectObject(memDc, oldBitmap);
+    DeleteObject(bitmap);
+    DeleteDC(memDc);
+    ReleaseDC(nullptr, screenDc);
+
+    if (updateOk) {
+        SetPopupWindowCaptureExclusion(hwnd, true);
+        ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+    }
+
+    std::lock_guard lock(g_popupOverlayWgcMutex);
+    if (!g_popupOverlayWgcRunning || hwnd != g_popupBackdropOverlay) {
+        return;
+    }
+    if (updateOk) {
+        static bool loggedFirstVisibleFrame = false;
+        if (!loggedFirstVisibleFrame) {
+            Wh_Log(L"Island: overlay WGC state first visible frame frames=%llu",
+                   static_cast<unsigned long long>(g_popupOverlayWgcFrameCount));
+            loggedFirstVisibleFrame = true;
+        }
+        g_popupOverlayWgcDiagnosticState =
+            PopupOverlayWgcDiagnosticState::VisibleFrame;
+        g_popupOverlayWgcReadbackHadVisibleFrame = true;
+        g_popupOverlayWgcFallbackPainted = true;
+    } else {
+        g_popupOverlayWgcDiagnosticState =
+            PopupOverlayWgcDiagnosticState::UpdateFailed;
+        ++g_popupOverlayWgcRenderFailCount;
+        Wh_Log(L"Island: overlay WGC state UpdateLayeredWindow failed err=%lu frames=%llu fails=%llu",
+               updateError,
                static_cast<unsigned long long>(g_popupOverlayWgcFrameCount),
                static_cast<unsigned long long>(g_popupOverlayWgcRenderFailCount));
     }
@@ -8232,6 +8468,8 @@ void StopPopupOverlayWgcBackdrop() {
         g_popupOverlayWgcFinalReadyTime = {};
         g_popupOverlayWgcFramesToSkip = 0;
     }
+
+    ClearPendingPopupOverlayWgcFrame();
 
     if (g_expandedPopup) {
         SetWindowDisplayAffinity(g_expandedPopup, WDA_NONE);
@@ -8386,7 +8624,10 @@ bool StartPopupOverlayWgcBackdrop(RECT const& captureRect,
                     return;
                 }
                 auto frame = sender.TryGetNextFrame();
-                RenderPopupOverlayWgcFrame(frame);
+                if (frame) {
+                    RenderPopupOverlayWgcFrame(frame);
+                    frame.Close();
+                }
             });
         g_popupOverlayWgcFrameCallbackHooked = true;
         g_popupOverlayWgcSession =
@@ -8447,16 +8688,16 @@ void UpdatePopupOverlayWgcCaptureRect(RECT const& captureRect) {
         g_popupOverlayWgcCaptureRectPx = captureRect;
     }
 }
-#else
-void StopPopupOverlayWgcBackdrop() {}
-void ReleasePopupOverlayWgcDeviceResources() {}
-bool StartPopupOverlayWgcBackdrop(RECT const&, int, int) {
-    g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
-    g_popupOverlayWgcDiagnosticHr = E_NOTIMPL;
-    return false;
-}
-void UpdatePopupOverlayWgcCaptureRect(RECT const&) {}
-#endif
+
+
+
+
+
+
+
+
+
+
 
 BYTE PopupRoundedRectAlpha(int x, int y, int width, int height, int radius) {
     if (width <= 0 || height <= 0) {
@@ -8781,8 +9022,30 @@ bool UpdatePopupBackdropOverlayLayeredBlur(HWND hwnd,
         return false;
     }
 
-    BoxBlurPbgraPixels(lowPixels, lowWidth, lowHeight,
-                       PopupBackdropFallbackBlurPasses());
+    std::vector<BYTE> cleanPixels(static_cast<size_t>(width) * height * 4);
+    for (int y = 0; y < height; ++y) {
+        double sampleY = ((static_cast<double>(y) + 0.5) * lowHeight / height) - 0.5;
+        for (int x = 0; x < width; ++x) {
+            double sampleX = ((static_cast<double>(x) + 0.5) * lowWidth / width) - 0.5;
+            int sb = 0;
+            int sg = 0;
+            int sr = 0;
+            SampleBilinearPbgra(lowPixels, lowWidth, lowHeight, sampleX, sampleY, sb, sg, sr);
+
+            BYTE* dst = cleanPixels.data() +
+                         (static_cast<size_t>(y) * width + x) * 4;
+            dst[0] = static_cast<BYTE>(sb);
+            dst[1] = static_cast<BYTE>(sg);
+            dst[2] = static_cast<BYTE>(sr);
+            dst[3] = 255;
+        }
+    }
+
+    int blurPasses = PopupBackdropFallbackBlurPasses();
+    if (g_settings.allowScreenCapture && IsLiquidGlassMaterial()) {
+        blurPasses = std::max(blurPasses, 3);
+    }
+    BoxBlurPbgraPixels(lowPixels, lowWidth, lowHeight, blurPasses);
 
     std::vector<BYTE> out(static_cast<size_t>(width) * height * 4);
     bool dark = IsDarkModeApprox();
@@ -8823,6 +9086,11 @@ bool UpdatePopupBackdropOverlayLayeredBlur(HWND hwnd,
         g_popupBackdropOverlayFallbackHeight = height;
         g_popupBackdropOverlayFallbackRadius = cornerRadiusPx;
         g_popupBackdropOverlayFallbackPixelsValid = true;
+        g_popupBackdropOverlayCleanPixels = cleanPixels;
+        g_popupBackdropOverlayCleanRect = screenRect;
+        g_popupBackdropOverlayCleanWidth = width;
+        g_popupBackdropOverlayCleanHeight = height;
+        g_popupBackdropOverlayCleanPixelsValid = true;
     }
 
     HDC screenDc = GetDC(nullptr);
@@ -8890,6 +9158,9 @@ LRESULT CALLBACK PopupBackdropOverlayWndProc(HWND hwnd, UINT message, WPARAM wPa
             return 1;
         case WM_NCHITTEST:
             return HTTRANSPARENT;
+        case kPopupBackdropOverlayPresentMessage:
+            PresentPopupOverlayWgcFrame(hwnd);
+            return 0;
         case WM_TIMER:
             if (wParam == kPopupBackdropOverlayTimerId) {
                 UpdatePopupBackdropOverlayWindow();
@@ -8900,6 +9171,7 @@ LRESULT CALLBACK PopupBackdropOverlayWndProc(HWND hwnd, UINT message, WPARAM wPa
             PaintPopupBackdropOverlay(hwnd);
             return 0;
         case WM_DESTROY:
+            ClearPendingPopupOverlayWgcFrame();
             KillTimer(hwnd, kPopupBackdropOverlayTimerId);
             SetPopupWindowCaptureExclusion(hwnd, false);
             if (g_popupBackdropOverlay == hwnd) {
@@ -9189,6 +9461,39 @@ void UpdatePopupBackdropOverlayWindow() {
     double progress = PopupProgress();
     bool finalGeometryReady = !g_popupClosing && progress >= 0.995;
 
+    if (g_settings.allowScreenCapture && UseOverlayPopupBackdropMaterial()) {
+        bool wasWgcRunning = g_popupOverlayWgcRunning;
+        if (wasWgcRunning) {
+            StopPopupOverlayWgcBackdrop();
+        }
+
+        // Use a capturable static blur instead of a live monitor capture.
+        // Exclude the popup only while taking the clean background snapshot.
+        SetPopupWindowCaptureExclusion(g_expandedPopup, true);
+        SetPopupWindowCaptureExclusion(g_popupBackdropOverlay, true);
+        DwmFlush();
+
+        bool forceSnapshot =
+            wasWgcRunning ||
+            !g_popupBackdropOverlayFallbackPixelsValid ||
+            g_popupBackdropOverlayFallbackWidth != width ||
+            g_popupBackdropOverlayFallbackHeight != height;
+        UpdatePopupBackdropOverlayLayeredBlur(g_popupBackdropOverlay,
+                                              overlayRect,
+                                              width,
+                                              height,
+                                              cornerRadiusPx,
+                                              forceSnapshot);
+        g_popupOverlayWgcFallbackPainted = true;
+        g_popupOverlayWgcFinalReadyTime = {};
+
+        // No internal WGC session is running, so both windows can safely be
+        // included in desktop capture without creating recursive feedback.
+        SetPopupWindowCaptureExclusion(g_popupBackdropOverlay, false);
+        SetPopupWindowCaptureExclusion(g_expandedPopup, false);
+        return;
+    }
+
     if (!finalGeometryReady && g_popupClosing) {
         // Closing still favors the stable fallback path; it avoids extra WGC
         // churn while the popup is being torn down.
@@ -9342,13 +9647,29 @@ bool EnsureExpandedPopup() {
         return false;
     }
 
+    HWND popupOwner = g_taskbarWnd && IsWindow(g_taskbarWnd)
+                          ? g_taskbarWnd
+                          : FindCurrentProcessTaskbarWnd();
+    RECT ownerRect{};
+    int initialX = 0;
+    int initialY = 0;
+    if (popupOwner && GetWindowRect(popupOwner, &ownerRect)) {
+        g_taskbarWnd = popupOwner;
+        initialX = ownerRect.left;
+        initialY = ownerRect.top;
+    }
+    int initialWidth =
+        std::max(1, PopupDipToPx(g_layout.compactWidth, popupOwner));
+    int initialHeight =
+        std::max(1, PopupDipToPx(g_layout.compactHeight, popupOwner));
+
     g_expandedPopup = CreateWindowExW(
         WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
         kPopupClassName, L"",
-        WS_POPUP, 0, 0,
-        static_cast<int>(std::lround(g_layout.compactWidth)),
-        static_cast<int>(std::lround(g_layout.compactHeight)),
-        g_taskbarWnd, nullptr, ModInstance(), nullptr);
+        WS_POPUP, initialX, initialY,
+        initialWidth,
+        initialHeight,
+        popupOwner, nullptr, ModInstance(), nullptr);
     if (!g_expandedPopup) {
         return false;
     }
@@ -10474,33 +10795,24 @@ Grid BuildIslandGrid() {
 }
 
 void StopTaskbarLayoutMonitor() {
-    if (g_taskbarLayoutRenderingHooked) {
-        try {
-            mediax::CompositionTarget::Rendering(g_taskbarLayoutRenderingToken);
-        } catch (...) {
-        }
-        g_taskbarLayoutRenderingHooked = false;
+    if (g_taskbarLayoutTimerWindow) {
+        KillTimer(g_taskbarLayoutTimerWindow, kTaskbarLayoutMonitorTimerId);
+        g_taskbarLayoutTimerWindow = nullptr;
     }
-    g_lastTaskbarLayoutCheckTime = {};
     g_taskbarLayoutWatchRoot = nullptr;
     g_taskbarLayoutWatchTarget = nullptr;
 }
 
-void OnTaskbarLayoutRendering(winrt::Windows::Foundation::IInspectable const&,
-                              winrt::Windows::Foundation::IInspectable const&) {
+void CALLBACK OnTaskbarLayoutTimer(HWND, UINT, UINT_PTR timerId, DWORD) {
     try {
+        if (timerId != kTaskbarLayoutMonitorTimerId) {
+            return;
+        }
         if (g_unloading || !g_playerGrid || !g_taskbarLayoutWatchRoot ||
             !g_taskbarLayoutWatchTarget) {
             StopTaskbarLayoutMonitor();
             return;
         }
-
-        auto now = std::chrono::steady_clock::now();
-        if (g_lastTaskbarLayoutCheckTime.time_since_epoch().count() != 0 &&
-            now - g_lastTaskbarLayoutCheckTime < std::chrono::milliseconds(600)) {
-            return;
-        }
-        g_lastTaskbarLayoutCheckTime = now;
 
         double oldHeight = g_layout.compactHeight;
         double oldWidth = g_layout.compactWidth;
@@ -10544,15 +10856,23 @@ void StartTaskbarLayoutMonitor(FrameworkElement const& root,
         return;
     }
 
+    StopTaskbarLayoutMonitor();
     g_taskbarLayoutWatchRoot = root;
     g_taskbarLayoutWatchTarget = targetElement;
-    g_lastTaskbarLayoutCheckTime = {};
 
-    if (!g_taskbarLayoutRenderingHooked) {
-        g_taskbarLayoutRenderingToken =
-            mediax::CompositionTarget::Rendering(OnTaskbarLayoutRendering);
-        g_taskbarLayoutRenderingHooked = true;
+    HWND hwnd = g_taskbarWnd && IsWindow(g_taskbarWnd)
+                    ? g_taskbarWnd
+                    : FindCurrentProcessTaskbarWnd();
+    if (!hwnd ||
+        !SetTimer(hwnd,
+                  kTaskbarLayoutMonitorTimerId,
+                  kTaskbarLayoutMonitorIntervalMs,
+                  OnTaskbarLayoutTimer)) {
+        g_taskbarLayoutWatchRoot = nullptr;
+        g_taskbarLayoutWatchTarget = nullptr;
+        return;
     }
+    g_taskbarLayoutTimerWindow = hwnd;
 }
 
 void UpdatePlayerContents() {
@@ -11344,6 +11664,14 @@ void Wh_ModSettingsChanged() {
     if (!IsModActive()) {
         return;
     }
+    if (Wh_GetIntValue(kMigrateMicaLikeMaterialValue, 0) &&
+        GetStringSetting(L"Main.Material", L"acrylic") == L"mica_like") {
+        // A settings-page change makes the current material an explicit user
+        // choice. Stop applying the one-time old-default migration so
+        // Mica-like can be selected normally after the update.
+        Wh_SetIntValue(kMigrateMicaLikeMaterialValue, 0);
+    }
+
     Settings settings = ReadSettings();
     {
         std::lock_guard lock(g_pendingSettingsMutex);

--- a/mods/island-media-controls.wh.cpp
+++ b/mods/island-media-controls.wh.cpp
@@ -2,7 +2,7 @@
 // @id              island-media-controls
 // @name            Island Media Controls
 // @description     Dynamic island-like media controls for the Windows 11 taskbar.
-// @version         0.9.87
+// @version         0.9.88
 // @author          usho
 // @github          https://github.com/usho-lear
 // @license         MIT
@@ -587,6 +587,8 @@ RECT g_lastPopupWindowRect{LONG_MIN, LONG_MIN, LONG_MIN, LONG_MIN};
 TextBlock g_compactTitleText = nullptr;
 TextBlock g_compactArtistText = nullptr;
 FrameworkElement g_compactTextHost = nullptr;
+Border g_compactTextLeftFade = nullptr;
+Border g_compactTextRightFade = nullptr;
 TextBlock g_compactOutgoingTitleText = nullptr;
 TextBlock g_compactOutgoingArtistText = nullptr;
 TranslateTransform g_compactTitleTranslate = nullptr;
@@ -603,6 +605,7 @@ winrt::event_token g_compactTextRenderingToken{};
 bool g_compactTextRenderingHooked = false;
 double g_compactTextProgress = 1.0;
 std::chrono::steady_clock::time_point g_lastCompactTextFrameTime{};
+bool g_compactTextEdgeFadeActive = false;
 winrt::event_token g_taskbarLayoutRenderingToken{};
 bool g_taskbarLayoutRenderingHooked = false;
 std::chrono::steady_clock::time_point g_lastTaskbarLayoutCheckTime{};
@@ -848,11 +851,11 @@ bool IsDarkModeApprox() {
     return value == 0;
 }
 
-mediax::Brush IslandBackgroundBrush() {
+winrt::Windows::UI::Color IslandBackgroundColor() {
     bool dark = IsDarkModeApprox();
     if (g_settings.material == L"mica_like") {
-        return Brush(dark ? Color(0xC8, 0x2A, 0x2A, 0x2F)
-                          : Color(0xD4, 0xF3, 0xF3, 0xF6));
+        return dark ? Color(0xC8, 0x2A, 0x2A, 0x2F)
+                    : Color(0xD4, 0xF3, 0xF3, 0xF6);
     }
 
     if (g_settings.material == L"acrylic") {
@@ -860,12 +863,16 @@ mediax::Brush IslandBackgroundBrush() {
         // island loses focus, which makes the compact island suddenly look gray
         // and dirty. The expanded acrylic path uses a native overlay instead;
         // keep the compact surface visually stable with a tinted brush.
-        return Brush(dark ? Color(0xD8, 0x20, 0x20, 0x24)
-                          : Color(0xEA, 0xF8, 0xF8, 0xFA));
+        return dark ? Color(0xD8, 0x20, 0x20, 0x24)
+                    : Color(0xEA, 0xF8, 0xF8, 0xFA);
     }
 
-    return Brush(dark ? Color(0xE8, 0x20, 0x20, 0x24)
-                      : Color(0xE8, 0xF4, 0xF4, 0xF6));
+    return dark ? Color(0xE8, 0x20, 0x20, 0x24)
+                : Color(0xE8, 0xF4, 0xF4, 0xF6);
+}
+
+mediax::Brush IslandBackgroundBrush() {
+    return Brush(IslandBackgroundColor());
 }
 
 mediax::Brush IslandBorderBrush() {
@@ -3212,6 +3219,54 @@ void ApplyElementClip(FrameworkElement const& element, double width, double heig
         element.Clip(clip);
     } catch (...) {
     }
+}
+
+void ApplyElementClipWithPadding(FrameworkElement const& element,
+                                 double width,
+                                 double height,
+                                 double horizontalPadding) {
+    if (!element || width <= 0.0 || height <= 0.0) {
+        return;
+    }
+    try {
+        horizontalPadding = std::max(0.0, horizontalPadding);
+        mediax::RectangleGeometry clip;
+        clip.Rect({static_cast<float>(-horizontalPadding), 0.0f,
+                   static_cast<float>(std::max(1.0, width + horizontalPadding * 2.0)),
+                   static_cast<float>(std::max(1.0, height))});
+        element.Clip(clip);
+    } catch (...) {
+    }
+}
+
+mediax::Brush CompactTextEdgeFadeBrush(bool leftEdge) {
+    auto bg = IslandBackgroundColor();
+    auto clear = bg;
+    clear.A = 0x00;
+
+    mediax::LinearGradientBrush brush;
+    brush.StartPoint({0.0, 0.5});
+    brush.EndPoint({1.0, 0.5});
+    mediax::GradientStopCollection stops;
+
+    auto addStop = [&](double offset, winrt::Windows::UI::Color const& color) {
+        mediax::GradientStop stop;
+        stop.Offset(offset);
+        stop.Color(color);
+        stops.Append(stop);
+    };
+
+    if (leftEdge) {
+        addStop(0.00, bg);
+        addStop(0.42, bg);
+        addStop(1.00, clear);
+    } else {
+        addStop(0.00, clear);
+        addStop(0.58, bg);
+        addStop(1.00, bg);
+    }
+    brush.GradientStops(stops);
+    return brush;
 }
 
 // The UWP XAML version used by Windhawk exposes UIElement::Clip as a
@@ -5570,8 +5625,21 @@ void StartCompactProgressRenderLoop() {
     }
     g_lastCompactProgressFrameTime = {};
     g_compactProgressRenderingToken =
-        mediax::CompositionTarget::Rendering(OnCompactProgressRendering);
+    mediax::CompositionTarget::Rendering(OnCompactProgressRendering);
     g_compactProgressRenderingHooked = true;
+}
+
+void SetCompactTextEdgeFadeOpacity(double opacity) {
+    opacity = Clamp(opacity, 0.0, 1.0);
+    try {
+        if (g_compactTextLeftFade) {
+            g_compactTextLeftFade.Opacity(opacity);
+        }
+        if (g_compactTextRightFade) {
+            g_compactTextRightFade.Opacity(opacity);
+        }
+    } catch (...) {
+    }
 }
 
 void ResetCompactTextAnimationVisuals() {
@@ -5607,6 +5675,8 @@ void ResetCompactTextAnimationVisuals() {
             g_compactAlbumArtFade.Opacity(0.0);
             g_compactAlbumArtFade.Source(nullptr);
         }
+        g_compactTextEdgeFadeActive = false;
+        SetCompactTextEdgeFadeOpacity(0.0);
     } catch (...) {
     }
 }
@@ -5622,6 +5692,14 @@ double CompactTextClipWidthFallback() {
 double CompactTextClipHeightFallback() {
     double height = g_layout.compactHeight - g_layout.contentMarginY * 2.0;
     return std::max(1.0, height);
+}
+
+double CompactTextClipPadding() {
+    return Clamp(g_layout.textMarginX * 0.75 + 2.0, 5.0, 9.0);
+}
+
+double CompactTextEdgeFadeWidth() {
+    return Clamp(g_layout.textMarginX + 9.0, 12.0, 18.0);
 }
 
 void RefreshCompactTextHostClip(bool forceLayout = false) {
@@ -5650,7 +5728,23 @@ void RefreshCompactTextHostClip(bool forceLayout = false) {
             clipHeight = fallbackHeight;
         }
 
-        ApplyElementClip(g_compactTextHost, clipWidth, clipHeight);
+        double clipPadding = CompactTextClipPadding();
+        ApplyElementClipWithPadding(g_compactTextHost, clipWidth, clipHeight,
+                                    clipPadding);
+
+        double fadeWidth = CompactTextEdgeFadeWidth() + clipPadding;
+        auto configureFade = [&](Border const& fade, bool leftEdge) {
+            if (!fade) {
+                return;
+            }
+            fade.Width(fadeWidth);
+            fade.Height(clipHeight);
+            fade.Margin(leftEdge ? xaml::Thickness{-clipPadding, 0, 0, 0}
+                                 : xaml::Thickness{0, 0, -clipPadding, 0});
+            fade.Background(CompactTextEdgeFadeBrush(leftEdge));
+        };
+        configureFade(g_compactTextLeftFade, true);
+        configureFade(g_compactTextRightFade, false);
     } catch (...) {
     }
 }
@@ -5699,6 +5793,11 @@ void OnCompactTextRendering(winrt::Windows::Foundation::IInspectable const&,
         double titleOut = SmootherStep(Clamp(g_compactTextProgress / 0.78, 0.0, 1.0));
         double artistOut = SmootherStep(Clamp((g_compactTextProgress - 0.18) / 0.72, 0.0, 1.0));
         double artIn = SmootherStep(Clamp(g_compactTextProgress / 0.96, 0.0, 1.0));
+        if (g_compactTextEdgeFadeActive) {
+            SetCompactTextEdgeFadeOpacity(
+                1.0 - SmootherStep(Clamp((g_compactTextProgress - 0.82) / 0.18,
+                                          0.0, 1.0)));
+        }
 
         // Reversed direction: new compact text now enters from the right.
         g_compactTitleTranslate.X(kTextSlideOffset * (1.0 - titleIn));
@@ -5769,6 +5868,8 @@ void StartCompactTrackTransition(std::wstring const& oldTitle,
         g_compactArtistTranslate.X(kTextSlideOffset);
         g_compactTitleText.Opacity(0.0);
         g_compactArtistText.Opacity(0.0);
+        g_compactTextEdgeFadeActive = true;
+        SetCompactTextEdgeFadeOpacity(1.0);
     } else {
         if (g_compactTitleTranslate) g_compactTitleTranslate.X(0.0);
         if (g_compactArtistTranslate) g_compactArtistTranslate.X(0.0);
@@ -5776,6 +5877,8 @@ void StartCompactTrackTransition(std::wstring const& oldTitle,
         if (g_compactArtistText) g_compactArtistText.Opacity(1.0);
         if (g_compactOutgoingTitleText) g_compactOutgoingTitleText.Opacity(0.0);
         if (g_compactOutgoingArtistText) g_compactOutgoingArtistText.Opacity(0.0);
+        g_compactTextEdgeFadeActive = false;
+        SetCompactTextEdgeFadeOpacity(0.0);
     }
 
     if (animateArt) {
@@ -8820,6 +8923,12 @@ void UpdateThemeVisuals() {
             artist.Foreground(secondaryTextBrush);
         }
     }
+    if (g_compactTextLeftFade) {
+        g_compactTextLeftFade.Background(CompactTextEdgeFadeBrush(true));
+    }
+    if (g_compactTextRightFade) {
+        g_compactTextRightFade.Background(CompactTextEdgeFadeBrush(false));
+    }
 
     UpdateButtonTheme(L"Island_Prev");
     UpdateButtonTheme(L"Island_Play");
@@ -9123,6 +9232,26 @@ Grid BuildIslandGrid() {
     textStack.Children().Append(title);
     textStack.Children().Append(artist);
     textHost.Children().Append(textStack);
+
+    Border leftTextFade;
+    leftTextFade.Name(L"Island_TextLeftFade");
+    leftTextFade.HorizontalAlignment(HorizontalAlignment::Left);
+    leftTextFade.VerticalAlignment(VerticalAlignment::Stretch);
+    leftTextFade.IsHitTestVisible(false);
+    leftTextFade.Opacity(0.0);
+    controls::Canvas::SetZIndex(leftTextFade, 10);
+    Border rightTextFade;
+    rightTextFade.Name(L"Island_TextRightFade");
+    rightTextFade.HorizontalAlignment(HorizontalAlignment::Right);
+    rightTextFade.VerticalAlignment(VerticalAlignment::Stretch);
+    rightTextFade.IsHitTestVisible(false);
+    rightTextFade.Opacity(0.0);
+    controls::Canvas::SetZIndex(rightTextFade, 10);
+    g_compactTextLeftFade = leftTextFade;
+    g_compactTextRightFade = rightTextFade;
+    textHost.Children().Append(leftTextFade);
+    textHost.Children().Append(rightTextFade);
+
     content.Children().Append(textHost);
 
     StackPanel details;
@@ -9738,6 +9867,8 @@ void RemoveIslandGrid() {
         g_compactTitleText = nullptr;
         g_compactArtistText = nullptr;
         g_compactTextHost = nullptr;
+        g_compactTextLeftFade = nullptr;
+        g_compactTextRightFade = nullptr;
         g_compactOutgoingTitleText = nullptr;
         g_compactOutgoingArtistText = nullptr;
         g_compactTitleTranslate = nullptr;
@@ -9747,6 +9878,7 @@ void RemoveIslandGrid() {
         g_compactAlbumArtImage = nullptr;
         g_compactAlbumArtFade = nullptr;
         g_compactProgress = nullptr;
+        g_compactTextEdgeFadeActive = false;
         g_compactTextInitialized = false;
         g_compactLastTitle.clear();
         g_compactLastArtist.clear();
@@ -9803,11 +9935,14 @@ void RemoveIslandGrid() {
     g_compactTitleText = nullptr;
     g_compactArtistText = nullptr;
     g_compactTextHost = nullptr;
+    g_compactTextLeftFade = nullptr;
+    g_compactTextRightFade = nullptr;
     g_compactOutgoingTitleText = nullptr;
     g_compactOutgoingArtistText = nullptr;
     g_compactTitleTranslate = nullptr;
     g_compactArtistTranslate = nullptr;
     g_compactProgress = nullptr;
+    g_compactTextEdgeFadeActive = false;
     g_compactTextInitialized = false;
     g_compactLastTitle.clear();
     g_compactLastArtist.clear();

--- a/mods/island-media-controls.wh.cpp
+++ b/mods/island-media-controls.wh.cpp
@@ -2,13 +2,13 @@
 // @id              island-media-controls
 // @name            Island Media Controls
 // @description     Dynamic island-like media controls for the Windows 11 taskbar.
-// @version         0.9.39
+// @version         0.9.87
 // @author          usho
 // @github          https://github.com/usho-lear
 // @license         MIT
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lwindowsapp -luuid -luser32 -lshell32 -lgdi32 -lmsimg32 -lshlwapi -lwindowscodecs -ldwmapi -luiautomationcore
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lwindowsapp -luuid -luser32 -lshell32 -lgdi32 -lmsimg32 -lshlwapi -lwindowscodecs -ldwmapi -luiautomationcore -ld3d11 -ldxgi -ld2d1
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -106,12 +106,30 @@ it fits naturally alongside your taskbar and system tray items.
     $name: Hover scale (%)
   - HoverLerpSpeed: 28
     $name: Hover smoothing
-  - Material: "mica_like"
+  - Material: "acrylic"
     $name: Background material
     $options:
     - "mica_like": "Mica-like content layer"
     - "solid": "Solid"
     - "acrylic": "Acrylic / glass"
+  - BackdropHandoffDelayMs: 0
+    $name: Backdrop handoff delay (ms)
+    $description: Wait after the popup reaches its final shape before switching from fallback blur to live WGC blur.
+  - BackdropHandoffFadeMs: 100
+    $name: Backdrop handoff fade (ms)
+    $description: Crossfade duration from the final fallback blur frame to live WGC blur.
+  - BackdropInitialFrameSkip: 2
+    $name: Backdrop initial frame skip
+    $description: Number of WGC frames to skip before replacing the fallback frame.
+  - BackdropFallbackBlurPasses: 5
+    $name: Backdrop fallback blur passes
+    $description: Blur strength for the animation-period fallback frame.
+  - BackdropFallbackCaptureScale: 2
+    $name: Backdrop fallback capture scale
+    $description: Lower values sample more pixels; higher values are faster but softer.
+  - BackdropWgcBlurStdDev: 18
+    $name: Backdrop WGC blur strength
+    $description: Gaussian blur standard deviation for live WGC blur.
 */
 // ==/WindhawkModSettings==
 
@@ -123,6 +141,59 @@ it fits naturally alongside your taskbar and system tray items.
 #include <shlwapi.h>
 #include <wincodec.h>
 #include <windows.ui.xaml.hosting.desktopwindowxamlsource.h>
+
+#if __has_include(<winrt/Windows.Graphics.Capture.h>) && \
+    __has_include(<winrt/Windows.Graphics.DirectX.Direct3D11.h>)
+#define IMC_WGC_OVERLAY_AVAILABLE 1
+#include <inspectable.h>
+#include <d3d11.h>
+#include <dxgi1_2.h>
+#include <d2d1_1.h>
+#include <d2d1_1helper.h>
+#include <d2d1effects.h>
+#include <winrt/Windows.Graphics.Capture.h>
+#include <winrt/Windows.Graphics.DirectX.h>
+#include <winrt/Windows.Graphics.DirectX.Direct3D11.h>
+
+// Windhawk's bundled SDK may miss the two small WinRT interop headers even
+// though the WinRT projection and D3D/D2D headers are present. Define the
+// minimal COM interfaces locally so the WGC path is actually compiled instead
+// of silently falling back to the stub branch.
+//
+// Do not use __declspec(uuid) here: Windhawk's Clang/MinGW configuration ignores
+// that attribute, which breaks winrt::guid_of<T>. Use explicit GUID constants
+// and raw QueryInterface instead.
+static constexpr GUID kIID_IGraphicsCaptureItemInterop{
+    0x3628E81B, 0x3CAC, 0x4C60,
+    {0xB7, 0xF4, 0x23, 0xCE, 0x0E, 0x0C, 0x33, 0x56}};
+static constexpr GUID kIID_IDirect3DDxgiInterfaceAccess{
+    0xA9B3D012, 0x3DF2, 0x4EE3,
+    {0xB8, 0xD1, 0x86, 0x95, 0xF4, 0x57, 0xD3, 0xC1}};
+static constexpr GUID kIID_IGraphicsCaptureItem{
+    0x79C3F95B, 0x31F7, 0x4EC2,
+    {0xA4, 0x64, 0x63, 0x2E, 0xF5, 0xD3, 0x07, 0x60}};
+
+struct IGraphicsCaptureItemInterop : ::IUnknown {
+    virtual HRESULT __stdcall CreateForWindow(HWND window,
+                                              REFIID riid,
+                                              void** result) = 0;
+    virtual HRESULT __stdcall CreateForMonitor(HMONITOR monitor,
+                                               REFIID riid,
+                                               void** result) = 0;
+};
+
+struct IDirect3DDxgiInterfaceAccess : ::IUnknown {
+    virtual HRESULT __stdcall GetInterface(REFIID iid,
+                                           void** p) = 0;
+};
+
+extern "C" HRESULT __stdcall CreateDirect3D11DeviceFromDXGIDevice(
+    IDXGIDevice* dxgiDevice,
+    IInspectable** graphicsDevice);
+#else
+#define IMC_WGC_OVERLAY_AVAILABLE 0
+#endif
+
 #include <windhawk_utils.h>
 
 #ifdef GetCurrentTime
@@ -135,6 +206,7 @@ it fits naturally alongside your taskbar and system tray items.
 #include <winrt/Windows.Foundation.Numerics.h>
 #include <winrt/Windows.Media.Control.h>
 #include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.h>
 #include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Input.h>
@@ -153,6 +225,7 @@ it fits naturally alongside your taskbar and system tray items.
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <cmath>
 #include <climits>
 #include <condition_variable>
@@ -167,6 +240,10 @@ it fits naturally alongside your taskbar and system tray items.
 #define WS_EX_NOREDIRECTIONBITMAP 0x00200000L
 #endif
 
+#ifndef DWMWA_WINDOW_CORNER_PREFERENCE
+#define DWMWA_WINDOW_CORNER_PREFERENCE 33
+#endif
+
 namespace xaml = winrt::Windows::UI::Xaml;
 namespace composition = winrt::Windows::UI::Composition;
 namespace controls = winrt::Windows::UI::Xaml::Controls;
@@ -176,6 +253,11 @@ namespace imaging = winrt::Windows::UI::Xaml::Media::Imaging;
 namespace hosting = winrt::Windows::UI::Xaml::Hosting;
 namespace streams = winrt::Windows::Storage::Streams;
 namespace gsm = winrt::Windows::Media::Control;
+#if IMC_WGC_OVERLAY_AVAILABLE
+namespace capture = winrt::Windows::Graphics::Capture;
+namespace directx = winrt::Windows::Graphics::DirectX;
+namespace direct3d11 = winrt::Windows::Graphics::DirectX::Direct3D11;
+#endif
 
 using xaml::FrameworkElement;
 using xaml::GridLength;
@@ -220,7 +302,13 @@ struct Settings {
     bool hideWhenNoMedia = false;
     double hoverScale = 1.06;
     double hoverLerpSpeed = 28.0;
-    std::wstring material = L"mica_like";
+    std::wstring material = L"acrylic";
+    int backdropHandoffDelayMs = 0;
+    int backdropHandoffFadeMs = 100;
+    int backdropInitialFrameSkip = 2;
+    int backdropFallbackBlurPasses = 5;
+    int backdropFallbackCaptureScale = 2;
+    int backdropWgcBlurStdDev = 18;
 };
 
 struct RuntimeLayout {
@@ -284,12 +372,17 @@ int64_t g_popupSeekCommitTargetTicks = 0;
 std::chrono::steady_clock::time_point g_popupSeekCommitUntil;
 
 std::atomic_bool g_unloading = false;
+std::atomic_bool g_modActive = false;
 std::atomic_bool g_mediaThreadRunning = false;
 std::thread* g_mediaThread = nullptr;
 std::mutex g_mediaCommandMutex;
 std::condition_variable g_mediaCommandCv;
 std::deque<MediaCommand> g_mediaCommands;
 std::atomic_bool g_mediaRefreshRequested = true;
+
+bool IsModActive() {
+    return g_modActive.load() && !g_unloading.load();
+}
 
 HWND g_taskbarWnd = nullptr;
 Grid g_playerGrid = nullptr;
@@ -313,6 +406,87 @@ int g_popupXamlThemeShadowDepth = -1;
 int g_popupXamlThemeShadowOpacity = -1;
 HWND g_expandedPopup = nullptr;
 bool g_popupClassRegistered = false;
+HWND g_popupBackdropOverlay = nullptr;
+bool g_popupBackdropOverlayClassRegistered = false;
+std::chrono::steady_clock::time_point g_popupBackdropOverlayLastPaintTime{};
+int g_popupBackdropOverlayLastWidth = 0;
+int g_popupBackdropOverlayLastHeight = 0;
+int g_popupBackdropOverlayLastRadius = 0;
+bool g_popupOverlayWgcReadbackHadVisibleFrame = false;
+std::chrono::steady_clock::time_point g_popupOverlayWgcReadbackDiagnosticTime{};
+enum class PopupOverlayWgcDiagnosticState {
+    NotStarted,
+    StartSkipped,
+    StartedNoFrame,
+    FrameArrived,
+    RenderFailed,
+    MapFailed,
+    UpdateFailed,
+    VisibleFrame,
+};
+PopupOverlayWgcDiagnosticState g_popupOverlayWgcDiagnosticState =
+    PopupOverlayWgcDiagnosticState::NotStarted;
+HRESULT g_popupOverlayWgcDiagnosticHr = S_OK;
+uint64_t g_popupOverlayWgcFrameCount = 0;
+uint64_t g_popupOverlayWgcRenderFailCount = 0;
+std::chrono::steady_clock::time_point g_popupOverlayWgcLastStartAttemptTime{};
+std::chrono::steady_clock::time_point g_popupOverlayWgcLastDiagnosticPaintTime{};
+HRESULT g_popupOverlayWgcCreateItemHr = S_OK;
+bool g_popupOverlayWgcCreateItemFailed = false;
+bool g_popupOverlayWgcFallbackPainted = false;
+std::chrono::steady_clock::time_point g_popupOverlayWgcStartTime{};
+int g_popupOverlayWgcFramesToSkip = 0;
+std::chrono::steady_clock::time_point g_popupOverlayWgcHandoffStartTime{};
+std::chrono::steady_clock::time_point g_popupOverlayWgcFinalReadyTime{};
+std::mutex g_popupBackdropOverlayHandoffMutex;
+std::vector<BYTE> g_popupBackdropOverlayFallbackPixels;
+RECT g_popupBackdropOverlayFallbackRect{};
+int g_popupBackdropOverlayFallbackWidth = 0;
+int g_popupBackdropOverlayFallbackHeight = 0;
+int g_popupBackdropOverlayFallbackRadius = 0;
+bool g_popupBackdropOverlayFallbackPixelsValid = false;
+
+void ClearPopupBackdropOverlayHandoffCache() {
+    std::lock_guard cacheLock(g_popupBackdropOverlayHandoffMutex);
+    g_popupBackdropOverlayFallbackPixels.clear();
+    g_popupBackdropOverlayFallbackRect = {};
+    g_popupBackdropOverlayFallbackWidth = 0;
+    g_popupBackdropOverlayFallbackHeight = 0;
+    g_popupBackdropOverlayFallbackRadius = 0;
+    g_popupBackdropOverlayFallbackPixelsValid = false;
+    g_popupOverlayWgcHandoffStartTime = {};
+    g_popupOverlayWgcFinalReadyTime = {};
+}
+
+
+#if IMC_WGC_OVERLAY_AVAILABLE
+std::mutex g_popupOverlayWgcMutex;
+bool g_popupOverlayWgcRunning = false;
+bool g_popupOverlayWgcFrameCallbackHooked = false;
+RECT g_popupOverlayWgcCaptureRectPx{LONG_MIN, LONG_MIN, LONG_MIN, LONG_MIN};
+RECT g_popupOverlayWgcMonitorRectPx{};
+int g_popupOverlayWgcTargetWidthPx = 0;
+int g_popupOverlayWgcTargetHeightPx = 0;
+HMONITOR g_popupOverlayWgcMonitor = nullptr;
+HRESULT g_popupOverlayWgcLastHr = S_OK;
+
+winrt::com_ptr<ID3D11Device> g_popupOverlayWgcD3dDevice;
+winrt::com_ptr<ID3D11DeviceContext> g_popupOverlayWgcD3dContext;
+winrt::com_ptr<IDXGIDevice> g_popupOverlayWgcDxgiDevice;
+winrt::com_ptr<ID3D11Texture2D> g_popupOverlayWgcRenderTexture;
+winrt::com_ptr<ID3D11Texture2D> g_popupOverlayWgcStagingTexture;
+winrt::com_ptr<ID2D1Factory1> g_popupOverlayWgcD2dFactory;
+winrt::com_ptr<ID2D1Device> g_popupOverlayWgcD2dDevice;
+winrt::com_ptr<ID2D1DeviceContext> g_popupOverlayWgcD2dContext;
+
+direct3d11::IDirect3DDevice g_popupOverlayWgcGraphicsDevice{nullptr};
+capture::GraphicsCaptureItem g_popupOverlayWgcItem{nullptr};
+capture::Direct3D11CaptureFramePool g_popupOverlayWgcFramePool{nullptr};
+capture::GraphicsCaptureSession g_popupOverlayWgcSession{nullptr};
+winrt::event_token g_popupOverlayWgcFrameArrivedToken{};
+bool g_popupOverlayWgcHadFrame = false;
+std::chrono::steady_clock::time_point g_popupOverlayWgcDiagnosticStartTime{};
+#endif
 hosting::DesktopWindowXamlSource g_popupXamlSource = nullptr;
 HWND g_popupXamlChild = nullptr;
 Grid g_popupXamlRoot = nullptr;
@@ -339,6 +513,10 @@ ScaleTransform g_popupXamlArtScale = nullptr;
 TranslateTransform g_popupXamlArtTranslate = nullptr;
 Image g_popupXamlArtFade = nullptr;
 Image g_popupXamlArt = nullptr;
+FrameworkElement g_popupXamlTitleHost = nullptr;
+FrameworkElement g_popupXamlArtistHost = nullptr;
+FrameworkElement g_popupXamlOutgoingTitleHost = nullptr;
+FrameworkElement g_popupXamlOutgoingArtistHost = nullptr;
 TextBlock g_popupXamlTitle = nullptr;
 TextBlock g_popupXamlArtist = nullptr;
 TextBlock g_popupXamlOutgoingTitle = nullptr;
@@ -678,17 +856,12 @@ mediax::Brush IslandBackgroundBrush() {
     }
 
     if (g_settings.material == L"acrylic") {
-        try {
-            mediax::AcrylicBrush brush;
-            brush.BackgroundSource(mediax::AcrylicBackgroundSource::HostBackdrop);
-            brush.TintColor(dark ? Color(0xFF, 0x20, 0x20, 0x24)
-                                 : Color(0xFF, 0xF3, 0xF3, 0xF6));
-            brush.TintOpacity(0.62);
-            brush.FallbackColor(dark ? Color(0xE8, 0x20, 0x20, 0x24)
-                                     : Color(0xE8, 0xF3, 0xF3, 0xF6));
-            return brush;
-        } catch (...) {
-        }
+        // XAML AcrylicBrush can switch to its fallback when the taskbar/XAML
+        // island loses focus, which makes the compact island suddenly look gray
+        // and dirty. The expanded acrylic path uses a native overlay instead;
+        // keep the compact surface visually stable with a tinted brush.
+        return Brush(dark ? Color(0xD8, 0x20, 0x20, 0x24)
+                          : Color(0xEA, 0xF8, 0xF8, 0xFA));
     }
 
     return Brush(dark ? Color(0xE8, 0x20, 0x20, 0x24)
@@ -736,6 +909,28 @@ std::wstring GetStringSetting(const wchar_t* key, const wchar_t* fallback) {
     return value && *value ? value : fallback;
 }
 
+constexpr int kSettingsMigrationVersion = 1;
+constexpr wchar_t kMigrateMicaLikeMaterialValue[] =
+    L"MigrateMicaLikeMaterialToAcrylic";
+
+void ApplySettingsMigrations(Settings* settings) {
+    int migratedVersion = Wh_GetIntValue(L"SettingsMigrationVersion", 0);
+    if (migratedVersion < 1) {
+        if (settings->material == L"mica_like") {
+            Wh_SetIntValue(kMigrateMicaLikeMaterialValue, 1);
+        }
+        Wh_SetIntValue(L"SettingsMigrationVersion", 1);
+    }
+
+    if (Wh_GetIntValue(kMigrateMicaLikeMaterialValue, 0)) {
+        if (settings->material == L"mica_like") {
+            settings->material = L"acrylic";
+        } else {
+            Wh_SetIntValue(kMigrateMicaLikeMaterialValue, 0);
+        }
+    }
+}
+
 Settings ReadSettings() {
     Settings settings;
     settings.position = GetStringSetting(L"Main.Position", L"tray_left");
@@ -777,12 +972,25 @@ Settings ReadSettings() {
         static_cast<double>(Clamp(Wh_GetIntSetting(L"Main.HoverScale"), 100, 125)) / 100.0;
     settings.hoverLerpSpeed =
         static_cast<double>(Clamp(Wh_GetIntSetting(L"Main.HoverLerpSpeed"), 1, 80));
-    settings.material = GetStringSetting(L"Main.Material", L"mica_like");
+    settings.material = GetStringSetting(L"Main.Material", L"acrylic");
     if (settings.material != L"mica_like" &&
         settings.material != L"solid" &&
         settings.material != L"acrylic") {
-        settings.material = L"mica_like";
+        settings.material = L"acrylic";
     }
+    ApplySettingsMigrations(&settings);
+    settings.backdropHandoffDelayMs =
+        Clamp(Wh_GetIntSetting(L"Main.BackdropHandoffDelayMs"), 0, 200);
+    settings.backdropHandoffFadeMs =
+        Clamp(Wh_GetIntSetting(L"Main.BackdropHandoffFadeMs"), 60, 160);
+    settings.backdropInitialFrameSkip =
+        Clamp(Wh_GetIntSetting(L"Main.BackdropInitialFrameSkip"), 1, 3);
+    settings.backdropFallbackBlurPasses =
+        Clamp(Wh_GetIntSetting(L"Main.BackdropFallbackBlurPasses"), 4, 6);
+    settings.backdropFallbackCaptureScale =
+        Clamp(Wh_GetIntSetting(L"Main.BackdropFallbackCaptureScale"), 2, 3);
+    settings.backdropWgcBlurStdDev =
+        Clamp(Wh_GetIntSetting(L"Main.BackdropWgcBlurStdDev"), 14, 22);
     return settings;
 }
 
@@ -1114,8 +1322,34 @@ void SetMedia(MediaState&& state) {
 }
 
 void RequestMediaRefresh() {
+    if (!IsModActive() || !g_mediaThreadRunning.load()) {
+        return;
+    }
     g_mediaRefreshRequested = true;
     g_mediaCommandCv.notify_one();
+}
+
+gsm::GlobalSystemMediaTransportControlsSessionManager
+RequestMediaManagerWithTimeout(std::chrono::milliseconds timeout) {
+    if (g_unloading) {
+        return nullptr;
+    }
+
+    try {
+        auto operation =
+            gsm::GlobalSystemMediaTransportControlsSessionManager::RequestAsync();
+        if (operation.wait_for(timeout) !=
+            winrt::Windows::Foundation::AsyncStatus::Completed) {
+            try {
+                operation.Cancel();
+            } catch (...) {
+            }
+            return nullptr;
+        }
+        return operation.GetResults();
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 gsm::GlobalSystemMediaTransportControlsSession SelectBestSession(
@@ -1164,8 +1398,7 @@ gsm::GlobalSystemMediaTransportControlsSession SelectBestSession(
 
 gsm::GlobalSystemMediaTransportControlsSession CurrentSession() {
     try {
-        auto manager =
-            gsm::GlobalSystemMediaTransportControlsSessionManager::RequestAsync().get();
+        auto manager = RequestMediaManagerWithTimeout(std::chrono::seconds(2));
         return SelectBestSession(manager);
     } catch (...) {
         return nullptr;
@@ -1231,7 +1464,7 @@ void RefreshMediaState(
 }
 
 void RunMediaCommand(MediaCommand command) {
-    if (!command || g_unloading || !g_mediaThreadRunning) {
+    if (!command || !IsModActive() || !g_mediaThreadRunning.load()) {
         return;
     }
 
@@ -1634,6 +1867,166 @@ std::vector<uint8_t> EncodePbgraPngBytes(UINT width, UINT height, std::vector<BY
     if (encoder) encoder->Release();
     if (outStream) outStream->Release();
     if (factory) factory->Release();
+    return output;
+}
+
+bool PopupCoverG2MaskContains(double px, double py, UINT size, double radius) {
+    if (size == 0 || radius <= 0.0) {
+        return true;
+    }
+
+    const double maxCoord = static_cast<double>(size);
+    double dx = 0.0;
+    double dy = 0.0;
+
+    if (px < radius) {
+        dx = radius - px;
+    } else if (px > maxCoord - radius) {
+        dx = px - (maxCoord - radius);
+    }
+
+    if (py < radius) {
+        dy = radius - py;
+    } else if (py > maxCoord - radius) {
+        dy = py - (maxCoord - radius);
+    }
+
+    if (dx <= 0.0 || dy <= 0.0) {
+        return true;
+    }
+
+    const double nx = dx / radius;
+    const double ny = dy / radius;
+    const double superellipse = nx * nx * nx * nx + ny * ny * ny * ny;
+    return superellipse <= 1.0;
+}
+
+double PopupCoverG2MaskScale(UINT x, UINT y, UINT size, double radius) {
+    constexpr int kSamplesPerAxis = 4;
+    int coveredSamples = 0;
+    for (int sampleY = 0; sampleY < kSamplesPerAxis; ++sampleY) {
+        double py = static_cast<double>(y) +
+                    (static_cast<double>(sampleY) + 0.5) /
+                        static_cast<double>(kSamplesPerAxis);
+        for (int sampleX = 0; sampleX < kSamplesPerAxis; ++sampleX) {
+            double px = static_cast<double>(x) +
+                        (static_cast<double>(sampleX) + 0.5) /
+                            static_cast<double>(kSamplesPerAxis);
+            if (PopupCoverG2MaskContains(px, py, size, radius)) {
+                ++coveredSamples;
+            }
+        }
+    }
+
+    return static_cast<double>(coveredSamples) /
+           static_cast<double>(kSamplesPerAxis * kSamplesPerAxis);
+}
+
+void ApplyPopupCoverG2Mask(std::vector<BYTE>& pixels, UINT size) {
+    if (size == 0 || pixels.size() < static_cast<size_t>(size) * size * 4) {
+        return;
+    }
+
+    constexpr double kPopupCoverG2RadiusRatio = 0.118;
+    const double radius = std::max(1.0, static_cast<double>(size) * kPopupCoverG2RadiusRatio);
+    for (UINT y = 0; y < size; ++y) {
+        for (UINT x = 0; x < size; ++x) {
+            double alphaScale = PopupCoverG2MaskScale(x, y, size, radius);
+            if (alphaScale >= 1.0) {
+                continue;
+            }
+
+            BYTE* pixel = pixels.data() + (static_cast<size_t>(y) * size + x) * 4;
+            pixel[0] = static_cast<BYTE>(std::lround(pixel[0] * alphaScale));
+            pixel[1] = static_cast<BYTE>(std::lround(pixel[1] * alphaScale));
+            pixel[2] = static_cast<BYTE>(std::lround(pixel[2] * alphaScale));
+            pixel[3] = static_cast<BYTE>(std::lround(pixel[3] * alphaScale));
+        }
+    }
+}
+
+std::vector<uint8_t> CreatePopupG2AlbumCoverBytes(std::vector<uint8_t> const& bytes, UINT size = 512) {
+    std::vector<uint8_t> output;
+    if (bytes.empty() || size == 0) {
+        return output;
+    }
+
+    IStream* stream = SHCreateMemStream(bytes.data(), static_cast<UINT>(bytes.size()));
+    IWICImagingFactory* factory = nullptr;
+    IWICBitmapDecoder* decoder = nullptr;
+    IWICBitmapFrameDecode* frame = nullptr;
+    IWICBitmapScaler* scaler = nullptr;
+    IWICFormatConverter* converter = nullptr;
+
+    UINT sourceWidth = 0;
+    UINT sourceHeight = 0;
+    HRESULT hr = stream ? S_OK : E_FAIL;
+    if (SUCCEEDED(hr)) {
+        hr = CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
+                              IID_PPV_ARGS(&factory));
+    }
+    if (SUCCEEDED(hr)) {
+        hr = factory->CreateDecoderFromStream(stream, nullptr,
+                                              WICDecodeMetadataCacheOnLoad, &decoder);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = decoder->GetFrame(0, &frame);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = frame->GetSize(&sourceWidth, &sourceHeight);
+    }
+
+    UINT scaledWidth = size;
+    UINT scaledHeight = size;
+    if (SUCCEEDED(hr) && sourceWidth > 0 && sourceHeight > 0) {
+        double scale = static_cast<double>(size) /
+                       static_cast<double>(std::min(sourceWidth, sourceHeight));
+        scaledWidth = std::max(size, static_cast<UINT>(std::ceil(sourceWidth * scale)));
+        scaledHeight = std::max(size, static_cast<UINT>(std::ceil(sourceHeight * scale)));
+    }
+    if (SUCCEEDED(hr)) {
+        hr = factory->CreateBitmapScaler(&scaler);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = scaler->Initialize(frame, scaledWidth, scaledHeight,
+                                WICBitmapInterpolationModeFant);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = factory->CreateFormatConverter(&converter);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = converter->Initialize(scaler, GUID_WICPixelFormat32bppPBGRA,
+                                   WICBitmapDitherTypeNone, nullptr, 0,
+                                   WICBitmapPaletteTypeCustom);
+    }
+
+    std::vector<BYTE> scaledPixels(static_cast<size_t>(scaledWidth) * scaledHeight * 4);
+    if (SUCCEEDED(hr)) {
+        hr = converter->CopyPixels(nullptr, scaledWidth * 4,
+                                   static_cast<UINT>(scaledPixels.size()),
+                                   scaledPixels.data());
+    }
+    if (SUCCEEDED(hr)) {
+        std::vector<BYTE> pixels(static_cast<size_t>(size) * size * 4);
+        UINT offsetX = (scaledWidth > size) ? (scaledWidth - size) / 2 : 0;
+        UINT offsetY = (scaledHeight > size) ? (scaledHeight - size) / 2 : 0;
+        for (UINT y = 0; y < size; ++y) {
+            BYTE* source = scaledPixels.data() +
+                (static_cast<size_t>(y + offsetY) * scaledWidth + offsetX) * 4;
+            BYTE* target = pixels.data() + static_cast<size_t>(y) * size * 4;
+            std::memcpy(target, source, static_cast<size_t>(size) * 4);
+        }
+
+        ApplyPopupCoverG2Mask(pixels, size);
+        output = EncodePbgraPngBytes(size, size, pixels);
+    }
+
+    if (converter) converter->Release();
+    if (scaler) scaler->Release();
+    if (frame) frame->Release();
+    if (decoder) decoder->Release();
+    if (factory) factory->Release();
+    if (stream) stream->Release();
     return output;
 }
 
@@ -2789,7 +3182,11 @@ void UpdatePopupAlbumBitmap(MediaState const& state) {
 }
 
 constexpr wchar_t kPopupClassName[] = L"WindhawkIslandMediaPopup";
+constexpr wchar_t kPopupBackdropOverlayClassName[] = L"WindhawkIslandMediaBackdropOverlay";
 constexpr UINT_PTR kPopupTimerId = 0x494D;
+constexpr UINT_PTR kPopupBackdropOverlayTimerId = 0x494E;
+constexpr int kPopupBackdropOverlayRefreshMs = 90;
+constexpr int kPopupBackdropOverlayMaxCaptureSize = 320;
 
 double SmoothStep(double value) {
     value = Clamp(value, 0.0, 1.0);
@@ -2804,6 +3201,27 @@ double SmootherStep(double value) {
 // Clip animated text to its own text lane. Without this, render transforms can
 // let the incoming/outgoing title briefly draw outside the compact/popup card.
 void ApplyElementClip(FrameworkElement const& element, double width, double height) {
+    if (!element || width <= 0.0 || height <= 0.0) {
+        return;
+    }
+    try {
+        mediax::RectangleGeometry clip;
+        clip.Rect({0.0f, 0.0f,
+                   static_cast<float>(std::max(1.0, width)),
+                   static_cast<float>(std::max(1.0, height))});
+        element.Clip(clip);
+    } catch (...) {
+    }
+}
+
+// The UWP XAML version used by Windhawk exposes UIElement::Clip as a
+// RectangleGeometry-only property, so this helper remains a rectangular
+// fallback for shell surfaces. The album cover uses a premultiplied alpha
+// superellipse mask in the bitmap itself.
+void ApplyContinuousRoundedRectClip(FrameworkElement const& element,
+                                    double width,
+                                    double height,
+                                    double radius) {
     if (!element || width <= 0.0 || height <= 0.0) {
         return;
     }
@@ -2843,6 +3261,24 @@ int PopupShadowDepth() {
 int PopupShadowOpacityPercent() {
     return Clamp(g_settings.popupShadowOpacity, 0, 100);
 }
+int PopupBackdropHandoffDelayMs() {
+    return Clamp(g_settings.backdropHandoffDelayMs, 0, 200);
+}
+int PopupBackdropHandoffFadeMs() {
+    return Clamp(g_settings.backdropHandoffFadeMs, 60, 160);
+}
+int PopupBackdropInitialFrameSkip() {
+    return Clamp(g_settings.backdropInitialFrameSkip, 1, 3);
+}
+int PopupBackdropFallbackBlurPasses() {
+    return Clamp(g_settings.backdropFallbackBlurPasses, 4, 6);
+}
+int PopupBackdropFallbackCaptureScale() {
+    return Clamp(g_settings.backdropFallbackCaptureScale, 2, 3);
+}
+float PopupBackdropWgcBlurStdDev() {
+    return static_cast<float>(Clamp(g_settings.backdropWgcBlurStdDev, 14, 22));
+}
 int PopupBackdropPadding() {
     return PopupSurfaceGap();
 }
@@ -2851,7 +3287,12 @@ constexpr int kPopupCardInnerPadding = 18;
 constexpr int kPopupTextTopPadding = 13;
 constexpr int kPopupTextLineGap = 24;
 constexpr int kPopupTimeTextHeight = 16;
+// G2-style popup radius family. Windhawk's UWP XAML surface does not expose
+// a true squircle clip here, so keep the visual language consistent by routing
+// every expanded popup corner through these shared radii.
 constexpr double kPopupUnifiedCornerRadius = 24.0;
+constexpr double kPopupG2ButtonCornerRadius = 14.0;
+constexpr double kPopupG2ProgressCornerRadius = 3.0;
 // Transparent host margin used only so the rounded XAML shadow can fit without
 // falling back to the rectangular HWND shadow.
 constexpr int kPopupHostShadowMargin = 18;
@@ -2859,6 +3300,30 @@ constexpr int kPopupHostShadowMargin = 18;
 // material is exactly the compact island material, so compact/expanded states
 // share one color, one stroke model, and one predictable XAML clipping path.
 constexpr double kPopupBackdropOpacity = 1.0;
+constexpr double kPopupOverlayInsetDip = 0.0;
+constexpr double kPopupOverlayRadiusAdjustDip = 0.0;
+
+bool UseOverlayPopupBackdropMaterial() {
+    //          0.9.50 diagnostic: Acrylic uses a separate native overlay window behind
+    // the XAML popup, clipped to the animated rounded popup shell instead of
+    // the full transparent host rectangle. This keeps the visibility test from
+    // leaking outside the actual visual surface.
+    return g_settings.material == L"acrylic";
+}
+
+double PopupBackdropOverlayOpacity() {
+    if (!UseOverlayPopupBackdropMaterial() || g_popupClosing) {
+        return 1.0;
+    }
+    double progress = PopupProgress();
+    return SmootherStep(Clamp((progress - 0.10) / 0.28, 0.0, 1.0));
+}
+
+BYTE PopupBackdropOverlayMaxAlpha() {
+    return static_cast<BYTE>(
+        Clamp(static_cast<int>(std::lround(255.0 * PopupBackdropOverlayOpacity())),
+              0, 255));
+}
 
 bool PopupBackdropCoverEffectEnabled() {
     if (g_settings.popupBackdropCoverEffect == L"on") {
@@ -2911,11 +3376,18 @@ mediax::Brush PopupControlCardBrush() {
     if (dark) {
         return Brush(Color(0x70, 0x20, 0x20, 0x26));
     }
-    return Brush(Color(0xB8, 0xFF, 0xFF, 0xFF));
+    return Brush(Color(0xD8, 0xFF, 0xFF, 0xFF));
 }
 
 mediax::Brush PopupBackdropCardTintBrush() {
     bool dark = IsDarkModeApprox();
+    if (UseOverlayPopupBackdropMaterial()) {
+        // Native blur comes from the overlay window itself. Add only a clean
+        // light-mode white veil here so acrylic keeps enough tint without the
+        // compact island inheriting AcrylicBrush's inactive fallback behavior.
+        return Brush(dark ? Color(0x00, 0x00, 0x00, 0x00)
+                          : Color(0x8C, 0xFF, 0xFF, 0xFF));
+    }
     // Backdrop and control tints are tuned separately so light mode can stay
     // brighter without making dark mode look washed out. In dark mode this
     // matches the previous version, where the backdrop card tint reused the
@@ -2923,7 +3395,7 @@ mediax::Brush PopupBackdropCardTintBrush() {
     if (dark) {
         return Brush(Color(0x70, 0x20, 0x20, 0x26));
     }
-    return Brush(Color(0xD0, 0xFF, 0xFF, 0xFF));
+    return Brush(Color(0xE8, 0xFF, 0xFF, 0xFF));
 }
 
 double PopupPanelCoverOpacityFactor() {
@@ -2933,6 +3405,12 @@ double PopupPanelCoverOpacityFactor() {
 }
 
 mediax::Brush PopupSurfaceBrush() {
+    if (UseOverlayPopupBackdropMaterial()) {
+        // Let the native overlay window provide the real-time blurred material.
+        // The XAML shell itself stays transparent so the clipped overlay can
+        // show through cleanly beneath the controls and artwork.
+        return Brush(Color(0x00, 0x00, 0x00, 0x00));
+    }
     // C version: extend the compact island material to the expanded surface.
     // This keeps compact->expanded transitions visually consistent and avoids
     // mixing DWM backdrop, XAML Acrylic, and extra tint layers.
@@ -2940,6 +3418,11 @@ mediax::Brush PopupSurfaceBrush() {
 }
 
 mediax::Brush PopupSurfaceStrokeBrush() {
+    if (UseOverlayPopupBackdropMaterial()) {
+        bool dark = IsDarkModeApprox();
+        return Brush(dark ? Color(0x10, 0xFF, 0xFF, 0xFF)
+                          : Color(0x00, 0x00, 0x00, 0x00));
+    }
     // Match the compact island outline exactly: the expanded popup surface
     // should use the same subtle theme-aware stroke and no extra DWM border.
     return IslandBorderBrush();
@@ -3346,7 +3829,7 @@ void ApplyPopupButtonVisual(Border const& surface, bool hovered = false) {
 
     double width = PopupButtonWidth();
     double height = PopupButtonHeight();
-    double corner = height * 0.5;
+    double corner = std::min(height * 0.5, kPopupG2ButtonCornerRadius);
     double fontSize = primary ? 21.0 : 20.0;
     mediax::Brush background = hovered ? PopupButtonHoverBrush(dark)
                                        : Brush(Color(0x00, 0x00, 0x00, 0x00));
@@ -3496,8 +3979,8 @@ void ApplyPopupXamlTheme(bool force = false) {
         g_popupXamlPanelCoverFrame.BorderBrush(Brush(Color(0x00, 0x00, 0x00, 0x00)));
     }
     if (g_popupXamlArtFrame) {
-        g_popupXamlArtFrame.BorderThickness({1, 1, 1, 1});
-        g_popupXamlArtFrame.BorderBrush(PopupSurfaceStrokeBrush());
+        g_popupXamlArtFrame.BorderThickness({0, 0, 0, 0});
+        g_popupXamlArtFrame.BorderBrush(Brush(Color(0x00, 0x00, 0x00, 0x00)));
     }
     g_popupXamlPanel.Background(PopupControlCardBrush());
     // Playback control card uses the same subtle outline as the compact island
@@ -3788,6 +4271,10 @@ void ResetPopupXamlElementState() {
     g_popupXamlArtTranslate = nullptr;
     g_popupXamlArtFade = nullptr;
     g_popupXamlArt = nullptr;
+    g_popupXamlTitleHost = nullptr;
+    g_popupXamlArtistHost = nullptr;
+    g_popupXamlOutgoingTitleHost = nullptr;
+    g_popupXamlOutgoingArtistHost = nullptr;
     g_popupXamlTitle = nullptr;
     g_popupXamlArtist = nullptr;
     g_popupXamlOutgoingTitle = nullptr;
@@ -3901,11 +4388,9 @@ bool InitializePopupXamlHost(HWND hwnd) {
         Border artFrame;
         artFrame.CornerRadius({kPopupUnifiedCornerRadius, kPopupUnifiedCornerRadius,
                                kPopupUnifiedCornerRadius, kPopupUnifiedCornerRadius});
-        // Match the compact no-media placeholder: when there is no thumbnail,
-        // the expanded cover still shows a proper placeholder instead of a blank frame.
-        artFrame.Background(Brush(DefaultPopupAccentColor()));
-        artFrame.BorderThickness({1, 1, 1, 1});
-        artFrame.BorderBrush(PopupSurfaceStrokeBrush());
+        artFrame.Background(Brush(Color(0x00, 0x00, 0x00, 0x00)));
+        artFrame.BorderThickness({0, 0, 0, 0});
+        artFrame.BorderBrush(Brush(Color(0x00, 0x00, 0x00, 0x00)));
         AttachGpuFriendlyTransform(artFrame, g_popupXamlArtScale, g_popupXamlArtTranslate);
         Grid artHost;
         Image artFade;
@@ -3919,6 +4404,8 @@ bool InitializePopupXamlHost(HWND hwnd) {
         artFrame.Child(artHost);
         canvas.Children().Append(artFrame);
 
+        Grid outgoingTitleHost;
+        outgoingTitleHost.IsHitTestVisible(false);
         TextBlock outgoingTitle;
         outgoingTitle.FontFamily(mediax::FontFamily(L"Segoe UI Variable Text"));
         outgoingTitle.FontWeight(winrt::Windows::UI::Text::FontWeights::Bold());
@@ -3927,8 +4414,11 @@ bool InitializePopupXamlHost(HWND hwnd) {
         outgoingTitle.Opacity(0.0);
         TranslateTransform outgoingTitleTranslate;
         outgoingTitle.RenderTransform(outgoingTitleTranslate);
-        canvas.Children().Append(outgoingTitle);
+        outgoingTitleHost.Children().Append(outgoingTitle);
+        canvas.Children().Append(outgoingTitleHost);
 
+        Grid outgoingArtistHost;
+        outgoingArtistHost.IsHitTestVisible(false);
         TextBlock outgoingArtist;
         outgoingArtist.FontFamily(mediax::FontFamily(L"Segoe UI Variable Text"));
         outgoingArtist.TextTrimming(xaml::TextTrimming::CharacterEllipsis);
@@ -3936,8 +4426,11 @@ bool InitializePopupXamlHost(HWND hwnd) {
         outgoingArtist.Opacity(0.0);
         TranslateTransform outgoingArtistTranslate;
         outgoingArtist.RenderTransform(outgoingArtistTranslate);
-        canvas.Children().Append(outgoingArtist);
+        outgoingArtistHost.Children().Append(outgoingArtist);
+        canvas.Children().Append(outgoingArtistHost);
 
+        Grid titleHost;
+        titleHost.IsHitTestVisible(false);
         TextBlock title;
         title.FontFamily(mediax::FontFamily(L"Segoe UI Variable Text"));
         title.FontWeight(winrt::Windows::UI::Text::FontWeights::Bold());
@@ -3945,15 +4438,19 @@ bool InitializePopupXamlHost(HWND hwnd) {
         title.VerticalAlignment(VerticalAlignment::Center);
         TranslateTransform titleTranslate;
         title.RenderTransform(titleTranslate);
-        canvas.Children().Append(title);
+        titleHost.Children().Append(title);
+        canvas.Children().Append(titleHost);
 
+        Grid artistHost;
+        artistHost.IsHitTestVisible(false);
         TextBlock artist;
         artist.FontFamily(mediax::FontFamily(L"Segoe UI Variable Text"));
         artist.TextTrimming(xaml::TextTrimming::CharacterEllipsis);
         artist.VerticalAlignment(VerticalAlignment::Center);
         TranslateTransform artistTranslate;
         artist.RenderTransform(artistTranslate);
-        canvas.Children().Append(artist);
+        artistHost.Children().Append(artist);
+        canvas.Children().Append(artistHost);
 
         TextBlock elapsed;
         elapsed.FontFamily(mediax::FontFamily(L"Segoe UI Variable Text"));
@@ -3972,13 +4469,19 @@ bool InitializePopupXamlHost(HWND hwnd) {
 
         Border progressTrack;
         progressTrack.Height(6);
-        progressTrack.CornerRadius({3, 3, 3, 3});
+        progressTrack.CornerRadius({kPopupG2ProgressCornerRadius,
+                                    kPopupG2ProgressCornerRadius,
+                                    kPopupG2ProgressCornerRadius,
+                                    kPopupG2ProgressCornerRadius});
         progressTrack.IsHitTestVisible(false);
         canvas.Children().Append(progressTrack);
 
         Border progressFill;
         progressFill.Height(6);
-        progressFill.CornerRadius({3, 3, 3, 3});
+        progressFill.CornerRadius({kPopupG2ProgressCornerRadius,
+                                   kPopupG2ProgressCornerRadius,
+                                   kPopupG2ProgressCornerRadius,
+                                   kPopupG2ProgressCornerRadius});
         progressFill.IsHitTestVisible(false);
         canvas.Children().Append(progressFill);
 
@@ -4022,7 +4525,10 @@ bool InitializePopupXamlHost(HWND hwnd) {
         Border progressGlowCore;
         progressGlowCore.Width(6);
         progressGlowCore.Height(6);
-        progressGlowCore.CornerRadius({3, 3, 3, 3});
+        progressGlowCore.CornerRadius({kPopupG2ProgressCornerRadius,
+                                       kPopupG2ProgressCornerRadius,
+                                       kPopupG2ProgressCornerRadius,
+                                       kPopupG2ProgressCornerRadius});
         progressGlowCore.IsHitTestVisible(false);
         progressGlowCore.Opacity(0.0);
         canvas.Children().Append(progressGlowCore);
@@ -4186,6 +4692,10 @@ bool InitializePopupXamlHost(HWND hwnd) {
         g_popupXamlArtFrame = artFrame;
         g_popupXamlArtFade = artFade;
         g_popupXamlArt = art;
+        g_popupXamlTitleHost = titleHost;
+        g_popupXamlArtistHost = artistHost;
+        g_popupXamlOutgoingTitleHost = outgoingTitleHost;
+        g_popupXamlOutgoingArtistHost = outgoingArtistHost;
         g_popupXamlTitle = title;
         g_popupXamlArtist = artist;
         g_popupXamlOutgoingTitle = outgoingTitle;
@@ -4350,8 +4860,8 @@ void UpdatePopupXamlVisuals() {
         LerpInt(sourceArtRect.right, targetArtScreen.right, progress),
         LerpInt(sourceArtRect.bottom, targetArtScreen.bottom, progress),
     };
-    double artRadius = kPopupUnifiedCornerRadius;
-    g_popupXamlArtFrame.CornerRadius({artRadius, artRadius, artRadius, artRadius});
+    g_popupXamlArtFrame.CornerRadius({0, 0, 0, 0});
+    g_popupXamlArtFrame.Clip(nullptr);
     ApplyCompositorRect(g_popupXamlArtFrame,
                         g_popupXamlArtScale,
                         g_popupXamlArtTranslate,
@@ -4389,25 +4899,36 @@ void UpdatePopupXamlVisuals() {
                         targetCard,
                         popupScreen);
 
-    auto placeText = [&](TextBlock const& text, RECT const& source, RECT const& target,
+    auto placeText = [&](FrameworkElement const& host, TextBlock const& text,
+                         RECT const& source, RECT const& target,
                          double compactSize, double expandedSize) {
+        if (!host || !text) {
+            return;
+        }
+
         RECT screen{LerpInt(source.left, target.left, progress),
                     LerpInt(source.top, target.top, progress),
                     LerpInt(source.right, target.right, progress),
                     LerpInt(source.bottom, target.bottom, progress)};
         double textWidth = std::max(1L, screen.right - screen.left);
         double textHeight = std::max(1L, screen.bottom - screen.top);
+        host.Width(textWidth);
+        host.Height(textHeight);
+        ApplyElementClip(host, textWidth, textHeight);
         text.Width(textWidth);
         text.Height(textHeight);
-        ApplyElementClip(text, textWidth, textHeight);
         text.FontSize(expandedSize);
-        controls::Canvas::SetLeft(text, screen.left - popupScreen.left);
-        controls::Canvas::SetTop(text, screen.top - popupScreen.top);
+        controls::Canvas::SetLeft(host, screen.left - popupScreen.left);
+        controls::Canvas::SetTop(host, screen.top - popupScreen.top);
     };
-    placeText(g_popupXamlOutgoingTitle, sourceTitleRect, targetTitle, 12, 16);
-    placeText(g_popupXamlOutgoingArtist, sourceArtistRect, targetArtist, 10, 13);
-    placeText(g_popupXamlTitle, sourceTitleRect, targetTitle, 12, 16);
-    placeText(g_popupXamlArtist, sourceArtistRect, targetArtist, 10, 13);
+    placeText(g_popupXamlOutgoingTitleHost, g_popupXamlOutgoingTitle,
+              sourceTitleRect, targetTitle, 12, 16);
+    placeText(g_popupXamlOutgoingArtistHost, g_popupXamlOutgoingArtist,
+              sourceArtistRect, targetArtist, 10, 13);
+    placeText(g_popupXamlTitleHost, g_popupXamlTitle,
+              sourceTitleRect, targetTitle, 12, 16);
+    placeText(g_popupXamlArtistHost, g_popupXamlArtist,
+              sourceArtistRect, targetArtist, 10, 13);
 
     double textOpacity = SmoothStep(Clamp(progress, 0.0, 1.0));
     g_popupTextBaseOpacity = textOpacity;
@@ -4473,7 +4994,7 @@ void UpdatePopupXamlVisuals() {
         g_popupXamlProgressTrack.Opacity(controlsOpacity);
         g_popupXamlProgressTrack.Width(progressWidth);
         g_popupXamlProgressTrack.Height(std::max(4.0, progressHeight));
-        double radius = std::max(2.0, g_popupXamlProgressTrack.Height() * 0.5);
+        double radius = kPopupG2ProgressCornerRadius;
         g_popupXamlProgressTrack.CornerRadius({radius, radius, radius, radius});
         controls::Canvas::SetLeft(g_popupXamlProgressTrack, progressLeft);
         controls::Canvas::SetTop(g_popupXamlProgressTrack, progressTop);
@@ -4498,7 +5019,7 @@ void UpdatePopupXamlVisuals() {
         g_popupXamlProgressFill.Opacity(controlsOpacity);
         g_popupXamlProgressFill.Width(fillWidth);
         g_popupXamlProgressFill.Height(progressThickness);
-        double fillRadius = std::max(2.0, progressThickness * 0.5);
+        double fillRadius = kPopupG2ProgressCornerRadius;
         g_popupXamlProgressFill.CornerRadius({fillRadius, fillRadius, fillRadius, fillRadius});
         controls::Canvas::SetLeft(g_popupXamlProgressFill, progressLeft);
         controls::Canvas::SetTop(g_popupXamlProgressFill, progressTop);
@@ -4899,6 +5420,15 @@ void CapturePopupSourceGeometry() {
     }
 }
 
+void UpdatePopupBackdropOverlayWindow();
+void HidePopupBackdropOverlayWindow();
+void StopPopupOverlayWgcBackdrop();
+bool StartPopupOverlayWgcBackdrop(RECT const& captureRect, int widthPx, int heightPx);
+void UpdatePopupOverlayWgcCaptureRect(RECT const& captureRect);
+void SetPopupWindowCaptureExclusion(HWND hwnd, bool exclude);
+void ClearPopupBackdropOverlayHandoffCache();
+bool ClearPopupBackdropOverlayLayeredSurface(HWND hwnd);
+
 void PositionExpandedPopup() {
     if (!g_expandedPopup || !g_taskbarWnd) {
         return;
@@ -4928,6 +5458,7 @@ void PositionExpandedPopup() {
                 MoveWindow(g_popupXamlChild, 0, 0, width, height, FALSE);
             }
         }
+        UpdatePopupBackdropOverlayWindow();
         return;
     }
 
@@ -4952,6 +5483,7 @@ void PositionExpandedPopup() {
     if (g_popupXamlChild) {
         MoveWindow(g_popupXamlChild, 0, 0, width, height, FALSE);
     }
+    UpdatePopupBackdropOverlayWindow();
 }
 void SetCompactIslandSuppressed(bool suppressed);
 void StartPopupXamlRenderLoop();
@@ -5524,6 +6056,7 @@ void StopPopupXamlRenderLoop() {
 
 void FinishCloseExpandedPopup(HWND hwnd) {
     StopPopupXamlRenderLoop();
+    HidePopupBackdropOverlayWindow();
     if (hwnd) {
         ShowWindow(hwnd, SW_HIDE);
         KillTimer(hwnd, kPopupTimerId);
@@ -5768,6 +6301,1786 @@ HINSTANCE ModInstance() {
     return instance;
 }
 
+void SetPopupBackdropOverlayNativeBlur(HWND hwnd, bool enable) {
+    // 0.9.56: native Accent Acrylic is intentionally disabled for the overlay.
+    // It adds an unavoidable light-mode gray veil and does not reliably follow
+    // Win32/DWM rounded regions. The overlay now paints its own blurred pixels
+    // with a per-pixel alpha mask via UpdateLayeredWindow.
+    if (!hwnd) {
+        return;
+    }
+
+    struct AccentPolicy {
+        int state;
+        int flags;
+        DWORD gradientColor;
+        int animationId;
+    };
+    struct CompositionAttributeData {
+        int attribute;
+        void* data;
+        SIZE_T size;
+    };
+    using SetWindowCompositionAttribute_t = BOOL(WINAPI*)(
+        HWND, CompositionAttributeData*);
+
+    static auto setWindowCompositionAttribute =
+        reinterpret_cast<SetWindowCompositionAttribute_t>(
+            GetProcAddress(GetModuleHandleW(L"user32.dll"),
+                           "SetWindowCompositionAttribute"));
+    if (setWindowCompositionAttribute) {
+        AccentPolicy policy{0, 0, 0x00000000, 0};
+        CompositionAttributeData data{19, &policy, sizeof(policy)};
+        setWindowCompositionAttribute(hwnd, &data);
+    }
+}
+
+
+
+BYTE PopupRoundedRectAlpha(int x, int y, int width, int height, int radius);
+bool UpdatePopupBackdropOverlayLayeredDiagnostic(HWND hwnd,
+                                                RECT const& screenRect,
+                                                int width,
+                                                int height,
+                                                int cornerRadiusPx) {
+    if (!hwnd || width <= 2 || height <= 2) {
+        return false;
+    }
+
+    auto now = std::chrono::steady_clock::now();
+    if (g_popupOverlayWgcLastDiagnosticPaintTime.time_since_epoch().count() != 0 &&
+        now - g_popupOverlayWgcLastDiagnosticPaintTime <
+            std::chrono::milliseconds(180)) {
+        return true;
+    }
+    g_popupOverlayWgcLastDiagnosticPaintTime = now;
+
+    std::vector<BYTE> out(static_cast<size_t>(width) * height * 4, 0);
+    if (g_popupOverlayWgcReadbackDiagnosticTime.time_since_epoch().count() == 0) {
+        g_popupOverlayWgcReadbackDiagnosticTime = now;
+    }
+    double seconds = std::chrono::duration<double>(
+                         now - g_popupOverlayWgcReadbackDiagnosticTime)
+                         .count();
+    int phase = static_cast<int>(std::fmod(seconds * 120.0, 96.0));
+    bool dark = IsDarkModeApprox();
+
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            int cell = 32;
+            int shiftedX = x + phase;
+            bool checker = ((shiftedX / cell) + (y / cell)) & 1;
+
+            // Visual diagnostic palette:
+            // blue/pink  = not started
+            // yellow     = start skipped / failed before session
+            // orange     = session started, no frame callback yet
+            // green      = frame arrived
+            // red        = render/map/update failure
+            // cyan       = at least one visible WGC frame was produced
+            int r = checker ? 70 : 235;
+            int g = checker ? 130 : 80;
+            int b = checker ? 245 : 190;
+            switch (g_popupOverlayWgcDiagnosticState) {
+                case PopupOverlayWgcDiagnosticState::StartSkipped:
+                    r = checker ? 255 : 180;
+                    g = checker ? 220 : 120;
+                    b = checker ? 40 : 20;
+                    break;
+                case PopupOverlayWgcDiagnosticState::StartedNoFrame:
+                    r = checker ? 255 : 230;
+                    g = checker ? 130 : 80;
+                    b = checker ? 30 : 10;
+                    break;
+                case PopupOverlayWgcDiagnosticState::FrameArrived:
+                    r = checker ? 60 : 30;
+                    g = checker ? 220 : 150;
+                    b = checker ? 90 : 40;
+                    break;
+                case PopupOverlayWgcDiagnosticState::RenderFailed:
+                case PopupOverlayWgcDiagnosticState::MapFailed:
+                case PopupOverlayWgcDiagnosticState::UpdateFailed:
+                    r = checker ? 255 : 150;
+                    g = checker ? 45 : 20;
+                    b = checker ? 45 : 20;
+                    break;
+                case PopupOverlayWgcDiagnosticState::VisibleFrame:
+                    r = checker ? 30 : 20;
+                    g = checker ? 220 : 160;
+                    b = checker ? 240 : 180;
+                    break;
+                case PopupOverlayWgcDiagnosticState::NotStarted:
+                default:
+                    if (!dark) {
+                        r = checker ? 70 : 245;
+                        g = checker ? 120 : 140;
+                        b = checker ? 220 : 210;
+                    }
+                    break;
+            }
+
+            BYTE edgeAlpha = PopupRoundedRectAlpha(x, y, width, height, cornerRadiusPx);
+            BYTE a = static_cast<BYTE>((static_cast<int>(edgeAlpha) * 230) / 255);
+            BYTE* dst = out.data() + (static_cast<size_t>(y) * width + x) * 4;
+            dst[0] = static_cast<BYTE>((b * a) / 255);
+            dst[1] = static_cast<BYTE>((g * a) / 255);
+            dst[2] = static_cast<BYTE>((r * a) / 255);
+            dst[3] = a;
+        }
+    }
+
+    HDC screenDc = GetDC(nullptr);
+    if (!screenDc) {
+        return false;
+    }
+    HDC memDc = CreateCompatibleDC(screenDc);
+    if (!memDc) {
+        ReleaseDC(nullptr, screenDc);
+        return false;
+    }
+
+    BITMAPINFO info{};
+    info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    info.bmiHeader.biWidth = width;
+    info.bmiHeader.biHeight = -height;
+    info.bmiHeader.biPlanes = 1;
+    info.bmiHeader.biBitCount = 32;
+    info.bmiHeader.biCompression = BI_RGB;
+
+    void* bits = nullptr;
+    HBITMAP bitmap = CreateDIBSection(screenDc, &info, DIB_RGB_COLORS,
+                                      &bits, nullptr, 0);
+    if (!bitmap || !bits) {
+        if (bitmap) DeleteObject(bitmap);
+        DeleteDC(memDc);
+        ReleaseDC(nullptr, screenDc);
+        return false;
+    }
+    std::memcpy(bits, out.data(), out.size());
+
+    HGDIOBJ oldBitmap = SelectObject(memDc, bitmap);
+    POINT srcPoint{0, 0};
+    SIZE size{width, height};
+    POINT dstPoint{screenRect.left, screenRect.top};
+    BLENDFUNCTION blend{AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
+
+    BOOL ok = UpdateLayeredWindow(hwnd, screenDc, &dstPoint, &size,
+                                  memDc, &srcPoint, 0, &blend, ULW_ALPHA);
+
+    SelectObject(memDc, oldBitmap);
+    DeleteObject(bitmap);
+    DeleteDC(memDc);
+    ReleaseDC(nullptr, screenDc);
+    return !!ok;
+}
+
+BYTE PopupRoundedRectAlpha(int x, int y, int width, int height, int radius);
+#if IMC_WGC_OVERLAY_AVAILABLE
+bool CreatePopupOverlayWgcCaptureItemForMonitor(HMONITOR monitor,
+                                                capture::GraphicsCaptureItem& item) {
+    item = nullptr;
+    g_popupOverlayWgcCreateItemHr = S_OK;
+    if (!monitor) {
+        g_popupOverlayWgcCreateItemHr = E_INVALIDARG;
+        Wh_Log(L"Island: overlay WGC CreateForMonitor skipped: null monitor");
+        return false;
+    }
+
+    try {
+        auto activationFactory =
+            winrt::get_activation_factory<capture::GraphicsCaptureItem>();
+
+        winrt::com_ptr<IGraphicsCaptureItemInterop> interopFactory;
+        HRESULT hr = reinterpret_cast<IUnknown*>(
+                         winrt::get_abi(activationFactory))
+                         ->QueryInterface(
+                             kIID_IGraphicsCaptureItemInterop,
+                             interopFactory.put_void());
+        if (FAILED(hr) || !interopFactory) {
+            g_popupOverlayWgcCreateItemHr = hr;
+            Wh_Log(L"Island: overlay WGC QI IGraphicsCaptureItemInterop failed hr=0x%08X",
+                   static_cast<unsigned>(hr));
+            return false;
+        }
+
+        void* rawItem = nullptr;
+        hr = interopFactory->CreateForMonitor(
+            monitor,
+            kIID_IGraphicsCaptureItem,
+            &rawItem);
+        g_popupOverlayWgcCreateItemHr = hr;
+        if (FAILED(hr)) {
+            Wh_Log(L"Island: overlay WGC CreateForMonitor failed hr=0x%08X monitor=%p",
+                   static_cast<unsigned>(hr),
+                   monitor);
+            return false;
+        }
+        if (!rawItem) {
+            g_popupOverlayWgcCreateItemHr = E_POINTER;
+            Wh_Log(L"Island: overlay WGC CreateForMonitor returned null item hr=0x%08X monitor=%p",
+                   static_cast<unsigned>(hr),
+                   monitor);
+            return false;
+        }
+
+        item = capture::GraphicsCaptureItem{
+            rawItem,
+            winrt::take_ownership_from_abi};
+        Wh_Log(L"Island: overlay WGC CreateForMonitor succeeded monitor=%p", monitor);
+        g_popupOverlayWgcCreateItemFailed = false;
+        return true;
+    } catch (winrt::hresult_error const& error) {
+        g_popupOverlayWgcCreateItemHr = error.code().value;
+        Wh_Log(L"Island: overlay WGC CreateForMonitor exception hr=0x%08X",
+               static_cast<unsigned>(g_popupOverlayWgcCreateItemHr));
+        return false;
+    } catch (...) {
+        g_popupOverlayWgcCreateItemHr = E_FAIL;
+        Wh_Log(L"Island: overlay WGC CreateForMonitor unknown exception");
+        return false;
+    }
+}
+
+bool RecreatePopupOverlayWgcReadbackTextures(int widthPx, int heightPx) {
+    if (!g_popupOverlayWgcD3dDevice || widthPx <= 0 || heightPx <= 0) {
+        return false;
+    }
+
+    if (g_popupOverlayWgcRenderTexture &&
+        g_popupOverlayWgcStagingTexture &&
+        g_popupOverlayWgcTargetWidthPx == widthPx &&
+        g_popupOverlayWgcTargetHeightPx == heightPx) {
+        return true;
+    }
+
+    winrt::com_ptr<ID3D11Texture2D> renderTexture;
+    winrt::com_ptr<ID3D11Texture2D> stagingTexture;
+
+    D3D11_TEXTURE2D_DESC renderDesc{};
+    renderDesc.Width = static_cast<UINT>(widthPx);
+    renderDesc.Height = static_cast<UINT>(heightPx);
+    renderDesc.MipLevels = 1;
+    renderDesc.ArraySize = 1;
+    renderDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+    renderDesc.SampleDesc.Count = 1;
+    renderDesc.SampleDesc.Quality = 0;
+    renderDesc.Usage = D3D11_USAGE_DEFAULT;
+    renderDesc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+    renderDesc.CPUAccessFlags = 0;
+    renderDesc.MiscFlags = 0;
+
+    HRESULT hr = g_popupOverlayWgcD3dDevice->CreateTexture2D(
+        &renderDesc,
+        nullptr,
+        renderTexture.put());
+    if (FAILED(hr)) {
+        Wh_Log(L"Island: overlay WGC render texture failed hr=0x%08X",
+               static_cast<unsigned>(hr));
+        return false;
+    }
+
+    D3D11_TEXTURE2D_DESC stagingDesc = renderDesc;
+    stagingDesc.Usage = D3D11_USAGE_STAGING;
+    stagingDesc.BindFlags = 0;
+    stagingDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+
+    hr = g_popupOverlayWgcD3dDevice->CreateTexture2D(
+        &stagingDesc,
+        nullptr,
+        stagingTexture.put());
+    if (FAILED(hr)) {
+        Wh_Log(L"Island: overlay WGC staging texture failed hr=0x%08X",
+               static_cast<unsigned>(hr));
+        return false;
+    }
+
+    g_popupOverlayWgcRenderTexture = std::move(renderTexture);
+    g_popupOverlayWgcStagingTexture = std::move(stagingTexture);
+    g_popupOverlayWgcTargetWidthPx = widthPx;
+    g_popupOverlayWgcTargetHeightPx = heightPx;
+    return true;
+}
+
+bool EnsurePopupOverlayWgcDeviceResources(HWND hwnd, int widthPx, int heightPx) {
+    if (!UseOverlayPopupBackdropMaterial() || !hwnd ||
+        widthPx <= 0 || heightPx <= 0) {
+        return false;
+    }
+
+    if (g_popupOverlayWgcD3dDevice &&
+        g_popupOverlayWgcRenderTexture &&
+        g_popupOverlayWgcStagingTexture &&
+        g_popupOverlayWgcTargetWidthPx == widthPx &&
+        g_popupOverlayWgcTargetHeightPx == heightPx) {
+        return true;
+    }
+
+    g_popupOverlayWgcSession = nullptr;
+    if (g_popupOverlayWgcFramePool && g_popupOverlayWgcFrameCallbackHooked) {
+        try {
+            g_popupOverlayWgcFramePool.FrameArrived(g_popupOverlayWgcFrameArrivedToken);
+        } catch (...) {
+        }
+        g_popupOverlayWgcFrameCallbackHooked = false;
+    }
+    g_popupOverlayWgcFramePool = nullptr;
+    g_popupOverlayWgcItem = nullptr;
+    g_popupOverlayWgcGraphicsDevice = nullptr;
+    g_popupOverlayWgcRenderTexture = nullptr;
+    g_popupOverlayWgcStagingTexture = nullptr;
+    g_popupOverlayWgcD2dContext = nullptr;
+    g_popupOverlayWgcD2dDevice = nullptr;
+    g_popupOverlayWgcD2dFactory = nullptr;
+    g_popupOverlayWgcDxgiDevice = nullptr;
+    g_popupOverlayWgcD3dContext = nullptr;
+    g_popupOverlayWgcD3dDevice = nullptr;
+
+    UINT deviceFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+    D3D_FEATURE_LEVEL featureLevels[] = {
+        D3D_FEATURE_LEVEL_11_1,
+        D3D_FEATURE_LEVEL_11_0,
+        D3D_FEATURE_LEVEL_10_1,
+        D3D_FEATURE_LEVEL_10_0,
+    };
+    D3D_FEATURE_LEVEL selectedFeatureLevel{};
+    HRESULT hr = D3D11CreateDevice(
+        nullptr,
+        D3D_DRIVER_TYPE_HARDWARE,
+        nullptr,
+        deviceFlags,
+        featureLevels,
+        ARRAYSIZE(featureLevels),
+        D3D11_SDK_VERSION,
+        g_popupOverlayWgcD3dDevice.put(),
+        &selectedFeatureLevel,
+        g_popupOverlayWgcD3dContext.put());
+    if (FAILED(hr)) {
+        hr = D3D11CreateDevice(
+            nullptr,
+            D3D_DRIVER_TYPE_WARP,
+            nullptr,
+            deviceFlags,
+            featureLevels,
+            ARRAYSIZE(featureLevels),
+            D3D11_SDK_VERSION,
+            g_popupOverlayWgcD3dDevice.put(),
+            &selectedFeatureLevel,
+            g_popupOverlayWgcD3dContext.put());
+    }
+    if (FAILED(hr)) {
+        Wh_Log(L"Island: overlay WGC D3D11CreateDevice failed hr=0x%08X",
+               static_cast<unsigned>(hr));
+        return false;
+    }
+
+    g_popupOverlayWgcDxgiDevice = g_popupOverlayWgcD3dDevice.as<IDXGIDevice>();
+
+    D2D1_FACTORY_OPTIONS factoryOptions{};
+    hr = D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED,
+                           __uuidof(ID2D1Factory1),
+                           &factoryOptions,
+                           reinterpret_cast<void**>(g_popupOverlayWgcD2dFactory.put()));
+    if (FAILED(hr)) {
+        Wh_Log(L"Island: overlay WGC D2D factory failed hr=0x%08X",
+               static_cast<unsigned>(hr));
+        return false;
+    }
+    hr = g_popupOverlayWgcD2dFactory->CreateDevice(g_popupOverlayWgcDxgiDevice.get(),
+                                                   g_popupOverlayWgcD2dDevice.put());
+    if (FAILED(hr)) {
+        Wh_Log(L"Island: overlay WGC D2D device failed hr=0x%08X",
+               static_cast<unsigned>(hr));
+        return false;
+    }
+    hr = g_popupOverlayWgcD2dDevice->CreateDeviceContext(
+        D2D1_DEVICE_CONTEXT_OPTIONS_NONE,
+        g_popupOverlayWgcD2dContext.put());
+    if (FAILED(hr)) {
+        Wh_Log(L"Island: overlay WGC D2D context failed hr=0x%08X",
+               static_cast<unsigned>(hr));
+        return false;
+    }
+
+    winrt::com_ptr<IInspectable> graphicsDeviceInspectable;
+    hr = CreateDirect3D11DeviceFromDXGIDevice(
+        g_popupOverlayWgcDxgiDevice.get(),
+        graphicsDeviceInspectable.put());
+    if (FAILED(hr)) {
+        Wh_Log(L"Island: overlay WGC CreateDirect3D11DeviceFromDXGIDevice failed hr=0x%08X",
+               static_cast<unsigned>(hr));
+        return false;
+    }
+    g_popupOverlayWgcGraphicsDevice =
+        graphicsDeviceInspectable.as<direct3d11::IDirect3DDevice>();
+
+    winrt::com_ptr<IDXGIAdapter> adapter;
+    hr = g_popupOverlayWgcDxgiDevice->GetAdapter(adapter.put());
+    if (FAILED(hr)) {
+        return false;
+    }
+    winrt::com_ptr<IDXGIFactory2> factory;
+    hr = adapter->GetParent(__uuidof(IDXGIFactory2), factory.put_void());
+    if (FAILED(hr)) {
+        return false;
+    }
+
+    return RecreatePopupOverlayWgcReadbackTextures(widthPx, heightPx);
+}
+
+void RenderPopupOverlayWgcDiagnosticFrame() {}
+
+void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
+    g_popupOverlayWgcHadFrame = true;
+    ++g_popupOverlayWgcFrameCount;
+    g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::FrameArrived;
+    if (!g_popupOverlayWgcRunning || !frame ||
+        !g_popupOverlayWgcD2dContext ||
+        !g_popupOverlayWgcRenderTexture ||
+        !g_popupOverlayWgcStagingTexture ||
+        !g_popupBackdropOverlay) {
+        return;
+    }
+
+    RECT captureRect = g_popupOverlayWgcCaptureRectPx;
+    RECT monitorRect = g_popupOverlayWgcMonitorRectPx;
+    int targetWidth = g_popupOverlayWgcTargetWidthPx;
+    int targetHeight = g_popupOverlayWgcTargetHeightPx;
+    if (targetWidth <= 0 || targetHeight <= 0 ||
+        captureRect.right <= captureRect.left ||
+        captureRect.bottom <= captureRect.top) {
+        return;
+    }
+
+    if (g_popupOverlayWgcFramesToSkip > 0) {
+        --g_popupOverlayWgcFramesToSkip;
+        return;
+    }
+
+    try {
+        auto surface = frame.Surface();
+        winrt::com_ptr<IDirect3DDxgiInterfaceAccess> access;
+        winrt::check_hresult(reinterpret_cast<IUnknown*>(winrt::get_abi(surface))
+                                 ->QueryInterface(
+                                     kIID_IDirect3DDxgiInterfaceAccess,
+                                     access.put_void()));
+        winrt::com_ptr<ID3D11Texture2D> frameTexture;
+        winrt::check_hresult(access->GetInterface(
+            __uuidof(ID3D11Texture2D),
+            frameTexture.put_void()));
+        winrt::com_ptr<IDXGISurface> frameSurface;
+        frameTexture.as(frameSurface);
+
+        winrt::com_ptr<IDXGISurface> renderSurface;
+        g_popupOverlayWgcRenderTexture.as(renderSurface);
+
+        D2D1_BITMAP_PROPERTIES1 targetProps = D2D1::BitmapProperties1(
+            D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
+            D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM,
+                              D2D1_ALPHA_MODE_IGNORE));
+        winrt::com_ptr<ID2D1Bitmap1> targetBitmap;
+        winrt::check_hresult(g_popupOverlayWgcD2dContext->CreateBitmapFromDxgiSurface(
+            renderSurface.get(),
+            &targetProps,
+            targetBitmap.put()));
+
+        D2D1_BITMAP_PROPERTIES1 sourceProps = D2D1::BitmapProperties1(
+            D2D1_BITMAP_OPTIONS_NONE,
+            D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM,
+                              D2D1_ALPHA_MODE_IGNORE));
+        winrt::com_ptr<ID2D1Bitmap1> sourceBitmap;
+        winrt::check_hresult(g_popupOverlayWgcD2dContext->CreateBitmapFromDxgiSurface(
+            frameSurface.get(),
+            &sourceProps,
+            sourceBitmap.put()));
+
+        float srcLeft = static_cast<float>(captureRect.left - monitorRect.left);
+        float srcTop = static_cast<float>(captureRect.top - monitorRect.top);
+        float srcRight = static_cast<float>(captureRect.right - monitorRect.left);
+        float srcBottom = static_cast<float>(captureRect.bottom - monitorRect.top);
+        D2D1_RECT_F sourceRect = D2D1::RectF(srcLeft, srcTop, srcRight, srcBottom);
+        D2D1_RECT_F targetRect = D2D1::RectF(
+            0.0f, 0.0f,
+            static_cast<float>(targetWidth),
+            static_cast<float>(targetHeight));
+
+        D2D1_BITMAP_PROPERTIES1 intermediateProps = D2D1::BitmapProperties1(
+            D2D1_BITMAP_OPTIONS_TARGET,
+            D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM,
+                              D2D1_ALPHA_MODE_IGNORE));
+        winrt::com_ptr<ID2D1Bitmap1> intermediateBitmap;
+        winrt::check_hresult(g_popupOverlayWgcD2dContext->CreateBitmap(
+            D2D1::SizeU(static_cast<UINT32>(targetWidth),
+                        static_cast<UINT32>(targetHeight)),
+            nullptr,
+            0,
+            &intermediateProps,
+            intermediateBitmap.put()));
+
+        // Step 1: crop/scale the monitor capture into an offscreen target-sized
+        // bitmap. This keeps the later Gaussian blur independent of monitor
+        // resolution and avoids trying to draw the full monitor-sized effect.
+        g_popupOverlayWgcD2dContext->SetTarget(intermediateBitmap.get());
+        g_popupOverlayWgcD2dContext->BeginDraw();
+        g_popupOverlayWgcD2dContext->Clear(D2D1::ColorF(0.0f, 0.0f, 0.0f, 1.0f));
+        g_popupOverlayWgcD2dContext->DrawBitmap(
+            sourceBitmap.get(),
+            targetRect,
+            1.0f,
+            D2D1_INTERPOLATION_MODE_LINEAR,
+            sourceRect);
+        HRESULT hr = g_popupOverlayWgcD2dContext->EndDraw();
+        if (FAILED(hr)) {
+            g_popupOverlayWgcLastHr = hr;
+            g_popupOverlayWgcDiagnosticHr = hr;
+            g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::RenderFailed;
+            ++g_popupOverlayWgcRenderFailCount;
+            Wh_Log(L"Island: overlay WGC state intermediate EndDraw failed hr=0x%08X frames=%llu fails=%llu",
+                   static_cast<unsigned>(hr),
+                   static_cast<unsigned long long>(g_popupOverlayWgcFrameCount),
+                   static_cast<unsigned long long>(g_popupOverlayWgcRenderFailCount));
+            return;
+        }
+
+        winrt::com_ptr<ID2D1Effect> blurEffect;
+        winrt::check_hresult(g_popupOverlayWgcD2dContext->CreateEffect(
+            CLSID_D2D1GaussianBlur,
+            blurEffect.put()));
+        blurEffect->SetInput(0, intermediateBitmap.get());
+        blurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION,
+                             PopupBackdropWgcBlurStdDev());
+        blurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_BORDER_MODE,
+                             D2D1_BORDER_MODE_HARD);
+
+        // Step 2: render the blurred target-sized image to the GPU texture that
+        // will be read back into the layered window.
+        g_popupOverlayWgcD2dContext->SetTarget(targetBitmap.get());
+        g_popupOverlayWgcD2dContext->BeginDraw();
+        g_popupOverlayWgcD2dContext->Clear(D2D1::ColorF(0.0f, 0.0f, 0.0f, 1.0f));
+        D2D1_POINT_2F blurTargetOffset = D2D1::Point2F(0.0f, 0.0f);
+        g_popupOverlayWgcD2dContext->DrawImage(
+            blurEffect.get(),
+            &blurTargetOffset,
+            nullptr,
+            D2D1_INTERPOLATION_MODE_LINEAR,
+            D2D1_COMPOSITE_MODE_SOURCE_COPY);
+        hr = g_popupOverlayWgcD2dContext->EndDraw();
+        if (FAILED(hr)) {
+            g_popupOverlayWgcLastHr = hr;
+            g_popupOverlayWgcDiagnosticHr = hr;
+            g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::RenderFailed;
+            ++g_popupOverlayWgcRenderFailCount;
+            Wh_Log(L"Island: overlay WGC state EndDraw failed hr=0x%08X frames=%llu fails=%llu",
+                   static_cast<unsigned>(hr),
+                   static_cast<unsigned long long>(g_popupOverlayWgcFrameCount),
+                   static_cast<unsigned long long>(g_popupOverlayWgcRenderFailCount));
+            return;
+        }
+
+        g_popupOverlayWgcD3dContext->CopyResource(
+            g_popupOverlayWgcStagingTexture.get(),
+            g_popupOverlayWgcRenderTexture.get());
+
+        D3D11_MAPPED_SUBRESOURCE mapped{};
+        hr = g_popupOverlayWgcD3dContext->Map(
+            g_popupOverlayWgcStagingTexture.get(),
+            0,
+            D3D11_MAP_READ,
+            0,
+            &mapped);
+        if (FAILED(hr)) {
+            g_popupOverlayWgcLastHr = hr;
+            g_popupOverlayWgcDiagnosticHr = hr;
+            g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::MapFailed;
+            ++g_popupOverlayWgcRenderFailCount;
+            Wh_Log(L"Island: overlay WGC state Map failed hr=0x%08X frames=%llu fails=%llu",
+                   static_cast<unsigned>(hr),
+                   static_cast<unsigned long long>(g_popupOverlayWgcFrameCount),
+                   static_cast<unsigned long long>(g_popupOverlayWgcRenderFailCount));
+            return;
+        }
+
+        std::vector<BYTE> layeredPixels(static_cast<size_t>(targetWidth) *
+                                        targetHeight * 4);
+        bool dark = IsDarkModeApprox();
+        double dim = dark ? 0.94 : 1.0;
+        BYTE maxAlpha = PopupBackdropOverlayMaxAlpha();
+        int cornerRadiusPx = g_popupBackdropOverlayLastRadius > 0
+                                  ? g_popupBackdropOverlayLastRadius
+                                  : static_cast<int>(std::lround(kPopupUnifiedCornerRadius *
+                                                                 PopupDpiScale(g_expandedPopup)));
+
+        BYTE const* srcBase = static_cast<BYTE const*>(mapped.pData);
+        for (int y = 0; y < targetHeight; ++y) {
+            BYTE const* srcRow = srcBase + static_cast<size_t>(y) * mapped.RowPitch;
+            for (int x = 0; x < targetWidth; ++x) {
+                BYTE const* src = srcRow + static_cast<size_t>(x) * 4;
+                BYTE edgeAlpha = PopupRoundedRectAlpha(x, y,
+                                                       targetWidth,
+                                                       targetHeight,
+                                                       cornerRadiusPx);
+                BYTE a = static_cast<BYTE>((static_cast<int>(edgeAlpha) *
+                                            maxAlpha) / 255);
+                int b = Clamp(static_cast<int>(std::lround(src[0] * dim)), 0, 255);
+                int g = Clamp(static_cast<int>(std::lround(src[1] * dim)), 0, 255);
+                int r = Clamp(static_cast<int>(std::lround(src[2] * dim)), 0, 255);
+
+                BYTE* dst = layeredPixels.data() +
+                             (static_cast<size_t>(y) * targetWidth + x) * 4;
+                dst[0] = static_cast<BYTE>((b * a) / 255);
+                dst[1] = static_cast<BYTE>((g * a) / 255);
+                dst[2] = static_cast<BYTE>((r * a) / 255);
+                dst[3] = a;
+            }
+        }
+
+        {
+            auto nowForHandoff = std::chrono::steady_clock::now();
+            if (g_popupOverlayWgcHandoffStartTime.time_since_epoch().count() == 0) {
+                g_popupOverlayWgcHandoffStartTime = nowForHandoff;
+            }
+            double elapsedMs =
+                std::chrono::duration<double, std::milli>(
+                    nowForHandoff - g_popupOverlayWgcHandoffStartTime)
+                    .count();
+            double wgcWeight =
+                Clamp(elapsedMs / static_cast<double>(PopupBackdropHandoffFadeMs()),
+                      0.0, 1.0);
+
+            if (wgcWeight < 1.0) {
+                std::lock_guard cacheLock(g_popupBackdropOverlayHandoffMutex);
+                if (g_popupBackdropOverlayFallbackPixelsValid &&
+                    g_popupBackdropOverlayFallbackWidth == targetWidth &&
+                    g_popupBackdropOverlayFallbackHeight == targetHeight &&
+                    g_popupBackdropOverlayFallbackPixels.size() == layeredPixels.size()) {
+                    double fallbackWeight = 1.0 - wgcWeight;
+                    for (size_t i = 0; i < layeredPixels.size(); ++i) {
+                        int blended = static_cast<int>(std::lround(
+                            g_popupBackdropOverlayFallbackPixels[i] * fallbackWeight +
+                            layeredPixels[i] * wgcWeight));
+                        layeredPixels[i] = static_cast<BYTE>(Clamp(blended, 0, 255));
+                    }
+                }
+            }
+        }
+
+        g_popupOverlayWgcD3dContext->Unmap(g_popupOverlayWgcStagingTexture.get(), 0);
+
+        HDC screenDc = GetDC(nullptr);
+        if (!screenDc) {
+            return;
+        }
+        HDC memDc = CreateCompatibleDC(screenDc);
+        if (!memDc) {
+            ReleaseDC(nullptr, screenDc);
+            return;
+        }
+
+        BITMAPINFO info{};
+        info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+        info.bmiHeader.biWidth = targetWidth;
+        info.bmiHeader.biHeight = -targetHeight;
+        info.bmiHeader.biPlanes = 1;
+        info.bmiHeader.biBitCount = 32;
+        info.bmiHeader.biCompression = BI_RGB;
+
+        void* bits = nullptr;
+        HBITMAP bitmap = CreateDIBSection(screenDc, &info, DIB_RGB_COLORS,
+                                          &bits, nullptr, 0);
+        if (!bitmap || !bits) {
+            if (bitmap) DeleteObject(bitmap);
+            DeleteDC(memDc);
+            ReleaseDC(nullptr, screenDc);
+            return;
+        }
+        std::memcpy(bits, layeredPixels.data(), layeredPixels.size());
+
+        HGDIOBJ oldBitmap = SelectObject(memDc, bitmap);
+        POINT srcPoint{0, 0};
+        SIZE size{targetWidth, targetHeight};
+        POINT dstPoint{captureRect.left, captureRect.top};
+        BLENDFUNCTION blend{AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
+
+        BOOL updateOk = UpdateLayeredWindow(g_popupBackdropOverlay,
+                                            screenDc,
+                                            &dstPoint,
+                                            &size,
+                                            memDc,
+                                            &srcPoint,
+                                            0,
+                                            &blend,
+                                            ULW_ALPHA);
+        if (updateOk) {
+            static bool loggedFirstVisibleFrame = false;
+            if (!loggedFirstVisibleFrame) {
+                Wh_Log(L"Island: overlay WGC state first visible frame frames=%llu",
+                       static_cast<unsigned long long>(g_popupOverlayWgcFrameCount));
+                loggedFirstVisibleFrame = true;
+            }
+            SetPopupWindowCaptureExclusion(g_popupBackdropOverlay, true);
+            ShowWindow(g_popupBackdropOverlay, SW_SHOWNOACTIVATE);
+            g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::VisibleFrame;
+            g_popupOverlayWgcReadbackHadVisibleFrame = true;
+            g_popupOverlayWgcFallbackPainted = true;
+        } else {
+            g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::UpdateFailed;
+            ++g_popupOverlayWgcRenderFailCount;
+            Wh_Log(L"Island: overlay WGC state UpdateLayeredWindow failed err=%lu frames=%llu fails=%llu",
+                   GetLastError(),
+                   static_cast<unsigned long long>(g_popupOverlayWgcFrameCount),
+                   static_cast<unsigned long long>(g_popupOverlayWgcRenderFailCount));
+        }
+
+        SelectObject(memDc, oldBitmap);
+        DeleteObject(bitmap);
+        DeleteDC(memDc);
+        ReleaseDC(nullptr, screenDc);
+    } catch (winrt::hresult_error const& error) {
+        g_popupOverlayWgcLastHr = error.code().value;
+        g_popupOverlayWgcDiagnosticHr = error.code().value;
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::RenderFailed;
+        ++g_popupOverlayWgcRenderFailCount;
+        Wh_Log(L"Island: overlay WGC state hresult_error=0x%08X frames=%llu fails=%llu",
+               static_cast<unsigned>(g_popupOverlayWgcLastHr),
+               static_cast<unsigned long long>(g_popupOverlayWgcFrameCount),
+               static_cast<unsigned long long>(g_popupOverlayWgcRenderFailCount));
+    } catch (...) {
+        g_popupOverlayWgcLastHr = E_FAIL;
+        g_popupOverlayWgcDiagnosticHr = E_FAIL;
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::RenderFailed;
+        ++g_popupOverlayWgcRenderFailCount;
+        Wh_Log(L"Island: overlay WGC state unknown failure frames=%llu fails=%llu",
+               static_cast<unsigned long long>(g_popupOverlayWgcFrameCount),
+               static_cast<unsigned long long>(g_popupOverlayWgcRenderFailCount));
+    }
+}
+
+void StopPopupOverlayWgcBackdrop() {
+    capture::GraphicsCaptureSession sessionToClose{nullptr};
+    capture::Direct3D11CaptureFramePool framePoolToClose{nullptr};
+    winrt::event_token frameArrivedToken{};
+    bool frameCallbackHooked = false;
+
+    {
+        std::lock_guard lock(g_popupOverlayWgcMutex);
+        g_popupOverlayWgcRunning = false;
+        sessionToClose = g_popupOverlayWgcSession;
+        framePoolToClose = g_popupOverlayWgcFramePool;
+        frameArrivedToken = g_popupOverlayWgcFrameArrivedToken;
+        frameCallbackHooked = g_popupOverlayWgcFrameCallbackHooked;
+        g_popupOverlayWgcFrameCallbackHooked = false;
+        g_popupOverlayWgcSession = nullptr;
+        g_popupOverlayWgcFramePool = nullptr;
+        g_popupOverlayWgcItem = nullptr;
+        g_popupOverlayWgcHadFrame = false;
+        g_popupOverlayWgcDiagnosticStartTime = {};
+        g_popupOverlayWgcReadbackHadVisibleFrame = false;
+        g_popupOverlayWgcReadbackDiagnosticTime = {};
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::NotStarted;
+        g_popupOverlayWgcDiagnosticHr = S_OK;
+        g_popupOverlayWgcFrameCount = 0;
+        g_popupOverlayWgcRenderFailCount = 0;
+        // Keep retry throttle fields intact here. This function is called before
+        // rebuilding WGC resources, so clearing them here would re-enable rapid
+        // CreateForMonitor retries after a failure.
+        g_popupOverlayWgcStartTime = {};
+        g_popupOverlayWgcHandoffStartTime = {};
+        g_popupOverlayWgcFinalReadyTime = {};
+        g_popupOverlayWgcFramesToSkip = 0;
+    }
+
+    if (g_expandedPopup) {
+        SetWindowDisplayAffinity(g_expandedPopup, WDA_NONE);
+    }
+    if (g_popupBackdropOverlay) {
+        SetWindowDisplayAffinity(g_popupBackdropOverlay, WDA_NONE);
+    }
+    try {
+        if (framePoolToClose && frameCallbackHooked) {
+            framePoolToClose.FrameArrived(frameArrivedToken);
+        }
+    } catch (...) {
+    }
+    try {
+        if (sessionToClose) {
+            sessionToClose.Close();
+        }
+        if (framePoolToClose) {
+            framePoolToClose.Close();
+        }
+    } catch (...) {
+    }
+}
+
+bool StartPopupOverlayWgcBackdrop(RECT const& captureRect,
+                                  int widthPx,
+                                  int heightPx) {
+    auto now = std::chrono::steady_clock::now();
+    if (g_popupOverlayWgcCreateItemFailed &&
+        g_popupOverlayWgcLastStartAttemptTime.time_since_epoch().count() != 0 &&
+        now - g_popupOverlayWgcLastStartAttemptTime <
+            std::chrono::seconds(3)) {
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
+        return false;
+    }
+    g_popupOverlayWgcLastStartAttemptTime = now;
+
+    if (g_unloading || widthPx <= 0 || heightPx <= 0) {
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
+        return false;
+    }
+
+    if (!UseOverlayPopupBackdropMaterial() || !g_popupBackdropOverlay ||
+        !g_expandedPopup) {
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
+        Wh_Log(L"Island: overlay WGC state start skipped material=%d overlay=%p popup=%p unloading=%d size=%dx%d",
+               UseOverlayPopupBackdropMaterial(),
+               g_popupBackdropOverlay,
+               g_expandedPopup,
+               g_unloading.load(),
+               widthPx,
+               heightPx);
+        return false;
+    }
+
+    HMONITOR monitor = MonitorFromRect(&captureRect, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO monitorInfo{sizeof(monitorInfo)};
+    if (!monitor || !GetMonitorInfoW(monitor, &monitorInfo)) {
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
+        Wh_Log(L"Island: overlay WGC state no monitor");
+        return false;
+    }
+
+    if (g_popupOverlayWgcRunning &&
+        g_popupOverlayWgcRenderTexture &&
+        g_popupOverlayWgcStagingTexture &&
+        g_popupOverlayWgcMonitor == monitor) {
+        // Keep the monitor capture session alive during the morph. Only the
+        // crop rectangle and layered-output size change frame to frame.
+        std::lock_guard lock(g_popupOverlayWgcMutex);
+        g_popupOverlayWgcCreateItemFailed = false;
+        if (!RecreatePopupOverlayWgcReadbackTextures(widthPx, heightPx)) {
+            g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::RenderFailed;
+            ++g_popupOverlayWgcRenderFailCount;
+            return false;
+        }
+        g_popupOverlayWgcCaptureRectPx = captureRect;
+        g_popupOverlayWgcMonitorRectPx = monitorInfo.rcMonitor;
+        return true;
+    }
+
+    StopPopupOverlayWgcBackdrop();
+
+    if (!capture::GraphicsCaptureSession::IsSupported()) {
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
+        Wh_Log(L"Island: overlay WGC state not supported");
+        return false;
+    }
+
+    if (!EnsurePopupOverlayWgcDeviceResources(g_popupBackdropOverlay,
+                                              widthPx,
+                                              heightPx)) {
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
+        Wh_Log(L"Island: overlay WGC state Ensure resources failed hr=0x%08X",
+               static_cast<unsigned>(g_popupOverlayWgcLastHr));
+        return false;
+    }
+
+    if (!CreatePopupOverlayWgcCaptureItemForMonitor(monitor,
+                                                    g_popupOverlayWgcItem)) {
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
+        g_popupOverlayWgcDiagnosticHr = g_popupOverlayWgcCreateItemHr;
+        g_popupOverlayWgcCreateItemFailed = true;
+        Wh_Log(L"Island: overlay WGC state Create capture item failed hr=0x%08X; throttling retries",
+               static_cast<unsigned>(g_popupOverlayWgcCreateItemHr));
+        return false;
+    }
+    g_popupOverlayWgcCreateItemFailed = false;
+
+    // Keep the existing blurred fallback visible until the first WGC frame is
+    // ready. Exclude the popup/overlay from capture first; then skip a few WGC
+    // frames to let DWM apply the exclusion before we replace the fallback.
+    SetWindowDisplayAffinity(g_expandedPopup, WDA_EXCLUDEFROMCAPTURE);
+    SetWindowDisplayAffinity(g_popupBackdropOverlay, WDA_EXCLUDEFROMCAPTURE);
+    DwmFlush();
+
+    std::lock_guard lock(g_popupOverlayWgcMutex);
+    g_popupOverlayWgcCaptureRectPx = captureRect;
+    g_popupOverlayWgcMonitorRectPx = monitorInfo.rcMonitor;
+    g_popupOverlayWgcMonitor = monitor;
+    g_popupOverlayWgcRunning = true;
+    g_popupOverlayWgcLastHr = S_OK;
+    g_popupOverlayWgcDiagnosticHr = S_OK;
+    g_popupOverlayWgcHadFrame = false;
+    g_popupOverlayWgcFrameCount = 0;
+    g_popupOverlayWgcRenderFailCount = 0;
+    g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartedNoFrame;
+    g_popupOverlayWgcDiagnosticStartTime = std::chrono::steady_clock::now();
+    g_popupOverlayWgcStartTime = g_popupOverlayWgcDiagnosticStartTime;
+    g_popupOverlayWgcHandoffStartTime = {};
+    g_popupOverlayWgcFramesToSkip = PopupBackdropInitialFrameSkip();
+
+    try {
+        g_popupOverlayWgcFramePool = capture::Direct3D11CaptureFramePool::CreateFreeThreaded(
+            g_popupOverlayWgcGraphicsDevice,
+            directx::DirectXPixelFormat::B8G8R8A8UIntNormalized,
+            2,
+            g_popupOverlayWgcItem.Size());
+        g_popupOverlayWgcFrameArrivedToken = g_popupOverlayWgcFramePool.FrameArrived(
+            [](capture::Direct3D11CaptureFramePool const& sender,
+               winrt::Windows::Foundation::IInspectable const&) {
+                std::lock_guard callbackLock(g_popupOverlayWgcMutex);
+                if (!g_popupOverlayWgcRunning) {
+                    return;
+                }
+                auto frame = sender.TryGetNextFrame();
+                RenderPopupOverlayWgcFrame(frame);
+            });
+        g_popupOverlayWgcFrameCallbackHooked = true;
+        g_popupOverlayWgcSession =
+            g_popupOverlayWgcFramePool.CreateCaptureSession(g_popupOverlayWgcItem);
+        try {
+            // Windows Graphics Capture shows a yellow border around monitor
+            // captures by default. On systems that support borderless capture
+            // and have permission, this disables it; otherwise Windows may
+            // ignore the request and still show the border.
+            g_popupOverlayWgcSession.IsBorderRequired(false);
+        } catch (...) {
+        }
+        try {
+            g_popupOverlayWgcSession.IsCursorCaptureEnabled(false);
+        } catch (...) {
+        }
+        g_popupOverlayWgcSession.StartCapture();
+        Wh_Log(L"Island: overlay WGC state backdrop started %dx%d monitor=(%ld,%ld,%ld,%ld)",
+               widthPx,
+               heightPx,
+               monitorInfo.rcMonitor.left,
+               monitorInfo.rcMonitor.top,
+               monitorInfo.rcMonitor.right,
+               monitorInfo.rcMonitor.bottom);
+        return true;
+    } catch (winrt::hresult_error const& error) {
+        g_popupOverlayWgcLastHr = error.code().value;
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
+        g_popupOverlayWgcDiagnosticHr = g_popupOverlayWgcLastHr;
+        Wh_Log(L"Island: overlay WGC state start failed hr=0x%08X",
+               static_cast<unsigned>(g_popupOverlayWgcLastHr));
+        g_popupOverlayWgcRunning = false;
+        return false;
+    } catch (...) {
+        g_popupOverlayWgcLastHr = E_FAIL;
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
+        g_popupOverlayWgcDiagnosticHr = E_FAIL;
+        Wh_Log(L"Island: overlay WGC state start failed unknown");
+        g_popupOverlayWgcRunning = false;
+        return false;
+    }
+}
+
+void UpdatePopupOverlayWgcCaptureRect(RECT const& captureRect) {
+    std::lock_guard lock(g_popupOverlayWgcMutex);
+    if (!g_popupOverlayWgcRunning) {
+        return;
+    }
+
+    int width = captureRect.right - captureRect.left;
+    int height = captureRect.bottom - captureRect.top;
+    if (width == g_popupOverlayWgcTargetWidthPx &&
+        height == g_popupOverlayWgcTargetHeightPx) {
+        g_popupOverlayWgcCaptureRectPx = captureRect;
+    }
+}
+#else
+void StopPopupOverlayWgcBackdrop() {}
+bool StartPopupOverlayWgcBackdrop(RECT const&, int, int) {
+    g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
+    g_popupOverlayWgcDiagnosticHr = E_NOTIMPL;
+    return false;
+}
+void UpdatePopupOverlayWgcCaptureRect(RECT const&) {}
+#endif
+
+BYTE PopupRoundedRectAlpha(int x, int y, int width, int height, int radius) {
+    if (width <= 0 || height <= 0) {
+        return 0;
+    }
+
+    radius = Clamp(radius, 1, std::max(1, std::min(width, height) / 2));
+    double px = static_cast<double>(x) + 0.5;
+    double py = static_cast<double>(y) + 0.5;
+    double left = 0.0;
+    double top = 0.0;
+    double right = static_cast<double>(width);
+    double bottom = static_cast<double>(height);
+    double r = static_cast<double>(radius);
+
+    double cx = Clamp(px, left + r, right - r);
+    double cy = Clamp(py, top + r, bottom - r);
+    double dx = px - cx;
+    double dy = py - cy;
+    double distance = std::sqrt(dx * dx + dy * dy);
+    double coverage = r - distance + 0.75;
+    coverage = Clamp(coverage, 0.0, 1.0);
+    return static_cast<BYTE>(std::lround(coverage * 255.0));
+}
+
+void BoxBlurPbgraPixels(std::vector<BYTE>& pixels, int width, int height, int passes) {
+    if (width <= 1 || height <= 1 || pixels.size() < static_cast<size_t>(width) * height * 4) {
+        return;
+    }
+
+    std::vector<BYTE> temp(pixels.size());
+    for (int pass = 0; pass < passes; ++pass) {
+        temp = pixels;
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                int sumB = 0, sumG = 0, sumR = 0, sumA = 0, count = 0;
+                for (int yy = std::max(0, y - 1); yy <= std::min(height - 1, y + 1); ++yy) {
+                    for (int xx = std::max(0, x - 1); xx <= std::min(width - 1, x + 1); ++xx) {
+                        BYTE* p = temp.data() + (static_cast<size_t>(yy) * width + xx) * 4;
+                        sumB += p[0];
+                        sumG += p[1];
+                        sumR += p[2];
+                        sumA += p[3];
+                        ++count;
+                    }
+                }
+                BYTE* out = pixels.data() + (static_cast<size_t>(y) * width + x) * 4;
+                out[0] = static_cast<BYTE>(sumB / count);
+                out[1] = static_cast<BYTE>(sumG / count);
+                out[2] = static_cast<BYTE>(sumR / count);
+                out[3] = static_cast<BYTE>(sumA / count);
+            }
+        }
+    }
+}
+
+void SetPopupWindowCaptureExclusion(HWND hwnd, bool exclude) {
+    if (!hwnd) {
+        return;
+    }
+
+#ifndef WDA_EXCLUDEFROMCAPTURE
+#define WDA_EXCLUDEFROMCAPTURE 0x00000011
+#endif
+#ifndef WDA_NONE
+#define WDA_NONE 0x00000000
+#endif
+
+    SetWindowDisplayAffinity(hwnd, exclude ? WDA_EXCLUDEFROMCAPTURE : WDA_NONE);
+}
+
+
+bool ClearPopupBackdropOverlayLayeredSurface(HWND hwnd) {
+    if (!hwnd) {
+        return false;
+    }
+
+    RECT rect{};
+    GetWindowRect(hwnd, &rect);
+    int width = std::max(1L, rect.right - rect.left);
+    int height = std::max(1L, rect.bottom - rect.top);
+
+    // Guard against invalid stale geometry during Explorer unload/reload.
+    width = Clamp(width, 1, 2048);
+    height = Clamp(height, 1, 2048);
+
+    HDC screenDc = GetDC(nullptr);
+    if (!screenDc) {
+        return false;
+    }
+    HDC memDc = CreateCompatibleDC(screenDc);
+    if (!memDc) {
+        ReleaseDC(nullptr, screenDc);
+        return false;
+    }
+
+    BITMAPINFO info{};
+    info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    info.bmiHeader.biWidth = width;
+    info.bmiHeader.biHeight = -height;
+    info.bmiHeader.biPlanes = 1;
+    info.bmiHeader.biBitCount = 32;
+    info.bmiHeader.biCompression = BI_RGB;
+
+    void* bits = nullptr;
+    HBITMAP bitmap = CreateDIBSection(screenDc, &info, DIB_RGB_COLORS,
+                                      &bits, nullptr, 0);
+    if (!bitmap || !bits) {
+        if (bitmap) {
+            DeleteObject(bitmap);
+        }
+        DeleteDC(memDc);
+        ReleaseDC(nullptr, screenDc);
+        return false;
+    }
+
+    std::memset(bits, 0, static_cast<size_t>(width) * height * 4);
+
+    HGDIOBJ oldBitmap = SelectObject(memDc, bitmap);
+    POINT srcPoint{0, 0};
+    SIZE size{width, height};
+    POINT dstPoint{rect.left, rect.top};
+    BLENDFUNCTION blend{AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
+
+    BOOL ok = UpdateLayeredWindow(hwnd, screenDc, &dstPoint, &size,
+                                  memDc, &srcPoint, 0, &blend, ULW_ALPHA);
+
+    SelectObject(memDc, oldBitmap);
+    DeleteObject(bitmap);
+    DeleteDC(memDc);
+    ReleaseDC(nullptr, screenDc);
+    return !!ok;
+}
+
+bool CaptureLowResScreenPixels(RECT const& screenRect,
+                               int lowWidth,
+                               int lowHeight,
+                               std::vector<BYTE>& pixels,
+                               HWND excludeOverlay = nullptr) {
+    if (lowWidth <= 0 || lowHeight <= 0 ||
+        screenRect.right <= screenRect.left ||
+        screenRect.bottom <= screenRect.top) {
+        return false;
+    }
+
+    pixels.assign(static_cast<size_t>(lowWidth) * lowHeight * 4, 0);
+
+    // Keep the overlay visible while sampling. Hiding/restoring the layered
+    // window here caused an obvious flash during the popup morph. Capture
+    // exclusion is still requested; if a build ignores it for GetDC(nullptr),
+    // WGC will take over after the final geometry is ready.
+    if (excludeOverlay) {
+        SetPopupWindowCaptureExclusion(excludeOverlay, true);
+    }
+    auto restoreExcludedOverlay = [&] {
+        if (excludeOverlay) {
+            // Keep the overlay excluded while a WGC session is active; otherwise
+            // restore normal visibility for plain GDI fallback mode.
+            SetPopupWindowCaptureExclusion(excludeOverlay,
+                                           g_popupOverlayWgcRunning);
+        }
+    };
+
+    HDC screenDc = GetDC(nullptr);
+    if (!screenDc) {
+        restoreExcludedOverlay();
+        return false;
+    }
+
+    HDC memDc = CreateCompatibleDC(screenDc);
+    if (!memDc) {
+        ReleaseDC(nullptr, screenDc);
+        restoreExcludedOverlay();
+        return false;
+    }
+
+    BITMAPINFO info{};
+    info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    info.bmiHeader.biWidth = lowWidth;
+    info.bmiHeader.biHeight = -lowHeight;
+    info.bmiHeader.biPlanes = 1;
+    info.bmiHeader.biBitCount = 32;
+    info.bmiHeader.biCompression = BI_RGB;
+
+    void* bits = nullptr;
+    HBITMAP bitmap = CreateDIBSection(screenDc, &info, DIB_RGB_COLORS, &bits, nullptr, 0);
+    if (!bitmap || !bits) {
+        if (bitmap) DeleteObject(bitmap);
+        DeleteDC(memDc);
+        ReleaseDC(nullptr, screenDc);
+        restoreExcludedOverlay();
+        return false;
+    }
+
+    HGDIOBJ oldBitmap = SelectObject(memDc, bitmap);
+    SetStretchBltMode(memDc, HALFTONE);
+    SetBrushOrgEx(memDc, 0, 0, nullptr);
+
+    int sourceWidth = screenRect.right - screenRect.left;
+    int sourceHeight = screenRect.bottom - screenRect.top;
+    BOOL ok = StretchBlt(memDc, 0, 0, lowWidth, lowHeight,
+                         screenDc, screenRect.left, screenRect.top,
+                         sourceWidth, sourceHeight, SRCCOPY);
+
+    if (ok) {
+        std::memcpy(pixels.data(), bits, pixels.size());
+    }
+
+    SelectObject(memDc, oldBitmap);
+    DeleteObject(bitmap);
+    DeleteDC(memDc);
+    ReleaseDC(nullptr, screenDc);
+    restoreExcludedOverlay();
+    return !!ok;
+}
+
+void SampleBilinearPbgra(std::vector<BYTE> const& pixels,
+                       int width,
+                       int height,
+                       double x,
+                       double y,
+                       int& b,
+                       int& g,
+                       int& r) {
+    if (width <= 0 || height <= 0 || pixels.empty()) {
+        b = g = r = 0;
+        return;
+    }
+
+    x = Clamp(x, 0.0, static_cast<double>(width - 1));
+    y = Clamp(y, 0.0, static_cast<double>(height - 1));
+    int x0 = Clamp(static_cast<int>(std::floor(x)), 0, width - 1);
+    int y0 = Clamp(static_cast<int>(std::floor(y)), 0, height - 1);
+    int x1 = Clamp(x0 + 1, 0, width - 1);
+    int y1 = Clamp(y0 + 1, 0, height - 1);
+    double fx = x - x0;
+    double fy = y - y0;
+
+    auto pixel = [&](int px, int py) -> BYTE const* {
+        return pixels.data() + (static_cast<size_t>(py) * width + px) * 4;
+    };
+
+    BYTE const* p00 = pixel(x0, y0);
+    BYTE const* p10 = pixel(x1, y0);
+    BYTE const* p01 = pixel(x0, y1);
+    BYTE const* p11 = pixel(x1, y1);
+
+    auto blend = [&](int channel) -> int {
+        double top = p00[channel] * (1.0 - fx) + p10[channel] * fx;
+        double bottom = p01[channel] * (1.0 - fx) + p11[channel] * fx;
+        return Clamp(static_cast<int>(std::lround(top * (1.0 - fy) + bottom * fy)), 0, 255);
+    };
+
+    b = blend(0);
+    g = blend(1);
+    r = blend(2);
+}
+
+bool UpdatePopupBackdropOverlayLayeredBlur(HWND hwnd,
+                                           RECT const& screenRect,
+                                           int width,
+                                           int height,
+                                           int cornerRadiusPx,
+                                           bool force) {
+    if (!hwnd || width <= 2 || height <= 2) {
+        return false;
+    }
+
+    auto now = std::chrono::steady_clock::now();
+    bool sizeChanged =
+        width != g_popupBackdropOverlayLastWidth ||
+        height != g_popupBackdropOverlayLastHeight ||
+        cornerRadiusPx != g_popupBackdropOverlayLastRadius;
+    if (!force && !sizeChanged &&
+        g_popupBackdropOverlayLastPaintTime.time_since_epoch().count() != 0) {
+        auto age = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       now - g_popupBackdropOverlayLastPaintTime)
+                       .count();
+        if (age < kPopupBackdropOverlayRefreshMs) {
+            return true;
+        }
+    }
+
+    int captureScale = PopupBackdropFallbackCaptureScale();
+    int lowWidth = Clamp(width / captureScale,
+                         40, kPopupBackdropOverlayMaxCaptureSize);
+    int lowHeight = Clamp(height / captureScale,
+                          40, kPopupBackdropOverlayMaxCaptureSize);
+    std::vector<BYTE> lowPixels;
+    if (!CaptureLowResScreenPixels(screenRect, lowWidth, lowHeight, lowPixels, hwnd)) {
+        return false;
+    }
+
+    BoxBlurPbgraPixels(lowPixels, lowWidth, lowHeight,
+                       PopupBackdropFallbackBlurPasses());
+
+    std::vector<BYTE> out(static_cast<size_t>(width) * height * 4);
+    bool dark = IsDarkModeApprox();
+    constexpr double kDarkDim = 0.94;
+    constexpr double kLightDim = 1.00;
+    double dim = dark ? kDarkDim : kLightDim;
+    BYTE maxAlpha = PopupBackdropOverlayMaxAlpha();
+
+    for (int y = 0; y < height; ++y) {
+        double sampleY = ((static_cast<double>(y) + 0.5) * lowHeight / height) - 0.5;
+        for (int x = 0; x < width; ++x) {
+            double sampleX = ((static_cast<double>(x) + 0.5) * lowWidth / width) - 0.5;
+            BYTE edgeAlpha = PopupRoundedRectAlpha(x, y, width, height, cornerRadiusPx);
+            BYTE a = static_cast<BYTE>((static_cast<int>(edgeAlpha) * maxAlpha) / 255);
+
+            int sb = 0;
+            int sg = 0;
+            int sr = 0;
+            SampleBilinearPbgra(lowPixels, lowWidth, lowHeight, sampleX, sampleY, sb, sg, sr);
+
+            int b = Clamp(static_cast<int>(std::lround(sb * dim)), 0, 255);
+            int g = Clamp(static_cast<int>(std::lround(sg * dim)), 0, 255);
+            int r = Clamp(static_cast<int>(std::lround(sr * dim)), 0, 255);
+
+            BYTE* dst = out.data() + (static_cast<size_t>(y) * width + x) * 4;
+            // UpdateLayeredWindow expects premultiplied BGRA for AC_SRC_ALPHA.
+            dst[0] = static_cast<BYTE>((b * a) / 255);
+            dst[1] = static_cast<BYTE>((g * a) / 255);
+            dst[2] = static_cast<BYTE>((r * a) / 255);
+            dst[3] = a;
+        }
+    }
+
+    {
+        std::lock_guard cacheLock(g_popupBackdropOverlayHandoffMutex);
+        g_popupBackdropOverlayFallbackPixels = out;
+        g_popupBackdropOverlayFallbackRect = screenRect;
+        g_popupBackdropOverlayFallbackWidth = width;
+        g_popupBackdropOverlayFallbackHeight = height;
+        g_popupBackdropOverlayFallbackRadius = cornerRadiusPx;
+        g_popupBackdropOverlayFallbackPixelsValid = true;
+    }
+
+    HDC screenDc = GetDC(nullptr);
+    if (!screenDc) {
+        return false;
+    }
+    HDC memDc = CreateCompatibleDC(screenDc);
+    if (!memDc) {
+        ReleaseDC(nullptr, screenDc);
+        return false;
+    }
+
+    BITMAPINFO info{};
+    info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    info.bmiHeader.biWidth = width;
+    info.bmiHeader.biHeight = -height;
+    info.bmiHeader.biPlanes = 1;
+    info.bmiHeader.biBitCount = 32;
+    info.bmiHeader.biCompression = BI_RGB;
+
+    void* bits = nullptr;
+    HBITMAP bitmap = CreateDIBSection(screenDc, &info, DIB_RGB_COLORS, &bits, nullptr, 0);
+    if (!bitmap || !bits) {
+        if (bitmap) DeleteObject(bitmap);
+        DeleteDC(memDc);
+        ReleaseDC(nullptr, screenDc);
+        return false;
+    }
+    std::memcpy(bits, out.data(), out.size());
+
+    HGDIOBJ oldBitmap = SelectObject(memDc, bitmap);
+    POINT srcPoint{0, 0};
+    SIZE size{width, height};
+    POINT dstPoint{screenRect.left, screenRect.top};
+    BLENDFUNCTION blend{AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
+
+    BOOL ok = UpdateLayeredWindow(hwnd, screenDc, &dstPoint, &size,
+                                  memDc, &srcPoint, 0, &blend, ULW_ALPHA);
+
+    SelectObject(memDc, oldBitmap);
+    DeleteObject(bitmap);
+    DeleteDC(memDc);
+    ReleaseDC(nullptr, screenDc);
+
+    if (ok) {
+        g_popupBackdropOverlayLastPaintTime = now;
+        g_popupBackdropOverlayLastWidth = width;
+        g_popupBackdropOverlayLastHeight = height;
+        g_popupBackdropOverlayLastRadius = cornerRadiusPx;
+    }
+    return !!ok;
+}
+
+void PaintPopupBackdropOverlay(HWND hwnd) {
+    PAINTSTRUCT paint{};
+    HDC dc = BeginPaint(hwnd, &paint);
+    if (dc) {
+        EndPaint(hwnd, &paint);
+    }
+}
+
+LRESULT CALLBACK PopupBackdropOverlayWndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {
+    switch (message) {
+        case WM_ERASEBKGND:
+            return 1;
+        case WM_NCHITTEST:
+            return HTTRANSPARENT;
+        case WM_TIMER:
+            if (wParam == kPopupBackdropOverlayTimerId) {
+                UpdatePopupBackdropOverlayWindow();
+                return 0;
+            }
+            break;
+        case WM_PAINT:
+            PaintPopupBackdropOverlay(hwnd);
+            return 0;
+        case WM_DESTROY:
+            KillTimer(hwnd, kPopupBackdropOverlayTimerId);
+            SetPopupWindowCaptureExclusion(hwnd, false);
+            if (g_popupBackdropOverlay == hwnd) {
+                g_popupBackdropOverlay = nullptr;
+            }
+            return 0;
+    }
+    return DefWindowProcW(hwnd, message, wParam, lParam);
+}
+
+bool RegisterPopupBackdropOverlayClass() {
+    if (g_popupBackdropOverlayClassRegistered) {
+        return true;
+    }
+    HINSTANCE moduleInstance = ModInstance();
+    if (!moduleInstance) {
+        return false;
+    }
+    WNDCLASSEXW windowClass{sizeof(windowClass)};
+    windowClass.lpfnWndProc = PopupBackdropOverlayWndProc;
+    windowClass.style = CS_HREDRAW | CS_VREDRAW;
+    windowClass.hInstance = moduleInstance;
+    windowClass.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+    windowClass.lpszClassName = kPopupBackdropOverlayClassName;
+    if (!RegisterClassExW(&windowClass)) {
+        Wh_Log(L"Island: failed to register popup backdrop overlay window class");
+        return false;
+    }
+    g_popupBackdropOverlayClassRegistered = true;
+    return true;
+}
+
+void UnregisterPopupBackdropOverlayClass() {
+    if (!g_popupBackdropOverlayClassRegistered) {
+        return;
+    }
+    HINSTANCE moduleInstance = ModInstance();
+    if (moduleInstance && UnregisterClassW(kPopupBackdropOverlayClassName, moduleInstance)) {
+        g_popupBackdropOverlayClassRegistered = false;
+    }
+}
+
+bool EnsurePopupBackdropOverlayWindow() {
+    if (!UseOverlayPopupBackdropMaterial()) {
+        return false;
+    }
+    if (g_popupBackdropOverlay) {
+        return true;
+    }
+    if (!RegisterPopupBackdropOverlayClass()) {
+        return false;
+    }
+    g_popupBackdropOverlay = CreateWindowExW(
+        WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_LAYERED,
+        kPopupBackdropOverlayClassName, L"",
+        WS_POPUP, 0, 0, 1, 1,
+        g_taskbarWnd, nullptr, ModInstance(), nullptr);
+    if (!g_popupBackdropOverlay) {
+        Wh_Log(L"Island: failed to create popup backdrop overlay window");
+        return false;
+    }
+    // Do not enable acrylic before the overlay has its final size and region.
+    // Some Windows builds cache the composition effect against the current
+    // rectangular window bounds, which can make later SetWindowRgn clipping
+    // ineffective for the blur material.
+    return true;
+}
+
+void ClearPopupBackdropOverlayDwmBlurRegion();
+
+void HidePopupBackdropOverlayWindow() {
+    if (g_popupBackdropOverlay) {
+        StopPopupOverlayWgcBackdrop();
+        SetPopupWindowCaptureExclusion(g_popupBackdropOverlay, false);
+        SetPopupBackdropOverlayNativeBlur(g_popupBackdropOverlay, false);
+        ClearPopupBackdropOverlayDwmBlurRegion();
+        ClearPopupBackdropOverlayLayeredSurface(g_popupBackdropOverlay);
+        SetWindowRgn(g_popupBackdropOverlay, nullptr, FALSE);
+        ShowWindow(g_popupBackdropOverlay, SW_HIDE);
+        g_popupBackdropOverlayLastPaintTime = {};
+        g_popupBackdropOverlayLastWidth = 0;
+        g_popupBackdropOverlayLastHeight = 0;
+        g_popupBackdropOverlayLastRadius = 0;
+        g_popupOverlayWgcFallbackPainted = false;
+        ClearPopupBackdropOverlayHandoffCache();
+        if (g_expandedPopup) {
+            SetPopupWindowCaptureExclusion(g_expandedPopup, false);
+        }
+    }
+}
+
+void DestroyPopupBackdropOverlayWindow() {
+    if (g_popupBackdropOverlay) {
+        StopPopupOverlayWgcBackdrop();
+        SetPopupWindowCaptureExclusion(g_popupBackdropOverlay, false);
+        SetPopupBackdropOverlayNativeBlur(g_popupBackdropOverlay, false);
+        ClearPopupBackdropOverlayDwmBlurRegion();
+        ClearPopupBackdropOverlayLayeredSurface(g_popupBackdropOverlay);
+        ClearPopupBackdropOverlayHandoffCache();
+        SetWindowRgn(g_popupBackdropOverlay, nullptr, FALSE);
+        DestroyWindow(g_popupBackdropOverlay);
+        g_popupBackdropOverlay = nullptr;
+    }
+}
+
+bool CalculatePopupBackdropOverlayRect(RECT& overlayRect, int& cornerRadiusPx) {
+    if (!g_expandedPopup) {
+        return false;
+    }
+
+    RECT popupScreenPx{};
+    GetWindowRect(g_expandedPopup, &popupScreenPx);
+    if (popupScreenPx.right <= popupScreenPx.left ||
+        popupScreenPx.bottom <= popupScreenPx.top) {
+        return false;
+    }
+
+    double dpiScale = PopupDpiScale(g_expandedPopup);
+    RECT sourceRect = PopupScreenRectToLocalDip(g_popupSourceRect,
+                                                popupScreenPx,
+                                                dpiScale);
+    RECT finalRect = PopupScreenRectToLocalDip(g_popupFinalRect,
+                                               popupScreenPx,
+                                               dpiScale);
+
+    RECT targetArt{};
+    RECT targetCard{};
+    RECT targetTitle{};
+    RECT targetArtist{};
+    RECT targetProgress{};
+    RECT targetElapsed{};
+    RECT targetDuration{};
+    RECT targetControls{};
+    CalculatePopupFinalLayout(finalRect, targetArt, targetCard,
+                              targetTitle, targetArtist,
+                              targetProgress, targetElapsed,
+                              targetDuration, targetControls);
+    RECT targetBackdrop = PopupBackdropRectFromParts(targetArt, targetCard);
+
+    double progress = PopupProgress();
+    // Once the popup is visually at the end of the morph, snap the native
+    // backdrop to the exact final XAML shell. This avoids a late 1-3 px WGC
+    // handoff offset caused by starting capture at progress≈0.985.
+    if (!g_popupClosing && progress >= 0.995) {
+        progress = 1.0;
+    }
+    RECT currentDip{
+        LerpInt(sourceRect.left, targetBackdrop.left, progress),
+        LerpInt(sourceRect.top, targetBackdrop.top, progress),
+        LerpInt(sourceRect.right, targetBackdrop.right, progress),
+        LerpInt(sourceRect.bottom, targetBackdrop.bottom, progress),
+    };
+
+    // Keep the overlay geometry exactly aligned to the XAML backdrop shell.
+    // The previous inset experiment helped hide hard native edges in some
+    // cases, but it made the blur layer visibly disagree with the component
+    // shape. For this test, prefer exact shape matching and remove all extra
+    // XAML tint/gray layers instead.
+    overlayRect = {
+        popupScreenPx.left + static_cast<LONG>(std::lround(currentDip.left * dpiScale)),
+        popupScreenPx.top + static_cast<LONG>(std::lround(currentDip.top * dpiScale)),
+        popupScreenPx.left + static_cast<LONG>(std::lround(currentDip.right * dpiScale)),
+        popupScreenPx.top + static_cast<LONG>(std::lround(currentDip.bottom * dpiScale)),
+    };
+
+    int width = overlayRect.right - overlayRect.left;
+    int height = overlayRect.bottom - overlayRect.top;
+    if (width <= 2 || height <= 2) {
+        return false;
+    }
+
+    double radiusDip = std::max(1.0, kPopupUnifiedCornerRadius + kPopupOverlayRadiusAdjustDip);
+    int desiredRadius = static_cast<int>(std::lround(radiusDip * dpiScale));
+    cornerRadiusPx = Clamp(desiredRadius, 1, std::max(1, std::min(width, height) / 2));
+    return true;
+}
+
+void ApplyPopupBackdropOverlayRegion(int width, int height, int cornerRadiusPx) {
+    if (!g_popupBackdropOverlay || width <= 0 || height <= 0) {
+        return;
+    }
+
+    HRGN region = CreateRoundRectRgn(0, 0, width + 1, height + 1,
+                                     cornerRadiusPx * 2, cornerRadiusPx * 2);
+    if (!region) {
+        return;
+    }
+
+    // SetWindowRgn takes ownership on success. If it fails, we must release it.
+    if (!SetWindowRgn(g_popupBackdropOverlay, region, FALSE)) {
+        DeleteObject(region);
+    }
+}
+
+void ApplyPopupBackdropOverlayDwmBlurRegion(int width, int height, int cornerRadiusPx) {
+    if (!g_popupBackdropOverlay || width <= 0 || height <= 0) {
+        return;
+    }
+
+    // Accent acrylic can ignore the HWND region on some builds unless DWM also
+    // receives an explicit blur-region hint. Use a separate region handle here:
+    // SetWindowRgn owns its region on success, while DwmEnableBlurBehindWindow
+    // does not document ownership transfer for hRgnBlur.
+    HRGN blurRegion = CreateRoundRectRgn(0, 0, width + 1, height + 1,
+                                         cornerRadiusPx * 2, cornerRadiusPx * 2);
+    if (!blurRegion) {
+        return;
+    }
+
+    DWM_BLURBEHIND blurBehind{};
+    blurBehind.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION;
+    blurBehind.fEnable = TRUE;
+    blurBehind.hRgnBlur = blurRegion;
+    DwmEnableBlurBehindWindow(g_popupBackdropOverlay, &blurBehind);
+    DeleteObject(blurRegion);
+}
+
+void ClearPopupBackdropOverlayDwmBlurRegion() {
+    if (!g_popupBackdropOverlay) {
+        return;
+    }
+
+    DWM_BLURBEHIND blurBehind{};
+    blurBehind.dwFlags = DWM_BB_ENABLE;
+    blurBehind.fEnable = FALSE;
+    DwmEnableBlurBehindWindow(g_popupBackdropOverlay, &blurBehind);
+}
+
+void UpdatePopupBackdropOverlayWindow() {
+    if (!UseOverlayPopupBackdropMaterial() || !g_expandedPopup || !g_expanded) {
+        HidePopupBackdropOverlayWindow();
+        return;
+    }
+    if (!EnsurePopupBackdropOverlayWindow()) {
+        return;
+    }
+
+    RECT overlayRect{};
+    int cornerRadiusPx = 1;
+    if (!CalculatePopupBackdropOverlayRect(overlayRect, cornerRadiusPx)) {
+        HidePopupBackdropOverlayWindow();
+        return;
+    }
+
+    int width = std::max(1L, overlayRect.right - overlayRect.left);
+    int height = std::max(1L, overlayRect.bottom - overlayRect.top);
+
+    // 0.9.58: real-time WGC/D3D producer. The overlay HWND is already known
+    // to be visible and clippable, so render a DXGI swap chain directly into it
+    // instead of using GDI screenshots + UpdateLayeredWindow.
+    SetWindowPos(g_popupBackdropOverlay, g_expandedPopup,
+                 overlayRect.left, overlayRect.top, width, height,
+                 SWP_NOACTIVATE | SWP_NOCOPYBITS |
+                     SWP_NOOWNERZORDER | SWP_NOSENDCHANGING | SWP_SHOWWINDOW);
+    ApplyPopupBackdropOverlayRegion(width, height, cornerRadiusPx);
+    g_popupBackdropOverlayLastWidth = width;
+    g_popupBackdropOverlayLastHeight = height;
+    g_popupBackdropOverlayLastRadius = cornerRadiusPx;
+    ShowWindow(g_popupBackdropOverlay, SW_SHOWNOACTIVATE);
+
+    double progress = PopupProgress();
+    bool finalGeometryReady = !g_popupClosing && progress >= 0.995;
+
+    if (!finalGeometryReady && g_popupClosing) {
+        // Closing still favors the stable fallback path; it avoids extra WGC
+        // churn while the popup is being torn down.
+        if (g_popupOverlayWgcRunning) {
+            StopPopupOverlayWgcBackdrop();
+        }
+        g_popupOverlayWgcFinalReadyTime = {};
+        UpdatePopupBackdropOverlayLayeredBlur(g_popupBackdropOverlay,
+                                              overlayRect,
+                                              width,
+                                              height,
+                                              cornerRadiusPx,
+                                              false);
+        g_popupOverlayWgcFallbackPainted = true;
+        return;
+    }
+
+    if (!finalGeometryReady) {
+        // While expanding, start WGC immediately and keep its crop/target size
+        // synced to the animated backdrop. A fallback frame stays underneath
+        // until the first live WGC readback arrives.
+        if (!g_popupOverlayWgcReadbackHadVisibleFrame) {
+            UpdatePopupBackdropOverlayLayeredBlur(g_popupBackdropOverlay,
+                                                  overlayRect,
+                                                  width,
+                                                  height,
+                                                  cornerRadiusPx,
+                                                  !g_popupOverlayWgcFallbackPainted);
+            g_popupOverlayWgcFallbackPainted = true;
+        }
+
+        bool startedWgc = StartPopupOverlayWgcBackdrop(overlayRect, width, height);
+        if (!startedWgc && !g_popupOverlayWgcFallbackPainted) {
+            UpdatePopupBackdropOverlayLayeredBlur(g_popupBackdropOverlay,
+                                                  overlayRect,
+                                                  width,
+                                                  height,
+                                                  cornerRadiusPx,
+                                                  true);
+            g_popupOverlayWgcFallbackPainted = true;
+        }
+        g_popupOverlayWgcFinalReadyTime = {};
+        return;
+    }
+
+    if (g_popupOverlayWgcDiagnosticState == PopupOverlayWgcDiagnosticState::NotStarted) {
+        g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
+    }
+
+    auto nowForFinalGeometry = std::chrono::steady_clock::now();
+    if (g_popupOverlayWgcFinalReadyTime.time_since_epoch().count() == 0) {
+        g_popupOverlayWgcFinalReadyTime = nowForFinalGeometry;
+    }
+
+    int handoffDelayMs = PopupBackdropHandoffDelayMs();
+    if (handoffDelayMs > 0 &&
+        !g_popupOverlayWgcRunning &&
+        !g_popupOverlayWgcReadbackHadVisibleFrame) {
+        double finalGeometryAgeMs =
+            std::chrono::duration<double, std::milli>(
+                nowForFinalGeometry - g_popupOverlayWgcFinalReadyTime)
+                .count();
+        if (finalGeometryAgeMs < handoffDelayMs) {
+            UpdatePopupBackdropOverlayLayeredBlur(g_popupBackdropOverlay,
+                                                  overlayRect,
+                                                  width,
+                                                  height,
+                                                  cornerRadiusPx,
+                                                  !g_popupOverlayWgcFallbackPainted);
+            g_popupOverlayWgcFallbackPainted = true;
+            return;
+        }
+    }
+
+    // Force one final-geometry fallback frame before WGC starts so the cached
+    // handoff frame has the same size/position as the WGC output. After that,
+    // start WGC immediately; otherwise the static fallback can remain visible
+    // and make the material look non-realtime.
+    bool needFinalFallback =
+        !g_popupOverlayWgcRunning &&
+        !g_popupOverlayWgcReadbackHadVisibleFrame &&
+        (!g_popupOverlayWgcFallbackPainted ||
+         g_popupBackdropOverlayFallbackWidth != width ||
+         g_popupBackdropOverlayFallbackHeight != height);
+    if (needFinalFallback) {
+        UpdatePopupBackdropOverlayLayeredBlur(g_popupBackdropOverlay,
+                                              overlayRect,
+                                              width,
+                                              height,
+                                              cornerRadiusPx,
+                                              true);
+        g_popupOverlayWgcFallbackPainted = true;
+    }
+
+    bool startedWgc = StartPopupOverlayWgcBackdrop(overlayRect, width, height);
+    if (!startedWgc && !g_popupOverlayWgcFallbackPainted) {
+        UpdatePopupBackdropOverlayLayeredBlur(g_popupBackdropOverlay,
+                                              overlayRect,
+                                              width,
+                                              height,
+                                              cornerRadiusPx,
+                                              true);
+        g_popupOverlayWgcFallbackPainted = true;
+    }
+}
+
 bool RegisterPopupWindowClass() {
     if (g_popupClassRegistered) {
         return true;
@@ -5795,6 +8108,7 @@ bool RegisterPopupWindowClass() {
 }
 
 void UnregisterPopupWindowClass() {
+    UnregisterPopupBackdropOverlayClass();
     if (!g_popupClassRegistered) {
         return;
     }
@@ -5864,10 +8178,14 @@ void ShowExpandedPopup() {
     }
     ApplyPopupBackdrop(g_expandedPopup);
     PositionExpandedPopup();
+    UpdatePopupBackdropOverlayWindow();
     RenderExpandedPopupLayer();
     SetCompactIslandSuppressed(true);
     ShowWindow(g_expandedPopup, SW_SHOW);
-    SetTimer(g_expandedPopup, kPopupTimerId, g_popupXamlRoot ? 80 : 15, nullptr);
+    // Re-apply after the popup becomes visible so the overlay is placed directly
+    // under the popup in the active top-level z-order.
+    UpdatePopupBackdropOverlayWindow();
+    SetTimer(g_expandedPopup, kPopupTimerId, g_popupXamlRoot ? 30 : 15, nullptr);
     if (g_popupXamlRoot) {
         StartPopupXamlRenderLoop();
     }
@@ -5875,6 +8193,7 @@ void ShowExpandedPopup() {
 
 void DestroyExpandedPopup() {
     StopPopupXamlRenderLoop();
+    DestroyPopupBackdropOverlayWindow();
     SetCompactIslandSuppressed(false);
     if (g_popupXamlSource) {
         try {
@@ -5909,6 +8228,10 @@ void DestroyExpandedPopup() {
     g_popupXamlArtTranslate = nullptr;
     g_popupXamlArtFade = nullptr;
     g_popupXamlArt = nullptr;
+    g_popupXamlTitleHost = nullptr;
+    g_popupXamlArtistHost = nullptr;
+    g_popupXamlOutgoingTitleHost = nullptr;
+    g_popupXamlOutgoingArtistHost = nullptr;
     g_popupXamlTitle = nullptr;
     g_popupXamlArtist = nullptr;
     g_popupXamlOutgoingTitle = nullptr;
@@ -6160,7 +8483,15 @@ void StartExpandRenderLoop(bool expanded) {
 bool InjectIslandGrid();
 
 void MediaThreadProc() {
-    winrt::init_apartment(winrt::apartment_type::multi_threaded);
+    bool apartmentInitialized = false;
+    try {
+        winrt::init_apartment(winrt::apartment_type::multi_threaded);
+        apartmentInitialized = true;
+    } catch (...) {
+        Wh_Log(L"Island: failed to initialize media thread apartment");
+        g_mediaThreadRunning = false;
+        return;
+    }
 
     struct SessionEventSubscription {
         gsm::GlobalSystemMediaTransportControlsSession session{nullptr};
@@ -6250,8 +8581,7 @@ void MediaThreadProc() {
     };
 
     try {
-        manager =
-            gsm::GlobalSystemMediaTransportControlsSessionManager::RequestAsync().get();
+        manager = RequestMediaManagerWithTimeout(std::chrono::seconds(3));
         if (manager) {
             sessionsChangedToken = manager.SessionsChanged(
                 [&](auto const&, auto const&) {
@@ -6311,10 +8641,13 @@ void MediaThreadProc() {
             if (!hwnd || !IsWindow(hwnd)) {
                 hwnd = FindCurrentProcessTaskbarWnd();
             }
-            if (hwnd) {
+            if (IsModActive() && hwnd) {
                 RunFromWindowThread(
                     hwnd,
                     [](void* param) {
+                        if (!IsModActive()) {
+                            return;
+                        }
                         HWND taskbarWnd = reinterpret_cast<HWND>(param);
                         if (!g_playerGrid) {
                             g_taskbarWnd = taskbarWnd;
@@ -6344,23 +8677,41 @@ void MediaThreadProc() {
     } catch (...) {
     }
 
-    winrt::uninit_apartment();
+    // Release the GSMTC manager before tearing down the WinRT apartment. Keeping
+    // the WinRT/COM object alive across winrt::uninit_apartment() can leave its
+    // final Release() running after the COM apartment has already been torn down,
+    // which is risky when the mod is unloaded inside explorer.exe.
+    manager = nullptr;
+
+    if (apartmentInitialized) {
+        winrt::uninit_apartment();
+    }
 }
 
 void StartMediaThread() {
-    if (g_mediaThreadRunning) {
+    if (g_mediaThreadRunning.exchange(true)) {
         return;
     }
-    g_mediaThreadRunning = true;
-    g_mediaThread = new std::thread(MediaThreadProc);
+    try {
+        g_mediaThread = new std::thread(MediaThreadProc);
+    } catch (...) {
+        g_mediaThreadRunning = false;
+        g_mediaThread = nullptr;
+        Wh_Log(L"Island: failed to start media thread");
+    }
 }
 
 void StopMediaThread() {
     g_mediaThreadRunning = false;
+    g_mediaRefreshRequested = false;
     g_mediaCommandCv.notify_all();
     if (g_mediaThread) {
         if (g_mediaThread->joinable()) {
-            g_mediaThread->join();
+            if (g_mediaThread->get_id() != std::this_thread::get_id()) {
+                g_mediaThread->join();
+            } else {
+                g_mediaThread->detach();
+            }
         }
         delete g_mediaThread;
         g_mediaThread = nullptr;
@@ -6393,7 +8744,10 @@ Button MakeMediaButton(const wchar_t* name, const wchar_t* glyph, void (*onClick
     button.Background(Brush(Color(0x18, 0xFF, 0xFF, 0xFF)));
     button.BorderBrush(Brush(Color(0x20, 0xFF, 0xFF, 0xFF)));
     button.BorderThickness({1, 1, 1, 1});
-    button.CornerRadius({14, 14, 14, 14});
+    button.CornerRadius({kPopupG2ButtonCornerRadius,
+                         kPopupG2ButtonCornerRadius,
+                         kPopupG2ButtonCornerRadius,
+                         kPopupG2ButtonCornerRadius});
 
     TextBlock icon = MakeTextBlock(L"", 13, true);
     icon.FontFamily(mediax::FontFamily(L"Segoe Fluent Icons"));
@@ -7250,10 +9604,14 @@ void UpdatePlayerContents() {
 
                     if (visualThumbnailBytes.empty()) {
                         auto placeholderArtBytes = CreatePlaceholderAlbumCoverBytes(128);
+                        auto placeholderG2ArtBytes = CreatePopupG2AlbumCoverBytes(placeholderArtBytes);
                         auto placeholderPanelBytes = CreatePlaceholderAlbumCoverBytes(20);
                         auto placeholderBackdropBytes = CreatePlaceholderAlbumCoverBytes(20, true);
-                        if (!placeholderArtBytes.empty()) {
-                            g_popupXamlArt.Source(makeBitmap(placeholderArtBytes));
+                        auto const& popupArtBytes = placeholderG2ArtBytes.empty()
+                                                        ? placeholderArtBytes
+                                                        : placeholderG2ArtBytes;
+                        if (!popupArtBytes.empty()) {
+                            g_popupXamlArt.Source(makeBitmap(popupArtBytes));
                         } else {
                             g_popupXamlArt.Source(nullptr);
                         }
@@ -7272,7 +9630,9 @@ void UpdatePlayerContents() {
                             }
                         }
                     } else {
-                        g_popupXamlArt.Source(makeBitmap(displayThumbnailBytes));
+                        auto popupArtBytes = CreatePopupG2AlbumCoverBytes(displayThumbnailBytes);
+                        g_popupXamlArt.Source(makeBitmap(
+                            popupArtBytes.empty() ? displayThumbnailBytes : popupArtBytes));
                         if (g_popupXamlBackdropCover) {
                             if (useBackdropCover) {
                                 auto lowDetailBackdropBytes =
@@ -7564,24 +9924,32 @@ void ApplyPendingSettings() {
     g_popupXamlThemeButtonStyle.clear();
 }
 
+void ApplyPendingSettingsAndInject() {
+    if (!IsModActive()) {
+        return;
+    }
+    ApplyPendingSettings();
+    InjectIslandGrid();
+}
+
 void ApplySettingsOnTaskbarThread() {
+    if (!IsModActive()) {
+        return;
+    }
     if (!g_taskbarWnd || !IsWindow(g_taskbarWnd)) {
         g_taskbarWnd = FindCurrentProcessTaskbarWnd();
     }
     if (g_taskbarWnd) {
         RunFromWindowThread(
             g_taskbarWnd,
-            [](void*) {
-                ApplyPendingSettings();
-                InjectIslandGrid();
-            },
+            [](void*) { ApplyPendingSettingsAndInject(); },
             nullptr);
     }
 }
 
 void WINAPI TrayUI_StartTaskbar_Hook(void* pThis) {
     TrayUI_StartTaskbar_Original(pThis);
-    if (g_unloading) {
+    if (!IsModActive()) {
         return;
     }
 
@@ -7589,10 +9957,7 @@ void WINAPI TrayUI_StartTaskbar_Hook(void* pThis) {
     if (g_taskbarWnd) {
         RunFromWindowThread(
             g_taskbarWnd,
-            [](void*) {
-                ApplyPendingSettings();
-                InjectIslandGrid();
-            },
+            [](void*) { ApplyPendingSettingsAndInject(); },
             nullptr);
     }
 }
@@ -7626,6 +9991,8 @@ bool HookTaskbarSymbols() {
 BOOL Wh_ModInit() {
     Wh_Log(L"Island: init");
     g_unloading = false;
+    g_modActive = false;
+    g_mediaRefreshRequested = false;
     g_settings = ReadSettings();
 
     if (!HookTaskbarSymbols()) {
@@ -7637,14 +10004,21 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModAfterInit() {
+    if (g_unloading) {
+        return;
+    }
+    g_modActive = true;
     g_taskbarWnd = FindCurrentProcessTaskbarWnd();
-    StartMediaThread();
     ApplySettingsOnTaskbarThread();
+    StartMediaThread();
     RequestMediaRefresh();
 }
 
 void Wh_ModUninit() {
-    g_unloading = true;
+    if (g_unloading.exchange(true)) {
+        return;
+    }
+    g_modActive = false;
     StopMediaThread();
 
     HWND hwnd = g_taskbarWnd && IsWindow(g_taskbarWnd)
@@ -7660,6 +10034,9 @@ void Wh_ModUninit() {
 }
 
 void Wh_ModSettingsChanged() {
+    if (!IsModActive()) {
+        return;
+    }
     Settings settings = ReadSettings();
     {
         std::lock_guard lock(g_pendingSettingsMutex);

--- a/mods/island-media-controls.wh.cpp
+++ b/mods/island-media-controls.wh.cpp
@@ -2,7 +2,7 @@
 // @id              island-media-controls
 // @name            Island Media Controls
 // @description     Dynamic island-like media controls for the Windows 11 taskbar.
-// @version         0.9.88
+// @version         0.9.136
 // @author          usho
 // @github          https://github.com/usho-lear
 // @license         MIT
@@ -112,6 +112,7 @@ it fits naturally alongside your taskbar and system tray items.
     - "mica_like": "Mica-like content layer"
     - "solid": "Solid"
     - "acrylic": "Acrylic / glass"
+    - "liquid_glass": "Liquid glass"
   - BackdropHandoffDelayMs: 0
     $name: Backdrop handoff delay (ms)
     $description: Wait after the popup reaches its final shape before switching from fallback blur to live WGC blur.
@@ -142,8 +143,6 @@ it fits naturally alongside your taskbar and system tray items.
 #include <wincodec.h>
 #include <windows.ui.xaml.hosting.desktopwindowxamlsource.h>
 
-#if __has_include(<winrt/Windows.Graphics.Capture.h>) && \
-    __has_include(<winrt/Windows.Graphics.DirectX.Direct3D11.h>)
 #define IMC_WGC_OVERLAY_AVAILABLE 1
 #include <inspectable.h>
 #include <d3d11.h>
@@ -190,9 +189,6 @@ struct IDirect3DDxgiInterfaceAccess : ::IUnknown {
 extern "C" HRESULT __stdcall CreateDirect3D11DeviceFromDXGIDevice(
     IDXGIDevice* dxgiDevice,
     IInspectable** graphicsDevice);
-#else
-#define IMC_WGC_OVERLAY_AVAILABLE 0
-#endif
 
 #include <windhawk_utils.h>
 
@@ -224,6 +220,7 @@ extern "C" HRESULT __stdcall CreateDirect3D11DeviceFromDXGIDevice(
 #include <functional>
 #include <atomic>
 #include <chrono>
+#include <cwctype>
 #include <cstdint>
 #include <cstring>
 #include <cmath>
@@ -375,6 +372,7 @@ std::atomic_bool g_unloading = false;
 std::atomic_bool g_modActive = false;
 std::atomic_bool g_mediaThreadRunning = false;
 std::thread* g_mediaThread = nullptr;
+std::atomic_bool g_mediaThreadExited = true;
 std::mutex g_mediaCommandMutex;
 std::condition_variable g_mediaCommandCv;
 std::deque<MediaCommand> g_mediaCommands;
@@ -382,6 +380,49 @@ std::atomic_bool g_mediaRefreshRequested = true;
 
 bool IsModActive() {
     return g_modActive.load() && !g_unloading.load();
+}
+
+constexpr auto kMediaPropertiesAsyncTimeout = std::chrono::milliseconds(1500);
+constexpr auto kThumbnailAsyncTimeout = std::chrono::milliseconds(900);
+constexpr auto kMediaCommandAsyncTimeout = std::chrono::milliseconds(1500);
+constexpr auto kUiLocalAsyncTimeout = std::chrono::milliseconds(500);
+constexpr auto kMediaThreadStopTimeout = std::chrono::milliseconds(5000);
+
+template <typename AsyncOperation>
+bool WaitForAsyncWithTimeout(AsyncOperation const& operation,
+                             std::chrono::milliseconds timeout,
+                             const wchar_t* label) {
+    if (!operation) {
+        return false;
+    }
+
+    auto status = operation.wait_for(timeout);
+    if (status == winrt::Windows::Foundation::AsyncStatus::Completed) {
+        return true;
+    }
+
+    try {
+        operation.Cancel();
+    } catch (...) {
+    }
+
+    Wh_Log(L"Island: async operation timed out label=%s status=%d timeoutMs=%lld",
+           label ? label : L"(unknown)",
+           static_cast<int>(status),
+           static_cast<long long>(timeout.count()));
+    return false;
+}
+
+template <typename AsyncOperation>
+auto GetAsyncResultWithTimeout(AsyncOperation const& operation,
+                               std::chrono::milliseconds timeout,
+                               const wchar_t* label)
+    -> decltype(operation.GetResults()) {
+    if (!WaitForAsyncWithTimeout(operation, timeout, label)) {
+        throw winrt::hresult_error(HRESULT_FROM_WIN32(ERROR_TIMEOUT));
+    }
+
+    return operation.GetResults();
 }
 
 HWND g_taskbarWnd = nullptr;
@@ -404,6 +445,10 @@ std::wstring g_popupXamlThemeMaterial;
 std::wstring g_popupXamlThemeButtonStyle;
 int g_popupXamlThemeShadowDepth = -1;
 int g_popupXamlThemeShadowOpacity = -1;
+bool g_popupTextForegroundValid = false;
+bool g_popupTextForegroundEdgeFade = false;
+bool g_popupTextForegroundDark = false;
+double g_popupTextForegroundEdgeFadeAmount = -1.0;
 HWND g_expandedPopup = nullptr;
 bool g_popupClassRegistered = false;
 HWND g_popupBackdropOverlay = nullptr;
@@ -412,6 +457,9 @@ std::chrono::steady_clock::time_point g_popupBackdropOverlayLastPaintTime{};
 int g_popupBackdropOverlayLastWidth = 0;
 int g_popupBackdropOverlayLastHeight = 0;
 int g_popupBackdropOverlayLastRadius = 0;
+RECT g_popupLiquidGlassPanelRectPx{};
+int g_popupLiquidGlassPanelRadiusPx = 0;
+bool g_popupLiquidGlassPanelRectValid = false;
 bool g_popupOverlayWgcReadbackHadVisibleFrame = false;
 std::chrono::steady_clock::time_point g_popupOverlayWgcReadbackDiagnosticTime{};
 enum class PopupOverlayWgcDiagnosticState {
@@ -478,6 +526,10 @@ winrt::com_ptr<ID3D11Texture2D> g_popupOverlayWgcStagingTexture;
 winrt::com_ptr<ID2D1Factory1> g_popupOverlayWgcD2dFactory;
 winrt::com_ptr<ID2D1Device> g_popupOverlayWgcD2dDevice;
 winrt::com_ptr<ID2D1DeviceContext> g_popupOverlayWgcD2dContext;
+winrt::com_ptr<ID2D1Bitmap1> g_popupOverlayWgcLensDisplacementMap;
+int g_popupOverlayWgcLensMapWidth = 0;
+int g_popupOverlayWgcLensMapHeight = 0;
+int g_popupOverlayWgcLensMapRadius = 0;
 
 direct3d11::IDirect3DDevice g_popupOverlayWgcGraphicsDevice{nullptr};
 capture::GraphicsCaptureItem g_popupOverlayWgcItem{nullptr};
@@ -500,6 +552,8 @@ TranslateTransform g_popupXamlBackdropTranslate = nullptr;
 Image g_popupXamlBackdropCoverFade = nullptr;
 Image g_popupXamlBackdropCover = nullptr;
 Border g_popupXamlBackdropTint = nullptr;
+Border g_popupXamlBackdropSurfaceHighlight = nullptr;
+Border g_popupXamlBackdropRimHighlight = nullptr;
 Border g_popupXamlPanelCoverFrame = nullptr;
 ScaleTransform g_popupXamlPanelCoverScale = nullptr;
 TranslateTransform g_popupXamlPanelCoverTranslate = nullptr;
@@ -517,6 +571,14 @@ FrameworkElement g_popupXamlTitleHost = nullptr;
 FrameworkElement g_popupXamlArtistHost = nullptr;
 FrameworkElement g_popupXamlOutgoingTitleHost = nullptr;
 FrameworkElement g_popupXamlOutgoingArtistHost = nullptr;
+Border g_popupXamlTitleLeftFade = nullptr;
+Border g_popupXamlTitleRightFade = nullptr;
+Border g_popupXamlArtistLeftFade = nullptr;
+Border g_popupXamlArtistRightFade = nullptr;
+Border g_popupXamlOutgoingTitleLeftFade = nullptr;
+Border g_popupXamlOutgoingTitleRightFade = nullptr;
+Border g_popupXamlOutgoingArtistLeftFade = nullptr;
+Border g_popupXamlOutgoingArtistRightFade = nullptr;
 TextBlock g_popupXamlTitle = nullptr;
 TextBlock g_popupXamlArtist = nullptr;
 TextBlock g_popupXamlOutgoingTitle = nullptr;
@@ -527,6 +589,9 @@ TranslateTransform g_popupXamlOutgoingTitleTranslate = nullptr;
 TranslateTransform g_popupXamlOutgoingArtistTranslate = nullptr;
 double g_popupTextBaseOpacity = 1.0;
 bool g_popupTextTransitionActive = false;
+int g_popupTextTransitionDirection = 1;
+int g_pendingMediaNavigationDirection = 0;
+std::chrono::steady_clock::time_point g_pendingMediaNavigationTime{};
 TextBlock g_popupXamlElapsed = nullptr;
 TextBlock g_popupXamlDuration = nullptr;
 ProgressBar g_popupXamlProgress = nullptr;
@@ -540,7 +605,6 @@ std::vector<Border> g_popupXamlProgressGlowLayers;
 std::vector<Border> g_popupXamlProgressCoreBlurLayers;
 Border g_popupXamlProgressGlowCore = nullptr;
 controls::Canvas g_popupXamlControls = nullptr;
-ScaleTransform g_popupXamlControlsScale = nullptr;
 uint64_t g_popupXamlThumbnailHash = UINT64_MAX;
 bool g_popupXamlBackdropCoverEnabled = false;
 uint64_t g_popupAccentThumbnailHash = UINT64_MAX;
@@ -851,11 +915,24 @@ bool IsDarkModeApprox() {
     return value == 0;
 }
 
+bool IsLiquidGlassMaterial() {
+    return g_settings.material == L"liquid_glass";
+}
+
+bool IsBlurredGlassMaterial() {
+    return g_settings.material == L"acrylic" || IsLiquidGlassMaterial();
+}
+
 winrt::Windows::UI::Color IslandBackgroundColor() {
     bool dark = IsDarkModeApprox();
     if (g_settings.material == L"mica_like") {
         return dark ? Color(0xC8, 0x2A, 0x2A, 0x2F)
                     : Color(0xD4, 0xF3, 0xF3, 0xF6);
+    }
+
+    if (IsLiquidGlassMaterial()) {
+        return dark ? Color(0xC8, 0x18, 0x1A, 0x20)
+                    : Color(0xDE, 0xFB, 0xFC, 0xFF);
     }
 
     if (g_settings.material == L"acrylic") {
@@ -875,10 +952,105 @@ mediax::Brush IslandBackgroundBrush() {
     return Brush(IslandBackgroundColor());
 }
 
+mediax::Brush LiquidGlassRimHighlightBrush() {
+    bool dark = IsDarkModeApprox();
+    mediax::LinearGradientBrush brush;
+    brush.StartPoint({0.0f, 0.0f});
+    brush.EndPoint({0.0f, 1.0f});
+    mediax::GradientStopCollection stops;
+
+    auto addStop = [&](double offset, winrt::Windows::UI::Color const& color) {
+        mediax::GradientStop stop;
+        stop.Offset(offset);
+        stop.Color(color);
+        stops.Append(stop);
+    };
+
+    addStop(0.00, dark ? Color(0xB8, 0xFF, 0xFF, 0xFF)
+                       : Color(0xD0, 0xFF, 0xFF, 0xFF));
+    addStop(0.12, dark ? Color(0x70, 0xFF, 0xFF, 0xFF)
+                       : Color(0x90, 0xFF, 0xFF, 0xFF));
+    addStop(0.42, dark ? Color(0x1C, 0xFF, 0xFF, 0xFF)
+                       : Color(0x28, 0xFF, 0xFF, 0xFF));
+    addStop(0.64, dark ? Color(0x24, 0xFF, 0xFF, 0xFF)
+                       : Color(0x36, 0xFF, 0xFF, 0xFF));
+    addStop(0.88, dark ? Color(0x7A, 0xFF, 0xFF, 0xFF)
+                       : Color(0x98, 0xFF, 0xFF, 0xFF));
+    addStop(1.00, dark ? Color(0xAE, 0xFF, 0xFF, 0xFF)
+                       : Color(0xC6, 0xFF, 0xFF, 0xFF));
+    brush.GradientStops(stops);
+    return brush;
+}
+
+mediax::Brush LiquidGlassSurfaceHighlightBrush() {
+    bool dark = IsDarkModeApprox();
+    mediax::LinearGradientBrush brush;
+    brush.StartPoint({0.08f, 0.0f});
+    brush.EndPoint({0.72f, 0.92f});
+    mediax::GradientStopCollection stops;
+
+    auto addStop = [&](double offset, winrt::Windows::UI::Color const& color) {
+        mediax::GradientStop stop;
+        stop.Offset(offset);
+        stop.Color(color);
+        stops.Append(stop);
+    };
+
+    addStop(0.00, dark ? Color(0x26, 0xFF, 0xFF, 0xFF)
+                       : Color(0x70, 0xFF, 0xFF, 0xFF));
+    addStop(0.16, dark ? Color(0x14, 0xFF, 0xFF, 0xFF)
+                       : Color(0x44, 0xFF, 0xFF, 0xFF));
+    addStop(0.48, Color(0x00, 0xFF, 0xFF, 0xFF));
+    addStop(0.76, Color(0x00, 0xFF, 0xFF, 0xFF));
+    addStop(1.00, dark ? Color(0x10, 0xFF, 0xFF, 0xFF)
+                       : Color(0x32, 0xFF, 0xFF, 0xFF));
+    brush.GradientStops(stops);
+    return brush;
+}
+
 mediax::Brush IslandBorderBrush() {
     bool dark = IsDarkModeApprox();
+    if (IsLiquidGlassMaterial()) {
+        return LiquidGlassRimHighlightBrush();
+    }
+
     return Brush(dark ? Color(0x36, 0xFF, 0xFF, 0xFF)
                       : Color(0x26, 0x00, 0x00, 0x00));
+}
+
+mediax::Brush CompactPlaybackControlStrokeBrush() {
+    if (IsLiquidGlassMaterial()) {
+        return LiquidGlassRimHighlightBrush();
+    }
+
+    bool dark = IsDarkModeApprox();
+    return Brush(dark ? Color(0x20, 0xFF, 0xFF, 0xFF)
+                      : Color(0x16, 0x00, 0x00, 0x00));
+}
+
+void ConfigureCompactAlbumArtStroke(Border const& stroke) {
+    if (!stroke) {
+        return;
+    }
+
+    // The stroke sits in Island_ArtShell, outside the clipped image host.
+    // Keep it exactly aligned with the artwork bounds; otherwise the border
+    // looks like it has drifted inward relative to the cover.
+    double size = std::max(1.0, g_layout.artSize);
+    double radius = std::max(1.0, g_layout.artCornerRadius);
+
+    stroke.Width(size);
+    stroke.Height(size);
+    stroke.Margin({0, 0, 0, 0});
+    stroke.HorizontalAlignment(HorizontalAlignment::Center);
+    stroke.VerticalAlignment(VerticalAlignment::Center);
+    stroke.CornerRadius({radius, radius, radius, radius});
+    stroke.Background(Brush(Color(0x00, 0x00, 0x00, 0x00)));
+    stroke.BorderThickness(IsLiquidGlassMaterial()
+                               ? Thickness{1.15, 1.15, 1.15, 1.15}
+                               : Thickness{1.0, 1.0, 1.0, 1.0});
+    stroke.BorderBrush(CompactPlaybackControlStrokeBrush());
+    stroke.IsHitTestVisible(false);
 }
 
 std::vector<uint8_t> ReadThumbnailBytes(streams::IRandomAccessStreamReference const& thumbnail) {
@@ -888,16 +1060,21 @@ std::vector<uint8_t> ReadThumbnailBytes(streams::IRandomAccessStreamReference co
     }
 
     try {
-        auto stream = thumbnail.OpenReadAsync().get();
+        auto stream = GetAsyncResultWithTimeout(
+            thumbnail.OpenReadAsync(),
+            kThumbnailAsyncTimeout,
+            L"thumbnail OpenReadAsync");
         uint64_t size64 = stream.Size();
         if (size64 == 0 || size64 > 8 * 1024 * 1024) {
             return bytes;
         }
 
         uint32_t size = static_cast<uint32_t>(size64);
-        auto buffer = stream.ReadAsync(streams::Buffer(size), size,
-                                       streams::InputStreamOptions::None)
-                          .get();
+        auto buffer = GetAsyncResultWithTimeout(
+            stream.ReadAsync(streams::Buffer(size), size,
+                             streams::InputStreamOptions::None),
+            kThumbnailAsyncTimeout,
+            L"thumbnail ReadAsync");
         streams::DataReader reader = streams::DataReader::FromBuffer(buffer);
         bytes.resize(buffer.Length());
         if (!bytes.empty()) {
@@ -982,7 +1159,8 @@ Settings ReadSettings() {
     settings.material = GetStringSetting(L"Main.Material", L"acrylic");
     if (settings.material != L"mica_like" &&
         settings.material != L"solid" &&
-        settings.material != L"acrylic") {
+        settings.material != L"acrylic" &&
+        settings.material != L"liquid_glass") {
         settings.material = L"acrylic";
     }
     ApplySettingsMigrations(&settings);
@@ -1233,16 +1411,52 @@ std::wstring MediaIdentityKey(MediaState const& state) {
            std::to_wstring(state.durationTicks);
 }
 
+bool LooksLikeNativeMusicMediaSource(std::wstring const& source) {
+    std::wstring lower;
+    lower.reserve(source.size());
+    for (wchar_t ch : source) {
+        lower.push_back(static_cast<wchar_t>(std::towlower(ch)));
+    }
+
+    // Explicitly keep native music players out of the browser/live-thumbnail
+    // path. Some providers use AppUserModelIds that contain generic substrings
+    // which can otherwise be over-matched by the browser heuristics below.
+    return lower.find(L"qqmusic") != std::wstring::npos ||
+           lower.find(L"qq音乐") != std::wstring::npos ||
+           lower.find(L"tencent.qqmusic") != std::wstring::npos ||
+           lower.find(L"tencentmusic") != std::wstring::npos ||
+           lower.find(L"spotify") != std::wstring::npos ||
+           lower.find(L"applemusic") != std::wstring::npos ||
+           lower.find(L"music.ui") != std::wstring::npos ||
+           lower.find(L"zunemusic") != std::wstring::npos;
+}
+
 bool LooksLikeBrowserMediaSource(std::wstring const& source) {
-    return source.find(L"Chrome") != std::wstring::npos ||
-           source.find(L"MSEdge") != std::wstring::npos ||
-           source.find(L"MicrosoftEdge") != std::wstring::npos ||
-           source.find(L"Firefox") != std::wstring::npos ||
-           source.find(L"Brave") != std::wstring::npos ||
-           source.find(L"Opera") != std::wstring::npos ||
-           source.find(L"Vivaldi") != std::wstring::npos ||
-           source.find(L"Arc") != std::wstring::npos ||
-           source.find(L"Browser") != std::wstring::npos;
+    std::wstring lower;
+    lower.reserve(source.size());
+    for (wchar_t ch : source) {
+        lower.push_back(static_cast<wchar_t>(std::towlower(ch)));
+    }
+
+    if (LooksLikeNativeMusicMediaSource(source)) {
+        return false;
+    }
+
+    return lower.find(L"chrome") != std::wstring::npos ||
+           lower.find(L"chromium") != std::wstring::npos ||
+           lower.find(L"msedge") != std::wstring::npos ||
+           lower.find(L"microsoftedge") != std::wstring::npos ||
+           lower.find(L"firefox") != std::wstring::npos ||
+           lower.find(L"brave") != std::wstring::npos ||
+           lower.find(L"opera") != std::wstring::npos ||
+           lower.find(L"vivaldi") != std::wstring::npos ||
+           lower.find(L"arc") != std::wstring::npos ||
+           lower.find(L"browser") != std::wstring::npos ||
+           lower.find(L"zen") != std::wstring::npos ||
+           lower.find(L"floorp") != std::wstring::npos ||
+           lower.find(L"librewolf") != std::wstring::npos ||
+           lower.find(L"yandex") != std::wstring::npos ||
+           lower.find(L"safari") != std::wstring::npos;
 }
 
 std::wstring MediaContentKey(MediaState const& state) {
@@ -1446,7 +1660,10 @@ void RefreshMediaState(
                 state.canSeek = false;
             }
 
-            auto props = session.TryGetMediaPropertiesAsync().get();
+            auto props = GetAsyncResultWithTimeout(
+                session.TryGetMediaPropertiesAsync(),
+                kMediaPropertiesAsyncTimeout,
+                L"TryGetMediaPropertiesAsync");
             state.title = props.Title().empty() ? L"Unknown title" : std::wstring(props.Title());
             state.artist = props.Artist().empty() ? std::wstring(props.AlbumArtist())
                                                   : std::wstring(props.Artist());
@@ -1463,6 +1680,7 @@ void RefreshMediaState(
                                             position - start, 0,
                                             state.durationTicks)
                                       : 0;
+
         }
     } catch (...) {
         state = {};
@@ -1507,15 +1725,15 @@ void SeekToMediaPosition(double ratio) {
                 return;
             }
 
-            bool changed = session
-                               .TryChangePlaybackPositionAsync(
-                                   relativePositionTicks)
-                               .get();
+            bool changed = GetAsyncResultWithTimeout(
+                session.TryChangePlaybackPositionAsync(relativePositionTicks),
+                kMediaCommandAsyncTimeout,
+                L"TryChangePlaybackPositionAsync relative");
             if (!changed && absolutePositionTicks != relativePositionTicks) {
-                changed = session
-                              .TryChangePlaybackPositionAsync(
-                                  absolutePositionTicks)
-                              .get();
+                changed = GetAsyncResultWithTimeout(
+                    session.TryChangePlaybackPositionAsync(absolutePositionTicks),
+                    kMediaCommandAsyncTimeout,
+                    L"TryChangePlaybackPositionAsync absolute");
             }
             Wh_Log(L"Island: seek source=%s result=%d advertised=%d relative=%lld absolute=%lld",
                    source.c_str(), changed,
@@ -2733,11 +2951,16 @@ std::vector<uint8_t> CreateEnergyFlameAlbumCoverBytes(std::vector<uint8_t> const
     });
 }
 
-std::vector<uint8_t> CreateDisplayAlbumCoverBytes(std::vector<uint8_t> const& bytes) {
+std::vector<uint8_t> CreateDisplayAlbumCoverBytes(
+    std::vector<uint8_t> const& bytes,
+    std::wstring const& sourceAppUserModelId) {
     if (bytes.empty()) {
         return {};
     }
-    if (!ShouldUseAbstractArtworkForDisplay(bytes) ||
+
+    bool browserSource = LooksLikeBrowserMediaSource(sourceAppUserModelId);
+    if (!browserSource ||
+        !ShouldUseAbstractArtworkForDisplay(bytes) ||
         g_settings.artworkAbstractMode == L"browser_original" ||
         g_settings.artworkAbstractMode == L"off") {
         return bytes;
@@ -3205,6 +3428,11 @@ double SmootherStep(double value) {
     return value * value * value * (value * (value * 6.0 - 15.0) + 10.0);
 }
 
+double PopupTextMotionEase(double value) {
+    value = Clamp(value, 0.0, 1.0);
+    return 0.5 - std::cos(value * 3.14159265358979323846) * 0.5;
+}
+
 // Clip animated text to its own text lane. Without this, render transforms can
 // let the incoming/outgoing title briefly draw outside the compact/popup card.
 void ApplyElementClip(FrameworkElement const& element, double width, double height) {
@@ -3326,13 +3554,30 @@ int PopupBackdropInitialFrameSkip() {
     return Clamp(g_settings.backdropInitialFrameSkip, 1, 3);
 }
 int PopupBackdropFallbackBlurPasses() {
-    return Clamp(g_settings.backdropFallbackBlurPasses, 4, 6);
+    int passes = Clamp(g_settings.backdropFallbackBlurPasses, 4, 6);
+    if (IsLiquidGlassMaterial()) {
+        return Clamp(passes - 4, 1, 2);
+    }
+
+    return passes;
 }
 int PopupBackdropFallbackCaptureScale() {
     return Clamp(g_settings.backdropFallbackCaptureScale, 2, 3);
 }
 float PopupBackdropWgcBlurStdDev() {
     return static_cast<float>(Clamp(g_settings.backdropWgcBlurStdDev, 14, 22));
+}
+float PopupBackdropWgcEffectiveBlurStdDev() {
+    float stdDev = PopupBackdropWgcBlurStdDev();
+    if (IsLiquidGlassMaterial()) {
+        return Clamp(stdDev * 0.28f, 3.5f, 5.2f);
+    }
+
+    return stdDev;
+}
+float PopupBackdropWgcLiquidRefractionBlurStdDev() {
+    float stdDev = PopupBackdropWgcBlurStdDev();
+    return Clamp(stdDev * 0.10f, 1.2f, 2.2f);
 }
 int PopupBackdropPadding() {
     return PopupSurfaceGap();
@@ -3363,7 +3608,7 @@ bool UseOverlayPopupBackdropMaterial() {
     // the XAML popup, clipped to the animated rounded popup shell instead of
     // the full transparent host rectangle. This keeps the visibility test from
     // leaking outside the actual visual surface.
-    return g_settings.material == L"acrylic";
+    return IsBlurredGlassMaterial();
 }
 
 double PopupBackdropOverlayOpacity() {
@@ -3390,6 +3635,14 @@ bool PopupBackdropCoverEffectEnabled() {
     // Default: keep the album color wash only in dark mode. In light mode the
     // compact-material surface stays clean and bright unless explicitly enabled.
     return IsDarkModeApprox();
+}
+
+bool PopupPanelCoverEffectEnabled() {
+    if (IsLiquidGlassMaterial()) {
+        return PopupBackdropCoverEffectEnabled();
+    }
+
+    return true;
 }
 
 int PopupTargetArtSize(int width, int height) {
@@ -3423,20 +3676,201 @@ int PopupFinalHeightFromArtSize(int artSize) {
            PopupSurfaceGap() * 2 + kPopupHostShadowMargin * 2;
 }
 
-mediax::Brush PopupControlCardBrush() {
+winrt::Windows::UI::Color PopupControlCardColor() {
     bool dark = IsDarkModeApprox();
+    if (IsLiquidGlassMaterial()) {
+        return dark ? Color(0x32, 0x12, 0x14, 0x1A)
+                    : Color(0x56, 0xFB, 0xFC, 0xFF);
+    }
+
     // Keep light and dark tint strengths independent. Light mode keeps the
     // stronger white-tint experiment, while dark mode is rolled back to the
     // earlier compact-material-d-backdrop-card-tint values.
     if (dark) {
-        return Brush(Color(0x70, 0x20, 0x20, 0x26));
+        return Color(0x70, 0x20, 0x20, 0x26);
     }
-    return Brush(Color(0xD8, 0xFF, 0xFF, 0xFF));
+    return Color(0xD8, 0xFF, 0xFF, 0xFF);
+}
+
+mediax::Brush PopupControlCardBrush() {
+    return Brush(PopupControlCardColor());
+}
+
+winrt::Windows::UI::Color PopupPrimaryTextColor() {
+    bool dark = IsDarkModeApprox();
+    return dark ? Color(0xFF, 0xFF, 0xFF, 0xFF)
+                : Color(0xFF, 0x00, 0x00, 0x00);
+}
+
+winrt::Windows::UI::Color PopupSecondaryTextColor() {
+    bool dark = IsDarkModeApprox();
+    return dark ? Color(0xC8, 0xFF, 0xFF, 0xFF)
+                : Color(0xC8, 0x00, 0x00, 0x00);
+}
+
+void NoteMediaNavigationDirection(int direction) {
+    g_pendingMediaNavigationDirection = direction < 0 ? -1 : (direction > 0 ? 1 : 0);
+    g_pendingMediaNavigationTime = std::chrono::steady_clock::now();
+}
+
+int ConsumeRecentMediaNavigationDirection() {
+    int direction = g_pendingMediaNavigationDirection;
+    if (direction == 0) {
+        return 0;
+    }
+
+    auto now = std::chrono::steady_clock::now();
+    auto ageMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                     now - g_pendingMediaNavigationTime)
+                     .count();
+    g_pendingMediaNavigationDirection = 0;
+    return ageMs <= 4000 ? direction : 0;
+}
+
+mediax::Brush PopupTextForegroundBrush(winrt::Windows::UI::Color color,
+                                       double edgeFadeAmount) {
+    edgeFadeAmount = Clamp(edgeFadeAmount, 0.0, 1.0);
+    auto clear = color;
+    clear.A = static_cast<BYTE>(std::lround(color.A * (1.0 - edgeFadeAmount)));
+
+    mediax::LinearGradientBrush brush;
+    brush.StartPoint({0.0f, 0.5f});
+    brush.EndPoint({1.0f, 0.5f});
+    mediax::GradientStopCollection stops;
+
+    auto addStop = [&](double offset, winrt::Windows::UI::Color const& stopColor) {
+        mediax::GradientStop stop;
+        stop.Offset(offset);
+        stop.Color(stopColor);
+        stops.Append(stop);
+    };
+
+    addStop(0.00, clear);
+    addStop(0.16, color);
+    addStop(0.84, color);
+    addStop(1.00, clear);
+    brush.GradientStops(stops);
+    return brush;
+}
+
+void ApplyPopupTextForegroundFade(double edgeFadeAmount, bool force = false) {
+    edgeFadeAmount = Clamp(edgeFadeAmount, 0.0, 1.0);
+    bool dark = IsDarkModeApprox();
+    if (!force && g_popupTextForegroundValid &&
+        std::abs(g_popupTextForegroundEdgeFadeAmount - edgeFadeAmount) < 0.003 &&
+        g_popupTextForegroundDark == dark) {
+        return;
+    }
+
+    g_popupTextForegroundValid = true;
+    g_popupTextForegroundEdgeFade = edgeFadeAmount > 0.001;
+    g_popupTextForegroundEdgeFadeAmount = edgeFadeAmount;
+    g_popupTextForegroundDark = dark;
+
+    auto primary = PopupTextForegroundBrush(PopupPrimaryTextColor(), edgeFadeAmount);
+    auto secondary = PopupTextForegroundBrush(PopupSecondaryTextColor(), edgeFadeAmount);
+    auto secondarySolid = Brush(PopupSecondaryTextColor());
+
+    if (g_popupXamlTitle) g_popupXamlTitle.Foreground(primary);
+    if (g_popupXamlOutgoingTitle) g_popupXamlOutgoingTitle.Foreground(primary);
+    if (g_popupXamlArtist) g_popupXamlArtist.Foreground(secondary);
+    if (g_popupXamlOutgoingArtist) g_popupXamlOutgoingArtist.Foreground(secondary);
+    if (g_popupXamlElapsed) g_popupXamlElapsed.Foreground(secondarySolid);
+    if (g_popupXamlDuration) g_popupXamlDuration.Foreground(secondarySolid);
+}
+
+void ApplyPopupTextForegrounds(bool edgeFade, bool force = false) {
+    ApplyPopupTextForegroundFade(edgeFade ? 1.0 : 0.0, force);
+}
+
+mediax::Brush PopupTextEdgeFadeBrush(bool leftEdge) {
+    auto bg = PopupControlCardColor();
+    if (IsLiquidGlassMaterial()) {
+        bool dark = IsDarkModeApprox();
+        bg = dark ? Color(0x20, 0x12, 0x14, 0x1A)
+                  : Color(0x3C, 0xFB, 0xFC, 0xFF);
+    }
+    auto clear = bg;
+    clear.A = 0x00;
+
+    mediax::LinearGradientBrush brush;
+    brush.StartPoint({0.0, 0.5});
+    brush.EndPoint({1.0, 0.5});
+    mediax::GradientStopCollection stops;
+
+    auto addStop = [&](double offset, winrt::Windows::UI::Color const& color) {
+        mediax::GradientStop stop;
+        stop.Offset(offset);
+        stop.Color(color);
+        stops.Append(stop);
+    };
+
+    if (leftEdge) {
+        addStop(0.00, bg);
+        addStop(0.42, bg);
+        addStop(1.00, clear);
+    } else {
+        addStop(0.00, clear);
+        addStop(0.58, bg);
+        addStop(1.00, bg);
+    }
+    brush.GradientStops(stops);
+    return brush;
+}
+
+double PopupTextClipPadding() {
+    return 2.0;
+}
+
+double PopupTextEdgeFadeWidth() {
+    return IsLiquidGlassMaterial() ? 24.0 : 18.0;
+}
+
+void ConfigurePopupTextEdgeFade(Border const& fade,
+                                bool leftEdge,
+                                double height) {
+    if (!fade) {
+        return;
+    }
+
+    double clipPadding = PopupTextClipPadding();
+    fade.Width(PopupTextEdgeFadeWidth() + clipPadding);
+    fade.Height(std::max(1.0, height));
+    fade.Margin(leftEdge ? xaml::Thickness{-clipPadding, 0, 0, 0}
+                         : xaml::Thickness{0, 0, -clipPadding, 0});
+    fade.Background(PopupTextEdgeFadeBrush(leftEdge));
+}
+
+void SetPopupTextEdgeFadeOpacity(double opacity) {
+    opacity = Clamp(opacity, 0.0, 1.0);
+    try {
+        Border fades[] = {
+            g_popupXamlTitleLeftFade,
+            g_popupXamlTitleRightFade,
+            g_popupXamlArtistLeftFade,
+            g_popupXamlArtistRightFade,
+            g_popupXamlOutgoingTitleLeftFade,
+            g_popupXamlOutgoingTitleRightFade,
+            g_popupXamlOutgoingArtistLeftFade,
+            g_popupXamlOutgoingArtistRightFade,
+        };
+        for (Border const& fade : fades) {
+            if (fade) {
+                fade.Opacity(opacity);
+            }
+        }
+    } catch (...) {
+    }
 }
 
 mediax::Brush PopupBackdropCardTintBrush() {
     bool dark = IsDarkModeApprox();
     if (UseOverlayPopupBackdropMaterial()) {
+        if (IsLiquidGlassMaterial()) {
+            return Brush(dark ? Color(0x04, 0xFF, 0xFF, 0xFF)
+                              : Color(0x38, 0xFF, 0xFF, 0xFF));
+        }
+
         // Native blur comes from the overlay window itself. Add only a clean
         // light-mode white veil here so acrylic keeps enough tint without the
         // compact island inheriting AcrylicBrush's inactive fallback behavior.
@@ -3454,6 +3888,10 @@ mediax::Brush PopupBackdropCardTintBrush() {
 }
 
 double PopupPanelCoverOpacityFactor() {
+    if (IsLiquidGlassMaterial()) {
+        return IsDarkModeApprox() ? 0.22 : 0.26;
+    }
+
     // The stronger light-mode white tint can hide the album color wash too much.
     // Boost only the light-mode cover-wash opacity; keep dark mode unchanged.
     return IsDarkModeApprox() ? 0.44 : 0.58;
@@ -3474,6 +3912,10 @@ mediax::Brush PopupSurfaceBrush() {
 
 mediax::Brush PopupSurfaceStrokeBrush() {
     if (UseOverlayPopupBackdropMaterial()) {
+        if (IsLiquidGlassMaterial()) {
+            return LiquidGlassRimHighlightBrush();
+        }
+
         bool dark = IsDarkModeApprox();
         return Brush(dark ? Color(0x10, 0xFF, 0xFF, 0xFF)
                           : Color(0x00, 0x00, 0x00, 0x00));
@@ -4013,13 +4455,26 @@ void ApplyPopupXamlTheme(bool force = false) {
     }
     if (g_popupXamlBackdrop) {
         g_popupXamlBackdrop.Background(PopupSurfaceBrush());
-        g_popupXamlBackdrop.BorderThickness({1, 1, 1, 1});
+        g_popupXamlBackdrop.BorderThickness(IsLiquidGlassMaterial()
+                                                ? Thickness{0.0, 0.0, 0.0, 0.0}
+                                                : Thickness{1.0, 1.0, 1.0, 1.0});
         g_popupXamlBackdrop.BorderBrush(PopupSurfaceStrokeBrush());
         InitializePopupCompositionShadow();
     }
     if (g_popupXamlBackdropTint) {
         g_popupXamlBackdropTint.Background(PopupBackdropCardTintBrush());
         g_popupXamlBackdropTint.BorderThickness({0, 0, 0, 0});
+    }
+    if (g_popupXamlBackdropSurfaceHighlight) {
+        g_popupXamlBackdropSurfaceHighlight.Background(LiquidGlassSurfaceHighlightBrush());
+        g_popupXamlBackdropSurfaceHighlight.BorderThickness({0, 0, 0, 0});
+    }
+    if (g_popupXamlBackdropRimHighlight) {
+        g_popupXamlBackdropRimHighlight.Background(Brush(Color(0x00, 0x00, 0x00, 0x00)));
+        g_popupXamlBackdropRimHighlight.BorderBrush(LiquidGlassRimHighlightBrush());
+        g_popupXamlBackdropRimHighlight.BorderThickness(IsLiquidGlassMaterial()
+                                                            ? Thickness{1.0, 1.0, 1.0, 1.0}
+                                                            : Thickness{0.0, 0.0, 0.0, 0.0});
     }
     if (g_popupXamlDropShadow) {
         float strength = static_cast<float>(PopupShadowOpacityPercent()) / 100.0f;
@@ -4034,23 +4489,26 @@ void ApplyPopupXamlTheme(bool force = false) {
         g_popupXamlPanelCoverFrame.BorderBrush(Brush(Color(0x00, 0x00, 0x00, 0x00)));
     }
     if (g_popupXamlArtFrame) {
-        g_popupXamlArtFrame.BorderThickness({0, 0, 0, 0});
-        g_popupXamlArtFrame.BorderBrush(Brush(Color(0x00, 0x00, 0x00, 0x00)));
+        g_popupXamlArtFrame.BorderThickness(IsLiquidGlassMaterial()
+                                                ? Thickness{1.35, 1.35, 1.35, 1.35}
+                                                : Thickness{1.0, 1.0, 1.0, 1.0});
+        g_popupXamlArtFrame.BorderBrush(CompactPlaybackControlStrokeBrush());
     }
     g_popupXamlPanel.Background(PopupControlCardBrush());
     // Playback control card uses the same subtle outline as the compact island
     // and the expanded outer surface.
     g_popupXamlPanel.BorderThickness({1, 1, 1, 1});
     g_popupXamlPanel.BorderBrush(PopupSurfaceStrokeBrush());
+    ConfigurePopupTextEdgeFade(g_popupXamlTitleLeftFade, true, 1.0);
+    ConfigurePopupTextEdgeFade(g_popupXamlTitleRightFade, false, 1.0);
+    ConfigurePopupTextEdgeFade(g_popupXamlArtistLeftFade, true, 1.0);
+    ConfigurePopupTextEdgeFade(g_popupXamlArtistRightFade, false, 1.0);
+    ConfigurePopupTextEdgeFade(g_popupXamlOutgoingTitleLeftFade, true, 1.0);
+    ConfigurePopupTextEdgeFade(g_popupXamlOutgoingTitleRightFade, false, 1.0);
+    ConfigurePopupTextEdgeFade(g_popupXamlOutgoingArtistLeftFade, true, 1.0);
+    ConfigurePopupTextEdgeFade(g_popupXamlOutgoingArtistRightFade, false, 1.0);
 
-    auto primary = Brush(dark ? Color(0xFF, 0xFF, 0xFF, 0xFF)
-                              : Color(0xFF, 0x00, 0x00, 0x00));
-    auto secondary = Brush(dark ? Color(0xC8, 0xFF, 0xFF, 0xFF)
-                                : Color(0xC8, 0x00, 0x00, 0x00));
-    if (g_popupXamlTitle) g_popupXamlTitle.Foreground(primary);
-    if (g_popupXamlArtist) g_popupXamlArtist.Foreground(secondary);
-    if (g_popupXamlElapsed) g_popupXamlElapsed.Foreground(secondary);
-    if (g_popupXamlDuration) g_popupXamlDuration.Foreground(secondary);
+    ApplyPopupTextForegrounds(false, true);
 
     auto accent = PopupAccentColor();
     auto accentBrush = Brush(accent);
@@ -4163,28 +4621,30 @@ void ApplyPopupMediaTransitionVisuals() {
                                             : 0.0);
     }
     if (g_popupXamlPanelCover) {
-        g_popupXamlPanelCover.Opacity(coverFade);
+        g_popupXamlPanelCover.Opacity(PopupPanelCoverEffectEnabled() ? coverFade : 0.0);
     }
     if (g_popupXamlPanelCoverFade) {
-        g_popupXamlPanelCoverFade.Opacity(coverTransitionActive ? (1.0 - fade) : 0.0);
+        g_popupXamlPanelCoverFade.Opacity(PopupPanelCoverEffectEnabled() && coverTransitionActive
+                                              ? (1.0 - fade)
+                                              : 0.0);
     }
 
     // Expanded-view text uses the same reversed direction as the compact island:
     // old title/artist slide left and fade out, while new title/artist slide in
     // from the right. The artist starts slightly later than the title.
-    constexpr double kPopupTextSlideOffset = 30.0;
+    constexpr double kPopupTextSlideOffset = 28.0;
     if (g_popupTextTransitionActive) {
         double p = Clamp(g_popupMediaTransitionProgress, 0.0, 1.0);
-        double titleIn = SmootherStep(Clamp((p - 0.04) / 0.86, 0.0, 1.0));
-        double artistIn = SmootherStep(Clamp((p - 0.34) / 0.62, 0.0, 1.0));
-        double titleOut = SmootherStep(Clamp((p - 0.00) / 0.78, 0.0, 1.0));
-        double artistOut = SmootherStep(Clamp((p - 0.18) / 0.72, 0.0, 1.0));
+        double titleIn = PopupTextMotionEase(Clamp((p - 0.02) / 0.92, 0.0, 1.0));
+        double artistIn = PopupTextMotionEase(Clamp((p - 0.28) / 0.70, 0.0, 1.0));
+        double titleOut = PopupTextMotionEase(Clamp((p + 0.02) / 0.84, 0.0, 1.0));
+        double artistOut = PopupTextMotionEase(Clamp((p - 0.12) / 0.80, 0.0, 1.0));
 
         if (g_popupXamlTitleTranslate) {
-            g_popupXamlTitleTranslate.X(kPopupTextSlideOffset * (1.0 - titleIn));
+            g_popupXamlTitleTranslate.X(kPopupTextSlideOffset * g_popupTextTransitionDirection * (1.0 - titleIn));
         }
         if (g_popupXamlArtistTranslate) {
-            g_popupXamlArtistTranslate.X(kPopupTextSlideOffset * (1.0 - artistIn));
+            g_popupXamlArtistTranslate.X(kPopupTextSlideOffset * g_popupTextTransitionDirection * (1.0 - artistIn));
         }
         if (g_popupXamlTitle) {
             g_popupXamlTitle.Opacity(g_popupTextBaseOpacity * titleIn);
@@ -4194,10 +4654,10 @@ void ApplyPopupMediaTransitionVisuals() {
         }
 
         if (g_popupXamlOutgoingTitleTranslate) {
-            g_popupXamlOutgoingTitleTranslate.X(-kPopupTextSlideOffset * titleOut);
+            g_popupXamlOutgoingTitleTranslate.X(-kPopupTextSlideOffset * g_popupTextTransitionDirection * titleOut);
         }
         if (g_popupXamlOutgoingArtistTranslate) {
-            g_popupXamlOutgoingArtistTranslate.X(-kPopupTextSlideOffset * artistOut);
+            g_popupXamlOutgoingArtistTranslate.X(-kPopupTextSlideOffset * g_popupTextTransitionDirection * artistOut);
         }
         if (g_popupXamlOutgoingTitle) {
             g_popupXamlOutgoingTitle.Opacity(g_popupTextBaseOpacity * (1.0 - titleOut));
@@ -4205,6 +4665,11 @@ void ApplyPopupMediaTransitionVisuals() {
         if (g_popupXamlOutgoingArtist) {
             g_popupXamlOutgoingArtist.Opacity(g_popupTextBaseOpacity * (1.0 - artistOut));
         }
+        double popupEdgeFadeIn = PopupTextMotionEase(Clamp((p - 0.08) / 0.20, 0.0, 1.0));
+        double popupEdgeFadeOut = 1.0 - PopupTextMotionEase(Clamp((p - 0.72) / 0.22, 0.0, 1.0));
+        double popupEdgeFade = popupEdgeFadeIn * popupEdgeFadeOut;
+        ApplyPopupTextForegroundFade(popupEdgeFade < 0.01 ? 0.0 : popupEdgeFade);
+        SetPopupTextEdgeFadeOpacity(0.0);
     } else {
         if (g_popupXamlTitleTranslate) g_popupXamlTitleTranslate.X(0.0);
         if (g_popupXamlArtistTranslate) g_popupXamlArtistTranslate.X(0.0);
@@ -4212,6 +4677,8 @@ void ApplyPopupMediaTransitionVisuals() {
         if (g_popupXamlOutgoingArtistTranslate) g_popupXamlOutgoingArtistTranslate.X(0.0);
         if (g_popupXamlOutgoingTitle) g_popupXamlOutgoingTitle.Opacity(0.0);
         if (g_popupXamlOutgoingArtist) g_popupXamlOutgoingArtist.Opacity(0.0);
+        ApplyPopupTextForegrounds(false);
+        SetPopupTextEdgeFadeOpacity(0.0);
     }
 }
 
@@ -4313,6 +4780,8 @@ void ResetPopupXamlElementState() {
     g_popupXamlBackdropCoverFade = nullptr;
     g_popupXamlBackdropCover = nullptr;
     g_popupXamlBackdropTint = nullptr;
+    g_popupXamlBackdropSurfaceHighlight = nullptr;
+    g_popupXamlBackdropRimHighlight = nullptr;
     g_popupXamlPanelCoverFrame = nullptr;
     g_popupXamlPanelCoverScale = nullptr;
     g_popupXamlPanelCoverTranslate = nullptr;
@@ -4330,6 +4799,19 @@ void ResetPopupXamlElementState() {
     g_popupXamlArtistHost = nullptr;
     g_popupXamlOutgoingTitleHost = nullptr;
     g_popupXamlOutgoingArtistHost = nullptr;
+    g_popupXamlTitleLeftFade = nullptr;
+    g_popupXamlTitleRightFade = nullptr;
+    g_popupXamlArtistLeftFade = nullptr;
+    g_popupXamlArtistRightFade = nullptr;
+    g_popupXamlOutgoingTitleLeftFade = nullptr;
+    g_popupXamlOutgoingTitleRightFade = nullptr;
+    g_popupXamlOutgoingArtistLeftFade = nullptr;
+    g_popupXamlOutgoingArtistRightFade = nullptr;
+    g_popupTextForegroundValid = false;
+    g_popupTextForegroundEdgeFade = false;
+    g_popupTextForegroundDark = false;
+    g_popupTextForegroundEdgeFadeAmount = -1.0;
+
     g_popupXamlTitle = nullptr;
     g_popupXamlArtist = nullptr;
     g_popupXamlOutgoingTitle = nullptr;
@@ -4353,7 +4835,6 @@ void ResetPopupXamlElementState() {
     g_popupXamlProgressCoreBlurLayers.clear();
     g_popupXamlProgressGlowCore = nullptr;
     g_popupXamlControls = nullptr;
-    g_popupXamlControlsScale = nullptr;
     g_popupXamlThumbnailHash = UINT64_MAX;
     g_popupXamlBackdropCoverEnabled = false;
     g_popupAccentThumbnailHash = UINT64_MAX;
@@ -4409,6 +4890,27 @@ bool InitializePopupXamlHost(HWND hwnd) {
         backdropTint.Background(PopupBackdropCardTintBrush());
         backdropTint.BorderThickness({0, 0, 0, 0});
         backdropCoverHost.Children().Append(backdropTint);
+        Border backdropSurfaceHighlight;
+        backdropSurfaceHighlight.Background(LiquidGlassSurfaceHighlightBrush());
+        backdropSurfaceHighlight.BorderThickness({0, 0, 0, 0});
+        backdropSurfaceHighlight.CornerRadius({kPopupUnifiedCornerRadius,
+                                               kPopupUnifiedCornerRadius,
+                                               kPopupUnifiedCornerRadius,
+                                               kPopupUnifiedCornerRadius});
+        backdropSurfaceHighlight.IsHitTestVisible(false);
+        backdropSurfaceHighlight.Opacity(0.0);
+        backdropCoverHost.Children().Append(backdropSurfaceHighlight);
+        Border backdropRimHighlight;
+        backdropRimHighlight.Background(Brush(Color(0x00, 0x00, 0x00, 0x00)));
+        backdropRimHighlight.BorderBrush(LiquidGlassRimHighlightBrush());
+        backdropRimHighlight.BorderThickness({1.0, 1.0, 1.0, 1.0});
+        backdropRimHighlight.CornerRadius({kPopupUnifiedCornerRadius,
+                                           kPopupUnifiedCornerRadius,
+                                           kPopupUnifiedCornerRadius,
+                                           kPopupUnifiedCornerRadius});
+        backdropRimHighlight.IsHitTestVisible(false);
+        backdropRimHighlight.Opacity(0.0);
+        backdropCoverHost.Children().Append(backdropRimHighlight);
         backdrop.Child(backdropCoverHost);
         AttachGpuFriendlyTransform(backdrop, g_popupXamlBackdropScale, g_popupXamlBackdropTranslate);
         canvas.Children().Append(backdrop);
@@ -4444,8 +4946,10 @@ bool InitializePopupXamlHost(HWND hwnd) {
         artFrame.CornerRadius({kPopupUnifiedCornerRadius, kPopupUnifiedCornerRadius,
                                kPopupUnifiedCornerRadius, kPopupUnifiedCornerRadius});
         artFrame.Background(Brush(Color(0x00, 0x00, 0x00, 0x00)));
-        artFrame.BorderThickness({0, 0, 0, 0});
-        artFrame.BorderBrush(Brush(Color(0x00, 0x00, 0x00, 0x00)));
+        artFrame.BorderThickness(IsLiquidGlassMaterial()
+                                     ? Thickness{1.35, 1.35, 1.35, 1.35}
+                                     : Thickness{1.0, 1.0, 1.0, 1.0});
+        artFrame.BorderBrush(CompactPlaybackControlStrokeBrush());
         AttachGpuFriendlyTransform(artFrame, g_popupXamlArtScale, g_popupXamlArtTranslate);
         Grid artHost;
         Image artFade;
@@ -4459,6 +4963,17 @@ bool InitializePopupXamlHost(HWND hwnd) {
         artFrame.Child(artHost);
         canvas.Children().Append(artFrame);
 
+        auto makePopupTextFade = [](bool leftEdge) {
+            Border fade;
+            fade.HorizontalAlignment(leftEdge ? HorizontalAlignment::Left
+                                              : HorizontalAlignment::Right);
+            fade.VerticalAlignment(VerticalAlignment::Stretch);
+            fade.IsHitTestVisible(false);
+            fade.Opacity(0.0);
+            controls::Canvas::SetZIndex(fade, 10);
+            return fade;
+        };
+
         Grid outgoingTitleHost;
         outgoingTitleHost.IsHitTestVisible(false);
         TextBlock outgoingTitle;
@@ -4470,6 +4985,10 @@ bool InitializePopupXamlHost(HWND hwnd) {
         TranslateTransform outgoingTitleTranslate;
         outgoingTitle.RenderTransform(outgoingTitleTranslate);
         outgoingTitleHost.Children().Append(outgoingTitle);
+        Border outgoingTitleLeftFade = makePopupTextFade(true);
+        Border outgoingTitleRightFade = makePopupTextFade(false);
+        outgoingTitleHost.Children().Append(outgoingTitleLeftFade);
+        outgoingTitleHost.Children().Append(outgoingTitleRightFade);
         canvas.Children().Append(outgoingTitleHost);
 
         Grid outgoingArtistHost;
@@ -4482,6 +5001,10 @@ bool InitializePopupXamlHost(HWND hwnd) {
         TranslateTransform outgoingArtistTranslate;
         outgoingArtist.RenderTransform(outgoingArtistTranslate);
         outgoingArtistHost.Children().Append(outgoingArtist);
+        Border outgoingArtistLeftFade = makePopupTextFade(true);
+        Border outgoingArtistRightFade = makePopupTextFade(false);
+        outgoingArtistHost.Children().Append(outgoingArtistLeftFade);
+        outgoingArtistHost.Children().Append(outgoingArtistRightFade);
         canvas.Children().Append(outgoingArtistHost);
 
         Grid titleHost;
@@ -4494,6 +5017,10 @@ bool InitializePopupXamlHost(HWND hwnd) {
         TranslateTransform titleTranslate;
         title.RenderTransform(titleTranslate);
         titleHost.Children().Append(title);
+        Border titleLeftFade = makePopupTextFade(true);
+        Border titleRightFade = makePopupTextFade(false);
+        titleHost.Children().Append(titleLeftFade);
+        titleHost.Children().Append(titleRightFade);
         canvas.Children().Append(titleHost);
 
         Grid artistHost;
@@ -4505,6 +5032,10 @@ bool InitializePopupXamlHost(HWND hwnd) {
         TranslateTransform artistTranslate;
         artist.RenderTransform(artistTranslate);
         artistHost.Children().Append(artist);
+        Border artistLeftFade = makePopupTextFade(true);
+        Border artistRightFade = makePopupTextFade(false);
+        artistHost.Children().Append(artistLeftFade);
+        artistHost.Children().Append(artistRightFade);
         canvas.Children().Append(artistHost);
 
         TextBlock elapsed;
@@ -4600,19 +5131,27 @@ bool InitializePopupXamlHost(HWND hwnd) {
         Border prevButton = MakePopupXamlButton(
             L"Popup_Prev", [] {
                 RunMediaCommand([](gsm::GlobalSystemMediaTransportControlsSession const& s) {
-                    s.TrySkipPreviousAsync().get();
+                    NoteMediaNavigationDirection(-1);
+                    GetAsyncResultWithTimeout(s.TrySkipPreviousAsync(),
+                                           kMediaCommandAsyncTimeout,
+                                           L"TrySkipPreviousAsync");
                 });
             });
         Border playButton = MakePopupXamlButton(
             L"Popup_Play", [] {
                 RunMediaCommand([](gsm::GlobalSystemMediaTransportControlsSession const& s) {
-                    s.TryTogglePlayPauseAsync().get();
+                    GetAsyncResultWithTimeout(s.TryTogglePlayPauseAsync(),
+                                           kMediaCommandAsyncTimeout,
+                                           L"TryTogglePlayPauseAsync");
                 });
             }, true);
         Border nextButton = MakePopupXamlButton(
             L"Popup_Next", [] {
                 RunMediaCommand([](gsm::GlobalSystemMediaTransportControlsSession const& s) {
-                    s.TrySkipNextAsync().get();
+                    NoteMediaNavigationDirection(1);
+                    GetAsyncResultWithTimeout(s.TrySkipNextAsync(),
+                                           kMediaCommandAsyncTimeout,
+                                           L"TrySkipNextAsync");
                 });
             });
 
@@ -4740,6 +5279,8 @@ bool InitializePopupXamlHost(HWND hwnd) {
         g_popupXamlBackdropCoverFade = backdropCoverFade;
         g_popupXamlBackdropCover = backdropCover;
         g_popupXamlBackdropTint = backdropTint;
+        g_popupXamlBackdropSurfaceHighlight = backdropSurfaceHighlight;
+        g_popupXamlBackdropRimHighlight = backdropRimHighlight;
         g_popupXamlPanelCoverFrame = panelCoverFrame;
         g_popupXamlPanelCoverFade = panelCoverFade;
         g_popupXamlPanelCover = panelCover;
@@ -4751,6 +5292,14 @@ bool InitializePopupXamlHost(HWND hwnd) {
         g_popupXamlArtistHost = artistHost;
         g_popupXamlOutgoingTitleHost = outgoingTitleHost;
         g_popupXamlOutgoingArtistHost = outgoingArtistHost;
+        g_popupXamlTitleLeftFade = titleLeftFade;
+        g_popupXamlTitleRightFade = titleRightFade;
+        g_popupXamlArtistLeftFade = artistLeftFade;
+        g_popupXamlArtistRightFade = artistRightFade;
+        g_popupXamlOutgoingTitleLeftFade = outgoingTitleLeftFade;
+        g_popupXamlOutgoingTitleRightFade = outgoingTitleRightFade;
+        g_popupXamlOutgoingArtistLeftFade = outgoingArtistLeftFade;
+        g_popupXamlOutgoingArtistRightFade = outgoingArtistRightFade;
         g_popupXamlTitle = title;
         g_popupXamlArtist = artist;
         g_popupXamlOutgoingTitle = outgoingTitle;
@@ -4772,7 +5321,6 @@ bool InitializePopupXamlHost(HWND hwnd) {
         g_popupXamlProgressCoreBlurLayers = progressCoreBlurLayers;
         g_popupXamlProgressGlowCore = progressGlowCore;
         g_popupXamlControls = controlsPanel;
-        g_popupXamlControlsScale = nullptr;
         g_popupXamlThumbnailHash = UINT64_MAX;
         InitializePopupCompositionShadow();
         ApplyPopupXamlTheme(true);
@@ -4902,6 +5450,24 @@ void UpdatePopupXamlVisuals() {
                 g_popupXamlBackdropCoverFade.Opacity(0.0);
             }
         }
+        double liquidHighlightOpacity = IsLiquidGlassMaterial() ? backdropOpacity : 0.0;
+        double liquidSurfaceHighlightOpacity =
+            IsLiquidGlassMaterial()
+                ? backdropOpacity * (IsDarkModeApprox() ? 0.45 : 0.78)
+                : 0.0;
+        if (g_popupXamlBackdropSurfaceHighlight) {
+            g_popupXamlBackdropSurfaceHighlight.CornerRadius(
+                {shellRadius, shellRadius, shellRadius, shellRadius});
+            g_popupXamlBackdropSurfaceHighlight.Opacity(liquidSurfaceHighlightOpacity);
+        }
+        if (g_popupXamlBackdropRimHighlight) {
+            g_popupXamlBackdropRimHighlight.CornerRadius(
+                {shellRadius, shellRadius, shellRadius, shellRadius});
+            g_popupXamlBackdropRimHighlight.BorderThickness(
+                IsLiquidGlassMaterial() ? Thickness{1.0, 1.0, 1.0, 1.0}
+                                        : Thickness{0.0, 0.0, 0.0, 0.0});
+            g_popupXamlBackdropRimHighlight.Opacity(liquidHighlightOpacity * 0.72);
+        }
         ApplyCompositorRect(g_popupXamlBackdrop,
                             g_popupXamlBackdropScale,
                             g_popupXamlBackdropTranslate,
@@ -4915,7 +5481,15 @@ void UpdatePopupXamlVisuals() {
         LerpInt(sourceArtRect.right, targetArtScreen.right, progress),
         LerpInt(sourceArtRect.bottom, targetArtScreen.bottom, progress),
     };
-    g_popupXamlArtFrame.CornerRadius({0, 0, 0, 0});
+    double popupArtSize =
+        static_cast<double>(std::max(1L, artScreen.right - artScreen.left));
+    double popupArtRadius = std::max(1.0, popupArtSize * 0.118);
+    g_popupXamlArtFrame.CornerRadius(
+        {popupArtRadius, popupArtRadius, popupArtRadius, popupArtRadius});
+    g_popupXamlArtFrame.BorderThickness(IsLiquidGlassMaterial()
+                                            ? Thickness{1.35, 1.35, 1.35, 1.35}
+                                            : Thickness{1.0, 1.0, 1.0, 1.0});
+    g_popupXamlArtFrame.BorderBrush(CompactPlaybackControlStrokeBrush());
     g_popupXamlArtFrame.Clip(nullptr);
     ApplyCompositorRect(g_popupXamlArtFrame,
                         g_popupXamlArtScale,
@@ -4937,7 +5511,8 @@ void UpdatePopupXamlVisuals() {
         // This preserves the color-wash clipping while avoiding per-frame
         // remeasure/arrange of the large blurred cover layer.
         g_popupXamlPanelCoverFrame.CornerRadius({panelRadius, panelRadius, panelRadius, panelRadius});
-        g_popupXamlPanelCoverFrame.Opacity(cardOpacity * PopupPanelCoverOpacityFactor());
+        g_popupXamlPanelCoverFrame.Opacity(
+            PopupPanelCoverEffectEnabled() ? cardOpacity * PopupPanelCoverOpacityFactor() : 0.0);
         ApplyCompositorRect(g_popupXamlPanelCoverFrame,
                             g_popupXamlPanelCoverScale,
                             g_popupXamlPanelCoverTranslate,
@@ -4954,9 +5529,14 @@ void UpdatePopupXamlVisuals() {
                         targetCard,
                         popupScreen);
 
-    auto placeText = [&](FrameworkElement const& host, TextBlock const& text,
-                         RECT const& source, RECT const& target,
-                         double compactSize, double expandedSize) {
+    auto placeText = [&](FrameworkElement const& host,
+                         TextBlock const& text,
+                         Border const& leftFade,
+                         Border const& rightFade,
+                         RECT const& source,
+                         RECT const& target,
+                         double compactSize,
+                         double expandedSize) {
         if (!host || !text) {
             return;
         }
@@ -4969,7 +5549,10 @@ void UpdatePopupXamlVisuals() {
         double textHeight = std::max(1L, screen.bottom - screen.top);
         host.Width(textWidth);
         host.Height(textHeight);
-        ApplyElementClip(host, textWidth, textHeight);
+        double clipPadding = PopupTextClipPadding();
+        ApplyElementClipWithPadding(host, textWidth, textHeight, clipPadding);
+        ConfigurePopupTextEdgeFade(leftFade, true, textHeight);
+        ConfigurePopupTextEdgeFade(rightFade, false, textHeight);
         text.Width(textWidth);
         text.Height(textHeight);
         text.FontSize(expandedSize);
@@ -4977,12 +5560,16 @@ void UpdatePopupXamlVisuals() {
         controls::Canvas::SetTop(host, screen.top - popupScreen.top);
     };
     placeText(g_popupXamlOutgoingTitleHost, g_popupXamlOutgoingTitle,
+              g_popupXamlOutgoingTitleLeftFade, g_popupXamlOutgoingTitleRightFade,
               sourceTitleRect, targetTitle, 12, 16);
     placeText(g_popupXamlOutgoingArtistHost, g_popupXamlOutgoingArtist,
+              g_popupXamlOutgoingArtistLeftFade, g_popupXamlOutgoingArtistRightFade,
               sourceArtistRect, targetArtist, 10, 13);
     placeText(g_popupXamlTitleHost, g_popupXamlTitle,
+              g_popupXamlTitleLeftFade, g_popupXamlTitleRightFade,
               sourceTitleRect, targetTitle, 12, 16);
     placeText(g_popupXamlArtistHost, g_popupXamlArtist,
+              g_popupXamlArtistLeftFade, g_popupXamlArtistRightFade,
               sourceArtistRect, targetArtist, 10, 13);
 
     double textOpacity = SmoothStep(Clamp(progress, 0.0, 1.0));
@@ -4994,6 +5581,8 @@ void UpdatePopupXamlVisuals() {
         if (g_popupXamlArtistTranslate) g_popupXamlArtistTranslate.X(0.0);
         if (g_popupXamlOutgoingTitle) g_popupXamlOutgoingTitle.Opacity(0.0);
         if (g_popupXamlOutgoingArtist) g_popupXamlOutgoingArtist.Opacity(0.0);
+        ApplyPopupTextForegrounds(false);
+        SetPopupTextEdgeFadeOpacity(0.0);
     }
 
     // Morph the transport controls from the compact island area to their final
@@ -5478,6 +6067,7 @@ void CapturePopupSourceGeometry() {
 void UpdatePopupBackdropOverlayWindow();
 void HidePopupBackdropOverlayWindow();
 void StopPopupOverlayWgcBackdrop();
+void ReleasePopupOverlayWgcDeviceResources();
 bool StartPopupOverlayWgcBackdrop(RECT const& captureRect, int widthPx, int heightPx);
 void UpdatePopupOverlayWgcCaptureRect(RECT const& captureRect);
 void SetPopupWindowCaptureExclusion(HWND hwnd, bool exclude);
@@ -5737,9 +6327,10 @@ void RefreshCompactTextHostClip(bool forceLayout = false) {
             if (!fade) {
                 return;
             }
-            fade.Width(fadeWidth);
+            double leftCoverOffset = leftEdge ? Clamp(g_layout.textMarginX + 4.0, 8.0, 16.0) : 0.0;
+            fade.Width(fadeWidth + leftCoverOffset);
             fade.Height(clipHeight);
-            fade.Margin(leftEdge ? xaml::Thickness{-clipPadding, 0, 0, 0}
+            fade.Margin(leftEdge ? xaml::Thickness{-(clipPadding + leftCoverOffset), 0, 0, 0}
                                  : xaml::Thickness{0, 0, -clipPadding, 0});
             fade.Background(CompactTextEdgeFadeBrush(leftEdge));
         };
@@ -5783,20 +6374,22 @@ void OnCompactTextRendering(winrt::Windows::Foundation::IInspectable const&,
         dtSec = Clamp(dtSec, 0.0, 0.05);
 
         // Slightly slower than the previous pass so the crossfade and slide are
-        // more visible. SmootherStep keeps both ends of the motion soft.
-        g_compactTextProgress = Clamp(g_compactTextProgress + dtSec * 2.45, 0.0, 1.0);
-        constexpr double kTextSlideOffset = 22.0;
+        // more visible. PopupTextMotionEase keeps velocity changes even.
+        g_compactTextProgress = Clamp(g_compactTextProgress + dtSec * 2.35, 0.0, 1.0);
+        constexpr double kTextSlideOffset = 21.0;
         RefreshCompactTextHostClip(false);
 
-        double titleIn = SmootherStep(Clamp((g_compactTextProgress - 0.04) / 0.86, 0.0, 1.0));
-        double artistIn = SmootherStep(Clamp((g_compactTextProgress - 0.34) / 0.62, 0.0, 1.0));
-        double titleOut = SmootherStep(Clamp(g_compactTextProgress / 0.78, 0.0, 1.0));
-        double artistOut = SmootherStep(Clamp((g_compactTextProgress - 0.18) / 0.72, 0.0, 1.0));
-        double artIn = SmootherStep(Clamp(g_compactTextProgress / 0.96, 0.0, 1.0));
+        double titleIn = PopupTextMotionEase(Clamp((g_compactTextProgress - 0.02) / 0.92, 0.0, 1.0));
+        double artistIn = PopupTextMotionEase(Clamp((g_compactTextProgress - 0.28) / 0.70, 0.0, 1.0));
+        double titleOut = PopupTextMotionEase(Clamp((g_compactTextProgress + 0.02) / 0.84, 0.0, 1.0));
+        double artistOut = PopupTextMotionEase(Clamp((g_compactTextProgress - 0.12) / 0.80, 0.0, 1.0));
+        double artIn = PopupTextMotionEase(Clamp(g_compactTextProgress / 0.96, 0.0, 1.0));
         if (g_compactTextEdgeFadeActive) {
-            SetCompactTextEdgeFadeOpacity(
-                1.0 - SmootherStep(Clamp((g_compactTextProgress - 0.82) / 0.18,
-                                          0.0, 1.0)));
+            double edgeFadeIn = PopupTextMotionEase(Clamp((g_compactTextProgress - 0.08) / 0.20,
+                                                          0.0, 1.0));
+            double edgeFadeOut = 1.0 - PopupTextMotionEase(Clamp((g_compactTextProgress - 0.78) / 0.18,
+                                                                 0.0, 1.0));
+            SetCompactTextEdgeFadeOpacity(edgeFadeIn * edgeFadeOut);
         }
 
         // Reversed direction: new compact text now enters from the right.
@@ -5869,7 +6462,7 @@ void StartCompactTrackTransition(std::wstring const& oldTitle,
         g_compactTitleText.Opacity(0.0);
         g_compactArtistText.Opacity(0.0);
         g_compactTextEdgeFadeActive = true;
-        SetCompactTextEdgeFadeOpacity(1.0);
+        SetCompactTextEdgeFadeOpacity(0.0);
     } else {
         if (g_compactTitleTranslate) g_compactTitleTranslate.X(0.0);
         if (g_compactArtistTranslate) g_compactArtistTranslate.X(0.0);
@@ -6305,15 +6898,23 @@ LRESULT CALLBACK ExpandedPopupWndProc(HWND hwnd, UINT message, WPARAM wParam, LP
                 }
                 if (i == 0) {
                     RunMediaCommand([](gsm::GlobalSystemMediaTransportControlsSession const& session) {
-                        session.TrySkipPreviousAsync().get();
+                        NoteMediaNavigationDirection(-1);
+                        GetAsyncResultWithTimeout(session.TrySkipPreviousAsync(),
+                                                   kMediaCommandAsyncTimeout,
+                                                   L"TrySkipPreviousAsync");
                     });
                 } else if (i == 1) {
                     RunMediaCommand([](gsm::GlobalSystemMediaTransportControlsSession const& session) {
-                        session.TryTogglePlayPauseAsync().get();
+                        GetAsyncResultWithTimeout(session.TryTogglePlayPauseAsync(),
+                                                   kMediaCommandAsyncTimeout,
+                                                   L"TryTogglePlayPauseAsync");
                     });
                 } else {
                     RunMediaCommand([](gsm::GlobalSystemMediaTransportControlsSession const& session) {
-                        session.TrySkipNextAsync().get();
+                        NoteMediaNavigationDirection(1);
+                        GetAsyncResultWithTimeout(session.TrySkipNextAsync(),
+                                                   kMediaCommandAsyncTimeout,
+                                                   L"TrySkipNextAsync");
                     });
                 }
                 return 0;
@@ -6644,6 +7245,327 @@ bool CreatePopupOverlayWgcCaptureItemForMonitor(HMONITOR monitor,
     }
 }
 
+void ClearPopupOverlayWgcLensDisplacementMap() {
+    g_popupOverlayWgcLensDisplacementMap = nullptr;
+    g_popupOverlayWgcLensMapWidth = 0;
+    g_popupOverlayWgcLensMapHeight = 0;
+    g_popupOverlayWgcLensMapRadius = 0;
+}
+
+double PopupOverlayWgcSmoothStep(double edge0, double edge1, double value) {
+    if (edge0 == edge1) {
+        return value < edge0 ? 0.0 : 1.0;
+    }
+
+    double t = Clamp((value - edge0) / (edge1 - edge0), 0.0, 1.0);
+    return t * t * (3.0 - 2.0 * t);
+}
+
+bool EnsurePopupOverlayWgcLensDisplacementMap(int width, int height, int radius) {
+    if (!g_popupOverlayWgcD2dContext || width <= 0 || height <= 0) {
+        return false;
+    }
+
+    radius = Clamp(radius, 1, std::max(1, std::min(width, height) / 2));
+    if (g_popupOverlayWgcLensDisplacementMap &&
+        g_popupOverlayWgcLensMapWidth == width &&
+        g_popupOverlayWgcLensMapHeight == height &&
+        g_popupOverlayWgcLensMapRadius == radius) {
+        return true;
+    }
+
+    std::vector<BYTE> pixels(static_cast<size_t>(width) * height * 4);
+    double widthD = static_cast<double>(width);
+    double heightD = static_cast<double>(height);
+    double radiusD = static_cast<double>(radius);
+    double halfWidth = widthD * 0.5;
+    double halfHeight = heightD * 0.5;
+    double innerHalfWidth = std::max(0.0, halfWidth - radiusD);
+    double innerHalfHeight = std::max(0.0, halfHeight - radiusD);
+    double centerX = widthD * 0.5;
+    double centerY = heightD * 0.5;
+
+    double edgeWidth = Clamp(std::min(width, height) * 0.14, 10.0, 30.0);
+    double outerWidth = Clamp(std::min(width, height) * 0.035, 2.2, 5.5);
+
+    auto smootherStep = [](double value) {
+        value = Clamp(value, 0.0, 1.0);
+        return value * value * value *
+               (value * (value * 6.0 - 15.0) + 10.0);
+    };
+
+    auto signedDistanceAndNormal = [&](double px,
+                                       double py,
+                                       double& distanceInside,
+                                       double& inwardX,
+                                       double& inwardY) {
+        double localX = px - centerX;
+        double localY = py - centerY;
+        double signX = localX < 0.0 ? -1.0 : 1.0;
+        double signY = localY < 0.0 ? -1.0 : 1.0;
+        double qx = std::abs(localX) - innerHalfWidth;
+        double qy = std::abs(localY) - innerHalfHeight;
+        double outsideX = std::max(qx, 0.0);
+        double outsideY = std::max(qy, 0.0);
+        double outsideLength = std::sqrt(outsideX * outsideX +
+                                         outsideY * outsideY);
+        double signedDistance =
+            outsideLength + std::min(std::max(qx, qy), 0.0) - radiusD;
+        distanceInside = -signedDistance;
+        if (distanceInside < 0.0) {
+            return false;
+        }
+
+        double outwardX = 0.0;
+        double outwardY = 0.0;
+        if (outsideLength > 0.001) {
+            outwardX = signX * outsideX / outsideLength;
+            outwardY = signY * outsideY / outsideLength;
+        } else if (qx > qy) {
+            outwardX = signX;
+        } else {
+            outwardY = signY;
+        }
+
+        inwardX = -outwardX;
+        inwardY = -outwardY;
+        return true;
+    };
+
+    for (int y = 0; y < height; ++y) {
+        double fy = static_cast<double>(y) + 0.5;
+        for (int x = 0; x < width; ++x) {
+            double fx = static_cast<double>(x) + 0.5;
+            double distance = 0.0;
+            double inwardX = 0.0;
+            double inwardY = 0.0;
+            double offsetX = 0.0;
+            double offsetY = 0.0;
+
+            if (signedDistanceAndNormal(fx, fy, distance, inwardX, inwardY) &&
+                distance <= edgeWidth) {
+                double transition =
+                    1.0 - smootherStep(distance / std::max(1.0, edgeWidth));
+                double peak =
+                    1.0 - smootherStep(distance / std::max(1.0, outerWidth));
+                double amount =
+                    Clamp(std::sqrt(transition) * 0.78 + peak * 0.22,
+                          0.0,
+                          1.0);
+                offsetX = inwardX * amount;
+                offsetY = inwardY * amount;
+            }
+
+            size_t index = (static_cast<size_t>(y) * width + x) * 4;
+            pixels[index + 0] = 0x80;
+            pixels[index + 1] = static_cast<BYTE>(
+                Clamp(static_cast<int>(std::lround(128.0 + offsetY * 127.0)),
+                      0,
+                      255));
+            pixels[index + 2] = static_cast<BYTE>(
+                Clamp(static_cast<int>(std::lround(128.0 + offsetX * 127.0)),
+                      0,
+                      255));
+            pixels[index + 3] = 0xFF;
+        }
+    }
+
+    D2D1_BITMAP_PROPERTIES1 props = D2D1::BitmapProperties1(
+        D2D1_BITMAP_OPTIONS_NONE,
+        D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM,
+                          D2D1_ALPHA_MODE_IGNORE));
+    winrt::com_ptr<ID2D1Bitmap1> map;
+    HRESULT hr = g_popupOverlayWgcD2dContext->CreateBitmap(
+        D2D1::SizeU(static_cast<UINT32>(width), static_cast<UINT32>(height)),
+        pixels.data(),
+        static_cast<UINT32>(width * 4),
+        &props,
+        map.put());
+    if (FAILED(hr)) {
+        g_popupOverlayWgcLastHr = hr;
+        Wh_Log(L"Island: overlay WGC lens displacement map failed hr=0x%08X",
+               static_cast<unsigned>(hr));
+        ClearPopupOverlayWgcLensDisplacementMap();
+        return false;
+    }
+
+    g_popupOverlayWgcLensDisplacementMap = std::move(map);
+    g_popupOverlayWgcLensMapWidth = width;
+    g_popupOverlayWgcLensMapHeight = height;
+    g_popupOverlayWgcLensMapRadius = radius;
+    return true;
+}
+
+void ApplyLiquidGlassCpuLensRefraction(std::vector<BYTE>& pixels,
+                                       int width,
+                                       int height,
+                                       int radius) {
+    if (!IsLiquidGlassMaterial() || pixels.empty() || width <= 1 || height <= 1) {
+        return;
+    }
+
+    radius = Clamp(radius, 1, std::max(1, std::min(width, height) / 2));
+    std::vector<BYTE> source = pixels;
+    double edgeWidth = Clamp(std::min(width, height) * 0.22, 18.0, 72.0);
+    double cornerWidth = Clamp(radius * 1.35, edgeWidth * 0.90, edgeWidth * 1.90);
+    double scale = Clamp(std::min(width, height) * 0.18, 24.0, 86.0);
+
+    auto smoothEdge = [](double value, double widthValue) {
+        double t = Clamp(value / widthValue, 0.0, 1.0);
+        return 1.0 - t * t * (3.0 - 2.0 * t);
+    };
+
+    auto sampleChannel = [&](double sampleX, double sampleY, int channel) -> BYTE {
+        sampleX = Clamp(sampleX, 0.0, static_cast<double>(width - 1));
+        sampleY = Clamp(sampleY, 0.0, static_cast<double>(height - 1));
+
+        int x0 = static_cast<int>(std::floor(sampleX));
+        int y0 = static_cast<int>(std::floor(sampleY));
+        int x1 = std::min(width - 1, x0 + 1);
+        int y1 = std::min(height - 1, y0 + 1);
+        double tx = sampleX - x0;
+        double ty = sampleY - y0;
+
+        auto at = [&](int sx, int sy) -> double {
+            return source[(static_cast<size_t>(sy) * width + sx) * 4 + channel];
+        };
+        double top = at(x0, y0) * (1.0 - tx) + at(x1, y0) * tx;
+        double bottom = at(x0, y1) * (1.0 - tx) + at(x1, y1) * tx;
+        return static_cast<BYTE>(
+            Clamp(static_cast<int>(std::lround(top * (1.0 - ty) + bottom * ty)),
+                  0,
+                  255));
+    };
+
+    for (int y = 0; y < height; ++y) {
+        double fy = y + 0.5;
+        double top = smoothEdge(fy, edgeWidth);
+        double bottom = smoothEdge(height - fy, edgeWidth);
+        for (int x = 0; x < width; ++x) {
+            double fx = x + 0.5;
+            double left = smoothEdge(fx, edgeWidth);
+            double right = smoothEdge(width - fx, edgeWidth);
+
+            double pullX = left - right;
+            double pullY = top - bottom;
+
+            double radiusD = static_cast<double>(radius);
+            double widthD = static_cast<double>(width);
+            double heightD = static_cast<double>(height);
+            struct CornerPull {
+                double x;
+                double y;
+                double dx;
+                double dy;
+            };
+            CornerPull pulls[] = {
+                {radiusD, radiusD, 1.0, 1.0},
+                {widthD - radiusD, radiusD, -1.0, 1.0},
+                {radiusD, heightD - radiusD, 1.0, -1.0},
+                {widthD - radiusD, heightD - radiusD, -1.0, -1.0},
+            };
+            double cornerAmount = 0.0;
+            for (CornerPull const& pull : pulls) {
+                double dx = fx - pull.x;
+                double dy = fy - pull.y;
+                double amount = smoothEdge(std::sqrt(dx * dx + dy * dy), cornerWidth);
+                pullX += pull.dx * amount * 0.85;
+                pullY += pull.dy * amount * 0.85;
+                cornerAmount = std::max(cornerAmount, amount);
+            }
+
+            double edgeAmount = std::max(std::max(left, right),
+                                         std::max(top, bottom));
+            edgeAmount = Clamp(std::max(edgeAmount, cornerAmount), 0.0, 1.0);
+            if (edgeAmount <= 0.001) {
+                continue;
+            }
+
+            pullX = Clamp(pullX, -1.35, 1.35);
+            pullY = Clamp(pullY, -1.35, 1.35);
+            double sampleX = x + pullX * scale;
+            double sampleY = y + pullY * scale;
+            size_t index = (static_cast<size_t>(y) * width + x) * 4;
+            for (int c = 0; c < 3; ++c) {
+                BYTE sampled = sampleChannel(sampleX, sampleY, c);
+                int mixed = static_cast<int>(std::lround(
+                    source[index + c] * (1.0 - edgeAmount) +
+                    sampled * edgeAmount));
+                pixels[index + c] = static_cast<BYTE>(Clamp(mixed, 0, 255));
+            }
+        }
+    }
+}
+
+bool DrawLiquidGlassGpuLensWarp(ID2D1DeviceContext* context,
+                                ID2D1Bitmap1* blurredBitmap,
+                                ID2D1Bitmap1* refractBitmap,
+                                int width,
+                                int height) {
+    if (!IsLiquidGlassMaterial() || !context || !blurredBitmap ||
+        width <= 2 || height <= 2) {
+        return false;
+    }
+
+    float widthF = static_cast<float>(width);
+    float heightF = static_cast<float>(height);
+    D2D1_POINT_2F imageTargetOffset{0.0f, 0.0f};
+
+    context->DrawBitmap(blurredBitmap,
+                        D2D1::RectF(0.0f, 0.0f, widthF, heightF),
+                        1.0f,
+                        D2D1_INTERPOLATION_MODE_LINEAR,
+                        D2D1::RectF(0.0f, 0.0f, widthF, heightF));
+
+    int radius = g_popupBackdropOverlayLastRadius > 0
+                     ? g_popupBackdropOverlayLastRadius
+                     : static_cast<int>(std::lround(
+                           std::min(std::min(widthF, heightF) * 0.17f, 36.0f)));
+    radius = Clamp(radius, 1, std::max(1, std::min(width, height) / 2));
+    if (!EnsurePopupOverlayWgcLensDisplacementMap(width, height, radius)) {
+        return true;
+    }
+
+    winrt::com_ptr<ID2D1Effect> displacementEffect;
+    HRESULT hr = context->CreateEffect(CLSID_D2D1DisplacementMap,
+                                       displacementEffect.put());
+    if (FAILED(hr) || !displacementEffect) {
+        return true;
+    }
+
+    displacementEffect->SetInput(0, blurredBitmap);
+    displacementEffect->SetInput(1, g_popupOverlayWgcLensDisplacementMap.get());
+
+    float scale =
+        static_cast<float>(Clamp(std::min(width, height) * 0.55, 18.0, 58.0));
+    hr = displacementEffect->SetValue(D2D1_DISPLACEMENTMAP_PROP_SCALE, scale);
+    if (FAILED(hr)) {
+        return true;
+    }
+    hr = displacementEffect->SetValue(
+        D2D1_DISPLACEMENTMAP_PROP_X_CHANNEL_SELECT,
+        D2D1_CHANNEL_SELECTOR_R);
+    if (FAILED(hr)) {
+        return true;
+    }
+    hr = displacementEffect->SetValue(
+        D2D1_DISPLACEMENTMAP_PROP_Y_CHANNEL_SELECT,
+        D2D1_CHANNEL_SELECTOR_G);
+    if (FAILED(hr)) {
+        return true;
+    }
+
+    // Draw the displaced image over the already-rendered base. The map is
+    // neutral in the interior, so this is effectively a smooth edge/corner
+    // refraction without per-tile pixel boundaries.
+    context->DrawImage(displacementEffect.get(),
+                       &imageTargetOffset,
+                       nullptr,
+                       D2D1_INTERPOLATION_MODE_LINEAR,
+                       D2D1_COMPOSITE_MODE_SOURCE_OVER);
+    return true;
+}
+
 bool RecreatePopupOverlayWgcReadbackTextures(int widthPx, int heightPx) {
     if (!g_popupOverlayWgcD3dDevice || widthPx <= 0 || heightPx <= 0) {
         return false;
@@ -6701,6 +7623,7 @@ bool RecreatePopupOverlayWgcReadbackTextures(int widthPx, int heightPx) {
     g_popupOverlayWgcStagingTexture = std::move(stagingTexture);
     g_popupOverlayWgcTargetWidthPx = widthPx;
     g_popupOverlayWgcTargetHeightPx = heightPx;
+    ClearPopupOverlayWgcLensDisplacementMap();
     return true;
 }
 
@@ -6731,6 +7654,7 @@ bool EnsurePopupOverlayWgcDeviceResources(HWND hwnd, int widthPx, int heightPx) 
     g_popupOverlayWgcGraphicsDevice = nullptr;
     g_popupOverlayWgcRenderTexture = nullptr;
     g_popupOverlayWgcStagingTexture = nullptr;
+    ClearPopupOverlayWgcLensDisplacementMap();
     g_popupOverlayWgcD2dContext = nullptr;
     g_popupOverlayWgcD2dDevice = nullptr;
     g_popupOverlayWgcD2dFactory = nullptr;
@@ -6944,28 +7868,123 @@ void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
             return;
         }
 
+        int cornerRadiusPx = g_popupBackdropOverlayLastRadius > 0
+                                  ? g_popupBackdropOverlayLastRadius
+                                  : static_cast<int>(std::lround(kPopupUnifiedCornerRadius *
+                                                                 PopupDpiScale(g_expandedPopup)));
+
         winrt::com_ptr<ID2D1Effect> blurEffect;
         winrt::check_hresult(g_popupOverlayWgcD2dContext->CreateEffect(
             CLSID_D2D1GaussianBlur,
             blurEffect.put()));
         blurEffect->SetInput(0, intermediateBitmap.get());
         blurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION,
-                             PopupBackdropWgcBlurStdDev());
+                             PopupBackdropWgcEffectiveBlurStdDev());
         blurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_BORDER_MODE,
                              D2D1_BORDER_MODE_HARD);
 
-        // Step 2: render the blurred target-sized image to the GPU texture that
-        // will be read back into the layered window.
-        g_popupOverlayWgcD2dContext->SetTarget(targetBitmap.get());
+        winrt::com_ptr<ID2D1Bitmap1> blurredBitmap;
+        winrt::check_hresult(g_popupOverlayWgcD2dContext->CreateBitmap(
+            D2D1::SizeU(static_cast<UINT32>(targetWidth),
+                        static_cast<UINT32>(targetHeight)),
+            nullptr,
+            0,
+            &intermediateProps,
+            blurredBitmap.put()));
+
+        g_popupOverlayWgcD2dContext->SetTarget(blurredBitmap.get());
         g_popupOverlayWgcD2dContext->BeginDraw();
         g_popupOverlayWgcD2dContext->Clear(D2D1::ColorF(0.0f, 0.0f, 0.0f, 1.0f));
-        D2D1_POINT_2F blurTargetOffset = D2D1::Point2F(0.0f, 0.0f);
+        D2D1_POINT_2F imageTargetOffset = D2D1::Point2F(0.0f, 0.0f);
         g_popupOverlayWgcD2dContext->DrawImage(
             blurEffect.get(),
-            &blurTargetOffset,
+            &imageTargetOffset,
             nullptr,
             D2D1_INTERPOLATION_MODE_LINEAR,
             D2D1_COMPOSITE_MODE_SOURCE_COPY);
+        hr = g_popupOverlayWgcD2dContext->EndDraw();
+        if (FAILED(hr)) {
+            g_popupOverlayWgcLastHr = hr;
+            g_popupOverlayWgcDiagnosticHr = hr;
+            g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::RenderFailed;
+            ++g_popupOverlayWgcRenderFailCount;
+            Wh_Log(L"Island: overlay WGC blur pass EndDraw failed hr=0x%08X frames=%llu fails=%llu",
+                   static_cast<unsigned>(hr),
+                   static_cast<unsigned long long>(g_popupOverlayWgcFrameCount),
+                   static_cast<unsigned long long>(g_popupOverlayWgcRenderFailCount));
+            return;
+        }
+
+        ID2D1Bitmap1* refractionBitmap = intermediateBitmap.get();
+        winrt::com_ptr<ID2D1Bitmap1> lightlyBlurredRefractionBitmap;
+        if (IsLiquidGlassMaterial()) {
+            winrt::com_ptr<ID2D1Effect> refractionBlurEffect;
+            winrt::check_hresult(g_popupOverlayWgcD2dContext->CreateEffect(
+                CLSID_D2D1GaussianBlur,
+                refractionBlurEffect.put()));
+            refractionBlurEffect->SetInput(0, intermediateBitmap.get());
+            refractionBlurEffect->SetValue(
+                D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION,
+                PopupBackdropWgcLiquidRefractionBlurStdDev());
+            refractionBlurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_BORDER_MODE,
+                                           D2D1_BORDER_MODE_HARD);
+
+            winrt::check_hresult(g_popupOverlayWgcD2dContext->CreateBitmap(
+                D2D1::SizeU(static_cast<UINT32>(targetWidth),
+                            static_cast<UINT32>(targetHeight)),
+                nullptr,
+                0,
+                &intermediateProps,
+                lightlyBlurredRefractionBitmap.put()));
+
+            g_popupOverlayWgcD2dContext->SetTarget(lightlyBlurredRefractionBitmap.get());
+            g_popupOverlayWgcD2dContext->BeginDraw();
+            g_popupOverlayWgcD2dContext->Clear(D2D1::ColorF(0.0f, 0.0f, 0.0f, 1.0f));
+            g_popupOverlayWgcD2dContext->DrawImage(
+                refractionBlurEffect.get(),
+                &imageTargetOffset,
+                nullptr,
+                D2D1_INTERPOLATION_MODE_LINEAR,
+                D2D1_COMPOSITE_MODE_SOURCE_COPY);
+            hr = g_popupOverlayWgcD2dContext->EndDraw();
+            if (FAILED(hr)) {
+                g_popupOverlayWgcLastHr = hr;
+                g_popupOverlayWgcDiagnosticHr = hr;
+                g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::RenderFailed;
+                ++g_popupOverlayWgcRenderFailCount;
+                Wh_Log(L"Island: overlay WGC liquid refraction blur EndDraw failed hr=0x%08X frames=%llu fails=%llu",
+                       static_cast<unsigned>(hr),
+                       static_cast<unsigned long long>(g_popupOverlayWgcFrameCount),
+                       static_cast<unsigned long long>(g_popupOverlayWgcRenderFailCount));
+                return;
+            }
+
+            refractionBitmap = lightlyBlurredRefractionBitmap.get();
+        }
+
+        ID2D1Image* renderImage = blurredBitmap.get();
+        if (!IsLiquidGlassMaterial()) {
+            ClearPopupOverlayWgcLensDisplacementMap();
+        }
+
+        // Step 2: render the blurred/refracted target-sized image to the GPU
+        // texture that will be read back into the layered window.
+        g_popupOverlayWgcD2dContext->SetTarget(targetBitmap.get());
+        g_popupOverlayWgcD2dContext->BeginDraw();
+        g_popupOverlayWgcD2dContext->Clear(D2D1::ColorF(0.0f, 0.0f, 0.0f, 1.0f));
+        bool drewGpuLens = DrawLiquidGlassGpuLensWarp(g_popupOverlayWgcD2dContext.get(),
+                                                      blurredBitmap.get(),
+                                                      refractionBitmap,
+                                                      targetWidth,
+                                                      targetHeight);
+        if (!drewGpuLens) {
+            g_popupOverlayWgcD2dContext->DrawImage(
+                renderImage,
+                &imageTargetOffset,
+                nullptr,
+                D2D1_INTERPOLATION_MODE_LINEAR,
+                D2D1_COMPOSITE_MODE_SOURCE_COPY);
+        }
         hr = g_popupOverlayWgcD2dContext->EndDraw();
         if (FAILED(hr)) {
             g_popupOverlayWgcLastHr = hr;
@@ -7007,10 +8026,6 @@ void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
         bool dark = IsDarkModeApprox();
         double dim = dark ? 0.94 : 1.0;
         BYTE maxAlpha = PopupBackdropOverlayMaxAlpha();
-        int cornerRadiusPx = g_popupBackdropOverlayLastRadius > 0
-                                  ? g_popupBackdropOverlayLastRadius
-                                  : static_cast<int>(std::lround(kPopupUnifiedCornerRadius *
-                                                                 PopupDpiScale(g_expandedPopup)));
 
         BYTE const* srcBase = static_cast<BYTE const*>(mapped.pData);
         for (int y = 0; y < targetHeight; ++y) {
@@ -7157,6 +8172,29 @@ void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
     }
 }
 
+void ResetPopupOverlayWgcDeviceResourcesLocked() {
+    g_popupOverlayWgcSession = nullptr;
+    g_popupOverlayWgcFramePool = nullptr;
+    g_popupOverlayWgcFrameArrivedToken = {};
+    g_popupOverlayWgcFrameCallbackHooked = false;
+    g_popupOverlayWgcItem = nullptr;
+    g_popupOverlayWgcGraphicsDevice = nullptr;
+    g_popupOverlayWgcRenderTexture = nullptr;
+    g_popupOverlayWgcStagingTexture = nullptr;
+    ClearPopupOverlayWgcLensDisplacementMap();
+    g_popupOverlayWgcD2dContext = nullptr;
+    g_popupOverlayWgcD2dDevice = nullptr;
+    g_popupOverlayWgcD2dFactory = nullptr;
+    g_popupOverlayWgcDxgiDevice = nullptr;
+    g_popupOverlayWgcD3dContext = nullptr;
+    g_popupOverlayWgcD3dDevice = nullptr;
+    g_popupOverlayWgcTargetWidthPx = 0;
+    g_popupOverlayWgcTargetHeightPx = 0;
+    g_popupOverlayWgcMonitor = nullptr;
+    g_popupOverlayWgcCaptureRectPx = {LONG_MIN, LONG_MIN, LONG_MIN, LONG_MIN};
+    g_popupOverlayWgcMonitorRectPx = {};
+}
+
 void StopPopupOverlayWgcBackdrop() {
     capture::GraphicsCaptureSession sessionToClose{nullptr};
     capture::Direct3D11CaptureFramePool framePoolToClose{nullptr};
@@ -7171,9 +8209,7 @@ void StopPopupOverlayWgcBackdrop() {
         frameArrivedToken = g_popupOverlayWgcFrameArrivedToken;
         frameCallbackHooked = g_popupOverlayWgcFrameCallbackHooked;
         g_popupOverlayWgcFrameCallbackHooked = false;
-        g_popupOverlayWgcSession = nullptr;
-        g_popupOverlayWgcFramePool = nullptr;
-        g_popupOverlayWgcItem = nullptr;
+        ResetPopupOverlayWgcDeviceResourcesLocked();
         g_popupOverlayWgcHadFrame = false;
         g_popupOverlayWgcDiagnosticStartTime = {};
         g_popupOverlayWgcReadbackHadVisibleFrame = false;
@@ -7212,6 +8248,13 @@ void StopPopupOverlayWgcBackdrop() {
         }
     } catch (...) {
     }
+}
+
+void ReleasePopupOverlayWgcDeviceResources() {
+    StopPopupOverlayWgcBackdrop();
+
+    std::lock_guard lock(g_popupOverlayWgcMutex);
+    ResetPopupOverlayWgcDeviceResourcesLocked();
 }
 
 bool StartPopupOverlayWgcBackdrop(RECT const& captureRect,
@@ -7369,6 +8412,8 @@ bool StartPopupOverlayWgcBackdrop(RECT const& captureRect,
         Wh_Log(L"Island: overlay WGC state start failed hr=0x%08X",
                static_cast<unsigned>(g_popupOverlayWgcLastHr));
         g_popupOverlayWgcRunning = false;
+        g_popupOverlayWgcFrameCallbackHooked = false;
+        ResetPopupOverlayWgcDeviceResourcesLocked();
         return false;
     } catch (...) {
         g_popupOverlayWgcLastHr = E_FAIL;
@@ -7376,6 +8421,8 @@ bool StartPopupOverlayWgcBackdrop(RECT const& captureRect,
         g_popupOverlayWgcDiagnosticHr = E_FAIL;
         Wh_Log(L"Island: overlay WGC state start failed unknown");
         g_popupOverlayWgcRunning = false;
+        g_popupOverlayWgcFrameCallbackHooked = false;
+        ResetPopupOverlayWgcDeviceResourcesLocked();
         return false;
     }
 }
@@ -7395,6 +8442,7 @@ void UpdatePopupOverlayWgcCaptureRect(RECT const& captureRect) {
 }
 #else
 void StopPopupOverlayWgcBackdrop() {}
+void ReleasePopupOverlayWgcDeviceResources() {}
 bool StartPopupOverlayWgcBackdrop(RECT const&, int, int) {
     g_popupOverlayWgcDiagnosticState = PopupOverlayWgcDiagnosticState::StartSkipped;
     g_popupOverlayWgcDiagnosticHr = E_NOTIMPL;
@@ -7409,22 +8457,53 @@ BYTE PopupRoundedRectAlpha(int x, int y, int width, int height, int radius) {
     }
 
     radius = Clamp(radius, 1, std::max(1, std::min(width, height) / 2));
+
+    auto contains = [&](double px, double py) {
+        double left = 0.0;
+        double top = 0.0;
+        double right = static_cast<double>(width);
+        double bottom = static_cast<double>(height);
+        double r = static_cast<double>(radius);
+
+        double cx = Clamp(px, left + r, right - r);
+        double cy = Clamp(py, top + r, bottom - r);
+        double dx = px - cx;
+        double dy = py - cy;
+        return dx * dx + dy * dy <= r * r;
+    };
+
     double px = static_cast<double>(x) + 0.5;
     double py = static_cast<double>(y) + 0.5;
-    double left = 0.0;
-    double top = 0.0;
-    double right = static_cast<double>(width);
-    double bottom = static_cast<double>(height);
-    double r = static_cast<double>(radius);
+    if (contains(px, py)) {
+        double innerMargin = 0.85;
+        double left = static_cast<double>(radius) + innerMargin;
+        double right = static_cast<double>(width - radius) - innerMargin;
+        double top = static_cast<double>(radius) + innerMargin;
+        double bottom = static_cast<double>(height - radius) - innerMargin;
+        if ((px >= left && px <= right) || (py >= top && py <= bottom)) {
+            return 255;
+        }
+    }
 
-    double cx = Clamp(px, left + r, right - r);
-    double cy = Clamp(py, top + r, bottom - r);
-    double dx = px - cx;
-    double dy = py - cy;
-    double distance = std::sqrt(dx * dx + dy * dy);
-    double coverage = r - distance + 0.75;
-    coverage = Clamp(coverage, 0.0, 1.0);
-    return static_cast<BYTE>(std::lround(coverage * 255.0));
+    constexpr int kSamplesPerAxis = 4;
+    int coveredSamples = 0;
+    for (int sy = 0; sy < kSamplesPerAxis; ++sy) {
+        double sampleY = static_cast<double>(y) +
+                         (static_cast<double>(sy) + 0.5) /
+                             static_cast<double>(kSamplesPerAxis);
+        for (int sx = 0; sx < kSamplesPerAxis; ++sx) {
+            double sampleX = static_cast<double>(x) +
+                             (static_cast<double>(sx) + 0.5) /
+                                 static_cast<double>(kSamplesPerAxis);
+            if (contains(sampleX, sampleY)) {
+                ++coveredSamples;
+            }
+        }
+    }
+
+    return static_cast<BYTE>(std::lround(
+        255.0 * static_cast<double>(coveredSamples) /
+        static_cast<double>(kSamplesPerAxis * kSamplesPerAxis)));
 }
 
 void BoxBlurPbgraPixels(std::vector<BYTE>& pixels, int width, int height, int passes) {
@@ -7729,7 +8808,6 @@ bool UpdatePopupBackdropOverlayLayeredBlur(HWND hwnd,
             dst[3] = a;
         }
     }
-
     {
         std::lock_guard cacheLock(g_popupBackdropOverlayHandoffMutex);
         g_popupBackdropOverlayFallbackPixels = out;
@@ -7887,7 +8965,7 @@ void ClearPopupBackdropOverlayDwmBlurRegion();
 
 void HidePopupBackdropOverlayWindow() {
     if (g_popupBackdropOverlay) {
-        StopPopupOverlayWgcBackdrop();
+        ReleasePopupOverlayWgcDeviceResources();
         SetPopupWindowCaptureExclusion(g_popupBackdropOverlay, false);
         SetPopupBackdropOverlayNativeBlur(g_popupBackdropOverlay, false);
         ClearPopupBackdropOverlayDwmBlurRegion();
@@ -7898,6 +8976,9 @@ void HidePopupBackdropOverlayWindow() {
         g_popupBackdropOverlayLastWidth = 0;
         g_popupBackdropOverlayLastHeight = 0;
         g_popupBackdropOverlayLastRadius = 0;
+        g_popupLiquidGlassPanelRectPx = {};
+        g_popupLiquidGlassPanelRadiusPx = 0;
+        g_popupLiquidGlassPanelRectValid = false;
         g_popupOverlayWgcFallbackPainted = false;
         ClearPopupBackdropOverlayHandoffCache();
         if (g_expandedPopup) {
@@ -7989,6 +9070,35 @@ bool CalculatePopupBackdropOverlayRect(RECT& overlayRect, int& cornerRadiusPx) {
     double radiusDip = std::max(1.0, kPopupUnifiedCornerRadius + kPopupOverlayRadiusAdjustDip);
     int desiredRadius = static_cast<int>(std::lround(radiusDip * dpiScale));
     cornerRadiusPx = Clamp(desiredRadius, 1, std::max(1, std::min(width, height) / 2));
+
+    RECT currentCardDip{
+        LerpInt(sourceRect.left, targetCard.left, progress),
+        LerpInt(sourceRect.top, targetCard.top, progress),
+        LerpInt(sourceRect.right, targetCard.right, progress),
+        LerpInt(sourceRect.bottom, targetCard.bottom, progress),
+    };
+    RECT panelRect{
+        static_cast<LONG>(std::lround(currentCardDip.left * dpiScale)) -
+            static_cast<LONG>(std::lround(currentDip.left * dpiScale)),
+        static_cast<LONG>(std::lround(currentCardDip.top * dpiScale)) -
+            static_cast<LONG>(std::lround(currentDip.top * dpiScale)),
+        static_cast<LONG>(std::lround(currentCardDip.right * dpiScale)) -
+            static_cast<LONG>(std::lround(currentDip.left * dpiScale)),
+        static_cast<LONG>(std::lround(currentCardDip.bottom * dpiScale)) -
+            static_cast<LONG>(std::lround(currentDip.top * dpiScale)),
+    };
+    panelRect.left = Clamp<LONG>(panelRect.left, 0L, static_cast<LONG>(width));
+    panelRect.top = Clamp<LONG>(panelRect.top, 0L, static_cast<LONG>(height));
+    panelRect.right = Clamp<LONG>(panelRect.right, 0L, static_cast<LONG>(width));
+    panelRect.bottom = Clamp<LONG>(panelRect.bottom, 0L, static_cast<LONG>(height));
+    int panelWidth = static_cast<int>(panelRect.right - panelRect.left);
+    int panelHeight = static_cast<int>(panelRect.bottom - panelRect.top);
+    g_popupLiquidGlassPanelRectPx = panelRect;
+    g_popupLiquidGlassPanelRadiusPx = Clamp(
+        desiredRadius,
+        1,
+        std::max(1, std::min(panelWidth, panelHeight) / 2));
+    g_popupLiquidGlassPanelRectValid = panelWidth > 4 && panelHeight > 4;
     return true;
 }
 
@@ -7997,16 +9107,10 @@ void ApplyPopupBackdropOverlayRegion(int width, int height, int cornerRadiusPx) 
         return;
     }
 
-    HRGN region = CreateRoundRectRgn(0, 0, width + 1, height + 1,
-                                     cornerRadiusPx * 2, cornerRadiusPx * 2);
-    if (!region) {
-        return;
-    }
-
-    // SetWindowRgn takes ownership on success. If it fails, we must release it.
-    if (!SetWindowRgn(g_popupBackdropOverlay, region, FALSE)) {
-        DeleteObject(region);
-    }
+    // The layered overlay already carries a per-pixel rounded-rect alpha mask.
+    // Keeping an additional Win32 HRGN here clips with a hard, non-AA boundary
+    // and can create visible corner seams in the refractive material.
+    SetWindowRgn(g_popupBackdropOverlay, nullptr, FALSE);
 }
 
 void ApplyPopupBackdropOverlayDwmBlurRegion(int width, int height, int cornerRadiusPx) {
@@ -8318,6 +9422,8 @@ void DestroyExpandedPopup() {
     g_popupXamlBackdropCoverFade = nullptr;
     g_popupXamlBackdropCover = nullptr;
     g_popupXamlBackdropTint = nullptr;
+    g_popupXamlBackdropSurfaceHighlight = nullptr;
+    g_popupXamlBackdropRimHighlight = nullptr;
     g_popupXamlPanelCoverFrame = nullptr;
     g_popupXamlPanelCoverScale = nullptr;
     g_popupXamlPanelCoverTranslate = nullptr;
@@ -8335,6 +9441,14 @@ void DestroyExpandedPopup() {
     g_popupXamlArtistHost = nullptr;
     g_popupXamlOutgoingTitleHost = nullptr;
     g_popupXamlOutgoingArtistHost = nullptr;
+    g_popupXamlTitleLeftFade = nullptr;
+    g_popupXamlTitleRightFade = nullptr;
+    g_popupXamlArtistLeftFade = nullptr;
+    g_popupXamlArtistRightFade = nullptr;
+    g_popupXamlOutgoingTitleLeftFade = nullptr;
+    g_popupXamlOutgoingTitleRightFade = nullptr;
+    g_popupXamlOutgoingArtistLeftFade = nullptr;
+    g_popupXamlOutgoingArtistRightFade = nullptr;
     g_popupXamlTitle = nullptr;
     g_popupXamlArtist = nullptr;
     g_popupXamlOutgoingTitle = nullptr;
@@ -8358,7 +9472,6 @@ void DestroyExpandedPopup() {
     g_popupXamlProgressCoreBlurLayers.clear();
     g_popupXamlProgressGlowCore = nullptr;
     g_popupXamlControls = nullptr;
-    g_popupXamlControlsScale = nullptr;
     g_popupXamlThumbnailHash = UINT64_MAX;
     g_popupXamlBackdropCoverEnabled = false;
     g_popupAccentThumbnailHash = UINT64_MAX;
@@ -8523,6 +9636,10 @@ void ApplyExpandedState() {
                               g_layout.artCornerRadius, g_layout.artCornerRadius});
         }
     }
+    if (auto artShellFe = FindChildByName(g_playerGrid, L"Island_ArtShell")) {
+        artShellFe.Width(g_layout.artSize);
+        artShellFe.Height(g_layout.artSize);
+    }
     if (auto artHostFe = FindChildByName(g_playerGrid, L"Island_ArtHost")) {
         artHostFe.Width(g_layout.artSize);
         artHostFe.Height(g_layout.artSize);
@@ -8547,12 +9664,8 @@ void ApplyExpandedState() {
         fadeFe.Margin({-1, -1, -1, -1});
     }
     if (auto strokeFe = FindChildByName(g_playerGrid, L"Island_ArtStroke")) {
-        strokeFe.Width(g_layout.artSize);
-        strokeFe.Height(g_layout.artSize);
         if (auto stroke = strokeFe.try_as<Border>()) {
-            stroke.CornerRadius({g_layout.artCornerRadius, g_layout.artCornerRadius,
-                                 g_layout.artCornerRadius, g_layout.artCornerRadius});
-            stroke.BorderBrush(IslandBorderBrush());
+            ConfigureCompactAlbumArtStroke(stroke);
         }
     }
 
@@ -8586,6 +9699,12 @@ void StartExpandRenderLoop(bool expanded) {
 bool InjectIslandGrid();
 
 void MediaThreadProc() {
+    struct MediaThreadExitGuard {
+        ~MediaThreadExitGuard() {
+            g_mediaThreadExited = true;
+        }
+    } mediaThreadExitGuard;
+
     bool apartmentInitialized = false;
     try {
         winrt::init_apartment(winrt::apartment_type::multi_threaded);
@@ -8795,10 +9914,12 @@ void StartMediaThread() {
     if (g_mediaThreadRunning.exchange(true)) {
         return;
     }
+    g_mediaThreadExited = false;
     try {
         g_mediaThread = new std::thread(MediaThreadProc);
     } catch (...) {
         g_mediaThreadRunning = false;
+        g_mediaThreadExited = true;
         g_mediaThread = nullptr;
         Wh_Log(L"Island: failed to start media thread");
     }
@@ -8811,7 +9932,20 @@ void StopMediaThread() {
     if (g_mediaThread) {
         if (g_mediaThread->joinable()) {
             if (g_mediaThread->get_id() != std::this_thread::get_id()) {
-                g_mediaThread->join();
+                auto deadline =
+                    std::chrono::steady_clock::now() +
+                    kMediaThreadStopTimeout;
+                while (!g_mediaThreadExited.load() &&
+                       std::chrono::steady_clock::now() < deadline) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+                }
+
+                if (g_mediaThreadExited.load()) {
+                    g_mediaThread->join();
+                } else {
+                    Wh_Log(L"Island: media thread stop timed out; detaching");
+                    g_mediaThread->detach();
+                }
             } else {
                 g_mediaThread->detach();
             }
@@ -8845,7 +9979,7 @@ Button MakeMediaButton(const wchar_t* name, const wchar_t* glyph, void (*onClick
     button.Padding({0, 0, 0, 0});
     button.Margin({2, 0, 2, 0});
     button.Background(Brush(Color(0x18, 0xFF, 0xFF, 0xFF)));
-    button.BorderBrush(Brush(Color(0x20, 0xFF, 0xFF, 0xFF)));
+    button.BorderBrush(CompactPlaybackControlStrokeBrush());
     button.BorderThickness({1, 1, 1, 1});
     button.CornerRadius({kPopupG2ButtonCornerRadius,
                          kPopupG2ButtonCornerRadius,
@@ -8871,8 +10005,7 @@ void UpdateButtonTheme(const wchar_t* name) {
         if (auto button = buttonFe.try_as<Button>()) {
             button.Background(Brush(dark ? Color(0x18, 0xFF, 0xFF, 0xFF)
                                          : Color(0x14, 0x00, 0x00, 0x00)));
-            button.BorderBrush(Brush(dark ? Color(0x20, 0xFF, 0xFF, 0xFF)
-                                          : Color(0x16, 0x00, 0x00, 0x00)));
+            button.BorderBrush(CompactPlaybackControlStrokeBrush());
             if (auto icon = button.Content().try_as<TextBlock>()) {
                 icon.Foreground(Brush(dark ? Color(0xF2, 0xFF, 0xFF, 0xFF)
                                            : Color(0xF2, 0x18, 0x18, 0x1B)));
@@ -8928,6 +10061,12 @@ void UpdateThemeVisuals() {
     }
     if (g_compactTextRightFade) {
         g_compactTextRightFade.Background(CompactTextEdgeFadeBrush(false));
+    }
+
+    if (auto strokeFe = FindChildByName(g_playerGrid, L"Island_ArtStroke")) {
+        if (auto stroke = strokeFe.try_as<Border>()) {
+            ConfigureCompactAlbumArtStroke(stroke);
+        }
     }
 
     UpdateButtonTheme(L"Island_Prev");
@@ -9119,11 +10258,17 @@ Grid BuildIslandGrid() {
     art.BorderBrush(Brush(Color(0x00, 0x00, 0x00, 0x00)));
     art.VerticalAlignment(VerticalAlignment::Center);
 
+    Grid artShell;
+    artShell.Name(L"Island_ArtShell");
+    artShell.Width(g_layout.artSize);
+    artShell.Height(g_layout.artSize);
+
     Grid artHost;
     artHost.Name(L"Island_ArtHost");
     artHost.Width(g_layout.artSize);
     artHost.Height(g_layout.artSize);
     ApplyElementClip(artHost, g_layout.artSize, g_layout.artSize);
+    artShell.Children().Append(artHost);
 
     Border artPlaceholder;
     artPlaceholder.Name(L"Island_ArtPlaceholder");
@@ -9155,16 +10300,10 @@ Grid BuildIslandGrid() {
 
     Border artStroke;
     artStroke.Name(L"Island_ArtStroke");
-    artStroke.Width(g_layout.artSize);
-    artStroke.Height(g_layout.artSize);
-    artStroke.CornerRadius({g_layout.artCornerRadius, g_layout.artCornerRadius, g_layout.artCornerRadius, g_layout.artCornerRadius});
-    artStroke.Background(Brush(Color(0x00, 0x00, 0x00, 0x00)));
-    artStroke.BorderThickness({1, 1, 1, 1});
-    artStroke.BorderBrush(IslandBorderBrush());
-    artStroke.IsHitTestVisible(false);
-    artHost.Children().Append(artStroke);
+    ConfigureCompactAlbumArtStroke(artStroke);
+    artShell.Children().Append(artStroke);
 
-    art.Child(artHost);
+    art.Child(artShell);
     g_compactAlbumArtImage = artImage;
     g_compactAlbumArtFade = artFade;
 
@@ -9266,21 +10405,29 @@ Grid BuildIslandGrid() {
         L"Island_Prev", L"\uE892",
         [] {
             RunMediaCommand([](gsm::GlobalSystemMediaTransportControlsSession const& s) {
-                s.TrySkipPreviousAsync().get();
+                NoteMediaNavigationDirection(-1);
+                GetAsyncResultWithTimeout(s.TrySkipPreviousAsync(),
+                                           kMediaCommandAsyncTimeout,
+                                           L"TrySkipPreviousAsync");
             });
         }));
     details.Children().Append(MakeMediaButton(
         L"Island_Play", L"\uE768",
         [] {
             RunMediaCommand([](gsm::GlobalSystemMediaTransportControlsSession const& s) {
-                s.TryTogglePlayPauseAsync().get();
+                GetAsyncResultWithTimeout(s.TryTogglePlayPauseAsync(),
+                                           kMediaCommandAsyncTimeout,
+                                           L"TryTogglePlayPauseAsync");
             });
         }));
     details.Children().Append(MakeMediaButton(
         L"Island_Next", L"\uE893",
         [] {
             RunMediaCommand([](gsm::GlobalSystemMediaTransportControlsSession const& s) {
-                s.TrySkipNextAsync().get();
+                NoteMediaNavigationDirection(1);
+                GetAsyncResultWithTimeout(s.TrySkipNextAsync(),
+                                           kMediaCommandAsyncTimeout,
+                                           L"TrySkipNextAsync");
             });
         }));
 
@@ -9488,9 +10635,13 @@ void UpdatePlayerContents() {
         visualThumbnailBytes.clear();
     }
 
-    std::vector<uint8_t> displayThumbnailBytes = CreateDisplayAlbumCoverBytes(visualThumbnailBytes);
-    bool useGeneratedBlurCover = ShouldUseAbstractArtworkForDisplay(visualThumbnailBytes) &&
-                                 !displayThumbnailBytes.empty();
+    std::vector<uint8_t> displayThumbnailBytes =
+        CreateDisplayAlbumCoverBytes(visualThumbnailBytes,
+                                     state.sourceAppUserModelId);
+    bool useGeneratedBlurCover =
+        LooksLikeBrowserMediaSource(state.sourceAppUserModelId) &&
+        ShouldUseAbstractArtworkForDisplay(visualThumbnailBytes) &&
+        !displayThumbnailBytes.empty();
     std::vector<uint8_t> popupBlurSourceBytes =
         useGeneratedBlurCover ? displayThumbnailBytes : visualThumbnailBytes;
 
@@ -9504,7 +10655,13 @@ void UpdatePlayerContents() {
         streams::InMemoryRandomAccessStream stream;
         streams::DataWriter writer(stream);
         writer.WriteBytes(winrt::array_view<const uint8_t>(bytes));
-        writer.StoreAsync().get();
+        try {
+            GetAsyncResultWithTimeout(writer.StoreAsync(),
+                                      kUiLocalAsyncTimeout,
+                                      L"DataWriter.StoreAsync");
+        } catch (...) {
+            return imaging::BitmapImage{nullptr};
+        }
         writer.DetachStream();
         stream.Seek(0);
         bitmap.SetSourceAsync(stream);
@@ -9667,12 +10824,15 @@ void UpdatePlayerContents() {
             if (canAnimatePopupText) {
                 g_popupXamlOutgoingTitle.Text(g_popupXamlTitle.Text());
                 g_popupXamlOutgoingArtist.Text(g_popupXamlArtist.Text());
+                int navigationDirection = ConsumeRecentMediaNavigationDirection();
+                g_popupTextTransitionDirection = navigationDirection < 0 ? -1 : 1;
+                double popupTextStartOffset = 30.0 * static_cast<double>(g_popupTextTransitionDirection);
                 if (g_popupXamlOutgoingTitleTranslate) g_popupXamlOutgoingTitleTranslate.X(0.0);
                 if (g_popupXamlOutgoingArtistTranslate) g_popupXamlOutgoingArtistTranslate.X(0.0);
                 g_popupXamlOutgoingTitle.Opacity(g_popupTextBaseOpacity);
                 g_popupXamlOutgoingArtist.Opacity(g_popupTextBaseOpacity);
-                if (g_popupXamlTitleTranslate) g_popupXamlTitleTranslate.X(30.0);
-                if (g_popupXamlArtistTranslate) g_popupXamlArtistTranslate.X(30.0);
+                if (g_popupXamlTitleTranslate) g_popupXamlTitleTranslate.X(popupTextStartOffset);
+                if (g_popupXamlArtistTranslate) g_popupXamlArtistTranslate.X(popupTextStartOffset);
                 g_popupXamlTitle.Opacity(0.0);
                 g_popupXamlArtist.Opacity(0.0);
                 g_popupTextTransitionActive = true;
@@ -9941,6 +11101,10 @@ void RemoveIslandGrid() {
     g_compactOutgoingArtistText = nullptr;
     g_compactTitleTranslate = nullptr;
     g_compactArtistTranslate = nullptr;
+    g_compactOutgoingTitleTranslate = nullptr;
+    g_compactOutgoingArtistTranslate = nullptr;
+    g_compactAlbumArtImage = nullptr;
+    g_compactAlbumArtFade = nullptr;
     g_compactProgress = nullptr;
     g_compactTextEdgeFadeActive = false;
     g_compactTextInitialized = false;
@@ -10154,6 +11318,7 @@ void Wh_ModUninit() {
         return;
     }
     g_modActive = false;
+    ReleasePopupOverlayWgcDeviceResources();
     StopMediaThread();
 
     HWND hwnd = g_taskbarWnd && IsWindow(g_taskbarWnd)

--- a/mods/island-media-controls.wh.cpp
+++ b/mods/island-media-controls.wh.cpp
@@ -2,7 +2,7 @@
 // @id              island-media-controls
 // @name            Island Media Controls
 // @description     Dynamic island-like media controls for the Windows 11 taskbar.
-// @version         0.9.136
+// @version         0.9.137
 // @author          usho
 // @github          https://github.com/usho-lear
 // @license         MIT
@@ -131,6 +131,9 @@ it fits naturally alongside your taskbar and system tray items.
   - BackdropWgcBlurStdDev: 18
     $name: Backdrop WGC blur strength
     $description: Gaussian blur standard deviation for live WGC blur.
+  - AllowScreenCapture: false
+    $name: Allow screen capture of expanded popup
+    $description: Makes the expanded popup visible to screen recorders. This is useful for recording Liquid glass, but may let the live backdrop capture the popup itself on some systems.
 */
 // ==/WindhawkModSettings==
 
@@ -306,6 +309,7 @@ struct Settings {
     int backdropFallbackBlurPasses = 5;
     int backdropFallbackCaptureScale = 2;
     int backdropWgcBlurStdDev = 18;
+    bool allowScreenCapture = false;
 };
 
 struct RuntimeLayout {
@@ -1176,6 +1180,8 @@ Settings ReadSettings() {
         Clamp(Wh_GetIntSetting(L"Main.BackdropFallbackCaptureScale"), 2, 3);
     settings.backdropWgcBlurStdDev =
         Clamp(Wh_GetIntSetting(L"Main.BackdropWgcBlurStdDev"), 14, 22);
+    settings.allowScreenCapture =
+        Wh_GetIntSetting(L"Main.AllowScreenCapture") != 0;
     return settings;
 }
 
@@ -8343,10 +8349,11 @@ bool StartPopupOverlayWgcBackdrop(RECT const& captureRect,
     g_popupOverlayWgcCreateItemFailed = false;
 
     // Keep the existing blurred fallback visible until the first WGC frame is
-    // ready. Exclude the popup/overlay from capture first; then skip a few WGC
-    // frames to let DWM apply the exclusion before we replace the fallback.
-    SetWindowDisplayAffinity(g_expandedPopup, WDA_EXCLUDEFROMCAPTURE);
-    SetWindowDisplayAffinity(g_popupBackdropOverlay, WDA_EXCLUDEFROMCAPTURE);
+    // ready. Exclude the overlay from capture first; optionally keep the popup
+    // capturable so users can record the expanded material effect.
+    SetPopupWindowCaptureExclusion(g_expandedPopup,
+                                   !g_settings.allowScreenCapture);
+    SetPopupWindowCaptureExclusion(g_popupBackdropOverlay, true);
     DwmFlush();
 
     std::lock_guard lock(g_popupOverlayWgcMutex);

--- a/mods/island-media-controls.wh.cpp
+++ b/mods/island-media-controls.wh.cpp
@@ -553,23 +553,23 @@ int g_popupOverlayWgcTargetHeightPx = 0;
 HMONITOR g_popupOverlayWgcMonitor = nullptr;
 HRESULT g_popupOverlayWgcLastHr = S_OK;
 
-winrt::com_ptr<ID3D11Device> g_popupOverlayWgcD3dDevice;
-winrt::com_ptr<ID3D11DeviceContext> g_popupOverlayWgcD3dContext;
-winrt::com_ptr<IDXGIDevice> g_popupOverlayWgcDxgiDevice;
-winrt::com_ptr<ID3D11Texture2D> g_popupOverlayWgcRenderTexture;
-winrt::com_ptr<ID3D11Texture2D> g_popupOverlayWgcStagingTexture;
-winrt::com_ptr<ID2D1Factory1> g_popupOverlayWgcD2dFactory;
-winrt::com_ptr<ID2D1Device> g_popupOverlayWgcD2dDevice;
-winrt::com_ptr<ID2D1DeviceContext> g_popupOverlayWgcD2dContext;
-winrt::com_ptr<ID2D1Bitmap1> g_popupOverlayWgcLensDisplacementMap;
+[[clang::no_destroy]] winrt::com_ptr<ID3D11Device> g_popupOverlayWgcD3dDevice;
+[[clang::no_destroy]] winrt::com_ptr<ID3D11DeviceContext> g_popupOverlayWgcD3dContext;
+[[clang::no_destroy]] winrt::com_ptr<IDXGIDevice> g_popupOverlayWgcDxgiDevice;
+[[clang::no_destroy]] winrt::com_ptr<ID3D11Texture2D> g_popupOverlayWgcRenderTexture;
+[[clang::no_destroy]] winrt::com_ptr<ID3D11Texture2D> g_popupOverlayWgcStagingTexture;
+[[clang::no_destroy]] winrt::com_ptr<ID2D1Factory1> g_popupOverlayWgcD2dFactory;
+[[clang::no_destroy]] winrt::com_ptr<ID2D1Device> g_popupOverlayWgcD2dDevice;
+[[clang::no_destroy]] winrt::com_ptr<ID2D1DeviceContext> g_popupOverlayWgcD2dContext;
+[[clang::no_destroy]] winrt::com_ptr<ID2D1Bitmap1> g_popupOverlayWgcLensDisplacementMap;
 int g_popupOverlayWgcLensMapWidth = 0;
 int g_popupOverlayWgcLensMapHeight = 0;
 int g_popupOverlayWgcLensMapRadius = 0;
 
-direct3d11::IDirect3DDevice g_popupOverlayWgcGraphicsDevice{nullptr};
-capture::GraphicsCaptureItem g_popupOverlayWgcItem{nullptr};
-capture::Direct3D11CaptureFramePool g_popupOverlayWgcFramePool{nullptr};
-capture::GraphicsCaptureSession g_popupOverlayWgcSession{nullptr};
+[[clang::no_destroy]] direct3d11::IDirect3DDevice g_popupOverlayWgcGraphicsDevice{nullptr};
+[[clang::no_destroy]] capture::GraphicsCaptureItem g_popupOverlayWgcItem{nullptr};
+[[clang::no_destroy]] capture::Direct3D11CaptureFramePool g_popupOverlayWgcFramePool{nullptr};
+[[clang::no_destroy]] capture::GraphicsCaptureSession g_popupOverlayWgcSession{nullptr};
 winrt::event_token g_popupOverlayWgcFrameArrivedToken{};
 bool g_popupOverlayWgcHadFrame = false;
 std::chrono::steady_clock::time_point g_popupOverlayWgcDiagnosticStartTime{};
@@ -1139,11 +1139,11 @@ constexpr wchar_t kMigrateMicaLikeMaterialValue[] =
 
 void ApplySettingsMigrations(Settings* settings) {
     int migratedVersion = Wh_GetIntValue(L"SettingsMigrationVersion", 0);
-    if (migratedVersion < 1) {
+    if (migratedVersion < kSettingsMigrationVersion) {
         if (settings->material == L"mica_like") {
             Wh_SetIntValue(kMigrateMicaLikeMaterialValue, 1);
         }
-        Wh_SetIntValue(L"SettingsMigrationVersion", 1);
+        Wh_SetIntValue(L"SettingsMigrationVersion", kSettingsMigrationVersion);
     }
 
     if (Wh_GetIntValue(kMigrateMicaLikeMaterialValue, 0)) {
@@ -7868,8 +7868,6 @@ bool EnsurePopupOverlayWgcDeviceResources(HWND hwnd, int widthPx, int heightPx) 
     return RecreatePopupOverlayWgcReadbackTextures(widthPx, heightPx);
 }
 
-void RenderPopupOverlayWgcDiagnosticFrame() {}
-
 void RenderPopupOverlayWgcFrame(capture::Direct3D11CaptureFrame const& frame) {
     g_popupOverlayWgcHadFrame = true;
     ++g_popupOverlayWgcFrameCount;
@@ -9153,31 +9151,34 @@ void PaintPopupBackdropOverlay(HWND hwnd) {
 }
 
 LRESULT CALLBACK PopupBackdropOverlayWndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {
-    switch (message) {
-        case WM_ERASEBKGND:
-            return 1;
-        case WM_NCHITTEST:
-            return HTTRANSPARENT;
-        case kPopupBackdropOverlayPresentMessage:
-            PresentPopupOverlayWgcFrame(hwnd);
-            return 0;
-        case WM_TIMER:
-            if (wParam == kPopupBackdropOverlayTimerId) {
-                UpdatePopupBackdropOverlayWindow();
+    try {
+        switch (message) {
+            case WM_ERASEBKGND:
+                return 1;
+            case WM_NCHITTEST:
+                return HTTRANSPARENT;
+            case kPopupBackdropOverlayPresentMessage:
+                PresentPopupOverlayWgcFrame(hwnd);
                 return 0;
-            }
-            break;
-        case WM_PAINT:
-            PaintPopupBackdropOverlay(hwnd);
-            return 0;
-        case WM_DESTROY:
-            ClearPendingPopupOverlayWgcFrame();
-            KillTimer(hwnd, kPopupBackdropOverlayTimerId);
-            SetPopupWindowCaptureExclusion(hwnd, false);
-            if (g_popupBackdropOverlay == hwnd) {
-                g_popupBackdropOverlay = nullptr;
-            }
-            return 0;
+            case WM_TIMER:
+                if (wParam == kPopupBackdropOverlayTimerId) {
+                    UpdatePopupBackdropOverlayWindow();
+                    return 0;
+                }
+                break;
+            case WM_PAINT:
+                PaintPopupBackdropOverlay(hwnd);
+                return 0;
+            case WM_DESTROY:
+                ClearPendingPopupOverlayWgcFrame();
+                KillTimer(hwnd, kPopupBackdropOverlayTimerId);
+                SetPopupWindowCaptureExclusion(hwnd, false);
+                if (g_popupBackdropOverlay == hwnd) {
+                    g_popupBackdropOverlay = nullptr;
+                }
+                return 0;
+        }
+    } catch (...) {
     }
     return DefWindowProcW(hwnd, message, wParam, lParam);
 }


### PR DESCRIPTION
## Summary

Updates Island Media Controls to version 0.9.146. This revision expands the original Acrylic and lifecycle work with a GPU-based Liquid Glass material, refined media transitions, recording-friendly static previews, improved browser media handling, and the latest maintainer-requested threading, DPI, migration, and performance fixes.

## Changelog

### Materials and defaults

- Changed the default material for new installs from Mica-like to Acrylic.
- Added a one-time migration for users who still had the old Mica-like default.
- Restored Mica-like as a normal explicit choice after migration.
- Fixed the light-mode Mica-like expanded background becoming almost pure white from a duplicated tint layer.
- Kept compact and expanded material colors consistent across light and dark themes.

### Liquid Glass and Acrylic rendering

- Added the Liquid Glass material option.
- Added GPU displacement-map refraction with a rounded-rectangle SDF so edge and corner refraction follows the component shape.
- Added a narrow high-index rim and a wider, smooth interior falloff into the center.
- Increased sampling quality and removed the earlier tiled/nine-slice appearance.
- Added theme-aware edge highlights, reduced dark-mode tint, and independently tuned blur for the main surface and playback card.
- Applied matching material treatment to the expanded playback controls.
- Retained the live WGC/D3D/D2D Acrylic backdrop and fallback blur handoff.

### Recording support

- Added an optional screen-capture setting for the expanded popup.
- Added a capturable static blurred backdrop for Acrylic and Liquid Glass recording.
- Avoided recursive self-capture while keeping the blur layer visible to recorders.
- Added dark/light Mica-like, Acrylic, and Liquid Glass screenshots to the mod details page.

### Media transitions and presentation

- Added smoother directional title and artist transitions.
- Added edge-aware fading that appears as text moves beneath the artwork or popup boundary.
- Reversed expanded transition direction when navigating to the previous track.
- Removed transition-end flicker, persistent fade overlays, black blocks, and abrupt clipping.
- Improved compact and expanded text clipping consistency.

### Media and browser session handling

- Improved browser/live-media artwork identity tracking.
- Prevented stale thumbnails from leaking between browser sessions.
- Added bounded waits around media properties, thumbnail reads, transport commands, and manager requests.
- Kept event-driven GSMTC refreshes with a low-frequency provider compatibility fallback.
- Preserved Apple Music seeking and transport-control compatibility.

### Lifecycle and unload safety

- Released GSMTC manager references before uninitializing the WinRT apartment.
- Explicitly released WGC D3D/DXGI/D2D and WinRT capture resources before DLL unload.
- Added lifecycle guards around injection, callbacks, settings changes, and teardown.
- Avoided indefinite unload joins and lost media-thread wakeups.
- Improved recompilation and reload behavior so Explorer no longer needs to be restarted after each build.

### Threading, performance, and DPI review fixes

- Removed the dead WGC availability macro and unreachable stub implementation.
- Moved overlay window presentation to its owning UI thread through an asynchronous latest-frame queue.
- Kept cross-thread WGC rendering under its resource mutex without holding that lock across `UpdateLayeredWindow`, `ShowWindow`, or capture-affinity calls.
- Replaced the permanent per-frame taskbar layout monitor with a 600 ms Win32 timer.
- Created the popup on the taskbar monitor before initializing XAML and added `WM_DPICHANGED` handling for mixed-DPI multi-monitor setups.
- Switched the D2D factory to multi-threaded mode.
- Allocated the readback buffer before mapping the staging texture and explicitly closed consumed WGC frames.
- Removed the duplicate Windows.Foundation include and the dead popup controls scale state.

### Details page

- Added a top-level What's new section.
- Added a three-material dark/light comparison table.
- Preserved the original overview, animated previews, and feature list.

## Validation

- `D:\Windhawk\Compiler\bin\clang++.exe @D:\Windhawk\Compiler\compile_flags.txt -ID:\Windhawk\Compiler\include -fsyntax-only mods\island-media-controls.wh.cpp`
- `git diff --check -- mods/island-media-controls.wh.cpp`
- Unicode format-control character scan: 0 matches.
- All six public material-preview URLs return `200 image/png` with the expected content lengths.