### PR TITLE
Add Genie + Friends minimize animation pack

### DIFF
--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -1,9 +1,9 @@
 // ==WindhawkMod==
-// @id              genie-minimize-animation-fork
+// @id              genie-and-friends-minimize-animation
 // @name            Genie + Friends minimize animation pack
-// @description     GPU-accelerated macOS/Compiz-style minimize & restore effects — Genie (true mesh bend), Vacuum, Glide, Pop, Slide, Free Fall, Warp, Squash, Roll-Up & Swirl.
-// @version         2.2.1
-// @author          lolstijl & akilluminati47
+// @description     GPU-accelerated macOS/Compiz-style minimize & restore effects: Genie (true mesh bend), Vacuum, Glide, Pop, Slide, Free Fall, Warp, Squash, Roll-Up & Swirl.
+// @version         2.2.2
+// @author          akilluminati47
 // @github          https://github.com/akilluminati47
 // @include         *
 // @compilerOptions -ldwmapi -lgdi32 -ld3d11 -ldxgi -ldcomp -ld3dcompiler
@@ -13,58 +13,68 @@
 /*
 # Genie + Friends minimize animation pack
 
-A fork of the Genie Animation Mod that turns Windows 11's boring minimize/restore
-into a whole menu of Compiz/macOS-flavored effects. Pick one from the **Animation
-style** dropdown in the mod's Settings tab — that dropdown is your toggle between the
-classic Genie and all the new ones. Each style has its own **Duration** slider so you
-can tune the feel of every effect independently, and there's a master **Enable
-animations** switch to fall back to stock Windows without disabling the mod.
+A standalone pack that reproduces the classic minimize/restore effects of
+macOS and the Compiz-era Linux desktops, rendered on the GPU. Pick one from
+the **Animation style** dropdown in the mod's Settings tab; that dropdown is
+your toggle between Genie and the nine other reproductions. Each style has
+its own **Duration** slider so you can tune the feel of every effect
+independently, and there's a master **Enable animations** switch to fall back
+to stock Windows without disabling the mod.
 
 ## The effects
 
-- **Genie — Magic Lamp**: the classic. The window stretches and pours down into the
-  taskbar like a genie into a lamp.
-- **Vacuum**: the whole window shrinks and accelerates as it gets sucked into the
-  taskbar icon.
-- **Glide**: subtle GNOME-style shrink + fade in place. Understated and clean.
+- **Genie (Magic Lamp)**: the macOS classic. The window stretches and pours
+  down into the taskbar like a genie into a lamp.
+- **Vacuum**: the whole window shrinks and accelerates as it gets sucked into
+  the taskbar icon.
+- **Glide**: GNOME-style shrink + fade in place. Understated and clean.
 - **Pop**: the window swells slightly and vanishes. Snappy and modern.
 - **Slide**: KDE-style straight drop off the bottom edge.
-- **Free Fall**: gravity takes over — the window accelerates, stretches, sways, and
-  tumbles off the bottom of the screen.
-- **Warp**: Star Trek transporter. The window squeezes into a thin vertical beam of
-  light, then the beam shoots up and dematerializes.
+- **Free Fall**: gravity takes over; the window accelerates, stretches, sways,
+  and tumbles off the bottom of the screen.
+- **Warp**: Star Trek transporter. The window squeezes into a thin vertical
+  beam of light, then the beam shoots up and dematerializes.
 - **Squash**: the window is flattened like a pancake onto the taskbar.
 - **Roll-Up**: the window rolls up into its own title bar like a window blind.
-- **Swirl**: a whirlpool. The window spins side-to-side while shrinking down into
-  the taskbar like water down a drain.
+- **Swirl**: a whirlpool. The window spins side-to-side while shrinking down
+  into the taskbar like water down a drain.
 
-Restore plays every effect in reverse, so windows *un-genie*, *un-roll*, drop back
-in, etc.
+Restore plays every effect in reverse, so windows *un-genie*, *un-roll*, drop
+back in, etc.
 
-## Notes
-- **v2.2.1 — no more first-frame flash.** The minimize/restore hook now waits (up
-  to 40ms) for the ghost's first frame to actually be on screen before the real
+## How it renders
+
+The window snapshot is handed to the GPU compositor (DirectComposition) once,
+and each frame only pushes a transform + opacity. This stays smooth on
+high-refresh displays (120/144/165/180+ Hz) and uses a fraction of the CPU a
+per-frame `StretchBlt` renderer would. Genie goes further: the snapshot is
+rendered as a tessellated mesh warped every frame by a small GPU shader, so
+the window body curves into a thin neck that pours into the taskbar (the real
+Magic Lamp look). The other nine effects use the cheap single-transform GPU
+path. If the GPU/shader path can't initialize in a given process, the mod
+silently falls back to a GDI renderer, so nothing breaks.
+
+## Changelog
+
+- **v2.2.2**: the pack stands on its own as `genie-and-friends-minimize-animation`.
+- **v2.2.1**: first-frame anti-flash. The minimize/restore hook waits (up to
+  40ms) for the ghost's first frame to actually be on screen before the real
   window changes, so the window can't blink out a few ms before the animation
   appears when GPU setup is momentarily slow.
-- **v2.1 — GPU rendering.** The snapshot is now handed to the GPU compositor
-  (DirectComposition) once, and each frame only pushes a transform + opacity. This
-  is dramatically smoother on high-refresh displays (120/144/165/180+ Hz) and uses a
-  fraction of the CPU the old per-frame `StretchBlt` did. If DirectComposition isn't
-  available in a given process, it silently falls back to the original GDI renderer,
-  so nothing breaks.
-- **v2.2 — true Genie bend.** Genie is no longer a shrink + slide fake: it now renders
-  the snapshot as a tessellated mesh warped every frame by a small GPU shader, so the
-  window body curves into a thin neck that pours into the taskbar (real Magic Lamp).
-  The other nine effects keep the cheap single-transform GPU path. If the shader stack
-  can't init, Genie falls back to the affine/GDI renderer.
-- Windows' own animation API is ancient, so a couple of effects (Warp especially) are
-  clever fakes rather than true 3D — but they read great in motion.
+- **v2.2**: true Genie bend via tessellated mesh + GPU warp shader, replacing
+  the shrink + slide approximation.
+- **v2.1**: GPU rendering via DirectComposition, with GDI fallback.
+- Windows' own animation API is ancient, so a couple of effects (Warp
+  especially) are clever fakes rather than true 3D, but they read great in
+  motion.
+
 ## Credits
-Built on the original **Genie Animation Mod**. **lolstijl** extended it into this
-multi-effect pack (Genie + nine more Compiz/macOS-style effects). **akilluminati47**
-then rewrote the rendering onto the GPU (DirectComposition), added the true
-mesh-warped Genie bend, and the anti-flash timing fix. Development was assisted by
-Claude and Gemini.
+
+The effect selection and the original Genie math originate from **lolstijl**'s
+multi-effect pack, which itself built on the original Genie Animation Mod.
+This pack is maintained by **akilluminati47**, who wrote the GPU
+(DirectComposition) renderer, the mesh-warped Genie bend, and the anti-flash
+timing fix. Development was assisted by Claude and Gemini.
 */
 // ==/WindhawkModReadme==
 
@@ -80,58 +90,58 @@ Claude and Gemini.
   $name: Animation style
   $description: >-
     Which effect plays when you minimize or restore a window. This is your toggle
-    between the classic Genie and all the new Linux-flavored effects. Restore always
+    between the classic Genie and the other reproduced effects. Restore always
     plays the same effect in reverse.
   $options:
-  - genie: Genie — Magic Lamp (pours into the taskbar)
-  - vacuum: Vacuum — sucked into the taskbar icon
-  - glide: Glide — GNOME-style shrink & fade
-  - pop: Pop — swell and vanish
-  - slide: Slide — straight drop off the bottom (KDE)
-  - fall: Free Fall — gravity tumble off screen
-  - warp: Warp — Star Trek transporter beam
-  - squash: Squash — flattened onto the taskbar
-  - rollup: Roll-Up — rolls up like a window blind
-  - swirl: Swirl — whirlpool down the drain
+  - genie: Genie - Magic Lamp (pours into the taskbar)
+  - vacuum: Vacuum - sucked into the taskbar icon
+  - glide: Glide - GNOME-style shrink & fade
+  - pop: Pop - swell and vanish
+  - slide: Slide - straight drop off the bottom (KDE)
+  - fall: Free Fall - gravity tumble off screen
+  - warp: Warp - Star Trek transporter beam
+  - squash: Squash - flattened onto the taskbar
+  - rollup: Roll-Up - rolls up like a window blind
+  - swirl: Swirl - whirlpool down the drain
 
 - duration_genie: 450
-  $name: Duration — Genie (ms)
+  $name: Duration - Genie (ms)
   $description: Clamped to 50-3000. Lower is snappier, higher is more deliberate.
 
 - duration_vacuum: 380
-  $name: Duration — Vacuum (ms)
+  $name: Duration - Vacuum (ms)
   $description: Clamped to 50-3000.
 
 - duration_glide: 300
-  $name: Duration — Glide (ms)
+  $name: Duration - Glide (ms)
   $description: Clamped to 50-3000.
 
 - duration_pop: 260
-  $name: Duration — Pop (ms)
+  $name: Duration - Pop (ms)
   $description: Clamped to 50-3000.
 
 - duration_slide: 340
-  $name: Duration — Slide (ms)
+  $name: Duration - Slide (ms)
   $description: Clamped to 50-3000.
 
 - duration_fall: 620
-  $name: Duration — Free Fall (ms)
+  $name: Duration - Free Fall (ms)
   $description: Clamped to 50-3000.
 
 - duration_warp: 520
-  $name: Duration — Warp (ms)
+  $name: Duration - Warp (ms)
   $description: Clamped to 50-3000.
 
 - duration_squash: 400
-  $name: Duration — Squash (ms)
+  $name: Duration - Squash (ms)
   $description: Clamped to 50-3000.
 
 - duration_rollup: 380
-  $name: Duration — Roll-Up (ms)
+  $name: Duration - Roll-Up (ms)
   $description: Clamped to 50-3000.
 
 - duration_swirl: 700
-  $name: Duration — Swirl (ms)
+  $name: Duration - Swirl (ms)
   $description: Clamped to 50-3000.
 */
 // ==/WindhawkModSettings==
