### PR TITLE
24-bit Icons v1.0

### DIFF
--- a/mods/24-bit-icons.wh.cpp
+++ b/mods/24-bit-icons.wh.cpp
@@ -153,6 +153,49 @@ HBITMAP __fastcall BitmapFromDIB_hook(
     return BitmapFromDIB_orig(cxNew, cyNew, bPlanesNew, bBitsPixelNew, LR_flags, cxOld, cyOld, lpBits, cbBits, lpbi, hpal);
 }
 
+#ifdef _WIN64
+HBITMAP (__fastcall *BitmapFromDIB_11_orig)(int, int, WORD, WORD, UINT, int, int, LPSTR, DWORD, LPBITMAPINFO, HPALETTE);
+HBITMAP __fastcall BitmapFromDIB_11_hook(
+    int          cxNew,
+    int          cyNew,
+    WORD         bPlanesNew,
+    WORD         bBitsPixelNew,
+    UINT         LR_flags,
+    int          cxOld,
+    int          cyOld,
+    LPSTR        lpBits,
+    DWORD        cbBits,
+    LPBITMAPINFO lpbi,
+    HPALETTE     hpal)
+#else
+HBITMAP (__fastcall *BitmapFromDIB_11_orig)(int, int, WORD, WORD, UINT, int, int, LPSTR, DWORD, LPBITMAPINFO, LPBITMAPINFO, HPALETTE);
+HBITMAP __fastcall BitmapFromDIB_11_hook(
+    int          cxNew,
+    int          cyNew,
+    WORD         bPlanesNew,
+    WORD         bBitsPixelNew,
+    UINT         LR_flags,
+    int          cxOld,
+    int          cyOld,
+    LPSTR        lpBits,
+    DWORD        cbBits,
+    LPBITMAPINFO lpbi,
+    LPBITMAPINFO unused,
+    HPALETTE     hpal)
+#endif
+{
+    if (g_fIcon && bBitsPixelNew == 32)
+    {
+        bBitsPixelNew = 24;
+        LR_flags &= ~(LR_CREATEREALDIB);
+    }
+#ifdef _WIN64
+    return BitmapFromDIB_11_orig(cxNew, cyNew, bPlanesNew, bBitsPixelNew, LR_flags, cxOld, cyOld, lpBits, cbBits, lpbi, hpal);
+#else
+    return BitmapFromDIB_11_orig(cxNew, cyNew, bPlanesNew, bBitsPixelNew, LR_flags, cxOld, cyOld, lpBits, cbBits, lpbi, unused, hpal);
+#endif
+}
+
 BOOL Wh_ModInit()
 {
     Wh_Log(L"Init");
@@ -176,16 +219,6 @@ BOOL Wh_ModInit()
         },
         {
             {
-                L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct HPALETTE__ *)",
-                // Extra parameter in Windows 11 32-bit is not used
-                L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct tagBITMAPINFO *,struct HPALETTE__ *)"
-            },
-            &BitmapFromDIB_orig,
-            BitmapFromDIB_hook,
-            false
-        },
-        {
-            {
                 L"struct HICON__ * " SSTDCALL " ConvertDIBIcon(struct tagBITMAPINFOHEADER *,unsigned long,struct HINSTANCE__ *,unsigned short const *,int,unsigned long,unsigned long,unsigned int)",
             },
             &ConvertDIBIcon_orig,
@@ -194,10 +227,42 @@ BOOL Wh_ModInit()
         }
     };
 
+    // user32.dll
+    const WindhawkUtils::SYMBOL_HOOK user32_10_DllHook
+    {
+        {
+            L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct HPALETTE__ *)"
+        },
+        &BitmapFromDIB_orig,
+        BitmapFromDIB_hook,
+        false
+    };
+
+    // user32.dll
+    const WindhawkUtils::SYMBOL_HOOK user32_11_DllHook
+    {
+        {
+            L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct HPALETTE__ *)",
+            L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct tagBITMAPINFO *,struct HPALETTE__ *)"
+        },
+        &BitmapFromDIB_11_orig,
+        BitmapFromDIB_11_hook,
+        false
+    };
+
     if (!WindhawkUtils::HookSymbols(hUser32, user32DllHooks, ARRAYSIZE(user32DllHooks)))
     {
         Wh_Log(L"Failed to hook user32.dll");
         return FALSE;
+    }
+
+    if (!WindhawkUtils::HookSymbols(hUser32, &user32_10_DllHook, 1))
+    {
+        if (!WindhawkUtils::HookSymbols(hUser32, &user32_11_DllHook, 1))
+        {
+            Wh_Log(L"Failed to hook function BitmapFromDIB");
+            return FALSE;
+        }
     }
 
     return TRUE;

