### PR TITLE
[Auto Custom Titlebar Colors]: Smart ignore UWP Apps and browser windows with settings caching

### DIFF
--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -48,9 +48,9 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
 // ==WindhawkModSettings==
 /*
 - customColours:
-  - light: false
+  - light: true
     $name: "Light Mode"
-  - dark: false
+  - dark: true
     $name: "Dark Mode"
   $name: "Custom Colours"
 
@@ -85,6 +85,16 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
     $name: "Use Hex Input"
     $description: "When on, use RRGGBB hex strings. When off, use separate R/G/B fields."
   - activeColour:
+    - hex: "000000"
+      $name: "Hex (RRGGBB)"
+    - r: 0
+      $name: "R (0-255)"
+    - g: 0
+      $name: "G (0-255)"
+    - b: 0
+      $name: "B (0-255)"
+    $name: "Active Window"
+  - inactiveColour:
     - hex: "202020"
       $name: "Hex (RRGGBB)"
     - r: 32
@@ -92,16 +102,6 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
     - g: 32
       $name: "G (0-255)"
     - b: 32
-      $name: "B (0-255)"
-    $name: "Active Window"
-  - inactiveColour:
-    - hex: "323232"
-      $name: "Hex (RRGGBB)"
-    - r: 50
-      $name: "R (0-255)"
-    - g: 50
-      $name: "G (0-255)"
-    - b: 50
       $name: "B (0-255)"
     $name: "Inactive Window"
   $name: "Dark Mode Colours"
@@ -170,6 +170,9 @@ static std::mutex g_appDarkModeMutex;
 
 static std::unordered_set<HWND> g_appliedWindows;
 static std::mutex g_appliedMutex;
+
+static std::unordered_set<HWND> g_appliedCustomColorWindows;
+static std::mutex g_appliedCustomColorMutex;
 
 // -----------------------------------------------------------------------------
 // Dark mode detection
@@ -330,10 +333,10 @@ static void LoadSettings()
     BOOL useHexDark = (BOOL)Wh_GetIntSetting(L"darkMode.useHex");
     if (useHexDark) {
         WindhawkUtils::StringSetting hexActive = WindhawkUtils::StringSetting::make(L"darkMode.activeColour.hex");
-        if (!HexToColorref(hexActive.get(), &g_settings.activeDark)) g_settings.activeDark = RGB(32, 32, 32);
+        if (!HexToColorref(hexActive.get(), &g_settings.activeDark)) g_settings.activeDark = RGB(0, 0, 0);
 
         WindhawkUtils::StringSetting hexInactive = WindhawkUtils::StringSetting::make(L"darkMode.inactiveColour.hex");
-        if (!HexToColorref(hexInactive.get(), &g_settings.inactiveDark)) g_settings.inactiveDark = RGB(50, 50, 50);
+        if (!HexToColorref(hexInactive.get(), &g_settings.inactiveDark)) g_settings.inactiveDark = RGB(32, 32, 32);
     } else {
         g_settings.activeDark = RGB(
             (BYTE)std::clamp((int)Wh_GetIntSetting(L"darkMode.activeColour.r"), 0, 255),
@@ -386,6 +389,12 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL allowCacheUpdate = TRUE
         }
         if (!wasApplied) return;
 
+        bool hadCustomColor;
+        {
+            std::lock_guard<std::mutex> lock(g_appliedCustomColorMutex);
+            hadCustomColor = g_appliedCustomColorWindows.erase(hWnd) != 0;
+        }
+
         BOOL dark = FALSE;
         {
             std::lock_guard<std::mutex> lockDark(g_appDarkModeMutex);
@@ -401,7 +410,7 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL allowCacheUpdate = TRUE
 
         InModGuard guard;
         DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(dark));
-        if (!appOwnsColour) {
+        if (!appOwnsColour && hadCustomColor) {
             const COLORREF def = DWMWA_COLOR_DEFAULT;
             DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
         }
@@ -433,23 +442,34 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL allowCacheUpdate = TRUE
     COLORREF colour;
     {
         std::lock_guard<std::mutex> lock(g_settingsMutex);
-        useCustom = g_isDarkMode ? g_settings.useCustomDark : g_settings.useCustomLight;
-        colour = g_isDarkMode 
+        useCustom = darkMode ? g_settings.useCustomDark : g_settings.useCustomLight;
+        colour = darkMode 
             ? (isActive ? g_settings.activeDark : g_settings.inactiveDark)
             : (isActive ? g_settings.activeLight : g_settings.inactiveLight);
     }
 
     if (useCustom) {
+        {
+            std::lock_guard<std::mutex> lock(g_appliedCustomColorMutex);
+            g_appliedCustomColorWindows.insert(hWnd);
+        }
         DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR,
             &colour, sizeof(colour));
         Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=#%02X%02X%02X",
-            hWnd, (BOOL)g_isDarkMode, isActive,
+            hWnd, darkMode, isActive,
             GetRValue(colour), GetGValue(colour), GetBValue(colour));
     } else {
-        const COLORREF def = DWMWA_COLOR_DEFAULT;
-        DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
-        Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=DEFAULT",
-            hWnd, (BOOL)g_isDarkMode, isActive);
+        bool hadCustomColor;
+        {
+            std::lock_guard<std::mutex> lock(g_appliedCustomColorMutex);
+            hadCustomColor = g_appliedCustomColorWindows.erase(hWnd) != 0;
+        }
+        if (hadCustomColor) {
+            const COLORREF def = DWMWA_COLOR_DEFAULT;
+            DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+            Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=DEFAULT",
+                hWnd, darkMode, isActive);
+        }
     }
 }
 
@@ -497,6 +517,10 @@ static VOID HandleWindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
             {
                 std::lock_guard<std::mutex> lock(g_appliedMutex);
                 g_appliedWindows.erase(hWnd);
+            }
+            {
+                std::lock_guard<std::mutex> lock(g_appliedCustomColorMutex);
+                g_appliedCustomColorWindows.erase(hWnd);
             }
             break;
         }
@@ -737,12 +761,18 @@ VOID Wh_ModUninit()
 {
     Wh_Log(L"[PID %d] Uninit - restoring system defaults", GetCurrentProcessId());
 
-    // Swap out the applied set atomically, then iterate over the captured snapshot.
-    // This avoids holding g_appliedMutex across DWM calls (cross-process, potentially slow).
+    // Swap out the applied sets atomically, then iterate over the captured snapshot.
+    // This avoids holding mutexes across DWM calls (cross-process, potentially slow).
     std::unordered_set<HWND> applied;
     {
         std::lock_guard<std::mutex> lock(g_appliedMutex);
         applied.swap(g_appliedWindows);
+    }
+
+    std::unordered_set<HWND> appliedCustomColors;
+    {
+        std::lock_guard<std::mutex> lock(g_appliedCustomColorMutex);
+        appliedCustomColors.swap(g_appliedCustomColorWindows);
     }
 
     for (HWND hWnd : applied) {
@@ -761,9 +791,11 @@ VOID Wh_ModUninit()
             appOwnsColour = g_appControlledWindows.count(hWnd) != 0;
         }
 
+        bool hadCustomColor = appliedCustomColors.count(hWnd) != 0;
+
         InModGuard guard;
         DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(dark));
-        if (!appOwnsColour) {
+        if (!appOwnsColour && hadCustomColor) {
             const COLORREF def = DWMWA_COLOR_DEFAULT;
             DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
         }

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -7,6 +7,11 @@
 // @github          https://github.com/Louis047
 // @include         *
 // @exclude         devenv.exe
+// @exclude         systemsettings.exe
+// @exclude         applicationframehost.exe
+// @exclude         startmenuexperiencehost.exe
+// @exclude         searchhost.exe
+// @exclude         shellexperiencehost.exe
 // @compilerOptions -ldwmapi -luser32
 // ==/WindhawkMod==
 
@@ -39,8 +44,9 @@ Combines automatic dark/light titlebar switching with per-mode, per-state custom
 Custom colours are only applied when the corresponding "Use Custom Colours" toggle is enabled.
 
 ## Notes
-- UWP/WinUI windows (`ApplicationFrameWindow`, WinUI 3, XAML islands) are automatically detected and skipped to avoid conflicts
-- Windows whose caption colour is set by the application itself have that colour left untouched; only the dark/light mode is kept in sync
+- Custom colours are enabled by default in v1.2.0 (`#FFFFFF`/`#E6E6E6` for light mode, `#000000`/`#202020` for dark mode)
+- UWP/WinUI windows (`ApplicationFrameWindow`, WinUI 3, XAML islands) and core shell hosts are automatically skipped to avoid conflicts
+- Windows whose caption colour is set by the application itself while the mod is loaded have that colour left untouched; only the dark/light mode is kept in sync
 - Visual attributes apply seamlessly on window activation and theme changes
 */
 // ==/WindhawkModReadme==

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -38,9 +38,7 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
 
 ## Notes
 - UWP/WinUI windows and Mozilla-based browsers are now auto-detected and skipped
-- Window redraws are debounced (50ms minimum) to prevent interference with window managers
-- Visual redraws (SetWindowPos) only occur during window activation, not deactivation, to avoid focus-grabbing issues with tiling window managers
-- No forced repaint is issued while a mouse button is held (prevents drag-state corruption)
+- Visual attributes (`DWMWA_CAPTION_COLOR` and `DWMWA_USE_IMMERSIVE_DARK_MODE`) apply seamlessly on window activation and theme changes
 */
 // ==/WindhawkModReadme==
 
@@ -113,6 +111,7 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
 
 #include <windows.h>
 #include <dwmapi.h>
+#include <windhawk_utils.h>
 #include <unordered_set>
 #include <unordered_map>
 #include <mutex>
@@ -133,7 +132,7 @@ struct ModSettings {
     COLORREF inactiveLight;
     COLORREF activeDark;
     COLORREF inactiveDark;
-    BOOL excludeMozilla;
+    std::atomic<BOOL> excludeMozilla;
 };
 static ModSettings g_settings;
 
@@ -148,7 +147,12 @@ static std::atomic<BOOL> g_isDarkMode = FALSE;
 // App-controlled window state tracking
 static std::unordered_set<HWND> g_appControlledWindows;
 static std::mutex g_appControlledMutex;
-thread_local bool g_inMod = false;
+static thread_local bool g_inMod = false;
+
+struct InModGuard {
+    InModGuard() { g_inMod = true; }
+    ~InModGuard() { g_inMod = false; }
+};
 
 static std::mutex g_settingsMutex;
 
@@ -158,11 +162,8 @@ static std::mutex g_eligibilityMutex;
 static std::unordered_map<HWND, BOOL> g_appDarkModeWindows;
 static std::mutex g_appDarkModeMutex;
 
-// Debounce mechanism: track last SetWindowPos time per window to prevent
-// rapid successive redraws that can interfere with window managers
-static std::unordered_map<HWND, DWORD> g_lastSetWindowPosTime;
-static std::mutex g_lastSetWindowPosMutex;
-const DWORD SETWINDOWPOS_DEBOUNCE_MS = 50;  // 50ms minimum between redraws
+static std::unordered_set<HWND> g_appliedWindows;
+static std::mutex g_appliedMutex;
 
 // -----------------------------------------------------------------------------
 // Dark mode detection
@@ -202,17 +203,13 @@ BOOL IsSystemDarkMode()
 // Window eligibility
 // -----------------------------------------------------------------------------
 
