### PR TITLE
Added taskbar activation threshold mod

### DIFF
--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -15,130 +15,58 @@
 /*
 # Taskbar Activation Threshold
 
-Reveal the auto-hidden Windows 11 taskbar from a configurable activation band
-above the bottom edge of the screen.
-
-The cursor stays stationary. The mod tracks cursor movement, asks Explorer to
-keep the target taskbar expanded while the pointer remains in the configured
-region, and uses Explorer's native taskbar show/hide paths on the taskbar UI
-thread.
-
-## Demonstration
+Reveal the auto-hidden Windows 11 taskbar when the pointer enters a configurable
+band above the bottom edge of the screen. The pointer itself is never moved.
 
 ![Taskbar Activation Threshold demonstration](https://raw.githubusercontent.com/themagnificentoofman/taskbar-activation-threshold-assets/main/taskbar-activation-threshold-demo.gif)
 
-## Features
-
-- Configurable activation-band height and hover delay
-- Per-monitor DPI scaling
-- Multi-monitor and secondary-taskbar support
-- Adjustable release delay
-- Optional fullscreen/presentation suppression
-- Optional suppression while a mouse button is held
-- Optional primary-monitor-only mode
-- No cursor injection, taskbar layout changes, synthetic pointer-over state, or
-  taskbar Z-order forcing
-
 ## Behavior
 
-The activation threshold controls where the taskbar can be revealed. After the
-hover delay, the mod marks that taskbar as "keep shown", calls Explorer's native
-unhide path, and asks `ViewCoordinator` to re-evaluate expansion. Explorer's own
-pointer-over notifications continue normally; the mod doesn't swallow or forge
-them.
+After the hover delay, the mod asks Explorer to keep the taskbar shown and uses
+Explorer's native unhide path. The taskbar stays available while the pointer is
+over the visible taskbar or inside the lower part of the activation band. After
+the pointer leaves, the release delay runs and Explorer resumes its normal
+hide policy. While the hold request is active, Explorer hide requests are
+intentionally deferred; leaving the hold area restores stock behavior. Open
+Start/tray flyouts are respected: release doesn't force the hide timer when
+Explorer still wants the taskbar expanded.
 
-The keep-shown policy remains active while the pointer is inside either the
-activation band or the visible taskbar. After the pointer leaves both, the
-release delay runs. The mod then removes its keep-shown policy and asks Explorer
-to resume its normal auto-hide path. Because the state lives only in this mod's
-hooks, disabling or unloading the mod can't leave Explorer with a synthetic
-pointer-over state latched.
+The configured threshold is used for the initial trigger. Once the taskbar is
+shown, the hold-open band is capped to the taskbar's own height, so very large
+thresholds don't create a floating hold-open strip above the taskbar.
 
-The default band is 12 DIPs. With a typical Windows 11 taskbar this is shorter
-than the taskbar itself, so the threshold mainly changes the trigger area; once
-revealed, the taskbar's own rectangle keeps it available while you use its
-buttons. Values larger than the taskbar height also create a hold-open strip
-above the visible taskbar and are intentionally more aggressive.
-
-Moving directly from one monitor's activation band to another releases the old
-monitor immediately and starts the new monitor's hover delay instead of stacking
-the old release delay with the new hover delay.
+Multi-monitor and secondary taskbars are supported. Moving directly from one
+monitor's activation band to another releases the old taskbar immediately and
+starts the new monitor's hover delay.
 
 ## Compatibility
 
-The mod is intended for the standard bottom-positioned Windows 11 taskbar. It
-doesn't modify taskbar XAML, height, icon size, animation duration,
-transparency, the Windows auto-hide setting, or Z-order.
-
-Taskbar Z-order remains Explorer's responsibility. Reveals go through the native
-`TrayUI::Unhide` / `CSecondaryTray::_Unhide` path before the expansion
-re-evaluation, but the mod never calls `SetWindowPos` or forces `HWND_TOPMOST`.
-This preserves Explorer's normal layering behavior and avoids fighting
-always-on-top applications or Z-order customization mods.
-
-**Taskbar auto-hide custom activation area** controls where along the taskbar a
-native edge trigger is accepted, while this mod adds trigger depth perpendicular
-to the bottom edge. These are closely related catalog features and may be better
-consolidated if the maintainer prefers. This implementation no longer hooks or
-suppresses `HandleIsPointerOverTaskbarFrameChanged`, so it doesn't hide
-pointer-leave notifications from that mod or from **Taskbar auto-hide fine
-tuning**. Mods that intentionally replace Explorer's hide/show policy can still
-conflict with the keep-shown hooks used here. Release uses Explorer's native
-hide timer and expansion reevaluation, so mods that intercept the hide timer or
-`TrayUI::_Hide` / `CSecondaryTray::_AutoHide` can alter release behavior.
-
-Mods that deliberately disable mouse-triggered taskbar reveals remain
-incompatible with the purpose of this mod.
-
-## Requirements
-
-- Windows 11
-- Standard Windows 11 taskbar
-- Bottom-positioned taskbar
-- **Automatically hide the taskbar** enabled, unless **Require Windows
-  auto-hide** is disabled
-
-## Known limitations
-
-- Top-, left-, right-, detached-, floating-, and arbitrary-position taskbars
-  aren't supported. Bottom placement is inferred from the live taskbar window
-  rectangle; mods that substantially reposition or resize the taskbar can make
-  the geometry check reject it.
-- ExplorerPatcher's legacy Windows 10 taskbar isn't supported.
-- The Windows `ABM_GETSTATE` auto-hide flag is system-wide. With per-monitor
-  auto-hide mods, **Require Windows auto-hide** can't determine the auto-hide
-  state of an individual monitor.
-- Reveal depends on undocumented Windows 11 taskbar symbols, including
-  `ViewCoordinator::ShouldTaskbarBeExpanded`, `ViewCoordinator::UpdateIsExpanded`,
-  `TrayUI::_Hide` / `TrayUI::Unhide`, and the corresponding secondary-taskbar
-  paths. A Windows update can require symbol updates. Secondary-taskbar symbols
-  are optional so a secondary symbol change doesn't disable the primary taskbar.
-- Fullscreen suppression checks Windows presentation/exclusive-fullscreen state
-  and the topmost eligible application window on the target monitor. Windows
-  presentation mode is system-wide. Background fullscreen windows behind another
-  normal app don't suppress the band. Click-through, tool, non-activating,
-  cloaked, desktop, and taskbar windows are ignored. A borderless window that
-  covers the monitor is intentionally treated as fullscreen even if the app
-  describes that state as maximized. The top-window verdict is cached for up to
-  one second to keep fullscreen detection off the cursor hot path. Suppression is
-  a pre-reveal gate; it doesn't continuously force-hide a taskbar if an app
-  becomes fullscreen after the reveal.
-- Cursor tracking uses a system-wide `EVENT_OBJECT_LOCATIONCHANGE` WinEvent hook
-  because Windows can't filter it to `OBJID_CURSOR` at registration time. The OS
-  still delivers other location-change events to the hook; the callback discards
-  them immediately. If the hook can't be installed, a 150 ms cursor-check timer
-  is used instead.
-- Transient reveal blockers such as a held mouse button, fullscreen app, or a
-  taskbar coordinator that hasn't been observed yet are retried at most once per
-  second while the pointer remains parked in the band. Settings-only conditions
-  and monitors without a supported taskbar are event-driven and aren't polled.
+- Windows 11 with the standard bottom-positioned taskbar.
+- **Automatically hide the taskbar** should normally be enabled. The optional
+  check uses Windows' system-wide auto-hide flag, so per-monitor auto-hide mods
+  can't be distinguished perfectly.
+- The mod doesn't move the cursor, synthesize taskbar pointer-over state, change
+  taskbar layout/XAML, alter animation speed, or force taskbar Z-order.
+  Explorer's native unhide path remains responsible for layering.
+- ExplorerPatcher's legacy Windows 10 taskbar and substantially repositioned,
+  detached, floating, top, left, or right taskbars aren't supported.
+- Fullscreen suppression applies before reveal to Windows presentation/exclusive
+  fullscreen state and to the foreground fullscreen app on the target monitor.
+  A background fullscreen app doesn't block the band. If an app becomes
+  fullscreen after the taskbar is already being held open, the taskbar is
+  released when the pointer leaves the hold area.
+- **Taskbar auto-hide custom activation area** controls where along the edge a
+  native trigger is accepted; this mod adds trigger depth above the edge. These
+  are closely related catalog features and may be better consolidated if the
+  maintainer prefers. Mods that replace Explorer's hide/show policy can still
+  interact with this mod's keep-shown hooks.
 
 ## Attribution and license
 
-The Windows 11 taskbar symbols and keep-shown pattern were informed by
-GPL-3.0-licensed Windhawk taskbar mods by m417z, especially **Taskbar auto-hide
-when maximized**, **Taskbar auto-hide fine tuning**, and **Taskbar auto-hide
-custom activation area**.
+The Windows 11 taskbar symbols and keep-shown pattern are based on GPL-3.0
+Windhawk taskbar mods by m417z, especially **Taskbar auto-hide when maximized**,
+**Taskbar auto-hide fine tuning**, and **Taskbar auto-hide custom activation
+area**.
 
 This mod is distributed under the GNU General Public License v3.0.
 */
@@ -149,33 +77,29 @@ This mod is distributed under the GNU General Public License v3.0.
 - activationThresholdPx: 12
   $name: Activation threshold
   $description: >-
-    Height of the activation band in logical pixels at 96 DPI, scaled for each
-    monitor. 8-24 is a practical range for most taskbars. Larger values are more
-    aggressive and, once taller than the taskbar, also create a hold-open strip
-    above it.
+    Height of the activation band in logical pixels at 96 DPI, scaled per
+    monitor. 8-24 is a practical range for most taskbars.
 - activationDelayMs: 75
   $name: Hover delay
   $description: >-
     Time the pointer must remain in the activation band before revealing the
-    taskbar. A short delay helps avoid accidental reveals when crossing between
-    vertically stacked monitors.
+    taskbar. A short delay helps prevent accidental reveals.
 - releaseDelayMs: 120
   $name: Release delay
   $description: >-
-    Delay before Explorer is allowed to hide the taskbar after the pointer leaves
-    both the activation band and the visible taskbar.
+    Delay before the mod releases its keep-shown request after the pointer leaves
+    both the visible taskbar and the active hold area.
 - requireWindowsAutoHide: true
   $name: Require Windows auto-hide
   $description: >-
     Only activate when Windows' system-wide auto-hide flag is enabled. Disable
-    this if another mod manages auto-hide independently; per-monitor auto-hide
-    states can't be distinguished by this Windows flag.
+    this if another mod manages auto-hide; per-monitor states can't be detected
+    through this Windows flag.
 - ignoreFullscreenApps: true
   $name: Ignore fullscreen apps
   $description: >-
     Don't reveal during Windows presentation/exclusive-fullscreen state or when
-    the topmost eligible app on the target monitor is fullscreen. Background
-    fullscreen apps behind another normal app don't suppress activation.
+    the foreground app on the target monitor is fullscreen.
 - ignoreWhileMouseButtonDown: true
   $name: Ignore while dragging
   $description: >-
@@ -195,8 +119,6 @@ This mod is distributed under the GNU General Public License v3.0.
 
 #include <algorithm>
 #include <atomic>
-#include <cstddef>
-#include <cstdint>
 #include <cwchar>
 #include <mutex>
 #include <unordered_map>
@@ -213,38 +135,511 @@ struct Settings {
 
 Settings g_settings;
 
+constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
+constexpr UINT kTransientRetryMs = 1000;
+constexpr UINT_PTR kTrayUITimerHide = 2;
+constexpr size_t kMaxInterfaceSlots = 20;
+
+std::atomic<bool> g_unloading{false};
 std::atomic<bool> g_taskbarViewDllLoaded{false};
 std::atomic<bool> g_viewCoordinatorSupportAvailable{false};
+std::atomic<bool> g_secondaryTaskbarSupportAvailable{false};
 std::atomic<DWORD> g_workerThreadId{0};
 std::atomic<bool> g_cursorUpdatePosted{false};
+std::atomic<bool> g_workerStateDirty{true};
 std::atomic<HWND> g_mainTaskbarWindow{nullptr};
-std::atomic<bool> g_secondaryTaskbarSupportAvailable{false};
 std::atomic<HWND> g_desiredKeptShownTaskbar{nullptr};
-std::atomic<HWND> g_appliedKeptShownTaskbar{nullptr};
 
 HANDLE g_stopEvent = nullptr;
 HANDLE g_workerThread = nullptr;  // Guarded by g_workerThreadMutex.
 std::mutex g_workerThreadMutex;
-std::atomic<bool> g_unloading{false};
-
-// Registered in Wh_ModInit rather than during DLL initialization, avoiding
-// user32 calls while the loader lock is held.
 UINT g_updateTaskbarStateMessage = 0;
 
-constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
-constexpr UINT kTransientRetryIntervalMs = 1000;
-constexpr UINT_PTR kTrayUITimerHide = 2;
-constexpr ULONGLONG kFullscreenCacheDurationMs = 1000;
-
-// These containers are accessed from Explorer's taskbar UI thread by the
-// hooked taskbar methods and the registered taskbar-state message.
-std::unordered_map<HWND, void*> g_trayUiWndProcObjects;
-std::unordered_map<HWND, void*> g_secondaryTrayObjects;
+// Taskbar UI-thread state. Explorer's taskbar hooks run on the shell taskbar
+// thread, matching the convention used by the maintained taskbar mods.
 std::unordered_map<HWND, void*> g_viewCoordinators;
 std::unordered_map<void*, HWND> g_taskbarsKeptShown;
 
 void* g_trayUiVtableIInspectable = nullptr;
 void* g_trayUiVtableITrayComponentHost = nullptr;
+
+using TrayUI_Hide_t = void(WINAPI*)(void* trayUiInspectable);
+using CSecondaryTray_AutoHide_t =
+    void(WINAPI*)(void* secondaryTray, bool parameter);
+using TrayUI_Unhide_t =
+    void(WINAPI*)(void* trayComponentHost, int trayUnhideFlags, int request);
+using CSecondaryTray_Unhide_t =
+    void(WINAPI*)(void* secondaryTray, int trayUnhideFlags, int request);
+using TrayUI_WndProc_t =
+    LRESULT(WINAPI*)(void* trayUi,
+                     HWND window,
+                     UINT message,
+                     WPARAM wParam,
+                     LPARAM lParam,
+                     bool* handled);
+using CSecondaryTray_WndProc_t =
+    LRESULT(WINAPI*)(void* secondaryTray,
+                     HWND window,
+                     UINT message,
+                     WPARAM wParam,
+                     LPARAM lParam);
+using ViewCoordinator_ShouldTaskbarBeExpanded_t =
+    bool(WINAPI*)(void* viewCoordinator, HWND taskbarWindow, bool expanded);
+using ViewCoordinator_UpdateIsExpanded_t =
+    void(WINAPI*)(void* viewCoordinator, HWND taskbarWindow, int reason);
+
+TrayUI_Hide_t TrayUI_Hide_Original;
+CSecondaryTray_AutoHide_t CSecondaryTray_AutoHide_Original;
+TrayUI_Unhide_t TrayUI_Unhide_Original;
+CSecondaryTray_Unhide_t CSecondaryTray_Unhide_Original;
+TrayUI_WndProc_t TrayUI_WndProc_Original;
+CSecondaryTray_WndProc_t CSecondaryTray_WndProc_Original;
+ViewCoordinator_ShouldTaskbarBeExpanded_t
+    ViewCoordinator_ShouldTaskbarBeExpanded_Original;
+ViewCoordinator_UpdateIsExpanded_t ViewCoordinator_UpdateIsExpanded_Original;
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t LoadLibraryExW_Original;
+
+DWORD WINAPI ActivationWorkerThread(LPVOID);
+
+void LoadSettings() {
+    g_settings.activationThresholdPx =
+        std::clamp(Wh_GetIntSetting(L"activationThresholdPx"), 1, 500);
+    g_settings.activationDelayMs =
+        std::clamp(Wh_GetIntSetting(L"activationDelayMs"), 0, 1000);
+    g_settings.releaseDelayMs =
+        std::clamp(Wh_GetIntSetting(L"releaseDelayMs"), 0, 5000);
+    g_settings.requireWindowsAutoHide =
+        Wh_GetIntSetting(L"requireWindowsAutoHide") != 0;
+    g_settings.ignoreFullscreenApps =
+        Wh_GetIntSetting(L"ignoreFullscreenApps") != 0;
+    g_settings.ignoreWhileMouseButtonDown =
+        Wh_GetIntSetting(L"ignoreWhileMouseButtonDown") != 0;
+    g_settings.primaryMonitorOnly =
+        Wh_GetIntSetting(L"primaryMonitorOnly") != 0;
+}
+
+void QueuePointerStateUpdate() {
+    DWORD threadId = g_workerThreadId.load();
+    if (!threadId || g_cursorUpdatePosted.exchange(true)) {
+        return;
+    }
+
+    if (!PostThreadMessageW(threadId, kWorkerCursorChangedMessage, 0, 0)) {
+        g_cursorUpdatePosted = false;
+        Wh_Log(L"Couldn't queue pointer-state update: %u", GetLastError());
+    }
+}
+
+void EnsureActivationWorker() {
+    if (g_workerThreadId.load() || g_unloading.load() || !g_stopEvent) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> guard(g_workerThreadMutex);
+    if (g_workerThreadId.load() || g_unloading.load()) {
+        return;
+    }
+
+    if (g_workerThread) {
+        DWORD state = WaitForSingleObject(g_workerThread, 0);
+        if (state == WAIT_TIMEOUT) {
+            return;
+        }
+        if (state != WAIT_OBJECT_0) {
+            Wh_Log(L"Couldn't query activation worker state: %u",
+                   GetLastError());
+            return;
+        }
+        CloseHandle(g_workerThread);
+        g_workerThread = nullptr;
+    }
+
+    g_workerThread =
+        CreateThread(nullptr, 0, ActivationWorkerThread, nullptr, 0, nullptr);
+    if (!g_workerThread) {
+        Wh_Log(L"CreateThread failed: %u", GetLastError());
+    }
+}
+
+enum class TaskbarKind {
+    kNone,
+    kMain,
+    kSecondary,
+};
+
+TaskbarKind GetTaskbarKind(HWND window) {
+    wchar_t className[64];
+    if (!window ||
+        !GetClassNameW(window, className, ARRAYSIZE(className))) {
+        return TaskbarKind::kNone;
+    }
+
+    if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
+        return TaskbarKind::kMain;
+    }
+    if (_wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0) {
+        return TaskbarKind::kSecondary;
+    }
+    return TaskbarKind::kNone;
+}
+
+bool IsCurrentProcessWindow(HWND window) {
+    DWORD processId = 0;
+    return window && GetWindowThreadProcessId(window, &processId) != 0 &&
+           processId == GetCurrentProcessId();
+}
+
+bool IsSupportedTaskbarWindow(HWND window) {
+    TaskbarKind kind = GetTaskbarKind(window);
+    return IsCurrentProcessWindow(window) &&
+           (kind == TaskbarKind::kMain ||
+            (kind == TaskbarKind::kSecondary &&
+             g_secondaryTaskbarSupportAvailable.load()));
+}
+
+HMONITOR GetTaskbarMonitor(HWND taskbarWindow) {
+    if (HMONITOR monitor = reinterpret_cast<HMONITOR>(
+            GetPropW(taskbarWindow, L"TaskbarMonitor"))) {
+        MONITORINFO info{};
+        info.cbSize = sizeof(info);
+        if (GetMonitorInfoW(monitor, &info)) {
+            return monitor;
+        }
+    }
+    return MonitorFromWindow(taskbarWindow, MONITOR_DEFAULTTONEAREST);
+}
+
+struct MonitorData {
+    RECT rect{};
+    UINT dpiY = 96;
+    bool primary = false;
+};
+
+struct WorkerTimer {
+    UINT_PTR id = 0;
+    ULONGLONG dueAt = 0;
+};
+
+struct WorkerState {
+    HWND activeTaskbar = nullptr;
+    HMONITOR activeMonitor = nullptr;
+    HMONITOR hoverMonitor = nullptr;
+    HMONITOR consumedBandMonitor = nullptr;
+    ULONGLONG hoverSince = 0;
+    WorkerTimer releaseTimer;
+    WorkerTimer retryTimer;
+    std::unordered_map<HMONITOR, MonitorData> monitors;
+    std::unordered_map<HMONITOR, HWND> taskbars;
+};
+
+bool GetMonitorData(WorkerState& state,
+                    HMONITOR monitor,
+                    MonitorData* data) {
+    if (!monitor || !data) {
+        return false;
+    }
+
+    auto it = state.monitors.find(monitor);
+    if (it != state.monitors.end()) {
+        *data = it->second;
+        return true;
+    }
+
+    MONITORINFO info{};
+    info.cbSize = sizeof(info);
+    if (!GetMonitorInfoW(monitor, &info)) {
+        return false;
+    }
+
+    UINT dpiX = 96;
+    UINT dpiY = 96;
+    if (FAILED(GetDpiForMonitor(monitor,
+                                MDT_EFFECTIVE_DPI,
+                                &dpiX,
+                                &dpiY))) {
+        dpiY = 96;
+    }
+
+    MonitorData value;
+    value.rect = info.rcMonitor;
+    value.dpiY = dpiY;
+    value.primary = (info.dwFlags & MONITORINFOF_PRIMARY) != 0;
+    state.monitors.emplace(monitor, value);
+    *data = value;
+    return true;
+}
+
+int ScaleDip(int logicalPixels, UINT dpiY) {
+    return std::max(1, MulDiv(logicalPixels, dpiY ? dpiY : 96, 96));
+}
+
+bool IsPointInBottomBand(const POINT& pointer,
+                         const MonitorData& monitor,
+                         int logicalHeight) {
+    int monitorHeight = monitor.rect.bottom - monitor.rect.top;
+    int height = std::min(ScaleDip(logicalHeight, monitor.dpiY),
+                          monitorHeight);
+    return pointer.x >= monitor.rect.left &&
+           pointer.x < monitor.rect.right &&
+           pointer.y >= monitor.rect.bottom - height &&
+           pointer.y < monitor.rect.bottom;
+}
+
+bool IsBottomTaskbar(HWND taskbarWindow,
+                     HMONITOR monitor,
+                     const MonitorData& data) {
+    RECT rect{};
+    if (!GetWindowRect(taskbarWindow, &rect)) {
+        return false;
+    }
+
+    int monitorWidth = data.rect.right - data.rect.left;
+    int monitorHeight = data.rect.bottom - data.rect.top;
+    int width = rect.right - rect.left;
+    int height = rect.bottom - rect.top;
+    if (width < monitorWidth / 2 || height <= 0 ||
+        height > monitorHeight / 2) {
+        return false;
+    }
+
+    int tolerance = ScaleDip(2, data.dpiY);
+    return GetTaskbarMonitor(taskbarWindow) == monitor &&
+           rect.top <= data.rect.bottom + tolerance &&
+           rect.bottom >= data.rect.bottom - tolerance;
+}
+
+HWND FindMainTaskbarWindow() {
+    HWND cached = g_mainTaskbarWindow.load();
+    if (cached && IsCurrentProcessWindow(cached) &&
+        GetTaskbarKind(cached) == TaskbarKind::kMain) {
+        return cached;
+    }
+
+    HWND result = nullptr;
+    EnumWindows(
+        [](HWND window, LPARAM parameter) -> BOOL {
+            if (IsCurrentProcessWindow(window) &&
+                GetTaskbarKind(window) == TaskbarKind::kMain) {
+                *reinterpret_cast<HWND*>(parameter) = window;
+                return FALSE;
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&result));
+    g_mainTaskbarWindow = result;
+    return result;
+}
+
+struct FindTaskbarContext {
+    HMONITOR monitor;
+    const MonitorData* data;
+    HWND result;
+};
+
+HWND FindTaskbarForMonitor(HMONITOR monitor, const MonitorData& data) {
+    HWND mainTaskbar = FindMainTaskbarWindow();
+    if (mainTaskbar && IsBottomTaskbar(mainTaskbar, monitor, data)) {
+        return mainTaskbar;
+    }
+
+    FindTaskbarContext context{monitor, &data, nullptr};
+    EnumWindows(
+        [](HWND window, LPARAM parameter) -> BOOL {
+            auto* context =
+                reinterpret_cast<FindTaskbarContext*>(parameter);
+            if (!IsSupportedTaskbarWindow(window) ||
+                GetTaskbarKind(window) != TaskbarKind::kSecondary) {
+                return TRUE;
+            }
+            if (IsBottomTaskbar(window,
+                                context->monitor,
+                                *context->data)) {
+                context->result = window;
+                return FALSE;
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&context));
+    return context.result;
+}
+
+HWND GetCachedTaskbarForMonitor(WorkerState& state,
+                                HMONITOR monitor,
+                                const MonitorData& data) {
+    auto it = state.taskbars.find(monitor);
+    if (it != state.taskbars.end()) {
+        if (!it->second) {
+            return nullptr;
+        }
+        if (IsSupportedTaskbarWindow(it->second) &&
+            IsBottomTaskbar(it->second, monitor, data)) {
+            return it->second;
+        }
+        state.taskbars.erase(it);
+    }
+
+    HWND taskbarWindow = FindTaskbarForMonitor(monitor, data);
+    state.taskbars[monitor] = taskbarWindow;
+    return taskbarWindow;
+}
+
+bool IsPointInActiveHoldArea(HWND taskbarWindow,
+                             const POINT& pointer,
+                             const MonitorData& monitor) {
+    RECT taskbarRect{};
+    if (!GetWindowRect(taskbarWindow, &taskbarRect)) {
+        return false;
+    }
+
+    if (PtInRect(&taskbarRect, pointer)) {
+        return true;
+    }
+
+    int taskbarHeight = std::max(1, static_cast<int>(taskbarRect.bottom - taskbarRect.top));
+    int triggerHeight = ScaleDip(g_settings.activationThresholdPx.load(),
+                                 monitor.dpiY);
+    int holdHeight = std::min(triggerHeight, taskbarHeight);
+    return pointer.x >= monitor.rect.left &&
+           pointer.x < monitor.rect.right &&
+           pointer.y >= monitor.rect.bottom - holdHeight &&
+           pointer.y < monitor.rect.bottom;
+}
+
+bool IsWindowsAutoHideEnabled() {
+    APPBARDATA data{};
+    data.cbSize = sizeof(data);
+    return (SHAppBarMessage(ABM_GETSTATE, &data) & ABS_AUTOHIDE) != 0;
+}
+
+bool IsAnyMouseButtonDown() {
+    constexpr int buttons[] = {
+        VK_LBUTTON,
+        VK_RBUTTON,
+        VK_MBUTTON,
+        VK_XBUTTON1,
+        VK_XBUTTON2,
+    };
+    for (int button : buttons) {
+        if ((GetAsyncKeyState(button) & 0x8000) != 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool IsWindowCloaked(HWND window) {
+    BOOL cloaked = FALSE;
+    return SUCCEEDED(DwmGetWindowAttribute(
+               window, DWMWA_CLOAKED, &cloaked, sizeof(cloaked))) &&
+           cloaked;
+}
+
+bool IsFullscreenForegroundWindow(HMONITOR monitor,
+                                  const MonitorData& data) {
+    QUERY_USER_NOTIFICATION_STATE notification = QUNS_ACCEPTS_NOTIFICATIONS;
+    if (SUCCEEDED(SHQueryUserNotificationState(&notification))) {
+        if (notification == QUNS_PRESENTATION_MODE) {
+            return true;
+        }
+        if (notification == QUNS_RUNNING_D3D_FULL_SCREEN) {
+            HWND foreground = GetForegroundWindow();
+            return foreground &&
+                   MonitorFromWindow(foreground,
+                                     MONITOR_DEFAULTTONEAREST) == monitor;
+        }
+    }
+
+    HWND window = GetForegroundWindow();
+    if (!window || !IsWindowVisible(window) || IsIconic(window) ||
+        MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST) != monitor) {
+        return false;
+    }
+
+    LONG_PTR style = GetWindowLongPtrW(window, GWL_STYLE);
+    LONG_PTR exStyle = GetWindowLongPtrW(window, GWL_EXSTYLE);
+    if ((style & WS_CHILD) != 0 ||
+        (exStyle & (WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW |
+                    WS_EX_NOACTIVATE)) != 0 ||
+        window == GetShellWindow() || IsWindowCloaked(window)) {
+        return false;
+    }
+
+    wchar_t className[64];
+    if (GetClassNameW(window, className, ARRAYSIZE(className)) &&
+        (_wcsicmp(className, L"Progman") == 0 ||
+         _wcsicmp(className, L"WorkerW") == 0 ||
+         _wcsicmp(className, L"Shell_TrayWnd") == 0 ||
+         _wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0)) {
+        return false;
+    }
+
+    // A styled maximized window fills the work area, which equals the monitor
+    // while auto-hide is enabled. Don't mistake that for fullscreen. Borderless
+    // windows are intentionally allowed through this guard.
+    if ((style & (WS_CAPTION | WS_THICKFRAME)) != 0 && IsZoomed(window)) {
+        return false;
+    }
+
+    RECT rect{};
+    if (FAILED(DwmGetWindowAttribute(window,
+                                     DWMWA_EXTENDED_FRAME_BOUNDS,
+                                     &rect,
+                                     sizeof(rect))) &&
+        !GetWindowRect(window, &rect)) {
+        return false;
+    }
+
+    int tolerance = ScaleDip(2, data.dpiY);
+    return rect.left <= data.rect.left + tolerance &&
+           rect.top <= data.rect.top + tolerance &&
+           rect.right >= data.rect.right - tolerance &&
+           rect.bottom >= data.rect.bottom - tolerance;
+}
+
+bool IsReadablePointerSlot(void* slot) {
+    MEMORY_BASIC_INFORMATION info{};
+    return slot && VirtualQuery(slot, &info, sizeof(info)) &&
+           info.State == MEM_COMMIT &&
+           (info.Protect & (PAGE_NOACCESS | PAGE_GUARD)) == 0;
+}
+
+void* FindInterfaceForward(void* object, void* targetVtable) {
+    uintptr_t address = reinterpret_cast<uintptr_t>(object);
+    for (size_t i = 0; i < kMaxInterfaceSlots; i++) {
+        uintptr_t offset = i * sizeof(void*);
+        if (address > UINTPTR_MAX - offset) {
+            break;
+        }
+        auto** slot = reinterpret_cast<void**>(address + offset);
+        if (!IsReadablePointerSlot(slot)) {
+            break;
+        }
+        if (*slot == targetVtable) {
+            return slot;
+        }
+    }
+    return nullptr;
+}
+
+void* FindInterfaceBackward(void* object, void* targetVtable) {
+    uintptr_t address = reinterpret_cast<uintptr_t>(object);
+    for (size_t i = 0; i < kMaxInterfaceSlots; i++) {
+        uintptr_t offset = i * sizeof(void*);
+        if (address < offset) {
+            break;
+        }
+        auto** slot = reinterpret_cast<void**>(address - offset);
+        if (!IsReadablePointerSlot(slot)) {
+            break;
+        }
+        if (*slot == targetVtable) {
+            return slot;
+        }
+    }
+    return nullptr;
+}
 
 bool EraseKeptShownForWindow(HWND taskbarWindow) {
     bool erased = false;
@@ -260,784 +655,33 @@ bool EraseKeptShownForWindow(HWND taskbarWindow) {
     return erased;
 }
 
-void ForgetTaskbarState(HWND taskbarWindow) {
-    g_viewCoordinators.erase(taskbarWindow);
-    EraseKeptShownForWindow(taskbarWindow);
-
-    HWND expected = taskbarWindow;
-    g_desiredKeptShownTaskbar.compare_exchange_strong(
-        expected, nullptr, std::memory_order_acq_rel);
-    expected = taskbarWindow;
-    g_appliedKeptShownTaskbar.compare_exchange_strong(
-        expected, nullptr, std::memory_order_acq_rel);
-}
-
-DWORD WINAPI ActivationWorkerThread(LPVOID);
-void ApplyTaskbarKeepShownStateOnUiThread(HWND taskbarWindow);
-
-void LoadSettings() {
-    g_settings.activationThresholdPx.store(
-        std::clamp(Wh_GetIntSetting(L"activationThresholdPx"), 1, 500),
-        std::memory_order_relaxed);
-
-    g_settings.activationDelayMs.store(
-        std::clamp(Wh_GetIntSetting(L"activationDelayMs"), 0, 1000),
-        std::memory_order_relaxed);
-
-    g_settings.releaseDelayMs.store(
-        std::clamp(Wh_GetIntSetting(L"releaseDelayMs"), 0, 5000),
-        std::memory_order_relaxed);
-
-    g_settings.requireWindowsAutoHide.store(
-        Wh_GetIntSetting(L"requireWindowsAutoHide") != 0,
-        std::memory_order_relaxed);
-
-    g_settings.ignoreFullscreenApps.store(
-        Wh_GetIntSetting(L"ignoreFullscreenApps") != 0,
-        std::memory_order_relaxed);
-
-    g_settings.ignoreWhileMouseButtonDown.store(
-        Wh_GetIntSetting(L"ignoreWhileMouseButtonDown") != 0,
-        std::memory_order_relaxed);
-
-    g_settings.primaryMonitorOnly.store(
-        Wh_GetIntSetting(L"primaryMonitorOnly") != 0,
-        std::memory_order_relaxed);
-}
-
-void EnsureActivationWorker() {
-    if (g_workerThreadId.load(std::memory_order_acquire)) {
-        return;
-    }
-
-    if (g_unloading.load(std::memory_order_acquire) || !g_stopEvent) {
-        return;
-    }
-
-    std::lock_guard<std::mutex> guard(g_workerThreadMutex);
-    if (g_unloading.load(std::memory_order_relaxed)) {
-        return;
-    }
-
-    if (g_workerThread) {
-        const DWORD state = WaitForSingleObject(g_workerThread, 0);
-        if (state == WAIT_TIMEOUT) {
-            return;
-        }
-        if (state == WAIT_OBJECT_0) {
-            CloseHandle(g_workerThread);
-            g_workerThread = nullptr;
-            Wh_Log(L"Restarting activation worker after prior thread exit");
-        } else {
-            Wh_Log(L"Couldn't query activation worker state: %u",
-                   GetLastError());
-            return;
-        }
-    }
-
-    g_workerThread = CreateThread(
-        nullptr, 0, ActivationWorkerThread, nullptr, 0, nullptr);
-    if (!g_workerThread) {
-        Wh_Log(L"CreateThread failed: %u", GetLastError());
-        return;
-    }
-
-    Wh_Log(L"Started activation worker in the taskbar Explorer process");
-}
-
-void QueuePointerStateUpdate() {
-    const DWORD workerThreadId =
-        g_workerThreadId.load(std::memory_order_acquire);
-    if (!workerThreadId ||
-        g_cursorUpdatePosted.exchange(true, std::memory_order_acq_rel)) {
-        return;
-    }
-
-    if (!PostThreadMessageW(workerThreadId,
-                            kWorkerCursorChangedMessage,
-                            0,
-                            0)) {
-        g_cursorUpdatePosted.store(false, std::memory_order_release);
-        Wh_Log(L"Couldn't queue pointer-state update: %u", GetLastError());
-    }
-}
-
-enum class TaskbarKind {
-    kNone,
-    kMain,
-    kSecondary,
-};
-
-TaskbarKind GetTaskbarKind(HWND window) {
-    if (!window) {
-        return TaskbarKind::kNone;
-    }
-
-    wchar_t className[64];
-    if (!GetClassNameW(window, className, ARRAYSIZE(className))) {
-        return TaskbarKind::kNone;
-    }
-
-    if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
-        return TaskbarKind::kMain;
-    }
-    if (_wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0) {
-        return TaskbarKind::kSecondary;
-    }
-    return TaskbarKind::kNone;
-}
-
-bool IsSupportedTaskbarWindow(HWND window) {
-    const TaskbarKind kind = GetTaskbarKind(window);
-    return kind == TaskbarKind::kMain ||
-           (kind == TaskbarKind::kSecondary &&
-            g_secondaryTaskbarSupportAvailable.load(std::memory_order_acquire));
-}
-
-bool IsCurrentProcessWindow(HWND window) {
-    if (!window) {
-        return false;
-    }
-
-    DWORD processId = 0;
-    GetWindowThreadProcessId(window, &processId);
-    return processId == GetCurrentProcessId();
-}
-
-bool IsMainTaskbarWindow(HWND window) {
-    return IsCurrentProcessWindow(window) &&
-           GetTaskbarKind(window) == TaskbarKind::kMain;
-}
-
-HWND FindMainTaskbarWindow() {
-    HWND cached = g_mainTaskbarWindow.load(std::memory_order_relaxed);
-    if (IsMainTaskbarWindow(cached)) {
-        return cached;
-    }
-
-    g_mainTaskbarWindow.store(nullptr, std::memory_order_relaxed);
-
-    HWND taskbarWindow = nullptr;
-    EnumWindows(
-        [](HWND window, LPARAM parameter) -> BOOL {
-            if (IsMainTaskbarWindow(window)) {
-                *reinterpret_cast<HWND*>(parameter) = window;
-                return FALSE;
-            }
-            return TRUE;
-        },
-        reinterpret_cast<LPARAM>(&taskbarWindow));
-
-    if (taskbarWindow) {
-        g_mainTaskbarWindow.store(taskbarWindow, std::memory_order_relaxed);
-    }
-    return taskbarWindow;
-}
-
-HMONITOR GetTaskbarMonitor(HWND taskbarWindow) {
-    if (HMONITOR monitor = reinterpret_cast<HMONITOR>(
-            GetPropW(taskbarWindow, L"TaskbarMonitor"))) {
-        MONITORINFO monitorInfo{};
-        monitorInfo.cbSize = sizeof(monitorInfo);
-        if (GetMonitorInfoW(monitor, &monitorInfo)) {
-            return monitor;
-        }
-    }
-
-    // A display-topology transition can briefly leave TaskbarMonitor pointing
-    // at a retired HMONITOR. Fall back to the window's current nearest monitor.
-    return MonitorFromWindow(taskbarWindow, MONITOR_DEFAULTTONEAREST);
-}
-
-bool LooksLikeHorizontalTaskbarRect(
-    const RECT& taskbarRect,
-    const MONITORINFO& monitorInfo) {
-    const int monitorWidth =
-        monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left;
-    const int monitorHeight =
-        monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top;
-    const int taskbarWidth = taskbarRect.right - taskbarRect.left;
-    const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
-
-    return taskbarWidth >= monitorWidth / 2 && taskbarHeight > 0 &&
-           taskbarHeight <= monitorHeight / 2;
-}
-
-bool IsBottomPositionedTaskbar(HWND taskbarWindow, HMONITOR monitor) {
-    MONITORINFO monitorInfo{};
-    monitorInfo.cbSize = sizeof(monitorInfo);
-    if (!GetMonitorInfoW(monitor, &monitorInfo)) {
-        return false;
-    }
-
-    // The auto-hidden taskbar remains a full-width horizontal window whose
-    // live rectangle sits at or just below the configured monitor edge. Avoid
-    // an extra undocumented symbol and cross-thread query for this check.
-    RECT taskbarRect{};
-    if (!GetWindowRect(taskbarWindow, &taskbarRect) ||
-        !LooksLikeHorizontalTaskbarRect(taskbarRect, monitorInfo)) {
-        return false;
-    }
-
-    // A visible bottom taskbar ends at the monitor bottom; an auto-hidden one
-    // straddles that edge with only a very small strip left onscreen. Scale a
-    // two-DIP tolerance for high-DPI monitors while keeping the test tight
-    // enough to reject detached taskbars.
-    const UINT dpi = GetDpiForWindow(taskbarWindow);
-    const int edgeTolerance =
-        std::max(2, MulDiv(2, dpi ? dpi : 96, 96));
-    return taskbarRect.top <= monitorInfo.rcMonitor.bottom + edgeTolerance &&
-           taskbarRect.bottom >= monitorInfo.rcMonitor.bottom - edgeTolerance;
-}
-
-struct FindTaskbarContext {
-    HMONITOR monitor;
-    HWND result;
-};
-
-BOOL CALLBACK FindTaskbarForMonitorCallback(HWND window, LPARAM parameter) {
-    if (!IsSupportedTaskbarWindow(window)) {
-        return TRUE;
-    }
-
-    DWORD processId = 0;
-    GetWindowThreadProcessId(window, &processId);
-    if (processId != GetCurrentProcessId()) {
-        return TRUE;
-    }
-
-    auto* context = reinterpret_cast<FindTaskbarContext*>(parameter);
-    HMONITOR taskbarMonitor = GetTaskbarMonitor(window);
-
-    if (taskbarMonitor == context->monitor &&
-        IsBottomPositionedTaskbar(window, taskbarMonitor)) {
-        context->result = window;
-        return FALSE;
-    }
-
-    return TRUE;
-}
-
-HWND FindTaskbarForMonitor(HMONITOR monitor) {
-    HWND mainTaskbar = FindMainTaskbarWindow();
-    if (mainTaskbar &&
-        GetTaskbarMonitor(mainTaskbar) == monitor &&
-        IsBottomPositionedTaskbar(mainTaskbar, monitor)) {
-        return mainTaskbar;
-    }
-
-    FindTaskbarContext context{
-        .monitor = monitor,
-        .result = nullptr,
-    };
-
-    EnumWindows(FindTaskbarForMonitorCallback,
-                reinterpret_cast<LPARAM>(&context));
-
-    return context.result;
-}
-
-bool IsWindowsAutoHideEnabled() {
-    APPBARDATA appBarData{};
-    appBarData.cbSize = sizeof(appBarData);
-    return (SHAppBarMessage(ABM_GETSTATE, &appBarData) & ABS_AUTOHIDE) != 0;
-}
-
-bool IsAnyMouseButtonDown() {
-    constexpr int mouseButtons[] = {
-        VK_LBUTTON,
-        VK_RBUTTON,
-        VK_MBUTTON,
-        VK_XBUTTON1,
-        VK_XBUTTON2,
-    };
-
-    for (int virtualKey : mouseButtons) {
-        if ((GetAsyncKeyState(virtualKey) & 0x8000) != 0) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-bool HasDesktopWindowClass(HWND window) {
-    wchar_t className[64];
-    if (!window || !GetClassNameW(window, className, ARRAYSIZE(className))) {
-        return false;
-    }
-
-    return _wcsicmp(className, L"Progman") == 0 ||
-           _wcsicmp(className, L"WorkerW") == 0;
-}
-
-bool IsShellDesktopWindow(HWND window) {
-    return window && IsWindowVisible(window) &&
-           (window == GetShellWindow() || GetPropW(window, L"DesktopWindow"));
-}
-
-bool IsWindowCloaked(HWND window) {
-    BOOL cloaked = FALSE;
-    return SUCCEEDED(DwmGetWindowAttribute(
-               window, DWMWA_CLOAKED, &cloaked, sizeof(cloaked))) &&
-           cloaked;
-}
-
-bool DoesClientAreaCoverMonitor(HWND window,
-                                const MONITORINFO& monitorInfo) {
-    RECT clientRect{};
-    if (!GetClientRect(window, &clientRect)) {
-        return false;
-    }
-
-    POINT points[2] = {
-        {clientRect.left, clientRect.top},
-        {clientRect.right, clientRect.bottom},
-    };
-    SetLastError(ERROR_SUCCESS);
-    if (MapWindowPoints(window, nullptr, points, ARRAYSIZE(points)) == 0 &&
-        GetLastError() != ERROR_SUCCESS) {
-        return false;
-    }
-
-    constexpr int tolerance = 2;
-    return points[0].x <= monitorInfo.rcMonitor.left + tolerance &&
-           points[0].y <= monitorInfo.rcMonitor.top + tolerance &&
-           points[1].x >= monitorInfo.rcMonitor.right - tolerance &&
-           points[1].y >= monitorInfo.rcMonitor.bottom - tolerance;
-}
-
-bool IsFullscreenTopWindow(HWND window,
-                           const RECT& windowRect,
-                           const MONITORINFO& monitorInfo) {
-    constexpr int tolerance = 2;
-    if (windowRect.left > monitorInfo.rcMonitor.left + tolerance ||
-        windowRect.top > monitorInfo.rcMonitor.top + tolerance ||
-        windowRect.right < monitorInfo.rcMonitor.right - tolerance ||
-        windowRect.bottom < monitorInfo.rcMonitor.bottom - tolerance) {
-        return false;
-    }
-
-    const LONG_PTR style = GetWindowLongPtrW(window, GWL_STYLE);
-    if ((style & (WS_CAPTION | WS_THICKFRAME)) == 0) {
-        return true;
-    }
-
-    if (IsZoomed(window)) {
-        return false;
-    }
-
-    return DoesClientAreaCoverMonitor(window, monitorInfo);
-}
-
-bool IsFullscreenOrPresentationNotificationState(HMONITOR monitor) {
-    QUERY_USER_NOTIFICATION_STATE state = QUNS_ACCEPTS_NOTIFICATIONS;
-    if (FAILED(SHQueryUserNotificationState(&state))) {
-        return false;
-    }
-
-    if (state == QUNS_PRESENTATION_MODE) {
-        return true;
-    }
-
-    if (state != QUNS_RUNNING_D3D_FULL_SCREEN) {
-        return false;
-    }
-
-    HWND foregroundWindow = GetForegroundWindow();
-    return foregroundWindow &&
-           MonitorFromWindow(foregroundWindow,
-                             MONITOR_DEFAULTTONEAREST) == monitor;
-}
-
-bool IsFullscreenWindowOnMonitor(HMONITOR monitor) {
-    if (IsFullscreenOrPresentationNotificationState(monitor)) {
-        return true;
-    }
-
-    MONITORINFO monitorInfo{};
-    monitorInfo.cbSize = sizeof(monitorInfo);
-    if (!GetMonitorInfoW(monitor, &monitorInfo)) {
-        return false;
-    }
-
-    struct Context {
-        MONITORINFO monitorInfo;
-        bool fullscreen = false;
-    } context{monitorInfo};
-
-    EnumWindows(
-        [](HWND window, LPARAM parameter) -> BOOL {
-            auto* context = reinterpret_cast<Context*>(parameter);
-
-            if (IsShellDesktopWindow(window)) {
-                return FALSE;
-            }
-            if (!IsWindowVisible(window) || IsIconic(window) ||
-                HasDesktopWindowClass(window) ||
-                GetTaskbarKind(window) != TaskbarKind::kNone) {
-                return TRUE;
-            }
-
-            const LONG_PTR style = GetWindowLongPtrW(window, GWL_STYLE);
-            const LONG_PTR exStyle = GetWindowLongPtrW(window, GWL_EXSTYLE);
-            if ((style & WS_CHILD) != 0 ||
-                (exStyle & (WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW |
-                            WS_EX_NOACTIVATE)) != 0) {
-                return TRUE;
-            }
-
-            RECT windowRect{};
-            RECT intersection{};
-            if (!GetWindowRect(window, &windowRect) ||
-                !IntersectRect(&intersection,
-                               &windowRect,
-                               &context->monitorInfo.rcMonitor) ||
-                IsWindowCloaked(window)) {
-                return TRUE;
-            }
-
-            // This is the topmost eligible app intersecting the target monitor.
-            // Don't continue into background windows after making this decision.
-            context->fullscreen = IsFullscreenTopWindow(
-                window, windowRect, context->monitorInfo);
-            if (context->fullscreen) {
-                DWORD processId = 0;
-                GetWindowThreadProcessId(window, &processId);
-                Wh_Log(L"Fullscreen top window: hwnd=%p pid=%u",
-                       window,
-                       processId);
-            }
-            return FALSE;
-        },
-        reinterpret_cast<LPARAM>(&context));
-
-    return context.fullscreen;
-}
-
-bool IsPointInsideActivationBand(const POINT& pointer,
-                                 const MONITORINFO& monitorInfo,
-                                 UINT dpiY) {
-    const int monitorHeight =
-        monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top;
-
-    const int logicalThreshold =
-        g_settings.activationThresholdPx.load(std::memory_order_relaxed);
-    const int threshold =
-        std::min(MulDiv(logicalThreshold, dpiY, 96), monitorHeight);
-
-    return pointer.x >= monitorInfo.rcMonitor.left &&
-           pointer.x < monitorInfo.rcMonitor.right &&
-           pointer.y >= monitorInfo.rcMonitor.bottom - threshold &&
-           pointer.y < monitorInfo.rcMonitor.bottom;
-}
-
-bool IsPointOverTaskbar(HWND taskbarWindow, const POINT& pointer) {
-    RECT taskbarRect{};
-    return GetWindowRect(taskbarWindow, &taskbarRect) &&
-           PtInRect(&taskbarRect, pointer);
-}
-
-void* QueryViaVtableDirectional(void* object,
-                                  void* targetVtable,
-                                  int direction) {
-    if (!object || !targetVtable || (direction != 1 && direction != -1)) {
-        return nullptr;
-    }
-
-    MEMORY_BASIC_INFORMATION memoryInfo{};
-    if (!VirtualQuery(object, &memoryInfo, sizeof(memoryInfo)) ||
-        memoryInfo.State != MEM_COMMIT ||
-        (memoryInfo.Protect & (PAGE_NOACCESS | PAGE_GUARD)) != 0) {
-        return nullptr;
-    }
-
-    const auto regionStart =
-        reinterpret_cast<uintptr_t>(memoryInfo.BaseAddress);
-    const auto regionEnd = regionStart + memoryInfo.RegionSize;
-    const auto objectAddress = reinterpret_cast<uintptr_t>(object);
-
-    for (size_t i = 0; i < 20; i++) {
-        const uintptr_t byteOffset = i * sizeof(void*);
-        uintptr_t candidateAddress = 0;
-        if (direction > 0) {
-            if (objectAddress > UINTPTR_MAX - byteOffset) {
-                break;
-            }
-            candidateAddress = objectAddress + byteOffset;
-        } else {
-            if (objectAddress < byteOffset) {
-                break;
-            }
-            candidateAddress = objectAddress - byteOffset;
-        }
-
-        if (candidateAddress < regionStart ||
-            candidateAddress > regionEnd - sizeof(void*)) {
-            break;
-        }
-
-        auto** candidate = reinterpret_cast<void**>(candidateAddress);
-        if (*candidate == targetVtable) {
-            return candidate;
-        }
-    }
-
-    return nullptr;
-}
-
-void* QueryViaVtable(void* object, void* targetVtable) {
-    return QueryViaVtableDirectional(object, targetVtable, 1);
-}
-
-void* QueryViaVtableBackwards(void* object, void* targetVtable) {
-    return QueryViaVtableDirectional(object, targetVtable, -1);
-}
-
-using TrayUI_Hide_t = void(WINAPI*)(void* trayUiInspectable);
-TrayUI_Hide_t TrayUI_Hide_Original;
-
-void WINAPI TrayUI_Hide_Hook(void* trayUiInspectable) {
-    auto it = g_taskbarsKeptShown.find(trayUiInspectable);
-    if (!g_unloading.load(std::memory_order_acquire) &&
-        it != g_taskbarsKeptShown.end() &&
-        g_desiredKeptShownTaskbar.load(std::memory_order_acquire) == it->second) {
-        KillTimer(it->second, kTrayUITimerHide);
-        return;
-    }
-
-    TrayUI_Hide_Original(trayUiInspectable);
-}
-
-using CSecondaryTray_AutoHide_t =
-    void(WINAPI*)(void* secondaryTray, bool parameter);
-CSecondaryTray_AutoHide_t CSecondaryTray_AutoHide_Original;
-
-void WINAPI CSecondaryTray_AutoHide_Hook(void* secondaryTray,
-                                         bool parameter) {
-    auto it = g_taskbarsKeptShown.find(secondaryTray);
-    if (!g_unloading.load(std::memory_order_acquire) &&
-        it != g_taskbarsKeptShown.end() &&
-        g_desiredKeptShownTaskbar.load(std::memory_order_acquire) == it->second) {
-        KillTimer(it->second, kTrayUITimerHide);
-        return;
-    }
-
-    CSecondaryTray_AutoHide_Original(secondaryTray, parameter);
-}
-
-using TrayUI_Unhide_t =
-    void(WINAPI*)(void* trayComponentHost,
-                  int trayUnhideFlags,
-                  int unhideRequest);
-
-TrayUI_Unhide_t TrayUI_Unhide_Original;
-
-using CSecondaryTray_Unhide_t =
-    void(WINAPI*)(void* secondaryTray,
-                  int trayUnhideFlags,
-                  int unhideRequest);
-
-CSecondaryTray_Unhide_t CSecondaryTray_Unhide_Original;
-
-using TrayUI_WndProc_t =
-    LRESULT(WINAPI*)(void* trayUi,
-                     HWND window,
-                     UINT message,
-                     WPARAM wParam,
-                     LPARAM lParam,
-                     bool* handled);
-
-TrayUI_WndProc_t TrayUI_WndProc_Original;
-
-void HandleTaskbarEnvironmentMessage(UINT message) {
-    if (message == WM_DISPLAYCHANGE || message == WM_DPICHANGED ||
-        message == WM_SETTINGCHANGE) {
-        EnsureActivationWorker();
-        QueuePointerStateUpdate();
-    }
-}
-
-LRESULT WINAPI TrayUI_WndProc_Hook(
-    void* trayUi,
-    HWND window,
-    UINT message,
-    WPARAM wParam,
-    LPARAM lParam,
-    bool* handled) {
-    if (message == g_updateTaskbarStateMessage) {
-        // Record the existing taskbar object's pThis for free: this message is
-        // already executing with the correct TrayUI instance on its UI thread.
-        g_trayUiWndProcObjects[window] = trayUi;
-        g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
-
-        ApplyTaskbarKeepShownStateOnUiThread(window);
-        if (handled) {
-            *handled = true;
-        }
-        return 0;
-    }
-
-    const bool taskbarCreating = message == WM_NCCREATE;
-    if (taskbarCreating) {
-        g_trayUiWndProcObjects[window] = trayUi;
-        g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
-        Wh_Log(L"Captured TrayUI object for taskbar %p", window);
-        EnsureActivationWorker();
-    } else if (message == WM_NCDESTROY) {
-        g_trayUiWndProcObjects.erase(window);
-        ForgetTaskbarState(window);
-        if (g_mainTaskbarWindow.load(std::memory_order_relaxed) == window) {
-            g_mainTaskbarWindow.store(nullptr, std::memory_order_relaxed);
-        }
-    }
-
-    const LRESULT originalResult = TrayUI_WndProc_Original(
-        trayUi,
-        window,
-        message,
-        wParam,
-        lParam,
-        handled);
-    HandleTaskbarEnvironmentMessage(message);
-    if (taskbarCreating || message == WM_NCDESTROY) {
-        // Re-evaluate after Explorer has processed creation/destruction. The
-        // worker message carries no HWND, so handle reuse can't make this stale.
-        QueuePointerStateUpdate();
-    }
-    return originalResult;
-}
-
-using CSecondaryTray_WndProc_t =
-    LRESULT(WINAPI*)(void* secondaryTray,
-                     HWND window,
-                     UINT message,
-                     WPARAM wParam,
-                     LPARAM lParam);
-
-CSecondaryTray_WndProc_t CSecondaryTray_WndProc_Original;
-
-LRESULT WINAPI CSecondaryTray_WndProc_Hook(
-    void* secondaryTray,
-    HWND window,
-    UINT message,
-    WPARAM wParam,
-    LPARAM lParam) {
-    if (message == g_updateTaskbarStateMessage) {
-        // As with the primary taskbar, the first UI operation records the
-        // existing CSecondaryTray object without a separate capture round-trip.
-        g_secondaryTrayObjects[window] = secondaryTray;
-
-        ApplyTaskbarKeepShownStateOnUiThread(window);
-        return 0;
-    }
-
-    const bool taskbarCreating = message == WM_NCCREATE;
-    if (taskbarCreating) {
-        g_secondaryTrayObjects[window] = secondaryTray;
-        Wh_Log(L"Captured CSecondaryTray object for taskbar %p", window);
-        EnsureActivationWorker();
-    } else if (message == WM_NCDESTROY) {
-        g_secondaryTrayObjects.erase(window);
-        ForgetTaskbarState(window);
-    }
-
-    const LRESULT originalResult = CSecondaryTray_WndProc_Original(
-        secondaryTray,
-        window,
-        message,
-        wParam,
-        lParam);
-    HandleTaskbarEnvironmentMessage(message);
-    if (taskbarCreating || message == WM_NCDESTROY) {
-        QueuePointerStateUpdate();
-    }
-    return originalResult;
-}
-
-bool InvokeNativeShellUnhideOnUiThread(HWND taskbarWindow) {
-    if (!taskbarWindow || !IsWindow(taskbarWindow)) {
-        return false;
-    }
-
-    const TaskbarKind kind = GetTaskbarKind(taskbarWindow);
-    if (kind == TaskbarKind::kMain) {
-        auto it = g_trayUiWndProcObjects.find(taskbarWindow);
-        if (it == g_trayUiWndProcObjects.end() ||
-            !TrayUI_Unhide_Original || !g_trayUiVtableITrayComponentHost) {
-            return false;
-        }
-
-        void* trayComponentHost = QueryViaVtable(
-            it->second, g_trayUiVtableITrayComponentHost);
-        if (!trayComponentHost) {
-            Wh_Log(L"Couldn't locate ITrayComponentHost for taskbar %p",
-                   taskbarWindow);
-            return false;
-        }
-
-        TrayUI_Unhide_Original(trayComponentHost, 0, 0);
-        return true;
-    }
-
-    if (kind == TaskbarKind::kSecondary) {
-        auto it = g_secondaryTrayObjects.find(taskbarWindow);
-        if (it == g_secondaryTrayObjects.end() ||
-            !CSecondaryTray_Unhide_Original) {
-            return false;
-        }
-
-        CSecondaryTray_Unhide_Original(it->second, 0, 0);
-        return true;
-    }
-
-    return false;
-}
-
 void RememberViewCoordinator(HWND taskbarWindow, void* viewCoordinator) {
     if (!taskbarWindow || !viewCoordinator) {
         return;
     }
+    auto [it, inserted] =
+        g_viewCoordinators.insert_or_assign(taskbarWindow, viewCoordinator);
+    (void)it;
+    if (inserted) {
+        Wh_Log(L"Captured ViewCoordinator %p for taskbar %p",
+               viewCoordinator,
+               taskbarWindow);
+    }
+}
 
+void UpdateViewCoordinator(HWND taskbarWindow) {
+    if (!ViewCoordinator_UpdateIsExpanded_Original) {
+        return;
+    }
     auto it = g_viewCoordinators.find(taskbarWindow);
-    if (it != g_viewCoordinators.end() && it->second == viewCoordinator) {
+    if (it == g_viewCoordinators.end()) {
         return;
     }
 
-    g_viewCoordinators[taskbarWindow] = viewCoordinator;
-    Wh_Log(L"Captured ViewCoordinator %p for taskbar %p",
-           viewCoordinator,
-           taskbarWindow);
-}
-
-void* GetViewCoordinator(HWND taskbarWindow) {
-    auto it = g_viewCoordinators.find(taskbarWindow);
-    return it != g_viewCoordinators.end() ? it->second : nullptr;
-}
-
-using ViewCoordinator_ShouldTaskbarBeExpanded_t =
-    bool(WINAPI*)(void* viewCoordinator,
-                  HWND taskbarWindow,
-                  bool expanded);
-
-ViewCoordinator_ShouldTaskbarBeExpanded_t
-    ViewCoordinator_ShouldTaskbarBeExpanded_Original;
-
-using ViewCoordinator_UpdateIsExpanded_t =
-    void(WINAPI*)(void* viewCoordinator,
-                  HWND taskbarWindow,
-                  int reason);
-
-ViewCoordinator_UpdateIsExpanded_t ViewCoordinator_UpdateIsExpanded_Original;
-
-bool IsTaskbarKeptShownOnUiThread(HWND taskbarWindow) {
-    for (const auto& [object, window] : g_taskbarsKeptShown) {
-        (void)object;
-        if (window == taskbarWindow) {
-            return true;
-        }
-    }
-    return false;
+    // ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged reason.
+    constexpr int kReasonPointerOverTaskbarFrameChanged = 7;
+    ViewCoordinator_UpdateIsExpanded_Original(
+        it->second, taskbarWindow, kReasonPointerOverTaskbarFrameChanged);
 }
 
 bool WINAPI ViewCoordinator_ShouldTaskbarBeExpanded_Hook(
@@ -1045,174 +689,207 @@ bool WINAPI ViewCoordinator_ShouldTaskbarBeExpanded_Hook(
     HWND taskbarWindow,
     bool expanded) {
     RememberViewCoordinator(taskbarWindow, viewCoordinator);
-
-    if (!g_unloading.load(std::memory_order_acquire) &&
-        g_desiredKeptShownTaskbar.load(std::memory_order_acquire) ==
-            taskbarWindow &&
-        IsTaskbarKeptShownOnUiThread(taskbarWindow)) {
+    if (!g_unloading.load() &&
+        g_desiredKeptShownTaskbar.load() == taskbarWindow) {
         return true;
     }
-
     return ViewCoordinator_ShouldTaskbarBeExpanded_Original(
         viewCoordinator, taskbarWindow, expanded);
 }
 
-bool UpdateViewCoordinatorIsExpandedOnUiThread(HWND taskbarWindow) {
-    if (!ViewCoordinator_UpdateIsExpanded_Original) {
-        return false;
-    }
-
-    void* viewCoordinator = GetViewCoordinator(taskbarWindow);
-    if (!viewCoordinator) {
-        return false;
-    }
-
-    // Reason 7 is ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged.
-    // The maintained keep-shown implementation uses it to request a normal
-    // expansion-policy reevaluation without modifying pointer-over bookkeeping.
-    constexpr int kReasonPointerOverTaskbarFrameChanged = 7;
-    ViewCoordinator_UpdateIsExpanded_Original(
-        viewCoordinator,
-        taskbarWindow,
-        kReasonPointerOverTaskbarFrameChanged);
-    return true;
-}
-
-void* GetKeepShownObjectForTaskbarOnUiThread(HWND taskbarWindow) {
-    switch (GetTaskbarKind(taskbarWindow)) {
-        case TaskbarKind::kMain: {
-            auto it = g_trayUiWndProcObjects.find(taskbarWindow);
-            if (it == g_trayUiWndProcObjects.end() ||
-                !g_trayUiVtableIInspectable) {
-                return nullptr;
-            }
-            return QueryViaVtableBackwards(
-                it->second, g_trayUiVtableIInspectable);
-        }
-
-        case TaskbarKind::kSecondary: {
-            auto it = g_secondaryTrayObjects.find(taskbarWindow);
-            return it != g_secondaryTrayObjects.end() ? it->second : nullptr;
-        }
-
-        default:
-            return nullptr;
-    }
-}
-
-void ApplyTaskbarKeepShownStateOnUiThread(HWND taskbarWindow) {
-    if (!taskbarWindow || !IsCurrentProcessWindow(taskbarWindow)) {
+void WINAPI TrayUI_Hide_Hook(void* trayUiInspectable) {
+    auto it = g_taskbarsKeptShown.find(trayUiInspectable);
+    if (!g_unloading.load() && it != g_taskbarsKeptShown.end() &&
+        g_desiredKeptShownTaskbar.load() == it->second) {
+        KillTimer(it->second, kTrayUITimerHide);
         return;
     }
-
-    const bool shouldKeepShown =
-        !g_unloading.load(std::memory_order_acquire) &&
-        g_desiredKeptShownTaskbar.load(std::memory_order_acquire) ==
-            taskbarWindow;
-
-    if (shouldKeepShown) {
-        void* keepShownObject =
-            GetKeepShownObjectForTaskbarOnUiThread(taskbarWindow);
-        if (!keepShownObject) {
-            Wh_Log(L"Couldn't resolve keep-shown object for taskbar %p",
-                   taskbarWindow);
-            return;
-        }
-
-        // Establish the policy before native Unhide. If Unhide asks
-        // ShouldTaskbarBeExpanded synchronously, the hook already returns true.
-        // Re-running the native unhide on an idempotent state update also repairs
-        // a stale visible/layering state without any manual Z-order changes.
-        g_taskbarsKeptShown[keepShownObject] = taskbarWindow;
-
-        if (!InvokeNativeShellUnhideOnUiThread(taskbarWindow)) {
-            g_taskbarsKeptShown.erase(keepShownObject);
-            Wh_Log(L"Native taskbar unhide failed for taskbar %p",
-                   taskbarWindow);
-            return;
-        }
-
-        if (UpdateViewCoordinatorIsExpandedOnUiThread(taskbarWindow)) {
-            g_appliedKeptShownTaskbar.store(taskbarWindow,
-                                           std::memory_order_release);
-        } else {
-            // Native Unhide can itself cause ShouldTaskbarBeExpanded to run. If
-            // it didn't, leave the state unconfirmed so the worker retries this
-            // idempotent show operation instead of assuming a partial reveal is
-            // fully established.
-            Wh_Log(L"ViewCoordinator not captured yet for taskbar %p",
-                   taskbarWindow);
-        }
-        return;
-    }
-
-    // Release is idempotent. Only poke Explorer's native hide path if this mod
-    // actually had keep-shown state for the taskbar; a stale/public registered
-    // message must not hide a taskbar that the mod never owned. Timer ID 2 is
-    // Explorer's native taskbar hide timer and this is the established Windhawk
-    // keep-shown release pattern.
-    const bool wasKeptShown = EraseKeptShownForWindow(taskbarWindow);
-    const bool wasApplied =
-        g_appliedKeptShownTaskbar.load(std::memory_order_acquire) ==
-        taskbarWindow;
-    if (wasKeptShown || wasApplied) {
-        if (IsWindow(taskbarWindow) &&
-            !SetTimer(taskbarWindow, kTrayUITimerHide, 0, nullptr)) {
-            Wh_Log(L"Couldn't arm Explorer's hide timer for taskbar %p: %u",
-                   taskbarWindow,
-                   GetLastError());
-        }
-        (void)UpdateViewCoordinatorIsExpandedOnUiThread(taskbarWindow);
-    }
-
-    HWND expected = taskbarWindow;
-    g_appliedKeptShownTaskbar.compare_exchange_strong(
-        expected, nullptr, std::memory_order_acq_rel);
+    TrayUI_Hide_Original(trayUiInspectable);
 }
 
-bool PostTaskbarStateUpdate(HWND taskbarWindow) {
-    if (!taskbarWindow || !IsSupportedTaskbarWindow(taskbarWindow) ||
-        !IsCurrentProcessWindow(taskbarWindow)) {
-        return false;
+void WINAPI CSecondaryTray_AutoHide_Hook(void* secondaryTray,
+                                         bool parameter) {
+    auto it = g_taskbarsKeptShown.find(secondaryTray);
+    if (!g_unloading.load() && it != g_taskbarsKeptShown.end() &&
+        g_desiredKeptShownTaskbar.load() == it->second) {
+        KillTimer(it->second, kTrayUITimerHide);
+        return;
+    }
+    CSecondaryTray_AutoHide_Original(secondaryTray, parameter);
+}
+
+void ReleaseExplorerTaskbar(HWND taskbarWindow) {
+    bool explorerWantsExpanded = false;
+    auto it = g_viewCoordinators.find(taskbarWindow);
+    if (it != g_viewCoordinators.end() &&
+        ViewCoordinator_ShouldTaskbarBeExpanded_Original) {
+        explorerWantsExpanded =
+            ViewCoordinator_ShouldTaskbarBeExpanded_Original(
+                it->second, taskbarWindow, true);
     }
 
-    if (!PostMessageW(taskbarWindow,
-                      g_updateTaskbarStateMessage,
-                      0,
-                      0)) {
-        Wh_Log(L"Couldn't post taskbar-state update for %p: %u",
+    if (!explorerWantsExpanded && IsWindow(taskbarWindow) &&
+        !SetTimer(taskbarWindow, kTrayUITimerHide, 0, nullptr)) {
+        Wh_Log(L"Couldn't arm Explorer's hide timer for taskbar %p: %u",
                taskbarWindow,
                GetLastError());
-        return false;
+    }
+    UpdateViewCoordinator(taskbarWindow);
+}
+
+bool ApplyPrimaryTaskbarState(void* trayUi, HWND taskbarWindow) {
+    bool wantShown = !g_unloading.load() &&
+                     g_desiredKeptShownTaskbar.load() == taskbarWindow;
+    if (wantShown) {
+        if (!TrayUI_Unhide_Original || !g_trayUiVtableIInspectable ||
+            !g_trayUiVtableITrayComponentHost) {
+            return false;
+        }
+
+        void* inspectable =
+            FindInterfaceBackward(trayUi, g_trayUiVtableIInspectable);
+        void* componentHost =
+            FindInterfaceForward(trayUi, g_trayUiVtableITrayComponentHost);
+        if (!inspectable || !componentHost) {
+            return false;
+        }
+
+        g_taskbarsKeptShown[inspectable] = taskbarWindow;
+        TrayUI_Unhide_Original(componentHost, 0, 0);
+        UpdateViewCoordinator(taskbarWindow);
+        return true;
     }
 
+    bool wasKeptShown = EraseKeptShownForWindow(taskbarWindow);
+    if (wasKeptShown) {
+        ReleaseExplorerTaskbar(taskbarWindow);
+    }
     return true;
 }
 
-struct WorkerTimer {
-    UINT_PTR id = 0;
-    ULONGLONG dueAt = 0;
-};
-
-struct ActivationWorkerState {
-    HWND activeTaskbar = nullptr;
-    HMONITOR activeTaskbarMonitor = nullptr;
-    HMONITOR activationCandidateMonitor = nullptr;
-    WorkerTimer releaseTimer;
-    WorkerTimer retryTimer;
-    ULONGLONG activationCandidateSince = 0;
-    HMONITOR fullscreenCacheMonitor = nullptr;
-    ULONGLONG fullscreenCacheTimestamp = 0;
-    bool fullscreenCacheValue = false;
-};
-
-UINT GetMonitorDpiY(HMONITOR monitor) {
-    UINT dpiX = 96;
-    UINT dpiY = 96;
-    if (FAILED(GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY))) {
-        return 96;
+bool ApplySecondaryTaskbarState(void* secondaryTray,
+                                HWND taskbarWindow) {
+    bool wantShown = !g_unloading.load() &&
+                     g_desiredKeptShownTaskbar.load() == taskbarWindow;
+    if (wantShown) {
+        if (!CSecondaryTray_Unhide_Original) {
+            return false;
+        }
+        g_taskbarsKeptShown[secondaryTray] = taskbarWindow;
+        CSecondaryTray_Unhide_Original(secondaryTray, 0, 0);
+        UpdateViewCoordinator(taskbarWindow);
+        return true;
     }
-    return dpiY;
+
+    bool wasKeptShown = EraseKeptShownForWindow(taskbarWindow);
+    if (wasKeptShown) {
+        ReleaseExplorerTaskbar(taskbarWindow);
+    }
+    return true;
+}
+
+void ForgetTaskbarWindow(HWND taskbarWindow) {
+    g_viewCoordinators.erase(taskbarWindow);
+    EraseKeptShownForWindow(taskbarWindow);
+    HWND expected = taskbarWindow;
+    g_desiredKeptShownTaskbar.compare_exchange_strong(expected, nullptr);
+    if (g_mainTaskbarWindow.load() == taskbarWindow) {
+        g_mainTaskbarWindow = nullptr;
+    }
+}
+
+void HandleTaskbarEnvironmentMessage(UINT message) {
+    if (message == WM_DISPLAYCHANGE || message == WM_DPICHANGED) {
+        g_workerStateDirty = true;
+        EnsureActivationWorker();
+        QueuePointerStateUpdate();
+    } else if (message == WM_SETTINGCHANGE) {
+        g_workerStateDirty = true;
+        EnsureActivationWorker();
+        QueuePointerStateUpdate();
+    }
+}
+
+LRESULT WINAPI TrayUI_WndProc_Hook(void* trayUi,
+                                   HWND window,
+                                   UINT message,
+                                   WPARAM wParam,
+                                   LPARAM lParam,
+                                   bool* handled) {
+    if (message == g_updateTaskbarStateMessage) {
+        g_mainTaskbarWindow = window;
+        bool ok = ApplyPrimaryTaskbarState(trayUi, window);
+        if (handled) {
+            *handled = true;
+        }
+        return ok ? 1 : 0;
+    }
+
+    bool created = message == WM_NCCREATE;
+    bool destroyed = message == WM_NCDESTROY;
+    if (created) {
+        g_mainTaskbarWindow = window;
+        EnsureActivationWorker();
+    } else if (destroyed) {
+        ForgetTaskbarWindow(window);
+    }
+
+    LRESULT result = TrayUI_WndProc_Original(
+        trayUi, window, message, wParam, lParam, handled);
+
+    HandleTaskbarEnvironmentMessage(message);
+    if (created || destroyed) {
+        g_workerStateDirty = true;
+        QueuePointerStateUpdate();
+    }
+    return result;
+}
+
+LRESULT WINAPI CSecondaryTray_WndProc_Hook(void* secondaryTray,
+                                           HWND window,
+                                           UINT message,
+                                           WPARAM wParam,
+                                           LPARAM lParam) {
+    if (message == g_updateTaskbarStateMessage) {
+        return ApplySecondaryTaskbarState(secondaryTray, window) ? 1 : 0;
+    }
+
+    bool created = message == WM_NCCREATE;
+    bool destroyed = message == WM_NCDESTROY;
+    if (created) {
+        EnsureActivationWorker();
+    } else if (destroyed) {
+        ForgetTaskbarWindow(window);
+    }
+
+    LRESULT result = CSecondaryTray_WndProc_Original(
+        secondaryTray, window, message, wParam, lParam);
+
+    HandleTaskbarEnvironmentMessage(message);
+    if (created || destroyed) {
+        g_workerStateDirty = true;
+        QueuePointerStateUpdate();
+    }
+    return result;
+}
+
+bool SendTaskbarStateUpdate(HWND taskbarWindow, DWORD timeoutMs) {
+    if (!IsSupportedTaskbarWindow(taskbarWindow)) {
+        return false;
+    }
+
+    DWORD_PTR result = 0;
+    if (!SendMessageTimeoutW(
+            taskbarWindow,
+            g_updateTaskbarStateMessage,
+            0,
+            0,
+            SMTO_ABORTIFHUNG | SMTO_BLOCK | SMTO_ERRORONEXIT,
+            timeoutMs,
+            &result)) {
+        return false;
+    }
+    return result != 0;
 }
 
 void CancelWorkerTimer(WorkerTimer& timer) {
@@ -1224,131 +901,87 @@ void CancelWorkerTimer(WorkerTimer& timer) {
 }
 
 bool ScheduleWorkerTimer(UINT delayMs, WorkerTimer& timer) {
-    const UINT effectiveDelay = std::max(delayMs, 1U);
-    const ULONGLONG requestedDueAt = GetTickCount64() + effectiveDelay;
-
-    if (timer.id) {
-        if (timer.dueAt && timer.dueAt <= requestedDueAt) {
-            return true;
-        }
-        CancelWorkerTimer(timer);
+    UINT effectiveDelay = std::max(delayMs, 1U);
+    ULONGLONG dueAt = GetTickCount64() + effectiveDelay;
+    if (timer.id && timer.dueAt <= dueAt) {
+        return true;
     }
-
+    CancelWorkerTimer(timer);
     timer.id = SetTimer(nullptr, 0, effectiveDelay, nullptr);
     if (!timer.id) {
         Wh_Log(L"Failed to create worker timer: %u", GetLastError());
         return false;
     }
-    timer.dueAt = requestedDueAt;
+    timer.dueAt = dueAt;
     return true;
 }
 
-bool ScheduleRetry(ActivationWorkerState& state, UINT delayMs) {
-    return ScheduleWorkerTimer(delayMs, state.retryTimer);
+void ResetHoverCandidate(WorkerState& state) {
+    state.hoverMonitor = nullptr;
+    state.hoverSince = 0;
 }
 
-void ResetActivationCandidate(ActivationWorkerState& state) {
-    state.activationCandidateMonitor = nullptr;
-    state.activationCandidateSince = 0;
-}
-
-void InvalidateFullscreenCache(ActivationWorkerState& state) {
-    state.fullscreenCacheMonitor = nullptr;
-    state.fullscreenCacheTimestamp = 0;
-    state.fullscreenCacheValue = false;
-}
-
-bool ReleaseActiveTaskbar(ActivationWorkerState& state,
-                          bool scheduleRetry = true) {
+void ClearActiveTaskbar(WorkerState& state) {
+    state.activeTaskbar = nullptr;
+    state.activeMonitor = nullptr;
     CancelWorkerTimer(state.releaseTimer);
+}
 
+void ReleaseActiveTaskbar(WorkerState& state) {
     if (!state.activeTaskbar) {
-        return true;
+        return;
     }
 
-    const HWND taskbarWindow = state.activeTaskbar;
+    HWND taskbarWindow = state.activeTaskbar;
     HWND expected = taskbarWindow;
-    g_desiredKeptShownTaskbar.compare_exchange_strong(
-        expected, nullptr, std::memory_order_acq_rel);
+    g_desiredKeptShownTaskbar.compare_exchange_strong(expected, nullptr);
 
     if (IsSupportedTaskbarWindow(taskbarWindow) &&
-        IsCurrentProcessWindow(taskbarWindow) &&
-        !PostTaskbarStateUpdate(taskbarWindow)) {
-        if (scheduleRetry) {
-            // During normal operation, preserve the current keep-shown intent
-            // until a release message can be queued. On worker shutdown, fail
-            // open instead: desired stays null so the hooks stop suppressing
-            // Explorer even if the UI thread is unavailable.
-            g_desiredKeptShownTaskbar.store(taskbarWindow,
-                                           std::memory_order_release);
-            if (ScheduleWorkerTimer(kTransientRetryIntervalMs,
-                                    state.releaseTimer)) {
-                return false;
-            }
-
-            // A failed retry timer must never turn a transient PostMessage
-            // failure into a permanently kept-open taskbar. Drop the intent and
-            // fail open; the stale UI-thread map is inert while desired is null.
-            g_desiredKeptShownTaskbar.store(nullptr,
-                                           std::memory_order_release);
-            HWND applied = taskbarWindow;
-            g_appliedKeptShownTaskbar.compare_exchange_strong(
-                applied, nullptr, std::memory_order_acq_rel);
-        }
+        !SendTaskbarStateUpdate(taskbarWindow, 250)) {
+            // Desired state is already null, so hooks fail open even if the UI
+            // thread is busy. Queue one best-effort cleanup to erase stale map
+            // state and re-arm Explorer's hide policy when the thread recovers.
+            PostMessageW(taskbarWindow, g_updateTaskbarStateMessage, 0, 0);
     }
 
-    state.activeTaskbar = nullptr;
-    state.activeTaskbarMonitor = nullptr;
-    return true;
+    ClearActiveTaskbar(state);
 }
 
-bool RequestTaskbarReveal(ActivationWorkerState& state,
-                          HWND taskbarWindow,
-                          HMONITOR monitor) {
-    const HWND previousDesired =
-        g_desiredKeptShownTaskbar.exchange(taskbarWindow,
-                                           std::memory_order_acq_rel);
-    if (previousDesired && previousDesired != taskbarWindow) {
-        PostTaskbarStateUpdate(previousDesired);
+bool RevealTaskbar(WorkerState& state,
+                   HWND taskbarWindow,
+                   HMONITOR monitor) {
+    HWND previous = g_desiredKeptShownTaskbar.exchange(taskbarWindow);
+    if (previous && previous != taskbarWindow &&
+        IsSupportedTaskbarWindow(previous)) {
+        SendTaskbarStateUpdate(previous, 100);
     }
 
-    if (!PostTaskbarStateUpdate(taskbarWindow)) {
+    if (!SendTaskbarStateUpdate(taskbarWindow, 250)) {
         HWND expected = taskbarWindow;
-        g_desiredKeptShownTaskbar.compare_exchange_strong(
-            expected, nullptr, std::memory_order_acq_rel);
+        g_desiredKeptShownTaskbar.compare_exchange_strong(expected, nullptr);
+        PostMessageW(taskbarWindow, g_updateTaskbarStateMessage, 0, 0);
         return false;
     }
 
     state.activeTaskbar = taskbarWindow;
-    state.activeTaskbarMonitor = monitor;
-    ResetActivationCandidate(state);
-
-    // Confirmation is asynchronous. If Explorer's taskbar UI thread was busy
-    // or the keep-shown object couldn't be resolved, retry idempotently at 1 Hz.
-    if (g_appliedKeptShownTaskbar.load(std::memory_order_acquire) !=
-        taskbarWindow) {
-        ScheduleRetry(state, kTransientRetryIntervalMs);
-    }
+    state.activeMonitor = monitor;
+    state.consumedBandMonitor = monitor;
+    ResetHoverCandidate(state);
     return true;
 }
 
-bool GetCachedFullscreenState(ActivationWorkerState& state,
-                              HMONITOR monitor,
-                              ULONGLONG now) {
-    if (state.fullscreenCacheMonitor == monitor &&
-        now - state.fullscreenCacheTimestamp < kFullscreenCacheDurationMs) {
-        return state.fullscreenCacheValue;
+void ProcessPointerState(WorkerState& state) {
+    if (g_unloading.load()) {
+        return;
     }
 
-    state.fullscreenCacheMonitor = monitor;
-    state.fullscreenCacheTimestamp = now;
-    state.fullscreenCacheValue = IsFullscreenWindowOnMonitor(monitor);
-    return state.fullscreenCacheValue;
-}
-
-void ProcessPointerState(ActivationWorkerState& state) {
-    if (g_unloading.load(std::memory_order_acquire)) {
-        return;
+    if (g_workerStateDirty.exchange(false)) {
+        state.monitors.clear();
+        state.taskbars.clear();
+        CancelWorkerTimer(state.releaseTimer);
+        CancelWorkerTimer(state.retryTimer);
+        ResetHoverCandidate(state);
+        state.consumedBandMonitor = nullptr;
     }
 
     POINT pointer{};
@@ -1359,206 +992,158 @@ void ProcessPointerState(ActivationWorkerState& state) {
     HMONITOR pointerMonitor =
         MonitorFromPoint(pointer, MONITOR_DEFAULTTONULL);
     if (!pointerMonitor) {
-        (void)ReleaseActiveTaskbar(state);
+        ReleaseActiveTaskbar(state);
         CancelWorkerTimer(state.retryTimer);
-        ResetActivationCandidate(state);
+        ResetHoverCandidate(state);
+        state.consumedBandMonitor = nullptr;
         return;
     }
 
-    MONITORINFO monitorInfo{};
-    monitorInfo.cbSize = sizeof(monitorInfo);
-    if (!GetMonitorInfoW(pointerMonitor, &monitorInfo)) {
+    MonitorData monitor;
+    if (!GetMonitorData(state, pointerMonitor, &monitor)) {
         return;
     }
 
-    const ULONGLONG now = GetTickCount64();
-    const bool insideActivationBand = IsPointInsideActivationBand(
-        pointer, monitorInfo, GetMonitorDpiY(pointerMonitor));
+    bool inTriggerBand = IsPointInBottomBand(
+        pointer, monitor, g_settings.activationThresholdPx.load());
 
-    if (state.activeTaskbar) {
-        // UI-thread destruction or a fail-open cleanup can clear the desired
-        // keep-shown target before the worker observes it. Don't let a stale or
-        // recycled HWND keep the worker logically active after that happens.
-        if (g_desiredKeptShownTaskbar.load(std::memory_order_acquire) !=
-            state.activeTaskbar) {
-            CancelWorkerTimer(state.releaseTimer);
-            state.activeTaskbar = nullptr;
-            state.activeTaskbarMonitor = nullptr;
-        }
+    if (state.activeTaskbar &&
+        g_desiredKeptShownTaskbar.load() != state.activeTaskbar) {
+        ClearActiveTaskbar(state);
     }
 
     if (state.activeTaskbar) {
-        bool activeTaskbarAllowed = true;
-        if (g_settings.primaryMonitorOnly.load(std::memory_order_relaxed)) {
-            MONITORINFO activeMonitorInfo{};
-            activeMonitorInfo.cbSize = sizeof(activeMonitorInfo);
-            activeTaskbarAllowed =
-                state.activeTaskbarMonitor &&
-                GetMonitorInfoW(state.activeTaskbarMonitor, &activeMonitorInfo) &&
-                (activeMonitorInfo.dwFlags & MONITORINFOF_PRIMARY) != 0;
+        bool activeAllowed = true;
+        if (g_settings.primaryMonitorOnly.load()) {
+            MonitorData activeData;
+            activeAllowed =
+                GetMonitorData(state, state.activeMonitor, &activeData) &&
+                activeData.primary;
         }
 
-        if (!activeTaskbarAllowed) {
-            if (!ReleaseActiveTaskbar(state)) {
-                return;
-            }
-        } else if (!IsSupportedTaskbarWindow(state.activeTaskbar) ||
-                   !IsCurrentProcessWindow(state.activeTaskbar)) {
+        if (!activeAllowed || !IsWindow(state.activeTaskbar)) {
+            ReleaseActiveTaskbar(state);
+        } else if (pointerMonitor == state.activeMonitor &&
+                   IsPointInActiveHoldArea(state.activeTaskbar,
+                                           pointer,
+                                           monitor)) {
             CancelWorkerTimer(state.releaseTimer);
-            state.activeTaskbar = nullptr;
-            state.activeTaskbarMonitor = nullptr;
+            return;
+        } else if (pointerMonitor != state.activeMonitor && inTriggerBand) {
+            // Don't stack the old monitor's release delay with the new monitor's
+            // hover delay.
+            ReleaseActiveTaskbar(state);
         } else {
-            const bool sameMonitorBand =
-                insideActivationBand &&
-                pointerMonitor == state.activeTaskbarMonitor;
-            const bool overTaskbar =
-                IsPointOverTaskbar(state.activeTaskbar, pointer);
-
-            if (sameMonitorBand || overTaskbar) {
-                CancelWorkerTimer(state.releaseTimer);
-
-                if (g_appliedKeptShownTaskbar.load(
-                        std::memory_order_acquire) != state.activeTaskbar) {
-                    // RequestTaskbarReveal already queued the first update. While
-                    // that update is pending, cursor movement must not flood the
-                    // taskbar UI queue with duplicate registered messages.
-                    if (!state.retryTimer.id) {
-                        (void)PostTaskbarStateUpdate(state.activeTaskbar);
-                        (void)ScheduleRetry(state, kTransientRetryIntervalMs);
-                    }
-                } else {
-                    CancelWorkerTimer(state.retryTimer);
-                }
+            int delay = g_settings.releaseDelayMs.load();
+            if (delay > 0 &&
+                ScheduleWorkerTimer(static_cast<UINT>(delay),
+                                    state.releaseTimer)) {
                 return;
             }
-
-            if (insideActivationBand &&
-                pointerMonitor != state.activeTaskbarMonitor) {
-                // Direct monitor transitions don't pay the old monitor's
-                // release delay before starting the new monitor's hover delay.
-                if (!ReleaseActiveTaskbar(state)) {
-                    return;
-                }
-            } else {
-                const int releaseDelay =
-                    g_settings.releaseDelayMs.load(std::memory_order_relaxed);
-                if (releaseDelay > 0 &&
-                    ScheduleWorkerTimer(static_cast<UINT>(releaseDelay),
-                                        state.releaseTimer)) {
-                    return;
-                }
-
-                // If the release-delay timer can't be created, fail open and
-                // release immediately rather than risking a taskbar that stays
-                // kept shown after the pointer has left.
-                if (!ReleaseActiveTaskbar(state)) {
-                    return;
-                }
-            }
+            ReleaseActiveTaskbar(state);
         }
     }
 
-    if (!insideActivationBand) {
+    if (!inTriggerBand) {
         CancelWorkerTimer(state.retryTimer);
-        ResetActivationCandidate(state);
-        InvalidateFullscreenCache(state);
+        ResetHoverCandidate(state);
+        state.consumedBandMonitor = nullptr;
         return;
     }
 
-    const int activationDelay =
-        g_settings.activationDelayMs.load(std::memory_order_relaxed);
-    if (state.activationCandidateMonitor != pointerMonitor) {
-        state.activationCandidateMonitor = pointerMonitor;
-        state.activationCandidateSince = now;
-        if (activationDelay > 0) {
-            ScheduleRetry(state, static_cast<UINT>(activationDelay));
+    // One reveal per continuous band entry. This prevents a large trigger band
+    // from becoming a show/hide loop after the post-reveal hold area is clamped
+    // to the taskbar's height.
+    if (state.consumedBandMonitor == pointerMonitor) {
+        CancelWorkerTimer(state.retryTimer);
+        return;
+    }
+
+    ULONGLONG now = GetTickCount64();
+    int hoverDelay = g_settings.activationDelayMs.load();
+    if (state.hoverMonitor != pointerMonitor) {
+        state.hoverMonitor = pointerMonitor;
+        state.hoverSince = now;
+        if (hoverDelay > 0) {
+            ScheduleWorkerTimer(static_cast<UINT>(hoverDelay),
+                                state.retryTimer);
             return;
         }
-    } else {
-        const ULONGLONG elapsed = now - state.activationCandidateSince;
-        if (elapsed < static_cast<ULONGLONG>(activationDelay)) {
-            ScheduleRetry(state, static_cast<UINT>(activationDelay - elapsed));
-            return;
-        }
+    } else if (now - state.hoverSince <
+               static_cast<ULONGLONG>(hoverDelay)) {
+        ScheduleWorkerTimer(
+            static_cast<UINT>(hoverDelay - (now - state.hoverSince)),
+            state.retryTimer);
+        return;
     }
 
     CancelWorkerTimer(state.retryTimer);
 
-    // Event-driven gates first. Settings changes and taskbar creation already
-    // queue a fresh pointer-state update, so these conditions aren't polled.
-    if (g_settings.primaryMonitorOnly.load(std::memory_order_relaxed) &&
-        (monitorInfo.dwFlags & MONITORINFOF_PRIMARY) == 0) {
+    // Conditions below either change through events we already observe or are
+    // transient. Event-driven blockers consume this band entry so cursor jitter
+    // doesn't repeatedly redo work that can't succeed until the environment
+    // changes; g_workerStateDirty clears the consumed state when that happens.
+    if (!g_viewCoordinatorSupportAvailable.load()) {
+        state.consumedBandMonitor = pointerMonitor;
         return;
     }
-
-    if (!g_viewCoordinatorSupportAvailable.load(std::memory_order_acquire)) {
+    if (g_settings.primaryMonitorOnly.load() && !monitor.primary) {
+        state.consumedBandMonitor = pointerMonitor;
         return;
     }
-
-    // A held button and fullscreen state can change while the cursor is parked.
-    if (g_settings.ignoreWhileMouseButtonDown.load(std::memory_order_relaxed) &&
+    if (g_settings.ignoreWhileMouseButtonDown.load() &&
         IsAnyMouseButtonDown()) {
-        ScheduleRetry(state, kTransientRetryIntervalMs);
+        ScheduleWorkerTimer(kTransientRetryMs, state.retryTimer);
         return;
     }
-
-    if (g_settings.requireWindowsAutoHide.load(std::memory_order_relaxed) &&
+    if (g_settings.requireWindowsAutoHide.load() &&
         !IsWindowsAutoHideEnabled()) {
+        state.consumedBandMonitor = pointerMonitor;
+        return;
+    }
+    if (g_settings.ignoreFullscreenApps.load() &&
+        IsFullscreenForegroundWindow(pointerMonitor, monitor)) {
+        ScheduleWorkerTimer(kTransientRetryMs, state.retryTimer);
         return;
     }
 
-    HWND taskbarWindow = FindTaskbarForMonitor(pointerMonitor);
+    HWND taskbarWindow =
+        GetCachedTaskbarForMonitor(state, pointerMonitor, monitor);
     if (!taskbarWindow) {
+        state.consumedBandMonitor = pointerMonitor;
         return;
     }
 
-    if (g_settings.ignoreFullscreenApps.load(std::memory_order_relaxed) &&
-        GetCachedFullscreenState(state, pointerMonitor, now)) {
-        ScheduleRetry(state, kTransientRetryIntervalMs);
-        return;
-    }
-
-    if (!RequestTaskbarReveal(state, taskbarWindow, pointerMonitor)) {
-        ScheduleRetry(state, kTransientRetryIntervalMs);
+    if (!RevealTaskbar(state, taskbarWindow, pointerMonitor)) {
+        ScheduleWorkerTimer(kTransientRetryMs, state.retryTimer);
     }
 }
 
-void HandleRetryTimer(ActivationWorkerState& state) {
-    CancelWorkerTimer(state.retryTimer);
-    ProcessPointerState(state);
-}
-
-void HandleReleaseTimer(ActivationWorkerState& state) {
+void HandleReleaseTimer(WorkerState& state) {
     CancelWorkerTimer(state.releaseTimer);
     if (!state.activeTaskbar) {
         return;
     }
 
     POINT pointer{};
-    bool keepActive = false;
-    if (GetCursorPos(&pointer) &&
-        IsSupportedTaskbarWindow(state.activeTaskbar) &&
-        IsCurrentProcessWindow(state.activeTaskbar)) {
-        HMONITOR pointerMonitor =
-            MonitorFromPoint(pointer, MONITOR_DEFAULTTONULL);
-        MONITORINFO monitorInfo{};
-        monitorInfo.cbSize = sizeof(monitorInfo);
-        if (pointerMonitor && GetMonitorInfoW(pointerMonitor, &monitorInfo)) {
-            const bool inBand = IsPointInsideActivationBand(
-                pointer, monitorInfo, GetMonitorDpiY(pointerMonitor));
-            keepActive =
-                (inBand && pointerMonitor == state.activeTaskbarMonitor) ||
-                IsPointOverTaskbar(state.activeTaskbar, pointer);
+    HMONITOR monitor = nullptr;
+    MonitorData data;
+    bool keepShown = false;
+    if (GetCursorPos(&pointer)) {
+        monitor = MonitorFromPoint(pointer, MONITOR_DEFAULTTONULL);
+        if (monitor == state.activeMonitor &&
+            GetMonitorData(state, monitor, &data)) {
+            keepShown = IsPointInActiveHoldArea(
+                state.activeTaskbar, pointer, data);
         }
     }
 
-    if (keepActive) {
+    if (keepShown) {
         return;
     }
 
-    if (ReleaseActiveTaskbar(state)) {
-        ProcessPointerState(state);
-    }
+    ReleaseActiveTaskbar(state);
+    ProcessPointerState(state);
 }
 
 void CALLBACK CursorWinEventProc(HWINEVENTHOOK,
@@ -1568,22 +1153,16 @@ void CALLBACK CursorWinEventProc(HWINEVENTHOOK,
                                  LONG,
                                  DWORD,
                                  DWORD) {
-    if (event != EVENT_OBJECT_LOCATIONCHANGE || idObject != OBJID_CURSOR) {
-        return;
+    if (event == EVENT_OBJECT_LOCATIONCHANGE && idObject == OBJID_CURSOR) {
+        QueuePointerStateUpdate();
     }
-
-    QueuePointerStateUpdate();
 }
 
 DWORD WINAPI ActivationWorkerThread(LPVOID) {
-    // Force creation of this thread's message queue before publishing its ID.
     MSG message{};
     PeekMessageW(&message, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
-    g_workerThreadId.store(GetCurrentThreadId(), std::memory_order_release);
+    g_workerThreadId = GetCurrentThreadId();
 
-    // The hook is system-wide because WinEvent can't filter by object ID at
-    // registration time. CursorWinEventProc immediately discards every event
-    // except OBJID_CURSOR, avoiding permanent polling while the mouse is idle.
     HWINEVENTHOOK cursorHook = SetWinEventHook(
         EVENT_OBJECT_LOCATIONCHANGE,
         EVENT_OBJECT_LOCATIONCHANGE,
@@ -1593,102 +1172,82 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
         0,
         WINEVENT_OUTOFCONTEXT);
 
-    UINT_PTR fallbackPollTimerId = 0;
+    UINT_PTR fallbackTimer = 0;
     if (!cursorHook) {
-        Wh_Log(L"SetWinEventHook for cursor movement failed: %u; "
-               L"using a 150 ms fallback timer",
+        Wh_Log(L"Cursor WinEvent hook failed: %u; using 150 ms fallback",
                GetLastError());
-        fallbackPollTimerId =
-            SetTimer(nullptr, 0, 150, nullptr);
-        if (!fallbackPollTimerId) {
-            Wh_Log(L"Fallback cursor timer creation failed: %u; cursor "
-                   L"tracking is unavailable",
-                   GetLastError());
-        }
+        fallbackTimer = SetTimer(nullptr, 0, 150, nullptr);
     }
 
-    ActivationWorkerState state;
+    WorkerState state;
     ProcessPointerState(state);
 
+    bool unexpectedExit = false;
     for (;;) {
         DWORD waitResult = MsgWaitForMultipleObjects(
-            1,
-            &g_stopEvent,
-            FALSE,
-            INFINITE,
-            QS_ALLINPUT);
-
+            1, &g_stopEvent, FALSE, INFINITE, QS_ALLINPUT);
         if (waitResult == WAIT_OBJECT_0) {
             break;
         }
-
         if (waitResult != WAIT_OBJECT_0 + 1) {
-            Wh_Log(L"Activation worker stopped: MsgWaitForMultipleObjects failed: %u; "
-                   L"a later shell/environment event will retry",
-                   GetLastError());
+            Wh_Log(L"Activation worker wait failed: %u", GetLastError());
+            unexpectedExit = true;
             break;
         }
 
         while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE)) {
-            switch (message.message) {
-                case kWorkerCursorChangedMessage:
-                    g_cursorUpdatePosted.store(false,
-                                               std::memory_order_release);
+            if (message.message == kWorkerCursorChangedMessage) {
+                g_cursorUpdatePosted = false;
+                ProcessPointerState(state);
+            } else if (message.message == WM_TIMER) {
+                if (state.releaseTimer.id &&
+                    message.wParam == state.releaseTimer.id) {
+                    HandleReleaseTimer(state);
+                } else if (state.retryTimer.id &&
+                           message.wParam == state.retryTimer.id) {
+                    CancelWorkerTimer(state.retryTimer);
                     ProcessPointerState(state);
-                    break;
-
-                case WM_TIMER:
-                    if (state.releaseTimer.id &&
-                        message.wParam == state.releaseTimer.id) {
-                        HandleReleaseTimer(state);
-                    } else if (state.retryTimer.id &&
-                               message.wParam == state.retryTimer.id) {
-                        HandleRetryTimer(state);
-                    } else if (fallbackPollTimerId &&
-                               message.wParam == fallbackPollTimerId) {
-                        ProcessPointerState(state);
-                    }
-                    break;
-
-                default:
-                    TranslateMessage(&message);
-                    DispatchMessageW(&message);
-                    break;
+                } else if (fallbackTimer &&
+                           message.wParam == fallbackTimer) {
+                    ProcessPointerState(state);
+                }
+            } else {
+                TranslateMessage(&message);
+                DispatchMessageW(&message);
             }
         }
     }
 
-    CancelWorkerTimer(state.retryTimer);
     CancelWorkerTimer(state.releaseTimer);
+    CancelWorkerTimer(state.retryTimer);
 
-    // Release the mod-owned keep-shown intent without waiting on Explorer's UI
-    // thread. If the posted reconciliation is delayed, the hooks fail open as
-    // soon as unloading begins, so no shell state can remain latched.
-    if (state.activeTaskbar) {
-        (void)ReleaseActiveTaskbar(state, false);
+    if (unexpectedExit && !g_unloading.load() && state.activeTaskbar) {
+        HWND taskbarWindow = state.activeTaskbar;
+        HWND expected = taskbarWindow;
+        g_desiredKeptShownTaskbar.compare_exchange_strong(expected, nullptr);
+        PostMessageW(taskbarWindow, g_updateTaskbarStateMessage, 0, 0);
     }
 
     if (cursorHook) {
         UnhookWinEvent(cursorHook);
-    } else if (fallbackPollTimerId) {
-        KillTimer(nullptr, fallbackPollTimerId);
+    } else if (fallbackTimer) {
+        KillTimer(nullptr, fallbackTimer);
     }
 
-    g_cursorUpdatePosted.store(false, std::memory_order_release);
-    g_workerThreadId.store(0, std::memory_order_release);
+    g_cursorUpdatePosted = false;
+    g_workerThreadId = 0;
     return 0;
 }
 
 bool HookTaskbarViewSymbols(HMODULE module) {
-    // Taskbar.View.dll, ExplorerExtensions.dll
-    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
         {
             {
                 LR"(public: bool __cdecl winrt::Taskbar::implementation::ViewCoordinator::ShouldTaskbarBeExpanded(unsigned __int64,bool))",
             },
             &ViewCoordinator_ShouldTaskbarBeExpanded_Original,
             ViewCoordinator_ShouldTaskbarBeExpanded_Hook,
-            true,  // Checked as a required pair below for a clearer diagnostic.
+            true,
         },
         {
             {
@@ -1696,223 +1255,148 @@ bool HookTaskbarViewSymbols(HMODULE module) {
             },
             &ViewCoordinator_UpdateIsExpanded_Original,
             nullptr,
-            true,  // Checked as a required pair below for a clearer diagnostic.
+            true,
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(
-            module,
-            symbolHooks,
-            ARRAYSIZE(symbolHooks))) {
-        Wh_Log(L"Failed to hook Windows 11 ViewCoordinator symbols");
-        return false;
-    }
-
-    if (!ViewCoordinator_ShouldTaskbarBeExpanded_Original ||
+    if (!WindhawkUtils::HookSymbols(module, hooks, ARRAYSIZE(hooks)) ||
+        !ViewCoordinator_ShouldTaskbarBeExpanded_Original ||
         !ViewCoordinator_UpdateIsExpanded_Original) {
-        Wh_Log(L"Taskbar keep-shown path unavailable: required ViewCoordinator "
-               L"symbols need updating");
+        Wh_Log(L"Required ViewCoordinator symbols are unavailable");
         return false;
     }
 
-    g_viewCoordinatorSupportAvailable.store(true, std::memory_order_release);
+    g_viewCoordinatorSupportAvailable = true;
     return true;
 }
 
-bool HookTaskbarUiThreadSymbol() {
-    HMODULE taskbarModule = LoadLibraryExW(
-        L"taskbar.dll",
-        nullptr,
-        LOAD_LIBRARY_SEARCH_SYSTEM32);
-
-    if (!taskbarModule) {
+bool HookTaskbarSymbols() {
+    HMODULE module = LoadLibraryExW(
+        L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!module) {
         Wh_Log(L"Couldn't load taskbar.dll: %u", GetLastError());
         return false;
     }
 
-    // taskbar.dll
-    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
         {
-            {
-                LR"(const TrayUI::`vftable'{for `IInspectable'})",
-            },
+            {LR"(const TrayUI::`vftable'{for `IInspectable'})"},
             &g_trayUiVtableIInspectable,
             nullptr,
         },
         {
-            {
-                LR"(const TrayUI::`vftable'{for `ITrayComponentHost'})",
-            },
+            {LR"(const TrayUI::`vftable'{for `ITrayComponentHost'})"},
             &g_trayUiVtableITrayComponentHost,
             nullptr,
         },
         {
-            {
-                LR"(public: void __cdecl TrayUI::_Hide(void))",
-            },
+            {LR"(public: void __cdecl TrayUI::_Hide(void))"},
             &TrayUI_Hide_Original,
             TrayUI_Hide_Hook,
         },
         {
-            {
-                LR"(private: void __cdecl CSecondaryTray::_AutoHide(bool))",
-            },
+            {LR"(private: void __cdecl CSecondaryTray::_AutoHide(bool))"},
             &CSecondaryTray_AutoHide_Original,
             CSecondaryTray_AutoHide_Hook,
             true,
         },
         {
-            {
-                LR"(public: virtual void __cdecl TrayUI::Unhide(enum TrayCommon::TrayUnhideFlags,enum TrayCommon::UnhideRequest))",
-            },
+            {LR"(public: virtual void __cdecl TrayUI::Unhide(enum TrayCommon::TrayUnhideFlags,enum TrayCommon::UnhideRequest))"},
             &TrayUI_Unhide_Original,
             nullptr,
         },
         {
-            {
-                LR"(private: void __cdecl CSecondaryTray::_Unhide(enum TrayCommon::TrayUnhideFlags,enum TrayCommon::UnhideRequest))",
-            },
+            {LR"(private: void __cdecl CSecondaryTray::_Unhide(enum TrayCommon::TrayUnhideFlags,enum TrayCommon::UnhideRequest))"},
             &CSecondaryTray_Unhide_Original,
             nullptr,
             true,
         },
         {
-            {
-                LR"(public: virtual __int64 __cdecl TrayUI::WndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64,bool *))",
-            },
+            {LR"(public: virtual __int64 __cdecl TrayUI::WndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64,bool *))"},
             &TrayUI_WndProc_Original,
             TrayUI_WndProc_Hook,
         },
         {
-            {
-                LR"(private: virtual __int64 __cdecl CSecondaryTray::v_WndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64))",
-            },
+            {LR"(private: virtual __int64 __cdecl CSecondaryTray::v_WndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64))"},
             &CSecondaryTray_WndProc_Original,
             CSecondaryTray_WndProc_Hook,
             true,
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(
-            taskbarModule,
-            symbolHooks,
-            ARRAYSIZE(symbolHooks))) {
-        Wh_Log(L"Failed to hook required native taskbar symbols");
+    if (!WindhawkUtils::HookSymbols(module, hooks, ARRAYSIZE(hooks))) {
+        Wh_Log(L"Required native taskbar symbols are unavailable");
         return false;
     }
 
-    const bool secondaryTaskbarSupportAvailable =
-        CSecondaryTray_AutoHide_Original && CSecondaryTray_Unhide_Original &&
+    g_secondaryTaskbarSupportAvailable =
+        CSecondaryTray_AutoHide_Original &&
+        CSecondaryTray_Unhide_Original &&
         CSecondaryTray_WndProc_Original;
-    g_secondaryTaskbarSupportAvailable.store(
-        secondaryTaskbarSupportAvailable,
-        std::memory_order_release);
-    if (!secondaryTaskbarSupportAvailable) {
-        Wh_Log(L"Secondary taskbar support unavailable: optional "
-               L"CSecondaryTray symbols need updating");
+    if (!g_secondaryTaskbarSupportAvailable.load()) {
+        Wh_Log(L"Secondary taskbar symbols are unavailable");
     }
-
     return true;
 }
 
 HMODULE GetTaskbarViewModuleHandle() {
     HMODULE module = GetModuleHandleW(L"Taskbar.View.dll");
-
-    if (!module) {
-        module = GetModuleHandleW(L"ExplorerExtensions.dll");
-    }
-
-    return module;
+    return module ? module : GetModuleHandleW(L"ExplorerExtensions.dll");
 }
 
-void HandleLoadedTaskbarViewModule(HMODULE module,
-                                   LPCWSTR libraryFileName) {
-    if (g_unloading.load(std::memory_order_acquire)) {
+void HandleLoadedTaskbarViewModule(HMODULE module) {
+    if (!module || g_unloading.load() || g_taskbarViewDllLoaded.load() ||
+        GetTaskbarViewModuleHandle() != module) {
         return;
     }
 
-    if (!module || g_taskbarViewDllLoaded.load(
-                       std::memory_order_acquire)) {
+    if (g_taskbarViewDllLoaded.exchange(true)) {
         return;
     }
-
-    if (GetTaskbarViewModuleHandle() != module) {
-        return;
-    }
-
-    if (g_taskbarViewDllLoaded.exchange(
-            true,
-            std::memory_order_acq_rel)) {
-        return;
-    }
-
-    Wh_Log(L"Loaded taskbar view module: %s",
-           libraryFileName ? libraryFileName : L"(unknown)");
 
     if (HookTaskbarViewSymbols(module)) {
         Wh_ApplyHookOperations();
+        g_workerStateDirty = true;
         QueuePointerStateUpdate();
     }
 }
 
-using LoadLibraryExW_t = decltype(&LoadLibraryExW);
-LoadLibraryExW_t LoadLibraryExW_Original;
-
-HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR libraryFileName,
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName,
                                    HANDLE file,
                                    DWORD flags) {
-    HMODULE module =
-        LoadLibraryExW_Original(libraryFileName, file, flags);
-
+    HMODULE module = LoadLibraryExW_Original(fileName, file, flags);
     if (module && !((ULONG_PTR)module & 3)) {
-        HandleLoadedTaskbarViewModule(module, libraryFileName);
+        HandleLoadedTaskbarViewModule(module);
     }
-
     return module;
 }
 
 BOOL Wh_ModInit() {
     Wh_Log(L"Initializing");
-
-    g_unloading.store(false, std::memory_order_relaxed);
-
-    g_updateTaskbarStateMessage = RegisterWindowMessageW(
-        L"Windhawk_updateTaskbarKeepShown_" WH_MOD_ID);
-    if (!g_updateTaskbarStateMessage) {
-        Wh_Log(L"RegisterWindowMessageW failed for taskbar-state channel");
-        return FALSE;
-    }
-
+    g_unloading = false;
     LoadSettings();
 
-    if (!HookTaskbarUiThreadSymbol()) {
+    g_updateTaskbarStateMessage = RegisterWindowMessageW(
+        L"Windhawk_UpdateTaskbarState_" WH_MOD_ID);
+    if (!g_updateTaskbarStateMessage) {
         return FALSE;
     }
 
-    if (HMODULE taskbarViewModule =
-            GetTaskbarViewModuleHandle()) {
-        if (!HookTaskbarViewSymbols(taskbarViewModule)) {
+    if (!HookTaskbarSymbols()) {
+        return FALSE;
+    }
+
+    if (HMODULE module = GetTaskbarViewModuleHandle()) {
+        if (!HookTaskbarViewSymbols(module)) {
             return FALSE;
         }
-
-        g_taskbarViewDllLoaded.store(
-            true,
-            std::memory_order_release);
+        g_taskbarViewDllLoaded = true;
     } else {
-        Wh_Log(L"Taskbar.View.dll/ExplorerExtensions.dll isn't loaded yet");
-
-        HMODULE kernelBaseModule =
-            GetModuleHandleW(L"kernelbase.dll");
-
+        HMODULE kernelBase = GetModuleHandleW(L"kernelbase.dll");
         auto loadLibraryExW = reinterpret_cast<decltype(&LoadLibraryExW)>(
-            GetProcAddress(kernelBaseModule, "LoadLibraryExW"));
-
-        if (!loadLibraryExW) {
-            Wh_Log(L"Couldn't find KernelBase!LoadLibraryExW");
-            return FALSE;
-        }
-
-        if (!WindhawkUtils::SetFunctionHook(
+            GetProcAddress(kernelBase, "LoadLibraryExW"));
+        if (!loadLibraryExW ||
+            !WindhawkUtils::SetFunctionHook(
                 loadLibraryExW,
                 LoadLibraryExW_Hook,
                 &LoadLibraryExW_Original)) {
@@ -1921,97 +1405,71 @@ BOOL Wh_ModInit() {
         }
     }
 
-    g_stopEvent =
-        CreateEventW(nullptr, TRUE, FALSE, nullptr);
-
+    g_stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
     if (!g_stopEvent) {
         Wh_Log(L"CreateEvent failed: %u", GetLastError());
         return FALSE;
     }
-
     return TRUE;
 }
 
 void Wh_ModAfterInit() {
-    Wh_Log(L"Looking for taskbar windows in this Explorer process");
-
-    // Only the shell Explorer instance registers Shell_TrayWnd. Folder-window
-    // Explorer processes never create the activation worker or its system-wide
-    // WinEvent hook.
     WNDCLASSW taskbarClass{};
     if (GetClassInfoW(GetModuleHandleW(nullptr),
                       L"Shell_TrayWnd",
                       &taskbarClass)) {
-        // Existing taskbar objects don't need a separate object-discovery send: the
-        // first posted taskbar-state update records its WndProc pThis before the
-        // operation is dispatched. This leaves worker startup independent of
-        // taskbar UI-thread responsiveness.
         EnsureActivationWorker();
-    } else {
-        Wh_Log(L"Shell_TrayWnd class isn't registered/created in this Explorer "
-               L"process yet; a later taskbar WM_NCCREATE can start the worker");
     }
 
-    // Retry in case the taskbar view module loaded between Wh_ModInit and hook
+    // Close the small race where Taskbar.View loads between Wh_ModInit and hook
     // application.
-    if (!g_taskbarViewDllLoaded.load(std::memory_order_acquire)) {
-        if (HMODULE taskbarViewModule =
-                GetTaskbarViewModuleHandle()) {
-            if (!g_taskbarViewDllLoaded.exchange(
-                    true,
-                    std::memory_order_acq_rel)) {
-                Wh_Log(L"Found taskbar view module after initialization");
-
-                if (HookTaskbarViewSymbols(taskbarViewModule)) {
-                    Wh_ApplyHookOperations();
-                    QueuePointerStateUpdate();
-                }
-            }
-        }
+    if (!g_taskbarViewDllLoaded.load()) {
+        HandleLoadedTaskbarViewModule(GetTaskbarViewModuleHandle());
     }
 }
 
 void Wh_ModBeforeUninit() {
     Wh_Log(L"Stopping activation worker");
-    g_unloading.store(true, std::memory_order_release);
-
+    g_unloading = true;
     if (g_stopEvent) {
         SetEvent(g_stopEvent);
     }
 
-    HANDLE workerThread = nullptr;
+    HANDLE worker = nullptr;
     {
         std::lock_guard<std::mutex> guard(g_workerThreadMutex);
-        workerThread = g_workerThread;
+        worker = g_workerThread;
     }
-    if (workerThread) {
-        WaitForSingleObject(workerThread, INFINITE);
+    if (worker) {
+        WaitForSingleObject(worker, INFINITE);
     }
 
-    // Fail open even if the taskbar UI thread is busy: ShouldTaskbarBeExpanded
-    // and the hide hooks stop enforcing keep-shown as soon as g_unloading is
-    // true. This post only asks Explorer to begin hiding promptly while the
-    // hooks are still installed; no persistent shell pointer state exists.
-    HWND desired =
-        g_desiredKeptShownTaskbar.exchange(nullptr, std::memory_order_acq_rel);
-    if (desired) {
-        PostTaskbarStateUpdate(desired);
-    }
+    // Reconcile every current taskbar while hooks are still installed, not only
+    // the latest desired HWND. This also cleans up the exceptional case where a
+    // prior release cleared desired state but its UI message never arrived.
+    g_desiredKeptShownTaskbar = nullptr;
+    EnumWindows(
+        [](HWND window, LPARAM) -> BOOL {
+            if (IsSupportedTaskbarWindow(window) &&
+                !SendTaskbarStateUpdate(window, 1000)) {
+                Wh_Log(L"Final taskbar-state release wasn't confirmed for %p",
+                       window);
+            }
+            return TRUE;
+        },
+        0);
 }
 
 void Wh_ModUninit() {
-    Wh_Log(L"Uninitializing");
-
-    HANDLE workerThread = nullptr;
+    HANDLE worker = nullptr;
     {
         std::lock_guard<std::mutex> guard(g_workerThreadMutex);
-        workerThread = g_workerThread;
+        worker = g_workerThread;
         g_workerThread = nullptr;
     }
-    if (workerThread) {
-        CloseHandle(workerThread);
+    if (worker) {
+        CloseHandle(worker);
     }
-
     if (g_stopEvent) {
         CloseHandle(g_stopEvent);
         g_stopEvent = nullptr;
@@ -2019,8 +1477,8 @@ void Wh_ModUninit() {
 }
 
 void Wh_ModSettingsChanged() {
-    Wh_Log(L"Settings changed");
     LoadSettings();
+    g_workerStateDirty = true;
     EnsureActivationWorker();
     QueuePointerStateUpdate();
 }

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/themagnificentoofman
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lshell32
+// @compilerOptions -lshell32 -lshcore
 // @license         GPL-3.0
 // ==/WindhawkMod==
 
@@ -16,10 +16,12 @@
 # Taskbar Activation Threshold
 
 Reveals an auto-hidden Windows 11 taskbar when the pointer enters a
-configurable activation band above the bottom edge of the monitor.
+configurable activation band above the bottom edge of the monitor. The pointer
+is never moved or injected; the mod invokes the taskbar's native reveal paths
+on Explorer's taskbar UI thread.
 
-Unlike version 0.1, this version **never moves the mouse cursor**. It invokes
-the Windows 11 taskbar's native pointer-over state on Explorer's UI thread.
+The activation band is scaled for each monitor's DPI, and cursor movement is
+observed through Windows accessibility events instead of continuous polling.
 
 ## Compatibility approach
 
@@ -48,12 +50,13 @@ bottom of the screen.
 
 - Taskbars moved to the top, left, right, or an arbitrary floating location
   aren't supported.
-- ExplorerPatcher's legacy Windows 10 taskbar isn't supported by version 0.2.
+- ExplorerPatcher's legacy Windows 10 taskbar isn't supported.
 - Mods which block or replace the taskbar's native expansion logic can
   conflict. In particular, keyboard-only or never-show auto-hide modes are
   intentionally incompatible with mouse activation.
 - Microsoft can rename undocumented taskbar symbols in a Windows update. If
-  that happens, the mod will need a symbol update.
+  that happens, one or more reveal paths may stop working until the symbols are
+  updated.
 - The taskbar's internal coordinator must have initialized before the first
   threshold activation. If the first attempt does nothing immediately after
   Explorer starts, leave and re-enter the activation band.
@@ -61,50 +64,14 @@ bottom of the screen.
 ## Suggested starting values
 
 - Activation threshold: `42`
-- Poll interval: `8`
 - Release delay: `120`
 - Activation cooldown: `250`
-
-## Version 0.2.4 fixes
-
-- Adds the missing shell-window reveal layer. Windows 11's
-  `ViewCoordinator::IsExpanded` can report true while the outer
-  `Shell_TrayWnd` is still physically hidden below the screen.
-- Calls the native `TrayUI::Unhide` or `CSecondaryTray::_Unhide` path before
-  setting the Windows 11 synthetic pointer-over state.
-- Captures the required taskbar objects after the mod loads, even though their
-  normal creation messages occurred before injection.
-- Keeps the pointer completely stationary.
-
-## Version 0.2.3 fixes
-
-- Explicitly calls `ViewCoordinator::UpdateIsExpanded` after changing the
-  synthetic pointer-over state.
-- Adds `ViewCoordinator::IsExpanded` verification to the diagnostic log.
-- Falls back to Explorer's native unhide timer if the explicit coordinator
-  update still reports the taskbar as collapsed.
-
-## Version 0.2.2 fixes
-
-- Forces `ShouldTaskbarBeExpanded` to return true while this mod owns the
-  synthetic pointer-over state.
-- Logs the taskbar expansion decision and update reason while diagnostic
-  logging is enabled.
-
-## Version 0.2.1 fixes
-
-- Disables fullscreen suppression by default because some borderless or
-  frameless maximized applications can resemble fullscreen windows.
-- Adds a native taskbar unhide-timer fallback when the Windows 11
-  `ViewCoordinator` hasn't been captured yet.
-- Adds clearer diagnostic logging for threshold entry and suppression.
 
 ## Attribution and license
 
 The Windows 11 `ViewCoordinator` symbol names and UI-thread invocation
 technique were informed by the GPL-3.0-licensed **Taskbar auto-hide fine
-tuning** Windhawk mod by m417z. Consequently, version 0.2 is distributed under
-GPL-3.0.
+tuning** Windhawk mod by m417z. This mod is distributed under GPL-3.0.
 */
 // ==/WindhawkModReadme==
 
@@ -113,13 +80,8 @@ GPL-3.0.
 - activationThresholdPx: 24
   $name: Activation threshold
   $description: >-
-    Height in physical screen pixels of the activation band above the bottom
-    edge. Recommended range: 12 to 48.
-- pollIntervalMs: 8
-  $name: Poll interval
-  $description: >-
-    How often the pointer position is checked, in milliseconds. Recommended:
-    8 to 16.
+    Height of the activation band in logical pixels at 96 DPI. The value is
+    scaled independently for each monitor. Recommended range: 12 to 48.
 - releaseDelayMs: 120
   $name: Release delay
   $description: >-
@@ -128,7 +90,7 @@ GPL-3.0.
 - activationCooldownMs: 200
   $name: Activation cooldown
   $description: >-
-    Minimum time between reveal attempts, in milliseconds.
+    Minimum time between reveal checks while the pointer remains in the band.
 - requireWindowsAutoHide: true
   $name: Require Windows auto-hide
   $description: >-
@@ -153,16 +115,12 @@ GPL-3.0.
     If the Windows 11 ViewCoordinator isn't available yet, ask Explorer's
     native taskbar unhide timer to reveal the taskbar. This doesn't move or
     inject the mouse cursor.
-- diagnosticLogging: false
-  $name: Diagnostic logging
-  $description: >-
-    Write detailed activation and suppression information to the Windhawk log.
-    Enable only while troubleshooting.
 */
 // ==/WindhawkModSettings==
 
 #include <windows.h>
 #include <shellapi.h>
+#include <shellscalingapi.h>
 #include <windhawk_utils.h>
 
 #include <algorithm>
@@ -174,7 +132,6 @@ GPL-3.0.
 
 struct Settings {
     std::atomic<int> activationThresholdPx{24};
-    std::atomic<int> pollIntervalMs{8};
     std::atomic<int> releaseDelayMs{120};
     std::atomic<int> activationCooldownMs{200};
     std::atomic<bool> requireWindowsAutoHide{true};
@@ -182,18 +139,21 @@ struct Settings {
     std::atomic<bool> ignoreWhileMouseButtonDown{true};
     std::atomic<bool> primaryMonitorOnly{false};
     std::atomic<bool> nativeTimerFallback{true};
-    std::atomic<bool> diagnosticLogging{false};
 };
 
 Settings g_settings;
 
 std::atomic<bool> g_taskbarViewDllLoaded{false};
 std::atomic<bool> g_settingsChanged{false};
+std::atomic<DWORD> g_workerThreadId{0};
+std::atomic<bool> g_cursorUpdatePosted{false};
+std::atomic<HWND> g_mainTaskbarWindow{nullptr};
 
 HANDLE g_stopEvent = nullptr;
+HANDLE g_workerReadyEvent = nullptr;
 HANDLE g_workerThread = nullptr;
 
-// A private message used to marshal operations from the polling worker to
+// A private message used to marshal operations from the cursor-event worker to
 // Explorer's taskbar UI thread.
 const UINT g_uiThreadMessage =
     RegisterWindowMessageW(L"Windhawk_TaskbarActivationThreshold_" WH_MOD_ID);
@@ -209,47 +169,41 @@ enum UiOperation : WPARAM {
     kUiRevealTaskbar = 1,
     kUiClearSyntheticPointerOver = 2,
     kUiClearAllSyntheticPointerOver = 3,
+    kUiTriggerNativeUnhideTimer = 4,
 };
 
-// The following maps are accessed only on Explorer's taskbar UI thread.
-// They provide the shell object needed to physically slide Shell_TrayWnd
-// onscreen. ViewCoordinator alone only controls the Windows 11 taskbar view's
-// logical expanded/collapsed state.
+constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
+constexpr UINT kWorkerSettingsChangedMessage = WM_APP + 2;
+constexpr UINT_PTR kWorkerReleaseTimer = 1;
+constexpr UINT_PTR kWorkerRetryTimer = 2;
+constexpr UINT_PTR kWorkerFallbackPollTimer = 3;
+
+// These containers are used by taskbar implementation callbacks and by
+// operations marshalled to the taskbar UI thread. This matches the threading
+// convention used by the maintained taskbar auto-hide mods.
 std::unordered_map<HWND, void*> g_trayUiWndProcObjects;
 std::unordered_map<HWND, void*> g_secondaryTrayObjects;
-
-void* g_trayUiVtableITrayComponentHost = nullptr;
-void* g_secondaryTrayVtableISecondaryTray = nullptr;
-
-// ViewCoordinator mappings are captured by hooks which run inside the taskbar
-// implementation. Access is protected because a Windows update could move a
-// callback to a different Explorer thread.
-SRWLOCK g_viewCoordinatorLock = SRWLOCK_INIT;
 std::unordered_map<HWND, void*> g_viewCoordinators;
-
-// Accessed only on the taskbar UI thread.
 std::unordered_set<HWND> g_syntheticPointerOverTaskbars;
 
-template <typename T>
-T ClampSetting(T value, T minimum, T maximum) {
-    return std::clamp(value, minimum, maximum);
+void* g_trayUiVtableITrayComponentHost = nullptr;
+
+void ForgetTaskbarState(HWND taskbarWindow) {
+    g_viewCoordinators.erase(taskbarWindow);
+    g_syntheticPointerOverTaskbars.erase(taskbarWindow);
 }
 
 void LoadSettings() {
     g_settings.activationThresholdPx.store(
-        ClampSetting(Wh_GetIntSetting(L"activationThresholdPx"), 1, 500),
-        std::memory_order_relaxed);
-
-    g_settings.pollIntervalMs.store(
-        ClampSetting(Wh_GetIntSetting(L"pollIntervalMs"), 1, 1000),
+        std::clamp(Wh_GetIntSetting(L"activationThresholdPx"), 1, 500),
         std::memory_order_relaxed);
 
     g_settings.releaseDelayMs.store(
-        ClampSetting(Wh_GetIntSetting(L"releaseDelayMs"), 0, 5000),
+        std::clamp(Wh_GetIntSetting(L"releaseDelayMs"), 0, 5000),
         std::memory_order_relaxed);
 
     g_settings.activationCooldownMs.store(
-        ClampSetting(Wh_GetIntSetting(L"activationCooldownMs"), 0, 10000),
+        std::clamp(Wh_GetIntSetting(L"activationCooldownMs"), 0, 10000),
         std::memory_order_relaxed);
 
     g_settings.requireWindowsAutoHide.store(
@@ -271,10 +225,6 @@ void LoadSettings() {
     g_settings.nativeTimerFallback.store(
         Wh_GetIntSetting(L"nativeTimerFallback") != 0,
         std::memory_order_relaxed);
-
-    g_settings.diagnosticLogging.store(
-        Wh_GetIntSetting(L"diagnosticLogging") != 0,
-        std::memory_order_relaxed);
 }
 
 bool IsTaskbarClass(HWND window) {
@@ -291,31 +241,41 @@ bool IsTaskbarClass(HWND window) {
            _wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0;
 }
 
+bool IsCurrentProcessWindow(HWND window) {
+    if (!window || !IsWindow(window)) {
+        return false;
+    }
+
+    DWORD processId = 0;
+    GetWindowThreadProcessId(window, &processId);
+    return processId == GetCurrentProcessId();
+}
+
+bool IsMainTaskbarWindow(HWND window) {
+    if (!IsCurrentProcessWindow(window)) {
+        return false;
+    }
+
+    wchar_t className[64];
+    return GetClassNameW(window, className, ARRAYSIZE(className)) &&
+           _wcsicmp(className, L"Shell_TrayWnd") == 0;
+}
+
 HWND FindMainTaskbarWindow() {
-    HWND result = nullptr;
-    EnumWindows(
-        [](HWND window, LPARAM parameter) -> BOOL {
-            auto* result = reinterpret_cast<HWND*>(parameter);
+    HWND cached = g_mainTaskbarWindow.load(std::memory_order_relaxed);
+    if (IsMainTaskbarWindow(cached)) {
+        return cached;
+    }
 
-            DWORD processId = 0;
-            GetWindowThreadProcessId(window, &processId);
+    g_mainTaskbarWindow.store(nullptr, std::memory_order_relaxed);
 
-            if (processId != GetCurrentProcessId()) {
-                return TRUE;
-            }
+    HWND taskbarWindow = FindWindowW(L"Shell_TrayWnd", nullptr);
+    if (!IsMainTaskbarWindow(taskbarWindow)) {
+        return nullptr;
+    }
 
-            wchar_t className[64];
-            if (GetClassNameW(window, className, ARRAYSIZE(className)) &&
-                _wcsicmp(className, L"Shell_TrayWnd") == 0) {
-                *result = window;
-                return FALSE;
-            }
-
-            return TRUE;
-        },
-        reinterpret_cast<LPARAM>(&result));
-
-    return result;
+    g_mainTaskbarWindow.store(taskbarWindow, std::memory_order_relaxed);
+    return taskbarWindow;
 }
 
 HWND GetTaskBandWindow() {
@@ -410,6 +370,13 @@ BOOL CALLBACK FindTaskbarForMonitorCallback(HWND window, LPARAM parameter) {
 }
 
 HWND FindTaskbarForMonitor(HMONITOR monitor) {
+    HWND mainTaskbar = FindMainTaskbarWindow();
+    if (mainTaskbar &&
+        GetTaskbarMonitor(mainTaskbar) == monitor &&
+        IsBottomPositionedTaskbar(mainTaskbar, monitor)) {
+        return mainTaskbar;
+    }
+
     FindTaskbarContext context{
         .monitor = monitor,
         .result = nullptr,
@@ -504,13 +471,21 @@ bool IsFullscreenWindowOnMonitor(HMONITOR monitor) {
 }
 
 bool IsPointInsideActivationBand(const POINT& pointer,
+                                 HMONITOR monitor,
                                  const MONITORINFO& monitorInfo) {
     const int monitorHeight =
         monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top;
 
-    const int threshold = std::min(
-        g_settings.activationThresholdPx.load(std::memory_order_relaxed),
-        monitorHeight);
+    UINT dpiX = 96;
+    UINT dpiY = 96;
+    if (FAILED(GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY))) {
+        dpiY = 96;
+    }
+
+    const int logicalThreshold =
+        g_settings.activationThresholdPx.load(std::memory_order_relaxed);
+    const int threshold =
+        std::min(MulDiv(logicalThreshold, dpiY, 96), monitorHeight);
 
     return pointer.x >= monitorInfo.rcMonitor.left &&
            pointer.x < monitorInfo.rcMonitor.right &&
@@ -537,8 +512,7 @@ void* QueryViaVtable(void* object, void* targetVtable) {
     auto** candidate = reinterpret_cast<void**>(object);
 
     for (size_t i = 0; i < 256; i++, candidate++) {
-        if (!IsBadReadPtr(candidate, sizeof(void*)) &&
-            *candidate == targetVtable) {
+        if (*candidate == targetVtable) {
             return candidate;
         }
     }
@@ -577,16 +551,24 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
     WPARAM wParam,
     LPARAM lParam,
     bool* handled) {
-    if (message == WM_NCCREATE ||
-        message == g_captureTaskbarObjectMessage) {
+    if (message == WM_NCCREATE) {
         g_trayUiWndProcObjects[window] = trayUi;
-
-        if (g_settings.diagnosticLogging.load(
-                std::memory_order_relaxed)) {
-            Wh_Log(L"Captured TrayUI object for taskbar %p", window);
+        g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
+        Wh_Log(L"Captured TrayUI object for taskbar %p", window);
+    } else if (message == g_captureTaskbarObjectMessage) {
+        g_trayUiWndProcObjects[window] = trayUi;
+        g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
+        Wh_Log(L"Captured TrayUI object for taskbar %p", window);
+        if (handled) {
+            *handled = true;
         }
+        return 0;
     } else if (message == WM_NCDESTROY) {
         g_trayUiWndProcObjects.erase(window);
+        ForgetTaskbarState(window);
+        if (g_mainTaskbarWindow.load(std::memory_order_relaxed) == window) {
+            g_mainTaskbarWindow.store(nullptr, std::memory_order_relaxed);
+        }
     }
 
     return TrayUI_WndProc_Original(
@@ -613,17 +595,16 @@ LRESULT WINAPI CSecondaryTray_WndProc_Hook(
     UINT message,
     WPARAM wParam,
     LPARAM lParam) {
-    if (message == WM_NCCREATE ||
-        message == g_captureTaskbarObjectMessage) {
+    if (message == WM_NCCREATE) {
         g_secondaryTrayObjects[window] = secondaryTray;
-
-        if (g_settings.diagnosticLogging.load(
-                std::memory_order_relaxed)) {
-            Wh_Log(L"Captured CSecondaryTray object for taskbar %p",
-                   window);
-        }
+        Wh_Log(L"Captured CSecondaryTray object for taskbar %p", window);
+    } else if (message == g_captureTaskbarObjectMessage) {
+        g_secondaryTrayObjects[window] = secondaryTray;
+        Wh_Log(L"Captured CSecondaryTray object for taskbar %p", window);
+        return 0;
     } else if (message == WM_NCDESTROY) {
         g_secondaryTrayObjects.erase(window);
+        ForgetTaskbarState(window);
     }
 
     return CSecondaryTray_WndProc_Original(
@@ -650,15 +631,13 @@ bool InvokeNativeShellUnhideOnUiThread(HWND taskbarWindow) {
         auto it = g_trayUiWndProcObjects.find(taskbarWindow);
 
         if (it == g_trayUiWndProcObjects.end() ||
-            !TrayUI_Unhide_Original) {
-            if (g_settings.diagnosticLogging.load(
-                    std::memory_order_relaxed)) {
-                Wh_Log(L"Native main-taskbar unhide unavailable: "
-                       L"object=%d function=%d",
-                       it != g_trayUiWndProcObjects.end(),
-                       TrayUI_Unhide_Original != nullptr);
-            }
-
+            !TrayUI_Unhide_Original ||
+            !g_trayUiVtableITrayComponentHost) {
+            Wh_Log(L"Native main-taskbar unhide unavailable: "
+                   L"object=%d vtable=%d function=%d",
+                   it != g_trayUiWndProcObjects.end(),
+                   g_trayUiVtableITrayComponentHost != nullptr,
+                   TrayUI_Unhide_Original != nullptr);
             return false;
         }
 
@@ -673,13 +652,7 @@ bool InvokeNativeShellUnhideOnUiThread(HWND taskbarWindow) {
         }
 
         TrayUI_Unhide_Original(trayComponentHost, 0, 0);
-
-        if (g_settings.diagnosticLogging.load(
-                std::memory_order_relaxed)) {
-            Wh_Log(L"Called TrayUI::Unhide for taskbar %p",
-                   taskbarWindow);
-        }
-
+        Wh_Log(L"Called TrayUI::Unhide for taskbar %p", taskbarWindow);
         return true;
     }
 
@@ -688,25 +661,16 @@ bool InvokeNativeShellUnhideOnUiThread(HWND taskbarWindow) {
 
         if (it == g_secondaryTrayObjects.end() ||
             !CSecondaryTray_Unhide_Original) {
-            if (g_settings.diagnosticLogging.load(
-                    std::memory_order_relaxed)) {
-                Wh_Log(L"Native secondary-taskbar unhide unavailable: "
-                       L"object=%d function=%d",
-                       it != g_secondaryTrayObjects.end(),
-                       CSecondaryTray_Unhide_Original != nullptr);
-            }
-
+            Wh_Log(L"Native secondary-taskbar unhide unavailable: "
+                   L"object=%d function=%d",
+                   it != g_secondaryTrayObjects.end(),
+                   CSecondaryTray_Unhide_Original != nullptr);
             return false;
         }
 
         CSecondaryTray_Unhide_Original(it->second, 0, 0);
-
-        if (g_settings.diagnosticLogging.load(
-                std::memory_order_relaxed)) {
-            Wh_Log(L"Called CSecondaryTray::_Unhide for taskbar %p",
-                   taskbarWindow);
-        }
-
+        Wh_Log(L"Called CSecondaryTray::_Unhide for taskbar %p",
+               taskbarWindow);
         return true;
     }
 
@@ -718,29 +682,16 @@ void RememberViewCoordinator(HWND taskbarWindow, void* viewCoordinator) {
         return;
     }
 
-    AcquireSRWLockExclusive(&g_viewCoordinatorLock);
     g_viewCoordinators[taskbarWindow] = viewCoordinator;
-    ReleaseSRWLockExclusive(&g_viewCoordinatorLock);
 }
 
 void ForgetInvalidViewCoordinator(HWND taskbarWindow) {
-    AcquireSRWLockExclusive(&g_viewCoordinatorLock);
-    g_viewCoordinators.erase(taskbarWindow);
-    ReleaseSRWLockExclusive(&g_viewCoordinatorLock);
+    ForgetTaskbarState(taskbarWindow);
 }
 
 void* GetViewCoordinator(HWND taskbarWindow) {
-    void* viewCoordinator = nullptr;
-
-    AcquireSRWLockShared(&g_viewCoordinatorLock);
-
     auto it = g_viewCoordinators.find(taskbarWindow);
-    if (it != g_viewCoordinators.end()) {
-        viewCoordinator = it->second;
-    }
-
-    ReleaseSRWLockShared(&g_viewCoordinatorLock);
-    return viewCoordinator;
+    return it != g_viewCoordinators.end() ? it->second : nullptr;
 }
 
 // Undocumented Windows 11 taskbar methods.
@@ -800,14 +751,10 @@ bool WINAPI ViewCoordinator_ShouldTaskbarBeExpanded_Hook(
     // taskbar frame. While this mod owns the synthetic pointer-over state,
     // explicitly authorize expansion in the coordinator's decision function.
     if (g_syntheticPointerOverTaskbars.contains(taskbarWindow)) {
-        if (g_settings.diagnosticLogging.load(
-                std::memory_order_relaxed)) {
-            Wh_Log(L"ShouldTaskbarBeExpanded: forcing true for taskbar %p "
-                   L"(requested=%d)",
-                   taskbarWindow,
-                   expanded);
-        }
-
+        Wh_Log(L"ShouldTaskbarBeExpanded: forcing true for taskbar %p "
+               L"(requested=%d)",
+               taskbarWindow,
+               expanded);
         return true;
     }
 
@@ -817,15 +764,11 @@ bool WINAPI ViewCoordinator_ShouldTaskbarBeExpanded_Hook(
             taskbarWindow,
             expanded);
 
-    if (g_settings.diagnosticLogging.load(
-            std::memory_order_relaxed)) {
-        Wh_Log(L"ShouldTaskbarBeExpanded: native result=%d for taskbar %p "
-               L"(requested=%d)",
-               result,
-               taskbarWindow,
-               expanded);
-    }
-
+    Wh_Log(L"ShouldTaskbarBeExpanded: native result=%d for taskbar %p "
+           L"(requested=%d)",
+           result,
+           taskbarWindow,
+           expanded);
     return result;
 }
 
@@ -843,13 +786,10 @@ void WINAPI ViewCoordinator_UpdateIsExpanded_Hook(
     int reason) {
     RememberViewCoordinator(taskbarWindow, viewCoordinator);
 
-    if (g_settings.diagnosticLogging.load(
-            std::memory_order_relaxed)) {
-        Wh_Log(L"UpdateIsExpanded: taskbar=%p reason=%d synthetic=%d",
-               taskbarWindow,
-               reason,
-               g_syntheticPointerOverTaskbars.contains(taskbarWindow));
-    }
+    Wh_Log(L"UpdateIsExpanded: taskbar=%p reason=%d synthetic=%d",
+           taskbarWindow,
+           reason,
+           g_syntheticPointerOverTaskbars.contains(taskbarWindow));
 
     ViewCoordinator_UpdateIsExpanded_Original(
         viewCoordinator,
@@ -858,15 +798,13 @@ void WINAPI ViewCoordinator_UpdateIsExpanded_Hook(
 }
 
 bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
-                                      bool isPointerOver) {
+                                       bool isPointerOver) {
     if (!taskbarWindow || !IsWindow(taskbarWindow) ||
         !ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original ||
         !ViewCoordinator_UpdateIsExpanded_Original) {
         if (taskbarWindow && !IsWindow(taskbarWindow)) {
             ForgetInvalidViewCoordinator(taskbarWindow);
-            g_syntheticPointerOverTaskbars.erase(taskbarWindow);
         }
-
         return false;
     }
 
@@ -888,16 +826,12 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
         Wh_Log(L"Setting synthetic pointer-over for taskbar %p",
                taskbarWindow);
 
-        // First update the coordinator's pointer-over state.
         ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
             viewCoordinator,
             taskbarWindow,
             true,
             0);
 
-        // Some Windows 11 builds don't immediately reevaluate expansion when
-        // HandleIsPointerOverTaskbarFrameChanged is invoked programmatically.
-        // Force the same reason-7 state recomputation used by the taskbar.
         ViewCoordinator_UpdateIsExpanded_Original(
             viewCoordinator,
             taskbarWindow,
@@ -908,18 +842,24 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
             expanded = ViewCoordinator_IsExpanded_Original(
                 viewCoordinator,
                 taskbarWindow);
-        }
-
-        if (g_settings.diagnosticLogging.load(
-                std::memory_order_relaxed)) {
             Wh_Log(L"Coordinator expansion result after synthetic enter: %d",
                    expanded);
         }
 
-        // Return false when verification is available and the coordinator is
-        // still collapsed. The caller can then try the native timer fallback.
+        // IsExpanded can be asynchronous. If verification is available and it
+        // still reports collapsed, fully undo the synthetic enter before the
+        // caller tries the native timer fallback.
         if (ViewCoordinator_IsExpanded_Original && !expanded) {
             g_syntheticPointerOverTaskbars.erase(taskbarWindow);
+            ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
+                viewCoordinator,
+                taskbarWindow,
+                false,
+                0);
+            ViewCoordinator_UpdateIsExpanded_Original(
+                viewCoordinator,
+                taskbarWindow,
+                kReasonIsPointerOverTaskbarFrameChanged);
             return false;
         }
     } else {
@@ -941,13 +881,10 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
             taskbarWindow,
             kReasonIsPointerOverTaskbarFrameChanged);
 
-        if (g_settings.diagnosticLogging.load(
-                std::memory_order_relaxed) &&
-            ViewCoordinator_IsExpanded_Original) {
+        if (ViewCoordinator_IsExpanded_Original) {
             bool expanded = ViewCoordinator_IsExpanded_Original(
                 viewCoordinator,
                 taskbarWindow);
-
             Wh_Log(L"Coordinator expansion result after synthetic leave: %d",
                    expanded);
         }
@@ -955,7 +892,6 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
 
     return true;
 }
-
 
 bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
     // The maintained Windhawk taskbar implementation invokes both paths:
@@ -965,17 +901,12 @@ bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
         InvokeNativeShellUnhideOnUiThread(taskbarWindow);
 
     const bool coordinatorExpanded =
-        SetSyntheticPointerOverOnUiThread(
-            taskbarWindow,
-            true);
+        SetSyntheticPointerOverOnUiThread(taskbarWindow, true);
 
-    if (g_settings.diagnosticLogging.load(
-            std::memory_order_relaxed)) {
-        Wh_Log(L"Reveal result for taskbar %p: shell=%d coordinator=%d",
-               taskbarWindow,
-               shellWindowRevealed,
-               coordinatorExpanded);
-    }
+    Wh_Log(L"Reveal result for taskbar %p: shell=%d coordinator=%d",
+           taskbarWindow,
+           shellWindowRevealed,
+           coordinatorExpanded);
 
     return shellWindowRevealed || coordinatorExpanded;
 }
@@ -993,7 +924,7 @@ void ClearAllSyntheticPointerOverOnUiThread() {
 }
 
 // This window belongs to Explorer's taskbar UI thread, so custom operations
-// sent here can safely invoke ViewCoordinator.
+// sent here can safely invoke ViewCoordinator and taskbar window timers.
 using CTaskBand_v_WndProc_t =
     LRESULT(WINAPI*)(void* taskBand,
                      HWND window,
@@ -1002,6 +933,28 @@ using CTaskBand_v_WndProc_t =
                      LPARAM lParam);
 
 CTaskBand_v_WndProc_t CTaskBand_v_WndProc_Original;
+
+constexpr UINT_PTR kTrayUITimerUnhide = 3;
+
+bool TriggerNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
+    if (!taskbarWindow || !IsWindow(taskbarWindow)) {
+        return false;
+    }
+
+    UINT_PTR timerResult =
+        SetTimer(taskbarWindow, kTrayUITimerUnhide, 1, nullptr);
+
+    if (!timerResult) {
+        Wh_Log(L"Native unhide timer failed for taskbar %p: %u",
+               taskbarWindow,
+               GetLastError());
+        return false;
+    }
+
+    Wh_Log(L"Requested native unhide timer for taskbar %p",
+           taskbarWindow);
+    return true;
+}
 
 LRESULT WINAPI CTaskBand_v_WndProc_Hook(
     void* taskBand,
@@ -1017,9 +970,7 @@ LRESULT WINAPI CTaskBand_v_WndProc_Hook(
 
         switch (operation) {
             case kUiRevealTaskbar:
-                return RevealTaskbarOnUiThread(targetTaskbar)
-                           ? 1
-                           : 0;
+                return RevealTaskbarOnUiThread(targetTaskbar) ? 1 : 0;
 
             case kUiClearSyntheticPointerOver:
                 return SetSyntheticPointerOverOnUiThread(
@@ -1031,6 +982,11 @@ LRESULT WINAPI CTaskBand_v_WndProc_Hook(
             case kUiClearAllSyntheticPointerOver:
                 ClearAllSyntheticPointerOverOnUiThread();
                 return 1;
+
+            case kUiTriggerNativeUnhideTimer:
+                return TriggerNativeUnhideTimerOnUiThread(targetTaskbar)
+                           ? 1
+                           : 0;
         }
 
         return 0;
@@ -1044,7 +1000,9 @@ LRESULT WINAPI CTaskBand_v_WndProc_Hook(
         lParam);
 }
 
-bool SendUiOperation(UiOperation operation, HWND taskbarWindow) {
+bool SendUiOperation(UiOperation operation,
+                     HWND taskbarWindow,
+                     DWORD timeoutMs = 250) {
     HWND taskBandWindow = GetTaskBandWindow();
     if (!taskBandWindow) {
         return false;
@@ -1058,7 +1016,7 @@ bool SendUiOperation(UiOperation operation, HWND taskbarWindow) {
             operation,
             reinterpret_cast<LPARAM>(taskbarWindow),
             SMTO_ABORTIFHUNG | SMTO_BLOCK,
-            250,
+            timeoutMs,
             &result)) {
         Wh_Log(L"UI-thread operation timed out or failed: %u",
                GetLastError());
@@ -1068,248 +1026,391 @@ bool SendUiOperation(UiOperation operation, HWND taskbarWindow) {
     return result != 0;
 }
 
+struct ActivationWorkerState {
+    HWND activeTaskbar = nullptr;
+    HMONITOR activeTaskbarMonitor = nullptr;
+    bool armed = true;
+    UINT_PTR releaseTimerId = 0;
+    UINT_PTR retryTimerId = 0;
+    ULONGLONG lastActivationCheck = 0;
+};
 
-constexpr UINT_PTR kTrayUITimerHide = 2;
-constexpr UINT_PTR kTrayUITimerUnhide = 3;
-
-bool TriggerNativeUnhideTimer(HWND taskbarWindow) {
-    if (!taskbarWindow || !IsWindow(taskbarWindow)) {
-        return false;
+void CancelWorkerTimer(UINT_PTR& timerId) {
+    if (!timerId) {
+        return;
     }
 
-    // Explorer's native taskbar hover path uses timer ID 3 for unhide. SetTimer
-    // associates the timer with the taskbar window, so WM_TIMER is handled on
-    // Explorer's taskbar thread. This does not move, spoof, or inject the mouse.
-    UINT_PTR timerResult =
-        SetTimer(taskbarWindow, kTrayUITimerUnhide, 1, nullptr);
-
-    if (!timerResult) {
-        Wh_Log(L"Native unhide timer failed for taskbar %p: %u",
-               taskbarWindow,
-               GetLastError());
-        return false;
-    }
-
-    if (g_settings.diagnosticLogging.load(std::memory_order_relaxed)) {
-        Wh_Log(L"Requested native unhide timer for taskbar %p",
-               taskbarWindow);
-    }
-
-    return true;
+    KillTimer(nullptr, timerId);
+    timerId = 0;
 }
 
-DWORD WINAPI ActivationWorkerThread(LPVOID) {
-    HWND activeTaskbar = nullptr;
-    bool armed = true;
-    ULONGLONG lastActivationAttempt = 0;
-    ULONGLONG outsideSince = 0;
+void ScheduleWorkerTimer(UINT_PTR requestedTimerId,
+                         UINT delayMs,
+                         UINT_PTR& timerId) {
+    if (timerId) {
+        return;
+    }
 
-    while (true) {
-        const int pollInterval =
-            g_settings.pollIntervalMs.load(std::memory_order_relaxed);
+    timerId = SetTimer(nullptr,
+                       requestedTimerId,
+                       std::max(delayMs, 1U),
+                       nullptr);
+    if (!timerId) {
+        Wh_Log(L"Failed to create worker timer %llu: %u",
+               static_cast<unsigned long long>(requestedTimerId),
+               GetLastError());
+    }
+}
 
-        if (WaitForSingleObject(g_stopEvent, pollInterval) ==
-            WAIT_OBJECT_0) {
-            break;
-        }
+void ClearActiveTaskbar(ActivationWorkerState& state) {
+    CancelWorkerTimer(state.releaseTimerId);
 
-        if (g_settingsChanged.exchange(false,
-                                       std::memory_order_relaxed)) {
-            if (activeTaskbar) {
-                SendUiOperation(kUiClearSyntheticPointerOver,
-                                activeTaskbar);
-            }
+    if (state.activeTaskbar) {
+        SendUiOperation(kUiClearSyntheticPointerOver,
+                        state.activeTaskbar);
+    }
 
-            activeTaskbar = nullptr;
-            armed = true;
-            outsideSince = 0;
-        }
+    state.activeTaskbar = nullptr;
+    state.activeTaskbarMonitor = nullptr;
+    state.armed = true;
+}
 
-        POINT pointer{};
-        if (!GetCursorPos(&pointer)) {
-            continue;
-        }
+void ScheduleRetry(ActivationWorkerState& state, UINT delayMs) {
+    ScheduleWorkerTimer(kWorkerRetryTimer,
+                        delayMs,
+                        state.retryTimerId);
+}
 
-        HMONITOR pointerMonitor =
-            MonitorFromPoint(pointer, MONITOR_DEFAULTTONULL);
+void ProcessPointerState(ActivationWorkerState& state) {
+    if (g_settingsChanged.exchange(false, std::memory_order_relaxed)) {
+        CancelWorkerTimer(state.retryTimerId);
+        ClearActiveTaskbar(state);
+        state.lastActivationCheck = 0;
+    }
 
-        if (!pointerMonitor) {
-            if (activeTaskbar) {
-                SendUiOperation(kUiClearSyntheticPointerOver,
-                                activeTaskbar);
-                activeTaskbar = nullptr;
-            }
+    POINT pointer{};
+    if (!GetCursorPos(&pointer)) {
+        return;
+    }
 
-            armed = true;
-            outsideSince = 0;
-            continue;
-        }
+    HMONITOR pointerMonitor =
+        MonitorFromPoint(pointer, MONITOR_DEFAULTTONULL);
 
-        MONITORINFO monitorInfo{};
-        monitorInfo.cbSize = sizeof(monitorInfo);
+    if (!pointerMonitor) {
+        ClearActiveTaskbar(state);
+        CancelWorkerTimer(state.retryTimerId);
+        return;
+    }
 
-        if (!GetMonitorInfoW(pointerMonitor, &monitorInfo)) {
-            continue;
-        }
+    MONITORINFO monitorInfo{};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if (!GetMonitorInfoW(pointerMonitor, &monitorInfo)) {
+        return;
+    }
 
-        const bool insideActivationBand =
-            IsPointInsideActivationBand(pointer, monitorInfo);
+    const bool insideActivationBand =
+        IsPointInsideActivationBand(pointer, pointerMonitor, monitorInfo);
 
-        if (activeTaskbar) {
-            if (!IsWindow(activeTaskbar)) {
-                activeTaskbar = nullptr;
-                armed = true;
-                outsideSince = 0;
-                continue;
-            }
-
+    if (state.activeTaskbar) {
+        if (!IsWindow(state.activeTaskbar)) {
+            CancelWorkerTimer(state.releaseTimerId);
+            state.activeTaskbar = nullptr;
+            state.activeTaskbarMonitor = nullptr;
+            state.armed = true;
+        } else {
             const bool overVisibleTaskbar =
-                IsPointOverTaskbar(activeTaskbar, pointer);
+                IsPointOverTaskbar(state.activeTaskbar, pointer);
 
-            if (insideActivationBand || overVisibleTaskbar) {
-                outsideSince = 0;
-                continue;
-            }
-
-            const ULONGLONG now = GetTickCount64();
-
-            if (!outsideSince) {
-                outsideSince = now;
-                continue;
+            if ((insideActivationBand &&
+                 pointerMonitor == state.activeTaskbarMonitor) ||
+                overVisibleTaskbar) {
+                CancelWorkerTimer(state.releaseTimerId);
+                return;
             }
 
             const int releaseDelay =
                 g_settings.releaseDelayMs.load(
                     std::memory_order_relaxed);
 
-            if (now - outsideSince <
-                static_cast<ULONGLONG>(releaseDelay)) {
-                continue;
+            if (releaseDelay == 0) {
+                ClearActiveTaskbar(state);
+            } else {
+                ScheduleWorkerTimer(
+                    kWorkerReleaseTimer,
+                    static_cast<UINT>(releaseDelay),
+                    state.releaseTimerId);
+                return;
             }
-
-            SendUiOperation(kUiClearSyntheticPointerOver,
-                            activeTaskbar);
-
-            activeTaskbar = nullptr;
-            armed = true;
-            outsideSince = 0;
-            continue;
-        }
-
-        if (!insideActivationBand) {
-            armed = true;
-            continue;
-        }
-
-        if (g_settings.diagnosticLogging.load(
-                std::memory_order_relaxed) &&
-            armed) {
-            Wh_Log(L"Pointer entered activation band: x=%d y=%d bottom=%d",
-                   pointer.x,
-                   pointer.y,
-                   monitorInfo.rcMonitor.bottom);
-        }
-
-        if (!armed) {
-            continue;
-        }
-
-        if (g_settings.primaryMonitorOnly.load(
-                std::memory_order_relaxed) &&
-            (monitorInfo.dwFlags & MONITORINFOF_PRIMARY) == 0) {
-            continue;
-        }
-
-        if (g_settings.requireWindowsAutoHide.load(
-                std::memory_order_relaxed) &&
-            !IsWindowsAutoHideEnabled()) {
-            continue;
-        }
-
-        if (g_settings.ignoreWhileMouseButtonDown.load(
-                std::memory_order_relaxed) &&
-            IsAnyMouseButtonDown()) {
-            continue;
-        }
-
-        if (g_settings.ignoreFullscreenApps.load(
-                std::memory_order_relaxed) &&
-            IsFullscreenWindowOnMonitor(pointerMonitor)) {
-            if (g_settings.diagnosticLogging.load(
-                    std::memory_order_relaxed)) {
-                Wh_Log(L"Activation suppressed: fullscreen app detected");
-            }
-            continue;
-        }
-
-        const ULONGLONG now = GetTickCount64();
-        const int cooldown =
-            g_settings.activationCooldownMs.load(
-                std::memory_order_relaxed);
-
-        if (now - lastActivationAttempt <
-            static_cast<ULONGLONG>(cooldown)) {
-            continue;
-        }
-
-        lastActivationAttempt = now;
-
-        HWND taskbarWindow =
-            FindTaskbarForMonitor(pointerMonitor);
-
-        if (!taskbarWindow) {
-            if (g_settings.diagnosticLogging.load(
-                    std::memory_order_relaxed)) {
-                Wh_Log(L"Activation suppressed: no bottom taskbar found");
-            }
-            continue;
-        }
-
-        bool activated =
-            SendUiOperation(kUiRevealTaskbar,
-                            taskbarWindow);
-
-        if (activated) {
-            Wh_Log(L"Activated taskbar %p through native shell/coordinator "
-                   L"path",
-                   taskbarWindow);
-
-            activeTaskbar = taskbarWindow;
-            armed = false;
-            outsideSince = 0;
-            continue;
-        }
-
-        if (g_settings.nativeTimerFallback.load(
-                std::memory_order_relaxed) &&
-            TriggerNativeUnhideTimer(taskbarWindow)) {
-            Wh_Log(L"Activated taskbar %p through native timer fallback",
-                   taskbarWindow);
-
-            // No synthetic pointer-over state was created, so Windows owns the
-            // normal hide behavior. Rearm only after the pointer leaves the
-            // configured activation band.
-            armed = false;
-            outsideSince = 0;
-            continue;
-        }
-
-        if (g_settings.diagnosticLogging.load(
-                std::memory_order_relaxed)) {
-            Wh_Log(L"Threshold entered, but no reveal backend succeeded");
         }
     }
 
-    if (activeTaskbar) {
-        SendUiOperation(kUiClearSyntheticPointerOver,
-                        activeTaskbar);
+    if (!insideActivationBand) {
+        state.armed = true;
+        CancelWorkerTimer(state.retryTimerId);
+        return;
     }
 
+    if (!state.armed) {
+        CancelWorkerTimer(state.retryTimerId);
+        return;
+    }
+
+    // Throttle the entire activation decision, including shell, mouse-button,
+    // and fullscreen suppression checks.
+    const ULONGLONG now = GetTickCount64();
+    const int cooldown =
+        g_settings.activationCooldownMs.load(
+            std::memory_order_relaxed);
+    const ULONGLONG elapsed = now - state.lastActivationCheck;
+
+    if (elapsed < static_cast<ULONGLONG>(cooldown)) {
+        ScheduleRetry(
+            state,
+            static_cast<UINT>(
+                static_cast<ULONGLONG>(cooldown) - elapsed));
+        return;
+    }
+
+    state.lastActivationCheck = now;
+    CancelWorkerTimer(state.retryTimerId);
+
+    Wh_Log(L"Pointer entered activation band: x=%d y=%d bottom=%d",
+           pointer.x,
+           pointer.y,
+           monitorInfo.rcMonitor.bottom);
+
+    if (g_settings.primaryMonitorOnly.load(
+            std::memory_order_relaxed) &&
+        (monitorInfo.dwFlags & MONITORINFOF_PRIMARY) == 0) {
+        return;
+    }
+
+    if (g_settings.requireWindowsAutoHide.load(
+            std::memory_order_relaxed) &&
+        !IsWindowsAutoHideEnabled()) {
+        ScheduleRetry(state, static_cast<UINT>(std::max(cooldown, 1)));
+        return;
+    }
+
+    if (g_settings.ignoreWhileMouseButtonDown.load(
+            std::memory_order_relaxed) &&
+        IsAnyMouseButtonDown()) {
+        ScheduleRetry(state, static_cast<UINT>(std::max(cooldown, 1)));
+        return;
+    }
+
+    if (g_settings.ignoreFullscreenApps.load(
+            std::memory_order_relaxed) &&
+        IsFullscreenWindowOnMonitor(pointerMonitor)) {
+        Wh_Log(L"Activation suppressed: fullscreen app detected");
+        ScheduleRetry(state, static_cast<UINT>(std::max(cooldown, 1)));
+        return;
+    }
+
+    HWND taskbarWindow = FindTaskbarForMonitor(pointerMonitor);
+    if (!taskbarWindow) {
+        Wh_Log(L"Activation suppressed: no bottom taskbar found");
+        ScheduleRetry(state, static_cast<UINT>(std::max(cooldown, 1)));
+        return;
+    }
+
+    if (SendUiOperation(kUiRevealTaskbar, taskbarWindow)) {
+        Wh_Log(L"Activated taskbar %p through native shell/coordinator path",
+               taskbarWindow);
+        state.activeTaskbar = taskbarWindow;
+        state.activeTaskbarMonitor = pointerMonitor;
+        state.armed = false;
+        return;
+    }
+
+    if (g_settings.nativeTimerFallback.load(
+            std::memory_order_relaxed) &&
+        SendUiOperation(kUiTriggerNativeUnhideTimer, taskbarWindow)) {
+        Wh_Log(L"Activated taskbar %p through native timer fallback",
+               taskbarWindow);
+
+        // No synthetic pointer-over state was created, so Windows owns normal
+        // hide behavior. Rearm only after the pointer leaves the band.
+        state.armed = false;
+        return;
+    }
+
+    Wh_Log(L"Threshold entered, but no reveal backend succeeded");
+    ScheduleRetry(state, static_cast<UINT>(std::max(cooldown, 1)));
+}
+
+void HandleReleaseTimer(ActivationWorkerState& state) {
+    CancelWorkerTimer(state.releaseTimerId);
+
+    if (!state.activeTaskbar) {
+        return;
+    }
+
+    POINT pointer{};
+    bool keepActive = false;
+
+    if (GetCursorPos(&pointer) && IsWindow(state.activeTaskbar)) {
+        HMONITOR pointerMonitor =
+            MonitorFromPoint(pointer, MONITOR_DEFAULTTONULL);
+        MONITORINFO monitorInfo{};
+        monitorInfo.cbSize = sizeof(monitorInfo);
+
+        if (pointerMonitor &&
+            GetMonitorInfoW(pointerMonitor, &monitorInfo)) {
+            const bool insideActivationBand =
+                IsPointInsideActivationBand(
+                    pointer,
+                    pointerMonitor,
+                    monitorInfo);
+            const bool overVisibleTaskbar =
+                IsPointOverTaskbar(state.activeTaskbar, pointer);
+
+            keepActive =
+                (insideActivationBand &&
+                 pointerMonitor == state.activeTaskbarMonitor) ||
+                overVisibleTaskbar;
+        }
+    }
+
+    if (keepActive) {
+        return;
+    }
+
+    ClearActiveTaskbar(state);
+    ProcessPointerState(state);
+}
+
+void CALLBACK CursorWinEventProc(HWINEVENTHOOK,
+                                 DWORD event,
+                                 HWND,
+                                 LONG idObject,
+                                 LONG,
+                                 DWORD,
+                                 DWORD) {
+    if (event != EVENT_OBJECT_LOCATIONCHANGE || idObject != OBJID_CURSOR) {
+        return;
+    }
+
+    DWORD workerThreadId =
+        g_workerThreadId.load(std::memory_order_relaxed);
+    if (!workerThreadId ||
+        g_cursorUpdatePosted.exchange(true, std::memory_order_relaxed)) {
+        return;
+    }
+
+    if (!PostThreadMessageW(workerThreadId,
+                            kWorkerCursorChangedMessage,
+                            0,
+                            0)) {
+        g_cursorUpdatePosted.store(false, std::memory_order_relaxed);
+    }
+}
+
+DWORD WINAPI ActivationWorkerThread(LPVOID) {
+    // Force creation of this thread's message queue before publishing its ID.
+    MSG message{};
+    PeekMessageW(&message, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+    g_workerThreadId.store(GetCurrentThreadId(), std::memory_order_relaxed);
+
+    HWINEVENTHOOK cursorHook = SetWinEventHook(
+        EVENT_OBJECT_LOCATIONCHANGE,
+        EVENT_OBJECT_LOCATIONCHANGE,
+        nullptr,
+        CursorWinEventProc,
+        0,
+        0,
+        WINEVENT_OUTOFCONTEXT);
+
+    UINT_PTR fallbackPollTimerId = 0;
+    if (!cursorHook) {
+        Wh_Log(L"SetWinEventHook for cursor movement failed: %u; "
+               L"using a 50 ms fallback timer",
+               GetLastError());
+        fallbackPollTimerId =
+            SetTimer(nullptr, kWorkerFallbackPollTimer, 50, nullptr);
+    }
+
+    if (g_workerReadyEvent) {
+        SetEvent(g_workerReadyEvent);
+    }
+
+    ActivationWorkerState state;
+    ProcessPointerState(state);
+
+    bool stop = false;
+    while (!stop) {
+        DWORD waitResult = MsgWaitForMultipleObjects(
+            1,
+            &g_stopEvent,
+            FALSE,
+            INFINITE,
+            QS_ALLINPUT);
+
+        if (waitResult == WAIT_OBJECT_0) {
+            break;
+        }
+
+        if (waitResult != WAIT_OBJECT_0 + 1) {
+            Wh_Log(L"Activation worker wait failed: %u", GetLastError());
+            break;
+        }
+
+        while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE)) {
+            if (message.message == WM_QUIT) {
+                stop = true;
+                break;
+            }
+
+            switch (message.message) {
+                case kWorkerCursorChangedMessage:
+                    g_cursorUpdatePosted.store(false,
+                                               std::memory_order_relaxed);
+                    ProcessPointerState(state);
+                    break;
+
+                case kWorkerSettingsChangedMessage:
+                    ProcessPointerState(state);
+                    break;
+
+                case WM_TIMER:
+                    if (state.releaseTimerId &&
+                        message.wParam == state.releaseTimerId) {
+                        HandleReleaseTimer(state);
+                    } else if (state.retryTimerId &&
+                               message.wParam == state.retryTimerId) {
+                        CancelWorkerTimer(state.retryTimerId);
+                        ProcessPointerState(state);
+                    } else if (fallbackPollTimerId &&
+                               message.wParam == fallbackPollTimerId) {
+                        ProcessPointerState(state);
+                    }
+                    break;
+
+                default:
+                    TranslateMessage(&message);
+                    DispatchMessageW(&message);
+                    break;
+            }
+        }
+    }
+
+    CancelWorkerTimer(state.releaseTimerId);
+    CancelWorkerTimer(state.retryTimerId);
+    ClearActiveTaskbar(state);
+
+    if (cursorHook) {
+        UnhookWinEvent(cursorHook);
+    } else if (fallbackPollTimerId) {
+        KillTimer(nullptr, fallbackPollTimerId);
+    }
+
+    g_cursorUpdatePosted.store(false, std::memory_order_relaxed);
+    g_workerThreadId.store(0, std::memory_order_relaxed);
     return 0;
 }
 
 bool HookTaskbarViewSymbols(HMODULE module) {
-    // user32.dll
+    // Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {
@@ -1317,6 +1418,7 @@ bool HookTaskbarViewSymbols(HMODULE module) {
             },
             &ViewCoordinator_IsExpanded_Original,
             nullptr,
+            true,
         },
         {
             {
@@ -1324,6 +1426,7 @@ bool HookTaskbarViewSymbols(HMODULE module) {
             },
             &ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original,
             ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook,
+            true,
         },
         {
             {
@@ -1331,6 +1434,7 @@ bool HookTaskbarViewSymbols(HMODULE module) {
             },
             &ViewCoordinator_ShouldTaskbarBeExpanded_Original,
             ViewCoordinator_ShouldTaskbarBeExpanded_Hook,
+            true,
         },
         {
             {
@@ -1338,6 +1442,7 @@ bool HookTaskbarViewSymbols(HMODULE module) {
             },
             &ViewCoordinator_UpdateIsExpanded_Original,
             ViewCoordinator_UpdateIsExpanded_Hook,
+            true,
         },
     };
 
@@ -1363,7 +1468,7 @@ bool HookTaskbarUiThreadSymbol() {
         return false;
     }
 
-    // user32.dll
+    // taskbar.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {
@@ -1371,13 +1476,7 @@ bool HookTaskbarUiThreadSymbol() {
             },
             &g_trayUiVtableITrayComponentHost,
             nullptr,
-        },
-        {
-            {
-                LR"(const CSecondaryTray::`vftable'{for `ISecondaryTray'})",
-            },
-            &g_secondaryTrayVtableISecondaryTray,
-            nullptr,
+            true,
         },
         {
             {
@@ -1385,6 +1484,7 @@ bool HookTaskbarUiThreadSymbol() {
             },
             &TrayUI_Unhide_Original,
             nullptr,
+            true,
         },
         {
             {
@@ -1392,6 +1492,7 @@ bool HookTaskbarUiThreadSymbol() {
             },
             &CSecondaryTray_Unhide_Original,
             nullptr,
+            true,
         },
         {
             {
@@ -1399,6 +1500,7 @@ bool HookTaskbarUiThreadSymbol() {
             },
             &TrayUI_WndProc_Original,
             TrayUI_WndProc_Hook,
+            true,
         },
         {
             {
@@ -1406,6 +1508,7 @@ bool HookTaskbarUiThreadSymbol() {
             },
             &CSecondaryTray_WndProc_Original,
             CSecondaryTray_WndProc_Hook,
+            true,
         },
         {
             {
@@ -1504,7 +1607,7 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR libraryFileName,
 }
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"Initializing version 0.2.4");
+    Wh_Log(L"Initializing");
 
     if (!g_uiThreadMessage || !g_captureTaskbarObjectMessage) {
         Wh_Log(L"RegisterWindowMessageW failed: ui=%u capture=%u",
@@ -1550,8 +1653,10 @@ BOOL Wh_ModInit() {
 
     g_stopEvent =
         CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    g_workerReadyEvent =
+        CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-    if (!g_stopEvent) {
+    if (!g_stopEvent || !g_workerReadyEvent) {
         Wh_Log(L"CreateEvent failed: %u", GetLastError());
         return FALSE;
     }
@@ -1595,6 +1700,12 @@ void Wh_ModAfterInit() {
 
     if (!g_workerThread) {
         Wh_Log(L"CreateThread failed: %u", GetLastError());
+        return;
+    }
+
+    if (g_workerReadyEvent &&
+        WaitForSingleObject(g_workerReadyEvent, 2000) != WAIT_OBJECT_0) {
+        Wh_Log(L"Activation worker didn't signal readiness");
     }
 }
 
@@ -1609,7 +1720,14 @@ void Wh_ModBeforeUninit() {
         WaitForSingleObject(g_workerThread, INFINITE);
     }
 
-    SendUiOperation(kUiClearAllSyntheticPointerOver, nullptr);
+    if (!SendUiOperation(kUiClearAllSyntheticPointerOver,
+                         nullptr,
+                         1000)) {
+        Sleep(50);
+        SendUiOperation(kUiClearAllSyntheticPointerOver,
+                        nullptr,
+                        2000);
+    }
 }
 
 void Wh_ModUninit() {
@@ -1625,10 +1743,12 @@ void Wh_ModUninit() {
         g_stopEvent = nullptr;
     }
 
-    AcquireSRWLockExclusive(&g_viewCoordinatorLock);
-    g_viewCoordinators.clear();
-    ReleaseSRWLockExclusive(&g_viewCoordinatorLock);
+    if (g_workerReadyEvent) {
+        CloseHandle(g_workerReadyEvent);
+        g_workerReadyEvent = nullptr;
+    }
 
+    g_viewCoordinators.clear();
     g_trayUiWndProcObjects.clear();
     g_secondaryTrayObjects.clear();
     g_syntheticPointerOverTaskbars.clear();
@@ -1639,4 +1759,13 @@ void Wh_ModSettingsChanged() {
 
     LoadSettings();
     g_settingsChanged.store(true, std::memory_order_relaxed);
+
+    DWORD workerThreadId =
+        g_workerThreadId.load(std::memory_order_relaxed);
+    if (workerThreadId) {
+        PostThreadMessageW(workerThreadId,
+                           kWorkerSettingsChangedMessage,
+                           0,
+                           0);
+    }
 }

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -1240,6 +1240,7 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
 }
 
 bool HookTaskbarViewSymbols(HMODULE module) {
+    // Taskbar.View.dll, ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK hooks[] = {
         {
             {
@@ -1278,7 +1279,7 @@ bool HookTaskbarSymbols() {
         return false;
     }
 
-    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+    WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
         {
             {LR"(const TrayUI::`vftable'{for `IInspectable'})"},
             &g_trayUiVtableIInspectable,
@@ -1324,7 +1325,8 @@ bool HookTaskbarSymbols() {
         },
     };
 
-    if (!WindhawkUtils::HookSymbols(module, hooks, ARRAYSIZE(hooks))) {
+    if (!WindhawkUtils::HookSymbols(
+            module, taskbarDllHooks, ARRAYSIZE(taskbarDllHooks))) {
         Wh_Log(L"Required native taskbar symbols are unavailable");
         return false;
     }

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -32,7 +32,7 @@ continuous polling, minimizing background activity while the pointer is idle.
 
 ## Features
 
-- Configurable activation-band height
+- Configurable activation-band height and hover delay
 - Per-monitor DPI scaling
 - Multi-monitor support
 - Adjustable release delay and activation cooldown
@@ -53,9 +53,11 @@ The mod does not modify:
 - Transparency
 - Windows' auto-hide setting
 
-When revealing the taskbar, the mod also restores its native topmost Z-order
-without activating it. This prevents normal application windows from covering
-the revealed taskbar while preserving focus in the current application.
+When revealing the taskbar, the mod brings it to the front of its existing
+Z-order band without activating it or changing whether Explorer currently
+treats it as topmost. This prevents ordinary windows in the same band from
+covering the taskbar while preserving fullscreen and third-party Z-order
+policies.
 
 The mod is designed to coexist with taskbar styling, sizing, transparency,
 animation, clock, label, and icon mods that retain the standard bottom-positioned
@@ -87,13 +89,15 @@ Windows 11 taskbar.
 ## Suggested settings
 
 - Activation threshold: `24`
+- Hover delay: `75`
 - Release delay: `120`
 - Activation cooldown: `200`
 
 These defaults provide a noticeably larger activation area while retaining
-responsive reveal and hide behavior. Increase the activation threshold for
-easier access, or reduce it to more closely match the standard Windows edge
-trigger.
+responsive reveal and hide behavior. The short hover delay prevents accidental
+reveals while crossing the bottom edge of an upper monitor in a vertically
+stacked layout. Increase the activation threshold for easier access, or reduce
+it to more closely match the standard Windows edge trigger.
 
 ## Attribution and license
 
@@ -112,11 +116,17 @@ This mod is distributed under the GNU General Public License v3.0.
   $description: >-
     Height of the activation band in logical pixels at 96 DPI. The value is
     scaled independently for each monitor. Recommended range: 12 to 48.
+- activationDelayMs: 75
+  $name: Hover delay
+  $description: >-
+    Time in milliseconds that the pointer must remain in the activation band
+    before the taskbar is revealed. A short delay prevents accidental reveals
+    while moving between vertically stacked monitors.
 - releaseDelayMs: 120
   $name: Release delay
   $description: >-
-    Delay before releasing the synthetic pointer-over state after the pointer
-    leaves both the activation band and the visible taskbar.
+    Delay before the taskbar is allowed to hide again after the pointer leaves
+    both the activation band and the visible taskbar.
 - activationCooldownMs: 200
   $name: Activation cooldown
   $description: >-
@@ -163,6 +173,7 @@ This mod is distributed under the GNU General Public License v3.0.
 
 struct Settings {
     std::atomic<int> activationThresholdPx{24};
+    std::atomic<int> activationDelayMs{75};
     std::atomic<int> releaseDelayMs{120};
     std::atomic<int> activationCooldownMs{200};
     std::atomic<bool> requireWindowsAutoHide{true};
@@ -175,7 +186,7 @@ struct Settings {
 Settings g_settings;
 
 std::atomic<bool> g_taskbarViewDllLoaded{false};
-std::atomic<bool> g_settingsChanged{false};
+std::atomic<unsigned> g_settingsGeneration{0};
 std::atomic<DWORD> g_workerThreadId{0};
 std::atomic<bool> g_cursorUpdatePosted{false};
 std::atomic<HWND> g_mainTaskbarWindow{nullptr};
@@ -189,24 +200,34 @@ UINT g_uiThreadMessage = 0;
 UINT g_captureTaskbarObjectMessage = 0;
 UINT g_queryTaskbarRectMessage = 0;
 
+// The taskbar-rectangle query can outlive SendMessageTimeoutW. Keeping all
+// request and result storage at file scope avoids passing a pointer to a worker
+// stack frame into Explorer's UI thread. Only the activation worker initiates
+// these queries, and a timed-out request remains pending until the UI thread
+// eventually consumes it.
+struct StuckRectQueryState {
+    std::atomic<bool> pending{false};
+    std::atomic<bool> succeeded{false};
+    HMONITOR monitor = nullptr;
+    RECT rect{};
+};
+
+StuckRectQueryState g_stuckRectQuery;
+
 enum UiOperation : WPARAM {
     kUiRevealTaskbar = 1,
     kUiClearSyntheticPointerOver = 2,
     kUiClearAllSyntheticPointerOver = 3,
     kUiTriggerNativeUnhideTimer = 4,
     kUiCancelNativeUnhideTimer = 5,
-    kUiRaiseTaskbarAboveWindows = 6,
+    kUiBringTaskbarToFront = 6,
 };
 
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
 constexpr UINT kWorkerSettingsChangedMessage = WM_APP + 2;
-constexpr UINT_PTR kWorkerReleaseTimer = 1;
-constexpr UINT_PTR kWorkerRetryTimer = 2;
-constexpr UINT_PTR kWorkerFallbackPollTimer = 3;
-constexpr UINT_PTR kWorkerNativeTimerCleanupTimer = 4;
-
 constexpr UINT kReleaseRetryMs = 250;
 constexpr UINT kFallbackStatusPollMs = 250;
+constexpr UINT kFallbackRearmBaseMs = 1000;
 constexpr UINT kNativeTimerCleanupMs = 250;
 constexpr UINT kSuppressionBackoffMaxMs = 5000;
 
@@ -232,6 +253,10 @@ void ForgetTaskbarState(HWND taskbarWindow) {
 void LoadSettings() {
     g_settings.activationThresholdPx.store(
         std::clamp(Wh_GetIntSetting(L"activationThresholdPx"), 1, 500),
+        std::memory_order_relaxed);
+
+    g_settings.activationDelayMs.store(
+        std::clamp(Wh_GetIntSetting(L"activationDelayMs"), 0, 1000),
         std::memory_order_relaxed);
 
     g_settings.releaseDelayMs.store(
@@ -323,7 +348,8 @@ HWND FindMainTaskbarWindow() {
 }
 
 bool GetTaskbarStuckRectForMonitor(HMONITOR monitor, RECT* rect) {
-    if (!monitor || !rect || !g_queryTaskbarRectMessage) {
+    if (!monitor || !rect || !g_queryTaskbarRectMessage ||
+        g_stuckRectQuery.pending.load(std::memory_order_acquire)) {
         return false;
     }
 
@@ -332,17 +358,41 @@ bool GetTaskbarStuckRectForMonitor(HMONITOR monitor, RECT* rect) {
         return false;
     }
 
-    SetRectEmpty(rect);
+    g_stuckRectQuery.monitor = monitor;
+    SetRectEmpty(&g_stuckRectQuery.rect);
+    g_stuckRectQuery.succeeded.store(false, std::memory_order_relaxed);
+    g_stuckRectQuery.pending.store(true, std::memory_order_release);
+
     DWORD_PTR result = 0;
-    return SendMessageTimeoutW(
-               taskbarWindow,
-               g_queryTaskbarRectMessage,
-               reinterpret_cast<WPARAM>(monitor),
-               reinterpret_cast<LPARAM>(rect),
-               SMTO_ABORTIFHUNG | SMTO_BLOCK,
-               250,
-               &result) &&
-           result != 0 && !IsRectEmpty(rect);
+    SetLastError(ERROR_SUCCESS);
+    if (!SendMessageTimeoutW(
+            taskbarWindow,
+            g_queryTaskbarRectMessage,
+            0,
+            0,
+            SMTO_ABORTIFHUNG | SMTO_BLOCK,
+            250,
+            &result)) {
+        const DWORD error = GetLastError();
+        if (error != ERROR_TIMEOUT && error != ERROR_SUCCESS) {
+            // The message wasn't left pending, so allow another query.
+            g_stuckRectQuery.pending.store(false,
+                                           std::memory_order_release);
+        }
+        return false;
+    }
+
+    // If the hook wasn't reached, don't leave the query permanently pending.
+    g_stuckRectQuery.pending.store(false, std::memory_order_release);
+
+    if (!result ||
+        !g_stuckRectQuery.succeeded.load(std::memory_order_acquire) ||
+        IsRectEmpty(&g_stuckRectQuery.rect)) {
+        return false;
+    }
+
+    *rect = g_stuckRectQuery.rect;
+    return true;
 }
 
 HWND GetTaskBandWindow() {
@@ -495,7 +545,7 @@ bool IsAnyMouseButtonDown() {
     return false;
 }
 
-bool IsDesktopWindow(HWND window) {
+bool HasDesktopWindowClass(HWND window) {
     if (!window) {
         return false;
     }
@@ -509,6 +559,10 @@ bool IsDesktopWindow(HWND window) {
            _wcsicmp(className, L"WorkerW") == 0;
 }
 
+bool IsShellDesktopWindow(HWND window) {
+    return HasDesktopWindowClass(window) && IsCurrentProcessWindow(window);
+}
+
 bool IsWindowCloaked(HWND window) {
     BOOL cloaked = FALSE;
     return SUCCEEDED(DwmGetWindowAttribute(
@@ -518,8 +572,7 @@ bool IsWindowCloaked(HWND window) {
 
 bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
     if (!window || !IsWindowVisible(window) || IsIconic(window) ||
-        IsDesktopWindow(window) || IsTaskbarClass(window) ||
-        IsWindowCloaked(window)) {
+        HasDesktopWindowClass(window) || IsTaskbarClass(window)) {
         return false;
     }
 
@@ -534,7 +587,8 @@ bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
         return false;
     }
 
-    if (MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST) != monitor) {
+    if (MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST) != monitor ||
+        IsWindowCloaked(window)) {
         return false;
     }
 
@@ -572,7 +626,37 @@ void LogFullscreenCandidate(HWND window) {
            title);
 }
 
+bool IsFullscreenOrPresentationNotificationState(HMONITOR monitor) {
+    QUERY_USER_NOTIFICATION_STATE state = QUNS_ACCEPTS_NOTIFICATIONS;
+    if (FAILED(SHQueryUserNotificationState(&state))) {
+        return false;
+    }
+
+    if (state == QUNS_PRESENTATION_MODE) {
+        return true;
+    }
+
+    if (state != QUNS_BUSY &&
+        state != QUNS_RUNNING_D3D_FULL_SCREEN) {
+        return false;
+    }
+
+    // The notification state is system-wide. Associate fullscreen/busy states
+    // with the foreground monitor to avoid suppressing unrelated taskbars.
+    HWND foregroundWindow = GetForegroundWindow();
+    return foregroundWindow &&
+           MonitorFromWindow(foregroundWindow,
+                             MONITOR_DEFAULTTONEAREST) == monitor;
+}
+
 bool IsFullscreenWindowOnMonitor(HMONITOR monitor) {
+    // This complements the per-monitor window walk. It catches exclusive D3D,
+    // fullscreen Store/UWP apps, and presentation mode, which don't always
+    // expose a borderless top-level window that can be recognized reliably.
+    if (IsFullscreenOrPresentationNotificationState(monitor)) {
+        return true;
+    }
+
     struct Context {
         HMONITOR monitor;
         bool found;
@@ -585,7 +669,7 @@ bool IsFullscreenWindowOnMonitor(HMONITOR monitor) {
         [](HWND window, LPARAM parameter) -> BOOL {
             auto* context = reinterpret_cast<Context*>(parameter);
 
-            if (IsDesktopWindow(window)) {
+            if (IsShellDesktopWindow(window)) {
                 return FALSE;
             }
 
@@ -649,7 +733,6 @@ bool IsTaskbarVisiblyRevealed(HWND taskbarWindow, HMONITOR monitor) {
     return intersection.bottom - intersection.top > 2;
 }
 
-
 void* QueryViaVtable(void* object, void* targetVtable) {
     if (!object || !targetVtable) {
         return nullptr;
@@ -706,16 +789,24 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
     LPARAM lParam,
     bool* handled) {
     if (message == g_queryTaskbarRectMessage) {
-        RECT* rect = reinterpret_cast<RECT*>(lParam);
-        const HMONITOR monitor = reinterpret_cast<HMONITOR>(wParam);
         bool succeeded = false;
-        if (rect && monitor && TrayUI_GetStuckRectForMonitor_Original) {
+        if (g_stuckRectQuery.pending.load(std::memory_order_acquire) &&
+            g_stuckRectQuery.monitor &&
+            TrayUI_GetStuckRectForMonitor_Original) {
+            RECT rect{};
             succeeded = TrayUI_GetStuckRectForMonitor_Original(
-                trayUi, monitor, rect);
+                trayUi, g_stuckRectQuery.monitor, &rect);
+            if (succeeded) {
+                g_stuckRectQuery.rect = rect;
+            } else {
+                SetRectEmpty(&g_stuckRectQuery.rect);
+            }
         }
-        if (!succeeded && rect) {
-            SetRectEmpty(rect);
-        }
+
+        g_stuckRectQuery.succeeded.store(succeeded,
+                                         std::memory_order_release);
+        g_stuckRectQuery.pending.store(false, std::memory_order_release);
+
         if (handled) {
             *handled = true;
         }
@@ -723,6 +814,7 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
     }
 
     if (message == WM_NCCREATE) {
+        g_stuckRectQuery.pending.store(false, std::memory_order_release);
         g_trayUiWndProcObjects[window] = trayUi;
         g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
         Wh_Log(L"Captured TrayUI object for taskbar %p", window);
@@ -739,6 +831,8 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
         ForgetTaskbarState(window);
         if (g_mainTaskbarWindow.load(std::memory_order_relaxed) == window) {
             g_mainTaskbarWindow.store(nullptr, std::memory_order_relaxed);
+            g_stuckRectQuery.pending.store(false,
+                                           std::memory_order_release);
         }
     }
 
@@ -967,6 +1061,11 @@ void WINAPI ViewCoordinator_UpdateIsExpanded_Hook(
 
 bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
                                        bool isPointerOver) {
+    if (!isPointerOver && taskbarWindow &&
+        !g_syntheticPointerOverTaskbars.contains(taskbarWindow)) {
+        return true;
+    }
+
     if (!taskbarWindow || !IsWindow(taskbarWindow) ||
         !ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original ||
         !ViewCoordinator_UpdateIsExpanded_Original) {
@@ -1063,60 +1162,64 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
     return true;
 }
 
-bool RaiseTaskbarAboveWindowsOnUiThread(HWND taskbarWindow) {
+bool BringTaskbarToFrontWithinCurrentBandOnUiThread(
+    HWND taskbarWindow) {
     if (!taskbarWindow || !IsWindow(taskbarWindow)) {
         return false;
     }
 
-    // A taskbar revealed without a real edge-hover can retain an old Z-order
-    // position and end up underneath an ordinary or topmost application
-    // window. Reinsert it at the top of the topmost band without activating,
-    // moving, resizing, or showing it. This matches the user-visible behavior
-    // of the native auto-hide reveal while leaving Explorer in control of the
-    // taskbar's geometry and animation.
+    // Reorder only within Explorer's current Z-order band. This brings the
+    // taskbar above ordinary windows when appropriate without forcing or
+    // clearing WS_EX_TOPMOST, preserving fullscreen behavior and compatibility
+    // with mods that intentionally manage the taskbar's Z-order policy.
+    const bool isTopmost =
+        (GetWindowLongPtrW(taskbarWindow, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0;
     if (!SetWindowPos(taskbarWindow,
-                      HWND_TOPMOST,
+                      isTopmost ? HWND_TOPMOST : HWND_TOP,
                       0,
                       0,
                       0,
                       0,
                       SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
                           SWP_NOOWNERZORDER)) {
-        Wh_Log(L"Couldn't raise taskbar %p above application windows: %u",
+        Wh_Log(L"Couldn't bring taskbar %p to the front of its Z-order "
+               L"band: %u",
                taskbarWindow,
                GetLastError());
         return false;
     }
 
-    Wh_Log(L"Raised taskbar %p to the topmost Z-order band", taskbarWindow);
+    Wh_Log(L"Brought taskbar %p to the front of its %s Z-order band",
+           taskbarWindow,
+           isTopmost ? L"topmost" : L"normal");
     return true;
 }
 
 bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
-    // The maintained Windhawk taskbar implementation invokes both paths:
-    // TrayUI::Unhide physically slides Shell_TrayWnd onscreen, while the
-    // Windows 11 ViewCoordinator establishes the logical expanded state.
-    const bool shellWindowRevealed =
-        InvokeNativeShellUnhideOnUiThread(taskbarWindow);
-
+    // Establish coordinator ownership first. If this fails, leave the legacy
+    // path untouched and let the caller use Explorer's native timer fallback,
+    // avoiding two independent reveal mechanisms for the same attempt.
     const bool coordinatorExpanded =
         SetSyntheticPointerOverOnUiThread(taskbarWindow, true);
 
-    // Reassert the native overlay Z-order after both reveal paths have run.
-    // SetWindowPos uses SWP_NOACTIVATE, so the foreground application keeps
-    // keyboard focus.
-    const bool raisedAboveWindows =
-        RaiseTaskbarAboveWindowsOnUiThread(taskbarWindow);
+    bool shellWindowRevealed = false;
+    bool broughtToFront = false;
+    if (coordinatorExpanded) {
+        // TrayUI::Unhide physically slides Shell_TrayWnd onscreen after the
+        // coordinator has established the matching logical expanded state.
+        shellWindowRevealed =
+            InvokeNativeShellUnhideOnUiThread(taskbarWindow);
+        broughtToFront =
+            BringTaskbarToFrontWithinCurrentBandOnUiThread(taskbarWindow);
+    }
 
     Wh_Log(L"Reveal result for taskbar %p: shell=%d coordinator=%d "
            L"zorder=%d",
            taskbarWindow,
            shellWindowRevealed,
            coordinatorExpanded,
-           raisedAboveWindows);
+           broughtToFront);
 
-    // The legacy Unhide path alone has no matching hide trigger on Windows 11,
-    // so only the coordinator path counts as a reveal owned by this mod.
     return coordinatorExpanded;
 }
 
@@ -1171,7 +1274,7 @@ bool TriggerNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
     // Put the hidden taskbar in the correct Z-order before Explorer processes
     // the asynchronous timer. A second reinforcement is sent by the worker
     // after the timer has had time to reveal the window.
-    RaiseTaskbarAboveWindowsOnUiThread(taskbarWindow);
+    BringTaskbarToFrontWithinCurrentBandOnUiThread(taskbarWindow);
 
     Wh_Log(L"Requested native unhide timer for taskbar %p",
            taskbarWindow);
@@ -1215,8 +1318,9 @@ LRESULT WINAPI CTaskBand_v_WndProc_Hook(
                            ? 1
                            : 0;
 
-            case kUiRaiseTaskbarAboveWindows:
-                return RaiseTaskbarAboveWindowsOnUiThread(targetTaskbar)
+            case kUiBringTaskbarToFront:
+                return BringTaskbarToFrontWithinCurrentBandOnUiThread(
+                           targetTaskbar)
                            ? 1
                            : 0;
         }
@@ -1232,16 +1336,32 @@ LRESULT WINAPI CTaskBand_v_WndProc_Hook(
         lParam);
 }
 
-bool SendUiOperation(UiOperation operation,
-                     HWND taskbarWindow,
-                     DWORD timeoutMs = 250) {
+enum class UiOperationResult {
+    kNotSent,
+    kCompletedFailure,
+    kCompletedSuccess,
+    kIndeterminate,
+};
+
+bool UiOperationSucceeded(UiOperationResult result) {
+    return result == UiOperationResult::kCompletedSuccess;
+}
+
+bool UiOperationMayHaveRun(UiOperationResult result) {
+    return result == UiOperationResult::kCompletedSuccess ||
+           result == UiOperationResult::kIndeterminate;
+}
+
+UiOperationResult SendUiOperation(UiOperation operation,
+                                  HWND taskbarWindow,
+                                  DWORD timeoutMs = 250) {
     HWND taskBandWindow = GetTaskBandWindow();
     if (!taskBandWindow) {
-        return false;
+        return UiOperationResult::kNotSent;
     }
 
     DWORD_PTR result = 0;
-
+    SetLastError(ERROR_SUCCESS);
     if (!SendMessageTimeoutW(
             taskBandWindow,
             g_uiThreadMessage,
@@ -1250,12 +1370,25 @@ bool SendUiOperation(UiOperation operation,
             SMTO_ABORTIFHUNG | SMTO_BLOCK,
             timeoutMs,
             &result)) {
-        Wh_Log(L"UI-thread operation timed out or failed: %u",
-               GetLastError());
-        return false;
+        const DWORD error = GetLastError();
+        Wh_Log(L"UI-thread operation timed out or failed: operation=%u "
+               L"error=%u",
+               static_cast<unsigned>(operation),
+               error);
+
+        // Once SendMessageTimeoutW has begun a cross-thread send, a timeout or
+        // an unspecified failure doesn't prove that the target WndProc won't
+        // process the message later. Only a vanished target window is treated
+        // as definitely not sent; all other failures are conservatively
+        // considered indeterminate.
+        if (error == ERROR_INVALID_WINDOW_HANDLE) {
+            return UiOperationResult::kNotSent;
+        }
+        return UiOperationResult::kIndeterminate;
     }
 
-    return result != 0;
+    return result != 0 ? UiOperationResult::kCompletedSuccess
+                       : UiOperationResult::kCompletedFailure;
 }
 
 struct ActivationWorkerState {
@@ -1263,13 +1396,18 @@ struct ActivationWorkerState {
     HMONITOR activeTaskbarMonitor = nullptr;
     HWND fallbackTaskbar = nullptr;
     HMONITOR fallbackTaskbarMonitor = nullptr;
+    HMONITOR activationCandidateMonitor = nullptr;
     bool armed = true;
     UINT_PTR releaseTimerId = 0;
     UINT_PTR retryTimerId = 0;
     UINT_PTR nativeTimerCleanupTimerId = 0;
     bool releaseRetryPending = false;
+    ULONGLONG activationCandidateSince = 0;
     ULONGLONG lastActivationCheck = 0;
+    ULONGLONG fallbackRearmNotBefore = 0;
     unsigned suppressionFailures = 0;
+    unsigned fallbackHideCount = 0;
+    unsigned appliedSettingsGeneration = 0;
 };
 
 void CancelWorkerTimer(UINT_PTR& timerId) {
@@ -1281,21 +1419,16 @@ void CancelWorkerTimer(UINT_PTR& timerId) {
     timerId = 0;
 }
 
-void ScheduleWorkerTimer(UINT_PTR requestedTimerId,
-                         UINT delayMs,
-                         UINT_PTR& timerId) {
+void ScheduleWorkerTimer(UINT delayMs, UINT_PTR& timerId) {
     if (timerId) {
         return;
     }
 
-    timerId = SetTimer(nullptr,
-                       requestedTimerId,
-                       std::max(delayMs, 1U),
-                       nullptr);
+    // With hWnd == nullptr, Windows allocates and returns the timer ID. The
+    // caller stores that returned value and compares WM_TIMER against it.
+    timerId = SetTimer(nullptr, 0, std::max(delayMs, 1U), nullptr);
     if (!timerId) {
-        Wh_Log(L"Failed to create worker timer %llu: %u",
-               static_cast<unsigned long long>(requestedTimerId),
-               GetLastError());
+        Wh_Log(L"Failed to create worker timer: %u", GetLastError());
     }
 }
 
@@ -1304,19 +1437,23 @@ bool ClearActiveTaskbar(ActivationWorkerState& state,
                         bool scheduleRetry = true) {
     CancelWorkerTimer(state.releaseTimerId);
 
-    if (state.activeTaskbar && IsWindow(state.activeTaskbar) &&
-        !SendUiOperation(kUiClearSyntheticPointerOver,
-                         state.activeTaskbar,
-                         timeoutMs)) {
-        // Keep ownership and retry instead of forgetting synthetic state that
-        // may still force Explorer's coordinator to remain expanded.
-        if (scheduleRetry) {
-            state.releaseRetryPending = true;
-            ScheduleWorkerTimer(kWorkerReleaseTimer,
-                                kReleaseRetryMs,
-                                state.releaseTimerId);
+    if (state.activeTaskbar && IsWindow(state.activeTaskbar)) {
+        const UiOperationResult clearResult =
+            SendUiOperation(kUiClearSyntheticPointerOver,
+                            state.activeTaskbar,
+                            timeoutMs);
+        if (!UiOperationSucceeded(clearResult)) {
+            // Keep ownership and retry instead of forgetting synthetic state
+            // that may still force Explorer's coordinator to remain expanded.
+            // An indeterminate result is especially important: the clear may
+            // still be waiting in the taskbar UI thread's sent-message queue.
+            if (scheduleRetry) {
+                state.releaseRetryPending = true;
+                ScheduleWorkerTimer(kReleaseRetryMs,
+                                    state.releaseTimerId);
+            }
+            return false;
         }
-        return false;
     }
 
     state.releaseRetryPending = false;
@@ -1329,9 +1466,9 @@ bool ClearActiveTaskbar(ActivationWorkerState& state,
 void CancelFallbackNativeTimer(ActivationWorkerState& state) {
     CancelWorkerTimer(state.nativeTimerCleanupTimerId);
     if (state.fallbackTaskbar && IsWindow(state.fallbackTaskbar)) {
-        SendUiOperation(kUiCancelNativeUnhideTimer,
-                        state.fallbackTaskbar,
-                        500);
+        (void)SendUiOperation(kUiCancelNativeUnhideTimer,
+                              state.fallbackTaskbar,
+                              500);
     }
 }
 
@@ -1343,9 +1480,7 @@ void ClearFallbackTaskbar(ActivationWorkerState& state) {
 }
 
 void ScheduleRetry(ActivationWorkerState& state, UINT delayMs) {
-    ScheduleWorkerTimer(kWorkerRetryTimer,
-                        delayMs,
-                        state.retryTimerId);
+    ScheduleWorkerTimer(delayMs, state.retryTimerId);
 }
 
 UINT GetSuppressionRetryDelay(ActivationWorkerState& state,
@@ -1362,15 +1497,40 @@ void ScheduleSuppressedRetry(ActivationWorkerState& state,
     ScheduleRetry(state, GetSuppressionRetryDelay(state, cooldownMs));
 }
 
+void ResetActivationCandidate(ActivationWorkerState& state) {
+    state.activationCandidateMonitor = nullptr;
+    state.activationCandidateSince = 0;
+}
+
+void ResetFallbackBackoff(ActivationWorkerState& state) {
+    state.fallbackHideCount = 0;
+    state.fallbackRearmNotBefore = 0;
+}
+
+UINT GetFallbackRearmDelay(ActivationWorkerState& state) {
+    state.fallbackHideCount = std::min(state.fallbackHideCount + 1, 4U);
+    const unsigned shift = state.fallbackHideCount - 1;
+    return std::min(kFallbackRearmBaseMs << shift,
+                    kSuppressionBackoffMaxMs);
+}
+
 void ProcessPointerState(ActivationWorkerState& state) {
-    if (g_settingsChanged.exchange(false, std::memory_order_relaxed)) {
+    const unsigned settingsGeneration =
+        g_settingsGeneration.load(std::memory_order_acquire);
+    if (state.appliedSettingsGeneration != settingsGeneration) {
         CancelWorkerTimer(state.retryTimerId);
         if (!ClearActiveTaskbar(state)) {
+            // Keep the old generation pending. Once the release retry succeeds,
+            // the complete settings reset will run instead of being forgotten.
             return;
         }
+
         ClearFallbackTaskbar(state);
+        ResetActivationCandidate(state);
+        ResetFallbackBackoff(state);
         state.lastActivationCheck = 0;
         state.suppressionFailures = 0;
+        state.appliedSettingsGeneration = settingsGeneration;
     }
 
     POINT pointer{};
@@ -1386,6 +1546,8 @@ void ProcessPointerState(ActivationWorkerState& state) {
         }
         ClearFallbackTaskbar(state);
         CancelWorkerTimer(state.retryTimerId);
+        ResetActivationCandidate(state);
+        ResetFallbackBackoff(state);
         state.suppressionFailures = 0;
         return;
     }
@@ -1396,6 +1558,7 @@ void ProcessPointerState(ActivationWorkerState& state) {
         return;
     }
 
+    const ULONGLONG now = GetTickCount64();
     const bool insideActivationBand =
         IsPointInsideActivationBand(pointer, pointerMonitor, monitorInfo);
 
@@ -1406,16 +1569,22 @@ void ProcessPointerState(ActivationWorkerState& state) {
             !sameMonitor) {
             ClearFallbackTaskbar(state);
             CancelWorkerTimer(state.retryTimerId);
+            ResetFallbackBackoff(state);
         } else if (IsTaskbarVisiblyRevealed(state.fallbackTaskbar,
                                             state.fallbackTaskbarMonitor)) {
             // Explorer owns the fallback reveal and its matching hide. Poll at
-            // a low rate only while the pointer remains in the activation band;
-            // once Explorer hides it again, rearm without requiring a leave.
+            // a low rate only while this exceptional path remains active.
             ScheduleRetry(state, kFallbackStatusPollMs);
             return;
         } else {
+            // Avoid a rapid hide/reveal oscillation if Explorer's timer path
+            // hides again before a ViewCoordinator becomes available.
             ClearFallbackTaskbar(state);
             CancelWorkerTimer(state.retryTimerId);
+            const UINT rearmDelay = GetFallbackRearmDelay(state);
+            state.fallbackRearmNotBefore = now + rearmDelay;
+            ScheduleRetry(state, rearmDelay);
+            return;
         }
     }
 
@@ -1442,18 +1611,15 @@ void ProcessPointerState(ActivationWorkerState& state) {
             }
 
             const int releaseDelay =
-                g_settings.releaseDelayMs.load(
-                    std::memory_order_relaxed);
+                g_settings.releaseDelayMs.load(std::memory_order_relaxed);
             if (releaseDelay == 0) {
                 if (!ClearActiveTaskbar(state)) {
                     return;
                 }
             } else {
                 state.releaseRetryPending = false;
-                ScheduleWorkerTimer(
-                    kWorkerReleaseTimer,
-                    static_cast<UINT>(releaseDelay),
-                    state.releaseTimerId);
+                ScheduleWorkerTimer(static_cast<UINT>(releaseDelay),
+                                    state.releaseTimerId);
                 return;
             }
         }
@@ -1463,6 +1629,8 @@ void ProcessPointerState(ActivationWorkerState& state) {
         state.armed = true;
         state.suppressionFailures = 0;
         CancelWorkerTimer(state.retryTimerId);
+        ResetActivationCandidate(state);
+        ResetFallbackBackoff(state);
         return;
     }
 
@@ -1471,10 +1639,37 @@ void ProcessPointerState(ActivationWorkerState& state) {
         return;
     }
 
-    const ULONGLONG now = GetTickCount64();
+    if (now < state.fallbackRearmNotBefore) {
+        ScheduleRetry(
+            state,
+            static_cast<UINT>(state.fallbackRearmNotBefore - now));
+        return;
+    }
+
+    const int activationDelay =
+        g_settings.activationDelayMs.load(std::memory_order_relaxed);
+    if (state.activationCandidateMonitor != pointerMonitor) {
+        state.activationCandidateMonitor = pointerMonitor;
+        state.activationCandidateSince = now;
+        if (activationDelay > 0) {
+            ScheduleRetry(state, static_cast<UINT>(activationDelay));
+            return;
+        }
+    } else {
+        const ULONGLONG candidateElapsed =
+            now - state.activationCandidateSince;
+        if (candidateElapsed < static_cast<ULONGLONG>(activationDelay)) {
+            ScheduleRetry(
+                state,
+                static_cast<UINT>(
+                    static_cast<ULONGLONG>(activationDelay) -
+                    candidateElapsed));
+            return;
+        }
+    }
+
     const int cooldown =
-        g_settings.activationCooldownMs.load(
-            std::memory_order_relaxed);
+        g_settings.activationCooldownMs.load(std::memory_order_relaxed);
     const ULONGLONG elapsed = now - state.lastActivationCheck;
     if (elapsed < static_cast<ULONGLONG>(cooldown)) {
         ScheduleRetry(
@@ -1487,13 +1682,12 @@ void ProcessPointerState(ActivationWorkerState& state) {
     state.lastActivationCheck = now;
     CancelWorkerTimer(state.retryTimerId);
 
-    Wh_Log(L"Pointer entered activation band: x=%d y=%d bottom=%d",
+    Wh_Log(L"Pointer remained in activation band: x=%d y=%d bottom=%d",
            pointer.x,
            pointer.y,
            monitorInfo.rcMonitor.bottom);
 
-    if (g_settings.primaryMonitorOnly.load(
-            std::memory_order_relaxed) &&
+    if (g_settings.primaryMonitorOnly.load(std::memory_order_relaxed) &&
         (monitorInfo.dwFlags & MONITORINFOF_PRIMARY) == 0) {
         ScheduleSuppressedRetry(state, cooldown);
         return;
@@ -1513,8 +1707,7 @@ void ProcessPointerState(ActivationWorkerState& state) {
         return;
     }
 
-    if (g_settings.ignoreFullscreenApps.load(
-            std::memory_order_relaxed) &&
+    if (g_settings.ignoreFullscreenApps.load(std::memory_order_relaxed) &&
         IsFullscreenWindowOnMonitor(pointerMonitor)) {
         Wh_Log(L"Activation suppressed: fullscreen app detected");
         ScheduleSuppressedRetry(state, cooldown);
@@ -1530,30 +1723,47 @@ void ProcessPointerState(ActivationWorkerState& state) {
 
     state.suppressionFailures = 0;
 
-    if (SendUiOperation(kUiRevealTaskbar, taskbarWindow)) {
-        Wh_Log(L"Activated taskbar %p through native shell/coordinator path",
-               taskbarWindow);
+    const UiOperationResult revealResult =
+        SendUiOperation(kUiRevealTaskbar, taskbarWindow);
+    if (UiOperationMayHaveRun(revealResult)) {
+        if (revealResult == UiOperationResult::kIndeterminate) {
+            Wh_Log(L"Taskbar reveal timed out; assuming coordinator ownership "
+                   L"until the matching release succeeds: %p",
+                   taskbarWindow);
+        } else {
+            Wh_Log(L"Activated taskbar %p through native "
+                   L"shell/coordinator path",
+                   taskbarWindow);
+        }
+
         ClearFallbackTaskbar(state);
+        ResetFallbackBackoff(state);
+        ResetActivationCandidate(state);
         state.activeTaskbar = taskbarWindow;
         state.activeTaskbarMonitor = pointerMonitor;
         state.armed = false;
         return;
     }
 
-    if (g_settings.nativeTimerFallback.load(
-            std::memory_order_relaxed) &&
-        SendUiOperation(kUiTriggerNativeUnhideTimer, taskbarWindow)) {
-        Wh_Log(L"Activated taskbar %p through native timer fallback",
-               taskbarWindow);
+    if (g_settings.nativeTimerFallback.load(std::memory_order_relaxed)) {
+        const UiOperationResult fallbackResult =
+            SendUiOperation(kUiTriggerNativeUnhideTimer, taskbarWindow);
+        if (UiOperationMayHaveRun(fallbackResult)) {
+            Wh_Log(L"Activated taskbar %p through native timer fallback%s",
+                   taskbarWindow,
+                   fallbackResult == UiOperationResult::kIndeterminate
+                       ? L" (delivery indeterminate)"
+                       : L"");
 
-        state.fallbackTaskbar = taskbarWindow;
-        state.fallbackTaskbarMonitor = pointerMonitor;
-        state.armed = false;
-        ScheduleWorkerTimer(kWorkerNativeTimerCleanupTimer,
-                            kNativeTimerCleanupMs,
-                            state.nativeTimerCleanupTimerId);
-        ScheduleRetry(state, kFallbackStatusPollMs);
-        return;
+            ResetActivationCandidate(state);
+            state.fallbackTaskbar = taskbarWindow;
+            state.fallbackTaskbarMonitor = pointerMonitor;
+            state.armed = false;
+            ScheduleWorkerTimer(kNativeTimerCleanupMs,
+                                state.nativeTimerCleanupTimerId);
+            ScheduleRetry(state, kFallbackStatusPollMs);
+            return;
+        }
     }
 
     Wh_Log(L"Threshold entered, but no reveal backend succeeded");
@@ -1643,6 +1853,9 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
     PeekMessageW(&message, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
     g_workerThreadId.store(GetCurrentThreadId(), std::memory_order_relaxed);
 
+    // The hook is system-wide because WinEvent can't filter by object ID at
+    // registration time. CursorWinEventProc immediately discards every event
+    // except OBJID_CURSOR, avoiding permanent polling while the mouse is idle.
     HWINEVENTHOOK cursorHook = SetWinEventHook(
         EVENT_OBJECT_LOCATIONCHANGE,
         EVENT_OBJECT_LOCATIONCHANGE,
@@ -1658,7 +1871,7 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
                L"using a 50 ms fallback timer",
                GetLastError());
         fallbackPollTimerId =
-            SetTimer(nullptr, kWorkerFallbackPollTimer, 50, nullptr);
+            SetTimer(nullptr, 0, 50, nullptr);
     }
 
     ActivationWorkerState state;
@@ -1714,20 +1927,20 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
                             state.nativeTimerCleanupTimerId);
                         if (state.fallbackTaskbar &&
                             IsWindow(state.fallbackTaskbar)) {
-                            SendUiOperation(kUiCancelNativeUnhideTimer,
-                                            state.fallbackTaskbar,
-                                            500);
+                            (void)SendUiOperation(
+                                kUiCancelNativeUnhideTimer,
+                                state.fallbackTaskbar,
+                                500);
 
-                            // The timer reveal is asynchronous. Reinforce the
-                            // taskbar's overlay Z-order after Explorer has had
-                            // time to move it onscreen, preventing a normal or
-                            // always-on-top app from covering part of it.
+                            // The timer reveal is asynchronous. Bring the
+                            // taskbar forward within its existing Z-order band
+                            // after Explorer has moved it onscreen.
                             if (state.fallbackTaskbarMonitor &&
                                 IsTaskbarVisiblyRevealed(
                                     state.fallbackTaskbar,
                                     state.fallbackTaskbarMonitor)) {
-                                SendUiOperation(
-                                    kUiRaiseTaskbarAboveWindows,
+                                (void)SendUiOperation(
+                                    kUiBringTaskbarToFront,
                                     state.fallbackTaskbar,
                                     500);
                             }
@@ -1897,7 +2110,6 @@ bool HookTaskbarUiThreadSymbol() {
     return true;
 }
 
-
 void CaptureExistingTaskbarObjects() {
     EnumWindows(
         [](HWND window, LPARAM) -> BOOL {
@@ -1909,10 +2121,21 @@ void CaptureExistingTaskbarObjects() {
             GetWindowThreadProcessId(window, &processId);
 
             if (processId == GetCurrentProcessId()) {
-                SendMessageW(window,
-                             g_captureTaskbarObjectMessage,
-                             0,
-                             0);
+                DWORD_PTR result = 0;
+                SetLastError(ERROR_SUCCESS);
+                if (!SendMessageTimeoutW(
+                        window,
+                        g_captureTaskbarObjectMessage,
+                        0,
+                        0,
+                        SMTO_ABORTIFHUNG | SMTO_BLOCK,
+                        500,
+                        &result)) {
+                    Wh_Log(L"Taskbar object capture timed out or failed for "
+                           L"%p: %u",
+                           window,
+                           GetLastError());
+                }
             }
 
             return TRUE;
@@ -2070,7 +2293,6 @@ void Wh_ModAfterInit() {
         Wh_Log(L"CreateThread failed: %u", GetLastError());
         return;
     }
-
 }
 
 void Wh_ModBeforeUninit() {
@@ -2084,13 +2306,15 @@ void Wh_ModBeforeUninit() {
         WaitForSingleObject(g_workerThread, INFINITE);
     }
 
-    if (!SendUiOperation(kUiClearAllSyntheticPointerOver,
-                         nullptr,
-                         1000)) {
+    UiOperationResult clearResult =
+        SendUiOperation(kUiClearAllSyntheticPointerOver, nullptr, 1000);
+    if (!UiOperationSucceeded(clearResult)) {
         Sleep(50);
-        SendUiOperation(kUiClearAllSyntheticPointerOver,
-                        nullptr,
-                        2000);
+        clearResult =
+            SendUiOperation(kUiClearAllSyntheticPointerOver, nullptr, 2000);
+        if (!UiOperationSucceeded(clearResult)) {
+            Wh_Log(L"Final synthetic pointer-over cleanup wasn't confirmed");
+        }
     }
 }
 
@@ -2107,7 +2331,7 @@ void Wh_ModUninit() {
         g_stopEvent = nullptr;
     }
 
-
+    g_stuckRectQuery.pending.store(false, std::memory_order_relaxed);
     g_viewCoordinators.clear();
     g_trayUiWndProcObjects.clear();
     g_secondaryTrayObjects.clear();
@@ -2118,7 +2342,7 @@ void Wh_ModSettingsChanged() {
     Wh_Log(L"Settings changed");
 
     LoadSettings();
-    g_settingsChanged.store(true, std::memory_order_relaxed);
+    g_settingsGeneration.fetch_add(1, std::memory_order_release);
 
     DWORD workerThreadId =
         g_workerThreadId.load(std::memory_order_relaxed);

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -236,10 +236,8 @@ enum UiOperation : WPARAM {
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
 constexpr UINT kWorkerSettingsChangedMessage = WM_APP + 2;
 constexpr UINT kWorkerNativePointerLeaveMessage = WM_APP + 3;
-constexpr UINT kWorkerTaskbarDestroyedMessage = WM_APP + 4;
 constexpr LPARAM kRevealFlagBringNormalTaskbarForward = 1;
 constexpr UINT kReleaseRetryMs = 250;
-constexpr UINT kTaskbarRebuildRetryMs = 100;
 constexpr UINT kFallbackProbeMs = 300;
 constexpr UINT kSuppressionBackoffMaxMs = 5000;
 constexpr ULONGLONG kAutoHideCacheDurationMs = 5000;
@@ -269,7 +267,6 @@ void ForgetTaskbarState(HWND taskbarWindow) {
 
 DWORD WINAPI ActivationWorkerThread(LPVOID);
 void EnsureActivationWorker();
-void NotifyActivationWorkerTaskbarDestroyed(HWND taskbarWindow);
 bool HandleTaskbarUiOperation(HWND taskbarWindow,
                               WPARAM operationValue,
                               LPARAM operationParameter,
@@ -338,25 +335,6 @@ void EnsureActivationWorker() {
 
     g_workerThread.store(workerThread, std::memory_order_release);
     Wh_Log(L"Started activation worker in the taskbar Explorer process");
-}
-
-void NotifyActivationWorkerTaskbarDestroyed(HWND taskbarWindow) {
-    const DWORD workerThreadId =
-        g_workerThreadId.load(std::memory_order_acquire);
-    if (!workerThreadId) {
-        return;
-    }
-
-    if (!PostThreadMessageW(
-            workerThreadId,
-            kWorkerTaskbarDestroyedMessage,
-            reinterpret_cast<WPARAM>(taskbarWindow),
-            0)) {
-        Wh_Log(L"Couldn't notify activation worker that taskbar %p was "
-               L"destroyed: %u",
-               taskbarWindow,
-               GetLastError());
-    }
 }
 
 bool IsTaskbarClass(HWND window) {
@@ -977,7 +955,6 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
     } else if (message == WM_NCDESTROY) {
         g_trayUiWndProcObjects.erase(window);
         ForgetTaskbarState(window);
-        NotifyActivationWorkerTaskbarDestroyed(window);
         if (g_mainTaskbarWindow.load(std::memory_order_relaxed) == window) {
             g_mainTaskbarWindow.store(nullptr, std::memory_order_relaxed);
             g_stuckRectQuery.pending.store(false,
@@ -1030,7 +1007,6 @@ LRESULT WINAPI CSecondaryTray_WndProc_Hook(
     } else if (message == WM_NCDESTROY) {
         g_secondaryTrayObjects.erase(window);
         ForgetTaskbarState(window);
-        NotifyActivationWorkerTaskbarDestroyed(window);
     }
 
     return CSecondaryTray_WndProc_Original(
@@ -2002,46 +1978,6 @@ void HandleNativePointerLeave(ActivationWorkerState& state,
     ProcessPointerState(state);
 }
 
-void HandleTaskbarDestroyed(ActivationWorkerState& state,
-                            HWND taskbarWindow) {
-    if (!taskbarWindow) {
-        return;
-    }
-
-    bool stateChanged = false;
-
-    if (state.activeTaskbar == taskbarWindow) {
-        CancelWorkerTimer(state.releaseTimerId);
-        state.releaseRetryPending = false;
-        state.activeTaskbar = nullptr;
-        state.activeTaskbarMonitor = nullptr;
-        stateChanged = true;
-    }
-
-    if (state.fallbackProbeTaskbar == taskbarWindow) {
-        state.fallbackProbeTaskbar = nullptr;
-        state.fallbackProbeMonitor = nullptr;
-        stateChanged = true;
-    }
-
-    if (!stateChanged) {
-        return;
-    }
-
-    CancelWorkerTimer(state.retryTimerId);
-    state.armed = true;
-    state.lastActivationCheck = 0;
-    state.suppressionFailures = 0;
-    ResetBandEntry(state);
-
-    // WM_NCDESTROY is observed before Explorer's original WndProc returns. Give
-    // the shell a short interval to finish destruction or create a replacement
-    // before searching for a taskbar again; otherwise the worker could briefly
-    // rediscover the window that's still being torn down.
-    Wh_Log(L"Forgot worker state for destroyed taskbar %p", taskbarWindow);
-    ScheduleRetry(state, kTaskbarRebuildRetryMs);
-}
-
 void HandleReleaseTimer(ActivationWorkerState& state) {
     CancelWorkerTimer(state.releaseTimerId);
 
@@ -2186,12 +2122,6 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
 
                 case kWorkerNativePointerLeaveMessage:
                     HandleNativePointerLeave(
-                        state,
-                        reinterpret_cast<HWND>(message.wParam));
-                    break;
-
-                case kWorkerTaskbarDestroyedMessage:
-                    HandleTaskbarDestroyed(
                         state,
                         reinterpret_cast<HWND>(message.wParam));
                     break;

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -53,15 +53,15 @@ The mod does not modify:
 - Transparency
 - Windows' auto-hide setting
 
-When needed, the mod can bring a normal-band taskbar in front of an ordinary
-normal-band window without activating it. It never promotes the taskbar into
-the topmost band or reorders it above an always-on-top window. Mods that
-intentionally keep the taskbar behind other normal windows can conflict with
-this narrowly scoped Z-order correction.
+When needed, the mod brings a covered taskbar to the front of its existing
+Z-order band without activating it or changing whether Explorer currently
+treats it as topmost. This prevents ordinary windows in the same band from
+covering the revealed taskbar while preserving fullscreen and third-party
+Z-order policies.
 
 The mod is designed to coexist with taskbar styling, sizing, transparency,
-animation, clock, label, and icon mods that retain the standard
-bottom-positioned Windows 11 taskbar and don't replace its reveal logic.
+animation, clock, label, and icon mods that retain the standard bottom-positioned
+Windows 11 taskbar.
 
 ## Requirements
 
@@ -85,14 +85,6 @@ bottom-positioned Windows 11 taskbar and don't replace its reveal logic.
   may not yet have been captured. The optional native timer fallback is tried
   once per activation-band entry, while coordinator activation continues to
   retry with backoff until the coordinator becomes available.
-- The native timer fallback uses Explorer's internal taskbar-unhide timer. A
-  mod that intercepts or replaces that timer can block the fallback, and
-  arming it can reset an already pending native unhide timer. This affects only
-  the brief pre-coordinator fallback path; normal coordinator activation is
-  independent of the timer.
-- Mods that deliberately control the taskbar's normal-window Z-order can
-  conflict with the correction used when an ordinary window covers a revealed
-  taskbar. The correction never crosses into the topmost window band.
 
 ## Suggested settings
 
@@ -161,9 +153,8 @@ This mod is distributed under the GNU General Public License v3.0.
   $name: Native timer fallback
   $description: >-
     If the Windows 11 taskbar coordinator isn't available yet, make one
-    best-effort request through Explorer's native unhide timer for each entry
-    into the activation band. Mods that intercept Explorer's taskbar timers can
-    block this temporary fallback. The pointer is never moved or injected.
+    best-effort request to Explorer's native reveal timer for each entry into
+    the activation band. The mod never cancels Explorer's timer.
 */
 // ==/WindhawkModSettings==
 
@@ -235,8 +226,6 @@ enum UiOperation : WPARAM {
 
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
 constexpr UINT kWorkerSettingsChangedMessage = WM_APP + 2;
-constexpr UINT kWorkerNativePointerLeaveMessage = WM_APP + 3;
-constexpr LPARAM kRevealFlagBringNormalTaskbarForward = 1;
 constexpr UINT kReleaseRetryMs = 250;
 constexpr UINT kFallbackProbeMs = 300;
 constexpr UINT kSuppressionBackoffMaxMs = 5000;
@@ -269,7 +258,6 @@ DWORD WINAPI ActivationWorkerThread(LPVOID);
 void EnsureActivationWorker();
 bool HandleTaskbarUiOperation(HWND taskbarWindow,
                               WPARAM operationValue,
-                              LPARAM operationParameter,
                               LRESULT* result);
 
 void InvalidateAutoHideCache() {
@@ -471,9 +459,8 @@ HMONITOR GetTaskbarMonitor(HWND taskbarWindow) {
     return MonitorFromWindow(taskbarWindow, MONITOR_DEFAULTTONEAREST);
 }
 
-bool LooksLikeHorizontalTaskbarRect(
-    const RECT& taskbarRect,
-    const MONITORINFO& monitorInfo) {
+bool IsBottomDockedRect(const RECT& taskbarRect,
+                        const MONITORINFO& monitorInfo) {
     const int monitorWidth =
         monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left;
     const int monitorHeight =
@@ -481,13 +468,10 @@ bool LooksLikeHorizontalTaskbarRect(
     const int taskbarWidth = taskbarRect.right - taskbarRect.left;
     const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
 
-    return taskbarWidth >= monitorWidth / 2 && taskbarHeight > 0 &&
-           taskbarHeight <= monitorHeight / 2;
-}
-
-bool IsBottomDockedRect(const RECT& taskbarRect,
-                        const MONITORINFO& monitorInfo) {
-    return LooksLikeHorizontalTaskbarRect(taskbarRect, monitorInfo) &&
+    const bool looksHorizontal =
+        taskbarWidth >= monitorWidth / 2 && taskbarHeight > 0 &&
+        taskbarHeight <= monitorHeight / 2;
+    return looksHorizontal &&
            std::abs(taskbarRect.bottom - monitorInfo.rcMonitor.bottom) <= 2;
 }
 
@@ -511,11 +495,19 @@ bool IsBottomPositionedTaskbar(HWND taskbarWindow, HMONITOR monitor) {
         return false;
     }
 
-    if (!LooksLikeHorizontalTaskbarRect(taskbarRect, monitorInfo)) {
+    const int monitorWidth =
+        monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left;
+    const int monitorHeight =
+        monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top;
+    const int taskbarWidth = taskbarRect.right - taskbarRect.left;
+    const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
+    const bool looksHorizontal =
+        taskbarWidth >= monitorWidth / 2 && taskbarHeight > 0 &&
+        taskbarHeight <= monitorHeight / 2;
+    if (!looksHorizontal) {
         return false;
     }
 
-    const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
     const int tolerance = std::max(16, taskbarHeight + 16);
     return std::abs(taskbarRect.bottom - monitorInfo.rcMonitor.bottom) <=
                tolerance ||
@@ -705,17 +697,10 @@ bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
 
     // Borderless windows are the common fullscreen case. Some Store/UWP apps
     // and browsers retain caption/frame style bits in fullscreen; for those,
-    // the client area must cover the monitor after excluding maximized windows.
+    // require the client area itself to cover the monitor. A regular maximized
+    // window keeps non-client chrome and therefore doesn't pass this test.
     if ((style & (WS_CAPTION | WS_THICKFRAME)) == 0) {
         return true;
-    }
-
-    // A maximized window fills the work area, which equals the monitor while
-    // auto-hide is enabled. Chromium, Electron, Terminal, File Explorer, and
-    // other custom-frame apps draw their title bar into the client area and
-    // would otherwise be indistinguishable from fullscreen here.
-    if (IsZoomed(window)) {
-        return false;
     }
 
     return DoesClientAreaCoverMonitor(window, monitorInfo);
@@ -747,14 +732,13 @@ bool IsFullscreenOrPresentationNotificationState(HMONITOR monitor) {
         return true;
     }
 
-    if (state != QUNS_RUNNING_D3D_FULL_SCREEN) {
+    if (state != QUNS_BUSY &&
+        state != QUNS_RUNNING_D3D_FULL_SCREEN) {
         return false;
     }
 
-    // The notification state is system-wide. Associate exclusive D3D
-    // fullscreen with the foreground monitor to avoid suppressing unrelated
-    // taskbars. QUNS_BUSY is deliberately not treated as fullscreen because it
-    // can mean that Presentation Settings are active without a fullscreen app.
+    // The notification state is system-wide. Associate fullscreen/busy states
+    // with the foreground monitor to avoid suppressing unrelated taskbars.
     HWND foregroundWindow = GetForegroundWindow();
     return foregroundWindow &&
            MonitorFromWindow(foregroundWindow,
@@ -902,7 +886,7 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
     bool* handled) {
     if (message == g_uiThreadMessage) {
         LRESULT result = 0;
-        if (HandleTaskbarUiOperation(window, wParam, lParam, &result)) {
+        if (HandleTaskbarUiOperation(window, wParam, &result)) {
             if (handled) {
                 *handled = true;
             }
@@ -988,7 +972,7 @@ LRESULT WINAPI CSecondaryTray_WndProc_Hook(
     LPARAM lParam) {
     if (message == g_uiThreadMessage) {
         LRESULT result = 0;
-        if (HandleTaskbarUiOperation(window, wParam, lParam, &result)) {
+        if (HandleTaskbarUiOperation(window, wParam, &result)) {
             return result;
         }
     }
@@ -1128,30 +1112,6 @@ ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook(
         taskbarWindow,
         isPointerOver,
         inputDeviceKind);
-
-    // Calls made by this mod invoke the original function directly, so a false
-    // value reaching this hook is Explorer's own pointer-leave transition. If
-    // it superseded our synthetic enter, relinquish UI-thread ownership and
-    // tell the worker to re-arm rather than waiting for a redundant release.
-    if (!isPointerOver &&
-        g_syntheticPointerOverTaskbars.erase(taskbarWindow) != 0) {
-        Wh_Log(L"Explorer cleared synthetic pointer-over for taskbar %p",
-               taskbarWindow);
-
-        const DWORD workerThreadId =
-            g_workerThreadId.load(std::memory_order_acquire);
-        if (workerThreadId &&
-            !PostThreadMessageW(
-                workerThreadId,
-                kWorkerNativePointerLeaveMessage,
-                reinterpret_cast<WPARAM>(taskbarWindow),
-                0)) {
-            Wh_Log(L"Couldn't notify activation worker about Explorer's "
-                   L"pointer leave for taskbar %p: %u",
-                   taskbarWindow,
-                   GetLastError());
-        }
-    }
 }
 
 using ViewCoordinator_ShouldTaskbarBeExpanded_t =
@@ -1309,27 +1269,16 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
     return true;
 }
 
-bool ShouldBringNormalTaskbarForward(HWND taskbarWindow) {
-    if (!taskbarWindow || !IsWindow(taskbarWindow)) {
-        return false;
-    }
-
-    // Never reorder a topmost taskbar. Windows such as the on-screen keyboard,
-    // always-on-top players, and capture overlays can legitimately sit above
-    // it, and this mod must not override that policy.
-    const LONG_PTR taskbarExStyle =
-        GetWindowLongPtrW(taskbarWindow, GWL_EXSTYLE);
-    if ((taskbarExStyle & WS_EX_TOPMOST) != 0) {
-        return false;
-    }
-
+bool IsTaskbarCoveredByHigherWindow(HWND taskbarWindow) {
     RECT taskbarRect{};
     if (!GetWindowRect(taskbarWindow, &taskbarRect)) {
         return false;
     }
 
-    // While auto-hidden, project the live taskbar rectangle to its visible
-    // bottom-docked position before testing windows above it in Z order.
+    // While auto-hidden, the live taskbar rectangle can sit just outside the
+    // monitor and therefore not intersect the window that will cover it after
+    // the reveal animation. Project it to its visible bottom-docked position
+    // before checking higher Z-order windows.
     const HMONITOR monitor = GetTaskbarMonitor(taskbarWindow);
     MONITORINFO monitorInfo{};
     monitorInfo.cbSize = sizeof(monitorInfo);
@@ -1348,12 +1297,11 @@ bool ShouldBringNormalTaskbarForward(HWND taskbarWindow) {
     struct Context {
         HWND taskbarWindow;
         RECT taskbarRect;
-        bool coveredByNormalWindow;
+        bool covered;
     } context{taskbarWindow, taskbarRect, false};
 
-    // This desktop-wide walk intentionally runs on the activation worker, not
-    // Explorer's taskbar UI thread. Only a normal-band window encountered above
-    // the normal-band taskbar is actionable; topmost windows are left alone.
+    // EnumWindows walks from top to bottom. Only windows encountered before the
+    // taskbar can cover it, so stop once the taskbar itself is reached.
     EnumWindows(
         [](HWND window, LPARAM parameter) -> BOOL {
             auto* context = reinterpret_cast<Context*>(parameter);
@@ -1368,11 +1316,8 @@ bool ShouldBringNormalTaskbarForward(HWND taskbarWindow) {
 
             const LONG_PTR exStyle = GetWindowLongPtrW(window, GWL_EXSTYLE);
             if ((exStyle & (WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW |
-                            WS_EX_NOACTIVATE | WS_EX_TOPMOST)) != 0) {
-                return TRUE;
-            }
-
-            if (IsWindowCloaked(window)) {
+                            WS_EX_NOACTIVATE)) != 0 ||
+                IsWindowCloaked(window)) {
                 return TRUE;
             }
 
@@ -1382,7 +1327,7 @@ bool ShouldBringNormalTaskbarForward(HWND taskbarWindow) {
                 IntersectRect(&intersection,
                               &windowRect,
                               &context->taskbarRect)) {
-                context->coveredByNormalWindow = true;
+                context->covered = true;
                 return FALSE;
             }
 
@@ -1390,40 +1335,47 @@ bool ShouldBringNormalTaskbarForward(HWND taskbarWindow) {
         },
         reinterpret_cast<LPARAM>(&context));
 
-    return context.coveredByNormalWindow;
+    return context.covered;
 }
 
-bool BringNormalTaskbarForwardOnUiThread(HWND taskbarWindow) {
+bool BringTaskbarToFrontWithinCurrentBandOnUiThread(
+    HWND taskbarWindow) {
     if (!taskbarWindow || !IsWindow(taskbarWindow)) {
         return false;
     }
 
-    // Recheck the band on the UI thread in case Explorer or another mod changed
-    // it after the worker's coverage snapshot. Never reorder a topmost taskbar.
-    if ((GetWindowLongPtrW(taskbarWindow, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0) {
+    // Explorer normally puts the revealed taskbar in front itself. Only nudge
+    // the Z-order when a higher window is actually intersecting it; this keeps
+    // the workaround for covered taskbars without reordering Explorer's window
+    // on every reveal.
+    if (!IsTaskbarCoveredByHigherWindow(taskbarWindow)) {
         return true;
     }
 
+    const bool isTopmost =
+        (GetWindowLongPtrW(taskbarWindow, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0;
     if (!SetWindowPos(taskbarWindow,
-                      HWND_TOP,
+                      isTopmost ? HWND_TOPMOST : HWND_TOP,
                       0,
                       0,
                       0,
                       0,
                       SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
                           SWP_NOOWNERZORDER)) {
-        Wh_Log(L"Couldn't bring covered normal-band taskbar %p forward: %u",
+        Wh_Log(L"Couldn't bring covered taskbar %p to the front of its "
+               L"Z-order band: %u",
                taskbarWindow,
                GetLastError());
         return false;
     }
 
-    Wh_Log(L"Brought covered normal-band taskbar %p forward", taskbarWindow);
+    Wh_Log(L"Brought covered taskbar %p to the front of its %s Z-order band",
+           taskbarWindow,
+           isTopmost ? L"topmost" : L"normal");
     return true;
 }
 
-bool RevealTaskbarOnUiThread(HWND taskbarWindow,
-                             bool bringNormalTaskbarForward) {
+bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
     // Establish coordinator ownership first. If no coordinator has been
     // captured yet, leave the legacy shell path untouched and let the worker
     // retry with backoff instead of starting competing reveal mechanisms.
@@ -1437,10 +1389,8 @@ bool RevealTaskbarOnUiThread(HWND taskbarWindow,
         // coordinator has established the matching logical expanded state.
         shellWindowRevealed =
             InvokeNativeShellUnhideOnUiThread(taskbarWindow);
-        if (bringNormalTaskbarForward) {
-            broughtToFront =
-                BringNormalTaskbarForwardOnUiThread(taskbarWindow);
-        }
+        broughtToFront =
+            BringTaskbarToFrontWithinCurrentBandOnUiThread(taskbarWindow);
     }
 
     Wh_Log(L"Reveal result for taskbar %p: shell=%d coordinator=%d "
@@ -1474,9 +1424,6 @@ bool TriggerNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
 
     // Explorer owns timer ID 3. Never kill or clean it up here: doing so can
     // cancel a genuine native edge-hover reveal that Explorer armed itself.
-    // SetTimer resets an existing timer with the same HWND and ID, so this
-    // compatibility fallback is deliberately limited to one attempt per band
-    // entry and is disclosed in the README.
     const UINT_PTR timerResult =
         SetTimer(taskbarWindow, kTrayUITimerUnhide, 1, nullptr);
     if (!timerResult) {
@@ -1492,7 +1439,6 @@ bool TriggerNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
 
 bool HandleTaskbarUiOperation(HWND taskbarWindow,
                               WPARAM operationValue,
-                              LPARAM operationParameter,
                               LRESULT* result) {
     if (!result) {
         return false;
@@ -1500,12 +1446,7 @@ bool HandleTaskbarUiOperation(HWND taskbarWindow,
 
     switch (static_cast<UiOperation>(operationValue)) {
         case kUiRevealTaskbar:
-            *result = RevealTaskbarOnUiThread(
-                          taskbarWindow,
-                          (operationParameter &
-                           kRevealFlagBringNormalTaskbarForward) != 0)
-                          ? 1
-                          : 0;
+            *result = RevealTaskbarOnUiThread(taskbarWindow) ? 1 : 0;
             return true;
 
         case kUiClearSyntheticPointerOver:
@@ -1548,8 +1489,7 @@ bool UiOperationMayHaveRun(UiOperationResult result) {
 
 UiOperationResult SendUiOperation(UiOperation operation,
                                   HWND taskbarWindow,
-                                  DWORD timeoutMs = 250,
-                                  LPARAM operationParameter = 0) {
+                                  DWORD timeoutMs = 250) {
     HWND destination = taskbarWindow;
     if (operation == kUiClearAllSyntheticPointerOver) {
         destination = FindAnyTaskbarWindow();
@@ -1566,7 +1506,7 @@ UiOperationResult SendUiOperation(UiOperation operation,
             destination,
             g_uiThreadMessage,
             operation,
-            operationParameter,
+            0,
             SMTO_ABORTIFHUNG | SMTO_BLOCK,
             timeoutMs,
             &result)) {
@@ -1635,23 +1575,14 @@ bool ClearActiveTaskbar(ActivationWorkerState& state,
                         bool scheduleRetry = true) {
     CancelWorkerTimer(state.releaseTimerId);
 
-    if (state.activeTaskbar) {
+    if (state.activeTaskbar && IsWindow(state.activeTaskbar)) {
         const UiOperationResult clearResult =
             SendUiOperation(kUiClearSyntheticPointerOver,
                             state.activeTaskbar,
                             timeoutMs);
-
-        if (clearResult == UiOperationResult::kNotSent) {
-            // The HWND is no longer a taskbar in this Explorer process. Its
-            // coordinator and synthetic state were already discarded by the
-            // taskbar WM_NCDESTROY hook, so retrying could loop forever if the
-            // numeric handle was recycled for another window.
-            Wh_Log(L"Release target is no longer a taskbar: %p",
-                   state.activeTaskbar);
-        } else if (!UiOperationSucceeded(clearResult)) {
-            // Completed failure or timeout means the taskbar might still own
-            // synthetic state. Keep worker ownership and retry rather than
-            // allowing Explorer's coordinator to remain forced open.
+        if (!UiOperationSucceeded(clearResult)) {
+            // Keep ownership and retry instead of forgetting synthetic state
+            // that may still force Explorer's coordinator to remain expanded.
             if (scheduleRetry) {
                 state.releaseRetryPending = true;
                 ScheduleWorkerTimer(kReleaseRetryMs,
@@ -1906,15 +1837,8 @@ void ProcessPointerState(ActivationWorkerState& state) {
         return;
     }
 
-    const bool bringNormalTaskbarForward =
-        ShouldBringNormalTaskbarForward(taskbarWindow);
-    const UiOperationResult revealResult = SendUiOperation(
-        kUiRevealTaskbar,
-        taskbarWindow,
-        250,
-        bringNormalTaskbarForward
-            ? kRevealFlagBringNormalTaskbarForward
-            : 0);
+    const UiOperationResult revealResult =
+        SendUiOperation(kUiRevealTaskbar, taskbarWindow);
     if (UiOperationMayHaveRun(revealResult)) {
         state.suppressionFailures = 0;
         if (revealResult == UiOperationResult::kIndeterminate) {
@@ -1955,27 +1879,6 @@ void ProcessPointerState(ActivationWorkerState& state) {
 
     Wh_Log(L"Threshold entered, but no reveal backend succeeded");
     ScheduleSuppressedRetry(state, cooldown);
-}
-
-void HandleNativePointerLeave(ActivationWorkerState& state,
-                              HWND taskbarWindow) {
-    if (!taskbarWindow || state.activeTaskbar != taskbarWindow) {
-        return;
-    }
-
-    CancelWorkerTimer(state.releaseTimerId);
-    CancelWorkerTimer(state.retryTimerId);
-    state.releaseRetryPending = false;
-    state.activeTaskbar = nullptr;
-    state.activeTaskbarMonitor = nullptr;
-    state.armed = true;
-    state.lastActivationCheck = 0;
-    state.suppressionFailures = 0;
-    ResetActivationCandidate(state);
-
-    Wh_Log(L"Re-arming after Explorer pointer leave for taskbar %p",
-           taskbarWindow);
-    ProcessPointerState(state);
 }
 
 void HandleReleaseTimer(ActivationWorkerState& state) {
@@ -2076,10 +1979,10 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
     UINT_PTR fallbackPollTimerId = 0;
     if (!cursorHook) {
         Wh_Log(L"SetWinEventHook for cursor movement failed: %u; "
-               L"using a 150 ms fallback timer",
+               L"using a 50 ms fallback timer",
                GetLastError());
         fallbackPollTimerId =
-            SetTimer(nullptr, 0, 150, nullptr);
+            SetTimer(nullptr, 0, 50, nullptr);
     }
 
     ActivationWorkerState state;
@@ -2118,12 +2021,6 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
 
                 case kWorkerSettingsChangedMessage:
                     ProcessPointerState(state);
-                    break;
-
-                case kWorkerNativePointerLeaveMessage:
-                    HandleNativePointerLeave(
-                        state,
-                        reinterpret_cast<HWND>(message.wParam));
                     break;
 
                 case WM_TIMER:

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -53,11 +53,10 @@ The mod does not modify:
 - Transparency
 - Windows' auto-hide setting
 
-When needed, the mod brings a covered taskbar to the front of its existing
-Z-order band without activating it or changing whether Explorer currently
-treats it as topmost. This prevents ordinary windows in the same band from
-covering the revealed taskbar while preserving fullscreen and third-party
-Z-order policies.
+When needed, the mod can bring a normal-band taskbar in front of an ordinary
+normal-band window without activating it. It never promotes the taskbar into
+the topmost band or reorders it above an always-on-top window, preserving
+fullscreen, accessibility-overlay, and third-party Z-order policies.
 
 The mod is designed to coexist with taskbar styling, sizing, transparency,
 animation, clock, label, and icon mods that retain the standard bottom-positioned
@@ -226,6 +225,8 @@ enum UiOperation : WPARAM {
 
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
 constexpr UINT kWorkerSettingsChangedMessage = WM_APP + 2;
+constexpr UINT kWorkerNativePointerLeaveMessage = WM_APP + 3;
+constexpr LPARAM kRevealFlagBringNormalTaskbarForward = 1;
 constexpr UINT kReleaseRetryMs = 250;
 constexpr UINT kFallbackProbeMs = 300;
 constexpr UINT kSuppressionBackoffMaxMs = 5000;
@@ -258,6 +259,7 @@ DWORD WINAPI ActivationWorkerThread(LPVOID);
 void EnsureActivationWorker();
 bool HandleTaskbarUiOperation(HWND taskbarWindow,
                               WPARAM operationValue,
+                              LPARAM operationParameter,
                               LRESULT* result);
 
 void InvalidateAutoHideCache() {
@@ -459,8 +461,9 @@ HMONITOR GetTaskbarMonitor(HWND taskbarWindow) {
     return MonitorFromWindow(taskbarWindow, MONITOR_DEFAULTTONEAREST);
 }
 
-bool IsBottomDockedRect(const RECT& taskbarRect,
-                        const MONITORINFO& monitorInfo) {
+bool LooksLikeHorizontalTaskbarRect(
+    const RECT& taskbarRect,
+    const MONITORINFO& monitorInfo) {
     const int monitorWidth =
         monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left;
     const int monitorHeight =
@@ -468,10 +471,13 @@ bool IsBottomDockedRect(const RECT& taskbarRect,
     const int taskbarWidth = taskbarRect.right - taskbarRect.left;
     const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
 
-    const bool looksHorizontal =
-        taskbarWidth >= monitorWidth / 2 && taskbarHeight > 0 &&
-        taskbarHeight <= monitorHeight / 2;
-    return looksHorizontal &&
+    return taskbarWidth >= monitorWidth / 2 && taskbarHeight > 0 &&
+           taskbarHeight <= monitorHeight / 2;
+}
+
+bool IsBottomDockedRect(const RECT& taskbarRect,
+                        const MONITORINFO& monitorInfo) {
+    return LooksLikeHorizontalTaskbarRect(taskbarRect, monitorInfo) &&
            std::abs(taskbarRect.bottom - monitorInfo.rcMonitor.bottom) <= 2;
 }
 
@@ -495,19 +501,11 @@ bool IsBottomPositionedTaskbar(HWND taskbarWindow, HMONITOR monitor) {
         return false;
     }
 
-    const int monitorWidth =
-        monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left;
-    const int monitorHeight =
-        monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top;
-    const int taskbarWidth = taskbarRect.right - taskbarRect.left;
-    const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
-    const bool looksHorizontal =
-        taskbarWidth >= monitorWidth / 2 && taskbarHeight > 0 &&
-        taskbarHeight <= monitorHeight / 2;
-    if (!looksHorizontal) {
+    if (!LooksLikeHorizontalTaskbarRect(taskbarRect, monitorInfo)) {
         return false;
     }
 
+    const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
     const int tolerance = std::max(16, taskbarHeight + 16);
     return std::abs(taskbarRect.bottom - monitorInfo.rcMonitor.bottom) <=
                tolerance ||
@@ -697,10 +695,17 @@ bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
 
     // Borderless windows are the common fullscreen case. Some Store/UWP apps
     // and browsers retain caption/frame style bits in fullscreen; for those,
-    // require the client area itself to cover the monitor. A regular maximized
-    // window keeps non-client chrome and therefore doesn't pass this test.
+    // the client area must cover the monitor after excluding maximized windows.
     if ((style & (WS_CAPTION | WS_THICKFRAME)) == 0) {
         return true;
+    }
+
+    // A maximized window fills the work area, which equals the monitor while
+    // auto-hide is enabled. Chromium, Electron, Terminal, File Explorer, and
+    // other custom-frame apps draw their title bar into the client area and
+    // would otherwise be indistinguishable from fullscreen here.
+    if (IsZoomed(window)) {
+        return false;
     }
 
     return DoesClientAreaCoverMonitor(window, monitorInfo);
@@ -732,13 +737,14 @@ bool IsFullscreenOrPresentationNotificationState(HMONITOR monitor) {
         return true;
     }
 
-    if (state != QUNS_BUSY &&
-        state != QUNS_RUNNING_D3D_FULL_SCREEN) {
+    if (state != QUNS_RUNNING_D3D_FULL_SCREEN) {
         return false;
     }
 
-    // The notification state is system-wide. Associate fullscreen/busy states
-    // with the foreground monitor to avoid suppressing unrelated taskbars.
+    // The notification state is system-wide. Associate exclusive D3D
+    // fullscreen with the foreground monitor to avoid suppressing unrelated
+    // taskbars. QUNS_BUSY is deliberately not treated as fullscreen because it
+    // can mean that Presentation Settings are active without a fullscreen app.
     HWND foregroundWindow = GetForegroundWindow();
     return foregroundWindow &&
            MonitorFromWindow(foregroundWindow,
@@ -886,7 +892,7 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
     bool* handled) {
     if (message == g_uiThreadMessage) {
         LRESULT result = 0;
-        if (HandleTaskbarUiOperation(window, wParam, &result)) {
+        if (HandleTaskbarUiOperation(window, wParam, lParam, &result)) {
             if (handled) {
                 *handled = true;
             }
@@ -972,7 +978,7 @@ LRESULT WINAPI CSecondaryTray_WndProc_Hook(
     LPARAM lParam) {
     if (message == g_uiThreadMessage) {
         LRESULT result = 0;
-        if (HandleTaskbarUiOperation(window, wParam, &result)) {
+        if (HandleTaskbarUiOperation(window, wParam, lParam, &result)) {
             return result;
         }
     }
@@ -1112,6 +1118,26 @@ ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook(
         taskbarWindow,
         isPointerOver,
         inputDeviceKind);
+
+    // Calls made by this mod invoke the original function directly, so a false
+    // value reaching this hook is Explorer's own pointer-leave transition. If
+    // it superseded our synthetic enter, relinquish UI-thread ownership and
+    // tell the worker to re-arm rather than waiting for a redundant release.
+    if (!isPointerOver &&
+        g_syntheticPointerOverTaskbars.erase(taskbarWindow) != 0) {
+        Wh_Log(L"Explorer cleared synthetic pointer-over for taskbar %p",
+               taskbarWindow);
+
+        const DWORD workerThreadId =
+            g_workerThreadId.load(std::memory_order_relaxed);
+        if (workerThreadId) {
+            PostThreadMessageW(
+                workerThreadId,
+                kWorkerNativePointerLeaveMessage,
+                reinterpret_cast<WPARAM>(taskbarWindow),
+                0);
+        }
+    }
 }
 
 using ViewCoordinator_ShouldTaskbarBeExpanded_t =
@@ -1269,16 +1295,27 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
     return true;
 }
 
-bool IsTaskbarCoveredByHigherWindow(HWND taskbarWindow) {
+bool ShouldBringNormalTaskbarForward(HWND taskbarWindow) {
+    if (!taskbarWindow || !IsWindow(taskbarWindow)) {
+        return false;
+    }
+
+    // Never reorder a topmost taskbar. Windows such as the on-screen keyboard,
+    // always-on-top players, and capture overlays can legitimately sit above
+    // it, and this mod must not override that policy.
+    const LONG_PTR taskbarExStyle =
+        GetWindowLongPtrW(taskbarWindow, GWL_EXSTYLE);
+    if ((taskbarExStyle & WS_EX_TOPMOST) != 0) {
+        return false;
+    }
+
     RECT taskbarRect{};
     if (!GetWindowRect(taskbarWindow, &taskbarRect)) {
         return false;
     }
 
-    // While auto-hidden, the live taskbar rectangle can sit just outside the
-    // monitor and therefore not intersect the window that will cover it after
-    // the reveal animation. Project it to its visible bottom-docked position
-    // before checking higher Z-order windows.
+    // While auto-hidden, project the live taskbar rectangle to its visible
+    // bottom-docked position before testing windows above it in Z order.
     const HMONITOR monitor = GetTaskbarMonitor(taskbarWindow);
     MONITORINFO monitorInfo{};
     monitorInfo.cbSize = sizeof(monitorInfo);
@@ -1297,11 +1334,12 @@ bool IsTaskbarCoveredByHigherWindow(HWND taskbarWindow) {
     struct Context {
         HWND taskbarWindow;
         RECT taskbarRect;
-        bool covered;
+        bool coveredByNormalWindow;
     } context{taskbarWindow, taskbarRect, false};
 
-    // EnumWindows walks from top to bottom. Only windows encountered before the
-    // taskbar can cover it, so stop once the taskbar itself is reached.
+    // This desktop-wide walk intentionally runs on the activation worker, not
+    // Explorer's taskbar UI thread. Only a normal-band window encountered above
+    // the normal-band taskbar is actionable; topmost windows are left alone.
     EnumWindows(
         [](HWND window, LPARAM parameter) -> BOOL {
             auto* context = reinterpret_cast<Context*>(parameter);
@@ -1316,8 +1354,11 @@ bool IsTaskbarCoveredByHigherWindow(HWND taskbarWindow) {
 
             const LONG_PTR exStyle = GetWindowLongPtrW(window, GWL_EXSTYLE);
             if ((exStyle & (WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW |
-                            WS_EX_NOACTIVATE)) != 0 ||
-                IsWindowCloaked(window)) {
+                            WS_EX_NOACTIVATE | WS_EX_TOPMOST)) != 0) {
+                return TRUE;
+            }
+
+            if (IsWindowCloaked(window)) {
                 return TRUE;
             }
 
@@ -1327,7 +1368,7 @@ bool IsTaskbarCoveredByHigherWindow(HWND taskbarWindow) {
                 IntersectRect(&intersection,
                               &windowRect,
                               &context->taskbarRect)) {
-                context->covered = true;
+                context->coveredByNormalWindow = true;
                 return FALSE;
             }
 
@@ -1335,47 +1376,40 @@ bool IsTaskbarCoveredByHigherWindow(HWND taskbarWindow) {
         },
         reinterpret_cast<LPARAM>(&context));
 
-    return context.covered;
+    return context.coveredByNormalWindow;
 }
 
-bool BringTaskbarToFrontWithinCurrentBandOnUiThread(
-    HWND taskbarWindow) {
+bool BringNormalTaskbarForwardOnUiThread(HWND taskbarWindow) {
     if (!taskbarWindow || !IsWindow(taskbarWindow)) {
         return false;
     }
 
-    // Explorer normally puts the revealed taskbar in front itself. Only nudge
-    // the Z-order when a higher window is actually intersecting it; this keeps
-    // the workaround for covered taskbars without reordering Explorer's window
-    // on every reveal.
-    if (!IsTaskbarCoveredByHigherWindow(taskbarWindow)) {
+    // Recheck the band on the UI thread in case Explorer or another mod changed
+    // it after the worker's coverage snapshot. Never reorder a topmost taskbar.
+    if ((GetWindowLongPtrW(taskbarWindow, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0) {
         return true;
     }
 
-    const bool isTopmost =
-        (GetWindowLongPtrW(taskbarWindow, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0;
     if (!SetWindowPos(taskbarWindow,
-                      isTopmost ? HWND_TOPMOST : HWND_TOP,
+                      HWND_TOP,
                       0,
                       0,
                       0,
                       0,
                       SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
                           SWP_NOOWNERZORDER)) {
-        Wh_Log(L"Couldn't bring covered taskbar %p to the front of its "
-               L"Z-order band: %u",
+        Wh_Log(L"Couldn't bring covered normal-band taskbar %p forward: %u",
                taskbarWindow,
                GetLastError());
         return false;
     }
 
-    Wh_Log(L"Brought covered taskbar %p to the front of its %s Z-order band",
-           taskbarWindow,
-           isTopmost ? L"topmost" : L"normal");
+    Wh_Log(L"Brought covered normal-band taskbar %p forward", taskbarWindow);
     return true;
 }
 
-bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
+bool RevealTaskbarOnUiThread(HWND taskbarWindow,
+                             bool bringNormalTaskbarForward) {
     // Establish coordinator ownership first. If no coordinator has been
     // captured yet, leave the legacy shell path untouched and let the worker
     // retry with backoff instead of starting competing reveal mechanisms.
@@ -1389,8 +1423,10 @@ bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
         // coordinator has established the matching logical expanded state.
         shellWindowRevealed =
             InvokeNativeShellUnhideOnUiThread(taskbarWindow);
-        broughtToFront =
-            BringTaskbarToFrontWithinCurrentBandOnUiThread(taskbarWindow);
+        if (bringNormalTaskbarForward) {
+            broughtToFront =
+                BringNormalTaskbarForwardOnUiThread(taskbarWindow);
+        }
     }
 
     Wh_Log(L"Reveal result for taskbar %p: shell=%d coordinator=%d "
@@ -1439,6 +1475,7 @@ bool TriggerNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
 
 bool HandleTaskbarUiOperation(HWND taskbarWindow,
                               WPARAM operationValue,
+                              LPARAM operationParameter,
                               LRESULT* result) {
     if (!result) {
         return false;
@@ -1446,7 +1483,12 @@ bool HandleTaskbarUiOperation(HWND taskbarWindow,
 
     switch (static_cast<UiOperation>(operationValue)) {
         case kUiRevealTaskbar:
-            *result = RevealTaskbarOnUiThread(taskbarWindow) ? 1 : 0;
+            *result = RevealTaskbarOnUiThread(
+                          taskbarWindow,
+                          (operationParameter &
+                           kRevealFlagBringNormalTaskbarForward) != 0)
+                          ? 1
+                          : 0;
             return true;
 
         case kUiClearSyntheticPointerOver:
@@ -1489,7 +1531,8 @@ bool UiOperationMayHaveRun(UiOperationResult result) {
 
 UiOperationResult SendUiOperation(UiOperation operation,
                                   HWND taskbarWindow,
-                                  DWORD timeoutMs = 250) {
+                                  DWORD timeoutMs = 250,
+                                  LPARAM operationParameter = 0) {
     HWND destination = taskbarWindow;
     if (operation == kUiClearAllSyntheticPointerOver) {
         destination = FindAnyTaskbarWindow();
@@ -1506,7 +1549,7 @@ UiOperationResult SendUiOperation(UiOperation operation,
             destination,
             g_uiThreadMessage,
             operation,
-            0,
+            operationParameter,
             SMTO_ABORTIFHUNG | SMTO_BLOCK,
             timeoutMs,
             &result)) {
@@ -1837,8 +1880,15 @@ void ProcessPointerState(ActivationWorkerState& state) {
         return;
     }
 
-    const UiOperationResult revealResult =
-        SendUiOperation(kUiRevealTaskbar, taskbarWindow);
+    const bool bringNormalTaskbarForward =
+        ShouldBringNormalTaskbarForward(taskbarWindow);
+    const UiOperationResult revealResult = SendUiOperation(
+        kUiRevealTaskbar,
+        taskbarWindow,
+        250,
+        bringNormalTaskbarForward
+            ? kRevealFlagBringNormalTaskbarForward
+            : 0);
     if (UiOperationMayHaveRun(revealResult)) {
         state.suppressionFailures = 0;
         if (revealResult == UiOperationResult::kIndeterminate) {
@@ -1879,6 +1929,27 @@ void ProcessPointerState(ActivationWorkerState& state) {
 
     Wh_Log(L"Threshold entered, but no reveal backend succeeded");
     ScheduleSuppressedRetry(state, cooldown);
+}
+
+void HandleNativePointerLeave(ActivationWorkerState& state,
+                              HWND taskbarWindow) {
+    if (!taskbarWindow || state.activeTaskbar != taskbarWindow) {
+        return;
+    }
+
+    CancelWorkerTimer(state.releaseTimerId);
+    CancelWorkerTimer(state.retryTimerId);
+    state.releaseRetryPending = false;
+    state.activeTaskbar = nullptr;
+    state.activeTaskbarMonitor = nullptr;
+    state.armed = true;
+    state.lastActivationCheck = 0;
+    state.suppressionFailures = 0;
+    ResetActivationCandidate(state);
+
+    Wh_Log(L"Re-arming after Explorer pointer leave for taskbar %p",
+           taskbarWindow);
+    ProcessPointerState(state);
 }
 
 void HandleReleaseTimer(ActivationWorkerState& state) {
@@ -1979,10 +2050,10 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
     UINT_PTR fallbackPollTimerId = 0;
     if (!cursorHook) {
         Wh_Log(L"SetWinEventHook for cursor movement failed: %u; "
-               L"using a 50 ms fallback timer",
+               L"using a 150 ms fallback timer",
                GetLastError());
         fallbackPollTimerId =
-            SetTimer(nullptr, 0, 50, nullptr);
+            SetTimer(nullptr, 0, 150, nullptr);
     }
 
     ActivationWorkerState state;
@@ -2021,6 +2092,12 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
 
                 case kWorkerSettingsChangedMessage:
                     ProcessPointerState(state);
+                    break;
+
+                case kWorkerNativePointerLeaveMessage:
+                    HandleNativePointerLeave(
+                        state,
+                        reinterpret_cast<HWND>(message.wParam));
                     break;
 
                 case WM_TIMER:

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -55,12 +55,13 @@ The mod does not modify:
 
 When needed, the mod can bring a normal-band taskbar in front of an ordinary
 normal-band window without activating it. It never promotes the taskbar into
-the topmost band or reorders it above an always-on-top window, preserving
-fullscreen, accessibility-overlay, and third-party Z-order policies.
+the topmost band or reorders it above an always-on-top window. Mods that
+intentionally keep the taskbar behind other normal windows can conflict with
+this narrowly scoped Z-order correction.
 
 The mod is designed to coexist with taskbar styling, sizing, transparency,
-animation, clock, label, and icon mods that retain the standard bottom-positioned
-Windows 11 taskbar.
+animation, clock, label, and icon mods that retain the standard
+bottom-positioned Windows 11 taskbar and don't replace its reveal logic.
 
 ## Requirements
 
@@ -84,6 +85,14 @@ Windows 11 taskbar.
   may not yet have been captured. The optional native timer fallback is tried
   once per activation-band entry, while coordinator activation continues to
   retry with backoff until the coordinator becomes available.
+- The native timer fallback uses Explorer's internal taskbar-unhide timer. A
+  mod that intercepts or replaces that timer can block the fallback, and
+  arming it can reset an already pending native unhide timer. This affects only
+  the brief pre-coordinator fallback path; normal coordinator activation is
+  independent of the timer.
+- Mods that deliberately control the taskbar's normal-window Z-order can
+  conflict with the correction used when an ordinary window covers a revealed
+  taskbar. The correction never crosses into the topmost window band.
 
 ## Suggested settings
 
@@ -152,8 +161,9 @@ This mod is distributed under the GNU General Public License v3.0.
   $name: Native timer fallback
   $description: >-
     If the Windows 11 taskbar coordinator isn't available yet, make one
-    best-effort request to Explorer's native reveal timer for each entry into
-    the activation band. The mod never cancels Explorer's timer.
+    best-effort request through Explorer's native unhide timer for each entry
+    into the activation band. Mods that intercept Explorer's taskbar timers can
+    block this temporary fallback. The pointer is never moved or injected.
 */
 // ==/WindhawkModSettings==
 
@@ -226,8 +236,10 @@ enum UiOperation : WPARAM {
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
 constexpr UINT kWorkerSettingsChangedMessage = WM_APP + 2;
 constexpr UINT kWorkerNativePointerLeaveMessage = WM_APP + 3;
+constexpr UINT kWorkerTaskbarDestroyedMessage = WM_APP + 4;
 constexpr LPARAM kRevealFlagBringNormalTaskbarForward = 1;
 constexpr UINT kReleaseRetryMs = 250;
+constexpr UINT kTaskbarRebuildRetryMs = 100;
 constexpr UINT kFallbackProbeMs = 300;
 constexpr UINT kSuppressionBackoffMaxMs = 5000;
 constexpr ULONGLONG kAutoHideCacheDurationMs = 5000;
@@ -257,6 +269,7 @@ void ForgetTaskbarState(HWND taskbarWindow) {
 
 DWORD WINAPI ActivationWorkerThread(LPVOID);
 void EnsureActivationWorker();
+void NotifyActivationWorkerTaskbarDestroyed(HWND taskbarWindow);
 bool HandleTaskbarUiOperation(HWND taskbarWindow,
                               WPARAM operationValue,
                               LPARAM operationParameter,
@@ -325,6 +338,25 @@ void EnsureActivationWorker() {
 
     g_workerThread.store(workerThread, std::memory_order_release);
     Wh_Log(L"Started activation worker in the taskbar Explorer process");
+}
+
+void NotifyActivationWorkerTaskbarDestroyed(HWND taskbarWindow) {
+    const DWORD workerThreadId =
+        g_workerThreadId.load(std::memory_order_acquire);
+    if (!workerThreadId) {
+        return;
+    }
+
+    if (!PostThreadMessageW(
+            workerThreadId,
+            kWorkerTaskbarDestroyedMessage,
+            reinterpret_cast<WPARAM>(taskbarWindow),
+            0)) {
+        Wh_Log(L"Couldn't notify activation worker that taskbar %p was "
+               L"destroyed: %u",
+               taskbarWindow,
+               GetLastError());
+    }
 }
 
 bool IsTaskbarClass(HWND window) {
@@ -945,6 +977,7 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
     } else if (message == WM_NCDESTROY) {
         g_trayUiWndProcObjects.erase(window);
         ForgetTaskbarState(window);
+        NotifyActivationWorkerTaskbarDestroyed(window);
         if (g_mainTaskbarWindow.load(std::memory_order_relaxed) == window) {
             g_mainTaskbarWindow.store(nullptr, std::memory_order_relaxed);
             g_stuckRectQuery.pending.store(false,
@@ -997,6 +1030,7 @@ LRESULT WINAPI CSecondaryTray_WndProc_Hook(
     } else if (message == WM_NCDESTROY) {
         g_secondaryTrayObjects.erase(window);
         ForgetTaskbarState(window);
+        NotifyActivationWorkerTaskbarDestroyed(window);
     }
 
     return CSecondaryTray_WndProc_Original(
@@ -1129,13 +1163,17 @@ ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook(
                taskbarWindow);
 
         const DWORD workerThreadId =
-            g_workerThreadId.load(std::memory_order_relaxed);
-        if (workerThreadId) {
-            PostThreadMessageW(
+            g_workerThreadId.load(std::memory_order_acquire);
+        if (workerThreadId &&
+            !PostThreadMessageW(
                 workerThreadId,
                 kWorkerNativePointerLeaveMessage,
                 reinterpret_cast<WPARAM>(taskbarWindow),
-                0);
+                0)) {
+            Wh_Log(L"Couldn't notify activation worker about Explorer's "
+                   L"pointer leave for taskbar %p: %u",
+                   taskbarWindow,
+                   GetLastError());
         }
     }
 }
@@ -1460,6 +1498,9 @@ bool TriggerNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
 
     // Explorer owns timer ID 3. Never kill or clean it up here: doing so can
     // cancel a genuine native edge-hover reveal that Explorer armed itself.
+    // SetTimer resets an existing timer with the same HWND and ID, so this
+    // compatibility fallback is deliberately limited to one attempt per band
+    // entry and is disclosed in the README.
     const UINT_PTR timerResult =
         SetTimer(taskbarWindow, kTrayUITimerUnhide, 1, nullptr);
     if (!timerResult) {
@@ -1618,14 +1659,23 @@ bool ClearActiveTaskbar(ActivationWorkerState& state,
                         bool scheduleRetry = true) {
     CancelWorkerTimer(state.releaseTimerId);
 
-    if (state.activeTaskbar && IsWindow(state.activeTaskbar)) {
+    if (state.activeTaskbar) {
         const UiOperationResult clearResult =
             SendUiOperation(kUiClearSyntheticPointerOver,
                             state.activeTaskbar,
                             timeoutMs);
-        if (!UiOperationSucceeded(clearResult)) {
-            // Keep ownership and retry instead of forgetting synthetic state
-            // that may still force Explorer's coordinator to remain expanded.
+
+        if (clearResult == UiOperationResult::kNotSent) {
+            // The HWND is no longer a taskbar in this Explorer process. Its
+            // coordinator and synthetic state were already discarded by the
+            // taskbar WM_NCDESTROY hook, so retrying could loop forever if the
+            // numeric handle was recycled for another window.
+            Wh_Log(L"Release target is no longer a taskbar: %p",
+                   state.activeTaskbar);
+        } else if (!UiOperationSucceeded(clearResult)) {
+            // Completed failure or timeout means the taskbar might still own
+            // synthetic state. Keep worker ownership and retry rather than
+            // allowing Explorer's coordinator to remain forced open.
             if (scheduleRetry) {
                 state.releaseRetryPending = true;
                 ScheduleWorkerTimer(kReleaseRetryMs,
@@ -1952,6 +2002,46 @@ void HandleNativePointerLeave(ActivationWorkerState& state,
     ProcessPointerState(state);
 }
 
+void HandleTaskbarDestroyed(ActivationWorkerState& state,
+                            HWND taskbarWindow) {
+    if (!taskbarWindow) {
+        return;
+    }
+
+    bool stateChanged = false;
+
+    if (state.activeTaskbar == taskbarWindow) {
+        CancelWorkerTimer(state.releaseTimerId);
+        state.releaseRetryPending = false;
+        state.activeTaskbar = nullptr;
+        state.activeTaskbarMonitor = nullptr;
+        stateChanged = true;
+    }
+
+    if (state.fallbackProbeTaskbar == taskbarWindow) {
+        state.fallbackProbeTaskbar = nullptr;
+        state.fallbackProbeMonitor = nullptr;
+        stateChanged = true;
+    }
+
+    if (!stateChanged) {
+        return;
+    }
+
+    CancelWorkerTimer(state.retryTimerId);
+    state.armed = true;
+    state.lastActivationCheck = 0;
+    state.suppressionFailures = 0;
+    ResetBandEntry(state);
+
+    // WM_NCDESTROY is observed before Explorer's original WndProc returns. Give
+    // the shell a short interval to finish destruction or create a replacement
+    // before searching for a taskbar again; otherwise the worker could briefly
+    // rediscover the window that's still being torn down.
+    Wh_Log(L"Forgot worker state for destroyed taskbar %p", taskbarWindow);
+    ScheduleRetry(state, kTaskbarRebuildRetryMs);
+}
+
 void HandleReleaseTimer(ActivationWorkerState& state) {
     CancelWorkerTimer(state.releaseTimerId);
 
@@ -2096,6 +2186,12 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
 
                 case kWorkerNativePointerLeaveMessage:
                     HandleNativePointerLeave(
+                        state,
+                        reinterpret_cast<HWND>(message.wParam));
+                    break;
+
+                case kWorkerTaskbarDestroyedMessage:
+                    HandleTaskbarDestroyed(
                         state,
                         reinterpret_cast<HWND>(message.wParam));
                     break;

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -18,8 +18,10 @@
 Reveal the auto-hidden Windows 11 taskbar from a configurable activation band
 above the bottom edge of the screen.
 
-The cursor stays stationary. The mod tracks cursor movement, then asks Explorer
-on the taskbar UI thread to use its native taskbar unhide and pointer-over paths.
+The cursor stays stationary. The mod tracks cursor movement, asks Explorer to
+keep the target taskbar expanded while the pointer remains in the configured
+region, and uses Explorer's native taskbar show/hide paths on the taskbar UI
+thread.
 
 ## Demonstration
 
@@ -34,52 +36,59 @@ on the taskbar UI thread to use its native taskbar unhide and pointer-over paths
 - Optional fullscreen/presentation suppression
 - Optional suppression while a mouse button is held
 - Optional primary-monitor-only mode
-- No cursor injection, taskbar layout changes, Explorer timer manipulation, or
+- No cursor injection, taskbar layout changes, synthetic pointer-over state, or
   taskbar Z-order forcing
 
 ## Behavior
 
-The activation threshold controls where the taskbar can be revealed. Once this
-mod reveals a taskbar, it keeps Explorer's synthetic pointer-over state until
-the pointer has left both the activation band and the visible taskbar, then
-waits for the configured release delay before clearing it.
+The activation threshold controls where the taskbar can be revealed. After the
+hover delay, the mod marks that taskbar as "keep shown", calls Explorer's native
+unhide path, and asks `ViewCoordinator` to re-evaluate expansion. Explorer's own
+pointer-over notifications continue normally; the mod doesn't swallow or forge
+them.
 
-With a typical Windows 11 taskbar, the default 24-DIP band is shorter than the
-taskbar itself. In that common case the threshold mainly changes the trigger
-area; after reveal, the taskbar's own rectangle keeps it open while you use its
-buttons. Values larger than the taskbar height additionally let the pointer sit
-in the strip above the visible taskbar without collapsing it. Moving directly
-from one monitor's activation band to another releases the old monitor
-immediately, then applies the new monitor's hover delay instead of stacking both
-release and hover delays.
+The keep-shown policy remains active while the pointer is inside either the
+activation band or the visible taskbar. After the pointer leaves both, the
+release delay runs. The mod then removes its keep-shown policy and asks Explorer
+to resume its normal auto-hide path. Because the state lives only in this mod's
+hooks, disabling or unloading the mod can't leave Explorer with a synthetic
+pointer-over state latched.
+
+The default band is 12 DIPs. With a typical Windows 11 taskbar this is shorter
+than the taskbar itself, so the threshold mainly changes the trigger area; once
+revealed, the taskbar's own rectangle keeps it available while you use its
+buttons. Values larger than the taskbar height also create a hold-open strip
+above the visible taskbar and are intentionally more aggressive.
+
+Moving directly from one monitor's activation band to another releases the old
+monitor immediately and starts the new monitor's hover delay instead of stacking
+the old release delay with the new hover delay.
 
 ## Compatibility
 
 The mod is intended for the standard bottom-positioned Windows 11 taskbar. It
-doesn't modify taskbar geometry, XAML, height, icon size, animation duration,
+doesn't modify taskbar XAML, height, icon size, animation duration,
 transparency, the Windows auto-hide setting, or Z-order.
 
-Taskbar Z-order remains Explorer's responsibility. The mod deliberately uses
-Explorer's native TrayUI/CSecondaryTray unhide before asserting synthetic
-pointer-over, but it never calls `SetWindowPos` or forces `HWND_TOPMOST`.
-Unusual shell layering or a Z-order customization can therefore still affect
-which window appears above the taskbar.
+Taskbar Z-order remains Explorer's responsibility. Reveals go through the native
+`TrayUI::Unhide` / `CSecondaryTray::_Unhide` path before the expansion
+re-evaluation, but the mod never calls `SetWindowPos` or forces `HWND_TOPMOST`.
+This preserves Explorer's normal layering behavior and avoids fighting
+always-on-top applications or Z-order customization mods.
 
-**Taskbar auto-hide custom activation area** controls the allowed region along
-the taskbar, while this mod enlarges the trigger distance perpendicular to the
-bottom edge. The implementations solve different trigger problems, but both
-hook Explorer's pointer-over path. This mod temporarily holds Explorer's
-mouse pointer-leave while it owns an enlarged-band reveal, whereas that mod
-observes and filters the same events. Touch/pen leave notifications aren't
-suppressed. Installing both can therefore be hook-order sensitive and isn't
-guaranteed to combine cleanly. The same mouse pointer-leave interception can
-affect **Taskbar auto-hide fine tuning / keyboard-only** state tracking, so
-combinations with mods that hook the same callback should be considered
-unsupported unless specifically tested.
+**Taskbar auto-hide custom activation area** controls where along the taskbar a
+native edge trigger is accepted, while this mod adds trigger depth perpendicular
+to the bottom edge. These are closely related catalog features and may be better
+consolidated if the maintainer prefers. This implementation no longer hooks or
+suppresses `HandleIsPointerOverTaskbarFrameChanged`, so it doesn't hide
+pointer-leave notifications from that mod or from **Taskbar auto-hide fine
+tuning**. Mods that intentionally replace Explorer's hide/show policy can still
+conflict with the keep-shown hooks used here. Release uses Explorer's native
+hide timer and expansion reevaluation, so mods that intercept the hide timer or
+`TrayUI::_Hide` / `CSecondaryTray::_AutoHide` can alter release behavior.
 
-Mods that replace or intentionally suppress Explorer's native reveal behavior
-(such as keyboard-only or never-show mouse modes) are intentionally
-incompatible with mouse activation from this mod.
+Mods that deliberately disable mouse-triggered taskbar reveals remain
+incompatible with the purpose of this mod.
 
 ## Requirements
 
@@ -91,40 +100,45 @@ incompatible with mouse activation from this mod.
 
 ## Known limitations
 
-- Top-, left-, right-, detached-, and arbitrary-position taskbars aren't
-  supported.
+- Top-, left-, right-, detached-, floating-, and arbitrary-position taskbars
+  aren't supported. Bottom placement is inferred from the live taskbar window
+  rectangle; mods that substantially reposition or resize the taskbar can make
+  the geometry check reject it.
 - ExplorerPatcher's legacy Windows 10 taskbar isn't supported.
 - The Windows `ABM_GETSTATE` auto-hide flag is system-wide. With per-monitor
   auto-hide mods, **Require Windows auto-hide** can't determine the auto-hide
   state of an individual monitor.
 - Reveal depends on undocumented Windows 11 taskbar symbols, including
-  `ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged`,
-  `ViewCoordinator::ShouldTaskbarBeExpanded`, and the native TrayUI/secondary
-  tray unhide paths. `ShouldTaskbarBeExpanded` is pass-through and is hooked
-  only to capture Explorer's coordinator early. A Windows update can require
-  symbol updates. Secondary-taskbar symbols are optional so a secondary symbol
-  change doesn't disable the primary taskbar.
-- Fullscreen suppression checks Windows presentation/exclusive-fullscreen
-  state and the topmost eligible application window on the target monitor.
-  Background fullscreen windows behind another normal app don't suppress the
-  band. Click-through, tool, non-activating, cloaked, desktop, and taskbar
-  windows are ignored. Presentation mode is system-wide. Suppression is checked
-  before reveal; it doesn't continuously force-hide an already revealed
-  taskbar if an app later becomes fullscreen.
-- Cursor tracking uses a system-wide `EVENT_OBJECT_LOCATIONCHANGE` WinEvent
-  hook because Windows can't filter that hook to `OBJID_CURSOR` at
-  registration time. Non-cursor events are discarded immediately. If the hook
-  can't be installed, a 150 ms cursor-check timer is used instead.
-- Reveal-blocking conditions that can change without cursor movement (a held
-  mouse button, fullscreen state, or a coordinator that hasn't been observed
-  yet) are retried at most once per second. Settings-only conditions and
-  monitors without a supported taskbar are event-driven and aren't polled.
+  `ViewCoordinator::ShouldTaskbarBeExpanded`, `ViewCoordinator::UpdateIsExpanded`,
+  `TrayUI::_Hide` / `TrayUI::Unhide`, and the corresponding secondary-taskbar
+  paths. A Windows update can require symbol updates. Secondary-taskbar symbols
+  are optional so a secondary symbol change doesn't disable the primary taskbar.
+- Fullscreen suppression checks Windows presentation/exclusive-fullscreen state
+  and the topmost eligible application window on the target monitor. Windows
+  presentation mode is system-wide. Background fullscreen windows behind another
+  normal app don't suppress the band. Click-through, tool, non-activating,
+  cloaked, desktop, and taskbar windows are ignored. A borderless window that
+  covers the monitor is intentionally treated as fullscreen even if the app
+  describes that state as maximized. The top-window verdict is cached for up to
+  one second to keep fullscreen detection off the cursor hot path. Suppression is
+  a pre-reveal gate; it doesn't continuously force-hide a taskbar if an app
+  becomes fullscreen after the reveal.
+- Cursor tracking uses a system-wide `EVENT_OBJECT_LOCATIONCHANGE` WinEvent hook
+  because Windows can't filter it to `OBJID_CURSOR` at registration time. The OS
+  still delivers other location-change events to the hook; the callback discards
+  them immediately. If the hook can't be installed, a 150 ms cursor-check timer
+  is used instead.
+- Transient reveal blockers such as a held mouse button, fullscreen app, or a
+  taskbar coordinator that hasn't been observed yet are retried at most once per
+  second while the pointer remains parked in the band. Settings-only conditions
+  and monitors without a supported taskbar are event-driven and aren't polled.
 
 ## Attribution and license
 
-The Windows 11 taskbar symbols and native reveal techniques were informed by
-GPL-3.0-licensed Windhawk taskbar mods by m417z, including **Taskbar auto-hide
-fine tuning** and **Taskbar auto-hide custom activation area**.
+The Windows 11 taskbar symbols and keep-shown pattern were informed by
+GPL-3.0-licensed Windhawk taskbar mods by m417z, especially **Taskbar auto-hide
+when maximized**, **Taskbar auto-hide fine tuning**, and **Taskbar auto-hide
+custom activation area**.
 
 This mod is distributed under the GNU General Public License v3.0.
 */
@@ -132,12 +146,13 @@ This mod is distributed under the GNU General Public License v3.0.
 
 // ==WindhawkModSettings==
 /*
-- activationThresholdPx: 24
+- activationThresholdPx: 12
   $name: Activation threshold
   $description: >-
     Height of the activation band in logical pixels at 96 DPI, scaled for each
-    monitor. 12-48 is a practical range for most taskbars; values taller than
-    the taskbar also keep it open while the pointer is in the strip above it.
+    monitor. 8-24 is a practical range for most taskbars. Larger values are more
+    aggressive and, once taller than the taskbar, also create a hold-open strip
+    above it.
 - activationDelayMs: 75
   $name: Hover delay
   $description: >-
@@ -147,8 +162,8 @@ This mod is distributed under the GNU General Public License v3.0.
 - releaseDelayMs: 120
   $name: Release delay
   $description: >-
-    Delay before the taskbar is allowed to hide after the pointer leaves both
-    the activation band and the visible taskbar.
+    Delay before Explorer is allowed to hide the taskbar after the pointer leaves
+    both the activation band and the visible taskbar.
 - requireWindowsAutoHide: true
   $name: Require Windows auto-hide
   $description: >-
@@ -180,14 +195,14 @@ This mod is distributed under the GNU General Public License v3.0.
 
 #include <algorithm>
 #include <atomic>
-#include <wchar.h>
+#include <cstddef>
+#include <cstdint>
+#include <cwchar>
 #include <mutex>
 #include <unordered_map>
-#include <unordered_set>
-#include <vector>
 
 struct Settings {
-    std::atomic<int> activationThresholdPx{24};
+    std::atomic<int> activationThresholdPx{12};
     std::atomic<int> activationDelayMs{75};
     std::atomic<int> releaseDelayMs{120};
     std::atomic<bool> requireWindowsAutoHide{true};
@@ -204,44 +219,61 @@ std::atomic<DWORD> g_workerThreadId{0};
 std::atomic<bool> g_cursorUpdatePosted{false};
 std::atomic<HWND> g_mainTaskbarWindow{nullptr};
 std::atomic<bool> g_secondaryTaskbarSupportAvailable{false};
+std::atomic<HWND> g_desiredKeptShownTaskbar{nullptr};
+std::atomic<HWND> g_appliedKeptShownTaskbar{nullptr};
 
 HANDLE g_stopEvent = nullptr;
-std::atomic<HANDLE> g_workerThread{nullptr};
+HANDLE g_workerThread = nullptr;  // Guarded by g_workerThreadMutex.
 std::mutex g_workerThreadMutex;
 std::atomic<bool> g_unloading{false};
 
 // Registered in Wh_ModInit rather than during DLL initialization, avoiding
 // user32 calls while the loader lock is held.
-UINT g_uiThreadMessage = 0;
-enum UiOperation : WPARAM {
-    kUiRevealTaskbar = 1,
-    kUiClearSyntheticPointerOver = 2,
-    kUiClearAllSyntheticPointerOver = 3,
-};
+UINT g_updateTaskbarStateMessage = 0;
 
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
 constexpr UINT kTransientRetryIntervalMs = 1000;
-constexpr UINT kActivationAttemptThrottleMs = 200;
+constexpr UINT_PTR kTrayUITimerHide = 2;
+constexpr ULONGLONG kFullscreenCacheDurationMs = 1000;
 
-// These containers are used by taskbar implementation callbacks and by
-// operations marshalled to the taskbar UI thread. This matches the threading
-// convention used by the maintained taskbar auto-hide mods.
+// These containers are accessed from Explorer's taskbar UI thread by the
+// hooked taskbar methods and the registered taskbar-state message.
 std::unordered_map<HWND, void*> g_trayUiWndProcObjects;
 std::unordered_map<HWND, void*> g_secondaryTrayObjects;
 std::unordered_map<HWND, void*> g_viewCoordinators;
-std::unordered_set<HWND> g_syntheticPointerOverTaskbars;
+std::unordered_map<void*, HWND> g_taskbarsKeptShown;
 
+void* g_trayUiVtableIInspectable = nullptr;
 void* g_trayUiVtableITrayComponentHost = nullptr;
+
+bool EraseKeptShownForWindow(HWND taskbarWindow) {
+    bool erased = false;
+    for (auto it = g_taskbarsKeptShown.begin();
+         it != g_taskbarsKeptShown.end();) {
+        if (it->second == taskbarWindow) {
+            it = g_taskbarsKeptShown.erase(it);
+            erased = true;
+        } else {
+            ++it;
+        }
+    }
+    return erased;
+}
 
 void ForgetTaskbarState(HWND taskbarWindow) {
     g_viewCoordinators.erase(taskbarWindow);
-    g_syntheticPointerOverTaskbars.erase(taskbarWindow);
+    EraseKeptShownForWindow(taskbarWindow);
+
+    HWND expected = taskbarWindow;
+    g_desiredKeptShownTaskbar.compare_exchange_strong(
+        expected, nullptr, std::memory_order_acq_rel);
+    expected = taskbarWindow;
+    g_appliedKeptShownTaskbar.compare_exchange_strong(
+        expected, nullptr, std::memory_order_acq_rel);
 }
 
 DWORD WINAPI ActivationWorkerThread(LPVOID);
-bool HandleTaskbarUiOperation(HWND taskbarWindow,
-                              WPARAM operationValue,
-                              LRESULT* result);
+void ApplyTaskbarKeepShownStateOnUiThread(HWND taskbarWindow);
 
 void LoadSettings() {
     g_settings.activationThresholdPx.store(
@@ -287,15 +319,14 @@ void EnsureActivationWorker() {
         return;
     }
 
-    HANDLE existing = g_workerThread.load(std::memory_order_acquire);
-    if (existing) {
-        const DWORD state = WaitForSingleObject(existing, 0);
+    if (g_workerThread) {
+        const DWORD state = WaitForSingleObject(g_workerThread, 0);
         if (state == WAIT_TIMEOUT) {
             return;
         }
         if (state == WAIT_OBJECT_0) {
-            g_workerThread.store(nullptr, std::memory_order_release);
-            CloseHandle(existing);
+            CloseHandle(g_workerThread);
+            g_workerThread = nullptr;
             Wh_Log(L"Restarting activation worker after prior thread exit");
         } else {
             Wh_Log(L"Couldn't query activation worker state: %u",
@@ -304,14 +335,13 @@ void EnsureActivationWorker() {
         }
     }
 
-    HANDLE workerThread = CreateThread(
+    g_workerThread = CreateThread(
         nullptr, 0, ActivationWorkerThread, nullptr, 0, nullptr);
-    if (!workerThread) {
+    if (!g_workerThread) {
         Wh_Log(L"CreateThread failed: %u", GetLastError());
         return;
     }
 
-    g_workerThread.store(workerThread, std::memory_order_release);
     Wh_Log(L"Started activation worker in the taskbar Explorer process");
 }
 
@@ -401,25 +431,6 @@ HWND FindMainTaskbarWindow() {
     if (taskbarWindow) {
         g_mainTaskbarWindow.store(taskbarWindow, std::memory_order_relaxed);
     }
-    return taskbarWindow;
-}
-
-HWND FindAnyTaskbarWindow() {
-    if (HWND mainTaskbar = FindMainTaskbarWindow()) {
-        return mainTaskbar;
-    }
-
-    HWND taskbarWindow = nullptr;
-    EnumWindows(
-        [](HWND window, LPARAM parameter) -> BOOL {
-            if (IsSupportedTaskbarWindow(window) &&
-                IsCurrentProcessWindow(window)) {
-                *reinterpret_cast<HWND*>(parameter) = window;
-                return FALSE;
-            }
-            return TRUE;
-        },
-        reinterpret_cast<LPARAM>(&taskbarWindow));
     return taskbarWindow;
 }
 
@@ -727,24 +738,92 @@ bool IsPointOverTaskbar(HWND taskbarWindow, const POINT& pointer) {
            PtInRect(&taskbarRect, pointer);
 }
 
-void* QueryViaVtable(void* object, void* targetVtable) {
-    if (!object || !targetVtable) {
+void* QueryViaVtableDirectional(void* object,
+                                  void* targetVtable,
+                                  int direction) {
+    if (!object || !targetVtable || (direction != 1 && direction != -1)) {
         return nullptr;
     }
 
-    // The maintained Windhawk taskbar implementation locates the
-    // ITrayComponentHost subobject by scanning the object's vtable pointers.
-    // Keep the small scan bound used by established Windhawk taskbar mods so
-    // an object-layout change can't turn this into a wide memory walk.
-    auto** candidate = reinterpret_cast<void**>(object);
+    MEMORY_BASIC_INFORMATION memoryInfo{};
+    if (!VirtualQuery(object, &memoryInfo, sizeof(memoryInfo)) ||
+        memoryInfo.State != MEM_COMMIT ||
+        (memoryInfo.Protect & (PAGE_NOACCESS | PAGE_GUARD)) != 0) {
+        return nullptr;
+    }
 
-    for (size_t i = 0; i < 20; i++, candidate++) {
+    const auto regionStart =
+        reinterpret_cast<uintptr_t>(memoryInfo.BaseAddress);
+    const auto regionEnd = regionStart + memoryInfo.RegionSize;
+    const auto objectAddress = reinterpret_cast<uintptr_t>(object);
+
+    for (size_t i = 0; i < 20; i++) {
+        const uintptr_t byteOffset = i * sizeof(void*);
+        uintptr_t candidateAddress = 0;
+        if (direction > 0) {
+            if (objectAddress > UINTPTR_MAX - byteOffset) {
+                break;
+            }
+            candidateAddress = objectAddress + byteOffset;
+        } else {
+            if (objectAddress < byteOffset) {
+                break;
+            }
+            candidateAddress = objectAddress - byteOffset;
+        }
+
+        if (candidateAddress < regionStart ||
+            candidateAddress > regionEnd - sizeof(void*)) {
+            break;
+        }
+
+        auto** candidate = reinterpret_cast<void**>(candidateAddress);
         if (*candidate == targetVtable) {
             return candidate;
         }
     }
 
     return nullptr;
+}
+
+void* QueryViaVtable(void* object, void* targetVtable) {
+    return QueryViaVtableDirectional(object, targetVtable, 1);
+}
+
+void* QueryViaVtableBackwards(void* object, void* targetVtable) {
+    return QueryViaVtableDirectional(object, targetVtable, -1);
+}
+
+using TrayUI_Hide_t = void(WINAPI*)(void* trayUiInspectable);
+TrayUI_Hide_t TrayUI_Hide_Original;
+
+void WINAPI TrayUI_Hide_Hook(void* trayUiInspectable) {
+    auto it = g_taskbarsKeptShown.find(trayUiInspectable);
+    if (!g_unloading.load(std::memory_order_acquire) &&
+        it != g_taskbarsKeptShown.end() &&
+        g_desiredKeptShownTaskbar.load(std::memory_order_acquire) == it->second) {
+        KillTimer(it->second, kTrayUITimerHide);
+        return;
+    }
+
+    TrayUI_Hide_Original(trayUiInspectable);
+}
+
+using CSecondaryTray_AutoHide_t =
+    void(WINAPI*)(void* secondaryTray, bool parameter);
+CSecondaryTray_AutoHide_t CSecondaryTray_AutoHide_Original;
+
+void WINAPI CSecondaryTray_AutoHide_Hook(void* secondaryTray,
+                                         bool parameter) {
+    auto it = g_taskbarsKeptShown.find(secondaryTray);
+    if (!g_unloading.load(std::memory_order_acquire) &&
+        it != g_taskbarsKeptShown.end() &&
+        g_desiredKeptShownTaskbar.load(std::memory_order_acquire) == it->second) {
+        KillTimer(it->second, kTrayUITimerHide);
+        return;
+    }
+
+    CSecondaryTray_AutoHide_Original(secondaryTray, parameter);
 }
 
 using TrayUI_Unhide_t =
@@ -786,22 +865,18 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
     WPARAM wParam,
     LPARAM lParam,
     bool* handled) {
-    if (message == g_uiThreadMessage) {
+    if (message == g_updateTaskbarStateMessage) {
         // Record the existing taskbar object's pThis for free: this message is
         // already executing with the correct TrayUI instance on its UI thread.
         g_trayUiWndProcObjects[window] = trayUi;
         g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
 
-        LRESULT result = 0;
-        if (HandleTaskbarUiOperation(window, wParam, &result)) {
-            if (handled) {
-                *handled = true;
-            }
-            return result;
+        ApplyTaskbarKeepShownStateOnUiThread(window);
+        if (handled) {
+            *handled = true;
         }
+        return 0;
     }
-
-    HandleTaskbarEnvironmentMessage(message);
 
     const bool taskbarCreating = message == WM_NCCREATE;
     if (taskbarCreating) {
@@ -824,9 +899,10 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
         wParam,
         lParam,
         handled);
-    if (taskbarCreating) {
-        // Wake a worker that may be backing off because this monitor previously
-        // had no taskbar. Queue only after Explorer has processed WM_NCCREATE.
+    HandleTaskbarEnvironmentMessage(message);
+    if (taskbarCreating || message == WM_NCDESTROY) {
+        // Re-evaluate after Explorer has processed creation/destruction. The
+        // worker message carries no HWND, so handle reuse can't make this stale.
         QueuePointerStateUpdate();
     }
     return originalResult;
@@ -847,18 +923,14 @@ LRESULT WINAPI CSecondaryTray_WndProc_Hook(
     UINT message,
     WPARAM wParam,
     LPARAM lParam) {
-    if (message == g_uiThreadMessage) {
+    if (message == g_updateTaskbarStateMessage) {
         // As with the primary taskbar, the first UI operation records the
         // existing CSecondaryTray object without a separate capture round-trip.
         g_secondaryTrayObjects[window] = secondaryTray;
 
-        LRESULT result = 0;
-        if (HandleTaskbarUiOperation(window, wParam, &result)) {
-            return result;
-        }
+        ApplyTaskbarKeepShownStateOnUiThread(window);
+        return 0;
     }
-
-    HandleTaskbarEnvironmentMessage(message);
 
     const bool taskbarCreating = message == WM_NCCREATE;
     if (taskbarCreating) {
@@ -876,7 +948,8 @@ LRESULT WINAPI CSecondaryTray_WndProc_Hook(
         message,
         wParam,
         lParam);
-    if (taskbarCreating) {
+    HandleTaskbarEnvironmentMessage(message);
+    if (taskbarCreating || message == WM_NCDESTROY) {
         QueuePointerStateUpdate();
     }
     return originalResult;
@@ -935,28 +1008,12 @@ void RememberViewCoordinator(HWND taskbarWindow, void* viewCoordinator) {
     Wh_Log(L"Captured ViewCoordinator %p for taskbar %p",
            viewCoordinator,
            taskbarWindow);
-
-    // A worker waiting for the first coordinator doesn't need to poll until the
-    // next retry interval; the capture itself is the event that makes reveal
-    // possible.
-    QueuePointerStateUpdate();
 }
 
 void* GetViewCoordinator(HWND taskbarWindow) {
     auto it = g_viewCoordinators.find(taskbarWindow);
     return it != g_viewCoordinators.end() ? it->second : nullptr;
 }
-
-// Undocumented Windows 11 taskbar method. inputDeviceKind 0 corresponds to
-// the mouse path used by Windows' taskbar implementation.
-using ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_t =
-    void(WINAPI*)(void* viewCoordinator,
-                  HWND taskbarWindow,
-                  bool isPointerOver,
-                  int inputDeviceKind);
-
-ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_t
-    ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original;
 
 using ViewCoordinator_ShouldTaskbarBeExpanded_t =
     bool(WINAPI*)(void* viewCoordinator,
@@ -966,220 +1023,170 @@ using ViewCoordinator_ShouldTaskbarBeExpanded_t =
 ViewCoordinator_ShouldTaskbarBeExpanded_t
     ViewCoordinator_ShouldTaskbarBeExpanded_Original;
 
+using ViewCoordinator_UpdateIsExpanded_t =
+    void(WINAPI*)(void* viewCoordinator,
+                  HWND taskbarWindow,
+                  int reason);
+
+ViewCoordinator_UpdateIsExpanded_t ViewCoordinator_UpdateIsExpanded_Original;
+
+bool IsTaskbarKeptShownOnUiThread(HWND taskbarWindow) {
+    for (const auto& [object, window] : g_taskbarsKeptShown) {
+        (void)object;
+        if (window == taskbarWindow) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool WINAPI ViewCoordinator_ShouldTaskbarBeExpanded_Hook(
     void* viewCoordinator,
     HWND taskbarWindow,
     bool expanded) {
     RememberViewCoordinator(taskbarWindow, viewCoordinator);
+
+    if (!g_unloading.load(std::memory_order_acquire) &&
+        g_desiredKeptShownTaskbar.load(std::memory_order_acquire) ==
+            taskbarWindow &&
+        IsTaskbarKeptShownOnUiThread(taskbarWindow)) {
+        return true;
+    }
+
     return ViewCoordinator_ShouldTaskbarBeExpanded_Original(
         viewCoordinator, taskbarWindow, expanded);
 }
 
-void WINAPI
-ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook(
-    void* viewCoordinator,
-    HWND taskbarWindow,
-    bool isPointerOver,
-    int inputDeviceKind) {
-    RememberViewCoordinator(taskbarWindow, viewCoordinator);
-
-    if (!isPointerOver && inputDeviceKind == 0 &&
-        g_syntheticPointerOverTaskbars.contains(taskbarWindow)) {
-        if (g_workerThreadId.load(std::memory_order_acquire)) {
-            // Explorer's physical frame is narrower than the configured band.
-            // Keep our synthetic enter until the worker applies releaseDelayMs.
-            return;
-        }
-
-        // Never leave the taskbar latched if the worker unexpectedly stopped.
-        g_syntheticPointerOverTaskbars.erase(taskbarWindow);
-        Wh_Log(L"Worker unavailable; releasing synthetic state for taskbar %p",
-               taskbarWindow);
-        EnsureActivationWorker();
-    }
-
-    ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
-        viewCoordinator,
-        taskbarWindow,
-        isPointerOver,
-        inputDeviceKind);
-}
-
-bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
-                                       bool isPointerOver) {
-    if (!isPointerOver && taskbarWindow &&
-        !g_syntheticPointerOverTaskbars.contains(taskbarWindow)) {
-        return true;
-    }
-
-    if (!taskbarWindow || !IsWindow(taskbarWindow) ||
-        !ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original) {
-        if (taskbarWindow && !IsWindow(taskbarWindow)) {
-            ForgetTaskbarState(taskbarWindow);
-        }
+bool UpdateViewCoordinatorIsExpandedOnUiThread(HWND taskbarWindow) {
+    if (!ViewCoordinator_UpdateIsExpanded_Original) {
         return false;
     }
 
     void* viewCoordinator = GetViewCoordinator(taskbarWindow);
     if (!viewCoordinator) {
-        Wh_Log(L"No ViewCoordinator captured yet for taskbar %p",
-               taskbarWindow);
         return false;
     }
 
-    if (isPointerOver) {
-        const auto [_, inserted] =
-            g_syntheticPointerOverTaskbars.insert(taskbarWindow);
-
-        if (!inserted) {
-            return true;
-        }
-
-        Wh_Log(L"Setting synthetic pointer-over for taskbar %p",
-               taskbarWindow);
-
-        // Explorer's native handler performs the corresponding expansion
-        // reevaluation internally. Calling it once mirrors the established
-        // taskbar auto-hide reveal path without overriding expansion policy.
-        ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
-            viewCoordinator,
-            taskbarWindow,
-            true,
-            0);
-    } else {
-        if (g_syntheticPointerOverTaskbars.erase(taskbarWindow) == 0) {
-            return true;
-        }
-
-        Wh_Log(L"Clearing synthetic pointer-over for taskbar %p",
-               taskbarWindow);
-
-        ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
-            viewCoordinator,
-            taskbarWindow,
-            false,
-            0);
-    }
-
+    // Reason 7 is ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged.
+    // The maintained keep-shown implementation uses it to request a normal
+    // expansion-policy reevaluation without modifying pointer-over bookkeeping.
+    constexpr int kReasonPointerOverTaskbarFrameChanged = 7;
+    ViewCoordinator_UpdateIsExpanded_Original(
+        viewCoordinator,
+        taskbarWindow,
+        kReasonPointerOverTaskbarFrameChanged);
     return true;
 }
 
-bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
-    if (!taskbarWindow || !IsWindow(taskbarWindow) ||
-        !ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original) {
-        return false;
-    }
-
-    // Don't start Explorer's visible unhide until the coordinator is available.
-    // This avoids a native-only first reveal that immediately collapses before
-    // the worker can take synthetic pointer-over ownership.
-    if (!GetViewCoordinator(taskbarWindow)) {
-        Wh_Log(L"ViewCoordinator isn't captured yet for taskbar %p",
-               taskbarWindow);
-        return false;
-    }
-
-    // Preserve Explorer's own slide/Z-order transition before asserting the
-    // synthetic mouse pointer-over state. This is important for shell layering,
-    // but only after we know the matching synthetic ownership can be established.
-    if (!InvokeNativeShellUnhideOnUiThread(taskbarWindow)) {
-        return false;
-    }
-
-    return SetSyntheticPointerOverOnUiThread(taskbarWindow, true);
-}
-
-void ClearAllSyntheticPointerOverOnUiThread() {
-    std::vector<HWND> taskbars(
-        g_syntheticPointerOverTaskbars.begin(),
-        g_syntheticPointerOverTaskbars.end());
-
-    for (HWND taskbarWindow : taskbars) {
-        SetSyntheticPointerOverOnUiThread(taskbarWindow, false);
-    }
-
-    g_syntheticPointerOverTaskbars.clear();
-}
-
-bool HandleTaskbarUiOperation(HWND taskbarWindow,
-                              WPARAM operationValue,
-                              LRESULT* result) {
-    if (!result || operationValue < kUiRevealTaskbar ||
-        operationValue > kUiClearAllSyntheticPointerOver) {
-        return false;
-    }
-
-    switch (static_cast<UiOperation>(operationValue)) {
-        case kUiRevealTaskbar:
-            *result = RevealTaskbarOnUiThread(taskbarWindow) ? 1 : 0;
-            return true;
-
-        case kUiClearSyntheticPointerOver:
-            *result = SetSyntheticPointerOverOnUiThread(
-                          taskbarWindow, false)
-                          ? 1
-                          : 0;
-            return true;
-
-        case kUiClearAllSyntheticPointerOver:
-            ClearAllSyntheticPointerOverOnUiThread();
-            *result = 1;
-            return true;
-    }
-
-    return false;
-}
-
-enum class UiCallResult {
-    kFailed,
-    kSucceeded,
-    kUncertain,
-};
-
-UiCallResult SendUiOperation(UiOperation operation,
-                             HWND taskbarWindow,
-                             DWORD timeoutMs = 250) {
-    HWND destination = taskbarWindow;
-    if (operation == kUiClearAllSyntheticPointerOver) {
-        destination = FindAnyTaskbarWindow();
-    }
-
-    if (!destination || !IsSupportedTaskbarWindow(destination) ||
-        !IsCurrentProcessWindow(destination)) {
-        return UiCallResult::kFailed;
-    }
-
-    DWORD_PTR result = 0;
-    SetLastError(ERROR_SUCCESS);
-    if (!SendMessageTimeoutW(
-            destination,
-            g_uiThreadMessage,
-            operation,
-            0,
-            SMTO_ABORTIFHUNG | SMTO_BLOCK | SMTO_ERRORONEXIT,
-            timeoutMs,
-            &result)) {
-        const DWORD error = GetLastError();
-        Wh_Log(L"Taskbar UI operation timed out/failed: operation=%u "
-               L"taskbar=%p error=%u",
-               static_cast<unsigned>(operation),
-               destination,
-               error);
-
-        // SendMessageTimeout can return after a destination WndProc has started
-        // processing but before it returns. In that narrow case the UI-side
-        // effect can still complete after this worker resumes. Preserve that
-        // distinction so a possible late synthetic enter is always reconciled.
-        // See Raymond Chen's documented explanation:
-        // https://devblogs.microsoft.com/oldnewthing/20110915-00/?p=9643
-        if (error != ERROR_INVALID_WINDOW_HANDLE && IsWindow(destination)) {
-            return UiCallResult::kUncertain;
+void* GetKeepShownObjectForTaskbarOnUiThread(HWND taskbarWindow) {
+    switch (GetTaskbarKind(taskbarWindow)) {
+        case TaskbarKind::kMain: {
+            auto it = g_trayUiWndProcObjects.find(taskbarWindow);
+            if (it == g_trayUiWndProcObjects.end() ||
+                !g_trayUiVtableIInspectable) {
+                return nullptr;
+            }
+            return QueryViaVtableBackwards(
+                it->second, g_trayUiVtableIInspectable);
         }
-        return UiCallResult::kFailed;
+
+        case TaskbarKind::kSecondary: {
+            auto it = g_secondaryTrayObjects.find(taskbarWindow);
+            return it != g_secondaryTrayObjects.end() ? it->second : nullptr;
+        }
+
+        default:
+            return nullptr;
+    }
+}
+
+void ApplyTaskbarKeepShownStateOnUiThread(HWND taskbarWindow) {
+    if (!taskbarWindow || !IsCurrentProcessWindow(taskbarWindow)) {
+        return;
     }
 
-    return result != 0 ? UiCallResult::kSucceeded
-                       : UiCallResult::kFailed;
+    const bool shouldKeepShown =
+        !g_unloading.load(std::memory_order_acquire) &&
+        g_desiredKeptShownTaskbar.load(std::memory_order_acquire) ==
+            taskbarWindow;
+
+    if (shouldKeepShown) {
+        void* keepShownObject =
+            GetKeepShownObjectForTaskbarOnUiThread(taskbarWindow);
+        if (!keepShownObject) {
+            Wh_Log(L"Couldn't resolve keep-shown object for taskbar %p",
+                   taskbarWindow);
+            return;
+        }
+
+        // Establish the policy before native Unhide. If Unhide asks
+        // ShouldTaskbarBeExpanded synchronously, the hook already returns true.
+        // Re-running the native unhide on an idempotent state update also repairs
+        // a stale visible/layering state without any manual Z-order changes.
+        g_taskbarsKeptShown[keepShownObject] = taskbarWindow;
+
+        if (!InvokeNativeShellUnhideOnUiThread(taskbarWindow)) {
+            g_taskbarsKeptShown.erase(keepShownObject);
+            Wh_Log(L"Native taskbar unhide failed for taskbar %p",
+                   taskbarWindow);
+            return;
+        }
+
+        if (UpdateViewCoordinatorIsExpandedOnUiThread(taskbarWindow)) {
+            g_appliedKeptShownTaskbar.store(taskbarWindow,
+                                           std::memory_order_release);
+        } else {
+            // Native Unhide can itself cause ShouldTaskbarBeExpanded to run. If
+            // it didn't, leave the state unconfirmed so the worker retries this
+            // idempotent show operation instead of assuming a partial reveal is
+            // fully established.
+            Wh_Log(L"ViewCoordinator not captured yet for taskbar %p",
+                   taskbarWindow);
+        }
+        return;
+    }
+
+    // Release is idempotent. Only poke Explorer's native hide path if this mod
+    // actually had keep-shown state for the taskbar; a stale/public registered
+    // message must not hide a taskbar that the mod never owned. Timer ID 2 is
+    // Explorer's native taskbar hide timer and this is the established Windhawk
+    // keep-shown release pattern.
+    const bool wasKeptShown = EraseKeptShownForWindow(taskbarWindow);
+    const bool wasApplied =
+        g_appliedKeptShownTaskbar.load(std::memory_order_acquire) ==
+        taskbarWindow;
+    if (wasKeptShown || wasApplied) {
+        if (IsWindow(taskbarWindow) &&
+            !SetTimer(taskbarWindow, kTrayUITimerHide, 0, nullptr)) {
+            Wh_Log(L"Couldn't arm Explorer's hide timer for taskbar %p: %u",
+                   taskbarWindow,
+                   GetLastError());
+        }
+        (void)UpdateViewCoordinatorIsExpandedOnUiThread(taskbarWindow);
+    }
+
+    HWND expected = taskbarWindow;
+    g_appliedKeptShownTaskbar.compare_exchange_strong(
+        expected, nullptr, std::memory_order_acq_rel);
+}
+
+bool PostTaskbarStateUpdate(HWND taskbarWindow) {
+    if (!taskbarWindow || !IsSupportedTaskbarWindow(taskbarWindow) ||
+        !IsCurrentProcessWindow(taskbarWindow)) {
+        return false;
+    }
+
+    if (!PostMessageW(taskbarWindow,
+                      g_updateTaskbarStateMessage,
+                      0,
+                      0)) {
+        Wh_Log(L"Couldn't post taskbar-state update for %p: %u",
+               taskbarWindow,
+               GetLastError());
+        return false;
+    }
+
+    return true;
 }
 
 struct WorkerTimer {
@@ -1191,13 +1198,12 @@ struct ActivationWorkerState {
     HWND activeTaskbar = nullptr;
     HMONITOR activeTaskbarMonitor = nullptr;
     HMONITOR activationCandidateMonitor = nullptr;
-    HMONITOR bandEntryMonitor = nullptr;
-    bool armed = true;
-    bool uiStateUncertain = false;
     WorkerTimer releaseTimer;
     WorkerTimer retryTimer;
     ULONGLONG activationCandidateSince = 0;
-    ULONGLONG lastActivationAttempt = 0;
+    HMONITOR fullscreenCacheMonitor = nullptr;
+    ULONGLONG fullscreenCacheTimestamp = 0;
+    bool fullscreenCacheValue = false;
 };
 
 UINT GetMonitorDpiY(HMONITOR monitor) {
@@ -1217,13 +1223,13 @@ void CancelWorkerTimer(WorkerTimer& timer) {
     timer.dueAt = 0;
 }
 
-void ScheduleWorkerTimer(UINT delayMs, WorkerTimer& timer) {
+bool ScheduleWorkerTimer(UINT delayMs, WorkerTimer& timer) {
     const UINT effectiveDelay = std::max(delayMs, 1U);
     const ULONGLONG requestedDueAt = GetTickCount64() + effectiveDelay;
 
     if (timer.id) {
         if (timer.dueAt && timer.dueAt <= requestedDueAt) {
-            return;
+            return true;
         }
         CancelWorkerTimer(timer);
     }
@@ -1231,55 +1237,14 @@ void ScheduleWorkerTimer(UINT delayMs, WorkerTimer& timer) {
     timer.id = SetTimer(nullptr, 0, effectiveDelay, nullptr);
     if (!timer.id) {
         Wh_Log(L"Failed to create worker timer: %u", GetLastError());
-        return;
-    }
-    timer.dueAt = requestedDueAt;
-}
-
-void ForgetWorkerActiveTaskbar(ActivationWorkerState& state) {
-    state.activeTaskbar = nullptr;
-    state.activeTaskbarMonitor = nullptr;
-    state.armed = true;
-    state.uiStateUncertain = false;
-}
-
-bool ClearActiveTaskbar(ActivationWorkerState& state,
-                        DWORD timeoutMs = 250,
-                        bool scheduleRetry = true) {
-    CancelWorkerTimer(state.releaseTimer);
-
-    if (!state.activeTaskbar) {
-        return true;
-    }
-
-    if (!IsSupportedTaskbarWindow(state.activeTaskbar) ||
-        !IsCurrentProcessWindow(state.activeTaskbar)) {
-        ForgetWorkerActiveTaskbar(state);
-        return true;
-    }
-
-    const UiCallResult result = SendUiOperation(
-        kUiClearSyntheticPointerOver, state.activeTaskbar, timeoutMs);
-    if (result != UiCallResult::kSucceeded) {
-        if (result == UiCallResult::kUncertain) {
-            state.uiStateUncertain = true;
-            if (scheduleRetry) {
-                ScheduleWorkerTimer(kTransientRetryIntervalMs,
-                                    state.retryTimer);
-            }
-        } else if (scheduleRetry) {
-            ScheduleWorkerTimer(kTransientRetryIntervalMs,
-                                state.releaseTimer);
-        }
         return false;
     }
-
-    ForgetWorkerActiveTaskbar(state);
+    timer.dueAt = requestedDueAt;
     return true;
 }
 
-void ScheduleRetry(ActivationWorkerState& state, UINT delayMs) {
-    ScheduleWorkerTimer(delayMs, state.retryTimer);
+bool ScheduleRetry(ActivationWorkerState& state, UINT delayMs) {
+    return ScheduleWorkerTimer(delayMs, state.retryTimer);
 }
 
 void ResetActivationCandidate(ActivationWorkerState& state) {
@@ -1287,13 +1252,105 @@ void ResetActivationCandidate(ActivationWorkerState& state) {
     state.activationCandidateSince = 0;
 }
 
-void ResetBandEntry(ActivationWorkerState& state) {
-    state.bandEntryMonitor = nullptr;
-    state.lastActivationAttempt = 0;
+void InvalidateFullscreenCache(ActivationWorkerState& state) {
+    state.fullscreenCacheMonitor = nullptr;
+    state.fullscreenCacheTimestamp = 0;
+    state.fullscreenCacheValue = false;
+}
+
+bool ReleaseActiveTaskbar(ActivationWorkerState& state,
+                          bool scheduleRetry = true) {
+    CancelWorkerTimer(state.releaseTimer);
+
+    if (!state.activeTaskbar) {
+        return true;
+    }
+
+    const HWND taskbarWindow = state.activeTaskbar;
+    HWND expected = taskbarWindow;
+    g_desiredKeptShownTaskbar.compare_exchange_strong(
+        expected, nullptr, std::memory_order_acq_rel);
+
+    if (IsSupportedTaskbarWindow(taskbarWindow) &&
+        IsCurrentProcessWindow(taskbarWindow) &&
+        !PostTaskbarStateUpdate(taskbarWindow)) {
+        if (scheduleRetry) {
+            // During normal operation, preserve the current keep-shown intent
+            // until a release message can be queued. On worker shutdown, fail
+            // open instead: desired stays null so the hooks stop suppressing
+            // Explorer even if the UI thread is unavailable.
+            g_desiredKeptShownTaskbar.store(taskbarWindow,
+                                           std::memory_order_release);
+            if (ScheduleWorkerTimer(kTransientRetryIntervalMs,
+                                    state.releaseTimer)) {
+                return false;
+            }
+
+            // A failed retry timer must never turn a transient PostMessage
+            // failure into a permanently kept-open taskbar. Drop the intent and
+            // fail open; the stale UI-thread map is inert while desired is null.
+            g_desiredKeptShownTaskbar.store(nullptr,
+                                           std::memory_order_release);
+            HWND applied = taskbarWindow;
+            g_appliedKeptShownTaskbar.compare_exchange_strong(
+                applied, nullptr, std::memory_order_acq_rel);
+        }
+    }
+
+    state.activeTaskbar = nullptr;
+    state.activeTaskbarMonitor = nullptr;
+    return true;
+}
+
+bool RequestTaskbarReveal(ActivationWorkerState& state,
+                          HWND taskbarWindow,
+                          HMONITOR monitor) {
+    const HWND previousDesired =
+        g_desiredKeptShownTaskbar.exchange(taskbarWindow,
+                                           std::memory_order_acq_rel);
+    if (previousDesired && previousDesired != taskbarWindow) {
+        PostTaskbarStateUpdate(previousDesired);
+    }
+
+    if (!PostTaskbarStateUpdate(taskbarWindow)) {
+        HWND expected = taskbarWindow;
+        g_desiredKeptShownTaskbar.compare_exchange_strong(
+            expected, nullptr, std::memory_order_acq_rel);
+        return false;
+    }
+
+    state.activeTaskbar = taskbarWindow;
+    state.activeTaskbarMonitor = monitor;
     ResetActivationCandidate(state);
+
+    // Confirmation is asynchronous. If Explorer's taskbar UI thread was busy
+    // or the keep-shown object couldn't be resolved, retry idempotently at 1 Hz.
+    if (g_appliedKeptShownTaskbar.load(std::memory_order_acquire) !=
+        taskbarWindow) {
+        ScheduleRetry(state, kTransientRetryIntervalMs);
+    }
+    return true;
+}
+
+bool GetCachedFullscreenState(ActivationWorkerState& state,
+                              HMONITOR monitor,
+                              ULONGLONG now) {
+    if (state.fullscreenCacheMonitor == monitor &&
+        now - state.fullscreenCacheTimestamp < kFullscreenCacheDurationMs) {
+        return state.fullscreenCacheValue;
+    }
+
+    state.fullscreenCacheMonitor = monitor;
+    state.fullscreenCacheTimestamp = now;
+    state.fullscreenCacheValue = IsFullscreenWindowOnMonitor(monitor);
+    return state.fullscreenCacheValue;
 }
 
 void ProcessPointerState(ActivationWorkerState& state) {
+    if (g_unloading.load(std::memory_order_acquire)) {
+        return;
+    }
+
     POINT pointer{};
     if (!GetCursorPos(&pointer)) {
         return;
@@ -1302,9 +1359,9 @@ void ProcessPointerState(ActivationWorkerState& state) {
     HMONITOR pointerMonitor =
         MonitorFromPoint(pointer, MONITOR_DEFAULTTONULL);
     if (!pointerMonitor) {
-        (void)ClearActiveTaskbar(state);
+        (void)ReleaseActiveTaskbar(state);
         CancelWorkerTimer(state.retryTimer);
-        ResetBandEntry(state);
+        ResetActivationCandidate(state);
         return;
     }
 
@@ -1319,6 +1376,18 @@ void ProcessPointerState(ActivationWorkerState& state) {
         pointer, monitorInfo, GetMonitorDpiY(pointerMonitor));
 
     if (state.activeTaskbar) {
+        // UI-thread destruction or a fail-open cleanup can clear the desired
+        // keep-shown target before the worker observes it. Don't let a stale or
+        // recycled HWND keep the worker logically active after that happens.
+        if (g_desiredKeptShownTaskbar.load(std::memory_order_acquire) !=
+            state.activeTaskbar) {
+            CancelWorkerTimer(state.releaseTimer);
+            state.activeTaskbar = nullptr;
+            state.activeTaskbarMonitor = nullptr;
+        }
+    }
+
+    if (state.activeTaskbar) {
         bool activeTaskbarAllowed = true;
         if (g_settings.primaryMonitorOnly.load(std::memory_order_relaxed)) {
             MONITORINFO activeMonitorInfo{};
@@ -1330,15 +1399,14 @@ void ProcessPointerState(ActivationWorkerState& state) {
         }
 
         if (!activeTaskbarAllowed) {
-            // A settings change can make an already-owned secondary taskbar
-            // ineligible even while the pointer hasn't moved out of its band.
-            if (!ClearActiveTaskbar(state)) {
+            if (!ReleaseActiveTaskbar(state)) {
                 return;
             }
         } else if (!IsSupportedTaskbarWindow(state.activeTaskbar) ||
                    !IsCurrentProcessWindow(state.activeTaskbar)) {
             CancelWorkerTimer(state.releaseTimer);
-            ForgetWorkerActiveTaskbar(state);
+            state.activeTaskbar = nullptr;
+            state.activeTaskbarMonitor = nullptr;
         } else {
             const bool sameMonitorBand =
                 insideActivationBand &&
@@ -1348,41 +1416,42 @@ void ProcessPointerState(ActivationWorkerState& state) {
 
             if (sameMonitorBand || overTaskbar) {
                 CancelWorkerTimer(state.releaseTimer);
-                // A timed-out UI operation must still be reconciled even if the
-                // pointer remains inside the band; otherwise an uncertain no-op
-                // can wedge this band entry until the pointer leaves and re-enters.
-                if (!state.uiStateUncertain) {
+
+                if (g_appliedKeptShownTaskbar.load(
+                        std::memory_order_acquire) != state.activeTaskbar) {
+                    // RequestTaskbarReveal already queued the first update. While
+                    // that update is pending, cursor movement must not flood the
+                    // taskbar UI queue with duplicate registered messages.
+                    if (!state.retryTimer.id) {
+                        (void)PostTaskbarStateUpdate(state.activeTaskbar);
+                        (void)ScheduleRetry(state, kTransientRetryIntervalMs);
+                    }
+                } else {
                     CancelWorkerTimer(state.retryTimer);
                 }
                 return;
             }
 
-            if (state.uiStateUncertain) {
-                const int releaseDelay =
-                    g_settings.releaseDelayMs.load(std::memory_order_relaxed);
-                ScheduleRetry(state,
-                              static_cast<UINT>(std::max(releaseDelay, 1)));
-                return;
-            }
-
             if (insideActivationBand &&
                 pointerMonitor != state.activeTaskbarMonitor) {
-                // A direct monitor-to-monitor transition shouldn't pay the old
-                // monitor's release delay. Release it now, then let the new
-                // monitor apply its own hover delay below.
-                if (!ClearActiveTaskbar(state)) {
+                // Direct monitor transitions don't pay the old monitor's
+                // release delay before starting the new monitor's hover delay.
+                if (!ReleaseActiveTaskbar(state)) {
                     return;
                 }
             } else {
                 const int releaseDelay =
                     g_settings.releaseDelayMs.load(std::memory_order_relaxed);
-                if (releaseDelay > 0) {
+                if (releaseDelay > 0 &&
                     ScheduleWorkerTimer(static_cast<UINT>(releaseDelay),
-                                        state.releaseTimer);
+                                        state.releaseTimer)) {
                     return;
                 }
 
-                if (!ClearActiveTaskbar(state)) {
+                // If the release-delay timer can't be created, fail open and
+                // release immediately rather than risking a taskbar that stays
+                // kept shown after the pointer has left.
+                if (!ReleaseActiveTaskbar(state)) {
                     return;
                 }
             }
@@ -1390,21 +1459,9 @@ void ProcessPointerState(ActivationWorkerState& state) {
     }
 
     if (!insideActivationBand) {
-        state.armed = true;
         CancelWorkerTimer(state.retryTimer);
-        ResetBandEntry(state);
-        return;
-    }
-
-    if (state.bandEntryMonitor != pointerMonitor) {
-        state.bandEntryMonitor = pointerMonitor;
-        state.armed = true;
-        state.lastActivationAttempt = 0;
         ResetActivationCandidate(state);
-    }
-
-    if (!state.armed) {
-        CancelWorkerTimer(state.retryTimer);
+        InvalidateFullscreenCache(state);
         return;
     }
 
@@ -1425,19 +1482,10 @@ void ProcessPointerState(ActivationWorkerState& state) {
         }
     }
 
-    const ULONGLONG sinceLastAttempt = now - state.lastActivationAttempt;
-    if (sinceLastAttempt < kActivationAttemptThrottleMs) {
-        ScheduleRetry(
-            state,
-            static_cast<UINT>(kActivationAttemptThrottleMs - sinceLastAttempt));
-        return;
-    }
-
-    state.lastActivationAttempt = now;
     CancelWorkerTimer(state.retryTimer);
 
-    // Cheap, event-driven gates first. These conditions don't need polling:
-    // settings changes and taskbar creation already queue a fresh state update.
+    // Event-driven gates first. Settings changes and taskbar creation already
+    // queue a fresh pointer-state update, so these conditions aren't polled.
     if (g_settings.primaryMonitorOnly.load(std::memory_order_relaxed) &&
         (monitorInfo.dwFlags & MONITORINFOF_PRIMARY) == 0) {
         return;
@@ -1447,71 +1495,36 @@ void ProcessPointerState(ActivationWorkerState& state) {
         return;
     }
 
-    // Button state can change without cursor movement, so keep a low-frequency
-    // retry for this transient condition.
+    // A held button and fullscreen state can change while the cursor is parked.
     if (g_settings.ignoreWhileMouseButtonDown.load(std::memory_order_relaxed) &&
         IsAnyMouseButtonDown()) {
         ScheduleRetry(state, kTransientRetryIntervalMs);
         return;
     }
 
-    // ABM_GETSTATE is system-wide and changes through shell/settings events that
-    // already wake the worker. Don't poll it while auto-hide is disabled.
     if (g_settings.requireWindowsAutoHide.load(std::memory_order_relaxed) &&
         !IsWindowsAutoHideEnabled()) {
         return;
     }
 
-    // Monitors without a supported taskbar are awakened by taskbar WM_NCCREATE
-    // or display changes, so this is also an event-driven no-retry gate.
     HWND taskbarWindow = FindTaskbarForMonitor(pointerMonitor);
     if (!taskbarWindow) {
         return;
     }
 
-    // Fullscreen state can end while the pointer is stationary. One check per
-    // second is responsive enough without maintaining a 4 Hz desktop walk.
     if (g_settings.ignoreFullscreenApps.load(std::memory_order_relaxed) &&
-        IsFullscreenWindowOnMonitor(pointerMonitor)) {
+        GetCachedFullscreenState(state, pointerMonitor, now)) {
         ScheduleRetry(state, kTransientRetryIntervalMs);
         return;
     }
 
-    const UiCallResult revealResult =
-        SendUiOperation(kUiRevealTaskbar, taskbarWindow, 250);
-    if (revealResult == UiCallResult::kSucceeded ||
-        revealResult == UiCallResult::kUncertain) {
-        state.activeTaskbar = taskbarWindow;
-        state.activeTaskbarMonitor = pointerMonitor;
-        state.armed = false;
-        state.uiStateUncertain = revealResult == UiCallResult::kUncertain;
-        ResetActivationCandidate(state);
-
-        if (state.uiStateUncertain) {
-            // Don't assume an uncertain reveal succeeded forever. Reconcile it
-            // after one second by forcing a confirmed leave, then retry from a
-            // clean state if the pointer is still eligible.
-            ScheduleRetry(state, kTransientRetryIntervalMs);
-        }
-        return;
+    if (!RequestTaskbarReveal(state, taskbarWindow, pointerMonitor)) {
+        ScheduleRetry(state, kTransientRetryIntervalMs);
     }
-
-    // A confirmed failure establishes no ownership. Retry at low frequency; if
-    // the coordinator is captured in the meantime, its hook also queues an
-    // immediate state update.
-    ScheduleRetry(state, kTransientRetryIntervalMs);
 }
 
 void HandleRetryTimer(ActivationWorkerState& state) {
     CancelWorkerTimer(state.retryTimer);
-
-    if (state.uiStateUncertain && state.activeTaskbar) {
-        if (!ClearActiveTaskbar(state, 250, false)) {
-            ScheduleRetry(state, kTransientRetryIntervalMs);
-            return;
-        }
-    }
-
     ProcessPointerState(state);
 }
 
@@ -1543,7 +1556,7 @@ void HandleReleaseTimer(ActivationWorkerState& state) {
         return;
     }
 
-    if (ClearActiveTaskbar(state)) {
+    if (ReleaseActiveTaskbar(state)) {
         ProcessPointerState(state);
     }
 }
@@ -1648,11 +1661,11 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
     CancelWorkerTimer(state.retryTimer);
     CancelWorkerTimer(state.releaseTimer);
 
-    // Keep unload bounded if Explorer's taskbar UI thread is unresponsive. A
-    // single best-effort release is enough here; Wh_ModBeforeUninit also sends
-    // one UI-thread-wide cleanup before hooks are removed.
+    // Release the mod-owned keep-shown intent without waiting on Explorer's UI
+    // thread. If the posted reconciliation is delayed, the hooks fail open as
+    // soon as unloading begins, so no shell state can remain latched.
     if (state.activeTaskbar) {
-        (void)ClearActiveTaskbar(state, 250, false);
+        (void)ReleaseActiveTaskbar(state, false);
     }
 
     if (cursorHook) {
@@ -1671,18 +1684,18 @@ bool HookTaskbarViewSymbols(HMODULE module) {
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {
-                LR"(public: void __cdecl winrt::Taskbar::implementation::ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged(unsigned __int64,bool,enum winrt::WindowsUdk::UI::Shell::InputDeviceKind))",
-            },
-            &ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original,
-            ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook,
-            true,  // Checked as a required pair below for a clearer diagnostic.
-        },
-        {
-            {
                 LR"(public: bool __cdecl winrt::Taskbar::implementation::ViewCoordinator::ShouldTaskbarBeExpanded(unsigned __int64,bool))",
             },
             &ViewCoordinator_ShouldTaskbarBeExpanded_Original,
             ViewCoordinator_ShouldTaskbarBeExpanded_Hook,
+            true,  // Checked as a required pair below for a clearer diagnostic.
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::Taskbar::implementation::ViewCoordinator::UpdateIsExpanded(unsigned __int64,enum TaskbarTipTest::TaskbarExpandCollapseReason))",
+            },
+            &ViewCoordinator_UpdateIsExpanded_Original,
+            nullptr,
             true,  // Checked as a required pair below for a clearer diagnostic.
         },
     };
@@ -1695,9 +1708,9 @@ bool HookTaskbarViewSymbols(HMODULE module) {
         return false;
     }
 
-    if (!ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original ||
-        !ViewCoordinator_ShouldTaskbarBeExpanded_Original) {
-        Wh_Log(L"Taskbar reveal path unavailable: required ViewCoordinator "
+    if (!ViewCoordinator_ShouldTaskbarBeExpanded_Original ||
+        !ViewCoordinator_UpdateIsExpanded_Original) {
+        Wh_Log(L"Taskbar keep-shown path unavailable: required ViewCoordinator "
                L"symbols need updating");
         return false;
     }
@@ -1721,10 +1734,32 @@ bool HookTaskbarUiThreadSymbol() {
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {
+                LR"(const TrayUI::`vftable'{for `IInspectable'})",
+            },
+            &g_trayUiVtableIInspectable,
+            nullptr,
+        },
+        {
+            {
                 LR"(const TrayUI::`vftable'{for `ITrayComponentHost'})",
             },
             &g_trayUiVtableITrayComponentHost,
             nullptr,
+        },
+        {
+            {
+                LR"(public: void __cdecl TrayUI::_Hide(void))",
+            },
+            &TrayUI_Hide_Original,
+            TrayUI_Hide_Hook,
+        },
+        {
+            {
+                LR"(private: void __cdecl CSecondaryTray::_AutoHide(bool))",
+            },
+            &CSecondaryTray_AutoHide_Original,
+            CSecondaryTray_AutoHide_Hook,
+            true,
         },
         {
             {
@@ -1767,7 +1802,8 @@ bool HookTaskbarUiThreadSymbol() {
     }
 
     const bool secondaryTaskbarSupportAvailable =
-        CSecondaryTray_Unhide_Original && CSecondaryTray_WndProc_Original;
+        CSecondaryTray_AutoHide_Original && CSecondaryTray_Unhide_Original &&
+        CSecondaryTray_WndProc_Original;
     g_secondaryTaskbarSupportAvailable.store(
         secondaryTaskbarSupportAvailable,
         std::memory_order_release);
@@ -1840,10 +1876,10 @@ BOOL Wh_ModInit() {
 
     g_unloading.store(false, std::memory_order_relaxed);
 
-    g_uiThreadMessage =
-        RegisterWindowMessageW(L"taskbar-activation-threshold.ui");
-    if (!g_uiThreadMessage) {
-        Wh_Log(L"RegisterWindowMessageW failed for UI operation channel");
+    g_updateTaskbarStateMessage = RegisterWindowMessageW(
+        L"Windhawk_updateTaskbarKeepShown_" WH_MOD_ID);
+    if (!g_updateTaskbarStateMessage) {
+        Wh_Log(L"RegisterWindowMessageW failed for taskbar-state channel");
         return FALSE;
     }
 
@@ -1907,7 +1943,7 @@ void Wh_ModAfterInit() {
                       L"Shell_TrayWnd",
                       &taskbarClass)) {
         // Existing taskbar objects don't need a separate object-discovery send: the
-        // first marshalled UI operation records its WndProc pThis before the
+        // first posted taskbar-state update records its WndProc pThis before the
         // operation is dispatched. This leaves worker startup independent of
         // taskbar UI-thread responsiveness.
         EnsureActivationWorker();
@@ -1946,18 +1982,20 @@ void Wh_ModBeforeUninit() {
     HANDLE workerThread = nullptr;
     {
         std::lock_guard<std::mutex> guard(g_workerThreadMutex);
-        workerThread = g_workerThread.load(std::memory_order_acquire);
+        workerThread = g_workerThread;
     }
     if (workerThread) {
         WaitForSingleObject(workerThread, INFINITE);
     }
 
-    // One bounded cleanup attempt keeps disable/reload responsive even when
-    // Explorer's taskbar UI thread is the component that's hung.
-    const UiCallResult clearResult =
-        SendUiOperation(kUiClearAllSyntheticPointerOver, nullptr, 500);
-    if (clearResult != UiCallResult::kSucceeded) {
-        Wh_Log(L"Final synthetic pointer-over cleanup wasn't confirmed");
+    // Fail open even if the taskbar UI thread is busy: ShouldTaskbarBeExpanded
+    // and the hide hooks stop enforcing keep-shown as soon as g_unloading is
+    // true. This post only asks Explorer to begin hiding promptly while the
+    // hooks are still installed; no persistent shell pointer state exists.
+    HWND desired =
+        g_desiredKeptShownTaskbar.exchange(nullptr, std::memory_order_acq_rel);
+    if (desired) {
+        PostTaskbarStateUpdate(desired);
     }
 }
 
@@ -1967,8 +2005,8 @@ void Wh_ModUninit() {
     HANDLE workerThread = nullptr;
     {
         std::lock_guard<std::mutex> guard(g_workerThreadMutex);
-        workerThread = g_workerThread.exchange(nullptr,
-                                                std::memory_order_acq_rel);
+        workerThread = g_workerThread;
+        g_workerThread = nullptr;
     }
     if (workerThread) {
         CloseHandle(workerThread);

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -1,0 +1,1633 @@
+// ==WindhawkMod==
+// @id              taskbar-activation-threshold
+// @name            Taskbar Activation Threshold
+// @description     Reveal the auto-hidden Windows 11 taskbar from a configurable bottom activation band without moving the cursor
+// @version         1.0.0
+// @author          themagnificentoofman
+// @github          https://github.com/themagnificentoofman
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lshell32
+// @license         GPL-3.0
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Taskbar Activation Threshold
+
+Reveals an auto-hidden Windows 11 taskbar when the pointer enters a
+configurable activation band above the bottom edge of the monitor.
+
+Unlike version 0.1, this version **never moves the mouse cursor**. It invokes
+the Windows 11 taskbar's native pointer-over state on Explorer's UI thread.
+
+## Compatibility approach
+
+The mod doesn't modify:
+
+- Taskbar position or geometry
+- XAML layout or styles
+- Taskbar height or icon size
+- Animation duration
+- Transparency
+- Windows' auto-hide setting
+
+It is therefore designed to coexist with styling, sizing, transparency,
+animation-speed, clock, label, and icon mods which leave the taskbar at the
+bottom of the screen.
+
+## Requirements
+
+- Windows 11
+- The standard Windows 11 taskbar
+- **Automatically hide the taskbar** enabled in Windows, unless
+  `requireWindowsAutoHide` is disabled
+- Bottom-positioned taskbars
+
+## Known incompatibilities and limitations
+
+- Taskbars moved to the top, left, right, or an arbitrary floating location
+  aren't supported.
+- ExplorerPatcher's legacy Windows 10 taskbar isn't supported by version 0.2.
+- Mods which block or replace the taskbar's native expansion logic can
+  conflict. In particular, keyboard-only or never-show auto-hide modes are
+  intentionally incompatible with mouse activation.
+- Microsoft can rename undocumented taskbar symbols in a Windows update. If
+  that happens, the mod will need a symbol update.
+- The taskbar's internal coordinator must have initialized before the first
+  threshold activation. If the first attempt does nothing immediately after
+  Explorer starts, leave and re-enter the activation band.
+
+## Suggested starting values
+
+- Activation threshold: `42`
+- Poll interval: `8`
+- Release delay: `120`
+- Activation cooldown: `250`
+
+## Version 0.2.4 fixes
+
+- Adds the missing shell-window reveal layer. Windows 11's
+  `ViewCoordinator::IsExpanded` can report true while the outer
+  `Shell_TrayWnd` is still physically hidden below the screen.
+- Calls the native `TrayUI::Unhide` or `CSecondaryTray::_Unhide` path before
+  setting the Windows 11 synthetic pointer-over state.
+- Captures the required taskbar objects after the mod loads, even though their
+  normal creation messages occurred before injection.
+- Keeps the pointer completely stationary.
+
+## Version 0.2.3 fixes
+
+- Explicitly calls `ViewCoordinator::UpdateIsExpanded` after changing the
+  synthetic pointer-over state.
+- Adds `ViewCoordinator::IsExpanded` verification to the diagnostic log.
+- Falls back to Explorer's native unhide timer if the explicit coordinator
+  update still reports the taskbar as collapsed.
+
+## Version 0.2.2 fixes
+
+- Forces `ShouldTaskbarBeExpanded` to return true while this mod owns the
+  synthetic pointer-over state.
+- Logs the taskbar expansion decision and update reason while diagnostic
+  logging is enabled.
+
+## Version 0.2.1 fixes
+
+- Disables fullscreen suppression by default because some borderless or
+  frameless maximized applications can resemble fullscreen windows.
+- Adds a native taskbar unhide-timer fallback when the Windows 11
+  `ViewCoordinator` hasn't been captured yet.
+- Adds clearer diagnostic logging for threshold entry and suppression.
+
+## Attribution and license
+
+The Windows 11 `ViewCoordinator` symbol names and UI-thread invocation
+technique were informed by the GPL-3.0-licensed **Taskbar auto-hide fine
+tuning** Windhawk mod by m417z. Consequently, version 0.2 is distributed under
+GPL-3.0.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- activationThresholdPx: 24
+  $name: Activation threshold
+  $description: >-
+    Height in physical screen pixels of the activation band above the bottom
+    edge. Recommended range: 12 to 48.
+- pollIntervalMs: 8
+  $name: Poll interval
+  $description: >-
+    How often the pointer position is checked, in milliseconds. Recommended:
+    8 to 16.
+- releaseDelayMs: 120
+  $name: Release delay
+  $description: >-
+    Delay before releasing the synthetic pointer-over state after the pointer
+    leaves both the activation band and the visible taskbar.
+- activationCooldownMs: 200
+  $name: Activation cooldown
+  $description: >-
+    Minimum time between reveal attempts, in milliseconds.
+- requireWindowsAutoHide: true
+  $name: Require Windows auto-hide
+  $description: >-
+    Only activate when Windows reports that taskbar auto-hide is enabled.
+    Disable this when another mod manages auto-hide without enabling the
+    Windows setting.
+- ignoreFullscreenApps: false
+  $name: Ignore fullscreen apps
+  $description: >-
+    Don't reveal the taskbar over borderless or exclusive-fullscreen apps.
+- ignoreWhileMouseButtonDown: true
+  $name: Ignore while dragging
+  $description: >-
+    Don't activate while a mouse button is held.
+- primaryMonitorOnly: false
+  $name: Primary monitor only
+  $description: >-
+    Only use the activation band on the primary monitor.
+- nativeTimerFallback: true
+  $name: Native timer fallback
+  $description: >-
+    If the Windows 11 ViewCoordinator isn't available yet, ask Explorer's
+    native taskbar unhide timer to reveal the taskbar. This doesn't move or
+    inject the mouse cursor.
+- diagnosticLogging: false
+  $name: Diagnostic logging
+  $description: >-
+    Write detailed activation and suppression information to the Windhawk log.
+    Enable only while troubleshooting.
+*/
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+#include <shellapi.h>
+#include <windhawk_utils.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdlib>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+struct Settings {
+    std::atomic<int> activationThresholdPx{24};
+    std::atomic<int> pollIntervalMs{8};
+    std::atomic<int> releaseDelayMs{120};
+    std::atomic<int> activationCooldownMs{200};
+    std::atomic<bool> requireWindowsAutoHide{true};
+    std::atomic<bool> ignoreFullscreenApps{false};
+    std::atomic<bool> ignoreWhileMouseButtonDown{true};
+    std::atomic<bool> primaryMonitorOnly{false};
+    std::atomic<bool> nativeTimerFallback{true};
+    std::atomic<bool> diagnosticLogging{false};
+};
+
+Settings g_settings;
+
+std::atomic<bool> g_taskbarViewDllLoaded{false};
+std::atomic<bool> g_settingsChanged{false};
+
+HANDLE g_stopEvent = nullptr;
+HANDLE g_workerThread = nullptr;
+
+// A private message used to marshal operations from the polling worker to
+// Explorer's taskbar UI thread.
+const UINT g_uiThreadMessage =
+    RegisterWindowMessageW(L"Windhawk_TaskbarActivationThreshold_" WH_MOD_ID);
+
+// Existing taskbar windows were created before this mod was injected. Sending
+// this message through their hooked WndProc captures the relevant `this`
+// pointers without restarting Explorer.
+const UINT g_captureTaskbarObjectMessage =
+    RegisterWindowMessageW(
+        L"Windhawk_TaskbarActivationThreshold_Capture_" WH_MOD_ID);
+
+enum UiOperation : WPARAM {
+    kUiRevealTaskbar = 1,
+    kUiClearSyntheticPointerOver = 2,
+    kUiClearAllSyntheticPointerOver = 3,
+};
+
+// The following maps are accessed only on Explorer's taskbar UI thread.
+// They provide the shell object needed to physically slide Shell_TrayWnd
+// onscreen. ViewCoordinator alone only controls the Windows 11 taskbar view's
+// logical expanded/collapsed state.
+std::unordered_map<HWND, void*> g_trayUiWndProcObjects;
+std::unordered_map<HWND, void*> g_secondaryTrayObjects;
+
+void* g_trayUiVtableITrayComponentHost = nullptr;
+void* g_secondaryTrayVtableISecondaryTray = nullptr;
+
+// ViewCoordinator mappings are captured by hooks which run inside the taskbar
+// implementation. Access is protected because a Windows update could move a
+// callback to a different Explorer thread.
+SRWLOCK g_viewCoordinatorLock = SRWLOCK_INIT;
+std::unordered_map<HWND, void*> g_viewCoordinators;
+
+// Accessed only on the taskbar UI thread.
+std::unordered_set<HWND> g_syntheticPointerOverTaskbars;
+
+template <typename T>
+T ClampSetting(T value, T minimum, T maximum) {
+    return std::clamp(value, minimum, maximum);
+}
+
+void LoadSettings() {
+    g_settings.activationThresholdPx.store(
+        ClampSetting(Wh_GetIntSetting(L"activationThresholdPx"), 1, 500),
+        std::memory_order_relaxed);
+
+    g_settings.pollIntervalMs.store(
+        ClampSetting(Wh_GetIntSetting(L"pollIntervalMs"), 1, 1000),
+        std::memory_order_relaxed);
+
+    g_settings.releaseDelayMs.store(
+        ClampSetting(Wh_GetIntSetting(L"releaseDelayMs"), 0, 5000),
+        std::memory_order_relaxed);
+
+    g_settings.activationCooldownMs.store(
+        ClampSetting(Wh_GetIntSetting(L"activationCooldownMs"), 0, 10000),
+        std::memory_order_relaxed);
+
+    g_settings.requireWindowsAutoHide.store(
+        Wh_GetIntSetting(L"requireWindowsAutoHide") != 0,
+        std::memory_order_relaxed);
+
+    g_settings.ignoreFullscreenApps.store(
+        Wh_GetIntSetting(L"ignoreFullscreenApps") != 0,
+        std::memory_order_relaxed);
+
+    g_settings.ignoreWhileMouseButtonDown.store(
+        Wh_GetIntSetting(L"ignoreWhileMouseButtonDown") != 0,
+        std::memory_order_relaxed);
+
+    g_settings.primaryMonitorOnly.store(
+        Wh_GetIntSetting(L"primaryMonitorOnly") != 0,
+        std::memory_order_relaxed);
+
+    g_settings.nativeTimerFallback.store(
+        Wh_GetIntSetting(L"nativeTimerFallback") != 0,
+        std::memory_order_relaxed);
+
+    g_settings.diagnosticLogging.store(
+        Wh_GetIntSetting(L"diagnosticLogging") != 0,
+        std::memory_order_relaxed);
+}
+
+bool IsTaskbarClass(HWND window) {
+    if (!window) {
+        return false;
+    }
+
+    wchar_t className[64];
+    if (!GetClassNameW(window, className, ARRAYSIZE(className))) {
+        return false;
+    }
+
+    return _wcsicmp(className, L"Shell_TrayWnd") == 0 ||
+           _wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0;
+}
+
+HWND FindMainTaskbarWindow() {
+    HWND result = nullptr;
+    EnumWindows(
+        [](HWND window, LPARAM parameter) -> BOOL {
+            auto* result = reinterpret_cast<HWND*>(parameter);
+
+            DWORD processId = 0;
+            GetWindowThreadProcessId(window, &processId);
+
+            if (processId != GetCurrentProcessId()) {
+                return TRUE;
+            }
+
+            wchar_t className[64];
+            if (GetClassNameW(window, className, ARRAYSIZE(className)) &&
+                _wcsicmp(className, L"Shell_TrayWnd") == 0) {
+                *result = window;
+                return FALSE;
+            }
+
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&result));
+
+    return result;
+}
+
+HWND GetTaskBandWindow() {
+    HWND taskbarWindow = FindMainTaskbarWindow();
+    if (!taskbarWindow) {
+        return nullptr;
+    }
+
+    return reinterpret_cast<HWND>(
+        GetPropW(taskbarWindow, L"TaskbandHWND"));
+}
+
+HMONITOR GetTaskbarMonitor(HWND taskbarWindow) {
+    if (HMONITOR monitor = reinterpret_cast<HMONITOR>(
+            GetPropW(taskbarWindow, L"TaskbarMonitor"))) {
+        return monitor;
+    }
+
+    return MonitorFromWindow(taskbarWindow, MONITOR_DEFAULTTONEAREST);
+}
+
+bool IsBottomPositionedTaskbar(HWND taskbarWindow, HMONITOR monitor) {
+    RECT taskbarRect{};
+    if (!GetWindowRect(taskbarWindow, &taskbarRect)) {
+        return false;
+    }
+
+    MONITORINFO monitorInfo{};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if (!GetMonitorInfoW(monitor, &monitorInfo)) {
+        return false;
+    }
+
+    const int monitorWidth =
+        monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left;
+    const int monitorHeight =
+        monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top;
+    const int taskbarWidth = taskbarRect.right - taskbarRect.left;
+    const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
+
+    // Reject vertical and detached taskbar windows. Visual "floating taskbar"
+    // styles normally retain a full-width Shell_TrayWnd and remain compatible.
+    const bool looksHorizontal =
+        taskbarWidth >= monitorWidth / 2 &&
+        taskbarHeight > 0 &&
+        taskbarHeight <= monitorHeight / 2;
+
+    if (!looksHorizontal) {
+        return false;
+    }
+
+    const int tolerance = std::max(16, taskbarHeight + 16);
+
+    // Handles both the visible and auto-hidden window positions.
+    const bool nearBottom =
+        std::abs(taskbarRect.bottom - monitorInfo.rcMonitor.bottom) <=
+            tolerance ||
+        std::abs(taskbarRect.top - monitorInfo.rcMonitor.bottom) <=
+            tolerance ||
+        (taskbarRect.top < monitorInfo.rcMonitor.bottom &&
+         taskbarRect.bottom >= monitorInfo.rcMonitor.bottom - 2);
+
+    return nearBottom;
+}
+
+struct FindTaskbarContext {
+    HMONITOR monitor;
+    HWND result;
+};
+
+BOOL CALLBACK FindTaskbarForMonitorCallback(HWND window, LPARAM parameter) {
+    if (!IsTaskbarClass(window)) {
+        return TRUE;
+    }
+
+    DWORD processId = 0;
+    GetWindowThreadProcessId(window, &processId);
+    if (processId != GetCurrentProcessId()) {
+        return TRUE;
+    }
+
+    auto* context = reinterpret_cast<FindTaskbarContext*>(parameter);
+    HMONITOR taskbarMonitor = GetTaskbarMonitor(window);
+
+    if (taskbarMonitor == context->monitor &&
+        IsBottomPositionedTaskbar(window, taskbarMonitor)) {
+        context->result = window;
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+HWND FindTaskbarForMonitor(HMONITOR monitor) {
+    FindTaskbarContext context{
+        .monitor = monitor,
+        .result = nullptr,
+    };
+
+    EnumWindows(FindTaskbarForMonitorCallback,
+                reinterpret_cast<LPARAM>(&context));
+
+    return context.result;
+}
+
+bool IsWindowsAutoHideEnabled() {
+    APPBARDATA appBarData{};
+    appBarData.cbSize = sizeof(appBarData);
+
+    return (SHAppBarMessage(ABM_GETSTATE, &appBarData) &
+            ABS_AUTOHIDE) != 0;
+}
+
+bool IsAnyMouseButtonDown() {
+    constexpr int mouseButtons[] = {
+        VK_LBUTTON,
+        VK_RBUTTON,
+        VK_MBUTTON,
+        VK_XBUTTON1,
+        VK_XBUTTON2,
+    };
+
+    for (int virtualKey : mouseButtons) {
+        if ((GetAsyncKeyState(virtualKey) & 0x8000) != 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool IsDesktopWindow(HWND window) {
+    if (!window) {
+        return false;
+    }
+
+    wchar_t className[64];
+    if (!GetClassNameW(window, className, ARRAYSIZE(className))) {
+        return false;
+    }
+
+    return _wcsicmp(className, L"Progman") == 0 ||
+           _wcsicmp(className, L"WorkerW") == 0;
+}
+
+bool IsFullscreenWindowOnMonitor(HMONITOR monitor) {
+    HWND foregroundWindow = GetForegroundWindow();
+
+    if (!foregroundWindow || IsIconic(foregroundWindow) ||
+        IsDesktopWindow(foregroundWindow)) {
+        return false;
+    }
+
+    if (MonitorFromWindow(foregroundWindow, MONITOR_DEFAULTTONEAREST) !=
+        monitor) {
+        return false;
+    }
+
+    const LONG_PTR style =
+        GetWindowLongPtrW(foregroundWindow, GWL_STYLE);
+
+    // A regular maximized desktop window normally retains caption/frame
+    // styles. Borderless and exclusive-fullscreen windows normally don't.
+    if ((style & WS_CHILD) != 0 ||
+        (style & (WS_CAPTION | WS_THICKFRAME)) != 0) {
+        return false;
+    }
+
+    RECT windowRect{};
+    if (!GetWindowRect(foregroundWindow, &windowRect)) {
+        return false;
+    }
+
+    MONITORINFO monitorInfo{};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if (!GetMonitorInfoW(monitor, &monitorInfo)) {
+        return false;
+    }
+
+    constexpr int tolerance = 2;
+
+    return windowRect.left <= monitorInfo.rcMonitor.left + tolerance &&
+           windowRect.top <= monitorInfo.rcMonitor.top + tolerance &&
+           windowRect.right >= monitorInfo.rcMonitor.right - tolerance &&
+           windowRect.bottom >= monitorInfo.rcMonitor.bottom - tolerance;
+}
+
+bool IsPointInsideActivationBand(const POINT& pointer,
+                                 const MONITORINFO& monitorInfo) {
+    const int monitorHeight =
+        monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top;
+
+    const int threshold = std::min(
+        g_settings.activationThresholdPx.load(std::memory_order_relaxed),
+        monitorHeight);
+
+    return pointer.x >= monitorInfo.rcMonitor.left &&
+           pointer.x < monitorInfo.rcMonitor.right &&
+           pointer.y >= monitorInfo.rcMonitor.bottom - threshold &&
+           pointer.y < monitorInfo.rcMonitor.bottom;
+}
+
+bool IsPointOverTaskbar(HWND taskbarWindow, const POINT& pointer) {
+    RECT taskbarRect{};
+    return GetWindowRect(taskbarWindow, &taskbarRect) &&
+           PtInRect(&taskbarRect, pointer);
+}
+
+
+void* QueryViaVtable(void* object, void* targetVtable) {
+    if (!object || !targetVtable) {
+        return nullptr;
+    }
+
+    // The maintained Windhawk taskbar implementation locates the
+    // ITrayComponentHost subobject by scanning the object's vtable pointers.
+    // Keep a conservative bound to avoid walking arbitrary memory if Microsoft
+    // changes the object layout.
+    auto** candidate = reinterpret_cast<void**>(object);
+
+    for (size_t i = 0; i < 256; i++, candidate++) {
+        if (!IsBadReadPtr(candidate, sizeof(void*)) &&
+            *candidate == targetVtable) {
+            return candidate;
+        }
+    }
+
+    return nullptr;
+}
+
+using TrayUI_Unhide_t =
+    void(WINAPI*)(void* trayComponentHost,
+                  int trayUnhideFlags,
+                  int unhideRequest);
+
+TrayUI_Unhide_t TrayUI_Unhide_Original;
+
+using CSecondaryTray_Unhide_t =
+    void(WINAPI*)(void* secondaryTray,
+                  int trayUnhideFlags,
+                  int unhideRequest);
+
+CSecondaryTray_Unhide_t CSecondaryTray_Unhide_Original;
+
+using TrayUI_WndProc_t =
+    LRESULT(WINAPI*)(void* trayUi,
+                     HWND window,
+                     UINT message,
+                     WPARAM wParam,
+                     LPARAM lParam,
+                     bool* handled);
+
+TrayUI_WndProc_t TrayUI_WndProc_Original;
+
+LRESULT WINAPI TrayUI_WndProc_Hook(
+    void* trayUi,
+    HWND window,
+    UINT message,
+    WPARAM wParam,
+    LPARAM lParam,
+    bool* handled) {
+    if (message == WM_NCCREATE ||
+        message == g_captureTaskbarObjectMessage) {
+        g_trayUiWndProcObjects[window] = trayUi;
+
+        if (g_settings.diagnosticLogging.load(
+                std::memory_order_relaxed)) {
+            Wh_Log(L"Captured TrayUI object for taskbar %p", window);
+        }
+    } else if (message == WM_NCDESTROY) {
+        g_trayUiWndProcObjects.erase(window);
+    }
+
+    return TrayUI_WndProc_Original(
+        trayUi,
+        window,
+        message,
+        wParam,
+        lParam,
+        handled);
+}
+
+using CSecondaryTray_WndProc_t =
+    LRESULT(WINAPI*)(void* secondaryTray,
+                     HWND window,
+                     UINT message,
+                     WPARAM wParam,
+                     LPARAM lParam);
+
+CSecondaryTray_WndProc_t CSecondaryTray_WndProc_Original;
+
+LRESULT WINAPI CSecondaryTray_WndProc_Hook(
+    void* secondaryTray,
+    HWND window,
+    UINT message,
+    WPARAM wParam,
+    LPARAM lParam) {
+    if (message == WM_NCCREATE ||
+        message == g_captureTaskbarObjectMessage) {
+        g_secondaryTrayObjects[window] = secondaryTray;
+
+        if (g_settings.diagnosticLogging.load(
+                std::memory_order_relaxed)) {
+            Wh_Log(L"Captured CSecondaryTray object for taskbar %p",
+                   window);
+        }
+    } else if (message == WM_NCDESTROY) {
+        g_secondaryTrayObjects.erase(window);
+    }
+
+    return CSecondaryTray_WndProc_Original(
+        secondaryTray,
+        window,
+        message,
+        wParam,
+        lParam);
+}
+
+bool InvokeNativeShellUnhideOnUiThread(HWND taskbarWindow) {
+    if (!taskbarWindow || !IsWindow(taskbarWindow)) {
+        return false;
+    }
+
+    wchar_t className[64];
+    if (!GetClassNameW(taskbarWindow,
+                       className,
+                       ARRAYSIZE(className))) {
+        return false;
+    }
+
+    if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
+        auto it = g_trayUiWndProcObjects.find(taskbarWindow);
+
+        if (it == g_trayUiWndProcObjects.end() ||
+            !TrayUI_Unhide_Original) {
+            if (g_settings.diagnosticLogging.load(
+                    std::memory_order_relaxed)) {
+                Wh_Log(L"Native main-taskbar unhide unavailable: "
+                       L"object=%d function=%d",
+                       it != g_trayUiWndProcObjects.end(),
+                       TrayUI_Unhide_Original != nullptr);
+            }
+
+            return false;
+        }
+
+        void* trayComponentHost =
+            QueryViaVtable(it->second,
+                           g_trayUiVtableITrayComponentHost);
+
+        if (!trayComponentHost) {
+            Wh_Log(L"Couldn't locate ITrayComponentHost for taskbar %p",
+                   taskbarWindow);
+            return false;
+        }
+
+        TrayUI_Unhide_Original(trayComponentHost, 0, 0);
+
+        if (g_settings.diagnosticLogging.load(
+                std::memory_order_relaxed)) {
+            Wh_Log(L"Called TrayUI::Unhide for taskbar %p",
+                   taskbarWindow);
+        }
+
+        return true;
+    }
+
+    if (_wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0) {
+        auto it = g_secondaryTrayObjects.find(taskbarWindow);
+
+        if (it == g_secondaryTrayObjects.end() ||
+            !CSecondaryTray_Unhide_Original) {
+            if (g_settings.diagnosticLogging.load(
+                    std::memory_order_relaxed)) {
+                Wh_Log(L"Native secondary-taskbar unhide unavailable: "
+                       L"object=%d function=%d",
+                       it != g_secondaryTrayObjects.end(),
+                       CSecondaryTray_Unhide_Original != nullptr);
+            }
+
+            return false;
+        }
+
+        CSecondaryTray_Unhide_Original(it->second, 0, 0);
+
+        if (g_settings.diagnosticLogging.load(
+                std::memory_order_relaxed)) {
+            Wh_Log(L"Called CSecondaryTray::_Unhide for taskbar %p",
+                   taskbarWindow);
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+void RememberViewCoordinator(HWND taskbarWindow, void* viewCoordinator) {
+    if (!taskbarWindow || !viewCoordinator) {
+        return;
+    }
+
+    AcquireSRWLockExclusive(&g_viewCoordinatorLock);
+    g_viewCoordinators[taskbarWindow] = viewCoordinator;
+    ReleaseSRWLockExclusive(&g_viewCoordinatorLock);
+}
+
+void ForgetInvalidViewCoordinator(HWND taskbarWindow) {
+    AcquireSRWLockExclusive(&g_viewCoordinatorLock);
+    g_viewCoordinators.erase(taskbarWindow);
+    ReleaseSRWLockExclusive(&g_viewCoordinatorLock);
+}
+
+void* GetViewCoordinator(HWND taskbarWindow) {
+    void* viewCoordinator = nullptr;
+
+    AcquireSRWLockShared(&g_viewCoordinatorLock);
+
+    auto it = g_viewCoordinators.find(taskbarWindow);
+    if (it != g_viewCoordinators.end()) {
+        viewCoordinator = it->second;
+    }
+
+    ReleaseSRWLockShared(&g_viewCoordinatorLock);
+    return viewCoordinator;
+}
+
+// Undocumented Windows 11 taskbar methods.
+//
+// inputDeviceKind 0 corresponds to the mouse path used by Windows' taskbar
+// implementation. Reason 7 is the coordinator's
+// IsPointerOverTaskbarFrameChanged update reason.
+constexpr int kReasonIsPointerOverTaskbarFrameChanged = 7;
+
+using ViewCoordinator_IsExpanded_t =
+    bool(WINAPI*)(void* viewCoordinator,
+                  HWND taskbarWindow);
+
+ViewCoordinator_IsExpanded_t
+    ViewCoordinator_IsExpanded_Original;
+
+using ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_t =
+    void(WINAPI*)(void* viewCoordinator,
+                  HWND taskbarWindow,
+                  bool isPointerOver,
+                  int inputDeviceKind);
+
+ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_t
+    ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original;
+
+void WINAPI
+ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook(
+    void* viewCoordinator,
+    HWND taskbarWindow,
+    bool isPointerOver,
+    int inputDeviceKind) {
+    RememberViewCoordinator(taskbarWindow, viewCoordinator);
+
+    ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
+        viewCoordinator,
+        taskbarWindow,
+        isPointerOver,
+        inputDeviceKind);
+}
+
+using ViewCoordinator_ShouldTaskbarBeExpanded_t =
+    bool(WINAPI*)(void* viewCoordinator,
+                  HWND taskbarWindow,
+                  bool expanded);
+
+ViewCoordinator_ShouldTaskbarBeExpanded_t
+    ViewCoordinator_ShouldTaskbarBeExpanded_Original;
+
+bool WINAPI ViewCoordinator_ShouldTaskbarBeExpanded_Hook(
+    void* viewCoordinator,
+    HWND taskbarWindow,
+    bool expanded) {
+    RememberViewCoordinator(taskbarWindow, viewCoordinator);
+
+    // HandleIsPointerOverTaskbarFrameChanged isn't sufficient on every Windows
+    // 11 build when the physical pointer remains above the real one-pixel
+    // taskbar frame. While this mod owns the synthetic pointer-over state,
+    // explicitly authorize expansion in the coordinator's decision function.
+    if (g_syntheticPointerOverTaskbars.contains(taskbarWindow)) {
+        if (g_settings.diagnosticLogging.load(
+                std::memory_order_relaxed)) {
+            Wh_Log(L"ShouldTaskbarBeExpanded: forcing true for taskbar %p "
+                   L"(requested=%d)",
+                   taskbarWindow,
+                   expanded);
+        }
+
+        return true;
+    }
+
+    bool result =
+        ViewCoordinator_ShouldTaskbarBeExpanded_Original(
+            viewCoordinator,
+            taskbarWindow,
+            expanded);
+
+    if (g_settings.diagnosticLogging.load(
+            std::memory_order_relaxed)) {
+        Wh_Log(L"ShouldTaskbarBeExpanded: native result=%d for taskbar %p "
+               L"(requested=%d)",
+               result,
+               taskbarWindow,
+               expanded);
+    }
+
+    return result;
+}
+
+using ViewCoordinator_UpdateIsExpanded_t =
+    void(WINAPI*)(void* viewCoordinator,
+                  HWND taskbarWindow,
+                  int reason);
+
+ViewCoordinator_UpdateIsExpanded_t
+    ViewCoordinator_UpdateIsExpanded_Original;
+
+void WINAPI ViewCoordinator_UpdateIsExpanded_Hook(
+    void* viewCoordinator,
+    HWND taskbarWindow,
+    int reason) {
+    RememberViewCoordinator(taskbarWindow, viewCoordinator);
+
+    if (g_settings.diagnosticLogging.load(
+            std::memory_order_relaxed)) {
+        Wh_Log(L"UpdateIsExpanded: taskbar=%p reason=%d synthetic=%d",
+               taskbarWindow,
+               reason,
+               g_syntheticPointerOverTaskbars.contains(taskbarWindow));
+    }
+
+    ViewCoordinator_UpdateIsExpanded_Original(
+        viewCoordinator,
+        taskbarWindow,
+        reason);
+}
+
+bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
+                                      bool isPointerOver) {
+    if (!taskbarWindow || !IsWindow(taskbarWindow) ||
+        !ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original ||
+        !ViewCoordinator_UpdateIsExpanded_Original) {
+        if (taskbarWindow && !IsWindow(taskbarWindow)) {
+            ForgetInvalidViewCoordinator(taskbarWindow);
+            g_syntheticPointerOverTaskbars.erase(taskbarWindow);
+        }
+
+        return false;
+    }
+
+    void* viewCoordinator = GetViewCoordinator(taskbarWindow);
+    if (!viewCoordinator) {
+        Wh_Log(L"No ViewCoordinator captured yet for taskbar %p",
+               taskbarWindow);
+        return false;
+    }
+
+    if (isPointerOver) {
+        const auto [_, inserted] =
+            g_syntheticPointerOverTaskbars.insert(taskbarWindow);
+
+        if (!inserted) {
+            return true;
+        }
+
+        Wh_Log(L"Setting synthetic pointer-over for taskbar %p",
+               taskbarWindow);
+
+        // First update the coordinator's pointer-over state.
+        ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
+            viewCoordinator,
+            taskbarWindow,
+            true,
+            0);
+
+        // Some Windows 11 builds don't immediately reevaluate expansion when
+        // HandleIsPointerOverTaskbarFrameChanged is invoked programmatically.
+        // Force the same reason-7 state recomputation used by the taskbar.
+        ViewCoordinator_UpdateIsExpanded_Original(
+            viewCoordinator,
+            taskbarWindow,
+            kReasonIsPointerOverTaskbarFrameChanged);
+
+        bool expanded = false;
+        if (ViewCoordinator_IsExpanded_Original) {
+            expanded = ViewCoordinator_IsExpanded_Original(
+                viewCoordinator,
+                taskbarWindow);
+        }
+
+        if (g_settings.diagnosticLogging.load(
+                std::memory_order_relaxed)) {
+            Wh_Log(L"Coordinator expansion result after synthetic enter: %d",
+                   expanded);
+        }
+
+        // Return false when verification is available and the coordinator is
+        // still collapsed. The caller can then try the native timer fallback.
+        if (ViewCoordinator_IsExpanded_Original && !expanded) {
+            g_syntheticPointerOverTaskbars.erase(taskbarWindow);
+            return false;
+        }
+    } else {
+        if (g_syntheticPointerOverTaskbars.erase(taskbarWindow) == 0) {
+            return true;
+        }
+
+        Wh_Log(L"Clearing synthetic pointer-over for taskbar %p",
+               taskbarWindow);
+
+        ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
+            viewCoordinator,
+            taskbarWindow,
+            false,
+            0);
+
+        ViewCoordinator_UpdateIsExpanded_Original(
+            viewCoordinator,
+            taskbarWindow,
+            kReasonIsPointerOverTaskbarFrameChanged);
+
+        if (g_settings.diagnosticLogging.load(
+                std::memory_order_relaxed) &&
+            ViewCoordinator_IsExpanded_Original) {
+            bool expanded = ViewCoordinator_IsExpanded_Original(
+                viewCoordinator,
+                taskbarWindow);
+
+            Wh_Log(L"Coordinator expansion result after synthetic leave: %d",
+                   expanded);
+        }
+    }
+
+    return true;
+}
+
+
+bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
+    // The maintained Windhawk taskbar implementation invokes both paths:
+    // TrayUI::Unhide physically slides Shell_TrayWnd onscreen, while the
+    // Windows 11 ViewCoordinator establishes the logical expanded state.
+    const bool shellWindowRevealed =
+        InvokeNativeShellUnhideOnUiThread(taskbarWindow);
+
+    const bool coordinatorExpanded =
+        SetSyntheticPointerOverOnUiThread(
+            taskbarWindow,
+            true);
+
+    if (g_settings.diagnosticLogging.load(
+            std::memory_order_relaxed)) {
+        Wh_Log(L"Reveal result for taskbar %p: shell=%d coordinator=%d",
+               taskbarWindow,
+               shellWindowRevealed,
+               coordinatorExpanded);
+    }
+
+    return shellWindowRevealed || coordinatorExpanded;
+}
+
+void ClearAllSyntheticPointerOverOnUiThread() {
+    std::vector<HWND> taskbars(
+        g_syntheticPointerOverTaskbars.begin(),
+        g_syntheticPointerOverTaskbars.end());
+
+    for (HWND taskbarWindow : taskbars) {
+        SetSyntheticPointerOverOnUiThread(taskbarWindow, false);
+    }
+
+    g_syntheticPointerOverTaskbars.clear();
+}
+
+// This window belongs to Explorer's taskbar UI thread, so custom operations
+// sent here can safely invoke ViewCoordinator.
+using CTaskBand_v_WndProc_t =
+    LRESULT(WINAPI*)(void* taskBand,
+                     HWND window,
+                     UINT message,
+                     WPARAM wParam,
+                     LPARAM lParam);
+
+CTaskBand_v_WndProc_t CTaskBand_v_WndProc_Original;
+
+LRESULT WINAPI CTaskBand_v_WndProc_Hook(
+    void* taskBand,
+    HWND window,
+    UINT message,
+    WPARAM wParam,
+    LPARAM lParam) {
+    if (message == g_uiThreadMessage) {
+        const UiOperation operation =
+            static_cast<UiOperation>(wParam);
+        HWND targetTaskbar =
+            reinterpret_cast<HWND>(lParam);
+
+        switch (operation) {
+            case kUiRevealTaskbar:
+                return RevealTaskbarOnUiThread(targetTaskbar)
+                           ? 1
+                           : 0;
+
+            case kUiClearSyntheticPointerOver:
+                return SetSyntheticPointerOverOnUiThread(
+                           targetTaskbar,
+                           false)
+                           ? 1
+                           : 0;
+
+            case kUiClearAllSyntheticPointerOver:
+                ClearAllSyntheticPointerOverOnUiThread();
+                return 1;
+        }
+
+        return 0;
+    }
+
+    return CTaskBand_v_WndProc_Original(
+        taskBand,
+        window,
+        message,
+        wParam,
+        lParam);
+}
+
+bool SendUiOperation(UiOperation operation, HWND taskbarWindow) {
+    HWND taskBandWindow = GetTaskBandWindow();
+    if (!taskBandWindow) {
+        return false;
+    }
+
+    DWORD_PTR result = 0;
+
+    if (!SendMessageTimeoutW(
+            taskBandWindow,
+            g_uiThreadMessage,
+            operation,
+            reinterpret_cast<LPARAM>(taskbarWindow),
+            SMTO_ABORTIFHUNG | SMTO_BLOCK,
+            250,
+            &result)) {
+        Wh_Log(L"UI-thread operation timed out or failed: %u",
+               GetLastError());
+        return false;
+    }
+
+    return result != 0;
+}
+
+
+constexpr UINT_PTR kTrayUITimerHide = 2;
+constexpr UINT_PTR kTrayUITimerUnhide = 3;
+
+bool TriggerNativeUnhideTimer(HWND taskbarWindow) {
+    if (!taskbarWindow || !IsWindow(taskbarWindow)) {
+        return false;
+    }
+
+    // Explorer's native taskbar hover path uses timer ID 3 for unhide. SetTimer
+    // associates the timer with the taskbar window, so WM_TIMER is handled on
+    // Explorer's taskbar thread. This does not move, spoof, or inject the mouse.
+    UINT_PTR timerResult =
+        SetTimer(taskbarWindow, kTrayUITimerUnhide, 1, nullptr);
+
+    if (!timerResult) {
+        Wh_Log(L"Native unhide timer failed for taskbar %p: %u",
+               taskbarWindow,
+               GetLastError());
+        return false;
+    }
+
+    if (g_settings.diagnosticLogging.load(std::memory_order_relaxed)) {
+        Wh_Log(L"Requested native unhide timer for taskbar %p",
+               taskbarWindow);
+    }
+
+    return true;
+}
+
+DWORD WINAPI ActivationWorkerThread(LPVOID) {
+    HWND activeTaskbar = nullptr;
+    bool armed = true;
+    ULONGLONG lastActivationAttempt = 0;
+    ULONGLONG outsideSince = 0;
+
+    while (true) {
+        const int pollInterval =
+            g_settings.pollIntervalMs.load(std::memory_order_relaxed);
+
+        if (WaitForSingleObject(g_stopEvent, pollInterval) ==
+            WAIT_OBJECT_0) {
+            break;
+        }
+
+        if (g_settingsChanged.exchange(false,
+                                       std::memory_order_relaxed)) {
+            if (activeTaskbar) {
+                SendUiOperation(kUiClearSyntheticPointerOver,
+                                activeTaskbar);
+            }
+
+            activeTaskbar = nullptr;
+            armed = true;
+            outsideSince = 0;
+        }
+
+        POINT pointer{};
+        if (!GetCursorPos(&pointer)) {
+            continue;
+        }
+
+        HMONITOR pointerMonitor =
+            MonitorFromPoint(pointer, MONITOR_DEFAULTTONULL);
+
+        if (!pointerMonitor) {
+            if (activeTaskbar) {
+                SendUiOperation(kUiClearSyntheticPointerOver,
+                                activeTaskbar);
+                activeTaskbar = nullptr;
+            }
+
+            armed = true;
+            outsideSince = 0;
+            continue;
+        }
+
+        MONITORINFO monitorInfo{};
+        monitorInfo.cbSize = sizeof(monitorInfo);
+
+        if (!GetMonitorInfoW(pointerMonitor, &monitorInfo)) {
+            continue;
+        }
+
+        const bool insideActivationBand =
+            IsPointInsideActivationBand(pointer, monitorInfo);
+
+        if (activeTaskbar) {
+            if (!IsWindow(activeTaskbar)) {
+                activeTaskbar = nullptr;
+                armed = true;
+                outsideSince = 0;
+                continue;
+            }
+
+            const bool overVisibleTaskbar =
+                IsPointOverTaskbar(activeTaskbar, pointer);
+
+            if (insideActivationBand || overVisibleTaskbar) {
+                outsideSince = 0;
+                continue;
+            }
+
+            const ULONGLONG now = GetTickCount64();
+
+            if (!outsideSince) {
+                outsideSince = now;
+                continue;
+            }
+
+            const int releaseDelay =
+                g_settings.releaseDelayMs.load(
+                    std::memory_order_relaxed);
+
+            if (now - outsideSince <
+                static_cast<ULONGLONG>(releaseDelay)) {
+                continue;
+            }
+
+            SendUiOperation(kUiClearSyntheticPointerOver,
+                            activeTaskbar);
+
+            activeTaskbar = nullptr;
+            armed = true;
+            outsideSince = 0;
+            continue;
+        }
+
+        if (!insideActivationBand) {
+            armed = true;
+            continue;
+        }
+
+        if (g_settings.diagnosticLogging.load(
+                std::memory_order_relaxed) &&
+            armed) {
+            Wh_Log(L"Pointer entered activation band: x=%d y=%d bottom=%d",
+                   pointer.x,
+                   pointer.y,
+                   monitorInfo.rcMonitor.bottom);
+        }
+
+        if (!armed) {
+            continue;
+        }
+
+        if (g_settings.primaryMonitorOnly.load(
+                std::memory_order_relaxed) &&
+            (monitorInfo.dwFlags & MONITORINFOF_PRIMARY) == 0) {
+            continue;
+        }
+
+        if (g_settings.requireWindowsAutoHide.load(
+                std::memory_order_relaxed) &&
+            !IsWindowsAutoHideEnabled()) {
+            continue;
+        }
+
+        if (g_settings.ignoreWhileMouseButtonDown.load(
+                std::memory_order_relaxed) &&
+            IsAnyMouseButtonDown()) {
+            continue;
+        }
+
+        if (g_settings.ignoreFullscreenApps.load(
+                std::memory_order_relaxed) &&
+            IsFullscreenWindowOnMonitor(pointerMonitor)) {
+            if (g_settings.diagnosticLogging.load(
+                    std::memory_order_relaxed)) {
+                Wh_Log(L"Activation suppressed: fullscreen app detected");
+            }
+            continue;
+        }
+
+        const ULONGLONG now = GetTickCount64();
+        const int cooldown =
+            g_settings.activationCooldownMs.load(
+                std::memory_order_relaxed);
+
+        if (now - lastActivationAttempt <
+            static_cast<ULONGLONG>(cooldown)) {
+            continue;
+        }
+
+        lastActivationAttempt = now;
+
+        HWND taskbarWindow =
+            FindTaskbarForMonitor(pointerMonitor);
+
+        if (!taskbarWindow) {
+            if (g_settings.diagnosticLogging.load(
+                    std::memory_order_relaxed)) {
+                Wh_Log(L"Activation suppressed: no bottom taskbar found");
+            }
+            continue;
+        }
+
+        bool activated =
+            SendUiOperation(kUiRevealTaskbar,
+                            taskbarWindow);
+
+        if (activated) {
+            Wh_Log(L"Activated taskbar %p through native shell/coordinator "
+                   L"path",
+                   taskbarWindow);
+
+            activeTaskbar = taskbarWindow;
+            armed = false;
+            outsideSince = 0;
+            continue;
+        }
+
+        if (g_settings.nativeTimerFallback.load(
+                std::memory_order_relaxed) &&
+            TriggerNativeUnhideTimer(taskbarWindow)) {
+            Wh_Log(L"Activated taskbar %p through native timer fallback",
+                   taskbarWindow);
+
+            // No synthetic pointer-over state was created, so Windows owns the
+            // normal hide behavior. Rearm only after the pointer leaves the
+            // configured activation band.
+            armed = false;
+            outsideSince = 0;
+            continue;
+        }
+
+        if (g_settings.diagnosticLogging.load(
+                std::memory_order_relaxed)) {
+            Wh_Log(L"Threshold entered, but no reveal backend succeeded");
+        }
+    }
+
+    if (activeTaskbar) {
+        SendUiOperation(kUiClearSyntheticPointerOver,
+                        activeTaskbar);
+    }
+
+    return 0;
+}
+
+bool HookTaskbarViewSymbols(HMODULE module) {
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {
+                LR"(public: bool __cdecl winrt::Taskbar::implementation::ViewCoordinator::IsExpanded(unsigned __int64))",
+            },
+            &ViewCoordinator_IsExpanded_Original,
+            nullptr,
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::Taskbar::implementation::ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged(unsigned __int64,bool,enum winrt::WindowsUdk::UI::Shell::InputDeviceKind))",
+            },
+            &ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original,
+            ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook,
+        },
+        {
+            {
+                LR"(public: bool __cdecl winrt::Taskbar::implementation::ViewCoordinator::ShouldTaskbarBeExpanded(unsigned __int64,bool))",
+            },
+            &ViewCoordinator_ShouldTaskbarBeExpanded_Original,
+            ViewCoordinator_ShouldTaskbarBeExpanded_Hook,
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::Taskbar::implementation::ViewCoordinator::UpdateIsExpanded(unsigned __int64,enum TaskbarTipTest::TaskbarExpandCollapseReason))",
+            },
+            &ViewCoordinator_UpdateIsExpanded_Original,
+            ViewCoordinator_UpdateIsExpanded_Hook,
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(
+            module,
+            symbolHooks,
+            ARRAYSIZE(symbolHooks))) {
+        Wh_Log(L"Failed to hook Windows 11 ViewCoordinator symbols");
+        return false;
+    }
+
+    return true;
+}
+
+bool HookTaskbarUiThreadSymbol() {
+    HMODULE taskbarModule = LoadLibraryExW(
+        L"taskbar.dll",
+        nullptr,
+        LOAD_LIBRARY_SEARCH_SYSTEM32);
+
+    if (!taskbarModule) {
+        Wh_Log(L"Couldn't load taskbar.dll: %u", GetLastError());
+        return false;
+    }
+
+    WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
+        {
+            {
+                LR"(const TrayUI::`vftable'{for `ITrayComponentHost'})",
+            },
+            &g_trayUiVtableITrayComponentHost,
+            nullptr,
+        },
+        {
+            {
+                LR"(const CSecondaryTray::`vftable'{for `ISecondaryTray'})",
+            },
+            &g_secondaryTrayVtableISecondaryTray,
+            nullptr,
+        },
+        {
+            {
+                LR"(public: virtual void __cdecl TrayUI::Unhide(enum TrayCommon::TrayUnhideFlags,enum TrayCommon::UnhideRequest))",
+            },
+            &TrayUI_Unhide_Original,
+            nullptr,
+        },
+        {
+            {
+                LR"(private: void __cdecl CSecondaryTray::_Unhide(enum TrayCommon::TrayUnhideFlags,enum TrayCommon::UnhideRequest))",
+            },
+            &CSecondaryTray_Unhide_Original,
+            nullptr,
+        },
+        {
+            {
+                LR"(public: virtual __int64 __cdecl TrayUI::WndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64,bool *))",
+            },
+            &TrayUI_WndProc_Original,
+            TrayUI_WndProc_Hook,
+        },
+        {
+            {
+                LR"(private: virtual __int64 __cdecl CSecondaryTray::v_WndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64))",
+            },
+            &CSecondaryTray_WndProc_Original,
+            CSecondaryTray_WndProc_Hook,
+        },
+        {
+            {
+                LR"(protected: virtual __int64 __cdecl CTaskBand::v_WndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64))",
+            },
+            &CTaskBand_v_WndProc_Original,
+            CTaskBand_v_WndProc_Hook,
+        },
+    };
+
+    if (!WindhawkUtils::HookSymbols(
+            taskbarModule,
+            symbolHooks,
+            ARRAYSIZE(symbolHooks))) {
+        Wh_Log(L"Failed to hook native taskbar symbols");
+        return false;
+    }
+
+    return true;
+}
+
+
+void CaptureExistingTaskbarObjects() {
+    EnumWindows(
+        [](HWND window, LPARAM) -> BOOL {
+            if (!IsTaskbarClass(window)) {
+                return TRUE;
+            }
+
+            DWORD processId = 0;
+            GetWindowThreadProcessId(window, &processId);
+
+            if (processId == GetCurrentProcessId()) {
+                SendMessageW(window,
+                             g_captureTaskbarObjectMessage,
+                             0,
+                             0);
+            }
+
+            return TRUE;
+        },
+        0);
+}
+
+HMODULE GetTaskbarViewModuleHandle() {
+    HMODULE module = GetModuleHandleW(L"Taskbar.View.dll");
+
+    if (!module) {
+        module = GetModuleHandleW(L"ExplorerExtensions.dll");
+    }
+
+    return module;
+}
+
+void HandleLoadedTaskbarViewModule(HMODULE module,
+                                   LPCWSTR libraryFileName) {
+    if (!module || g_taskbarViewDllLoaded.load(
+                       std::memory_order_relaxed)) {
+        return;
+    }
+
+    if (GetTaskbarViewModuleHandle() != module) {
+        return;
+    }
+
+    if (g_taskbarViewDllLoaded.exchange(
+            true,
+            std::memory_order_relaxed)) {
+        return;
+    }
+
+    Wh_Log(L"Loaded taskbar view module: %s",
+           libraryFileName ? libraryFileName : L"(unknown)");
+
+    if (HookTaskbarViewSymbols(module)) {
+        Wh_ApplyHookOperations();
+    } else {
+        g_taskbarViewDllLoaded.store(false, std::memory_order_relaxed);
+    }
+}
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t LoadLibraryExW_Original;
+
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR libraryFileName,
+                                   HANDLE file,
+                                   DWORD flags) {
+    HMODULE module =
+        LoadLibraryExW_Original(libraryFileName, file, flags);
+
+    if (module) {
+        HandleLoadedTaskbarViewModule(module, libraryFileName);
+    }
+
+    return module;
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"Initializing version 0.2.4");
+
+    LoadSettings();
+
+    if (!HookTaskbarUiThreadSymbol()) {
+        return FALSE;
+    }
+
+    if (HMODULE taskbarViewModule =
+            GetTaskbarViewModuleHandle()) {
+        if (!HookTaskbarViewSymbols(taskbarViewModule)) {
+            return FALSE;
+        }
+
+        g_taskbarViewDllLoaded.store(
+            true,
+            std::memory_order_relaxed);
+    } else {
+        Wh_Log(L"Taskbar.View.dll/ExplorerExtensions.dll isn't loaded yet");
+    }
+
+    HMODULE kernelBaseModule =
+        GetModuleHandleW(L"kernelbase.dll");
+
+    auto loadLibraryExW = reinterpret_cast<decltype(&LoadLibraryExW)>(
+        GetProcAddress(kernelBaseModule, "LoadLibraryExW"));
+
+    if (!loadLibraryExW) {
+        Wh_Log(L"Couldn't find KernelBase!LoadLibraryExW");
+        return FALSE;
+    }
+
+    WindhawkUtils::SetFunctionHook(
+        loadLibraryExW,
+        LoadLibraryExW_Hook,
+        &LoadLibraryExW_Original);
+
+    g_stopEvent =
+        CreateEventW(nullptr, TRUE, FALSE, nullptr);
+
+    if (!g_stopEvent) {
+        Wh_Log(L"CreateEvent failed: %u", GetLastError());
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    Wh_Log(L"Starting activation worker");
+
+    CaptureExistingTaskbarObjects();
+
+    // Retry in case the taskbar view module loaded between Wh_ModInit and hook
+    // application.
+    if (!g_taskbarViewDllLoaded.load(std::memory_order_relaxed)) {
+        if (HMODULE taskbarViewModule =
+                GetTaskbarViewModuleHandle()) {
+            if (!g_taskbarViewDllLoaded.exchange(
+                    true,
+                    std::memory_order_relaxed)) {
+                Wh_Log(L"Found taskbar view module after initialization");
+
+                if (HookTaskbarViewSymbols(taskbarViewModule)) {
+                    Wh_ApplyHookOperations();
+                } else {
+                    g_taskbarViewDllLoaded.store(
+                        false,
+                        std::memory_order_relaxed);
+                }
+            }
+        }
+    }
+
+    g_workerThread = CreateThread(
+        nullptr,
+        0,
+        ActivationWorkerThread,
+        nullptr,
+        0,
+        nullptr);
+
+    if (!g_workerThread) {
+        Wh_Log(L"CreateThread failed: %u", GetLastError());
+    }
+}
+
+void Wh_ModBeforeUninit() {
+    Wh_Log(L"Stopping activation worker");
+
+    if (g_stopEvent) {
+        SetEvent(g_stopEvent);
+    }
+
+    if (g_workerThread) {
+        WaitForSingleObject(g_workerThread, INFINITE);
+    }
+
+    SendUiOperation(kUiClearAllSyntheticPointerOver, nullptr);
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"Uninitializing");
+
+    if (g_workerThread) {
+        CloseHandle(g_workerThread);
+        g_workerThread = nullptr;
+    }
+
+    if (g_stopEvent) {
+        CloseHandle(g_stopEvent);
+        g_stopEvent = nullptr;
+    }
+
+    AcquireSRWLockExclusive(&g_viewCoordinatorLock);
+    g_viewCoordinators.clear();
+    ReleaseSRWLockExclusive(&g_viewCoordinatorLock);
+
+    g_trayUiWndProcObjects.clear();
+    g_secondaryTrayObjects.clear();
+    g_syntheticPointerOverTaskbars.clear();
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L"Settings changed");
+
+    LoadSettings();
+    g_settingsChanged.store(true, std::memory_order_relaxed);
+}

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -35,7 +35,7 @@ continuous polling, minimizing background activity while the pointer is idle.
 - Configurable activation-band height and hover delay
 - Per-monitor DPI scaling
 - Multi-monitor and secondary-taskbar support
-- Adjustable release delay and activation cooldown
+- Adjustable release delay
 - Optional suppression over fullscreen applications and presentation mode
 - Optional suppression while a mouse button is held
 - Optional restriction to the primary monitor
@@ -74,30 +74,40 @@ Windows 11 taskbar and don't replace its native reveal logic.
 - Mods that disable, replace, or override the taskbar's native expansion logic
   can conflict with this mod. Keyboard-only and never-show auto-hide modes are
   intentionally incompatible with mouse activation.
-- Reveal depends on the undocumented Windows 11
-  `ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged` method. If a
-  Windows update renames or changes it, the mod will log that the coordinator
-  reveal path is unavailable and will need a symbol update.
-- Shortly after Explorer starts, the internal taskbar coordinator may not yet
-  have been observed by the mod. Activation retries with bounded backoff while
-  the pointer remains in the band and begins working as soon as Explorer emits
-  a coordinator pointer-over transition.
+- Reveal depends on the undocumented Windows 11 `ViewCoordinator`
+  `HandleIsPointerOverTaskbarFrameChanged` and `UpdateIsExpanded` methods. The
+  latter is used only to capture Explorer's coordinator before the first
+  activation-band reveal. If a Windows update renames or changes either
+  method, the mod will log that the coordinator reveal path needs a symbol
+  update.
 - Fullscreen suppression ignores click-through, tool, non-activating, cloaked,
   desktop, and taskbar windows. It is intentionally conservative otherwise: a
   qualifying fullscreen window anywhere above the desktop on the target
   monitor can suppress activation even when another app has focus. A
   borderless custom-chrome window that covers the monitor can therefore be
   treated as fullscreen. Windows presentation mode is reported system-wide, so
-  it suppresses activation on every monitor while active.
+  it suppresses activation on every monitor while active. Suppression is
+  checked before a reveal; it doesn't forcibly hide a taskbar that was already
+  revealed if an app becomes fullscreen afterwards.
 - Cursor tracking uses a system-wide `EVENT_OBJECT_LOCATIONCHANGE` WinEvent
   hook because Windows can't filter that hook to `OBJID_CURSOR` at
   registration time. Non-cursor events are discarded immediately by the
   callback. If the WinEvent hook can't be installed, the mod falls back to a
   150 ms cursor check.
 
+## Tested configurations
+
+- Multi-monitor Windows 11 setup with taskbars shown on all displays
+- Secondary `Shell_SecondaryTrayWnd` taskbar activation and release
+- Moving the pointer between monitors with independent per-monitor activation
+  bands
+- Multi-monitor setup with **Show my taskbar on all displays** disabled; a
+  monitor with no taskbar is ignored instead of redirecting activation to
+  another monitor's taskbar
+
 ## Attribution and license
 
-The Windows 11 `ViewCoordinator` symbol and UI-thread invocation technique were
+The Windows 11 `ViewCoordinator` symbols and UI-thread invocation technique were
 informed by the GPL-3.0-licensed **Taskbar auto-hide fine tuning** Windhawk mod
 by m417z.
 
@@ -123,11 +133,6 @@ This mod is distributed under the GNU General Public License v3.0.
   $description: >-
     Delay before the taskbar is allowed to hide again after the pointer leaves
     both the activation band and the visible taskbar.
-- activationCooldownMs: 200
-  $name: Activation cooldown
-  $description: >-
-    Minimum time between reveal attempts while the pointer remains in the
-    activation band.
 - requireWindowsAutoHide: true
   $name: Require Windows auto-hide
   $description: >-
@@ -171,7 +176,6 @@ struct Settings {
     std::atomic<int> activationThresholdPx{24};
     std::atomic<int> activationDelayMs{75};
     std::atomic<int> releaseDelayMs{120};
-    std::atomic<int> activationCooldownMs{200};
     std::atomic<bool> requireWindowsAutoHide{true};
     std::atomic<bool> ignoreFullscreenApps{true};
     std::atomic<bool> ignoreWhileMouseButtonDown{true};
@@ -205,12 +209,9 @@ constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
 constexpr UINT kWorkerSettingsChangedMessage = WM_APP + 2;
 constexpr UINT kWorkerNativePointerLeaveMessage = WM_APP + 3;
 constexpr UINT kReleaseRetryMs = 250;
+constexpr UINT kActivationRetryIntervalMs = 200;
 constexpr UINT kSuppressionBackoffMaxMs = 5000;
-constexpr ULONGLONG kAutoHideCacheDurationMs = 5000;
-
-std::atomic<bool> g_autoHideCacheValid{false};
-std::atomic<bool> g_autoHideCacheValue{false};
-std::atomic<ULONGLONG> g_autoHideCacheTimestamp{0};
+constexpr ULONGLONG kRevealVisibilityGraceMs = 400;
 
 // These containers are used by taskbar implementation callbacks and by
 // operations marshalled to the taskbar UI thread. This matches the threading
@@ -233,10 +234,6 @@ bool HandleTaskbarUiOperation(HWND taskbarWindow,
                               WPARAM operationValue,
                               LRESULT* result);
 
-void InvalidateAutoHideCache() {
-    g_autoHideCacheValid.store(false, std::memory_order_release);
-}
-
 void LoadSettings() {
     g_settings.activationThresholdPx.store(
         std::clamp(Wh_GetIntSetting(L"activationThresholdPx"), 1, 500),
@@ -248,10 +245,6 @@ void LoadSettings() {
 
     g_settings.releaseDelayMs.store(
         std::clamp(Wh_GetIntSetting(L"releaseDelayMs"), 0, 5000),
-        std::memory_order_relaxed);
-
-    g_settings.activationCooldownMs.store(
-        std::clamp(Wh_GetIntSetting(L"activationCooldownMs"), 0, 10000),
         std::memory_order_relaxed);
 
     g_settings.requireWindowsAutoHide.store(
@@ -468,24 +461,9 @@ HWND FindTaskbarForMonitor(HMONITOR monitor) {
 }
 
 bool IsWindowsAutoHideEnabled() {
-    const ULONGLONG now = GetTickCount64();
-    if (g_autoHideCacheValid.load(std::memory_order_acquire)) {
-        const ULONGLONG cachedAt =
-            g_autoHideCacheTimestamp.load(std::memory_order_relaxed);
-        if (now - cachedAt < kAutoHideCacheDurationMs) {
-            return g_autoHideCacheValue.load(std::memory_order_relaxed);
-        }
-    }
-
     APPBARDATA appBarData{};
     appBarData.cbSize = sizeof(appBarData);
-    const bool enabled =
-        (SHAppBarMessage(ABM_GETSTATE, &appBarData) & ABS_AUTOHIDE) != 0;
-
-    g_autoHideCacheValue.store(enabled, std::memory_order_relaxed);
-    g_autoHideCacheTimestamp.store(now, std::memory_order_relaxed);
-    g_autoHideCacheValid.store(true, std::memory_order_release);
-    return enabled;
+    return (SHAppBarMessage(ABM_GETSTATE, &appBarData) & ABS_AUTOHIDE) != 0;
 }
 
 bool IsAnyMouseButtonDown() {
@@ -521,7 +499,8 @@ bool HasDesktopWindowClass(HWND window) {
 }
 
 bool IsShellDesktopWindow(HWND window) {
-    return HasDesktopWindowClass(window) && IsCurrentProcessWindow(window);
+    return window && IsWindowVisible(window) &&
+           (window == GetShellWindow() || GetPropW(window, L"DesktopWindow"));
 }
 
 bool IsWindowCloaked(HWND window) {
@@ -713,6 +692,28 @@ bool IsPointOverTaskbar(HWND taskbarWindow, const POINT& pointer) {
            PtInRect(&taskbarRect, pointer);
 }
 
+bool IsTaskbarVisiblyRevealed(HWND taskbarWindow, HMONITOR monitor) {
+    if (!taskbarWindow || !monitor) {
+        return false;
+    }
+
+    RECT taskbarRect{};
+    MONITORINFO monitorInfo{};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if (!GetWindowRect(taskbarWindow, &taskbarRect) ||
+        !GetMonitorInfoW(monitor, &monitorInfo)) {
+        return false;
+    }
+
+    RECT intersection{};
+    if (!IntersectRect(&intersection, &taskbarRect, &monitorInfo.rcMonitor)) {
+        return false;
+    }
+
+    // A hidden Windows 11 taskbar normally leaves only a one-pixel edge.
+    return intersection.bottom - intersection.top > 2;
+}
+
 void* QueryViaVtable(void* object, void* targetVtable) {
     if (!object || !targetVtable) {
         return nullptr;
@@ -788,8 +789,6 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
             *handled = true;
         }
         return 0;
-    } else if (message == WM_SETTINGCHANGE) {
-        InvalidateAutoHideCache();
     } else if (message == WM_NCDESTROY) {
         g_trayUiWndProcObjects.erase(window);
         ForgetTaskbarState(window);
@@ -838,8 +837,6 @@ LRESULT WINAPI CSecondaryTray_WndProc_Hook(
         Wh_Log(L"Captured CSecondaryTray object for taskbar %p", window);
         EnsureActivationWorker();
         return 0;
-    } else if (message == WM_SETTINGCHANGE) {
-        InvalidateAutoHideCache();
     } else if (message == WM_NCDESTROY) {
         g_secondaryTrayObjects.erase(window);
         ForgetTaskbarState(window);
@@ -920,7 +917,15 @@ void RememberViewCoordinator(HWND taskbarWindow, void* viewCoordinator) {
         return;
     }
 
+    auto it = g_viewCoordinators.find(taskbarWindow);
+    if (it != g_viewCoordinators.end() && it->second == viewCoordinator) {
+        return;
+    }
+
     g_viewCoordinators[taskbarWindow] = viewCoordinator;
+    Wh_Log(L"Captured ViewCoordinator %p for taskbar %p",
+           viewCoordinator,
+           taskbarWindow);
 }
 
 void* GetViewCoordinator(HWND taskbarWindow) {
@@ -938,6 +943,22 @@ using ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_t =
 
 ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_t
     ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original;
+
+using ViewCoordinator_UpdateIsExpanded_t =
+    void(WINAPI*)(void* viewCoordinator,
+                  HWND taskbarWindow,
+                  int reason);
+
+ViewCoordinator_UpdateIsExpanded_t ViewCoordinator_UpdateIsExpanded_Original;
+
+void WINAPI ViewCoordinator_UpdateIsExpanded_Hook(
+    void* viewCoordinator,
+    HWND taskbarWindow,
+    int reason) {
+    RememberViewCoordinator(taskbarWindow, viewCoordinator);
+    ViewCoordinator_UpdateIsExpanded_Original(
+        viewCoordinator, taskbarWindow, reason);
+}
 
 void WINAPI
 ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook(
@@ -1032,7 +1053,6 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
             taskbarWindow,
             false,
             0);
-
     }
 
     return true;
@@ -1171,11 +1191,13 @@ struct ActivationWorkerState {
     HMONITOR activeTaskbarMonitor = nullptr;
     HMONITOR activationCandidateMonitor = nullptr;
     HMONITOR bandEntryMonitor = nullptr;
+    HMONITOR activationDelayBypassMonitor = nullptr;
     bool armed = true;
     WorkerTimer releaseTimer;
     WorkerTimer retryTimer;
     bool releaseRetryPending = false;
     ULONGLONG activationCandidateSince = 0;
+    ULONGLONG activeSince = 0;
     ULONGLONG lastActivationCheck = 0;
     unsigned suppressionFailures = 0;
     unsigned appliedSettingsGeneration = 0;
@@ -1199,7 +1221,7 @@ void ScheduleWorkerTimer(UINT delayMs, WorkerTimer& timer) {
     if (timer.id) {
         // Keep an existing timer when it will fire no later than the new
         // request. If the new deadline is earlier, replace the timer so a
-        // long suppression backoff can't delay a short hover/cooldown retry.
+        // long suppression backoff can't delay a short hover/retry deadline.
         if (timer.dueAt && timer.dueAt <= requestedDueAt) {
             return;
         }
@@ -1252,6 +1274,7 @@ bool ClearActiveTaskbar(ActivationWorkerState& state,
     state.releaseRetryPending = false;
     state.activeTaskbar = nullptr;
     state.activeTaskbarMonitor = nullptr;
+    state.activeSince = 0;
     state.armed = true;
     return true;
 }
@@ -1260,18 +1283,16 @@ void ScheduleRetry(ActivationWorkerState& state, UINT delayMs) {
     ScheduleWorkerTimer(delayMs, state.retryTimer);
 }
 
-UINT AdvanceSuppressionBackoff(ActivationWorkerState& state,
-                                   int cooldownMs) {
+UINT AdvanceSuppressionBackoff(ActivationWorkerState& state) {
     state.suppressionFailures =
         std::min(state.suppressionFailures + 1, 8U);
-    const UINT base = static_cast<UINT>(std::max(cooldownMs, 200));
     const unsigned shift = std::min(state.suppressionFailures - 1, 4U);
-    return std::min(base << shift, kSuppressionBackoffMaxMs);
+    return std::min(kActivationRetryIntervalMs << shift,
+                    kSuppressionBackoffMaxMs);
 }
 
-void ScheduleSuppressedRetry(ActivationWorkerState& state,
-                             int cooldownMs) {
-    ScheduleRetry(state, AdvanceSuppressionBackoff(state, cooldownMs));
+void ScheduleSuppressedRetry(ActivationWorkerState& state) {
+    ScheduleRetry(state, AdvanceSuppressionBackoff(state));
 }
 
 void ResetActivationCandidate(ActivationWorkerState& state) {
@@ -1281,6 +1302,7 @@ void ResetActivationCandidate(ActivationWorkerState& state) {
 
 void ResetBandEntry(ActivationWorkerState& state) {
     state.bandEntryMonitor = nullptr;
+    state.activationDelayBypassMonitor = nullptr;
     ResetActivationCandidate(state);
 }
 
@@ -1338,29 +1360,51 @@ void ProcessPointerState(ActivationWorkerState& state) {
             state.releaseRetryPending = false;
             state.activeTaskbar = nullptr;
             state.activeTaskbarMonitor = nullptr;
+            state.activeSince = 0;
             state.armed = true;
         } else {
+            const bool sameMonitorBand =
+                insideActivationBand &&
+                pointerMonitor == state.activeTaskbarMonitor;
             const bool overVisibleTaskbar =
                 IsPointOverTaskbar(state.activeTaskbar, pointer);
 
-            if ((insideActivationBand &&
-                 pointerMonitor == state.activeTaskbarMonitor) ||
-                overVisibleTaskbar) {
-                CancelWorkerTimer(state.releaseTimer);
-                return;
-            }
-
-            const int releaseDelay =
-                g_settings.releaseDelayMs.load(std::memory_order_relaxed);
-            if (releaseDelay == 0) {
+            // Explorer or another taskbar component can hide the taskbar without
+            // sending the pointer-leave transition this mod normally observes.
+            // After the reveal animation has had time to finish, detect that
+            // state and re-arm instead of remaining stuck until the pointer
+            // leaves and re-enters the activation band.
+            const bool visibilityCheckReady =
+                state.activeSince != 0 &&
+                now - state.activeSince >= kRevealVisibilityGraceMs;
+            if (sameMonitorBand && !overVisibleTaskbar &&
+                visibilityCheckReady &&
+                !IsTaskbarVisiblyRevealed(state.activeTaskbar,
+                                           state.activeTaskbarMonitor)) {
+                HMONITOR hiddenMonitor = state.activeTaskbarMonitor;
+                Wh_Log(L"Active taskbar %p is no longer visibly revealed; "
+                       L"re-arming",
+                       state.activeTaskbar);
                 if (!ClearActiveTaskbar(state)) {
                     return;
                 }
-            } else {
-                state.releaseRetryPending = false;
-                ScheduleWorkerTimer(static_cast<UINT>(releaseDelay),
-                                    state.releaseTimer);
+                state.activationDelayBypassMonitor = hiddenMonitor;
+            } else if (sameMonitorBand || overVisibleTaskbar) {
+                CancelWorkerTimer(state.releaseTimer);
                 return;
+            } else {
+                const int releaseDelay =
+                    g_settings.releaseDelayMs.load(std::memory_order_relaxed);
+                if (releaseDelay == 0) {
+                    if (!ClearActiveTaskbar(state)) {
+                        return;
+                    }
+                } else {
+                    state.releaseRetryPending = false;
+                    ScheduleWorkerTimer(static_cast<UINT>(releaseDelay),
+                                        state.releaseTimer);
+                    return;
+                }
             }
         }
     }
@@ -1388,14 +1432,16 @@ void ProcessPointerState(ActivationWorkerState& state) {
 
     const int activationDelay =
         g_settings.activationDelayMs.load(std::memory_order_relaxed);
+    const bool bypassActivationDelay =
+        state.activationDelayBypassMonitor == pointerMonitor;
     if (state.activationCandidateMonitor != pointerMonitor) {
         state.activationCandidateMonitor = pointerMonitor;
         state.activationCandidateSince = now;
-        if (activationDelay > 0) {
+        if (activationDelay > 0 && !bypassActivationDelay) {
             ScheduleRetry(state, static_cast<UINT>(activationDelay));
             return;
         }
-    } else {
+    } else if (!bypassActivationDelay) {
         const ULONGLONG candidateElapsed =
             now - state.activationCandidateSince;
         if (candidateElapsed < static_cast<ULONGLONG>(activationDelay)) {
@@ -1408,17 +1454,15 @@ void ProcessPointerState(ActivationWorkerState& state) {
         }
     }
 
-    const int cooldown =
-        g_settings.activationCooldownMs.load(std::memory_order_relaxed);
     const ULONGLONG elapsed = now - state.lastActivationCheck;
-    if (elapsed < static_cast<ULONGLONG>(cooldown)) {
+    if (elapsed < kActivationRetryIntervalMs) {
         ScheduleRetry(
             state,
-            static_cast<UINT>(
-                static_cast<ULONGLONG>(cooldown) - elapsed));
+            static_cast<UINT>(kActivationRetryIntervalMs - elapsed));
         return;
     }
 
+    state.activationDelayBypassMonitor = nullptr;
     state.lastActivationCheck = now;
     CancelWorkerTimer(state.retryTimer);
 
@@ -1429,35 +1473,35 @@ void ProcessPointerState(ActivationWorkerState& state) {
 
     if (g_settings.primaryMonitorOnly.load(std::memory_order_relaxed) &&
         (monitorInfo.dwFlags & MONITORINFOF_PRIMARY) == 0) {
-        ScheduleSuppressedRetry(state, cooldown);
+        ScheduleSuppressedRetry(state);
         return;
     }
 
     if (g_settings.requireWindowsAutoHide.load(
             std::memory_order_relaxed) &&
         !IsWindowsAutoHideEnabled()) {
-        ScheduleSuppressedRetry(state, cooldown);
+        ScheduleSuppressedRetry(state);
         return;
     }
 
     if (g_settings.ignoreWhileMouseButtonDown.load(
             std::memory_order_relaxed) &&
         IsAnyMouseButtonDown()) {
-        ScheduleSuppressedRetry(state, cooldown);
+        ScheduleSuppressedRetry(state);
         return;
     }
 
     if (g_settings.ignoreFullscreenApps.load(std::memory_order_relaxed) &&
         IsFullscreenWindowOnMonitor(pointerMonitor)) {
         Wh_Log(L"Activation suppressed: fullscreen app detected");
-        ScheduleSuppressedRetry(state, cooldown);
+        ScheduleSuppressedRetry(state);
         return;
     }
 
     HWND taskbarWindow = FindTaskbarForMonitor(pointerMonitor);
     if (!taskbarWindow) {
         Wh_Log(L"Activation suppressed: no bottom taskbar found");
-        ScheduleSuppressedRetry(state, cooldown);
+        ScheduleSuppressedRetry(state);
         return;
     }
 
@@ -1478,12 +1522,13 @@ void ProcessPointerState(ActivationWorkerState& state) {
         ResetActivationCandidate(state);
         state.activeTaskbar = taskbarWindow;
         state.activeTaskbarMonitor = pointerMonitor;
+        state.activeSince = now;
         state.armed = false;
         return;
     }
 
     Wh_Log(L"Threshold entered, but coordinator reveal is not available yet");
-    ScheduleSuppressedRetry(state, cooldown);
+    ScheduleSuppressedRetry(state);
 }
 
 void HandleNativePointerLeave(ActivationWorkerState& state,
@@ -1492,14 +1537,17 @@ void HandleNativePointerLeave(ActivationWorkerState& state,
         return;
     }
 
+    const HMONITOR previousMonitor = state.activeTaskbarMonitor;
     CancelWorkerTimer(state.releaseTimer);
     CancelWorkerTimer(state.retryTimer);
     state.releaseRetryPending = false;
     state.activeTaskbar = nullptr;
     state.activeTaskbarMonitor = nullptr;
+    state.activeSince = 0;
     state.armed = true;
     state.suppressionFailures = 0;
     ResetActivationCandidate(state);
+    state.activationDelayBypassMonitor = previousMonitor;
 
     Wh_Log(L"Re-arming after Explorer pointer leave for taskbar %p",
            taskbarWindow);
@@ -1707,6 +1755,14 @@ bool HookTaskbarViewSymbols(HMODULE module) {
             ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook,
             true,
         },
+        {
+            {
+                LR"(public: void __cdecl winrt::Taskbar::implementation::ViewCoordinator::UpdateIsExpanded(unsigned __int64,enum TaskbarTipTest::TaskbarExpandCollapseReason))",
+            },
+            &ViewCoordinator_UpdateIsExpanded_Original,
+            ViewCoordinator_UpdateIsExpanded_Hook,
+            true,
+        },
     };
 
     if (!WindhawkUtils::HookSymbols(
@@ -1717,9 +1773,10 @@ bool HookTaskbarViewSymbols(HMODULE module) {
         return false;
     }
 
-    if (!ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original) {
+    if (!ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original ||
+        !ViewCoordinator_UpdateIsExpanded_Original) {
         Wh_Log(L"Taskbar reveal path unavailable: required ViewCoordinator "
-               L"symbol needs updating");
+               L"symbols need updating");
         return false;
     }
 
@@ -1867,7 +1924,7 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR libraryFileName,
     HMODULE module =
         LoadLibraryExW_Original(libraryFileName, file, flags);
 
-    if (module && !((ULONG_PTR)module & 3)) {
+    if (module) {
         HandleLoadedTaskbarViewModule(module, libraryFileName);
     }
 
@@ -1878,7 +1935,6 @@ BOOL Wh_ModInit() {
     Wh_Log(L"Initializing");
 
     g_unloading.store(false, std::memory_order_relaxed);
-    InvalidateAutoHideCache();
 
     g_uiThreadMessage =
         RegisterWindowMessageW(L"taskbar-activation-threshold.ui");
@@ -2015,12 +2071,6 @@ void Wh_ModUninit() {
         CloseHandle(g_stopEvent);
         g_stopEvent = nullptr;
     }
-
-    InvalidateAutoHideCache();
-    g_viewCoordinators.clear();
-    g_trayUiWndProcObjects.clear();
-    g_secondaryTrayObjects.clear();
-    g_syntheticPointerOverTaskbars.clear();
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -1309,6 +1309,7 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
 }
 
 bool HookTaskbarViewSymbols(HMODULE module) {
+    // user32.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {
@@ -1362,6 +1363,7 @@ bool HookTaskbarUiThreadSymbol() {
         return false;
     }
 
+    // user32.dll
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -39,7 +39,7 @@ continuous polling, minimizing background activity while the pointer is idle.
 - Optional suppression over fullscreen applications
 - Optional suppression while a mouse button is held
 - Optional restriction to the primary monitor
-- Native timer fallback while the Windows 11 taskbar coordinator is unavailable
+- Best-effort native timer fallback while the taskbar coordinator is unavailable
 - No cursor movement, pointer injection, or taskbar layout modification
 
 ## Compatibility
@@ -53,11 +53,11 @@ The mod does not modify:
 - Transparency
 - Windows' auto-hide setting
 
-When revealing the taskbar, the mod brings it to the front of its existing
+When needed, the mod brings a covered taskbar to the front of its existing
 Z-order band without activating it or changing whether Explorer currently
 treats it as topmost. This prevents ordinary windows in the same band from
-covering the taskbar while preserving fullscreen and third-party Z-order
-policies.
+covering the revealed taskbar while preserving fullscreen and third-party
+Z-order policies.
 
 The mod is designed to coexist with taskbar styling, sizing, transparency,
 animation, clock, label, and icon mods that retain the standard bottom-positioned
@@ -69,7 +69,7 @@ Windows 11 taskbar.
 - The standard Windows 11 taskbar
 - A bottom-positioned taskbar
 - **Automatically hide the taskbar** enabled in Windows, unless
-  `requireWindowsAutoHide` is disabled
+  **Require Windows auto-hide** is disabled in the mod settings
 
 ## Known limitations
 
@@ -82,9 +82,9 @@ Windows 11 taskbar.
 - Windows updates can rename undocumented taskbar symbols. If this occurs, one
   or more reveal paths may require a symbol update.
 - Shortly after Explorer starts, the internal Windows 11 taskbar coordinator
-  may not yet have been captured. During this period, the optional native timer
-  fallback is used. Coordinator-controlled activation begins automatically once
-  the coordinator becomes available.
+  may not yet have been captured. The optional native timer fallback is tried
+  once per activation-band entry, while coordinator activation continues to
+  retry with backoff until the coordinator becomes available.
 
 ## Suggested settings
 
@@ -152,9 +152,9 @@ This mod is distributed under the GNU General Public License v3.0.
 - nativeTimerFallback: true
   $name: Native timer fallback
   $description: >-
-    If the Windows 11 ViewCoordinator isn't available yet, ask Explorer's
-    native taskbar unhide timer to reveal the taskbar. This doesn't move or
-    inject the mouse cursor.
+    If the Windows 11 taskbar coordinator isn't available yet, make one
+    best-effort request to Explorer's native reveal timer for each entry into
+    the activation band. The mod never cancels Explorer's timer.
 */
 // ==/WindhawkModSettings==
 
@@ -167,6 +167,7 @@ This mod is distributed under the GNU General Public License v3.0.
 #include <algorithm>
 #include <atomic>
 #include <cstdlib>
+#include <mutex>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -192,7 +193,9 @@ std::atomic<bool> g_cursorUpdatePosted{false};
 std::atomic<HWND> g_mainTaskbarWindow{nullptr};
 
 HANDLE g_stopEvent = nullptr;
-HANDLE g_workerThread = nullptr;
+std::atomic<HANDLE> g_workerThread{nullptr};
+std::mutex g_workerThreadMutex;
+std::atomic<bool> g_unloading{false};
 
 // Registered in Wh_ModInit rather than during DLL initialization, avoiding
 // user32 calls while the loader lock is held.
@@ -219,17 +222,18 @@ enum UiOperation : WPARAM {
     kUiClearSyntheticPointerOver = 2,
     kUiClearAllSyntheticPointerOver = 3,
     kUiTriggerNativeUnhideTimer = 4,
-    kUiCancelNativeUnhideTimer = 5,
-    kUiBringTaskbarToFront = 6,
 };
 
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
 constexpr UINT kWorkerSettingsChangedMessage = WM_APP + 2;
 constexpr UINT kReleaseRetryMs = 250;
-constexpr UINT kFallbackStatusPollMs = 250;
-constexpr UINT kFallbackRearmBaseMs = 1000;
-constexpr UINT kNativeTimerCleanupMs = 250;
+constexpr UINT kFallbackProbeMs = 300;
 constexpr UINT kSuppressionBackoffMaxMs = 5000;
+constexpr ULONGLONG kAutoHideCacheDurationMs = 5000;
+
+std::atomic<bool> g_autoHideCacheValid{false};
+std::atomic<bool> g_autoHideCacheValue{false};
+std::atomic<ULONGLONG> g_autoHideCacheTimestamp{0};
 
 // These containers are used by taskbar implementation callbacks and by
 // operations marshalled to the taskbar UI thread. This matches the threading
@@ -248,6 +252,16 @@ void* g_trayUiVtableITrayComponentHost = nullptr;
 void ForgetTaskbarState(HWND taskbarWindow) {
     g_viewCoordinators.erase(taskbarWindow);
     g_syntheticPointerOverTaskbars.erase(taskbarWindow);
+}
+
+DWORD WINAPI ActivationWorkerThread(LPVOID);
+void EnsureActivationWorker();
+bool HandleTaskbarUiOperation(HWND taskbarWindow,
+                              WPARAM operationValue,
+                              LRESULT* result);
+
+void InvalidateAutoHideCache() {
+    g_autoHideCacheValid.store(false, std::memory_order_release);
 }
 
 void LoadSettings() {
@@ -286,6 +300,29 @@ void LoadSettings() {
     g_settings.nativeTimerFallback.store(
         Wh_GetIntSetting(L"nativeTimerFallback") != 0,
         std::memory_order_relaxed);
+}
+
+void EnsureActivationWorker() {
+    if (g_unloading.load(std::memory_order_acquire) || !g_stopEvent ||
+        g_workerThread.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> guard(g_workerThreadMutex);
+    if (g_unloading.load(std::memory_order_relaxed) ||
+        g_workerThread.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    HANDLE workerThread = CreateThread(
+        nullptr, 0, ActivationWorkerThread, nullptr, 0, nullptr);
+    if (!workerThread) {
+        Wh_Log(L"CreateThread failed: %u", GetLastError());
+        return;
+    }
+
+    g_workerThread.store(workerThread, std::memory_order_release);
+    Wh_Log(L"Started activation worker in the taskbar Explorer process");
 }
 
 bool IsTaskbarClass(HWND window) {
@@ -347,6 +384,24 @@ HWND FindMainTaskbarWindow() {
     return taskbarWindow;
 }
 
+HWND FindAnyTaskbarWindow() {
+    if (HWND mainTaskbar = FindMainTaskbarWindow()) {
+        return mainTaskbar;
+    }
+
+    HWND taskbarWindow = nullptr;
+    EnumWindows(
+        [](HWND window, LPARAM parameter) -> BOOL {
+            if (IsTaskbarClass(window) && IsCurrentProcessWindow(window)) {
+                *reinterpret_cast<HWND*>(parameter) = window;
+                return FALSE;
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&taskbarWindow));
+    return taskbarWindow;
+}
+
 bool GetTaskbarStuckRectForMonitor(HMONITOR monitor, RECT* rect) {
     if (!monitor || !rect || !g_queryTaskbarRectMessage ||
         g_stuckRectQuery.pending.load(std::memory_order_acquire)) {
@@ -393,16 +448,6 @@ bool GetTaskbarStuckRectForMonitor(HMONITOR monitor, RECT* rect) {
 
     *rect = g_stuckRectQuery.rect;
     return true;
-}
-
-HWND GetTaskBandWindow() {
-    HWND taskbarWindow = FindMainTaskbarWindow();
-    if (!taskbarWindow) {
-        return nullptr;
-    }
-
-    return reinterpret_cast<HWND>(
-        GetPropW(taskbarWindow, L"TaskbandHWND"));
 }
 
 HMONITOR GetTaskbarMonitor(HWND taskbarWindow) {
@@ -520,11 +565,24 @@ HWND FindTaskbarForMonitor(HMONITOR monitor) {
 }
 
 bool IsWindowsAutoHideEnabled() {
+    const ULONGLONG now = GetTickCount64();
+    if (g_autoHideCacheValid.load(std::memory_order_acquire)) {
+        const ULONGLONG cachedAt =
+            g_autoHideCacheTimestamp.load(std::memory_order_relaxed);
+        if (now - cachedAt < kAutoHideCacheDurationMs) {
+            return g_autoHideCacheValue.load(std::memory_order_relaxed);
+        }
+    }
+
     APPBARDATA appBarData{};
     appBarData.cbSize = sizeof(appBarData);
+    const bool enabled =
+        (SHAppBarMessage(ABM_GETSTATE, &appBarData) & ABS_AUTOHIDE) != 0;
 
-    return (SHAppBarMessage(ABM_GETSTATE, &appBarData) &
-            ABS_AUTOHIDE) != 0;
+    g_autoHideCacheValue.store(enabled, std::memory_order_relaxed);
+    g_autoHideCacheTimestamp.store(now, std::memory_order_relaxed);
+    g_autoHideCacheValid.store(true, std::memory_order_release);
+    return enabled;
 }
 
 bool IsAnyMouseButtonDown() {
@@ -570,6 +628,30 @@ bool IsWindowCloaked(HWND window) {
            cloaked;
 }
 
+bool DoesClientAreaCoverMonitor(HWND window,
+                                const MONITORINFO& monitorInfo) {
+    RECT clientRect{};
+    if (!GetClientRect(window, &clientRect)) {
+        return false;
+    }
+
+    POINT points[2] = {
+        {clientRect.left, clientRect.top},
+        {clientRect.right, clientRect.bottom},
+    };
+    SetLastError(ERROR_SUCCESS);
+    if (MapWindowPoints(window, nullptr, points, ARRAYSIZE(points)) == 0 &&
+        GetLastError() != ERROR_SUCCESS) {
+        return false;
+    }
+
+    constexpr int tolerance = 2;
+    return points[0].x <= monitorInfo.rcMonitor.left + tolerance &&
+           points[0].y <= monitorInfo.rcMonitor.top + tolerance &&
+           points[1].x >= monitorInfo.rcMonitor.right - tolerance &&
+           points[1].y >= monitorInfo.rcMonitor.bottom - tolerance;
+}
+
 bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
     if (!window || !IsWindowVisible(window) || IsIconic(window) ||
         HasDesktopWindowClass(window) || IsTaskbarClass(window)) {
@@ -582,18 +664,13 @@ bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
     // Tool, click-through, wallpaper, and other non-activating surfaces can be
     // full-monitor windows without representing a fullscreen application.
     if ((style & WS_CHILD) != 0 ||
-        (style & (WS_CAPTION | WS_THICKFRAME)) != 0 ||
         (exStyle & (WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE)) != 0) {
         return false;
     }
 
+    // Keep the expensive DWM query after the cheap style and monitor checks.
     if (MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST) != monitor ||
         IsWindowCloaked(window)) {
-        return false;
-    }
-
-    RECT windowRect{};
-    if (!GetWindowRect(window, &windowRect)) {
         return false;
     }
 
@@ -603,11 +680,30 @@ bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
         return false;
     }
 
+    RECT windowRect{};
+    if (!GetWindowRect(window, &windowRect)) {
+        return false;
+    }
+
     constexpr int tolerance = 2;
-    return windowRect.left <= monitorInfo.rcMonitor.left + tolerance &&
-           windowRect.top <= monitorInfo.rcMonitor.top + tolerance &&
-           windowRect.right >= monitorInfo.rcMonitor.right - tolerance &&
-           windowRect.bottom >= monitorInfo.rcMonitor.bottom - tolerance;
+    const bool windowCoversMonitor =
+        windowRect.left <= monitorInfo.rcMonitor.left + tolerance &&
+        windowRect.top <= monitorInfo.rcMonitor.top + tolerance &&
+        windowRect.right >= monitorInfo.rcMonitor.right - tolerance &&
+        windowRect.bottom >= monitorInfo.rcMonitor.bottom - tolerance;
+    if (!windowCoversMonitor) {
+        return false;
+    }
+
+    // Borderless windows are the common fullscreen case. Some Store/UWP apps
+    // and browsers retain caption/frame style bits in fullscreen; for those,
+    // require the client area itself to cover the monitor. A regular maximized
+    // window keeps non-client chrome and therefore doesn't pass this test.
+    if ((style & (WS_CAPTION | WS_THICKFRAME)) == 0) {
+        return true;
+    }
+
+    return DoesClientAreaCoverMonitor(window, monitorInfo);
 }
 
 void LogFullscreenCandidate(HWND window) {
@@ -788,6 +884,16 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
     WPARAM wParam,
     LPARAM lParam,
     bool* handled) {
+    if (message == g_uiThreadMessage) {
+        LRESULT result = 0;
+        if (HandleTaskbarUiOperation(window, wParam, &result)) {
+            if (handled) {
+                *handled = true;
+            }
+            return result;
+        }
+    }
+
     if (message == g_queryTaskbarRectMessage) {
         bool succeeded = false;
         if (g_stuckRectQuery.pending.load(std::memory_order_acquire) &&
@@ -818,14 +924,18 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
         g_trayUiWndProcObjects[window] = trayUi;
         g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
         Wh_Log(L"Captured TrayUI object for taskbar %p", window);
+        EnsureActivationWorker();
     } else if (message == g_captureTaskbarObjectMessage) {
         g_trayUiWndProcObjects[window] = trayUi;
         g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
         Wh_Log(L"Captured TrayUI object for taskbar %p", window);
+        EnsureActivationWorker();
         if (handled) {
             *handled = true;
         }
         return 0;
+    } else if (message == WM_SETTINGCHANGE) {
+        InvalidateAutoHideCache();
     } else if (message == WM_NCDESTROY) {
         g_trayUiWndProcObjects.erase(window);
         ForgetTaskbarState(window);
@@ -860,13 +970,24 @@ LRESULT WINAPI CSecondaryTray_WndProc_Hook(
     UINT message,
     WPARAM wParam,
     LPARAM lParam) {
+    if (message == g_uiThreadMessage) {
+        LRESULT result = 0;
+        if (HandleTaskbarUiOperation(window, wParam, &result)) {
+            return result;
+        }
+    }
+
     if (message == WM_NCCREATE) {
         g_secondaryTrayObjects[window] = secondaryTray;
         Wh_Log(L"Captured CSecondaryTray object for taskbar %p", window);
+        EnsureActivationWorker();
     } else if (message == g_captureTaskbarObjectMessage) {
         g_secondaryTrayObjects[window] = secondaryTray;
         Wh_Log(L"Captured CSecondaryTray object for taskbar %p", window);
+        EnsureActivationWorker();
         return 0;
+    } else if (message == WM_SETTINGCHANGE) {
+        InvalidateAutoHideCache();
     } else if (message == WM_NCDESTROY) {
         g_secondaryTrayObjects.erase(window);
         ForgetTaskbarState(window);
@@ -1106,30 +1227,16 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
             kReasonIsPointerOverTaskbarFrameChanged);
         g_syntheticExpansionUpdateInProgress = false;
 
-        bool expanded = false;
+        // IsExpanded can lag behind the logical pointer-over update while the
+        // taskbar animation/XAML state catches up. Treat it as diagnostics only;
+        // undoing the synthetic enter here would turn every asynchronous build
+        // into a permanent fallback path.
         if (ViewCoordinator_IsExpanded_Original) {
-            expanded = ViewCoordinator_IsExpanded_Original(
+            const bool expanded = ViewCoordinator_IsExpanded_Original(
                 viewCoordinator,
                 taskbarWindow);
-            Wh_Log(L"Coordinator expansion result after synthetic enter: %d",
+            Wh_Log(L"Coordinator expansion snapshot after synthetic enter: %d",
                    expanded);
-        }
-
-        // IsExpanded can be asynchronous. If verification is available and it
-        // still reports collapsed, fully undo the synthetic enter before the
-        // caller tries the native timer fallback.
-        if (ViewCoordinator_IsExpanded_Original && !expanded) {
-            g_syntheticPointerOverTaskbars.erase(taskbarWindow);
-            ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
-                viewCoordinator,
-                taskbarWindow,
-                false,
-                0);
-            ViewCoordinator_UpdateIsExpanded_Original(
-                viewCoordinator,
-                taskbarWindow,
-                kReasonIsPointerOverTaskbarFrameChanged);
-            return false;
         }
     } else {
         if (g_syntheticPointerOverTaskbars.erase(taskbarWindow) == 0) {
@@ -1162,16 +1269,89 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
     return true;
 }
 
+bool IsTaskbarCoveredByHigherWindow(HWND taskbarWindow) {
+    RECT taskbarRect{};
+    if (!GetWindowRect(taskbarWindow, &taskbarRect)) {
+        return false;
+    }
+
+    // While auto-hidden, the live taskbar rectangle can sit just outside the
+    // monitor and therefore not intersect the window that will cover it after
+    // the reveal animation. Project it to its visible bottom-docked position
+    // before checking higher Z-order windows.
+    const HMONITOR monitor = GetTaskbarMonitor(taskbarWindow);
+    MONITORINFO monitorInfo{};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if (monitor && GetMonitorInfoW(monitor, &monitorInfo)) {
+        const int height = taskbarRect.bottom - taskbarRect.top;
+        if (height > 0) {
+            taskbarRect.top = monitorInfo.rcMonitor.bottom - height;
+            taskbarRect.bottom = monitorInfo.rcMonitor.bottom;
+            taskbarRect.left = std::max(taskbarRect.left,
+                                        monitorInfo.rcMonitor.left);
+            taskbarRect.right = std::min(taskbarRect.right,
+                                         monitorInfo.rcMonitor.right);
+        }
+    }
+
+    struct Context {
+        HWND taskbarWindow;
+        RECT taskbarRect;
+        bool covered;
+    } context{taskbarWindow, taskbarRect, false};
+
+    // EnumWindows walks from top to bottom. Only windows encountered before the
+    // taskbar can cover it, so stop once the taskbar itself is reached.
+    EnumWindows(
+        [](HWND window, LPARAM parameter) -> BOOL {
+            auto* context = reinterpret_cast<Context*>(parameter);
+            if (window == context->taskbarWindow) {
+                return FALSE;
+            }
+
+            if (!IsWindowVisible(window) || IsIconic(window) ||
+                HasDesktopWindowClass(window) || IsTaskbarClass(window)) {
+                return TRUE;
+            }
+
+            const LONG_PTR exStyle = GetWindowLongPtrW(window, GWL_EXSTYLE);
+            if ((exStyle & (WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW |
+                            WS_EX_NOACTIVATE)) != 0 ||
+                IsWindowCloaked(window)) {
+                return TRUE;
+            }
+
+            RECT windowRect{};
+            RECT intersection{};
+            if (GetWindowRect(window, &windowRect) &&
+                IntersectRect(&intersection,
+                              &windowRect,
+                              &context->taskbarRect)) {
+                context->covered = true;
+                return FALSE;
+            }
+
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&context));
+
+    return context.covered;
+}
+
 bool BringTaskbarToFrontWithinCurrentBandOnUiThread(
     HWND taskbarWindow) {
     if (!taskbarWindow || !IsWindow(taskbarWindow)) {
         return false;
     }
 
-    // Reorder only within Explorer's current Z-order band. This brings the
-    // taskbar above ordinary windows when appropriate without forcing or
-    // clearing WS_EX_TOPMOST, preserving fullscreen behavior and compatibility
-    // with mods that intentionally manage the taskbar's Z-order policy.
+    // Explorer normally puts the revealed taskbar in front itself. Only nudge
+    // the Z-order when a higher window is actually intersecting it; this keeps
+    // the workaround for covered taskbars without reordering Explorer's window
+    // on every reveal.
+    if (!IsTaskbarCoveredByHigherWindow(taskbarWindow)) {
+        return true;
+    }
+
     const bool isTopmost =
         (GetWindowLongPtrW(taskbarWindow, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0;
     if (!SetWindowPos(taskbarWindow,
@@ -1182,23 +1362,23 @@ bool BringTaskbarToFrontWithinCurrentBandOnUiThread(
                       0,
                       SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
                           SWP_NOOWNERZORDER)) {
-        Wh_Log(L"Couldn't bring taskbar %p to the front of its Z-order "
-               L"band: %u",
+        Wh_Log(L"Couldn't bring covered taskbar %p to the front of its "
+               L"Z-order band: %u",
                taskbarWindow,
                GetLastError());
         return false;
     }
 
-    Wh_Log(L"Brought taskbar %p to the front of its %s Z-order band",
+    Wh_Log(L"Brought covered taskbar %p to the front of its %s Z-order band",
            taskbarWindow,
            isTopmost ? L"topmost" : L"normal");
     return true;
 }
 
 bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
-    // Establish coordinator ownership first. If this fails, leave the legacy
-    // path untouched and let the caller use Explorer's native timer fallback,
-    // avoiding two independent reveal mechanisms for the same attempt.
+    // Establish coordinator ownership first. If no coordinator has been
+    // captured yet, leave the legacy shell path untouched and let the worker
+    // retry with backoff instead of starting competing reveal mechanisms.
     const bool coordinatorExpanded =
         SetSyntheticPointerOverOnUiThread(taskbarWindow, true);
 
@@ -1235,35 +1415,17 @@ void ClearAllSyntheticPointerOverOnUiThread() {
     g_syntheticPointerOverTaskbars.clear();
 }
 
-// This window belongs to Explorer's taskbar UI thread, so custom operations
-// sent here can safely invoke ViewCoordinator and taskbar window timers.
-using CTaskBand_v_WndProc_t =
-    LRESULT(WINAPI*)(void* taskBand,
-                     HWND window,
-                     UINT message,
-                     WPARAM wParam,
-                     LPARAM lParam);
-
-CTaskBand_v_WndProc_t CTaskBand_v_WndProc_Original;
-
 constexpr UINT_PTR kTrayUITimerUnhide = 3;
-
-bool CancelNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
-    return taskbarWindow && IsWindow(taskbarWindow) &&
-           KillTimer(taskbarWindow, kTrayUITimerUnhide);
-}
 
 bool TriggerNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
     if (!taskbarWindow || !IsWindow(taskbarWindow)) {
         return false;
     }
 
-    // Avoid carrying over a stale repeating timer if Explorer changed how it
-    // handles timer ID 3, then arm the established native unhide timer.
-    KillTimer(taskbarWindow, kTrayUITimerUnhide);
-    UINT_PTR timerResult =
+    // Explorer owns timer ID 3. Never kill or clean it up here: doing so can
+    // cancel a genuine native edge-hover reveal that Explorer armed itself.
+    const UINT_PTR timerResult =
         SetTimer(taskbarWindow, kTrayUITimerUnhide, 1, nullptr);
-
     if (!timerResult) {
         Wh_Log(L"Native unhide timer failed for taskbar %p: %u",
                taskbarWindow,
@@ -1271,69 +1433,42 @@ bool TriggerNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
         return false;
     }
 
-    // Put the hidden taskbar in the correct Z-order before Explorer processes
-    // the asynchronous timer. A second reinforcement is sent by the worker
-    // after the timer has had time to reveal the window.
-    BringTaskbarToFrontWithinCurrentBandOnUiThread(taskbarWindow);
-
-    Wh_Log(L"Requested native unhide timer for taskbar %p",
-           taskbarWindow);
+    Wh_Log(L"Requested native unhide timer for taskbar %p", taskbarWindow);
     return true;
 }
 
-LRESULT WINAPI CTaskBand_v_WndProc_Hook(
-    void* taskBand,
-    HWND window,
-    UINT message,
-    WPARAM wParam,
-    LPARAM lParam) {
-    if (message == g_uiThreadMessage) {
-        const UiOperation operation =
-            static_cast<UiOperation>(wParam);
-        HWND targetTaskbar =
-            reinterpret_cast<HWND>(lParam);
-
-        switch (operation) {
-            case kUiRevealTaskbar:
-                return RevealTaskbarOnUiThread(targetTaskbar) ? 1 : 0;
-
-            case kUiClearSyntheticPointerOver:
-                return SetSyntheticPointerOverOnUiThread(
-                           targetTaskbar,
-                           false)
-                           ? 1
-                           : 0;
-
-            case kUiClearAllSyntheticPointerOver:
-                ClearAllSyntheticPointerOverOnUiThread();
-                return 1;
-
-            case kUiTriggerNativeUnhideTimer:
-                return TriggerNativeUnhideTimerOnUiThread(targetTaskbar)
-                           ? 1
-                           : 0;
-
-            case kUiCancelNativeUnhideTimer:
-                return CancelNativeUnhideTimerOnUiThread(targetTaskbar)
-                           ? 1
-                           : 0;
-
-            case kUiBringTaskbarToFront:
-                return BringTaskbarToFrontWithinCurrentBandOnUiThread(
-                           targetTaskbar)
-                           ? 1
-                           : 0;
-        }
-
-        return 0;
+bool HandleTaskbarUiOperation(HWND taskbarWindow,
+                              WPARAM operationValue,
+                              LRESULT* result) {
+    if (!result) {
+        return false;
     }
 
-    return CTaskBand_v_WndProc_Original(
-        taskBand,
-        window,
-        message,
-        wParam,
-        lParam);
+    switch (static_cast<UiOperation>(operationValue)) {
+        case kUiRevealTaskbar:
+            *result = RevealTaskbarOnUiThread(taskbarWindow) ? 1 : 0;
+            return true;
+
+        case kUiClearSyntheticPointerOver:
+            *result = SetSyntheticPointerOverOnUiThread(
+                          taskbarWindow, false)
+                          ? 1
+                          : 0;
+            return true;
+
+        case kUiClearAllSyntheticPointerOver:
+            ClearAllSyntheticPointerOverOnUiThread();
+            *result = 1;
+            return true;
+
+        case kUiTriggerNativeUnhideTimer:
+            *result = TriggerNativeUnhideTimerOnUiThread(taskbarWindow)
+                          ? 1
+                          : 0;
+            return true;
+    }
+
+    return false;
 }
 
 enum class UiOperationResult {
@@ -1355,33 +1490,37 @@ bool UiOperationMayHaveRun(UiOperationResult result) {
 UiOperationResult SendUiOperation(UiOperation operation,
                                   HWND taskbarWindow,
                                   DWORD timeoutMs = 250) {
-    HWND taskBandWindow = GetTaskBandWindow();
-    if (!taskBandWindow) {
+    HWND destination = taskbarWindow;
+    if (operation == kUiClearAllSyntheticPointerOver) {
+        destination = FindAnyTaskbarWindow();
+    }
+
+    if (!destination || !IsTaskbarClass(destination) ||
+        !IsCurrentProcessWindow(destination)) {
         return UiOperationResult::kNotSent;
     }
 
     DWORD_PTR result = 0;
     SetLastError(ERROR_SUCCESS);
     if (!SendMessageTimeoutW(
-            taskBandWindow,
+            destination,
             g_uiThreadMessage,
             operation,
-            reinterpret_cast<LPARAM>(taskbarWindow),
+            0,
             SMTO_ABORTIFHUNG | SMTO_BLOCK,
             timeoutMs,
             &result)) {
         const DWORD error = GetLastError();
-        Wh_Log(L"UI-thread operation timed out or failed: operation=%u "
-               L"error=%u",
+        Wh_Log(L"Taskbar UI operation timed out or failed: operation=%u "
+               L"taskbar=%p error=%u",
                static_cast<unsigned>(operation),
+               destination,
                error);
 
-        // Once SendMessageTimeoutW has begun a cross-thread send, a timeout or
-        // an unspecified failure doesn't prove that the target WndProc won't
-        // process the message later. Only a vanished target window is treated
-        // as definitely not sent; all other failures are conservatively
-        // considered indeterminate.
-        if (error == ERROR_INVALID_WINDOW_HANDLE) {
+        // A timeout doesn't cancel a cross-thread send. Treat it as possibly
+        // delivered so the worker retains ownership and still sends the
+        // matching release. A vanished window is the only definite no-send.
+        if (error == ERROR_INVALID_WINDOW_HANDLE || !IsWindow(destination)) {
             return UiOperationResult::kNotSent;
         }
         return UiOperationResult::kIndeterminate;
@@ -1394,19 +1533,18 @@ UiOperationResult SendUiOperation(UiOperation operation,
 struct ActivationWorkerState {
     HWND activeTaskbar = nullptr;
     HMONITOR activeTaskbarMonitor = nullptr;
-    HWND fallbackTaskbar = nullptr;
-    HMONITOR fallbackTaskbarMonitor = nullptr;
+    HWND fallbackProbeTaskbar = nullptr;
+    HMONITOR fallbackProbeMonitor = nullptr;
     HMONITOR activationCandidateMonitor = nullptr;
+    HMONITOR bandEntryMonitor = nullptr;
     bool armed = true;
+    bool fallbackAttemptedForEntry = false;
     UINT_PTR releaseTimerId = 0;
     UINT_PTR retryTimerId = 0;
-    UINT_PTR nativeTimerCleanupTimerId = 0;
     bool releaseRetryPending = false;
     ULONGLONG activationCandidateSince = 0;
     ULONGLONG lastActivationCheck = 0;
-    ULONGLONG fallbackRearmNotBefore = 0;
     unsigned suppressionFailures = 0;
-    unsigned fallbackHideCount = 0;
     unsigned appliedSettingsGeneration = 0;
 };
 
@@ -1445,8 +1583,6 @@ bool ClearActiveTaskbar(ActivationWorkerState& state,
         if (!UiOperationSucceeded(clearResult)) {
             // Keep ownership and retry instead of forgetting synthetic state
             // that may still force Explorer's coordinator to remain expanded.
-            // An indeterminate result is especially important: the clear may
-            // still be waiting in the taskbar UI thread's sent-message queue.
             if (scheduleRetry) {
                 state.releaseRetryPending = true;
                 ScheduleWorkerTimer(kReleaseRetryMs,
@@ -1461,22 +1597,6 @@ bool ClearActiveTaskbar(ActivationWorkerState& state,
     state.activeTaskbarMonitor = nullptr;
     state.armed = true;
     return true;
-}
-
-void CancelFallbackNativeTimer(ActivationWorkerState& state) {
-    CancelWorkerTimer(state.nativeTimerCleanupTimerId);
-    if (state.fallbackTaskbar && IsWindow(state.fallbackTaskbar)) {
-        (void)SendUiOperation(kUiCancelNativeUnhideTimer,
-                              state.fallbackTaskbar,
-                              500);
-    }
-}
-
-void ClearFallbackTaskbar(ActivationWorkerState& state) {
-    CancelFallbackNativeTimer(state);
-    state.fallbackTaskbar = nullptr;
-    state.fallbackTaskbarMonitor = nullptr;
-    state.armed = true;
 }
 
 void ScheduleRetry(ActivationWorkerState& state, UINT delayMs) {
@@ -1502,16 +1622,12 @@ void ResetActivationCandidate(ActivationWorkerState& state) {
     state.activationCandidateSince = 0;
 }
 
-void ResetFallbackBackoff(ActivationWorkerState& state) {
-    state.fallbackHideCount = 0;
-    state.fallbackRearmNotBefore = 0;
-}
-
-UINT GetFallbackRearmDelay(ActivationWorkerState& state) {
-    state.fallbackHideCount = std::min(state.fallbackHideCount + 1, 4U);
-    const unsigned shift = state.fallbackHideCount - 1;
-    return std::min(kFallbackRearmBaseMs << shift,
-                    kSuppressionBackoffMaxMs);
+void ResetBandEntry(ActivationWorkerState& state) {
+    state.bandEntryMonitor = nullptr;
+    state.fallbackAttemptedForEntry = false;
+    state.fallbackProbeTaskbar = nullptr;
+    state.fallbackProbeMonitor = nullptr;
+    ResetActivationCandidate(state);
 }
 
 void ProcessPointerState(ActivationWorkerState& state) {
@@ -1525,9 +1641,7 @@ void ProcessPointerState(ActivationWorkerState& state) {
             return;
         }
 
-        ClearFallbackTaskbar(state);
-        ResetActivationCandidate(state);
-        ResetFallbackBackoff(state);
+        ResetBandEntry(state);
         state.lastActivationCheck = 0;
         state.suppressionFailures = 0;
         state.appliedSettingsGeneration = settingsGeneration;
@@ -1544,10 +1658,8 @@ void ProcessPointerState(ActivationWorkerState& state) {
         if (!ClearActiveTaskbar(state)) {
             return;
         }
-        ClearFallbackTaskbar(state);
         CancelWorkerTimer(state.retryTimerId);
-        ResetActivationCandidate(state);
-        ResetFallbackBackoff(state);
+        ResetBandEntry(state);
         state.suppressionFailures = 0;
         return;
     }
@@ -1562,29 +1674,30 @@ void ProcessPointerState(ActivationWorkerState& state) {
     const bool insideActivationBand =
         IsPointInsideActivationBand(pointer, pointerMonitor, monitorInfo);
 
-    if (state.fallbackTaskbar) {
+    if (state.fallbackProbeTaskbar) {
         const bool sameMonitor =
-            pointerMonitor == state.fallbackTaskbarMonitor;
-        if (!IsWindow(state.fallbackTaskbar) || !insideActivationBand ||
-            !sameMonitor) {
-            ClearFallbackTaskbar(state);
+            pointerMonitor == state.fallbackProbeMonitor;
+        if (!IsWindow(state.fallbackProbeTaskbar) ||
+            !insideActivationBand || !sameMonitor) {
+            state.fallbackProbeTaskbar = nullptr;
+            state.fallbackProbeMonitor = nullptr;
+            state.armed = true;
+        } else if (IsTaskbarVisiblyRevealed(state.fallbackProbeTaskbar,
+                                            state.fallbackProbeMonitor)) {
+            // Explorer owns the fallback reveal and its matching hide. Don't
+            // keep probing or re-reveal while the pointer remains in this band.
+            state.fallbackProbeTaskbar = nullptr;
+            state.fallbackProbeMonitor = nullptr;
+            state.armed = false;
             CancelWorkerTimer(state.retryTimerId);
-            ResetFallbackBackoff(state);
-        } else if (IsTaskbarVisiblyRevealed(state.fallbackTaskbar,
-                                            state.fallbackTaskbarMonitor)) {
-            // Explorer owns the fallback reveal and its matching hide. Poll at
-            // a low rate only while this exceptional path remains active.
-            ScheduleRetry(state, kFallbackStatusPollMs);
             return;
         } else {
-            // Avoid a rapid hide/reveal oscillation if Explorer's timer path
-            // hides again before a ViewCoordinator becomes available.
-            ClearFallbackTaskbar(state);
-            CancelWorkerTimer(state.retryTimerId);
-            const UINT rearmDelay = GetFallbackRearmDelay(state);
-            state.fallbackRearmNotBefore = now + rearmDelay;
-            ScheduleRetry(state, rearmDelay);
-            return;
+            // The timer was filtered or didn't reveal the taskbar. Continue
+            // coordinator retries, but don't arm timer ID 3 again until the
+            // pointer leaves and re-enters the activation band.
+            state.fallbackProbeTaskbar = nullptr;
+            state.fallbackProbeMonitor = nullptr;
+            state.armed = true;
         }
     }
 
@@ -1629,20 +1742,23 @@ void ProcessPointerState(ActivationWorkerState& state) {
         state.armed = true;
         state.suppressionFailures = 0;
         CancelWorkerTimer(state.retryTimerId);
-        ResetActivationCandidate(state);
-        ResetFallbackBackoff(state);
+        ResetBandEntry(state);
         return;
+    }
+
+    // Entering the activation band on another monitor is a new activation
+    // opportunity even if the pointer never left the combined bottom edge.
+    if (state.bandEntryMonitor != pointerMonitor) {
+        state.bandEntryMonitor = pointerMonitor;
+        state.armed = true;
+        state.fallbackAttemptedForEntry = false;
+        state.fallbackProbeTaskbar = nullptr;
+        state.fallbackProbeMonitor = nullptr;
+        ResetActivationCandidate(state);
     }
 
     if (!state.armed) {
         CancelWorkerTimer(state.retryTimerId);
-        return;
-    }
-
-    if (now < state.fallbackRearmNotBefore) {
-        ScheduleRetry(
-            state,
-            static_cast<UINT>(state.fallbackRearmNotBefore - now));
         return;
     }
 
@@ -1721,11 +1837,10 @@ void ProcessPointerState(ActivationWorkerState& state) {
         return;
     }
 
-    state.suppressionFailures = 0;
-
     const UiOperationResult revealResult =
         SendUiOperation(kUiRevealTaskbar, taskbarWindow);
     if (UiOperationMayHaveRun(revealResult)) {
+        state.suppressionFailures = 0;
         if (revealResult == UiOperationResult::kIndeterminate) {
             Wh_Log(L"Taskbar reveal timed out; assuming coordinator ownership "
                    L"until the matching release succeeds: %p",
@@ -1736,8 +1851,6 @@ void ProcessPointerState(ActivationWorkerState& state) {
                    taskbarWindow);
         }
 
-        ClearFallbackTaskbar(state);
-        ResetFallbackBackoff(state);
         ResetActivationCandidate(state);
         state.activeTaskbar = taskbarWindow;
         state.activeTaskbarMonitor = pointerMonitor;
@@ -1745,23 +1858,21 @@ void ProcessPointerState(ActivationWorkerState& state) {
         return;
     }
 
-    if (g_settings.nativeTimerFallback.load(std::memory_order_relaxed)) {
+    if (!state.fallbackAttemptedForEntry &&
+        g_settings.nativeTimerFallback.load(std::memory_order_relaxed)) {
+        state.fallbackAttemptedForEntry = true;
         const UiOperationResult fallbackResult =
             SendUiOperation(kUiTriggerNativeUnhideTimer, taskbarWindow);
         if (UiOperationMayHaveRun(fallbackResult)) {
-            Wh_Log(L"Activated taskbar %p through native timer fallback%s",
+            Wh_Log(L"Requested native timer fallback for taskbar %p%s",
                    taskbarWindow,
                    fallbackResult == UiOperationResult::kIndeterminate
                        ? L" (delivery indeterminate)"
                        : L"");
-
-            ResetActivationCandidate(state);
-            state.fallbackTaskbar = taskbarWindow;
-            state.fallbackTaskbarMonitor = pointerMonitor;
+            state.fallbackProbeTaskbar = taskbarWindow;
+            state.fallbackProbeMonitor = pointerMonitor;
             state.armed = false;
-            ScheduleWorkerTimer(kNativeTimerCleanupMs,
-                                state.nativeTimerCleanupTimerId);
-            ScheduleRetry(state, kFallbackStatusPollMs);
+            ScheduleRetry(state, kFallbackProbeMs);
             return;
         }
     }
@@ -1920,31 +2031,6 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
                                message.wParam == state.retryTimerId) {
                         CancelWorkerTimer(state.retryTimerId);
                         ProcessPointerState(state);
-                    } else if (state.nativeTimerCleanupTimerId &&
-                               message.wParam ==
-                                   state.nativeTimerCleanupTimerId) {
-                        CancelWorkerTimer(
-                            state.nativeTimerCleanupTimerId);
-                        if (state.fallbackTaskbar &&
-                            IsWindow(state.fallbackTaskbar)) {
-                            (void)SendUiOperation(
-                                kUiCancelNativeUnhideTimer,
-                                state.fallbackTaskbar,
-                                500);
-
-                            // The timer reveal is asynchronous. Bring the
-                            // taskbar forward within its existing Z-order band
-                            // after Explorer has moved it onscreen.
-                            if (state.fallbackTaskbarMonitor &&
-                                IsTaskbarVisiblyRevealed(
-                                    state.fallbackTaskbar,
-                                    state.fallbackTaskbarMonitor)) {
-                                (void)SendUiOperation(
-                                    kUiBringTaskbarToFront,
-                                    state.fallbackTaskbar,
-                                    500);
-                            }
-                        }
                     } else if (fallbackPollTimerId &&
                                message.wParam == fallbackPollTimerId) {
                         ProcessPointerState(state);
@@ -1960,14 +2046,12 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
     }
 
     CancelWorkerTimer(state.retryTimerId);
-    CancelWorkerTimer(state.nativeTimerCleanupTimerId);
-    ClearFallbackTaskbar(state);
 
-    for (int attempt = 0; state.activeTaskbar && attempt < 3; attempt++) {
-        if (ClearActiveTaskbar(state, 1000, false)) {
-            break;
-        }
-        Sleep(50);
+    // Keep unload bounded if Explorer's taskbar UI thread is unresponsive. A
+    // single best-effort release is sufficient; an indeterminate send may still
+    // be delivered later, and a real pointer transition repairs stale state.
+    if (state.activeTaskbar) {
+        (void)ClearActiveTaskbar(state, 250, false);
     }
 
     if (cursorHook) {
@@ -2080,7 +2164,6 @@ bool HookTaskbarUiThreadSymbol() {
             },
             &TrayUI_WndProc_Original,
             TrayUI_WndProc_Hook,
-            true,
         },
         {
             {
@@ -2088,14 +2171,6 @@ bool HookTaskbarUiThreadSymbol() {
             },
             &CSecondaryTray_WndProc_Original,
             CSecondaryTray_WndProc_Hook,
-            true,
-        },
-        {
-            {
-                LR"(protected: virtual __int64 __cdecl CTaskBand::v_WndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64))",
-            },
-            &CTaskBand_v_WndProc_Original,
-            CTaskBand_v_WndProc_Hook,
         },
     };
 
@@ -2197,6 +2272,9 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR libraryFileName,
 BOOL Wh_ModInit() {
     Wh_Log(L"Initializing");
 
+    g_unloading.store(false, std::memory_order_relaxed);
+    InvalidateAutoHideCache();
+
     g_uiThreadMessage =
         RegisterWindowMessageW(L"taskbar-activation-threshold.ui");
     g_captureTaskbarObjectMessage =
@@ -2260,9 +2338,20 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModAfterInit() {
-    Wh_Log(L"Starting activation worker");
+    Wh_Log(L"Looking for taskbar windows in this Explorer process");
 
-    CaptureExistingTaskbarObjects();
+    // Only the shell Explorer instance registers Shell_TrayWnd. Folder-window
+    // Explorer processes skip the capture pass and never create the activation
+    // worker or its system-wide WinEvent hook.
+    WNDCLASSW taskbarClass{};
+    if (GetClassInfoW(GetModuleHandleW(nullptr),
+                      L"Shell_TrayWnd",
+                      &taskbarClass)) {
+        CaptureExistingTaskbarObjects();
+    } else {
+        Wh_Log(L"No Shell_TrayWnd class in this Explorer process; worker not "
+               L"started");
+    }
 
     // Retry in case the taskbar view module loaded between Wh_ModInit and hook
     // application.
@@ -2280,50 +2369,46 @@ void Wh_ModAfterInit() {
             }
         }
     }
-
-    g_workerThread = CreateThread(
-        nullptr,
-        0,
-        ActivationWorkerThread,
-        nullptr,
-        0,
-        nullptr);
-
-    if (!g_workerThread) {
-        Wh_Log(L"CreateThread failed: %u", GetLastError());
-        return;
-    }
 }
 
 void Wh_ModBeforeUninit() {
     Wh_Log(L"Stopping activation worker");
+    g_unloading.store(true, std::memory_order_release);
 
     if (g_stopEvent) {
         SetEvent(g_stopEvent);
     }
 
-    if (g_workerThread) {
-        WaitForSingleObject(g_workerThread, INFINITE);
+    HANDLE workerThread = nullptr;
+    {
+        std::lock_guard<std::mutex> guard(g_workerThreadMutex);
+        workerThread = g_workerThread.load(std::memory_order_acquire);
+    }
+    if (workerThread) {
+        WaitForSingleObject(workerThread, INFINITE);
     }
 
-    UiOperationResult clearResult =
-        SendUiOperation(kUiClearAllSyntheticPointerOver, nullptr, 1000);
-    if (!UiOperationSucceeded(clearResult)) {
-        Sleep(50);
-        clearResult =
-            SendUiOperation(kUiClearAllSyntheticPointerOver, nullptr, 2000);
-        if (!UiOperationSucceeded(clearResult)) {
-            Wh_Log(L"Final synthetic pointer-over cleanup wasn't confirmed");
-        }
+    // One bounded cleanup attempt keeps disable/reload responsive even when
+    // Explorer's taskbar UI thread is the component that's hung.
+    const UiOperationResult clearResult =
+        SendUiOperation(kUiClearAllSyntheticPointerOver, nullptr, 500);
+    if (!UiOperationSucceeded(clearResult) &&
+        clearResult != UiOperationResult::kNotSent) {
+        Wh_Log(L"Final synthetic pointer-over cleanup wasn't confirmed");
     }
 }
 
 void Wh_ModUninit() {
     Wh_Log(L"Uninitializing");
 
-    if (g_workerThread) {
-        CloseHandle(g_workerThread);
-        g_workerThread = nullptr;
+    HANDLE workerThread = nullptr;
+    {
+        std::lock_guard<std::mutex> guard(g_workerThreadMutex);
+        workerThread = g_workerThread.exchange(nullptr,
+                                                std::memory_order_acq_rel);
+    }
+    if (workerThread) {
+        CloseHandle(workerThread);
     }
 
     if (g_stopEvent) {
@@ -2332,6 +2417,7 @@ void Wh_ModUninit() {
     }
 
     g_stuckRectQuery.pending.store(false, std::memory_order_relaxed);
+    InvalidateAutoHideCache();
     g_viewCoordinators.clear();
     g_trayUiWndProcObjects.clear();
     g_secondaryTrayObjects.clear();

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -36,7 +36,7 @@ continuous polling, minimizing background activity while the pointer is idle.
 - Per-monitor DPI scaling
 - Multi-monitor support
 - Adjustable release delay and activation cooldown
-- Optional suppression over fullscreen applications
+- Optional suppression over fullscreen applications and presentation mode
 - Optional suppression while a mouse button is held
 - Optional restriction to the primary monitor
 - Best-effort native timer fallback while the taskbar coordinator is unavailable
@@ -55,12 +55,13 @@ The mod does not modify:
 
 When needed, the mod can bring a normal-band taskbar in front of an ordinary
 normal-band window without activating it. It never promotes the taskbar into
-the topmost band or reorders it above an always-on-top window, preserving
-fullscreen, accessibility-overlay, and third-party Z-order policies.
+the topmost band or reorders it above an always-on-top window. Mods that
+intentionally keep the taskbar behind other normal windows can conflict with
+this narrowly scoped Z-order correction.
 
 The mod is designed to coexist with taskbar styling, sizing, transparency,
-animation, clock, label, and icon mods that retain the standard bottom-positioned
-Windows 11 taskbar.
+animation, clock, label, and icon mods that retain the standard
+bottom-positioned Windows 11 taskbar and don't replace its reveal logic.
 
 ## Requirements
 
@@ -78,12 +79,27 @@ Windows 11 taskbar.
 - Mods that disable, replace, or override the taskbar's native expansion logic
   may conflict with this mod. Keyboard-only and never-show auto-hide modes are
   intentionally incompatible with mouse activation.
-- Windows updates can rename undocumented taskbar symbols. If this occurs, one
-  or more reveal paths may require a symbol update.
+- The primary reveal path depends on undocumented Windows 11 taskbar symbols.
+  If a Windows update renames either required coordinator method, the mod logs
+  that the reveal path is unavailable and needs a symbol update.
 - Shortly after Explorer starts, the internal Windows 11 taskbar coordinator
   may not yet have been captured. The optional native timer fallback is tried
   once per activation-band entry, while coordinator activation continues to
   retry with backoff until the coordinator becomes available.
+- The native timer fallback uses Explorer's internal taskbar-unhide timer. A
+  mod that intercepts or replaces that timer can block the fallback, and
+  arming it can reset an already pending native unhide timer. This affects only
+  the brief pre-coordinator fallback path; normal coordinator activation is
+  independent of the timer.
+- Mods that deliberately control the taskbar's normal-window Z-order can
+  conflict with the correction used when an ordinary window covers a revealed
+  taskbar. The correction never crosses into the topmost window band. Stock
+  topmost taskbars bypass the coverage scan and aren't reordered.
+- Fullscreen suppression ignores click-through, tool, non-activating, cloaked,
+  desktop, and taskbar windows. It is intentionally conservative otherwise: a
+  qualifying fullscreen window anywhere above the desktop on the target monitor
+  can suppress activation even when another app has focus. A borderless custom-
+  chrome app that covers the monitor can therefore be treated as fullscreen.
 
 ## Suggested settings
 
@@ -139,7 +155,10 @@ This mod is distributed under the GNU General Public License v3.0.
 - ignoreFullscreenApps: true
   $name: Ignore fullscreen apps
   $description: >-
-    Don't reveal the taskbar over borderless or exclusive-fullscreen apps.
+    Don't reveal the taskbar when a fullscreen app or presentation state is
+    detected on the target monitor. Click-through, tool, non-activating,
+    cloaked, desktop, and taskbar windows are ignored. A qualifying background
+    fullscreen window on that monitor can still suppress activation.
 - ignoreWhileMouseButtonDown: true
   $name: Ignore while dragging
   $description: >-
@@ -152,8 +171,9 @@ This mod is distributed under the GNU General Public License v3.0.
   $name: Native timer fallback
   $description: >-
     If the Windows 11 taskbar coordinator isn't available yet, make one
-    best-effort request to Explorer's native reveal timer for each entry into
-    the activation band. The mod never cancels Explorer's timer.
+    best-effort request through Explorer's native unhide timer for each entry
+    into the activation band. Mods that intercept Explorer's taskbar timers can
+    block this temporary fallback. The pointer is never moved or injected.
 */
 // ==/WindhawkModSettings==
 
@@ -247,6 +267,26 @@ std::unordered_set<HWND> g_syntheticPointerOverTaskbars;
 // Set only while this mod is applying its reason-7 synthetic enter update on
 // the taskbar UI thread. This keeps ShouldTaskbarBeExpanded narrowly scoped.
 bool g_syntheticExpansionUpdateInProgress = false;
+
+class ScopedSyntheticExpansionUpdate {
+public:
+    ScopedSyntheticExpansionUpdate()
+        : previous_(g_syntheticExpansionUpdateInProgress) {
+        g_syntheticExpansionUpdateInProgress = true;
+    }
+
+    ~ScopedSyntheticExpansionUpdate() {
+        g_syntheticExpansionUpdateInProgress = previous_;
+    }
+
+    ScopedSyntheticExpansionUpdate(const ScopedSyntheticExpansionUpdate&) =
+        delete;
+    ScopedSyntheticExpansionUpdate& operator=(
+        const ScopedSyntheticExpansionUpdate&) = delete;
+
+private:
+    bool previous_;
+};
 
 void* g_trayUiVtableITrayComponentHost = nullptr;
 
@@ -662,7 +702,8 @@ bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
     // Tool, click-through, wallpaper, and other non-activating surfaces can be
     // full-monitor windows without representing a fullscreen application.
     if ((style & WS_CHILD) != 0 ||
-        (exStyle & (WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE)) != 0) {
+        (exStyle & (WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW |
+                    WS_EX_NOACTIVATE)) != 0) {
         return false;
     }
 
@@ -1089,13 +1130,6 @@ void* GetViewCoordinator(HWND taskbarWindow) {
 // IsPointerOverTaskbarFrameChanged update reason.
 constexpr int kReasonIsPointerOverTaskbarFrameChanged = 7;
 
-using ViewCoordinator_IsExpanded_t =
-    bool(WINAPI*)(void* viewCoordinator,
-                  HWND taskbarWindow);
-
-ViewCoordinator_IsExpanded_t
-    ViewCoordinator_IsExpanded_Original;
-
 using ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_t =
     void(WINAPI*)(void* viewCoordinator,
                   HWND taskbarWindow,
@@ -1129,13 +1163,17 @@ ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook(
                taskbarWindow);
 
         const DWORD workerThreadId =
-            g_workerThreadId.load(std::memory_order_relaxed);
-        if (workerThreadId) {
-            PostThreadMessageW(
+            g_workerThreadId.load(std::memory_order_acquire);
+        if (workerThreadId &&
+            !PostThreadMessageW(
                 workerThreadId,
                 kWorkerNativePointerLeaveMessage,
                 reinterpret_cast<WPARAM>(taskbarWindow),
-                0);
+                0)) {
+            Wh_Log(L"Couldn't notify activation worker about Explorer's "
+                   L"pointer leave for taskbar %p: %u",
+                   taskbarWindow,
+                   GetLastError());
         }
     }
 }
@@ -1189,23 +1227,6 @@ using ViewCoordinator_UpdateIsExpanded_t =
 ViewCoordinator_UpdateIsExpanded_t
     ViewCoordinator_UpdateIsExpanded_Original;
 
-void WINAPI ViewCoordinator_UpdateIsExpanded_Hook(
-    void* viewCoordinator,
-    HWND taskbarWindow,
-    int reason) {
-    RememberViewCoordinator(taskbarWindow, viewCoordinator);
-
-    Wh_Log(L"UpdateIsExpanded: taskbar=%p reason=%d synthetic=%d",
-           taskbarWindow,
-           reason,
-           g_syntheticPointerOverTaskbars.contains(taskbarWindow));
-
-    ViewCoordinator_UpdateIsExpanded_Original(
-        viewCoordinator,
-        taskbarWindow,
-        reason);
-}
-
 bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
                                        bool isPointerOver) {
     if (!isPointerOver && taskbarWindow &&
@@ -1240,7 +1261,7 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
         Wh_Log(L"Setting synthetic pointer-over for taskbar %p",
                taskbarWindow);
 
-        g_syntheticExpansionUpdateInProgress = true;
+        ScopedSyntheticExpansionUpdate expansionUpdate;
         ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
             viewCoordinator,
             taskbarWindow,
@@ -1251,19 +1272,6 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
             viewCoordinator,
             taskbarWindow,
             kReasonIsPointerOverTaskbarFrameChanged);
-        g_syntheticExpansionUpdateInProgress = false;
-
-        // IsExpanded can lag behind the logical pointer-over update while the
-        // taskbar animation/XAML state catches up. Treat it as diagnostics only;
-        // undoing the synthetic enter here would turn every asynchronous build
-        // into a permanent fallback path.
-        if (ViewCoordinator_IsExpanded_Original) {
-            const bool expanded = ViewCoordinator_IsExpanded_Original(
-                viewCoordinator,
-                taskbarWindow);
-            Wh_Log(L"Coordinator expansion snapshot after synthetic enter: %d",
-                   expanded);
-        }
     } else {
         if (g_syntheticPointerOverTaskbars.erase(taskbarWindow) == 0) {
             return true;
@@ -1283,13 +1291,6 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
             taskbarWindow,
             kReasonIsPointerOverTaskbarFrameChanged);
 
-        if (ViewCoordinator_IsExpanded_Original) {
-            bool expanded = ViewCoordinator_IsExpanded_Original(
-                viewCoordinator,
-                taskbarWindow);
-            Wh_Log(L"Coordinator expansion result after synthetic leave: %d",
-                   expanded);
-        }
     }
 
     return true;
@@ -1460,6 +1461,9 @@ bool TriggerNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
 
     // Explorer owns timer ID 3. Never kill or clean it up here: doing so can
     // cancel a genuine native edge-hover reveal that Explorer armed itself.
+    // SetTimer resets an existing timer with the same HWND and ID, so this
+    // compatibility fallback is deliberately limited to one attempt per band
+    // entry and is disclosed in the README.
     const UINT_PTR timerResult =
         SetTimer(taskbarWindow, kTrayUITimerUnhide, 1, nullptr);
     if (!timerResult) {
@@ -1618,14 +1622,23 @@ bool ClearActiveTaskbar(ActivationWorkerState& state,
                         bool scheduleRetry = true) {
     CancelWorkerTimer(state.releaseTimerId);
 
-    if (state.activeTaskbar && IsWindow(state.activeTaskbar)) {
+    if (state.activeTaskbar) {
         const UiOperationResult clearResult =
             SendUiOperation(kUiClearSyntheticPointerOver,
                             state.activeTaskbar,
                             timeoutMs);
-        if (!UiOperationSucceeded(clearResult)) {
-            // Keep ownership and retry instead of forgetting synthetic state
-            // that may still force Explorer's coordinator to remain expanded.
+
+        if (clearResult == UiOperationResult::kNotSent) {
+            // The HWND is no longer a taskbar in this Explorer process. Its
+            // coordinator and synthetic state were already discarded by the
+            // taskbar WM_NCDESTROY hook, so retrying could loop forever if the
+            // numeric handle was recycled for another window.
+            Wh_Log(L"Release target is no longer a taskbar: %p",
+                   state.activeTaskbar);
+        } else if (!UiOperationSucceeded(clearResult)) {
+            // Completed failure or timeout means the taskbar might still own
+            // synthetic state. Keep worker ownership and retry rather than
+            // allowing Explorer's coordinator to remain forced open.
             if (scheduleRetry) {
                 state.releaseRetryPending = true;
                 ScheduleWorkerTimer(kReleaseRetryMs,
@@ -1943,7 +1956,6 @@ void HandleNativePointerLeave(ActivationWorkerState& state,
     state.activeTaskbar = nullptr;
     state.activeTaskbarMonitor = nullptr;
     state.armed = true;
-    state.lastActivationCheck = 0;
     state.suppressionFailures = 0;
     ResetActivationCandidate(state);
 
@@ -2147,14 +2159,6 @@ bool HookTaskbarViewSymbols(HMODULE module) {
     WindhawkUtils::SYMBOL_HOOK symbolHooks[] = {
         {
             {
-                LR"(public: bool __cdecl winrt::Taskbar::implementation::ViewCoordinator::IsExpanded(unsigned __int64))",
-            },
-            &ViewCoordinator_IsExpanded_Original,
-            nullptr,
-            true,
-        },
-        {
-            {
                 LR"(public: void __cdecl winrt::Taskbar::implementation::ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged(unsigned __int64,bool,enum winrt::WindowsUdk::UI::Shell::InputDeviceKind))",
             },
             &ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original,
@@ -2174,7 +2178,7 @@ bool HookTaskbarViewSymbols(HMODULE module) {
                 LR"(public: void __cdecl winrt::Taskbar::implementation::ViewCoordinator::UpdateIsExpanded(unsigned __int64,enum TaskbarTipTest::TaskbarExpandCollapseReason))",
             },
             &ViewCoordinator_UpdateIsExpanded_Original,
-            ViewCoordinator_UpdateIsExpanded_Hook,
+            nullptr,
             true,
         },
     };
@@ -2184,6 +2188,13 @@ bool HookTaskbarViewSymbols(HMODULE module) {
             symbolHooks,
             ARRAYSIZE(symbolHooks))) {
         Wh_Log(L"Failed to hook Windows 11 ViewCoordinator symbols");
+        return false;
+    }
+
+    if (!ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original ||
+        !ViewCoordinator_UpdateIsExpanded_Original) {
+        Wh_Log(L"Taskbar reveal path unavailable: required ViewCoordinator "
+               L"symbols need updating");
         return false;
     }
 
@@ -2385,23 +2396,23 @@ BOOL Wh_ModInit() {
             std::memory_order_relaxed);
     } else {
         Wh_Log(L"Taskbar.View.dll/ExplorerExtensions.dll isn't loaded yet");
+
+        HMODULE kernelBaseModule =
+            GetModuleHandleW(L"kernelbase.dll");
+
+        auto loadLibraryExW = reinterpret_cast<decltype(&LoadLibraryExW)>(
+            GetProcAddress(kernelBaseModule, "LoadLibraryExW"));
+
+        if (!loadLibraryExW) {
+            Wh_Log(L"Couldn't find KernelBase!LoadLibraryExW");
+            return FALSE;
+        }
+
+        WindhawkUtils::SetFunctionHook(
+            loadLibraryExW,
+            LoadLibraryExW_Hook,
+            &LoadLibraryExW_Original);
     }
-
-    HMODULE kernelBaseModule =
-        GetModuleHandleW(L"kernelbase.dll");
-
-    auto loadLibraryExW = reinterpret_cast<decltype(&LoadLibraryExW)>(
-        GetProcAddress(kernelBaseModule, "LoadLibraryExW"));
-
-    if (!loadLibraryExW) {
-        Wh_Log(L"Couldn't find KernelBase!LoadLibraryExW");
-        return FALSE;
-    }
-
-    WindhawkUtils::SetFunctionHook(
-        loadLibraryExW,
-        LoadLibraryExW_Hook,
-        &LoadLibraryExW_Original);
 
     g_stopEvent =
         CreateEventW(nullptr, TRUE, FALSE, nullptr);

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/themagnificentoofman
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lshell32 -lshcore
+// @compilerOptions -lshell32 -lshcore -ldwmapi
 // @license         GPL-3.0
 // ==/WindhawkMod==
 
@@ -57,15 +57,15 @@ bottom of the screen.
 - Microsoft can rename undocumented taskbar symbols in a Windows update. If
   that happens, one or more reveal paths may stop working until the symbols are
   updated.
-- The taskbar's internal coordinator must have initialized before the first
-  threshold activation. If the first attempt does nothing immediately after
-  Explorer starts, leave and re-enter the activation band.
+- Until the taskbar's internal coordinator is captured, the optional native
+  timer fallback is used. Coordinator-owned reveals are used as soon as the
+  coordinator becomes available.
 
 ## Suggested starting values
 
-- Activation threshold: `42`
+- Activation threshold: `24`
 - Release delay: `120`
-- Activation cooldown: `250`
+- Activation cooldown: `200`
 
 ## Attribution and license
 
@@ -97,7 +97,7 @@ tuning** Windhawk mod by m417z. This mod is distributed under GPL-3.0.
     Only activate when Windows reports that taskbar auto-hide is enabled.
     Disable this when another mod manages auto-hide without enabling the
     Windows setting.
-- ignoreFullscreenApps: false
+- ignoreFullscreenApps: true
   $name: Ignore fullscreen apps
   $description: >-
     Don't reveal the taskbar over borderless or exclusive-fullscreen apps.
@@ -121,6 +121,7 @@ tuning** Windhawk mod by m417z. This mod is distributed under GPL-3.0.
 #include <windows.h>
 #include <shellapi.h>
 #include <shellscalingapi.h>
+#include <dwmapi.h>
 #include <windhawk_utils.h>
 
 #include <algorithm>
@@ -135,7 +136,7 @@ struct Settings {
     std::atomic<int> releaseDelayMs{120};
     std::atomic<int> activationCooldownMs{200};
     std::atomic<bool> requireWindowsAutoHide{true};
-    std::atomic<bool> ignoreFullscreenApps{false};
+    std::atomic<bool> ignoreFullscreenApps{true};
     std::atomic<bool> ignoreWhileMouseButtonDown{true};
     std::atomic<bool> primaryMonitorOnly{false};
     std::atomic<bool> nativeTimerFallback{true};
@@ -150,26 +151,20 @@ std::atomic<bool> g_cursorUpdatePosted{false};
 std::atomic<HWND> g_mainTaskbarWindow{nullptr};
 
 HANDLE g_stopEvent = nullptr;
-HANDLE g_workerReadyEvent = nullptr;
 HANDLE g_workerThread = nullptr;
 
-// A private message used to marshal operations from the cursor-event worker to
-// Explorer's taskbar UI thread.
-const UINT g_uiThreadMessage =
-    RegisterWindowMessageW(L"Windhawk_TaskbarActivationThreshold_" WH_MOD_ID);
-
-// Existing taskbar windows were created before this mod was injected. Sending
-// this message through their hooked WndProc captures the relevant `this`
-// pointers without restarting Explorer.
-const UINT g_captureTaskbarObjectMessage =
-    RegisterWindowMessageW(
-        L"Windhawk_TaskbarActivationThreshold_Capture_" WH_MOD_ID);
+// Registered in Wh_ModInit rather than during DLL initialization, avoiding
+// user32 calls while the loader lock is held.
+UINT g_uiThreadMessage = 0;
+UINT g_captureTaskbarObjectMessage = 0;
+UINT g_queryTaskbarRectMessage = 0;
 
 enum UiOperation : WPARAM {
     kUiRevealTaskbar = 1,
     kUiClearSyntheticPointerOver = 2,
     kUiClearAllSyntheticPointerOver = 3,
     kUiTriggerNativeUnhideTimer = 4,
+    kUiCancelNativeUnhideTimer = 5,
 };
 
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
@@ -177,6 +172,12 @@ constexpr UINT kWorkerSettingsChangedMessage = WM_APP + 2;
 constexpr UINT_PTR kWorkerReleaseTimer = 1;
 constexpr UINT_PTR kWorkerRetryTimer = 2;
 constexpr UINT_PTR kWorkerFallbackPollTimer = 3;
+constexpr UINT_PTR kWorkerNativeTimerCleanupTimer = 4;
+
+constexpr UINT kReleaseRetryMs = 250;
+constexpr UINT kFallbackStatusPollMs = 250;
+constexpr UINT kNativeTimerCleanupMs = 250;
+constexpr UINT kSuppressionBackoffMaxMs = 5000;
 
 // These containers are used by taskbar implementation callbacks and by
 // operations marshalled to the taskbar UI thread. This matches the threading
@@ -185,6 +186,10 @@ std::unordered_map<HWND, void*> g_trayUiWndProcObjects;
 std::unordered_map<HWND, void*> g_secondaryTrayObjects;
 std::unordered_map<HWND, void*> g_viewCoordinators;
 std::unordered_set<HWND> g_syntheticPointerOverTaskbars;
+
+// Set only while this mod is applying its reason-7 synthetic enter update on
+// the taskbar UI thread. This keeps ShouldTaskbarBeExpanded narrowly scoped.
+bool g_syntheticExpansionUpdateInProgress = false;
 
 void* g_trayUiVtableITrayComponentHost = nullptr;
 
@@ -269,13 +274,44 @@ HWND FindMainTaskbarWindow() {
 
     g_mainTaskbarWindow.store(nullptr, std::memory_order_relaxed);
 
-    HWND taskbarWindow = FindWindowW(L"Shell_TrayWnd", nullptr);
-    if (!IsMainTaskbarWindow(taskbarWindow)) {
-        return nullptr;
+    HWND taskbarWindow = nullptr;
+    EnumWindows(
+        [](HWND window, LPARAM parameter) -> BOOL {
+            if (IsMainTaskbarWindow(window)) {
+                *reinterpret_cast<HWND*>(parameter) = window;
+                return FALSE;
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&taskbarWindow));
+
+    if (taskbarWindow) {
+        g_mainTaskbarWindow.store(taskbarWindow, std::memory_order_relaxed);
+    }
+    return taskbarWindow;
+}
+
+bool GetTaskbarStuckRectForMonitor(HMONITOR monitor, RECT* rect) {
+    if (!monitor || !rect || !g_queryTaskbarRectMessage) {
+        return false;
     }
 
-    g_mainTaskbarWindow.store(taskbarWindow, std::memory_order_relaxed);
-    return taskbarWindow;
+    HWND taskbarWindow = FindMainTaskbarWindow();
+    if (!taskbarWindow) {
+        return false;
+    }
+
+    SetRectEmpty(rect);
+    DWORD_PTR result = 0;
+    return SendMessageTimeoutW(
+               taskbarWindow,
+               g_queryTaskbarRectMessage,
+               reinterpret_cast<WPARAM>(monitor),
+               reinterpret_cast<LPARAM>(rect),
+               SMTO_ABORTIFHUNG | SMTO_BLOCK,
+               250,
+               &result) &&
+           result != 0 && !IsRectEmpty(rect);
 }
 
 HWND GetTaskBandWindow() {
@@ -297,15 +333,39 @@ HMONITOR GetTaskbarMonitor(HWND taskbarWindow) {
     return MonitorFromWindow(taskbarWindow, MONITOR_DEFAULTTONEAREST);
 }
 
-bool IsBottomPositionedTaskbar(HWND taskbarWindow, HMONITOR monitor) {
-    RECT taskbarRect{};
-    if (!GetWindowRect(taskbarWindow, &taskbarRect)) {
-        return false;
-    }
+bool IsBottomDockedRect(const RECT& taskbarRect,
+                        const MONITORINFO& monitorInfo) {
+    const int monitorWidth =
+        monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left;
+    const int monitorHeight =
+        monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top;
+    const int taskbarWidth = taskbarRect.right - taskbarRect.left;
+    const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
 
+    const bool looksHorizontal =
+        taskbarWidth >= monitorWidth / 2 && taskbarHeight > 0 &&
+        taskbarHeight <= monitorHeight / 2;
+    return looksHorizontal &&
+           std::abs(taskbarRect.bottom - monitorInfo.rcMonitor.bottom) <= 2;
+}
+
+bool IsBottomPositionedTaskbar(HWND taskbarWindow, HMONITOR monitor) {
     MONITORINFO monitorInfo{};
     monitorInfo.cbSize = sizeof(monitorInfo);
     if (!GetMonitorInfoW(monitor, &monitorInfo)) {
+        return false;
+    }
+
+    // Prefer Explorer's own docked rectangle. Unlike the live window geometry,
+    // this identifies the configured edge even while the taskbar is hidden.
+    RECT stuckRect{};
+    if (GetTaskbarStuckRectForMonitor(monitor, &stuckRect)) {
+        return IsBottomDockedRect(stuckRect, monitorInfo);
+    }
+
+    // Fallback for Windows builds where the optional symbol is unavailable.
+    RECT taskbarRect{};
+    if (!GetWindowRect(taskbarWindow, &taskbarRect)) {
         return false;
     }
 
@@ -315,30 +375,20 @@ bool IsBottomPositionedTaskbar(HWND taskbarWindow, HMONITOR monitor) {
         monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top;
     const int taskbarWidth = taskbarRect.right - taskbarRect.left;
     const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
-
-    // Reject vertical and detached taskbar windows. Visual "floating taskbar"
-    // styles normally retain a full-width Shell_TrayWnd and remain compatible.
     const bool looksHorizontal =
-        taskbarWidth >= monitorWidth / 2 &&
-        taskbarHeight > 0 &&
+        taskbarWidth >= monitorWidth / 2 && taskbarHeight > 0 &&
         taskbarHeight <= monitorHeight / 2;
-
     if (!looksHorizontal) {
         return false;
     }
 
     const int tolerance = std::max(16, taskbarHeight + 16);
-
-    // Handles both the visible and auto-hidden window positions.
-    const bool nearBottom =
-        std::abs(taskbarRect.bottom - monitorInfo.rcMonitor.bottom) <=
-            tolerance ||
-        std::abs(taskbarRect.top - monitorInfo.rcMonitor.bottom) <=
-            tolerance ||
-        (taskbarRect.top < monitorInfo.rcMonitor.bottom &&
-         taskbarRect.bottom >= monitorInfo.rcMonitor.bottom - 2);
-
-    return nearBottom;
+    return std::abs(taskbarRect.bottom - monitorInfo.rcMonitor.bottom) <=
+               tolerance ||
+           std::abs(taskbarRect.top - monitorInfo.rcMonitor.bottom) <=
+               tolerance ||
+           (taskbarRect.top < monitorInfo.rcMonitor.bottom &&
+            taskbarRect.bottom >= monitorInfo.rcMonitor.bottom - 2);
 }
 
 struct FindTaskbarContext {
@@ -428,31 +478,32 @@ bool IsDesktopWindow(HWND window) {
            _wcsicmp(className, L"WorkerW") == 0;
 }
 
-bool IsFullscreenWindowOnMonitor(HMONITOR monitor) {
-    HWND foregroundWindow = GetForegroundWindow();
+bool IsWindowCloaked(HWND window) {
+    BOOL cloaked = FALSE;
+    return SUCCEEDED(DwmGetWindowAttribute(
+               window, DWMWA_CLOAKED, &cloaked, sizeof(cloaked))) &&
+           cloaked;
+}
 
-    if (!foregroundWindow || IsIconic(foregroundWindow) ||
-        IsDesktopWindow(foregroundWindow)) {
+bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
+    if (!window || !IsWindowVisible(window) || IsIconic(window) ||
+        IsDesktopWindow(window) || IsTaskbarClass(window) ||
+        IsWindowCloaked(window)) {
         return false;
     }
 
-    if (MonitorFromWindow(foregroundWindow, MONITOR_DEFAULTTONEAREST) !=
-        monitor) {
-        return false;
-    }
-
-    const LONG_PTR style =
-        GetWindowLongPtrW(foregroundWindow, GWL_STYLE);
-
-    // A regular maximized desktop window normally retains caption/frame
-    // styles. Borderless and exclusive-fullscreen windows normally don't.
+    const LONG_PTR style = GetWindowLongPtrW(window, GWL_STYLE);
     if ((style & WS_CHILD) != 0 ||
         (style & (WS_CAPTION | WS_THICKFRAME)) != 0) {
         return false;
     }
 
+    if (MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST) != monitor) {
+        return false;
+    }
+
     RECT windowRect{};
-    if (!GetWindowRect(foregroundWindow, &windowRect)) {
+    if (!GetWindowRect(window, &windowRect)) {
         return false;
     }
 
@@ -463,11 +514,30 @@ bool IsFullscreenWindowOnMonitor(HMONITOR monitor) {
     }
 
     constexpr int tolerance = 2;
-
     return windowRect.left <= monitorInfo.rcMonitor.left + tolerance &&
            windowRect.top <= monitorInfo.rcMonitor.top + tolerance &&
            windowRect.right >= monitorInfo.rcMonitor.right - tolerance &&
            windowRect.bottom >= monitorInfo.rcMonitor.bottom - tolerance;
+}
+
+bool IsFullscreenWindowOnMonitor(HMONITOR monitor) {
+    struct Context {
+        HMONITOR monitor;
+        bool found;
+    } context{monitor, false};
+
+    EnumWindows(
+        [](HWND window, LPARAM parameter) -> BOOL {
+            auto* context = reinterpret_cast<Context*>(parameter);
+            if (IsFullscreenCandidateOnMonitor(window, context->monitor)) {
+                context->found = true;
+                return FALSE;
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&context));
+
+    return context.found;
 }
 
 bool IsPointInsideActivationBand(const POINT& pointer,
@@ -497,6 +567,24 @@ bool IsPointOverTaskbar(HWND taskbarWindow, const POINT& pointer) {
     RECT taskbarRect{};
     return GetWindowRect(taskbarWindow, &taskbarRect) &&
            PtInRect(&taskbarRect, pointer);
+}
+
+bool IsTaskbarVisiblyRevealed(HWND taskbarWindow, HMONITOR monitor) {
+    RECT taskbarRect{};
+    MONITORINFO monitorInfo{};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if (!GetWindowRect(taskbarWindow, &taskbarRect) ||
+        !GetMonitorInfoW(monitor, &monitorInfo)) {
+        return false;
+    }
+
+    RECT intersection{};
+    if (!IntersectRect(&intersection, &taskbarRect, &monitorInfo.rcMonitor)) {
+        return false;
+    }
+
+    // An auto-hidden taskbar normally leaves only a one-pixel edge onscreen.
+    return intersection.bottom - intersection.top > 2;
 }
 
 
@@ -534,6 +622,10 @@ using CSecondaryTray_Unhide_t =
 
 CSecondaryTray_Unhide_t CSecondaryTray_Unhide_Original;
 
+using TrayUI_GetStuckRectForMonitor_t =
+    bool(WINAPI*)(void* trayUi, HMONITOR monitor, RECT* rect);
+TrayUI_GetStuckRectForMonitor_t TrayUI_GetStuckRectForMonitor_Original;
+
 using TrayUI_WndProc_t =
     LRESULT(WINAPI*)(void* trayUi,
                      HWND window,
@@ -551,6 +643,23 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
     WPARAM wParam,
     LPARAM lParam,
     bool* handled) {
+    if (message == g_queryTaskbarRectMessage) {
+        RECT* rect = reinterpret_cast<RECT*>(lParam);
+        const HMONITOR monitor = reinterpret_cast<HMONITOR>(wParam);
+        bool succeeded = false;
+        if (rect && monitor && TrayUI_GetStuckRectForMonitor_Original) {
+            succeeded = TrayUI_GetStuckRectForMonitor_Original(
+                trayUi, monitor, rect);
+        }
+        if (!succeeded && rect) {
+            SetRectEmpty(rect);
+        }
+        if (handled) {
+            *handled = true;
+        }
+        return succeeded ? 1 : 0;
+    }
+
     if (message == WM_NCCREATE) {
         g_trayUiWndProcObjects[window] = trayUi;
         g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
@@ -685,10 +794,6 @@ void RememberViewCoordinator(HWND taskbarWindow, void* viewCoordinator) {
     g_viewCoordinators[taskbarWindow] = viewCoordinator;
 }
 
-void ForgetInvalidViewCoordinator(HWND taskbarWindow) {
-    ForgetTaskbarState(taskbarWindow);
-}
-
 void* GetViewCoordinator(HWND taskbarWindow) {
     auto it = g_viewCoordinators.find(taskbarWindow);
     return it != g_viewCoordinators.end() ? it->second : nullptr;
@@ -750,7 +855,8 @@ bool WINAPI ViewCoordinator_ShouldTaskbarBeExpanded_Hook(
     // 11 build when the physical pointer remains above the real one-pixel
     // taskbar frame. While this mod owns the synthetic pointer-over state,
     // explicitly authorize expansion in the coordinator's decision function.
-    if (g_syntheticPointerOverTaskbars.contains(taskbarWindow)) {
+    if (g_syntheticExpansionUpdateInProgress &&
+        g_syntheticPointerOverTaskbars.contains(taskbarWindow)) {
         Wh_Log(L"ShouldTaskbarBeExpanded: forcing true for taskbar %p "
                L"(requested=%d)",
                taskbarWindow,
@@ -803,7 +909,7 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
         !ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original ||
         !ViewCoordinator_UpdateIsExpanded_Original) {
         if (taskbarWindow && !IsWindow(taskbarWindow)) {
-            ForgetInvalidViewCoordinator(taskbarWindow);
+            ForgetTaskbarState(taskbarWindow);
         }
         return false;
     }
@@ -826,6 +932,7 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
         Wh_Log(L"Setting synthetic pointer-over for taskbar %p",
                taskbarWindow);
 
+        g_syntheticExpansionUpdateInProgress = true;
         ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
             viewCoordinator,
             taskbarWindow,
@@ -836,6 +943,7 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
             viewCoordinator,
             taskbarWindow,
             kReasonIsPointerOverTaskbarFrameChanged);
+        g_syntheticExpansionUpdateInProgress = false;
 
         bool expanded = false;
         if (ViewCoordinator_IsExpanded_Original) {
@@ -908,7 +1016,9 @@ bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
            shellWindowRevealed,
            coordinatorExpanded);
 
-    return shellWindowRevealed || coordinatorExpanded;
+    // The legacy Unhide path alone has no matching hide trigger on Windows 11,
+    // so only the coordinator path counts as a reveal owned by this mod.
+    return coordinatorExpanded;
 }
 
 void ClearAllSyntheticPointerOverOnUiThread() {
@@ -936,11 +1046,19 @@ CTaskBand_v_WndProc_t CTaskBand_v_WndProc_Original;
 
 constexpr UINT_PTR kTrayUITimerUnhide = 3;
 
+bool CancelNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
+    return taskbarWindow && IsWindow(taskbarWindow) &&
+           KillTimer(taskbarWindow, kTrayUITimerUnhide);
+}
+
 bool TriggerNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
     if (!taskbarWindow || !IsWindow(taskbarWindow)) {
         return false;
     }
 
+    // Avoid carrying over a stale repeating timer if Explorer changed how it
+    // handles timer ID 3, then arm the established native unhide timer.
+    KillTimer(taskbarWindow, kTrayUITimerUnhide);
     UINT_PTR timerResult =
         SetTimer(taskbarWindow, kTrayUITimerUnhide, 1, nullptr);
 
@@ -987,6 +1105,11 @@ LRESULT WINAPI CTaskBand_v_WndProc_Hook(
                 return TriggerNativeUnhideTimerOnUiThread(targetTaskbar)
                            ? 1
                            : 0;
+
+            case kUiCancelNativeUnhideTimer:
+                return CancelNativeUnhideTimerOnUiThread(targetTaskbar)
+                           ? 1
+                           : 0;
         }
 
         return 0;
@@ -1029,10 +1152,15 @@ bool SendUiOperation(UiOperation operation,
 struct ActivationWorkerState {
     HWND activeTaskbar = nullptr;
     HMONITOR activeTaskbarMonitor = nullptr;
+    HWND fallbackTaskbar = nullptr;
+    HMONITOR fallbackTaskbarMonitor = nullptr;
     bool armed = true;
     UINT_PTR releaseTimerId = 0;
     UINT_PTR retryTimerId = 0;
+    UINT_PTR nativeTimerCleanupTimerId = 0;
+    bool releaseRetryPending = false;
     ULONGLONG lastActivationCheck = 0;
+    unsigned suppressionFailures = 0;
 };
 
 void CancelWorkerTimer(UINT_PTR& timerId) {
@@ -1062,16 +1190,46 @@ void ScheduleWorkerTimer(UINT_PTR requestedTimerId,
     }
 }
 
-void ClearActiveTaskbar(ActivationWorkerState& state) {
+bool ClearActiveTaskbar(ActivationWorkerState& state,
+                        DWORD timeoutMs = 250,
+                        bool scheduleRetry = true) {
     CancelWorkerTimer(state.releaseTimerId);
 
-    if (state.activeTaskbar) {
-        SendUiOperation(kUiClearSyntheticPointerOver,
-                        state.activeTaskbar);
+    if (state.activeTaskbar && IsWindow(state.activeTaskbar) &&
+        !SendUiOperation(kUiClearSyntheticPointerOver,
+                         state.activeTaskbar,
+                         timeoutMs)) {
+        // Keep ownership and retry instead of forgetting synthetic state that
+        // may still force Explorer's coordinator to remain expanded.
+        if (scheduleRetry) {
+            state.releaseRetryPending = true;
+            ScheduleWorkerTimer(kWorkerReleaseTimer,
+                                kReleaseRetryMs,
+                                state.releaseTimerId);
+        }
+        return false;
     }
 
+    state.releaseRetryPending = false;
     state.activeTaskbar = nullptr;
     state.activeTaskbarMonitor = nullptr;
+    state.armed = true;
+    return true;
+}
+
+void CancelFallbackNativeTimer(ActivationWorkerState& state) {
+    CancelWorkerTimer(state.nativeTimerCleanupTimerId);
+    if (state.fallbackTaskbar && IsWindow(state.fallbackTaskbar)) {
+        SendUiOperation(kUiCancelNativeUnhideTimer,
+                        state.fallbackTaskbar,
+                        500);
+    }
+}
+
+void ClearFallbackTaskbar(ActivationWorkerState& state) {
+    CancelFallbackNativeTimer(state);
+    state.fallbackTaskbar = nullptr;
+    state.fallbackTaskbarMonitor = nullptr;
     state.armed = true;
 }
 
@@ -1081,11 +1239,29 @@ void ScheduleRetry(ActivationWorkerState& state, UINT delayMs) {
                         state.retryTimerId);
 }
 
+UINT GetSuppressionRetryDelay(ActivationWorkerState& state,
+                              int cooldownMs) {
+    state.suppressionFailures =
+        std::min(state.suppressionFailures + 1, 8U);
+    const UINT base = static_cast<UINT>(std::max(cooldownMs, 200));
+    const unsigned shift = std::min(state.suppressionFailures - 1, 4U);
+    return std::min(base << shift, kSuppressionBackoffMaxMs);
+}
+
+void ScheduleSuppressedRetry(ActivationWorkerState& state,
+                             int cooldownMs) {
+    ScheduleRetry(state, GetSuppressionRetryDelay(state, cooldownMs));
+}
+
 void ProcessPointerState(ActivationWorkerState& state) {
     if (g_settingsChanged.exchange(false, std::memory_order_relaxed)) {
         CancelWorkerTimer(state.retryTimerId);
-        ClearActiveTaskbar(state);
+        if (!ClearActiveTaskbar(state)) {
+            return;
+        }
+        ClearFallbackTaskbar(state);
         state.lastActivationCheck = 0;
+        state.suppressionFailures = 0;
     }
 
     POINT pointer{};
@@ -1095,10 +1271,13 @@ void ProcessPointerState(ActivationWorkerState& state) {
 
     HMONITOR pointerMonitor =
         MonitorFromPoint(pointer, MONITOR_DEFAULTTONULL);
-
     if (!pointerMonitor) {
-        ClearActiveTaskbar(state);
+        if (!ClearActiveTaskbar(state)) {
+            return;
+        }
+        ClearFallbackTaskbar(state);
         CancelWorkerTimer(state.retryTimerId);
+        state.suppressionFailures = 0;
         return;
     }
 
@@ -1111,9 +1290,34 @@ void ProcessPointerState(ActivationWorkerState& state) {
     const bool insideActivationBand =
         IsPointInsideActivationBand(pointer, pointerMonitor, monitorInfo);
 
+    if (state.fallbackTaskbar) {
+        const bool sameMonitor =
+            pointerMonitor == state.fallbackTaskbarMonitor;
+        if (!IsWindow(state.fallbackTaskbar) || !insideActivationBand ||
+            !sameMonitor) {
+            ClearFallbackTaskbar(state);
+            CancelWorkerTimer(state.retryTimerId);
+        } else if (IsTaskbarVisiblyRevealed(state.fallbackTaskbar,
+                                            state.fallbackTaskbarMonitor)) {
+            // Explorer owns the fallback reveal and its matching hide. Poll at
+            // a low rate only while the pointer remains in the activation band;
+            // once Explorer hides it again, rearm without requiring a leave.
+            ScheduleRetry(state, kFallbackStatusPollMs);
+            return;
+        } else {
+            ClearFallbackTaskbar(state);
+            CancelWorkerTimer(state.retryTimerId);
+        }
+    }
+
     if (state.activeTaskbar) {
-        if (!IsWindow(state.activeTaskbar)) {
+        if (state.releaseRetryPending) {
+            if (!ClearActiveTaskbar(state)) {
+                return;
+            }
+        } else if (!IsWindow(state.activeTaskbar)) {
             CancelWorkerTimer(state.releaseTimerId);
+            state.releaseRetryPending = false;
             state.activeTaskbar = nullptr;
             state.activeTaskbarMonitor = nullptr;
             state.armed = true;
@@ -1131,10 +1335,12 @@ void ProcessPointerState(ActivationWorkerState& state) {
             const int releaseDelay =
                 g_settings.releaseDelayMs.load(
                     std::memory_order_relaxed);
-
             if (releaseDelay == 0) {
-                ClearActiveTaskbar(state);
+                if (!ClearActiveTaskbar(state)) {
+                    return;
+                }
             } else {
+                state.releaseRetryPending = false;
                 ScheduleWorkerTimer(
                     kWorkerReleaseTimer,
                     static_cast<UINT>(releaseDelay),
@@ -1146,6 +1352,7 @@ void ProcessPointerState(ActivationWorkerState& state) {
 
     if (!insideActivationBand) {
         state.armed = true;
+        state.suppressionFailures = 0;
         CancelWorkerTimer(state.retryTimerId);
         return;
     }
@@ -1155,14 +1362,11 @@ void ProcessPointerState(ActivationWorkerState& state) {
         return;
     }
 
-    // Throttle the entire activation decision, including shell, mouse-button,
-    // and fullscreen suppression checks.
     const ULONGLONG now = GetTickCount64();
     const int cooldown =
         g_settings.activationCooldownMs.load(
             std::memory_order_relaxed);
     const ULONGLONG elapsed = now - state.lastActivationCheck;
-
     if (elapsed < static_cast<ULONGLONG>(cooldown)) {
         ScheduleRetry(
             state,
@@ -1182,20 +1386,21 @@ void ProcessPointerState(ActivationWorkerState& state) {
     if (g_settings.primaryMonitorOnly.load(
             std::memory_order_relaxed) &&
         (monitorInfo.dwFlags & MONITORINFOF_PRIMARY) == 0) {
+        ScheduleSuppressedRetry(state, cooldown);
         return;
     }
 
     if (g_settings.requireWindowsAutoHide.load(
             std::memory_order_relaxed) &&
         !IsWindowsAutoHideEnabled()) {
-        ScheduleRetry(state, static_cast<UINT>(std::max(cooldown, 1)));
+        ScheduleSuppressedRetry(state, cooldown);
         return;
     }
 
     if (g_settings.ignoreWhileMouseButtonDown.load(
             std::memory_order_relaxed) &&
         IsAnyMouseButtonDown()) {
-        ScheduleRetry(state, static_cast<UINT>(std::max(cooldown, 1)));
+        ScheduleSuppressedRetry(state, cooldown);
         return;
     }
 
@@ -1203,20 +1408,23 @@ void ProcessPointerState(ActivationWorkerState& state) {
             std::memory_order_relaxed) &&
         IsFullscreenWindowOnMonitor(pointerMonitor)) {
         Wh_Log(L"Activation suppressed: fullscreen app detected");
-        ScheduleRetry(state, static_cast<UINT>(std::max(cooldown, 1)));
+        ScheduleSuppressedRetry(state, cooldown);
         return;
     }
 
     HWND taskbarWindow = FindTaskbarForMonitor(pointerMonitor);
     if (!taskbarWindow) {
         Wh_Log(L"Activation suppressed: no bottom taskbar found");
-        ScheduleRetry(state, static_cast<UINT>(std::max(cooldown, 1)));
+        ScheduleSuppressedRetry(state, cooldown);
         return;
     }
+
+    state.suppressionFailures = 0;
 
     if (SendUiOperation(kUiRevealTaskbar, taskbarWindow)) {
         Wh_Log(L"Activated taskbar %p through native shell/coordinator path",
                taskbarWindow);
+        ClearFallbackTaskbar(state);
         state.activeTaskbar = taskbarWindow;
         state.activeTaskbarMonitor = pointerMonitor;
         state.armed = false;
@@ -1229,20 +1437,32 @@ void ProcessPointerState(ActivationWorkerState& state) {
         Wh_Log(L"Activated taskbar %p through native timer fallback",
                taskbarWindow);
 
-        // No synthetic pointer-over state was created, so Windows owns normal
-        // hide behavior. Rearm only after the pointer leaves the band.
+        state.fallbackTaskbar = taskbarWindow;
+        state.fallbackTaskbarMonitor = pointerMonitor;
         state.armed = false;
+        ScheduleWorkerTimer(kWorkerNativeTimerCleanupTimer,
+                            kNativeTimerCleanupMs,
+                            state.nativeTimerCleanupTimerId);
+        ScheduleRetry(state, kFallbackStatusPollMs);
         return;
     }
 
     Wh_Log(L"Threshold entered, but no reveal backend succeeded");
-    ScheduleRetry(state, static_cast<UINT>(std::max(cooldown, 1)));
+    ScheduleSuppressedRetry(state, cooldown);
 }
 
 void HandleReleaseTimer(ActivationWorkerState& state) {
     CancelWorkerTimer(state.releaseTimerId);
 
     if (!state.activeTaskbar) {
+        return;
+    }
+
+    if (state.releaseRetryPending) {
+        if (!ClearActiveTaskbar(state)) {
+            return;
+        }
+        ProcessPointerState(state);
         return;
     }
 
@@ -1276,7 +1496,9 @@ void HandleReleaseTimer(ActivationWorkerState& state) {
         return;
     }
 
-    ClearActiveTaskbar(state);
+    if (!ClearActiveTaskbar(state)) {
+        return;
+    }
     ProcessPointerState(state);
 }
 
@@ -1330,10 +1552,6 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
             SetTimer(nullptr, kWorkerFallbackPollTimer, 50, nullptr);
     }
 
-    if (g_workerReadyEvent) {
-        SetEvent(g_workerReadyEvent);
-    }
-
     ActivationWorkerState state;
     ProcessPointerState(state);
 
@@ -1380,6 +1598,17 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
                                message.wParam == state.retryTimerId) {
                         CancelWorkerTimer(state.retryTimerId);
                         ProcessPointerState(state);
+                    } else if (state.nativeTimerCleanupTimerId &&
+                               message.wParam ==
+                                   state.nativeTimerCleanupTimerId) {
+                        CancelWorkerTimer(
+                            state.nativeTimerCleanupTimerId);
+                        if (state.fallbackTaskbar &&
+                            IsWindow(state.fallbackTaskbar)) {
+                            SendUiOperation(kUiCancelNativeUnhideTimer,
+                                            state.fallbackTaskbar,
+                                            500);
+                        }
                     } else if (fallbackPollTimerId &&
                                message.wParam == fallbackPollTimerId) {
                         ProcessPointerState(state);
@@ -1394,9 +1623,16 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
         }
     }
 
-    CancelWorkerTimer(state.releaseTimerId);
     CancelWorkerTimer(state.retryTimerId);
-    ClearActiveTaskbar(state);
+    CancelWorkerTimer(state.nativeTimerCleanupTimerId);
+    ClearFallbackTaskbar(state);
+
+    for (int attempt = 0; state.activeTaskbar && attempt < 3; attempt++) {
+        if (ClearActiveTaskbar(state, 1000, false)) {
+            break;
+        }
+        Sleep(50);
+    }
 
     if (cursorHook) {
         UnhookWinEvent(cursorHook);
@@ -1475,6 +1711,14 @@ bool HookTaskbarUiThreadSymbol() {
                 LR"(const TrayUI::`vftable'{for `ITrayComponentHost'})",
             },
             &g_trayUiVtableITrayComponentHost,
+            nullptr,
+            true,
+        },
+        {
+            {
+                LR"(public: virtual bool __cdecl TrayUI::GetStuckRectForMonitor(struct HMONITOR__ *,struct tagRECT *))",
+            },
+            &TrayUI_GetStuckRectForMonitor_Original,
             nullptr,
             true,
         },
@@ -1585,8 +1829,6 @@ void HandleLoadedTaskbarViewModule(HMODULE module,
 
     if (HookTaskbarViewSymbols(module)) {
         Wh_ApplyHookOperations();
-    } else {
-        g_taskbarViewDllLoaded.store(false, std::memory_order_relaxed);
     }
 }
 
@@ -1599,7 +1841,7 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR libraryFileName,
     HMODULE module =
         LoadLibraryExW_Original(libraryFileName, file, flags);
 
-    if (module) {
+    if (module && !((ULONG_PTR)module & 3)) {
         HandleLoadedTaskbarViewModule(module, libraryFileName);
     }
 
@@ -1609,10 +1851,19 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR libraryFileName,
 BOOL Wh_ModInit() {
     Wh_Log(L"Initializing");
 
-    if (!g_uiThreadMessage || !g_captureTaskbarObjectMessage) {
-        Wh_Log(L"RegisterWindowMessageW failed: ui=%u capture=%u",
+    g_uiThreadMessage =
+        RegisterWindowMessageW(L"taskbar-activation-threshold.ui");
+    g_captureTaskbarObjectMessage =
+        RegisterWindowMessageW(L"taskbar-activation-threshold.capture");
+    g_queryTaskbarRectMessage =
+        RegisterWindowMessageW(L"taskbar-activation-threshold.stuck-rect");
+
+    if (!g_uiThreadMessage || !g_captureTaskbarObjectMessage ||
+        !g_queryTaskbarRectMessage) {
+        Wh_Log(L"RegisterWindowMessageW failed: ui=%u capture=%u rect=%u",
                g_uiThreadMessage,
-               g_captureTaskbarObjectMessage);
+               g_captureTaskbarObjectMessage,
+               g_queryTaskbarRectMessage);
         return FALSE;
     }
 
@@ -1653,10 +1904,8 @@ BOOL Wh_ModInit() {
 
     g_stopEvent =
         CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    g_workerReadyEvent =
-        CreateEventW(nullptr, TRUE, FALSE, nullptr);
 
-    if (!g_stopEvent || !g_workerReadyEvent) {
+    if (!g_stopEvent) {
         Wh_Log(L"CreateEvent failed: %u", GetLastError());
         return FALSE;
     }
@@ -1681,10 +1930,6 @@ void Wh_ModAfterInit() {
 
                 if (HookTaskbarViewSymbols(taskbarViewModule)) {
                     Wh_ApplyHookOperations();
-                } else {
-                    g_taskbarViewDllLoaded.store(
-                        false,
-                        std::memory_order_relaxed);
                 }
             }
         }
@@ -1703,10 +1948,6 @@ void Wh_ModAfterInit() {
         return;
     }
 
-    if (g_workerReadyEvent &&
-        WaitForSingleObject(g_workerReadyEvent, 2000) != WAIT_OBJECT_0) {
-        Wh_Log(L"Activation worker didn't signal readiness");
-    }
 }
 
 void Wh_ModBeforeUninit() {
@@ -1743,10 +1984,6 @@ void Wh_ModUninit() {
         g_stopEvent = nullptr;
     }
 
-    if (g_workerReadyEvent) {
-        CloseHandle(g_workerReadyEvent);
-        g_workerReadyEvent = nullptr;
-    }
 
     g_viewCoordinators.clear();
     g_trayUiWndProcObjects.clear();

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -19,8 +19,8 @@ Reveal the auto-hidden Windows 11 taskbar from a configurable activation band
 above the bottom edge of the screen.
 
 Unlike approaches that move or inject the pointer, this mod keeps the cursor
-stationary and invokes Explorer's native taskbar reveal logic on the taskbar UI
-thread.
+stationary and invokes Explorer's native Windows 11 taskbar pointer-over path
+on the taskbar UI thread.
 
 The activation threshold is scaled independently for each monitor's DPI.
 Cursor movement is detected through Windows accessibility events rather than
@@ -34,13 +34,13 @@ continuous polling, minimizing background activity while the pointer is idle.
 
 - Configurable activation-band height and hover delay
 - Per-monitor DPI scaling
-- Multi-monitor support
+- Multi-monitor and secondary-taskbar support
 - Adjustable release delay and activation cooldown
 - Optional suppression over fullscreen applications and presentation mode
 - Optional suppression while a mouse button is held
 - Optional restriction to the primary monitor
-- Best-effort native timer fallback while the taskbar coordinator is unavailable
-- No cursor movement, pointer injection, or taskbar layout modification
+- No cursor movement, pointer injection, taskbar layout modification, or
+  Explorer timer manipulation
 
 ## Compatibility
 
@@ -52,16 +52,11 @@ The mod does not modify:
 - Animation duration
 - Transparency
 - Windows' auto-hide setting
+- Taskbar Z-order
 
-When needed, the mod can bring a normal-band taskbar in front of an ordinary
-normal-band window without activating it. It never promotes the taskbar into
-the topmost band or reorders it above an always-on-top window. Mods that
-intentionally keep the taskbar behind other normal windows can conflict with
-this narrowly scoped Z-order correction.
-
-The mod is designed to coexist with taskbar styling, sizing, transparency,
-animation, clock, label, and icon mods that retain the standard
-bottom-positioned Windows 11 taskbar and don't replace its reveal logic.
+It is designed to coexist with taskbar styling, sizing, transparency,
+animation, clock, label, icon, and Z-order mods that retain the standard
+Windows 11 taskbar and don't replace its native reveal logic.
 
 ## Requirements
 
@@ -77,48 +72,34 @@ bottom-positioned Windows 11 taskbar and don't replace its reveal logic.
   supported.
 - ExplorerPatcher's legacy Windows 10 taskbar is not supported.
 - Mods that disable, replace, or override the taskbar's native expansion logic
-  may conflict with this mod. Keyboard-only and never-show auto-hide modes are
+  can conflict with this mod. Keyboard-only and never-show auto-hide modes are
   intentionally incompatible with mouse activation.
-- The primary reveal path depends on undocumented Windows 11 taskbar symbols.
-  If a Windows update renames either required coordinator method, the mod logs
-  that the reveal path is unavailable and needs a symbol update.
-- Shortly after Explorer starts, the internal Windows 11 taskbar coordinator
-  may not yet have been captured. The optional native timer fallback is tried
-  once per activation-band entry, while coordinator activation continues to
-  retry with backoff until the coordinator becomes available.
-- The native timer fallback uses Explorer's internal taskbar-unhide timer. A
-  mod that intercepts or replaces that timer can block the fallback, and
-  arming it can reset an already pending native unhide timer. This affects only
-  the brief pre-coordinator fallback path; normal coordinator activation is
-  independent of the timer.
-- Mods that deliberately control the taskbar's normal-window Z-order can
-  conflict with the correction used when an ordinary window covers a revealed
-  taskbar. The correction never crosses into the topmost window band. Stock
-  topmost taskbars bypass the coverage scan and aren't reordered.
+- Reveal depends on the undocumented Windows 11
+  `ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged` method. If a
+  Windows update renames or changes it, the mod will log that the coordinator
+  reveal path is unavailable and will need a symbol update.
+- Shortly after Explorer starts, the internal taskbar coordinator may not yet
+  have been observed by the mod. Activation retries with bounded backoff while
+  the pointer remains in the band and begins working as soon as Explorer emits
+  a coordinator pointer-over transition.
 - Fullscreen suppression ignores click-through, tool, non-activating, cloaked,
   desktop, and taskbar windows. It is intentionally conservative otherwise: a
-  qualifying fullscreen window anywhere above the desktop on the target monitor
-  can suppress activation even when another app has focus. A borderless custom-
-  chrome app that covers the monitor can therefore be treated as fullscreen.
-
-## Suggested settings
-
-- Activation threshold: `24`
-- Hover delay: `75`
-- Release delay: `120`
-- Activation cooldown: `200`
-
-These defaults provide a noticeably larger activation area while retaining
-responsive reveal and hide behavior. The short hover delay prevents accidental
-reveals while crossing the bottom edge of an upper monitor in a vertically
-stacked layout. Increase the activation threshold for easier access, or reduce
-it to more closely match the standard Windows edge trigger.
+  qualifying fullscreen window anywhere above the desktop on the target
+  monitor can suppress activation even when another app has focus. A
+  borderless custom-chrome window that covers the monitor can therefore be
+  treated as fullscreen. Windows presentation mode is reported system-wide, so
+  it suppresses activation on every monitor while active.
+- Cursor tracking uses a system-wide `EVENT_OBJECT_LOCATIONCHANGE` WinEvent
+  hook because Windows can't filter that hook to `OBJID_CURSOR` at
+  registration time. Non-cursor events are discarded immediately by the
+  callback. If the WinEvent hook can't be installed, the mod falls back to a
+  150 ms cursor check.
 
 ## Attribution and license
 
-The Windows 11 `ViewCoordinator` symbol names and UI-thread invocation
-technique were informed by the GPL-3.0-licensed **Taskbar auto-hide fine
-tuning** Windhawk mod by m417z.
+The Windows 11 `ViewCoordinator` symbol and UI-thread invocation technique were
+informed by the GPL-3.0-licensed **Taskbar auto-hide fine tuning** Windhawk mod
+by m417z.
 
 This mod is distributed under the GNU General Public License v3.0.
 */
@@ -145,7 +126,8 @@ This mod is distributed under the GNU General Public License v3.0.
 - activationCooldownMs: 200
   $name: Activation cooldown
   $description: >-
-    Minimum time between reveal checks while the pointer remains in the band.
+    Minimum time between reveal attempts while the pointer remains in the
+    activation band.
 - requireWindowsAutoHide: true
   $name: Require Windows auto-hide
   $description: >-
@@ -155,10 +137,11 @@ This mod is distributed under the GNU General Public License v3.0.
 - ignoreFullscreenApps: true
   $name: Ignore fullscreen apps
   $description: >-
-    Don't reveal the taskbar when a fullscreen app or presentation state is
-    detected on the target monitor. Click-through, tool, non-activating,
-    cloaked, desktop, and taskbar windows are ignored. A qualifying background
-    fullscreen window on that monitor can still suppress activation.
+    Don't reveal while Windows presentation mode is active or when a
+    qualifying fullscreen app is detected on the target monitor. Click-through,
+    tool, non-activating, cloaked, desktop, and taskbar windows are ignored. A
+    qualifying background fullscreen window on that monitor can still suppress
+    activation.
 - ignoreWhileMouseButtonDown: true
   $name: Ignore while dragging
   $description: >-
@@ -167,13 +150,6 @@ This mod is distributed under the GNU General Public License v3.0.
   $name: Primary monitor only
   $description: >-
     Only use the activation band on the primary monitor.
-- nativeTimerFallback: true
-  $name: Native timer fallback
-  $description: >-
-    If the Windows 11 taskbar coordinator isn't available yet, make one
-    best-effort request through Explorer's native unhide timer for each entry
-    into the activation band. Mods that intercept Explorer's taskbar timers can
-    block this temporary fallback. The pointer is never moved or injected.
 */
 // ==/WindhawkModSettings==
 
@@ -200,7 +176,6 @@ struct Settings {
     std::atomic<bool> ignoreFullscreenApps{true};
     std::atomic<bool> ignoreWhileMouseButtonDown{true};
     std::atomic<bool> primaryMonitorOnly{false};
-    std::atomic<bool> nativeTimerFallback{true};
 };
 
 Settings g_settings;
@@ -220,35 +195,16 @@ std::atomic<bool> g_unloading{false};
 // user32 calls while the loader lock is held.
 UINT g_uiThreadMessage = 0;
 UINT g_captureTaskbarObjectMessage = 0;
-UINT g_queryTaskbarRectMessage = 0;
-
-// The taskbar-rectangle query can outlive SendMessageTimeoutW. Keeping all
-// request and result storage at file scope avoids passing a pointer to a worker
-// stack frame into Explorer's UI thread. Only the activation worker initiates
-// these queries, and a timed-out request remains pending until the UI thread
-// eventually consumes it.
-struct StuckRectQueryState {
-    std::atomic<bool> pending{false};
-    std::atomic<bool> succeeded{false};
-    HMONITOR monitor = nullptr;
-    RECT rect{};
-};
-
-StuckRectQueryState g_stuckRectQuery;
-
 enum UiOperation : WPARAM {
     kUiRevealTaskbar = 1,
     kUiClearSyntheticPointerOver = 2,
     kUiClearAllSyntheticPointerOver = 3,
-    kUiTriggerNativeUnhideTimer = 4,
 };
 
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
 constexpr UINT kWorkerSettingsChangedMessage = WM_APP + 2;
 constexpr UINT kWorkerNativePointerLeaveMessage = WM_APP + 3;
-constexpr LPARAM kRevealFlagBringNormalTaskbarForward = 1;
 constexpr UINT kReleaseRetryMs = 250;
-constexpr UINT kFallbackProbeMs = 300;
 constexpr UINT kSuppressionBackoffMaxMs = 5000;
 constexpr ULONGLONG kAutoHideCacheDurationMs = 5000;
 
@@ -264,30 +220,6 @@ std::unordered_map<HWND, void*> g_secondaryTrayObjects;
 std::unordered_map<HWND, void*> g_viewCoordinators;
 std::unordered_set<HWND> g_syntheticPointerOverTaskbars;
 
-// Set only while this mod is applying its reason-7 synthetic enter update on
-// the taskbar UI thread. This keeps ShouldTaskbarBeExpanded narrowly scoped.
-bool g_syntheticExpansionUpdateInProgress = false;
-
-class ScopedSyntheticExpansionUpdate {
-public:
-    ScopedSyntheticExpansionUpdate()
-        : previous_(g_syntheticExpansionUpdateInProgress) {
-        g_syntheticExpansionUpdateInProgress = true;
-    }
-
-    ~ScopedSyntheticExpansionUpdate() {
-        g_syntheticExpansionUpdateInProgress = previous_;
-    }
-
-    ScopedSyntheticExpansionUpdate(const ScopedSyntheticExpansionUpdate&) =
-        delete;
-    ScopedSyntheticExpansionUpdate& operator=(
-        const ScopedSyntheticExpansionUpdate&) = delete;
-
-private:
-    bool previous_;
-};
-
 void* g_trayUiVtableITrayComponentHost = nullptr;
 
 void ForgetTaskbarState(HWND taskbarWindow) {
@@ -299,7 +231,6 @@ DWORD WINAPI ActivationWorkerThread(LPVOID);
 void EnsureActivationWorker();
 bool HandleTaskbarUiOperation(HWND taskbarWindow,
                               WPARAM operationValue,
-                              LPARAM operationParameter,
                               LRESULT* result);
 
 void InvalidateAutoHideCache() {
@@ -337,10 +268,6 @@ void LoadSettings() {
 
     g_settings.primaryMonitorOnly.store(
         Wh_GetIntSetting(L"primaryMonitorOnly") != 0,
-        std::memory_order_relaxed);
-
-    g_settings.nativeTimerFallback.store(
-        Wh_GetIntSetting(L"nativeTimerFallback") != 0,
         std::memory_order_relaxed);
 }
 
@@ -382,7 +309,7 @@ bool IsTaskbarClass(HWND window) {
 }
 
 bool IsCurrentProcessWindow(HWND window) {
-    if (!window || !IsWindow(window)) {
+    if (!window) {
         return false;
     }
 
@@ -444,54 +371,6 @@ HWND FindAnyTaskbarWindow() {
     return taskbarWindow;
 }
 
-bool GetTaskbarStuckRectForMonitor(HMONITOR monitor, RECT* rect) {
-    if (!monitor || !rect || !g_queryTaskbarRectMessage ||
-        g_stuckRectQuery.pending.load(std::memory_order_acquire)) {
-        return false;
-    }
-
-    HWND taskbarWindow = FindMainTaskbarWindow();
-    if (!taskbarWindow) {
-        return false;
-    }
-
-    g_stuckRectQuery.monitor = monitor;
-    SetRectEmpty(&g_stuckRectQuery.rect);
-    g_stuckRectQuery.succeeded.store(false, std::memory_order_relaxed);
-    g_stuckRectQuery.pending.store(true, std::memory_order_release);
-
-    DWORD_PTR result = 0;
-    SetLastError(ERROR_SUCCESS);
-    if (!SendMessageTimeoutW(
-            taskbarWindow,
-            g_queryTaskbarRectMessage,
-            0,
-            0,
-            SMTO_ABORTIFHUNG | SMTO_BLOCK,
-            250,
-            &result)) {
-        const DWORD error = GetLastError();
-        if (error != ERROR_TIMEOUT && error != ERROR_SUCCESS) {
-            // The message wasn't left pending, so allow another query.
-            g_stuckRectQuery.pending.store(false,
-                                           std::memory_order_release);
-        }
-        return false;
-    }
-
-    // If the hook wasn't reached, don't leave the query permanently pending.
-    g_stuckRectQuery.pending.store(false, std::memory_order_release);
-
-    if (!result ||
-        !g_stuckRectQuery.succeeded.load(std::memory_order_acquire) ||
-        IsRectEmpty(&g_stuckRectQuery.rect)) {
-        return false;
-    }
-
-    *rect = g_stuckRectQuery.rect;
-    return true;
-}
-
 HMONITOR GetTaskbarMonitor(HWND taskbarWindow) {
     if (HMONITOR monitor = reinterpret_cast<HMONITOR>(
             GetPropW(taskbarWindow, L"TaskbarMonitor"))) {
@@ -515,12 +394,6 @@ bool LooksLikeHorizontalTaskbarRect(
            taskbarHeight <= monitorHeight / 2;
 }
 
-bool IsBottomDockedRect(const RECT& taskbarRect,
-                        const MONITORINFO& monitorInfo) {
-    return LooksLikeHorizontalTaskbarRect(taskbarRect, monitorInfo) &&
-           std::abs(taskbarRect.bottom - monitorInfo.rcMonitor.bottom) <= 2;
-}
-
 bool IsBottomPositionedTaskbar(HWND taskbarWindow, HMONITOR monitor) {
     MONITORINFO monitorInfo{};
     monitorInfo.cbSize = sizeof(monitorInfo);
@@ -528,20 +401,12 @@ bool IsBottomPositionedTaskbar(HWND taskbarWindow, HMONITOR monitor) {
         return false;
     }
 
-    // Prefer Explorer's own docked rectangle. Unlike the live window geometry,
-    // this identifies the configured edge even while the taskbar is hidden.
-    RECT stuckRect{};
-    if (GetTaskbarStuckRectForMonitor(monitor, &stuckRect)) {
-        return IsBottomDockedRect(stuckRect, monitorInfo);
-    }
-
-    // Fallback for Windows builds where the optional symbol is unavailable.
+    // The auto-hidden taskbar remains a full-width horizontal window whose
+    // live rectangle sits at or just below the configured monitor edge. Avoid
+    // an extra undocumented symbol and cross-thread query for this check.
     RECT taskbarRect{};
-    if (!GetWindowRect(taskbarWindow, &taskbarRect)) {
-        return false;
-    }
-
-    if (!LooksLikeHorizontalTaskbarRect(taskbarRect, monitorInfo)) {
+    if (!GetWindowRect(taskbarWindow, &taskbarRect) ||
+        !LooksLikeHorizontalTaskbarRect(taskbarRect, monitorInfo)) {
         return false;
     }
 
@@ -753,19 +618,9 @@ bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
 }
 
 void LogFullscreenCandidate(HWND window) {
-    wchar_t className[128] = L"";
-    wchar_t title[256] = L"";
-    GetClassNameW(window, className, ARRAYSIZE(className));
-    GetWindowTextW(window, title, ARRAYSIZE(title));
-
     DWORD processId = 0;
     GetWindowThreadProcessId(window, &processId);
-
-    Wh_Log(L"Fullscreen candidate: hwnd=%p pid=%u class=\"%s\" title=\"%s\"",
-           window,
-           processId,
-           className,
-           title);
+    Wh_Log(L"Fullscreen candidate: hwnd=%p pid=%u", window, processId);
 }
 
 bool IsFullscreenOrPresentationNotificationState(HMONITOR monitor) {
@@ -858,24 +713,6 @@ bool IsPointOverTaskbar(HWND taskbarWindow, const POINT& pointer) {
            PtInRect(&taskbarRect, pointer);
 }
 
-bool IsTaskbarVisiblyRevealed(HWND taskbarWindow, HMONITOR monitor) {
-    RECT taskbarRect{};
-    MONITORINFO monitorInfo{};
-    monitorInfo.cbSize = sizeof(monitorInfo);
-    if (!GetWindowRect(taskbarWindow, &taskbarRect) ||
-        !GetMonitorInfoW(monitor, &monitorInfo)) {
-        return false;
-    }
-
-    RECT intersection{};
-    if (!IntersectRect(&intersection, &taskbarRect, &monitorInfo.rcMonitor)) {
-        return false;
-    }
-
-    // An auto-hidden taskbar normally leaves only a one-pixel edge onscreen.
-    return intersection.bottom - intersection.top > 2;
-}
-
 void* QueryViaVtable(void* object, void* targetVtable) {
     if (!object || !targetVtable) {
         return nullptr;
@@ -910,10 +747,6 @@ using CSecondaryTray_Unhide_t =
 
 CSecondaryTray_Unhide_t CSecondaryTray_Unhide_Original;
 
-using TrayUI_GetStuckRectForMonitor_t =
-    bool(WINAPI*)(void* trayUi, HMONITOR monitor, RECT* rect);
-TrayUI_GetStuckRectForMonitor_t TrayUI_GetStuckRectForMonitor_Original;
-
 using TrayUI_WndProc_t =
     LRESULT(WINAPI*)(void* trayUi,
                      HWND window,
@@ -933,7 +766,7 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
     bool* handled) {
     if (message == g_uiThreadMessage) {
         LRESULT result = 0;
-        if (HandleTaskbarUiOperation(window, wParam, lParam, &result)) {
+        if (HandleTaskbarUiOperation(window, wParam, &result)) {
             if (handled) {
                 *handled = true;
             }
@@ -941,33 +774,7 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
         }
     }
 
-    if (message == g_queryTaskbarRectMessage) {
-        bool succeeded = false;
-        if (g_stuckRectQuery.pending.load(std::memory_order_acquire) &&
-            g_stuckRectQuery.monitor &&
-            TrayUI_GetStuckRectForMonitor_Original) {
-            RECT rect{};
-            succeeded = TrayUI_GetStuckRectForMonitor_Original(
-                trayUi, g_stuckRectQuery.monitor, &rect);
-            if (succeeded) {
-                g_stuckRectQuery.rect = rect;
-            } else {
-                SetRectEmpty(&g_stuckRectQuery.rect);
-            }
-        }
-
-        g_stuckRectQuery.succeeded.store(succeeded,
-                                         std::memory_order_release);
-        g_stuckRectQuery.pending.store(false, std::memory_order_release);
-
-        if (handled) {
-            *handled = true;
-        }
-        return succeeded ? 1 : 0;
-    }
-
     if (message == WM_NCCREATE) {
-        g_stuckRectQuery.pending.store(false, std::memory_order_release);
         g_trayUiWndProcObjects[window] = trayUi;
         g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
         Wh_Log(L"Captured TrayUI object for taskbar %p", window);
@@ -988,8 +795,6 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
         ForgetTaskbarState(window);
         if (g_mainTaskbarWindow.load(std::memory_order_relaxed) == window) {
             g_mainTaskbarWindow.store(nullptr, std::memory_order_relaxed);
-            g_stuckRectQuery.pending.store(false,
-                                           std::memory_order_release);
         }
     }
 
@@ -1019,7 +824,7 @@ LRESULT WINAPI CSecondaryTray_WndProc_Hook(
     LPARAM lParam) {
     if (message == g_uiThreadMessage) {
         LRESULT result = 0;
-        if (HandleTaskbarUiOperation(window, wParam, lParam, &result)) {
+        if (HandleTaskbarUiOperation(window, wParam, &result)) {
             return result;
         }
     }
@@ -1123,13 +928,8 @@ void* GetViewCoordinator(HWND taskbarWindow) {
     return it != g_viewCoordinators.end() ? it->second : nullptr;
 }
 
-// Undocumented Windows 11 taskbar methods.
-//
-// inputDeviceKind 0 corresponds to the mouse path used by Windows' taskbar
-// implementation. Reason 7 is the coordinator's
-// IsPointerOverTaskbarFrameChanged update reason.
-constexpr int kReasonIsPointerOverTaskbarFrameChanged = 7;
-
+// Undocumented Windows 11 taskbar method. inputDeviceKind 0 corresponds to
+// the mouse path used by Windows' taskbar implementation.
 using ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_t =
     void(WINAPI*)(void* viewCoordinator,
                   HWND taskbarWindow,
@@ -1178,55 +978,6 @@ ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook(
     }
 }
 
-using ViewCoordinator_ShouldTaskbarBeExpanded_t =
-    bool(WINAPI*)(void* viewCoordinator,
-                  HWND taskbarWindow,
-                  bool expanded);
-
-ViewCoordinator_ShouldTaskbarBeExpanded_t
-    ViewCoordinator_ShouldTaskbarBeExpanded_Original;
-
-bool WINAPI ViewCoordinator_ShouldTaskbarBeExpanded_Hook(
-    void* viewCoordinator,
-    HWND taskbarWindow,
-    bool expanded) {
-    RememberViewCoordinator(taskbarWindow, viewCoordinator);
-
-    // HandleIsPointerOverTaskbarFrameChanged isn't sufficient on every Windows
-    // 11 build when the physical pointer remains above the real one-pixel
-    // taskbar frame. While this mod owns the synthetic pointer-over state,
-    // explicitly authorize expansion in the coordinator's decision function.
-    if (g_syntheticExpansionUpdateInProgress &&
-        g_syntheticPointerOverTaskbars.contains(taskbarWindow)) {
-        Wh_Log(L"ShouldTaskbarBeExpanded: forcing true for taskbar %p "
-               L"(requested=%d)",
-               taskbarWindow,
-               expanded);
-        return true;
-    }
-
-    bool result =
-        ViewCoordinator_ShouldTaskbarBeExpanded_Original(
-            viewCoordinator,
-            taskbarWindow,
-            expanded);
-
-    Wh_Log(L"ShouldTaskbarBeExpanded: native result=%d for taskbar %p "
-           L"(requested=%d)",
-           result,
-           taskbarWindow,
-           expanded);
-    return result;
-}
-
-using ViewCoordinator_UpdateIsExpanded_t =
-    void(WINAPI*)(void* viewCoordinator,
-                  HWND taskbarWindow,
-                  int reason);
-
-ViewCoordinator_UpdateIsExpanded_t
-    ViewCoordinator_UpdateIsExpanded_Original;
-
 bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
                                        bool isPointerOver) {
     if (!isPointerOver && taskbarWindow &&
@@ -1235,8 +986,7 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
     }
 
     if (!taskbarWindow || !IsWindow(taskbarWindow) ||
-        !ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original ||
-        !ViewCoordinator_UpdateIsExpanded_Original) {
+        !ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original) {
         if (taskbarWindow && !IsWindow(taskbarWindow)) {
             ForgetTaskbarState(taskbarWindow);
         }
@@ -1261,17 +1011,14 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
         Wh_Log(L"Setting synthetic pointer-over for taskbar %p",
                taskbarWindow);
 
-        ScopedSyntheticExpansionUpdate expansionUpdate;
+        // Explorer's native handler performs the corresponding expansion
+        // reevaluation internally. Calling it once mirrors the established
+        // taskbar auto-hide reveal path without overriding expansion policy.
         ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
             viewCoordinator,
             taskbarWindow,
             true,
             0);
-
-        ViewCoordinator_UpdateIsExpanded_Original(
-            viewCoordinator,
-            taskbarWindow,
-            kReasonIsPointerOverTaskbarFrameChanged);
     } else {
         if (g_syntheticPointerOverTaskbars.erase(taskbarWindow) == 0) {
             return true;
@@ -1286,156 +1033,30 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
             false,
             0);
 
-        ViewCoordinator_UpdateIsExpanded_Original(
-            viewCoordinator,
-            taskbarWindow,
-            kReasonIsPointerOverTaskbarFrameChanged);
-
     }
 
     return true;
 }
 
-bool ShouldBringNormalTaskbarForward(HWND taskbarWindow) {
-    if (!taskbarWindow || !IsWindow(taskbarWindow)) {
-        return false;
-    }
-
-    // Never reorder a topmost taskbar. Windows such as the on-screen keyboard,
-    // always-on-top players, and capture overlays can legitimately sit above
-    // it, and this mod must not override that policy.
-    const LONG_PTR taskbarExStyle =
-        GetWindowLongPtrW(taskbarWindow, GWL_EXSTYLE);
-    if ((taskbarExStyle & WS_EX_TOPMOST) != 0) {
-        return false;
-    }
-
-    RECT taskbarRect{};
-    if (!GetWindowRect(taskbarWindow, &taskbarRect)) {
-        return false;
-    }
-
-    // While auto-hidden, project the live taskbar rectangle to its visible
-    // bottom-docked position before testing windows above it in Z order.
-    const HMONITOR monitor = GetTaskbarMonitor(taskbarWindow);
-    MONITORINFO monitorInfo{};
-    monitorInfo.cbSize = sizeof(monitorInfo);
-    if (monitor && GetMonitorInfoW(monitor, &monitorInfo)) {
-        const int height = taskbarRect.bottom - taskbarRect.top;
-        if (height > 0) {
-            taskbarRect.top = monitorInfo.rcMonitor.bottom - height;
-            taskbarRect.bottom = monitorInfo.rcMonitor.bottom;
-            taskbarRect.left = std::max(taskbarRect.left,
-                                        monitorInfo.rcMonitor.left);
-            taskbarRect.right = std::min(taskbarRect.right,
-                                         monitorInfo.rcMonitor.right);
-        }
-    }
-
-    struct Context {
-        HWND taskbarWindow;
-        RECT taskbarRect;
-        bool coveredByNormalWindow;
-    } context{taskbarWindow, taskbarRect, false};
-
-    // This desktop-wide walk intentionally runs on the activation worker, not
-    // Explorer's taskbar UI thread. Only a normal-band window encountered above
-    // the normal-band taskbar is actionable; topmost windows are left alone.
-    EnumWindows(
-        [](HWND window, LPARAM parameter) -> BOOL {
-            auto* context = reinterpret_cast<Context*>(parameter);
-            if (window == context->taskbarWindow) {
-                return FALSE;
-            }
-
-            if (!IsWindowVisible(window) || IsIconic(window) ||
-                HasDesktopWindowClass(window) || IsTaskbarClass(window)) {
-                return TRUE;
-            }
-
-            const LONG_PTR exStyle = GetWindowLongPtrW(window, GWL_EXSTYLE);
-            if ((exStyle & (WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW |
-                            WS_EX_NOACTIVATE | WS_EX_TOPMOST)) != 0) {
-                return TRUE;
-            }
-
-            if (IsWindowCloaked(window)) {
-                return TRUE;
-            }
-
-            RECT windowRect{};
-            RECT intersection{};
-            if (GetWindowRect(window, &windowRect) &&
-                IntersectRect(&intersection,
-                              &windowRect,
-                              &context->taskbarRect)) {
-                context->coveredByNormalWindow = true;
-                return FALSE;
-            }
-
-            return TRUE;
-        },
-        reinterpret_cast<LPARAM>(&context));
-
-    return context.coveredByNormalWindow;
-}
-
-bool BringNormalTaskbarForwardOnUiThread(HWND taskbarWindow) {
-    if (!taskbarWindow || !IsWindow(taskbarWindow)) {
-        return false;
-    }
-
-    // Recheck the band on the UI thread in case Explorer or another mod changed
-    // it after the worker's coverage snapshot. Never reorder a topmost taskbar.
-    if ((GetWindowLongPtrW(taskbarWindow, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0) {
-        return true;
-    }
-
-    if (!SetWindowPos(taskbarWindow,
-                      HWND_TOP,
-                      0,
-                      0,
-                      0,
-                      0,
-                      SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
-                          SWP_NOOWNERZORDER)) {
-        Wh_Log(L"Couldn't bring covered normal-band taskbar %p forward: %u",
-               taskbarWindow,
-               GetLastError());
-        return false;
-    }
-
-    Wh_Log(L"Brought covered normal-band taskbar %p forward", taskbarWindow);
-    return true;
-}
-
-bool RevealTaskbarOnUiThread(HWND taskbarWindow,
-                             bool bringNormalTaskbarForward) {
+bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
     // Establish coordinator ownership first. If no coordinator has been
-    // captured yet, leave the legacy shell path untouched and let the worker
-    // retry with backoff instead of starting competing reveal mechanisms.
+    // captured yet, the worker retries with bounded backoff.
     const bool coordinatorExpanded =
         SetSyntheticPointerOverOnUiThread(taskbarWindow, true);
 
     bool shellWindowRevealed = false;
-    bool broughtToFront = false;
     if (coordinatorExpanded) {
-        // TrayUI::Unhide physically slides Shell_TrayWnd onscreen after the
-        // coordinator has established the matching logical expanded state.
+        // Keep the native shell unhide call for the physical Shell_TrayWnd /
+        // Shell_SecondaryTrayWnd slide, but leave Explorer's Z-order policy
+        // untouched.
         shellWindowRevealed =
             InvokeNativeShellUnhideOnUiThread(taskbarWindow);
-        if (bringNormalTaskbarForward) {
-            broughtToFront =
-                BringNormalTaskbarForwardOnUiThread(taskbarWindow);
-        }
     }
 
-    Wh_Log(L"Reveal result for taskbar %p: shell=%d coordinator=%d "
-           L"zorder=%d",
+    Wh_Log(L"Reveal result for taskbar %p: shell=%d coordinator=%d",
            taskbarWindow,
            shellWindowRevealed,
-           coordinatorExpanded,
-           broughtToFront);
+           coordinatorExpanded);
 
     return coordinatorExpanded;
 }
@@ -1452,34 +1073,8 @@ void ClearAllSyntheticPointerOverOnUiThread() {
     g_syntheticPointerOverTaskbars.clear();
 }
 
-constexpr UINT_PTR kTrayUITimerUnhide = 3;
-
-bool TriggerNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
-    if (!taskbarWindow || !IsWindow(taskbarWindow)) {
-        return false;
-    }
-
-    // Explorer owns timer ID 3. Never kill or clean it up here: doing so can
-    // cancel a genuine native edge-hover reveal that Explorer armed itself.
-    // SetTimer resets an existing timer with the same HWND and ID, so this
-    // compatibility fallback is deliberately limited to one attempt per band
-    // entry and is disclosed in the README.
-    const UINT_PTR timerResult =
-        SetTimer(taskbarWindow, kTrayUITimerUnhide, 1, nullptr);
-    if (!timerResult) {
-        Wh_Log(L"Native unhide timer failed for taskbar %p: %u",
-               taskbarWindow,
-               GetLastError());
-        return false;
-    }
-
-    Wh_Log(L"Requested native unhide timer for taskbar %p", taskbarWindow);
-    return true;
-}
-
 bool HandleTaskbarUiOperation(HWND taskbarWindow,
                               WPARAM operationValue,
-                              LPARAM operationParameter,
                               LRESULT* result) {
     if (!result) {
         return false;
@@ -1487,12 +1082,7 @@ bool HandleTaskbarUiOperation(HWND taskbarWindow,
 
     switch (static_cast<UiOperation>(operationValue)) {
         case kUiRevealTaskbar:
-            *result = RevealTaskbarOnUiThread(
-                          taskbarWindow,
-                          (operationParameter &
-                           kRevealFlagBringNormalTaskbarForward) != 0)
-                          ? 1
-                          : 0;
+            *result = RevealTaskbarOnUiThread(taskbarWindow) ? 1 : 0;
             return true;
 
         case kUiClearSyntheticPointerOver:
@@ -1507,11 +1097,6 @@ bool HandleTaskbarUiOperation(HWND taskbarWindow,
             *result = 1;
             return true;
 
-        case kUiTriggerNativeUnhideTimer:
-            *result = TriggerNativeUnhideTimerOnUiThread(taskbarWindow)
-                          ? 1
-                          : 0;
-            return true;
     }
 
     return false;
@@ -1535,8 +1120,7 @@ bool UiOperationMayHaveRun(UiOperationResult result) {
 
 UiOperationResult SendUiOperation(UiOperation operation,
                                   HWND taskbarWindow,
-                                  DWORD timeoutMs = 250,
-                                  LPARAM operationParameter = 0) {
+                                  DWORD timeoutMs = 250) {
     HWND destination = taskbarWindow;
     if (operation == kUiClearAllSyntheticPointerOver) {
         destination = FindAnyTaskbarWindow();
@@ -1553,7 +1137,7 @@ UiOperationResult SendUiOperation(UiOperation operation,
             destination,
             g_uiThreadMessage,
             operation,
-            operationParameter,
+            0,
             SMTO_ABORTIFHUNG | SMTO_BLOCK,
             timeoutMs,
             &result)) {
@@ -1577,17 +1161,19 @@ UiOperationResult SendUiOperation(UiOperation operation,
                        : UiOperationResult::kCompletedFailure;
 }
 
+struct WorkerTimer {
+    UINT_PTR id = 0;
+    ULONGLONG dueAt = 0;
+};
+
 struct ActivationWorkerState {
     HWND activeTaskbar = nullptr;
     HMONITOR activeTaskbarMonitor = nullptr;
-    HWND fallbackProbeTaskbar = nullptr;
-    HMONITOR fallbackProbeMonitor = nullptr;
     HMONITOR activationCandidateMonitor = nullptr;
     HMONITOR bandEntryMonitor = nullptr;
     bool armed = true;
-    bool fallbackAttemptedForEntry = false;
-    UINT_PTR releaseTimerId = 0;
-    UINT_PTR retryTimerId = 0;
+    WorkerTimer releaseTimer;
+    WorkerTimer retryTimer;
     bool releaseRetryPending = false;
     ULONGLONG activationCandidateSince = 0;
     ULONGLONG lastActivationCheck = 0;
@@ -1595,32 +1181,47 @@ struct ActivationWorkerState {
     unsigned appliedSettingsGeneration = 0;
 };
 
-void CancelWorkerTimer(UINT_PTR& timerId) {
-    if (!timerId) {
+void CancelWorkerTimer(WorkerTimer& timer) {
+    if (!timer.id) {
+        timer.dueAt = 0;
         return;
     }
 
-    KillTimer(nullptr, timerId);
-    timerId = 0;
+    KillTimer(nullptr, timer.id);
+    timer.id = 0;
+    timer.dueAt = 0;
 }
 
-void ScheduleWorkerTimer(UINT delayMs, UINT_PTR& timerId) {
-    if (timerId) {
-        return;
+void ScheduleWorkerTimer(UINT delayMs, WorkerTimer& timer) {
+    const UINT effectiveDelay = std::max(delayMs, 1U);
+    const ULONGLONG requestedDueAt = GetTickCount64() + effectiveDelay;
+
+    if (timer.id) {
+        // Keep an existing timer when it will fire no later than the new
+        // request. If the new deadline is earlier, replace the timer so a
+        // long suppression backoff can't delay a short hover/cooldown retry.
+        if (timer.dueAt && timer.dueAt <= requestedDueAt) {
+            return;
+        }
+        CancelWorkerTimer(timer);
     }
 
     // With hWnd == nullptr, Windows allocates and returns the timer ID. The
     // caller stores that returned value and compares WM_TIMER against it.
-    timerId = SetTimer(nullptr, 0, std::max(delayMs, 1U), nullptr);
-    if (!timerId) {
+    timer.id = SetTimer(nullptr, 0, effectiveDelay, nullptr);
+    if (!timer.id) {
+        timer.dueAt = 0;
         Wh_Log(L"Failed to create worker timer: %u", GetLastError());
+        return;
     }
+
+    timer.dueAt = requestedDueAt;
 }
 
 bool ClearActiveTaskbar(ActivationWorkerState& state,
                         DWORD timeoutMs = 250,
                         bool scheduleRetry = true) {
-    CancelWorkerTimer(state.releaseTimerId);
+    CancelWorkerTimer(state.releaseTimer);
 
     if (state.activeTaskbar) {
         const UiOperationResult clearResult =
@@ -1642,7 +1243,7 @@ bool ClearActiveTaskbar(ActivationWorkerState& state,
             if (scheduleRetry) {
                 state.releaseRetryPending = true;
                 ScheduleWorkerTimer(kReleaseRetryMs,
-                                    state.releaseTimerId);
+                                    state.releaseTimer);
             }
             return false;
         }
@@ -1656,11 +1257,11 @@ bool ClearActiveTaskbar(ActivationWorkerState& state,
 }
 
 void ScheduleRetry(ActivationWorkerState& state, UINT delayMs) {
-    ScheduleWorkerTimer(delayMs, state.retryTimerId);
+    ScheduleWorkerTimer(delayMs, state.retryTimer);
 }
 
-UINT GetSuppressionRetryDelay(ActivationWorkerState& state,
-                              int cooldownMs) {
+UINT AdvanceSuppressionBackoff(ActivationWorkerState& state,
+                                   int cooldownMs) {
     state.suppressionFailures =
         std::min(state.suppressionFailures + 1, 8U);
     const UINT base = static_cast<UINT>(std::max(cooldownMs, 200));
@@ -1670,7 +1271,7 @@ UINT GetSuppressionRetryDelay(ActivationWorkerState& state,
 
 void ScheduleSuppressedRetry(ActivationWorkerState& state,
                              int cooldownMs) {
-    ScheduleRetry(state, GetSuppressionRetryDelay(state, cooldownMs));
+    ScheduleRetry(state, AdvanceSuppressionBackoff(state, cooldownMs));
 }
 
 void ResetActivationCandidate(ActivationWorkerState& state) {
@@ -1680,9 +1281,6 @@ void ResetActivationCandidate(ActivationWorkerState& state) {
 
 void ResetBandEntry(ActivationWorkerState& state) {
     state.bandEntryMonitor = nullptr;
-    state.fallbackAttemptedForEntry = false;
-    state.fallbackProbeTaskbar = nullptr;
-    state.fallbackProbeMonitor = nullptr;
     ResetActivationCandidate(state);
 }
 
@@ -1690,7 +1288,7 @@ void ProcessPointerState(ActivationWorkerState& state) {
     const unsigned settingsGeneration =
         g_settingsGeneration.load(std::memory_order_acquire);
     if (state.appliedSettingsGeneration != settingsGeneration) {
-        CancelWorkerTimer(state.retryTimerId);
+        CancelWorkerTimer(state.retryTimer);
         if (!ClearActiveTaskbar(state)) {
             // Keep the old generation pending. Once the release retry succeeds,
             // the complete settings reset will run instead of being forgotten.
@@ -1714,7 +1312,7 @@ void ProcessPointerState(ActivationWorkerState& state) {
         if (!ClearActiveTaskbar(state)) {
             return;
         }
-        CancelWorkerTimer(state.retryTimerId);
+        CancelWorkerTimer(state.retryTimer);
         ResetBandEntry(state);
         state.suppressionFailures = 0;
         return;
@@ -1730,40 +1328,13 @@ void ProcessPointerState(ActivationWorkerState& state) {
     const bool insideActivationBand =
         IsPointInsideActivationBand(pointer, pointerMonitor, monitorInfo);
 
-    if (state.fallbackProbeTaskbar) {
-        const bool sameMonitor =
-            pointerMonitor == state.fallbackProbeMonitor;
-        if (!IsWindow(state.fallbackProbeTaskbar) ||
-            !insideActivationBand || !sameMonitor) {
-            state.fallbackProbeTaskbar = nullptr;
-            state.fallbackProbeMonitor = nullptr;
-            state.armed = true;
-        } else if (IsTaskbarVisiblyRevealed(state.fallbackProbeTaskbar,
-                                            state.fallbackProbeMonitor)) {
-            // Explorer owns the fallback reveal and its matching hide. Don't
-            // keep probing or re-reveal while the pointer remains in this band.
-            state.fallbackProbeTaskbar = nullptr;
-            state.fallbackProbeMonitor = nullptr;
-            state.armed = false;
-            CancelWorkerTimer(state.retryTimerId);
-            return;
-        } else {
-            // The timer was filtered or didn't reveal the taskbar. Continue
-            // coordinator retries, but don't arm timer ID 3 again until the
-            // pointer leaves and re-enters the activation band.
-            state.fallbackProbeTaskbar = nullptr;
-            state.fallbackProbeMonitor = nullptr;
-            state.armed = true;
-        }
-    }
-
     if (state.activeTaskbar) {
         if (state.releaseRetryPending) {
             if (!ClearActiveTaskbar(state)) {
                 return;
             }
         } else if (!IsWindow(state.activeTaskbar)) {
-            CancelWorkerTimer(state.releaseTimerId);
+            CancelWorkerTimer(state.releaseTimer);
             state.releaseRetryPending = false;
             state.activeTaskbar = nullptr;
             state.activeTaskbarMonitor = nullptr;
@@ -1775,7 +1346,7 @@ void ProcessPointerState(ActivationWorkerState& state) {
             if ((insideActivationBand &&
                  pointerMonitor == state.activeTaskbarMonitor) ||
                 overVisibleTaskbar) {
-                CancelWorkerTimer(state.releaseTimerId);
+                CancelWorkerTimer(state.releaseTimer);
                 return;
             }
 
@@ -1788,7 +1359,7 @@ void ProcessPointerState(ActivationWorkerState& state) {
             } else {
                 state.releaseRetryPending = false;
                 ScheduleWorkerTimer(static_cast<UINT>(releaseDelay),
-                                    state.releaseTimerId);
+                                    state.releaseTimer);
                 return;
             }
         }
@@ -1797,7 +1368,7 @@ void ProcessPointerState(ActivationWorkerState& state) {
     if (!insideActivationBand) {
         state.armed = true;
         state.suppressionFailures = 0;
-        CancelWorkerTimer(state.retryTimerId);
+        CancelWorkerTimer(state.retryTimer);
         ResetBandEntry(state);
         return;
     }
@@ -1807,14 +1378,11 @@ void ProcessPointerState(ActivationWorkerState& state) {
     if (state.bandEntryMonitor != pointerMonitor) {
         state.bandEntryMonitor = pointerMonitor;
         state.armed = true;
-        state.fallbackAttemptedForEntry = false;
-        state.fallbackProbeTaskbar = nullptr;
-        state.fallbackProbeMonitor = nullptr;
         ResetActivationCandidate(state);
     }
 
     if (!state.armed) {
-        CancelWorkerTimer(state.retryTimerId);
+        CancelWorkerTimer(state.retryTimer);
         return;
     }
 
@@ -1852,7 +1420,7 @@ void ProcessPointerState(ActivationWorkerState& state) {
     }
 
     state.lastActivationCheck = now;
-    CancelWorkerTimer(state.retryTimerId);
+    CancelWorkerTimer(state.retryTimer);
 
     Wh_Log(L"Pointer remained in activation band: x=%d y=%d bottom=%d",
            pointer.x,
@@ -1893,15 +1461,8 @@ void ProcessPointerState(ActivationWorkerState& state) {
         return;
     }
 
-    const bool bringNormalTaskbarForward =
-        ShouldBringNormalTaskbarForward(taskbarWindow);
-    const UiOperationResult revealResult = SendUiOperation(
-        kUiRevealTaskbar,
-        taskbarWindow,
-        250,
-        bringNormalTaskbarForward
-            ? kRevealFlagBringNormalTaskbarForward
-            : 0);
+    const UiOperationResult revealResult =
+        SendUiOperation(kUiRevealTaskbar, taskbarWindow, 250);
     if (UiOperationMayHaveRun(revealResult)) {
         state.suppressionFailures = 0;
         if (revealResult == UiOperationResult::kIndeterminate) {
@@ -1921,26 +1482,7 @@ void ProcessPointerState(ActivationWorkerState& state) {
         return;
     }
 
-    if (!state.fallbackAttemptedForEntry &&
-        g_settings.nativeTimerFallback.load(std::memory_order_relaxed)) {
-        state.fallbackAttemptedForEntry = true;
-        const UiOperationResult fallbackResult =
-            SendUiOperation(kUiTriggerNativeUnhideTimer, taskbarWindow);
-        if (UiOperationMayHaveRun(fallbackResult)) {
-            Wh_Log(L"Requested native timer fallback for taskbar %p%s",
-                   taskbarWindow,
-                   fallbackResult == UiOperationResult::kIndeterminate
-                       ? L" (delivery indeterminate)"
-                       : L"");
-            state.fallbackProbeTaskbar = taskbarWindow;
-            state.fallbackProbeMonitor = pointerMonitor;
-            state.armed = false;
-            ScheduleRetry(state, kFallbackProbeMs);
-            return;
-        }
-    }
-
-    Wh_Log(L"Threshold entered, but no reveal backend succeeded");
+    Wh_Log(L"Threshold entered, but coordinator reveal is not available yet");
     ScheduleSuppressedRetry(state, cooldown);
 }
 
@@ -1950,8 +1492,8 @@ void HandleNativePointerLeave(ActivationWorkerState& state,
         return;
     }
 
-    CancelWorkerTimer(state.releaseTimerId);
-    CancelWorkerTimer(state.retryTimerId);
+    CancelWorkerTimer(state.releaseTimer);
+    CancelWorkerTimer(state.retryTimer);
     state.releaseRetryPending = false;
     state.activeTaskbar = nullptr;
     state.activeTaskbarMonitor = nullptr;
@@ -1965,7 +1507,7 @@ void HandleNativePointerLeave(ActivationWorkerState& state,
 }
 
 void HandleReleaseTimer(ActivationWorkerState& state) {
-    CancelWorkerTimer(state.releaseTimerId);
+    CancelWorkerTimer(state.releaseTimer);
 
     if (!state.activeTaskbar) {
         return;
@@ -2113,12 +1655,12 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
                     break;
 
                 case WM_TIMER:
-                    if (state.releaseTimerId &&
-                        message.wParam == state.releaseTimerId) {
+                    if (state.releaseTimer.id &&
+                        message.wParam == state.releaseTimer.id) {
                         HandleReleaseTimer(state);
-                    } else if (state.retryTimerId &&
-                               message.wParam == state.retryTimerId) {
-                        CancelWorkerTimer(state.retryTimerId);
+                    } else if (state.retryTimer.id &&
+                               message.wParam == state.retryTimer.id) {
+                        CancelWorkerTimer(state.retryTimer);
                         ProcessPointerState(state);
                     } else if (fallbackPollTimerId &&
                                message.wParam == fallbackPollTimerId) {
@@ -2134,7 +1676,7 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
         }
     }
 
-    CancelWorkerTimer(state.retryTimerId);
+    CancelWorkerTimer(state.retryTimer);
 
     // Keep unload bounded if Explorer's taskbar UI thread is unresponsive. A
     // single best-effort release is sufficient; an indeterminate send may still
@@ -2165,22 +1707,6 @@ bool HookTaskbarViewSymbols(HMODULE module) {
             ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook,
             true,
         },
-        {
-            {
-                LR"(public: bool __cdecl winrt::Taskbar::implementation::ViewCoordinator::ShouldTaskbarBeExpanded(unsigned __int64,bool))",
-            },
-            &ViewCoordinator_ShouldTaskbarBeExpanded_Original,
-            ViewCoordinator_ShouldTaskbarBeExpanded_Hook,
-            true,
-        },
-        {
-            {
-                LR"(public: void __cdecl winrt::Taskbar::implementation::ViewCoordinator::UpdateIsExpanded(unsigned __int64,enum TaskbarTipTest::TaskbarExpandCollapseReason))",
-            },
-            &ViewCoordinator_UpdateIsExpanded_Original,
-            nullptr,
-            true,
-        },
     };
 
     if (!WindhawkUtils::HookSymbols(
@@ -2191,10 +1717,9 @@ bool HookTaskbarViewSymbols(HMODULE module) {
         return false;
     }
 
-    if (!ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original ||
-        !ViewCoordinator_UpdateIsExpanded_Original) {
+    if (!ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original) {
         Wh_Log(L"Taskbar reveal path unavailable: required ViewCoordinator "
-               L"symbols need updating");
+               L"symbol needs updating");
         return false;
     }
 
@@ -2219,14 +1744,6 @@ bool HookTaskbarUiThreadSymbol() {
                 LR"(const TrayUI::`vftable'{for `ITrayComponentHost'})",
             },
             &g_trayUiVtableITrayComponentHost,
-            nullptr,
-            true,
-        },
-        {
-            {
-                LR"(public: virtual bool __cdecl TrayUI::GetStuckRectForMonitor(struct HMONITOR__ *,struct tagRECT *))",
-            },
-            &TrayUI_GetStuckRectForMonitor_Original,
             nullptr,
             true,
         },
@@ -2367,15 +1884,10 @@ BOOL Wh_ModInit() {
         RegisterWindowMessageW(L"taskbar-activation-threshold.ui");
     g_captureTaskbarObjectMessage =
         RegisterWindowMessageW(L"taskbar-activation-threshold.capture");
-    g_queryTaskbarRectMessage =
-        RegisterWindowMessageW(L"taskbar-activation-threshold.stuck-rect");
-
-    if (!g_uiThreadMessage || !g_captureTaskbarObjectMessage ||
-        !g_queryTaskbarRectMessage) {
-        Wh_Log(L"RegisterWindowMessageW failed: ui=%u capture=%u rect=%u",
+    if (!g_uiThreadMessage || !g_captureTaskbarObjectMessage) {
+        Wh_Log(L"RegisterWindowMessageW failed: ui=%u capture=%u",
                g_uiThreadMessage,
-               g_captureTaskbarObjectMessage,
-               g_queryTaskbarRectMessage);
+               g_captureTaskbarObjectMessage);
         return FALSE;
     }
 
@@ -2504,7 +2016,6 @@ void Wh_ModUninit() {
         g_stopEvent = nullptr;
     }
 
-    g_stuckRectQuery.pending.store(false, std::memory_order_relaxed);
     InvalidateAutoHideCache();
     g_viewCoordinators.clear();
     g_trayUiWndProcObjects.clear();

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -15,17 +15,36 @@
 /*
 # Taskbar Activation Threshold
 
-Reveals an auto-hidden Windows 11 taskbar when the pointer enters a
-configurable activation band above the bottom edge of the monitor. The pointer
-is never moved or injected; the mod invokes the taskbar's native reveal paths
-on Explorer's taskbar UI thread.
+Reveal the auto-hidden Windows 11 taskbar from a configurable activation band
+above the bottom edge of the screen.
 
-The activation band is scaled for each monitor's DPI, and cursor movement is
-observed through Windows accessibility events instead of continuous polling.
+Unlike approaches that move or inject the pointer, this mod keeps the cursor
+stationary and invokes Explorer's native taskbar reveal logic on the taskbar UI
+thread.
 
-## Compatibility approach
+The activation threshold is scaled independently for each monitor's DPI.
+Cursor movement is detected through Windows accessibility events rather than
+continuous polling, minimizing background activity while the pointer is idle.
 
-The mod doesn't modify:
+## Demonstration
+
+![Taskbar Activation Threshold demonstration](https://raw.githubusercontent.com/themagnificentoofman/taskbar-activation-threshold-assets/main/taskbar-activation-threshold-demo.gif)
+
+## Features
+
+- Configurable activation-band height
+- Per-monitor DPI scaling
+- Multi-monitor support
+- Adjustable release delay and activation cooldown
+- Optional suppression over fullscreen applications
+- Optional suppression while a mouse button is held
+- Optional restriction to the primary monitor
+- Native timer fallback while the Windows 11 taskbar coordinator is unavailable
+- No cursor movement, pointer injection, or taskbar layout modification
+
+## Compatibility
+
+The mod does not modify:
 
 - Taskbar position or geometry
 - XAML layout or styles
@@ -34,44 +53,55 @@ The mod doesn't modify:
 - Transparency
 - Windows' auto-hide setting
 
-It is therefore designed to coexist with styling, sizing, transparency,
-animation-speed, clock, label, and icon mods which leave the taskbar at the
-bottom of the screen.
+When revealing the taskbar, the mod also restores its native topmost Z-order
+without activating it. This prevents normal application windows from covering
+the revealed taskbar while preserving focus in the current application.
+
+The mod is designed to coexist with taskbar styling, sizing, transparency,
+animation, clock, label, and icon mods that retain the standard bottom-positioned
+Windows 11 taskbar.
 
 ## Requirements
 
 - Windows 11
 - The standard Windows 11 taskbar
+- A bottom-positioned taskbar
 - **Automatically hide the taskbar** enabled in Windows, unless
   `requireWindowsAutoHide` is disabled
-- Bottom-positioned taskbars
 
-## Known incompatibilities and limitations
+## Known limitations
 
-- Taskbars moved to the top, left, right, or an arbitrary floating location
-  aren't supported.
-- ExplorerPatcher's legacy Windows 10 taskbar isn't supported.
-- Mods which block or replace the taskbar's native expansion logic can
-  conflict. In particular, keyboard-only or never-show auto-hide modes are
+- Top-, left-, right-, detached-, and arbitrarily positioned taskbars are not
+  supported.
+- ExplorerPatcher's legacy Windows 10 taskbar is not supported.
+- Mods that disable, replace, or override the taskbar's native expansion logic
+  may conflict with this mod. Keyboard-only and never-show auto-hide modes are
   intentionally incompatible with mouse activation.
-- Microsoft can rename undocumented taskbar symbols in a Windows update. If
-  that happens, one or more reveal paths may stop working until the symbols are
-  updated.
-- Until the taskbar's internal coordinator is captured, the optional native
-  timer fallback is used. Coordinator-owned reveals are used as soon as the
-  coordinator becomes available.
+- Windows updates can rename undocumented taskbar symbols. If this occurs, one
+  or more reveal paths may require a symbol update.
+- Shortly after Explorer starts, the internal Windows 11 taskbar coordinator
+  may not yet have been captured. During this period, the optional native timer
+  fallback is used. Coordinator-controlled activation begins automatically once
+  the coordinator becomes available.
 
-## Suggested starting values
+## Suggested settings
 
 - Activation threshold: `24`
 - Release delay: `120`
 - Activation cooldown: `200`
 
+These defaults provide a noticeably larger activation area while retaining
+responsive reveal and hide behavior. Increase the activation threshold for
+easier access, or reduce it to more closely match the standard Windows edge
+trigger.
+
 ## Attribution and license
 
 The Windows 11 `ViewCoordinator` symbol names and UI-thread invocation
 technique were informed by the GPL-3.0-licensed **Taskbar auto-hide fine
-tuning** Windhawk mod by m417z. This mod is distributed under GPL-3.0.
+tuning** Windhawk mod by m417z.
+
+This mod is distributed under the GNU General Public License v3.0.
 */
 // ==/WindhawkModReadme==
 
@@ -165,6 +195,7 @@ enum UiOperation : WPARAM {
     kUiClearAllSyntheticPointerOver = 3,
     kUiTriggerNativeUnhideTimer = 4,
     kUiCancelNativeUnhideTimer = 5,
+    kUiRaiseTaskbarAboveWindows = 6,
 };
 
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
@@ -493,8 +524,13 @@ bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
     }
 
     const LONG_PTR style = GetWindowLongPtrW(window, GWL_STYLE);
+    const LONG_PTR exStyle = GetWindowLongPtrW(window, GWL_EXSTYLE);
+
+    // Tool, click-through, wallpaper, and other non-activating surfaces can be
+    // full-monitor windows without representing a fullscreen application.
     if ((style & WS_CHILD) != 0 ||
-        (style & (WS_CAPTION | WS_THICKFRAME)) != 0) {
+        (style & (WS_CAPTION | WS_THICKFRAME)) != 0 ||
+        (exStyle & (WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE)) != 0) {
         return false;
     }
 
@@ -520,19 +556,45 @@ bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
            windowRect.bottom >= monitorInfo.rcMonitor.bottom - tolerance;
 }
 
+void LogFullscreenCandidate(HWND window) {
+    wchar_t className[128] = L"";
+    wchar_t title[256] = L"";
+    GetClassNameW(window, className, ARRAYSIZE(className));
+    GetWindowTextW(window, title, ARRAYSIZE(title));
+
+    DWORD processId = 0;
+    GetWindowThreadProcessId(window, &processId);
+
+    Wh_Log(L"Fullscreen candidate: hwnd=%p pid=%u class=\"%s\" title=\"%s\"",
+           window,
+           processId,
+           className,
+           title);
+}
+
 bool IsFullscreenWindowOnMonitor(HMONITOR monitor) {
     struct Context {
         HMONITOR monitor;
         bool found;
     } context{monitor, false};
 
+    // EnumWindows walks top-level windows from top to bottom in Z order. Once
+    // the desktop host is reached, all remaining windows are background or
+    // wallpaper surfaces and must not suppress taskbar activation.
     EnumWindows(
         [](HWND window, LPARAM parameter) -> BOOL {
             auto* context = reinterpret_cast<Context*>(parameter);
+
+            if (IsDesktopWindow(window)) {
+                return FALSE;
+            }
+
             if (IsFullscreenCandidateOnMonitor(window, context->monitor)) {
+                LogFullscreenCandidate(window);
                 context->found = true;
                 return FALSE;
             }
+
             return TRUE;
         },
         reinterpret_cast<LPARAM>(&context));
@@ -1001,6 +1063,35 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
     return true;
 }
 
+bool RaiseTaskbarAboveWindowsOnUiThread(HWND taskbarWindow) {
+    if (!taskbarWindow || !IsWindow(taskbarWindow)) {
+        return false;
+    }
+
+    // A taskbar revealed without a real edge-hover can retain an old Z-order
+    // position and end up underneath an ordinary or topmost application
+    // window. Reinsert it at the top of the topmost band without activating,
+    // moving, resizing, or showing it. This matches the user-visible behavior
+    // of the native auto-hide reveal while leaving Explorer in control of the
+    // taskbar's geometry and animation.
+    if (!SetWindowPos(taskbarWindow,
+                      HWND_TOPMOST,
+                      0,
+                      0,
+                      0,
+                      0,
+                      SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
+                          SWP_NOOWNERZORDER)) {
+        Wh_Log(L"Couldn't raise taskbar %p above application windows: %u",
+               taskbarWindow,
+               GetLastError());
+        return false;
+    }
+
+    Wh_Log(L"Raised taskbar %p to the topmost Z-order band", taskbarWindow);
+    return true;
+}
+
 bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
     // The maintained Windhawk taskbar implementation invokes both paths:
     // TrayUI::Unhide physically slides Shell_TrayWnd onscreen, while the
@@ -1011,10 +1102,18 @@ bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
     const bool coordinatorExpanded =
         SetSyntheticPointerOverOnUiThread(taskbarWindow, true);
 
-    Wh_Log(L"Reveal result for taskbar %p: shell=%d coordinator=%d",
+    // Reassert the native overlay Z-order after both reveal paths have run.
+    // SetWindowPos uses SWP_NOACTIVATE, so the foreground application keeps
+    // keyboard focus.
+    const bool raisedAboveWindows =
+        RaiseTaskbarAboveWindowsOnUiThread(taskbarWindow);
+
+    Wh_Log(L"Reveal result for taskbar %p: shell=%d coordinator=%d "
+           L"zorder=%d",
            taskbarWindow,
            shellWindowRevealed,
-           coordinatorExpanded);
+           coordinatorExpanded,
+           raisedAboveWindows);
 
     // The legacy Unhide path alone has no matching hide trigger on Windows 11,
     // so only the coordinator path counts as a reveal owned by this mod.
@@ -1069,6 +1168,11 @@ bool TriggerNativeUnhideTimerOnUiThread(HWND taskbarWindow) {
         return false;
     }
 
+    // Put the hidden taskbar in the correct Z-order before Explorer processes
+    // the asynchronous timer. A second reinforcement is sent by the worker
+    // after the timer has had time to reveal the window.
+    RaiseTaskbarAboveWindowsOnUiThread(taskbarWindow);
+
     Wh_Log(L"Requested native unhide timer for taskbar %p",
            taskbarWindow);
     return true;
@@ -1108,6 +1212,11 @@ LRESULT WINAPI CTaskBand_v_WndProc_Hook(
 
             case kUiCancelNativeUnhideTimer:
                 return CancelNativeUnhideTimerOnUiThread(targetTaskbar)
+                           ? 1
+                           : 0;
+
+            case kUiRaiseTaskbarAboveWindows:
+                return RaiseTaskbarAboveWindowsOnUiThread(targetTaskbar)
                            ? 1
                            : 0;
         }
@@ -1608,6 +1717,20 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
                             SendUiOperation(kUiCancelNativeUnhideTimer,
                                             state.fallbackTaskbar,
                                             500);
+
+                            // The timer reveal is asynchronous. Reinforce the
+                            // taskbar's overlay Z-order after Explorer has had
+                            // time to move it onscreen, preventing a normal or
+                            // always-on-top app from covering part of it.
+                            if (state.fallbackTaskbarMonitor &&
+                                IsTaskbarVisiblyRevealed(
+                                    state.fallbackTaskbar,
+                                    state.fallbackTaskbarMonitor)) {
+                                SendUiOperation(
+                                    kUiRaiseTaskbarAboveWindows,
+                                    state.fallbackTaskbar,
+                                    500);
+                            }
                         }
                     } else if (fallbackPollTimerId &&
                                message.wParam == fallbackPollTimerId) {

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -48,7 +48,10 @@ With a typical Windows 11 taskbar, the default 24-DIP band is shorter than the
 taskbar itself. In that common case the threshold mainly changes the trigger
 area; after reveal, the taskbar's own rectangle keeps it open while you use its
 buttons. Values larger than the taskbar height additionally let the pointer sit
-in the strip above the visible taskbar without collapsing it.
+in the strip above the visible taskbar without collapsing it. Moving directly
+from one monitor's activation band to another releases the old monitor
+immediately, then applies the new monitor's hover delay instead of stacking both
+release and hover delays.
 
 ## Compatibility
 
@@ -66,9 +69,13 @@ which window appears above the taskbar.
 the taskbar, while this mod enlarges the trigger distance perpendicular to the
 bottom edge. The implementations solve different trigger problems, but both
 hook Explorer's pointer-over path. This mod temporarily holds Explorer's
-pointer-leave while it owns an enlarged-band reveal, whereas that mod observes
-and filters the same events. Installing both can therefore be hook-order
-sensitive and isn't guaranteed to combine cleanly.
+mouse pointer-leave while it owns an enlarged-band reveal, whereas that mod
+observes and filters the same events. Touch/pen leave notifications aren't
+suppressed. Installing both can therefore be hook-order sensitive and isn't
+guaranteed to combine cleanly. The same mouse pointer-leave interception can
+affect **Taskbar auto-hide fine tuning / keyboard-only** state tracking, so
+combinations with mods that hook the same callback should be considered
+unsupported unless specifically tested.
 
 Mods that replace or intentionally suppress Explorer's native reveal behavior
 (such as keyboard-only or never-show mouse modes) are intentionally
@@ -108,6 +115,10 @@ incompatible with mouse activation from this mod.
   hook because Windows can't filter that hook to `OBJID_CURSOR` at
   registration time. Non-cursor events are discarded immediately. If the hook
   can't be installed, a 150 ms cursor-check timer is used instead.
+- Reveal-blocking conditions that can change without cursor movement (a held
+  mouse button, fullscreen state, or a coordinator that hasn't been observed
+  yet) are retried at most once per second. Settings-only conditions and
+  monitors without a supported taskbar are event-driven and aren't polled.
 
 ## Attribution and license
 
@@ -169,6 +180,7 @@ This mod is distributed under the GNU General Public License v3.0.
 
 #include <algorithm>
 #include <atomic>
+#include <wchar.h>
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
@@ -187,6 +199,7 @@ struct Settings {
 Settings g_settings;
 
 std::atomic<bool> g_taskbarViewDllLoaded{false};
+std::atomic<bool> g_viewCoordinatorSupportAvailable{false};
 std::atomic<DWORD> g_workerThreadId{0};
 std::atomic<bool> g_cursorUpdatePosted{false};
 std::atomic<HWND> g_mainTaskbarWindow{nullptr};
@@ -207,8 +220,8 @@ enum UiOperation : WPARAM {
 };
 
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
-constexpr UINT kUiRetryIntervalMs = 250;
-constexpr UINT kActivationCheckIntervalMs = 200;
+constexpr UINT kTransientRetryIntervalMs = 1000;
+constexpr UINT kActivationAttemptThrottleMs = 200;
 
 // These containers are used by taskbar implementation callbacks and by
 // operations marshalled to the taskbar UI thread. This matches the threading
@@ -226,7 +239,6 @@ void ForgetTaskbarState(HWND taskbarWindow) {
 }
 
 DWORD WINAPI ActivationWorkerThread(LPVOID);
-void EnsureActivationWorker();
 bool HandleTaskbarUiOperation(HWND taskbarWindow,
                               WPARAM operationValue,
                               LRESULT* result);
@@ -262,6 +274,10 @@ void LoadSettings() {
 }
 
 void EnsureActivationWorker() {
+    if (g_workerThreadId.load(std::memory_order_acquire)) {
+        return;
+    }
+
     if (g_unloading.load(std::memory_order_acquire) || !g_stopEvent) {
         return;
     }
@@ -919,6 +935,11 @@ void RememberViewCoordinator(HWND taskbarWindow, void* viewCoordinator) {
     Wh_Log(L"Captured ViewCoordinator %p for taskbar %p",
            viewCoordinator,
            taskbarWindow);
+
+    // A worker waiting for the first coordinator doesn't need to poll until the
+    // next retry interval; the capture itself is the event that makes reveal
+    // possible.
+    QueuePointerStateUpdate();
 }
 
 void* GetViewCoordinator(HWND taskbarWindow) {
@@ -962,7 +983,7 @@ ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook(
     int inputDeviceKind) {
     RememberViewCoordinator(taskbarWindow, viewCoordinator);
 
-    if (!isPointerOver &&
+    if (!isPointerOver && inputDeviceKind == 0 &&
         g_syntheticPointerOverTaskbars.contains(taskbarWindow)) {
         if (g_workerThreadId.load(std::memory_order_acquire)) {
             // Explorer's physical frame is narrower than the configured band.
@@ -1049,16 +1070,19 @@ bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
         return false;
     }
 
-    // Explorer's own unhide first preserves its slide/Z-order behavior and also
-    // provides a harmless first-use nudge: it can cause
-    // ShouldTaskbarBeExpanded to run and expose the ViewCoordinator.
-    if (!InvokeNativeShellUnhideOnUiThread(taskbarWindow)) {
-        return false;
-    }
-
+    // Don't start Explorer's visible unhide until the coordinator is available.
+    // This avoids a native-only first reveal that immediately collapses before
+    // the worker can take synthetic pointer-over ownership.
     if (!GetViewCoordinator(taskbarWindow)) {
         Wh_Log(L"ViewCoordinator isn't captured yet for taskbar %p",
                taskbarWindow);
+        return false;
+    }
+
+    // Preserve Explorer's own slide/Z-order transition before asserting the
+    // synthetic mouse pointer-over state. This is important for shell layering,
+    // but only after we know the matching synthetic ownership can be established.
+    if (!InvokeNativeShellUnhideOnUiThread(taskbarWindow)) {
         return false;
     }
 
@@ -1132,7 +1156,7 @@ UiCallResult SendUiOperation(UiOperation operation,
             g_uiThreadMessage,
             operation,
             0,
-            SMTO_ABORTIFHUNG | SMTO_BLOCK,
+            SMTO_ABORTIFHUNG | SMTO_BLOCK | SMTO_ERRORONEXIT,
             timeoutMs,
             &result)) {
         const DWORD error = GetLastError();
@@ -1142,10 +1166,12 @@ UiCallResult SendUiOperation(UiOperation operation,
                destination,
                error);
 
-        // A timeout doesn't prove that the send was cancelled. Keep this one
-        // three-state result so a late synthetic enter is always paired with a
-        // later release attempt; the larger historical ownership protocol isn't
-        // needed.
+        // SendMessageTimeout can return after a destination WndProc has started
+        // processing but before it returns. In that narrow case the UI-side
+        // effect can still complete after this worker resumes. Preserve that
+        // distinction so a possible late synthetic enter is always reconciled.
+        // See Raymond Chen's documented explanation:
+        // https://devblogs.microsoft.com/oldnewthing/20110915-00/?p=9643
         if (error != ERROR_INVALID_WINDOW_HANDLE && IsWindow(destination)) {
             return UiCallResult::kUncertain;
         }
@@ -1167,10 +1193,11 @@ struct ActivationWorkerState {
     HMONITOR activationCandidateMonitor = nullptr;
     HMONITOR bandEntryMonitor = nullptr;
     bool armed = true;
+    bool uiStateUncertain = false;
     WorkerTimer releaseTimer;
     WorkerTimer retryTimer;
     ULONGLONG activationCandidateSince = 0;
-    ULONGLONG lastActivationCheck = 0;
+    ULONGLONG lastActivationAttempt = 0;
 };
 
 UINT GetMonitorDpiY(HMONITOR monitor) {
@@ -1213,6 +1240,7 @@ void ForgetWorkerActiveTaskbar(ActivationWorkerState& state) {
     state.activeTaskbar = nullptr;
     state.activeTaskbarMonitor = nullptr;
     state.armed = true;
+    state.uiStateUncertain = false;
 }
 
 bool ClearActiveTaskbar(ActivationWorkerState& state,
@@ -1233,8 +1261,15 @@ bool ClearActiveTaskbar(ActivationWorkerState& state,
     const UiCallResult result = SendUiOperation(
         kUiClearSyntheticPointerOver, state.activeTaskbar, timeoutMs);
     if (result != UiCallResult::kSucceeded) {
-        if (scheduleRetry) {
-            ScheduleWorkerTimer(kUiRetryIntervalMs, state.releaseTimer);
+        if (result == UiCallResult::kUncertain) {
+            state.uiStateUncertain = true;
+            if (scheduleRetry) {
+                ScheduleWorkerTimer(kTransientRetryIntervalMs,
+                                    state.retryTimer);
+            }
+        } else if (scheduleRetry) {
+            ScheduleWorkerTimer(kTransientRetryIntervalMs,
+                                state.releaseTimer);
         }
         return false;
     }
@@ -1254,7 +1289,7 @@ void ResetActivationCandidate(ActivationWorkerState& state) {
 
 void ResetBandEntry(ActivationWorkerState& state) {
     state.bandEntryMonitor = nullptr;
-    state.lastActivationCheck = 0;
+    state.lastActivationAttempt = 0;
     ResetActivationCandidate(state);
 }
 
@@ -1284,8 +1319,24 @@ void ProcessPointerState(ActivationWorkerState& state) {
         pointer, monitorInfo, GetMonitorDpiY(pointerMonitor));
 
     if (state.activeTaskbar) {
-        if (!IsSupportedTaskbarWindow(state.activeTaskbar) ||
-            !IsCurrentProcessWindow(state.activeTaskbar)) {
+        bool activeTaskbarAllowed = true;
+        if (g_settings.primaryMonitorOnly.load(std::memory_order_relaxed)) {
+            MONITORINFO activeMonitorInfo{};
+            activeMonitorInfo.cbSize = sizeof(activeMonitorInfo);
+            activeTaskbarAllowed =
+                state.activeTaskbarMonitor &&
+                GetMonitorInfoW(state.activeTaskbarMonitor, &activeMonitorInfo) &&
+                (activeMonitorInfo.dwFlags & MONITORINFOF_PRIMARY) != 0;
+        }
+
+        if (!activeTaskbarAllowed) {
+            // A settings change can make an already-owned secondary taskbar
+            // ineligible even while the pointer hasn't moved out of its band.
+            if (!ClearActiveTaskbar(state)) {
+                return;
+            }
+        } else if (!IsSupportedTaskbarWindow(state.activeTaskbar) ||
+                   !IsCurrentProcessWindow(state.activeTaskbar)) {
             CancelWorkerTimer(state.releaseTimer);
             ForgetWorkerActiveTaskbar(state);
         } else {
@@ -1297,19 +1348,43 @@ void ProcessPointerState(ActivationWorkerState& state) {
 
             if (sameMonitorBand || overTaskbar) {
                 CancelWorkerTimer(state.releaseTimer);
+                // A timed-out UI operation must still be reconciled even if the
+                // pointer remains inside the band; otherwise an uncertain no-op
+                // can wedge this band entry until the pointer leaves and re-enters.
+                if (!state.uiStateUncertain) {
+                    CancelWorkerTimer(state.retryTimer);
+                }
                 return;
             }
 
-            const int releaseDelay =
-                g_settings.releaseDelayMs.load(std::memory_order_relaxed);
-            if (releaseDelay > 0) {
-                ScheduleWorkerTimer(static_cast<UINT>(releaseDelay),
-                                    state.releaseTimer);
+            if (state.uiStateUncertain) {
+                const int releaseDelay =
+                    g_settings.releaseDelayMs.load(std::memory_order_relaxed);
+                ScheduleRetry(state,
+                              static_cast<UINT>(std::max(releaseDelay, 1)));
                 return;
             }
 
-            if (!ClearActiveTaskbar(state)) {
-                return;
+            if (insideActivationBand &&
+                pointerMonitor != state.activeTaskbarMonitor) {
+                // A direct monitor-to-monitor transition shouldn't pay the old
+                // monitor's release delay. Release it now, then let the new
+                // monitor apply its own hover delay below.
+                if (!ClearActiveTaskbar(state)) {
+                    return;
+                }
+            } else {
+                const int releaseDelay =
+                    g_settings.releaseDelayMs.load(std::memory_order_relaxed);
+                if (releaseDelay > 0) {
+                    ScheduleWorkerTimer(static_cast<UINT>(releaseDelay),
+                                        state.releaseTimer);
+                    return;
+                }
+
+                if (!ClearActiveTaskbar(state)) {
+                    return;
+                }
             }
         }
     }
@@ -1324,7 +1399,7 @@ void ProcessPointerState(ActivationWorkerState& state) {
     if (state.bandEntryMonitor != pointerMonitor) {
         state.bandEntryMonitor = pointerMonitor;
         state.armed = true;
-        state.lastActivationCheck = 0;
+        state.lastActivationAttempt = 0;
         ResetActivationCandidate(state);
     }
 
@@ -1350,46 +1425,55 @@ void ProcessPointerState(ActivationWorkerState& state) {
         }
     }
 
-    const ULONGLONG sinceLastCheck = now - state.lastActivationCheck;
-    if (sinceLastCheck < kActivationCheckIntervalMs) {
+    const ULONGLONG sinceLastAttempt = now - state.lastActivationAttempt;
+    if (sinceLastAttempt < kActivationAttemptThrottleMs) {
         ScheduleRetry(
             state,
-            static_cast<UINT>(kActivationCheckIntervalMs - sinceLastCheck));
+            static_cast<UINT>(kActivationAttemptThrottleMs - sinceLastAttempt));
         return;
     }
 
-    state.lastActivationCheck = now;
+    state.lastActivationAttempt = now;
     CancelWorkerTimer(state.retryTimer);
 
+    // Cheap, event-driven gates first. These conditions don't need polling:
+    // settings changes and taskbar creation already queue a fresh state update.
     if (g_settings.primaryMonitorOnly.load(std::memory_order_relaxed) &&
         (monitorInfo.dwFlags & MONITORINFOF_PRIMARY) == 0) {
-        ScheduleRetry(state, kUiRetryIntervalMs);
         return;
     }
 
-    // Cheap lookup first: monitors without a taskbar shouldn't pay for the
-    // fullscreen Z-order walk.
-    HWND taskbarWindow = FindTaskbarForMonitor(pointerMonitor);
-    if (!taskbarWindow) {
-        ScheduleRetry(state, kUiRetryIntervalMs);
+    if (!g_viewCoordinatorSupportAvailable.load(std::memory_order_acquire)) {
         return;
     }
 
-    if (g_settings.requireWindowsAutoHide.load(std::memory_order_relaxed) &&
-        !IsWindowsAutoHideEnabled()) {
-        ScheduleRetry(state, kUiRetryIntervalMs);
-        return;
-    }
-
+    // Button state can change without cursor movement, so keep a low-frequency
+    // retry for this transient condition.
     if (g_settings.ignoreWhileMouseButtonDown.load(std::memory_order_relaxed) &&
         IsAnyMouseButtonDown()) {
-        ScheduleRetry(state, kUiRetryIntervalMs);
+        ScheduleRetry(state, kTransientRetryIntervalMs);
         return;
     }
 
+    // ABM_GETSTATE is system-wide and changes through shell/settings events that
+    // already wake the worker. Don't poll it while auto-hide is disabled.
+    if (g_settings.requireWindowsAutoHide.load(std::memory_order_relaxed) &&
+        !IsWindowsAutoHideEnabled()) {
+        return;
+    }
+
+    // Monitors without a supported taskbar are awakened by taskbar WM_NCCREATE
+    // or display changes, so this is also an event-driven no-retry gate.
+    HWND taskbarWindow = FindTaskbarForMonitor(pointerMonitor);
+    if (!taskbarWindow) {
+        return;
+    }
+
+    // Fullscreen state can end while the pointer is stationary. One check per
+    // second is responsive enough without maintaining a 4 Hz desktop walk.
     if (g_settings.ignoreFullscreenApps.load(std::memory_order_relaxed) &&
         IsFullscreenWindowOnMonitor(pointerMonitor)) {
-        ScheduleRetry(state, kUiRetryIntervalMs);
+        ScheduleRetry(state, kTransientRetryIntervalMs);
         return;
     }
 
@@ -1397,18 +1481,38 @@ void ProcessPointerState(ActivationWorkerState& state) {
         SendUiOperation(kUiRevealTaskbar, taskbarWindow, 250);
     if (revealResult == UiCallResult::kSucceeded ||
         revealResult == UiCallResult::kUncertain) {
-        // A timed-out send may still execute later. Conservatively own it so
-        // leaving the band always causes a matching release attempt.
         state.activeTaskbar = taskbarWindow;
         state.activeTaskbarMonitor = pointerMonitor;
         state.armed = false;
+        state.uiStateUncertain = revealResult == UiCallResult::kUncertain;
         ResetActivationCandidate(state);
+
+        if (state.uiStateUncertain) {
+            // Don't assume an uncertain reveal succeeded forever. Reconcile it
+            // after one second by forcing a confirmed leave, then retry from a
+            // clean state if the pointer is still eligible.
+            ScheduleRetry(state, kTransientRetryIntervalMs);
+        }
         return;
     }
 
-    // Native unhide runs before coordinator lookup on the UI thread, so this
-    // first failed attempt can itself prompt Explorer to expose the coordinator.
-    ScheduleRetry(state, kUiRetryIntervalMs);
+    // A confirmed failure establishes no ownership. Retry at low frequency; if
+    // the coordinator is captured in the meantime, its hook also queues an
+    // immediate state update.
+    ScheduleRetry(state, kTransientRetryIntervalMs);
+}
+
+void HandleRetryTimer(ActivationWorkerState& state) {
+    CancelWorkerTimer(state.retryTimer);
+
+    if (state.uiStateUncertain && state.activeTaskbar) {
+        if (!ClearActiveTaskbar(state, 250, false)) {
+            ScheduleRetry(state, kTransientRetryIntervalMs);
+            return;
+        }
+    }
+
+    ProcessPointerState(state);
 }
 
 void HandleReleaseTimer(ActivationWorkerState& state) {
@@ -1493,8 +1597,7 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
     ActivationWorkerState state;
     ProcessPointerState(state);
 
-    bool stop = false;
-    while (!stop) {
+    for (;;) {
         DWORD waitResult = MsgWaitForMultipleObjects(
             1,
             &g_stopEvent,
@@ -1514,11 +1617,6 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
         }
 
         while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE)) {
-            if (message.message == WM_QUIT) {
-                stop = true;
-                break;
-            }
-
             switch (message.message) {
                 case kWorkerCursorChangedMessage:
                     g_cursorUpdatePosted.store(false,
@@ -1532,8 +1630,7 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
                         HandleReleaseTimer(state);
                     } else if (state.retryTimer.id &&
                                message.wParam == state.retryTimer.id) {
-                        CancelWorkerTimer(state.retryTimer);
-                        ProcessPointerState(state);
+                        HandleRetryTimer(state);
                     } else if (fallbackPollTimerId &&
                                message.wParam == fallbackPollTimerId) {
                         ProcessPointerState(state);
@@ -1605,6 +1702,7 @@ bool HookTaskbarViewSymbols(HMODULE module) {
         return false;
     }
 
+    g_viewCoordinatorSupportAvailable.store(true, std::memory_order_release);
     return true;
 }
 

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -34,13 +34,23 @@ continuous polling, minimizing background activity while the pointer is idle.
 
 - Configurable activation-band height and hover delay
 - Per-monitor DPI scaling
-- Multi-monitor and secondary-taskbar support
+- Multi-monitor and secondary-taskbar support; monitors without a taskbar are
+  ignored rather than redirected to another monitor
 - Adjustable release delay
 - Optional suppression over fullscreen applications and presentation mode
 - Optional suppression while a mouse button is held
 - Optional restriction to the primary monitor
 - No cursor movement, pointer injection, taskbar layout modification, or
   Explorer timer manipulation
+
+## Behavior
+
+The activation band controls where the taskbar can be revealed. After it is
+visible, the taskbar stays open while the pointer is either inside that band or
+over the taskbar itself, so moving onto taskbar buttons doesn't immediately hide
+it. If the band is taller than the taskbar, moving from the taskbar into the
+upper part of the band also keeps the reveal stable. The release delay begins
+only after the pointer has left both areas.
 
 ## Compatibility
 
@@ -55,8 +65,10 @@ The mod does not modify:
 - Taskbar Z-order
 
 It is designed to coexist with taskbar styling, sizing, transparency,
-animation, clock, label, icon, and Z-order mods that retain the standard
-Windows 11 taskbar and don't replace its native reveal logic.
+animation, clock, label, and icon mods that retain the standard Windows 11
+taskbar and don't replace its native reveal logic. Taskbar Z-order is left to
+Explorer; this mod never forces the taskbar topmost or reorders application
+windows, so mods that deliberately change shell Z-order can affect layering.
 
 ## Requirements
 
@@ -74,12 +86,21 @@ Windows 11 taskbar and don't replace its native reveal logic.
 - Mods that disable, replace, or override the taskbar's native expansion logic
   can conflict with this mod. Keyboard-only and never-show auto-hide modes are
   intentionally incompatible with mouse activation.
-- Reveal depends on the undocumented Windows 11 `ViewCoordinator`
-  `HandleIsPointerOverTaskbarFrameChanged` and `UpdateIsExpanded` methods. The
-  latter is used only to capture Explorer's coordinator before the first
-  activation-band reveal. If a Windows update renames or changes either
-  method, the mod will log that the coordinator reveal path needs a symbol
-  update.
+- The mod relies on Explorer's native unhide path to maintain normal taskbar
+  layering. It doesn't apply an independent Z-order correction; unusual shell
+  layering or a Z-order customization can therefore leave a reveal behind
+  another window until Explorer re-establishes its normal ordering.
+- Reveal depends on Windows 11 taskbar implementation symbols, including
+  `ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged`,
+  `ViewCoordinator::ShouldTaskbarBeExpanded`, and the native TrayUI/secondary
+  tray unhide paths. `ShouldTaskbarBeExpanded` is hooked only to capture
+  Explorer's coordinator early; its return value is never changed. The mod
+  requires the complete coordinator + native-shell reveal path for a taskbar
+  rather than accepting a partial reveal. If a Windows update changes a
+  required primary-taskbar symbol, initialization fails or the reveal path logs
+  that it needs an update. Secondary-taskbar symbols are optional so a secondary
+  symbol change doesn't disable primary-monitor operation; affected secondary
+  taskbars are skipped instead of using a partial reveal.
 - Fullscreen suppression ignores click-through, tool, non-activating, cloaked,
   desktop, and taskbar windows. It is intentionally conservative otherwise: a
   qualifying fullscreen window anywhere above the desktop on the target
@@ -94,16 +115,6 @@ Windows 11 taskbar and don't replace its native reveal logic.
   registration time. Non-cursor events are discarded immediately by the
   callback. If the WinEvent hook can't be installed, the mod falls back to a
   150 ms cursor check.
-
-## Tested configurations
-
-- Multi-monitor Windows 11 setup with taskbars shown on all displays
-- Secondary `Shell_SecondaryTrayWnd` taskbar activation and release
-- Moving the pointer between monitors with independent per-monitor activation
-  bands
-- Multi-monitor setup with **Show my taskbar on all displays** disabled; a
-  monitor with no taskbar is ignored instead of redirecting activation to
-  another monitor's taskbar
 
 ## Attribution and license
 
@@ -166,7 +177,6 @@ This mod is distributed under the GNU General Public License v3.0.
 
 #include <algorithm>
 #include <atomic>
-#include <cstdlib>
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
@@ -189,6 +199,7 @@ std::atomic<unsigned> g_settingsGeneration{0};
 std::atomic<DWORD> g_workerThreadId{0};
 std::atomic<bool> g_cursorUpdatePosted{false};
 std::atomic<HWND> g_mainTaskbarWindow{nullptr};
+std::atomic<bool> g_secondaryTaskbarSupportAvailable{false};
 
 HANDLE g_stopEvent = nullptr;
 std::atomic<HANDLE> g_workerThread{nullptr};
@@ -198,7 +209,6 @@ std::atomic<bool> g_unloading{false};
 // Registered in Wh_ModInit rather than during DLL initialization, avoiding
 // user32 calls while the loader lock is held.
 UINT g_uiThreadMessage = 0;
-UINT g_captureTaskbarObjectMessage = 0;
 enum UiOperation : WPARAM {
     kUiRevealTaskbar = 1,
     kUiClearSyntheticPointerOver = 2,
@@ -207,11 +217,13 @@ enum UiOperation : WPARAM {
 
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
 constexpr UINT kWorkerSettingsChangedMessage = WM_APP + 2;
-constexpr UINT kWorkerNativePointerLeaveMessage = WM_APP + 3;
 constexpr UINT kReleaseRetryMs = 250;
 constexpr UINT kActivationRetryIntervalMs = 200;
 constexpr UINT kSuppressionBackoffMaxMs = 5000;
 constexpr ULONGLONG kRevealVisibilityGraceMs = 400;
+constexpr unsigned kMaxHiddenRepairsPerBandEntry = 1;
+
+std::atomic<unsigned> g_displayGeneration{0};
 
 // These containers are used by taskbar implementation callbacks and by
 // operations marshalled to the taskbar UI thread. This matches the threading
@@ -287,6 +299,23 @@ void EnsureActivationWorker() {
     Wh_Log(L"Started activation worker in the taskbar Explorer process");
 }
 
+void QueuePointerStateUpdate() {
+    const DWORD workerThreadId =
+        g_workerThreadId.load(std::memory_order_acquire);
+    if (!workerThreadId ||
+        g_cursorUpdatePosted.exchange(true, std::memory_order_acq_rel)) {
+        return;
+    }
+
+    if (!PostThreadMessageW(workerThreadId,
+                            kWorkerCursorChangedMessage,
+                            0,
+                            0)) {
+        g_cursorUpdatePosted.store(false, std::memory_order_release);
+        Wh_Log(L"Couldn't queue pointer-state update: %u", GetLastError());
+    }
+}
+
 bool IsTaskbarClass(HWND window) {
     if (!window) {
         return false;
@@ -299,6 +328,25 @@ bool IsTaskbarClass(HWND window) {
 
     return _wcsicmp(className, L"Shell_TrayWnd") == 0 ||
            _wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0;
+}
+
+bool IsSecondaryTaskbarClass(HWND window) {
+    if (!window) {
+        return false;
+    }
+
+    wchar_t className[64];
+    return GetClassNameW(window, className, ARRAYSIZE(className)) &&
+           _wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0;
+}
+
+bool IsSupportedTaskbarWindow(HWND window) {
+    if (!IsTaskbarClass(window)) {
+        return false;
+    }
+
+    return !IsSecondaryTaskbarClass(window) ||
+           g_secondaryTaskbarSupportAvailable.load(std::memory_order_acquire);
 }
 
 bool IsCurrentProcessWindow(HWND window) {
@@ -354,7 +402,8 @@ HWND FindAnyTaskbarWindow() {
     HWND taskbarWindow = nullptr;
     EnumWindows(
         [](HWND window, LPARAM parameter) -> BOOL {
-            if (IsTaskbarClass(window) && IsCurrentProcessWindow(window)) {
+            if (IsSupportedTaskbarWindow(window) &&
+                IsCurrentProcessWindow(window)) {
                 *reinterpret_cast<HWND*>(parameter) = window;
                 return FALSE;
             }
@@ -367,9 +416,15 @@ HWND FindAnyTaskbarWindow() {
 HMONITOR GetTaskbarMonitor(HWND taskbarWindow) {
     if (HMONITOR monitor = reinterpret_cast<HMONITOR>(
             GetPropW(taskbarWindow, L"TaskbarMonitor"))) {
-        return monitor;
+        MONITORINFO monitorInfo{};
+        monitorInfo.cbSize = sizeof(monitorInfo);
+        if (GetMonitorInfoW(monitor, &monitorInfo)) {
+            return monitor;
+        }
     }
 
+    // A display-topology transition can briefly leave TaskbarMonitor pointing
+    // at a retired HMONITOR. Fall back to the window's current nearest monitor.
     return MonitorFromWindow(taskbarWindow, MONITOR_DEFAULTTONEAREST);
 }
 
@@ -403,14 +458,15 @@ bool IsBottomPositionedTaskbar(HWND taskbarWindow, HMONITOR monitor) {
         return false;
     }
 
-    const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
-    const int tolerance = std::max(16, taskbarHeight + 16);
-    return std::abs(taskbarRect.bottom - monitorInfo.rcMonitor.bottom) <=
-               tolerance ||
-           std::abs(taskbarRect.top - monitorInfo.rcMonitor.bottom) <=
-               tolerance ||
-           (taskbarRect.top < monitorInfo.rcMonitor.bottom &&
-            taskbarRect.bottom >= monitorInfo.rcMonitor.bottom - 2);
+    // A visible bottom taskbar ends at the monitor bottom; an auto-hidden one
+    // straddles that edge with only a very small strip left onscreen. Scale a
+    // two-DIP tolerance for high-DPI monitors while keeping the test tight
+    // enough to reject detached taskbars.
+    const UINT dpi = GetDpiForWindow(taskbarWindow);
+    const int edgeTolerance =
+        std::max(2, MulDiv(2, dpi ? dpi : 96, 96));
+    return taskbarRect.top <= monitorInfo.rcMonitor.bottom + edgeTolerance &&
+           taskbarRect.bottom >= monitorInfo.rcMonitor.bottom - edgeTolerance;
 }
 
 struct FindTaskbarContext {
@@ -419,7 +475,7 @@ struct FindTaskbarContext {
 };
 
 BOOL CALLBACK FindTaskbarForMonitorCallback(HWND window, LPARAM parameter) {
-    if (!IsTaskbarClass(window)) {
+    if (!IsSupportedTaskbarWindow(window)) {
         return TRUE;
     }
 
@@ -664,16 +720,10 @@ bool IsFullscreenWindowOnMonitor(HMONITOR monitor) {
 }
 
 bool IsPointInsideActivationBand(const POINT& pointer,
-                                 HMONITOR monitor,
-                                 const MONITORINFO& monitorInfo) {
+                                 const MONITORINFO& monitorInfo,
+                                 UINT dpiY) {
     const int monitorHeight =
         monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top;
-
-    UINT dpiX = 96;
-    UINT dpiY = 96;
-    if (FAILED(GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY))) {
-        dpiY = 96;
-    }
 
     const int logicalThreshold =
         g_settings.activationThresholdPx.load(std::memory_order_relaxed);
@@ -710,8 +760,15 @@ bool IsTaskbarVisiblyRevealed(HWND taskbarWindow, HMONITOR monitor) {
         return false;
     }
 
-    // A hidden Windows 11 taskbar normally leaves only a one-pixel edge.
-    return intersection.bottom - intersection.top > 2;
+    // Hidden auto-hide taskbars leave only a thin edge onscreen. Use a small
+    // fraction of the taskbar's own height rather than a fixed physical-pixel
+    // cutoff so the repair check remains sensible on high-DPI monitors and
+    // with modest taskbar-size customization.
+    const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
+    const int visibleHeight = intersection.bottom - intersection.top;
+    const int revealedThreshold =
+        std::clamp(taskbarHeight / 4, 4, 12);
+    return visibleHeight >= revealedThreshold;
 }
 
 void* QueryViaVtable(void* object, void* targetVtable) {
@@ -766,6 +823,11 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
     LPARAM lParam,
     bool* handled) {
     if (message == g_uiThreadMessage) {
+        // Record the existing taskbar object's pThis for free: this message is
+        // already executing with the correct TrayUI instance on its UI thread.
+        g_trayUiWndProcObjects[window] = trayUi;
+        g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
+
         LRESULT result = 0;
         if (HandleTaskbarUiOperation(window, wParam, &result)) {
             if (handled) {
@@ -775,20 +837,22 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
         }
     }
 
-    if (message == WM_NCCREATE) {
+    if (message == WM_DISPLAYCHANGE || message == WM_DPICHANGED) {
+        g_displayGeneration.fetch_add(1, std::memory_order_release);
+        QueuePointerStateUpdate();
+    } else if (message == WM_SETTINGCHANGE) {
+        // Auto-hide and multi-monitor taskbar settings can change while the
+        // pointer is parked in the band. Re-evaluate without waiting for the
+        // current suppression backoff to expire.
+        QueuePointerStateUpdate();
+    }
+
+    const bool taskbarCreating = message == WM_NCCREATE;
+    if (taskbarCreating) {
         g_trayUiWndProcObjects[window] = trayUi;
         g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
         Wh_Log(L"Captured TrayUI object for taskbar %p", window);
         EnsureActivationWorker();
-    } else if (message == g_captureTaskbarObjectMessage) {
-        g_trayUiWndProcObjects[window] = trayUi;
-        g_mainTaskbarWindow.store(window, std::memory_order_relaxed);
-        Wh_Log(L"Captured TrayUI object for taskbar %p", window);
-        EnsureActivationWorker();
-        if (handled) {
-            *handled = true;
-        }
-        return 0;
     } else if (message == WM_NCDESTROY) {
         g_trayUiWndProcObjects.erase(window);
         ForgetTaskbarState(window);
@@ -797,13 +861,19 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
         }
     }
 
-    return TrayUI_WndProc_Original(
+    const LRESULT originalResult = TrayUI_WndProc_Original(
         trayUi,
         window,
         message,
         wParam,
         lParam,
         handled);
+    if (taskbarCreating) {
+        // Wake a worker that may be backing off because this monitor previously
+        // had no taskbar. Queue only after Explorer has processed WM_NCCREATE.
+        QueuePointerStateUpdate();
+    }
+    return originalResult;
 }
 
 using CSecondaryTray_WndProc_t =
@@ -822,32 +892,46 @@ LRESULT WINAPI CSecondaryTray_WndProc_Hook(
     WPARAM wParam,
     LPARAM lParam) {
     if (message == g_uiThreadMessage) {
+        // As with the primary taskbar, the first UI operation records the
+        // existing CSecondaryTray object without a separate capture round-trip.
+        g_secondaryTrayObjects[window] = secondaryTray;
+
         LRESULT result = 0;
         if (HandleTaskbarUiOperation(window, wParam, &result)) {
             return result;
         }
     }
 
-    if (message == WM_NCCREATE) {
+    if (message == WM_DISPLAYCHANGE || message == WM_DPICHANGED) {
+        g_displayGeneration.fetch_add(1, std::memory_order_release);
+        QueuePointerStateUpdate();
+    } else if (message == WM_SETTINGCHANGE) {
+        // Auto-hide and multi-monitor taskbar settings can change while the
+        // pointer is parked in the band. Re-evaluate without waiting for the
+        // current suppression backoff to expire.
+        QueuePointerStateUpdate();
+    }
+
+    const bool taskbarCreating = message == WM_NCCREATE;
+    if (taskbarCreating) {
         g_secondaryTrayObjects[window] = secondaryTray;
         Wh_Log(L"Captured CSecondaryTray object for taskbar %p", window);
         EnsureActivationWorker();
-    } else if (message == g_captureTaskbarObjectMessage) {
-        g_secondaryTrayObjects[window] = secondaryTray;
-        Wh_Log(L"Captured CSecondaryTray object for taskbar %p", window);
-        EnsureActivationWorker();
-        return 0;
     } else if (message == WM_NCDESTROY) {
         g_secondaryTrayObjects.erase(window);
         ForgetTaskbarState(window);
     }
 
-    return CSecondaryTray_WndProc_Original(
+    const LRESULT originalResult = CSecondaryTray_WndProc_Original(
         secondaryTray,
         window,
         message,
         wParam,
         lParam);
+    if (taskbarCreating) {
+        QueuePointerStateUpdate();
+    }
+    return originalResult;
 }
 
 bool InvokeNativeShellUnhideOnUiThread(HWND taskbarWindow) {
@@ -944,20 +1028,21 @@ using ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_t =
 ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_t
     ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original;
 
-using ViewCoordinator_UpdateIsExpanded_t =
-    void(WINAPI*)(void* viewCoordinator,
+using ViewCoordinator_ShouldTaskbarBeExpanded_t =
+    bool(WINAPI*)(void* viewCoordinator,
                   HWND taskbarWindow,
-                  int reason);
+                  bool expanded);
 
-ViewCoordinator_UpdateIsExpanded_t ViewCoordinator_UpdateIsExpanded_Original;
+ViewCoordinator_ShouldTaskbarBeExpanded_t
+    ViewCoordinator_ShouldTaskbarBeExpanded_Original;
 
-void WINAPI ViewCoordinator_UpdateIsExpanded_Hook(
+bool WINAPI ViewCoordinator_ShouldTaskbarBeExpanded_Hook(
     void* viewCoordinator,
     HWND taskbarWindow,
-    int reason) {
+    bool expanded) {
     RememberViewCoordinator(taskbarWindow, viewCoordinator);
-    ViewCoordinator_UpdateIsExpanded_Original(
-        viewCoordinator, taskbarWindow, reason);
+    return ViewCoordinator_ShouldTaskbarBeExpanded_Original(
+        viewCoordinator, taskbarWindow, expanded);
 }
 
 void WINAPI
@@ -968,35 +1053,26 @@ ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook(
     int inputDeviceKind) {
     RememberViewCoordinator(taskbarWindow, viewCoordinator);
 
+    // Calls made by this mod invoke the original function directly, so a false
+    // value reaching this hook is Explorer's physical taskbar-frame leave.
+    // While the enlarged activation band still owns a synthetic pointer-over,
+    // don't let that narrower native frame cancel it. The worker sends the
+    // matching false directly when the pointer leaves both the activation band
+    // and the visible taskbar. This also keeps thresholds taller than the
+    // taskbar from entering a native hide/reveal flicker loop.
+    if (!isPointerOver &&
+        g_syntheticPointerOverTaskbars.contains(taskbarWindow)) {
+        Wh_Log(L"Deferring Explorer pointer-leave while synthetic activation "
+               L"is owned for taskbar %p",
+               taskbarWindow);
+        return;
+    }
+
     ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
         viewCoordinator,
         taskbarWindow,
         isPointerOver,
         inputDeviceKind);
-
-    // Calls made by this mod invoke the original function directly, so a false
-    // value reaching this hook is Explorer's own pointer-leave transition. If
-    // it superseded our synthetic enter, relinquish UI-thread ownership and
-    // tell the worker to re-arm rather than waiting for a redundant release.
-    if (!isPointerOver &&
-        g_syntheticPointerOverTaskbars.erase(taskbarWindow) != 0) {
-        Wh_Log(L"Explorer cleared synthetic pointer-over for taskbar %p",
-               taskbarWindow);
-
-        const DWORD workerThreadId =
-            g_workerThreadId.load(std::memory_order_acquire);
-        if (workerThreadId &&
-            !PostThreadMessageW(
-                workerThreadId,
-                kWorkerNativePointerLeaveMessage,
-                reinterpret_cast<WPARAM>(taskbarWindow),
-                0)) {
-            Wh_Log(L"Couldn't notify activation worker about Explorer's "
-                   L"pointer leave for taskbar %p: %u",
-                   taskbarWindow,
-                   GetLastError());
-        }
-    }
 }
 
 bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
@@ -1059,26 +1135,43 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
 }
 
 bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
-    // Establish coordinator ownership first. If no coordinator has been
-    // captured yet, the worker retries with bounded backoff.
-    const bool coordinatorExpanded =
-        SetSyntheticPointerOverOnUiThread(taskbarWindow, true);
-
-    bool shellWindowRevealed = false;
-    if (coordinatorExpanded) {
-        // Keep the native shell unhide call for the physical Shell_TrayWnd /
-        // Shell_SecondaryTrayWnd slide, but leave Explorer's Z-order policy
-        // untouched.
-        shellWindowRevealed =
-            InvokeNativeShellUnhideOnUiThread(taskbarWindow);
+    // Refuse a shell-only reveal if Explorer's coordinator hasn't been captured
+    // yet. This keeps the operation all-or-nothing from the worker's point of
+    // view while allowing the native shell unhide to run first, matching the
+    // established Windows 11 taskbar reveal order used by maintained mods.
+    if (!taskbarWindow || !IsWindow(taskbarWindow) ||
+        !ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original ||
+        !GetViewCoordinator(taskbarWindow)) {
+        Wh_Log(L"Reveal result for taskbar %p: coordinator=0 shell=0",
+               taskbarWindow);
+        return false;
     }
 
-    Wh_Log(L"Reveal result for taskbar %p: shell=%d coordinator=%d",
-           taskbarWindow,
-           shellWindowRevealed,
-           coordinatorExpanded);
+    // Ask TrayUI/CSecondaryTray to perform the physical shell-window unhide
+    // before asserting synthetic pointer-over. Besides matching Explorer-facing
+    // precedent, this avoids accepting a coordinator-only reveal whose window
+    // could remain on an incorrect slide/Z-order path.
+    if (!InvokeNativeShellUnhideOnUiThread(taskbarWindow)) {
+        Wh_Log(L"Native shell unhide unavailable for taskbar %p; reveal "
+               L"aborted before synthetic ownership",
+               taskbarWindow);
+        return false;
+    }
 
-    return coordinatorExpanded;
+    if (!SetSyntheticPointerOverOnUiThread(taskbarWindow, true)) {
+        // The prerequisites were checked immediately above on the same UI
+        // thread, so this is only a defensive race/reentrancy case. Explorer's
+        // native unhide owns any transient reveal and can hide it normally;
+        // don't record synthetic ownership in the worker.
+        Wh_Log(L"Coordinator enter failed after native shell unhide for taskbar "
+               L"%p",
+               taskbarWindow);
+        return false;
+    }
+
+    Wh_Log(L"Reveal result for taskbar %p: shell=1 coordinator=1",
+           taskbarWindow);
+    return true;
 }
 
 void ClearAllSyntheticPointerOverOnUiThread() {
@@ -1116,7 +1209,6 @@ bool HandleTaskbarUiOperation(HWND taskbarWindow,
             ClearAllSyntheticPointerOverOnUiThread();
             *result = 1;
             return true;
-
     }
 
     return false;
@@ -1146,7 +1238,7 @@ UiOperationResult SendUiOperation(UiOperation operation,
         destination = FindAnyTaskbarWindow();
     }
 
-    if (!destination || !IsTaskbarClass(destination) ||
+    if (!destination || !IsSupportedTaskbarWindow(destination) ||
         !IsCurrentProcessWindow(destination)) {
         return UiOperationResult::kNotSent;
     }
@@ -1191,7 +1283,6 @@ struct ActivationWorkerState {
     HMONITOR activeTaskbarMonitor = nullptr;
     HMONITOR activationCandidateMonitor = nullptr;
     HMONITOR bandEntryMonitor = nullptr;
-    HMONITOR activationDelayBypassMonitor = nullptr;
     bool armed = true;
     WorkerTimer releaseTimer;
     WorkerTimer retryTimer;
@@ -1200,8 +1291,34 @@ struct ActivationWorkerState {
     ULONGLONG activeSince = 0;
     ULONGLONG lastActivationCheck = 0;
     unsigned suppressionFailures = 0;
+    unsigned hiddenRepairAttempts = 0;
     unsigned appliedSettingsGeneration = 0;
+    unsigned appliedDisplayGeneration = 0;
+    std::unordered_map<HMONITOR, UINT> monitorDpiYCache;
 };
+
+UINT GetMonitorDpiYCached(ActivationWorkerState& state, HMONITOR monitor) {
+    const unsigned displayGeneration =
+        g_displayGeneration.load(std::memory_order_acquire);
+    if (state.appliedDisplayGeneration != displayGeneration) {
+        state.monitorDpiYCache.clear();
+        state.appliedDisplayGeneration = displayGeneration;
+    }
+
+    if (auto it = state.monitorDpiYCache.find(monitor);
+        it != state.monitorDpiYCache.end()) {
+        return it->second;
+    }
+
+    UINT dpiX = 96;
+    UINT dpiY = 96;
+    if (FAILED(GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY))) {
+        dpiY = 96;
+    }
+
+    state.monitorDpiYCache.emplace(monitor, dpiY);
+    return dpiY;
+}
 
 void CancelWorkerTimer(WorkerTimer& timer) {
     if (!timer.id) {
@@ -1286,7 +1403,7 @@ void ScheduleRetry(ActivationWorkerState& state, UINT delayMs) {
 UINT AdvanceSuppressionBackoff(ActivationWorkerState& state) {
     state.suppressionFailures =
         std::min(state.suppressionFailures + 1, 8U);
-    const unsigned shift = std::min(state.suppressionFailures - 1, 4U);
+    const unsigned shift = std::min(state.suppressionFailures - 1, 5U);
     return std::min(kActivationRetryIntervalMs << shift,
                     kSuppressionBackoffMaxMs);
 }
@@ -1302,7 +1419,8 @@ void ResetActivationCandidate(ActivationWorkerState& state) {
 
 void ResetBandEntry(ActivationWorkerState& state) {
     state.bandEntryMonitor = nullptr;
-    state.activationDelayBypassMonitor = nullptr;
+    state.hiddenRepairAttempts = 0;
+    state.lastActivationCheck = 0;
     ResetActivationCandidate(state);
 }
 
@@ -1318,7 +1436,6 @@ void ProcessPointerState(ActivationWorkerState& state) {
         }
 
         ResetBandEntry(state);
-        state.lastActivationCheck = 0;
         state.suppressionFailures = 0;
         state.appliedSettingsGeneration = settingsGeneration;
     }
@@ -1347,8 +1464,10 @@ void ProcessPointerState(ActivationWorkerState& state) {
     }
 
     const ULONGLONG now = GetTickCount64();
+    const UINT pointerMonitorDpiY =
+        GetMonitorDpiYCached(state, pointerMonitor);
     const bool insideActivationBand =
-        IsPointInsideActivationBand(pointer, pointerMonitor, monitorInfo);
+        IsPointInsideActivationBand(pointer, monitorInfo, pointerMonitorDpiY);
 
     if (state.activeTaskbar) {
         if (state.releaseRetryPending) {
@@ -1381,14 +1500,26 @@ void ProcessPointerState(ActivationWorkerState& state) {
                 visibilityCheckReady &&
                 !IsTaskbarVisiblyRevealed(state.activeTaskbar,
                                            state.activeTaskbarMonitor)) {
-                HMONITOR hiddenMonitor = state.activeTaskbarMonitor;
-                Wh_Log(L"Active taskbar %p is no longer visibly revealed; "
-                       L"re-arming",
+                Wh_Log(L"Active taskbar %p is no longer visibly revealed",
                        state.activeTaskbar);
                 if (!ClearActiveTaskbar(state)) {
                     return;
                 }
-                state.activationDelayBypassMonitor = hiddenMonitor;
+
+                if (state.hiddenRepairAttempts >=
+                    kMaxHiddenRepairsPerBandEntry) {
+                    // Another component is persistently hiding the taskbar.
+                    // Don't fight it at 5 Hz; wait for a genuine band exit
+                    // before allowing another activation attempt.
+                    Wh_Log(L"Unexpected hide persisted; waiting for activation "
+                           L"band exit before retrying");
+                    state.armed = false;
+                    CancelWorkerTimer(state.retryTimer);
+                    return;
+                }
+
+                state.hiddenRepairAttempts++;
+                ResetActivationCandidate(state);
             } else if (sameMonitorBand || overVisibleTaskbar) {
                 CancelWorkerTimer(state.releaseTimer);
                 return;
@@ -1422,6 +1553,9 @@ void ProcessPointerState(ActivationWorkerState& state) {
     if (state.bandEntryMonitor != pointerMonitor) {
         state.bandEntryMonitor = pointerMonitor;
         state.armed = true;
+        state.lastActivationCheck = 0;
+        state.suppressionFailures = 0;
+        state.hiddenRepairAttempts = 0;
         ResetActivationCandidate(state);
     }
 
@@ -1432,16 +1566,14 @@ void ProcessPointerState(ActivationWorkerState& state) {
 
     const int activationDelay =
         g_settings.activationDelayMs.load(std::memory_order_relaxed);
-    const bool bypassActivationDelay =
-        state.activationDelayBypassMonitor == pointerMonitor;
     if (state.activationCandidateMonitor != pointerMonitor) {
         state.activationCandidateMonitor = pointerMonitor;
         state.activationCandidateSince = now;
-        if (activationDelay > 0 && !bypassActivationDelay) {
+        if (activationDelay > 0) {
             ScheduleRetry(state, static_cast<UINT>(activationDelay));
             return;
         }
-    } else if (!bypassActivationDelay) {
+    } else {
         const ULONGLONG candidateElapsed =
             now - state.activationCandidateSince;
         if (candidateElapsed < static_cast<ULONGLONG>(activationDelay)) {
@@ -1462,7 +1594,6 @@ void ProcessPointerState(ActivationWorkerState& state) {
         return;
     }
 
-    state.activationDelayBypassMonitor = nullptr;
     state.lastActivationCheck = now;
     CancelWorkerTimer(state.retryTimer);
 
@@ -1473,6 +1604,13 @@ void ProcessPointerState(ActivationWorkerState& state) {
 
     if (g_settings.primaryMonitorOnly.load(std::memory_order_relaxed) &&
         (monitorInfo.dwFlags & MONITORINFOF_PRIMARY) == 0) {
+        ScheduleSuppressedRetry(state);
+        return;
+    }
+
+    HWND taskbarWindow = FindTaskbarForMonitor(pointerMonitor);
+    if (!taskbarWindow) {
+        Wh_Log(L"Activation suppressed: no bottom taskbar found");
         ScheduleSuppressedRetry(state);
         return;
     }
@@ -1494,13 +1632,6 @@ void ProcessPointerState(ActivationWorkerState& state) {
     if (g_settings.ignoreFullscreenApps.load(std::memory_order_relaxed) &&
         IsFullscreenWindowOnMonitor(pointerMonitor)) {
         Wh_Log(L"Activation suppressed: fullscreen app detected");
-        ScheduleSuppressedRetry(state);
-        return;
-    }
-
-    HWND taskbarWindow = FindTaskbarForMonitor(pointerMonitor);
-    if (!taskbarWindow) {
-        Wh_Log(L"Activation suppressed: no bottom taskbar found");
         ScheduleSuppressedRetry(state);
         return;
     }
@@ -1531,29 +1662,6 @@ void ProcessPointerState(ActivationWorkerState& state) {
     ScheduleSuppressedRetry(state);
 }
 
-void HandleNativePointerLeave(ActivationWorkerState& state,
-                              HWND taskbarWindow) {
-    if (!taskbarWindow || state.activeTaskbar != taskbarWindow) {
-        return;
-    }
-
-    const HMONITOR previousMonitor = state.activeTaskbarMonitor;
-    CancelWorkerTimer(state.releaseTimer);
-    CancelWorkerTimer(state.retryTimer);
-    state.releaseRetryPending = false;
-    state.activeTaskbar = nullptr;
-    state.activeTaskbarMonitor = nullptr;
-    state.activeSince = 0;
-    state.armed = true;
-    state.suppressionFailures = 0;
-    ResetActivationCandidate(state);
-    state.activationDelayBypassMonitor = previousMonitor;
-
-    Wh_Log(L"Re-arming after Explorer pointer leave for taskbar %p",
-           taskbarWindow);
-    ProcessPointerState(state);
-}
-
 void HandleReleaseTimer(ActivationWorkerState& state) {
     CancelWorkerTimer(state.releaseTimer);
 
@@ -1580,11 +1688,13 @@ void HandleReleaseTimer(ActivationWorkerState& state) {
 
         if (pointerMonitor &&
             GetMonitorInfoW(pointerMonitor, &monitorInfo)) {
+            const UINT pointerMonitorDpiY =
+                GetMonitorDpiYCached(state, pointerMonitor);
             const bool insideActivationBand =
                 IsPointInsideActivationBand(
                     pointer,
-                    pointerMonitor,
-                    monitorInfo);
+                    monitorInfo,
+                    pointerMonitorDpiY);
             const bool overVisibleTaskbar =
                 IsPointOverTaskbar(state.activeTaskbar, pointer);
 
@@ -1616,26 +1726,14 @@ void CALLBACK CursorWinEventProc(HWINEVENTHOOK,
         return;
     }
 
-    DWORD workerThreadId =
-        g_workerThreadId.load(std::memory_order_relaxed);
-    if (!workerThreadId ||
-        g_cursorUpdatePosted.exchange(true, std::memory_order_relaxed)) {
-        return;
-    }
-
-    if (!PostThreadMessageW(workerThreadId,
-                            kWorkerCursorChangedMessage,
-                            0,
-                            0)) {
-        g_cursorUpdatePosted.store(false, std::memory_order_relaxed);
-    }
+    QueuePointerStateUpdate();
 }
 
 DWORD WINAPI ActivationWorkerThread(LPVOID) {
     // Force creation of this thread's message queue before publishing its ID.
     MSG message{};
     PeekMessageW(&message, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
-    g_workerThreadId.store(GetCurrentThreadId(), std::memory_order_relaxed);
+    g_workerThreadId.store(GetCurrentThreadId(), std::memory_order_release);
 
     // The hook is system-wide because WinEvent can't filter by object ID at
     // registration time. CursorWinEventProc immediately discards every event
@@ -1656,6 +1754,11 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
                GetLastError());
         fallbackPollTimerId =
             SetTimer(nullptr, 0, 150, nullptr);
+        if (!fallbackPollTimerId) {
+            Wh_Log(L"Fallback cursor timer creation failed: %u; cursor "
+                   L"tracking is unavailable",
+                   GetLastError());
+        }
     }
 
     ActivationWorkerState state;
@@ -1688,18 +1791,12 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
             switch (message.message) {
                 case kWorkerCursorChangedMessage:
                     g_cursorUpdatePosted.store(false,
-                                               std::memory_order_relaxed);
+                                               std::memory_order_release);
                     ProcessPointerState(state);
                     break;
 
                 case kWorkerSettingsChangedMessage:
                     ProcessPointerState(state);
-                    break;
-
-                case kWorkerNativePointerLeaveMessage:
-                    HandleNativePointerLeave(
-                        state,
-                        reinterpret_cast<HWND>(message.wParam));
                     break;
 
                 case WM_TIMER:
@@ -1725,10 +1822,12 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
     }
 
     CancelWorkerTimer(state.retryTimer);
+    CancelWorkerTimer(state.releaseTimer);
 
     // Keep unload bounded if Explorer's taskbar UI thread is unresponsive. A
     // single best-effort release is sufficient; an indeterminate send may still
-    // be delivered later, and a real pointer transition repairs stale state.
+    // be delivered later, and Explorer teardown discards taskbar coordinator
+    // state with the window.
     if (state.activeTaskbar) {
         (void)ClearActiveTaskbar(state, 250, false);
     }
@@ -1739,8 +1838,8 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
         KillTimer(nullptr, fallbackPollTimerId);
     }
 
-    g_cursorUpdatePosted.store(false, std::memory_order_relaxed);
-    g_workerThreadId.store(0, std::memory_order_relaxed);
+    g_cursorUpdatePosted.store(false, std::memory_order_release);
+    g_workerThreadId.store(0, std::memory_order_release);
     return 0;
 }
 
@@ -1753,15 +1852,15 @@ bool HookTaskbarViewSymbols(HMODULE module) {
             },
             &ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original,
             ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook,
-            true,
+            true,  // Checked as a required pair below for a clearer diagnostic.
         },
         {
             {
-                LR"(public: void __cdecl winrt::Taskbar::implementation::ViewCoordinator::UpdateIsExpanded(unsigned __int64,enum TaskbarTipTest::TaskbarExpandCollapseReason))",
+                LR"(public: bool __cdecl winrt::Taskbar::implementation::ViewCoordinator::ShouldTaskbarBeExpanded(unsigned __int64,bool))",
             },
-            &ViewCoordinator_UpdateIsExpanded_Original,
-            ViewCoordinator_UpdateIsExpanded_Hook,
-            true,
+            &ViewCoordinator_ShouldTaskbarBeExpanded_Original,
+            ViewCoordinator_ShouldTaskbarBeExpanded_Hook,
+            true,  // Checked as a required pair below for a clearer diagnostic.
         },
     };
 
@@ -1774,7 +1873,7 @@ bool HookTaskbarViewSymbols(HMODULE module) {
     }
 
     if (!ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original ||
-        !ViewCoordinator_UpdateIsExpanded_Original) {
+        !ViewCoordinator_ShouldTaskbarBeExpanded_Original) {
         Wh_Log(L"Taskbar reveal path unavailable: required ViewCoordinator "
                L"symbols need updating");
         return false;
@@ -1802,7 +1901,6 @@ bool HookTaskbarUiThreadSymbol() {
             },
             &g_trayUiVtableITrayComponentHost,
             nullptr,
-            true,
         },
         {
             {
@@ -1810,7 +1908,6 @@ bool HookTaskbarUiThreadSymbol() {
             },
             &TrayUI_Unhide_Original,
             nullptr,
-            true,
         },
         {
             {
@@ -1833,6 +1930,7 @@ bool HookTaskbarUiThreadSymbol() {
             },
             &CSecondaryTray_WndProc_Original,
             CSecondaryTray_WndProc_Hook,
+            true,
         },
     };
 
@@ -1840,44 +1938,21 @@ bool HookTaskbarUiThreadSymbol() {
             taskbarModule,
             symbolHooks,
             ARRAYSIZE(symbolHooks))) {
-        Wh_Log(L"Failed to hook native taskbar symbols");
+        Wh_Log(L"Failed to hook required native taskbar symbols");
         return false;
     }
 
+    const bool secondaryTaskbarSupportAvailable =
+        CSecondaryTray_Unhide_Original && CSecondaryTray_WndProc_Original;
+    g_secondaryTaskbarSupportAvailable.store(
+        secondaryTaskbarSupportAvailable,
+        std::memory_order_release);
+    if (!secondaryTaskbarSupportAvailable) {
+        Wh_Log(L"Secondary taskbar support unavailable: optional "
+               L"CSecondaryTray symbols need updating");
+    }
+
     return true;
-}
-
-void CaptureExistingTaskbarObjects() {
-    EnumWindows(
-        [](HWND window, LPARAM) -> BOOL {
-            if (!IsTaskbarClass(window)) {
-                return TRUE;
-            }
-
-            DWORD processId = 0;
-            GetWindowThreadProcessId(window, &processId);
-
-            if (processId == GetCurrentProcessId()) {
-                DWORD_PTR result = 0;
-                SetLastError(ERROR_SUCCESS);
-                if (!SendMessageTimeoutW(
-                        window,
-                        g_captureTaskbarObjectMessage,
-                        0,
-                        0,
-                        SMTO_ABORTIFHUNG | SMTO_BLOCK,
-                        500,
-                        &result)) {
-                    Wh_Log(L"Taskbar object capture timed out or failed for "
-                           L"%p: %u",
-                           window,
-                           GetLastError());
-                }
-            }
-
-            return TRUE;
-        },
-        0);
 }
 
 HMODULE GetTaskbarViewModuleHandle() {
@@ -1892,8 +1967,12 @@ HMODULE GetTaskbarViewModuleHandle() {
 
 void HandleLoadedTaskbarViewModule(HMODULE module,
                                    LPCWSTR libraryFileName) {
+    if (g_unloading.load(std::memory_order_acquire)) {
+        return;
+    }
+
     if (!module || g_taskbarViewDllLoaded.load(
-                       std::memory_order_relaxed)) {
+                       std::memory_order_acquire)) {
         return;
     }
 
@@ -1903,7 +1982,7 @@ void HandleLoadedTaskbarViewModule(HMODULE module,
 
     if (g_taskbarViewDllLoaded.exchange(
             true,
-            std::memory_order_relaxed)) {
+            std::memory_order_acq_rel)) {
         return;
     }
 
@@ -1912,6 +1991,7 @@ void HandleLoadedTaskbarViewModule(HMODULE module,
 
     if (HookTaskbarViewSymbols(module)) {
         Wh_ApplyHookOperations();
+        QueuePointerStateUpdate();
     }
 }
 
@@ -1924,7 +2004,7 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR libraryFileName,
     HMODULE module =
         LoadLibraryExW_Original(libraryFileName, file, flags);
 
-    if (module) {
+    if (module && !((ULONG_PTR)module & 3)) {
         HandleLoadedTaskbarViewModule(module, libraryFileName);
     }
 
@@ -1938,12 +2018,8 @@ BOOL Wh_ModInit() {
 
     g_uiThreadMessage =
         RegisterWindowMessageW(L"taskbar-activation-threshold.ui");
-    g_captureTaskbarObjectMessage =
-        RegisterWindowMessageW(L"taskbar-activation-threshold.capture");
-    if (!g_uiThreadMessage || !g_captureTaskbarObjectMessage) {
-        Wh_Log(L"RegisterWindowMessageW failed: ui=%u capture=%u",
-               g_uiThreadMessage,
-               g_captureTaskbarObjectMessage);
+    if (!g_uiThreadMessage) {
+        Wh_Log(L"RegisterWindowMessageW failed for UI operation channel");
         return FALSE;
     }
 
@@ -1961,7 +2037,7 @@ BOOL Wh_ModInit() {
 
         g_taskbarViewDllLoaded.store(
             true,
-            std::memory_order_relaxed);
+            std::memory_order_release);
     } else {
         Wh_Log(L"Taskbar.View.dll/ExplorerExtensions.dll isn't loaded yet");
 
@@ -1997,30 +2073,35 @@ void Wh_ModAfterInit() {
     Wh_Log(L"Looking for taskbar windows in this Explorer process");
 
     // Only the shell Explorer instance registers Shell_TrayWnd. Folder-window
-    // Explorer processes skip the capture pass and never create the activation
-    // worker or its system-wide WinEvent hook.
+    // Explorer processes never create the activation worker or its system-wide
+    // WinEvent hook.
     WNDCLASSW taskbarClass{};
     if (GetClassInfoW(GetModuleHandleW(nullptr),
                       L"Shell_TrayWnd",
                       &taskbarClass)) {
-        CaptureExistingTaskbarObjects();
+        // Existing taskbar objects don't need a separate object-discovery send: the
+        // first marshalled UI operation records its WndProc pThis before the
+        // operation is dispatched. This leaves worker startup independent of
+        // taskbar UI-thread responsiveness.
+        EnsureActivationWorker();
     } else {
-        Wh_Log(L"No Shell_TrayWnd class in this Explorer process; worker not "
-               L"started");
+        Wh_Log(L"Shell_TrayWnd class isn't registered/created in this Explorer "
+               L"process yet; a later taskbar WM_NCCREATE can start the worker");
     }
 
     // Retry in case the taskbar view module loaded between Wh_ModInit and hook
     // application.
-    if (!g_taskbarViewDllLoaded.load(std::memory_order_relaxed)) {
+    if (!g_taskbarViewDllLoaded.load(std::memory_order_acquire)) {
         if (HMODULE taskbarViewModule =
                 GetTaskbarViewModuleHandle()) {
             if (!g_taskbarViewDllLoaded.exchange(
                     true,
-                    std::memory_order_relaxed)) {
+                    std::memory_order_acq_rel)) {
                 Wh_Log(L"Found taskbar view module after initialization");
 
                 if (HookTaskbarViewSymbols(taskbarViewModule)) {
                     Wh_ApplyHookOperations();
+                    QueuePointerStateUpdate();
                 }
             }
         }
@@ -2079,12 +2160,13 @@ void Wh_ModSettingsChanged() {
     LoadSettings();
     g_settingsGeneration.fetch_add(1, std::memory_order_release);
 
-    DWORD workerThreadId =
-        g_workerThreadId.load(std::memory_order_relaxed);
-    if (workerThreadId) {
-        PostThreadMessageW(workerThreadId,
-                           kWorkerSettingsChangedMessage,
-                           0,
-                           0);
+    const DWORD workerThreadId =
+        g_workerThreadId.load(std::memory_order_acquire);
+    if (workerThreadId &&
+        !PostThreadMessageW(workerThreadId,
+                            kWorkerSettingsChangedMessage,
+                            0,
+                            0)) {
+        Wh_Log(L"Couldn't queue settings update: %u", GetLastError());
     }
 }

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -18,13 +18,8 @@
 Reveal the auto-hidden Windows 11 taskbar from a configurable activation band
 above the bottom edge of the screen.
 
-Unlike approaches that move or inject the pointer, this mod keeps the cursor
-stationary and invokes Explorer's native Windows 11 taskbar pointer-over path
-on the taskbar UI thread.
-
-The activation threshold is scaled independently for each monitor's DPI.
-Cursor movement is detected through Windows accessibility events rather than
-continuous polling, minimizing background activity while the pointer is idle.
+The cursor stays stationary. The mod tracks cursor movement, then asks Explorer
+on the taskbar UI thread to use its native taskbar unhide and pointer-over paths.
 
 ## Demonstration
 
@@ -34,93 +29,91 @@ continuous polling, minimizing background activity while the pointer is idle.
 
 - Configurable activation-band height and hover delay
 - Per-monitor DPI scaling
-- Multi-monitor and secondary-taskbar support; monitors without a taskbar are
-  ignored rather than redirected to another monitor
+- Multi-monitor and secondary-taskbar support
 - Adjustable release delay
-- Optional suppression over fullscreen applications and presentation mode
+- Optional fullscreen/presentation suppression
 - Optional suppression while a mouse button is held
-- Optional restriction to the primary monitor
-- No cursor movement, pointer injection, taskbar layout modification, or
-  Explorer timer manipulation
+- Optional primary-monitor-only mode
+- No cursor injection, taskbar layout changes, Explorer timer manipulation, or
+  taskbar Z-order forcing
 
 ## Behavior
 
-The activation band controls where the taskbar can be revealed. After it is
-visible, the taskbar stays open while the pointer is either inside that band or
-over the taskbar itself, so moving onto taskbar buttons doesn't immediately hide
-it. If the band is taller than the taskbar, moving from the taskbar into the
-upper part of the band also keeps the reveal stable. The release delay begins
-only after the pointer has left both areas.
+The activation threshold controls where the taskbar can be revealed. Once this
+mod reveals a taskbar, it keeps Explorer's synthetic pointer-over state until
+the pointer has left both the activation band and the visible taskbar, then
+waits for the configured release delay before clearing it.
+
+With a typical Windows 11 taskbar, the default 24-DIP band is shorter than the
+taskbar itself. In that common case the threshold mainly changes the trigger
+area; after reveal, the taskbar's own rectangle keeps it open while you use its
+buttons. Values larger than the taskbar height additionally let the pointer sit
+in the strip above the visible taskbar without collapsing it.
 
 ## Compatibility
 
-The mod does not modify:
+The mod is intended for the standard bottom-positioned Windows 11 taskbar. It
+doesn't modify taskbar geometry, XAML, height, icon size, animation duration,
+transparency, the Windows auto-hide setting, or Z-order.
 
-- Taskbar position or geometry
-- XAML layout or styles
-- Taskbar height or icon size
-- Animation duration
-- Transparency
-- Windows' auto-hide setting
-- Taskbar Z-order
+Taskbar Z-order remains Explorer's responsibility. The mod deliberately uses
+Explorer's native TrayUI/CSecondaryTray unhide before asserting synthetic
+pointer-over, but it never calls `SetWindowPos` or forces `HWND_TOPMOST`.
+Unusual shell layering or a Z-order customization can therefore still affect
+which window appears above the taskbar.
 
-It is designed to coexist with taskbar styling, sizing, transparency,
-animation, clock, label, and icon mods that retain the standard Windows 11
-taskbar and don't replace its native reveal logic. Taskbar Z-order is left to
-Explorer; this mod never forces the taskbar topmost or reorders application
-windows, so mods that deliberately change shell Z-order can affect layering.
+**Taskbar auto-hide custom activation area** controls the allowed region along
+the taskbar, while this mod enlarges the trigger distance perpendicular to the
+bottom edge. The implementations solve different trigger problems, but both
+hook Explorer's pointer-over path. This mod temporarily holds Explorer's
+pointer-leave while it owns an enlarged-band reveal, whereas that mod observes
+and filters the same events. Installing both can therefore be hook-order
+sensitive and isn't guaranteed to combine cleanly.
+
+Mods that replace or intentionally suppress Explorer's native reveal behavior
+(such as keyboard-only or never-show mouse modes) are intentionally
+incompatible with mouse activation from this mod.
 
 ## Requirements
 
 - Windows 11
-- The standard Windows 11 taskbar
-- A bottom-positioned taskbar
-- **Automatically hide the taskbar** enabled in Windows, unless
-  **Require Windows auto-hide** is disabled in the mod settings
+- Standard Windows 11 taskbar
+- Bottom-positioned taskbar
+- **Automatically hide the taskbar** enabled, unless **Require Windows
+  auto-hide** is disabled
 
 ## Known limitations
 
-- Top-, left-, right-, detached-, and arbitrarily positioned taskbars are not
+- Top-, left-, right-, detached-, and arbitrary-position taskbars aren't
   supported.
-- ExplorerPatcher's legacy Windows 10 taskbar is not supported.
-- Mods that disable, replace, or override the taskbar's native expansion logic
-  can conflict with this mod. Keyboard-only and never-show auto-hide modes are
-  intentionally incompatible with mouse activation.
-- The mod relies on Explorer's native unhide path to maintain normal taskbar
-  layering. It doesn't apply an independent Z-order correction; unusual shell
-  layering or a Z-order customization can therefore leave a reveal behind
-  another window until Explorer re-establishes its normal ordering.
-- Reveal depends on Windows 11 taskbar implementation symbols, including
+- ExplorerPatcher's legacy Windows 10 taskbar isn't supported.
+- The Windows `ABM_GETSTATE` auto-hide flag is system-wide. With per-monitor
+  auto-hide mods, **Require Windows auto-hide** can't determine the auto-hide
+  state of an individual monitor.
+- Reveal depends on undocumented Windows 11 taskbar symbols, including
   `ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged`,
   `ViewCoordinator::ShouldTaskbarBeExpanded`, and the native TrayUI/secondary
-  tray unhide paths. `ShouldTaskbarBeExpanded` is hooked only to capture
-  Explorer's coordinator early; its return value is never changed. The mod
-  requires the complete coordinator + native-shell reveal path for a taskbar
-  rather than accepting a partial reveal. If a Windows update changes a
-  required primary-taskbar symbol, initialization fails or the reveal path logs
-  that it needs an update. Secondary-taskbar symbols are optional so a secondary
-  symbol change doesn't disable primary-monitor operation; affected secondary
-  taskbars are skipped instead of using a partial reveal.
-- Fullscreen suppression ignores click-through, tool, non-activating, cloaked,
-  desktop, and taskbar windows. It is intentionally conservative otherwise: a
-  qualifying fullscreen window anywhere above the desktop on the target
-  monitor can suppress activation even when another app has focus. A
-  borderless custom-chrome window that covers the monitor can therefore be
-  treated as fullscreen. Windows presentation mode is reported system-wide, so
-  it suppresses activation on every monitor while active. Suppression is
-  checked before a reveal; it doesn't forcibly hide a taskbar that was already
-  revealed if an app becomes fullscreen afterwards.
+  tray unhide paths. `ShouldTaskbarBeExpanded` is pass-through and is hooked
+  only to capture Explorer's coordinator early. A Windows update can require
+  symbol updates. Secondary-taskbar symbols are optional so a secondary symbol
+  change doesn't disable the primary taskbar.
+- Fullscreen suppression checks Windows presentation/exclusive-fullscreen
+  state and the topmost eligible application window on the target monitor.
+  Background fullscreen windows behind another normal app don't suppress the
+  band. Click-through, tool, non-activating, cloaked, desktop, and taskbar
+  windows are ignored. Presentation mode is system-wide. Suppression is checked
+  before reveal; it doesn't continuously force-hide an already revealed
+  taskbar if an app later becomes fullscreen.
 - Cursor tracking uses a system-wide `EVENT_OBJECT_LOCATIONCHANGE` WinEvent
   hook because Windows can't filter that hook to `OBJID_CURSOR` at
-  registration time. Non-cursor events are discarded immediately by the
-  callback. If the WinEvent hook can't be installed, the mod falls back to a
-  150 ms cursor check.
+  registration time. Non-cursor events are discarded immediately. If the hook
+  can't be installed, a 150 ms cursor-check timer is used instead.
 
 ## Attribution and license
 
-The Windows 11 `ViewCoordinator` symbols and UI-thread invocation technique were
-informed by the GPL-3.0-licensed **Taskbar auto-hide fine tuning** Windhawk mod
-by m417z.
+The Windows 11 taskbar symbols and native reveal techniques were informed by
+GPL-3.0-licensed Windhawk taskbar mods by m417z, including **Taskbar auto-hide
+fine tuning** and **Taskbar auto-hide custom activation area**.
 
 This mod is distributed under the GNU General Public License v3.0.
 */
@@ -131,33 +124,32 @@ This mod is distributed under the GNU General Public License v3.0.
 - activationThresholdPx: 24
   $name: Activation threshold
   $description: >-
-    Height of the activation band in logical pixels at 96 DPI. The value is
-    scaled independently for each monitor. Recommended range: 12 to 48.
+    Height of the activation band in logical pixels at 96 DPI, scaled for each
+    monitor. 12-48 is a practical range for most taskbars; values taller than
+    the taskbar also keep it open while the pointer is in the strip above it.
 - activationDelayMs: 75
   $name: Hover delay
   $description: >-
-    Time in milliseconds that the pointer must remain in the activation band
-    before the taskbar is revealed. A short delay prevents accidental reveals
-    while moving between vertically stacked monitors.
+    Time the pointer must remain in the activation band before revealing the
+    taskbar. A short delay helps avoid accidental reveals when crossing between
+    vertically stacked monitors.
 - releaseDelayMs: 120
   $name: Release delay
   $description: >-
-    Delay before the taskbar is allowed to hide again after the pointer leaves
-    both the activation band and the visible taskbar.
+    Delay before the taskbar is allowed to hide after the pointer leaves both
+    the activation band and the visible taskbar.
 - requireWindowsAutoHide: true
   $name: Require Windows auto-hide
   $description: >-
-    Only activate when Windows reports that taskbar auto-hide is enabled.
-    Disable this when another mod manages auto-hide without enabling the
-    Windows setting.
+    Only activate when Windows' system-wide auto-hide flag is enabled. Disable
+    this if another mod manages auto-hide independently; per-monitor auto-hide
+    states can't be distinguished by this Windows flag.
 - ignoreFullscreenApps: true
   $name: Ignore fullscreen apps
   $description: >-
-    Don't reveal while Windows presentation mode is active or when a
-    qualifying fullscreen app is detected on the target monitor. Click-through,
-    tool, non-activating, cloaked, desktop, and taskbar windows are ignored. A
-    qualifying background fullscreen window on that monitor can still suppress
-    activation.
+    Don't reveal during Windows presentation/exclusive-fullscreen state or when
+    the topmost eligible app on the target monitor is fullscreen. Background
+    fullscreen apps behind another normal app don't suppress activation.
 - ignoreWhileMouseButtonDown: true
   $name: Ignore while dragging
   $description: >-
@@ -195,7 +187,6 @@ struct Settings {
 Settings g_settings;
 
 std::atomic<bool> g_taskbarViewDllLoaded{false};
-std::atomic<unsigned> g_settingsGeneration{0};
 std::atomic<DWORD> g_workerThreadId{0};
 std::atomic<bool> g_cursorUpdatePosted{false};
 std::atomic<HWND> g_mainTaskbarWindow{nullptr};
@@ -216,14 +207,8 @@ enum UiOperation : WPARAM {
 };
 
 constexpr UINT kWorkerCursorChangedMessage = WM_APP + 1;
-constexpr UINT kWorkerSettingsChangedMessage = WM_APP + 2;
-constexpr UINT kReleaseRetryMs = 250;
-constexpr UINT kActivationRetryIntervalMs = 200;
-constexpr UINT kSuppressionBackoffMaxMs = 5000;
-constexpr ULONGLONG kRevealVisibilityGraceMs = 400;
-constexpr unsigned kMaxHiddenRepairsPerBandEntry = 1;
-
-std::atomic<unsigned> g_displayGeneration{0};
+constexpr UINT kUiRetryIntervalMs = 250;
+constexpr UINT kActivationCheckIntervalMs = 200;
 
 // These containers are used by taskbar implementation callbacks and by
 // operations marshalled to the taskbar UI thread. This matches the threading
@@ -277,15 +262,30 @@ void LoadSettings() {
 }
 
 void EnsureActivationWorker() {
-    if (g_unloading.load(std::memory_order_acquire) || !g_stopEvent ||
-        g_workerThread.load(std::memory_order_acquire)) {
+    if (g_unloading.load(std::memory_order_acquire) || !g_stopEvent) {
         return;
     }
 
     std::lock_guard<std::mutex> guard(g_workerThreadMutex);
-    if (g_unloading.load(std::memory_order_relaxed) ||
-        g_workerThread.load(std::memory_order_relaxed)) {
+    if (g_unloading.load(std::memory_order_relaxed)) {
         return;
+    }
+
+    HANDLE existing = g_workerThread.load(std::memory_order_acquire);
+    if (existing) {
+        const DWORD state = WaitForSingleObject(existing, 0);
+        if (state == WAIT_TIMEOUT) {
+            return;
+        }
+        if (state == WAIT_OBJECT_0) {
+            g_workerThread.store(nullptr, std::memory_order_release);
+            CloseHandle(existing);
+            Wh_Log(L"Restarting activation worker after prior thread exit");
+        } else {
+            Wh_Log(L"Couldn't query activation worker state: %u",
+                   GetLastError());
+            return;
+        }
     }
 
     HANDLE workerThread = CreateThread(
@@ -316,37 +316,36 @@ void QueuePointerStateUpdate() {
     }
 }
 
-bool IsTaskbarClass(HWND window) {
+enum class TaskbarKind {
+    kNone,
+    kMain,
+    kSecondary,
+};
+
+TaskbarKind GetTaskbarKind(HWND window) {
     if (!window) {
-        return false;
+        return TaskbarKind::kNone;
     }
 
     wchar_t className[64];
     if (!GetClassNameW(window, className, ARRAYSIZE(className))) {
-        return false;
+        return TaskbarKind::kNone;
     }
 
-    return _wcsicmp(className, L"Shell_TrayWnd") == 0 ||
-           _wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0;
-}
-
-bool IsSecondaryTaskbarClass(HWND window) {
-    if (!window) {
-        return false;
+    if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
+        return TaskbarKind::kMain;
     }
-
-    wchar_t className[64];
-    return GetClassNameW(window, className, ARRAYSIZE(className)) &&
-           _wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0;
+    if (_wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0) {
+        return TaskbarKind::kSecondary;
+    }
+    return TaskbarKind::kNone;
 }
 
 bool IsSupportedTaskbarWindow(HWND window) {
-    if (!IsTaskbarClass(window)) {
-        return false;
-    }
-
-    return !IsSecondaryTaskbarClass(window) ||
-           g_secondaryTaskbarSupportAvailable.load(std::memory_order_acquire);
+    const TaskbarKind kind = GetTaskbarKind(window);
+    return kind == TaskbarKind::kMain ||
+           (kind == TaskbarKind::kSecondary &&
+            g_secondaryTaskbarSupportAvailable.load(std::memory_order_acquire));
 }
 
 bool IsCurrentProcessWindow(HWND window) {
@@ -360,13 +359,8 @@ bool IsCurrentProcessWindow(HWND window) {
 }
 
 bool IsMainTaskbarWindow(HWND window) {
-    if (!IsCurrentProcessWindow(window)) {
-        return false;
-    }
-
-    wchar_t className[64];
-    return GetClassNameW(window, className, ARRAYSIZE(className)) &&
-           _wcsicmp(className, L"Shell_TrayWnd") == 0;
+    return IsCurrentProcessWindow(window) &&
+           GetTaskbarKind(window) == TaskbarKind::kMain;
 }
 
 HWND FindMainTaskbarWindow() {
@@ -541,12 +535,8 @@ bool IsAnyMouseButtonDown() {
 }
 
 bool HasDesktopWindowClass(HWND window) {
-    if (!window) {
-        return false;
-    }
-
     wchar_t className[64];
-    if (!GetClassNameW(window, className, ARRAYSIZE(className))) {
+    if (!window || !GetClassNameW(window, className, ARRAYSIZE(className))) {
         return false;
     }
 
@@ -590,72 +580,27 @@ bool DoesClientAreaCoverMonitor(HWND window,
            points[1].y >= monitorInfo.rcMonitor.bottom - tolerance;
 }
 
-bool IsFullscreenCandidateOnMonitor(HWND window, HMONITOR monitor) {
-    if (!window || !IsWindowVisible(window) || IsIconic(window) ||
-        HasDesktopWindowClass(window) || IsTaskbarClass(window)) {
+bool IsFullscreenTopWindow(HWND window,
+                           const RECT& windowRect,
+                           const MONITORINFO& monitorInfo) {
+    constexpr int tolerance = 2;
+    if (windowRect.left > monitorInfo.rcMonitor.left + tolerance ||
+        windowRect.top > monitorInfo.rcMonitor.top + tolerance ||
+        windowRect.right < monitorInfo.rcMonitor.right - tolerance ||
+        windowRect.bottom < monitorInfo.rcMonitor.bottom - tolerance) {
         return false;
     }
 
     const LONG_PTR style = GetWindowLongPtrW(window, GWL_STYLE);
-    const LONG_PTR exStyle = GetWindowLongPtrW(window, GWL_EXSTYLE);
-
-    // Tool, click-through, wallpaper, and other non-activating surfaces can be
-    // full-monitor windows without representing a fullscreen application.
-    if ((style & WS_CHILD) != 0 ||
-        (exStyle & (WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW |
-                    WS_EX_NOACTIVATE)) != 0) {
-        return false;
-    }
-
-    // Keep the expensive DWM query after the cheap style and monitor checks.
-    if (MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST) != monitor ||
-        IsWindowCloaked(window)) {
-        return false;
-    }
-
-    MONITORINFO monitorInfo{};
-    monitorInfo.cbSize = sizeof(monitorInfo);
-    if (!GetMonitorInfoW(monitor, &monitorInfo)) {
-        return false;
-    }
-
-    RECT windowRect{};
-    if (!GetWindowRect(window, &windowRect)) {
-        return false;
-    }
-
-    constexpr int tolerance = 2;
-    const bool windowCoversMonitor =
-        windowRect.left <= monitorInfo.rcMonitor.left + tolerance &&
-        windowRect.top <= monitorInfo.rcMonitor.top + tolerance &&
-        windowRect.right >= monitorInfo.rcMonitor.right - tolerance &&
-        windowRect.bottom >= monitorInfo.rcMonitor.bottom - tolerance;
-    if (!windowCoversMonitor) {
-        return false;
-    }
-
-    // Borderless windows are the common fullscreen case. Some Store/UWP apps
-    // and browsers retain caption/frame style bits in fullscreen; for those,
-    // the client area must cover the monitor after excluding maximized windows.
     if ((style & (WS_CAPTION | WS_THICKFRAME)) == 0) {
         return true;
     }
 
-    // A maximized window fills the work area, which equals the monitor while
-    // auto-hide is enabled. Chromium, Electron, Terminal, File Explorer, and
-    // other custom-frame apps draw their title bar into the client area and
-    // would otherwise be indistinguishable from fullscreen here.
     if (IsZoomed(window)) {
         return false;
     }
 
     return DoesClientAreaCoverMonitor(window, monitorInfo);
-}
-
-void LogFullscreenCandidate(HWND window) {
-    DWORD processId = 0;
-    GetWindowThreadProcessId(window, &processId);
-    Wh_Log(L"Fullscreen candidate: hwnd=%p pid=%u", window, processId);
 }
 
 bool IsFullscreenOrPresentationNotificationState(HMONITOR monitor) {
@@ -672,10 +617,6 @@ bool IsFullscreenOrPresentationNotificationState(HMONITOR monitor) {
         return false;
     }
 
-    // The notification state is system-wide. Associate exclusive D3D
-    // fullscreen with the foreground monitor to avoid suppressing unrelated
-    // taskbars. QUNS_BUSY is deliberately not treated as fullscreen because it
-    // can mean that Presentation Settings are active without a fullscreen app.
     HWND foregroundWindow = GetForegroundWindow();
     return foregroundWindow &&
            MonitorFromWindow(foregroundWindow,
@@ -683,21 +624,21 @@ bool IsFullscreenOrPresentationNotificationState(HMONITOR monitor) {
 }
 
 bool IsFullscreenWindowOnMonitor(HMONITOR monitor) {
-    // This complements the per-monitor window walk. It catches exclusive D3D,
-    // fullscreen Store/UWP apps, and presentation mode, which don't always
-    // expose a borderless top-level window that can be recognized reliably.
     if (IsFullscreenOrPresentationNotificationState(monitor)) {
         return true;
     }
 
-    struct Context {
-        HMONITOR monitor;
-        bool found;
-    } context{monitor, false};
+    MONITORINFO monitorInfo{};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if (!GetMonitorInfoW(monitor, &monitorInfo)) {
+        return false;
+    }
 
-    // EnumWindows walks top-level windows from top to bottom in Z order. Once
-    // the desktop host is reached, all remaining windows are background or
-    // wallpaper surfaces and must not suppress taskbar activation.
+    struct Context {
+        MONITORINFO monitorInfo;
+        bool fullscreen = false;
+    } context{monitorInfo};
+
     EnumWindows(
         [](HWND window, LPARAM parameter) -> BOOL {
             auto* context = reinterpret_cast<Context*>(parameter);
@@ -705,18 +646,46 @@ bool IsFullscreenWindowOnMonitor(HMONITOR monitor) {
             if (IsShellDesktopWindow(window)) {
                 return FALSE;
             }
-
-            if (IsFullscreenCandidateOnMonitor(window, context->monitor)) {
-                LogFullscreenCandidate(window);
-                context->found = true;
-                return FALSE;
+            if (!IsWindowVisible(window) || IsIconic(window) ||
+                HasDesktopWindowClass(window) ||
+                GetTaskbarKind(window) != TaskbarKind::kNone) {
+                return TRUE;
             }
 
-            return TRUE;
+            const LONG_PTR style = GetWindowLongPtrW(window, GWL_STYLE);
+            const LONG_PTR exStyle = GetWindowLongPtrW(window, GWL_EXSTYLE);
+            if ((style & WS_CHILD) != 0 ||
+                (exStyle & (WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW |
+                            WS_EX_NOACTIVATE)) != 0) {
+                return TRUE;
+            }
+
+            RECT windowRect{};
+            RECT intersection{};
+            if (!GetWindowRect(window, &windowRect) ||
+                !IntersectRect(&intersection,
+                               &windowRect,
+                               &context->monitorInfo.rcMonitor) ||
+                IsWindowCloaked(window)) {
+                return TRUE;
+            }
+
+            // This is the topmost eligible app intersecting the target monitor.
+            // Don't continue into background windows after making this decision.
+            context->fullscreen = IsFullscreenTopWindow(
+                window, windowRect, context->monitorInfo);
+            if (context->fullscreen) {
+                DWORD processId = 0;
+                GetWindowThreadProcessId(window, &processId);
+                Wh_Log(L"Fullscreen top window: hwnd=%p pid=%u",
+                       window,
+                       processId);
+            }
+            return FALSE;
         },
         reinterpret_cast<LPARAM>(&context));
 
-    return context.found;
+    return context.fullscreen;
 }
 
 bool IsPointInsideActivationBand(const POINT& pointer,
@@ -742,35 +711,6 @@ bool IsPointOverTaskbar(HWND taskbarWindow, const POINT& pointer) {
            PtInRect(&taskbarRect, pointer);
 }
 
-bool IsTaskbarVisiblyRevealed(HWND taskbarWindow, HMONITOR monitor) {
-    if (!taskbarWindow || !monitor) {
-        return false;
-    }
-
-    RECT taskbarRect{};
-    MONITORINFO monitorInfo{};
-    monitorInfo.cbSize = sizeof(monitorInfo);
-    if (!GetWindowRect(taskbarWindow, &taskbarRect) ||
-        !GetMonitorInfoW(monitor, &monitorInfo)) {
-        return false;
-    }
-
-    RECT intersection{};
-    if (!IntersectRect(&intersection, &taskbarRect, &monitorInfo.rcMonitor)) {
-        return false;
-    }
-
-    // Hidden auto-hide taskbars leave only a thin edge onscreen. Use a small
-    // fraction of the taskbar's own height rather than a fixed physical-pixel
-    // cutoff so the repair check remains sensible on high-DPI monitors and
-    // with modest taskbar-size customization.
-    const int taskbarHeight = taskbarRect.bottom - taskbarRect.top;
-    const int visibleHeight = intersection.bottom - intersection.top;
-    const int revealedThreshold =
-        std::clamp(taskbarHeight / 4, 4, 12);
-    return visibleHeight >= revealedThreshold;
-}
-
 void* QueryViaVtable(void* object, void* targetVtable) {
     if (!object || !targetVtable) {
         return nullptr;
@@ -778,11 +718,11 @@ void* QueryViaVtable(void* object, void* targetVtable) {
 
     // The maintained Windhawk taskbar implementation locates the
     // ITrayComponentHost subobject by scanning the object's vtable pointers.
-    // Keep a conservative bound to avoid walking arbitrary memory if Microsoft
-    // changes the object layout.
+    // Keep the small scan bound used by established Windhawk taskbar mods so
+    // an object-layout change can't turn this into a wide memory walk.
     auto** candidate = reinterpret_cast<void**>(object);
 
-    for (size_t i = 0; i < 256; i++, candidate++) {
+    for (size_t i = 0; i < 20; i++, candidate++) {
         if (*candidate == targetVtable) {
             return candidate;
         }
@@ -815,6 +755,14 @@ using TrayUI_WndProc_t =
 
 TrayUI_WndProc_t TrayUI_WndProc_Original;
 
+void HandleTaskbarEnvironmentMessage(UINT message) {
+    if (message == WM_DISPLAYCHANGE || message == WM_DPICHANGED ||
+        message == WM_SETTINGCHANGE) {
+        EnsureActivationWorker();
+        QueuePointerStateUpdate();
+    }
+}
+
 LRESULT WINAPI TrayUI_WndProc_Hook(
     void* trayUi,
     HWND window,
@@ -837,15 +785,7 @@ LRESULT WINAPI TrayUI_WndProc_Hook(
         }
     }
 
-    if (message == WM_DISPLAYCHANGE || message == WM_DPICHANGED) {
-        g_displayGeneration.fetch_add(1, std::memory_order_release);
-        QueuePointerStateUpdate();
-    } else if (message == WM_SETTINGCHANGE) {
-        // Auto-hide and multi-monitor taskbar settings can change while the
-        // pointer is parked in the band. Re-evaluate without waiting for the
-        // current suppression backoff to expire.
-        QueuePointerStateUpdate();
-    }
+    HandleTaskbarEnvironmentMessage(message);
 
     const bool taskbarCreating = message == WM_NCCREATE;
     if (taskbarCreating) {
@@ -902,15 +842,7 @@ LRESULT WINAPI CSecondaryTray_WndProc_Hook(
         }
     }
 
-    if (message == WM_DISPLAYCHANGE || message == WM_DPICHANGED) {
-        g_displayGeneration.fetch_add(1, std::memory_order_release);
-        QueuePointerStateUpdate();
-    } else if (message == WM_SETTINGCHANGE) {
-        // Auto-hide and multi-monitor taskbar settings can change while the
-        // pointer is parked in the band. Re-evaluate without waiting for the
-        // current suppression backoff to expire.
-        QueuePointerStateUpdate();
-    }
+    HandleTaskbarEnvironmentMessage(message);
 
     const bool taskbarCreating = message == WM_NCCREATE;
     if (taskbarCreating) {
@@ -939,31 +871,16 @@ bool InvokeNativeShellUnhideOnUiThread(HWND taskbarWindow) {
         return false;
     }
 
-    wchar_t className[64];
-    if (!GetClassNameW(taskbarWindow,
-                       className,
-                       ARRAYSIZE(className))) {
-        return false;
-    }
-
-    if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
+    const TaskbarKind kind = GetTaskbarKind(taskbarWindow);
+    if (kind == TaskbarKind::kMain) {
         auto it = g_trayUiWndProcObjects.find(taskbarWindow);
-
         if (it == g_trayUiWndProcObjects.end() ||
-            !TrayUI_Unhide_Original ||
-            !g_trayUiVtableITrayComponentHost) {
-            Wh_Log(L"Native main-taskbar unhide unavailable: "
-                   L"object=%d vtable=%d function=%d",
-                   it != g_trayUiWndProcObjects.end(),
-                   g_trayUiVtableITrayComponentHost != nullptr,
-                   TrayUI_Unhide_Original != nullptr);
+            !TrayUI_Unhide_Original || !g_trayUiVtableITrayComponentHost) {
             return false;
         }
 
-        void* trayComponentHost =
-            QueryViaVtable(it->second,
-                           g_trayUiVtableITrayComponentHost);
-
+        void* trayComponentHost = QueryViaVtable(
+            it->second, g_trayUiVtableITrayComponentHost);
         if (!trayComponentHost) {
             Wh_Log(L"Couldn't locate ITrayComponentHost for taskbar %p",
                    taskbarWindow);
@@ -971,25 +888,17 @@ bool InvokeNativeShellUnhideOnUiThread(HWND taskbarWindow) {
         }
 
         TrayUI_Unhide_Original(trayComponentHost, 0, 0);
-        Wh_Log(L"Called TrayUI::Unhide for taskbar %p", taskbarWindow);
         return true;
     }
 
-    if (_wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0) {
+    if (kind == TaskbarKind::kSecondary) {
         auto it = g_secondaryTrayObjects.find(taskbarWindow);
-
         if (it == g_secondaryTrayObjects.end() ||
             !CSecondaryTray_Unhide_Original) {
-            Wh_Log(L"Native secondary-taskbar unhide unavailable: "
-                   L"object=%d function=%d",
-                   it != g_secondaryTrayObjects.end(),
-                   CSecondaryTray_Unhide_Original != nullptr);
             return false;
         }
 
         CSecondaryTray_Unhide_Original(it->second, 0, 0);
-        Wh_Log(L"Called CSecondaryTray::_Unhide for taskbar %p",
-               taskbarWindow);
         return true;
     }
 
@@ -1053,19 +962,19 @@ ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Hook(
     int inputDeviceKind) {
     RememberViewCoordinator(taskbarWindow, viewCoordinator);
 
-    // Calls made by this mod invoke the original function directly, so a false
-    // value reaching this hook is Explorer's physical taskbar-frame leave.
-    // While the enlarged activation band still owns a synthetic pointer-over,
-    // don't let that narrower native frame cancel it. The worker sends the
-    // matching false directly when the pointer leaves both the activation band
-    // and the visible taskbar. This also keeps thresholds taller than the
-    // taskbar from entering a native hide/reveal flicker loop.
     if (!isPointerOver &&
         g_syntheticPointerOverTaskbars.contains(taskbarWindow)) {
-        Wh_Log(L"Deferring Explorer pointer-leave while synthetic activation "
-               L"is owned for taskbar %p",
+        if (g_workerThreadId.load(std::memory_order_acquire)) {
+            // Explorer's physical frame is narrower than the configured band.
+            // Keep our synthetic enter until the worker applies releaseDelayMs.
+            return;
+        }
+
+        // Never leave the taskbar latched if the worker unexpectedly stopped.
+        g_syntheticPointerOverTaskbars.erase(taskbarWindow);
+        Wh_Log(L"Worker unavailable; releasing synthetic state for taskbar %p",
                taskbarWindow);
-        return;
+        EnsureActivationWorker();
     }
 
     ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original(
@@ -1135,43 +1044,25 @@ bool SetSyntheticPointerOverOnUiThread(HWND taskbarWindow,
 }
 
 bool RevealTaskbarOnUiThread(HWND taskbarWindow) {
-    // Refuse a shell-only reveal if Explorer's coordinator hasn't been captured
-    // yet. This keeps the operation all-or-nothing from the worker's point of
-    // view while allowing the native shell unhide to run first, matching the
-    // established Windows 11 taskbar reveal order used by maintained mods.
     if (!taskbarWindow || !IsWindow(taskbarWindow) ||
-        !ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original ||
-        !GetViewCoordinator(taskbarWindow)) {
-        Wh_Log(L"Reveal result for taskbar %p: coordinator=0 shell=0",
-               taskbarWindow);
+        !ViewCoordinator_HandleIsPointerOverTaskbarFrameChanged_Original) {
         return false;
     }
 
-    // Ask TrayUI/CSecondaryTray to perform the physical shell-window unhide
-    // before asserting synthetic pointer-over. Besides matching Explorer-facing
-    // precedent, this avoids accepting a coordinator-only reveal whose window
-    // could remain on an incorrect slide/Z-order path.
+    // Explorer's own unhide first preserves its slide/Z-order behavior and also
+    // provides a harmless first-use nudge: it can cause
+    // ShouldTaskbarBeExpanded to run and expose the ViewCoordinator.
     if (!InvokeNativeShellUnhideOnUiThread(taskbarWindow)) {
-        Wh_Log(L"Native shell unhide unavailable for taskbar %p; reveal "
-               L"aborted before synthetic ownership",
+        return false;
+    }
+
+    if (!GetViewCoordinator(taskbarWindow)) {
+        Wh_Log(L"ViewCoordinator isn't captured yet for taskbar %p",
                taskbarWindow);
         return false;
     }
 
-    if (!SetSyntheticPointerOverOnUiThread(taskbarWindow, true)) {
-        // The prerequisites were checked immediately above on the same UI
-        // thread, so this is only a defensive race/reentrancy case. Explorer's
-        // native unhide owns any transient reveal and can hide it normally;
-        // don't record synthetic ownership in the worker.
-        Wh_Log(L"Coordinator enter failed after native shell unhide for taskbar "
-               L"%p",
-               taskbarWindow);
-        return false;
-    }
-
-    Wh_Log(L"Reveal result for taskbar %p: shell=1 coordinator=1",
-           taskbarWindow);
-    return true;
+    return SetSyntheticPointerOverOnUiThread(taskbarWindow, true);
 }
 
 void ClearAllSyntheticPointerOverOnUiThread() {
@@ -1189,7 +1080,8 @@ void ClearAllSyntheticPointerOverOnUiThread() {
 bool HandleTaskbarUiOperation(HWND taskbarWindow,
                               WPARAM operationValue,
                               LRESULT* result) {
-    if (!result) {
+    if (!result || operationValue < kUiRevealTaskbar ||
+        operationValue > kUiClearAllSyntheticPointerOver) {
         return false;
     }
 
@@ -1214,25 +1106,15 @@ bool HandleTaskbarUiOperation(HWND taskbarWindow,
     return false;
 }
 
-enum class UiOperationResult {
-    kNotSent,
-    kCompletedFailure,
-    kCompletedSuccess,
-    kIndeterminate,
+enum class UiCallResult {
+    kFailed,
+    kSucceeded,
+    kUncertain,
 };
 
-bool UiOperationSucceeded(UiOperationResult result) {
-    return result == UiOperationResult::kCompletedSuccess;
-}
-
-bool UiOperationMayHaveRun(UiOperationResult result) {
-    return result == UiOperationResult::kCompletedSuccess ||
-           result == UiOperationResult::kIndeterminate;
-}
-
-UiOperationResult SendUiOperation(UiOperation operation,
-                                  HWND taskbarWindow,
-                                  DWORD timeoutMs = 250) {
+UiCallResult SendUiOperation(UiOperation operation,
+                             HWND taskbarWindow,
+                             DWORD timeoutMs = 250) {
     HWND destination = taskbarWindow;
     if (operation == kUiClearAllSyntheticPointerOver) {
         destination = FindAnyTaskbarWindow();
@@ -1240,7 +1122,7 @@ UiOperationResult SendUiOperation(UiOperation operation,
 
     if (!destination || !IsSupportedTaskbarWindow(destination) ||
         !IsCurrentProcessWindow(destination)) {
-        return UiOperationResult::kNotSent;
+        return UiCallResult::kFailed;
     }
 
     DWORD_PTR result = 0;
@@ -1254,23 +1136,24 @@ UiOperationResult SendUiOperation(UiOperation operation,
             timeoutMs,
             &result)) {
         const DWORD error = GetLastError();
-        Wh_Log(L"Taskbar UI operation timed out or failed: operation=%u "
+        Wh_Log(L"Taskbar UI operation timed out/failed: operation=%u "
                L"taskbar=%p error=%u",
                static_cast<unsigned>(operation),
                destination,
                error);
 
-        // A timeout doesn't cancel a cross-thread send. Treat it as possibly
-        // delivered so the worker retains ownership and still sends the
-        // matching release. A vanished window is the only definite no-send.
-        if (error == ERROR_INVALID_WINDOW_HANDLE || !IsWindow(destination)) {
-            return UiOperationResult::kNotSent;
+        // A timeout doesn't prove that the send was cancelled. Keep this one
+        // three-state result so a late synthetic enter is always paired with a
+        // later release attempt; the larger historical ownership protocol isn't
+        // needed.
+        if (error != ERROR_INVALID_WINDOW_HANDLE && IsWindow(destination)) {
+            return UiCallResult::kUncertain;
         }
-        return UiOperationResult::kIndeterminate;
+        return UiCallResult::kFailed;
     }
 
-    return result != 0 ? UiOperationResult::kCompletedSuccess
-                       : UiOperationResult::kCompletedFailure;
+    return result != 0 ? UiCallResult::kSucceeded
+                       : UiCallResult::kFailed;
 }
 
 struct WorkerTimer {
@@ -1286,47 +1169,23 @@ struct ActivationWorkerState {
     bool armed = true;
     WorkerTimer releaseTimer;
     WorkerTimer retryTimer;
-    bool releaseRetryPending = false;
     ULONGLONG activationCandidateSince = 0;
-    ULONGLONG activeSince = 0;
     ULONGLONG lastActivationCheck = 0;
-    unsigned suppressionFailures = 0;
-    unsigned hiddenRepairAttempts = 0;
-    unsigned appliedSettingsGeneration = 0;
-    unsigned appliedDisplayGeneration = 0;
-    std::unordered_map<HMONITOR, UINT> monitorDpiYCache;
 };
 
-UINT GetMonitorDpiYCached(ActivationWorkerState& state, HMONITOR monitor) {
-    const unsigned displayGeneration =
-        g_displayGeneration.load(std::memory_order_acquire);
-    if (state.appliedDisplayGeneration != displayGeneration) {
-        state.monitorDpiYCache.clear();
-        state.appliedDisplayGeneration = displayGeneration;
-    }
-
-    if (auto it = state.monitorDpiYCache.find(monitor);
-        it != state.monitorDpiYCache.end()) {
-        return it->second;
-    }
-
+UINT GetMonitorDpiY(HMONITOR monitor) {
     UINT dpiX = 96;
     UINT dpiY = 96;
     if (FAILED(GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY))) {
-        dpiY = 96;
+        return 96;
     }
-
-    state.monitorDpiYCache.emplace(monitor, dpiY);
     return dpiY;
 }
 
 void CancelWorkerTimer(WorkerTimer& timer) {
-    if (!timer.id) {
-        timer.dueAt = 0;
-        return;
+    if (timer.id) {
+        KillTimer(nullptr, timer.id);
     }
-
-    KillTimer(nullptr, timer.id);
     timer.id = 0;
     timer.dueAt = 0;
 }
@@ -1336,25 +1195,24 @@ void ScheduleWorkerTimer(UINT delayMs, WorkerTimer& timer) {
     const ULONGLONG requestedDueAt = GetTickCount64() + effectiveDelay;
 
     if (timer.id) {
-        // Keep an existing timer when it will fire no later than the new
-        // request. If the new deadline is earlier, replace the timer so a
-        // long suppression backoff can't delay a short hover/retry deadline.
         if (timer.dueAt && timer.dueAt <= requestedDueAt) {
             return;
         }
         CancelWorkerTimer(timer);
     }
 
-    // With hWnd == nullptr, Windows allocates and returns the timer ID. The
-    // caller stores that returned value and compares WM_TIMER against it.
     timer.id = SetTimer(nullptr, 0, effectiveDelay, nullptr);
     if (!timer.id) {
-        timer.dueAt = 0;
         Wh_Log(L"Failed to create worker timer: %u", GetLastError());
         return;
     }
-
     timer.dueAt = requestedDueAt;
+}
+
+void ForgetWorkerActiveTaskbar(ActivationWorkerState& state) {
+    state.activeTaskbar = nullptr;
+    state.activeTaskbarMonitor = nullptr;
+    state.armed = true;
 }
 
 bool ClearActiveTaskbar(ActivationWorkerState& state,
@@ -1362,54 +1220,31 @@ bool ClearActiveTaskbar(ActivationWorkerState& state,
                         bool scheduleRetry = true) {
     CancelWorkerTimer(state.releaseTimer);
 
-    if (state.activeTaskbar) {
-        const UiOperationResult clearResult =
-            SendUiOperation(kUiClearSyntheticPointerOver,
-                            state.activeTaskbar,
-                            timeoutMs);
-
-        if (clearResult == UiOperationResult::kNotSent) {
-            // The HWND is no longer a taskbar in this Explorer process. Its
-            // coordinator and synthetic state were already discarded by the
-            // taskbar WM_NCDESTROY hook, so retrying could loop forever if the
-            // numeric handle was recycled for another window.
-            Wh_Log(L"Release target is no longer a taskbar: %p",
-                   state.activeTaskbar);
-        } else if (!UiOperationSucceeded(clearResult)) {
-            // Completed failure or timeout means the taskbar might still own
-            // synthetic state. Keep worker ownership and retry rather than
-            // allowing Explorer's coordinator to remain forced open.
-            if (scheduleRetry) {
-                state.releaseRetryPending = true;
-                ScheduleWorkerTimer(kReleaseRetryMs,
-                                    state.releaseTimer);
-            }
-            return false;
-        }
+    if (!state.activeTaskbar) {
+        return true;
     }
 
-    state.releaseRetryPending = false;
-    state.activeTaskbar = nullptr;
-    state.activeTaskbarMonitor = nullptr;
-    state.activeSince = 0;
-    state.armed = true;
+    if (!IsSupportedTaskbarWindow(state.activeTaskbar) ||
+        !IsCurrentProcessWindow(state.activeTaskbar)) {
+        ForgetWorkerActiveTaskbar(state);
+        return true;
+    }
+
+    const UiCallResult result = SendUiOperation(
+        kUiClearSyntheticPointerOver, state.activeTaskbar, timeoutMs);
+    if (result != UiCallResult::kSucceeded) {
+        if (scheduleRetry) {
+            ScheduleWorkerTimer(kUiRetryIntervalMs, state.releaseTimer);
+        }
+        return false;
+    }
+
+    ForgetWorkerActiveTaskbar(state);
     return true;
 }
 
 void ScheduleRetry(ActivationWorkerState& state, UINT delayMs) {
     ScheduleWorkerTimer(delayMs, state.retryTimer);
-}
-
-UINT AdvanceSuppressionBackoff(ActivationWorkerState& state) {
-    state.suppressionFailures =
-        std::min(state.suppressionFailures + 1, 8U);
-    const unsigned shift = std::min(state.suppressionFailures - 1, 5U);
-    return std::min(kActivationRetryIntervalMs << shift,
-                    kSuppressionBackoffMaxMs);
-}
-
-void ScheduleSuppressedRetry(ActivationWorkerState& state) {
-    ScheduleRetry(state, AdvanceSuppressionBackoff(state));
 }
 
 void ResetActivationCandidate(ActivationWorkerState& state) {
@@ -1419,27 +1254,11 @@ void ResetActivationCandidate(ActivationWorkerState& state) {
 
 void ResetBandEntry(ActivationWorkerState& state) {
     state.bandEntryMonitor = nullptr;
-    state.hiddenRepairAttempts = 0;
     state.lastActivationCheck = 0;
     ResetActivationCandidate(state);
 }
 
 void ProcessPointerState(ActivationWorkerState& state) {
-    const unsigned settingsGeneration =
-        g_settingsGeneration.load(std::memory_order_acquire);
-    if (state.appliedSettingsGeneration != settingsGeneration) {
-        CancelWorkerTimer(state.retryTimer);
-        if (!ClearActiveTaskbar(state)) {
-            // Keep the old generation pending. Once the release retry succeeds,
-            // the complete settings reset will run instead of being forgotten.
-            return;
-        }
-
-        ResetBandEntry(state);
-        state.suppressionFailures = 0;
-        state.appliedSettingsGeneration = settingsGeneration;
-    }
-
     POINT pointer{};
     if (!GetCursorPos(&pointer)) {
         return;
@@ -1448,12 +1267,9 @@ void ProcessPointerState(ActivationWorkerState& state) {
     HMONITOR pointerMonitor =
         MonitorFromPoint(pointer, MONITOR_DEFAULTTONULL);
     if (!pointerMonitor) {
-        if (!ClearActiveTaskbar(state)) {
-            return;
-        }
+        (void)ClearActiveTaskbar(state);
         CancelWorkerTimer(state.retryTimer);
         ResetBandEntry(state);
-        state.suppressionFailures = 0;
         return;
     }
 
@@ -1464,98 +1280,51 @@ void ProcessPointerState(ActivationWorkerState& state) {
     }
 
     const ULONGLONG now = GetTickCount64();
-    const UINT pointerMonitorDpiY =
-        GetMonitorDpiYCached(state, pointerMonitor);
-    const bool insideActivationBand =
-        IsPointInsideActivationBand(pointer, monitorInfo, pointerMonitorDpiY);
+    const bool insideActivationBand = IsPointInsideActivationBand(
+        pointer, monitorInfo, GetMonitorDpiY(pointerMonitor));
 
     if (state.activeTaskbar) {
-        if (state.releaseRetryPending) {
-            if (!ClearActiveTaskbar(state)) {
-                return;
-            }
-        } else if (!IsWindow(state.activeTaskbar)) {
+        if (!IsSupportedTaskbarWindow(state.activeTaskbar) ||
+            !IsCurrentProcessWindow(state.activeTaskbar)) {
             CancelWorkerTimer(state.releaseTimer);
-            state.releaseRetryPending = false;
-            state.activeTaskbar = nullptr;
-            state.activeTaskbarMonitor = nullptr;
-            state.activeSince = 0;
-            state.armed = true;
+            ForgetWorkerActiveTaskbar(state);
         } else {
             const bool sameMonitorBand =
                 insideActivationBand &&
                 pointerMonitor == state.activeTaskbarMonitor;
-            const bool overVisibleTaskbar =
+            const bool overTaskbar =
                 IsPointOverTaskbar(state.activeTaskbar, pointer);
 
-            // Explorer or another taskbar component can hide the taskbar without
-            // sending the pointer-leave transition this mod normally observes.
-            // After the reveal animation has had time to finish, detect that
-            // state and re-arm instead of remaining stuck until the pointer
-            // leaves and re-enters the activation band.
-            const bool visibilityCheckReady =
-                state.activeSince != 0 &&
-                now - state.activeSince >= kRevealVisibilityGraceMs;
-            if (sameMonitorBand && !overVisibleTaskbar &&
-                visibilityCheckReady &&
-                !IsTaskbarVisiblyRevealed(state.activeTaskbar,
-                                           state.activeTaskbarMonitor)) {
-                Wh_Log(L"Active taskbar %p is no longer visibly revealed",
-                       state.activeTaskbar);
-                if (!ClearActiveTaskbar(state)) {
-                    return;
-                }
-
-                if (state.hiddenRepairAttempts >=
-                    kMaxHiddenRepairsPerBandEntry) {
-                    // Another component is persistently hiding the taskbar.
-                    // Don't fight it at 5 Hz; wait for a genuine band exit
-                    // before allowing another activation attempt.
-                    Wh_Log(L"Unexpected hide persisted; waiting for activation "
-                           L"band exit before retrying");
-                    state.armed = false;
-                    CancelWorkerTimer(state.retryTimer);
-                    return;
-                }
-
-                state.hiddenRepairAttempts++;
-                ResetActivationCandidate(state);
-            } else if (sameMonitorBand || overVisibleTaskbar) {
+            if (sameMonitorBand || overTaskbar) {
                 CancelWorkerTimer(state.releaseTimer);
                 return;
-            } else {
-                const int releaseDelay =
-                    g_settings.releaseDelayMs.load(std::memory_order_relaxed);
-                if (releaseDelay == 0) {
-                    if (!ClearActiveTaskbar(state)) {
-                        return;
-                    }
-                } else {
-                    state.releaseRetryPending = false;
-                    ScheduleWorkerTimer(static_cast<UINT>(releaseDelay),
-                                        state.releaseTimer);
-                    return;
-                }
+            }
+
+            const int releaseDelay =
+                g_settings.releaseDelayMs.load(std::memory_order_relaxed);
+            if (releaseDelay > 0) {
+                ScheduleWorkerTimer(static_cast<UINT>(releaseDelay),
+                                    state.releaseTimer);
+                return;
+            }
+
+            if (!ClearActiveTaskbar(state)) {
+                return;
             }
         }
     }
 
     if (!insideActivationBand) {
         state.armed = true;
-        state.suppressionFailures = 0;
         CancelWorkerTimer(state.retryTimer);
         ResetBandEntry(state);
         return;
     }
 
-    // Entering the activation band on another monitor is a new activation
-    // opportunity even if the pointer never left the combined bottom edge.
     if (state.bandEntryMonitor != pointerMonitor) {
         state.bandEntryMonitor = pointerMonitor;
         state.armed = true;
         state.lastActivationCheck = 0;
-        state.suppressionFailures = 0;
-        state.hiddenRepairAttempts = 0;
         ResetActivationCandidate(state);
     }
 
@@ -1574,134 +1343,95 @@ void ProcessPointerState(ActivationWorkerState& state) {
             return;
         }
     } else {
-        const ULONGLONG candidateElapsed =
-            now - state.activationCandidateSince;
-        if (candidateElapsed < static_cast<ULONGLONG>(activationDelay)) {
-            ScheduleRetry(
-                state,
-                static_cast<UINT>(
-                    static_cast<ULONGLONG>(activationDelay) -
-                    candidateElapsed));
+        const ULONGLONG elapsed = now - state.activationCandidateSince;
+        if (elapsed < static_cast<ULONGLONG>(activationDelay)) {
+            ScheduleRetry(state, static_cast<UINT>(activationDelay - elapsed));
             return;
         }
     }
 
-    const ULONGLONG elapsed = now - state.lastActivationCheck;
-    if (elapsed < kActivationRetryIntervalMs) {
+    const ULONGLONG sinceLastCheck = now - state.lastActivationCheck;
+    if (sinceLastCheck < kActivationCheckIntervalMs) {
         ScheduleRetry(
             state,
-            static_cast<UINT>(kActivationRetryIntervalMs - elapsed));
+            static_cast<UINT>(kActivationCheckIntervalMs - sinceLastCheck));
         return;
     }
 
     state.lastActivationCheck = now;
     CancelWorkerTimer(state.retryTimer);
 
-    Wh_Log(L"Pointer remained in activation band: x=%d y=%d bottom=%d",
-           pointer.x,
-           pointer.y,
-           monitorInfo.rcMonitor.bottom);
-
     if (g_settings.primaryMonitorOnly.load(std::memory_order_relaxed) &&
         (monitorInfo.dwFlags & MONITORINFOF_PRIMARY) == 0) {
-        ScheduleSuppressedRetry(state);
+        ScheduleRetry(state, kUiRetryIntervalMs);
         return;
     }
 
+    // Cheap lookup first: monitors without a taskbar shouldn't pay for the
+    // fullscreen Z-order walk.
     HWND taskbarWindow = FindTaskbarForMonitor(pointerMonitor);
     if (!taskbarWindow) {
-        Wh_Log(L"Activation suppressed: no bottom taskbar found");
-        ScheduleSuppressedRetry(state);
+        ScheduleRetry(state, kUiRetryIntervalMs);
         return;
     }
 
-    if (g_settings.requireWindowsAutoHide.load(
-            std::memory_order_relaxed) &&
+    if (g_settings.requireWindowsAutoHide.load(std::memory_order_relaxed) &&
         !IsWindowsAutoHideEnabled()) {
-        ScheduleSuppressedRetry(state);
+        ScheduleRetry(state, kUiRetryIntervalMs);
         return;
     }
 
-    if (g_settings.ignoreWhileMouseButtonDown.load(
-            std::memory_order_relaxed) &&
+    if (g_settings.ignoreWhileMouseButtonDown.load(std::memory_order_relaxed) &&
         IsAnyMouseButtonDown()) {
-        ScheduleSuppressedRetry(state);
+        ScheduleRetry(state, kUiRetryIntervalMs);
         return;
     }
 
     if (g_settings.ignoreFullscreenApps.load(std::memory_order_relaxed) &&
         IsFullscreenWindowOnMonitor(pointerMonitor)) {
-        Wh_Log(L"Activation suppressed: fullscreen app detected");
-        ScheduleSuppressedRetry(state);
+        ScheduleRetry(state, kUiRetryIntervalMs);
         return;
     }
 
-    const UiOperationResult revealResult =
+    const UiCallResult revealResult =
         SendUiOperation(kUiRevealTaskbar, taskbarWindow, 250);
-    if (UiOperationMayHaveRun(revealResult)) {
-        state.suppressionFailures = 0;
-        if (revealResult == UiOperationResult::kIndeterminate) {
-            Wh_Log(L"Taskbar reveal timed out; assuming coordinator ownership "
-                   L"until the matching release succeeds: %p",
-                   taskbarWindow);
-        } else {
-            Wh_Log(L"Activated taskbar %p through native "
-                   L"shell/coordinator path",
-                   taskbarWindow);
-        }
-
-        ResetActivationCandidate(state);
+    if (revealResult == UiCallResult::kSucceeded ||
+        revealResult == UiCallResult::kUncertain) {
+        // A timed-out send may still execute later. Conservatively own it so
+        // leaving the band always causes a matching release attempt.
         state.activeTaskbar = taskbarWindow;
         state.activeTaskbarMonitor = pointerMonitor;
-        state.activeSince = now;
         state.armed = false;
+        ResetActivationCandidate(state);
         return;
     }
 
-    Wh_Log(L"Threshold entered, but coordinator reveal is not available yet");
-    ScheduleSuppressedRetry(state);
+    // Native unhide runs before coordinator lookup on the UI thread, so this
+    // first failed attempt can itself prompt Explorer to expose the coordinator.
+    ScheduleRetry(state, kUiRetryIntervalMs);
 }
 
 void HandleReleaseTimer(ActivationWorkerState& state) {
     CancelWorkerTimer(state.releaseTimer);
-
     if (!state.activeTaskbar) {
-        return;
-    }
-
-    if (state.releaseRetryPending) {
-        if (!ClearActiveTaskbar(state)) {
-            return;
-        }
-        ProcessPointerState(state);
         return;
     }
 
     POINT pointer{};
     bool keepActive = false;
-
-    if (GetCursorPos(&pointer) && IsWindow(state.activeTaskbar)) {
+    if (GetCursorPos(&pointer) &&
+        IsSupportedTaskbarWindow(state.activeTaskbar) &&
+        IsCurrentProcessWindow(state.activeTaskbar)) {
         HMONITOR pointerMonitor =
             MonitorFromPoint(pointer, MONITOR_DEFAULTTONULL);
         MONITORINFO monitorInfo{};
         monitorInfo.cbSize = sizeof(monitorInfo);
-
-        if (pointerMonitor &&
-            GetMonitorInfoW(pointerMonitor, &monitorInfo)) {
-            const UINT pointerMonitorDpiY =
-                GetMonitorDpiYCached(state, pointerMonitor);
-            const bool insideActivationBand =
-                IsPointInsideActivationBand(
-                    pointer,
-                    monitorInfo,
-                    pointerMonitorDpiY);
-            const bool overVisibleTaskbar =
-                IsPointOverTaskbar(state.activeTaskbar, pointer);
-
+        if (pointerMonitor && GetMonitorInfoW(pointerMonitor, &monitorInfo)) {
+            const bool inBand = IsPointInsideActivationBand(
+                pointer, monitorInfo, GetMonitorDpiY(pointerMonitor));
             keepActive =
-                (insideActivationBand &&
-                 pointerMonitor == state.activeTaskbarMonitor) ||
-                overVisibleTaskbar;
+                (inBand && pointerMonitor == state.activeTaskbarMonitor) ||
+                IsPointOverTaskbar(state.activeTaskbar, pointer);
         }
     }
 
@@ -1709,10 +1439,9 @@ void HandleReleaseTimer(ActivationWorkerState& state) {
         return;
     }
 
-    if (!ClearActiveTaskbar(state)) {
-        return;
+    if (ClearActiveTaskbar(state)) {
+        ProcessPointerState(state);
     }
-    ProcessPointerState(state);
 }
 
 void CALLBACK CursorWinEventProc(HWINEVENTHOOK,
@@ -1778,7 +1507,9 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
         }
 
         if (waitResult != WAIT_OBJECT_0 + 1) {
-            Wh_Log(L"Activation worker wait failed: %u", GetLastError());
+            Wh_Log(L"Activation worker stopped: MsgWaitForMultipleObjects failed: %u; "
+                   L"a later shell/environment event will retry",
+                   GetLastError());
             break;
         }
 
@@ -1792,10 +1523,6 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
                 case kWorkerCursorChangedMessage:
                     g_cursorUpdatePosted.store(false,
                                                std::memory_order_release);
-                    ProcessPointerState(state);
-                    break;
-
-                case kWorkerSettingsChangedMessage:
                     ProcessPointerState(state);
                     break;
 
@@ -1825,9 +1552,8 @@ DWORD WINAPI ActivationWorkerThread(LPVOID) {
     CancelWorkerTimer(state.releaseTimer);
 
     // Keep unload bounded if Explorer's taskbar UI thread is unresponsive. A
-    // single best-effort release is sufficient; an indeterminate send may still
-    // be delivered later, and Explorer teardown discards taskbar coordinator
-    // state with the window.
+    // single best-effort release is enough here; Wh_ModBeforeUninit also sends
+    // one UI-thread-wide cleanup before hooks are removed.
     if (state.activeTaskbar) {
         (void)ClearActiveTaskbar(state, 250, false);
     }
@@ -2052,10 +1778,13 @@ BOOL Wh_ModInit() {
             return FALSE;
         }
 
-        WindhawkUtils::SetFunctionHook(
-            loadLibraryExW,
-            LoadLibraryExW_Hook,
-            &LoadLibraryExW_Original);
+        if (!WindhawkUtils::SetFunctionHook(
+                loadLibraryExW,
+                LoadLibraryExW_Hook,
+                &LoadLibraryExW_Original)) {
+            Wh_Log(L"Couldn't hook KernelBase!LoadLibraryExW");
+            return FALSE;
+        }
     }
 
     g_stopEvent =
@@ -2127,10 +1856,9 @@ void Wh_ModBeforeUninit() {
 
     // One bounded cleanup attempt keeps disable/reload responsive even when
     // Explorer's taskbar UI thread is the component that's hung.
-    const UiOperationResult clearResult =
+    const UiCallResult clearResult =
         SendUiOperation(kUiClearAllSyntheticPointerOver, nullptr, 500);
-    if (!UiOperationSucceeded(clearResult) &&
-        clearResult != UiOperationResult::kNotSent) {
+    if (clearResult != UiCallResult::kSucceeded) {
         Wh_Log(L"Final synthetic pointer-over cleanup wasn't confirmed");
     }
 }
@@ -2156,17 +1884,7 @@ void Wh_ModUninit() {
 
 void Wh_ModSettingsChanged() {
     Wh_Log(L"Settings changed");
-
     LoadSettings();
-    g_settingsGeneration.fetch_add(1, std::memory_order_release);
-
-    const DWORD workerThreadId =
-        g_workerThreadId.load(std::memory_order_acquire);
-    if (workerThreadId &&
-        !PostThreadMessageW(workerThreadId,
-                            kWorkerSettingsChangedMessage,
-                            0,
-                            0)) {
-        Wh_Log(L"Couldn't queue settings update: %u", GetLastError());
-    }
+    EnsureActivationWorker();
+    QueuePointerStateUpdate();
 }

--- a/mods/taskbar-activation-threshold.wh.cpp
+++ b/mods/taskbar-activation-threshold.wh.cpp
@@ -1504,6 +1504,13 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR libraryFileName,
 BOOL Wh_ModInit() {
     Wh_Log(L"Initializing version 0.2.4");
 
+    if (!g_uiThreadMessage || !g_captureTaskbarObjectMessage) {
+        Wh_Log(L"RegisterWindowMessageW failed: ui=%u capture=%u",
+               g_uiThreadMessage,
+               g_captureTaskbarObjectMessage);
+        return FALSE;
+    }
+
     LoadSettings();
 
     if (!HookTaskbarUiThreadSymbol()) {


### PR DESCRIPTION
## Taskbar Activation Threshold

Adds a configurable activation region above the bottom edge of the screen for
Windows 11's auto-hidden taskbar.

Instead of requiring the pointer to reach the exact bottom pixel, the taskbar
can be revealed when the pointer enters a user-configurable threshold region.

### Implementation

- Uses the native Windows 11 taskbar reveal and expansion paths.
- Does not move or inject the mouse cursor.
- Supports primary and secondary bottom-positioned taskbars.
- Does not modify taskbar layout, styling, size, transparency, or animation.
- Includes optional fullscreen and drag suppression.
- Includes diagnostic logging for troubleshooting.

### Tested

- Primary-monitor activation, taskbar interaction, and release
- Multi-monitor setup with taskbars shown on all displays
- Secondary `Shell_SecondaryTrayWnd` activation, interaction, and release
- Moving directly between monitor activation bands
- **Show my taskbar on all displays** disabled: a monitor with no taskbar is ignored rather than redirecting activation

## Relationship to Taskbar auto-hide custom activation area

This mod is complementary to **Taskbar auto-hide custom activation area**, but it uses a materially different trigger path:

- The existing mod restricts activation *along* the taskbar's length after Explorer has already detected a native edge-hover event.
- This mod extends activation *perpendicular* to the taskbar, above the native one-pixel edge.
- Explorer doesn't emit its normal taskbar-edge hover callback while the pointer is in that enlarged off-taskbar band, so this implementation must observe cursor-location events separately and marshal a synthetic pointer-over update to the taskbar UI thread.
- The reveal/release ownership, fallback, multi-monitor, and delayed-release bookkeeping are therefore independent of the existing region-filter implementation.
- This mod and **Taskbar auto-hide custom activation area** both hook Explorer's `ViewCoordinator::HandleIsPointerOverTaskbarFrameChanged` path. While this mod owns an enlarged-band reveal it temporarily holds mouse-kind pointer-leave callbacks; touch/pen leaves pass through. Mods that maintain their own state from the same mouse callback, including **Taskbar auto-hide custom activation area** and **Taskbar auto-hide fine tuning / keyboard-only**, can therefore be hook-order-sensitive and are not guaranteed to combine cleanly unless specifically tested.

I am happy to merge the user-facing setting into the existing mod if that is the maintainers' preference, but keeping it separate avoids coupling an event-driven synthetic activation mechanism to a mod that currently filters Explorer's native activation events. Please advise which repository structure you prefer.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [X] The submitter, with AI assistance
- - [ ] Claude
- - [X] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 
