### PR TITLE
Update word-local-autosave.wh.cpp

### DIFF
--- a/mods/word-local-autosave.wh.cpp
+++ b/mods/word-local-autosave.wh.cpp
@@ -2,7 +2,7 @@
 // @id              word-local-autosave
 // @name            Word Local AutoSave
 // @description     Enables AutoSave functionality for local documents in Microsoft Word via direct Word saves
-// @version         3.8
+// @version         4.0.0
 // @author          communism420
 // @github          https://github.com/communism420
 // @include         WINWORD.EXE
@@ -45,13 +45,20 @@ shortcut activations.
 - Keeps pending changes armed after direct save failures so transient file errors can be retried
 - Only saves when the active Word document window is focused
 
-## Shortcut Safety (v3.8)
+## Shortcut Safety (v4.0.0)
 
 - No `SendInput`
 - No synthetic `Ctrl` state
 - No partial `Ctrl+...` races
 - Save execution stays on one owner UI thread
 - Pending input and held modifiers postpone auto-save instead of racing it
+
+## Performance and Reliability (v4.0.0)
+
+- Uses Word events as the primary signal with an adaptive low-frequency watchdog
+- Reuses cached Word application, document, metadata, and automation member IDs
+- Avoids filesystem path resolution in the steady editing path
+- Uses one owner-window timer with reason-aware bounded retry backoff
 
 ## Limitations
 
@@ -83,6 +90,8 @@ shortcut activations.
 #include <ocidl.h>
 #include <oleauto.h>
 #include <oleacc.h>
+#include <atomic>
+#include <limits>
 #include <new>
 #include <utility>
 
@@ -112,24 +121,49 @@ const DWORD ACTION_BURST_SETTLE_DELAY_MS = 250;
 const DWORD AUTOMATION_RECOVERY_DELAY_MS = 125;
 const DWORD DOCUMENT_STATE_ACTIVE_POLL_INTERVAL_MS = 350;
 const DWORD DOCUMENT_STATE_IDLE_POLL_INTERVAL_MS = 1500;
-const DWORD DOCUMENT_STATE_EVENT_IDLE_POLL_INTERVAL_MS = 5000;
-const DWORD MAX_SAVE_RETRY_INTERVAL_MS = 1000;
-const DWORD MAX_DOCUMENT_STATE_RETRY_INTERVAL_MS = 2000;
-const DWORD FAILURE_LOG_INTERVAL_MS = 2000;
+const DWORD DOCUMENT_STATE_EVENT_IDLE_POLL_INTERVAL_MS = 30000;
+const DWORD DOCUMENT_STATE_PENDING_WATCHDOG_MS = 1500;
+const DWORD SAVE_AUTOMATION_RETRY_INITIAL_MS = 125;
+const DWORD SAVE_AUTOMATION_RETRY_MAX_MS = 5000;
+const DWORD SAVE_HARD_RETRY_INITIAL_MS = 2000;
+const DWORD SAVE_HARD_RETRY_MAX_MS = 30000;
+const DWORD SAVE_TARGET_RETRY_INITIAL_MS = 250;
+const DWORD SAVE_TARGET_RETRY_MAX_MS = 5000;
+const DWORD SAVE_DEFERRED_WATCHDOG_MS = 10000;
+const DWORD SAVE_INACTIVE_EVENT_WATCHDOG_MS = 30000;
+const DWORD SAVE_INACTIVE_FALLBACK_WATCHDOG_MS = 5000;
+const DWORD SAVE_UI_INPUT_WATCHDOG_MS = 2000;
+const DWORD DOCUMENT_BUSY_RETRY_INITIAL_MS = 125;
+const DWORD DOCUMENT_BUSY_RETRY_MAX_MS = 5000;
+const DWORD DOCUMENT_TARGET_RETRY_INITIAL_MS = 250;
+const DWORD DOCUMENT_TARGET_RETRY_MAX_MS = 5000;
+const DWORD DOCUMENT_HARD_RETRY_INITIAL_MS = 2000;
+const DWORD DOCUMENT_HARD_RETRY_MAX_MS = 30000;
+const DWORD SAVE_FAILURE_LOG_INTERVAL_MS = 30000;
+const DWORD DOCUMENT_FAILURE_LOG_INTERVAL_MS = 10000;
+const DWORD RETRY_REASON_CHANGE_LOG_INTERVAL_MS = 2000;
+const DWORD RETRY_BUSY_LOG_INTERVAL_MS = 10000;
+const DWORD RETRY_HARD_LOG_INTERVAL_MS = 30000;
+const DWORD RETRY_WAIT_LOG_INTERVAL_MS = 60000;
 const DWORD STATUS_LOG_INTERVAL_MS = 3000;
 const DWORD WORD_EVENT_DISCONNECT_FAILURE_LOG_INTERVAL_MS = 10000;
 const DWORD WORD_EVENT_SHUTDOWN_DISCONNECT_RETRY_DELAY_MS = 50;
 const DWORD TEXT_INPUT_KEYDOWN_CHAR_SUPPRESSION_MS = 1000;
 const DWORD COM_MESSAGE_FILTER_RETRY_DELAY_MS = 150;
 const DWORD COM_MESSAGE_FILTER_CANCEL_AFTER_MS = 10000;
+const DWORD COM_BACKGROUND_RETRY_DELAY_MS = 100;
+const DWORD COM_BACKGROUND_RETRY_BUDGET_MS = 1000;
 const DWORD SAVE_AS_MIGRATION_TIMEOUT_MS = 15000;
 const DWORD WORD_EVENT_RECONNECT_INTERVAL_MS = 2000;
 const DWORD WORD_EVENT_DISCONNECT_RETRY_INTERVAL_MS = 2000;
 const int WORD_EVENT_SHUTDOWN_DISCONNECT_RETRY_ATTEMPTS = 6;
 const int WORD_EVENT_PENDING_DISCONNECT_CAPACITY = 4;
 const DWORD MAX_CANONICAL_PATH_CHARS = 32768;
-const int DISPATCH_MEMBER_ID_CACHE_CAPACITY = 48;
 const DWORD OBJID_NATIVEOM_VALUE = 0xFFFFFFF0u;
+const UINT WORD_LOCAL_AUTOSAVE_CONTROL_MESSAGE = WM_APP + 0x4A3;
+const UINT_PTR SCHEDULER_WINDOW_TIMER_ID = 0x574C;
+const DWORD OWNER_SHUTDOWN_WAKE_INTERVAL_MS = 100;
+const DWORD OWNER_SHUTDOWN_FAILSAFE_TIMEOUT_MS = 10000;
 
 const IID kIIDNull = {};
 const IID kIIDIDispatch = {
@@ -166,22 +200,44 @@ struct WordEventDispIds {
     DISPID documentBeforeSave = DISPID_UNKNOWN;
     DISPID documentBeforeClose = DISPID_UNKNOWN;
     DISPID documentChange = DISPID_UNKNOWN;
+    DISPID windowActivate = DISPID_UNKNOWN;
     DISPID windowDeactivate = DISPID_UNKNOWN;
 
     void Reset() {
         documentBeforeSave = DISPID_UNKNOWN;
         documentBeforeClose = DISPID_UNKNOWN;
         documentChange = DISPID_UNKNOWN;
+        windowActivate = DISPID_UNKNOWN;
         windowDeactivate = DISPID_UNKNOWN;
     }
 };
 
-struct DispatchMemberIdCacheEntry {
-    GUID typeGuid = GUID_NULL;
-    bool hasTypeGuid = false;
-    const wchar_t* name = nullptr;
+enum class WordMember {
+    ApplicationActiveWindow,
+    ApplicationWindows,
+    ApplicationHwnd,
+    ApplicationActiveDocument,
+    ApplicationActiveProtectedViewWindow,
+    ApplicationDocuments,
+    WindowHwnd,
+    WindowDocument,
+    WindowsCount,
+    WindowsItem,
+    DocumentsCount,
+    DocumentsItem,
+    DocumentApplication,
+    DocumentSaved,
+    DocumentReadOnly,
+    DocumentPath,
+    DocumentFullName,
+    DocumentName,
+    DocumentSave,
+    Count,
+};
+
+struct WordMemberIdCacheEntry {
     DISPID dispId = DISPID_UNKNOWN;
-    ULONGLONG lastUseTime = 0;
+    bool resolved = false;
 };
 
 template <typename T>
@@ -221,11 +277,14 @@ public:
             return;
         }
 
-        if (m_ptr) {
-            m_ptr->Release();
-        }
-
+        // Publish the replacement before Release. Releasing an STA proxy can
+        // pump messages and re-enter the mod; no re-entrant observer may see
+        // a pointer whose final Release is already in progress.
+        T* previous = m_ptr;
         m_ptr = ptr;
+        if (previous) {
+            previous->Release();
+        }
     }
 
     T* Detach() {
@@ -369,14 +428,76 @@ private:
 // Global State
 // ============================================================================
 
-struct {
+struct RuntimeSettings {
     int saveDelay;
     int minTimeBetweenSaves;
-} g_settings;
+};
+
+RuntimeSettings g_settings = {};
 
 TranslateMessage_t g_originalTranslateMessage = nullptr;
 
 class WordApplicationEventSink;
+
+enum class AutomationFailureClass {
+    None,
+    Busy,
+    Disconnected,
+    Hard,
+};
+
+enum class SaveRetryReason {
+    None,
+    AutomationBusy,
+    HardFailure,
+    TargetUnavailable,
+    DeferredProtectedView,
+    InactiveWindow,
+    UiPaused,
+    InputBusy,
+};
+
+enum class DocumentRetryReason {
+    None,
+    Busy,
+    Disconnected,
+    Hard,
+    InactiveWindow,
+    UiPaused,
+    InputBusy,
+};
+
+enum class SaveResumeSignal {
+    None,
+    WordActivated,
+    DocumentChanged,
+    UiReleased,
+    ActionBoundary,
+};
+
+enum class ComRetryProfile {
+    Background,
+    CriticalClose,
+    LegacyLifecycle,
+};
+
+struct RuntimeSaveRetryState {
+    SaveRetryReason reason = SaveRetryReason::None;
+    SaveRetryReason lastLoggedReason = SaveRetryReason::None;
+    DWORD automationNextDelayMs = SAVE_AUTOMATION_RETRY_INITIAL_MS;
+    DWORD hardNextDelayMs = SAVE_HARD_RETRY_INITIAL_MS;
+    DWORD targetNextDelayMs = SAVE_TARGET_RETRY_INITIAL_MS;
+    ULONGLONG lastReasonLogTime = 0;
+};
+
+struct RuntimeDocumentRetryState {
+    DocumentRetryReason reason = DocumentRetryReason::None;
+    DocumentRetryReason lastLoggedReason = DocumentRetryReason::None;
+    DWORD busyNextDelayMs = DOCUMENT_BUSY_RETRY_INITIAL_MS;
+    DWORD disconnectedNextDelayMs = DOCUMENT_TARGET_RETRY_INITIAL_MS;
+    DWORD hardNextDelayMs = DOCUMENT_HARD_RETRY_INITIAL_MS;
+    ULONGLONG lastReasonLogTime = 0;
+};
 
 struct RuntimeTimingState {
     UINT_PTR schedulerTimerId = 0;
@@ -390,8 +511,6 @@ struct RuntimeTimingState {
     ULONGLONG lastEventConnectAttemptTime = 0;
     ULONGLONG lastTextInputKeyDownTime = 0;
     ULONGLONG pendingSaveAsTime = 0;
-    DWORD saveRetryDelayMs = MIN_RETRY_INTERVAL_MS;
-    DWORD documentStateRetryDelayMs = MIN_RETRY_INTERVAL_MS;
 };
 
 struct RuntimeStatusState {
@@ -412,10 +531,34 @@ struct RuntimeDocumentState {
     ScopedComPtr<IUnknown> observedDocumentIdentity;
     ScopedComPtr<IUnknown> pendingSaveAsDocumentIdentity;
     ScopedComPtr<IUnknown> transitionFlushDocumentIdentity;
+    unsigned int observedDocumentGeneration = 0;
+    unsigned int transitionFlushGeneration = 0;
+    unsigned int pendingSaveAsGeneration = 0;
+};
+
+struct RuntimeAutomationCacheState {
+    ScopedComPtr<IDispatch> application;
+    ScopedComPtr<IUnknown> applicationIdentity;
+    LONG_PTR applicationHwnd = 0;
+    ScopedComPtr<IDispatch> activeDocument;
+    ScopedComPtr<IUnknown> activeDocumentIdentity;
+    ScopedBstr activeDocumentPath;
+    unsigned int applicationGeneration = 0;
+    unsigned int documentGeneration = 0;
+    unsigned int resetDepth = 0;
+    unsigned int activeDocumentResetDepth = 0;
+    bool activeDocumentStale = true;
+    bool activeDocumentMetadataValid = false;
+    bool activeDocumentReadOnly = false;
+    bool activeDocumentHasPath = false;
 };
 
 struct WordEventSession {
     WordEventSession() = default;
+    ~WordEventSession() {
+        Reset();
+    }
+
     WordEventSession(const WordEventSession&) = delete;
     WordEventSession& operator=(const WordEventSession&) = delete;
     WordEventSession(WordEventSession&& other) noexcept {
@@ -424,7 +567,10 @@ struct WordEventSession {
 
     WordEventSession& operator=(WordEventSession&& other) noexcept {
         if (this != &other) {
-            Reset();
+            // Publish the replacement before releasing the previous session.
+            // A COM Release can pump messages and re-enter event management.
+            WordEventSession previous;
+            previous.MoveFrom(this);
             MoveFrom(&other);
         }
 
@@ -439,16 +585,29 @@ struct WordEventSession {
     DWORD cookie = 0;
 
     void Reset() {
+        // Make the aggregate observably disconnected before any Release.
         applicationHwnd = 0;
-        application.Reset();
-        connectionPoint.Reset();
-        sink.Reset();
         sinkControl = nullptr;
         cookie = 0;
+
+        // Keep the sink alive while the application and connection point are
+        // released, but detach every field before the first Release so a
+        // re-entrant replacement can't be erased by the remainder of Reset.
+        ScopedComPtr<IDispatch> previousSink;
+        ScopedComPtr<IConnectionPoint> previousConnectionPoint;
+        ScopedComPtr<IDispatch> previousApplication;
+        previousSink.Reset(sink.Detach());
+        previousConnectionPoint.Reset(connectionPoint.Detach());
+        previousApplication.Reset(application.Detach());
     }
 
     bool IsConnected() const {
         return connectionPoint && cookie != 0;
+    }
+
+    bool IsEmpty() const {
+        return applicationHwnd == 0 && !application && !connectionPoint &&
+               !sink && !sinkControl && cookie == 0;
     }
 
 private:
@@ -472,7 +631,17 @@ private:
 
 struct RuntimeEventState {
     WordEventSession session;
+    // A connection candidate lives in runtime-owned storage until commit or a
+    // proven Unadvise. This prevents a failed rollback from dying with a stack
+    // temporary when the deferred-disconnect queue is full.
+    WordEventSession stagedSession;
     WordEventSession pendingDisconnectSessions[WORD_EVENT_PENDING_DISCONNECT_CAPACITY];
+    WordEventDispIds cachedDispIds;
+    bool cachedDispIdsValid = false;
+    unsigned int connectionEpoch = 0;
+    unsigned int connectionBuildDepth = 0;
+    unsigned int primaryDisconnectDepth = 0;
+    unsigned int pendingDisconnectRetryDepth = 0;
 };
 
 struct RuntimeUiCacheState {
@@ -482,62 +651,122 @@ struct RuntimeUiCacheState {
 };
 
 struct RuntimeFlagState {
-    volatile LONG pendingSave = FALSE;
-    volatile LONG documentDirtyKnown = FALSE;
-    volatile LONG documentDirty = FALSE;
-    volatile LONG manualSavePending = FALSE;
-    volatile LONG expeditedSavePending = FALSE;
-    volatile LONG transitionFlushPending = FALSE;
-    volatile LONG imeComposing = FALSE;
-    volatile LONG automationBusyPending = FALSE;
-    volatile LONG pendingSaveAsMigration = FALSE;
-    volatile LONG wordEventsConnected = FALSE;
-    volatile LONG wordEventDisconnectRetryPending = FALSE;
-    volatile LONG autoSaveInProgress = FALSE;
-    volatile LONG postTransitionRefreshPending = FALSE;
-    volatile LONG suppressNextCharacterInput = FALSE;
-    volatile LONG moduleActive = FALSE;
+    std::atomic<LONG> pendingSave{FALSE};
+    std::atomic<LONG> documentDirtyKnown{FALSE};
+    std::atomic<LONG> documentDirty{FALSE};
+    std::atomic<LONG> manualSavePending{FALSE};
+    std::atomic<LONG> expeditedSavePending{FALSE};
+    std::atomic<LONG> transitionFlushPending{FALSE};
+    std::atomic<LONG> imeComposing{FALSE};
+    std::atomic<LONG> automationBusyPending{FALSE};
+    std::atomic<LONG> pendingSaveAsMigration{FALSE};
+    std::atomic<LONG> wordEventsConnected{FALSE};
+    std::atomic<LONG> wordEventDisconnectRetryPending{FALSE};
+    std::atomic<LONG> autoSaveInProgress{FALSE};
+    std::atomic<LONG> postTransitionRefreshPending{FALSE};
+    std::atomic<LONG> suppressNextCharacterInput{FALSE};
+    std::atomic<LONG> moduleActive{FALSE};
 };
+
+static_assert(std::atomic<LONG>::is_always_lock_free,
+              "runtime flags require lock-free 32-bit atomics");
 
 struct RuntimeState {
     DWORD wordProcessId = 0;
     volatile LONG ownerThreadId = 0;
+    unsigned int ownerWorkDepth = 0;
+    bool shutdownInProgress = false;
     RuntimeTimingState timing;
+    RuntimeSaveRetryState saveRetry;
+    RuntimeDocumentRetryState documentRetry;
     RuntimeStatusState status;
     RuntimeDocumentState document;
+    RuntimeAutomationCacheState automation;
     RuntimeEventState events;
     RuntimeUiCacheState ui;
-    DispatchMemberIdCacheEntry
-        dispatchMemberIdCache[DISPATCH_MEMBER_ID_CACHE_CAPACITY] = {};
+    WordMemberIdCacheEntry
+        wordMemberIdCache[static_cast<size_t>(WordMember::Count)] = {};
     RuntimeFlagState flags;
 };
 
 RuntimeState g_runtime = {};
 UINT g_startupBootstrapMessage = 0;
 
+enum RuntimeControlRequest : LONG {
+    RuntimeControlApplySettings = 1 << 0,
+    RuntimeControlShutdown = 1 << 1,
+    RuntimeControlRepairScheduler = 1 << 2,
+};
+
+enum RuntimeControlLifecycle : LONG {
+    RuntimeControlAwaitingOwner = 0,
+    RuntimeControlOwnerActive = 1,
+    RuntimeControlStopRequested = 2,
+    RuntimeControlStopped = 3,
+};
+
+enum RuntimeShutdownOutcome : LONG {
+    RuntimeShutdownPending = 0,
+    RuntimeShutdownCompleted = 1,
+    RuntimeShutdownFallbackClaimed = 2,
+};
+
+struct RuntimeControlState {
+    std::atomic<LONG> pendingRequests = 0;
+    std::atomic<LONG> lifecycle = RuntimeControlAwaitingOwner;
+    std::atomic<ULONG> settingsSequence = 0;
+    std::atomic<ULONG> appliedSettingsSequence = 0;
+    std::atomic<ULONGLONG> packedSettings = 0;
+    std::atomic<HWND> messageWindow = nullptr;
+    std::atomic<bool> ownerRuntimeLive = false;
+    std::atomic<bool> shutdownRequested = false;
+    std::atomic<bool> shutdownComplete = false;
+    std::atomic<LONG> shutdownOutcome = RuntimeShutdownPending;
+    std::atomic<bool> requiresPinnedShutdown = false;
+    std::atomic<bool> modulePinnedForSafety = false;
+    HANDLE shutdownCompleteEvent = nullptr;
+};
+
+RuntimeControlState g_control;
+
 // ============================================================================
 // Utility Helpers
 // ============================================================================
 
-bool LoadFlag(const volatile LONG& value) {
-    return InterlockedCompareExchange(const_cast<volatile LONG*>(&value), TRUE, TRUE) == TRUE;
+bool LoadFlag(const std::atomic<LONG>& value) {
+    return value.load(std::memory_order_acquire) != FALSE;
 }
 
-void StoreFlag(volatile LONG& value, bool enabled) {
-    InterlockedExchange(&value, enabled ? TRUE : FALSE);
+void StoreFlag(std::atomic<LONG>& value, bool enabled) {
+    value.store(enabled ? TRUE : FALSE, std::memory_order_release);
 }
 
-void SetFlag(volatile LONG& value) {
+void SetFlag(std::atomic<LONG>& value) {
     StoreFlag(value, true);
 }
 
-void ClearFlag(volatile LONG& value) {
+void ClearFlag(std::atomic<LONG>& value) {
     StoreFlag(value, false);
+}
+
+bool LoadInterlockedFlag(const volatile LONG& value) {
+    return InterlockedCompareExchange(
+               const_cast<volatile LONG*>(&value),
+               FALSE,
+               FALSE) != FALSE;
+}
+
+void SetInterlockedFlag(volatile LONG& value) {
+    InterlockedExchange(&value, TRUE);
+}
+
+void ClearInterlockedFlag(volatile LONG& value) {
+    InterlockedExchange(&value, FALSE);
 }
 
 class ScopedFlagSet {
 public:
-    explicit ScopedFlagSet(volatile LONG& flag) : m_flag(&flag) {
+    explicit ScopedFlagSet(std::atomic<LONG>& flag) : m_flag(&flag) {
         SetFlag(*m_flag);
     }
 
@@ -551,7 +780,45 @@ public:
     }
 
 private:
-    volatile LONG* m_flag = nullptr;
+    std::atomic<LONG>* m_flag = nullptr;
+};
+
+class ScopedInterlockedCount {
+public:
+    explicit ScopedInterlockedCount(volatile LONG& value) : m_value(&value) {
+        InterlockedIncrement(m_value);
+    }
+
+    ScopedInterlockedCount(const ScopedInterlockedCount&) = delete;
+    ScopedInterlockedCount& operator=(const ScopedInterlockedCount&) = delete;
+
+    ~ScopedInterlockedCount() {
+        if (m_value) {
+            InterlockedDecrement(m_value);
+        }
+    }
+
+private:
+    volatile LONG* m_value = nullptr;
+};
+
+class ScopedOwnerDepth {
+public:
+    explicit ScopedOwnerDepth(unsigned int& value) : m_value(&value) {
+        ++*m_value;
+    }
+
+    ScopedOwnerDepth(const ScopedOwnerDepth&) = delete;
+    ScopedOwnerDepth& operator=(const ScopedOwnerDepth&) = delete;
+
+    ~ScopedOwnerDepth() {
+        if (m_value && *m_value != 0) {
+            --*m_value;
+        }
+    }
+
+private:
+    unsigned int* m_value = nullptr;
 };
 
 DWORD LoadOwnerThreadId() {
@@ -580,13 +847,43 @@ bool IsOwnerThread() {
     return ownerThreadId != 0 && GetCurrentThreadId() == ownerThreadId;
 }
 
-void ClearDispatchMemberIdCache() {
-    for (int index = 0; index < DISPATCH_MEMBER_ID_CACHE_CAPACITY; ++index) {
-        g_runtime.dispatchMemberIdCache[index].typeGuid = GUID_NULL;
-        g_runtime.dispatchMemberIdCache[index].hasTypeGuid = false;
-        g_runtime.dispatchMemberIdCache[index].name = nullptr;
-        g_runtime.dispatchMemberIdCache[index].dispId = DISPID_UNKNOWN;
-        g_runtime.dispatchMemberIdCache[index].lastUseTime = 0;
+void ProcessOwnerControlRequests();
+void SignalOwnerShutdownComplete();
+void QueueOwnerControlRequest(LONG request);
+
+class ScopedOwnerRuntimeWork {
+public:
+    ScopedOwnerRuntimeWork() : m_active(IsOwnerThread()) {
+        if (m_active) {
+            ++g_runtime.ownerWorkDepth;
+        }
+    }
+
+    ScopedOwnerRuntimeWork(const ScopedOwnerRuntimeWork&) = delete;
+    ScopedOwnerRuntimeWork& operator=(const ScopedOwnerRuntimeWork&) = delete;
+
+    ~ScopedOwnerRuntimeWork() {
+        if (!m_active) {
+            return;
+        }
+
+        if (g_runtime.ownerWorkDepth > 0) {
+            --g_runtime.ownerWorkDepth;
+        }
+
+        if (g_runtime.ownerWorkDepth == 0) {
+            ProcessOwnerControlRequests();
+        }
+    }
+
+private:
+    bool m_active = false;
+};
+
+void ClearWordMemberIdCache() {
+    for (WordMemberIdCacheEntry& entry : g_runtime.wordMemberIdCache) {
+        entry.dispId = DISPID_UNKNOWN;
+        entry.resolved = false;
     }
 }
 
@@ -608,7 +905,16 @@ bool ReplaceStoredComPtr(ScopedComPtr<T>* storage, T* value) {
     return true;
 }
 
-bool AreSameDocumentPath(const wchar_t* left, const wchar_t* right);
+enum class DocumentPathTextComparison {
+    Equal,
+    Different,
+    RequiresResolution,
+};
+
+DocumentPathTextComparison CompareDocumentPathText(const wchar_t* left,
+                                                   const wchar_t* right);
+bool AreSameDocumentPathText(const wchar_t* left, const wchar_t* right);
+bool AreSameResolvedDocumentPath(const wchar_t* left, const wchar_t* right);
 bool ReplaceStoredBstr(BSTR* storage, const wchar_t* value);
 bool ReplaceStoredBstr(ScopedBstr* storage, const wchar_t* value);
 bool ReplaceStoredTextBstr(BSTR* storage, const wchar_t* value);
@@ -617,13 +923,13 @@ void LogSaveStatus(const wchar_t* message);
 void LogDocumentStateStatus(const wchar_t* message);
 bool AreModifiersOrMouseButtonsHeld();
 HRESULT GetComIdentity(IUnknown* unknown, IUnknown** result);
-HRESULT GetDispatchTypeGuid(IDispatch* dispatch, GUID* result);
 HRESULT GetDocumentIdentityAndPathState(IDispatch* document,
                                         BSTR* result,
                                         bool* hasSavedPath);
 HRESULT GetWordDocumentFromActiveWindow(IDispatch** document);
 bool IsWindowInCurrentWordProcess(HWND hwnd);
 void InvalidateTransitionFlushDocumentCache();
+bool IsWordEventTeardownInProgress();
 struct RuntimeFlagSnapshot;
 DWORD GetSteadyDocumentStatePollDelay(const RuntimeFlagSnapshot* flags = nullptr);
 
@@ -666,6 +972,8 @@ enum class ScheduledTaskScheduleMode {
     ArmEarlier,
     Reschedule,
 };
+
+bool IsScheduledTaskArmed(ScheduledTaskKind taskKind);
 
 enum class RuntimeResetMode {
     Shutdown,
@@ -715,6 +1023,65 @@ bool IsOwnerCandidateMessage(UINT message) {
     }
 
     return false;
+}
+
+enum class HookMessageRoute {
+    Ignore,
+    AdoptOwner,
+    HandleOnOwner,
+};
+
+bool IsAutosaveRelevantMessage(UINT message) {
+    switch (message) {
+        case WM_KEYDOWN:
+        case WM_SYSKEYDOWN:
+        case WM_CHAR:
+        case WM_LBUTTONUP:
+        case WM_RBUTTONUP:
+        case WM_MBUTTONUP:
+        case WM_XBUTTONUP:
+        case WM_MOUSEWHEEL:
+        case WM_MOUSEHWHEEL:
+        case WM_COMMAND:
+        case WM_PASTE:
+        case WM_CUT:
+        case WM_UNDO:
+        case WM_CONTEXTMENU:
+        case WM_ACTIVATE:
+        case WM_ACTIVATEAPP:
+        case WM_KILLFOCUS:
+        case WM_SETFOCUS:
+        case WM_NCACTIVATE:
+        case WM_DESTROY:
+        case WM_CLOSE:
+        case WM_QUERYENDSESSION:
+        case WM_ENDSESSION:
+        case WM_SYSCOMMAND:
+        case WM_IME_STARTCOMPOSITION:
+        case WM_IME_ENDCOMPOSITION:
+        case WM_EXITMENULOOP:
+        case WM_CANCELMODE:
+            return true;
+    }
+
+    return false;
+}
+
+HookMessageRoute SelectHookMessageRoute(bool relevantMessage,
+                                        bool controlRequestPending,
+                                        DWORD ownerThreadId,
+                                        DWORD currentThreadId) {
+    if (!relevantMessage && !controlRequestPending) {
+        return HookMessageRoute::Ignore;
+    }
+
+    if (ownerThreadId == 0) {
+        return HookMessageRoute::AdoptOwner;
+    }
+
+    return ownerThreadId == currentThreadId
+               ? HookMessageRoute::HandleOnOwner
+               : HookMessageRoute::Ignore;
 }
 
 bool ShouldAttemptOwnerThreadAdoptionForState(
@@ -767,6 +1134,149 @@ bool IsActionBoundaryMessage(const MSG* lpMsg) {
         case WM_ENDSESSION:
         case WM_SYSCOMMAND:
             return true;
+    }
+
+    return false;
+}
+
+SaveResumeSignal ClassifySaveResumeSignal(const MSG* lpMsg) {
+    if (!lpMsg) {
+        return SaveResumeSignal::None;
+    }
+
+    switch (lpMsg->message) {
+        case WM_ACTIVATE:
+            return LOWORD(lpMsg->wParam) != WA_INACTIVE
+                       ? SaveResumeSignal::WordActivated
+                       : SaveResumeSignal::None;
+
+        case WM_ACTIVATEAPP:
+        case WM_NCACTIVATE:
+            return lpMsg->wParam != FALSE
+                       ? SaveResumeSignal::WordActivated
+                       : SaveResumeSignal::None;
+
+        case WM_SETFOCUS:
+            return SaveResumeSignal::UiReleased;
+
+        case WM_IME_ENDCOMPOSITION:
+        case WM_EXITMENULOOP:
+        case WM_CANCELMODE:
+            return SaveResumeSignal::UiReleased;
+
+        case WM_LBUTTONUP:
+        case WM_RBUTTONUP:
+        case WM_MBUTTONUP:
+        case WM_XBUTTONUP:
+        case WM_MOUSEWHEEL:
+        case WM_MOUSEHWHEEL:
+        case WM_COMMAND:
+        case WM_PASTE:
+        case WM_CUT:
+        case WM_UNDO:
+        case WM_CONTEXTMENU:
+            return SaveResumeSignal::ActionBoundary;
+    }
+
+    return SaveResumeSignal::None;
+}
+
+bool ShouldResumeSaveForSignal(SaveRetryReason reason,
+                               SaveResumeSignal signal) {
+    if (reason == SaveRetryReason::None || signal == SaveResumeSignal::None) {
+        return false;
+    }
+
+    switch (signal) {
+        case SaveResumeSignal::WordActivated:
+        case SaveResumeSignal::DocumentChanged:
+            return true;
+
+        case SaveResumeSignal::UiReleased:
+        case SaveResumeSignal::ActionBoundary:
+            return reason == SaveRetryReason::AutomationBusy ||
+                   reason == SaveRetryReason::UiPaused ||
+                   reason == SaveRetryReason::InputBusy;
+
+        case SaveResumeSignal::None:
+            return false;
+    }
+
+    return false;
+}
+
+bool ShouldResumeDocumentForSignal(DocumentRetryReason reason,
+                                   SaveResumeSignal signal) {
+    if (reason == DocumentRetryReason::None ||
+        signal == SaveResumeSignal::None) {
+        return false;
+    }
+
+    switch (signal) {
+        case SaveResumeSignal::WordActivated:
+        case SaveResumeSignal::DocumentChanged:
+            return true;
+
+        case SaveResumeSignal::UiReleased:
+        case SaveResumeSignal::ActionBoundary:
+            return reason == DocumentRetryReason::Busy ||
+                   reason == DocumentRetryReason::UiPaused ||
+                   reason == DocumentRetryReason::InputBusy;
+
+        case SaveResumeSignal::None:
+            return false;
+    }
+
+    return false;
+}
+
+bool IsDocumentFailureRetryReason(DocumentRetryReason reason) {
+    return reason == DocumentRetryReason::Busy ||
+           reason == DocumentRetryReason::Disconnected ||
+           reason == DocumentRetryReason::Hard;
+}
+
+bool ShouldWakeSaveForOrdinaryFallback(SaveRetryReason reason,
+                                       bool saveTimerArmed) {
+    return !saveTimerArmed ||
+           reason == SaveRetryReason::None ||
+           ShouldResumeSaveForSignal(reason, SaveResumeSignal::ActionBoundary);
+}
+
+bool ShouldWakeDocumentForOrdinaryFallback(DocumentRetryReason reason,
+                                           bool documentTimerArmed) {
+    return !documentTimerArmed ||
+           reason == DocumentRetryReason::None ||
+           ShouldResumeDocumentForSignal(reason,
+                                         SaveResumeSignal::ActionBoundary);
+}
+
+bool ShouldApplyMessageAutosaveRole(MessageAutosaveRole role,
+                                    bool pendingAutosave,
+                                    SaveRetryReason saveReason,
+                                    bool saveTimerArmed,
+                                    DocumentRetryReason documentReason,
+                                    bool documentTimerArmed) {
+    switch (role) {
+        case MessageAutosaveRole::TextKeyDownInput:
+        case MessageAutosaveRole::EditingInput:
+        case MessageAutosaveRole::TransitionBoundaryFallback:
+            return true;
+
+        case MessageAutosaveRole::DocumentRefreshFallback:
+            return ShouldWakeDocumentForOrdinaryFallback(documentReason,
+                                                         documentTimerArmed);
+
+        case MessageAutosaveRole::ActionBoundaryFallback:
+            return pendingAutosave
+                       ? ShouldWakeSaveForOrdinaryFallback(saveReason,
+                                                           saveTimerArmed)
+                       : ShouldWakeDocumentForOrdinaryFallback(
+                             documentReason,
+                             documentTimerArmed);
+
+        case MessageAutosaveRole::None:
+            return false;
     }
 
     return false;
@@ -846,19 +1356,60 @@ bool IsRetryableAutomationFailure(HRESULT hr) {
     return hr == RPC_E_CALL_REJECTED || hr == RPC_E_SERVERCALL_RETRYLATER;
 }
 
-bool ShouldLogFailureNow(ULONGLONG* lastLogTime) {
+bool IsTerminalAutomationObjectFailure(HRESULT hr) {
+    return hr == kCoEObjectNotConnected ||
+           hr == RPC_E_DISCONNECTED ||
+           hr == RPC_E_SERVER_DIED ||
+           hr == RPC_E_SERVER_DIED_DNE ||
+           hr == HRESULT_FROM_WIN32(RPC_S_SERVER_UNAVAILABLE);
+}
+
+AutomationFailureClass ClassifyAutomationFailure(HRESULT hr) {
+    if (IsRetryableAutomationFailure(hr)) {
+        return AutomationFailureClass::Busy;
+    }
+
+    if (IsTerminalAutomationObjectFailure(hr)) {
+        return AutomationFailureClass::Disconnected;
+    }
+
+    return FAILED(hr) ? AutomationFailureClass::Hard
+                      : AutomationFailureClass::None;
+}
+
+bool ShouldLogFailureNow(ULONGLONG* lastLogTime,
+                         DWORD intervalMs) {
     if (!lastLogTime) {
         return true;
     }
 
     const ULONGLONG now = GetTickCount64();
     const ULONGLONG previous = *lastLogTime;
-    if (previous != 0 && now - previous < FAILURE_LOG_INTERVAL_MS) {
+    if (previous != 0 && now - previous < intervalMs) {
         return false;
     }
 
     *lastLogTime = now;
     return true;
+}
+
+bool ShouldLogRetryReasonNow(int lastReason,
+                             int reason,
+                             ULONGLONG lastLogTime,
+                             ULONGLONG now,
+                             DWORD reminderIntervalMs) {
+    if (reason == 0) {
+        return false;
+    }
+
+    if (lastLogTime == 0) {
+        return true;
+    }
+
+    const DWORD intervalMs = lastReason == reason
+                                 ? reminderIntervalMs
+                                 : RETRY_REASON_CHANGE_LOG_INTERVAL_MS;
+    return now - lastLogTime >= intervalMs;
 }
 
 bool ShouldLogStatusNow(ULONGLONG* lastLogTime) {
@@ -917,22 +1468,28 @@ bool ShouldLogStatusMessageNow(ScopedBstr* lastMessage,
     return true;
 }
 
-DWORD AdvanceRetryDelay(DWORD* retryDelayMs, DWORD maxRetryDelayMs) {
+DWORD AdvanceRetryDelayForPolicy(DWORD* retryDelayMs,
+                                 DWORD initialDelayMs,
+                                 DWORD maxRetryDelayMs) {
     if (!retryDelayMs) {
-        return MIN_RETRY_INTERVAL_MS;
+        return initialDelayMs;
     }
 
     DWORD delayMs = *retryDelayMs;
-    if (delayMs < MIN_RETRY_INTERVAL_MS) {
-        delayMs = MIN_RETRY_INTERVAL_MS;
+    if (delayMs < initialDelayMs) {
+        delayMs = initialDelayMs;
+    }
+    if (delayMs > maxRetryDelayMs) {
+        delayMs = maxRetryDelayMs;
     }
 
     DWORD nextDelayMs = delayMs;
     if (nextDelayMs < maxRetryDelayMs) {
-        if (nextDelayMs > maxRetryDelayMs / 2) {
+        nextDelayMs = nextDelayMs > maxRetryDelayMs / 2
+                          ? maxRetryDelayMs
+                          : nextDelayMs * 2;
+        if (nextDelayMs > maxRetryDelayMs) {
             nextDelayMs = maxRetryDelayMs;
-        } else {
-            nextDelayMs *= 2;
         }
     }
 
@@ -940,7 +1497,27 @@ DWORD AdvanceRetryDelay(DWORD* retryDelayMs, DWORD maxRetryDelayMs) {
     return delayMs;
 }
 
-bool AreSameDocumentPath(const wchar_t* left, const wchar_t* right);
+DWORD GetComRetryBudgetMs(ComRetryProfile profile) {
+    return profile == ComRetryProfile::Background
+               ? COM_BACKGROUND_RETRY_BUDGET_MS
+               : COM_MESSAGE_FILTER_CANCEL_AFTER_MS;
+}
+
+DWORD SelectRejectedCallRetryDelay(ComRetryProfile profile,
+                                   DWORD rejectType,
+                                   DWORD elapsedMs,
+                                   ULONGLONG now,
+                                   ULONGLONG deadline) {
+    if (rejectType != SERVERCALL_RETRYLATER ||
+        elapsedMs >= GetComRetryBudgetMs(profile) ||
+        now >= deadline) {
+        return static_cast<DWORD>(-1);
+    }
+
+    return profile == ComRetryProfile::Background
+               ? COM_BACKGROUND_RETRY_DELAY_MS
+               : COM_MESSAGE_FILTER_RETRY_DELAY_MS;
+}
 
 bool ReplaceStoredBstr(BSTR* storage, const wchar_t* value) {
     if (!storage) {
@@ -949,7 +1526,11 @@ bool ReplaceStoredBstr(BSTR* storage, const wchar_t* value) {
 
     const bool currentEmpty = !*storage || !**storage;
     const bool valueEmpty = !value || !*value;
-    if ((!currentEmpty || !valueEmpty) && AreSameDocumentPath(*storage, value)) {
+    if (currentEmpty && valueEmpty) {
+        return true;
+    }
+    if (!currentEmpty && !valueEmpty &&
+        AreSameDocumentPathText(*storage, value)) {
         return true;
     }
 
@@ -976,7 +1557,11 @@ bool ReplaceStoredBstr(ScopedBstr* storage, const wchar_t* value) {
 
     const bool currentEmpty = !storage->Get() || !*storage->Get();
     const bool valueEmpty = !value || !*value;
-    if ((!currentEmpty || !valueEmpty) && AreSameDocumentPath(storage->Get(), value)) {
+    if (currentEmpty && valueEmpty) {
+        return true;
+    }
+    if (!currentEmpty && !valueEmpty &&
+        AreSameDocumentPathText(storage->Get(), value)) {
         return true;
     }
 
@@ -1071,7 +1656,8 @@ bool IsAsciiDriveLetter(wchar_t value) {
 }
 
 bool HasWin32NamespacePrefix(const wchar_t* path, DWORD pathLength) {
-    return pathLength > 4 &&
+    return path &&
+           pathLength >= 4 &&
            path[0] == L'\\' &&
            path[1] == L'\\' &&
            path[2] == L'?' &&
@@ -1124,43 +1710,8 @@ bool StoreNormalizedFinalPath(const wchar_t* finalPath, DWORD finalPathLength, S
     return true;
 }
 
-bool TryGetCanonicalDocumentPath(const wchar_t* path, ScopedBstr* result) {
-    if (!path || !*path || !result) {
-        return false;
-    }
-
-    wchar_t fullPath[MAX_CANONICAL_PATH_CHARS] = {};
-    const DWORD fullPathLength =
-        GetFullPathNameW(path, ARRAYSIZE(fullPath), fullPath, nullptr);
-    if (fullPathLength == 0 || fullPathLength >= ARRAYSIZE(fullPath)) {
-        return false;
-    }
-
-    ScopedHandle file(CreateFileW(fullPath,
-                                  0,
-                                  FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                                  nullptr,
-                                  OPEN_EXISTING,
-                                  FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS,
-                                  nullptr));
-    if (!file.IsValid()) {
-        return StoreNormalizedFinalPath(fullPath, fullPathLength, result);
-    }
-
-    wchar_t finalPath[MAX_CANONICAL_PATH_CHARS] = {};
-    const DWORD finalPathLength =
-        GetFinalPathNameByHandleW(file.Get(),
-                                  finalPath,
-                                  ARRAYSIZE(finalPath),
-                                  FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
-    if (finalPathLength == 0 || finalPathLength >= ARRAYSIZE(finalPath)) {
-        return StoreNormalizedFinalPath(fullPath, fullPathLength, result);
-    }
-
-    return StoreNormalizedFinalPath(finalPath, finalPathLength, result);
-}
-
-bool AreSameNormalizedDocumentPathText(const wchar_t* left, const wchar_t* right) {
+bool AreSameNormalizedDocumentPathText(const wchar_t* left,
+                                       const wchar_t* right) {
     const bool leftEmpty = !left || !*left;
     const bool rightEmpty = !right || !*right;
     if (leftEmpty || rightEmpty) {
@@ -1170,8 +1721,18 @@ bool AreSameNormalizedDocumentPathText(const wchar_t* left, const wchar_t* right
     auto isSlash = [](wchar_t value) {
         return value == L'\\' || value == L'/';
     };
-    auto normalizedLength = [&isSlash](const wchar_t* value) {
-        int length = lstrlenW(value);
+    const int rawLeftLength = lstrlenW(left);
+    const int rawRightLength = lstrlenW(right);
+    const bool hasWin32Namespace =
+        HasWin32NamespacePrefix(left, static_cast<DWORD>(rawLeftLength)) ||
+        HasWin32NamespacePrefix(right, static_cast<DWORD>(rawRightLength));
+    auto normalizedLength = [&isSlash, hasWin32Namespace](const wchar_t* value,
+                                                         int rawLength) {
+        if (hasWin32Namespace) {
+            return rawLength;
+        }
+
+        int length = rawLength;
         while (length > 3 && isSlash(value[length - 1])) {
             --length;
         }
@@ -1179,15 +1740,35 @@ bool AreSameNormalizedDocumentPathText(const wchar_t* left, const wchar_t* right
         return length;
     };
 
-    const int leftLength = normalizedLength(left);
-    const int rightLength = normalizedLength(right);
+    const int leftLength = normalizedLength(left, rawLeftLength);
+    const int rightLength = normalizedLength(right, rawRightLength);
     if (leftLength != rightLength) {
         return false;
     }
 
+    if (CompareStringOrdinal(left,
+                             leftLength,
+                             right,
+                             rightLength,
+                             TRUE) == CSTR_EQUAL) {
+        return true;
+    }
+
+    // The extended Win32 namespace deliberately disables normal Win32 path
+    // parsing. In particular, don't equate '/' with '\\' or remove a trailing
+    // separator there. A filesystem-backed comparison can still prove that two
+    // such spellings refer to the same file at explicitly rare call sites.
+    if (hasWin32Namespace) {
+        return false;
+    }
+
     for (int index = 0; index < leftLength; ++index) {
-        wchar_t leftChar = isSlash(left[index]) ? L'\\' : left[index];
-        wchar_t rightChar = isSlash(right[index]) ? L'\\' : right[index];
+        const wchar_t leftChar = isSlash(left[index]) ? L'\\' : left[index];
+        const wchar_t rightChar = isSlash(right[index]) ? L'\\' : right[index];
+        if (leftChar == rightChar) {
+            continue;
+        }
+
         if (CompareStringOrdinal(&leftChar, 1, &rightChar, 1, TRUE) != CSTR_EQUAL) {
             return false;
         }
@@ -1196,56 +1777,281 @@ bool AreSameNormalizedDocumentPathText(const wchar_t* left, const wchar_t* right
     return true;
 }
 
-bool AreSameDocumentPath(const wchar_t* left, const wchar_t* right) {
+DocumentPathTextComparison CompareDocumentPathText(const wchar_t* left,
+                                                   const wchar_t* right) {
     if (AreSameNormalizedDocumentPathText(left, right)) {
-        return true;
+        return DocumentPathTextComparison::Equal;
     }
 
     const bool leftEmpty = !left || !*left;
     const bool rightEmpty = !right || !*right;
     if (leftEmpty || rightEmpty) {
-        return false;
+        return DocumentPathTextComparison::Different;
     }
 
-    ScopedBstr canonicalLeft;
-    ScopedBstr canonicalRight;
-    if (!TryGetCanonicalDocumentPath(left, &canonicalLeft) ||
-        !TryGetCanonicalDocumentPath(right, &canonicalRight)) {
-        return false;
+    return DocumentPathTextComparison::RequiresResolution;
+}
+
+bool AreSameDocumentPathText(const wchar_t* left, const wchar_t* right) {
+    return CompareDocumentPathText(left, right) ==
+           DocumentPathTextComparison::Equal;
+}
+
+class GrowablePathBuffer {
+public:
+    GrowablePathBuffer() = default;
+
+    GrowablePathBuffer(const GrowablePathBuffer&) = delete;
+    GrowablePathBuffer& operator=(const GrowablePathBuffer&) = delete;
+
+    ~GrowablePathBuffer() {
+        delete[] m_data;
     }
 
-    return AreSameNormalizedDocumentPathText(canonicalLeft.CStr(), canonicalRight.CStr());
-}
+    bool EnsureCapacity(DWORD requiredCapacity) {
+        if (requiredCapacity == 0 ||
+            requiredCapacity > MAX_CANONICAL_PATH_CHARS) {
+            return false;
+        }
 
-bool SetObservedDocumentPath(const wchar_t* path) {
-    return ReplaceStoredBstr(&g_runtime.document.observedDocumentPath, path);
-}
+        if (m_capacity >= requiredCapacity) {
+            return true;
+        }
 
-bool SetTransitionFlushDocumentPath(const wchar_t* path) {
-    return ReplaceStoredBstr(&g_runtime.document.transitionFlushDocumentPath, path);
-}
+        DWORD newCapacity = m_capacity != 0 ? m_capacity : MAX_PATH;
+        while (newCapacity < requiredCapacity) {
+            if (newCapacity > MAX_CANONICAL_PATH_CHARS / 2) {
+                newCapacity = MAX_CANONICAL_PATH_CHARS;
+            } else {
+                newCapacity *= 2;
+            }
+        }
 
-bool SetTransitionFlushDocument(IDispatch* document) {
-    if (!ReplaceStoredComPtr(&g_runtime.document.transitionFlushDocument, document)) {
-        return false;
-    }
+        wchar_t* replacement = new (std::nothrow) wchar_t[newCapacity];
+        if (!replacement) {
+            return false;
+        }
 
-    if (!document) {
-        g_runtime.document.transitionFlushDocumentIdentity.Reset();
+        delete[] m_data;
+        m_data = replacement;
+        m_capacity = newCapacity;
         return true;
     }
 
-    IUnknown* identity = nullptr;
-    if (FAILED(GetComIdentity(document, &identity)) || !identity) {
-        g_runtime.document.transitionFlushDocument.Reset();
-        g_runtime.document.transitionFlushDocumentIdentity.Reset();
+    wchar_t* Data() const {
+        return m_data;
+    }
+
+    DWORD Capacity() const {
+        return m_capacity;
+    }
+
+private:
+    wchar_t* m_data = nullptr;
+    DWORD m_capacity = 0;
+};
+
+DWORD GetNextPathBufferCapacity(DWORD returnedLength,
+                                DWORD currentCapacity) {
+    if (returnedLength > MAX_CANONICAL_PATH_CHARS ||
+        currentCapacity > MAX_CANONICAL_PATH_CHARS) {
+        return 0;
+    }
+
+    if (returnedLength > currentCapacity) {
+        return returnedLength;
+    }
+
+    if (currentCapacity >= MAX_CANONICAL_PATH_CHARS) {
+        return 0;
+    }
+
+    return currentCapacity + 1;
+}
+
+bool TryGetFullPathText(const wchar_t* path,
+                        GrowablePathBuffer* buffer,
+                        DWORD* pathLength) {
+    if (!path || !*path || !buffer || !pathLength ||
+        !buffer->EnsureCapacity(MAX_PATH)) {
         return false;
     }
 
-    const bool replaced =
-        ReplaceStoredComPtr(&g_runtime.document.transitionFlushDocumentIdentity, identity);
-    identity->Release();
-    return replaced;
+    for (;;) {
+        const DWORD length = GetFullPathNameW(path,
+                                              buffer->Capacity(),
+                                              buffer->Data(),
+                                              nullptr);
+        if (length == 0) {
+            return false;
+        }
+
+        if (length < buffer->Capacity()) {
+            *pathLength = length;
+            return true;
+        }
+
+        const DWORD requiredCapacity =
+            GetNextPathBufferCapacity(length, buffer->Capacity());
+        if (!buffer->EnsureCapacity(requiredCapacity)) {
+            return false;
+        }
+    }
+}
+
+bool TryGetFinalPathText(HANDLE file,
+                         GrowablePathBuffer* buffer,
+                         DWORD* pathLength) {
+    if (!file || file == INVALID_HANDLE_VALUE || !buffer || !pathLength ||
+        !buffer->EnsureCapacity(MAX_PATH)) {
+        return false;
+    }
+
+    for (;;) {
+        const DWORD length = GetFinalPathNameByHandleW(
+            file,
+            buffer->Data(),
+            buffer->Capacity(),
+            FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
+        if (length == 0) {
+            return false;
+        }
+
+        if (length < buffer->Capacity()) {
+            *pathLength = length;
+            return true;
+        }
+
+        const DWORD requiredCapacity =
+            GetNextPathBufferCapacity(length, buffer->Capacity());
+        if (!buffer->EnsureCapacity(requiredCapacity)) {
+            return false;
+        }
+    }
+}
+
+bool TryGetResolvedDocumentPath(const wchar_t* path,
+                                ScopedBstr* result,
+                                GrowablePathBuffer* buffer) {
+    if (!path || !*path || !result || !buffer) {
+        return false;
+    }
+
+    result->Reset();
+
+    DWORD fullPathLength = 0;
+    if (!TryGetFullPathText(path, buffer, &fullPathLength)) {
+        return false;
+    }
+
+    ScopedHandle file(CreateFileW(buffer->Data(),
+                                  0,
+                                  FILE_SHARE_READ | FILE_SHARE_WRITE |
+                                      FILE_SHARE_DELETE,
+                                  nullptr,
+                                  OPEN_EXISTING,
+                                  FILE_ATTRIBUTE_NORMAL |
+                                      FILE_FLAG_BACKUP_SEMANTICS,
+                                  nullptr));
+    if (!file.IsValid()) {
+        return false;
+    }
+
+    DWORD finalPathLength = 0;
+    if (!TryGetFinalPathText(file.Get(), buffer, &finalPathLength)) {
+        return false;
+    }
+
+    return StoreNormalizedFinalPath(buffer->Data(), finalPathLength, result);
+}
+
+bool AreSameResolvedDocumentPath(const wchar_t* left, const wchar_t* right) {
+    const DocumentPathTextComparison comparison =
+        CompareDocumentPathText(left, right);
+    if (comparison == DocumentPathTextComparison::Equal) {
+        return true;
+    }
+
+    if (comparison == DocumentPathTextComparison::Different) {
+        return false;
+    }
+
+    GrowablePathBuffer buffer;
+    ScopedBstr resolvedLeft;
+    ScopedBstr resolvedRight;
+    if (!TryGetResolvedDocumentPath(left, &resolvedLeft, &buffer) ||
+        !TryGetResolvedDocumentPath(right, &resolvedRight, &buffer)) {
+        return false;
+    }
+
+    return AreSameDocumentPathText(resolvedLeft.CStr(), resolvedRight.CStr());
+}
+
+struct DetachedDocumentBinding {
+    // Declaration order keeps the identity alive until after document Release.
+    ScopedComPtr<IUnknown> identity;
+    ScopedComPtr<IDispatch> document;
+};
+
+void DetachDocumentBinding(ScopedComPtr<IDispatch>* document,
+                           ScopedComPtr<IUnknown>* identity,
+                           DetachedDocumentBinding* detached) {
+    if (!document || !identity || !detached) {
+        return;
+    }
+
+    detached->identity.Reset(identity->Detach());
+    detached->document.Reset(document->Detach());
+}
+
+struct PreparedTransitionFlushTarget {
+    ScopedBstr path;
+    ScopedComPtr<IUnknown> identity;
+    ScopedComPtr<IDispatch> document;
+};
+
+enum class TransitionFlushTargetPreparation {
+    Ready,
+    Failed,
+    Superseded,
+};
+
+TransitionFlushTargetPreparation PrepareTransitionFlushTarget(
+    const wchar_t* path,
+    IDispatch* document,
+    unsigned int expectedGeneration,
+    PreparedTransitionFlushTarget* target) {
+    if (!target || ((!path || !*path) && !document)) {
+        return TransitionFlushTargetPreparation::Failed;
+    }
+
+    if (path && *path && !ReplaceStoredBstr(&target->path, path)) {
+        return TransitionFlushTargetPreparation::Failed;
+    }
+
+    if (document) {
+        ReplaceStoredComPtr(&target->document, document);
+        const HRESULT hr =
+            GetComIdentity(document, target->identity.Put());
+        if (g_runtime.document.transitionFlushGeneration !=
+            expectedGeneration) {
+            return TransitionFlushTargetPreparation::Superseded;
+        }
+
+        if (FAILED(hr) || !target->identity) {
+            // A path remains a valid recovery target even when the optional
+            // strong COM binding couldn't be prepared.
+            target->document.Reset();
+            target->identity.Reset();
+            if (target->path.Length() == 0) {
+                return TransitionFlushTargetPreparation::Failed;
+            }
+        }
+    }
+
+    return g_runtime.document.transitionFlushGeneration == expectedGeneration
+               ? TransitionFlushTargetPreparation::Ready
+               : TransitionFlushTargetPreparation::Superseded;
 }
 
 void ClearManualSavePending() {
@@ -1268,15 +2074,37 @@ enum class TransitionFlushClearMode {
 void ClearTransitionFlushRequest(
     TransitionFlushClearMode clearMode =
         TransitionFlushClearMode::ClearPostTransitionRefresh) {
+    const bool clearPostTransitionRefresh =
+        clearMode == TransitionFlushClearMode::ClearPostTransitionRefresh;
+    const bool hasTransitionState =
+        LoadFlag(g_runtime.flags.transitionFlushPending) ||
+        g_runtime.timing.transitionFlushRequestTime != 0 ||
+        g_runtime.document.transitionFlushDocumentPath.Get() != nullptr ||
+        g_runtime.document.transitionFlushDocument.Get() != nullptr ||
+        g_runtime.document.transitionFlushDocumentIdentity.Get() != nullptr;
+    if (!hasTransitionState &&
+        (!clearPostTransitionRefresh ||
+         !LoadFlag(g_runtime.flags.postTransitionRefreshPending))) {
+        return;
+    }
+
+    // transitionFlushPending is the commit marker. Withdraw it before
+    // changing payload and before any COM Release.
     ClearFlag(g_runtime.flags.transitionFlushPending);
-    g_runtime.document.transitionFlushDocumentPath.Reset();
+    ++g_runtime.document.transitionFlushGeneration;
     g_runtime.timing.transitionFlushRequestTime = 0;
-
-    InvalidateTransitionFlushDocumentCache();
-
-    if (clearMode == TransitionFlushClearMode::ClearPostTransitionRefresh) {
+    if (clearPostTransitionRefresh) {
         ClearPostTransitionRefreshPending();
     }
+
+    ScopedBstr previousPath;
+    DetachedDocumentBinding previousBinding;
+    previousPath.Reset(
+        g_runtime.document.transitionFlushDocumentPath.Detach());
+    DetachDocumentBinding(
+        &g_runtime.document.transitionFlushDocument,
+        &g_runtime.document.transitionFlushDocumentIdentity,
+        &previousBinding);
 }
 
 bool HasPendingSaveWork() {
@@ -1289,21 +2117,252 @@ bool HasPendingAutosave() {
     return LoadFlag(g_runtime.flags.pendingSave);
 }
 
-void ClearAutomationBusyPending() {
-    ClearFlag(g_runtime.flags.automationBusyPending);
+void RefreshAutomationBusyPendingFromRetryState() {
+    const bool automationBusy =
+        g_runtime.saveRetry.reason == SaveRetryReason::AutomationBusy ||
+        g_runtime.documentRetry.reason == DocumentRetryReason::Busy;
+    StoreFlag(g_runtime.flags.automationBusyPending, automationBusy);
 }
 
-void NoteAutomationBusy(const wchar_t* message) {
-    SetFlag(g_runtime.flags.automationBusyPending);
-    if (message) {
-        LogSaveStatus(message);
+DWORD GetSaveRetryReasonLogInterval(SaveRetryReason reason) {
+    switch (reason) {
+        case SaveRetryReason::AutomationBusy:
+            return RETRY_BUSY_LOG_INTERVAL_MS;
+
+        case SaveRetryReason::HardFailure:
+            return RETRY_HARD_LOG_INTERVAL_MS;
+
+        case SaveRetryReason::TargetUnavailable:
+        case SaveRetryReason::DeferredProtectedView:
+        case SaveRetryReason::InactiveWindow:
+        case SaveRetryReason::UiPaused:
+        case SaveRetryReason::InputBusy:
+            return RETRY_WAIT_LOG_INTERVAL_MS;
+
+        case SaveRetryReason::None:
+            return RETRY_WAIT_LOG_INTERVAL_MS;
     }
+
+    return RETRY_WAIT_LOG_INTERVAL_MS;
+}
+
+const wchar_t* DescribeSaveRetryReason(SaveRetryReason reason) {
+    switch (reason) {
+        case SaveRetryReason::AutomationBusy:
+            return L"Word automation is busy; pending auto-save target is retained";
+        case SaveRetryReason::HardFailure:
+            return L"auto-save failed; pending changes are retained for a slower retry";
+        case SaveRetryReason::TargetUnavailable:
+            return L"auto-save target is temporarily unavailable; pending target is retained";
+        case SaveRetryReason::DeferredProtectedView:
+            return L"auto-save is deferred while Word is in Protected View";
+        case SaveRetryReason::InactiveWindow:
+            return L"auto-save is waiting for a Word document window to become active";
+        case SaveRetryReason::UiPaused:
+            return L"auto-save is waiting for Word UI interaction to finish";
+        case SaveRetryReason::InputBusy:
+            return L"auto-save is waiting for input to settle";
+        case SaveRetryReason::None:
+            return L"";
+    }
+
+    return L"";
+}
+
+const wchar_t* DescribeDocumentRetryReason(DocumentRetryReason reason) {
+    switch (reason) {
+        case DocumentRetryReason::Busy:
+            return L"Word automation is busy; document-state refresh will retry";
+        case DocumentRetryReason::Disconnected:
+            return L"Word automation target changed or disconnected; document-state refresh will recover";
+        case DocumentRetryReason::Hard:
+            return L"document-state refresh failed; using a slower retry";
+        case DocumentRetryReason::InactiveWindow:
+            return L"document-state refresh is waiting for a Word document window";
+        case DocumentRetryReason::UiPaused:
+            return L"document-state refresh is waiting for Word UI interaction to finish";
+        case DocumentRetryReason::InputBusy:
+            return L"document-state refresh is waiting for input to settle";
+        case DocumentRetryReason::None:
+            return L"";
+    }
+
+    return L"";
+}
+
+void LogSaveRetryReasonIfNeeded(SaveRetryReason reason) {
+    RuntimeSaveRetryState* retry = &g_runtime.saveRetry;
+    const ULONGLONG now = GetTickCount64();
+    if (!ShouldLogRetryReasonNow(
+            static_cast<int>(retry->lastLoggedReason),
+            static_cast<int>(reason),
+            retry->lastReasonLogTime,
+            now,
+            GetSaveRetryReasonLogInterval(reason))) {
+        return;
+    }
+
+    retry->lastLoggedReason = reason;
+    retry->lastReasonLogTime = now;
+    Wh_Log(L"Auto-save retry: %ls", DescribeSaveRetryReason(reason));
+}
+
+void LogDocumentRetryReasonIfNeeded(DocumentRetryReason reason) {
+    RuntimeDocumentRetryState* retry = &g_runtime.documentRetry;
+    const ULONGLONG now = GetTickCount64();
+    const DWORD reminderInterval =
+        reason == DocumentRetryReason::Busy
+            ? RETRY_BUSY_LOG_INTERVAL_MS
+            : (reason == DocumentRetryReason::Hard
+                   ? RETRY_HARD_LOG_INTERVAL_MS
+                   : RETRY_WAIT_LOG_INTERVAL_MS);
+    if (!ShouldLogRetryReasonNow(
+            static_cast<int>(retry->lastLoggedReason),
+            static_cast<int>(reason),
+            retry->lastReasonLogTime,
+            now,
+            reminderInterval)) {
+        return;
+    }
+
+    retry->lastLoggedReason = reason;
+    retry->lastReasonLogTime = now;
+    Wh_Log(L"Document state retry: %ls", DescribeDocumentRetryReason(reason));
+}
+
+void SetCurrentSaveRetryReason(SaveRetryReason reason) {
+    g_runtime.saveRetry.reason = reason;
+    RefreshAutomationBusyPendingFromRetryState();
+    LogSaveRetryReasonIfNeeded(reason);
+}
+
+void SetCurrentDocumentRetryReason(DocumentRetryReason reason) {
+    g_runtime.documentRetry.reason = reason;
+    RefreshAutomationBusyPendingFromRetryState();
+    LogDocumentRetryReasonIfNeeded(reason);
+}
+
+void ClearCurrentSaveRetryReason() {
+    if (g_runtime.saveRetry.reason == SaveRetryReason::None) {
+        return;
+    }
+
+    g_runtime.saveRetry.reason = SaveRetryReason::None;
+    RefreshAutomationBusyPendingFromRetryState();
+}
+
+void ClearCurrentDocumentRetryReason() {
+    if (g_runtime.documentRetry.reason == DocumentRetryReason::None) {
+        return;
+    }
+
+    g_runtime.documentRetry.reason = DocumentRetryReason::None;
+    RefreshAutomationBusyPendingFromRetryState();
+}
+
+void ResetRuntimeSaveRetryState(RuntimeSaveRetryState* retry) {
+    if (retry) {
+        *retry = RuntimeSaveRetryState{};
+    }
+}
+
+void ResetRuntimeDocumentRetryState(RuntimeDocumentRetryState* retry) {
+    if (retry) {
+        *retry = RuntimeDocumentRetryState{};
+    }
+}
+
+void ResetSaveRetryState() {
+    ResetRuntimeSaveRetryState(&g_runtime.saveRetry);
+    RefreshAutomationBusyPendingFromRetryState();
+}
+
+void ResetDocumentRetryState() {
+    ResetRuntimeDocumentRetryState(&g_runtime.documentRetry);
+    RefreshAutomationBusyPendingFromRetryState();
+}
+
+DWORD AdvanceSaveRetryDelay(SaveRetryReason reason) {
+    RuntimeSaveRetryState* retry = &g_runtime.saveRetry;
+    SetCurrentSaveRetryReason(reason);
+
+    switch (reason) {
+        case SaveRetryReason::AutomationBusy:
+            return AdvanceRetryDelayForPolicy(
+                &retry->automationNextDelayMs,
+                SAVE_AUTOMATION_RETRY_INITIAL_MS,
+                SAVE_AUTOMATION_RETRY_MAX_MS);
+
+        case SaveRetryReason::HardFailure:
+            return AdvanceRetryDelayForPolicy(&retry->hardNextDelayMs,
+                                              SAVE_HARD_RETRY_INITIAL_MS,
+                                              SAVE_HARD_RETRY_MAX_MS);
+
+        case SaveRetryReason::TargetUnavailable:
+            return AdvanceRetryDelayForPolicy(&retry->targetNextDelayMs,
+                                              SAVE_TARGET_RETRY_INITIAL_MS,
+                                              SAVE_TARGET_RETRY_MAX_MS);
+
+        case SaveRetryReason::DeferredProtectedView:
+            return SAVE_DEFERRED_WATCHDOG_MS;
+
+        case SaveRetryReason::InactiveWindow:
+            return SAVE_INACTIVE_FALLBACK_WATCHDOG_MS;
+
+        case SaveRetryReason::UiPaused:
+        case SaveRetryReason::InputBusy:
+            return SAVE_UI_INPUT_WATCHDOG_MS;
+
+        case SaveRetryReason::None:
+            return MIN_RETRY_INTERVAL_MS;
+    }
+
+    return MIN_RETRY_INTERVAL_MS;
+}
+
+DWORD AdvanceDocumentRetryDelay(DocumentRetryReason reason) {
+    RuntimeDocumentRetryState* retry = &g_runtime.documentRetry;
+    SetCurrentDocumentRetryReason(reason);
+
+    switch (reason) {
+        case DocumentRetryReason::Busy:
+            return AdvanceRetryDelayForPolicy(&retry->busyNextDelayMs,
+                                              DOCUMENT_BUSY_RETRY_INITIAL_MS,
+                                              DOCUMENT_BUSY_RETRY_MAX_MS);
+
+        case DocumentRetryReason::Disconnected:
+            return AdvanceRetryDelayForPolicy(
+                &retry->disconnectedNextDelayMs,
+                DOCUMENT_TARGET_RETRY_INITIAL_MS,
+                DOCUMENT_TARGET_RETRY_MAX_MS);
+
+        case DocumentRetryReason::Hard:
+            return AdvanceRetryDelayForPolicy(&retry->hardNextDelayMs,
+                                              DOCUMENT_HARD_RETRY_INITIAL_MS,
+                                              DOCUMENT_HARD_RETRY_MAX_MS);
+
+        case DocumentRetryReason::InactiveWindow:
+            return SAVE_INACTIVE_FALLBACK_WATCHDOG_MS;
+
+        case DocumentRetryReason::UiPaused:
+        case DocumentRetryReason::InputBusy:
+            return SAVE_UI_INPUT_WATCHDOG_MS;
+
+        case DocumentRetryReason::None:
+            return MIN_RETRY_INTERVAL_MS;
+    }
+
+    return MIN_RETRY_INTERVAL_MS;
 }
 
 void ClearPendingSaveAsMigration() {
     ClearFlag(g_runtime.flags.pendingSaveAsMigration);
+    ++g_runtime.document.pendingSaveAsGeneration;
     g_runtime.timing.pendingSaveAsTime = 0;
-    g_runtime.document.pendingSaveAsDocumentIdentity.Reset();
+
+    ScopedComPtr<IUnknown> previousIdentity;
+    previousIdentity.Reset(
+        g_runtime.document.pendingSaveAsDocumentIdentity.Detach());
 }
 
 bool HasPendingSaveAsMigration() {
@@ -1350,7 +2409,7 @@ DWORD ComputeBoundaryCoalesceDelay(bool transitionFlush,
     return INPUT_SETTLE_DELAY_MS;
 }
 
-bool ShouldUseMessageDocumentRefreshFallback(bool /*wordEventsConnected*/) {
+bool ShouldUseMessageDocumentRefreshFallback() {
     return true;
 }
 
@@ -1361,12 +2420,17 @@ bool ShouldUseMessageBoundaryFallback(bool wordEventsConnected, bool transitionF
 void ResetObservedDocumentState();
 
 void ResetObservedDocumentState() {
-    g_runtime.document.observedDocumentPath.Reset();
-    g_runtime.document.observedDocument.Reset();
-    g_runtime.document.observedDocumentIdentity.Reset();
-
+    // documentDirtyKnown is the commit marker for the observed payload.
     ClearFlag(g_runtime.flags.documentDirtyKnown);
     ClearFlag(g_runtime.flags.documentDirty);
+    ++g_runtime.document.observedDocumentGeneration;
+
+    ScopedBstr previousPath;
+    DetachedDocumentBinding previousBinding;
+    previousPath.Reset(g_runtime.document.observedDocumentPath.Detach());
+    DetachDocumentBinding(&g_runtime.document.observedDocument,
+                          &g_runtime.document.observedDocumentIdentity,
+                          &previousBinding);
 }
 
 void RequestTransitionFlush(const wchar_t* path,
@@ -1376,26 +2440,59 @@ void RequestTransitionFlush(const wchar_t* path,
         return;
     }
 
-    if (!SetTransitionFlushDocumentPath(path)) {
+    const unsigned int expectedGeneration =
+        g_runtime.document.transitionFlushGeneration;
+    PreparedTransitionFlushTarget target;
+    const TransitionFlushTargetPreparation preparation =
+        PrepareTransitionFlushTarget(path,
+                                     document,
+                                     expectedGeneration,
+                                     &target);
+    if (preparation == TransitionFlushTargetPreparation::Superseded) {
+        return;
+    }
+
+    if (preparation == TransitionFlushTargetPreparation::Failed) {
         ClearTransitionFlushRequest();
         return;
     }
 
-    if (document && !SetTransitionFlushDocument(document)) {
-        InvalidateTransitionFlushDocumentCache();
-        if (g_runtime.document.transitionFlushDocumentPath.Length() == 0) {
-            ClearTransitionFlushRequest();
-            return;
-        }
-    } else if (!document) {
-        SetTransitionFlushDocument(nullptr);
+    if (g_runtime.document.transitionFlushGeneration != expectedGeneration) {
+        return;
     }
 
-    SetFlag(g_runtime.flags.transitionFlushPending);
+    const bool wasPending =
+        LoadFlag(g_runtime.flags.transitionFlushPending);
+    const ULONGLONG previousRequestTime =
+        g_runtime.timing.transitionFlushRequestTime;
+
+    // Withdraw the old commit marker, replace every payload field without a
+    // COM call, then publish the new marker last.
+    ClearFlag(g_runtime.flags.transitionFlushPending);
+    ScopedBstr previousPath;
+    DetachedDocumentBinding previousBinding;
+    previousPath.Reset(
+        g_runtime.document.transitionFlushDocumentPath.Detach());
+    DetachDocumentBinding(
+        &g_runtime.document.transitionFlushDocument,
+        &g_runtime.document.transitionFlushDocumentIdentity,
+        &previousBinding);
+
+    g_runtime.document.transitionFlushDocumentPath.Reset(
+        target.path.Detach());
+    g_runtime.document.transitionFlushDocumentIdentity.Reset(
+        target.identity.Detach());
+    g_runtime.document.transitionFlushDocument.Reset(
+        target.document.Detach());
+    ++g_runtime.document.transitionFlushGeneration;
+
+    ClearCurrentSaveRetryReason();
+    g_runtime.timing.transitionFlushRequestTime =
+        wasPending && previousRequestTime != 0
+            ? previousRequestTime
+            : GetTickCount64();
     SetFlag(g_runtime.flags.expeditedSavePending);
-    if (g_runtime.timing.transitionFlushRequestTime == 0) {
-        g_runtime.timing.transitionFlushRequestTime = GetTickCount64();
-    }
+    SetFlag(g_runtime.flags.transitionFlushPending);
     if (reason) {
         LogSaveStatus(reason);
     }
@@ -1921,6 +3018,7 @@ struct RuntimeTickSnapshot {
     bool pendingSaveWork = false;
     bool pendingSaveAsMigration = false;
     bool documentDirtyKnown = false;
+    bool saveTaskArmed = false;
 };
 
 struct TickDecision {
@@ -1935,7 +3033,8 @@ bool IsOwnerThreadStillPreferred(DWORD preferredOwnerThreadId) {
 }
 
 bool IsOwnerThreadSchedulerContextValid() {
-    return LoadOwnerThreadId() != 0 && IsOwnerThread();
+    const DWORD ownerThreadId = LoadOwnerThreadId();
+    return ownerThreadId != 0 && ownerThreadId == GetCurrentThreadId();
 }
 
 bool CanRunOwnerThreadRuntimeWork() {
@@ -2006,6 +3105,7 @@ RuntimeTickSnapshot CaptureDocumentStateTickSnapshot(const MSG* lpMsg = nullptr)
                                snapshot.flags.documentDirty;
     snapshot.pendingSaveAsMigration = snapshot.flags.pendingSaveAsMigration;
     snapshot.documentDirtyKnown = snapshot.flags.documentDirtyKnown;
+    snapshot.saveTaskArmed = IsScheduledTaskArmed(ScheduledTaskKind::Save);
     return snapshot;
 }
 
@@ -2024,6 +3124,8 @@ RuntimeTickSnapshot CaptureAutosaveTickSnapshot(const MSG* lpMsg = nullptr) {
         LoadFlag(g_runtime.flags.documentDirty);
     snapshot.flags.pendingSaveAsMigration =
         LoadFlag(g_runtime.flags.pendingSaveAsMigration);
+    snapshot.runtime.wordEventsConnected =
+        LoadFlag(g_runtime.flags.wordEventsConnected);
     CaptureTickWindowAndInputObservation(&snapshot.runtime, lpMsg);
     return snapshot;
 }
@@ -2053,14 +3155,46 @@ ULONGLONG GetAutosaveDelayBaseTime(bool transitionFlushRequested) {
     return g_runtime.timing.lastEditTime;
 }
 
+DWORD GetOwnerThreadSyncWatchdogDelay(bool criticalWork,
+                                      bool wordEventsConnected) {
+    if (criticalWork) {
+        return DOCUMENT_STATE_PENDING_WATCHDOG_MS;
+    }
+
+    return wordEventsConnected ? SAVE_INACTIVE_EVENT_WATCHDOG_MS
+                               : SAVE_INACTIVE_FALLBACK_WATCHDOG_MS;
+}
+
 TickDecision EvaluateDocumentStateTickDecision(const RuntimeTickSnapshot& snapshot) {
+    const bool criticalObservation =
+        snapshot.runtime.transitionFlushRequested ||
+        snapshot.runtime.expeditedSaveRequested;
     if (!snapshot.runtime.ownerThreadSynchronized) {
-        return {RuntimeStatePhase::WaitingForOwnerThread, TickDecisionAction::None, 0};
+        return MakeDocumentStateRearmDecision(
+            RuntimeStatePhase::WaitingForOwnerThread,
+            GetOwnerThreadSyncWatchdogDelay(
+                criticalObservation,
+                snapshot.runtime.wordEventsConnected));
+    }
+
+    const bool canYieldToArmedSave =
+        snapshot.runtime.pendingSave &&
+        snapshot.saveTaskArmed &&
+        !snapshot.runtime.manualSavePending &&
+        !snapshot.pendingSaveAsMigration;
+    if (canYieldToArmedSave &&
+        (snapshot.runtime.pauseReason != WordUiPauseReason::None ||
+         !snapshot.runtime.activeWordDocumentWindow ||
+         snapshot.runtime.inputBusy)) {
+        return {RuntimeStatePhase::WaitingForSaveDelay, TickDecisionAction::None, 0};
     }
 
     if (snapshot.runtime.pauseReason != WordUiPauseReason::None) {
         return MakeDocumentStateRearmDecision(RuntimeStatePhase::WaitingForWordUi,
-                                              GetWordUiPauseDelay(snapshot.runtime.pauseReason));
+                                              criticalObservation
+                                                  ? GetWordUiPauseDelay(
+                                                        snapshot.runtime.pauseReason)
+                                                  : SAVE_UI_INPUT_WATCHDOG_MS);
     }
 
     if (!snapshot.runtime.activeWordDocumentWindow) {
@@ -2068,25 +3202,21 @@ TickDecision EvaluateDocumentStateTickDecision(const RuntimeTickSnapshot& snapsh
                                                   snapshot.pendingSaveAsMigration,
                                                   snapshot.runtime.wordEventsConnected)) {
             return MakeDocumentStateRearmDecision(RuntimeStatePhase::WaitingForWordWindow,
-                                                  snapshot.steadyPollDelay);
+                                                  criticalObservation
+                                                      ? snapshot.steadyPollDelay
+                                                      : (snapshot.runtime.wordEventsConnected
+                                                             ? SAVE_INACTIVE_EVENT_WATCHDOG_MS
+                                                             : SAVE_INACTIVE_FALLBACK_WATCHDOG_MS));
         }
 
         return {RuntimeStatePhase::Idle, TickDecisionAction::None, 0};
     }
 
-    if (snapshot.runtime.pendingSave &&
-        !snapshot.runtime.manualSavePending &&
-        !snapshot.pendingSaveAsMigration &&
-        snapshot.flags.documentDirtyKnown &&
-        snapshot.flags.documentDirty &&
-        g_runtime.document.observedDocumentPath.Length() != 0) {
-        return MakeDocumentStateRearmDecision(RuntimeStatePhase::WaitingForSaveDelay,
-                                              DOCUMENT_STATE_ACTIVE_POLL_INTERVAL_MS);
-    }
-
     if (snapshot.runtime.inputBusy) {
         return MakeDocumentStateRearmDecision(RuntimeStatePhase::WaitingForInputToSettle,
-                                              INPUT_SETTLE_DELAY_MS);
+                                              criticalObservation
+                                                  ? INPUT_SETTLE_DELAY_MS
+                                                  : SAVE_UI_INPUT_WATCHDOG_MS);
     }
 
     return {RuntimeStatePhase::ReadyToRefreshDocumentState,
@@ -2100,18 +3230,27 @@ TickDecision EvaluateAutosaveTickDecision(const RuntimeTickSnapshot& snapshot) {
     }
 
     if (!snapshot.runtime.ownerThreadSynchronized) {
-        return {RuntimeStatePhase::WaitingForOwnerThread, TickDecisionAction::None, 0};
+        return MakeSaveRearmDecision(
+            RuntimeStatePhase::WaitingForOwnerThread,
+            GetOwnerThreadSyncWatchdogDelay(
+                snapshot.runtime.transitionFlushRequested ||
+                    snapshot.runtime.expeditedSaveRequested,
+                snapshot.runtime.wordEventsConnected));
     }
 
     if (snapshot.runtime.pauseReason != WordUiPauseReason::None) {
         return MakeSaveRearmDecision(RuntimeStatePhase::WaitingForWordUi,
-                                     GetWordUiPauseDelay(snapshot.runtime.pauseReason));
+                                     snapshot.runtime.transitionFlushRequested
+                                         ? GetWordUiPauseDelay(snapshot.runtime.pauseReason)
+                                         : SAVE_UI_INPUT_WATCHDOG_MS);
     }
 
     if (!snapshot.runtime.transitionFlushRequested &&
         !snapshot.runtime.activeWordDocumentWindow) {
         return MakeSaveRearmDecision(RuntimeStatePhase::WaitingForWordWindow,
-                                     DOCUMENT_STATE_ACTIVE_POLL_INTERVAL_MS);
+                                     snapshot.runtime.wordEventsConnected
+                                         ? SAVE_INACTIVE_EVENT_WATCHDOG_MS
+                                         : SAVE_INACTIVE_FALLBACK_WATCHDOG_MS);
     }
 
     const DWORD effectiveDelayMs =
@@ -2139,7 +3278,9 @@ TickDecision EvaluateAutosaveTickDecision(const RuntimeTickSnapshot& snapshot) {
 
     if (snapshot.runtime.inputBusy) {
         return MakeSaveRearmDecision(RuntimeStatePhase::WaitingForInputToSettle,
-                                     INPUT_SETTLE_DELAY_MS);
+                                     snapshot.runtime.transitionFlushRequested
+                                         ? INPUT_SETTLE_DELAY_MS
+                                         : SAVE_UI_INPUT_WATCHDOG_MS);
     }
 
     return {RuntimeStatePhase::ReadyToSave, TickDecisionAction::SaveDocument, 0};
@@ -2165,13 +3306,76 @@ HWND FindNativeWordViewWindow() {
 bool ArmDocumentStateTimer(DWORD delayMs);
 bool ArmSaveTimer(DWORD delayMs);
 bool RescheduleSaveTimer(DWORD delayMs);
+void ReconcileDocumentStateSchedule();
 void CancelSchedulerTimer();
 bool EnsureWordApplicationEventsConnected(bool forceReconnect = false);
-void DisconnectWordApplicationEvents(bool allowDeferredRetry = true);
+bool DisconnectWordApplicationEvents(bool allowDeferredRetry = true);
 void RetryPendingWordEventDisconnects();
-void CALLBACK SchedulerTimerProc(HWND, UINT, UINT_PTR, DWORD);
+bool ArmPendingWordEventDisconnectRetry();
+void HandleSchedulerTimerMessage(UINT_PTR timerId);
 struct ActiveDocumentSnapshot;
 enum class SaveAttemptResult;
+
+bool EnsureSchedulerMessageWindow() {
+    if (!IsOwnerThread()) {
+        return false;
+    }
+
+    HWND messageWindow = g_control.messageWindow.load(std::memory_order_acquire);
+    if (messageWindow && IsWindow(messageWindow) &&
+        GetWindowThreadProcessId(messageWindow, nullptr) == GetCurrentThreadId()) {
+        return true;
+    }
+
+    if (messageWindow) {
+        return false;
+    }
+
+    messageWindow = CreateWindowExW(0,
+                                    L"STATIC",
+                                    L"Windhawk.WordLocalAutoSave.Control",
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    HWND_MESSAGE,
+                                    nullptr,
+                                    GetModuleHandleW(nullptr),
+                                    nullptr);
+    if (!messageWindow) {
+        Wh_Log(L"Scheduler: failed to create the owner message window, error=%lu",
+               GetLastError());
+        return false;
+    }
+
+    g_control.messageWindow.store(messageWindow, std::memory_order_release);
+    return true;
+}
+
+void DestroySchedulerMessageWindow() {
+    HWND messageWindow =
+        g_control.messageWindow.load(std::memory_order_acquire);
+    if (!messageWindow) {
+        return;
+    }
+
+    DWORD windowThreadId = GetWindowThreadProcessId(messageWindow, nullptr);
+    if (windowThreadId != GetCurrentThreadId()) {
+        Wh_Log(L"Scheduler: refusing to destroy the owner message window from another thread");
+        return;
+    }
+
+    if (!g_control.messageWindow.compare_exchange_strong(
+            messageWindow,
+            nullptr,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
+        return;
+    }
+
+    DestroyWindow(messageWindow);
+}
 
 bool ShouldTryOwnerThreadAdoptionForMessage(const MSG* lpMsg) {
     if (!lpMsg) {
@@ -2197,13 +3401,35 @@ bool ShouldTryOwnerThreadAdoptionForMessage(const MSG* lpMsg) {
 }
 
 void AdoptOwnerThreadIfNeeded(const MSG* lpMsg) {
-    if (!ShouldTryOwnerThreadAdoptionForMessage(lpMsg)) {
+    if (!lpMsg) {
         return;
     }
 
     const DWORD currentThreadId = GetCurrentThreadId();
+    const DWORD previousOwnerThreadId = LoadOwnerThreadId();
+    if (previousOwnerThreadId != 0) {
+        // The runtime is intentionally bound to one STA owner for its complete
+        // lifetime. Steady owner messages never need HWND/native discovery,
+        // and a different UI thread cannot take over without explicit COM
+        // marshaling.
+        return;
+    }
+
+    if (!ShouldTryOwnerThreadAdoptionForMessage(lpMsg)) {
+        return;
+    }
+
     const DWORD preferredThreadId = ResolvePreferredOwnerThreadId(lpMsg);
     if (preferredThreadId == 0 || currentThreadId != preferredThreadId) {
+        return;
+    }
+
+    LONG expectedLifecycle = RuntimeControlAwaitingOwner;
+    if (!g_control.lifecycle.compare_exchange_strong(
+            expectedLifecycle,
+            RuntimeControlOwnerActive,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
         return;
     }
 
@@ -2222,22 +3448,44 @@ void AdoptOwnerThreadIfNeeded(const MSG* lpMsg) {
         }
     }
 
-    const DWORD previousOwnerThreadId = LoadOwnerThreadId();
-    if (previousOwnerThreadId == currentThreadId) {
-        return;
-    }
-
     CancelSchedulerTimer();
     g_runtime.timing.saveTimerDueTime = 0;
     g_runtime.timing.documentStateTimerDueTime = 0;
-    g_runtime.timing.saveRetryDelayMs = MIN_RETRY_INTERVAL_MS;
-    g_runtime.timing.documentStateRetryDelayMs = MIN_RETRY_INTERVAL_MS;
+    ResetSaveRetryState();
+    ResetDocumentRetryState();
 
     ExchangeOwnerThreadId(currentThreadId);
+    ScopedOwnerRuntimeWork ownerWork;
+    if (!EnsureSchedulerMessageWindow()) {
+        ClearOwnerThreadId();
+        LONG expectedLifecycle = RuntimeControlOwnerActive;
+        if (!g_control.lifecycle.compare_exchange_strong(
+                expectedLifecycle,
+                RuntimeControlAwaitingOwner,
+                std::memory_order_acq_rel,
+                std::memory_order_acquire) &&
+            expectedLifecycle == RuntimeControlStopRequested) {
+            SignalOwnerShutdownComplete();
+        }
+        return;
+    }
+
+    g_control.ownerRuntimeLive.store(true, std::memory_order_release);
+    ProcessOwnerControlRequests();
+    if (g_control.shutdownRequested.load(std::memory_order_acquire)) {
+        return;
+    }
+    if (!CanRunOwnerThreadRuntimeWork()) {
+        return;
+    }
+
     EnsureWordApplicationEventsConnected(true);
     ArmDocumentStateTimer(INPUT_SETTLE_DELAY_MS);
     if (LoadFlag(g_runtime.flags.pendingSave)) {
         ArmSaveTimer(INPUT_SETTLE_DELAY_MS);
+    }
+    if (HasPendingWordEventDisconnectRetry()) {
+        ArmPendingWordEventDisconnectRetry();
     }
 }
 
@@ -2282,7 +3530,11 @@ ULONGLONG GetNextScheduledTaskDueTime() {
 
 void CancelSchedulerTimer() {
     if (g_runtime.timing.schedulerTimerId != 0) {
-        KillTimer(nullptr, g_runtime.timing.schedulerTimerId);
+        HWND messageWindow =
+            g_control.messageWindow.load(std::memory_order_acquire);
+        if (messageWindow) {
+            KillTimer(messageWindow, SCHEDULER_WINDOW_TIMER_ID);
+        }
         g_runtime.timing.schedulerTimerId = 0;
     }
 
@@ -2300,6 +3552,10 @@ bool RefreshSchedulerTimer() {
         return false;
     }
 
+    if (!EnsureSchedulerMessageWindow()) {
+        return false;
+    }
+
     if (g_runtime.timing.schedulerTimerId != 0 &&
         g_runtime.timing.schedulerTimerDueTime != 0 &&
         g_runtime.timing.schedulerTimerDueTime <= nextDueTime) {
@@ -2311,14 +3567,48 @@ bool RefreshSchedulerTimer() {
     const ULONGLONG now = GetTickCount64();
     const DWORD delayMs =
         nextDueTime <= now ? 1 : static_cast<DWORD>(nextDueTime - now);
-    g_runtime.timing.schedulerTimerId = SetTimer(nullptr, 0, delayMs, SchedulerTimerProc);
-    if (g_runtime.timing.schedulerTimerId == 0) {
+    HWND messageWindow =
+        g_control.messageWindow.load(std::memory_order_acquire);
+    if (!messageWindow ||
+        SetTimer(messageWindow,
+                 SCHEDULER_WINDOW_TIMER_ID,
+                 delayMs,
+                 nullptr) == 0) {
         Wh_Log(L"Scheduler: SetTimer failed, error=%lu", GetLastError());
         return false;
     }
 
+    g_runtime.timing.schedulerTimerId = SCHEDULER_WINDOW_TIMER_ID;
     g_runtime.timing.schedulerTimerDueTime = nextDueTime;
     return true;
+}
+
+bool ShouldQueueSchedulerRepair(bool refreshSucceeded,
+                                ULONGLONG nextDueTime,
+                                bool shutdownRequested,
+                                bool repairAlreadyPending) {
+    return !refreshSucceeded &&
+           nextDueTime != 0 &&
+           !shutdownRequested &&
+           !repairAlreadyPending;
+}
+
+bool RefreshSchedulerTimerWithRecovery() {
+    const bool refreshSucceeded = RefreshSchedulerTimer();
+    if (refreshSucceeded) {
+        return true;
+    }
+
+    const LONG pendingRequests =
+        g_control.pendingRequests.load(std::memory_order_acquire);
+    if (ShouldQueueSchedulerRepair(
+            refreshSucceeded,
+            GetNextScheduledTaskDueTime(),
+            g_control.shutdownRequested.load(std::memory_order_acquire),
+            (pendingRequests & RuntimeControlRepairScheduler) != 0)) {
+        QueueOwnerControlRequest(RuntimeControlRepairScheduler);
+    }
+    return false;
 }
 
 bool ShouldKeepExistingScheduledTaskDueTime(ULONGLONG existingDueTime,
@@ -2347,11 +3637,11 @@ bool ScheduleTask(ScheduledTaskKind taskKind,
     if (ShouldKeepExistingScheduledTaskDueTime(*dueTimeStorage,
                                                dueTime,
                                                scheduleMode)) {
-        return RefreshSchedulerTimer();
+        return RefreshSchedulerTimerWithRecovery();
     }
 
     *dueTimeStorage = dueTime;
-    return RefreshSchedulerTimer();
+    return RefreshSchedulerTimerWithRecovery();
 }
 
 void CancelScheduledTask(ScheduledTaskKind taskKind) {
@@ -2361,7 +3651,7 @@ void CancelScheduledTask(ScheduledTaskKind taskKind) {
     }
 
     *dueTimeStorage = 0;
-    RefreshSchedulerTimer();
+    RefreshSchedulerTimerWithRecovery();
 }
 
 bool IsScheduledTaskArmed(ScheduledTaskKind taskKind) {
@@ -2387,7 +3677,9 @@ void HandleDocumentStateTick();
 void ExpirePendingSaveAsMigrationIfNeeded();
 SaveAttemptResult TrySaveActiveDocument(ActiveDocumentSnapshot* snapshot,
                                         const wchar_t* specificPath = nullptr,
-                                        IDispatch* specificDocument = nullptr);
+                                        IDispatch* specificDocument = nullptr,
+                                        ComRetryProfile retryProfile =
+                                            ComRetryProfile::Background);
 void HandleAutosaveAttemptResult(SaveAttemptResult result,
                                  const ActiveDocumentSnapshot* snapshot,
                                  const RuntimeTickSnapshot& tick);
@@ -2404,6 +3696,62 @@ DWORD ComputeSteadyDocumentStatePollDelay(bool hasActivePollWork,
     }
 
     return DOCUMENT_STATE_IDLE_POLL_INTERVAL_MS;
+}
+
+enum class DocumentMonitorScheduleKind {
+    None,
+    RepairSaveTask,
+    ActiveRetry,
+    EventWatchdog,
+    FallbackPoll,
+};
+
+DocumentMonitorScheduleKind SelectDocumentMonitorSchedule(
+    bool pendingSave,
+    bool documentDirty,
+    bool manualSavePending,
+    bool automationBusyPending,
+    bool pendingSaveAsMigration,
+    bool saveTaskArmed,
+    bool wordEventsConnected) {
+    if (manualSavePending || pendingSaveAsMigration) {
+        return DocumentMonitorScheduleKind::ActiveRetry;
+    }
+
+    if (pendingSave) {
+        return saveTaskArmed ? DocumentMonitorScheduleKind::None
+                             : DocumentMonitorScheduleKind::RepairSaveTask;
+    }
+
+    if (documentDirty) {
+        return DocumentMonitorScheduleKind::RepairSaveTask;
+    }
+
+    if (automationBusyPending) {
+        return DocumentMonitorScheduleKind::ActiveRetry;
+    }
+
+    return wordEventsConnected ? DocumentMonitorScheduleKind::EventWatchdog
+                               : DocumentMonitorScheduleKind::FallbackPoll;
+}
+
+DWORD GetDocumentMonitorScheduleDelay(DocumentMonitorScheduleKind scheduleKind) {
+    switch (scheduleKind) {
+        case DocumentMonitorScheduleKind::ActiveRetry:
+            return DOCUMENT_STATE_PENDING_WATCHDOG_MS;
+
+        case DocumentMonitorScheduleKind::EventWatchdog:
+            return DOCUMENT_STATE_EVENT_IDLE_POLL_INTERVAL_MS;
+
+        case DocumentMonitorScheduleKind::FallbackPoll:
+            return DOCUMENT_STATE_IDLE_POLL_INTERVAL_MS;
+
+        case DocumentMonitorScheduleKind::None:
+        case DocumentMonitorScheduleKind::RepairSaveTask:
+            return 0;
+    }
+
+    return 0;
 }
 
 DWORD GetSteadyDocumentStatePollDelay(const RuntimeFlagSnapshot* flags) {
@@ -2428,9 +3776,11 @@ DWORD GetBoundaryCoalesceDelay(bool transitionFlush) {
 void RequestPendingSaveExpedite(bool transitionFlush,
                                 const wchar_t* reason,
                                 DWORD delayMs = INPUT_SETTLE_DELAY_MS) {
+    ClearCurrentSaveRetryReason();
     if (transitionFlush) {
         if (g_runtime.document.observedDocumentPath.Length() == 0 &&
             !g_runtime.document.observedDocument) {
+            SetFlag(g_runtime.flags.expeditedSavePending);
             CancelSaveTimer();
             ArmDocumentStateTimer(INPUT_SETTLE_DELAY_MS);
             if (reason) {
@@ -2456,32 +3806,29 @@ void RequestPendingSaveExpedite(bool transitionFlush,
     }
 }
 
-void MaybeKickAutomationRecovery(bool inputBusy) {
-    if (!LoadFlag(g_runtime.flags.automationBusyPending)) {
+void ResumePendingRuntimeWorkForSignal(SaveResumeSignal signal) {
+    if (signal == SaveResumeSignal::None) {
         return;
     }
 
-    if (inputBusy) {
-        return;
-    }
-
-    ClearAutomationBusyPending();
-    if (HasPendingAutosave()) {
-        LogSaveStatus(L"Word is responsive again, retrying pending changes");
+    if (HasPendingAutosave() &&
+        ShouldResumeSaveForSignal(g_runtime.saveRetry.reason, signal)) {
+        ClearCurrentSaveRetryReason();
         ArmSaveTimer(AUTOMATION_RECOVERY_DELAY_MS);
-    } else if (HasPendingSaveWork()) {
-        LogDocumentStateStatus(L"Word is responsive again, refreshing document state");
+    }
+
+    if (ShouldResumeDocumentForSignal(g_runtime.documentRetry.reason, signal)) {
+        ClearCurrentDocumentRetryReason();
         ArmDocumentStateTimer(AUTOMATION_RECOVERY_DELAY_MS);
     }
 }
 
-void MaybeKickAutomationRecovery() {
-    MaybeKickAutomationRecovery(GetInputState() || AreModifiersOrMouseButtonsHeld());
-}
-
 class ScopedComMessageFilter final : public IMessageFilter {
 public:
-    ScopedComMessageFilter() {
+    explicit ScopedComMessageFilter(
+        ComRetryProfile profile = ComRetryProfile::LegacyLifecycle)
+        : m_profile(profile),
+          m_deadline(GetTickCount64() + GetComRetryBudgetMs(profile)) {
         HRESULT hr = CoRegisterMessageFilter(this, &m_previousFilter);
         m_registered = SUCCEEDED(hr);
     }
@@ -2536,9 +3883,14 @@ public:
     STDMETHODIMP_(DWORD) RetryRejectedCall(HTASK,
                                            DWORD elapsedMs,
                                            DWORD rejectType) override {
-        if (rejectType == SERVERCALL_RETRYLATER &&
-            elapsedMs < COM_MESSAGE_FILTER_CANCEL_AFTER_MS) {
-            return COM_MESSAGE_FILTER_RETRY_DELAY_MS;
+        const DWORD delayMs = SelectRejectedCallRetryDelay(
+            m_profile,
+            rejectType,
+            elapsedMs,
+            GetTickCount64(),
+            m_deadline);
+        if (delayMs != static_cast<DWORD>(-1)) {
+            return delayMs;
         }
 
         return static_cast<DWORD>(-1);
@@ -2551,6 +3903,8 @@ public:
 private:
     volatile LONG m_refCount = 1;
     IMessageFilter* m_previousFilter = nullptr;
+    ComRetryProfile m_profile = ComRetryProfile::LegacyLifecycle;
+    ULONGLONG m_deadline = 0;
     bool m_registered = false;
 };
 
@@ -2559,19 +3913,25 @@ bool ArmDocumentStateTimer(DWORD delayMs) {
 }
 
 void ScheduleSaveFromEdit() {
-    const bool transitionFlushPending =
+    ClearCurrentSaveRetryReason();
+    bool transitionFlushPending =
         LoadFlag(g_runtime.flags.transitionFlushPending);
     if (!transitionFlushPending) {
-        ClearTransitionFlushRequest();
         ClearExpeditedSavePending();
         ClearPostTransitionRefreshPending();
         g_runtime.timing.lastEditTime = GetTickCount64();
-    } else {
+        ClearTransitionFlushRequest();
+
+        // A retired COM target can re-enter and publish a newer transition.
+        transitionFlushPending =
+            LoadFlag(g_runtime.flags.transitionFlushPending);
+    }
+
+    if (transitionFlushPending) {
         SetFlag(g_runtime.flags.expeditedSavePending);
         SetFlag(g_runtime.flags.postTransitionRefreshPending);
     }
 
-    ClearAutomationBusyPending();
     SetFlag(g_runtime.flags.pendingSave);
     const bool documentDirtyKnown = LoadFlag(g_runtime.flags.documentDirtyKnown);
     const bool documentDirty = LoadFlag(g_runtime.flags.documentDirty);
@@ -2587,9 +3947,51 @@ void ScheduleSaveFromEdit() {
                             : static_cast<DWORD>(g_settings.saveDelay));
 }
 
+void ReconcileDocumentStateSchedule() {
+    if (!CanRunOwnerThreadRuntimeWork()) {
+        return;
+    }
+
+    if (IsDocumentFailureRetryReason(g_runtime.documentRetry.reason) &&
+        IsScheduledTaskArmed(ScheduledTaskKind::DocumentState)) {
+        return;
+    }
+
+    const bool pendingSave = LoadFlag(g_runtime.flags.pendingSave);
+    const DocumentMonitorScheduleKind scheduleKind =
+        SelectDocumentMonitorSchedule(
+            pendingSave,
+            LoadFlag(g_runtime.flags.documentDirty),
+            LoadFlag(g_runtime.flags.manualSavePending),
+            LoadFlag(g_runtime.flags.automationBusyPending),
+            LoadFlag(g_runtime.flags.pendingSaveAsMigration),
+            IsScheduledTaskArmed(ScheduledTaskKind::Save),
+            LoadFlag(g_runtime.flags.wordEventsConnected));
+
+    switch (scheduleKind) {
+        case DocumentMonitorScheduleKind::RepairSaveTask:
+            if (pendingSave) {
+                ArmSaveTimer(INPUT_SETTLE_DELAY_MS);
+            } else {
+                ScheduleSaveFromEdit();
+            }
+            return;
+
+        case DocumentMonitorScheduleKind::ActiveRetry:
+        case DocumentMonitorScheduleKind::EventWatchdog:
+        case DocumentMonitorScheduleKind::FallbackPoll:
+            ArmDocumentStateTimer(GetDocumentMonitorScheduleDelay(scheduleKind));
+            return;
+
+        case DocumentMonitorScheduleKind::None:
+            return;
+    }
+}
+
 void ClearPendingSave() {
     ClearFlag(g_runtime.flags.pendingSave);
     ClearExpeditedSavePending();
+    ResetSaveRetryState();
 }
 
 bool ShouldPreserveTransitionFlushForManualSave(bool transitionFlushPending) {
@@ -2597,15 +3999,23 @@ bool ShouldPreserveTransitionFlushForManualSave(bool transitionFlushPending) {
 }
 
 void PrepareManualSaveObservation() {
-    if (ShouldPreserveTransitionFlushForManualSave(
-            LoadFlag(g_runtime.flags.transitionFlushPending))) {
+    ClearCurrentSaveRetryReason();
+    ClearCurrentDocumentRetryReason();
+    bool preserveTransition =
+        ShouldPreserveTransitionFlushForManualSave(
+            LoadFlag(g_runtime.flags.transitionFlushPending));
+    if (!preserveTransition) {
+        ClearPostTransitionRefreshPending();
+        CancelSaveTimer();
+        ClearTransitionFlushRequest();
+        preserveTransition =
+            LoadFlag(g_runtime.flags.transitionFlushPending);
+    }
+
+    if (preserveTransition) {
         SetFlag(g_runtime.flags.expeditedSavePending);
         SetFlag(g_runtime.flags.postTransitionRefreshPending);
         ArmSaveTimer(INPUT_SETTLE_DELAY_MS);
-    } else {
-        ClearTransitionFlushRequest();
-        ClearPostTransitionRefreshPending();
-        CancelSaveTimer();
     }
 
     SetFlag(g_runtime.flags.manualSavePending);
@@ -2669,121 +4079,131 @@ public:
         return &m_value;
     }
 
+    BSTR DetachBstr() {
+        if (m_value.vt != VT_BSTR) {
+            return nullptr;
+        }
+
+        BSTR value = m_value.bstrVal;
+        VariantInit(&m_value);
+        return value;
+    }
+
+    IDispatch* DetachDispatch() {
+        if (m_value.vt != VT_DISPATCH) {
+            return nullptr;
+        }
+
+        IDispatch* value = m_value.pdispVal;
+        VariantInit(&m_value);
+        return value;
+    }
+
 private:
     VARIANT m_value = {};
 };
 
-bool TryGetCachedDispatchMemberId(IDispatch* dispatch,
-                                  const wchar_t* name,
-                                  DISPID* dispatchId) {
-    if (!dispatch || !name || !dispatchId) {
-        return false;
-    }
-
-    GUID typeGuid = GUID_NULL;
-    if (FAILED(GetDispatchTypeGuid(dispatch, &typeGuid)) ||
-        IsEqualGUID(typeGuid, GUID_NULL)) {
-        return false;
-    }
-
-    const ULONGLONG now = GetTickCount64();
-    for (int index = 0; index < DISPATCH_MEMBER_ID_CACHE_CAPACITY; ++index) {
-        DispatchMemberIdCacheEntry* entry = &g_runtime.dispatchMemberIdCache[index];
-        if (!entry->hasTypeGuid ||
-            !IsEqualGUID(entry->typeGuid, typeGuid) ||
-            !entry->name) {
-            continue;
-        }
-
-        if (entry->name == name || lstrcmpW(entry->name, name) == 0) {
-            *dispatchId = entry->dispId;
-            entry->lastUseTime = now;
-            return true;
-        }
-    }
-
-    return false;
-}
-
-void StoreCachedDispatchMemberId(IDispatch* dispatch,
-                                 const wchar_t* name,
-                                 DISPID dispatchId) {
-    if (!dispatch || !name || dispatchId == DISPID_UNKNOWN) {
-        return;
-    }
-
-    GUID typeGuid = GUID_NULL;
-    if (FAILED(GetDispatchTypeGuid(dispatch, &typeGuid)) ||
-        IsEqualGUID(typeGuid, GUID_NULL)) {
-        return;
-    }
-
-    const ULONGLONG now = GetTickCount64();
-    DispatchMemberIdCacheEntry* selectedEntry = nullptr;
-    DispatchMemberIdCacheEntry* oldestEntry = nullptr;
-
-    for (int index = 0; index < DISPATCH_MEMBER_ID_CACHE_CAPACITY; ++index) {
-        DispatchMemberIdCacheEntry* entry = &g_runtime.dispatchMemberIdCache[index];
-        if (entry->hasTypeGuid &&
-            IsEqualGUID(entry->typeGuid, typeGuid) &&
-            entry->name &&
-            (entry->name == name || lstrcmpW(entry->name, name) == 0)) {
-            selectedEntry = entry;
+const wchar_t* GetWordMemberName(WordMember member) {
+    switch (member) {
+        case WordMember::ApplicationActiveWindow:
+            return L"ActiveWindow";
+        case WordMember::ApplicationWindows:
+            return L"Windows";
+        case WordMember::ApplicationHwnd:
+        case WordMember::WindowHwnd:
+            return L"Hwnd";
+        case WordMember::ApplicationActiveDocument:
+            return L"ActiveDocument";
+        case WordMember::ApplicationActiveProtectedViewWindow:
+            return L"ActiveProtectedViewWindow";
+        case WordMember::ApplicationDocuments:
+            return L"Documents";
+        case WordMember::WindowDocument:
+            return L"Document";
+        case WordMember::WindowsCount:
+        case WordMember::DocumentsCount:
+            return L"Count";
+        case WordMember::WindowsItem:
+        case WordMember::DocumentsItem:
+            return L"Item";
+        case WordMember::DocumentApplication:
+            return L"Application";
+        case WordMember::DocumentSaved:
+            return L"Saved";
+        case WordMember::DocumentReadOnly:
+            return L"ReadOnly";
+        case WordMember::DocumentPath:
+            return L"Path";
+        case WordMember::DocumentFullName:
+            return L"FullName";
+        case WordMember::DocumentName:
+            return L"Name";
+        case WordMember::DocumentSave:
+            return L"Save";
+        case WordMember::Count:
             break;
-        }
-
-        if (!selectedEntry &&
-            (!entry->hasTypeGuid || entry->lastUseTime == 0)) {
-            selectedEntry = entry;
-        }
-
-        if (!oldestEntry || entry->lastUseTime < oldestEntry->lastUseTime) {
-            oldestEntry = entry;
-        }
     }
 
-    if (!selectedEntry) {
-        selectedEntry = oldestEntry;
-    }
-
-    if (!selectedEntry) {
-        return;
-    }
-
-    selectedEntry->typeGuid = typeGuid;
-    selectedEntry->hasTypeGuid = true;
-    selectedEntry->name = name;
-    selectedEntry->dispId = dispatchId;
-    selectedEntry->lastUseTime = now;
+    return nullptr;
 }
 
-HRESULT InvokeDispatch(IDispatch* dispatch,
-                       WORD flags,
-                       LPOLESTR name,
-                       VARIANT* result = nullptr,
-                       int argCount = 0,
-                       VARIANT* args = nullptr) {
-    if (!dispatch) {
+WordMemberIdCacheEntry* GetWordMemberIdCacheEntry(WordMember member) {
+    const size_t index = static_cast<size_t>(member);
+    if (index >= static_cast<size_t>(WordMember::Count)) {
+        return nullptr;
+    }
+
+    return &g_runtime.wordMemberIdCache[index];
+}
+
+HRESULT ResolveWordMemberId(IDispatch* dispatch,
+                            WordMember member,
+                            DISPID* dispatchId) {
+    if (!dispatch || !dispatchId) {
         return E_POINTER;
     }
 
-    DISPID dispatchId = DISPID_UNKNOWN;
-    HRESULT hr = S_OK;
-    if (!TryGetCachedDispatchMemberId(dispatch, name, &dispatchId)) {
-        hr = dispatch->GetIDsOfNames(kIIDNull, &name, 1, LOCALE_USER_DEFAULT, &dispatchId);
-        if (SUCCEEDED(hr)) {
-            StoreCachedDispatchMemberId(dispatch, name, dispatchId);
-        }
-    }
-
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    if (argCount < 0) {
+    WordMemberIdCacheEntry* entry = GetWordMemberIdCacheEntry(member);
+    const wchar_t* memberName = GetWordMemberName(member);
+    if (!entry || !memberName) {
         return E_INVALIDARG;
     }
 
+    if (entry->resolved) {
+        *dispatchId = entry->dispId;
+        return S_OK;
+    }
+
+    LPOLESTR mutableName = const_cast<LPOLESTR>(memberName);
+    DISPID resolvedId = DISPID_UNKNOWN;
+    const HRESULT hr = dispatch->GetIDsOfNames(kIIDNull,
+                                               &mutableName,
+                                               1,
+                                               LOCALE_USER_DEFAULT,
+                                               &resolvedId);
+    if (SUCCEEDED(hr)) {
+        entry->dispId = resolvedId;
+        entry->resolved = true;
+        *dispatchId = resolvedId;
+    }
+
+    return hr;
+}
+
+void InvalidateWordMemberId(WordMember member) {
+    WordMemberIdCacheEntry* entry = GetWordMemberIdCacheEntry(member);
+    if (entry) {
+        entry->dispId = DISPID_UNKNOWN;
+        entry->resolved = false;
+    }
+}
+
+HRESULT InvokeResolvedDispatch(IDispatch* dispatch,
+                               DISPID dispatchId,
+                               WORD flags,
+                               VARIANT* result,
+                               int argCount,
+                               VARIANT* args) {
     DISPPARAMS params = {};
     params.cArgs = static_cast<UINT>(argCount);
     params.rgvarg = args;
@@ -2804,6 +4224,92 @@ HRESULT InvokeDispatch(IDispatch* dispatch,
                             nullptr);
 }
 
+HRESULT InvokeWordMember(IDispatch* dispatch,
+                         WORD flags,
+                         WordMember member,
+                         VARIANT* result = nullptr,
+                         int argCount = 0,
+                         VARIANT* args = nullptr) {
+    if (!dispatch) {
+        return E_POINTER;
+    }
+
+    if (argCount < 0) {
+        return E_INVALIDARG;
+    }
+
+    for (int attempt = 0; attempt < 2; ++attempt) {
+        DISPID dispatchId = DISPID_UNKNOWN;
+        HRESULT hr = ResolveWordMemberId(dispatch, member, &dispatchId);
+        if (FAILED(hr)) {
+            return hr;
+        }
+
+        hr = InvokeResolvedDispatch(dispatch,
+                                    dispatchId,
+                                    flags,
+                                    result,
+                                    argCount,
+                                    args);
+        if (hr != DISP_E_MEMBERNOTFOUND) {
+            return hr;
+        }
+
+        // A failed Invoke isn't required to leave pVarResult untouched. Drain
+        // any value produced by the stale DISPID before invoking again, or a
+        // BSTR/interface result can leak and the retry can receive a dirty
+        // VARIANT.
+        if (result) {
+            const HRESULT clearHr = VariantClear(result);
+            if (FAILED(clearHr)) {
+                InvalidateWordMemberId(member);
+                return clearHr;
+            }
+            VariantInit(result);
+        }
+
+        InvalidateWordMemberId(member);
+        if (attempt != 0) {
+            return hr;
+        }
+    }
+
+    return DISP_E_MEMBERNOTFOUND;
+}
+
+HRESULT InvokeDispatchUncached(IDispatch* dispatch,
+                               WORD flags,
+                               const wchar_t* name,
+                               VARIANT* result = nullptr,
+                               int argCount = 0,
+                               VARIANT* args = nullptr) {
+    if (!dispatch || !name) {
+        return E_POINTER;
+    }
+
+    if (argCount < 0) {
+        return E_INVALIDARG;
+    }
+
+    LPOLESTR mutableName = const_cast<LPOLESTR>(name);
+    DISPID dispatchId = DISPID_UNKNOWN;
+    HRESULT hr = dispatch->GetIDsOfNames(kIIDNull,
+                                         &mutableName,
+                                         1,
+                                         LOCALE_USER_DEFAULT,
+                                         &dispatchId);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    return InvokeResolvedDispatch(dispatch,
+                                  dispatchId,
+                                  flags,
+                                  result,
+                                  argCount,
+                                  args);
+}
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wlanguage-extension-token"
@@ -2822,7 +4328,24 @@ HRESULT QueryInterfaceTyped(IUnknown* unknown, T** result) {
 #pragma clang diagnostic pop
 #endif
 
-HRESULT GetDispatchProperty(IDispatch* dispatch, const wchar_t* name, IDispatch** result) {
+HRESULT ExtractDispatchFromVariant(ScopedVariant* value, IDispatch** result) {
+    if (!value || !result) {
+        return E_POINTER;
+    }
+
+    if (value->Get()->vt == VT_DISPATCH && value->Get()->pdispVal) {
+        *result = value->DetachDispatch();
+        return S_OK;
+    }
+
+    if (value->Get()->vt == VT_UNKNOWN && value->Get()->punkVal) {
+        return QueryInterfaceTyped(value->Get()->punkVal, result);
+    }
+
+    return DISP_E_TYPEMISMATCH;
+}
+
+HRESULT GetDispatchProperty(IDispatch* dispatch, WordMember member, IDispatch** result) {
     if (!result) {
         return E_POINTER;
     }
@@ -2830,30 +4353,40 @@ HRESULT GetDispatchProperty(IDispatch* dispatch, const wchar_t* name, IDispatch*
     *result = nullptr;
 
     ScopedVariant value;
-    HRESULT hr = InvokeDispatch(dispatch,
-                                DISPATCH_PROPERTYGET,
-                                const_cast<LPOLESTR>(name),
-                                value.Get());
+    HRESULT hr = InvokeWordMember(dispatch,
+                                  DISPATCH_PROPERTYGET,
+                                  member,
+                                  value.Get());
     if (FAILED(hr)) {
         return hr;
     }
 
-    if (value.Get()->vt == VT_DISPATCH && value.Get()->pdispVal) {
-        *result = value.Get()->pdispVal;
-        value.Get()->pdispVal = nullptr;
-        return S_OK;
+    return ExtractDispatchFromVariant(&value, result);
+}
+
+HRESULT GetDispatchPropertyUncached(IDispatch* dispatch,
+                                    const wchar_t* name,
+                                    IDispatch** result) {
+    if (!result) {
+        return E_POINTER;
     }
 
-    if (value.Get()->vt == VT_UNKNOWN && value.Get()->punkVal) {
-        hr = QueryInterfaceTyped(value.Get()->punkVal, result);
+    *result = nullptr;
+
+    ScopedVariant value;
+    HRESULT hr = InvokeDispatchUncached(dispatch,
+                                        DISPATCH_PROPERTYGET,
+                                        name,
+                                        value.Get());
+    if (FAILED(hr)) {
         return hr;
     }
 
-    return DISP_E_TYPEMISMATCH;
+    return ExtractDispatchFromVariant(&value, result);
 }
 
 HRESULT GetDispatchMethodObject(IDispatch* dispatch,
-                                const wchar_t* name,
+                                WordMember member,
                                 IDispatch** result,
                                 int argCount = 0,
                                 VARIANT* args = nullptr) {
@@ -2864,30 +4397,20 @@ HRESULT GetDispatchMethodObject(IDispatch* dispatch,
     *result = nullptr;
 
     ScopedVariant value;
-    HRESULT hr = InvokeDispatch(dispatch,
-                                DISPATCH_METHOD | DISPATCH_PROPERTYGET,
-                                const_cast<LPOLESTR>(name),
-                                value.Get(),
-                                argCount,
-                                args);
+    HRESULT hr = InvokeWordMember(dispatch,
+                                  DISPATCH_METHOD | DISPATCH_PROPERTYGET,
+                                  member,
+                                  value.Get(),
+                                  argCount,
+                                  args);
     if (FAILED(hr)) {
         return hr;
     }
 
-    if (value.Get()->vt == VT_DISPATCH && value.Get()->pdispVal) {
-        *result = value.Get()->pdispVal;
-        value.Get()->pdispVal = nullptr;
-        return S_OK;
-    }
-
-    if (value.Get()->vt == VT_UNKNOWN && value.Get()->punkVal) {
-        return QueryInterfaceTyped(value.Get()->punkVal, result);
-    }
-
-    return DISP_E_TYPEMISMATCH;
+    return ExtractDispatchFromVariant(&value, result);
 }
 
-HRESULT GetBoolProperty(IDispatch* dispatch, const wchar_t* name, bool* result) {
+HRESULT GetBoolProperty(IDispatch* dispatch, WordMember member, bool* result) {
     if (!result) {
         return E_POINTER;
     }
@@ -2896,21 +4419,28 @@ HRESULT GetBoolProperty(IDispatch* dispatch, const wchar_t* name, bool* result) 
 
     ScopedVariant value;
     ScopedVariant converted;
-    HRESULT hr = InvokeDispatch(dispatch,
-                                DISPATCH_PROPERTYGET,
-                                const_cast<LPOLESTR>(name),
-                                value.Get());
+    HRESULT hr = InvokeWordMember(dispatch,
+                                  DISPATCH_PROPERTYGET,
+                                  member,
+                                  value.Get());
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    if (value.Get()->vt == VT_BOOL) {
+        *result = value.Get()->boolVal != VARIANT_FALSE;
+        return S_OK;
+    }
+
+    hr = VariantChangeType(converted.Get(), value.Get(), 0, VT_BOOL);
     if (SUCCEEDED(hr)) {
-        hr = VariantChangeType(converted.Get(), value.Get(), 0, VT_BOOL);
-        if (SUCCEEDED(hr)) {
-            *result = converted.Get()->boolVal != VARIANT_FALSE;
-        }
+        *result = converted.Get()->boolVal != VARIANT_FALSE;
     }
 
     return hr;
 }
 
-HRESULT GetBstrProperty(IDispatch* dispatch, const wchar_t* name, BSTR* result) {
+HRESULT GetBstrProperty(IDispatch* dispatch, WordMember member, BSTR* result) {
     if (!result) {
         return E_POINTER;
     }
@@ -2919,22 +4449,28 @@ HRESULT GetBstrProperty(IDispatch* dispatch, const wchar_t* name, BSTR* result) 
 
     ScopedVariant value;
     ScopedVariant converted;
-    HRESULT hr = InvokeDispatch(dispatch,
-                                DISPATCH_PROPERTYGET,
-                                const_cast<LPOLESTR>(name),
-                                value.Get());
+    HRESULT hr = InvokeWordMember(dispatch,
+                                  DISPATCH_PROPERTYGET,
+                                  member,
+                                  value.Get());
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    if (value.Get()->vt == VT_BSTR) {
+        *result = value.DetachBstr();
+        return S_OK;
+    }
+
+    hr = VariantChangeType(converted.Get(), value.Get(), 0, VT_BSTR);
     if (SUCCEEDED(hr)) {
-        hr = VariantChangeType(converted.Get(), value.Get(), 0, VT_BSTR);
-        if (SUCCEEDED(hr) && converted.Get()->bstrVal) {
-            *result = SysAllocString(converted.Get()->bstrVal);
-            hr = *result ? S_OK : E_OUTOFMEMORY;
-        }
+        *result = converted.DetachBstr();
     }
 
     return hr;
 }
 
-HRESULT GetIntProperty(IDispatch* dispatch, const wchar_t* name, long* result) {
+HRESULT GetIntProperty(IDispatch* dispatch, WordMember member, long* result) {
     if (!result) {
         return E_POINTER;
     }
@@ -2943,15 +4479,22 @@ HRESULT GetIntProperty(IDispatch* dispatch, const wchar_t* name, long* result) {
 
     ScopedVariant value;
     ScopedVariant converted;
-    HRESULT hr = InvokeDispatch(dispatch,
-                                DISPATCH_PROPERTYGET,
-                                const_cast<LPOLESTR>(name),
-                                value.Get());
+    HRESULT hr = InvokeWordMember(dispatch,
+                                  DISPATCH_PROPERTYGET,
+                                  member,
+                                  value.Get());
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    if (value.Get()->vt == VT_I4) {
+        *result = value.Get()->lVal;
+        return S_OK;
+    }
+
+    hr = VariantChangeType(converted.Get(), value.Get(), 0, VT_I4);
     if (SUCCEEDED(hr)) {
-        hr = VariantChangeType(converted.Get(), value.Get(), 0, VT_I4);
-        if (SUCCEEDED(hr)) {
-            *result = converted.Get()->lVal;
-        }
+        *result = converted.Get()->lVal;
     }
 
     return hr;
@@ -2964,32 +4507,6 @@ HRESULT GetComIdentity(IUnknown* unknown, IUnknown** result) {
 
     *result = nullptr;
     return QueryInterfaceTyped(unknown, result);
-}
-
-HRESULT GetDispatchTypeGuid(IDispatch* dispatch, GUID* result) {
-    if (!dispatch || !result) {
-        return E_POINTER;
-    }
-
-    *result = GUID_NULL;
-
-    ITypeInfo* typeInfo = nullptr;
-    HRESULT hr = dispatch->GetTypeInfo(0, LOCALE_USER_DEFAULT, &typeInfo);
-    if (FAILED(hr) || !typeInfo) {
-        return FAILED(hr) ? hr : E_FAIL;
-    }
-
-    TYPEATTR* typeAttr = nullptr;
-    hr = typeInfo->GetTypeAttr(&typeAttr);
-    if (SUCCEEDED(hr) && typeAttr) {
-        *result = typeAttr->guid;
-        typeInfo->ReleaseTypeAttr(typeAttr);
-    } else if (SUCCEEDED(hr)) {
-        hr = E_FAIL;
-    }
-
-    typeInfo->Release();
-    return hr;
 }
 
 bool AreSameComIdentity(IUnknown* left, IUnknown* right) {
@@ -3069,16 +4586,19 @@ bool IsUsableWordApplicationWindowHandle(LONG_PTR hwndValue) {
     return ResolveCurrentProcessWordRootWindowFromHandle(hwndValue) != nullptr;
 }
 
-HRESULT GetApplicationWindowHandle(IDispatch* application, LONG_PTR* hwndValue);
+HRESULT GetDispatchWindowHandle(IDispatch* dispatch,
+                                WordMember hwndMember,
+                                LONG_PTR* hwndValue);
 
 bool TryResolveCurrentProcessWordWindowFromDispatch(IDispatch* dispatch,
-                                                    LONG_PTR* hwndValue) {
+                                                     WordMember hwndMember,
+                                                     LONG_PTR* hwndValue) {
     if (!dispatch) {
         return false;
     }
 
     LONG_PTR rawHwndValue = 0;
-    if (FAILED(GetApplicationWindowHandle(dispatch, &rawHwndValue))) {
+    if (FAILED(GetDispatchWindowHandle(dispatch, hwndMember, &rawHwndValue))) {
         return false;
     }
 
@@ -3100,19 +4620,25 @@ bool TryResolveCurrentProcessWordWindowFromApplicationWindows(IDispatch* applica
     }
 
     ScopedComPtr<IDispatch> activeWindow;
-    if (SUCCEEDED(GetDispatchProperty(application, L"ActiveWindow", activeWindow.Put())) &&
-        TryResolveCurrentProcessWordWindowFromDispatch(activeWindow.Get(), hwndValue)) {
+    if (SUCCEEDED(GetDispatchProperty(application,
+                                      WordMember::ApplicationActiveWindow,
+                                      activeWindow.Put())) &&
+        TryResolveCurrentProcessWordWindowFromDispatch(activeWindow.Get(),
+                                                       WordMember::WindowHwnd,
+                                                       hwndValue)) {
         return true;
     }
 
     ScopedComPtr<IDispatch> windows;
-    HRESULT hr = GetDispatchProperty(application, L"Windows", windows.Put());
+    HRESULT hr = GetDispatchProperty(application,
+                                     WordMember::ApplicationWindows,
+                                     windows.Put());
     if (FAILED(hr) || !windows) {
         return false;
     }
 
     long count = 0;
-    hr = GetIntProperty(windows.Get(), L"Count", &count);
+    hr = GetIntProperty(windows.Get(), WordMember::WindowsCount, &count);
     if (FAILED(hr)) {
         return false;
     }
@@ -3123,12 +4649,18 @@ bool TryResolveCurrentProcessWordWindowFromApplicationWindows(IDispatch* applica
         indexArg.Get()->lVal = index;
 
         ScopedComPtr<IDispatch> window;
-        hr = GetDispatchMethodObject(windows.Get(), L"Item", window.Put(), 1, indexArg.Get());
+        hr = GetDispatchMethodObject(windows.Get(),
+                                     WordMember::WindowsItem,
+                                     window.Put(),
+                                     1,
+                                     indexArg.Get());
         if (FAILED(hr) || !window) {
             continue;
         }
 
-        if (TryResolveCurrentProcessWordWindowFromDispatch(window.Get(), hwndValue)) {
+        if (TryResolveCurrentProcessWordWindowFromDispatch(window.Get(),
+                                                           WordMember::WindowHwnd,
+                                                           hwndValue)) {
             return true;
         }
     }
@@ -3136,33 +4668,44 @@ bool TryResolveCurrentProcessWordWindowFromApplicationWindows(IDispatch* applica
     return false;
 }
 
-HRESULT GetApplicationWindowHandle(IDispatch* application, LONG_PTR* hwndValue) {
-    if (!application || !hwndValue) {
+HRESULT GetDispatchWindowHandle(IDispatch* dispatch,
+                                WordMember hwndMember,
+                                LONG_PTR* hwndValue) {
+    if (!dispatch || !hwndValue) {
         return E_POINTER;
     }
 
     *hwndValue = 0;
 
     ScopedVariant value;
-    HRESULT hr = InvokeDispatch(application,
-                                DISPATCH_PROPERTYGET,
-                                const_cast<LPOLESTR>(L"Hwnd"),
-                                value.Get());
+    HRESULT hr = InvokeWordMember(dispatch,
+                                  DISPATCH_PROPERTYGET,
+                                  hwndMember,
+                                  value.Get());
     if (FAILED(hr)) {
         return hr;
     }
 
-    ScopedVariant converted;
-    hr = VariantChangeType(converted.Get(), value.Get(), 0, VT_I8);
-    if (SUCCEEDED(hr)) {
-        *hwndValue = static_cast<LONG_PTR>(converted.Get()->llVal);
+    if (value.Get()->vt == VT_I4) {
+        *hwndValue = static_cast<LONG_PTR>(value.Get()->lVal);
+    } else if (value.Get()->vt == VT_I8) {
+        *hwndValue = static_cast<LONG_PTR>(value.Get()->llVal);
     } else {
-        hr = VariantChangeType(converted.Get(), value.Get(), 0, VT_I4);
-        if (FAILED(hr)) {
-            return hr;
-        }
+        ScopedVariant convertedI8;
+        hr = VariantChangeType(convertedI8.Get(), value.Get(), 0, VT_I8);
+        if (SUCCEEDED(hr)) {
+            *hwndValue = static_cast<LONG_PTR>(convertedI8.Get()->llVal);
+        } else {
+            // Use a fresh destination because a failed conversion is allowed
+            // to leave its output VARIANT in an unspecified state.
+            ScopedVariant convertedI4;
+            hr = VariantChangeType(convertedI4.Get(), value.Get(), 0, VT_I4);
+            if (FAILED(hr)) {
+                return hr;
+            }
 
-        *hwndValue = static_cast<LONG_PTR>(converted.Get()->lVal);
+            *hwndValue = static_cast<LONG_PTR>(convertedI4.Get()->lVal);
+        }
     }
 
     if (*hwndValue == 0) {
@@ -3174,7 +4717,9 @@ HRESULT GetApplicationWindowHandle(IDispatch* application, LONG_PTR* hwndValue) 
 
 bool DoesApplicationBelongToCurrentProcess(IDispatch* application, LONG_PTR* hwndValue = nullptr) {
     LONG_PTR resolvedHwndValue = 0;
-    if (TryResolveCurrentProcessWordWindowFromDispatch(application, &resolvedHwndValue) ||
+    if (TryResolveCurrentProcessWordWindowFromDispatch(application,
+                                                       WordMember::ApplicationHwnd,
+                                                       &resolvedHwndValue) ||
         TryResolveCurrentProcessWordWindowFromApplicationWindows(application, &resolvedHwndValue)) {
         if (hwndValue) {
             *hwndValue = resolvedHwndValue;
@@ -3185,25 +4730,278 @@ bool DoesApplicationBelongToCurrentProcess(IDispatch* application, LONG_PTR* hwn
     return false;
 }
 
+void ResetCachedActiveDocumentState() {
+    ++g_runtime.automation.activeDocumentResetDepth;
+    {
+        // Make the cache unusable before releasing any COM proxy. Cache
+        // publication is gated until every retired reference is released.
+        ++g_runtime.automation.documentGeneration;
+        g_runtime.automation.activeDocumentStale = true;
+        g_runtime.automation.activeDocumentMetadataValid = false;
+        g_runtime.automation.activeDocumentReadOnly = false;
+        g_runtime.automation.activeDocumentHasPath = false;
+        g_runtime.automation.activeDocumentPath.Reset();
+
+        ScopedComPtr<IUnknown> previousIdentity;
+        ScopedComPtr<IDispatch> previousDocument;
+        previousIdentity.Reset(
+            g_runtime.automation.activeDocumentIdentity.Detach());
+        previousDocument.Reset(g_runtime.automation.activeDocument.Detach());
+    }
+    --g_runtime.automation.activeDocumentResetDepth;
+}
+
+void ResetAutomationCacheState() {
+    ++g_runtime.automation.resetDepth;
+    ++g_runtime.automation.applicationGeneration;
+    {
+        g_runtime.automation.applicationHwnd = 0;
+
+        ScopedComPtr<IUnknown> previousApplicationIdentity;
+        ScopedComPtr<IDispatch> previousApplication;
+        previousApplicationIdentity.Reset(
+            g_runtime.automation.applicationIdentity.Detach());
+        previousApplication.Reset(g_runtime.automation.application.Detach());
+
+        ResetCachedActiveDocumentState();
+    }
+    --g_runtime.automation.resetDepth;
+}
+
+HRESULT CacheWordApplication(IDispatch* application, LONG_PTR applicationHwnd) {
+    if (!application || applicationHwnd == 0 ||
+        !IsUsableWordApplicationWindowHandle(applicationHwnd)) {
+        return E_INVALIDARG;
+    }
+
+    if (g_runtime.automation.resetDepth != 0) {
+        return S_FALSE;
+    }
+
+    const unsigned int expectedGeneration =
+        g_runtime.automation.applicationGeneration;
+    ScopedComPtr<IDispatch> nextApplication;
+    ReplaceStoredComPtr(&nextApplication, application);
+    ScopedComPtr<IUnknown> identity;
+    const HRESULT hr = GetComIdentity(application, identity.Put());
+    if (g_runtime.automation.resetDepth != 0 ||
+        g_runtime.automation.applicationGeneration != expectedGeneration) {
+        return S_FALSE;
+    }
+    if (FAILED(hr) || !identity) {
+        return FAILED(hr) ? hr : E_FAIL;
+    }
+
+    const bool sameApplication =
+        AreSameComIdentity(identity.Get(),
+                           g_runtime.automation.applicationIdentity.Get());
+    if (!sameApplication) {
+        // DISPIDs are stable for one Word automation type library, but a new
+        // application identity can expose a different proxy/type version.
+        ClearWordMemberIdCache();
+    }
+
+    // Hwnd is the application-cache commit marker. Withdraw it, publish the
+    // complete replacement, then release retired proxies with no later write.
+    g_runtime.automation.applicationHwnd = 0;
+    ScopedComPtr<IUnknown> previousApplicationIdentity;
+    ScopedComPtr<IDispatch> previousApplication;
+    DetachedDocumentBinding previousActiveDocument;
+    previousApplicationIdentity.Reset(
+        g_runtime.automation.applicationIdentity.Detach());
+    previousApplication.Reset(g_runtime.automation.application.Detach());
+
+    if (!sameApplication) {
+        ++g_runtime.automation.documentGeneration;
+        g_runtime.automation.activeDocumentStale = true;
+        g_runtime.automation.activeDocumentMetadataValid = false;
+        g_runtime.automation.activeDocumentReadOnly = false;
+        g_runtime.automation.activeDocumentHasPath = false;
+        g_runtime.automation.activeDocumentPath.Reset();
+        DetachDocumentBinding(
+            &g_runtime.automation.activeDocument,
+            &g_runtime.automation.activeDocumentIdentity,
+            &previousActiveDocument);
+    }
+
+    g_runtime.automation.applicationIdentity.Reset(identity.Detach());
+    g_runtime.automation.application.Reset(nextApplication.Detach());
+    ++g_runtime.automation.applicationGeneration;
+    g_runtime.automation.applicationHwnd = applicationHwnd;
+    return S_OK;
+}
+
+HRESULT CopyCachedWordApplication(IDispatch** application) {
+    if (!application) {
+        return E_POINTER;
+    }
+
+    *application = nullptr;
+    if (!g_runtime.automation.application) {
+        return E_FAIL;
+    }
+
+    if (!g_runtime.automation.applicationIdentity ||
+        !IsUsableWordApplicationWindowHandle(
+            g_runtime.automation.applicationHwnd)) {
+        ResetAutomationCacheState();
+        return E_FAIL;
+    }
+
+    const unsigned int expectedGeneration =
+        g_runtime.automation.applicationGeneration;
+    IDispatch* cachedApplication =
+        g_runtime.automation.application.Get();
+    const LONG_PTR cachedHwnd = g_runtime.automation.applicationHwnd;
+    cachedApplication->AddRef();
+    if (g_runtime.automation.resetDepth != 0 ||
+        g_runtime.automation.applicationGeneration != expectedGeneration ||
+        g_runtime.automation.application.Get() != cachedApplication ||
+        g_runtime.automation.applicationHwnd != cachedHwnd ||
+        !g_runtime.automation.applicationIdentity) {
+        cachedApplication->Release();
+        return E_FAIL;
+    }
+
+    *application = cachedApplication;
+    return S_OK;
+}
+
+HRESULT CacheActiveDocumentBinding(IDispatch* document) {
+    if (!document) {
+        ResetCachedActiveDocumentState();
+        return S_FALSE;
+    }
+
+    if (g_runtime.automation.resetDepth != 0 ||
+        g_runtime.automation.activeDocumentResetDepth != 0) {
+        return S_FALSE;
+    }
+
+    const unsigned int expectedGeneration =
+        g_runtime.automation.documentGeneration;
+    ScopedComPtr<IDispatch> nextDocument;
+    ReplaceStoredComPtr(&nextDocument, document);
+    ScopedComPtr<IUnknown> identity;
+    const HRESULT hr = GetComIdentity(document, identity.Put());
+    if (g_runtime.automation.resetDepth != 0 ||
+        g_runtime.automation.activeDocumentResetDepth != 0 ||
+        g_runtime.automation.documentGeneration != expectedGeneration) {
+        return S_FALSE;
+    }
+    if (FAILED(hr) || !identity) {
+        // The caller is presenting the current document. Until its identity
+        // can be established, the previous binding must not be reused.
+        g_runtime.automation.activeDocumentStale = true;
+        return FAILED(hr) ? hr : E_FAIL;
+    }
+
+    const bool sameDocument =
+        AreSameComIdentity(identity.Get(),
+                           g_runtime.automation.activeDocumentIdentity.Get());
+    g_runtime.automation.activeDocumentStale = true;
+    DetachedDocumentBinding previousDocument;
+    DetachDocumentBinding(&g_runtime.automation.activeDocument,
+                          &g_runtime.automation.activeDocumentIdentity,
+                          &previousDocument);
+    if (!sameDocument) {
+        ++g_runtime.automation.documentGeneration;
+        g_runtime.automation.activeDocumentMetadataValid = false;
+        g_runtime.automation.activeDocumentReadOnly = false;
+        g_runtime.automation.activeDocumentHasPath = false;
+        g_runtime.automation.activeDocumentPath.Reset();
+    }
+
+    g_runtime.automation.activeDocumentIdentity.Reset(identity.Detach());
+    g_runtime.automation.activeDocument.Reset(nextDocument.Detach());
+    g_runtime.automation.activeDocumentStale = false;
+    return S_OK;
+}
+
+HRESULT CopyCachedActiveDocument(IDispatch** document) {
+    if (!document) {
+        return E_POINTER;
+    }
+
+    *document = nullptr;
+    if (g_runtime.automation.activeDocumentStale ||
+        !g_runtime.automation.activeDocument ||
+        !g_runtime.automation.activeDocumentIdentity) {
+        return E_FAIL;
+    }
+
+    const unsigned int expectedGeneration =
+        g_runtime.automation.documentGeneration;
+    IDispatch* cachedDocument =
+        g_runtime.automation.activeDocument.Get();
+    cachedDocument->AddRef();
+    if (g_runtime.automation.resetDepth != 0 ||
+        g_runtime.automation.activeDocumentResetDepth != 0 ||
+        g_runtime.automation.documentGeneration != expectedGeneration ||
+        g_runtime.automation.activeDocumentStale ||
+        g_runtime.automation.activeDocument.Get() != cachedDocument ||
+        !g_runtime.automation.activeDocumentIdentity) {
+        cachedDocument->Release();
+        return E_FAIL;
+    }
+
+    *document = cachedDocument;
+    return S_OK;
+}
+
+bool IsCachedActiveDocument(IDispatch* document) {
+    if (!document || !g_runtime.automation.activeDocumentIdentity) {
+        return false;
+    }
+
+    if (document == g_runtime.automation.activeDocument.Get()) {
+        return true;
+    }
+
+    ScopedComPtr<IUnknown> identity;
+    return SUCCEEDED(GetComIdentity(document, identity.Put())) &&
+           identity &&
+           AreSameComIdentity(identity.Get(),
+                              g_runtime.automation.activeDocumentIdentity.Get());
+}
+
+void MarkCachedActiveDocumentStale() {
+    g_runtime.automation.activeDocumentStale = true;
+}
+
+void InvalidateCachedActiveDocumentIfMatches(IDispatch* document) {
+    if (!document || IsCachedActiveDocument(document)) {
+        ResetCachedActiveDocumentState();
+    }
+}
+
+void InvalidateCachedActiveDocumentMetadataIfMatches(IDispatch* document) {
+    if (document && !IsCachedActiveDocument(document)) {
+        return;
+    }
+
+    g_runtime.automation.activeDocumentMetadataValid = false;
+    g_runtime.automation.activeDocumentReadOnly = false;
+    g_runtime.automation.activeDocumentHasPath = false;
+    g_runtime.automation.activeDocumentPath.Reset();
+}
+
+void InvalidateActiveDocumentCacheForEventCoverageGap() {
+    // While the connection point is down, Word can switch documents or
+    // complete Save As without delivering the invalidation events below.
+    MarkCachedActiveDocumentStale();
+    InvalidateCachedActiveDocumentMetadataIfMatches(nullptr);
+}
+
 bool IsWordEventSessionApplicationCacheValid(const WordEventSession& session,
-                                             LONG_PTR* applicationHwnd = nullptr) {
-    if (!session.application) {
-        return false;
-    }
-
-    LONG_PTR localApplicationHwnd = 0;
-    if (!DoesApplicationBelongToCurrentProcess(session.application.Get(),
-                                               &localApplicationHwnd)) {
-        return false;
-    }
-
-    if (session.applicationHwnd != 0 &&
-        session.applicationHwnd != localApplicationHwnd) {
+                                              LONG_PTR* applicationHwnd = nullptr) {
+    if (!session.application || session.applicationHwnd == 0 ||
+        !IsUsableWordApplicationWindowHandle(session.applicationHwnd)) {
         return false;
     }
 
     if (applicationHwnd) {
-        *applicationHwnd = localApplicationHwnd;
+        *applicationHwnd = session.applicationHwnd;
     }
 
     return true;
@@ -3220,8 +5018,20 @@ HRESULT CopyWordEventSessionApplication(const WordEventSession& session, IDispat
         return E_FAIL;
     }
 
-    session.application.Get()->AddRef();
-    *application = session.application.Get();
+    const unsigned int expectedEpoch =
+        g_runtime.events.connectionEpoch;
+    IDispatch* cachedApplication = session.application.Get();
+    const LONG_PTR cachedHwnd = session.applicationHwnd;
+    cachedApplication->AddRef();
+    if (g_runtime.events.connectionEpoch != expectedEpoch ||
+        IsWordEventTeardownInProgress() ||
+        session.application.Get() != cachedApplication ||
+        session.applicationHwnd != cachedHwnd) {
+        cachedApplication->Release();
+        return E_FAIL;
+    }
+
+    *application = cachedApplication;
     return S_OK;
 }
 
@@ -3237,6 +5047,31 @@ HRESULT GetNativeWordObjectFromWindow(HWND hwnd, IDispatch** nativeObject) {
                                       reinterpret_cast<void**>(nativeObject));
 }
 
+bool ShouldPropagateNativeDocumentProbeFailure(HRESULT hr) {
+    return FAILED(hr) &&
+           (IsRetryableAutomationFailure(hr) ||
+            IsTerminalAutomationObjectFailure(hr));
+}
+
+bool IsExpectedNativeDocumentProbeMiss(HRESULT hr) {
+    return hr == DISP_E_UNKNOWNNAME || hr == DISP_E_MEMBERNOTFOUND;
+}
+
+void RememberNativeDocumentProbeFailure(HRESULT hr,
+                                        HRESULT* firstHardFailure) {
+    if (!firstHardFailure || FAILED(*firstHardFailure) || !FAILED(hr) ||
+        IsExpectedNativeDocumentProbeMiss(hr) ||
+        ShouldPropagateNativeDocumentProbeFailure(hr)) {
+        return;
+    }
+
+    *firstHardFailure = hr;
+}
+
+HRESULT SelectNativeDocumentProbeMissResult(HRESULT firstHardFailure) {
+    return FAILED(firstHardFailure) ? firstHardFailure : S_FALSE;
+}
+
 HRESULT GetDocumentFromObjectChain(IDispatch* nativeObject, IDispatch** document) {
     if (!nativeObject || !document) {
         return E_POINTER;
@@ -3247,21 +5082,34 @@ HRESULT GetDocumentFromObjectChain(IDispatch* nativeObject, IDispatch** document
     ScopedComPtr<IDispatch> current;
     nativeObject->AddRef();
     current.Reset(nativeObject);
+    HRESULT firstHardFailure = S_OK;
 
     for (int depth = 0; depth < 4 && current; ++depth) {
-        HRESULT hr = GetDispatchProperty(current.Get(), L"Document", document);
+        HRESULT hr = GetDispatchPropertyUncached(current.Get(), L"Document", document);
         if (SUCCEEDED(hr) && *document) {
             return S_OK;
         }
+        if (ShouldPropagateNativeDocumentProbeFailure(hr)) {
+            return hr;
+        }
+        RememberNativeDocumentProbeFailure(hr, &firstHardFailure);
 
-        hr = GetDispatchProperty(current.Get(), L"ActiveDocument", document);
+        hr = GetDispatchPropertyUncached(current.Get(), L"ActiveDocument", document);
         if (SUCCEEDED(hr) && *document) {
             return S_OK;
         }
+        if (ShouldPropagateNativeDocumentProbeFailure(hr)) {
+            return hr;
+        }
+        RememberNativeDocumentProbeFailure(hr, &firstHardFailure);
 
         ScopedComPtr<IDispatch> parent;
-        hr = GetDispatchProperty(current.Get(), L"Parent", parent.Put());
+        hr = GetDispatchPropertyUncached(current.Get(), L"Parent", parent.Put());
         if (FAILED(hr) || !parent) {
+            if (ShouldPropagateNativeDocumentProbeFailure(hr)) {
+                return hr;
+            }
+            RememberNativeDocumentProbeFailure(hr, &firstHardFailure);
             break;
         }
 
@@ -3269,21 +5117,45 @@ HRESULT GetDocumentFromObjectChain(IDispatch* nativeObject, IDispatch** document
     }
 
     ScopedComPtr<IDispatch> application;
-    HRESULT hr = GetDispatchProperty(nativeObject, L"Application", application.Put());
+    HRESULT hr = GetDispatchPropertyUncached(nativeObject,
+                                             L"Application",
+                                             application.Put());
     if (FAILED(hr) || !application) {
         return FAILED(hr) ? hr : E_FAIL;
     }
 
     ScopedComPtr<IDispatch> activeWindow;
-    hr = GetDispatchProperty(application.Get(), L"ActiveWindow", activeWindow.Put());
+    hr = GetDispatchProperty(application.Get(),
+                             WordMember::ApplicationActiveWindow,
+                             activeWindow.Put());
+    if (ShouldPropagateNativeDocumentProbeFailure(hr)) {
+        return hr;
+    }
+    RememberNativeDocumentProbeFailure(hr, &firstHardFailure);
     if (SUCCEEDED(hr) && activeWindow) {
-        hr = GetDispatchProperty(activeWindow.Get(), L"Document", document);
+        hr = GetDispatchProperty(activeWindow.Get(),
+                                 WordMember::WindowDocument,
+                                 document);
         if (SUCCEEDED(hr) && *document) {
             return S_OK;
         }
+        if (ShouldPropagateNativeDocumentProbeFailure(hr)) {
+            return hr;
+        }
+        RememberNativeDocumentProbeFailure(hr, &firstHardFailure);
     }
 
-    return GetDispatchProperty(application.Get(), L"ActiveDocument", document);
+    hr = GetDispatchProperty(application.Get(),
+                             WordMember::ApplicationActiveDocument,
+                             document);
+    if (SUCCEEDED(hr) && *document) {
+        return S_OK;
+    }
+    if (ShouldPropagateNativeDocumentProbeFailure(hr)) {
+        return hr;
+    }
+    RememberNativeDocumentProbeFailure(hr, &firstHardFailure);
+    return SelectNativeDocumentProbeMissResult(firstHardFailure);
 }
 
 HRESULT GetDocumentIdentityAndPathState(IDispatch* document,
@@ -3297,7 +5169,7 @@ HRESULT GetDocumentIdentityAndPathState(IDispatch* document,
     *hasSavedPath = false;
 
     ScopedBstr path;
-    HRESULT hr = GetBstrProperty(document, L"Path", path.Put());
+    HRESULT hr = GetBstrProperty(document, WordMember::DocumentPath, path.Put());
     if (FAILED(hr)) {
         return hr;
     }
@@ -3308,7 +5180,9 @@ HRESULT GetDocumentIdentityAndPathState(IDispatch* document,
     }
 
     ScopedBstr fullName;
-    if (SUCCEEDED(GetBstrProperty(document, L"FullName", fullName.Put())) &&
+    if (SUCCEEDED(GetBstrProperty(document,
+                                  WordMember::DocumentFullName,
+                                  fullName.Put())) &&
         fullName.Length() > 0) {
         *hasSavedPath = true;
         *result = fullName.Detach();
@@ -3316,7 +5190,7 @@ HRESULT GetDocumentIdentityAndPathState(IDispatch* document,
     }
 
     ScopedBstr name;
-    hr = GetBstrProperty(document, L"Name", name.Put());
+    hr = GetBstrProperty(document, WordMember::DocumentName, name.Put());
     if (FAILED(hr)) {
         return hr;
     }
@@ -3331,7 +5205,13 @@ HRESULT GetDocumentIdentityAndPathState(IDispatch* document,
     const UINT pathLength = path.Length();
     const UINT nameLength = name.Length();
     const bool needsSlash = path.CStr()[pathLength - 1] != L'\\' && path.CStr()[pathLength - 1] != L'/';
-    const UINT totalLength = pathLength + (needsSlash ? 1u : 0u) + nameLength;
+    const UINT separatorLength = needsSlash ? 1u : 0u;
+    const UINT maxLength = (std::numeric_limits<UINT>::max)();
+    if (pathLength > maxLength - separatorLength ||
+        nameLength > maxLength - pathLength - separatorLength) {
+        return E_OUTOFMEMORY;
+    }
+    const UINT totalLength = pathLength + separatorLength + nameLength;
 
     BSTR identity = SysAllocStringLen(nullptr, totalLength);
     if (!identity) {
@@ -3357,41 +5237,100 @@ HRESULT GetDocumentIdentity(IDispatch* document, BSTR* result) {
 }
 
 void InvalidateTransitionFlushDocumentCache() {
-    g_runtime.document.transitionFlushDocument.Reset();
-    g_runtime.document.transitionFlushDocumentIdentity.Reset();
+    DetachedDocumentBinding previousBinding;
+    DetachDocumentBinding(
+        &g_runtime.document.transitionFlushDocument,
+        &g_runtime.document.transitionFlushDocumentIdentity,
+        &previousBinding);
 }
 
-bool IsTransitionFlushDocumentCacheValid(const wchar_t* expectedPath = nullptr) {
-    if (!g_runtime.document.transitionFlushDocument || !g_runtime.document.transitionFlushDocumentIdentity) {
+bool IsCurrentTransitionFlushDocumentBinding(unsigned int expectedGeneration,
+                                             IDispatch* document,
+                                             IUnknown* identity) {
+    return LoadFlag(g_runtime.flags.transitionFlushPending) &&
+           g_runtime.document.transitionFlushGeneration == expectedGeneration &&
+           g_runtime.document.transitionFlushDocument.Get() == document &&
+           g_runtime.document.transitionFlushDocumentIdentity.Get() == identity;
+}
+
+bool CopyValidTransitionFlushDocument(
+    const wchar_t* expectedPath,
+    ScopedComPtr<IDispatch>* result) {
+    if (!result || !LoadFlag(g_runtime.flags.transitionFlushPending)) {
         return false;
     }
 
-    IUnknown* identity = nullptr;
-    if (FAILED(GetComIdentity(g_runtime.document.transitionFlushDocument.Get(), &identity)) || !identity) {
-        InvalidateTransitionFlushDocumentCache();
+    const unsigned int expectedGeneration =
+        g_runtime.document.transitionFlushGeneration;
+    IDispatch* document =
+        g_runtime.document.transitionFlushDocument.Get();
+    IUnknown* storedIdentity =
+        g_runtime.document.transitionFlushDocumentIdentity.Get();
+    if (!document || !storedIdentity) {
         return false;
     }
 
-    const bool sameIdentity =
-        AreSameComIdentity(identity, g_runtime.document.transitionFlushDocumentIdentity.Get());
-    identity->Release();
-    if (!sameIdentity) {
-        InvalidateTransitionFlushDocumentCache();
+    ScopedComPtr<IDispatch> documentRef;
+    ScopedComPtr<IUnknown> storedIdentityRef;
+    document->AddRef();
+    documentRef.Reset(document);
+    if (!IsCurrentTransitionFlushDocumentBinding(expectedGeneration,
+                                                 document,
+                                                 storedIdentity)) {
         return false;
     }
 
-    if (expectedPath && *expectedPath) {
+    // The first AddRef can re-enter and retire the identity. Confirm that the
+    // pair is still current before touching the second raw pointer; once the
+    // document is pinned, a later identity AddRef re-entry is harmless.
+    storedIdentity->AddRef();
+    storedIdentityRef.Reset(storedIdentity);
+    if (!IsCurrentTransitionFlushDocumentBinding(expectedGeneration,
+                                                 document,
+                                                 storedIdentity)) {
+        return false;
+    }
+
+    ScopedComPtr<IUnknown> resolvedIdentity;
+    const HRESULT identityHr =
+        GetComIdentity(documentRef.Get(), resolvedIdentity.Put());
+    bool shouldInvalidate =
+        IsTerminalAutomationObjectFailure(identityHr);
+    bool valid = SUCCEEDED(identityHr) && resolvedIdentity &&
+                 AreSameComIdentity(resolvedIdentity.Get(),
+                                    storedIdentityRef.Get());
+    if (SUCCEEDED(identityHr) && resolvedIdentity && !valid) {
+        shouldInvalidate = true;
+    }
+
+    if (valid && expectedPath && *expectedPath) {
         ScopedBstr cachedPath;
-        const HRESULT hr =
-            GetDocumentIdentity(g_runtime.document.transitionFlushDocument.Get(), cachedPath.Put());
-        if (FAILED(hr) ||
-            cachedPath.Length() == 0 ||
-            !AreSameDocumentPath(cachedPath.CStr(), expectedPath)) {
-            InvalidateTransitionFlushDocumentCache();
-            return false;
+        const HRESULT pathHr =
+            GetDocumentIdentity(documentRef.Get(), cachedPath.Put());
+        if (FAILED(pathHr)) {
+            shouldInvalidate =
+                IsTerminalAutomationObjectFailure(pathHr);
+            valid = false;
+        } else if (cachedPath.Length() == 0 ||
+                   !AreSameResolvedDocumentPath(cachedPath.CStr(),
+                                                expectedPath)) {
+            shouldInvalidate = true;
+            valid = false;
         }
     }
 
+    const bool stillCurrent =
+        IsCurrentTransitionFlushDocumentBinding(expectedGeneration,
+                                                document,
+                                                storedIdentity);
+    if (!valid || !stillCurrent) {
+        if (shouldInvalidate && stillCurrent) {
+            InvalidateTransitionFlushDocumentCache();
+        }
+        return false;
+    }
+
+    result->Reset(documentRef.Detach());
     return true;
 }
 
@@ -3419,12 +5358,15 @@ HRESULT GetWordApplicationFromRot(IDispatch** application) {
         return hr;
     }
 
-    if (!DoesApplicationBelongToCurrentProcess(*application)) {
+    LONG_PTR applicationHwnd = 0;
+    if (!DoesApplicationBelongToCurrentProcess(*application,
+                                               &applicationHwnd)) {
         (*application)->Release();
         *application = nullptr;
         return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
     }
 
+    CacheWordApplication(*application, applicationHwnd);
     return S_OK;
 }
 
@@ -3446,13 +5388,15 @@ HRESULT GetWordApplicationFromActiveWindow(IDispatch** application) {
         return hr;
     }
 
-    hr = GetDispatchProperty(nativeObject.Get(), L"Application", application);
+    hr = GetDispatchPropertyUncached(nativeObject.Get(), L"Application", application);
     if (FAILED(hr) || !*application) {
         ScopedComPtr<IDispatch> activeDocument;
-        if (SUCCEEDED(GetDispatchProperty(nativeObject.Get(),
-                                          L"ActiveDocument",
-                                          activeDocument.Put()))) {
-            hr = GetDispatchProperty(activeDocument.Get(), L"Application", application);
+        if (SUCCEEDED(GetDispatchPropertyUncached(nativeObject.Get(),
+                                                  L"ActiveDocument",
+                                                  activeDocument.Put()))) {
+            hr = GetDispatchProperty(activeDocument.Get(),
+                                     WordMember::DocumentApplication,
+                                     application);
             if (FAILED(hr) || !*application) {
                 nativeObject.Get()->AddRef();
                 *application = nativeObject.Get();
@@ -3473,8 +5417,11 @@ HRESULT GetWordApplicationFromActiveWindow(IDispatch** application) {
             *application = nullptr;
             return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
         }
+
+        hwndValue = reinterpret_cast<LONG_PTR>(rootWindow);
     }
 
+    CacheWordApplication(*application, hwndValue);
     return S_OK;
 }
 
@@ -3489,6 +5436,9 @@ HRESULT GetWordApplicationFromConnectedInstance(IDispatch** application) {
         DisconnectWordApplicationEvents();
         return E_FAIL;
     }
+
+    CacheWordApplication(*application,
+                         g_runtime.events.session.applicationHwnd);
     return S_OK;
 }
 
@@ -3525,6 +5475,26 @@ HRESULT SelectWordApplicationResolutionFailure(bool hasRetryableFailure,
     return hasRetryableFailure ? lastRetryableFailure : lastFailure;
 }
 
+HRESULT RememberFirstDocumentLookupHardFailure(HRESULT firstHardFailure,
+                                               HRESULT candidateFailure) {
+    if (FAILED(firstHardFailure) || !FAILED(candidateFailure)) {
+        return firstHardFailure;
+    }
+
+    return candidateFailure;
+}
+
+bool ShouldReturnDocumentLookupFailureImmediately(HRESULT hr) {
+    return IsRetryableAutomationFailure(hr) ||
+           IsTerminalAutomationObjectFailure(hr);
+}
+
+HRESULT SelectDocumentPathLookupMissResult(HRESULT firstHardFailure) {
+    return FAILED(firstHardFailure)
+               ? firstHardFailure
+               : HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+}
+
 HRESULT ResolveWordApplication(WordApplicationResolutionStrategy strategy,
                                IDispatch** application) {
     if (!application) {
@@ -3532,6 +5502,10 @@ HRESULT ResolveWordApplication(WordApplicationResolutionStrategy strategy,
     }
 
     *application = nullptr;
+
+    if (SUCCEEDED(CopyCachedWordApplication(application)) && *application) {
+        return S_OK;
+    }
 
     WordApplicationSource sources[3] = {};
     if (strategy == WordApplicationResolutionStrategy::PreferConnectedInstance) {
@@ -3587,49 +5561,116 @@ HRESULT GetWordDocumentByPath(const wchar_t* path, IDispatch** document) {
     }
 
     ScopedComPtr<IDispatch> documents;
-    hr = GetDispatchProperty(application.Get(), L"Documents", documents.Put());
+    hr = GetDispatchProperty(application.Get(),
+                             WordMember::ApplicationDocuments,
+                             documents.Put());
     if (FAILED(hr) || !documents) {
+        if (IsTerminalAutomationObjectFailure(hr)) {
+            ResetAutomationCacheState();
+            DisconnectWordApplicationEvents();
+        }
         return FAILED(hr) ? hr : E_FAIL;
     }
 
     long count = 0;
-    hr = GetIntProperty(documents.Get(), L"Count", &count);
+    hr = GetIntProperty(documents.Get(), WordMember::DocumentsCount, &count);
     if (FAILED(hr)) {
+        if (IsTerminalAutomationObjectFailure(hr)) {
+            ResetAutomationCacheState();
+            DisconnectWordApplicationEvents();
+        }
         return hr;
     }
 
+    GrowablePathBuffer pathBuffer;
+    ScopedBstr resolvedTargetPath;
+    bool targetResolutionAttempted = false;
+    bool targetResolutionAvailable = false;
+    HRESULT firstHardFailure = S_OK;
     for (long index = 1; index <= count; ++index) {
         ScopedVariant indexArg;
         indexArg.Get()->vt = VT_I4;
         indexArg.Get()->lVal = index;
 
         ScopedComPtr<IDispatch> candidate;
-        hr = GetDispatchMethodObject(documents.Get(), L"Item", candidate.Put(), 1, indexArg.Get());
+        hr = GetDispatchMethodObject(documents.Get(),
+                                     WordMember::DocumentsItem,
+                                     candidate.Put(),
+                                     1,
+                                     indexArg.Get());
         if (FAILED(hr)) {
-            if (IsRetryableAutomationFailure(hr)) {
+            if (IsTerminalAutomationObjectFailure(hr)) {
+                ResetAutomationCacheState();
+                DisconnectWordApplicationEvents();
                 return hr;
             }
 
+            if (ShouldReturnDocumentLookupFailureImmediately(hr)) {
+                return hr;
+            }
+
+            firstHardFailure =
+                RememberFirstDocumentLookupHardFailure(firstHardFailure, hr);
             continue;
         }
 
         ScopedBstr candidateIdentity;
         hr = GetDocumentIdentity(candidate.Get(), candidateIdentity.Put());
         if (FAILED(hr) || candidateIdentity.Length() == 0) {
-            if (FAILED(hr) && IsRetryableAutomationFailure(hr)) {
+            if (IsTerminalAutomationObjectFailure(hr)) {
+                ResetAutomationCacheState();
+                DisconnectWordApplicationEvents();
                 return hr;
             }
 
+            if (FAILED(hr) &&
+                ShouldReturnDocumentLookupFailureImmediately(hr)) {
+                return hr;
+            }
+
+            if (FAILED(hr)) {
+                firstHardFailure = RememberFirstDocumentLookupHardFailure(
+                    firstHardFailure,
+                    hr);
+            }
             continue;
         }
 
-        if (AreSameDocumentPath(candidateIdentity.CStr(), path)) {
+        const DocumentPathTextComparison textComparison =
+            CompareDocumentPathText(candidateIdentity.CStr(), path);
+        if (textComparison == DocumentPathTextComparison::Equal) {
+            *document = candidate.Detach();
+            return S_OK;
+        }
+
+        if (textComparison != DocumentPathTextComparison::RequiresResolution) {
+            continue;
+        }
+
+        if (!targetResolutionAttempted) {
+            targetResolutionAttempted = true;
+            targetResolutionAvailable =
+                TryGetResolvedDocumentPath(path,
+                                           &resolvedTargetPath,
+                                           &pathBuffer);
+        }
+
+        if (!targetResolutionAvailable) {
+            continue;
+        }
+
+        ScopedBstr resolvedCandidatePath;
+        if (TryGetResolvedDocumentPath(candidateIdentity.CStr(),
+                                       &resolvedCandidatePath,
+                                       &pathBuffer) &&
+            AreSameDocumentPathText(resolvedCandidatePath.CStr(),
+                                    resolvedTargetPath.CStr())) {
             *document = candidate.Detach();
             return S_OK;
         }
     }
 
-    return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+    return SelectDocumentPathLookupMissResult(firstHardFailure);
 }
 
 HRESULT GetWordDocumentFromActiveWindow(IDispatch** document) {
@@ -3641,21 +5682,47 @@ HRESULT GetWordDocumentFromActiveWindow(IDispatch** document) {
 
     HWND viewWindow = FindNativeWordViewWindow();
     if (!viewWindow) {
-        return E_FAIL;
+        return S_FALSE;
     }
 
     ScopedComPtr<IDispatch> nativeObject;
     HRESULT hr = GetNativeWordObjectFromWindow(viewWindow, nativeObject.Put());
-    if (FAILED(hr) || !nativeObject) {
+    if (FAILED(hr)) {
         return hr;
+    }
+    if (!nativeObject) {
+        return S_FALSE;
     }
 
     hr = GetDocumentFromObjectChain(nativeObject.Get(), document);
-    if (FAILED(hr) || !*document) {
-        return FAILED(hr) ? hr : E_FAIL;
+    if (FAILED(hr)) {
+        return hr;
+    }
+    if (!*document) {
+        return S_FALSE;
     }
 
     return S_OK;
+}
+
+enum class NativeDocumentLookupOutcome {
+    Ready,
+    Missing,
+    RetryLater,
+};
+
+NativeDocumentLookupOutcome ClassifyNativeDocumentLookupResult(
+    HRESULT hr,
+    bool hasDocument) {
+    if (SUCCEEDED(hr) && hasDocument) {
+        return NativeDocumentLookupOutcome::Ready;
+    }
+
+    if (hr == S_FALSE) {
+        return NativeDocumentLookupOutcome::Missing;
+    }
+
+    return NativeDocumentLookupOutcome::RetryLater;
 }
 
 HRESULT ResolveTypeInfoDispId(ITypeInfo* typeInfo, const wchar_t* name, DISPID* dispId) {
@@ -3677,6 +5744,11 @@ HRESULT ResolveTypeInfoDispId(ITypeInfo* typeInfo, const wchar_t* name, DISPID* 
 HRESULT ResolveWordEventDispIds(IDispatch* application, WordEventDispIds* dispIds) {
     if (!application || !dispIds) {
         return E_POINTER;
+    }
+
+    if (g_runtime.events.cachedDispIdsValid) {
+        *dispIds = g_runtime.events.cachedDispIds;
+        return S_OK;
     }
 
     dispIds->Reset();
@@ -3720,12 +5792,21 @@ HRESULT ResolveWordEventDispIds(IDispatch* application, WordEventDispIds* dispId
     }
 
     hr = ResolveTypeInfoDispId(eventTypeInfo.Get(),
+                               L"WindowActivate",
+                               &dispIds->windowActivate);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    hr = ResolveTypeInfoDispId(eventTypeInfo.Get(),
                                L"WindowDeactivate",
                                &dispIds->windowDeactivate);
     if (FAILED(hr)) {
         return hr;
     }
 
+    g_runtime.events.cachedDispIds = *dispIds;
+    g_runtime.events.cachedDispIdsValid = true;
     return S_OK;
 }
 
@@ -3813,22 +5894,39 @@ void HandleWordDocumentBeforeSaveEvent(const DISPPARAMS* params) {
 
     PrepareManualSaveObservation();
 
+    // SaveAsUI only reports whether Word displayed the Save As dialog. A
+    // programmatic SaveAs/SaveAs2 can change FullName with SaveAsUI == false,
+    // so every external save event must invalidate cached path metadata.
+    if (document) {
+        InvalidateCachedActiveDocumentMetadataIfMatches(document.Get());
+    }
+
     if (!saveAsUi || !document) {
         return;
     }
 
+    const unsigned int expectedGeneration =
+        g_runtime.document.pendingSaveAsGeneration;
     ScopedComPtr<IUnknown> documentIdentity;
-    if (SUCCEEDED(GetComIdentity(document.Get(), documentIdentity.Put())) && documentIdentity) {
-        ReplaceStoredComPtr(&g_runtime.document.pendingSaveAsDocumentIdentity,
-                            documentIdentity.Get());
+    GetComIdentity(document.Get(), documentIdentity.Put());
+    if (g_runtime.document.pendingSaveAsGeneration != expectedGeneration) {
+        return;
     }
 
+    ClearFlag(g_runtime.flags.pendingSaveAsMigration);
+    ScopedComPtr<IUnknown> previousIdentity;
+    previousIdentity.Reset(
+        g_runtime.document.pendingSaveAsDocumentIdentity.Detach());
+    g_runtime.document.pendingSaveAsDocumentIdentity.Reset(
+        documentIdentity.Detach());
+    ++g_runtime.document.pendingSaveAsGeneration;
     g_runtime.timing.pendingSaveAsTime = GetTickCount64();
     SetFlag(g_runtime.flags.pendingSaveAsMigration);
     LogSaveStatus(L"tracking Save As to migrate the current document state");
 }
 
 void HandleWordDocumentBeforeCloseEvent(const DISPPARAMS* params) {
+    MarkCachedActiveDocumentStale();
     if (!HasPendingSaveWork()) {
         return;
     }
@@ -3866,18 +5964,39 @@ void HandleWordDocumentBeforeCloseEvent(const DISPPARAMS* params) {
 }
 
 void HandleWordDocumentChangeEvent() {
+    MarkCachedActiveDocumentStale();
+    InvalidateCachedActiveDocumentMetadataIfMatches(nullptr);
     InvalidateWordUiWindowCache();
     ExpirePendingSaveAsMigrationIfNeeded();
-    MaybeKickAutomationRecovery();
+    ResumePendingRuntimeWorkForSignal(SaveResumeSignal::DocumentChanged);
+    ArmDocumentStateTimer(INPUT_SETTLE_DELAY_MS);
+}
+
+void HandleWordWindowActivateEvent(const DISPPARAMS* params) {
+    ScopedComPtr<IDispatch> document;
+    if (SUCCEEDED(CopyDispatchFromVariant(GetEventArgument(params, 0),
+                                          document.Put())) &&
+        document) {
+        if (FAILED(CacheActiveDocumentBinding(document.Get()))) {
+            MarkCachedActiveDocumentStale();
+        }
+    } else {
+        MarkCachedActiveDocumentStale();
+    }
+
+    InvalidateWordUiWindowCache();
+    ExpirePendingSaveAsMigrationIfNeeded();
+    ResumePendingRuntimeWorkForSignal(SaveResumeSignal::WordActivated);
     ArmDocumentStateTimer(INPUT_SETTLE_DELAY_MS);
 }
 
 void HandleWordWindowDeactivateEvent(const DISPPARAMS* params) {
+    MarkCachedActiveDocumentStale();
+    InvalidateWordUiWindowCache();
+
     if (!HasPendingSaveWork()) {
         return;
     }
-
-    InvalidateWordUiWindowCache();
 
     ScopedComPtr<IDispatch> document;
     CopyDispatchFromVariant(GetEventArgument(params, 0), document.Put());
@@ -3907,6 +6026,7 @@ enum class WordApplicationEventKind {
     DocumentBeforeSave,
     DocumentBeforeClose,
     DocumentChange,
+    WindowActivate,
     WindowDeactivate,
 };
 
@@ -3922,6 +6042,10 @@ WordApplicationEventKind ClassifyWordApplicationEvent(const WordEventDispIds& di
 
     if (dispIdMember == dispIds.documentChange) {
         return WordApplicationEventKind::DocumentChange;
+    }
+
+    if (dispIdMember == dispIds.windowActivate) {
+        return WordApplicationEventKind::WindowActivate;
     }
 
     if (dispIdMember == dispIds.windowDeactivate) {
@@ -3948,6 +6072,10 @@ void DispatchWordApplicationEvent(WordApplicationEventKind eventKind,
 
         case WordApplicationEventKind::DocumentChange:
             HandleWordDocumentChangeEvent();
+            return;
+
+        case WordApplicationEventKind::WindowActivate:
+            HandleWordWindowActivateEvent(params);
             return;
 
         case WordApplicationEventKind::WindowDeactivate:
@@ -4021,22 +6149,56 @@ public:
                         VARIANT*,
                         EXCEPINFO*,
                         UINT*) override {
-        if (!LoadFlag(m_active)) {
+        ScopedInterlockedCount activeInvoke(m_activeInvokeCount);
+        if (!LoadInterlockedFlag(m_active)) {
+            SetInterlockedFlag(m_invokeAfterDeactivateObserved);
+            if (g_control.shutdownRequested.load(std::memory_order_acquire)) {
+                g_control.requiresPinnedShutdown.store(true,
+                                                       std::memory_order_release);
+            }
             return S_OK;
         }
 
-        DispatchWordApplicationEvent(ClassifyWordApplicationEvent(m_dispIds, dispIdMember),
-                                     params);
+        if (!IsOwnerThread()) {
+            SetInterlockedFlag(m_offOwnerInvokeObserved);
+            g_control.requiresPinnedShutdown.store(true,
+                                                   std::memory_order_release);
+            return S_OK;
+        }
+
+        try {
+            ScopedOwnerRuntimeWork ownerWork;
+            DispatchWordApplicationEvent(
+                ClassifyWordApplicationEvent(m_dispIds, dispIdMember),
+                params);
+        } catch (...) {
+            return E_UNEXPECTED;
+        }
         return S_OK;
     }
 
     void Deactivate() {
-        ClearFlag(m_active);
+        ClearInterlockedFlag(m_active);
+    }
+
+    bool HasActiveInvokes() const {
+        return InterlockedCompareExchange(
+                   const_cast<volatile LONG*>(&m_activeInvokeCount),
+                   0,
+                   0) != 0;
+    }
+
+    bool RequiresPinnedRundown() const {
+        return LoadInterlockedFlag(m_offOwnerInvokeObserved) ||
+               LoadInterlockedFlag(m_invokeAfterDeactivateObserved);
     }
 
 private:
     volatile LONG m_refCount = 1;
     volatile LONG m_active = TRUE;
+    volatile LONG m_activeInvokeCount = 0;
+    volatile LONG m_offOwnerInvokeObserved = FALSE;
+    volatile LONG m_invokeAfterDeactivateObserved = FALSE;
     WordEventDispIds m_dispIds = {};
 };
 
@@ -4089,7 +6251,9 @@ void LogWordEventDisconnectFailure(const wchar_t* message, HRESULT hr) {
 }
 
 void RefreshPendingWordEventDisconnectRetryFlag() {
-    bool pending = false;
+    bool pending = g_runtime.events.stagedSession.IsConnected() ||
+                   (!LoadFlag(g_runtime.flags.wordEventsConnected) &&
+                    g_runtime.events.session.IsConnected());
     for (int index = 0; index < WORD_EVENT_PENDING_DISCONNECT_CAPACITY; ++index) {
         if (g_runtime.events.pendingDisconnectSessions[index].IsConnected()) {
             pending = true;
@@ -4104,7 +6268,7 @@ WordEventSession* FindFreePendingWordEventDisconnectSlot() {
     for (int index = 0; index < WORD_EVENT_PENDING_DISCONNECT_CAPACITY; ++index) {
         WordEventSession* session =
             &g_runtime.events.pendingDisconnectSessions[index];
-        if (!session->IsConnected()) {
+        if (session->IsEmpty()) {
             return session;
         }
     }
@@ -4157,10 +6321,29 @@ void RequestWordEventDisconnectRetryWakeup() {
     // The retry flag stays set and will be armed after owner-thread adoption.
 }
 
+bool IsWordEventTeardownInProgress() {
+    return g_runtime.events.primaryDisconnectDepth != 0 ||
+           g_runtime.events.pendingDisconnectRetryDepth != 0;
+}
+
+bool IsWordEventConnectionBuildInProgress() {
+    return g_runtime.events.connectionBuildDepth != 0;
+}
+
+bool CanCommitWordEventConnection(unsigned int expectedEpoch) {
+    return !IsWordEventTeardownInProgress() &&
+           g_runtime.events.connectionEpoch == expectedEpoch;
+}
+
 void RetryPendingWordEventDisconnects() {
-    if (!HasPendingWordEventDisconnectRetry()) {
+    if (!HasPendingWordEventDisconnectRetry() ||
+        g_runtime.events.primaryDisconnectDepth != 0 ||
+        g_runtime.events.pendingDisconnectRetryDepth != 0) {
         return;
     }
+
+    ScopedOwnerDepth retryDepth(
+        g_runtime.events.pendingDisconnectRetryDepth);
 
     ScopedComInit comInit;
     if (FAILED(comInit.GetResult())) {
@@ -4172,9 +6355,16 @@ void RetryPendingWordEventDisconnects() {
     }
 
     ScopedComMessageFilter messageFilter;
-    for (int index = 0; index < WORD_EVENT_PENDING_DISCONNECT_CAPACITY; ++index) {
+    // Index -1 is the runtime-owned candidate whose commit/rollback may have
+    // been interrupted after Advise. It must follow the same retry policy as
+    // retired primary sessions.
+    for (int index = -1;
+         index < WORD_EVENT_PENDING_DISCONNECT_CAPACITY;
+         ++index) {
         WordEventSession* session =
-            &g_runtime.events.pendingDisconnectSessions[index];
+            index < 0
+                ? &g_runtime.events.stagedSession
+                : &g_runtime.events.pendingDisconnectSessions[index];
         if (!session->IsConnected()) {
             session->Reset();
             continue;
@@ -4197,6 +6387,14 @@ void RetryPendingWordEventDisconnects() {
         LogWordEventDisconnectFailure(L"deferred unadvise still failed", hr);
     }
 
+    // A primary session is restored in place when the retirement queue is
+    // full. Once the loop above frees a slot, retry it automatically rather
+    // than waiting for an unrelated reconnect or shutdown.
+    if (!LoadFlag(g_runtime.flags.wordEventsConnected) &&
+        g_runtime.events.session.IsConnected()) {
+        DisconnectWordApplicationEvents(true);
+    }
+
     RefreshPendingWordEventDisconnectRetryFlag();
     if (HasPendingWordEventDisconnectRetry()) {
         RequestWordEventDisconnectRetryWakeup();
@@ -4215,17 +6413,15 @@ bool QueueWordEventSessionDisconnectRetry(WordEventSession* session) {
         return false;
     }
 
-    slot->Reset();
     *slot = std::move(*session);
-    session->Reset();
     SetFlag(g_runtime.flags.wordEventDisconnectRetryPending);
     RequestWordEventDisconnectRetryWakeup();
     return true;
 }
 
-void DisconnectWordEventSession(WordEventSession* session, bool allowDeferredRetry) {
+bool DisconnectWordEventSession(WordEventSession* session, bool allowDeferredRetry) {
     if (!session) {
-        return;
+        return true;
     }
 
     const bool connected = session->IsConnected();
@@ -4247,7 +6443,7 @@ void DisconnectWordEventSession(WordEventSession* session, bool allowDeferredRet
                     hr);
             }
             session->Reset();
-            return;
+            return true;
         }
 
         LogWordEventDisconnectFailure(
@@ -4257,7 +6453,7 @@ void DisconnectWordEventSession(WordEventSession* session, bool allowDeferredRet
             hr);
         if (allowDeferredRetry &&
             QueueWordEventSessionDisconnectRetry(session)) {
-            return;
+            return true;
         }
     } else if (connected) {
         LogWordEventDisconnectFailure(
@@ -4265,27 +6461,177 @@ void DisconnectWordEventSession(WordEventSession* session, bool allowDeferredRet
             comInit.GetResult());
         if (allowDeferredRetry &&
             QueueWordEventSessionDisconnectRetry(session)) {
-            return;
+            return true;
         }
     }
 
+    if (connected && session->IsConnected()) {
+        // The caller owns persistent storage for this session. Never release a
+        // still-advised sink merely because the bounded retirement queue is
+        // full; retain it and stop new connection builds until Unadvise wins.
+        SetFlag(g_runtime.flags.wordEventDisconnectRetryPending);
+        if (allowDeferredRetry) {
+            RequestWordEventDisconnectRetryWakeup();
+        }
+        return false;
+    }
+
     session->Reset();
+    return true;
 }
 
-void DisconnectWordApplicationEvents(bool allowDeferredRetry) {
-    DisconnectWordEventSession(&g_runtime.events.session, allowDeferredRetry);
+bool DisconnectWordApplicationEvents(bool allowDeferredRetry) {
+    if (g_runtime.events.primaryDisconnectDepth != 0) {
+        return g_runtime.events.session.IsEmpty();
+    }
+
+    ScopedOwnerDepth disconnectDepth(
+        g_runtime.events.primaryDisconnectDepth);
+    ++g_runtime.events.connectionEpoch;
     ClearFlag(g_runtime.flags.wordEventsConnected);
+    InvalidateActiveDocumentCacheForEventCoverageGap();
+
+    // Remove the observable session before Deactivate/Unadvise/Release. A
+    // nested disconnect sees an empty global and Ensure is gated by depth.
+    WordEventSession disconnectedSession(
+        std::move(g_runtime.events.session));
+    const bool disconnected =
+        DisconnectWordEventSession(&disconnectedSession, allowDeferredRetry);
+    if (!disconnected && !disconnectedSession.IsEmpty()) {
+        // primaryDisconnectDepth prevents a nested connection commit, so the
+        // primary slot is still empty here. Restore the live session rather
+        // than letting the stack aggregate release an advised sink.
+        g_runtime.events.session = std::move(disconnectedSession);
+    }
+    return disconnected;
 }
 
 void DisconnectPendingWordEventDisconnectSessionsForShutdown() {
-    for (int index = 0; index < WORD_EVENT_PENDING_DISCONNECT_CAPACITY; ++index) {
-        WordEventSession* session =
-            &g_runtime.events.pendingDisconnectSessions[index];
-        DisconnectWordEventSession(session, false);
-        session->Reset();
+    if (IsWordEventTeardownInProgress()) {
+        return;
     }
 
-    ClearFlag(g_runtime.flags.wordEventDisconnectRetryPending);
+    ScopedOwnerDepth retryDepth(
+        g_runtime.events.pendingDisconnectRetryDepth);
+    bool complete = true;
+    for (int index = -1;
+         index < WORD_EVENT_PENDING_DISCONNECT_CAPACITY;
+         ++index) {
+        WordEventSession* session =
+            index < 0
+                ? &g_runtime.events.stagedSession
+                : &g_runtime.events.pendingDisconnectSessions[index];
+        if (!DisconnectWordEventSession(session, false)) {
+            complete = false;
+        }
+    }
+
+    if (complete) {
+        ClearFlag(g_runtime.flags.wordEventDisconnectRetryPending);
+    } else {
+        g_control.requiresPinnedShutdown.store(true,
+                                               std::memory_order_release);
+        RefreshPendingWordEventDisconnectRetryFlag();
+    }
+}
+
+bool TryDisconnectWordEventSessionForOwnerShutdown(WordEventSession* session) {
+    if (!session) {
+        return true;
+    }
+
+    DeactivateWordApplicationEventSink(session);
+
+    if (!session->IsConnected()) {
+        if (session->sinkControl &&
+            session->sinkControl->RequiresPinnedRundown()) {
+            g_control.requiresPinnedShutdown.store(true,
+                                                   std::memory_order_release);
+            return false;
+        }
+        if (session->sinkControl && session->sinkControl->HasActiveInvokes()) {
+            return false;
+        }
+        session->Reset();
+        return true;
+    }
+
+    ScopedComInit comInit;
+    if (FAILED(comInit.GetResult())) {
+        LogWordEventDisconnectFailure(
+            L"COM initialization failed during owner-thread shutdown",
+            comInit.GetResult());
+        return false;
+    }
+
+    ScopedComMessageFilter messageFilter;
+    const HRESULT hr =
+        UnadviseWordEventSessionWithInitializedCom(session);
+    if (!DidWordEventUnadviseComplete(hr)) {
+        LogWordEventDisconnectFailure(
+            L"owner-thread shutdown is waiting to unadvise application events",
+            hr);
+        return false;
+    }
+
+    if (FAILED(hr)) {
+        LogWordEventDisconnectFailure(
+            L"shutdown unadvise found no active application event connection",
+            hr);
+    }
+
+    // Preserve the connection point and sink references while any already
+    // entered Invoke drains, but never call Unadvise for this cookie twice.
+    session->cookie = 0;
+
+    if (session->sinkControl &&
+        session->sinkControl->RequiresPinnedRundown()) {
+        g_control.requiresPinnedShutdown.store(true,
+                                               std::memory_order_release);
+        return false;
+    }
+
+    if (session->sinkControl && session->sinkControl->HasActiveInvokes()) {
+        return false;
+    }
+
+    session->Reset();
+    return true;
+}
+
+bool TryDisconnectAllWordEventsForOwnerShutdown() {
+    if (IsWordEventTeardownInProgress()) {
+        return false;
+    }
+
+    ScopedOwnerDepth disconnectDepth(
+        g_runtime.events.primaryDisconnectDepth);
+    ++g_runtime.events.connectionEpoch;
+    ClearFlag(g_runtime.flags.wordEventsConnected);
+    InvalidateActiveDocumentCacheForEventCoverageGap();
+
+    bool complete =
+        TryDisconnectWordEventSessionForOwnerShutdown(
+            &g_runtime.events.session);
+
+    if (!TryDisconnectWordEventSessionForOwnerShutdown(
+            &g_runtime.events.stagedSession)) {
+        complete = false;
+    }
+
+    for (int index = 0;
+         index < WORD_EVENT_PENDING_DISCONNECT_CAPACITY;
+         ++index) {
+        if (!TryDisconnectWordEventSessionForOwnerShutdown(
+                &g_runtime.events.pendingDisconnectSessions[index])) {
+            complete = false;
+        }
+    }
+
+    if (complete) {
+        ClearFlag(g_runtime.flags.wordEventDisconnectRetryPending);
+    }
+    return complete;
 }
 
 HRESULT BuildWordEventSession(IDispatch* application, WordEventSession* session) {
@@ -4344,25 +6690,64 @@ HRESULT BuildWordEventSession(IDispatch* application, WordEventSession* session)
     return S_OK;
 }
 
-void CommitWordEventSession(WordEventSession* session) {
+HRESULT CommitWordEventSession(WordEventSession* session,
+                               unsigned int expectedEpoch) {
     if (!session) {
-        return;
+        return E_POINTER;
     }
 
-    DisconnectWordApplicationEvents();
+    if (!CanCommitWordEventConnection(expectedEpoch)) {
+        ScopedOwnerDepth teardownDepth(
+            g_runtime.events.pendingDisconnectRetryDepth);
+        DisconnectWordEventSession(session, true);
+        return E_ABORT;
+    }
+
+    CacheWordApplication(session->application.Get(), session->applicationHwnd);
+    if (!CanCommitWordEventConnection(expectedEpoch)) {
+        ScopedOwnerDepth teardownDepth(
+            g_runtime.events.pendingDisconnectRetryDepth);
+        DisconnectWordEventSession(session, true);
+        return E_ABORT;
+    }
+
+    if (!DisconnectWordApplicationEvents()) {
+        ScopedOwnerDepth teardownDepth(
+            g_runtime.events.pendingDisconnectRetryDepth);
+        DisconnectWordEventSession(session, true);
+        return E_ABORT;
+    }
     g_runtime.events.session = std::move(*session);
     SetFlag(g_runtime.flags.wordEventsConnected);
+    return S_OK;
 }
 
-HRESULT ConnectWordApplicationEvents(IDispatch* application) {
-    WordEventSession session;
-    const HRESULT hr = BuildWordEventSession(application, &session);
+HRESULT ConnectWordApplicationEvents(IDispatch* application,
+                                      unsigned int expectedEpoch) {
+    WordEventSession* session = &g_runtime.events.stagedSession;
+    if (!session->IsEmpty()) {
+        ScopedOwnerDepth teardownDepth(
+            g_runtime.events.pendingDisconnectRetryDepth);
+        if (!DisconnectWordEventSession(session, true)) {
+            return E_PENDING;
+        }
+    }
+
+    // Keep one normal retirement slot available before Advise. If commit is
+    // invalidated by re-entrancy, the staged session can then be retired
+    // without dropping a live callback object.
+    if (!FindFreePendingWordEventDisconnectSlot()) {
+        SetFlag(g_runtime.flags.wordEventDisconnectRetryPending);
+        RequestWordEventDisconnectRetryWakeup();
+        return E_PENDING;
+    }
+
+    const HRESULT hr = BuildWordEventSession(application, session);
     if (FAILED(hr)) {
         return hr;
     }
 
-    CommitWordEventSession(&session);
-    return S_OK;
+    return CommitWordEventSession(session, expectedEpoch);
 }
 
 bool CanReuseConnectedWordEventState(bool forceReconnect,
@@ -4417,6 +6802,11 @@ HRESULT ResolveWordApplicationForEventConnection(ScopedComPtr<IDispatch>* applic
     }
 
     if (!DoesApplicationBelongToCurrentProcess(application->Get(), applicationHwnd)) {
+        // GetWordApplication can return the strong cached proxy before trying
+        // the native/ROT sources. Evict a proxy that no longer validates so a
+        // later reconnect can resolve the live application instead of looping
+        // on the same dead object.
+        ResetAutomationCacheState();
         return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
     }
 
@@ -4430,7 +6820,18 @@ WordEventConnectionResult EnsureWordEventSessionConnected(bool forceReconnect) {
         return result;
     }
 
+    if (IsWordEventTeardownInProgress() ||
+        IsWordEventConnectionBuildInProgress()) {
+        return result;
+    }
+
+    ScopedOwnerDepth connectionBuildDepth(
+        g_runtime.events.connectionBuildDepth);
+
     RetryPendingWordEventDisconnects();
+    if (IsWordEventTeardownInProgress()) {
+        return result;
+    }
 
     const bool wordEventsConnected =
         LoadFlag(g_runtime.flags.wordEventsConnected);
@@ -4461,12 +6862,18 @@ WordEventConnectionResult EnsureWordEventSessionConnected(bool forceReconnect) {
         DisconnectWordApplicationEvents();
     }
 
+    if (IsWordEventTeardownInProgress()) {
+        return result;
+    }
+
     ScopedComInit comInit;
     if (FAILED(comInit.GetResult())) {
         return result;
     }
 
-    ScopedComMessageFilter messageFilter;
+    ScopedComMessageFilter messageFilter(ComRetryProfile::Background);
+    const unsigned int expectedEpoch =
+        g_runtime.events.connectionEpoch;
 
     ScopedComPtr<IDispatch> application;
     LONG_PTR applicationHwnd = 0;
@@ -4480,6 +6887,10 @@ WordEventConnectionResult EnsureWordEventSessionConnected(bool forceReconnect) {
         return result;
     }
 
+    if (!CanCommitWordEventConnection(expectedEpoch)) {
+        return result;
+    }
+
     if (ShouldReuseWordEventConnectionForHwnd(forceReconnect,
                                               wordEventsConnected,
                                               g_runtime.events.session.applicationHwnd,
@@ -4488,8 +6899,11 @@ WordEventConnectionResult EnsureWordEventSessionConnected(bool forceReconnect) {
         return result;
     }
 
-    hr = ConnectWordApplicationEvents(application.Get());
+    hr = ConnectWordApplicationEvents(application.Get(), expectedEpoch);
     if (FAILED(hr)) {
+        if (hr == E_ABORT || hr == E_PENDING) {
+            return result;
+        }
         DisconnectWordApplicationEvents();
         result.outcome = WordEventConnectionOutcome::Failed;
         result.hr = hr;
@@ -4513,7 +6927,8 @@ bool EnsureWordApplicationEventsConnected(bool forceReconnect) {
     }
 
     if (result.outcome == WordEventConnectionOutcome::Failed &&
-        ShouldLogFailureNow(&g_runtime.status.lastDocumentStateFailureLogTime)) {
+        ShouldLogFailureNow(&g_runtime.status.lastDocumentStateFailureLogTime,
+                            DOCUMENT_FAILURE_LOG_INTERVAL_MS)) {
         Wh_Log(L"Document state monitor: failed to connect Word application events, hr=0x%08X",
                result.hr);
     }
@@ -4566,11 +6981,21 @@ enum class SnapshotClearedReason {
     ProtectedView,
 };
 
+enum class SnapshotMetadataState {
+    NotRequested,
+    Cached,
+    Refreshed,
+    Unavailable,
+};
+
 struct ActiveDocumentSnapshot {
     ScopedComPtr<IDispatch> document;
     ScopedComPtr<IUnknown> identity;
     ScopedBstr path;
     SnapshotClearedReason clearedReason = SnapshotClearedReason::None;
+    SnapshotMetadataState metadataState = SnapshotMetadataState::NotRequested;
+    AutomationFailureClass failureClass = AutomationFailureClass::None;
+    HRESULT failureHr = S_OK;
     bool readOnly = false;
     bool saved = true;
     bool hasPath = false;
@@ -4580,11 +7005,58 @@ struct ActiveDocumentSnapshot {
         identity.Reset();
         path.Reset();
         clearedReason = SnapshotClearedReason::None;
+        metadataState = SnapshotMetadataState::NotRequested;
+        failureClass = AutomationFailureClass::None;
+        failureHr = S_OK;
         readOnly = false;
         saved = true;
         hasPath = false;
     }
 };
+
+void RecordSnapshotFailure(ActiveDocumentSnapshot* snapshot, HRESULT hr) {
+    if (!snapshot) {
+        return;
+    }
+
+    const HRESULT effectiveHr = FAILED(hr) ? hr : E_FAIL;
+    snapshot->failureHr = effectiveHr;
+    snapshot->failureClass = ClassifyAutomationFailure(effectiveHr);
+}
+
+SaveRetryReason GetSaveRetryReasonForSnapshot(
+    const ActiveDocumentSnapshot* snapshot) {
+    const AutomationFailureClass failureClass =
+        snapshot ? snapshot->failureClass : AutomationFailureClass::Hard;
+    switch (failureClass) {
+        case AutomationFailureClass::Busy:
+            return SaveRetryReason::AutomationBusy;
+        case AutomationFailureClass::Disconnected:
+            return SaveRetryReason::TargetUnavailable;
+        case AutomationFailureClass::Hard:
+        case AutomationFailureClass::None:
+            return SaveRetryReason::HardFailure;
+    }
+
+    return SaveRetryReason::HardFailure;
+}
+
+DocumentRetryReason GetDocumentRetryReasonForSnapshot(
+    const ActiveDocumentSnapshot* snapshot) {
+    const AutomationFailureClass failureClass =
+        snapshot ? snapshot->failureClass : AutomationFailureClass::Hard;
+    switch (failureClass) {
+        case AutomationFailureClass::Busy:
+            return DocumentRetryReason::Busy;
+        case AutomationFailureClass::Disconnected:
+            return DocumentRetryReason::Disconnected;
+        case AutomationFailureClass::Hard:
+        case AutomationFailureClass::None:
+            return DocumentRetryReason::Hard;
+    }
+
+    return DocumentRetryReason::Hard;
+}
 
 const wchar_t* DescribeSnapshotClearedReason(SnapshotClearedReason reason) {
     switch (reason) {
@@ -4609,7 +7081,10 @@ void LogSnapshotFailure(SnapshotLogContext context, const wchar_t* message, HRES
     ULONGLONG* lastLogTime = context == SnapshotLogContext::Save
                                  ? &g_runtime.status.lastSaveFailureLogTime
                                  : &g_runtime.status.lastDocumentStateFailureLogTime;
-    if (!ShouldLogFailureNow(lastLogTime)) {
+    const DWORD intervalMs = context == SnapshotLogContext::Save
+                                 ? SAVE_FAILURE_LOG_INTERVAL_MS
+                                 : DOCUMENT_FAILURE_LOG_INTERVAL_MS;
+    if (!ShouldLogFailureNow(lastLogTime, intervalMs)) {
         return;
     }
 
@@ -4643,8 +7118,14 @@ SnapshotQueryResult PopulateSnapshotSavedState(ActiveDocumentSnapshot* snapshot,
         return SnapshotQueryResult::Cleared;
     }
 
-    const HRESULT hr = GetBoolProperty(snapshot->document.Get(), L"Saved", &snapshot->saved);
+    const HRESULT hr = GetBoolProperty(snapshot->document.Get(),
+                                       WordMember::DocumentSaved,
+                                       &snapshot->saved);
     if (FAILED(hr)) {
+        RecordSnapshotFailure(snapshot, hr);
+        if (IsTerminalAutomationObjectFailure(hr)) {
+            InvalidateCachedActiveDocumentIfMatches(snapshot->document.Get());
+        }
         LogSnapshotFailure(context, L"failed to query Saved state", hr);
         return SnapshotQueryResult::RetryLater;
     }
@@ -4652,21 +7133,29 @@ SnapshotQueryResult PopulateSnapshotSavedState(ActiveDocumentSnapshot* snapshot,
     return SnapshotQueryResult::Ready;
 }
 
-SnapshotQueryResult PopulateSnapshotMetadata(ActiveDocumentSnapshot* snapshot,
-                                            SnapshotLogContext context) {
-    if (!snapshot || !snapshot->document) {
-        return SnapshotQueryResult::Cleared;
-    }
-
-    HRESULT hr = GetComIdentity(snapshot->document.Get(), snapshot->identity.Put());
-    if (FAILED(hr) || !snapshot->identity) {
-        LogSnapshotFailure(context, L"failed to resolve document COM identity", hr);
+SnapshotQueryResult CopyCachedActiveDocumentMetadata(
+    ActiveDocumentSnapshot* snapshot) {
+    if (!snapshot || !snapshot->document ||
+        !AreWordEventsConnected() ||
+        g_runtime.automation.activeDocumentStale ||
+        !g_runtime.automation.activeDocumentMetadataValid ||
+        !IsCachedActiveDocument(snapshot->document.Get()) ||
+        !g_runtime.automation.activeDocumentIdentity) {
         return SnapshotQueryResult::RetryLater;
     }
 
-    hr = GetBoolProperty(snapshot->document.Get(), L"ReadOnly", &snapshot->readOnly);
-    if (FAILED(hr)) {
-        LogSnapshotFailure(context, L"failed to query ReadOnly", hr);
+    ReplaceStoredComPtr(
+        &snapshot->identity,
+        g_runtime.automation.activeDocumentIdentity.Get());
+    snapshot->readOnly = g_runtime.automation.activeDocumentReadOnly;
+    snapshot->hasPath = g_runtime.automation.activeDocumentHasPath;
+    snapshot->metadataState = SnapshotMetadataState::Cached;
+
+    if (snapshot->hasPath &&
+        !ReplaceStoredTextBstr(&snapshot->path,
+                               g_runtime.automation.activeDocumentPath.Get())) {
+        snapshot->metadataState = SnapshotMetadataState::Unavailable;
+        RecordSnapshotFailure(snapshot, E_OUTOFMEMORY);
         return SnapshotQueryResult::RetryLater;
     }
 
@@ -4675,13 +7164,105 @@ SnapshotQueryResult PopulateSnapshotMetadata(ActiveDocumentSnapshot* snapshot,
         return SnapshotQueryResult::Cleared;
     }
 
+    if (!snapshot->hasPath) {
+        snapshot->clearedReason = SnapshotClearedReason::NoPath;
+        return SnapshotQueryResult::Cleared;
+    }
+
+    return SnapshotQueryResult::Ready;
+}
+
+void CacheActiveDocumentMetadata(const ActiveDocumentSnapshot* snapshot) {
+    if (!snapshot || !snapshot->document || !snapshot->identity ||
+        !IsCachedActiveDocument(snapshot->document.Get())) {
+        return;
+    }
+
+    if (snapshot->hasPath &&
+        !ReplaceStoredTextBstr(&g_runtime.automation.activeDocumentPath,
+                               snapshot->path.Get())) {
+        g_runtime.automation.activeDocumentMetadataValid = false;
+        return;
+    }
+
+    if (!snapshot->hasPath) {
+        g_runtime.automation.activeDocumentPath.Reset();
+    }
+
+    g_runtime.automation.activeDocumentReadOnly = snapshot->readOnly;
+    g_runtime.automation.activeDocumentHasPath = snapshot->hasPath;
+    g_runtime.automation.activeDocumentMetadataValid = true;
+}
+
+SnapshotQueryResult PopulateSnapshotMetadata(ActiveDocumentSnapshot* snapshot,
+                                             SnapshotLogContext context) {
+    if (!snapshot || !snapshot->document) {
+        return SnapshotQueryResult::Cleared;
+    }
+
+    const SnapshotQueryResult cachedResult =
+        CopyCachedActiveDocumentMetadata(snapshot);
+    if (cachedResult != SnapshotQueryResult::RetryLater) {
+        return cachedResult;
+    }
+
+    snapshot->failureClass = AutomationFailureClass::None;
+    snapshot->failureHr = S_OK;
+    snapshot->metadataState = SnapshotMetadataState::Unavailable;
+
+    HRESULT hr = S_OK;
+    if (snapshot->document.Get() ==
+            g_runtime.automation.activeDocument.Get() &&
+        g_runtime.automation.activeDocumentIdentity) {
+        ReplaceStoredComPtr(
+            &snapshot->identity,
+            g_runtime.automation.activeDocumentIdentity.Get());
+    } else {
+        hr = GetComIdentity(snapshot->document.Get(), snapshot->identity.Put());
+    }
+    if (FAILED(hr) || !snapshot->identity) {
+        const HRESULT failureHr = FAILED(hr) ? hr : E_FAIL;
+        RecordSnapshotFailure(snapshot, failureHr);
+        if (IsTerminalAutomationObjectFailure(hr)) {
+            InvalidateCachedActiveDocumentIfMatches(snapshot->document.Get());
+        }
+        LogSnapshotFailure(context, L"failed to resolve document COM identity", hr);
+        return SnapshotQueryResult::RetryLater;
+    }
+
+    hr = GetBoolProperty(snapshot->document.Get(),
+                         WordMember::DocumentReadOnly,
+                         &snapshot->readOnly);
+    if (FAILED(hr)) {
+        RecordSnapshotFailure(snapshot, hr);
+        if (IsTerminalAutomationObjectFailure(hr)) {
+            InvalidateCachedActiveDocumentIfMatches(snapshot->document.Get());
+        }
+        LogSnapshotFailure(context, L"failed to query ReadOnly", hr);
+        return SnapshotQueryResult::RetryLater;
+    }
+
+    if (snapshot->readOnly) {
+        snapshot->metadataState = SnapshotMetadataState::Refreshed;
+        CacheActiveDocumentMetadata(snapshot);
+        snapshot->clearedReason = SnapshotClearedReason::ReadOnly;
+        return SnapshotQueryResult::Cleared;
+    }
+
     hr = GetDocumentIdentityAndPathState(snapshot->document.Get(),
                                          snapshot->path.Put(),
                                          &snapshot->hasPath);
     if (FAILED(hr)) {
+        RecordSnapshotFailure(snapshot, hr);
+        if (IsTerminalAutomationObjectFailure(hr)) {
+            InvalidateCachedActiveDocumentIfMatches(snapshot->document.Get());
+        }
         LogSnapshotFailure(context, L"failed to query Path/Name identity", hr);
         return SnapshotQueryResult::RetryLater;
     }
+
+    snapshot->metadataState = SnapshotMetadataState::Refreshed;
+    CacheActiveDocumentMetadata(snapshot);
 
     if (!snapshot->hasPath || hr == S_FALSE) {
         snapshot->clearedReason = SnapshotClearedReason::NoPath;
@@ -4703,9 +7284,18 @@ bool ShouldPopulateSnapshotMetadataForMode(bool saved, SnapshotMetadataMode meta
     return true;
 }
 
-bool ShouldRetryInvalidCachedSnapshotDocument(bool usingCachedSpecificDocument,
-                                              bool retriedAfterInvalidCachedDocument) {
-    return usingCachedSpecificDocument && !retriedAfterInvalidCachedDocument;
+bool ShouldInvalidateTransitionFlushTargetForFailure(
+    AutomationFailureClass failureClass) {
+    return failureClass == AutomationFailureClass::Disconnected;
+}
+
+bool ShouldRetryInvalidCachedSnapshotDocument(
+    bool usingCachedSpecificDocument,
+    bool retriedAfterInvalidCachedDocument,
+    AutomationFailureClass failureClass) {
+    return usingCachedSpecificDocument &&
+           !retriedAfterInvalidCachedDocument &&
+           ShouldInvalidateTransitionFlushTargetForFailure(failureClass);
 }
 
 void PrepareInvalidCachedSnapshotDocumentRetry(
@@ -4729,7 +7319,9 @@ SnapshotQueryResult ResolveSpecificSnapshotDocument(const SnapshotRequest& reque
 
     const HRESULT hr = GetWordDocumentByPath(request.path, snapshot->document.Put());
     if (FAILED(hr) || !snapshot->document) {
-        if (IsRetryableAutomationFailure(hr)) {
+        if (FAILED(hr) &&
+            hr != HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+            RecordSnapshotFailure(snapshot, FAILED(hr) ? hr : E_FAIL);
             return SnapshotQueryResult::RetryLater;
         }
 
@@ -4757,6 +7349,7 @@ SnapshotQueryResult ResolveSpecificSnapshotDocumentObject(const SnapshotRequest&
 }
 
 SnapshotQueryResult EnsureSnapshotApplication(ScopedComPtr<IDispatch>* application,
+                                              ActiveDocumentSnapshot* snapshot,
                                               SnapshotLogContext context) {
     if (!application) {
         return SnapshotQueryResult::Cleared;
@@ -4764,11 +7357,13 @@ SnapshotQueryResult EnsureSnapshotApplication(ScopedComPtr<IDispatch>* applicati
 
     HRESULT hr = GetWordApplication(application->Put());
     if (FAILED(hr) || !application->Get()) {
+        const HRESULT failureHr = FAILED(hr) ? hr : E_FAIL;
+        RecordSnapshotFailure(snapshot, failureHr);
         if (IsRetryableAutomationFailure(hr)) {
             return SnapshotQueryResult::RetryLater;
         }
 
-        LogSnapshotFailure(context, L"failed to get Word application", hr);
+        LogSnapshotFailure(context, L"failed to get Word application", failureHr);
         return SnapshotQueryResult::RetryLater;
     }
 
@@ -4782,10 +7377,26 @@ SnapshotQueryResult ResolveActiveSnapshotDocumentFromApplication(IDispatch* appl
     }
 
     const HRESULT hr =
-        GetDispatchProperty(application, L"ActiveDocument", snapshot->document.Put());
+        GetDispatchProperty(application,
+                            WordMember::ApplicationActiveDocument,
+                            snapshot->document.Put());
     if (FAILED(hr) || !snapshot->document) {
-        return IsRetryableAutomationFailure(hr) ? SnapshotQueryResult::RetryLater
-                                                : SnapshotQueryResult::Cleared;
+        if (FAILED(hr)) {
+            RecordSnapshotFailure(snapshot, hr);
+            if (IsTerminalAutomationObjectFailure(hr)) {
+                ResetAutomationCacheState();
+                DisconnectWordApplicationEvents();
+            }
+            return SnapshotQueryResult::RetryLater;
+        }
+        return SnapshotQueryResult::Cleared;
+    }
+
+    const HRESULT cacheHr = CacheActiveDocumentBinding(snapshot->document.Get());
+    if (FAILED(cacheHr)) {
+        RecordSnapshotFailure(snapshot, cacheHr);
+        snapshot->document.Reset();
+        return SnapshotQueryResult::RetryLater;
     }
 
     return SnapshotQueryResult::Ready;
@@ -4799,12 +7410,23 @@ SnapshotQueryResult FinalizeMissingActiveSnapshotDocument(IDispatch* application
 
     if (application) {
         ScopedComPtr<IDispatch> protectedViewWindow;
-        if (SUCCEEDED(GetDispatchProperty(application,
-                                          L"ActiveProtectedViewWindow",
-                                          protectedViewWindow.Put())) &&
+        const HRESULT hr = GetDispatchProperty(
+            application,
+            WordMember::ApplicationActiveProtectedViewWindow,
+            protectedViewWindow.Put());
+        if (SUCCEEDED(hr) &&
             protectedViewWindow) {
             snapshot->clearedReason = SnapshotClearedReason::ProtectedView;
             return SnapshotQueryResult::Cleared;
+        }
+
+        if (FAILED(hr)) {
+            RecordSnapshotFailure(snapshot, hr);
+            if (IsTerminalAutomationObjectFailure(hr)) {
+                ResetAutomationCacheState();
+                DisconnectWordApplicationEvents();
+            }
+            return SnapshotQueryResult::RetryLater;
         }
     }
 
@@ -4831,18 +7453,15 @@ SnapshotQueryResult ResolveSnapshotDocument(const SnapshotRequest& request,
             break;
     }
 
-    ScopedComPtr<IDispatch> application;
-    HRESULT hr = GetWordDocumentFromActiveWindow(snapshot->document.Put());
-    if (SUCCEEDED(hr) && snapshot->document) {
+    if (AreWordEventsConnected() &&
+        SUCCEEDED(CopyCachedActiveDocument(snapshot->document.Put())) &&
+        snapshot->document) {
         return SnapshotQueryResult::Ready;
     }
 
-    if (IsRetryableAutomationFailure(hr)) {
-        return SnapshotQueryResult::RetryLater;
-    }
-
+    ScopedComPtr<IDispatch> application;
     const SnapshotQueryResult applicationResult =
-        EnsureSnapshotApplication(&application, request.context);
+        EnsureSnapshotApplication(&application, snapshot, request.context);
     if (applicationResult != SnapshotQueryResult::Ready) {
         return applicationResult;
     }
@@ -4853,7 +7472,36 @@ SnapshotQueryResult ResolveSnapshotDocument(const SnapshotRequest& request,
         return activeDocumentResult;
     }
 
-    return FinalizeMissingActiveSnapshotDocument(application.Get(), snapshot);
+    const HRESULT nativeDocumentHr =
+        GetWordDocumentFromActiveWindow(snapshot->document.Put());
+    switch (ClassifyNativeDocumentLookupResult(
+        nativeDocumentHr,
+        static_cast<bool>(snapshot->document))) {
+        case NativeDocumentLookupOutcome::Ready: {
+            const HRESULT cacheHr =
+                CacheActiveDocumentBinding(snapshot->document.Get());
+            if (FAILED(cacheHr)) {
+                RecordSnapshotFailure(snapshot, cacheHr);
+            }
+            return SUCCEEDED(cacheHr) ? SnapshotQueryResult::Ready
+                                      : SnapshotQueryResult::RetryLater;
+        }
+
+        case NativeDocumentLookupOutcome::Missing:
+            CacheActiveDocumentBinding(nullptr);
+            return FinalizeMissingActiveSnapshotDocument(application.Get(),
+                                                          snapshot);
+
+        case NativeDocumentLookupOutcome::RetryLater:
+            RecordSnapshotFailure(snapshot, nativeDocumentHr);
+            if (IsTerminalAutomationObjectFailure(nativeDocumentHr)) {
+                ResetAutomationCacheState();
+                DisconnectWordApplicationEvents();
+            }
+            return SnapshotQueryResult::RetryLater;
+    }
+
+    return SnapshotQueryResult::RetryLater;
 }
 
 SnapshotQueryResult ResolveSnapshotDocumentFromRequest(const SnapshotRequest& request,
@@ -4864,24 +7512,27 @@ SnapshotQueryResult ResolveSnapshotDocumentFromRequest(const SnapshotRequest& re
 
     if (request.source == SnapshotSource::SpecificPath &&
         request.path &&
-        *request.path &&
-        IsTransitionFlushDocumentCacheValid(request.path)) {
-        snapshot->Reset();
-        g_runtime.document.transitionFlushDocument.Get()->AddRef();
-        snapshot->document.Reset(g_runtime.document.transitionFlushDocument.Get());
-        return SnapshotQueryResult::Ready;
+        *request.path) {
+        ScopedComPtr<IDispatch> cachedDocument;
+        if (CopyValidTransitionFlushDocument(request.path,
+                                             &cachedDocument)) {
+            snapshot->Reset();
+            snapshot->document.Reset(cachedDocument.Detach());
+            return SnapshotQueryResult::Ready;
+        }
     }
 
     if (request.source == SnapshotSource::SpecificDocument &&
-        request.document &&
-        g_runtime.document.transitionFlushDocument &&
-        AreSameDispatchComIdentity(request.document,
-                                   g_runtime.document.transitionFlushDocument.Get()) &&
-        IsTransitionFlushDocumentCacheValid()) {
-        snapshot->Reset();
-        g_runtime.document.transitionFlushDocument.Get()->AddRef();
-        snapshot->document.Reset(g_runtime.document.transitionFlushDocument.Get());
-        return SnapshotQueryResult::Ready;
+        request.document) {
+        ScopedComPtr<IDispatch> cachedDocument;
+        if (CopyValidTransitionFlushDocument(nullptr,
+                                             &cachedDocument) &&
+            AreSameDispatchComIdentity(request.document,
+                                       cachedDocument.Get())) {
+            snapshot->Reset();
+            snapshot->document.Reset(cachedDocument.Detach());
+            return SnapshotQueryResult::Ready;
+        }
     }
 
     return ResolveSnapshotDocument(request, snapshot);
@@ -4901,26 +7552,31 @@ SnapshotQueryResult ExecuteSnapshotLoadPlan(const SnapshotLoadPlan& plan,
             return documentResult;
         }
 
+        ScopedComPtr<IDispatch> cachedSpecificDocument;
         const bool usingCachedSpecificDocument =
             (plan.request.source == SnapshotSource::SpecificPath ||
              plan.request.source == SnapshotSource::SpecificDocument) &&
             snapshot->document &&
-            g_runtime.document.transitionFlushDocument &&
+            CopyValidTransitionFlushDocument(nullptr,
+                                             &cachedSpecificDocument) &&
             AreSameDispatchComIdentity(snapshot->document.Get(),
-                                       g_runtime.document.transitionFlushDocument.Get());
+                                       cachedSpecificDocument.Get());
         const SnapshotQueryResult savedStateResult =
             PopulateSnapshotSavedState(snapshot, plan.request.context);
         if (savedStateResult != SnapshotQueryResult::Ready) {
             if (ShouldRetryInvalidCachedSnapshotDocument(
                     usingCachedSpecificDocument,
-                    retriedAfterInvalidCachedDocument)) {
+                    retriedAfterInvalidCachedDocument,
+                    snapshot->failureClass)) {
                 PrepareInvalidCachedSnapshotDocumentRetry(
                     snapshot,
                     &retriedAfterInvalidCachedDocument);
                 continue;
             }
 
-            if (usingCachedSpecificDocument) {
+            if (usingCachedSpecificDocument &&
+                ShouldInvalidateTransitionFlushTargetForFailure(
+                    snapshot->failureClass)) {
                 InvalidateTransitionFlushDocumentCache();
             }
             return savedStateResult;
@@ -4935,14 +7591,17 @@ SnapshotQueryResult ExecuteSnapshotLoadPlan(const SnapshotLoadPlan& plan,
         if (metadataResult != SnapshotQueryResult::Ready) {
             if (ShouldRetryInvalidCachedSnapshotDocument(
                     usingCachedSpecificDocument,
-                    retriedAfterInvalidCachedDocument)) {
+                    retriedAfterInvalidCachedDocument,
+                    snapshot->failureClass)) {
                 PrepareInvalidCachedSnapshotDocumentRetry(
                     snapshot,
                     &retriedAfterInvalidCachedDocument);
                 continue;
             }
 
-            if (usingCachedSpecificDocument) {
+            if (usingCachedSpecificDocument &&
+                ShouldInvalidateTransitionFlushTargetForFailure(
+                    snapshot->failureClass)) {
                 InvalidateTransitionFlushDocumentCache();
             }
             return metadataResult;
@@ -4951,14 +7610,16 @@ SnapshotQueryResult ExecuteSnapshotLoadPlan(const SnapshotLoadPlan& plan,
         if (!usingCachedSpecificDocument ||
             plan.request.source == SnapshotSource::SpecificDocument ||
             (snapshot->hasPath &&
-             AreSameDocumentPath(snapshot->path.CStr(), plan.request.path))) {
+             AreSameResolvedDocumentPath(snapshot->path.CStr(),
+                                         plan.request.path))) {
             return SnapshotQueryResult::Ready;
         }
 
         snapshot->Reset();
         if (!ShouldRetryInvalidCachedSnapshotDocument(
                 usingCachedSpecificDocument,
-                retriedAfterInvalidCachedDocument)) {
+                retriedAfterInvalidCachedDocument,
+                AutomationFailureClass::Disconnected)) {
             return SnapshotQueryResult::Cleared;
         }
 
@@ -5004,30 +7665,50 @@ void ExpirePendingSaveAsMigrationIfNeeded() {
     }
 }
 
-bool SetObservedDocumentIdentity(IUnknown* identity) {
-    return ReplaceStoredComPtr(&g_runtime.document.observedDocumentIdentity, identity);
-}
-
 bool SetObservedDocumentFromSnapshot(const ActiveDocumentSnapshot* snapshot, bool dirty) {
     if (!snapshot || !snapshot->hasPath || !snapshot->path.Length() || !snapshot->identity) {
         ResetObservedDocumentState();
         return false;
     }
 
-    if (!SetObservedDocumentPath(snapshot->path.CStr()) ||
-        !SetObservedDocumentIdentity(snapshot->identity.Get()) ||
-        (dirty && !ReplaceStoredComPtr(&g_runtime.document.observedDocument,
-                                       snapshot->document.Get()))) {
+    const unsigned int expectedGeneration =
+        g_runtime.document.observedDocumentGeneration;
+    ScopedBstr nextPath;
+    ScopedComPtr<IUnknown> nextIdentity;
+    ScopedComPtr<IDispatch> nextDocument;
+    if (!ReplaceStoredBstr(&nextPath, snapshot->path.CStr()) ||
+        !ReplaceStoredComPtr(&nextIdentity, snapshot->identity.Get()) ||
+        (dirty &&
+         !ReplaceStoredComPtr(&nextDocument, snapshot->document.Get()))) {
+        if (g_runtime.document.observedDocumentGeneration !=
+            expectedGeneration) {
+            return true;
+        }
         ResetObservedDocumentState();
         return false;
     }
 
-    if (!dirty) {
-        g_runtime.document.observedDocument.Reset();
+    // AddRef on an automation proxy is normally local, but a custom object can
+    // still re-enter. Preserve any newer nested observation.
+    if (g_runtime.document.observedDocumentGeneration !=
+        expectedGeneration) {
+        return true;
     }
 
-    SetFlag(g_runtime.flags.documentDirtyKnown);
+    ClearFlag(g_runtime.flags.documentDirtyKnown);
+    ScopedBstr previousPath;
+    DetachedDocumentBinding previousBinding;
+    previousPath.Reset(g_runtime.document.observedDocumentPath.Detach());
+    DetachDocumentBinding(&g_runtime.document.observedDocument,
+                          &g_runtime.document.observedDocumentIdentity,
+                          &previousBinding);
+
+    g_runtime.document.observedDocumentPath.Reset(nextPath.Detach());
+    g_runtime.document.observedDocumentIdentity.Reset(nextIdentity.Detach());
+    g_runtime.document.observedDocument.Reset(nextDocument.Detach());
+    ++g_runtime.document.observedDocumentGeneration;
     StoreFlag(g_runtime.flags.documentDirty, dirty);
+    SetFlag(g_runtime.flags.documentDirtyKnown);
     return true;
 }
 
@@ -5042,7 +7723,8 @@ bool NoteObservedDocumentDirty(const ActiveDocumentSnapshot* snapshot) {
     }
 
     const bool pathChanged =
-        !AreSameDocumentPath(g_runtime.document.observedDocumentPath.Get(), snapshot->path.CStr());
+        !AreSameDocumentPathText(g_runtime.document.observedDocumentPath.Get(),
+                                 snapshot->path.CStr());
     const bool identityChanged =
         !AreSameComIdentity(g_runtime.document.observedDocumentIdentity.Get(),
                             snapshot->identity.Get());
@@ -5066,6 +7748,12 @@ bool IsPendingSaveAsSnapshot(const ActiveDocumentSnapshot* snapshot) {
                               g_runtime.document.pendingSaveAsDocumentIdentity.Get());
 }
 
+void FinalizeSaveAttemptState(
+    const ActiveDocumentSnapshot* snapshot,
+    bool clearPendingSave,
+    bool clearTransitionRequest,
+    TransitionFlushClearMode transitionClearMode);
+
 bool TryMigrateObservedDocumentIdentity(
     const ActiveDocumentSnapshot* snapshot,
     bool clearPendingAutosaveOnClean,
@@ -5084,7 +7772,8 @@ bool TryMigrateObservedDocumentIdentity(
     }
 
     const bool pathChanged =
-        !AreSameDocumentPath(g_runtime.document.observedDocumentPath.Get(), snapshot->path.CStr());
+        !AreSameDocumentPathText(g_runtime.document.observedDocumentPath.Get(),
+                                 snapshot->path.CStr());
     if (!pathChanged) {
         if (saveAsIdentityMatch) {
             ClearPendingSaveAsMigration();
@@ -5092,21 +7781,26 @@ bool TryMigrateObservedDocumentIdentity(
         return false;
     }
 
-    const bool wasDirty = LoadFlag(g_runtime.flags.documentDirty);
-    if (!SetObservedDocumentFromSnapshot(snapshot, !snapshot->saved && wasDirty)) {
-        return false;
-    }
-
     if (snapshot->saved) {
         g_runtime.timing.lastSaveTime = GetTickCount64();
-        ClearManualSavePending();
-        ClearTransitionFlushRequest(transitionClearMode);
-        if (clearPendingAutosaveOnClean) {
-            ClearPendingSave();
+        FinalizeSaveAttemptState(snapshot,
+                                 clearPendingAutosaveOnClean,
+                                 true,
+                                 transitionClearMode);
+    } else {
+        const unsigned int expectedSaveAsGeneration =
+            g_runtime.document.pendingSaveAsGeneration;
+        const bool wasDirty = LoadFlag(g_runtime.flags.documentDirty);
+        if (!SetObservedDocumentFromSnapshot(snapshot, wasDirty)) {
+            return false;
+        }
+
+        if (g_runtime.document.pendingSaveAsGeneration ==
+            expectedSaveAsGeneration) {
+            ClearPendingSaveAsMigration();
         }
     }
 
-    ClearPendingSaveAsMigration();
     LogDocumentStateStatus(L"migrated the tracked document after Save As or rename");
     return true;
 }
@@ -5115,7 +7809,9 @@ bool ShouldTransitionFlushObservedDocument(const ActiveDocumentSnapshot* snapsho
     return snapshot &&
            snapshot->hasPath &&
            g_runtime.document.observedDocumentPath.Length() != 0 &&
-           !AreSameDocumentPath(snapshot->path.CStr(), g_runtime.document.observedDocumentPath.Get()) &&
+           !AreSameDocumentPathText(
+               snapshot->path.CStr(),
+               g_runtime.document.observedDocumentPath.Get()) &&
            HasPendingAutosave();
 }
 
@@ -5124,7 +7820,6 @@ void BeginTransitionFlushForObservedDocument() {
                            L"finishing the previous document before switching to another one",
                            g_runtime.document.observedDocument.Get());
     ArmSaveTimer(INPUT_SETTLE_DELAY_MS);
-    ArmDocumentStateTimer(DOCUMENT_STATE_ACTIVE_POLL_INTERVAL_MS);
 }
 
 void SyncObservedDocumentCleanState(const ActiveDocumentSnapshot* snapshot) {
@@ -5140,15 +7835,84 @@ void FinalizeSaveAttemptState(const ActiveDocumentSnapshot* snapshot,
                               bool clearTransitionRequest,
                               TransitionFlushClearMode transitionClearMode =
                                   TransitionFlushClearMode::ClearPostTransitionRefresh) {
-    if (clearTransitionRequest) {
-        ClearTransitionFlushRequest(transitionClearMode);
+    const unsigned int expectedObservedGeneration =
+        g_runtime.document.observedDocumentGeneration;
+    const unsigned int expectedTransitionGeneration =
+        g_runtime.document.transitionFlushGeneration;
+    const unsigned int expectedSaveAsGeneration =
+        g_runtime.document.pendingSaveAsGeneration;
+
+    ScopedBstr nextObservedPath;
+    ScopedComPtr<IUnknown> nextObservedIdentity;
+    bool publishObserved = snapshot && snapshot->hasPath &&
+                           snapshot->path.Length() != 0 && snapshot->identity;
+    if (publishObserved &&
+        (!ReplaceStoredBstr(&nextObservedPath, snapshot->path.CStr()) ||
+         !ReplaceStoredComPtr(&nextObservedIdentity,
+                              snapshot->identity.Get()))) {
+        publishObserved = false;
     }
 
-    ClearManualSavePending();
-    ClearPendingSaveAsMigration();
-    SyncObservedDocumentCleanState(snapshot);
+    // If staging re-entered a newer state transition, preserve the nested
+    // work rather than finalizing the older save attempt over it.
+    if (g_runtime.document.observedDocumentGeneration !=
+            expectedObservedGeneration ||
+        g_runtime.document.pendingSaveAsGeneration !=
+            expectedSaveAsGeneration ||
+        (clearTransitionRequest &&
+         g_runtime.document.transitionFlushGeneration !=
+             expectedTransitionGeneration)) {
+        return;
+    }
+
     if (clearPendingSave) {
         ClearPendingSave();
+    }
+    ClearManualSavePending();
+
+    ScopedComPtr<IUnknown> previousSaveAsIdentity;
+    ClearFlag(g_runtime.flags.pendingSaveAsMigration);
+    ++g_runtime.document.pendingSaveAsGeneration;
+    g_runtime.timing.pendingSaveAsTime = 0;
+    previousSaveAsIdentity.Reset(
+        g_runtime.document.pendingSaveAsDocumentIdentity.Detach());
+
+    ScopedBstr previousTransitionPath;
+    DetachedDocumentBinding previousTransitionBinding;
+    if (clearTransitionRequest) {
+        ClearFlag(g_runtime.flags.transitionFlushPending);
+        ++g_runtime.document.transitionFlushGeneration;
+        g_runtime.timing.transitionFlushRequestTime = 0;
+        if (transitionClearMode ==
+            TransitionFlushClearMode::ClearPostTransitionRefresh) {
+            ClearPostTransitionRefreshPending();
+        }
+        previousTransitionPath.Reset(
+            g_runtime.document.transitionFlushDocumentPath.Detach());
+        DetachDocumentBinding(
+            &g_runtime.document.transitionFlushDocument,
+            &g_runtime.document.transitionFlushDocumentIdentity,
+            &previousTransitionBinding);
+    }
+
+    ScopedBstr previousObservedPath;
+    DetachedDocumentBinding previousObservedBinding;
+    ClearFlag(g_runtime.flags.documentDirtyKnown);
+    ClearFlag(g_runtime.flags.documentDirty);
+    ++g_runtime.document.observedDocumentGeneration;
+    previousObservedPath.Reset(
+        g_runtime.document.observedDocumentPath.Detach());
+    DetachDocumentBinding(&g_runtime.document.observedDocument,
+                          &g_runtime.document.observedDocumentIdentity,
+                          &previousObservedBinding);
+
+    if (publishObserved) {
+        g_runtime.document.observedDocumentPath.Reset(
+            nextObservedPath.Detach());
+        g_runtime.document.observedDocumentIdentity.Reset(
+            nextObservedIdentity.Detach());
+        StoreFlag(g_runtime.flags.documentDirty, false);
+        SetFlag(g_runtime.flags.documentDirtyKnown);
     }
 }
 
@@ -5160,14 +7924,20 @@ TransitionFlushClearMode GetTransitionFlushClearModeForTick(
 }
 
 void NoteDocumentStateRefreshReady() {
-    g_runtime.timing.documentStateRetryDelayMs = MIN_RETRY_INTERVAL_MS;
-    ClearAutomationBusyPending();
+    ResetDocumentRetryState();
 }
 
-void NoteSaveOperationReady(ULONGLONG now) {
-    g_runtime.timing.saveRetryDelayMs = MIN_RETRY_INTERVAL_MS;
-    ClearAutomationBusyPending();
+void NoteSaveOperationTime(ULONGLONG now) {
     g_runtime.timing.lastSaveTime = now;
+}
+
+void NoteSaveOperationReady() {
+    ResetSaveRetryState();
+}
+
+bool ShouldResetSaveRetryAfterSuccessfulSnapshot(
+    bool keepPendingForUnexpectedSnapshot) {
+    return !keepPendingForUnexpectedSnapshot;
 }
 
 bool IsSnapshotExpectedForPendingAutosave(const ActiveDocumentSnapshot* snapshot,
@@ -5182,8 +7952,8 @@ bool IsSnapshotExpectedForPendingAutosave(const ActiveDocumentSnapshot* snapshot
     }
 
     return IsObservedDocumentSnapshot(snapshot) ||
-           AreSameDocumentPath(g_runtime.document.observedDocumentPath.Get(),
-                               snapshot->path.CStr());
+           AreSameDocumentPathText(g_runtime.document.observedDocumentPath.Get(),
+                                   snapshot->path.CStr());
 }
 
 bool KeepPendingAutosaveForUnexpectedSnapshot(const ActiveDocumentSnapshot* snapshot,
@@ -5237,10 +8007,11 @@ DocumentObservationApplyResult ApplyDirtyDocumentObservation(
         if (tick.runtime.manualSavePending &&
             tick.runtime.pendingSave &&
             (IsObservedDocumentSnapshot(snapshot) ||
-             AreSameDocumentPath(g_runtime.document.observedDocumentPath.Get(),
-                                 snapshot->path.CStr()))) {
+             AreSameDocumentPathText(
+                 g_runtime.document.observedDocumentPath.Get(),
+                 snapshot->path.CStr()))) {
             ClearManualSavePending();
-            ClearAutomationBusyPending();
+            ClearCurrentSaveRetryReason();
             SetFlag(g_runtime.flags.expeditedSavePending);
             g_runtime.timing.lastEditTime = tick.now;
             LogSaveStatus(L"manual save did not finish, retrying pending auto-save");
@@ -5261,6 +8032,11 @@ DocumentObservationApplyResult ApplyDirtyDocumentObservation(
 DocumentObservationApplyResult ApplyCleanDocumentObservation(
     const ActiveDocumentSnapshot* snapshot,
     const RuntimeTickSnapshot& tick) {
+    if (snapshot &&
+        snapshot->metadataState == SnapshotMetadataState::NotRequested) {
+        return DocumentObservationApplyResult::None;
+    }
+
     if (TryMigrateObservedDocumentIdentity(snapshot, true)) {
         return DocumentObservationApplyResult::RearmSteadyPoll;
     }
@@ -5273,8 +8049,9 @@ DocumentObservationApplyResult ApplyCleanDocumentObservation(
     if (snapshot && snapshot->hasPath) {
         const bool sameObservedDocument =
             IsObservedDocumentSnapshot(snapshot) ||
-            AreSameDocumentPath(g_runtime.document.observedDocumentPath.Get(),
-                                snapshot->path.CStr());
+            AreSameDocumentPathText(
+                g_runtime.document.observedDocumentPath.Get(),
+                snapshot->path.CStr());
         if (tick.runtime.pendingSave &&
             !sameObservedDocument &&
             g_runtime.document.observedDocumentPath.Length() == 0) {
@@ -5286,9 +8063,12 @@ DocumentObservationApplyResult ApplyCleanDocumentObservation(
             g_runtime.timing.lastSaveTime = tick.now;
         }
 
-        SyncObservedDocumentCleanState(snapshot);
         if (sameObservedDocument && tick.runtime.pendingSave) {
             ClearPendingSave();
+        }
+
+        SyncObservedDocumentCleanState(snapshot);
+        if (sameObservedDocument && tick.runtime.pendingSave) {
             LogSaveStatus(L"pending changes were already saved by Word");
         }
     } else {
@@ -5319,20 +8099,22 @@ DocumentDirtyState InterpretDocumentStateSnapshotQueryResult(
 
 DocumentDirtyState QueryActiveDocumentDirtyState(ActiveDocumentSnapshot* snapshot,
                                                  bool requireCleanSnapshotDetails = false) {
+    ActiveDocumentSnapshot localSnapshot;
+    if (!snapshot) {
+        snapshot = &localSnapshot;
+    }
+    snapshot->Reset();
+
     ScopedComInit comInit;
     if (FAILED(comInit.GetResult())) {
+        RecordSnapshotFailure(snapshot, comInit.GetResult());
         LogSnapshotFailure(SnapshotLogContext::DocumentState,
                            L"CoInitializeEx failed",
                            comInit.GetResult());
         return DocumentDirtyState::RetryLater;
     }
 
-    ScopedComMessageFilter messageFilter;
-
-    ActiveDocumentSnapshot localSnapshot;
-    if (!snapshot) {
-        snapshot = &localSnapshot;
-    }
+    ScopedComMessageFilter messageFilter(ComRetryProfile::Background);
 
     const SnapshotLoadPlan plan =
         MakeDocumentStateSnapshotLoadPlan(requireCleanSnapshotDetails);
@@ -5365,19 +8147,22 @@ SaveAttemptResult InterpretSaveSnapshotQueryResult(const wchar_t* specificPath,
 
 SaveAttemptResult TrySaveActiveDocument(ActiveDocumentSnapshot* snapshot,
                                         const wchar_t* specificPath,
-                                        IDispatch* specificDocument) {
-    ScopedComInit comInit;
-    if (FAILED(comInit.GetResult())) {
-        LogSnapshotFailure(SnapshotLogContext::Save, L"CoInitializeEx failed", comInit.GetResult());
-        return SaveAttemptResult::RetryLater;
-    }
-
-    ScopedComMessageFilter messageFilter;
-
+                                        IDispatch* specificDocument,
+                                        ComRetryProfile retryProfile) {
     ActiveDocumentSnapshot localSnapshot;
     if (!snapshot) {
         snapshot = &localSnapshot;
     }
+    snapshot->Reset();
+
+    ScopedComInit comInit;
+    if (FAILED(comInit.GetResult())) {
+        RecordSnapshotFailure(snapshot, comInit.GetResult());
+        LogSnapshotFailure(SnapshotLogContext::Save, L"CoInitializeEx failed", comInit.GetResult());
+        return SaveAttemptResult::RetryLater;
+    }
+
+    ScopedComMessageFilter messageFilter(retryProfile);
 
     const SnapshotLoadPlan plan = MakeSaveSnapshotLoadPlan(specificPath, specificDocument);
     const SnapshotQueryResult snapshotResult = ExecuteSnapshotLoadPlan(plan, snapshot);
@@ -5394,34 +8179,62 @@ SaveAttemptResult TrySaveActiveDocument(ActiveDocumentSnapshot* snapshot,
     HRESULT hr = E_FAIL;
     {
         ScopedFlagSet autoSaveFlag(g_runtime.flags.autoSaveInProgress);
-        hr = InvokeDispatch(snapshot->document.Get(),
-                            DISPATCH_METHOD,
-                            const_cast<LPOLESTR>(L"Save"));
+        hr = InvokeWordMember(snapshot->document.Get(),
+                              DISPATCH_METHOD,
+                              WordMember::DocumentSave);
     }
     if (SUCCEEDED(hr)) {
         return SaveAttemptResult::Saved;
     }
 
     if (IsRetryableAutomationFailure(hr)) {
+        RecordSnapshotFailure(snapshot, hr);
         return SaveAttemptResult::RetryLater;
     }
 
+    if (IsTerminalAutomationObjectFailure(hr)) {
+        RecordSnapshotFailure(snapshot, hr);
+        InvalidateCachedActiveDocumentIfMatches(snapshot->document.Get());
+        if (ShouldInvalidateTransitionFlushTargetForFailure(
+                snapshot->failureClass) &&
+            snapshot->document.Get() ==
+                g_runtime.document.transitionFlushDocument.Get()) {
+            InvalidateTransitionFlushDocumentCache();
+        }
+        return SaveAttemptResult::RetryLater;
+    }
+
+    RecordSnapshotFailure(snapshot, hr);
     LogSnapshotFailure(SnapshotLogContext::Save, L"document save failed", hr);
     return SaveAttemptResult::Failed;
 }
 
-void CALLBACK SchedulerTimerProc(HWND, UINT, UINT_PTR idEvent, DWORD) {
-    KillTimer(nullptr, idEvent);
+void HandleSchedulerTimerMessage(UINT_PTR timerId) {
+    ScopedOwnerRuntimeWork ownerWork;
 
     if (!CanRunOwnerThreadRuntimeWork() ||
-        g_runtime.timing.schedulerTimerId != idEvent) {
+        timerId != SCHEDULER_WINDOW_TIMER_ID ||
+        g_runtime.timing.schedulerTimerId != SCHEDULER_WINDOW_TIMER_ID) {
         return;
     }
 
+    const ULONGLONG now = GetTickCount64();
+    if (g_runtime.timing.schedulerTimerDueTime == 0 ||
+        now < g_runtime.timing.schedulerTimerDueTime) {
+        // KillTimer doesn't remove an already queued WM_TIMER. If an older
+        // message arrives after the physical timer was moved, leave the new
+        // timer intact and let its current deadline fire normally.
+        return;
+    }
+
+    HWND messageWindow =
+        g_control.messageWindow.load(std::memory_order_acquire);
+    if (messageWindow) {
+        KillTimer(messageWindow, SCHEDULER_WINDOW_TIMER_ID);
+    }
     g_runtime.timing.schedulerTimerId = 0;
     g_runtime.timing.schedulerTimerDueTime = 0;
 
-    const ULONGLONG now = GetTickCount64();
     const bool saveDue = IsScheduledTaskDue(ScheduledTaskKind::Save, now);
     if (saveDue &&
         CanRunOwnerThreadRuntimeWork()) {
@@ -5444,7 +8257,7 @@ void CALLBACK SchedulerTimerProc(HWND, UINT, UINT_PTR idEvent, DWORD) {
     }
 
     if (CanRunOwnerThreadRuntimeWork()) {
-        RefreshSchedulerTimer();
+        RefreshSchedulerTimerWithRecovery();
     }
 }
 
@@ -5472,11 +8285,10 @@ void RefreshTickWordEventState(RuntimeTickSnapshot* tick) {
     }
 }
 
-bool HandleDocumentObservationApplyOutcome(DocumentObservationApplyResult result,
-                                           DWORD steadyPollDelay) {
+bool HandleDocumentObservationApplyOutcome(DocumentObservationApplyResult result) {
     switch (result) {
         case DocumentObservationApplyResult::RearmSteadyPoll:
-            ArmDocumentStateTimer(steadyPollDelay);
+            ReconcileDocumentStateSchedule();
             return true;
 
         case DocumentObservationApplyResult::StartedTransitionFlush:
@@ -5490,7 +8302,7 @@ bool HandleDocumentObservationApplyOutcome(DocumentObservationApplyResult result
     return false;
 }
 
-bool HandleDocumentStateTickDecisionOutcome(const RuntimeTickSnapshot& tick,
+bool HandleDocumentStateTickDecisionOutcome(const RuntimeTickSnapshot&,
                                             const TickDecision& decision) {
     if (decision.action == TickDecisionAction::None) {
         return true;
@@ -5500,8 +8312,21 @@ bool HandleDocumentStateTickDecisionOutcome(const RuntimeTickSnapshot& tick,
         return false;
     }
 
-    if (tick.runtime.pauseReason != WordUiPauseReason::None) {
-        LogDocumentStateStatus(DescribeWordUiPauseReason(tick.runtime.pauseReason));
+    switch (decision.state) {
+        case RuntimeStatePhase::WaitingForWordUi:
+            SetCurrentDocumentRetryReason(DocumentRetryReason::UiPaused);
+            break;
+
+        case RuntimeStatePhase::WaitingForWordWindow:
+            SetCurrentDocumentRetryReason(DocumentRetryReason::InactiveWindow);
+            break;
+
+        case RuntimeStatePhase::WaitingForInputToSettle:
+            SetCurrentDocumentRetryReason(DocumentRetryReason::InputBusy);
+            break;
+
+        default:
+            break;
     }
 
     ArmDocumentStateTimer(decision.delayMs);
@@ -5515,27 +8340,23 @@ bool HandleDocumentStateRefreshResult(DocumentDirtyState dirtyState,
         case DocumentDirtyState::Dirty:
             NoteDocumentStateRefreshReady();
             return HandleDocumentObservationApplyOutcome(
-                ApplyDirtyDocumentObservation(snapshot, tick),
-                tick.steadyPollDelay);
+                ApplyDirtyDocumentObservation(snapshot, tick));
 
         case DocumentDirtyState::Clean:
             NoteDocumentStateRefreshReady();
             return HandleDocumentObservationApplyOutcome(
-                ApplyCleanDocumentObservation(snapshot, tick),
-                tick.steadyPollDelay);
+                ApplyCleanDocumentObservation(snapshot, tick));
 
         case DocumentDirtyState::RetryLater:
-            NoteAutomationBusy(L"Word automation is busy, waiting to retry document-state refresh");
-            ArmDocumentStateTimer(
-                AdvanceRetryDelay(&g_runtime.timing.documentStateRetryDelayMs,
-                                  MAX_DOCUMENT_STATE_RETRY_INTERVAL_MS));
+            ArmDocumentStateTimer(AdvanceDocumentRetryDelay(
+                GetDocumentRetryReasonForSnapshot(snapshot)));
             return true;
     }
 
     return false;
 }
 
-bool HandleAutosaveTickDecisionOutcome(const RuntimeTickSnapshot& tick,
+bool HandleAutosaveTickDecisionOutcome(const RuntimeTickSnapshot&,
                                        const TickDecision& decision) {
     if (decision.action == TickDecisionAction::None) {
         return true;
@@ -5545,16 +8366,21 @@ bool HandleAutosaveTickDecisionOutcome(const RuntimeTickSnapshot& tick,
         return false;
     }
 
-    if (tick.runtime.pauseReason != WordUiPauseReason::None) {
-        LogSaveStatus(DescribeWordUiPauseReason(tick.runtime.pauseReason));
-    }
+    switch (decision.state) {
+        case RuntimeStatePhase::WaitingForWordUi:
+            SetCurrentSaveRetryReason(SaveRetryReason::UiPaused);
+            break;
 
-    if (tick.runtime.pendingSave &&
-        !tick.runtime.transitionFlushRequested &&
-        (!tick.flags.documentDirtyKnown ||
-         !tick.flags.documentDirty ||
-         g_runtime.document.observedDocumentPath.Length() == 0)) {
-        ArmDocumentStateTimer(INPUT_SETTLE_DELAY_MS);
+        case RuntimeStatePhase::WaitingForWordWindow:
+            SetCurrentSaveRetryReason(SaveRetryReason::InactiveWindow);
+            break;
+
+        case RuntimeStatePhase::WaitingForInputToSettle:
+            SetCurrentSaveRetryReason(SaveRetryReason::InputBusy);
+            break;
+
+        default:
+            break;
     }
 
     ArmSaveTimer(decision.delayMs);
@@ -5566,21 +8392,25 @@ void HandleAutosaveAttemptResult(SaveAttemptResult result,
                                  const RuntimeTickSnapshot& tick) {
     switch (result) {
         case SaveAttemptResult::Saved:
-            NoteSaveOperationReady(tick.now);
+            NoteSaveOperationTime(tick.now);
             if (snapshot->hasPath) {
                 TryMigrateObservedDocumentIdentity(
                     snapshot,
                     false,
                     GetTransitionFlushClearModeForTick(tick));
             }
-            if (KeepPendingAutosaveForUnexpectedSnapshot(snapshot, tick)) {
+            if (!ShouldResetSaveRetryAfterSuccessfulSnapshot(
+                    KeepPendingAutosaveForUnexpectedSnapshot(snapshot,
+                                                             tick))) {
                 return;
             }
+            NoteSaveOperationReady();
             FinalizeSaveAttemptState(snapshot,
                                      true,
                                      true,
                                      GetTransitionFlushClearModeForTick(tick));
             MaybeSchedulePostTransitionRefresh(tick);
+            ReconcileDocumentStateSchedule();
             if (tick.runtime.transitionFlushRequested) {
                 LogSaveStatus(L"flushed pending changes for the previous document");
             } else {
@@ -5589,37 +8419,43 @@ void HandleAutosaveAttemptResult(SaveAttemptResult result,
             return;
 
         case SaveAttemptResult::AlreadyClean:
-            NoteSaveOperationReady(tick.now);
+            NoteSaveOperationTime(tick.now);
             if (snapshot->hasPath &&
                 TryMigrateObservedDocumentIdentity(
                     snapshot,
                     true,
                     GetTransitionFlushClearModeForTick(tick))) {
+                NoteSaveOperationReady();
                 MaybeSchedulePostTransitionRefresh(tick);
+                ReconcileDocumentStateSchedule();
                 return;
             }
-            if (KeepPendingAutosaveForUnexpectedSnapshot(snapshot, tick)) {
+            if (!ShouldResetSaveRetryAfterSuccessfulSnapshot(
+                    KeepPendingAutosaveForUnexpectedSnapshot(snapshot,
+                                                             tick))) {
                 return;
             }
+            NoteSaveOperationReady();
             FinalizeSaveAttemptState(snapshot,
                                      true,
                                      true,
                                      GetTransitionFlushClearModeForTick(tick));
             MaybeSchedulePostTransitionRefresh(tick);
+            ReconcileDocumentStateSchedule();
             LogSaveStatus(tick.runtime.transitionFlushRequested
                               ? L"the previous document was already clean"
                               : L"pending changes were already saved");
             return;
 
         case SaveAttemptResult::Cleared:
-            g_runtime.timing.saveRetryDelayMs = MIN_RETRY_INTERVAL_MS;
-            ClearAutomationBusyPending();
+            ResetSaveRetryState();
             if (snapshot->hasPath &&
                 TryMigrateObservedDocumentIdentity(
                     snapshot,
                     true,
                     GetTransitionFlushClearModeForTick(tick))) {
                 MaybeSchedulePostTransitionRefresh(tick);
+                ReconcileDocumentStateSchedule();
                 return;
             }
             if (snapshot->clearedReason != SnapshotClearedReason::None) {
@@ -5630,26 +8466,22 @@ void HandleAutosaveAttemptResult(SaveAttemptResult result,
                                      true,
                                      GetTransitionFlushClearModeForTick(tick));
             MaybeSchedulePostTransitionRefresh(tick);
+            ReconcileDocumentStateSchedule();
             return;
 
         case SaveAttemptResult::Deferred:
-            LogSaveStatus(DescribeSnapshotClearedReason(snapshot->clearedReason));
-            ArmSaveTimer(DOCUMENT_STATE_ACTIVE_POLL_INTERVAL_MS);
+            ArmSaveTimer(
+                AdvanceSaveRetryDelay(SaveRetryReason::DeferredProtectedView));
             return;
 
         case SaveAttemptResult::RetryLater:
-            NoteAutomationBusy(L"Word automation is busy, waiting to retry auto-save");
-            ArmSaveTimer(
-                AdvanceRetryDelay(&g_runtime.timing.saveRetryDelayMs,
-                                  MAX_SAVE_RETRY_INTERVAL_MS));
+            ArmSaveTimer(AdvanceSaveRetryDelay(
+                GetSaveRetryReasonForSnapshot(snapshot)));
             return;
 
         case SaveAttemptResult::Failed:
-            ClearAutomationBusyPending();
-            LogSaveStatus(L"document save failed, keeping pending changes for retry");
             ArmSaveTimer(
-                AdvanceRetryDelay(&g_runtime.timing.saveRetryDelayMs,
-                                  MAX_SAVE_RETRY_INTERVAL_MS));
+                AdvanceSaveRetryDelay(SaveRetryReason::HardFailure));
             return;
     }
 }
@@ -5671,7 +8503,8 @@ void TryCriticalTransitionSaveNow(const wchar_t* path, IDispatch* document) {
     }
 
     if (!copiedTarget) {
-        LogSaveStatus(L"critical auto-save target was unavailable, keeping pending changes");
+        ArmSaveTimer(
+            AdvanceSaveRetryDelay(SaveRetryReason::TargetUnavailable));
         return;
     }
 
@@ -5684,7 +8517,8 @@ void TryCriticalTransitionSaveNow(const wchar_t* path, IDispatch* document) {
     HandleAutosaveAttemptResult(
         TrySaveActiveDocument(&snapshot,
                               pathCopy.Length() != 0 ? pathCopy.CStr() : nullptr,
-                              documentRef.Get()),
+                              documentRef.Get(),
+                              ComRetryProfile::CriticalClose),
         &snapshot,
         tick);
 }
@@ -5755,8 +8589,6 @@ void HandleDocumentStateTick() {
         return;
     }
 
-    MaybeKickAutomationRecovery(tick.runtime.inputBusy);
-
     ActiveDocumentSnapshot snapshot;
     const bool requireCleanSnapshotDetails =
         ShouldRequireCleanSnapshotDetails(tick.runtime.manualSavePending,
@@ -5770,7 +8602,7 @@ void HandleDocumentStateTick() {
         return;
     }
 
-    ArmDocumentStateTimer(tick.steadyPollDelay);
+    ReconcileDocumentStateSchedule();
 }
 
 void HandleAutosaveTick() {
@@ -5785,14 +8617,15 @@ void HandleAutosaveTick() {
         return;
     }
 
+    ClearCurrentSaveRetryReason();
+
     ActiveDocumentSnapshot snapshot;
     ScopedBstr targetPath;
     ScopedComPtr<IDispatch> targetDocument;
     if (!CopyAutosaveTargetForTick(tick, &targetPath, &targetDocument)) {
-        LogSaveStatus(L"auto-save target was unavailable, keeping pending changes for retry");
         ArmDocumentStateTimer(INPUT_SETTLE_DELAY_MS);
-        ArmSaveTimer(AdvanceRetryDelay(&g_runtime.timing.saveRetryDelayMs,
-                                       MAX_SAVE_RETRY_INTERVAL_MS));
+        ArmSaveTimer(
+            AdvanceSaveRetryDelay(SaveRetryReason::TargetUnavailable));
         return;
     }
 
@@ -5807,44 +8640,6 @@ void HandleAutosaveTick() {
 // ============================================================================
 // Input Detection
 // ============================================================================
-
-bool IsEditingKey(WPARAM wParam) {
-    const bool ctrlPressed = IsQueueKeyDown(VK_CONTROL);
-    const bool shiftPressed = IsQueueKeyDown(VK_SHIFT);
-    const bool altPressed = IsQueueKeyDown(VK_MENU);
-
-    if (ctrlPressed && !shiftPressed && !altPressed && wParam == 'S') {
-        HandleManualSave();
-        return false;
-    }
-
-    if (ctrlPressed && !altPressed) {
-        if (wParam == 'B' || wParam == 'I' || wParam == 'U' ||
-            wParam == 'V' || wParam == 'X' || wParam == 'Y' || wParam == 'Z') {
-            return true;
-        }
-
-        if (wParam == VK_RETURN) {
-            return true;
-        }
-
-        return false;
-    }
-
-    if (altPressed) {
-        return false;
-    }
-
-    switch (wParam) {
-        case VK_BACK:
-        case VK_DELETE:
-        case VK_RETURN:
-        case VK_TAB:
-            return true;
-    }
-
-    return false;
-}
 
 bool IsPlainTextInputVirtualKeyForState(WPARAM wParam,
                                         bool ctrlPressed,
@@ -5886,12 +8681,90 @@ bool IsPlainTextInputVirtualKeyForState(WPARAM wParam,
     return false;
 }
 
-bool IsPlainTextInputKey(WPARAM wParam) {
-    return IsPlainTextInputVirtualKeyForState(
-        wParam,
-        IsQueueKeyDown(VK_CONTROL),
-        IsQueueKeyDown(VK_MENU),
-        IsQueueKeyDown(VK_LWIN) || IsQueueKeyDown(VK_RWIN));
+enum class KeyDownAutosaveAction {
+    None,
+    ManualSave,
+    EditingInput,
+    TextInput,
+};
+
+bool IsPotentialAutosaveKeyDown(WPARAM wParam) {
+    switch (wParam) {
+        case VK_BACK:
+        case VK_DELETE:
+        case VK_RETURN:
+        case VK_TAB:
+            return true;
+    }
+
+    return IsPlainTextInputVirtualKeyForState(wParam, false, false, false);
+}
+
+KeyDownAutosaveAction ClassifyKeyDownAutosaveActionForState(
+    WPARAM wParam,
+    bool ctrlPressed,
+    bool shiftPressed,
+    bool altPressed,
+    bool winPressed) {
+    if (ctrlPressed && !shiftPressed && !altPressed && wParam == 'S') {
+        return KeyDownAutosaveAction::ManualSave;
+    }
+
+    if (ctrlPressed && !altPressed) {
+        if (wParam == 'B' || wParam == 'I' || wParam == 'U' ||
+            wParam == 'V' || wParam == 'X' || wParam == 'Y' || wParam == 'Z' ||
+            wParam == VK_RETURN) {
+            return KeyDownAutosaveAction::EditingInput;
+        }
+
+        return KeyDownAutosaveAction::None;
+    }
+
+    if (altPressed) {
+        return KeyDownAutosaveAction::None;
+    }
+
+    switch (wParam) {
+        case VK_BACK:
+        case VK_DELETE:
+        case VK_RETURN:
+        case VK_TAB:
+            return KeyDownAutosaveAction::EditingInput;
+    }
+
+    return IsPlainTextInputVirtualKeyForState(wParam,
+                                              ctrlPressed,
+                                              altPressed,
+                                              winPressed)
+               ? KeyDownAutosaveAction::TextInput
+               : KeyDownAutosaveAction::None;
+}
+
+KeyDownAutosaveAction ClassifyKeyDownAutosaveAction(WPARAM wParam) {
+    if (!IsPotentialAutosaveKeyDown(wParam)) {
+        return KeyDownAutosaveAction::None;
+    }
+
+    // Read each modifier at most once, and only read modifiers whose state can
+    // affect this key. This avoids two full GetKeyState passes for ordinary
+    // WM_KEYDOWN traffic.
+    const bool ctrlPressed = IsQueueKeyDown(VK_CONTROL);
+    const bool altPressed = IsQueueKeyDown(VK_MENU);
+    const bool shiftPressed =
+        ctrlPressed && !altPressed && wParam == 'S' &&
+        IsQueueKeyDown(VK_SHIFT);
+
+    bool winPressed = false;
+    if (!ctrlPressed && !altPressed &&
+        IsPlainTextInputVirtualKeyForState(wParam, false, false, false)) {
+        winPressed = IsQueueKeyDown(VK_LWIN) || IsQueueKeyDown(VK_RWIN);
+    }
+
+    return ClassifyKeyDownAutosaveActionForState(wParam,
+                                                 ctrlPressed,
+                                                 shiftPressed,
+                                                 altPressed,
+                                                 winPressed);
 }
 
 bool ShouldSuppressCharacterInputAfterKeyDown(bool suppressionPending,
@@ -5911,26 +8784,37 @@ void NoteTextInputKeyDownScheduled() {
 bool ConsumeTextInputKeyDownCharacterSuppression() {
     const bool suppressionPending =
         LoadFlag(g_runtime.flags.suppressNextCharacterInput);
+    if (!suppressionPending) {
+        return false;
+    }
+
     ClearFlag(g_runtime.flags.suppressNextCharacterInput);
 
     return ShouldSuppressCharacterInputAfterKeyDown(
-        suppressionPending,
+        true,
         g_runtime.timing.lastTextInputKeyDownTime,
         GetTickCount64());
 }
 
-MessageAutosaveRole ClassifyMessageAutosaveRole(const MSG* lpMsg, bool wordEventsConnected) {
+MessageAutosaveRole ClassifyMessageAutosaveRole(const MSG* lpMsg) {
     if (!lpMsg) {
         return MessageAutosaveRole::None;
     }
 
     if (lpMsg->message == WM_KEYDOWN) {
-        if (IsEditingKey(lpMsg->wParam)) {
-            return MessageAutosaveRole::EditingInput;
-        }
+        switch (ClassifyKeyDownAutosaveAction(lpMsg->wParam)) {
+            case KeyDownAutosaveAction::ManualSave:
+                HandleManualSave();
+                return MessageAutosaveRole::None;
 
-        if (IsPlainTextInputKey(lpMsg->wParam)) {
-            return MessageAutosaveRole::TextKeyDownInput;
+            case KeyDownAutosaveAction::EditingInput:
+                return MessageAutosaveRole::EditingInput;
+
+            case KeyDownAutosaveAction::TextInput:
+                return MessageAutosaveRole::TextKeyDownInput;
+
+            case KeyDownAutosaveAction::None:
+                break;
         }
     }
 
@@ -5941,7 +8825,7 @@ MessageAutosaveRole ClassifyMessageAutosaveRole(const MSG* lpMsg, bool wordEvent
     }
 
     if (IsDocumentStateRefreshMessage(lpMsg->message) &&
-        ShouldUseMessageDocumentRefreshFallback(wordEventsConnected)) {
+        ShouldUseMessageDocumentRefreshFallback()) {
         return MessageAutosaveRole::DocumentRefreshFallback;
     }
 
@@ -5950,7 +8834,8 @@ MessageAutosaveRole ClassifyMessageAutosaveRole(const MSG* lpMsg, bool wordEvent
     }
 
     const bool transitionFlush = IsTransitionFlushMessage(lpMsg);
-    if (!ShouldUseMessageBoundaryFallback(wordEventsConnected, transitionFlush)) {
+    if (!transitionFlush &&
+        !ShouldUseMessageBoundaryFallback(AreWordEventsConnected(), false)) {
         return MessageAutosaveRole::None;
     }
 
@@ -5958,9 +8843,46 @@ MessageAutosaveRole ClassifyMessageAutosaveRole(const MSG* lpMsg, bool wordEvent
                            : MessageAutosaveRole::ActionBoundaryFallback;
 }
 
-void HandleClassifiedMessageAutosaveRole(const MSG* lpMsg, bool wordEventsConnected) {
+void HandleClassifiedMessageAutosaveRole(const MSG* lpMsg) {
     const MessageAutosaveRole messageRole =
-        ClassifyMessageAutosaveRole(lpMsg, wordEventsConnected);
+        ClassifyMessageAutosaveRole(lpMsg);
+    if (messageRole == MessageAutosaveRole::None) {
+        return;
+    }
+
+    if (messageRole == MessageAutosaveRole::DocumentRefreshFallback) {
+        if (!ShouldApplyMessageAutosaveRole(
+                messageRole,
+                false,
+                SaveRetryReason::None,
+                false,
+                g_runtime.documentRetry.reason,
+                IsScheduledTaskArmed(ScheduledTaskKind::DocumentState))) {
+            return;
+        }
+    } else if (messageRole == MessageAutosaveRole::ActionBoundaryFallback) {
+        const bool pendingAutosave = HasPendingAutosave();
+        const bool shouldApply =
+            pendingAutosave
+                ? ShouldApplyMessageAutosaveRole(
+                      messageRole,
+                      true,
+                      g_runtime.saveRetry.reason,
+                      IsScheduledTaskArmed(ScheduledTaskKind::Save),
+                      DocumentRetryReason::None,
+                      false)
+                : ShouldApplyMessageAutosaveRole(
+                      messageRole,
+                      false,
+                      SaveRetryReason::None,
+                      false,
+                      g_runtime.documentRetry.reason,
+                      IsScheduledTaskArmed(ScheduledTaskKind::DocumentState));
+        if (!shouldApply) {
+            return;
+        }
+    }
+
     switch (messageRole) {
         case MessageAutosaveRole::TextKeyDownInput:
             NoteTextInputKeyDownScheduled();
@@ -5990,23 +8912,6 @@ void HandleClassifiedMessageAutosaveRole(const MSG* lpMsg, bool wordEventsConnec
 
         case MessageAutosaveRole::None:
             break;
-    }
-}
-
-void MaybeArmDocumentStateMonitorFromMessage() {
-    const bool hasActivePollWork = HasActiveDocumentStatePollWork();
-    if (!IsScheduledTaskArmed(ScheduledTaskKind::DocumentState) &&
-        hasActivePollWork) {
-        ArmDocumentStateTimer(
-            ComputeSteadyDocumentStatePollDelay(hasActivePollWork,
-                                                AreWordEventsConnected()));
-    }
-}
-
-void MaybeArmEventDisconnectRetryFromMessage() {
-    if (HasPendingWordEventDisconnectRetry() &&
-        !IsScheduledTaskArmed(ScheduledTaskKind::EventDisconnectRetry)) {
-        ArmPendingWordEventDisconnectRetry();
     }
 }
 
@@ -6048,24 +8953,109 @@ void HandleTranslateMessageAutosave(const MSG* lpMsg) {
         return;
     }
 
-    if (!LoadFlag(g_runtime.flags.moduleActive)) {
+    const bool relevantMessage =
+        IsAutosaveRelevantMessage(lpMsg->message) ||
+        (g_startupBootstrapMessage != 0 &&
+         lpMsg->message == g_startupBootstrapMessage);
+    const bool controlRequestPending =
+        g_control.pendingRequests.load(std::memory_order_acquire) != 0;
+    if (!relevantMessage && !controlRequestPending) {
+        return;
+    }
+    if (!controlRequestPending &&
+        !LoadFlag(g_runtime.flags.moduleActive)) {
         return;
     }
 
+    const DWORD ownerThreadId = LoadOwnerThreadId();
+    const DWORD currentThreadId = GetCurrentThreadId();
+    const HookMessageRoute route =
+        SelectHookMessageRoute(relevantMessage,
+                               controlRequestPending,
+                               ownerThreadId,
+                               currentThreadId);
+    if (route == HookMessageRoute::Ignore) {
+        return;
+    }
+
+    if (route == HookMessageRoute::AdoptOwner) {
+        AdoptOwnerThreadIfNeeded(lpMsg);
+    }
+    if (!IsOwnerThreadSchedulerContextValid()) {
+        return;
+    }
+
+    if (controlRequestPending) {
+        ProcessOwnerControlRequests();
+        if (!CanRunOwnerThreadRuntimeWork()) {
+            return;
+        }
+    }
+
+    if (!relevantMessage) {
+        return;
+    }
+
+    ScopedOwnerRuntimeWork ownerWork;
     if (ShouldInvalidateWordUiCacheForMessage(lpMsg)) {
         InvalidateWordUiWindowCache();
     }
 
     UpdateImeCompositionState(lpMsg);
-    AdoptOwnerThreadIfNeeded(lpMsg);
-    if (!IsOwnerThreadSchedulerContextValid()) {
-        return;
+    ResumePendingRuntimeWorkForSignal(ClassifySaveResumeSignal(lpMsg));
+    HandleClassifiedMessageAutosaveRole(lpMsg);
+}
+
+bool HandlePrivateRuntimeMessage(const MSG* lpMsg) {
+    if (!lpMsg) {
+        return false;
     }
 
-    const bool wordEventsConnected = AreWordEventsConnected();
-    MaybeArmEventDisconnectRetryFromMessage();
-    HandleClassifiedMessageAutosaveRole(lpMsg, wordEventsConnected);
-    MaybeArmDocumentStateMonitorFromMessage();
+    const bool isControlMessage =
+        lpMsg->message == WORD_LOCAL_AUTOSAVE_CONTROL_MESSAGE;
+    const bool isSchedulerMessage =
+        lpMsg->message == WM_TIMER &&
+        lpMsg->wParam == SCHEDULER_WINDOW_TIMER_ID;
+    if (!isControlMessage && !isSchedulerMessage) {
+        return false;
+    }
+
+    const HWND messageWindow =
+        g_control.messageWindow.load(std::memory_order_acquire);
+    if (!messageWindow || lpMsg->hwnd != messageWindow) {
+        return false;
+    }
+
+    if (isControlMessage) {
+        if (IsOwnerThread()) {
+            ProcessOwnerControlRequests();
+        }
+        return true;
+    }
+
+    if (IsOwnerThread()) {
+        HandleSchedulerTimerMessage(
+            static_cast<UINT_PTR>(lpMsg->wParam));
+    }
+    return true;
+}
+
+bool HasPotentialHookRuntimeWork(const MSG* lpMsg) {
+    if (lpMsg) {
+        const bool privateMessageType =
+            lpMsg->message == WORD_LOCAL_AUTOSAVE_CONTROL_MESSAGE ||
+            (lpMsg->message == WM_TIMER &&
+             lpMsg->wParam == SCHEDULER_WINDOW_TIMER_ID);
+        const bool relevantMessage =
+            IsAutosaveRelevantMessage(lpMsg->message) ||
+            (g_startupBootstrapMessage != 0 &&
+             lpMsg->message == g_startupBootstrapMessage);
+        if (privateMessageType || relevantMessage) {
+            return true;
+        }
+    }
+
+    return g_control.pendingRequests.load(std::memory_order_acquire) != 0;
 }
 
 BOOL WINAPI TranslateMessage_Hook(const MSG* lpMsg) {
@@ -6073,8 +9063,23 @@ BOOL WINAPI TranslateMessage_Hook(const MSG* lpMsg) {
         return TRUE;
     }
 
-    HandleTranslateMessageAutosave(lpMsg);
+    // The overwhelming majority of queue traffic isn't relevant to the mod.
+    // Atomic reads and the message classifier don't touch LastError, so pass
+    // it straight to the original API without any bookkeeping.
+    if (!HasPotentialHookRuntimeWork(lpMsg)) {
+        return g_originalTranslateMessage(lpMsg);
+    }
 
+    const DWORD entryLastError = GetLastError();
+
+    if (!HandlePrivateRuntimeMessage(lpMsg)) {
+        HandleTranslateMessageAutosave(lpMsg);
+    }
+
+    // Present the original API with the same thread error state it would have
+    // seen without the hook. Returning it directly also preserves the error
+    // state it leaves behind.
+    SetLastError(entryLastError);
     return g_originalTranslateMessage(lpMsg);
 }
 
@@ -6082,6 +9087,7 @@ BOOL WINAPI TranslateMessage_Hook(const MSG* lpMsg) {
 // Windhawk Callbacks
 // ============================================================================
 
+#ifdef WH_STANDALONE_COMPILE_CHECK
 template <typename T>
 class ScopedValueRestore {
 public:
@@ -6175,6 +9181,1181 @@ public:
     }
 };
 
+using SelfTestCallback = void (*)(void* context);
+
+class CountingDispatch final : public IDispatch {
+public:
+    CountingDispatch(const wchar_t* memberName, DISPID dispatchId)
+        : m_memberName(memberName), m_dispatchId(dispatchId) {
+    }
+
+    void RebindAfterNextMemberNotFound(DISPID dispatchId) {
+        m_rebindDispatchId = dispatchId;
+        m_rebindPending = true;
+    }
+
+    void FailNextInvoke(HRESULT hr) {
+        m_nextInvokeResult = hr;
+        m_hasNextInvokeResult = true;
+    }
+
+    void FailIdentityQueries(bool fail = true) {
+        m_failIdentityQueries = fail;
+    }
+
+    void PopulateResultBeforeNextMemberNotFound() {
+        m_populateResultBeforeMemberNotFound = true;
+    }
+
+    void ReturnVariantBool(VARIANT_BOOL value) {
+        m_resultType = VT_BOOL;
+        m_resultBool = value;
+    }
+
+    void ReturnVariantLong(long value) {
+        m_resultType = VT_I4;
+        m_resultLong = value;
+    }
+
+    void ReturnVariantInt64(LONGLONG value) {
+        m_resultType = VT_I8;
+        m_resultInt64 = value;
+    }
+
+    void ReturnVariantInt16(short value) {
+        m_resultType = VT_I2;
+        m_resultInt16 = value;
+    }
+
+    void ReturnVariantBstr(const wchar_t* value) {
+        m_resultType = VT_BSTR;
+        m_resultText = value;
+    }
+
+    BSTR LastProducedBstr() const {
+        return m_lastProducedBstr;
+    }
+
+    bool WasRetryResultEmpty() const {
+        return m_retryResultWasEmpty;
+    }
+
+    void ObserveStorageDuringRelease(ScopedComPtr<IDispatch>* storage,
+                                     bool* observedEmpty) {
+        m_releaseObservedStorage = storage;
+        m_releaseObservedEmpty = observedEmpty;
+    }
+
+    void RunOnceOnNextAddRef(SelfTestCallback callback, void* context) {
+        m_addRefCallback = callback;
+        m_addRefCallbackContext = context;
+    }
+
+    void RunOnceOnNextRelease(SelfTestCallback callback, void* context) {
+        m_releaseCallback = callback;
+        m_releaseCallbackContext = context;
+    }
+
+    int GetIdsCallCount() const {
+        return m_getIdsCallCount;
+    }
+
+    int GetTypeInfoCallCount() const {
+        return m_getTypeInfoCallCount;
+    }
+
+    int InvokeCallCount() const {
+        return m_invokeCallCount;
+    }
+
+    DISPID LastInvokedDispId() const {
+        return m_lastInvokedDispId;
+    }
+
+    STDMETHODIMP QueryInterface(REFIID riid, void** object) override {
+        if (!object) {
+            return E_POINTER;
+        }
+
+        *object = nullptr;
+        if (m_failIdentityQueries && riid == IID_IUnknown) {
+            return E_NOINTERFACE;
+        }
+
+        if (riid == IID_IUnknown || riid == kIIDIDispatch) {
+            *object = static_cast<IDispatch*>(this);
+            AddRef();
+            return S_OK;
+        }
+
+        return E_NOINTERFACE;
+    }
+
+    STDMETHODIMP_(ULONG) AddRef() override {
+        SelfTestCallback callback = m_addRefCallback;
+        void* context = m_addRefCallbackContext;
+        m_addRefCallback = nullptr;
+        m_addRefCallbackContext = nullptr;
+        if (callback) {
+            callback(context);
+        }
+        return 2;
+    }
+
+    STDMETHODIMP_(ULONG) Release() override {
+        if (m_releaseObservedStorage && m_releaseObservedEmpty) {
+            *m_releaseObservedEmpty =
+                m_releaseObservedStorage->Get() == nullptr;
+        }
+        SelfTestCallback callback = m_releaseCallback;
+        void* context = m_releaseCallbackContext;
+        m_releaseCallback = nullptr;
+        m_releaseCallbackContext = nullptr;
+        if (callback) {
+            callback(context);
+        }
+        return 1;
+    }
+
+    STDMETHODIMP GetTypeInfoCount(UINT* pctinfo) override {
+        if (pctinfo) {
+            *pctinfo = 0;
+        }
+        return S_OK;
+    }
+
+    STDMETHODIMP GetTypeInfo(UINT, LCID, ITypeInfo**) override {
+        ++m_getTypeInfoCallCount;
+        return E_NOTIMPL;
+    }
+
+    STDMETHODIMP GetIDsOfNames(REFIID,
+                                LPOLESTR* names,
+                                UINT nameCount,
+                                LCID,
+                                DISPID* dispatchIds) override {
+        ++m_getIdsCallCount;
+        if (!names || nameCount != 1 || !names[0] || !dispatchIds ||
+            !m_memberName || lstrcmpW(names[0], m_memberName) != 0) {
+            return DISP_E_UNKNOWNNAME;
+        }
+
+        dispatchIds[0] = m_dispatchId;
+        return S_OK;
+    }
+
+    STDMETHODIMP Invoke(DISPID dispatchId,
+                        REFIID,
+                        LCID,
+                        WORD,
+                        DISPPARAMS*,
+                        VARIANT* result,
+                        EXCEPINFO*,
+                        UINT*) override {
+        ++m_invokeCallCount;
+        m_lastInvokedDispId = dispatchId;
+        if (m_expectEmptyResultOnNextInvoke) {
+            m_retryResultWasEmpty = !result || result->vt == VT_EMPTY;
+            m_expectEmptyResultOnNextInvoke = false;
+            if (!m_retryResultWasEmpty) {
+                return E_UNEXPECTED;
+            }
+        }
+
+        if (m_rebindPending) {
+            m_rebindPending = false;
+            m_dispatchId = m_rebindDispatchId;
+            if (m_populateResultBeforeMemberNotFound && result) {
+                VariantInit(result);
+                result->vt = VT_BSTR;
+                result->bstrVal = SysAllocString(L"stale retry result");
+                if (!result->bstrVal) {
+                    return E_OUTOFMEMORY;
+                }
+                m_expectEmptyResultOnNextInvoke = true;
+                m_populateResultBeforeMemberNotFound = false;
+            }
+            return DISP_E_MEMBERNOTFOUND;
+        }
+
+        if (m_hasNextInvokeResult) {
+            m_hasNextInvokeResult = false;
+            return m_nextInvokeResult;
+        }
+
+        if (dispatchId != m_dispatchId) {
+            return DISP_E_MEMBERNOTFOUND;
+        }
+
+        if (result) {
+            VariantInit(result);
+            result->vt = m_resultType;
+            switch (m_resultType) {
+                case VT_BOOL:
+                    result->boolVal = m_resultBool;
+                    break;
+
+                case VT_I2:
+                    result->iVal = m_resultInt16;
+                    break;
+
+                case VT_I4:
+                    result->lVal = m_resultLong;
+                    break;
+
+                case VT_I8:
+                    result->llVal = m_resultInt64;
+                    break;
+
+                case VT_BSTR:
+                    result->bstrVal = m_resultText
+                                          ? SysAllocString(m_resultText)
+                                          : nullptr;
+                    if (m_resultText && !result->bstrVal) {
+                        result->vt = VT_EMPTY;
+                        return E_OUTOFMEMORY;
+                    }
+                    m_lastProducedBstr = result->bstrVal;
+                    break;
+
+                default:
+                    return E_UNEXPECTED;
+            }
+        }
+        return S_OK;
+    }
+
+private:
+    const wchar_t* m_memberName = nullptr;
+    DISPID m_dispatchId = DISPID_UNKNOWN;
+    DISPID m_rebindDispatchId = DISPID_UNKNOWN;
+    DISPID m_lastInvokedDispId = DISPID_UNKNOWN;
+    HRESULT m_nextInvokeResult = S_OK;
+    VARTYPE m_resultType = VT_BOOL;
+    VARIANT_BOOL m_resultBool = VARIANT_TRUE;
+    short m_resultInt16 = 0;
+    long m_resultLong = 0;
+    LONGLONG m_resultInt64 = 0;
+    const wchar_t* m_resultText = nullptr;
+    BSTR m_lastProducedBstr = nullptr;
+    int m_getIdsCallCount = 0;
+    int m_getTypeInfoCallCount = 0;
+    int m_invokeCallCount = 0;
+    bool m_rebindPending = false;
+    bool m_hasNextInvokeResult = false;
+    bool m_failIdentityQueries = false;
+    bool m_populateResultBeforeMemberNotFound = false;
+    bool m_expectEmptyResultOnNextInvoke = false;
+    bool m_retryResultWasEmpty = true;
+    ScopedComPtr<IDispatch>* m_releaseObservedStorage = nullptr;
+    bool* m_releaseObservedEmpty = nullptr;
+    SelfTestCallback m_addRefCallback = nullptr;
+    void* m_addRefCallbackContext = nullptr;
+    SelfTestCallback m_releaseCallback = nullptr;
+    void* m_releaseCallbackContext = nullptr;
+};
+
+class SelfTestConnectionPoint final : public IConnectionPoint {
+public:
+    void SetUnadviseResult(HRESULT result) {
+        m_unadviseResult = result;
+    }
+
+    void RunOnceOnNextUnadvise(SelfTestCallback callback, void* context) {
+        m_unadviseCallback = callback;
+        m_unadviseCallbackContext = context;
+    }
+
+    int UnadviseCallCount() const {
+        return m_unadviseCallCount;
+    }
+
+    STDMETHODIMP QueryInterface(REFIID riid, void** object) override {
+        if (!object) {
+            return E_POINTER;
+        }
+
+        *object = nullptr;
+        if (riid == IID_IUnknown || riid == IID_IConnectionPoint) {
+            *object = static_cast<IConnectionPoint*>(this);
+            AddRef();
+            return S_OK;
+        }
+        return E_NOINTERFACE;
+    }
+
+    STDMETHODIMP_(ULONG) AddRef() override {
+        return 2;
+    }
+
+    STDMETHODIMP_(ULONG) Release() override {
+        return 1;
+    }
+
+    STDMETHODIMP GetConnectionInterface(IID* iid) override {
+        if (!iid) {
+            return E_POINTER;
+        }
+        *iid = kDIIDWordApplicationEvents4;
+        return S_OK;
+    }
+
+    STDMETHODIMP GetConnectionPointContainer(
+        IConnectionPointContainer** container) override {
+        if (container) {
+            *container = nullptr;
+        }
+        return E_NOTIMPL;
+    }
+
+    STDMETHODIMP Advise(IUnknown*, DWORD*) override {
+        return E_NOTIMPL;
+    }
+
+    STDMETHODIMP Unadvise(DWORD) override {
+        ++m_unadviseCallCount;
+        SelfTestCallback callback = m_unadviseCallback;
+        void* context = m_unadviseCallbackContext;
+        m_unadviseCallback = nullptr;
+        m_unadviseCallbackContext = nullptr;
+        if (callback) {
+            callback(context);
+        }
+        return m_unadviseResult;
+    }
+
+    STDMETHODIMP EnumConnections(IEnumConnections** connections) override {
+        if (connections) {
+            *connections = nullptr;
+        }
+        return E_NOTIMPL;
+    }
+
+private:
+    HRESULT m_unadviseResult = S_OK;
+    int m_unadviseCallCount = 0;
+    SelfTestCallback m_unadviseCallback = nullptr;
+    void* m_unadviseCallbackContext = nullptr;
+};
+
+struct SessionResetReentryTestContext {
+    WordEventSession* session = nullptr;
+    CountingDispatch* replacementApplication = nullptr;
+    bool observedFullyDetached = false;
+};
+
+void ReenterWordEventSessionReset(void* rawContext) {
+    SessionResetReentryTestContext* context =
+        static_cast<SessionResetReentryTestContext*>(rawContext);
+    if (!context || !context->session || !context->replacementApplication) {
+        return;
+    }
+
+    context->observedFullyDetached = context->session->IsEmpty();
+    context->replacementApplication->AddRef();
+    context->session->application.Reset(context->replacementApplication);
+    context->session->applicationHwnd = 77;
+}
+
+struct EventDisconnectReentryTestContext {
+    bool observedDisconnected = false;
+    bool observedGlobalSessionEmpty = false;
+    bool observedTeardownGuard = false;
+};
+
+void ReenterPrimaryWordEventDisconnect(void* rawContext) {
+    EventDisconnectReentryTestContext* context =
+        static_cast<EventDisconnectReentryTestContext*>(rawContext);
+    if (context) {
+        context->observedDisconnected =
+            !LoadFlag(g_runtime.flags.wordEventsConnected);
+        context->observedGlobalSessionEmpty =
+            g_runtime.events.session.IsEmpty();
+        context->observedTeardownGuard =
+            IsWordEventTeardownInProgress();
+    }
+    DisconnectWordApplicationEvents(false);
+}
+
+void ReenterPendingWordEventDisconnectRetry(void*) {
+    RetryPendingWordEventDisconnects();
+}
+
+void ReenterWordEventShutdown(void* rawContext) {
+    bool* completed = static_cast<bool*>(rawContext);
+    const bool result = TryDisconnectAllWordEventsForOwnerShutdown();
+    if (completed) {
+        *completed = result;
+    }
+}
+
+struct TransitionReentryTestContext {
+    const wchar_t* path = nullptr;
+    IDispatch* document = nullptr;
+};
+
+void PublishNestedTransitionFlushTarget(void* rawContext) {
+    TransitionReentryTestContext* context =
+        static_cast<TransitionReentryTestContext*>(rawContext);
+    if (context) {
+        RequestTransitionFlush(context->path, nullptr, context->document);
+    }
+}
+
+struct ObservedDocumentReentryTestContext {
+    const ActiveDocumentSnapshot* snapshot = nullptr;
+    bool dirty = false;
+};
+
+void PublishNestedObservedDocument(void* rawContext) {
+    ObservedDocumentReentryTestContext* context =
+        static_cast<ObservedDocumentReentryTestContext*>(rawContext);
+    if (context) {
+        SetObservedDocumentFromSnapshot(context->snapshot, context->dirty);
+    }
+}
+
+struct ActiveDocumentBindingReentryTestContext {
+    IDispatch* document = nullptr;
+    HRESULT result = E_UNEXPECTED;
+};
+
+void PublishNestedActiveDocumentBinding(void* rawContext) {
+    ActiveDocumentBindingReentryTestContext* context =
+        static_cast<ActiveDocumentBindingReentryTestContext*>(rawContext);
+    if (context) {
+        context->result = CacheActiveDocumentBinding(context->document);
+    }
+}
+
+const DWORD SELF_TEST_TRANSLATE_LAST_ERROR = 0x13572468u;
+DWORD g_selfTestTranslateEntryLastError = 0;
+
+BOOL WINAPI SelfTestOriginalTranslateMessage(const MSG*) {
+    g_selfTestTranslateEntryLastError = GetLastError();
+    SetLastError(SELF_TEST_TRANSLATE_LAST_ERROR);
+    return FALSE;
+}
+
+bool RunDispatchAndAutomationCacheSelfTests() {
+    bool success = true;
+    ClearWordMemberIdCache();
+
+    ScopedVariant detachedBstrVariant;
+    BSTR detachSource = SysAllocString(L"detached BSTR");
+    if (!detachSource) {
+        ReportSelfTestFailure(&success, L"VARIANT BSTR detach allocation");
+    } else {
+        detachedBstrVariant.Get()->vt = VT_BSTR;
+        detachedBstrVariant.Get()->bstrVal = detachSource;
+        BSTR detachedBstr = detachedBstrVariant.DetachBstr();
+        if (detachedBstr != detachSource ||
+            detachedBstrVariant.Get()->vt != VT_EMPTY) {
+            ReportSelfTestFailure(&success, L"VARIANT BSTR ownership detach");
+        }
+        SysFreeString(detachedBstr);
+    }
+
+    SelfTestDispatch detachDispatch;
+    ScopedVariant detachedDispatchVariant;
+    detachDispatch.AddRef();
+    detachedDispatchVariant.Get()->vt = VT_DISPATCH;
+    detachedDispatchVariant.Get()->pdispVal = &detachDispatch;
+    IDispatch* detachedDispatch = nullptr;
+    if (FAILED(ExtractDispatchFromVariant(&detachedDispatchVariant,
+                                          &detachedDispatch)) ||
+        detachedDispatch != &detachDispatch ||
+        detachedDispatchVariant.Get()->vt != VT_EMPTY) {
+        ReportSelfTestFailure(&success, L"VARIANT dispatch ownership detach");
+    }
+    if (detachedDispatch) {
+        detachedDispatch->Release();
+    }
+
+    CountingDispatch directBoolDispatch(L"Saved", 91);
+    directBoolDispatch.ReturnVariantBool(VARIANT_TRUE);
+    bool directBool = false;
+    if (FAILED(GetBoolProperty(&directBoolDispatch,
+                               WordMember::DocumentSaved,
+                               &directBool)) ||
+        !directBool) {
+        ReportSelfTestFailure(&success, L"direct VT_BOOL property path");
+    }
+
+    CountingDispatch directIntDispatch(L"Count", 92);
+    directIntDispatch.ReturnVariantLong(4242);
+    long directInt = 0;
+    if (FAILED(GetIntProperty(&directIntDispatch,
+                              WordMember::DocumentsCount,
+                              &directInt)) ||
+        directInt != 4242) {
+        ReportSelfTestFailure(&success, L"direct VT_I4 property path");
+    }
+
+    CountingDispatch fallbackIntDispatch(L"Count", 93);
+    fallbackIntDispatch.ReturnVariantInt16(123);
+    long fallbackInt = 0;
+    if (FAILED(GetIntProperty(&fallbackIntDispatch,
+                              WordMember::WindowsCount,
+                              &fallbackInt)) ||
+        fallbackInt != 123) {
+        ReportSelfTestFailure(&success, L"fallback integer property conversion");
+    }
+
+    CountingDispatch directBstrDispatch(L"Name", 94);
+    directBstrDispatch.ReturnVariantBstr(L"direct BSTR");
+    ScopedBstr directBstr;
+    if (FAILED(GetBstrProperty(&directBstrDispatch,
+                               WordMember::DocumentName,
+                               directBstr.Put())) ||
+        directBstr.Get() != directBstrDispatch.LastProducedBstr() ||
+        lstrcmpW(directBstr.CStr(), L"direct BSTR") != 0) {
+        ReportSelfTestFailure(&success, L"direct VT_BSTR ownership transfer");
+    }
+
+    CountingDispatch emptyBstrDispatch(L"Path", 95);
+    emptyBstrDispatch.ReturnVariantBstr(nullptr);
+    BSTR emptyBstr = reinterpret_cast<BSTR>(1);
+    const HRESULT emptyBstrHr =
+        GetBstrProperty(&emptyBstrDispatch,
+                        WordMember::DocumentPath,
+                        &emptyBstr);
+    if (emptyBstrHr != S_OK || emptyBstr != nullptr) {
+        ReportSelfTestFailure(&success, L"empty VT_BSTR property path");
+    }
+
+    CountingDispatch directHwndDispatch(L"Hwnd", 96);
+    directHwndDispatch.ReturnVariantInt64(0x1234);
+    LONG_PTR directHwnd = 0;
+    if (FAILED(GetDispatchWindowHandle(&directHwndDispatch,
+                                       WordMember::ApplicationHwnd,
+                                       &directHwnd)) ||
+        directHwnd != 0x1234) {
+        ReportSelfTestFailure(&success, L"direct VT_I8 window handle path");
+    }
+
+    ClearWordMemberIdCache();
+
+    CountingDispatch savedDispatch(L"Saved", 101);
+    if (FAILED(InvokeWordMember(&savedDispatch,
+                                DISPATCH_PROPERTYGET,
+                                WordMember::DocumentSaved)) ||
+        FAILED(InvokeWordMember(&savedDispatch,
+                                DISPATCH_PROPERTYGET,
+                                WordMember::DocumentSaved)) ||
+        savedDispatch.GetIdsCallCount() != 1 ||
+        savedDispatch.InvokeCallCount() != 2 ||
+        savedDispatch.GetTypeInfoCallCount() != 0) {
+        ReportSelfTestFailure(&success, L"typed DISPID steady-state cache");
+    }
+
+    CountingDispatch applicationHwndDispatch(L"Hwnd", 201);
+    CountingDispatch windowHwndDispatch(L"Hwnd", 202);
+    if (FAILED(InvokeWordMember(&applicationHwndDispatch,
+                                DISPATCH_PROPERTYGET,
+                                WordMember::ApplicationHwnd)) ||
+        FAILED(InvokeWordMember(&windowHwndDispatch,
+                                DISPATCH_PROPERTYGET,
+                                WordMember::WindowHwnd)) ||
+        applicationHwndDispatch.LastInvokedDispId() != 201 ||
+        windowHwndDispatch.LastInvokedDispId() != 202 ||
+        applicationHwndDispatch.GetIdsCallCount() != 1 ||
+        windowHwndDispatch.GetIdsCallCount() != 1) {
+        ReportSelfTestFailure(&success, L"typed DISPID object-kind separation");
+    }
+
+    CountingDispatch rebindingDispatch(L"ReadOnly", 301);
+    rebindingDispatch.RebindAfterNextMemberNotFound(302);
+    if (FAILED(InvokeWordMember(&rebindingDispatch,
+                                DISPATCH_PROPERTYGET,
+                                WordMember::DocumentReadOnly)) ||
+        rebindingDispatch.GetIdsCallCount() != 2 ||
+        rebindingDispatch.InvokeCallCount() != 2 ||
+        rebindingDispatch.LastInvokedDispId() != 302) {
+        ReportSelfTestFailure(&success, L"typed DISPID one-shot rebind");
+    }
+
+    CountingDispatch dirtyResultDispatch(L"Name", 311);
+    dirtyResultDispatch.RebindAfterNextMemberNotFound(312);
+    dirtyResultDispatch.PopulateResultBeforeNextMemberNotFound();
+    ScopedVariant reboundResult;
+    if (FAILED(InvokeWordMember(&dirtyResultDispatch,
+                                DISPATCH_PROPERTYGET,
+                                WordMember::DocumentName,
+                                reboundResult.Get())) ||
+        !dirtyResultDispatch.WasRetryResultEmpty() ||
+        reboundResult.Get()->vt != VT_BOOL) {
+        ReportSelfTestFailure(&success,
+                              L"typed DISPID dirty-result retry cleanup");
+    }
+
+    CountingDispatch releaseDispatch(L"Saved", 321);
+    ScopedComPtr<IDispatch> releaseObservedStorage;
+    bool releaseObservedEmpty = false;
+    releaseDispatch.ObserveStorageDuringRelease(&releaseObservedStorage,
+                                                &releaseObservedEmpty);
+    releaseObservedStorage.Reset(&releaseDispatch);
+    releaseObservedStorage.Reset();
+    if (!releaseObservedEmpty) {
+        ReportSelfTestFailure(&success,
+                              L"COM pointer re-entrant release publication");
+    }
+
+    CountingDispatch busyDispatch(L"Path", 401);
+    busyDispatch.FailNextInvoke(RPC_E_CALL_REJECTED);
+    if (InvokeWordMember(&busyDispatch,
+                         DISPATCH_PROPERTYGET,
+                         WordMember::DocumentPath) != RPC_E_CALL_REJECTED ||
+        FAILED(InvokeWordMember(&busyDispatch,
+                                DISPATCH_PROPERTYGET,
+                                WordMember::DocumentPath)) ||
+        busyDispatch.GetIdsCallCount() != 1 ||
+        busyDispatch.InvokeCallCount() != 2) {
+        ReportSelfTestFailure(&success, L"busy COM failure cache preservation");
+    }
+
+    if (IsTerminalAutomationObjectFailure(RPC_E_CALL_REJECTED) ||
+        IsTerminalAutomationObjectFailure(RPC_E_SERVERCALL_RETRYLATER) ||
+        !IsTerminalAutomationObjectFailure(kCoEObjectNotConnected) ||
+        !IsTerminalAutomationObjectFailure(RPC_E_DISCONNECTED) ||
+        !IsTerminalAutomationObjectFailure(RPC_E_SERVER_DIED)) {
+        ReportSelfTestFailure(&success, L"COM failure invalidation classes");
+    }
+
+    ResetAutomationCacheState();
+    SelfTestDispatch firstDocument;
+    SelfTestDispatch secondDocument;
+    if (FAILED(CacheActiveDocumentBinding(&firstDocument))) {
+        ReportSelfTestFailure(&success, L"active document cache binding");
+    } else {
+        const unsigned int firstGeneration =
+            g_runtime.automation.documentGeneration;
+        g_runtime.automation.activeDocumentPath.Reset(
+            SysAllocString(L"C:\\dummy.docx"));
+        g_runtime.automation.activeDocumentMetadataValid =
+            g_runtime.automation.activeDocumentPath.Get() != nullptr;
+        g_runtime.automation.activeDocumentHasPath = true;
+
+        if (FAILED(CacheActiveDocumentBinding(&firstDocument)) ||
+            g_runtime.automation.documentGeneration != firstGeneration ||
+            !g_runtime.automation.activeDocumentMetadataValid) {
+            ReportSelfTestFailure(&success,
+                                  L"same active document metadata preservation");
+        }
+
+        CountingDispatch invalidIdentityDocument(L"Saved", 501);
+        invalidIdentityDocument.FailIdentityQueries();
+        if (SUCCEEDED(CacheActiveDocumentBinding(&invalidIdentityDocument)) ||
+            !g_runtime.automation.activeDocumentStale) {
+            ReportSelfTestFailure(&success,
+                                  L"failed active document binding invalidation");
+        }
+
+        if (FAILED(CacheActiveDocumentBinding(&firstDocument))) {
+            ReportSelfTestFailure(&success,
+                                  L"active document cache recovery after failed binding");
+        }
+
+        InvalidateActiveDocumentCacheForEventCoverageGap();
+        if (!g_runtime.automation.activeDocumentStale ||
+            g_runtime.automation.activeDocumentMetadataValid ||
+            g_runtime.automation.activeDocumentPath.Get() != nullptr ||
+            g_runtime.automation.activeDocumentHasPath) {
+            ReportSelfTestFailure(&success,
+                                  L"event coverage gap cache invalidation");
+        }
+
+        if (FAILED(CacheActiveDocumentBinding(&firstDocument))) {
+            ReportSelfTestFailure(&success,
+                                  L"active document cache recovery after event gap");
+        }
+
+        if (FAILED(CacheActiveDocumentBinding(&secondDocument)) ||
+            g_runtime.automation.documentGeneration == firstGeneration ||
+            g_runtime.automation.activeDocumentMetadataValid) {
+            ReportSelfTestFailure(&success,
+                                  L"active document identity invalidation");
+        }
+
+        MarkCachedActiveDocumentStale();
+        ScopedComPtr<IDispatch> copiedDocument;
+        if (SUCCEEDED(CopyCachedActiveDocument(copiedDocument.Put())) ||
+            copiedDocument) {
+            ReportSelfTestFailure(&success, L"stale active document rejection");
+        }
+    }
+
+    ResetAutomationCacheState();
+
+    CountingDispatch supersededDocument(L"Saved", 601);
+    CountingDispatch nestedDocument(L"Saved", 602);
+    ActiveDocumentBindingReentryTestContext bindingContext = {};
+    bindingContext.document = &nestedDocument;
+    supersededDocument.RunOnceOnNextAddRef(
+        PublishNestedActiveDocumentBinding,
+        &bindingContext);
+    const HRESULT supersededBindingHr =
+        CacheActiveDocumentBinding(&supersededDocument);
+    if (bindingContext.result != S_OK || supersededBindingHr != S_FALSE ||
+        g_runtime.automation.activeDocument.Get() != &nestedDocument ||
+        g_runtime.automation.activeDocumentStale) {
+        ReportSelfTestFailure(
+            &success,
+            L"re-entrant active document binding supersession");
+    }
+
+    ResetAutomationCacheState();
+    CountingDispatch copiedDocumentBeforeReentry(L"Saved", 603);
+    CountingDispatch copiedDocumentReplacement(L"Saved", 604);
+    if (FAILED(CacheActiveDocumentBinding(&copiedDocumentBeforeReentry))) {
+        ReportSelfTestFailure(&success,
+                              L"active document copy re-entry setup");
+    } else {
+        ActiveDocumentBindingReentryTestContext copyContext = {};
+        copyContext.document = &copiedDocumentReplacement;
+        copiedDocumentBeforeReentry.RunOnceOnNextAddRef(
+            PublishNestedActiveDocumentBinding,
+            &copyContext);
+        ScopedComPtr<IDispatch> copiedAfterReentry;
+        const HRESULT copyHr =
+            CopyCachedActiveDocument(copiedAfterReentry.Put());
+        if (copyContext.result != S_OK || SUCCEEDED(copyHr) ||
+            copiedAfterReentry ||
+            g_runtime.automation.activeDocument.Get() !=
+                &copiedDocumentReplacement ||
+            g_runtime.automation.activeDocumentStale) {
+            ReportSelfTestFailure(
+                &success,
+                L"re-entrant active document copy generation check");
+        }
+    }
+
+    ResetAutomationCacheState();
+    ClearTransitionFlushRequest();
+    CountingDispatch supersededTransitionDocument(L"Saved", 605);
+    CountingDispatch nestedTransitionDocument(L"Saved", 606);
+    TransitionReentryTestContext transitionContext = {};
+    transitionContext.path = L"C:\\nested-transition.docx";
+    transitionContext.document = &nestedTransitionDocument;
+    supersededTransitionDocument.RunOnceOnNextAddRef(
+        PublishNestedTransitionFlushTarget,
+        &transitionContext);
+    RequestTransitionFlush(L"C:\\superseded-transition.docx",
+                           nullptr,
+                           &supersededTransitionDocument);
+    if (!LoadFlag(g_runtime.flags.transitionFlushPending) ||
+        g_runtime.document.transitionFlushDocument.Get() !=
+            &nestedTransitionDocument ||
+        lstrcmpW(g_runtime.document.transitionFlushDocumentPath.Get(),
+                 transitionContext.path) != 0) {
+        ReportSelfTestFailure(&success,
+                              L"re-entrant transition target supersession");
+    }
+
+    ClearTransitionFlushRequest();
+    RequestTransitionFlush(L"C:\\copied-transition.docx",
+                           nullptr,
+                           &supersededTransitionDocument);
+    supersededTransitionDocument.RunOnceOnNextAddRef(
+        PublishNestedTransitionFlushTarget,
+        &transitionContext);
+    ScopedComPtr<IDispatch> copiedTransitionDocument;
+    if (CopyValidTransitionFlushDocument(nullptr,
+                                         &copiedTransitionDocument) ||
+        copiedTransitionDocument ||
+        g_runtime.document.transitionFlushDocument.Get() !=
+            &nestedTransitionDocument ||
+        lstrcmpW(g_runtime.document.transitionFlushDocumentPath.Get(),
+                 transitionContext.path) != 0) {
+        ReportSelfTestFailure(
+            &success,
+            L"re-entrant transition target copy generation check");
+    }
+    ClearTransitionFlushRequest();
+
+    CountingDispatch supersededObservedDocument(L"Saved", 607);
+    CountingDispatch nestedObservedDocument(L"Saved", 608);
+    ActiveDocumentSnapshot supersededObservedSnapshot;
+    ActiveDocumentSnapshot nestedObservedSnapshot;
+    const bool observedSetupReady =
+        ReplaceStoredBstr(&supersededObservedSnapshot.path,
+                          L"C:\\superseded-observed.docx") &&
+        ReplaceStoredComPtr(&supersededObservedSnapshot.document,
+                            static_cast<IDispatch*>(
+                                &supersededObservedDocument)) &&
+        SUCCEEDED(GetComIdentity(&supersededObservedDocument,
+                                 supersededObservedSnapshot.identity.Put())) &&
+        ReplaceStoredBstr(&nestedObservedSnapshot.path,
+                          L"C:\\nested-observed.docx") &&
+        ReplaceStoredComPtr(&nestedObservedSnapshot.document,
+                            static_cast<IDispatch*>(
+                                &nestedObservedDocument)) &&
+        SUCCEEDED(GetComIdentity(&nestedObservedDocument,
+                                 nestedObservedSnapshot.identity.Put()));
+    supersededObservedSnapshot.hasPath = observedSetupReady;
+    nestedObservedSnapshot.hasPath = observedSetupReady;
+    if (!observedSetupReady) {
+        ReportSelfTestFailure(&success,
+                              L"observed document re-entry setup");
+    } else {
+        ObservedDocumentReentryTestContext observedContext = {};
+        observedContext.snapshot = &nestedObservedSnapshot;
+        observedContext.dirty = true;
+        supersededObservedDocument.RunOnceOnNextAddRef(
+            PublishNestedObservedDocument,
+            &observedContext);
+        if (!SetObservedDocumentFromSnapshot(&supersededObservedSnapshot,
+                                             true) ||
+            !LoadFlag(g_runtime.flags.documentDirtyKnown) ||
+            !LoadFlag(g_runtime.flags.documentDirty) ||
+            g_runtime.document.observedDocument.Get() !=
+                &nestedObservedDocument ||
+            lstrcmpW(g_runtime.document.observedDocumentPath.Get(),
+                     nestedObservedSnapshot.path.CStr()) != 0) {
+            ReportSelfTestFailure(
+                &success,
+                L"re-entrant observed document supersession");
+        }
+    }
+    ResetObservedDocumentState();
+
+    ClearWordMemberIdCache();
+    return success;
+}
+
+bool RunHotPathAndMonitoringPolicySelfTests() {
+    bool success = true;
+
+    if (!IsPotentialAutosaveKeyDown('A') ||
+        !IsPotentialAutosaveKeyDown(VK_BACK) ||
+        IsPotentialAutosaveKeyDown(VK_F1) ||
+        ClassifyKeyDownAutosaveActionForState(
+            'A', false, false, false, false) !=
+            KeyDownAutosaveAction::TextInput ||
+        ClassifyKeyDownAutosaveActionForState(
+            'A', false, true, false, false) !=
+            KeyDownAutosaveAction::TextInput ||
+        ClassifyKeyDownAutosaveActionForState(
+            'A', false, false, false, true) !=
+            KeyDownAutosaveAction::None ||
+        ClassifyKeyDownAutosaveActionForState(
+            VK_BACK, false, false, false, true) !=
+            KeyDownAutosaveAction::EditingInput ||
+        ClassifyKeyDownAutosaveActionForState(
+            VK_BACK, true, false, false, false) !=
+            KeyDownAutosaveAction::None ||
+        ClassifyKeyDownAutosaveActionForState(
+            'B', true, true, false, false) !=
+            KeyDownAutosaveAction::EditingInput ||
+        ClassifyKeyDownAutosaveActionForState(
+            VK_RETURN, true, true, false, false) !=
+            KeyDownAutosaveAction::EditingInput ||
+        ClassifyKeyDownAutosaveActionForState(
+            'S', true, false, false, false) !=
+            KeyDownAutosaveAction::ManualSave ||
+        ClassifyKeyDownAutosaveActionForState(
+            'S', true, true, false, false) !=
+            KeyDownAutosaveAction::None ||
+        ClassifyKeyDownAutosaveActionForState(
+            'B', true, false, true, false) !=
+            KeyDownAutosaveAction::None) {
+        ReportSelfTestFailure(&success, L"unified keydown shortcut classification");
+    }
+
+    GrowablePathBuffer smallPathBuffer;
+    if (smallPathBuffer.EnsureCapacity(0) ||
+        !smallPathBuffer.EnsureCapacity(1) ||
+        smallPathBuffer.Capacity() < 1 ||
+        !smallPathBuffer.EnsureCapacity(smallPathBuffer.Capacity()) ||
+        GetNextPathBufferCapacity(0, 0) != 1 ||
+        GetNextPathBufferCapacity(MAX_PATH, MAX_PATH) != MAX_PATH + 1 ||
+        GetNextPathBufferCapacity(MAX_CANONICAL_PATH_CHARS,
+                                  MAX_CANONICAL_PATH_CHARS) != 0 ||
+        GetNextPathBufferCapacity(MAX_CANONICAL_PATH_CHARS + 1,
+                                  MAX_CANONICAL_PATH_CHARS) != 0) {
+        ReportSelfTestFailure(&success, L"growable path buffer boundaries");
+    }
+
+    const TranslateMessage_t previousTranslateMessage =
+        g_originalTranslateMessage;
+    const bool previousModuleActive =
+        LoadFlag(g_runtime.flags.moduleActive);
+    const LONG previousPendingRequests =
+        g_control.pendingRequests.exchange(0, std::memory_order_acq_rel);
+    ClearFlag(g_runtime.flags.moduleActive);
+
+    g_originalTranslateMessage = nullptr;
+    const DWORD missingOriginalLastError = 0x24681357u;
+    SetLastError(missingOriginalLastError);
+    const BOOL missingOriginalResult = TranslateMessage_Hook(nullptr);
+    const DWORD missingOriginalObservedError = GetLastError();
+
+    g_originalTranslateMessage = SelfTestOriginalTranslateMessage;
+    MSG irrelevantMessage = {};
+    irrelevantMessage.message = WM_PAINT;
+    const bool irrelevantFastPathEligible =
+        !HasPotentialHookRuntimeWork(&irrelevantMessage);
+    const DWORD originalEntryLastError = 0x10203040u;
+    g_selfTestTranslateEntryLastError = 0;
+    SetLastError(originalEntryLastError);
+    const BOOL originalResult = TranslateMessage_Hook(&irrelevantMessage);
+    const DWORD originalObservedError = GetLastError();
+
+    g_originalTranslateMessage = previousTranslateMessage;
+    g_control.pendingRequests.store(previousPendingRequests,
+                                    std::memory_order_release);
+    StoreFlag(g_runtime.flags.moduleActive, previousModuleActive);
+    if (!missingOriginalResult ||
+        missingOriginalObservedError != missingOriginalLastError ||
+        !irrelevantFastPathEligible ||
+        originalResult != FALSE ||
+        g_selfTestTranslateEntryLastError != originalEntryLastError ||
+        originalObservedError != SELF_TEST_TRANSLATE_LAST_ERROR) {
+        ReportSelfTestFailure(&success, L"TranslateMessage last-error preservation");
+    }
+
+    if (!IsAutosaveRelevantMessage(WM_KEYDOWN) ||
+        !IsAutosaveRelevantMessage(WM_MOUSEWHEEL) ||
+        !IsAutosaveRelevantMessage(WM_ACTIVATE) ||
+        !IsAutosaveRelevantMessage(WM_IME_ENDCOMPOSITION) ||
+        !IsAutosaveRelevantMessage(WM_EXITMENULOOP) ||
+        !IsAutosaveRelevantMessage(WM_CANCELMODE) ||
+        IsAutosaveRelevantMessage(WM_MOUSEMOVE) ||
+        IsAutosaveRelevantMessage(WM_PAINT) ||
+        IsAutosaveRelevantMessage(WM_TIMER)) {
+        ReportSelfTestFailure(&success, L"hot-path message interest filter");
+    }
+
+    MSG activationMessage = {};
+    activationMessage.message = WM_ACTIVATE;
+    activationMessage.wParam = WA_ACTIVE;
+    MSG deactivationMessage = activationMessage;
+    deactivationMessage.wParam = WA_INACTIVE;
+    MSG menuReleaseMessage = {};
+    menuReleaseMessage.message = WM_EXITMENULOOP;
+    MSG focusMessage = {};
+    focusMessage.message = WM_SETFOCUS;
+    MSG actionReleaseMessage = {};
+    actionReleaseMessage.message = WM_LBUTTONUP;
+    if (ClassifySaveResumeSignal(&activationMessage) !=
+            SaveResumeSignal::WordActivated ||
+        ClassifySaveResumeSignal(&deactivationMessage) !=
+            SaveResumeSignal::None ||
+        ClassifySaveResumeSignal(&menuReleaseMessage) !=
+            SaveResumeSignal::UiReleased ||
+        ClassifySaveResumeSignal(&focusMessage) !=
+            SaveResumeSignal::UiReleased ||
+        ClassifySaveResumeSignal(&actionReleaseMessage) !=
+            SaveResumeSignal::ActionBoundary) {
+        ReportSelfTestFailure(&success, L"retry resume signal classification");
+    }
+
+    if (ShouldResumeSaveForSignal(SaveRetryReason::None,
+                                  SaveResumeSignal::WordActivated) ||
+        !ShouldResumeSaveForSignal(SaveRetryReason::InactiveWindow,
+                                   SaveResumeSignal::WordActivated) ||
+        !ShouldResumeSaveForSignal(SaveRetryReason::HardFailure,
+                                   SaveResumeSignal::DocumentChanged) ||
+        !ShouldResumeSaveForSignal(SaveRetryReason::AutomationBusy,
+                                   SaveResumeSignal::ActionBoundary) ||
+        ShouldResumeSaveForSignal(SaveRetryReason::HardFailure,
+                                  SaveResumeSignal::ActionBoundary) ||
+        !ShouldResumeDocumentForSignal(DocumentRetryReason::Disconnected,
+                                       SaveResumeSignal::WordActivated) ||
+        !ShouldResumeDocumentForSignal(DocumentRetryReason::Busy,
+                                       SaveResumeSignal::UiReleased) ||
+        ShouldResumeDocumentForSignal(DocumentRetryReason::Hard,
+                                      SaveResumeSignal::UiReleased)) {
+        ReportSelfTestFailure(&success, L"reason-aware event resume policy");
+    }
+
+    if (ShouldWakeSaveForOrdinaryFallback(SaveRetryReason::HardFailure,
+                                          true) ||
+        ShouldWakeSaveForOrdinaryFallback(
+            SaveRetryReason::TargetUnavailable,
+            true) ||
+        ShouldWakeSaveForOrdinaryFallback(
+            SaveRetryReason::DeferredProtectedView,
+            true) ||
+        !ShouldWakeSaveForOrdinaryFallback(
+            SaveRetryReason::AutomationBusy,
+            true) ||
+        !ShouldWakeSaveForOrdinaryFallback(SaveRetryReason::UiPaused,
+                                           true) ||
+        !ShouldWakeSaveForOrdinaryFallback(SaveRetryReason::InputBusy,
+                                           true) ||
+        !ShouldWakeSaveForOrdinaryFallback(SaveRetryReason::HardFailure,
+                                           false)) {
+        ReportSelfTestFailure(&success,
+                              L"ordinary save fallback retry policy");
+    }
+
+    if (ShouldWakeDocumentForOrdinaryFallback(DocumentRetryReason::Hard,
+                                              true) ||
+        ShouldWakeDocumentForOrdinaryFallback(
+            DocumentRetryReason::Disconnected,
+            true) ||
+        !ShouldWakeDocumentForOrdinaryFallback(DocumentRetryReason::Busy,
+                                               true) ||
+        !ShouldWakeDocumentForOrdinaryFallback(DocumentRetryReason::UiPaused,
+                                               true) ||
+        !ShouldWakeDocumentForOrdinaryFallback(DocumentRetryReason::InputBusy,
+                                               true) ||
+        !ShouldWakeDocumentForOrdinaryFallback(DocumentRetryReason::Hard,
+                                               false)) {
+        ReportSelfTestFailure(&success,
+                              L"ordinary document fallback retry policy");
+    }
+
+    if (!ShouldApplyMessageAutosaveRole(
+            MessageAutosaveRole::EditingInput,
+            true,
+            SaveRetryReason::HardFailure,
+            true,
+            DocumentRetryReason::Hard,
+            true) ||
+        !ShouldApplyMessageAutosaveRole(
+            MessageAutosaveRole::TransitionBoundaryFallback,
+            true,
+            SaveRetryReason::HardFailure,
+            true,
+            DocumentRetryReason::Disconnected,
+            true) ||
+        ShouldApplyMessageAutosaveRole(
+            MessageAutosaveRole::ActionBoundaryFallback,
+            true,
+            SaveRetryReason::HardFailure,
+            true,
+            DocumentRetryReason::Busy,
+            true) ||
+        ShouldApplyMessageAutosaveRole(
+            MessageAutosaveRole::ActionBoundaryFallback,
+            false,
+            SaveRetryReason::None,
+            false,
+            DocumentRetryReason::Disconnected,
+            true) ||
+        !ShouldApplyMessageAutosaveRole(
+            MessageAutosaveRole::ActionBoundaryFallback,
+            false,
+            SaveRetryReason::None,
+            false,
+            DocumentRetryReason::Busy,
+            true) ||
+        ShouldApplyMessageAutosaveRole(
+            MessageAutosaveRole::DocumentRefreshFallback,
+            false,
+            SaveRetryReason::None,
+            false,
+            DocumentRetryReason::Hard,
+            true) ||
+        !ShouldApplyMessageAutosaveRole(
+            MessageAutosaveRole::DocumentRefreshFallback,
+            false,
+            SaveRetryReason::None,
+            false,
+            DocumentRetryReason::Busy,
+            true) ||
+        ShouldApplyMessageAutosaveRole(MessageAutosaveRole::None,
+                                       false,
+                                       SaveRetryReason::None,
+                                       false,
+                                       DocumentRetryReason::None,
+                                       false)) {
+        ReportSelfTestFailure(&success,
+                              L"message autosave fallback override policy");
+    }
+
+    if (SelectHookMessageRoute(false, false, 0, 42) !=
+            HookMessageRoute::Ignore ||
+        SelectHookMessageRoute(true, false, 0, 42) !=
+            HookMessageRoute::AdoptOwner ||
+        SelectHookMessageRoute(true, false, 42, 42) !=
+            HookMessageRoute::HandleOnOwner ||
+        SelectHookMessageRoute(false, true, 42, 42) !=
+            HookMessageRoute::HandleOnOwner ||
+        SelectHookMessageRoute(true, false, 43, 42) !=
+            HookMessageRoute::Ignore) {
+        ReportSelfTestFailure(&success, L"hot-path owner routing");
+    }
+
+    if (!ShouldQueueSchedulerRepair(false, 100, false, false) ||
+        ShouldQueueSchedulerRepair(true, 100, false, false) ||
+        ShouldQueueSchedulerRepair(false, 0, false, false) ||
+        ShouldQueueSchedulerRepair(false, 100, true, false) ||
+        ShouldQueueSchedulerRepair(false, 100, false, true)) {
+        ReportSelfTestFailure(&success, L"bounded scheduler repair policy");
+    }
+
+    if (SelectDocumentMonitorSchedule(true,
+                                      true,
+                                      false,
+                                      false,
+                                      false,
+                                      true,
+                                      true) != DocumentMonitorScheduleKind::None ||
+        SelectDocumentMonitorSchedule(true,
+                                      true,
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                      true) !=
+            DocumentMonitorScheduleKind::RepairSaveTask ||
+        SelectDocumentMonitorSchedule(false,
+                                      true,
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                      true) !=
+            DocumentMonitorScheduleKind::RepairSaveTask ||
+        SelectDocumentMonitorSchedule(false,
+                                      false,
+                                      true,
+                                      false,
+                                      false,
+                                      false,
+                                      true) != DocumentMonitorScheduleKind::ActiveRetry ||
+        SelectDocumentMonitorSchedule(false,
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                      true) != DocumentMonitorScheduleKind::EventWatchdog ||
+        SelectDocumentMonitorSchedule(false,
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                      false,
+                                      false) != DocumentMonitorScheduleKind::FallbackPoll) {
+        ReportSelfTestFailure(&success, L"one-shot document monitor selection");
+    }
+
+    if (GetDocumentMonitorScheduleDelay(DocumentMonitorScheduleKind::ActiveRetry) !=
+            DOCUMENT_STATE_PENDING_WATCHDOG_MS ||
+        GetDocumentMonitorScheduleDelay(DocumentMonitorScheduleKind::EventWatchdog) !=
+            DOCUMENT_STATE_EVENT_IDLE_POLL_INTERVAL_MS ||
+        GetDocumentMonitorScheduleDelay(DocumentMonitorScheduleKind::FallbackPoll) !=
+            DOCUMENT_STATE_IDLE_POLL_INTERVAL_MS ||
+        GetDocumentMonitorScheduleDelay(DocumentMonitorScheduleKind::None) != 0 ||
+        GetDocumentMonitorScheduleDelay(DocumentMonitorScheduleKind::RepairSaveTask) != 0) {
+        ReportSelfTestFailure(&success, L"document monitor delay selection");
+    }
+
+    if (!IsDocumentFailureRetryReason(DocumentRetryReason::Busy) ||
+        !IsDocumentFailureRetryReason(DocumentRetryReason::Disconnected) ||
+        !IsDocumentFailureRetryReason(DocumentRetryReason::Hard) ||
+        IsDocumentFailureRetryReason(DocumentRetryReason::UiPaused) ||
+        IsDocumentFailureRetryReason(DocumentRetryReason::None)) {
+        ReportSelfTestFailure(&success, L"document failure retry classification");
+    }
+
+    return success;
+}
+
 void ResetRuntimeTimingState(RuntimeTimingState* timing);
 void ResetRuntimeStatusState(RuntimeStatusState* status);
 void ResetRuntimeUiCacheState(RuntimeUiCacheState* ui);
@@ -6190,13 +10371,35 @@ bool RunTimingAndFallbackSelfTests() {
         ReportSelfTestFailure(&success, L"transition coalescing delay");
     }
 
-    if (!AreSameDocumentPath(L"C:\\Docs\\Test.docx", L"c:/docs/test.docx") ||
-        !AreSameDocumentPath(L"C:\\Docs\\Test.docx\\", L"c:/docs/test.docx") ||
-        AreSameDocumentPath(L"C:\\Docs\\One.docx", L"C:\\Docs\\Two.docx")) {
-        ReportSelfTestFailure(&success, L"path comparison normalization");
+    if (!AreSameDocumentPathText(L"C:\\Docs\\Test.docx",
+                                 L"c:/docs/test.docx") ||
+        !AreSameDocumentPathText(L"C:\\Docs\\Test.docx\\",
+                                 L"c:/docs/test.docx") ||
+        AreSameDocumentPathText(L"C:\\Docs\\One.docx",
+                                L"C:\\Docs\\Two.docx") ||
+        CompareDocumentPathText(L"C:\\Docs\\One.docx",
+                                L"C:\\Docs\\Two.docx") !=
+            DocumentPathTextComparison::RequiresResolution ||
+        CompareDocumentPathText(nullptr, L"C:\\Docs\\Test.docx") !=
+            DocumentPathTextComparison::Different ||
+        CompareDocumentPathText(nullptr, L"") !=
+            DocumentPathTextComparison::Equal) {
+        ReportSelfTestFailure(&success, L"no-I/O path text comparison");
     }
 
     const wchar_t win32DrivePath[] = L"\\\\?\\C:\\Docs\\Test.docx";
+    if (AreSameDocumentPathText(win32DrivePath, L"C:\\Docs\\Test.docx") ||
+        CompareDocumentPathText(win32DrivePath,
+                                L"C:\\Docs\\Test.docx") !=
+            DocumentPathTextComparison::RequiresResolution ||
+        AreSameDocumentPathText(L"\\\\?\\C:\\Docs/Test.docx",
+                                win32DrivePath) ||
+        !AreSameDocumentPathText(L"\\\\?\\C:\\DOCS\\TEST.DOCX",
+                                 win32DrivePath)) {
+        ReportSelfTestFailure(&success,
+                              L"extended namespace lexical isolation");
+    }
+
     ScopedBstr normalizedDrivePath;
     if (!StoreNormalizedFinalPath(win32DrivePath,
                                   static_cast<DWORD>(lstrlenW(win32DrivePath)),
@@ -6224,10 +10427,100 @@ bool RunTimingAndFallbackSelfTests() {
         ReportSelfTestFailure(&success, L"Win32 volume path preservation");
     }
 
-    DWORD retryDelayMs = MIN_RETRY_INTERVAL_MS;
-    const DWORD firstDelay = AdvanceRetryDelay(&retryDelayMs, MAX_SAVE_RETRY_INTERVAL_MS);
-    if (firstDelay != MIN_RETRY_INTERVAL_MS || retryDelayMs != MIN_RETRY_INTERVAL_MS * 2) {
-        ReportSelfTestFailure(&success, L"retry backoff progression");
+    const auto verifyBackoff = [&success](DWORD initialDelayMs,
+                                          DWORD maxDelayMs,
+                                          const DWORD* expectedDelays,
+                                          size_t expectedCount,
+                                          const wchar_t* testName) {
+        DWORD nextDelayMs = initialDelayMs;
+        for (size_t index = 0; index < expectedCount; ++index) {
+            if (AdvanceRetryDelayForPolicy(&nextDelayMs,
+                                           initialDelayMs,
+                                           maxDelayMs) != expectedDelays[index]) {
+                ReportSelfTestFailure(&success, testName);
+                return;
+            }
+        }
+
+        if (nextDelayMs != maxDelayMs) {
+            ReportSelfTestFailure(&success, testName);
+        }
+    };
+
+    const DWORD busyDelays[] = {125, 250, 500, 1000, 2000, 4000, 5000, 5000};
+    const DWORD hardDelays[] = {2000, 4000, 8000, 16000, 30000, 30000};
+    const DWORD targetDelays[] = {250, 500, 1000, 2000, 4000, 5000, 5000};
+    verifyBackoff(SAVE_AUTOMATION_RETRY_INITIAL_MS,
+                  SAVE_AUTOMATION_RETRY_MAX_MS,
+                  busyDelays,
+                  ARRAYSIZE(busyDelays),
+                  L"busy retry backoff progression");
+    verifyBackoff(SAVE_HARD_RETRY_INITIAL_MS,
+                  SAVE_HARD_RETRY_MAX_MS,
+                  hardDelays,
+                  ARRAYSIZE(hardDelays),
+                  L"hard retry backoff progression");
+    verifyBackoff(SAVE_TARGET_RETRY_INITIAL_MS,
+                  SAVE_TARGET_RETRY_MAX_MS,
+                  targetDelays,
+                  ARRAYSIZE(targetDelays),
+                  L"target retry backoff progression");
+    verifyBackoff(DOCUMENT_BUSY_RETRY_INITIAL_MS,
+                  DOCUMENT_BUSY_RETRY_MAX_MS,
+                  busyDelays,
+                  ARRAYSIZE(busyDelays),
+                  L"document busy retry backoff progression");
+    verifyBackoff(DOCUMENT_HARD_RETRY_INITIAL_MS,
+                  DOCUMENT_HARD_RETRY_MAX_MS,
+                  hardDelays,
+                  ARRAYSIZE(hardDelays),
+                  L"document hard retry backoff progression");
+    verifyBackoff(DOCUMENT_TARGET_RETRY_INITIAL_MS,
+                  DOCUMENT_TARGET_RETRY_MAX_MS,
+                  targetDelays,
+                  ARRAYSIZE(targetDelays),
+                  L"document target retry backoff progression");
+
+    const DWORD canceledRetry = static_cast<DWORD>(-1);
+    if (SelectRejectedCallRetryDelay(ComRetryProfile::Background,
+                                     SERVERCALL_RETRYLATER,
+                                     999,
+                                     99,
+                                     100) != COM_BACKGROUND_RETRY_DELAY_MS ||
+        SelectRejectedCallRetryDelay(ComRetryProfile::Background,
+                                     SERVERCALL_RETRYLATER,
+                                     1000,
+                                     99,
+                                     100) != canceledRetry ||
+        SelectRejectedCallRetryDelay(ComRetryProfile::Background,
+                                     SERVERCALL_RETRYLATER,
+                                     10,
+                                     100,
+                                     100) != canceledRetry ||
+        SelectRejectedCallRetryDelay(ComRetryProfile::CriticalClose,
+                                     SERVERCALL_RETRYLATER,
+                                     9999,
+                                     99,
+                                     100) != COM_MESSAGE_FILTER_RETRY_DELAY_MS ||
+        SelectRejectedCallRetryDelay(ComRetryProfile::LegacyLifecycle,
+                                     SERVERCALL_RETRYLATER,
+                                     10000,
+                                     99,
+                                     100) != canceledRetry ||
+        SelectRejectedCallRetryDelay(ComRetryProfile::Background,
+                                     SERVERCALL_REJECTED,
+                                     10,
+                                     99,
+                                     100) != canceledRetry) {
+        ReportSelfTestFailure(&success, L"COM retry profile deadline policy");
+    }
+
+    if (!ShouldLogRetryReasonNow(0, 1, 0, 100, 10000) ||
+        ShouldLogRetryReasonNow(1, 1, 100, 1000, 10000) ||
+        !ShouldLogRetryReasonNow(1, 1, 100, 10100, 10000) ||
+        ShouldLogRetryReasonNow(1, 2, 100, 2000, 10000) ||
+        !ShouldLogRetryReasonNow(1, 2, 100, 2100, 10000)) {
+        ReportSelfTestFailure(&success, L"bounded retry reason logging");
     }
 
     BSTR selfResetText = SysAllocString(L"self-reset");
@@ -6250,8 +10543,7 @@ bool RunTimingAndFallbackSelfTests() {
         ReportSelfTestFailure(&success, L"COM pointer self-reset guard");
     }
 
-    if (!ShouldUseMessageDocumentRefreshFallback(false) ||
-        !ShouldUseMessageDocumentRefreshFallback(true)) {
+    if (!ShouldUseMessageDocumentRefreshFallback()) {
         ReportSelfTestFailure(&success, L"message refresh fallback gating");
     }
 
@@ -6394,7 +10686,8 @@ bool RunWordEventPolicySelfTests() {
     dispIds.documentBeforeSave = 1;
     dispIds.documentBeforeClose = 2;
     dispIds.documentChange = 3;
-    dispIds.windowDeactivate = 4;
+    dispIds.windowActivate = 4;
+    dispIds.windowDeactivate = 5;
     if (ClassifyWordApplicationEvent(dispIds, 1) !=
             WordApplicationEventKind::DocumentBeforeSave ||
         ClassifyWordApplicationEvent(dispIds, 2) !=
@@ -6402,6 +10695,8 @@ bool RunWordEventPolicySelfTests() {
         ClassifyWordApplicationEvent(dispIds, 3) !=
             WordApplicationEventKind::DocumentChange ||
         ClassifyWordApplicationEvent(dispIds, 4) !=
+            WordApplicationEventKind::WindowActivate ||
+        ClassifyWordApplicationEvent(dispIds, 5) !=
             WordApplicationEventKind::WindowDeactivate ||
         ClassifyWordApplicationEvent(dispIds, 99) !=
             WordApplicationEventKind::None) {
@@ -6440,11 +10735,348 @@ bool RunWordEventPolicySelfTests() {
         ReportSelfTestFailure(&success, L"Word event reset preservation policy");
     }
 
+    g_runtime.events.session.Reset();
+    g_runtime.events.stagedSession.Reset();
+    for (int index = 0;
+         index < WORD_EVENT_PENDING_DISCONNECT_CAPACITY;
+         ++index) {
+        g_runtime.events.pendingDisconnectSessions[index].Reset();
+    }
+    g_runtime.events.connectionBuildDepth = 0;
+    ClearFlag(g_runtime.flags.wordEventsConnected);
+    ClearFlag(g_runtime.flags.wordEventDisconnectRetryPending);
+
+    const unsigned int policyEpoch = g_runtime.events.connectionEpoch;
+    if (!CanCommitWordEventConnection(policyEpoch) ||
+        CanCommitWordEventConnection(policyEpoch + 1)) {
+        ReportSelfTestFailure(&success, L"Word event connection epoch policy");
+    }
+    {
+        ScopedOwnerDepth buildDepth(
+            g_runtime.events.connectionBuildDepth);
+        if (!IsWordEventConnectionBuildInProgress()) {
+            ReportSelfTestFailure(&success,
+                                  L"Word event connection build guard");
+        }
+    }
+    {
+        ScopedOwnerDepth primaryDepth(
+            g_runtime.events.primaryDisconnectDepth);
+        if (CanCommitWordEventConnection(policyEpoch)) {
+            ReportSelfTestFailure(&success,
+                                  L"primary teardown commit exclusion");
+        }
+    }
+    {
+        ScopedOwnerDepth retryDepth(
+            g_runtime.events.pendingDisconnectRetryDepth);
+        if (CanCommitWordEventConnection(policyEpoch)) {
+            ReportSelfTestFailure(&success,
+                                  L"pending teardown commit exclusion");
+        }
+    }
+
+    CountingDispatch resetApplication(L"Saved", 701);
+    CountingDispatch resetSink(L"Saved", 702);
+    CountingDispatch replacementApplication(L"Saved", 703);
+    SelfTestConnectionPoint resetConnectionPoint;
+    WordEventSession resetSession;
+    ReplaceStoredComPtr(&resetSession.application,
+                        static_cast<IDispatch*>(&resetApplication));
+    ReplaceStoredComPtr(&resetSession.connectionPoint,
+                        static_cast<IConnectionPoint*>(
+                            &resetConnectionPoint));
+    ReplaceStoredComPtr(&resetSession.sink,
+                        static_cast<IDispatch*>(&resetSink));
+    resetSession.applicationHwnd = 42;
+    resetSession.cookie = 1;
+    SessionResetReentryTestContext resetContext = {};
+    resetContext.session = &resetSession;
+    resetContext.replacementApplication = &replacementApplication;
+    resetApplication.RunOnceOnNextRelease(ReenterWordEventSessionReset,
+                                          &resetContext);
+    resetSession.Reset();
+    if (!resetContext.observedFullyDetached ||
+        resetSession.application.Get() != &replacementApplication ||
+        resetSession.applicationHwnd != 77 || resetSession.connectionPoint ||
+        resetSession.sink || resetSession.sinkControl ||
+        resetSession.cookie != 0) {
+        ReportSelfTestFailure(&success,
+                              L"re-entrant Word event session reset");
+    }
+    resetSession.Reset();
+
+    SelfTestConnectionPoint primaryConnectionPoint;
+    ReplaceStoredComPtr(&g_runtime.events.session.connectionPoint,
+                        static_cast<IConnectionPoint*>(
+                            &primaryConnectionPoint));
+    g_runtime.events.session.cookie = 11;
+    SetFlag(g_runtime.flags.wordEventsConnected);
+    EventDisconnectReentryTestContext disconnectContext = {};
+    primaryConnectionPoint.RunOnceOnNextUnadvise(
+        ReenterPrimaryWordEventDisconnect,
+        &disconnectContext);
+    const unsigned int disconnectEpoch =
+        g_runtime.events.connectionEpoch;
+    DisconnectWordApplicationEvents(false);
+    if (primaryConnectionPoint.UnadviseCallCount() != 1 ||
+        !disconnectContext.observedDisconnected ||
+        !disconnectContext.observedGlobalSessionEmpty ||
+        !disconnectContext.observedTeardownGuard ||
+        !g_runtime.events.session.IsEmpty() ||
+        LoadFlag(g_runtime.flags.wordEventsConnected) ||
+        g_runtime.events.primaryDisconnectDepth != 0 ||
+        g_runtime.events.connectionEpoch != disconnectEpoch + 1) {
+        ReportSelfTestFailure(&success,
+                              L"recursive primary Word event disconnect");
+    }
+
+    WordEventSession* pendingSession =
+        &g_runtime.events.pendingDisconnectSessions[0];
+    SelfTestConnectionPoint retryConnectionPoint;
+    ReplaceStoredComPtr(&pendingSession->connectionPoint,
+                        static_cast<IConnectionPoint*>(
+                            &retryConnectionPoint));
+    pendingSession->cookie = 12;
+    retryConnectionPoint.RunOnceOnNextUnadvise(
+        ReenterPendingWordEventDisconnectRetry,
+        nullptr);
+    SetFlag(g_runtime.flags.wordEventDisconnectRetryPending);
+    RetryPendingWordEventDisconnects();
+    if (retryConnectionPoint.UnadviseCallCount() != 1 ||
+        !pendingSession->IsEmpty() ||
+        LoadFlag(g_runtime.flags.wordEventDisconnectRetryPending) ||
+        g_runtime.events.pendingDisconnectRetryDepth != 0) {
+        ReportSelfTestFailure(&success,
+                              L"recursive deferred Word event disconnect");
+    }
+
+    SelfTestConnectionPoint shutdownConnectionPoint;
+    ReplaceStoredComPtr(&pendingSession->connectionPoint,
+                        static_cast<IConnectionPoint*>(
+                            &shutdownConnectionPoint));
+    pendingSession->cookie = 13;
+    bool nestedShutdownCompleted = true;
+    shutdownConnectionPoint.RunOnceOnNextUnadvise(
+        ReenterWordEventShutdown,
+        &nestedShutdownCompleted);
+    SetFlag(g_runtime.flags.wordEventDisconnectRetryPending);
+    RetryPendingWordEventDisconnects();
+    if (nestedShutdownCompleted ||
+        shutdownConnectionPoint.UnadviseCallCount() != 1 ||
+        !pendingSession->IsEmpty() ||
+        g_runtime.events.pendingDisconnectRetryDepth != 0) {
+        ReportSelfTestFailure(
+            &success,
+            L"shutdown exclusion during deferred event disconnect");
+    }
+
+    CountingDispatch retainedPendingApplication(L"Saved", 704);
+    ReplaceStoredComPtr(&pendingSession->application,
+                        static_cast<IDispatch*>(
+                            &retainedPendingApplication));
+    if (FindFreePendingWordEventDisconnectSlot() == pendingSession) {
+        ReportSelfTestFailure(&success,
+                              L"retained pending event slot exclusion");
+    }
+    pendingSession->Reset();
+
+    SelfTestConnectionPoint staleConnectionPoint;
+    WordEventSession staleSession;
+    ReplaceStoredComPtr(&staleSession.connectionPoint,
+                        static_cast<IConnectionPoint*>(
+                            &staleConnectionPoint));
+    staleSession.cookie = 14;
+    const unsigned int staleCommitEpoch =
+        g_runtime.events.connectionEpoch;
+    const HRESULT staleCommitHr =
+        CommitWordEventSession(&staleSession, staleCommitEpoch + 1);
+    if (staleCommitHr != E_ABORT ||
+        staleConnectionPoint.UnadviseCallCount() != 1 ||
+        !staleSession.IsEmpty() || !g_runtime.events.session.IsEmpty() ||
+        g_runtime.events.connectionEpoch != staleCommitEpoch ||
+        g_runtime.events.pendingDisconnectRetryDepth != 0) {
+        ReportSelfTestFailure(&success,
+                              L"stale Word event connection commit");
+    }
+
+    SelfTestConnectionPoint fullQueueConnectionPoints[
+        WORD_EVENT_PENDING_DISCONNECT_CAPACITY];
+    for (int index = 0;
+         index < WORD_EVENT_PENDING_DISCONNECT_CAPACITY;
+         ++index) {
+        fullQueueConnectionPoints[index].SetUnadviseResult(E_FAIL);
+        WordEventSession* fullSlot =
+            &g_runtime.events.pendingDisconnectSessions[index];
+        ReplaceStoredComPtr(
+            &fullSlot->connectionPoint,
+            static_cast<IConnectionPoint*>(
+                &fullQueueConnectionPoints[index]));
+        fullSlot->cookie = 100u + static_cast<DWORD>(index);
+    }
+
+    SelfTestConnectionPoint retainedPrimaryConnectionPoint;
+    retainedPrimaryConnectionPoint.SetUnadviseResult(E_FAIL);
+    ReplaceStoredComPtr(
+        &g_runtime.events.session.connectionPoint,
+        static_cast<IConnectionPoint*>(&retainedPrimaryConnectionPoint));
+    g_runtime.events.session.cookie = 200;
+    SetFlag(g_runtime.flags.wordEventsConnected);
+    SetFlag(g_runtime.flags.wordEventDisconnectRetryPending);
+    const bool fullQueueDisconnectCompleted =
+        DisconnectWordApplicationEvents(true);
+    if (fullQueueDisconnectCompleted ||
+        retainedPrimaryConnectionPoint.UnadviseCallCount() != 1 ||
+        !g_runtime.events.session.IsConnected() ||
+        !g_runtime.events.stagedSession.IsEmpty() ||
+        FindFreePendingWordEventDisconnectSlot() != nullptr ||
+        LoadFlag(g_runtime.flags.wordEventsConnected) ||
+        !LoadFlag(g_runtime.flags.wordEventDisconnectRetryPending)) {
+        ReportSelfTestFailure(&success,
+                              L"full event disconnect queue retention");
+    }
+
+    for (int index = 0;
+         index < WORD_EVENT_PENDING_DISCONNECT_CAPACITY;
+         ++index) {
+        fullQueueConnectionPoints[index].SetUnadviseResult(S_OK);
+    }
+    retainedPrimaryConnectionPoint.SetUnadviseResult(S_OK);
+    RetryPendingWordEventDisconnects();
+    if (retainedPrimaryConnectionPoint.UnadviseCallCount() != 2 ||
+        !g_runtime.events.session.IsEmpty() ||
+        !g_runtime.events.stagedSession.IsEmpty() ||
+        LoadFlag(g_runtime.flags.wordEventDisconnectRetryPending)) {
+        ReportSelfTestFailure(&success,
+                              L"retained event session cleanup");
+    }
+
+    ClearFlag(g_runtime.flags.wordEventsConnected);
+    ClearFlag(g_runtime.flags.wordEventDisconnectRetryPending);
+
     return success;
 }
 
 bool RunSnapshotPolicySelfTests() {
     bool success = true;
+
+    ActiveDocumentSnapshot metadataStateSnapshot;
+    if (metadataStateSnapshot.metadataState !=
+            SnapshotMetadataState::NotRequested ||
+        metadataStateSnapshot.failureClass != AutomationFailureClass::None ||
+        metadataStateSnapshot.hasPath) {
+        ReportSelfTestFailure(&success,
+                              L"snapshot metadata-not-requested state");
+    }
+
+    if (ClassifyAutomationFailure(RPC_E_CALL_REJECTED) !=
+            AutomationFailureClass::Busy ||
+        ClassifyAutomationFailure(kCoEObjectNotConnected) !=
+            AutomationFailureClass::Disconnected ||
+        ClassifyAutomationFailure(E_FAIL) != AutomationFailureClass::Hard ||
+        ClassifyAutomationFailure(S_OK) != AutomationFailureClass::None) {
+        ReportSelfTestFailure(&success, L"automation failure classification");
+    }
+
+    HRESULT firstDocumentLookupHardFailure =
+        RememberFirstDocumentLookupHardFailure(S_OK, E_FAIL);
+    firstDocumentLookupHardFailure = RememberFirstDocumentLookupHardFailure(
+        firstDocumentLookupHardFailure,
+        E_OUTOFMEMORY);
+    if (firstDocumentLookupHardFailure != E_FAIL ||
+        RememberFirstDocumentLookupHardFailure(S_OK, S_OK) != S_OK ||
+        SelectDocumentPathLookupMissResult(firstDocumentLookupHardFailure) !=
+            E_FAIL ||
+        SelectDocumentPathLookupMissResult(S_OK) !=
+            HRESULT_FROM_WIN32(ERROR_NOT_FOUND) ||
+        !ShouldReturnDocumentLookupFailureImmediately(
+            RPC_E_SERVERCALL_RETRYLATER) ||
+        !ShouldReturnDocumentLookupFailureImmediately(
+            kCoEObjectNotConnected) ||
+        ShouldReturnDocumentLookupFailureImmediately(E_FAIL)) {
+        ReportSelfTestFailure(&success,
+                              L"document path lookup failure selection");
+    }
+
+    HRESULT firstNativeDocumentProbeHardFailure = S_OK;
+    RememberNativeDocumentProbeFailure(DISP_E_UNKNOWNNAME,
+                                       &firstNativeDocumentProbeHardFailure);
+    RememberNativeDocumentProbeFailure(E_FAIL,
+                                       &firstNativeDocumentProbeHardFailure);
+    RememberNativeDocumentProbeFailure(E_OUTOFMEMORY,
+                                       &firstNativeDocumentProbeHardFailure);
+    RememberNativeDocumentProbeFailure(RPC_E_CALL_REJECTED,
+                                       &firstNativeDocumentProbeHardFailure);
+
+    HRESULT ignoredNativeDocumentProbeFailure = S_OK;
+    RememberNativeDocumentProbeFailure(DISP_E_MEMBERNOTFOUND,
+                                       &ignoredNativeDocumentProbeFailure);
+    RememberNativeDocumentProbeFailure(kCoEObjectNotConnected,
+                                       &ignoredNativeDocumentProbeFailure);
+
+    if (ClassifyNativeDocumentLookupResult(S_OK, true) !=
+            NativeDocumentLookupOutcome::Ready ||
+        ClassifyNativeDocumentLookupResult(S_FALSE, false) !=
+            NativeDocumentLookupOutcome::Missing ||
+        ClassifyNativeDocumentLookupResult(S_OK, false) !=
+            NativeDocumentLookupOutcome::RetryLater ||
+        ClassifyNativeDocumentLookupResult(E_FAIL, false) !=
+            NativeDocumentLookupOutcome::RetryLater ||
+        ClassifyNativeDocumentLookupResult(RPC_E_CALL_REJECTED, false) !=
+            NativeDocumentLookupOutcome::RetryLater ||
+        ClassifyNativeDocumentLookupResult(kCoEObjectNotConnected, false) !=
+            NativeDocumentLookupOutcome::RetryLater ||
+        !ShouldPropagateNativeDocumentProbeFailure(
+            RPC_E_SERVERCALL_RETRYLATER) ||
+        !ShouldPropagateNativeDocumentProbeFailure(
+            kCoEObjectNotConnected) ||
+        ShouldPropagateNativeDocumentProbeFailure(E_FAIL) ||
+        ShouldPropagateNativeDocumentProbeFailure(E_OUTOFMEMORY) ||
+        ShouldPropagateNativeDocumentProbeFailure(DISP_E_UNKNOWNNAME) ||
+        ShouldPropagateNativeDocumentProbeFailure(DISP_E_MEMBERNOTFOUND) ||
+        !IsExpectedNativeDocumentProbeMiss(DISP_E_UNKNOWNNAME) ||
+        !IsExpectedNativeDocumentProbeMiss(DISP_E_MEMBERNOTFOUND) ||
+        IsExpectedNativeDocumentProbeMiss(E_FAIL) ||
+        firstNativeDocumentProbeHardFailure != E_FAIL ||
+        FAILED(ignoredNativeDocumentProbeFailure) ||
+        SelectNativeDocumentProbeMissResult(
+            firstNativeDocumentProbeHardFailure) != E_FAIL ||
+        SelectNativeDocumentProbeMissResult(S_OK) != S_FALSE) {
+        ReportSelfTestFailure(&success,
+                              L"native active-document lookup policy");
+    }
+
+    ActiveDocumentSnapshot failureSnapshot;
+    RecordSnapshotFailure(&failureSnapshot, RPC_E_SERVERCALL_RETRYLATER);
+    if (failureSnapshot.failureClass != AutomationFailureClass::Busy ||
+        failureSnapshot.failureHr != RPC_E_SERVERCALL_RETRYLATER ||
+        GetSaveRetryReasonForSnapshot(&failureSnapshot) !=
+            SaveRetryReason::AutomationBusy ||
+        GetDocumentRetryReasonForSnapshot(&failureSnapshot) !=
+            DocumentRetryReason::Busy) {
+        ReportSelfTestFailure(&success, L"busy snapshot retry metadata");
+    }
+
+    RecordSnapshotFailure(&failureSnapshot, kCoEObjectNotConnected);
+    if (GetSaveRetryReasonForSnapshot(&failureSnapshot) !=
+            SaveRetryReason::TargetUnavailable ||
+        GetDocumentRetryReasonForSnapshot(&failureSnapshot) !=
+            DocumentRetryReason::Disconnected) {
+        ReportSelfTestFailure(&success, L"disconnected snapshot retry metadata");
+    }
+
+    RecordSnapshotFailure(&failureSnapshot, E_OUTOFMEMORY);
+    if (GetSaveRetryReasonForSnapshot(&failureSnapshot) !=
+            SaveRetryReason::HardFailure ||
+        GetDocumentRetryReasonForSnapshot(&failureSnapshot) !=
+            DocumentRetryReason::Hard) {
+        ReportSelfTestFailure(&success, L"hard snapshot retry metadata");
+    }
+    failureSnapshot.Reset();
+    if (failureSnapshot.failureClass != AutomationFailureClass::None ||
+        failureSnapshot.failureHr != S_OK) {
+        ReportSelfTestFailure(&success, L"snapshot retry metadata reset");
+    }
 
     if (!ShouldPopulateSnapshotMetadataForMode(false, SnapshotMetadataMode::WhenDirty) ||
         ShouldPopulateSnapshotMetadataForMode(true, SnapshotMetadataMode::WhenDirty) ||
@@ -6452,9 +11084,32 @@ bool RunSnapshotPolicySelfTests() {
         ReportSelfTestFailure(&success, L"snapshot metadata mode gating");
     }
 
-    if (!ShouldRetryInvalidCachedSnapshotDocument(true, false) ||
-        ShouldRetryInvalidCachedSnapshotDocument(true, true) ||
-        ShouldRetryInvalidCachedSnapshotDocument(false, false)) {
+    if (!ShouldRetryInvalidCachedSnapshotDocument(
+            true,
+            false,
+            AutomationFailureClass::Disconnected) ||
+        ShouldRetryInvalidCachedSnapshotDocument(
+            true,
+            false,
+            AutomationFailureClass::Busy) ||
+        ShouldRetryInvalidCachedSnapshotDocument(
+            true,
+            false,
+            AutomationFailureClass::Hard) ||
+        ShouldRetryInvalidCachedSnapshotDocument(
+            true,
+            true,
+            AutomationFailureClass::Disconnected) ||
+        ShouldRetryInvalidCachedSnapshotDocument(
+            false,
+            false,
+            AutomationFailureClass::Disconnected) ||
+        !ShouldInvalidateTransitionFlushTargetForFailure(
+            AutomationFailureClass::Disconnected) ||
+        ShouldInvalidateTransitionFlushTargetForFailure(
+            AutomationFailureClass::Busy) ||
+        ShouldInvalidateTransitionFlushTargetForFailure(
+            AutomationFailureClass::Hard)) {
         ReportSelfTestFailure(&success, L"invalid cached snapshot retry policy");
     }
 
@@ -6515,7 +11170,8 @@ bool RunSnapshotPolicySelfTests() {
                                      nullptr,
                                      &copiedAutosavePath,
                                      &copiedAutosaveDocument) ||
-        !AreSameDocumentPath(sourceAutosavePath.CStr(), copiedAutosavePath.CStr())) {
+        !AreSameDocumentPathText(sourceAutosavePath.CStr(),
+                                 copiedAutosavePath.CStr())) {
         ReportSelfTestFailure(&success, L"auto-save target copy");
     }
 
@@ -6548,11 +11204,51 @@ bool RunSnapshotPolicySelfTests() {
         ReportSelfTestFailure(&success, L"document-state snapshot interpretation");
     }
 
+    ScopedValueRestore<RuntimeSaveRetryState> saveRetryRestore(
+        &g_runtime.saveRetry);
+    ScopedValueRestore<ULONGLONG> lastSaveTimeRestore(
+        &g_runtime.timing.lastSaveTime);
+    g_runtime.saveRetry.reason = SaveRetryReason::HardFailure;
+    g_runtime.saveRetry.hardNextDelayMs = SAVE_HARD_RETRY_MAX_MS;
+    NoteSaveOperationTime(1234);
+    if (g_runtime.timing.lastSaveTime != 1234 ||
+        g_runtime.saveRetry.reason != SaveRetryReason::HardFailure ||
+        g_runtime.saveRetry.hardNextDelayMs != SAVE_HARD_RETRY_MAX_MS ||
+        ShouldResetSaveRetryAfterSuccessfulSnapshot(true) ||
+        !ShouldResetSaveRetryAfterSuccessfulSnapshot(false)) {
+        ReportSelfTestFailure(
+            &success,
+            L"unexpected successful snapshot retry preservation");
+    }
+
     return success;
 }
 
 bool RunOwnerThreadAndSchedulerSelfTests() {
     bool success = true;
+
+    std::atomic<LONG> atomicFlag{FALSE};
+    if (LoadFlag(atomicFlag)) {
+        ReportSelfTestFailure(&success, L"atomic runtime flag initial state");
+    }
+    SetFlag(atomicFlag);
+    if (!LoadFlag(atomicFlag)) {
+        ReportSelfTestFailure(&success, L"atomic runtime flag set/load");
+    }
+    {
+        ScopedFlagSet scopedFlag(atomicFlag);
+        if (!LoadFlag(atomicFlag)) {
+            ReportSelfTestFailure(&success, L"atomic scoped flag publication");
+        }
+    }
+    if (LoadFlag(atomicFlag)) {
+        ReportSelfTestFailure(&success, L"atomic scoped flag clear");
+    }
+    StoreFlag(atomicFlag, true);
+    ClearFlag(atomicFlag);
+    if (LoadFlag(atomicFlag)) {
+        ReportSelfTestFailure(&success, L"atomic runtime flag store/clear");
+    }
 
     ScopedOwnerThreadRestore ownerThreadRestore;
     ClearOwnerThreadId();
@@ -6652,17 +11348,42 @@ bool RunOwnerThreadAndSchedulerSelfTests() {
     timingState.lastEditTime = 7;
     timingState.transitionFlushRequestTime = 8;
     timingState.lastTextInputKeyDownTime = 9;
-    timingState.saveRetryDelayMs = 123;
-    timingState.documentStateRetryDelayMs = 456;
     ResetRuntimeTimingState(&timingState);
     if (timingState.schedulerTimerId != 0 ||
         timingState.eventDisconnectRetryTimerDueTime != 0 ||
         timingState.lastEditTime != 0 ||
         timingState.transitionFlushRequestTime != 0 ||
-        timingState.lastTextInputKeyDownTime != 0 ||
-        timingState.saveRetryDelayMs != MIN_RETRY_INTERVAL_MS ||
-        timingState.documentStateRetryDelayMs != MIN_RETRY_INTERVAL_MS) {
+        timingState.lastTextInputKeyDownTime != 0) {
         ReportSelfTestFailure(&success, L"timing-state reset helper");
+    }
+
+    RuntimeSaveRetryState saveRetryState = {};
+    saveRetryState.reason = SaveRetryReason::HardFailure;
+    saveRetryState.hardNextDelayMs = SAVE_HARD_RETRY_MAX_MS;
+    saveRetryState.lastReasonLogTime = 42;
+    ResetRuntimeSaveRetryState(&saveRetryState);
+    if (saveRetryState.reason != SaveRetryReason::None ||
+        saveRetryState.automationNextDelayMs !=
+            SAVE_AUTOMATION_RETRY_INITIAL_MS ||
+        saveRetryState.hardNextDelayMs != SAVE_HARD_RETRY_INITIAL_MS ||
+        saveRetryState.targetNextDelayMs != SAVE_TARGET_RETRY_INITIAL_MS ||
+        saveRetryState.lastReasonLogTime != 0) {
+        ReportSelfTestFailure(&success, L"save retry-state reset helper");
+    }
+
+    RuntimeDocumentRetryState documentRetryState = {};
+    documentRetryState.reason = DocumentRetryReason::Disconnected;
+    documentRetryState.disconnectedNextDelayMs =
+        DOCUMENT_TARGET_RETRY_MAX_MS;
+    documentRetryState.lastReasonLogTime = 42;
+    ResetRuntimeDocumentRetryState(&documentRetryState);
+    if (documentRetryState.reason != DocumentRetryReason::None ||
+        documentRetryState.busyNextDelayMs != DOCUMENT_BUSY_RETRY_INITIAL_MS ||
+        documentRetryState.disconnectedNextDelayMs !=
+            DOCUMENT_TARGET_RETRY_INITIAL_MS ||
+        documentRetryState.hardNextDelayMs != DOCUMENT_HARD_RETRY_INITIAL_MS ||
+        documentRetryState.lastReasonLogTime != 0) {
+        ReportSelfTestFailure(&success, L"document retry-state reset helper");
     }
 
     RuntimeUiCacheState uiCacheState = {};
@@ -6714,6 +11435,58 @@ bool RunOwnerThreadAndSchedulerSelfTests() {
 bool RunTickDecisionSelfTests() {
     bool success = true;
 
+    if (GetOwnerThreadSyncWatchdogDelay(true, true) !=
+            DOCUMENT_STATE_PENDING_WATCHDOG_MS ||
+        GetOwnerThreadSyncWatchdogDelay(false, true) !=
+            SAVE_INACTIVE_EVENT_WATCHDOG_MS ||
+        GetOwnerThreadSyncWatchdogDelay(false, false) !=
+            SAVE_INACTIVE_FALLBACK_WATCHDOG_MS) {
+        ReportSelfTestFailure(&success,
+                              L"owner-thread synchronization watchdog policy");
+    }
+
+    RuntimeTickSnapshot ownerMismatchDocumentTick = {};
+    ownerMismatchDocumentTick.runtime.wordEventsConnected = true;
+    TickDecision ownerMismatchDocumentDecision =
+        EvaluateDocumentStateTickDecision(ownerMismatchDocumentTick);
+    ownerMismatchDocumentTick.runtime.expeditedSaveRequested = true;
+    TickDecision criticalOwnerMismatchDocumentDecision =
+        EvaluateDocumentStateTickDecision(ownerMismatchDocumentTick);
+    if (ownerMismatchDocumentDecision.action !=
+            TickDecisionAction::RearmDocumentStateTimer ||
+        ownerMismatchDocumentDecision.state !=
+            RuntimeStatePhase::WaitingForOwnerThread ||
+        ownerMismatchDocumentDecision.delayMs !=
+            SAVE_INACTIVE_EVENT_WATCHDOG_MS ||
+        criticalOwnerMismatchDocumentDecision.action !=
+            TickDecisionAction::RearmDocumentStateTimer ||
+        criticalOwnerMismatchDocumentDecision.delayMs !=
+            DOCUMENT_STATE_PENDING_WATCHDOG_MS) {
+        ReportSelfTestFailure(&success,
+                              L"owner-mismatch document-state rearm");
+    }
+
+    RuntimeTickSnapshot ownerMismatchSaveTick = {};
+    ownerMismatchSaveTick.runtime.pendingSave = true;
+    TickDecision ownerMismatchSaveDecision =
+        EvaluateAutosaveTickDecision(ownerMismatchSaveTick);
+    ownerMismatchSaveTick.runtime.transitionFlushRequested = true;
+    TickDecision criticalOwnerMismatchSaveDecision =
+        EvaluateAutosaveTickDecision(ownerMismatchSaveTick);
+    if (ownerMismatchSaveDecision.action !=
+            TickDecisionAction::RearmSaveTimer ||
+        ownerMismatchSaveDecision.state !=
+            RuntimeStatePhase::WaitingForOwnerThread ||
+        ownerMismatchSaveDecision.delayMs !=
+            SAVE_INACTIVE_FALLBACK_WATCHDOG_MS ||
+        criticalOwnerMismatchSaveDecision.action !=
+            TickDecisionAction::RearmSaveTimer ||
+        criticalOwnerMismatchSaveDecision.delayMs !=
+            DOCUMENT_STATE_PENDING_WATCHDOG_MS) {
+        ReportSelfTestFailure(&success,
+                              L"owner-mismatch save rearm");
+    }
+
     RuntimeTickSnapshot pausedDocumentTick = {};
     pausedDocumentTick.runtime.ownerThreadSynchronized = true;
     pausedDocumentTick.runtime.pauseReason = WordUiPauseReason::MenuMode;
@@ -6721,8 +11494,60 @@ bool RunTickDecisionSelfTests() {
     TickDecision pausedDocumentDecision = EvaluateDocumentStateTickDecision(pausedDocumentTick);
     if (pausedDocumentDecision.action != TickDecisionAction::RearmDocumentStateTimer ||
         pausedDocumentDecision.state != RuntimeStatePhase::WaitingForWordUi ||
-        pausedDocumentDecision.delayMs != INPUT_SETTLE_DELAY_MS) {
+        pausedDocumentDecision.delayMs != SAVE_UI_INPUT_WATCHDOG_MS) {
         ReportSelfTestFailure(&success, L"paused document-state tick decision");
+    }
+
+    RuntimeTickSnapshot criticalPausedDocumentTick = pausedDocumentTick;
+    criticalPausedDocumentTick.runtime.expeditedSaveRequested = true;
+    TickDecision criticalPausedDocumentDecision =
+        EvaluateDocumentStateTickDecision(criticalPausedDocumentTick);
+    if (criticalPausedDocumentDecision.delayMs != INPUT_SETTLE_DELAY_MS) {
+        ReportSelfTestFailure(&success,
+                              L"critical paused document-state tick decision");
+    }
+
+    RuntimeTickSnapshot inactiveEventDocumentTick = {};
+    inactiveEventDocumentTick.runtime.ownerThreadSynchronized = true;
+    inactiveEventDocumentTick.runtime.wordEventsConnected = true;
+    inactiveEventDocumentTick.pendingSaveWork = true;
+    inactiveEventDocumentTick.steadyPollDelay =
+        DOCUMENT_STATE_ACTIVE_POLL_INTERVAL_MS;
+    TickDecision inactiveEventDocumentDecision =
+        EvaluateDocumentStateTickDecision(inactiveEventDocumentTick);
+    RuntimeTickSnapshot inactiveFallbackDocumentTick =
+        inactiveEventDocumentTick;
+    inactiveFallbackDocumentTick.runtime.wordEventsConnected = false;
+    TickDecision inactiveFallbackDocumentDecision =
+        EvaluateDocumentStateTickDecision(inactiveFallbackDocumentTick);
+    RuntimeTickSnapshot criticalInactiveDocumentTick =
+        inactiveEventDocumentTick;
+    criticalInactiveDocumentTick.runtime.expeditedSaveRequested = true;
+    TickDecision criticalInactiveDocumentDecision =
+        EvaluateDocumentStateTickDecision(criticalInactiveDocumentTick);
+    if (inactiveEventDocumentDecision.delayMs !=
+            SAVE_INACTIVE_EVENT_WATCHDOG_MS ||
+        inactiveFallbackDocumentDecision.delayMs !=
+            SAVE_INACTIVE_FALLBACK_WATCHDOG_MS ||
+        criticalInactiveDocumentDecision.delayMs !=
+            DOCUMENT_STATE_ACTIVE_POLL_INTERVAL_MS) {
+        ReportSelfTestFailure(&success,
+                              L"inactive document-state watchdog policy");
+    }
+
+    RuntimeTickSnapshot inputBusyDocumentTick = {};
+    inputBusyDocumentTick.runtime.ownerThreadSynchronized = true;
+    inputBusyDocumentTick.runtime.activeWordDocumentWindow = true;
+    inputBusyDocumentTick.runtime.inputBusy = true;
+    TickDecision inputBusyDocumentDecision =
+        EvaluateDocumentStateTickDecision(inputBusyDocumentTick);
+    inputBusyDocumentTick.runtime.transitionFlushRequested = true;
+    TickDecision criticalInputBusyDocumentDecision =
+        EvaluateDocumentStateTickDecision(inputBusyDocumentTick);
+    if (inputBusyDocumentDecision.delayMs != SAVE_UI_INPUT_WATCHDOG_MS ||
+        criticalInputBusyDocumentDecision.delayMs != INPUT_SETTLE_DELAY_MS) {
+        ReportSelfTestFailure(&success,
+                              L"document-state input watchdog policy");
     }
 
     RuntimeTickSnapshot readyDocumentTick = {};
@@ -6745,6 +11570,34 @@ bool RunTickDecisionSelfTests() {
     if (pendingUnknownDocumentDecision.action != TickDecisionAction::RefreshDocumentState ||
         pendingUnknownDocumentDecision.state != RuntimeStatePhase::ReadyToRefreshDocumentState) {
         ReportSelfTestFailure(&success, L"pending unknown-document tick decision");
+    }
+
+    RuntimeTickSnapshot pendingArmedInactiveDocumentTick = {};
+    pendingArmedInactiveDocumentTick.runtime.ownerThreadSynchronized = true;
+    pendingArmedInactiveDocumentTick.runtime.pendingSave = true;
+    pendingArmedInactiveDocumentTick.saveTaskArmed = true;
+    TickDecision pendingArmedInactiveDocumentDecision =
+        EvaluateDocumentStateTickDecision(pendingArmedInactiveDocumentTick);
+    if (pendingArmedInactiveDocumentDecision.action != TickDecisionAction::None ||
+        pendingArmedInactiveDocumentDecision.state !=
+            RuntimeStatePhase::WaitingForSaveDelay) {
+        ReportSelfTestFailure(&success,
+                              L"pending save suppresses blocked document polling");
+    }
+
+    RuntimeTickSnapshot pendingArmedReadyDocumentTick =
+        pendingArmedInactiveDocumentTick;
+    pendingArmedReadyDocumentTick.runtime.activeWordDocumentWindow = true;
+    pendingArmedReadyDocumentTick.flags.documentDirtyKnown = true;
+    pendingArmedReadyDocumentTick.flags.documentDirty = true;
+    TickDecision pendingArmedReadyDocumentDecision =
+        EvaluateDocumentStateTickDecision(pendingArmedReadyDocumentTick);
+    if (pendingArmedReadyDocumentDecision.action !=
+            TickDecisionAction::RefreshDocumentState ||
+        pendingArmedReadyDocumentDecision.state !=
+            RuntimeStatePhase::ReadyToRefreshDocumentState) {
+        ReportSelfTestFailure(&success,
+                              L"explicit one-shot refresh for pending document");
     }
 
     ScopedValueRestore<int> saveDelayRestore(&g_settings.saveDelay);
@@ -6783,6 +11636,43 @@ bool RunTickDecisionSelfTests() {
         ReportSelfTestFailure(&success, L"known-clean auto-save readiness");
     }
 
+    RuntimeTickSnapshot pausedSaveTick = unknownSaveTick;
+    pausedSaveTick.runtime.pauseReason = WordUiPauseReason::MenuMode;
+    TickDecision pausedSaveDecision = EvaluateAutosaveTickDecision(pausedSaveTick);
+    pausedSaveTick.runtime.transitionFlushRequested = true;
+    TickDecision criticalPausedSaveDecision =
+        EvaluateAutosaveTickDecision(pausedSaveTick);
+    if (pausedSaveDecision.delayMs != SAVE_UI_INPUT_WATCHDOG_MS ||
+        criticalPausedSaveDecision.delayMs != INPUT_SETTLE_DELAY_MS) {
+        ReportSelfTestFailure(&success, L"auto-save UI watchdog policy");
+    }
+
+    RuntimeTickSnapshot inactiveSaveTick = unknownSaveTick;
+    inactiveSaveTick.runtime.activeWordDocumentWindow = false;
+    inactiveSaveTick.runtime.wordEventsConnected = true;
+    TickDecision inactiveEventSaveDecision =
+        EvaluateAutosaveTickDecision(inactiveSaveTick);
+    inactiveSaveTick.runtime.wordEventsConnected = false;
+    TickDecision inactiveFallbackSaveDecision =
+        EvaluateAutosaveTickDecision(inactiveSaveTick);
+    if (inactiveEventSaveDecision.delayMs != SAVE_INACTIVE_EVENT_WATCHDOG_MS ||
+        inactiveFallbackSaveDecision.delayMs !=
+            SAVE_INACTIVE_FALLBACK_WATCHDOG_MS) {
+        ReportSelfTestFailure(&success, L"inactive auto-save watchdog policy");
+    }
+
+    RuntimeTickSnapshot inputBusySaveTick = unknownSaveTick;
+    inputBusySaveTick.runtime.inputBusy = true;
+    TickDecision inputBusySaveDecision =
+        EvaluateAutosaveTickDecision(inputBusySaveTick);
+    inputBusySaveTick.runtime.transitionFlushRequested = true;
+    TickDecision criticalInputBusySaveDecision =
+        EvaluateAutosaveTickDecision(inputBusySaveTick);
+    if (inputBusySaveDecision.delayMs != SAVE_UI_INPUT_WATCHDOG_MS ||
+        criticalInputBusySaveDecision.delayMs != INPUT_SETTLE_DELAY_MS) {
+        ReportSelfTestFailure(&success, L"auto-save input watchdog policy");
+    }
+
     ScopedValueRestore<int> minSaveIntervalRestore(&g_settings.minTimeBetweenSaves);
     ScopedValueRestore<ULONGLONG> lastSaveTimeRestore(&g_runtime.timing.lastSaveTime);
     ScopedValueRestore<ULONGLONG> transitionFlushRequestTimeRestore(
@@ -6814,6 +11704,8 @@ bool RunTickDecisionSelfTests() {
 
 bool RunInternalSelfTests() {
     bool success = true;
+    success = RunDispatchAndAutomationCacheSelfTests() && success;
+    success = RunHotPathAndMonitoringPolicySelfTests() && success;
     success = RunTimingAndFallbackSelfTests() && success;
     success = RunWordEventPolicySelfTests() && success;
     success = RunSnapshotPolicySelfTests() && success;
@@ -6821,6 +11713,7 @@ bool RunInternalSelfTests() {
     success = RunTickDecisionSelfTests() && success;
     return success;
 }
+#endif
 
 void ResetRuntimeTimingState(RuntimeTimingState* timing) {
     if (!timing) {
@@ -6838,8 +11731,6 @@ void ResetRuntimeTimingState(RuntimeTimingState* timing) {
     timing->lastEventConnectAttemptTime = 0;
     timing->lastTextInputKeyDownTime = 0;
     timing->pendingSaveAsTime = 0;
-    timing->saveRetryDelayMs = MIN_RETRY_INTERVAL_MS;
-    timing->documentStateRetryDelayMs = MIN_RETRY_INTERVAL_MS;
 }
 
 void ResetRuntimeStatusState(RuntimeStatusState* status) {
@@ -6872,17 +11763,20 @@ void ResetRuntimeState(RuntimeResetMode resetMode = RuntimeResetMode::Shutdown) 
     const bool preserveDeferredEventDisconnects =
         ShouldPreserveDeferredWordEventDisconnects(resetMode);
     CancelSchedulerTimer();
-    ClearOwnerThreadId();
     ResetRuntimeTimingState(&g_runtime.timing);
-    ResetRuntimeStatusState(&g_runtime.status);
-    ClearDispatchMemberIdCache();
+    ResetSaveRetryState();
+    ResetDocumentRetryState();
     DisconnectWordApplicationEvents(preserveDeferredEventDisconnects);
     if (preserveDeferredEventDisconnects) {
         RefreshPendingWordEventDisconnectRetryFlag();
     } else {
         DisconnectPendingWordEventDisconnectSessionsForShutdown();
     }
-    ClearAutomationBusyPending();
+    ResetRuntimeStatusState(&g_runtime.status);
+    ClearWordMemberIdCache();
+    ResetAutomationCacheState();
+    g_runtime.events.cachedDispIds.Reset();
+    g_runtime.events.cachedDispIdsValid = false;
     ClearPendingSaveAsMigration();
     ClearPendingSave();
     ClearExpeditedSavePending();
@@ -6894,39 +11788,437 @@ void ResetRuntimeState(RuntimeResetMode resetMode = RuntimeResetMode::Shutdown) 
     ClearFlag(g_runtime.flags.suppressNextCharacterInput);
     ResetObservedDocumentState();
     ResetRuntimeUiCacheState(&g_runtime.ui);
+    DestroySchedulerMessageWindow();
+    g_runtime.ownerWorkDepth = 0;
+    ClearOwnerThreadId();
 }
 
-void LoadSettings() {
-    g_settings.saveDelay = Wh_GetIntSetting(L"saveDelay");
-    g_settings.minTimeBetweenSaves = Wh_GetIntSetting(L"minTimeBetweenSaves");
+RuntimeSettings ReadValidatedSettings() {
+    RuntimeSettings settings = {};
+    settings.saveDelay = Wh_GetIntSetting(L"saveDelay");
+    settings.minTimeBetweenSaves = Wh_GetIntSetting(L"minTimeBetweenSaves");
 
-    if (g_settings.saveDelay < MIN_SAVE_DELAY_MS) {
-        g_settings.saveDelay = MIN_SAVE_DELAY_MS;
+    if (settings.saveDelay < MIN_SAVE_DELAY_MS) {
+        settings.saveDelay = MIN_SAVE_DELAY_MS;
     }
-    if (g_settings.saveDelay > MAX_SAVE_DELAY_MS) {
-        g_settings.saveDelay = MAX_SAVE_DELAY_MS;
+    if (settings.saveDelay > MAX_SAVE_DELAY_MS) {
+        settings.saveDelay = MAX_SAVE_DELAY_MS;
     }
-    if (g_settings.minTimeBetweenSaves < 0) {
-        g_settings.minTimeBetweenSaves = 0;
+    if (settings.minTimeBetweenSaves < 0) {
+        settings.minTimeBetweenSaves = 0;
     }
-    if (g_settings.minTimeBetweenSaves > MAX_MIN_TIME_BETWEEN_SAVES) {
-        g_settings.minTimeBetweenSaves = MAX_MIN_TIME_BETWEEN_SAVES;
+    if (settings.minTimeBetweenSaves > MAX_MIN_TIME_BETWEEN_SAVES) {
+        settings.minTimeBetweenSaves = MAX_MIN_TIME_BETWEEN_SAVES;
     }
 
+    return settings;
+}
+
+ULONGLONG PackRuntimeSettings(const RuntimeSettings& settings) {
+    const ULONGLONG saveDelay =
+        static_cast<ULONGLONG>(static_cast<DWORD>(settings.saveDelay));
+    const ULONGLONG minSaveInterval =
+        static_cast<ULONGLONG>(static_cast<DWORD>(settings.minTimeBetweenSaves));
+    return saveDelay | (minSaveInterval << 32);
+}
+
+RuntimeSettings UnpackRuntimeSettings(ULONGLONG packedSettings) {
+    RuntimeSettings settings = {};
+    settings.saveDelay =
+        static_cast<int>(static_cast<DWORD>(packedSettings & 0xFFFFFFFFull));
+    settings.minTimeBetweenSaves = static_cast<int>(
+        static_cast<DWORD>((packedSettings >> 32) & 0xFFFFFFFFull));
+    return settings;
+}
+
+ULONG PublishRuntimeSettings(const RuntimeSettings& settings) {
+    g_control.settingsSequence.fetch_add(1, std::memory_order_acq_rel);
+    g_control.packedSettings.store(PackRuntimeSettings(settings),
+                                   std::memory_order_relaxed);
+    const ULONG stableSequence =
+        g_control.settingsSequence.fetch_add(1, std::memory_order_release) + 1;
+    g_control.pendingRequests.fetch_or(RuntimeControlApplySettings,
+                                       std::memory_order_release);
+    return stableSequence;
+}
+
+RuntimeSettings ReadPublishedRuntimeSettings(ULONG* stableSequence) {
+    for (;;) {
+        const ULONG before =
+            g_control.settingsSequence.load(std::memory_order_acquire);
+        if (before & 1) {
+            SwitchToThread();
+            continue;
+        }
+
+        const ULONGLONG packed =
+            g_control.packedSettings.load(std::memory_order_relaxed);
+        const ULONG after =
+            g_control.settingsSequence.load(std::memory_order_acquire);
+        if (before == after && !(after & 1)) {
+            if (stableSequence) {
+                *stableSequence = after;
+            }
+            return UnpackRuntimeSettings(packed);
+        }
+    }
+}
+
+void ApplyRuntimeSettings(const RuntimeSettings& settings) {
+    g_settings = settings;
     Wh_Log(L"Settings: saveDelay=%d ms, minTimeBetweenSaves=%d ms",
-           g_settings.saveDelay, g_settings.minTimeBetweenSaves);
+           settings.saveDelay,
+           settings.minTimeBetweenSaves);
+}
+
+void ApplyPublishedSettingsOnOwnerThread() {
+    if (!IsOwnerThread() ||
+        g_control.shutdownRequested.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    ULONG stableSequence = 0;
+    const RuntimeSettings settings =
+        ReadPublishedRuntimeSettings(&stableSequence);
+    if (g_control.appliedSettingsSequence.load(std::memory_order_acquire) ==
+        stableSequence) {
+        return;
+    }
+
+    ApplyRuntimeSettings(settings);
+    g_control.appliedSettingsSequence.store(stableSequence,
+                                            std::memory_order_release);
+
+    // Re-evaluate current work immediately. This preserves the tracked
+    // document and Word event connection while correctly honoring both
+    // shorter and longer delays.
+    if (HasPendingAutosave()) {
+        RescheduleSaveTimer(1);
+    } else if (HasPendingSaveWork()) {
+        ArmDocumentStateTimer(1);
+    }
+}
+
+bool PostOwnerControlMessage() {
+    HWND messageWindow =
+        g_control.messageWindow.load(std::memory_order_acquire);
+    return messageWindow &&
+           IsWindow(messageWindow) &&
+           PostMessageW(messageWindow,
+                        WORD_LOCAL_AUTOSAVE_CONTROL_MESSAGE,
+                        0,
+                        0) != FALSE;
+}
+
+void QueueOwnerControlRequest(LONG request) {
+    g_control.pendingRequests.fetch_or(request, std::memory_order_release);
+    if (PostOwnerControlMessage()) {
+        return;
+    }
+
+    if (!(request & RuntimeControlShutdown)) {
+        // No owner exists yet. The already established bootstrap path will
+        // adopt one; the pending request itself remains in the control plane.
+        PostStartupBootstrapMessageToWordUi();
+    }
+}
+
+void SignalOwnerShutdownComplete() {
+    g_control.ownerRuntimeLive.store(false, std::memory_order_release);
+    g_control.lifecycle.store(RuntimeControlStopped,
+                              std::memory_order_release);
+
+    LONG expectedOutcome = RuntimeShutdownPending;
+    g_control.shutdownOutcome.compare_exchange_strong(
+        expectedOutcome,
+        RuntimeShutdownCompleted,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire);
+
+    HANDLE shutdownCompleteEvent = g_control.shutdownCompleteEvent;
+    if (shutdownCompleteEvent) {
+        SetEvent(shutdownCompleteEvent);
+    }
+    // Publish completion only after the owner has finished its final use of
+    // the management-owned event handle.
+    g_control.shutdownComplete.store(true, std::memory_order_release);
+}
+
+void ShutdownRuntimeOnOwnerThread() {
+    if (!IsOwnerThread() ||
+        g_runtime.ownerWorkDepth != 0 ||
+        g_runtime.shutdownInProgress) {
+        return;
+    }
+
+    g_runtime.shutdownInProgress = true;
+    ClearFlag(g_runtime.flags.moduleActive);
+    CancelSchedulerTimer();
+
+    if (!TryDisconnectAllWordEventsForOwnerShutdown()) {
+        // Keep every connection-point and sink reference in its owner STA.
+        // The management thread will repost the pointer-free control wake;
+        // only a completed/terminal Unadvise may advance to module unload.
+        g_runtime.shutdownInProgress = false;
+        g_control.pendingRequests.fetch_or(RuntimeControlShutdown,
+                                           std::memory_order_release);
+        return;
+    }
+
+    // ResetRuntimeState now releases event sessions and document COM state
+    // before clearing the owner id, destroys the private window on this same
+    // thread, and leaves no callback-based timer behind.
+    ResetRuntimeState(RuntimeResetMode::Shutdown);
+    SignalOwnerShutdownComplete();
+}
+
+void ProcessOwnerControlRequests() {
+    if (!IsOwnerThread() ||
+        g_runtime.ownerWorkDepth != 0 ||
+        g_runtime.shutdownInProgress) {
+        return;
+    }
+
+    const LONG requests =
+        g_control.pendingRequests.exchange(0, std::memory_order_acq_rel);
+    if (g_control.shutdownRequested.load(std::memory_order_acquire) ||
+        (requests & RuntimeControlShutdown)) {
+        ShutdownRuntimeOnOwnerThread();
+        return;
+    }
+
+    if (requests & RuntimeControlApplySettings) {
+        ApplyPublishedSettingsOnOwnerThread();
+    }
+
+    if ((requests & RuntimeControlRepairScheduler) &&
+        !RefreshSchedulerTimer() &&
+        GetNextScheduledTaskDueTime() != 0) {
+        // Keep the repair request pending without posting an unbounded stream
+        // of control messages if USER32 is temporarily unable to create a timer.
+        // The next owner-side relevant message or control wake will retry it.
+        g_control.pendingRequests.fetch_or(RuntimeControlRepairScheduler,
+                                           std::memory_order_release);
+    }
+}
+
+bool PinCurrentModuleForSafeShutdownFallback() {
+    if (g_control.modulePinnedForSafety.load(std::memory_order_acquire)) {
+        return true;
+    }
+
+    HMODULE module = nullptr;
+    const auto moduleAddress =
+        reinterpret_cast<LPCWSTR>(static_cast<const void*>(&g_control));
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                GET_MODULE_HANDLE_EX_FLAG_PIN,
+                            moduleAddress,
+                            &module)) {
+        Wh_Log(L"Shutdown: failed to pin the module for the safety fallback, error=%lu",
+               GetLastError());
+        return false;
+    }
+
+    g_control.modulePinnedForSafety.store(true, std::memory_order_release);
+    Wh_Log(L"Shutdown: teardown could not be proven safe; the inactive module was pinned "
+           L"until process exit to keep outstanding COM callbacks safe");
+    return true;
+}
+
+void QuiesceWindowRuntimeForPinnedShutdown() {
+    ClearFlag(g_runtime.flags.moduleActive);
+
+    HWND messageWindow =
+        g_control.messageWindow.load(std::memory_order_acquire);
+    if (!messageWindow) {
+        return;
+    }
+
+    // A window-associated timer can be cancelled by HWND/ID without touching
+    // any COM state. WM_CLOSE is handled by the system STATIC window procedure
+    // on its owner thread even after the TranslateMessage hook is removed.
+    KillTimer(messageWindow, SCHEDULER_WINDOW_TIMER_ID);
+    PostMessageW(messageWindow, WM_CLOSE, 0, 0);
+}
+
+bool TryClaimPinnedShutdownFallback() {
+    LONG expectedOutcome = RuntimeShutdownPending;
+    if (!g_control.shutdownOutcome.compare_exchange_strong(
+            expectedOutcome,
+            RuntimeShutdownFallbackClaimed,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
+        return expectedOutcome == RuntimeShutdownFallbackClaimed &&
+               g_control.modulePinnedForSafety.load(std::memory_order_acquire);
+    }
+
+    QuiesceWindowRuntimeForPinnedShutdown();
+    if (PinCurrentModuleForSafeShutdownFallback()) {
+        return true;
+    }
+
+    if (g_control.shutdownComplete.load(std::memory_order_acquire)) {
+        return false;
+    }
+
+    expectedOutcome = RuntimeShutdownFallbackClaimed;
+    g_control.shutdownOutcome.compare_exchange_strong(
+        expectedOutcome,
+        RuntimeShutdownPending,
+        std::memory_order_acq_rel,
+        std::memory_order_acquire);
+    return false;
+}
+
+bool RequestOwnerShutdownAndWait() {
+    if (g_control.shutdownComplete.load(std::memory_order_acquire)) {
+        return true;
+    }
+
+    g_control.shutdownRequested.store(true, std::memory_order_release);
+
+    const LONG previousLifecycle =
+        g_control.lifecycle.exchange(RuntimeControlStopRequested,
+                                     std::memory_order_acq_rel);
+
+    ClearFlag(g_runtime.flags.moduleActive);
+    g_control.pendingRequests.fetch_or(RuntimeControlShutdown,
+                                       std::memory_order_release);
+
+    if (g_control.shutdownOutcome.load(std::memory_order_acquire) ==
+            RuntimeShutdownFallbackClaimed &&
+        g_control.modulePinnedForSafety.load(std::memory_order_acquire)) {
+        return false;
+    }
+
+    if ((previousLifecycle == RuntimeControlAwaitingOwner ||
+         previousLifecycle == RuntimeControlStopped) &&
+        !g_control.ownerRuntimeLive.load(std::memory_order_acquire) &&
+        LoadOwnerThreadId() == 0) {
+        SignalOwnerShutdownComplete();
+        return true;
+    }
+
+    HANDLE shutdownCompleteEvent = g_control.shutdownCompleteEvent;
+
+    if (IsOwnerThread()) {
+        ProcessOwnerControlRequests();
+    } else {
+        PostOwnerControlMessage();
+    }
+
+    const ULONGLONG waitStartTime = GetTickCount64();
+    unsigned int timeoutCount = 0;
+    for (;;) {
+        const DWORD waitResult = shutdownCompleteEvent
+                                     ? WaitForSingleObject(
+                                           shutdownCompleteEvent,
+                                           OWNER_SHUTDOWN_WAKE_INTERVAL_MS)
+                                     : WAIT_TIMEOUT;
+        if (waitResult == WAIT_OBJECT_0) {
+            return true;
+        }
+
+        if (waitResult == WAIT_FAILED) {
+            Wh_Log(L"Shutdown: waiting for the owner thread failed, error=%lu",
+                   GetLastError());
+        } else if (!shutdownCompleteEvent) {
+            Sleep(OWNER_SHUTDOWN_WAKE_INTERVAL_MS);
+        }
+
+        // A modal Word loop may consume an earlier wake without calling
+        // TranslateMessage. Reposting is idempotent and carries no pointer.
+        PostOwnerControlMessage();
+        ++timeoutCount;
+        if (timeoutCount % 50 == 0) {
+            Wh_Log(L"Shutdown: still waiting for owner-thread COM teardown");
+        }
+
+        const ULONGLONG now = GetTickCount64();
+        const bool fallbackRequired =
+            waitResult == WAIT_FAILED ||
+            g_control.requiresPinnedShutdown.load(std::memory_order_acquire) ||
+            (now >= waitStartTime &&
+             now - waitStartTime >= OWNER_SHUTDOWN_FAILSAFE_TIMEOUT_MS);
+        if (fallbackRequired) {
+            if (g_control.shutdownComplete.load(std::memory_order_acquire) ||
+                (shutdownCompleteEvent &&
+                 WaitForSingleObject(shutdownCompleteEvent, 0) == WAIT_OBJECT_0)) {
+                return true;
+            }
+
+            if (TryClaimPinnedShutdownFallback()) {
+                return false;
+            }
+        }
+    }
 }
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"Word Local AutoSave v3.8 initializing...");
+    Wh_Log(L"Word Local AutoSave v4.0.0 initializing...");
+
+    const bool residentPinned =
+        g_control.modulePinnedForSafety.load(std::memory_order_acquire);
+    if (residentPinned &&
+        !g_control.shutdownComplete.load(std::memory_order_acquire)) {
+        Wh_Log(L"ERROR: Refusing to reinitialize while the previous pinned runtime "
+               L"is still active; restart Word first");
+        return FALSE;
+    }
+
+    if (g_control.shutdownCompleteEvent) {
+        CloseHandle(g_control.shutdownCompleteEvent);
+        g_control.shutdownCompleteEvent = nullptr;
+    }
+
+    g_control.pendingRequests.store(0, std::memory_order_relaxed);
+    g_control.lifecycle.store(RuntimeControlAwaitingOwner,
+                              std::memory_order_relaxed);
+    g_control.settingsSequence.store(0, std::memory_order_relaxed);
+    g_control.appliedSettingsSequence.store(0, std::memory_order_relaxed);
+    g_control.packedSettings.store(0, std::memory_order_relaxed);
+    g_control.messageWindow.store(nullptr, std::memory_order_relaxed);
+    g_control.ownerRuntimeLive.store(false, std::memory_order_relaxed);
+    g_control.shutdownRequested.store(false, std::memory_order_relaxed);
+    g_control.shutdownComplete.store(false, std::memory_order_relaxed);
+    g_control.shutdownOutcome.store(RuntimeShutdownPending,
+                                    std::memory_order_relaxed);
+    g_control.requiresPinnedShutdown.store(false,
+                                           std::memory_order_relaxed);
 
     g_runtime.wordProcessId = GetCurrentProcessId();
     ResetRuntimeState(RuntimeResetMode::Shutdown);
+#ifdef WH_STANDALONE_COMPILE_CHECK
     const bool internalSelfTestsPassed = RunInternalSelfTests();
     ResetRuntimeState(RuntimeResetMode::Shutdown);
-    LoadSettings();
+#endif
+    g_runtime.shutdownInProgress = false;
+
+    const RuntimeSettings initialSettings = ReadValidatedSettings();
+    const ULONG initialSettingsSequence =
+        PublishRuntimeSettings(initialSettings);
+    ApplyRuntimeSettings(initialSettings);
+    g_control.appliedSettingsSequence.store(initialSettingsSequence,
+                                            std::memory_order_relaxed);
+    g_control.pendingRequests.fetch_and(~RuntimeControlApplySettings,
+                                        std::memory_order_relaxed);
+#ifdef WH_STANDALONE_COMPILE_CHECK
     if (!internalSelfTestsPassed) {
         Wh_Log(L"WARNING: One or more internal self-tests failed");
+    }
+#endif
+
+    ScopedHandle shutdownCompleteEvent(
+        CreateEventW(nullptr, TRUE, FALSE, nullptr));
+    if (!shutdownCompleteEvent.IsValid()) {
+        Wh_Log(L"ERROR: Failed to create owner shutdown event, error=%lu",
+               GetLastError());
+        return FALSE;
+    }
+
+    if (EnsureStartupBootstrapMessage() == 0) {
+        Wh_Log(L"ERROR: Failed to register startup bootstrap message");
+        return FALSE;
     }
 
     HMODULE user32 = GetModuleHandleW(L"user32.dll");
@@ -6953,6 +12245,7 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
+    g_control.shutdownCompleteEvent = shutdownCompleteEvent.Detach();
     SetFlag(g_runtime.flags.moduleActive);
     PostStartupBootstrapMessageToWordUi();
 
@@ -6960,18 +12253,38 @@ BOOL Wh_ModInit() {
     return TRUE;
 }
 
+void Wh_ModBeforeUninit() {
+    Wh_Log(L"Word Local AutoSave preparing owner-thread teardown...");
+    if (!RequestOwnerShutdownAndWait()) {
+        Wh_Log(L"ERROR: Owner-thread teardown handshake failed");
+    }
+}
+
 void Wh_ModUninit() {
     Wh_Log(L"Word Local AutoSave uninitializing...");
 
     ClearFlag(g_runtime.flags.moduleActive);
-    ResetRuntimeState(RuntimeResetMode::Shutdown);
+    if (!g_control.shutdownComplete.load(std::memory_order_acquire) &&
+        !RequestOwnerShutdownAndWait()) {
+        Wh_Log(L"ERROR: Owner-thread runtime was not fully torn down");
+    }
+
+    if (g_control.shutdownCompleteEvent &&
+        (g_control.shutdownComplete.load(std::memory_order_acquire) ||
+         !g_control.modulePinnedForSafety.load(std::memory_order_acquire))) {
+        CloseHandle(g_control.shutdownCompleteEvent);
+        g_control.shutdownCompleteEvent = nullptr;
+    }
 
     Wh_Log(L"Word Local AutoSave uninitialized");
 }
 
 void Wh_ModSettingsChanged() {
-    Wh_Log(L"Settings changed, reloading...");
-    ResetRuntimeState(RuntimeResetMode::Reload);
-    LoadSettings();
-    PostStartupBootstrapMessageToWordUi();
+    if (g_control.shutdownRequested.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    Wh_Log(L"Settings changed, publishing to the owner thread...");
+    PublishRuntimeSettings(ReadValidatedSettings());
+    QueueOwnerControlRequest(RuntimeControlApplySettings);
 }


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

### Overview

Version 4.0.0 is a major internal performance and reliability rewrite. It reduces background activity during normal editing and idle periods, improves recovery from Word/COM failures, and makes event connection, document tracking, Save As handling, reload, and shutdown significantly safer.

The core behavior remains unchanged: the mod listens for Word activity and saves through Word’s native `Document.Save` method.

## Added

- A unified background scheduler based on one message-only window and one physical `WM_TIMER`.
- Adaptive monitoring intervals based on the current runtime state.
- Reason-specific retry and backoff policies for:
  - Busy Word automation
  - Disconnected COM objects
  - Temporary document unavailability
  - Hard COM failures
  - Protected View
  - Modal Word interfaces
  - Active keyboard, mouse, and IME input
  - Inactive Word windows
- Separate COM retry profiles:
  - A short background profile for normal monitoring
  - A longer critical profile for document closing and lifecycle transitions
- Caching for:
  - Word Application
  - Active Document
  - COM object identities
  - Document paths and metadata
  - Word window handles and UI threads
  - Word property and method `DISPID` values
  - Word event `DISPID` values
- Generation and epoch tracking for cached objects, document transitions, settings, and event sessions.
- Deferred and retried Word event disconnection when `Unadvise` cannot be completed immediately.
- Internal standalone tests for scheduling, retries, COM ownership, reentrancy, event lifecycle, path handling, NativeOM fallback, and `VARIANT` conversions.

The internal test framework is excluded entirely from production builds.

## Scheduler and background activity

- Replaced separate timers and timer callbacks with one centralized scheduler.
- Word events are now treated as the primary activity signal.
- Polling remains only as a watchdog and fallback mechanism.
- Monitoring frequency now adapts to the current situation:

| Runtime condition | Monitoring interval |
|---|---:|
| Word events connected, no pending work | 30 seconds | | Word events unavailable | 1.5 seconds |
| Pending or critical work | Up to 1.5 seconds |
| Active critical or UI transition | Down to 350 milliseconds | | Inactive Word with working events | 30 seconds | | Inactive Word without events | 5 seconds |
| Modal UI or unfinished input watchdog | 2 seconds | | Event reconnection or deferred disconnection | 2 seconds | | Save As migration timeout | 15 seconds |

- Ordinary input and boundary messages no longer shorten unrelated long retry deadlines.
- A signal can accelerate a retry only when it is relevant to the reason the operation is waiting.
- An owner-thread mismatch no longer consumes an already-due scheduled task.
- Stale queued `WM_TIMER` messages can no longer cancel a newer timer deadline.
- Reload and shutdown now safely transfer or stop scheduler ownership.

## Word event handling

- Reworked the existing native Word event integration into a transactional connection model.
- Event sessions are built separately and published only after the complete connection succeeds.
- A failed or reentrant connection attempt cannot overwrite a newer valid session.
- Existing support for the following events is retained and hardened:
  - `DocumentBeforeSave`
  - `DocumentBeforeClose`
  - `DocumentChange`
  - `WindowActivate`
  - `WindowDeactivate`
- Event reconnection is automatically scheduled after a temporary failure.
- An event connection is retained until `Unadvise` is confirmed successful.
- Failed disconnects are queued and retried later.
- A live advised event sink is no longer discarded if the deferred-disconnect queue is temporarily full.
- Retained connections automatically retry disconnection when capacity becomes available.
- Event sinks can be deactivated before final COM release.
- Shutdown performs bounded `Unadvise` retries instead of abandoning a connection immediately.
- Active event callbacks are allowed to drain safely during shutdown.
- Reentrant `AddRef`, `Release`, `Invoke`, `Unadvise`, reset, and session replacement are handled safely.

## Save and document tracking

- The existing direct `Document.Save` implementation is preserved.
- Saving now runs through one stable owner STA thread.
- The currently bound document object is reused whenever it is still valid.
- Document matching now prefers COM identity instead of repeatedly comparing filesystem paths.
- Active-document identity and metadata are published as one consistent snapshot.
- Cached document information is invalidated when:
  - The active document changes
  - The active Word window changes
  - A document closes
  - Save As begins or completes
  - Word reports an external save
  - A terminal COM error occurs
- A successful snapshot of an unexpected document no longer incorrectly clears retry state for the expected document.
- The time of the last actual save is now maintained separately from retry-state resets.
- Temporary loss of the target document no longer causes an immediate permanent failure.
- Pending autosaves are preserved while Word is:
  - Temporarily busy
  - Showing a modal dialog
  - Processing IME input
  - Receiving keyboard or mouse input
  - Inactive
  - Switching owner threads
  - Temporarily unable to expose the target document

## Save As handling

- Strengthened the existing Save As tracking and migration logic.
- External save operations now invalidate the cached path before the document is evaluated again.
- Programmatic `SaveAs` and `SaveAs2` operations are detected even when `SaveAsUI` is `false`.
- Save As transitions are tied to the document’s COM identity and generation.
- Stale Save As results cannot be applied to a newer document state.
- Incomplete Save As transitions expire safely after 15 seconds.
- Path and identity caches are refreshed after the migration completes.

## COM performance

- Repeated Word property and method resolution now uses typed `DISPID` caches.
- `GetIDsOfNames` is no longer executed repeatedly in normal operation.
- If a cached member returns `DISP_E_MEMBERNOTFOUND`, the member is resolved again once and the call is safely retried.
- Generic NativeOM fallback chains remain uncached because their object types may vary.
- Word Application acquisition now tries, in order:
  1. The active Word window
  2. The current event session
  3. The Running Object Table
- Every acquired Application object is verified as belonging to the current Word process.
- Repeated Word Application and active Document discovery has been removed from steady-state processing.
- Terminal COM errors invalidate only the affected cached state.
- Composite COM state is published atomically so another call cannot observe mismatched document and identity values.

## Retry and recovery behavior

Retries now depend on the failure reason instead of using a single generic delay.

| Failure type | Retry range |
|---|---:|
| Word automation busy | 125 ms → 5 seconds |
| Document automation busy | 125 ms → 5 seconds |
| Disconnected object | 250 ms → 5 seconds |
| Target temporarily unavailable | 250 ms → 5 seconds | | Hard COM failure | 2 seconds → 30 seconds |
| Protected View | 10 seconds |

- Background COM calls use a retry budget of approximately 1 second with 100-millisecond intervals.
- Critical close and lifecycle operations can retry for up to approximately 10 seconds with 150-millisecond intervals.
- Retry delays increase gradually and remain bounded.
- Relevant activity can wake an operation early without resetting unrelated backoff state.
- Repeated retry and COM error messages are rate-limited to prevent log flooding.

## Input hot-path optimization

- Added an immediate fast path to the `TranslateMessage` hook.
- Irrelevant messages are passed directly to Word without:
  - Window discovery
  - Word Application discovery
  - Document discovery
  - COM calls
  - Filesystem access
  - Scheduler bookkeeping
- The normal hot path performs only a lightweight pending-state check.
- `LastError` preservation is performed only when the mod actually handles a relevant message.
- Keyboard modifiers are queried once and only for potentially relevant keys.
- Duplicate scheduling from the corresponding `WM_KEYDOWN` and `WM_CHAR` pair has been eliminated.
- Mouse, keyboard, and IME state checks are performed only when they can affect a pending save.

## Path handling

- Filesystem path canonicalization has been removed from normal editing and monitoring paths.
- The steady-state path comparison is now lexical.
- `CreateFileW` and `GetFinalPathNameByHandleW` are used only for rare ambiguous specific-path resolution.
- Fixed-size path assumptions were replaced with growable buffers.
- Buffers can grow safely up to the supported Win32 path limit.
- Added capacity and integer-overflow checks when constructing or expanding paths.
- Corrected handling of boundary-sized path results.

## `VARIANT`, `BSTR`, and dispatch optimization

- Common Word values are extracted directly from:
  - `VT_BOOL`
  - `VT_I4`
  - `VT_I8`
  - `VT_BSTR`
  - `VT_DISPATCH`
- `VariantChangeType` is now used only as a fallback.
- Removed unnecessary BSTR copying and temporary allocation.
- Ownership can be transferred directly from a `VARIANT` where safe.
- Conversion retries always use a fresh destination `VARIANT`.
- Results are cleared before retrying a call with a newly resolved `DISPID`.

## Fixed

- Fixed pending autosaves being lost when Word temporarily returned an automation-busy error.
- Fixed pending work being cleared during modal Word UI, active input, IME composition, window deactivation, or temporary target loss.
- Fixed document enumeration returning a false “not found” result when a real COM failure occurred.
- Document enumeration now preserves and returns the first hard failure if no matching document is found.
- Fixed NativeOM fallback stopping too early after a non-terminal property failure.
- Expected missing NativeOM properties are now treated as normal misses.
- Non-terminal hard errors are remembered while other property chains continue to be checked.
- Busy and disconnected NativeOM results are still returned immediately.
- Fixed long hard-error and target-unavailable retries being repeatedly shortened by normal message activity.
- Fixed owner-thread changes consuming scheduled work.
- Fixed stale timer messages cancelling later deadlines.
- Fixed stale active-document caches surviving window changes, closes, Save As, or terminal COM errors.
- Fixed older event sessions overwriting newer sessions during reentrant COM calls.
- Fixed COM pointers being released before their published state was safely cleared.
- Fixed failed `Unadvise` calls causing live event connections to be forgotten.
- Fixed potential event-sink loss when deferred-disconnect storage was temporarily unavailable.
- Fixed a possible `VARIANT` result leak when a stale `DISPID` returned `DISP_E_MEMBERNOTFOUND`.
- Fixed potential double release of transferred `VT_DISPATCH` values.
- Fixed potential double free of transferred `VT_BSTR` values.
- Fixed reuse of a partially modified conversion destination after `VariantChangeType` failed.
- Fixed inconsistent observation of document pointer, document identity, transition target, event session, and cache generation.
- Fixed sign-extended 32-bit Word window handles being interpreted incorrectly in a 64-bit Word process.
- Fixed possible length and capacity overflow while building paths.
- Fixed shutdown and reload races involving active COM callbacks.
- Added a module-pinning fail-safe when callback detachment cannot be proven safe within the shutdown deadline.

## Removed from performance-critical paths

- Multiple independent physical timers.
- Frequent polling while Word events are connected and the runtime is idle.
- Repeated Word Application discovery.
- Repeated active-document discovery.
- Repeated `GetIDsOfNames` calls.
- Routine filesystem I/O during normal typing.
- Unnecessary BSTR allocations and copies.
- Unnecessary `VARIANT` conversions.
- Repeated modifier-key queries.
- Duplicate edit scheduling from related keyboard messages.
- Unrestricted repetitive retry logging.

## Compatibility

- User settings remain unchanged:
  - `saveDelay`
  - `minTimeBetweenSaves`
- Both settings retain their previous meaning.
- The mod still saves through Word’s native `Document.Save`.
- Existing Word event and Save As behavior remains supported.

## Validation

Version 4.0.0 was validated with:

- Strict Clang compilation with warnings treated as errors
- `clang-cl` `/W4 /WX` compilation
- Static analyzer checks
- Linked standalone internal tests
- Production preprocessing checks confirming that the self-test framework is absent from the release build
## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