-struct XamlSearchContext {
-    BOOL hasXaml;
-};
-
 static BOOL CALLBACK CheckXamlChildProc(HWND hwnd, LPARAM lParam) {
     WCHAR className[256];
     if (GetClassNameW(hwnd, className, 256)) {
         if (wcscmp(className, L"DesktopWindowXamlSource") == 0 ||
             wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
             wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0) {
-            ((XamlSearchContext*)lParam)->hasXaml = TRUE;
+            *(BOOL*)lParam = TRUE;
             return FALSE; // Stop enumerating, we found it!
         }
     }
@@ -230,13 +227,13 @@ BOOL IsWindowEligible(HWND hWnd, BOOL allowCacheUpdate = TRUE)
     if (styleEx & WS_EX_TOOLWINDOW)  return FALSE;
     if (style & WS_CHILD)            return FALSE;
 
-    // Fast top-level check for Mozilla/Gecko browsers (Firefox, Zen, Floorp)
-    if (g_settings.excludeMozilla) {
-        WCHAR className[256];
-        if (GetClassNameW(hWnd, className, 256)) {
-            if (wcsncmp(className, L"Mozilla", 7) == 0) {
-                return FALSE;
-            }
+    WCHAR className[256];
+    if (GetClassNameW(hWnd, className, 256)) {
+        if (wcscmp(className, L"ApplicationFrameWindow") == 0) {
+            return FALSE;
+        }
+        if (g_settings.excludeMozilla && wcsncmp(className, L"Mozilla", 7) == 0) {
+            return FALSE;
         }
     }
 
@@ -248,14 +245,16 @@ BOOL IsWindowEligible(HWND hWnd, BOOL allowCacheUpdate = TRUE)
 
     // Detect WinUI 3 / UWP modern apps and complex composite windows
     // These apps host their modern UI inside specific child bridge windows.
-    XamlSearchContext ctx = { FALSE };
-    EnumChildWindows(hWnd, CheckXamlChildProc, (LPARAM)&ctx);
+    BOOL hasXaml = FALSE;
+    EnumChildWindows(hWnd, CheckXamlChildProc, (LPARAM)&hasXaml);
     
-    BOOL isEligible = !ctx.hasXaml;
+    BOOL isEligible = !hasXaml;
     
     if (allowCacheUpdate) {
-        std::lock_guard<std::mutex> lock(g_eligibilityMutex);
-        g_eligibilityCache[hWnd] = isEligible;
+        if (!isEligible || IsWindowVisible(hWnd)) {
+            std::lock_guard<std::mutex> lock(g_eligibilityMutex);
+            g_eligibilityCache[hWnd] = isEligible;
+        }
     }
 
     return isEligible;
@@ -303,13 +302,11 @@ static void LoadSettings()
 
     BOOL useHexLight = (BOOL)Wh_GetIntSetting(L"lightMode.useHex");
     if (useHexLight) {
-        PCWSTR hexActive = Wh_GetStringSetting(L"lightMode.activeColour.hex");
-        if (!HexToColorref(hexActive, &g_settings.activeLight)) g_settings.activeLight = RGB(255, 255, 255);
-        Wh_FreeStringSetting(hexActive);
+        WindhawkUtils::StringSetting hexActive = WindhawkUtils::StringSetting::make(L"lightMode.activeColour.hex");
+        if (!HexToColorref(hexActive.get(), &g_settings.activeLight)) g_settings.activeLight = RGB(255, 255, 255);
 
-        PCWSTR hexInactive = Wh_GetStringSetting(L"lightMode.inactiveColour.hex");
-        if (!HexToColorref(hexInactive, &g_settings.inactiveLight)) g_settings.inactiveLight = RGB(230, 230, 230);
-        Wh_FreeStringSetting(hexInactive);
+        WindhawkUtils::StringSetting hexInactive = WindhawkUtils::StringSetting::make(L"lightMode.inactiveColour.hex");
+        if (!HexToColorref(hexInactive.get(), &g_settings.inactiveLight)) g_settings.inactiveLight = RGB(230, 230, 230);
     } else {
         g_settings.activeLight = RGB(
             (BYTE)Wh_GetIntSetting(L"lightMode.activeColour.r"),
@@ -325,13 +322,11 @@ static void LoadSettings()
 
     BOOL useHexDark = (BOOL)Wh_GetIntSetting(L"darkMode.useHex");
     if (useHexDark) {
-        PCWSTR hexActive = Wh_GetStringSetting(L"darkMode.activeColour.hex");
-        if (!HexToColorref(hexActive, &g_settings.activeDark)) g_settings.activeDark = RGB(32, 32, 32);
-        Wh_FreeStringSetting(hexActive);
+        WindhawkUtils::StringSetting hexActive = WindhawkUtils::StringSetting::make(L"darkMode.activeColour.hex");
+        if (!HexToColorref(hexActive.get(), &g_settings.activeDark)) g_settings.activeDark = RGB(32, 32, 32);
 
-        PCWSTR hexInactive = Wh_GetStringSetting(L"darkMode.inactiveColour.hex");
-        if (!HexToColorref(hexInactive, &g_settings.inactiveDark)) g_settings.inactiveDark = RGB(50, 50, 50);
-        Wh_FreeStringSetting(hexInactive);
+        WindhawkUtils::StringSetting hexInactive = WindhawkUtils::StringSetting::make(L"darkMode.inactiveColour.hex");
+        if (!HexToColorref(hexInactive.get(), &g_settings.inactiveDark)) g_settings.inactiveDark = RGB(50, 50, 50);
     } else {
         g_settings.activeDark = RGB(
             (BYTE)Wh_GetIntSetting(L"darkMode.activeColour.r"),
@@ -368,16 +363,41 @@ HRESULT WINAPI DwmSetWindowAttribute_hook(HWND hwnd, DWORD dwAttribute, LPCVOID 
     return DwmSetWindowAttribute_orig(hwnd, dwAttribute, pvAttribute, cbAttribute);
 }
 
-static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL forceRedraw, BOOL allowCacheUpdate = TRUE)
+static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL allowCacheUpdate = TRUE)
 {
-    if (!IsWindowEligible(hWnd, allowCacheUpdate)) return;
+    if (!IsWindowEligible(hWnd, allowCacheUpdate)) {
+        std::lock_guard<std::mutex> lock(g_appliedMutex);
+        if (g_appliedWindows.count(hWnd)) {
+            g_appliedWindows.erase(hWnd);
+
+            InModGuard guard;
+            BOOL off = FALSE;
+            {
+                std::lock_guard<std::mutex> lockDark(g_appDarkModeMutex);
+                auto it = g_appDarkModeWindows.find(hWnd);
+                if (it != g_appDarkModeWindows.end()) {
+                    off = it->second;
+                }
+            }
+            DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &off, sizeof(off));
+
+            const COLORREF def = DWMWA_COLOR_DEFAULT;
+            DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+        }
+        return;
+    }
 
     {
         std::lock_guard<std::mutex> lock(g_appControlledMutex);
         if (g_appControlledWindows.count(hWnd)) return;
     }
 
-    g_inMod = true;
+    {
+        std::lock_guard<std::mutex> lock(g_appliedMutex);
+        g_appliedWindows.insert(hWnd);
+    }
+
+    InModGuard guard;
     BOOL darkMode = g_isDarkMode;
     
     DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
@@ -404,47 +424,25 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL forceRedraw, BOOL allow
         Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=DEFAULT",
             hWnd, (BOOL)g_isDarkMode, isActive);
     }
-    
-    g_inMod = false;
-
-    // Debounce SetWindowPos calls to prevent interference with window managers.
-    // Only allow redraws if enough time has passed since the last redraw.
-    if (forceRedraw && !(GetAsyncKeyState(VK_LBUTTON) & 0x8000)) {
-        DWORD currentTime = GetTickCount();
-        std::lock_guard<std::mutex> lock(g_lastSetWindowPosMutex);
-        DWORD lastTime = g_lastSetWindowPosTime[hWnd];
-        DWORD timeSinceLastRedraw = currentTime - lastTime;
-        
-        if (timeSinceLastRedraw >= SETWINDOWPOS_DEBOUNCE_MS || lastTime == 0) {
-            SetWindowPos(hWnd, nullptr, 0, 0, 0, 0,
-                SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE |
-                SWP_NOZORDER | SWP_NOOWNERZORDER);
-            g_lastSetWindowPosTime[hWnd] = currentTime;
-        }
-    }
 }
 
 // -----------------------------------------------------------------------------
 // Enumerate all eligible windows in the current process
 
-static BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam)
+static BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM)
 {
     DWORD pid = 0;
     if (!GetWindowThreadProcessId(hWnd, &pid) || pid != GetCurrentProcessId())
         return TRUE;
 
     BOOL isActive = (GetForegroundWindow() == hWnd);
-    
-    // Only refresh with SetWindowPos if it's the active window to minimize
-    // interference with tiling window managers
-    BOOL forceRedraw = (BOOL)lParam;
-    ApplyTitleBar(hWnd, isActive, forceRedraw && isActive);
+    ApplyTitleBar(hWnd, isActive);
     return TRUE;
 }
 
-static VOID ApplyToAllWindows(BOOL forceRedraw)
+static VOID ApplyToAllWindows()
 {
-    EnumWindows(EnumWindowsProc, forceRedraw);
+    EnumWindows(EnumWindowsProc, 0);
 }
 
 static VOID ApplyToForegroundWindow()
@@ -453,8 +451,7 @@ static VOID ApplyToForegroundWindow()
     if (hWnd) {
         DWORD pid = 0;
         if (GetWindowThreadProcessId(hWnd, &pid) && pid == GetCurrentProcessId()) {
-            BOOL isActive = TRUE;
-            ApplyTitleBar(hWnd, isActive, TRUE);
+            ApplyTitleBar(hWnd, TRUE);
         }
     }
 }
@@ -463,7 +460,7 @@ static VOID ApplyToForegroundWindow()
 // Shared message handler
 // -----------------------------------------------------------------------------
 
-static VOID HandleWindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
+static VOID HandleWindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam, BOOL isAnsi = FALSE)
 {
     switch (Msg)
     {
@@ -482,41 +479,39 @@ static VOID HandleWindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
                 g_appDarkModeWindows.erase(hWnd);
             }
             {
-                std::lock_guard<std::mutex> lock(g_lastSetWindowPosMutex);
-                g_lastSetWindowPosTime.erase(hWnd);
+                std::lock_guard<std::mutex> lock(g_appliedMutex);
+                g_appliedWindows.erase(hWnd);
             }
             break;
         }
         case WM_ACTIVATE:
         {
             BOOL isActive = (LOWORD(wParam) != WA_INACTIVE);
-            // Only force visual redraw when a window becomes active.
-            // During deactivation, apply attributes without SetWindowPos
-            // to prevent interfering with window manager focus changes.
-            BOOL forceRedraw = isActive;  // Only redraw on activation
-            ApplyTitleBar(hWnd, isActive, forceRedraw);
+            ApplyTitleBar(hWnd, isActive);
             break;
         }
         case WM_NCACTIVATE:
         {
-            // Only force visual redraw when a window becomes active.
-            // When deactivating (wParam == FALSE), apply attributes without
-            // SetWindowPos to avoid interfering with window manager focus handling.
             BOOL isActive = (BOOL)wParam;
-            BOOL forceRedraw = isActive;  // Only redraw on activation
-            ApplyTitleBar(hWnd, isActive, forceRedraw);
+            ApplyTitleBar(hWnd, isActive);
             break;
         }
         case WM_DWMCOLORIZATIONCOLORCHANGED:
         {
             BOOL isActive = (GetForegroundWindow() == hWnd);
-            ApplyTitleBar(hWnd, isActive, TRUE);
+            ApplyTitleBar(hWnd, isActive);
             break;
         }
         case WM_SETTINGCHANGE:
         {
-            BOOL isThemeChange = !lParam ||
-                wcscmp((LPCWSTR)lParam, L"ImmersiveColorSet") == 0;
+            BOOL isThemeChange = !lParam;
+            if (!isThemeChange) {
+                if (isAnsi) {
+                    isThemeChange = (strcmp((LPCSTR)lParam, "ImmersiveColorSet") == 0);
+                } else {
+                    isThemeChange = (wcscmp((LPCWSTR)lParam, L"ImmersiveColorSet") == 0);
+                }
+            }
             if (!isThemeChange) break;
 
             BOOL newDarkMode = IsSystemDarkMode();
@@ -525,15 +520,8 @@ static VOID HandleWindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
                 Wh_Log(L"[PID %d] Theme changed to %s",
                     GetCurrentProcessId(), newDarkMode ? L"DARK" : L"LIGHT");
                 
-                // Only update the foreground window to minimize interference
-                // with tiling window managers. Other windows will be updated
-                // when they receive activation messages.
                 ApplyToForegroundWindow();
-                
-                // Still update all windows, but without forced redraw
-                // to apply the dark mode attribute. SetWindowPos is only
-                // called for the foreground window.
-                ApplyToAllWindows(FALSE);
+                ApplyToAllWindows();
             }
             break;
         }
@@ -550,7 +538,7 @@ static DefWindowProcW_t DefWindowProcW_orig;
 LRESULT WINAPI DefWindowProcW_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefWindowProcW_orig(hWnd, Msg, wParam, lParam);
-    HandleWindowMessage(hWnd, Msg, wParam, lParam);
+    HandleWindowMessage(hWnd, Msg, wParam, lParam, FALSE);
     return result;
 }
 
@@ -560,7 +548,7 @@ static DefWindowProcA_t DefWindowProcA_orig;
 LRESULT WINAPI DefWindowProcA_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefWindowProcA_orig(hWnd, Msg, wParam, lParam);
-    HandleWindowMessage(hWnd, Msg, wParam, lParam);
+    HandleWindowMessage(hWnd, Msg, wParam, lParam, TRUE);
     return result;
 }
 
@@ -574,7 +562,7 @@ static DefDlgProcW_t DefDlgProcW_orig;
 LRESULT WINAPI DefDlgProcW_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefDlgProcW_orig(hWnd, Msg, wParam, lParam);
-    HandleWindowMessage(hWnd, Msg, wParam, lParam);
+    HandleWindowMessage(hWnd, Msg, wParam, lParam, FALSE);
     return result;
 }
 
@@ -584,13 +572,36 @@ static DefDlgProcA_t DefDlgProcA_orig;
 LRESULT WINAPI DefDlgProcA_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefDlgProcA_orig(hWnd, Msg, wParam, lParam);
-    HandleWindowMessage(hWnd, Msg, wParam, lParam);
+    HandleWindowMessage(hWnd, Msg, wParam, lParam, TRUE);
     return result;
 }
 
 // -----------------------------------------------------------------------------
 // Hook: CreateWindowExW / CreateWindowExA
 // -----------------------------------------------------------------------------
