### PR TITLE
Add mod to fix checkbox background in conflict dialog

### DIFF
--- a/mods/fix-conflict-dialog-checkbox-bg.wh.cpp
+++ b/mods/fix-conflict-dialog-checkbox-bg.wh.cpp
@@ -2,11 +2,11 @@
 // @id              fix-conflict-dialog-checkbox-bg
 // @name            Fix File Conflict Dialog Checkbox Background
 // @description     Fixes black background on the checkbox in the file conflict dialog (Classic Theme)
-// @version         1.0.0
+// @version         1.0
 // @author          Anixx
 // @github          https://github.com/Anixx
 // @include         *
-// @compilerOptions -lgdi32
+// @compilerOptions -lgdi32 -lcomctl32 -luxtheme
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -16,7 +16,7 @@
 Fixes the black background of the "Apply to all conflicts" checkbox
 in the Explorer file copy/move conflict dialog when Windows Classic theme is active.
 
-This bug has appeared in recent cumulative uptates.
+This bug has appeared in recent cumulative updates.
 
 Before:
 
@@ -24,14 +24,15 @@ Before:
 
 After:
 
-![before](https://i.imgur.com/pK0Z0u8.png)
+![after](https://i.imgur.com/pK0Z0u8.png)
 
 */
 // ==/WindhawkModReadme==
 
-#include <windows.h>
+#include <uxtheme.h>
 #include <vector>
 #include <mutex>
+#include <windhawk_utils.h>
 
 using CreateWindowExW_t = HWND(WINAPI*)(DWORD, LPCWSTR, LPCWSTR, DWORD, int, int, int, int, HWND, HMENU, HINSTANCE, LPVOID);
 static CreateWindowExW_t pOriginalCreateWindowExW = nullptr;
@@ -44,39 +45,41 @@ static bool CheckHierarchy(HWND hWndParent)
     // Button -> CtrlNotifySink -> DirectUIHWND -> #32770
     wchar_t cls[64];
 
-    GetClassNameW(hWndParent, cls, sizeof(cls) / sizeof(wchar_t));
+    GetClassNameW(hWndParent, cls, ARRAYSIZE(cls));
     if (wcscmp(cls, L"CtrlNotifySink"))
         return false;
 
     HWND hLevel2 = GetParent(hWndParent);
     if (!hLevel2)
         return false;
-    GetClassNameW(hLevel2, cls, sizeof(cls) / sizeof(wchar_t));
+    GetClassNameW(hLevel2, cls, ARRAYSIZE(cls));
     if (wcscmp(cls, L"DirectUIHWND"))
         return false;
 
     HWND hLevel3 = GetParent(hLevel2);
     if (!hLevel3)
         return false;
-    GetClassNameW(hLevel3, cls, sizeof(cls) / sizeof(wchar_t));
+    GetClassNameW(hLevel3, cls, ARRAYSIZE(cls));
     if (wcscmp(cls, L"#32770"))
         return false;
 
     return true;
 }
 
-static LRESULT CALLBACK ParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK ParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam,
+                                           LPARAM lParam, DWORD_PTR dwRefData)
 {
     if (uMsg == WM_CTLCOLORBTN || uMsg == WM_CTLCOLORSTATIC)
     {
         HWND hCtrl = (HWND)lParam;
-        char szClass[32];
-        GetClassNameA(hCtrl, szClass, sizeof(szClass));
+        wchar_t szClass[32];
+        GetClassNameW(hCtrl, szClass, ARRAYSIZE(szClass));
 
-        if (_stricmp(szClass, "Button") == 0)
+        if (!_wcsicmp(szClass, L"Button"))
         {
-            LONG_PTR style = GetWindowLongPtrA(hCtrl, GWL_STYLE);
-            if ((style & BS_TYPEMASK) == BS_AUTOCHECKBOX || (style & BS_TYPEMASK) == BS_CHECKBOX)
+            LONG_PTR style = GetWindowLongPtrW(hCtrl, GWL_STYLE);
+            LONG_PTR type  = style & BS_TYPEMASK;
+            if (type == BS_AUTOCHECKBOX || type == BS_CHECKBOX)
             {
                 HDC hdc = (HDC)wParam;
                 SetBkColor(hdc, GetSysColor(COLOR_BTNFACE));
@@ -87,26 +90,22 @@ static LRESULT CALLBACK ParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, 
     }
     else if (uMsg == WM_NCDESTROY)
     {
-        {
-            std::lock_guard<std::mutex> lock(g_windowsMutex);
-            auto it = std::find(g_subclassedWindows.begin(), g_subclassedWindows.end(), hWnd);
-            if (it != g_subclassedWindows.end())
-                g_subclassedWindows.erase(it);
-        }
-        RemovePropW(hWnd, L"OrigParentProc");
+        std::lock_guard<std::mutex> lock(g_windowsMutex);
+        auto it = std::find(g_subclassedWindows.begin(),
+                            g_subclassedWindows.end(), hWnd);
+        if (it != g_subclassedWindows.end())
+            g_subclassedWindows.erase(it);
     }
 
-    WNDPROC origProc = (WNDPROC)GetPropW(hWnd, L"OrigParentProc");
-    return origProc ? CallWindowProcW(origProc, hWnd, uMsg, wParam, lParam)
-                    : DefWindowProcW(hWnd, uMsg, wParam, lParam);
+    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
 }
 
-static HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName,
-    DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu,
-    HINSTANCE hInstance, LPVOID lpParam)
+static HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle, LPCWSTR lpClassName,
+    LPCWSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
+    HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
 {
-    HWND hWnd = pOriginalCreateWindowExW(dwExStyle, lpClassName, lpWindowName, dwStyle,
-        X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+    HWND hWnd = pOriginalCreateWindowExW(dwExStyle, lpClassName, lpWindowName,
+        dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 
     if (!hWnd || !hWndParent)
         return hWnd;
@@ -121,17 +120,24 @@ static HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LP
     if (type != BS_AUTOCHECKBOX && type != BS_CHECKBOX)
         return hWnd;
 
+    if (IsAppThemed())
+        return hWnd;
+
     if (!CheckHierarchy(hWndParent))
         return hWnd;
 
     std::lock_guard<std::mutex> lock(g_windowsMutex);
 
-    // Субклассируем только прямого родителя (CtrlNotifySink)
-    if (!GetPropW(hWndParent, L"OrigParentProc"))
+    bool alreadySubclassed = std::find(g_subclassedWindows.begin(),
+                                       g_subclassedWindows.end(),
+                                       hWndParent) != g_subclassedWindows.end();
+    if (!alreadySubclassed)
     {
-        WNDPROC oldParentProc = (WNDPROC)SetWindowLongPtrW(hWndParent, GWLP_WNDPROC, (LONG_PTR)ParentSubclassProc);
-        SetPropW(hWndParent, L"OrigParentProc", (HANDLE)oldParentProc);
-        g_subclassedWindows.push_back(hWndParent);
+        if (WindhawkUtils::SetWindowSubclassFromAnyThread(
+                hWndParent, ParentSubclassProc, 0))
+        {
+            g_subclassedWindows.push_back(hWndParent);
+        }
     }
 
     return hWnd;
@@ -141,7 +147,9 @@ BOOL Wh_ModInit()
 {
     Wh_Log(L"Init");
 
-    Wh_SetFunctionHook((void*)CreateWindowExW, (void*)CreateWindowExW_Hook, (void**)&pOriginalCreateWindowExW);
+    Wh_SetFunctionHook((void*)CreateWindowExW,
+                       (void*)CreateWindowExW_Hook,
+                       (void**)&pOriginalCreateWindowExW);
 
     return TRUE;
 }
@@ -150,20 +158,12 @@ void Wh_ModUninit()
 {
     Wh_Log(L"Uninit");
 
-    std::lock_guard<std::mutex> lock(g_windowsMutex);
-
-    for (HWND hWnd : g_subclassedWindows)
+    std::vector<HWND> hwnds;
     {
-        if (!IsWindow(hWnd))
-            continue;
-
-        WNDPROC origParentProc = (WNDPROC)GetPropW(hWnd, L"OrigParentProc");
-        if (origParentProc)
-        {
-            SetWindowLongPtrW(hWnd, GWLP_WNDPROC, (LONG_PTR)origParentProc);
-            RemovePropW(hWnd, L"OrigParentProc");
-        }
+        std::lock_guard<std::mutex> lock(g_windowsMutex);
+        hwnds.swap(g_subclassedWindows);
     }
 
-    g_subclassedWindows.clear();
+    for (HWND hWnd : hwnds)
+        WindhawkUtils::RemoveWindowSubclassFromAnyThread(hWnd, ParentSubclassProc);
 }

--- a/mods/fix-conflict-dialog-checkbox-bg.wh.cpp
+++ b/mods/fix-conflict-dialog-checkbox-bg.wh.cpp
@@ -1,0 +1,169 @@
+// ==WindhawkMod==
+// @id              fix-conflict-dialog-checkbox-bg
+// @name            Fix File Conflict Dialog Checkbox Background
+// @description     Fixes black background on the checkbox in the file conflict dialog (Classic Theme)
+// @version         1.0.0
+// @author          Anixx
+// @github          https://github.com/Anixx
+// @include         *
+// @compilerOptions -lgdi32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Fix File Conflict Dialog Checkbox Background
+
+Fixes the black background of the "Apply to all conflicts" checkbox
+in the Explorer file copy/move conflict dialog when Windows Classic theme is active.
+
+This bug has appeared in recent cumulative uptates.
+
+Before:
+
+![before](https://i.imgur.com/jMGJOHd.png)
+
+After:
+
+![before](https://i.imgur.com/pK0Z0u8.png)
+
+*/
+// ==/WindhawkModReadme==
+
+#include <windows.h>
+#include <vector>
+#include <mutex>
+
+using CreateWindowExW_t = HWND(WINAPI*)(DWORD, LPCWSTR, LPCWSTR, DWORD, int, int, int, int, HWND, HMENU, HINSTANCE, LPVOID);
+static CreateWindowExW_t pOriginalCreateWindowExW = nullptr;
+
+static std::vector<HWND> g_subclassedWindows;
+static std::mutex g_windowsMutex;
+
+static bool CheckHierarchy(HWND hWndParent)
+{
+    // Button -> CtrlNotifySink -> DirectUIHWND -> #32770
+    wchar_t cls[64];
+
+    GetClassNameW(hWndParent, cls, sizeof(cls) / sizeof(wchar_t));
+    if (wcscmp(cls, L"CtrlNotifySink"))
+        return false;
+
+    HWND hLevel2 = GetParent(hWndParent);
+    if (!hLevel2)
+        return false;
+    GetClassNameW(hLevel2, cls, sizeof(cls) / sizeof(wchar_t));
+    if (wcscmp(cls, L"DirectUIHWND"))
+        return false;
+
+    HWND hLevel3 = GetParent(hLevel2);
+    if (!hLevel3)
+        return false;
+    GetClassNameW(hLevel3, cls, sizeof(cls) / sizeof(wchar_t));
+    if (wcscmp(cls, L"#32770"))
+        return false;
+
+    return true;
+}
+
+static LRESULT CALLBACK ParentSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    if (uMsg == WM_CTLCOLORBTN || uMsg == WM_CTLCOLORSTATIC)
+    {
+        HWND hCtrl = (HWND)lParam;
+        char szClass[32];
+        GetClassNameA(hCtrl, szClass, sizeof(szClass));
+
+        if (_stricmp(szClass, "Button") == 0)
+        {
+            LONG_PTR style = GetWindowLongPtrA(hCtrl, GWL_STYLE);
+            if ((style & BS_TYPEMASK) == BS_AUTOCHECKBOX || (style & BS_TYPEMASK) == BS_CHECKBOX)
+            {
+                HDC hdc = (HDC)wParam;
+                SetBkColor(hdc, GetSysColor(COLOR_BTNFACE));
+                SetTextColor(hdc, GetSysColor(COLOR_BTNTEXT));
+                return (LRESULT)GetSysColorBrush(COLOR_BTNFACE);
+            }
+        }
+    }
+    else if (uMsg == WM_NCDESTROY)
+    {
+        {
+            std::lock_guard<std::mutex> lock(g_windowsMutex);
+            auto it = std::find(g_subclassedWindows.begin(), g_subclassedWindows.end(), hWnd);
+            if (it != g_subclassedWindows.end())
+                g_subclassedWindows.erase(it);
+        }
+        RemovePropW(hWnd, L"OrigParentProc");
+    }
+
+    WNDPROC origProc = (WNDPROC)GetPropW(hWnd, L"OrigParentProc");
+    return origProc ? CallWindowProcW(origProc, hWnd, uMsg, wParam, lParam)
+                    : DefWindowProcW(hWnd, uMsg, wParam, lParam);
+}
+
+static HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName,
+    DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu,
+    HINSTANCE hInstance, LPVOID lpParam)
+{
+    HWND hWnd = pOriginalCreateWindowExW(dwExStyle, lpClassName, lpWindowName, dwStyle,
+        X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+
+    if (!hWnd || !hWndParent)
+        return hWnd;
+
+    if (!lpClassName || IS_INTRESOURCE(lpClassName))
+        return hWnd;
+
+    if (wcscmp(lpClassName, L"Button"))
+        return hWnd;
+
+    LONG_PTR type = dwStyle & BS_TYPEMASK;
+    if (type != BS_AUTOCHECKBOX && type != BS_CHECKBOX)
+        return hWnd;
+
+    if (!CheckHierarchy(hWndParent))
+        return hWnd;
+
+    std::lock_guard<std::mutex> lock(g_windowsMutex);
+
+    // Субклассируем только прямого родителя (CtrlNotifySink)
+    if (!GetPropW(hWndParent, L"OrigParentProc"))
+    {
+        WNDPROC oldParentProc = (WNDPROC)SetWindowLongPtrW(hWndParent, GWLP_WNDPROC, (LONG_PTR)ParentSubclassProc);
+        SetPropW(hWndParent, L"OrigParentProc", (HANDLE)oldParentProc);
+        g_subclassedWindows.push_back(hWndParent);
+    }
+
+    return hWnd;
+}
+
+BOOL Wh_ModInit()
+{
+    Wh_Log(L"Init");
+
+    Wh_SetFunctionHook((void*)CreateWindowExW, (void*)CreateWindowExW_Hook, (void**)&pOriginalCreateWindowExW);
+
+    return TRUE;
+}
+
+void Wh_ModUninit()
+{
+    Wh_Log(L"Uninit");
+
+    std::lock_guard<std::mutex> lock(g_windowsMutex);
+
+    for (HWND hWnd : g_subclassedWindows)
+    {
+        if (!IsWindow(hWnd))
+            continue;
+
+        WNDPROC origParentProc = (WNDPROC)GetPropW(hWnd, L"OrigParentProc");
+        if (origParentProc)
+        {
+            SetWindowLongPtrW(hWnd, GWLP_WNDPROC, (LONG_PTR)origParentProc);
+            RemovePropW(hWnd, L"OrigParentProc");
+        }
+    }
+
+    g_subclassedWindows.clear();
+}


### PR DESCRIPTION
This mod fixes the black background issue on the 'Apply to all conflicts' checkbox in the file conflict dialog when using the Windows Classic theme.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
