### PR TITLE
Startup states check | Fix disabled states to disable functionality |…

### DIFF
--- a/mods/dynamic-taskbar-transparency.wh.cpp
+++ b/mods/dynamic-taskbar-transparency.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              dynamic-taskbar-transparency
 // @name            Dynamic Taskbar Transparency
-// @description     Dynamically changes the Windows 11 taskbar XAML background transparency for desktop, Start, search, tray flyouts, task view, and maximized windows.
-// @version         0.3.8
+// @description     Dynamically changes the Windows 11 taskbar XAML background transparency for desktop, Start, search, tray flyouts, task view, and maximized windows, with per-monitor state.
+// @version         0.4.3
 // @author          11581
 // @github          https://github.com/r1file
 // @include         explorer.exe
@@ -44,6 +44,27 @@ appearance and fade duration. taskbar-background-helper is a lower-level
 background helper for always/maximized behavior and pairs well with Taskbar
 Styler; this mod adds per-shell-state switching and animation on top of the
 same general taskbar background use case.
+
+Disabled states are excluded from state resolution entirely: their triggers
+are ignored and the taskbar keeps the appearance of the next matching active
+state (e.g. maximized or desktop), with no transition fired.
+
+Version 0.4 resolves states per monitor: each taskbar reacts only to
+maximized windows and shell surfaces (Start, search, task view, flyouts) on
+its own monitor. Taskbar XAML islands are matched to monitors by comparing
+each island's XamlRoot against the primary taskbar's XamlRoot resolved from
+the CTaskBand/TaskbarHost chain (taskbar.dll symbols), with island content,
+UI thread, and island pixel width heuristics as fallbacks. If an island
+can't be resolved to a monitor, it falls back to the combined behavior of
+all monitors, matching the pre-0.4 behavior. On setups with three or more
+monitors of identical resolution, secondary taskbars may not be
+distinguishable from each other and can fall back to combined behavior.
+
+On startup, the current state is applied immediately: the primary taskbar's
+XAML tree is scanned directly via its TaskbarHost, and secondary taskbars
+whose islands haven't been discovered yet are nudged with a momentary
+invisible window on their monitor so the shell refreshes their button list
+and the element hooks fire.
 */
 // ==/WindhawkModReadme==
 
@@ -176,6 +197,7 @@ same general taskbar background use case.
 #include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.ViewManagement.h>
+#include <winrt/Windows.UI.Xaml.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
@@ -188,7 +210,9 @@ same general taskbar background use case.
 #include <cmath>
 #include <condition_variable>
 #include <cwctype>
+#include <map>
 #include <mutex>
+#include <set>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -256,6 +280,40 @@ struct ShellActivity {
     bool otherInteraction = false;
 };
 