+
+static void HandleCreatedWindow(HWND hWnd)
+{
+    if (!hWnd) return;
+
+    WCHAR className[256];
+    if (GetClassNameW(hWnd, className, 256) &&
+        (wcscmp(className, L"DesktopWindowXamlSource") == 0 ||
+         wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
+         wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0)) {
+        HWND hRoot = GetAncestor(hWnd, GA_ROOT);
+        if (hRoot) {
+            {
+                std::lock_guard<std::mutex> lock(g_eligibilityMutex);
+                g_eligibilityCache[hRoot] = FALSE;
+            }
+            InModGuard guard;
+            const COLORREF def = DWMWA_COLOR_DEFAULT;
+            DwmSetWindowAttribute(hRoot, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+        }
+    }
+    ApplyTitleBar(hWnd, FALSE, FALSE);
+}
 
 using CreateWindowExW_t = decltype(&CreateWindowExW);
 static CreateWindowExW_t CreateWindowExW_orig;
@@ -604,23 +615,7 @@ HWND WINAPI CreateWindowExW_hook(
         dwExStyle, lpClassName, lpWindowName, dwStyle,
         X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 
-    if (hWnd) {
-        if (lpClassName && !IS_INTRESOURCE(lpClassName) && (
-            wcscmp(lpClassName, L"DesktopWindowXamlSource") == 0 ||
-            wcscmp(lpClassName, L"Windows.UI.Core.CoreWindow") == 0 ||
-            wcscmp(lpClassName, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0)) {
-            HWND hRoot = GetAncestor(hWnd, GA_ROOT);
-            if (hRoot) {
-                {
-                    std::lock_guard<std::mutex> lock(g_eligibilityMutex);
-                    g_eligibilityCache[hRoot] = FALSE;
-                }
-                const COLORREF def = DWMWA_COLOR_DEFAULT;
-                DwmSetWindowAttribute(hRoot, DWMWA_CAPTION_COLOR, &def, sizeof(def));
-            }
-        }
-        ApplyTitleBar(hWnd, FALSE, FALSE, FALSE);
-    }
+    HandleCreatedWindow(hWnd);
     return hWnd;
 }
 
@@ -636,27 +631,7 @@ HWND WINAPI CreateWindowExA_hook(
         dwExStyle, lpClassName, lpWindowName, dwStyle,
         X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 
-    if (hWnd) {
-        if (lpClassName && !IS_INTRESOURCE(lpClassName)) {
-            WCHAR classNameW[256];
-            if (MultiByteToWideChar(CP_ACP, 0, lpClassName, -1, classNameW, 256)) {
-                if (wcscmp(classNameW, L"DesktopWindowXamlSource") == 0 ||
-                    wcscmp(classNameW, L"Windows.UI.Core.CoreWindow") == 0 ||
-                    wcscmp(classNameW, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0) {
-                    HWND hRoot = GetAncestor(hWnd, GA_ROOT);
-                    if (hRoot) {
-                        {
-                            std::lock_guard<std::mutex> lock(g_eligibilityMutex);
-                            g_eligibilityCache[hRoot] = FALSE;
-                        }
-                        const COLORREF def = DWMWA_COLOR_DEFAULT;
-                        DwmSetWindowAttribute(hRoot, DWMWA_CAPTION_COLOR, &def, sizeof(def));
-                    }
-                }
-            }
-        }
-        ApplyTitleBar(hWnd, FALSE, FALSE, FALSE);
-    }
+    HandleCreatedWindow(hWnd);
     return hWnd;
 }
 
@@ -695,7 +670,7 @@ BOOL Wh_ModInit()
 VOID Wh_ModAfterInit()
 {
     Wh_Log(L"[PID %d] Applying to existing windows...", GetCurrentProcessId());
-    ApplyToAllWindows(TRUE);
+    ApplyToAllWindows();
     Wh_Log(L"[PID %d] Done", GetCurrentProcessId());
 }
 
@@ -707,7 +682,7 @@ VOID Wh_ModSettingsChanged()
     LoadSettings();
     g_isDarkMode = IsSystemDarkMode();
     ApplyToForegroundWindow();
-    ApplyToAllWindows(FALSE);
+    ApplyToAllWindows();
     Wh_Log(L"[PID %d] Reapply done", GetCurrentProcessId());
 }
 
@@ -723,6 +698,12 @@ static BOOL CALLBACK UninitEnumWindowsProc(HWND hWnd, LPARAM)
         if (g_appControlledWindows.count(hWnd)) return TRUE;
     }
 
+    {
+        std::lock_guard<std::mutex> lock(g_appliedMutex);
+        g_appliedWindows.erase(hWnd);
+    }
+
+    InModGuard guard;
     BOOL off = FALSE;
     {
         std::lock_guard<std::mutex> lock(g_appDarkModeMutex);
@@ -735,10 +716,6 @@ static BOOL CALLBACK UninitEnumWindowsProc(HWND hWnd, LPARAM)
 
     const COLORREF def = DWMWA_COLOR_DEFAULT;
     DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
-
-    SetWindowPos(hWnd, nullptr, 0, 0, 0, 0,
-        SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE |
-        SWP_NOZORDER | SWP_NOOWNERZORDER);
 
     return TRUE;
 }

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -2,7 +2,7 @@
 // @id              auto-custom-titlebar-colors
 // @name            Auto Custom Titlebar Colors
 // @description     Auto-switches titlebar dark/light mode with the Windows theme, with separate custom colours for active/inactive windows in both modes
-// @version         1.1.2
+// @version         1.2.0
 // @author          Lone
 // @github          https://github.com/Louis047
 // @include         *

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -39,7 +39,7 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
 
 ## Notes
 - UWP/WinUI windows (`ApplicationFrameWindow`, WinUI 3, XAML islands) are automatically detected and skipped to avoid conflicts
-- Windows whose caption colour is set by the application itself are left untouched
+- Windows whose caption colour is set by the application itself have that colour left untouched; only the dark/light mode is kept in sync
 - Visual attributes apply seamlessly on window activation and theme changes
 */
 // ==/WindhawkModReadme==
@@ -231,7 +231,11 @@ static BOOL IsWindowEligible(HWND hWnd, BOOL allowCacheUpdate = TRUE)
 
     WCHAR className[256];
     if (GetClassNameW(hWnd, className, 256)) {
-        if (wcscmp(className, L"ApplicationFrameWindow") == 0) {
+        if (wcscmp(className, L"ApplicationFrameWindow") == 0 ||
+            wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
+            wcscmp(className, L"DesktopWindowXamlSource") == 0 ||
+            wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0 ||
+            wcscmp(className, L"WinUIDesktopWin32WindowClass") == 0) {
             return FALSE;
         }
         if (g_settings.excludeMozilla && wcsncmp(className, L"Mozilla", 7) == 0) {
@@ -350,7 +354,7 @@ static void LoadSettings()
 using DwmSetWindowAttribute_t = decltype(&DwmSetWindowAttribute);
 static DwmSetWindowAttribute_t DwmSetWindowAttribute_orig;
 
-HRESULT WINAPI DwmSetWindowAttribute_hook(HWND hwnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute)
+static HRESULT WINAPI DwmSetWindowAttribute_hook(HWND hwnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute)
 {
     HRESULT hr = DwmSetWindowAttribute_orig(hwnd, dwAttribute, pvAttribute, cbAttribute);
     if (!g_inMod && SUCCEEDED(hr)) {
@@ -542,7 +546,7 @@ static VOID HandleWindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
 using DefWindowProcW_t = decltype(&DefWindowProcW);
 static DefWindowProcW_t DefWindowProcW_orig;
 
-LRESULT WINAPI DefWindowProcW_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
+static LRESULT WINAPI DefWindowProcW_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefWindowProcW_orig(hWnd, Msg, wParam, lParam);
     HandleWindowMessage(hWnd, Msg, wParam, lParam, FALSE);
@@ -552,7 +556,7 @@ LRESULT WINAPI DefWindowProcW_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 using DefWindowProcA_t = decltype(&DefWindowProcA);
 static DefWindowProcA_t DefWindowProcA_orig;
 
-LRESULT WINAPI DefWindowProcA_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
+static LRESULT WINAPI DefWindowProcA_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefWindowProcA_orig(hWnd, Msg, wParam, lParam);
     HandleWindowMessage(hWnd, Msg, wParam, lParam, TRUE);
@@ -566,7 +570,7 @@ LRESULT WINAPI DefWindowProcA_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 using DefDlgProcW_t = decltype(&DefDlgProcW);
 static DefDlgProcW_t DefDlgProcW_orig;
 
-LRESULT WINAPI DefDlgProcW_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
+static LRESULT WINAPI DefDlgProcW_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefDlgProcW_orig(hWnd, Msg, wParam, lParam);
     HandleWindowMessage(hWnd, Msg, wParam, lParam, FALSE);
@@ -576,7 +580,7 @@ LRESULT WINAPI DefDlgProcW_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
 using DefDlgProcA_t = decltype(&DefDlgProcA);
 static DefDlgProcA_t DefDlgProcA_orig;
 
-LRESULT WINAPI DefDlgProcA_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
+static LRESULT WINAPI DefDlgProcA_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefDlgProcA_orig(hWnd, Msg, wParam, lParam);
     HandleWindowMessage(hWnd, Msg, wParam, lParam, TRUE);
@@ -590,6 +594,25 @@ LRESULT WINAPI DefDlgProcA_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
 static void HandleCreatedWindow(HWND hWnd)
 {
     if (!hWnd) return;
+
+    // Clear any stale entries for this HWND in case it was recycled and
+    // WM_NCDESTROY did not chain through DefWindowProc.
+    {
+        std::lock_guard<std::mutex> lock(g_eligibilityMutex);
+        g_eligibilityCache.erase(hWnd);
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_appControlledMutex);
+        g_appControlledWindows.erase(hWnd);
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_appDarkModeMutex);
+        g_appDarkModeWindows.erase(hWnd);
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_appliedMutex);
+        g_appliedWindows.erase(hWnd);
+    }
 
     WCHAR className[256];
     if (GetClassNameW(hWnd, className, 256) &&
@@ -614,7 +637,7 @@ static void HandleCreatedWindow(HWND hWnd)
 using CreateWindowExW_t = decltype(&CreateWindowExW);
 static CreateWindowExW_t CreateWindowExW_orig;
 
-HWND WINAPI CreateWindowExW_hook(
+static HWND WINAPI CreateWindowExW_hook(
     DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName,
     DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
     HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
@@ -630,7 +653,7 @@ HWND WINAPI CreateWindowExW_hook(
 using CreateWindowExA_t = decltype(&CreateWindowExA);
 static CreateWindowExA_t CreateWindowExA_orig;
 
-HWND WINAPI CreateWindowExA_hook(
+static HWND WINAPI CreateWindowExA_hook(
     DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName,
     DWORD dwStyle, int X, int Y, int nWidth, int nHeight,
     HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -7,12 +7,6 @@
 // @github          https://github.com/Louis047
 // @include         *
 // @exclude         devenv.exe
-// @exclude         systemsettings.exe
-// @exclude         applicationframehost.exe
-// @exclude         StartMenuExperienceHost.exe
-// @exclude         ShellExperienceHost.exe
-// @exclude         SearchHost.exe
-// @exclude         SearchApp.exe
 // @compilerOptions -ldwmapi -luxtheme -luser32
 // ==/WindhawkMod==
 
@@ -115,6 +109,8 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
 
 #include <windows.h>
 #include <dwmapi.h>
+#include <unordered_set>
+#include <mutex>
 
 #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
@@ -127,6 +123,11 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
 typedef HRESULT(WINAPI* pShouldSystemUseDarkMode)();
 static pShouldSystemUseDarkMode g_ShouldSystemUseDarkMode = nullptr;
 static BOOL g_isDarkMode = FALSE;
+
+// App-controlled window state tracking
+static std::unordered_set<HWND> g_appControlledWindows;
+static std::mutex g_appControlledMutex;
+thread_local bool g_inMod = false;
 
 // Debounce mechanism: track last SetWindowPos time per window to prevent
 // rapid successive redraws that can interfere with window managers
@@ -171,6 +172,24 @@ BOOL IsSystemDarkMode()
 // Window eligibility
 // -----------------------------------------------------------------------------
 
+struct XamlSearchContext {
+    BOOL hasXaml;
+};
+
+static BOOL CALLBACK CheckXamlChildProc(HWND hwnd, LPARAM lParam) {
+    WCHAR className[256];
+    if (GetClassNameW(hwnd, className, 256)) {
+        if (wcscmp(className, L"DesktopWindowXamlSource") == 0 ||
+            wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
+            wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0 ||
+            wcscmp(className, L"MozillaCompositorWindowClass") == 0) {
+            ((XamlSearchContext*)lParam)->hasXaml = TRUE;
+            return FALSE; // Stop enumerating, we found it!
+        }
+    }
+    return TRUE; // Continue enumerating
+}
+
 BOOL IsWindowEligible(HWND hWnd)
 {
     if (!hWnd || !IsWindow(hWnd)) return FALSE;
@@ -181,6 +200,22 @@ BOOL IsWindowEligible(HWND hWnd)
     if (!(style & WS_CAPTION))       return FALSE;
     if (styleEx & WS_EX_TOOLWINDOW)  return FALSE;
     if (style & WS_CHILD)            return FALSE;
+
+    // Fast top-level check for Mozilla/Gecko browsers (Firefox, Zen, Floorp)
+    WCHAR className[256];
+    if (GetClassNameW(hWnd, className, 256)) {
+        if (wcscmp(className, L"MozillaWindowClass") == 0) {
+            return FALSE;
+        }
+    }
+
+    // Detect WinUI 3 / UWP modern apps and complex composite windows
+    // These apps host their modern UI inside specific child bridge windows.
+    XamlSearchContext ctx = { FALSE };
+    EnumChildWindows(hWnd, CheckXamlChildProc, (LPARAM)&ctx);
+    if (ctx.hasXaml) {
+        return FALSE;
+    }
 
     return TRUE;
 }
@@ -285,29 +320,84 @@ static void LoadSettings()
 // Core: apply dark-mode attribute + caption colour to one window
 // -----------------------------------------------------------------------------
 
+using DwmSetWindowAttribute_t = decltype(&DwmSetWindowAttribute);
+static DwmSetWindowAttribute_t DwmSetWindowAttribute_orig;
+
+HRESULT WINAPI DwmSetWindowAttribute_hook(HWND hwnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute)
+{
+    if (!g_inMod && dwAttribute == DWMWA_CAPTION_COLOR) {
+        std::lock_guard<std::mutex> lock(g_appControlledMutex);
+        g_appControlledWindows.insert(hwnd);
+        Wh_Log(L"App controls DWMWA_CAPTION_COLOR for hWnd=%p", hwnd);
+    }
+    return DwmSetWindowAttribute_orig(hwnd, dwAttribute, pvAttribute, cbAttribute);
+}
+
 static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL forceRedraw)
 {
     if (!IsWindowEligible(hWnd)) return;
 
-    BOOL darkMode = g_isDarkMode;
-    DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
-        &darkMode, sizeof(darkMode));
+    {
+        std::lock_guard<std::mutex> lock(g_appControlledMutex);
+        if (g_appControlledWindows.count(hWnd)) return;
 
-    BOOL useCustom = g_isDarkMode ? g_settings.useCustomDark : g_settings.useCustomLight;
-    if (useCustom) {
-        COLORREF colour = g_isDarkMode 
-            ? (isActive ? g_settings.activeDark : g_settings.inactiveDark)
-            : (isActive ? g_settings.activeLight : g_settings.inactiveLight);
-        DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR,
-            &colour, sizeof(colour));
-        Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=#%06X",
-            hWnd, g_isDarkMode, isActive, colour);
-    } else {
-        const COLORREF def = DWMWA_COLOR_DEFAULT;
-        DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
-        Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=DEFAULT",
-            hWnd, g_isDarkMode, isActive);
+        // Fallback: check if window already has a custom color applied before our mod touches it
+        static std::unordered_set<HWND> seenWindows;
+        if (seenWindows.find(hWnd) == seenWindows.end()) {
+            seenWindows.insert(hWnd);
+            COLORREF currentColor = 0;
+            if (SUCCEEDED(DwmGetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &currentColor, sizeof(currentColor)))) {
+                if (currentColor != DWMWA_COLOR_DEFAULT) { // 0xFFFFFFFF
+                    g_appControlledWindows.insert(hWnd);
+                    Wh_Log(L"ApplyTitleBar: Window %p already has custom DWMWA_CAPTION_COLOR %08X, ignoring", hWnd, currentColor);
+                    return;
+                }
+            }
+        }
     }
+
+    g_inMod = true;
+    BOOL darkMode = g_isDarkMode;
+    if (DwmSetWindowAttribute_orig) {
+        DwmSetWindowAttribute_orig(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+            &darkMode, sizeof(darkMode));
+
+        BOOL useCustom = g_isDarkMode ? g_settings.useCustomDark : g_settings.useCustomLight;
+        if (useCustom) {
+            COLORREF colour = g_isDarkMode 
+                ? (isActive ? g_settings.activeDark : g_settings.inactiveDark)
+                : (isActive ? g_settings.activeLight : g_settings.inactiveLight);
+            DwmSetWindowAttribute_orig(hWnd, DWMWA_CAPTION_COLOR,
+                &colour, sizeof(colour));
+            Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=#%06X",
+                hWnd, g_isDarkMode, isActive, colour);
+        } else {
+            const COLORREF def = DWMWA_COLOR_DEFAULT;
+            DwmSetWindowAttribute_orig(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+            Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=DEFAULT",
+                hWnd, g_isDarkMode, isActive);
+        }
+    } else {
+        DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+            &darkMode, sizeof(darkMode));
+
+        BOOL useCustom = g_isDarkMode ? g_settings.useCustomDark : g_settings.useCustomLight;
+        if (useCustom) {
+            COLORREF colour = g_isDarkMode 
+                ? (isActive ? g_settings.activeDark : g_settings.inactiveDark)
+                : (isActive ? g_settings.activeLight : g_settings.inactiveLight);
+            DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR,
+                &colour, sizeof(colour));
+            Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=#%06X",
+                hWnd, g_isDarkMode, isActive, colour);
+        } else {
+            const COLORREF def = DWMWA_COLOR_DEFAULT;
+            DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+            Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=DEFAULT",
+                hWnd, g_isDarkMode, isActive);
+        }
+    }
+    g_inMod = false;
 
     // Debounce SetWindowPos calls to prevent interference with window managers.
     // Only allow redraws if enough time has passed since the last redraw.
@@ -545,6 +635,7 @@ BOOL Wh_ModInit()
     hook((void*)DefDlgProcA,     (void*)DefDlgProcA_hook,     (void**)&DefDlgProcA_orig,     L"DefDlgProcA");
     hook((void*)CreateWindowExW, (void*)CreateWindowExW_hook, (void**)&CreateWindowExW_orig, L"CreateWindowExW");
     hook((void*)CreateWindowExA, (void*)CreateWindowExA_hook, (void**)&CreateWindowExA_orig, L"CreateWindowExA");
+    hook((void*)DwmSetWindowAttribute, (void*)DwmSetWindowAttribute_hook, (void**)&DwmSetWindowAttribute_orig, L"DwmSetWindowAttribute");
 
     Wh_Log(L"=== Init complete ===");
     return TRUE;

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -28,6 +28,7 @@ Combines automatic dark/light titlebar switching with per-mode, per-state custom
 - Real-time theme change detection (responds to `WM_SETTINGCHANGE` / `WM_DWMCOLORIZATIONCOLORCHANGED`)
 - New windows receive the correct style immediately via `CreateWindowEx` hooks
 - Dialog windows handled via `DefDlgProc` hooks
+- MDI frame windows (e.g. `mmc.exe`, Event Viewer, Device Manager) handled via `DefFrameProc` hooks
 - Live settings reload: colour changes apply instantly without restarting the process
 - **Exclude Mozilla Browsers** toggle (default: on) -- skips Firefox, Zen Browser, Floorp, etc.; disable to re-enable titlebar colouring for those browsers
 
@@ -145,7 +146,7 @@ static ModSettings g_settings;
 // Globals
 // -----------------------------------------------------------------------------
 
-typedef bool (WINAPI* pShouldSystemUseDarkMode)();
+typedef bool (WINAPI* pShouldAppsUseDarkMode)();
 static std::atomic<BOOL> g_isDarkMode = FALSE;
 
 // App-controlled window state tracking
@@ -191,9 +192,9 @@ static BOOL IsSystemDarkMode()
         RegCloseKey(hKey);
     }
 
