### PR TITLE
Translucent Windows v1.8.0

### DIFF
--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -5263,7 +5263,7 @@ void __fastcall Hooked_BorderRect(HDC hdc, COLORREF color, LPRECT pRect, INT cxT
 
 VOID UxThemeHooks(BOOL isFlyoutEffectEnabled)
 {
-    WindhawkUtils::SYMBOL_HOOK uxthemedll_hooks[] =
+    WindhawkUtils::SYMBOL_HOOK uxtheme_dll_hooks[] =
     {        
         {
             {
@@ -5312,7 +5312,7 @@ VOID UxThemeHooks(BOOL isFlyoutEffectEnabled)
     }
 
     // If flyout effects setting isn't enabled hook to all symbols except the last one -> CThemeMenu::MenuKeyboardMsgProc
-    if (!WindhawkUtils::HookSymbols(hUxTheme, uxthemedll_hooks, !isFlyoutEffectEnabled ? ARRAYSIZE(uxthemedll_hooks) - 1 : ARRAYSIZE(uxthemedll_hooks))) {
+    if (!WindhawkUtils::HookSymbols(hUxTheme, uxtheme_dll_hooks, !isFlyoutEffectEnabled ? ARRAYSIZE(uxtheme_dll_hooks) - 1 : ARRAYSIZE(uxtheme_dll_hooks))) {
         Wh_Log(L"Failed to hook one or more symbol functions in uxtheme.dll");
         return;
     }
@@ -5659,7 +5659,7 @@ void __fastcall HookedRenderTooltip(HWND hWnd, HDC hdc, HGDIOBJ *a3)
 VOID User32Hooks(BOOL areSysColorsApplied)
 {
     //WindhawkUtils::SetFunctionHook(SetClassLongPtrW, HookedSetClassLongPtrW, &SetClassLongPtrW_orig);
-    WindhawkUtils::SYMBOL_HOOK user32dll_hooks[] =
+    WindhawkUtils::SYMBOL_HOOK user32_dll_hooks[] =
     {  
         {
             {
@@ -5720,7 +5720,7 @@ VOID User32Hooks(BOOL areSysColorsApplied)
     }
 
     // If SetSysColors API is executed then hook only the first two symbols of the array -> RealDefWindowProcWorker, RenderTooltip routines
-    if (!WindhawkUtils::HookSymbols(hUser32, user32dll_hooks, areSysColorsApplied ? 2 : ARRAYSIZE(user32dll_hooks))) {
+    if (!WindhawkUtils::HookSymbols(hUser32, user32_dll_hooks, areSysColorsApplied ? 2 : ARRAYSIZE(user32_dll_hooks))) {
         Wh_Log(L"Failed to hook one or more symbol functions in user32.dll");
         return;
     }
@@ -5814,7 +5814,7 @@ void STDCALL HookedComboEx_OnDrawItem(struct COMBOEX *a1, struct tagDRAWITEMSTRU
 
 VOID Comctl32Hooks()
 {
-    WindhawkUtils::SYMBOL_HOOK comctl32_hooks[] =
+    WindhawkUtils::SYMBOL_HOOK comctl32_dll_hooks[] =
     {        
         {
             {
@@ -5884,7 +5884,7 @@ VOID Comctl32Hooks()
         return;
     }
 
-    if (!WindhawkUtils::HookSymbols(hComCtl32, comctl32_hooks, ARRAYSIZE(comctl32_hooks))) {
+    if (!WindhawkUtils::HookSymbols(hComCtl32, comctl32_dll_hooks, ARRAYSIZE(comctl32_dll_hooks))) {
         Wh_Log(L"Failed to hook one or more symbol functions in comctl32.dll");
         return;
     }
@@ -5972,7 +5972,7 @@ void __thiscall Hooked_CNscTree_DrawDivider(CNscTree *__this, HDC hdc, struct _T
 
 VOID ExplorerFrameHooks()
 {
-    WindhawkUtils::SYMBOL_HOOK ExplorerFrame_hooks[] =
+    WindhawkUtils::SYMBOL_HOOK explorerframe_dll_hooks[] =
     {
         {
             {
@@ -5994,7 +5994,7 @@ VOID ExplorerFrameHooks()
         return;
     }
 
-    if (!WindhawkUtils::HookSymbols(hExplorerFrame, ExplorerFrame_hooks, ARRAYSIZE(ExplorerFrame_hooks))) {
+    if (!WindhawkUtils::HookSymbols(hExplorerFrame, explorerframe_dll_hooks, ARRAYSIZE(explorerframe_dll_hooks))) {
         Wh_Log(L"Failed to hook one or more symbol functions in ExplorerFrame.dll");
         return;
     }
@@ -6066,7 +6066,7 @@ HANDLE __fastcall HookedBrandingLoadImage(LPCWSTR pszBrand, UINT uID, UINT type,
 
 VOID WinbrandHooks()
 {
-    WindhawkUtils::SYMBOL_HOOK Winbrand_hooks[] =
+    WindhawkUtils::SYMBOL_HOOK winbrand_dll_hooks[] =
     {
         {
             {
@@ -6088,7 +6088,7 @@ VOID WinbrandHooks()
         return;
     }
 
-    if (!WindhawkUtils::HookSymbols(hWinbrand , Winbrand_hooks, ARRAYSIZE(Winbrand_hooks))) {
+    if (!WindhawkUtils::HookSymbols(hWinbrand , winbrand_dll_hooks, ARRAYSIZE(winbrand_dll_hooks))) {
         Wh_Log(L"Failed to hook one or more symbol functions in winbrand.dll");
         return;
     }
@@ -6154,7 +6154,7 @@ BOOL STDCALL HookedCComboBoxExBase_OnWinEvent(class CComboBoxExBase *__this, HWN
 
 VOID Comdlg32Hooks()
 {
-    WindhawkUtils::SYMBOL_HOOK hComDlg32_hooks[] =
+    WindhawkUtils::SYMBOL_HOOK comdlg32_dll_hooks[] =
     {
         
         {
@@ -6204,7 +6204,7 @@ VOID Comdlg32Hooks()
         return;
     }
 
-    if (!WindhawkUtils::HookSymbols(hComDlg32 , hComDlg32_hooks, ARRAYSIZE(hComDlg32_hooks))) {
+    if (!WindhawkUtils::HookSymbols(hComDlg32 , comdlg32_dll_hooks, ARRAYSIZE(comdlg32_dll_hooks))) {
         Wh_Log(L"Failed to hook one or more symbol functions in comdlg32.dll");
         return;
     }

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -184,7 +184,7 @@ This is caused by default by the AccentBlur API.❕
 #define RECTWIDTH(lprc)     ((lprc)->right - (lprc)->left)
 #define RECTHEIGHT(lprc)    ((lprc)->bottom - (lprc)->top)
 
-static UINT ENABLE = 1;
+static constexpr UINT ENABLE = 1;
 static constexpr UINT AUTO = 0; // DWMSBT_AUTO
 //static constexpr UINT NONE = 1; // DWMSBT_NONE
 static constexpr UINT MAINWINDOW = 2; // DWMSBT_MAINWINDOW
@@ -599,10 +599,6 @@ std::wstring GetCurrProcStr() {
 
 BOOL InExplorerProcess() {
     return GetCurrProcStr() == L"explorer.exe";
-}
-
-BOOL InWindhawkProcess() {
-    return GetCurrProcStr() == L"windhawk.exe";
 }
 
 BOOL InTaskManagerProcess() {
@@ -1723,7 +1719,6 @@ public:
 
     BOOL CreateDIB(HDC& elementHdc, INT Width, INT Height)
     {
-        Wh_Log(L"CreateDIB");
         if (elementHdc)
             DeleteHDC(elementHdc);
 
@@ -5213,7 +5208,7 @@ HRESULT STDCALL Hooked_GetBrushesForPart(HTHEME hTheme, int iPartId, COLORREF Co
             return S_OK; 
         }
 
-        // 2. Assign a pure black brush. GetStockObject is safer here than 
+        // 2. Assign a pure black brush.
         // CreateSolidBrush because the stock object cannot be accidentally destroyed.
         if (phBrush) {
             *phBrush = (HBRUSH)GetStockObject(BLACK_BRUSH);

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -2,28 +2,49 @@
 // @id              translucent-windows
 // @name            Translucent Windows
 // @description     Enables native translucent effects in Windows 11
-// @version         1.7.4
+// @version         1.8.0
 // @author          Undisputed00x
 // @github          https://github.com/Undisputed00x
 // @include         *
-// @compilerOptions -ldwmapi -luxtheme -lcomctl32 -lgdi32 -ld2d1 -lmsimg32 -lshcore
+// @compilerOptions -ldwmapi -luxtheme -lcomctl32 -lgdi32 -ld2d1 -lmsimg32 -lshcore -lversion -ffp-exception-behavior=maytrap
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
 /*
 
-# ⚠️ FAQ section below ⚠️
+### ⚠️ FAQ section below ⚠️
+### ❗For any excluded process, if the global "New system colors" setting is enabled, please add the excluded processes to the process rules in the mod settings instead.❗
 
-### Blur (AccentBlurBehind)
-![AccentBlurBehind](https://i.imgur.com/tSf5ztk.png)
-### Acrylic (SystemBackdrop)
-![Acrylic SystemBackdrop](https://i.imgur.com/YNktLTu.png)
-### Mica (SystemBackdrop)
-![Mica](https://i.imgur.com/1ciJJck.png)
-### MicaAlt (SystemBackdrop)
-![MicaTabbed](https://i.imgur.com/5Dxj5PS.png)
+- ## Theme Customization
+| **Default cleartype text** | **Greyscale text** |
+|:---:|:---:|
+| ![Cleartype](https://i.imgur.com/utajxyq.png) | ![Greyscale](https://i.imgur.com/0OelxZH.png) |
 
-# FAQ
+| **Default text** | **Alpha blended text** |
+|:---:|:---:|
+| ![Default](https://i.imgur.com/ZgrJMgP.png) | ![Composited](https://i.imgur.com/4lQU2a4.png) |
+
+| **Default themed controls** | **Custom themed controls** |
+|:---:|:---:|
+| ![Default Theme](https://i.imgur.com/8hYI1DZ.png) | ![Custom Theme](https://i.imgur.com/vWbelew.png) |
+
+- ## Translucent effects
+| **Blur (AccentBlurBehind)** | **Acrylic (SystemBackdrop)** |
+|:---:|:---:|
+| ![AccentBlurBehind](https://i.imgur.com/tSf5ztk.png) | ![Acrylic SystemBackdrop](https://i.imgur.com/YNktLTu.png) |
+
+| **Mica (SystemBackdrop)** | **MicaAlt (SystemBackdrop)** |
+|:---:|:---:|
+| ![Mica](https://i.imgur.com/1ciJJck.png) | ![MicaTabbed](https://i.imgur.com/5Dxj5PS.png) |
+
+## Credits 
+The custom theme is a close copy of the Rectify 11 theme created by [WinExperiments](https://github.com/WinExperiments).
+#
+The inspiration for this mod came from the awesome Windows effects customization projects of [Maplespe](https://github.com/Maplespe) and [ALTaleX531](https://github.com/ALTaleX531).
+#
+Thanks also to [m417z](https://github.com/m417z) for his help and input in completing the mod.
+
+## FAQ
 
 * ⚠️Use Windows 11 File Explorer Styler mod and select the Translucent Explorer11 theme
 in order to get translucent WinUI parts of the new file explorer.⚠️
@@ -42,9 +63,6 @@ Extending effects to the entire window can result in text being barely readable 
 Enabling HDR, 10bit color depth output, having a black color, or a white background behind the window can cause this. 
 This is because most GDI rendering operations ignore or do not preserve alpha values.❗
 
-* ⚠️The background color of the properties window may remain unchanged after applying the Windows theme custom rendering.
-Restart explorer.exe to change the background color.⚠️
-
 * ⚠️Prerequisited windows settings to enable the background effects⚠️
     - Transparency effects enabled
     - Energy saver disabled
@@ -58,8 +76,6 @@ Changing the theme to the default and vice versa fixes the problem. As a last re
 * ❕The blur effect may show a bleeding effect at the edges of a window when maximized or snapped to the edge of the screen. 
 This is caused by default by the AccentBlur API.❕
 
-* ✨It is recommended to use the mod with a custom black/dark window themes like the Rectify11 "Dark theme with Mica".✨
-
 * ✨The mod works best on the default dark theme.✨
 
 */
@@ -69,248 +85,88 @@ This is caused by default by the AccentBlur API.❕
 /*
 - RenderingMod:
     - ThemeBackground: TRUE
-      $name: Windows theme custom rendering
+      $name: 🔷 Windows theme custom rendering
       $description: >-
        Modifies parts of the Windows theme using the Direct2D graphics API and modifies 
        Windows GDI text rendering by patching the alpha channel and adjusting text colors.
         ✨It is recommended to enable this with background translucent effects.
-    - SysColors: TRUE
-      $name: New system colors
+    - SysColors: FALSE
+      $name: 🔷 New system colors
       $description: >-
        Modifies additional system UI colors by calling SetSysColors API.
         ⚠️For issues with excluded processes, use process rules in mod's settings. For more refer to the FAQ.
-         ✨It is recommended to enable this with Windows theme custom rendering.
     - AccentColorControls: TRUE
-      $name: Windows theme accent colorizer
+      $name: 🔷 Windows theme accent colorizer
       $description: >-
        Paint with accent color parts of windows theme. (Requires Windows theme custom rendering)
-  $name: Rendering Customization
-- type: acrylicblur
-  $name: Background translucent effects
-  $description: >-
-     Windows 11 version >= 22621.xxx (22H2) is required for SystemBackdrop effects.
-  $options:
-  - none: Default
-  - acrylicblur: Blur (AccentBlurBehind)
-  - acrylicsystem: Acrylic (SystemBackdrop)
-  - mica: Mica (SystemBackdrop)
-  - mica_tabbed: MicaAlt (SystemBackdrop)
-- AccentBlurBehind: "3A232323"
-  $name: AccentBlurBehind color blend
-  $description: >-
-    Blending color with blur background.
-     Color in hexadecimal ARGB format e.g. 3A232323
+  $name: 🔶 Theme Customization
+- BackgroundEffects:
+    - type: acrylicblur
+      $name: 🔷 Background effects
+      $description: >-
+        Windows 11 version >= 22621.xxx (22H2) is required for SystemBackdrop effects.
+      $options:
+      - none: Default
+      - acrylicblur: Blur (AccentBlurBehind)
+      - acrylicsystem: Acrylic (SystemBackdrop)
+      - mica: Mica (SystemBackdrop)
+      - mica_tabbed: MicaAlt (SystemBackdrop)
+    - AccentBlurBehind: "3A232323"
+      $name: 🔷 AccentBlurBehind color blend
+      $description: >-
+        Blending color with blur background.
+        Color in hexadecimal ARGB format e.g. 3A232323
+  $name: 🔶 Translucent Effects
 - FlyoutsEffects: TRUE
-  $name: Flyout effects
+  $name: 🔶 Flyout effects
   $description: >-
     Expand the effects to Win32 flyouts (context menus, dropdown menus, tooltips)
      ✨It is recommended to enable this with both background translucent effects and Windows theme custom rendering.
-- ImmersiveDarkTitle: TRUE
-  $name: Immersive darkmode titlebar
-  $description: >-
-    Affects the tintcolor of SystemBackdrop effects and the glyph color of the titlebar caption buttons.
-     ✨It is recommended to enable this with background translucent effects.
-- ExtendFrame: TRUE
-  $name: Extend effects into entire window
-  $description: >-
-    Extends the effects into the entire window background using DwmExtendFrameIntoClientArea.
-     ✨It is recommended to enable this with background translucent effects.
-- CornerOption: default
-  $name: Window corner type
-  $description: >-
-     Specifies the rounded corner preference for a window
-      Windows 11 version >= 22000.xxx (21H2) is required.
-  $options: 
-  - default: Default
-  - notrounded: Not Rounded
-  - smallround: Small Corner
-- RainbowSpeed: 1
-  $name: Rainbow Speed
-  $description: Adjust the refresh speed of the rainbow colors (Value between 1 and 100).
-- TitlebarColor:
-    - ColorTitlebar: FALSE
-      $name: Enable
-    - RainbowTitlebar: FALSE
-      $name: Rainbow Titlebar
-      $description: Enables rainbow effect on windows titlebar.
-    - titlerbarstyles_active: "FF0000"
-      $name: Focused window color
-      $description: >-
-       Color in hexadecimal RGB format e.g. Red = FF0000
-        SystemAccentColor = 2
-    - titlerbarstyles_inactive: "00FFFF"
-      $name: Unfocused window color
-      $description: >-
-       Color in hexadecimal RGB format e.g. Red = FF0000
-        SystemAccentColor = 2
-  $name: Titlebar color
-  $description: Windows 11 version >= 22000.xxx (21H2) is required. Overrides effects settings
-- TitlebarTextColor:
-    - ColorTitlebarText: FALSE
-      $name: Enable
-    - RainbowTextColor: FALSE
-      $name: Rainbow Titlebar text
-      $description: Enables rainbow effect on windows titlebar text.
-    - titlerbarcolorstyles_active: "FF0000"
-      $name: Focused window color
-      $description: >-
-       Color in hexadecimal RGB format e.g. Red = FF0000
-        Default = 1
-        SystemAccentColor = 2
-    - titlerbarcolorstyles_inactive: "00FFFF"
-      $name: Unfocused window color
-      $description: >-
-       Color in hexadecimal RGB format e.g. Red = FF0000
-        Default = 1
-        SystemAccentColor = 2
-  $name: Titlebar text color
-  $description: >-
-     Windows 11 version >= 22000.xxx (21H2) is required.
-      NOTE: This settings affects only Win32 windows. Since Win11 22H2 File Explorer changed titlebar text rendering to DirectWrite API. To modify the text color of File Explorer title bar, use Windhawk's File Explorer Styler mod.
-- BorderColor:
-    - ColorBorder: FALSE
-      $name: Enable
-    - RainbowBorder: FALSE
-      $name: Rainbow Border
-      $description: Enables rainbow effect on windows borders.
-    - borderstyles_active: "FF0000"
-      $name: Focused window color
-      $description: >-
-       Color in hexadecimal RGB format e.g. Red = FF0000
-        Transparent = 0
-        Default = 1
-        SystemAccentColor = 2
-    - borderstyles_inactive: "00FFFF"
-      $name: Unfocused window color
-      $description: >-
-       Color in hexadecimal RGB format e.g. Red = FF0000
-        Transparent = 0
-        Default = 1
-        SystemAccentColor = 2
-  $name: Border color
-  $description: >-
-      Windows 11 version >= 22000.xxx (21H2) is required.
 - RuledPrograms:
     - - target: "mspaint.exe"
-        $name: Process
+        $name: 🔶 Process
         $description: >-
-         Entries can be process names or paths, for example:
-          mspaint.exe
-          C:\Windows\System32\notepad.exe
+         Entries can be process names, paths or subdirectories for example:
+          • Taskmgr.exe
+          • C:\Windows\System32\Taskmgr.exe
+          • C:\Windows
       - RenderingMod:
           - ThemeBackground: FALSE
-            $name: Windows theme custom rendering
+            $name: 🔷 Windows theme custom rendering
             $description: >-
-              Modifies parts of the Windows theme using the Direct2D graphics API and modifies 
-              Windows GDI text rendering by patching the alpha channel and adjusting text colors.
+              Modifies parts of the Windows theme using the Direct2D graphics API and modifies Windows GDI text rendering by patching the alpha channel and adjusting text colors.
                ✨It is recommended to enable this with background translucent effects.
+          - SysColors: FALSE
+            $name: 🔷 New system colors
+            $description: >-
+             ⚠️Effective if global setting "New System Colors" is disabled.
+              Modifies additional system UI colors by hooking to GetSysColor/GetSysColorBrush API.  
           - AccentColorControls: FALSE
-            $name: Windows theme accent colorizer
+            $name: 🔷 Windows theme accent colorizer
             $description: >-
               Paint with accent color parts of windows theme. (Requires Windows theme custom rendering)
-      - type: none
-        $name: Background translucent effects
-        $description: >-
-         Windows 11 version >= 22621.xxx (22H2) is required for SystemBackdrop effects.
-        $options:
+        $name: 🔶 Theme Customization
+      - BackgroundEffects:
+        - type: none
+          $name: 🔷 Background translucent effects
+          $description: >-
+           Windows 11 version >= 22621.xxx (22H2) is required for SystemBackdrop effects.
+          $options:
           - none: Default
           - acrylicblur: Blur (AccentBlurBehind)
           - acrylicsystem: Acrylic (SystemBackdrop)
           - mica: Mica (SystemBackdrop)
           - mica_tabbed: MicaAlt (SystemBackdrop)
-      - AccentBlurBehind: "3A232323"
-        $name: AccentBlurBehind color blend
-        $description: >-
-          Blending color with blur background.
-           Color in hexadecimal ARGB format e.g. 3A232323
-      - ImmersiveDarkTitle: FALSE
-        $name: Immersive darkmode titlebar
-        $description: >-
-            Affects the tintcolor of SystemBackdrop effects and the glyph color of the titlebar caption buttons.
-             ✨It is recommended to enable this with background translucent effects.
-      - ExtendFrame: FALSE
-        $name: Extend effects into entire window
-        $description: >-
-          Extends the effects into the entire window background using DwmExtendFrameIntoClientArea.
-           ✨It is recommended to enable this with background translucent effects.
-      - CornerOption: default
-        $name: Window corner type
-        $description: >-
-             Specifies the rounded corner preference for a window
-              Windows 11 version >= 22000.xxx (21H2) is required.
-        $options: 
-        - default: Default
-        - notrounded: Not Rounded
-        - smallround: Small Corner
-      - RainbowSpeed: 1
-        $name: Rainbow Speed
-        $description: Adjust the refresh speed of the rainbow colors (Value between 1 and 100).
-      - TitlebarColor:
-          - ColorTitlebar: FALSE
-            $name: Enable
-          - RainbowTitlebar: FALSE
-            $name: Rainbow Titlebar
-            $description: Enables rainbow effect on windows titlebar.
-          - titlerbarstyles_active: "FF0000"
-            $name: Focused window color
-            $description: >-
-             Color in hexadecimal RGB format e.g. Red = FF0000
-              SystemAccentColor = 2
-          - titlerbarstyles_inactive: "00FFFF"
-            $name: Unfocused window color
-            $description: >-
-             Color in hexadecimal RGB format e.g. Red = FF0000
-              SystemAccentColor = 2
-        $name: Titlebar color
-        $description: Windows 11 version >= 22000.xxx (21H2) is required. Overrides effects settings
-      - TitlebarTextColor:
-          - ColorTitlebarText: FALSE
-            $name: Enable
-          - RainbowTextColor: FALSE
-            $name: Rainbow Titlebar text
-            $description: Enables rainbow effect on windows titlebar text.
-          - titlerbarcolorstyles_active: "FF0000"
-            $name: Focused window color
-            $description: >-
-             Color in hexadecimal RGB format e.g. Red = FF0000
-              Default = 1
-              SystemAccentColor = 2
-          - titlerbarcolorstyles_inactive: "00FFFF"
-            $name: Unfocused window color
-            $description: >-
-             Color in hexadecimal RGB format e.g. Red = FF0000
-              Default = 1
-              SystemAccentColor = 2
-        $name: Titlebar text color
-        $description: >-
-         Windows 11 version >= 22000.xxx (21H2) is required.
-          NOTE: This settings affects only Win32 windows. Since Win11 22H2 File Explorer changed titlebar text rendering to DirectWrite API. To modify the text color of File Explorer title bar, use Windhawk's File Explorer Styler mod.
-      - BorderColor:
-          - ColorBorder: FALSE
-            $name: Enable
-          - RainbowBorder: FALSE
-            $name: Rainbow Border
-            $description: Enables rainbow effect on windows borders.
-          - borderstyles_active: "FF0000"
-            $name: Focused window color
-            $description: >-
-             Color in hexadecimal RGB format e.g. Red = FF0000
-              Transparent = 0
-              Default = 1
-              SystemAccentColor = 2
-          - borderstyles_inactive: "00FFFF"
-            $name: Unfocused window color
-            $description: >-
-             Color in hexadecimal RGB format e.g. Red = FF0000
-              Transparent = 0
-              Default = 1
-              SystemAccentColor = 2
-        $name: Border color
-        $description: >-
-           Windows 11 version >= 22000.xxx (21H2) is required.
-  $name: Process Rules
+        - AccentBlurBehind: "3A232323"
+          $name: 🔷 AccentBlurBehind color blend
+          $description: >-
+           Blending color with blur background.
+            Color in hexadecimal ARGB format e.g. 3A232323
+        $name: 🔶 Translucent Effects
+  $name: ⏩ Process Rules
   $description: >-
-      Add rules to each specified process
+      Add rules to each specified process or processes from specific subdirectories
+       ❗ Add process rules for the excluded process instead of using Windhawk's process exclusion when the "New system colors" global setting is enabled.
 */
 // ==/WindhawkModSettings==
 
@@ -318,11 +174,9 @@ This is caused by default by the AccentBlur API.❕
 #include <dwmapi.h>
 #include <vssym32.h>
 #include <uxtheme.h>
-#include <random>
+#include <cmath>
 #include <string>
 #include <array>
-#include <mutex>
-#include <unordered_set>
 #include <d2d1.h>
 #include <wrl.h>
 #include <ShellScalingApi.h>
@@ -330,17 +184,14 @@ This is caused by default by the AccentBlur API.❕
 #define RECTWIDTH(lprc)     ((lprc)->right - (lprc)->left)
 #define RECTHEIGHT(lprc)    ((lprc)->bottom - (lprc)->top)
 
+#define WM_CTLCOLOR 0x19
+
 static UINT ENABLE = 1;
 static constexpr UINT AUTO = 0; // DWMSBT_AUTO
 //static constexpr UINT NONE = 1; // DWMSBT_NONE
 static constexpr UINT MAINWINDOW = 2; // DWMSBT_MAINWINDOW
 static constexpr UINT TRANSIENTWINDOW = 3; // DWMSBT_TRANSIENTWINDOW
 static constexpr UINT TABBEDWINDOW = 4; // DWMSBT_TABBEDWINDOW
-
-static constexpr UINT DEFAULTROUND = 0; // DWMWCP_DEFAULT
-static constexpr UINT DONTROUND = 1; // DWMWCP_DONOTROUND
-//static constexpr UINT ROUND = 2; // DWMWCP_ROUND
-//static constexpr UINT SMALLROUND = 3; // DWMWCP_ROUNDSMALL
 
 // Get DPI value from the primary monitor without dependance to DPI-aware API
 // TODO: Get DPI per window monitor
@@ -354,56 +205,43 @@ UINT GetDpiFromMonitor()
     return USER_DEFAULT_SCREEN_DPI;
 }
 UINT g_Dpi = GetDpiFromMonitor();
+SRWLOCK g_DpiChangeLock = SRWLOCK_INIT;
 
-UINT g_msgRainbowTimer = RegisterWindowMessage(L"Rainbow_effect");
-
-enum {
-    RAINBOW_LOAD,
-    RAINBOW_UNLOAD,
-    RAINBOW_PAUSED,
-    RAINBOW_RESTART
-};
-
-struct RainbowData {
-    DOUBLE initialHue = 0.0;
-    DOUBLE baseTime = 0.0;        // when timer first started
-    DOUBLE pausedTotal = 0.0;     // accumulated paused duration
-    DOUBLE pausedStart = 0.0;     // when current pause began
-    BOOL isPaused = FALSE;
-    UINT_PTR timerId = 0;
-};
-
-std::wstring g_RainbowPropStr = L"Windhawk_TranslucentMod_Rainbow";
-std::mutex g_rainbowWindowsMutex;
-std::unordered_set<HWND> g_rainbowWindows;
-
-thread_local BOOL g_DrawTextWithGlowEntry;
-
-typedef HRESULT(WINAPI* pDrawTextWithGlow)(HDC hdcMem, wchar_t const* pszText, unsigned cch, RECT* prc, DWORD dwFlags, COLORREF crText,
-                                          COLORREF crGlow, unsigned nGlowRadius, unsigned nGlowIntensity, BOOL fPreMultiply,
+typedef HRESULT(WINAPI* pDrawTextWithGlow)(HDC hdcMem, LPWSTR pszText, UINT cch, RECT* pRect, DWORD dwFlags, COLORREF crText,
+                                          COLORREF crGlow, UINT nGlowRadius, UINT nGlowIntensity, BOOL fPreMultiply,
                                           DTT_CALLBACK_PROC pfnDrawTextCallback, LPARAM lParam);
 static auto DrawTextWithGlow = (pDrawTextWithGlow)GetProcAddress(GetModuleHandle(L"uxtheme.dll"), MAKEINTRESOURCEA(126));
 
-// Detect system dark/light theme mode
-typedef HRESULT(WINAPI* pShouldSystemUseDarkMode)();
+// Detects system dark/light theme mode
+typedef BOOL(WINAPI* pShouldSystemUseDarkMode)();
 static auto ShouldSystemUseDarkMode = (pShouldSystemUseDarkMode)GetProcAddress(GetModuleHandle(L"uxtheme.dll"), MAKEINTRESOURCEA(138));
-HRESULT g_IsSysThemeDarkMode = ShouldSystemUseDarkMode();
+BOOL g_IsSysThemeDarkMode = ShouldSystemUseDarkMode();
 
-thread_local HHOOK g_callWndProcHook;
-std::mutex g_allCallWndProcHooksMutex;
-std::unordered_set<HHOOK> g_allCallWndProcHooks;
+// Global theme handle used for SysColors OpenThemeData usage
+HTHEME g_hThemeSysMetrics = nullptr;
 
-std::mutex g_subclassedflyoutsmutex;
-std::unordered_set<HWND> g_subclassedflyouts;
+// Treeview window handle used in our CNscTree_DrawDivider() hook to draw our alpha blended navigation pane divider
+thread_local HWND tl_hwndTreeView = nullptr;
 
-HTHEME g_hTheme = nullptr;
+// Redirect per ruled program the system colors to hardcoded default ones 
+// when custom system colors are applied in global settings.
 BOOL g_DefaultSysColors = FALSE;
+// Global system colors buffers like Windows does.
 std::array<HBRUSH, COLOR_MENUBAR> g_themeCachedCustomSysColorBrushes {nullptr};
 std::array<HBRUSH, COLOR_MENUBAR> g_themeCachedDefaultSysColorBrushes {nullptr};
+SRWLOCK g_SysColorsLock = SRWLOCK_INIT;
+
+// Helpers for resetting theming containers and attributes
+std::wstring GetCurrentWindowsThemePath();
+// Lock in order to safely reset theme cache and attributes on theme change
+SRWLOCK g_ThemeChangeLock = SRWLOCK_INIT;
+std::wstring g_LastThemePath = GetCurrentWindowsThemePath();
 
 using PUNICODE_STRING = PVOID;
 constexpr auto MENUPOPUP_CLASS = L"#32768";
 constexpr UINT THEMECLS_COMMONPROPS_PART = 0;
+
+ATOM g_explorerStylerNoBackgroundEffectAtom = 0;
 
 struct Settings{
     BOOL FillBg = FALSE;
@@ -412,30 +250,8 @@ struct Settings{
     BOOL TextAlphaBlend = FALSE;
     BOOL SetSystemColors = FALSE;
     COLORREF AccentBlurBehindClr = 0x00000000;
-    BOOL ImmersiveDarkmode = FALSE;
     BOOL FlyoutsEffects = FALSE;
-    BOOL ExtendFrame = FALSE;
     BOOL Unload = FALSE;
-    BOOL TitlebarFlag = FALSE;
-    BOOL CaptionTextFlag = FALSE;
-    BOOL BorderFlag = FALSE;
-    COLORREF TitlebarActiveColor = DWMWA_COLOR_DEFAULT;
-    COLORREF CaptionActiveTextColor = DWMWA_COLOR_DEFAULT;
-    COLORREF BorderActiveColor = DWMWA_COLOR_DEFAULT;
-
-    COLORREF g_TitlebarColor = DWMWA_COLOR_DEFAULT;
-    COLORREF g_CaptionColor = DWMWA_COLOR_DEFAULT;
-    COLORREF g_BorderColor = DWMWA_COLOR_DEFAULT;
-
-    COLORREF TitlebarInactiveColor = DWMWA_COLOR_DEFAULT;
-    COLORREF CaptionInactiveTextColor = DWMWA_COLOR_DEFAULT;
-    COLORREF BorderInactiveColor = DWMWA_COLOR_DEFAULT;
-    
-    FLOAT RainbowSpeed = 1.0f;
-
-    BOOL TitlebarRainbowFlag = FALSE;
-    BOOL CaptionRainbowFlag = FALSE;
-    BOOL BorderRainbowFlag = FALSE;
 
     enum BACKGROUNDTYPE
     {
@@ -445,14 +261,6 @@ struct Settings{
         Mica,
         MicaAlt,
     } BgType = Default;
-
-    enum CORNERTYPE
-    {
-        DefaultRound = 0,
-        NotRounded = 1,
-        Rounded = 2,
-        SmallRounded = 3
-    } CornerPref = DefaultRound;
 
 } g_settings;
 
@@ -532,9 +340,8 @@ enum WINDOWCOMPOSITIONATTRIB
     WCA_LAST
 };
 
-ACCENT_POLICY g_accent = {};
-WINCOMPATTRDATA g_attrib = {};
-DWM_BLURBEHIND g_bb = { 0 };
+typedef BOOL(WINAPI* pSetWindowCompositionAttribute)(HWND, WINCOMPATTRDATA*);
+auto SetWindowCompositionAttribute = (pSetWindowCompositionAttribute) GetProcAddress(GetModuleHandleW(L"user32.dll"), "SetWindowCompositionAttribute");
 
 ID2D1Factory* g_d2dFactory = nullptr;
 
@@ -547,24 +354,71 @@ VOID InitDirect2D()
     }
 }
 
-// Credits to @m417z
-DOUBLE g_recipCyclesPerSecond;
+VS_FIXEDFILEINFO* GetModuleVersionInfo(HMODULE hModule, UINT *puPtrLen)
+{
+    void *pFixedFileInfo = nullptr;
+    UINT uPtrLen = 0;
 
-VOID TimerInitialize() {
-    LARGE_INTEGER freq;
-    QueryPerformanceFrequency(&freq);
-    DOUBLE cyclesPerSecond = static_cast<DOUBLE>(freq.QuadPart);
-    g_recipCyclesPerSecond = 1.0 / cyclesPerSecond;
+    HRSRC hResource =
+        FindResourceW(hModule, MAKEINTRESOURCEW(VS_VERSION_INFO), RT_VERSION);
+    if (hResource)
+    {
+        HGLOBAL hGlobal = LoadResource(hModule, hResource);
+        if (hGlobal)
+        {
+            void *pData = LockResource(hGlobal);
+            if (pData)
+            {
+                if (!VerQueryValueW(pData, L"\\", &pFixedFileInfo, &uPtrLen)
+                || uPtrLen == 0)
+                {
+                    pFixedFileInfo = nullptr;
+                    uPtrLen = 0;
+                }
+            }
+        }
+    }
+
+    if (puPtrLen)
+    {
+        *puPtrLen = uPtrLen;
+    }
+
+    return (VS_FIXEDFILEINFO *)pFixedFileInfo;
 }
 
-DOUBLE TimerGetCycles() {
-    LARGE_INTEGER T1;
-    QueryPerformanceCounter(&T1);
-    return static_cast<DOUBLE>(T1.QuadPart);
-}
-
-DOUBLE TimerGetSeconds() {
-    return TimerGetCycles() * g_recipCyclesPerSecond;
+/*
+  * Loads comctl32.dll, version 6.0.
+  * This uses an activation context that uses shell32.dll's manifest
+  * to load 6.0, even in apps which don't have the proper manifest for
+  * it.
+  * From: https://github.com/ramensoftware/windhawk-mods/blob/main/mods/classic-list-group-fix.wh.cpp
+*/
+HMODULE LoadComCtlModule(void)
+{
+    HMODULE hShell32 = LoadLibraryW(L"shell32.dll");
+    ACTCTXW actCtx = { sizeof(actCtx) };
+    actCtx.dwFlags = ACTCTX_FLAG_RESOURCE_NAME_VALID | ACTCTX_FLAG_HMODULE_VALID;
+    actCtx.lpResourceName = MAKEINTRESOURCEW(124);
+    actCtx.hModule = hShell32;
+    HANDLE hActCtx = CreateActCtxW(&actCtx);
+    ULONG_PTR ulCookie;
+    ActivateActCtx(hActCtx, &ulCookie);
+    HMODULE hComCtl = LoadLibraryExW(L"comctl32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    /**
+      * Certain processes will ignore the activation context and load
+      * comctl32.dll 5.82 anyway. If that occurs, just reject it.
+      */
+    VS_FIXEDFILEINFO *pVerInfo = GetModuleVersionInfo(hComCtl, nullptr);
+    if (!pVerInfo || HIWORD(pVerInfo->dwFileVersionMS) < 6)
+    {
+        FreeLibrary(hComCtl);
+        hComCtl = NULL;
+    }
+    DeactivateActCtx(0, ulCookie);
+    ReleaseActCtx(hActCtx);
+    FreeLibrary(hShell32);
+    return hComCtl;
 }
 
 using NtUserCreateWindowEx_t = HWND(WINAPI*)(DWORD, PUNICODE_STRING, LPCWSTR, PUNICODE_STRING, DWORD, LONG, LONG, LONG, LONG, HWND, HMENU, HINSTANCE, LPVOID, DWORD, DWORD, DWORD, VOID*);
@@ -572,21 +426,22 @@ NtUserCreateWindowEx_t NtUserCreateWindowEx_Original;
 
 static decltype(&DwmExtendFrameIntoClientArea) DwmExtendFrameIntoClientArea_orig = nullptr;
 static decltype(&DwmSetWindowAttribute) DwmSetWindowAttribute_orig = nullptr;
-decltype(&TrackPopupMenuEx) TrackPopupMenuEx_orig;
 
 static decltype(&DrawTextW) DrawTextW_orig = nullptr;
-static decltype(&DrawTextExW) DrawTextExW_orig = nullptr;
 static decltype(&ExtTextOutW) ExtTextOutW_orig = nullptr;
 static decltype(&DrawThemeText) DrawThemeText_orig = nullptr;
 static decltype(&DrawThemeTextEx) DrawThemeTextEx_orig = nullptr;
 
-static decltype(&GetThemeBitmap) GetThemeBitmap_orig = nullptr;
 static decltype(&GetThemeColor) GetThemeColor_orig = nullptr;
 static decltype(&DrawThemeBackground) DrawThemeBackground_orig = nullptr;
 static decltype(&DrawThemeBackgroundEx) DrawThemeBackgroundEx_orig = nullptr;
 static decltype(&GetThemeMargins) GetThemeMargins_orig = nullptr;
-static decltype(&GetSysColor) GetSysColor_orig = nullptr;
-static decltype(&GetSysColorBrush) GetSysColorBrush_orig = nullptr;
+static decltype(&GetThemeTransitionDuration) GetThemeTransitionDuration_orig = nullptr;
+static decltype (&GetThemeFont) GetThemeFont_orig = nullptr;
+static decltype(&GetSysColor) GetSysColor_orig = GetSysColor; // Assign the pointer to the original function as we call HookedSysColor() even if the function isn't hooked.
+static decltype(&GetSysColorBrush) GetSysColorBrush_orig = GetSysColorBrush;
+static decltype(&FillRect) FillRect_orig = nullptr;
+static decltype(&DrawThemeEdge) DrawThemeEdge_orig = nullptr;
 static decltype(&DefWindowProcW) DefWindowProc_orig = nullptr;
 
 VOID NewWindowShown(HWND);
@@ -594,6 +449,8 @@ VOID HandleEffects(HWND hWnd);
 
 std::wstring GetWindowClass(HWND hWnd)
 {
+    if (!hWnd)
+        return L"";
     WCHAR buffer[MAX_PATH];
     GetClassNameW(hWnd, buffer, MAX_PATH);
     return buffer;
@@ -601,6 +458,8 @@ std::wstring GetWindowClass(HWND hWnd)
 
 BOOL IsWindowClass(HWND hWnd, LPCWSTR className)
 {
+    if (!hWnd)
+        return FALSE;
     return GetWindowClass(hWnd) == className;
 }
 
@@ -611,11 +470,20 @@ BOOL IsWindowCloaked(HWND hwnd) {
            isCloaked;
 }
 
+BOOL isWindowFlyout(HWND hWnd)
+{
+    return IsWindowClass(hWnd, TOOLTIPS_CLASS) || IsWindowClass(hWnd, L"DropDown") || IsWindowClass(hWnd, L"ViewControlClass") 
+           || IsWindowClass(hWnd, MENUPOPUP_CLASS) || IsWindowClass(hWnd, L"MicrosoftWindowsTooltip") ||IsWindowClass(hWnd, L"BaseBar"); // Support m417z Folder Hover Menu mod
+}
+
 BOOL IsWindowEligible(HWND hWnd) 
-{    
-    BOOL isFlyoutWindow = IsWindowClass(hWnd, TOOLTIPS_CLASS) || IsWindowClass(hWnd, L"DropDown") || IsWindowClass(hWnd, L"ViewControlClass");
-    if (isFlyoutWindow && g_settings.FlyoutsEffects)
-        return TRUE;   
+{   
+    // store the treeview handle for alpha blending when drawing the divider in the navigation pane hook.
+    if (g_settings.FillBg && IsWindowClass(hWnd, L"SysTreeView32"))
+        tl_hwndTreeView = hWnd;
+    
+    if (isWindowFlyout(hWnd) && g_settings.FlyoutsEffects)
+        return TRUE;
     
     LONG_PTR styleEx = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
     LONG_PTR style = GetWindowLongPtrW(hWnd, GWL_STYLE);
@@ -630,7 +498,7 @@ BOOL IsWindowEligible(HWND hWnd)
     BOOL hasThickFrame = (style & WS_THICKFRAME) == WS_THICKFRAME;
     BOOL isWindowCEF = (IsWindowClass(hWnd, L"Chrome_WidgetWin_1") || IsWindowClass(hWnd, L"Chrome_WidgetWin_0"));
 
-    //https://devblogs.microsoft.com/oldnewthing/20200302-00/?p=103507
+    // https://devblogs.microsoft.com/oldnewthing/20200302-00/?p=103507
     // Allow containers of Windows Store apps (WinStore.exe, Settings.exe, etc.)
     // Allow also Chromium Embedded Framework (Brave.exe) created as cloaked.
     if (IsWindowCloaked(hWnd) && !IsWindowClass(hWnd, L"ApplicationFrameWindow") && !isWindowCEF)
@@ -648,7 +516,7 @@ BOOL IsWindowEligible(HWND hWnd)
         return FALSE;
     // Most top-level windows
     if ((style & WS_POPUPWINDOW) == WS_POPUPWINDOW || (style & WS_OVERLAPPEDWINDOW) == WS_OVERLAPPEDWINDOW 
-       || (styleEx & WS_EX_DLGMODALFRAME) == WS_EX_DLGMODALFRAME)
+       || (styleEx & WS_EX_DLGMODALFRAME) == WS_EX_DLGMODALFRAME) // || (styleEx & WS_EX_CONTROLPARENT) == WS_EX_CONTROLPARENT)
             return TRUE;
     // Overlapped windows like the Win32 progress window
     if (hasTitleBar && hasSystemMenu && (hasCaptionButtons || hasThickFrame))
@@ -657,28 +525,93 @@ BOOL IsWindowEligible(HWND hWnd)
     return FALSE;
 }
 
-BOOL IsWindowFullscreen(HWND hWnd)
+std::wstring GetCurrentWindowsThemePath() 
 {
-    WINDOWPLACEMENT wp{.length = sizeof(WINDOWPLACEMENT)};
+    std::wstring themePath;
+    HKEY hKey = nullptr;
 
-    if (GetWindowPlacement(hWnd, &wp) && wp.showCmd == SW_SHOWMAXIMIZED)
-        return TRUE;
+    LSTATUS status = RegOpenKeyExW(
+        HKEY_CURRENT_USER,
+        L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes",
+        0,
+        KEY_READ,
+        &hKey
+    );
 
-    HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
-    if (!hMon)
-        return FALSE;
+    if (status != ERROR_SUCCESS)
+        return L"";
 
-    MONITORINFO mi = { sizeof(mi) };
-    GetMonitorInfoW(hMon, &mi);
+    // 2. Query the size of the string buffer first
+    DWORD bufferSize = 0;
+    status = RegQueryValueExW(
+        hKey,
+        L"CurrentTheme",
+        nullptr,
+        nullptr,
+        nullptr, // Pass nullptr to just get the required size
+        &bufferSize
+    );
 
-    RECT windowRect{};
-    DwmGetWindowAttribute(hWnd, DWMWA_EXTENDED_FRAME_BOUNDS, &windowRect,
-                          sizeof(windowRect));
+    // 3. Allocate the string buffer and fetch the actual data
+    if (status == ERROR_SUCCESS && bufferSize > 0) 
+    {
+        // Resize our wstring to fit the data (bufferSize includes the null terminator)
+        themePath.resize(bufferSize / sizeof(wchar_t) - 1);
 
-    if (EqualRect(&windowRect, &mi.rcMonitor))
-        return TRUE;
+        status = RegQueryValueExW(
+            hKey,
+            L"CurrentTheme",
+            nullptr,
+            nullptr,
+            reinterpret_cast<LPBYTE>(&themePath[0]),
+            &bufferSize
+        );
 
-    return FALSE;
+        if (status != ERROR_SUCCESS)
+            themePath.clear();
+    }
+    RegCloseKey(hKey);
+
+    return themePath;
+}
+
+std::wstring GetProcStrFromPath(std::wstring path) {
+    size_t pos = path.find_last_of(L"\\/");
+    if (pos != std::wstring::npos && pos + 1 < path.length()) {
+        path = path.substr(pos + 1);
+    }
+
+    if (!path.empty()) 
+    {
+        LCMapStringEx(
+            LOCALE_NAME_USER_DEFAULT, 
+            LCMAP_LOWERCASE,
+            path.c_str(),
+            path.length(),
+            &path[0],
+            path.length(),
+            nullptr, nullptr, 0);
+    }
+    return path;
+}
+
+std::wstring GetCurrProcStr() {
+    WCHAR modulePath[MAX_PATH];
+    GetModuleFileNameW(NULL, modulePath, MAX_PATH);
+
+    return GetProcStrFromPath(modulePath);
+}
+
+BOOL InExplorerProcess() {
+    return GetCurrProcStr() == L"explorer.exe";
+}
+
+BOOL InWindhawkProcess() {
+    return GetCurrProcStr() == L"windhawk.exe";
+}
+
+BOOL InTaskManagerProcess() {
+    return GetCurrProcStr() == L"taskmgr.exe";
 }
 
 enum AccentColorShade
@@ -735,112 +668,14 @@ BOOL AccentPalette::LoadAccentPalette()
     return TRUE;
 }
 
-static COLORREF HSLToRGB(FLOAT h, FLOAT s, FLOAT l) {
-    FLOAT c = (1.0f - fabs(2.0f * l - 1.0f)) * s;
-    FLOAT x = c * (1.0f - fabs(fmod(h / 60.0f, 2.0f) - 1.0f));
-    FLOAT m = l - c / 2.0f;
-
-    FLOAT r_prime, g_prime, b_prime;
-    if (0.0f <= h && h < 60.0f) {
-        r_prime = c; g_prime = x; b_prime = 0.0f;
-    } else if (60.0f <= h && h < 120.0f) {
-        r_prime = x; g_prime = c; b_prime = 0.0f;
-    } else if (120.0f <= h && h < 180.0f) {
-        r_prime = 0.0f; g_prime = c; b_prime = x;
-    } else if (180.0f <= h && h < 240.0f) {
-        r_prime = 0.0f; g_prime = x; b_prime = c;
-    } else if (240.0f <= h && h < 300.0f) {
-        r_prime = x; g_prime = 0.0f; b_prime = c;
-    } else {
-        r_prime = c; g_prime = 0.0f; b_prime = x;
-    }
-
-    BYTE r = static_cast<BYTE>((r_prime + m) * 255.0f);
-    BYTE g = static_cast<BYTE>((g_prime + m) * 255.0f);
-    BYTE b = static_cast<BYTE>((b_prime + m) * 255.0f);
-    return RGB(r, g, b);
-}
-
-/*
-struct HSL
-{
-    DOUBLE h; // Hue:        0–360
-    DOUBLE s; // Saturation: 0–1
-    DOUBLE l; // Lightness:  0–1
-};
-
-static HSL RGBToHSL(COLORREF color)
-{
-    DOUBLE r = GetRValue(color) / 255.0;
-    DOUBLE g = GetGValue(color) / 255.0;
-    DOUBLE b = GetBValue(color) / 255.0;
-
-    DOUBLE maxc = std::max({ r, g, b });
-    DOUBLE minc = std::min({ r, g, b });
-    DOUBLE delta = maxc - minc;
-
-    HSL hsl{};
-    hsl.l = (maxc + minc) * 0.5;
-
-    if (delta == 0.0)
-    {
-        // Gray (no saturation)
-        hsl.h = 0.0;
-        hsl.s = 0.0;
-    }
-    else
-    {
-        // Saturation
-        hsl.s = (hsl.l > 0.5)
-            ? delta / (2.0 - maxc - minc)
-            : delta / (maxc + minc);
-
-        // Hue
-        if (maxc == r)
-            hsl.h = (g - b) / delta + (g < b ? 6.0 : 0.0);
-        else if (maxc == g)
-            hsl.h = (b - r) / delta + 2.0;
-        else
-            hsl.h = (r - g) / delta + 4.0;
-
-        hsl.h *= 60.0;
-    }
-
-    return hsl;
-}
-
-
-// Lazy AI gen'd glow generator
-static COLORREF ComputeGlowHSL(COLORREF textColor)
-{
-    HSL hsl = RGBToHSL(textColor);
-
-    // --- Opposite lightness ---
-    float glowL = 1.0f - hsl.l;
-
-    // Clamp extremes (avoid harsh halos)
-    glowL = std::clamp(glowL, 0.10f, 0.90f);
-
-    // --- Suppress saturation ---
-    float glowS = hsl.s * 0.15f;
-
-    // If text is clearly colored → fully neutral glow
-    if (hsl.s > 0.25f)
-        glowS = 0.0f;
-
-    // Hue irrelevant when S ≈ 0
-    return HSLToRGB(hsl.h, glowS, glowL);
-}
-*/
-
 BOOL GetAccentColor(COLORREF& outColor)
 {
     // In some programs, e.g. snippingtool.exe, the default blue accent color is used instead of the Windows theme with DwmGetColorizationColor.
     // Use the immersive color API if available, fall back to DwmGetColorizationColor
     // https://github.com/ALTaleX531/TranslucentFlyouts/blob/017970cbac7b77758ab6217628912a8d551fcf7c/Common/ThemeHelper.hpp#L278
-    static const auto s_GetImmersiveColorFromColorSetEx{ reinterpret_cast<DWORD(WINAPI*)(DWORD dwImmersiveColorSet, DWORD dwImmersiveColorType, BOOL bIgnoreHighContrast, DWORD dwHighContrastCacheMode)>(GetProcAddress(GetModuleHandleW(L"UxTheme.dll"), MAKEINTRESOURCEA(95))) };
-    static const auto s_GetImmersiveColorTypeFromName{ reinterpret_cast<DWORD(WINAPI*)(LPCWSTR name)>(GetProcAddress(GetModuleHandleW(L"UxTheme.dll"), MAKEINTRESOURCEA(96))) };
-    static const auto s_GetImmersiveUserColorSetPreference{ reinterpret_cast<DWORD(WINAPI*)(BOOL bForceCheckRegistry, BOOL bSkipCheckOnFail)>(GetProcAddress(GetModuleHandleW(L"UxTheme.dll"), MAKEINTRESOURCEA(98))) };
+    static const auto s_GetImmersiveColorFromColorSetEx{reinterpret_cast<DWORD(WINAPI*)(DWORD dwImmersiveColorSet, DWORD dwImmersiveColorType, BOOL bIgnoreHighContrast, DWORD dwHighContrastCacheMode)>(GetProcAddress(GetModuleHandleW(L"UxTheme.dll"), MAKEINTRESOURCEA(95)))};
+    static const auto s_GetImmersiveColorTypeFromName{reinterpret_cast<DWORD(WINAPI*)(LPCWSTR name)>(GetProcAddress(GetModuleHandleW(L"UxTheme.dll"), MAKEINTRESOURCEA(96)))};
+    static const auto s_GetImmersiveUserColorSetPreference{reinterpret_cast<DWORD(WINAPI*)(BOOL bForceCheckRegistry, BOOL bSkipCheckOnFail)>(GetProcAddress(GetModuleHandleW(L"UxTheme.dll"), MAKEINTRESOURCEA(98)))};
 
     COLORREF AccentClr{ 0 };
     BOOL opaque = FALSE;
@@ -920,50 +755,28 @@ D2D1_COLOR_F IsAccentColorPossibleD2D(BYTE R, BYTE G, BYTE B, AccentColorShade A
 }
 
 HRESULT WINAPI HookedDwmSetWindowAttribute(HWND hWnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute)
-{
-    // Popup menus (#32768) pass here by default to paint 
-    // the window border and corners
-    if (IsWindowClass(hWnd, MENUPOPUP_CLASS) && g_settings.FlyoutsEffects)
-    {
-        if (dwAttribute == DWMWA_BORDER_COLOR && g_settings.BorderFlag)
-        {
-            if (g_settings.BorderActiveColor == DWMWA_COLOR_NONE) {
-                COLORREF Transparent = DWMWA_COLOR_NONE;
-                return DwmSetWindowAttribute_orig(hWnd, DWMWA_BORDER_COLOR, &Transparent, sizeof(COLORREF));
-            }
-            else if (g_settings.BorderActiveColor != DWMWA_COLOR_DEFAULT)
-                return DwmSetWindowAttribute_orig(hWnd, DWMWA_BORDER_COLOR, &g_settings.BorderActiveColor, sizeof(COLORREF));
-        }
-        else if (dwAttribute == DWMWA_WINDOW_CORNER_PREFERENCE && g_settings.BgType != g_settings.Default) {
-            UINT cornerType = (g_settings.CornerPref == DEFAULTROUND) ? g_settings.Rounded : g_settings.CornerPref;
-            return DwmSetWindowAttribute_orig(hWnd, DWMWA_WINDOW_CORNER_PREFERENCE, &cornerType, sizeof(UINT));
-        }
-    }
-            
+{    
     if(!IsWindowEligible(hWnd))
         return DwmSetWindowAttribute_orig(hWnd, dwAttribute, pvAttribute, cbAttribute);
     
-    if(!g_settings.TitlebarFlag)
-    {
-        if ((dwAttribute == DWMWA_SYSTEMBACKDROP_TYPE || dwAttribute == DWMWA_USE_HOSTBACKDROPBRUSH) && g_settings.BgType != g_settings.Default)
-        {
-            if (g_settings.BgType == g_settings.AccentBlurBehind)
-                return DwmSetWindowAttribute_orig(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, &AUTO, sizeof(UINT));
-            if(g_settings.BgType == g_settings.AcrylicSystemBackdrop)
-                return DwmSetWindowAttribute_orig(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, &TRANSIENTWINDOW, sizeof(UINT));
-            else if(g_settings.BgType == g_settings.MicaAlt)
-                return DwmSetWindowAttribute_orig(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, &TABBEDWINDOW, sizeof(UINT));
-            else if(g_settings.BgType == g_settings.Mica)
-                return DwmSetWindowAttribute_orig(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, &MAINWINDOW, sizeof(UINT));
-        }
+    // Popup menus (#32768) pass here by default to paint 
+    // handle by the internal uxtheme function CThemeMenuPopup::EnableRoundedCorners()
+    if (IsWindowClass(hWnd, MENUPOPUP_CLASS) && g_settings.FlyoutsEffects && dwAttribute == DWMWA_WINDOW_CORNER_PREFERENCE) {
+        UINT menuCornerRadius = DWMWCP_ROUND;
+        return DwmSetWindowAttribute_orig(hWnd, DWMWA_WINDOW_CORNER_PREFERENCE, &menuCornerRadius, sizeof(menuCornerRadius));
     }
-    else if ((dwAttribute == DWMWA_CAPTION_COLOR || (dwAttribute == DWMWA_SYSTEMBACKDROP_TYPE 
-        && (IsWindowClass(hWnd, L"CabinetWClass") || IsWindowClass(hWnd, L"TaskManagerWindow")))) && g_settings.TitlebarFlag)
-            return DwmSetWindowAttribute_orig(hWnd, DWMWA_CAPTION_COLOR, &g_settings.g_TitlebarColor, sizeof(COLORREF));
     
-    // Effects on VS Studio, Windows Terminal ...
-    if(dwAttribute == DWMWA_BORDER_COLOR && g_settings.BorderFlag)
-        return DwmSetWindowAttribute_orig(hWnd, DWMWA_BORDER_COLOR, &g_settings.g_BorderColor, sizeof(COLORREF));
+    if ((dwAttribute == DWMWA_SYSTEMBACKDROP_TYPE || dwAttribute == DWMWA_USE_HOSTBACKDROPBRUSH) && g_settings.BgType != g_settings.Default)
+    {
+        if (g_settings.BgType == g_settings.AccentBlurBehind)
+            return DwmSetWindowAttribute_orig(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, &AUTO, sizeof(UINT));
+        if(g_settings.BgType == g_settings.AcrylicSystemBackdrop)
+            return DwmSetWindowAttribute_orig(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, &TRANSIENTWINDOW, sizeof(UINT));
+        else if(g_settings.BgType == g_settings.MicaAlt)
+            return DwmSetWindowAttribute_orig(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, &TABBEDWINDOW, sizeof(UINT));
+        else if(g_settings.BgType == g_settings.Mica)
+            return DwmSetWindowAttribute_orig(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, &MAINWINDOW, sizeof(UINT));
+    }
     
     return DwmSetWindowAttribute_orig(hWnd, dwAttribute, pvAttribute, cbAttribute);
 }
@@ -973,7 +786,7 @@ HRESULT WINAPI HookedDwmExtendFrameIntoClientArea(HWND hWnd, const MARGINS* pMar
     if(!IsWindowEligible(hWnd))
         [[clang::musttail]]return DwmExtendFrameIntoClientArea_orig(hWnd, pMarInset);
     
-    if(g_settings.ExtendFrame && !IsWindowClass(hWnd, L"CASCADIA_HOSTING_WINDOW_CLASS")) {
+    if(!IsWindowClass(hWnd, L"CASCADIA_HOSTING_WINDOW_CLASS")) {
         static const MARGINS margins = {-1, -1, -1, -1};
         [[clang::musttail]]return DwmExtendFrameIntoClientArea_orig(hWnd, &margins);
     }
@@ -982,22 +795,22 @@ HRESULT WINAPI HookedDwmExtendFrameIntoClientArea(HWND hWnd, const MARGINS* pMar
 }
 
 HWND WINAPI HookedNtUserCreateWindowEx(DWORD dwExStyle,
-                                          PUNICODE_STRING UnsafeClassName,
-                                          LPCWSTR VersionedClass,
-                                          PUNICODE_STRING UnsafeWindowName,
-                                          DWORD dwStyle,
-                                          LONG x,
-                                          LONG y,
-                                          LONG nWidth,
-                                          LONG nHeight,
-                                          HWND hWndParent,
-                                          HMENU hMenu,
-                                          HINSTANCE hInstance,
-                                          LPVOID lpParam,
-                                          DWORD dwShowMode,
-                                          DWORD dwUnknown1,
-                                          DWORD dwUnknown2,
-                                          VOID* qwUnknown3) 
+                                       PUNICODE_STRING UnsafeClassName,
+                                       LPCWSTR         VersionedClass,
+                                       PUNICODE_STRING UnsafeWindowName,
+                                       DWORD           dwStyle,
+                                       LONG            x,
+                                       LONG            y,
+                                       LONG            nWidth,
+                                       LONG            nHeight,
+                                       HWND            hWndParent,
+                                       HMENU           hMenu,
+                                       HINSTANCE       hInstance,
+                                       LPVOID          lpParam,
+                                       DWORD           dwShowMode,
+                                       DWORD           dwUnknown1,
+                                       DWORD           dwUnknown2,
+                                       VOID*           qwUnknown3) 
 {
     HWND hWnd = NtUserCreateWindowEx_Original(
         dwExStyle, UnsafeClassName, VersionedClass, UnsafeWindowName, dwStyle,
@@ -1025,74 +838,28 @@ std::wstring GetThemeClass(HTHEME hTheme)
     return ret;
 }
 
-// Fix Alpha of DrawTextW
-// https://github.com/Maplespe/ExplorerBlurMica/blob/79c0ef4d017e32890e107ff98113507f831608b6/ExplorerBlurMica/HookDef.cpp#L859
-INT WINAPI HookedDrawTextW(HDC hdc, LPCWSTR lpchText, INT cchText, LPRECT lprc, UINT format) 
+// Alpha gamma correction LUT — built once at process startup.
+// Applies sRGB inverse gamma ^(1/1.4) to coverage values, which:
+// Brightens antialiased edge pixels
+// Closely matches DrawTextWithGlow's CGamma table behavior
+// Requires no RGB linearization — operates on alpha only
+static std::array<BYTE, 256> g_textAlphaGammaLUT = {1};
+VOID GenerateTextAlphaGammaLUT()
 {
-    if (format & DT_CALCRECT || g_DrawTextWithGlowEntry)
-        return DrawTextW_orig(hdc, lpchText, cchText, lprc, format);
-    
-    HRESULT hr = S_OK;
-    BLENDFUNCTION bf = { AC_SRC_OVER, 0, 255, AC_SRC_ALPHA };
-
-    BP_PAINTPARAMS bpParam;
-    bpParam.cbSize = sizeof(BP_PAINTPARAMS);
-    bpParam.dwFlags = BPPF_ERASE;
-    bpParam.prcExclude = nullptr;
-    bpParam.pBlendFunction = &bf;
-    
-    HDC hDC = nullptr;
-    HPAINTBUFFER pbuffer = BeginBufferedPaint(hdc, lprc, BPBF_TOPDOWNDIB, &bpParam, &hDC);
-    if (pbuffer && hDC)
+    for (int i = 0; i < 256; ++i) 
     {
-        g_DrawTextWithGlowEntry = TRUE;
-        // Set the original DC information
-        SelectObject(hDC, GetCurrentObject(hdc, OBJ_FONT));
-        SetBkMode(hDC, GetBkMode(hdc));
-        SetBkColor(hDC, GetBkColor(hdc));
-        SetTextAlign(hDC, GetTextAlign(hdc));
-        SetTextCharacterExtra(hDC, GetTextCharacterExtra(hdc));
-        SetMapMode(hDC, GetMapMode(hdc));
-
-        COLORREF TextColor = GetTextColor(hdc);
-        COLORREF GlowColor = 0;
-        UINT GlowIntensity = 0;
-        UINT GlowRadius = 0;
-        BOOL Premultiply = FALSE;
-        
-        // Glow blends with Desktop folders list view shadowed texts
-        // creating a very opaque effect
-        /* 
-        GlowColor = ComputeGlowHSL(textcolor);
-        GlowIntensity = GlowColor ? 32 : GlowIntensity;
-        GlowRadius = GlowIntensity ? 2 : GlowRadius;
-        Premultiply = TRUE;
-        */
-
-        hr = DrawTextWithGlow(hDC, lpchText, cchText, lprc, format,
-        TextColor, GlowColor, GlowRadius, GlowIntensity, Premultiply,
-        [](HDC hdc, LPWSTR lpchText, INT cchText, LPRECT lprc, UINT format, LPARAM lParam) WINAPI
-        {
-            return DrawTextW_orig(hdc, lpchText, cchText, lprc, format);
-        },
-        0);
-
-        EndBufferedPaint(pbuffer, TRUE);
-        g_DrawTextWithGlowEntry = FALSE;
-        return (SUCCEEDED(hr)) ? TRUE : DrawTextW_orig(hdc, lpchText, cchText, lprc, format);
+        float a = i * (1.0f / 255.0f);
+        float g = powf(a, 1.0f / 1.4f);
+        g_textAlphaGammaLUT[i] = (BYTE)(g * 255.0f + 0.5f);
     }
-    return DrawTextW_orig(hdc, lpchText, cchText, lprc, format);
 }
 
-BOOL WINAPI HookedDrawTextExW(HDC hdc, LPWSTR lpchText, INT cchText, LPRECT lprc, UINT format, LPDRAWTEXTPARAMS lpdtp)
-{
-    if (!lpdtp && !(format & DT_CALCRECT) && !g_DrawTextWithGlowEntry) {
-
-        auto ret = HookedDrawTextW(hdc, lpchText, cchText, lprc, format);
-        return ret;
-    }
-    return DrawTextExW_orig(hdc, lpchText, cchText, lprc, format, lpdtp);
-}
+// BufferedPaintInit must be called once per thread before any BeginBufferedPaint
+struct BPGuard {
+    BPGuard()  { BufferedPaintInit(); }
+    ~BPGuard() { BufferedPaintUnInit(); }
+};
+thread_local BPGuard tl_bpGuard;
 
 BOOL WINAPI HookedExtTextOutW(
     HDC hdc,
@@ -1104,43 +871,29 @@ BOOL WINAPI HookedExtTextOutW(
     UINT c,
     const INT* lpDx)
 {
-    if (!hdc || (!lpString && options != ETO_OPAQUE) || g_DrawTextWithGlowEntry)
-        return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
-    
-    if (options == (ETO_CLIPPED | ETO_OPAQUE) && lprect) {
-        RECT rect = *lprect;
-        auto ret = HookedDrawTextW(hdc, lpString, c, &rect, DT_LEFT | DT_TOP | DT_SINGLELINE);
-        return (ret) ? TRUE : FALSE;
-    }
-
-    if (options & ETO_OPAQUE && !lprect)
+    if (!hdc || !lpString || !c)
         return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
 
     RECT textRect {0};
     SIZE textSize = {0};
     
-    if (lprect) {
-        // Pass one line (borders) drawings
-        if (options == ETO_OPAQUE && (RECTWIDTH(lprect) == 1 || RECTHEIGHT(lprect) == 1))
-            textRect = *lprect;
-        else if (options != ETO_OPAQUE)
-            textRect = *lprect;
-    }
+    // Boundary calculations
+    if (lprect)
+        textRect = *lprect;
     else if (options == ETO_GLYPH_INDEX)
     {
         if (GetTextExtentPointI(hdc, (WORD*)lpString, c, &textSize))
         {
             textRect.left   = x;
             textRect.top    = y - textSize.cy;
-            textRect.right  = x + textSize.cx ;
+            textRect.right  = x + textSize.cx;
             textRect.bottom = textSize.cy + y;
         }
         else
             return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
     }
-    else if (options == ETO_IGNORELANGUAGE)
-    {
-        if(!GetClipBox(hdc, &textRect)) // GetClipBox has a performance impact, not ideal
+    else if (options == ETO_IGNORELANGUAGE) {
+        if(!GetClipBox(hdc, &textRect))
             return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
     }
     else if (options)
@@ -1155,182 +908,161 @@ BOOL WINAPI HookedExtTextOutW(
         else
             return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
     }
+    else
+        return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
     
-    INT textRectWidth = RECTWIDTH(&textRect);
+    INT textRectWidth  = RECTWIDTH(&textRect);
     INT textRectHeight = RECTHEIGHT(&textRect);
 
     if (textRectWidth <= 0 || textRectHeight <= 0)
         return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
-        
-    BITMAPINFO bmi = {};
-    bmi.bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
-    bmi.bmiHeader.biWidth       = textRectWidth;
-    bmi.bmiHeader.biHeight      = -textRectHeight;
-    bmi.bmiHeader.biPlanes      = 1;
-    bmi.bmiHeader.biBitCount    = 32;
-    bmi.bmiHeader.biCompression = BI_RGB;
 
-    VOID* pixels = nullptr;
-    HDC memDC = CreateCompatibleDC(hdc);
-    if (!memDC)
+    // https://devblogs.microsoft.com/oldnewthing/20110520-00/?p=10613
+    BP_PAINTPARAMS params = { sizeof(BP_PAINTPARAMS) };
+    params.dwFlags = BPPF_ERASE | BPPF_NOCLIP;
+    HDC memDC = nullptr;
+    // Acquire OS cached bitmap
+    HPAINTBUFFER hpb = BeginBufferedPaint(hdc, &textRect, BPBF_TOPDOWNDIB, &params, &memDC);
+    if (!hpb) {
+        Wh_Log(L"Failed BeginBufferedPaint error:0x%08x", GetLastError());
         return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
+    }
 
-    HBITMAP dib = CreateDIBSection(memDC, &bmi, DIB_RGB_COLORS, &pixels, NULL, 0);
-    if (!dib) {
-        DeleteDC(memDC);
+    RGBQUAD* pPixels = nullptr;
+    int rowWidth = 0; // stride in RGBQUADs, not bytes
+    if (FAILED(GetBufferedPaintBits(hpb, &pPixels, &rowWidth))) {
+        EndBufferedPaint(hpb, FALSE); // was missing on this path - leaked hpb
+        Wh_Log(L"Failed GetBufferedPaintBits error:0x%08x", GetLastError());
         return ExtTextOutW_orig(hdc, x, y, options, lprect, lpString, c, lpDx);
-   }
-    HGDIOBJ oldBmp  = SelectObject(memDC, dib);
-    HGDIOBJ oldFont = SelectObject(memDC, GetCurrentObject(hdc, OBJ_FONT));
-    SetTextAlign(memDC, GetTextAlign(hdc));
+    }
 
-    COLORREF origTextColor = GetTextColor(hdc);
-    COLORREF origBkColor = GetBkColor(hdc);
+    // Original DC coloring values
+    COLORREF origTxtClr = GetTextColor(hdc);
+    COLORREF origBkClr = GetBkColor(hdc);
     COLORREF highlightSysClr = GetSysColor(COLOR_HIGHLIGHT);
+    BOOL HighlightedText = (options & ETO_OPAQUE && origBkClr == highlightSysClr);
 
-    origTextColor = (options == ETO_OPAQUE && !lpString) ? origBkColor : origTextColor;
+    SelectObject(memDC, GetCurrentObject(hdc, OBJ_FONT));
+    SetTextAlign(memDC, GetTextAlign(hdc));
     SetBkMode(memDC, TRANSPARENT);
+    SetTextColor(memDC, RGB(255, 255, 255)); // White text mask
 
-    RECT pRect;
-    if (lprect) {
-        pRect = {lprect->left - textRect.left, lprect->top - textRect.top, 
-        lprect->right - textRect.left, lprect->bottom - textRect.top};
-    }
-    
-    // The opaque text background applied to the background of text within editboxes
-    if (options & ETO_OPAQUE && lprect)
-    {
-        if (origBkColor == highlightSysClr) {
-            FillRect(hdc, lprect, (HBRUSH)GetStockObject(BLACK_BRUSH));
-            HBRUSH brush = CreateSolidBrush(origBkColor);
-            FillRect(memDC, &pRect, brush);
-            DeleteObject(brush);
-        }
-        else if (origBkColor != 0x00383838) // bypass editbox BkColor on open/save dialogs
-        {
-            FillRect(hdc, lprect, (HBRUSH)GetStockObject(BLACK_BRUSH));
-            HBRUSH brush = CreateSolidBrush(origBkColor);
-            FillRect(memDC, &pRect, brush);
-            DeleteObject(brush);
-        }
-    }
-        
-    // White text mask
-    SetTextColor(memDC, RGB(255, 255, 255));
-
-    // Render text with removed the opaque background text flag, because it has already been done by us
-    WINBOOL res = ExtTextOutW_orig(memDC, x - textRect.left, y - textRect.top, options &~ ETO_OPAQUE, &pRect, lpString, c, lpDx);
-
-    BYTE txtR = GetRValue(origTextColor);
-    BYTE txtG = GetGValue(origTextColor);
-    BYTE txtB = GetBValue(origTextColor);
-
-    BYTE dstB = !(options & ETO_OPAQUE) ? 0 : GetBValue(origBkColor);
-    BYTE dstG = !(options & ETO_OPAQUE) ? 0 : GetGValue(origBkColor);
-    BYTE dstR = !(options & ETO_OPAQUE) ? 0 : GetRValue(origBkColor);
-
-    // Alpha Blend
-    BYTE alpha;
-    BYTE* p = (BYTE*)pixels;
-    for (INT i = 0; i < textRectWidth * textRectHeight; ++i) {
-        // Rec.709/sRGB luminance 
-        alpha = (BYTE)((p[2] * 54 + p[1] * 183 + p[0] * 19) >> 8);
-        if (alpha) 
-        {
-            p[0] = (BYTE)((txtB * alpha + dstB * (255 - alpha)) >> 8); // B
-            p[1] = (BYTE)((txtG * alpha + dstG * (255 - alpha)) >> 8); // G
-            p[2] = (BYTE)((txtR * alpha + dstR * (255 - alpha)) >> 8); // R
-            // full alpha highlight background fixes antialiased pixel bleed
-            p[3] = (options & ETO_OPAQUE && (origBkColor == highlightSysClr)) ? 255 : alpha; // A
-        }
-        p += 4;
+    if ((options & ETO_OPAQUE) && lprect) {
+        HBRUSH brush = CreateSolidBrush(origBkClr);
+        FillRect(hdc, lprect, brush);
+        DeleteObject(brush);
     }
 
-    // Blend composited text
+    WINBOOL res = ExtTextOutW_orig(memDC, x, y, options & ~ETO_OPAQUE, lprect, lpString, c, lpDx);
+
+    // Compositing
+    for (INT cy = 0; cy < textRectHeight; ++cy) {
+        RGBQUAD* row = pPixels + (cy * rowWidth);
+        for (INT cx = 0; cx < textRectWidth; ++cx) {
+            RGBQUAD& p = row[cx];
+            // Alpha extraction + gamma correction
+            BYTE luma = (BYTE)((p.rgbBlue + (p.rgbGreen << 1) + p.rgbRed) >> 2);
+            BYTE txtA = g_textAlphaGammaLUT[luma];
+            if (txtA == 0 && !(options & ETO_OPAQUE))
+                continue;
+            // handle background transparency only for selected text
+            BYTE bgWeight = HighlightedText ? (255 - txtA) : 0;
+            p.rgbBlue     = (((GetBValue(origTxtClr) * txtA) + (GetBValue(origBkClr) * bgWeight)) >> 8);
+            p.rgbGreen    = (((GetGValue(origTxtClr) * txtA) + (GetGValue(origBkClr) * bgWeight)) >> 8);
+            p.rgbRed      = (((GetRValue(origTxtClr) * txtA) + (GetRValue(origBkClr) * bgWeight)) >> 8);
+            p.rgbReserved = bgWeight ? 255 : txtA;
+        }
+    }
+
     BLENDFUNCTION blend = {AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
     AlphaBlend(hdc, textRect.left, textRect.top, textRectWidth, textRectHeight,
-               memDC, 0, 0, textRectWidth, textRectHeight, blend);
+            memDC, textRect.left, textRect.top, textRectWidth, textRectHeight, blend);
 
-    SelectObject(memDC, oldFont);
-    SelectObject(memDC, oldBmp);
-    DeleteObject(dib);
-    DeleteDC(memDC);
+    EndBufferedPaint(hpb, FALSE);
+    return res;
+
     return res;
 }
 
-// Prevent recursive calls within the DrawText class API and perform Alpha repair
-// https://github.com/Maplespe/ExplorerBlurMica/blob/79c0ef4d017e32890e107ff98113507f831608b6/ExplorerBlurMica/HookDef.cpp#L1085
+// Bypass alpha blending operation done by default (e.g context menus, win32 adressbar) as it is done by our ExtTextOutW hook.
+HRESULT WINAPI HookedDrawTextWithGlow(HDC hdcMem, LPWSTR pszText, UINT cch, RECT* pRect, DWORD dwFlags, COLORREF crText,
+                                      COLORREF crGlow, UINT nGlowRadius, UINT nGlowIntensity, BOOL fPreMultiply,
+                                      DTT_CALLBACK_PROC pfnDrawTextCallback, LPARAM lParam)
+{
+    if (pRect->right == pRect->left || pRect->bottom == pRect->top) { 
+        if ((dwFlags & DT_CALCRECT) == 0)
+            return DrawTextWithGlow(hdcMem, pszText, cch, pRect, dwFlags, crText, crGlow, nGlowRadius, nGlowIntensity, fPreMultiply, pfnDrawTextCallback, lParam);
+    }
+
+    // Do not mess with text using glow effects (if such exist in Win11)
+    if (nGlowRadius > 0)
+        return DrawTextWithGlow(hdcMem, pszText, cch, pRect, dwFlags, crText, crGlow, nGlowRadius, nGlowIntensity, fPreMultiply, pfnDrawTextCallback, lParam);
+
+    SetTextColor(hdcMem, crText);
+    SetBkColor(hdcMem, RGB(0, 0, 0));
+    
+    HRESULT hr = S_OK;
+    
+    if (pfnDrawTextCallback)
+        hr = pfnDrawTextCallback(hdcMem, pszText, cch, pRect, dwFlags, lParam);
+    else
+        hr = DrawTextW(hdcMem, pszText, cch, pRect, dwFlags & ~DT_MODIFYSTRING);
+
+    return hr;
+}
+
+INT WINAPI HookedDrawTextW(HDC hdc, LPCWSTR lpchText, int cchText, LPRECT lprc, UINT format)
+{   
+    // Windows 11 context menus use Fluent icons as glyphs
+    // Handled internally in the shell32 routine s_DrawGlyph()
+    auto ContextMenuGlyphs = [&hdc, &lpchText]() {
+        const WCHAR fluentIconGlyph_ChevronRightMed = 0xE974;
+        const WCHAR fluentIconGlyph_ChevronLeftMed = 0xE973;
+        const WCHAR fluentIconGlyph_AcceptMedium = 0xF78C;
+        const WCHAR fluentIconGlyph_RadioBullet = 0xE915;
+        
+        if (*lpchText == fluentIconGlyph_ChevronRightMed || *lpchText == fluentIconGlyph_ChevronLeftMed 
+            || *lpchText == fluentIconGlyph_AcceptMedium || *lpchText == fluentIconGlyph_RadioBullet)
+                g_IsSysThemeDarkMode ? SetTextColor(hdc, RGB(255, 255, 255)) : SetTextColor(hdc, RGB(0, 0, 0));
+    };
+
+    // Catch and modify context menu fluent icons coloring
+    if (cchText == 1)
+        ContextMenuGlyphs();
+
+    // Modify and convert hardcoded Syslink black text color into white (e.g. inside "Sharing" win32 Properties tab)
+    if (!g_IsSysThemeDarkMode || (GetTextColor(hdc) & 0x00FFFFFF) != RGB(0, 0, 0))
+        return DrawTextW_orig(hdc, lpchText, cchText, lprc, format);
+    
+    HWND hWnd = WindowFromDC(hdc);
+    if (GetWindowClass(hWnd) == L"SysLink")
+        SetTextColor(hdc, RGB(255, 255, 255));
+
+    return DrawTextW_orig(hdc, lpchText, cchText, lprc, format);
+}
+
 HRESULT WINAPI HookedDrawThemeTextEx(HTHEME hTheme, HDC hdc, INT iPartId, INT iStateId, LPCWSTR pszText,
-        INT cchText, DWORD dwTextFlags, LPRECT pRect, const DTTOPTS* pOptions)
+    INT cchText, DWORD dwTextFlags, LPRECT pRect, const DTTOPTS* pOptions)
 {
     std::wstring ThemeClassName = GetThemeClass(hTheme);
-
     if (pOptions == nullptr) {
         DTTOPTS Options = { sizeof(DTTOPTS) };
         GetThemeColor(hTheme, iPartId, iStateId, TMT_TEXTCOLOR, &Options.crText);
-        Options.dwFlags = DTT_TEXTCOLOR;
+        Options.dwFlags |= DTT_TEXTCOLOR;
         return DrawThemeTextEx_orig(hTheme, hdc, iPartId, iStateId, pszText, cchText, dwTextFlags, (LPRECT)pRect, &Options);
     }
+
+    if ((pOptions->dwFlags & DTT_CALCRECT))
+        return DrawThemeTextEx_orig(hTheme, hdc, iPartId, iStateId, pszText, cchText, dwTextFlags, (LPRECT)pRect, pOptions);
     
-    if (pOptions && !(pOptions->dwFlags & DTT_CALCRECT) && !((pOptions->dwFlags & DTT_COMPOSITED) && ThemeClassName != L"Menu"))
-    {
-        HRESULT hr;
-        BLENDFUNCTION bf = { AC_SRC_OVER, 0, 255, AC_SRC_ALPHA };
+    DTTOPTS Options = { sizeof(DTTOPTS) };
+    Options = *pOptions;
+    GetThemeColor(hTheme, iPartId, iStateId, TMT_TEXTCOLOR, &Options.crText);
+    Options.dwFlags |= DTT_TEXTCOLOR;
+    return DrawThemeTextEx_orig(hTheme, hdc, iPartId, iStateId, pszText, cchText, dwTextFlags, (LPRECT)pRect, &Options);
 
-        BP_PAINTPARAMS bpParam;
-        bpParam.cbSize = sizeof(BP_PAINTPARAMS);
-        bpParam.dwFlags = BPPF_ERASE;
-        bpParam.prcExclude = nullptr;
-        bpParam.pBlendFunction = &bf;
-        
-        HDC hDC = nullptr;
-        HPAINTBUFFER pbuffer = BeginBufferedPaint(hdc, pRect, BPBF_TOPDOWNDIB, &bpParam, &hDC);
-        if (pbuffer && hDC)
-        {
-            g_DrawTextWithGlowEntry = TRUE;
-            // Set the original DC information
-            SelectObject(hDC, GetCurrentObject(hdc, OBJ_FONT));
-            SetBkMode(hDC, GetBkMode(hdc));
-            SetBkColor(hDC, GetBkColor(hdc));
-            SetTextAlign(hDC, GetTextAlign(hdc));
-            SetTextCharacterExtra(hDC, GetTextCharacterExtra(hdc));
-            //SetTextColor(hDC, GetTextColor(hdc));
-
-            COLORREF TextColor = pOptions->crText;
-            GetThemeColor(hTheme, iPartId, iStateId, TMT_TEXTCOLOR, &TextColor);
-
-            COLORREF GlowColor = 0;
-            UINT GlowIntensity = 0;
-            UINT GlowRadius = 0;
-            BOOL Premultiply = FALSE;
-            
-            // Text drawing with both alpha composited and text shadows doesn't seem to work with DrawThemeTextEx.
-            // (DTT_COMPOSITED | DTT_SHADOWCOLOR | DTT_SHADOWTYPE | DTT_SHADOWOFFSET)
-            // Instead the internal DrawTextWithGlow is already used which composites the texts and also adds a glow effect.
-            // Unfortunately, not all text passes here for the HTHEME class to detect and handle.
-            /*
-            GlowColor = ComputeGlowHSL(textcolor);
-            GlowIntensity = GlowColor ? 32 : GlowIntensity;
-            GlowRadius = GlowIntensity ? 2 : GlowRadius;
-            Premultiply = GlowRadius ? TRUE : Premultiply;
-
-            // Move the text so the glow doesn't get cut off
-            OffsetRect(pRect, 1, 0);
-            */
-
-            hr = DrawTextWithGlow(hDC, pszText, cchText, pRect, dwTextFlags,
-            TextColor, GlowColor, GlowRadius, GlowIntensity, Premultiply, pOptions->pfnDrawTextCallback, pOptions->lParam);
-
-            EndBufferedPaint(pbuffer, TRUE);
-            g_DrawTextWithGlowEntry = FALSE;
-            return (SUCCEEDED(hr)) ? TRUE : FALSE;
-        }
-    }
-    return DrawThemeTextEx_orig(hTheme, hdc, iPartId, iStateId, pszText, cchText, dwTextFlags, (LPRECT)pRect, pOptions);
 }
 
-// Convert to DrawThemeTextEx call
-// https://github.com/Maplespe/ExplorerBlurMica/blob/79c0ef4d017e32890e107ff98113507f831608b6/ExplorerBlurMica/HookDef.cpp#L1072
 HRESULT WINAPI HookedDrawThemeText(HTHEME hTheme, HDC hdc, INT iPartId, INT iStateId, LPCTSTR pszText,
     INT cchText, DWORD dwTextFlags, DWORD dwTextFlags2, LPCRECT pRect) 
 {
@@ -1421,11 +1153,13 @@ constexpr INT SysColorElements[] = {
 
 BOOL SetCurrentTheme(LPCWSTR themeclass)
 {
-    if (g_hTheme != nullptr)
-        g_hTheme = nullptr;
+    if (g_hThemeSysMetrics != nullptr)
+        g_hThemeSysMetrics = nullptr;
 
-    g_hTheme = OpenThemeData(NULL, themeclass);
-    return (g_hTheme) ? TRUE : FALSE;
+    g_hThemeSysMetrics = OpenThemeData(NULL, themeclass);
+    if (!g_hThemeSysMetrics)
+        CloseThemeData(g_hThemeSysMetrics);
+    return (g_hThemeSysMetrics) ? TRUE : FALSE;
 }
 
 void ClearSysColorsRegKey() {
@@ -1434,20 +1168,19 @@ void ClearSysColorsRegKey() {
 
 VOID RevertSysColors()
 {
-    if (!SetCurrentTheme(L"sysmetrics")) {
-        CloseThemeData(g_hTheme);
+    if (!SetCurrentTheme(L"sysmetrics"))
         return;
-    }
+    
     COLORREF aNewColors[ARRAYSIZE(SysColorElements)];
 
-    for (UINT i = 0; i < ARRAYSIZE(SysColorElements); i++)
-        aNewColors[i] = GetThemeSysColor(g_hTheme, i);
-    SetSysColors(ARRAYSIZE(SysColorElements), SysColorElements, aNewColors);
+    for (UINT i = 0; i < ARRAYSIZE(SysColorElements); i++) 
+        aNewColors[i] = GetThemeSysColor(g_hThemeSysMetrics, i); 
+    SetSysColors(ARRAYSIZE(SysColorElements), SysColorElements, aNewColors); 
 
-    CloseThemeData(g_hTheme);
-    g_hTheme = nullptr;
+    CloseThemeData(g_hThemeSysMetrics);
+    g_hThemeSysMetrics = nullptr;
 
-    ClearSysColorsRegKey();
+    //ClearSysColorsRegKey();
 }
 
 static COLORREF GetDefaultSysColor(INT nIndex)
@@ -1493,25 +1226,26 @@ static COLORREF GetDefaultSysColor(INT nIndex)
     return GetSysColor_orig(nIndex);
 }
 
-static COLORREF GetCustomSysColor(INT nIndex) 
+static COLORREF GetCustomSysColor(INT nIndex)
 {
-    if (nIndex == COLOR_SCROLLBAR || nIndex == COLOR_BACKGROUND || nIndex == COLOR_MENU ||
-        nIndex == COLOR_WINDOW || nIndex == COLOR_INACTIVEBORDER || nIndex == COLOR_INFOBK ||
+    if (nIndex == COLOR_SCROLLBAR || nIndex == COLOR_BACKGROUND || nIndex == COLOR_MENU || nIndex == COLOR_WINDOW || nIndex == COLOR_INACTIVEBORDER || nIndex == COLOR_INFOBK ||
         nIndex == COLOR_MENUBAR)
         return RGB(0, 0, 0);
     else if (nIndex == COLOR_GRADIENTACTIVECAPTION || nIndex == COLOR_INACTIVECAPTION)
         return (g_settings.AccentColorize) ? g_settings.AccentColor : RGB(0, 0, 0);
     else if (nIndex == COLOR_ACTIVECAPTION || nIndex == COLOR_GRADIENTINACTIVECAPTION)
         return (g_settings.AccentColorize) ? g_settings.AccentColor : RGB(32, 32, 32);
-    else if (nIndex == COLOR_ACTIVEBORDER || nIndex == COLOR_BTNSHADOW)
+    else if (nIndex == COLOR_ACTIVEBORDER)
         return RGB(32, 32, 32);
-    else if (nIndex == COLOR_WINDOWFRAME || nIndex == COLOR_BTNHIGHLIGHT)
+    else if (nIndex == COLOR_BTNSHADOW)
+        return RGB(32, 32, 32);
+    else if (nIndex == COLOR_WINDOWFRAME)
+        return RGB(96, 96, 96);
+    else if (nIndex == COLOR_BTNHIGHLIGHT)
         return RGB(64, 64, 64);
-    else if (nIndex == COLOR_MENUTEXT || nIndex == COLOR_CAPTIONTEXT ||
+    else if (nIndex == COLOR_WINDOWTEXT || nIndex == COLOR_MENUTEXT || nIndex == COLOR_CAPTIONTEXT ||
              nIndex == COLOR_BTNTEXT || nIndex == COLOR_INFOTEXT || nIndex == COLOR_HIGHLIGHTTEXT)
-        return RGB(220, 220, 220);
-    else if (nIndex == COLOR_WINDOWTEXT)
-        return RGB(198, 198, 198);
+        return RGB(255, 255, 255);
     else if (nIndex == COLOR_APPWORKSPACE)
         return RGB(8, 8, 8);
     else if (nIndex == COLOR_HIGHLIGHT || nIndex == COLOR_MENUHILIGHT)
@@ -1532,7 +1266,8 @@ static COLORREF GetCustomSysColor(INT nIndex)
     return GetSysColor_orig(nIndex);
 }
 
-COLORREF WINAPI HookedGetSysColor(INT nIndex) {
+COLORREF WINAPI HookedGetSysColor(INT nIndex) 
+{
     if (g_DefaultSysColors)
         return GetDefaultSysColor(nIndex);
     else
@@ -1541,91 +1276,50 @@ COLORREF WINAPI HookedGetSysColor(INT nIndex) {
 
 HBRUSH WINAPI HookedGetSysColorBrush(INT nIndex) 
 {
-    COLORREF color = HookedGetSysColor(nIndex);
-    if (g_DefaultSysColors) {
-        if (!g_themeCachedDefaultSysColorBrushes[nIndex])
-            g_themeCachedDefaultSysColorBrushes[nIndex] = CreateSolidBrush(color);
-        return g_themeCachedDefaultSysColorBrushes[nIndex];
+    auto& cacheArray = g_DefaultSysColors ? g_themeCachedDefaultSysColorBrushes : g_themeCachedCustomSysColorBrushes;
+    
+    HBRUSH cachedBrush = cacheArray[nIndex];
+    
+    if (cachedBrush && GetObjectType(cachedBrush) == OBJ_BRUSH)
+        return cachedBrush; 
+
+    AcquireSRWLockExclusive(&g_SysColorsLock);
+    
+    HBRUSH& refSysBrush = cacheArray[nIndex];
+    
+    if (refSysBrush && GetObjectType(refSysBrush) != OBJ_BRUSH)
+        refSysBrush = NULL; 
+
+    if (!refSysBrush) {
+        COLORREF color = HookedGetSysColor(nIndex);
+        refSysBrush = CreateSolidBrush(color);
     }
-    else {
-        if (!g_themeCachedCustomSysColorBrushes[nIndex])
-            g_themeCachedCustomSysColorBrushes[nIndex] = CreateSolidBrush(color);
-        return g_themeCachedCustomSysColorBrushes[nIndex];
-    }
+
+    HBRUSH hbr = refSysBrush;
+    ReleaseSRWLockExclusive(&g_SysColorsLock);
+    
+    return hbr;
 }
 
 VOID ColorizeSysColors()
-{
+{   
     // Stop recalling SetSysColors if syscolor changes have been applied.
     // SetSysColors redraws all top level windows causing flickering.
-    if (GetSysColor(COLOR_WINDOW) == RGB(0, 0, 0))
-    {
-        if (g_settings.AccentColorize && GetSysColor(COLOR_HIGHLIGHT) == g_settings.AccentColor)
-            return;
-        else if (!g_settings.AccentColorize)
-            return ;
-    }
+    if (GetSysColor_orig(COLOR_WINDOW) == RGB(0, 0, 0))
+        return;
     
     COLORREF aNewColors[ARRAYSIZE(SysColorElements)];
     for (UINT i = 0; i < ARRAYSIZE(SysColorElements); i++)
         aNewColors[i] = GetCustomSysColor(SysColorElements[i]);
-
+        
     SetSysColors(ARRAYSIZE(SysColorElements), SysColorElements, aNewColors);
-}
-
-HRESULT WINAPI HookedGetThemeBitmap(
-    HTHEME hTheme,
-    INT iPartId,
-    INT iStateId,
-    INT iPropId,
-    ULONG dwFlags,
-    HBITMAP* phBitmap)
-{   
-    std::wstring ThemeClassName = GetThemeClass(hTheme);
-
-    if (ThemeClassName == L"Tab" && iPartId == 10)
-    {    
-        BITMAP bm = {};
-        if (!GetObject(*phBitmap, sizeof(bm), &bm))
-            return FALSE;
-
-        if (bm.bmBitsPixel != 32)
-            return FALSE;
-
-        INT size = bm.bmWidth * bm.bmHeight * 4;
-        BYTE* pBits = new BYTE[size];
-        if (!pBits)
-            return FALSE;
-
-        if (GetBitmapBits(*phBitmap, size, pBits) != size)
-        {
-            delete[] pBits;
-            return FALSE;
-        }
-
-        for (INT y = 0; y < bm.bmHeight; y++)
-        {
-            BYTE* pPixel = pBits + bm.bmWidth * 4 * y;
-            for (INT x = 0; x < bm.bmWidth; x++, pPixel += 4)
-            {
-                pPixel[0] = 0; //B
-                pPixel[1] = 0; //G
-                pPixel[2] = 0; //R
-                pPixel[3] = 0; //A
-            }
-        }
-
-        SetBitmapBits(*phBitmap, size, pBits);
-        delete[] pBits;
-    }
-    return GetThemeBitmap_orig(hTheme, iPartId, iStateId, iPropId, dwFlags, phBitmap);
 }
 
 HRESULT WINAPI HookedGetColorTheme(HTHEME hTheme, INT iPartId, INT iStateId, INT iPropId, COLORREF *pColor) 
 {
     HRESULT hr = GetThemeColor_orig(hTheme, iPartId, iStateId, iPropId, pColor);
     std::wstring ThemeClassName = GetThemeClass(hTheme);
-    
+
     if (ThemeClassName == L"ItemsView" && iPropId == TMT_TEXTCOLOR && ((iPartId == 4 && iStateId == 1) || iPartId == 5))
     {
         *pColor = (!g_IsSysThemeDarkMode && *pColor == 0x006D6D6D) ? RGB(0, 0, 0) : *pColor;
@@ -1633,13 +1327,23 @@ HRESULT WINAPI HookedGetColorTheme(HTHEME hTheme, INT iPartId, INT iStateId, INT
     }
     if (ThemeClassName == L"ListView" && iPropId == TMT_TEXTCOLOR && iPartId == LVP_LISTITEM)
     {
+        *pColor = (g_IsSysThemeDarkMode && (iStateId == THEMECLS_COMMONPROPS_PART || iStateId == LISS_SELECTED)) ? RGB(255, 255, 255) : *pColor;
         *pColor = (!g_IsSysThemeDarkMode && *pColor == 0x006D6D6D) ? RGB(0, 0, 0) : *pColor;
+        return S_OK;
+    }
+    else if (ThemeClassName == L"ListView" && iPartId == LVP_GROUPHEADER)
+    {
+        *pColor = (g_IsSysThemeDarkMode) ? RGB(255, 255, 255) : *pColor;
         return S_OK;
     }
     else if (ThemeClassName == L"PreviewPane" && (iPartId == 5 || iPartId == 7 || iPartId == 6) && iPropId == TMT_FILLCOLOR) {
         *pColor = (iPartId == 6) ? RGB(192, 192, 192) : RGB(255, 255, 255);
         return S_OK;
-    } 
+    }
+    else if (ThemeClassName == L"PreviewPane" && iPropId == TMT_TEXTCOLOR) {
+        *pColor = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : *pColor;
+        return S_OK;
+    }  
     else if (ThemeClassName == L"ControlPanelStyle" && iPropId == TMT_TEXTCOLOR)
     {
         if ((iPartId == CPANEL_BODYTITLE || iPartId == CPANEL_GROUPTEXT || iPartId == CPANEL_MESSAGETEXT 
@@ -1737,9 +1441,19 @@ HRESULT WINAPI HookedGetColorTheme(HTHEME hTheme, INT iPartId, INT iStateId, INT
             return S_OK;
         }
         else if (iPartId == THEMECLS_COMMONPROPS_PART) {
-            *pColor = RGB(255, 255, 255);
+            *pColor = (g_IsSysThemeDarkMode && (*pColor & 0xff000000) == RGB(0, 0, 0)) ? RGB(255, 255, 255) : *pColor;
             return S_OK;
         }
+    }
+    else if (ThemeClassName == L"Header" && iPropId == TMT_TEXTCOLOR)
+    {
+        *pColor = (g_IsSysThemeDarkMode) ? RGB(255, 255, 255) : *pColor;
+        return S_OK;
+    }
+    else if (ThemeClassName == L"SearchEditBox" && iPropId == TMT_TEXTCOLOR)
+    {
+        *pColor = (*pColor == 0x006d6d6d) ? ((g_IsSysThemeDarkMode) ? RGB(255, 255, 255) : RGB(0, 0, 0)) : *pColor;
+        return S_OK;
     }
     else if (ThemeClassName == L"Combobox" && iPropId == TMT_TEXTCOLOR)
     {
@@ -1751,22 +1465,17 @@ HRESULT WINAPI HookedGetColorTheme(HTHEME hTheme, INT iPartId, INT iStateId, INT
     else if (ThemeClassName == L"Menu" && iPropId == TMT_TEXTCOLOR)
     {
         if (iPartId == MENU_BARITEM && (iStateId != MBI_DISABLED && iStateId != MBI_DISABLEDPUSHED)) {
-            *pColor = (g_IsSysThemeDarkMode && *pColor == RGB(0, 0, 0)) ? RGB(255, 255, 255) : *pColor;
+            *pColor = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0);
             return S_OK;
         }
         else if ((iPartId == MENU_POPUPITEM || iPartId == 27) && (iStateId != 3 && iStateId != 4)) {
-            *pColor = (g_IsSysThemeDarkMode && *pColor == RGB(0, 0, 0)) ? RGB(255, 255, 255) : *pColor;
+            *pColor = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0);
             return S_OK;
         }
     }
     else if (ThemeClassName == L"Menu" && (iPropId == TMT_FILLCOLOR || iPropId == TMT_FILLCOLORHINT))
     {
-        if (iPartId == 10) {
-            if (g_settings.BorderActiveColor == DWMWA_COLOR_NONE)
-                *pColor = (g_settings.FlyoutsEffects) ? RGB(0, 0, 0) : (g_settings.FillBg) ? RGB(32, 32, 32) : *pColor;
-        }
-        else
-            *pColor = (g_settings.FlyoutsEffects) ? RGB(0, 0, 0) : (g_settings.FillBg) ? RGB(32, 32, 32) : *pColor;
+        *pColor = (g_settings.FlyoutsEffects) ? RGB(0, 0, 0) : (g_settings.FillBg) ? RGB(32, 32, 32) : *pColor;
         return S_OK;
     }
     else if ((ThemeClassName == L"Toolbar") && iPropId == TMT_TEXTCOLOR)
@@ -1793,7 +1502,7 @@ HRESULT WINAPI HookedGetColorTheme(HTHEME hTheme, INT iPartId, INT iStateId, INT
     }
     else if (ThemeClassName == L"DragDrop" && iPropId == TMT_TEXTCOLOR)
     {
-        *pColor = (iStateId == 1) ? RGB(96, 205, 255) : RGB(255, 255, 255);
+        *pColor = (iStateId == 1) ? ((g_settings.AccentColorize) ? g_settings.AccentColor : RGB(96, 205, 255)) : RGB(255, 255, 255);
         return S_OK;
     }
     else if (ThemeClassName == L"ChartView")
@@ -1820,6 +1529,11 @@ HRESULT WINAPI HookedGetColorTheme(HTHEME hTheme, INT iPartId, INT iStateId, INT
     else if (ThemeClassName == L"AeroWizardStyle" && iPropId == TMT_TEXTCOLOR)
     {
         *pColor = RGB(255, 255, 255);
+        return S_OK;
+    }
+    else if (ThemeClassName == L"ScrollbarStyle" && iPropId == TMT_FILLCOLORHINT)
+    {
+        *pColor = RGB(96, 96, 96);
         return S_OK;
     }
     else if (ThemeClassName == L"TaskManager")
@@ -1902,7 +1616,7 @@ HRESULT WINAPI HookedGetColorTheme(HTHEME hTheme, INT iPartId, INT iStateId, INT
     {
         if (iPropId == TMT_TEXTCOLOR)
         {
-            *pColor = (g_IsSysThemeDarkMode && *pColor == RGB(0, 0, 0) ) ? RGB(255, 255, 255) : *pColor;
+            *pColor = (g_IsSysThemeDarkMode && (*pColor & 0xff000000) == RGB(0, 0, 0)) ? RGB(255, 255, 255) : *pColor;
             return S_OK;
         }
         if (iPropId == TMT_FILLCOLOR)
@@ -1971,11 +1685,12 @@ public:
     std::array<HDC, 2> trackbar;
     std::array<HDC, 24> trackbarthumb;
     std::array<HDC, 2> header;
-    std::array<HDC, 1> previewseperator;
+    std::array<HDC, 1> previewseparator;
     std::array<HDC, 4> modulebutton;
     std::array<HDC, 4> modulelocationbutton;
     std::array<HDC, 8> modulesplitbutton;
     std::array<HDC, 12> navigationbutton;
+    std::array<HDC, 1> navigationdivider;
     std::array<HDC, 5> toolbarbutton;
     std::array<HDC, 4> addressband;
     std::array<HDC, 4> menuitem;
@@ -2003,11 +1718,12 @@ public:
     BOOL CacheTrackBarThumb(HDC, INT, INT, INT);
     BOOL CacheTrackBarPointedThumb(HDC, INT, INT, INT);
     BOOL CacheHeader(HDC, INT, INT);
-    BOOL CachePreviewPaneSeperator(HDC);
+    BOOL CachePreviewPaneSeparator(HDC);
     BOOL CacheModuleButton(HDC, INT, INT);
     BOOL CacheModuleLocationButton(HDC, INT, INT);
     BOOL CacheModuleSplitButton(HDC,INT, INT, INT);
     BOOL CacheNavigationButton(HDC, INT, INT, INT);
+    BOOL CacheNavigationDivider(HDC);
     BOOL CacheToolbarButton(HDC, INT, INT);
     BOOL CacheAddressBand(HDC, INT, INT);
     BOOL CacheMenuItem(HDC, INT, INT, INT);
@@ -2016,11 +1732,10 @@ public:
 
     BOOL CreateDIB(HDC& elementHdc, HDC hDC, INT Width, INT Height)
     {
-        if (!elementHdc) {
-            if (!(elementHdc = CreateCompatibleDC(hDC)))
-                return FALSE;
-        }
-        else if (!(elementHdc = CreateCompatibleDC(NULL)))
+        if (elementHdc)
+            DeleteHDC(elementHdc);
+
+        if (!(elementHdc = CreateCompatibleDC(NULL)))
             return FALSE;
 
         BITMAPINFO bmi;
@@ -2030,9 +1745,6 @@ public:
         bmi.bmiHeader.biPlanes = 1;
         bmi.bmiHeader.biBitCount = 32;
         bmi.bmiHeader.biCompression = BI_RGB;
-
-        if (HBITMAP hOldBmp = (HBITMAP)SelectObject(elementHdc, nullptr))
-            DeleteObject(hOldBmp);
         
         VOID* pvBits;
         HBITMAP hBitmap = CreateDIBSection(elementHdc, &bmi, DIB_RGB_COLORS, &pvBits, nullptr, 0);
@@ -2081,7 +1793,7 @@ public:
             DeleteHDC(hDC);
         for (HDC& hDC : header)
             DeleteHDC(hDC);
-        for (HDC& hDC : previewseperator)
+        for (HDC& hDC : previewseparator)
             DeleteHDC(hDC);
         for (HDC& hDC : modulebutton)
             DeleteHDC(hDC);
@@ -2090,6 +1802,8 @@ public:
         for (HDC& hDC : modulesplitbutton)
             DeleteHDC(hDC);
         for (HDC& hDC : navigationbutton)
+            DeleteHDC(hDC);
+        for (HDC& hDC : navigationdivider)
             DeleteHDC(hDC);
         for (HDC& hDC : toolbarbutton)
             DeleteHDC(hDC);
@@ -2226,18 +1940,18 @@ BOOL PaintScroll(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     if (!g_themeCache.scrollbar[index])
         if (!g_themeCache.CacheScrollbar(hdc, iPartId, iStateId, index))
             return FALSE;
-    // Make scrollbar thinner by moving the rect's left and right edges
-    RECT rc = (iPartId == SBP_THUMBBTNVERT) ? 
-    RECT(static_cast<LONG>(pRect->left + (RECTWIDTH(pRect) * 0.25f)), pRect->top, static_cast<LONG>(pRect->right - (RECTWIDTH(pRect) * 0.25f)), pRect->bottom)
-    : RECT(pRect->left, static_cast<LONG>(pRect->top + (RECTHEIGHT(pRect) * 0.25f)) , pRect->right, static_cast<LONG>(pRect->bottom - (RECTHEIGHT(pRect) * 0.25f)));
-    DrawNineGridStretch(hdc, g_themeCache.scrollbar[index], &rc, 6, 6, 6, 6);
+
+    FillRect(hdc, pRect, (HBRUSH)GetStockObject(BLACK_BRUSH));
+    DrawNineGridStretch(hdc, g_themeCache.scrollbar[index], pRect, 8, 5, 8, 5);
     return TRUE;
 }
 
 BOOL CThemeCache::CacheScrollbar(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
-    INT width = 18, height = 18;
+    INT width = 17 * scale, height = 11 * scale;
+    if (iPartId == SBP_THUMBBTNHORZ)
+        width = 20 * scale, height = 17 * scale;
     FLOAT cornerRadius = 4.f * scale;
 
     if (!g_themeCache.CreateDIB(g_themeCache.scrollbar[stateIndex], hdc, width, height))
@@ -2248,7 +1962,16 @@ BOOL CThemeCache::CacheScrollbar(HDC hdc, INT iPartId, INT iStateId, INT stateIn
     if (FAILED(CreateBoundD2DRenderTarget(g_themeCache.scrollbar[stateIndex], &rc, g_d2dFactory, &pRenderTarget)))
         return FALSE;
 
-    D2D1_RECT_F Rect{D2D1::Rect(0, 0, width, height)};
+    D2D1_RECT_F Rect;
+    if (iPartId == SBP_THUMBBTNVERT && iStateId == SCRBS_NORMAL)
+        Rect = D2D1::RectF(width*0.35, 0, width-width*0.35, height);
+    else if (iPartId == SBP_THUMBBTNHORZ && iStateId == SCRBS_NORMAL)
+        Rect = D2D1::RectF(0, height*0.35, width, height-height*0.35);
+    else if (iPartId == SBP_THUMBBTNVERT)
+        Rect = D2D1::RectF(width*0.25, 0, width-width*0.25, height);
+    else if (iPartId == SBP_THUMBBTNHORZ)
+        Rect = D2D1::RectF(0, height*0.25, width, height-height*0.25);
+    
     D2D1_COLOR_F Color = (iStateId == SCRBS_NORMAL) ? MyD2D1Color(128, 160, 160, 160) : MyD2D1Color(160, 224, 224, 224);
 
     Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush = nullptr;
@@ -2294,7 +2017,7 @@ BOOL PaintScrollBarArrows(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush = nullptr;
     dcRenderTarget->CreateSolidColorBrush(arrowColor, &brush);
     D2D1_POINT_2F points[6] = {};
-    if (iStateId >= ABS_UPNORMAL && iStateId <= ABS_UPDISABLED)
+    if ((iStateId > ABS_UPNORMAL && iStateId <= ABS_UPDISABLED) || iStateId == ABS_UPHOVER)
     {
         points[0] = D2D1::Point2F(centerX-1 - triangleBaseWidth / 2.0f, centerY + triangleHeight / 2.0f);
         points[1] = D2D1::Point2F(centerX-1 - triangleBaseWidth / 2.0f, centerY+2 + triangleHeight / 2.0f);
@@ -2303,7 +2026,7 @@ BOOL PaintScrollBarArrows(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
         points[4] = D2D1::Point2F(centerX, centerY - triangleHeight / 2.0f);
         points[5] = D2D1::Point2F(centerX-1, centerY - triangleHeight / 2.0f);
     }
-    else if (iStateId >= ABS_DOWNNORMAL && iStateId <= ABS_DOWNDISABLED)
+    else if ((iStateId > ABS_DOWNNORMAL && iStateId <= ABS_DOWNDISABLED) || iStateId == ABS_DOWNHOVER)
     {
         points[0] = D2D1::Point2F(centerX-1 - triangleBaseWidth / 2.0f, centerY - triangleHeight / 2.0f);
         points[1] = D2D1::Point2F(centerX-1 - triangleBaseWidth / 2.0f, centerY-2 - triangleHeight / 2.0f);
@@ -2312,7 +2035,7 @@ BOOL PaintScrollBarArrows(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
         points[4] = D2D1::Point2F(centerX, centerY + triangleHeight / 2.0f);
         points[5] = D2D1::Point2F(centerX-1, centerY + triangleHeight / 2.0f);
     }
-    else if (iStateId >= ABS_LEFTNORMAL && iStateId <= ABS_LEFTDISABLED)
+    else if ((iStateId > ABS_LEFTNORMAL && iStateId <= ABS_LEFTDISABLED) || iStateId == ABS_LEFTHOVER)
     {
         points[0] = D2D1::Point2F(centerX + triangleHeight / 2.0f, centerY - 1 - triangleBaseWidth / 2.0f);
         points[1] = D2D1::Point2F(centerX+2 + triangleHeight / 2.0f, centerY - 1 - triangleBaseWidth / 2.0f);
@@ -2321,7 +2044,7 @@ BOOL PaintScrollBarArrows(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
         points[4] = D2D1::Point2F(centerX - triangleHeight / 2.0f, centerY);
         points[5] = D2D1::Point2F(centerX - triangleHeight / 2.0f, centerY-1);
     }
-    else if (iStateId >= ABS_RIGHTNORMAL && iStateId <= ABS_RIGHTDISABLED)
+    else if ((iStateId > ABS_RIGHTNORMAL && iStateId <= ABS_RIGHTDISABLED) || iStateId == ABS_RIGHTHOVER)
     {
         points[0] = D2D1::Point2F(centerX - triangleHeight / 2.0f, centerY-1 - triangleBaseWidth / 2.0f);
         points[1] = D2D1::Point2F(centerX-2 - triangleHeight / 2.0f, centerY-1 - triangleBaseWidth / 2.0f);
@@ -2330,6 +2053,8 @@ BOOL PaintScrollBarArrows(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
         points[4] = D2D1::Point2F(centerX + triangleHeight / 2.0f, centerY);
         points[5] = D2D1::Point2F(centerX + triangleHeight / 2.0f, centerY-1);
     }
+
+    FillRect(hdc, pRect, (HBRUSH)GetStockObject(BLACK_BRUSH));
 
     dcRenderTarget->BeginDraw();
 
@@ -2538,7 +2263,7 @@ BOOL CThemeCache::CacheCheckButton(HDC hdc, LPCRECT pRect, INT iStateId, INT sta
     RECT rc = { 0, 0, (INT)width, (INT)height};
     if (FAILED(CreateBoundD2DRenderTarget(g_themeCache.checkbutton[stateIndex], &rc, g_d2dFactory, &pRenderTarget)))
         return FALSE;
-
+    
     D2D1_ROUNDED_RECT roundedRect = {
         D2D1::RectF(0, 0, width, height),
         cornerRadius, cornerRadius
@@ -2964,7 +2689,7 @@ BOOL CThemeCache::CacheEditBox(HDC hdc, INT iPartId, INT iStateId, INT stateInde
     if (iPartId == EP_BACKGROUNDWITHBORDER)
     {
         Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush;
-        pRenderTarget->CreateSolidColorBrush(MyD2D1Color(0, 0, 0), &brush);
+        pRenderTarget->CreateSolidColorBrush(g_IsSysThemeDarkMode ? MyD2D1Color(0, 0, 0) : MyD2D1Color(255, 255, 255), &brush);
         D2D1_RECT_F rc (0, 0, (FLOAT)width, (FLOAT)height);
         pRenderTarget->FillRectangle(&rc, brush.Get());
     }
@@ -3110,8 +2835,8 @@ BOOL PaintTab(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     if (!g_themeCache.tab[index])
         if (!g_themeCache.CacheTab(hdc, iStateId, index))
             return FALSE;
-    RECT newRc = {pRect->left-1, pRect->top-1, pRect->right+1, pRect->bottom+1};
-    DrawNineGridStretch(hdc, g_themeCache.tab[index], &newRc, 9, 9, 8, 8);
+
+    DrawNineGridStretch(hdc, g_themeCache.tab[index], pRect, 9, 9, 8, 8);
     return TRUE;
 }
 
@@ -3134,7 +2859,7 @@ BOOL CThemeCache::CacheTab(HDC hdc, INT iStateId, INT stateIndex)
     {
         D2D1_RECT_F rect{0, 0, (FLOAT)width, (FLOAT)height};
         Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush;
-        pRenderTarget->CreateSolidColorBrush(MyD2D1Color(0, 0 , 0, 0), &brush);
+        pRenderTarget->CreateSolidColorBrush(MyD2D1Color(0, 0, 0, 0), &brush);
         pRenderTarget->FillRectangle(rect, brush.Get());
     }
     else if (iStateId == TIS_HOT || iStateId == TIS_DISABLED)
@@ -3147,22 +2872,17 @@ BOOL CThemeCache::CacheTab(HDC hdc, INT iStateId, INT stateIndex)
     }
     else if (iStateId == TIS_SELECTED || iStateId == TIS_FOCUSED)
     {
-        const FLOAT desiredHeight = 2.0f;       
+        const FLOAT desiredHeight = 2.0f + round(scale);       
         const FLOAT widthPadding  = 5.0f;
-        const FLOAT verticalOffset = 2.0f;      
+        const FLOAT verticalOffset = 1.0f;      
     
         FLOAT pillLeft   = widthPadding;
         FLOAT pillRight  = width - widthPadding;
         FLOAT pillBottom = height - verticalOffset;
         FLOAT pillTop    = pillBottom - desiredHeight;
+        FLOAT pillRadius = 1.f + round(scale);
 
-        FLOAT pillHeight = desiredHeight;
-        FLOAT radius     = pillHeight / 2.0f * scale;
-
-        D2D1_ROUNDED_RECT pillRect = D2D1::RoundedRect(
-            D2D1::RectF(pillLeft, pillTop, pillRight, pillBottom),
-            radius, radius
-        );
+        D2D1_ROUNDED_RECT pillRect = D2D1::RoundedRect(D2D1::RectF(pillLeft, pillTop, pillRight, pillBottom),pillRadius, pillRadius);
 
         D2D1_COLOR_F pillColor = IsAccentColorPossibleD2D(102, 206, 255, SystemAccentColorLight2);
         Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush;
@@ -3795,8 +3515,8 @@ BOOL PaintTreeViewButton(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
 BOOL CThemeCache::CacheTreeViewButton(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
-    FLOAT cornerRadius = 4.f * scale;
-    INT x = 0, y = 0;
+    FLOAT cornerRadius = 5.f * scale;
+    FLOAT x = 0, y = 0;
     INT width = 18, height = 18;
 
     if (!g_themeCache.CreateDIB(g_themeCache.treeview[stateIndex], hdc, width, height))
@@ -3829,15 +3549,9 @@ BOOL CThemeCache::CacheTreeViewButton(HDC hdc, INT iPartId, INT iStateId, INT st
 
         if (iStateId == TREIS_SELECTED || iStateId == TREIS_SELECTEDNOTFOCUS || iStateId == TREIS_HOTSELECTED)
         {
-            FLOAT lineLength = height * 0.45f;
-            FLOAT offsetY = (height - lineLength) / 2;
+            FLOAT pillOffsetY = 7, pillWidth = 2.f + round(scale), pillRadius = 1.f + round(scale);
             brush->SetColor(IsAccentColorPossibleD2D(102, 206, 255, SystemAccentColorLight2));
-
-            D2D1_POINT_2F p1 = D2D1::Point2F(x + 0.5f, y + offsetY);
-            D2D1_POINT_2F p2 = D2D1::Point2F(x + 0.5f, y + offsetY + lineLength);
-            pRenderTarget->DrawLine(p1, p2, brush.Get());
-            p1.x += 1.0f; p2.x += 1.0f;
-            pRenderTarget->DrawLine(p1, p2, brush.Get());
+            pRenderTarget->FillRoundedRectangle(D2D1::RoundedRect(D2D1::RectF(x, y + pillOffsetY, x + pillWidth, height - pillOffsetY), pillRadius, pillRadius),brush.Get());
         }
     }
     auto hr = pRenderTarget->EndDraw();
@@ -3855,7 +3569,7 @@ BOOL PaintTreeViewGlyph(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
 
     // TreeView glyph symbols have a fixed bitmap size (marked as SIZINGTYPE=TRUESIZE)
     // The TreeView theme class has a bitmap size of 9x9px, while the Explorer::TreeView theme class has a bitmap size of 16x16px
-    // Unfortunately, OpenThemeData only detects the parent TreeView theme class by passing the current HDC
+    // Unfortunately, OpenThemeData only detects the parent TreeView theme class
     BOOL ExplorerTreeView = FALSE;
     if (width / (16 * scale) == 1)
         ExplorerTreeView = TRUE;
@@ -3902,7 +3616,7 @@ BOOL CThemeCache::CacheTreeViewGlyph(HDC hdc, INT iPartId, INT iStateId, INT sta
 
     FLOAT centerX = width / 2.f;
     FLOAT centerY = height / 2.f;
-    FLOAT arrowLength = (ExplorerTreeView) ? width * 0.3f * scale : width * 0.55f * scale;
+    FLOAT arrowLength = (ExplorerTreeView) ? width * 0.3f : width * 0.55f;
     // 60 degrees
     FLOAT dx = arrowLength * 0.866f;
     FLOAT dy = arrowLength * 0.5f;
@@ -3924,8 +3638,8 @@ BOOL CThemeCache::CacheTreeViewGlyph(HDC hdc, INT iPartId, INT iStateId, INT sta
 
     pRenderTarget->BeginDraw();
 
-    pRenderTarget->DrawLine(ptLeft, ptTip, arrowBrush.Get(), 2.f);
-    pRenderTarget->DrawLine(ptRight, ptTip, arrowBrush.Get(), 2.f);
+    pRenderTarget->DrawLine(ptLeft, ptTip, arrowBrush.Get(), 1.5f * scale);
+    pRenderTarget->DrawLine(ptRight, ptTip, arrowBrush.Get(), 1.5f * scale);
 
     auto hr = pRenderTarget->EndDraw();
     if (FAILED(hr)) {Wh_Log(L"Failed D2D drawing [ERROR]: 0x%08X\n", hr); return FALSE;}
@@ -4090,30 +3804,30 @@ BOOL CThemeCache::CacheHeader(HDC hdc, INT iStateId, INT stateIndex)
     return TRUE;
 }
 
-BOOL PaintPreviewPaneSeperator(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
+BOOL PaintPreviewPaneSeparator(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
 {
     if (!g_d2dFactory || (iPartId != 3 && iPartId != 4))
         return FALSE;
 
-    if (!g_themeCache.previewseperator[0])
-        if (!g_themeCache.CachePreviewPaneSeperator(hdc))
+    if (!g_themeCache.previewseparator[0])
+        if (!g_themeCache.CachePreviewPaneSeparator(hdc))
             return FALSE;
     
     RECT rc{pRect->left+1, pRect->top, pRect->right, pRect->bottom};
-    DrawNineGridStretch(hdc, g_themeCache.previewseperator[0], &rc, 1, 0, 0, 0);
+    DrawNineGridStretch(hdc, g_themeCache.previewseparator[0], &rc, 1, 0, 0, 0);
     return TRUE;
 }
 
-BOOL CThemeCache::CachePreviewPaneSeperator(HDC hdc)
+BOOL CThemeCache::CachePreviewPaneSeparator(HDC hdc)
 {
     INT x = 0, y = 0;
     INT width = 3, height = 3;
-    if(!g_themeCache.CreateDIB(g_themeCache.previewseperator[0], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.previewseparator[0], hdc, width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
     RECT rc = { x, y, width, height};
-    if (FAILED(CreateBoundD2DRenderTarget(g_themeCache.previewseperator[0], &rc, g_d2dFactory, &pRenderTarget)))
+    if (FAILED(CreateBoundD2DRenderTarget(g_themeCache.previewseparator[0], &rc, g_d2dFactory, &pRenderTarget)))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush;
@@ -4669,7 +4383,7 @@ BOOL CThemeCache::CacheAddressBand(HDC hdc, INT iStateId, INT stateIndex)
             borderColor = MyD2D1Color(64, 255, 255, 255);
             break;
         case 4:
-            fillColor = MyD2D1Color(0, 0, 0);
+            fillColor = g_IsSysThemeDarkMode ? MyD2D1Color(0, 0, 0) : MyD2D1Color(255, 255, 255);
             borderColor = IsAccentColorPossibleD2D(105, 205, 255, SystemAccentColorLight2);
             break;
     }
@@ -4698,7 +4412,7 @@ BOOL PaintMenu(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     if ((iPartId == MENU_BARITEM) && 
         (iStateId == MBI_NORMAL || iStateId == MBI_DISABLED || iStateId == MBI_DISABLEDPUSHED)) return FALSE;
 
-    INT index = (iPartId == 27 || iPartId == MENU_POPUPITEM) ? 0 : (iStateId == MBI_PUSHED) ? 1 : (iPartId == MENU_POPUPSEPARATOR) ? 3 : 2;
+    INT index = (iPartId == MENU_POPUPSEPARATOR) ? 0 : (iPartId == 27 || iPartId == MENU_POPUPITEM) ? 1 : (iPartId == MENU_BARITEM && iStateId == MBI_PUSHED) ?  3 : 2;
 
     if (!g_themeCache.menuitem[index])
         if (!g_themeCache.CacheMenuItem(hdc, iPartId, iStateId, index))
@@ -4747,7 +4461,7 @@ BOOL CThemeCache::CacheMenuItem(HDC hdc, INT iPartId, INT iStateId, INT indexSta
         pRenderTarget->DrawLine({0, (FLOAT)height/2}, {(FLOAT)width, (FLOAT)height/2}, lineBrush.Get());
     }
     else {
-        D2D1_COLOR_F fillColor = (iPartId == MBI_PUSHED) ? MyD2D1Color(64, 144, 144, 144) : MyD2D1Color(128, 96, 96, 96);
+        D2D1_COLOR_F fillColor = (iStateId == MBI_PUSHED) ? MyD2D1Color(64, 144, 144, 144) : MyD2D1Color(128, 96, 96, 96);
         D2D1_ROUNDED_RECT Rect = D2D1::RoundedRect(D2D1::RectF(0, 0, width, height), cornerRadius, cornerRadius);
         Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> fillBrush;
         pRenderTarget->CreateSolidColorBrush(fillColor, &fillBrush);
@@ -4932,7 +4646,7 @@ HRESULT WINAPI HookedDrawThemeBackground(
     INT iStateId,
     LPCRECT pRect,
     LPCRECT pClipRect)
-{    
+{       
     std::wstring ThemeClassName = GetThemeClass(hTheme);
 
     if (ThemeClassName == L"ScrollBar")
@@ -5074,6 +4788,17 @@ HRESULT WINAPI HookedDrawThemeBackground(
     {
         if (PaintMenu(hdc, iPartId, iStateId, pRect))
             return S_OK;
+        // Force menu white glyphs
+        else if (iPartId <= MENU_SYSTEMRESTORE && iPartId >= MENU_SYSTEMCLOSE && g_IsSysThemeDarkMode) {
+            HTHEME theme = NULL;
+            HRESULT hr = S_OK;
+            if ((theme = OpenThemeData(WindowFromDC(hdc), L"DarkMode::Menu"))) {
+                hr = DrawThemeBackground_orig(theme, hdc, iPartId, iStateId, pRect, pClipRect);
+                CloseThemeData(theme);
+                return hr;
+            }
+            CloseThemeData(theme);
+        }
     }
     else if (ThemeClassName == L"DragDrop")
     {
@@ -5107,7 +4832,7 @@ HRESULT WINAPI HookedDrawThemeBackground(
         return S_OK;
     }
     else if (ThemeClassName == L"Menu" && (iPartId == MENU_POPUPBACKGROUND || iPartId == MENU_POPUPBORDERS || iPartId == MENU_POPUPGUTTER || 
-            ((iPartId == MENU_POPUPITEM || iPartId == 27) && iStateId != MPI_HOT)))
+        iPartId == MENU_POPUPCHECKBACKGROUND || ((iPartId == MENU_POPUPITEM || iPartId == 27) && iStateId != MPI_HOT)))
     {
         RECT clipRect{*pRect};
         if (pClipRect)
@@ -5140,7 +4865,7 @@ HRESULT WINAPI HookedDrawThemeBackgroundEx(
     INT iStateId,
     LPCRECT pRect,
     const DTBGOPTS* pOptions)
-{
+{    
     std::wstring ThemeClassName = GetThemeClass(hTheme);
 
     if (ThemeClassName == L"ListView")
@@ -5178,7 +4903,7 @@ HRESULT WINAPI HookedDrawThemeBackgroundEx(
     }
     else if (ThemeClassName == L"PreviewPane")
     {
-        if (PaintPreviewPaneSeperator(hdc, iPartId, iStateId, pRect))
+        if (PaintPreviewPaneSeparator(hdc, iPartId, iStateId, pRect))
             return S_OK;
     }
     else if (ThemeClassName == L"Progress")
@@ -5232,6 +4957,18 @@ HRESULT WINAPI HookedDrawThemeBackgroundEx(
     return hr;
 }
 
+HRESULT WINAPI HookedDrawThemeEdge(HTHEME hTheme, HDC hdc, int iPartId, int iStateId, const RECT *pDestRect, UINT uEdge, UINT uFlags, RECT *pContentRect)
+{
+    std::wstring ThemeClass = GetThemeClass(hTheme);
+
+    if (ThemeClass == L"Rebar" && iPartId == RP_BAND) {
+        FillRect(hdc, pContentRect, (HBRUSH)GetStockObject(BLACK_BRUSH));
+        return S_OK;
+    }
+
+    return DrawThemeEdge_orig(hTheme, hdc, iPartId, iStateId, pDestRect, uEdge, uFlags, pContentRect);
+}
+
 HRESULT WINAPI HookedGetThemeMargins(HTHEME hTheme, HDC hdc, INT iPartId, INT iStateId, INT iPropId, RECT* prc, MARGINS *pMargins)
 {
     std::wstring ThemeClassName = GetThemeClass(hTheme);
@@ -5269,10 +5006,27 @@ HRESULT WINAPI HookedGetThemeMargins(HTHEME hTheme, HDC hdc, INT iPartId, INT iS
     return ret;
 }
 
-VOID ApplyFrameExtension(HWND hWnd) 
+HRESULT WINAPI HookedGetThemeFont (HTHEME hTheme, HDC hdc, INT iPartId, INT iStateId, INT iPropId, LOGFONTW* pFont)
 {
-    MARGINS margins = {-1, -1, -1, -1};
-    DwmExtendFrameIntoClientArea(hWnd, &margins);
+    auto hr = GetThemeFont_orig(hTheme, hdc, iPartId, iStateId, iPropId, pFont);
+    std::wstring ThemeClassName = GetThemeClass(hTheme);
+    
+    if (ThemeClassName == L"Menu" && iPropId == TMT_FONT) 
+    {
+        // Return if it's not the original font
+        if (wcscmp(pFont->lfFaceName, L"Segoe UI"))
+            return hr;
+        wcscpy_s(pFont->lfFaceName, LF_FACESIZE, L"Segoe UI Variable Small");
+        pFont->lfHeight = -13;
+        pFont->lfWeight = 400;
+        pFont->lfQuality = CLEARTYPE_QUALITY;
+        pFont->lfPitchAndFamily = DEFAULT_PITCH;
+    }
+    else if (ThemeClassName == L"ControlPanelStyle" && iPartId == CPANEL_TITLE && iPropId == TMT_FONT) {
+        wcscpy_s(pFont->lfFaceName, LF_FACESIZE, L"Segoe UI Variable Display Semib");
+        pFont->lfHeight = -24;
+    }
+    return hr;
 }
 
 //https://github.com/ALTaleX531/TranslucentFlyouts/blob/master/TFMain/EffectHelper.hpp
@@ -5281,7 +5035,7 @@ VOID TriggerWindowNCRendering(HWND hwnd)
 {
     // NOTICE WINDOWS THAT WE HAVE ACTIVATED THE WINDOW
     DefWindowProcW(hwnd, WM_NCACTIVATE, TRUE, 0);
-    SetWindowPos(hwnd, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_DRAWFRAME | SWP_NOACTIVATE);
+    //SetWindowPos(hwnd, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_DRAWFRAME | SWP_NOACTIVATE);
 }
 
 VOID DwmMakeWindowTransparent(HWND hwnd)
@@ -5296,595 +5050,76 @@ VOID EnableBlurBehind(HWND hWnd)
     // Does not interfere with the Windows Terminal, GameBar overlay
     if(!(IsWindowClass(hWnd, L"CASCADIA_HOSTING_WINDOW_CLASS") || IsWindowClass(hWnd, L"ApplicationFrameWindow")))
     {
-        g_bb.fEnable = TRUE;
-        g_bb.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION | DWM_BB_TRANSITIONONMAXIMIZED;
+        ACCENT_POLICY accentPolicy = {};
+        WINCOMPATTRDATA winCompositionAttrib = {};
+        DWM_BLURBEHIND dwmBlurBehindData = { };
+
+        dwmBlurBehindData.fEnable = TRUE;
+        dwmBlurBehindData.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION | DWM_BB_TRANSITIONONMAXIMIZED;
         // Blurs window client area
         HRGN hRgn = CreateRectRgn(0, 0, -1, -1);
-        g_bb.hRgnBlur = hRgn;
-        g_bb.fTransitionOnMaximized = TRUE;
+        dwmBlurBehindData.hRgnBlur = hRgn;
+        dwmBlurBehindData.fTransitionOnMaximized = TRUE;
 
-        DwmEnableBlurBehindWindow(hWnd, &g_bb);
+        DwmEnableBlurBehindWindow(hWnd, &dwmBlurBehindData);
         DeleteObject(hRgn);
 
-        g_accent.AccentState = ACCENT_STATE_ENABLE_ACRYLICBLURBEHIND;
-        g_accent.GradientColor = g_settings.AccentBlurBehindClr;
-        //accent.AccentFlags = ACCENT_FLAG_ENABLE_BORDER;
-        //accent.AnimationId = NULL;
+        accentPolicy.AccentState = ACCENT_STATE_ENABLE_ACRYLICBLURBEHIND;
+        accentPolicy.GradientColor = g_settings.AccentBlurBehindClr;
 
-        g_attrib.Attrib = WCA_ACCENT_POLICY;
-        g_attrib.pvData = &g_accent;
-        g_attrib.cbData = sizeof(g_accent);
+        winCompositionAttrib.Attrib = WCA_ACCENT_POLICY;
+        winCompositionAttrib.pvData = &accentPolicy;
+        winCompositionAttrib.cbData = sizeof(accentPolicy);
 
-        typedef BOOL(WINAPI* pSetWindowCompositionAttribute)(HWND, WINCOMPATTRDATA*);
-        auto SetWindowCompositionAttribute = (pSetWindowCompositionAttribute) GetProcAddress(GetModuleHandleW(L"user32.dll"), "SetWindowCompositionAttribute");
-        if (SetWindowCompositionAttribute) 
-            SetWindowCompositionAttribute(hWnd, &g_attrib);
+        if (SetWindowCompositionAttribute)
+            SetWindowCompositionAttribute(hWnd, &winCompositionAttrib);    
     }
 }
 
-VOID SetSystemBackdrop(HWND hWnd, const UINT type) {
-    DwmSetWindowAttribute(hWnd, DWMWA_SYSTEMBACKDROP_TYPE , &type, sizeof(UINT));
-}
-
-VOID EnableColoredTitlebar(HWND hWnd) {
-    g_settings.g_TitlebarColor = g_settings.TitlebarActiveColor;
-    DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &g_settings.g_TitlebarColor, sizeof(COLORREF));
-}
-
-VOID EnableCaptionTextColor(HWND hWnd) {
-    g_settings.g_CaptionColor = g_settings.CaptionActiveTextColor;
-    DwmSetWindowAttribute(hWnd, DWMWA_TEXT_COLOR, &g_settings.g_CaptionColor, sizeof(COLORREF));
-}
-
-VOID EnableColoredBorder(HWND hWnd) {
-    g_settings.g_BorderColor = g_settings.BorderActiveColor;
-    DwmSetWindowAttribute(hWnd, DWMWA_BORDER_COLOR, &g_settings.g_BorderColor, sizeof(COLORREF));
-}
-
-VOID SetCornerType(HWND hWnd, UINT type) {
-    BOOL isFlyoutWindow = IsWindowClass(hWnd, MENUPOPUP_CLASS) || IsWindowClass(hWnd, L"DropDown") 
-                    || IsWindowClass(hWnd, L"ViewControlClass") || IsWindowClass(hWnd, TOOLTIPS_CLASS);
-    if (g_settings.CornerPref == DEFAULTROUND && isFlyoutWindow)
-        type = g_settings.Rounded;
-    else if (g_settings.CornerPref == DEFAULTROUND)
-        return;
-    DwmSetWindowAttribute(hWnd, DWMWA_WINDOW_CORNER_PREFERENCE, &type , sizeof(UINT));
-}
-
-constexpr UINT MN_SIZEWINDOW{ 0x01E2 };
-
-// https://github.com/ALTaleX531/TranslucentFlyouts/blob/017970cbac7b77758ab6217628912a8d551fcf7c/TFMain/MenuHandler.cpp#L236C31-L236C47
-LRESULT CALLBACK FlyoutsSubclassProc(
-    HWND hWnd,
-    UINT uMsg,
-    WPARAM wParam,
-    LPARAM lParam,
-    DWORD_PTR dwRefData)
-{
-    switch (uMsg)
+static LRESULT WINAPI HookedDefWindowProcW(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{    
+    if (msg == WM_SETTINGCHANGE) 
     {
-        case WM_PRINT:
-        {   
-            if (!IsWindowClass(hWnd, MENUPOPUP_CLASS))
-                break;     
-            // Let the system/theme draw first
-            LRESULT result = DefSubclassProc(hWnd, uMsg, wParam, lParam);
-
-            if (g_settings.BorderRainbowFlag) {
-                SendMessage(hWnd, g_msgRainbowTimer, RAINBOW_LOAD, 0);
-                break;
-            }
-            else if (!g_settings.BorderFlag || g_settings.BorderActiveColor == DWMWA_COLOR_DEFAULT)
-                break;
-            
-            HDC hdc = reinterpret_cast<HDC>(wParam);
-            // Remove desktop context menu white outline
-            RECT paintRect{};
-            GetWindowRect(hWnd, &paintRect);
-            OffsetRect(&paintRect, -paintRect.left, -paintRect.top);
-            
-            if (g_settings.BorderActiveColor == DWMWA_COLOR_NONE)
-                FrameRect(hdc, &paintRect, (HBRUSH)GetStockObject(BLACK_BRUSH));
-            else {
-                HBRUSH brush = CreateSolidBrush(g_settings.BorderActiveColor);
-                FrameRect(hdc, &paintRect, brush);
-                DeleteObject(brush);
-            }
-            
-            return result;
-        }
-        // The WM_PRINT command is not fired when the user selects a menu item
-        // and then very quickly activates a new menu with the keyboard (SHIFT+F10)
-        // or by right-clicking
-        case WM_NCPAINT:
-        {    
-            if (g_settings.BorderRainbowFlag) {
-                SendMessage(hWnd, g_msgRainbowTimer, RAINBOW_LOAD, 0);
-                break;
-            }
-            else if (!g_settings.BorderFlag || g_settings.BorderActiveColor == DWMWA_COLOR_DEFAULT)
-                break;
-            
-            HDC hdc = GetWindowDC(hWnd);
-            if (wParam != NULLREGION && wParam != ERROR)
-				SelectClipRgn(hdc, reinterpret_cast<HRGN>(wParam));
-            
-            RECT windowRect{};
-            GetWindowRect(hWnd, &windowRect);
-
-            MENUBARINFO mbi{ sizeof(MENUBARINFO) };
-            GetMenuBarInfo(hWnd, OBJID_CLIENT, 0, &mbi);
-            MARGINS mr{ mbi.rcBar.left - windowRect.left, windowRect.right - mbi.rcBar.right, mbi.rcBar.top - windowRect.top, windowRect.bottom - mbi.rcBar.bottom };
-
-			RECT paintRect{};
-			GetWindowRect(hWnd, &paintRect);
-			OffsetRect(&paintRect, -paintRect.left, -paintRect.top);
-            ExcludeClipRect(hdc, paintRect.left + mr.cxLeftWidth, paintRect.top + mr.cyTopHeight, paintRect.right - mr.cxRightWidth, paintRect.bottom - mr.cyBottomHeight);
-            PatBlt(hdc, paintRect.left, paintRect.top, paintRect.right-paintRect.left, paintRect.bottom-paintRect.top, BLACKNESS);
-
-            if (g_settings.BorderActiveColor == DWMWA_COLOR_NONE)
-                FrameRect(hdc, &paintRect, (HBRUSH)GetStockObject(BLACK_BRUSH));
-            else {
-                HBRUSH brush = CreateSolidBrush(g_settings.BorderActiveColor);
-                FrameRect(hdc, &paintRect, brush);
-                DeleteObject(brush);
-            }
-
-            return 0;
-        }
-        case MN_SIZEWINDOW:
+        // System theme change
+        if (lParam && wcscmp((LPCWSTR)lParam, L"ImmersiveColorSet") == 0) 
         {
-            if (!IsWindowClass(hWnd, MENUPOPUP_CLASS))
-                break;
-            HandleEffects(hWnd);
-            break;
-        }
-    }
-    return DefSubclassProc(hWnd, uMsg, wParam, lParam);
-}
+            // Fetch the actual current theme file path from registry
+            std::wstring currentTheme = GetCurrentWindowsThemePath();
 
-VOID CALLBACK MyRainbowTimerProc(HWND, UINT, UINT_PTR t_id, DWORD)
-{
-    HWND WndHwnd= nullptr;
-    RainbowData* pRainbowWndData = nullptr;
-    {
-        std::lock_guard<std::mutex> guard(g_rainbowWindowsMutex);
-        for(auto& hWnd : g_rainbowWindows)
-        {
-            RainbowData* pTempRainbowWndData = reinterpret_cast<RainbowData*>(
-                GetPropW(hWnd, g_RainbowPropStr.c_str()));
-            
-            if (pTempRainbowWndData && pTempRainbowWndData->timerId == t_id)
+            AcquireSRWLockExclusive(&g_ThemeChangeLock);
+
+            if (currentTheme != g_LastThemePath) 
             {
-                WndHwnd = hWnd;
-                pRainbowWndData = pTempRainbowWndData;
-                break;
+                g_LastThemePath = currentTheme; 
+
+                // Process the theme change
+                g_themeCache.ClearCache();
+                g_IsSysThemeDarkMode = ShouldSystemUseDarkMode();
+                g_AccentPalette.LoadAccentPalette();
+                
+                if (g_settings.AccentColorize)
+                    g_settings.AccentColorize = GetAccentColor(g_settings.AccentColor);
+                
+                if (g_settings.SetSystemColors)
+                    ColorizeSysColors();
             }
-        }
-    }
-
-    if (!WndHwnd)
-        return;
-    
-    DOUBLE tNow = TimerGetSeconds();
-    DOUBLE effectiveTime = (tNow - pRainbowWndData->baseTime) - pRainbowWndData->pausedTotal;
-    DOUBLE wndHue = fmod(pRainbowWndData->initialHue + effectiveTime * g_settings.RainbowSpeed, 360.0);
-
-    if (g_settings.TitlebarRainbowFlag)
-    {
-        COLORREF titlebarColor = HSLToRGB(wndHue, 1.0f, 0.5f); 
-        DwmSetWindowAttribute_orig(WndHwnd, DWMWA_CAPTION_COLOR, &titlebarColor, sizeof(COLORREF));
-    }
-    if (g_settings.CaptionRainbowFlag)
-    {
-        COLORREF captionColor;
-        if (g_settings.TitlebarRainbowFlag)
-            captionColor = HSLToRGB(fmod(wndHue + 120.0f, 360.0f), 1.0f, 0.5f);
-        else
-            captionColor = HSLToRGB(wndHue, 1.0f, 0.5f);
-        DwmSetWindowAttribute_orig(WndHwnd, DWMWA_TEXT_COLOR, &captionColor, sizeof(COLORREF));
-    }
-    if (g_settings.BorderRainbowFlag)
-    {
-        COLORREF borderColor = HSLToRGB(wndHue, 1.0f, 0.5f);  
-        DwmSetWindowAttribute_orig(WndHwnd, DWMWA_BORDER_COLOR, &borderColor, sizeof(COLORREF));
-    }
-}
-
-VOID AddFlyoutsSubclass(HWND hWnd)
-{
-    auto it = g_subclassedflyouts.find(hWnd);
-    if (it == g_subclassedflyouts.end()) {
-        if (WindhawkUtils::SetWindowSubclassFromAnyThread(hWnd, FlyoutsSubclassProc, NULL)) {
-            std::lock_guard<std::mutex> guard(g_subclassedflyoutsmutex);
-            g_subclassedflyouts.insert(hWnd);
-        }
-    }
-}
-
-VOID RemoveOrUnloadFlyoutSubclass(HWND hWnd = nullptr, BOOL Clean = FALSE)
-{
-    if (Clean && !g_subclassedflyouts.empty())
-    {
-        std::unordered_set<HWND> subclassedflyouts;
-        {
-            std::lock_guard<std::mutex> guard(g_subclassedflyoutsmutex);
-            subclassedflyouts = std::move(g_subclassedflyouts);
-            g_subclassedflyouts.clear();
-        }
-        for(auto hwnd : subclassedflyouts)
-            WindhawkUtils::RemoveWindowSubclassFromAnyThread(hwnd, FlyoutsSubclassProc);
-        subclassedflyouts.clear();
-    }
-    else 
-    {
-        auto it = g_subclassedflyouts.find(hWnd);
-        if (it != g_subclassedflyouts.end()) {
-            std::lock_guard<std::mutex> guard(g_subclassedflyoutsmutex);
-            g_subclassedflyouts.erase(hWnd);
-        }
-    }
-}
-
-VOID RemoveOrUnloadWindowsHooks(BOOL);
-
-LRESULT CALLBACK CallWndProc(INT nCode, WPARAM wParam, LPARAM lParam)
-{
-    const CWPSTRUCT* cwp = (const CWPSTRUCT*)lParam;
-    if (nCode != HC_ACTION) {
-        return CallNextHookEx(nullptr, nCode, wParam, lParam);
-    }
-
-    switch (cwp->message)
-    {
-        case WM_CREATE:
-        {
-            BOOL isFlyoutWindow = IsWindowClass(cwp->hwnd, MENUPOPUP_CLASS) || IsWindowClass(cwp->hwnd, L"DropDown") || IsWindowClass(cwp->hwnd, L"ViewControlClass");
-            if (!isFlyoutWindow || !g_settings.FlyoutsEffects)
-                break;
-
-            AddFlyoutsSubclass(cwp->hwnd);
-            break;
-        }
-        case WM_SIZE:
-        {
-            // Due to applying effects too early in NtUserCreateWindowEx
-            // effects are passed on to unelegible child windows such as fullscreen borderless DirectX windows
-            // e.g. Duckstation Qt emulator, PCSX2 Qt emulator, Windows Legacy Photos etc.
-            // providing a minimal filtering for unwanted windows.
-            LONG_PTR styleEx = GetWindowLongPtrW(cwp->hwnd, GWL_EXSTYLE);
-            LONG_PTR style = GetWindowLongPtrW(cwp->hwnd, GWL_STYLE);
             
-            HWND hParentWnd = GetAncestor(cwp->hwnd, GA_PARENT);
-            if (hParentWnd && hParentWnd != GetDesktopWindow())
-                break;
-
-            if (IsWindowCloaked(cwp->hwnd) && !IsWindowClass(cwp->hwnd, L"ApplicationFrameWindow"))
-                return FALSE;
-            if (!IsWindowEnabled(cwp->hwnd) && !IsWindowVisible(cwp->hwnd))
-                return FALSE;
-
-            if (style & WS_CHILD || (styleEx & WS_EX_NOACTIVATE) || (styleEx & WS_EX_TRANSPARENT))
-                break;
-
-            BOOL isFullscreen = IsWindowFullscreen(cwp->hwnd);
-            // hide colored borders on fullscreen/maximized windows
-            if (isFullscreen) {
-                UINT borderType;
-                DwmGetWindowAttribute(cwp->hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, &borderType, sizeof(UINT));
-                if (borderType != DONTROUND)
-                    DwmSetWindowAttribute(cwp->hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, &DONTROUND, sizeof(UINT));
-
-                if (g_settings.BorderRainbowFlag)
-                    SendMessage(cwp->hwnd, g_msgRainbowTimer, RAINBOW_PAUSED, 0);
-            }
-            else if (IsWindowEligible(cwp->hwnd)) {
-                BOOL isFlyoutWindow = IsWindowClass(cwp->hwnd, MENUPOPUP_CLASS) || IsWindowClass(cwp->hwnd, TOOLTIPS_CLASS) 
-                                || IsWindowClass(cwp->hwnd, L"DropDown") || IsWindowClass(cwp->hwnd, L"ViewControlClass");
-                UINT borderType;
-                DwmGetWindowAttribute(cwp->hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, &borderType, sizeof(UINT));
-                if (borderType != g_settings.CornerPref && !isFlyoutWindow) {
-                    DwmSetWindowAttribute(cwp->hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, &g_settings.CornerPref, sizeof(UINT));
-                    if (g_settings.BorderRainbowFlag)
-                        SendMessage(cwp->hwnd, g_msgRainbowTimer, RAINBOW_RESTART, 0);
-                }
-            }
-            break;
+            ReleaseSRWLockExclusive(&g_ThemeChangeLock);
         }
-        case WM_ACTIVATE:
-        {
-            BOOL isMinimized = HIWORD(cwp->wParam);
-            if (isMinimized || !IsWindowEligible(cwp->hwnd))
-                break;
-            
-            WORD activationState = LOWORD(cwp->wParam);
+    }   
 
-            if ((activationState == WA_ACTIVE || activationState == WA_CLICKACTIVE))
-            {
-                if(g_settings.TitlebarFlag && !g_settings.TitlebarRainbowFlag)
-                {
-                    g_settings.g_TitlebarColor = g_settings.TitlebarActiveColor;
-                    DwmSetWindowAttribute(cwp->hwnd, DWMWA_CAPTION_COLOR, &g_settings.g_TitlebarColor, sizeof(COLORREF));
-                }
-                if(g_settings.CaptionTextFlag && !g_settings.CaptionRainbowFlag)
-                {
-                    g_settings.g_CaptionColor = g_settings.CaptionActiveTextColor;
-                    DwmSetWindowAttribute(cwp->hwnd, DWMWA_TEXT_COLOR, &g_settings.g_CaptionColor, sizeof(COLORREF));
-                }
-                if((g_settings.BorderFlag && !g_settings.BorderRainbowFlag))
-                {
-                    g_settings.g_BorderColor = g_settings.BorderActiveColor;
-                    DwmSetWindowAttribute(cwp->hwnd, DWMWA_BORDER_COLOR, &g_settings.BorderActiveColor, sizeof(COLORREF));
-                }
-            }
-            else if (activationState == WA_INACTIVE)
-            {
-                // Workaround in order to bypass the neutral background color in SystemBackdrop effects on inactive windows
-                //if (g_settings.BgType > g_settings.AccentBlurBehind)
-                    //DefWindowProcW(cwp->hwnd, WM_NCACTIVATE, TRUE, 0);
-            
-                if(g_settings.TitlebarFlag && !g_settings.TitlebarRainbowFlag)
-                {
-                    g_settings.g_TitlebarColor = g_settings.TitlebarInactiveColor;
-                    DwmSetWindowAttribute(cwp->hwnd, DWMWA_CAPTION_COLOR, &g_settings.g_TitlebarColor, sizeof(COLORREF));
-                }
-                if(g_settings.CaptionTextFlag && !g_settings.CaptionRainbowFlag)
-                {
-                    g_settings.g_CaptionColor = g_settings.CaptionInactiveTextColor;
-                    DwmSetWindowAttribute(cwp->hwnd, DWMWA_TEXT_COLOR, &g_settings.g_CaptionColor, sizeof(COLORREF));
-                }
-                if((g_settings.BorderFlag && !g_settings.BorderRainbowFlag))
-                {
-                    g_settings.g_BorderColor = g_settings.BorderInactiveColor;
-                    DwmSetWindowAttribute(cwp->hwnd, DWMWA_BORDER_COLOR, &g_settings.BorderInactiveColor, sizeof(COLORREF));
-                }
-            }
-
-            break;
-        }
-        case WM_ENTERSIZEMOVE:
-        {
-            if (!g_settings.BorderRainbowFlag && !g_settings.CaptionRainbowFlag && !g_settings.TitlebarRainbowFlag)
-                break;
-            
-            if (!IsWindowEligible(cwp->hwnd))
-                break;
-
-            // Pause rainbow effects while the window is being moved/resized.
-            SendMessage(cwp->hwnd, g_msgRainbowTimer, RAINBOW_PAUSED, 0);
-            break;
-        }
-        case WM_EXITSIZEMOVE:
-        {
-            if (!g_settings.BorderRainbowFlag && !g_settings.CaptionRainbowFlag && !g_settings.TitlebarRainbowFlag)
-                break;
-
-            if (!IsWindowEligible(cwp->hwnd))
-                break;
-            // Resume rainbow effects after move/resize ends.
-            SendMessage(cwp->hwnd, g_msgRainbowTimer, RAINBOW_RESTART, 0);
-            break;
-        }
-        case WM_DESTROY:
-        {       
-           RainbowData* pRainbowWndData = reinterpret_cast<RainbowData*>(RemovePropW(cwp->hwnd, g_RainbowPropStr.c_str()));
-            if (!pRainbowWndData)
-                break;
-
-            if (KillTimer(NULL, pRainbowWndData->timerId))
-            {
-                std::lock_guard<std::mutex> guard(g_rainbowWindowsMutex);
-                g_rainbowWindows.erase(cwp->hwnd);
-                Wh_Log(L"Timer termination success for window: %p", cwp->hwnd);
-                delete pRainbowWndData;
-            }
-            else
-                Wh_Log(L"[ERROR] Timer termination failure for window: %p", cwp->hwnd);
-
-            RemoveOrUnloadFlyoutSubclass(cwp->hwnd);
-            break;
-        }
-        default:
-        {
-            if (cwp->message == g_msgRainbowTimer)
-            {
-                switch (cwp->wParam)
-                {
-                    case RAINBOW_LOAD:
-                    {
-                        HANDLE Data = GetPropW(cwp->hwnd, g_RainbowPropStr.c_str());
-                        if (Data)
-                            break;
-                        
-                        RainbowData* pRainbowWndData = new RainbowData();
-                        DOUBLE now = TimerGetSeconds();
-                        
-                        std::mt19937 gen((UINT_PTR)cwp->hwnd);
-                        std::uniform_real_distribution<> distr(0.0, 360.0);
-                        pRainbowWndData->initialHue = distr(gen);
-                        pRainbowWndData->baseTime = now;
-                        pRainbowWndData->pausedTotal = 0.0;
-                        pRainbowWndData->pausedStart = 0.0;
-                        pRainbowWndData->isPaused = FALSE;                        
-
-                        pRainbowWndData->timerId = SetTimer(NULL, NULL, 32, MyRainbowTimerProc);
-                        if (pRainbowWndData->timerId)
-                        {
-                            SetPropW(cwp->hwnd, g_RainbowPropStr.c_str(), reinterpret_cast<HANDLE>(pRainbowWndData));
-                            {
-                                std::lock_guard<std::mutex> guard(g_rainbowWindowsMutex);
-                                g_rainbowWindows.insert(cwp->hwnd);
-                            }
-                            Wh_Log(L"Timer set success for window: %p", cwp->hwnd);
-                        }
-                        else {
-                            Wh_Log(L"[ERROR] Timer set failure for window: %p", cwp->hwnd);
-                            delete pRainbowWndData;
-                        }
-                        
-                        break;
-                    }
-                    case RAINBOW_RESTART:
-                    {
-                        RainbowData* pRainbowWndData = reinterpret_cast<RainbowData*>(GetPropW(cwp->hwnd, g_RainbowPropStr.c_str()));
-                        if (!pRainbowWndData)
-                            break;
-
-                        DOUBLE now = TimerGetSeconds();
-                        if (pRainbowWndData->isPaused) {
-                            pRainbowWndData->pausedTotal += now - pRainbowWndData->pausedStart;
-                            pRainbowWndData->isPaused = FALSE;
-                        }
-                        
-                        if (!pRainbowWndData->timerId) {
-                            pRainbowWndData->timerId = SetTimer(NULL, NULL, 32, MyRainbowTimerProc);
-                            if (!pRainbowWndData->timerId)
-                                Wh_Log(L"[ERROR] Timer restart failure for window: %p", cwp->hwnd);
-                        }
-
-                        break;
-                    }
-                    case RAINBOW_PAUSED:
-                    {
-                        RainbowData* pRainbowWndData = reinterpret_cast<RainbowData*>(GetPropW(cwp->hwnd, g_RainbowPropStr.c_str()));
-                        if (!pRainbowWndData)
-                            break;
-
-                        DOUBLE now = TimerGetSeconds();
-                        if (!pRainbowWndData->isPaused) {
-                            pRainbowWndData->pausedStart = now;
-                            pRainbowWndData->isPaused = TRUE;
-                        }
-                        
-                        if (pRainbowWndData->timerId) {
-                            if (KillTimer(NULL, (UINT_PTR)pRainbowWndData->timerId))
-                                pRainbowWndData->timerId = 0;
-                            else
-                                Wh_Log(L"[ERROR] Timer pause failure for window: %p", cwp->hwnd);
-                        }
-                            
-                        break;
-                    }
-                    case RAINBOW_UNLOAD:
-                    {
-                        RainbowData* pRainbowWndData = reinterpret_cast<RainbowData*>(RemovePropW(cwp->hwnd, g_RainbowPropStr.c_str()));
-                        if (!pRainbowWndData)
-                            break;
-                                                    
-                        if (KillTimer(NULL, (UINT_PTR)pRainbowWndData->timerId))
-                            Wh_Log(L"Timer unload success for window: %p", cwp->hwnd);
-                        else
-                            Wh_Log(L"[ERROR] Timer unload failure for window: %p", cwp->hwnd);
-
-                        delete pRainbowWndData;
-    
-                        break;
-                    }
-                }
-            }
-            break;
-        }
+    if (IsWindowClass(hWnd, L"ViewControlClass") && msg == WM_NCPAINT) {
+        UINT borderType = DWMWCP_ROUND;
+        DwmSetWindowAttribute(hWnd, DWMWA_WINDOW_CORNER_PREFERENCE, &borderType, sizeof(UINT));
     }
-
-    return CallNextHookEx(nullptr, nCode, wParam, lParam);
-}
-
-VOID AddWindowHookPerWindowThread(HWND hWnd)
-{   
-    if(g_settings.BorderFlag || g_settings.CaptionTextFlag || g_settings.TitlebarFlag || g_settings.BgType != g_settings.Default)
-    {
-        {
-            std::lock_guard<std::mutex> guard(g_allCallWndProcHooksMutex);   
-            DWORD dwThreadId = GetWindowThreadProcessId(hWnd, NULL);
-            HHOOK callWndProcHook = SetWindowsHookEx(WH_CALLWNDPROC, CallWndProc, nullptr, dwThreadId);
-            if (callWndProcHook) {
-                g_callWndProcHook = callWndProcHook;
-                g_allCallWndProcHooks.insert(callWndProcHook);
-            }
-            else
-                Wh_Log(L"[ERROR] SetWindowsHookEx failed for thread %u", dwThreadId);
-        }
-        if (g_settings.BorderRainbowFlag || g_settings.CaptionRainbowFlag || g_settings.TitlebarRainbowFlag)
-            SendMessage(hWnd, g_msgRainbowTimer, RAINBOW_LOAD, 0);
-    }
-}
-
-VOID RemoveOrUnloadWindowsHooks(BOOL Clean)
-{
-    if (Clean) 
-    {
-        for (HHOOK hook : g_allCallWndProcHooks)
-            UnhookWindowsHookEx(hook);
-        g_allCallWndProcHooks.clear();
-    }
-    else if (g_callWndProcHook)
-    {
-        auto it = g_allCallWndProcHooks.find(g_callWndProcHook);
-        if (it != g_allCallWndProcHooks.end()) {
-            std::lock_guard<std::mutex> guard(g_allCallWndProcHooksMutex);
-            UnhookWindowsHookEx(g_callWndProcHook);
-            g_allCallWndProcHooks.erase(it);
-        }
-    }
-}
-
-BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved)
-{
-    switch (fdwReason) {
-    case DLL_PROCESS_ATTACH:
-        break;
-
-    case DLL_THREAD_ATTACH:
-        break;
-
-    case DLL_THREAD_DETACH:
-        RemoveOrUnloadWindowsHooks(FALSE);
-        break;
-
-    case DLL_PROCESS_DETACH:
-        break;
-    }
-
-    return TRUE;
-}
-
-BOOL WINAPI HookedTrackPopupMenuEx(HMENU hMenu, UINT uFlags, INT x, INT y, HWND hWnd, LPTPMPARAMS lptpm)
-{
-    // System tray popup menus
-    AddWindowHookPerWindowThread(hWnd);
-    return TrackPopupMenuEx_orig(hMenu, uFlags, x, y, hWnd, lptpm);
-}
-
-static LRESULT WINAPI HookedDefWindowProcW(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
-{  
-    if (Msg == WM_DWMCOLORIZATIONCOLORCHANGED)
-    {
-        COLORREF oldAccentClr = g_settings.AccentColor;
-        GetAccentColor(g_settings.AccentColor);
-        if (oldAccentClr != g_settings.AccentColor) 
-        {            
-            if (g_settings.BorderActiveColor == oldAccentClr)
-                g_settings.BorderActiveColor = g_settings.AccentColor;
-            if (g_settings.BorderInactiveColor == oldAccentClr)
-                g_settings.BorderInactiveColor = g_settings.AccentColor;
-            ColorizeSysColors();
-            g_AccentPalette.LoadAccentPalette();
-            g_themeCache.ClearCache();
-            g_IsSysThemeDarkMode = ShouldSystemUseDarkMode();
-        }
-    }
-    return DefWindowProc_orig(hWnd, Msg, wParam, lParam);
+    return DefWindowProc_orig(hWnd, msg, wParam, lParam);
 }
 
 VOID HandleEffects(HWND hWnd)
 {
-    BOOL isFlyoutWindow = (IsWindowClass(hWnd, TOOLTIPS_CLASS) || IsWindowClass(hWnd, MENUPOPUP_CLASS) 
-        || IsWindowClass(hWnd, L"DropDown") || IsWindowClass(hWnd, L"ViewControlClass"));
+    BOOL isFlyoutWindow = isWindowFlyout(hWnd);
 
-    if (g_settings.ExtendFrame && !isFlyoutWindow)
-            ApplyFrameExtension(hWnd);
-
-    if (g_settings.ImmersiveDarkmode)
+    if (g_IsSysThemeDarkMode) 
         DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &ENABLE, sizeof(UINT));
 
     if(g_settings.BgType == g_settings.AccentBlurBehind)
@@ -5895,58 +5130,194 @@ VOID HandleEffects(HWND hWnd)
             DwmMakeWindowTransparent(hWnd);
             TriggerWindowNCRendering(hWnd);
         }
-        SetSystemBackdrop(hWnd, g_settings.BgType);
+        DwmSetWindowAttribute(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, &g_settings.BgType, sizeof(UINT));
     }
 
-    if(g_settings.BorderFlag && !g_settings.BorderRainbowFlag)
-        EnableColoredBorder(hWnd);
+    if (!isFlyoutWindow && g_settings.BgType != g_settings.Default) {
+        MARGINS margins = {-1, -1, -1, -1};
+        DwmExtendFrameIntoClientArea(hWnd, &margins);
+    }
     
-    SetCornerType(hWnd, g_settings.CornerPref);
+    if (isFlyoutWindow) {
+        UINT borderType = DWMWCP_ROUND;
+        DwmSetWindowAttribute(hWnd, DWMWA_WINDOW_CORNER_PREFERENCE, &borderType, sizeof(UINT));
+    }
+    
+    return;
 }
 
 VOID NewWindowShown(HWND hWnd) 
 {
     if(!IsWindowEligible(hWnd))
         return;        
-    else
-        Wh_Log(L"Eligible window: %p", hWnd);
-
+    //else
+        //Wh_Log(L"Eligible window: %p", hWnd);
     HandleEffects(hWnd);
-    AddWindowHookPerWindowThread(hWnd);
 }
 
-VOID DwmExpandFrameIntoClientAreaHook(){
+VOID DwmExpandFrameIntoClientAreaHook() {
     WindhawkUtils::SetFunctionHook(DwmExtendFrameIntoClientArea, HookedDwmExtendFrameIntoClientArea, &DwmExtendFrameIntoClientArea_orig);
 }
 
-VOID DwmSetWindowAttributeHook(){
+VOID DwmSetWindowAttributeHook() {
     WindhawkUtils::SetFunctionHook(DwmSetWindowAttribute, HookedDwmSetWindowAttribute, &DwmSetWindowAttribute_orig); 
 }
 
-VOID CustomRendering()
+HRESULT WINAPI HookedGetThemeTransitionDuration(HTHEME hTheme, INT iPartId, INT iStateIdFrom, INT iStateIdTo, INT iPropId, DWORD *pdwDuration)
 {
-    InitDirect2D();
+    auto hr = GetThemeTransitionDuration_orig(hTheme, iPartId, iStateIdFrom, iStateIdTo, iPropId, pdwDuration);
+    std::wstring ThemeClassStr = GetThemeClass(hTheme);
+    
+    if (ThemeClassStr == L"ScrollBar" && (iPartId == SBP_ARROWBTN || iPartId == SBP_THUMBBTNHORZ || iPartId == SBP_THUMBBTNVERT) && iStateIdTo == SCRBS_NORMAL)
+        *pdwDuration = 40;
+    else if (ThemeClassStr == L"ScrollBar" && (iPartId == SBP_ARROWBTN && iStateIdFrom == SCRBS_HOT && iStateIdTo == SCRBS_HOVER))
+        *pdwDuration = 40;
+    
+    return hr;
+}
+
+#ifdef _WIN64
+#define STDCALL  __cdecl
+#define SSTDCALL L"__cdecl"
+#else
+#define STDCALL  __stdcall
+#define SSTDCALL L"__stdcall"
+#endif
+
+LRESULT (STDCALL *CThemeMenu_MenuKeyboardMsgProc_orig)(INT code, WPARAM wParam, LPARAM lParam);
+LRESULT STDCALL HookedCThemeMenu_MenuKeyboardMsgProc_orig(INT code, WPARAM wParam, LPARAM lParam)
+{
+    auto res = CThemeMenu_MenuKeyboardMsgProc_orig(code, wParam, lParam);
+
     #ifdef _WIN64
-        CplDuiHook();
+        INT archOffset = 1;
+    #else
+        INT archOffset = 2;
     #endif
-    WindhawkUtils::SetFunctionHook(DefWindowProc, HookedDefWindowProcW, &DefWindowProc_orig);
-    WindhawkUtils::SetFunctionHook(GetThemeBitmap, HookedGetThemeBitmap, &GetThemeBitmap_orig);
-    WindhawkUtils::SetFunctionHook(GetThemeColor, HookedGetColorTheme, &GetThemeColor_orig);   
-    WindhawkUtils::SetFunctionHook(DrawThemeBackground, HookedDrawThemeBackground, &DrawThemeBackground_orig);
-    WindhawkUtils::SetFunctionHook(DrawThemeBackgroundEx, HookedDrawThemeBackgroundEx, &DrawThemeBackgroundEx_orig);
-    if (!g_settings.SetSystemColors) {
-        WindhawkUtils::SetFunctionHook(GetSysColor, HookedGetSysColor, &GetSysColor_orig);
-        WindhawkUtils::SetFunctionHook(GetSysColorBrush, HookedGetSysColorBrush, &GetSysColorBrush_orig);
+
+    UINT msg = *reinterpret_cast<DWORD*>(lParam + 16 / archOffset);
+    HWND hWnd = *reinterpret_cast<HWND*>(lParam + 24 / archOffset);
+
+    if (IsWindowClass(hWnd, MENUPOPUP_CLASS) && (msg == WM_NCPAINT || msg == WM_PRINT))
+        HandleEffects(hWnd);
+
+    return res;
+}
+
+HRESULT (STDCALL *_GetBrushesForPart_orig)(HTHEME hTheme, int iPartId, COLORREF Color, HBITMAP *phBitmap, HBRUSH *phBrush);
+HRESULT STDCALL Hooked_GetBrushesForPart(HTHEME hTheme, int iPartId, COLORREF Color, HBITMAP *phBitmap, HBRUSH * phBrush)
+{
+    std::wstring ThemeClass = GetThemeClass(hTheme);
+    
+    if (ThemeClass == L"Tab" && (iPartId == TABP_BODY || iPartId == TABP_AEROWIZARDBODY)) {
+        *phBrush = GetSysColorBrush(COLOR_WINDOW);
+        return S_OK;
     }
-    WindhawkUtils::SetFunctionHook(DrawTextW, HookedDrawTextW, &DrawTextW_orig);
-    WindhawkUtils::SetFunctionHook(DrawTextExW, HookedDrawTextExW, &DrawTextExW_orig);
-    // Edtiboxes get black without proper custom system colors
-    if (g_settings.SetSystemColors)
-        WindhawkUtils::SetFunctionHook(ExtTextOutW, HookedExtTextOutW, &ExtTextOutW_orig);
-    WindhawkUtils::SetFunctionHook(DrawThemeText, HookedDrawThemeText, &DrawThemeText_orig);
-    WindhawkUtils::SetFunctionHook(DrawThemeTextEx, HookedDrawThemeTextEx, &DrawThemeTextEx_orig);
-    if (g_settings.FlyoutsEffects)
-        WindhawkUtils::SetFunctionHook(GetThemeMargins, HookedGetThemeMargins, &GetThemeMargins_orig);
+    return _GetBrushesForPart_orig(hTheme, iPartId, Color, phBitmap, phBrush);
+}
+
+void (__fastcall *_BorderRect_orig)(HDC, COLORREF, LPRECT, INT, INT);
+void __fastcall Hooked_BorderRect(HDC hdc, COLORREF color, LPRECT pRect, INT cxThickness, INT cyThickness)
+{
+    if (!pRect) return;
+
+    auto ComposeRectBorders = [&](RECT rcBorder)
+    {
+        BP_PAINTPARAMS params = { sizeof(BP_PAINTPARAMS) };
+        params.dwFlags = BPPF_ERASE | BPPF_NONCLIENT;
+        HDC memDC = NULL;
+
+        HPAINTBUFFER hpb = BeginBufferedPaint(hdc, &rcBorder, BPBF_TOPDOWNDIB, &params, &memDC);
+        if (!hpb) {
+            Wh_Log(L"Failed BeginBufferedPaint error:0x%08x", GetLastError());
+            return _BorderRect_orig(hdc, color, pRect, cxThickness, cyThickness);
+        }
+
+        SetBkColor(memDC, color);
+        ExtTextOutW(memDC, pRect->left, pRect->top, ETO_OPAQUE, pRect, NULL, NULL, NULL);
+
+        BufferedPaintSetAlpha(hpb, pRect, 255);
+        EndBufferedPaint(hpb, TRUE);
+    };
+
+    RECT rcBorder;
+    // 1. Bottom Border
+    rcBorder = *pRect;
+    rcBorder.top = rcBorder.bottom - cyThickness;
+    ComposeRectBorders(rcBorder);
+
+    // 2. Right Border
+    rcBorder = *pRect;
+    rcBorder.left = rcBorder.right - cxThickness;
+    ComposeRectBorders(rcBorder);
+
+    // 3. Left Border
+    rcBorder = *pRect;
+    rcBorder.right = rcBorder.left + cxThickness;
+    ComposeRectBorders(rcBorder);
+
+    // 4. Top Border
+    rcBorder = *pRect;
+    rcBorder.bottom = rcBorder.top + cyThickness;
+    ComposeRectBorders(rcBorder);
+    return;
+}
+
+VOID UxThemeHooks(BOOL isFlyoutEffectEnabled)
+{
+    WindhawkUtils::SYMBOL_HOOK uxthemedll_hooks[] =
+    {        
+        {
+            {
+                #ifdef _WIN64
+                    L"void __cdecl _BorderRect(struct HDC__ *,unsigned long,struct tagRECT const *,int,int)"
+                #else
+                    L"void __stdcall _BorderRect(struct HDC__ *,unsigned long,struct tagRECT const *,int,int)"
+                #endif
+            },
+            &_BorderRect_orig,
+            Hooked_BorderRect,
+            FALSE
+        },
+        
+        {
+            {
+                #ifdef _WIN64
+                    L"long __cdecl _GetBrushesForPart(void *,int,int,struct HBITMAP__ * *,struct HBRUSH__ * *)"
+                #else
+                    L"long __stdcall _GetBrushesForPart(void *,int,int,struct HBITMAP__ * *,struct HBRUSH__ * *)"
+                #endif
+            },
+            &_GetBrushesForPart_orig,
+            Hooked_GetBrushesForPart,
+            FALSE
+        },
+        
+        {
+            {
+                #ifdef _WIN64
+                    L"protected: static __int64 __cdecl CThemeMenu::MenuKeyboardMsgProc(int,unsigned __int64,__int64)"
+                #else
+                    L"protected: static long __stdcall CThemeMenu::MenuKeyboardMsgProc(int,unsigned int,long)"
+                #endif
+            },
+            &CThemeMenu_MenuKeyboardMsgProc_orig,
+            HookedCThemeMenu_MenuKeyboardMsgProc_orig,
+            FALSE
+        },
+    };
+
+    HMODULE hUxTheme = LoadLibraryEx(L"uxtheme.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!hUxTheme) {
+        Wh_Log(L"Failed to load uxtheme.dll");
+        return;
+    }
+
+    // If flyout effects setting isn't enabled hook to all symbols except the last one -> CThemeMenu::MenuKeyboardMsgProc
+    if (!WindhawkUtils::HookSymbols(hUxTheme, uxthemedll_hooks, !isFlyoutEffectEnabled ? ARRAYSIZE(uxthemedll_hooks) - 1 : ARRAYSIZE(uxthemedll_hooks))) {
+        Wh_Log(L"Failed to hook one or more symbol functions in uxtheme.dll");
+        return;
+    }
 }
 
 VOID RestoreWindowCustomizations(HWND hWnd)
@@ -5955,39 +5326,28 @@ VOID RestoreWindowCustomizations(HWND hWnd)
         return;
     
     // Manually restore frame extension
-    if(!(IsWindowClass(hWnd,  L"TaskManagerWindow")))
+    if(!(IsWindowClass(hWnd,  L"TaskManagerWindow") && g_settings.BgType != g_settings.Default))
     {
         MARGINS margins = { 0, 0, 0, 0 };
         DwmExtendFrameIntoClientArea(hWnd, &margins);
     }
 
-    g_settings.BorderActiveColor = DWMWA_COLOR_DEFAULT;
-    DwmSetWindowAttribute(hWnd, DWMWA_BORDER_COLOR , &g_settings.BorderActiveColor, sizeof(COLORREF));
-    
-    g_settings.TitlebarActiveColor = DWMWA_COLOR_DEFAULT;
-    DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR , &g_settings.TitlebarActiveColor, sizeof(COLORREF));
-
-    g_settings.CaptionActiveTextColor = DWMWA_COLOR_DEFAULT;
-    DwmSetWindowAttribute(hWnd, DWMWA_TEXT_COLOR , &g_settings.CaptionActiveTextColor, sizeof(COLORREF));
-
-    if (g_settings.CornerPref != g_settings.Rounded)
-        DwmSetWindowAttribute(hWnd, DWMWA_WINDOW_CORNER_PREFERENCE, &DEFAULTROUND , sizeof(UINT));
+    ACCENT_POLICY accentPolicy = {};
+    WINCOMPATTRDATA winCompositionAttrib = {};
+    DWM_BLURBEHIND dwmBlurBehindData = {};
 
     // Disabling AccentBlurBehind temp workaround
-    g_bb.fEnable = FALSE;
-    g_bb.hRgnBlur = NULL;
-    DwmEnableBlurBehindWindow(hWnd, &g_bb);
+    dwmBlurBehindData.fEnable = FALSE;
+    dwmBlurBehindData.hRgnBlur = NULL;
+    DwmEnableBlurBehindWindow(hWnd, &dwmBlurBehindData);
 
-    g_accent.AccentState = 0;
+    accentPolicy.AccentState = 0;
 
-    g_attrib.Attrib = WCA_ACCENT_POLICY;
-    g_attrib.pvData = &g_accent;
-    g_attrib.cbData = sizeof(g_accent);
+    winCompositionAttrib.Attrib = WCA_ACCENT_POLICY;
+    winCompositionAttrib.pvData = &accentPolicy;
+    winCompositionAttrib.cbData = sizeof(accentPolicy);
 
-    typedef BOOL(WINAPI* pSetWindowCompositionAttribute)(HWND, WINCOMPATTRDATA*);
-    auto SetWindowCompositionAttribute = (pSetWindowCompositionAttribute)GetProcAddress(GetModuleHandleW(L"user32.dll"), "SetWindowCompositionAttribute");
-    if (SetWindowCompositionAttribute) 
-        SetWindowCompositionAttribute(hWnd, &g_attrib);
+    SetWindowCompositionAttribute(hWnd, &winCompositionAttrib);
     
     DwmSetWindowAttribute(hWnd, DWMWA_SYSTEMBACKDROP_TYPE , &AUTO, sizeof(UINT));
 }
@@ -6088,160 +5448,948 @@ BOOL GetColorSetting(LPCWSTR hexColor, COLORREF& outColor)
     }
 }
 
-DOUBLE RainbowSpeedInput(INT input)
+// ---------------------------------------------------------------------------------------------
+// User32.dll internal operations in most cases use the gpsi pointer (global pointer shared info) in order to fetch useful attributes about the system session
+// one of them being the system color buffer, gpsi pointing to offest 4568 to system COLORREFs and offset 4696 to system BRUSHES
+//
+// Kernel operations (e.g. win32kfull.sys) use: W32GetUserSessionState() + offset (<20016> as of Win11-26200.8655) + <System color offset>
+//
+// System color offsets:
+//
+//     -System colors-                      -System brushes-
+//
+// 4568: COLOR_SCROLLBAR                4696: COLOR_SCROLLBAR
+// 4572: COLOR_BACKGROUND               4704: COLOR_BACKGROUND
+// 4576: COLOR_ACTIVECAPTION            4712: COLOR_ACTIVECAPTION
+// 4580: COLOR_INACTIVECAPTION          4720: COLOR_INACTIVECAPTION
+// 4584: COLOR_MENU                     4728: COLOR_MENU
+// 4588: COLOR_WINDOW                   4736: COLOR_WINDOW
+// 4592: COLOR_WINDOWFRAME              4744: COLOR_WINDOWFRAME
+// 4596: COLOR_MENUTEXT                 4752: COLOR_MENUTEXT
+// 4600: COLOR_WINDOWTEXT               4760: COLOR_WINDOWTEXT
+// 4604: COLOR_CAPTIONTEXT              4768: COLOR_CAPTIONTEXT
+// 4608: COLOR_ACTIVEBORDER             4776: COLOR_ACTIVEBORDER
+// 4612: COLOR_INACTIVEBORDER           4784: COLOR_INACTIVEBORDER
+// 4616: COLOR_APPWORKSPACE             4792: COLOR_APPWORKSPACE
+// 4620: COLOR_HIGHLIGHT                4800: COLOR_HIGHLIGHT
+// 4624: COLOR_HIGHLIGHTTEXT            4808: COLOR_HIGHLIGHTTEXT
+// 4628: COLOR_BTNFACE                  4816: COLOR_BTNFACE
+// 4632: COLOR_BTNSHADOW                4824: COLOR_BTNSHADOW
+// 4636: COLOR_GRAYTEXT                 4832: COLOR_GRAYTEXT
+// 4640: COLOR_BTNTEXT                  4840: COLOR_BTNTEXT
+// 4644: COLOR_INACTIVECAPTIONTEXT      4848: COLOR_INACTIVECAPTIONTEXT
+// 4648: COLOR_BTNHIGHLIGHT             4856: COLOR_BTNHIGHLIGHT
+// 4652: COLOR_3DDKSHADOW               4864: COLOR_3DDKSHADOW
+// 4656: COLOR_3DLIGHT                  4872: COLOR_3DLIGHT
+// 4660: COLOR_INFOTEXT                 4880: COLOR_INFOTEXT
+// 4664: COLOR_INFOBK                   4888: COLOR_INFOBK
+// 4668: COLOR_HOTLIGHT                 4896: COLOR_HOTLIGHT
+// 4672: COLOR_GRADIENTACTIVECAPTION    4904: COLOR_GRADIENTACTIVECAPTION
+// 4676: COLOR_GRADIENTACTIVECAPTION    4912: COLOR_GRADIENTACTIVECAPTION
+// 4680: COLOR_MENUHIGHLIGHT            4920: COLOR_MENUHIGHLIGHT
+// 4688: COLOR_MENUBAR                  4928: COLOR_MENUBAR
+// ---------------------------------------------------------------------------------------------
+
+// A considerable portion of coloring comes from CTL messages, replace the gpsi pointer inside user32 functions with system colors API getters
+LRESULT (__fastcall *RealDefWindowProcWorker_orig)(struct tagWND*, UINT, WPARAM, LPARAM, UINT);
+LRESULT __fastcall HookedRealDefWindowProcWorker(struct tagWND* pwnd, UINT msg, WPARAM wParam, LPARAM lParam, UINT flags)
 {
-    if (input < 1 || input > 100)
-        return 1.0f;
-
-    return (DOUBLE)input * 3.6;    
-}
-
-VOID GetProcStrFromPath(std::wstring& path) {
-    size_t pos = path.find_last_of(L"\\/");
-    if (pos != std::wstring::npos && pos + 1 < path.length()) {
-        path = path.substr(pos + 1);
-    }
-
-    if (!path.empty()) 
+    switch (msg)
     {
-        LCMapStringEx(
-            LOCALE_NAME_USER_DEFAULT, 
-            LCMAP_UPPERCASE,
-            path.c_str(),
-            path.length(),
-            &path[0],
-            path.length(),
-            nullptr, nullptr, 0);
+        case WM_CTLCOLOR:
+        case WM_CTLCOLORMSGBOX:
+        case WM_CTLCOLOREDIT:
+        case WM_CTLCOLORLISTBOX:
+        case WM_CTLCOLORBTN:
+        case WM_CTLCOLORDLG:
+        case WM_CTLCOLORSCROLLBAR:
+        case WM_CTLCOLORSTATIC:
+        {
+            COLORREF sysColorBk = 0;
+            COLORREF sysColorTxt = 0;
+            HBRUSH sysBrush = nullptr;
+            if (msg == WM_CTLCOLOR || msg == WM_CTLCOLOREDIT || msg == WM_CTLCOLORLISTBOX)
+            {
+                sysColorBk = GetSysColor(COLOR_WINDOW);                                 // Default: *gpsi + 4588 (COLOR_WINDOW)
+                sysColorTxt = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0); // Default: *gpsi + 4600 (COLOR_WINDOWTEXT)
+                sysBrush = GetSysColorBrush(COLOR_WINDOW);                              // Default: *gpsi + 4736 (COLOR_WINDOW)
+            }
+            else if (msg == WM_CTLCOLORMSGBOX || msg == WM_CTLCOLORDLG || msg == WM_CTLCOLORSTATIC)
+            {
+                sysColorBk = GetSysColor(COLOR_BTNFACE);                                // Default: *gpsi + 4628 (COLOR_BTNTEXT)
+                sysColorTxt = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0); // Default: *gpsi + 4600 (COLOR_WINDOWTEXT)
+                sysBrush = GetSysColorBrush(COLOR_BTNFACE);                             // Default: *gpsi + 4816 (COLOR_BTNTEXT)
+            }
+            else if (msg == WM_CTLCOLORBTN)
+            {
+                sysColorBk = GetSysColor(COLOR_BTNFACE);                                // Default: *gpsi + 4628 (COLOR_BTNTEXT)
+                sysColorTxt = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0); // Default: *gpsi + 4816 (COLOR_BTNTEXT)
+                sysBrush = GetSysColorBrush(COLOR_BTNFACE);                             // Default: *gpsi + 4816 (COLOR_BTNTEXT)
+            }
+            else if (msg == WM_CTLCOLORSCROLLBAR)
+            {
+                sysColorBk = GetSysColor(COLOR_BTNHIGHLIGHT);                           // Default: *gpsi + 4648 (COLOR_BTNHIGHLIGHT)
+                sysColorTxt = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0); // Default: *gpsi + 4840 (COLOR_BTNTEXT)
+                sysBrush = GetSysColorBrush(COLOR_BTNHIGHLIGHT);                        // Default: *gpsi + 4856 (COLOR_BTNHIGHLIGHT)
+            }
+
+            HDC hdc = reinterpret_cast<HDC>(wParam);
+
+            SetTextColor(hdc, sysColorTxt);
+            SetBkColor(hdc, sysColorBk);
+            return reinterpret_cast<LRESULT>(sysBrush);
+        }
+    }     
+    return RealDefWindowProcWorker_orig(pwnd, msg, wParam, lParam, flags);
+}
+
+// Paints the background of message boxes
+HBRUSH (STDCALL *MB_DlgProc_orig)(HWND, UINT, WPARAM, LPARAM);
+HBRUSH STDCALL Hooked_MB_DlgProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    if (msg == WM_CTLCOLORDLG || msg == WM_CTLCOLORSTATIC)
+        return GetSysColorBrush(COLOR_WINDOW); // Default: gpsi + 4736 (COLOR_WINDOW)
+    return MB_DlgProc_orig(hwnd, msg, wParam, lParam);
+}
+
+// Paints the lower part of message boxes
+void (STDCALL *DrawCommandRectangle_orig)(HWND);
+void STDCALL Hooked_DrawCommandRectangle(HWND hWnd)
+{
+    PAINTSTRUCT ps{};
+    HDC hdc = BeginPaint(hWnd, &ps);
+    if (!hdc)
+        return;
+
+    // Get window or client rectangle
+    RECT rc{};
+    GetClientRect(hWnd, &rc);
+
+    // Match USER behavior
+    HBRUSH hBrush = CreateSolidBrush(GetSysColor(COLOR_WINDOW)); // Default: gpsi + 4736 (COLOR_WINDOW)
+    HGDIOBJ oldBrush = SelectObject(hdc, hBrush);
+
+    HPEN hPen = CreatePen(PS_NULL, 0, 0);
+    HGDIOBJ oldPen = SelectObject(hdc, hPen);
+
+    Rectangle(hdc, rc.left, rc.top, rc.right, rc.bottom);
+
+    // Restore
+    SelectObject(hdc, oldPen);
+    DeleteObject(hPen);
+
+    SelectObject(hdc, oldBrush);
+    DeleteObject(hBrush);
+
+    EndPaint(hWnd, &ps);
+}
+
+// Modifying the background and text color of the classic Win32 tooltip (e.g., the one that appears when hovering the pointer over title bar buttons) which uses the gpsi pointer.
+// Additionally, enlarging the tooltip window and applying mod's effects.
+void (__fastcall *RenderTooltip_orig)(HWND, HDC, HGDIOBJ*);
+void __fastcall HookedRenderTooltip(HWND hWnd, HDC hdc, HGDIOBJ *a3)
+{
+    HGDIOBJ oldObj = SelectObject(hdc, a3[1]);
+    
+    LPCWCHAR lpString = reinterpret_cast<LPCWCHAR>(*a3);
+    UINT cch = wcslen(lpString); 
+
+    SIZE textSize;
+    GetTextExtentPoint32W(hdc, lpString, static_cast<INT>(cch), &textSize);
+
+    RECT clientRect {0};
+    GetClientRect(hWnd, &clientRect);
+
+    // Inflate tooltip window rect by x1.8
+    if (clientRect.bottom < static_cast<LONG>(textSize.cy * 1.8)) 
+    {
+        RECT winRect {0};
+        GetWindowRect(hWnd, &winRect);
+        
+        INT newWidth = static_cast<INT>((winRect.right - winRect.left) * 1.8);
+        INT newHeight = static_cast<INT>((winRect.bottom - winRect.top) * 1.8);
+
+        // Start with the X and Y coordinates the system originally gave it
+        INT newX = winRect.left;
+        INT newY = winRect.top;
+
+        // Screen Edge Detection
+        POINT cursorPos;
+        GetCursorPos(&cursorPos);
+        
+        // Find out exactly which monitor the cursor is currently on
+        HMONITOR hMonitor = MonitorFromPoint(cursorPos, MONITOR_DEFAULTTONEAREST);
+        MONITORINFO mi = { sizeof(mi) };
+        GetMonitorInfoW(hMonitor, &mi);
+
+        // Check if our new width pushes it past the right edge of this monitor
+        if ((newX + newWidth) > mi.rcMonitor.right)
+            // Shift X leftwards so the right edge of the tooltip matches the screen edge
+            // (Subtracting an extra 2 pixels so it doesn't touch the absolute physical bezel)
+            newX = mi.rcMonitor.right - newWidth - 2;
+
+        // Optional bonus: Do the same check for the bottom edge, just in case
+        if ((newY + newHeight) > mi.rcMonitor.bottom)
+            newY = mi.rcMonitor.bottom - newHeight - 2;
+
+        // Apply the new position and dimensions
+        SetWindowPos(hWnd, NULL, newX, newY, newWidth, newHeight,
+                     SWP_NOZORDER | SWP_NOACTIVATE
+                     );
+        
+        GetClientRect(hWnd, &clientRect);
+    }
+
+    COLORREF oldTextClr = SetTextColor(hdc, g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0)); // Default: gpsi + 4660 (COLOR_WINDOWTEXT)
+    COLORREF oldBkClr = SetBkColor(hdc, RGB(0, 0, 0)); // Default: gpsi + 4888 (COLOR_INFOTEXT)
+
+    INT textX = (clientRect.right - textSize.cx) / 2;
+    INT textY = (clientRect.bottom - textSize.cy) / 2;
+    
+    if (textX < 0) textX = 2;
+    if (textY < 0) textY = 1;
+
+    ExtTextOutW(hdc, textX, textY, ETO_OPAQUE, &clientRect, lpString, cch, 0);
+    
+    SetTextColor(hdc, oldTextClr);
+    SetBkColor(hdc, oldBkClr);
+    SelectObject(hdc, oldObj);
+    
+    return;
+}
+
+VOID User32Hooks(BOOL areSysColorsApplied)
+{
+    //WindhawkUtils::SetFunctionHook(SetClassLongPtrW, HookedSetClassLongPtrW, &SetClassLongPtrW_orig);
+    WindhawkUtils::SYMBOL_HOOK user32dll_hooks[] =
+    {  
+        {
+            {
+                #ifdef _WIN64
+                    L"__int64 __cdecl RealDefWindowProcWorker(struct tagWND *,unsigned int,unsigned __int64,__int64,unsigned long)"
+                #else
+                    L"long __stdcall RealDefWindowProcWorker(struct tagWND *,unsigned int,unsigned int,long,unsigned long)"
+                #endif
+            },
+            &RealDefWindowProcWorker_orig,
+            HookedRealDefWindowProcWorker,
+            FALSE
+        },
+        {
+            {
+                #ifdef _WIN64
+                    L"void __cdecl RenderTooltip(struct HWND__ *,struct HDC__ *,struct TooltipInfo *)"
+                #else
+                    L"void __stdcall RenderTooltip(struct HWND__ *,struct HDC__ *,struct TooltipInfo *)"
+                #endif
+            },
+            &RenderTooltip_orig,
+            HookedRenderTooltip,
+            FALSE
+        },
+        {
+            {
+                #ifdef _WIN64
+                    L"__int64 __cdecl MB_DlgProc(struct HWND__ *,unsigned int,unsigned __int64,__int64)"
+                #else
+                    L"int __stdcall MB_DlgProc(struct HWND__ *,unsigned int,unsigned int,long)"
+                #endif
+
+            },
+            &MB_DlgProc_orig,
+            Hooked_MB_DlgProc,
+            FALSE
+        },
+        {
+            {
+                #ifdef _WIN64
+                    L"void __cdecl DrawCommandRectangle(struct HWND__ *)"
+                #else
+                    L"void __stdcall DrawCommandRectangle(struct HWND__ *)"
+                #endif
+
+            },
+            &DrawCommandRectangle_orig,
+            Hooked_DrawCommandRectangle,
+            FALSE
+        }
+    };
+
+    HMODULE hUser32 = LoadLibraryEx(L"user32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!hUser32) {
+        Wh_Log(L"Failed to load user32.dll");
+        return;
+    }
+
+    // If SetSysColors API is executed then hook only the first two symbols of the array -> RealDefWindowProcWorker, RenderTooltip routines
+    if (!WindhawkUtils::HookSymbols(hUser32, user32dll_hooks, areSysColorsApplied ? 2 : ARRAYSIZE(user32dll_hooks))) {
+        Wh_Log(L"Failed to hook one or more symbol functions in user32.dll");
+        return;
     }
 }
 
-VOID GetCurrProcInfo(std::wstring& outName, DWORD& outPID) {
-    WCHAR modulePath[MAX_PATH];
-    GetModuleFileNameW(NULL, modulePath, MAX_PATH);
+void (__fastcall *SHThemeDrawText_orig)(void*, HDC, int, int, DTTOPTS*, LPCWSTR, LPRECT, int, UINT, int, __int64, COLORREF, COLORREF a13);
+void __fastcall Hooked_SHThemeDrawText(void *a1, HDC a2, int a3, int a4, DTTOPTS *a5, LPCWSTR lpString, LPRECT lprc, int a8, UINT format, int a10, __int64 a11, COLORREF color, COLORREF a13)
+{
+    if (!InTaskManagerProcess())
+        color = g_IsSysThemeDarkMode && (color & 0x00ffffff) <= RGB(96, 96, 96) ? RGB(255, 255, 255) : !g_IsSysThemeDarkMode ? RGB(0, 0, 0) : color;
+    
+    SHThemeDrawText_orig(a1, a2, a3, a4, a5, lpString, lprc, a8, format, a10, a11, color, a13);
+    return;
 
-    outName = modulePath;
-    GetProcStrFromPath(outName);
+}
 
-    outPID = GetCurrentProcessId();
+// Alpha blend highlighted text rectangle
+void (__fastcall *SHThemeFillTextRect_orig)(HDC hDC, RECT *lprc, COLORREF color, INT sysColorCode);
+void __fastcall HookedSHThemeFillTextRect(HDC hDC, RECT *lprc, COLORREF color, INT sysColorCode)
+{
+    if (color != GetSysColor(COLOR_HIGHLIGHT))
+        return SHThemeFillTextRect_orig(hDC, lprc, color, sysColorCode);
+    
+    BP_PAINTPARAMS params = { sizeof(BP_PAINTPARAMS) };
+    params.dwFlags = BPPF_ERASE;
+
+    HDC memDC = nullptr;
+    HPAINTBUFFER hpb = BeginBufferedPaint(hDC, lprc, BPBF_TOPDOWNDIB, &params, &memDC); 
+    if (!hpb) {
+        Wh_Log(L"Failed BeginBufferedPaint error:0x%08x", GetLastError());
+        return SHThemeFillTextRect_orig(hDC, lprc, color, sysColorCode); 
+    }
+
+    SHThemeFillTextRect_orig(memDC, lprc, color, sysColorCode);
+
+    BufferedPaintMakeOpaque(hpb, lprc);
+    EndBufferedPaint(hpb, TRUE); 
+}
+
+// Alpha blend highlighted text rectangle
+COLORREF (__fastcall *FillRectClr_orig)(HDC hdc, RECT *lprect, COLORREF color);
+COLORREF __fastcall HookedFillRectClr(HDC hdc, RECT *lprect, COLORREF color)
+{
+    if (color != GetSysColor(COLOR_HIGHLIGHT))
+        return FillRectClr_orig(hdc, lprect, color);
+        
+    BP_PAINTPARAMS params = { sizeof(BP_PAINTPARAMS) };
+    params.dwFlags = BPPF_ERASE;
+
+    HDC memDC = nullptr;
+    HPAINTBUFFER hpb = BeginBufferedPaint(hdc, lprect, BPBF_TOPDOWNDIB, &params, &memDC);
+    if (!hpb) {
+        Wh_Log(L"Failed BeginBufferedPaint error:0x%08x", GetLastError());
+        return FillRectClr_orig(hdc, lprect, color);
+    }
+
+    HBRUSH highlightedBrush = GetSysColorBrush(COLOR_HIGHLIGHT);
+    FillRect(memDC, lprect, highlightedBrush);
+
+    BufferedPaintMakeOpaque(hpb, lprect);
+    EndBufferedPaint(hpb, TRUE); 
+    
+    return color;
+}
+
+// Listbox background fill color return COLOR_WINDOW system color
+// We return white color so the black text inside listboxes are readable on system light theme.
+HBRUSH (STDCALL *ListBox_GetBrush_orig)(struct tagLBIV*, HBRUSH*);
+HBRUSH STDCALL HookedListBox_GetBrush(struct tagLBIV *a1, HBRUSH *hbr)
+{   
+    // Default return brush: GetSysColorBrush(COLOR_WINDOW)
+    HBRUSH ret = g_IsSysThemeDarkMode ? ListBox_GetBrush_orig(a1, hbr) : (HBRUSH)GetStockObject(WHITE_BRUSH);
+    return ret;
+}
+
+// The ComboBox control (e.g., the Windows address bar) draws an internal rectangle using a brush with the COLOR_WINDOW system color.
+// Since the custom COLOR_WINDOW is black, whereas the rest of the ComboBox control's background is intended to be drawn in white,
+// we intervene to correct this behavior in light theme mode.
+void (STDCALL *ComboEx_OnDrawItem_orig)(struct COMBOEX*, struct tagDRAWITEMSTRUCT*);
+void STDCALL HookedComboEx_OnDrawItem(struct COMBOEX *a1, struct tagDRAWITEMSTRUCT *a2)
+{
+    if (!g_IsSysThemeDarkMode) 
+    {
+        InflateRect(&a2->rcItem, 1, 1);
+        FillRect(a2->hDC, &a2->rcItem, (HBRUSH)GetStockObject(WHITE_BRUSH));
+        InflateRect(&a2->rcItem, -1, -1);
+    }
+    ComboEx_OnDrawItem_orig(a1, a2);
+    return;
+}
+
+VOID Comctl32Hooks()
+{
+    WindhawkUtils::SYMBOL_HOOK comctl32_hooks[] =
+    {        
+        {
+            {
+                #ifdef _WIN64
+                    L"SHThemeDrawText"
+                #else
+                    L"_SHThemeDrawText@56"
+                #endif
+            },
+            &SHThemeDrawText_orig,
+            Hooked_SHThemeDrawText,
+            FALSE
+        },
+        // SHThemeFillTextRect is 64-bit only
+        // 32-bit version is implemented inside SHThemeDrawText
+        #ifdef _WIN64
+        {
+            {
+                L"SHThemeFillTextRect"
+            },
+            &SHThemeFillTextRect_orig,
+            HookedSHThemeFillTextRect,
+            FALSE
+        },
+        #endif
+        {
+            {
+                #ifdef _WIN64
+                    L"FillRectClr"
+                #else
+                    L"_FillRectClr@12"
+                #endif
+            },
+            &FillRectClr_orig,
+            HookedFillRectClr,
+            FALSE
+        },
+        {
+            {
+                #ifdef _WIN64
+                    L"struct HBRUSH__ * __cdecl ListBox_GetBrush(struct tagLBIV *,struct HBRUSH__ * *)"
+                #else
+                    L"struct HBRUSH__ * __stdcall ListBox_GetBrush(struct tagLBIV *,struct HBRUSH__ * *)"
+                #endif
+            },
+            &ListBox_GetBrush_orig,
+            HookedListBox_GetBrush,
+            FALSE
+        },
+        {
+            {
+                #ifdef _WIN64
+                    L"void __cdecl ComboEx_OnDrawItem(struct COMBOEX *,struct tagDRAWITEMSTRUCT *)"
+                #else
+                    L"void __stdcall ComboEx_OnDrawItem(struct COMBOEX *,struct tagDRAWITEMSTRUCT *)"
+                #endif
+            },
+            &ComboEx_OnDrawItem_orig,
+            HookedComboEx_OnDrawItem,
+            FALSE
+        },           
+    };
+
+    HMODULE hComCtl32 = LoadComCtlModule();
+    if (!hComCtl32) {
+        Wh_Log(L"Failed to load comctl32.dll");
+        return;
+    }
+
+    if (!WindhawkUtils::HookSymbols(hComCtl32, comctl32_hooks, ARRAYSIZE(comctl32_hooks))) {
+        Wh_Log(L"Failed to hook one or more symbol functions in comctl32.dll");
+        return;
+    }
+}
+
+BOOL CThemeCache::CacheNavigationDivider(HDC hdc)
+{
+    FLOAT x = 0, y = 0;
+    FLOAT width = 2, height = 2;
+
+    if(!g_themeCache.CreateDIB(g_themeCache.navigationdivider[0], hdc, width, height))
+        return FALSE;
+
+    RECT rc = {(INT)x, (INT)y, (INT)width, (INT)height};
+    
+    Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
+    if (FAILED(CreateBoundD2DRenderTarget(g_themeCache.navigationdivider[0], &rc, g_d2dFactory, &pRenderTarget)))
+        return FALSE;
+    
+    Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush;
+    pRenderTarget->CreateSolidColorBrush(g_IsSysThemeDarkMode ? MyD2D1Color(96, 160, 160, 160) : MyD2D1Color(96, 0, 0, 0), &brush);
+
+    pRenderTarget->BeginDraw();
+
+    // 0.5f makes stroke height 1px
+    pRenderTarget->DrawLine(D2D1_POINT_2F(x, y + .5f), D2D1_POINT_2F(width, y + .5f), brush.Get());
+
+    HRESULT hr = pRenderTarget->EndDraw();
+    if (FAILED(hr)) {Wh_Log(L"Failed D2D drawing [ERROR]: 0x%08X\n", hr); return FALSE;}
+    return TRUE;
+}
+
+// Render custom D2D alpha blended navigation pane divider
+void (__thiscall *CNscTree_DrawDivider_orig)(class CNscTree* , HDC, struct _TREEITEM*);
+void __thiscall Hooked_CNscTree_DrawDivider(CNscTree *__this, HDC hdc, struct _TREEITEM *hTreeItem)
+{
+    auto Fallback = [&](LPCWSTR errorMessage = NULL) {
+        if (errorMessage)
+            Wh_Log(L"%s", errorMessage);
+        CNscTree_DrawDivider_orig(__this, hdc, hTreeItem);
+        return;
+    };
+
+    // As of Win11 26200.8737 hwnd offsets 64-bit: offset 50, 32-bit: offset 61
+    auto GetTreeViewHWND = [&__this]() 
+    {
+        #ifdef _WIN64
+            return reinterpret_cast<HWND*>(__this)[50];
+        #else
+            return reinterpret_cast<HWND>(reinterpret_cast<DWORD*>(__this)[61]);
+        #endif
+    };
+
+    // TreeView window handle retrieved from NtUserCreateWindowEx hook
+    HWND hwndTreeView = tl_hwndTreeView;
+    if (!IsWindow(hwndTreeView) || !IsWindowClass(hwndTreeView, L"SysTreeView32"))
+        hwndTreeView = GetTreeViewHWND();
+    
+    if (!IsWindow(hwndTreeView) || !IsWindowClass(hwndTreeView, L"SysTreeView32"))
+        Fallback(L"Not valid TreeView window");
+    
+    RECT treeItemRect = {0};
+    *reinterpret_cast<HTREEITEM*>(&treeItemRect) = (HTREEITEM)hTreeItem;
+    
+    if (!SendMessageW(hwndTreeView, TVM_GETITEMRECT, 0, (LPARAM)&treeItemRect))
+        Fallback();
+    
+    if (!g_d2dFactory)
+        Fallback();
+
+    if (!g_themeCache.navigationdivider[0])
+        if (!g_themeCache.CacheNavigationDivider(hdc))
+            Fallback();
+    
+    RECT lineRc = treeItemRect;
+    INT middlePoint = RECTHEIGHT(&treeItemRect) / 4.f;
+    lineRc.top = treeItemRect.top + middlePoint - 1;
+    lineRc.bottom = treeItemRect.top + middlePoint + 1;
+    lineRc.left = treeItemRect.left + RECTWIDTH(&treeItemRect) * 0.05f; // default horizontal bounds offset
+    lineRc.right = treeItemRect.right - lineRc.left;
+
+    DrawNineGridStretch(hdc, g_themeCache.navigationdivider[0], &lineRc, 1, 1, 0, 0);
+    return;
+}
+
+VOID ExplorerFrameHooks()
+{
+    WindhawkUtils::SYMBOL_HOOK ExplorerFrame_hooks[] =
+    {
+        {
+            {
+                #ifdef _WIN64
+                    L"private: void __cdecl CNscTree::DrawDivider(struct HDC__ *,struct _TREEITEM *)"
+                #else
+                    L"private: void __thiscall CNscTree::DrawDivider(struct HDC__ *,struct _TREEITEM *)"
+                #endif
+            },
+            &CNscTree_DrawDivider_orig,
+            Hooked_CNscTree_DrawDivider,
+            FALSE
+        },          
+    };
+
+    HMODULE hExplorerFrame = LoadLibraryEx(L"ExplorerFrame.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!hExplorerFrame) {
+        Wh_Log(L"Failed to load ExplorerFrame.dll");
+        return;
+    }
+
+    if (!WindhawkUtils::HookSymbols(hExplorerFrame, ExplorerFrame_hooks, ARRAYSIZE(ExplorerFrame_hooks))) {
+        Wh_Log(L"Failed to hook one or more symbol functions in ExplorerFrame.dll");
+        return;
+    }
+}
+
+// Branding images are painted using TransparentBlt() with white transparency mask.
+// Paint everything except the image text into white in order to force transparency to the background.
+void RecolorBrandingLogoBackground(HBITMAP hbm)
+{
+    if (!hbm) 
+        return;
+
+    BITMAP bm{};
+    if (!GetObject(hbm, sizeof(bm), &bm)) 
+        return;
+
+    BITMAPINFO bmi{};
+    bmi.bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth       = bm.bmWidth;
+    bmi.bmiHeader.biHeight      = bm.bmHeight;
+    bmi.bmiHeader.biPlanes      = 1;
+    bmi.bmiHeader.biBitCount    = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    HDC hdc = CreateCompatibleDC(nullptr);
+    if (!hdc) 
+        return;
+
+    size_t pixels = static_cast<size_t>(bm.bmWidth) * bm.bmHeight;
+    
+    auto px = std::make_unique<COLORREF[]>(pixels);
+
+    if (GetDIBits(hdc, hbm, 0, bm.bmHeight, px.get(), &bmi, DIB_RGB_COLORS))
+    {
+        // Check if the first pixel is RGB(240, 240, 240). If not, it's probably a custom image -> abort.
+        if ((px[0] & 0x00FFFFFF) == 0x00F0F0F0)
+        {
+            // Target color to keep: RGB(0, 120, 212)
+            constexpr COLORREF targetColor = 0x000078D4; 
+
+            for (size_t i = 0; i < pixels; ++i)
+            {
+                if ((px[i] & 0x00FFFFFF) != targetColor)
+                    px[i] = 0xFFFFFFFF; // Turn white
+                else
+                    px[i] = g_settings.AccentColorize ?
+                            // bgr -> rgb 
+                            (0xFF000000 | ((g_settings.AccentColor & 0x0000FF) << 16) | (g_settings.AccentColor & 0x00FF00) | ((g_settings.AccentColor & 0xFF0000) >> 16))
+                            : px[i];
+            }
+            SetDIBits(hdc, hbm, 0, bm.bmHeight, px.get(), &bmi, DIB_RGB_COLORS);
+        }
+    }
+    DeleteDC(hdc); 
+}
+
+// Intercept the windows branding logo image (e.g winver, shutdown dialog, regedit etc.)
+// Winver loads the bitmap using LoadAboutBitmaps() routine, shutdown dialog using LoadBrandingBitmap().
+HANDLE (__fastcall *BrandingLoadImage_orig)(LPCWSTR pszBrand, UINT uID, UINT type, int cx, int cy, UINT  fuLoad);
+HANDLE __fastcall HookedBrandingLoadImage(LPCWSTR pszBrand, UINT uID, UINT type, int cx, int cy, UINT  fuLoad)
+{    
+    auto hImage = BrandingLoadImage_orig(pszBrand, uID, type, cx, cy, fuLoad);
+
+    // The image resource is fetched from basebrd.dll resource image 121.
+    if (!wcscmp(pszBrand, L"Basebrd") && uID == 121)
+        RecolorBrandingLogoBackground(reinterpret_cast<HBITMAP>(hImage));
+    return hImage;
+}
+
+VOID WinbrandHooks()
+{
+    WindhawkUtils::SYMBOL_HOOK Winbrand_hooks[] =
+    {
+        {
+            {
+                #ifdef _WIN64
+                    L"BrandingLoadImage"
+                #else
+                    L"_BrandingLoadImage@24"
+                #endif
+            },
+            &BrandingLoadImage_orig,
+            HookedBrandingLoadImage,
+            FALSE
+        },
+    };
+
+    HMODULE hWinbrand = LoadLibraryEx(L"winbrand.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!hWinbrand ) {
+        Wh_Log(L"Failed to load winbrand.dll");
+        return;
+    }
+
+    if (!WindhawkUtils::HookSymbols(hWinbrand , Winbrand_hooks, ARRAYSIZE(Winbrand_hooks))) {
+        Wh_Log(L"Failed to hook one or more symbol functions in winbrand.dll");
+        return;
+    }
+}
+
+// Imitate the internal pseudohandle logic and replace gpsi pointer with GetSysColorBrush getter API.
+BOOL WINAPI HookedFillRect(HDC hdc, LPCRECT lprc, HBRUSH hbr)
+{    
+    ULONG_PTR pseudoSystemBrush = (ULONG_PTR)hbr - 1;
+    if (pseudoSystemBrush <= 30)
+        return FillRect_orig(hdc, lprc, GetSysColorBrush((INT)pseudoSystemBrush));    
+
+    return FillRect_orig(hdc, lprc, hbr);
+}
+
+// Paint the explorer dialogs bottom part background
+BOOL (__fastcall *SetDarkThemeColors_orig)(void **, HDC);
+BOOL __fastcall HookedSetDarkThemeColors(void **Brush, HDC hdc)
+{
+    SetBkColor(hdc, RGB(0, 0, 0));
+    SetTextColor(hdc, g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0));
+    //if ( !*Brush )
+        *Brush = (void*)GetSysColorBrush(COLOR_WINDOW);
+    return *Brush != nullptr;
+}
+
+// Paint the explorer dialogs editbox background
+LRESULT (STDCALL *CFileNameComboBox_s_ComboBoxRootSubclass_orig)(HWND, UINT, HDC, LPARAM, UINT_PTR, DWORD_PTR);
+LRESULT STDCALL HookedCFileNameComboBox_s_ComboBoxRootSubclass(HWND hWnd, UINT uMsg, HDC wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
+{
+    auto ret = CFileNameComboBox_s_ComboBoxRootSubclass_orig(hWnd, uMsg, wParam, lParam, uIdSubclass, dwRefData);
+
+    // Intercept the paint messages
+    if (uMsg != WM_CTLCOLOREDIT && uMsg != WM_CTLCOLORLISTBOX && uMsg != WM_CTLCOLORSTATIC) 
+        return ret;
+    
+    HDC hdc = reinterpret_cast<HDC>(wParam);
+    SetBkColor(hdc, RGB(0, 0, 0));
+    SetTextColor(hdc, g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0));
+    return reinterpret_cast<LRESULT>(GetSysColorBrush(COLOR_WINDOW));
+}
+
+BOOL (STDCALL *CComboBoxExBase_OnWinEvent_orig)(class CComboBoxExBase *, HWND, UINT, HDC, LPARAM, LRESULT*);
+BOOL STDCALL HookedCComboBoxExBase_OnWinEvent(class CComboBoxExBase *__this, HWND hWnd, UINT uMsg, HDC hdc, LPARAM lParam, LRESULT* pResult)
+{
+    auto ret = CComboBoxExBase_OnWinEvent_orig(__this, hWnd, uMsg, hdc, lParam, pResult);
+
+    // Intercept the paint messages
+    if (uMsg != WM_CTLCOLOREDIT && uMsg != WM_CTLCOLORLISTBOX && uMsg != WM_CTLCOLORSTATIC) 
+        return ret;
+
+    if (ret == false && pResult != nullptr && *pResult != 0) 
+    {
+        // C. Overwrite the original SetBkColor and SetTextColor
+        SetBkColor(hdc, RGB(0, 0, 0));          // Black Background
+        SetTextColor(hdc, g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0));  // White Text
+
+        // D. Replace the original Dark Gray brush in the out-parameter with our Black Brush
+        *pResult = reinterpret_cast<LRESULT>(GetSysColorBrush(COLOR_WINDOW));
+    }
+    return ret;
+}
+
+VOID Comdlg32Hooks()
+{
+    WindhawkUtils::SYMBOL_HOOK hComDlg32_hooks[] =
+    {
+        
+        {
+            {
+                #ifdef _WIN64
+                    L"bool __cdecl SetDarkThemeColors(class wil::unique_any_t<class wil::details::unique_storage<struct wil::details::resource_policy<struct HBRUSH__ *,int (__cdecl*)(void *),&int __cdecl DeleteObject(void *),struct wistd::integral_constant<unsigned __int64,0>,struct HBRUSH__ *,struct HBRUSH__ *,0,std::nullptr_t> > > &,struct HDC__ *)"
+                #else
+                    L"bool __stdcall SetDarkThemeColors(class wil::unique_any_t<class wil::details::unique_storage<struct wil::details::resource_policy<struct HBRUSH__ *,int (__stdcall*)(void *),&int __stdcall DeleteObject(void *),struct wistd::integral_constant<unsigned int,0>,struct HBRUSH__ *,struct HBRUSH__ *,0,std::nullptr_t> > > &,struct HDC__ *)"
+                #endif
+            },
+            &SetDarkThemeColors_orig,
+            HookedSetDarkThemeColors,
+            FALSE
+        },
+        
+        {
+            {
+                #ifdef _WIN64
+                    L"private: static __int64 __cdecl CFileNameComboBox::s_ComboBoxRootSubclass(struct HWND__ *,unsigned int,unsigned __int64,__int64,unsigned __int64,unsigned __int64)"
+                #else
+                    L"private: static long __stdcall CFileNameComboBox::s_ComboBoxRootSubclass(struct HWND__ *,unsigned int,unsigned int,long,unsigned int,unsigned long)"
+                #endif
+            },
+            &CFileNameComboBox_s_ComboBoxRootSubclass_orig,
+            HookedCFileNameComboBox_s_ComboBoxRootSubclass,
+            FALSE
+        },
+        
+        {
+            {
+                #ifdef _WIN64
+                    L"public: virtual long __cdecl CComboBoxExBase::OnWinEvent(struct HWND__ *,unsigned int,unsigned __int64,__int64,__int64 *)"
+                #else
+                    L"public: virtual long __stdcall CComboBoxExBase::OnWinEvent(struct HWND__ *,unsigned int,unsigned int,long,long *)"
+                #endif
+            },
+            &CComboBoxExBase_OnWinEvent_orig,
+            HookedCComboBoxExBase_OnWinEvent,
+            FALSE
+        },
+        
+    };
+
+    HMODULE hComDlg32 = LoadLibraryEx(L"comdlg32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!hComDlg32 ) {
+        Wh_Log(L"Failed to load comdlg32.dll");
+        return;
+    }
+
+    if (!WindhawkUtils::HookSymbols(hComDlg32 , hComDlg32_hooks, ARRAYSIZE(hComDlg32_hooks))) {
+        Wh_Log(L"Failed to hook one or more symbol functions in comdlg32.dll");
+        return;
+    }
+}
+
+VOID CustomRenderingHooks()
+{
+    InitDirect2D();
+    #ifdef _WIN64
+        CplDuiHook();
+    #endif
+    WindhawkUtils::SetFunctionHook(DefWindowProc, HookedDefWindowProcW, &DefWindowProc_orig);
+    WindhawkUtils::SetFunctionHook(GetThemeColor, HookedGetColorTheme, &GetThemeColor_orig);   
+    WindhawkUtils::SetFunctionHook(DrawThemeBackground, HookedDrawThemeBackground, &DrawThemeBackground_orig);
+    WindhawkUtils::SetFunctionHook(DrawThemeBackgroundEx, HookedDrawThemeBackgroundEx, &DrawThemeBackgroundEx_orig);
+    WindhawkUtils::SetFunctionHook(DrawThemeEdge, HookedDrawThemeEdge, &DrawThemeEdge_orig);
+    ExplorerFrameHooks();
+    Comctl32Hooks();
+    if (g_IsSysThemeDarkMode)
+        Comdlg32Hooks();
+    WinbrandHooks();
+    User32Hooks(g_settings.SetSystemColors);
+    if (!g_settings.SetSystemColors) {
+        WindhawkUtils::SetFunctionHook(FillRect, HookedFillRect, &FillRect_orig);
+        WindhawkUtils::SetFunctionHook(GetSysColor, HookedGetSysColor, &GetSysColor_orig);
+        WindhawkUtils::SetFunctionHook(GetSysColorBrush, HookedGetSysColorBrush, &GetSysColorBrush_orig);
+    }
+    WindhawkUtils::SetFunctionHook(DrawTextWithGlow, HookedDrawTextWithGlow, &DrawTextWithGlow);
+    WindhawkUtils::SetFunctionHook(DrawTextW, HookedDrawTextW, &DrawTextW_orig);
+    WindhawkUtils::SetFunctionHook(ExtTextOutW, HookedExtTextOutW, &ExtTextOutW_orig);
+    WindhawkUtils::SetFunctionHook(DrawThemeText, HookedDrawThemeText, &DrawThemeText_orig);
+    WindhawkUtils::SetFunctionHook(DrawThemeTextEx, HookedDrawThemeTextEx, &DrawThemeTextEx_orig);
+    UxThemeHooks(g_settings.FlyoutsEffects);
+    if (g_settings.FlyoutsEffects)
+        WindhawkUtils::SetFunctionHook(GetThemeMargins, HookedGetThemeMargins, &GetThemeMargins_orig);
+    WindhawkUtils::SetFunctionHook(GetThemeTransitionDuration, HookedGetThemeTransitionDuration, &GetThemeTransitionDuration_orig);
+    WindhawkUtils::SetFunctionHook(GetThemeFont, HookedGetThemeFont, &GetThemeFont_orig);
 }
 
 VOID ApplyHooks()
 {
     if(g_settings.FillBg)
-        CustomRendering();
+        CustomRenderingHooks();
     if (g_settings.SetSystemColors)
         ColorizeSysColors();
-    if(g_settings.ExtendFrame)
-        DwmExpandFrameIntoClientAreaHook();
-    if (g_settings.TitlebarFlag || g_settings.BorderFlag || g_settings.CaptionTextFlag || g_settings.BgType != g_settings.Default)
+    if (g_settings.BgType != g_settings.Default) {
         DwmSetWindowAttributeHook();
-    if (g_settings.FlyoutsEffects) {
-        // Intercept and subclass system tray popupmenus
-        WindhawkUtils::SetFunctionHook(TrackPopupMenuEx, HookedTrackPopupMenuEx, &TrackPopupMenuEx_orig);
+        DwmExpandFrameIntoClientAreaHook();
+    }        
+}
+
+// Normalizes a path: flips slashes, trims trailing slashes, lowercases.
+std::wstring NormalizeRule(std::wstring path) 
+{
+    if (path.empty()) return path;
+
+    // 1. Normalize slashes
+    for (auto& ch : path)
+        if (ch == L'/') 
+            ch = L'\\';
+
+    // 2. Trim trailing slashes (now guaranteed to be backslashes)
+    while (!path.empty() && path.back() == L'\\')
+        path.pop_back();
+    
+    if (path.empty()) 
+        return path;
+
+    // 3. Lowercase
+    LCMapStringEx(LOCALE_NAME_USER_DEFAULT, LCMAP_LOWERCASE, 
+                  path.c_str(), (int)path.length(), &path[0], (int)path.length(), 
+                  nullptr, nullptr, 0);
+
+    return path;
+}
+
+struct CurrentProcessInfo {
+    std::wstring fullPath;   // (e.g. c:\windows\system32\notepad.exe)
+    std::wstring fileName;   // (e.g. notepad.exe)
+    std::wstring directory;  // (e.g. c:\windows\system32)
+};
+
+CurrentProcessInfo GetCurrentProcessInfo() 
+{
+    WCHAR modulePath[MAX_PATH];
+    GetModuleFileNameW(nullptr, modulePath, MAX_PATH);
+
+    CurrentProcessInfo info;
+    info.fullPath = modulePath;
+
+    // FIX 1: Strip Windows long path prefix if present, otherwise string matches fail
+    if (info.fullPath.find(L"\\\\?\\") == 0) {
+        info.fullPath.erase(0, 4);
     }
+
+    // FIX 2: Process paths can occasionally contain forward slashes depending on launch method.
+    for (auto& ch : info.fullPath) {
+        if (ch == L'/') ch = L'\\';
+    }
+
+    // Lowercase the main string once
+    LCMapStringEx(LOCALE_NAME_USER_DEFAULT, LCMAP_LOWERCASE, 
+                  info.fullPath.c_str(), (int)info.fullPath.length(), 
+                  &info.fullPath[0], (int)info.fullPath.length(), 
+                  nullptr, nullptr, 0);
+
+    // Extract substrings cleanly 
+    size_t pos = info.fullPath.find_last_of(L'\\');
+    if (pos != std::wstring::npos) {
+        info.fileName = info.fullPath.substr(pos + 1);
+        info.directory = info.fullPath.substr(0, pos);
+    } else {
+        info.fileName = info.fullPath;
+        info.directory = L""; 
+    }
+
+    return info;
+}
+
+bool MatchesProcessRule(const std::wstring& rawEntry, const CurrentProcessInfo& proc) 
+{
+    std::wstring entry = NormalizeRule(rawEntry);
+    if (entry.empty()) return false;
+
+    // Exact full path or directory match
+    if (entry == proc.fullPath || entry == proc.directory)
+        return true;
+
+    // Bare name, e.g. "mspaint.exe"
+    if (entry.find(L'\\') == std::wstring::npos) {
+        return entry == proc.fileName;
+    }
+
+    // FIX 3: Subfolder match. Use .find() == 0 for a bulletproof "starts_with" check.
+    std::wstring prefix = entry + L"\\";
+    if (proc.fullPath.find(prefix) == 0)
+        return true;
+
+    return false;
 }
 
 VOID LoadWindowProcessRules()
 {
-    // Process Rules
-    DWORD currProcID = NULL;
-    std::wstring currproc = {};
-    GetCurrProcInfo(currproc, currProcID);
+    CurrentProcessInfo currProc = GetCurrentProcessInfo();
 
     for (INT i = 0;; i++) 
     {
         auto program = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].target", i));
         
-        BOOL hasProgram = *program;
-        if (hasProgram) 
+        if (!*program)
+            break; 
+
+        if (MatchesProcessRule(program.get(), currProc))
         {
-            std::wstring ruledproc = program.get();
-            GetProcStrFromPath(ruledproc);
+            g_settings.FillBg = Wh_GetIntSetting(L"RuledPrograms[%d].RenderingMod.ThemeBackground", i);
             
-            if(currproc == ruledproc)
-            {
-                g_settings.AccentColorize = Wh_GetIntSetting(L"RuledPrograms[%d].RenderingMod.AccentColorControls", i);
-                if (g_settings.AccentColorize)
-                    g_settings.AccentColorize = GetAccentColor(g_settings.AccentColor);
-                
-                g_settings.FillBg = Wh_GetIntSetting(L"RuledPrograms[%d].RenderingMod.ThemeBackground", i);
+            g_settings.AccentColorize = Wh_GetIntSetting(L"RuledPrograms[%d].RenderingMod.AccentColorControls", i);
+            if (g_settings.AccentColorize)
+                g_settings.AccentColorize = GetAccentColor(g_settings.AccentColor);
+            
+            g_settings.SetSystemColors = Wh_GetIntSetting(L"RuledPrograms[%d].RenderingMod.Syscolors", i);
+            // Check if custom system colors have been already applied, 
+            // not need to hook if custom system colors haven't been applied
+            if (!g_settings.SetSystemColors && GetSysColor_orig(COLOR_WINDOW) == RGB(0, 0, 0)) {
+                g_DefaultSysColors = TRUE;
+                WindhawkUtils::SetFunctionHook(GetSysColor, HookedGetSysColor, &GetSysColor_orig);
+                WindhawkUtils::SetFunctionHook(GetSysColorBrush, HookedGetSysColorBrush, &GetSysColorBrush_orig);
+                User32Hooks(g_settings.SetSystemColors);
+                WindhawkUtils::SetFunctionHook(FillRect, HookedFillRect, &FillRect_orig);
+            }          
+            auto strStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].BackgroundEffects.type", i));
+            if (0 == wcscmp(strStyle, L"acrylicblur"))
+                g_settings.BgType = g_settings.AccentBlurBehind;
+            else if (0 == wcscmp(strStyle, L"acrylicsystem"))
+                g_settings.BgType = g_settings.AcrylicSystemBackdrop;
+            else if (0 == wcscmp(strStyle, L"mica"))
+                g_settings.BgType = g_settings.Mica;
+            else if (0 == wcscmp(strStyle, L"mica_tabbed"))
+                g_settings.BgType = g_settings.MicaAlt;
+            else 
+                g_settings.BgType = g_settings.Default;
 
-                // Check if custom system colors have been already applied, 
-                // not need to hook if custom system colors haven't been applied
-                if (!g_settings.FillBg && GetSysColor(COLOR_WINDOW) == RGB(0, 0, 0)) {
-                    g_DefaultSysColors = TRUE;
-                    WindhawkUtils::SetFunctionHook(GetSysColor, HookedGetSysColor, &GetSysColor_orig);
-                    WindhawkUtils::SetFunctionHook(GetSysColorBrush, HookedGetSysColorBrush, &GetSysColorBrush_orig);
-                }
-                
-                auto strStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].type", i));
-                if (0 == wcscmp(strStyle, L"acrylicblur"))
-                    g_settings.BgType = g_settings.AccentBlurBehind;
-                else if (0 == wcscmp(strStyle, L"acrylicsystem"))
-                    g_settings.BgType = g_settings.AcrylicSystemBackdrop;
-                else if (0 == wcscmp(strStyle, L"mica"))
-                    g_settings.BgType = g_settings.Mica;
-                else if (0 == wcscmp(strStyle, L"mica_tabbed"))
-                    g_settings.BgType = g_settings.MicaAlt;
-                else 
-                    g_settings.BgType = g_settings.Default;
-
-                GetColorSetting(WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].AccentBlurBehind", i)), g_settings.AccentBlurBehindClr);
-
-                g_settings.ImmersiveDarkmode = Wh_GetIntSetting(L"RuledPrograms[%d].ImmersiveDarkTitle", i);
-
-                g_settings.ExtendFrame = Wh_GetIntSetting(L"RuledPrograms[%d].ExtendFrame", i);
-
-                auto strCornerType = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].CornerOption", i));
-                if (0 == wcscmp(strCornerType, L"notrounded"))
-                    g_settings.CornerPref = g_settings.NotRounded;
-                else if (0 == wcscmp(strCornerType, L"smallround"))
-                    g_settings.CornerPref = g_settings.SmallRounded;
-                else
-                    g_settings.CornerPref = g_settings.DefaultRound;
-                
-                g_settings.RainbowSpeed = RainbowSpeedInput(Wh_GetIntSetting(L"RuledPrograms[%d].RainbowSpeed", i));
-
-                g_settings.TitlebarFlag = Wh_GetIntSetting(L"RuledPrograms[%d].TitlebarColor.ColorTitlebar", i);
-                g_settings.TitlebarRainbowFlag = Wh_GetIntSetting(L"RuledPrograms[%d].TitlebarColor.RainbowTitlebar", i) && g_settings.TitlebarFlag;
-                if(g_settings.TitlebarFlag)
-                {
-                    auto strTitlebarStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].TitlebarColor.Titlerbarstyles_active", i));
-                    g_settings.TitlebarFlag = GetColorSetting(strTitlebarStyle, g_settings.TitlebarActiveColor);
-                    strTitlebarStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].TitlebarColor.Titlerbarstyles_inactive", i));
-                    g_settings.TitlebarFlag = GetColorSetting(strTitlebarStyle, g_settings.TitlebarInactiveColor) || g_settings.TitlebarFlag;
-
-                    if ((g_settings.TitlebarActiveColor == DWMWA_COLOR_DEFAULT || g_settings.TitlebarActiveColor == DWMWA_COLOR_NONE) ||
-                        (g_settings.TitlebarInactiveColor == DWMWA_COLOR_DEFAULT || g_settings.TitlebarInactiveColor == DWMWA_COLOR_NONE))
-                            g_settings.TitlebarFlag = FALSE;
-                }
-
-                g_settings.CaptionTextFlag = Wh_GetIntSetting(L"RuledPrograms[%d].TitlebarTextColor.ColorTitlebarText", i);
-                g_settings.CaptionRainbowFlag = Wh_GetIntSetting(L"RuledPrograms[%d].TitlebarTextColor.RainbowTextColor", i) && g_settings.CaptionTextFlag;
-                if(g_settings.CaptionTextFlag)
-                {
-                    auto strTitlebarTextColorStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].TitlebarTextColor.titlerbarcolorstyles_active", i));
-                    g_settings.CaptionTextFlag = GetColorSetting(strTitlebarTextColorStyle, g_settings.CaptionActiveTextColor);
-                    strTitlebarTextColorStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].TitlebarTextColor.titlerbarcolorstyles_inactive", i));
-                    g_settings.CaptionTextFlag = GetColorSetting(strTitlebarTextColorStyle, g_settings.CaptionInactiveTextColor) || g_settings.CaptionTextFlag;
-                }
-
-                g_settings.BorderFlag = Wh_GetIntSetting(L"RuledPrograms[%d].BorderColor.ColorBorder", i);
-
-                g_settings.BorderFlag = Wh_GetIntSetting(L"RuledPrograms[%d].BorderColor.ColorBorder", i);
-                g_settings.BorderRainbowFlag = Wh_GetIntSetting(L"RuledPrograms[%d].BorderColor.RainbowBorder", i) && g_settings.BorderFlag;
-                if(g_settings.BorderFlag)
-                {
-                    auto strBorderStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].BorderColor.borderstyles_active", i));
-                    g_settings.BorderFlag = GetColorSetting(strBorderStyle, g_settings.BorderActiveColor);
-                    strBorderStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].BorderColor.borderstyles_inactive", i));
-                    g_settings.BorderFlag = GetColorSetting(strBorderStyle, g_settings.BorderInactiveColor) || g_settings.BorderFlag;
-                }
-            }
-        }
-
-        if (!hasProgram) {
-            break;
+            GetColorSetting(WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].BackgroundEffects.AccentBlurBehind", i)), g_settings.AccentBlurBehindClr);
         }
     }
 }
@@ -6253,10 +6401,14 @@ VOID LoadSettings()
        g_settings.AccentColorize = GetAccentColor(g_settings.AccentColor);
 
     g_settings.FillBg = Wh_GetIntSetting(L"RenderingMod.ThemeBackground");
+    if (g_settings.FillBg)
+        GenerateTextAlphaGammaLUT();
     
     g_settings.SetSystemColors = Wh_GetIntSetting(L"RenderingMod.Syscolors");
+    if (g_settings.SetSystemColors)
+        ColorizeSysColors();
     
-    auto strStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"type"));
+    auto strStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"BackgroundEffects.type"));
     if (0 == wcscmp(strStyle, L"acrylicblur"))
         g_settings.BgType = g_settings.AccentBlurBehind;
     else if (0 == wcscmp(strStyle, L"acrylicsystem"))
@@ -6268,66 +6420,19 @@ VOID LoadSettings()
     else 
         g_settings.BgType = g_settings.Default;
     
-    GetColorSetting(WindhawkUtils::StringSetting(Wh_GetStringSetting(L"AccentBlurBehind")), g_settings.AccentBlurBehindClr);
+    GetColorSetting(WindhawkUtils::StringSetting(Wh_GetStringSetting(L"BackgroundEffects.AccentBlurBehind")), g_settings.AccentBlurBehindClr);
 
     g_settings.FlyoutsEffects = Wh_GetIntSetting(L"FlyoutsEffects");
-
-    g_settings.ImmersiveDarkmode = Wh_GetIntSetting(L"ImmersiveDarkTitle");
-    
-    g_settings.ExtendFrame = Wh_GetIntSetting(L"ExtendFrame");
-    
-    auto strCornerType = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"CornerOption"));
-    if (0 == wcscmp(strCornerType, L"notrounded"))
-        g_settings.CornerPref = g_settings.NotRounded;
-    else if (0 == wcscmp(strCornerType, L"smallround"))
-        g_settings.CornerPref = g_settings.SmallRounded;
-    else
-        g_settings.CornerPref = g_settings.DefaultRound;
-
-    g_settings.RainbowSpeed = RainbowSpeedInput(Wh_GetIntSetting(L"RainbowSpeed"));
-
-    g_settings.TitlebarFlag = Wh_GetIntSetting(L"TitlebarColor.ColorTitlebar");
-    g_settings.TitlebarRainbowFlag = Wh_GetIntSetting(L"TitlebarColor.RainbowTitlebar") && g_settings.TitlebarFlag;
-    if(g_settings.TitlebarFlag)
-    {
-        auto strTitlebarStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"TitlebarColor.titlerbarstyles_active"));
-        g_settings.TitlebarFlag = GetColorSetting(strTitlebarStyle, g_settings.TitlebarActiveColor);
-        strTitlebarStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"TitlebarColor.titlerbarstyles_inactive"));
-        g_settings.TitlebarFlag = GetColorSetting(strTitlebarStyle, g_settings.TitlebarInactiveColor) || g_settings.TitlebarFlag;
-
-        if ((g_settings.TitlebarActiveColor == DWMWA_COLOR_DEFAULT || g_settings.TitlebarActiveColor == DWMWA_COLOR_NONE) ||
-            (g_settings.TitlebarInactiveColor == DWMWA_COLOR_DEFAULT || g_settings.TitlebarInactiveColor == DWMWA_COLOR_NONE))
-                g_settings.TitlebarFlag = FALSE;
-    }
-
-    g_settings.CaptionTextFlag = Wh_GetIntSetting(L"TitlebarTextColor.ColorTitlebarText");
-    g_settings.CaptionRainbowFlag = Wh_GetIntSetting(L"TitlebarTextColor.RainbowTextColor") && g_settings.CaptionTextFlag;
-    if(g_settings.CaptionTextFlag)
-    {
-        auto strTitlebarTextColorStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"TitlebarTextColor.titlerbarcolorstyles_active"));
-        g_settings.CaptionTextFlag = GetColorSetting(strTitlebarTextColorStyle, g_settings.CaptionActiveTextColor);
-        strTitlebarTextColorStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"TitlebarTextColor.titlerbarcolorstyles_inactive"));
-        g_settings.CaptionTextFlag = GetColorSetting(strTitlebarTextColorStyle, g_settings.CaptionInactiveTextColor) || g_settings.CaptionTextFlag;
-    }
-
-    g_settings.BorderFlag = Wh_GetIntSetting(L"BorderColor.ColorBorder");
-    g_settings.BorderRainbowFlag = Wh_GetIntSetting(L"BorderColor.RainbowBorder") && g_settings.BorderFlag;
-    if(g_settings.BorderFlag)
-    {
-        auto strBorderStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"BorderColor.borderstyles_active"));
-        g_settings.BorderFlag = GetColorSetting(strBorderStyle, g_settings.BorderActiveColor);
-        strBorderStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"BorderColor.borderstyles_inactive"));
-        g_settings.BorderFlag = GetColorSetting(strBorderStyle, g_settings.BorderInactiveColor) || g_settings.BorderFlag;
-    }
-
+        
     LoadWindowProcessRules();
     
-    ApplyHooks();   
+    ApplyHooks();
 }
 
 BOOL Wh_ModInit(VOID) 
 {
-    TimerInitialize();
+    if (InExplorerProcess())
+        g_explorerStylerNoBackgroundEffectAtom = AddAtom(L"WindhawkFileExplorerStylerNoBackgroundEffect");
 
     LoadSettings();
 
@@ -6335,14 +6440,11 @@ BOOL Wh_ModInit(VOID)
     if (!hModule) 
         return FALSE;
         
-    NtUserCreateWindowEx_t pNtUserCreateWindowEx =
-        (NtUserCreateWindowEx_t)GetProcAddress(hModule, "NtUserCreateWindowEx");
+    NtUserCreateWindowEx_t pNtUserCreateWindowEx = (NtUserCreateWindowEx_t)GetProcAddress(hModule, "NtUserCreateWindowEx");
     if (!pNtUserCreateWindowEx)
         return FALSE;
     
-    WindhawkUtils::SetFunctionHook(pNtUserCreateWindowEx,
-                       HookedNtUserCreateWindowEx,
-                       &NtUserCreateWindowEx_Original);
+    WindhawkUtils::SetFunctionHook(pNtUserCreateWindowEx, HookedNtUserCreateWindowEx, &NtUserCreateWindowEx_Original);
     
     return TRUE;
 }
@@ -6360,7 +6462,10 @@ VOID Wh_ModAfterInit()
 }
 
 VOID Wh_ModUninit(VOID) 
-{ 
+{
+    if (g_explorerStylerNoBackgroundEffectAtom)
+        DeleteAtom(g_explorerStylerNoBackgroundEffectAtom);
+     
     g_settings.Unload = TRUE;
     if (g_settings.FillBg)
         g_d2dFactory->Release();
@@ -6368,32 +6473,11 @@ VOID Wh_ModUninit(VOID)
     if (g_settings.SetSystemColors)
         RevertSysColors();
 
-    for (HBRUSH& brush : g_themeCachedCustomSysColorBrushes)
+    for (HBRUSH brush : g_themeCachedCustomSysColorBrushes)
         DeleteObject(brush);
-    for (HBRUSH& brush : g_themeCachedDefaultSysColorBrushes)
+    for (HBRUSH brush : g_themeCachedDefaultSysColorBrushes)
         DeleteObject(brush);
 
-    if (!g_rainbowWindows.empty())
-    {
-        std::unordered_set<HWND> RainbowWindows;
-        {
-            std::lock_guard<std::mutex> guard(g_rainbowWindowsMutex);
-
-            RainbowWindows = std::move(g_rainbowWindows);
-            g_rainbowWindows.clear();
-        }
-
-        if (g_settings.BorderRainbowFlag || g_settings.CaptionRainbowFlag || g_settings.TitlebarRainbowFlag)
-        {
-            for (auto hWnd : RainbowWindows)
-                SendMessageW(hWnd, g_msgRainbowTimer, RAINBOW_UNLOAD, 0);
-        }
-
-        RainbowWindows.clear();
-    }
-    
-    RemoveOrUnloadWindowsHooks(TRUE);
-    RemoveOrUnloadFlyoutSubclass(nullptr, TRUE);    
     ApplyForExistingWindows();
 }
 

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -139,8 +139,7 @@ This is caused by default by the AccentBlur API.❕
           - SysColors: FALSE
             $name: 🔷 New system colors
             $description: >-
-             ⚠️Effective if global setting "New System Colors" is disabled.
-              Modifies additional system UI colors by hooking to GetSysColor/GetSysColorBrush API.  
+              Modifies additional system UI colors.
           - AccentColorControls: FALSE
             $name: 🔷 Windows theme accent colorizer
             $description: >-
@@ -171,6 +170,7 @@ This is caused by default by the AccentBlur API.❕
 // ==/WindhawkModSettings==
 
 #include <windhawk_utils.h>
+#include <windowsx.h>
 #include <dwmapi.h>
 #include <vssym32.h>
 #include <uxtheme.h>
@@ -183,8 +183,6 @@ This is caused by default by the AccentBlur API.❕
 
 #define RECTWIDTH(lprc)     ((lprc)->right - (lprc)->left)
 #define RECTHEIGHT(lprc)    ((lprc)->bottom - (lprc)->top)
-
-#define WM_CTLCOLOR 0x19
 
 static UINT ENABLE = 1;
 static constexpr UINT AUTO = 0; // DWMSBT_AUTO

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -93,7 +93,7 @@ This is caused by default by the AccentBlur API.❕
     - SysColors: FALSE
       $name: 🔷 New system colors
       $description: >-
-       Modifies additional system UI colors by calling SetSysColors API.
+       Modifies additional system UI colors by calling SetSysColors API. (Requires Windows theme custom rendering)
         ⚠️For issues with excluded processes, use process rules in mod's settings. For more refer to the FAQ.
     - AccentColorControls: TRUE
       $name: 🔷 Windows theme accent colorizer
@@ -136,10 +136,6 @@ This is caused by default by the AccentBlur API.❕
             $description: >-
               Modifies parts of the Windows theme using the Direct2D graphics API and modifies Windows GDI text rendering by patching the alpha channel and adjusting text colors.
                ✨It is recommended to enable this with background translucent effects.
-          - SysColors: FALSE
-            $name: 🔷 New system colors
-            $description: >-
-              Modifies additional system UI colors.
           - AccentColorControls: FALSE
             $name: 🔷 Windows theme accent colorizer
             $description: >-
@@ -837,7 +833,7 @@ std::wstring GetThemeClass(HTHEME hTheme)
 // Brightens antialiased edge pixels
 // Closely matches DrawTextWithGlow's CGamma table behavior
 // Requires no RGB linearization — operates on alpha only
-static std::array<BYTE, 256> g_textAlphaGammaLUT = {1};
+static std::array<BYTE, 256> g_textAlphaGammaLUT = {0};
 VOID GenerateTextAlphaGammaLUT()
 {
     for (int i = 0; i < 256; ++i) 
@@ -5094,9 +5090,6 @@ static LRESULT WINAPI HookedDefWindowProcW(HWND hWnd, UINT msg, WPARAM wParam, L
 
                 for (HBRUSH brush : g_themeCachedCustomSysColorBrushes)
                     DeleteObject(brush);
-                
-                if (g_settings.SetSystemColors)
-                    ColorizeSysColors();
             }
             
             ReleaseSRWLockExclusive(&g_ThemeChangeLock);
@@ -5205,24 +5198,10 @@ HRESULT STDCALL Hooked_GetBrushesForPart(HTHEME hTheme, int iPartId, COLORREF Co
     std::wstring ThemeClass = GetThemeClass(hTheme);
     
     if (ThemeClass == L"Tab" && (iPartId == TABP_BODY || iPartId == TABP_AEROWIZARDBODY)) {
-        
-        // 1. Respect the early exit to prevent cache corruption and GDI leaks
-        if (phBrush && *phBrush) {
-            return S_OK; 
+        if (!*phBrush || *phBrush != GetSysColorBrush(COLOR_WINDOW)) {
+            *phBrush = GetSysColorBrush(COLOR_WINDOW);
+            return S_OK;
         }
-
-        // 2. Assign a pure black brush.
-        // CreateSolidBrush because the stock object cannot be accidentally destroyed.
-        if (phBrush) {
-            *phBrush = (HBRUSH)GetStockObject(BLACK_BRUSH);
-        }
-        
-        // 3. Prevent uxtheme from reading garbage memory for the pattern bitmap
-        if (phBitmap) {
-            *phBitmap = NULL;
-        }
-        
-        return S_OK;
     }
     
     return _GetBrushesForPart_orig(hTheme, iPartId, Color, phBitmap, phBrush);
@@ -5336,13 +5315,6 @@ VOID RestoreWindowCustomizations(HWND hWnd)
 {
     if(!IsWindowEligible(hWnd))
         return;
-    
-    // Manually restore frame extension
-    if(!(IsWindowClass(hWnd,  L"TaskManagerWindow") && g_settings.BgType != g_settings.Default))
-    {
-        MARGINS margins = { 0, 0, 0, 0 };
-        DwmExtendFrameIntoClientArea(hWnd, &margins);
-    }
 
     ACCENT_POLICY accentPolicy = {};
     WINCOMPATTRDATA winCompositionAttrib = {};
@@ -5350,10 +5322,10 @@ VOID RestoreWindowCustomizations(HWND hWnd)
 
     // Disabling AccentBlurBehind temp workaround
     dwmBlurBehindData.fEnable = FALSE;
-    dwmBlurBehindData.hRgnBlur = NULL;
+    dwmBlurBehindData.dwFlags = DWM_BB_ENABLE;
     DwmEnableBlurBehindWindow(hWnd, &dwmBlurBehindData);
 
-    accentPolicy.AccentState = 0;
+    accentPolicy.AccentState = ACCENT_STATE_DISABLED;
 
     winCompositionAttrib.Attrib = WCA_ACCENT_POLICY;
     winCompositionAttrib.pvData = &accentPolicy;
@@ -5361,7 +5333,15 @@ VOID RestoreWindowCustomizations(HWND hWnd)
 
     SetWindowCompositionAttribute(hWnd, &winCompositionAttrib);
     
-    DwmSetWindowAttribute(hWnd, DWMWA_SYSTEMBACKDROP_TYPE , &AUTO, sizeof(UINT));
+    DWM_SYSTEMBACKDROP_TYPE backdrop = DWMSBT_NONE;
+    DwmSetWindowAttribute(hWnd, DWMWA_SYSTEMBACKDROP_TYPE , &backdrop, sizeof(UINT));
+
+    // Manually restore frame extension
+    if(!(IsWindowClass(hWnd,  L"TaskManagerWindow") && g_settings.BgType != g_settings.Default))
+    {
+        MARGINS margins = { 0, 0, 0, 0 };
+        DwmExtendFrameIntoClientArea(hWnd, &margins);
+    }
 }
 
 BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam) 
@@ -5672,7 +5652,6 @@ void __fastcall HookedRenderTooltip(HWND hWnd, HDC hdc, HGDIOBJ *a3)
 
 VOID User32Hooks(BOOL areSysColorsApplied)
 {
-    //WindhawkUtils::SetFunctionHook(SetClassLongPtrW, HookedSetClassLongPtrW, &SetClassLongPtrW_orig);
     WindhawkUtils::SYMBOL_HOOK user32_dll_hooks[] =
     {  
         {
@@ -6261,8 +6240,6 @@ VOID ApplyHooks()
 {
     if(g_settings.FillBg)
         CustomRenderingHooks();
-    if (g_settings.SetSystemColors)
-        ColorizeSysColors();
     if (g_settings.BgType != g_settings.Default) {
         DwmSetWindowAttributeHook();
         DwmExpandFrameIntoClientAreaHook();
@@ -6374,23 +6351,28 @@ VOID LoadWindowProcessRules()
         {
             g_settings.FillBg = Wh_GetIntSetting(L"RuledPrograms[%d].RenderingMod.ThemeBackground", i);
             
+            BOOL globalSetting_CustomTheme = Wh_GetIntSetting(L"RenderingMod.ThemeBackground");
+            if (!globalSetting_CustomTheme)
+                GenerateTextAlphaGammaLUT();
+            
             g_settings.AccentColorize = Wh_GetIntSetting(L"RuledPrograms[%d].RenderingMod.AccentColorControls", i);
             if (g_settings.AccentColorize)
                 g_settings.AccentColorize = GetAccentColor(g_settings.AccentColor);
             
-            g_settings.SetSystemColors = Wh_GetIntSetting(L"RuledPrograms[%d].RenderingMod.Syscolors", i);
+            BOOL globalSetting_SetSysColorAPI = Wh_GetIntSetting(L"RenderingMod.Syscolors");
 
-            BOOL globalSetting_SetSystemColors = Wh_GetIntSetting(L"RenderingMod.Syscolors");
-
-            // Reset system colors to default values if the system color setting is disabled for the specific ruled process,
-            // Hook all necessary API to restore system colors
-            if (!g_settings.SetSystemColors && globalSetting_SetSystemColors) {
+            // Reset system colors to default values if the system color setting is disabled for the specific ruled process
+            if (!g_settings.FillBg && globalSetting_SetSysColorAPI)
                 g_DefaultSysColors = TRUE;
+            
+            // Hook all necessary APIs to restore system colors when SetSysColors API hasn't been executed by the mod
+            if (g_DefaultSysColors) {
                 WindhawkUtils::SetFunctionHook(GetSysColor, HookedGetSysColor, &GetSysColor_orig);
-                WindhawkUtils::SetFunctionHook(GetSysColorBrush, HookedGetSysColorBrush, &GetSysColorBrush_orig);
-                User32Hooks(g_settings.SetSystemColors);
+                WindhawkUtils::SetFunctionHook(GetSysColorBrush, HookedGetSysColorBrush, &GetSysColorBrush_orig);               
                 WindhawkUtils::SetFunctionHook(FillRect, HookedFillRect, &FillRect_orig);
-            }          
+                User32Hooks(g_settings.SetSystemColors);
+            }   
+
             auto strStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].BackgroundEffects.type", i));
             if (0 == wcscmp(strStyle, L"acrylicblur"))
                 g_settings.BgType = g_settings.AccentBlurBehind;
@@ -6419,7 +6401,8 @@ VOID LoadSettings()
         GenerateTextAlphaGammaLUT();
     
     g_settings.SetSystemColors = Wh_GetIntSetting(L"RenderingMod.Syscolors");
-    if (g_settings.SetSystemColors)
+    // SetSysColors API available only in theme customization
+    if (g_settings.SetSystemColors && g_settings.FillBg)
         ColorizeSysColors();
     
     auto strStyle = WindhawkUtils::StringSetting(Wh_GetStringSetting(L"BackgroundEffects.type"));
@@ -6499,7 +6482,6 @@ VOID Wh_ModUninit(VOID)
 
 BOOL Wh_ModSettingsChanged(BOOL* bReload) 
 {
-    Wh_Log(L"SettingsChanged");
     *bReload = TRUE;
     return TRUE;
 }

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -5198,14 +5198,31 @@ LRESULT STDCALL HookedCThemeMenu_MenuKeyboardMsgProc_orig(INT code, WPARAM wPara
 }
 
 HRESULT (STDCALL *_GetBrushesForPart_orig)(HTHEME hTheme, int iPartId, COLORREF Color, HBITMAP *phBitmap, HBRUSH *phBrush);
-HRESULT STDCALL Hooked_GetBrushesForPart(HTHEME hTheme, int iPartId, COLORREF Color, HBITMAP *phBitmap, HBRUSH * phBrush)
+HRESULT STDCALL Hooked_GetBrushesForPart(HTHEME hTheme, int iPartId, COLORREF Color, HBITMAP *phBitmap, HBRUSH *phBrush)
 {
     std::wstring ThemeClass = GetThemeClass(hTheme);
     
     if (ThemeClass == L"Tab" && (iPartId == TABP_BODY || iPartId == TABP_AEROWIZARDBODY)) {
-        *phBrush = GetSysColorBrush(COLOR_WINDOW);
+        
+        // 1. Respect the early exit to prevent cache corruption and GDI leaks
+        if (phBrush && *phBrush) {
+            return S_OK; 
+        }
+
+        // 2. Assign a pure black brush.
+        // CreateSolidBrush because the stock object cannot be accidentally destroyed.
+        if (phBrush) {
+            *phBrush = (HBRUSH)GetStockObject(BLACK_BRUSH);
+        }
+        
+        // 3. Prevent uxtheme from reading garbage memory for the pattern bitmap
+        if (phBitmap) {
+            *phBitmap = NULL;
+        }
+        
         return S_OK;
     }
+    
     return _GetBrushesForPart_orig(hTheme, iPartId, Color, phBitmap, phBrush);
 }
 

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -6358,11 +6358,11 @@ VOID LoadWindowProcessRules()
             
             g_settings.SetSystemColors = Wh_GetIntSetting(L"RuledPrograms[%d].RenderingMod.Syscolors", i);
 
-            BOOL globalSetting_SetSystenColors = Wh_GetIntSetting(L"RenderingMod.Syscolors");
+            BOOL globalSetting_SetSystemColors = Wh_GetIntSetting(L"RenderingMod.Syscolors");
 
             // Reset system colors to default values if the system color setting is disabled for the specific ruled process,
             // Hook all necessary API to restore system colors
-            if (!g_settings.SetSystemColors && globalSetting_SetSystenColors) {
+            if (!g_settings.SetSystemColors && globalSetting_SetSystemColors) {
                 g_DefaultSysColors = TRUE;
                 WindhawkUtils::SetFunctionHook(GetSysColor, HookedGetSysColor, &GetSysColor_orig);
                 WindhawkUtils::SetFunctionHook(GetSysColorBrush, HookedGetSysColorBrush, &GetSysColorBrush_orig);

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -6360,8 +6360,8 @@ VOID LoadWindowProcessRules()
 
             BOOL globalSetting_SetSystenColors = Wh_GetIntSetting(L"RenderingMod.Syscolors");
 
-            // Reset system colors to default values ​​if the system color setting is disabled for the specific ruled process.
-            // Hook all necessary API to restore system colors.
+            // Reset system colors to default values if the system color setting is disabled for the specific ruled process,
+            // Hook all necessary API to restore system colors
             if (!g_settings.SetSystemColors && globalSetting_SetSystenColors) {
                 g_DefaultSysColors = TRUE;
                 WindhawkUtils::SetFunctionHook(GetSysColor, HookedGetSysColor, &GetSysColor_orig);

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -215,9 +215,6 @@ typedef BOOL(WINAPI* pShouldSystemUseDarkMode)();
 static auto ShouldSystemUseDarkMode = (pShouldSystemUseDarkMode)GetProcAddress(GetModuleHandle(L"uxtheme.dll"), MAKEINTRESOURCEA(138));
 BOOL g_IsSysThemeDarkMode = ShouldSystemUseDarkMode();
 
-// Global theme handle used for SysColors OpenThemeData usage
-HTHEME g_hThemeSysMetrics = nullptr;
-
 // Treeview window handle used in our CNscTree_DrawDivider() hook to draw our alpha blended navigation pane divider
 thread_local HWND tl_hwndTreeView = nullptr;
 
@@ -1147,34 +1144,29 @@ constexpr INT SysColorElements[] = {
     COLOR_HOTLIGHT
 };
 
-BOOL SetCurrentTheme(LPCWSTR themeclass)
-{
-    if (g_hThemeSysMetrics != nullptr)
-        g_hThemeSysMetrics = nullptr;
-
-    g_hThemeSysMetrics = OpenThemeData(NULL, themeclass);
-    if (!g_hThemeSysMetrics)
-        CloseThemeData(g_hThemeSysMetrics);
-    return (g_hThemeSysMetrics) ? TRUE : FALSE;
-}
-
 void ClearSysColorsRegKey() {
     RegDeleteTreeW(HKEY_CURRENT_USER, L"Control Panel\\Colors");
 }
 
+HTHEME SetThemeHandle(HWND hWnd, HTHEME& hTheme, LPCWSTR themeclass)
+{
+    return hTheme = OpenThemeData(hWnd, themeclass);
+}
+
 VOID RevertSysColors()
 {
-    if (!SetCurrentTheme(L"sysmetrics"))
+    HTHEME hThemeSysMetrics = nullptr;
+    if (!SetThemeHandle(nullptr, hThemeSysMetrics, L"sysmetrics"))
         return;
     
     COLORREF aNewColors[ARRAYSIZE(SysColorElements)];
 
     for (UINT i = 0; i < ARRAYSIZE(SysColorElements); i++) 
-        aNewColors[i] = GetThemeSysColor(g_hThemeSysMetrics, i); 
+        aNewColors[i] = GetThemeSysColor(hThemeSysMetrics, i); 
     SetSysColors(ARRAYSIZE(SysColorElements), SysColorElements, aNewColors); 
 
-    CloseThemeData(g_hThemeSysMetrics);
-    g_hThemeSysMetrics = nullptr;
+    CloseThemeData(hThemeSysMetrics);
+    hThemeSysMetrics = nullptr;
 
     //ClearSysColorsRegKey();
 }
@@ -1830,6 +1822,9 @@ CThemeCache g_themeCache;
 
 VOID DrawNineGridStretch(HDC hdc, HDC& srcDC, LPCRECT dstRect, INT left = 0, INT top = 0, INT right = 0, INT bottom = 0)
 {
+    if (!hdc || !srcDC)
+        return;
+    
     HBITMAP hBmp = (HBITMAP)GetCurrentObject(srcDC, OBJ_BITMAP);
     BITMAP bmp = {};
     GetObject(hBmp, sizeof(bmp), &bmp);
@@ -2542,11 +2537,11 @@ BOOL CThemeCache::CacheCommandlinkGlyph(INT iStateId, INT stateIndex)
 
 BOOL SanitizeAddressCombobox(HTHEME hTheme, HDC hdc, INT iPartId, INT iStateId)
 {
-    HTHEME MyhTheme = nullptr;
-    if ((MyhTheme = OpenThemeData(WindowFromDC(hdc), L"AddressComposited::ComboBox")) 
+    HTHEME hThemeAddressCB = nullptr;
+    if (SetThemeHandle(WindowFromDC(hdc), hThemeAddressCB, L"AddressComposited::ComboBox")
     && (iPartId == CP_BORDER || iPartId == CP_TRANSPARENTBACKGROUND))
     {
-        CloseThemeData(MyhTheme);
+        CloseThemeData(hThemeAddressCB);
         return TRUE;
     }
     return FALSE;
@@ -2632,13 +2627,12 @@ BOOL CThemeCache::CacheCombobox(INT iPartId, INT iStateId, INT stateIndex)
 
 BOOL IsAddressInnerBackground(HTHEME hTheme, HDC hdc, INT iPartId)
 {
-    HTHEME theme = NULL;
-    if ((theme = OpenThemeData(WindowFromDC(hdc), L"AddressComposited::Edit")) && iPartId == EP_BACKGROUNDWITHBORDER)
+    HTHEME hThemeAddress = NULL;
+    if (SetThemeHandle(WindowFromDC(hdc), hThemeAddress, L"AddressComposited::Edit") && iPartId == EP_BACKGROUNDWITHBORDER)
     {
-        CloseThemeData(theme);
+        CloseThemeData(hThemeAddress);
         return TRUE;
     }
-    CloseThemeData(theme);
     return FALSE;
 }
 
@@ -4666,15 +4660,17 @@ HRESULT WINAPI HookedDrawThemeBackground(
             return S_OK;
         else if (iPartId == BP_GROUPBOX)
         {
-            HTHEME hGroupBoxTheme;
-            if (hTheme == (hGroupBoxTheme = OpenThemeData(WindowFromDC(hdc), L"Button")))
+            HTHEME hThemeGroupBox = nullptr;
+            if (hTheme == SetThemeHandle(WindowFromDC(hdc), hThemeGroupBox, L"Button"))
             {
                 if (PaintGroupBox(hdc, iPartId, iStateId, pRect, pClipRect)) {
-                    CloseThemeData(hGroupBoxTheme);
+                    CloseThemeData(hThemeGroupBox);
                     return S_OK;
                 }
             }
-            CloseThemeData(hGroupBoxTheme);
+            
+            if (hThemeGroupBox)
+                CloseThemeData(hThemeGroupBox);
         }
     }
     else if (ThemeClassName == L"Tab")
@@ -4722,22 +4718,23 @@ HRESULT WINAPI HookedDrawThemeBackground(
         // The exported GetThemeClass function does not provide
         // full string of theme class names of derived theme classes
         // Use the OpenThemeData API instead.
-        HTHEME theme = NULL;
-        if (hTheme == (theme = OpenThemeData(WindowFromDC(hdc), L"Indeterminate::Progress")))
+        HTHEME hThemeProgress = NULL;
+        if (hTheme == SetThemeHandle(WindowFromDC(hdc), hThemeProgress, L"Indeterminate::Progress"))
         {
             if (PaintIndeterminateProgressBar(hdc, iPartId, iStateId, pRect))
             {
-                CloseThemeData(theme);
+                CloseThemeData(hThemeProgress);
                 return S_OK;
             }
-            CloseThemeData(theme);
+            CloseThemeData(hThemeProgress);
         }
         else if (PaintProgressBar(hdc, iPartId, iStateId, pRect)) 
         {
-            CloseThemeData(theme);
+            CloseThemeData(hThemeProgress);
             return S_OK;
         }
-        CloseThemeData(theme);
+        if (hThemeProgress)
+            CloseThemeData(hThemeProgress);
     } 
     else if (ThemeClassName == L"ListView")
     {
@@ -4763,14 +4760,13 @@ HRESULT WINAPI HookedDrawThemeBackground(
     }
     else if (ThemeClassName == L"Toolbar")
     {
-        HTHEME theme = NULL;
-        if ((theme = OpenThemeData(WindowFromDC(hdc), L"BB::Toolbar")))
+        HTHEME hThemeToolbar = NULL;
+        if (SetThemeHandle(WindowFromDC(hdc), hThemeToolbar, L"BB::Toolbar"))
         {
             if (PaintToolbarSplitDropDown(hdc, iPartId, iStateId, pRect)) {
-                CloseThemeData(theme);
+                CloseThemeData(hThemeToolbar);
                 return S_OK;
             }
-            CloseThemeData(theme);
         }
         if (PaintToolbarButton(hdc, iPartId, iStateId, pRect))
             return S_OK;
@@ -4786,14 +4782,12 @@ HRESULT WINAPI HookedDrawThemeBackground(
             return S_OK;
         // Force menu white glyphs
         else if (iPartId <= MENU_SYSTEMRESTORE && iPartId >= MENU_SYSTEMCLOSE && g_IsSysThemeDarkMode) {
-            HTHEME theme = NULL;
-            HRESULT hr = S_OK;
-            if ((theme = OpenThemeData(WindowFromDC(hdc), L"DarkMode::Menu"))) {
-                hr = DrawThemeBackground_orig(theme, hdc, iPartId, iStateId, pRect, pClipRect);
-                CloseThemeData(theme);
+            HTHEME hThemeMenu = NULL;
+            if (SetThemeHandle(WindowFromDC(hdc), hThemeMenu, L"DarkMode::Menu")) {
+                auto hr = DrawThemeBackground_orig(hThemeMenu, hdc, iPartId, iStateId, pRect, pClipRect);
+                CloseThemeData(hThemeMenu);
                 return hr;
             }
-            CloseThemeData(theme);
         }
     }
     else if (ThemeClassName == L"DragDrop")
@@ -4843,13 +4837,12 @@ HRESULT WINAPI HookedDrawThemeBackground(
         return S_OK;
     }
     else if (ThemeClassName == L"Toolbar" && iPartId == THEMECLS_COMMONPROPS_PART) {
-        HTHEME Toolbar;
-        if ((Toolbar = OpenThemeData(WindowFromDC(hdc), L"Placesbar::Toolbar"))) {
+        HTHEME hThemeToolbar = nullptr;
+        if ((SetThemeHandle(WindowFromDC(hdc), hThemeToolbar, L"Placesbar::Toolbar"))) {
             FillRect(hdc, pRect, (HBRUSH)GetStockObject(BLACK_BRUSH));
-            CloseThemeData(Toolbar);
+            CloseThemeData(hThemeToolbar);
             return S_OK;
         }
-        CloseThemeData(Toolbar);
     }
     return hr;
 }
@@ -4904,22 +4897,23 @@ HRESULT WINAPI HookedDrawThemeBackgroundEx(
     }
     else if (ThemeClassName == L"Progress")
     {
-        HTHEME theme = NULL;
-        if (hTheme == (theme = OpenThemeData(WindowFromDC(hdc), L"Indeterminate::Progress")))
+        HTHEME hThemeProgress = NULL;
+        if (hTheme == SetThemeHandle(WindowFromDC(hdc), hThemeProgress, L"Indeterminate::Progress"))
         {
             if (PaintIndeterminateProgressBar(hdc, iPartId, iStateId, pRect))
             {
-                CloseThemeData(theme);
+                CloseThemeData(hThemeProgress);
                 return S_OK;
             }
-            CloseThemeData(theme);
         }
         else if (PaintProgressBar(hdc, iPartId, iStateId, pRect)) 
         {
-            CloseThemeData(theme);
+            CloseThemeData(hThemeProgress);
             return S_OK;
         }
-        CloseThemeData(theme);
+
+        if (hThemeProgress)
+            CloseThemeData(hThemeProgress);
     } 
     else if (ThemeClassName == L"CommandModule")
     {
@@ -5945,20 +5939,19 @@ void __thiscall Hooked_CNscTree_DrawDivider(CNscTree *__this, HDC hdc, struct _T
         hwndTreeView = GetTreeViewHWND();
     
     if (!IsWindow(hwndTreeView) || !IsWindowClass(hwndTreeView, L"SysTreeView32"))
-        Fallback(L"Not valid TreeView window");
+        return Fallback(L"Not valid TreeView window");
     
     RECT treeItemRect = {0};
     *reinterpret_cast<HTREEITEM*>(&treeItemRect) = (HTREEITEM)hTreeItem;
     
     if (!SendMessageW(hwndTreeView, TVM_GETITEMRECT, 0, (LPARAM)&treeItemRect))
-        Fallback();
+        return Fallback();
     
     if (!g_d2dFactory)
-        Fallback();
+        return Fallback();
 
-    if (!g_themeCache.navigationdivider[0])
-        if (!g_themeCache.CacheNavigationDivider())
-            Fallback();
+    if (!g_themeCache.navigationdivider[0] && !g_themeCache.CacheNavigationDivider())
+        return Fallback();
     
     RECT lineRc = treeItemRect;
     INT middlePoint = RECTHEIGHT(&treeItemRect) / 4.f;
@@ -6370,8 +6363,8 @@ VOID LoadWindowProcessRules()
 
             BOOL globalSetting_SetSystemColors = Wh_GetIntSetting(L"RenderingMod.Syscolors");
 
-            // Reset system colors to default values ​​if the system color setting is disabled for the specific ruled process.
-            // Hook all necessary API to restore system colors.
+            // Reset system colors to default values if the system color setting is disabled for the specific ruled process,
+            // Hook all necessary API to restore system colors
             if (!g_settings.SetSystemColors && globalSetting_SetSystemColors) {
                 g_DefaultSysColors = TRUE;
                 WindhawkUtils::SetFunctionHook(GetSysColor, HookedGetSysColor, &GetSysColor_orig);

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -199,7 +199,6 @@ UINT GetDpiFromMonitor()
     return USER_DEFAULT_SCREEN_DPI;
 }
 UINT g_Dpi = GetDpiFromMonitor();
-SRWLOCK g_DpiChangeLock = SRWLOCK_INIT;
 
 typedef HRESULT(WINAPI* pDrawTextWithGlow)(HDC hdcMem, LPWSTR pszText, UINT cch, RECT* pRect, DWORD dwFlags, COLORREF crText,
                                           COLORREF crGlow, UINT nGlowRadius, UINT nGlowIntensity, BOOL fPreMultiply,
@@ -836,7 +835,7 @@ std::wstring GetThemeClass(HTHEME hTheme)
 static std::array<BYTE, 256> g_textAlphaGammaLUT = {0};
 VOID GenerateTextAlphaGammaLUT()
 {
-    for (int i = 0; i < 256; ++i) 
+    for (INT i = 0; i < 256; ++i) 
     {
         float a = i * (1.0f / 255.0f);
         float g = powf(a, 1.0f / 1.4f);
@@ -870,7 +869,7 @@ BOOL WINAPI HookedExtTextOutW(
     // Boundary calculations
     if (lprect)
         textRect = *lprect;
-    else if (options == ETO_GLYPH_INDEX)
+    else if (options & ETO_GLYPH_INDEX)
     {
         if (GetTextExtentPointI(hdc, (WORD*)lpString, c, &textSize))
         {
@@ -919,7 +918,7 @@ BOOL WINAPI HookedExtTextOutW(
     }
 
     RGBQUAD* pPixels = nullptr;
-    int rowWidth = 0; // stride in RGBQUADs, not bytes
+    INT rowWidth = 0; // stride in RGBQUADs, not bytes
     if (FAILED(GetBufferedPaintBits(hpb, &pPixels, &rowWidth))) {
         EndBufferedPaint(hpb, FALSE); // was missing on this path - leaked hpb
         Wh_Log(L"Failed GetBufferedPaintBits error:0x%08x", GetLastError());
@@ -999,7 +998,7 @@ HRESULT WINAPI HookedDrawTextWithGlow(HDC hdcMem, LPWSTR pszText, UINT cch, RECT
     return hr;
 }
 
-INT WINAPI HookedDrawTextW(HDC hdc, LPCWSTR lpchText, int cchText, LPRECT lprc, UINT format)
+INT WINAPI HookedDrawTextW(HDC hdc, LPCWSTR lpchText, INT cchText, LPRECT lprc, UINT format)
 {   
     // Windows 11 context menus use Fluent icons as glyphs
     // Handled internally in the shell32 routine s_DrawGlyph()
@@ -2460,7 +2459,7 @@ BOOL CThemeCache::CacheCommandlinkButton(INT iStateId, INT stateIndex)
     }
     auto hr = pRenderTarget->EndDraw();
     if (FAILED(hr)) {Wh_Log(L"Failed D2D drawing [ERROR]: 0x%08X\n", hr); return FALSE;}
-    return FALSE;
+    return TRUE;
 }
 
 BOOL PaintCommandLinkGlyph(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
@@ -2717,7 +2716,7 @@ BOOL PaintListBox(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     if (!g_d2dFactory)
         return FALSE;
 
-    ID2D1DCRenderTarget* pRenderTarget = nullptr;
+    Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
     if (FAILED(CreateBoundD2DRenderTarget(hdc, pRect, g_d2dFactory, &pRenderTarget)))
         return FALSE;
 
@@ -2765,7 +2764,7 @@ BOOL PaintDropDownArrow(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect, BOOL 
         && iPartId != CP_DROPDOWNBUTTONLEFT))
         return FALSE;
 
-    ID2D1DCRenderTarget* pRenderTarget = nullptr;
+    Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
     if (FAILED(CreateBoundD2DRenderTarget(hdc, pRect, g_d2dFactory, &pRenderTarget)))
         return FALSE;
 
@@ -4290,7 +4289,7 @@ BOOL PaintToolbarSplitDropDown(HDC hdc, INT iPartId,  INT iStateId, LPCRECT pRec
     FLOAT cornerRadius = 4.f * scale;
     INT width = RECTWIDTH(pRect), height = RECTHEIGHT(pRect);
 
-    ID2D1DCRenderTarget* pRenderTarget = nullptr;
+    Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
     if (FAILED(CreateBoundD2DRenderTarget(hdc, pRect, g_d2dFactory, &pRenderTarget)))
         return FALSE;
 
@@ -4495,7 +4494,7 @@ BOOL CThemeCache::CacheDragDrop()
 
     auto hr = pRenderTarget->EndDraw();
     if (FAILED(hr)) {Wh_Log(L"Failed D2D drawing [ERROR]: 0x%08X\n", hr); return FALSE;}
-    return FALSE;
+    return TRUE;
 }
 
 BOOL PaintSpinArrowGlyph(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
@@ -4945,7 +4944,8 @@ HRESULT WINAPI HookedDrawThemeBackgroundEx(
     return hr;
 }
 
-HRESULT WINAPI HookedDrawThemeEdge(HTHEME hTheme, HDC hdc, int iPartId, int iStateId, const RECT *pDestRect, UINT uEdge, UINT uFlags, RECT *pContentRect)
+// Remove white rect below menubar (e.g. seen in mmc.exe)
+HRESULT WINAPI HookedDrawThemeEdge(HTHEME hTheme, HDC hdc, INT iPartId, INT iStateId, const RECT *pDestRect, UINT uEdge, UINT uFlags, RECT *pContentRect)
 {
     std::wstring ThemeClass = GetThemeClass(hTheme);
 
@@ -5088,8 +5088,13 @@ static LRESULT WINAPI HookedDefWindowProcW(HWND hWnd, UINT msg, WPARAM wParam, L
                 if (g_settings.AccentColorize)
                     g_settings.AccentColorize = GetAccentColor(g_settings.AccentColor);
 
-                for (HBRUSH brush : g_themeCachedCustomSysColorBrushes)
-                    DeleteObject(brush);
+                AcquireSRWLockExclusive(&g_SysColorsLock);
+                for (HBRUSH& brush : g_themeCachedCustomSysColorBrushes) {
+                    if (brush) { 
+                        DeleteObject(brush); brush = nullptr; 
+                    }
+                }
+                ReleaseSRWLockExclusive(&g_SysColorsLock);
             }
             
             ReleaseSRWLockExclusive(&g_ThemeChangeLock);
@@ -5172,7 +5177,7 @@ HRESULT WINAPI HookedGetThemeTransitionDuration(HTHEME hTheme, INT iPartId, INT 
 #define SSTDCALL L"__stdcall"
 #endif
 
-LRESULT (STDCALL *CThemeMenu_MenuKeyboardMsgProc_orig)(INT code, WPARAM wParam, LPARAM lParam);
+LRESULT (STDCALL *CThemeMenu_MenuKeyboardMsgProc_orig)(INT, WPARAM, LPARAM);
 LRESULT STDCALL HookedCThemeMenu_MenuKeyboardMsgProc_orig(INT code, WPARAM wParam, LPARAM lParam)
 {
     auto res = CThemeMenu_MenuKeyboardMsgProc_orig(code, wParam, lParam);
@@ -5192,8 +5197,8 @@ LRESULT STDCALL HookedCThemeMenu_MenuKeyboardMsgProc_orig(INT code, WPARAM wPara
     return res;
 }
 
-HRESULT (STDCALL *_GetBrushesForPart_orig)(HTHEME hTheme, int iPartId, COLORREF Color, HBITMAP *phBitmap, HBRUSH *phBrush);
-HRESULT STDCALL Hooked_GetBrushesForPart(HTHEME hTheme, int iPartId, COLORREF Color, HBITMAP *phBitmap, HBRUSH *phBrush)
+HRESULT (__fastcall *_GetBrushesForPart_orig)(HTHEME, INT, COLORREF, HBITMAP*, HBRUSH*);
+HRESULT __fastcall Hooked_GetBrushesForPart(HTHEME hTheme, INT iPartId, COLORREF Color, HBITMAP *phBitmap, HBRUSH *phBrush)
 {
     std::wstring ThemeClass = GetThemeClass(hTheme);
     
@@ -5257,7 +5262,7 @@ void __fastcall Hooked_BorderRect(HDC hdc, COLORREF color, LPRECT pRect, INT cxT
 VOID UxThemeHooks(BOOL isFlyoutEffectEnabled)
 {
     WindhawkUtils::SYMBOL_HOOK uxtheme_dll_hooks[] =
-    {        
+    {    
         {
             {
                 #ifdef _WIN64
@@ -5331,7 +5336,8 @@ VOID RestoreWindowCustomizations(HWND hWnd)
     winCompositionAttrib.pvData = &accentPolicy;
     winCompositionAttrib.cbData = sizeof(accentPolicy);
 
-    SetWindowCompositionAttribute(hWnd, &winCompositionAttrib);
+    if (SetWindowCompositionAttribute)
+        SetWindowCompositionAttribute(hWnd, &winCompositionAttrib);
     
     DWM_SYSTEMBACKDROP_TYPE backdrop = DWMSBT_NONE;
     DwmSetWindowAttribute(hWnd, DWMWA_SYSTEMBACKDROP_TYPE , &backdrop, sizeof(UINT));
@@ -5653,7 +5659,7 @@ void __fastcall HookedRenderTooltip(HWND hWnd, HDC hdc, HGDIOBJ *a3)
 VOID User32Hooks(BOOL areSysColorsApplied)
 {
     WindhawkUtils::SYMBOL_HOOK user32_dll_hooks[] =
-    {  
+    {
         {
             {
                 #ifdef _WIN64
@@ -5719,8 +5725,8 @@ VOID User32Hooks(BOOL areSysColorsApplied)
     }
 }
 
-void (__fastcall *SHThemeDrawText_orig)(void*, HDC, int, int, DTTOPTS*, LPCWSTR, LPRECT, int, UINT, int, __int64, COLORREF, COLORREF a13);
-void __fastcall Hooked_SHThemeDrawText(void *a1, HDC a2, int a3, int a4, DTTOPTS *a5, LPCWSTR lpString, LPRECT lprc, int a8, UINT format, int a10, __int64 a11, COLORREF color, COLORREF a13)
+void (__fastcall *SHThemeDrawText_orig)(void*, HDC, INT, INT, DTTOPTS*, LPCWSTR, LPRECT, INT, UINT, INT, __int64, COLORREF, COLORREF);
+void __fastcall Hooked_SHThemeDrawText(void *a1, HDC a2, INT a3, INT a4, DTTOPTS *a5, LPCWSTR lpString, LPRECT lprc, INT a8, UINT format, INT a10, __int64 a11, COLORREF color, COLORREF a13)
 {
     if (!g_InsideTaskMgrProc)
         color = g_IsSysThemeDarkMode && (color & 0x00ffffff) <= RGB(96, 96, 96) ? RGB(255, 255, 255) : !g_IsSysThemeDarkMode ? RGB(0, 0, 0) : color;
@@ -5731,8 +5737,8 @@ void __fastcall Hooked_SHThemeDrawText(void *a1, HDC a2, int a3, int a4, DTTOPTS
 }
 
 // Alpha blend highlighted text rectangle
-void (__fastcall *SHThemeFillTextRect_orig)(HDC hDC, RECT *lprc, COLORREF color, INT sysColorCode);
-void __fastcall HookedSHThemeFillTextRect(HDC hDC, RECT *lprc, COLORREF color, INT sysColorCode)
+void (__fastcall *SHThemeFillTextRect_orig)(HDC, LPRECT, COLORREF, INT);
+void __fastcall HookedSHThemeFillTextRect(HDC hDC, LPRECT lprc, COLORREF color, INT sysColorCode)
 {
     if (color != GetSysColor(COLOR_HIGHLIGHT))
         return SHThemeFillTextRect_orig(hDC, lprc, color, sysColorCode);
@@ -5754,8 +5760,8 @@ void __fastcall HookedSHThemeFillTextRect(HDC hDC, RECT *lprc, COLORREF color, I
 }
 
 // Alpha blend highlighted text rectangle
-COLORREF (__fastcall *FillRectClr_orig)(HDC hdc, RECT *lprect, COLORREF color);
-COLORREF __fastcall HookedFillRectClr(HDC hdc, RECT *lprect, COLORREF color)
+COLORREF (__fastcall *FillRectClr_orig)(HDC, LPRECT, COLORREF);
+COLORREF __fastcall HookedFillRectClr(HDC hdc, LPRECT lprect, COLORREF color)
 {
     if (color != GetSysColor(COLOR_HIGHLIGHT))
         return FillRectClr_orig(hdc, lprect, color);
@@ -6045,8 +6051,8 @@ void RecolorBrandingLogoBackground(HBITMAP hbm)
 
 // Intercept the windows branding logo image (e.g winver, shutdown dialog, regedit etc.)
 // Winver loads the bitmap using LoadAboutBitmaps() routine, shutdown dialog using LoadBrandingBitmap().
-HANDLE (__fastcall *BrandingLoadImage_orig)(LPCWSTR pszBrand, UINT uID, UINT type, int cx, int cy, UINT  fuLoad);
-HANDLE __fastcall HookedBrandingLoadImage(LPCWSTR pszBrand, UINT uID, UINT type, int cx, int cy, UINT  fuLoad)
+HANDLE (STDCALL *BrandingLoadImage_orig)(LPCWSTR, UINT, UINT, INT, INT, UINT);
+HANDLE STDCALL HookedBrandingLoadImage(LPCWSTR pszBrand, UINT uID, UINT type, INT cx, INT cy, UINT  fuLoad)
 {    
     auto hImage = BrandingLoadImage_orig(pszBrand, uID, type, cx, cy, fuLoad);
 
@@ -6265,7 +6271,7 @@ std::wstring NormalizeRule(std::wstring path)
 
     // 3. Lowercase
     LCMapStringEx(LOCALE_NAME_USER_DEFAULT, LCMAP_LOWERCASE, 
-                  path.c_str(), (int)path.length(), &path[0], (int)path.length(), 
+                  path.c_str(), (INT)path.length(), &path[0], (INT)path.length(), 
                   nullptr, nullptr, 0);
 
     return path;
@@ -6297,8 +6303,8 @@ CurrentProcessInfo GetCurrentProcessInfo()
 
     // Lowercase the main string once
     LCMapStringEx(LOCALE_NAME_USER_DEFAULT, LCMAP_LOWERCASE, 
-                  info.fullPath.c_str(), (int)info.fullPath.length(), 
-                  &info.fullPath[0], (int)info.fullPath.length(), 
+                  info.fullPath.c_str(), (INT)info.fullPath.length(), 
+                  &info.fullPath[0], (INT)info.fullPath.length(), 
                   nullptr, nullptr, 0);
 
     // Extract substrings cleanly 
@@ -6386,6 +6392,8 @@ VOID LoadWindowProcessRules()
                 g_settings.BgType = g_settings.Default;
 
             GetColorSetting(WindhawkUtils::StringSetting(Wh_GetStringSetting(L"RuledPrograms[%d].BackgroundEffects.AccentBlurBehind", i)), g_settings.AccentBlurBehindClr);
+            
+            break;
         }
     }
 }
@@ -6472,10 +6480,18 @@ VOID Wh_ModUninit(VOID)
     if (g_settings.SetSystemColors)
         RevertSysColors();
 
-    for (HBRUSH brush : g_themeCachedCustomSysColorBrushes)
-        DeleteObject(brush);
-    for (HBRUSH brush : g_themeCachedDefaultSysColorBrushes)
-        DeleteObject(brush);
+    for (size_t i = 0; i < g_themeCachedDefaultSysColorBrushes.size(); i++) {
+        HBRUSH& brushCustom = g_themeCachedCustomSysColorBrushes[i];
+        HBRUSH& brushDefault = g_themeCachedDefaultSysColorBrushes[i];
+        if (brushCustom) { 
+            DeleteObject(brushCustom); 
+            brushCustom = nullptr; 
+        }
+        if (brushDefault) { 
+            DeleteObject(brushDefault); 
+            brushDefault = nullptr; 
+        }
+    }
 
     ApplyForExistingWindows();
 }

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -215,9 +215,6 @@ typedef BOOL(WINAPI* pShouldSystemUseDarkMode)();
 static auto ShouldSystemUseDarkMode = (pShouldSystemUseDarkMode)GetProcAddress(GetModuleHandle(L"uxtheme.dll"), MAKEINTRESOURCEA(138));
 BOOL g_IsSysThemeDarkMode = ShouldSystemUseDarkMode();
 
-// Global theme handle used for SysColors OpenThemeData usage
-HTHEME g_hThemeSysMetrics = nullptr;
-
 // Treeview window handle used in our CNscTree_DrawDivider() hook to draw our alpha blended navigation pane divider
 thread_local HWND tl_hwndTreeView = nullptr;
 
@@ -5939,20 +5936,19 @@ void __thiscall Hooked_CNscTree_DrawDivider(CNscTree *__this, HDC hdc, struct _T
         hwndTreeView = GetTreeViewHWND();
     
     if (!IsWindow(hwndTreeView) || !IsWindowClass(hwndTreeView, L"SysTreeView32"))
-        Fallback(L"Not valid TreeView window");
+        return Fallback(L"Not valid TreeView window");
     
     RECT treeItemRect = {0};
     *reinterpret_cast<HTREEITEM*>(&treeItemRect) = (HTREEITEM)hTreeItem;
     
     if (!SendMessageW(hwndTreeView, TVM_GETITEMRECT, 0, (LPARAM)&treeItemRect))
-        Fallback();
+        return Fallback();
     
     if (!g_d2dFactory)
-        Fallback();
+        return Fallback();
 
-    if (!g_themeCache.navigationdivider[0])
-        if (!g_themeCache.CacheNavigationDivider(hdc))
-            Fallback();
+    if (!g_themeCache.navigationdivider[0] && !g_themeCache.CacheNavigationDivider(hdc))
+        return Fallback();
     
     RECT lineRc = treeItemRect;
     INT middlePoint = RECTHEIGHT(&treeItemRect) / 4.f;

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -215,6 +215,9 @@ typedef BOOL(WINAPI* pShouldSystemUseDarkMode)();
 static auto ShouldSystemUseDarkMode = (pShouldSystemUseDarkMode)GetProcAddress(GetModuleHandle(L"uxtheme.dll"), MAKEINTRESOURCEA(138));
 BOOL g_IsSysThemeDarkMode = ShouldSystemUseDarkMode();
 
+// Global theme handle used for SysColors OpenThemeData usage
+HTHEME g_hThemeSysMetrics = nullptr;
+
 // Treeview window handle used in our CNscTree_DrawDivider() hook to draw our alpha blended navigation pane divider
 thread_local HWND tl_hwndTreeView = nullptr;
 
@@ -1144,29 +1147,34 @@ constexpr INT SysColorElements[] = {
     COLOR_HOTLIGHT
 };
 
+BOOL SetCurrentTheme(LPCWSTR themeclass)
+{
+    if (g_hThemeSysMetrics != nullptr)
+        g_hThemeSysMetrics = nullptr;
+
+    g_hThemeSysMetrics = OpenThemeData(NULL, themeclass);
+    if (!g_hThemeSysMetrics)
+        CloseThemeData(g_hThemeSysMetrics);
+    return (g_hThemeSysMetrics) ? TRUE : FALSE;
+}
+
 void ClearSysColorsRegKey() {
     RegDeleteTreeW(HKEY_CURRENT_USER, L"Control Panel\\Colors");
 }
 
-HTHEME SetThemeHandle(HWND hWnd, HTHEME& hTheme, LPCWSTR themeclass)
-{
-    return hTheme = OpenThemeData(hWnd, themeclass);
-}
-
 VOID RevertSysColors()
 {
-    HTHEME hThemeSysMetrics = nullptr;
-    if (!SetThemeHandle(nullptr, hThemeSysMetrics, L"sysmetrics"))
+    if (!SetCurrentTheme(L"sysmetrics"))
         return;
     
     COLORREF aNewColors[ARRAYSIZE(SysColorElements)];
 
     for (UINT i = 0; i < ARRAYSIZE(SysColorElements); i++) 
-        aNewColors[i] = GetThemeSysColor(hThemeSysMetrics, i); 
+        aNewColors[i] = GetThemeSysColor(g_hThemeSysMetrics, i); 
     SetSysColors(ARRAYSIZE(SysColorElements), SysColorElements, aNewColors); 
 
-    CloseThemeData(hThemeSysMetrics);
-    hThemeSysMetrics = nullptr;
+    CloseThemeData(g_hThemeSysMetrics);
+    g_hThemeSysMetrics = nullptr;
 
     //ClearSysColorsRegKey();
 }
@@ -1685,40 +1693,40 @@ public:
     std::array<HDC, 1> dragdrop;
     std::array<HDC, 8> spin;
 
-    BOOL CachePushButton(HDC, INT, INT);
-    BOOL CacheRadioButton(HDC, LPCRECT, INT, INT);
-    BOOL CacheCheckButton(HDC, LPCRECT, INT, INT);
-    BOOL CacheCommandlinkButton(HDC, INT, INT);
-    BOOL CacheCommandlinkGlyph(HDC, INT, INT);
-    BOOL CacheListItem(HDC, INT, INT, INT);
-    BOOL CacheListGroupHeader(HDC, INT, INT, INT);
-    BOOL CacheScrollbar(HDC, INT, INT, INT);
-    BOOL CacheScrollArrow(HDC, INT, INT);
-    BOOL CacheTab(HDC, INT, INT);
-    BOOL CacheCombobox(HDC, INT, INT, INT);
-    BOOL CacheEditBox(HDC, INT, INT, INT);
-    BOOL CacheTreeViewButton(HDC, INT, INT, INT);
-    BOOL CacheTreeViewGlyph(HDC, INT, INT, INT, BOOL);
-    BOOL CacheItemsView(HDC, INT, INT, INT);
-    BOOL CacheProgressBar(HDC, INT, INT, INT);
-    BOOL CacheIndeterminateBar(HDC, INT, INT);
-    BOOL CacheTrackBar(HDC, INT, INT);
-    BOOL CacheTrackBarThumb(HDC, INT, INT, INT);
-    BOOL CacheTrackBarPointedThumb(HDC, INT, INT, INT);
-    BOOL CacheHeader(HDC, INT, INT);
-    BOOL CachePreviewPaneSeparator(HDC);
-    BOOL CacheModuleButton(HDC, INT, INT);
-    BOOL CacheModuleLocationButton(HDC, INT, INT);
-    BOOL CacheModuleSplitButton(HDC,INT, INT, INT);
-    BOOL CacheNavigationButton(HDC, INT, INT, INT);
-    BOOL CacheNavigationDivider(HDC);
-    BOOL CacheToolbarButton(HDC, INT, INT);
-    BOOL CacheAddressBand(HDC, INT, INT);
-    BOOL CacheMenuItem(HDC, INT, INT, INT);
-    BOOL CacheDragDrop(HDC);
-    BOOL CacheSpinButton(HDC, INT, INT, INT);
+    BOOL CachePushButton(INT, INT);
+    BOOL CacheRadioButton(LPCRECT, INT, INT);
+    BOOL CacheCheckButton(LPCRECT, INT, INT);
+    BOOL CacheCommandlinkButton(INT, INT);
+    BOOL CacheCommandlinkGlyph(INT, INT);
+    BOOL CacheListItem(INT, INT, INT);
+    BOOL CacheListGroupHeader(INT, INT, INT);
+    BOOL CacheScrollbar(INT, INT, INT);
+    BOOL CacheScrollArrow(INT, INT);
+    BOOL CacheTab(INT, INT);
+    BOOL CacheCombobox(INT, INT, INT);
+    BOOL CacheEditBox(INT, INT, INT);
+    BOOL CacheTreeViewButton(INT, INT, INT);
+    BOOL CacheTreeViewGlyph(INT, INT, INT, BOOL);
+    BOOL CacheItemsView(INT, INT, INT);
+    BOOL CacheProgressBar(INT, INT, INT);
+    BOOL CacheIndeterminateBar(INT, INT);
+    BOOL CacheTrackBar(INT, INT);
+    BOOL CacheTrackBarThumb(INT, INT, INT);
+    BOOL CacheTrackBarPointedThumb(INT, INT, INT);
+    BOOL CacheHeader(INT, INT);
+    BOOL CachePreviewPaneSeparator();
+    BOOL CacheModuleButton(INT, INT);
+    BOOL CacheModuleLocationButton(INT, INT);
+    BOOL CacheModuleSplitButton(INT, INT, INT);
+    BOOL CacheNavigationButton(INT, INT, INT);
+    BOOL CacheNavigationDivider();
+    BOOL CacheToolbarButton(INT, INT);
+    BOOL CacheAddressBand(INT, INT);
+    BOOL CacheMenuItem(INT, INT, INT);
+    BOOL CacheDragDrop();
+    BOOL CacheSpinButton(INT, INT, INT);
 
-    BOOL CreateDIB(HDC& elementHdc, HDC hDC, INT Width, INT Height)
+    BOOL CreateDIB(HDC& elementHdc, INT Width, INT Height)
     {
         if (elementHdc)
             DeleteHDC(elementHdc);
@@ -1926,7 +1934,7 @@ BOOL PaintScroll(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     if (iPartId == SBP_THUMBBTNHORZ) index += 2;
 
     if (!g_themeCache.scrollbar[index])
-        if (!g_themeCache.CacheScrollbar(hdc, iPartId, iStateId, index))
+        if (!g_themeCache.CacheScrollbar(iPartId, iStateId, index))
             return FALSE;
 
     FillRect(hdc, pRect, (HBRUSH)GetStockObject(BLACK_BRUSH));
@@ -1934,7 +1942,7 @@ BOOL PaintScroll(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     return TRUE;
 }
 
-BOOL CThemeCache::CacheScrollbar(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheScrollbar(INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     INT width = 17 * scale, height = 11 * scale;
@@ -1942,7 +1950,7 @@ BOOL CThemeCache::CacheScrollbar(HDC hdc, INT iPartId, INT iStateId, INT stateIn
         width = 20 * scale, height = 17 * scale;
     FLOAT cornerRadius = 4.f * scale;
 
-    if (!g_themeCache.CreateDIB(g_themeCache.scrollbar[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.scrollbar[stateIndex], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -2082,19 +2090,19 @@ BOOL PaintPushButton(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect, LPCRECT 
     : (iStateId == PBS_DISABLED) ? 3 : 0;
 
     if (!g_themeCache.pushbutton[index])
-        if (!g_themeCache.CachePushButton(hdc, iStateId, index))
+        if (!g_themeCache.CachePushButton(iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.pushbutton[index], &clipRect, 9, 9, 8, 8);
     return TRUE;
 }
 
-BOOL CThemeCache::CachePushButton(HDC hdc, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CachePushButton(INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     INT width = 18, height = 18;
     FLOAT cornerRadius = 3.f * scale;
 
-    if (!g_themeCache.CreateDIB(g_themeCache.pushbutton[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.pushbutton[stateIndex], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -2134,18 +2142,18 @@ BOOL PaintRadioButton(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = iStateId - 1;
 
     if (!g_themeCache.radiobutton[index])
-        if (!g_themeCache.CacheRadioButton(hdc, pRect, iStateId, index))
+        if (!g_themeCache.CacheRadioButton(pRect, iStateId, index))
             return FALSE;
     // Some theme parts are always fixed size so no stretching is needed
     DrawNineGridStretch(hdc, g_themeCache.radiobutton[index], pRect);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheRadioButton(HDC hdc, LPCRECT pRect,  INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheRadioButton(LPCRECT pRect,  INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT width = RECTWIDTH(pRect), height = RECTHEIGHT(pRect);
-    if (!g_themeCache.CreateDIB(g_themeCache.radiobutton[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.radiobutton[stateIndex], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -2232,19 +2240,19 @@ BOOL PaintCheckBox(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = iStateId - 1;
 
     if (!g_themeCache.checkbutton[index])
-        if (!g_themeCache.CacheCheckButton(hdc, pRect, iStateId, index))
+        if (!g_themeCache.CacheCheckButton(pRect, iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.checkbutton[index], pRect);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheCheckButton(HDC hdc, LPCRECT pRect, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheCheckButton(LPCRECT pRect, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT width = RECTWIDTH(pRect), height = RECTHEIGHT(pRect);
     FLOAT cornerRadius = 3.f * scale;
 
-    if (!g_themeCache.CreateDIB(g_themeCache.checkbutton[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.checkbutton[stateIndex], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -2412,19 +2420,19 @@ BOOL PaintCommandLink(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     : (iStateId == CMDLS_PRESSED) ? 2 : 3;
 
     if (!g_themeCache.commandlinkbutton[index])
-        if (!g_themeCache.CacheCommandlinkButton(hdc, iStateId, index))
+        if (!g_themeCache.CacheCommandlinkButton(iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.commandlinkbutton[index], pRect, 9, 9, 8, 8);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheCommandlinkButton(HDC hdc, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheCommandlinkButton(INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     INT width = 18, height = 18;
     FLOAT cornerRadius = 4.f * scale;
 
-    if (!g_themeCache.CreateDIB(g_themeCache.commandlinkbutton[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.commandlinkbutton[stateIndex], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -2471,18 +2479,18 @@ BOOL PaintCommandLinkGlyph(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     : (iStateId == CMDLGS_DISABLED) ? 3 : 0;
 
     if (!g_themeCache.commandlinkglyph[index])
-        if (!g_themeCache.CacheCommandlinkGlyph(hdc, iStateId, index))
+        if (!g_themeCache.CacheCommandlinkGlyph(iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.commandlinkglyph[index], pRect);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheCommandlinkGlyph(HDC hdc, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheCommandlinkGlyph(INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     INT x = 0;
     INT width = 20 * scale, height = 20 * scale;
-    if (!g_themeCache.CreateDIB(g_themeCache.commandlinkglyph[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.commandlinkglyph[stateIndex], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -2534,11 +2542,11 @@ BOOL CThemeCache::CacheCommandlinkGlyph(HDC hdc, INT iStateId, INT stateIndex)
 
 BOOL SanitizeAddressCombobox(HTHEME hTheme, HDC hdc, INT iPartId, INT iStateId)
 {
-    HTHEME hThemeAddressCB = nullptr;
-    if (SetThemeHandle(WindowFromDC(hdc), hThemeAddressCB, L"AddressComposited::ComboBox")
+    HTHEME MyhTheme = nullptr;
+    if ((MyhTheme = OpenThemeData(WindowFromDC(hdc), L"AddressComposited::ComboBox")) 
     && (iPartId == CP_BORDER || iPartId == CP_TRANSPARENTBACKGROUND))
     {
-        CloseThemeData(hThemeAddressCB);
+        CloseThemeData(MyhTheme);
         return TRUE;
     }
     return FALSE;
@@ -2552,19 +2560,19 @@ BOOL PaintCombobox(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = (iPartId == CP_READONLY) ? iStateId - 1 : iStateId + 3;
     
     if (!g_themeCache.combobox[index])
-        if (!g_themeCache.CacheCombobox(hdc, iPartId, iStateId, index))
+        if (!g_themeCache.CacheCombobox(iPartId, iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.combobox[index], pRect, 9, 9, 8, 8);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheCombobox(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheCombobox(INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 3.f * scale;
     INT width = 18, height = 18;
 
-    if (!g_themeCache.CreateDIB(g_themeCache.combobox[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.combobox[stateIndex], width, height))
         return FALSE;
     
     // Direct2D render target
@@ -2624,12 +2632,13 @@ BOOL CThemeCache::CacheCombobox(HDC hdc, INT iPartId, INT iStateId, INT stateInd
 
 BOOL IsAddressInnerBackground(HTHEME hTheme, HDC hdc, INT iPartId)
 {
-    HTHEME hThemeAddress = NULL;
-    if (SetThemeHandle(WindowFromDC(hdc), hThemeAddress, L"AddressComposited::Edit") && iPartId == EP_BACKGROUNDWITHBORDER)
+    HTHEME theme = NULL;
+    if ((theme = OpenThemeData(WindowFromDC(hdc), L"AddressComposited::Edit")) && iPartId == EP_BACKGROUNDWITHBORDER)
     {
-        CloseThemeData(hThemeAddress);
+        CloseThemeData(theme);
         return TRUE;
     }
+    CloseThemeData(theme);
     return FALSE;
 }
 
@@ -2649,7 +2658,7 @@ BOOL PaintEditBox(HTHEME hTheme, HDC hdc, INT iPartId, INT iStateId, LPCRECT pRe
     INT index = (iPartId == EP_BACKGROUNDWITHBORDER) ? 3 : (iStateId == 1) ? 0 : iStateId - 2;
 
     if (!g_themeCache.editbox[index])
-        if (!g_themeCache.CacheEditBox(hdc, iPartId, iStateId, index))
+        if (!g_themeCache.CacheEditBox(iPartId, iStateId, index))
             return FALSE;
     // hide the borders of the inner black background of EP_BACKGROUNDWITHBORDER theme class by expanding the black drawing.
     RECT rc = (iPartId == EP_BACKGROUNDWITHBORDER) ? RECT{pRect->left-1, pRect->top-1, pRect->right+3,pRect->bottom+1} : *pRect;
@@ -2657,13 +2666,13 @@ BOOL PaintEditBox(HTHEME hTheme, HDC hdc, INT iPartId, INT iStateId, LPCRECT pRe
     return TRUE;
 }
 
-BOOL CThemeCache::CacheEditBox(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheEditBox(INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 3.f * scale;
     INT x = 0, y = 0;
     INT width = 18, height = 18;
-    if(!g_themeCache.CreateDIB(g_themeCache.editbox[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.editbox[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -2820,20 +2829,20 @@ BOOL PaintTab(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
               : (iStateId == TIS_HOT) ? 1 : (iStateId == TIS_DISABLED) ? 2 : 3;
 
     if (!g_themeCache.tab[index])
-        if (!g_themeCache.CacheTab(hdc, iStateId, index))
+        if (!g_themeCache.CacheTab(iStateId, index))
             return FALSE;
 
     DrawNineGridStretch(hdc, g_themeCache.tab[index], pRect, 9, 9, 8, 8);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheTab(HDC hdc, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheTab(INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 4.f * scale;
     INT width = 18, height = 18;
 
-    if(!g_themeCache.CreateDIB(g_themeCache.tab[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.tab[stateIndex], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -2889,16 +2898,16 @@ BOOL PaintTrackbar(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = (iPartId == TKP_TRACK) ? 0 : 1;
 
     if (!g_themeCache.trackbar[index])
-        if (!g_themeCache.CacheTrackBar(hdc, iPartId, index))
+        if (!g_themeCache.CacheTrackBar(iPartId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.trackbar[index], pRect, 2, 2, 2, 2);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheTrackBar(HDC hdc, INT iPartId, INT stateIndex)
+BOOL CThemeCache::CacheTrackBar(INT iPartId, INT stateIndex)
 {
     INT width = 6, height = 6;
-    if(!g_themeCache.CreateDIB(g_themeCache.trackbar[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.trackbar[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -2926,13 +2935,13 @@ BOOL PaintTrackbarThumb(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = (iPartId == TKP_THUMB) ? iStateId - 1 : iStateId + 3;
 
     if (!g_themeCache.trackbarthumb[index])
-        if (!g_themeCache.CacheTrackBarThumb(hdc, iPartId, iStateId, index))
+        if (!g_themeCache.CacheTrackBarThumb(iPartId, iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.trackbarthumb[index], pRect);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheTrackBarThumb(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheTrackBarThumb(INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 3.f * scale;
@@ -2941,7 +2950,7 @@ BOOL CThemeCache::CacheTrackBarThumb(HDC hdc, INT iPartId, INT iStateId, INT sta
     if (iPartId == TKP_THUMBVERT)
         width = std::exchange(height, width);
     
-    if(!g_themeCache.CreateDIB(g_themeCache.trackbarthumb[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.trackbarthumb[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -2974,13 +2983,13 @@ BOOL PaintTrackBarPointedThumb(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect
                 (iPartId == TKP_THUMBLEFT) ? iStateId + 15 : iStateId + 19;
 
     if (!g_themeCache.trackbarthumb[index])
-        if (!g_themeCache.CacheTrackBarPointedThumb(hdc, iPartId, iStateId, index))
+        if (!g_themeCache.CacheTrackBarPointedThumb(iPartId, iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.trackbarthumb[index], pRect);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheTrackBarPointedThumb(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheTrackBarPointedThumb(INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     INT width = 11 * scale, height = 19 * scale;
@@ -2988,7 +2997,7 @@ BOOL CThemeCache::CacheTrackBarPointedThumb(HDC hdc, INT iPartId, INT iStateId, 
     if (iPartId == TKP_THUMBLEFT || iPartId == TKP_THUMBRIGHT)
         width = std::exchange(height, width);
     
-    if(!g_themeCache.CreateDIB(g_themeCache.trackbarthumb[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.trackbarthumb[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -3114,7 +3123,7 @@ BOOL PaintProgressBar(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
               : (iPartId == PP_CHUNK || iPartId == PP_CHUNKVERT) ? 8 : 9;
     
     if (!g_themeCache.progressbar[index])
-        if (!g_themeCache.CacheProgressBar(hdc, iPartId, iStateId, index))
+        if (!g_themeCache.CacheProgressBar(iPartId, iStateId, index))
             return FALSE;
     if (iPartId == PP_FILL)
         DrawNineGridStretch(hdc, g_themeCache.progressbar[index], pRect, 8, 10, 8, 10);
@@ -3125,7 +3134,7 @@ BOOL PaintProgressBar(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     return TRUE;
 }
 
-BOOL CThemeCache::CacheProgressBar(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheProgressBar(INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 3.f * scale;
@@ -3137,7 +3146,7 @@ BOOL CThemeCache::CacheProgressBar(HDC hdc, INT iPartId, INT iStateId, INT state
     else if (iPartId == PP_FILLVERT)
         width = 23, height = 50;
 
-    if(!g_themeCache.CreateDIB(g_themeCache.progressbar[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.progressbar[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -3247,13 +3256,13 @@ BOOL PaintIndeterminateProgressBar(HDC hdc, INT iPartId, INT iStateId, LPCRECT p
     }
     
     if (!g_themeCache.indeterminatebar[index])
-        if (!g_themeCache.CacheIndeterminateBar(hdc, iStateId, index))
+        if (!g_themeCache.CacheIndeterminateBar(iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.indeterminatebar[index], &overlayRect, 6, 6, 5, 5);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheIndeterminateBar(HDC hdc, INT iPartId, INT stateIndex)
+BOOL CThemeCache::CacheIndeterminateBar(INT iPartId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 3.f * scale;
@@ -3262,7 +3271,7 @@ BOOL CThemeCache::CacheIndeterminateBar(HDC hdc, INT iPartId, INT stateIndex)
     if (iPartId == PP_MOVEOVERLAYVERT)
         width = std::exchange(height, width);
 
-    if(!g_themeCache.CreateDIB(g_themeCache.indeterminatebar[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.indeterminatebar[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -3308,18 +3317,18 @@ BOOL PaintListView(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     {
         if (index <= 6)
         {
-            if (!g_themeCache.CacheListItem(hdc, iPartId, iStateId, index))
+            if (!g_themeCache.CacheListItem(iPartId, iStateId, index))
                 return FALSE;
         }
         else
-            if (!g_themeCache.CacheListGroupHeader(hdc, iPartId, iStateId, index))
+            if (!g_themeCache.CacheListGroupHeader(iPartId, iStateId, index))
                 return FALSE;
     }
     DrawNineGridStretch(hdc, g_themeCache.listview[index], pRect, 9, 9, 8, 8);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheListItem(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheListItem(INT iPartId, INT iStateId, INT stateIndex)
 {
     if (iPartId != THEMECLS_COMMONPROPS_PART && iPartId != LVP_LISTITEM)
         return FALSE;
@@ -3329,7 +3338,7 @@ BOOL CThemeCache::CacheListItem(HDC hdc, INT iPartId, INT iStateId, INT stateInd
     INT x = 0, y = 0;
     INT width = 18, height = 18;
 
-    if(!g_themeCache.CreateDIB(g_themeCache.listview[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.listview[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -3394,7 +3403,7 @@ BOOL CThemeCache::CacheListItem(HDC hdc, INT iPartId, INT iStateId, INT stateInd
     return TRUE;
 }
 
-BOOL CThemeCache::CacheListGroupHeader(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheListGroupHeader(INT iPartId, INT iStateId, INT stateIndex)
 {
     if (iPartId != LVP_GROUPHEADER && iPartId != LVP_GROUPHEADERLINE && iPartId != LVP_COLUMNDETAIL)
         return FALSE;
@@ -3404,7 +3413,7 @@ BOOL CThemeCache::CacheListGroupHeader(HDC hdc, INT iPartId, INT iStateId, INT s
     INT x = 0, y = 0;
     INT width = (iPartId == LVP_COLUMNDETAIL) ? 2 : 18, height = (iPartId == LVP_COLUMNDETAIL) ? 1 : 18;
 
-    if (!g_themeCache.CreateDIB(g_themeCache.listview[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.listview[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -3493,20 +3502,20 @@ BOOL PaintTreeViewButton(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
                 (iStateId == TREIS_SELECTEDNOTFOCUS) ? 3 : 4;
 
     if (!g_themeCache.treeview[index])
-        if (!g_themeCache.CacheTreeViewButton(hdc, iPartId, iStateId, index))
+        if (!g_themeCache.CacheTreeViewButton(iPartId, iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.treeview[index], pRect, 9, 9, 8, 8);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheTreeViewButton(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheTreeViewButton(INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 5.f * scale;
     FLOAT x = 0, y = 0;
     INT width = 18, height = 18;
 
-    if (!g_themeCache.CreateDIB(g_themeCache.treeview[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.treeview[stateIndex], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -3565,13 +3574,13 @@ BOOL PaintTreeViewGlyph(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     index = (ExplorerTreeView) ? index + 4 : index;
 
     if (!g_themeCache.treeviewglyph[index])
-        if (!g_themeCache.CacheTreeViewGlyph(hdc, iPartId, iStateId, index, ExplorerTreeView))
+        if (!g_themeCache.CacheTreeViewGlyph(iPartId, iStateId, index, ExplorerTreeView))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.treeviewglyph[index], pRect);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheTreeViewGlyph(HDC hdc, INT iPartId, INT iStateId, INT stateIndex, BOOL ExplorerTreeView)
+BOOL CThemeCache::CacheTreeViewGlyph(INT iPartId, INT iStateId, INT stateIndex, BOOL ExplorerTreeView)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     INT width = 9 * scale;
@@ -3580,7 +3589,7 @@ BOOL CThemeCache::CacheTreeViewGlyph(HDC hdc, INT iPartId, INT iStateId, INT sta
     if (ExplorerTreeView)
         width = height = 16 * scale;
 
-    if (!g_themeCache.CreateDIB(g_themeCache.treeviewglyph[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.treeviewglyph[stateIndex], width, height))
         return FALSE;
 
     RECT rc {0, 0, width, height};
@@ -3649,20 +3658,20 @@ BOOL PaintItemsView(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
         return PaintListView(hdc, 1, 2, pRect);
     
     if (!g_themeCache.itemsview[index])
-        if (!g_themeCache.CacheItemsView(hdc, iPartId, iStateId, index))
+        if (!g_themeCache.CacheItemsView(iPartId, iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.itemsview[index], pRect, 9, 9, 8, 8);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheItemsView(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheItemsView(INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 4.f * scale;
     INT x = 0, y = 0;
     INT width = 18, height = 18;
 
-    if(!g_themeCache.CreateDIB(g_themeCache.itemsview[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.itemsview[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -3727,20 +3736,20 @@ BOOL PaintHeader(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = (iStateId % 3 == 2) ? 0 : 1;
     
     if (!g_themeCache.header[index])
-        if (!g_themeCache.CacheHeader(hdc, iStateId, index))
+        if (!g_themeCache.CacheHeader(iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.header[index], pRect, 12, 0, 11, 12);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheHeader(HDC hdc, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheHeader(INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 6.f * scale;
     INT x = 0, y = 0;
     INT width = 24, height = 24;
 
-    if(!g_themeCache.CreateDIB(g_themeCache.header[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.header[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -3797,7 +3806,7 @@ BOOL PaintPreviewPaneSeparator(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect
         return FALSE;
 
     if (!g_themeCache.previewseparator[0])
-        if (!g_themeCache.CachePreviewPaneSeparator(hdc))
+        if (!g_themeCache.CachePreviewPaneSeparator())
             return FALSE;
     
     RECT rc{pRect->left+1, pRect->top, pRect->right, pRect->bottom};
@@ -3805,11 +3814,11 @@ BOOL PaintPreviewPaneSeparator(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect
     return TRUE;
 }
 
-BOOL CThemeCache::CachePreviewPaneSeparator(HDC hdc)
+BOOL CThemeCache::CachePreviewPaneSeparator()
 {
     INT x = 0, y = 0;
     INT width = 3, height = 3;
-    if(!g_themeCache.CreateDIB(g_themeCache.previewseparator[0], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.previewseparator[0], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -3837,20 +3846,20 @@ BOOL PaintModuleButton(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = iStateId - 2; 
 
     if (!g_themeCache.modulebutton[index])
-        if (!g_themeCache.CacheModuleButton(hdc, iStateId, index))
+        if (!g_themeCache.CacheModuleButton(iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.modulebutton[index], pRect, 9, 9, 8, 8);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheModuleButton(HDC hdc, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheModuleButton(INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 4.f * scale;
     INT x = 0, y = 0;
     INT width = 18, height = 18;
 
-    if(!g_themeCache.CreateDIB(g_themeCache.modulebutton[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.modulebutton[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -3908,19 +3917,19 @@ BOOL PaintModuleLocation(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = iStateId - 1; 
 
     if (!g_themeCache.modulelocationbutton[index])
-        if (!g_themeCache.CacheModuleLocationButton(hdc, iStateId, index))
+        if (!g_themeCache.CacheModuleLocationButton(iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.modulelocationbutton[index], pRect, 9, 9, 8, 8);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheModuleLocationButton(HDC hdc, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheModuleLocationButton(INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 4.f * scale;
     INT x = 0, y = 0;
     INT width = 18, height = 18;
-    if(!g_themeCache.CreateDIB(g_themeCache.modulelocationbutton[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.modulelocationbutton[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -3983,21 +3992,21 @@ BOOL PaintModuleSplitButton(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = (iPartId == 4) ? iStateId - 2 : iStateId + 2; 
 
     if (!g_themeCache.modulesplitbutton[index])
-        if (!g_themeCache.CacheModuleSplitButton(hdc, iPartId, iStateId, index))
+        if (!g_themeCache.CacheModuleSplitButton(iPartId, iStateId, index))
             return FALSE;
     RECT newRc = (iPartId == 4 && iStateId == 4) ? RECT{pRect->left, pRect->top, pRect->right+2, pRect->bottom} : *pRect;
     DrawNineGridStretch(hdc, g_themeCache.modulesplitbutton[index], &newRc, 9, 9, 8, 8);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheModuleSplitButton(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheModuleSplitButton(INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 4.f * scale;
     INT x = 0, y = 0;
     INT width = 18, height = 18;
 
-    if(!g_themeCache.CreateDIB(g_themeCache.modulesplitbutton[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.modulesplitbutton[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -4098,13 +4107,13 @@ BOOL PaintNavigationButton(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = (iPartId == NAV_BACKBUTTON) ? iStateId - 1 : (iPartId == NAV_FORWARDBUTTON) ? iStateId + 3 : iStateId + 7;
 
     if (!g_themeCache.navigationbutton[index])
-        if (!g_themeCache.CacheNavigationButton(hdc, iPartId, iStateId, index))
+        if (!g_themeCache.CacheNavigationButton(iPartId, iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.navigationbutton[index], pRect);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheNavigationButton(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheNavigationButton(INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 4.f * scale;
@@ -4114,7 +4123,7 @@ BOOL CThemeCache::CacheNavigationButton(HDC hdc, INT iPartId, INT iStateId, INT 
     if (iPartId == NAV_MENUBUTTON)
         width = 13 * scale, height = 27 * scale;
     
-    if(!g_themeCache.CreateDIB(g_themeCache.navigationbutton[stateIndex], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.navigationbutton[stateIndex], width, height))
         return FALSE;
     
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -4239,19 +4248,19 @@ BOOL PaintToolbarButton(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = (iStateId == TS_HOTCHECKED) ? 0 : (iStateId == TS_PRESSED) ? 1 : (iStateId == TS_CHECKED) ? 2 : 3;
 
     if (!g_themeCache.toolbarbutton[index])
-        if (!g_themeCache.CacheToolbarButton(hdc, iStateId, index))
+        if (!g_themeCache.CacheToolbarButton(iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.toolbarbutton[index], pRect, 9, 9, 8, 8);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheToolbarButton(HDC hdc, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheToolbarButton(INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 4.f * scale;
     INT width = 18, height = 18;
 
-    if (!g_themeCache.CreateDIB(g_themeCache.toolbarbutton[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.toolbarbutton[stateIndex], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -4335,19 +4344,19 @@ BOOL PaintAddressBand(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = iStateId - 1;
 
     if (!g_themeCache.addressband[index])
-        if (!g_themeCache.CacheAddressBand(hdc, iStateId, index))
+        if (!g_themeCache.CacheAddressBand(iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.addressband[index], pRect, 12, 12, 11, 11);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheAddressBand(HDC hdc, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheAddressBand(INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 5.f * scale;
     INT width = 24, height = 24;
 
-    if (!g_themeCache.CreateDIB(g_themeCache.addressband[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.addressband[stateIndex], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -4402,7 +4411,7 @@ BOOL PaintMenu(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     INT index = (iPartId == MENU_POPUPSEPARATOR) ? 0 : (iPartId == 27 || iPartId == MENU_POPUPITEM) ? 1 : (iPartId == MENU_BARITEM && iStateId == MBI_PUSHED) ?  3 : 2;
 
     if (!g_themeCache.menuitem[index])
-        if (!g_themeCache.CacheMenuItem(hdc, iPartId, iStateId, index))
+        if (!g_themeCache.CacheMenuItem(iPartId, iStateId, index))
             return FALSE;
     if (iPartId != MENU_POPUPSEPARATOR)
         DrawNineGridStretch(hdc, g_themeCache.menuitem[index], pRect, 9, 9, 8, 8);
@@ -4411,7 +4420,7 @@ BOOL PaintMenu(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     return TRUE;
 }
 
-BOOL CThemeCache::CacheMenuItem(HDC hdc, INT iPartId, INT iStateId, INT indexState)
+BOOL CThemeCache::CacheMenuItem(INT iPartId, INT iStateId, INT indexState)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     FLOAT cornerRadius = 4.f * scale;
@@ -4422,7 +4431,7 @@ BOOL CThemeCache::CacheMenuItem(HDC hdc, INT iPartId, INT iStateId, INT indexSta
         height = 5;
     }
 
-    if (!g_themeCache.CreateDIB(g_themeCache.menuitem[indexState], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.menuitem[indexState], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -4465,19 +4474,19 @@ BOOL PaintDragDrop(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
         return FALSE;
 
     if (!g_themeCache.dragdrop[0])
-        if (!g_themeCache.CacheDragDrop(hdc))
+        if (!g_themeCache.CacheDragDrop())
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.dragdrop[0], pRect);
     return TRUE;
 }
 
-BOOL CThemeCache::CacheDragDrop(HDC hdc)
+BOOL CThemeCache::CacheDragDrop()
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     INT width = 108, height = 108;
     FLOAT cornerRadius = 4.f * scale;
 
-    if (!g_themeCache.CreateDIB(g_themeCache.dragdrop[0], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.dragdrop[0], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -4574,7 +4583,7 @@ BOOL PaintSpin(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     PatBlt(hdc, pRect->left, pRect->top, RECTWIDTH(pRect), RECTHEIGHT(pRect), BLACKNESS);
 
     if (!g_themeCache.spin[index])
-        if (!g_themeCache.CacheSpinButton(hdc, iPartId, iStateId, index))
+        if (!g_themeCache.CacheSpinButton(iPartId, iStateId, index))
             return FALSE;
     DrawNineGridStretch(hdc, g_themeCache.spin[index], pRect, 6, 5, 6, 5);
 
@@ -4588,13 +4597,13 @@ BOOL PaintSpin(HDC hdc, INT iPartId, INT iStateId, LPCRECT pRect)
     }
 }
 
-BOOL CThemeCache::CacheSpinButton(HDC hdc, INT iPartId, INT iStateId, INT stateIndex)
+BOOL CThemeCache::CacheSpinButton(INT iPartId, INT iStateId, INT stateIndex)
 {
     FLOAT scale = (FLOAT)g_Dpi / USER_DEFAULT_SCREEN_DPI;
     INT width = 12, height = 12;
     FLOAT cornerRadius = 2.f * scale;
 
-    if (!g_themeCache.CreateDIB(g_themeCache.spin[stateIndex], hdc, width, height))
+    if (!g_themeCache.CreateDIB(g_themeCache.spin[stateIndex], width, height))
         return FALSE;
 
     Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> pRenderTarget;
@@ -4657,17 +4666,15 @@ HRESULT WINAPI HookedDrawThemeBackground(
             return S_OK;
         else if (iPartId == BP_GROUPBOX)
         {
-            HTHEME hThemeGroupBox = nullptr;
-            if (hTheme == SetThemeHandle(WindowFromDC(hdc), hThemeGroupBox, L"Button"))
+            HTHEME hGroupBoxTheme;
+            if (hTheme == (hGroupBoxTheme = OpenThemeData(WindowFromDC(hdc), L"Button")))
             {
                 if (PaintGroupBox(hdc, iPartId, iStateId, pRect, pClipRect)) {
-                    CloseThemeData(hThemeGroupBox);
+                    CloseThemeData(hGroupBoxTheme);
                     return S_OK;
                 }
             }
-            
-            if (hThemeGroupBox)
-                CloseThemeData(hThemeGroupBox);
+            CloseThemeData(hGroupBoxTheme);
         }
     }
     else if (ThemeClassName == L"Tab")
@@ -4715,23 +4722,22 @@ HRESULT WINAPI HookedDrawThemeBackground(
         // The exported GetThemeClass function does not provide
         // full string of theme class names of derived theme classes
         // Use the OpenThemeData API instead.
-        HTHEME hThemeProgress = NULL;
-        if (hTheme == SetThemeHandle(WindowFromDC(hdc), hThemeProgress, L"Indeterminate::Progress"))
+        HTHEME theme = NULL;
+        if (hTheme == (theme = OpenThemeData(WindowFromDC(hdc), L"Indeterminate::Progress")))
         {
             if (PaintIndeterminateProgressBar(hdc, iPartId, iStateId, pRect))
             {
-                CloseThemeData(hThemeProgress);
+                CloseThemeData(theme);
                 return S_OK;
             }
-            CloseThemeData(hThemeProgress);
+            CloseThemeData(theme);
         }
         else if (PaintProgressBar(hdc, iPartId, iStateId, pRect)) 
         {
-            CloseThemeData(hThemeProgress);
+            CloseThemeData(theme);
             return S_OK;
         }
-        if (hThemeProgress)
-            CloseThemeData(hThemeProgress);
+        CloseThemeData(theme);
     } 
     else if (ThemeClassName == L"ListView")
     {
@@ -4757,13 +4763,14 @@ HRESULT WINAPI HookedDrawThemeBackground(
     }
     else if (ThemeClassName == L"Toolbar")
     {
-        HTHEME hThemeToolbar = NULL;
-        if (SetThemeHandle(WindowFromDC(hdc), hThemeToolbar, L"BB::Toolbar"))
+        HTHEME theme = NULL;
+        if ((theme = OpenThemeData(WindowFromDC(hdc), L"BB::Toolbar")))
         {
             if (PaintToolbarSplitDropDown(hdc, iPartId, iStateId, pRect)) {
-                CloseThemeData(hThemeToolbar);
+                CloseThemeData(theme);
                 return S_OK;
             }
+            CloseThemeData(theme);
         }
         if (PaintToolbarButton(hdc, iPartId, iStateId, pRect))
             return S_OK;
@@ -4779,12 +4786,14 @@ HRESULT WINAPI HookedDrawThemeBackground(
             return S_OK;
         // Force menu white glyphs
         else if (iPartId <= MENU_SYSTEMRESTORE && iPartId >= MENU_SYSTEMCLOSE && g_IsSysThemeDarkMode) {
-            HTHEME hThemeMenu = NULL;
-            if (SetThemeHandle(WindowFromDC(hdc), hThemeMenu, L"DarkMode::Menu")) {
-                auto hr = DrawThemeBackground_orig(hThemeMenu, hdc, iPartId, iStateId, pRect, pClipRect);
-                CloseThemeData(hThemeMenu);
+            HTHEME theme = NULL;
+            HRESULT hr = S_OK;
+            if ((theme = OpenThemeData(WindowFromDC(hdc), L"DarkMode::Menu"))) {
+                hr = DrawThemeBackground_orig(theme, hdc, iPartId, iStateId, pRect, pClipRect);
+                CloseThemeData(theme);
                 return hr;
             }
+            CloseThemeData(theme);
         }
     }
     else if (ThemeClassName == L"DragDrop")
@@ -4834,12 +4843,13 @@ HRESULT WINAPI HookedDrawThemeBackground(
         return S_OK;
     }
     else if (ThemeClassName == L"Toolbar" && iPartId == THEMECLS_COMMONPROPS_PART) {
-        HTHEME hThemeToolbar = nullptr;
-        if ((SetThemeHandle(WindowFromDC(hdc), hThemeToolbar, L"Placesbar::Toolbar"))) {
+        HTHEME Toolbar;
+        if ((Toolbar = OpenThemeData(WindowFromDC(hdc), L"Placesbar::Toolbar"))) {
             FillRect(hdc, pRect, (HBRUSH)GetStockObject(BLACK_BRUSH));
-            CloseThemeData(hThemeToolbar);
+            CloseThemeData(Toolbar);
             return S_OK;
         }
+        CloseThemeData(Toolbar);
     }
     return hr;
 }
@@ -4894,23 +4904,22 @@ HRESULT WINAPI HookedDrawThemeBackgroundEx(
     }
     else if (ThemeClassName == L"Progress")
     {
-        HTHEME hThemeProgress = NULL;
-        if (hTheme == SetThemeHandle(WindowFromDC(hdc), hThemeProgress, L"Indeterminate::Progress"))
+        HTHEME theme = NULL;
+        if (hTheme == (theme = OpenThemeData(WindowFromDC(hdc), L"Indeterminate::Progress")))
         {
             if (PaintIndeterminateProgressBar(hdc, iPartId, iStateId, pRect))
             {
-                CloseThemeData(hThemeProgress);
+                CloseThemeData(theme);
                 return S_OK;
             }
+            CloseThemeData(theme);
         }
         else if (PaintProgressBar(hdc, iPartId, iStateId, pRect)) 
         {
-            CloseThemeData(hThemeProgress);
+            CloseThemeData(theme);
             return S_OK;
         }
-
-        if (hThemeProgress)
-            CloseThemeData(hThemeProgress);
+        CloseThemeData(theme);
     } 
     else if (ThemeClassName == L"CommandModule")
     {
@@ -5882,12 +5891,12 @@ VOID Comctl32Hooks()
     }
 }
 
-BOOL CThemeCache::CacheNavigationDivider(HDC hdc)
+BOOL CThemeCache::CacheNavigationDivider()
 {
     FLOAT x = 0, y = 0;
     FLOAT width = 2, height = 2;
 
-    if(!g_themeCache.CreateDIB(g_themeCache.navigationdivider[0], hdc, width, height))
+    if(!g_themeCache.CreateDIB(g_themeCache.navigationdivider[0], width, height))
         return FALSE;
 
     RECT rc = {(INT)x, (INT)y, (INT)width, (INT)height};
@@ -5936,19 +5945,20 @@ void __thiscall Hooked_CNscTree_DrawDivider(CNscTree *__this, HDC hdc, struct _T
         hwndTreeView = GetTreeViewHWND();
     
     if (!IsWindow(hwndTreeView) || !IsWindowClass(hwndTreeView, L"SysTreeView32"))
-        return Fallback(L"Not valid TreeView window");
+        Fallback(L"Not valid TreeView window");
     
     RECT treeItemRect = {0};
     *reinterpret_cast<HTREEITEM*>(&treeItemRect) = (HTREEITEM)hTreeItem;
     
     if (!SendMessageW(hwndTreeView, TVM_GETITEMRECT, 0, (LPARAM)&treeItemRect))
-        return Fallback();
+        Fallback();
     
     if (!g_d2dFactory)
-        return Fallback();
+        Fallback();
 
-    if (!g_themeCache.navigationdivider[0] && !g_themeCache.CacheNavigationDivider(hdc))
-        return Fallback();
+    if (!g_themeCache.navigationdivider[0])
+        if (!g_themeCache.CacheNavigationDivider())
+            Fallback();
     
     RECT lineRc = treeItemRect;
     INT middlePoint = RECTHEIGHT(&treeItemRect) / 4.f;
@@ -6360,8 +6370,8 @@ VOID LoadWindowProcessRules()
 
             BOOL globalSetting_SetSystemColors = Wh_GetIntSetting(L"RenderingMod.Syscolors");
 
-            // Reset system colors to default values if the system color setting is disabled for the specific ruled process,
-            // Hook all necessary API to restore system colors
+            // Reset system colors to default values ​​if the system color setting is disabled for the specific ruled process.
+            // Hook all necessary API to restore system colors.
             if (!g_settings.SetSystemColors && globalSetting_SetSystemColors) {
                 g_DefaultSysColors = TRUE;
                 WindhawkUtils::SetFunctionHook(GetSysColor, HookedGetSysColor, &GetSysColor_orig);

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -1147,34 +1147,29 @@ constexpr INT SysColorElements[] = {
     COLOR_HOTLIGHT
 };
 
-BOOL SetCurrentTheme(LPCWSTR themeclass)
-{
-    if (g_hThemeSysMetrics != nullptr)
-        g_hThemeSysMetrics = nullptr;
-
-    g_hThemeSysMetrics = OpenThemeData(NULL, themeclass);
-    if (!g_hThemeSysMetrics)
-        CloseThemeData(g_hThemeSysMetrics);
-    return (g_hThemeSysMetrics) ? TRUE : FALSE;
-}
-
 void ClearSysColorsRegKey() {
     RegDeleteTreeW(HKEY_CURRENT_USER, L"Control Panel\\Colors");
 }
 
+HTHEME SetThemeHandle(HWND hWnd, HTHEME& hTheme, LPCWSTR themeclass)
+{
+    return hTheme = OpenThemeData(hWnd, themeclass);
+}
+
 VOID RevertSysColors()
 {
-    if (!SetCurrentTheme(L"sysmetrics"))
+    HTHEME hThemeSysMetrics = nullptr;
+    if (!SetThemeHandle(nullptr, hThemeSysMetrics, L"sysmetrics"))
         return;
     
     COLORREF aNewColors[ARRAYSIZE(SysColorElements)];
 
     for (UINT i = 0; i < ARRAYSIZE(SysColorElements); i++) 
-        aNewColors[i] = GetThemeSysColor(g_hThemeSysMetrics, i); 
+        aNewColors[i] = GetThemeSysColor(hThemeSysMetrics, i); 
     SetSysColors(ARRAYSIZE(SysColorElements), SysColorElements, aNewColors); 
 
-    CloseThemeData(g_hThemeSysMetrics);
-    g_hThemeSysMetrics = nullptr;
+    CloseThemeData(hThemeSysMetrics);
+    hThemeSysMetrics = nullptr;
 
     //ClearSysColorsRegKey();
 }
@@ -2542,11 +2537,11 @@ BOOL CThemeCache::CacheCommandlinkGlyph(HDC hdc, INT iStateId, INT stateIndex)
 
 BOOL SanitizeAddressCombobox(HTHEME hTheme, HDC hdc, INT iPartId, INT iStateId)
 {
-    HTHEME MyhTheme = nullptr;
-    if ((MyhTheme = OpenThemeData(WindowFromDC(hdc), L"AddressComposited::ComboBox")) 
+    HTHEME hThemeAddressCB = nullptr;
+    if (SetThemeHandle(WindowFromDC(hdc), hThemeAddressCB, L"AddressComposited::ComboBox")
     && (iPartId == CP_BORDER || iPartId == CP_TRANSPARENTBACKGROUND))
     {
-        CloseThemeData(MyhTheme);
+        CloseThemeData(hThemeAddressCB);
         return TRUE;
     }
     return FALSE;
@@ -2632,13 +2627,12 @@ BOOL CThemeCache::CacheCombobox(HDC hdc, INT iPartId, INT iStateId, INT stateInd
 
 BOOL IsAddressInnerBackground(HTHEME hTheme, HDC hdc, INT iPartId)
 {
-    HTHEME theme = NULL;
-    if ((theme = OpenThemeData(WindowFromDC(hdc), L"AddressComposited::Edit")) && iPartId == EP_BACKGROUNDWITHBORDER)
+    HTHEME hThemeAddress = NULL;
+    if (SetThemeHandle(WindowFromDC(hdc), hThemeAddress, L"AddressComposited::Edit") && iPartId == EP_BACKGROUNDWITHBORDER)
     {
-        CloseThemeData(theme);
+        CloseThemeData(hThemeAddress);
         return TRUE;
     }
-    CloseThemeData(theme);
     return FALSE;
 }
 
@@ -4666,15 +4660,17 @@ HRESULT WINAPI HookedDrawThemeBackground(
             return S_OK;
         else if (iPartId == BP_GROUPBOX)
         {
-            HTHEME hGroupBoxTheme;
-            if (hTheme == (hGroupBoxTheme = OpenThemeData(WindowFromDC(hdc), L"Button")))
+            HTHEME hThemeGroupBox = nullptr;
+            if (hTheme == SetThemeHandle(WindowFromDC(hdc), hThemeGroupBox, L"Button"))
             {
                 if (PaintGroupBox(hdc, iPartId, iStateId, pRect, pClipRect)) {
-                    CloseThemeData(hGroupBoxTheme);
+                    CloseThemeData(hThemeGroupBox);
                     return S_OK;
                 }
             }
-            CloseThemeData(hGroupBoxTheme);
+            
+            if (hThemeGroupBox)
+                CloseThemeData(hThemeGroupBox);
         }
     }
     else if (ThemeClassName == L"Tab")
@@ -4722,22 +4718,23 @@ HRESULT WINAPI HookedDrawThemeBackground(
         // The exported GetThemeClass function does not provide
         // full string of theme class names of derived theme classes
         // Use the OpenThemeData API instead.
-        HTHEME theme = NULL;
-        if (hTheme == (theme = OpenThemeData(WindowFromDC(hdc), L"Indeterminate::Progress")))
+        HTHEME hThemeProgress = NULL;
+        if (hTheme == SetThemeHandle(WindowFromDC(hdc), hThemeProgress, L"Indeterminate::Progress"))
         {
             if (PaintIndeterminateProgressBar(hdc, iPartId, iStateId, pRect))
             {
-                CloseThemeData(theme);
+                CloseThemeData(hThemeProgress);
                 return S_OK;
             }
-            CloseThemeData(theme);
+            CloseThemeData(hThemeProgress);
         }
         else if (PaintProgressBar(hdc, iPartId, iStateId, pRect)) 
         {
-            CloseThemeData(theme);
+            CloseThemeData(hThemeProgress);
             return S_OK;
         }
-        CloseThemeData(theme);
+        if (hThemeProgress)
+            CloseThemeData(hThemeProgress);
     } 
     else if (ThemeClassName == L"ListView")
     {
@@ -4763,14 +4760,13 @@ HRESULT WINAPI HookedDrawThemeBackground(
     }
     else if (ThemeClassName == L"Toolbar")
     {
-        HTHEME theme = NULL;
-        if ((theme = OpenThemeData(WindowFromDC(hdc), L"BB::Toolbar")))
+        HTHEME hThemeToolbar = NULL;
+        if (SetThemeHandle(WindowFromDC(hdc), hThemeToolbar, L"BB::Toolbar"))
         {
             if (PaintToolbarSplitDropDown(hdc, iPartId, iStateId, pRect)) {
-                CloseThemeData(theme);
+                CloseThemeData(hThemeToolbar);
                 return S_OK;
             }
-            CloseThemeData(theme);
         }
         if (PaintToolbarButton(hdc, iPartId, iStateId, pRect))
             return S_OK;
@@ -4786,14 +4782,12 @@ HRESULT WINAPI HookedDrawThemeBackground(
             return S_OK;
         // Force menu white glyphs
         else if (iPartId <= MENU_SYSTEMRESTORE && iPartId >= MENU_SYSTEMCLOSE && g_IsSysThemeDarkMode) {
-            HTHEME theme = NULL;
-            HRESULT hr = S_OK;
-            if ((theme = OpenThemeData(WindowFromDC(hdc), L"DarkMode::Menu"))) {
-                hr = DrawThemeBackground_orig(theme, hdc, iPartId, iStateId, pRect, pClipRect);
-                CloseThemeData(theme);
+            HTHEME hThemeMenu = NULL;
+            if (SetThemeHandle(WindowFromDC(hdc), hThemeMenu, L"DarkMode::Menu")) {
+                auto hr = DrawThemeBackground_orig(hThemeMenu, hdc, iPartId, iStateId, pRect, pClipRect);
+                CloseThemeData(hThemeMenu);
                 return hr;
             }
-            CloseThemeData(theme);
         }
     }
     else if (ThemeClassName == L"DragDrop")
@@ -4843,13 +4837,12 @@ HRESULT WINAPI HookedDrawThemeBackground(
         return S_OK;
     }
     else if (ThemeClassName == L"Toolbar" && iPartId == THEMECLS_COMMONPROPS_PART) {
-        HTHEME Toolbar;
-        if ((Toolbar = OpenThemeData(WindowFromDC(hdc), L"Placesbar::Toolbar"))) {
+        HTHEME hThemeToolbar = nullptr;
+        if ((SetThemeHandle(WindowFromDC(hdc), hThemeToolbar, L"Placesbar::Toolbar"))) {
             FillRect(hdc, pRect, (HBRUSH)GetStockObject(BLACK_BRUSH));
-            CloseThemeData(Toolbar);
+            CloseThemeData(hThemeToolbar);
             return S_OK;
         }
-        CloseThemeData(Toolbar);
     }
     return hr;
 }
@@ -4904,22 +4897,23 @@ HRESULT WINAPI HookedDrawThemeBackgroundEx(
     }
     else if (ThemeClassName == L"Progress")
     {
-        HTHEME theme = NULL;
-        if (hTheme == (theme = OpenThemeData(WindowFromDC(hdc), L"Indeterminate::Progress")))
+        HTHEME hThemeProgress = NULL;
+        if (hTheme == SetThemeHandle(WindowFromDC(hdc), hThemeProgress, L"Indeterminate::Progress"))
         {
             if (PaintIndeterminateProgressBar(hdc, iPartId, iStateId, pRect))
             {
-                CloseThemeData(theme);
+                CloseThemeData(hThemeProgress);
                 return S_OK;
             }
-            CloseThemeData(theme);
         }
         else if (PaintProgressBar(hdc, iPartId, iStateId, pRect)) 
         {
-            CloseThemeData(theme);
+            CloseThemeData(hThemeProgress);
             return S_OK;
         }
-        CloseThemeData(theme);
+
+        if (hThemeProgress)
+            CloseThemeData(hThemeProgress);
     } 
     else if (ThemeClassName == L"CommandModule")
     {
@@ -6370,7 +6364,7 @@ VOID LoadWindowProcessRules()
 
             BOOL globalSetting_SetSystenColors = Wh_GetIntSetting(L"RenderingMod.Syscolors");
 
-            // Reset system colors to default values ​​if the "New system colors" setting is disabled for the specific ruled process.
+            // Reset system colors to default values ​​if the system color setting is disabled for the specific ruled process.
             // Hook all necessary API to restore system colors.
             if (!g_settings.SetSystemColors && globalSetting_SetSystenColors) {
                 g_DefaultSysColors = TRUE;

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -222,8 +222,8 @@ thread_local HWND tl_hwndTreeView = nullptr;
 // when custom system colors are applied in global settings.
 BOOL g_DefaultSysColors = FALSE;
 // Global system colors buffers like Windows does.
-std::array<HBRUSH, COLOR_MENUBAR> g_themeCachedCustomSysColorBrushes {nullptr};
-std::array<HBRUSH, COLOR_MENUBAR> g_themeCachedDefaultSysColorBrushes {nullptr};
+std::array<HBRUSH, COLOR_MENUBAR + 1> g_themeCachedCustomSysColorBrushes {nullptr};
+std::array<HBRUSH, COLOR_MENUBAR + 1> g_themeCachedDefaultSysColorBrushes {nullptr};
 SRWLOCK g_SysColorsLock = SRWLOCK_INIT;
 
 // Helpers for resetting theming containers and attributes
@@ -1264,16 +1264,19 @@ COLORREF WINAPI HookedGetSysColor(INT nIndex)
 
 HBRUSH WINAPI HookedGetSysColorBrush(INT nIndex) 
 {
+    if (nIndex < 0 || nIndex > COLOR_MENUBAR)
+        return GetSysColorBrush_orig(nIndex);
+    
     auto& cacheArray = g_DefaultSysColors ? g_themeCachedDefaultSysColorBrushes : g_themeCachedCustomSysColorBrushes;
     
-    HBRUSH cachedBrush = cacheArray[nIndex-1];
+    HBRUSH cachedBrush = cacheArray[nIndex];
     
     if (cachedBrush && GetObjectType(cachedBrush) == OBJ_BRUSH)
         return cachedBrush; 
 
     AcquireSRWLockExclusive(&g_SysColorsLock);
     
-    HBRUSH& refSysBrush = cacheArray[nIndex-1];
+    HBRUSH& refSysBrush = cacheArray[nIndex];
     
     if (refSysBrush && GetObjectType(refSysBrush) != OBJ_BRUSH)
         refSysBrush = NULL; 
@@ -1720,6 +1723,7 @@ public:
 
     BOOL CreateDIB(HDC& elementHdc, INT Width, INT Height)
     {
+        Wh_Log(L"CreateDIB");
         if (elementHdc)
             DeleteHDC(elementHdc);
 
@@ -5209,7 +5213,7 @@ HRESULT STDCALL Hooked_GetBrushesForPart(HTHEME hTheme, int iPartId, COLORREF Co
             return S_OK; 
         }
 
-        // 2. Assign a pure black brush.
+        // 2. Assign a pure black brush. GetStockObject is safer here than 
         // CreateSolidBrush because the stock object cannot be accidentally destroyed.
         if (phBrush) {
             *phBrush = (HBRUSH)GetStockObject(BLACK_BRUSH);

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -978,8 +978,6 @@ BOOL WINAPI HookedExtTextOutW(
 
     EndBufferedPaint(hpb, FALSE);
     return res;
-
-    return res;
 }
 
 // Bypass alpha blending operation done by default (e.g context menus, win32 adressbar) as it is done by our ExtTextOutW hook.
@@ -1276,14 +1274,14 @@ HBRUSH WINAPI HookedGetSysColorBrush(INT nIndex)
 {
     auto& cacheArray = g_DefaultSysColors ? g_themeCachedDefaultSysColorBrushes : g_themeCachedCustomSysColorBrushes;
     
-    HBRUSH cachedBrush = cacheArray[nIndex];
+    HBRUSH cachedBrush = cacheArray[nIndex-1];
     
     if (cachedBrush && GetObjectType(cachedBrush) == OBJ_BRUSH)
         return cachedBrush; 
 
     AcquireSRWLockExclusive(&g_SysColorsLock);
     
-    HBRUSH& refSysBrush = cacheArray[nIndex];
+    HBRUSH& refSysBrush = cacheArray[nIndex-1];
     
     if (refSysBrush && GetObjectType(refSysBrush) != OBJ_BRUSH)
         refSysBrush = NULL; 
@@ -5097,6 +5095,9 @@ static LRESULT WINAPI HookedDefWindowProcW(HWND hWnd, UINT msg, WPARAM wParam, L
                 
                 if (g_settings.AccentColorize)
                     g_settings.AccentColorize = GetAccentColor(g_settings.AccentColor);
+
+                for (HBRUSH brush : g_themeCachedCustomSysColorBrushes)
+                    DeleteObject(brush);
                 
                 if (g_settings.SetSystemColors)
                     ColorizeSysColors();
@@ -6366,9 +6367,12 @@ VOID LoadWindowProcessRules()
                 g_settings.AccentColorize = GetAccentColor(g_settings.AccentColor);
             
             g_settings.SetSystemColors = Wh_GetIntSetting(L"RuledPrograms[%d].RenderingMod.Syscolors", i);
-            // Check if custom system colors have been already applied, 
-            // not need to hook if custom system colors haven't been applied
-            if (!g_settings.SetSystemColors && GetSysColor_orig(COLOR_WINDOW) == RGB(0, 0, 0)) {
+
+            BOOL globalSetting_SetSystenColors = Wh_GetIntSetting(L"RenderingMod.Syscolors");
+
+            // Reset system colors to default values ​​if the "New system colors" setting is disabled for the specific ruled process.
+            // Hook all necessary API to restore system colors.
+            if (!g_settings.SetSystemColors && globalSetting_SetSystenColors) {
                 g_DefaultSysColors = TRUE;
                 WindhawkUtils::SetFunctionHook(GetSysColor, HookedGetSysColor, &GetSysColor_orig);
                 WindhawkUtils::SetFunctionHook(GetSysColorBrush, HookedGetSysColorBrush, &GetSysColorBrush_orig);
@@ -6465,7 +6469,7 @@ VOID Wh_ModUninit(VOID)
         DeleteAtom(g_explorerStylerNoBackgroundEffectAtom);
      
     g_settings.Unload = TRUE;
-    if (g_settings.FillBg)
+    if (g_settings.FillBg && g_d2dFactory)
         g_d2dFactory->Release();
     
     if (g_settings.SetSystemColors)

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -232,6 +232,9 @@ std::wstring GetCurrentWindowsThemePath();
 SRWLOCK g_ThemeChangeLock = SRWLOCK_INIT;
 std::wstring g_LastThemePath = GetCurrentWindowsThemePath();
 
+// Flag to prevent customizing text colors of Task Manager
+BOOL g_InsideTaskMgrProc = FALSE;
+
 using PUNICODE_STRING = PVOID;
 constexpr auto MENUPOPUP_CLASS = L"#32768";
 constexpr UINT THEMECLS_COMMONPROPS_PART = 0;
@@ -5740,7 +5743,7 @@ VOID User32Hooks(BOOL areSysColorsApplied)
 void (__fastcall *SHThemeDrawText_orig)(void*, HDC, int, int, DTTOPTS*, LPCWSTR, LPRECT, int, UINT, int, __int64, COLORREF, COLORREF a13);
 void __fastcall Hooked_SHThemeDrawText(void *a1, HDC a2, int a3, int a4, DTTOPTS *a5, LPCWSTR lpString, LPRECT lprc, int a8, UINT format, int a10, __int64 a11, COLORREF color, COLORREF a13)
 {
-    if (!InTaskManagerProcess())
+    if (!g_InsideTaskMgrProc)
         color = g_IsSysThemeDarkMode && (color & 0x00ffffff) <= RGB(96, 96, 96) ? RGB(255, 255, 255) : !g_IsSysThemeDarkMode ? RGB(0, 0, 0) : color;
     
     SHThemeDrawText_orig(a1, a2, a3, a4, a5, lpString, lprc, a8, format, a10, a11, color, a13);
@@ -6444,6 +6447,8 @@ BOOL Wh_ModInit(VOID)
 {
     if (InExplorerProcess())
         g_explorerStylerNoBackgroundEffectAtom = AddAtom(L"WindhawkFileExplorerStylerNoBackgroundEffect");
+    if (InTaskManagerProcess())
+        g_InsideTaskMgrProc = TRUE;
 
     LoadSettings();
 

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -6365,7 +6365,7 @@ VOID LoadWindowProcessRules()
             if (!g_settings.FillBg && globalSetting_SetSysColorAPI)
                 g_DefaultSysColors = TRUE;
             
-            // Hook all necessary APIs to restore system colors when SetSysColors API hasn't been executed by the mod
+            // Hook all necessary APIs to restore system colors when SetSysColors API has been executed by the mod
             if (g_DefaultSysColors) {
                 WindhawkUtils::SetFunctionHook(GetSysColor, HookedGetSysColor, &GetSysColor_orig);
                 WindhawkUtils::SetFunctionHook(GetSysColorBrush, HookedGetSysColorBrush, &GetSysColorBrush_orig);               

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -5274,19 +5274,20 @@ VOID UxThemeHooks(BOOL isFlyoutEffectEnabled)
     WindhawkUtils::SYMBOL_HOOK uxtheme_dll_hooks[] =
     {   
         // Inlined symbol in ARM64 system, avoid hooking.
-        #if !defined(_M_ARM64)
-        {
+        #ifdef _M_ARM64
+        #else
             {
-                #ifdef _WIN64
-                    L"void __cdecl _BorderRect(struct HDC__ *,unsigned long,struct tagRECT const *,int,int)"
-                #else
-                    L"void __stdcall _BorderRect(struct HDC__ *,unsigned long,struct tagRECT const *,int,int)"
-                #endif
+                {
+                    #ifdef _WIN64
+                        L"void __cdecl _BorderRect(struct HDC__ *,unsigned long,struct tagRECT const *,int,int)"
+                    #else
+                        L"void __stdcall _BorderRect(struct HDC__ *,unsigned long,struct tagRECT const *,int,int)"
+                    #endif
+                },
+                &_BorderRect_orig,
+                Hooked_BorderRect,
+                FALSE
             },
-            &_BorderRect_orig,
-            Hooked_BorderRect,
-            FALSE
-        },
         #endif
         {
             {
@@ -5871,7 +5872,8 @@ VOID Comctl32Hooks()
             FALSE
         },
         // Symbols are inlined in ARM64, avoid hooking.
-        #if !defined(_M_ARM64)
+        #ifdef _M_ARM64
+        #else
             // SHThemeFillTextRect is 64-bit only
             // 32-bit version is implemented inside SHThemeDrawText
             #ifdef _WIN64

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -180,6 +180,22 @@ This is caused by default by the AccentBlur API.❕
 #define RECTWIDTH(lprc)     ((lprc)->right - (lprc)->left)
 #define RECTHEIGHT(lprc)    ((lprc)->bottom - (lprc)->top)
 
+#ifdef _WIN64
+#define THISCALL  __cdecl
+#define _THISCALL L"__cdecl"
+#else
+#define THISCALL  __thiscall
+#define _THISCALL L"__thiscall"
+#endif
+
+#ifdef _WIN64
+#define STDCALL  __cdecl
+#define _STDCALL L"__cdecl"
+#else
+#define STDCALL  __stdcall
+#define _STDCALL L"__stdcall"
+#endif
+
 static constexpr UINT ENABLE = 1;
 static constexpr UINT AUTO = 0; // DWMSBT_AUTO
 //static constexpr UINT NONE = 1; // DWMSBT_NONE
@@ -5169,14 +5185,6 @@ HRESULT WINAPI HookedGetThemeTransitionDuration(HTHEME hTheme, INT iPartId, INT 
     return hr;
 }
 
-#ifdef _WIN64
-#define STDCALL  __cdecl
-#define SSTDCALL L"__cdecl"
-#else
-#define STDCALL  __stdcall
-#define SSTDCALL L"__stdcall"
-#endif
-
 LRESULT (STDCALL *CThemeMenu_MenuKeyboardMsgProc_orig)(INT, WPARAM, LPARAM);
 LRESULT STDCALL HookedCThemeMenu_MenuKeyboardMsgProc_orig(INT code, WPARAM wParam, LPARAM lParam)
 {
@@ -5200,7 +5208,7 @@ LRESULT STDCALL HookedCThemeMenu_MenuKeyboardMsgProc_orig(INT code, WPARAM wPara
 HRESULT (__fastcall *_GetBrushesForPart_orig)(HTHEME, INT, COLORREF, HBITMAP*, HBRUSH*);
 HRESULT __fastcall Hooked_GetBrushesForPart(HTHEME hTheme, INT iPartId, COLORREF Color, HBITMAP *phBitmap, HBRUSH *phBrush)
 {
-    std::wstring ThemeClass = GetThemeClass(hTheme);
+   std::wstring ThemeClass = GetThemeClass(hTheme);
     
     if (ThemeClass == L"Tab" && (iPartId == TABP_BODY || iPartId == TABP_AEROWIZARDBODY)) {
         if (!*phBrush || *phBrush != GetSysColorBrush(COLOR_WINDOW)) {
@@ -5450,7 +5458,7 @@ BOOL GetColorSetting(LPCWSTR hexColor, COLORREF& outColor)
 // User32.dll internal operations in most cases use the gpsi pointer (global pointer shared info) in order to fetch useful attributes about the system session
 // one of them being the system color buffer, gpsi pointing to offest 4568 to system COLORREFs and offset 4696 to system BRUSHES
 //
-// Kernel operations (e.g. win32kfull.sys) use: W32GetUserSessionState() + offset (<20016> as of Win11-26200.8655) + <System color offset>
+// Kernel operations (e.g. win32kfull.sys) use: W32GetUserSessionState() + offset (<20016> as of Win11 26200.8655) + <System color offset>
 //
 // System color offsets:
 //
@@ -5489,57 +5497,88 @@ BOOL GetColorSetting(LPCWSTR hexColor, COLORREF& outColor)
 // ---------------------------------------------------------------------------------------------
 
 // A considerable portion of coloring comes from CTL messages, replace the gpsi pointer inside user32 functions with system colors API getters
-LRESULT (__fastcall *RealDefWindowProcWorker_orig)(struct tagWND*, UINT, WPARAM, LPARAM, UINT);
-LRESULT __fastcall HookedRealDefWindowProcWorker(struct tagWND* pwnd, UINT msg, WPARAM wParam, LPARAM lParam, UINT flags)
+LRESULT MyRealDefWindowProcWorker(UINT msg, WPARAM wParam)
 {
-    switch (msg)
+    COLORREF sysColorBk = 0;
+    COLORREF sysColorTxt = 0;
+    HBRUSH sysBrush = nullptr;
+    if (msg == WM_CTLCOLOR || msg == WM_CTLCOLOREDIT || msg == WM_CTLCOLORLISTBOX)
     {
-        case WM_CTLCOLOR:
-        case WM_CTLCOLORMSGBOX:
-        case WM_CTLCOLOREDIT:
-        case WM_CTLCOLORLISTBOX:
-        case WM_CTLCOLORBTN:
-        case WM_CTLCOLORDLG:
-        case WM_CTLCOLORSCROLLBAR:
-        case WM_CTLCOLORSTATIC:
-        {
-            COLORREF sysColorBk = 0;
-            COLORREF sysColorTxt = 0;
-            HBRUSH sysBrush = nullptr;
-            if (msg == WM_CTLCOLOR || msg == WM_CTLCOLOREDIT || msg == WM_CTLCOLORLISTBOX)
-            {
-                sysColorBk = GetSysColor(COLOR_WINDOW);                                 // Default: *gpsi + 4588 (COLOR_WINDOW)
-                sysColorTxt = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0); // Default: *gpsi + 4600 (COLOR_WINDOWTEXT)
-                sysBrush = GetSysColorBrush(COLOR_WINDOW);                              // Default: *gpsi + 4736 (COLOR_WINDOW)
-            }
-            else if (msg == WM_CTLCOLORMSGBOX || msg == WM_CTLCOLORDLG || msg == WM_CTLCOLORSTATIC)
-            {
-                sysColorBk = GetSysColor(COLOR_BTNFACE);                                // Default: *gpsi + 4628 (COLOR_BTNTEXT)
-                sysColorTxt = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0); // Default: *gpsi + 4600 (COLOR_WINDOWTEXT)
-                sysBrush = GetSysColorBrush(COLOR_BTNFACE);                             // Default: *gpsi + 4816 (COLOR_BTNTEXT)
-            }
-            else if (msg == WM_CTLCOLORBTN)
-            {
-                sysColorBk = GetSysColor(COLOR_BTNFACE);                                // Default: *gpsi + 4628 (COLOR_BTNTEXT)
-                sysColorTxt = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0); // Default: *gpsi + 4816 (COLOR_BTNTEXT)
-                sysBrush = GetSysColorBrush(COLOR_BTNFACE);                             // Default: *gpsi + 4816 (COLOR_BTNTEXT)
-            }
-            else if (msg == WM_CTLCOLORSCROLLBAR)
-            {
-                sysColorBk = GetSysColor(COLOR_BTNHIGHLIGHT);                           // Default: *gpsi + 4648 (COLOR_BTNHIGHLIGHT)
-                sysColorTxt = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0); // Default: *gpsi + 4840 (COLOR_BTNTEXT)
-                sysBrush = GetSysColorBrush(COLOR_BTNHIGHLIGHT);                        // Default: *gpsi + 4856 (COLOR_BTNHIGHLIGHT)
-            }
+        sysColorBk = GetSysColor(COLOR_WINDOW);                                 // Default: *gpsi + 4588 (COLOR_WINDOW)
+        sysColorTxt = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0); // Default: *gpsi + 4600 (COLOR_WINDOWTEXT)
+        sysBrush = GetSysColorBrush(COLOR_WINDOW);                              // Default: *gpsi + 4736 (COLOR_WINDOW)
+    }
+    else if (msg == WM_CTLCOLORMSGBOX || msg == WM_CTLCOLORDLG || msg == WM_CTLCOLORSTATIC)
+    {
+        sysColorBk = GetSysColor(COLOR_BTNFACE);                                // Default: *gpsi + 4628 (COLOR_BTNTEXT)
+        sysColorTxt = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0); // Default: *gpsi + 4600 (COLOR_WINDOWTEXT)
+        sysBrush = GetSysColorBrush(COLOR_BTNFACE);                             // Default: *gpsi + 4816 (COLOR_BTNTEXT)
+    }
+    else if (msg == WM_CTLCOLORBTN)
+    {
+        sysColorBk = GetSysColor(COLOR_BTNFACE);                                // Default: *gpsi + 4628 (COLOR_BTNTEXT)
+        sysColorTxt = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0); // Default: *gpsi + 4816 (COLOR_BTNTEXT)
+        sysBrush = GetSysColorBrush(COLOR_BTNFACE);                             // Default: *gpsi + 4816 (COLOR_BTNTEXT)
+    }
+    else if (msg == WM_CTLCOLORSCROLLBAR)
+    {
+        sysColorBk = GetSysColor(COLOR_BTNHIGHLIGHT);                           // Default: *gpsi + 4648 (COLOR_BTNHIGHLIGHT)
+        sysColorTxt = g_IsSysThemeDarkMode ? RGB(255, 255, 255) : RGB(0, 0, 0); // Default: *gpsi + 4840 (COLOR_BTNTEXT)
+        sysBrush = GetSysColorBrush(COLOR_BTNHIGHLIGHT);                        // Default: *gpsi + 4856 (COLOR_BTNHIGHLIGHT)
+    }
 
-            HDC hdc = reinterpret_cast<HDC>(wParam);
+    HDC hdc = reinterpret_cast<HDC>(wParam);
 
-            SetTextColor(hdc, sysColorTxt);
-            SetBkColor(hdc, sysColorBk);
-            return reinterpret_cast<LRESULT>(sysBrush);
-        }
-    }     
-    return RealDefWindowProcWorker_orig(pwnd, msg, wParam, lParam, flags);
+    SetTextColor(hdc, sysColorTxt);
+    SetBkColor(hdc, sysColorBk);
+    return reinterpret_cast<LRESULT>(sysBrush);
 }
+
+#ifdef _WIN64
+    LRESULT (__fastcall *RealDefWindowProcWorker_orig)(struct tagWND*, UINT, WPARAM, LPARAM, UINT);
+    LRESULT __fastcall HookedRealDefWindowProcWorker(struct tagWND* pwnd, UINT msg, WPARAM wParam, LPARAM lParam, UINT flags)
+    {
+        switch (msg)
+        {
+            case WM_CTLCOLOR:
+            case WM_CTLCOLORMSGBOX:
+            case WM_CTLCOLOREDIT:
+            case WM_CTLCOLORLISTBOX:
+            case WM_CTLCOLORBTN:
+            case WM_CTLCOLORDLG:
+            case WM_CTLCOLORSCROLLBAR:
+            case WM_CTLCOLORSTATIC:
+            {
+                LRESULT res = MyRealDefWindowProcWorker(msg, wParam);
+                return res;
+            }
+        }
+
+        return RealDefWindowProcWorker_orig(pwnd, msg, wParam, lParam, flags);
+    }
+#else
+    LRESULT (__fastcall *RealDefWindowProcWorker_orig)(UINT, WPARAM, struct tagWND*, UINT, LPARAM, UINT);
+    LRESULT __fastcall HookedRealDefWindowProcWorker(UINT msg, WPARAM wParam, struct tagWND* pwnd, UINT msg_dup, LPARAM lParam, UINT flags)
+    {
+        switch (msg)
+        {
+            case WM_CTLCOLOR:
+            case WM_CTLCOLORMSGBOX:
+            case WM_CTLCOLOREDIT:
+            case WM_CTLCOLORLISTBOX:
+            case WM_CTLCOLORBTN:
+            case WM_CTLCOLORDLG:
+            case WM_CTLCOLORSCROLLBAR:
+            case WM_CTLCOLORSTATIC:
+            {
+                LRESULT res = MyRealDefWindowProcWorker(msg, wParam);
+                return res;
+            }
+        }
+
+        return RealDefWindowProcWorker_orig(msg, wParam, pwnd, msg_dup, lParam, flags);
+    }
+#endif
 
 // Paints the background of message boxes
 HBRUSH (STDCALL *MB_DlgProc_orig)(HWND, UINT, WPARAM, LPARAM);
@@ -5551,8 +5590,8 @@ HBRUSH STDCALL Hooked_MB_DlgProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPar
 }
 
 // Paints the lower part of message boxes
-void (STDCALL *DrawCommandRectangle_orig)(HWND);
-void STDCALL Hooked_DrawCommandRectangle(HWND hWnd)
+void (THISCALL *DrawCommandRectangle_orig)(HWND);
+void THISCALL Hooked_DrawCommandRectangle(HWND hWnd)
 {
     PAINTSTRUCT ps{};
     HDC hdc = BeginPaint(hWnd, &ps);
@@ -5785,21 +5824,21 @@ COLORREF __fastcall HookedFillRectClr(HDC hdc, LPRECT lprect, COLORREF color)
     return color;
 }
 
-// Listbox background fill color return COLOR_WINDOW system color
+// As of Win11 26200.8655 - Listbox background fill color return COLOR_WINDOW system color
 // We return white color so the black text inside listboxes are readable on system light theme.
-HBRUSH (STDCALL *ListBox_GetBrush_orig)(struct tagLBIV*, HBRUSH*);
-HBRUSH STDCALL HookedListBox_GetBrush(struct tagLBIV *a1, HBRUSH *hbr)
+HBRUSH (__fastcall *ListBox_GetBrush_orig)(struct tagLBIV*, HBRUSH*);
+HBRUSH __fastcall HookedListBox_GetBrush(struct tagLBIV *a1, HBRUSH *hbr)
 {   
     // Default return brush: GetSysColorBrush(COLOR_WINDOW)
     HBRUSH ret = g_IsSysThemeDarkMode ? ListBox_GetBrush_orig(a1, hbr) : (HBRUSH)GetStockObject(WHITE_BRUSH);
     return ret;
 }
 
-// The ComboBox control (e.g., the Windows address bar) draws an internal rectangle using a brush with the COLOR_WINDOW system color.
+// As of Win11 26200.8655 - The ComboBox control (e.g., the Windows address bar) draws an internal rectangle using a brush with the COLOR_WINDOW system color.
 // Since the custom COLOR_WINDOW is black, whereas the rest of the ComboBox control's background is intended to be drawn in white,
 // we intervene to correct this behavior in light theme mode.
-void (STDCALL *ComboEx_OnDrawItem_orig)(struct COMBOEX*, struct tagDRAWITEMSTRUCT*);
-void STDCALL HookedComboEx_OnDrawItem(struct COMBOEX *a1, struct tagDRAWITEMSTRUCT *a2)
+void (__fastcall *ComboEx_OnDrawItem_orig)(struct COMBOEX*, struct tagDRAWITEMSTRUCT*);
+void __fastcall HookedComboEx_OnDrawItem(struct COMBOEX *a1, struct tagDRAWITEMSTRUCT *a2)
 {
     if (!g_IsSysThemeDarkMode) 
     {
@@ -5917,8 +5956,8 @@ BOOL CThemeCache::CacheNavigationDivider()
 }
 
 // Render custom D2D alpha blended navigation pane divider
-void (__thiscall *CNscTree_DrawDivider_orig)(class CNscTree* , HDC, struct _TREEITEM*);
-void __thiscall Hooked_CNscTree_DrawDivider(CNscTree *__this, HDC hdc, struct _TREEITEM *hTreeItem)
+void (THISCALL *CNscTree_DrawDivider_orig)(class CNscTree* , HDC, struct _TREEITEM*);
+void THISCALL Hooked_CNscTree_DrawDivider(CNscTree *__this, HDC hdc, struct _TREEITEM *hTreeItem)
 {
     auto Fallback = [&](LPCWSTR errorMessage = NULL) {
         if (errorMessage)
@@ -5927,7 +5966,7 @@ void __thiscall Hooked_CNscTree_DrawDivider(CNscTree *__this, HDC hdc, struct _T
         return;
     };
 
-    // As of Win11 26200.8737 hwnd offsets 64-bit: offset 50, 32-bit: offset 61
+    // As of Win11 26200.8737 - hwnd offsets 64-bit: offset 50, 32-bit: offset 61
     auto GetTreeViewHWND = [&__this]() 
     {
         #ifdef _WIN64
@@ -6129,6 +6168,7 @@ LRESULT STDCALL HookedCFileNameComboBox_s_ComboBoxRootSubclass(HWND hWnd, UINT u
     return reinterpret_cast<LRESULT>(GetSysColorBrush(COLOR_WINDOW));
 }
 
+// Paint the explorer dialogs editbox background
 BOOL (STDCALL *CComboBoxExBase_OnWinEvent_orig)(class CComboBoxExBase *, HWND, UINT, HDC, LPARAM, LRESULT*);
 BOOL STDCALL HookedCComboBoxExBase_OnWinEvent(class CComboBoxExBase *__this, HWND hWnd, UINT uMsg, HDC hdc, LPARAM lParam, LRESULT* pResult)
 {

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -73,6 +73,8 @@ apps with different front-end rendering (e.g Qt, Electron, Chromium etc.. progra
 * ⚠️If parts of the Windows UI colors remain modified after disabling the modification, this is happening when new system colors are applied in a selected Windows custom theme.
 Changing the theme to the default and vice versa fixes the problem. As a last resort, you can delete the registry key HKEY_CURRENT_USER\Control Panel\Colors and reboot.⚠️
 
+* ⚠️From version 1.8 ARM64 system is partially supported.⚠️
+
 * ❕The blur effect may show a bleeding effect at the edges of a window when maximized or snapped to the edge of the screen. 
 This is caused by default by the AccentBlur API.❕
 
@@ -6092,7 +6094,7 @@ void RecolorBrandingLogoBackground(HBITMAP hbm)
 // Winver loads the bitmap using LoadAboutBitmaps() routine, shutdown dialog using LoadBrandingBitmap().
 HANDLE (STDCALL *BrandingLoadImage_orig)(LPCWSTR, UINT, UINT, INT, INT, UINT);
 HANDLE STDCALL HookedBrandingLoadImage(LPCWSTR pszBrand, UINT uID, UINT type, INT cx, INT cy, UINT  fuLoad)
-{    
+{   
     auto hImage = BrandingLoadImage_orig(pszBrand, uID, type, cx, cy, fuLoad);
 
     // The image resource is fetched from basebrd.dll resource image 121.

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -5274,7 +5274,7 @@ VOID UxThemeHooks(BOOL isFlyoutEffectEnabled)
     WindhawkUtils::SYMBOL_HOOK uxtheme_dll_hooks[] =
     {   
         // Inlined symbol in ARM64 system, avoid hooking.
-        #ifndef _M_ARM64
+        #if !defined(_M_ARM64)
         {
             {
                 #ifdef _WIN64
@@ -5871,7 +5871,7 @@ VOID Comctl32Hooks()
             FALSE
         },
         // Symbols are inlined in ARM64, avoid hooking.
-        #ifndef _M_ARM64
+        #if !defined(_M_ARM64)
             // SHThemeFillTextRect is 64-bit only
             // 32-bit version is implemented inside SHThemeDrawText
             #ifdef _WIN64

--- a/mods/translucent-windows.wh.cpp
+++ b/mods/translucent-windows.wh.cpp
@@ -73,7 +73,7 @@ apps with different front-end rendering (e.g Qt, Electron, Chromium etc.. progra
 * ⚠️If parts of the Windows UI colors remain modified after disabling the modification, this is happening when new system colors are applied in a selected Windows custom theme.
 Changing the theme to the default and vice versa fixes the problem. As a last resort, you can delete the registry key HKEY_CURRENT_USER\Control Panel\Colors and reboot.⚠️
 
-* ⚠️From version 1.8 ARM64 system is partially supported.⚠️
+* ⚠️ARM64 system is only partially supported.⚠️
 
 * ❕The blur effect may show a bleeding effect at the edges of a window when maximized or snapped to the edge of the screen. 
 This is caused by default by the AccentBlur API.❕
@@ -5272,7 +5272,9 @@ void __fastcall Hooked_BorderRect(HDC hdc, COLORREF color, LPRECT pRect, INT cxT
 VOID UxThemeHooks(BOOL isFlyoutEffectEnabled)
 {
     WindhawkUtils::SYMBOL_HOOK uxtheme_dll_hooks[] =
-    {    
+    {   
+        // Inlined symbol in ARM64 system, avoid hooking.
+        #ifndef _M_ARM64
         {
             {
                 #ifdef _WIN64
@@ -5285,7 +5287,7 @@ VOID UxThemeHooks(BOOL isFlyoutEffectEnabled)
             Hooked_BorderRect,
             FALSE
         },
-        
+        #endif
         {
             {
                 #ifdef _WIN64
@@ -5868,42 +5870,45 @@ VOID Comctl32Hooks()
             Hooked_SHThemeDrawText,
             FALSE
         },
-        // SHThemeFillTextRect is 64-bit only
-        // 32-bit version is implemented inside SHThemeDrawText
-        #ifdef _WIN64
-        {
+        // Symbols are inlined in ARM64, avoid hooking.
+        #ifndef _M_ARM64
+            // SHThemeFillTextRect is 64-bit only
+            // 32-bit version is implemented inside SHThemeDrawText
+            #ifdef _WIN64
             {
-                L"SHThemeFillTextRect"
+                {
+                    L"SHThemeFillTextRect"
+                },
+                &SHThemeFillTextRect_orig,
+                HookedSHThemeFillTextRect,
+                FALSE
             },
-            &SHThemeFillTextRect_orig,
-            HookedSHThemeFillTextRect,
-            FALSE
-        },
+            #endif
+            {
+                {
+                    #ifdef _WIN64
+                        L"FillRectClr"
+                    #else
+                        L"_FillRectClr@12"
+                    #endif
+                },
+                &FillRectClr_orig,
+                HookedFillRectClr,
+                FALSE
+            },
+            {
+                {
+                    #ifdef _WIN64
+                        L"struct HBRUSH__ * __cdecl ListBox_GetBrush(struct tagLBIV *,struct HBRUSH__ * *)"
+                    #else
+                        L"struct HBRUSH__ * __stdcall ListBox_GetBrush(struct tagLBIV *,struct HBRUSH__ * *)"
+                    #endif
+                },
+                &ListBox_GetBrush_orig,
+                HookedListBox_GetBrush,
+                FALSE
+            },
         #endif
-        {
-            {
-                #ifdef _WIN64
-                    L"FillRectClr"
-                #else
-                    L"_FillRectClr@12"
-                #endif
-            },
-            &FillRectClr_orig,
-            HookedFillRectClr,
-            FALSE
-        },
-        {
-            {
-                #ifdef _WIN64
-                    L"struct HBRUSH__ * __cdecl ListBox_GetBrush(struct tagLBIV *,struct HBRUSH__ * *)"
-                #else
-                    L"struct HBRUSH__ * __stdcall ListBox_GetBrush(struct tagLBIV *,struct HBRUSH__ * *)"
-                #endif
-            },
-            &ListBox_GetBrush_orig,
-            HookedListBox_GetBrush,
-            FALSE
-        },
         {
             {
                 #ifdef _WIN64


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Some settings that can be considered outside the scope of translucent effects are removed due to my limited free time to maintain these features, fortunately the Windhawk community has provided some separate mods for those listed below.
* Settings removed:
	- Border color setting - replacement: [Window Border Customizer](https://windhawk.net/mods/window-border-customizer) by [Lockframe](https://github.com/Lockframe).
	- Titlebar color - replacement: [Auto Custom Title Bar Colors](https://windhawk.net/mods/auto-custom-titlebar-colors) by [Louis047](https://github.com/Louis047).
	- Window Corner Type - replacement: [Custom Window Corner Radius](https://windhawk.net/mods/custom-corner-radius) by [m417z](https://github.com/m417z).
	- Titlebar text color. 
	- Rainbow effect - Very high performance overhead, e.g. 30% usage on a modern midrange GPU.
	- Extend effects into entire window - Will be enabled by default when a translucent effect is selected.
	- Immersive darkmode title bar - Will be enabled by default when the system is in dark mode.

* Added compatibility with [Windows 11 File Explorer Styler](https://windhawk.net/mods/windows-11-file-explorer-styler).
* System color improvements without the need to apply the SetSysColors API - Global setting "New system colors". Related topic: https://github.com/ramensoftware/windhawk-mods/issues/2010
* Processes launching from given subdirectories can be ruled/excluded as a whole in the mod settings.

* Numerous improvements and additions to theme customization.
	- Fixed chevron arrow scaling in treeview.
	- Improved buttons pill (e.g. treeview, tabs)
	- Fixed properties window background coloring without the need to restart explorer.
	- Adjusted the size of the custom scrollbar close to the original.
	- Recolored black text in dark mode (e.g. syslinks, address bar dropdown text, context menu icons)
	- Alpha blended more UI elements (e.g. treeview separator, highlighted text accent background)
	- Removed dark gray bottom part in explorer dialogs in dark mode (e.g. Open/Save dialogs)
	- Removed Windows brand logo background in dialogs (e.g. winver.exe)
	- Improved text composition performance.
## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