--- a/mods/24-bit-icons.wh.cpp
+++ b/mods/24-bit-icons.wh.cpp
@@ -34,6 +34,23 @@ Forces 24-bit icons like Windows 2000 and before.
 
 #define LR_CREATEREALDIB 0x0800 
 
+typedef struct tagICONDIR
+{
+    BYTE  Width;
+    BYTE  Height;
+    BYTE  ColorCount;
+    BYTE  reserved;
+} ICONDIR;
+
+typedef struct tagRESDIR
+{
+    ICONDIR Icon;
+    WORD    Planes;
+    WORD    BitCount;
+    DWORD   BytesInRes;
+    WORD    idIcon;
+} RESDIR, *LPRESDIR;
+
 thread_local bool g_fIcon = false;
 
 bool IsExplorerProcess() {
@@ -79,11 +96,12 @@ void InvalidateIconCache()
     }
 }
 
-DWORD (__thiscall *GetIcoCurBpp_orig)(UINT);
-DWORD __thiscall GetIcoCurBpp_hook(UINT LR_flags)
+UINT (__fastcall *GetBestImage_orig)(LPRESDIR, UINT, int, int, UINT, BOOL);
+UINT __fastcall GetBestImage_hook(LPRESDIR lprd, UINT uCount, int cxDesired, int cyDesired, UINT bppDesired, BOOL fIcon)
 {
-    DWORD curBpp = GetIcoCurBpp_orig(LR_flags);
-    return curBpp ? curBpp : 8;
+    if (lprd->Icon.ColorCount == 16)
+        bppDesired = 8;
+    return GetBestImage_orig(lprd, uCount, cxDesired, cyDesired, bppDesired, fIcon);
 }
 
 HICON (__fastcall *ConvertDIBIcon_orig)(
@@ -160,10 +178,10 @@ BOOL Wh_ModInit()
     {
         {
             {
-                L"unsigned long " SSTDCALL L" GetIcoCurBpp(unsigned int)",
+                L"unsigned int " SSTDCALL " GetBestImage(struct tagRESDIR *,unsigned int,int,int,unsigned int,int)"
             },
-            &GetIcoCurBpp_orig,
-            GetIcoCurBpp_hook,
+            &GetBestImage_orig,
+            GetBestImage_hook,
             false
         },
         {

--- a/mods/24-bit-icons.wh.cpp
+++ b/mods/24-bit-icons.wh.cpp
@@ -1,0 +1,204 @@
+// ==WindhawkMod==
+// @id              24-bit-icons
+// @name            24-bit Icons
+// @description     Forces 24-bit icons like Windows 2000 and before
+// @version         1.0
+// @author          xalejandro
+// @github          https://github.com/tetawaves
+// @include         *
+// @compilerOptions -lgdi32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# 24-bit Icons
+Forces 24-bit icons like Windows 2000 and before.  
+![Before / After](https://i.imgur.com/Gl5ykd6.png)
+## Notes
+* Icons that are already 24-bit or lower are never touched.
+* Icons stored as PNG are left alone.
+* Windows caches icons, so already running programs keep their old icons until they are restarted.
+*/
+// ==/WindhawkModReadme==
+
+#include <windhawk_utils.h>
+#include <shlobj.h>
+
+#ifdef _WIN64
+#   define STDCALL  __cdecl
+#   define SSTDCALL L"__cdecl"
+#else
+#   define STDCALL  __stdcall
+#   define SSTDCALL L"__stdcall"
+#endif
+
+#define LR_CREATEREALDIB 0x0800 
+
+thread_local bool g_fIcon = false;
+
+bool IsExplorerProcess() {
+    WCHAR path[MAX_PATH];
+    if (!GetWindowsDirectory(path, ARRAYSIZE(path))) {
+        Wh_Log(L"GetWindowsDirectory failed");
+        return false;
+    }
+
+    wcscat_s(path, MAX_PATH, L"\\explorer.exe");
+
+    return GetModuleHandle(path) == GetModuleHandle(nullptr);
+}
+
+HWND FindCurrentProcessTaskbarWnd() 
+{
+    HWND hTaskbarWnd = nullptr;
+
+    EnumWindows(
+        [](HWND hWnd, LPARAM lParam) WINAPI -> BOOL {
+            DWORD dwProcessId;
+            WCHAR className[32];
+            if (GetWindowThreadProcessId(hWnd, &dwProcessId) &&
+                dwProcessId == GetCurrentProcessId() &&
+                GetClassName(hWnd, className, ARRAYSIZE(className)) &&
+                _wcsicmp(className, L"Shell_TrayWnd") == 0) {
+                *reinterpret_cast<HWND*>(lParam) = hWnd;
+                return FALSE;
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&hTaskbarWnd));
+
+    return hTaskbarWnd;
+}
+
+void InvalidateIconCache() 
+{
+    if (IsExplorerProcess() && FindCurrentProcessTaskbarWnd())
+    {
+        Sleep(400);
+        SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
+    }
+}
+
+DWORD (__thiscall *GetIcoCurBpp_orig)(UINT);
+DWORD __thiscall GetIcoCurBpp_hook(UINT LR_flags)
+{
+    DWORD curBpp = GetIcoCurBpp_orig(LR_flags);
+    return curBpp ? curBpp : 8;
+}
+
+HICON (__fastcall *ConvertDIBIcon_orig)(
+    LPBITMAPINFOHEADER lpbih,
+    unsigned int       a2,
+    HINSTANCE          hmod,
+    LPCWSTR            lpName,
+    BOOL               fIcon,
+    DWORD              cxNew,
+    DWORD              cyNew,
+    UINT               LR_flags);
+HICON __fastcall ConvertDIBIcon_hook(
+    LPBITMAPINFOHEADER lpbih,
+    unsigned int       a2,
+    HINSTANCE          hmod,
+    LPCWSTR            lpName,
+    BOOL               fIcon,
+    DWORD              cxNew,
+    DWORD              cyNew,
+    UINT               LR_flags)
+{
+    g_fIcon = fIcon;
+    HICON hIcon = ConvertDIBIcon_orig(lpbih, a2, hmod, lpName, fIcon, cxNew, cyNew, LR_flags);
+    g_fIcon = false;
+    return hIcon;
+}
+
+HBITMAP (__fastcall *BitmapFromDIB_orig)(int, int, WORD, WORD, UINT, int, int, LPSTR, DWORD, LPBITMAPINFO, HPALETTE);
+HBITMAP __fastcall BitmapFromDIB_hook(
+    int          cxNew,
+    int          cyNew,
+    WORD         bPlanesNew,
+    WORD         bBitsPixelNew,
+    UINT         LR_flags,
+    int          cxOld,
+    int          cyOld,
+    LPSTR        lpBits,
+    DWORD        cbBits,
+    LPBITMAPINFO lpbi,
+    HPALETTE     hpal)
+{
+    if (g_fIcon && bBitsPixelNew == 32)
+    {
+        bBitsPixelNew = 24;
+        LR_flags &= ~(LR_CREATEREALDIB);
+    }
+    return BitmapFromDIB_orig(cxNew, cyNew, bPlanesNew, bBitsPixelNew, LR_flags, cxOld, cyOld, lpBits, cbBits, lpbi, hpal);
+}
+
+using GetDeviceCaps_t = decltype(&GetDeviceCaps);
+GetDeviceCaps_t GetDeviceCaps_orig;
+int WINAPI GetDeviceCaps_hook(HDC hdc, int index)
+ {
+    int result = GetDeviceCaps_orig(hdc, index);
+    if (index == BITSPIXEL) 
+    {
+        result = 24;
+    }
+    return result;
+}
+
+BOOL Wh_ModInit()
+{
+    Wh_Log(L"Init");
+
+    HMODULE hUser32 = LoadLibraryExW(L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!hUser32)
+    {
+        Wh_Log(L"Failed to load user32.dll");
+        return FALSE;
+    }
+
+    const WindhawkUtils::SYMBOL_HOOK user32DllHooks[] =
+    {
+        {
+            {
+                L"unsigned long " SSTDCALL L" GetIcoCurBpp(unsigned int)",
+            },
+            &GetIcoCurBpp_orig,
+            GetIcoCurBpp_hook,
+            false
+        },
+        {
+            {
+                L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct HPALETTE__ *)"
+            },
+            &BitmapFromDIB_orig,
+            BitmapFromDIB_hook,
+            false
+        },
+        {
+            {
+                L"struct HICON__ * " SSTDCALL " ConvertDIBIcon(struct tagBITMAPINFOHEADER *,unsigned long,struct HINSTANCE__ *,unsigned short const *,int,unsigned long,unsigned long,unsigned int)"
+            },
+            &ConvertDIBIcon_orig,
+            ConvertDIBIcon_hook,
+            false
+        }
+    };
+
+    if (!WindhawkUtils::HookSymbols(hUser32, user32DllHooks, ARRAYSIZE(user32DllHooks)))
+    {
+        Wh_Log(L"Failed to hook user32.dll");
+        return FALSE;
+    }
+
+    Wh_SetFunctionHook((void*)GetDeviceCaps, (void*)GetDeviceCaps_hook,
+                       (void**)&GetDeviceCaps_orig);
+
+    InvalidateIconCache();
+
+    return TRUE;
+}
+
+void Wh_ModUninit()
+{
+    InvalidateIconCache();
+}

--- a/mods/24-bit-icons.wh.cpp
+++ b/mods/24-bit-icons.wh.cpp
@@ -227,7 +227,7 @@ BOOL Wh_ModInit()
         }
     };
 
-    const WindhawkUtils::SYMBOL_HOOK user32_10_DllHook
+    const WindhawkUtils::SYMBOL_HOOK user32DllHook_10
     {
         {
             L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct HPALETTE__ *)"
@@ -237,7 +237,7 @@ BOOL Wh_ModInit()
         false
     };
 
-    const WindhawkUtils::SYMBOL_HOOK user32_11_DllHook
+    const WindhawkUtils::SYMBOL_HOOK user32DllHook_11
     {
         {
             L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct HPALETTE__ *)",
@@ -254,9 +254,9 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
-    if (!WindhawkUtils::HookSymbols(hUser32, &user32_10_DllHook, 1))
+    if (!WindhawkUtils::HookSymbols(hUser32, &user32DllHook_10, 1))
     {
-        if (!WindhawkUtils::HookSymbols(hUser32, &user32_11_DllHook, 1))
+        if (!WindhawkUtils::HookSymbols(hUser32, &user32DllHook_11, 1))
         {
             Wh_Log(L"Failed to hook function BitmapFromDIB");
             return FALSE;

--- a/mods/24-bit-icons.wh.cpp
+++ b/mods/24-bit-icons.wh.cpp
@@ -227,7 +227,8 @@ BOOL Wh_ModInit()
         }
     };
 
-    const WindhawkUtils::SYMBOL_HOOK user32DllHook_10
+    // user32.dll
+    const WindhawkUtils::SYMBOL_HOOK bitmapFromDibHook_10
     {
         {
             L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct HPALETTE__ *)"
@@ -236,8 +237,8 @@ BOOL Wh_ModInit()
         BitmapFromDIB_hook,
         false
     };
-
-    const WindhawkUtils::SYMBOL_HOOK user32DllHook_11
+    // user32.dll
+    const WindhawkUtils::SYMBOL_HOOK bitmapFromDibHook_11
     {
         {
             L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct HPALETTE__ *)",
@@ -254,9 +255,9 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
-    if (!WindhawkUtils::HookSymbols(hUser32, &user32DllHook_10, 1))
+    if (!WindhawkUtils::HookSymbols(hUser32, &bitmapFromDibHook_10, 1))
     {
-        if (!WindhawkUtils::HookSymbols(hUser32, &user32DllHook_11, 1))
+        if (!WindhawkUtils::HookSymbols(hUser32, &bitmapFromDibHook_11, 1))
         {
             Wh_Log(L"Failed to hook function BitmapFromDIB");
             return FALSE;

--- a/mods/24-bit-icons.wh.cpp
+++ b/mods/24-bit-icons.wh.cpp
@@ -227,7 +227,6 @@ BOOL Wh_ModInit()
         }
     };
 
-    // user32.dll
     const WindhawkUtils::SYMBOL_HOOK user32_10_DllHook
     {
         {
@@ -238,7 +237,6 @@ BOOL Wh_ModInit()
         false
     };
 
-    // user32.dll
     const WindhawkUtils::SYMBOL_HOOK user32_11_DllHook
     {
         {

--- a/mods/24-bit-icons.wh.cpp
+++ b/mods/24-bit-icons.wh.cpp
@@ -6,7 +6,6 @@
 // @author          xalejandro
 // @github          https://github.com/tetawaves
 // @include         *
-// @compilerOptions -lgdi32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -91,7 +90,6 @@ void InvalidateIconCache()
 {
     if (IsExplorerProcess() && FindCurrentProcessTaskbarWnd())
     {
-        Sleep(400);
         SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
     }
 }
@@ -99,8 +97,12 @@ void InvalidateIconCache()
 UINT (__fastcall *GetBestImage_orig)(LPRESDIR, UINT, int, int, UINT, BOOL);
 UINT __fastcall GetBestImage_hook(LPRESDIR lprd, UINT uCount, int cxDesired, int cyDesired, UINT bppDesired, BOOL fIcon)
 {
-    if (lprd->Icon.ColorCount == 16)
-        bppDesired = 8;
+    if (fIcon)
+    {
+        if (lprd->Icon.ColorCount == 16)
+            // bppDesired equal to 8 will get the 24-bit icon
+            bppDesired = 8;
+    }
     return GetBestImage_orig(lprd, uCount, cxDesired, cyDesired, bppDesired, fIcon);
 }
 
@@ -151,18 +153,6 @@ HBITMAP __fastcall BitmapFromDIB_hook(
     return BitmapFromDIB_orig(cxNew, cyNew, bPlanesNew, bBitsPixelNew, LR_flags, cxOld, cyOld, lpBits, cbBits, lpbi, hpal);
 }
 
-using GetDeviceCaps_t = decltype(&GetDeviceCaps);
-GetDeviceCaps_t GetDeviceCaps_orig;
-int WINAPI GetDeviceCaps_hook(HDC hdc, int index)
- {
-    int result = GetDeviceCaps_orig(hdc, index);
-    if (index == BITSPIXEL) 
-    {
-        result = 24;
-    }
-    return result;
-}
-
 BOOL Wh_ModInit()
 {
     Wh_Log(L"Init");
@@ -178,7 +168,7 @@ BOOL Wh_ModInit()
     {
         {
             {
-                L"unsigned int " SSTDCALL " GetBestImage(struct tagRESDIR *,unsigned int,int,int,unsigned int,int)"
+                L"unsigned int " SSTDCALL " GetBestImage(struct tagRESDIR *,unsigned int,int,int,unsigned int,int)",
             },
             &GetBestImage_orig,
             GetBestImage_hook,
@@ -186,7 +176,9 @@ BOOL Wh_ModInit()
         },
         {
             {
-                L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct HPALETTE__ *)"
+                L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct HPALETTE__ *)",
+                // Extra parameter in Windows 11 32-bit is not used
+                L"struct HBITMAP__ * " SSTDCALL " BitmapFromDIB(int,int,unsigned short,unsigned short,unsigned int,int,int,char *,unsigned long,struct tagBITMAPINFO *,struct tagBITMAPINFO *,struct HPALETTE__ *)"
             },
             &BitmapFromDIB_orig,
             BitmapFromDIB_hook,
@@ -194,7 +186,7 @@ BOOL Wh_ModInit()
         },
         {
             {
-                L"struct HICON__ * " SSTDCALL " ConvertDIBIcon(struct tagBITMAPINFOHEADER *,unsigned long,struct HINSTANCE__ *,unsigned short const *,int,unsigned long,unsigned long,unsigned int)"
+                L"struct HICON__ * " SSTDCALL " ConvertDIBIcon(struct tagBITMAPINFOHEADER *,unsigned long,struct HINSTANCE__ *,unsigned short const *,int,unsigned long,unsigned long,unsigned int)",
             },
             &ConvertDIBIcon_orig,
             ConvertDIBIcon_hook,
@@ -208,12 +200,12 @@ BOOL Wh_ModInit()
         return FALSE;
     }
 
-    Wh_SetFunctionHook((void*)GetDeviceCaps, (void*)GetDeviceCaps_hook,
-                       (void**)&GetDeviceCaps_orig);
-
-    InvalidateIconCache();
-
     return TRUE;
+}
+
+void Wh_ModAfterInit()
+{
+    InvalidateIconCache();
 }
 
 void Wh_ModUninit()


### PR DESCRIPTION
Forces 24-bit icons like Windows 2000 and before.
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [x] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 