-    static pShouldSystemUseDarkMode fn = []() -> pShouldSystemUseDarkMode {
+    static pShouldAppsUseDarkMode fn = []() -> pShouldAppsUseDarkMode {
         HMODULE hUxtheme = GetModuleHandleW(L"uxtheme.dll");
-        return hUxtheme ? (pShouldSystemUseDarkMode)GetProcAddress(hUxtheme, MAKEINTRESOURCEA(138)) : nullptr;
+        return hUxtheme ? (pShouldAppsUseDarkMode)GetProcAddress(hUxtheme, MAKEINTRESOURCEA(132)) : nullptr;
     }();
     if (fn)
         return fn() != 0;
@@ -235,7 +236,7 @@ static BOOL IsWindowEligible(HWND hWnd, BOOL allowCacheUpdate = TRUE)
             wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
             wcscmp(className, L"DesktopWindowXamlSource") == 0 ||
             wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0 ||
-            wcscmp(className, L"WinUIDesktopWin32WindowClass") == 0) {
+            wcsncmp(className, L"WinUIDesktopWin32WindowClass", 28) == 0) {
             return FALSE;
         }
         if (g_settings.excludeMozilla && wcsncmp(className, L"Mozilla", 7) == 0) {
@@ -588,31 +589,36 @@ static LRESULT WINAPI DefDlgProcA_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARA
 }
 
 // -----------------------------------------------------------------------------
+// Hook: DefFrameProcW / DefFrameProcA (MDI Frame windows, e.g. MMC)
+// -----------------------------------------------------------------------------
+
+using DefFrameProcW_t = decltype(&DefFrameProcW);
+static DefFrameProcW_t DefFrameProcW_orig;
+
+static LRESULT WINAPI DefFrameProcW_hook(HWND hWnd, HWND hWndMDIClient, UINT Msg, WPARAM wParam, LPARAM lParam)
+{
+    LRESULT result = DefFrameProcW_orig(hWnd, hWndMDIClient, Msg, wParam, lParam);
+    HandleWindowMessage(hWnd, Msg, wParam, lParam, FALSE);
+    return result;
+}
+
+using DefFrameProcA_t = decltype(&DefFrameProcA);
+static DefFrameProcA_t DefFrameProcA_orig;
+
+static LRESULT WINAPI DefFrameProcA_hook(HWND hWnd, HWND hWndMDIClient, UINT Msg, WPARAM wParam, LPARAM lParam)
+{
+    LRESULT result = DefFrameProcA_orig(hWnd, hWndMDIClient, Msg, wParam, lParam);
+    HandleWindowMessage(hWnd, Msg, wParam, lParam, TRUE);
+    return result;
+}
+
+// -----------------------------------------------------------------------------
 // Hook: CreateWindowExW / CreateWindowExA
 // -----------------------------------------------------------------------------
 
 static void HandleCreatedWindow(HWND hWnd)
 {
     if (!hWnd) return;
-
-    // Clear any stale entries for this HWND in case it was recycled and
-    // WM_NCDESTROY did not chain through DefWindowProc.
-    {
-        std::lock_guard<std::mutex> lock(g_eligibilityMutex);
-        g_eligibilityCache.erase(hWnd);
-    }
-    {
-        std::lock_guard<std::mutex> lock(g_appControlledMutex);
-        g_appControlledWindows.erase(hWnd);
-    }
-    {
-        std::lock_guard<std::mutex> lock(g_appDarkModeMutex);
-        g_appDarkModeWindows.erase(hWnd);
-    }
-    {
-        std::lock_guard<std::mutex> lock(g_appliedMutex);
-        g_appliedWindows.erase(hWnd);
-    }
 
     WCHAR className[256];
     if (GetClassNameW(hWnd, className, 256) &&
@@ -694,6 +700,8 @@ BOOL Wh_ModInit()
     success &= Hook(DefWindowProcA,  DefWindowProcA_hook,  &DefWindowProcA_orig,  L"DefWindowProcA");
     success &= Hook(DefDlgProcW,     DefDlgProcW_hook,     &DefDlgProcW_orig,     L"DefDlgProcW");
     success &= Hook(DefDlgProcA,     DefDlgProcA_hook,     &DefDlgProcA_orig,     L"DefDlgProcA");
+    success &= Hook(DefFrameProcW,   DefFrameProcW_hook,   &DefFrameProcW_orig,   L"DefFrameProcW");
+    success &= Hook(DefFrameProcA,   DefFrameProcA_hook,   &DefFrameProcA_orig,   L"DefFrameProcA");
     success &= Hook(CreateWindowExW, CreateWindowExW_hook, &CreateWindowExW_orig, L"CreateWindowExW");
     success &= Hook(CreateWindowExA, CreateWindowExA_hook, &CreateWindowExA_orig, L"CreateWindowExA");
     success &= Hook(DwmSetWindowAttribute, DwmSetWindowAttribute_hook, &DwmSetWindowAttribute_orig, L"DwmSetWindowAttribute");

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -38,7 +38,6 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
 
 ## Notes
 - `systemsettings.exe` and `applicationframehost.exe` are excluded to avoid conflicts
-- No forced repaint is issued while a mouse button is held (prevents drag-state corruption)
 - Window redraws are debounced (50ms minimum) to prevent interference with window managers
 - Visual redraws (SetWindowPos) only occur during window activation, not deactivation, to avoid focus-grabbing issues with tiling window managers
 */
@@ -110,6 +109,7 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
 #include <windows.h>
 #include <dwmapi.h>
 #include <unordered_set>
+#include <unordered_map>
 #include <mutex>
 
 #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
@@ -128,6 +128,11 @@ static BOOL g_isDarkMode = FALSE;
 static std::unordered_set<HWND> g_appControlledWindows;
 static std::mutex g_appControlledMutex;
 thread_local bool g_inMod = false;
+
+static std::mutex g_settingsMutex;
+
+static std::unordered_map<HWND, BOOL> g_eligibilityCache;
+static std::mutex g_eligibilityMutex;
 
 // Debounce mechanism: track last SetWindowPos time per window to prevent
 // rapid successive redraws that can interfere with window managers
@@ -209,15 +214,25 @@ BOOL IsWindowEligible(HWND hWnd)
         }
     }
 
+    {
+        std::lock_guard<std::mutex> lock(g_eligibilityMutex);
+        auto it = g_eligibilityCache.find(hWnd);
+        if (it != g_eligibilityCache.end()) return it->second;
+    }
+
     // Detect WinUI 3 / UWP modern apps and complex composite windows
     // These apps host their modern UI inside specific child bridge windows.
     XamlSearchContext ctx = { FALSE };
     EnumChildWindows(hWnd, CheckXamlChildProc, (LPARAM)&ctx);
-    if (ctx.hasXaml) {
-        return FALSE;
+    
+    BOOL isEligible = !ctx.hasXaml;
+    
+    {
+        std::lock_guard<std::mutex> lock(g_eligibilityMutex);
+        g_eligibilityCache[hWnd] = isEligible;
     }
 
-    return TRUE;
+    return isEligible;
 }
 
 // -----------------------------------------------------------------------------
