### PR TITLE
Add Taskbar audio device switcher

### DIFF
--- a/mods/taskbar-audio-device-switcher.wh.cpp
+++ b/mods/taskbar-audio-device-switcher.wh.cpp
@@ -2,10 +2,10 @@
 // @id              taskbar-audio-device-switcher
 // @name            Taskbar audio device switcher
 // @description     Shows a tray icon for every connected audio device and switches the default device with a click
-// @version         1.1.0
+// @version         1.2.0
 // @author          Maksim Chingin
 // @github          https://github.com/umnik1
-// @include         explorer.exe
+// @include         windhawk.exe
 // @architecture    x86-64
 // @compilerOptions -lole32 -loleaut32 -lshell32 -lgdi32 -luser32
 // ==/WindhawkMod==
@@ -22,6 +22,20 @@ options.
 
 Each device uses its own icon, the one Windows shows in the sound settings, so
 headphones, speakers, HDMI output and a microphone are easy to tell apart.
+
+## How this differs from the other audio switching mods
+
+The catalog already has several mods for switching audio devices, but the
+interaction model here is different: instead of one icon that you click through
+or scroll on, every device gets its own icon, with its own graphic, and you
+click the device you want directly. Nothing is cycled, and no list of devices
+has to be configured in advance.
+
+* **Audioswap** / **Microswap** — a single tray icon which cycles through a
+  preconfigured list of up to 6 devices.
+* **Mic Tray Control** — one microphone icon, focused on mute and volume.
+* **Audio scroll switcher** — switches devices by scrolling over the taskbar,
+  without adding any icon.
 
 ## Choosing which devices are shown
 
@@ -40,14 +54,20 @@ New tray icons are hidden inside the overflow ("^") flyout by default. To make
 the audio device icons always visible, either drag them out of the flyout onto
 the taskbar, or go to
 *Settings → Personalization → Taskbar → Other system tray icons* and turn the
-relevant `explorer.exe` entries on.
+`windhawk.exe` entries on.
 
 ## Notes
 
+* The mod runs in a dedicated `windhawk.exe` process and doesn't hook anything,
+  see [Mods as
+  tools](https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process).
 * Devices are refreshed automatically when a device is plugged in/out, enabled,
   disabled, or when the default device changes from somewhere else.
 * Switching the default device uses the undocumented `IPolicyConfig` interface,
   the same one used by nircmd, SoundSwitch and similar tools.
+* Middle click sets the device as the communications device only. With the
+  default settings a left click already does that too, so middle click is only
+  useful if the *Switch the communications device too* option is turned off.
 */
 // ==/WindhawkModReadme==
 
@@ -78,11 +98,15 @@ relevant `explorer.exe` entries on.
 */
 // ==/WindhawkModSettings==
 
+#include <windhawk_utils.h>
+
 #include <windows.h>
 #include <shellapi.h>
 #include <propsys.h>
 #include <mmdeviceapi.h>
+#include <stdio.h>
 
+#include <atomic>
 #include <cstring>
 #include <cwchar>
 #include <string>
@@ -199,15 +223,15 @@ struct AudioDevice {
     bool isDefaultComm = false;
     // Hidden through the tray menu, can be toggled back from there.
     bool hidden = false;
-    // Hidden through the "Hidden devices" setting, can only be brought back by
-    // changing the setting.
+    // Hidden through the "Always hidden devices" setting, can only be brought
+    // back by changing the setting.
     bool hiddenBySetting = false;
     UINT trayId = 0;
 };
 
 struct TrayIcon {
     UINT trayId = 0;
-    HICON icon = nullptr;
+    HICON icon = nullptr;  // owned by the icon cache, not by this struct
     std::wstring tip;
 };
 
@@ -223,12 +247,23 @@ Settings g_settings;
 
 HANDLE g_thread;
 HANDLE g_windowReadyEvent;
-HWND g_hWnd;
+// Written by the mod thread, read from the Windhawk callbacks and from the
+// MMDevice notification threads.
+std::atomic<HWND> g_hWnd;
 UINT g_taskbarCreatedMessage;
+int g_iconSize = 16;
 
 std::vector<AudioDevice> g_devices;  // all devices, hidden ones included
 std::unordered_map<std::wstring, TrayIcon> g_trayIcons;  // device id -> icon
 std::vector<std::wstring> g_hiddenIds;
+
+// Extracting an icon from a DLL is expensive and the device list is rebuilt on
+// every notification, so the built icons are kept around. The cache owns the
+// handles.
+std::unordered_map<std::wstring, HICON> g_iconCache;
+
+// Kept alive for the notification callback and reused for the enumeration.
+IMMDeviceEnumerator* g_enumerator;
 
 using PrivateExtractIconsW_t = UINT(WINAPI*)(LPCWSTR, int, int, int, HICON*, UINT*, UINT, UINT);
 PrivateExtractIconsW_t g_pPrivateExtractIcons;