+// Per-monitor shell activity. `combined` is the OR of all monitors and is
+// used for islands that can't be resolved to a monitor.
+struct ShellActivitySnapshot {
+    std::map<HMONITOR, ShellActivity> perMonitor;
+    ShellActivity combined;
+};
+
+// How an island was classified from its content. Secondary taskbars have an
+// empty (width < 5) ControlCenterButton; the primary has a real one.
+enum class IslandKind {
+    unknown,
+    primary,
+    secondary,
+};
+
+struct TaskbarWindow {
+    HWND hwnd = nullptr;
+    HMONITOR monitor = nullptr;
+    RECT rect{};
+    int clientWidthPx = 0;
+    int clientHeightPx = 0;
+    bool isSecondary = false;
+    std::vector<DWORD> islandThreadIds;
+};
+
+std::mutex g_taskbarsMutex;
+std::vector<TaskbarWindow> g_lastTaskbars;
+
+HMONITOR ResolveMonitorForElement(DWORD uiThreadId,
+                                  double islandWidthPx,
+                                  IslandKind islandKind,
+                                  const std::vector<TaskbarWindow>& taskbars);
+PCWSTR IslandKindName(IslandKind kind);
+
 struct TrackedBackgroundElement {
     winrt::weak_ref<Shapes::Rectangle> element;
     winrt::weak_ref<Controls::Grid> parentGrid;
@@ -267,6 +325,11 @@ struct TrackedBackgroundElement {
     double nativeOpacity = 1.0;
     bool hasAppliedAppearance = false;
     AppearanceStyle appliedStyle = AppearanceStyle::clear;
+    DWORD uiThreadId = 0;
+    double islandWidthPx = 0;
+    double islandHeightPx = 0;
+    IslandKind islandKind = IslandKind::unknown;
+    HMONITOR monitor = nullptr;
     void* abi = nullptr;
 };
 
@@ -279,14 +342,18 @@ std::vector<TrackedBackgroundElement>& BackgroundElements() {
     return *elements;
 }
 
-struct ActiveAppearance {
+// The most recently applied appearance, per monitor, used to style late
+// registered elements. `fallbackAppearance` is the combined-state appearance
+// used for islands that can't be resolved to a monitor.
+struct ActiveAppearanceState {
     bool hasValue = false;
-    Appearance appearance;
     bool restoreOriginal = false;
+    Appearance fallbackAppearance;
+    std::map<HMONITOR, Appearance> perMonitor;
 };
 
 std::mutex g_activeAppearanceMutex;
-ActiveAppearance g_activeAppearance;
+ActiveAppearanceState g_activeAppearance;
 
 std::atomic<bool> g_stopWorker = false;
 std::thread* g_workerThread = nullptr;
@@ -297,9 +364,6 @@ std::atomic<bool> g_scanPending = false;
 std::atomic<bool> g_detectionPending = true;
 std::mutex g_detectionMutex;
 std::condition_variable g_detectionCondition;
-
-TaskbarDynamicState g_lastLoggedState = TaskbarDynamicState::desktop;
-bool g_hasLoggedState = false;
 
 using TaskListButton_UpdateVisualStates_t = void(WINAPI*)(void*);
 TaskListButton_UpdateVisualStates_t TaskListButton_UpdateVisualStates_Original;
@@ -1174,26 +1238,386 @@ void StoreAppliedAppearance(void* abi,
     }
 }
 
+FrameworkElement FindDirectChildByName(FrameworkElement element, PCWSTR name) {
+    int childrenCount = 0;
+    try {
+        childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
+    } catch (...) {
+        return nullptr;
+    }
+
+    for (int i = 0; i < childrenCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i)
+                         .try_as<FrameworkElement>();
+        if (child && child.Name() == name) {
+            return child;
+        }
+    }
+
+    return nullptr;
+}
+
+FrameworkElement FindDirectChildByClassName(FrameworkElement element,
+                                            PCWSTR className) {
+    int childrenCount = 0;
+    try {
+        childrenCount = Media::VisualTreeHelper::GetChildrenCount(element);
+    } catch (...) {
+        return nullptr;
+    }
+
+    for (int i = 0; i < childrenCount; i++) {
+        auto child = Media::VisualTreeHelper::GetChild(element, i)
+                         .try_as<FrameworkElement>();
+        if (child && winrt::get_class_name(child) == className) {
+            return child;
+        }
+    }
+
+    return nullptr;
+}
+
+// Classifies an island as belonging to the primary or a secondary taskbar
+// based on its content. Same heuristic as m417z's taskbar-vertical mod: on
+// secondary taskbars, the ControlCenterButton is empty and has a width of 2.
+IslandKind ClassifyIsland(winrt::Windows::UI::Xaml::XamlRoot xamlRoot) {
+    try {
+        auto content = xamlRoot.Content().try_as<FrameworkElement>();
+        if (!content) {
+            return IslandKind::unknown;
+        }
+
+        auto trayFrame = FindDirectChildByClassName(
+            content, L"SystemTray.SystemTrayFrame");
+        if (!trayFrame) {
+            return IslandKind::unknown;
+        }
+
+        auto trayGrid =
+            FindDirectChildByName(trayFrame, L"SystemTrayFrameGrid");
+        if (!trayGrid) {
+            return IslandKind::unknown;
+        }
+
+        auto controlCenterButton =
+            FindDirectChildByName(trayGrid, L"ControlCenterButton");
+        if (!controlCenterButton) {
+            return IslandKind::unknown;
+        }
+
+        return controlCenterButton.ActualWidth() < 5 ? IslandKind::secondary
+                                                     : IslandKind::primary;
+    } catch (...) {
+        return IslandKind::unknown;
+    }
+}
+
+// Exact primary-island anchor, ported from m417z's taskbar mods
+// (e.g. taskbar-tray-system-icon-tweaks): resolves the primary taskbar's
+// XamlRoot from the CTaskBand -> TaskbarHost chain, allowing exact
+// primary/secondary classification by XamlRoot identity instead of content
+// heuristics. Address-only symbol lookups, no behavioral hooks.
+void* CTaskBand_ITaskListWndSite_vftable;
+
+using CTaskBand_GetTaskbarHost_t = void*(WINAPI*)(void* pThis, void** result);
+CTaskBand_GetTaskbarHost_t CTaskBand_GetTaskbarHost_Original;
+
+void* TaskbarHost_FrameHeight_Original;
+
+using std__Ref_count_base__Decref_t = void(WINAPI*)(void* pThis);
+std__Ref_count_base__Decref_t std__Ref_count_base__Decref_Original;
+
+std::atomic<bool> g_taskbarDllSymbolsResolved = false;
+
+bool HookTaskbarDllSymbols() {
+    HMODULE module =
+        LoadLibraryEx(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!module) {
+        Wh_Log(L"Failed to load taskbar.dll");
+        return false;
+    }
+
+    // clang-format off
+    WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
+        {
+            {LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})"},
+            &CTaskBand_ITaskListWndSite_vftable,
+        },
+        {
+            {LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )"},
+            &CTaskBand_GetTaskbarHost_Original,
+        },
+        {
+            {LR"(public: int __cdecl TaskbarHost::FrameHeight(void)const )"},
+            &TaskbarHost_FrameHeight_Original,
+        },
+        {
+            {LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))"},
+            &std__Ref_count_base__Decref_Original,
+        },
+    };
+    // clang-format on
+
+    return HookSymbols(module, taskbarDllHooks, ARRAYSIZE(taskbarDllHooks));
+}
+
+winrt::Windows::UI::Xaml::XamlRoot GetTaskbarXamlRoot(HWND hTaskbarWnd) {
+    HWND hTaskSwWnd = (HWND)GetProp(hTaskbarWnd, L"TaskbandHWND");
+    if (!hTaskSwWnd) {
+        return nullptr;
+    }
+
+    void* taskBand = (void*)GetWindowLongPtr(hTaskSwWnd, 0);
+    void* taskBandForTaskListWndSite = taskBand;
+    for (int i = 0; *(void**)taskBandForTaskListWndSite !=
+                    CTaskBand_ITaskListWndSite_vftable;
+         i++) {
+        if (i == 20) {
+            return nullptr;
+        }
+
+        taskBandForTaskListWndSite = (void**)taskBandForTaskListWndSite + 1;
+    }
+
+    void* taskbarHostSharedPtr[2]{};
+    CTaskBand_GetTaskbarHost_Original(taskBandForTaskListWndSite,
+                                      taskbarHostSharedPtr);
+    if (!taskbarHostSharedPtr[0] && !taskbarHostSharedPtr[1]) {
+        return nullptr;
+    }
+
+    size_t taskbarElementIUnknownOffset = 0x48;
+
+#if defined(_M_X64)
+    {
+        // 48:83EC 28 | sub rsp,28
+        // 48:83C1 48 | add rcx,48
+        const BYTE* b = (const BYTE*)TaskbarHost_FrameHeight_Original;
+        if (b[0] == 0x48 && b[1] == 0x83 && b[2] == 0xEC && b[4] == 0x48 &&
+            b[5] == 0x83 && b[6] == 0xC1 && b[7] <= 0x7F) {
+            taskbarElementIUnknownOffset = b[7];
+        } else {
+            Wh_Log(L"Unsupported TaskbarHost::FrameHeight");
+        }
+    }
+#else
+#error "Unsupported architecture"
+#endif
+
+    auto* taskbarElementIUnknown =
+        *(IUnknown**)((BYTE*)taskbarHostSharedPtr[0] +
+                      taskbarElementIUnknownOffset);
+
+    FrameworkElement taskbarElement = nullptr;
+    taskbarElementIUnknown->QueryInterface(winrt::guid_of<FrameworkElement>(),
+                                           winrt::put_abi(taskbarElement));
+
+    auto result = taskbarElement ? taskbarElement.XamlRoot() : nullptr;
+
+    std__Ref_count_base__Decref_Original(taskbarHostSharedPtr[1]);
+
+    return result;
+}
+
+HWND FindCurrentProcessTaskbarWnd() {
+    HWND hwnd = FindWindow(L"Shell_TrayWnd", nullptr);
+    if (!hwnd) {
+        return nullptr;
+    }
+
+    DWORD processId = 0;
+    GetWindowThreadProcessId(hwnd, &processId);
+    return processId == GetCurrentProcessId() ? hwnd : nullptr;
+}
+
+using RunFromWindowThreadProc_t = void(WINAPI*)(void* parameter);
+
+bool RunFromWindowThread(HWND hWnd,
+                         RunFromWindowThreadProc_t proc,
+                         void* procParam) {
+    static const UINT runFromWindowThreadRegisteredMsg =
+        RegisterWindowMessage(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
+
+    struct RUN_FROM_WINDOW_THREAD_PARAM {
+        RunFromWindowThreadProc_t proc;
+        void* procParam;
+    };
+
+    DWORD dwThreadId = GetWindowThreadProcessId(hWnd, nullptr);
+    if (dwThreadId == 0) {
+        return false;
+    }
+
+    if (dwThreadId == GetCurrentThreadId()) {
+        proc(procParam);
+        return true;
+    }
+
+    HHOOK hook = SetWindowsHookEx(
+        WH_CALLWNDPROC,
+        [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
+            if (nCode == HC_ACTION) {
+                const CWPSTRUCT* cwp = (const CWPSTRUCT*)lParam;
+                if (cwp->message == runFromWindowThreadRegisteredMsg) {
+                    RUN_FROM_WINDOW_THREAD_PARAM* param =
+                        (RUN_FROM_WINDOW_THREAD_PARAM*)cwp->lParam;
+                    param->proc(param->procParam);
+                }
+            }
+
+            return CallNextHookEx(nullptr, nCode, wParam, lParam);
+        },
+        nullptr, dwThreadId);
+    if (!hook) {
+        return false;
+    }
+
+    RUN_FROM_WINDOW_THREAD_PARAM param;
+    param.proc = proc;
+    param.procParam = procParam;
+    SendMessage(hWnd, runFromWindowThreadRegisteredMsg, 0, (LPARAM)&param);
+
+    UnhookWindowsHookEx(hook);
+
+    return true;
+}
+
+// Exact classification: an island is the primary island iff its XamlRoot is
+// identical to the XamlRoot resolved from the primary taskbar's TaskbarHost.
+// Must be called on the taskbar UI thread.
+IslandKind ClassifyIslandExact(winrt::Windows::UI::Xaml::XamlRoot xamlRoot) {
+    if (!g_taskbarDllSymbolsResolved) {
+        return IslandKind::unknown;
+    }
+
+    HWND primaryTaskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (!primaryTaskbarWnd) {
+        return IslandKind::unknown;
+    }
+
+    if (GetWindowThreadProcessId(primaryTaskbarWnd, nullptr) !=
+        GetCurrentThreadId()) {
+        // XamlRoot access is only valid from the owning UI thread.
+        return IslandKind::unknown;
+    }
+
+    try {
+        auto primaryXamlRoot = GetTaskbarXamlRoot(primaryTaskbarWnd);
+        if (!primaryXamlRoot) {
+            return IslandKind::unknown;
+        }
+
+        return xamlRoot == primaryXamlRoot ? IslandKind::primary
+                                           : IslandKind::secondary;
+    } catch (...) {
+        return IslandKind::unknown;
+    }
+}
+
+// Must be called on the element's UI thread. Captures the dispatcher thread,
+// the XAML island's size in physical pixels, and the island kind, all used
+// to associate the island with a taskbar window/monitor.
+void CaptureElementIslandInfo(void* abi, Shapes::Rectangle rectangle) {
+    const DWORD uiThreadId = GetCurrentThreadId();
+    double islandWidthPx = 0;
+    double islandHeightPx = 0;
+    IslandKind islandKind = IslandKind::unknown;
+    try {
+        if (auto xamlRoot = rectangle.XamlRoot()) {
+            const auto size = xamlRoot.Size();
+            const double scale = xamlRoot.RasterizationScale();
+            islandWidthPx = size.Width * scale;
+            islandHeightPx = size.Height * scale;
+            islandKind = ClassifyIslandExact(xamlRoot);
+            if (islandKind == IslandKind::unknown) {
+                islandKind = ClassifyIsland(xamlRoot);
+            }
+        }
+    } catch (...) {
+    }
+
+    std::lock_guard<std::mutex> lock(g_elementsMutex);
+    for (auto& tracked : BackgroundElements()) {
+        if (tracked.abi == abi) {
+            tracked.uiThreadId = uiThreadId;
+            if (islandWidthPx > 0) {
+                tracked.islandWidthPx = islandWidthPx;
+                tracked.islandHeightPx = islandHeightPx;
+            }
+            if (islandKind != IslandKind::unknown) {
+                tracked.islandKind = islandKind;
+            }
+            return;
+        }
+    }
+}
+
+void StoreElementMonitor(void* abi, HMONITOR monitor) {
+    std::lock_guard<std::mutex> lock(g_elementsMutex);
+    for (auto& tracked : BackgroundElements()) {
+        if (tracked.abi == abi) {
+            tracked.monitor = monitor;
+            return;
+        }
+    }
+}
+
 struct BackgroundElementSnapshot {
     winrt::weak_ref<Shapes::Rectangle> element;
+    HMONITOR monitor = nullptr;
     void* abi = nullptr;
 };
 
-void StoreActiveAppearance(const Appearance& appearance, bool restoreOriginal) {
+void StoreActiveAppearance(HMONITOR monitor,
+                           const Appearance& appearance,
+                           bool restoreOriginal) {
     std::lock_guard<std::mutex> lock(g_activeAppearanceMutex);
     g_activeAppearance.hasValue = true;
-    g_activeAppearance.appearance = appearance;
     g_activeAppearance.restoreOriginal = restoreOriginal;
+    if (monitor) {
+        g_activeAppearance.perMonitor[monitor] = appearance;
+    } else {
+        g_activeAppearance.fallbackAppearance = appearance;
+    }
 }
 
-ActiveAppearance GetActiveAppearance() {
+void PruneActiveAppearances(const std::set<HMONITOR>& liveMonitors) {
     std::lock_guard<std::mutex> lock(g_activeAppearanceMutex);
-    return g_activeAppearance;
+    std::erase_if(g_activeAppearance.perMonitor,
+                  [&liveMonitors](const auto& entry) {
+                      return liveMonitors.find(entry.first) ==
+                             liveMonitors.end();
+                  });
+}
+
+struct ActiveAppearanceForElement {
+    bool hasValue = false;
+    Appearance appearance;
+    bool restoreOriginal = false;
+};
+
+ActiveAppearanceForElement GetActiveAppearanceForMonitor(HMONITOR monitor) {
+    std::lock_guard<std::mutex> lock(g_activeAppearanceMutex);
+    if (!g_activeAppearance.hasValue) {
+        return {};
+    }
+
+    Appearance appearance = g_activeAppearance.fallbackAppearance;
+    if (monitor) {
+        auto it = g_activeAppearance.perMonitor.find(monitor);
+        if (it != g_activeAppearance.perMonitor.end()) {
+            appearance = it->second;
+        }
+    }
+
+    return {true, appearance, g_activeAppearance.restoreOriginal};
 }
 
 void DispatchApplyAppearance(const Appearance& appearance,
                              bool restoreOriginal,
-                             bool waitForCompletion = false) {
+                             bool waitForCompletion = false,
+                             bool filterByMonitor = false,
+                             HMONITOR monitorFilter = nullptr) {
     std::vector<BackgroundElementSnapshot> snapshot;
     {
         std::lock_guard<std::mutex> lock(g_elementsMutex);
@@ -1203,7 +1627,10 @@ void DispatchApplyAppearance(const Appearance& appearance,
         });
         snapshot.reserve(elements.size());
         for (const auto& tracked : elements) {
-            snapshot.push_back({tracked.element, tracked.abi});
+            if (filterByMonitor && tracked.monitor != monitorFilter) {
+                continue;
+            }
+            snapshot.push_back({tracked.element, tracked.monitor, tracked.abi});
         }
     }
 
@@ -1225,6 +1652,7 @@ void DispatchApplyAppearance(const Appearance& appearance,
         auto apply = [weakElement = item.element, abi = item.abi, appearance,
                       restoreOriginal, completionEvent]() {
             if (auto rectangle = weakElement.get()) {
+                CaptureElementIslandInfo(abi, rectangle);
                 TrackedBackgroundElement originalInfo =
                     GetOriginalElementInfo(abi);
                 const bool refreshStyle =
@@ -1290,7 +1718,7 @@ void ReleaseTrackedBackgroundElements() {
         auto& elements = BackgroundElements();
         snapshot.reserve(elements.size());
         for (const auto& tracked : elements) {
-            snapshot.push_back({tracked.element, tracked.abi});
+            snapshot.push_back({tracked.element, tracked.monitor, tracked.abi});
         }
     }
 
@@ -1427,7 +1855,30 @@ void RegisterBackgroundElement(FrameworkElement element) {
                winrt::get_class_name(element).c_str(),
                element.Name().c_str());
 
-        const ActiveAppearance activeAppearance = GetActiveAppearance();
+        // We're on the element's UI thread here.
+        CaptureElementIslandInfo(abi, rectangle);
+
+        HMONITOR monitor = nullptr;
+        {
+            std::vector<TaskbarWindow> taskbars;
+            {
+                std::lock_guard<std::mutex> lock(g_taskbarsMutex);
+                taskbars = g_lastTaskbars;
+            }
+
+            TrackedBackgroundElement info = GetOriginalElementInfo(abi);
+            monitor =
+                ResolveMonitorForElement(info.uiThreadId, info.islandWidthPx,
+                                         info.islandKind, taskbars);
+            Wh_Log(L"Element registered: abi=%p kind=%s uiThread=%u "
+                   L"islandWidth=%.0f -> monitor=%p",
+                   abi, IslandKindName(info.islandKind), info.uiThreadId,
+                   info.islandWidthPx, monitor);
+        }
+        StoreElementMonitor(abi, monitor);
+
+        const ActiveAppearanceForElement activeAppearance =
+            GetActiveAppearanceForMonitor(monitor);
         if (activeAppearance.hasValue) {
             TrackedBackgroundElement originalInfo =
                 GetOriginalElementInfo(abi);
@@ -1472,6 +1923,79 @@ void ScanTaskbarBackgroundsRecursive(FrameworkElement element, int depth = 32) {
         if (child) {
             ScanTaskbarBackgroundsRecursive(child, depth - 1);
         }
+    }
+}
+
+// Bootstrap discovery of the primary taskbar's background elements without
+// waiting for a TaskListButton hook to fire. Runs the scan on the taskbar UI
+// thread using the TaskbarHost-resolved XamlRoot.
+void WINAPI BootstrapPrimaryScanProc(void* param) {
+    HWND primaryTaskbarWnd = (HWND)param;
+    try {
+        auto xamlRoot = GetTaskbarXamlRoot(primaryTaskbarWnd);
+        if (!xamlRoot) {
+            return;
+        }
+
+        auto content = xamlRoot.Content().try_as<FrameworkElement>();
+        if (content) {
+            ScanTaskbarBackgroundsRecursive(content);
+        }
+    } catch (...) {
+    }
+}
+
+bool BootstrapPrimaryIslandScan() {
+    if (!g_taskbarDllSymbolsResolved) {
+        return false;
+    }
+
+    HWND primaryTaskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (!primaryTaskbarWnd) {
+        return false;
+    }
+
+    return RunFromWindowThread(primaryTaskbarWnd, BootstrapPrimaryScanProc,
+                               (void*)primaryTaskbarWnd);
+}
+
+// Secondary islands have no TaskbandHWND-style handle, so discovery is
+// nudged instead: a momentary invisible 1x1 window on the target monitor
+// makes the shell update that taskbar's button list, which fires the
+// TaskListButton hooks and triggers the element scan.
+std::atomic<int> g_pokeThreadsActive = 0;
+
+void PokeWindowThreadProc(RECT taskbarRect) {
+    HWND hwnd = CreateWindowExW(
+        WS_EX_NOACTIVATE | WS_EX_LAYERED | WS_EX_APPWINDOW, L"Static", L" ",
+        WS_POPUP, taskbarRect.left, taskbarRect.top, 1, 1, nullptr, nullptr,
+        GetModuleHandleW(nullptr), nullptr);
+    if (hwnd) {
+        SetLayeredWindowAttributes(hwnd, 0, 1, LWA_ALPHA);
+        ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+
+        const ULONGLONG endTick = GetTickCount64() + 250;
+        MSG msg;
+        while (!g_stopWorker && GetTickCount64() < endTick) {
+            while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+                TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+            Sleep(15);
+        }
+
+        DestroyWindow(hwnd);
+    }
+
+    g_pokeThreadsActive--;
+}
+
+void PokeTaskbarForDiscovery(const RECT& taskbarRect) {
+    g_pokeThreadsActive++;
+    try {
+        std::thread(PokeWindowThreadProc, taskbarRect).detach();
+    } catch (...) {
+        g_pokeThreadsActive--;
     }
 }
 
@@ -1663,8 +2187,23 @@ bool LooksLikeShellFlyout(HWND hwnd, const RECT& rect) {
 }
 
 struct EnumShellActivityContext {
-    ShellActivity activity;
+    const std::set<HMONITOR>* taskbarMonitors;
+    ShellActivitySnapshot* snapshot;
 };
+
+void MergeShellActivity(ShellActivity& into, const ShellActivity& from) {
+    into.startOpened |= from.startOpened;
+    into.searchOpened |= from.searchOpened;
+    into.taskViewOpened |= from.taskViewOpened;
+    into.trayFlyoutOpened |= from.trayFlyoutOpened;
+    into.otherInteraction |= from.otherInteraction;
+}
+
+bool HasAnyShellActivity(const ShellActivity& activity) {
+    return activity.startOpened || activity.searchOpened ||
+           activity.taskViewOpened || activity.trayFlyoutOpened ||
+           activity.otherInteraction;
+}
 
 BOOL CALLBACK EnumShellActivityProc(HWND hwnd, LPARAM lParam) {
     RECT rect{};
@@ -1674,50 +2213,84 @@ BOOL CALLBACK EnumShellActivityProc(HWND hwnd, LPARAM lParam) {
 
     auto* context = reinterpret_cast<EnumShellActivityContext*>(lParam);
     const std::wstring className = ToLower(GetWindowClassName(hwnd));
-    const std::wstring processName = GetProcessFileName(hwnd);
+
+    ShellActivity activity{};
 
     if (className.find(L"multitasking") != std::wstring::npos) {
-        context->activity.taskViewOpened = true;
+        activity.taskViewOpened = true;
+    } else if (className.find(L"notifyiconoverflow") != std::wstring::npos ||
+               className.find(L"clockflyout") != std::wstring::npos ||
+               className.find(L"shellflyout") != std::wstring::npos) {
+        activity.trayFlyoutOpened = true;
+    } else if (LooksLikeShellFlyout(hwnd, rect)) {
+        const std::wstring processName = GetProcessFileName(hwnd);
+        if (processName == L"startmenuexperiencehost.exe") {
+            activity.startOpened = true;
+        } else if (processName == L"searchhost.exe") {
+            activity.searchOpened = true;
+        } else if (processName == L"shellexperiencehost.exe" ||
+                   processName == L"shellhost.exe") {
+            activity.trayFlyoutOpened = true;
+        } else {
+            activity.otherInteraction = true;
+        }
+    }
+
+    if (!HasAnyShellActivity(activity)) {
         return TRUE;
     }
 
-    if (className.find(L"notifyiconoverflow") != std::wstring::npos ||
-        className.find(L"clockflyout") != std::wstring::npos ||
-        className.find(L"shellflyout") != std::wstring::npos) {
-        context->activity.trayFlyoutOpened = true;
-        return TRUE;
-    }
+    MergeShellActivity(context->snapshot->combined, activity);
 
-    if (!LooksLikeShellFlyout(hwnd, rect)) {
-        return TRUE;
-    }
-
-    if (processName == L"startmenuexperiencehost.exe") {
-        context->activity.startOpened = true;
-    } else if (processName == L"searchhost.exe") {
-        context->activity.searchOpened = true;
-    } else if (processName == L"shellexperiencehost.exe" ||
-               processName == L"shellhost.exe") {
-        context->activity.trayFlyoutOpened = true;
-    } else {
-        context->activity.otherInteraction = true;
+    HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    if (monitor && context->taskbarMonitors->find(monitor) !=
+                       context->taskbarMonitors->end()) {
+        MergeShellActivity(context->snapshot->perMonitor[monitor], activity);
     }
 
     return TRUE;
 }
 
-ShellActivity DetectShellActivity() {
-    EnumShellActivityContext context{};
+ShellActivitySnapshot DetectShellActivity(
+    const std::vector<TaskbarWindow>& taskbars) {
+    std::set<HMONITOR> taskbarMonitors;
+    for (const auto& taskbar : taskbars) {
+        if (taskbar.monitor) {
+            taskbarMonitors.insert(taskbar.monitor);
+        }
+    }
+
+    ShellActivitySnapshot snapshot;
+    EnumShellActivityContext context{&taskbarMonitors, &snapshot};
     EnumWindows(EnumShellActivityProc, reinterpret_cast<LPARAM>(&context));
 
-    return context.activity;
+    return snapshot;
 }
 
-struct TaskbarWindow {
-    HWND hwnd;
-    HMONITOR monitor;
-    RECT rect;
-};
+// Collects the thread IDs of XAML island host windows
+// (DesktopWindowContentBridge) under a taskbar window. Each island's
+// content bridge window is owned by the island's UI thread, which lets us
+// match XAML elements (whose dispatcher thread we capture) to taskbars.
+BOOL CALLBACK EnumBridgeThreadsProc(HWND hwnd, LPARAM lParam) {
+    WCHAR className[128]{};
+    if (!GetClassNameW(hwnd, className, ARRAYSIZE(className))) {
+        return TRUE;
+    }
+
+    if (_wcsicmp(className,
+                 L"Windows.UI.Composition.DesktopWindowContentBridge") != 0) {
+        return TRUE;
+    }
+
+    auto* threadIds = reinterpret_cast<std::vector<DWORD>*>(lParam);
+    const DWORD threadId = GetWindowThreadProcessId(hwnd, nullptr);
+    if (threadId && std::find(threadIds->begin(), threadIds->end(),
+                              threadId) == threadIds->end()) {
+        threadIds->push_back(threadId);
+    }
+
+    return TRUE;
+}
 
 struct EnumTaskbarsContext {
     std::vector<TaskbarWindow>* taskbars;
@@ -1743,8 +2316,23 @@ BOOL CALLBACK EnumTaskbarsProc(HWND hwnd, LPARAM lParam) {
         return TRUE;
     }
 
-    context->taskbars->push_back(
-        {hwnd, MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST), rect});
+    TaskbarWindow taskbar{};
+    taskbar.hwnd = hwnd;
+    taskbar.monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    taskbar.rect = rect;
+    taskbar.isSecondary =
+        _wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0;
+
+    RECT clientRect{};
+    if (GetClientRect(hwnd, &clientRect)) {
+        taskbar.clientWidthPx = clientRect.right - clientRect.left;
+        taskbar.clientHeightPx = clientRect.bottom - clientRect.top;
+    }
+
+    EnumChildWindows(hwnd, EnumBridgeThreadsProc,
+                     reinterpret_cast<LPARAM>(&taskbar.islandThreadIds));
+
+    context->taskbars->push_back(std::move(taskbar));
     return TRUE;
 }
 
@@ -1753,6 +2341,148 @@ std::vector<TaskbarWindow> FindTaskbars() {
     EnumTaskbarsContext context{&taskbars, GetCurrentProcessId()};
     EnumWindows(EnumTaskbarsProc, reinterpret_cast<LPARAM>(&context));
     return taskbars;
+}
+
+// Associates a XAML island with a taskbar monitor. Filters taskbars by the
+// island kind (primary vs. secondary, from island content) first, then by
+// the island's UI thread, then disambiguates by the island's width in
+// physical pixels. Returns nullptr when the island can't be resolved, in
+// which case the element uses the combined (all-monitor) state.
+HMONITOR ResolveMonitorForElement(DWORD uiThreadId,
+                                  double islandWidthPx,
+                                  IslandKind islandKind,
+                                  const std::vector<TaskbarWindow>& taskbars) {
+    if (taskbars.empty()) {
+        return nullptr;
+    }
+
+    if (taskbars.size() == 1) {
+        return taskbars[0].monitor;
+    }
+
+    std::vector<const TaskbarWindow*> candidates;
+    for (const auto& taskbar : taskbars) {
+        candidates.push_back(&taskbar);
+    }
+
+    // Stage 1: island kind. The primary island can only be Shell_TrayWnd and
+    // secondary islands can only be Shell_SecondaryTrayWnd windows. This
+    // stage alone fully resolves two-monitor setups.
+    if (islandKind != IslandKind::unknown) {
+        std::vector<const TaskbarWindow*> kindMatches;
+        const bool wantSecondary = islandKind == IslandKind::secondary;
+        for (const auto* taskbar : candidates) {
+            if (taskbar->isSecondary == wantSecondary) {
+                kindMatches.push_back(taskbar);
+            }
+        }
+
+        if (!kindMatches.empty()) {
+            candidates = std::move(kindMatches);
+        }
+    }
+
+    if (candidates.size() == 1) {
+        return candidates[0]->monitor;
+    }
+
+    // Stage 2: island UI thread against the taskbar's content bridge
+    // window threads.
+    if (uiThreadId) {
+        std::vector<const TaskbarWindow*> threadMatches;
+        for (const auto* taskbar : candidates) {
+            if (std::find(taskbar->islandThreadIds.begin(),
+                          taskbar->islandThreadIds.end(),
+                          uiThreadId) != taskbar->islandThreadIds.end()) {
+                threadMatches.push_back(taskbar);
+            }
+        }
+
+        if (!threadMatches.empty()) {
+            candidates = std::move(threadMatches);
+        }
+    }
+
+    if (candidates.size() == 1) {
+        return candidates[0]->monitor;
+    }
+
+    // Stage 3: island width in physical pixels.
+    if (islandWidthPx > 0) {
+        const TaskbarWindow* widthMatch = nullptr;
+        int widthMatchCount = 0;
+        for (const auto* taskbar : candidates) {
+            if (std::abs(taskbar->clientWidthPx - islandWidthPx) <= 2.5) {
+                widthMatch = taskbar;
+                widthMatchCount++;
+            }
+        }
+
+        if (widthMatchCount == 1) {
+            return widthMatch->monitor;
+        }
+    }
+
+    return nullptr;
+}
+
+// Returns true if any element's monitor assignment changed, in which case
+// appearances should be re-dispatched so remapped elements don't keep a
+// stale appearance.
+bool RefreshElementMonitors(const std::vector<TaskbarWindow>& taskbars) {
+    bool changed = false;
+    std::lock_guard<std::mutex> lock(g_elementsMutex);
+    for (auto& tracked : BackgroundElements()) {
+        HMONITOR monitor =
+            ResolveMonitorForElement(tracked.uiThreadId, tracked.islandWidthPx,
+                                     tracked.islandKind, taskbars);
+        if (tracked.monitor != monitor) {
+            tracked.monitor = monitor;
+            changed = true;
+        }
+    }
+    return changed;
+}
+
+PCWSTR IslandKindName(IslandKind kind) {
+    switch (kind) {
+        case IslandKind::primary:
+            return L"primary";
+        case IslandKind::secondary:
+            return L"secondary";
+        case IslandKind::unknown:
+            break;
+    }
+    return L"unknown";
+}
+
+void LogMappingDiagnostics(const std::vector<TaskbarWindow>& taskbars) {
+    for (const auto& taskbar : taskbars) {
+        WCHAR threads[128] = L"";
+        size_t offset = 0;
+        for (DWORD threadId : taskbar.islandThreadIds) {
+            const int written =
+                swprintf_s(threads + offset, ARRAYSIZE(threads) - offset,
+                           L"%s%u", offset ? L"," : L"", threadId);
+            if (written <= 0) {
+                break;
+            }
+            offset += written;
+        }
+
+        Wh_Log(L"Taskbar %s hwnd=%p monitor=%p clientWidth=%d "
+               L"islandThreads=[%s]",
+               taskbar.isSecondary ? L"secondary" : L"primary", taskbar.hwnd,
+               taskbar.monitor, taskbar.clientWidthPx, threads);
+    }
+
+    std::lock_guard<std::mutex> lock(g_elementsMutex);
+    for (const auto& tracked : BackgroundElements()) {
+        Wh_Log(L"Element abi=%p kind=%s uiThread=%u islandWidth=%.0f -> "
+               L"monitor=%p",
+               tracked.abi, IslandKindName(tracked.islandKind),
+               tracked.uiThreadId, tracked.islandWidthPx, tracked.monitor);
+    }
 }
 
 bool RectCoversMonitor(HWND hwnd, HMONITOR monitor) {
@@ -1812,7 +2542,7 @@ bool IsUserCandidateWindow(HWND hwnd) {
 struct EnumMaximizedContext {
     bool fullscreenAsMaximized;
     const std::vector<TaskbarWindow>* taskbars;
-    bool found;
+    std::set<HMONITOR>* monitors;
 };
 
 bool MonitorMatchesTaskbar(HMONITOR monitor,
@@ -1832,30 +2562,34 @@ bool MonitorMatchesTaskbar(HMONITOR monitor,
 
 BOOL CALLBACK EnumMaximizedProc(HWND hwnd, LPARAM lParam) {
     auto* context = reinterpret_cast<EnumMaximizedContext*>(lParam);
-    if (context->found || !IsUserCandidateWindow(hwnd)) {
+    if (!IsUserCandidateWindow(hwnd)) {
         return TRUE;
     }
 
     HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONULL);
-    if (!MonitorMatchesTaskbar(monitor, *context->taskbars)) {
+    if (!monitor || !MonitorMatchesTaskbar(monitor, *context->taskbars)) {
+        return TRUE;
+    }
+
+    if (context->monitors->find(monitor) != context->monitors->end()) {
         return TRUE;
     }
 
     if (IsZoomed(hwnd) ||
-        (context->fullscreenAsMaximized &&
-         monitor && RectCoversMonitor(hwnd, monitor))) {
-        context->found = true;
-        return FALSE;
+        (context->fullscreenAsMaximized && RectCoversMonitor(hwnd, monitor))) {
+        context->monitors->insert(monitor);
     }
 
     return TRUE;
 }
 
-bool HasMaximizedWindow(bool fullscreenAsMaximized,
-                        const std::vector<TaskbarWindow>& taskbars) {
-    EnumMaximizedContext context{fullscreenAsMaximized, &taskbars, false};
+std::set<HMONITOR> FindMaximizedMonitors(
+    bool fullscreenAsMaximized,
+    const std::vector<TaskbarWindow>& taskbars) {
+    std::set<HMONITOR> monitors;
+    EnumMaximizedContext context{fullscreenAsMaximized, &taskbars, &monitors};
     EnumWindows(EnumMaximizedProc, reinterpret_cast<LPARAM>(&context));
-    return context.found;
+    return monitors;
 }
 
 struct StateResolution {
@@ -1866,43 +2600,33 @@ struct StateResolution {
 
 Appearance GetAppearanceForState(const Settings& settings,
                                  TaskbarDynamicState state) {
+    // ResolveState only yields enabled states, so no enabled checks are
+    // needed here.
     Appearance appearance = settings.desktop;
 
     switch (state) {
         case TaskbarDynamicState::maximized:
-            if (settings.maximized.enabled) {
-                appearance = settings.maximized;
-            }
+            appearance = settings.maximized;
             break;
 
         case TaskbarDynamicState::startOpened:
-            if (settings.startOpened.enabled) {
-                appearance = settings.startOpened;
-            }
+            appearance = settings.startOpened;
             break;
 
         case TaskbarDynamicState::searchOpened:
-            if (settings.searchOpened.enabled) {
-                appearance = settings.searchOpened;
-            }
+            appearance = settings.searchOpened;
             break;
 
         case TaskbarDynamicState::taskViewOpened:
-            if (settings.taskViewOpened.enabled) {
-                appearance = settings.taskViewOpened;
-            }
+            appearance = settings.taskViewOpened;
             break;
 
         case TaskbarDynamicState::trayFlyoutOpened:
-            if (settings.trayFlyoutOpened.enabled) {
-                appearance = settings.trayFlyoutOpened;
-            }
+            appearance = settings.trayFlyoutOpened;
             break;
 
         case TaskbarDynamicState::otherInteraction:
-            if (settings.otherInteraction.enabled) {
-                appearance = settings.otherInteraction;
-            }
+            appearance = settings.otherInteraction;
             break;
 
         case TaskbarDynamicState::desktop:
@@ -1925,36 +2649,36 @@ Appearance GetAppearanceForState(const Settings& settings,
 
 StateResolution ResolveState(const Settings& settings,
                              const ShellActivity& shellActivity,
-                             const std::vector<TaskbarWindow>& taskbars) {
-    const bool hasMaximizedWindow =
-        HasMaximizedWindow(settings.fullscreenAsMaximized, taskbars);
-
-    if (shellActivity.taskViewOpened) {
+                             bool hasMaximizedWindow) {
+    // Disabled states are skipped entirely so their triggers are invisible
+    // to the state machine and resolution falls through to the next
+    // matching enabled state.
+    if (settings.taskViewOpened.enabled && shellActivity.taskViewOpened) {
         return {TaskbarDynamicState::taskViewOpened, L"taskViewOpened",
                 hasMaximizedWindow};
     }
 
-    if (shellActivity.startOpened) {
+    if (settings.startOpened.enabled && shellActivity.startOpened) {
         return {TaskbarDynamicState::startOpened, L"startOpened",
                 hasMaximizedWindow};
     }
 
-    if (shellActivity.searchOpened) {
+    if (settings.searchOpened.enabled && shellActivity.searchOpened) {
         return {TaskbarDynamicState::searchOpened, L"searchOpened",
                 hasMaximizedWindow};
     }
 
-    if (shellActivity.trayFlyoutOpened) {
+    if (settings.trayFlyoutOpened.enabled && shellActivity.trayFlyoutOpened) {
         return {TaskbarDynamicState::trayFlyoutOpened, L"trayFlyoutOpened",
                 hasMaximizedWindow};
     }
 
-    if (hasMaximizedWindow) {
+    if (settings.maximized.enabled && hasMaximizedWindow) {
         return {TaskbarDynamicState::maximized, L"maximizedWindow",
                 hasMaximizedWindow};
     }
 
-    if (shellActivity.otherInteraction) {
+    if (settings.otherInteraction.enabled && shellActivity.otherInteraction) {
         return {TaskbarDynamicState::otherInteraction, L"otherShellInteraction",
                 hasMaximizedWindow};
     }
@@ -1998,7 +2722,13 @@ BYTE InterpolateOpacity(BYTE from, BYTE to, double progress) {
 }
 
 void RequestStateDetection() {
-    g_detectionPending = true;
+    // The flag must be set under the mutex, otherwise the worker can check
+    // its predicate, miss the notify, and block forever (which also leaks a
+    // zombie worker thread on mod unload).
+    {
+        std::lock_guard<std::mutex> lock(g_detectionMutex);
+        g_detectionPending = true;
+    }
     g_detectionCondition.notify_one();
 }
 
@@ -2117,18 +2847,26 @@ void StopWinEventThread() {
 }
 
 void WorkerLoop() {
-    Appearance currentAppearance{};
-    Appearance animationStartAppearance{};
-    Appearance targetAppearance{};
-    Appearance lastAppliedAppearance{};
-    bool hasCurrentAppearance = false;
-    bool hasLastAppliedAppearance = false;
+    // Animation/appearance state per monitor. The nullptr key is the
+    // combined fallback used by elements whose island can't be resolved to
+    // a monitor.
+    struct MonitorAnimation {
+        Appearance current{};
+        Appearance start{};
+        Appearance target{};
+        Appearance lastApplied{};
+        ULONGLONG startTick = 0;
+        bool hasLastApplied = false;
+    };
+
+    std::map<HMONITOR, MonitorAnimation> animations;
+    std::map<HMONITOR, TaskbarDynamicState> lastLoggedStates;
+    ULONGLONG lastPrimaryBootstrapTick = 0;
+    std::map<HMONITOR, int> pokeAttempts;
+    std::map<HMONITOR, ULONGLONG> lastPokeTicks;
+    bool hasDetectedOnce = false;
     bool loggedNoElements = false;
     const ULONGLONG workerStartTick = GetTickCount64();
-    ULONGLONG animationStartTick = GetTickCount64();
-    ShellActivity shellActivity{};
-    StateResolution resolution{TaskbarDynamicState::desktop, L"desktop",
-                               false};
     constexpr int frameTimeMs = 1000 / 60;
 
     while (!g_stopWorker) {
@@ -2140,40 +2878,171 @@ void WorkerLoop() {
 
         const ULONGLONG now = GetTickCount64();
 
-        if (!hasCurrentAppearance || g_detectionPending.exchange(false)) {
+        if (!hasDetectedOnce || g_detectionPending.exchange(false)) {
+            hasDetectedOnce = true;
+
             const auto taskbars = FindTaskbars();
-            shellActivity = DetectShellActivity();
-            resolution = ResolveState(settings, shellActivity, taskbars);
-
-            const TaskbarDynamicState state = resolution.state;
-            if (!g_hasLoggedState || g_lastLoggedState != state) {
-                Wh_Log(L"Taskbar state: %s (%s; taskView=%d start=%d "
-                       L"search=%d tray=%d max=%d other=%d)",
-                       StateName(state), resolution.reason,
-                       shellActivity.taskViewOpened, shellActivity.startOpened,
-                       shellActivity.searchOpened,
-                       shellActivity.trayFlyoutOpened,
-                       resolution.hasMaximizedWindow,
-                       shellActivity.otherInteraction);
-                g_lastLoggedState = state;
-                g_hasLoggedState = true;
+            bool taskbarsChanged = false;
+            {
+                std::lock_guard<std::mutex> lock(g_taskbarsMutex);
+                taskbarsChanged =
+                    g_lastTaskbars.size() != taskbars.size() ||
+                    !std::equal(taskbars.begin(), taskbars.end(),
+                                g_lastTaskbars.begin(),
+                                [](const auto& a, const auto& b) {
+                                    return a.hwnd == b.hwnd &&
+                                           a.monitor == b.monitor &&
+                                           a.isSecondary == b.isSecondary &&
+                                           a.clientWidthPx == b.clientWidthPx &&
+                                           a.islandThreadIds ==
+                                               b.islandThreadIds;
+                                });
+                g_lastTaskbars = taskbars;
             }
 
-            Appearance desiredAppearance =
-                GetAppearanceForState(settings, state);
-
-            if (!hasCurrentAppearance) {
-                currentAppearance = desiredAppearance;
-                animationStartAppearance = desiredAppearance;
-                targetAppearance = desiredAppearance;
-                hasCurrentAppearance = true;
-                animationStartTick = now;
+            const bool elementMappingChanged =
+                RefreshElementMonitors(taskbars);
+            if (taskbarsChanged || elementMappingChanged) {
+                LogMappingDiagnostics(taskbars);
             }
 
-            if (!AppearanceSameTarget(targetAppearance, desiredAppearance)) {
-                animationStartAppearance = currentAppearance;
-                targetAppearance = desiredAppearance;
-                animationStartTick = now;
+            // Bootstrap: ensure every taskbar island is discovered without
+            // waiting for taskbar button activity.
+            {
+                std::set<HMONITOR> coveredMonitors;
+                {
+                    std::lock_guard<std::mutex> lock(g_elementsMutex);
+                    for (const auto& tracked : BackgroundElements()) {
+                        if (tracked.monitor) {
+                            coveredMonitors.insert(tracked.monitor);
+                        }
+                    }
+                }
+
+                bool bootstrapped = false;
+                for (const auto& taskbar : taskbars) {
+                    if (!taskbar.monitor ||
+                        coveredMonitors.find(taskbar.monitor) !=
+                            coveredMonitors.end()) {
+                        continue;
+                    }
+
+                    if (!taskbar.isSecondary) {
+                        if (now - lastPrimaryBootstrapTick >= 1000) {
+                            lastPrimaryBootstrapTick = now;
+                            Wh_Log(L"Bootstrap: scanning primary island");
+                            if (BootstrapPrimaryIslandScan()) {
+                                bootstrapped = true;
+                            }
+                        }
+                    } else {
+                        int& attempts = pokeAttempts[taskbar.monitor];
+                        ULONGLONG& lastTick = lastPokeTicks[taskbar.monitor];
+                        if (attempts < 3 && now - lastTick >= 1500) {
+                            attempts++;
+                            lastTick = now;
+                            Wh_Log(L"Bootstrap: poking taskbar on monitor %p "
+                                   L"(attempt %d)",
+                                   taskbar.monitor, attempts);
+                            PokeTaskbarForDiscovery(taskbar.rect);
+                        }
+                    }
+                }
+
+                if (bootstrapped) {
+                    // The primary scan registers elements synchronously;
+                    // re-run detection so mapping and coverage update.
+                    RequestStateDetection();
+                }
+            }
+
+            const ShellActivitySnapshot shellActivity =
+                DetectShellActivity(taskbars);
+            const std::set<HMONITOR> maximizedMonitors = FindMaximizedMonitors(
+                settings.fullscreenAsMaximized, taskbars);
+
+            struct MonitorResolution {
+                StateResolution resolution;
+                ShellActivity activity;
+            };
+            std::map<HMONITOR, MonitorResolution> resolutions;
+
+            for (const auto& taskbar : taskbars) {
+                HMONITOR monitor = taskbar.monitor;
+                if (!monitor ||
+                    resolutions.find(monitor) != resolutions.end()) {
+                    continue;
+                }
+
+                ShellActivity monitorActivity{};
+                auto it = shellActivity.perMonitor.find(monitor);
+                if (it != shellActivity.perMonitor.end()) {
+                    monitorActivity = it->second;
+                }
+
+                const bool hasMaximized =
+                    maximizedMonitors.find(monitor) != maximizedMonitors.end();
+                resolutions[monitor] = {
+                    ResolveState(settings, monitorActivity, hasMaximized),
+                    monitorActivity};
+            }
+
+            // Combined fallback for unresolved islands.
+            resolutions[nullptr] = {
+                ResolveState(settings, shellActivity.combined,
+                             !maximizedMonitors.empty()),
+                shellActivity.combined};
+
+            std::set<HMONITOR> liveKeys;
+            for (const auto& [monitor, entry] : resolutions) {
+                liveKeys.insert(monitor);
+
+                auto logged = lastLoggedStates.find(monitor);
+                if (logged == lastLoggedStates.end() ||
+                    logged->second != entry.resolution.state) {
+                    Wh_Log(L"Taskbar state [monitor %p]: %s (%s; taskView=%d "
+                           L"start=%d search=%d tray=%d max=%d other=%d)",
+                           monitor, StateName(entry.resolution.state),
+                           entry.resolution.reason,
+                           entry.activity.taskViewOpened,
+                           entry.activity.startOpened,
+                           entry.activity.searchOpened,
+                           entry.activity.trayFlyoutOpened,
+                           entry.resolution.hasMaximizedWindow,
+                           entry.activity.otherInteraction);
+                    lastLoggedStates[monitor] = entry.resolution.state;
+                }
+            }
+
+            std::erase_if(lastLoggedStates, [&liveKeys](const auto& entry) {
+                return liveKeys.find(entry.first) == liveKeys.end();
+            });
+            std::erase_if(animations, [&liveKeys](const auto& entry) {
+                return liveKeys.find(entry.first) == liveKeys.end();
+            });
+            PruneActiveAppearances(liveKeys);
+
+            for (const auto& [monitor, entry] : resolutions) {
+                const Appearance desiredAppearance =
+                    GetAppearanceForState(settings, entry.resolution.state);
+
+                auto [it, inserted] = animations.try_emplace(monitor);
+                MonitorAnimation& animation = it->second;
+                if (inserted) {
+                    animation.current = desiredAppearance;
+                    animation.start = desiredAppearance;
+                    animation.target = desiredAppearance;
+                    animation.startTick = now;
+                } else if (!AppearanceSameTarget(animation.target,
+                                                 desiredAppearance)) {
+                    animation.start = animation.current;
+                    animation.target = desiredAppearance;
+                    animation.startTick = now;
+                }
+
+                if (elementMappingChanged) {
+                    animation.hasLastApplied = false;
+                }
             }
         }
 
@@ -2191,51 +3060,58 @@ void WorkerLoop() {
             loggedNoElements = true;
         }
 
-        double progress = 1.0;
-        if (settings.animationDurationMs > 0) {
-            progress =
-                static_cast<double>(now - animationStartTick) /
-                static_cast<double>(settings.animationDurationMs);
-            progress = std::clamp(progress, 0.0, 1.0);
+        bool allAnimationsDone = true;
+        for (auto& [monitor, animation] : animations) {
+            double progress = 1.0;
+            if (settings.animationDurationMs > 0) {
+                progress =
+                    static_cast<double>(now - animation.startTick) /
+                    static_cast<double>(settings.animationDurationMs);
+                progress = std::clamp(progress, 0.0, 1.0);
+            }
+
+            const bool visibleStyleChange =
+                settings.animationDurationMs > 0 &&
+                animation.start.style != animation.target.style &&
+                animation.start.opacity > 0 && animation.target.opacity > 0;
+
+            if (visibleStyleChange && progress < 0.5) {
+                animation.current = animation.start;
+                const BYTE floorOpacity =
+                    std::min<BYTE>(animation.start.opacity, 245);
+                animation.current.opacity =
+                    InterpolateOpacity(animation.start.opacity, floorOpacity,
+                                       progress * 2.0);
+            } else if (visibleStyleChange) {
+                animation.current = animation.target;
+                const BYTE floorOpacity =
+                    std::min<BYTE>(animation.target.opacity, 245);
+                animation.current.opacity =
+                    InterpolateOpacity(floorOpacity, animation.target.opacity,
+                                       (progress - 0.5) * 2.0);
+            } else {
+                animation.current = animation.target;
+                animation.current.opacity =
+                    InterpolateOpacity(animation.start.opacity,
+                                       animation.target.opacity, progress);
+            }
+
+            if (progress < 1.0) {
+                allAnimationsDone = false;
+            }
+
+            if (!animation.hasLastApplied ||
+                !AppearanceSameTarget(animation.lastApplied,
+                                      animation.current)) {
+                StoreActiveAppearance(monitor, animation.current, false);
+                DispatchApplyAppearance(animation.current, false, false, true,
+                                        monitor);
+                animation.lastApplied = animation.current;
+                animation.hasLastApplied = true;
+            }
         }
 
-        const bool visibleStyleChange =
-            settings.animationDurationMs > 0 &&
-            animationStartAppearance.style != targetAppearance.style &&
-            animationStartAppearance.opacity > 0 && targetAppearance.opacity > 0;
-
-        if (visibleStyleChange && progress < 0.5) {
-            currentAppearance = animationStartAppearance;
-            const BYTE floorOpacity =
-                std::min<BYTE>(animationStartAppearance.opacity, 245);
-            currentAppearance.opacity =
-                InterpolateOpacity(animationStartAppearance.opacity,
-                                   floorOpacity,
-                                   progress * 2.0);
-        } else if (visibleStyleChange) {
-            currentAppearance = targetAppearance;
-            const BYTE floorOpacity =
-                std::min<BYTE>(targetAppearance.opacity, 245);
-            currentAppearance.opacity =
-                InterpolateOpacity(floorOpacity, targetAppearance.opacity,
-                                   (progress - 0.5) * 2.0);
-        } else {
-            currentAppearance = targetAppearance;
-            currentAppearance.opacity =
-                InterpolateOpacity(animationStartAppearance.opacity,
-                                   targetAppearance.opacity, progress);
-        }
-
-        const bool animationDone = progress >= 1.0;
-        if (!hasLastAppliedAppearance ||
-            !AppearanceSameTarget(lastAppliedAppearance, currentAppearance)) {
-            StoreActiveAppearance(currentAppearance, false);
-            DispatchApplyAppearance(currentAppearance, false);
-            lastAppliedAppearance = currentAppearance;
-            hasLastAppliedAppearance = true;
-        }
-
-        if (animationDone) {
+        if (allAnimationsDone) {
             std::unique_lock<std::mutex> lock(g_detectionMutex);
             g_detectionCondition.wait(lock, [] {
                 return g_stopWorker || g_detectionPending.load();
@@ -2249,7 +3125,7 @@ void WorkerLoop() {
         }
     }
 
-    DispatchApplyAppearance(currentAppearance, true, true);
+    DispatchApplyAppearance(Appearance{}, true, true);
     {
         std::lock_guard<std::mutex> lock(g_activeAppearanceMutex);
         g_activeAppearance = {};
@@ -2329,7 +3205,12 @@ BOOL Wh_ModInit() {
     g_stopWorker = false;
     g_taskbarViewDllLoaded = false;
     g_scanPending = false;
-    g_hasLoggedState = false;
+
+    g_taskbarDllSymbolsResolved = HookTaskbarDllSymbols();
+    if (!g_taskbarDllSymbolsResolved) {
+        Wh_Log(L"taskbar.dll symbols unavailable; falling back to island "
+               L"content heuristics for primary/secondary classification");
+    }
 
     if (HMODULE module = GetTaskbarViewModuleHandle()) {
         g_taskbarViewDllLoaded = true;
@@ -2373,8 +3254,12 @@ void Wh_ModSettingsChanged() {
 void Wh_ModUninit() {
     Wh_Log(L"Uninitializing Dynamic Taskbar Transparency");
     StopWinEventThread();
-    g_stopWorker = true;
-    RequestStateDetection();
+    {
+        std::lock_guard<std::mutex> lock(g_detectionMutex);
+        g_stopWorker = true;
+        g_detectionPending = true;
+    }
+    g_detectionCondition.notify_one();
     if (g_workerThread) {
         if (g_workerThread->joinable()) {
             g_workerThread->join();
@@ -2384,4 +3269,15 @@ void Wh_ModUninit() {
     }
 
     ReleaseTrackedBackgroundElements();
+
+    // Wait for any in-flight discovery poke threads (bounded at ~250ms each)
+    // so no mod code runs after the DLL unloads.
+    for (int i = 0; i < 100 && g_pokeThreadsActive > 0; i++) {
+        Sleep(10);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_taskbarsMutex);
+        g_lastTaskbars.clear();
+    }
 }


### PR DESCRIPTION
This patch fixes 3 issues with the Mod:

1) The Mod doesn't initiate first startup states check. This patch fixes this by triggering inital check and update after enabling the Mod.

2) Currently, when disabling states, they still function. The patch fixes this by actually disabling functionality.

3) The current Mod has no multi-monitor support, all monitors duplicate behavior. I propose a fix where each monitor behaves independently.

* Fixes done via Claude Fable 5