@@ -268,6 +283,8 @@ static ModSettings g_settings;
 
 static void LoadSettings()
 {
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
+
     g_settings.useCustomLight = (BOOL)Wh_GetIntSetting(L"customColours.light");
     g_settings.useCustomDark = (BOOL)Wh_GetIntSetting(L"customColours.dark");
 
@@ -340,63 +357,36 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL forceRedraw)
     {
         std::lock_guard<std::mutex> lock(g_appControlledMutex);
         if (g_appControlledWindows.count(hWnd)) return;
-
-        // Fallback: check if window already has a custom color applied before our mod touches it
-        static std::unordered_set<HWND> seenWindows;
-        if (seenWindows.find(hWnd) == seenWindows.end()) {
-            seenWindows.insert(hWnd);
-            COLORREF currentColor = 0;
-            if (SUCCEEDED(DwmGetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &currentColor, sizeof(currentColor)))) {
-                if (currentColor != DWMWA_COLOR_DEFAULT) { // 0xFFFFFFFF
-                    g_appControlledWindows.insert(hWnd);
-                    Wh_Log(L"ApplyTitleBar: Window %p already has custom DWMWA_CAPTION_COLOR %08X, ignoring", hWnd, currentColor);
-                    return;
-                }
-            }
-        }
     }
 
     g_inMod = true;
     BOOL darkMode = g_isDarkMode;
-    if (DwmSetWindowAttribute_orig) {
-        DwmSetWindowAttribute_orig(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
-            &darkMode, sizeof(darkMode));
+    
+    DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+        &darkMode, sizeof(darkMode));
 
-        BOOL useCustom = g_isDarkMode ? g_settings.useCustomDark : g_settings.useCustomLight;
-        if (useCustom) {
-            COLORREF colour = g_isDarkMode 
-                ? (isActive ? g_settings.activeDark : g_settings.inactiveDark)
-                : (isActive ? g_settings.activeLight : g_settings.inactiveLight);
-            DwmSetWindowAttribute_orig(hWnd, DWMWA_CAPTION_COLOR,
-                &colour, sizeof(colour));
-            Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=#%06X",
-                hWnd, g_isDarkMode, isActive, colour);
-        } else {
-            const COLORREF def = DWMWA_COLOR_DEFAULT;
-            DwmSetWindowAttribute_orig(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
-            Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=DEFAULT",
-                hWnd, g_isDarkMode, isActive);
-        }
-    } else {
-        DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
-            &darkMode, sizeof(darkMode));
-
-        BOOL useCustom = g_isDarkMode ? g_settings.useCustomDark : g_settings.useCustomLight;
-        if (useCustom) {
-            COLORREF colour = g_isDarkMode 
-                ? (isActive ? g_settings.activeDark : g_settings.inactiveDark)
-                : (isActive ? g_settings.activeLight : g_settings.inactiveLight);
-            DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR,
-                &colour, sizeof(colour));
-            Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=#%06X",
-                hWnd, g_isDarkMode, isActive, colour);
-        } else {
-            const COLORREF def = DWMWA_COLOR_DEFAULT;
-            DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
-            Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=DEFAULT",
-                hWnd, g_isDarkMode, isActive);
-        }
+    BOOL useCustom;
+    COLORREF colour;
+    {
+        std::lock_guard<std::mutex> lock(g_settingsMutex);
+        useCustom = g_isDarkMode ? g_settings.useCustomDark : g_settings.useCustomLight;
+        colour = g_isDarkMode 
+            ? (isActive ? g_settings.activeDark : g_settings.inactiveDark)
+            : (isActive ? g_settings.activeLight : g_settings.inactiveLight);
     }
+
+    if (useCustom) {
+        DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR,
+            &colour, sizeof(colour));
+        Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=#%06X",
+            hWnd, g_isDarkMode, isActive, colour);
+    } else {
+        const COLORREF def = DWMWA_COLOR_DEFAULT;
+        DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+        Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=DEFAULT",
+            hWnd, g_isDarkMode, isActive);
+    }
+    
     g_inMod = false;
 
     // Debounce SetWindowPos calls to prevent interference with window managers.
@@ -464,6 +454,18 @@ static VOID HandleWindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
 {
     switch (Msg)
     {
+        case WM_NCDESTROY:
+        {
+            {
+                std::lock_guard<std::mutex> lock(g_appControlledMutex);
+                g_appControlledWindows.erase(hWnd);
+            }
+            {
+                std::lock_guard<std::mutex> lock(g_eligibilityMutex);
+                g_eligibilityCache.erase(hWnd);
+            }
+            break;
+        }
         case WM_ACTIVATE:
         {
             BOOL isActive = (LOWORD(wParam) != WA_INACTIVE);
@@ -666,6 +668,11 @@ static BOOL CALLBACK UninitEnumWindowsProc(HWND hWnd, LPARAM)
     if (!GetWindowThreadProcessId(hWnd, &pid) || pid != GetCurrentProcessId())
         return TRUE;
     if (!IsWindowEligible(hWnd)) return TRUE;
+
+    {
+        std::lock_guard<std::mutex> lock(g_appControlledMutex);
+        if (g_appControlledWindows.count(hWnd)) return TRUE;
+    }
 
     BOOL off = FALSE;
     DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &off, sizeof(off));

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/Louis047
 // @include         *
 // @exclude         devenv.exe
-// @compilerOptions -ldwmapi -luxtheme -luser32
+// @compilerOptions -ldwmapi -luser32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -37,9 +37,10 @@ Combines automatic dark/light titlebar switching with per-mode, per-state custom
 Custom colours are only applied when the corresponding "Use Custom Colours" toggle is enabled.
 
 ## Notes
-- `systemsettings.exe` and `applicationframehost.exe` are excluded to avoid conflicts
+- UWP/WinUI windows and Mozilla-based browsers are now auto-detected and skipped
 - Window redraws are debounced (50ms minimum) to prevent interference with window managers
 - Visual redraws (SetWindowPos) only occur during window activation, not deactivation, to avoid focus-grabbing issues with tiling window managers
+- No forced repaint is issued while a mouse button is held (prevents drag-state corruption)
 */
 // ==/WindhawkModReadme==
 
@@ -103,6 +104,10 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
       $name: "B (0-255)"
     $name: "Inactive Window"
   $name: "Dark Mode Colours"
+
+- excludeMozilla: true
+  $name: "Exclude Mozilla Browsers"
+  $description: "Skip Firefox, Zen Browser, etc."
 */
 // ==/WindhawkModSettings==
 
@@ -111,10 +116,26 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
 #include <unordered_set>
 #include <unordered_map>
 #include <mutex>
+#include <atomic>
 
 #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
 #endif
+
+// -----------------------------------------------------------------------------
+// Settings helpers
+// -----------------------------------------------------------------------------
+
+struct ModSettings {
+    BOOL useCustomLight;
+    BOOL useCustomDark;
+    COLORREF activeLight;
+    COLORREF inactiveLight;
+    COLORREF activeDark;
+    COLORREF inactiveDark;
+    BOOL excludeMozilla;
+};
+static ModSettings g_settings;
 
 // -----------------------------------------------------------------------------
 // Globals
@@ -122,7 +143,7 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
 
 typedef HRESULT(WINAPI* pShouldSystemUseDarkMode)();
 static pShouldSystemUseDarkMode g_ShouldSystemUseDarkMode = nullptr;
-static BOOL g_isDarkMode = FALSE;
+static std::atomic<BOOL> g_isDarkMode = FALSE;
 
 // App-controlled window state tracking
 static std::unordered_set<HWND> g_appControlledWindows;
@@ -134,9 +155,13 @@ static std::mutex g_settingsMutex;
 static std::unordered_map<HWND, BOOL> g_eligibilityCache;
 static std::mutex g_eligibilityMutex;
 
+static std::unordered_map<HWND, BOOL> g_appDarkModeWindows;
+static std::mutex g_appDarkModeMutex;
+
 // Debounce mechanism: track last SetWindowPos time per window to prevent
 // rapid successive redraws that can interfere with window managers
-static DWORD g_lastSetWindowPosTime = 0;
+static std::unordered_map<HWND, DWORD> g_lastSetWindowPosTime;
+static std::mutex g_lastSetWindowPosMutex;
 const DWORD SETWINDOWPOS_DEBOUNCE_MS = 50;  // 50ms minimum between redraws
 
 // -----------------------------------------------------------------------------
@@ -186,8 +211,7 @@ static BOOL CALLBACK CheckXamlChildProc(HWND hwnd, LPARAM lParam) {
     if (GetClassNameW(hwnd, className, 256)) {
         if (wcscmp(className, L"DesktopWindowXamlSource") == 0 ||
             wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
-            wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0 ||
-            wcscmp(className, L"MozillaCompositorWindowClass") == 0) {
+            wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0) {
             ((XamlSearchContext*)lParam)->hasXaml = TRUE;
             return FALSE; // Stop enumerating, we found it!
         }
@@ -195,7 +219,7 @@ static BOOL CALLBACK CheckXamlChildProc(HWND hwnd, LPARAM lParam) {
     return TRUE; // Continue enumerating
 }
 
-BOOL IsWindowEligible(HWND hWnd)
+BOOL IsWindowEligible(HWND hWnd, BOOL allowCacheUpdate = TRUE)
 {
     if (!hWnd || !IsWindow(hWnd)) return FALSE;
 
@@ -207,10 +231,12 @@ BOOL IsWindowEligible(HWND hWnd)
     if (style & WS_CHILD)            return FALSE;
 
     // Fast top-level check for Mozilla/Gecko browsers (Firefox, Zen, Floorp)
-    WCHAR className[256];
-    if (GetClassNameW(hWnd, className, 256)) {
-        if (wcscmp(className, L"MozillaWindowClass") == 0) {
-            return FALSE;
+    if (g_settings.excludeMozilla) {
+        WCHAR className[256];
+        if (GetClassNameW(hWnd, className, 256)) {
+            if (wcsncmp(className, L"Mozilla", 7) == 0) {
+                return FALSE;
+            }
         }
     }
 
@@ -227,7 +253,7 @@ BOOL IsWindowEligible(HWND hWnd)
     
     BOOL isEligible = !ctx.hasXaml;
     
-    {
+    if (allowCacheUpdate) {
         std::lock_guard<std::mutex> lock(g_eligibilityMutex);
         g_eligibilityCache[hWnd] = isEligible;
     }
@@ -267,26 +293,13 @@ static BOOL HexToColorref(PCWSTR hex, COLORREF* out)
     return TRUE;
 }
 
-// -----------------------------------------------------------------------------
-// Settings helpers
-// -----------------------------------------------------------------------------
-
-struct ModSettings {
-    BOOL useCustomLight;
-    BOOL useCustomDark;
-    COLORREF activeLight;
-    COLORREF inactiveLight;
-    COLORREF activeDark;
-    COLORREF inactiveDark;
-};
-static ModSettings g_settings;
-
 static void LoadSettings()
 {
     std::lock_guard<std::mutex> lock(g_settingsMutex);
 
     g_settings.useCustomLight = (BOOL)Wh_GetIntSetting(L"customColours.light");
     g_settings.useCustomDark = (BOOL)Wh_GetIntSetting(L"customColours.dark");
+    g_settings.excludeMozilla = (BOOL)Wh_GetIntSetting(L"excludeMozilla");
 
     BOOL useHexLight = (BOOL)Wh_GetIntSetting(L"lightMode.useHex");
     if (useHexLight) {
@@ -342,17 +355,22 @@ static DwmSetWindowAttribute_t DwmSetWindowAttribute_orig;
 
 HRESULT WINAPI DwmSetWindowAttribute_hook(HWND hwnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute)
 {
-    if (!g_inMod && dwAttribute == DWMWA_CAPTION_COLOR) {
-        std::lock_guard<std::mutex> lock(g_appControlledMutex);
-        g_appControlledWindows.insert(hwnd);
-        Wh_Log(L"App controls DWMWA_CAPTION_COLOR for hWnd=%p", hwnd);
+    if (!g_inMod) {
+        if (dwAttribute == DWMWA_CAPTION_COLOR) {
+            std::lock_guard<std::mutex> lock(g_appControlledMutex);
+            g_appControlledWindows.insert(hwnd);
+            Wh_Log(L"App controls DWMWA_CAPTION_COLOR for hWnd=%p", hwnd);
+        } else if (dwAttribute == DWMWA_USE_IMMERSIVE_DARK_MODE && pvAttribute && cbAttribute == sizeof(BOOL)) {
+            std::lock_guard<std::mutex> lock(g_appDarkModeMutex);
+            g_appDarkModeWindows[hwnd] = *(BOOL*)pvAttribute;
+        }
     }
     return DwmSetWindowAttribute_orig(hwnd, dwAttribute, pvAttribute, cbAttribute);
 }
 
-static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL forceRedraw)
+static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL forceRedraw, BOOL allowCacheUpdate = TRUE)
 {
-    if (!IsWindowEligible(hWnd)) return;
+    if (!IsWindowEligible(hWnd, allowCacheUpdate)) return;
 
     {
         std::lock_guard<std::mutex> lock(g_appControlledMutex);
@@ -379,12 +397,12 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL forceRedraw)
         DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR,
             &colour, sizeof(colour));
         Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=#%06X",
-            hWnd, g_isDarkMode, isActive, colour);
+            hWnd, (BOOL)g_isDarkMode, isActive, colour);
     } else {
         const COLORREF def = DWMWA_COLOR_DEFAULT;
         DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
         Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=DEFAULT",
-            hWnd, g_isDarkMode, isActive);
+            hWnd, (BOOL)g_isDarkMode, isActive);
     }
     
     g_inMod = false;
@@ -393,13 +411,15 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL forceRedraw)
     // Only allow redraws if enough time has passed since the last redraw.
     if (forceRedraw && !(GetAsyncKeyState(VK_LBUTTON) & 0x8000)) {
         DWORD currentTime = GetTickCount();
-        DWORD timeSinceLastRedraw = currentTime - g_lastSetWindowPosTime;
+        std::lock_guard<std::mutex> lock(g_lastSetWindowPosMutex);
+        DWORD lastTime = g_lastSetWindowPosTime[hWnd];
+        DWORD timeSinceLastRedraw = currentTime - lastTime;
         
-        if (timeSinceLastRedraw >= SETWINDOWPOS_DEBOUNCE_MS) {
+        if (timeSinceLastRedraw >= SETWINDOWPOS_DEBOUNCE_MS || lastTime == 0) {
             SetWindowPos(hWnd, nullptr, 0, 0, 0, 0,
                 SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE |
                 SWP_NOZORDER | SWP_NOOWNERZORDER);
-            g_lastSetWindowPosTime = currentTime;
+            g_lastSetWindowPosTime[hWnd] = currentTime;
         }
     }
 }
@@ -409,9 +429,6 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL forceRedraw)
 
 static BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam)
 {
-    HWND parent = GetAncestor(hWnd, GA_PARENT);
-    if (parent && parent != GetDesktopWindow()) return TRUE;
-
     DWORD pid = 0;
     if (!GetWindowThreadProcessId(hWnd, &pid) || pid != GetCurrentProcessId())
         return TRUE;
@@ -421,11 +438,7 @@ static BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam)
     // Only refresh with SetWindowPos if it's the active window to minimize
     // interference with tiling window managers
     BOOL forceRedraw = (BOOL)lParam;
