### PR TITLE
Explorer Command Bar 1.0.0

### DIFF
--- a/mods/explorer-command-bar.wh.cpp
+++ b/mods/explorer-command-bar.wh.cpp
@@ -4,7 +4,7 @@
 // @description     Add your own buttons and dropdown menus to the Windows 11 File Explorer command bar, and hide the built-in ones
 // @version         1.0.0
 // @author          DanRotaru
-// @github          https://github.com/DanRotaru
+// @github          https://github.com/danrotaru
 // @homepage        https://dan13.me/
 // @include         explorer.exe
 // @architecture    x86-64
@@ -20,7 +20,7 @@ Add your own buttons and dropdown menus to the **Windows 11 File Explorer
 command bar** (the toolbar with New / Sort / View), and hide the built-in
 buttons, separators and spacing you don't want.
 
-![Explorer Command Bar demo](https://cepret.md/img/placeholder.svg)
+![Explorer Command Bar demo](https://github.com/DanRotaru/windhawk-mods/blob/master/exporer-command-bar/screenshots/main.gif?raw=true)
 
 Designed for Windows 11 24H2 / 25H2 with the WinAppSDK (WinUI 3) File
 Explorer.
@@ -50,17 +50,14 @@ Explorer.
 
 ## Screenshots
 
-Custom buttons on the command bar:
 
-![Buttons](https://cepret.md/img/placeholder.svg)
+Hiding built‑in buttons and separators:
 
-Dropdown menu with submenus:
+![Hide buttons](https://github.com/DanRotaru/windhawk-mods/blob/master/exporer-command-bar/screenshots/hide-buttons.gif?raw=true)
 
-![Dropdown menu](https://cepret.md/img/placeholder.svg)
+You may hide even all options, and use only your custom ones:
 
-Hiding built-in buttons and separators:
-
-![Hide buttons](https://cepret.md/img/placeholder.svg)
+![Hide All buttons](https://github.com/DanRotaru/windhawk-mods/blob/master/exporer-command-bar/screenshots/hide-all-buttons.jpg?raw=true)
 
 ## Command parameters
 
@@ -110,12 +107,23 @@ in the mod settings.
 
 ## How it works
 
-The mod injects a XAML diagnostics provider into Explorer and watches the WinUI
-3 visual tree for the File Explorer command bar. When it appears, the configured
-buttons are inserted and the visibility / spacing settings are applied. The mod
-listens for the command bar being rebuilt so the buttons stay in place across
-navigation, new tabs and new windows, and it restores the original state of any
-element it touches when disabled.
+The mod hooks a couple of functions of File Explorer's own WinUI 3 code
+(`FileExplorerExtensions.dll`) which run when the command bar is built, and
+finds the command bars from there by walking the XAML tree. The configured
+buttons are then inserted and the visibility / spacing settings are applied. The
+mod also listens for the command bar being rebuilt so the buttons stay in place
+across navigation, new tabs and new windows, and it restores the original state
+of any element it touches when disabled.
+
+Notably, the mod does **not** use XAML Diagnostics
+(`InitializeXamlDiagnosticsEx`), since only one XAML diagnostics consumer can be
+active in a process at a time. That makes it compatible with mods and tools
+which do use it, such as **Windows 11 File Explorer Styler**, ExplorerBlurMica
+and TranslucentTB.
+
+File Explorer windows which are already open when the mod is enabled are
+handled too, but if the buttons don't show up in one of them right away, opening
+a new tab or navigating to another folder makes them appear.
 
 */
 // ==/WindhawkModReadme==
@@ -386,12 +394,13 @@ element it touches when disabled.
 
 #include <windows.h>
 
+#include <windhawk_utils.h>
+
 #include <exdisp.h>
 #include <servprov.h>
 #include <shellapi.h>
 #include <shlobj.h>
 #include <shobjidl.h>
-#include <xamlom.h>
 
 #include <atomic>
 #include <memory>
@@ -402,15 +411,7 @@ element it touches when disabled.
 #include <unordered_set>
 #include <vector>
 
-std::atomic<bool> g_initialized;
 std::atomic<bool> g_unloading;
-
-// {7B0A0F2C-3D1E-4C8B-9A65-2E8F41D0B7A3}
-static constexpr CLSID CLSID_WindhawkTAP = {
-    0x7b0a0f2c,
-    0x3d1e,
-    0x4c8b,
-    {0x9a, 0x65, 0x2e, 0x8f, 0x41, 0xd0, 0xb7, 0xa3}};
 
 static constexpr CLSID kCLSID_ShellWindows = {
     0x9ba05972,
@@ -480,17 +481,6 @@ struct {
     std::vector<ActionItem> items;
 } g_settings;
 
-HMODULE GetCurrentModuleHandle() {
-    HMODULE module;
-    if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-                               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                           L"", &module)) {
-        return nullptr;
-    }
-
-    return module;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // clang-format off
 
@@ -523,308 +513,6 @@ namespace muxc = winrt::Microsoft::UI::Xaml::Controls;
 namespace muxm = winrt::Microsoft::UI::Xaml::Media;
 
 #pragma endregion  // winrt_hpp
-
-void OnCommandBarAdded(muxc::CommandBar const& commandBar);
-
-#pragma region visualtreewatcher_hpp
-
-class VisualTreeWatcher : public winrt::implements<VisualTreeWatcher, IVisualTreeServiceCallback2, winrt::non_agile>
-{
-public:
-    VisualTreeWatcher(winrt::com_ptr<IUnknown> site);
-
-    VisualTreeWatcher(const VisualTreeWatcher&) = delete;
-    VisualTreeWatcher& operator=(const VisualTreeWatcher&) = delete;
-
-    VisualTreeWatcher(VisualTreeWatcher&&) = delete;
-    VisualTreeWatcher& operator=(VisualTreeWatcher&&) = delete;
-
-    ~VisualTreeWatcher();
-
-    void UnadviseVisualTreeChange();
-
-private:
-    HRESULT STDMETHODCALLTYPE OnVisualTreeChange(ParentChildRelation relation, VisualElement element, VisualMutationType mutationType) override;
-    HRESULT STDMETHODCALLTYPE OnElementStateChanged(InstanceHandle element, VisualElementState elementState, LPCWSTR context) noexcept override;
-
-    wf::IInspectable FromHandle(InstanceHandle handle)
-    {
-        wf::IInspectable obj;
-        winrt::check_hresult(m_XamlDiagnostics->GetIInspectableFromHandle(handle, reinterpret_cast<::IInspectable**>(winrt::put_abi(obj))));
-        return obj;
-    }
-
-    winrt::com_ptr<IXamlDiagnostics> m_XamlDiagnostics = nullptr;
-};
-
-#pragma endregion  // visualtreewatcher_hpp
-
-#pragma region visualtreewatcher_cpp
-
-VisualTreeWatcher::VisualTreeWatcher(winrt::com_ptr<IUnknown> site) :
-    m_XamlDiagnostics(site.as<IXamlDiagnostics>())
-{
-    Wh_Log(L"Constructing VisualTreeWatcher");
-
-    // Calling AdviseVisualTreeChange from the current thread causes the app to
-    // hang sometimes. Creating a new thread and calling it from there fixes
-    // it.
-    HANDLE thread = CreateThread(
-        nullptr, 0,
-        [](LPVOID lpParam) -> DWORD {
-            auto watcher = reinterpret_cast<VisualTreeWatcher*>(lpParam);
-            HRESULT hr = watcher->m_XamlDiagnostics.as<IVisualTreeService3>()->AdviseVisualTreeChange(watcher);
-            watcher->Release();
-            if (FAILED(hr)) {
-                Wh_Log(L"Error %08X", hr);
-            }
-            return 0;
-        },
-        this, 0, nullptr);
-    if (thread) {
-        AddRef();
-        CloseHandle(thread);
-    }
-}
-
-VisualTreeWatcher::~VisualTreeWatcher()
-{
-    Wh_Log(L"Destructing VisualTreeWatcher");
-}
-
-void VisualTreeWatcher::UnadviseVisualTreeChange()
-{
-    Wh_Log(L"UnadviseVisualTreeChange VisualTreeWatcher");
-    HRESULT hr = m_XamlDiagnostics.as<IVisualTreeService3>()->UnadviseVisualTreeChange(this);
-    if (FAILED(hr)) {
-        Wh_Log(L"UnadviseVisualTreeChange failed with error %08X", hr);
-    }
-}
-
-HRESULT VisualTreeWatcher::OnVisualTreeChange(ParentChildRelation, VisualElement element, VisualMutationType mutationType) try
-{
-    if (g_unloading)
-    {
-        return S_OK;
-    }
-
-    if (mutationType == Add)
-    {
-        const auto inspectable = FromHandle(element.Handle);
-        if (auto commandBar = inspectable.try_as<muxc::CommandBar>())
-        {
-            auto name = commandBar.Name();
-            if (name == L"FileExplorerCommandBar" ||
-                name == L"FileExplorerSecondaryCommandBar")
-            {
-                Wh_Log(L"%s added, thread %u", name.c_str(), GetCurrentThreadId());
-                OnCommandBarAdded(commandBar);
-            }
-        }
-    }
-
-    return S_OK;
-}
-catch (...)
-{
-    HRESULT hr = winrt::to_hresult();
-    Wh_Log(L"Error %08X", hr);
-
-    // Returning an error prevents (some?) further messages, always return
-    // success.
-    return S_OK;
-}
-
-HRESULT VisualTreeWatcher::OnElementStateChanged(InstanceHandle, VisualElementState, LPCWSTR) noexcept
-{
-    return S_OK;
-}
-
-#pragma endregion  // visualtreewatcher_cpp
-
-#pragma region tap_hpp
-
-#include <ocidl.h>
-
-winrt::com_ptr<VisualTreeWatcher> g_visualTreeWatcher;
-
-class WindhawkTAP : public winrt::implements<WindhawkTAP, IObjectWithSite, winrt::non_agile>
-{
-public:
-    HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite) override;
-    HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite) noexcept override;
-
-private:
-    winrt::com_ptr<IUnknown> site;
-};
-
-#pragma endregion  // tap_hpp
-
-#pragma region tap_cpp
-
-HRESULT WindhawkTAP::SetSite(IUnknown *pUnkSite) try
-{
-    // Only ever 1 VTW at once.
-    if (g_visualTreeWatcher)
-    {
-        g_visualTreeWatcher->UnadviseVisualTreeChange();
-        g_visualTreeWatcher = nullptr;
-    }
-
-    site.copy_from(pUnkSite);
-
-    if (site)
-    {
-        // Decrease refcount increased by InitializeXamlDiagnosticsEx.
-        FreeLibrary(GetCurrentModuleHandle());
-
-        g_visualTreeWatcher = winrt::make_self<VisualTreeWatcher>(site);
-    }
-
-    return S_OK;
-}
-catch (...)
-{
-    HRESULT hr = winrt::to_hresult();
-    Wh_Log(L"Error %08X", hr);
-    return hr;
-}
-
-HRESULT WindhawkTAP::GetSite(REFIID riid, void **ppvSite) noexcept
-{
-    return site.as(riid, ppvSite);
-}
-
-#pragma endregion  // tap_cpp
-
-#pragma region simplefactory_hpp
-
-template<class T>
-struct SimpleFactory : winrt::implements<SimpleFactory<T>, IClassFactory, winrt::non_agile>
-{
-    HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown* pUnkOuter, REFIID riid, void** ppvObject) override try
-    {
-        if (!pUnkOuter)
-        {
-            *ppvObject = nullptr;
-            return winrt::make<T>().as(riid, ppvObject);
-        }
-        else
-        {
-            return CLASS_E_NOAGGREGATION;
-        }
-    }
-    catch (...)
-    {
-        HRESULT hr = winrt::to_hresult();
-        Wh_Log(L"Error %08X", hr);
-        return hr;
-    }
-
-    HRESULT STDMETHODCALLTYPE LockServer(BOOL) noexcept override
-    {
-        return S_OK;
-    }
-};
-
-#pragma endregion  // simplefactory_hpp
-
-#pragma region module_cpp
-
-#include <combaseapi.h>
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdll-attribute-on-redeclaration"
-
-__declspec(dllexport)
-_Use_decl_annotations_ STDAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv) try
-{
-    if (rclsid == CLSID_WindhawkTAP)
-    {
-        *ppv = nullptr;
-        return winrt::make<SimpleFactory<WindhawkTAP>>().as(riid, ppv);
-    }
-    else
-    {
-        return CLASS_E_CLASSNOTAVAILABLE;
-    }
-}
-catch (...)
-{
-    HRESULT hr = winrt::to_hresult();
-    Wh_Log(L"Error %08X", hr);
-    return hr;
-}
-
-__declspec(dllexport)
-_Use_decl_annotations_ STDAPI DllCanUnloadNow()
-{
-    if (winrt::get_module_lock())
-    {
-        return S_FALSE;
-    }
-    else
-    {
-        return S_OK;
-    }
-}
-
-#pragma clang diagnostic pop
-
-#pragma endregion  // module_cpp
-
-#pragma region api_cpp
-
-using PFN_INITIALIZE_XAML_DIAGNOSTICS_EX = decltype(&InitializeXamlDiagnosticsEx);
-
-HRESULT InjectWindhawkTAP() noexcept
-{
-    HMODULE module = GetCurrentModuleHandle();
-    if (!module)
-    {
-        return HRESULT_FROM_WIN32(GetLastError());
-    }
-
-    WCHAR location[MAX_PATH];
-    switch (GetModuleFileName(module, location, ARRAYSIZE(location)))
-    {
-    case 0:
-    case ARRAYSIZE(location):
-        return HRESULT_FROM_WIN32(GetLastError());
-    }
-
-    const HMODULE wux(GetModuleHandle(L"Microsoft.Internal.FrameworkUdk.dll"));
-    if (!wux) [[unlikely]]
-    {
-        return HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND);
-    }
-
-    const auto ixde = reinterpret_cast<PFN_INITIALIZE_XAML_DIAGNOSTICS_EX>(GetProcAddress(wux, "InitializeXamlDiagnosticsEx"));
-    if (!ixde) [[unlikely]]
-    {
-        return HRESULT_FROM_WIN32(GetLastError());
-    }
-
-    // I didn't find a better way than trying many connections until one works.
-    // Reference:
-    // https://github.com/microsoft/microsoft-ui-xaml/blob/d74a0332cf0d5e58f12eddce1070fa7a79b4c2db/src/dxaml/xcp/dxaml/lib/DXamlCore.cpp#L2782
-    HRESULT hr = E_FAIL;
-    for (int i = 0; i < 10000; i++)
-    {
-        WCHAR connectionName[256];
-        wsprintf(connectionName, L"WinUIVisualDiagConnection%d", i + 1);
-
-        hr = ixde(connectionName, GetCurrentProcessId(), L"", location, CLSID_WindhawkTAP, nullptr);
-        if (hr != HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
-        {
-            break;
-        }
-    }
-
-    return hr;
-}
-
-#pragma endregion  // api_cpp
 
 // clang-format on
 ////////////////////////////////////////////////////////////////////////////////
@@ -2578,80 +2266,381 @@ void RefreshButtonsForCurrentThread() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Initialization plumbing.
+// Command bar discovery.
+//
+// The command bars are found by hooking a couple of functions of File
+// Explorer's own WinUI 3 code (FileExplorerExtensions.dll) and by walking the
+// XAML tree from there with the public VisualTreeHelper API.
+//
+// Note: XAML Diagnostics (InitializeXamlDiagnosticsEx) would be an easier way
+// to watch for the command bar, but only one XAML diagnostics consumer can be
+// active per process, which makes it conflict with other tools and mods, such
+// as Windows 11 File Explorer Styler. That's why it's not used here.
 
-void InitializeSettingsAndTap() {
-    if (g_initialized.exchange(true)) {
+// Note: the `this` pointer our hooks get is a C++/WinRT implementation object,
+// not a XAML object, and there's no supported way to turn one into the other.
+// Guessing at its layout is a good way to crash Explorer, so the hooks which
+// only have a `this` pointer are used as a signal to rescan the thread, and the
+// XAML objects themselves only ever come from typed parameters, from the
+// command bars we already know about, or from the focused element.
+
+bool IsTargetCommandBarName(std::wstring_view name) {
+    return name == L"FileExplorerCommandBar" ||
+           name == L"FileExplorerSecondaryCommandBar";
+}
+
+void CollectCommandBars(mux::DependencyObject const& root,
+                        int depth,
+                        std::vector<muxc::CommandBar>* commandBars) {
+    if (depth > 64) {
         return;
     }
 
-    HRESULT hr = InjectWindhawkTAP();
-    if (FAILED(hr)) {
-        Wh_Log(L"InjectWindhawkTAP failed: %08X", hr);
-        // Allow retrying, e.g. if the WinUI runtime wasn't loaded yet.
-        g_initialized = false;
+    int count = muxm::VisualTreeHelper::GetChildrenCount(root);
+    for (int i = 0; i < count; i++) {
+        auto child = muxm::VisualTreeHelper::GetChild(root, i);
+        if (auto commandBar = child.try_as<muxc::CommandBar>();
+            commandBar && IsTargetCommandBarName(commandBar.Name())) {
+            commandBars->push_back(std::move(commandBar));
+            // No need to descend into a command bar we already found.
+            continue;
+        }
+
+        CollectCommandBars(child, depth + 1, commandBars);
     }
 }
 
-void UninitializeSettingsAndTap() {
-    if (g_visualTreeWatcher) {
-        g_visualTreeWatcher->UnadviseVisualTreeChange();
-        g_visualTreeWatcher = nullptr;
+// Finds all of the File Explorer command bars of the XAML island the given
+// element belongs to. Must run on the element's UI thread.
+void ScanXamlRootForCommandBars(mux::UIElement const& element) try {
+    if (g_unloading || !element) {
+        return;
     }
 
-    g_initialized = false;
+    auto xamlRoot = element.XamlRoot();
+    if (!xamlRoot) {
+        return;
+    }
+
+    auto content = xamlRoot.Content();
+    if (!content) {
+        return;
+    }
+
+    std::vector<muxc::CommandBar> commandBars;
+    CollectCommandBars(content, 0, &commandBars);
+    for (auto const& commandBar : commandBars) {
+        OnCommandBarAdded(commandBar);
+    }
+} catch (...) {
+    Wh_Log(L"Error %08X", winrt::to_hresult().value);
 }
 
-bool IsTargetTriggerWindow(HWND hWnd) {
-    WCHAR className[64];
-    if (!GetClassName(hWnd, className, ARRAYSIZE(className))) {
-        return false;
+// Same as above, but deferred, for the cases where the command bar isn't in
+// the tree yet by the time our hook runs.
+void ScheduleXamlRootScan(mux::UIElement const& element) try {
+    if (g_unloading || !element) {
+        return;
     }
 
-    if (_wcsicmp(className, L"CabinetWClass") == 0) {
-        return true;
+    auto dispatcherQueue =
+        winrt::Microsoft::UI::Dispatching::DispatcherQueue::GetForCurrentThread();
+    if (!dispatcherQueue) {
+        ScanXamlRootForCommandBars(element);
+        return;
     }
 
-    // The WinUI content bridge windows of a File Explorer window. By the time
-    // they're created, the WinUI runtime is loaded, so use them as a fallback
-    // trigger in case injection failed for the top-level window.
-    if (_wcsicmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") ==
-        0) {
-        HWND hRootWnd = GetAncestor(hWnd, GA_ROOT);
-        WCHAR rootClassName[64];
-        if (hRootWnd &&
-            GetClassName(hRootWnd, rootClassName, ARRAYSIZE(rootClassName)) &&
-            _wcsicmp(rootClassName, L"CabinetWClass") == 0) {
-            return true;
+    dispatcherQueue.TryEnqueue([weakElement = winrt::make_weak(element)]() {
+        if (auto element = weakElement.get()) {
+            ScanXamlRootForCommandBars(element);
+        }
+    });
+} catch (...) {
+    Wh_Log(L"Error %08X", winrt::to_hresult().value);
+}
+
+muxc::CommandBar GetKnownCommandBarForCurrentThread() {
+    DWORD threadId = GetCurrentThreadId();
+
+    std::lock_guard<std::mutex> lock(g_entriesMutex);
+    for (auto const& entry : g_entries) {
+        if (entry.threadId != threadId) {
+            continue;
+        }
+
+        if (auto commandBar = entry.commandBar.get()) {
+            return commandBar;
         }
     }
 
-    return false;
+    return nullptr;
 }
 
-using CreateWindowExW_t = decltype(&CreateWindowExW);
-CreateWindowExW_t CreateWindowExW_Original;
-HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle,
-                                 LPCWSTR lpClassName,
-                                 LPCWSTR lpWindowName,
-                                 DWORD dwStyle,
-                                 int X,
-                                 int Y,
-                                 int nWidth,
-                                 int nHeight,
-                                 HWND hWndParent,
-                                 HMENU hMenu,
-                                 HINSTANCE hInstance,
-                                 PVOID lpParam) {
-    HWND hWnd = CreateWindowExW_Original(dwExStyle, lpClassName, lpWindowName,
-                                         dwStyle, X, Y, nWidth, nHeight,
-                                         hWndParent, hMenu, hInstance, lpParam);
-    if (hWnd && !g_unloading && IsTargetTriggerWindow(hWnd)) {
-        InitializeSettingsAndTap();
+// Looks for the command bars of the current thread's XAML island without an
+// element to start from: either from a command bar which is already known for
+// this thread, or from the focused element. Must run on the UI thread.
+void ScanCurrentThreadForCommandBars() try {
+    if (g_unloading) {
+        return;
     }
 
-    return hWnd;
+    if (auto knownCommandBar = GetKnownCommandBarForCurrentThread()) {
+        ScanXamlRootForCommandBars(knownCommandBar);
+        return;
+    }
+
+    auto focused = mux::Input::FocusManager::GetFocusedElement();
+    auto element = focused ? focused.try_as<mux::UIElement>() : nullptr;
+    if (!element) {
+        Wh_Log(L"No XAML element to start from on thread %u",
+               GetCurrentThreadId());
+        return;
+    }
+
+    ScanXamlRootForCommandBars(element);
+} catch (...) {
+    Wh_Log(L"Error %08X", winrt::to_hresult().value);
 }
+
+// Same as above, deferred to after the current layout pass.
+void ScheduleCurrentThreadScan() try {
+    if (g_unloading) {
+        return;
+    }
+
+    auto dispatcherQueue =
+        winrt::Microsoft::UI::Dispatching::DispatcherQueue::GetForCurrentThread();
+    if (!dispatcherQueue) {
+        ScanCurrentThreadForCommandBars();
+        return;
+    }
+
+    dispatcherQueue.TryEnqueue([]() { ScanCurrentThreadForCommandBars(); });
+} catch (...) {
+    Wh_Log(L"Error %08X", winrt::to_hresult().value);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Hooks of File Explorer's WinUI 3 code.
+
+// void CommandBarManager::CommandBar(muxc::CommandBar const& value)
+//
+// Called with the command bar element itself, which is the most direct way to
+// get hold of it.
+using CommandBarManager_CommandBar_t = void(WINAPI*)(void* pThis,
+                                                     void* commandBar);
+CommandBarManager_CommandBar_t CommandBarManager_CommandBar_Original;
+void WINAPI CommandBarManager_CommandBar_Hook(void* pThis, void* commandBar) {
+    Wh_Log(L">");
+
+    CommandBarManager_CommandBar_Original(pThis, commandBar);
+
+    if (g_unloading || !commandBar) {
+        return;
+    }
+
+    try {
+        auto const& element =
+            *reinterpret_cast<muxc::CommandBar const*>(commandBar);
+        if (!element) {
+            return;
+        }
+
+        Wh_Log(L"Command bar %s, thread %u", element.Name().c_str(),
+               GetCurrentThreadId());
+        OnCommandBarAdded(element);
+
+        // The secondary command bar has no manager of its own, and the bar
+        // isn't necessarily attached to the tree yet, so also scan the island
+        // once the current layout pass is done.
+        ScheduleXamlRootScan(element);
+    } catch (...) {
+        Wh_Log(L"Error %08X", winrt::to_hresult().value);
+    }
+}
+
+// void CommandBarControl::OnApplyTemplate()
+//
+// Runs when the control which hosts the command bar builds its contents, both
+// for new windows and tabs and when Explorer rebuilds it.
+using CommandBarControl_OnApplyTemplate_t = void(WINAPI*)(void* pThis);
+CommandBarControl_OnApplyTemplate_t CommandBarControl_OnApplyTemplate_Original;
+CommandBarControl_OnApplyTemplate_t
+    CommandBarControl_Wave1_OnApplyTemplate_Original;
+
+void WINAPI CommandBarControl_OnApplyTemplate_Hook(void* pThis) {
+    Wh_Log(L">");
+
+    CommandBarControl_OnApplyTemplate_Original(pThis);
+    ScheduleCurrentThreadScan();
+}
+
+void WINAPI CommandBarControl_Wave1_OnApplyTemplate_Hook(void* pThis) {
+    Wh_Log(L">");
+
+    CommandBarControl_Wave1_OnApplyTemplate_Original(pThis);
+    ScheduleCurrentThreadScan();
+}
+
+// void CommandBarControl::CommandBarControlGotFocusHandler(
+//     IInspectable const& sender, RoutedEventArgs const&)
+//
+// A cheap extra chance to pick up a command bar we haven't seen yet, e.g. in a
+// window which was already open when the mod was loaded.
+using CommandBarControl_GotFocusHandler_t = void(WINAPI*)(void* pThis,
+                                                          void* sender,
+                                                          void* args);
+CommandBarControl_GotFocusHandler_t
+    CommandBarControl_GotFocusHandler_Original;
+CommandBarControl_GotFocusHandler_t
+    CommandBarControl_Wave1_GotFocusHandler_Original;
+
+void HandleCommandBarControlGotFocus(void* sender) {
+    if (g_unloading || !sender) {
+        return;
+    }
+
+    try {
+        auto const& inspectable = *reinterpret_cast<wf::IInspectable const*>(
+            sender);
+        if (auto element = inspectable ? inspectable.try_as<mux::UIElement>()
+                                       : nullptr) {
+            ScanXamlRootForCommandBars(element);
+        }
+    } catch (...) {
+        Wh_Log(L"Error %08X", winrt::to_hresult().value);
+    }
+}
+
+void WINAPI CommandBarControl_GotFocusHandler_Hook(void* pThis,
+                                                   void* sender,
+                                                   void* args) {
+    CommandBarControl_GotFocusHandler_Original(pThis, sender, args);
+    HandleCommandBarControlGotFocus(sender);
+}
+
+void WINAPI CommandBarControl_Wave1_GotFocusHandler_Hook(void* pThis,
+                                                         void* sender,
+                                                         void* args) {
+    CommandBarControl_Wave1_GotFocusHandler_Original(pThis, sender, args);
+    HandleCommandBarControlGotFocus(sender);
+}
+
+std::atomic<bool> g_symbolsHooked;
+
+bool HookFileExplorerExtensionsSymbols(HMODULE module) {
+    // All hooks are optional, since the set of functions differs between
+    // Windows builds, but at least one of the discovery hooks must be found.
+    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+        {
+            {
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarManager::CommandBar(struct winrt::Microsoft::UI::Xaml::Controls::CommandBar const &))",
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarManager::CommandBar(struct winrt::Microsoft::UI::Xaml::Controls::CommandBar const & __ptr64) __ptr64)",
+            },
+            &CommandBarManager_CommandBar_Original,
+            CommandBarManager_CommandBar_Hook,
+            true,
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl::OnApplyTemplate(void))",
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl::OnApplyTemplate(void) __ptr64)",
+            },
+            &CommandBarControl_OnApplyTemplate_Original,
+            CommandBarControl_OnApplyTemplate_Hook,
+            true,
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl_Wave1::OnApplyTemplate(void))",
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl_Wave1::OnApplyTemplate(void) __ptr64)",
+            },
+            &CommandBarControl_Wave1_OnApplyTemplate_Original,
+            CommandBarControl_Wave1_OnApplyTemplate_Hook,
+            true,
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl::CommandBarControlGotFocusHandler(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const &))",
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl::CommandBarControlGotFocusHandler(struct winrt::Windows::Foundation::IInspectable const & __ptr64,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const & __ptr64) __ptr64)",
+            },
+            &CommandBarControl_GotFocusHandler_Original,
+            CommandBarControl_GotFocusHandler_Hook,
+            true,
+        },
+        {
+            {
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl_Wave1::CommandBarControlGotFocusHandler(struct winrt::Windows::Foundation::IInspectable const &,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const &))",
+                LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarControl_Wave1::CommandBarControlGotFocusHandler(struct winrt::Windows::Foundation::IInspectable const & __ptr64,struct winrt::Microsoft::UI::Xaml::RoutedEventArgs const & __ptr64) __ptr64)",
+            },
+            &CommandBarControl_Wave1_GotFocusHandler_Original,
+            CommandBarControl_Wave1_GotFocusHandler_Hook,
+            true,
+        },
+    };
+
+    if (!HookSymbols(module, hooks, ARRAYSIZE(hooks))) {
+        Wh_Log(L"HookSymbols failed");
+        return false;
+    }
+
+    if (!CommandBarManager_CommandBar_Original &&
+        !CommandBarControl_OnApplyTemplate_Original &&
+        !CommandBarControl_Wave1_OnApplyTemplate_Original) {
+        Wh_Log(L"No command bar symbol was found");
+        return false;
+    }
+
+    return true;
+}
+
+HMODULE GetFileExplorerExtensionsModuleHandle() {
+    return GetModuleHandle(L"FileExplorerExtensions.dll");
+}
+
+// Returns false only if the module is loaded but hooking it failed.
+bool HookFileExplorerExtensionsIfLoaded(bool applyHooks) {
+    if (g_symbolsHooked) {
+        return true;
+    }
+
+    HMODULE module = GetFileExplorerExtensionsModuleHandle();
+    if (!module) {
+        return true;
+    }
+
+    if (g_symbolsHooked.exchange(true)) {
+        return true;
+    }
+
+    Wh_Log(L"Hooking FileExplorerExtensions.dll");
+
+    if (!HookFileExplorerExtensionsSymbols(module)) {
+        return false;
+    }
+
+    if (applyHooks) {
+        Wh_ApplyHookOperations();
+    }
+
+    return true;
+}
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t LoadLibraryExW_Original;
+HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
+                                   HANDLE hFile,
+                                   DWORD dwFlags) {
+    HMODULE module = LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
+    if (module && !g_unloading) {
+        HookFileExplorerExtensionsIfLoaded(/*applyHooks=*/true);
+    }
+
+    return module;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Initialization plumbing.
 
 using RunFromWindowThreadProc_t = void(WINAPI*)(PVOID parameter);
 
@@ -2838,8 +2827,25 @@ BOOL Wh_ModInit() {
 
     LoadSettings();
 
-    Wh_SetFunctionHook((void*)CreateWindowExW, (void*)CreateWindowExW_Hook,
-                       (void**)&CreateWindowExW_Original);
+    if (GetFileExplorerExtensionsModuleHandle()) {
+        if (!HookFileExplorerExtensionsIfLoaded(/*applyHooks=*/false)) {
+            return FALSE;
+        }
+    } else {
+        Wh_Log(L"FileExplorerExtensions.dll isn't loaded yet");
+
+        HMODULE kernelBaseModule = GetModuleHandle(L"kernelbase.dll");
+        auto pKernelBaseLoadLibraryExW =
+            (decltype(&LoadLibraryExW))GetProcAddress(kernelBaseModule,
+                                                      "LoadLibraryExW");
+        if (!pKernelBaseLoadLibraryExW) {
+            return FALSE;
+        }
+
+        WindhawkUtils::SetFunctionHook(pKernelBaseLoadLibraryExW,
+                                       LoadLibraryExW_Hook,
+                                       &LoadLibraryExW_Original);
+    }
 
     return TRUE;
 }
@@ -2847,9 +2853,13 @@ BOOL Wh_ModInit() {
 void Wh_ModAfterInit() {
     Wh_Log(L">");
 
-    if (!GetFileExplorerWnds().empty()) {
-        Wh_Log(L"Found existing File Explorer windows, injecting TAP");
-        InitializeSettingsAndTap();
+    HookFileExplorerExtensionsIfLoaded(/*applyHooks=*/true);
+
+    // Windows which were already open when the mod was loaded won't
+    // necessarily rebuild their command bar, so look for it explicitly.
+    for (HWND hWnd : GetFileExplorerWnds()) {
+        RunFromWindowThread(
+            hWnd, [](PVOID) { ScanCurrentThreadForCommandBars(); }, nullptr);
     }
 }
 
@@ -2857,8 +2867,6 @@ void Wh_ModUninit() {
     Wh_Log(L">");
 
     g_unloading = true;
-
-    UninitializeSettingsAndTap();
 
     for (HWND hWnd : GetFileExplorerWnds()) {
         Wh_Log(L"Removing buttons for window %08X", (DWORD)(ULONG_PTR)hWnd);

--- a/mods/explorer-command-bar.wh.cpp
+++ b/mods/explorer-command-bar.wh.cpp
@@ -89,40 +89,22 @@ The **Icon glyph or icon path** field accepts several forms:
 
 ## Default configuration
 
-Out of the box the mod adds only apps which are part of a stock Windows 11
-install:
+Out of the box the mod adds:
 
 * **Open in Terminal** - `wt.exe -d "%path%"`
 * **Open in Notepad** - `notepad.exe "%sel%"`
 * **Additional** ▾ (dropdown)
+  * Open in VS Code - `code.exe "%path%"`
   * Open Paint - `mspaint.exe`
   * Open Calculator - `calc.exe`
-  * **System** ▸ - Task Manager (`taskmgr.exe`), Control Panel (`control.exe`)
+  * **Commands** ▸ - `vite`, `npm init`, `npm install`, `npm run dev`,
+    `npm run build`, `npm run start`
+  * **AI** ▸ - `Claude`, `Codex`
 
+Items whose command isn't installed simply do nothing when clicked (the failure
+is written to the mod log), so remove the ones you don't need and add your own.
 All of the built-in buttons stay visible by default. Everything is configurable
 in the mod settings.
-
-## Example configurations
-
-A few items worth adding if you have the corresponding tools installed. Set
-*Command* and *Parameters* as shown; leave *Icon glyph or icon path* empty to
-use the executable's own icon.
-
-* **Open in VS Code** - command `code.exe`, parameters `"%path%"`.
-* **Open in your editor of choice** - e.g. command
-  `%LOCALAPPDATA%\Programs\<editor>\<editor>.exe`, parameters `"%path%"`.
-* **A dropdown of project commands** (type *Dropdown menu*), each entry with
-  command `cmd.exe` and parameters `/k npm install`, `/k npm run dev`,
-  `/k npm run build`, and so on. `cmd.exe /k` keeps the console open so you can
-  see the output.
-* **A dropdown of CLI tools** - command `cmd.exe` with parameters `/k claude`,
-  `/k codex`, `/k gh pr list`, ...
-* **Open a terminal as administrator** - command
-  `powershell.exe`, parameters
-  `-Command "Start-Process wt.exe -ArgumentList '-d \"%path%\"' -Verb RunAs"`.
-
-Enable *Hide icon* for the menu entries of such commands: an `.exe` like
-`cmd.exe` contributes little as an icon next to a text label.
 
 ## How it works
 
@@ -261,6 +243,12 @@ a new tab or navigating to another folder makes them appear.
     - separatorAfter: false
     - subItems:
       - - type: button
+        - name: Open in VS Code
+        - command: code.exe
+        - parameters: '"%path%"'
+        - iconGlyph: ""
+        - separatorAfter: false
+      - - type: button
         - name: Open Paint
         - command: mspaint.exe
         - parameters: ""
@@ -273,23 +261,66 @@ a new tab or navigating to another folder makes them appear.
         - iconGlyph: 'shell:AppsFolder\Microsoft.WindowsCalculator_8wekyb3d8bbwe!App'
         - separatorAfter: true
       - - type: menu
-        - name: System
+        - name: Commands
         - command: ""
         - parameters: ""
-        - iconGlyph: E713
+        - iconGlyph: EC7A
         - separatorAfter: false
         - subItems:
-          - - name: Task Manager
-            - command: taskmgr.exe
-            - parameters: ""
+          - - name: vite
+            - command: cmd.exe
+            - parameters: /k vite
             - iconGlyph: ""
-            - hideIcon: false
+            - hideIcon: true
+            - separatorAfter: true
+          - - name: npm init
+            - command: cmd.exe
+            - parameters: /k npm init
+            - iconGlyph: ""
+            - hideIcon: true
             - separatorAfter: false
-          - - name: Control Panel
-            - command: control.exe
-            - parameters: ""
+          - - name: npm install
+            - command: cmd.exe
+            - parameters: /k npm install
             - iconGlyph: ""
-            - hideIcon: false
+            - hideIcon: true
+            - separatorAfter: false
+          - - name: npm run dev
+            - command: cmd.exe
+            - parameters: /k npm run dev
+            - iconGlyph: ""
+            - hideIcon: true
+            - separatorAfter: false
+          - - name: npm run build
+            - command: cmd.exe
+            - parameters: /k npm run build
+            - iconGlyph: ""
+            - hideIcon: true
+            - separatorAfter: false
+          - - name: npm run start
+            - command: cmd.exe
+            - parameters: /k npm run start
+            - iconGlyph: ""
+            - hideIcon: true
+            - separatorAfter: false
+      - - type: menu
+        - name: AI
+        - command: ""
+        - parameters: ""
+        - iconGlyph: E794
+        - separatorAfter: false
+        - subItems:
+          - - name: Claude
+            - command: cmd.exe
+            - parameters: /k claude
+            - iconGlyph: ""
+            - hideIcon: true
+            - separatorAfter: false
+          - - name: Codex
+            - command: cmd.exe
+            - parameters: /k codex
+            - iconGlyph: ""
+            - hideIcon: true
             - separatorAfter: false
   $name: Toolbar items
   $description: >-
@@ -375,6 +406,7 @@ a new tab or navigating to another folder makes them appear.
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -495,15 +527,27 @@ namespace muxm = winrt::Microsoft::UI::Xaml::Media;
 
 constexpr PCWSTR kButtonNamePrefix = L"WindhawkActionButton";
 
+// Everything below is per-UI-thread state, and every XAML object in it belongs
+// to the thread that created it: a weak reference to a live non-agile XAML
+// element can only be resolved from its own thread, and its event handlers can
+// only be unregistered there. The state is therefore thread_local rather than
+// a global keyed by thread id - the cross-thread access becomes impossible by
+// construction, the storage goes away with the window's thread, and the
+// lookups don't scan other windows' entries. Both Wh_ModUninit and
+// Wh_ModSettingsChanged already reach every thread through
+// RunFromWindowThread.
+
 struct CommandBarEntry {
-    DWORD threadId;
     winrt::weak_ref<muxc::CommandBar> commandBar;
     winrt::event_token loadedToken{};
     winrt::event_token vectorChangedToken{};
 };
 
-std::mutex g_entriesMutex;
-std::vector<CommandBarEntry> g_entries;
+thread_local std::vector<CommandBarEntry> g_entries;
+
+// Set once a scan of this thread's XAML island found its command bars, so the
+// focus hook can skip the tree walk while they're still around.
+thread_local bool g_threadScanned;
 
 // The Explorer elements we touch, each with the original state captured the
 // first time we touched it, so it can be restored exactly instead of forcing a
@@ -514,7 +558,6 @@ std::vector<CommandBarEntry> g_entries;
 // it, never by its address: XAML objects die with their window or tab, and the
 // heap happily hands the same address to an unrelated element of the next one.
 struct ManagedElement {
-    DWORD threadId;
     winrt::weak_ref<mux::UIElement> element;
 
     bool hasOriginalVisibility = false;
@@ -533,19 +576,11 @@ struct ManagedElement {
     int64_t visibilityToken = 0;
 };
 
-std::mutex g_managedElementsMutex;
-std::vector<ManagedElement> g_managedElements;
-
-// The lookups below must run on the element's own UI thread, and the caller
-// must hold g_managedElementsMutex. A weak reference to a live non-agile XAML
-// element can only be resolved from its own thread, which is also why entries
-// of other threads are skipped rather than treated as dead.
+thread_local std::vector<ManagedElement> g_managedElements;
 
 ManagedElement* FindManagedElement(mux::UIElement const& element) {
-    DWORD threadId = GetCurrentThreadId();
-
     for (auto& entry : g_managedElements) {
-        if (entry.threadId == threadId && entry.element.get() == element) {
+        if (entry.element.get() == element) {
             return &entry;
         }
     }
@@ -554,13 +589,11 @@ ManagedElement* FindManagedElement(mux::UIElement const& element) {
 }
 
 ManagedElement& GetManagedElement(mux::UIElement const& element) {
-    DWORD threadId = GetCurrentThreadId();
-
-    // Drop the entries of this thread whose element is gone, so the list
-    // doesn't grow for the whole Explorer session.
+    // Drop the entries whose element is gone, so the list doesn't grow for the
+    // lifetime of the window.
     for (auto it = g_managedElements.begin();
          it != g_managedElements.end();) {
-        if (it->threadId == threadId && !it->element.get()) {
+        if (!it->element.get()) {
             it = g_managedElements.erase(it);
         } else {
             ++it;
@@ -571,8 +604,70 @@ ManagedElement& GetManagedElement(mux::UIElement const& element) {
         return *entry;
     }
 
-    g_managedElements.push_back({threadId, winrt::make_weak(element)});
+    g_managedElements.push_back({winrt::make_weak(element)});
     return g_managedElements.back();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Resolving a configured command. Used both for launching it and for taking
+// its icon.
+
+std::wstring ExpandEnvVars(std::wstring const& str) {
+    WCHAR buffer[MAX_PATH];
+    DWORD length =
+        ExpandEnvironmentStringsW(str.c_str(), buffer, ARRAYSIZE(buffer));
+    if (length == 0 || length > ARRAYSIZE(buffer)) {
+        return str;
+    }
+
+    return buffer;
+}
+
+// Resolves a bare executable name to a full path the way ShellExecute does:
+// through the search path, then through the App Paths registry keys.
+std::wstring ResolveCommandPath(std::wstring const& command) {
+    std::wstring expanded = ExpandEnvVars(command);
+
+    if (expanded.find(L'\\') != std::wstring::npos) {
+        return expanded;
+    }
+
+    WCHAR resolved[MAX_PATH];
+    if (SearchPathW(nullptr, expanded.c_str(), L".exe", ARRAYSIZE(resolved),
+                    resolved, nullptr)) {
+        return resolved;
+    }
+
+    std::wstring keyPath =
+        L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\" +
+        expanded;
+    std::wstring lower = expanded;
+    for (auto& c : lower) {
+        c = towlower(c);
+    }
+    if (!lower.ends_with(L".exe")) {
+        keyPath += L".exe";
+    }
+
+    for (HKEY rootKey : {HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE}) {
+        WCHAR buffer[MAX_PATH];
+        DWORD size = sizeof(buffer);
+        if (RegGetValueW(rootKey, keyPath.c_str(), nullptr, RRF_RT_REG_SZ,
+                         nullptr, buffer, &size) == ERROR_SUCCESS &&
+            buffer[0]) {
+            std::wstring appPath = ExpandEnvVars(buffer);
+
+            // The value is sometimes quoted.
+            if (appPath.size() >= 2 && appPath.front() == L'"' &&
+                appPath.back() == L'"') {
+                appPath = appPath.substr(1, appPath.size() - 2);
+            }
+
+            return appPath;
+        }
+    }
+
+    return expanded;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -793,13 +888,34 @@ void LaunchItemForWindow(HWND hExplorerWnd, ActionItem const& item) {
 
     std::wstring parameters = BuildParameters(item.parameters, context);
 
-    HINSTANCE hInst = ShellExecuteW(
-        nullptr, nullptr, item.command.c_str(),
-        parameters.empty() ? nullptr : parameters.c_str(),
-        context.folderPath.empty() ? nullptr : context.folderPath.c_str(),
-        SW_SHOWNORMAL);
-    if ((INT_PTR)hInst <= 32) {
-        Wh_Log(L"ShellExecuteW failed: %d", (int)(INT_PTR)hInst);
+    // A bare command name has to be resolved before it's launched: the working
+    // directory is the browsed folder, and the shell resolves a relative file
+    // against it, so a same-named executable sitting in the folder the user
+    // happens to be looking at would win over the real one.
+    std::wstring command = ResolveCommandPath(item.command);
+    bool isPath = command.find(L'\\') != std::wstring::npos;
+    if (!isPath) {
+        Wh_Log(L"Couldn't resolve %s to a path, launching without a working "
+               L"directory",
+               item.command.c_str());
+    }
+
+    SHELLEXECUTEINFOW execInfo = {sizeof(execInfo)};
+    // No UI: a command which doesn't exist would otherwise put up a modal
+    // error box on this thread, which the mod would then have to wait for
+    // while unloading. The failure is logged below instead. NOASYNC because
+    // this thread exits right after.
+    execInfo.fMask = SEE_MASK_FLAG_NO_UI | SEE_MASK_NOASYNC;
+    execInfo.lpFile = command.c_str();
+    execInfo.lpParameters = parameters.empty() ? nullptr : parameters.c_str();
+    execInfo.lpDirectory = (isPath && !context.folderPath.empty())
+                               ? context.folderPath.c_str()
+                               : nullptr;
+    execInfo.nShow = SW_SHOWNORMAL;
+
+    if (!ShellExecuteExW(&execInfo)) {
+        Wh_Log(L"ShellExecuteExW failed for %s: %u", command.c_str(),
+               GetLastError());
     }
 }
 
@@ -872,64 +988,6 @@ void OnActionInvoked(mux::FrameworkElement const& elementForWindow,
 ////////////////////////////////////////////////////////////////////////////////
 // Icons.
 
-std::wstring ExpandEnvVars(std::wstring const& str) {
-    WCHAR buffer[MAX_PATH];
-    DWORD length =
-        ExpandEnvironmentStringsW(str.c_str(), buffer, ARRAYSIZE(buffer));
-    if (length == 0 || length > ARRAYSIZE(buffer)) {
-        return str;
-    }
-
-    return buffer;
-}
-
-// Resolves a bare executable name to a full path the way ShellExecute does:
-// through the search path, then through the App Paths registry keys.
-std::wstring ResolveCommandPath(std::wstring const& command) {
-    std::wstring expanded = ExpandEnvVars(command);
-
-    if (expanded.find(L'\\') != std::wstring::npos) {
-        return expanded;
-    }
-
-    WCHAR resolved[MAX_PATH];
-    if (SearchPathW(nullptr, expanded.c_str(), L".exe", ARRAYSIZE(resolved),
-                    resolved, nullptr)) {
-        return resolved;
-    }
-
-    std::wstring keyPath =
-        L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\" +
-        expanded;
-    std::wstring lower = expanded;
-    for (auto& c : lower) {
-        c = towlower(c);
-    }
-    if (!lower.ends_with(L".exe")) {
-        keyPath += L".exe";
-    }
-
-    for (HKEY rootKey : {HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE}) {
-        WCHAR buffer[MAX_PATH];
-        DWORD size = sizeof(buffer);
-        if (RegGetValueW(rootKey, keyPath.c_str(), nullptr, RRF_RT_REG_SZ,
-                         nullptr, buffer, &size) == ERROR_SUCCESS &&
-            buffer[0]) {
-            std::wstring appPath = ExpandEnvVars(buffer);
-
-            // The value is sometimes quoted.
-            if (appPath.size() >= 2 && appPath.front() == L'"' &&
-                appPath.back() == L'"') {
-                appPath = appPath.substr(1, appPath.size() - 2);
-            }
-
-            return appPath;
-        }
-    }
-
-    return expanded;
-}
-
 #ifndef IO_REPARSE_TAG_APPEXECLINK
 #define IO_REPARSE_TAG_APPEXECLINK (0x8000001BL)
 #endif
@@ -962,7 +1020,7 @@ std::wstring ResolveAppExecutionAlias(std::wstring const& path) {
         WCHAR stringList[1];
     };
 
-    alignas(8) BYTE buffer[16 * 1024];
+    alignas(8) BYTE buffer[MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
     DWORD bytesReturned = 0;
     BOOL succeeded =
         DeviceIoControl(hFile, FSCTL_GET_REPARSE_POINT, nullptr, 0, buffer,
@@ -1066,7 +1124,10 @@ bool ReadBitmapPixels(HBITMAP hBitmap, DecodedIcon* decoded) {
 }
 
 // True if every pixel is fully transparent, which is how a bitmap without an
-// alpha channel comes back.
+// alpha channel comes back. Note that this can't be told apart from an icon
+// which is genuinely fully transparent; such an icon ends up opaque (and thus
+// visible) rather than invisible, which is the better of the two failure modes
+// for a toolbar button.
 bool HasNoAlphaChannel(std::vector<uint8_t> const& pixels) {
     for (size_t p = 3; p < pixels.size(); p += 4) {
         if (pixels[p]) {
@@ -1187,6 +1248,16 @@ std::wstring ParseGlyphSetting(PCWSTR glyphSetting) {
     if (!glyphSetting[1]) {
         // A literal glyph character.
         return std::wstring(1, glyphSetting[0]);
+    }
+
+    // Every character has to be a hex digit, so that a typo ends up as no icon
+    // instead of an unrelated glyph (`abc` would otherwise parse as 0xABC, and
+    // `E756x` as 0xE756).
+    for (PCWSTR p = glyphSetting; *p; p++) {
+        if (!iswxdigit(*p)) {
+            Wh_Log(L"%s is not a glyph code point", glyphSetting);
+            return std::wstring();
+        }
     }
 
     unsigned long parsed = wcstoul(glyphSetting, nullptr, 16);
@@ -1550,12 +1621,9 @@ bool ShouldHide(ManagedTarget const& target);
 // Explorer last set, which we track, or its current value if we've never
 // touched it.
 mux::Visibility EffectiveVisibility(mux::UIElement const& element) {
-    {
-        std::lock_guard<std::mutex> lock(g_managedElementsMutex);
-        auto* entry = FindManagedElement(element);
-        if (entry && entry->hasOriginalVisibility) {
-            return entry->originalVisibility;
-        }
+    auto* entry = FindManagedElement(element);
+    if (entry && entry->hasOriginalVisibility) {
+        return entry->originalVisibility;
     }
 
     return element.Visibility();
@@ -1643,8 +1711,8 @@ void UpdateCommandBar(muxc::CommandBar const& commandBar);
 // The pending entries are keyed by address, which is safe here because the
 // queued work always removes its own entry: an entry can't outlive the command
 // bar it belongs to and be matched against a later one at the same address.
-std::mutex g_pendingUpdatesMutex;
-std::unordered_map<void*, bool> g_pendingUpdates;  // Value: full update.
+thread_local std::unordered_map<void*, bool>
+    g_pendingUpdates;  // Value: full update.
 
 void QueueCommandBarUpdate(
     winrt::weak_ref<muxc::CommandBar> const& weakCommandBar,
@@ -1655,19 +1723,17 @@ void QueueCommandBarUpdate(
     }
 
     void* key = winrt::get_abi(commandBar);
-    {
-        std::lock_guard<std::mutex> lock(g_pendingUpdatesMutex);
-        auto [it, inserted] = g_pendingUpdates.insert({key, fullUpdate});
-        if (!inserted) {
-            // Already queued; the queued work reads the flag when it runs, so
-            // a full update can still be requested on top of a recompute.
-            it->second = it->second || fullUpdate;
-            return;
-        }
+    auto [it, inserted] = g_pendingUpdates.insert({key, fullUpdate});
+    if (!inserted) {
+        // Already queued; the queued work reads the flag when it runs, so a
+        // full update can still be requested on top of a recompute.
+        it->second = it->second || fullUpdate;
+        return;
     }
 
+    // Runs on this same thread, either from the dispatcher queue or right
+    // below if queueing failed.
     auto takePending = [key]() {
-        std::lock_guard<std::mutex> lock(g_pendingUpdatesMutex);
         bool full = false;
         auto it = g_pendingUpdates.find(key);
         if (it != g_pendingUpdates.end()) {
@@ -1740,13 +1806,16 @@ void WatchVisibility(mux::UIElement const& element,
             // Explorer changed it, so this is the new baseline to restore.
             mux::Visibility visibility = element.Visibility();
             {
-                std::lock_guard<std::mutex> lock(g_managedElementsMutex);
                 auto& entry = GetManagedElement(element);
                 entry.originalVisibility = visibility;
                 entry.hasOriginalVisibility = true;
             }
 
-            if (visibility != mux::Visibility::Collapsed &&
+            // A group separator isn't decided here: the group snapshot this
+            // watcher was registered with can be stale, and the recompute
+            // below re-collects it anyway.
+            if (target.kind != ManagedKind::GroupSeparator &&
+                visibility != mux::Visibility::Collapsed &&
                 ShouldHide(target)) {
                 SetVisibilityInternal(element, mux::Visibility::Collapsed);
             }
@@ -1756,7 +1825,6 @@ void WatchVisibility(mux::UIElement const& element,
             QueueVisibilityRecompute(owner);
         });
 
-    std::lock_guard<std::mutex> lock(g_managedElementsMutex);
     auto& entry = GetManagedElement(element);
     entry.watched = true;
     entry.visibilityToken = token;
@@ -1765,26 +1833,21 @@ void WatchVisibility(mux::UIElement const& element,
 // Unregisters the watchers of this thread's elements, keeping their remembered
 // original state for the restore which follows.
 void UnwatchVisibilityForCurrentThread() {
-    DWORD threadId = GetCurrentThreadId();
-
-    std::vector<std::pair<mux::UIElement, int64_t>> taken;
-    {
-        std::lock_guard<std::mutex> lock(g_managedElementsMutex);
-        for (auto& entry : g_managedElements) {
-            if (entry.threadId != threadId || !entry.watched) {
-                continue;
-            }
-
-            if (auto element = entry.element.get()) {
-                taken.push_back({element, entry.visibilityToken});
-            }
-
-            entry.watched = false;
-            entry.visibilityToken = 0;
+    for (auto& entry : g_managedElements) {
+        if (!entry.watched) {
+            continue;
         }
-    }
 
-    for (auto const& [element, token] : taken) {
+        auto element = entry.element.get();
+        int64_t token = entry.visibilityToken;
+
+        entry.watched = false;
+        entry.visibilityToken = 0;
+
+        if (!element) {
+            continue;
+        }
+
         try {
             element.UnregisterPropertyChangedCallback(
                 mux::UIElement::VisibilityProperty(), token);
@@ -1795,17 +1858,7 @@ void UnwatchVisibilityForCurrentThread() {
 }
 
 void ForgetManagedElementsForCurrentThread() {
-    DWORD threadId = GetCurrentThreadId();
-
-    std::lock_guard<std::mutex> lock(g_managedElementsMutex);
-    for (auto it = g_managedElements.begin();
-         it != g_managedElements.end();) {
-        if (it->threadId == threadId) {
-            it = g_managedElements.erase(it);
-        } else {
-            ++it;
-        }
-    }
+    g_managedElements.clear();
 }
 
 // Sets an element's visibility to Collapsed when hiding, or restores its
@@ -1819,7 +1872,6 @@ void SetManagedVisibility(mux::UIElement const& element,
     mux::Visibility original;
     bool watch;
     {
-        std::lock_guard<std::mutex> lock(g_managedElementsMutex);
         auto& entry = GetManagedElement(element);
         if (!entry.hasOriginalVisibility) {
             entry.originalVisibility = element.Visibility();
@@ -1850,7 +1902,6 @@ void ApplyItemSpacing(muxc::AppBarButton const& button,
     mux::Thickness originalMargin;
     double originalMinWidth;
     {
-        std::lock_guard<std::mutex> lock(g_managedElementsMutex);
         auto& entry = GetManagedElement(button);
         if (!entry.hasOriginalSpacing) {
             entry.originalMargin = button.Margin();
@@ -1978,18 +2029,14 @@ void ApplyDefaultButtonVisibility(muxc::CommandBar const& commandBar,
         entries[firstCustomIndex - 1].isSeparator) {
         viewSeparatorIndex = firstCustomIndex - 1;
     } else {
-        // Without custom buttons (the mod can be used just to hide the
-        // built-in ones) it's the first separator after the View button.
-        for (uint32_t i = 0; i < count && viewSeparatorIndex == count; i++) {
-            if (entries[i].defaultIndex != kViewButtonIndex) {
-                continue;
-            }
-
-            for (uint32_t j = i + 1; j < count; j++) {
-                if (entries[j].isSeparator) {
-                    viewSeparatorIndex = j;
-                    break;
-                }
+        // The mod can also be used just to hide the built-in buttons, without
+        // any custom ones. Then it's the last of Explorer's own separators -
+        // the same element our buttons would have followed, so the option keeps
+        // targeting the same line either way.
+        for (uint32_t i = count; i > 0; i--) {
+            if (entries[i - 1].isSeparator) {
+                viewSeparatorIndex = i - 1;
+                break;
             }
         }
     }
@@ -2084,7 +2131,6 @@ void ApplyDefaultButtonVisibility(muxc::CommandBar const& commandBar,
     if (isPrimary) {
         muxc::CommandBarOverflowButtonVisibility originalOverflow;
         {
-            std::lock_guard<std::mutex> lock(g_managedElementsMutex);
             auto& entry = GetManagedElement(commandBar);
             if (!entry.hasOriginalOverflow) {
                 entry.originalOverflow = commandBar.OverflowButtonVisibility();
@@ -2128,7 +2174,8 @@ muxc::AppBarButton CreateBareButton(int index,
 }
 
 muxc::AppBarButton CreateActionButton(ActionItem const& item, int index) {
-    muxc::AppBarButton button = CreateBareButton(index, item.name, MakeCommandButtonIcon(item));
+    muxc::AppBarButton button =
+        CreateBareButton(index, item.name, MakeCommandButtonIcon(item));
 
     button.Click([item](wf::IInspectable const& sender,
                         mux::RoutedEventArgs const&) {
@@ -2194,56 +2241,32 @@ void AppendMenuEntries(std::vector<ActionItem> const& items,
 // The hover timers of our menu buttons. A started timer is rooted by the
 // dispatcher queue and its Tick handler lives in this DLL, so the timers have
 // to be stopped before the mod is unloaded.
-struct HoverTimerEntry {
-    DWORD threadId;
-    winrt::weak_ref<mux::DispatcherTimer> timer;
-};
-
-std::mutex g_hoverTimersMutex;
-std::vector<HoverTimerEntry> g_hoverTimers;
+thread_local std::vector<winrt::weak_ref<mux::DispatcherTimer>> g_hoverTimers;
 
 void TrackHoverTimer(mux::DispatcherTimer const& timer) {
-    DWORD threadId = GetCurrentThreadId();
-
-    std::lock_guard<std::mutex> lock(g_hoverTimersMutex);
-
-    // Drop this thread's timers which are gone with their button.
+    // Drop the timers which are gone with their button.
     for (auto it = g_hoverTimers.begin(); it != g_hoverTimers.end();) {
-        if (it->threadId == threadId && !it->timer.get()) {
+        if (!it->get()) {
             it = g_hoverTimers.erase(it);
         } else {
             ++it;
         }
     }
 
-    g_hoverTimers.push_back({threadId, winrt::make_weak(timer)});
+    g_hoverTimers.push_back(winrt::make_weak(timer));
 }
 
 void StopHoverTimersForCurrentThread() {
-    DWORD threadId = GetCurrentThreadId();
+    std::vector<winrt::weak_ref<mux::DispatcherTimer>> taken;
+    taken.swap(g_hoverTimers);
 
-    std::vector<mux::DispatcherTimer> taken;
-    {
-        std::lock_guard<std::mutex> lock(g_hoverTimersMutex);
-        for (auto it = g_hoverTimers.begin(); it != g_hoverTimers.end();) {
-            if (it->threadId != threadId) {
-                ++it;
-                continue;
+    for (auto const& weakTimer : taken) {
+        if (auto timer = weakTimer.get()) {
+            try {
+                timer.Stop();
+            } catch (...) {
+                Wh_Log(L"Error %08X", winrt::to_hresult().value);
             }
-
-            if (auto timer = it->timer.get()) {
-                taken.push_back(std::move(timer));
-            }
-
-            it = g_hoverTimers.erase(it);
-        }
-    }
-
-    for (auto const& timer : taken) {
-        try {
-            timer.Stop();
-        } catch (...) {
-            Wh_Log(L"Error %08X", winrt::to_hresult().value);
         }
     }
 }
@@ -2252,7 +2275,8 @@ muxc::AppBarButton CreateMenuButton(ActionItem const& item,
                                     int index,
                                     bool openOnHover,
                                     int hoverDelayMs) {
-    muxc::AppBarButton button = CreateBareButton(index, item.name, MakeCommandButtonIcon(item));
+    muxc::AppBarButton button =
+        CreateBareButton(index, item.name, MakeCommandButtonIcon(item));
 
     // The menu flyout is shown in its own popup window, so resolve the
     // Explorer window from the anchor button, not from the clicked menu item.
@@ -2420,28 +2444,25 @@ void RemoveOurButtons(muxc::CommandBar const& commandBar) {
 }
 
 void OnCommandBarAdded(muxc::CommandBar const& commandBar) {
-    {
-        std::lock_guard<std::mutex> lock(g_entriesMutex);
-
-        // Prune entries whose command bar is gone.
-        for (auto it = g_entries.begin(); it != g_entries.end();) {
-            if (!it->commandBar.get()) {
-                it = g_entries.erase(it);
-            } else {
-                ++it;
-            }
+    // Prune entries whose command bar is gone. Only this thread's, since
+    // g_entries is thread_local - a command bar can only ever be tracked by
+    // the thread which owns it.
+    for (auto it = g_entries.begin(); it != g_entries.end();) {
+        if (!it->commandBar.get()) {
+            it = g_entries.erase(it);
+        } else {
+            ++it;
         }
+    }
 
-        for (auto const& entry : g_entries) {
-            if (entry.commandBar.get() == commandBar) {
-                // Already tracked (e.g. re-added to the tree).
-                return;
-            }
+    for (auto const& entry : g_entries) {
+        if (entry.commandBar.get() == commandBar) {
+            // Already tracked (e.g. re-added to the tree).
+            return;
         }
     }
 
     CommandBarEntry entry;
-    entry.threadId = GetCurrentThreadId();
     entry.commandBar = winrt::make_weak(commandBar);
 
     // Re-add the buttons whenever the command bar reloads.
@@ -2468,29 +2489,9 @@ void OnCommandBarAdded(muxc::CommandBar const& commandBar) {
             QueueCommandBarUpdate(weakCommandBar, /*fullUpdate=*/true);
         });
 
-    {
-        std::lock_guard<std::mutex> lock(g_entriesMutex);
-        g_entries.push_back(std::move(entry));
-    }
+    g_entries.push_back(std::move(entry));
 
     UpdateCommandBar(commandBar);
-}
-
-std::vector<CommandBarEntry> TakeEntriesForCurrentThread() {
-    DWORD threadId = GetCurrentThreadId();
-    std::vector<CommandBarEntry> taken;
-
-    std::lock_guard<std::mutex> lock(g_entriesMutex);
-    for (auto it = g_entries.begin(); it != g_entries.end();) {
-        if (it->threadId == threadId) {
-            taken.push_back(std::move(*it));
-            it = g_entries.erase(it);
-        } else {
-            ++it;
-        }
-    }
-
-    return taken;
 }
 
 void RemoveButtonsForCurrentThread() {
@@ -2498,7 +2499,10 @@ void RemoveButtonsForCurrentThread() {
     UnwatchVisibilityForCurrentThread();
     StopHoverTimersForCurrentThread();
 
-    for (auto& entry : TakeEntriesForCurrentThread()) {
+    std::vector<CommandBarEntry> taken;
+    taken.swap(g_entries);
+
+    for (auto& entry : taken) {
         auto commandBar = entry.commandBar.get();
         if (!commandBar) {
             continue;
@@ -2516,8 +2520,11 @@ void RemoveButtonsForCurrentThread() {
     }
 
     // Everything has been restored, so the remembered original state of this
-    // thread's elements isn't needed anymore.
+    // thread's elements isn't needed anymore. Any update still queued on the
+    // dispatcher gives up on its own, since g_unloading is set.
     ForgetManagedElementsForCurrentThread();
+    g_pendingUpdates.clear();
+    g_threadScanned = false;
 }
 
 void RefreshButtonsForCurrentThread() {
@@ -2525,15 +2532,10 @@ void RefreshButtonsForCurrentThread() {
     // stopped and forgotten first.
     StopHoverTimersForCurrentThread();
 
+    // A copy, since UpdateCommandBar below can add entries.
     std::vector<winrt::weak_ref<muxc::CommandBar>> commandBars;
-    {
-        DWORD threadId = GetCurrentThreadId();
-        std::lock_guard<std::mutex> lock(g_entriesMutex);
-        for (auto const& entry : g_entries) {
-            if (entry.threadId == threadId) {
-                commandBars.push_back(entry.commandBar);
-            }
-        }
+    for (auto const& entry : g_entries) {
+        commandBars.push_back(entry.commandBar);
     }
 
     for (auto const& weakCommandBar : commandBars) {
@@ -2641,6 +2643,14 @@ void ScanXamlRootForCommandBars(mux::UIElement const& element) try {
     for (auto const& commandBar : commandBars) {
         OnCommandBarAdded(commandBar);
     }
+
+    if (!commandBars.empty()) {
+        // The island is built and its command bars are tracked; the focus hook
+        // doesn't have to keep looking. Not conditioned on both bars being
+        // found, since a layout without a secondary bar would otherwise be
+        // rescanned on every focus change.
+        g_threadScanned = true;
+    }
 } catch (...) {
     Wh_Log(L"Error %08X", winrt::to_hresult().value);
 }
@@ -2669,14 +2679,7 @@ void ScheduleXamlRootScan(mux::UIElement const& element) try {
 }
 
 muxc::CommandBar GetKnownCommandBarForCurrentThread() {
-    DWORD threadId = GetCurrentThreadId();
-
-    std::lock_guard<std::mutex> lock(g_entriesMutex);
     for (auto const& entry : g_entries) {
-        if (entry.threadId != threadId) {
-            continue;
-        }
-
         if (auto commandBar = entry.commandBar.get()) {
             return commandBar;
         }
@@ -2806,6 +2809,13 @@ CommandBarControl_GotFocusHandler_t
 
 void HandleCommandBarControlGotFocus(void* sender) {
     if (g_unloading || !sender) {
+        return;
+    }
+
+    // This runs on every focus change, and the scan walks the whole visual
+    // tree, so skip it once this thread's command bars are known. A rebuilt
+    // command bar comes back through OnApplyTemplate / Loaded instead.
+    if (g_threadScanned && GetKnownCommandBarForCurrentThread()) {
         return;
     }
 
@@ -3174,6 +3184,15 @@ void Wh_ModAfterInit() {
     }
 }
 
+// Our function hooks are gone by the time Wh_ModUninit runs, but the XAML
+// delegates aren't - they stay live until they're unregistered below. Setting
+// the flag one callback earlier shortens the window in which they still act.
+void Wh_ModBeforeUninit() {
+    Wh_Log(L">");
+
+    g_unloading = true;
+}
+
 void Wh_ModUninit() {
     Wh_Log(L">");
 
@@ -3189,37 +3208,12 @@ void Wh_ModUninit() {
         }
     }
 
-    // Anything left here belongs to a thread which couldn't be reached above.
-    // Its watchers and timers can only be released from that thread, so all
-    // that's left to do is to drop the records.
-    {
-        std::lock_guard<std::mutex> lock(g_managedElementsMutex);
-        if (!g_managedElements.empty()) {
-            Wh_Log(L"%zu elements couldn't be restored",
-                   g_managedElements.size());
-        }
-
-        g_managedElements.clear();
-    }
-
-    {
-        std::lock_guard<std::mutex> lock(g_hoverTimersMutex);
-        g_hoverTimers.clear();
-    }
-
-    {
-        std::lock_guard<std::mutex> lock(g_pendingUpdatesMutex);
-        g_pendingUpdates.clear();
-    }
-
+    // The per-thread state (g_entries, g_managedElements, g_hoverTimers,
+    // g_pendingUpdates) was released above, on each thread which owns it - it's
+    // thread_local, so there's nothing here to clean up for other threads.
     {
         std::lock_guard<std::mutex> lock(g_iconCacheMutex);
         g_iconCache.clear();
-    }
-
-    {
-        std::lock_guard<std::mutex> lock(g_entriesMutex);
-        g_entries.clear();
     }
 
     // Last, since the launch threads run our code: the DLL can't be unmapped

--- a/mods/explorer-command-bar.wh.cpp
+++ b/mods/explorer-command-bar.wh.cpp
@@ -4,7 +4,7 @@
 // @description     Add your own buttons and dropdown menus to the Windows 11 File Explorer command bar, and hide the built-in ones
 // @version         1.0.0
 // @author          DanRotaru
-// @github          https://github.com/danrotaru
+// @github          https://github.com/DanRotaru
 // @homepage        https://dan13.me/
 // @include         explorer.exe
 // @architecture    x86-64

--- a/mods/explorer-command-bar.wh.cpp
+++ b/mods/explorer-command-bar.wh.cpp
@@ -20,7 +20,7 @@ Add your own buttons and dropdown menus to the **Windows 11 File Explorer
 command bar** (the toolbar with New / Sort / View), and hide the built-in
 buttons, separators and spacing you don't want.
 
-![Explorer Command Bar demo](https://github.com/DanRotaru/windhawk-mods/blob/master/exporer-command-bar/screenshots/main.gif?raw=true)
+![Explorer Command Bar demo](https://raw.githubusercontent.com/DanRotaru/windhawk-mods/master/exporer-command-bar/screenshots/main.gif)
 
 Designed for Windows 11 24H2 / 25H2 with the WinAppSDK (WinUI 3) File
 Explorer.
@@ -41,7 +41,7 @@ Explorer.
   menu, the contextual commands (Set as background, Rotate left, Rotate right,
   Extract all) and the Details pane toggle.
 - **Custom item spacing** - set the exact spacing between the command bar
-  buttons, in pixels.
+  buttons.
 - **Open menus on hover** - optionally open dropdowns on hover, with a
   configurable delay.
 - **Rock solid** - buttons are re-applied automatically across tab switches,
@@ -50,14 +50,13 @@ Explorer.
 
 ## Screenshots
 
-
 Hiding built‑in buttons and separators:
 
-![Hide buttons](https://github.com/DanRotaru/windhawk-mods/blob/master/exporer-command-bar/screenshots/hide-buttons.gif?raw=true)
+![Hide buttons](https://raw.githubusercontent.com/DanRotaru/windhawk-mods/master/exporer-command-bar/screenshots/hide-buttons.gif)
 
 You may hide even all options, and use only your custom ones:
 
-![Hide All buttons](https://github.com/DanRotaru/windhawk-mods/blob/master/exporer-command-bar/screenshots/hide-all-buttons.jpg?raw=true)
+![Hide All buttons](https://raw.githubusercontent.com/DanRotaru/windhawk-mods/master/exporer-command-bar/screenshots/hide-all-buttons.jpg)
 
 ## Command parameters
 
@@ -90,20 +89,40 @@ The **Icon glyph or icon path** field accepts several forms:
 
 ## Default configuration
 
-Out of the box the mod adds:
+Out of the box the mod adds only apps which are part of a stock Windows 11
+install:
 
 * **Open in Terminal** - `wt.exe -d "%path%"`
 * **Open in Notepad** - `notepad.exe "%sel%"`
 * **Additional** ▾ (dropdown)
-  * Open in VS Code - `code.exe "%path%"`
   * Open Paint - `mspaint.exe`
   * Open Calculator - `calc.exe`
-  * **Commands** ▸ - `vite`, `npm init`, `npm install`, `npm run dev`,
-    `npm run build`, `npm run start`
-  * **AI** ▸ - `Claude`, `Codex`
+  * **System** ▸ - Task Manager (`taskmgr.exe`), Control Panel (`control.exe`)
 
 All of the built-in buttons stay visible by default. Everything is configurable
 in the mod settings.
+
+## Example configurations
+
+A few items worth adding if you have the corresponding tools installed. Set
+*Command* and *Parameters* as shown; leave *Icon glyph or icon path* empty to
+use the executable's own icon.
+
+* **Open in VS Code** - command `code.exe`, parameters `"%path%"`.
+* **Open in your editor of choice** - e.g. command
+  `%LOCALAPPDATA%\Programs\<editor>\<editor>.exe`, parameters `"%path%"`.
+* **A dropdown of project commands** (type *Dropdown menu*), each entry with
+  command `cmd.exe` and parameters `/k npm install`, `/k npm run dev`,
+  `/k npm run build`, and so on. `cmd.exe /k` keeps the console open so you can
+  see the output.
+* **A dropdown of CLI tools** - command `cmd.exe` with parameters `/k claude`,
+  `/k codex`, `/k gh pr list`, ...
+* **Open a terminal as administrator** - command
+  `powershell.exe`, parameters
+  `-Command "Start-Process wt.exe -ArgumentList '-d \"%path%\"' -Verb RunAs"`.
+
+Enable *Hide icon* for the menu entries of such commands: an `.exe` like
+`cmd.exe` contributes little as an icon next to a text label.
 
 ## How it works
 
@@ -242,12 +261,6 @@ a new tab or navigating to another folder makes them appear.
     - separatorAfter: false
     - subItems:
       - - type: button
-        - name: Open in VS Code
-        - command: code.exe
-        - parameters: '"%path%"'
-        - iconGlyph: ""
-        - separatorAfter: false
-      - - type: button
         - name: Open Paint
         - command: mspaint.exe
         - parameters: ""
@@ -260,66 +273,23 @@ a new tab or navigating to another folder makes them appear.
         - iconGlyph: 'shell:AppsFolder\Microsoft.WindowsCalculator_8wekyb3d8bbwe!App'
         - separatorAfter: true
       - - type: menu
-        - name: Commands
+        - name: System
         - command: ""
         - parameters: ""
-        - iconGlyph: EC7A
+        - iconGlyph: E713
         - separatorAfter: false
         - subItems:
-          - - name: vite
-            - command: cmd.exe
-            - parameters: /k vite
+          - - name: Task Manager
+            - command: taskmgr.exe
+            - parameters: ""
             - iconGlyph: ""
-            - hideIcon: true
-            - separatorAfter: true
-          - - name: npm init
-            - command: cmd.exe
-            - parameters: /k npm init
-            - iconGlyph: ""
-            - hideIcon: true
+            - hideIcon: false
             - separatorAfter: false
-          - - name: npm install
-            - command: cmd.exe
-            - parameters: /k npm install
+          - - name: Control Panel
+            - command: control.exe
+            - parameters: ""
             - iconGlyph: ""
-            - hideIcon: true
-            - separatorAfter: false
-          - - name: npm run dev
-            - command: cmd.exe
-            - parameters: /k npm run dev
-            - iconGlyph: ""
-            - hideIcon: true
-            - separatorAfter: false
-          - - name: npm run build
-            - command: cmd.exe
-            - parameters: /k npm run build
-            - iconGlyph: ""
-            - hideIcon: true
-            - separatorAfter: false
-          - - name: npm run start
-            - command: cmd.exe
-            - parameters: /k npm run start
-            - iconGlyph: ""
-            - hideIcon: true
-            - separatorAfter: false
-      - - type: menu
-        - name: AI
-        - command: ""
-        - parameters: ""
-        - iconGlyph: E794
-        - separatorAfter: false
-        - subItems:
-          - - name: Claude
-            - command: cmd.exe
-            - parameters: /k claude
-            - iconGlyph: ""
-            - hideIcon: true
-            - separatorAfter: false
-          - - name: Codex
-            - command: cmd.exe
-            - parameters: /k codex
-            - iconGlyph: ""
-            - hideIcon: true
+            - hideIcon: false
             - separatorAfter: false
   $name: Toolbar items
   $description: >-
@@ -382,15 +352,16 @@ a new tab or navigating to another folder makes them appear.
     How long the cursor has to stay over the button before the menu opens.
     Only used when "Open menus on hover" is enabled.
 - itemSpacing: -1
-  $name: Item spacing (pixels)
+  $name: Item spacing (pixels at 100% scaling)
   $description: >-
-    Horizontal spacing between the command bar buttons, in pixels. -1 leaves
-    the default spacing unchanged; 0 places the buttons right next to each
-    other; 5 means 5 pixels between buttons, and so on.
+    Horizontal spacing between the command bar buttons. -1 leaves the default
+    spacing unchanged; 0 places the buttons right next to each other; 5 means 5
+    pixels between buttons, and so on. The value is in effective pixels, so at
+    150% display scaling it results in 1.5 times as many physical pixels. Note
+    that any value other than -1 also removes the built-in buttons' minimum
+    width, which shrinks their click area down to the icon.
 */
 // ==/WindhawkModSettings==
-
-#include <initguid.h>
 
 #include <windows.h>
 
@@ -403,12 +374,17 @@ a new tab or navigating to another folder makes them appear.
 #include <shobjidl.h>
 
 #include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cwctype>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <unordered_set>
+#include <utility>
 #include <vector>
 
 std::atomic<bool> g_unloading;
@@ -529,15 +505,75 @@ struct CommandBarEntry {
 std::mutex g_entriesMutex;
 std::vector<CommandBarEntry> g_entries;
 
-// Original visibility state of Explorer's own elements, captured the first
-// time we touch each one, so we can restore it exactly instead of forcing a
-// guessed default (which would reveal elements Explorer keeps collapsed).
-std::mutex g_originalStateMutex;
-std::unordered_map<void*, mux::Visibility> g_originalVisibility;
-std::unordered_map<void*, muxc::CommandBarOverflowButtonVisibility>
-    g_originalOverflow;
-std::unordered_map<void*, mux::Thickness> g_originalMargin;
-std::unordered_map<void*, double> g_originalMinWidth;
+// The Explorer elements we touch, each with the original state captured the
+// first time we touched it, so it can be restored exactly instead of forcing a
+// guessed default (which would reveal elements Explorer keeps collapsed), and
+// with the visibility watcher registered on it (see below).
+//
+// The element is held as a weak reference and entries are matched by resolving
+// it, never by its address: XAML objects die with their window or tab, and the
+// heap happily hands the same address to an unrelated element of the next one.
+struct ManagedElement {
+    DWORD threadId;
+    winrt::weak_ref<mux::UIElement> element;
+
+    bool hasOriginalVisibility = false;
+    mux::Visibility originalVisibility = mux::Visibility::Visible;
+
+    bool hasOriginalSpacing = false;
+    mux::Thickness originalMargin{};
+    double originalMinWidth = 0;
+
+    // Command bars only.
+    bool hasOriginalOverflow = false;
+    muxc::CommandBarOverflowButtonVisibility originalOverflow =
+        muxc::CommandBarOverflowButtonVisibility::Auto;
+
+    bool watched = false;
+    int64_t visibilityToken = 0;
+};
+
+std::mutex g_managedElementsMutex;
+std::vector<ManagedElement> g_managedElements;
+
+// The lookups below must run on the element's own UI thread, and the caller
+// must hold g_managedElementsMutex. A weak reference to a live non-agile XAML
+// element can only be resolved from its own thread, which is also why entries
+// of other threads are skipped rather than treated as dead.
+
+ManagedElement* FindManagedElement(mux::UIElement const& element) {
+    DWORD threadId = GetCurrentThreadId();
+
+    for (auto& entry : g_managedElements) {
+        if (entry.threadId == threadId && entry.element.get() == element) {
+            return &entry;
+        }
+    }
+
+    return nullptr;
+}
+
+ManagedElement& GetManagedElement(mux::UIElement const& element) {
+    DWORD threadId = GetCurrentThreadId();
+
+    // Drop the entries of this thread whose element is gone, so the list
+    // doesn't grow for the whole Explorer session.
+    for (auto it = g_managedElements.begin();
+         it != g_managedElements.end();) {
+        if (it->threadId == threadId && !it->element.get()) {
+            it = g_managedElements.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    if (auto* entry = FindManagedElement(element)) {
+        return *entry;
+    }
+
+    g_managedElements.push_back({threadId, winrt::make_weak(element)});
+    return g_managedElements.back();
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Getting the current folder path and launching commands.
@@ -713,6 +749,42 @@ std::wstring BuildParameters(std::wstring parameters,
     return parameters;
 }
 
+// The threads which are busy resolving the Explorer context and launching a
+// command. Their code lives in this DLL, so the mod can't be unloaded while
+// one of them is still running - see
+// https://github.com/ramensoftware/windhawk/wiki/Global-objects-and-process-shutdown
+std::mutex g_launchThreadsMutex;
+std::vector<HANDLE> g_launchThreads;
+
+void TrackLaunchThread(HANDLE thread) {
+    std::lock_guard<std::mutex> lock(g_launchThreadsMutex);
+
+    // Reap the ones which already finished.
+    for (auto it = g_launchThreads.begin(); it != g_launchThreads.end();) {
+        if (WaitForSingleObject(*it, 0) == WAIT_OBJECT_0) {
+            CloseHandle(*it);
+            it = g_launchThreads.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    g_launchThreads.push_back(thread);
+}
+
+void WaitForLaunchThreads() {
+    std::vector<HANDLE> threads;
+    {
+        std::lock_guard<std::mutex> lock(g_launchThreadsMutex);
+        threads.swap(g_launchThreads);
+    }
+
+    for (HANDLE thread : threads) {
+        WaitForSingleObject(thread, INFINITE);
+        CloseHandle(thread);
+    }
+}
+
 void LaunchItemForWindow(HWND hExplorerWnd, ActionItem const& item) {
     ExplorerContext context = GetExplorerContext(hExplorerWnd);
     Wh_Log(L"Launching %s for window %08X, path: %s, selection: %s",
@@ -733,7 +805,7 @@ void LaunchItemForWindow(HWND hExplorerWnd, ActionItem const& item) {
 
 void OnActionInvoked(mux::FrameworkElement const& elementForWindow,
                      ActionItem const& item) {
-    if (item.command.empty()) {
+    if (item.command.empty() || g_unloading) {
         return;
     }
 
@@ -769,8 +841,10 @@ void OnActionInvoked(mux::FrameworkElement const& elementForWindow,
 
     auto launchParams = std::make_unique<LaunchParams>(hWnd, item);
 
-    // Do the shell COM work off the UI thread to avoid blocking or
-    // deadlocking it.
+    // Do the shell COM work off the UI thread, so a slow or unresponsive
+    // shell can't block the click handler. Note that IShellBrowser and
+    // friends are owned by the Explorer UI thread, so the calls marshal back
+    // to it; only the waiting happens elsewhere.
     HANDLE thread = CreateThread(
         nullptr, 0,
         [](LPVOID lpParam) -> DWORD {
@@ -789,7 +863,9 @@ void OnActionInvoked(mux::FrameworkElement const& elementForWindow,
         launchParams.get(), 0, nullptr);
     if (thread) {
         launchParams.release();  // Owned by the thread now.
-        CloseHandle(thread);
+        // The handle is closed once the thread finished, either here on a
+        // later launch or in Wh_ModUninit, which waits for it.
+        TrackLaunchThread(thread);
     }
 }
 
@@ -938,75 +1014,144 @@ HICON ExtractCommandIcon(std::wstring const& command) {
     return nullptr;
 }
 
-muxm::ImageSource CreateImageSourceFromIcon(HICON hIcon) {
-    muxm::ImageSource result = nullptr;
+// A decoded icon: premultiplied BGRA pixels, top-down. Plain pixel data with
+// no thread affinity, which is what lets it be cached globally and turned into
+// a WriteableBitmap per XamlRoot.
+struct DecodedIcon {
+    int width = 0;
+    int height = 0;
+    std::vector<uint8_t> pixels;
 
-    ICONINFO iconInfo{};
-    if (!GetIconInfo(hIcon, &iconInfo)) {
-        return result;
+    bool empty() const { return pixels.empty(); }
+};
+
+// Reads a bitmap as 32-bit top-down pixels, whatever its own format is.
+bool ReadBitmapPixels(HBITMAP hBitmap, DecodedIcon* decoded) {
+    BITMAP bm{};
+    if (!GetObject(hBitmap, sizeof(bm), &bm) || bm.bmWidth <= 0 ||
+        bm.bmHeight <= 0) {
+        return false;
     }
 
+    int width = bm.bmWidth;
+    int height = bm.bmHeight;
+
+    BITMAPINFO bmi{};
+    bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
+    bmi.bmiHeader.biWidth = width;
+    bmi.bmiHeader.biHeight = -height;  // Top-down.
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    std::vector<uint8_t> pixels((size_t)width * height * 4);
+
+    HDC hdc = CreateCompatibleDC(nullptr);
+    if (!hdc) {
+        return false;
+    }
+
+    bool succeeded = GetDIBits(hdc, hBitmap, 0, height, pixels.data(), &bmi,
+                               DIB_RGB_COLORS) != 0;
+    DeleteDC(hdc);
+
+    if (!succeeded) {
+        return false;
+    }
+
+    decoded->width = width;
+    decoded->height = height;
+    decoded->pixels = std::move(pixels);
+    return true;
+}
+
+// True if every pixel is fully transparent, which is how a bitmap without an
+// alpha channel comes back.
+bool HasNoAlphaChannel(std::vector<uint8_t> const& pixels) {
+    for (size_t p = 3; p < pixels.size(); p += 4) {
+        if (pixels[p]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void MakeOpaque(std::vector<uint8_t>& pixels) {
+    for (size_t p = 3; p < pixels.size(); p += 4) {
+        pixels[p] = 255;
+    }
+}
+
+// 1-bpp icons have no color bitmap at all: their mask holds an AND mask
+// stacked on top of an XOR (monochrome color) mask.
+bool DecodeMonochromeIcon(HBITMAP hbmMask, DecodedIcon* decoded) {
+    DecodedIcon mask;
+    if (!ReadBitmapPixels(hbmMask, &mask) || mask.height % 2 != 0) {
+        return false;
+    }
+
+    int width = mask.width;
+    int height = mask.height / 2;
+
+    DecodedIcon result;
+    result.width = width;
+    result.height = height;
+    result.pixels.assign((size_t)width * height * 4, 0);
+
+    for (int y = 0; y < height; y++) {
+        for (int x = 0; x < width; x++) {
+            size_t andIndex = ((size_t)y * width + x) * 4;
+            size_t xorIndex = ((size_t)(y + height) * width + x) * 4;
+
+            // A set AND mask bit means "leave the background alone", i.e.
+            // transparent - the pixel stays zeroed.
+            if (mask.pixels[andIndex]) {
+                continue;
+            }
+
+            uint8_t value = mask.pixels[xorIndex] ? 255 : 0;
+            result.pixels[andIndex + 0] = value;
+            result.pixels[andIndex + 1] = value;
+            result.pixels[andIndex + 2] = value;
+            result.pixels[andIndex + 3] = 255;
+        }
+    }
+
+    *decoded = std::move(result);
+    return true;
+}
+
+bool DecodeIcon(HICON hIcon, DecodedIcon* decoded) {
+    ICONINFO iconInfo{};
+    if (!GetIconInfo(hIcon, &iconInfo)) {
+        return false;
+    }
+
+    bool succeeded = false;
+
     if (iconInfo.hbmColor) {
-        BITMAP bm{};
-        if (GetObject(iconInfo.hbmColor, sizeof(bm), &bm) && bm.bmWidth > 0 &&
-            bm.bmHeight > 0) {
-            int width = bm.bmWidth;
-            int height = bm.bmHeight;
-
-            BITMAPINFO bmi{};
-            bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
-            bmi.bmiHeader.biWidth = width;
-            bmi.bmiHeader.biHeight = -height;  // Top-down.
-            bmi.bmiHeader.biPlanes = 1;
-            bmi.bmiHeader.biBitCount = 32;
-            bmi.bmiHeader.biCompression = BI_RGB;
-
-            std::vector<uint8_t> pixels((size_t)width * height * 4);
-
-            HDC hdc = CreateCompatibleDC(nullptr);
-            if (hdc) {
-                if (GetDIBits(hdc, iconInfo.hbmColor, 0, height, pixels.data(),
-                              &bmi, DIB_RGB_COLORS)) {
-                    // Icons without an alpha channel come back fully
-                    // transparent, make them opaque.
-                    bool hasAlpha = false;
-                    for (size_t p = 3; p < pixels.size(); p += 4) {
-                        if (pixels[p]) {
-                            hasAlpha = true;
-                            break;
-                        }
-                    }
-
-                    if (!hasAlpha) {
-                        for (size_t p = 3; p < pixels.size(); p += 4) {
-                            pixels[p] = 255;
-                        }
-                    }
-
-                    // The XAML bitmap expects premultiplied alpha.
-                    for (size_t p = 0; p < pixels.size(); p += 4) {
-                        uint8_t alpha = pixels[p + 3];
-                        if (alpha != 255) {
-                            pixels[p] = pixels[p] * alpha / 255;
-                            pixels[p + 1] = pixels[p + 1] * alpha / 255;
-                            pixels[p + 2] = pixels[p + 2] * alpha / 255;
-                        }
-                    }
-
-                    try {
-                        muxm::Imaging::WriteableBitmap bitmap(width, height);
-                        memcpy(bitmap.PixelBuffer().data(), pixels.data(),
-                               pixels.size());
-                        bitmap.Invalidate();
-                        result = bitmap;
-                    } catch (...) {
-                        Wh_Log(L"Error %08X", winrt::to_hresult().value);
+        if (ReadBitmapPixels(iconInfo.hbmColor, decoded)) {
+            if (HasNoAlphaChannel(decoded->pixels)) {
+                MakeOpaque(decoded->pixels);
+            } else {
+                // The XAML bitmap expects premultiplied alpha.
+                for (size_t p = 0; p < decoded->pixels.size(); p += 4) {
+                    uint8_t alpha = decoded->pixels[p + 3];
+                    if (alpha != 255) {
+                        decoded->pixels[p] = decoded->pixels[p] * alpha / 255;
+                        decoded->pixels[p + 1] =
+                            decoded->pixels[p + 1] * alpha / 255;
+                        decoded->pixels[p + 2] =
+                            decoded->pixels[p + 2] * alpha / 255;
                     }
                 }
-
-                DeleteDC(hdc);
             }
+
+            succeeded = true;
         }
+    } else if (iconInfo.hbmMask) {
+        succeeded = DecodeMonochromeIcon(iconInfo.hbmMask, decoded);
     }
 
     if (iconInfo.hbmColor) {
@@ -1016,7 +1161,22 @@ muxm::ImageSource CreateImageSourceFromIcon(HICON hIcon) {
         DeleteObject(iconInfo.hbmMask);
     }
 
-    return result;
+    return succeeded;
+}
+
+muxm::ImageSource CreateImageSource(DecodedIcon const& decoded) try {
+    if (decoded.empty()) {
+        return nullptr;
+    }
+
+    muxm::Imaging::WriteableBitmap bitmap(decoded.width, decoded.height);
+    memcpy(bitmap.PixelBuffer().data(), decoded.pixels.data(),
+           decoded.pixels.size());
+    bitmap.Invalidate();
+    return bitmap;
+} catch (...) {
+    Wh_Log(L"Error %08X", winrt::to_hresult().value);
+    return nullptr;
 }
 
 std::wstring ParseGlyphSetting(PCWSTR glyphSetting) {
@@ -1106,66 +1266,7 @@ bool IsShellPath(std::wstring const& s) {
     return s.size() >= 6 && _wcsnicmp(s.c_str(), L"shell:", 6) == 0;
 }
 
-muxm::ImageSource CreateImageSourceFromHBitmap(HBITMAP hBitmap) {
-    muxm::ImageSource result = nullptr;
-
-    BITMAP bm{};
-    if (!GetObject(hBitmap, sizeof(bm), &bm) || bm.bmWidth <= 0 ||
-        bm.bmHeight <= 0) {
-        return result;
-    }
-
-    int width = bm.bmWidth;
-    int height = bm.bmHeight;
-
-    BITMAPINFO bmi{};
-    bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
-    bmi.bmiHeader.biWidth = width;
-    bmi.bmiHeader.biHeight = -height;  // Top-down.
-    bmi.bmiHeader.biPlanes = 1;
-    bmi.bmiHeader.biBitCount = 32;
-    bmi.bmiHeader.biCompression = BI_RGB;
-
-    std::vector<uint8_t> pixels((size_t)width * height * 4);
-
-    HDC hdc = CreateCompatibleDC(nullptr);
-    if (!hdc) {
-        return result;
-    }
-
-    if (GetDIBits(hdc, hBitmap, 0, height, pixels.data(), &bmi,
-                  DIB_RGB_COLORS)) {
-        // The shell returns premultiplied alpha already; just handle the
-        // fully-opaque (no alpha channel) case.
-        bool hasAlpha = false;
-        for (size_t p = 3; p < pixels.size(); p += 4) {
-            if (pixels[p]) {
-                hasAlpha = true;
-                break;
-            }
-        }
-
-        if (!hasAlpha) {
-            for (size_t p = 3; p < pixels.size(); p += 4) {
-                pixels[p] = 255;
-            }
-        }
-
-        try {
-            muxm::Imaging::WriteableBitmap bitmap(width, height);
-            memcpy(bitmap.PixelBuffer().data(), pixels.data(), pixels.size());
-            bitmap.Invalidate();
-            result = bitmap;
-        } catch (...) {
-            Wh_Log(L"Error %08X", winrt::to_hresult().value);
-        }
-    }
-
-    DeleteDC(hdc);
-    return result;
-}
-
-muxm::ImageSource LoadImageSourceFromShellPath(std::wstring const& path) {
+bool DecodeShellPathIcon(std::wstring const& path, DecodedIcon* decoded) {
     std::wstring expanded = ExpandEnvVars(path);
 
     PIDLIST_ABSOLUTE pidl = nullptr;
@@ -1173,14 +1274,14 @@ muxm::ImageSource LoadImageSourceFromShellPath(std::wstring const& path) {
                                   nullptr)) ||
         !pidl) {
         Wh_Log(L"Couldn't parse shell path %s", path.c_str());
-        return nullptr;
+        return false;
     }
 
     winrt::com_ptr<IShellItemImageFactory> factory;
     HRESULT hr = SHCreateItemFromIDList(pidl, IID_PPV_ARGS(factory.put()));
     CoTaskMemFree(pidl);
     if (FAILED(hr) || !factory) {
-        return nullptr;
+        return false;
     }
 
     SIZE size = {32, 32};
@@ -1188,12 +1289,73 @@ muxm::ImageSource LoadImageSourceFromShellPath(std::wstring const& path) {
     hr = factory->GetImage(size, SIIGBF_ICONONLY | SIIGBF_BIGGERSIZEOK,
                            &hBitmap);
     if (FAILED(hr) || !hBitmap) {
-        return nullptr;
+        return false;
     }
 
-    auto source = CreateImageSourceFromHBitmap(hBitmap);
+    bool succeeded = ReadBitmapPixels(hBitmap, decoded);
     DeleteObject(hBitmap);
-    return source;
+
+    // The shell returns premultiplied alpha already; just handle the
+    // fully-opaque (no alpha channel) case.
+    if (succeeded && HasNoAlphaChannel(decoded->pixels)) {
+        MakeOpaque(decoded->pixels);
+    }
+
+    return succeeded;
+}
+
+std::shared_ptr<DecodedIcon> ResolveIcon(std::wstring const& iconSetting,
+                                         std::wstring const& command) {
+    auto decoded = std::make_shared<DecodedIcon>();
+
+    bool isPath = !iconSetting.empty() && LooksLikeIconPath(iconSetting);
+    if (isPath && IsShellPath(iconSetting)) {
+        DecodeShellPathIcon(iconSetting, decoded.get());
+        return decoded;
+    }
+
+    HICON hIcon = nullptr;
+    if (isPath) {
+        hIcon = LoadIconFromPath(iconSetting);
+    } else if (iconSetting.empty() && !command.empty()) {
+        hIcon = ExtractCommandIcon(command);
+    }
+
+    if (hIcon) {
+        DecodeIcon(hIcon, decoded.get());
+        DestroyIcon(hIcon);
+    }
+
+    return decoded;
+}
+
+// Resolving an icon is expensive - the search path, the App Paths registry
+// keys, a reparse point, and for a shell path the package metadata of a Store
+// app - and it happens on the Explorer UI thread while a window or a tab is
+// being built. The decoded pixels don't depend on the thread or the window, so
+// they're resolved once and reused; the cache is dropped when the settings
+// change. An entry with no pixels is a remembered failure.
+std::mutex g_iconCacheMutex;
+std::unordered_map<std::wstring, std::shared_ptr<DecodedIcon>> g_iconCache;
+
+std::shared_ptr<DecodedIcon> GetIcon(std::wstring const& iconSetting,
+                                     std::wstring const& command) {
+    // '\n' can't appear in either part, so it's an unambiguous separator.
+    std::wstring key = iconSetting + L'\n' + command;
+
+    {
+        std::lock_guard<std::mutex> lock(g_iconCacheMutex);
+        auto it = g_iconCache.find(key);
+        if (it != g_iconCache.end()) {
+            return it->second;
+        }
+    }
+
+    auto decoded = ResolveIcon(iconSetting, command);
+
+    std::lock_guard<std::mutex> lock(g_iconCacheMutex);
+    return g_iconCache.insert_or_assign(std::move(key), std::move(decoded))
+        .first->second;
 }
 
 // Returns nullptr if no icon could be resolved from the settings.
@@ -1201,27 +1363,12 @@ muxc::IconElement TryCreateIconElement(std::wstring const& iconSetting,
                                        std::wstring const& command) {
     bool isPath = !iconSetting.empty() && LooksLikeIconPath(iconSetting);
 
-    muxm::ImageSource source = nullptr;
-    if (isPath && IsShellPath(iconSetting)) {
-        source = LoadImageSourceFromShellPath(iconSetting);
-    } else {
-        HICON hIcon = nullptr;
-        if (isPath) {
-            hIcon = LoadIconFromPath(iconSetting);
-        } else if (iconSetting.empty() && !command.empty()) {
-            hIcon = ExtractCommandIcon(command);
+    if (isPath || iconSetting.empty()) {
+        if (auto source = CreateImageSource(*GetIcon(iconSetting, command))) {
+            muxc::ImageIcon imageIcon;
+            imageIcon.Source(source);
+            return imageIcon;
         }
-
-        if (hIcon) {
-            source = CreateImageSourceFromIcon(hIcon);
-            DestroyIcon(hIcon);
-        }
-    }
-
-    if (source) {
-        muxc::ImageIcon imageIcon;
-        imageIcon.Source(source);
-        return imageIcon;
     }
 
     std::wstring glyph;
@@ -1253,11 +1400,14 @@ muxc::IconElement CreateIconElement(std::wstring const& iconSetting,
 }
 
 // Icon for a command bar button, honoring the item's "Hide icon" option.
+// Since the label is collapsed, a button without any icon would render as an
+// empty box, so an icon which couldn't be resolved (a mistyped command, a
+// missing executable) falls back to a visible placeholder glyph.
 muxc::IconElement MakeCommandButtonIcon(ActionItem const& item) {
     if (item.hideIcon) {
         return nullptr;
     }
-    return CreateIconElement(item.icon, item.command, L"");
+    return CreateIconElement(item.icon, item.command, L"");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1401,10 +1551,10 @@ bool ShouldHide(ManagedTarget const& target);
 // touched it.
 mux::Visibility EffectiveVisibility(mux::UIElement const& element) {
     {
-        std::lock_guard<std::mutex> lock(g_originalStateMutex);
-        auto it = g_originalVisibility.find(winrt::get_abi(element));
-        if (it != g_originalVisibility.end()) {
-            return it->second;
+        std::lock_guard<std::mutex> lock(g_managedElementsMutex);
+        auto* entry = FindManagedElement(element);
+        if (entry && entry->hasOriginalVisibility) {
+            return entry->originalVisibility;
         }
     }
 
@@ -1479,33 +1629,26 @@ void SetVisibilityInternal(mux::UIElement const& element,
     g_settingVisibilityDepth--;
 }
 
-// Explorer shows and hides its contextual commands (Set as background, Rotate
-// left/right, Extract all, ...) as the selection changes, which overwrites our
-// collapse. Watching the property lets us re-apply immediately, and keeps the
-// remembered original in sync so disabling the mod restores what Explorer
-// wanted rather than what it happened to be when we first saw the element.
-struct VisibilityWatch {
-    DWORD threadId;
-    void* key;
-    winrt::weak_ref<mux::UIElement> element;
-    int64_t token;
-};
-
-std::mutex g_watchesMutex;
-std::vector<VisibilityWatch> g_watches;
-
 void ApplyDefaultButtonVisibility(muxc::CommandBar const& commandBar,
                                   bool forceShow = false);
 
-// Hiding a group separator depends on the whole group, so a single element
-// changing isn't enough to decide: re-run the pass for the command bar once the
-// current batch of changes has settled. Coalesced per command bar, since
-// Explorer updates a whole run of commands on every selection change.
-std::mutex g_pendingRecomputeMutex;
-std::unordered_set<void*> g_pendingRecompute;
+void UpdateCommandBar(muxc::CommandBar const& commandBar);
 
-void QueueVisibilityRecompute(
-    winrt::weak_ref<muxc::CommandBar> const& weakCommandBar) {
+// Both a visibility recompute (hiding a group separator depends on the whole
+// group, so a single element changing isn't enough to decide) and a full
+// update after Explorer touched the command list are deferred and coalesced
+// per command bar: Explorer updates a whole run of commands on every selection
+// change, and appending our own buttons raises one change notification each.
+//
+// The pending entries are keyed by address, which is safe here because the
+// queued work always removes its own entry: an entry can't outlive the command
+// bar it belongs to and be matched against a later one at the same address.
+std::mutex g_pendingUpdatesMutex;
+std::unordered_map<void*, bool> g_pendingUpdates;  // Value: full update.
+
+void QueueCommandBarUpdate(
+    winrt::weak_ref<muxc::CommandBar> const& weakCommandBar,
+    bool fullUpdate) {
     auto commandBar = weakCommandBar.get();
     if (!commandBar) {
         return;
@@ -1513,27 +1656,38 @@ void QueueVisibilityRecompute(
 
     void* key = winrt::get_abi(commandBar);
     {
-        std::lock_guard<std::mutex> lock(g_pendingRecomputeMutex);
-        if (!g_pendingRecompute.insert(key).second) {
-            return;  // Already queued.
+        std::lock_guard<std::mutex> lock(g_pendingUpdatesMutex);
+        auto [it, inserted] = g_pendingUpdates.insert({key, fullUpdate});
+        if (!inserted) {
+            // Already queued; the queued work reads the flag when it runs, so
+            // a full update can still be requested on top of a recompute.
+            it->second = it->second || fullUpdate;
+            return;
         }
     }
 
-    auto forgetPending = [key]() {
-        std::lock_guard<std::mutex> lock(g_pendingRecomputeMutex);
-        g_pendingRecompute.erase(key);
+    auto takePending = [key]() {
+        std::lock_guard<std::mutex> lock(g_pendingUpdatesMutex);
+        bool full = false;
+        auto it = g_pendingUpdates.find(key);
+        if (it != g_pendingUpdates.end()) {
+            full = it->second;
+            g_pendingUpdates.erase(it);
+        }
+
+        return full;
     };
 
     auto dispatcherQueue =
         winrt::Microsoft::UI::Dispatching::DispatcherQueue::
             GetForCurrentThread();
     if (!dispatcherQueue) {
-        forgetPending();
+        takePending();
         return;
     }
 
-    if (!dispatcherQueue.TryEnqueue([weakCommandBar, forgetPending]() {
-            forgetPending();
+    if (!dispatcherQueue.TryEnqueue([weakCommandBar, takePending]() {
+            bool full = takePending();
 
             if (g_unloading) {
                 return;
@@ -1541,44 +1695,39 @@ void QueueVisibilityRecompute(
 
             if (auto commandBar = weakCommandBar.get()) {
                 try {
-                    ApplyDefaultButtonVisibility(commandBar);
+                    if (full) {
+                        UpdateCommandBar(commandBar);
+                    } else {
+                        ApplyDefaultButtonVisibility(commandBar);
+                    }
                 } catch (...) {
                     Wh_Log(L"Error %08X", winrt::to_hresult().value);
                 }
             }
         })) {
-        forgetPending();
+        takePending();
     }
 }
 
+void QueueVisibilityRecompute(
+    winrt::weak_ref<muxc::CommandBar> const& weakCommandBar) {
+    QueueCommandBarUpdate(weakCommandBar, /*fullUpdate=*/false);
+}
+
+// Explorer shows and hides its contextual commands (Set as background, Rotate
+// left/right, Extract all, ...) as the selection changes, which overwrites our
+// collapse. Watching the property lets us re-apply immediately, and keeps the
+// remembered original in sync so disabling the mod restores what Explorer
+// wanted rather than what it happened to be when we first saw the element.
+// The caller has established, under the lock, that the element isn't watched
+// yet.
 void WatchVisibility(mux::UIElement const& element,
-                     void* key,
                      ManagedTarget const& target,
                      winrt::weak_ref<muxc::CommandBar> const& owner) {
-    {
-        std::lock_guard<std::mutex> lock(g_watchesMutex);
-
-        DWORD threadId = GetCurrentThreadId();
-        for (auto it = g_watches.begin(); it != g_watches.end();) {
-            if (it->key == key) {
-                return;  // Already watched.
-            }
-
-            // Drop entries of elements that are gone. Only our own thread's,
-            // since a weak reference to a live non-agile element can't be
-            // resolved from another thread.
-            if (it->threadId == threadId && !it->element.get()) {
-                it = g_watches.erase(it);
-            } else {
-                ++it;
-            }
-        }
-    }
-
     int64_t token = element.RegisterPropertyChangedCallback(
         mux::UIElement::VisibilityProperty(),
-        [key, target, owner](mux::DependencyObject const& sender,
-                             mux::DependencyProperty const&) {
+        [target, owner](mux::DependencyObject const& sender,
+                        mux::DependencyProperty const&) {
             if (g_unloading || g_settingVisibilityDepth > 0) {
                 return;
             }
@@ -1591,8 +1740,10 @@ void WatchVisibility(mux::UIElement const& element,
             // Explorer changed it, so this is the new baseline to restore.
             mux::Visibility visibility = element.Visibility();
             {
-                std::lock_guard<std::mutex> lock(g_originalStateMutex);
-                g_originalVisibility[key] = visibility;
+                std::lock_guard<std::mutex> lock(g_managedElementsMutex);
+                auto& entry = GetManagedElement(element);
+                entry.originalVisibility = visibility;
+                entry.hasOriginalVisibility = true;
             }
 
             if (visibility != mux::Visibility::Collapsed &&
@@ -1605,34 +1756,54 @@ void WatchVisibility(mux::UIElement const& element,
             QueueVisibilityRecompute(owner);
         });
 
-    std::lock_guard<std::mutex> lock(g_watchesMutex);
-    g_watches.push_back({GetCurrentThreadId(), key,
-                         winrt::make_weak(element), token});
+    std::lock_guard<std::mutex> lock(g_managedElementsMutex);
+    auto& entry = GetManagedElement(element);
+    entry.watched = true;
+    entry.visibilityToken = token;
 }
 
+// Unregisters the watchers of this thread's elements, keeping their remembered
+// original state for the restore which follows.
 void UnwatchVisibilityForCurrentThread() {
     DWORD threadId = GetCurrentThreadId();
-    std::vector<VisibilityWatch> taken;
+
+    std::vector<std::pair<mux::UIElement, int64_t>> taken;
     {
-        std::lock_guard<std::mutex> lock(g_watchesMutex);
-        for (auto it = g_watches.begin(); it != g_watches.end();) {
-            if (it->threadId == threadId) {
-                taken.push_back(std::move(*it));
-                it = g_watches.erase(it);
-            } else {
-                ++it;
+        std::lock_guard<std::mutex> lock(g_managedElementsMutex);
+        for (auto& entry : g_managedElements) {
+            if (entry.threadId != threadId || !entry.watched) {
+                continue;
             }
+
+            if (auto element = entry.element.get()) {
+                taken.push_back({element, entry.visibilityToken});
+            }
+
+            entry.watched = false;
+            entry.visibilityToken = 0;
         }
     }
 
-    for (auto const& watch : taken) {
-        if (auto element = watch.element.get()) {
-            try {
-                element.UnregisterPropertyChangedCallback(
-                    mux::UIElement::VisibilityProperty(), watch.token);
-            } catch (...) {
-                Wh_Log(L"Error %08X", winrt::to_hresult().value);
-            }
+    for (auto const& [element, token] : taken) {
+        try {
+            element.UnregisterPropertyChangedCallback(
+                mux::UIElement::VisibilityProperty(), token);
+        } catch (...) {
+            Wh_Log(L"Error %08X", winrt::to_hresult().value);
+        }
+    }
+}
+
+void ForgetManagedElementsForCurrentThread() {
+    DWORD threadId = GetCurrentThreadId();
+
+    std::lock_guard<std::mutex> lock(g_managedElementsMutex);
+    for (auto it = g_managedElements.begin();
+         it != g_managedElements.end();) {
+        if (it->threadId == threadId) {
+            it = g_managedElements.erase(it);
+        } else {
+            ++it;
         }
     }
 }
@@ -1645,20 +1816,22 @@ void SetManagedVisibility(mux::UIElement const& element,
                           ManagedTarget const& target,
                           bool forceShow,
                           winrt::weak_ref<muxc::CommandBar> const& owner) {
-    void* key = winrt::get_abi(element);
-
     mux::Visibility original;
+    bool watch;
     {
-        std::lock_guard<std::mutex> lock(g_originalStateMutex);
-        auto it = g_originalVisibility.find(key);
-        if (it == g_originalVisibility.end()) {
-            it = g_originalVisibility.emplace(key, element.Visibility()).first;
+        std::lock_guard<std::mutex> lock(g_managedElementsMutex);
+        auto& entry = GetManagedElement(element);
+        if (!entry.hasOriginalVisibility) {
+            entry.originalVisibility = element.Visibility();
+            entry.hasOriginalVisibility = true;
         }
-        original = it->second;
+
+        original = entry.originalVisibility;
+        watch = !forceShow && !entry.watched;
     }
 
-    if (!forceShow) {
-        WatchVisibility(element, key, target, owner);
+    if (watch) {
+        WatchVisibility(element, target, owner);
     }
 
     SetVisibilityInternal(element, !forceShow && ShouldHide(target)
@@ -1674,25 +1847,19 @@ void SetManagedVisibility(mux::UIElement const& element,
 void ApplyItemSpacing(muxc::AppBarButton const& button,
                       int spacing,
                       bool reset) {
-    void* key = winrt::get_abi(button);
-
     mux::Thickness originalMargin;
     double originalMinWidth;
     {
-        std::lock_guard<std::mutex> lock(g_originalStateMutex);
-
-        auto marginIt = g_originalMargin.find(key);
-        if (marginIt == g_originalMargin.end()) {
-            marginIt = g_originalMargin.emplace(key, button.Margin()).first;
+        std::lock_guard<std::mutex> lock(g_managedElementsMutex);
+        auto& entry = GetManagedElement(button);
+        if (!entry.hasOriginalSpacing) {
+            entry.originalMargin = button.Margin();
+            entry.originalMinWidth = button.MinWidth();
+            entry.hasOriginalSpacing = true;
         }
-        originalMargin = marginIt->second;
 
-        auto minWidthIt = g_originalMinWidth.find(key);
-        if (minWidthIt == g_originalMinWidth.end()) {
-            minWidthIt =
-                g_originalMinWidth.emplace(key, button.MinWidth()).first;
-        }
-        originalMinWidth = minWidthIt->second;
+        originalMargin = entry.originalMargin;
+        originalMinWidth = entry.originalMinWidth;
     }
 
     if (reset || spacing < 0) {
@@ -1777,6 +1944,16 @@ void ApplyDefaultButtonVisibility(muxc::CommandBar const& commandBar,
                     entry.isDetailsToggle = true;
                 } else {
                     entry.defaultIndex = IdentifyDefaultButton(button);
+                    if (entry.defaultIndex < 0) {
+                        // Expected for the contextual commands Explorer keeps
+                        // in the list, but it's also what a built-in button
+                        // whose icon file was renamed in a new Windows build
+                        // looks like, so log enough to tell the two apart.
+                        Wh_Log(L"Unrecognized command %u: icon %s, "
+                               L"automation id %s",
+                               i, GetButtonIconUri(button).c_str(),
+                               GetAutomationId(button).c_str());
+                    }
                 }
             }
         }
@@ -1787,12 +1964,33 @@ void ApplyDefaultButtonVisibility(muxc::CommandBar const& commandBar,
     // Explorer keeps ~20 contextual, zero-width commands (Extract, Eject, ...)
     // in the list between the View group and the overflow region. The vertical
     // line the user sees "after View" is really the separator right before our
-    // first custom button, so locate that.
+    // first custom button, so locate that one.
     uint32_t firstCustomIndex = count;
     for (uint32_t i = 0; i < count; i++) {
         if (entries[i].isOurs) {
             firstCustomIndex = i;
             break;
+        }
+    }
+
+    uint32_t viewSeparatorIndex = count;
+    if (firstCustomIndex > 0 && firstCustomIndex < count &&
+        entries[firstCustomIndex - 1].isSeparator) {
+        viewSeparatorIndex = firstCustomIndex - 1;
+    } else {
+        // Without custom buttons (the mod can be used just to hide the
+        // built-in ones) it's the first separator after the View button.
+        for (uint32_t i = 0; i < count && viewSeparatorIndex == count; i++) {
+            if (entries[i].defaultIndex != kViewButtonIndex) {
+                continue;
+            }
+
+            for (uint32_t j = i + 1; j < count; j++) {
+                if (entries[j].isSeparator) {
+                    viewSeparatorIndex = j;
+                    break;
+                }
+            }
         }
     }
 
@@ -1842,8 +2040,7 @@ void ApplyDefaultButtonVisibility(muxc::CommandBar const& commandBar,
                 target = kNewButtonIndex;
             } else if (prevIndex == kDeleteButtonIndex) {
                 target = kDeleteButtonIndex;
-            } else if (firstCustomIndex < count && i + 1 == firstCustomIndex) {
-                // The separator right before our custom buttons.
+            } else if (i == viewSeparatorIndex) {
                 target = kViewButtonIndex;
             }
 
@@ -1885,17 +2082,16 @@ void ApplyDefaultButtonVisibility(muxc::CommandBar const& commandBar,
     // part). OverflowButtonVisibility alone doesn't hide the separator in
     // Explorer's template, so collapse it explicitly too.
     if (isPrimary) {
-        void* key = winrt::get_abi(commandBar);
         muxc::CommandBarOverflowButtonVisibility originalOverflow;
         {
-            std::lock_guard<std::mutex> lock(g_originalStateMutex);
-            auto it = g_originalOverflow.find(key);
-            if (it == g_originalOverflow.end()) {
-                it = g_originalOverflow
-                         .emplace(key, commandBar.OverflowButtonVisibility())
-                         .first;
+            std::lock_guard<std::mutex> lock(g_managedElementsMutex);
+            auto& entry = GetManagedElement(commandBar);
+            if (!entry.hasOriginalOverflow) {
+                entry.originalOverflow = commandBar.OverflowButtonVisibility();
+                entry.hasOriginalOverflow = true;
             }
-            originalOverflow = it->second;
+
+            originalOverflow = entry.originalOverflow;
         }
 
         commandBar.OverflowButtonVisibility(
@@ -1995,6 +2191,63 @@ void AppendMenuEntries(std::vector<ActionItem> const& items,
     }
 }
 
+// The hover timers of our menu buttons. A started timer is rooted by the
+// dispatcher queue and its Tick handler lives in this DLL, so the timers have
+// to be stopped before the mod is unloaded.
+struct HoverTimerEntry {
+    DWORD threadId;
+    winrt::weak_ref<mux::DispatcherTimer> timer;
+};
+
+std::mutex g_hoverTimersMutex;
+std::vector<HoverTimerEntry> g_hoverTimers;
+
+void TrackHoverTimer(mux::DispatcherTimer const& timer) {
+    DWORD threadId = GetCurrentThreadId();
+
+    std::lock_guard<std::mutex> lock(g_hoverTimersMutex);
+
+    // Drop this thread's timers which are gone with their button.
+    for (auto it = g_hoverTimers.begin(); it != g_hoverTimers.end();) {
+        if (it->threadId == threadId && !it->timer.get()) {
+            it = g_hoverTimers.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    g_hoverTimers.push_back({threadId, winrt::make_weak(timer)});
+}
+
+void StopHoverTimersForCurrentThread() {
+    DWORD threadId = GetCurrentThreadId();
+
+    std::vector<mux::DispatcherTimer> taken;
+    {
+        std::lock_guard<std::mutex> lock(g_hoverTimersMutex);
+        for (auto it = g_hoverTimers.begin(); it != g_hoverTimers.end();) {
+            if (it->threadId != threadId) {
+                ++it;
+                continue;
+            }
+
+            if (auto timer = it->timer.get()) {
+                taken.push_back(std::move(timer));
+            }
+
+            it = g_hoverTimers.erase(it);
+        }
+    }
+
+    for (auto const& timer : taken) {
+        try {
+            timer.Stop();
+        } catch (...) {
+            Wh_Log(L"Error %08X", winrt::to_hresult().value);
+        }
+    }
+}
+
 muxc::AppBarButton CreateMenuButton(ActionItem const& item,
                                     int index,
                                     bool openOnHover,
@@ -2008,7 +2261,38 @@ muxc::AppBarButton CreateMenuButton(ActionItem const& item,
     muxc::MenuFlyout menu;
     menu.Placement(
         muxc::Primitives::FlyoutPlacementMode::BottomEdgeAlignedLeft);
-    AppendMenuEntries(item.subItems, menu.Items(), weakButton);
+
+    // Every menu entry resolves an icon, which is the expensive part of
+    // building the menu, so the entries are created the first time the menu is
+    // needed instead of while the window or the tab is being built.
+    auto ensureMenuEntries = [subItems = item.subItems, weakButton](
+                                 muxc::MenuFlyout const& menu) {
+        if (!menu || menu.Items().Size() > 0) {
+            return;
+        }
+
+        try {
+            AppendMenuEntries(subItems, menu.Items(), weakButton);
+        } catch (...) {
+            Wh_Log(L"Error %08X", winrt::to_hresult().value);
+        }
+    };
+
+    menu.Opening([ensureMenuEntries](wf::IInspectable const& sender,
+                                     wf::IInspectable const&) {
+        ensureMenuEntries(sender.try_as<muxc::MenuFlyout>());
+    });
+
+    // Also while the pointer is on its way to the button, which is both a
+    // little earlier than the click and a safety net for the case above.
+    button.PointerEntered(
+        [ensureMenuEntries, weakButton](
+            wf::IInspectable const&,
+            mux::Input::PointerRoutedEventArgs const&) {
+            if (auto button = weakButton.get()) {
+                ensureMenuEntries(button.Flyout().try_as<muxc::MenuFlyout>());
+            }
+        });
 
     button.Flyout(menu);
 
@@ -2033,6 +2317,7 @@ muxc::AppBarButton CreateMenuButton(ActionItem const& item,
         } else {
             mux::DispatcherTimer timer;
             timer.Interval(std::chrono::milliseconds(hoverDelayMs));
+            TrackHoverTimer(timer);
 
             // Capture the timer weakly in its own Tick handler to avoid a
             // reference cycle.
@@ -2177,17 +2462,10 @@ void OnCommandBarAdded(muxc::CommandBar const& commandBar) {
                 return;
             }
 
-            // Defer the update; mutating the vector from within its own
-            // change notification isn't allowed.
-            auto dispatcherQueue = winrt::Microsoft::UI::Dispatching::
-                DispatcherQueue::GetForCurrentThread();
-            if (dispatcherQueue) {
-                dispatcherQueue.TryEnqueue([weakCommandBar]() {
-                    if (auto commandBar = weakCommandBar.get()) {
-                        UpdateCommandBar(commandBar);
-                    }
-                });
-            }
+            // Defer the update; mutating the vector from within its own change
+            // notification isn't allowed. Coalesced, since adding our own
+            // buttons raises one notification per button.
+            QueueCommandBarUpdate(weakCommandBar, /*fullUpdate=*/true);
         });
 
     {
@@ -2218,6 +2496,7 @@ std::vector<CommandBarEntry> TakeEntriesForCurrentThread() {
 void RemoveButtonsForCurrentThread() {
     // Before restoring anything, so the watcher can't fight the restore.
     UnwatchVisibilityForCurrentThread();
+    StopHoverTimersForCurrentThread();
 
     for (auto& entry : TakeEntriesForCurrentThread()) {
         auto commandBar = entry.commandBar.get();
@@ -2235,9 +2514,17 @@ void RemoveButtonsForCurrentThread() {
             Wh_Log(L"Error %08X", winrt::to_hresult().value);
         }
     }
+
+    // Everything has been restored, so the remembered original state of this
+    // thread's elements isn't needed anymore.
+    ForgetManagedElementsForCurrentThread();
 }
 
 void RefreshButtonsForCurrentThread() {
+    // The buttons are recreated below, so the hover timers of the old ones are
+    // stopped and forgotten first.
+    StopHoverTimersForCurrentThread();
+
     std::vector<winrt::weak_ref<muxc::CommandBar>> commandBars;
     {
         DWORD threadId = GetCurrentThreadId();
@@ -2289,6 +2576,22 @@ bool IsTargetCommandBarName(std::wstring_view name) {
            name == L"FileExplorerSecondaryCommandBar";
 }
 
+// Both command bars are found, so there's nothing left to look for.
+bool FoundAllCommandBars(std::vector<muxc::CommandBar> const& commandBars) {
+    bool primary = false;
+    bool secondary = false;
+
+    for (auto const& commandBar : commandBars) {
+        if (commandBar.Name() == L"FileExplorerCommandBar") {
+            primary = true;
+        } else if (commandBar.Name() == L"FileExplorerSecondaryCommandBar") {
+            secondary = true;
+        }
+    }
+
+    return primary && secondary;
+}
+
 void CollectCommandBars(mux::DependencyObject const& root,
                         int depth,
                         std::vector<muxc::CommandBar>* commandBars) {
@@ -2298,6 +2601,12 @@ void CollectCommandBars(mux::DependencyObject const& root,
 
     int count = muxm::VisualTreeHelper::GetChildrenCount(root);
     for (int i = 0; i < count; i++) {
+        // The scan runs on every focus event, so stop walking the tree as soon
+        // as there's nothing left to find.
+        if (FoundAllCommandBars(*commandBars)) {
+            return;
+        }
+
         auto child = muxm::VisualTreeHelper::GetChild(root, i);
         if (auto commandBar = child.try_as<muxc::CommandBar>();
             commandBar && IsTargetCommandBarName(commandBar.Name())) {
@@ -2617,6 +2926,9 @@ bool HookFileExplorerExtensionsIfLoaded(bool applyHooks) {
     Wh_Log(L"Hooking FileExplorerExtensions.dll");
 
     if (!HookFileExplorerExtensionsSymbols(module)) {
+        // Let a later attempt (e.g. the next LoadLibraryExW) try again instead
+        // of leaving the mod permanently disabled for this process.
+        g_symbolsHooked = false;
         return false;
     }
 
@@ -2724,29 +3036,27 @@ std::vector<HWND> GetFileExplorerWnds() {
 constexpr int kMaxMenuDepth = 2;
 
 ActionItem LoadActionItem(PCWSTR prefix, int depth, bool* isEmpty) {
-    PCWSTR type = Wh_GetStringSetting(L"%s.type", prefix);
-    PCWSTR name = Wh_GetStringSetting(L"%s.name", prefix);
-    PCWSTR command = Wh_GetStringSetting(L"%s.command", prefix);
-    PCWSTR parameters = Wh_GetStringSetting(L"%s.parameters", prefix);
-    PCWSTR iconGlyph = Wh_GetStringSetting(L"%s.iconGlyph", prefix);
+    auto name = WindhawkUtils::StringSetting::make(L"%s.name", prefix);
+    auto command = WindhawkUtils::StringSetting::make(L"%s.command", prefix);
+    auto parameters =
+        WindhawkUtils::StringSetting::make(L"%s.parameters", prefix);
+    auto iconGlyph =
+        WindhawkUtils::StringSetting::make(L"%s.iconGlyph", prefix);
 
     ActionItem item;
-    item.name = name;
-    item.command = command;
-    item.parameters = parameters;
-    item.icon = iconGlyph;
+    item.name = name.get();
+    item.command = command.get();
+    item.parameters = parameters.get();
+    item.icon = iconGlyph.get();
     item.hideIcon = Wh_GetIntSetting(L"%s.hideIcon", prefix) != 0;
-    item.isMenu = wcscmp(type, L"menu") == 0;
     item.separatorAfter =
         Wh_GetIntSetting(L"%s.separatorAfter", prefix) != 0;
 
-    Wh_FreeStringSetting(type);
-    Wh_FreeStringSetting(name);
-    Wh_FreeStringSetting(command);
-    Wh_FreeStringSetting(parameters);
-    Wh_FreeStringSetting(iconGlyph);
-
+    // The deepest level can't hold a submenu, so it declares no type at all.
     if (depth < kMaxMenuDepth) {
+        auto type = WindhawkUtils::StringSetting::make(L"%s.type", prefix);
+        item.isMenu = wcscmp(type.get(), L"menu") == 0;
+
         for (int i = 0; i < 100; i++) {
             WCHAR subPrefix[256];
             swprintf(subPrefix, ARRAYSIZE(subPrefix), L"%s.subItems[%d]",
@@ -2769,6 +3079,12 @@ ActionItem LoadActionItem(PCWSTR prefix, int depth, bool* isEmpty) {
 }
 
 void LoadSettings() {
+    {
+        // The items, and with them the icons they ask for, may have changed.
+        std::lock_guard<std::mutex> lock(g_iconCacheMutex);
+        g_iconCache.clear();
+    }
+
     std::lock_guard<std::mutex> lock(g_settings.mutex);
 
     g_settings.openMenuOnHover = Wh_GetIntSetting(L"openMenuOnHover") != 0;
@@ -2813,14 +3129,8 @@ void LoadSettings() {
         g_settings.items.push_back(std::move(item));
     }
 
-    if (g_settings.items.empty()) {
-        ActionItem item;
-        item.name = L"Open in Terminal";
-        item.command = L"wt.exe";
-        item.parameters = L"-d \"%path%\"";
-        item.icon = L"";
-        g_settings.items.push_back(std::move(item));
-    }
+    // No fallback item if the list is empty: using the mod only to hide
+    // built-in buttons is a supported configuration.
 }
 
 BOOL Wh_ModInit() {
@@ -2871,30 +3181,50 @@ void Wh_ModUninit() {
 
     for (HWND hWnd : GetFileExplorerWnds()) {
         Wh_Log(L"Removing buttons for window %08X", (DWORD)(ULONG_PTR)hWnd);
-        RunFromWindowThread(
-            hWnd, [](PVOID) { RemoveButtonsForCurrentThread(); }, nullptr);
+        if (!RunFromWindowThread(
+                hWnd, [](PVOID) { RemoveButtonsForCurrentThread(); },
+                nullptr)) {
+            Wh_Log(L"Couldn't reach the thread of window %08X",
+                   (DWORD)(ULONG_PTR)hWnd);
+        }
+    }
+
+    // Anything left here belongs to a thread which couldn't be reached above.
+    // Its watchers and timers can only be released from that thread, so all
+    // that's left to do is to drop the records.
+    {
+        std::lock_guard<std::mutex> lock(g_managedElementsMutex);
+        if (!g_managedElements.empty()) {
+            Wh_Log(L"%zu elements couldn't be restored",
+                   g_managedElements.size());
+        }
+
+        g_managedElements.clear();
     }
 
     {
-        std::lock_guard<std::mutex> lock(g_watchesMutex);
-        g_watches.clear();
+        std::lock_guard<std::mutex> lock(g_hoverTimersMutex);
+        g_hoverTimers.clear();
     }
 
     {
-        std::lock_guard<std::mutex> lock(g_pendingRecomputeMutex);
-        g_pendingRecompute.clear();
+        std::lock_guard<std::mutex> lock(g_pendingUpdatesMutex);
+        g_pendingUpdates.clear();
     }
 
     {
-        std::lock_guard<std::mutex> lock(g_originalStateMutex);
-        g_originalVisibility.clear();
-        g_originalOverflow.clear();
-        g_originalMargin.clear();
-        g_originalMinWidth.clear();
+        std::lock_guard<std::mutex> lock(g_iconCacheMutex);
+        g_iconCache.clear();
     }
 
-    std::lock_guard<std::mutex> lock(g_entriesMutex);
-    g_entries.clear();
+    {
+        std::lock_guard<std::mutex> lock(g_entriesMutex);
+        g_entries.clear();
+    }
+
+    // Last, since the launch threads run our code: the DLL can't be unmapped
+    // while one of them is still working.
+    WaitForLaunchThreads();
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/explorer-command-bar.wh.cpp
+++ b/mods/explorer-command-bar.wh.cpp
@@ -2847,7 +2847,19 @@ void WINAPI CommandBarControl_Wave1_GotFocusHandler_Hook(void* pThis,
 
 std::atomic<bool> g_symbolsHooked;
 
-bool HookFileExplorerExtensionsSymbols(HMODULE module) {
+enum class SymbolHookResult {
+    Success,
+    // Symbol resolution itself failed, e.g. the PDB couldn't be downloaded.
+    // Transient, so trying again later can succeed.
+    ResolutionFailed,
+    // The symbols resolved, but this build has none of the functions the mod
+    // needs. Permanent for this Explorer, so it must not be retried: each
+    // HookSymbols call for a module invalidates its symbol cache and forces a
+    // re-resolution.
+    NoSymbolFound,
+};
+
+SymbolHookResult HookFileExplorerExtensionsSymbols(HMODULE module) {
     // All hooks are optional, since the set of functions differs between
     // Windows builds, but at least one of the discovery hooks must be found.
     WindhawkUtils::SYMBOL_HOOK fileExplorerExtensionsDllHooks[] = {
@@ -2901,17 +2913,17 @@ bool HookFileExplorerExtensionsSymbols(HMODULE module) {
     if (!HookSymbols(module, fileExplorerExtensionsDllHooks,
                      ARRAYSIZE(fileExplorerExtensionsDllHooks))) {
         Wh_Log(L"HookSymbols failed");
-        return false;
+        return SymbolHookResult::ResolutionFailed;
     }
 
     if (!CommandBarManager_CommandBar_Original &&
         !CommandBarControl_OnApplyTemplate_Original &&
         !CommandBarControl_Wave1_OnApplyTemplate_Original) {
         Wh_Log(L"No command bar symbol was found");
-        return false;
+        return SymbolHookResult::NoSymbolFound;
     }
 
-    return true;
+    return SymbolHookResult::Success;
 }
 
 HMODULE GetFileExplorerExtensionsModuleHandle() {
@@ -2935,11 +2947,21 @@ bool HookFileExplorerExtensionsIfLoaded(bool applyHooks) {
 
     Wh_Log(L"Hooking FileExplorerExtensions.dll");
 
-    if (!HookFileExplorerExtensionsSymbols(module)) {
-        // Let a later attempt (e.g. the next LoadLibraryExW) try again instead
-        // of leaving the mod permanently disabled for this process.
-        g_symbolsHooked = false;
-        return false;
+    switch (HookFileExplorerExtensionsSymbols(module)) {
+        case SymbolHookResult::Success:
+            break;
+
+        case SymbolHookResult::ResolutionFailed:
+            // Transient, so let a later attempt try again instead of leaving
+            // the mod disabled for this process.
+            g_symbolsHooked = false;
+            return false;
+
+        case SymbolHookResult::NoSymbolFound:
+            // Keep the flag set: this build doesn't have what the mod needs,
+            // and re-resolving the symbols on every module load would only
+            // make Explorer slow for the rest of the session.
+            return false;
     }
 
     if (applyHooks) {
@@ -2955,7 +2977,24 @@ HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR lpLibFileName,
                                    HANDLE hFile,
                                    DWORD dwFlags) {
     HMODULE module = LoadLibraryExW_Original(lpLibFileName, hFile, dwFlags);
-    if (module && !g_unloading) {
+    if (!module || g_unloading || !lpLibFileName) {
+        return module;
+    }
+
+    // Explorer loads modules constantly (shell extensions, thumbnail and
+    // preview handlers), and this runs inline on whatever thread did the load,
+    // so only look at the one module the mod cares about.
+    PCWSTR fileName = lpLibFileName;
+    for (PCWSTR p = lpLibFileName; *p; p++) {
+        if (*p == L'\\' || *p == L'/') {
+            fileName = p + 1;
+        }
+    }
+
+    // LoadLibraryEx appends the default extension itself, so the caller may
+    // have left it out.
+    if (_wcsicmp(fileName, L"FileExplorerExtensions.dll") == 0 ||
+        _wcsicmp(fileName, L"FileExplorerExtensions") == 0) {
         HookFileExplorerExtensionsIfLoaded(/*applyHooks=*/true);
     }
 

--- a/mods/explorer-command-bar.wh.cpp
+++ b/mods/explorer-command-bar.wh.cpp
@@ -2531,7 +2531,7 @@ std::atomic<bool> g_symbolsHooked;
 bool HookFileExplorerExtensionsSymbols(HMODULE module) {
     // All hooks are optional, since the set of functions differs between
     // Windows builds, but at least one of the discovery hooks must be found.
-    WindhawkUtils::SYMBOL_HOOK hooks[] = {
+    WindhawkUtils::SYMBOL_HOOK fileExplorerExtensionsDllHooks[] = {
         {
             {
                 LR"(public: void __cdecl winrt::FileExplorerExtensions::implementation::CommandBarManager::CommandBar(struct winrt::Microsoft::UI::Xaml::Controls::CommandBar const &))",
@@ -2579,7 +2579,8 @@ bool HookFileExplorerExtensionsSymbols(HMODULE module) {
         },
     };
 
-    if (!HookSymbols(module, hooks, ARRAYSIZE(hooks))) {
+    if (!HookSymbols(module, fileExplorerExtensionsDllHooks,
+                     ARRAYSIZE(fileExplorerExtensionsDllHooks))) {
         Wh_Log(L"HookSymbols failed");
         return false;
     }

--- a/mods/explorer-command-bar.wh.cpp
+++ b/mods/explorer-command-bar.wh.cpp
@@ -1,5 +1,5 @@
 // ==WindhawkMod==
-// @id              exporer-command-bar
+// @id              explorer-command-bar
 // @name            Explorer Command Bar
 // @description     Add your own buttons and dropdown menus to the Windows 11 File Explorer command bar, and hide the built-in ones
 // @version         1.0.0

--- a/mods/exporer-command-bar.wh.cpp
+++ b/mods/exporer-command-bar.wh.cpp
@@ -4,7 +4,7 @@
 // @description     Add your own buttons and dropdown menus to the Windows 11 File Explorer command bar, and hide the built-in ones
 // @version         1.0.0
 // @author          DanRotaru
-// @github          https://github.com/danrotaru
+// @github          https://github.com/DanRotaru
 // @homepage        https://dan13.me/
 // @include         explorer.exe
 // @architecture    x86-64

--- a/mods/exporer-command-bar.wh.cpp
+++ b/mods/exporer-command-bar.wh.cpp
@@ -1,0 +1,2900 @@
+// ==WindhawkMod==
+// @id              exporer-command-bar
+// @name            Explorer Command Bar
+// @description     Add your own buttons and dropdown menus to the Windows 11 File Explorer command bar, and hide the built-in ones
+// @version         1.0.0
+// @author          DanRotaru
+// @github          https://github.com/danrotaru
+// @homepage        https://dan13.me/
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -ladvapi32 -lgdi32 -lole32 -loleaut32 -lruntimeobject -lshell32
+// @license         MIT
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Explorer Command Bar
+
+Add your own buttons and dropdown menus to the **Windows 11 File Explorer
+command bar** (the toolbar with New / Sort / View), and hide the built-in
+buttons, separators and spacing you don't want.
+
+![Explorer Command Bar demo](https://cepret.md/img/placeholder.svg)
+
+Designed for Windows 11 24H2 / 25H2 with the WinAppSDK (WinUI 3) File
+Explorer.
+
+## Features
+
+- **Custom buttons** - add as many toolbar buttons as you like, each running a
+  command of your choice.
+- **Dropdown menus & submenus** - a button can open a menu, and menu entries
+  can themselves be submenus (three levels deep).
+- **Path & selection placeholders** - `%path%` (active tab folder) and `%sel%`
+  (selected file/folder) are substituted into the command parameters.
+- **Flexible icons** - a Segoe Fluent Icons glyph, an `.exe` / `.dll` / `.ico`
+  file, a Store-app icon (`shell:AppsFolder\…`), the command executable's own
+  icon, or no icon at all.
+- **Hide built-in elements** - individually hide New, Cut, Copy, Paste, Rename,
+  Share, Delete, Sort, View, the group separators, the "See more" (…) overflow
+  menu, the contextual commands (Set as background, Rotate left, Rotate right,
+  Extract all) and the Details pane toggle.
+- **Custom item spacing** - set the exact spacing between the command bar
+  buttons, in pixels.
+- **Open menus on hover** - optionally open dropdowns on hover, with a
+  configurable delay.
+- **Rock solid** - buttons are re-applied automatically across tab switches,
+  navigation, new tabs and new windows, and everything is cleanly restored when
+  the mod is disabled.
+
+## Screenshots
+
+Custom buttons on the command bar:
+
+![Buttons](https://cepret.md/img/placeholder.svg)
+
+Dropdown menu with submenus:
+
+![Dropdown menu](https://cepret.md/img/placeholder.svg)
+
+Hiding built-in buttons and separators:
+
+![Hide buttons](https://cepret.md/img/placeholder.svg)
+
+## Command parameters
+
+The following placeholders can be used in an item's parameters:
+
+* `%path%` - the folder path of the currently active tab.
+* `%sel%` - the full path of the selected file or folder in the active tab (the
+  first one, if several are selected).
+
+Wrap placeholders in quotes so paths with spaces work, e.g. `-d "%path%"`. If a
+used placeholder has no value (nothing selected, or a non-filesystem location
+like *This PC*), the command is launched without any parameters. Commands run
+with the active tab's folder as their working directory.
+
+## Icons
+
+The **Icon glyph or icon path** field accepts several forms:
+
+* **A glyph** - a hex code point of a
+  [Segoe Fluent Icons](https://learn.microsoft.com/en-us/windows/apps/design/iconography/segoe-fluent-icons-font)
+  glyph, e.g. `E756`.
+* **A file path** - an `.exe`, `.dll` or `.ico` file to take the icon from,
+  optionally with an icon index, e.g. `C:\Windows\System32\shell32.dll,3`.
+* **A Store app** - `shell:AppsFolder\<AppUserModelID>` to use a modern Store
+  app's icon (useful for apps whose `.exe` stub carries a legacy icon, such as
+  Notepad and Calculator).
+* **Empty** - the icon is extracted from the command's executable (app
+  execution aliases such as `wt.exe` are resolved to their real target).
+* **Hide icon** - enable the toggle to show no icon at all.
+
+## Default configuration
+
+Out of the box the mod adds:
+
+* **Open in Terminal** - `wt.exe -d "%path%"`
+* **Open in Notepad** - `notepad.exe "%sel%"`
+* **Additional** ▾ (dropdown)
+  * Open in VS Code - `code.exe "%path%"`
+  * Open Paint - `mspaint.exe`
+  * Open Calculator - `calc.exe`
+  * **Commands** ▸ - `vite`, `npm init`, `npm install`, `npm run dev`,
+    `npm run build`, `npm run start`
+  * **AI** ▸ - `Claude`, `Codex`
+
+All of the built-in buttons stay visible by default. Everything is configurable
+in the mod settings.
+
+## How it works
+
+The mod injects a XAML diagnostics provider into Explorer and watches the WinUI
+3 visual tree for the File Explorer command bar. When it appears, the configured
+buttons are inserted and the visibility / spacing settings are applied. The mod
+listens for the command bar being rebuilt so the buttons stay in place across
+navigation, new tabs and new windows, and it restores the original state of any
+element it touches when disabled.
+
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- items:
+  - - type: button
+      $name: Main Item Type
+      $options:
+      - button: Single button
+      - menu: Dropdown menu
+    - name: Open in Terminal
+      $name: Name
+      $description: Shown as the button tooltip.
+    - command: wt.exe
+      $name: Command
+      $description: >-
+        The executable to run. For dropdown menus it's only used as an icon
+        source.
+    - parameters: -d "%path%"
+      $name: Parameters
+      $description: >-
+        Command line parameters. %path% is replaced with the current folder
+        path, %sel% with the path of the selected file/folder. If a used
+        placeholder has no value (e.g. no selection, or a location like This
+        PC), the command is launched without parameters.
+    - iconGlyph: ""
+      $name: Icon glyph or icon path
+      $description: >-
+        Hex code point of a Segoe Fluent Icons glyph, e.g. E756
+        (CommandPrompt) or EC7A. The list of glyphs:
+        https://learn.microsoft.com/en-us/windows/apps/design/iconography/segoe-fluent-icons-font
+        Alternatively, a path to an .exe, .dll or
+        .ico file to use its icon, optionally with an icon index, e.g.
+        C:\Windows\System32\shell32.dll,3. Leave empty to use the icon of the
+        command's executable.
+    - hideIcon: false
+      $name: Hide icon
+      $description: Don't show an icon for this item.
+    - separatorAfter: false
+      $name: Vertical separator after
+      $description: Show a vertical separator line after this button.
+    - subItems:
+      - - type: button
+          $name: Menu Items Item Type
+          $options:
+          - button: Menu item
+          - menu: Submenu
+        - name: ""
+          $name: Name
+          $description: The menu item text.
+        - command: ""
+          $name: Command
+          $description: >-
+            The executable to run. For submenus it's only used as an icon
+            source.
+        - parameters: ""
+          $name: Parameters
+          $description: >-
+            Command line parameters. %path% is replaced with the current
+            folder path, %sel% with the path of the selected file/folder.
+        - iconGlyph: ""
+          $name: Icon glyph or icon path
+          $description: >-
+            Hex code point of a Segoe Fluent Icons glyph
+            (https://learn.microsoft.com/en-us/windows/apps/design/iconography/segoe-fluent-icons-font),
+            or a path to an .exe, .dll or .ico file, optionally with an icon
+            index. Leave empty to use the icon of the command's executable.
+        - hideIcon: false
+          $name: Hide icon
+          $description: Don't show an icon for this menu item.
+        - separatorAfter: false
+          $name: Separator after
+          $description: Show a separator line below this menu item.
+        - subItems:
+          - - name: ""
+              $name: Name
+              $description: The menu item text.
+            - command: ""
+              $name: Command
+            - parameters: ""
+              $name: Parameters
+              $description: >-
+                Command line parameters. %path% is replaced with the current
+                folder path, %sel% with the path of the selected file/folder.
+            - iconGlyph: ""
+              $name: Icon glyph or icon path
+              $description: >-
+                Hex code point of a Segoe Fluent Icons glyph
+                (https://learn.microsoft.com/en-us/windows/apps/design/iconography/segoe-fluent-icons-font),
+                or a path to an .exe, .dll or .ico file, optionally with an
+                icon index. Leave empty to use the icon of the command's
+                executable.
+            - hideIcon: false
+              $name: Hide icon
+              $description: Don't show an icon for this menu item.
+            - separatorAfter: false
+              $name: Separator after
+              $description: Show a separator line below this menu item.
+          $name: Submenu items
+          $description: The entries of the submenu, for the submenu type.
+      $name: Menu items
+      $description: The entries of the dropdown menu, for the dropdown type.
+  - - type: button
+    - name: Open in Notepad
+    - command: notepad.exe
+    - parameters: '"%sel%"'
+    - iconGlyph: 'shell:AppsFolder\Microsoft.WindowsNotepad_8wekyb3d8bbwe!App'
+    - separatorAfter: false
+  - - type: menu
+    - name: Additional
+    - command: ""
+    - parameters: ""
+    - iconGlyph: E81E
+    - separatorAfter: false
+    - subItems:
+      - - type: button
+        - name: Open in VS Code
+        - command: code.exe
+        - parameters: '"%path%"'
+        - iconGlyph: ""
+        - separatorAfter: false
+      - - type: button
+        - name: Open Paint
+        - command: mspaint.exe
+        - parameters: ""
+        - iconGlyph: ""
+        - separatorAfter: false
+      - - type: button
+        - name: Open Calculator
+        - command: calc.exe
+        - parameters: ""
+        - iconGlyph: 'shell:AppsFolder\Microsoft.WindowsCalculator_8wekyb3d8bbwe!App'
+        - separatorAfter: true
+      - - type: menu
+        - name: Commands
+        - command: ""
+        - parameters: ""
+        - iconGlyph: EC7A
+        - separatorAfter: false
+        - subItems:
+          - - name: vite
+            - command: cmd.exe
+            - parameters: /k vite
+            - iconGlyph: ""
+            - hideIcon: true
+            - separatorAfter: true
+          - - name: npm init
+            - command: cmd.exe
+            - parameters: /k npm init
+            - iconGlyph: ""
+            - hideIcon: true
+            - separatorAfter: false
+          - - name: npm install
+            - command: cmd.exe
+            - parameters: /k npm install
+            - iconGlyph: ""
+            - hideIcon: true
+            - separatorAfter: false
+          - - name: npm run dev
+            - command: cmd.exe
+            - parameters: /k npm run dev
+            - iconGlyph: ""
+            - hideIcon: true
+            - separatorAfter: false
+          - - name: npm run build
+            - command: cmd.exe
+            - parameters: /k npm run build
+            - iconGlyph: ""
+            - hideIcon: true
+            - separatorAfter: false
+          - - name: npm run start
+            - command: cmd.exe
+            - parameters: /k npm run start
+            - iconGlyph: ""
+            - hideIcon: true
+            - separatorAfter: false
+      - - type: menu
+        - name: AI
+        - command: ""
+        - parameters: ""
+        - iconGlyph: E794
+        - separatorAfter: false
+        - subItems:
+          - - name: Claude
+            - command: cmd.exe
+            - parameters: /k claude
+            - iconGlyph: ""
+            - hideIcon: true
+            - separatorAfter: false
+          - - name: Codex
+            - command: cmd.exe
+            - parameters: /k codex
+            - iconGlyph: ""
+            - hideIcon: true
+            - separatorAfter: false
+  $name: Toolbar items
+  $description: >-
+    Each toolbar item is either a single button or a dropdown menu. Use the
+    plus button to add another one.
+- hideDefaultButtons:
+  - new: false
+    $name: New
+  - separatorAfterNew: false
+    $name: Vertical separator after New
+  - cut: false
+    $name: Cut
+  - copy: false
+    $name: Copy
+  - paste: false
+    $name: Paste
+  - rename: false
+    $name: Rename
+  - share: false
+    $name: Share
+  - delete: false
+    $name: Delete
+  - separatorAfterDelete: false
+    $name: Vertical separator after Delete
+  - sort: false
+    $name: Sort
+  - view: false
+    $name: View
+  - separatorAfterView: false
+    $name: Vertical separator after View
+  - moreOptions: false
+    $name: See more (the three dots menu)
+  - setAsBackground: false
+    $name: Set as background
+    $description: Shown when an image file is selected.
+  - rotateLeft: false
+    $name: Rotate left
+    $description: Shown when an image file is selected.
+  - rotateRight: false
+    $name: Rotate right
+    $description: Shown when an image file is selected.
+  - extractAll: false
+    $name: Extract all
+    $description: Shown when a zip or other archive file is selected.
+  - details: false
+    $name: Details pane toggle
+  $name: Hide default toolbar buttons
+  $description: >-
+    Hide the built-in buttons of the File Explorer command bar. The vertical
+    separator of the contextual commands (Set as background, Rotate left,
+    Rotate right, Extract all) is hidden along with them, once none of them is
+    left to show.
+- openMenuOnHover: false
+  $name: Open menus on hover
+  $description: >-
+    Open dropdown menus by hovering over the button instead of clicking it.
+- menuHoverDelay: 400
+  $name: Hover delay (milliseconds)
+  $description: >-
+    How long the cursor has to stay over the button before the menu opens.
+    Only used when "Open menus on hover" is enabled.
+- itemSpacing: -1
+  $name: Item spacing (pixels)
+  $description: >-
+    Horizontal spacing between the command bar buttons, in pixels. -1 leaves
+    the default spacing unchanged; 0 places the buttons right next to each
+    other; 5 means 5 pixels between buttons, and so on.
+*/
+// ==/WindhawkModSettings==
+
+#include <initguid.h>
+
+#include <windows.h>
+
+#include <exdisp.h>
+#include <servprov.h>
+#include <shellapi.h>
+#include <shlobj.h>
+#include <shobjidl.h>
+#include <xamlom.h>
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+std::atomic<bool> g_initialized;
+std::atomic<bool> g_unloading;
+
+// {7B0A0F2C-3D1E-4C8B-9A65-2E8F41D0B7A3}
+static constexpr CLSID CLSID_WindhawkTAP = {
+    0x7b0a0f2c,
+    0x3d1e,
+    0x4c8b,
+    {0x9a, 0x65, 0x2e, 0x8f, 0x41, 0xd0, 0xb7, 0xa3}};
+
+static constexpr CLSID kCLSID_ShellWindows = {
+    0x9ba05972,
+    0xf6a8,
+    0x11cf,
+    {0xa4, 0x42, 0x00, 0xa0, 0xc9, 0x0a, 0x8f, 0x39}};
+
+static constexpr GUID kSID_STopLevelBrowser = {
+    0x4c96be40,
+    0x915c,
+    0x11cf,
+    {0x99, 0xd3, 0x00, 0xaa, 0x00, 0x4a, 0xe8, 0x37}};
+
+struct ActionItem {
+    std::wstring name;
+    std::wstring command;
+    std::wstring parameters;
+    std::wstring icon;  // Raw icon setting: a glyph code point, a path to an
+                        // icon file, or empty to use the command's
+                        // executable icon.
+    bool hideIcon = false;
+    bool isMenu = false;
+    bool separatorAfter = false;
+    std::vector<ActionItem> subItems;
+};
+
+// The built-in command bar buttons. They're identified at runtime by the SVG
+// file name of their icon, which is stable across languages.
+struct DefaultButtonDef {
+    PCWSTR settingKey;
+    PCWSTR svgFileName;
+};
+
+constexpr DefaultButtonDef kDefaultButtons[] = {
+    {L"new", L"windows.newitem.svg"},
+    {L"cut", L"windows.cut.svg"},
+    {L"copy", L"windows.copy.svg"},
+    {L"paste", L"windows.paste.svg"},
+    {L"rename", L"windows.rename.svg"},
+    {L"share", L"windows.modernshare.svg"},
+    {L"delete", L"windows.ribbondelete.svg"},
+    {L"sort", L"sortby.svg"},
+    {L"view", L"view.svg"},
+    // Contextual buttons, shown only for the matching selection: an image
+    // file for the first three, an archive for Extract all.
+    {L"setAsBackground", L"windows.setdesktopwallpaper.svg"},
+    {L"rotateLeft", L"windows.rotate270.svg"},
+    {L"rotateRight", L"windows.rotate90.svg"},
+    {L"extractAll", L"windows.compressedfile.extract.svg"},
+};
+
+constexpr int kDefaultButtonCount = ARRAYSIZE(kDefaultButtons);
+constexpr int kNewButtonIndex = 0;
+constexpr int kDeleteButtonIndex = 6;
+constexpr int kSortButtonIndex = 7;
+constexpr int kViewButtonIndex = 8;
+
+struct {
+    std::mutex mutex;
+    bool openMenuOnHover = false;
+    int menuHoverDelay = 400;
+    bool hideDefaultButtons[kDefaultButtonCount] = {};
+    bool hideSeparatorAfterButton[kDefaultButtonCount] = {};
+    bool hideMoreButton = false;
+    bool hideDetailsButton = false;
+    int itemSpacing = -1;
+    std::vector<ActionItem> items;
+} g_settings;
+
+HMODULE GetCurrentModuleHandle() {
+    HMODULE module;
+    if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           L"", &module)) {
+        return nullptr;
+    }
+
+    return module;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// clang-format off
+
+#pragma region winrt_hpp
+
+#include <Unknwn.h>
+
+// Conflicts with a winrt method of the same name.
+#undef GetCurrentTime
+
+#include <winrt/base.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Microsoft.UI.h>
+#include <winrt/Microsoft.UI.Content.h>
+#include <winrt/Microsoft.UI.Dispatching.h>
+#include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Microsoft.UI.Xaml.Automation.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Microsoft.UI.Xaml.Input.h>
+#include <winrt/Microsoft.UI.Xaml.Media.h>
+#include <winrt/Microsoft.UI.Xaml.Media.Imaging.h>
+
+namespace wf = winrt::Windows::Foundation;
+namespace wfc = winrt::Windows::Foundation::Collections;
+namespace mux = winrt::Microsoft::UI::Xaml;
+namespace muxc = winrt::Microsoft::UI::Xaml::Controls;
+namespace muxm = winrt::Microsoft::UI::Xaml::Media;
+
+#pragma endregion  // winrt_hpp
+
+void OnCommandBarAdded(muxc::CommandBar const& commandBar);
+
+#pragma region visualtreewatcher_hpp
+
+class VisualTreeWatcher : public winrt::implements<VisualTreeWatcher, IVisualTreeServiceCallback2, winrt::non_agile>
+{
+public:
+    VisualTreeWatcher(winrt::com_ptr<IUnknown> site);
+
+    VisualTreeWatcher(const VisualTreeWatcher&) = delete;
+    VisualTreeWatcher& operator=(const VisualTreeWatcher&) = delete;
+
+    VisualTreeWatcher(VisualTreeWatcher&&) = delete;
+    VisualTreeWatcher& operator=(VisualTreeWatcher&&) = delete;
+
+    ~VisualTreeWatcher();
+
+    void UnadviseVisualTreeChange();
+
+private:
+    HRESULT STDMETHODCALLTYPE OnVisualTreeChange(ParentChildRelation relation, VisualElement element, VisualMutationType mutationType) override;
+    HRESULT STDMETHODCALLTYPE OnElementStateChanged(InstanceHandle element, VisualElementState elementState, LPCWSTR context) noexcept override;
+
+    wf::IInspectable FromHandle(InstanceHandle handle)
+    {
+        wf::IInspectable obj;
+        winrt::check_hresult(m_XamlDiagnostics->GetIInspectableFromHandle(handle, reinterpret_cast<::IInspectable**>(winrt::put_abi(obj))));
+        return obj;
+    }
+
+    winrt::com_ptr<IXamlDiagnostics> m_XamlDiagnostics = nullptr;
+};
+
+#pragma endregion  // visualtreewatcher_hpp
+
+#pragma region visualtreewatcher_cpp
+
+VisualTreeWatcher::VisualTreeWatcher(winrt::com_ptr<IUnknown> site) :
+    m_XamlDiagnostics(site.as<IXamlDiagnostics>())
+{
+    Wh_Log(L"Constructing VisualTreeWatcher");
+
+    // Calling AdviseVisualTreeChange from the current thread causes the app to
+    // hang sometimes. Creating a new thread and calling it from there fixes
+    // it.
+    HANDLE thread = CreateThread(
+        nullptr, 0,
+        [](LPVOID lpParam) -> DWORD {
+            auto watcher = reinterpret_cast<VisualTreeWatcher*>(lpParam);
+            HRESULT hr = watcher->m_XamlDiagnostics.as<IVisualTreeService3>()->AdviseVisualTreeChange(watcher);
+            watcher->Release();
+            if (FAILED(hr)) {
+                Wh_Log(L"Error %08X", hr);
+            }
+            return 0;
+        },
+        this, 0, nullptr);
+    if (thread) {
+        AddRef();
+        CloseHandle(thread);
+    }
+}
+
+VisualTreeWatcher::~VisualTreeWatcher()
+{
+    Wh_Log(L"Destructing VisualTreeWatcher");
+}
+
+void VisualTreeWatcher::UnadviseVisualTreeChange()
+{
+    Wh_Log(L"UnadviseVisualTreeChange VisualTreeWatcher");
+    HRESULT hr = m_XamlDiagnostics.as<IVisualTreeService3>()->UnadviseVisualTreeChange(this);
+    if (FAILED(hr)) {
+        Wh_Log(L"UnadviseVisualTreeChange failed with error %08X", hr);
+    }
+}
+
+HRESULT VisualTreeWatcher::OnVisualTreeChange(ParentChildRelation, VisualElement element, VisualMutationType mutationType) try
+{
+    if (g_unloading)
+    {
+        return S_OK;
+    }
+
+    if (mutationType == Add)
+    {
+        const auto inspectable = FromHandle(element.Handle);
+        if (auto commandBar = inspectable.try_as<muxc::CommandBar>())
+        {
+            auto name = commandBar.Name();
+            if (name == L"FileExplorerCommandBar" ||
+                name == L"FileExplorerSecondaryCommandBar")
+            {
+                Wh_Log(L"%s added, thread %u", name.c_str(), GetCurrentThreadId());
+                OnCommandBarAdded(commandBar);
+            }
+        }
+    }
+
+    return S_OK;
+}
+catch (...)
+{
+    HRESULT hr = winrt::to_hresult();
+    Wh_Log(L"Error %08X", hr);
+
+    // Returning an error prevents (some?) further messages, always return
+    // success.
+    return S_OK;
+}
+
+HRESULT VisualTreeWatcher::OnElementStateChanged(InstanceHandle, VisualElementState, LPCWSTR) noexcept
+{
+    return S_OK;
+}
+
+#pragma endregion  // visualtreewatcher_cpp
+
+#pragma region tap_hpp
+
+#include <ocidl.h>
+
+winrt::com_ptr<VisualTreeWatcher> g_visualTreeWatcher;
+
+class WindhawkTAP : public winrt::implements<WindhawkTAP, IObjectWithSite, winrt::non_agile>
+{
+public:
+    HRESULT STDMETHODCALLTYPE SetSite(IUnknown *pUnkSite) override;
+    HRESULT STDMETHODCALLTYPE GetSite(REFIID riid, void **ppvSite) noexcept override;
+
+private:
+    winrt::com_ptr<IUnknown> site;
+};
+
+#pragma endregion  // tap_hpp
+
+#pragma region tap_cpp
+
+HRESULT WindhawkTAP::SetSite(IUnknown *pUnkSite) try
+{
+    // Only ever 1 VTW at once.
+    if (g_visualTreeWatcher)
+    {
+        g_visualTreeWatcher->UnadviseVisualTreeChange();
+        g_visualTreeWatcher = nullptr;
+    }
+
+    site.copy_from(pUnkSite);
+
+    if (site)
+    {
+        // Decrease refcount increased by InitializeXamlDiagnosticsEx.
+        FreeLibrary(GetCurrentModuleHandle());
+
+        g_visualTreeWatcher = winrt::make_self<VisualTreeWatcher>(site);
+    }
+
+    return S_OK;
+}
+catch (...)
+{
+    HRESULT hr = winrt::to_hresult();
+    Wh_Log(L"Error %08X", hr);
+    return hr;
+}
+
+HRESULT WindhawkTAP::GetSite(REFIID riid, void **ppvSite) noexcept
+{
+    return site.as(riid, ppvSite);
+}
+
+#pragma endregion  // tap_cpp
+
+#pragma region simplefactory_hpp
+
+template<class T>
+struct SimpleFactory : winrt::implements<SimpleFactory<T>, IClassFactory, winrt::non_agile>
+{
+    HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown* pUnkOuter, REFIID riid, void** ppvObject) override try
+    {
+        if (!pUnkOuter)
+        {
+            *ppvObject = nullptr;
+            return winrt::make<T>().as(riid, ppvObject);
+        }
+        else
+        {
+            return CLASS_E_NOAGGREGATION;
+        }
+    }
+    catch (...)
+    {
+        HRESULT hr = winrt::to_hresult();
+        Wh_Log(L"Error %08X", hr);
+        return hr;
+    }
+
+    HRESULT STDMETHODCALLTYPE LockServer(BOOL) noexcept override
+    {
+        return S_OK;
+    }
+};
+
+#pragma endregion  // simplefactory_hpp
+
+#pragma region module_cpp
+
+#include <combaseapi.h>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdll-attribute-on-redeclaration"
+
+__declspec(dllexport)
+_Use_decl_annotations_ STDAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv) try
+{
+    if (rclsid == CLSID_WindhawkTAP)
+    {
+        *ppv = nullptr;
+        return winrt::make<SimpleFactory<WindhawkTAP>>().as(riid, ppv);
+    }
+    else
+    {
+        return CLASS_E_CLASSNOTAVAILABLE;
+    }
+}
+catch (...)
+{
+    HRESULT hr = winrt::to_hresult();
+    Wh_Log(L"Error %08X", hr);
+    return hr;
+}
+
+__declspec(dllexport)
+_Use_decl_annotations_ STDAPI DllCanUnloadNow()
+{
+    if (winrt::get_module_lock())
+    {
+        return S_FALSE;
+    }
+    else
+    {
+        return S_OK;
+    }
+}
+
+#pragma clang diagnostic pop
+
+#pragma endregion  // module_cpp
+
+#pragma region api_cpp
+
+using PFN_INITIALIZE_XAML_DIAGNOSTICS_EX = decltype(&InitializeXamlDiagnosticsEx);
+
+HRESULT InjectWindhawkTAP() noexcept
+{
+    HMODULE module = GetCurrentModuleHandle();
+    if (!module)
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    WCHAR location[MAX_PATH];
+    switch (GetModuleFileName(module, location, ARRAYSIZE(location)))
+    {
+    case 0:
+    case ARRAYSIZE(location):
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    const HMODULE wux(GetModuleHandle(L"Microsoft.Internal.FrameworkUdk.dll"));
+    if (!wux) [[unlikely]]
+    {
+        return HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND);
+    }
+
+    const auto ixde = reinterpret_cast<PFN_INITIALIZE_XAML_DIAGNOSTICS_EX>(GetProcAddress(wux, "InitializeXamlDiagnosticsEx"));
+    if (!ixde) [[unlikely]]
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    // I didn't find a better way than trying many connections until one works.
+    // Reference:
+    // https://github.com/microsoft/microsoft-ui-xaml/blob/d74a0332cf0d5e58f12eddce1070fa7a79b4c2db/src/dxaml/xcp/dxaml/lib/DXamlCore.cpp#L2782
+    HRESULT hr = E_FAIL;
+    for (int i = 0; i < 10000; i++)
+    {
+        WCHAR connectionName[256];
+        wsprintf(connectionName, L"WinUIVisualDiagConnection%d", i + 1);
+
+        hr = ixde(connectionName, GetCurrentProcessId(), L"", location, CLSID_WindhawkTAP, nullptr);
+        if (hr != HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
+        {
+            break;
+        }
+    }
+
+    return hr;
+}
+
+#pragma endregion  // api_cpp
+
+// clang-format on
+////////////////////////////////////////////////////////////////////////////////
+
+constexpr PCWSTR kButtonNamePrefix = L"WindhawkActionButton";
+
+struct CommandBarEntry {
+    DWORD threadId;
+    winrt::weak_ref<muxc::CommandBar> commandBar;
+    winrt::event_token loadedToken{};
+    winrt::event_token vectorChangedToken{};
+};
+
+std::mutex g_entriesMutex;
+std::vector<CommandBarEntry> g_entries;
+
+// Original visibility state of Explorer's own elements, captured the first
+// time we touch each one, so we can restore it exactly instead of forcing a
+// guessed default (which would reveal elements Explorer keeps collapsed).
+std::mutex g_originalStateMutex;
+std::unordered_map<void*, mux::Visibility> g_originalVisibility;
+std::unordered_map<void*, muxc::CommandBarOverflowButtonVisibility>
+    g_originalOverflow;
+std::unordered_map<void*, mux::Thickness> g_originalMargin;
+std::unordered_map<void*, double> g_originalMinWidth;
+
+////////////////////////////////////////////////////////////////////////////////
+// Getting the current folder path and launching commands.
+
+struct ExplorerContext {
+    std::wstring folderPath;
+    std::wstring selectedPath;
+};
+
+ExplorerContext GetExplorerContext(HWND hExplorerWnd) {
+    ExplorerContext result;
+
+    winrt::com_ptr<IShellWindows> shellWindows;
+    HRESULT hr = CoCreateInstance(kCLSID_ShellWindows, nullptr, CLSCTX_ALL,
+                                  IID_PPV_ARGS(shellWindows.put()));
+    if (FAILED(hr) || !shellWindows) {
+        Wh_Log(L"CoCreateInstance(ShellWindows) failed: %08X", hr);
+        return result;
+    }
+
+    long count = 0;
+    shellWindows->get_Count(&count);
+
+    // The active tab's ShellTabWindowClass window is the first one in the
+    // Z-order of the CabinetWClass window's children.
+    HWND hActiveTabWnd =
+        hExplorerWnd ? FindWindowExW(hExplorerWnd, nullptr,
+                                     L"ShellTabWindowClass", nullptr)
+                     : nullptr;
+
+    for (long i = 0; i < count && result.folderPath.empty(); i++) {
+        VARIANT index;
+        VariantInit(&index);
+        index.vt = VT_I4;
+        index.lVal = i;
+
+        winrt::com_ptr<IDispatch> dispatch;
+        if (FAILED(shellWindows->Item(index, dispatch.put())) || !dispatch) {
+            continue;
+        }
+
+        auto webBrowser = dispatch.try_as<IWebBrowser2>();
+        if (!webBrowser) {
+            continue;
+        }
+
+        SHANDLE_PTR hWndRaw = 0;
+        if (FAILED(webBrowser->get_HWND(&hWndRaw))) {
+            continue;
+        }
+
+        if (hExplorerWnd && (HWND)hWndRaw != hExplorerWnd) {
+            continue;
+        }
+
+        auto serviceProvider = dispatch.try_as<IServiceProvider>();
+        if (!serviceProvider) {
+            continue;
+        }
+
+        winrt::com_ptr<IShellBrowser> shellBrowser;
+        if (FAILED(serviceProvider->QueryService(
+                kSID_STopLevelBrowser, IID_PPV_ARGS(shellBrowser.put()))) ||
+            !shellBrowser) {
+            continue;
+        }
+
+        // With tabs, every tab is a separate ShellWindows entry with the same
+        // top-level window. Skip the entries of inactive tabs.
+        HWND hTabWnd = nullptr;
+        if (SUCCEEDED(shellBrowser->GetWindow(&hTabWnd)) && hTabWnd) {
+            if (hActiveTabWnd) {
+                if (hTabWnd != hActiveTabWnd) {
+                    continue;
+                }
+            } else if (!IsWindowVisible(hTabWnd)) {
+                continue;
+            }
+        }
+
+        winrt::com_ptr<IShellView> shellView;
+        if (FAILED(shellBrowser->QueryActiveShellView(shellView.put())) ||
+            !shellView) {
+            continue;
+        }
+
+        auto folderView = shellView.try_as<IFolderView>();
+        if (!folderView) {
+            continue;
+        }
+
+        winrt::com_ptr<IPersistFolder2> persistFolder;
+        if (FAILED(folderView->GetFolder(IID_PPV_ARGS(persistFolder.put()))) ||
+            !persistFolder) {
+            continue;
+        }
+
+        LPITEMIDLIST pidl = nullptr;
+        if (FAILED(persistFolder->GetCurFolder(&pidl)) || !pidl) {
+            continue;
+        }
+
+        WCHAR path[MAX_PATH];
+        if (SHGetPathFromIDListEx(pidl, path, ARRAYSIZE(path),
+                                  GPFIDL_DEFAULT)) {
+            result.folderPath = path;
+        }
+
+        CoTaskMemFree(pidl);
+
+        // The first selected file or folder, if any.
+        winrt::com_ptr<IShellItemArray> selection;
+        if (SUCCEEDED(shellView->GetItemObject(
+                SVGIO_SELECTION, IID_PPV_ARGS(selection.put()))) &&
+            selection) {
+            winrt::com_ptr<IShellItem> shellItem;
+            if (SUCCEEDED(selection->GetItemAt(0, shellItem.put())) &&
+                shellItem) {
+                PWSTR selectedPath = nullptr;
+                if (SUCCEEDED(shellItem->GetDisplayName(
+                        SIGDN_FILESYSPATH, &selectedPath)) &&
+                    selectedPath) {
+                    result.selectedPath = selectedPath;
+                    CoTaskMemFree(selectedPath);
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+// Replaces all occurrences of the placeholder. Returns false if the
+// placeholder is used but has no value.
+bool ReplacePlaceholder(std::wstring& parameters,
+                        std::wstring_view placeholder,
+                        std::wstring const& value) {
+    size_t pos = parameters.find(placeholder);
+    if (pos == std::wstring::npos) {
+        return true;
+    }
+
+    if (value.empty()) {
+        return false;
+    }
+
+    while (pos != std::wstring::npos) {
+        std::wstring replacement = value;
+        // A trailing backslash would escape a closing quote right after the
+        // placeholder (e.g. for C:\).
+        if (replacement.back() == L'\\' &&
+            pos + placeholder.size() < parameters.size() &&
+            parameters[pos + placeholder.size()] == L'"') {
+            replacement += L'\\';
+        }
+
+        parameters.replace(pos, placeholder.size(), replacement);
+        pos = parameters.find(placeholder, pos + replacement.size());
+    }
+
+    return true;
+}
+
+std::wstring BuildParameters(std::wstring parameters,
+                             ExplorerContext const& context) {
+    // If a used placeholder has no value (no filesystem path, no selection),
+    // launch without parameters.
+    if (!ReplacePlaceholder(parameters, L"%path%", context.folderPath) ||
+        !ReplacePlaceholder(parameters, L"%sel%", context.selectedPath)) {
+        return std::wstring();
+    }
+
+    return parameters;
+}
+
+void LaunchItemForWindow(HWND hExplorerWnd, ActionItem const& item) {
+    ExplorerContext context = GetExplorerContext(hExplorerWnd);
+    Wh_Log(L"Launching %s for window %08X, path: %s, selection: %s",
+           item.command.c_str(), (DWORD)(ULONG_PTR)hExplorerWnd,
+           context.folderPath.c_str(), context.selectedPath.c_str());
+
+    std::wstring parameters = BuildParameters(item.parameters, context);
+
+    HINSTANCE hInst = ShellExecuteW(
+        nullptr, nullptr, item.command.c_str(),
+        parameters.empty() ? nullptr : parameters.c_str(),
+        context.folderPath.empty() ? nullptr : context.folderPath.c_str(),
+        SW_SHOWNORMAL);
+    if ((INT_PTR)hInst <= 32) {
+        Wh_Log(L"ShellExecuteW failed: %d", (int)(INT_PTR)hInst);
+    }
+}
+
+void OnActionInvoked(mux::FrameworkElement const& elementForWindow,
+                     ActionItem const& item) {
+    if (item.command.empty()) {
+        return;
+    }
+
+    HWND hWnd = nullptr;
+
+    try {
+        if (auto xamlRoot = elementForWindow.XamlRoot()) {
+            if (auto environment = xamlRoot.ContentIslandEnvironment()) {
+                hWnd = (HWND)(uintptr_t)environment.AppWindowId().Value;
+            }
+        }
+    } catch (...) {
+        Wh_Log(L"Failed to get window from XamlRoot: %08X",
+               winrt::to_hresult().value);
+    }
+
+    if (!hWnd) {
+        hWnd = GetActiveWindow();
+    }
+
+    if (!hWnd) {
+        hWnd = GetForegroundWindow();
+    }
+
+    if (hWnd) {
+        hWnd = GetAncestor(hWnd, GA_ROOT);
+    }
+
+    struct LaunchParams {
+        HWND hExplorerWnd;
+        ActionItem item;
+    };
+
+    auto launchParams = std::make_unique<LaunchParams>(hWnd, item);
+
+    // Do the shell COM work off the UI thread to avoid blocking or
+    // deadlocking it.
+    HANDLE thread = CreateThread(
+        nullptr, 0,
+        [](LPVOID lpParam) -> DWORD {
+            std::unique_ptr<LaunchParams> launchParams(
+                reinterpret_cast<LaunchParams*>(lpParam));
+
+            HRESULT hrInit = CoInitializeEx(
+                nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+            LaunchItemForWindow(launchParams->hExplorerWnd,
+                                launchParams->item);
+            if (SUCCEEDED(hrInit)) {
+                CoUninitialize();
+            }
+            return 0;
+        },
+        launchParams.get(), 0, nullptr);
+    if (thread) {
+        launchParams.release();  // Owned by the thread now.
+        CloseHandle(thread);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Icons.
+
+std::wstring ExpandEnvVars(std::wstring const& str) {
+    WCHAR buffer[MAX_PATH];
+    DWORD length =
+        ExpandEnvironmentStringsW(str.c_str(), buffer, ARRAYSIZE(buffer));
+    if (length == 0 || length > ARRAYSIZE(buffer)) {
+        return str;
+    }
+
+    return buffer;
+}
+
+// Resolves a bare executable name to a full path the way ShellExecute does:
+// through the search path, then through the App Paths registry keys.
+std::wstring ResolveCommandPath(std::wstring const& command) {
+    std::wstring expanded = ExpandEnvVars(command);
+
+    if (expanded.find(L'\\') != std::wstring::npos) {
+        return expanded;
+    }
+
+    WCHAR resolved[MAX_PATH];
+    if (SearchPathW(nullptr, expanded.c_str(), L".exe", ARRAYSIZE(resolved),
+                    resolved, nullptr)) {
+        return resolved;
+    }
+
+    std::wstring keyPath =
+        L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\" +
+        expanded;
+    std::wstring lower = expanded;
+    for (auto& c : lower) {
+        c = towlower(c);
+    }
+    if (!lower.ends_with(L".exe")) {
+        keyPath += L".exe";
+    }
+
+    for (HKEY rootKey : {HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE}) {
+        WCHAR buffer[MAX_PATH];
+        DWORD size = sizeof(buffer);
+        if (RegGetValueW(rootKey, keyPath.c_str(), nullptr, RRF_RT_REG_SZ,
+                         nullptr, buffer, &size) == ERROR_SUCCESS &&
+            buffer[0]) {
+            std::wstring appPath = ExpandEnvVars(buffer);
+
+            // The value is sometimes quoted.
+            if (appPath.size() >= 2 && appPath.front() == L'"' &&
+                appPath.back() == L'"') {
+                appPath = appPath.substr(1, appPath.size() - 2);
+            }
+
+            return appPath;
+        }
+    }
+
+    return expanded;
+}
+
+#ifndef IO_REPARSE_TAG_APPEXECLINK
+#define IO_REPARSE_TAG_APPEXECLINK (0x8000001BL)
+#endif
+
+// App execution aliases (e.g. wt.exe) are zero-byte reparse points without
+// icons. Resolve them to the target executable.
+std::wstring ResolveAppExecutionAlias(std::wstring const& path) {
+    DWORD attributes = GetFileAttributesW(path.c_str());
+    if (attributes == INVALID_FILE_ATTRIBUTES ||
+        !(attributes & FILE_ATTRIBUTE_REPARSE_POINT)) {
+        return path;
+    }
+
+    HANDLE hFile = CreateFileW(
+        path.c_str(), FILE_READ_ATTRIBUTES,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+        OPEN_EXISTING,
+        FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+    if (hFile == INVALID_HANDLE_VALUE) {
+        return path;
+    }
+
+    struct AppExecLinkReparseBuffer {
+        ULONG reparseTag;
+        USHORT reparseDataLength;
+        USHORT reserved;
+        ULONG version;
+        // Four NUL-separated strings follow: package id, entry point,
+        // executable path, application type.
+        WCHAR stringList[1];
+    };
+
+    alignas(8) BYTE buffer[16 * 1024];
+    DWORD bytesReturned = 0;
+    BOOL succeeded =
+        DeviceIoControl(hFile, FSCTL_GET_REPARSE_POINT, nullptr, 0, buffer,
+                        sizeof(buffer), &bytesReturned, nullptr);
+    CloseHandle(hFile);
+
+    auto* reparse = reinterpret_cast<AppExecLinkReparseBuffer*>(buffer);
+    if (!succeeded || bytesReturned < sizeof(AppExecLinkReparseBuffer) ||
+        reparse->reparseTag != IO_REPARSE_TAG_APPEXECLINK) {
+        return path;
+    }
+
+    const WCHAR* p = reparse->stringList;
+    const WCHAR* end =
+        reinterpret_cast<const WCHAR*>(buffer + bytesReturned);
+    for (int i = 0; i < 3 && p < end; i++) {
+        size_t length = wcsnlen(p, end - p);
+        if (p + length >= end) {
+            break;
+        }
+
+        if (i == 2) {
+            // The executable path.
+            return std::wstring(p, length);
+        }
+
+        p += length + 1;
+    }
+
+    return path;
+}
+
+HICON ExtractCommandIcon(std::wstring const& command) {
+    std::wstring path = ResolveAppExecutionAlias(ResolveCommandPath(command));
+
+    HICON hIcon = nullptr;
+    if (ExtractIconExW(path.c_str(), 0, &hIcon, nullptr, 1) && hIcon) {
+        return hIcon;
+    }
+
+    SHFILEINFOW fileInfo{};
+    if (SHGetFileInfoW(path.c_str(), 0, &fileInfo, sizeof(fileInfo),
+                       SHGFI_ICON | SHGFI_LARGEICON)) {
+        return fileInfo.hIcon;
+    }
+
+    Wh_Log(L"Couldn't get an icon for %s (%s)", command.c_str(),
+           path.c_str());
+    return nullptr;
+}
+
+muxm::ImageSource CreateImageSourceFromIcon(HICON hIcon) {
+    muxm::ImageSource result = nullptr;
+
+    ICONINFO iconInfo{};
+    if (!GetIconInfo(hIcon, &iconInfo)) {
+        return result;
+    }
+
+    if (iconInfo.hbmColor) {
+        BITMAP bm{};
+        if (GetObject(iconInfo.hbmColor, sizeof(bm), &bm) && bm.bmWidth > 0 &&
+            bm.bmHeight > 0) {
+            int width = bm.bmWidth;
+            int height = bm.bmHeight;
+
+            BITMAPINFO bmi{};
+            bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
+            bmi.bmiHeader.biWidth = width;
+            bmi.bmiHeader.biHeight = -height;  // Top-down.
+            bmi.bmiHeader.biPlanes = 1;
+            bmi.bmiHeader.biBitCount = 32;
+            bmi.bmiHeader.biCompression = BI_RGB;
+
+            std::vector<uint8_t> pixels((size_t)width * height * 4);
+
+            HDC hdc = CreateCompatibleDC(nullptr);
+            if (hdc) {
+                if (GetDIBits(hdc, iconInfo.hbmColor, 0, height, pixels.data(),
+                              &bmi, DIB_RGB_COLORS)) {
+                    // Icons without an alpha channel come back fully
+                    // transparent, make them opaque.
+                    bool hasAlpha = false;
+                    for (size_t p = 3; p < pixels.size(); p += 4) {
+                        if (pixels[p]) {
+                            hasAlpha = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasAlpha) {
+                        for (size_t p = 3; p < pixels.size(); p += 4) {
+                            pixels[p] = 255;
+                        }
+                    }
+
+                    // The XAML bitmap expects premultiplied alpha.
+                    for (size_t p = 0; p < pixels.size(); p += 4) {
+                        uint8_t alpha = pixels[p + 3];
+                        if (alpha != 255) {
+                            pixels[p] = pixels[p] * alpha / 255;
+                            pixels[p + 1] = pixels[p + 1] * alpha / 255;
+                            pixels[p + 2] = pixels[p + 2] * alpha / 255;
+                        }
+                    }
+
+                    try {
+                        muxm::Imaging::WriteableBitmap bitmap(width, height);
+                        memcpy(bitmap.PixelBuffer().data(), pixels.data(),
+                               pixels.size());
+                        bitmap.Invalidate();
+                        result = bitmap;
+                    } catch (...) {
+                        Wh_Log(L"Error %08X", winrt::to_hresult().value);
+                    }
+                }
+
+                DeleteDC(hdc);
+            }
+        }
+    }
+
+    if (iconInfo.hbmColor) {
+        DeleteObject(iconInfo.hbmColor);
+    }
+    if (iconInfo.hbmMask) {
+        DeleteObject(iconInfo.hbmMask);
+    }
+
+    return result;
+}
+
+std::wstring ParseGlyphSetting(PCWSTR glyphSetting) {
+    if (!glyphSetting[0]) {
+        return std::wstring();
+    }
+
+    if (!glyphSetting[1]) {
+        // A literal glyph character.
+        return std::wstring(1, glyphSetting[0]);
+    }
+
+    unsigned long parsed = wcstoul(glyphSetting, nullptr, 16);
+    if (parsed > 0 && parsed <= 0xFFFF) {
+        return std::wstring(1, (WCHAR)parsed);
+    }
+
+    return std::wstring();
+}
+
+bool LooksLikeIconPath(std::wstring const& iconSetting) {
+    if (iconSetting.find(L'\\') != std::wstring::npos ||
+        iconSetting.find(L'/') != std::wstring::npos ||
+        iconSetting.find(L':') != std::wstring::npos) {
+        return true;
+    }
+
+    std::wstring lower = iconSetting;
+    for (auto& c : lower) {
+        c = towlower(c);
+    }
+
+    // Also allow a bare file name, possibly with an icon index.
+    size_t comma = lower.rfind(L',');
+    if (comma != std::wstring::npos) {
+        lower.resize(comma);
+    }
+
+    return lower.ends_with(L".exe") || lower.ends_with(L".dll") ||
+           lower.ends_with(L".ico");
+}
+
+HICON LoadIconFromPath(std::wstring const& iconPath) {
+    std::wstring expanded = ExpandEnvVars(iconPath);
+
+    // Support an icon index suffix, e.g. shell32.dll,3.
+    int iconIndex = 0;
+    size_t comma = expanded.rfind(L',');
+    if (comma != std::wstring::npos && comma + 1 < expanded.size()) {
+        bool isNumber = true;
+        for (size_t i = comma + 1; i < expanded.size(); i++) {
+            WCHAR c = expanded[i];
+            bool isDigit = c >= L'0' && c <= L'9';
+            if (!isDigit && !(i == comma + 1 && c == L'-')) {
+                isNumber = false;
+                break;
+            }
+        }
+
+        if (isNumber) {
+            iconIndex = _wtoi(expanded.c_str() + comma + 1);
+            expanded.resize(comma);
+        }
+    }
+
+    expanded = ResolveAppExecutionAlias(expanded);
+
+    HICON hIcon = nullptr;
+    if (ExtractIconExW(expanded.c_str(), iconIndex, &hIcon, nullptr, 1) &&
+        hIcon) {
+        return hIcon;
+    }
+
+    SHFILEINFOW fileInfo{};
+    if (SHGetFileInfoW(expanded.c_str(), 0, &fileInfo, sizeof(fileInfo),
+                       SHGFI_ICON | SHGFI_LARGEICON)) {
+        return fileInfo.hIcon;
+    }
+
+    Wh_Log(L"Couldn't load an icon from %s", iconPath.c_str());
+    return nullptr;
+}
+
+// A "shell:" path, e.g. shell:AppsFolder\<AUMID> for a Store app whose icon
+// (Notepad, Calculator, ...) can't be extracted from its legacy .exe stub.
+bool IsShellPath(std::wstring const& s) {
+    return s.size() >= 6 && _wcsnicmp(s.c_str(), L"shell:", 6) == 0;
+}
+
+muxm::ImageSource CreateImageSourceFromHBitmap(HBITMAP hBitmap) {
+    muxm::ImageSource result = nullptr;
+
+    BITMAP bm{};
+    if (!GetObject(hBitmap, sizeof(bm), &bm) || bm.bmWidth <= 0 ||
+        bm.bmHeight <= 0) {
+        return result;
+    }
+
+    int width = bm.bmWidth;
+    int height = bm.bmHeight;
+
+    BITMAPINFO bmi{};
+    bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
+    bmi.bmiHeader.biWidth = width;
+    bmi.bmiHeader.biHeight = -height;  // Top-down.
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    std::vector<uint8_t> pixels((size_t)width * height * 4);
+
+    HDC hdc = CreateCompatibleDC(nullptr);
+    if (!hdc) {
+        return result;
+    }
+
+    if (GetDIBits(hdc, hBitmap, 0, height, pixels.data(), &bmi,
+                  DIB_RGB_COLORS)) {
+        // The shell returns premultiplied alpha already; just handle the
+        // fully-opaque (no alpha channel) case.
+        bool hasAlpha = false;
+        for (size_t p = 3; p < pixels.size(); p += 4) {
+            if (pixels[p]) {
+                hasAlpha = true;
+                break;
+            }
+        }
+
+        if (!hasAlpha) {
+            for (size_t p = 3; p < pixels.size(); p += 4) {
+                pixels[p] = 255;
+            }
+        }
+
+        try {
+            muxm::Imaging::WriteableBitmap bitmap(width, height);
+            memcpy(bitmap.PixelBuffer().data(), pixels.data(), pixels.size());
+            bitmap.Invalidate();
+            result = bitmap;
+        } catch (...) {
+            Wh_Log(L"Error %08X", winrt::to_hresult().value);
+        }
+    }
+
+    DeleteDC(hdc);
+    return result;
+}
+
+muxm::ImageSource LoadImageSourceFromShellPath(std::wstring const& path) {
+    std::wstring expanded = ExpandEnvVars(path);
+
+    PIDLIST_ABSOLUTE pidl = nullptr;
+    if (FAILED(SHParseDisplayName(expanded.c_str(), nullptr, &pidl, 0,
+                                  nullptr)) ||
+        !pidl) {
+        Wh_Log(L"Couldn't parse shell path %s", path.c_str());
+        return nullptr;
+    }
+
+    winrt::com_ptr<IShellItemImageFactory> factory;
+    HRESULT hr = SHCreateItemFromIDList(pidl, IID_PPV_ARGS(factory.put()));
+    CoTaskMemFree(pidl);
+    if (FAILED(hr) || !factory) {
+        return nullptr;
+    }
+
+    SIZE size = {32, 32};
+    HBITMAP hBitmap = nullptr;
+    hr = factory->GetImage(size, SIIGBF_ICONONLY | SIIGBF_BIGGERSIZEOK,
+                           &hBitmap);
+    if (FAILED(hr) || !hBitmap) {
+        return nullptr;
+    }
+
+    auto source = CreateImageSourceFromHBitmap(hBitmap);
+    DeleteObject(hBitmap);
+    return source;
+}
+
+// Returns nullptr if no icon could be resolved from the settings.
+muxc::IconElement TryCreateIconElement(std::wstring const& iconSetting,
+                                       std::wstring const& command) {
+    bool isPath = !iconSetting.empty() && LooksLikeIconPath(iconSetting);
+
+    muxm::ImageSource source = nullptr;
+    if (isPath && IsShellPath(iconSetting)) {
+        source = LoadImageSourceFromShellPath(iconSetting);
+    } else {
+        HICON hIcon = nullptr;
+        if (isPath) {
+            hIcon = LoadIconFromPath(iconSetting);
+        } else if (iconSetting.empty() && !command.empty()) {
+            hIcon = ExtractCommandIcon(command);
+        }
+
+        if (hIcon) {
+            source = CreateImageSourceFromIcon(hIcon);
+            DestroyIcon(hIcon);
+        }
+    }
+
+    if (source) {
+        muxc::ImageIcon imageIcon;
+        imageIcon.Source(source);
+        return imageIcon;
+    }
+
+    std::wstring glyph;
+    if (!isPath) {
+        glyph = ParseGlyphSetting(iconSetting.c_str());
+    }
+
+    if (glyph.empty()) {
+        return nullptr;
+    }
+
+    muxc::FontIcon fontIcon;
+    fontIcon.FontFamily(muxm::FontFamily(L"Segoe Fluent Icons"));
+    fontIcon.Glyph(glyph.c_str());
+    return fontIcon;
+}
+
+muxc::IconElement CreateIconElement(std::wstring const& iconSetting,
+                                    std::wstring const& command,
+                                    PCWSTR defaultGlyph) {
+    if (auto icon = TryCreateIconElement(iconSetting, command)) {
+        return icon;
+    }
+
+    muxc::FontIcon fontIcon;
+    fontIcon.FontFamily(muxm::FontFamily(L"Segoe Fluent Icons"));
+    fontIcon.Glyph(defaultGlyph);
+    return fontIcon;
+}
+
+// Icon for a command bar button, honoring the item's "Hide icon" option.
+muxc::IconElement MakeCommandButtonIcon(ActionItem const& item) {
+    if (item.hideIcon) {
+        return nullptr;
+    }
+    return CreateIconElement(item.icon, item.command, L"");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Managing the buttons in the command bar.
+
+bool IsOurElement(muxc::ICommandBarElement const& command) {
+    // Matches both our buttons and our separators.
+    auto element = command.try_as<mux::FrameworkElement>();
+    return element &&
+           std::wstring_view(element.Name()).starts_with(kButtonNamePrefix);
+}
+
+bool HasOurButtons(muxc::CommandBar const& commandBar) {
+    for (auto const& command : commandBar.PrimaryCommands()) {
+        if (IsOurElement(command)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+std::wstring GetButtonIconUri(muxc::AppBarButton const& button) try {
+    auto icon = button.Icon();
+    if (!icon) {
+        return std::wstring();
+    }
+
+    wf::Uri uri{nullptr};
+    if (auto imageIcon = icon.try_as<muxc::ImageIcon>()) {
+        if (auto source = imageIcon.Source()) {
+            if (auto svgSource =
+                    source.try_as<muxm::Imaging::SvgImageSource>()) {
+                uri = svgSource.UriSource();
+            }
+        }
+    } else if (auto iconSourceElement =
+                   icon.try_as<muxc::IconSourceElement>()) {
+        if (auto iconSource = iconSourceElement.IconSource()) {
+            if (auto imageIconSource =
+                    iconSource.try_as<muxc::ImageIconSource>()) {
+                if (auto source = imageIconSource.ImageSource()) {
+                    if (auto svgSource =
+                            source.try_as<muxm::Imaging::SvgImageSource>()) {
+                        uri = svgSource.UriSource();
+                    }
+                }
+            }
+        }
+    } else if (auto bitmapIcon = icon.try_as<muxc::BitmapIcon>()) {
+        uri = bitmapIcon.UriSource();
+    }
+
+    if (!uri) {
+        return std::wstring();
+    }
+
+    return std::wstring{uri.AbsoluteUri()};
+} catch (...) {
+    return std::wstring();
+}
+
+// Returns an index into kDefaultButtons, or -1.
+int IdentifyDefaultButton(muxc::AppBarButton const& button) {
+    std::wstring uri = GetButtonIconUri(button);
+    if (!uri.empty()) {
+        for (auto& c : uri) {
+            c = towlower(c);
+        }
+
+        size_t slash = uri.find_last_of(L'/');
+        std::wstring_view fileName =
+            slash == std::wstring::npos
+                ? std::wstring_view(uri)
+                : std::wstring_view(uri).substr(slash + 1);
+
+        // The View button's icon reflects the current view mode
+        // (windows.iconsize.list.svg, windows.iconsize.details.svg, etc.).
+        if (fileName.starts_with(L"windows.iconsize.")) {
+            return kViewButtonIndex;
+        }
+
+        for (int i = 0; i < kDefaultButtonCount; i++) {
+            if (fileName == kDefaultButtons[i].svgFileName) {
+                return i;
+            }
+        }
+    }
+
+    // The sort button has an automation id.
+    try {
+        if (mux::Automation::AutomationProperties::GetAutomationId(button) ==
+            L"SortAndGroupButton") {
+            return kSortButtonIndex;
+        }
+    } catch (...) {
+    }
+
+    return -1;
+}
+
+std::wstring GetAutomationId(mux::FrameworkElement const& element) {
+    try {
+        return std::wstring{
+            mux::Automation::AutomationProperties::GetAutomationId(element)};
+    } catch (...) {
+        return std::wstring();
+    }
+}
+
+// Which "hide" setting an element we touch is governed by. Looked up live
+// rather than snapshotted, because the visibility watcher below re-applies the
+// setting long after the command bar was processed.
+enum class ManagedKind {
+    Button,           // A default button, index into kDefaultButtons.
+    SeparatorAfter,   // A separator, index of the button it follows.
+    GroupSeparator,   // A separator that's redundant once its group is empty.
+    DetailsToggle,    // The Details pane toggle.
+    OverflowElement,  // The "See more" button's separator.
+};
+
+// A command a group separator delimits, remembered so the separator can be
+// hidden once nothing in its group is left to show.
+struct GroupMember {
+    winrt::weak_ref<mux::UIElement> element;
+    int defaultButtonIndex;  // -1 for commands we don't manage.
+};
+
+struct ManagedTarget {
+    ManagedKind kind;
+    int index = 0;
+    // GroupSeparator only. Shared so the target stays cheap to copy into the
+    // visibility watcher below.
+    std::shared_ptr<std::vector<GroupMember>> group;
+};
+
+bool ShouldHide(ManagedTarget const& target);
+
+// The visibility an element would have if we weren't hiding it: the value
+// Explorer last set, which we track, or its current value if we've never
+// touched it.
+mux::Visibility EffectiveVisibility(mux::UIElement const& element) {
+    {
+        std::lock_guard<std::mutex> lock(g_originalStateMutex);
+        auto it = g_originalVisibility.find(winrt::get_abi(element));
+        if (it != g_originalVisibility.end()) {
+            return it->second;
+        }
+    }
+
+    return element.Visibility();
+}
+
+// True when every command in the group is hidden, by us or by Explorer, so its
+// separator would leave a double line behind.
+bool IsGroupHidden(std::shared_ptr<std::vector<GroupMember>> const& group) {
+    if (!group || group->empty()) {
+        return false;
+    }
+
+    for (auto const& member : *group) {
+        auto element = member.element.get();
+        if (!element) {
+            continue;
+        }
+
+        if (member.defaultButtonIndex >= 0 &&
+            ShouldHide({ManagedKind::Button, member.defaultButtonIndex})) {
+            continue;
+        }
+
+        if (EffectiveVisibility(element) == mux::Visibility::Collapsed) {
+            continue;
+        }
+
+        return false;
+    }
+
+    return true;
+}
+
+bool ShouldHide(ManagedTarget const& target) {
+    // Evaluated before taking the settings lock: it consults the setting of
+    // each group member itself.
+    if (target.kind == ManagedKind::GroupSeparator) {
+        return IsGroupHidden(target.group);
+    }
+
+    std::lock_guard<std::mutex> lock(g_settings.mutex);
+    switch (target.kind) {
+        case ManagedKind::Button:
+            return g_settings.hideDefaultButtons[target.index];
+        case ManagedKind::SeparatorAfter:
+            return g_settings.hideSeparatorAfterButton[target.index];
+        case ManagedKind::DetailsToggle:
+            return g_settings.hideDetailsButton;
+        case ManagedKind::OverflowElement:
+            return g_settings.hideMoreButton;
+        case ManagedKind::GroupSeparator:
+            break;
+    }
+
+    return false;
+}
+
+// Set while we're the ones assigning Visibility, so the watcher can tell our
+// own writes apart from Explorer's. The callback runs synchronously on the
+// thread doing the write, hence thread_local.
+thread_local int g_settingVisibilityDepth;
+
+void SetVisibilityInternal(mux::UIElement const& element,
+                           mux::Visibility visibility) {
+    g_settingVisibilityDepth++;
+    try {
+        element.Visibility(visibility);
+    } catch (...) {
+        Wh_Log(L"Error %08X", winrt::to_hresult().value);
+    }
+    g_settingVisibilityDepth--;
+}
+
+// Explorer shows and hides its contextual commands (Set as background, Rotate
+// left/right, Extract all, ...) as the selection changes, which overwrites our
+// collapse. Watching the property lets us re-apply immediately, and keeps the
+// remembered original in sync so disabling the mod restores what Explorer
+// wanted rather than what it happened to be when we first saw the element.
+struct VisibilityWatch {
+    DWORD threadId;
+    void* key;
+    winrt::weak_ref<mux::UIElement> element;
+    int64_t token;
+};
+
+std::mutex g_watchesMutex;
+std::vector<VisibilityWatch> g_watches;
+
+void ApplyDefaultButtonVisibility(muxc::CommandBar const& commandBar,
+                                  bool forceShow = false);
+
+// Hiding a group separator depends on the whole group, so a single element
+// changing isn't enough to decide: re-run the pass for the command bar once the
+// current batch of changes has settled. Coalesced per command bar, since
+// Explorer updates a whole run of commands on every selection change.
+std::mutex g_pendingRecomputeMutex;
+std::unordered_set<void*> g_pendingRecompute;
+
+void QueueVisibilityRecompute(
+    winrt::weak_ref<muxc::CommandBar> const& weakCommandBar) {
+    auto commandBar = weakCommandBar.get();
+    if (!commandBar) {
+        return;
+    }
+
+    void* key = winrt::get_abi(commandBar);
+    {
+        std::lock_guard<std::mutex> lock(g_pendingRecomputeMutex);
+        if (!g_pendingRecompute.insert(key).second) {
+            return;  // Already queued.
+        }
+    }
+
+    auto forgetPending = [key]() {
+        std::lock_guard<std::mutex> lock(g_pendingRecomputeMutex);
+        g_pendingRecompute.erase(key);
+    };
+
+    auto dispatcherQueue =
+        winrt::Microsoft::UI::Dispatching::DispatcherQueue::
+            GetForCurrentThread();
+    if (!dispatcherQueue) {
+        forgetPending();
+        return;
+    }
+
+    if (!dispatcherQueue.TryEnqueue([weakCommandBar, forgetPending]() {
+            forgetPending();
+
+            if (g_unloading) {
+                return;
+            }
+
+            if (auto commandBar = weakCommandBar.get()) {
+                try {
+                    ApplyDefaultButtonVisibility(commandBar);
+                } catch (...) {
+                    Wh_Log(L"Error %08X", winrt::to_hresult().value);
+                }
+            }
+        })) {
+        forgetPending();
+    }
+}
+
+void WatchVisibility(mux::UIElement const& element,
+                     void* key,
+                     ManagedTarget const& target,
+                     winrt::weak_ref<muxc::CommandBar> const& owner) {
+    {
+        std::lock_guard<std::mutex> lock(g_watchesMutex);
+
+        DWORD threadId = GetCurrentThreadId();
+        for (auto it = g_watches.begin(); it != g_watches.end();) {
+            if (it->key == key) {
+                return;  // Already watched.
+            }
+
+            // Drop entries of elements that are gone. Only our own thread's,
+            // since a weak reference to a live non-agile element can't be
+            // resolved from another thread.
+            if (it->threadId == threadId && !it->element.get()) {
+                it = g_watches.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    int64_t token = element.RegisterPropertyChangedCallback(
+        mux::UIElement::VisibilityProperty(),
+        [key, target, owner](mux::DependencyObject const& sender,
+                             mux::DependencyProperty const&) {
+            if (g_unloading || g_settingVisibilityDepth > 0) {
+                return;
+            }
+
+            auto element = sender.try_as<mux::UIElement>();
+            if (!element) {
+                return;
+            }
+
+            // Explorer changed it, so this is the new baseline to restore.
+            mux::Visibility visibility = element.Visibility();
+            {
+                std::lock_guard<std::mutex> lock(g_originalStateMutex);
+                g_originalVisibility[key] = visibility;
+            }
+
+            if (visibility != mux::Visibility::Collapsed &&
+                ShouldHide(target)) {
+                SetVisibilityInternal(element, mux::Visibility::Collapsed);
+            }
+
+            // This element may belong to a group whose separator now has to
+            // appear or disappear with it.
+            QueueVisibilityRecompute(owner);
+        });
+
+    std::lock_guard<std::mutex> lock(g_watchesMutex);
+    g_watches.push_back({GetCurrentThreadId(), key,
+                         winrt::make_weak(element), token});
+}
+
+void UnwatchVisibilityForCurrentThread() {
+    DWORD threadId = GetCurrentThreadId();
+    std::vector<VisibilityWatch> taken;
+    {
+        std::lock_guard<std::mutex> lock(g_watchesMutex);
+        for (auto it = g_watches.begin(); it != g_watches.end();) {
+            if (it->threadId == threadId) {
+                taken.push_back(std::move(*it));
+                it = g_watches.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    for (auto const& watch : taken) {
+        if (auto element = watch.element.get()) {
+            try {
+                element.UnregisterPropertyChangedCallback(
+                    mux::UIElement::VisibilityProperty(), watch.token);
+            } catch (...) {
+                Wh_Log(L"Error %08X", winrt::to_hresult().value);
+            }
+        }
+    }
+}
+
+// Sets an element's visibility to Collapsed when hiding, or restores its
+// original (pre-modification) visibility otherwise. The original is captured
+// the first time the element is seen, so we never force-show something
+// Explorer intentionally kept collapsed.
+void SetManagedVisibility(mux::UIElement const& element,
+                          ManagedTarget const& target,
+                          bool forceShow,
+                          winrt::weak_ref<muxc::CommandBar> const& owner) {
+    void* key = winrt::get_abi(element);
+
+    mux::Visibility original;
+    {
+        std::lock_guard<std::mutex> lock(g_originalStateMutex);
+        auto it = g_originalVisibility.find(key);
+        if (it == g_originalVisibility.end()) {
+            it = g_originalVisibility.emplace(key, element.Visibility()).first;
+        }
+        original = it->second;
+    }
+
+    if (!forceShow) {
+        WatchVisibility(element, key, target, owner);
+    }
+
+    SetVisibilityInternal(element, !forceShow && ShouldHide(target)
+                                       ? mux::Visibility::Collapsed
+                                       : original);
+}
+
+// Controls the gap between command bar buttons. Command bar buttons have a
+// fixed MinWidth that leaves padding around the icon, so we drop it to let the
+// button hug its content and use the horizontal margin (half of `spacing` on
+// each side) as the actual gap. A negative spacing (or reset) restores the
+// button's original margin and MinWidth, leaving the default untouched.
+void ApplyItemSpacing(muxc::AppBarButton const& button,
+                      int spacing,
+                      bool reset) {
+    void* key = winrt::get_abi(button);
+
+    mux::Thickness originalMargin;
+    double originalMinWidth;
+    {
+        std::lock_guard<std::mutex> lock(g_originalStateMutex);
+
+        auto marginIt = g_originalMargin.find(key);
+        if (marginIt == g_originalMargin.end()) {
+            marginIt = g_originalMargin.emplace(key, button.Margin()).first;
+        }
+        originalMargin = marginIt->second;
+
+        auto minWidthIt = g_originalMinWidth.find(key);
+        if (minWidthIt == g_originalMinWidth.end()) {
+            minWidthIt =
+                g_originalMinWidth.emplace(key, button.MinWidth()).first;
+        }
+        originalMinWidth = minWidthIt->second;
+    }
+
+    if (reset || spacing < 0) {
+        button.Margin(originalMargin);
+        button.MinWidth(originalMinWidth);
+        return;
+    }
+
+    double half = spacing / 2.0;
+    mux::Thickness margin = originalMargin;
+    margin.Left = half;
+    margin.Right = half;
+    button.Margin(margin);
+    button.MinWidth(0);
+}
+
+mux::FrameworkElement FindDescendantByName(mux::DependencyObject const& root,
+                                           std::wstring_view name) {
+    int count = muxm::VisualTreeHelper::GetChildrenCount(root);
+    for (int i = 0; i < count; i++) {
+        auto child = muxm::VisualTreeHelper::GetChild(root, i);
+        if (auto element = child.try_as<mux::FrameworkElement>();
+            element && element.Name() == name) {
+            return element;
+        }
+
+        if (auto found = FindDescendantByName(child, name)) {
+            return found;
+        }
+    }
+
+    return nullptr;
+}
+
+void ApplyDefaultButtonVisibility(muxc::CommandBar const& commandBar,
+                                  bool forceShow) {
+    bool hideMore;
+    int itemSpacing;
+    {
+        std::lock_guard<std::mutex> lock(g_settings.mutex);
+        hideMore = g_settings.hideMoreButton;
+        itemSpacing = g_settings.itemSpacing;
+    }
+
+    bool isPrimary = commandBar.Name() == L"FileExplorerCommandBar";
+
+    auto weakCommandBar = winrt::make_weak(commandBar);
+    auto setVisibility = [&weakCommandBar, forceShow](
+                             mux::UIElement const& element,
+                             ManagedTarget const& target) {
+        SetManagedVisibility(element, target, forceShow, weakCommandBar);
+    };
+
+    auto commands = commandBar.PrimaryCommands();
+    uint32_t count = commands.Size();
+
+    // Classify everything up front: identifying a button is relatively
+    // expensive, and the separator handling below needs to look ahead.
+    struct Entry {
+        muxc::ICommandBarElement command;
+        bool isOurs = false;
+        bool isSeparator = false;
+        bool isDetailsToggle = false;
+        int defaultIndex = -1;  // Index into kDefaultButtons, or -1.
+    };
+
+    std::vector<Entry> entries;
+    entries.reserve(count);
+
+    for (uint32_t i = 0; i < count; i++) {
+        Entry entry;
+        entry.command = commands.GetAt(i);
+        entry.isOurs = IsOurElement(entry.command);
+        entry.isSeparator =
+            !entry.isOurs &&
+            static_cast<bool>(entry.command.try_as<muxc::AppBarSeparator>());
+
+        if (!entry.isOurs && !entry.isSeparator) {
+            if (auto button = entry.command.try_as<muxc::AppBarButton>()) {
+                // The Details pane toggle lives in the secondary command bar.
+                if (GetAutomationId(button) == L"DetailsPaneToggleButton") {
+                    entry.isDetailsToggle = true;
+                } else {
+                    entry.defaultIndex = IdentifyDefaultButton(button);
+                }
+            }
+        }
+
+        entries.push_back(std::move(entry));
+    }
+
+    // Explorer keeps ~20 contextual, zero-width commands (Extract, Eject, ...)
+    // in the list between the View group and the overflow region. The vertical
+    // line the user sees "after View" is really the separator right before our
+    // first custom button, so locate that.
+    uint32_t firstCustomIndex = count;
+    for (uint32_t i = 0; i < count; i++) {
+        if (entries[i].isOurs) {
+            firstCustomIndex = i;
+            break;
+        }
+    }
+
+    // The commands a separator introduces, up to the next separator (or our
+    // own buttons, or the end of the list). Explorer puts a separator in front
+    // of its contextual commands; once all of them are hidden, that separator
+    // would sit right next to the next one as a double line, so it's hidden
+    // together with the group it belongs to.
+    auto collectGroup = [&entries, count](uint32_t separatorIndex) {
+        auto group = std::make_shared<std::vector<GroupMember>>();
+
+        for (uint32_t i = separatorIndex + 1; i < count; i++) {
+            auto const& entry = entries[i];
+            if (entry.isSeparator || entry.isOurs) {
+                break;
+            }
+
+            if (auto element = entry.command.try_as<mux::UIElement>()) {
+                group->push_back(
+                    {winrt::make_weak(element), entry.defaultIndex});
+            }
+        }
+
+        return group;
+    };
+
+    // The default-button index of the immediately preceding element, so a
+    // separator can be attributed to the button right before it.
+    int prevIndex = -1;
+    for (uint32_t i = 0; i < count; i++) {
+        auto const& entry = entries[i];
+
+        if (entry.isOurs) {
+            // Our custom buttons get the spacing too, for a uniform look.
+            if (auto button = entry.command.try_as<muxc::AppBarButton>()) {
+                ApplyItemSpacing(button, itemSpacing, forceShow);
+            }
+            prevIndex = -1;
+            continue;
+        }
+
+        if (entry.isSeparator) {
+            auto separator = entry.command.as<muxc::AppBarSeparator>();
+
+            int target = -1;
+            if (prevIndex == kNewButtonIndex) {
+                target = kNewButtonIndex;
+            } else if (prevIndex == kDeleteButtonIndex) {
+                target = kDeleteButtonIndex;
+            } else if (firstCustomIndex < count && i + 1 == firstCustomIndex) {
+                // The separator right before our custom buttons.
+                target = kViewButtonIndex;
+            }
+
+            if (target >= 0) {
+                setVisibility(separator,
+                              {ManagedKind::SeparatorAfter, target});
+            } else {
+                // One of Explorer's contextual separators. Hidden only when
+                // everything it introduces is hidden, so we never reveal a
+                // separator Explorer keeps collapsed.
+                setVisibility(
+                    separator,
+                    {ManagedKind::GroupSeparator, -1, collectGroup(i)});
+            }
+
+            prevIndex = -1;
+            continue;
+        }
+
+        if (entry.isDetailsToggle) {
+            setVisibility(entry.command.as<mux::UIElement>(),
+                          {ManagedKind::DetailsToggle});
+            prevIndex = -1;
+            continue;
+        }
+
+        if (entry.defaultIndex >= 0) {
+            auto button = entry.command.as<muxc::AppBarButton>();
+            setVisibility(button, {ManagedKind::Button, entry.defaultIndex});
+            // Spacing is applied only to real buttons, never the zero-width
+            // contextual commands (which would otherwise occupy space).
+            ApplyItemSpacing(button, itemSpacing, forceShow);
+        }
+
+        prevIndex = entry.defaultIndex;
+    }
+
+    // The "See more" (...) overflow button and its separator (a template
+    // part). OverflowButtonVisibility alone doesn't hide the separator in
+    // Explorer's template, so collapse it explicitly too.
+    if (isPrimary) {
+        void* key = winrt::get_abi(commandBar);
+        muxc::CommandBarOverflowButtonVisibility originalOverflow;
+        {
+            std::lock_guard<std::mutex> lock(g_originalStateMutex);
+            auto it = g_originalOverflow.find(key);
+            if (it == g_originalOverflow.end()) {
+                it = g_originalOverflow
+                         .emplace(key, commandBar.OverflowButtonVisibility())
+                         .first;
+            }
+            originalOverflow = it->second;
+        }
+
+        commandBar.OverflowButtonVisibility(
+            !forceShow && hideMore
+                ? muxc::CommandBarOverflowButtonVisibility::Collapsed
+                : originalOverflow);
+
+        if (auto overflowSeparator =
+                FindDescendantByName(commandBar, L"OverflowSeparator")) {
+            setVisibility(overflowSeparator, {ManagedKind::OverflowElement});
+        }
+    }
+}
+
+muxc::AppBarButton CreateBareButton(int index,
+                                    std::wstring const& tooltip,
+                                    muxc::IconElement const& icon) {
+    std::wstring name = kButtonNamePrefix;
+    name += L'_';
+    name += std::to_wstring(index);
+
+    muxc::AppBarButton button;
+    button.Name(name.c_str());
+    button.Label(tooltip.c_str());
+    button.LabelPosition(muxc::CommandBarLabelPosition::Collapsed);
+    button.Icon(icon);
+
+    if (!tooltip.empty()) {
+        muxc::ToolTipService::SetToolTip(button, winrt::box_value(
+                                                     winrt::hstring{tooltip}));
+    }
+
+    return button;
+}
+
+muxc::AppBarButton CreateActionButton(ActionItem const& item, int index) {
+    muxc::AppBarButton button = CreateBareButton(index, item.name, MakeCommandButtonIcon(item));
+
+    button.Click([item](wf::IInspectable const& sender,
+                        mux::RoutedEventArgs const&) {
+        if (auto element = sender.try_as<mux::FrameworkElement>()) {
+            OnActionInvoked(element, item);
+        }
+    });
+
+    return button;
+}
+
+void AppendMenuEntries(std::vector<ActionItem> const& items,
+                       wfc::IVector<muxc::MenuFlyoutItemBase> const& target,
+                       winrt::weak_ref<muxc::AppBarButton> const& weakButton);
+
+// A regular menu item, or a submenu with a further level of entries.
+muxc::MenuFlyoutItemBase CreateMenuEntry(
+    ActionItem const& item,
+    winrt::weak_ref<muxc::AppBarButton> const& weakButton) {
+    if (item.isMenu && !item.subItems.empty()) {
+        muxc::MenuFlyoutSubItem subMenu;
+        subMenu.Text(item.name.c_str());
+        if (!item.hideIcon) {
+            if (auto icon = TryCreateIconElement(item.icon, item.command)) {
+                subMenu.Icon(icon);
+            }
+        }
+
+        AppendMenuEntries(item.subItems, subMenu.Items(), weakButton);
+        return subMenu;
+    }
+
+    muxc::MenuFlyoutItem menuItem;
+    menuItem.Text(item.name.c_str());
+    if (!item.hideIcon) {
+        if (auto icon = TryCreateIconElement(item.icon, item.command)) {
+            menuItem.Icon(icon);
+        }
+    }
+
+    menuItem.Click([item, weakButton](wf::IInspectable const&,
+                                      mux::RoutedEventArgs const&) {
+        if (auto button = weakButton.get()) {
+            OnActionInvoked(button, item);
+        }
+    });
+
+    return menuItem;
+}
+
+void AppendMenuEntries(std::vector<ActionItem> const& items,
+                       wfc::IVector<muxc::MenuFlyoutItemBase> const& target,
+                       winrt::weak_ref<muxc::AppBarButton> const& weakButton) {
+    for (auto const& item : items) {
+        target.Append(CreateMenuEntry(item, weakButton));
+
+        if (item.separatorAfter) {
+            target.Append(muxc::MenuFlyoutSeparator());
+        }
+    }
+}
+
+muxc::AppBarButton CreateMenuButton(ActionItem const& item,
+                                    int index,
+                                    bool openOnHover,
+                                    int hoverDelayMs) {
+    muxc::AppBarButton button = CreateBareButton(index, item.name, MakeCommandButtonIcon(item));
+
+    // The menu flyout is shown in its own popup window, so resolve the
+    // Explorer window from the anchor button, not from the clicked menu item.
+    auto weakButton = winrt::make_weak(button);
+
+    muxc::MenuFlyout menu;
+    menu.Placement(
+        muxc::Primitives::FlyoutPlacementMode::BottomEdgeAlignedLeft);
+    AppendMenuEntries(item.subItems, menu.Items(), weakButton);
+
+    button.Flyout(menu);
+
+    if (openOnHover) {
+        auto showMenu = [weakButton]() {
+            auto button = weakButton.get();
+            if (!button) {
+                return;
+            }
+
+            if (auto flyout = button.Flyout(); flyout && !flyout.IsOpen()) {
+                flyout.ShowAt(button);
+            }
+        };
+
+        if (hoverDelayMs <= 0) {
+            button.PointerEntered(
+                [showMenu](wf::IInspectable const&,
+                           mux::Input::PointerRoutedEventArgs const&) {
+                    showMenu();
+                });
+        } else {
+            mux::DispatcherTimer timer;
+            timer.Interval(std::chrono::milliseconds(hoverDelayMs));
+
+            // Capture the timer weakly in its own Tick handler to avoid a
+            // reference cycle.
+            timer.Tick([weakTimer = winrt::make_weak(timer), showMenu](
+                           wf::IInspectable const&,
+                           wf::IInspectable const&) {
+                if (auto timer = weakTimer.get()) {
+                    timer.Stop();
+                }
+                showMenu();
+            });
+
+            button.PointerEntered(
+                [timer](wf::IInspectable const&,
+                        mux::Input::PointerRoutedEventArgs const&) {
+                    timer.Stop();  // Restart the delay.
+                    timer.Start();
+                });
+
+            auto stopTimer =
+                [timer](wf::IInspectable const&,
+                        mux::Input::PointerRoutedEventArgs const&) {
+                    timer.Stop();
+                };
+            button.PointerExited(stopTimer);
+            button.PointerCanceled(stopTimer);
+        }
+    }
+
+    return button;
+}
+
+void EnsureButtons(muxc::CommandBar const& commandBar) {
+    if (g_unloading) {
+        return;
+    }
+
+    if (HasOurButtons(commandBar)) {
+        return;
+    }
+
+    bool openMenuOnHover;
+    int menuHoverDelay;
+    std::vector<ActionItem> items;
+    {
+        std::lock_guard<std::mutex> lock(g_settings.mutex);
+        openMenuOnHover = g_settings.openMenuOnHover;
+        menuHoverDelay = g_settings.menuHoverDelay;
+        items = g_settings.items;
+    }
+
+    if (items.empty()) {
+        return;
+    }
+
+    Wh_Log(L"Adding %zu items to command bar", items.size());
+
+    auto commands = commandBar.PrimaryCommands();
+    for (size_t i = 0; i < items.size(); i++) {
+        auto const& item = items[i];
+        if (item.isMenu && !item.subItems.empty()) {
+            commands.Append(CreateMenuButton(item, (int)i, openMenuOnHover,
+                                             menuHoverDelay));
+        } else {
+            commands.Append(CreateActionButton(item, (int)i));
+        }
+
+        if (item.separatorAfter) {
+            muxc::AppBarSeparator separator;
+            std::wstring name = kButtonNamePrefix;
+            name += L"_Sep_";
+            name += std::to_wstring(i);
+            separator.Name(name.c_str());
+            commands.Append(separator);
+        }
+    }
+}
+
+void UpdateCommandBar(muxc::CommandBar const& commandBar) {
+    if (g_unloading) {
+        return;
+    }
+
+    // Custom buttons only go in the primary command bar; the secondary bar
+    // just holds the Details pane toggle.
+    if (commandBar.Name() == L"FileExplorerCommandBar") {
+        EnsureButtons(commandBar);
+    }
+
+    ApplyDefaultButtonVisibility(commandBar);
+}
+
+void RemoveOurButtons(muxc::CommandBar const& commandBar) {
+    auto commands = commandBar.PrimaryCommands();
+    for (uint32_t i = commands.Size(); i > 0; i--) {
+        if (IsOurElement(commands.GetAt(i - 1))) {
+            commands.RemoveAt(i - 1);
+        }
+    }
+}
+
+void OnCommandBarAdded(muxc::CommandBar const& commandBar) {
+    {
+        std::lock_guard<std::mutex> lock(g_entriesMutex);
+
+        // Prune entries whose command bar is gone.
+        for (auto it = g_entries.begin(); it != g_entries.end();) {
+            if (!it->commandBar.get()) {
+                it = g_entries.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
+        for (auto const& entry : g_entries) {
+            if (entry.commandBar.get() == commandBar) {
+                // Already tracked (e.g. re-added to the tree).
+                return;
+            }
+        }
+    }
+
+    CommandBarEntry entry;
+    entry.threadId = GetCurrentThreadId();
+    entry.commandBar = winrt::make_weak(commandBar);
+
+    // Re-add the buttons whenever the command bar reloads.
+    entry.loadedToken = commandBar.Loaded(
+        [](wf::IInspectable const& sender, mux::RoutedEventArgs const&) {
+            if (auto commandBar = sender.try_as<muxc::CommandBar>()) {
+                UpdateCommandBar(commandBar);
+            }
+        });
+
+    // Re-add the buttons and reapply visibility if Explorer ever rebuilds
+    // the command list.
+    entry.vectorChangedToken = commandBar.PrimaryCommands().VectorChanged(
+        [weakCommandBar = winrt::make_weak(commandBar)](
+            wfc::IObservableVector<muxc::ICommandBarElement> const&,
+            wfc::IVectorChangedEventArgs const&) {
+            if (g_unloading) {
+                return;
+            }
+
+            // Defer the update; mutating the vector from within its own
+            // change notification isn't allowed.
+            auto dispatcherQueue = winrt::Microsoft::UI::Dispatching::
+                DispatcherQueue::GetForCurrentThread();
+            if (dispatcherQueue) {
+                dispatcherQueue.TryEnqueue([weakCommandBar]() {
+                    if (auto commandBar = weakCommandBar.get()) {
+                        UpdateCommandBar(commandBar);
+                    }
+                });
+            }
+        });
+
+    {
+        std::lock_guard<std::mutex> lock(g_entriesMutex);
+        g_entries.push_back(std::move(entry));
+    }
+
+    UpdateCommandBar(commandBar);
+}
+
+std::vector<CommandBarEntry> TakeEntriesForCurrentThread() {
+    DWORD threadId = GetCurrentThreadId();
+    std::vector<CommandBarEntry> taken;
+
+    std::lock_guard<std::mutex> lock(g_entriesMutex);
+    for (auto it = g_entries.begin(); it != g_entries.end();) {
+        if (it->threadId == threadId) {
+            taken.push_back(std::move(*it));
+            it = g_entries.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    return taken;
+}
+
+void RemoveButtonsForCurrentThread() {
+    // Before restoring anything, so the watcher can't fight the restore.
+    UnwatchVisibilityForCurrentThread();
+
+    for (auto& entry : TakeEntriesForCurrentThread()) {
+        auto commandBar = entry.commandBar.get();
+        if (!commandBar) {
+            continue;
+        }
+
+        try {
+            commandBar.Loaded(entry.loadedToken);
+            commandBar.PrimaryCommands().VectorChanged(
+                entry.vectorChangedToken);
+            RemoveOurButtons(commandBar);
+            ApplyDefaultButtonVisibility(commandBar, /*forceShow=*/true);
+        } catch (...) {
+            Wh_Log(L"Error %08X", winrt::to_hresult().value);
+        }
+    }
+}
+
+void RefreshButtonsForCurrentThread() {
+    std::vector<winrt::weak_ref<muxc::CommandBar>> commandBars;
+    {
+        DWORD threadId = GetCurrentThreadId();
+        std::lock_guard<std::mutex> lock(g_entriesMutex);
+        for (auto const& entry : g_entries) {
+            if (entry.threadId == threadId) {
+                commandBars.push_back(entry.commandBar);
+            }
+        }
+    }
+
+    for (auto const& weakCommandBar : commandBars) {
+        auto commandBar = weakCommandBar.get();
+        if (!commandBar) {
+            continue;
+        }
+
+        try {
+            // Recreate the buttons with the new settings.
+            RemoveOurButtons(commandBar);
+            UpdateCommandBar(commandBar);
+        } catch (...) {
+            Wh_Log(L"Error %08X", winrt::to_hresult().value);
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Initialization plumbing.
+
+void InitializeSettingsAndTap() {
+    if (g_initialized.exchange(true)) {
+        return;
+    }
+
+    HRESULT hr = InjectWindhawkTAP();
+    if (FAILED(hr)) {
+        Wh_Log(L"InjectWindhawkTAP failed: %08X", hr);
+        // Allow retrying, e.g. if the WinUI runtime wasn't loaded yet.
+        g_initialized = false;
+    }
+}
+
+void UninitializeSettingsAndTap() {
+    if (g_visualTreeWatcher) {
+        g_visualTreeWatcher->UnadviseVisualTreeChange();
+        g_visualTreeWatcher = nullptr;
+    }
+
+    g_initialized = false;
+}
+
+bool IsTargetTriggerWindow(HWND hWnd) {
+    WCHAR className[64];
+    if (!GetClassName(hWnd, className, ARRAYSIZE(className))) {
+        return false;
+    }
+
+    if (_wcsicmp(className, L"CabinetWClass") == 0) {
+        return true;
+    }
+
+    // The WinUI content bridge windows of a File Explorer window. By the time
+    // they're created, the WinUI runtime is loaded, so use them as a fallback
+    // trigger in case injection failed for the top-level window.
+    if (_wcsicmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") ==
+        0) {
+        HWND hRootWnd = GetAncestor(hWnd, GA_ROOT);
+        WCHAR rootClassName[64];
+        if (hRootWnd &&
+            GetClassName(hRootWnd, rootClassName, ARRAYSIZE(rootClassName)) &&
+            _wcsicmp(rootClassName, L"CabinetWClass") == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+using CreateWindowExW_t = decltype(&CreateWindowExW);
+CreateWindowExW_t CreateWindowExW_Original;
+HWND WINAPI CreateWindowExW_Hook(DWORD dwExStyle,
+                                 LPCWSTR lpClassName,
+                                 LPCWSTR lpWindowName,
+                                 DWORD dwStyle,
+                                 int X,
+                                 int Y,
+                                 int nWidth,
+                                 int nHeight,
+                                 HWND hWndParent,
+                                 HMENU hMenu,
+                                 HINSTANCE hInstance,
+                                 PVOID lpParam) {
+    HWND hWnd = CreateWindowExW_Original(dwExStyle, lpClassName, lpWindowName,
+                                         dwStyle, X, Y, nWidth, nHeight,
+                                         hWndParent, hMenu, hInstance, lpParam);
+    if (hWnd && !g_unloading && IsTargetTriggerWindow(hWnd)) {
+        InitializeSettingsAndTap();
+    }
+
+    return hWnd;
+}
+
+using RunFromWindowThreadProc_t = void(WINAPI*)(PVOID parameter);
+
+bool RunFromWindowThread(HWND hWnd,
+                         RunFromWindowThreadProc_t proc,
+                         PVOID procParam) {
+    static const UINT runFromWindowThreadRegisteredMsg =
+        RegisterWindowMessage(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
+
+    struct RUN_FROM_WINDOW_THREAD_PARAM {
+        RunFromWindowThreadProc_t proc;
+        PVOID procParam;
+    };
+
+    DWORD dwThreadId = GetWindowThreadProcessId(hWnd, nullptr);
+    if (dwThreadId == 0) {
+        return false;
+    }
+
+    if (dwThreadId == GetCurrentThreadId()) {
+        proc(procParam);
+        return true;
+    }
+
+    HHOOK hook = SetWindowsHookEx(
+        WH_CALLWNDPROC,
+        [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
+            if (nCode == HC_ACTION) {
+                const CWPSTRUCT* cwp = (const CWPSTRUCT*)lParam;
+                if (cwp->message == runFromWindowThreadRegisteredMsg) {
+                    RUN_FROM_WINDOW_THREAD_PARAM* param =
+                        (RUN_FROM_WINDOW_THREAD_PARAM*)cwp->lParam;
+                    param->proc(param->procParam);
+                }
+            }
+
+            return CallNextHookEx(nullptr, nCode, wParam, lParam);
+        },
+        nullptr, dwThreadId);
+    if (!hook) {
+        return false;
+    }
+
+    RUN_FROM_WINDOW_THREAD_PARAM param;
+    param.proc = proc;
+    param.procParam = procParam;
+    SendMessage(hWnd, runFromWindowThreadRegisteredMsg, 0, (LPARAM)&param);
+
+    UnhookWindowsHookEx(hook);
+
+    return true;
+}
+
+std::vector<HWND> GetFileExplorerWnds() {
+    std::vector<HWND> hWnds;
+    EnumWindows(
+        [](HWND hWnd, LPARAM lParam) -> BOOL {
+            auto& hWnds = *(std::vector<HWND>*)lParam;
+
+            DWORD dwProcessId = 0;
+            if (!GetWindowThreadProcessId(hWnd, &dwProcessId) ||
+                dwProcessId != GetCurrentProcessId()) {
+                return TRUE;
+            }
+
+            WCHAR className[64];
+            if (GetClassName(hWnd, className, ARRAYSIZE(className)) &&
+                _wcsicmp(className, L"CabinetWClass") == 0) {
+                hWnds.push_back(hWnd);
+            }
+
+            return TRUE;
+        },
+        (LPARAM)&hWnds);
+
+    return hWnds;
+}
+
+// Levels: command bar items (0) -> menu items (1) -> submenu items (2).
+constexpr int kMaxMenuDepth = 2;
+
+ActionItem LoadActionItem(PCWSTR prefix, int depth, bool* isEmpty) {
+    PCWSTR type = Wh_GetStringSetting(L"%s.type", prefix);
+    PCWSTR name = Wh_GetStringSetting(L"%s.name", prefix);
+    PCWSTR command = Wh_GetStringSetting(L"%s.command", prefix);
+    PCWSTR parameters = Wh_GetStringSetting(L"%s.parameters", prefix);
+    PCWSTR iconGlyph = Wh_GetStringSetting(L"%s.iconGlyph", prefix);
+
+    ActionItem item;
+    item.name = name;
+    item.command = command;
+    item.parameters = parameters;
+    item.icon = iconGlyph;
+    item.hideIcon = Wh_GetIntSetting(L"%s.hideIcon", prefix) != 0;
+    item.isMenu = wcscmp(type, L"menu") == 0;
+    item.separatorAfter =
+        Wh_GetIntSetting(L"%s.separatorAfter", prefix) != 0;
+
+    Wh_FreeStringSetting(type);
+    Wh_FreeStringSetting(name);
+    Wh_FreeStringSetting(command);
+    Wh_FreeStringSetting(parameters);
+    Wh_FreeStringSetting(iconGlyph);
+
+    if (depth < kMaxMenuDepth) {
+        for (int i = 0; i < 100; i++) {
+            WCHAR subPrefix[256];
+            swprintf(subPrefix, ARRAYSIZE(subPrefix), L"%s.subItems[%d]",
+                     prefix, i);
+
+            bool subEmpty = false;
+            ActionItem subItem = LoadActionItem(subPrefix, depth + 1,
+                                                &subEmpty);
+            if (subEmpty) {
+                break;
+            }
+
+            item.subItems.push_back(std::move(subItem));
+        }
+    }
+
+    *isEmpty =
+        item.name.empty() && item.command.empty() && item.subItems.empty();
+    return item;
+}
+
+void LoadSettings() {
+    std::lock_guard<std::mutex> lock(g_settings.mutex);
+
+    g_settings.openMenuOnHover = Wh_GetIntSetting(L"openMenuOnHover") != 0;
+
+    int menuHoverDelay = Wh_GetIntSetting(L"menuHoverDelay");
+    g_settings.menuHoverDelay = menuHoverDelay >= 0 ? menuHoverDelay : 0;
+
+    for (int i = 0; i < kDefaultButtonCount; i++) {
+        g_settings.hideDefaultButtons[i] =
+            Wh_GetIntSetting(L"hideDefaultButtons.%s",
+                             kDefaultButtons[i].settingKey) != 0;
+    }
+
+    g_settings.hideMoreButton =
+        Wh_GetIntSetting(L"hideDefaultButtons.moreOptions") != 0;
+    g_settings.hideDetailsButton =
+        Wh_GetIntSetting(L"hideDefaultButtons.details") != 0;
+
+    memset(g_settings.hideSeparatorAfterButton, 0,
+           sizeof(g_settings.hideSeparatorAfterButton));
+    g_settings.hideSeparatorAfterButton[kNewButtonIndex] =
+        Wh_GetIntSetting(L"hideDefaultButtons.separatorAfterNew") != 0;
+    g_settings.hideSeparatorAfterButton[kDeleteButtonIndex] =
+        Wh_GetIntSetting(L"hideDefaultButtons.separatorAfterDelete") != 0;
+    g_settings.hideSeparatorAfterButton[kViewButtonIndex] =
+        Wh_GetIntSetting(L"hideDefaultButtons.separatorAfterView") != 0;
+
+    int itemSpacing = Wh_GetIntSetting(L"itemSpacing");
+    g_settings.itemSpacing = itemSpacing < 0 ? -1 : itemSpacing;
+
+    g_settings.items.clear();
+    for (int i = 0; i < 100; i++) {
+        WCHAR prefix[64];
+        swprintf(prefix, ARRAYSIZE(prefix), L"items[%d]", i);
+
+        bool isEmpty = false;
+        ActionItem item = LoadActionItem(prefix, 0, &isEmpty);
+        if (isEmpty) {
+            break;
+        }
+
+        g_settings.items.push_back(std::move(item));
+    }
+
+    if (g_settings.items.empty()) {
+        ActionItem item;
+        item.name = L"Open in Terminal";
+        item.command = L"wt.exe";
+        item.parameters = L"-d \"%path%\"";
+        item.icon = L"";
+        g_settings.items.push_back(std::move(item));
+    }
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L">");
+
+    LoadSettings();
+
+    Wh_SetFunctionHook((void*)CreateWindowExW, (void*)CreateWindowExW_Hook,
+                       (void**)&CreateWindowExW_Original);
+
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    Wh_Log(L">");
+
+    if (!GetFileExplorerWnds().empty()) {
+        Wh_Log(L"Found existing File Explorer windows, injecting TAP");
+        InitializeSettingsAndTap();
+    }
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L">");
+
+    g_unloading = true;
+
+    UninitializeSettingsAndTap();
+
+    for (HWND hWnd : GetFileExplorerWnds()) {
+        Wh_Log(L"Removing buttons for window %08X", (DWORD)(ULONG_PTR)hWnd);
+        RunFromWindowThread(
+            hWnd, [](PVOID) { RemoveButtonsForCurrentThread(); }, nullptr);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_watchesMutex);
+        g_watches.clear();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_pendingRecomputeMutex);
+        g_pendingRecompute.clear();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_originalStateMutex);
+        g_originalVisibility.clear();
+        g_originalOverflow.clear();
+        g_originalMargin.clear();
+        g_originalMinWidth.clear();
+    }
+
+    std::lock_guard<std::mutex> lock(g_entriesMutex);
+    g_entries.clear();
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L">");
+
+    LoadSettings();
+
+    for (HWND hWnd : GetFileExplorerWnds()) {
+        RunFromWindowThread(
+            hWnd, [](PVOID) { RefreshButtonsForCurrentThread(); }, nullptr);
+    }
+}


### PR DESCRIPTION
# Explorer Command Bar 1.0.0

Add your own buttons and dropdown menus to the **Windows 11 File Explorer command bar** (the toolbar with New / Sort / View), and hide the built‑in buttons, separators and spacing you don't want.

![Explorer Command Bar demo](https://github.com/DanRotaru/windhawk-mods/blob/master/exporer-command-bar/screenshots/main.gif?raw=true)

Designed for Windows 11 24H2 / 25H2 with the WinAppSDK (WinUI 3) File Explorer.

## Features

- **Custom buttons** — add as many toolbar buttons as you like, each running a command of your choice.
- **Dropdown menus & submenus** — a button can open a menu, and menu entries can themselves be submenus (three levels deep).
- **Path & selection placeholders** — `%path%` (active tab folder) and `%sel%` (selected file/folder) are substituted into the command parameters.
- **Flexible icons** — a Segoe Fluent Icons glyph, an `.exe` / `.dll` / `.ico` file, a Store‑app icon (`shell:AppsFolder\…`), the command executable's own icon, or no icon at all.
- **Hide built‑in elements** — individually hide New, Cut, Copy, Paste, Rename, Share, Delete, Sort, View, the group separators, the "See more" (…) overflow menu, the contextual commands (Set as background, Rotate left, Rotate right, Extract all) and the Details pane toggle.
- **Custom item spacing** — set the exact spacing between the command bar buttons, in pixels.
- **Open menus on hover** — optionally open dropdowns on hover, with a configurable delay.
- **Rock solid** — buttons are re‑applied automatically across tab switches, navigation, new tabs and new windows, and everything is cleanly restored when the mod is disabled.

## Screenshots

Hiding built‑in buttons and separators:

![Hide buttons](https://github.com/DanRotaru/windhawk-mods/blob/master/exporer-command-bar/screenshots/hide-buttons.gif?raw=true)

You may hide even all options, and use only your custom ones:

![Hide All buttons](https://github.com/DanRotaru/windhawk-mods/blob/master/exporer-command-bar/screenshots/hide-all-buttons.jpg?raw=true)

## Command parameters

The following placeholders can be used in an item's parameters:

* `%path%` — the folder path of the currently active tab.
* `%sel%` — the full path of the selected file or folder in the active tab (the
  first one, if several are selected).

Wrap placeholders in quotes so paths with spaces work, e.g. `-d "%path%"`. If a used placeholder has no value (nothing selected, or a non‑filesystem location like *This PC*), the command is launched without any parameters. Commands run with the active tab's folder as their working directory.

## Icons

The **Icon glyph or icon path** field accepts several forms:

* **A glyph** — a hex code point of a [Segoe Fluent Icons](https://learn.microsoft.com/en-us/windows/apps/design/iconography/segoe-fluent-icons-font) glyph, e.g. `E756`.
* **A file path** — an `.exe`, `.dll` or `.ico` file to take the icon from, optionally with an icon index, e.g. `C:\Windows\System32\shell32.dll,3`.
* **A Store app** — `shell:AppsFolder\<AppUserModelID>` to use a modern Store app's icon (useful for apps whose `.exe` stub carries a legacy icon, such as Notepad and Calculator).
* **Empty** — the icon is extracted from the command's executable (app execution aliases such as `wt.exe` are resolved to their real target).
* **Hide icon** — enable the toggle to show no icon at all.

## Default configuration

Out of the box the mod adds:

* **Open in Terminal** — `wt.exe -d "%path%"`
* **Open in Notepad** — `notepad.exe "%sel%"`
* **Additional** ▾ (dropdown)
  * Open in VS Code — `code.exe "%path%"`
  * Open Paint — `mspaint.exe`
  * Open Calculator — `calc.exe`
  * **Commands** ▸ — `vite`, `npm init`, `npm install`, `npm run dev`,
    `npm run build`, `npm run start`
  * **AI** ▸ — `Claude`, `Codex`

All of the built‑in buttons stay visible by default. Everything is configurable in the mod settings.

## How it works

The mod injects a XAML diagnostics provider into Explorer and watches the WinUI 3 visual tree for the File Explorer command bar. When it appears, the configured buttons are inserted and the visibility / spacing settings are applied. The mod listens for the command bar being rebuilt so the buttons stay in place across navigation, new tabs and new windows, and it restores the original state of any element it touches when disabled.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* No.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
