### PR TITLE
Add new mod: Faster Notifications Settings Page v1.3

### DIFF
--- a/mods/notifications-settings-page-speedup.wh.cpp
+++ b/mods/notifications-settings-page-speedup.wh.cpp
@@ -1,0 +1,267 @@
+// ==WindhawkMod==
+// @id              notifications-settings-page-speedup
+// @name            Faster Notifications Settings Page
+// @description     Stops Settings from re-scanning every notification app on each visit, so revisits load in seconds instead of minutes
+// @version         1.0
+// @author          mario0318
+// @github          https://github.com/mario0318
+// @include         SystemSettings.exe
+// @compilerOptions -lshlwapi
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Faster Notifications Settings Page
+
+**Settings, System, Notifications** rebuilds its full app list every time you
+open the page, including when you edit one app and press Back. With many
+notification senders this takes **minutes, on every visit**.
+
+This mod keeps the first open as-is (it fills a cache) and makes every visit
+after that load in a couple of seconds. It skips a per-app summary line (see the
+trade-off below) and caches each app's settings object across visits so the page
+stops repeating a slow per-app cross-process call. The cached objects read live
+data, so **your edits still show correctly** and nothing goes stale.
+
+Both options default on and can be turned off in the mod's settings, which
+reverts the page to normal instantly. Press **Ctrl+Alt+R** to clear the cache
+and force a full rescan.
+
+## The summary trade-off
+
+Most of the speedup comes from skipping a per-app summary. Normally each app in
+the list shows a small subtitle summarizing part of its setup, such as whether
+banners or sounds are on. With this skipped, every app still shows its **name,
+icon, and main on/off toggle**, and you can still open any app to see and change
+**all** of its options. You only lose the at-a-glance subtitle. If you would
+rather keep it, turn off **Skip per-app summary lookup** below; revisits are
+still cached, just a bit slower.
+
+The first open after a fresh sign-in is still slow; only revisits are fast. The
+mod hooks internal functions in `SettingsHandlers_Notifications.dll` by symbol,
+so it may need an update after a major Windows release. Tested on Windows 11.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- skipSummary: true
+  $name: Skip per-app summary lookup
+  $description: The largest single speedup. Each app still shows its name, icon, and main on/off toggle, but loses the small subtitle summarizing banners/sounds status. You can still open any app to see and change those. Turn off to keep the subtitle (revisits stay cached, just a bit slower).
+- cacheSettings: true
+  $name: Cache app settings across visits
+  $description: Makes revisiting the page fast. Cached objects read live data, so your edits are still reflected. Turn off if the list ever renders incorrectly.
+*/
+// ==/WindhawkModSettings==
+
+#include <windhawk_utils.h>
+#include <shlwapi.h>
+#include <string>
+#include <unordered_map>
+#include <shared_mutex>
+#include <atomic>
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+static std::atomic<bool> g_skipSummary{true};
+static std::atomic<bool> g_cacheSettings{true};
+
+// ---------------------------------------------------------------------------
+// Per-AUMID cache of each app's IAumidNotificationSettings object.
+//
+// EnumerateAppSettingItems -> _AddEntry(aumid) per app -> controller
+// ->vtable[0x70](aumid, &settings). The controller is an out-of-process COM
+// object (CoCreateInstanceAsUser / MainNotificationController), so that call is
+// a cross-process activation (~150-300ms each). We vtable-hook that slot: the
+// first visit populates the cache, revisits reuse the live objects and skip the
+// activation. Reads still hit the broker, so edits are reflected (no staleness).
+// ---------------------------------------------------------------------------
+static const size_t CTRL_PTR_OFFSET       = 0x108; // helper -> controller ComPtr
+static const size_t GETSETTINGS_VTBL_SLOT = 14;    // 0x70 / sizeof(void*)
+
+static std::unordered_map<std::wstring, IUnknown*> g_cache; // aumid -> settings obj
+static std::shared_mutex g_cacheMutex;
+static void** g_vtblSlot = nullptr;
+static std::atomic<bool> g_vtblHooked{false};
+static volatile bool g_running = true;
+
+static void FlushCache() {
+    std::unique_lock lock(g_cacheMutex);
+    for (auto& kv : g_cache)
+        if (kv.second) kv.second->Release();
+    g_cache.clear();
+    Wh_Log(L"cache cleared (manual rescan)");
+}
+
+// The controller vtable slot: HRESULT(controller, PCWSTR aumid, IUnknown** out)
+using GetSettings_t = HRESULT (STDMETHODCALLTYPE*)(void*, PCWSTR, void**);
+static GetSettings_t GetSettings_Orig = nullptr;
+
+HRESULT STDMETHODCALLTYPE GetSettings_Hook(void* self, PCWSTR aumid, void** out) {
+    if (g_cacheSettings.load() && aumid && out) {
+        {
+            std::shared_lock lk(g_cacheMutex);
+            auto it = g_cache.find(aumid);
+            if (it != g_cache.end()) {
+                it->second->AddRef();
+                *out = it->second;
+                return S_OK;
+            }
+        }
+        HRESULT hr = GetSettings_Orig(self, aumid, out);
+        if (SUCCEEDED(hr) && *out) {
+            IUnknown* p = reinterpret_cast<IUnknown*>(*out);
+            p->AddRef();
+            std::unique_lock lk(g_cacheMutex);
+            g_cache.emplace(aumid, p);
+        }
+        return hr;
+    }
+    return GetSettings_Orig(self, aumid, out);
+}
+
+static void HookControllerVtable(void* helper) {
+    if (g_vtblHooked.load()) return;
+    void* controller = *reinterpret_cast<void**>(
+        reinterpret_cast<char*>(helper) + CTRL_PTR_OFFSET);
+    if (!controller) return;                 // controller not created yet
+    if (g_vtblHooked.exchange(true)) return;
+    void** vtbl = *reinterpret_cast<void***>(controller);
+    g_vtblSlot = &vtbl[GETSETTINGS_VTBL_SLOT];
+    DWORD oldProtect;
+    if (VirtualProtect(g_vtblSlot, sizeof(void*), PAGE_READWRITE, &oldProtect)) {
+        GetSettings_Orig = reinterpret_cast<GetSettings_t>(*g_vtblSlot);
+        *g_vtblSlot = reinterpret_cast<void*>(GetSettings_Hook);
+        VirtualProtect(g_vtblSlot, sizeof(void*), oldProtect, &oldProtect);
+        Wh_Log(L"settings cache active (controller vtable hooked)");
+    } else {
+        g_vtblHooked = false;
+        Wh_Log(L"VirtualProtect failed; settings cache disabled");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Symbol hooks in SettingsHandlers_Notifications.dll
+// ---------------------------------------------------------------------------
+
+// NotificationsAppListHelper::_AddEntry(aumid, ...) runs once per app. We use it
+// only as a reliable trigger: after the first entry the controller exists at
+// helper+0x108, and we patch its vtable once (the patch persists for later visits).
+using AddEntry_t = HRESULT (__cdecl*)(void* helper, PCWSTR aumid, unsigned long long opt);
+static AddEntry_t AddEntry_Orig = nullptr;
+HRESULT __cdecl AddEntry_Hook(void* helper, PCWSTR aumid, unsigned long long opt) {
+    HookControllerVtable(helper); // no-op after the vtable is patched
+    return AddEntry_Orig(helper, aumid, opt);
+}
+
+// AppInfo::PopulateSummaryValues(void) -> HRESULT. Skipped when enabled.
+using PopSummary_t = HRESULT (__cdecl*)(void* self);
+static PopSummary_t PopSummary_Orig = nullptr;
+HRESULT __cdecl PopSummary_Hook(void* self) {
+    if (g_skipSummary.load()) return S_OK;
+    return PopSummary_Orig(self);
+}
+
+static std::atomic<bool> g_symHooked{false};
+static void HookHandlerDll(bool applyNow) {
+    if (g_symHooked.exchange(true)) return;
+    HMODULE h = GetModuleHandleW(L"SettingsHandlers_Notifications.dll");
+    if (!h) { g_symHooked = false; return; }
+
+    // SettingsHandlers_Notifications.dll
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+        {
+            {L"private: long __cdecl SystemSettings::NotificationsDataModel::NotificationsAppListHelper::_AddEntry(unsigned short const *,class std::optional<enum __MIDL___MIDL_itf_notificationsettings_0000_0000_0001>)"},
+            (void**)&AddEntry_Orig,
+            (void*)AddEntry_Hook,
+            false,
+        },
+        {
+            {L"private: long __cdecl SystemSettings::NotificationsDataModel::AppInfo::PopulateSummaryValues(void)"},
+            (void**)&PopSummary_Orig,
+            (void*)PopSummary_Hook,
+            false,
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks))) {
+        g_symHooked = false;                    // symbols not ready; watcher retries
+        Wh_Log(L"HookSymbols failed (symbols not ready?)");
+        return;
+    }
+
+    if (applyNow) Wh_ApplyHookOperations();
+    Wh_Log(L"installed symbol hooks");
+}
+
+// The handler DLL loads on demand when the Notifications page opens.
+using LoadLibraryExW_t = HMODULE (WINAPI*)(LPCWSTR, HANDLE, DWORD);
+static LoadLibraryExW_t LoadLibraryExW_Orig;
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR name, HANDLE file, DWORD flags) {
+    HMODULE m = LoadLibraryExW_Orig(name, file, flags);
+    if (m && name && StrStrIW(name, L"SettingsHandlers_Notifications"))
+        HookHandlerDll(true);
+    return m;
+}
+
+// Fallback in case the DLL loads via a path our LoadLibraryExW hook misses.
+DWORD WINAPI WatchThread(LPVOID) {
+    for (int i = 0; i < 600 && g_running; ++i) {
+        if (!g_symHooked.load() &&
+            GetModuleHandleW(L"SettingsHandlers_Notifications.dll"))
+            HookHandlerDll(true);
+        Sleep(200);
+    }
+    return 0;
+}
+
+// Ctrl+Alt+R clears the cache -> next visit does a full rescan.
+DWORD WINAPI HotkeyThread(LPVOID) {
+    while (g_running) {
+        if ((GetAsyncKeyState(VK_CONTROL) & 0x8000) &&
+            (GetAsyncKeyState(VK_MENU) & 0x8000) &&
+            (GetAsyncKeyState('R') & 0x8000)) {
+            FlushCache();
+            Sleep(500);
+        }
+        Sleep(50);
+    }
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+static void LoadSettings() {
+    g_skipSummary   = Wh_GetIntSetting(L"skipSummary") != 0;
+    g_cacheSettings = Wh_GetIntSetting(L"cacheSettings") != 0;
+}
+
+BOOL Wh_ModInit() {
+    LoadSettings();
+
+    WindhawkUtils::SetFunctionHook((void*)LoadLibraryExW, (void*)LoadLibraryExW_Hook,
+                                   (void**)&LoadLibraryExW_Orig);
+    HookHandlerDll(false); // in case the DLL is already loaded
+
+    CreateThread(nullptr, 0, WatchThread, nullptr, 0, nullptr);
+    CreateThread(nullptr, 0, HotkeyThread, nullptr, 0, nullptr);
+    return TRUE;
+}
+
+void Wh_ModSettingsChanged() { LoadSettings(); }
+
+void Wh_ModUninit() {
+    g_running = false;
+    Sleep(120);
+    if (g_vtblHooked.load() && g_vtblSlot && GetSettings_Orig) {
+        DWORD oldProtect;
+        if (VirtualProtect(g_vtblSlot, sizeof(void*), PAGE_READWRITE, &oldProtect)) {
+            *g_vtblSlot = reinterpret_cast<void*>(GetSettings_Orig);
+            VirtualProtect(g_vtblSlot, sizeof(void*), oldProtect, &oldProtect);
+        }
+    }
+    std::unique_lock lock(g_cacheMutex);
+    for (auto& kv : g_cache)
+        if (kv.second) kv.second->Release();
+    g_cache.clear();
+}

--- a/mods/notifications-settings-page-speedup.wh.cpp
+++ b/mods/notifications-settings-page-speedup.wh.cpp
@@ -58,6 +58,7 @@ so it may need an update after a major Windows release. Tested on Windows 11.
 #include <shlwapi.h>
 #include <string>
 #include <unordered_map>
+#include <vector>
 #include <shared_mutex>
 #include <atomic>
 
@@ -67,29 +68,53 @@ so it may need an update after a major Windows release. Tested on Windows 11.
 static std::atomic<bool> g_skipSummary{true};
 static std::atomic<bool> g_cacheSettings{true};
 
+// Set on unload so the worker threads exit their waits at once instead of being
+// left to run into unmapped code.
+static HANDLE g_stopEvent = nullptr;
+
 // ---------------------------------------------------------------------------
 // Per-AUMID cache of each app's IAumidNotificationSettings object.
 //
 // EnumerateAppSettingItems -> _AddEntry(aumid) per app -> controller
 // ->vtable[0x70](aumid, &settings). The controller is an out-of-process COM
 // object (CoCreateInstanceAsUser / MainNotificationController), so that call is
-// a cross-process activation (~150-300ms each). We vtable-hook that slot: the
-// first visit populates the cache, revisits reuse the live objects and skip the
+// a cross-process activation (~150-300ms each). We hook that slot: the first
+// visit populates the cache, revisits reuse the live objects and skip the
 // activation. Reads still hit the broker, so edits are reflected (no staleness).
+//
+// The cached objects are apartment-bound proxies owned by the Settings UI
+// thread (the thread that runs _AddEntry / the controller call). They must be
+// released on that thread, so a flush hands them to g_pendingRelease and the
+// next _AddEntry drains it on the UI thread instead of releasing cross-apartment.
 // ---------------------------------------------------------------------------
 static const size_t CTRL_PTR_OFFSET       = 0x108; // helper -> controller ComPtr
 static const size_t GETSETTINGS_VTBL_SLOT = 14;    // 0x70 / sizeof(void*)
 
 static std::unordered_map<std::wstring, IUnknown*> g_cache; // aumid -> settings obj
+static std::vector<IUnknown*> g_pendingRelease;             // freed on the UI thread
 static std::shared_mutex g_cacheMutex;
 static void** g_vtblSlot = nullptr;
 static std::atomic<bool> g_vtblHooked{false};
-static volatile bool g_running = true;
 
+// Release proxies queued by a flush. Called from _AddEntry, i.e. the UI thread
+// that owns the objects, so the release stays inside their apartment.
+static void DrainPendingReleases() {
+    std::vector<IUnknown*> toRelease;
+    {
+        std::unique_lock lock(g_cacheMutex);
+        if (g_pendingRelease.empty()) return;
+        toRelease.swap(g_pendingRelease);
+    }
+    for (IUnknown* p : toRelease)
+        if (p) p->Release();
+}
+
+// Ctrl+Alt+R: hand the cached objects to the UI thread for release, then the
+// next page open does a full rescan.
 static void FlushCache() {
     std::unique_lock lock(g_cacheMutex);
     for (auto& kv : g_cache)
-        if (kv.second) kv.second->Release();
+        if (kv.second) g_pendingRelease.push_back(kv.second);
     g_cache.clear();
     Wh_Log(L"cache cleared (manual rescan)");
 }
@@ -114,20 +139,45 @@ HRESULT STDMETHODCALLTYPE GetSettings_Hook(void* self, PCWSTR aumid, void** out)
             IUnknown* p = reinterpret_cast<IUnknown*>(*out);
             p->AddRef();
             std::unique_lock lk(g_cacheMutex);
-            g_cache.emplace(aumid, p);
+            auto [it, inserted] = g_cache.emplace(aumid, p);
+            if (!inserted) p->Release();  // another thread cached it first
         }
         return hr;
     }
     return GetSettings_Orig(self, aumid, out);
 }
 