-    if (forceRedraw && !isActive) {
-        ApplyTitleBar(hWnd, isActive, FALSE);
-    } else {
-        ApplyTitleBar(hWnd, isActive, forceRedraw);
-    }
+    ApplyTitleBar(hWnd, isActive, forceRedraw && isActive);
     return TRUE;
 }
 
@@ -463,6 +476,14 @@ static VOID HandleWindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
             {
                 std::lock_guard<std::mutex> lock(g_eligibilityMutex);
                 g_eligibilityCache.erase(hWnd);
+            }
+            {
+                std::lock_guard<std::mutex> lock(g_appDarkModeMutex);
+                g_appDarkModeWindows.erase(hWnd);
+            }
+            {
+                std::lock_guard<std::mutex> lock(g_lastSetWindowPosMutex);
+                g_lastSetWindowPosTime.erase(hWnd);
             }
             break;
         }
@@ -553,11 +574,7 @@ static DefDlgProcW_t DefDlgProcW_orig;
 LRESULT WINAPI DefDlgProcW_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefDlgProcW_orig(hWnd, Msg, wParam, lParam);
-    if (Msg == WM_NCACTIVATE) {
-        BOOL isActive = (BOOL)wParam;
-        // Only force redraw on activation, not deactivation
-        ApplyTitleBar(hWnd, isActive, isActive);
-    }
+    HandleWindowMessage(hWnd, Msg, wParam, lParam);
     return result;
 }
 
@@ -567,11 +584,7 @@ static DefDlgProcA_t DefDlgProcA_orig;
 LRESULT WINAPI DefDlgProcA_hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = DefDlgProcA_orig(hWnd, Msg, wParam, lParam);
-    if (Msg == WM_NCACTIVATE) {
-        BOOL isActive = (BOOL)wParam;
-        // Only force redraw on activation, not deactivation
-        ApplyTitleBar(hWnd, isActive, isActive);
-    }
+    HandleWindowMessage(hWnd, Msg, wParam, lParam);
     return result;
 }
 