@@ -244,16 +279,13 @@ void LoadSettings() {
     g_settings.setCommunications = Wh_GetIntSetting(L"setCommunications") != 0;
 
     g_settings.excluded.clear();
-    for (int i = 0; i < 64; i++) {
-        PCWSTR value = Wh_GetStringSetting(L"excludedDevices[%d]", i);
-        bool empty = !value || !*value;
-        if (!empty) {
-            g_settings.excluded.emplace_back(value);
-        }
-        Wh_FreeStringSetting(value);
-        if (empty) {
+    for (int i = 0;; i++) {
+        WindhawkUtils::StringSetting value =
+            WindhawkUtils::StringSetting::make(L"excludedDevices[%d]", i);
+        if (!*value) {
             break;
         }
+        g_settings.excluded.emplace_back(value.get());
     }
 }
 
@@ -359,20 +391,65 @@ void SetDeviceHidden(const std::wstring& deviceId, bool hidden) {
 // Icons
 // ---------------------------------------------------------------------------
 
+// The size the shell expects, for the DPI of the monitor the taskbar is on.
+int GetTrayIconSize() {
+    using GetDpiForWindow_t = UINT(WINAPI*)(HWND);
+    using GetSystemMetricsForDpi_t = int(WINAPI*)(int, UINT);
+
+    static bool initialized = false;
+    static GetDpiForWindow_t pGetDpiForWindow;
+    static GetSystemMetricsForDpi_t pGetSystemMetricsForDpi;
+    if (!initialized) {
+        initialized = true;
+        if (HMODULE user32 = GetModuleHandleW(L"user32.dll")) {
+            pGetDpiForWindow = reinterpret_cast<GetDpiForWindow_t>(
+                GetProcAddress(user32, "GetDpiForWindow"));
+            pGetSystemMetricsForDpi = reinterpret_cast<GetSystemMetricsForDpi_t>(
+                GetProcAddress(user32, "GetSystemMetricsForDpi"));
+        }
+    }
+
+    if (pGetDpiForWindow && pGetSystemMetricsForDpi) {
+        if (HWND tray = FindWindowW(L"Shell_TrayWnd", nullptr)) {
+            UINT dpi = pGetDpiForWindow(tray);
+            if (dpi != 0) {
+                int size = pGetSystemMetricsForDpi(SM_CXSMICON, dpi);
+                if (size > 0) {
+                    return size;
+                }
+            }
+        }
+    }
+
+    int size = GetSystemMetrics(SM_CXSMICON);
+    return size > 0 ? size : 16;
+}
+
 HICON ExtractIconFromSpec(std::wstring spec, int size) {
     if (spec.empty()) {
         return nullptr;
     }
 
+    // Only a trailing ",<number>" is an icon index. Paths may legitimately
+    // contain a comma of their own.
     int index = 0;
     size_t comma = spec.find_last_of(L',');
-    if (comma != std::wstring::npos) {
-        index = static_cast<int>(wcstol(spec.c_str() + comma + 1, nullptr, 10));
-        spec.resize(comma);
+    if (comma != std::wstring::npos && comma + 1 < spec.size()) {
+        size_t digits = comma + 1;
+        if (spec[digits] == L'-' || spec[digits] == L'+') {
+            digits++;
+        }
+        if (digits < spec.size() &&
+            spec.find_first_not_of(L"0123456789", digits) == std::wstring::npos) {
+            index = static_cast<int>(wcstol(spec.c_str() + comma + 1, nullptr, 10));
+            spec.resize(comma);
+        }
     }
 
     WCHAR expanded[MAX_PATH * 2];
-    if (ExpandEnvironmentStringsW(spec.c_str(), expanded, ARRAYSIZE(expanded))) {
+    DWORD expandedLength =
+        ExpandEnvironmentStringsW(spec.c_str(), expanded, ARRAYSIZE(expanded));
+    if (expandedLength > 0 && expandedLength <= ARRAYSIZE(expanded)) {
         spec = expanded;
     }
 
@@ -423,6 +500,11 @@ HICON ExtractFallbackIcon(EDataFlow flow, int size) {
 }
 
 // Returns a faded, mostly grayscale copy of the icon, or nullptr on failure.
+//
+// Only the alpha channel is scaled. An icon's colour bitmap holds straight,
+// non-premultiplied alpha, which is also how the icon drawing path composites
+// it, so scaling the colour channels as well would darken the icon instead of
+// fading it.
 HICON MakeDimmedIcon(HICON source) {
     ICONINFO info = {};
     if (!GetIconInfo(source, &info)) {
@@ -521,12 +603,7 @@ HICON MakeDimmedIcon(HICON source) {
     return result;
 }
 
-HICON BuildDeviceIcon(const AudioDevice& device) {
-    int size = GetSystemMetrics(SM_CXSMICON);
-    if (size <= 0) {
-        size = 16;
-    }
-
+HICON BuildDeviceIcon(const AudioDevice& device, int size, bool dim) {
     HICON icon = ExtractIconFromSpec(device.iconPath, size);
     if (!icon) {
         icon = ExtractFallbackIcon(device.flow, size);
@@ -535,7 +612,7 @@ HICON BuildDeviceIcon(const AudioDevice& device) {
         return nullptr;
     }
 
-    if (g_settings.dimInactive && !device.isDefault) {
+    if (dim) {
         if (HICON dimmed = MakeDimmedIcon(icon)) {
             DestroyIcon(icon);
             icon = dimmed;
@@ -543,6 +620,49 @@ HICON BuildDeviceIcon(const AudioDevice& device) {
     }
 
     return icon;
+}
+
+// The returned icon belongs to the cache, the caller must not destroy it.
+HICON GetDeviceIcon(const AudioDevice& device) {
+    bool dim = g_settings.dimInactive && !device.isDefault;
+
+    std::wstring key = std::to_wstring(g_iconSize);
+    key += dim ? L"|d|" : L"|n|";
+    key += device.flow == eCapture ? L"c|" : L"r|";
+    key += device.iconPath;
+
+    auto it = g_iconCache.find(key);
+    if (it != g_iconCache.end()) {
+        return it->second;
+    }
+
+    HICON icon = BuildDeviceIcon(device, g_iconSize, dim);
+    if (icon) {
+        g_iconCache[key] = icon;
+    }
+    return icon;
+}
+
+// Drops the cached icons built for a size which is no longer in use. Called
+// after the tray icons have been updated, so that the shell never holds a
+// destroyed handle.
+void PurgeStaleIcons() {
+    std::wstring prefix = std::to_wstring(g_iconSize) + L"|";
+    for (auto it = g_iconCache.begin(); it != g_iconCache.end();) {
+        if (it->first.compare(0, prefix.size(), prefix) != 0) {
+            DestroyIcon(it->second);
+            it = g_iconCache.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void ClearIconCache() {
+    for (auto& entry : g_iconCache) {
+        DestroyIcon(entry.second);
+    }
+    g_iconCache.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -592,13 +712,17 @@ UINT TrayIdForDevice(const std::wstring& deviceId) {
 }
 
 void EnumerateDevices(std::vector<AudioDevice>& devices) {
-    IMMDeviceEnumerator* enumerator = nullptr;
-    if (FAILED(CoCreateInstance(kCLSID_MMDeviceEnumerator, nullptr, CLSCTX_ALL,
-                                kIID_IMMDeviceEnumerator,
-                                reinterpret_cast<void**>(&enumerator))) ||
-        !enumerator) {
-        Wh_Log(L"Failed to create the device enumerator");
-        return;
+    IMMDeviceEnumerator* enumerator = g_enumerator;
+    IMMDeviceEnumerator* ownedEnumerator = nullptr;
+    if (!enumerator) {
+        if (FAILED(CoCreateInstance(kCLSID_MMDeviceEnumerator, nullptr, CLSCTX_ALL,
+                                    kIID_IMMDeviceEnumerator,
+                                    reinterpret_cast<void**>(&ownedEnumerator))) ||
+            !ownedEnumerator) {
+            Wh_Log(L"Failed to create the device enumerator");
+            return;
+        }
+        enumerator = ownedEnumerator;
     }
 
     const struct {
@@ -688,7 +812,9 @@ void EnumerateDevices(std::vector<AudioDevice>& devices) {
         collection->Release();
     }
 
-    enumerator->Release();
+    if (ownedEnumerator) {
+        ownedEnumerator->Release();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -698,18 +824,15 @@ void EnumerateDevices(std::vector<AudioDevice>& devices) {
 void RemoveTrayIcon(UINT trayId) {
     NOTIFYICONDATAW nid = {};
     nid.cbSize = sizeof(nid);
-    nid.hWnd = g_hWnd;
+    nid.hWnd = g_hWnd.load();
     nid.uID = trayId;
     Shell_NotifyIconW(NIM_DELETE, &nid);
 }
 
 void RemoveAllTrayIcons(bool notifyShell) {
-    for (auto& entry : g_trayIcons) {
-        if (notifyShell) {
+    if (notifyShell) {
+        for (auto& entry : g_trayIcons) {
             RemoveTrayIcon(entry.second.trayId);
-        }
-        if (entry.second.icon) {
-            DestroyIcon(entry.second.icon);
         }
     }
     g_trayIcons.clear();
@@ -749,9 +872,6 @@ void RefreshDevices() {
             continue;
         }
         RemoveTrayIcon(it->second.trayId);
-        if (it->second.icon) {
-            DestroyIcon(it->second.icon);
-        }
         it = g_trayIcons.erase(it);
     }
 
@@ -760,12 +880,18 @@ void RefreshDevices() {
             continue;
         }
 
-        HICON icon = BuildDeviceIcon(device);
+        HICON icon = GetDeviceIcon(device);
         std::wstring tip = MakeTooltip(device);
+
+        auto it = g_trayIcons.find(device.id);
+        if (it != g_trayIcons.end() && it->second.icon == icon &&
+            it->second.tip == tip) {
+            continue;  // nothing changed for this device
+        }
 
         NOTIFYICONDATAW nid = {};
         nid.cbSize = sizeof(nid);
-        nid.hWnd = g_hWnd;
+        nid.hWnd = g_hWnd.load();
         nid.uID = device.trayId;
         nid.uFlags = NIF_MESSAGE | NIF_TIP | NIF_SHOWTIP;
         nid.uCallbackMessage = WM_APP_TRAY;
@@ -775,23 +901,15 @@ void RefreshDevices() {
             nid.hIcon = icon;
         }
 
-        auto it = g_trayIcons.find(device.id);
         if (it == g_trayIcons.end()) {
             if (!Shell_NotifyIconW(NIM_ADD, &nid)) {
-                // A leftover icon from a previous session of the mod.
-                RemoveTrayIcon(device.trayId);
-                if (!Shell_NotifyIconW(NIM_ADD, &nid)) {
-                    Wh_Log(L"Failed to add a tray icon for %s", device.name.c_str());
-                    if (icon) {
-                        DestroyIcon(icon);
-                    }
-                    continue;
-                }
+                Wh_Log(L"Failed to add a tray icon for %s", device.name.c_str());
+                continue;
             }
 
             NOTIFYICONDATAW version = {};
             version.cbSize = sizeof(version);
-            version.hWnd = g_hWnd;
+            version.hWnd = g_hWnd.load();
             version.uID = device.trayId;
             version.uVersion = NOTIFYICON_VERSION_4;
             Shell_NotifyIconW(NIM_SETVERSION, &version);
@@ -803,15 +921,14 @@ void RefreshDevices() {
             g_trayIcons[device.id] = std::move(state);
         } else {
             Shell_NotifyIconW(NIM_MODIFY, &nid);
-            if (it->second.icon) {
-                DestroyIcon(it->second.icon);
-            }
             it->second.icon = icon;
             it->second.tip = std::move(tip);
         }
     }
 
     g_devices = std::move(devices);
+
+    PurgeStaleIcons();
 }
 
 const AudioDevice* FindDeviceByTrayId(UINT trayId) {
@@ -827,22 +944,32 @@ const AudioDevice* FindDeviceByTrayId(UINT trayId) {
 // Switching the default device
 // ---------------------------------------------------------------------------
 
-void SetDefaultDevice(const std::wstring& deviceId, bool communicationsOnly) {
+// deviceId is taken by value on purpose: the caller's string usually lives in
+// g_devices, and the outgoing COM calls below can be re-entered by this thread,
+// which may rebuild that list.
+void SetDefaultDevice(std::wstring deviceId, bool communicationsOnly) {
     IPolicyConfig* config = nullptr;
     HRESULT hr = CoCreateInstance(kCLSID_PolicyConfigClient, nullptr, CLSCTX_ALL,
                                   kIID_IPolicyConfig, reinterpret_cast<void**>(&config));
     if (SUCCEEDED(hr) && config) {
-        if (communicationsOnly) {
-            config->SetDefaultEndpoint(deviceId.c_str(), eCommunications);
-        } else {
-            config->SetDefaultEndpoint(deviceId.c_str(), eConsole);
-            config->SetDefaultEndpoint(deviceId.c_str(), eMultimedia);
-            if (g_settings.setCommunications) {
-                config->SetDefaultEndpoint(deviceId.c_str(), eCommunications);
+        HRESULT setResult =
+            config->SetDefaultEndpoint(deviceId.c_str(),
+                                       communicationsOnly ? eCommunications : eConsole);
+        if (SUCCEEDED(setResult)) {
+            if (!communicationsOnly) {
+                config->SetDefaultEndpoint(deviceId.c_str(), eMultimedia);
+                if (g_settings.setCommunications) {
+                    config->SetDefaultEndpoint(deviceId.c_str(), eCommunications);
+                }
             }
+            config->Release();
+            return;
         }
+
+        // Fall through to the Vista interface.
+        Wh_Log(L"SetDefaultEndpoint failed, hr=0x%08X",
+               static_cast<unsigned>(setResult));
         config->Release();
-        return;
     }
 
     IPolicyConfigVista* vista = nullptr;
@@ -862,7 +989,7 @@ void SetDefaultDevice(const std::wstring& deviceId, bool communicationsOnly) {
         return;
     }
 
-    Wh_Log(L"Failed to create the policy config client, hr=0x%08X",
+    Wh_Log(L"Failed to switch the default device, hr=0x%08X",
            static_cast<unsigned>(hr));
 }
 
@@ -925,8 +1052,8 @@ class NotificationClient final : public IMMNotificationClient {
 
    private:
     void NotifyChanged() {
-        if (g_hWnd) {
-            PostMessageW(g_hWnd, WM_APP_REFRESH, 0, 0);
+        if (HWND hWnd = g_hWnd.load()) {
+            PostMessageW(hWnd, WM_APP_REFRESH, 0, 0);
         }
     }
 
@@ -960,8 +1087,8 @@ HMENU BuildShownDevicesMenu(const std::vector<AudioDevice>& devices,
             }
         } else {
             anyHidden = true;
-            // Devices filtered out by the "Hidden devices" setting can't be
-            // brought back from here.
+            // Devices filtered out by the "Always hidden devices" setting can't
+            // be brought back from here.
             if (device.hiddenBySetting) {
                 flags |= MF_GRAYED;
             }
@@ -985,6 +1112,15 @@ HMENU BuildShownDevicesMenu(const std::vector<AudioDevice>& devices,
     }
 
     return menu;
+}
+
+void OpenVolumeMixer() {
+    // ms-settings:apps-volume only exists on Windows 10 1803 and newer.
+    HINSTANCE result = ShellExecuteW(nullptr, L"open", L"ms-settings:apps-volume",
+                                    nullptr, nullptr, SW_SHOWNORMAL);
+    if (reinterpret_cast<INT_PTR>(result) <= 32) {
+        ShellExecuteW(nullptr, L"open", L"SndVol.exe", nullptr, nullptr, SW_SHOWNORMAL);
+    }
 }
 
 void ShowContextMenu(HWND hWnd,
@@ -1064,12 +1200,11 @@ void ShowContextMenu(HWND hWnd,
                           SW_SHOWNORMAL);
             break;
         case IDM_VOLUME_MIXER:
-            ShellExecuteW(nullptr, L"open", L"ms-settings:apps-volume", nullptr, nullptr,
-                          SW_SHOWNORMAL);
+            OpenVolumeMixer();
             break;
         case IDM_LEGACY_APPLET:
-            ShellExecuteW(nullptr, L"open", L"rundll32.exe",
-                          L"shell32.dll,Control_RunDLL mmsys.cpl", nullptr, SW_SHOWNORMAL);
+            ShellExecuteW(nullptr, L"open", L"mmsys.cpl", nullptr, nullptr,
+                          SW_SHOWNORMAL);
             break;
     }
 }
@@ -1129,7 +1264,6 @@ LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPara
 
         case WM_APP_RELOAD_SETTINGS:
             LoadSettings();
-            RemoveAllTrayIcons(true);
             RefreshDevices();
             return 0;
 
@@ -1143,9 +1277,15 @@ LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPara
 
         case WM_SETTINGCHANGE:
         case WM_DISPLAYCHANGE:
-        case WM_DPICHANGED:
-            SetTimer(hWnd, kRefreshTimerId, 500, nullptr);
+        case WM_DPICHANGED: {
+            // These arrive often, only act when the icon size really changed.
+            int size = GetTrayIconSize();
+            if (size != g_iconSize) {
+                g_iconSize = size;
+                SetTimer(hWnd, kRefreshTimerId, 500, nullptr);
+            }
             break;
+        }
 
         case WM_DESTROY:
             KillTimer(hWnd, kRefreshTimerId);
@@ -1168,6 +1308,7 @@ DWORD WINAPI ThreadProc(LPVOID) {
     }
 
     g_taskbarCreatedMessage = RegisterWindowMessageW(L"TaskbarCreated");
+    g_iconSize = GetTrayIconSize();
 
     LoadHiddenIds();
 
@@ -1176,14 +1317,7 @@ DWORD WINAPI ThreadProc(LPVOID) {
     wc.lpfnWndProc = WindowProc;
     wc.hInstance = GetModuleHandleW(nullptr);
     wc.lpszClassName = kWindowClassName;
-    ATOM atom = RegisterClassExW(&wc);
-    if (!atom && GetLastError() == ERROR_CLASS_ALREADY_EXISTS) {
-        // Left over from a previous instance of the mod, its window procedure
-        // points into an unloaded module.
-        UnregisterClassW(kWindowClassName, wc.hInstance);
-        atom = RegisterClassExW(&wc);
-    }
-    if (!atom) {
+    if (!RegisterClassExW(&wc)) {
         Wh_Log(L"RegisterClassExW failed, error %u", GetLastError());
         SetEvent(g_windowReadyEvent);
         if (SUCCEEDED(comInit)) {
@@ -1204,17 +1338,16 @@ DWORD WINAPI ThreadProc(LPVOID) {
         return 1;
     }
 
-    g_hWnd = hWnd;
+    g_hWnd.store(hWnd);
     SetEvent(g_windowReadyEvent);
 
-    IMMDeviceEnumerator* enumerator = nullptr;
     NotificationClient* client = nullptr;
     if (SUCCEEDED(CoCreateInstance(kCLSID_MMDeviceEnumerator, nullptr, CLSCTX_ALL,
                                    kIID_IMMDeviceEnumerator,
-                                   reinterpret_cast<void**>(&enumerator))) &&
-        enumerator) {
+                                   reinterpret_cast<void**>(&g_enumerator))) &&
+        g_enumerator) {
         client = new NotificationClient();
-        if (FAILED(enumerator->RegisterEndpointNotificationCallback(client))) {
+        if (FAILED(g_enumerator->RegisterEndpointNotificationCallback(client))) {
             client->Release();
             client = nullptr;
             Wh_Log(L"Failed to register the endpoint notification callback");
@@ -1233,17 +1366,19 @@ DWORD WINAPI ThreadProc(LPVOID) {
         DispatchMessageW(&msg);
     }
 
-    if (enumerator) {
+    if (g_enumerator) {
         if (client) {
-            enumerator->UnregisterEndpointNotificationCallback(client);
+            g_enumerator->UnregisterEndpointNotificationCallback(client);
             client->Release();
         }
-        enumerator->Release();
+        g_enumerator->Release();
+        g_enumerator = nullptr;
     }
 
-    g_hWnd = nullptr;
+    g_hWnd.store(nullptr);
     DestroyWindow(hWnd);
     UnregisterClassW(kWindowClassName, wc.hInstance);
+    ClearIconCache();
 
     if (SUCCEEDED(comInit)) {
         CoUninitialize();
@@ -1254,10 +1389,10 @@ DWORD WINAPI ThreadProc(LPVOID) {
 }  // namespace
 
 // ---------------------------------------------------------------------------
-// Windhawk entry points
+// Tool mod callbacks
 // ---------------------------------------------------------------------------
 
-BOOL Wh_ModInit() {
+BOOL WhTool_ModInit() {
     Wh_Log(L">");
 
     LoadSettings();
@@ -1277,30 +1412,32 @@ BOOL Wh_ModInit() {
     return TRUE;
 }
 
-void Wh_ModSettingsChanged() {
+void WhTool_ModSettingsChanged() {
     Wh_Log(L">");
 
-    if (g_hWnd) {
-        PostMessageW(g_hWnd, WM_APP_RELOAD_SETTINGS, 0, 0);
+    // The window may still be coming up, the settings must not be dropped.
+    if (g_windowReadyEvent) {
+        WaitForSingleObject(g_windowReadyEvent, 5000);
+    }
+
+    if (HWND hWnd = g_hWnd.load()) {
+        PostMessageW(hWnd, WM_APP_RELOAD_SETTINGS, 0, 0);
     }
 }
 
-void Wh_ModUninit() {
+void WhTool_ModUninit() {
     Wh_Log(L">");
 
     if (g_windowReadyEvent) {
         WaitForSingleObject(g_windowReadyEvent, 5000);
     }
 
-    HWND hWnd = g_hWnd;
-    if (hWnd) {
+    if (HWND hWnd = g_hWnd.load()) {
         PostMessageW(hWnd, WM_CLOSE, 0, 0);
     }
 
     if (g_thread) {
-        if (WaitForSingleObject(g_thread, 5000) == WAIT_TIMEOUT) {
-            Wh_Log(L"The mod thread did not exit in time");
-        }
+        WaitForSingleObject(g_thread, 5000);
         CloseHandle(g_thread);
         g_thread = nullptr;
     }
@@ -1309,4 +1446,183 @@ void Wh_ModUninit() {
         CloseHandle(g_windowReadyEvent);
         g_windowReadyEvent = nullptr;
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Windhawk tool mod implementation for mods which don't need to inject to other
+// processes or hook other functions. Context:
+// https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
+//
+// The mod will load and run in a dedicated windhawk.exe process.
+//
+// Paste the code below as part of the mod code, and use these callbacks:
+// * WhTool_ModInit
+// * WhTool_ModSettingsChanged
+// * WhTool_ModUninit
+//
+// Currently, other callbacks are not supported.
+
+bool g_isToolModProcessLauncher;
+HANDLE g_toolModProcessMutex;
+
+void WINAPI EntryPoint_Hook() {
+    Wh_Log(L">");
+    ExitThread(0);
+}
+
+BOOL Wh_ModInit() {
+    DWORD sessionId;
+    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
+        sessionId == 0) {
+        return FALSE;
+    }
+
+    bool isExcluded = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+    int argc;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
+    if (!argv) {
+        Wh_Log(L"CommandLineToArgvW failed");
+        return FALSE;
+    }
+
+    for (int i = 1; i < argc; i++) {
+        if (wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0) {
+            isExcluded = true;
+            break;
+        }
+    }
+
+    for (int i = 1; i < argc - 1; i++) {
+        if (wcscmp(argv[i], L"-tool-mod") == 0) {
+            isToolModProcess = true;
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
+                isCurrentToolModProcess = true;
+            }
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isExcluded) {
+        return FALSE;
+    }
+
+    if (isCurrentToolModProcess) {
+        g_toolModProcessMutex =
+            CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
+        if (!g_toolModProcessMutex) {
+            Wh_Log(L"CreateMutex failed");
+            ExitProcess(1);
+        }
+
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
+            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
+            ExitProcess(1);
+        }
+
+        if (!WhTool_ModInit()) {
+            ExitProcess(1);
+        }
+
+        IMAGE_DOS_HEADER* dosHeader =
+            (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
+        IMAGE_NT_HEADERS* ntHeaders =
+            (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
+
+        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
+        void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
+
+        Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
+        return TRUE;
+    }
+
+    if (isToolModProcess) {
+        return FALSE;
+    }
+
+    g_isToolModProcessLauncher = true;
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (!g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WCHAR currentProcessPath[MAX_PATH];
+    switch (GetModuleFileName(nullptr, currentProcessPath,
+                              ARRAYSIZE(currentProcessPath))) {
+        case 0:
+        case ARRAYSIZE(currentProcessPath):
+            Wh_Log(L"GetModuleFileName failed");
+            return;
+    }
+
+    WCHAR
+    commandLine[MAX_PATH + 2 +
+                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
+    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
+               WH_MOD_ID);
+
+    HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
+    if (!kernelModule) {
+        kernelModule = GetModuleHandle(L"kernel32.dll");
+        if (!kernelModule) {
+            Wh_Log(L"No kernelbase.dll/kernel32.dll");
+            return;
+        }
+    }
+
+    using CreateProcessInternalW_t = BOOL(WINAPI*)(
+        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+        LPSECURITY_ATTRIBUTES lpProcessAttributes,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
+        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
+        LPSTARTUPINFOW lpStartupInfo,
+        LPPROCESS_INFORMATION lpProcessInformation,
+        PHANDLE hRestrictedUserToken);
+    CreateProcessInternalW_t pCreateProcessInternalW =
+        (CreateProcessInternalW_t)GetProcAddress(kernelModule,
+                                                 "CreateProcessInternalW");
+    if (!pCreateProcessInternalW) {
+        Wh_Log(L"No CreateProcessInternalW");
+        return;
+    }
+
+    STARTUPINFO si{
+        .cb = sizeof(STARTUPINFO),
+        .dwFlags = STARTF_FORCEOFFFEEDBACK,
+    };
+    PROCESS_INFORMATION pi;
+    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
+                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
+                                 nullptr, nullptr, &si, &pi, nullptr)) {
+        Wh_Log(L"CreateProcess failed");
+        return;
+    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+}
+
+void Wh_ModSettingsChanged() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModSettingsChanged();
+}
+
+void Wh_ModUninit() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModUninit();
+    ExitProcess(0);
 }

--- a/mods/taskbar-audio-device-switcher.wh.cpp
+++ b/mods/taskbar-audio-device-switcher.wh.cpp
@@ -2,11 +2,10 @@
 // @id              taskbar-audio-device-switcher
 // @name            Taskbar audio device switcher
 // @description     Shows a tray icon for every connected audio device and switches the default device with a click
-// @version         1.2.0
+// @version         1.3.0
 // @author          Maksim Chingin
 // @github          https://github.com/umnik1
 // @include         windhawk.exe
-// @architecture    x86-64
 // @compilerOptions -lole32 -loleaut32 -lshell32 -lgdi32 -luser32
 // ==/WindhawkMod==
 
@@ -257,7 +256,18 @@ HANDLE g_windowReadyEvent;
 // MMDevice notification threads.
 std::atomic<HWND> g_hWnd;
 UINT g_taskbarCreatedMessage;
-int g_iconSize = 16;
+int g_iconSize;
+// Whether g_iconSize could be derived from the taskbar's monitor, or whether
+// it is the less accurate fallback and should be retried.
+bool g_iconSizeFromTaskbar;
+
+// Shell_NotifyIconW blocks in a cross-process SendMessage, and a thread which
+// is blocked there keeps dispatching inbound sent messages. Nothing may touch
+// g_trayIcons from such a handler while the loops in RefreshDevices hold an
+// iterator into it, so the work is deferred through these flags instead.
+bool g_refreshing;
+bool g_refreshPending;
+bool g_trayIconsLost;
 
 std::vector<AudioDevice> g_devices;  // all devices, hidden ones included
 std::unordered_map<std::wstring, TrayIcon> g_trayIcons;  // device id -> icon
@@ -278,6 +288,13 @@ PrivateExtractIconsW_t g_pPrivateExtractIcons;
 // Settings
 // ---------------------------------------------------------------------------
 
+std::wstring ToLower(std::wstring str) {
+    if (!str.empty()) {
+        CharLowerBuffW(&str[0], static_cast<DWORD>(str.size()));
+    }
+    return str;
+}
+
 void LoadSettings() {
     g_settings.showPlayback = Wh_GetIntSetting(L"showPlayback") != 0;
     g_settings.showRecording = Wh_GetIntSetting(L"showRecording") != 0;
@@ -291,24 +308,19 @@ void LoadSettings() {
         if (!*value) {
             break;
         }
-        g_settings.excluded.emplace_back(value.get());
+        // Stored lowercased, IsExcluded runs on every device on every refresh.
+        g_settings.excluded.push_back(ToLower(value.get()));
     }
 }
 
-std::wstring ToLower(std::wstring str) {
-    if (!str.empty()) {
-        CharLowerBuffW(&str[0], static_cast<DWORD>(str.size()));
-    }
-    return str;
-}
-
+// The patterns in g_settings.excluded are already lowercased.
 bool IsExcluded(const std::wstring& name) {
     if (g_settings.excluded.empty()) {
         return false;
     }
     std::wstring lowerName = ToLower(name);
     for (const auto& pattern : g_settings.excluded) {
-        if (lowerName.find(ToLower(pattern)) != std::wstring::npos) {
+        if (lowerName.find(pattern) != std::wstring::npos) {
             return true;
         }
     }
@@ -398,7 +410,13 @@ void SetDeviceHidden(const std::wstring& deviceId, bool hidden) {
 // ---------------------------------------------------------------------------
 
 // The size the shell expects, for the DPI of the monitor the taskbar is on.
-int GetTrayIconSize() {
+//
+// fromTaskbar reports whether the taskbar was actually found. The tool mod
+// process can be started before the shell is up, and the fallback value
+// reflects this thread's DPI context rather than the taskbar's monitor, so it
+// has to be retried later.
+int GetTrayIconSize(bool* fromTaskbar) {
+    *fromTaskbar = false;
     using GetDpiForWindow_t = UINT(WINAPI*)(HWND);
     using GetSystemMetricsForDpi_t = int(WINAPI*)(int, UINT);
 
@@ -421,6 +439,7 @@ int GetTrayIconSize() {
             if (dpi != 0) {
                 int size = pGetSystemMetricsForDpi(SM_CXSMICON, dpi);
                 if (size > 0) {
+                    *fromTaskbar = true;
                     return size;
                 }
             }
@@ -429,6 +448,18 @@ int GetTrayIconSize() {
 
     int size = GetSystemMetrics(SM_CXSMICON);
     return size > 0 ? size : 16;
+}
+
+// Returns whether the size changed.
+bool UpdateIconSize() {
+    bool fromTaskbar = false;
+    int size = GetTrayIconSize(&fromTaskbar);
+    g_iconSizeFromTaskbar = fromTaskbar;
+    if (size == g_iconSize) {
+        return false;
+    }
+    g_iconSize = size;
+    return true;
 }
 
 HICON ExtractIconFromSpec(std::wstring spec, int size) {
@@ -470,6 +501,9 @@ HICON ExtractIconFromSpec(std::wstring spec, int size) {
     }
 
     if (!icon) {
+        // A negative index is a resource id, which ExtractIconExW resolves as
+        // documented, so this also covers the mmres.dll,-3010 form the device
+        // icon paths use.
         HICON large = nullptr;
         HICON small = nullptr;
         if (ExtractIconExW(spec.c_str(), index, &large, &small, 1) != UINT_MAX) {
@@ -861,6 +895,27 @@ std::wstring MakeTooltip(const AudioDevice& device) {
 }
 
 void RefreshDevices() {
+    // The loops below hold iterators into g_trayIcons across blocking
+    // Shell_NotifyIconW calls, during which this thread keeps dispatching
+    // inbound sent messages. Re-entering would invalidate them.
+    if (g_refreshing) {
+        g_refreshPending = true;
+        return;
+    }
+    g_refreshing = true;
+
+    if (g_trayIconsLost) {
+        // The tray was re-created, so the shell already dropped our icons and
+        // there is nothing to delete.
+        g_trayIcons.clear();
+        g_trayIconsLost = false;
+    }
+
+    if (!g_iconSizeFromTaskbar) {
+        // The taskbar wasn't up when the size was last derived.
+        UpdateIconSize();
+    }
+
     std::vector<AudioDevice> devices;
     EnumerateDevices(devices);
 
@@ -935,6 +990,15 @@ void RefreshDevices() {
     g_devices = std::move(devices);
 
     PurgeStaleIcons();
+
+    g_refreshing = false;
+
+    if (g_refreshPending) {
+        g_refreshPending = false;
+        if (HWND hWnd = g_hWnd.load()) {
+            SetTimer(hWnd, kRefreshTimerId, 250, nullptr);
+        }
+    }
 }
 
 const AudioDevice* FindDeviceByTrayId(UINT trayId) {
@@ -1120,12 +1184,28 @@ HMENU BuildShownDevicesMenu(const std::vector<AudioDevice>& devices,
     return menu;
 }
 
+// An absolute path under System32. A bare file name would be resolved through
+// the process search path, which starts at the current directory, inherited
+// from windhawk.exe.
+std::wstring SystemPath(PCWSTR fileName) {
+    WCHAR directory[MAX_PATH];
+    UINT length = GetSystemDirectoryW(directory, ARRAYSIZE(directory));
+    if (length == 0 || length >= ARRAYSIZE(directory)) {
+        return fileName;
+    }
+    std::wstring path(directory, length);
+    path += L'\\';
+    path += fileName;
+    return path;
+}
+
 void OpenVolumeMixer() {
     // ms-settings:apps-volume only exists on Windows 10 1803 and newer.
     HINSTANCE result = ShellExecuteW(nullptr, L"open", L"ms-settings:apps-volume",
                                     nullptr, nullptr, SW_SHOWNORMAL);
     if (reinterpret_cast<INT_PTR>(result) <= 32) {
-        ShellExecuteW(nullptr, L"open", L"SndVol.exe", nullptr, nullptr, SW_SHOWNORMAL);
+        ShellExecuteW(nullptr, nullptr, SystemPath(L"SndVol.exe").c_str(), nullptr,
+                      nullptr, SW_SHOWNORMAL);
     }
 }
 
@@ -1209,17 +1289,25 @@ void ShowContextMenu(HWND hWnd,
             OpenVolumeMixer();
             break;
         case IDM_LEGACY_APPLET:
-            ShellExecuteW(nullptr, L"open", L"mmsys.cpl", nullptr, nullptr,
-                          SW_SHOWNORMAL);
+            // .cpl files register a "cplopen" verb and no "open" verb, so the
+            // default verb has to be used.
+            ShellExecuteW(nullptr, nullptr, SystemPath(L"mmsys.cpl").c_str(), nullptr,
+                          nullptr, SW_SHOWNORMAL);
             break;
     }
 }
 
 LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
     if (message == g_taskbarCreatedMessage && g_taskbarCreatedMessage) {
-        // The tray was re-created, our icons are gone with it.
-        RemoveAllTrayIcons(false);
-        RefreshDevices();
+        // The tray was re-created, our icons are gone with it. This is a sent
+        // message, so it can arrive while this thread is blocked inside
+        // Shell_NotifyIconW with an iterator into g_trayIcons alive: only set
+        // the flags here and do the work from the timer.
+        g_trayIconsLost = true;
+        // Also the point at which the taskbar is known to exist, so the icon
+        // size can finally be derived from its monitor.
+        UpdateIconSize();
+        SetTimer(hWnd, kRefreshTimerId, 250, nullptr);
         return 0;
     }
 
@@ -1240,7 +1328,9 @@ LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPara
                     }
                     break;
                 case WM_MBUTTONUP:
-                    SetDefaultDevice(device->id, true);
+                    if (!device->isDefaultComm) {
+                        SetDefaultDevice(device->id, true);
+                    }
                     break;
                 case WM_CONTEXTMENU:
                 case WM_RBUTTONUP: {
@@ -1281,17 +1371,16 @@ LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPara
             }
             break;
 
+        // WM_DPICHANGED only reaches per-monitor-DPI-aware windows, so in
+        // practice the other two do the work here.
         case WM_SETTINGCHANGE:
         case WM_DISPLAYCHANGE:
-        case WM_DPICHANGED: {
+        case WM_DPICHANGED:
             // These arrive often, only act when the icon size really changed.
-            int size = GetTrayIconSize();
-            if (size != g_iconSize) {
-                g_iconSize = size;
+            if (UpdateIconSize()) {
                 SetTimer(hWnd, kRefreshTimerId, 500, nullptr);
             }
             break;
-        }
 
         case WM_DESTROY:
             KillTimer(hWnd, kRefreshTimerId);
@@ -1314,7 +1403,7 @@ DWORD WINAPI ThreadProc(LPVOID) {
     }
 
     g_taskbarCreatedMessage = RegisterWindowMessageW(L"TaskbarCreated");
-    g_iconSize = GetTrayIconSize();
+    UpdateIconSize();
 
     LoadHiddenIds();
 
@@ -1381,8 +1470,10 @@ DWORD WINAPI ThreadProc(LPVOID) {
         g_enumerator = nullptr;
     }
 
-    g_hWnd.store(nullptr);
+    // Destroy first: WM_DESTROY removes the tray icons and needs g_hWnd to
+    // still be set to build the NOTIFYICONDATA.
     DestroyWindow(hWnd);
+    g_hWnd.store(nullptr);
     UnregisterClassW(kWindowClassName, wc.hInstance);
     ClearIconCache();
 

--- a/mods/taskbar-audio-device-switcher.wh.cpp
+++ b/mods/taskbar-audio-device-switcher.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-audio-device-switcher
 // @name            Taskbar audio device switcher
 // @description     Shows a tray icon for every connected audio device and switches the default device with a click
-// @version         1.4.0
+// @version         1.5.0
 // @author          Maksim Chingin
 // @github          https://github.com/umnik1
 // @include         windhawk.exe
@@ -51,7 +51,9 @@ choice is remembered across restarts. There is also **Hide this icon** for the
 device that was clicked, and **Show all devices** to undo everything.
 
 The icon of the last remaining device can't be hidden, otherwise there would be
-no menu left to bring the other ones back.
+no menu left to bring the other ones back. For the same reason, if every device
+that is currently connected happens to be hidden — say the only visible one was
+unplugged — the hidden ones are shown anyway until that changes.
 
 ## Windows 11 note
 
@@ -939,6 +941,25 @@ void RefreshDevices() {
 
     std::vector<AudioDevice> devices;
     EnumerateDevices(devices);
+
+    // The menu lives on the tray icons, so at least one device has to keep one,
+    // otherwise there is no way left to unhide anything. The menu already
+    // refuses to hide the last visible device, but that device can also just
+    // disappear afterwards, by being unplugged or switched off. Devices hidden
+    // through the setting stay hidden: that one is recoverable from the
+    // Windhawk settings, the manual list is not.
+    bool anyVisible = false;
+    for (const auto& device : devices) {
+        if (!device.hidden) {
+            anyVisible = true;
+            break;
+        }
+    }
+    if (!anyVisible) {
+        for (auto& device : devices) {
+            device.hidden = device.hiddenBySetting;
+        }
+    }
 
     // Remove the icons of devices which are gone or which were hidden.
     for (auto it = g_trayIcons.begin(); it != g_trayIcons.end();) {

--- a/mods/taskbar-audio-device-switcher.wh.cpp
+++ b/mods/taskbar-audio-device-switcher.wh.cpp
@@ -23,6 +23,12 @@ options.
 Each device uses its own icon, the one Windows shows in the sound settings, so
 headphones, speakers, HDMI output and a microphone are easy to tell apart.
 
+![Tray icons](https://raw.githubusercontent.com/umnik1/windhawk-mods/refs/heads/assets/taskbar-audio-device-switcher/tray-icons.png) \
+*Two playback devices: the default one is drawn normally, the other one dimmed*
+
+![Right click menu](https://raw.githubusercontent.com/umnik1/windhawk-mods/refs/heads/assets/taskbar-audio-device-switcher/context-menu.png) \
+*The right click menu of a device*
+
 ## How this differs from the other audio switching mods
 
 The catalog already has several mods for switching audio devices, but the

--- a/mods/taskbar-audio-device-switcher.wh.cpp
+++ b/mods/taskbar-audio-device-switcher.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-audio-device-switcher
 // @name            Taskbar audio device switcher
 // @description     Shows a tray icon for every connected audio device and switches the default device with a click
-// @version         1.3.0
+// @version         1.4.0
 // @author          Maksim Chingin
 // @github          https://github.com/umnik1
 // @include         windhawk.exe
@@ -256,18 +256,23 @@ HANDLE g_windowReadyEvent;
 // MMDevice notification threads.
 std::atomic<HWND> g_hWnd;
 UINT g_taskbarCreatedMessage;
+// Only ever written at startup and at the beginning of a refresh, never from a
+// message handler: PurgeStaleIcons relies on the size staying put for the whole
+// duration of a refresh, and the handlers which notice a size change can run
+// re-entrantly in the middle of one.
 int g_iconSize;
-// Whether g_iconSize could be derived from the taskbar's monitor, or whether
-// it is the less accurate fallback and should be retried.
-bool g_iconSizeFromTaskbar;
 
 // Shell_NotifyIconW blocks in a cross-process SendMessage, and a thread which
 // is blocked there keeps dispatching inbound sent messages. Nothing may touch
-// g_trayIcons from such a handler while the loops in RefreshDevices hold an
-// iterator into it, so the work is deferred through these flags instead.
+// g_trayIcons or g_iconSize from such a handler while a refresh is in flight,
+// so the work is deferred through these flags instead.
 bool g_refreshing;
 bool g_refreshPending;
 bool g_trayIconsLost;
+// Set when g_iconSize has to be re-derived at the start of the next refresh,
+// either because the taskbar wasn't up yet or because a broadcast suggests the
+// size changed.
+bool g_iconSizeStale;
 
 std::vector<AudioDevice> g_devices;  // all devices, hidden ones included
 std::unordered_map<std::wstring, TrayIcon> g_trayIcons;  // device id -> icon
@@ -450,16 +455,20 @@ int GetTrayIconSize(bool* fromTaskbar) {
     return size > 0 ? size : 16;
 }
 
-// Returns whether the size changed.
-bool UpdateIconSize() {
+// Stores the current size. Only to be called at startup and at the start of a
+// refresh, see g_iconSize.
+void UpdateIconSize() {
     bool fromTaskbar = false;
-    int size = GetTrayIconSize(&fromTaskbar);
-    g_iconSizeFromTaskbar = fromTaskbar;
-    if (size == g_iconSize) {
-        return false;
-    }
-    g_iconSize = size;
-    return true;
+    g_iconSize = GetTrayIconSize(&fromTaskbar);
+    // A fallback value has to be retried once the taskbar exists.
+    g_iconSizeStale = !fromTaskbar;
+}
+
+// Reads the size without storing it, so that this stays safe to call from a
+// message handler which may run in the middle of a refresh.
+bool IconSizeChanged() {
+    bool fromTaskbar = false;
+    return GetTrayIconSize(&fromTaskbar) != g_iconSize;
 }
 
 HICON ExtractIconFromSpec(std::wstring spec, int size) {
@@ -689,7 +698,17 @@ HICON GetDeviceIcon(const AudioDevice& device) {
 void PurgeStaleIcons() {
     std::wstring prefix = std::to_wstring(g_iconSize) + L"|";
     for (auto it = g_iconCache.begin(); it != g_iconCache.end();) {
-        if (it->first.compare(0, prefix.size(), prefix) != 0) {
+        // A handle the shell still displays must never be destroyed, whatever
+        // size it was built for. g_trayIcons tracks exactly what was handed
+        // over, so it is the authority here.
+        bool inUse = false;
+        for (const auto& entry : g_trayIcons) {
+            if (entry.second.icon == it->second) {
+                inUse = true;
+                break;
+            }
+        }
+        if (!inUse && it->first.compare(0, prefix.size(), prefix) != 0) {
             DestroyIcon(it->second);
             it = g_iconCache.erase(it);
         } else {
@@ -911,8 +930,10 @@ void RefreshDevices() {
         g_trayIconsLost = false;
     }
 
-    if (!g_iconSizeFromTaskbar) {
-        // The taskbar wasn't up when the size was last derived.
+    if (g_iconSizeStale) {
+        // Either the taskbar wasn't up when the size was last derived, or a
+        // broadcast reported a change. This is the only place the size is
+        // updated once running, so it stays fixed for the whole refresh.
         UpdateIconSize();
     }
 
@@ -982,7 +1003,13 @@ void RefreshDevices() {
             g_trayIcons[device.id] = std::move(state);
         } else {
             Shell_NotifyIconW(NIM_MODIFY, &nid);
-            it->second.icon = icon;
+            if (icon) {
+                it->second.icon = icon;
+            }
+            // Without NIF_ICON the shell keeps displaying the previous icon, so
+            // the recorded handle has to keep pointing at it — otherwise nothing
+            // holds a reference and PurgeStaleIcons would destroy a handle which
+            // is still on screen.
             it->second.tip = std::move(tip);
         }
     }
@@ -1305,8 +1332,9 @@ LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPara
         // the flags here and do the work from the timer.
         g_trayIconsLost = true;
         // Also the point at which the taskbar is known to exist, so the icon
-        // size can finally be derived from its monitor.
-        UpdateIconSize();
+        // size can finally be derived from its monitor. The refresh does it,
+        // this handler must not touch g_iconSize itself.
+        g_iconSizeStale = true;
         SetTimer(hWnd, kRefreshTimerId, 250, nullptr);
         return 0;
     }
@@ -1377,7 +1405,10 @@ LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPara
         case WM_DISPLAYCHANGE:
         case WM_DPICHANGED:
             // These arrive often, only act when the icon size really changed.
-            if (UpdateIconSize()) {
+            // The new size is picked up by the refresh, not stored here: this
+            // can run while a refresh is in flight.
+            if (IconSizeChanged()) {
+                g_iconSizeStale = true;
                 SetTimer(hWnd, kRefreshTimerId, 500, nullptr);
             }
             break;

--- a/mods/taskbar-audio-device-switcher.wh.cpp
+++ b/mods/taskbar-audio-device-switcher.wh.cpp
@@ -1,0 +1,1312 @@
+// ==WindhawkMod==
+// @id              taskbar-audio-device-switcher
+// @name            Taskbar audio device switcher
+// @description     Shows a tray icon for every connected audio device and switches the default device with a click
+// @version         1.1.0
+// @author          Maksim Chingin
+// @github          https://github.com/umnik1
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lole32 -loleaut32 -lshell32 -lgdi32 -luser32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Taskbar audio device switcher
+
+Adds one tray (notification area) icon per connected audio device. The icon of
+the device that is currently the default one is drawn normally, all the other
+ones are dimmed and grayed out. **Left click** on an icon makes that device the
+default playback/recording device, **right click** opens a menu with additional
+options.
+
+Each device uses its own icon, the one Windows shows in the sound settings, so
+headphones, speakers, HDMI output and a microphone are easy to tell apart.
+
+## Choosing which devices are shown
+
+The right click menu has a **Shown devices** submenu which lists every device,
+including the ones which are currently hidden, with a check mark next to the
+ones that have an icon. Clicking an entry shows or hides that device, and the
+choice is remembered across restarts. There is also **Hide this icon** for the
+device that was clicked, and **Show all devices** to undo everything.
+
+The icon of the last remaining device can't be hidden, otherwise there would be
+no menu left to bring the other ones back.
+
+## Windows 11 note
+
+New tray icons are hidden inside the overflow ("^") flyout by default. To make
+the audio device icons always visible, either drag them out of the flyout onto
+the taskbar, or go to
+*Settings → Personalization → Taskbar → Other system tray icons* and turn the
+relevant `explorer.exe` entries on.
+
+## Notes
+
+* Devices are refreshed automatically when a device is plugged in/out, enabled,
+  disabled, or when the default device changes from somewhere else.
+* Switching the default device uses the undocumented `IPolicyConfig` interface,
+  the same one used by nircmd, SoundSwitch and similar tools.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- showPlayback: true
+  $name: Playback devices
+  $description: Show an icon for every active playback (output) device
+- showRecording: false
+  $name: Recording devices
+  $description: Show an icon for every active recording (input) device
+- dimInactive: true
+  $name: Dim inactive devices
+  $description: >-
+    Draw the icons of the devices which are not the default one faded and
+    grayscale
+- setCommunications: true
+  $name: Switch the communications device too
+  $description: >-
+    On click, also set the device as the default communications device, and not
+    only as the default console/multimedia device
+- excludedDevices: [""]
+  $name: Always hidden devices
+  $description: >-
+    Devices whose name contains one of these strings are never shown, for
+    example: HDMI. Individual devices can also be hidden from the tray icon
+    right click menu, without touching this list.
+*/
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+#include <shellapi.h>
+#include <propsys.h>
+#include <mmdeviceapi.h>
+
+#include <cstring>
+#include <cwchar>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#ifndef NOTIFYICON_VERSION_4
+#define NOTIFYICON_VERSION_4 4
+#endif
+#ifndef NIF_SHOWTIP
+#define NIF_SHOWTIP 0x00000080
+#endif
+#ifndef NIN_SELECT
+#define NIN_SELECT (WM_USER + 0)
+#endif
+#ifndef NINF_KEY
+#define NINF_KEY 0x1
+#endif
+#ifndef NIN_KEYSELECT
+#define NIN_KEYSELECT (NIN_SELECT | NINF_KEY)
+#endif
+
+// ---------------------------------------------------------------------------
+// GUIDs and interfaces (declared locally so that no extra import libs and no
+// SDK-only headers are needed).
+// ---------------------------------------------------------------------------
+
+static const IID kIID_IUnknown = {
+    0x00000000, 0x0000, 0x0000, {0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46}};
+static const CLSID kCLSID_MMDeviceEnumerator = {
+    0xbcde0395, 0xe52f, 0x467c, {0x8e, 0x3d, 0xc4, 0x57, 0x92, 0x91, 0x69, 0x2e}};
+static const IID kIID_IMMDeviceEnumerator = {
+    0xa95664d2, 0x9614, 0x4f35, {0xa7, 0x46, 0xde, 0x8d, 0xb6, 0x36, 0x17, 0xe6}};
+static const IID kIID_IMMNotificationClient = {
+    0x7991eec9, 0x7e89, 0x4d85, {0x83, 0x90, 0x6c, 0x70, 0x3c, 0xec, 0x60, 0xc0}};
+static const CLSID kCLSID_PolicyConfigClient = {
+    0x870af99c, 0x171d, 0x4f9e, {0xaf, 0x0d, 0xe6, 0x3d, 0xf4, 0x0c, 0x2b, 0xc9}};
+static const IID kIID_IPolicyConfig = {
+    0xf8679f50, 0x850a, 0x41cf, {0x9c, 0x72, 0x43, 0x0f, 0x29, 0x02, 0x90, 0xc8}};
+static const IID kIID_IPolicyConfigVista = {
+    0x568b9108, 0x44bf, 0x40b4, {0x90, 0x06, 0x86, 0xaf, 0xe5, 0xb5, 0xa6, 0x20}};
+
+static const PROPERTYKEY kPKEY_Device_FriendlyName = {
+    {0xa45c254e, 0xdf1c, 0x4efd, {0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0}}, 14};
+static const PROPERTYKEY kPKEY_DeviceClass_IconPath = {
+    {0x259abffc, 0x50a7, 0x47ce, {0xaf, 0x08, 0x68, 0xc9, 0xa7, 0xd7, 0x33, 0x66}}, 12};
+
+struct DeviceShareModeOpaque;
+
+// The undocumented interface used by the sound applet to change the default
+// endpoint. Only SetDefaultEndpoint is called, the other methods are declared
+// just to keep the vtable layout correct.
+struct IPolicyConfig : public IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE GetMixFormat(PCWSTR, WAVEFORMATEX**) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetDeviceFormat(PCWSTR, INT, WAVEFORMATEX**) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ResetDeviceFormat(PCWSTR) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetDeviceFormat(PCWSTR, WAVEFORMATEX*, WAVEFORMATEX*) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetProcessingPeriod(PCWSTR, INT, PINT64, PINT64) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetProcessingPeriod(PCWSTR, PINT64) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetShareMode(PCWSTR, DeviceShareModeOpaque*) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetShareMode(PCWSTR, DeviceShareModeOpaque*) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetPropertyValue(PCWSTR, const PROPERTYKEY&, PROPVARIANT*) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetPropertyValue(PCWSTR, const PROPERTYKEY&, PROPVARIANT*) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetDefaultEndpoint(PCWSTR deviceId, ERole role) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetEndpointVisibility(PCWSTR, INT) = 0;
+};
+
+// The Vista variant, kept as a fallback. It has one method less before
+// SetDefaultEndpoint (no ResetDeviceFormat).
+struct IPolicyConfigVista : public IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE GetMixFormat(PCWSTR, WAVEFORMATEX**) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetDeviceFormat(PCWSTR, INT, WAVEFORMATEX**) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetDeviceFormat(PCWSTR, WAVEFORMATEX*, WAVEFORMATEX*) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetProcessingPeriod(PCWSTR, INT, PINT64, PINT64) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetProcessingPeriod(PCWSTR, PINT64) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetShareMode(PCWSTR, DeviceShareModeOpaque*) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetShareMode(PCWSTR, DeviceShareModeOpaque*) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetPropertyValue(PCWSTR, const PROPERTYKEY&, PROPVARIANT*) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetPropertyValue(PCWSTR, const PROPERTYKEY&, PROPVARIANT*) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetDefaultEndpoint(PCWSTR deviceId, ERole role) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetEndpointVisibility(PCWSTR, INT) = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Mod state
+// ---------------------------------------------------------------------------
+
+namespace {
+
+constexpr UINT WM_APP_TRAY = WM_APP + 1;
+constexpr UINT WM_APP_REFRESH = WM_APP + 2;
+constexpr UINT WM_APP_RELOAD_SETTINGS = WM_APP + 3;
+constexpr UINT_PTR kRefreshTimerId = 1;
+
+constexpr UINT IDM_SET_DEFAULT = 1;
+constexpr UINT IDM_SET_COMMUNICATIONS = 2;
+constexpr UINT IDM_SOUND_SETTINGS = 3;
+constexpr UINT IDM_VOLUME_MIXER = 4;
+constexpr UINT IDM_LEGACY_APPLET = 5;
+constexpr UINT IDM_HIDE_THIS = 6;
+constexpr UINT IDM_SHOW_ALL = 7;
+// One command per device, for the "Shown devices" submenu.
+constexpr UINT IDM_TOGGLE_FIRST = 100;
+
+// The name of the mod storage value holding the manually hidden device ids.
+constexpr PCWSTR kHiddenDevicesValueName = L"hiddenDevices";
+
+struct AudioDevice {
+    std::wstring id;
+    std::wstring name;
+    std::wstring iconPath;
+    EDataFlow flow = eRender;
+    bool isDefault = false;
+    bool isDefaultComm = false;
+    // Hidden through the tray menu, can be toggled back from there.
+    bool hidden = false;
+    // Hidden through the "Hidden devices" setting, can only be brought back by
+    // changing the setting.
+    bool hiddenBySetting = false;
+    UINT trayId = 0;
+};
+
+struct TrayIcon {
+    UINT trayId = 0;
+    HICON icon = nullptr;
+    std::wstring tip;
+};
+
+struct Settings {
+    bool showPlayback = true;
+    bool showRecording = false;
+    bool dimInactive = true;
+    bool setCommunications = true;
+    std::vector<std::wstring> excluded;
+};
+
+Settings g_settings;
+
+HANDLE g_thread;
+HANDLE g_windowReadyEvent;
+HWND g_hWnd;
+UINT g_taskbarCreatedMessage;
+
+std::vector<AudioDevice> g_devices;  // all devices, hidden ones included
+std::unordered_map<std::wstring, TrayIcon> g_trayIcons;  // device id -> icon
+std::vector<std::wstring> g_hiddenIds;
+
+using PrivateExtractIconsW_t = UINT(WINAPI*)(LPCWSTR, int, int, int, HICON*, UINT*, UINT, UINT);
+PrivateExtractIconsW_t g_pPrivateExtractIcons;
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+void LoadSettings() {
+    g_settings.showPlayback = Wh_GetIntSetting(L"showPlayback") != 0;
+    g_settings.showRecording = Wh_GetIntSetting(L"showRecording") != 0;
+    g_settings.dimInactive = Wh_GetIntSetting(L"dimInactive") != 0;
+    g_settings.setCommunications = Wh_GetIntSetting(L"setCommunications") != 0;
+
+    g_settings.excluded.clear();
+    for (int i = 0; i < 64; i++) {
+        PCWSTR value = Wh_GetStringSetting(L"excludedDevices[%d]", i);
+        bool empty = !value || !*value;
+        if (!empty) {
+            g_settings.excluded.emplace_back(value);
+        }
+        Wh_FreeStringSetting(value);
+        if (empty) {
+            break;
+        }
+    }
+}
+
+std::wstring ToLower(std::wstring str) {
+    if (!str.empty()) {
+        CharLowerBuffW(&str[0], static_cast<DWORD>(str.size()));
+    }
+    return str;
+}
+
+bool IsExcluded(const std::wstring& name) {
+    if (g_settings.excluded.empty()) {
+        return false;
+    }
+    std::wstring lowerName = ToLower(name);
+    for (const auto& pattern : g_settings.excluded) {
+        if (lowerName.find(ToLower(pattern)) != std::wstring::npos) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// The list of devices hidden through the tray menu. It lives in the mod
+// storage and not in the settings, because a mod can read its settings but not
+// write them.
+// ---------------------------------------------------------------------------
+
+void LoadHiddenIds() {
+    g_hiddenIds.clear();
+
+    // Device ids are about 55 characters long, so this is enough for hundreds
+    // of them.
+    std::vector<WCHAR> buffer(32768);
+    size_t length = Wh_GetStringValue(kHiddenDevicesValueName, buffer.data(),
+                                      buffer.size());
+    if (length == 0) {
+        return;
+    }
+
+    std::wstring stored(buffer.data(), length);
+    size_t start = 0;
+    while (start <= stored.size()) {
+        size_t end = stored.find(L'\n', start);
+        if (end == std::wstring::npos) {
+            end = stored.size();
+        }
+        if (end > start) {
+            g_hiddenIds.emplace_back(stored, start, end - start);
+        }
+        start = end + 1;
+    }
+}
+
+void SaveHiddenIds() {
+    if (g_hiddenIds.empty()) {
+        Wh_DeleteValue(kHiddenDevicesValueName);
+        return;
+    }
+
+    std::wstring joined;
+    for (const auto& id : g_hiddenIds) {
+        if (!joined.empty()) {
+            joined += L'\n';
+        }
+        joined += id;
+    }
+    Wh_SetStringValue(kHiddenDevicesValueName, joined.c_str());
+}
+
+bool IsHiddenById(const std::wstring& deviceId) {
+    for (const auto& id : g_hiddenIds) {
+        if (id == deviceId) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void SetDeviceHidden(const std::wstring& deviceId, bool hidden) {
+    bool changed = false;
+    if (hidden) {
+        if (!IsHiddenById(deviceId)) {
+            g_hiddenIds.push_back(deviceId);
+            changed = true;
+        }
+    } else {
+        for (auto it = g_hiddenIds.begin(); it != g_hiddenIds.end(); ++it) {
+            if (*it == deviceId) {
+                g_hiddenIds.erase(it);
+                changed = true;
+                break;
+            }
+        }
+    }
+    if (changed) {
+        SaveHiddenIds();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
+
+HICON ExtractIconFromSpec(std::wstring spec, int size) {
+    if (spec.empty()) {
+        return nullptr;
+    }
+
+    int index = 0;
+    size_t comma = spec.find_last_of(L',');
+    if (comma != std::wstring::npos) {
+        index = static_cast<int>(wcstol(spec.c_str() + comma + 1, nullptr, 10));
+        spec.resize(comma);
+    }
+
+    WCHAR expanded[MAX_PATH * 2];
+    if (ExpandEnvironmentStringsW(spec.c_str(), expanded, ARRAYSIZE(expanded))) {
+        spec = expanded;
+    }
+
+    HICON icon = nullptr;
+
+    if (g_pPrivateExtractIcons) {
+        UINT id = 0;
+        if (g_pPrivateExtractIcons(spec.c_str(), index, size, size, &icon, &id, 1,
+                                   LR_DEFAULTCOLOR) != 1) {
+            icon = nullptr;
+        }
+    }
+
+    if (!icon) {
+        HICON large = nullptr;
+        HICON small = nullptr;
+        if (ExtractIconExW(spec.c_str(), index, &large, &small, 1) != UINT_MAX) {
+            HICON source = small ? small : large;
+            if (source) {
+                icon = static_cast<HICON>(
+                    CopyImage(source, IMAGE_ICON, size, size, LR_DEFAULTCOLOR));
+            }
+        }
+        if (large) {
+            DestroyIcon(large);
+        }
+        if (small) {
+            DestroyIcon(small);
+        }
+    }
+
+    return icon;
+}
+
+HICON ExtractFallbackIcon(EDataFlow flow, int size) {
+    PCWSTR candidates[] = {
+        flow == eCapture ? L"%windir%\\system32\\mmres.dll,-3020"
+                         : L"%windir%\\system32\\mmres.dll,-3010",
+        L"%windir%\\system32\\SndVol.exe,0",
+        L"%windir%\\system32\\mmres.dll,0",
+    };
+    for (PCWSTR candidate : candidates) {
+        if (HICON icon = ExtractIconFromSpec(candidate, size)) {
+            return icon;
+        }
+    }
+    return nullptr;
+}
+
+// Returns a faded, mostly grayscale copy of the icon, or nullptr on failure.
+HICON MakeDimmedIcon(HICON source) {
+    ICONINFO info = {};
+    if (!GetIconInfo(source, &info)) {
+        return nullptr;
+    }
+
+    HICON result = nullptr;
+    HDC hdc = GetDC(nullptr);
+    BITMAP bitmap = {};
+
+    if (hdc && info.hbmColor && GetObjectW(info.hbmColor, sizeof(bitmap), &bitmap) &&
+        bitmap.bmWidth > 0 && bitmap.bmHeight > 0) {
+        const int width = bitmap.bmWidth;
+        const int height = bitmap.bmHeight;
+
+        BITMAPINFO bi = {};
+        bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+        bi.bmiHeader.biWidth = width;
+        bi.bmiHeader.biHeight = -height;  // top-down
+        bi.bmiHeader.biPlanes = 1;
+        bi.bmiHeader.biBitCount = 32;
+        bi.bmiHeader.biCompression = BI_RGB;
+
+        std::vector<DWORD> pixels(static_cast<size_t>(width) * height, 0);
+        if (GetDIBits(hdc, info.hbmColor, 0, height, pixels.data(), &bi, DIB_RGB_COLORS)) {
+            bool hasAlpha = false;
+            for (DWORD pixel : pixels) {
+                if ((pixel >> 24) != 0) {
+                    hasAlpha = true;
+                    break;
+                }
+            }
+
+            // Icons without an alpha channel: build one from the AND mask.
+            if (!hasAlpha && info.hbmMask) {
+                std::vector<DWORD> mask(pixels.size(), 0);
+                if (GetDIBits(hdc, info.hbmMask, 0, height, mask.data(), &bi,
+                              DIB_RGB_COLORS)) {
+                    for (size_t i = 0; i < pixels.size(); i++) {
+                        DWORD alpha = (mask[i] & 0x00FFFFFF) ? 0u : 0xFFu;
+                        pixels[i] = (pixels[i] & 0x00FFFFFF) | (alpha << 24);
+                    }
+                    hasAlpha = true;
+                }
+            }
+
+            if (hasAlpha) {
+                for (DWORD& pixel : pixels) {
+                    BYTE a = static_cast<BYTE>(pixel >> 24);
+                    BYTE r = static_cast<BYTE>(pixel >> 16);
+                    BYTE g = static_cast<BYTE>(pixel >> 8);
+                    BYTE b = static_cast<BYTE>(pixel);
+                    BYTE gray = static_cast<BYTE>((r * 77 + g * 151 + b * 28) >> 8);
+                    r = static_cast<BYTE>((r + gray * 3) / 4);
+                    g = static_cast<BYTE>((g + gray * 3) / 4);
+                    b = static_cast<BYTE>((b + gray * 3) / 4);
+                    a = static_cast<BYTE>(a * 45 / 100);
+                    pixel = (static_cast<DWORD>(a) << 24) | (static_cast<DWORD>(r) << 16) |
+                            (static_cast<DWORD>(g) << 8) | b;
+                }
+
+                void* bits = nullptr;
+                HBITMAP color = CreateDIBSection(hdc, &bi, DIB_RGB_COLORS, &bits, nullptr, 0);
+                if (color && bits) {
+                    memcpy(bits, pixels.data(), pixels.size() * sizeof(DWORD));
+
+                    // An all-zero AND mask, the alpha channel does the masking.
+                    std::vector<BYTE> maskBits(
+                        static_cast<size_t>(((width + 31) / 32) * 4) * height, 0);
+                    HBITMAP maskBitmap = CreateBitmap(width, height, 1, 1, maskBits.data());
+                    if (maskBitmap) {
+                        ICONINFO out = {};
+                        out.fIcon = TRUE;
+                        out.hbmColor = color;
+                        out.hbmMask = maskBitmap;
+                        result = CreateIconIndirect(&out);
+                        DeleteObject(maskBitmap);
+                    }
+                }
+                if (color) {
+                    DeleteObject(color);
+                }
+            }
+        }
+    }
+
+    if (hdc) {
+        ReleaseDC(nullptr, hdc);
+    }
+    if (info.hbmColor) {
+        DeleteObject(info.hbmColor);
+    }
+    if (info.hbmMask) {
+        DeleteObject(info.hbmMask);
+    }
+    return result;
+}
+
+HICON BuildDeviceIcon(const AudioDevice& device) {
+    int size = GetSystemMetrics(SM_CXSMICON);
+    if (size <= 0) {
+        size = 16;
+    }
+
+    HICON icon = ExtractIconFromSpec(device.iconPath, size);
+    if (!icon) {
+        icon = ExtractFallbackIcon(device.flow, size);
+    }
+    if (!icon) {
+        return nullptr;
+    }
+
+    if (g_settings.dimInactive && !device.isDefault) {
+        if (HICON dimmed = MakeDimmedIcon(icon)) {
+            DestroyIcon(icon);
+            icon = dimmed;
+        }
+    }
+
+    return icon;
+}
+
+// ---------------------------------------------------------------------------
+// Device enumeration
+// ---------------------------------------------------------------------------
+
+std::wstring GetDeviceId(IMMDevice* device) {
+    std::wstring result;
+    LPWSTR id = nullptr;
+    if (SUCCEEDED(device->GetId(&id)) && id) {
+        result = id;
+    }
+    if (id) {
+        CoTaskMemFree(id);
+    }
+    return result;
+}
+
+std::wstring GetStringProperty(IMMDevice* device, const PROPERTYKEY& key) {
+    std::wstring result;
+    IPropertyStore* store = nullptr;
+    if (SUCCEEDED(device->OpenPropertyStore(STGM_READ, &store)) && store) {
+        PROPVARIANT value;
+        PropVariantInit(&value);
+        if (SUCCEEDED(store->GetValue(key, &value)) && value.vt == VT_LPWSTR &&
+            value.pwszVal) {
+            result = value.pwszVal;
+        }
+        PropVariantClear(&value);
+        store->Release();
+    }
+    return result;
+}
+
+// A stable id derived from the device id, so that Windows remembers the "show
+// this icon on the taskbar" choice across sessions and reconnects. The tray
+// callback message of NOTIFYICON_VERSION_4 carries the id in the high word, so
+// it has to fit in 16 bits.
+UINT TrayIdForDevice(const std::wstring& deviceId) {
+    UINT hash = 2166136261u;
+    for (wchar_t c : deviceId) {
+        hash = (hash ^ static_cast<UINT>(c & 0xFF)) * 16777619u;
+        hash = (hash ^ static_cast<UINT>((c >> 8) & 0xFF)) * 16777619u;
+    }
+    hash = (hash ^ (hash >> 16)) & 0xFFFF;
+    return hash ? hash : 1;
+}
+
+void EnumerateDevices(std::vector<AudioDevice>& devices) {
+    IMMDeviceEnumerator* enumerator = nullptr;
+    if (FAILED(CoCreateInstance(kCLSID_MMDeviceEnumerator, nullptr, CLSCTX_ALL,
+                                kIID_IMMDeviceEnumerator,
+                                reinterpret_cast<void**>(&enumerator))) ||
+        !enumerator) {
+        Wh_Log(L"Failed to create the device enumerator");
+        return;
+    }
+
+    const struct {
+        EDataFlow flow;
+        bool enabled;
+    } flows[] = {
+        {eRender, g_settings.showPlayback},
+        {eCapture, g_settings.showRecording},
+    };
+
+    for (const auto& entry : flows) {
+        if (!entry.enabled) {
+            continue;
+        }
+
+        std::wstring defaultId;
+        std::wstring defaultCommId;
+        IMMDevice* defaultDevice = nullptr;
+        if (SUCCEEDED(enumerator->GetDefaultAudioEndpoint(entry.flow, eConsole,
+                                                          &defaultDevice)) &&
+            defaultDevice) {
+            defaultId = GetDeviceId(defaultDevice);
+            defaultDevice->Release();
+            defaultDevice = nullptr;
+        }
+        if (SUCCEEDED(enumerator->GetDefaultAudioEndpoint(entry.flow, eCommunications,
+                                                          &defaultDevice)) &&
+            defaultDevice) {
+            defaultCommId = GetDeviceId(defaultDevice);
+            defaultDevice->Release();
+            defaultDevice = nullptr;
+        }
+
+        IMMDeviceCollection* collection = nullptr;
+        if (FAILED(enumerator->EnumAudioEndpoints(entry.flow, DEVICE_STATE_ACTIVE,
+                                                  &collection)) ||
+            !collection) {
+            continue;
+        }
+
+        UINT count = 0;
+        collection->GetCount(&count);
+        for (UINT i = 0; i < count; i++) {
+            IMMDevice* device = nullptr;
+            if (FAILED(collection->Item(i, &device)) || !device) {
+                continue;
+            }
+
+            AudioDevice info;
+            info.id = GetDeviceId(device);
+            info.name = GetStringProperty(device, kPKEY_Device_FriendlyName);
+            info.iconPath = GetStringProperty(device, kPKEY_DeviceClass_IconPath);
+            info.flow = entry.flow;
+            info.isDefault = !info.id.empty() && info.id == defaultId;
+            info.isDefaultComm = !info.id.empty() && info.id == defaultCommId;
+            device->Release();
+
+            if (info.id.empty()) {
+                continue;
+            }
+            if (info.name.empty()) {
+                info.name = entry.flow == eCapture ? L"Recording device" : L"Playback device";
+            }
+
+            // Hidden devices stay in the list, they are only skipped when the
+            // tray icons are created. This way they can still be listed in the
+            // "Shown devices" submenu.
+            info.hiddenBySetting = IsExcluded(info.name);
+            info.hidden = info.hiddenBySetting || IsHiddenById(info.id);
+
+            info.trayId = TrayIdForDevice(info.id);
+            // 16 bits are not a lot, make sure two devices never share an id.
+            bool taken;
+            do {
+                taken = false;
+                for (const auto& other : devices) {
+                    if (other.trayId == info.trayId) {
+                        taken = true;
+                        info.trayId = (info.trayId % 0xFFFF) + 1;
+                        break;
+                    }
+                }
+            } while (taken);
+
+            devices.push_back(std::move(info));
+        }
+        collection->Release();
+    }
+
+    enumerator->Release();
+}
+
+// ---------------------------------------------------------------------------
+// Tray icons
+// ---------------------------------------------------------------------------
+
+void RemoveTrayIcon(UINT trayId) {
+    NOTIFYICONDATAW nid = {};
+    nid.cbSize = sizeof(nid);
+    nid.hWnd = g_hWnd;
+    nid.uID = trayId;
+    Shell_NotifyIconW(NIM_DELETE, &nid);
+}
+
+void RemoveAllTrayIcons(bool notifyShell) {
+    for (auto& entry : g_trayIcons) {
+        if (notifyShell) {
+            RemoveTrayIcon(entry.second.trayId);
+        }
+        if (entry.second.icon) {
+            DestroyIcon(entry.second.icon);
+        }
+    }
+    g_trayIcons.clear();
+}
+
+std::wstring MakeTooltip(const AudioDevice& device) {
+    std::wstring tip;
+    if (device.isDefault) {
+        tip += L"✔ ";  // heavy check mark
+    }
+    tip += device.name;
+    if (device.isDefault) {
+        tip += device.flow == eCapture ? L"\n(default recording device)"
+                                       : L"\n(default playback device)";
+    }
+    if (tip.size() > 127) {
+        tip.resize(127);
+    }
+    return tip;
+}
+
+void RefreshDevices() {
+    std::vector<AudioDevice> devices;
+    EnumerateDevices(devices);
+
+    // Remove the icons of devices which are gone or which were hidden.
+    for (auto it = g_trayIcons.begin(); it != g_trayIcons.end();) {
+        bool stillShown = false;
+        for (const auto& device : devices) {
+            if (device.id == it->first && !device.hidden) {
+                stillShown = true;
+                break;
+            }
+        }
+        if (stillShown) {
+            ++it;
+            continue;
+        }
+        RemoveTrayIcon(it->second.trayId);
+        if (it->second.icon) {
+            DestroyIcon(it->second.icon);
+        }
+        it = g_trayIcons.erase(it);
+    }
+
+    for (const auto& device : devices) {
+        if (device.hidden) {
+            continue;
+        }
+
+        HICON icon = BuildDeviceIcon(device);
+        std::wstring tip = MakeTooltip(device);
+
+        NOTIFYICONDATAW nid = {};
+        nid.cbSize = sizeof(nid);
+        nid.hWnd = g_hWnd;
+        nid.uID = device.trayId;
+        nid.uFlags = NIF_MESSAGE | NIF_TIP | NIF_SHOWTIP;
+        nid.uCallbackMessage = WM_APP_TRAY;
+        lstrcpynW(nid.szTip, tip.c_str(), ARRAYSIZE(nid.szTip));
+        if (icon) {
+            nid.uFlags |= NIF_ICON;
+            nid.hIcon = icon;
+        }
+
+        auto it = g_trayIcons.find(device.id);
+        if (it == g_trayIcons.end()) {
+            if (!Shell_NotifyIconW(NIM_ADD, &nid)) {
+                // A leftover icon from a previous session of the mod.
+                RemoveTrayIcon(device.trayId);
+                if (!Shell_NotifyIconW(NIM_ADD, &nid)) {
+                    Wh_Log(L"Failed to add a tray icon for %s", device.name.c_str());
+                    if (icon) {
+                        DestroyIcon(icon);
+                    }
+                    continue;
+                }
+            }
+
+            NOTIFYICONDATAW version = {};
+            version.cbSize = sizeof(version);
+            version.hWnd = g_hWnd;
+            version.uID = device.trayId;
+            version.uVersion = NOTIFYICON_VERSION_4;
+            Shell_NotifyIconW(NIM_SETVERSION, &version);
+
+            TrayIcon state;
+            state.trayId = device.trayId;
+            state.icon = icon;
+            state.tip = std::move(tip);
+            g_trayIcons[device.id] = std::move(state);
+        } else {
+            Shell_NotifyIconW(NIM_MODIFY, &nid);
+            if (it->second.icon) {
+                DestroyIcon(it->second.icon);
+            }
+            it->second.icon = icon;
+            it->second.tip = std::move(tip);
+        }
+    }
+
+    g_devices = std::move(devices);
+}
+
+const AudioDevice* FindDeviceByTrayId(UINT trayId) {
+    for (const auto& device : g_devices) {
+        if (device.trayId == trayId) {
+            return &device;
+        }
+    }
+    return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Switching the default device
+// ---------------------------------------------------------------------------
+
+void SetDefaultDevice(const std::wstring& deviceId, bool communicationsOnly) {
+    IPolicyConfig* config = nullptr;
+    HRESULT hr = CoCreateInstance(kCLSID_PolicyConfigClient, nullptr, CLSCTX_ALL,
+                                  kIID_IPolicyConfig, reinterpret_cast<void**>(&config));
+    if (SUCCEEDED(hr) && config) {
+        if (communicationsOnly) {
+            config->SetDefaultEndpoint(deviceId.c_str(), eCommunications);
+        } else {
+            config->SetDefaultEndpoint(deviceId.c_str(), eConsole);
+            config->SetDefaultEndpoint(deviceId.c_str(), eMultimedia);
+            if (g_settings.setCommunications) {
+                config->SetDefaultEndpoint(deviceId.c_str(), eCommunications);
+            }
+        }
+        config->Release();
+        return;
+    }
+
+    IPolicyConfigVista* vista = nullptr;
+    hr = CoCreateInstance(kCLSID_PolicyConfigClient, nullptr, CLSCTX_ALL,
+                          kIID_IPolicyConfigVista, reinterpret_cast<void**>(&vista));
+    if (SUCCEEDED(hr) && vista) {
+        if (communicationsOnly) {
+            vista->SetDefaultEndpoint(deviceId.c_str(), eCommunications);
+        } else {
+            vista->SetDefaultEndpoint(deviceId.c_str(), eConsole);
+            vista->SetDefaultEndpoint(deviceId.c_str(), eMultimedia);
+            if (g_settings.setCommunications) {
+                vista->SetDefaultEndpoint(deviceId.c_str(), eCommunications);
+            }
+        }
+        vista->Release();
+        return;
+    }
+
+    Wh_Log(L"Failed to create the policy config client, hr=0x%08X",
+           static_cast<unsigned>(hr));
+}
+
+// ---------------------------------------------------------------------------
+// Device change notifications
+// ---------------------------------------------------------------------------
+
+class NotificationClient final : public IMMNotificationClient {
+   public:
+    virtual ~NotificationClient() = default;
+
+    // IUnknown
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppv) override {
+        if (!ppv) {
+            return E_POINTER;
+        }
+        if (IsEqualGUID(riid, kIID_IUnknown) ||
+            IsEqualGUID(riid, kIID_IMMNotificationClient)) {
+            *ppv = static_cast<IMMNotificationClient*>(this);
+            AddRef();
+            return S_OK;
+        }
+        *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
+
+    ULONG STDMETHODCALLTYPE AddRef() override {
+        return InterlockedIncrement(&m_refCount);
+    }
+
+    ULONG STDMETHODCALLTYPE Release() override {
+        LONG count = InterlockedDecrement(&m_refCount);
+        if (count == 0) {
+            delete this;
+        }
+        return count;
+    }
+
+    // IMMNotificationClient
+    HRESULT STDMETHODCALLTYPE OnDeviceStateChanged(LPCWSTR, DWORD) override {
+        NotifyChanged();
+        return S_OK;
+    }
+    HRESULT STDMETHODCALLTYPE OnDeviceAdded(LPCWSTR) override {
+        NotifyChanged();
+        return S_OK;
+    }
+    HRESULT STDMETHODCALLTYPE OnDeviceRemoved(LPCWSTR) override {
+        NotifyChanged();
+        return S_OK;
+    }
+    HRESULT STDMETHODCALLTYPE OnDefaultDeviceChanged(EDataFlow, ERole, LPCWSTR) override {
+        NotifyChanged();
+        return S_OK;
+    }
+    HRESULT STDMETHODCALLTYPE OnPropertyValueChanged(LPCWSTR, const PROPERTYKEY) override {
+        NotifyChanged();
+        return S_OK;
+    }
+
+   private:
+    void NotifyChanged() {
+        if (g_hWnd) {
+            PostMessageW(g_hWnd, WM_APP_REFRESH, 0, 0);
+        }
+    }
+
+    LONG m_refCount = 1;
+};
+
+// ---------------------------------------------------------------------------
+// Window
+// ---------------------------------------------------------------------------
+
+// The submenu which lets the user pick which devices get a tray icon. It lists
+// every device, the hidden ones included, since a hidden device has no icon of
+// its own to right click on.
+HMENU BuildShownDevicesMenu(const std::vector<AudioDevice>& devices,
+                            size_t visibleCount) {
+    HMENU menu = CreatePopupMenu();
+    if (!menu) {
+        return nullptr;
+    }
+
+    bool anyHidden = false;
+    for (size_t i = 0; i < devices.size(); i++) {
+        const AudioDevice& device = devices[i];
+        UINT flags = MF_STRING;
+        if (!device.hidden) {
+            flags |= MF_CHECKED;
+            // Never let the user hide the last icon, it would leave no way
+            // back to this menu.
+            if (visibleCount <= 1) {
+                flags |= MF_GRAYED;
+            }
+        } else {
+            anyHidden = true;
+            // Devices filtered out by the "Hidden devices" setting can't be
+            // brought back from here.
+            if (device.hiddenBySetting) {
+                flags |= MF_GRAYED;
+            }
+        }
+
+        std::wstring text = device.name;
+        if (device.flow == eCapture) {
+            text += L" — microphone";
+        }
+        if (device.hiddenBySetting) {
+            text += L" — hidden by the settings";
+        }
+
+        AppendMenuW(menu, flags, IDM_TOGGLE_FIRST + static_cast<UINT_PTR>(i),
+                    text.c_str());
+    }
+
+    if (anyHidden) {
+        AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
+        AppendMenuW(menu, MF_STRING, IDM_SHOW_ALL, L"Show all devices");
+    }
+
+    return menu;
+}
+
+void ShowContextMenu(HWND hWnd,
+                     const std::vector<AudioDevice>& devices,
+                     size_t clickedIndex,
+                     int x,
+                     int y) {
+    if (clickedIndex >= devices.size()) {
+        return;
+    }
+    const AudioDevice& device = devices[clickedIndex];
+
+    HMENU menu = CreatePopupMenu();
+    if (!menu) {
+        return;
+    }
+
+    size_t visibleCount = 0;
+    for (const auto& other : devices) {
+        if (!other.hidden) {
+            visibleCount++;
+        }
+    }
+
+    AppendMenuW(menu, MF_STRING | MF_GRAYED, 0, device.name.c_str());
+    AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
+    AppendMenuW(menu, MF_STRING | (device.isDefault ? MF_CHECKED : 0), IDM_SET_DEFAULT,
+                L"Use as the default device");
+    AppendMenuW(menu, MF_STRING | (device.isDefaultComm ? MF_CHECKED : 0),
+                IDM_SET_COMMUNICATIONS, L"Use as the communications device");
+    AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
+
+    HMENU shownDevicesMenu = BuildShownDevicesMenu(devices, visibleCount);
+    if (shownDevicesMenu) {
+        AppendMenuW(menu, MF_POPUP, reinterpret_cast<UINT_PTR>(shownDevicesMenu),
+                    L"Shown devices");
+    }
+    AppendMenuW(menu, MF_STRING | (visibleCount <= 1 ? MF_GRAYED : 0), IDM_HIDE_THIS,
+                L"Hide this icon");
+    AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
+    AppendMenuW(menu, MF_STRING, IDM_SOUND_SETTINGS, L"Sound settings");
+    AppendMenuW(menu, MF_STRING, IDM_VOLUME_MIXER, L"Volume mixer");
+    AppendMenuW(menu, MF_STRING, IDM_LEGACY_APPLET, L"Sound control panel");
+
+    SetForegroundWindow(hWnd);
+    UINT command = TrackPopupMenu(menu, TPM_RETURNCMD | TPM_NONOTIFY | TPM_RIGHTBUTTON, x,
+                                  y, 0, hWnd, nullptr);
+    PostMessageW(hWnd, WM_NULL, 0, 0);
+    DestroyMenu(menu);  // destroys the submenu as well
+
+    if (command >= IDM_TOGGLE_FIRST &&
+        command < IDM_TOGGLE_FIRST + devices.size()) {
+        const AudioDevice& toggled = devices[command - IDM_TOGGLE_FIRST];
+        SetDeviceHidden(toggled.id, !toggled.hidden);
+        RefreshDevices();
+        return;
+    }
+
+    switch (command) {
+        case IDM_SET_DEFAULT:
+            SetDefaultDevice(device.id, false);
+            break;
+        case IDM_SET_COMMUNICATIONS:
+            SetDefaultDevice(device.id, true);
+            break;
+        case IDM_HIDE_THIS:
+            SetDeviceHidden(device.id, true);
+            RefreshDevices();
+            break;
+        case IDM_SHOW_ALL:
+            g_hiddenIds.clear();
+            SaveHiddenIds();
+            RefreshDevices();
+            break;
+        case IDM_SOUND_SETTINGS:
+            ShellExecuteW(nullptr, L"open", L"ms-settings:sound", nullptr, nullptr,
+                          SW_SHOWNORMAL);
+            break;
+        case IDM_VOLUME_MIXER:
+            ShellExecuteW(nullptr, L"open", L"ms-settings:apps-volume", nullptr, nullptr,
+                          SW_SHOWNORMAL);
+            break;
+        case IDM_LEGACY_APPLET:
+            ShellExecuteW(nullptr, L"open", L"rundll32.exe",
+                          L"shell32.dll,Control_RunDLL mmsys.cpl", nullptr, SW_SHOWNORMAL);
+            break;
+    }
+}
+
+LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
+    if (message == g_taskbarCreatedMessage && g_taskbarCreatedMessage) {
+        // The tray was re-created, our icons are gone with it.
+        RemoveAllTrayIcons(false);
+        RefreshDevices();
+        return 0;
+    }
+
+    switch (message) {
+        case WM_APP_TRAY: {
+            UINT event = LOWORD(lParam);
+            UINT trayId = HIWORD(lParam);
+            const AudioDevice* device = FindDeviceByTrayId(trayId);
+            if (!device) {
+                return 0;
+            }
+            switch (event) {
+                case NIN_SELECT:
+                case NIN_KEYSELECT:
+                case WM_LBUTTONUP:
+                    if (!device->isDefault) {
+                        SetDefaultDevice(device->id, false);
+                    }
+                    break;
+                case WM_MBUTTONUP:
+                    SetDefaultDevice(device->id, true);
+                    break;
+                case WM_CONTEXTMENU:
+                case WM_RBUTTONUP: {
+                    // The menu runs its own message loop, during which
+                    // g_devices can be rebuilt, so work on a snapshot.
+                    std::vector<AudioDevice> snapshot = g_devices;
+                    size_t clickedIndex = snapshot.size();
+                    for (size_t i = 0; i < snapshot.size(); i++) {
+                        if (snapshot[i].trayId == trayId) {
+                            clickedIndex = i;
+                            break;
+                        }
+                    }
+                    ShowContextMenu(hWnd, snapshot, clickedIndex,
+                                    static_cast<short>(LOWORD(wParam)),
+                                    static_cast<short>(HIWORD(wParam)));
+                    break;
+                }
+            }
+            return 0;
+        }
+
+        case WM_APP_REFRESH:
+            // Coalesce the bursts of notifications a device change produces.
+            SetTimer(hWnd, kRefreshTimerId, 250, nullptr);
+            return 0;
+
+        case WM_APP_RELOAD_SETTINGS:
+            LoadSettings();
+            RemoveAllTrayIcons(true);
+            RefreshDevices();
+            return 0;
+
+        case WM_TIMER:
+            if (wParam == kRefreshTimerId) {
+                KillTimer(hWnd, kRefreshTimerId);
+                RefreshDevices();
+                return 0;
+            }
+            break;
+
+        case WM_SETTINGCHANGE:
+        case WM_DISPLAYCHANGE:
+        case WM_DPICHANGED:
+            SetTimer(hWnd, kRefreshTimerId, 500, nullptr);
+            break;
+
+        case WM_DESTROY:
+            KillTimer(hWnd, kRefreshTimerId);
+            RemoveAllTrayIcons(true);
+            PostQuitMessage(0);
+            return 0;
+    }
+
+    return DefWindowProcW(hWnd, message, wParam, lParam);
+}
+
+constexpr PCWSTR kWindowClassName = L"WindhawkTaskbarAudioDeviceSwitcher";
+
+DWORD WINAPI ThreadProc(LPVOID) {
+    HRESULT comInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+
+    if (HMODULE user32 = GetModuleHandleW(L"user32.dll")) {
+        g_pPrivateExtractIcons = reinterpret_cast<PrivateExtractIconsW_t>(
+            GetProcAddress(user32, "PrivateExtractIconsW"));
+    }
+
+    g_taskbarCreatedMessage = RegisterWindowMessageW(L"TaskbarCreated");
+
+    LoadHiddenIds();
+
+    WNDCLASSEXW wc = {};
+    wc.cbSize = sizeof(wc);
+    wc.lpfnWndProc = WindowProc;
+    wc.hInstance = GetModuleHandleW(nullptr);
+    wc.lpszClassName = kWindowClassName;
+    ATOM atom = RegisterClassExW(&wc);
+    if (!atom && GetLastError() == ERROR_CLASS_ALREADY_EXISTS) {
+        // Left over from a previous instance of the mod, its window procedure
+        // points into an unloaded module.
+        UnregisterClassW(kWindowClassName, wc.hInstance);
+        atom = RegisterClassExW(&wc);
+    }
+    if (!atom) {
+        Wh_Log(L"RegisterClassExW failed, error %u", GetLastError());
+        SetEvent(g_windowReadyEvent);
+        if (SUCCEEDED(comInit)) {
+            CoUninitialize();
+        }
+        return 1;
+    }
+
+    HWND hWnd = CreateWindowExW(WS_EX_TOOLWINDOW, kWindowClassName, L"", WS_POPUP, 0, 0, 0,
+                                0, nullptr, nullptr, wc.hInstance, nullptr);
+    if (!hWnd) {
+        Wh_Log(L"CreateWindowExW failed, error %u", GetLastError());
+        UnregisterClassW(kWindowClassName, wc.hInstance);
+        SetEvent(g_windowReadyEvent);
+        if (SUCCEEDED(comInit)) {
+            CoUninitialize();
+        }
+        return 1;
+    }
+
+    g_hWnd = hWnd;
+    SetEvent(g_windowReadyEvent);
+
+    IMMDeviceEnumerator* enumerator = nullptr;
+    NotificationClient* client = nullptr;
+    if (SUCCEEDED(CoCreateInstance(kCLSID_MMDeviceEnumerator, nullptr, CLSCTX_ALL,
+                                   kIID_IMMDeviceEnumerator,
+                                   reinterpret_cast<void**>(&enumerator))) &&
+        enumerator) {
+        client = new NotificationClient();
+        if (FAILED(enumerator->RegisterEndpointNotificationCallback(client))) {
+            client->Release();
+            client = nullptr;
+            Wh_Log(L"Failed to register the endpoint notification callback");
+        }
+    }
+
+    RefreshDevices();
+
+    MSG msg;
+    BOOL result;
+    while ((result = GetMessageW(&msg, nullptr, 0, 0)) != 0) {
+        if (result == -1) {
+            break;
+        }
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    if (enumerator) {
+        if (client) {
+            enumerator->UnregisterEndpointNotificationCallback(client);
+            client->Release();
+        }
+        enumerator->Release();
+    }
+
+    g_hWnd = nullptr;
+    DestroyWindow(hWnd);
+    UnregisterClassW(kWindowClassName, wc.hInstance);
+
+    if (SUCCEEDED(comInit)) {
+        CoUninitialize();
+    }
+    return 0;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Windhawk entry points
+// ---------------------------------------------------------------------------
+
+BOOL Wh_ModInit() {
+    Wh_Log(L">");
+
+    LoadSettings();
+
+    g_windowReadyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (!g_windowReadyEvent) {
+        return FALSE;
+    }
+
+    g_thread = CreateThread(nullptr, 0, ThreadProc, nullptr, 0, nullptr);
+    if (!g_thread) {
+        CloseHandle(g_windowReadyEvent);
+        g_windowReadyEvent = nullptr;
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L">");
+
+    if (g_hWnd) {
+        PostMessageW(g_hWnd, WM_APP_RELOAD_SETTINGS, 0, 0);
+    }
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L">");
+
+    if (g_windowReadyEvent) {
+        WaitForSingleObject(g_windowReadyEvent, 5000);
+    }
+
+    HWND hWnd = g_hWnd;
+    if (hWnd) {
+        PostMessageW(hWnd, WM_CLOSE, 0, 0);
+    }
+
+    if (g_thread) {
+        if (WaitForSingleObject(g_thread, 5000) == WAIT_TIMEOUT) {
+            Wh_Log(L"The mod thread did not exit in time");
+        }
+        CloseHandle(g_thread);
+        g_thread = nullptr;
+    }
+
+    if (g_windowReadyEvent) {
+        CloseHandle(g_windowReadyEvent);
+        g_windowReadyEvent = nullptr;
+    }
+}


### PR DESCRIPTION
Adds `mods/taskbar-audio-device-switcher.wh.cpp`, a new mod.

The mod adds one tray icon per connected audio device, using the icon of the device itself (`PKEY_DeviceClass_IconPath`), so headphones, speakers, an HDMI output and a microphone are easy to tell apart. The icon of the current default device is drawn normally, the other ones are faded and grayscale.

* **Left click** — make the device the default one (console + multimedia, optionally communications).
* **Middle click** — set it as the communications device.
* **Right click** — a menu with the default/communications device options, a **Shown devices** submenu to pick which devices get an icon, and shortcuts to the sound settings, the volume mixer and `mmsys.cpl`.

The list of devices is kept up to date through `IMMNotificationClient`, so plugging a device in or out, enabling/disabling it, or changing the default device elsewhere is picked up automatically. Switching the default device is done with the undocumented `IPolicyConfig` interface, with a fallback to the Vista variant.

Devices hidden from the tray menu are stored in the mod storage rather than in the settings, since a mod can only read its settings. Tray icon ids are derived from the device id, so the Windows 11 "show this icon on the taskbar" choice survives restarts and reconnects.

The mod hooks nothing — it only runs its own hidden window and message loop in a thread inside `explorer.exe`, and cleans up its window, class, icons and COM references in `Wh_ModUninit`.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* New mod, no changelog.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
