### PR TITLE
Customize Windows notifications placement v1.2.4

### DIFF
--- a/mods/notifications-placement.wh.cpp
+++ b/mods/notifications-placement.wh.cpp
@@ -2,7 +2,7 @@
 // @id              notifications-placement
 // @name            Customize Windows notifications placement
 // @description     Move notifications to another monitor or another corner of the screen
-// @version         1.2.3
+// @version         1.2.4
 // @author          m417z
 // @github          https://github.com/m417z
 // @twitter         https://twitter.com/m417z
@@ -736,23 +736,32 @@ void UpdateAnimationDirectionStyle() {
             return false;  // continue enumeration
         }
 
-        FrameworkElement revealGrid = FindChildByName(mainGrid, L"RevealGrid");
-        if (!revealGrid) {
-            // Older Windows 11 versions use this name (before ~Jul 2026).
-            revealGrid = FindChildByName(mainGrid, L"RevealGrid2");
-            if (!revealGrid) {
-                return false;  // continue enumeration
-            }
+        if (FrameworkElement revealGrid =
+                FindChildByName(mainGrid, L"RevealGrid")) {
+            Wh_Log(L"Applying transform to toast view %s", name.c_str());
+
+            Media::RotateTransform transform;
+            transform.Angle(-angle);
+            revealGrid.RenderTransform(transform);
+            revealGrid.RenderTransformOrigin(origin);
+
+            foundAnyRootGridContent = true;
         }
 
-        Wh_Log(L"Applying transform to toast view %s", name.c_str());
+        // Older Windows 11 versions have both RevealGrid and RevealGrid2
+        // (before ~Jul 2026). Newer builds only have RevealGrid.
+        if (FrameworkElement revealGrid2 =
+                FindChildByName(mainGrid, L"RevealGrid2")) {
+            Wh_Log(L"Applying transform to toast view %s", name.c_str());
 
-        Media::RotateTransform transform;
-        transform.Angle(-angle);
-        revealGrid.RenderTransform(transform);
-        revealGrid.RenderTransformOrigin(origin);
+            Media::RotateTransform transform;
+            transform.Angle(-angle);
+            revealGrid2.RenderTransform(transform);
+            revealGrid2.RenderTransformOrigin(origin);
 
-        foundAnyRootGridContent = true;
+            foundAnyRootGridContent = true;
+        }
+
         return false;  // continue enumeration to find all matching children
     });
 


### PR DESCRIPTION
* Fixed a regression in version 1.2.3 which caused notifications to be rotated in older Windows 11 versions.