@@ -591,7 +604,23 @@ HWND WINAPI CreateWindowExW_hook(
         dwExStyle, lpClassName, lpWindowName, dwStyle,
         X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 
-    if (hWnd) ApplyTitleBar(hWnd, FALSE, FALSE);
+    if (hWnd) {
+        if (lpClassName && !IS_INTRESOURCE(lpClassName) && (
+            wcscmp(lpClassName, L"DesktopWindowXamlSource") == 0 ||
+            wcscmp(lpClassName, L"Windows.UI.Core.CoreWindow") == 0 ||
+            wcscmp(lpClassName, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0)) {
+            HWND hRoot = GetAncestor(hWnd, GA_ROOT);
+            if (hRoot) {
+                {
+                    std::lock_guard<std::mutex> lock(g_eligibilityMutex);
+                    g_eligibilityCache[hRoot] = FALSE;
+                }
+                const COLORREF def = DWMWA_COLOR_DEFAULT;
+                DwmSetWindowAttribute(hRoot, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+            }
+        }
+        ApplyTitleBar(hWnd, FALSE, FALSE, FALSE);
+    }
     return hWnd;
 }
 
@@ -607,7 +636,27 @@ HWND WINAPI CreateWindowExA_hook(
         dwExStyle, lpClassName, lpWindowName, dwStyle,
         X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 
-    if (hWnd) ApplyTitleBar(hWnd, FALSE, FALSE);
+    if (hWnd) {
+        if (lpClassName && !IS_INTRESOURCE(lpClassName)) {
+            WCHAR classNameW[256];
+            if (MultiByteToWideChar(CP_ACP, 0, lpClassName, -1, classNameW, 256)) {
+                if (wcscmp(classNameW, L"DesktopWindowXamlSource") == 0 ||
+                    wcscmp(classNameW, L"Windows.UI.Core.CoreWindow") == 0 ||
+                    wcscmp(classNameW, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0) {
+                    HWND hRoot = GetAncestor(hWnd, GA_ROOT);
+                    if (hRoot) {
+                        {
+                            std::lock_guard<std::mutex> lock(g_eligibilityMutex);
+                            g_eligibilityCache[hRoot] = FALSE;
+                        }
+                        const COLORREF def = DWMWA_COLOR_DEFAULT;
+                        DwmSetWindowAttribute(hRoot, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+                    }
+                }
+            }
+        }
+        ApplyTitleBar(hWnd, FALSE, FALSE, FALSE);
+    }
     return hWnd;
 }
 
@@ -622,7 +671,7 @@ BOOL Wh_ModInit()
 
     LoadSettings();
     g_isDarkMode = IsSystemDarkMode();
-    Wh_Log(L"Initial theme: %s", g_isDarkMode ? L"DARK" : L"LIGHT");
+    Wh_Log(L"Initial theme: %s", (BOOL)g_isDarkMode ? L"DARK" : L"LIGHT");
 
     auto hook = [](void* target, void* replacement, void** orig, const wchar_t* name) {
         if (!Wh_SetFunctionHook(target, replacement, orig))
@@ -667,7 +716,7 @@ static BOOL CALLBACK UninitEnumWindowsProc(HWND hWnd, LPARAM)
     DWORD pid = 0;
     if (!GetWindowThreadProcessId(hWnd, &pid) || pid != GetCurrentProcessId())
         return TRUE;
-    if (!IsWindowEligible(hWnd)) return TRUE;
+    if (!IsWindowEligible(hWnd, FALSE)) return TRUE;
 
     {
         std::lock_guard<std::mutex> lock(g_appControlledMutex);
@@ -675,6 +724,13 @@ static BOOL CALLBACK UninitEnumWindowsProc(HWND hWnd, LPARAM)
     }
 
     BOOL off = FALSE;
+    {
+        std::lock_guard<std::mutex> lock(g_appDarkModeMutex);
+        auto it = g_appDarkModeWindows.find(hWnd);
+        if (it != g_appDarkModeWindows.end()) {
+            off = it->second;
+        }
+    }
     DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &off, sizeof(off));
 
     const COLORREF def = DWMWA_COLOR_DEFAULT;

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -9,6 +9,10 @@
 // @exclude         devenv.exe
 // @exclude         systemsettings.exe
 // @exclude         applicationframehost.exe
+// @exclude         StartMenuExperienceHost.exe
+// @exclude         ShellExperienceHost.exe
+// @exclude         SearchHost.exe
+// @exclude         SearchApp.exe
 // @compilerOptions -ldwmapi -luxtheme -luser32
 // ==/WindhawkMod==
 
@@ -217,43 +221,64 @@ static BOOL HexToColorref(PCWSTR hex, COLORREF* out)
 // Settings helpers
 // -----------------------------------------------------------------------------
 
-static BOOL UseCustomColourForMode(BOOL isDarkMode)
+struct ModSettings {
+    BOOL useCustomLight;
+    BOOL useCustomDark;
+    COLORREF activeLight;
+    COLORREF inactiveLight;
+    COLORREF activeDark;
+    COLORREF inactiveDark;
+};
+static ModSettings g_settings;
+
+static void LoadSettings()
 {
-    return (BOOL)Wh_GetIntSetting(isDarkMode
-        ? L"customColours.dark"
-        : L"customColours.light");
-}
+    g_settings.useCustomLight = (BOOL)Wh_GetIntSetting(L"customColours.light");
+    g_settings.useCustomDark = (BOOL)Wh_GetIntSetting(L"customColours.dark");
 
-static COLORREF GetTitleBarColour(BOOL isDarkMode, BOOL isActive)
-{
-    const WCHAR* modePrefix  = isDarkMode ? L"darkMode"     : L"lightMode";
-    const WCHAR* statePrefix = isActive   ? L"activeColour" : L"inactiveColour";
+    BOOL useHexLight = (BOOL)Wh_GetIntSetting(L"lightMode.useHex");
+    if (useHexLight) {
+        PCWSTR hexActive = Wh_GetStringSetting(L"lightMode.activeColour.hex");
+        if (!HexToColorref(hexActive, &g_settings.activeLight)) g_settings.activeLight = RGB(255, 255, 255);
+        Wh_FreeStringSetting(hexActive);
 
-    WCHAR useHexKey[64], hexKey[64], rKey[64], gKey[64], bKey[64];
-    wsprintfW(useHexKey, L"%s.useHex",  modePrefix);
-    wsprintfW(hexKey,    L"%s.%s.hex",  modePrefix, statePrefix);
-    wsprintfW(rKey,      L"%s.%s.r",    modePrefix, statePrefix);
-    wsprintfW(gKey,      L"%s.%s.g",    modePrefix, statePrefix);
-    wsprintfW(bKey,      L"%s.%s.b",    modePrefix, statePrefix);
-
-    BOOL useHex = (BOOL)Wh_GetIntSetting(useHexKey);
-
-    if (useHex) {
-        PCWSTR hexVal = Wh_GetStringSetting(hexKey);
-        COLORREF colour = 0;
-        BOOL ok = HexToColorref(hexVal, &colour);
-        Wh_FreeStringSetting(hexVal);
-
-        if (ok) return colour;
-
-        // Invalid hex: log and fall through to RGB
-        Wh_Log(L"GetTitleBarColour: invalid hex for key '%s', falling back to RGB", hexKey);
+        PCWSTR hexInactive = Wh_GetStringSetting(L"lightMode.inactiveColour.hex");
+        if (!HexToColorref(hexInactive, &g_settings.inactiveLight)) g_settings.inactiveLight = RGB(230, 230, 230);
+        Wh_FreeStringSetting(hexInactive);
+    } else {
+        g_settings.activeLight = RGB(
+            (BYTE)Wh_GetIntSetting(L"lightMode.activeColour.r"),
+            (BYTE)Wh_GetIntSetting(L"lightMode.activeColour.g"),
+            (BYTE)Wh_GetIntSetting(L"lightMode.activeColour.b")
+        );
+        g_settings.inactiveLight = RGB(
+            (BYTE)Wh_GetIntSetting(L"lightMode.inactiveColour.r"),
+            (BYTE)Wh_GetIntSetting(L"lightMode.inactiveColour.g"),
+            (BYTE)Wh_GetIntSetting(L"lightMode.inactiveColour.b")
+        );
     }
 
-    BYTE r = (BYTE)Wh_GetIntSetting(rKey);
-    BYTE g = (BYTE)Wh_GetIntSetting(gKey);
-    BYTE b = (BYTE)Wh_GetIntSetting(bKey);
-    return RGB(r, g, b);
+    BOOL useHexDark = (BOOL)Wh_GetIntSetting(L"darkMode.useHex");
+    if (useHexDark) {
+        PCWSTR hexActive = Wh_GetStringSetting(L"darkMode.activeColour.hex");
+        if (!HexToColorref(hexActive, &g_settings.activeDark)) g_settings.activeDark = RGB(32, 32, 32);
+        Wh_FreeStringSetting(hexActive);
+
+        PCWSTR hexInactive = Wh_GetStringSetting(L"darkMode.inactiveColour.hex");
+        if (!HexToColorref(hexInactive, &g_settings.inactiveDark)) g_settings.inactiveDark = RGB(50, 50, 50);
+        Wh_FreeStringSetting(hexInactive);
+    } else {
+        g_settings.activeDark = RGB(
+            (BYTE)Wh_GetIntSetting(L"darkMode.activeColour.r"),
+            (BYTE)Wh_GetIntSetting(L"darkMode.activeColour.g"),
+            (BYTE)Wh_GetIntSetting(L"darkMode.activeColour.b")
+        );
+        g_settings.inactiveDark = RGB(
+            (BYTE)Wh_GetIntSetting(L"darkMode.inactiveColour.r"),
+            (BYTE)Wh_GetIntSetting(L"darkMode.inactiveColour.g"),
+            (BYTE)Wh_GetIntSetting(L"darkMode.inactiveColour.b")
+        );
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -268,8 +293,11 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL forceRedraw)
     DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
         &darkMode, sizeof(darkMode));
 
-    if (UseCustomColourForMode(g_isDarkMode)) {
-        COLORREF colour = GetTitleBarColour(g_isDarkMode, isActive);
+    BOOL useCustom = g_isDarkMode ? g_settings.useCustomDark : g_settings.useCustomLight;
+    if (useCustom) {
+        COLORREF colour = g_isDarkMode 
+            ? (isActive ? g_settings.activeDark : g_settings.inactiveDark)
+            : (isActive ? g_settings.activeLight : g_settings.inactiveLight);
         DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR,
             &colour, sizeof(colour));
         Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=#%06X",
@@ -500,6 +528,7 @@ BOOL Wh_ModInit()
     Wh_Log(L"=== Auto Custom Titlebar Colors - Init [PID %d] ===",
         GetCurrentProcessId());
 
+    LoadSettings();
     g_isDarkMode = IsSystemDarkMode();
     Wh_Log(L"Initial theme: %s", g_isDarkMode ? L"DARK" : L"LIGHT");
 
@@ -533,6 +562,7 @@ VOID Wh_ModAfterInit()
 VOID Wh_ModSettingsChanged()
 {
     Wh_Log(L"[PID %d] Settings changed - reapplying...", GetCurrentProcessId());
+    LoadSettings();
     g_isDarkMode = IsSystemDarkMode();
     ApplyToForegroundWindow();
     ApplyToAllWindows(FALSE);

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -114,6 +114,9 @@ Custom colours are only applied when the corresponding "Use Custom Colours" togg
 #include <windows.h>
 #include <dwmapi.h>
 #include <windhawk_utils.h>
+#include <algorithm>
+#include <cstring>
+#include <cwchar>
 #include <unordered_set>
 #include <unordered_map>
 #include <mutex>
@@ -152,8 +155,9 @@ static std::mutex g_appControlledMutex;
 static thread_local bool g_inMod = false;
 
 struct InModGuard {
+    bool prev = g_inMod;
     InModGuard() { g_inMod = true; }
-    ~InModGuard() { g_inMod = false; }
+    ~InModGuard() { g_inMod = prev; }
 };
 
 static std::mutex g_settingsMutex;
@@ -311,14 +315,14 @@ static void LoadSettings()
         if (!HexToColorref(hexInactive.get(), &g_settings.inactiveLight)) g_settings.inactiveLight = RGB(230, 230, 230);
     } else {
         g_settings.activeLight = RGB(
-            (BYTE)Wh_GetIntSetting(L"lightMode.activeColour.r"),
-            (BYTE)Wh_GetIntSetting(L"lightMode.activeColour.g"),
-            (BYTE)Wh_GetIntSetting(L"lightMode.activeColour.b")
+            (BYTE)std::clamp((int)Wh_GetIntSetting(L"lightMode.activeColour.r"), 0, 255),
+            (BYTE)std::clamp((int)Wh_GetIntSetting(L"lightMode.activeColour.g"), 0, 255),
+            (BYTE)std::clamp((int)Wh_GetIntSetting(L"lightMode.activeColour.b"), 0, 255)
         );
         g_settings.inactiveLight = RGB(
-            (BYTE)Wh_GetIntSetting(L"lightMode.inactiveColour.r"),
-            (BYTE)Wh_GetIntSetting(L"lightMode.inactiveColour.g"),
-            (BYTE)Wh_GetIntSetting(L"lightMode.inactiveColour.b")
+            (BYTE)std::clamp((int)Wh_GetIntSetting(L"lightMode.inactiveColour.r"), 0, 255),
+            (BYTE)std::clamp((int)Wh_GetIntSetting(L"lightMode.inactiveColour.g"), 0, 255),
+            (BYTE)std::clamp((int)Wh_GetIntSetting(L"lightMode.inactiveColour.b"), 0, 255)
         );
     }
 
@@ -331,14 +335,14 @@ static void LoadSettings()
         if (!HexToColorref(hexInactive.get(), &g_settings.inactiveDark)) g_settings.inactiveDark = RGB(50, 50, 50);
     } else {
         g_settings.activeDark = RGB(
-            (BYTE)Wh_GetIntSetting(L"darkMode.activeColour.r"),
-            (BYTE)Wh_GetIntSetting(L"darkMode.activeColour.g"),
-            (BYTE)Wh_GetIntSetting(L"darkMode.activeColour.b")
+            (BYTE)std::clamp((int)Wh_GetIntSetting(L"darkMode.activeColour.r"), 0, 255),
+            (BYTE)std::clamp((int)Wh_GetIntSetting(L"darkMode.activeColour.g"), 0, 255),
+            (BYTE)std::clamp((int)Wh_GetIntSetting(L"darkMode.activeColour.b"), 0, 255)
         );
         g_settings.inactiveDark = RGB(
-            (BYTE)Wh_GetIntSetting(L"darkMode.inactiveColour.r"),
-            (BYTE)Wh_GetIntSetting(L"darkMode.inactiveColour.g"),
-            (BYTE)Wh_GetIntSetting(L"darkMode.inactiveColour.b")
+            (BYTE)std::clamp((int)Wh_GetIntSetting(L"darkMode.inactiveColour.r"), 0, 255),
+            (BYTE)std::clamp((int)Wh_GetIntSetting(L"darkMode.inactiveColour.g"), 0, 255),
+            (BYTE)std::clamp((int)Wh_GetIntSetting(L"darkMode.inactiveColour.b"), 0, 255)
         );
     }
 }
@@ -381,11 +385,6 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL allowCacheUpdate = TRUE
         }
         if (!wasApplied) return;
 
-        {
-            std::lock_guard<std::mutex> lock(g_appControlledMutex);
-            if (g_appControlledWindows.count(hWnd)) return; // app owns the colour now
-        }
-
         BOOL dark = FALSE;
         {
             std::lock_guard<std::mutex> lockDark(g_appDarkModeMutex);
@@ -393,10 +392,18 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL allowCacheUpdate = TRUE
             if (it != g_appDarkModeWindows.end()) dark = it->second;
         }
 
+        bool appOwnsColour;
+        {
+            std::lock_guard<std::mutex> lock(g_appControlledMutex);
+            appOwnsColour = g_appControlledWindows.count(hWnd) != 0;
+        }
+
         InModGuard guard;
         DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(dark));
-        const COLORREF def = DWMWA_COLOR_DEFAULT;
-        DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+        if (!appOwnsColour) {
+            const COLORREF def = DWMWA_COLOR_DEFAULT;
+            DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+        }
         return;
     }
 
@@ -429,8 +436,9 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL allowCacheUpdate = TRUE
     if (useCustom) {
         DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR,
             &colour, sizeof(colour));
-        Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=#%06X",
-            hWnd, (BOOL)g_isDarkMode, isActive, colour);
+        Wh_Log(L"ApplyTitleBar: hWnd=%p dark=%d active=%d colour=#%02X%02X%02X",
+            hWnd, (BOOL)g_isDarkMode, isActive,
+            GetRValue(colour), GetGValue(colour), GetBValue(colour));
     } else {
         const COLORREF def = DWMWA_COLOR_DEFAULT;
         DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
@@ -516,8 +524,7 @@ static VOID HandleWindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
             if (!isThemeChange) break;
 
             BOOL newDarkMode = IsSystemDarkMode();
-            if (newDarkMode != g_isDarkMode) {
-                g_isDarkMode = newDarkMode;
+            if (g_isDarkMode.exchange(newDarkMode) != newDarkMode) {
                 Wh_Log(L"[PID %d] Theme changed to %s",
                     GetCurrentProcessId(), newDarkMode ? L"DARK" : L"LIGHT");
                 ApplyToAllWindows();
@@ -638,6 +645,16 @@ HWND WINAPI CreateWindowExA_hook(
 // Windhawk lifecycle
 // -----------------------------------------------------------------------------
 
+template <typename TargetType, typename ReplacementType, typename OrigType>
+static bool Hook(TargetType target, ReplacementType replacement, OrigType orig, const wchar_t* name) {
+    if (!WindhawkUtils::SetFunctionHook(target, replacement, orig)) {
+        Wh_Log(L"WARNING: Failed to hook %s", name);
+        return false;
+    }
+    Wh_Log(L"Hooked %s", name);
+    return true;
+}
+
 BOOL Wh_ModInit()
 {
     Wh_Log(L"=== Auto Custom Titlebar Colors - Init [PID %d] ===",
@@ -647,20 +664,19 @@ BOOL Wh_ModInit()
     g_isDarkMode = IsSystemDarkMode();
     Wh_Log(L"Initial theme: %s", (BOOL)g_isDarkMode ? L"DARK" : L"LIGHT");
 
-    auto hook = [](void* target, void* replacement, void** orig, const wchar_t* name) {
-        if (!Wh_SetFunctionHook(target, replacement, orig))
-            Wh_Log(L"WARNING: Failed to hook %s", name);
-        else
-            Wh_Log(L"Hooked %s", name);
-    };
+    bool success = true;
+    success &= Hook(DefWindowProcW,  DefWindowProcW_hook,  &DefWindowProcW_orig,  L"DefWindowProcW");
+    success &= Hook(DefWindowProcA,  DefWindowProcA_hook,  &DefWindowProcA_orig,  L"DefWindowProcA");
+    success &= Hook(DefDlgProcW,     DefDlgProcW_hook,     &DefDlgProcW_orig,     L"DefDlgProcW");
+    success &= Hook(DefDlgProcA,     DefDlgProcA_hook,     &DefDlgProcA_orig,     L"DefDlgProcA");
+    success &= Hook(CreateWindowExW, CreateWindowExW_hook, &CreateWindowExW_orig, L"CreateWindowExW");
+    success &= Hook(CreateWindowExA, CreateWindowExA_hook, &CreateWindowExA_orig, L"CreateWindowExA");
+    success &= Hook(DwmSetWindowAttribute, DwmSetWindowAttribute_hook, &DwmSetWindowAttribute_orig, L"DwmSetWindowAttribute");
 
-    hook((void*)DefWindowProcW,  (void*)DefWindowProcW_hook,  (void**)&DefWindowProcW_orig,  L"DefWindowProcW");
-    hook((void*)DefWindowProcA,  (void*)DefWindowProcA_hook,  (void**)&DefWindowProcA_orig,  L"DefWindowProcA");
-    hook((void*)DefDlgProcW,     (void*)DefDlgProcW_hook,     (void**)&DefDlgProcW_orig,     L"DefDlgProcW");
-    hook((void*)DefDlgProcA,     (void*)DefDlgProcA_hook,     (void**)&DefDlgProcA_orig,     L"DefDlgProcA");
-    hook((void*)CreateWindowExW, (void*)CreateWindowExW_hook, (void**)&CreateWindowExW_orig, L"CreateWindowExW");
-    hook((void*)CreateWindowExA, (void*)CreateWindowExA_hook, (void**)&CreateWindowExA_orig, L"CreateWindowExA");
-    hook((void*)DwmSetWindowAttribute, (void*)DwmSetWindowAttribute_hook, (void**)&DwmSetWindowAttribute_orig, L"DwmSetWindowAttribute");
+    if (!success) {
+        Wh_Log(L"=== Init failed: one or more hooks could not be set ===");
+        return FALSE;
+    }
 
     Wh_Log(L"=== Init complete ===");
     return TRUE;
@@ -698,20 +714,26 @@ VOID Wh_ModUninit()
 
     for (HWND hWnd : applied) {
         if (!IsWindow(hWnd)) continue;
-        {
-            std::lock_guard<std::mutex> lock(g_appControlledMutex);
-            if (g_appControlledWindows.count(hWnd)) continue;
-        }
+
         BOOL dark = FALSE;
         {
             std::lock_guard<std::mutex> lock(g_appDarkModeMutex);
             auto it = g_appDarkModeWindows.find(hWnd);
             if (it != g_appDarkModeWindows.end()) dark = it->second;
         }
+
+        bool appOwnsColour;
+        {
+            std::lock_guard<std::mutex> lock(g_appControlledMutex);
+            appOwnsColour = g_appControlledWindows.count(hWnd) != 0;
+        }
+
         InModGuard guard;
         DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(dark));
-        const COLORREF def = DWMWA_COLOR_DEFAULT;
-        DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+        if (!appOwnsColour) {
+            const COLORREF def = DWMWA_COLOR_DEFAULT;
+            DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+        }
     }
 
     Wh_Log(L"[PID %d] Cleanup complete", GetCurrentProcessId());

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -29,6 +29,7 @@ Combines automatic dark/light titlebar switching with per-mode, per-state custom
 - New windows receive the correct style immediately via `CreateWindowEx` hooks
 - Dialog windows handled via `DefDlgProc` hooks
 - Live settings reload: colour changes apply instantly without restarting the process
+- **Exclude Mozilla Browsers** toggle (default: on) -- skips Firefox, Zen Browser, Floorp, etc.; disable to re-enable titlebar colouring for those browsers
 
 ## Colour Format
 - **Hex mode**: enter a 6-character hex string, e.g. `FF0000` for red (no `#` prefix)
@@ -37,8 +38,9 @@ Combines automatic dark/light titlebar switching with per-mode, per-state custom
 Custom colours are only applied when the corresponding "Use Custom Colours" toggle is enabled.
 
 ## Notes
-- UWP/WinUI windows and Mozilla-based browsers are now auto-detected and skipped
-- Visual attributes (`DWMWA_CAPTION_COLOR` and `DWMWA_USE_IMMERSIVE_DARK_MODE`) apply seamlessly on window activation and theme changes
+- UWP/WinUI windows (`ApplicationFrameWindow`, WinUI 3, XAML islands) are automatically detected and skipped to avoid conflicts
+- Windows whose caption colour is set by the application itself are left untouched
+- Visual attributes apply seamlessly on window activation and theme changes
 */
 // ==/WindhawkModReadme==
 
@@ -140,7 +142,7 @@ static ModSettings g_settings;
 // Globals
 // -----------------------------------------------------------------------------
 
-typedef HRESULT(WINAPI* pShouldSystemUseDarkMode)();
+typedef bool (WINAPI* pShouldSystemUseDarkMode)();
 static pShouldSystemUseDarkMode g_ShouldSystemUseDarkMode = nullptr;
 static std::atomic<BOOL> g_isDarkMode = FALSE;
 
@@ -169,7 +171,7 @@ static std::mutex g_appliedMutex;
 // Dark mode detection
 // -----------------------------------------------------------------------------
 
-BOOL IsSystemDarkMode()
+static BOOL IsSystemDarkMode()
 {
     HKEY hKey;
     if (RegOpenKeyExW(HKEY_CURRENT_USER,
@@ -216,14 +218,14 @@ static BOOL CALLBACK CheckXamlChildProc(HWND hwnd, LPARAM lParam) {
     return TRUE; // Continue enumerating
 }
 
-BOOL IsWindowEligible(HWND hWnd, BOOL allowCacheUpdate = TRUE)
+static BOOL IsWindowEligible(HWND hWnd, BOOL allowCacheUpdate = TRUE)
 {
     if (!hWnd || !IsWindow(hWnd)) return FALSE;
 
     LONG style   = GetWindowLongW(hWnd, GWL_STYLE);
     LONG styleEx = GetWindowLongW(hWnd, GWL_EXSTYLE);
 
-    if (!(style & WS_CAPTION))       return FALSE;
+    if ((style & WS_CAPTION) != WS_CAPTION) return FALSE;
     if (styleEx & WS_EX_TOOLWINDOW)  return FALSE;
     if (style & WS_CHILD)            return FALSE;
 
@@ -350,40 +352,51 @@ static DwmSetWindowAttribute_t DwmSetWindowAttribute_orig;
 
 HRESULT WINAPI DwmSetWindowAttribute_hook(HWND hwnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute)
 {
-    if (!g_inMod) {
-        if (dwAttribute == DWMWA_CAPTION_COLOR) {
+    HRESULT hr = DwmSetWindowAttribute_orig(hwnd, dwAttribute, pvAttribute, cbAttribute);
+    if (!g_inMod && SUCCEEDED(hr)) {
+        if (dwAttribute == DWMWA_CAPTION_COLOR && pvAttribute && cbAttribute == sizeof(COLORREF)) {
+            COLORREF colour = *(COLORREF*)pvAttribute;
             std::lock_guard<std::mutex> lock(g_appControlledMutex);
-            g_appControlledWindows.insert(hwnd);
-            Wh_Log(L"App controls DWMWA_CAPTION_COLOR for hWnd=%p", hwnd);
+            if (colour == DWMWA_COLOR_DEFAULT) {
+                g_appControlledWindows.erase(hwnd); // app released control
+            } else {
+                g_appControlledWindows.insert(hwnd);
+                Wh_Log(L"App controls DWMWA_CAPTION_COLOR for hWnd=%p", hwnd);
+            }
         } else if (dwAttribute == DWMWA_USE_IMMERSIVE_DARK_MODE && pvAttribute && cbAttribute == sizeof(BOOL)) {
             std::lock_guard<std::mutex> lock(g_appDarkModeMutex);
             g_appDarkModeWindows[hwnd] = *(BOOL*)pvAttribute;
         }
     }
-    return DwmSetWindowAttribute_orig(hwnd, dwAttribute, pvAttribute, cbAttribute);
+    return hr;
 }
 
 static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL allowCacheUpdate = TRUE)
 {
     if (!IsWindowEligible(hWnd, allowCacheUpdate)) {
-        std::lock_guard<std::mutex> lock(g_appliedMutex);
-        if (g_appliedWindows.count(hWnd)) {
-            g_appliedWindows.erase(hWnd);
-
-            InModGuard guard;
-            BOOL off = FALSE;
-            {
-                std::lock_guard<std::mutex> lockDark(g_appDarkModeMutex);
-                auto it = g_appDarkModeWindows.find(hWnd);
-                if (it != g_appDarkModeWindows.end()) {
-                    off = it->second;
-                }
-            }
-            DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &off, sizeof(off));
-
-            const COLORREF def = DWMWA_COLOR_DEFAULT;
-            DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+        bool wasApplied;
+        {
+            std::lock_guard<std::mutex> lock(g_appliedMutex);
+            wasApplied = g_appliedWindows.erase(hWnd) != 0;
         }
+        if (!wasApplied) return;
+
+        {
+            std::lock_guard<std::mutex> lock(g_appControlledMutex);
+            if (g_appControlledWindows.count(hWnd)) return; // app owns the colour now
+        }
+
+        BOOL dark = FALSE;
+        {
+            std::lock_guard<std::mutex> lockDark(g_appDarkModeMutex);
+            auto it = g_appDarkModeWindows.find(hWnd);
+            if (it != g_appDarkModeWindows.end()) dark = it->second;
+        }
+
+        InModGuard guard;
+        DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(dark));
+        const COLORREF def = DWMWA_COLOR_DEFAULT;
+        DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
         return;
     }
 
@@ -445,17 +458,6 @@ static VOID ApplyToAllWindows()
     EnumWindows(EnumWindowsProc, 0);
 }
 
-static VOID ApplyToForegroundWindow()
-{
-    HWND hWnd = GetForegroundWindow();
-    if (hWnd) {
-        DWORD pid = 0;
-        if (GetWindowThreadProcessId(hWnd, &pid) && pid == GetCurrentProcessId()) {
-            ApplyTitleBar(hWnd, TRUE);
-        }
-    }
-}
-
 // -----------------------------------------------------------------------------
 // Shared message handler
 // -----------------------------------------------------------------------------
@@ -504,14 +506,13 @@ static VOID HandleWindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
         }
         case WM_SETTINGCHANGE:
         {
-            BOOL isThemeChange = !lParam;
-            if (!isThemeChange) {
-                if (isAnsi) {
-                    isThemeChange = (strcmp((LPCSTR)lParam, "ImmersiveColorSet") == 0);
-                } else {
-                    isThemeChange = (wcscmp((LPCWSTR)lParam, L"ImmersiveColorSet") == 0);
-                }
-            }
+            // Only respond to the theme change notification — other WM_SETTINGCHANGE
+            // broadcasts (work area, metrics, etc.) do not require a re-check.
+            BOOL isThemeChange = lParam && (
+                isAnsi
+                    ? strcmp((LPCSTR)lParam, "ImmersiveColorSet") == 0
+                    : wcscmp((LPCWSTR)lParam, L"ImmersiveColorSet") == 0
+            );
             if (!isThemeChange) break;
 
             BOOL newDarkMode = IsSystemDarkMode();
@@ -519,8 +520,6 @@ static VOID HandleWindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPara
                 g_isDarkMode = newDarkMode;
                 Wh_Log(L"[PID %d] Theme changed to %s",
                     GetCurrentProcessId(), newDarkMode ? L"DARK" : L"LIGHT");
-                
-                ApplyToForegroundWindow();
                 ApplyToAllWindows();
             }
             break;
@@ -591,13 +590,13 @@ static void HandleCreatedWindow(HWND hWnd)
          wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0)) {
         HWND hRoot = GetAncestor(hWnd, GA_ROOT);
         if (hRoot) {
+            // Mark root ineligible in the cache, then let ApplyTitleBar's revert
+            // path do the full cleanup of both DWM attributes consistently.
             {
                 std::lock_guard<std::mutex> lock(g_eligibilityMutex);
                 g_eligibilityCache[hRoot] = FALSE;
             }
-            InModGuard guard;
-            const COLORREF def = DWMWA_COLOR_DEFAULT;
-            DwmSetWindowAttribute(hRoot, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+            ApplyTitleBar(hRoot, FALSE);
         }
     }
     ApplyTitleBar(hWnd, FALSE, FALSE);
@@ -681,48 +680,39 @@ VOID Wh_ModSettingsChanged()
     Wh_Log(L"[PID %d] Settings changed - reapplying...", GetCurrentProcessId());
     LoadSettings();
     g_isDarkMode = IsSystemDarkMode();
-    ApplyToForegroundWindow();
     ApplyToAllWindows();
     Wh_Log(L"[PID %d] Reapply done", GetCurrentProcessId());
-}
-
-static BOOL CALLBACK UninitEnumWindowsProc(HWND hWnd, LPARAM)
-{
-    DWORD pid = 0;
-    if (!GetWindowThreadProcessId(hWnd, &pid) || pid != GetCurrentProcessId())
-        return TRUE;
-    if (!IsWindowEligible(hWnd, FALSE)) return TRUE;
-
-    {
-        std::lock_guard<std::mutex> lock(g_appControlledMutex);
-        if (g_appControlledWindows.count(hWnd)) return TRUE;
-    }
-
-    {
-        std::lock_guard<std::mutex> lock(g_appliedMutex);
-        g_appliedWindows.erase(hWnd);
-    }
-
-    InModGuard guard;
-    BOOL off = FALSE;
-    {
-        std::lock_guard<std::mutex> lock(g_appDarkModeMutex);
-        auto it = g_appDarkModeWindows.find(hWnd);
-        if (it != g_appDarkModeWindows.end()) {
-            off = it->second;
-        }
-    }
-    DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &off, sizeof(off));
-
-    const COLORREF def = DWMWA_COLOR_DEFAULT;
-    DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
-
-    return TRUE;
 }
 
 VOID Wh_ModUninit()
 {
     Wh_Log(L"[PID %d] Uninit - restoring system defaults", GetCurrentProcessId());
-    EnumWindows(UninitEnumWindowsProc, 0);
+
+    // Swap out the applied set atomically, then iterate over the captured snapshot.
+    // This avoids holding g_appliedMutex across DWM calls (cross-process, potentially slow).
+    std::unordered_set<HWND> applied;
+    {
+        std::lock_guard<std::mutex> lock(g_appliedMutex);
+        applied.swap(g_appliedWindows);
+    }
+
+    for (HWND hWnd : applied) {
+        if (!IsWindow(hWnd)) continue;
+        {
+            std::lock_guard<std::mutex> lock(g_appControlledMutex);
+            if (g_appControlledWindows.count(hWnd)) continue;
+        }
+        BOOL dark = FALSE;
+        {
+            std::lock_guard<std::mutex> lock(g_appDarkModeMutex);
+            auto it = g_appDarkModeWindows.find(hWnd);
+            if (it != g_appDarkModeWindows.end()) dark = it->second;
+        }
+        InModGuard guard;
+        DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(dark));
+        const COLORREF def = DWMWA_COLOR_DEFAULT;
+        DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &def, sizeof(def));
+    }
+
     Wh_Log(L"[PID %d] Cleanup complete", GetCurrentProcessId());
 }

--- a/mods/auto-custom-titlebar-colors.wh.cpp
+++ b/mods/auto-custom-titlebar-colors.wh.cpp
@@ -146,7 +146,6 @@ static ModSettings g_settings;
 // -----------------------------------------------------------------------------
 
 typedef bool (WINAPI* pShouldSystemUseDarkMode)();
-static pShouldSystemUseDarkMode g_ShouldSystemUseDarkMode = nullptr;
 static std::atomic<BOOL> g_isDarkMode = FALSE;
 
 // App-controlled window state tracking
@@ -192,15 +191,12 @@ static BOOL IsSystemDarkMode()
         RegCloseKey(hKey);
     }
 
-    if (!g_ShouldSystemUseDarkMode) {
+    static pShouldSystemUseDarkMode fn = []() -> pShouldSystemUseDarkMode {
         HMODULE hUxtheme = GetModuleHandleW(L"uxtheme.dll");
-        if (hUxtheme) {
-            g_ShouldSystemUseDarkMode = (pShouldSystemUseDarkMode)
-                GetProcAddress(hUxtheme, MAKEINTRESOURCEA(138));
-        }
-    }
-    if (g_ShouldSystemUseDarkMode)
-        return g_ShouldSystemUseDarkMode() != 0;
+        return hUxtheme ? (pShouldSystemUseDarkMode)GetProcAddress(hUxtheme, MAKEINTRESOURCEA(138)) : nullptr;
+    }();
+    if (fn)
+        return fn() != 0;
 
     return FALSE;
 }
@@ -407,9 +403,10 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL allowCacheUpdate = TRUE
         return;
     }
 
