### PR TITLE
Fix disabled Dynamic Taskbar Transparency states

### DIFF
--- a/mods/dynamic-taskbar-transparency.wh.cpp
+++ b/mods/dynamic-taskbar-transparency.wh.cpp
@@ -2,7 +2,7 @@
 // @id              dynamic-taskbar-transparency
 // @name            Dynamic Taskbar Transparency
 // @description     Dynamically changes the Windows 11 taskbar XAML background transparency for desktop, Start, search, tray flyouts, task view, and maximized windows.
-// @version         0.3.8
+// @version         0.3.9
 // @author          11581
 // @github          https://github.com/r1file
 // @include         explorer.exe
@@ -1929,32 +1929,32 @@ StateResolution ResolveState(const Settings& settings,
     const bool hasMaximizedWindow =
         HasMaximizedWindow(settings.fullscreenAsMaximized, taskbars);
 
-    if (shellActivity.taskViewOpened) {
+    if (shellActivity.taskViewOpened && settings.taskViewOpened.enabled) {
         return {TaskbarDynamicState::taskViewOpened, L"taskViewOpened",
                 hasMaximizedWindow};
     }
 
-    if (shellActivity.startOpened) {
+    if (shellActivity.startOpened && settings.startOpened.enabled) {
         return {TaskbarDynamicState::startOpened, L"startOpened",
                 hasMaximizedWindow};
     }
 
-    if (shellActivity.searchOpened) {
+    if (shellActivity.searchOpened && settings.searchOpened.enabled) {
         return {TaskbarDynamicState::searchOpened, L"searchOpened",
                 hasMaximizedWindow};
     }
 
-    if (shellActivity.trayFlyoutOpened) {
+    if (shellActivity.trayFlyoutOpened && settings.trayFlyoutOpened.enabled) {
         return {TaskbarDynamicState::trayFlyoutOpened, L"trayFlyoutOpened",
                 hasMaximizedWindow};
     }
 
-    if (hasMaximizedWindow) {
+    if (hasMaximizedWindow && settings.maximized.enabled) {
         return {TaskbarDynamicState::maximized, L"maximizedWindow",
                 hasMaximizedWindow};
     }
 
-    if (shellActivity.otherInteraction) {
+    if (shellActivity.otherInteraction && settings.otherInteraction.enabled) {
         return {TaskbarDynamicState::otherInteraction, L"otherShellInteraction",
                 hasMaximizedWindow};
     }


### PR DESCRIPTION
## Summary

- Make disabled shell states fall through instead of overriding the current taskbar appearance
- Bump Dynamic Taskbar Transparency to 0.3.9

## Details

When Start/Search/Task View/tray/other shell states were disabled, `ResolveState` still selected those states. `GetAppearanceForState` then fell back to the desktop appearance, so opening Start could ignore the maximized-window appearance. Disabled states now behave as inactive and allow later state checks, such as maximized windows, to apply.

This addresses the disabled-state behavior reported in #4677 and #4686. The multi-monitor maximized behavior from #4686 is intentionally left as a separate larger change.

## Validation

- `python .github/pr_validation.py` with one changed mod file
- `python -u scripts/compile_mod.py -w "C:\Program Files\Windhawk" -f mods/dynamic-taskbar-transparency.wh.cpp -o32 "$env:TEMP\dynamic-taskbar-transparency_32.dll" -o64 "$env:TEMP\dynamic-taskbar-transparency_64.dll" -oarm64 "$env:TEMP\dynamic-taskbar-transparency_arm64.dll"`