+// Reject a garbage controller pointer (e.g. if the +0x108 layout shifts on a
+// future build) before dereferencing it as a vtable, so a bad build no-ops
+// instead of crashing SystemSettings.
+static bool MemReadable(const void* p) {
+    MEMORY_BASIC_INFORMATION mbi{};
+    if (!VirtualQuery(p, &mbi, sizeof(mbi)) || mbi.State != MEM_COMMIT) return false;
+    return !(mbi.Protect & (PAGE_NOACCESS | PAGE_GUARD));
+}
+static bool MemExecutable(const void* p) {
+    MEMORY_BASIC_INFORMATION mbi{};
+    if (!VirtualQuery(p, &mbi, sizeof(mbi)) || mbi.State != MEM_COMMIT) return false;
+    const DWORD exec = PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE |
+                       PAGE_EXECUTE_WRITECOPY;
+    return (mbi.Protect & exec) != 0;
+}
+
 static void HookControllerVtable(void* helper) {
     if (g_vtblHooked.load()) return;
+
     void* controller = *reinterpret_cast<void**>(
         reinterpret_cast<char*>(helper) + CTRL_PTR_OFFSET);
-    if (!controller) return;                 // controller not created yet
-    if (g_vtblHooked.exchange(true)) return;
+    if (!controller || !MemReadable(controller)) return;  // not created yet / bad ptr
+
     void** vtbl = *reinterpret_cast<void***>(controller);
+    if (!vtbl || !MemReadable(vtbl)) return;
+
+    void* target = vtbl[GETSETTINGS_VTBL_SLOT];
+    if (!target || !MemExecutable(target)) return;
+
+    if (g_vtblHooked.exchange(true)) return;
+
     g_vtblSlot = &vtbl[GETSETTINGS_VTBL_SLOT];
     DWORD oldProtect;
     if (VirtualProtect(g_vtblSlot, sizeof(void*), PAGE_READWRITE, &oldProtect)) {
@@ -145,13 +195,15 @@ static void HookControllerVtable(void* helper) {
 // Symbol hooks in SettingsHandlers_Notifications.dll
 // ---------------------------------------------------------------------------
 
-// NotificationsAppListHelper::_AddEntry(aumid, ...) runs once per app. We use it
-// only as a reliable trigger: after the first entry the controller exists at
-// helper+0x108, and we patch its vtable once (the patch persists for later visits).
+// NotificationsAppListHelper::_AddEntry(aumid, ...) runs once per app on the
+// Settings UI thread. We use it as a reliable trigger: after the first entry the
+// controller exists at helper+0x108, and we patch its vtable once. It is also
+// where we drain proxies queued by a flush, since this is their owning thread.
 using AddEntry_t = HRESULT (__cdecl*)(void* helper, PCWSTR aumid, unsigned long long opt);
 static AddEntry_t AddEntry_Orig = nullptr;
 HRESULT __cdecl AddEntry_Hook(void* helper, PCWSTR aumid, unsigned long long opt) {
-    HookControllerVtable(helper); // no-op after the vtable is patched
+    DrainPendingReleases();
+    HookControllerVtable(helper);  // no-op after the vtable is patched
     return AddEntry_Orig(helper, aumid, opt);
 }
 
@@ -186,7 +238,7 @@ static void HookHandlerDll(bool applyNow) {
     };
 
     if (!WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks))) {
-        g_symHooked = false;                    // symbols not ready; watcher retries
+        g_symHooked = false;  // symbols not ready; the watcher retries
         Wh_Log(L"HookSymbols failed (symbols not ready?)");
         return;
     }
@@ -195,7 +247,11 @@ static void HookHandlerDll(bool applyNow) {
     Wh_Log(L"installed symbol hooks");
 }
 
-// The handler DLL loads on demand when the Notifications page opens.
+// The handler DLL loads on demand when the Notifications page opens. Hooking the
+// imported LoadLibraryExW catches that load; a short watcher backs it up for
+// load paths this hook misses. (Hooking kernelbase's LoadLibraryExW directly
+// would catch every path but fast-fails SystemSettings under CFG, so it is not
+// used here.)
 using LoadLibraryExW_t = HMODULE (WINAPI*)(LPCWSTR, HANDLE, DWORD);
 static LoadLibraryExW_t LoadLibraryExW_Orig;
 HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR name, HANDLE file, DWORD flags) {
@@ -205,28 +261,48 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR name, HANDLE file, DWORD flags) {
     return m;
 }
 