+    bool appOwnsColour;
     {
         std::lock_guard<std::mutex> lock(g_appControlledMutex);
-        if (g_appControlledWindows.count(hWnd)) return;
+        appOwnsColour = g_appControlledWindows.count(hWnd) != 0;
     }
 
     {
@@ -422,6 +419,10 @@ static VOID ApplyTitleBar(HWND hWnd, BOOL isActive, BOOL allowCacheUpdate = TRUE
     
     DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
         &darkMode, sizeof(darkMode));
+
+    if (appOwnsColour) {
+        return;
+    }
 
     BOOL useCustom;
     COLORREF colour;
@@ -606,7 +607,8 @@ static void HandleCreatedWindow(HWND hWnd)
             ApplyTitleBar(hRoot, FALSE);
         }
     }
-    ApplyTitleBar(hWnd, FALSE, FALSE);
+    BOOL isActive = (GetForegroundWindow() == hWnd);
+    ApplyTitleBar(hWnd, isActive, FALSE);
 }
 
 using CreateWindowExW_t = decltype(&CreateWindowExW);


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

- Added a new method to detect and ignore UWP apps by default
- Added classes to ignore browser windows (conflict with Zen Browser which is a special case)
- Added a toggle setting to exclude Zen related browser windows

## Issue References

- https://github.com/ramensoftware/windhawk-mods/issues/4582

**Note:** Custom colours are now enabled by default in v1.2.0 with default dark mode colors updated to `#000000` (active) and `#202020` (inactive). Make sure to update your colors if not using default colors