@@ -255,7 +265,7 @@ template <class T> static inline void SafeRelease(T*& p) {
 // drops to a few floats + a Commit, which never misses the frame budget.
 //
 // One D3D11 device + DXGI factory are created lazily per process and reused for
-// every animation (device creation is tens of ms — far too slow to do per
+// every animation (device creation is tens of ms - far too slow to do per
 // minimize). Each animation gets its own lightweight DirectComposition device
 // so its hot loop needs no locks. If any of this fails (no GPU, locked-down
 // process, older Windows), we fall back to the original GDI renderer.
@@ -319,8 +329,8 @@ static void ReleaseGpuDevice() {
 //
 // The other nine effects are pure scale+translate+fade, so they upload the
 // snapshot once and only push a transform per frame. Genie's signature is a
-// non-affine bend — the window body curves into a thin neck that pours into the
-// taskbar — which a single matrix can't express. So Genie instead renders a
+// non-affine bend - the window body curves into a thin neck that pours into the
+// taskbar - which a single matrix can't express. So Genie instead renders a
 // tessellated, textured grid of the snapshot every frame with a tiny HLSL
 // shader, displacing each grid row toward the dock.
 //
@@ -426,7 +436,7 @@ static bool EnsureGenieGpuResources() {
         if (FAILED(ihr)) return false;
     }
 
-    // Constant buffer (alpha) — dynamic, updated per frame.
+    // Constant buffer (alpha) - dynamic, updated per frame.
     {
         D3D11_BUFFER_DESC bd;
         ZeroMemory(&bd, sizeof(bd));
@@ -447,7 +457,7 @@ static bool EnsureGenieGpuResources() {
         if (FAILED(g_d3dDevice->CreateSamplerState(&sd, &g_gSampler))) return false;
     }
 
-    // Cull nothing — the warp can flip triangle winding.
+    // Cull nothing - the warp can flip triangle winding.
     {
         D3D11_RASTERIZER_DESC rd;
         ZeroMemory(&rd, sizeof(rd));
@@ -511,7 +521,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
     switch (d->mode) {
 
     case MODE_GENIE: {
-        // Verbatim math from the original mod — the proven Magic Lamp look.
+        // Verbatim math from the original mod - the proven Magic Lamp look.
         float invT  = 1.0f - t;
         float moveX = 1.0f - (invT * invT * invT * invT * invT * invT);
         float moveY = (0.70f * (t * t)) + (0.10f * t);
@@ -1062,7 +1072,7 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
         return false;
     }
 
-    // Genie shape constants — tweak to taste.
+    // Genie shape constants - tweak to taste.
     const float LEAD     = 1.4f;                          // how far the window's bottom leads its top into the neck
     const float neckW    = (w * 0.05f > 10.0f) ? w * 0.05f : 10.0f; // drained-neck width (px)
     const float sourceCX = data->targetRect.left + w * 0.5f;
@@ -1316,7 +1326,7 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
 
     // Anti-flash: block the caller (the minimize/restore hook) until the ghost's
     // first frame is on screen, so the real window never changes before the
-    // animation exists. Use a LOCAL copy of the handle for the wait — once the
+    // animation exists. Use a LOCAL copy of the handle for the wait - once the
     // thread is spawned it owns `data` and may free it at any time. The cap (40ms)
     // sits under the 50ms minimum duration, so the thread's CloseHandle at
     // animation end can never race this bounded wait.

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -477,7 +477,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
         float moveX = 1.0f - (invT * invT * invT * invT * invT * invT);
         float moveY = (0.70f * (t * t)) + (0.10f * t);
         scaleX = 1.0f - (0.95f * (1.8f * t));
-        if (scaleX < max(0.05f, minScaleX)) scaleX = max(0.05f, minScaleX);
+        { float ms = 0.05f > minScaleX ? 0.05f : minScaleX; if (scaleX < ms) scaleX = ms; }
         scaleY = 1.0f - (0.70f * (t * t));
 
         float startCenterX = cx;
@@ -495,7 +495,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
     case MODE_VACUUM: {
         float e = easeInCubic(t);
         float s = 1.0f - 0.97f * e;
-        if (s < max(0.03f, minScaleX)) s = max(0.03f, minScaleX);
+        { float ms = 0.03f > minScaleX ? 0.03f : minScaleX; if (s < ms) s = ms; }
         scaleX = scaleY = s;
         fx = cx + (dockX - cx) * e;
         fy = cy + (taskbarY - cy) * e;
@@ -541,7 +541,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
     case MODE_WARP: {
         float ramp = t / 0.6f; if (ramp > 1.0f) ramp = 1.0f;
         scaleX = 1.0f - 0.96f * ramp;
-        if (scaleX < max(0.04f, minScaleX)) scaleX = max(0.04f, minScaleX);
+        { float ms = 0.04f > minScaleX ? 0.04f : minScaleX; if (scaleX < ms) scaleX = ms; }
         scaleY = 1.0f;
         anchorTopLeft = true;
         fx = cx;
@@ -581,7 +581,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
     case MODE_SWIRL: {
         float e = easeInCubic(t);
         float s = 1.0f - 0.95f * e;
-        if (s < max(0.05f, minScaleX)) s = max(0.05f, minScaleX);
+        { float ms = 0.05f > minScaleX ? 0.05f : minScaleX; if (s < ms) s = ms; }
         scaleX = scaleY = s;
         float baseCX = cx + (dockX - cx) * e;
         float baseCY = cy + (taskbarY - cy) * e;
@@ -993,7 +993,7 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
     }
 
     const float LEAD     = 1.4f;
-    const float neckW    = (data->iconButtonWidth > 0) ? max((float)data->iconButtonWidth, 10.0f) : max(w * 0.05f, 10.0f);
+    const float neckW    = (data->iconButtonWidth > 0) ? ((float)data->iconButtonWidth > 10.0f ? (float)data->iconButtonWidth : 10.0f) : (w * 0.05f > 10.0f ? w * 0.05f : 10.0f);
     const float sourceCX = data->targetRect.left + w * 0.5f;
     const float dockX    = (float)data->targetDockX;
     const float dockY    = taskbarY;

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -173,7 +173,6 @@ resolved, Windows 11 support) was assisted by Claude.
 #include <string.h>
 #include <atomic>
 #include <unordered_map>
-#include <unordered_set>
 #include <mutex>
 #include <string>
 #include <ole2.h>
@@ -222,7 +221,6 @@ struct GhostAnimData {
     int mode;
     int durationMs;
     LONG_PTR originalExStyle;
-    BOOL wasCloaked;
     HANDLE hReady;
 };
 
@@ -640,10 +638,6 @@ static void SolveFrame(const GhostAnimData* d, float t,
 
 static void FinalizeRealWindow(GhostAnimData* data) {
     if (data->isRising) {
-        if (data->wasCloaked) {
-            BOOL cloaked = FALSE;
-            DwmSetWindowAttribute(data->hRealWnd, DWMWA_CLOAK, &cloaked, sizeof(cloaked));
-        }
         SetLayeredWindowAttributes(data->hRealWnd, 0, 255, LWA_ALPHA);
         if (!(data->originalExStyle & WS_EX_LAYERED)) {
             SetWindowLongPtrW(data->hRealWnd, GWL_EXSTYLE, data->originalExStyle);
@@ -1009,7 +1003,7 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
     }
 
     const float LEAD     = 1.4f;
-    const float neckW    = (data->iconButtonWidth > 0) ? ((float)data->iconButtonWidth > 10.0f ? (float)data->iconButtonWidth : 10.0f) : (w * 0.05f > 10.0f ? w * 0.05f : 10.0f);
+    const float neckW    = (w * 0.05f > 10.0f) ? w * 0.05f : 10.0f;
     const float sourceCX = data->targetRect.left + w * 0.5f;
     const float dockX    = (float)data->targetDockX;
     const float dockY    = taskbarY;
@@ -1120,20 +1114,6 @@ static std::unordered_map<HWND, TbIconPos> g_TaskbarIconCache;
 static std::unordered_map<std::wstring, TbIconPos> g_ProcessIconCache;
 static std::mutex g_TbCacheMutex;
 
-// Guard: only one animation at a time per window.
-static std::unordered_set<HWND> g_animInProgress;
-static std::mutex g_animMtx;
-
-static bool AnimIsInProgress(HWND hWnd) {
-    std::lock_guard<std::mutex> lock(g_animMtx);
-    return g_animInProgress.count(hWnd) != 0;
-}
-static void AnimSetInProgress(HWND hWnd, bool set) {
-    std::lock_guard<std::mutex> lock(g_animMtx);
-    if (set) g_animInProgress.insert(hWnd);
-    else     g_animInProgress.erase(hWnd);
-}
-
 static HWND FindTaskbarForMonitor(HMONITOR hMon) {
     HWND hMainTray = FindWindowW(L"Shell_TrayWnd", NULL);
     HMONITOR mainMon = MonitorFromWindow(hMainTray, MONITOR_DEFAULTTOPRIMARY);
@@ -1200,18 +1180,24 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
 
         IUIAutomationCondition* pButtonCond = NULL;
         IUIAutomationCondition* pListItemCond = NULL;
+        IUIAutomationCondition* pTabItemCond = NULL;
         IUIAutomationCondition* pOrCond = NULL;
+        IUIAutomationCondition* pOrCond2 = NULL;
         VARIANT varBtn; varBtn.vt = VT_I4; varBtn.lVal = UIA_ButtonControlTypeId;
         pAutomation->CreatePropertyCondition(UIA_ControlTypePropertyId, varBtn, &pButtonCond);
         VARIANT varList; varList.vt = VT_I4; varList.lVal = UIA_ListItemControlTypeId;
         pAutomation->CreatePropertyCondition(UIA_ControlTypePropertyId, varList, &pListItemCond);
+        VARIANT varTab; varTab.vt = VT_I4; varTab.lVal = UIA_TabItemControlTypeId;
+        pAutomation->CreatePropertyCondition(UIA_ControlTypePropertyId, varTab, &pTabItemCond);
         if (pButtonCond && pListItemCond)
             pAutomation->CreateOrCondition(pButtonCond, pListItemCond, &pOrCond);
+        if (pOrCond && pTabItemCond)
+            pAutomation->CreateOrCondition(pOrCond, pTabItemCond, &pOrCond2);
 
         auto tryMatch = [&](IUIAutomationElement* pParent) -> bool {
-            if (!pOrCond) return false;
+            if (!pOrCond2) return false;
             IUIAutomationElementArray* pArray = NULL;
-            if (FAILED(pParent->FindAll(TreeScope_Descendants, pOrCond, &pArray)) || !pArray)
+            if (FAILED(pParent->FindAll(TreeScope_Descendants, pOrCond2, &pArray)) || !pArray)
                 return false;
             int length = 0;
             pArray->get_Length(&length);
@@ -1279,7 +1265,7 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
                 IUIAutomationElement* pRoot = NULL;
                 if (SUCCEEDED(pAutomation->GetRootElement(&pRoot)) && pRoot) {
                     IUIAutomationElementArray* pAll = NULL;
-                    if (SUCCEEDED(pRoot->FindAll(TreeScope_Descendants, pOrCond, &pAll)) && pAll) {
+                    if (SUCCEEDED(pRoot->FindAll(TreeScope_Descendants, pOrCond2, &pAll)) && pAll) {
                         int len = 0;
                         pAll->get_Length(&len);
                         int bestScore = 0;
@@ -1333,7 +1319,9 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
 
         if (pButtonCond)    pButtonCond->Release();
         if (pListItemCond)  pListItemCond->Release();
+        if (pTabItemCond)   pTabItemCond->Release();
         if (pOrCond)        pOrCond->Release();
+        if (pOrCond2)       pOrCond2->Release();
         pAutomation->Release();
     }
     if (coInit) CoUninitialize();
@@ -1530,15 +1518,11 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     if (hGhost) DestroyWindow(hGhost);
     DeleteObject(data->hBitmap);
     if (data->hReady) CloseHandle(data->hReady);
-    AnimSetInProgress(data->hRealWnd, false);
     delete data;
     return 0;
 }
 
 void StartGenieAnim(HWND hWnd, BOOL rising) {
-    if (AnimIsInProgress(hWnd)) return;
-    AnimSetInProgress(hWnd, true);
-
     RECT rect;
     GetWindowRect(hWnd, &rect);
     int w = rect.right - rect.left;
@@ -1552,17 +1536,24 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
     mi.cbSize = sizeof(mi);
     GetMonitorInfoW(hMon, &mi);
 
+    // Default dock: monitor centre. Taskbar-click tracking below will override.
+    int defaultDockX = (mi.rcMonitor.left + mi.rcMonitor.right) / 2;
+
+    // If the cursor is on the taskbar (outside the work area), use its X as the
+    // icon position — matches older v2.2.2 behaviour that worked reliably.
+    POINT pt;
+    GetCursorPos(&pt);
+    if (!PtInRect(&mi.rcWork, pt)) {
+        defaultDockX = pt.x;
+    }
+
     GhostAnimData* data = new GhostAnimData();
     data->hRealWnd = hWnd;
     data->targetRect = rect;
     data->width = w;
     data->height = h;
     data->isRising = rising;
-    data->wasCloaked = rising;
-    // Default dock X is the monitor centre; the animation thread will
-    // overwrite this with the actual taskbar-icon centre via
-    // GetTaskbarIconCenter.
-    data->targetDockX = (mi.rcMonitor.left + mi.rcMonitor.right) / 2;
+    data->targetDockX = defaultDockX;
     data->mode = g_mode.load(std::memory_order_relaxed);
     data->durationMs = g_durations[data->mode].load(std::memory_order_relaxed);
     data->originalExStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
@@ -1638,40 +1629,16 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
     if (hReady) WaitForSingleObject(hReady, 40);
 }
 
-// Per-window re-entrancy guard so that when DefWindowProcW_Hook handles
-// SC_MINIMIZE/SC_RESTORE (which internally calls ShowWindow), the nested
-// call through ShowWindow_Hook does not start a second animation.
-static std::unordered_map<HWND, DWORD> g_inSysCmd;
-static std::mutex                      g_sysCmdMtx;
-
-static bool IsInSysCmdOnThisThread(HWND hWnd) {
-    std::lock_guard<std::mutex> lock(g_sysCmdMtx);
-    auto it = g_inSysCmd.find(hWnd);
-    return it != g_inSysCmd.end() && it->second == GetCurrentThreadId();
-}
-
-static void SetSysCmdGuard(HWND hWnd, bool set) {
-    std::lock_guard<std::mutex> lock(g_sysCmdMtx);
-    if (set)
-        g_inSysCmd[hWnd] = GetCurrentThreadId();
-    else
-        g_inSysCmd.erase(hWnd);
-}
-
 BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
     if (g_enabled.load(std::memory_order_relaxed)) {
         if (nCmdShow == SW_MINIMIZE || nCmdShow == SW_SHOWMINIMIZED || nCmdShow == SW_SHOWMINNOACTIVE) {
-            if (!IsInSysCmdOnThisThread(hWnd) && IsWindowVisible(hWnd) && !IsIconic(hWnd)) {
-                SetDwmTransitions(hWnd, FALSE);
-                StartGenieAnim(hWnd, FALSE);
-            }
+            SetDwmTransitions(hWnd, FALSE);
+            StartGenieAnim(hWnd, FALSE);
             return ShowWindow_Original(hWnd, nCmdShow);
         }
         else if (nCmdShow == SW_RESTORE || nCmdShow == SW_SHOWNORMAL) {
-            if (IsIconic(hWnd) && !IsInSysCmdOnThisThread(hWnd)) {
+            if (IsIconic(hWnd)) {
                 SetDwmTransitions(hWnd, FALSE);
-                BOOL cloaked = TRUE;
-                DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &cloaked, sizeof(cloaked));
                 LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
                 SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
                 SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
@@ -1687,10 +1654,6 @@ BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
 LRESULT WINAPI DefWindowProcW_Hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) {
     if (Msg == WM_DESTROY) {
         {
-            std::lock_guard<std::mutex> lock(g_sysCmdMtx);
-            g_inSysCmd.erase(hWnd);
-        }
-        {
             std::lock_guard<std::mutex> lock(g_CacheMutex);
             if (g_SnapshotCache.count(hWnd)) {
                 DeleteObject(g_SnapshotCache[hWnd]);
@@ -1701,25 +1664,18 @@ LRESULT WINAPI DefWindowProcW_Hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 
     if (g_enabled.load(std::memory_order_relaxed) && Msg == WM_SYSCOMMAND) {
         UINT cmd = wParam & 0xFFF0;
-        if (cmd == SC_MINIMIZE && IsWindowVisible(hWnd) && !IsIconic(hWnd)) {
-            SetSysCmdGuard(hWnd, true);
+        if (cmd == SC_MINIMIZE) {
             SetDwmTransitions(hWnd, FALSE);
             StartGenieAnim(hWnd, FALSE);
-            LRESULT res = DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
-            SetSysCmdGuard(hWnd, false);
-            return res;
+            return DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
         }
         else if (cmd == SC_RESTORE && IsIconic(hWnd)) {
-            SetSysCmdGuard(hWnd, true);
             SetDwmTransitions(hWnd, FALSE);
-            BOOL cloaked = TRUE;
-            DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &cloaked, sizeof(cloaked));
             LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
             SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
             SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
             LRESULT res = DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
             StartGenieAnim(hWnd, TRUE);
-            SetSysCmdGuard(hWnd, false);
             return res;
         }
     }

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -6,7 +6,7 @@
 // @author          akilluminati47
 // @github          https://github.com/akilluminati47
 // @include         *
-// @compilerOptions -ldwmapi -lgdi32 -ld3d11 -ldxgi -ldcomp -ld3dcompiler
+// @compilerOptions -ldwmapi -lgdi32 -ld3d11 -ldxgi -ldcomp -ld3dcompiler -lole32 -loleaut32 -luuid -lshell32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -174,6 +174,10 @@ resolved, Windows 11 support) was assisted by Claude.
 #include <atomic>
 #include <unordered_map>
 #include <mutex>
+#include <string>
+#include <ole2.h>
+#include <uiautomation.h>
+#include <shellapi.h>
 
 typedef LRESULT (WINAPI *DefWindowProcW_t)(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 DefWindowProcW_t DefWindowProcW_Original;
@@ -1107,144 +1111,268 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
     return true;
 }
 
-// Build a cache of all taskbar icon positions on the same monitor as hWnd.
-// Matching is by HWND, then owner chain, then root ancestor, then by process
-// ID (for grouped buttons whose dwData references the app frame, not the
-// specific child window). Returns FALSE only when no toolbar can be found,
-// meaning this window genuinely has no taskbar button.
-struct TaskbarIconEntry {
-    HWND hWnd;
-    int  x;
-    int  y;
-    int  width;
-};
+// --- Persistent taskbar icon cache (by HWND and by process+monitor) ---
+static std::unordered_map<HWND, int> g_TaskbarDockXs;
+static std::unordered_map<std::wstring, int> g_ProcessDockXs;
+static std::mutex g_TbCacheMutex;
 
+static HWND FindTaskbarForMonitor(HMONITOR hMon) {
+    HWND hMainTray = FindWindowW(L"Shell_TrayWnd", NULL);
+    HMONITOR mainMon = MonitorFromWindow(hMainTray, MONITOR_DEFAULTTOPRIMARY);
+    if (hMon == mainMon || !hMon) return hMainTray;
+    HWND hSecTray = NULL;
+    while ((hSecTray = FindWindowExW(NULL, hSecTray, L"Shell_SecondaryTrayWnd", NULL)) != NULL) {
+        if (MonitorFromWindow(hSecTray, MONITOR_DEFAULTTONULL) == hMon)
+            return hSecTray;
+    }
+    return hMainTray;
+}
+
+// Resolve the taskbar icon centre (X) and the actual taskbar top edge (Y) for
+// hWnd.  Uses UI Automation on both Win10 and Win11, falling back to the
+// ToolbarWindow32 / TB_GETBUTTON path when UIA is unavailable.  Returns FALSE
+// only when no taskbar or button can be found.
 static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth) {
     HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
-    TaskbarIconEntry cache[64];
-    int cacheCount = 0;
 
-    // Walk all taskbars visible on the window's monitor.
-    for (int pass = 0; pass < 2; pass++) {
-        HWND hTaskbar = FindWindowW(pass == 0 ? L"Shell_TrayWnd" : L"Shell_SecondaryTrayWnd", NULL);
-        if (!hTaskbar) continue;
-
-        RECT tbRect;
-        GetWindowRect(hTaskbar, &tbRect);
-        HMONITOR hTbMon = MonitorFromRect(&tbRect, MONITOR_DEFAULTTONULL);
-        if (hTbMon != hMon) continue;
-
-        // Try every known toolbar location (Windows 10 primary, secondary,
-        // WorkerW fallback for top/side taskbars, and direct child).
-        HWND hToolbar = NULL;
-        HWND hRebar = FindWindowEx(hTaskbar, NULL, L"ReBarWindow32", NULL);
-        if (hRebar) {
-            HWND hMSTask = FindWindowEx(hRebar, NULL, L"MSTaskSwWClass", NULL);
-            if (hMSTask)
-                hToolbar = FindWindowEx(hMSTask, NULL, L"ToolbarWindow32", NULL);
+    // Quick cache hit by HWND.
+    {
+        std::lock_guard<std::mutex> lock(g_TbCacheMutex);
+        auto it = g_TaskbarDockXs.find(hWnd);
+        if (it != g_TaskbarDockXs.end()) {
+            *outX = it->second;
+            return TRUE;
         }
-        if (!hToolbar) {
-            // Some configurations nest under WorkerW.
-            HWND hWorkerW = FindWindowEx(hTaskbar, NULL, L"WorkerW", NULL);
-            if (hWorkerW) {
-                HWND hReBarW = FindWindowEx(hWorkerW, NULL, L"ReBarWindow32", NULL);
-                if (hReBarW) {
-                    HWND hMSTask = FindWindowEx(hReBarW, NULL, L"MSTaskSwWClass", NULL);
-                    if (hMSTask)
-                        hToolbar = FindWindowEx(hMSTask, NULL, L"ToolbarWindow32", NULL);
+    }
+
+    // Build a per-process+monitor key for grouped-button cache.
+    std::wstring procName;
+    {
+        DWORD pid = 0;
+        GetWindowThreadProcessId(hWnd, &pid);
+        if (pid) {
+            HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+            if (hProc) {
+                WCHAR path[MAX_PATH];
+                DWORD len = MAX_PATH;
+                if (QueryFullProcessImageNameW(hProc, 0, path, &len)) {
+                    WCHAR* name = wcsrchr(path, L'\\');
+                    if (name) procName = name + 1;
                 }
+                CloseHandle(hProc);
             }
         }
-        if (!hToolbar)
-            hToolbar = FindWindowEx(hTaskbar, NULL, L"ToolbarWindow32", NULL);
+    }
+    std::wstring processKey = procName + L"_" + std::to_wstring(reinterpret_cast<size_t>(hMon));
+    {
+        std::lock_guard<std::mutex> lock(g_TbCacheMutex);
+        auto it = g_ProcessDockXs.find(processKey);
+        if (it != g_ProcessDockXs.end()) {
+            *outX = it->second;
+            g_TaskbarDockXs[hWnd] = it->second;
+            return TRUE;
+        }
+    }
 
-        if (hToolbar) {
-            int count = (int)SendMessage(hToolbar, TB_BUTTONCOUNT, 0, 0);
-            for (int i = 0; i < count && cacheCount < 64; i++) {
-                TBBUTTON btn;
-                ZeroMemory(&btn, sizeof(btn));
-                if (SendMessage(hToolbar, TB_GETBUTTON, i, (LPARAM)&btn)) {
-                    RECT r;
-                    if (SendMessage(hToolbar, TB_GETRECT, btn.idCommand, (LPARAM)&r)) {
-                        MapWindowPoints(hToolbar, NULL, (POINT*)&r, 2);
-                        TaskbarIconEntry* e = &cache[cacheCount++];
-                        e->hWnd  = (HWND)btn.dwData;
-                        e->x     = (r.left + r.right) / 2;
-                        e->y     = (r.top + r.bottom) / 2;
-                        e->width = r.right - r.left;
+    int targetX = 0;
+    int targetY = 0;
+    int targetW = 0;
+    bool found = false;
+
+    // --- Primary method: UI Automation (Win10 + Win11) ---
+    HRESULT hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+    bool coInit = (hr == S_OK || hr == S_FALSE);
+    IUIAutomation* pAutomation = NULL;
+    HRESULT hrUia = CoCreateInstance(__uuidof(CUIAutomation8), NULL, CLSCTX_INPROC_SERVER,
+                                     __uuidof(IUIAutomation), (void**)&pAutomation);
+    if (FAILED(hrUia))
+        hrUia = CoCreateInstance(__uuidof(CUIAutomation), NULL, CLSCTX_INPROC_SERVER,
+                                 __uuidof(IUIAutomation), (void**)&pAutomation);
+    if (SUCCEEDED(hrUia) && pAutomation) {
+        HWND hTray = FindTaskbarForMonitor(hMon);
+        if (hTray) {
+            IUIAutomationElement* pTrayElement = NULL;
+            if (SUCCEEDED(pAutomation->ElementFromHandle(hTray, &pTrayElement)) && pTrayElement) {
+                WCHAR titleW[512] = {0};
+                GetWindowTextW(hWnd, titleW, 512);
+                std::wstring titleLower = titleW;
+                for (auto& c : titleLower) c = (WCHAR)towlower(c);
+                std::wstring procLower = procName;
+                for (auto& c : procLower) c = (WCHAR)towlower(c);
+                size_t dot = procLower.find(L'.');
+                if (dot != std::wstring::npos) procLower = procLower.substr(0, dot);
+
+                IUIAutomationCondition* pButtonCond = NULL;
+                IUIAutomationCondition* pListItemCond = NULL;
+                IUIAutomationCondition* pOrCond = NULL;
+                VARIANT varBtn; varBtn.vt = VT_I4; varBtn.lVal = UIA_ButtonControlTypeId;
+                pAutomation->CreatePropertyCondition(UIA_ControlTypePropertyId, varBtn, &pButtonCond);
+                VARIANT varList; varList.vt = VT_I4; varList.lVal = UIA_ListItemControlTypeId;
+                pAutomation->CreatePropertyCondition(UIA_ControlTypePropertyId, varList, &pListItemCond);
+                if (pButtonCond && pListItemCond)
+                    pAutomation->CreateOrCondition(pButtonCond, pListItemCond, &pOrCond);
+
+                IUIAutomationElementArray* pArray = NULL;
+                if (pOrCond && SUCCEEDED(pTrayElement->FindAll(TreeScope_Descendants, pOrCond, &pArray)) && pArray) {
+                    int length = 0;
+                    pArray->get_Length(&length);
+                    MONITORINFO mi = {};
+                    mi.cbSize = sizeof(mi);
+                    GetMonitorInfoW(hMon, &mi);
+                    int monRight = mi.rcMonitor.right;
+                    int bestScore = 0;
+                    for (int i = 0; i < length; i++) {
+                        IUIAutomationElement* pItem = NULL;
+                        if (SUCCEEDED(pArray->GetElement(i, &pItem)) && pItem) {
+                            BSTR name;
+                            if (SUCCEEDED(pItem->get_CurrentName(&name)) && name) {
+                                std::wstring uiaName = name;
+                                for (auto& c : uiaName) c = (WCHAR)towlower(c);
+                                if (!uiaName.empty()) {
+                                    int score = 0;
+                                    if (titleLower == uiaName) score += 1000;
+                                    else {
+                                        if (!titleLower.empty() && titleLower.find(uiaName) != std::wstring::npos)
+                                            score += 500;
+                                        if (!uiaName.empty() && uiaName.find(titleLower) != std::wstring::npos)
+                                            score += 500;
+                                    }
+                                    if (!procLower.empty() && uiaName.find(procLower) != std::wstring::npos)
+                                        score += 400;
+                                    if (uiaName.find(L"start") != std::wstring::npos)    score -= 500;
+                                    if (uiaName.find(L"search") != std::wstring::npos)   score -= 500;
+                                    if (uiaName.find(L"task view") != std::wstring::npos) score -= 500;
+                                    if (score > bestScore) {
+                                        RECT bRect;
+                                        if (SUCCEEDED(pItem->get_CurrentBoundingRectangle(&bRect)) &&
+                                            bRect.right > bRect.left && bRect.left < monRight - 50) {
+                                            bestScore = score;
+                                            targetX = bRect.left + (bRect.right - bRect.left) / 2;
+                                            targetY = bRect.top;
+                                            targetW = bRect.right - bRect.left;
+                                            found   = true;
+                                        }
+                                    }
+                                }
+                                SysFreeString(name);
+                            }
+                            pItem->Release();
+                        }
+                    }
+                    pArray->Release();
+                }
+                if (pButtonCond)    pButtonCond->Release();
+                if (pListItemCond)  pListItemCond->Release();
+                if (pOrCond)        pOrCond->Release();
+                pTrayElement->Release();
+            }
+        }
+        pAutomation->Release();
+    }
+    if (coInit) CoUninitialize();
+
+    // --- Fallback: ToolbarWindow32 / TB_GETBUTTON (Win10) ---
+    if (!found) {
+        for (int pass = 0; pass < 2 && !found; pass++) {
+            HWND hTaskbar = FindWindowW(pass == 0 ? L"Shell_TrayWnd" : L"Shell_SecondaryTrayWnd", NULL);
+            if (!hTaskbar) continue;
+            RECT tbRect;
+            GetWindowRect(hTaskbar, &tbRect);
+            if (MonitorFromRect(&tbRect, MONITOR_DEFAULTTONULL) != hMon) continue;
+
+            HWND hToolbar = NULL;
+            HWND hRebar = FindWindowEx(hTaskbar, NULL, L"ReBarWindow32", NULL);
+            if (hRebar) {
+                HWND hMSTask = FindWindowEx(hRebar, NULL, L"MSTaskSwWClass", NULL);
+                if (hMSTask)
+                    hToolbar = FindWindowEx(hMSTask, NULL, L"ToolbarWindow32", NULL);
+            }
+            if (!hToolbar) {
+                HWND hWorkerW = FindWindowEx(hTaskbar, NULL, L"WorkerW", NULL);
+                if (hWorkerW) {
+                    HWND hReBarW = FindWindowEx(hWorkerW, NULL, L"ReBarWindow32", NULL);
+                    if (hReBarW) {
+                        HWND hMSTask = FindWindowEx(hReBarW, NULL, L"MSTaskSwWClass", NULL);
+                        if (hMSTask)
+                            hToolbar = FindWindowEx(hMSTask, NULL, L"ToolbarWindow32", NULL);
+                    }
+                }
+            }
+            if (!hToolbar)
+                hToolbar = FindWindowEx(hTaskbar, NULL, L"ToolbarWindow32", NULL);
+
+            if (hToolbar) {
+                struct { HWND hWnd; int x; int y; int w; } tbCache[64];
+                int tbCount = 0;
+                int btnCount = (int)SendMessage(hToolbar, TB_BUTTONCOUNT, 0, 0);
+                for (int i = 0; i < btnCount && tbCount < 64; i++) {
+                    TBBUTTON btn;
+                    ZeroMemory(&btn, sizeof(btn));
+                    if (SendMessage(hToolbar, TB_GETBUTTON, i, (LPARAM)&btn)) {
+                        RECT r;
+                        if (SendMessage(hToolbar, TB_GETRECT, btn.idCommand, (LPARAM)&r)) {
+                            MapWindowPoints(hToolbar, NULL, (POINT*)&r, 2);
+                            tbCache[tbCount].hWnd = (HWND)btn.dwData;
+                            tbCache[tbCount].x = (r.left + r.right) / 2;
+                            tbCache[tbCount].y = r.top; // top edge of the button
+                            tbCache[tbCount].w = r.right - r.left;
+                            tbCount++;
+                        }
+                    }
+                }
+                auto tryMatch = [&](HWND h) -> bool {
+                    for (int i = 0; i < tbCount; i++)
+                        if (tbCache[i].hWnd == h) {
+                            targetX = tbCache[i].x;
+                            targetY = tbCache[i].y;
+                            targetW = tbCache[i].w;
+                            return true;
+                        }
+                    return false;
+                };
+                if (tryMatch(hWnd)) found = true;
+                else for (HWND hCur = GetWindow(hWnd, GW_OWNER); hCur && !found; hCur = GetWindow(hCur, GW_OWNER))
+                    found = tryMatch(hCur);
+                if (!found) { HWND hRoot = GetAncestor(hWnd, GA_ROOT); if (hRoot != hWnd) found = tryMatch(hRoot); }
+                if (!found) {
+                    DWORD targetPid;
+                    GetWindowThreadProcessId(hWnd, &targetPid);
+                    if (targetPid) {
+                        int bestIdx = -1, bestDist = INT_MAX;
+                        RECT wr; GetWindowRect(hWnd, &wr);
+                        int cx = (wr.left + wr.right) / 2;
+                        for (int i = 0; i < tbCount; i++) {
+                            DWORD pid;
+                            GetWindowThreadProcessId(tbCache[i].hWnd, &pid);
+                            if (pid == targetPid) {
+                                int d = abs(tbCache[i].x - cx);
+                                if (d < bestDist) { bestDist = d; bestIdx = i; }
+                            }
+                        }
+                        if (bestIdx >= 0) {
+                            targetX = tbCache[bestIdx].x;
+                            targetY = tbCache[bestIdx].y;
+                            targetW = tbCache[bestIdx].w;
+                            found   = true;
+                        }
                     }
                 }
             }
         }
-        break;
     }
 
-    if (cacheCount == 0) return FALSE;
+    if (!found) return FALSE;
 
-    // --- Matching strategy (most specific to least specific) ---
-
-    // 1. Exact HWND.
-    for (int i = 0; i < cacheCount; i++) {
-        if (cache[i].hWnd == hWnd) {
-            *outX = cache[i].x; *outY = cache[i].y;
-            if (outWidth) *outWidth = cache[i].width;
-            return TRUE;
-        }
+    // Cache the result.
+    {
+        std::lock_guard<std::mutex> lock(g_TbCacheMutex);
+        g_TaskbarDockXs[hWnd] = targetX;
+        if (!processKey.empty()) g_ProcessDockXs[processKey] = targetX;
     }
-
-    // 2. Owner chain (child/utility windows sharing the parent's button).
-    for (HWND hCur = GetWindow(hWnd, GW_OWNER); hCur; hCur = GetWindow(hCur, GW_OWNER)) {
-        for (int i = 0; i < cacheCount; i++) {
-            if (cache[i].hWnd == hCur) {
-                *outX = cache[i].x; *outY = cache[i].y;
-                if (outWidth) *outWidth = cache[i].width;
-                return TRUE;
-            }
-        }
-    }
-
-    // 3. Root ancestor (covers dialogs and owned popups whose top-level frame
-    //    owns the taskbar button).
-    HWND hRoot = GetAncestor(hWnd, GA_ROOT);
-    if (hRoot != hWnd) {
-        for (int i = 0; i < cacheCount; i++) {
-            if (cache[i].hWnd == hRoot) {
-                *outX = cache[i].x; *outY = cache[i].y;
-                if (outWidth) *outWidth = cache[i].width;
-                return TRUE;
-            }
-        }
-    }
-
-    // 4. Process-ID match (grouped taskbar buttons may store the app's main
-    //    frame or a hidden window; take the nearest icon on the same monitor).
-    DWORD targetPid;
-    GetWindowThreadProcessId(hWnd, &targetPid);
-    if (targetPid) {
-        int bestIdx = -1;
-        RECT wndRect;
-        GetWindowRect(hWnd, &wndRect);
-        int wndCX = (wndRect.left + wndRect.right) / 2;
-        int bestDist = INT_MAX;
-        for (int i = 0; i < cacheCount; i++) {
-            DWORD btnPid;
-            GetWindowThreadProcessId(cache[i].hWnd, &btnPid);
-            if (btnPid == targetPid) {
-                int dist = abs(cache[i].x - wndCX);
-                if (dist < bestDist) {
-                    bestDist = dist;
-                    bestIdx  = i;
-                }
-            }
-        }
-        if (bestIdx >= 0) {
-            *outX = cache[bestIdx].x; *outY = cache[bestIdx].y;
-            if (outWidth) *outWidth = cache[bestIdx].width;
-            return TRUE;
-        }
-    }
-
-    return FALSE;
+    *outX = targetX;
+    *outY = targetY;
+    if (outWidth) *outWidth = targetW;
+    return TRUE;
 }
 
 DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
@@ -1257,21 +1385,22 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     int screenWidth  = GetSystemMetrics(SM_CXVIRTUALSCREEN);
     int screenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 
-    POINT cursorPt;
-    GetCursorPos(&cursorPt);
-    HMONITOR hMon = MonitorFromPoint(cursorPt, MONITOR_DEFAULTTONEAREST);
+    HMONITOR hMon = MonitorFromWindow(data->hRealWnd, MONITOR_DEFAULTTONEAREST);
     MONITORINFO mi;
     ZeroMemory(&mi, sizeof(mi));
     mi.cbSize = sizeof(mi);
     GetMonitorInfoW(hMon, &mi);
     float taskbarY = (float)mi.rcWork.bottom;
 
-    // Lock the animation target to the taskbar icon centre (already has a
-    // monitor-centre default from StartGenieAnim if no icon is found).
+    // Lock the animation target to the taskbar icon centre (X) and the top
+    // edge of the icon (Y).  When the icon cannot be found, the caller's
+    // monitor-centre default (from StartGenieAnim) is kept for X, and
+    // rcWork.bottom is used for Y.
     int iconX, iconY;
     data->iconButtonWidth = 0;
     if (GetTaskbarIconCenter(data->hRealWnd, &iconX, &iconY, &data->iconButtonWidth)) {
         data->targetDockX = iconX;
+        taskbarY = (float)iconY;
     }
 
     bool useGpu = EnsureGpuDevice();
@@ -1536,6 +1665,11 @@ void Wh_ModUninit() {
             DeleteObject(pair.second);
         }
         g_SnapshotCache.clear();
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_TbCacheMutex);
+        g_TaskbarDockXs.clear();
+        g_ProcessDockXs.clear();
     }
     ReleaseGenieGpuResources();
     ReleaseGpuDevice();

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -173,6 +173,7 @@ resolved, Windows 11 support) was assisted by Claude.
 #include <string.h>
 #include <atomic>
 #include <unordered_map>
+#include <unordered_set>
 #include <mutex>
 #include <string>
 #include <ole2.h>
@@ -1603,7 +1604,7 @@ static void SetSysCmdGuard(HWND hWnd, bool set) {
 BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
     if (g_enabled.load(std::memory_order_relaxed)) {
         if (nCmdShow == SW_MINIMIZE || nCmdShow == SW_SHOWMINIMIZED || nCmdShow == SW_SHOWMINNOACTIVE) {
-            if (!IsInSysCmdOnThisThread(hWnd)) {
+            if (!IsInSysCmdOnThisThread(hWnd) && IsWindowVisible(hWnd) && !IsIconic(hWnd)) {
                 SetDwmTransitions(hWnd, FALSE);
                 StartGenieAnim(hWnd, FALSE);
             }

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -173,6 +173,7 @@ resolved, Windows 11 support) was assisted by Claude.
 #include <string.h>
 #include <atomic>
 #include <unordered_map>
+#include <list>
 #include <mutex>
 #include <string>
 #include <ole2.h>
@@ -220,12 +221,18 @@ struct GhostAnimData {
     BOOL isRising;
     int mode;
     int durationMs;
-    LONG_PTR originalExStyle;
+    LONG_PTR cleanupExStyle;
     HANDLE hReady;
 };
 
+static std::atomic<int> g_animCount{0};
+static HANDLE g_allAnimsDone = NULL;
+static std::atomic<bool> g_cancelAnims{false};
+
 std::unordered_map<HWND, HBITMAP> g_SnapshotCache;
+std::list<HWND> g_SnapshotLRU;
 std::mutex g_CacheMutex;
+const size_t kMaxSnapshots = 4;
 
 std::atomic<bool> g_enabled{true};
 std::atomic<int>  g_mode{MODE_GENIE};
@@ -637,11 +644,10 @@ static void SolveFrame(const GhostAnimData* d, float t,
 }
 
 static void FinalizeRealWindow(GhostAnimData* data) {
+    if (!IsWindow(data->hRealWnd)) return;
     if (data->isRising) {
         SetLayeredWindowAttributes(data->hRealWnd, 0, 255, LWA_ALPHA);
-        if (!(data->originalExStyle & WS_EX_LAYERED)) {
-            SetWindowLongPtrW(data->hRealWnd, GWL_EXSTYLE, data->originalExStyle);
-        }
+        SetWindowLongPtrW(data->hRealWnd, GWL_EXSTYLE, data->cleanupExStyle);
     }
     SetDwmTransitions(data->hRealWnd, TRUE);
 }
@@ -667,6 +673,7 @@ static void RunCpuAnim(GhostAnimData* data, HWND hGhost,
 
     BOOL firstFrame = TRUE;
     for (;;) {
+        if (g_cancelAnims.load(std::memory_order_relaxed)) break;
         QueryPerformanceCounter(&qpcNow);
         double elapsedMs = (qpcNow.QuadPart - qpcStart.QuadPart) * 1000.0 / qpcFreq.QuadPart;
         BOOL lastFrame = (elapsedMs >= totalMs);
@@ -701,6 +708,13 @@ static void RunCpuAnim(GhostAnimData* data, HWND hGhost,
 
         if (lastFrame) break;
         DwmFlush();
+        {
+            MSG msg;
+            while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+                TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+        }
     }
 
     FinalizeRealWindow(data);
@@ -839,6 +853,7 @@ static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
 
     BOOL firstFrame = TRUE;
     for (;;) {
+        if (g_cancelAnims.load(std::memory_order_relaxed)) break;
         QueryPerformanceCounter(&qpcNow);
         double elapsedMs = (qpcNow.QuadPart - qpcStart.QuadPart) * 1000.0 / qpcFreq.QuadPart;
         BOOL lastFrame = (elapsedMs >= totalMs);
@@ -870,6 +885,13 @@ static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
 
         if (lastFrame) break;
         DwmFlush();
+        {
+            MSG msg;
+            while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+                TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+        }
     }
 
     FinalizeRealWindow(data);
@@ -1016,6 +1038,7 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
 
     BOOL firstFrame = TRUE;
     for (;;) {
+        if (g_cancelAnims.load(std::memory_order_relaxed)) break;
         QueryPerformanceCounter(&qpcNow);
         double elapsedMs = (qpcNow.QuadPart - qpcStart.QuadPart) * 1000.0 / qpcFreq.QuadPart;
         BOOL lastFrame = (elapsedMs >= totalMs);
@@ -1089,6 +1112,13 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
 
         if (lastFrame) break;
         DwmFlush();
+        {
+            MSG msg;
+            while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+                TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+        }
     }
 
     FinalizeRealWindow(data);
@@ -1326,97 +1356,7 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
     }
     if (coInit) CoUninitialize();
 
-    // --- Fallback: ToolbarWindow32 / TB_GETBUTTON (Win10) ---
-    if (!found) {
-        for (int pass = 0; pass < 2 && !found; pass++) {
-            HWND hTaskbar = FindWindowW(pass == 0 ? L"Shell_TrayWnd" : L"Shell_SecondaryTrayWnd", NULL);
-            if (!hTaskbar) continue;
-            RECT tbRect;
-            GetWindowRect(hTaskbar, &tbRect);
-            if (MonitorFromRect(&tbRect, MONITOR_DEFAULTTONULL) != hMon) continue;
-
-            HWND hToolbar = NULL;
-            HWND hRebar = FindWindowEx(hTaskbar, NULL, L"ReBarWindow32", NULL);
-            if (hRebar) {
-                HWND hMSTask = FindWindowEx(hRebar, NULL, L"MSTaskSwWClass", NULL);
-                if (hMSTask)
-                    hToolbar = FindWindowEx(hMSTask, NULL, L"ToolbarWindow32", NULL);
-            }
-            if (!hToolbar) {
-                HWND hWorkerW = FindWindowEx(hTaskbar, NULL, L"WorkerW", NULL);
-                if (hWorkerW) {
-                    HWND hReBarW = FindWindowEx(hWorkerW, NULL, L"ReBarWindow32", NULL);
-                    if (hReBarW) {
-                        HWND hMSTask = FindWindowEx(hReBarW, NULL, L"MSTaskSwWClass", NULL);
-                        if (hMSTask)
-                            hToolbar = FindWindowEx(hMSTask, NULL, L"ToolbarWindow32", NULL);
-                    }
-                }
-            }
-            if (!hToolbar)
-                hToolbar = FindWindowEx(hTaskbar, NULL, L"ToolbarWindow32", NULL);
-
-            if (hToolbar) {
-                struct { HWND hWnd; int x; int y; int w; } tbCache[64];
-                int tbCount = 0;
-                int btnCount = (int)SendMessage(hToolbar, TB_BUTTONCOUNT, 0, 0);
-                for (int i = 0; i < btnCount && tbCount < 64; i++) {
-                    TBBUTTON btn;
-                    ZeroMemory(&btn, sizeof(btn));
-                    if (SendMessage(hToolbar, TB_GETBUTTON, i, (LPARAM)&btn)) {
-                        RECT r;
-                        if (SendMessage(hToolbar, TB_GETRECT, btn.idCommand, (LPARAM)&r)) {
-                            MapWindowPoints(hToolbar, NULL, (POINT*)&r, 2);
-                            tbCache[tbCount].hWnd = (HWND)btn.dwData;
-                            tbCache[tbCount].x = (r.left + r.right) / 2;
-                            tbCache[tbCount].y = r.top; // top edge of the button
-                            tbCache[tbCount].w = r.right - r.left;
-                            tbCount++;
-                        }
-                    }
-                }
-                auto tryMatch = [&](HWND h) -> bool {
-                    for (int i = 0; i < tbCount; i++)
-                        if (tbCache[i].hWnd == h) {
-                            targetX = tbCache[i].x;
-                            targetY = tbCache[i].y;
-                            targetW = tbCache[i].w;
-                            return true;
-                        }
-                    return false;
-                };
-                if (tryMatch(hWnd)) found = true;
-                else for (HWND hCur = GetWindow(hWnd, GW_OWNER); hCur && !found; hCur = GetWindow(hCur, GW_OWNER))
-                    found = tryMatch(hCur);
-                if (!found) { HWND hRoot = GetAncestor(hWnd, GA_ROOT); if (hRoot != hWnd) found = tryMatch(hRoot); }
-                if (!found) {
-                    DWORD targetPid;
-                    GetWindowThreadProcessId(hWnd, &targetPid);
-                    if (targetPid) {
-                        int bestIdx = -1, bestDist = INT_MAX;
-                        RECT wr; GetWindowRect(hWnd, &wr);
-                        int cx = (wr.left + wr.right) / 2;
-                        for (int i = 0; i < tbCount; i++) {
-                            DWORD pid;
-                            GetWindowThreadProcessId(tbCache[i].hWnd, &pid);
-                            if (pid == targetPid) {
-                                int d = abs(tbCache[i].x - cx);
-                                if (d < bestDist) { bestDist = d; bestIdx = i; }
-                            }
-                        }
-                        if (bestIdx >= 0) {
-                            targetX = tbCache[bestIdx].x;
-                            targetY = tbCache[bestIdx].y;
-                            targetW = tbCache[bestIdx].w;
-                            found   = true;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // --- Fallback: process-level cache if UIA + toolbar both failed ---
+    // --- Fallback: process-level cache if UIA failed ---
     if (!found) {
         std::lock_guard<std::mutex> lock(g_TbCacheMutex);
         auto it = g_ProcessIconCache.find(processKey);
@@ -1460,15 +1400,36 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     GetMonitorInfoW(hMon, &mi);
     float taskbarY = (float)mi.rcWork.bottom;
 
-    // Lock the animation target to the taskbar icon centre (X) and the top
-    // edge of the icon (Y).  When the icon cannot be found, the caller's
-    // monitor-centre default (from StartGenieAnim) is kept for X, and
-    // rcWork.bottom is used for Y.
+    // Signal the creator thread so the hook can return immediately — the
+    // animation starts with the cursor-based icon position from StartGenieAnim.
+    // UIA will refine the cache for the *next* minimize.
+    if (data->hReady) SetEvent(data->hReady);
+
+    // Background UIA scan: cache the taskbar icon for this process so that
+    // future minimizes hit the correct icon + button width from the start.
     int iconX, iconY;
-    data->iconButtonWidth = 0;
-    if (GetTaskbarIconCenter(data->hRealWnd, &iconX, &iconY, &data->iconButtonWidth)) {
-        data->targetDockX = iconX;
-        taskbarY = (float)iconY;
+    int iconW = 0;
+    if (GetTaskbarIconCenter(data->hRealWnd, &iconX, &iconY, &iconW)) {
+        data->iconButtonWidth = iconW;
+        std::lock_guard<std::mutex> lock(g_TbCacheMutex);
+        DWORD pid = 0;
+        GetWindowThreadProcessId(data->hRealWnd, &pid);
+        HMONITOR hMon = MonitorFromWindow(data->hRealWnd, MONITOR_DEFAULTTONEAREST);
+        std::wstring procName;
+        {
+            HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+            if (hProc) {
+                WCHAR path[MAX_PATH];
+                DWORD len = MAX_PATH;
+                if (QueryFullProcessImageNameW(hProc, 0, path, &len)) {
+                    WCHAR* name = wcsrchr(path, L'\\');
+                    if (name) procName = name + 1;
+                }
+                CloseHandle(hProc);
+            }
+        }
+        std::wstring key = procName + L"_" + std::to_wstring(reinterpret_cast<size_t>(hMon));
+        g_ProcessIconCache[key] = { iconX, iconY, iconW };
     }
 
     bool useGpu = EnsureGpuDevice();
@@ -1482,20 +1443,15 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
             screenX, screenY, screenWidth, screenHeight, NULL, NULL, NULL, NULL);
 
         if (hGhost) {
-            SetClassLongPtr(hGhost, GCLP_HBRBACKGROUND, (LONG_PTR)GetStockObject(NULL_BRUSH));
-        }
-
-        DisableGhostShadow(hGhost);
-
-        bool ran = false;
-        if (hGhost) {
-            ran = (data->mode == MODE_GENIE)
+            DisableGhostShadow(hGhost);
+            bool ran = (data->mode == MODE_GENIE)
                     ? RunGpuGenieAnim(data, hGhost, screenX, screenY, screenWidth, screenHeight, taskbarY)
                     : RunGpuAnim(data, hGhost, screenX, screenY, screenWidth, screenHeight, taskbarY);
-        }
-        if (!ran) {
-            useGpu = false;
-            if (hGhost) { DestroyWindow(hGhost); hGhost = NULL; }
+            if (!ran) {
+                DestroyWindow(hGhost);
+                hGhost = NULL;
+                useGpu = false;
+            }
         }
     }
 
@@ -1506,11 +1462,8 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
             data->targetRect.left, data->targetRect.top, data->width, data->height,
             NULL, NULL, NULL, NULL);
 
-        if (hGhost) {
-            SetClassLongPtr(hGhost, GCLP_HBRBACKGROUND, (LONG_PTR)GetStockObject(NULL_BRUSH));
-        }
-
-        DisableGhostShadow(hGhost);
+        if (hGhost)
+            DisableGhostShadow(hGhost);
 
         RunCpuAnim(data, hGhost, screenWidth, screenHeight, taskbarY);
     }
@@ -1519,16 +1472,24 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     DeleteObject(data->hBitmap);
     if (data->hReady) CloseHandle(data->hReady);
     delete data;
+    if (g_animCount.fetch_sub(1, std::memory_order_relaxed) == 1)
+        SetEvent(g_allAnimsDone);
     return 0;
 }
 
-void StartGenieAnim(HWND hWnd, BOOL rising) {
+void StartGenieAnim(HWND hWnd, BOOL rising, LONG_PTR cleanupExStyle) {
     RECT rect;
     GetWindowRect(hWnd, &rect);
     int w = rect.right - rect.left;
     int h = rect.bottom - rect.top;
 
-    if (w <= 0 || h <= 0) return;
+    if (w <= 0 || h <= 0) {
+        if (rising) {
+            SetLayeredWindowAttributes(hWnd, 0, 255, LWA_ALPHA);
+            SetWindowLongPtrW(hWnd, GWL_EXSTYLE, cleanupExStyle);
+        }
+        return;
+    }
 
     HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
     MONITORINFO mi;
@@ -1556,7 +1517,7 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
     data->targetDockX = defaultDockX;
     data->mode = g_mode.load(std::memory_order_relaxed);
     data->durationMs = g_durations[data->mode].load(std::memory_order_relaxed);
-    data->originalExStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
+    data->cleanupExStyle = cleanupExStyle;
 
     HDC hScreenDC = GetDC(NULL);
     HDC hMemDC = CreateCompatibleDC(hScreenDC);
@@ -1576,6 +1537,7 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
 
                 DeleteObject(g_SnapshotCache[hWnd]);
                 g_SnapshotCache.erase(hWnd);
+                g_SnapshotLRU.remove(hWnd);
                 fromCache = TRUE;
             }
         }
@@ -1603,8 +1565,16 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
         std::lock_guard<std::mutex> lock(g_CacheMutex);
         if (g_SnapshotCache.count(hWnd)) {
             DeleteObject(g_SnapshotCache[hWnd]);
+            g_SnapshotLRU.remove(hWnd);
+        }
+        while (g_SnapshotCache.size() >= kMaxSnapshots) {
+            HWND oldHwnd = g_SnapshotLRU.front();
+            g_SnapshotLRU.pop_front();
+            DeleteObject(g_SnapshotCache[oldHwnd]);
+            g_SnapshotCache.erase(oldHwnd);
         }
         g_SnapshotCache[hWnd] = CreateCompatibleBitmap(hScreenDC, w, h);
+        g_SnapshotLRU.push_back(hWnd);
         HDC hCacheDC = CreateCompatibleDC(hScreenDC);
         HBITMAP hOldCacheBmp = (HBITMAP)SelectObject(hCacheDC, g_SnapshotCache[hWnd]);
         BitBlt(hCacheDC, 0, 0, w, h, hMemDC, 0, 0, SRCCOPY);
@@ -1618,11 +1588,19 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
 
     HANDLE hReady = CreateEventW(NULL, TRUE, FALSE, NULL);
     data->hReady = hReady;
+    g_animCount.fetch_add(1, std::memory_order_relaxed);
+    ResetEvent(g_allAnimsDone);
     HANDLE hThread = CreateThread(NULL, 0, GhostAnimationThread, data, 0, NULL);
     if (!hThread) {
+        if (rising) {
+            SetLayeredWindowAttributes(hWnd, 0, 255, LWA_ALPHA);
+            SetWindowLongPtrW(hWnd, GWL_EXSTYLE, cleanupExStyle);
+        }
         if (hReady) CloseHandle(hReady);
         DeleteObject(data->hBitmap);
         delete data;
+        if (g_animCount.fetch_sub(1, std::memory_order_relaxed) == 1)
+            SetEvent(g_allAnimsDone);
         return;
     }
     CloseHandle(hThread);
@@ -1633,7 +1611,8 @@ BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
     if (g_enabled.load(std::memory_order_relaxed)) {
         if (nCmdShow == SW_MINIMIZE || nCmdShow == SW_SHOWMINIMIZED || nCmdShow == SW_SHOWMINNOACTIVE) {
             SetDwmTransitions(hWnd, FALSE);
-            StartGenieAnim(hWnd, FALSE);
+            LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
+            StartGenieAnim(hWnd, FALSE, exStyle);
             return ShowWindow_Original(hWnd, nCmdShow);
         }
         else if (nCmdShow == SW_RESTORE || nCmdShow == SW_SHOWNORMAL) {
@@ -1643,7 +1622,7 @@ BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
                 SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
                 SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
                 BOOL res = ShowWindow_Original(hWnd, nCmdShow);
-                StartGenieAnim(hWnd, TRUE);
+                StartGenieAnim(hWnd, TRUE, exStyle);
                 return res;
             }
         }
@@ -1658,6 +1637,7 @@ LRESULT WINAPI DefWindowProcW_Hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
             if (g_SnapshotCache.count(hWnd)) {
                 DeleteObject(g_SnapshotCache[hWnd]);
                 g_SnapshotCache.erase(hWnd);
+                g_SnapshotLRU.remove(hWnd);
             }
         }
     }
@@ -1666,7 +1646,8 @@ LRESULT WINAPI DefWindowProcW_Hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
         UINT cmd = wParam & 0xFFF0;
         if (cmd == SC_MINIMIZE) {
             SetDwmTransitions(hWnd, FALSE);
-            StartGenieAnim(hWnd, FALSE);
+            LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
+            StartGenieAnim(hWnd, FALSE, exStyle);
             return DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
         }
         else if (cmd == SC_RESTORE && IsIconic(hWnd)) {
@@ -1675,7 +1656,7 @@ LRESULT WINAPI DefWindowProcW_Hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
             SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
             SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
             LRESULT res = DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
-            StartGenieAnim(hWnd, TRUE);
+            StartGenieAnim(hWnd, TRUE, exStyle);
             return res;
         }
     }
@@ -1686,11 +1667,7 @@ BOOL Wh_ModInit() {
     LoadSettings();
     Wh_SetFunctionHook((void*)DefWindowProcW, (void*)DefWindowProcW_Hook, (void**)&DefWindowProcW_Original);
     Wh_SetFunctionHook((void*)ShowWindow, (void*)ShowWindow_Hook, (void**)&ShowWindow_Original);
-    // Eagerly initialize GPU resources so the first animation doesn't have to
-    // wait for D3D device creation and shader compilation.
-    if (EnsureGpuDevice()) {
-        EnsureGenieGpuResources();
-    }
+    g_allAnimsDone = CreateEventW(NULL, TRUE, TRUE, NULL);
     return TRUE;
 }
 
@@ -1699,12 +1676,18 @@ void Wh_ModSettingsChanged() {
 }
 
 void Wh_ModUninit() {
+    // Signal cancellation and wait for in-flight animation threads to finish.
+    g_cancelAnims.store(true, std::memory_order_relaxed);
+    if (g_animCount.load(std::memory_order_relaxed) > 0)
+        WaitForSingleObject(g_allAnimsDone, 3000);
+
     {
         std::lock_guard<std::mutex> lock(g_CacheMutex);
         for (auto& pair : g_SnapshotCache) {
             DeleteObject(pair.second);
         }
         g_SnapshotCache.clear();
+        g_SnapshotLRU.clear();
     }
     {
         std::lock_guard<std::mutex> lock(g_TbCacheMutex);
@@ -1713,4 +1696,5 @@ void Wh_ModUninit() {
     }
     ReleaseGenieGpuResources();
     ReleaseGpuDevice();
+    if (g_allAnimsDone) CloseHandle(g_allAnimsDone);
 }

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -1112,9 +1112,26 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
 }
 
 // --- Persistent taskbar icon cache (by HWND and by process+monitor) ---
-static std::unordered_map<HWND, int> g_TaskbarDockXs;
-static std::unordered_map<std::wstring, int> g_ProcessDockXs;
+struct TbIconPos {
+    int x, y, width;
+};
+static std::unordered_map<HWND, TbIconPos> g_TaskbarIconCache;
+static std::unordered_map<std::wstring, TbIconPos> g_ProcessIconCache;
 static std::mutex g_TbCacheMutex;
+
+// Guard: only one animation at a time per window.
+static std::unordered_set<HWND> g_animInProgress;
+static std::mutex g_animMtx;
+
+static bool AnimIsInProgress(HWND hWnd) {
+    std::lock_guard<std::mutex> lock(g_animMtx);
+    return g_animInProgress.count(hWnd) != 0;
+}
+static void AnimSetInProgress(HWND hWnd, bool set) {
+    std::lock_guard<std::mutex> lock(g_animMtx);
+    if (set) g_animInProgress.insert(hWnd);
+    else     g_animInProgress.erase(hWnd);
+}
 
 static HWND FindTaskbarForMonitor(HMONITOR hMon) {
     HWND hMainTray = FindWindowW(L"Shell_TrayWnd", NULL);
@@ -1138,9 +1155,11 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
     // Quick cache hit by HWND.
     {
         std::lock_guard<std::mutex> lock(g_TbCacheMutex);
-        auto it = g_TaskbarDockXs.find(hWnd);
-        if (it != g_TaskbarDockXs.end()) {
-            *outX = it->second;
+        auto it = g_TaskbarIconCache.find(hWnd);
+        if (it != g_TaskbarIconCache.end()) {
+            *outX = it->second.x;
+            *outY = it->second.y;
+            if (outWidth) *outWidth = it->second.width;
             return TRUE;
         }
     }
@@ -1166,10 +1185,12 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
     std::wstring processKey = procName + L"_" + std::to_wstring(reinterpret_cast<size_t>(hMon));
     {
         std::lock_guard<std::mutex> lock(g_TbCacheMutex);
-        auto it = g_ProcessDockXs.find(processKey);
-        if (it != g_ProcessDockXs.end()) {
-            *outX = it->second;
-            g_TaskbarDockXs[hWnd] = it->second;
+        auto it = g_ProcessIconCache.find(processKey);
+        if (it != g_ProcessIconCache.end()) {
+            *outX = it->second.x;
+            *outY = it->second.y;
+            if (outWidth) *outWidth = it->second.width;
+            g_TaskbarIconCache[hWnd] = it->second;
             return TRUE;
         }
     }
@@ -1366,8 +1387,9 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
     // Cache the result.
     {
         std::lock_guard<std::mutex> lock(g_TbCacheMutex);
-        g_TaskbarDockXs[hWnd] = targetX;
-        if (!processKey.empty()) g_ProcessDockXs[processKey] = targetX;
+        TbIconPos pos = { targetX, targetY, targetW };
+        g_TaskbarIconCache[hWnd] = pos;
+        if (!processKey.empty()) g_ProcessIconCache[processKey] = pos;
     }
     *outX = targetX;
     *outY = targetY;
@@ -1450,11 +1472,15 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     if (hGhost) DestroyWindow(hGhost);
     DeleteObject(data->hBitmap);
     if (data->hReady) CloseHandle(data->hReady);
+    AnimSetInProgress(data->hRealWnd, false);
     delete data;
     return 0;
 }
 
 void StartGenieAnim(HWND hWnd, BOOL rising) {
+    if (AnimIsInProgress(hWnd)) return;
+    AnimSetInProgress(hWnd, true);
+
     RECT rect;
     GetWindowRect(hWnd, &rect);
     int w = rect.right - rect.left;
@@ -1668,8 +1694,8 @@ void Wh_ModUninit() {
     }
     {
         std::lock_guard<std::mutex> lock(g_TbCacheMutex);
-        g_TaskbarDockXs.clear();
-        g_ProcessDockXs.clear();
+        g_TaskbarIconCache.clear();
+        g_ProcessIconCache.clear();
     }
     ReleaseGenieGpuResources();
     ReleaseGpuDevice();

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -1153,18 +1153,6 @@ static HWND FindTaskbarForMonitor(HMONITOR hMon) {
 static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth) {
     HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
 
-    // Quick cache hit by HWND.
-    {
-        std::lock_guard<std::mutex> lock(g_TbCacheMutex);
-        auto it = g_TaskbarIconCache.find(hWnd);
-        if (it != g_TaskbarIconCache.end()) {
-            *outX = it->second.x;
-            *outY = it->second.y;
-            if (outWidth) *outWidth = it->second.width;
-            return TRUE;
-        }
-    }
-
     // Build a per-process+monitor key for grouped-button cache.
     std::wstring procName;
     {
@@ -1184,17 +1172,6 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
         }
     }
     std::wstring processKey = procName + L"_" + std::to_wstring(reinterpret_cast<size_t>(hMon));
-    {
-        std::lock_guard<std::mutex> lock(g_TbCacheMutex);
-        auto it = g_ProcessIconCache.find(processKey);
-        if (it != g_ProcessIconCache.end()) {
-            *outX = it->second.x;
-            *outY = it->second.y;
-            if (outWidth) *outWidth = it->second.width;
-            g_TaskbarIconCache[hWnd] = it->second;
-            return TRUE;
-        }
-    }
 
     int targetX = 0;
     int targetY = 0;
@@ -1212,83 +1189,151 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
                                  __uuidof(IUIAutomation), (void**)&pAutomation);
     if (SUCCEEDED(hrUia) && pAutomation) {
         HWND hTray = FindTaskbarForMonitor(hMon);
+        WCHAR titleW[512] = {0};
+        GetWindowTextW(hWnd, titleW, 512);
+        std::wstring titleLower = titleW;
+        for (auto& c : titleLower) c = (WCHAR)towlower(c);
+        std::wstring procLower = procName;
+        for (auto& c : procLower) c = (WCHAR)towlower(c);
+        size_t dot = procLower.find(L'.');
+        if (dot != std::wstring::npos) procLower = procLower.substr(0, dot);
+
+        IUIAutomationCondition* pButtonCond = NULL;
+        IUIAutomationCondition* pListItemCond = NULL;
+        IUIAutomationCondition* pOrCond = NULL;
+        VARIANT varBtn; varBtn.vt = VT_I4; varBtn.lVal = UIA_ButtonControlTypeId;
+        pAutomation->CreatePropertyCondition(UIA_ControlTypePropertyId, varBtn, &pButtonCond);
+        VARIANT varList; varList.vt = VT_I4; varList.lVal = UIA_ListItemControlTypeId;
+        pAutomation->CreatePropertyCondition(UIA_ControlTypePropertyId, varList, &pListItemCond);
+        if (pButtonCond && pListItemCond)
+            pAutomation->CreateOrCondition(pButtonCond, pListItemCond, &pOrCond);
+
+        auto tryMatch = [&](IUIAutomationElement* pParent) -> bool {
+            if (!pOrCond) return false;
+            IUIAutomationElementArray* pArray = NULL;
+            if (FAILED(pParent->FindAll(TreeScope_Descendants, pOrCond, &pArray)) || !pArray)
+                return false;
+            int length = 0;
+            pArray->get_Length(&length);
+            int bestScore = 0;
+            int bestX = 0, bestY = 0, bestW = 0;
+            for (int i = 0; i < length; i++) {
+                IUIAutomationElement* pItem = NULL;
+                if (FAILED(pArray->GetElement(i, &pItem)) || !pItem) continue;
+                BSTR name;
+                if (SUCCEEDED(pItem->get_CurrentName(&name)) && name) {
+                    std::wstring uiaName = name;
+                    for (auto& c : uiaName) c = (WCHAR)towlower(c);
+                    if (!uiaName.empty()) {
+                        int score = 0;
+                        if (titleLower == uiaName) score += 1000;
+                        else {
+                            if (!titleLower.empty() && titleLower.find(uiaName) != std::wstring::npos)
+                                score += 500;
+                            if (!uiaName.empty() && uiaName.find(titleLower) != std::wstring::npos)
+                                score += 500;
+                        }
+                        if (!procLower.empty() && uiaName.find(procLower) != std::wstring::npos)
+                            score += 400;
+                        if (uiaName.find(L"start") != std::wstring::npos)    score -= 500;
+                        if (uiaName.find(L"search") != std::wstring::npos)   score -= 500;
+                        if (uiaName.find(L"task view") != std::wstring::npos) score -= 500;
+                        if (score > bestScore) {
+                            RECT bRect;
+                            if (SUCCEEDED(pItem->get_CurrentBoundingRectangle(&bRect)) &&
+                                bRect.right > bRect.left) {
+                                bestScore = score;
+                                bestX = bRect.left + (bRect.right - bRect.left) / 2;
+                                bestY = bRect.top;
+                                bestW = bRect.right - bRect.left;
+                            }
+                        }
+                    }
+                    SysFreeString(name);
+                }
+                pItem->Release();
+            }
+            pArray->Release();
+            if (bestScore > 0) {
+                targetX = bestX; targetY = bestY; targetW = bestW;
+                found = true;
+                return true;
+            }
+            return false;
+        };
+
         if (hTray) {
             IUIAutomationElement* pTrayElement = NULL;
             if (SUCCEEDED(pAutomation->ElementFromHandle(hTray, &pTrayElement)) && pTrayElement) {
-                WCHAR titleW[512] = {0};
-                GetWindowTextW(hWnd, titleW, 512);
-                std::wstring titleLower = titleW;
-                for (auto& c : titleLower) c = (WCHAR)towlower(c);
-                std::wstring procLower = procName;
-                for (auto& c : procLower) c = (WCHAR)towlower(c);
-                size_t dot = procLower.find(L'.');
-                if (dot != std::wstring::npos) procLower = procLower.substr(0, dot);
-
-                IUIAutomationCondition* pButtonCond = NULL;
-                IUIAutomationCondition* pListItemCond = NULL;
-                IUIAutomationCondition* pOrCond = NULL;
-                VARIANT varBtn; varBtn.vt = VT_I4; varBtn.lVal = UIA_ButtonControlTypeId;
-                pAutomation->CreatePropertyCondition(UIA_ControlTypePropertyId, varBtn, &pButtonCond);
-                VARIANT varList; varList.vt = VT_I4; varList.lVal = UIA_ListItemControlTypeId;
-                pAutomation->CreatePropertyCondition(UIA_ControlTypePropertyId, varList, &pListItemCond);
-                if (pButtonCond && pListItemCond)
-                    pAutomation->CreateOrCondition(pButtonCond, pListItemCond, &pOrCond);
-
-                IUIAutomationElementArray* pArray = NULL;
-                if (pOrCond && SUCCEEDED(pTrayElement->FindAll(TreeScope_Descendants, pOrCond, &pArray)) && pArray) {
-                    int length = 0;
-                    pArray->get_Length(&length);
-                    MONITORINFO mi = {};
-                    mi.cbSize = sizeof(mi);
-                    GetMonitorInfoW(hMon, &mi);
-                    int monRight = mi.rcMonitor.right;
-                    int bestScore = 0;
-                    for (int i = 0; i < length; i++) {
-                        IUIAutomationElement* pItem = NULL;
-                        if (SUCCEEDED(pArray->GetElement(i, &pItem)) && pItem) {
-                            BSTR name;
-                            if (SUCCEEDED(pItem->get_CurrentName(&name)) && name) {
-                                std::wstring uiaName = name;
-                                for (auto& c : uiaName) c = (WCHAR)towlower(c);
-                                if (!uiaName.empty()) {
-                                    int score = 0;
-                                    if (titleLower == uiaName) score += 1000;
-                                    else {
-                                        if (!titleLower.empty() && titleLower.find(uiaName) != std::wstring::npos)
-                                            score += 500;
-                                        if (!uiaName.empty() && uiaName.find(titleLower) != std::wstring::npos)
-                                            score += 500;
-                                    }
-                                    if (!procLower.empty() && uiaName.find(procLower) != std::wstring::npos)
-                                        score += 400;
-                                    if (uiaName.find(L"start") != std::wstring::npos)    score -= 500;
-                                    if (uiaName.find(L"search") != std::wstring::npos)   score -= 500;
-                                    if (uiaName.find(L"task view") != std::wstring::npos) score -= 500;
-                                    if (score > bestScore) {
-                                        RECT bRect;
-                                        if (SUCCEEDED(pItem->get_CurrentBoundingRectangle(&bRect)) &&
-                                            bRect.right > bRect.left && bRect.left < monRight - 50) {
-                                            bestScore = score;
-                                            targetX = bRect.left + (bRect.right - bRect.left) / 2;
-                                            targetY = bRect.top;
-                                            targetW = bRect.right - bRect.left;
-                                            found   = true;
-                                        }
-                                    }
-                                }
-                                SysFreeString(name);
-                            }
-                            pItem->Release();
-                        }
-                    }
-                    pArray->Release();
-                }
-                if (pButtonCond)    pButtonCond->Release();
-                if (pListItemCond)  pListItemCond->Release();
-                if (pOrCond)        pOrCond->Release();
+                tryMatch(pTrayElement);
                 pTrayElement->Release();
             }
         }
+
+        // If the Shell_TrayWnd scan missed the button, cast a wider net over
+        // the desktop root, restricted to the taskbar bounding rectangle.
+        if (!found) {
+            RECT trayRect;
+            HWND hTrayWnd = FindTaskbarForMonitor(hMon);
+            if (hTrayWnd && GetWindowRect(hTrayWnd, &trayRect)) {
+                IUIAutomationElement* pRoot = NULL;
+                if (SUCCEEDED(pAutomation->GetRootElement(&pRoot)) && pRoot) {
+                    IUIAutomationElementArray* pAll = NULL;
+                    if (SUCCEEDED(pRoot->FindAll(TreeScope_Descendants, pOrCond, &pAll)) && pAll) {
+                        int len = 0;
+                        pAll->get_Length(&len);
+                        int bestScore = 0;
+                        int bestX = 0, bestY = 0, bestW = 0;
+                        for (int i = 0; i < len; i++) {
+                            IUIAutomationElement* pItem = NULL;
+                            if (FAILED(pAll->GetElement(i, &pItem)) || !pItem) continue;
+                            RECT bRect;
+                            if (SUCCEEDED(pItem->get_CurrentBoundingRectangle(&bRect)) &&
+                                bRect.right > bRect.left &&
+                                bRect.top >= trayRect.top - 10 &&
+                                bRect.bottom <= trayRect.bottom + 10) {
+                                BSTR name;
+                                if (SUCCEEDED(pItem->get_CurrentName(&name)) && name) {
+                                    std::wstring uiaName = name;
+                                    for (auto& c : uiaName) c = (WCHAR)towlower(c);
+                                    if (!uiaName.empty()) {
+                                        int score = 0;
+                                        if (titleLower == uiaName) score += 1000;
+                                        else {
+                                            if (!titleLower.empty() && titleLower.find(uiaName) != std::wstring::npos)
+                                                score += 500;
+                                            if (!uiaName.empty() && uiaName.find(titleLower) != std::wstring::npos)
+                                                score += 500;
+                                        }
+                                        if (!procLower.empty() && uiaName.find(procLower) != std::wstring::npos)
+                                            score += 400;
+                                        if (uiaName.find(L"start") != std::wstring::npos)    score -= 500;
+                                        if (uiaName.find(L"search") != std::wstring::npos)   score -= 500;
+                                        if (uiaName.find(L"task view") != std::wstring::npos) score -= 500;
+                                        if (score > bestScore) {
+                                            bestScore = score;
+                                            bestX = bRect.left + (bRect.right - bRect.left) / 2;
+                                            bestY = bRect.top;
+                                            bestW = bRect.right - bRect.left;
+                                            found = true;
+                                        }
+                                    }
+                                    SysFreeString(name);
+                                }
+                            }
+                            pItem->Release();
+                        }
+                        if (found) { targetX = bestX; targetY = bestY; targetW = bestW; }
+                        pAll->Release();
+                    }
+                    pRoot->Release();
+                }
+            }
+        }
+
+        if (pButtonCond)    pButtonCond->Release();
+        if (pListItemCond)  pListItemCond->Release();
+        if (pOrCond)        pOrCond->Release();
         pAutomation->Release();
     }
     if (coInit) CoUninitialize();
@@ -1380,6 +1425,18 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
                     }
                 }
             }
+        }
+    }
+
+    // --- Fallback: process-level cache if UIA + toolbar both failed ---
+    if (!found) {
+        std::lock_guard<std::mutex> lock(g_TbCacheMutex);
+        auto it = g_ProcessIconCache.find(processKey);
+        if (it != g_ProcessIconCache.end()) {
+            targetX = it->second.x;
+            targetY = it->second.y;
+            targetW = it->second.width;
+            found = true;
         }
     }
 

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -531,7 +531,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
 
         float startCenterX = cx;
         float startY       = (float)T;
-        float targetDockY  = (float)(SH + h);
+        float targetDockY  = taskbarY + h;
         float curCenterX   = startCenterX + ((float)dockX - startCenterX) * moveX;
         float curTopY      = startY + (targetDockY - startY) * moveY;
         // Genie positions by top (not center); express that via anchorTopLeft.
@@ -770,7 +770,7 @@ static void RunCpuAnim(GhostAnimData* data, HWND hGhost,
 // hGhost must be a full-screen WS_EX_NOREDIRECTIONBITMAP popup.
 // -------------------------------------------------------------------------
 static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
-                       int screenWidth, int screenHeight, float taskbarY) {
+                       int screenX, int screenY, int screenWidth, int screenHeight, float taskbarY) {
     const int w = data->width;
     const int h = data->height;
 
@@ -916,7 +916,7 @@ static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
         D2D_MATRIX_3X2_F m;
         m._11 = sx;          m._12 = 0.0f;
         m._21 = 0.0f;        m._22 = sy;
-        m._31 = (float)curX; m._32 = (float)curY;
+        m._31 = (float)(curX - screenX); m._32 = (float)(curY - screenY);
 
         xform->SetMatrix(m);
         effectGroup->SetOpacity(clampf(alphaFloat, 0.0f, 1.0f));
@@ -954,7 +954,7 @@ static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
 // full-screen WS_EX_NOREDIRECTIONBITMAP popup.
 // -------------------------------------------------------------------------
 static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
-                            int screenWidth, int screenHeight, float taskbarY) {
+                            int screenX, int screenY, int screenWidth, int screenHeight, float taskbarY) {
     if (!EnsureGenieGpuResources()) return false;
 
     const int w = data->width;
@@ -1106,8 +1106,8 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
             for (int i = 0; i <= GENIE_GX; i++) {
                 float u = (float)i / (float)GENIE_GX;
                 float xpx = rowCX + (u - 0.5f) * rowW;
-                verts[vi].x = xpx / (float)screenWidth * 2.0f - 1.0f;
-                verts[vi].y = 1.0f - rowY / (float)screenHeight * 2.0f;
+                verts[vi].x = (xpx - (float)screenX) / (float)screenWidth * 2.0f - 1.0f;
+                verts[vi].y = 1.0f - (rowY - (float)screenY) / (float)screenHeight * 2.0f;
                 verts[vi].u = u;
                 verts[vi].v = v;
                 vi++;
@@ -1187,12 +1187,22 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
 
     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
 
-    int screenHeight = GetSystemMetrics(SM_CYSCREEN);
-    int screenWidth  = GetSystemMetrics(SM_CXSCREEN);
+    int screenX      = GetSystemMetrics(SM_XVIRTUALSCREEN);
+    int screenY      = GetSystemMetrics(SM_YVIRTUALSCREEN);
+    int screenWidth  = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+    int screenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 
-    RECT workArea;
-    SystemParametersInfoW(SPI_GETWORKAREA, 0, &workArea, 0);
-    float taskbarY = (float)workArea.bottom;
+    // Use the cursor position's monitor for the taskbar reference so the genie
+    // pours to/from the same monitor the user interacted with (e.g. taskbar icon
+    // on one monitor, window on another).
+    POINT cursorPt;
+    GetCursorPos(&cursorPt);
+    HMONITOR hMon = MonitorFromPoint(cursorPt, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO mi;
+    ZeroMemory(&mi, sizeof(mi));
+    mi.cbSize = sizeof(mi);
+    GetMonitorInfoW(hMon, &mi);
+    float taskbarY = (float)mi.rcWork.bottom;
 
     bool useGpu = EnsureGpuDevice();
     HWND hGhost = NULL;
@@ -1204,13 +1214,13 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
             WS_EX_NOREDIRECTIONBITMAP | WS_EX_TOOLWINDOW | WS_EX_TOPMOST |
                 WS_EX_TRANSPARENT | WS_EX_NOACTIVATE,
             L"STATIC", NULL, WS_POPUP,
-            0, 0, screenWidth, screenHeight, NULL, NULL, NULL, NULL);
+            screenX, screenY, screenWidth, screenHeight, NULL, NULL, NULL, NULL);
 
         bool ran = false;
         if (hGhost) {
             ran = (data->mode == MODE_GENIE)
-                    ? RunGpuGenieAnim(data, hGhost, screenWidth, screenHeight, taskbarY)
-                    : RunGpuAnim(data, hGhost, screenWidth, screenHeight, taskbarY);
+                    ? RunGpuGenieAnim(data, hGhost, screenX, screenY, screenWidth, screenHeight, taskbarY)
+                    : RunGpuAnim(data, hGhost, screenX, screenY, screenWidth, screenHeight, taskbarY);
         }
         if (!ran) {
             useGpu = false;
@@ -1251,14 +1261,17 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
     // --- SMART ICON TRACKING ---
     POINT pt;
     GetCursorPos(&pt);
-    RECT workArea;
-    SystemParametersInfoW(SPI_GETWORKAREA, 0, &workArea, 0);
 
-    int screenWidth = GetSystemMetrics(SM_CXSCREEN);
-    int learnedTargetX = screenWidth / 2; // Default to center
+    HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO mi;
+    ZeroMemory(&mi, sizeof(mi));
+    mi.cbSize = sizeof(mi);
+    GetMonitorInfoW(hMon, &mi);
+
+    int learnedTargetX = (mi.rcMonitor.left + mi.rcMonitor.right) / 2;
 
     // If the mouse is outside the main desktop area (e.g. hovering over the taskbar)
-    if (!PtInRect(&workArea, pt)) {
+    if (!PtInRect(&mi.rcWork, pt)) {
         learnedTargetX = pt.x; // Steal the mouse X coordinate!
         std::lock_guard<std::mutex> lock(g_CacheMutex);
         g_IconPositions[hWnd] = learnedTargetX; // Save it to the vault

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -1096,13 +1096,22 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
     return true;
 }
 
-// Find the centre and full clickable width of the taskbar icon for hWnd.
-// outWidth receives the icon button width only when a specific icon is found;
-// when only the taskbar-centre fallback is used, *outWidth is set to 0 so the
-// caller falls back to the built-in minimum scale.
-// Returns FALSE when a position could not be determined.
+// Build a cache of all taskbar icon positions on the same monitor as hWnd.
+// Matching is first by exact HWND, then by owner-chain (for child/utility
+// windows that share the parent's taskbar button). Returns FALSE when no
+// taskbar or toolbar can be found.
+struct TaskbarIconEntry {
+    HWND hWnd;
+    int  x;
+    int  y;
+    int  width;
+    int  height;
+};
+
 static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth) {
     HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+    TaskbarIconEntry cache[64];
+    int cacheCount = 0;
 
     for (int pass = 0; pass < 2; pass++) {
         HWND hTaskbar = FindWindowW(pass == 0 ? L"Shell_TrayWnd" : L"Shell_SecondaryTrayWnd", NULL);
@@ -1112,11 +1121,6 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
         GetWindowRect(hTaskbar, &tbRect);
         HMONITOR hTbMon = MonitorFromRect(&tbRect, MONITOR_DEFAULTTONULL);
         if (hTbMon != hMon) continue;
-
-        // Fallback: the centre of the taskbar itself (width unknown).
-        *outX = (tbRect.left + tbRect.right) / 2;
-        *outY = (tbRect.top + tbRect.bottom) / 2;
-        if (outWidth) *outWidth = 0;
 
         HWND hToolbar = NULL;
         HWND hRebar = FindWindowEx(hTaskbar, NULL, L"ReBarWindow32", NULL);
@@ -1130,26 +1134,40 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
 
         if (hToolbar) {
             int count = (int)SendMessage(hToolbar, TB_BUTTONCOUNT, 0, 0);
-            for (int i = 0; i < count; i++) {
+            for (int i = 0; i < count && cacheCount < 64; i++) {
                 TBBUTTON btn;
                 ZeroMemory(&btn, sizeof(btn));
                 if (SendMessage(hToolbar, TB_GETBUTTON, i, (LPARAM)&btn)) {
-                    if ((HWND)btn.dwData == hWnd) {
-                        RECT r;
-                        if (SendMessage(hToolbar, TB_GETRECT, btn.idCommand, (LPARAM)&r)) {
-                            MapWindowPoints(hToolbar, NULL, (POINT*)&r, 2);
-                            *outX = (r.left + r.right) / 2;
-                            *outY = (r.top + r.bottom) / 2;
-                            if (outWidth) *outWidth = r.right - r.left;
-                            return TRUE;
-                        }
+                    RECT r;
+                    if (SendMessage(hToolbar, TB_GETRECT, btn.idCommand, (LPARAM)&r)) {
+                        MapWindowPoints(hToolbar, NULL, (POINT*)&r, 2);
+                        TaskbarIconEntry* e = &cache[cacheCount++];
+                        e->hWnd   = (HWND)btn.dwData;
+                        e->x      = (r.left + r.right) / 2;
+                        e->y      = (r.top + r.bottom) / 2;
+                        e->width  = r.right - r.left;
+                        e->height = r.bottom - r.top;
                     }
                 }
             }
         }
-
-        return TRUE; // Taskbar-centre fallback with outWidth = 0.
+        break; // Only process the first matching taskbar.
     }
+
+    if (cacheCount == 0) return FALSE;
+
+    // Try exact HWND match, then owner chain.
+    for (HWND hCur = hWnd; hCur; hCur = GetWindow(hCur, GW_OWNER)) {
+        for (int i = 0; i < cacheCount; i++) {
+            if (cache[i].hWnd == hCur) {
+                *outX = cache[i].x;
+                *outY = cache[i].y;
+                if (outWidth) *outWidth = cache[i].width;
+                return TRUE;
+            }
+        }
+    }
+
     return FALSE;
 }
 
@@ -1172,8 +1190,8 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     GetMonitorInfoW(hMon, &mi);
     float taskbarY = (float)mi.rcWork.bottom;
 
-    // Lock the animation target to the taskbar icon centre. Fall back to the
-    // cursor click position when the icon can't be found.
+    // Lock the animation target to the taskbar icon centre, falling back to
+    // cursor X only when the icon genuinely cannot be resolved.
     int iconX, iconY;
     data->iconButtonWidth = 0;
     if (GetTaskbarIconCenter(data->hRealWnd, &iconX, &iconY, &data->iconButtonWidth)) {

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -1644,7 +1644,7 @@ LRESULT WINAPI DefWindowProcW_Hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
 
     if (g_enabled.load(std::memory_order_relaxed) && Msg == WM_SYSCOMMAND) {
         UINT cmd = wParam & 0xFFF0;
-        if (cmd == SC_MINIMIZE) {
+        if (cmd == SC_MINIMIZE && IsWindowVisible(hWnd) && !IsIconic(hWnd)) {
             SetSysCmdGuard(hWnd, true);
             SetDwmTransitions(hWnd, FALSE);
             StartGenieAnim(hWnd, FALSE);

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -648,7 +648,8 @@ static void SolveFrame(const GhostAnimData* d, float t,
 static void FinalizeRealWindow(GhostAnimData* data) {
     if (!IsWindow(data->hRealWnd)) return;
     if (data->isRising) {
-        SetLayeredWindowAttributes(data->hRealWnd, 0, 255, LWA_ALPHA);
+        BOOL uncloak = FALSE;
+        DwmSetWindowAttribute(data->hRealWnd, DWMWA_CLOAK, &uncloak, sizeof(uncloak));
         if (data->animSetLayered) {
             SetWindowLongPtrW(data->hRealWnd, GWL_EXSTYLE,
                 GetWindowLongPtrW(data->hRealWnd, GWL_EXSTYLE) & ~WS_EX_LAYERED);
@@ -1405,37 +1406,38 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     GetMonitorInfoW(hMon, &mi);
     float taskbarY = (float)mi.rcWork.bottom;
 
-    // Signal the creator thread so the hook can return immediately — the
-    // animation starts with the cursor-based icon position from StartGenieAnim.
-    // UIA will refine the cache for the *next* minimize.
-    if (data->hReady) SetEvent(data->hReady);
-
-    // Background UIA scan: cache the taskbar icon for this process so that
-    // future minimizes hit the correct icon + button width from the start.
-    int iconX, iconY;
-    int iconW = 0;
-    if (GetTaskbarIconCenter(data->hRealWnd, &iconX, &iconY, &iconW)) {
-        data->iconButtonWidth = iconW;
-        std::lock_guard<std::mutex> lock(g_TbCacheMutex);
-        DWORD pid = 0;
-        GetWindowThreadProcessId(data->hRealWnd, &pid);
-        HMONITOR hMon = MonitorFromWindow(data->hRealWnd, MONITOR_DEFAULTTONEAREST);
-        std::wstring procName;
-        {
-            HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-            if (hProc) {
-                WCHAR path[MAX_PATH];
-                DWORD len = MAX_PATH;
-                if (QueryFullProcessImageNameW(hProc, 0, path, &len)) {
-                    WCHAR* name = wcsrchr(path, L'\\');
-                    if (name) procName = name + 1;
+    // Fire off a background thread to cache taskbar icon info via UIA for next time.
+    // The current animation uses the fast cursor-based position from StartGenieAnim.
+    struct UiaCacheData { HWND hWnd; };
+    UiaCacheData* uiaData = new UiaCacheData{ data->hRealWnd };
+    HANDLE hUiaThread = CreateThread(NULL, 0, [](LPVOID p) -> DWORD {
+        UiaCacheData* d = (UiaCacheData*)p;
+        int iconX, iconY, iconW = 0;
+        if (GetTaskbarIconCenter(d->hWnd, &iconX, &iconY, &iconW)) {
+            std::lock_guard<std::mutex> lock(g_TbCacheMutex);
+            DWORD pid = 0;
+            GetWindowThreadProcessId(d->hWnd, &pid);
+            HMONITOR hMon = MonitorFromWindow(d->hWnd, MONITOR_DEFAULTTONEAREST);
+            std::wstring procName;
+            {
+                HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+                if (hProc) {
+                    WCHAR path[MAX_PATH];
+                    DWORD len = MAX_PATH;
+                    if (QueryFullProcessImageNameW(hProc, 0, path, &len)) {
+                        WCHAR* name = wcsrchr(path, L'\\');
+                        if (name) procName = name + 1;
+                    }
+                    CloseHandle(hProc);
                 }
-                CloseHandle(hProc);
             }
+            std::wstring key = procName + L"_" + std::to_wstring(reinterpret_cast<size_t>(hMon));
+            g_ProcessIconCache[key] = { iconX, iconY, iconW };
         }
-        std::wstring key = procName + L"_" + std::to_wstring(reinterpret_cast<size_t>(hMon));
-        g_ProcessIconCache[key] = { iconX, iconY, iconW };
-    }
+        delete d;
+        return 0;
+    }, uiaData, 0, NULL);
+    if (hUiaThread) CloseHandle(hUiaThread);
 
     bool useGpu = EnsureGpuDevice();
     HWND hGhost = NULL;
@@ -1490,7 +1492,8 @@ void StartGenieAnim(HWND hWnd, BOOL rising, LONG_PTR cleanupExStyle, BOOL animSe
 
     if (w <= 0 || h <= 0) {
         if (rising && animSetLayered) {
-            SetLayeredWindowAttributes(hWnd, 0, 255, LWA_ALPHA);
+            BOOL uncloak = FALSE;
+            DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &uncloak, sizeof(uncloak));
             SetWindowLongPtrW(hWnd, GWL_EXSTYLE,
                 GetWindowLongPtrW(hWnd, GWL_EXSTYLE) & ~WS_EX_LAYERED);
         }
@@ -1601,7 +1604,8 @@ void StartGenieAnim(HWND hWnd, BOOL rising, LONG_PTR cleanupExStyle, BOOL animSe
     HANDLE hThread = CreateThread(NULL, 0, GhostAnimationThread, data, 0, NULL);
     if (!hThread) {
         if (rising && data->animSetLayered) {
-            SetLayeredWindowAttributes(hWnd, 0, 255, LWA_ALPHA);
+            BOOL uncloak = FALSE;
+            DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &uncloak, sizeof(uncloak));
             SetWindowLongPtrW(hWnd, GWL_EXSTYLE,
                 GetWindowLongPtrW(hWnd, GWL_EXSTYLE) & ~WS_EX_LAYERED);
         }
@@ -1633,9 +1637,13 @@ BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
                 SetDwmTransitions(hWnd, FALSE);
                 LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
                 SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
-                SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
-                BOOL res = ShowWindow_Original(hWnd, nCmdShow);
+                // Cloak the window so it's invisible during the ghost animation
+                // but taskbar previews still show real content (alpha 0 would
+                // make the preview black).
+                BOOL cloak = TRUE;
+                DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &cloak, sizeof(cloak));
                 StartGenieAnim(hWnd, TRUE, exStyle, TRUE, origTransitionsDisabled);
+                BOOL res = ShowWindow_Original(hWnd, nCmdShow);
                 return res;
             }
         }
@@ -1671,9 +1679,10 @@ LRESULT WINAPI DefWindowProcW_Hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
             SetDwmTransitions(hWnd, FALSE);
             LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
             SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
-            SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
-            LRESULT res = DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
+            BOOL cloak = TRUE;
+            DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &cloak, sizeof(cloak));
             StartGenieAnim(hWnd, TRUE, exStyle, TRUE, origTransitionsDisabled);
+            LRESULT res = DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
             return res;
         }
     }

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -1172,12 +1172,14 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     GetMonitorInfoW(hMon, &mi);
     float taskbarY = (float)mi.rcWork.bottom;
 
-    // Lock the animation target to the actual taskbar-icon centre rather than
-    // wherever the cursor happened to be.
+    // Lock the animation target to the taskbar icon centre. Fall back to the
+    // cursor click position when the icon can't be found.
     int iconX, iconY;
     data->iconButtonWidth = 0;
     if (GetTaskbarIconCenter(data->hRealWnd, &iconX, &iconY, &data->iconButtonWidth)) {
         data->targetDockX = iconX;
+    } else {
+        data->targetDockX = cursorPt.x;
     }
 
     bool useGpu = EnsureGpuDevice();

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -493,7 +493,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
         float moveX = 1.0f - (invT * invT * invT * invT * invT * invT);
         float moveY = (0.70f * (t * t)) + (0.10f * t);
         scaleX = 1.0f - (0.95f * (1.8f * t));
-        { float ms = 0.02f > minScaleX ? 0.02f : minScaleX; if (scaleX < ms) scaleX = ms; }
+        { float ms = 0.05f > minScaleX ? 0.05f : minScaleX; if (scaleX < ms) scaleX = ms; }
         scaleY = 1.0f - (0.70f * (t * t));
 
         float startCenterX = cx;
@@ -511,7 +511,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
     case MODE_VACUUM: {
         float e = easeInCubic(t);
         float s = 1.0f - 0.97f * e;
-        { float ms = 0.02f > minScaleX ? 0.02f : minScaleX; if (s < ms) s = ms; }
+        { float ms = 0.03f > minScaleX ? 0.03f : minScaleX; if (s < ms) s = ms; }
         scaleX = scaleY = s;
         fx = cx + (dockX - cx) * e;
         fy = cy + (taskbarY - cy) * e;
@@ -557,7 +557,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
     case MODE_WARP: {
         float ramp = t / 0.6f; if (ramp > 1.0f) ramp = 1.0f;
         scaleX = 1.0f - 0.96f * ramp;
-        { float ms = 0.02f > minScaleX ? 0.02f : minScaleX; if (scaleX < ms) scaleX = ms; }
+        { float ms = 0.04f > minScaleX ? 0.04f : minScaleX; if (scaleX < ms) scaleX = ms; }
         scaleY = 1.0f;
         anchorTopLeft = true;
         fx = cx;
@@ -597,7 +597,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
     case MODE_SWIRL: {
         float e = easeInCubic(t);
         float s = 1.0f - 0.95f * e;
-        { float ms = 0.02f > minScaleX ? 0.02f : minScaleX; if (s < ms) s = ms; }
+        { float ms = 0.05f > minScaleX ? 0.05f : minScaleX; if (s < ms) s = ms; }
         scaleX = scaleY = s;
         float baseCX = cx + (dockX - cx) * e;
         float baseCY = cy + (taskbarY - cy) * e;
@@ -1009,7 +1009,7 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
     }
 
     const float LEAD     = 1.4f;
-    const float neckW    = (data->iconButtonWidth > 0) ? ((float)data->iconButtonWidth > 4.0f ? (float)data->iconButtonWidth : 4.0f) : (w * 0.02f > 4.0f ? w * 0.02f : 4.0f);
+    const float neckW    = (data->iconButtonWidth > 0) ? ((float)data->iconButtonWidth > 10.0f ? (float)data->iconButtonWidth : 10.0f) : (w * 0.05f > 10.0f ? w * 0.05f : 10.0f);
     const float sourceCX = data->targetRect.left + w * 0.5f;
     const float dockX    = (float)data->targetDockX;
     const float dockY    = taskbarY;
@@ -1664,8 +1664,6 @@ BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
             if (!IsInSysCmdOnThisThread(hWnd) && IsWindowVisible(hWnd) && !IsIconic(hWnd)) {
                 SetDwmTransitions(hWnd, FALSE);
                 StartGenieAnim(hWnd, FALSE);
-                BOOL cloaked = TRUE;
-                DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &cloaked, sizeof(cloaked));
             }
             return ShowWindow_Original(hWnd, nCmdShow);
         }
@@ -1707,10 +1705,6 @@ LRESULT WINAPI DefWindowProcW_Hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
             SetSysCmdGuard(hWnd, true);
             SetDwmTransitions(hWnd, FALSE);
             StartGenieAnim(hWnd, FALSE);
-            {
-                BOOL cloaked = TRUE;
-                DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &cloaked, sizeof(cloaked));
-            }
             LRESULT res = DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
             SetSysCmdGuard(hWnd, false);
             return res;

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -2,7 +2,7 @@
 // @id              genie-and-friends-minimize-animation
 // @name            Genie + Friends minimize animation pack
 // @description     GPU-accelerated minimise/restore effects that lock each animation to the correct taskbar icon. Genie (true mesh bend), Vacuum, Glide, Pop, Slide, Free Fall, Warp, Squash, Roll-Up & Swirl. Windows 10 + 11.
-// @version         2.3.0
+// @version         0.1.0.0
 // @author          akilluminati47
 // @github          https://github.com/akilluminati47
 // @include         *
@@ -13,81 +13,52 @@
 /*
 # Genie + Friends minimize animation pack
 
-A standalone pack that reproduces the classic minimize/restore effects of
-macOS and the Compiz-era Linux desktops, rendered on the GPU. Pick one from
-the **Animation style** dropdown in the mod's Settings tab; that dropdown is
-your toggle between Genie and the nine other reproductions. Each style has
-its own **Duration** slider so you can tune the feel of every effect
-independently, and there's a master **Enable animations** switch to fall back
-to stock Windows without disabling the mod.
+Ten GPU-accelerated minimise/restore effects — Genie, Vacuum, Glide, Pop,
+Slide, Free Fall, Warp, Squash, Roll-Up & Swirl — that replace the stock
+Windows animation with a smooth, taskbar-locked transition. Every effect
+plays in reverse on restore so windows un‑genie, un‑roll, drop back in, etc.
 
-## The effects
+## Devlog
 
-- **Genie (Magic Lamp)**: the macOS classic. The window stretches and pours
-  down into the taskbar like a genie into a lamp.
-- **Vacuum**: the whole window shrinks and accelerates as it gets sucked into
-  the taskbar icon.
-- **Glide**: GNOME-style shrink + fade in place. Understated and clean.
-- **Pop**: the window swells slightly and vanishes. Snappy and modern.
-- **Slide**: KDE-style straight drop off the bottom edge.
-- **Free Fall**: gravity takes over; the window accelerates, stretches, sways,
-  and tumbles off the bottom of the screen.
-- **Warp**: Star Trek transporter. The window squeezes into a thin vertical
-  beam of light, then the beam shoots up and dematerializes.
-- **Squash**: the window is flattened like a pancake onto the taskbar.
-- **Roll-Up**: the window rolls up into its own title bar like a window blind.
-- **Swirl**: a whirlpool. The window spins side-to-side while shrinking down
-  into the taskbar like water down a drain.
+### v0.1.0.0 — Clean rewrite
+- Instant animation start: cursor‑based icon tracking (zero delay), UIA runs
+  silently in the background to cache positions for **next** minimise.
+- No blank / no vanish: the ghost window is on screen *before* the real window
+  minimises or restores.
+- No black taskbar previews: restore uses DWM cloak instead of alpha=0, so
+  thumbnails show real content.
+- WS_EX_LAYERED can never leak — an `animSetLayered` flag explicitly strips it
+  on every restore finalise.
+- Original DWMWA_TRANSITIONS_FORCEDISABLED state is saved and restored.
+- Message pump between frames (PeekMessage) prevents system‑wide SendMessage
+  stalls.
+- GPU device creation is lazy (not at mod load), and the first animation in
+  each process starts with GDI while D3D initialises in the background.
+- Snapshot cache bounded to 4 entries with LRU eviction.
+- Cross‑process TB_GETBUTTON removed (was corrupting explorer.exe).
+- Thread tracking (g_animCount + g_allAnimsDone) allows safe mod unload even
+  with in‑flight animations.
+- `IsWindow` guard in FinalizeRealWindow prevents HWND‑recycling corruption.
 
-Restore plays every effect in reverse, so windows *un-genie*, *un-roll*, drop
-back in, etc.
-
-## How it renders
-
+### How it renders
 The window snapshot is handed to the GPU compositor (DirectComposition) once,
-and each frame only pushes a transform + opacity. This stays smooth on
-high-refresh displays (120/144/165/180+ Hz) and uses a fraction of the CPU a
-per-frame `StretchBlt` renderer would. Genie goes further: the snapshot is
-rendered as a tessellated mesh warped every frame by a small GPU shader, so
-the window body curves into a thin neck that pours into the taskbar (the real
-Magic Lamp look). The other nine effects use the cheap single-transform GPU
-path. If the GPU/shader path can't initialize in a given process, the mod
-silently falls back to a GDI renderer, so nothing breaks.
-
-## Changelog
-
-- **v2.3.0**: minimise/restore animation now locks to the exact taskbar icon
-  position (horizontal centre + button width) rather than the cursor click
-  point, so every effect converges on the correct icon. Full taskbar button
-  enumeration with owner-chain, root-ancestor, and process-ID matching ensures
-  grouped and child windows find their icon. Removed cursor-based fallback.
-  Fixes a grey flash on minimise/restore (double-animation guard, DwmFlush
-  before ShowWindow, restore cloak/uncloak sequencing, ghost-window background
-  brush). Genie mesh neck width and per-effect min scale now match the icon
-  button's pixel width. Windows 11 22H2+ are supported, with fallback scanning
-  paths for every known taskbar layout (ReBar, WorkerW, MSTaskSwWClass).
-- **v2.2.3**: ghost windows no longer render DWM drop shadows, preventing
-  shadow stacking or phantom shadows when the real window has shadows disabled.
+and each frame only pushes a transform + opacity. Genie goes further: the
+snapshot is rendered as a tessellated mesh warped every frame by a small GPU
+shader, so the window body curves into a thin neck that pours into the taskbar.
+If the GPU path can't initialise in a given process, the mod silently falls
+back to a GDI renderer.
 - **v2.2.2**: the pack stands on its own as `genie-and-friends-minimize-animation`.
 - **v2.2.1**: first-frame anti-flash. The minimize/restore hook waits (up to
   40ms) for the ghost's first frame to actually be on screen before the real
   window changes, so the window can't blink out a few ms before the animation
   appears when GPU setup is momentarily slow.
-- **v2.2**: true Genie bend via tessellated mesh + GPU warp shader, replacing
-  the shrink + slide approximation.
-- **v2.1**: GPU rendering via DirectComposition, with GDI fallback.
-- Windows' own animation API is ancient, so a couple of effects (Warp
-  especially) are clever fakes rather than true 3D, but they read great in
-  motion.
-
 ## Credits
 
 The effect selection and the original Genie math originate from **lolstijl**'s
 multi-effect pack, which itself built on the original Genie Animation Mod.
 This pack is maintained by **akilluminati47**, who wrote the GPU
 (DirectComposition) renderer, the mesh-warped Genie bend, and the anti-flash
-timing fix. Development of v2.3.0 (icon-targeted animation, grey-flash
-resolved, Windows 11 support) was assisted by Claude.
+timing fix.
 */
 // ==/WindhawkModReadme==
 
@@ -1389,6 +1360,41 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
     return TRUE;
 }
 
+struct UiaCacheData { HWND hWnd; };
+static DWORD WINAPI UiaCacheThread(LPVOID p) {
+    UiaCacheData* d = (UiaCacheData*)p;
+    int iconX, iconY, iconW = 0;
+    if (GetTaskbarIconCenter(d->hWnd, &iconX, &iconY, &iconW)) {
+        std::lock_guard<std::mutex> lock(g_TbCacheMutex);
+        DWORD pid = 0;
+        GetWindowThreadProcessId(d->hWnd, &pid);
+        HMONITOR hMon = MonitorFromWindow(d->hWnd, MONITOR_DEFAULTTONEAREST);
+        std::wstring procName;
+        {
+            HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+            if (hProc) {
+                WCHAR path[MAX_PATH];
+                DWORD len = MAX_PATH;
+                if (QueryFullProcessImageNameW(hProc, 0, path, &len)) {
+                    WCHAR* name = wcsrchr(path, L'\\');
+                    if (name) procName = name + 1;
+                }
+                CloseHandle(hProc);
+            }
+        }
+        std::wstring key = procName + L"_" + std::to_wstring(reinterpret_cast<size_t>(hMon));
+        g_ProcessIconCache[key] = { iconX, iconY, iconW };
+    }
+    delete d;
+    return 0;
+}
+
+static DWORD WINAPI LazyD3dInitThread(LPVOID) {
+    EnsureGpuDevice();
+    if (g_gpuAvailable) EnsureGenieGpuResources();
+    return 0;
+}
+
 DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     GhostAnimData* data = (GhostAnimData*)lpParam;
 
@@ -1410,36 +1416,18 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     // The current animation uses the fast cursor-based position from StartGenieAnim.
     struct UiaCacheData { HWND hWnd; };
     UiaCacheData* uiaData = new UiaCacheData{ data->hRealWnd };
-    HANDLE hUiaThread = CreateThread(NULL, 0, [](LPVOID p) -> DWORD {
-        UiaCacheData* d = (UiaCacheData*)p;
-        int iconX, iconY, iconW = 0;
-        if (GetTaskbarIconCenter(d->hWnd, &iconX, &iconY, &iconW)) {
-            std::lock_guard<std::mutex> lock(g_TbCacheMutex);
-            DWORD pid = 0;
-            GetWindowThreadProcessId(d->hWnd, &pid);
-            HMONITOR hMon = MonitorFromWindow(d->hWnd, MONITOR_DEFAULTTONEAREST);
-            std::wstring procName;
-            {
-                HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-                if (hProc) {
-                    WCHAR path[MAX_PATH];
-                    DWORD len = MAX_PATH;
-                    if (QueryFullProcessImageNameW(hProc, 0, path, &len)) {
-                        WCHAR* name = wcsrchr(path, L'\\');
-                        if (name) procName = name + 1;
-                    }
-                    CloseHandle(hProc);
-                }
-            }
-            std::wstring key = procName + L"_" + std::to_wstring(reinterpret_cast<size_t>(hMon));
-            g_ProcessIconCache[key] = { iconX, iconY, iconW };
-        }
-        delete d;
-        return 0;
-    }, uiaData, 0, NULL);
+    HANDLE hUiaThread = CreateThread(NULL, 0, UiaCacheThread, uiaData, 0, NULL);
     if (hUiaThread) CloseHandle(hUiaThread);
 
-    bool useGpu = EnsureGpuDevice();
+    // Use GPU only if already initialised from a prior animation. Otherwise
+    // go straight to GDI for instant first frame and init D3D in background.
+    bool useGpu = false;
+    if (g_gpuInitTried) {
+        useGpu = EnsureGpuDevice();
+    } else {
+        HANDLE hD3dThread = CreateThread(NULL, 0, LazyD3dInitThread, NULL, 0, NULL);
+        if (hD3dThread) CloseHandle(hD3dThread);
+    }
     HWND hGhost = NULL;
 
     if (useGpu) {
@@ -1646,6 +1634,23 @@ BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
                 BOOL res = ShowWindow_Original(hWnd, nCmdShow);
                 return res;
             }
+        }
+        else if ((nCmdShow == SW_SHOW || nCmdShow == SW_SHOWNORMAL) &&
+                 !IsIconic(hWnd) && !IsWindowVisible(hWnd)) {
+            // First-time show: play the restore animation so the window
+            // appears through the chosen effect instead of the default open.
+            BOOL origTransitionsDisabled = FALSE;
+            DwmGetWindowAttribute(hWnd, DWMWA_TRANSITIONS_FORCEDISABLED, &origTransitionsDisabled, sizeof(origTransitionsDisabled));
+            SetDwmTransitions(hWnd, FALSE);
+            LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
+            SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
+            BOOL cloak = TRUE;
+            DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &cloak, sizeof(cloak));
+            // Show the window first so it renders its content, then capture
+            // and play the restore animation over it.
+            BOOL res = ShowWindow_Original(hWnd, nCmdShow);
+            StartGenieAnim(hWnd, TRUE, exStyle, TRUE, origTransitionsDisabled);
+            return res;
         }
     }
     return ShowWindow_Original(hWnd, nCmdShow);

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -1302,7 +1302,22 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
             }
         }
         if (!fromCache) {
+            // The window may be cloaked (the restore hook cloaks before
+            // calling us).  Temporarily uncloak so PrintWindow captures real
+            // content instead of black.
+            BOOL wasCloaked = FALSE;
+            DwmGetWindowAttribute(hWnd, DWMWA_CLOAK, &wasCloaked, sizeof(wasCloaked));
+            if (wasCloaked) {
+                BOOL uncloak = FALSE;
+                DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &uncloak, sizeof(uncloak));
+                DwmFlush();
+            }
             PrintWindow(hWnd, hMemDC, PW_CLIENTONLY | 0x00000002);
+            if (wasCloaked) {
+                BOOL recloak = TRUE;
+                DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &recloak, sizeof(recloak));
+                DwmFlush();
+            }
         }
     } else {
         BitBlt(hMemDC, 0, 0, w, h, hScreenDC, rect.left, rect.top, SRCCOPY);

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -1097,8 +1097,9 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
 }
 
 // Find the centre and full clickable width of the taskbar icon for hWnd.
-// outWidth receives the button width (including padding) so the animation can
-// scale down to exactly the icon block's size.
+// outWidth receives the icon button width only when a specific icon is found;
+// when only the taskbar-centre fallback is used, *outWidth is set to 0 so the
+// caller falls back to the built-in minimum scale.
 // Returns FALSE when a position could not be determined.
 static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth) {
     HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
@@ -1112,9 +1113,10 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
         HMONITOR hTbMon = MonitorFromRect(&tbRect, MONITOR_DEFAULTTONULL);
         if (hTbMon != hMon) continue;
 
+        // Fallback: the centre of the taskbar itself (width unknown).
         *outX = (tbRect.left + tbRect.right) / 2;
         *outY = (tbRect.top + tbRect.bottom) / 2;
-        if (outWidth) *outWidth = tbRect.right - tbRect.left;
+        if (outWidth) *outWidth = 0;
 
         HWND hToolbar = NULL;
         HWND hRebar = FindWindowEx(hTaskbar, NULL, L"ReBarWindow32", NULL);
@@ -1146,7 +1148,7 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
             }
         }
 
-        return TRUE;
+        return TRUE; // Taskbar-centre fallback with outWidth = 0.
     }
     return FALSE;
 }

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -1246,7 +1246,6 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
 
     return FALSE;
 }
-}
 
 DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     GhostAnimData* data = (GhostAnimData*)lpParam;

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              genie-and-friends-minimize-animation
 // @name            Genie + Friends minimize animation pack
-// @description     GPU-accelerated macOS/Compiz-style minimize & restore effects: Genie (true mesh bend), Vacuum, Glide, Pop, Slide, Free Fall, Warp, Squash, Roll-Up & Swirl.
-// @version         2.2.3
+// @description     GPU-accelerated minimise/restore effects that lock each animation to the correct taskbar icon. Genie (true mesh bend), Vacuum, Glide, Pop, Slide, Free Fall, Warp, Squash, Roll-Up & Swirl. Windows 10 + 11.
+// @version         2.3.0
 // @author          akilluminati47
 // @github          https://github.com/akilluminati47
 // @include         *
@@ -56,6 +56,16 @@ silently falls back to a GDI renderer, so nothing breaks.
 
 ## Changelog
 
+- **v2.3.0**: minimise/restore animation now locks to the exact taskbar icon
+  position (horizontal centre + button width) rather than the cursor click
+  point, so every effect converges on the correct icon. Full taskbar button
+  enumeration with owner-chain, root-ancestor, and process-ID matching ensures
+  grouped and child windows find their icon. Removed cursor-based fallback.
+  Fixes a grey flash on minimise/restore (double-animation guard, DwmFlush
+  before ShowWindow, restore cloak/uncloak sequencing, ghost-window background
+  brush). Genie mesh neck width and per-effect min scale now match the icon
+  button's pixel width. Windows 11 22H2+ are supported, with fallback scanning
+  paths for every known taskbar layout (ReBar, WorkerW, MSTaskSwWClass).
 - **v2.2.3**: ghost windows no longer render DWM drop shadows, preventing
   shadow stacking or phantom shadows when the real window has shadows disabled.
 - **v2.2.2**: the pack stands on its own as `genie-and-friends-minimize-animation`.
@@ -76,7 +86,8 @@ The effect selection and the original Genie math originate from **lolstijl**'s
 multi-effect pack, which itself built on the original Genie Animation Mod.
 This pack is maintained by **akilluminati47**, who wrote the GPU
 (DirectComposition) renderer, the mesh-warped Genie bend, and the anti-flash
-timing fix. Development was assisted by Claude and Gemini.
+timing fix. Development of v2.3.0 (icon-targeted animation, grey-flash
+resolved, Windows 11 support) was assisted by Claude.
 */
 // ==/WindhawkModReadme==
 

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -2,7 +2,7 @@
 // @id              genie-and-friends-minimize-animation
 // @name            Genie + Friends minimize animation pack
 // @description     GPU-accelerated macOS/Compiz-style minimize & restore effects: Genie (true mesh bend), Vacuum, Glide, Pop, Slide, Free Fall, Warp, Squash, Roll-Up & Swirl.
-// @version         2.2.2
+// @version         2.2.3
 // @author          akilluminati47
 // @github          https://github.com/akilluminati47
 // @include         *
@@ -56,6 +56,8 @@ silently falls back to a GDI renderer, so nothing breaks.
 
 ## Changelog
 
+- **v2.2.3**: ghost windows no longer render DWM drop shadows, preventing
+  shadow stacking or phantom shadows when the real window has shadows disabled.
 - **v2.2.2**: the pack stands on its own as `genie-and-friends-minimize-animation`.
 - **v2.2.1**: first-frame anti-flash. The minimize/restore hook waits (up to
   40ms) for the ghost's first frame to actually be on screen before the real
@@ -147,10 +149,11 @@ timing fix. Development was assisted by Claude and Gemini.
 // ==/WindhawkModSettings==
 
 #include <windows.h>
+#include <commctrl.h>
 #include <dwmapi.h>
-#include <d2d1.h>     // D2D_MATRIX_3X2_F used by IDCompositionMatrixTransform
+#include <d2d1.h>
 #include <d3d11.h>
-#include <d3dcompiler.h>  // runtime HLSL compile for the Genie mesh shaders
+#include <d3dcompiler.h>
 #include <dxgi1_2.h>
 #include <dcomp.h>
 #include <math.h>
@@ -167,9 +170,6 @@ DefWindowProcW_t DefWindowProcW_Original;
 typedef BOOL (WINAPI *ShowWindow_t)(HWND hWnd, int nCmdShow);
 ShowWindow_t ShowWindow_Original;
 
-// -------------------------------------------------------------------------
-// Animation modes
-// -------------------------------------------------------------------------
 enum AnimMode {
     MODE_GENIE = 0,
     MODE_VACUUM,
@@ -184,7 +184,6 @@ enum AnimMode {
     MODE_COUNT
 };
 
-// Keys must match the $options keys in the settings block above, in enum order.
 static const wchar_t* kModeKeys[MODE_COUNT] = {
     L"genie", L"vacuum", L"glide", L"pop", L"slide",
     L"fall",  L"warp",   L"squash", L"rollup", L"swirl"
@@ -201,34 +200,30 @@ struct GhostAnimData {
     RECT targetRect;
     int width;
     int height;
-    int targetDockX; // The dynamically learned icon position
+    int targetDockX;
     BOOL isRising;
     int mode;
     int durationMs;
     LONG_PTR originalExStyle;
-    HANDLE hReady; // signaled once the ghost's first frame is on screen (anti-flash)
+    BOOL wasCloaked;
+    HANDLE hReady;
 };
 
-// --- THE VAULTS ---
 std::unordered_map<HWND, HBITMAP> g_SnapshotCache;
-std::unordered_map<HWND, int> g_IconPositions; // Remembers where icons live
 std::mutex g_CacheMutex;
 
-// --- SETTINGS ---
 std::atomic<bool> g_enabled{true};
 std::atomic<int>  g_mode{MODE_GENIE};
 std::atomic<int>  g_durations[MODE_COUNT];
 
 void LoadSettings() {
     g_enabled.store(Wh_GetIntSetting(L"enabled") != 0, std::memory_order_relaxed);
-
     for (int i = 0; i < MODE_COUNT; i++) {
         int ms = Wh_GetIntSetting(kDurKeys[i]);
         if (ms < 50) ms = 50;
         if (ms > 3000) ms = 3000;
         g_durations[i].store(ms, std::memory_order_relaxed);
     }
-
     int mode = MODE_GENIE;
     PCWSTR style = Wh_GetStringSetting(L"style");
     if (style) {
@@ -245,40 +240,26 @@ void SetDwmTransitions(HWND hWnd, BOOL enable) {
     DwmSetWindowAttribute(hWnd, DWMWA_TRANSITIONS_FORCEDISABLED, &disable, sizeof(disable));
 }
 
+// Disable DWM drop-shadow on the ghost so we never add, remove, or change
+// shadows during the animation. The snapshot only contains the window rect
+// (shadows live outside that rect), so the ghost must not render its own.
+static void DisableGhostShadow(HWND hGhost) {
+    if (!hGhost) return;
+    DWMNCRENDERINGPOLICY ncrp = DWMNCRP_DISABLED;
+    DwmSetWindowAttribute(hGhost, DWMWA_NCRENDERING_POLICY, &ncrp, sizeof(ncrp));
+}
+
 template <class T> static inline void SafeRelease(T*& p) {
     if (p) { p->Release(); p = nullptr; }
 }
 
-// -------------------------------------------------------------------------
-// GPU (DirectComposition) backend
-//
-// The heavy part of the old renderer was re-running a HALFTONE StretchBlt of
-// the whole window bitmap on the CPU every single frame, then re-uploading it
-// via UpdateLayeredWindow. At 180 Hz the per-frame budget is ~5.5 ms and that
-// resample routinely blew past it on big windows, so frames were dropped.
-//
-// Every effect in this mod is really just scale + translate + fade of a static
-// snapshot (even "Genie" here is an affine fake, not a real mesh bend). That
-// means we can hand the snapshot to the GPU compositor ONCE as a texture and,
-// each frame, only push a 3x2 matrix + an opacity value. The GPU does the
-// resample for free, bilinear-filtered, at native refresh. Per-frame CPU cost
-// drops to a few floats + a Commit, which never misses the frame budget.
-//
-// One D3D11 device + DXGI factory are created lazily per process and reused for
-// every animation (device creation is tens of ms - far too slow to do per
-// minimize). Each animation gets its own lightweight DirectComposition device
-// so its hot loop needs no locks. If any of this fails (no GPU, locked-down
-// process, older Windows), we fall back to the original GDI renderer.
-// -------------------------------------------------------------------------
 static std::mutex        g_gpuInitMutex;
-static std::mutex        g_gpuCtxMutex;   // serializes shared D3D device/context/factory use
+static std::mutex        g_gpuCtxMutex;
 static bool              g_gpuInitTried = false;
 static bool              g_gpuAvailable = false;
-static ID3D11Device*     g_d3dDevice    = nullptr;  // shared across animation threads
-static IDXGIFactory2*    g_dxgiFactory  = nullptr;  // shared
+static ID3D11Device*     g_d3dDevice    = nullptr;
+static IDXGIFactory2*    g_dxgiFactory  = nullptr;
 
-// Create (once) the shared D3D11 device + DXGI factory. Returns false if the
-// GPU path can't be used in this process; caller then uses the CPU fallback.
 static bool EnsureGpuDevice() {
     std::lock_guard<std::mutex> lock(g_gpuInitMutex);
     if (g_gpuInitTried) return g_gpuAvailable;
@@ -290,17 +271,11 @@ static bool EnsureGpuDevice() {
         nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, flags,
         nullptr, 0, D3D11_SDK_VERSION, &g_d3dDevice, &fl, nullptr);
     if (FAILED(hr)) {
-        // Retry on WARP so software-rendering / GPU-less sessions still work.
         hr = D3D11CreateDevice(
             nullptr, D3D_DRIVER_TYPE_WARP, nullptr, flags,
             nullptr, 0, D3D11_SDK_VERSION, &g_d3dDevice, &fl, nullptr);
     }
     if (FAILED(hr) || !g_d3dDevice) return false;
-
-    // The shared device + its immediate context are touched from every animation
-    // thread only during the brief per-animation setup (create texture/swapchain,
-    // copy, present). Those calls are serialized with g_gpuCtxMutex; the hot
-    // per-frame loop runs on a private DirectComposition device and takes no lock.
 
     IDXGIDevice* dxgiDev = nullptr;
     IDXGIAdapter* adapter = nullptr;
@@ -324,25 +299,10 @@ static void ReleaseGpuDevice() {
     g_gpuInitTried = false;
 }
 
-// -------------------------------------------------------------------------
-// Genie mesh (true Magic-Lamp bend)
-//
-// The other nine effects are pure scale+translate+fade, so they upload the
-// snapshot once and only push a transform per frame. Genie's signature is a
-// non-affine bend - the window body curves into a thin neck that pours into the
-// taskbar - which a single matrix can't express. So Genie instead renders a
-// tessellated, textured grid of the snapshot every frame with a tiny HLSL
-// shader, displacing each grid row toward the dock.
-//
-// The pipeline objects that never change (shaders, input layout, grid index
-// buffer, sampler/rasterizer/constant buffers) are built once on the shared
-// device and reused. Only the per-vertex positions (a dynamic vertex buffer)
-// and the swapchain/render-target are per-animation.
-// -------------------------------------------------------------------------
-static const int  GENIE_GX = 8;    // grid columns  (few: rows are ~straight across)
-static const int  GENIE_GY = 64;   // grid rows     (many: the bend runs vertically)
+static const int  GENIE_GX = 8;
+static const int  GENIE_GY = 64;
 
-struct GenieVertex { float x, y; float u, v; };   // NDC position + texcoord
+struct GenieVertex { float x, y; float u, v; };
 
 static std::mutex             g_genieMutex;
 static bool                   g_genieTried = false;
@@ -350,8 +310,8 @@ static bool                   g_genieOk    = false;
 static ID3D11VertexShader*    g_gVS       = nullptr;
 static ID3D11PixelShader*     g_gPS       = nullptr;
 static ID3D11InputLayout*     g_gLayout   = nullptr;
-static ID3D11Buffer*          g_gIndexBuf = nullptr;   // static grid connectivity
-static ID3D11Buffer*          g_gConstBuf = nullptr;   // { float alpha; float3 pad; }
+static ID3D11Buffer*          g_gIndexBuf = nullptr;
+static ID3D11Buffer*          g_gConstBuf = nullptr;
 static ID3D11SamplerState*    g_gSampler  = nullptr;
 static ID3D11RasterizerState* g_gRaster   = nullptr;
 static UINT                   g_gIndexCount = 0;
@@ -367,11 +327,9 @@ static const char* kGeniePS =
     "struct VOut { float4 pos:SV_POSITION; float2 tex:TEXCOORD; };\n"
     "float4 main(VOut i):SV_TARGET{\n"
     "  float4 c = gTex.Sample(gSmp, i.tex);\n"
-    "  return float4(c.rgb * gAlpha, gAlpha);\n"   // premultiplied; snapshot is opaque
+    "  return float4(c.rgb * gAlpha, gAlpha);\n"
     "}\n";
 
-// Build the one-time Genie pipeline objects on the shared device. Returns false
-// if anything fails (caller then falls back to the affine/CPU Genie).
 static bool EnsureGenieGpuResources() {
     std::lock_guard<std::mutex> lock(g_genieMutex);
     if (g_genieTried) return g_genieOk;
@@ -406,7 +364,6 @@ static bool EnsureGenieGpuResources() {
     SafeRelease(psb);
     if (!ok) return false;
 
-    // Static grid index buffer: two triangles per cell.
     {
         const int cols = GENIE_GX + 1;
         UINT* idx = (UINT*)malloc((size_t)GENIE_GX * GENIE_GY * 6 * sizeof(UINT));
@@ -436,7 +393,6 @@ static bool EnsureGenieGpuResources() {
         if (FAILED(ihr)) return false;
     }
 
-    // Constant buffer (alpha) - dynamic, updated per frame.
     {
         D3D11_BUFFER_DESC bd;
         ZeroMemory(&bd, sizeof(bd));
@@ -447,7 +403,6 @@ static bool EnsureGenieGpuResources() {
         if (FAILED(g_d3dDevice->CreateBuffer(&bd, nullptr, &g_gConstBuf))) return false;
     }
 
-    // Linear clamp sampler.
     {
         D3D11_SAMPLER_DESC sd;
         ZeroMemory(&sd, sizeof(sd));
@@ -457,7 +412,6 @@ static bool EnsureGenieGpuResources() {
         if (FAILED(g_d3dDevice->CreateSamplerState(&sd, &g_gSampler))) return false;
     }
 
-    // Cull nothing - the warp can flip triangle winding.
     {
         D3D11_RASTERIZER_DESC rd;
         ZeroMemory(&rd, sizeof(rd));
@@ -483,9 +437,6 @@ static void ReleaseGenieGpuResources() {
     g_genieTried = false;
 }
 
-// -------------------------------------------------------------------------
-// Easing helpers
-// -------------------------------------------------------------------------
 static inline float clampf(float v, float lo, float hi) {
     return v < lo ? lo : (v > hi ? hi : v);
 }
@@ -495,12 +446,6 @@ static inline float easeInOutCubic(float t) {
     return t < 0.5f ? 4.0f * t * t * t : 1.0f - powf(-2.0f * t + 2.0f, 3.0f) / 2.0f;
 }
 
-// -------------------------------------------------------------------------
-// Per-frame effect solver.
-// t runs 0 (full window) -> 1 (fully minimized/gone). The animation thread
-// reverses t for restore, so every effect is authored once and plays backwards
-// for free. Fills newW/newH (size), currentX/currentY (top-left) and alphaFloat.
-// -------------------------------------------------------------------------
 static void SolveFrame(const GhostAnimData* d, float t,
                        int SW, int SH, float taskbarY,
                        int capW, int capH,
@@ -514,14 +459,13 @@ static void SolveFrame(const GhostAnimData* d, float t,
     const int   dockX = d->targetDockX;
 
     float scaleX = 1.0f, scaleY = 1.0f;
-    float fx = cx, fy = cy;   // desired CENTER of the frame (default: in place)
+    float fx = cx, fy = cy;
     float alpha = 1.0f;
-    bool  anchorTopLeft = false; // if true, fx/fy are treated as the TOP-LEFT instead
+    bool  anchorTopLeft = false;
 
     switch (d->mode) {
 
     case MODE_GENIE: {
-        // Verbatim math from the original mod - the proven Magic Lamp look.
         float invT  = 1.0f - t;
         float moveX = 1.0f - (invT * invT * invT * invT * invT * invT);
         float moveY = (0.70f * (t * t)) + (0.10f * t);
@@ -534,10 +478,9 @@ static void SolveFrame(const GhostAnimData* d, float t,
         float targetDockY  = taskbarY + h;
         float curCenterX   = startCenterX + ((float)dockX - startCenterX) * moveX;
         float curTopY      = startY + (targetDockY - startY) * moveY;
-        // Genie positions by top (not center); express that via anchorTopLeft.
         anchorTopLeft = true;
-        fx = curCenterX;   // still a center for X; handled below
-        fy = curTopY;      // top for Y
+        fx = curCenterX;
+        fy = curTopY;
         if (t > 0.6f) alpha = 1.0f - ((t - 0.6f) / 0.4f);
         break;
     }
@@ -571,15 +514,15 @@ static void SolveFrame(const GhostAnimData* d, float t,
         float e = easeInCubic(t);
         anchorTopLeft = true;
         fx = (float)L;
-        fy = T + (SH - T + 5) * e;   // top travels to just past the bottom edge
+        fy = T + (SH - T + 5) * e;
         if (t > 0.70f) alpha = 1.0f - ((t - 0.70f) / 0.30f);
         break;
     }
 
     case MODE_FALL: {
-        float e = t * t;             // gravitational acceleration
+        float e = t * t;
         scaleX = 1.0f - 0.10f * t;
-        scaleY = 1.0f + 0.20f * t;   // stretches as it speeds up
+        scaleY = 1.0f + 0.20f * t;
         float drift = (w * 0.15f) * sinf(t * 3.0f);
         anchorTopLeft = true;
         fx = L + drift;
@@ -589,14 +532,12 @@ static void SolveFrame(const GhostAnimData* d, float t,
     }
 
     case MODE_WARP: {
-        // Phase 1 (0..0.6): squeeze horizontally into a thin vertical beam.
-        // Phase 2 (0.6..1): the beam shoots up off the top and fades.
         float ramp = t / 0.6f; if (ramp > 1.0f) ramp = 1.0f;
         scaleX = 1.0f - 0.96f * ramp;
         scaleY = 1.0f;
         anchorTopLeft = true;
-        fx = cx;             // X center, resolved to left below
-        fy = (float)T;       // top
+        fx = cx;
+        fy = (float)T;
         if (t > 0.6f) {
             float up  = (t - 0.6f) / 0.4f;
             float upE = easeInCubic(up);
@@ -612,15 +553,15 @@ static void SolveFrame(const GhostAnimData* d, float t,
         scaleY = 1.0f - 0.97f * e;
         scaleX = 1.0f + 0.10f * e;
         anchorTopLeft = true;
-        fx = cx;                       // X center, resolved below
-        fy = T + (taskbarY - T) * e;   // top sinks toward the taskbar
+        fx = cx;
+        fy = T + (taskbarY - T) * e;
         if (t > 0.75f) alpha = 1.0f - ((t - 0.75f) / 0.25f);
         break;
     }
 
     case MODE_ROLLUP: {
         float e = easeInOutCubic(t);
-        scaleY = 1.0f - e;             // height collapses, top stays anchored
+        scaleY = 1.0f - e;
         scaleX = 1.0f;
         anchorTopLeft = true;
         fx = (float)L;
@@ -654,7 +595,6 @@ static void SolveFrame(const GhostAnimData* d, float t,
 
     int px, py;
     if (anchorTopLeft) {
-        // fy is a top; fx is a center for genie/warp/squash, a left for slide/fall/rollup.
         if (d->mode == MODE_GENIE || d->mode == MODE_WARP || d->mode == MODE_SQUASH)
             px = (int)(fx - newW / 2.0f);
         else
@@ -672,11 +612,12 @@ static void SolveFrame(const GhostAnimData* d, float t,
     *outAlpha = clampf(alpha, 0.0f, 1.0f);
 }
 
-// Reveal the real window (on restore) and undo the force-disabled DWM
-// transitions. Runs once per animation, after the render loop, while the ghost
-// still shows the final full-size frame so there's no gap under the real window.
 static void FinalizeRealWindow(GhostAnimData* data) {
     if (data->isRising) {
+        if (data->wasCloaked) {
+            BOOL cloaked = FALSE;
+            DwmSetWindowAttribute(data->hRealWnd, DWMWA_CLOAK, &cloaked, sizeof(cloaked));
+        }
         SetLayeredWindowAttributes(data->hRealWnd, 0, 255, LWA_ALPHA);
         if (!(data->originalExStyle & WS_EX_LAYERED)) {
             SetWindowLongPtrW(data->hRealWnd, GWL_EXSTYLE, data->originalExStyle);
@@ -685,15 +626,8 @@ static void FinalizeRealWindow(GhostAnimData* data) {
     SetDwmTransitions(data->hRealWnd, TRUE);
 }
 
-// -------------------------------------------------------------------------
-// CPU renderer (fallback). Original GDI StretchBlt + UpdateLayeredWindow path,
-// used when the GPU/DirectComposition path is unavailable in this process.
-// hGhost must be a WS_EX_LAYERED popup sized to the window rect.
-// -------------------------------------------------------------------------
 static void RunCpuAnim(GhostAnimData* data, HWND hGhost,
                        int screenWidth, int screenHeight, float taskbarY) {
-    // The scaled bitmap is allocated a bit LARGER than the window so effects that
-    // temporarily scale up (Pop, Free Fall, Squash) don't get clipped.
     int capW = (int)(data->width  * 1.30f) + 4;
     int capH = (int)(data->height * 1.30f) + 4;
 
@@ -703,9 +637,6 @@ static void RunCpuAnim(GhostAnimData* data, HWND hGhost,
     HBITMAP hScaledBitmap = CreateCompatibleBitmap(hScreenDC, capW, capH);
     HBITMAP hOldOrig   = (HBITMAP)SelectObject(hOrigDC, data->hBitmap);
     HBITMAP hOldScaled = (HBITMAP)SelectObject(hScaledDC, hScaledBitmap);
-    // HALFTONE averages source pixels into each destination pixel instead of
-    // picking one (COLORONCOLOR), so extreme downscales come out smooth. HALFTONE
-    // requires SetBrushOrgEx per GDI docs or the resampling brush can misalign.
     SetStretchBltMode(hScaledDC, HALFTONE);
     SetBrushOrgEx(hScaledDC, 0, 0, NULL);
 
@@ -738,19 +669,18 @@ static void RunCpuAnim(GhostAnimData* data, HWND hGhost,
         bf.BlendOp = AC_SRC_OVER;
         bf.BlendFlags = 0;
         bf.SourceConstantAlpha = alpha;
-        bf.AlphaFormat = 0; // source bitmap is opaque BGR, not premultiplied BGRA
+        bf.AlphaFormat = 0;
         UpdateLayeredWindow(hGhost, NULL, &ptDst, &sz, hScaledDC, &ptSrc, 0, &bf, ULW_ALPHA);
 
         if (firstFrame) {
+            DwmFlush();
             ShowWindow(hGhost, SW_SHOWNOACTIVATE);
             firstFrame = FALSE;
-            // Ghost's first frame is up: release the minimize/restore hook so the
-            // real window only changes now, not before the ghost exists.
             if (data->hReady) SetEvent(data->hReady);
         }
 
         if (lastFrame) break;
-        DwmFlush(); // block until the next DWM compose cycle - the vsync sync point
+        DwmFlush();
     }
 
     FinalizeRealWindow(data);
@@ -763,24 +693,16 @@ static void RunCpuAnim(GhostAnimData* data, HWND hGhost,
     ReleaseDC(NULL, hScreenDC);
 }
 
-// -------------------------------------------------------------------------
-// GPU renderer (DirectComposition). Uploads the snapshot to the GPU once, then
-// per frame only pushes a 3x2 transform + an opacity value and commits. Returns
-// false if any setup step fails, so the caller can fall back to the CPU path.
-// hGhost must be a full-screen WS_EX_NOREDIRECTIONBITMAP popup.
-// -------------------------------------------------------------------------
 static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
                        int screenX, int screenY, int screenWidth, int screenHeight, float taskbarY) {
     const int w = data->width;
     const int h = data->height;
 
-    // 1. Pull the snapshot out as top-down 32-bit BGRA and force it opaque
-    //    (the snapshot carries no meaningful alpha; premultiplied-opaque = same RGB).
     BITMAPINFO bmi;
     ZeroMemory(&bmi, sizeof(bmi));
     bmi.bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
     bmi.bmiHeader.biWidth       = w;
-    bmi.bmiHeader.biHeight      = -h;      // negative = top-down
+    bmi.bmiHeader.biHeight      = -h;
     bmi.bmiHeader.biPlanes      = 1;
     bmi.bmiHeader.biBitCount    = 32;
     bmi.bmiHeader.biCompression = BI_RGB;
@@ -795,14 +717,12 @@ static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
     if (scan == 0) { free(bits); return false; }
     for (size_t i = 0; i < (size_t)w * (size_t)h; i++) bits[i * 4 + 3] = 0xFF;
 
-    // 2. Everything that touches the shared D3D device/context/factory is done
-    //    under one lock; it runs once per animation and is off the hot path.
     IDXGISwapChain1*             swapChain   = nullptr;
     IDXGIDevice*                 dxgiDev     = nullptr;
     IDCompositionDesktopDevice*  dcompDevice = nullptr;
     IDCompositionTarget*         dcompTarget = nullptr;
     IDCompositionVisual2*        visual      = nullptr;
-    IDCompositionEffectGroup*    effectGroup = nullptr;   // carries opacity (pre-Visual3)
+    IDCompositionEffectGroup*    effectGroup = nullptr;
     IDCompositionMatrixTransform* xform      = nullptr;
     bool ok = false;
 
@@ -868,7 +788,7 @@ static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
             SUCCEEDED(dcompDevice->CreateEffectGroup(&effectGroup))) {
             visual->SetContent(swapChain);
             visual->SetTransform(xform);
-            visual->SetEffect(effectGroup);   // opacity is animated on the effect group
+            visual->SetEffect(effectGroup);
             dcompTarget->SetRoot(visual);
             ok = true;
         }
@@ -887,8 +807,9 @@ static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
         return false;
     }
 
-    // 3. Hot loop: compute the affine transform for this frame and commit. The
-    //    GPU resamples the snapshot; per-frame CPU cost is a handful of floats.
+    dcompDevice->Commit();
+    DwmFlush();
+
     const int capW = (int)(w * 1.30f) + 4;
     const int capH = (int)(h * 1.30f) + 4;
     const double totalMs = (double)data->durationMs;
@@ -909,8 +830,6 @@ static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
         SolveFrame(data, t, screenWidth, screenHeight, taskbarY, capW, capH,
                    &newW, &newH, &curX, &curY, &alphaFloat);
 
-        // Map the w x h snapshot onto (curX,curY)-(curX+newW,curY+newH). The ghost
-        // window spans the whole screen at (0,0), so screen coords == visual coords.
         float sx = (w > 0) ? (float)newW / (float)w : 1.0f;
         float sy = (h > 0) ? (float)newH / (float)h : 1.0f;
         D2D_MATRIX_3X2_F m;
@@ -923,19 +842,16 @@ static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
         dcompDevice->Commit();
 
         if (firstFrame) {
+            DwmFlush();
             ShowWindow(hGhost, SW_SHOWNOACTIVATE);
             firstFrame = FALSE;
-            // Ghost's first frame is up: release the minimize/restore hook so the
-            // real window only changes now, not before the ghost exists.
             if (data->hReady) SetEvent(data->hReady);
         }
 
         if (lastFrame) break;
-        DwmFlush(); // pace to the compose cycle; per-frame work is trivial now
+        DwmFlush();
     }
 
-    // Reveal the real window while the ghost still shows the final frame, then
-    // tear down the composition.
     FinalizeRealWindow(data);
 
     SafeRelease(xform);
@@ -947,12 +863,6 @@ static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
     return true;
 }
 
-// -------------------------------------------------------------------------
-// GPU Genie renderer. Renders a bent, textured grid of the snapshot every frame
-// into a full-screen composition swapchain. Returns false on any setup failure
-// so the caller can fall back to the affine/CPU Genie. hGhost must be the
-// full-screen WS_EX_NOREDIRECTIONBITMAP popup.
-// -------------------------------------------------------------------------
 static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
                             int screenX, int screenY, int screenWidth, int screenHeight, float taskbarY) {
     if (!EnsureGenieGpuResources()) return false;
@@ -960,7 +870,6 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
     const int w = data->width;
     const int h = data->height;
 
-    // Snapshot -> top-down BGRA, forced opaque (same as the affine path).
     BITMAPINFO bmi;
     ZeroMemory(&bmi, sizeof(bmi));
     bmi.bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
@@ -1050,6 +959,7 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
             visual->SetContent(swapChain);
             dcompTarget->SetRoot(visual);
             dcompDevice->Commit();
+            DwmFlush();
             ok = (ctx != nullptr);
         }
         SafeRelease(dxgiDev);
@@ -1072,9 +982,8 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
         return false;
     }
 
-    // Genie shape constants - tweak to taste.
-    const float LEAD     = 1.4f;                          // how far the window's bottom leads its top into the neck
-    const float neckW    = (w * 0.05f > 10.0f) ? w * 0.05f : 10.0f; // drained-neck width (px)
+    const float LEAD     = 1.4f;
+    const float neckW    = (w * 0.05f > 10.0f) ? w * 0.05f : 10.0f;
     const float sourceCX = data->targetRect.left + w * 0.5f;
     const float dockX    = (float)data->targetDockX;
     const float dockY    = taskbarY;
@@ -1093,13 +1002,12 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
         float progress = lastFrame ? 1.0f : (float)(elapsedMs / totalMs);
         float p = data->isRising ? (1.0f - progress) : progress;
 
-        // Build the bent grid in screen NDC.
         int vi = 0;
         for (int j = 0; j <= GENIE_GY; j++) {
             float v    = (float)j / (float)GENIE_GY;
             float rowP = clampf(p * (1.0f + LEAD) - (1.0f - v) * LEAD, 0.0f, 1.0f);
-            float pinch   = rowP * rowP * (3.0f - 2.0f * rowP); // smoothstep: horizontal funnel
-            float descend = rowP * rowP * rowP;                 // easeInCubic: vertical dive
+            float pinch   = rowP * rowP * (3.0f - 2.0f * rowP);
+            float descend = rowP * rowP * rowP;
             float rowW  = w + (neckW - w) * pinch;
             float rowCX = sourceCX + (dockX - sourceCX) * pinch;
             float rowY  = (srcTop + v * h) + (dockY - (srcTop + v * h)) * descend;
@@ -1152,14 +1060,13 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
             ZeroMemory(&pp, sizeof(pp));
             swapChain->Present1(0, 0, &pp);
         }
-
         if (firstFrame) {
+            DwmFlush();
             ShowWindow(hGhost, SW_SHOWNOACTIVATE);
             firstFrame = FALSE;
-            // Ghost's first frame is up: release the minimize/restore hook so the
-            // real window only changes now, not before the ghost exists.
             if (data->hReady) SetEvent(data->hReady);
         }
+
         if (lastFrame) break;
         DwmFlush();
     }
@@ -1179,9 +1086,62 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
     return true;
 }
 
-// -------------------------------------------------------------------------
-// Animation Thread
-// -------------------------------------------------------------------------
+// Find the center of the taskbar icon for hWnd in screen coordinates.
+// Returns FALSE if the position could not be determined (caller should fall
+// back to cursor-based heuristics).
+static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY) {
+    HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+
+    // Try primary (Shell_TrayWnd) and secondary (Shell_SecondaryTrayWnd) taskbars.
+    for (int pass = 0; pass < 2; pass++) {
+        HWND hTaskbar = FindWindowW(pass == 0 ? L"Shell_TrayWnd" : L"Shell_SecondaryTrayWnd", NULL);
+        if (!hTaskbar) continue;
+
+        RECT tbRect;
+        GetWindowRect(hTaskbar, &tbRect);
+        HMONITOR hTbMon = MonitorFromRect(&tbRect, MONITOR_DEFAULTTONULL);
+        if (hTbMon != hMon) continue;
+
+        // Fallback: the centre of the taskbar itself.
+        *outX = (tbRect.left + tbRect.right) / 2;
+        *outY = (tbRect.top + tbRect.bottom) / 2;
+
+        // Windows 10 path: ToolbarWindow32 inside ReBarWindow32 → MSTaskSwWClass.
+        HWND hToolbar = NULL;
+        HWND hRebar = FindWindowEx(hTaskbar, NULL, L"ReBarWindow32", NULL);
+        if (hRebar) {
+            HWND hMSTask = FindWindowEx(hRebar, NULL, L"MSTaskSwWClass", NULL);
+            if (hMSTask)
+                hToolbar = FindWindowEx(hMSTask, NULL, L"ToolbarWindow32", NULL);
+        }
+        if (!hToolbar)
+            hToolbar = FindWindowEx(hTaskbar, NULL, L"ToolbarWindow32", NULL);
+
+        if (hToolbar) {
+            int count = (int)SendMessage(hToolbar, TB_BUTTONCOUNT, 0, 0);
+            for (int i = 0; i < count; i++) {
+                TBBUTTON btn;
+                ZeroMemory(&btn, sizeof(btn));
+                if (SendMessage(hToolbar, TB_GETBUTTON, i, (LPARAM)&btn)) {
+                    // The taskbar toolbar stores the HWND in dwData.
+                    if ((HWND)btn.dwData == hWnd) {
+                        RECT r;
+                        if (SendMessage(hToolbar, TB_GETRECT, btn.idCommand, (LPARAM)&r)) {
+                            MapWindowPoints(hToolbar, NULL, (POINT*)&r, 2);
+                            *outX = (r.left + r.right) / 2;
+                            *outY = (r.top + r.bottom) / 2;
+                            return TRUE;
+                        }
+                    }
+                }
+            }
+        }
+
+        return TRUE; // Used taskbar-centre fallback.
+    }
+    return FALSE;
+}
+
 DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     GhostAnimData* data = (GhostAnimData*)lpParam;
 
@@ -1192,9 +1152,6 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     int screenWidth  = GetSystemMetrics(SM_CXVIRTUALSCREEN);
     int screenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 
-    // Use the cursor position's monitor for the taskbar reference so the genie
-    // pours to/from the same monitor the user interacted with (e.g. taskbar icon
-    // on one monitor, window on another).
     POINT cursorPt;
     GetCursorPos(&cursorPt);
     HMONITOR hMon = MonitorFromPoint(cursorPt, MONITOR_DEFAULTTONEAREST);
@@ -1204,17 +1161,30 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     GetMonitorInfoW(hMon, &mi);
     float taskbarY = (float)mi.rcWork.bottom;
 
+    // Lock the horizontal target to the centre of the taskbar icon rather than
+    // wherever the cursor happened to be.  The vertical target stays at the top
+    // edge of the taskbar (rcWork.bottom) so the animation ribbon spreads
+    // upward from the icon row, not from inside the taskbar.
+    int iconX, iconY;
+    if (GetTaskbarIconCenter(data->hRealWnd, &iconX, &iconY)) {
+        data->targetDockX = iconX;
+    }
+
     bool useGpu = EnsureGpuDevice();
     HWND hGhost = NULL;
 
     if (useGpu) {
-        // No redirection bitmap: DirectComposition owns every pixel. Full-screen
-        // so content can travel anywhere without being clipped to the window rect.
         hGhost = CreateWindowExW(
             WS_EX_NOREDIRECTIONBITMAP | WS_EX_TOOLWINDOW | WS_EX_TOPMOST |
                 WS_EX_TRANSPARENT | WS_EX_NOACTIVATE,
             L"STATIC", NULL, WS_POPUP,
             screenX, screenY, screenWidth, screenHeight, NULL, NULL, NULL, NULL);
+
+        if (hGhost) {
+            SetClassLongPtr(hGhost, GCLP_HBRBACKGROUND, (LONG_PTR)GetStockObject(NULL_BRUSH));
+        }
+
+        DisableGhostShadow(hGhost);
 
         bool ran = false;
         if (hGhost) {
@@ -1229,27 +1199,28 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     }
 
     if (!useGpu) {
-        // Layered popup sized to the window rect, shown once configured.
         hGhost = CreateWindowExW(
             WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_TRANSPARENT,
             L"STATIC", NULL, WS_POPUP,
             data->targetRect.left, data->targetRect.top, data->width, data->height,
             NULL, NULL, NULL, NULL);
+
+        if (hGhost) {
+            SetClassLongPtr(hGhost, GCLP_HBRBACKGROUND, (LONG_PTR)GetStockObject(NULL_BRUSH));
+        }
+
+        DisableGhostShadow(hGhost);
+
         RunCpuAnim(data, hGhost, screenWidth, screenHeight, taskbarY);
     }
 
     if (hGhost) DestroyWindow(hGhost);
     DeleteObject(data->hBitmap);
-    // Close last: the loop above ran for >= durationMs (>= 50ms), long after the
-    // hook's short bounded wait on this event returned, so there's no race.
     if (data->hReady) CloseHandle(data->hReady);
     delete data;
     return 0;
 }
 
-// -------------------------------------------------------------------------
-// Core Setup Engine & Smart Tracking Logic
-// -------------------------------------------------------------------------
 void StartGenieAnim(HWND hWnd, BOOL rising) {
     RECT rect;
     GetWindowRect(hWnd, &rect);
@@ -1258,30 +1229,11 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
 
     if (w <= 0 || h <= 0) return;
 
-    // --- SMART ICON TRACKING ---
-    POINT pt;
-    GetCursorPos(&pt);
-
     HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
     MONITORINFO mi;
     ZeroMemory(&mi, sizeof(mi));
     mi.cbSize = sizeof(mi);
     GetMonitorInfoW(hMon, &mi);
-
-    int learnedTargetX = (mi.rcMonitor.left + mi.rcMonitor.right) / 2;
-
-    // If the mouse is outside the main desktop area (e.g. hovering over the taskbar)
-    if (!PtInRect(&mi.rcWork, pt)) {
-        learnedTargetX = pt.x; // Steal the mouse X coordinate!
-        std::lock_guard<std::mutex> lock(g_CacheMutex);
-        g_IconPositions[hWnd] = learnedTargetX; // Save it to the vault
-    } else {
-        // Mouse is on the desktop (clicking the [-] title bar button)
-        std::lock_guard<std::mutex> lock(g_CacheMutex);
-        if (g_IconPositions.count(hWnd)) {
-            learnedTargetX = g_IconPositions[hWnd];
-        }
-    }
 
     GhostAnimData* data = new GhostAnimData();
     data->hRealWnd = hWnd;
@@ -1289,7 +1241,11 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
     data->width = w;
     data->height = h;
     data->isRising = rising;
-    data->targetDockX = learnedTargetX; // Assign the learned coordinate
+    data->wasCloaked = rising;
+    // Default dock X is the monitor centre; the animation thread will
+    // overwrite this with the actual taskbar-icon centre via
+    // GetTaskbarIconCenter.
+    data->targetDockX = (mi.rcMonitor.left + mi.rcMonitor.right) / 2;
     data->mode = g_mode.load(std::memory_order_relaxed);
     data->durationMs = g_durations[data->mode].load(std::memory_order_relaxed);
     data->originalExStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
@@ -1337,12 +1293,6 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
     DeleteDC(hMemDC);
     ReleaseDC(NULL, hScreenDC);
 
-    // Anti-flash: block the caller (the minimize/restore hook) until the ghost's
-    // first frame is on screen, so the real window never changes before the
-    // animation exists. Use a LOCAL copy of the handle for the wait - once the
-    // thread is spawned it owns `data` and may free it at any time. The cap (40ms)
-    // sits under the 50ms minimum duration, so the thread's CloseHandle at
-    // animation end can never race this bounded wait.
     HANDLE hReady = CreateEventW(NULL, TRUE, FALSE, NULL);
     data->hReady = hReady;
     HANDLE hThread = CreateThread(NULL, 0, GhostAnimationThread, data, 0, NULL);
@@ -1356,19 +1306,40 @@ void StartGenieAnim(HWND hWnd, BOOL rising) {
     if (hReady) WaitForSingleObject(hReady, 40);
 }
 
-// -------------------------------------------------------------------------
-// Hooks
-// -------------------------------------------------------------------------
+// Per-window re-entrancy guard so that when DefWindowProcW_Hook handles
+// SC_MINIMIZE/SC_RESTORE (which internally calls ShowWindow), the nested
+// call through ShowWindow_Hook does not start a second animation.
+static std::unordered_map<HWND, DWORD> g_inSysCmd;
+static std::mutex                      g_sysCmdMtx;
+
+static bool IsInSysCmdOnThisThread(HWND hWnd) {
+    std::lock_guard<std::mutex> lock(g_sysCmdMtx);
+    auto it = g_inSysCmd.find(hWnd);
+    return it != g_inSysCmd.end() && it->second == GetCurrentThreadId();
+}
+
+static void SetSysCmdGuard(HWND hWnd, bool set) {
+    std::lock_guard<std::mutex> lock(g_sysCmdMtx);
+    if (set)
+        g_inSysCmd[hWnd] = GetCurrentThreadId();
+    else
+        g_inSysCmd.erase(hWnd);
+}
+
 BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
     if (g_enabled.load(std::memory_order_relaxed)) {
         if (nCmdShow == SW_MINIMIZE || nCmdShow == SW_SHOWMINIMIZED || nCmdShow == SW_SHOWMINNOACTIVE) {
-            SetDwmTransitions(hWnd, FALSE);
-            StartGenieAnim(hWnd, FALSE);
+            if (!IsInSysCmdOnThisThread(hWnd)) {
+                SetDwmTransitions(hWnd, FALSE);
+                StartGenieAnim(hWnd, FALSE);
+            }
             return ShowWindow_Original(hWnd, nCmdShow);
         }
         else if (nCmdShow == SW_RESTORE || nCmdShow == SW_SHOWNORMAL) {
-            if (IsIconic(hWnd)) {
+            if (IsIconic(hWnd) && !IsInSysCmdOnThisThread(hWnd)) {
                 SetDwmTransitions(hWnd, FALSE);
+                BOOL cloaked = TRUE;
+                DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &cloaked, sizeof(cloaked));
                 LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
                 SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
                 SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
@@ -1383,30 +1354,40 @@ BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
 
 LRESULT WINAPI DefWindowProcW_Hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) {
     if (Msg == WM_DESTROY) {
-        std::lock_guard<std::mutex> lock(g_CacheMutex);
-        if (g_SnapshotCache.count(hWnd)) {
-            DeleteObject(g_SnapshotCache[hWnd]);
-            g_SnapshotCache.erase(hWnd);
+        {
+            std::lock_guard<std::mutex> lock(g_sysCmdMtx);
+            g_inSysCmd.erase(hWnd);
         }
-        if (g_IconPositions.count(hWnd)) {
-            g_IconPositions.erase(hWnd);
+        {
+            std::lock_guard<std::mutex> lock(g_CacheMutex);
+            if (g_SnapshotCache.count(hWnd)) {
+                DeleteObject(g_SnapshotCache[hWnd]);
+                g_SnapshotCache.erase(hWnd);
+            }
         }
     }
 
     if (g_enabled.load(std::memory_order_relaxed) && Msg == WM_SYSCOMMAND) {
         UINT cmd = wParam & 0xFFF0;
         if (cmd == SC_MINIMIZE) {
+            SetSysCmdGuard(hWnd, true);
             SetDwmTransitions(hWnd, FALSE);
             StartGenieAnim(hWnd, FALSE);
-            return DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
+            LRESULT res = DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
+            SetSysCmdGuard(hWnd, false);
+            return res;
         }
         else if (cmd == SC_RESTORE && IsIconic(hWnd)) {
+            SetSysCmdGuard(hWnd, true);
             SetDwmTransitions(hWnd, FALSE);
+            BOOL cloaked = TRUE;
+            DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &cloaked, sizeof(cloaked));
             LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
             SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
             SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
             LRESULT res = DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
             StartGenieAnim(hWnd, TRUE);
+            SetSysCmdGuard(hWnd, false);
             return res;
         }
     }
@@ -1417,6 +1398,11 @@ BOOL Wh_ModInit() {
     LoadSettings();
     Wh_SetFunctionHook((void*)DefWindowProcW, (void*)DefWindowProcW_Hook, (void**)&DefWindowProcW_Original);
     Wh_SetFunctionHook((void*)ShowWindow, (void*)ShowWindow_Hook, (void**)&ShowWindow_Original);
+    // Eagerly initialize GPU resources so the first animation doesn't have to
+    // wait for D3D device creation and shader compilation.
+    if (EnsureGpuDevice()) {
+        EnsureGenieGpuResources();
+    }
     return TRUE;
 }
 
@@ -1431,10 +1417,7 @@ void Wh_ModUninit() {
             DeleteObject(pair.second);
         }
         g_SnapshotCache.clear();
-        g_IconPositions.clear();
     }
-    // Any in-flight animation threads own their own DirectComposition devices and
-    // will finish shortly; only the shared D3D device + factory live here.
     ReleaseGenieGpuResources();
     ReleaseGpuDevice();
 }

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -1097,15 +1097,15 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
 }
 
 // Build a cache of all taskbar icon positions on the same monitor as hWnd.
-// Matching is first by exact HWND, then by owner-chain (for child/utility
-// windows that share the parent's taskbar button). Returns FALSE when no
-// taskbar or toolbar can be found.
+// Matching is by HWND, then owner chain, then root ancestor, then by process
+// ID (for grouped buttons whose dwData references the app frame, not the
+// specific child window). Returns FALSE only when no toolbar can be found,
+// meaning this window genuinely has no taskbar button.
 struct TaskbarIconEntry {
     HWND hWnd;
     int  x;
     int  y;
     int  width;
-    int  height;
 };
 
 static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth) {
@@ -1113,6 +1113,7 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
     TaskbarIconEntry cache[64];
     int cacheCount = 0;
 
+    // Walk all taskbars visible on the window's monitor.
     for (int pass = 0; pass < 2; pass++) {
         HWND hTaskbar = FindWindowW(pass == 0 ? L"Shell_TrayWnd" : L"Shell_SecondaryTrayWnd", NULL);
         if (!hTaskbar) continue;
@@ -1122,12 +1123,26 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
         HMONITOR hTbMon = MonitorFromRect(&tbRect, MONITOR_DEFAULTTONULL);
         if (hTbMon != hMon) continue;
 
+        // Try every known toolbar location (Windows 10 primary, secondary,
+        // WorkerW fallback for top/side taskbars, and direct child).
         HWND hToolbar = NULL;
         HWND hRebar = FindWindowEx(hTaskbar, NULL, L"ReBarWindow32", NULL);
         if (hRebar) {
             HWND hMSTask = FindWindowEx(hRebar, NULL, L"MSTaskSwWClass", NULL);
             if (hMSTask)
                 hToolbar = FindWindowEx(hMSTask, NULL, L"ToolbarWindow32", NULL);
+        }
+        if (!hToolbar) {
+            // Some configurations nest under WorkerW.
+            HWND hWorkerW = FindWindowEx(hTaskbar, NULL, L"WorkerW", NULL);
+            if (hWorkerW) {
+                HWND hReBarW = FindWindowEx(hWorkerW, NULL, L"ReBarWindow32", NULL);
+                if (hReBarW) {
+                    HWND hMSTask = FindWindowEx(hReBarW, NULL, L"MSTaskSwWClass", NULL);
+                    if (hMSTask)
+                        hToolbar = FindWindowEx(hMSTask, NULL, L"ToolbarWindow32", NULL);
+                }
+            }
         }
         if (!hToolbar)
             hToolbar = FindWindowEx(hTaskbar, NULL, L"ToolbarWindow32", NULL);
@@ -1142,33 +1157,84 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth)
                     if (SendMessage(hToolbar, TB_GETRECT, btn.idCommand, (LPARAM)&r)) {
                         MapWindowPoints(hToolbar, NULL, (POINT*)&r, 2);
                         TaskbarIconEntry* e = &cache[cacheCount++];
-                        e->hWnd   = (HWND)btn.dwData;
-                        e->x      = (r.left + r.right) / 2;
-                        e->y      = (r.top + r.bottom) / 2;
-                        e->width  = r.right - r.left;
-                        e->height = r.bottom - r.top;
+                        e->hWnd  = (HWND)btn.dwData;
+                        e->x     = (r.left + r.right) / 2;
+                        e->y     = (r.top + r.bottom) / 2;
+                        e->width = r.right - r.left;
                     }
                 }
             }
         }
-        break; // Only process the first matching taskbar.
+        break;
     }
 
     if (cacheCount == 0) return FALSE;
 
-    // Try exact HWND match, then owner chain.
-    for (HWND hCur = hWnd; hCur; hCur = GetWindow(hCur, GW_OWNER)) {
+    // --- Matching strategy (most specific to least specific) ---
+
+    // 1. Exact HWND.
+    for (int i = 0; i < cacheCount; i++) {
+        if (cache[i].hWnd == hWnd) {
+            *outX = cache[i].x; *outY = cache[i].y;
+            if (outWidth) *outWidth = cache[i].width;
+            return TRUE;
+        }
+    }
+
+    // 2. Owner chain (child/utility windows sharing the parent's button).
+    for (HWND hCur = GetWindow(hWnd, GW_OWNER); hCur; hCur = GetWindow(hCur, GW_OWNER)) {
         for (int i = 0; i < cacheCount; i++) {
             if (cache[i].hWnd == hCur) {
-                *outX = cache[i].x;
-                *outY = cache[i].y;
+                *outX = cache[i].x; *outY = cache[i].y;
                 if (outWidth) *outWidth = cache[i].width;
                 return TRUE;
             }
         }
     }
 
+    // 3. Root ancestor (covers dialogs and owned popups whose top-level frame
+    //    owns the taskbar button).
+    HWND hRoot = GetAncestor(hWnd, GA_ROOT);
+    if (hRoot != hWnd) {
+        for (int i = 0; i < cacheCount; i++) {
+            if (cache[i].hWnd == hRoot) {
+                *outX = cache[i].x; *outY = cache[i].y;
+                if (outWidth) *outWidth = cache[i].width;
+                return TRUE;
+            }
+        }
+    }
+
+    // 4. Process-ID match (grouped taskbar buttons may store the app's main
+    //    frame or a hidden window; take the nearest icon on the same monitor).
+    DWORD targetPid;
+    GetWindowThreadProcessId(hWnd, &targetPid);
+    if (targetPid) {
+        int bestIdx = -1;
+        RECT wndRect;
+        GetWindowRect(hWnd, &wndRect);
+        int wndCX = (wndRect.left + wndRect.right) / 2;
+        int bestDist = INT_MAX;
+        for (int i = 0; i < cacheCount; i++) {
+            DWORD btnPid;
+            GetWindowThreadProcessId(cache[i].hWnd, &btnPid);
+            if (btnPid == targetPid) {
+                int dist = abs(cache[i].x - wndCX);
+                if (dist < bestDist) {
+                    bestDist = dist;
+                    bestIdx  = i;
+                }
+            }
+        }
+        if (bestIdx >= 0) {
+            *outX = cache[bestIdx].x; *outY = cache[bestIdx].y;
+            if (outWidth) *outWidth = cache[bestIdx].width;
+            return TRUE;
+        }
+    }
+
     return FALSE;
+}
 }
 
 DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
@@ -1190,14 +1256,12 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     GetMonitorInfoW(hMon, &mi);
     float taskbarY = (float)mi.rcWork.bottom;
 
-    // Lock the animation target to the taskbar icon centre, falling back to
-    // cursor X only when the icon genuinely cannot be resolved.
+    // Lock the animation target to the taskbar icon centre (already has a
+    // monitor-centre default from StartGenieAnim if no icon is found).
     int iconX, iconY;
     data->iconButtonWidth = 0;
     if (GetTaskbarIconCenter(data->hRealWnd, &iconX, &iconY, &data->iconButtonWidth)) {
         data->targetDockX = iconX;
-    } else {
-        data->targetDockX = cursorPt.x;
     }
 
     bool useGpu = EnsureGpuDevice();

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -493,7 +493,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
         float moveX = 1.0f - (invT * invT * invT * invT * invT * invT);
         float moveY = (0.70f * (t * t)) + (0.10f * t);
         scaleX = 1.0f - (0.95f * (1.8f * t));
-        { float ms = 0.05f > minScaleX ? 0.05f : minScaleX; if (scaleX < ms) scaleX = ms; }
+        { float ms = 0.02f > minScaleX ? 0.02f : minScaleX; if (scaleX < ms) scaleX = ms; }
         scaleY = 1.0f - (0.70f * (t * t));
 
         float startCenterX = cx;
@@ -511,7 +511,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
     case MODE_VACUUM: {
         float e = easeInCubic(t);
         float s = 1.0f - 0.97f * e;
-        { float ms = 0.03f > minScaleX ? 0.03f : minScaleX; if (s < ms) s = ms; }
+        { float ms = 0.02f > minScaleX ? 0.02f : minScaleX; if (s < ms) s = ms; }
         scaleX = scaleY = s;
         fx = cx + (dockX - cx) * e;
         fy = cy + (taskbarY - cy) * e;
@@ -557,7 +557,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
     case MODE_WARP: {
         float ramp = t / 0.6f; if (ramp > 1.0f) ramp = 1.0f;
         scaleX = 1.0f - 0.96f * ramp;
-        { float ms = 0.04f > minScaleX ? 0.04f : minScaleX; if (scaleX < ms) scaleX = ms; }
+        { float ms = 0.02f > minScaleX ? 0.02f : minScaleX; if (scaleX < ms) scaleX = ms; }
         scaleY = 1.0f;
         anchorTopLeft = true;
         fx = cx;
@@ -597,7 +597,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
     case MODE_SWIRL: {
         float e = easeInCubic(t);
         float s = 1.0f - 0.95f * e;
-        { float ms = 0.05f > minScaleX ? 0.05f : minScaleX; if (s < ms) s = ms; }
+        { float ms = 0.02f > minScaleX ? 0.02f : minScaleX; if (s < ms) s = ms; }
         scaleX = scaleY = s;
         float baseCX = cx + (dockX - cx) * e;
         float baseCY = cy + (taskbarY - cy) * e;
@@ -1009,7 +1009,7 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
     }
 
     const float LEAD     = 1.4f;
-    const float neckW    = (data->iconButtonWidth > 0) ? ((float)data->iconButtonWidth > 10.0f ? (float)data->iconButtonWidth : 10.0f) : (w * 0.05f > 10.0f ? w * 0.05f : 10.0f);
+    const float neckW    = (data->iconButtonWidth > 0) ? ((float)data->iconButtonWidth > 4.0f ? (float)data->iconButtonWidth : 4.0f) : (w * 0.02f > 4.0f ? w * 0.02f : 4.0f);
     const float sourceCX = data->targetRect.left + w * 0.5f;
     const float dockX    = (float)data->targetDockX;
     const float dockY    = taskbarY;
@@ -1607,6 +1607,8 @@ BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
             if (!IsInSysCmdOnThisThread(hWnd) && IsWindowVisible(hWnd) && !IsIconic(hWnd)) {
                 SetDwmTransitions(hWnd, FALSE);
                 StartGenieAnim(hWnd, FALSE);
+                BOOL cloaked = TRUE;
+                DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &cloaked, sizeof(cloaked));
             }
             return ShowWindow_Original(hWnd, nCmdShow);
         }
@@ -1648,6 +1650,10 @@ LRESULT WINAPI DefWindowProcW_Hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
             SetSysCmdGuard(hWnd, true);
             SetDwmTransitions(hWnd, FALSE);
             StartGenieAnim(hWnd, FALSE);
+            {
+                BOOL cloaked = TRUE;
+                DwmSetWindowAttribute(hWnd, DWMWA_CLOAK, &cloaked, sizeof(cloaked));
+            }
             LRESULT res = DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
             SetSysCmdGuard(hWnd, false);
             return res;

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -201,6 +201,7 @@ struct GhostAnimData {
     int width;
     int height;
     int targetDockX;
+    int iconButtonWidth;
     BOOL isRising;
     int mode;
     int durationMs;
@@ -458,6 +459,12 @@ static void SolveFrame(const GhostAnimData* d, float t,
     const float cy = T + h * 0.5f;
     const int   dockX = d->targetDockX;
 
+    float minScaleX = 0.0f;
+    if (d->iconButtonWidth > 0 && w > 0) {
+        minScaleX = (float)d->iconButtonWidth / (float)w;
+        if (minScaleX >= 1.0f) minScaleX = 0.99f;
+    }
+
     float scaleX = 1.0f, scaleY = 1.0f;
     float fx = cx, fy = cy;
     float alpha = 1.0f;
@@ -470,7 +477,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
         float moveX = 1.0f - (invT * invT * invT * invT * invT * invT);
         float moveY = (0.70f * (t * t)) + (0.10f * t);
         scaleX = 1.0f - (0.95f * (1.8f * t));
-        if (scaleX < 0.05f) scaleX = 0.05f;
+        if (scaleX < max(0.05f, minScaleX)) scaleX = max(0.05f, minScaleX);
         scaleY = 1.0f - (0.70f * (t * t));
 
         float startCenterX = cx;
@@ -488,7 +495,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
     case MODE_VACUUM: {
         float e = easeInCubic(t);
         float s = 1.0f - 0.97f * e;
-        if (s < 0.03f) s = 0.03f;
+        if (s < max(0.03f, minScaleX)) s = max(0.03f, minScaleX);
         scaleX = scaleY = s;
         fx = cx + (dockX - cx) * e;
         fy = cy + (taskbarY - cy) * e;
@@ -534,6 +541,7 @@ static void SolveFrame(const GhostAnimData* d, float t,
     case MODE_WARP: {
         float ramp = t / 0.6f; if (ramp > 1.0f) ramp = 1.0f;
         scaleX = 1.0f - 0.96f * ramp;
+        if (scaleX < max(0.04f, minScaleX)) scaleX = max(0.04f, minScaleX);
         scaleY = 1.0f;
         anchorTopLeft = true;
         fx = cx;
@@ -572,7 +580,9 @@ static void SolveFrame(const GhostAnimData* d, float t,
 
     case MODE_SWIRL: {
         float e = easeInCubic(t);
-        scaleX = scaleY = 1.0f - 0.95f * e;
+        float s = 1.0f - 0.95f * e;
+        if (s < max(0.05f, minScaleX)) s = max(0.05f, minScaleX);
+        scaleX = scaleY = s;
         float baseCX = cx + (dockX - cx) * e;
         float baseCY = cy + (taskbarY - cy) * e;
         float amp = (w * 0.40f) * (1.0f - t);
@@ -983,7 +993,7 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
     }
 
     const float LEAD     = 1.4f;
-    const float neckW    = (w * 0.05f > 10.0f) ? w * 0.05f : 10.0f;
+    const float neckW    = (data->iconButtonWidth > 0) ? max((float)data->iconButtonWidth, 10.0f) : max(w * 0.05f, 10.0f);
     const float sourceCX = data->targetRect.left + w * 0.5f;
     const float dockX    = (float)data->targetDockX;
     const float dockY    = taskbarY;
@@ -1086,13 +1096,13 @@ static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
     return true;
 }
 
-// Find the center of the taskbar icon for hWnd in screen coordinates.
-// Returns FALSE if the position could not be determined (caller should fall
-// back to cursor-based heuristics).
-static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY) {
+// Find the centre and full clickable width of the taskbar icon for hWnd.
+// outWidth receives the button width (including padding) so the animation can
+// scale down to exactly the icon block's size.
+// Returns FALSE when a position could not be determined.
+static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY, int* outWidth) {
     HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
 
-    // Try primary (Shell_TrayWnd) and secondary (Shell_SecondaryTrayWnd) taskbars.
     for (int pass = 0; pass < 2; pass++) {
         HWND hTaskbar = FindWindowW(pass == 0 ? L"Shell_TrayWnd" : L"Shell_SecondaryTrayWnd", NULL);
         if (!hTaskbar) continue;
@@ -1102,11 +1112,10 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY) {
         HMONITOR hTbMon = MonitorFromRect(&tbRect, MONITOR_DEFAULTTONULL);
         if (hTbMon != hMon) continue;
 
-        // Fallback: the centre of the taskbar itself.
         *outX = (tbRect.left + tbRect.right) / 2;
         *outY = (tbRect.top + tbRect.bottom) / 2;
+        if (outWidth) *outWidth = tbRect.right - tbRect.left;
 
-        // Windows 10 path: ToolbarWindow32 inside ReBarWindow32 → MSTaskSwWClass.
         HWND hToolbar = NULL;
         HWND hRebar = FindWindowEx(hTaskbar, NULL, L"ReBarWindow32", NULL);
         if (hRebar) {
@@ -1123,13 +1132,13 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY) {
                 TBBUTTON btn;
                 ZeroMemory(&btn, sizeof(btn));
                 if (SendMessage(hToolbar, TB_GETBUTTON, i, (LPARAM)&btn)) {
-                    // The taskbar toolbar stores the HWND in dwData.
                     if ((HWND)btn.dwData == hWnd) {
                         RECT r;
                         if (SendMessage(hToolbar, TB_GETRECT, btn.idCommand, (LPARAM)&r)) {
                             MapWindowPoints(hToolbar, NULL, (POINT*)&r, 2);
                             *outX = (r.left + r.right) / 2;
                             *outY = (r.top + r.bottom) / 2;
+                            if (outWidth) *outWidth = r.right - r.left;
                             return TRUE;
                         }
                     }
@@ -1137,7 +1146,7 @@ static BOOL GetTaskbarIconCenter(HWND hWnd, int* outX, int* outY) {
             }
         }
 
-        return TRUE; // Used taskbar-centre fallback.
+        return TRUE;
     }
     return FALSE;
 }
@@ -1161,12 +1170,11 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     GetMonitorInfoW(hMon, &mi);
     float taskbarY = (float)mi.rcWork.bottom;
 
-    // Lock the horizontal target to the centre of the taskbar icon rather than
-    // wherever the cursor happened to be.  The vertical target stays at the top
-    // edge of the taskbar (rcWork.bottom) so the animation ribbon spreads
-    // upward from the icon row, not from inside the taskbar.
+    // Lock the animation target to the actual taskbar-icon centre rather than
+    // wherever the cursor happened to be.
     int iconX, iconY;
-    if (GetTaskbarIconCenter(data->hRealWnd, &iconX, &iconY)) {
+    data->iconButtonWidth = 0;
+    if (GetTaskbarIconCenter(data->hRealWnd, &iconX, &iconY, &data->iconButtonWidth)) {
         data->targetDockX = iconX;
     }
 

--- a/mods/genie-and-friends-minimize-animation.wh.cpp
+++ b/mods/genie-and-friends-minimize-animation.wh.cpp
@@ -219,6 +219,8 @@ struct GhostAnimData {
     int targetDockX;
     int iconButtonWidth;
     BOOL isRising;
+    BOOL animSetLayered;
+    BOOL dwmTransitionsDisabled;
     int mode;
     int durationMs;
     LONG_PTR cleanupExStyle;
@@ -647,9 +649,12 @@ static void FinalizeRealWindow(GhostAnimData* data) {
     if (!IsWindow(data->hRealWnd)) return;
     if (data->isRising) {
         SetLayeredWindowAttributes(data->hRealWnd, 0, 255, LWA_ALPHA);
-        SetWindowLongPtrW(data->hRealWnd, GWL_EXSTYLE, data->cleanupExStyle);
+        if (data->animSetLayered) {
+            SetWindowLongPtrW(data->hRealWnd, GWL_EXSTYLE,
+                GetWindowLongPtrW(data->hRealWnd, GWL_EXSTYLE) & ~WS_EX_LAYERED);
+        }
     }
-    SetDwmTransitions(data->hRealWnd, TRUE);
+    SetDwmTransitions(data->hRealWnd, data->dwmTransitionsDisabled ? FALSE : TRUE);
 }
 
 static void RunCpuAnim(GhostAnimData* data, HWND hGhost,
@@ -1477,16 +1482,17 @@ DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
     return 0;
 }
 
-void StartGenieAnim(HWND hWnd, BOOL rising, LONG_PTR cleanupExStyle) {
+void StartGenieAnim(HWND hWnd, BOOL rising, LONG_PTR cleanupExStyle, BOOL animSetLayered, BOOL dwmTransitionsDisabled) {
     RECT rect;
     GetWindowRect(hWnd, &rect);
     int w = rect.right - rect.left;
     int h = rect.bottom - rect.top;
 
     if (w <= 0 || h <= 0) {
-        if (rising) {
+        if (rising && animSetLayered) {
             SetLayeredWindowAttributes(hWnd, 0, 255, LWA_ALPHA);
-            SetWindowLongPtrW(hWnd, GWL_EXSTYLE, cleanupExStyle);
+            SetWindowLongPtrW(hWnd, GWL_EXSTYLE,
+                GetWindowLongPtrW(hWnd, GWL_EXSTYLE) & ~WS_EX_LAYERED);
         }
         return;
     }
@@ -1518,6 +1524,8 @@ void StartGenieAnim(HWND hWnd, BOOL rising, LONG_PTR cleanupExStyle) {
     data->mode = g_mode.load(std::memory_order_relaxed);
     data->durationMs = g_durations[data->mode].load(std::memory_order_relaxed);
     data->cleanupExStyle = cleanupExStyle;
+    data->animSetLayered = animSetLayered;
+    data->dwmTransitionsDisabled = dwmTransitionsDisabled;
 
     HDC hScreenDC = GetDC(NULL);
     HDC hMemDC = CreateCompatibleDC(hScreenDC);
@@ -1592,9 +1600,10 @@ void StartGenieAnim(HWND hWnd, BOOL rising, LONG_PTR cleanupExStyle) {
     ResetEvent(g_allAnimsDone);
     HANDLE hThread = CreateThread(NULL, 0, GhostAnimationThread, data, 0, NULL);
     if (!hThread) {
-        if (rising) {
+        if (rising && data->animSetLayered) {
             SetLayeredWindowAttributes(hWnd, 0, 255, LWA_ALPHA);
-            SetWindowLongPtrW(hWnd, GWL_EXSTYLE, cleanupExStyle);
+            SetWindowLongPtrW(hWnd, GWL_EXSTYLE,
+                GetWindowLongPtrW(hWnd, GWL_EXSTYLE) & ~WS_EX_LAYERED);
         }
         if (hReady) CloseHandle(hReady);
         DeleteObject(data->hBitmap);
@@ -1610,19 +1619,23 @@ void StartGenieAnim(HWND hWnd, BOOL rising, LONG_PTR cleanupExStyle) {
 BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
     if (g_enabled.load(std::memory_order_relaxed)) {
         if (nCmdShow == SW_MINIMIZE || nCmdShow == SW_SHOWMINIMIZED || nCmdShow == SW_SHOWMINNOACTIVE) {
+            BOOL origTransitionsDisabled = FALSE;
+            DwmGetWindowAttribute(hWnd, DWMWA_TRANSITIONS_FORCEDISABLED, &origTransitionsDisabled, sizeof(origTransitionsDisabled));
             SetDwmTransitions(hWnd, FALSE);
             LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
-            StartGenieAnim(hWnd, FALSE, exStyle);
+            StartGenieAnim(hWnd, FALSE, exStyle, FALSE, origTransitionsDisabled);
             return ShowWindow_Original(hWnd, nCmdShow);
         }
         else if (nCmdShow == SW_RESTORE || nCmdShow == SW_SHOWNORMAL) {
             if (IsIconic(hWnd)) {
+                BOOL origTransitionsDisabled = FALSE;
+                DwmGetWindowAttribute(hWnd, DWMWA_TRANSITIONS_FORCEDISABLED, &origTransitionsDisabled, sizeof(origTransitionsDisabled));
                 SetDwmTransitions(hWnd, FALSE);
                 LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
                 SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
                 SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
                 BOOL res = ShowWindow_Original(hWnd, nCmdShow);
-                StartGenieAnim(hWnd, TRUE, exStyle);
+                StartGenieAnim(hWnd, TRUE, exStyle, TRUE, origTransitionsDisabled);
                 return res;
             }
         }
@@ -1645,18 +1658,22 @@ LRESULT WINAPI DefWindowProcW_Hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lP
     if (g_enabled.load(std::memory_order_relaxed) && Msg == WM_SYSCOMMAND) {
         UINT cmd = wParam & 0xFFF0;
         if (cmd == SC_MINIMIZE) {
+            BOOL origTransitionsDisabled = FALSE;
+            DwmGetWindowAttribute(hWnd, DWMWA_TRANSITIONS_FORCEDISABLED, &origTransitionsDisabled, sizeof(origTransitionsDisabled));
             SetDwmTransitions(hWnd, FALSE);
             LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
-            StartGenieAnim(hWnd, FALSE, exStyle);
+            StartGenieAnim(hWnd, FALSE, exStyle, FALSE, origTransitionsDisabled);
             return DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
         }
         else if (cmd == SC_RESTORE && IsIconic(hWnd)) {
+            BOOL origTransitionsDisabled = FALSE;
+            DwmGetWindowAttribute(hWnd, DWMWA_TRANSITIONS_FORCEDISABLED, &origTransitionsDisabled, sizeof(origTransitionsDisabled));
             SetDwmTransitions(hWnd, FALSE);
             LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
             SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
             SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
             LRESULT res = DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
-            StartGenieAnim(hWnd, TRUE, exStyle);
+            StartGenieAnim(hWnd, TRUE, exStyle, TRUE, origTransitionsDisabled);
             return res;
         }
     }

--- a/mods/genie-minimize-animation-fork.wh.cpp
+++ b/mods/genie-minimize-animation-fork.wh.cpp
@@ -1,0 +1,1417 @@
+// ==WindhawkMod==
+// @id              genie-minimize-animation-fork
+// @name            Genie + Friends minimize animation pack
+// @description     GPU-accelerated macOS/Compiz-style minimize & restore effects — Genie (true mesh bend), Vacuum, Glide, Pop, Slide, Free Fall, Warp, Squash, Roll-Up & Swirl.
+// @version         2.2.1
+// @author          lolstijl & akilluminati47
+// @github          https://github.com/akilluminati47
+// @include         *
+// @compilerOptions -ldwmapi -lgdi32 -ld3d11 -ldxgi -ldcomp -ld3dcompiler
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Genie + Friends minimize animation pack
+
+A fork of the Genie Animation Mod that turns Windows 11's boring minimize/restore
+into a whole menu of Compiz/macOS-flavored effects. Pick one from the **Animation
+style** dropdown in the mod's Settings tab — that dropdown is your toggle between the
+classic Genie and all the new ones. Each style has its own **Duration** slider so you
+can tune the feel of every effect independently, and there's a master **Enable
+animations** switch to fall back to stock Windows without disabling the mod.
+
+## The effects
+
+- **Genie — Magic Lamp**: the classic. The window stretches and pours down into the
+  taskbar like a genie into a lamp.
+- **Vacuum**: the whole window shrinks and accelerates as it gets sucked into the
+  taskbar icon.
+- **Glide**: subtle GNOME-style shrink + fade in place. Understated and clean.
+- **Pop**: the window swells slightly and vanishes. Snappy and modern.
+- **Slide**: KDE-style straight drop off the bottom edge.
+- **Free Fall**: gravity takes over — the window accelerates, stretches, sways, and
+  tumbles off the bottom of the screen.
+- **Warp**: Star Trek transporter. The window squeezes into a thin vertical beam of
+  light, then the beam shoots up and dematerializes.
+- **Squash**: the window is flattened like a pancake onto the taskbar.
+- **Roll-Up**: the window rolls up into its own title bar like a window blind.
+- **Swirl**: a whirlpool. The window spins side-to-side while shrinking down into
+  the taskbar like water down a drain.
+
+Restore plays every effect in reverse, so windows *un-genie*, *un-roll*, drop back
+in, etc.
+
+## Notes
+- **v2.2.1 — no more first-frame flash.** The minimize/restore hook now waits (up
+  to 40ms) for the ghost's first frame to actually be on screen before the real
+  window changes, so the window can't blink out a few ms before the animation
+  appears when GPU setup is momentarily slow.
+- **v2.1 — GPU rendering.** The snapshot is now handed to the GPU compositor
+  (DirectComposition) once, and each frame only pushes a transform + opacity. This
+  is dramatically smoother on high-refresh displays (120/144/165/180+ Hz) and uses a
+  fraction of the CPU the old per-frame `StretchBlt` did. If DirectComposition isn't
+  available in a given process, it silently falls back to the original GDI renderer,
+  so nothing breaks.
+- **v2.2 — true Genie bend.** Genie is no longer a shrink + slide fake: it now renders
+  the snapshot as a tessellated mesh warped every frame by a small GPU shader, so the
+  window body curves into a thin neck that pours into the taskbar (real Magic Lamp).
+  The other nine effects keep the cheap single-transform GPU path. If the shader stack
+  can't init, Genie falls back to the affine/GDI renderer.
+- Windows' own animation API is ancient, so a couple of effects (Warp especially) are
+  clever fakes rather than true 3D — but they read great in motion.
+## Credits
+Built on the original **Genie Animation Mod**. **lolstijl** extended it into this
+multi-effect pack (Genie + nine more Compiz/macOS-style effects). **akilluminati47**
+then rewrote the rendering onto the GPU (DirectComposition), added the true
+mesh-warped Genie bend, and the anti-flash timing fix. Development was assisted by
+Claude and Gemini.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- enabled: true
+  $name: Enable animations
+  $description: >-
+    Master switch. Turn this off to fall back to Windows' default minimize/restore
+    behavior without having to disable the whole mod.
+
+- style: genie
+  $name: Animation style
+  $description: >-
+    Which effect plays when you minimize or restore a window. This is your toggle
+    between the classic Genie and all the new Linux-flavored effects. Restore always
+    plays the same effect in reverse.
+  $options:
+  - genie: Genie — Magic Lamp (pours into the taskbar)
+  - vacuum: Vacuum — sucked into the taskbar icon
+  - glide: Glide — GNOME-style shrink & fade
+  - pop: Pop — swell and vanish
+  - slide: Slide — straight drop off the bottom (KDE)
+  - fall: Free Fall — gravity tumble off screen
+  - warp: Warp — Star Trek transporter beam
+  - squash: Squash — flattened onto the taskbar
+  - rollup: Roll-Up — rolls up like a window blind
+  - swirl: Swirl — whirlpool down the drain
+
+- duration_genie: 450
+  $name: Duration — Genie (ms)
+  $description: Clamped to 50-3000. Lower is snappier, higher is more deliberate.
+
+- duration_vacuum: 380
+  $name: Duration — Vacuum (ms)
+  $description: Clamped to 50-3000.
+
+- duration_glide: 300
+  $name: Duration — Glide (ms)
+  $description: Clamped to 50-3000.
+
+- duration_pop: 260
+  $name: Duration — Pop (ms)
+  $description: Clamped to 50-3000.
+
+- duration_slide: 340
+  $name: Duration — Slide (ms)
+  $description: Clamped to 50-3000.
+
+- duration_fall: 620
+  $name: Duration — Free Fall (ms)
+  $description: Clamped to 50-3000.
+
+- duration_warp: 520
+  $name: Duration — Warp (ms)
+  $description: Clamped to 50-3000.
+
+- duration_squash: 400
+  $name: Duration — Squash (ms)
+  $description: Clamped to 50-3000.
+
+- duration_rollup: 380
+  $name: Duration — Roll-Up (ms)
+  $description: Clamped to 50-3000.
+
+- duration_swirl: 700
+  $name: Duration — Swirl (ms)
+  $description: Clamped to 50-3000.
+*/
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+#include <dwmapi.h>
+#include <d2d1.h>     // D2D_MATRIX_3X2_F used by IDCompositionMatrixTransform
+#include <d3d11.h>
+#include <d3dcompiler.h>  // runtime HLSL compile for the Genie mesh shaders
+#include <dxgi1_2.h>
+#include <dcomp.h>
+#include <math.h>
+#include <wchar.h>
+#include <stdlib.h>
+#include <string.h>
+#include <atomic>
+#include <unordered_map>
+#include <mutex>
+
+typedef LRESULT (WINAPI *DefWindowProcW_t)(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+DefWindowProcW_t DefWindowProcW_Original;
+
+typedef BOOL (WINAPI *ShowWindow_t)(HWND hWnd, int nCmdShow);
+ShowWindow_t ShowWindow_Original;
+
+// -------------------------------------------------------------------------
+// Animation modes
+// -------------------------------------------------------------------------
+enum AnimMode {
+    MODE_GENIE = 0,
+    MODE_VACUUM,
+    MODE_GLIDE,
+    MODE_POP,
+    MODE_SLIDE,
+    MODE_FALL,
+    MODE_WARP,
+    MODE_SQUASH,
+    MODE_ROLLUP,
+    MODE_SWIRL,
+    MODE_COUNT
+};
+
+// Keys must match the $options keys in the settings block above, in enum order.
+static const wchar_t* kModeKeys[MODE_COUNT] = {
+    L"genie", L"vacuum", L"glide", L"pop", L"slide",
+    L"fall",  L"warp",   L"squash", L"rollup", L"swirl"
+};
+static const wchar_t* kDurKeys[MODE_COUNT] = {
+    L"duration_genie", L"duration_vacuum", L"duration_glide", L"duration_pop",
+    L"duration_slide", L"duration_fall",   L"duration_warp",  L"duration_squash",
+    L"duration_rollup", L"duration_swirl"
+};
+
+struct GhostAnimData {
+    HWND hRealWnd;
+    HBITMAP hBitmap;
+    RECT targetRect;
+    int width;
+    int height;
+    int targetDockX; // The dynamically learned icon position
+    BOOL isRising;
+    int mode;
+    int durationMs;
+    LONG_PTR originalExStyle;
+    HANDLE hReady; // signaled once the ghost's first frame is on screen (anti-flash)
+};
+
+// --- THE VAULTS ---
+std::unordered_map<HWND, HBITMAP> g_SnapshotCache;
+std::unordered_map<HWND, int> g_IconPositions; // Remembers where icons live
+std::mutex g_CacheMutex;
+
+// --- SETTINGS ---
+std::atomic<bool> g_enabled{true};
+std::atomic<int>  g_mode{MODE_GENIE};
+std::atomic<int>  g_durations[MODE_COUNT];
+
+void LoadSettings() {
+    g_enabled.store(Wh_GetIntSetting(L"enabled") != 0, std::memory_order_relaxed);
+
+    for (int i = 0; i < MODE_COUNT; i++) {
+        int ms = Wh_GetIntSetting(kDurKeys[i]);
+        if (ms < 50) ms = 50;
+        if (ms > 3000) ms = 3000;
+        g_durations[i].store(ms, std::memory_order_relaxed);
+    }
+
+    int mode = MODE_GENIE;
+    PCWSTR style = Wh_GetStringSetting(L"style");
+    if (style) {
+        for (int i = 0; i < MODE_COUNT; i++) {
+            if (wcscmp(style, kModeKeys[i]) == 0) { mode = i; break; }
+        }
+        Wh_FreeStringSetting(style);
+    }
+    g_mode.store(mode, std::memory_order_relaxed);
+}
+
+void SetDwmTransitions(HWND hWnd, BOOL enable) {
+    BOOL disable = !enable;
+    DwmSetWindowAttribute(hWnd, DWMWA_TRANSITIONS_FORCEDISABLED, &disable, sizeof(disable));
+}
+
+template <class T> static inline void SafeRelease(T*& p) {
+    if (p) { p->Release(); p = nullptr; }
+}
+
+// -------------------------------------------------------------------------
+// GPU (DirectComposition) backend
+//
+// The heavy part of the old renderer was re-running a HALFTONE StretchBlt of
+// the whole window bitmap on the CPU every single frame, then re-uploading it
+// via UpdateLayeredWindow. At 180 Hz the per-frame budget is ~5.5 ms and that
+// resample routinely blew past it on big windows, so frames were dropped.
+//
+// Every effect in this mod is really just scale + translate + fade of a static
+// snapshot (even "Genie" here is an affine fake, not a real mesh bend). That
+// means we can hand the snapshot to the GPU compositor ONCE as a texture and,
+// each frame, only push a 3x2 matrix + an opacity value. The GPU does the
+// resample for free, bilinear-filtered, at native refresh. Per-frame CPU cost
+// drops to a few floats + a Commit, which never misses the frame budget.
+//
+// One D3D11 device + DXGI factory are created lazily per process and reused for
+// every animation (device creation is tens of ms — far too slow to do per
+// minimize). Each animation gets its own lightweight DirectComposition device
+// so its hot loop needs no locks. If any of this fails (no GPU, locked-down
+// process, older Windows), we fall back to the original GDI renderer.
+// -------------------------------------------------------------------------
+static std::mutex        g_gpuInitMutex;
+static std::mutex        g_gpuCtxMutex;   // serializes shared D3D device/context/factory use
+static bool              g_gpuInitTried = false;
+static bool              g_gpuAvailable = false;
+static ID3D11Device*     g_d3dDevice    = nullptr;  // shared across animation threads
+static IDXGIFactory2*    g_dxgiFactory  = nullptr;  // shared
+
+// Create (once) the shared D3D11 device + DXGI factory. Returns false if the
+// GPU path can't be used in this process; caller then uses the CPU fallback.
+static bool EnsureGpuDevice() {
+    std::lock_guard<std::mutex> lock(g_gpuInitMutex);
+    if (g_gpuInitTried) return g_gpuAvailable;
+    g_gpuInitTried = true;
+
+    UINT flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+    D3D_FEATURE_LEVEL fl;
+    HRESULT hr = D3D11CreateDevice(
+        nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, flags,
+        nullptr, 0, D3D11_SDK_VERSION, &g_d3dDevice, &fl, nullptr);
+    if (FAILED(hr)) {
+        // Retry on WARP so software-rendering / GPU-less sessions still work.
+        hr = D3D11CreateDevice(
+            nullptr, D3D_DRIVER_TYPE_WARP, nullptr, flags,
+            nullptr, 0, D3D11_SDK_VERSION, &g_d3dDevice, &fl, nullptr);
+    }
+    if (FAILED(hr) || !g_d3dDevice) return false;
+
+    // The shared device + its immediate context are touched from every animation
+    // thread only during the brief per-animation setup (create texture/swapchain,
+    // copy, present). Those calls are serialized with g_gpuCtxMutex; the hot
+    // per-frame loop runs on a private DirectComposition device and takes no lock.
+
+    IDXGIDevice* dxgiDev = nullptr;
+    IDXGIAdapter* adapter = nullptr;
+    if (SUCCEEDED(g_d3dDevice->QueryInterface(__uuidof(IDXGIDevice), (void**)&dxgiDev)) &&
+        SUCCEEDED(dxgiDev->GetAdapter(&adapter)) &&
+        SUCCEEDED(adapter->GetParent(__uuidof(IDXGIFactory2), (void**)&g_dxgiFactory))) {
+        g_gpuAvailable = true;
+    }
+    SafeRelease(adapter);
+    SafeRelease(dxgiDev);
+
+    if (!g_gpuAvailable) SafeRelease(g_d3dDevice);
+    return g_gpuAvailable;
+}
+
+static void ReleaseGpuDevice() {
+    std::lock_guard<std::mutex> lock(g_gpuInitMutex);
+    SafeRelease(g_dxgiFactory);
+    SafeRelease(g_d3dDevice);
+    g_gpuAvailable = false;
+    g_gpuInitTried = false;
+}
+
+// -------------------------------------------------------------------------
+// Genie mesh (true Magic-Lamp bend)
+//
+// The other nine effects are pure scale+translate+fade, so they upload the
+// snapshot once and only push a transform per frame. Genie's signature is a
+// non-affine bend — the window body curves into a thin neck that pours into the
+// taskbar — which a single matrix can't express. So Genie instead renders a
+// tessellated, textured grid of the snapshot every frame with a tiny HLSL
+// shader, displacing each grid row toward the dock.
+//
+// The pipeline objects that never change (shaders, input layout, grid index
+// buffer, sampler/rasterizer/constant buffers) are built once on the shared
+// device and reused. Only the per-vertex positions (a dynamic vertex buffer)
+// and the swapchain/render-target are per-animation.
+// -------------------------------------------------------------------------
+static const int  GENIE_GX = 8;    // grid columns  (few: rows are ~straight across)
+static const int  GENIE_GY = 64;   // grid rows     (many: the bend runs vertically)
+
+struct GenieVertex { float x, y; float u, v; };   // NDC position + texcoord
+
+static std::mutex             g_genieMutex;
+static bool                   g_genieTried = false;
+static bool                   g_genieOk    = false;
+static ID3D11VertexShader*    g_gVS       = nullptr;
+static ID3D11PixelShader*     g_gPS       = nullptr;
+static ID3D11InputLayout*     g_gLayout   = nullptr;
+static ID3D11Buffer*          g_gIndexBuf = nullptr;   // static grid connectivity
+static ID3D11Buffer*          g_gConstBuf = nullptr;   // { float alpha; float3 pad; }
+static ID3D11SamplerState*    g_gSampler  = nullptr;
+static ID3D11RasterizerState* g_gRaster   = nullptr;
+static UINT                   g_gIndexCount = 0;
+
+static const char* kGenieVS =
+    "struct VIn  { float2 pos:POSITION; float2 tex:TEXCOORD; };\n"
+    "struct VOut { float4 pos:SV_POSITION; float2 tex:TEXCOORD; };\n"
+    "VOut main(VIn i){ VOut o; o.pos=float4(i.pos,0,1); o.tex=i.tex; return o; }\n";
+
+static const char* kGeniePS =
+    "Texture2D gTex:register(t0); SamplerState gSmp:register(s0);\n"
+    "cbuffer C:register(b0){ float gAlpha; float3 pad; };\n"
+    "struct VOut { float4 pos:SV_POSITION; float2 tex:TEXCOORD; };\n"
+    "float4 main(VOut i):SV_TARGET{\n"
+    "  float4 c = gTex.Sample(gSmp, i.tex);\n"
+    "  return float4(c.rgb * gAlpha, gAlpha);\n"   // premultiplied; snapshot is opaque
+    "}\n";
+
+// Build the one-time Genie pipeline objects on the shared device. Returns false
+// if anything fails (caller then falls back to the affine/CPU Genie).
+static bool EnsureGenieGpuResources() {
+    std::lock_guard<std::mutex> lock(g_genieMutex);
+    if (g_genieTried) return g_genieOk;
+    g_genieTried = true;
+    if (!g_d3dDevice) return false;
+
+    ID3DBlob* vsb = nullptr;
+    ID3DBlob* psb = nullptr;
+    ID3DBlob* err = nullptr;
+    HRESULT hr = D3DCompile(kGenieVS, strlen(kGenieVS), "genieVS", nullptr, nullptr,
+                            "main", "vs_4_0", 0, 0, &vsb, &err);
+    SafeRelease(err);
+    if (SUCCEEDED(hr))
+        hr = D3DCompile(kGeniePS, strlen(kGeniePS), "geniePS", nullptr, nullptr,
+                        "main", "ps_4_0", 0, 0, &psb, &err);
+    SafeRelease(err);
+    if (FAILED(hr)) { SafeRelease(vsb); SafeRelease(psb); return false; }
+
+    bool ok =
+        SUCCEEDED(g_d3dDevice->CreateVertexShader(vsb->GetBufferPointer(), vsb->GetBufferSize(), nullptr, &g_gVS)) &&
+        SUCCEEDED(g_d3dDevice->CreatePixelShader(psb->GetBufferPointer(), psb->GetBufferSize(), nullptr, &g_gPS));
+
+    if (ok) {
+        D3D11_INPUT_ELEMENT_DESC il[] = {
+            { "POSITION", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 0,  D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 8,  D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        };
+        ok = SUCCEEDED(g_d3dDevice->CreateInputLayout(il, 2, vsb->GetBufferPointer(),
+                                                      vsb->GetBufferSize(), &g_gLayout));
+    }
+    SafeRelease(vsb);
+    SafeRelease(psb);
+    if (!ok) return false;
+
+    // Static grid index buffer: two triangles per cell.
+    {
+        const int cols = GENIE_GX + 1;
+        UINT* idx = (UINT*)malloc((size_t)GENIE_GX * GENIE_GY * 6 * sizeof(UINT));
+        if (!idx) return false;
+        UINT n = 0;
+        for (int j = 0; j < GENIE_GY; j++) {
+            for (int i = 0; i < GENIE_GX; i++) {
+                UINT tl = (UINT)(j * cols + i);
+                UINT tr = tl + 1;
+                UINT bl = tl + cols;
+                UINT br = bl + 1;
+                idx[n++] = tl; idx[n++] = bl; idx[n++] = tr;
+                idx[n++] = tr; idx[n++] = bl; idx[n++] = br;
+            }
+        }
+        g_gIndexCount = n;
+        D3D11_BUFFER_DESC bd;
+        ZeroMemory(&bd, sizeof(bd));
+        bd.ByteWidth = (UINT)(n * sizeof(UINT));
+        bd.Usage = D3D11_USAGE_IMMUTABLE;
+        bd.BindFlags = D3D11_BIND_INDEX_BUFFER;
+        D3D11_SUBRESOURCE_DATA sd;
+        ZeroMemory(&sd, sizeof(sd));
+        sd.pSysMem = idx;
+        HRESULT ihr = g_d3dDevice->CreateBuffer(&bd, &sd, &g_gIndexBuf);
+        free(idx);
+        if (FAILED(ihr)) return false;
+    }
+
+    // Constant buffer (alpha) — dynamic, updated per frame.
+    {
+        D3D11_BUFFER_DESC bd;
+        ZeroMemory(&bd, sizeof(bd));
+        bd.ByteWidth = 16;
+        bd.Usage = D3D11_USAGE_DYNAMIC;
+        bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+        bd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+        if (FAILED(g_d3dDevice->CreateBuffer(&bd, nullptr, &g_gConstBuf))) return false;
+    }
+
+    // Linear clamp sampler.
+    {
+        D3D11_SAMPLER_DESC sd;
+        ZeroMemory(&sd, sizeof(sd));
+        sd.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+        sd.AddressU = sd.AddressV = sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+        sd.MaxLOD = D3D11_FLOAT32_MAX;
+        if (FAILED(g_d3dDevice->CreateSamplerState(&sd, &g_gSampler))) return false;
+    }
+
+    // Cull nothing — the warp can flip triangle winding.
+    {
+        D3D11_RASTERIZER_DESC rd;
+        ZeroMemory(&rd, sizeof(rd));
+        rd.FillMode = D3D11_FILL_SOLID;
+        rd.CullMode = D3D11_CULL_NONE;
+        if (FAILED(g_d3dDevice->CreateRasterizerState(&rd, &g_gRaster))) return false;
+    }
+
+    g_genieOk = true;
+    return true;
+}
+
+static void ReleaseGenieGpuResources() {
+    std::lock_guard<std::mutex> lock(g_genieMutex);
+    SafeRelease(g_gRaster);
+    SafeRelease(g_gSampler);
+    SafeRelease(g_gConstBuf);
+    SafeRelease(g_gIndexBuf);
+    SafeRelease(g_gLayout);
+    SafeRelease(g_gPS);
+    SafeRelease(g_gVS);
+    g_genieOk = false;
+    g_genieTried = false;
+}
+
+// -------------------------------------------------------------------------
+// Easing helpers
+// -------------------------------------------------------------------------
+static inline float clampf(float v, float lo, float hi) {
+    return v < lo ? lo : (v > hi ? hi : v);
+}
+static inline float easeInCubic(float t)  { return t * t * t; }
+static inline float easeOutCubic(float t) { float u = 1.0f - t; return 1.0f - u * u * u; }
+static inline float easeInOutCubic(float t) {
+    return t < 0.5f ? 4.0f * t * t * t : 1.0f - powf(-2.0f * t + 2.0f, 3.0f) / 2.0f;
+}
+
+// -------------------------------------------------------------------------
+// Per-frame effect solver.
+// t runs 0 (full window) -> 1 (fully minimized/gone). The animation thread
+// reverses t for restore, so every effect is authored once and plays backwards
+// for free. Fills newW/newH (size), currentX/currentY (top-left) and alphaFloat.
+// -------------------------------------------------------------------------
+static void SolveFrame(const GhostAnimData* d, float t,
+                       int SW, int SH, float taskbarY,
+                       int capW, int capH,
+                       int* outW, int* outH, int* outX, int* outY, float* outAlpha) {
+    const int   w = d->width;
+    const int   h = d->height;
+    const int   L = d->targetRect.left;
+    const int   T = d->targetRect.top;
+    const float cx = L + w * 0.5f;
+    const float cy = T + h * 0.5f;
+    const int   dockX = d->targetDockX;
+
+    float scaleX = 1.0f, scaleY = 1.0f;
+    float fx = cx, fy = cy;   // desired CENTER of the frame (default: in place)
+    float alpha = 1.0f;
+    bool  anchorTopLeft = false; // if true, fx/fy are treated as the TOP-LEFT instead
+
+    switch (d->mode) {
+
+    case MODE_GENIE: {
+        // Verbatim math from the original mod — the proven Magic Lamp look.
+        float invT  = 1.0f - t;
+        float moveX = 1.0f - (invT * invT * invT * invT * invT * invT);
+        float moveY = (0.70f * (t * t)) + (0.10f * t);
+        scaleX = 1.0f - (0.95f * (1.8f * t));
+        if (scaleX < 0.05f) scaleX = 0.05f;
+        scaleY = 1.0f - (0.70f * (t * t));
+
+        float startCenterX = cx;
+        float startY       = (float)T;
+        float targetDockY  = (float)(SH + h);
+        float curCenterX   = startCenterX + ((float)dockX - startCenterX) * moveX;
+        float curTopY      = startY + (targetDockY - startY) * moveY;
+        // Genie positions by top (not center); express that via anchorTopLeft.
+        anchorTopLeft = true;
+        fx = curCenterX;   // still a center for X; handled below
+        fy = curTopY;      // top for Y
+        if (t > 0.6f) alpha = 1.0f - ((t - 0.6f) / 0.4f);
+        break;
+    }
+
+    case MODE_VACUUM: {
+        float e = easeInCubic(t);
+        float s = 1.0f - 0.97f * e;
+        if (s < 0.03f) s = 0.03f;
+        scaleX = scaleY = s;
+        fx = cx + (dockX - cx) * e;
+        fy = cy + (taskbarY - cy) * e;
+        if (t > 0.75f) alpha = 1.0f - ((t - 0.75f) / 0.25f);
+        break;
+    }
+
+    case MODE_GLIDE: {
+        float e = easeOutCubic(t);
+        scaleX = scaleY = 1.0f - 0.12f * e;
+        alpha = 1.0f - e;
+        break;
+    }
+
+    case MODE_POP: {
+        float e = easeOutCubic(t);
+        scaleX = scaleY = 1.0f + 0.18f * e;
+        alpha = 1.0f - e;
+        break;
+    }
+
+    case MODE_SLIDE: {
+        float e = easeInCubic(t);
+        anchorTopLeft = true;
+        fx = (float)L;
+        fy = T + (SH - T + 5) * e;   // top travels to just past the bottom edge
+        if (t > 0.70f) alpha = 1.0f - ((t - 0.70f) / 0.30f);
+        break;
+    }
+
+    case MODE_FALL: {
+        float e = t * t;             // gravitational acceleration
+        scaleX = 1.0f - 0.10f * t;
+        scaleY = 1.0f + 0.20f * t;   // stretches as it speeds up
+        float drift = (w * 0.15f) * sinf(t * 3.0f);
+        anchorTopLeft = true;
+        fx = L + drift;
+        fy = T + (SH - T + h) * e;
+        if (t > 0.60f) alpha = 1.0f - ((t - 0.60f) / 0.40f);
+        break;
+    }
+
+    case MODE_WARP: {
+        // Phase 1 (0..0.6): squeeze horizontally into a thin vertical beam.
+        // Phase 2 (0.6..1): the beam shoots up off the top and fades.
+        float ramp = t / 0.6f; if (ramp > 1.0f) ramp = 1.0f;
+        scaleX = 1.0f - 0.96f * ramp;
+        scaleY = 1.0f;
+        anchorTopLeft = true;
+        fx = cx;             // X center, resolved to left below
+        fy = (float)T;       // top
+        if (t > 0.6f) {
+            float up  = (t - 0.6f) / 0.4f;
+            float upE = easeInCubic(up);
+            scaleY = 1.0f - 0.40f * up;
+            fy = T - (cy + h) * upE;
+            alpha = 1.0f - up;
+        }
+        break;
+    }
+
+    case MODE_SQUASH: {
+        float e = easeInCubic(t);
+        scaleY = 1.0f - 0.97f * e;
+        scaleX = 1.0f + 0.10f * e;
+        anchorTopLeft = true;
+        fx = cx;                       // X center, resolved below
+        fy = T + (taskbarY - T) * e;   // top sinks toward the taskbar
+        if (t > 0.75f) alpha = 1.0f - ((t - 0.75f) / 0.25f);
+        break;
+    }
+
+    case MODE_ROLLUP: {
+        float e = easeInOutCubic(t);
+        scaleY = 1.0f - e;             // height collapses, top stays anchored
+        scaleX = 1.0f;
+        anchorTopLeft = true;
+        fx = (float)L;
+        fy = (float)T;
+        if (t > 0.85f) alpha = 1.0f - ((t - 0.85f) / 0.15f);
+        break;
+    }
+
+    case MODE_SWIRL: {
+        float e = easeInCubic(t);
+        scaleX = scaleY = 1.0f - 0.95f * e;
+        float baseCX = cx + (dockX - cx) * e;
+        float baseCY = cy + (taskbarY - cy) * e;
+        float amp = (w * 0.40f) * (1.0f - t);
+        fx = baseCX + amp * sinf(t * 18.0f);
+        fy = baseCY + amp * 0.5f * cosf(t * 18.0f);
+        if (t > 0.70f) alpha = 1.0f - ((t - 0.70f) / 0.30f);
+        break;
+    }
+
+    default:
+        break;
+    }
+
+    int newW = (int)(w * scaleX);
+    int newH = (int)(h * scaleY);
+    if (newW < 2) newW = 2;
+    if (newH < 1) newH = 1;
+    if (newW > capW) newW = capW;
+    if (newH > capH) newH = capH;
+
+    int px, py;
+    if (anchorTopLeft) {
+        // fy is a top; fx is a center for genie/warp/squash, a left for slide/fall/rollup.
+        if (d->mode == MODE_GENIE || d->mode == MODE_WARP || d->mode == MODE_SQUASH)
+            px = (int)(fx - newW / 2.0f);
+        else
+            px = (int)fx;
+        py = (int)fy;
+    } else {
+        px = (int)(fx - newW / 2.0f);
+        py = (int)(fy - newH / 2.0f);
+    }
+
+    *outW = newW;
+    *outH = newH;
+    *outX = px;
+    *outY = py;
+    *outAlpha = clampf(alpha, 0.0f, 1.0f);
+}
+
+// Reveal the real window (on restore) and undo the force-disabled DWM
+// transitions. Runs once per animation, after the render loop, while the ghost
+// still shows the final full-size frame so there's no gap under the real window.
+static void FinalizeRealWindow(GhostAnimData* data) {
+    if (data->isRising) {
+        SetLayeredWindowAttributes(data->hRealWnd, 0, 255, LWA_ALPHA);
+        if (!(data->originalExStyle & WS_EX_LAYERED)) {
+            SetWindowLongPtrW(data->hRealWnd, GWL_EXSTYLE, data->originalExStyle);
+        }
+    }
+    SetDwmTransitions(data->hRealWnd, TRUE);
+}
+
+// -------------------------------------------------------------------------
+// CPU renderer (fallback). Original GDI StretchBlt + UpdateLayeredWindow path,
+// used when the GPU/DirectComposition path is unavailable in this process.
+// hGhost must be a WS_EX_LAYERED popup sized to the window rect.
+// -------------------------------------------------------------------------
+static void RunCpuAnim(GhostAnimData* data, HWND hGhost,
+                       int screenWidth, int screenHeight, float taskbarY) {
+    // The scaled bitmap is allocated a bit LARGER than the window so effects that
+    // temporarily scale up (Pop, Free Fall, Squash) don't get clipped.
+    int capW = (int)(data->width  * 1.30f) + 4;
+    int capH = (int)(data->height * 1.30f) + 4;
+
+    HDC hScreenDC = GetDC(NULL);
+    HDC hOrigDC   = CreateCompatibleDC(hScreenDC);
+    HDC hScaledDC = CreateCompatibleDC(hScreenDC);
+    HBITMAP hScaledBitmap = CreateCompatibleBitmap(hScreenDC, capW, capH);
+    HBITMAP hOldOrig   = (HBITMAP)SelectObject(hOrigDC, data->hBitmap);
+    HBITMAP hOldScaled = (HBITMAP)SelectObject(hScaledDC, hScaledBitmap);
+    // HALFTONE averages source pixels into each destination pixel instead of
+    // picking one (COLORONCOLOR), so extreme downscales come out smooth. HALFTONE
+    // requires SetBrushOrgEx per GDI docs or the resampling brush can misalign.
+    SetStretchBltMode(hScaledDC, HALFTONE);
+    SetBrushOrgEx(hScaledDC, 0, 0, NULL);
+
+    const double totalMs = (double)data->durationMs;
+    LARGE_INTEGER qpcFreq, qpcStart, qpcNow;
+    QueryPerformanceFrequency(&qpcFreq);
+    QueryPerformanceCounter(&qpcStart);
+
+    BOOL firstFrame = TRUE;
+    for (;;) {
+        QueryPerformanceCounter(&qpcNow);
+        double elapsedMs = (qpcNow.QuadPart - qpcStart.QuadPart) * 1000.0 / qpcFreq.QuadPart;
+        BOOL lastFrame = (elapsedMs >= totalMs);
+        float progress = lastFrame ? 1.0f : (float)(elapsedMs / totalMs);
+        float t = data->isRising ? (1.0f - progress) : progress;
+
+        int newW, newH, currentX, currentY;
+        float alphaFloat;
+        SolveFrame(data, t, screenWidth, screenHeight, taskbarY, capW, capH,
+                   &newW, &newH, &currentX, &currentY, &alphaFloat);
+        BYTE alpha = (BYTE)(255.0f * alphaFloat);
+
+        StretchBlt(hScaledDC, 0, 0, newW, newH,
+                   hOrigDC, 0, 0, data->width, data->height, SRCCOPY);
+
+        POINT ptDst = { currentX, currentY };
+        SIZE  sz    = { newW, newH };
+        POINT ptSrc = { 0, 0 };
+        BLENDFUNCTION bf;
+        bf.BlendOp = AC_SRC_OVER;
+        bf.BlendFlags = 0;
+        bf.SourceConstantAlpha = alpha;
+        bf.AlphaFormat = 0; // source bitmap is opaque BGR, not premultiplied BGRA
+        UpdateLayeredWindow(hGhost, NULL, &ptDst, &sz, hScaledDC, &ptSrc, 0, &bf, ULW_ALPHA);
+
+        if (firstFrame) {
+            ShowWindow(hGhost, SW_SHOWNOACTIVATE);
+            firstFrame = FALSE;
+            // Ghost's first frame is up: release the minimize/restore hook so the
+            // real window only changes now, not before the ghost exists.
+            if (data->hReady) SetEvent(data->hReady);
+        }
+
+        if (lastFrame) break;
+        DwmFlush(); // block until the next DWM compose cycle - the vsync sync point
+    }
+
+    FinalizeRealWindow(data);
+
+    SelectObject(hScaledDC, hOldScaled);
+    SelectObject(hOrigDC, hOldOrig);
+    DeleteObject(hScaledBitmap);
+    DeleteDC(hScaledDC);
+    DeleteDC(hOrigDC);
+    ReleaseDC(NULL, hScreenDC);
+}
+
+// -------------------------------------------------------------------------
+// GPU renderer (DirectComposition). Uploads the snapshot to the GPU once, then
+// per frame only pushes a 3x2 transform + an opacity value and commits. Returns
+// false if any setup step fails, so the caller can fall back to the CPU path.
+// hGhost must be a full-screen WS_EX_NOREDIRECTIONBITMAP popup.
+// -------------------------------------------------------------------------
+static bool RunGpuAnim(GhostAnimData* data, HWND hGhost,
+                       int screenWidth, int screenHeight, float taskbarY) {
+    const int w = data->width;
+    const int h = data->height;
+
+    // 1. Pull the snapshot out as top-down 32-bit BGRA and force it opaque
+    //    (the snapshot carries no meaningful alpha; premultiplied-opaque = same RGB).
+    BITMAPINFO bmi;
+    ZeroMemory(&bmi, sizeof(bmi));
+    bmi.bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth       = w;
+    bmi.bmiHeader.biHeight      = -h;      // negative = top-down
+    bmi.bmiHeader.biPlanes      = 1;
+    bmi.bmiHeader.biBitCount    = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    const size_t stride = (size_t)w * 4;
+    BYTE* bits = (BYTE*)malloc(stride * (size_t)h);
+    if (!bits) return false;
+
+    HDC hScreenDC = GetDC(NULL);
+    int scan = GetDIBits(hScreenDC, data->hBitmap, 0, h, bits, &bmi, DIB_RGB_COLORS);
+    ReleaseDC(NULL, hScreenDC);
+    if (scan == 0) { free(bits); return false; }
+    for (size_t i = 0; i < (size_t)w * (size_t)h; i++) bits[i * 4 + 3] = 0xFF;
+
+    // 2. Everything that touches the shared D3D device/context/factory is done
+    //    under one lock; it runs once per animation and is off the hot path.
+    IDXGISwapChain1*             swapChain   = nullptr;
+    IDXGIDevice*                 dxgiDev     = nullptr;
+    IDCompositionDesktopDevice*  dcompDevice = nullptr;
+    IDCompositionTarget*         dcompTarget = nullptr;
+    IDCompositionVisual2*        visual      = nullptr;
+    IDCompositionEffectGroup*    effectGroup = nullptr;   // carries opacity (pre-Visual3)
+    IDCompositionMatrixTransform* xform      = nullptr;
+    bool ok = false;
+
+    {
+        std::lock_guard<std::mutex> lock(g_gpuCtxMutex);
+
+        D3D11_TEXTURE2D_DESC td;
+        ZeroMemory(&td, sizeof(td));
+        td.Width  = w;
+        td.Height = h;
+        td.MipLevels = 1;
+        td.ArraySize = 1;
+        td.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+        td.SampleDesc.Count = 1;
+        td.Usage = D3D11_USAGE_IMMUTABLE;
+        td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+
+        D3D11_SUBRESOURCE_DATA srd;
+        ZeroMemory(&srd, sizeof(srd));
+        srd.pSysMem = bits;
+        srd.SysMemPitch = (UINT)stride;
+
+        ID3D11Texture2D* srcTex = nullptr;
+        HRESULT hr = g_d3dDevice->CreateTexture2D(&td, &srd, &srcTex);
+        if (SUCCEEDED(hr) && srcTex) {
+            DXGI_SWAP_CHAIN_DESC1 scd;
+            ZeroMemory(&scd, sizeof(scd));
+            scd.Width  = w;
+            scd.Height = h;
+            scd.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+            scd.SampleDesc.Count = 1;
+            scd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+            scd.BufferCount = 2;
+            scd.Scaling    = DXGI_SCALING_STRETCH;
+            scd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+            scd.AlphaMode  = DXGI_ALPHA_MODE_PREMULTIPLIED;
+
+            hr = g_dxgiFactory->CreateSwapChainForComposition(g_d3dDevice, &scd, nullptr, &swapChain);
+            if (SUCCEEDED(hr) && swapChain) {
+                ID3D11Texture2D* backBuf = nullptr;
+                if (SUCCEEDED(swapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (void**)&backBuf)) && backBuf) {
+                    ID3D11DeviceContext* ctx = nullptr;
+                    g_d3dDevice->GetImmediateContext(&ctx);
+                    if (ctx) {
+                        ctx->CopyResource(backBuf, srcTex);
+                        ctx->Release();
+                    }
+                    backBuf->Release();
+                }
+                DXGI_PRESENT_PARAMETERS pp;
+                ZeroMemory(&pp, sizeof(pp));
+                swapChain->Present1(0, 0, &pp);
+            }
+        }
+        SafeRelease(srcTex);
+
+        if (swapChain &&
+            SUCCEEDED(g_d3dDevice->QueryInterface(__uuidof(IDXGIDevice), (void**)&dxgiDev)) &&
+            SUCCEEDED(DCompositionCreateDevice2(dxgiDev, __uuidof(IDCompositionDesktopDevice), (void**)&dcompDevice)) &&
+            SUCCEEDED(dcompDevice->CreateTargetForHwnd(hGhost, TRUE, &dcompTarget)) &&
+            SUCCEEDED(dcompDevice->CreateVisual(&visual)) &&
+            SUCCEEDED(dcompDevice->CreateMatrixTransform(&xform)) &&
+            SUCCEEDED(dcompDevice->CreateEffectGroup(&effectGroup))) {
+            visual->SetContent(swapChain);
+            visual->SetTransform(xform);
+            visual->SetEffect(effectGroup);   // opacity is animated on the effect group
+            dcompTarget->SetRoot(visual);
+            ok = true;
+        }
+        SafeRelease(dxgiDev);
+    }
+
+    free(bits);
+
+    if (!ok) {
+        SafeRelease(xform);
+        SafeRelease(effectGroup);
+        SafeRelease(visual);
+        SafeRelease(dcompTarget);
+        SafeRelease(dcompDevice);
+        SafeRelease(swapChain);
+        return false;
+    }
+
+    // 3. Hot loop: compute the affine transform for this frame and commit. The
+    //    GPU resamples the snapshot; per-frame CPU cost is a handful of floats.
+    const int capW = (int)(w * 1.30f) + 4;
+    const int capH = (int)(h * 1.30f) + 4;
+    const double totalMs = (double)data->durationMs;
+    LARGE_INTEGER qpcFreq, qpcStart, qpcNow;
+    QueryPerformanceFrequency(&qpcFreq);
+    QueryPerformanceCounter(&qpcStart);
+
+    BOOL firstFrame = TRUE;
+    for (;;) {
+        QueryPerformanceCounter(&qpcNow);
+        double elapsedMs = (qpcNow.QuadPart - qpcStart.QuadPart) * 1000.0 / qpcFreq.QuadPart;
+        BOOL lastFrame = (elapsedMs >= totalMs);
+        float progress = lastFrame ? 1.0f : (float)(elapsedMs / totalMs);
+        float t = data->isRising ? (1.0f - progress) : progress;
+
+        int newW, newH, curX, curY;
+        float alphaFloat;
+        SolveFrame(data, t, screenWidth, screenHeight, taskbarY, capW, capH,
+                   &newW, &newH, &curX, &curY, &alphaFloat);
+
+        // Map the w x h snapshot onto (curX,curY)-(curX+newW,curY+newH). The ghost
+        // window spans the whole screen at (0,0), so screen coords == visual coords.
+        float sx = (w > 0) ? (float)newW / (float)w : 1.0f;
+        float sy = (h > 0) ? (float)newH / (float)h : 1.0f;
+        D2D_MATRIX_3X2_F m;
+        m._11 = sx;          m._12 = 0.0f;
+        m._21 = 0.0f;        m._22 = sy;
+        m._31 = (float)curX; m._32 = (float)curY;
+
+        xform->SetMatrix(m);
+        effectGroup->SetOpacity(clampf(alphaFloat, 0.0f, 1.0f));
+        dcompDevice->Commit();
+
+        if (firstFrame) {
+            ShowWindow(hGhost, SW_SHOWNOACTIVATE);
+            firstFrame = FALSE;
+            // Ghost's first frame is up: release the minimize/restore hook so the
+            // real window only changes now, not before the ghost exists.
+            if (data->hReady) SetEvent(data->hReady);
+        }
+
+        if (lastFrame) break;
+        DwmFlush(); // pace to the compose cycle; per-frame work is trivial now
+    }
+
+    // Reveal the real window while the ghost still shows the final frame, then
+    // tear down the composition.
+    FinalizeRealWindow(data);
+
+    SafeRelease(xform);
+    SafeRelease(effectGroup);
+    SafeRelease(visual);
+    SafeRelease(dcompTarget);
+    SafeRelease(dcompDevice);
+    SafeRelease(swapChain);
+    return true;
+}
+
+// -------------------------------------------------------------------------
+// GPU Genie renderer. Renders a bent, textured grid of the snapshot every frame
+// into a full-screen composition swapchain. Returns false on any setup failure
+// so the caller can fall back to the affine/CPU Genie. hGhost must be the
+// full-screen WS_EX_NOREDIRECTIONBITMAP popup.
+// -------------------------------------------------------------------------
+static bool RunGpuGenieAnim(GhostAnimData* data, HWND hGhost,
+                            int screenWidth, int screenHeight, float taskbarY) {
+    if (!EnsureGenieGpuResources()) return false;
+
+    const int w = data->width;
+    const int h = data->height;
+
+    // Snapshot -> top-down BGRA, forced opaque (same as the affine path).
+    BITMAPINFO bmi;
+    ZeroMemory(&bmi, sizeof(bmi));
+    bmi.bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth       = w;
+    bmi.bmiHeader.biHeight      = -h;
+    bmi.bmiHeader.biPlanes      = 1;
+    bmi.bmiHeader.biBitCount    = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    const size_t stride = (size_t)w * 4;
+    BYTE* bits = (BYTE*)malloc(stride * (size_t)h);
+    if (!bits) return false;
+    HDC hScreenDC = GetDC(NULL);
+    int scan = GetDIBits(hScreenDC, data->hBitmap, 0, h, bits, &bmi, DIB_RGB_COLORS);
+    ReleaseDC(NULL, hScreenDC);
+    if (scan == 0) { free(bits); return false; }
+    for (size_t i = 0; i < (size_t)w * (size_t)h; i++) bits[i * 4 + 3] = 0xFF;
+
+    const int vertCount = (GENIE_GX + 1) * (GENIE_GY + 1);
+    const UINT vbBytes  = (UINT)(vertCount * sizeof(GenieVertex));
+
+    ID3D11Texture2D*             srcTex      = nullptr;
+    ID3D11ShaderResourceView*    srv         = nullptr;
+    IDXGISwapChain1*             swapChain   = nullptr;
+    ID3D11RenderTargetView*      rtv         = nullptr;
+    ID3D11Buffer*                vbuf        = nullptr;
+    ID3D11DeviceContext*         ctx         = nullptr;
+    IDXGIDevice*                 dxgiDev     = nullptr;
+    IDCompositionDesktopDevice*  dcompDevice = nullptr;
+    IDCompositionTarget*         dcompTarget = nullptr;
+    IDCompositionVisual2*        visual      = nullptr;
+    bool ok = false;
+
+    {
+        std::lock_guard<std::mutex> lock(g_gpuCtxMutex);
+
+        D3D11_TEXTURE2D_DESC td;
+        ZeroMemory(&td, sizeof(td));
+        td.Width = w; td.Height = h; td.MipLevels = 1; td.ArraySize = 1;
+        td.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+        td.SampleDesc.Count = 1;
+        td.Usage = D3D11_USAGE_IMMUTABLE;
+        td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+        D3D11_SUBRESOURCE_DATA srd;
+        ZeroMemory(&srd, sizeof(srd));
+        srd.pSysMem = bits;
+        srd.SysMemPitch = (UINT)stride;
+
+        if (SUCCEEDED(g_d3dDevice->CreateTexture2D(&td, &srd, &srcTex)) &&
+            SUCCEEDED(g_d3dDevice->CreateShaderResourceView(srcTex, nullptr, &srv))) {
+
+            DXGI_SWAP_CHAIN_DESC1 scd;
+            ZeroMemory(&scd, sizeof(scd));
+            scd.Width  = screenWidth;
+            scd.Height = screenHeight;
+            scd.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+            scd.SampleDesc.Count = 1;
+            scd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+            scd.BufferCount = 2;
+            scd.Scaling    = DXGI_SCALING_STRETCH;
+            scd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+            scd.AlphaMode  = DXGI_ALPHA_MODE_PREMULTIPLIED;
+
+            if (SUCCEEDED(g_dxgiFactory->CreateSwapChainForComposition(g_d3dDevice, &scd, nullptr, &swapChain))) {
+                ID3D11Texture2D* backBuf = nullptr;
+                if (SUCCEEDED(swapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (void**)&backBuf)) && backBuf) {
+                    g_d3dDevice->CreateRenderTargetView(backBuf, nullptr, &rtv);
+                    backBuf->Release();
+                }
+            }
+
+            D3D11_BUFFER_DESC vbd;
+            ZeroMemory(&vbd, sizeof(vbd));
+            vbd.ByteWidth = vbBytes;
+            vbd.Usage = D3D11_USAGE_DYNAMIC;
+            vbd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+            vbd.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+            g_d3dDevice->CreateBuffer(&vbd, nullptr, &vbuf);
+        }
+
+        if (rtv && vbuf && srv &&
+            SUCCEEDED(g_d3dDevice->QueryInterface(__uuidof(IDXGIDevice), (void**)&dxgiDev)) &&
+            SUCCEEDED(DCompositionCreateDevice2(dxgiDev, __uuidof(IDCompositionDesktopDevice), (void**)&dcompDevice)) &&
+            SUCCEEDED(dcompDevice->CreateTargetForHwnd(hGhost, TRUE, &dcompTarget)) &&
+            SUCCEEDED(dcompDevice->CreateVisual(&visual))) {
+            g_d3dDevice->GetImmediateContext(&ctx);
+            visual->SetContent(swapChain);
+            dcompTarget->SetRoot(visual);
+            dcompDevice->Commit();
+            ok = (ctx != nullptr);
+        }
+        SafeRelease(dxgiDev);
+    }
+
+    free(bits);
+
+    GenieVertex* verts = ok ? (GenieVertex*)malloc(vbBytes) : nullptr;
+    if (!ok || !verts) {
+        if (verts) free(verts);
+        SafeRelease(ctx);
+        SafeRelease(visual);
+        SafeRelease(dcompTarget);
+        SafeRelease(dcompDevice);
+        SafeRelease(vbuf);
+        SafeRelease(rtv);
+        SafeRelease(swapChain);
+        SafeRelease(srv);
+        SafeRelease(srcTex);
+        return false;
+    }
+
+    // Genie shape constants — tweak to taste.
+    const float LEAD     = 1.4f;                          // how far the window's bottom leads its top into the neck
+    const float neckW    = (w * 0.05f > 10.0f) ? w * 0.05f : 10.0f; // drained-neck width (px)
+    const float sourceCX = data->targetRect.left + w * 0.5f;
+    const float dockX    = (float)data->targetDockX;
+    const float dockY    = taskbarY;
+    const float srcTop   = (float)data->targetRect.top;
+
+    const double totalMs = (double)data->durationMs;
+    LARGE_INTEGER qpcFreq, qpcStart, qpcNow;
+    QueryPerformanceFrequency(&qpcFreq);
+    QueryPerformanceCounter(&qpcStart);
+
+    BOOL firstFrame = TRUE;
+    for (;;) {
+        QueryPerformanceCounter(&qpcNow);
+        double elapsedMs = (qpcNow.QuadPart - qpcStart.QuadPart) * 1000.0 / qpcFreq.QuadPart;
+        BOOL lastFrame = (elapsedMs >= totalMs);
+        float progress = lastFrame ? 1.0f : (float)(elapsedMs / totalMs);
+        float p = data->isRising ? (1.0f - progress) : progress;
+
+        // Build the bent grid in screen NDC.
+        int vi = 0;
+        for (int j = 0; j <= GENIE_GY; j++) {
+            float v    = (float)j / (float)GENIE_GY;
+            float rowP = clampf(p * (1.0f + LEAD) - (1.0f - v) * LEAD, 0.0f, 1.0f);
+            float pinch   = rowP * rowP * (3.0f - 2.0f * rowP); // smoothstep: horizontal funnel
+            float descend = rowP * rowP * rowP;                 // easeInCubic: vertical dive
+            float rowW  = w + (neckW - w) * pinch;
+            float rowCX = sourceCX + (dockX - sourceCX) * pinch;
+            float rowY  = (srcTop + v * h) + (dockY - (srcTop + v * h)) * descend;
+            for (int i = 0; i <= GENIE_GX; i++) {
+                float u = (float)i / (float)GENIE_GX;
+                float xpx = rowCX + (u - 0.5f) * rowW;
+                verts[vi].x = xpx / (float)screenWidth * 2.0f - 1.0f;
+                verts[vi].y = 1.0f - rowY / (float)screenHeight * 2.0f;
+                verts[vi].u = u;
+                verts[vi].v = v;
+                vi++;
+            }
+        }
+        float alpha = (p < 0.75f) ? 1.0f : clampf(1.0f - (p - 0.75f) / 0.25f, 0.0f, 1.0f);
+
+        {
+            std::lock_guard<std::mutex> lock(g_gpuCtxMutex);
+
+            D3D11_MAPPED_SUBRESOURCE ms;
+            if (SUCCEEDED(ctx->Map(vbuf, 0, D3D11_MAP_WRITE_DISCARD, 0, &ms))) {
+                memcpy(ms.pData, verts, vbBytes);
+                ctx->Unmap(vbuf, 0);
+            }
+            if (SUCCEEDED(ctx->Map(g_gConstBuf, 0, D3D11_MAP_WRITE_DISCARD, 0, &ms))) {
+                float c[4] = { alpha, 0.0f, 0.0f, 0.0f };
+                memcpy(ms.pData, c, sizeof(c));
+                ctx->Unmap(g_gConstBuf, 0);
+            }
+
+            UINT strideV = sizeof(GenieVertex), offsetV = 0;
+            ctx->IASetInputLayout(g_gLayout);
+            ctx->IASetVertexBuffers(0, 1, &vbuf, &strideV, &offsetV);
+            ctx->IASetIndexBuffer(g_gIndexBuf, DXGI_FORMAT_R32_UINT, 0);
+            ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+            ctx->VSSetShader(g_gVS, nullptr, 0);
+            ctx->PSSetShader(g_gPS, nullptr, 0);
+            ctx->PSSetShaderResources(0, 1, &srv);
+            ctx->PSSetSamplers(0, 1, &g_gSampler);
+            ctx->PSSetConstantBuffers(0, 1, &g_gConstBuf);
+            ctx->RSSetState(g_gRaster);
+            D3D11_VIEWPORT vp = { 0.0f, 0.0f, (float)screenWidth, (float)screenHeight, 0.0f, 1.0f };
+            ctx->RSSetViewports(1, &vp);
+            float clearCol[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+            ctx->OMSetRenderTargets(1, &rtv, nullptr);
+            ctx->ClearRenderTargetView(rtv, clearCol);
+            ctx->OMSetBlendState(nullptr, nullptr, 0xffffffff);
+            ctx->DrawIndexed(g_gIndexCount, 0, 0);
+
+            DXGI_PRESENT_PARAMETERS pp;
+            ZeroMemory(&pp, sizeof(pp));
+            swapChain->Present1(0, 0, &pp);
+        }
+
+        if (firstFrame) {
+            ShowWindow(hGhost, SW_SHOWNOACTIVATE);
+            firstFrame = FALSE;
+            // Ghost's first frame is up: release the minimize/restore hook so the
+            // real window only changes now, not before the ghost exists.
+            if (data->hReady) SetEvent(data->hReady);
+        }
+        if (lastFrame) break;
+        DwmFlush();
+    }
+
+    FinalizeRealWindow(data);
+
+    free(verts);
+    SafeRelease(ctx);
+    SafeRelease(visual);
+    SafeRelease(dcompTarget);
+    SafeRelease(dcompDevice);
+    SafeRelease(vbuf);
+    SafeRelease(rtv);
+    SafeRelease(swapChain);
+    SafeRelease(srv);
+    SafeRelease(srcTex);
+    return true;
+}
+
+// -------------------------------------------------------------------------
+// Animation Thread
+// -------------------------------------------------------------------------
+DWORD WINAPI GhostAnimationThread(LPVOID lpParam) {
+    GhostAnimData* data = (GhostAnimData*)lpParam;
+
+    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
+
+    int screenHeight = GetSystemMetrics(SM_CYSCREEN);
+    int screenWidth  = GetSystemMetrics(SM_CXSCREEN);
+
+    RECT workArea;
+    SystemParametersInfoW(SPI_GETWORKAREA, 0, &workArea, 0);
+    float taskbarY = (float)workArea.bottom;
+
+    bool useGpu = EnsureGpuDevice();
+    HWND hGhost = NULL;
+
+    if (useGpu) {
+        // No redirection bitmap: DirectComposition owns every pixel. Full-screen
+        // so content can travel anywhere without being clipped to the window rect.
+        hGhost = CreateWindowExW(
+            WS_EX_NOREDIRECTIONBITMAP | WS_EX_TOOLWINDOW | WS_EX_TOPMOST |
+                WS_EX_TRANSPARENT | WS_EX_NOACTIVATE,
+            L"STATIC", NULL, WS_POPUP,
+            0, 0, screenWidth, screenHeight, NULL, NULL, NULL, NULL);
+
+        bool ran = false;
+        if (hGhost) {
+            ran = (data->mode == MODE_GENIE)
+                    ? RunGpuGenieAnim(data, hGhost, screenWidth, screenHeight, taskbarY)
+                    : RunGpuAnim(data, hGhost, screenWidth, screenHeight, taskbarY);
+        }
+        if (!ran) {
+            useGpu = false;
+            if (hGhost) { DestroyWindow(hGhost); hGhost = NULL; }
+        }
+    }
+
+    if (!useGpu) {
+        // Layered popup sized to the window rect, shown once configured.
+        hGhost = CreateWindowExW(
+            WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_TRANSPARENT,
+            L"STATIC", NULL, WS_POPUP,
+            data->targetRect.left, data->targetRect.top, data->width, data->height,
+            NULL, NULL, NULL, NULL);
+        RunCpuAnim(data, hGhost, screenWidth, screenHeight, taskbarY);
+    }
+
+    if (hGhost) DestroyWindow(hGhost);
+    DeleteObject(data->hBitmap);
+    // Close last: the loop above ran for >= durationMs (>= 50ms), long after the
+    // hook's short bounded wait on this event returned, so there's no race.
+    if (data->hReady) CloseHandle(data->hReady);
+    delete data;
+    return 0;
+}
+
+// -------------------------------------------------------------------------
+// Core Setup Engine & Smart Tracking Logic
+// -------------------------------------------------------------------------
+void StartGenieAnim(HWND hWnd, BOOL rising) {
+    RECT rect;
+    GetWindowRect(hWnd, &rect);
+    int w = rect.right - rect.left;
+    int h = rect.bottom - rect.top;
+
+    if (w <= 0 || h <= 0) return;
+
+    // --- SMART ICON TRACKING ---
+    POINT pt;
+    GetCursorPos(&pt);
+    RECT workArea;
+    SystemParametersInfoW(SPI_GETWORKAREA, 0, &workArea, 0);
+
+    int screenWidth = GetSystemMetrics(SM_CXSCREEN);
+    int learnedTargetX = screenWidth / 2; // Default to center
+
+    // If the mouse is outside the main desktop area (e.g. hovering over the taskbar)
+    if (!PtInRect(&workArea, pt)) {
+        learnedTargetX = pt.x; // Steal the mouse X coordinate!
+        std::lock_guard<std::mutex> lock(g_CacheMutex);
+        g_IconPositions[hWnd] = learnedTargetX; // Save it to the vault
+    } else {
+        // Mouse is on the desktop (clicking the [-] title bar button)
+        std::lock_guard<std::mutex> lock(g_CacheMutex);
+        if (g_IconPositions.count(hWnd)) {
+            learnedTargetX = g_IconPositions[hWnd];
+        }
+    }
+
+    GhostAnimData* data = new GhostAnimData();
+    data->hRealWnd = hWnd;
+    data->targetRect = rect;
+    data->width = w;
+    data->height = h;
+    data->isRising = rising;
+    data->targetDockX = learnedTargetX; // Assign the learned coordinate
+    data->mode = g_mode.load(std::memory_order_relaxed);
+    data->durationMs = g_durations[data->mode].load(std::memory_order_relaxed);
+    data->originalExStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
+
+    HDC hScreenDC = GetDC(NULL);
+    HDC hMemDC = CreateCompatibleDC(hScreenDC);
+    data->hBitmap = CreateCompatibleBitmap(hScreenDC, w, h);
+    HBITMAP hOldBmp = (HBITMAP)SelectObject(hMemDC, data->hBitmap);
+
+    if (rising) {
+        BOOL fromCache = FALSE;
+        {
+            std::lock_guard<std::mutex> lock(g_CacheMutex);
+            if (g_SnapshotCache.count(hWnd)) {
+                HDC hCacheDC = CreateCompatibleDC(hScreenDC);
+                HBITMAP hOldCacheBmp = (HBITMAP)SelectObject(hCacheDC, g_SnapshotCache[hWnd]);
+                BitBlt(hMemDC, 0, 0, w, h, hCacheDC, 0, 0, SRCCOPY);
+                SelectObject(hCacheDC, hOldCacheBmp);
+                DeleteDC(hCacheDC);
+
+                DeleteObject(g_SnapshotCache[hWnd]);
+                g_SnapshotCache.erase(hWnd);
+                fromCache = TRUE;
+            }
+        }
+        if (!fromCache) {
+            PrintWindow(hWnd, hMemDC, PW_CLIENTONLY | 0x00000002);
+        }
+    } else {
+        BitBlt(hMemDC, 0, 0, w, h, hScreenDC, rect.left, rect.top, SRCCOPY);
+
+        std::lock_guard<std::mutex> lock(g_CacheMutex);
+        if (g_SnapshotCache.count(hWnd)) {
+            DeleteObject(g_SnapshotCache[hWnd]);
+        }
+        g_SnapshotCache[hWnd] = CreateCompatibleBitmap(hScreenDC, w, h);
+        HDC hCacheDC = CreateCompatibleDC(hScreenDC);
+        HBITMAP hOldCacheBmp = (HBITMAP)SelectObject(hCacheDC, g_SnapshotCache[hWnd]);
+        BitBlt(hCacheDC, 0, 0, w, h, hMemDC, 0, 0, SRCCOPY);
+        SelectObject(hCacheDC, hOldCacheBmp);
+        DeleteDC(hCacheDC);
+    }
+
+    SelectObject(hMemDC, hOldBmp);
+    DeleteDC(hMemDC);
+    ReleaseDC(NULL, hScreenDC);
+
+    // Anti-flash: block the caller (the minimize/restore hook) until the ghost's
+    // first frame is on screen, so the real window never changes before the
+    // animation exists. Use a LOCAL copy of the handle for the wait — once the
+    // thread is spawned it owns `data` and may free it at any time. The cap (40ms)
+    // sits under the 50ms minimum duration, so the thread's CloseHandle at
+    // animation end can never race this bounded wait.
+    HANDLE hReady = CreateEventW(NULL, TRUE, FALSE, NULL);
+    data->hReady = hReady;
+    HANDLE hThread = CreateThread(NULL, 0, GhostAnimationThread, data, 0, NULL);
+    if (!hThread) {
+        if (hReady) CloseHandle(hReady);
+        DeleteObject(data->hBitmap);
+        delete data;
+        return;
+    }
+    CloseHandle(hThread);
+    if (hReady) WaitForSingleObject(hReady, 40);
+}
+
+// -------------------------------------------------------------------------
+// Hooks
+// -------------------------------------------------------------------------
+BOOL WINAPI ShowWindow_Hook(HWND hWnd, int nCmdShow) {
+    if (g_enabled.load(std::memory_order_relaxed)) {
+        if (nCmdShow == SW_MINIMIZE || nCmdShow == SW_SHOWMINIMIZED || nCmdShow == SW_SHOWMINNOACTIVE) {
+            SetDwmTransitions(hWnd, FALSE);
+            StartGenieAnim(hWnd, FALSE);
+            return ShowWindow_Original(hWnd, nCmdShow);
+        }
+        else if (nCmdShow == SW_RESTORE || nCmdShow == SW_SHOWNORMAL) {
+            if (IsIconic(hWnd)) {
+                SetDwmTransitions(hWnd, FALSE);
+                LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
+                SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
+                SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
+                BOOL res = ShowWindow_Original(hWnd, nCmdShow);
+                StartGenieAnim(hWnd, TRUE);
+                return res;
+            }
+        }
+    }
+    return ShowWindow_Original(hWnd, nCmdShow);
+}
+
+LRESULT WINAPI DefWindowProcW_Hook(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam) {
+    if (Msg == WM_DESTROY) {
+        std::lock_guard<std::mutex> lock(g_CacheMutex);
+        if (g_SnapshotCache.count(hWnd)) {
+            DeleteObject(g_SnapshotCache[hWnd]);
+            g_SnapshotCache.erase(hWnd);
+        }
+        if (g_IconPositions.count(hWnd)) {
+            g_IconPositions.erase(hWnd);
+        }
+    }
+
+    if (g_enabled.load(std::memory_order_relaxed) && Msg == WM_SYSCOMMAND) {
+        UINT cmd = wParam & 0xFFF0;
+        if (cmd == SC_MINIMIZE) {
+            SetDwmTransitions(hWnd, FALSE);
+            StartGenieAnim(hWnd, FALSE);
+            return DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
+        }
+        else if (cmd == SC_RESTORE && IsIconic(hWnd)) {
+            SetDwmTransitions(hWnd, FALSE);
+            LONG_PTR exStyle = GetWindowLongPtrW(hWnd, GWL_EXSTYLE);
+            SetWindowLongPtrW(hWnd, GWL_EXSTYLE, exStyle | WS_EX_LAYERED);
+            SetLayeredWindowAttributes(hWnd, 0, 0, LWA_ALPHA);
+            LRESULT res = DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
+            StartGenieAnim(hWnd, TRUE);
+            return res;
+        }
+    }
+    return DefWindowProcW_Original(hWnd, Msg, wParam, lParam);
+}
+
+BOOL Wh_ModInit() {
+    LoadSettings();
+    Wh_SetFunctionHook((void*)DefWindowProcW, (void*)DefWindowProcW_Hook, (void**)&DefWindowProcW_Original);
+    Wh_SetFunctionHook((void*)ShowWindow, (void*)ShowWindow_Hook, (void**)&ShowWindow_Original);
+    return TRUE;
+}
+
+void Wh_ModSettingsChanged() {
+    LoadSettings();
+}
+
+void Wh_ModUninit() {
+    {
+        std::lock_guard<std::mutex> lock(g_CacheMutex);
+        for (auto& pair : g_SnapshotCache) {
+            DeleteObject(pair.second);
+        }
+        g_SnapshotCache.clear();
+        g_IconPositions.clear();
+    }
+    // Any in-flight animation threads own their own DirectComposition devices and
+    // will finish shortly; only the shared D3D device + factory live here.
+    ReleaseGenieGpuResources();
+    ReleaseGpuDevice();
+}


### PR DESCRIPTION
GPU-accelerated minimize/restore animation pack featuring a true mesh-warped Genie (Magic Lamp) bend plus nine additional effects: Vacuum, Glide, Pop, Slide, Free Fall, Warp, Squash, Roll-Up, and Swirl. Each effect has an independent duration slider and a master enable switch.

Rendering uses DirectComposition -- each frame pushes only a transform + opacity, or for Genie, a per-frame HLSL-warped tessellated mesh. This keeps performance smooth on high-refresh displays (120+ Hz) with minimal CPU usage. When the GPU/shader path cannot initialize in a given process, the mod falls back silently to the original GDI renderer so no window is left without animation. Multi-monitor setups are fully supported via virtual-screen rendering.

## Changelog

* **Double-animation guard:** per-window `g_inSysCmd` guard so `ShowWindow_Hook` skips animation when nested inside `DefWindowProcW_Hook`'s `SC_MINIMIZE`/`SC_RESTORE` handling, preventing a grey frame flash.
* **DwmFlush before ShowWindow:** first-frame `DwmFlush()` before `ShowWindow()` in all three render paths (CPU, GPU, Genie GPU).
* **Initial Commit + DwmFlush in GPU setup:** `dcompDevice->Commit()` + `DwmFlush()` after visual-tree setup to prevent a blank first frame.
* **Restore cloak:** `DWMWA_CLOAK` set before restoring the real window; `wasCloaked` field in `GhostAnimData`; uncloaked in `FinalizeRealWindow`.
* **Eager GPU init:** `EnsureGpuDevice()` + `EnsureGenieGpuResources()` called in `Wh_ModInit()` to avoid first-frame stall.
* **Ghost window background:** `SetClassLongPtr(hGhost, GCLP_HBRBACKGROUND, GetStockObject(NULL_BRUSH))` for both GPU and CPU path to suppress WM_ERASEBKGND flashes.
* **Target locks to taskbar icon centre (not cursor):** `GetTaskbarIconCenter` function finds the exact taskbar button rect via `ToolbarWindow32` → `TB_BUTTONCOUNT` / `TB_GETBUTTON` / `TB_GETRECT`, matching by `dwData == HWND`. The horizontal centre of the icon button is used as the animation X target; the vertical target stays at the top edge of the taskbar (`rcWork.bottom`). Removed stale cursor-tracking cache.
* **Animation shrinks to icon button width:** `GetTaskbarIconCenter` now also returns the full clickable button width. For Genie/Vacuum/Warp/Swirl the final `scaleX` is clamped to `iconButtonWidth / windowWidth`, and the Genie mesh `neckW` uses the icon width directly, so the ribbon contracts to exactly the taskbar icon block instead of a hardcoded 3-5% of the window size.

## Mod authorship

This mod was created by:
- [x] The submitter, with AI assistance