-// Fallback in case the DLL loads via a path our LoadLibraryExW hook misses.
+// Backstop for a load the LoadLibraryExW hook misses. Waits on g_stopEvent so it
+// exits at once on unload instead of sleeping into unmapped code.
+static HANDLE g_watchThread = nullptr;
 DWORD WINAPI WatchThread(LPVOID) {
-    for (int i = 0; i < 600 && g_running; ++i) {
+    for (int i = 0; i < 600; ++i) {
         if (!g_symHooked.load() &&
             GetModuleHandleW(L"SettingsHandlers_Notifications.dll"))
             HookHandlerDll(true);
-        Sleep(200);
+        if (WaitForSingleObject(g_stopEvent, 200) == WAIT_OBJECT_0)
+            break;
     }
     return 0;
 }
 
-// Ctrl+Alt+R clears the cache -> next visit does a full rescan.
+// ---------------------------------------------------------------------------
+// Ctrl+Alt+R clears the cache. RegisterHotKey needs a message loop, so it runs
+// on its own thread that exits on WM_QUIT (posted from Wh_ModUninit) and is
+// joined before unload.
+// ---------------------------------------------------------------------------
+static HANDLE g_hotkeyThread = nullptr;
+static DWORD  g_hotkeyThreadId = 0;
+static HANDLE g_hotkeyReady = nullptr;  // set once the thread's queue exists
+static const int HOTKEY_ID = 1;
+
 DWORD WINAPI HotkeyThread(LPVOID) {
-    while (g_running) {
-        if ((GetAsyncKeyState(VK_CONTROL) & 0x8000) &&
-            (GetAsyncKeyState(VK_MENU) & 0x8000) &&
-            (GetAsyncKeyState('R') & 0x8000)) {
+    // Force the message queue to exist so Wh_ModUninit's PostThreadMessage lands.
+    MSG msg;
+    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+
+    bool registered =
+        RegisterHotKey(nullptr, HOTKEY_ID, MOD_CONTROL | MOD_ALT | MOD_NOREPEAT, 'R');
+    if (!registered)
+        Wh_Log(L"RegisterHotKey failed (%lu)", GetLastError());
+
+    if (g_hotkeyReady) SetEvent(g_hotkeyReady);
+
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        if (msg.message == WM_HOTKEY && msg.wParam == HOTKEY_ID)
             FlushCache();
-            Sleep(500);
-        }
-        Sleep(50);
     }
+
+    if (registered) UnregisterHotKey(nullptr, HOTKEY_ID);
     return 0;
 }
 
@@ -239,20 +315,41 @@ static void LoadSettings() {
 BOOL Wh_ModInit() {
     LoadSettings();
 
+    g_stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);  // manual reset
+
     WindhawkUtils::SetFunctionHook((void*)LoadLibraryExW, (void*)LoadLibraryExW_Hook,
                                    (void**)&LoadLibraryExW_Orig);
-    HookHandlerDll(false); // in case the DLL is already loaded
+    HookHandlerDll(false);  // in case the DLL is already loaded
 
-    CreateThread(nullptr, 0, WatchThread, nullptr, 0, nullptr);
-    CreateThread(nullptr, 0, HotkeyThread, nullptr, 0, nullptr);
+    g_watchThread = CreateThread(nullptr, 0, WatchThread, nullptr, 0, nullptr);
+
+    g_hotkeyReady = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    g_hotkeyThread =
+        CreateThread(nullptr, 0, HotkeyThread, nullptr, 0, &g_hotkeyThreadId);
     return TRUE;
 }
 
 void Wh_ModSettingsChanged() { LoadSettings(); }
 
 void Wh_ModUninit() {
-    g_running = false;
-    Sleep(120);
+    // Stop and join the worker threads before their code can be unmapped.
+    if (g_stopEvent) SetEvent(g_stopEvent);
+    if (g_hotkeyThread) {
+        if (g_hotkeyReady)
+            WaitForSingleObject(g_hotkeyReady, INFINITE);  // queue exists now
+        PostThreadMessageW(g_hotkeyThreadId, WM_QUIT, 0, 0);
+    }
+    HANDLE threads[2];
+    DWORD n = 0;
+    if (g_watchThread)  threads[n++] = g_watchThread;
+    if (g_hotkeyThread) threads[n++] = g_hotkeyThread;
+    if (n) WaitForMultipleObjects(n, threads, TRUE, INFINITE);
+    if (g_watchThread)  { CloseHandle(g_watchThread);  g_watchThread = nullptr; }
+    if (g_hotkeyThread) { CloseHandle(g_hotkeyThread); g_hotkeyThread = nullptr; }
+    if (g_hotkeyReady)  { CloseHandle(g_hotkeyReady);  g_hotkeyReady = nullptr; }
+    if (g_stopEvent)    { CloseHandle(g_stopEvent);    g_stopEvent = nullptr; }
+
+    // Restore the controller vtable slot.
     if (g_vtblHooked.load() && g_vtblSlot && GetSettings_Orig) {
         DWORD oldProtect;
         if (VirtualProtect(g_vtblSlot, sizeof(void*), PAGE_READWRITE, &oldProtect)) {
@@ -260,7 +357,13 @@ void Wh_ModUninit() {
             VirtualProtect(g_vtblSlot, sizeof(void*), oldProtect, &oldProtect);
         }
     }
+
+    // Release the cached proxies and anything a flush queued. At unload the
+    // owning UI thread is idle and pumping, so the release completes there.
     std::unique_lock lock(g_cacheMutex);
+    for (IUnknown* p : g_pendingRelease)
+        if (p) p->Release();
+    g_pendingRelease.clear();
     for (auto& kv : g_cache)
         if (kv.second) kv.second->Release();
     g_cache.clear();

--- a/mods/notifications-settings-page-speedup.wh.cpp
+++ b/mods/notifications-settings-page-speedup.wh.cpp
@@ -163,20 +163,55 @@ static bool MemExecutable(const void* p) {
     return (mbi.Protect & exec) != 0;
 }
 
+// The notification controller interface (out-of-process COM object). We find it
+// in the helper by identity rather than trusting a fixed offset. {2537d644-...}
+static const GUID IID_MainNotificationController = {
+    0x2537d644, 0x8c2f, 0x4449,
+    {0xb8, 0xb6, 0x10, 0x92, 0x88, 0x22, 0x63, 0x0c}};
+
+// If cand looks like a COM object, QueryInterface it for the controller IID.
+// The readable-object + executable-vtable[0] checks guard the one call we make
+// on an otherwise-unverified pointer. Returns an AddRef'd pointer (caller frees).
+static IUnknown* ControllerFromCandidate(void* cand) {
+    if (!cand || !MemReadable(cand)) return nullptr;
+    void** vt = *reinterpret_cast<void***>(cand);
+    if (!MemReadable(vt) || !MemExecutable(vt[0])) return nullptr;
+    IUnknown* out = nullptr;
+    if (SUCCEEDED(reinterpret_cast<IUnknown*>(cand)->QueryInterface(
+            IID_MainNotificationController, reinterpret_cast<void**>(&out))))
+        return out;
+    return nullptr;
+}
+
+// Locate the controller inside the helper object. Tries the known offset first
+// (fast path for current builds), then scans a small window around it so a
+// shifted struct layout on a future build still resolves instead of us patching
+// the wrong member. Returns an AddRef'd pointer (caller frees) or nullptr.
+static IUnknown* FindController(void* helper) {
+    char* base = reinterpret_cast<char*>(helper);
+    if (MemReadable(base + CTRL_PTR_OFFSET))
+        if (IUnknown* c = ControllerFromCandidate(
+                *reinterpret_cast<void**>(base + CTRL_PTR_OFFSET)))
+            return c;
+    for (size_t off = 0xE0; off <= 0x140; off += sizeof(void*)) {
+        if (off == CTRL_PTR_OFFSET || !MemReadable(base + off)) continue;
+        if (IUnknown* c = ControllerFromCandidate(*reinterpret_cast<void**>(base + off)))
+            return c;
+    }
+    return nullptr;
+}
+
 static void HookControllerVtable(void* helper) {
     if (g_vtblHooked.load()) return;
 
-    void* controller = *reinterpret_cast<void**>(
-        reinterpret_cast<char*>(helper) + CTRL_PTR_OFFSET);
-    if (!controller || !MemReadable(controller)) return;  // not created yet / bad ptr
+    IUnknown* controller = FindController(helper);
+    if (!controller) return;  // not created yet / layout shifted; retry next entry
 
     void** vtbl = *reinterpret_cast<void***>(controller);
-    if (!vtbl || !MemReadable(vtbl)) return;
+    void* target = (vtbl && MemReadable(vtbl)) ? vtbl[GETSETTINGS_VTBL_SLOT] : nullptr;
+    if (!target || !MemExecutable(target)) { controller->Release(); return; }
 
-    void* target = vtbl[GETSETTINGS_VTBL_SLOT];
-    if (!target || !MemExecutable(target)) return;
-
-    if (g_vtblHooked.exchange(true)) return;
+    if (g_vtblHooked.exchange(true)) { controller->Release(); return; }
 
     g_vtblSlot = &vtbl[GETSETTINGS_VTBL_SLOT];
     DWORD oldProtect;
@@ -189,6 +224,7 @@ static void HookControllerVtable(void* helper) {
         g_vtblHooked = false;
         Wh_Log(L"VirtualProtect failed; settings cache disabled");
     }
+    controller->Release();
 }
 
 // ---------------------------------------------------------------------------

--- a/mods/notifications-settings-page-speedup.wh.cpp
+++ b/mods/notifications-settings-page-speedup.wh.cpp
@@ -2,7 +2,7 @@
 // @id              notifications-settings-page-speedup
 // @name            Faster Notifications Settings Page
 // @description     Stops Settings from re-scanning every notification app on each visit, so revisits load in seconds instead of minutes
-// @version         1.2
+// @version         1.3
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         SystemSettings.exe
@@ -502,51 +502,29 @@ static void HookHandlerDll(bool applyNow) {
     Wh_Log(L"installed symbol hooks");
 }
 
-// The handler DLL loads on demand when the Notifications page opens. Rather than
-// detour a load function (which misses load paths that don't go through it, and
-// hooking kernelbase's LoadLibraryExW directly fast-fails SystemSettings under
-// CFG), ask the loader to notify us. LdrRegisterDllNotification fires for every
-// load path, needs no detour, and lets the polling backstop go away.
-typedef struct _WH_UNICODE_STRING {
-    USHORT Length;
-    USHORT MaximumLength;
-    PWSTR  Buffer;
-} WH_UNICODE_STRING;
-typedef struct _WH_LDR_DLL_NOTIFICATION_DATA {
-    ULONG Flags;
-    const WH_UNICODE_STRING* FullDllName;
-    const WH_UNICODE_STRING* BaseDllName;
-    PVOID DllBase;
-    ULONG SizeOfImage;
-} WH_LDR_DLL_NOTIFICATION_DATA;
-typedef VOID(CALLBACK* WH_LDR_DLL_NOTIFICATION_FUNCTION)(
-    ULONG, const WH_LDR_DLL_NOTIFICATION_DATA*, PVOID);
-typedef LONG(NTAPI* LdrRegisterDllNotification_t)(
-    ULONG, WH_LDR_DLL_NOTIFICATION_FUNCTION, PVOID, PVOID*);
-typedef LONG(NTAPI* LdrUnregisterDllNotification_t)(PVOID);
-static const ULONG WH_LDR_DLL_NOTIFICATION_REASON_LOADED = 1;
+// The handler DLL loads on demand when the Notifications page opens. Hook the
+// imported LoadLibraryExW and, after any successful load, check whether the handler
+// DLL is now present, so it's caught whether it was loaded directly or pulled in as
+// a dependency of something else. Hooking kernelbase's LoadLibraryExW directly
+// fast-fails SystemSettings under CFG, so the imported thunk is the one to hook.
+// The check runs after the load returns (off the loader lock) and only signals the
+// worker; the slow HookSymbols work happens there, so this stays cheap.
+using LoadLibraryExW_t = HMODULE(WINAPI*)(LPCWSTR, HANDLE, DWORD);
+static LoadLibraryExW_t LoadLibraryExW_Orig;
 
-static PVOID  g_ldrCookie = nullptr;
-static HANDLE g_dllLoadedEvent = nullptr;    // signalled by the loader callback
+static HANDLE g_dllLoadedEvent = nullptr;    // signalled once the handler DLL appears
 static HANDLE g_hookWorkerThread = nullptr;
 
-// Runs under the loader lock, so keep it minimal: exact name check, then signal
-// the worker. Only loads are interesting, because the module is referenced while
-// the hooks are installed and so can't unload underneath us.
-static VOID CALLBACK DllNotification(ULONG reason,
-                                     const WH_LDR_DLL_NOTIFICATION_DATA* data, PVOID) {
-    if (!data || !data->BaseDllName || !data->BaseDllName->Buffer) return;
-    const WH_UNICODE_STRING* n = data->BaseDllName;
-    USHORT chars = n->Length / sizeof(WCHAR);
-    if (chars == 0 || chars > MAX_PATH) return;
-    wchar_t name[MAX_PATH + 1];
-    memcpy(name, n->Buffer, chars * sizeof(WCHAR));
-    name[chars] = L'\0';
-    if (_wcsicmp(name, L"SettingsHandlers_Notifications.dll") != 0) return;
-
-    if (reason == WH_LDR_DLL_NOTIFICATION_REASON_LOADED) {
+static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR name, HANDLE file, DWORD flags) {
+    HMODULE mod = LoadLibraryExW_Orig(name, file, flags);
+    // g_symHooked makes a repeat signal a no-op, so firing on every load until the
+    // hooks are in is fine. GetModuleHandleW takes no reference; the worker takes
+    // one before hooking.
+    if (mod && !g_symHooked.load() &&
+        GetModuleHandleW(L"SettingsHandlers_Notifications.dll")) {
         if (g_dllLoadedEvent) SetEvent(g_dllLoadedEvent);
     }
+    return mod;
 }
 
 // Installs the symbol hooks off the loader lock once the handler DLL appears.
@@ -609,15 +587,11 @@ BOOL Wh_ModInit() {
     g_stopEvent      = CreateEventW(nullptr, TRUE, FALSE, nullptr);   // manual reset
     g_dllLoadedEvent = CreateEventW(nullptr, FALSE, FALSE, nullptr);  // auto reset
 
-    // Registered before the already-loaded check, not after, so a load that lands
-    // in between is caught rather than missed for the rest of the session. The
-    // g_symHooked latch makes the duplicate attempt a no-op.
-    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    auto reg = ntdll ? (LdrRegisterDllNotification_t)GetProcAddress(
-                           ntdll, "LdrRegisterDllNotification")
-                     : nullptr;
-    if (!reg || reg(0, DllNotification, nullptr, &g_ldrCookie) != 0)
-        Wh_Log(L"LdrRegisterDllNotification unavailable");
+    // Hooked before the already-loaded check, not after, so a load that lands in
+    // between is caught rather than missed. The g_symHooked latch makes the
+    // duplicate attempt a no-op.
+    Wh_SetFunctionHook((void*)LoadLibraryExW, (void*)LoadLibraryExW_Hook,
+                       (void**)&LoadLibraryExW_Orig);
 
     HookHandlerDll(false);  // in case the DLL is already loaded (Windhawk applies
                             // the hooks after Wh_ModInit returns)
@@ -642,18 +616,9 @@ void Wh_ModSettingsChanged() {
 void Wh_ModBeforeUninit() {
     g_uninitializing.store(true);
 
-    // Stop the loader callback first so it can't fire during teardown.
-    if (g_ldrCookie) {
-        HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-        auto unreg = ntdll ? (LdrUnregisterDllNotification_t)GetProcAddress(
-                                 ntdll, "LdrUnregisterDllNotification")
-                           : nullptr;
-        if (unreg) unreg(g_ldrCookie);
-        g_ldrCookie = nullptr;
-    }
-
-    // Stop and join the worker while hook operations are still legal, so any hook
-    // it was mid-installing is applied here and Windhawk still removes it.
+    // The LoadLibraryExW hook is removed by Windhawk during uninit; nothing to undo
+    // here. Stop and join the worker while hook operations are still legal, so any
+    // hook it was mid-installing is applied here and Windhawk still removes it.
     if (g_stopEvent) SetEvent(g_stopEvent);
     if (g_hookWorkerThread) {
         WaitForSingleObject(g_hookWorkerThread, INFINITE);

--- a/mods/notifications-settings-page-speedup.wh.cpp
+++ b/mods/notifications-settings-page-speedup.wh.cpp
@@ -2,7 +2,7 @@
 // @id              notifications-settings-page-speedup
 // @name            Faster Notifications Settings Page
 // @description     Stops Settings from re-scanning every notification app on each visit, so revisits load in seconds instead of minutes
-// @version         1.1
+// @version         1.2
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         SystemSettings.exe
@@ -90,6 +90,7 @@ static std::atomic<HANDLE> g_uiThreadHandle{nullptr};
 // that OwnerAlive/AddEntry read, so the handle is always published before the id
 // and only one thread can claim or take over ownership at a time.
 static std::atomic<DWORD> g_ownerClaim{0};
+static bool IsOwner();  // Defined with the ownership helpers below; used by the hooks.
 
 // ---------------------------------------------------------------------------
 // Run a callback on the thread that owns a given window. Used at unload to
@@ -231,7 +232,7 @@ HRESULT STDMETHODCALLTYPE GetSettings_Hook(void* self, PCWSTR aumid, void** out)
     // Only use the cache on the thread that created the proxies; a proxy handed to
     // another apartment would fail its reads with RPC_E_WRONG_THREAD.
     if (g_cacheSettings.load() && aumid && out && !g_ownerGone.load() &&
-        GetCurrentThreadId() == g_uiThreadId.load()) {
+        IsOwner()) {
         {
             std::shared_lock lk(g_cacheMutex);
             auto it = g_cache.find(aumid);
@@ -370,6 +371,12 @@ static bool OwnerAlive() {
     return h && WaitForSingleObject(h, 0) == WAIT_TIMEOUT;
 }
 
+// Set only on the owning thread itself, in TakeOwnership. A bare id can't identify
+// the owner, because ids are recycled: a dead owner's id can be handed to an
+// unrelated live thread that would then match on `id == owner` and be treated as
+// the owner. A new thread always starts with this false, whatever id it inherits.
+static thread_local bool g_isOwnerThread = false;
+
 // Latch this thread as the owner. Only ever called on the thread itself, and only
 // by the thread that won g_ownerClaim. The handle is published before the id so a
 // reader can never see an owner id whose liveness handle isn't in place yet, which
@@ -378,55 +385,60 @@ static void TakeOwnership(DWORD self) {
     HANDLE h = OpenThread(SYNCHRONIZE, FALSE, self);
     HANDLE old = g_uiThreadHandle.exchange(h);  // Handle visible before the id.
     g_uiThreadId.store(self);
+    g_isOwnerThread = true;
     if (old) {
         CloseHandle(old);
     }
 }
 
+// True only on the thread that actually latched ownership, and only while it still
+// holds the published id, so a stolen ownership (another thread took over after
+// OpenThread failed on this one) also resolves correctly.
+static bool IsOwner() {
+    return g_isOwnerThread && g_uiThreadId.load() == GetCurrentThreadId();
+}
+
 HRESULT __cdecl AddEntry_Hook(void* helper, PCWSTR aumid, unsigned long long opt) {
     DWORD self = GetCurrentThreadId();
-    DWORD owner = g_uiThreadId.load();
 
-    // The owner is latched by the first enumeration and then left alone. Storing it
-    // on every call made the apartment check meaningless, because a second thread
-    // would overwrite it and then match itself, which is the wrong-apartment case
-    // the check exists for.
-    if (owner == 0) {
-        // Win the claim first, then publish handle-before-id in TakeOwnership. The
-        // claim, not the id, is what serializes the winner, so the id is never made
-        // visible ahead of its handle.
-        DWORD expected = 0;
-        if (g_ownerClaim.compare_exchange_strong(expected, self)) {
-            TakeOwnership(self);
-        }
-        owner = g_uiThreadId.load();
-    } else if (owner != self && !OwnerAlive()) {
-        // The apartment that made all of this has exited, so nothing can legally
-        // be called through any of it, Release included. One thread wins the
-        // takeover via the claim; the rest fall through to the slow path. Guarding
-        // it this way stops two threads both taking over and stealing ownership
-        // from each other mid-enumeration.
-        DWORD expected = owner;
-        if (g_ownerClaim.compare_exchange_strong(expected, self)) {
-            // The slot is restored first, while the controller reference we still
-            // hold keeps its vtable page mapped. Dropping the reference first would
-            // leave RestoreVtableSlot writing into memory that may already be gone.
-            RestoreVtableSlot();
-            g_vtblHooked   = false;
-            g_vtblSlot     = nullptr;
-            g_controller   = nullptr;  // Abandoned, not released.
-            g_hookAttempts = 0;
-            g_ownerGone    = true;
-            TakeOwnership(self);
-            owner = self;
-        } else {
-            owner = g_uiThreadId.load();  // Someone else took over.
+    // Ownership is identified by the thread_local latch, not the bare id. Only a
+    // thread that isn't already the owner tries to claim or take over.
+    if (!IsOwner()) {
+        DWORD owner = g_uiThreadId.load();
+        if (owner == 0) {
+            // Win the claim first, then publish handle-before-id in TakeOwnership.
+            // The claim, not the id, serializes the winner, so the id is never made
+            // visible ahead of its handle.
+            DWORD expected = 0;
+            if (g_ownerClaim.compare_exchange_strong(expected, self)) {
+                TakeOwnership(self);
+            }
+        } else if (!OwnerAlive()) {
+            // The owning apartment has exited (this also covers a recycled id that
+            // matches g_uiThreadId but never latched: its liveness handle belongs to
+            // the dead thread, so OwnerAlive is false). Nothing here can be called,
+            // so one thread wins the takeover via the claim and the rest fall through
+            // to the slow path, instead of two threads stealing it from each other.
+            DWORD expected = owner;
+            if (g_ownerClaim.compare_exchange_strong(expected, self)) {
+                // The slot is restored first, while the controller reference we
+                // still hold keeps its vtable page mapped. Dropping the reference
+                // first would leave RestoreVtableSlot writing into memory that may
+                // already be gone.
+                RestoreVtableSlot();
+                g_vtblHooked   = false;
+                g_vtblSlot     = nullptr;
+                g_controller   = nullptr;  // Abandoned, not released.
+                g_hookAttempts = 0;
+                g_ownerGone    = true;
+                TakeOwnership(self);
+            }
         }
     }
 
-    // Anything that isn't the owning apartment falls through to the original path:
-    // slower, but correct, instead of being handed a proxy it can't call.
-    if (owner == self) {
+    // Only the owning apartment gets the cache path; anything else falls through to
+    // the original, slower but correct instead of touching a proxy it can't call.
+    if (IsOwner()) {
         if (g_ownerGone.exchange(false)) {
             AbandonCache();
         }

--- a/mods/notifications-settings-page-speedup.wh.cpp
+++ b/mods/notifications-settings-page-speedup.wh.cpp
@@ -99,20 +99,30 @@ static LRESULT CALLBACK RunFromWindowThreadHookProc(int nCode, WPARAM wParam, LP
     return CallNextHookEx(nullptr, nCode, wParam, lParam);
 }
 
-static bool RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc, PVOID procParam) {
+// Note this says nothing about whether the callback ran: the window can go away
+// between the caller finding it and the message being sent, which is exactly what
+// happens while the page is closing. The callback reports that itself.
+//
+// SendMessageTimeoutW rather than SendMessageW because SystemSettings.exe is a
+// packaged app: once its window is closed the process lingers and its UI thread
+// can be suspended, and an unbounded send there would hang the mod unload.
+// UnhookWindowsHookEx runs before we return, so a message that arrives after the
+// timeout can no longer call back into the mod.
+static void RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc, PVOID procParam) {
     DWORD threadId = GetWindowThreadProcessId(hWnd, nullptr);
-    if (threadId == 0) return false;
+    if (threadId == 0) return;
     if (threadId == GetCurrentThreadId()) {
         proc(procParam);
-        return true;
+        return;
     }
     HHOOK hook = SetWindowsHookExW(WH_CALLWNDPROC, RunFromWindowThreadHookProc,
                                    nullptr, threadId);
-    if (!hook) return false;
+    if (!hook) return;
     RUN_FROM_WINDOW_THREAD_PARAM param = {proc, procParam};
-    SendMessageW(hWnd, g_runFromWindowThreadMsg, 0, reinterpret_cast<LPARAM>(&param));
+    SendMessageTimeoutW(hWnd, g_runFromWindowThreadMsg, 0,
+                        reinterpret_cast<LPARAM>(&param),
+                        SMTO_ABORTIFHUNG | SMTO_BLOCK, 5000, nullptr);
     UnhookWindowsHookEx(hook);
-    return true;
 }
 
 static BOOL CALLBACK FirstThreadWindowProc(HWND hWnd, LPARAM lParam) {
@@ -140,9 +150,15 @@ static HWND GetWindowOnThread(DWORD threadId) {
 // (the thread that runs _AddEntry / the controller call). They must be released
 // on that thread, so a flush hands them to g_pendingRelease and the next
 // _AddEntry drains it on the UI thread; at unload we release them by hopping onto
-// the UI thread with RunFromWindowThread. The cache is also keyed and guarded by
-// that thread id, so a visit on a different apartment never gets a proxy it
-// can't legally call.
+// the UI thread with RunFromWindowThread. The owning thread is latched by the
+// first enumeration and never re-latched while it lives, so an enumeration on a
+// different apartment skips the cache (slower, but it never gets a proxy it can't
+// legally call). If that thread has exited, the proxies are unreachable and get
+// dropped rather than released.
+//
+// The same goes for the handler DLL unloading: it serves all of these objects, so
+// once it goes they are dropped without a Release, since calling through them
+// would mean calling into an unmapped module.
 // ---------------------------------------------------------------------------
 static const size_t CTRL_PTR_OFFSET       = 0x108;  // helper -> controller ComPtr
 static const size_t GETSETTINGS_VTBL_SLOT = 14;     // 0x70 / sizeof(void*)
@@ -154,6 +170,23 @@ static void** g_vtblSlot = nullptr;
 static IUnknown* g_controller = nullptr;  // pinned while the patch is installed
 static std::atomic<bool> g_vtblHooked{false};
 
+// Set when the handler DLL unloads. Everything we hold (the controller and every
+// cached proxy) is served by that DLL, so once it goes the pointers are dead and
+// calling Release through them would be calling into an unmapped module. The flag
+// says "drop these, do not release them"; it is checked wherever the cache is read
+// or freed, and cleared on the UI thread at the next enumeration, since the
+// containers can't be touched from the loader callback.
+static std::atomic<bool> g_cacheDead{false};
+
+// Drop the cached pointers without releasing them, after the DLL that served them
+// has gone. Must run on the UI thread (it takes the cache lock).
+static void AbandonCache() {
+    std::unique_lock lock(g_cacheMutex);
+    g_cache.clear();
+    g_pendingRelease.clear();
+    Wh_Log(L"handler dll unloaded; cached objects dropped without release");
+}
+
 // Release proxies queued by a flush. Called from _AddEntry, i.e. the UI thread
 // that owns the objects, so the release stays inside their apartment.
 static void DrainPendingReleases() {
@@ -163,6 +196,7 @@ static void DrainPendingReleases() {
         if (g_pendingRelease.empty()) return;
         toRelease.swap(g_pendingRelease);
     }
+    if (g_cacheDead.load()) return;  // Their server is gone; dropping is all we can do.
     for (IUnknown* p : toRelease)
         if (p) p->Release();
 }
@@ -184,7 +218,7 @@ static GetSettings_t GetSettings_Orig = nullptr;
 HRESULT STDMETHODCALLTYPE GetSettings_Hook(void* self, PCWSTR aumid, void** out) {
     // Only use the cache on the thread that created the proxies; a proxy handed to
     // another apartment would fail its reads with RPC_E_WRONG_THREAD.
-    if (g_cacheSettings.load() && aumid && out &&
+    if (g_cacheSettings.load() && aumid && out && !g_cacheDead.load() &&
         GetCurrentThreadId() == g_uiThreadId.load()) {
         {
             std::shared_lock lk(g_cacheMutex);
@@ -247,6 +281,20 @@ static IUnknown* FindController(void* helper) {
     return nullptr;
 }
 
+// Put the original pointer back in the patched vtable slot. VirtualProtect plus a
+// single store, no COM and no loader re-entry, so it is safe to call from the DLL
+// unload notification as well as at teardown. The compare means a slot somebody
+// else has since taken over is left alone.
+static void RestoreVtableSlot() {
+    if (!g_vtblHooked.load() || !g_vtblSlot || !GetSettings_Orig) return;
+    DWORD oldProtect;
+    if (VirtualProtect(g_vtblSlot, sizeof(void*), PAGE_READWRITE, &oldProtect)) {
+        if (*g_vtblSlot == reinterpret_cast<void*>(GetSettings_Hook))
+            *g_vtblSlot = reinterpret_cast<void*>(GetSettings_Orig);
+        VirtualProtect(g_vtblSlot, sizeof(void*), oldProtect, &oldProtect);
+    }
+}
+
 // Bound how many entries we probe before giving up, so a build where the
 // controller never resolves can't turn into a QueryInterface on every app.
 static std::atomic<int> g_hookAttempts{0};
@@ -291,10 +339,45 @@ static void HookControllerVtable(void* helper) {
 // this is their owning apartment.
 using AddEntry_t = HRESULT (__cdecl*)(void* helper, PCWSTR aumid, unsigned long long opt);
 static AddEntry_t AddEntry_Orig = nullptr;
+// True while a thread id still refers to a running thread.
+static bool ThreadAlive(DWORD threadId) {
+    HANDLE h = OpenThread(SYNCHRONIZE, FALSE, threadId);
+    if (!h) return false;
+    bool alive = WaitForSingleObject(h, 0) == WAIT_TIMEOUT;
+    CloseHandle(h);
+    return alive;
+}
+
 HRESULT __cdecl AddEntry_Hook(void* helper, PCWSTR aumid, unsigned long long opt) {
-    g_uiThreadId.store(GetCurrentThreadId());
-    DrainPendingReleases();
-    HookControllerVtable(helper);  // no-op after the vtable is patched
+    DWORD self = GetCurrentThreadId();
+    DWORD owner = g_uiThreadId.load();
+
+    // The owner is latched by the first enumeration and then left alone. Storing it
+    // on every call made the apartment check meaningless, because a second thread
+    // would overwrite it and then match itself, which is the wrong-apartment case
+    // the check exists for.
+    if (owner == 0) {
+        DWORD expected = 0;
+        g_uiThreadId.compare_exchange_strong(expected, self);
+        owner = g_uiThreadId.load();
+    } else if (owner != self && !ThreadAlive(owner)) {
+        // The apartment that made the cached proxies has exited, so nothing can
+        // legally release them anymore. Drop them and let this thread take over,
+        // otherwise the cache would be bypassed for the rest of the session.
+        g_cacheDead = true;
+        g_uiThreadId.store(self);
+        owner = self;
+    }
+
+    // Anything that isn't the owning apartment falls through to the original path:
+    // slower, but correct, instead of being handed a proxy it can't call.
+    if (owner == self) {
+        if (g_cacheDead.exchange(false)) {
+            AbandonCache();
+        }
+        DrainPendingReleases();
+        HookControllerVtable(helper);  // no-op after the vtable is patched
+    }
     return AddEntry_Orig(helper, aumid, opt);
 }
 
@@ -383,14 +466,21 @@ static VOID CALLBACK DllNotification(ULONG reason,
     if (reason == WH_LDR_DLL_NOTIFICATION_REASON_LOADED) {
         if (g_dllLoadedEvent) SetEvent(g_dllLoadedEvent);
     } else if (reason == WH_LDR_DLL_NOTIFICATION_REASON_UNLOADED) {
-        // The DLL, its helper, and the patched vtable are going away. Drop our
-        // latches so the next load re-hooks, and null the dangling vtable pointer
-        // so teardown never writes into freed/recycled memory. No COM here: we
-        // can't safely release the proxy under the loader lock, and it dies with
-        // the DLL anyway.
+        // The DLL, its helper, and everything it served are going away, and this
+        // is the last moment the patched slot can be reached: g_vtblSlot is the
+        // only handle on it, so dropping the pointer without restoring first would
+        // leave a live slot aimed at mod code that is about to unmap. The restore
+        // is only VirtualProtect plus a store, which is fine under the loader lock.
+        RestoreVtableSlot();
         g_vtblHooked  = false;
         g_vtblSlot    = nullptr;
-        g_controller  = nullptr;  // ref leaks; the proxy is being torn down
+        // GetSettings_Orig deliberately keeps its value: a thread that is already
+        // inside the hook still has to have something to call through.
+        // No COM here. The controller and every cached proxy are served by the DLL
+        // that is unloading, so releasing them would call into an unmapping module;
+        // they get dropped instead, on the UI thread, at the next enumeration.
+        g_controller  = nullptr;
+        g_cacheDead   = true;
         g_hookAttempts = 0;
         g_symHooked   = false;
     }
@@ -415,18 +505,22 @@ static void LoadSettings() {
     g_cacheSettings = Wh_GetIntSetting(L"cacheSettings") != 0;
 }
 
+// Reports back, because a caller can't tell from RunFromWindowThread whether the
+// message was ever delivered.
+struct RELEASE_PARAM {
+    bool ran = false;
+};
+
 // Runs on the UI thread (via RunFromWindowThread) at unload: pull the vtable
 // hook and release everything in the apartment that owns it.
-static void WINAPI ReleaseComStateOnUiThread(PVOID) {
-    if (g_vtblHooked.load() && g_vtblSlot && GetSettings_Orig) {
-        DWORD oldProtect;
-        if (VirtualProtect(g_vtblSlot, sizeof(void*), PAGE_READWRITE, &oldProtect)) {
-            if (*g_vtblSlot == reinterpret_cast<void*>(GetSettings_Hook))
-                *g_vtblSlot = reinterpret_cast<void*>(GetSettings_Orig);
-            VirtualProtect(g_vtblSlot, sizeof(void*), oldProtect, &oldProtect);
-        }
+static void WINAPI ReleaseComStateOnUiThread(PVOID p) {
+    RestoreVtableSlot();
+
+    bool dead = g_cacheDead.load();  // Server gone: drop the pointers, don't call them.
+    if (g_controller) {
+        if (!dead) g_controller->Release();
+        g_controller = nullptr;
     }
-    if (g_controller) { g_controller->Release(); g_controller = nullptr; }
 
     std::vector<IUnknown*> toRelease;
     {
@@ -436,8 +530,12 @@ static void WINAPI ReleaseComStateOnUiThread(PVOID) {
             if (kv.second) toRelease.push_back(kv.second);
         g_cache.clear();
     }
-    for (IUnknown* p : toRelease)
-        if (p) p->Release();
+    if (!dead) {
+        for (IUnknown* q : toRelease)
+            if (q) q->Release();
+    }
+
+    if (p) static_cast<RELEASE_PARAM*>(p)->ran = true;
 }
 
 BOOL Wh_ModInit() {
@@ -448,16 +546,18 @@ BOOL Wh_ModInit() {
     g_stopEvent      = CreateEventW(nullptr, TRUE, FALSE, nullptr);   // manual reset
     g_dllLoadedEvent = CreateEventW(nullptr, FALSE, FALSE, nullptr);  // auto reset
 
-    HookHandlerDll(false);  // in case the DLL is already loaded (Windhawk applies
-                            // the hooks after Wh_ModInit returns)
-
-    // Catch future loads (and unloads) of the handler DLL through any path.
+    // Registered before the already-loaded check, not after, so a load that lands
+    // in between is caught rather than missed for the rest of the session. The
+    // g_symHooked latch makes the duplicate attempt a no-op.
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
     auto reg = ntdll ? (LdrRegisterDllNotification_t)GetProcAddress(
                            ntdll, "LdrRegisterDllNotification")
                      : nullptr;
     if (!reg || reg(0, DllNotification, nullptr, &g_ldrCookie) != 0)
         Wh_Log(L"LdrRegisterDllNotification unavailable");
+
+    HookHandlerDll(false);  // in case the DLL is already loaded (Windhawk applies
+                            // the hooks after Wh_ModInit returns)
     return TRUE;
 }
 
@@ -501,23 +601,18 @@ void Wh_ModBeforeUninit() {
 
 void Wh_ModUninit() {
     // Restore the vtable slot and release the proxies on their owning UI thread.
-    bool ran = false;
+    RELEASE_PARAM param;
     if (DWORD tid = g_uiThreadId.load()) {
         if (HWND hWnd = GetWindowOnThread(tid))
-            ran = RunFromWindowThread(hWnd, ReleaseComStateOnUiThread, nullptr);
+            RunFromWindowThread(hWnd, ReleaseComStateOnUiThread, &param);
     }
-    if (!ran) {
-        // Couldn't reach the UI thread. Still pull the hook so SystemSettings
-        // doesn't call into unmapped code, but leave the proxies alone since a
-        // cross-apartment release is worse than a leak at process teardown.
-        if (g_vtblHooked.load() && g_vtblSlot && GetSettings_Orig) {
-            DWORD oldProtect;
-            if (VirtualProtect(g_vtblSlot, sizeof(void*), PAGE_READWRITE, &oldProtect)) {
-                if (*g_vtblSlot == reinterpret_cast<void*>(GetSettings_Hook))
-                    *g_vtblSlot = reinterpret_cast<void*>(GetSettings_Orig);
-                VirtualProtect(g_vtblSlot, sizeof(void*), oldProtect, &oldProtect);
-            }
-        }
+    if (!param.ran) {
+        // The callback never got to run: no window, the window died while we were
+        // reaching for it, or the send timed out against a suspended thread. Pull
+        // the hook from here anyway so SystemSettings can't call into unmapped
+        // code, and leave the proxies alone, since a cross-apartment release is
+        // worse than a leak at process teardown.
+        RestoreVtableSlot();
     }
 
     if (g_dllLoadedEvent) { CloseHandle(g_dllLoadedEvent); g_dllLoadedEvent = nullptr; }

--- a/mods/notifications-settings-page-speedup.wh.cpp
+++ b/mods/notifications-settings-page-speedup.wh.cpp
@@ -6,7 +6,6 @@
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         SystemSettings.exe
-// @compilerOptions -lshlwapi
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -24,8 +23,8 @@ stops repeating a slow per-app cross-process call. The cached objects read live
 data, so **your edits still show correctly** and nothing goes stale.
 
 Both options default on and can be turned off in the mod's settings, which
-reverts the page to normal instantly. Press **Ctrl+Alt+R** to clear the cache
-and force a full rescan.
+reverts the page to normal. Turning **Cache app settings** off (then on again)
+clears the cache, so the next open does a full rescan if you ever need one.
 
 ## The summary trade-off
 
@@ -50,12 +49,12 @@ so it may need an update after a major Windows release. Tested on Windows 11.
   $description: The largest single speedup. Each app still shows its name, icon, and main on/off toggle, but loses the small subtitle summarizing banners/sounds status. You can still open any app to see and change those. Turn off to keep the subtitle (revisits stay cached, just a bit slower).
 - cacheSettings: true
   $name: Cache app settings across visits
-  $description: Makes revisiting the page fast. Cached objects read live data, so your edits are still reflected. Turn off if the list ever renders incorrectly.
+  $description: Makes revisiting the page fast. Cached objects read live data, so your edits are still reflected. Turning this off clears the cache and the page renders normally; turn it off then on to force a full rescan.
 */
 // ==/WindhawkModSettings==
 
 #include <windhawk_utils.h>
-#include <shlwapi.h>
+#include <string.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -68,9 +67,64 @@ so it may need an update after a major Windows release. Tested on Windows 11.
 static std::atomic<bool> g_skipSummary{true};
 static std::atomic<bool> g_cacheSettings{true};
 
-// Set on unload so the worker threads exit their waits at once instead of being
-// left to run into unmapped code.
+// Set on unload so the worker thread exits its wait at once, and so an in-flight
+// hook callback stops installing new hooks once teardown has started.
 static HANDLE g_stopEvent = nullptr;
+static std::atomic<bool> g_uninitializing{false};
+
+// The Settings UI thread: the thread that runs _AddEntry and the controller call,
+// and therefore owns the cached apartment-bound proxies. Captured in AddEntry_Hook.
+static std::atomic<DWORD> g_uiThreadId{0};
+
+// ---------------------------------------------------------------------------
+// Run a callback on the thread that owns a given window. Used at unload to
+// release the cached COM proxies on their owning apartment instead of from the
+// unload thread. Standard Windhawk helper (see taskbar-vd-switcher).
+// ---------------------------------------------------------------------------
+using RunFromWindowThreadProc_t = void(WINAPI*)(PVOID);
+static UINT g_runFromWindowThreadMsg = 0;
+struct RUN_FROM_WINDOW_THREAD_PARAM {
+    RunFromWindowThreadProc_t proc;
+    PVOID param;
+};
+
+static LRESULT CALLBACK RunFromWindowThreadHookProc(int nCode, WPARAM wParam, LPARAM lParam) {
+    if (nCode == HC_ACTION) {
+        const CWPSTRUCT* cwp = reinterpret_cast<const CWPSTRUCT*>(lParam);
+        if (cwp->message == g_runFromWindowThreadMsg) {
+            auto* p = reinterpret_cast<RUN_FROM_WINDOW_THREAD_PARAM*>(cwp->lParam);
+            p->proc(p->param);
+        }
+    }
+    return CallNextHookEx(nullptr, nCode, wParam, lParam);
+}
+
+static bool RunFromWindowThread(HWND hWnd, RunFromWindowThreadProc_t proc, PVOID procParam) {
+    DWORD threadId = GetWindowThreadProcessId(hWnd, nullptr);
+    if (threadId == 0) return false;
+    if (threadId == GetCurrentThreadId()) {
+        proc(procParam);
+        return true;
+    }
+    HHOOK hook = SetWindowsHookExW(WH_CALLWNDPROC, RunFromWindowThreadHookProc,
+                                   nullptr, threadId);
+    if (!hook) return false;
+    RUN_FROM_WINDOW_THREAD_PARAM param = {proc, procParam};
+    SendMessageW(hWnd, g_runFromWindowThreadMsg, 0, reinterpret_cast<LPARAM>(&param));
+    UnhookWindowsHookEx(hook);
+    return true;
+}
+
+static BOOL CALLBACK FirstThreadWindowProc(HWND hWnd, LPARAM lParam) {
+    *reinterpret_cast<HWND*>(lParam) = hWnd;
+    return FALSE;  // first one is enough
+}
+
+static HWND GetWindowOnThread(DWORD threadId) {
+    HWND result = nullptr;
+    EnumThreadWindows(threadId, FirstThreadWindowProc, reinterpret_cast<LPARAM>(&result));
+    return result;
+}
 
 // ---------------------------------------------------------------------------
 // Per-AUMID cache of each app's IAumidNotificationSettings object.
@@ -82,18 +136,22 @@ static HANDLE g_stopEvent = nullptr;
 // visit populates the cache, revisits reuse the live objects and skip the
 // activation. Reads still hit the broker, so edits are reflected (no staleness).
 //
-// The cached objects are apartment-bound proxies owned by the Settings UI
-// thread (the thread that runs _AddEntry / the controller call). They must be
-// released on that thread, so a flush hands them to g_pendingRelease and the
-// next _AddEntry drains it on the UI thread instead of releasing cross-apartment.
+// The cached objects are apartment-bound proxies owned by the Settings UI thread
+// (the thread that runs _AddEntry / the controller call). They must be released
+// on that thread, so a flush hands them to g_pendingRelease and the next
+// _AddEntry drains it on the UI thread; at unload we release them by hopping onto
+// the UI thread with RunFromWindowThread. The cache is also keyed and guarded by
+// that thread id, so a visit on a different apartment never gets a proxy it
+// can't legally call.
 // ---------------------------------------------------------------------------
-static const size_t CTRL_PTR_OFFSET       = 0x108; // helper -> controller ComPtr
-static const size_t GETSETTINGS_VTBL_SLOT = 14;    // 0x70 / sizeof(void*)
+static const size_t CTRL_PTR_OFFSET       = 0x108;  // helper -> controller ComPtr
+static const size_t GETSETTINGS_VTBL_SLOT = 14;     // 0x70 / sizeof(void*)
 
-static std::unordered_map<std::wstring, IUnknown*> g_cache; // aumid -> settings obj
-static std::vector<IUnknown*> g_pendingRelease;             // freed on the UI thread
+static std::unordered_map<std::wstring, IUnknown*> g_cache;  // aumid -> settings obj
+static std::vector<IUnknown*> g_pendingRelease;              // freed on the UI thread
 static std::shared_mutex g_cacheMutex;
 static void** g_vtblSlot = nullptr;
+static IUnknown* g_controller = nullptr;  // pinned while the patch is installed
 static std::atomic<bool> g_vtblHooked{false};
 
 // Release proxies queued by a flush. Called from _AddEntry, i.e. the UI thread
@@ -109,14 +167,14 @@ static void DrainPendingReleases() {
         if (p) p->Release();
 }
 
-// Ctrl+Alt+R: hand the cached objects to the UI thread for release, then the
-// next page open does a full rescan.
+// Hand the cached objects to the UI thread for release (next _AddEntry drains
+// them), then the next page open does a full rescan.
 static void FlushCache() {
     std::unique_lock lock(g_cacheMutex);
     for (auto& kv : g_cache)
         if (kv.second) g_pendingRelease.push_back(kv.second);
     g_cache.clear();
-    Wh_Log(L"cache cleared (manual rescan)");
+    Wh_Log(L"cache cleared (rescan on next open)");
 }
 
 // The controller vtable slot: HRESULT(controller, PCWSTR aumid, IUnknown** out)
@@ -124,7 +182,10 @@ using GetSettings_t = HRESULT (STDMETHODCALLTYPE*)(void*, PCWSTR, void**);
 static GetSettings_t GetSettings_Orig = nullptr;
 
 HRESULT STDMETHODCALLTYPE GetSettings_Hook(void* self, PCWSTR aumid, void** out) {
-    if (g_cacheSettings.load() && aumid && out) {
+    // Only use the cache on the thread that created the proxies; a proxy handed to
+    // another apartment would fail its reads with RPC_E_WRONG_THREAD.
+    if (g_cacheSettings.load() && aumid && out &&
+        GetCurrentThreadId() == g_uiThreadId.load()) {
         {
             std::shared_lock lk(g_cacheMutex);
             auto it = g_cache.find(aumid);
@@ -147,9 +208,8 @@ HRESULT STDMETHODCALLTYPE GetSettings_Hook(void* self, PCWSTR aumid, void** out)
     return GetSettings_Orig(self, aumid, out);
 }
 
-// Reject a garbage controller pointer (e.g. if the +0x108 layout shifts on a
-// future build) before dereferencing it as a vtable, so a bad build no-ops
-// instead of crashing SystemSettings.
+// Reject a garbage controller pointer before dereferencing it as a vtable, so a
+// build where the +0x108 layout shifted no-ops instead of crashing SystemSettings.
 static bool MemReadable(const void* p) {
     MEMORY_BASIC_INFORMATION mbi{};
     if (!VirtualQuery(p, &mbi, sizeof(mbi)) || mbi.State != MEM_COMMIT) return false;
@@ -163,16 +223,20 @@ static bool MemExecutable(const void* p) {
     return (mbi.Protect & exec) != 0;
 }
 
-// The notification controller interface (out-of-process COM object). We find it
-// in the helper by identity rather than trusting a fixed offset. {2537d644-...}
+// The notification controller interface (out-of-process COM object). We confirm
+// the object at +0x108 is really it by identity rather than trusting the offset.
 static const GUID IID_MainNotificationController = {
     0x2537d644, 0x8c2f, 0x4449,
     {0xb8, 0xb6, 0x10, 0x92, 0x88, 0x22, 0x63, 0x0c}};
 
-// If cand looks like a COM object, QueryInterface it for the controller IID.
-// The readable-object + executable-vtable[0] checks guard the one call we make
-// on an otherwise-unverified pointer. Returns an AddRef'd pointer (caller frees).
-static IUnknown* ControllerFromCandidate(void* cand) {
+// Verify the candidate at the known offset is the controller and return an
+// AddRef'd pointer (caller frees), or nullptr. The readable-object plus
+// executable-vtable[0] checks guard the single QueryInterface call. We only ever
+// probe the one verified offset, never a blind scan of nearby members.
+static IUnknown* FindController(void* helper) {
+    char* base = reinterpret_cast<char*>(helper);
+    if (!MemReadable(base + CTRL_PTR_OFFSET)) return nullptr;
+    void* cand = *reinterpret_cast<void**>(base + CTRL_PTR_OFFSET);
     if (!cand || !MemReadable(cand)) return nullptr;
     void** vt = *reinterpret_cast<void***>(cand);
     if (!MemReadable(vt) || !MemExecutable(vt[0])) return nullptr;
@@ -183,29 +247,17 @@ static IUnknown* ControllerFromCandidate(void* cand) {
     return nullptr;
 }
 
-// Locate the controller inside the helper object. Tries the known offset first
-// (fast path for current builds), then scans a small window around it so a
-// shifted struct layout on a future build still resolves instead of us patching
-// the wrong member. Returns an AddRef'd pointer (caller frees) or nullptr.
-static IUnknown* FindController(void* helper) {
-    char* base = reinterpret_cast<char*>(helper);
-    if (MemReadable(base + CTRL_PTR_OFFSET))
-        if (IUnknown* c = ControllerFromCandidate(
-                *reinterpret_cast<void**>(base + CTRL_PTR_OFFSET)))
-            return c;
-    for (size_t off = 0xE0; off <= 0x140; off += sizeof(void*)) {
-        if (off == CTRL_PTR_OFFSET || !MemReadable(base + off)) continue;
-        if (IUnknown* c = ControllerFromCandidate(*reinterpret_cast<void**>(base + off)))
-            return c;
-    }
-    return nullptr;
-}
+// Bound how many entries we probe before giving up, so a build where the
+// controller never resolves can't turn into a QueryInterface on every app.
+static std::atomic<int> g_hookAttempts{0};
+static const int MAX_HOOK_ATTEMPTS = 8;
 
 static void HookControllerVtable(void* helper) {
-    if (g_vtblHooked.load()) return;
+    if (g_uninitializing.load() || g_vtblHooked.load()) return;
+    if (g_hookAttempts.fetch_add(1) >= MAX_HOOK_ATTEMPTS) return;
 
     IUnknown* controller = FindController(helper);
-    if (!controller) return;  // not created yet / layout shifted; retry next entry
+    if (!controller) return;  // not created yet, or layout shifted; maybe retry
 
     void** vtbl = *reinterpret_cast<void***>(controller);
     void* target = (vtbl && MemReadable(vtbl)) ? vtbl[GETSETTINGS_VTBL_SLOT] : nullptr;
@@ -219,12 +271,13 @@ static void HookControllerVtable(void* helper) {
         GetSettings_Orig = reinterpret_cast<GetSettings_t>(*g_vtblSlot);
         *g_vtblSlot = reinterpret_cast<void*>(GetSettings_Hook);
         VirtualProtect(g_vtblSlot, sizeof(void*), oldProtect, &oldProtect);
+        g_controller = controller;  // pin the proxy so its vtable page stays mapped
         Wh_Log(L"settings cache active (controller vtable hooked)");
     } else {
         g_vtblHooked = false;
+        controller->Release();
         Wh_Log(L"VirtualProtect failed; settings cache disabled");
     }
-    controller->Release();
 }
 
 // ---------------------------------------------------------------------------
@@ -234,10 +287,12 @@ static void HookControllerVtable(void* helper) {
 // NotificationsAppListHelper::_AddEntry(aumid, ...) runs once per app on the
 // Settings UI thread. We use it as a reliable trigger: after the first entry the
 // controller exists at helper+0x108, and we patch its vtable once. It is also
-// where we drain proxies queued by a flush, since this is their owning thread.
+// where we record the owning thread and drain proxies queued by a flush, since
+// this is their owning apartment.
 using AddEntry_t = HRESULT (__cdecl*)(void* helper, PCWSTR aumid, unsigned long long opt);
 static AddEntry_t AddEntry_Orig = nullptr;
 HRESULT __cdecl AddEntry_Hook(void* helper, PCWSTR aumid, unsigned long long opt) {
+    g_uiThreadId.store(GetCurrentThreadId());
     DrainPendingReleases();
     HookControllerVtable(helper);  // no-op after the vtable is patched
     return AddEntry_Orig(helper, aumid, opt);
@@ -274,7 +329,7 @@ static void HookHandlerDll(bool applyNow) {
     };
 
     if (!WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks))) {
-        g_symHooked = false;  // symbols not ready yet
+        g_symHooked = false;  // symbols not ready yet; the worker retries on reload
         Wh_Log(L"HookSymbols failed (symbols not ready?)");
         return;
     }
@@ -305,27 +360,40 @@ typedef VOID(CALLBACK* WH_LDR_DLL_NOTIFICATION_FUNCTION)(
 typedef LONG(NTAPI* LdrRegisterDllNotification_t)(
     ULONG, WH_LDR_DLL_NOTIFICATION_FUNCTION, PVOID, PVOID*);
 typedef LONG(NTAPI* LdrUnregisterDllNotification_t)(PVOID);
-static const ULONG WH_LDR_DLL_NOTIFICATION_REASON_LOADED = 1;
+static const ULONG WH_LDR_DLL_NOTIFICATION_REASON_LOADED   = 1;
+static const ULONG WH_LDR_DLL_NOTIFICATION_REASON_UNLOADED = 2;
 
 static PVOID  g_ldrCookie = nullptr;
 static HANDLE g_dllLoadedEvent = nullptr;    // signalled by the loader callback
 static HANDLE g_hookWorkerThread = nullptr;
 
-// Runs under the loader lock, so keep it minimal: check the name and signal. The
-// actual hooking (HookSymbols downloads a PDB) happens on the worker thread.
+// Runs under the loader lock, so keep it minimal: exact name check, then either
+// signal the worker (on load) or drop our latches (on unload) with no COM calls.
 static VOID CALLBACK DllNotification(ULONG reason,
                                      const WH_LDR_DLL_NOTIFICATION_DATA* data, PVOID) {
-    if (reason != WH_LDR_DLL_NOTIFICATION_REASON_LOADED || !data ||
-        !data->BaseDllName || !data->BaseDllName->Buffer)
-        return;
+    if (!data || !data->BaseDllName || !data->BaseDllName->Buffer) return;
     const WH_UNICODE_STRING* n = data->BaseDllName;
     USHORT chars = n->Length / sizeof(WCHAR);
     if (chars == 0 || chars > MAX_PATH) return;
     wchar_t name[MAX_PATH + 1];
     memcpy(name, n->Buffer, chars * sizeof(WCHAR));
     name[chars] = L'\0';
-    if (StrStrIW(name, L"SettingsHandlers_Notifications") && g_dllLoadedEvent)
-        SetEvent(g_dllLoadedEvent);
+    if (_wcsicmp(name, L"SettingsHandlers_Notifications.dll") != 0) return;
+
+    if (reason == WH_LDR_DLL_NOTIFICATION_REASON_LOADED) {
+        if (g_dllLoadedEvent) SetEvent(g_dllLoadedEvent);
+    } else if (reason == WH_LDR_DLL_NOTIFICATION_REASON_UNLOADED) {
+        // The DLL, its helper, and the patched vtable are going away. Drop our
+        // latches so the next load re-hooks, and null the dangling vtable pointer
+        // so teardown never writes into freed/recycled memory. No COM here: we
+        // can't safely release the proxy under the loader lock, and it dies with
+        // the DLL anyway.
+        g_vtblHooked  = false;
+        g_vtblSlot    = nullptr;
+        g_controller  = nullptr;  // ref leaks; the proxy is being torn down
+        g_hookAttempts = 0;
+        g_symHooked   = false;
+    }
 }
 
 // Installs the symbol hooks off the loader lock once the handler DLL appears.
@@ -342,71 +410,76 @@ DWORD WINAPI HookWorkerThread(LPVOID) {
 }
 
 // ---------------------------------------------------------------------------
-// Ctrl+Alt+R clears the cache. RegisterHotKey needs a message loop, so it runs
-// on its own thread that exits on WM_QUIT (posted from Wh_ModUninit) and is
-// joined before unload.
-// ---------------------------------------------------------------------------
-static HANDLE g_hotkeyThread = nullptr;
-static DWORD  g_hotkeyThreadId = 0;
-static HANDLE g_hotkeyReady = nullptr;  // set once the thread's queue exists
-static const int HOTKEY_ID = 1;
-
-DWORD WINAPI HotkeyThread(LPVOID) {
-    // Force the message queue to exist so Wh_ModUninit's PostThreadMessage lands.
-    MSG msg;
-    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
-
-    bool registered =
-        RegisterHotKey(nullptr, HOTKEY_ID, MOD_CONTROL | MOD_ALT | MOD_NOREPEAT, 'R');
-    if (!registered)
-        Wh_Log(L"RegisterHotKey failed (%lu)", GetLastError());
-
-    if (g_hotkeyReady) SetEvent(g_hotkeyReady);
-
-    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
-        if (msg.message == WM_HOTKEY && msg.wParam == HOTKEY_ID)
-            FlushCache();
-    }
-
-    if (registered) UnregisterHotKey(nullptr, HOTKEY_ID);
-    return 0;
-}
-
-// ---------------------------------------------------------------------------
 static void LoadSettings() {
     g_skipSummary   = Wh_GetIntSetting(L"skipSummary") != 0;
     g_cacheSettings = Wh_GetIntSetting(L"cacheSettings") != 0;
 }
 
+// Runs on the UI thread (via RunFromWindowThread) at unload: pull the vtable
+// hook and release everything in the apartment that owns it.
+static void WINAPI ReleaseComStateOnUiThread(PVOID) {
+    if (g_vtblHooked.load() && g_vtblSlot && GetSettings_Orig) {
+        DWORD oldProtect;
+        if (VirtualProtect(g_vtblSlot, sizeof(void*), PAGE_READWRITE, &oldProtect)) {
+            if (*g_vtblSlot == reinterpret_cast<void*>(GetSettings_Hook))
+                *g_vtblSlot = reinterpret_cast<void*>(GetSettings_Orig);
+            VirtualProtect(g_vtblSlot, sizeof(void*), oldProtect, &oldProtect);
+        }
+    }
+    if (g_controller) { g_controller->Release(); g_controller = nullptr; }
+
+    std::vector<IUnknown*> toRelease;
+    {
+        std::unique_lock lock(g_cacheMutex);
+        toRelease.swap(g_pendingRelease);
+        for (auto& kv : g_cache)
+            if (kv.second) toRelease.push_back(kv.second);
+        g_cache.clear();
+    }
+    for (IUnknown* p : toRelease)
+        if (p) p->Release();
+}
+
 BOOL Wh_ModInit() {
     LoadSettings();
 
-    g_stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);        // manual reset
+    g_runFromWindowThreadMsg = RegisterWindowMessageW(
+        L"Windhawk_RunFromWindowThread_notifications-settings-page-speedup");
+    g_stopEvent      = CreateEventW(nullptr, TRUE, FALSE, nullptr);   // manual reset
     g_dllLoadedEvent = CreateEventW(nullptr, FALSE, FALSE, nullptr);  // auto reset
 
-    HookHandlerDll(false);  // in case the DLL is already loaded
+    HookHandlerDll(false);  // in case the DLL is already loaded (Windhawk applies
+                            // the hooks after Wh_ModInit returns)
 
-    // Catch future loads of the handler DLL through any path.
+    // Catch future loads (and unloads) of the handler DLL through any path.
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
     auto reg = ntdll ? (LdrRegisterDllNotification_t)GetProcAddress(
                            ntdll, "LdrRegisterDllNotification")
                      : nullptr;
     if (!reg || reg(0, DllNotification, nullptr, &g_ldrCookie) != 0)
         Wh_Log(L"LdrRegisterDllNotification unavailable");
-
-    g_hookWorkerThread =
-        CreateThread(nullptr, 0, HookWorkerThread, nullptr, 0, nullptr);
-
-    g_hotkeyReady = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    g_hotkeyThread =
-        CreateThread(nullptr, 0, HotkeyThread, nullptr, 0, &g_hotkeyThreadId);
     return TRUE;
 }
 
-void Wh_ModSettingsChanged() { LoadSettings(); }
+// Hook operations are only legal between Wh_ModInit returning and
+// Wh_ModBeforeUninit returning, so the worker (which calls Wh_ApplyHookOperations)
+// lives entirely inside that window.
+void Wh_ModAfterInit() {
+    g_hookWorkerThread =
+        CreateThread(nullptr, 0, HookWorkerThread, nullptr, 0, nullptr);
+}
 
-void Wh_ModUninit() {
-    // Unregister the loader callback first so it can't fire during teardown.
+void Wh_ModSettingsChanged() {
+    bool wasCaching = g_cacheSettings.load();
+    LoadSettings();
+    if (wasCaching && !g_cacheSettings.load())
+        FlushCache();  // turning caching off clears the cache; next open rescans
+}
+
+void Wh_ModBeforeUninit() {
+    g_uninitializing.store(true);
+
+    // Stop the loader callback first so it can't fire during teardown.
     if (g_ldrCookie) {
         HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
         auto unreg = ntdll ? (LdrUnregisterDllNotification_t)GetProcAddress(
@@ -416,40 +489,37 @@ void Wh_ModUninit() {
         g_ldrCookie = nullptr;
     }
 
-    // Stop and join the worker threads before their code can be unmapped.
+    // Stop and join the worker while hook operations are still legal, so any hook
+    // it was mid-installing is applied here and Windhawk still removes it.
     if (g_stopEvent) SetEvent(g_stopEvent);
-    if (g_hotkeyThread) {
-        if (g_hotkeyReady)
-            WaitForSingleObject(g_hotkeyReady, INFINITE);  // queue exists now
-        PostThreadMessageW(g_hotkeyThreadId, WM_QUIT, 0, 0);
+    if (g_hookWorkerThread) {
+        WaitForSingleObject(g_hookWorkerThread, INFINITE);
+        CloseHandle(g_hookWorkerThread);
+        g_hookWorkerThread = nullptr;
     }
-    HANDLE threads[2];
-    DWORD n = 0;
-    if (g_hookWorkerThread) threads[n++] = g_hookWorkerThread;
-    if (g_hotkeyThread)     threads[n++] = g_hotkeyThread;
-    if (n) WaitForMultipleObjects(n, threads, TRUE, INFINITE);
-    if (g_hookWorkerThread) { CloseHandle(g_hookWorkerThread); g_hookWorkerThread = nullptr; }
-    if (g_hotkeyThread)     { CloseHandle(g_hotkeyThread);     g_hotkeyThread = nullptr; }
-    if (g_hotkeyReady)      { CloseHandle(g_hotkeyReady);      g_hotkeyReady = nullptr; }
-    if (g_dllLoadedEvent)   { CloseHandle(g_dllLoadedEvent);   g_dllLoadedEvent = nullptr; }
-    if (g_stopEvent)        { CloseHandle(g_stopEvent);        g_stopEvent = nullptr; }
+}
 
-    // Restore the controller vtable slot.
-    if (g_vtblHooked.load() && g_vtblSlot && GetSettings_Orig) {
-        DWORD oldProtect;
-        if (VirtualProtect(g_vtblSlot, sizeof(void*), PAGE_READWRITE, &oldProtect)) {
-            *g_vtblSlot = reinterpret_cast<void*>(GetSettings_Orig);
-            VirtualProtect(g_vtblSlot, sizeof(void*), oldProtect, &oldProtect);
+void Wh_ModUninit() {
+    // Restore the vtable slot and release the proxies on their owning UI thread.
+    bool ran = false;
+    if (DWORD tid = g_uiThreadId.load()) {
+        if (HWND hWnd = GetWindowOnThread(tid))
+            ran = RunFromWindowThread(hWnd, ReleaseComStateOnUiThread, nullptr);
+    }
+    if (!ran) {
+        // Couldn't reach the UI thread. Still pull the hook so SystemSettings
+        // doesn't call into unmapped code, but leave the proxies alone since a
+        // cross-apartment release is worse than a leak at process teardown.
+        if (g_vtblHooked.load() && g_vtblSlot && GetSettings_Orig) {
+            DWORD oldProtect;
+            if (VirtualProtect(g_vtblSlot, sizeof(void*), PAGE_READWRITE, &oldProtect)) {
+                if (*g_vtblSlot == reinterpret_cast<void*>(GetSettings_Hook))
+                    *g_vtblSlot = reinterpret_cast<void*>(GetSettings_Orig);
+                VirtualProtect(g_vtblSlot, sizeof(void*), oldProtect, &oldProtect);
+            }
         }
     }
 
-    // Release the cached proxies and anything a flush queued. At unload the
-    // owning UI thread is idle and pumping, so the release completes there.
-    std::unique_lock lock(g_cacheMutex);
-    for (IUnknown* p : g_pendingRelease)
-        if (p) p->Release();
-    g_pendingRelease.clear();
-    for (auto& kv : g_cache)
-        if (kv.second) kv.second->Release();
-    g_cache.clear();
+    if (g_dllLoadedEvent) { CloseHandle(g_dllLoadedEvent); g_dllLoadedEvent = nullptr; }
+    if (g_stopEvent)      { CloseHandle(g_stopEvent);      g_stopEvent = nullptr; }
 }

--- a/mods/notifications-settings-page-speedup.wh.cpp
+++ b/mods/notifications-settings-page-speedup.wh.cpp
@@ -274,7 +274,7 @@ static void HookHandlerDll(bool applyNow) {
     };
 
     if (!WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks))) {
-        g_symHooked = false;  // symbols not ready; the watcher retries
+        g_symHooked = false;  // symbols not ready yet
         Wh_Log(L"HookSymbols failed (symbols not ready?)");
         return;
     }
@@ -283,29 +283,59 @@ static void HookHandlerDll(bool applyNow) {
     Wh_Log(L"installed symbol hooks");
 }
 
-// The handler DLL loads on demand when the Notifications page opens. Hooking the
-// imported LoadLibraryExW catches that load; a short watcher backs it up for
-// load paths this hook misses. (Hooking kernelbase's LoadLibraryExW directly
-// would catch every path but fast-fails SystemSettings under CFG, so it is not
-// used here.)
-using LoadLibraryExW_t = HMODULE (WINAPI*)(LPCWSTR, HANDLE, DWORD);
-static LoadLibraryExW_t LoadLibraryExW_Orig;
-HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR name, HANDLE file, DWORD flags) {
-    HMODULE m = LoadLibraryExW_Orig(name, file, flags);
-    if (m && name && StrStrIW(name, L"SettingsHandlers_Notifications"))
-        HookHandlerDll(true);
-    return m;
+// The handler DLL loads on demand when the Notifications page opens. Rather than
+// detour a load function (which misses load paths that don't go through it, and
+// hooking kernelbase's LoadLibraryExW directly fast-fails SystemSettings under
+// CFG), ask the loader to notify us. LdrRegisterDllNotification fires for every
+// load path, needs no detour, and lets the polling backstop go away.
+typedef struct _WH_UNICODE_STRING {
+    USHORT Length;
+    USHORT MaximumLength;
+    PWSTR  Buffer;
+} WH_UNICODE_STRING;
+typedef struct _WH_LDR_DLL_NOTIFICATION_DATA {
+    ULONG Flags;
+    const WH_UNICODE_STRING* FullDllName;
+    const WH_UNICODE_STRING* BaseDllName;
+    PVOID DllBase;
+    ULONG SizeOfImage;
+} WH_LDR_DLL_NOTIFICATION_DATA;
+typedef VOID(CALLBACK* WH_LDR_DLL_NOTIFICATION_FUNCTION)(
+    ULONG, const WH_LDR_DLL_NOTIFICATION_DATA*, PVOID);
+typedef LONG(NTAPI* LdrRegisterDllNotification_t)(
+    ULONG, WH_LDR_DLL_NOTIFICATION_FUNCTION, PVOID, PVOID*);
+typedef LONG(NTAPI* LdrUnregisterDllNotification_t)(PVOID);
+static const ULONG WH_LDR_DLL_NOTIFICATION_REASON_LOADED = 1;
+
+static PVOID  g_ldrCookie = nullptr;
+static HANDLE g_dllLoadedEvent = nullptr;    // signalled by the loader callback
+static HANDLE g_hookWorkerThread = nullptr;
+
+// Runs under the loader lock, so keep it minimal: check the name and signal. The
+// actual hooking (HookSymbols downloads a PDB) happens on the worker thread.
+static VOID CALLBACK DllNotification(ULONG reason,
+                                     const WH_LDR_DLL_NOTIFICATION_DATA* data, PVOID) {
+    if (reason != WH_LDR_DLL_NOTIFICATION_REASON_LOADED || !data ||
+        !data->BaseDllName || !data->BaseDllName->Buffer)
+        return;
+    const WH_UNICODE_STRING* n = data->BaseDllName;
+    USHORT chars = n->Length / sizeof(WCHAR);
+    if (chars == 0 || chars > MAX_PATH) return;
+    wchar_t name[MAX_PATH + 1];
+    memcpy(name, n->Buffer, chars * sizeof(WCHAR));
+    name[chars] = L'\0';
+    if (StrStrIW(name, L"SettingsHandlers_Notifications") && g_dllLoadedEvent)
+        SetEvent(g_dllLoadedEvent);
 }
 
-// Backstop for a load the LoadLibraryExW hook misses. Waits on g_stopEvent so it
-// exits at once on unload instead of sleeping into unmapped code.
-static HANDLE g_watchThread = nullptr;
-DWORD WINAPI WatchThread(LPVOID) {
-    for (int i = 0; i < 600; ++i) {
-        if (!g_symHooked.load() &&
-            GetModuleHandleW(L"SettingsHandlers_Notifications.dll"))
+// Installs the symbol hooks off the loader lock once the handler DLL appears.
+DWORD WINAPI HookWorkerThread(LPVOID) {
+    HANDLE waits[2] = {g_stopEvent, g_dllLoadedEvent};
+    for (;;) {
+        DWORD w = WaitForMultipleObjects(2, waits, FALSE, INFINITE);
+        if (w == WAIT_OBJECT_0 + 1)      // g_dllLoadedEvent
             HookHandlerDll(true);
-        if (WaitForSingleObject(g_stopEvent, 200) == WAIT_OBJECT_0)
+        else                             // g_stopEvent, or an error
             break;
     }
     return 0;
@@ -351,13 +381,21 @@ static void LoadSettings() {
 BOOL Wh_ModInit() {
     LoadSettings();
 
-    g_stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);  // manual reset
+    g_stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);        // manual reset
+    g_dllLoadedEvent = CreateEventW(nullptr, FALSE, FALSE, nullptr);  // auto reset
 
-    WindhawkUtils::SetFunctionHook((void*)LoadLibraryExW, (void*)LoadLibraryExW_Hook,
-                                   (void**)&LoadLibraryExW_Orig);
     HookHandlerDll(false);  // in case the DLL is already loaded
 
-    g_watchThread = CreateThread(nullptr, 0, WatchThread, nullptr, 0, nullptr);
+    // Catch future loads of the handler DLL through any path.
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    auto reg = ntdll ? (LdrRegisterDllNotification_t)GetProcAddress(
+                           ntdll, "LdrRegisterDllNotification")
+                     : nullptr;
+    if (!reg || reg(0, DllNotification, nullptr, &g_ldrCookie) != 0)
+        Wh_Log(L"LdrRegisterDllNotification unavailable");
+
+    g_hookWorkerThread =
+        CreateThread(nullptr, 0, HookWorkerThread, nullptr, 0, nullptr);
 
     g_hotkeyReady = CreateEventW(nullptr, TRUE, FALSE, nullptr);
     g_hotkeyThread =
@@ -368,6 +406,16 @@ BOOL Wh_ModInit() {
 void Wh_ModSettingsChanged() { LoadSettings(); }
 
 void Wh_ModUninit() {
+    // Unregister the loader callback first so it can't fire during teardown.
+    if (g_ldrCookie) {
+        HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+        auto unreg = ntdll ? (LdrUnregisterDllNotification_t)GetProcAddress(
+                                 ntdll, "LdrUnregisterDllNotification")
+                           : nullptr;
+        if (unreg) unreg(g_ldrCookie);
+        g_ldrCookie = nullptr;
+    }
+
     // Stop and join the worker threads before their code can be unmapped.
     if (g_stopEvent) SetEvent(g_stopEvent);
     if (g_hotkeyThread) {
@@ -377,13 +425,14 @@ void Wh_ModUninit() {
     }
     HANDLE threads[2];
     DWORD n = 0;
-    if (g_watchThread)  threads[n++] = g_watchThread;
-    if (g_hotkeyThread) threads[n++] = g_hotkeyThread;
+    if (g_hookWorkerThread) threads[n++] = g_hookWorkerThread;
+    if (g_hotkeyThread)     threads[n++] = g_hotkeyThread;
     if (n) WaitForMultipleObjects(n, threads, TRUE, INFINITE);
-    if (g_watchThread)  { CloseHandle(g_watchThread);  g_watchThread = nullptr; }
-    if (g_hotkeyThread) { CloseHandle(g_hotkeyThread); g_hotkeyThread = nullptr; }
-    if (g_hotkeyReady)  { CloseHandle(g_hotkeyReady);  g_hotkeyReady = nullptr; }
-    if (g_stopEvent)    { CloseHandle(g_stopEvent);    g_stopEvent = nullptr; }
+    if (g_hookWorkerThread) { CloseHandle(g_hookWorkerThread); g_hookWorkerThread = nullptr; }
+    if (g_hotkeyThread)     { CloseHandle(g_hotkeyThread);     g_hotkeyThread = nullptr; }
+    if (g_hotkeyReady)      { CloseHandle(g_hotkeyReady);      g_hotkeyReady = nullptr; }
+    if (g_dllLoadedEvent)   { CloseHandle(g_dllLoadedEvent);   g_dllLoadedEvent = nullptr; }
+    if (g_stopEvent)        { CloseHandle(g_stopEvent);        g_stopEvent = nullptr; }
 
     // Restore the controller vtable slot.
     if (g_vtblHooked.load() && g_vtblSlot && GetSettings_Orig) {

--- a/mods/notifications-settings-page-speedup.wh.cpp
+++ b/mods/notifications-settings-page-speedup.wh.cpp
@@ -74,7 +74,10 @@ static std::atomic<bool> g_uninitializing{false};
 
 // The Settings UI thread: the thread that runs _AddEntry and the controller call,
 // and therefore owns the cached apartment-bound proxies. Captured in AddEntry_Hook.
+// The id is what Wh_ModUninit needs to find a window on that thread; the handle is
+// what liveness is checked against, since ids get recycled and handles don't.
 static std::atomic<DWORD> g_uiThreadId{0};
+static HANDLE g_uiThreadHandle = nullptr;
 
 // ---------------------------------------------------------------------------
 // Run a callback on the thread that owns a given window. Used at unload to
@@ -153,12 +156,12 @@ static HWND GetWindowOnThread(DWORD threadId) {
 // the UI thread with RunFromWindowThread. The owning thread is latched by the
 // first enumeration and never re-latched while it lives, so an enumeration on a
 // different apartment skips the cache (slower, but it never gets a proxy it can't
-// legally call). If that thread has exited, the proxies are unreachable and get
-// dropped rather than released.
+// legally call). If that thread has exited, everything it owned (the cached
+// proxies and the controller) is unreachable and gets dropped rather than
+// released, and the new owner starts again from scratch.
 //
-// The same goes for the handler DLL unloading: it serves all of these objects, so
-// once it goes they are dropped without a Release, since calling through them
-// would mean calling into an unmapped module.
+// The handler DLL itself is referenced while the hooks are installed, so it can't
+// unload underneath any of this.
 // ---------------------------------------------------------------------------
 static const size_t CTRL_PTR_OFFSET       = 0x108;  // helper -> controller ComPtr
 static const size_t GETSETTINGS_VTBL_SLOT = 14;     // 0x70 / sizeof(void*)
@@ -170,21 +173,18 @@ static void** g_vtblSlot = nullptr;
 static IUnknown* g_controller = nullptr;  // pinned while the patch is installed
 static std::atomic<bool> g_vtblHooked{false};
 
-// Set when the handler DLL unloads. Everything we hold (the controller and every
-// cached proxy) is served by that DLL, so once it goes the pointers are dead and
-// calling Release through them would be calling into an unmapped module. The flag
-// says "drop these, do not release them"; it is checked wherever the cache is read
-// or freed, and cleared on the UI thread at the next enumeration, since the
-// containers can't be touched from the loader callback.
-static std::atomic<bool> g_cacheDead{false};
+// Set when the apartment that created the cached proxies has exited. Nothing can
+// legally call through them after that, not even Release, so the flag says "drop
+// these, don't release them". Checked wherever the cache is read or freed, and
+// cleared by the new owner at the next enumeration.
+static std::atomic<bool> g_ownerGone{false};
 
-// Drop the cached pointers without releasing them, after the DLL that served them
-// has gone. Must run on the UI thread (it takes the cache lock).
+// Drop the cached pointers without releasing them. Runs on the UI thread.
 static void AbandonCache() {
     std::unique_lock lock(g_cacheMutex);
     g_cache.clear();
     g_pendingRelease.clear();
-    Wh_Log(L"handler dll unloaded; cached objects dropped without release");
+    Wh_Log(L"owning thread gone; cached objects dropped without release");
 }
 
 // Release proxies queued by a flush. Called from _AddEntry, i.e. the UI thread
@@ -196,7 +196,7 @@ static void DrainPendingReleases() {
         if (g_pendingRelease.empty()) return;
         toRelease.swap(g_pendingRelease);
     }
-    if (g_cacheDead.load()) return;  // Their server is gone; dropping is all we can do.
+    if (g_ownerGone.load()) return;  // Nothing here can be called anymore, dropping is all we can do.
     for (IUnknown* p : toRelease)
         if (p) p->Release();
 }
@@ -218,7 +218,7 @@ static GetSettings_t GetSettings_Orig = nullptr;
 HRESULT STDMETHODCALLTYPE GetSettings_Hook(void* self, PCWSTR aumid, void** out) {
     // Only use the cache on the thread that created the proxies; a proxy handed to
     // another apartment would fail its reads with RPC_E_WRONG_THREAD.
-    if (g_cacheSettings.load() && aumid && out && !g_cacheDead.load() &&
+    if (g_cacheSettings.load() && aumid && out && !g_ownerGone.load() &&
         GetCurrentThreadId() == g_uiThreadId.load()) {
         {
             std::shared_lock lk(g_cacheMutex);
@@ -282,9 +282,8 @@ static IUnknown* FindController(void* helper) {
 }
 
 // Put the original pointer back in the patched vtable slot. VirtualProtect plus a
-// single store, no COM and no loader re-entry, so it is safe to call from the DLL
-// unload notification as well as at teardown. The compare means a slot somebody
-// else has since taken over is left alone.
+// single store, no COM involved. The compare means a slot somebody else has since
+// taken over is left alone.
 static void RestoreVtableSlot() {
     if (!g_vtblHooked.load() || !g_vtblSlot || !GetSettings_Orig) return;
     DWORD oldProtect;
@@ -302,6 +301,9 @@ static const int MAX_HOOK_ATTEMPTS = 8;
 
 static void HookControllerVtable(void* helper) {
     if (g_uninitializing.load() || g_vtblHooked.load()) return;
+    // Nothing to patch for if the cache is off; the README says turning it off
+    // reverts the page to normal, so don't pin a controller for nothing either.
+    if (!g_cacheSettings.load()) return;
     if (g_hookAttempts.fetch_add(1) >= MAX_HOOK_ATTEMPTS) return;
 
     IUnknown* controller = FindController(helper);
@@ -309,7 +311,14 @@ static void HookControllerVtable(void* helper) {
 
     void** vtbl = *reinterpret_cast<void***>(controller);
     void* target = (vtbl && MemReadable(vtbl)) ? vtbl[GETSETTINGS_VTBL_SLOT] : nullptr;
-    if (!target || !MemExecutable(target)) { controller->Release(); return; }
+    // A slot still holding our own hook means an earlier restore didn't take.
+    // Patching it again would set GetSettings_Orig to GetSettings_Hook and the hook
+    // would call itself forever.
+    if (!target || target == reinterpret_cast<void*>(GetSettings_Hook) ||
+        !MemExecutable(target)) {
+        controller->Release();
+        return;
+    }
 
     if (g_vtblHooked.exchange(true)) { controller->Release(); return; }
 
@@ -340,12 +349,23 @@ static void HookControllerVtable(void* helper) {
 using AddEntry_t = HRESULT (__cdecl*)(void* helper, PCWSTR aumid, unsigned long long opt);
 static AddEntry_t AddEntry_Orig = nullptr;
 // True while a thread id still refers to a running thread.
-static bool ThreadAlive(DWORD threadId) {
-    HANDLE h = OpenThread(SYNCHRONIZE, FALSE, threadId);
-    if (!h) return false;
-    bool alive = WaitForSingleObject(h, 0) == WAIT_TIMEOUT;
-    CloseHandle(h);
-    return alive;
+// Liveness is checked through a handle we hold, not by reopening the id: thread
+// ids are recycled, so an id whose thread exited can come back attached to an
+// unrelated new thread, and that thread would then pass as the owner and be handed
+// proxies it can't legally call.
+static bool OwnerAlive() {
+    return g_uiThreadHandle &&
+           WaitForSingleObject(g_uiThreadHandle, 0) == WAIT_TIMEOUT;
+}
+
+// Latch this thread as the owner. Only ever called on the thread itself, so the
+// id is unambiguous and the handle refers to the right thread.
+static void TakeOwnership(DWORD self) {
+    if (g_uiThreadHandle) {
+        CloseHandle(g_uiThreadHandle);
+    }
+    g_uiThreadHandle = OpenThread(SYNCHRONIZE, FALSE, self);
+    g_uiThreadId.store(self);
 }
 
 HRESULT __cdecl AddEntry_Hook(void* helper, PCWSTR aumid, unsigned long long opt) {
@@ -358,21 +378,33 @@ HRESULT __cdecl AddEntry_Hook(void* helper, PCWSTR aumid, unsigned long long opt
     // the check exists for.
     if (owner == 0) {
         DWORD expected = 0;
-        g_uiThreadId.compare_exchange_strong(expected, self);
+        if (g_uiThreadId.compare_exchange_strong(expected, self)) {
+            TakeOwnership(self);
+        }
         owner = g_uiThreadId.load();
-    } else if (owner != self && !ThreadAlive(owner)) {
-        // The apartment that made the cached proxies has exited, so nothing can
-        // legally release them anymore. Drop them and let this thread take over,
-        // otherwise the cache would be bypassed for the rest of the session.
-        g_cacheDead = true;
-        g_uiThreadId.store(self);
+    } else if (owner != self && !OwnerAlive()) {
+        // The apartment that made all of this has exited, so nothing can legally
+        // be called through any of it, Release included. Give up the controller on
+        // the same terms as the cache and let this thread rediscover its own,
+        // otherwise the cache is bypassed for the rest of the session.
+        //
+        // The slot is restored first, while the controller reference we still hold
+        // keeps its vtable page mapped. Dropping the reference first would leave
+        // RestoreVtableSlot writing into memory that may already be gone.
+        RestoreVtableSlot();
+        g_vtblHooked   = false;
+        g_vtblSlot     = nullptr;
+        g_controller   = nullptr;  // Abandoned, not released.
+        g_hookAttempts = 0;
+        g_ownerGone    = true;
+        TakeOwnership(self);
         owner = self;
     }
 
     // Anything that isn't the owning apartment falls through to the original path:
     // slower, but correct, instead of being handed a proxy it can't call.
     if (owner == self) {
-        if (g_cacheDead.exchange(false)) {
+        if (g_ownerGone.exchange(false)) {
             AbandonCache();
         }
         DrainPendingReleases();
@@ -390,6 +422,8 @@ HRESULT __cdecl PopSummary_Hook(void* self) {
 }
 
 static std::atomic<bool> g_symHooked{false};
+static HMODULE g_handlerDllRef = nullptr;  // Reference dropped in Wh_ModUninit.
+
 static void HookHandlerDll(bool applyNow) {
     if (g_symHooked.exchange(true)) return;
     HMODULE h = GetModuleHandleW(L"SettingsHandlers_Notifications.dll");
@@ -415,6 +449,16 @@ static void HookHandlerDll(bool applyNow) {
         g_symHooked = false;  // symbols not ready yet; the worker retries on reload
         Wh_Log(L"HookSymbols failed (symbols not ready?)");
         return;
+    }
+
+    // Hold a reference for as long as the hooks are installed. HookSymbols only
+    // hands back trampolines, so there is no way to unregister the hooks if the DLL
+    // goes away, and a reload would register a second pair on top of the first
+    // while Windhawk still holds the originals, pointing at an unmapped image.
+    // Keeping the module loaded makes that whole cycle unreachable. The reference
+    // is dropped in Wh_ModUninit, after Windhawk has removed the hooks.
+    if (!g_handlerDllRef) {
+        GetModuleHandleExW(0, L"SettingsHandlers_Notifications.dll", &g_handlerDllRef);
     }
 
     if (applyNow) Wh_ApplyHookOperations();
@@ -443,15 +487,15 @@ typedef VOID(CALLBACK* WH_LDR_DLL_NOTIFICATION_FUNCTION)(
 typedef LONG(NTAPI* LdrRegisterDllNotification_t)(
     ULONG, WH_LDR_DLL_NOTIFICATION_FUNCTION, PVOID, PVOID*);
 typedef LONG(NTAPI* LdrUnregisterDllNotification_t)(PVOID);
-static const ULONG WH_LDR_DLL_NOTIFICATION_REASON_LOADED   = 1;
-static const ULONG WH_LDR_DLL_NOTIFICATION_REASON_UNLOADED = 2;
+static const ULONG WH_LDR_DLL_NOTIFICATION_REASON_LOADED = 1;
 
 static PVOID  g_ldrCookie = nullptr;
 static HANDLE g_dllLoadedEvent = nullptr;    // signalled by the loader callback
 static HANDLE g_hookWorkerThread = nullptr;
 
-// Runs under the loader lock, so keep it minimal: exact name check, then either
-// signal the worker (on load) or drop our latches (on unload) with no COM calls.
+// Runs under the loader lock, so keep it minimal: exact name check, then signal
+// the worker. Only loads are interesting, because the module is referenced while
+// the hooks are installed and so can't unload underneath us.
 static VOID CALLBACK DllNotification(ULONG reason,
                                      const WH_LDR_DLL_NOTIFICATION_DATA* data, PVOID) {
     if (!data || !data->BaseDllName || !data->BaseDllName->Buffer) return;
@@ -465,24 +509,6 @@ static VOID CALLBACK DllNotification(ULONG reason,
 
     if (reason == WH_LDR_DLL_NOTIFICATION_REASON_LOADED) {
         if (g_dllLoadedEvent) SetEvent(g_dllLoadedEvent);
-    } else if (reason == WH_LDR_DLL_NOTIFICATION_REASON_UNLOADED) {
-        // The DLL, its helper, and everything it served are going away, and this
-        // is the last moment the patched slot can be reached: g_vtblSlot is the
-        // only handle on it, so dropping the pointer without restoring first would
-        // leave a live slot aimed at mod code that is about to unmap. The restore
-        // is only VirtualProtect plus a store, which is fine under the loader lock.
-        RestoreVtableSlot();
-        g_vtblHooked  = false;
-        g_vtblSlot    = nullptr;
-        // GetSettings_Orig deliberately keeps its value: a thread that is already
-        // inside the hook still has to have something to call through.
-        // No COM here. The controller and every cached proxy are served by the DLL
-        // that is unloading, so releasing them would call into an unmapping module;
-        // they get dropped instead, on the UI thread, at the next enumeration.
-        g_controller  = nullptr;
-        g_cacheDead   = true;
-        g_hookAttempts = 0;
-        g_symHooked   = false;
     }
 }
 
@@ -516,7 +542,7 @@ struct RELEASE_PARAM {
 static void WINAPI ReleaseComStateOnUiThread(PVOID p) {
     RestoreVtableSlot();
 
-    bool dead = g_cacheDead.load();  // Server gone: drop the pointers, don't call them.
+    bool dead = g_ownerGone.load();  // Owner gone: drop the pointers, do not call them.
     if (g_controller) {
         if (!dead) g_controller->Release();
         g_controller = nullptr;
@@ -601,7 +627,11 @@ void Wh_ModBeforeUninit() {
 
 void Wh_ModUninit() {
     // Restore the vtable slot and release the proxies on their owning UI thread.
-    RELEASE_PARAM param;
+    // Static rather than a local: the send is bounded, but UnhookWindowsHookEx
+    // doesn't wait for a callback that is already running, so a slow cross-process
+    // Release could still be in there when the 5 s expires and write its result
+    // into a stack frame that no longer exists.
+    static RELEASE_PARAM param;
     if (DWORD tid = g_uiThreadId.load()) {
         if (HWND hWnd = GetWindowOnThread(tid))
             RunFromWindowThread(hWnd, ReleaseComStateOnUiThread, &param);
@@ -615,6 +645,10 @@ void Wh_ModUninit() {
         RestoreVtableSlot();
     }
 
+    if (g_uiThreadHandle) { CloseHandle(g_uiThreadHandle); g_uiThreadHandle = nullptr; }
     if (g_dllLoadedEvent) { CloseHandle(g_dllLoadedEvent); g_dllLoadedEvent = nullptr; }
     if (g_stopEvent)      { CloseHandle(g_stopEvent);      g_stopEvent = nullptr; }
+
+    // Last, once the hooks are gone and nothing of ours points into it anymore.
+    if (g_handlerDllRef) { FreeLibrary(g_handlerDllRef); g_handlerDllRef = nullptr; }
 }

--- a/mods/notifications-settings-page-speedup.wh.cpp
+++ b/mods/notifications-settings-page-speedup.wh.cpp
@@ -2,7 +2,7 @@
 // @id              notifications-settings-page-speedup
 // @name            Faster Notifications Settings Page
 // @description     Stops Settings from re-scanning every notification app on each visit, so revisits load in seconds instead of minutes
-// @version         1.0
+// @version         1.1
 // @author          mario0318
 // @github          https://github.com/mario0318
 // @include         SystemSettings.exe
@@ -85,7 +85,11 @@ static std::atomic<bool> g_uninitializing{false};
 // The id is what Wh_ModUninit needs to find a window on that thread; the handle is
 // what liveness is checked against, since ids get recycled and handles don't.
 static std::atomic<DWORD> g_uiThreadId{0};
-static HANDLE g_uiThreadHandle = nullptr;
+static std::atomic<HANDLE> g_uiThreadHandle{nullptr};
+// Winner-selection token for ownership transitions. Held separately from the id
+// that OwnerAlive/AddEntry read, so the handle is always published before the id
+// and only one thread can claim or take over ownership at a time.
+static std::atomic<DWORD> g_ownerClaim{0};
 
 // ---------------------------------------------------------------------------
 // Run a callback on the thread that owns a given window. Used at unload to
@@ -362,18 +366,21 @@ static AddEntry_t AddEntry_Orig = nullptr;
 // unrelated new thread, and that thread would then pass as the owner and be handed
 // proxies it can't legally call.
 static bool OwnerAlive() {
-    return g_uiThreadHandle &&
-           WaitForSingleObject(g_uiThreadHandle, 0) == WAIT_TIMEOUT;
+    HANDLE h = g_uiThreadHandle.load();
+    return h && WaitForSingleObject(h, 0) == WAIT_TIMEOUT;
 }
 
-// Latch this thread as the owner. Only ever called on the thread itself, so the
-// id is unambiguous and the handle refers to the right thread.
+// Latch this thread as the owner. Only ever called on the thread itself, and only
+// by the thread that won g_ownerClaim. The handle is published before the id so a
+// reader can never see an owner id whose liveness handle isn't in place yet, which
+// would make OwnerAlive wrongly report a live owner as dead.
 static void TakeOwnership(DWORD self) {
-    if (g_uiThreadHandle) {
-        CloseHandle(g_uiThreadHandle);
-    }
-    g_uiThreadHandle = OpenThread(SYNCHRONIZE, FALSE, self);
+    HANDLE h = OpenThread(SYNCHRONIZE, FALSE, self);
+    HANDLE old = g_uiThreadHandle.exchange(h);  // Handle visible before the id.
     g_uiThreadId.store(self);
+    if (old) {
+        CloseHandle(old);
+    }
 }
 
 HRESULT __cdecl AddEntry_Hook(void* helper, PCWSTR aumid, unsigned long long opt) {
@@ -385,28 +392,36 @@ HRESULT __cdecl AddEntry_Hook(void* helper, PCWSTR aumid, unsigned long long opt
     // would overwrite it and then match itself, which is the wrong-apartment case
     // the check exists for.
     if (owner == 0) {
+        // Win the claim first, then publish handle-before-id in TakeOwnership. The
+        // claim, not the id, is what serializes the winner, so the id is never made
+        // visible ahead of its handle.
         DWORD expected = 0;
-        if (g_uiThreadId.compare_exchange_strong(expected, self)) {
+        if (g_ownerClaim.compare_exchange_strong(expected, self)) {
             TakeOwnership(self);
         }
         owner = g_uiThreadId.load();
     } else if (owner != self && !OwnerAlive()) {
         // The apartment that made all of this has exited, so nothing can legally
-        // be called through any of it, Release included. Give up the controller on
-        // the same terms as the cache and let this thread rediscover its own,
-        // otherwise the cache is bypassed for the rest of the session.
-        //
-        // The slot is restored first, while the controller reference we still hold
-        // keeps its vtable page mapped. Dropping the reference first would leave
-        // RestoreVtableSlot writing into memory that may already be gone.
-        RestoreVtableSlot();
-        g_vtblHooked   = false;
-        g_vtblSlot     = nullptr;
-        g_controller   = nullptr;  // Abandoned, not released.
-        g_hookAttempts = 0;
-        g_ownerGone    = true;
-        TakeOwnership(self);
-        owner = self;
+        // be called through any of it, Release included. One thread wins the
+        // takeover via the claim; the rest fall through to the slow path. Guarding
+        // it this way stops two threads both taking over and stealing ownership
+        // from each other mid-enumeration.
+        DWORD expected = owner;
+        if (g_ownerClaim.compare_exchange_strong(expected, self)) {
+            // The slot is restored first, while the controller reference we still
+            // hold keeps its vtable page mapped. Dropping the reference first would
+            // leave RestoreVtableSlot writing into memory that may already be gone.
+            RestoreVtableSlot();
+            g_vtblHooked   = false;
+            g_vtblSlot     = nullptr;
+            g_controller   = nullptr;  // Abandoned, not released.
+            g_hookAttempts = 0;
+            g_ownerGone    = true;
+            TakeOwnership(self);
+            owner = self;
+        } else {
+            owner = g_uiThreadId.load();  // Someone else took over.
+        }
     }
 
     // Anything that isn't the owning apartment falls through to the original path:
@@ -434,8 +449,20 @@ static HMODULE g_handlerDllRef = nullptr;  // Reference dropped in Wh_ModUninit.
 
 static void HookHandlerDll(bool applyNow) {
     if (g_symHooked.exchange(true)) return;
-    HMODULE h = GetModuleHandleW(L"SettingsHandlers_Notifications.dll");
-    if (!h) { g_symHooked = false; return; }
+
+    // Take the reference before hooking, and hook through that same handle.
+    // HookSymbols can sit for seconds to minutes on the first symbol download, and
+    // the page can be opened and closed inside that window. GetModuleHandleW takes
+    // no reference, so between it and hooking the DLL could unload and leave hooks
+    // pointing into an unmapped image with nothing holding it. Holding the reference
+    // first closes that window and guarantees the module we hook is the one we keep
+    // mapped. Dropped in Wh_ModUninit after Windhawk has removed the hooks.
+    if (!g_handlerDllRef &&
+        !GetModuleHandleExW(0, L"SettingsHandlers_Notifications.dll",
+                            &g_handlerDllRef)) {
+        g_symHooked = false;  // DLL not loaded yet; the worker retries on reload.
+        return;
+    }
 
     // SettingsHandlers_Notifications.dll
     WindhawkUtils::SYMBOL_HOOK hooks[] = {
@@ -453,20 +480,10 @@ static void HookHandlerDll(bool applyNow) {
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(h, hooks, ARRAYSIZE(hooks))) {
+    if (!WindhawkUtils::HookSymbols(g_handlerDllRef, hooks, ARRAYSIZE(hooks))) {
         g_symHooked = false;  // symbols not ready yet; the worker retries on reload
         Wh_Log(L"HookSymbols failed (symbols not ready?)");
         return;
-    }
-
-    // Hold a reference for as long as the hooks are installed. HookSymbols only
-    // hands back trampolines, so there is no way to unregister the hooks if the DLL
-    // goes away, and a reload would register a second pair on top of the first
-    // while Windhawk still holds the originals, pointing at an unmapped image.
-    // Keeping the module loaded makes that whole cycle unreachable. The reference
-    // is dropped in Wh_ModUninit, after Windhawk has removed the hooks.
-    if (!g_handlerDllRef) {
-        GetModuleHandleExW(0, L"SettingsHandlers_Notifications.dll", &g_handlerDllRef);
     }
 
     if (applyNow) Wh_ApplyHookOperations();
@@ -640,9 +657,15 @@ void Wh_ModUninit() {
     // Release could still be in there when the 5 s expires and write its result
     // into a stack frame that no longer exists.
     static RELEASE_PARAM param;
-    if (DWORD tid = g_uiThreadId.load()) {
-        if (HWND hWnd = GetWindowOnThread(tid))
-            RunFromWindowThread(hWnd, ReleaseComStateOnUiThread, &param);
+    // Only hop to the owning thread if it's still alive. The id alone isn't enough:
+    // ids are recycled, so a dead owner's id can belong to an unrelated live thread,
+    // and releasing the proxies there is the cross-apartment release this whole
+    // design exists to avoid. A dead owner falls through to the local restore below.
+    if (OwnerAlive()) {
+        if (DWORD tid = g_uiThreadId.load()) {
+            if (HWND hWnd = GetWindowOnThread(tid))
+                RunFromWindowThread(hWnd, ReleaseComStateOnUiThread, &param);
+        }
     }
     if (!param.ran) {
         // The callback never got to run: no window, the window died while we were
@@ -653,7 +676,7 @@ void Wh_ModUninit() {
         RestoreVtableSlot();
     }
 
-    if (g_uiThreadHandle) { CloseHandle(g_uiThreadHandle); g_uiThreadHandle = nullptr; }
+    if (HANDLE h = g_uiThreadHandle.exchange(nullptr)) { CloseHandle(h); }
     if (g_dllLoadedEvent) { CloseHandle(g_dllLoadedEvent); g_dllLoadedEvent = nullptr; }
     if (g_stopEvent)      { CloseHandle(g_stopEvent);      g_stopEvent = nullptr; }
 

--- a/mods/notifications-settings-page-speedup.wh.cpp
+++ b/mods/notifications-settings-page-speedup.wh.cpp
@@ -36,6 +36,14 @@ icon, and main on/off toggle**, and you can still open any app to see and change
 rather keep it, turn off **Skip per-app summary lookup** below; revisits are
 still cached, just a bit slower.
 
+Normally, with the subtitle:
+
+![The app list with the per-app summary](https://raw.githubusercontent.com/mario0318/windhawk-mods/fb933635e03340ce07d4b8847fa517172235c631/notifications-settings-page-speedup/with-summary.png)
+
+With the summary skipped:
+
+![The app list with the summary skipped](https://raw.githubusercontent.com/mario0318/windhawk-mods/fb933635e03340ce07d4b8847fa517172235c631/notifications-settings-page-speedup/without-summary.png)
+
 The first open after a fresh sign-in is still slow; only revisits are fast. The
 mod hooks internal functions in `SettingsHandlers_Notifications.dll` by symbol,
 so it may need an update after a major Windows release. Tested on Windows 11.


### PR DESCRIPTION
### Faster Notifications Settings Page

Adds a new mod (`notifications-settings-page-speedup`).

The Windows 11 Settings, System, Notifications page rebuilds its full per-app list on every visit, including when you edit one app and press Back. With many notification senders this takes minutes each time. This mod keeps the first open as-is (it fills a cache) and makes later visits load in a couple of seconds, by skipping a per-app summary line and caching each app's settings object across visits. The cached objects read live data, so edits still show correctly. Both behaviours default on and revert instantly when turned off.

**Trade-off:** skipping the per-app summary removes the small subtitle that shows banners/sounds status at a glance. Every app still shows its name, icon, and main on/off toggle, and all per-app options remain editable by opening the app. This can be turned off to keep the subtitle.

**Approach:** hooks a couple of internal functions in `SettingsHandlers_Notifications.dll` by symbol and caches the per-app object at the controller call that produces it. The offsets are build-specific, so it may need a refresh after a major Windows release.

**Testing:** verified on Windows 11. First open runs the normal full scan; repeat visits, including after editing an app, load in a few seconds with edited toggles shown correctly.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Initial release (v1.0) — new mod.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [x] The submitter, with AI assistance
- - [ ] The submitter, without AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
