### PR TITLE
Add CJK Spacer mod

### DIFF
--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.10
+// @version         0.1.11
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -130,11 +130,9 @@ Rewritten strings are recorded and restored when the popup closes.
 
 #include <winrt/base.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
-#include <winrt/Microsoft.UI.Xaml.Media.h>
 #include <winrt/Microsoft.UI.Xaml.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.h>
 
 namespace {
@@ -1041,7 +1039,9 @@ HTHEME WINAPI OpenThemeDataForDpiHook(HWND window,
 }
 
 HRESULT WINAPI CloseThemeDataHook(HTHEME theme) {
-    UntrackClassicTooltipTheme(theme);
+    if (g_classicTooltipThemeCount.load(std::memory_order_relaxed) != 0) {
+        UntrackClassicTooltipTheme(theme);
+    }
     return g_originalCloseThemeData(theme);
 }
 
@@ -1340,14 +1340,16 @@ struct TooltipContentAccess {
             return false;
         }
 
-        try {
-            const auto value =
-                winrt::unbox_value<winrt::hstring>(content);
-            text->assign(value.c_str(), value.size());
-            return true;
-        } catch (const winrt::hresult_error&) {
+        const auto propertyValue =
+            content.template try_as<wf::IPropertyValue>();
+        if (!propertyValue ||
+            propertyValue.Type() != wf::PropertyType::String) {
             return false;
         }
+
+        const auto value = propertyValue.GetString();
+        text->assign(value.c_str(), value.size());
+        return true;
     }
 
     template <typename Element>
@@ -1384,7 +1386,7 @@ public:
 
         try {
             auto element = m_element.get();
-            if (!element || !element.IsLoaded()) {
+            if (!element) {
                 return;
             }
 
@@ -1505,13 +1507,11 @@ using ModernTextStateMap =
                        std::shared_ptr<ModernTextStateBase>,
                        ModernElementKeyHash>;
 
-[[clang::no_destroy]] thread_local
-    std::optional<ModernTextStateMap>
-        g_modernTextStatesForThread{std::in_place};
+thread_local std::optional<ModernTextStateMap>
+    g_modernTextStatesForThread{std::in_place};
 
 std::mutex g_modernTextStateThreadsMutex;
-[[clang::no_destroy]] std::unordered_set<DWORD>
-    g_modernTextStateThreads;
+std::unordered_set<DWORD> g_modernTextStateThreads;
 
 void RegisterModernTextStateThread() {
     std::lock_guard<std::mutex> guard(
@@ -1753,14 +1753,17 @@ class WindhawkTap
 public:
     HRESULT STDMETHODCALLTYPE SetSite(IUnknown* site) override try {
         m_site.copy_from(site);
-        if (!site || g_stoppingModernUi.load(
-                         std::memory_order_relaxed)) {
+        if (!site) {
             return S_OK;
         }
 
         // Balance the reference added when XAML Diagnostics loads this module.
         if (HMODULE module = GetCurrentModuleHandle()) {
             FreeLibrary(module);
+        }
+
+        if (g_stoppingModernUi.load(std::memory_order_relaxed)) {
+            return S_OK;
         }
 
         auto watcher =
@@ -1855,6 +1858,7 @@ using InitializeXamlDiagnosticsEx_t =
     decltype(&InitializeXamlDiagnosticsEx);
 
 std::mutex g_xamlDiagnosticsInitializationMutex;
+std::mutex g_xamlDiagnosticsWorkerMutex;
 bool g_windowsUiXamlDiagnosticsConnected;
 bool g_microsoftUiXamlDiagnosticsConnected;
 HANDLE g_xamlDiagnosticsWakeEvent;
@@ -1942,11 +1946,12 @@ void EnsureModernXamlDiagnostics() {
     }
 }
 
-DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID) {
+DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
+    const HANDLE wakeEvent = static_cast<HANDLE>(parameter);
     const HRESULT initializeResult =
         CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-    while (WaitForSingleObject(
-               g_xamlDiagnosticsWakeEvent, INFINITE) == WAIT_OBJECT_0) {
+    while (WaitForSingleObject(wakeEvent, INFINITE) ==
+           WAIT_OBJECT_0) {
         if (g_stopXamlDiagnosticsWorker.load(
                 std::memory_order_relaxed)) {
             break;
@@ -1963,24 +1968,31 @@ DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID) {
 bool StartXamlDiagnosticsWorker() {
     g_stopXamlDiagnosticsWorker.store(
         false, std::memory_order_relaxed);
-    g_xamlDiagnosticsWakeEvent =
+    const HANDLE wakeEvent =
         CreateEventW(nullptr, FALSE, FALSE, nullptr);
-    if (!g_xamlDiagnosticsWakeEvent) {
+    if (!wakeEvent) {
         return false;
     }
 
-    g_xamlDiagnosticsWorkerThread = CreateThread(
-        nullptr, 0, XamlDiagnosticsWorkerProc, nullptr, 0, nullptr);
-    if (!g_xamlDiagnosticsWorkerThread) {
-        CloseHandle(g_xamlDiagnosticsWakeEvent);
-        g_xamlDiagnosticsWakeEvent = nullptr;
+    const HANDLE workerThread = CreateThread(
+        nullptr, 0, XamlDiagnosticsWorkerProc, wakeEvent, 0, nullptr);
+    if (!workerThread) {
+        CloseHandle(wakeEvent);
         return false;
     }
 
+    {
+        std::lock_guard<std::mutex> guard(
+            g_xamlDiagnosticsWorkerMutex);
+        g_xamlDiagnosticsWakeEvent = wakeEvent;
+        g_xamlDiagnosticsWorkerThread = workerThread;
+    }
     return true;
 }
 
 void RequestXamlDiagnosticsInitialization() {
+    std::lock_guard<std::mutex> guard(
+        g_xamlDiagnosticsWorkerMutex);
     if (!g_xamlDiagnosticsWakeEvent ||
         g_stoppingModernUi.load(std::memory_order_relaxed)) {
         return;
@@ -2000,18 +2012,27 @@ void RequestXamlDiagnosticsInitialization() {
 }
 
 void StopXamlDiagnosticsWorker() {
-    if (!g_xamlDiagnosticsWorkerThread) {
-        return;
+    HANDLE workerThread;
+    HANDLE wakeEvent;
+    {
+        std::lock_guard<std::mutex> guard(
+            g_xamlDiagnosticsWorkerMutex);
+        workerThread = g_xamlDiagnosticsWorkerThread;
+        wakeEvent = g_xamlDiagnosticsWakeEvent;
+        if (!workerThread) {
+            return;
+        }
+
+        g_xamlDiagnosticsWorkerThread = nullptr;
+        g_xamlDiagnosticsWakeEvent = nullptr;
+        g_stopXamlDiagnosticsWorker.store(
+            true, std::memory_order_relaxed);
+        SetEvent(wakeEvent);
     }
 
-    g_stopXamlDiagnosticsWorker.store(
-        true, std::memory_order_relaxed);
-    SetEvent(g_xamlDiagnosticsWakeEvent);
-    WaitForSingleObject(g_xamlDiagnosticsWorkerThread, INFINITE);
-    CloseHandle(g_xamlDiagnosticsWorkerThread);
-    CloseHandle(g_xamlDiagnosticsWakeEvent);
-    g_xamlDiagnosticsWorkerThread = nullptr;
-    g_xamlDiagnosticsWakeEvent = nullptr;
+    WaitForSingleObject(workerThread, INFINITE);
+    CloseHandle(workerThread);
+    CloseHandle(wakeEvent);
 }
 
 void CALLBACK ModernPopupWinEventProc(
@@ -2065,7 +2086,7 @@ bool RunFromWindowThread(HWND window,
                          RunFromWindowThreadProc_t procedure,
                          PVOID parameter) {
     static const UINT message = RegisterWindowMessageW(
-        L"Windhawk_RunFromWindowThread_CJKSpacer");
+        L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
 
     struct RunParameter {
         RunFromWindowThreadProc_t procedure;
@@ -2193,9 +2214,8 @@ void UninitializeModernUi() {
                     CleanupModernTextStatesForCurrentThread();
                 },
                 nullptr)) {
-            // The thread-local state is deliberately no_destroy. If its UI
-            // thread can't be reached, retaining weak references is safer than
-            // releasing thread-affine XAML objects from this thread.
+            // Don't call Restore from the wrong thread. The state contains
+            // weak references only and is released when its UI thread exits.
             Wh_Log(L"Leaving modern XAML state for unreachable thread %u",
                    threadId);
         }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.14
+// @version         0.1.15
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer menus and tooltips
-// @version         0.1.1
+// @version         0.1.2
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -49,6 +49,9 @@ keyboard shortcut text are also preserved.
 - Classic Win32 popup menus are rewritten through public `HMENU` APIs. This
   includes File Explorer, desktop, taskbar, tray, and jump-list menus hosted by
   `explorer.exe`.
+- Classic Win32 tooltips, including legacy notification-area icon tooltips, are
+  rewritten only through theme handles opened for the `TOOLTIP` class, covering
+  both text measurement and drawing without touching unrelated GDI text.
 - Windows 11 context menus and XAML/WinUI tooltips use an experimental,
   display-only DirectWrite hook. UI Automation is used when a popup is shown to
   distinguish menus and tooltips from other Explorer flyouts.
@@ -70,6 +73,9 @@ strings after the mod is disabled until Explorer restarts.
 - classicMenus: true
   $name: Classic context menus
   $description: Process classic Win32 popup-menu text.
+- classicTooltips: true
+  $name: Classic Win32 tooltips
+  $description: Process text in legacy tooltips such as notification-area icon tooltips.
 - modernUiText: true
   $name: Windows 11 menus and tooltips (experimental)
   $description: Process DirectWrite text in Explorer XAML/WinUI context menus and tooltips.
@@ -92,6 +98,7 @@ strings after the mod is disabled until Explorer restarts.
 #include <dwrite.h>
 #include <initguid.h>
 #include <uiautomation.h>
+#include <uxtheme.h>
 #include <windows.h>
 
 namespace {
@@ -104,6 +111,7 @@ enum class CharacterKind {
 };
 
 std::atomic_bool g_classicMenus{true};
+std::atomic_bool g_classicTooltips{true};
 std::atomic_bool g_modernUiText{true};
 std::atomic_bool g_unicodeLettersAndDigits{true};
 std::atomic_uint g_activeModernPopupCount{0};
@@ -539,6 +547,221 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU menu,
     }
 
     return g_originalTrackPopupMenuEx(menu, flags, x, y, owner, parameters);
+}
+
+// -------------------------------------------------------------------------
+// Classic Win32 tooltips
+// -------------------------------------------------------------------------
+
+using OpenThemeData_t = decltype(&OpenThemeData);
+using OpenThemeDataEx_t = decltype(&OpenThemeDataEx);
+using OpenThemeDataForDpi_t = decltype(&OpenThemeDataForDpi);
+using CloseThemeData_t = decltype(&CloseThemeData);
+using DrawThemeText_t = decltype(&DrawThemeText);
+using DrawThemeTextEx_t = decltype(&DrawThemeTextEx);
+
+OpenThemeData_t g_originalOpenThemeData;
+OpenThemeDataEx_t g_originalOpenThemeDataEx;
+OpenThemeDataForDpi_t g_originalOpenThemeDataForDpi;
+CloseThemeData_t g_originalCloseThemeData;
+DrawThemeText_t g_originalDrawThemeText;
+DrawThemeTextEx_t g_originalDrawThemeTextEx;
+
+constexpr size_t kClassicTooltipThemeCapacity = 16;
+std::atomic<HTHEME>
+    g_classicTooltipThemes[kClassicTooltipThemeCapacity] = {};
+thread_local bool g_rewritingClassicTooltipText = false;
+
+bool IsClassicTooltipThemeClassList(LPCWSTR classList) {
+    if (!classList) {
+        return false;
+    }
+
+    constexpr wchar_t needle[] = L"tooltip";
+    constexpr size_t needleLength = ARRAYSIZE(needle) - 1;
+    for (const wchar_t* cursor = classList; *cursor; ++cursor) {
+        if (_wcsnicmp(cursor, needle, needleLength) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool IsTrackedClassicTooltipTheme(HTHEME theme) {
+    if (!theme) {
+        return false;
+    }
+
+    for (auto& trackedTheme : g_classicTooltipThemes) {
+        if (trackedTheme.load(std::memory_order_relaxed) == theme) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void TrackClassicTooltipTheme(HTHEME theme) {
+    if (!theme || IsTrackedClassicTooltipTheme(theme)) {
+        return;
+    }
+
+    for (auto& trackedTheme : g_classicTooltipThemes) {
+        HTHEME empty = nullptr;
+        if (trackedTheme.compare_exchange_strong(
+                empty, theme, std::memory_order_relaxed)) {
+            Wh_Log(L"Tracking classic Win32 tooltip theme");
+            return;
+        }
+    }
+
+    Wh_Log(L"Classic tooltip theme tracking capacity reached");
+}
+
+void UntrackClassicTooltipTheme(HTHEME theme) {
+    if (!theme) {
+        return;
+    }
+
+    for (auto& trackedTheme : g_classicTooltipThemes) {
+        HTHEME expected = theme;
+        trackedTheme.compare_exchange_strong(
+            expected, nullptr, std::memory_order_relaxed);
+    }
+}
+
+HTHEME WINAPI OpenThemeDataHook(HWND window, LPCWSTR classList) {
+    HTHEME theme = g_originalOpenThemeData(window, classList);
+    if (IsClassicTooltipThemeClassList(classList)) {
+        TrackClassicTooltipTheme(theme);
+    }
+
+    return theme;
+}
+
+HTHEME WINAPI OpenThemeDataExHook(HWND window,
+                                  LPCWSTR classList,
+                                  DWORD flags) {
+    HTHEME theme =
+        g_originalOpenThemeDataEx(window, classList, flags);
+    if (IsClassicTooltipThemeClassList(classList)) {
+        TrackClassicTooltipTheme(theme);
+    }
+
+    return theme;
+}
+
+HTHEME WINAPI OpenThemeDataForDpiHook(HWND window,
+                                      LPCWSTR classList,
+                                      UINT dpi) {
+    HTHEME theme =
+        g_originalOpenThemeDataForDpi(window, classList, dpi);
+    if (IsClassicTooltipThemeClassList(classList)) {
+        TrackClassicTooltipTheme(theme);
+    }
+
+    return theme;
+}
+
+HRESULT WINAPI CloseThemeDataHook(HTHEME theme) {
+    UntrackClassicTooltipTheme(theme);
+    return g_originalCloseThemeData(theme);
+}
+
+bool BuildSpacedClassicTooltipText(LPCWSTR text,
+                                   int textLength,
+                                   DWORD textFlags,
+                                   std::wstring* spaced) {
+    if (!text || textLength < -1) {
+        return false;
+    }
+
+    const size_t length =
+        textLength < 0 ? wcslen(text)
+                       : static_cast<size_t>(textLength);
+    if (length == 0) {
+        return false;
+    }
+
+    const std::wstring_view original(text, length);
+    if (!ContainsCjkCodePoint(original)) {
+        return false;
+    }
+
+    const bool preserveMnemonics = !(textFlags & DT_NOPREFIX);
+    *spaced = AddCjkSpacing(original, preserveMnemonics);
+    return spaced->size() != original.size();
+}
+
+HRESULT WINAPI DrawThemeTextHook(HTHEME theme,
+                                 HDC dc,
+                                 int partId,
+                                 int stateId,
+                                 LPCWSTR text,
+                                 int textLength,
+                                 DWORD textFlags,
+                                 DWORD textFlags2,
+                                 LPCRECT rectangle) {
+    if (!g_classicTooltips.load(std::memory_order_relaxed) ||
+        g_rewritingClassicTooltipText ||
+        !IsTrackedClassicTooltipTheme(theme)) {
+        return g_originalDrawThemeText(
+            theme, dc, partId, stateId, text, textLength, textFlags,
+            textFlags2, rectangle);
+    }
+
+    std::wstring spaced;
+    if (!BuildSpacedClassicTooltipText(
+            text, textLength, textFlags, &spaced)) {
+        return g_originalDrawThemeText(
+            theme, dc, partId, stateId, text, textLength, textFlags,
+            textFlags2, rectangle);
+    }
+
+    Wh_Log(L"Applied CJK spacing (classic tooltip/DrawThemeText)");
+    g_rewritingClassicTooltipText = true;
+    const HRESULT result = g_originalDrawThemeText(
+        theme, dc, partId, stateId, spaced.c_str(),
+        static_cast<int>(spaced.size()), textFlags, textFlags2,
+        rectangle);
+    g_rewritingClassicTooltipText = false;
+    return result;
+}
+
+HRESULT WINAPI DrawThemeTextExHook(HTHEME theme,
+                                   HDC dc,
+                                   int partId,
+                                   int stateId,
+                                   LPCWSTR text,
+                                   int textLength,
+                                   DWORD textFlags,
+                                   LPRECT rectangle,
+                                   const DTTOPTS* options) {
+    if (!g_classicTooltips.load(std::memory_order_relaxed) ||
+        g_rewritingClassicTooltipText ||
+        !IsTrackedClassicTooltipTheme(theme)) {
+        return g_originalDrawThemeTextEx(
+            theme, dc, partId, stateId, text, textLength, textFlags,
+            rectangle, options);
+    }
+
+    std::wstring spaced;
+    if (!BuildSpacedClassicTooltipText(
+            text, textLength, textFlags, &spaced)) {
+        return g_originalDrawThemeTextEx(
+            theme, dc, partId, stateId, text, textLength, textFlags,
+            rectangle, options);
+    }
+
+    Wh_Log(L"Applied CJK spacing (classic tooltip/DrawThemeTextEx)");
+    g_rewritingClassicTooltipText = true;
+    const HRESULT result = g_originalDrawThemeTextEx(
+        theme, dc, partId, stateId, spaced.c_str(),
+        static_cast<int>(spaced.size()), textFlags, rectangle,
+        options);
+    g_rewritingClassicTooltipText = false;
+    return result;
 }
 
 // -------------------------------------------------------------------------
@@ -981,9 +1204,92 @@ bool InstallHook(Function target,
     return true;
 }
 
+bool HookClassicTooltipThemeDrawing() {
+    HMODULE themeModule = LoadLibraryExW(
+        L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!themeModule) {
+        Wh_Log(L"Couldn't load uxtheme.dll");
+        return false;
+    }
+
+    bool hooked = false;
+
+    const auto openThemeData =
+        reinterpret_cast<OpenThemeData_t>(
+            GetProcAddress(themeModule, "OpenThemeData"));
+    if (openThemeData) {
+        hooked |= InstallHook(
+            openThemeData, OpenThemeDataHook,
+            &g_originalOpenThemeData, L"OpenThemeData");
+    } else {
+        Wh_Log(L"Couldn't find OpenThemeData");
+    }
+
+    const auto openThemeDataEx =
+        reinterpret_cast<OpenThemeDataEx_t>(
+            GetProcAddress(themeModule, "OpenThemeDataEx"));
+    if (openThemeDataEx) {
+        hooked |= InstallHook(
+            openThemeDataEx, OpenThemeDataExHook,
+            &g_originalOpenThemeDataEx, L"OpenThemeDataEx");
+    } else {
+        Wh_Log(L"Couldn't find OpenThemeDataEx");
+    }
+
+    const auto openThemeDataForDpi =
+        reinterpret_cast<OpenThemeDataForDpi_t>(
+            GetProcAddress(themeModule, "OpenThemeDataForDpi"));
+    if (openThemeDataForDpi) {
+        hooked |= InstallHook(
+            openThemeDataForDpi, OpenThemeDataForDpiHook,
+            &g_originalOpenThemeDataForDpi,
+            L"OpenThemeDataForDpi");
+    } else {
+        Wh_Log(L"Couldn't find OpenThemeDataForDpi");
+    }
+
+    const auto closeThemeData =
+        reinterpret_cast<CloseThemeData_t>(
+            GetProcAddress(themeModule, "CloseThemeData"));
+    if (closeThemeData) {
+        hooked |= InstallHook(
+            closeThemeData, CloseThemeDataHook,
+            &g_originalCloseThemeData, L"CloseThemeData");
+    } else {
+        Wh_Log(L"Couldn't find CloseThemeData");
+    }
+
+    const auto drawThemeText =
+        reinterpret_cast<DrawThemeText_t>(
+            GetProcAddress(themeModule, "DrawThemeText"));
+    if (drawThemeText) {
+        hooked |= InstallHook(
+            drawThemeText, DrawThemeTextHook,
+            &g_originalDrawThemeText, L"DrawThemeText");
+    } else {
+        Wh_Log(L"Couldn't find DrawThemeText");
+    }
+
+    const auto drawThemeTextEx =
+        reinterpret_cast<DrawThemeTextEx_t>(
+            GetProcAddress(themeModule, "DrawThemeTextEx"));
+    if (drawThemeTextEx) {
+        hooked |= InstallHook(
+            drawThemeTextEx, DrawThemeTextExHook,
+            &g_originalDrawThemeTextEx, L"DrawThemeTextEx");
+    } else {
+        Wh_Log(L"Couldn't find DrawThemeTextEx");
+    }
+
+    return hooked;
+}
+
 void LoadSettings() {
     g_classicMenus.store(Wh_GetIntSetting(L"classicMenus") != 0,
                          std::memory_order_relaxed);
+    g_classicTooltips.store(
+        Wh_GetIntSetting(L"classicTooltips") != 0,
+        std::memory_order_relaxed);
     g_modernUiText.store(Wh_GetIntSetting(L"modernUiText") != 0,
                          std::memory_order_relaxed);
 
@@ -1001,6 +1307,7 @@ BOOL Wh_ModInit() {
     LoadSettings();
 
     if (!g_classicMenus.load(std::memory_order_relaxed) &&
+        !g_classicTooltips.load(std::memory_order_relaxed) &&
         !g_modernUiText.load(std::memory_order_relaxed)) {
         Wh_Log(L"CJK Spacer has no enabled UI targets");
         return FALSE;
@@ -1027,6 +1334,8 @@ BOOL Wh_ModInit() {
         InstallHook(TrackPopupMenuEx, TrackPopupMenuExHook,
                     &g_originalTrackPopupMenuEx, L"TrackPopupMenuEx");
 
+    installedAnyHook |= HookClassicTooltipThemeDrawing();
+
     installedAnyHook |= InstallHook(ShowWindow, ShowWindowHook,
                                     &g_originalShowWindow, L"ShowWindow");
     installedAnyHook |= InstallHook(SetWindowPos, SetWindowPosHook,
@@ -1037,8 +1346,10 @@ BOOL Wh_ModInit() {
 
     installedAnyHook |= HookDirectWrite();
 
-    Wh_Log(L"CJK Spacer initialized (classic=%d, modern=%d, unicode=%d)",
-           g_classicMenus.load(), g_modernUiText.load(),
+    Wh_Log(L"CJK Spacer initialized (classicMenus=%d, "
+           L"classicTooltips=%d, modern=%d, unicode=%d)",
+           g_classicMenus.load(), g_classicTooltips.load(),
+           g_modernUiText.load(),
            g_unicodeLettersAndDigits.load());
     return installedAnyHook ? TRUE : FALSE;
 }
@@ -1049,7 +1360,9 @@ void Wh_ModUninit() {
 
 void Wh_ModSettingsChanged() {
     LoadSettings();
-    Wh_Log(L"CJK Spacer settings changed (classic=%d, modern=%d, unicode=%d)",
-           g_classicMenus.load(), g_modernUiText.load(),
+    Wh_Log(L"CJK Spacer settings changed (classicMenus=%d, "
+           L"classicTooltips=%d, modern=%d, unicode=%d)",
+           g_classicMenus.load(), g_classicTooltips.load(),
+           g_modernUiText.load(),
            g_unicodeLettersAndDigits.load());
 }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.15
+// @version         0.1.16
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -23,6 +23,12 @@
 
 Adds a normal ASCII space at a direct boundary between a CJK character and a
 letter or digit in UI text hosted by `explorer.exe`.
+
+On Windows 11, the primary Explorer and desktop context menus are modern XAML
+menus. The `modernUiText` setting is disabled by default because XAML
+Diagnostics permits only one consumer per connection; enable it if you want
+those menus and pointer tooltips processed. `classicMenus` still covers the
+Win32 menu opened through "Show more options".
 
 Examples:
 
@@ -50,7 +56,9 @@ keyboard shortcut text are also preserved.
 - Classic Win32 popup menus are rewritten through public `HMENU` APIs. This
   happens only while `TrackPopupMenu` is active, including items added or
   changed while the menu is open. It covers File Explorer, desktop, taskbar,
-  tray, and jump-list context menus hosted by `explorer.exe`.
+  and jump-list context menus that Explorer itself hosts. Context menus shown
+  by third-party notification-area icon processes are outside the injected
+  `explorer.exe` process and aren't covered.
 - Classic Win32 tooltips, including legacy notification-area icon tooltips, are
   rewritten only through theme handles opened for the `TOOLTIP` class, covering
   both text measurement and drawing without touching unrelated GDI text.
@@ -100,7 +108,7 @@ Rewritten strings are recorded and restored when the popup closes.
   $description: Process text in legacy tooltips such as notification-area icon tooltips.
 - modernUiText: false
   $name: Windows 11 context menus and tooltips
-  $description: Process text elements in Explorer XAML context menus and pointer tooltips. Uses exclusive XAML Diagnostics connections and can conflict with Windows 11 Taskbar Styler, Windows 11 File Explorer Styler, or other diagnostics-based tools.
+  $description: Process text elements in Explorer XAML context menus and pointer tooltips (disabled by default; enable for the primary Windows 11 menu). Uses exclusive XAML Diagnostics connections and can conflict with Windows 11 Taskbar Styler, Windows 11 File Explorer Styler, or other diagnostics-based tools.
 - characterMode: unicode
   $name: Non-CJK character set
   $description: Choose which letters and digits form a spacing boundary with CJK.
@@ -111,6 +119,8 @@ Rewritten strings are recorded and restored when the popup closes.
 // ==/WindhawkModSettings==
 
 #include <xamlom.h>
+
+#include <windhawk_utils.h>
 
 #include <atomic>
 #include <cstdint>
@@ -426,6 +436,8 @@ struct RewrittenMenuItem {
     std::wstring spaced;
 };
 
+constexpr UINT kUnknownMenuItemIndex = static_cast<UINT>(-1);
+
 std::mutex g_rewrittenMenuItemsMutex;
 std::vector<RewrittenMenuItem> g_rewrittenMenuItems;
 thread_local unsigned int g_classicPopupMenuDepth = 0;
@@ -504,10 +516,11 @@ BOOL WINAPI InsertMenuWHook(HMENU menu,
                         menu, static_cast<UINT>(itemId),
                         false);
                 }
-                if (index >= 0) {
-                    RememberRewrittenMenuItem(
-                        menu, static_cast<UINT>(index), newItem, spaced);
-                }
+                RememberRewrittenMenuItem(
+                    menu,
+                    index >= 0 ? static_cast<UINT>(index)
+                               : kUnknownMenuItemIndex,
+                    newItem, spaced);
             }
             return result;
         }
@@ -557,9 +570,12 @@ BOOL WINAPI ModifyMenuWHook(HMENU menu,
                 menu, position, (flags & MF_BYPOSITION) != 0);
             const BOOL result = g_originalModifyMenuW(
                 menu, position, flags, itemId, spaced.c_str());
-            if (result && index >= 0) {
+            if (result) {
                 RememberRewrittenMenuItem(
-                    menu, static_cast<UINT>(index), newItem, spaced);
+                    menu,
+                    index >= 0 ? static_cast<UINT>(index)
+                               : kUnknownMenuItemIndex,
+                    newItem, spaced);
             }
             return result;
         }
@@ -636,7 +652,12 @@ void RememberRewrittenMenuItem(HMENU menu,
                                std::wstring spaced) {
     std::lock_guard<std::mutex> guard(g_rewrittenMenuItemsMutex);
 
-    if (g_rewrittenMenuItems.size() >= 256) {
+    constexpr size_t kRewrittenMenuCleanupThreshold = 256;
+    if (g_rewrittenMenuItems.size() >=
+        kRewrittenMenuCleanupThreshold) {
+        // Popup teardown normally clears this vector. If a menu is destroyed
+        // before teardown, remove only entries that can no longer be restored;
+        // never evict a live entry just to enforce an arbitrary cap.
         std::erase_if(g_rewrittenMenuItems, [](const auto& item) {
             return !IsMenu(item.menu);
         });
@@ -675,10 +696,13 @@ void RestoreRewrittenMenuItems(HMENU rootMenu = nullptr) {
             continue;
         }
 
-        int index = static_cast<int>(iterator->index);
+        int index = iterator->index == kUnknownMenuItemIndex
+                        ? -1
+                        : static_cast<int>(iterator->index);
         std::wstring current;
-        if (!ReadMenuItemText(
-                iterator->menu, iterator->index, &current) ||
+        if (index < 0 ||
+            !ReadMenuItemText(
+                iterator->menu, static_cast<UINT>(index), &current) ||
             current != iterator->spaced) {
             index = FindMenuItemIndexByText(
                 iterator->menu, iterator->spaced);
@@ -729,11 +753,12 @@ BOOL WINAPI InsertMenuItemWHook(HMENU menu,
                         : byPosition
                               ? GetMenuItemCount(menu) - 1
                               : FindMenuItemIndexByText(menu, spaced);
-                if (insertedIndex >= 0) {
-                    RememberRewrittenMenuItem(
-                        menu, static_cast<UINT>(insertedIndex),
-                        itemInfo->dwTypeData, spaced);
-                }
+                RememberRewrittenMenuItem(
+                    menu,
+                    insertedIndex >= 0
+                        ? static_cast<UINT>(insertedIndex)
+                        : kUnknownMenuItemIndex,
+                    itemInfo->dwTypeData, spaced);
             }
             return result;
         }
@@ -760,9 +785,11 @@ BOOL WINAPI SetMenuItemInfoWHook(HMENU menu,
             copy.dwTypeData = const_cast<wchar_t*>(spaced.c_str());
             const BOOL result = g_originalSetMenuItemInfoW(
                 menu, item, byPosition, &copy);
-            if (result && index >= 0) {
+            if (result) {
                 RememberRewrittenMenuItem(
-                    menu, static_cast<UINT>(index),
+                    menu,
+                    index >= 0 ? static_cast<UINT>(index)
+                               : kUnknownMenuItemIndex,
                     itemInfo->dwTypeData, spaced);
             }
             return result;
@@ -892,8 +919,6 @@ GetWindowTheme_t g_getWindowTheme;
 GetThemeTextExtent_t g_originalGetThemeTextExtent;
 DrawThemeText_t g_originalDrawThemeText;
 DrawThemeTextEx_t g_originalDrawThemeTextEx;
-HMODULE g_loadedUxThemeModule;
-
 std::shared_mutex g_classicTooltipThemesMutex;
 std::unordered_set<HTHEME> g_classicTooltipThemes;
 std::atomic_uint g_classicTooltipThemeCount{0};
@@ -1011,6 +1036,8 @@ HTHEME WINAPI OpenThemeDataHook(HWND window, LPCWSTR classList) {
     HTHEME theme = g_originalOpenThemeData(window, classList);
     if (IsClassicTooltipThemeClassList(classList)) {
         TrackClassicTooltipTheme(theme);
+    } else {
+        UntrackClassicTooltipTheme(theme);
     }
 
     return theme;
@@ -1023,6 +1050,8 @@ HTHEME WINAPI OpenThemeDataExHook(HWND window,
         g_originalOpenThemeDataEx(window, classList, flags);
     if (IsClassicTooltipThemeClassList(classList)) {
         TrackClassicTooltipTheme(theme);
+    } else {
+        UntrackClassicTooltipTheme(theme);
     }
 
     return theme;
@@ -1035,6 +1064,8 @@ HTHEME WINAPI OpenThemeDataForDpiHook(HWND window,
         g_originalOpenThemeDataForDpi(window, classList, dpi);
     if (IsClassicTooltipThemeClassList(classList)) {
         TrackClassicTooltipTheme(theme);
+    } else {
+        UntrackClassicTooltipTheme(theme);
     }
 
     return theme;
@@ -1256,7 +1287,7 @@ struct TooltipContentAccess {
 class ModernTextStateBase {
 public:
     virtual ~ModernTextStateBase() = default;
-    virtual void Apply() = 0;
+    virtual bool Apply() = 0;
     virtual void Restore() = 0;
 };
 
@@ -1266,40 +1297,38 @@ public:
     explicit ModernTextState(const Element& element)
         : m_element(winrt::make_weak(element)) {}
 
-    void Apply() override {
-        if (!g_modernUiText.load(std::memory_order_relaxed)) {
-            return;
-        }
-
+    bool Apply() override {
         try {
             auto element = m_element.get();
             if (!element) {
-                return;
+                return false;
             }
 
             std::wstring current;
             if (!SourceAccess::Read(element, &current)) {
-                return;
+                return false;
             }
 
             if (!ContainsCjkCodePoint(current)) {
-                return;
+                return false;
             }
 
             std::wstring spaced = AddCjkSpacing(current, false);
             if (spaced.size() == current.size()) {
-                return;
+                return false;
             }
 
             m_originalText = std::move(current);
             m_spacedText = std::move(spaced);
-            m_modified = true;
             SourceAccess::Write(element, m_spacedText);
+            m_modified = true;
             Wh_Log(L"Applied CJK spacing (modern XAML %s)",
                    SourceAccess::Name());
+            return true;
         } catch (const winrt::hresult_error& error) {
             Wh_Log(L"Couldn't update modern XAML source: 0x%08X",
                    error.code());
+            return false;
         }
     }
 
@@ -1363,7 +1392,7 @@ bool IsModernTooltipSourceType(std::wstring_view type) {
 
 using ModernTextStateMap =
     std::unordered_map<ModernElementKey,
-                       std::shared_ptr<ModernTextStateBase>,
+                       std::unique_ptr<ModernTextStateBase>,
                        ModernElementKeyHash>;
 
 struct ModernThreadState {
@@ -1431,6 +1460,7 @@ void RegisterModernTextStateThread() {
 
     std::lock_guard<std::mutex> guard(
         g_modernTextStateThreadsMutex);
+    PruneModernTextStateThreadsLocked();
     g_modernTextStateThreads[GetCurrentThreadId()] = creationTime;
 }
 
@@ -1564,19 +1594,23 @@ private:
             return false;
         }
 
-        auto state =
-            std::make_shared<ModernTextState<Element, SourceAccess>>(
-                element);
         const ModernElementKey key{this, handle};
         auto& threadState = *g_modernTextStatesForThread;
         if (threadState.states.contains(key)) {
             RemoveModernTextState(threadState, key);
         }
+
+        auto state =
+            std::make_unique<ModernTextState<Element, SourceAccess>>(
+                element);
+        if (!state->Apply()) {
+            return false;
+        }
+
         if (threadState.states.empty()) {
             RegisterModernTextStateThread();
         }
-        threadState.states.emplace(key, state);
-        state->Apply();
+        threadState.states.emplace(key, std::move(state));
         return true;
     }
 
@@ -2152,13 +2186,8 @@ HWND FindWindowForThread(DWORD threadId) {
         threadId,
         [](HWND window, LPARAM parameter) -> BOOL {
             auto* result = reinterpret_cast<HWND*>(parameter);
-            DWORD processId;
-            GetWindowThreadProcessId(window, &processId);
-            if (processId == GetCurrentProcessId()) {
-                *result = window;
-                return FALSE;
-            }
-            return TRUE;
+            *result = window;
+            return FALSE;
         },
         reinterpret_cast<LPARAM>(&result));
     return result;
@@ -2228,9 +2257,7 @@ bool InstallHook(Function target,
                  Function hook,
                  Function* original,
                  const wchar_t* name) {
-    if (!Wh_SetFunctionHook(reinterpret_cast<void*>(target),
-                            reinterpret_cast<void*>(hook),
-                            reinterpret_cast<void**>(original))) {
+    if (!WindhawkUtils::SetFunctionHook(target, hook, original)) {
         Wh_Log(L"Couldn't hook %s", name);
         return false;
     }
@@ -2241,12 +2268,7 @@ bool InstallHook(Function target,
 bool HookClassicTooltipThemeDrawing() {
     HMODULE themeModule = GetModuleHandleW(L"uxtheme.dll");
     if (!themeModule) {
-        themeModule = LoadLibraryExW(
-            L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-        g_loadedUxThemeModule = themeModule;
-    }
-    if (!themeModule) {
-        Wh_Log(L"Couldn't load uxtheme.dll");
+        Wh_Log(L"Couldn't find loaded uxtheme.dll");
         return false;
     }
 
@@ -2337,10 +2359,6 @@ bool HookClassicTooltipThemeDrawing() {
         Wh_Log(L"Couldn't find DrawThemeTextEx");
     }
 
-    if (!hooked && g_loadedUxThemeModule) {
-        FreeLibrary(g_loadedUxThemeModule);
-        g_loadedUxThemeModule = nullptr;
-    }
     return hooked;
 }
 
@@ -2353,12 +2371,12 @@ void LoadSettings() {
     g_modernUiText.store(Wh_GetIntSetting(L"modernUiText") != 0,
                          std::memory_order_relaxed);
 
-    PCWSTR characterMode = Wh_GetStringSetting(L"characterMode");
+    auto characterMode =
+        WindhawkUtils::StringSetting::make(L"characterMode");
     const bool unicodeMode =
         _wcsicmp(characterMode, L"ascii") != 0;
     g_unicodeLettersAndDigits.store(unicodeMode,
                                     std::memory_order_relaxed);
-    Wh_FreeStringSetting(characterMode);
 }
 
 }  // namespace
@@ -2434,7 +2452,9 @@ BOOL Wh_ModInit() {
            g_classicMenus.load(), g_classicTooltips.load(),
            g_modernUiText.load(),
            g_unicodeLettersAndDigits.load());
-    return installedAnyHook ? TRUE : FALSE;
+    // The modern path can still initialize against XAML modules that are
+    // already loaded even if the late-load notification hook is unavailable.
+    return installedAnyHook || modernUiTextEnabled ? TRUE : FALSE;
 }
 
 void Wh_ModAfterInit() {
@@ -2450,10 +2470,6 @@ void Wh_ModAfterInit() {
 void Wh_ModUninit() {
     RestoreRewrittenMenuItems();
     ClearTrackedClassicTooltipThemes();
-    if (g_loadedUxThemeModule) {
-        FreeLibrary(g_loadedUxThemeModule);
-        g_loadedUxThemeModule = nullptr;
-    }
     if (g_modernUiText.load(std::memory_order_relaxed)) {
         UninitializeModernUi();
     }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.16
+// @version         0.1.17
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -59,9 +59,13 @@ keyboard shortcut text are also preserved.
   and jump-list context menus that Explorer itself hosts. Context menus shown
   by third-party notification-area icon processes are outside the injected
   `explorer.exe` process and aren't covered.
+  Classic menu bars and window system menus do not use these popup APIs and
+  aren't covered.
 - Classic Win32 tooltips, including legacy notification-area icon tooltips, are
   rewritten only through theme handles opened for the `TOOLTIP` class, covering
   both text measurement and drawing without touching unrelated GDI text.
+  Each tracked theme is tied to the Tooltip window that opened it, and a DC
+  mapped to another window is rejected.
   Existing tooltip controls are discovered when the mod is enabled in a
   running Explorer. Basic or classic-theme tooltips drawn directly with
   `DrawTextW` aren't covered.
@@ -82,6 +86,10 @@ path; a single-flight worker retains requests that arrive while it is running,
 tracks the Windows.UI.Xaml and Microsoft.UI.Xaml connections independently,
 and retries only the connection that was lost. The worker pins the mod image
 until `FreeLibraryAndExitThread`, so it cannot execute unloaded mod code.
+When Taskbar Styler is configured to alert on competing XAML Diagnostics
+consumers, enabling this path can show its confirmation dialog.
+Each reload switches to a new modern-UI generation, so detached workers and
+watcher callbacks from an older load cannot reuse its connection state.
 
 The mod is injected only into `explorer.exe`. Start, Search, and some shell
 flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
@@ -94,7 +102,9 @@ threads and restores them when the source leaves the visual tree or the mod
 unloads. The classic path updates
 strings stored in active `HMENU` objects, so menu text read through
 accessibility APIs also contains the inserted spaces while the popup is open.
-Rewritten strings are recorded and restored when the popup closes.
+Rewritten strings are recorded and restored when the popup closes. If multiple
+items have identical rewritten text, text-based fallback restoration can select
+the first match; the idempotent transformation does not compound spaces.
 */
 // ==/WindhawkModReadme==
 
@@ -124,17 +134,18 @@ Rewritten strings are recorded and restored when the popup closes.
 
 #include <atomic>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <cwchar>
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <optional>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include <windows.h>
@@ -919,8 +930,9 @@ GetWindowTheme_t g_getWindowTheme;
 GetThemeTextExtent_t g_originalGetThemeTextExtent;
 DrawThemeText_t g_originalDrawThemeText;
 DrawThemeTextEx_t g_originalDrawThemeTextEx;
+HMODULE g_loadedUxThemeModule;
 std::shared_mutex g_classicTooltipThemesMutex;
-std::unordered_set<HTHEME> g_classicTooltipThemes;
+std::unordered_map<HTHEME, HWND> g_classicTooltipThemes;
 std::atomic_uint g_classicTooltipThemeCount{0};
 thread_local bool g_rewritingClassicTooltipText = false;
 
@@ -947,20 +959,27 @@ bool IsClassicTooltipThemeClassList(LPCWSTR classList) {
     return false;
 }
 
-bool IsTrackedClassicTooltipTheme(HTHEME theme) {
+HWND FindTrackedClassicTooltipWindow(HTHEME theme) {
     if (!theme ||
         g_classicTooltipThemeCount.load(
             std::memory_order_relaxed) == 0) {
-        return false;
+        return nullptr;
     }
 
     std::shared_lock<std::shared_mutex> guard(
         g_classicTooltipThemesMutex);
-    return g_classicTooltipThemes.contains(theme);
+    const auto iterator = g_classicTooltipThemes.find(theme);
+    return iterator != g_classicTooltipThemes.end()
+               ? iterator->second
+               : nullptr;
 }
 
-void TrackClassicTooltipTheme(HTHEME theme) {
-    if (!theme) {
+bool IsTrackedClassicTooltipTheme(HTHEME theme) {
+    return FindTrackedClassicTooltipWindow(theme) != nullptr;
+}
+
+void TrackClassicTooltipTheme(HTHEME theme, HWND window) {
+    if (!theme || !window) {
         return;
     }
 
@@ -968,7 +987,10 @@ void TrackClassicTooltipTheme(HTHEME theme) {
     {
         std::lock_guard<std::shared_mutex> guard(
             g_classicTooltipThemesMutex);
-        inserted = g_classicTooltipThemes.insert(theme).second;
+        inserted = g_classicTooltipThemes.emplace(theme, window).second;
+        if (!inserted) {
+            g_classicTooltipThemes[theme] = window;
+        }
         g_classicTooltipThemeCount.store(
             static_cast<unsigned int>(g_classicTooltipThemes.size()),
             std::memory_order_relaxed);
@@ -980,16 +1002,19 @@ void TrackClassicTooltipTheme(HTHEME theme) {
 }
 
 void UntrackClassicTooltipTheme(HTHEME theme) {
-    if (!theme) {
+    if (!theme ||
+        g_classicTooltipThemeCount.load(
+            std::memory_order_relaxed) == 0) {
         return;
     }
 
     std::lock_guard<std::shared_mutex> guard(
         g_classicTooltipThemesMutex);
-    g_classicTooltipThemes.erase(theme);
-    g_classicTooltipThemeCount.store(
-        static_cast<unsigned int>(g_classicTooltipThemes.size()),
-        std::memory_order_relaxed);
+    if (g_classicTooltipThemes.erase(theme) != 0) {
+        g_classicTooltipThemeCount.store(
+            static_cast<unsigned int>(g_classicTooltipThemes.size()),
+            std::memory_order_relaxed);
+    }
 }
 
 void ClearTrackedClassicTooltipThemes() {
@@ -1007,12 +1032,13 @@ bool IsClassicTooltipWindow(HWND window) {
 }
 
 bool IsClassicTooltipTarget(HTHEME theme, HDC dc) {
-    if (!IsTrackedClassicTooltipTheme(theme)) {
+    const HWND trackedWindow = FindTrackedClassicTooltipWindow(theme);
+    if (!trackedWindow || !IsClassicTooltipWindow(trackedWindow)) {
         return false;
     }
 
     const HWND window = dc ? WindowFromDC(dc) : nullptr;
-    return !window || IsClassicTooltipWindow(window);
+    return !window || window == trackedWindow;
 }
 
 BOOL CALLBACK EnumExistingClassicTooltipWindow(HWND window, LPARAM) {
@@ -1020,7 +1046,7 @@ BOOL CALLBACK EnumExistingClassicTooltipWindow(HWND window, LPARAM) {
     GetWindowThreadProcessId(window, &processId);
     if (processId == GetCurrentProcessId() &&
         IsClassicTooltipWindow(window)) {
-        TrackClassicTooltipTheme(g_getWindowTheme(window));
+        TrackClassicTooltipTheme(g_getWindowTheme(window), window);
     }
 
     return TRUE;
@@ -1035,7 +1061,7 @@ void DiscoverExistingClassicTooltipThemes() {
 HTHEME WINAPI OpenThemeDataHook(HWND window, LPCWSTR classList) {
     HTHEME theme = g_originalOpenThemeData(window, classList);
     if (IsClassicTooltipThemeClassList(classList)) {
-        TrackClassicTooltipTheme(theme);
+        TrackClassicTooltipTheme(theme, window);
     } else {
         UntrackClassicTooltipTheme(theme);
     }
@@ -1049,7 +1075,7 @@ HTHEME WINAPI OpenThemeDataExHook(HWND window,
     HTHEME theme =
         g_originalOpenThemeDataEx(window, classList, flags);
     if (IsClassicTooltipThemeClassList(classList)) {
-        TrackClassicTooltipTheme(theme);
+        TrackClassicTooltipTheme(theme, window);
     } else {
         UntrackClassicTooltipTheme(theme);
     }
@@ -1063,7 +1089,7 @@ HTHEME WINAPI OpenThemeDataForDpiHook(HWND window,
     HTHEME theme =
         g_originalOpenThemeDataForDpi(window, classList, dpi);
     if (IsClassicTooltipThemeClassList(classList)) {
-        TrackClassicTooltipTheme(theme);
+        TrackClassicTooltipTheme(theme, window);
     } else {
         UntrackClassicTooltipTheme(theme);
     }
@@ -1506,15 +1532,21 @@ enum class XamlDiagnosticsFlavor {
 extern std::atomic_bool g_windowsUiXamlDiagnosticsConnected;
 extern std::atomic_bool g_microsoftUiXamlDiagnosticsConnected;
 extern std::atomic_bool g_stoppingModernUi;
+extern std::atomic_uint64_t g_modernUiGeneration;
 extern thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics;
+extern thread_local uint64_t g_connectingXamlDiagnosticsGeneration;
+
+bool IsCurrentModernUiGeneration(uint64_t generation);
 
 class VisualTreeWatcher
     : public winrt::implements<VisualTreeWatcher,
                                IVisualTreeServiceCallback2,
                                winrt::non_agile> {
 public:
-    explicit VisualTreeWatcher(winrt::com_ptr<IUnknown> site)
-        : m_xamlDiagnostics(site.as<IXamlDiagnostics>()) {
+    explicit VisualTreeWatcher(winrt::com_ptr<IUnknown> site,
+                               uint64_t generation)
+        : m_xamlDiagnostics(site.as<IXamlDiagnostics>()),
+          m_generation(generation) {
         m_moduleReference = AcquireCurrentModuleReference();
         if (!m_moduleReference) {
             winrt::throw_hresult(HRESULT_FROM_WIN32(GetLastError()));
@@ -1618,6 +1650,10 @@ private:
         ParentChildRelation,
         VisualElement element,
         VisualMutationType mutationType) override try {
+        if (!IsCurrentModernUiGeneration(m_generation)) {
+            return S_OK;
+        }
+
         if (!g_modernTextStatesForThread) {
             g_modernTextStatesForThread.emplace();
         }
@@ -1697,16 +1733,25 @@ private:
 
     winrt::com_ptr<IXamlDiagnostics> m_xamlDiagnostics;
     HMODULE m_moduleReference = nullptr;
+    uint64_t m_generation;
     std::atomic_bool m_advised{false};
     std::atomic_bool m_unadviseRequested{false};
 };
 
 std::mutex g_visualTreeWatchersMutex;
+std::mutex g_modernUiLifecycleMutex;
 [[clang::no_destroy]]
-    std::optional<std::vector<winrt::com_ptr<VisualTreeWatcher>>>
+std::optional<std::vector<winrt::com_ptr<VisualTreeWatcher>>>
         g_visualTreeWatchers{std::in_place};
 std::atomic_bool g_stoppingModernUi{false};
 std::atomic_uint64_t g_visualTreeWatcherGeneration;
+std::atomic_uint64_t g_modernUiGeneration{0};
+
+bool IsCurrentModernUiGeneration(uint64_t generation) {
+    return generation ==
+               g_modernUiGeneration.load(std::memory_order_acquire) &&
+           !g_stoppingModernUi.load(std::memory_order_acquire);
+}
 
 bool RemoveVisualTreeWatcher(VisualTreeWatcher* watcher) {
     std::lock_guard<std::mutex> guard(g_visualTreeWatchersMutex);
@@ -1763,6 +1808,12 @@ public:
 
         m_site.copy_from(site);
         if (!site) {
+            if (m_generation !=
+                g_modernUiGeneration.load(std::memory_order_acquire)) {
+                m_flavor = XamlDiagnosticsFlavor::None;
+                return S_OK;
+            }
+
             const XamlDiagnosticsFlavor disconnectedFlavor =
                 m_flavor;
             m_flavor = XamlDiagnosticsFlavor::None;
@@ -1783,6 +1834,11 @@ public:
             return S_OK;
         }
 
+        m_generation =
+            g_connectingXamlDiagnosticsGeneration != 0
+                ? g_connectingXamlDiagnosticsGeneration
+                : g_modernUiGeneration.load(
+                      std::memory_order_acquire);
         if (g_connectingXamlDiagnostics !=
             XamlDiagnosticsFlavor::None) {
             m_flavor = g_connectingXamlDiagnostics;
@@ -1796,14 +1852,14 @@ public:
         {
             std::lock_guard<std::mutex> guard(
                 g_visualTreeWatchersMutex);
-            if (g_stoppingModernUi.load(
-                    std::memory_order_relaxed) ||
+            if (!IsCurrentModernUiGeneration(m_generation) ||
                 !g_visualTreeWatchers) {
                 return S_OK;
             }
 
             auto watcher =
-                winrt::make_self<VisualTreeWatcher>(m_site);
+                winrt::make_self<VisualTreeWatcher>(
+                    m_site, m_generation);
             g_visualTreeWatchers->push_back(watcher);
             g_visualTreeWatcherGeneration.fetch_add(
                 1, std::memory_order_release);
@@ -1826,6 +1882,7 @@ private:
     winrt::com_ptr<IUnknown> m_site;
     winrt::com_ptr<VisualTreeWatcher> m_watcher;
     XamlDiagnosticsFlavor m_flavor = XamlDiagnosticsFlavor::None;
+    uint64_t m_generation = 0;
 };
 
 template <typename Class>
@@ -1899,10 +1956,17 @@ std::atomic_bool g_xamlDiagnosticsRequestPending{false};
 thread_local bool g_loadingXamlDiagnostics;
 thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics =
     XamlDiagnosticsFlavor::None;
+thread_local uint64_t g_connectingXamlDiagnosticsGeneration = 0;
+
+struct ModernDiagnosticsWorkerContext {
+    HMODULE module;
+    uint64_t generation;
+};
 
 HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
                               LPCWSTR connectionPrefix,
-                              XamlDiagnosticsFlavor flavor) {
+                              XamlDiagnosticsFlavor flavor,
+                              uint64_t generation) {
     const auto initialize =
         reinterpret_cast<InitializeXamlDiagnosticsEx_t>(
             GetProcAddress(xamlModule,
@@ -1926,7 +1990,7 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
 
     HRESULT result = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
     for (int index = 1; index <= 10000; ++index) {
-        if (g_stoppingModernUi.load(std::memory_order_relaxed)) {
+        if (!IsCurrentModernUiGeneration(generation)) {
             return HRESULT_FROM_WIN32(ERROR_CANCELLED);
         }
 
@@ -1935,11 +1999,15 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
                      connectionPrefix, index);
         const XamlDiagnosticsFlavor previousFlavor =
             g_connectingXamlDiagnostics;
+        const uint64_t previousGeneration =
+            g_connectingXamlDiagnosticsGeneration;
         g_connectingXamlDiagnostics = flavor;
+        g_connectingXamlDiagnosticsGeneration = generation;
         result = initialize(
             connectionName, GetCurrentProcessId(), L"",
             modulePath, CLSID_CjkSpacerTap, nullptr);
         g_connectingXamlDiagnostics = previousFlavor;
+        g_connectingXamlDiagnosticsGeneration = previousGeneration;
         if (result != HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
             break;
         }
@@ -1948,8 +2016,8 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
     return result;
 }
 
-void EnsureModernXamlDiagnostics() {
-    if (g_stoppingModernUi.load(std::memory_order_relaxed) ||
+void EnsureModernXamlDiagnostics(uint64_t generation) {
+    if (!IsCurrentModernUiGeneration(generation) ||
         g_loadingXamlDiagnostics) {
         return;
     }
@@ -1968,7 +2036,7 @@ void EnsureModernXamlDiagnostics() {
 
     std::lock_guard<std::mutex> guard(
         g_xamlDiagnosticsInitializationMutex);
-    if (g_stoppingModernUi.load(std::memory_order_relaxed)) {
+    if (!IsCurrentModernUiGeneration(generation)) {
         return;
     }
 
@@ -1981,8 +2049,9 @@ void EnsureModernXamlDiagnostics() {
                     std::memory_order_acquire);
             const HRESULT result = InjectXamlDiagnostics(
                 module, L"VisualDiagConnection",
-                XamlDiagnosticsFlavor::Windows);
+                XamlDiagnosticsFlavor::Windows, generation);
             if (SUCCEEDED(result) &&
+                IsCurrentModernUiGeneration(generation) &&
                 g_visualTreeWatcherGeneration.load(
                     std::memory_order_acquire) >
                     watcherGeneration) {
@@ -2012,8 +2081,9 @@ void EnsureModernXamlDiagnostics() {
                     std::memory_order_acquire);
             const HRESULT result = InjectXamlDiagnostics(
                 module, L"WinUIVisualDiagConnection",
-                XamlDiagnosticsFlavor::Microsoft);
+                XamlDiagnosticsFlavor::Microsoft, generation);
             if (SUCCEEDED(result) &&
+                IsCurrentModernUiGeneration(generation) &&
                 g_visualTreeWatcherGeneration.load(
                     std::memory_order_acquire) >
                     watcherGeneration) {
@@ -2036,7 +2106,11 @@ void EnsureModernXamlDiagnostics() {
 }
 
 void RequestModernXamlDiagnosticsInitialization() {
-    if (g_stoppingModernUi.load(std::memory_order_relaxed)) {
+    std::lock_guard<std::mutex> lifecycleGuard(
+        g_modernUiLifecycleMutex);
+    const uint64_t generation =
+        g_modernUiGeneration.load(std::memory_order_acquire);
+    if (!IsCurrentModernUiGeneration(generation)) {
         return;
     }
 
@@ -2053,49 +2127,68 @@ void RequestModernXamlDiagnosticsInitialization() {
     // until the worker exits through FreeLibraryAndExitThread.
     HMODULE module = AcquireCurrentModuleReference();
     if (!module) {
-        g_xamlDiagnosticsWorkerRunning.store(
-            false, std::memory_order_release);
+        if (IsCurrentModernUiGeneration(generation)) {
+            g_xamlDiagnosticsWorkerRunning.store(
+                false, std::memory_order_release);
+        }
         Wh_Log(L"Couldn't retain the mod for XAML diagnostics");
         return;
     }
 
+    auto context = std::unique_ptr<ModernDiagnosticsWorkerContext>(
+        new (std::nothrow) ModernDiagnosticsWorkerContext{
+            module, generation});
+    if (!context) {
+        g_xamlDiagnosticsWorkerRunning.store(
+            false, std::memory_order_release);
+        FreeLibrary(module);
+        Wh_Log(L"Couldn't allocate the XAML diagnostics context");
+        return;
+    }
     HANDLE thread = CreateThread(
         nullptr, 0,
         [](LPVOID parameter) -> DWORD {
-            HMODULE module = static_cast<HMODULE>(parameter);
+            auto context = std::unique_ptr<ModernDiagnosticsWorkerContext>(
+                static_cast<ModernDiagnosticsWorkerContext*>(parameter));
+            const HMODULE module = context->module;
+            const uint64_t generation = context->generation;
+            context.reset();
             const HRESULT initializeResult =
                 CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-            while (!g_stoppingModernUi.load(
-                       std::memory_order_relaxed) &&
+            while (IsCurrentModernUiGeneration(generation) &&
                    g_xamlDiagnosticsRequestPending.exchange(
                        false, std::memory_order_acq_rel)) {
-                EnsureModernXamlDiagnostics();
+                EnsureModernXamlDiagnostics(generation);
             }
             if (SUCCEEDED(initializeResult)) {
                 CoUninitialize();
             }
 
-            g_xamlDiagnosticsWorkerRunning.store(
-                false, std::memory_order_release);
-            if (g_xamlDiagnosticsRequestPending.load(
-                    std::memory_order_acquire) &&
-                !g_stoppingModernUi.load(
-                    std::memory_order_relaxed)) {
-                RequestModernXamlDiagnosticsInitialization();
+            if (IsCurrentModernUiGeneration(generation)) {
+                g_xamlDiagnosticsWorkerRunning.store(
+                    false, std::memory_order_release);
+                if (g_xamlDiagnosticsRequestPending.load(
+                        std::memory_order_acquire)) {
+                    RequestModernXamlDiagnosticsInitialization();
+                }
             }
             FreeLibraryAndExitThread(module, 0);
         },
-        module, 0, nullptr);
+        context.get(), 0, nullptr);
     if (!thread) {
         const DWORD error = GetLastError();
-        g_xamlDiagnosticsWorkerRunning.store(
-            false, std::memory_order_release);
+        context.reset();
+        if (IsCurrentModernUiGeneration(generation)) {
+            g_xamlDiagnosticsWorkerRunning.store(
+                false, std::memory_order_release);
+        }
         FreeLibrary(module);
         Wh_Log(L"Couldn't create the XAML diagnostics thread: %u",
                error);
         return;
     }
 
+    context.release();
     CloseHandle(thread);
 }
 
@@ -2194,7 +2287,20 @@ HWND FindWindowForThread(DWORD threadId) {
 }
 
 void InitializeModernUi() {
-    g_stoppingModernUi.store(false, std::memory_order_relaxed);
+    std::lock_guard<std::mutex> lifecycleGuard(
+        g_modernUiLifecycleMutex);
+    g_stoppingModernUi.store(true, std::memory_order_release);
+    g_modernUiGeneration.fetch_add(1, std::memory_order_acq_rel);
+    g_windowsUiXamlDiagnosticsConnected.store(
+        false, std::memory_order_release);
+    g_microsoftUiXamlDiagnosticsConnected.store(
+        false, std::memory_order_release);
+    g_xamlDiagnosticsWorkerRunning.store(
+        false, std::memory_order_release);
+    g_xamlDiagnosticsRequestPending.store(
+        false, std::memory_order_release);
+    g_visualTreeWatcherGeneration.store(
+        0, std::memory_order_release);
     {
         std::lock_guard<std::mutex> guard(
             g_visualTreeWatchersMutex);
@@ -2202,6 +2308,12 @@ void InitializeModernUi() {
             g_visualTreeWatchers.emplace();
         }
     }
+    {
+        std::lock_guard<std::mutex> guard(
+            g_modernTextStateThreadsMutex);
+        g_modernTextStateThreads.clear();
+    }
+    g_stoppingModernUi.store(false, std::memory_order_release);
 }
 
 void UninitializeModernUi() {
@@ -2268,7 +2380,14 @@ bool InstallHook(Function target,
 bool HookClassicTooltipThemeDrawing() {
     HMODULE themeModule = GetModuleHandleW(L"uxtheme.dll");
     if (!themeModule) {
-        Wh_Log(L"Couldn't find loaded uxtheme.dll");
+        themeModule = LoadLibraryExW(
+            L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+        if (themeModule) {
+            g_loadedUxThemeModule = themeModule;
+        }
+    }
+    if (!themeModule) {
+        Wh_Log(L"Couldn't load uxtheme.dll");
         return false;
     }
 
@@ -2359,7 +2478,17 @@ bool HookClassicTooltipThemeDrawing() {
         Wh_Log(L"Couldn't find DrawThemeTextEx");
     }
 
+    if (!hooked && g_loadedUxThemeModule) {
+        FreeLibrary(g_loadedUxThemeModule);
+        g_loadedUxThemeModule = nullptr;
+    }
     return hooked;
+}
+
+bool ReadUnicodeLettersAndDigitsSetting() {
+    auto characterMode =
+        WindhawkUtils::StringSetting::make(L"characterMode");
+    return _wcsicmp(characterMode, L"ascii") != 0;
 }
 
 void LoadSettings() {
@@ -2371,10 +2500,7 @@ void LoadSettings() {
     g_modernUiText.store(Wh_GetIntSetting(L"modernUiText") != 0,
                          std::memory_order_relaxed);
 
-    auto characterMode =
-        WindhawkUtils::StringSetting::make(L"characterMode");
-    const bool unicodeMode =
-        _wcsicmp(characterMode, L"ascii") != 0;
+    const bool unicodeMode = ReadUnicodeLettersAndDigitsSetting();
     g_unicodeLettersAndDigits.store(unicodeMode,
                                     std::memory_order_relaxed);
 }
@@ -2473,10 +2599,24 @@ void Wh_ModUninit() {
     if (g_modernUiText.load(std::memory_order_relaxed)) {
         UninitializeModernUi();
     }
+    if (g_loadedUxThemeModule) {
+        FreeLibrary(g_loadedUxThemeModule);
+        g_loadedUxThemeModule = nullptr;
+    }
     Wh_Log(L"Uninitialized");
 }
 
 BOOL Wh_ModSettingsChanged(BOOL* reload) {
-    *reload = TRUE;
+    const bool hooksChanged =
+        g_classicMenus.load(std::memory_order_relaxed) !=
+            (Wh_GetIntSetting(L"classicMenus") != 0) ||
+        g_classicTooltips.load(std::memory_order_relaxed) !=
+            (Wh_GetIntSetting(L"classicTooltips") != 0) ||
+        g_modernUiText.load(std::memory_order_relaxed) !=
+            (Wh_GetIntSetting(L"modernUiText") != 0);
+    g_unicodeLettersAndDigits.store(
+        ReadUnicodeLettersAndDigitsSetting(),
+        std::memory_order_relaxed);
+    *reload = hooksChanged ? TRUE : FALSE;
     return TRUE;
 }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer menus, tooltips, and popups
-// @version         0.1.3
+// @version         0.1.4
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -51,7 +51,7 @@ keyboard shortcut text are also preserved.
 - Classic Win32 tooltips, including legacy notification-area icon tooltips, are
   rewritten only through theme handles opened for the `TOOLTIP` class, covering
   both text measurement and drawing without touching unrelated GDI text.
-- Windows 11 XAML/WinUI popup text uses an experimental, display-only
+- Windows 11 XAML popup text uses an experimental, display-only
   DirectWrite hook. This includes context menus, tooltips, and other Explorer
   flyouts. Tracking is scoped to the popup's UI thread so it doesn't enable
   rewriting on unrelated Explorer or taskbar threads. Taskbar thumbnail
@@ -61,11 +61,12 @@ The modern path is intentionally conservative and can miss text if a Windows
 build uses a different popup window class. Disable `modernUiText` if it causes
 a problem.
 
-The mod doesn't edit system files, registry values, or file names. The modern
-DirectWrite path changes display text only. The classic path updates strings
-stored in `HMENU` objects, so menu text read through accessibility APIs also
-contains the inserted spaces while the mod is enabled. Strings rewritten just
-before display are recorded and restored when the mod is disabled.
+The mod doesn't edit system files, registry values, or file names. A file name
+shown in a classic menu can nevertheless be displayed with inserted spaces.
+The modern DirectWrite path changes display text only. The classic path updates
+strings stored in `HMENU` objects, so menu text read through accessibility APIs
+also contains the inserted spaces while the mod is enabled. Strings rewritten
+just before display are recorded and restored when the mod is disabled.
 */
 // ==/WindhawkModReadme==
 
@@ -79,7 +80,7 @@ before display are recorded and restored when the mod is disabled.
   $description: Process text in legacy tooltips such as notification-area icon tooltips.
 - modernUiText: true
   $name: Windows 11 popup text (experimental)
-  $description: Process DirectWrite text in Explorer XAML/WinUI menus, tooltips, and flyouts.
+  $description: Process DirectWrite text in Explorer XAML menus, tooltips, and flyouts.
 - characterMode: unicode
   $name: Non-CJK character set
   $description: Choose which letters and digits form a spacing boundary with CJK.
@@ -89,7 +90,6 @@ before display are recorded and restored when the mod is disabled.
 */
 // ==/WindhawkModSettings==
 
-#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <cstring>
@@ -98,6 +98,7 @@ before display are recorded and restored when the mod is disabled.
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <dwrite.h>
@@ -155,9 +156,12 @@ bool IsCjkCodePoint(uint32_t codePoint) {
     // Jamo, CJK strokes, and Katakana phonetic extensions. CJK punctuation is
     // deliberately excluded except for the ideographic iteration mark and
     // ideographic zero.
+    const bool isKana =
+        IsInRange(codePoint, 0x3040, 0x30FF) &&
+        codePoint != 0x30A0 && codePoint != 0x30FB;
     if (IsInRange(codePoint, 0x2E80, 0x2FDF) ||
         codePoint == 0x3005 || codePoint == 0x3007 ||
-        IsInRange(codePoint, 0x3040, 0x30FF) ||
+        isKana ||
         IsInRange(codePoint, 0x3100, 0x318F) ||
         IsInRange(codePoint, 0x31A0, 0x31BF) ||
         IsInRange(codePoint, 0x31C0, 0x31EF) ||
@@ -393,7 +397,7 @@ BOOL WINAPI InsertMenuWHook(HMENU menu,
                             UINT_PTR itemId,
                             LPCWSTR newItem) {
     if (g_classicMenus.load(std::memory_order_relaxed) && newItem &&
-        IsStringMenuFlags(flags)) {
+        IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
         if (spaced != newItem) {
             Wh_Log(L"Applied CJK spacing (classic/InsertMenuW)");
@@ -410,7 +414,7 @@ BOOL WINAPI AppendMenuWHook(HMENU menu,
                             UINT_PTR itemId,
                             LPCWSTR newItem) {
     if (g_classicMenus.load(std::memory_order_relaxed) && newItem &&
-        IsStringMenuFlags(flags)) {
+        IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
         if (spaced != newItem) {
             Wh_Log(L"Applied CJK spacing (classic/AppendMenuW)");
@@ -427,7 +431,7 @@ BOOL WINAPI ModifyMenuWHook(HMENU menu,
                             UINT_PTR itemId,
                             LPCWSTR newItem) {
     if (g_classicMenus.load(std::memory_order_relaxed) && newItem &&
-        IsStringMenuFlags(flags)) {
+        IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
         if (spaced != newItem) {
             Wh_Log(L"Applied CJK spacing (classic/ModifyMenuW)");
@@ -539,13 +543,8 @@ void RestoreRewrittenMenuItems() {
         replacement.dwTypeData =
             const_cast<wchar_t*>(iterator->original.c_str());
 
-        if (g_originalSetMenuItemInfoW) {
-            g_originalSetMenuItemInfoW(
-                iterator->menu, iterator->index, TRUE, &replacement);
-        } else {
-            SetMenuItemInfoW(
-                iterator->menu, iterator->index, TRUE, &replacement);
-        }
+        SetMenuItemInfoW(
+            iterator->menu, iterator->index, TRUE, &replacement);
     }
 }
 
@@ -554,7 +553,8 @@ BOOL WINAPI InsertMenuItemWHook(HMENU menu,
                                 BOOL byPosition,
                                 LPCMENUITEMINFOW itemInfo) {
     if (g_classicMenus.load(std::memory_order_relaxed) &&
-        MenuItemInfoContainsString(itemInfo)) {
+        MenuItemInfoContainsString(itemInfo) &&
+        ContainsCjkCodePoint(itemInfo->dwTypeData)) {
         const std::wstring spaced = AddCjkSpacing(itemInfo->dwTypeData);
         if (spaced != itemInfo->dwTypeData) {
             Wh_Log(L"Applied CJK spacing (classic/InsertMenuItemW)");
@@ -573,7 +573,8 @@ BOOL WINAPI SetMenuItemInfoWHook(HMENU menu,
                                  BOOL byPosition,
                                  LPCMENUITEMINFOW itemInfo) {
     if (g_classicMenus.load(std::memory_order_relaxed) &&
-        MenuItemInfoContainsString(itemInfo)) {
+        MenuItemInfoContainsString(itemInfo) &&
+        ContainsCjkCodePoint(itemInfo->dwTypeData)) {
         const std::wstring spaced = AddCjkSpacing(itemInfo->dwTypeData);
         if (spaced != itemInfo->dwTypeData) {
             Wh_Log(L"Applied CJK spacing (classic/SetMenuItemInfoW)");
@@ -604,7 +605,8 @@ void RewriteMenuTree(HMENU menu) {
 
         if (isTextItem && itemInfo.cch > 0) {
             std::wstring original;
-            if (ReadMenuItemText(menu, index, &original)) {
+            if (ReadMenuItemText(menu, index, &original) &&
+                ContainsCjkCodePoint(original)) {
                 const std::wstring spaced = AddCjkSpacing(original);
                 if (spaced != original) {
                     Wh_Log(L"Applied CJK spacing (classic/pre-display)");
@@ -676,9 +678,9 @@ GetThemeTextExtent_t g_originalGetThemeTextExtent;
 DrawThemeText_t g_originalDrawThemeText;
 DrawThemeTextEx_t g_originalDrawThemeTextEx;
 
-constexpr size_t kClassicTooltipThemeCapacity = 16;
-std::atomic<HTHEME>
-    g_classicTooltipThemes[kClassicTooltipThemeCapacity] = {};
+std::mutex g_classicTooltipThemesMutex;
+std::unordered_set<HTHEME> g_classicTooltipThemes;
+std::atomic_uint g_classicTooltipThemeCount{0};
 thread_local bool g_rewritingClassicTooltipText = false;
 
 bool IsClassicTooltipThemeClassList(LPCWSTR classList) {
@@ -705,34 +707,33 @@ bool IsClassicTooltipThemeClassList(LPCWSTR classList) {
 }
 
 bool IsTrackedClassicTooltipTheme(HTHEME theme) {
-    if (!theme) {
+    if (!theme ||
+        g_classicTooltipThemeCount.load(
+            std::memory_order_relaxed) == 0) {
         return false;
     }
 
-    for (auto& trackedTheme : g_classicTooltipThemes) {
-        if (trackedTheme.load(std::memory_order_relaxed) == theme) {
-            return true;
-        }
-    }
-
-    return false;
+    std::lock_guard<std::mutex> guard(g_classicTooltipThemesMutex);
+    return g_classicTooltipThemes.contains(theme);
 }
 
 void TrackClassicTooltipTheme(HTHEME theme) {
-    if (!theme || IsTrackedClassicTooltipTheme(theme)) {
+    if (!theme) {
         return;
     }
 
-    for (auto& trackedTheme : g_classicTooltipThemes) {
-        HTHEME empty = nullptr;
-        if (trackedTheme.compare_exchange_strong(
-                empty, theme, std::memory_order_relaxed)) {
-            Wh_Log(L"Tracking classic Win32 tooltip theme");
-            return;
-        }
+    bool inserted;
+    {
+        std::lock_guard<std::mutex> guard(g_classicTooltipThemesMutex);
+        inserted = g_classicTooltipThemes.insert(theme).second;
+        g_classicTooltipThemeCount.store(
+            static_cast<unsigned int>(g_classicTooltipThemes.size()),
+            std::memory_order_relaxed);
     }
 
-    Wh_Log(L"Classic tooltip theme tracking capacity reached");
+    if (inserted) {
+        Wh_Log(L"Tracking classic Win32 tooltip theme");
+    }
 }
 
 void UntrackClassicTooltipTheme(HTHEME theme) {
@@ -740,11 +741,17 @@ void UntrackClassicTooltipTheme(HTHEME theme) {
         return;
     }
 
-    for (auto& trackedTheme : g_classicTooltipThemes) {
-        HTHEME expected = theme;
-        trackedTheme.compare_exchange_strong(
-            expected, nullptr, std::memory_order_relaxed);
-    }
+    std::lock_guard<std::mutex> guard(g_classicTooltipThemesMutex);
+    g_classicTooltipThemes.erase(theme);
+    g_classicTooltipThemeCount.store(
+        static_cast<unsigned int>(g_classicTooltipThemes.size()),
+        std::memory_order_relaxed);
+}
+
+void ClearTrackedClassicTooltipThemes() {
+    std::lock_guard<std::mutex> guard(g_classicTooltipThemesMutex);
+    g_classicTooltipThemes.clear();
+    g_classicTooltipThemeCount.store(0, std::memory_order_relaxed);
 }
 
 HTHEME WINAPI OpenThemeDataHook(HWND window, LPCWSTR classList) {
@@ -917,7 +924,7 @@ HRESULT WINAPI DrawThemeTextExHook(HTHEME theme,
 }
 
 // -------------------------------------------------------------------------
-// Windows 11 XAML/WinUI popup detection
+// Windows 11 XAML popup detection
 // -------------------------------------------------------------------------
 
 using ShowWindow_t = decltype(&ShowWindow);
@@ -949,9 +956,7 @@ ModernWindowKind ClassifyModernWindowClassName(LPCWSTR className) {
         return ModernWindowKind::Other;
     }
 
-    if (_wcsicmp(className, L"Xaml_WindowedPopupClass") == 0 ||
-        _wcsicmp(className,
-                 L"Microsoft.UI.Content.PopupWindowSiteBridge") == 0) {
+    if (_wcsicmp(className, L"Xaml_WindowedPopupClass") == 0) {
         return ModernWindowKind::Popup;
     }
 
@@ -974,9 +979,10 @@ bool TrackModernWindow(HWND window, ModernWindowKind kind) {
         return false;
     }
 
+    DWORD processId;
     const DWORD threadId =
-        GetWindowThreadProcessId(window, nullptr);
-    if (!threadId) {
+        GetWindowThreadProcessId(window, &processId);
+    if (!threadId || processId != GetCurrentProcessId()) {
         return false;
     }
 
@@ -1031,6 +1037,11 @@ void ClearTrackedModernWindows() {
 }
 
 bool IsModernPopupActiveForCurrentThread() {
+    if (g_trackedModernWindowCount.load(
+            std::memory_order_relaxed) == 0) {
+        return false;
+    }
+
     const DWORD currentThreadId = GetCurrentThreadId();
     bool popupActive = false;
     bool taskbarThumbnailActive = false;
@@ -1150,7 +1161,7 @@ BOOL WINAPI DestroyWindowHook(HWND window) {
 }
 
 // -------------------------------------------------------------------------
-// DirectWrite text layout used by Windows 11 XAML/WinUI popups
+// DirectWrite text layout used by Windows 11 XAML popups
 // -------------------------------------------------------------------------
 
 using IDWriteFactory_CreateTextLayout_t =
@@ -1279,24 +1290,20 @@ HRESULT STDMETHODCALLTYPE CreateGdiCompatibleTextLayoutHook(
         transform, useGdiNatural, textLayout);
 }
 
-bool HookDWriteFactory(HMODULE module,
-                       const char* factoryExport,
-                       void* createTextLayoutHook,
-                       IDWriteFactory_CreateTextLayout_t* originalTextLayout,
-                       void* createGdiLayoutHook,
-                       IDWriteFactory_CreateGdiCompatibleTextLayout_t*
-                           originalGdiLayout,
-                       const wchar_t* implementationName) {
-    if (!module) {
+bool HookDirectWrite() {
+    HMODULE dwrite =
+        LoadLibraryExW(L"dwrite.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!dwrite) {
+        Wh_Log(L"Couldn't load dwrite.dll");
         return false;
     }
 
     using DWriteCreateFactory_t =
         HRESULT(WINAPI*)(DWRITE_FACTORY_TYPE, REFIID, IUnknown**);
     const auto createFactory = reinterpret_cast<DWriteCreateFactory_t>(
-        GetProcAddress(module, factoryExport));
+        GetProcAddress(dwrite, "DWriteCreateFactory"));
     if (!createFactory) {
-        Wh_Log(L"Couldn't find %s factory export", implementationName);
+        Wh_Log(L"Couldn't find DWriteCreateFactory");
         return false;
     }
 
@@ -1305,46 +1312,27 @@ bool HookDWriteFactory(HMODULE module,
         createFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory),
                       reinterpret_cast<IUnknown**>(&factory));
     if (FAILED(result) || !factory) {
-        Wh_Log(L"%s factory creation failed: 0x%08X", implementationName,
-               result);
+        Wh_Log(L"DirectWrite factory creation failed: 0x%08X", result);
         return false;
     }
 
     void** vtable = *reinterpret_cast<void***>(factory);
     const bool textLayoutHooked = Wh_SetFunctionHook(
-        vtable[18], createTextLayoutHook,
-        reinterpret_cast<void**>(originalTextLayout));
+        vtable[18], reinterpret_cast<void*>(CreateTextLayoutHook),
+        reinterpret_cast<void**>(&g_originalCreateTextLayout));
     const bool gdiLayoutHooked = Wh_SetFunctionHook(
-        vtable[19], createGdiLayoutHook,
-        reinterpret_cast<void**>(originalGdiLayout));
+        vtable[19],
+        reinterpret_cast<void*>(CreateGdiCompatibleTextLayoutHook),
+        reinterpret_cast<void**>(
+            &g_originalCreateGdiCompatibleTextLayout));
 
     factory->Release();
 
     if (!textLayoutHooked || !gdiLayoutHooked) {
-        Wh_Log(L"Couldn't install one or more %s hooks",
-               implementationName);
+        Wh_Log(L"Couldn't install one or more DirectWrite hooks");
     }
 
     return textLayoutHooked || gdiLayoutHooked;
-}
-
-bool HookDirectWrite() {
-    bool hooked = false;
-
-    HMODULE dwrite =
-        LoadLibraryExW(L"dwrite.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-    if (dwrite) {
-        hooked |= HookDWriteFactory(
-            dwrite, "DWriteCreateFactory",
-            reinterpret_cast<void*>(CreateTextLayoutHook),
-            &g_originalCreateTextLayout,
-            reinterpret_cast<void*>(CreateGdiCompatibleTextLayoutHook),
-            &g_originalCreateGdiCompatibleTextLayout, L"DirectWrite");
-    } else {
-        Wh_Log(L"Couldn't load dwrite.dll");
-    }
-
-    return hooked;
 }
 
 template <typename Function>
@@ -1526,6 +1514,7 @@ BOOL Wh_ModInit() {
 
 void Wh_ModUninit() {
     RestoreRewrittenMenuItems();
+    ClearTrackedClassicTooltipThemes();
     ClearTrackedModernWindows();
     Wh_Log(L"CJK Spacer uninitialized");
 }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips; modern XAML UI is opt-in and may conflict with other XAML Diagnostics mods
-// @version         0.1.19
+// @version         0.1.20
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -66,8 +66,9 @@ keyboard shortcut text are also preserved.
 - Classic Win32 tooltips, including legacy notification-area icon tooltips, are
   rewritten only through theme handles opened for the `TOOLTIP` class, covering
   both text measurement and drawing without touching unrelated GDI text.
-  Each tracked theme is tied to the Tooltip window that opened it, and a DC
-  mapped to another window is rejected.
+  Shared theme handles retain a reference for every Tooltip window that opened
+  them. A DC mapped to another window is rejected, while buffered DCs that do
+  not map to a window are accepted.
   Existing tooltip controls are discovered when the mod is enabled in a
   running Explorer. Basic or classic-theme tooltips drawn directly with
   `DrawTextW` aren't covered.
@@ -625,6 +626,9 @@ MENUITEMINFOW CopyMenuItemInfoForRewrite(
         itemInfo->cbSize < sizeof(copy) ? itemInfo->cbSize
                                         : sizeof(copy);
     std::memcpy(&copy, itemInfo, copySize);
+    // Keep the copied structure self-consistent when callers provide a
+    // smaller version of MENUITEMINFOW.
+    copy.cbSize = static_cast<UINT>(copySize);
     return copy;
 }
 
@@ -941,7 +945,10 @@ DrawThemeText_t g_originalDrawThemeText;
 DrawThemeTextEx_t g_originalDrawThemeTextEx;
 HMODULE g_loadedUxThemeModule;
 std::shared_mutex g_classicTooltipThemesMutex;
-std::unordered_map<HTHEME, HWND> g_classicTooltipThemes;
+// A theme handle can be shared by multiple tooltip windows. Keep one entry
+// per matching OpenThemeData call so CloseThemeData can release the right
+// number of references without letting the last window overwrite the rest.
+std::unordered_map<HTHEME, std::vector<HWND>> g_classicTooltipThemes;
 std::atomic_uint g_classicTooltipThemeCount{0};
 thread_local bool g_rewritingClassicTooltipText = false;
 
@@ -979,27 +986,22 @@ bool IsClassicTooltipThemeClassList(LPCWSTR classList) {
     return false;
 }
 
-HWND FindTrackedClassicTooltipWindow(HTHEME theme) {
+bool IsClassicTooltipWindow(HWND window);
+
+bool IsTrackedClassicTooltipTheme(HTHEME theme) {
     if (!theme ||
         g_classicTooltipThemeCount.load(
             std::memory_order_relaxed) == 0) {
-        return nullptr;
+        return false;
     }
 
     std::shared_lock<std::shared_mutex> guard(
         g_classicTooltipThemesMutex);
-    const auto iterator = g_classicTooltipThemes.find(theme);
-    return iterator != g_classicTooltipThemes.end()
-               ? iterator->second
-               : nullptr;
-}
-
-bool IsTrackedClassicTooltipTheme(HTHEME theme) {
-    return FindTrackedClassicTooltipWindow(theme) != nullptr;
+    return g_classicTooltipThemes.contains(theme);
 }
 
 void TrackClassicTooltipTheme(HTHEME theme, HWND window) {
-    if (!theme || !window) {
+    if (!theme || !window || !IsClassicTooltipWindow(window)) {
         return;
     }
 
@@ -1007,10 +1009,10 @@ void TrackClassicTooltipTheme(HTHEME theme, HWND window) {
     {
         std::lock_guard<std::shared_mutex> guard(
             g_classicTooltipThemesMutex);
-        inserted = g_classicTooltipThemes.emplace(theme, window).second;
-        if (!inserted) {
-            g_classicTooltipThemes[theme] = window;
-        }
+        auto [iterator, wasInserted] =
+            g_classicTooltipThemes.try_emplace(theme);
+        inserted = wasInserted;
+        iterator->second.push_back(window);
         g_classicTooltipThemeCount.store(
             static_cast<unsigned int>(g_classicTooltipThemes.size()),
             std::memory_order_relaxed);
@@ -1021,28 +1023,30 @@ void TrackClassicTooltipTheme(HTHEME theme, HWND window) {
     }
 }
 
-void UntrackClassicTooltipTheme(HTHEME theme) {
+bool UntrackClassicTooltipTheme(HTHEME theme) {
     if (!theme ||
         g_classicTooltipThemeCount.load(
             std::memory_order_relaxed) == 0) {
-        return;
-    }
-
-    {
-        std::shared_lock<std::shared_mutex> guard(
-            g_classicTooltipThemesMutex);
-        if (!g_classicTooltipThemes.contains(theme)) {
-            return;
-        }
+        return false;
     }
 
     std::lock_guard<std::shared_mutex> guard(
         g_classicTooltipThemesMutex);
-    if (g_classicTooltipThemes.erase(theme) != 0) {
+    const auto iterator = g_classicTooltipThemes.find(theme);
+    if (iterator == g_classicTooltipThemes.end()) {
+        return false;
+    }
+
+    if (!iterator->second.empty()) {
+        iterator->second.pop_back();
+    }
+    if (iterator->second.empty()) {
+        g_classicTooltipThemes.erase(iterator);
         g_classicTooltipThemeCount.store(
             static_cast<unsigned int>(g_classicTooltipThemes.size()),
             std::memory_order_relaxed);
     }
+    return true;
 }
 
 void ClearTrackedClassicTooltipThemes() {
@@ -1060,13 +1064,15 @@ bool IsClassicTooltipWindow(HWND window) {
 }
 
 bool IsClassicTooltipTarget(HTHEME theme, HDC dc) {
-    const HWND trackedWindow = FindTrackedClassicTooltipWindow(theme);
-    if (!trackedWindow || !IsClassicTooltipWindow(trackedWindow)) {
+    if (!IsTrackedClassicTooltipTheme(theme)) {
         return false;
     }
 
     const HWND window = dc ? WindowFromDC(dc) : nullptr;
-    return !window || window == trackedWindow;
+    // Buffered theme drawing may not expose an HWND through WindowFromDC.
+    // When it does, accept any actual classic tooltip window: a single HTHEME
+    // is commonly shared by several tooltips in the same process.
+    return !window || IsClassicTooltipWindow(window);
 }
 
 BOOL CALLBACK EnumExistingClassicTooltipWindow(HWND window, LPARAM) {
@@ -1090,8 +1096,6 @@ HTHEME WINAPI OpenThemeDataHook(HWND window, LPCWSTR classList) {
     HTHEME theme = g_originalOpenThemeData(window, classList);
     if (IsClassicTooltipThemeClassList(classList)) {
         TrackClassicTooltipTheme(theme, window);
-    } else {
-        UntrackClassicTooltipTheme(theme);
     }
 
     return theme;
@@ -1104,8 +1108,6 @@ HTHEME WINAPI OpenThemeDataExHook(HWND window,
         g_originalOpenThemeDataEx(window, classList, flags);
     if (IsClassicTooltipThemeClassList(classList)) {
         TrackClassicTooltipTheme(theme, window);
-    } else {
-        UntrackClassicTooltipTheme(theme);
     }
 
     return theme;
@@ -1118,17 +1120,13 @@ HTHEME WINAPI OpenThemeDataForDpiHook(HWND window,
         g_originalOpenThemeDataForDpi(window, classList, dpi);
     if (IsClassicTooltipThemeClassList(classList)) {
         TrackClassicTooltipTheme(theme, window);
-    } else {
-        UntrackClassicTooltipTheme(theme);
     }
 
     return theme;
 }
 
 HRESULT WINAPI CloseThemeDataHook(HTHEME theme) {
-    if (IsTrackedClassicTooltipTheme(theme)) {
-        UntrackClassicTooltipTheme(theme);
-    }
+    UntrackClassicTooltipTheme(theme);
     return g_originalCloseThemeData(theme);
 }
 
@@ -2132,10 +2130,26 @@ void EnsureModernXamlDiagnostics(uint64_t generation) {
     }
 }
 
+bool NeedsXamlDiagnosticsConnection() {
+    return (!g_windowsUiXamlDiagnosticsConnected.load(
+                 std::memory_order_acquire) &&
+            GetModuleHandleW(L"Windows.UI.Xaml.dll")) ||
+           (!g_microsoftUiXamlDiagnosticsConnected.load(
+                 std::memory_order_acquire) &&
+            GetModuleHandleW(L"Microsoft.Internal.FrameworkUdk.dll"));
+}
+
 void RequestModernXamlDiagnosticsInitialization() {
     const uint64_t generation =
         g_modernUiGeneration.load(std::memory_order_acquire);
     if (!IsCurrentModernUiGeneration(generation)) {
+        return;
+    }
+
+    // Host-window creation can be noisy. Once all currently loaded XAML
+    // diagnostics connections are established, avoid creating another worker
+    // until SetSite(nullptr) explicitly marks one as disconnected.
+    if (!NeedsXamlDiagnosticsConnection()) {
         return;
     }
 

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,13 +2,13 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.9
+// @version         0.1.10
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject
 // ==/WindhawkMod==
 
 // Source code is published under the GNU General Public License v3.0.
@@ -58,11 +58,12 @@ keyboard shortcut text are also preserved.
   running Explorer. Basic or classic-theme tooltips drawn directly with
   `DrawTextW` aren't covered.
 - Windows 11 XAML context menus and pointer tooltips are handled at the XAML
-  element level. Only `TextBlock` elements below a `MenuFlyoutPresenter` or
-  `ToolTip` are changed; ordinary XAML text and taskbar thumbnail previews are
-  outside this scope. Popup visibility is maintained from accessibility
-  show/hide/destroy events, and modified text is restored when an element is
-  unloaded. This path is disabled by default; enable `modernUiText` to opt in.
+  source-element level. Only the `Text` source of XAML menu items and
+  string-valued `ToolTip.Content` are changed; presenter `TextBlock` bindings,
+  ordinary XAML text, and taskbar thumbnail previews are untouched. Popup
+  visibility is maintained from accessibility show/hide/destroy events, and
+  each source is restored only when its owning popup closes. This path is
+  disabled by default; enable `modernUiText` to opt in.
 
 The modern path supports both Windows.UI.Xaml and Microsoft.UI.Xaml content
 hosted by Explorer. XAML Diagnostics allows one consumer per XAML connection,
@@ -75,11 +76,11 @@ flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
 
 The mod doesn't edit system files, registry values, or file names. A file name
 shown in a classic menu can nevertheless be displayed with inserted spaces.
-The modern path temporarily changes target `TextBlock` values and restores
-them when the elements are unloaded. The classic path updates strings stored in
-active `HMENU` objects, so menu text read through accessibility APIs also
-contains the inserted spaces while the popup is open. Rewritten strings are
-recorded and restored when the popup closes.
+The modern path temporarily changes target source values on their XAML UI
+threads and restores them with their owning popup. The classic path updates
+strings stored in active `HMENU` objects, so menu text read through
+accessibility APIs also contains the inserted spaces while the popup is open.
+Rewritten strings are recorded and restored when the popup closes.
 */
 // ==/WindhawkModReadme==
 
@@ -111,6 +112,7 @@ recorded and restored when the popup closes.
 #include <cwchar>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
@@ -130,6 +132,7 @@ recorded and restored when the popup closes.
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Media.h>
 #include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.h>
@@ -963,9 +966,12 @@ bool IsClassicTooltipWindow(HWND window) {
 }
 
 bool IsClassicTooltipTarget(HTHEME theme, HDC dc) {
+    if (!IsTrackedClassicTooltipTheme(theme)) {
+        return false;
+    }
+
     const HWND window = dc ? WindowFromDC(dc) : nullptr;
-    return window ? IsClassicTooltipWindow(window)
-                  : IsTrackedClassicTooltipTheme(theme);
+    return !window || IsClassicTooltipWindow(window);
 }
 
 BOOL CALLBACK EnumExistingClassicTooltipWindow(HWND window, LPARAM) {
@@ -1190,10 +1196,12 @@ namespace mux = winrt::Microsoft::UI::Xaml;
 
 struct VisibleModernPopup {
     DWORD threadId;
+    uint64_t sequence;
 };
 
 std::mutex g_visibleModernPopupsMutex;
 std::unordered_map<HWND, VisibleModernPopup> g_visibleModernPopups;
+uint64_t g_nextModernPopupSequence;
 HWINEVENTHOOK g_modernPopupWinEventHook;
 
 bool IsModernPopupClassName(LPCWSTR className) {
@@ -1210,8 +1218,9 @@ bool IsModernPopupWindow(HWND window) {
            IsModernPopupClassName(className);
 }
 
-bool TrackVisibleModernPopup(HWND window) {
-    if (!window || !IsWindowVisible(window) ||
+bool TrackVisibleModernPopup(HWND window, bool requireVisible) {
+    if (!window ||
+        (requireVisible && !IsWindowVisible(window)) ||
         !IsModernPopupWindow(window)) {
         return false;
     }
@@ -1224,54 +1233,69 @@ bool TrackVisibleModernPopup(HWND window) {
     }
 
     std::lock_guard<std::mutex> guard(g_visibleModernPopupsMutex);
-    g_visibleModernPopups[window] = {threadId};
+    g_visibleModernPopups[window] = {
+        threadId, ++g_nextModernPopupSequence};
     return true;
 }
 
+bool IsTrackedModernPopup(HWND window, DWORD threadId) {
+    std::lock_guard<std::mutex> guard(g_visibleModernPopupsMutex);
+    const auto iterator = g_visibleModernPopups.find(window);
+    return iterator != g_visibleModernPopups.end() &&
+           iterator->second.threadId == threadId &&
+           IsWindow(window) && IsModernPopupWindow(window);
+}
+
 struct FindVisibleModernPopupData {
-    bool found;
+    HWND window;
 };
 
 BOOL CALLBACK FindVisibleModernPopupForThread(HWND window, LPARAM parameter) {
     auto* data =
         reinterpret_cast<FindVisibleModernPopupData*>(parameter);
     if (IsWindowVisible(window) && IsModernPopupWindow(window)) {
-        data->found = true;
-        TrackVisibleModernPopup(window);
+        data->window = window;
+        TrackVisibleModernPopup(window, true);
         return FALSE;
     }
 
     return TRUE;
 }
 
-bool IsModernPopupVisibleOnThread(DWORD threadId) {
+HWND GetMostRecentModernPopupForThread(DWORD threadId) {
+    HWND result = nullptr;
+    uint64_t latestSequence = 0;
     {
         std::lock_guard<std::mutex> guard(
             g_visibleModernPopupsMutex);
         for (auto iterator = g_visibleModernPopups.begin();
              iterator != g_visibleModernPopups.end();) {
             if (!IsWindow(iterator->first) ||
-                !IsWindowVisible(iterator->first) ||
                 !IsModernPopupWindow(iterator->first)) {
                 iterator = g_visibleModernPopups.erase(iterator);
                 continue;
             }
 
-            if (iterator->second.threadId == threadId) {
-                return true;
+            if (iterator->second.threadId == threadId &&
+                iterator->second.sequence > latestSequence) {
+                result = iterator->first;
+                latestSequence = iterator->second.sequence;
             }
 
             ++iterator;
         }
     }
 
-    // SHOW normally populates the map before XAML Loaded runs. This fallback
-    // covers an already-visible popup and delayed out-of-context delivery.
+    if (result) {
+        return result;
+    }
+
+    // Covers a popup that was already visible when the mod was enabled.
     FindVisibleModernPopupData data{};
     EnumThreadWindows(
         threadId, FindVisibleModernPopupForThread,
         reinterpret_cast<LPARAM>(&data));
-    return data.found;
+    return data.window;
 }
 
 BOOL CALLBACK DiscoverVisibleModernPopup(HWND window, LPARAM) {
@@ -1279,7 +1303,7 @@ BOOL CALLBACK DiscoverVisibleModernPopup(HWND window, LPARAM) {
     GetWindowThreadProcessId(window, &processId);
     if (processId == GetCurrentProcessId() &&
         IsWindowVisible(window)) {
-        TrackVisibleModernPopup(window);
+        TrackVisibleModernPopup(window, true);
     }
 
     return TRUE;
@@ -1290,212 +1314,253 @@ void ClearVisibleModernPopups() {
     g_visibleModernPopups.clear();
 }
 
-bool IsTargetModernAncestorClass(std::wstring_view className) {
-    return className.ends_with(L".MenuFlyoutPresenter") ||
-           className.ends_with(L".ToolTip");
-}
+struct TextSourceAccess {
+    template <typename Element>
+    static bool Read(const Element& element, std::wstring* text) {
+        const auto value = element.Text();
+        text->assign(value.c_str(), value.size());
+        return true;
+    }
 
-template <typename TextBlock, typename VisualTreeHelper>
-bool IsTargetModernTextElement(const TextBlock& textBlock) {
-    auto current = VisualTreeHelper::GetParent(textBlock);
-    for (unsigned int depth = 0; depth < 64; ++depth) {
-        if (!current) {
+    template <typename Element>
+    static void Write(const Element& element, std::wstring_view text) {
+        element.Text(winrt::hstring(text));
+    }
+
+    static constexpr PCWSTR Name() {
+        return L"menu source";
+    }
+};
+
+struct TooltipContentAccess {
+    template <typename Element>
+    static bool Read(const Element& element, std::wstring* text) {
+        const auto content = element.Content();
+        if (!content) {
             return false;
         }
 
-        const auto className = winrt::get_class_name(current);
-        if (IsTargetModernAncestorClass(
-                std::wstring_view(className.c_str(), className.size()))) {
+        try {
+            const auto value =
+                winrt::unbox_value<winrt::hstring>(content);
+            text->assign(value.c_str(), value.size());
             return true;
+        } catch (const winrt::hresult_error&) {
+            return false;
         }
-
-        current = VisualTreeHelper::GetParent(current);
     }
 
-    return false;
-}
+    template <typename Element>
+    static void Write(const Element& element, std::wstring_view text) {
+        element.Content(winrt::box_value(winrt::hstring(text)));
+    }
+
+    static constexpr PCWSTR Name() {
+        return L"tooltip source";
+    }
+};
 
 class ModernTextStateBase {
 public:
-    explicit ModernTextStateBase(DWORD threadId)
-        : m_threadId(threadId) {}
     virtual ~ModernTextStateBase() = default;
-
-    DWORD ThreadId() const {
-        return m_threadId;
-    }
-
-    virtual void Apply() = 0;
+    virtual void Apply(HWND popupWindow) = 0;
     virtual void Restore() = 0;
-    virtual void Detach() = 0;
-
-private:
-    DWORD m_threadId;
+    virtual HWND PopupWindow() const = 0;
 };
 
-std::mutex g_modernTextStatesMutex;
-std::vector<std::weak_ptr<ModernTextStateBase>> g_modernTextStates;
-
-void RegisterModernTextState(
-    const std::shared_ptr<ModernTextStateBase>& state) {
-    std::lock_guard<std::mutex> guard(g_modernTextStatesMutex);
-    g_modernTextStates.emplace_back(state);
-}
-
-void RefreshModernTextStates(DWORD threadId, bool apply) {
-    std::vector<std::shared_ptr<ModernTextStateBase>> states;
-    {
-        std::lock_guard<std::mutex> guard(g_modernTextStatesMutex);
-        auto output = g_modernTextStates.begin();
-        for (auto iterator = g_modernTextStates.begin();
-             iterator != g_modernTextStates.end(); ++iterator) {
-            if (auto state = iterator->lock()) {
-                *output++ = *iterator;
-                if (state->ThreadId() == threadId) {
-                    states.push_back(std::move(state));
-                }
-            }
-        }
-        g_modernTextStates.erase(output, g_modernTextStates.end());
-    }
-
-    for (const auto& state : states) {
-        apply ? state->Apply() : state->Restore();
-    }
-}
-
-template <typename TextBlock, typename VisualTreeHelper>
-class ModernTextState final
-    : public ModernTextStateBase,
-      public std::enable_shared_from_this<
-          ModernTextState<TextBlock, VisualTreeHelper>> {
+template <typename Element, typename SourceAccess>
+class ModernTextState final : public ModernTextStateBase {
 public:
-    explicit ModernTextState(const TextBlock& textBlock)
-        : ModernTextStateBase(GetCurrentThreadId()),
-          m_textBlock(winrt::make_weak(textBlock)) {}
+    explicit ModernTextState(const Element& element)
+        : m_element(winrt::make_weak(element)) {}
 
-    void Attach() {
-        auto textBlock = m_textBlock.get();
-        if (!textBlock) {
-            return;
-        }
-
-        const auto self = this->shared_from_this();
-        m_loadedToken = textBlock.Loaded(
-            [self](const auto&, const auto&) {
-                self->Apply();
-            });
-        m_unloadedToken = textBlock.Unloaded(
-            [self](const auto&, const auto&) {
-                self->Restore();
-            });
-        m_attached = true;
-    }
-
-    void Apply() override {
+    void Apply(HWND popupWindow) override {
+        const DWORD threadId = GetCurrentThreadId();
         if (!g_modernUiText.load(std::memory_order_relaxed) ||
-            !IsModernPopupVisibleOnThread(ThreadId())) {
+            !popupWindow ||
+            !IsTrackedModernPopup(popupWindow, threadId)) {
             return;
         }
 
         try {
-            auto textBlock = m_textBlock.get();
-            if (!textBlock || !textBlock.IsLoaded() ||
-                !IsTargetModernTextElement<TextBlock, VisualTreeHelper>(
-                    textBlock)) {
+            auto element = m_element.get();
+            if (!element || !element.IsLoaded()) {
+                return;
+            }
+
+            if (m_popupWindow && m_popupWindow != popupWindow) {
+                if (IsTrackedModernPopup(m_popupWindow, threadId)) {
+                    return;
+                }
+                Restore();
+            }
+
+            std::wstring current;
+            if (!SourceAccess::Read(element, &current)) {
                 return;
             }
 
             if (m_modified) {
-                const auto current = textBlock.Text();
-                if (std::wstring_view(current.c_str(), current.size()) ==
-                    m_spacedText) {
+                if (current == m_spacedText) {
                     return;
                 }
 
-                // The app updated the text while the popup was open. Use the
-                // new value instead of restoring stale text over it.
+                // The application updated the source while the popup was
+                // visible. Preserve that update and use it as the new source.
                 m_modified = false;
+                m_popupWindow = nullptr;
                 m_originalText.clear();
                 m_spacedText.clear();
             }
 
-            const auto current = textBlock.Text();
-            const std::wstring_view original(current.c_str(),
-                                             current.size());
-            if (!ContainsCjkCodePoint(original)) {
+            if (!ContainsCjkCodePoint(current)) {
                 return;
             }
 
-            std::wstring spaced = AddCjkSpacing(original, false);
-            if (spaced.size() == original.size()) {
+            std::wstring spaced = AddCjkSpacing(current, false);
+            if (spaced.size() == current.size()) {
                 return;
             }
 
-            m_originalText.assign(original);
+            m_originalText = std::move(current);
             m_spacedText = std::move(spaced);
+            m_popupWindow = popupWindow;
             m_modified = true;
-            textBlock.Text(winrt::hstring(m_spacedText));
-            Wh_Log(L"Applied CJK spacing (modern XAML TextBlock)");
+            SourceAccess::Write(element, m_spacedText);
+            Wh_Log(L"Applied CJK spacing (modern XAML %s)",
+                   SourceAccess::Name());
         } catch (const winrt::hresult_error& error) {
-            Wh_Log(L"Couldn't update modern XAML text: 0x%08X",
+            Wh_Log(L"Couldn't update modern XAML source: 0x%08X",
                    error.code());
         }
     }
 
     void Restore() override {
         if (!m_modified) {
+            m_popupWindow = nullptr;
             return;
         }
 
         try {
-            auto textBlock = m_textBlock.get();
-            if (textBlock) {
-                const auto current = textBlock.Text();
-                if (std::wstring_view(current.c_str(), current.size()) ==
-                    m_spacedText) {
-                    textBlock.Text(winrt::hstring(m_originalText));
+            auto element = m_element.get();
+            if (element) {
+                std::wstring current;
+                if (SourceAccess::Read(element, &current) &&
+                    current == m_spacedText) {
+                    SourceAccess::Write(element, m_originalText);
                 }
             }
         } catch (const winrt::hresult_error& error) {
-            Wh_Log(L"Couldn't restore modern XAML text: 0x%08X",
+            Wh_Log(L"Couldn't restore modern XAML source: 0x%08X",
                    error.code());
         }
 
         m_modified = false;
+        m_popupWindow = nullptr;
         m_originalText.clear();
         m_spacedText.clear();
     }
 
-    void Detach() override {
-        Restore();
-        if (!m_attached) {
-            return;
-        }
-
-        try {
-            auto textBlock = m_textBlock.get();
-            if (textBlock) {
-                textBlock.Loaded(m_loadedToken);
-                textBlock.Unloaded(m_unloadedToken);
-            }
-        } catch (const winrt::hresult_error& error) {
-            Wh_Log(L"Couldn't detach modern XAML events: 0x%08X",
-                   error.code());
-        }
-
-        m_attached = false;
+    HWND PopupWindow() const override {
+        return m_popupWindow;
     }
 
 private:
-    winrt::weak_ref<TextBlock> m_textBlock;
-    winrt::event_token m_loadedToken{};
-    winrt::event_token m_unloadedToken{};
-    bool m_attached = false;
+    winrt::weak_ref<Element> m_element;
+    HWND m_popupWindow = nullptr;
     bool m_modified = false;
     std::wstring m_originalText;
     std::wstring m_spacedText;
 };
+
+struct ModernElementKey {
+    const void* watcher;
+    InstanceHandle handle;
+
+    bool operator==(const ModernElementKey&) const = default;
+};
+
+struct ModernElementKeyHash {
+    size_t operator()(const ModernElementKey& key) const {
+        const auto watcher =
+            reinterpret_cast<uintptr_t>(key.watcher);
+        return std::hash<uintptr_t>{}(watcher) ^
+               (std::hash<InstanceHandle>{}(key.handle) << 1);
+    }
+};
+
+bool IsModernMenuSourceType(std::wstring_view type) {
+    return type.ends_with(L".MenuFlyoutItem") ||
+           type.ends_with(L".ToggleMenuFlyoutItem") ||
+           type.ends_with(L".RadioMenuFlyoutItem") ||
+           type.ends_with(L".MenuFlyoutSubItem");
+}
+
+bool IsModernTooltipSourceType(std::wstring_view type) {
+    return type.ends_with(L".ToolTip");
+}
+
+using ModernTextStateMap =
+    std::unordered_map<ModernElementKey,
+                       std::shared_ptr<ModernTextStateBase>,
+                       ModernElementKeyHash>;
+
+[[clang::no_destroy]] thread_local
+    std::optional<ModernTextStateMap>
+        g_modernTextStatesForThread{std::in_place};
+
+std::mutex g_modernTextStateThreadsMutex;
+[[clang::no_destroy]] std::unordered_set<DWORD>
+    g_modernTextStateThreads;
+
+void RegisterModernTextStateThread() {
+    std::lock_guard<std::mutex> guard(
+        g_modernTextStateThreadsMutex);
+    g_modernTextStateThreads.insert(GetCurrentThreadId());
+}
+
+void UnregisterModernTextStateThread() {
+    std::lock_guard<std::mutex> guard(
+        g_modernTextStateThreadsMutex);
+    g_modernTextStateThreads.erase(GetCurrentThreadId());
+}
+
+void ApplyModernTextStatesForPopup(HWND popupWindow) {
+    if (!g_modernTextStatesForThread) {
+        return;
+    }
+
+    for (const auto& [key, state] :
+         *g_modernTextStatesForThread) {
+        state->Apply(popupWindow);
+    }
+}
+
+void RestoreModernTextStatesForPopup(HWND popupWindow) {
+    if (!g_modernTextStatesForThread) {
+        return;
+    }
+
+    for (const auto& [key, state] :
+         *g_modernTextStatesForThread) {
+        if (state->PopupWindow() == popupWindow) {
+            state->Restore();
+        }
+    }
+}
+
+void CleanupModernTextStatesForCurrentThread() {
+    if (!g_modernTextStatesForThread) {
+        return;
+    }
+
+    for (const auto& [key, state] :
+         *g_modernTextStatesForThread) {
+        state->Restore();
+    }
+    g_modernTextStatesForThread.reset();
+    UnregisterModernTextStateThread();
+}
 
 class VisualTreeWatcher
     : public winrt::implements<VisualTreeWatcher,
@@ -1538,11 +1603,6 @@ public:
             Wh_Log(L"UnadviseVisualTreeChange failed: 0x%08X",
                    result);
         }
-
-        for (auto& [handle, state] : m_textStates) {
-            state->Detach();
-        }
-        m_textStates.clear();
     }
 
 private:
@@ -1556,62 +1616,97 @@ private:
         return object;
     }
 
-    template <typename TextBlock, typename VisualTreeHelper>
-    void RegisterTextBlock(InstanceHandle handle,
-                           const TextBlock& textBlock) {
-        if (!IsTargetModernTextElement<TextBlock, VisualTreeHelper>(
-                textBlock)) {
-            return;
+    template <typename Element, typename SourceAccess>
+    bool TryRegisterSource(InstanceHandle handle,
+                           const wf::IInspectable& inspectable) {
+        auto element = inspectable.try_as<Element>();
+        if (!element) {
+            return false;
         }
 
-        auto state = std::make_shared<
-            ModernTextState<TextBlock, VisualTreeHelper>>(textBlock);
-        state->Attach();
-        RegisterModernTextState(state);
-        state->Apply();
-
-        if (auto iterator = m_textStates.find(handle);
-            iterator != m_textStates.end()) {
-            iterator->second->Detach();
-            iterator->second = std::move(state);
+        auto state =
+            std::make_shared<ModernTextState<Element, SourceAccess>>(
+                element);
+        const ModernElementKey key{this, handle};
+        auto& states = *g_modernTextStatesForThread;
+        if (auto iterator = states.find(key);
+            iterator != states.end()) {
+            iterator->second->Restore();
+            iterator->second = state;
         } else {
-            m_textStates.emplace(handle, std::move(state));
+            if (states.empty()) {
+                RegisterModernTextStateThread();
+            }
+            states.emplace(key, state);
         }
+
+        state->Apply(
+            GetMostRecentModernPopupForThread(GetCurrentThreadId()));
+        return true;
     }
 
     HRESULT STDMETHODCALLTYPE OnVisualTreeChange(
         ParentChildRelation,
         VisualElement element,
         VisualMutationType mutationType) override try {
+        if (!g_modernTextStatesForThread) {
+            g_modernTextStatesForThread.emplace();
+        }
+
+        const ModernElementKey key{this, element.Handle};
+        auto& states = *g_modernTextStatesForThread;
+
         if (mutationType == Add &&
             g_modernUiText.load(std::memory_order_relaxed)) {
             const std::wstring_view type(
                 element.Type ? element.Type : L"");
-            if (!type.ends_with(L".TextBlock")) {
+            const bool isMenuSource = IsModernMenuSourceType(type);
+            const bool isTooltipSource =
+                IsModernTooltipSourceType(type);
+            if (!isMenuSource && !isTooltipSource) {
                 return S_OK;
             }
 
             const auto inspectable = FromHandle(element.Handle);
-            if (auto textBlock =
-                    inspectable.try_as<
-                        wux::Controls::TextBlock>()) {
-                RegisterTextBlock<
-                    wux::Controls::TextBlock,
-                    wux::Media::VisualTreeHelper>(
-                        element.Handle, textBlock);
-            } else if (auto textBlock =
-                           inspectable.try_as<
-                               mux::Controls::TextBlock>()) {
-                RegisterTextBlock<
-                    mux::Controls::TextBlock,
-                    mux::Media::VisualTreeHelper>(
-                        element.Handle, textBlock);
+            if (isMenuSource) {
+                if (TryRegisterSource<
+                        wux::Controls::MenuFlyoutItem,
+                        TextSourceAccess>(
+                        element.Handle, inspectable) ||
+                    TryRegisterSource<
+                        wux::Controls::MenuFlyoutSubItem,
+                        TextSourceAccess>(
+                        element.Handle, inspectable) ||
+                    TryRegisterSource<
+                        mux::Controls::MenuFlyoutItem,
+                        TextSourceAccess>(
+                        element.Handle, inspectable) ||
+                    TryRegisterSource<
+                        mux::Controls::MenuFlyoutSubItem,
+                        TextSourceAccess>(
+                        element.Handle, inspectable)) {
+                    return S_OK;
+                }
+            } else {
+                if (TryRegisterSource<
+                        wux::Controls::ToolTip,
+                        TooltipContentAccess>(
+                        element.Handle, inspectable) ||
+                    TryRegisterSource<
+                        mux::Controls::ToolTip,
+                        TooltipContentAccess>(
+                        element.Handle, inspectable)) {
+                    return S_OK;
+                }
             }
         } else if (mutationType == Remove) {
-            if (auto iterator = m_textStates.find(element.Handle);
-                iterator != m_textStates.end()) {
-                iterator->second->Detach();
-                m_textStates.erase(iterator);
+            if (auto iterator = states.find(key);
+                iterator != states.end()) {
+                iterator->second->Restore();
+                states.erase(iterator);
+                if (states.empty()) {
+                    UnregisterModernTextStateThread();
+                }
             }
         }
 
@@ -1630,14 +1725,12 @@ private:
     }
 
     winrt::com_ptr<IXamlDiagnostics> m_xamlDiagnostics;
-    std::unordered_map<
-        InstanceHandle,
-        std::shared_ptr<ModernTextStateBase>> m_textStates;
 };
 
 std::mutex g_visualTreeWatchersMutex;
-std::vector<winrt::com_ptr<VisualTreeWatcher>>
-    g_visualTreeWatchers;
+[[clang::no_destroy]]
+    std::optional<std::vector<winrt::com_ptr<VisualTreeWatcher>>>
+        g_visualTreeWatchers{std::in_place};
 std::atomic_bool g_stoppingModernUi{false};
 
 HMODULE GetCurrentModuleHandle() {
@@ -1675,7 +1768,9 @@ public:
         {
             std::lock_guard<std::mutex> guard(
                 g_visualTreeWatchersMutex);
-            g_visualTreeWatchers.push_back(watcher);
+            if (g_visualTreeWatchers) {
+                g_visualTreeWatchers->push_back(watcher);
+            }
         }
         m_watcher = std::move(watcher);
         return S_OK;
@@ -1762,6 +1857,10 @@ using InitializeXamlDiagnosticsEx_t =
 std::mutex g_xamlDiagnosticsInitializationMutex;
 bool g_windowsUiXamlDiagnosticsConnected;
 bool g_microsoftUiXamlDiagnosticsConnected;
+HANDLE g_xamlDiagnosticsWakeEvent;
+HANDLE g_xamlDiagnosticsWorkerThread;
+std::atomic_bool g_stopXamlDiagnosticsWorker{false};
+std::atomic_uint64_t g_nextXamlDiagnosticsAttemptTick{0};
 
 HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
                               LPCWSTR connectionPrefix) {
@@ -1843,6 +1942,78 @@ void EnsureModernXamlDiagnostics() {
     }
 }
 
+DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID) {
+    const HRESULT initializeResult =
+        CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    while (WaitForSingleObject(
+               g_xamlDiagnosticsWakeEvent, INFINITE) == WAIT_OBJECT_0) {
+        if (g_stopXamlDiagnosticsWorker.load(
+                std::memory_order_relaxed)) {
+            break;
+        }
+        EnsureModernXamlDiagnostics();
+    }
+
+    if (SUCCEEDED(initializeResult)) {
+        CoUninitialize();
+    }
+    return 0;
+}
+
+bool StartXamlDiagnosticsWorker() {
+    g_stopXamlDiagnosticsWorker.store(
+        false, std::memory_order_relaxed);
+    g_xamlDiagnosticsWakeEvent =
+        CreateEventW(nullptr, FALSE, FALSE, nullptr);
+    if (!g_xamlDiagnosticsWakeEvent) {
+        return false;
+    }
+
+    g_xamlDiagnosticsWorkerThread = CreateThread(
+        nullptr, 0, XamlDiagnosticsWorkerProc, nullptr, 0, nullptr);
+    if (!g_xamlDiagnosticsWorkerThread) {
+        CloseHandle(g_xamlDiagnosticsWakeEvent);
+        g_xamlDiagnosticsWakeEvent = nullptr;
+        return false;
+    }
+
+    return true;
+}
+
+void RequestXamlDiagnosticsInitialization() {
+    if (!g_xamlDiagnosticsWakeEvent ||
+        g_stoppingModernUi.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    const uint64_t now = GetTickCount64();
+    uint64_t next =
+        g_nextXamlDiagnosticsAttemptTick.load(
+            std::memory_order_relaxed);
+    if (now < next ||
+        !g_nextXamlDiagnosticsAttemptTick.compare_exchange_strong(
+            next, now + 10000, std::memory_order_relaxed)) {
+        return;
+    }
+
+    SetEvent(g_xamlDiagnosticsWakeEvent);
+}
+
+void StopXamlDiagnosticsWorker() {
+    if (!g_xamlDiagnosticsWorkerThread) {
+        return;
+    }
+
+    g_stopXamlDiagnosticsWorker.store(
+        true, std::memory_order_relaxed);
+    SetEvent(g_xamlDiagnosticsWakeEvent);
+    WaitForSingleObject(g_xamlDiagnosticsWorkerThread, INFINITE);
+    CloseHandle(g_xamlDiagnosticsWorkerThread);
+    CloseHandle(g_xamlDiagnosticsWakeEvent);
+    g_xamlDiagnosticsWorkerThread = nullptr;
+    g_xamlDiagnosticsWakeEvent = nullptr;
+}
+
 void CALLBACK ModernPopupWinEventProc(
     HWINEVENTHOOK,
     DWORD event,
@@ -1860,19 +2031,18 @@ void CALLBACK ModernPopupWinEventProc(
     DWORD processId;
     const DWORD threadId =
         GetWindowThreadProcessId(window, &processId);
-    if (!threadId || processId != GetCurrentProcessId()) {
+    if (!threadId || processId != GetCurrentProcessId() ||
+        GetCurrentThreadId() != threadId) {
         return;
     }
 
     if (event == EVENT_OBJECT_SHOW) {
-        if (!TrackVisibleModernPopup(window)) {
+        if (!TrackVisibleModernPopup(window, false)) {
             return;
         }
 
-        EnsureModernXamlDiagnostics();
-        if (GetCurrentThreadId() == threadId) {
-            RefreshModernTextStates(threadId, true);
-        }
+        RequestXamlDiagnosticsInitialization();
+        ApplyModernTextStatesForPopup(window);
     } else if (event == EVENT_OBJECT_HIDE ||
                event == EVENT_OBJECT_DESTROY) {
         bool wasTracked;
@@ -1883,33 +2053,104 @@ void CALLBACK ModernPopupWinEventProc(
                 g_visibleModernPopups.erase(window) != 0;
         }
 
-        if (wasTracked && GetCurrentThreadId() == threadId) {
-            // Restore on the UI thread which generated the in-context event.
-            // Loaded applies spacing if a reusable popup is shown again.
-            RefreshModernTextStates(threadId, false);
+        if (wasTracked) {
+            RestoreModernTextStatesForPopup(window);
         }
     }
 }
 
+using RunFromWindowThreadProc_t = void(WINAPI*)(PVOID parameter);
+
+bool RunFromWindowThread(HWND window,
+                         RunFromWindowThreadProc_t procedure,
+                         PVOID parameter) {
+    static const UINT message = RegisterWindowMessageW(
+        L"Windhawk_RunFromWindowThread_CJKSpacer");
+
+    struct RunParameter {
+        RunFromWindowThreadProc_t procedure;
+        PVOID parameter;
+    };
+
+    const DWORD threadId =
+        GetWindowThreadProcessId(window, nullptr);
+    if (!threadId) {
+        return false;
+    }
+
+    if (threadId == GetCurrentThreadId()) {
+        procedure(parameter);
+        return true;
+    }
+
+    HHOOK hook = SetWindowsHookExW(
+        WH_CALLWNDPROC,
+        [](int code, WPARAM wParam, LPARAM lParam) -> LRESULT {
+            if (code == HC_ACTION) {
+                const auto* call =
+                    reinterpret_cast<const CWPSTRUCT*>(lParam);
+                if (call->message == message) {
+                    auto* run = reinterpret_cast<RunParameter*>(
+                        call->lParam);
+                    run->procedure(run->parameter);
+                }
+            }
+            return CallNextHookEx(nullptr, code, wParam, lParam);
+        },
+        nullptr, threadId);
+    if (!hook) {
+        return false;
+    }
+
+    RunParameter run{procedure, parameter};
+    DWORD_PTR messageResult;
+    const LRESULT sent = SendMessageTimeoutW(
+        window, message, 0, reinterpret_cast<LPARAM>(&run),
+        SMTO_ABORTIFHUNG, 5000, &messageResult);
+    UnhookWindowsHookEx(hook);
+    return sent != 0;
+}
+
+HWND FindWindowForThread(DWORD threadId) {
+    HWND result = nullptr;
+    EnumThreadWindows(
+        threadId,
+        [](HWND window, LPARAM parameter) -> BOOL {
+            auto* result = reinterpret_cast<HWND*>(parameter);
+            DWORD processId;
+            GetWindowThreadProcessId(window, &processId);
+            if (processId == GetCurrentProcessId()) {
+                *result = window;
+                return FALSE;
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&result));
+    return result;
+}
+
 bool InitializeModernUi() {
     g_stoppingModernUi.store(false, std::memory_order_relaxed);
+    g_nextXamlDiagnosticsAttemptTick.store(
+        0, std::memory_order_relaxed);
+
+    if (!StartXamlDiagnosticsWorker()) {
+        Wh_Log(L"Couldn't start the XAML diagnostics worker");
+        return false;
+    }
 
     g_modernPopupWinEventHook = SetWinEventHook(
         EVENT_OBJECT_DESTROY, EVENT_OBJECT_HIDE,
         GetCurrentModuleHandle(), ModernPopupWinEventProc,
         GetCurrentProcessId(), 0, WINEVENT_INCONTEXT);
     if (!g_modernPopupWinEventHook) {
-        Wh_Log(L"In-context popup event hook failed, trying "
-               L"out-of-context");
-        g_modernPopupWinEventHook = SetWinEventHook(
-            EVENT_OBJECT_DESTROY, EVENT_OBJECT_HIDE, nullptr,
-            ModernPopupWinEventProc, GetCurrentProcessId(), 0,
-            WINEVENT_OUTOFCONTEXT);
+        Wh_Log(L"Couldn't install the modern popup event hook");
+        StopXamlDiagnosticsWorker();
+        return false;
     }
 
     EnumWindows(DiscoverVisibleModernPopup, 0);
-    EnsureModernXamlDiagnostics();
-    return g_modernPopupWinEventHook != nullptr;
+    return true;
 }
 
 void UninitializeModernUi() {
@@ -1919,21 +2160,47 @@ void UninitializeModernUi() {
         UnhookWinEvent(g_modernPopupWinEventHook);
         g_modernPopupWinEventHook = nullptr;
     }
+    StopXamlDiagnosticsWorker();
 
     std::vector<winrt::com_ptr<VisualTreeWatcher>> watchers;
     {
         std::lock_guard<std::mutex> guard(
             g_visualTreeWatchersMutex);
-        watchers.swap(g_visualTreeWatchers);
+        if (g_visualTreeWatchers) {
+            g_visualTreeWatchers->swap(watchers);
+            g_visualTreeWatchers.reset();
+        }
     }
     for (const auto& watcher : watchers) {
         watcher->UnadviseVisualTreeChange();
     }
 
+    std::vector<DWORD> stateThreads;
     {
-        std::lock_guard<std::mutex> guard(g_modernTextStatesMutex);
-        g_modernTextStates.clear();
+        std::lock_guard<std::mutex> guard(
+            g_modernTextStateThreadsMutex);
+        stateThreads.assign(
+            g_modernTextStateThreads.begin(),
+            g_modernTextStateThreads.end());
     }
+
+    for (DWORD threadId : stateThreads) {
+        const HWND window = FindWindowForThread(threadId);
+        if (!window ||
+            !RunFromWindowThread(
+                window,
+                [](PVOID) {
+                    CleanupModernTextStatesForCurrentThread();
+                },
+                nullptr)) {
+            // The thread-local state is deliberately no_destroy. If its UI
+            // thread can't be reached, retaining weak references is safer than
+            // releasing thread-affine XAML objects from this thread.
+            Wh_Log(L"Leaving modern XAML state for unreachable thread %u",
+                   threadId);
+        }
+    }
+
     ClearVisibleModernPopups();
 }
 
@@ -2132,6 +2399,9 @@ void Wh_ModAfterInit() {
         DiscoverExistingClassicTooltipThemes();
     }
 
+    if (g_modernUiText.load(std::memory_order_relaxed)) {
+        RequestXamlDiagnosticsInitialization();
+    }
 }
 
 void Wh_ModUninit() {

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.17
+// @version         0.1.18
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -86,6 +86,10 @@ path; a single-flight worker retains requests that arrive while it is running,
 tracks the Windows.UI.Xaml and Microsoft.UI.Xaml connections independently,
 and retries only the connection that was lost. The worker pins the mod image
 until `FreeLibraryAndExitThread`, so it cannot execute unloaded mod code.
+In addition to the XAML DLL load hook, creation of the Explorer/taskbar XAML
+host windows is used as an independent initialization trigger, so a module
+loaded through a static import, delay-load helper, or lower-level loader path
+still gets a connection attempt after an Explorer restart.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
 consumers, enabling this path can show its confirmation dialog.
 Each reload switches to a new modern-UI generation, so detached workers and
@@ -102,6 +106,9 @@ threads and restores them when the source leaves the visual tree or the mod
 unloads. The classic path updates
 strings stored in active `HMENU` objects, so menu text read through
 accessibility APIs also contains the inserted spaces while the popup is open.
+Other menu-cleanup mods that match items by their displayed text, such as
+Remove Context Menu Items, may therefore need rules that account for the
+temporary spaces while the popup is open.
 Rewritten strings are recorded and restored when the popup closes. If multiple
 items have identical rewritten text, text-based fallback restoration can select
 the first match; the idempotent transformation does not compound spaces.
@@ -426,6 +433,9 @@ std::wstring AddCjkSpacing(std::wstring_view text,
 using InsertMenuW_t = decltype(&InsertMenuW);
 using AppendMenuW_t = decltype(&AppendMenuW);
 using ModifyMenuW_t = decltype(&ModifyMenuW);
+using InsertMenuA_t = decltype(&InsertMenuA);
+using AppendMenuA_t = decltype(&AppendMenuA);
+using ModifyMenuA_t = decltype(&ModifyMenuA);
 using InsertMenuItemW_t = decltype(&InsertMenuItemW);
 using SetMenuItemInfoW_t = decltype(&SetMenuItemInfoW);
 using TrackPopupMenu_t = decltype(&TrackPopupMenu);
@@ -434,6 +444,9 @@ using TrackPopupMenuEx_t = decltype(&TrackPopupMenuEx);
 InsertMenuW_t g_originalInsertMenuW;
 AppendMenuW_t g_originalAppendMenuW;
 ModifyMenuW_t g_originalModifyMenuW;
+InsertMenuA_t g_originalInsertMenuA;
+AppendMenuA_t g_originalAppendMenuA;
+ModifyMenuA_t g_originalModifyMenuA;
 InsertMenuItemW_t g_originalInsertMenuItemW;
 SetMenuItemInfoW_t g_originalSetMenuItemInfoW;
 TrackPopupMenu_t g_originalTrackPopupMenu;
@@ -465,6 +478,66 @@ int FindMenuItemIndexByText(
 
 bool IsStringMenuFlags(UINT flags) {
     return !(flags & (MF_BITMAP | MF_OWNERDRAW | MF_SEPARATOR));
+}
+
+bool ConvertAnsiMenuTextToWide(LPCSTR text, std::wstring* wide) {
+    if (!text || !wide) {
+        return false;
+    }
+
+    const int length = MultiByteToWideChar(
+        CP_ACP, 0, text, -1, nullptr, 0);
+    if (length <= 0) {
+        return false;
+    }
+
+    wide->resize(static_cast<size_t>(length));
+    if (MultiByteToWideChar(
+            CP_ACP, 0, text, -1, wide->data(), length) != length) {
+        wide->clear();
+        return false;
+    }
+
+    wide->resize(static_cast<size_t>(length - 1));
+    return true;
+}
+
+bool ConvertWideMenuTextToAnsi(const std::wstring& wide,
+                               std::string* ansi) {
+    if (!ansi) {
+        return false;
+    }
+
+    const int length = WideCharToMultiByte(
+        CP_ACP, 0, wide.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    if (length <= 0) {
+        return false;
+    }
+
+    ansi->resize(static_cast<size_t>(length));
+    if (WideCharToMultiByte(
+            CP_ACP, 0, wide.c_str(), -1, ansi->data(), length,
+            nullptr, nullptr) != length) {
+        ansi->clear();
+        return false;
+    }
+
+    ansi->resize(static_cast<size_t>(length - 1));
+    return true;
+}
+
+bool PrepareAnsiMenuText(LPCSTR text,
+                         std::wstring* original,
+                         std::wstring* spaced,
+                         std::string* spacedAnsi) {
+    if (!ConvertAnsiMenuTextToWide(text, original) ||
+        !ContainsCjkCodePoint(*original)) {
+        return false;
+    }
+
+    *spaced = AddCjkSpacing(*original);
+    return *spaced != *original &&
+           ConvertWideMenuTextToAnsi(*spaced, spacedAnsi);
 }
 
 int FindMenuItemIndex(HMENU menu, UINT item, bool byPosition) {
@@ -593,6 +666,110 @@ BOOL WINAPI ModifyMenuWHook(HMENU menu,
     }
 
     return g_originalModifyMenuW(menu, position, flags, itemId, newItem);
+}
+
+BOOL WINAPI InsertMenuAHook(HMENU menu,
+                            UINT position,
+                            UINT flags,
+                            UINT_PTR itemId,
+                            LPCSTR newItem) {
+    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+        g_classicMenus.load(std::memory_order_relaxed) && newItem &&
+        IsStringMenuFlags(flags)) {
+        std::wstring original;
+        std::wstring spaced;
+        std::string spacedAnsi;
+        if (PrepareAnsiMenuText(
+                newItem, &original, &spaced, &spacedAnsi)) {
+            Wh_Log(L"Applied CJK spacing (classic/InsertMenuA)");
+            const BOOL result = g_originalInsertMenuA(
+                menu, position, flags, itemId, spacedAnsi.c_str());
+            if (result) {
+                int index;
+                if (flags & MF_BYPOSITION) {
+                    index = FindMenuItemIndex(menu, position, true);
+                    if (index < 0) {
+                        index = GetMenuItemCount(menu) - 1;
+                    }
+                } else if (flags & MF_POPUP) {
+                    index = FindMenuItemIndexByText(menu, spaced);
+                } else {
+                    index = FindMenuItemIndex(
+                        menu, static_cast<UINT>(itemId), false);
+                }
+                RememberRewrittenMenuItem(
+                    menu,
+                    index >= 0 ? static_cast<UINT>(index)
+                               : kUnknownMenuItemIndex,
+                    std::move(original), std::move(spaced));
+            }
+            return result;
+        }
+    }
+
+    return g_originalInsertMenuA(menu, position, flags, itemId, newItem);
+}
+
+BOOL WINAPI AppendMenuAHook(HMENU menu,
+                            UINT flags,
+                            UINT_PTR itemId,
+                            LPCSTR newItem) {
+    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+        g_classicMenus.load(std::memory_order_relaxed) && newItem &&
+        IsStringMenuFlags(flags)) {
+        std::wstring original;
+        std::wstring spaced;
+        std::string spacedAnsi;
+        if (PrepareAnsiMenuText(
+                newItem, &original, &spaced, &spacedAnsi)) {
+            Wh_Log(L"Applied CJK spacing (classic/AppendMenuA)");
+            const BOOL result = g_originalAppendMenuA(
+                menu, flags, itemId, spacedAnsi.c_str());
+            if (result) {
+                const int index = GetMenuItemCount(menu) - 1;
+                if (index >= 0) {
+                    RememberRewrittenMenuItem(
+                        menu, static_cast<UINT>(index),
+                        std::move(original), std::move(spaced));
+                }
+            }
+            return result;
+        }
+    }
+
+    return g_originalAppendMenuA(menu, flags, itemId, newItem);
+}
+
+BOOL WINAPI ModifyMenuAHook(HMENU menu,
+                            UINT position,
+                            UINT flags,
+                            UINT_PTR itemId,
+                            LPCSTR newItem) {
+    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+        g_classicMenus.load(std::memory_order_relaxed) && newItem &&
+        IsStringMenuFlags(flags)) {
+        std::wstring original;
+        std::wstring spaced;
+        std::string spacedAnsi;
+        if (PrepareAnsiMenuText(
+                newItem, &original, &spaced, &spacedAnsi)) {
+            Wh_Log(L"Applied CJK spacing (classic/ModifyMenuA)");
+            const int index = FindMenuItemIndex(
+                menu, position, (flags & MF_BYPOSITION) != 0);
+            const BOOL result = g_originalModifyMenuA(
+                menu, position, flags, itemId, spacedAnsi.c_str());
+            if (result) {
+                RememberRewrittenMenuItem(
+                    menu,
+                    index >= 0 ? static_cast<UINT>(index)
+                               : kUnknownMenuItemIndex,
+                    std::move(original), std::move(spaced));
+            }
+            return result;
+        }
+    }
+
+    return g_originalModifyMenuA(menu, position, flags, itemId, newItem);
 }
 
 bool MenuItemInfoContainsString(const MENUITEMINFOW* itemInfo) {
@@ -936,6 +1113,17 @@ std::unordered_map<HTHEME, HWND> g_classicTooltipThemes;
 std::atomic_uint g_classicTooltipThemeCount{0};
 thread_local bool g_rewritingClassicTooltipText = false;
 
+void ClearUxThemeFunctionPointers() {
+    g_getWindowTheme = nullptr;
+    g_originalOpenThemeData = nullptr;
+    g_originalOpenThemeDataEx = nullptr;
+    g_originalOpenThemeDataForDpi = nullptr;
+    g_originalCloseThemeData = nullptr;
+    g_originalGetThemeTextExtent = nullptr;
+    g_originalDrawThemeText = nullptr;
+    g_originalDrawThemeTextEx = nullptr;
+}
+
 bool IsClassicTooltipThemeClassList(LPCWSTR classList) {
     if (!classList) {
         return false;
@@ -1006,6 +1194,14 @@ void UntrackClassicTooltipTheme(HTHEME theme) {
         g_classicTooltipThemeCount.load(
             std::memory_order_relaxed) == 0) {
         return;
+    }
+
+    {
+        std::shared_lock<std::shared_mutex> guard(
+            g_classicTooltipThemesMutex);
+        if (!g_classicTooltipThemes.contains(theme)) {
+            return;
+        }
     }
 
     std::lock_guard<std::shared_mutex> guard(
@@ -2223,6 +2419,148 @@ HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
     return module;
 }
 
+bool IsTextualWindowClassName(LPCWSTR className) {
+    return className &&
+           (reinterpret_cast<ULONG_PTR>(className) &
+            ~static_cast<ULONG_PTR>(0xFFFF)) != 0;
+}
+
+bool IsModernXamlHostWindow(HWND window,
+                            HWND parent,
+                            LPCWSTR className) {
+    if (!window || !IsTextualWindowClassName(className)) {
+        return false;
+    }
+
+    if (_wcsicmp(
+            className,
+            L"Windows.UI.Composition.DesktopWindowContentBridge") == 0) {
+        wchar_t parentClassName[64];
+        return parent &&
+               GetClassNameW(
+                   parent, parentClassName, ARRAYSIZE(parentClassName)) > 0 &&
+               _wcsicmp(parentClassName, L"Shell_TrayWnd") == 0;
+    }
+
+    return _wcsicmp(className, L"XamlExplorerHostIslandWindow") == 0 ||
+           _wcsicmp(className, L"XamlExplorerHostIslandWindow_WASDK") == 0;
+}
+
+void OnModernXamlHostWindowCreated(HWND window,
+                                   HWND parent,
+                                   LPCWSTR className,
+                                   LPCWSTR source) {
+    if (!IsModernXamlHostWindow(window, parent, className)) {
+        return;
+    }
+
+    Wh_Log(L"Modern XAML initialization requested by %s (%s)",
+           source, className);
+    // Window creation is an independent trigger from LoadLibraryExW. It also
+    // covers XAML modules mapped through static imports, delay-load helpers,
+    // or lower-level loader calls that don't pass through our loader hook.
+    RequestModernXamlDiagnosticsInitialization();
+}
+
+using CreateWindowExW_t = decltype(&CreateWindowExW);
+CreateWindowExW_t g_originalCreateWindowExW;
+
+HWND WINAPI CreateWindowExWHook(DWORD exStyle,
+                                LPCWSTR className,
+                                LPCWSTR windowName,
+                                DWORD style,
+                                int x,
+                                int y,
+                                int width,
+                                int height,
+                                HWND parent,
+                                HMENU menu,
+                                HINSTANCE instance,
+                                PVOID parameter) {
+    HWND window = g_originalCreateWindowExW(
+        exStyle, className, windowName, style, x, y, width, height,
+        parent, menu, instance, parameter);
+    OnModernXamlHostWindowCreated(
+        window, parent, className, L"CreateWindowExW");
+    return window;
+}
+
+using CreateWindowInBand_t = HWND(WINAPI*)(
+    DWORD exStyle,
+    LPCWSTR className,
+    LPCWSTR windowName,
+    DWORD style,
+    int x,
+    int y,
+    int width,
+    int height,
+    HWND parent,
+    HMENU menu,
+    HINSTANCE instance,
+    PVOID parameter,
+    DWORD band);
+CreateWindowInBand_t g_originalCreateWindowInBand;
+
+HWND WINAPI CreateWindowInBandHook(DWORD exStyle,
+                                    LPCWSTR className,
+                                    LPCWSTR windowName,
+                                    DWORD style,
+                                    int x,
+                                    int y,
+                                    int width,
+                                    int height,
+                                    HWND parent,
+                                    HMENU menu,
+                                    HINSTANCE instance,
+                                    PVOID parameter,
+                                    DWORD band) {
+    HWND window = g_originalCreateWindowInBand(
+        exStyle, className, windowName, style, x, y, width, height,
+        parent, menu, instance, parameter, band);
+    OnModernXamlHostWindowCreated(
+        window, parent, className, L"CreateWindowInBand");
+    return window;
+}
+
+using CreateWindowInBandEx_t = HWND(WINAPI*)(
+    DWORD exStyle,
+    LPCWSTR className,
+    LPCWSTR windowName,
+    DWORD style,
+    int x,
+    int y,
+    int width,
+    int height,
+    HWND parent,
+    HMENU menu,
+    HINSTANCE instance,
+    PVOID parameter,
+    DWORD band,
+    DWORD typeFlags);
+CreateWindowInBandEx_t g_originalCreateWindowInBandEx;
+
+HWND WINAPI CreateWindowInBandExHook(DWORD exStyle,
+                                      LPCWSTR className,
+                                      LPCWSTR windowName,
+                                      DWORD style,
+                                      int x,
+                                      int y,
+                                      int width,
+                                      int height,
+                                      HWND parent,
+                                      HMENU menu,
+                                      HINSTANCE instance,
+                                      PVOID parameter,
+                                      DWORD band,
+                                      DWORD typeFlags) {
+    HWND window = g_originalCreateWindowInBandEx(
+        exStyle, className, windowName, style, x, y, width, height,
+        parent, menu, instance, parameter, band, typeFlags);
+    OnModernXamlHostWindowCreated(
+        window, parent, className, L"CreateWindowInBandEx");
+    return window;
+}
+
 using RunFromWindowThreadProc_t = void(WINAPI*)(PVOID parameter);
 
 bool RunFromWindowThread(HWND window,
@@ -2317,7 +2655,7 @@ void InitializeModernUi() {
 }
 
 void UninitializeModernUi() {
-    g_stoppingModernUi.store(true, std::memory_order_relaxed);
+    g_stoppingModernUi.store(true, std::memory_order_release);
 
     std::vector<winrt::com_ptr<VisualTreeWatcher>> watchers;
     {
@@ -2481,6 +2819,7 @@ bool HookClassicTooltipThemeDrawing() {
     if (!hooked && g_loadedUxThemeModule) {
         FreeLibrary(g_loadedUxThemeModule);
         g_loadedUxThemeModule = nullptr;
+        ClearUxThemeFunctionPointers();
     }
     return hooked;
 }
@@ -2536,6 +2875,15 @@ BOOL Wh_ModInit() {
             ModifyMenuW, ModifyMenuWHook, &g_originalModifyMenuW,
             L"ModifyMenuW");
         installedAnyHook |= InstallHook(
+            InsertMenuA, InsertMenuAHook, &g_originalInsertMenuA,
+            L"InsertMenuA");
+        installedAnyHook |= InstallHook(
+            AppendMenuA, AppendMenuAHook, &g_originalAppendMenuA,
+            L"AppendMenuA");
+        installedAnyHook |= InstallHook(
+            ModifyMenuA, ModifyMenuAHook, &g_originalModifyMenuA,
+            L"ModifyMenuA");
+        installedAnyHook |= InstallHook(
             InsertMenuItemW, InsertMenuItemWHook,
             &g_originalInsertMenuItemW, L"InsertMenuItemW");
         installedAnyHook |= InstallHook(
@@ -2555,6 +2903,33 @@ BOOL Wh_ModInit() {
 
     if (modernUiTextEnabled) {
         InitializeModernUi();
+        installedAnyHook |= InstallHook(
+            CreateWindowExW, CreateWindowExWHook,
+            &g_originalCreateWindowExW, L"CreateWindowExW");
+
+        HMODULE user32Module = GetModuleHandleW(L"user32.dll");
+        if (user32Module) {
+            const auto createWindowInBand =
+                reinterpret_cast<CreateWindowInBand_t>(
+                    GetProcAddress(user32Module, "CreateWindowInBand"));
+            if (createWindowInBand) {
+                installedAnyHook |= InstallHook(
+                    createWindowInBand, CreateWindowInBandHook,
+                    &g_originalCreateWindowInBand,
+                    L"CreateWindowInBand");
+            }
+
+            const auto createWindowInBandEx =
+                reinterpret_cast<CreateWindowInBandEx_t>(
+                    GetProcAddress(user32Module, "CreateWindowInBandEx"));
+            if (createWindowInBandEx) {
+                installedAnyHook |= InstallHook(
+                    createWindowInBandEx, CreateWindowInBandExHook,
+                    &g_originalCreateWindowInBandEx,
+                    L"CreateWindowInBandEx");
+            }
+        }
+
         HMODULE kernelBaseModule =
             GetModuleHandleW(L"kernelbase.dll");
         const auto loadLibraryExW =
@@ -2603,6 +2978,7 @@ void Wh_ModUninit() {
         FreeLibrary(g_loadedUxThemeModule);
         g_loadedUxThemeModule = nullptr;
     }
+    ClearUxThemeFunctionPointers();
     Wh_Log(L"Uninitialized");
 }
 

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -1,0 +1,994 @@
+// ==WindhawkMod==
+// @id              cjk-spacer
+// @name            CJK Spacer
+// @description     Add spaces between CJK characters and letters or digits in File Explorer context-menu text
+// @version         0.1.0
+// @author          aenerv7
+// @github          https://github.com/aenerv7
+// @license         GPL-3.0
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -ldwrite
+// ==/WindhawkMod==
+
+// Source code is published under the GNU General Public License v3.0.
+//
+// The Win32 menu and DirectWrite hook techniques are based in part on the
+// open-source Windhawk "Text Replace" mod by m417z.
+
+// ==WindhawkModReadme==
+/*
+# CJK Spacer
+
+Adds a normal ASCII space at a direct boundary between a CJK character and a
+letter or digit in File Explorer context-menu UI text.
+
+Examples:
+
+- `使用VS Code打开` becomes `使用 VS Code 打开`
+- `压缩为ZIP文件` becomes `压缩为 ZIP 文件`
+- `使用 VS Code 打开` is unchanged
+- `打开(&O)` is unchanged
+
+The transformation is idempotent. Punctuation and existing whitespace break a
+boundary and are preserved. Win32 `&` mnemonic markers and tab-separated
+keyboard shortcut text are also preserved.
+
+## Menu implementations
+
+- Classic menus are rewritten through public Win32 `HMENU` APIs.
+- The Windows 11 menu uses an experimental, display-only DirectWrite hook while
+  a XAML/WinUI popup window is being created or displayed.
+
+The modern-menu path is intentionally conservative, but Windows doesn't expose
+a supported global filter for menu titles. It can miss text on some Windows
+builds, and it can also affect text in another Explorer XAML popup while that
+popup is visible. Disable `modernMenus` if it causes a problem.
+
+This mod changes only text rendered by `explorer.exe`. It doesn't edit system
+files, registry values, file names, or the text returned to assistive
+technologies.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- classicMenus: true
+  $name: Classic context menus
+  $description: Process classic Win32 popup-menu text.
+- modernMenus: true
+  $name: Windows 11 context menus (experimental)
+  $description: Process text rendered while an Explorer XAML/WinUI popup is active.
+- characterMode: unicode
+  $name: Non-CJK character set
+  $description: Choose which letters and digits form a spacing boundary with CJK.
+  $options:
+  - unicode: Unicode letters and digits
+  - ascii: ASCII letters and digits only
+- debugLogging: false
+  $name: Debug logging
+  $description: Log each changed menu string to Windhawk's log output.
+*/
+// ==/WindhawkModSettings==
+
+#include <atomic>
+#include <cstdint>
+#include <cwchar>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <dwrite.h>
+#include <windows.h>
+
+namespace {
+
+enum class CharacterKind {
+    Other,
+    Cjk,
+    Word,
+    Extend,
+};
+
+std::atomic_bool g_classicMenus{true};
+std::atomic_bool g_modernMenus{true};
+std::atomic_bool g_unicodeLettersAndDigits{true};
+std::atomic_bool g_debugLogging{false};
+
+// XAML usually creates or shows its popup before laying out the menu text.
+// This short activity window covers layout that happens before the popup HWND
+// becomes visible.
+std::atomic<ULONGLONG> g_modernPopupActivityUntil{0};
+std::atomic<ULONGLONG> g_lastPopupScanTick{0};
+std::atomic_bool g_lastPopupScanResult{false};
+
+bool IsHighSurrogate(wchar_t value) {
+    return value >= 0xD800 && value <= 0xDBFF;
+}
+
+bool IsLowSurrogate(wchar_t value) {
+    return value >= 0xDC00 && value <= 0xDFFF;
+}
+
+uint32_t DecodeCodePoint(std::wstring_view text,
+                         size_t offset,
+                         size_t* codeUnitCount) {
+    const uint32_t first = static_cast<uint16_t>(text[offset]);
+    if (IsHighSurrogate(text[offset]) && offset + 1 < text.size() &&
+        IsLowSurrogate(text[offset + 1])) {
+        const uint32_t second = static_cast<uint16_t>(text[offset + 1]);
+        *codeUnitCount = 2;
+        return 0x10000 + ((first - 0xD800) << 10) + (second - 0xDC00);
+    }
+
+    *codeUnitCount = 1;
+    return first;
+}
+
+bool IsInRange(uint32_t codePoint, uint32_t first, uint32_t last) {
+    return codePoint >= first && codePoint <= last;
+}
+
+bool IsCjkCodePoint(uint32_t codePoint) {
+    // Hangul Jamo.
+    if (IsInRange(codePoint, 0x1100, 0x11FF)) {
+        return true;
+    }
+
+    // CJK radicals, Kangxi radicals, kana, Bopomofo, Hangul compatibility
+    // Jamo, CJK strokes, and Katakana phonetic extensions. CJK punctuation is
+    // deliberately excluded.
+    if (IsInRange(codePoint, 0x2E80, 0x2FDF) ||
+        IsInRange(codePoint, 0x3040, 0x30FF) ||
+        IsInRange(codePoint, 0x3100, 0x318F) ||
+        IsInRange(codePoint, 0x31A0, 0x31BF) ||
+        IsInRange(codePoint, 0x31C0, 0x31EF) ||
+        IsInRange(codePoint, 0x31F0, 0x31FF)) {
+        return true;
+    }
+
+    // Unified ideographs, Extension A, and compatibility ideographs.
+    if (IsInRange(codePoint, 0x3400, 0x4DBF) ||
+        IsInRange(codePoint, 0x4E00, 0x9FFF) ||
+        IsInRange(codePoint, 0xF900, 0xFAFF)) {
+        return true;
+    }
+
+    // Hangul extensions and syllables.
+    if (IsInRange(codePoint, 0xA960, 0xA97F) ||
+        IsInRange(codePoint, 0xAC00, 0xD7AF) ||
+        IsInRange(codePoint, 0xD7B0, 0xD7FF)) {
+        return true;
+    }
+
+    // Halfwidth Katakana.
+    if (IsInRange(codePoint, 0xFF66, 0xFF9D)) {
+        return true;
+    }
+
+    // Kana Supplement, Kana Extended-A, and Small Kana Extension.
+    if (IsInRange(codePoint, 0x1B000, 0x1B16F)) {
+        return true;
+    }
+
+    // Supplementary CJK unified and compatibility ideographs. The broad
+    // ranges intentionally include reserved gaps so newly assigned Han
+    // characters continue to behave sensibly.
+    return IsInRange(codePoint, 0x20000, 0x2FA1F) ||
+           IsInRange(codePoint, 0x30000, 0x323AF);
+}
+
+bool IsExtendingCodePoint(uint32_t codePoint) {
+    // Combining marks and variation selectors stay attached to the preceding
+    // base character and don't interrupt a CJK/word boundary.
+    return IsInRange(codePoint, 0x0300, 0x036F) ||
+           IsInRange(codePoint, 0x1AB0, 0x1AFF) ||
+           IsInRange(codePoint, 0x1DC0, 0x1DFF) ||
+           IsInRange(codePoint, 0x20D0, 0x20FF) ||
+           IsInRange(codePoint, 0xFE00, 0xFE0F) ||
+           IsInRange(codePoint, 0xFE20, 0xFE2F) ||
+           IsInRange(codePoint, 0xE0100, 0xE01EF);
+}
+
+bool IsAsciiLetterOrDigit(uint32_t codePoint) {
+    return (codePoint >= L'0' && codePoint <= L'9') ||
+           (codePoint >= L'A' && codePoint <= L'Z') ||
+           (codePoint >= L'a' && codePoint <= L'z');
+}
+
+bool IsUnicodeLetterOrDigit(uint32_t codePoint) {
+    wchar_t utf16[2];
+    int length;
+
+    if (codePoint <= 0xFFFF) {
+        utf16[0] = static_cast<wchar_t>(codePoint);
+        length = 1;
+    } else if (codePoint <= 0x10FFFF) {
+        const uint32_t value = codePoint - 0x10000;
+        utf16[0] = static_cast<wchar_t>(0xD800 + (value >> 10));
+        utf16[1] = static_cast<wchar_t>(0xDC00 + (value & 0x3FF));
+        length = 2;
+    } else {
+        return false;
+    }
+
+    WORD characterTypes[2] = {};
+    if (!GetStringTypeW(CT_CTYPE1, utf16, length, characterTypes)) {
+        return false;
+    }
+
+    for (int i = 0; i < length; ++i) {
+        if (characterTypes[i] & (C1_ALPHA | C1_DIGIT)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+CharacterKind ClassifyCodePoint(uint32_t codePoint) {
+    if (IsExtendingCodePoint(codePoint)) {
+        return CharacterKind::Extend;
+    }
+
+    if (IsCjkCodePoint(codePoint)) {
+        return CharacterKind::Cjk;
+    }
+
+    const bool isWord =
+        g_unicodeLettersAndDigits.load(std::memory_order_relaxed)
+            ? IsUnicodeLetterOrDigit(codePoint)
+            : IsAsciiLetterOrDigit(codePoint);
+    return isWord ? CharacterKind::Word : CharacterKind::Other;
+}
+
+bool NeedsSpace(CharacterKind left, CharacterKind right) {
+    return (left == CharacterKind::Cjk && right == CharacterKind::Word) ||
+           (left == CharacterKind::Word && right == CharacterKind::Cjk);
+}
+
+// A token is a base code point, its combining marks/variation selectors, and
+// an optional Win32 mnemonic '&' prefix. Keeping the prefix in the token makes
+// "打开&Open" become "打开 &Open", which Windows displays as "打开 Open"
+// while preserving the O mnemonic.
+std::wstring AddCjkSpacing(std::wstring_view text) {
+    std::wstring result;
+    result.reserve(text.size() + 4);
+
+    CharacterKind previousKind = CharacterKind::Other;
+    size_t offset = 0;
+
+    while (offset < text.size()) {
+        const size_t tokenStart = offset;
+
+        if (text[offset] == L'&') {
+            if (offset + 1 < text.size() && text[offset + 1] == L'&') {
+                // An escaped ampersand is visible punctuation.
+                result.append(text.substr(offset, 2));
+                offset += 2;
+                previousKind = CharacterKind::Other;
+                continue;
+            }
+
+            if (offset + 1 < text.size()) {
+                ++offset;
+            }
+        }
+
+        size_t codeUnitCount;
+        const uint32_t codePoint =
+            DecodeCodePoint(text, offset, &codeUnitCount);
+        CharacterKind currentKind = ClassifyCodePoint(codePoint);
+        offset += codeUnitCount;
+
+        // Attach combining characters and variation selectors to this token.
+        while (offset < text.size()) {
+            size_t extensionLength;
+            const uint32_t extension =
+                DecodeCodePoint(text, offset, &extensionLength);
+            if (!IsExtendingCodePoint(extension)) {
+                break;
+            }
+            offset += extensionLength;
+        }
+
+        if (currentKind == CharacterKind::Extend) {
+            // A malformed standalone combining mark doesn't reset the previous
+            // visible character's classification.
+            result.append(text.substr(tokenStart, offset - tokenStart));
+            continue;
+        }
+
+        if (NeedsSpace(previousKind, currentKind)) {
+            result.push_back(L' ');
+        }
+
+        result.append(text.substr(tokenStart, offset - tokenStart));
+        previousKind = currentKind;
+    }
+
+    return result;
+}
+
+void LogReplacement(const wchar_t* source,
+                    std::wstring_view before,
+                    std::wstring_view after) {
+    if (!g_debugLogging.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    const std::wstring beforeCopy(before);
+    const std::wstring afterCopy(after);
+    Wh_Log(L"%s: \"%s\" -> \"%s\"", source, beforeCopy.c_str(),
+           afterCopy.c_str());
+}
+
+// -------------------------------------------------------------------------
+// Classic Win32 menus
+// -------------------------------------------------------------------------
+
+using InsertMenuW_t = decltype(&InsertMenuW);
+using AppendMenuW_t = decltype(&AppendMenuW);
+using ModifyMenuW_t = decltype(&ModifyMenuW);
+using InsertMenuItemW_t = decltype(&InsertMenuItemW);
+using SetMenuItemInfoW_t = decltype(&SetMenuItemInfoW);
+using TrackPopupMenu_t = decltype(&TrackPopupMenu);
+using TrackPopupMenuEx_t = decltype(&TrackPopupMenuEx);
+
+InsertMenuW_t g_originalInsertMenuW;
+AppendMenuW_t g_originalAppendMenuW;
+ModifyMenuW_t g_originalModifyMenuW;
+InsertMenuItemW_t g_originalInsertMenuItemW;
+SetMenuItemInfoW_t g_originalSetMenuItemInfoW;
+TrackPopupMenu_t g_originalTrackPopupMenu;
+TrackPopupMenuEx_t g_originalTrackPopupMenuEx;
+
+bool IsStringMenuFlags(UINT flags) {
+    return !(flags & (MF_BITMAP | MF_OWNERDRAW | MF_SEPARATOR));
+}
+
+BOOL WINAPI InsertMenuWHook(HMENU menu,
+                            UINT position,
+                            UINT flags,
+                            UINT_PTR itemId,
+                            LPCWSTR newItem) {
+    if (g_classicMenus.load(std::memory_order_relaxed) && newItem &&
+        IsStringMenuFlags(flags)) {
+        const std::wstring spaced = AddCjkSpacing(newItem);
+        if (spaced != newItem) {
+            LogReplacement(L"classic/InsertMenuW", newItem, spaced);
+            return g_originalInsertMenuW(menu, position, flags, itemId,
+                                         spaced.c_str());
+        }
+    }
+
+    return g_originalInsertMenuW(menu, position, flags, itemId, newItem);
+}
+
+BOOL WINAPI AppendMenuWHook(HMENU menu,
+                            UINT flags,
+                            UINT_PTR itemId,
+                            LPCWSTR newItem) {
+    if (g_classicMenus.load(std::memory_order_relaxed) && newItem &&
+        IsStringMenuFlags(flags)) {
+        const std::wstring spaced = AddCjkSpacing(newItem);
+        if (spaced != newItem) {
+            LogReplacement(L"classic/AppendMenuW", newItem, spaced);
+            return g_originalAppendMenuW(menu, flags, itemId, spaced.c_str());
+        }
+    }
+
+    return g_originalAppendMenuW(menu, flags, itemId, newItem);
+}
+
+BOOL WINAPI ModifyMenuWHook(HMENU menu,
+                            UINT position,
+                            UINT flags,
+                            UINT_PTR itemId,
+                            LPCWSTR newItem) {
+    if (g_classicMenus.load(std::memory_order_relaxed) && newItem &&
+        IsStringMenuFlags(flags)) {
+        const std::wstring spaced = AddCjkSpacing(newItem);
+        if (spaced != newItem) {
+            LogReplacement(L"classic/ModifyMenuW", newItem, spaced);
+            return g_originalModifyMenuW(menu, position, flags, itemId,
+                                         spaced.c_str());
+        }
+    }
+
+    return g_originalModifyMenuW(menu, position, flags, itemId, newItem);
+}
+
+bool MenuItemInfoContainsString(const MENUITEMINFOW* itemInfo) {
+    if (!itemInfo || !itemInfo->dwTypeData) {
+        return false;
+    }
+
+    if ((itemInfo->fMask & (MIIM_FTYPE | MIIM_TYPE)) &&
+        (itemInfo->fType & (MFT_BITMAP | MFT_OWNERDRAW | MFT_SEPARATOR))) {
+        return false;
+    }
+
+    return (itemInfo->fMask & MIIM_STRING) ||
+           (itemInfo->fMask & MIIM_TYPE);
+}
+
+BOOL WINAPI InsertMenuItemWHook(HMENU menu,
+                                UINT item,
+                                BOOL byPosition,
+                                LPCMENUITEMINFOW itemInfo) {
+    if (g_classicMenus.load(std::memory_order_relaxed) &&
+        MenuItemInfoContainsString(itemInfo)) {
+        const std::wstring spaced = AddCjkSpacing(itemInfo->dwTypeData);
+        if (spaced != itemInfo->dwTypeData) {
+            LogReplacement(L"classic/InsertMenuItemW", itemInfo->dwTypeData,
+                           spaced);
+            MENUITEMINFOW copy = *itemInfo;
+            copy.dwTypeData = const_cast<wchar_t*>(spaced.c_str());
+            copy.cch = static_cast<UINT>(spaced.size());
+            return g_originalInsertMenuItemW(menu, item, byPosition, &copy);
+        }
+    }
+
+    return g_originalInsertMenuItemW(menu, item, byPosition, itemInfo);
+}
+
+BOOL WINAPI SetMenuItemInfoWHook(HMENU menu,
+                                 UINT item,
+                                 BOOL byPosition,
+                                 LPCMENUITEMINFOW itemInfo) {
+    if (g_classicMenus.load(std::memory_order_relaxed) &&
+        MenuItemInfoContainsString(itemInfo)) {
+        const std::wstring spaced = AddCjkSpacing(itemInfo->dwTypeData);
+        if (spaced != itemInfo->dwTypeData) {
+            LogReplacement(L"classic/SetMenuItemInfoW", itemInfo->dwTypeData,
+                           spaced);
+            MENUITEMINFOW copy = *itemInfo;
+            copy.dwTypeData = const_cast<wchar_t*>(spaced.c_str());
+            copy.cch = static_cast<UINT>(spaced.size());
+            return g_originalSetMenuItemInfoW(menu, item, byPosition, &copy);
+        }
+    }
+
+    return g_originalSetMenuItemInfoW(menu, item, byPosition, itemInfo);
+}
+
+void RewriteMenuTree(HMENU menu) {
+    const int itemCount = GetMenuItemCount(menu);
+    for (int index = 0; index < itemCount; ++index) {
+        MENUITEMINFOW itemInfo = {};
+        itemInfo.cbSize = sizeof(itemInfo);
+        itemInfo.fMask = MIIM_FTYPE | MIIM_STRING | MIIM_SUBMENU;
+
+        if (!GetMenuItemInfoW(menu, index, TRUE, &itemInfo)) {
+            continue;
+        }
+
+        const bool isTextItem =
+            !(itemInfo.fType &
+              (MFT_BITMAP | MFT_OWNERDRAW | MFT_SEPARATOR));
+
+        if (isTextItem && itemInfo.cch > 0) {
+            std::vector<wchar_t> buffer(itemInfo.cch + 1);
+            itemInfo.dwTypeData = buffer.data();
+            itemInfo.cch = static_cast<UINT>(buffer.size());
+
+            if (GetMenuItemInfoW(menu, index, TRUE, &itemInfo)) {
+                const std::wstring original(buffer.data(), itemInfo.cch);
+                const std::wstring spaced = AddCjkSpacing(original);
+                if (spaced != original) {
+                    LogReplacement(L"classic/pre-display", original, spaced);
+
+                    MENUITEMINFOW replacement = {};
+                    replacement.cbSize = sizeof(replacement);
+                    replacement.fMask = MIIM_STRING;
+                    replacement.dwTypeData =
+                        const_cast<wchar_t*>(spaced.c_str());
+                    replacement.cch = static_cast<UINT>(spaced.size());
+                    if (g_originalSetMenuItemInfoW) {
+                        g_originalSetMenuItemInfoW(menu, index, TRUE,
+                                                   &replacement);
+                    } else {
+                        SetMenuItemInfoW(menu, index, TRUE, &replacement);
+                    }
+                }
+            }
+        }
+
+        if (itemInfo.hSubMenu) {
+            RewriteMenuTree(itemInfo.hSubMenu);
+        }
+    }
+}
+
+BOOL WINAPI TrackPopupMenuHook(HMENU menu,
+                               UINT flags,
+                               int x,
+                               int y,
+                               int reserved,
+                               HWND owner,
+                               const RECT* rect) {
+    if (g_classicMenus.load(std::memory_order_relaxed)) {
+        RewriteMenuTree(menu);
+    }
+
+    return g_originalTrackPopupMenu(menu, flags, x, y, reserved, owner, rect);
+}
+
+BOOL WINAPI TrackPopupMenuExHook(HMENU menu,
+                                 UINT flags,
+                                 int x,
+                                 int y,
+                                 HWND owner,
+                                 LPTPMPARAMS parameters) {
+    if (g_classicMenus.load(std::memory_order_relaxed)) {
+        RewriteMenuTree(menu);
+    }
+
+    return g_originalTrackPopupMenuEx(menu, flags, x, y, owner, parameters);
+}
+
+// -------------------------------------------------------------------------
+// Windows 11 XAML/WinUI popup detection
+// -------------------------------------------------------------------------
+
+using CreateWindowExW_t = decltype(&CreateWindowExW);
+using ShowWindow_t = decltype(&ShowWindow);
+using SetWindowPos_t = decltype(&SetWindowPos);
+
+CreateWindowExW_t g_originalCreateWindowExW;
+ShowWindow_t g_originalShowWindow;
+SetWindowPos_t g_originalSetWindowPos;
+
+bool IsStringClassName(LPCWSTR className) {
+    return className &&
+           reinterpret_cast<ULONG_PTR>(className) > 0xFFFF;
+}
+
+bool IsModernPopupClassName(LPCWSTR className) {
+    if (!IsStringClassName(className)) {
+        return false;
+    }
+
+    return _wcsicmp(className, L"Xaml_WindowedPopupClass") == 0 ||
+           _wcsicmp(className,
+                    L"Microsoft.UI.Content.PopupWindowSiteBridge") == 0 ||
+           wcsstr(className, L"PopupWindowSiteBridge") != nullptr;
+}
+
+bool IsModernPopupWindow(HWND window) {
+    wchar_t className[128];
+    const int length = GetClassNameW(window, className, ARRAYSIZE(className));
+    return length > 0 && IsModernPopupClassName(className);
+}
+
+void MarkModernPopupActivity() {
+    g_modernPopupActivityUntil.store(GetTickCount64() + 1000,
+                                     std::memory_order_relaxed);
+}
+
+HWND WINAPI CreateWindowExWHook(DWORD extendedStyle,
+                                LPCWSTR className,
+                                LPCWSTR windowName,
+                                DWORD style,
+                                int x,
+                                int y,
+                                int width,
+                                int height,
+                                HWND parent,
+                                HMENU menu,
+                                HINSTANCE instance,
+                                LPVOID parameter) {
+    if (g_modernMenus.load(std::memory_order_relaxed) &&
+        IsModernPopupClassName(className)) {
+        MarkModernPopupActivity();
+    }
+
+    HWND window = g_originalCreateWindowExW(
+        extendedStyle, className, windowName, style, x, y, width, height,
+        parent, menu, instance, parameter);
+
+    if (g_modernMenus.load(std::memory_order_relaxed) && window &&
+        IsModernPopupWindow(window)) {
+        MarkModernPopupActivity();
+    }
+
+    return window;
+}
+
+BOOL WINAPI ShowWindowHook(HWND window, int command) {
+    if (g_modernMenus.load(std::memory_order_relaxed) &&
+        command != SW_HIDE && IsModernPopupWindow(window)) {
+        MarkModernPopupActivity();
+    }
+
+    return g_originalShowWindow(window, command);
+}
+
+BOOL WINAPI SetWindowPosHook(HWND window,
+                             HWND insertAfter,
+                             int x,
+                             int y,
+                             int width,
+                             int height,
+                             UINT flags) {
+    if (g_modernMenus.load(std::memory_order_relaxed) &&
+        (flags & SWP_SHOWWINDOW) && IsModernPopupWindow(window)) {
+        MarkModernPopupActivity();
+    }
+
+    return g_originalSetWindowPos(window, insertAfter, x, y, width, height,
+                                  flags);
+}
+
+struct PopupScanContext {
+    DWORD processId;
+    bool found;
+};
+
+BOOL CALLBACK FindVisibleModernPopup(HWND window, LPARAM parameter) {
+    auto* context = reinterpret_cast<PopupScanContext*>(parameter);
+
+    DWORD processId;
+    GetWindowThreadProcessId(window, &processId);
+    if (processId == context->processId && IsWindowVisible(window) &&
+        IsModernPopupWindow(window)) {
+        context->found = true;
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+bool IsModernPopupActive() {
+    const ULONGLONG now = GetTickCount64();
+    if (now <=
+        g_modernPopupActivityUntil.load(std::memory_order_relaxed)) {
+        return true;
+    }
+
+    const ULONGLONG lastScan =
+        g_lastPopupScanTick.load(std::memory_order_relaxed);
+    if (now >= lastScan && now - lastScan < 50) {
+        return g_lastPopupScanResult.load(std::memory_order_relaxed);
+    }
+
+    PopupScanContext context = {GetCurrentProcessId(), false};
+    EnumWindows(FindVisibleModernPopup,
+                reinterpret_cast<LPARAM>(&context));
+
+    g_lastPopupScanResult.store(context.found, std::memory_order_relaxed);
+    g_lastPopupScanTick.store(now, std::memory_order_relaxed);
+    return context.found;
+}
+
+// -------------------------------------------------------------------------
+// DirectWrite text layout used by the Windows 11 menu
+// -------------------------------------------------------------------------
+
+using IDWriteFactory_CreateTextLayout_t =
+    HRESULT(STDMETHODCALLTYPE*)(IDWriteFactory* factory,
+                                const WCHAR* text,
+                                UINT32 textLength,
+                                IDWriteTextFormat* textFormat,
+                                FLOAT maxWidth,
+                                FLOAT maxHeight,
+                                IDWriteTextLayout** textLayout);
+
+using IDWriteFactory_CreateGdiCompatibleTextLayout_t =
+    HRESULT(STDMETHODCALLTYPE*)(IDWriteFactory* factory,
+                                const WCHAR* text,
+                                UINT32 textLength,
+                                IDWriteTextFormat* textFormat,
+                                FLOAT layoutWidth,
+                                FLOAT layoutHeight,
+                                FLOAT pixelsPerDip,
+                                const DWRITE_MATRIX* transform,
+                                BOOL useGdiNatural,
+                                IDWriteTextLayout** textLayout);
+
+IDWriteFactory_CreateTextLayout_t g_originalCreateTextLayout;
+IDWriteFactory_CreateGdiCompatibleTextLayout_t
+    g_originalCreateGdiCompatibleTextLayout;
+IDWriteFactory_CreateTextLayout_t g_originalCoreCreateTextLayout;
+IDWriteFactory_CreateGdiCompatibleTextLayout_t
+    g_originalCoreCreateGdiCompatibleTextLayout;
+
+HRESULT CreateTextLayoutWithSpacing(
+    IDWriteFactory_CreateTextLayout_t originalFunction,
+    const wchar_t* source,
+    IDWriteFactory* factory,
+    const WCHAR* text,
+    UINT32 textLength,
+    IDWriteTextFormat* textFormat,
+    FLOAT maxWidth,
+    FLOAT maxHeight,
+    IDWriteTextLayout** textLayout) {
+    if (g_modernMenus.load(std::memory_order_relaxed) && text) {
+        const std::wstring_view original(text, textLength);
+        const std::wstring spaced = AddCjkSpacing(original);
+        if (spaced.size() != original.size() && IsModernPopupActive()) {
+            LogReplacement(source, original, spaced);
+            return originalFunction(
+                factory, spaced.c_str(), static_cast<UINT32>(spaced.size()),
+                textFormat, maxWidth, maxHeight, textLayout);
+        }
+    }
+
+    return originalFunction(factory, text, textLength, textFormat, maxWidth,
+                            maxHeight, textLayout);
+}
+
+HRESULT CreateGdiCompatibleTextLayoutWithSpacing(
+    IDWriteFactory_CreateGdiCompatibleTextLayout_t originalFunction,
+    const wchar_t* source,
+    IDWriteFactory* factory,
+    const WCHAR* text,
+    UINT32 textLength,
+    IDWriteTextFormat* textFormat,
+    FLOAT layoutWidth,
+    FLOAT layoutHeight,
+    FLOAT pixelsPerDip,
+    const DWRITE_MATRIX* transform,
+    BOOL useGdiNatural,
+    IDWriteTextLayout** textLayout) {
+    if (g_modernMenus.load(std::memory_order_relaxed) && text) {
+        const std::wstring_view original(text, textLength);
+        const std::wstring spaced = AddCjkSpacing(original);
+        if (spaced.size() != original.size() && IsModernPopupActive()) {
+            LogReplacement(source, original, spaced);
+            return originalFunction(
+                factory, spaced.c_str(), static_cast<UINT32>(spaced.size()),
+                textFormat, layoutWidth, layoutHeight, pixelsPerDip, transform,
+                useGdiNatural, textLayout);
+        }
+    }
+
+    return originalFunction(factory, text, textLength, textFormat, layoutWidth,
+                            layoutHeight, pixelsPerDip, transform,
+                            useGdiNatural, textLayout);
+}
+
+HRESULT STDMETHODCALLTYPE CreateTextLayoutHook(
+    IDWriteFactory* factory,
+    const WCHAR* text,
+    UINT32 textLength,
+    IDWriteTextFormat* textFormat,
+    FLOAT maxWidth,
+    FLOAT maxHeight,
+    IDWriteTextLayout** textLayout) {
+    return CreateTextLayoutWithSpacing(
+        g_originalCreateTextLayout, L"modern/DirectWrite/CreateTextLayout",
+        factory, text, textLength, textFormat, maxWidth, maxHeight,
+        textLayout);
+}
+
+HRESULT STDMETHODCALLTYPE CreateGdiCompatibleTextLayoutHook(
+    IDWriteFactory* factory,
+    const WCHAR* text,
+    UINT32 textLength,
+    IDWriteTextFormat* textFormat,
+    FLOAT layoutWidth,
+    FLOAT layoutHeight,
+    FLOAT pixelsPerDip,
+    const DWRITE_MATRIX* transform,
+    BOOL useGdiNatural,
+    IDWriteTextLayout** textLayout) {
+    return CreateGdiCompatibleTextLayoutWithSpacing(
+        g_originalCreateGdiCompatibleTextLayout,
+        L"modern/DirectWrite/CreateGdiCompatibleTextLayout", factory, text,
+        textLength, textFormat, layoutWidth, layoutHeight, pixelsPerDip,
+        transform, useGdiNatural, textLayout);
+}
+
+HRESULT STDMETHODCALLTYPE CoreCreateTextLayoutHook(
+    IDWriteFactory* factory,
+    const WCHAR* text,
+    UINT32 textLength,
+    IDWriteTextFormat* textFormat,
+    FLOAT maxWidth,
+    FLOAT maxHeight,
+    IDWriteTextLayout** textLayout) {
+    return CreateTextLayoutWithSpacing(
+        g_originalCoreCreateTextLayout,
+        L"modern/DWriteCore/CreateTextLayout", factory, text, textLength,
+        textFormat, maxWidth, maxHeight, textLayout);
+}
+
+HRESULT STDMETHODCALLTYPE CoreCreateGdiCompatibleTextLayoutHook(
+    IDWriteFactory* factory,
+    const WCHAR* text,
+    UINT32 textLength,
+    IDWriteTextFormat* textFormat,
+    FLOAT layoutWidth,
+    FLOAT layoutHeight,
+    FLOAT pixelsPerDip,
+    const DWRITE_MATRIX* transform,
+    BOOL useGdiNatural,
+    IDWriteTextLayout** textLayout) {
+    return CreateGdiCompatibleTextLayoutWithSpacing(
+        g_originalCoreCreateGdiCompatibleTextLayout,
+        L"modern/DWriteCore/CreateGdiCompatibleTextLayout", factory, text,
+        textLength, textFormat, layoutWidth, layoutHeight, pixelsPerDip,
+        transform, useGdiNatural, textLayout);
+}
+
+bool HookDWriteFactory(HMODULE module,
+                       const char* factoryExport,
+                       void* createTextLayoutHook,
+                       IDWriteFactory_CreateTextLayout_t* originalTextLayout,
+                       void* createGdiLayoutHook,
+                       IDWriteFactory_CreateGdiCompatibleTextLayout_t*
+                           originalGdiLayout,
+                       const wchar_t* implementationName) {
+    if (!module) {
+        return false;
+    }
+
+    using DWriteCreateFactory_t =
+        HRESULT(WINAPI*)(DWRITE_FACTORY_TYPE, REFIID, IUnknown**);
+    const auto createFactory = reinterpret_cast<DWriteCreateFactory_t>(
+        GetProcAddress(module, factoryExport));
+    if (!createFactory) {
+        Wh_Log(L"Couldn't find %s factory export", implementationName);
+        return false;
+    }
+
+    IDWriteFactory* factory = nullptr;
+    const HRESULT result =
+        createFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory),
+                      reinterpret_cast<IUnknown**>(&factory));
+    if (FAILED(result) || !factory) {
+        Wh_Log(L"%s factory creation failed: 0x%08X", implementationName,
+               result);
+        return false;
+    }
+
+    void** vtable = *reinterpret_cast<void***>(factory);
+    const bool textLayoutHooked = Wh_SetFunctionHook(
+        vtable[18], createTextLayoutHook,
+        reinterpret_cast<void**>(originalTextLayout));
+    const bool gdiLayoutHooked = Wh_SetFunctionHook(
+        vtable[19], createGdiLayoutHook,
+        reinterpret_cast<void**>(originalGdiLayout));
+
+    factory->Release();
+
+    if (!textLayoutHooked || !gdiLayoutHooked) {
+        Wh_Log(L"Couldn't install one or more %s hooks",
+               implementationName);
+    }
+
+    return textLayoutHooked || gdiLayoutHooked;
+}
+
+bool HookDirectWrite() {
+    bool hooked = false;
+
+    HMODULE dwrite =
+        LoadLibraryExW(L"dwrite.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (dwrite) {
+        hooked |= HookDWriteFactory(
+            dwrite, "DWriteCreateFactory",
+            reinterpret_cast<void*>(CreateTextLayoutHook),
+            &g_originalCreateTextLayout,
+            reinterpret_cast<void*>(CreateGdiCompatibleTextLayoutHook),
+            &g_originalCreateGdiCompatibleTextLayout, L"DirectWrite");
+    } else {
+        Wh_Log(L"Couldn't load dwrite.dll");
+    }
+
+    // Windows App SDK uses the same IDWriteFactory ABI through DWriteCore.
+    // Don't load a second copy from an arbitrary location; hook it only when
+    // Explorer already has the module loaded.
+    HMODULE dwriteCore = GetModuleHandleW(L"DWriteCore.dll");
+    if (dwriteCore) {
+        hooked |= HookDWriteFactory(
+            dwriteCore, "DWriteCoreCreateFactory",
+            reinterpret_cast<void*>(CoreCreateTextLayoutHook),
+            &g_originalCoreCreateTextLayout,
+            reinterpret_cast<void*>(
+                CoreCreateGdiCompatibleTextLayoutHook),
+            &g_originalCoreCreateGdiCompatibleTextLayout, L"DWriteCore");
+    } else if (g_debugLogging.load(std::memory_order_relaxed)) {
+        Wh_Log(L"DWriteCore.dll isn't loaded in Explorer; skipping it");
+    }
+
+    return hooked;
+}
+
+template <typename Function>
+bool InstallHook(Function target,
+                 void* hook,
+                 Function* original,
+                 const wchar_t* name) {
+    if (!Wh_SetFunctionHook(reinterpret_cast<void*>(target), hook,
+                            reinterpret_cast<void**>(original))) {
+        Wh_Log(L"Couldn't hook %s", name);
+        return false;
+    }
+
+    return true;
+}
+
+void LoadSettings() {
+    g_classicMenus.store(Wh_GetIntSetting(L"classicMenus") != 0,
+                         std::memory_order_relaxed);
+    g_modernMenus.store(Wh_GetIntSetting(L"modernMenus") != 0,
+                        std::memory_order_relaxed);
+    g_debugLogging.store(Wh_GetIntSetting(L"debugLogging") != 0,
+                         std::memory_order_relaxed);
+
+    PCWSTR characterMode = Wh_GetStringSetting(L"characterMode");
+    const bool unicodeMode =
+        characterMode && _wcsicmp(characterMode, L"ascii") != 0;
+    g_unicodeLettersAndDigits.store(unicodeMode,
+                                    std::memory_order_relaxed);
+    if (characterMode) {
+        Wh_FreeStringSetting(characterMode);
+    }
+}
+
+}  // namespace
+
+BOOL Wh_ModInit() {
+    LoadSettings();
+
+    bool installedAnyHook = false;
+
+    installedAnyHook |= InstallHook(InsertMenuW,
+                                    reinterpret_cast<void*>(InsertMenuWHook),
+                                    &g_originalInsertMenuW, L"InsertMenuW");
+    installedAnyHook |= InstallHook(AppendMenuW,
+                                    reinterpret_cast<void*>(AppendMenuWHook),
+                                    &g_originalAppendMenuW, L"AppendMenuW");
+    installedAnyHook |= InstallHook(ModifyMenuW,
+                                    reinterpret_cast<void*>(ModifyMenuWHook),
+                                    &g_originalModifyMenuW, L"ModifyMenuW");
+    installedAnyHook |=
+        InstallHook(InsertMenuItemW,
+                    reinterpret_cast<void*>(InsertMenuItemWHook),
+                    &g_originalInsertMenuItemW, L"InsertMenuItemW");
+    installedAnyHook |=
+        InstallHook(SetMenuItemInfoW,
+                    reinterpret_cast<void*>(SetMenuItemInfoWHook),
+                    &g_originalSetMenuItemInfoW, L"SetMenuItemInfoW");
+    installedAnyHook |=
+        InstallHook(TrackPopupMenu,
+                    reinterpret_cast<void*>(TrackPopupMenuHook),
+                    &g_originalTrackPopupMenu, L"TrackPopupMenu");
+    installedAnyHook |=
+        InstallHook(TrackPopupMenuEx,
+                    reinterpret_cast<void*>(TrackPopupMenuExHook),
+                    &g_originalTrackPopupMenuEx, L"TrackPopupMenuEx");
+
+    installedAnyHook |=
+        InstallHook(CreateWindowExW,
+                    reinterpret_cast<void*>(CreateWindowExWHook),
+                    &g_originalCreateWindowExW, L"CreateWindowExW");
+    installedAnyHook |= InstallHook(ShowWindow,
+                                    reinterpret_cast<void*>(ShowWindowHook),
+                                    &g_originalShowWindow, L"ShowWindow");
+    installedAnyHook |=
+        InstallHook(SetWindowPos,
+                    reinterpret_cast<void*>(SetWindowPosHook),
+                    &g_originalSetWindowPos, L"SetWindowPos");
+
+    installedAnyHook |= HookDirectWrite();
+
+    Wh_Log(L"CJK Spacer initialized (classic=%d, modern=%d, unicode=%d)",
+           g_classicMenus.load(), g_modernMenus.load(),
+           g_unicodeLettersAndDigits.load());
+    return installedAnyHook ? TRUE : FALSE;
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"CJK Spacer uninitialized");
+}
+
+void Wh_ModSettingsChanged() {
+    LoadSettings();
+    Wh_Log(L"CJK Spacer settings changed (classic=%d, modern=%d, unicode=%d)",
+           g_classicMenus.load(), g_modernMenus.load(),
+           g_unicodeLettersAndDigits.load());
+}

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              cjk-spacer
 // @name            CJK Spacer
-// @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.18
+// @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips; modern XAML UI is opt-in and may conflict with other XAML Diagnostics mods
+// @version         0.1.19
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -25,10 +25,12 @@ Adds a normal ASCII space at a direct boundary between a CJK character and a
 letter or digit in UI text hosted by `explorer.exe`.
 
 On Windows 11, the primary Explorer and desktop context menus are modern XAML
-menus. The `modernUiText` setting is disabled by default because XAML
-Diagnostics permits only one consumer per connection; enable it if you want
-those menus and pointer tooltips processed. `classicMenus` still covers the
-Win32 menu opened through "Show more options".
+menus. The `modernUiText` setting is disabled by default because each named
+XAML Diagnostics connection permits only one consumer, and tools such as
+Taskbar Styler or File Explorer Styler may already use or block those
+connections. Enable it explicitly if you want those menus and pointer
+tooltips processed. `classicMenus` still covers the Win32 menu opened through
+"Show more options".
 
 Examples:
 
@@ -78,7 +80,7 @@ keyboard shortcut text are also preserved.
   path is disabled by default; enable `modernUiText` to opt in.
 
 The modern path supports both Windows.UI.Xaml and Microsoft.UI.Xaml content
-hosted by Explorer. XAML Diagnostics allows one consumer per XAML connection,
+hosted by Explorer. Each named XAML Diagnostics connection allows one consumer,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
 initializing. Connection attempts are scheduled outside the Windows loader
@@ -125,7 +127,7 @@ the first match; the idempotent transformation does not compound spaces.
   $description: Process text in legacy tooltips such as notification-area icon tooltips.
 - modernUiText: false
   $name: Windows 11 context menus and tooltips
-  $description: Process text elements in Explorer XAML context menus and pointer tooltips (disabled by default; enable for the primary Windows 11 menu). Uses exclusive XAML Diagnostics connections and can conflict with Windows 11 Taskbar Styler, Windows 11 File Explorer Styler, or other diagnostics-based tools.
+  $description: Process text elements in Explorer XAML context menus and pointer tooltips (disabled by default; enable for the primary Windows 11 menu). Each named XAML Diagnostics connection has one consumer, so this can conflict with Windows 11 Taskbar Styler, Windows 11 File Explorer Styler, or other diagnostics-based tools.
 - characterMode: unicode
   $name: Non-CJK character set
   $description: Choose which letters and digits form a spacing boundary with CJK.
@@ -433,9 +435,6 @@ std::wstring AddCjkSpacing(std::wstring_view text,
 using InsertMenuW_t = decltype(&InsertMenuW);
 using AppendMenuW_t = decltype(&AppendMenuW);
 using ModifyMenuW_t = decltype(&ModifyMenuW);
-using InsertMenuA_t = decltype(&InsertMenuA);
-using AppendMenuA_t = decltype(&AppendMenuA);
-using ModifyMenuA_t = decltype(&ModifyMenuA);
 using InsertMenuItemW_t = decltype(&InsertMenuItemW);
 using SetMenuItemInfoW_t = decltype(&SetMenuItemInfoW);
 using TrackPopupMenu_t = decltype(&TrackPopupMenu);
@@ -444,9 +443,6 @@ using TrackPopupMenuEx_t = decltype(&TrackPopupMenuEx);
 InsertMenuW_t g_originalInsertMenuW;
 AppendMenuW_t g_originalAppendMenuW;
 ModifyMenuW_t g_originalModifyMenuW;
-InsertMenuA_t g_originalInsertMenuA;
-AppendMenuA_t g_originalAppendMenuA;
-ModifyMenuA_t g_originalModifyMenuA;
 InsertMenuItemW_t g_originalInsertMenuItemW;
 SetMenuItemInfoW_t g_originalSetMenuItemInfoW;
 TrackPopupMenu_t g_originalTrackPopupMenu;
@@ -478,66 +474,6 @@ int FindMenuItemIndexByText(
 
 bool IsStringMenuFlags(UINT flags) {
     return !(flags & (MF_BITMAP | MF_OWNERDRAW | MF_SEPARATOR));
-}
-
-bool ConvertAnsiMenuTextToWide(LPCSTR text, std::wstring* wide) {
-    if (!text || !wide) {
-        return false;
-    }
-
-    const int length = MultiByteToWideChar(
-        CP_ACP, 0, text, -1, nullptr, 0);
-    if (length <= 0) {
-        return false;
-    }
-
-    wide->resize(static_cast<size_t>(length));
-    if (MultiByteToWideChar(
-            CP_ACP, 0, text, -1, wide->data(), length) != length) {
-        wide->clear();
-        return false;
-    }
-
-    wide->resize(static_cast<size_t>(length - 1));
-    return true;
-}
-
-bool ConvertWideMenuTextToAnsi(const std::wstring& wide,
-                               std::string* ansi) {
-    if (!ansi) {
-        return false;
-    }
-
-    const int length = WideCharToMultiByte(
-        CP_ACP, 0, wide.c_str(), -1, nullptr, 0, nullptr, nullptr);
-    if (length <= 0) {
-        return false;
-    }
-
-    ansi->resize(static_cast<size_t>(length));
-    if (WideCharToMultiByte(
-            CP_ACP, 0, wide.c_str(), -1, ansi->data(), length,
-            nullptr, nullptr) != length) {
-        ansi->clear();
-        return false;
-    }
-
-    ansi->resize(static_cast<size_t>(length - 1));
-    return true;
-}
-
-bool PrepareAnsiMenuText(LPCSTR text,
-                         std::wstring* original,
-                         std::wstring* spaced,
-                         std::string* spacedAnsi) {
-    if (!ConvertAnsiMenuTextToWide(text, original) ||
-        !ContainsCjkCodePoint(*original)) {
-        return false;
-    }
-
-    *spaced = AddCjkSpacing(*original);
-    return *spaced != *original &&
-           ConvertWideMenuTextToAnsi(*spaced, spacedAnsi);
 }
 
 int FindMenuItemIndex(HMENU menu, UINT item, bool byPosition) {
@@ -666,110 +602,6 @@ BOOL WINAPI ModifyMenuWHook(HMENU menu,
     }
 
     return g_originalModifyMenuW(menu, position, flags, itemId, newItem);
-}
-
-BOOL WINAPI InsertMenuAHook(HMENU menu,
-                            UINT position,
-                            UINT flags,
-                            UINT_PTR itemId,
-                            LPCSTR newItem) {
-    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
-        g_classicMenus.load(std::memory_order_relaxed) && newItem &&
-        IsStringMenuFlags(flags)) {
-        std::wstring original;
-        std::wstring spaced;
-        std::string spacedAnsi;
-        if (PrepareAnsiMenuText(
-                newItem, &original, &spaced, &spacedAnsi)) {
-            Wh_Log(L"Applied CJK spacing (classic/InsertMenuA)");
-            const BOOL result = g_originalInsertMenuA(
-                menu, position, flags, itemId, spacedAnsi.c_str());
-            if (result) {
-                int index;
-                if (flags & MF_BYPOSITION) {
-                    index = FindMenuItemIndex(menu, position, true);
-                    if (index < 0) {
-                        index = GetMenuItemCount(menu) - 1;
-                    }
-                } else if (flags & MF_POPUP) {
-                    index = FindMenuItemIndexByText(menu, spaced);
-                } else {
-                    index = FindMenuItemIndex(
-                        menu, static_cast<UINT>(itemId), false);
-                }
-                RememberRewrittenMenuItem(
-                    menu,
-                    index >= 0 ? static_cast<UINT>(index)
-                               : kUnknownMenuItemIndex,
-                    std::move(original), std::move(spaced));
-            }
-            return result;
-        }
-    }
-
-    return g_originalInsertMenuA(menu, position, flags, itemId, newItem);
-}
-
-BOOL WINAPI AppendMenuAHook(HMENU menu,
-                            UINT flags,
-                            UINT_PTR itemId,
-                            LPCSTR newItem) {
-    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
-        g_classicMenus.load(std::memory_order_relaxed) && newItem &&
-        IsStringMenuFlags(flags)) {
-        std::wstring original;
-        std::wstring spaced;
-        std::string spacedAnsi;
-        if (PrepareAnsiMenuText(
-                newItem, &original, &spaced, &spacedAnsi)) {
-            Wh_Log(L"Applied CJK spacing (classic/AppendMenuA)");
-            const BOOL result = g_originalAppendMenuA(
-                menu, flags, itemId, spacedAnsi.c_str());
-            if (result) {
-                const int index = GetMenuItemCount(menu) - 1;
-                if (index >= 0) {
-                    RememberRewrittenMenuItem(
-                        menu, static_cast<UINT>(index),
-                        std::move(original), std::move(spaced));
-                }
-            }
-            return result;
-        }
-    }
-
-    return g_originalAppendMenuA(menu, flags, itemId, newItem);
-}
-
-BOOL WINAPI ModifyMenuAHook(HMENU menu,
-                            UINT position,
-                            UINT flags,
-                            UINT_PTR itemId,
-                            LPCSTR newItem) {
-    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
-        g_classicMenus.load(std::memory_order_relaxed) && newItem &&
-        IsStringMenuFlags(flags)) {
-        std::wstring original;
-        std::wstring spaced;
-        std::string spacedAnsi;
-        if (PrepareAnsiMenuText(
-                newItem, &original, &spaced, &spacedAnsi)) {
-            Wh_Log(L"Applied CJK spacing (classic/ModifyMenuA)");
-            const int index = FindMenuItemIndex(
-                menu, position, (flags & MF_BYPOSITION) != 0);
-            const BOOL result = g_originalModifyMenuA(
-                menu, position, flags, itemId, spacedAnsi.c_str());
-            if (result) {
-                RememberRewrittenMenuItem(
-                    menu,
-                    index >= 0 ? static_cast<UINT>(index)
-                               : kUnknownMenuItemIndex,
-                    std::move(original), std::move(spaced));
-            }
-            return result;
-        }
-    }
-
-    return g_originalModifyMenuA(menu, position, flags, itemId, newItem);
 }
 
 bool MenuItemInfoContainsString(const MENUITEMINFOW* itemInfo) {
@@ -1549,7 +1381,7 @@ public:
             return true;
         } catch (const winrt::hresult_error& error) {
             Wh_Log(L"Couldn't update modern XAML source: 0x%08X",
-                   error.code());
+                   static_cast<HRESULT>(error.code()));
             return false;
         }
     }
@@ -1570,7 +1402,7 @@ public:
             }
         } catch (const winrt::hresult_error& error) {
             Wh_Log(L"Couldn't restore modern XAML source: 0x%08X",
-                   error.code());
+                   static_cast<HRESULT>(error.code()));
         }
 
         m_modified = false;
@@ -1935,7 +1767,6 @@ private:
 };
 
 std::mutex g_visualTreeWatchersMutex;
-std::mutex g_modernUiLifecycleMutex;
 [[clang::no_destroy]]
 std::optional<std::vector<winrt::com_ptr<VisualTreeWatcher>>>
         g_visualTreeWatchers{std::in_place};
@@ -2302,8 +2133,6 @@ void EnsureModernXamlDiagnostics(uint64_t generation) {
 }
 
 void RequestModernXamlDiagnosticsInitialization() {
-    std::lock_guard<std::mutex> lifecycleGuard(
-        g_modernUiLifecycleMutex);
     const uint64_t generation =
         g_modernUiGeneration.load(std::memory_order_acquire);
     if (!IsCurrentModernUiGeneration(generation)) {
@@ -2319,6 +2148,8 @@ void RequestModernXamlDiagnosticsInitialization() {
         return;
     }
 
+    // Do not hold a mutex across these calls. The request can originate from
+    // LoadLibraryExW, whose caller may still own the Windows loader lock.
     // The worker isn't joined during unload, so keep the mod image loaded
     // until the worker exits through FreeLibraryAndExitThread.
     HMODULE module = AcquireCurrentModuleReference();
@@ -2425,6 +2256,16 @@ bool IsTextualWindowClassName(LPCWSTR className) {
             ~static_cast<ULONG_PTR>(0xFFFF)) != 0;
 }
 
+bool IsModernXamlHostClassName(LPCWSTR className) {
+    return className &&
+           (_wcsicmp(
+                className,
+                L"Windows.UI.Composition.DesktopWindowContentBridge") == 0 ||
+            _wcsicmp(className, L"XamlExplorerHostIslandWindow") == 0 ||
+            _wcsicmp(
+                className, L"XamlExplorerHostIslandWindow_WASDK") == 0);
+}
+
 bool IsModernXamlHostWindow(HWND window,
                             HWND parent,
                             LPCWSTR className) {
@@ -2442,8 +2283,7 @@ bool IsModernXamlHostWindow(HWND window,
                _wcsicmp(parentClassName, L"Shell_TrayWnd") == 0;
     }
 
-    return _wcsicmp(className, L"XamlExplorerHostIslandWindow") == 0 ||
-           _wcsicmp(className, L"XamlExplorerHostIslandWindow_WASDK") == 0;
+    return IsModernXamlHostClassName(className);
 }
 
 void OnModernXamlHostWindowCreated(HWND window,
@@ -2612,21 +2452,34 @@ bool RunFromWindowThread(HWND window,
 }
 
 HWND FindWindowForThread(DWORD threadId) {
-    HWND result = nullptr;
+    struct FindWindowParameter {
+        HWND first = nullptr;
+        HWND xamlHost = nullptr;
+    } parameter;
+
     EnumThreadWindows(
         threadId,
         [](HWND window, LPARAM parameter) -> BOOL {
-            auto* result = reinterpret_cast<HWND*>(parameter);
-            *result = window;
-            return FALSE;
+            auto* state = reinterpret_cast<FindWindowParameter*>(parameter);
+            if (!state->first) {
+                state->first = window;
+            }
+
+            wchar_t className[128];
+            if (GetClassNameW(
+                    window, className, ARRAYSIZE(className)) > 0 &&
+                IsModernXamlHostClassName(className)) {
+                state->xamlHost = window;
+                return FALSE;
+            }
+
+            return TRUE;
         },
-        reinterpret_cast<LPARAM>(&result));
-    return result;
+        reinterpret_cast<LPARAM>(&parameter));
+    return parameter.xamlHost ? parameter.xamlHost : parameter.first;
 }
 
 void InitializeModernUi() {
-    std::lock_guard<std::mutex> lifecycleGuard(
-        g_modernUiLifecycleMutex);
     g_stoppingModernUi.store(true, std::memory_order_release);
     g_modernUiGeneration.fetch_add(1, std::memory_order_acq_rel);
     g_windowsUiXamlDiagnosticsConnected.store(
@@ -2684,6 +2537,9 @@ void UninitializeModernUi() {
             continue;
         }
 
+        // Prefer an Explorer/taskbar XAML host window. If the host was
+        // replaced, the helper still falls back to another window on the same
+        // UI thread so cleanup can run on the owning thread.
         const HWND window = FindWindowForThread(threadId);
         if (!window ||
             !IsRegisteredThreadAlive(threadId, creationTime) ||
@@ -2875,15 +2731,6 @@ BOOL Wh_ModInit() {
             ModifyMenuW, ModifyMenuWHook, &g_originalModifyMenuW,
             L"ModifyMenuW");
         installedAnyHook |= InstallHook(
-            InsertMenuA, InsertMenuAHook, &g_originalInsertMenuA,
-            L"InsertMenuA");
-        installedAnyHook |= InstallHook(
-            AppendMenuA, AppendMenuAHook, &g_originalAppendMenuA,
-            L"AppendMenuA");
-        installedAnyHook |= InstallHook(
-            ModifyMenuA, ModifyMenuAHook, &g_originalModifyMenuA,
-            L"ModifyMenuA");
-        installedAnyHook |= InstallHook(
             InsertMenuItemW, InsertMenuItemWHook,
             &g_originalInsertMenuItemW, L"InsertMenuItemW");
         installedAnyHook |= InstallHook(
@@ -2978,7 +2825,6 @@ void Wh_ModUninit() {
         FreeLibrary(g_loadedUxThemeModule);
         g_loadedUxThemeModule = nullptr;
     }
-    ClearUxThemeFunctionPointers();
     Wh_Log(L"Uninitialized");
 }
 

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.11
+// @version         0.1.12
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -58,12 +58,13 @@ keyboard shortcut text are also preserved.
   running Explorer. Basic or classic-theme tooltips drawn directly with
   `DrawTextW` aren't covered.
 - Windows 11 XAML context menus and pointer tooltips are handled at the XAML
-  source-element level. Only the `Text` source of XAML menu items and
-  string-valued `ToolTip.Content` are changed; presenter `TextBlock` bindings,
-  ordinary XAML text, and taskbar thumbnail previews are untouched. Popup
-  visibility is maintained from accessibility show/hide/destroy events, and
-  each source is restored only when its owning popup closes. This path is
-  disabled by default; enable `modernUiText` to opt in.
+  source-element level. Only plain local string values in the `Text` source of
+  XAML menu items and `ToolTip.Content` are changed; bindings, styles,
+  presenter `TextBlock` values, ordinary XAML text, and taskbar thumbnail
+  previews are untouched. Popup visibility is maintained from accessibility
+  show/hide/destroy events, and each source is restored only when its owning
+  popup closes. This path is disabled by default; enable `modernUiText` to opt
+  in.
 
 The modern path supports both Windows.UI.Xaml and Microsoft.UI.Xaml content
 hosted by Explorer. XAML Diagnostics allows one consumer per XAML connection,
@@ -110,6 +111,7 @@ Rewritten strings are recorded and restored when the popup closes.
 #include <cstdint>
 #include <cstring>
 #include <cwchar>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -456,9 +458,10 @@ int FindMenuItemIndex(HMENU menu, UINT item, bool byPosition) {
     for (int index = 0; index < itemCount; ++index) {
         MENUITEMINFOW itemInfo = {};
         itemInfo.cbSize = sizeof(itemInfo);
-        itemInfo.fMask = MIIM_ID;
+        itemInfo.fMask = MIIM_ID | MIIM_SUBMENU;
         if (GetMenuItemInfoW(
                 menu, index, TRUE, &itemInfo) &&
+            !itemInfo.hSubMenu &&
             itemInfo.wID == item) {
             return index;
         }
@@ -485,6 +488,9 @@ BOOL WINAPI InsertMenuWHook(HMENU menu,
                 if (flags & MF_BYPOSITION) {
                     index = FindMenuItemIndex(
                         menu, position, true);
+                    if (index < 0) {
+                        index = GetMenuItemCount(menu) - 1;
+                    }
                 } else if (flags & MF_POPUP) {
                     index = FindMenuItemIndexByText(
                         menu, spaced);
@@ -712,9 +718,15 @@ BOOL WINAPI InsertMenuItemWHook(HMENU menu,
                         ? item
                         : itemInfo->wID,
                     byPosition != FALSE);
-                if (index >= 0) {
+                const int insertedIndex =
+                    index >= 0
+                        ? index
+                        : byPosition
+                              ? GetMenuItemCount(menu) - 1
+                              : FindMenuItemIndexByText(menu, spaced);
+                if (insertedIndex >= 0) {
                     RememberRewrittenMenuItem(
-                        menu, static_cast<UINT>(index),
+                        menu, static_cast<UINT>(insertedIndex),
                         itemInfo->dwTypeData, spaced);
                 }
             }
@@ -875,6 +887,7 @@ GetWindowTheme_t g_getWindowTheme;
 GetThemeTextExtent_t g_originalGetThemeTextExtent;
 DrawThemeText_t g_originalDrawThemeText;
 DrawThemeTextEx_t g_originalDrawThemeTextEx;
+HMODULE g_loadedUxThemeModule;
 
 std::shared_mutex g_classicTooltipThemesMutex;
 std::unordered_set<HTHEME> g_classicTooltipThemes;
@@ -983,25 +996,9 @@ BOOL CALLBACK EnumExistingClassicTooltipWindow(HWND window, LPARAM) {
     return TRUE;
 }
 
-BOOL CALLBACK EnumExistingClassicTooltipTopLevelWindow(
-    HWND window,
-    LPARAM) {
-    DWORD processId;
-    GetWindowThreadProcessId(window, &processId);
-    if (processId != GetCurrentProcessId()) {
-        return TRUE;
-    }
-
-    EnumExistingClassicTooltipWindow(window, 0);
-    EnumChildWindows(
-        window, EnumExistingClassicTooltipWindow, 0);
-    return TRUE;
-}
-
 void DiscoverExistingClassicTooltipThemes() {
     if (g_getWindowTheme) {
-        EnumWindows(
-            EnumExistingClassicTooltipTopLevelWindow, 0);
+        EnumWindows(EnumExistingClassicTooltipWindow, 0);
     }
 }
 
@@ -1314,12 +1311,33 @@ void ClearVisibleModernPopups() {
     g_visibleModernPopups.clear();
 }
 
+template <typename Element, typename DependencyProperty>
+bool ReadLocalStringValue(const Element& element,
+                          DependencyProperty property,
+                          std::wstring* text) {
+    const auto localValue = element.ReadLocalValue(property);
+    if (!localValue ||
+        localValue == DependencyProperty::UnsetValue()) {
+        return false;
+    }
+
+    const auto propertyValue =
+        localValue.template try_as<wf::IPropertyValue>();
+    if (!propertyValue ||
+        propertyValue.Type() != wf::PropertyType::String) {
+        return false;
+    }
+
+    const auto value = propertyValue.GetString();
+    text->assign(value.c_str(), value.size());
+    return true;
+}
+
 struct TextSourceAccess {
     template <typename Element>
     static bool Read(const Element& element, std::wstring* text) {
-        const auto value = element.Text();
-        text->assign(value.c_str(), value.size());
-        return true;
+        return ReadLocalStringValue(
+            element, Element::TextProperty(), text);
     }
 
     template <typename Element>
@@ -1332,24 +1350,12 @@ struct TextSourceAccess {
     }
 };
 
+template <typename ContentControl>
 struct TooltipContentAccess {
     template <typename Element>
     static bool Read(const Element& element, std::wstring* text) {
-        const auto content = element.Content();
-        if (!content) {
-            return false;
-        }
-
-        const auto propertyValue =
-            content.template try_as<wf::IPropertyValue>();
-        if (!propertyValue ||
-            propertyValue.Type() != wf::PropertyType::String) {
-            return false;
-        }
-
-        const auto value = propertyValue.GetString();
-        text->assign(value.c_str(), value.size());
-        return true;
+        return ReadLocalStringValue(
+            element, ContentControl::ContentProperty(), text);
     }
 
     template <typename Element>
@@ -1366,7 +1372,7 @@ class ModernTextStateBase {
 public:
     virtual ~ModernTextStateBase() = default;
     virtual void Apply(HWND popupWindow) = 0;
-    virtual void Restore() = 0;
+    virtual void Restore(bool clearOwnership) = 0;
     virtual HWND PopupWindow() const = 0;
 };
 
@@ -1385,16 +1391,17 @@ public:
         }
 
         try {
-            auto element = m_element.get();
-            if (!element) {
-                return;
-            }
-
             if (m_popupWindow && m_popupWindow != popupWindow) {
                 if (IsTrackedModernPopup(m_popupWindow, threadId)) {
                     return;
                 }
-                Restore();
+                Restore(true);
+            }
+            m_popupWindow = popupWindow;
+
+            auto element = m_element.get();
+            if (!element) {
+                return;
             }
 
             std::wstring current;
@@ -1410,7 +1417,6 @@ public:
                 // The application updated the source while the popup was
                 // visible. Preserve that update and use it as the new source.
                 m_modified = false;
-                m_popupWindow = nullptr;
                 m_originalText.clear();
                 m_spacedText.clear();
             }
@@ -1426,7 +1432,6 @@ public:
 
             m_originalText = std::move(current);
             m_spacedText = std::move(spaced);
-            m_popupWindow = popupWindow;
             m_modified = true;
             SourceAccess::Write(element, m_spacedText);
             Wh_Log(L"Applied CJK spacing (modern XAML %s)",
@@ -1437,9 +1442,11 @@ public:
         }
     }
 
-    void Restore() override {
+    void Restore(bool clearOwnership) override {
         if (!m_modified) {
-            m_popupWindow = nullptr;
+            if (clearOwnership) {
+                m_popupWindow = nullptr;
+            }
             return;
         }
 
@@ -1458,7 +1465,9 @@ public:
         }
 
         m_modified = false;
-        m_popupWindow = nullptr;
+        if (clearOwnership) {
+            m_popupWindow = nullptr;
+        }
         m_originalText.clear();
         m_spacedText.clear();
     }
@@ -1507,7 +1516,18 @@ using ModernTextStateMap =
                        std::shared_ptr<ModernTextStateBase>,
                        ModernElementKeyHash>;
 
-thread_local std::optional<ModernTextStateMap>
+using ModernElementKeySet =
+    std::unordered_set<ModernElementKey, ModernElementKeyHash>;
+
+struct ModernThreadState {
+    ModernTextStateMap states;
+    // Newly observed sources wait for the next popup SHOW. Ownership is kept
+    // across HIDE so another popup can't claim a cached source.
+    ModernElementKeySet pending;
+    std::unordered_map<HWND, ModernElementKeySet> ownedByPopup;
+};
+
+thread_local std::optional<ModernThreadState>
     g_modernTextStatesForThread{std::in_place};
 
 std::mutex g_modernTextStateThreadsMutex;
@@ -1530,23 +1550,92 @@ void ApplyModernTextStatesForPopup(HWND popupWindow) {
         return;
     }
 
-    for (const auto& [key, state] :
-         *g_modernTextStatesForThread) {
-        state->Apply(popupWindow);
+    auto& threadState = *g_modernTextStatesForThread;
+    if (auto ownerIterator =
+            threadState.ownedByPopup.find(popupWindow);
+        ownerIterator != threadState.ownedByPopup.end()) {
+        for (auto iterator = ownerIterator->second.begin();
+             iterator != ownerIterator->second.end();) {
+            const auto stateIterator =
+                threadState.states.find(*iterator);
+            if (stateIterator == threadState.states.end()) {
+                iterator = ownerIterator->second.erase(iterator);
+                continue;
+            }
+
+            stateIterator->second->Apply(popupWindow);
+            ++iterator;
+        }
+    }
+
+    ModernElementKeySet pending;
+    pending.swap(threadState.pending);
+    if (!pending.empty()) {
+        auto& owned = threadState.ownedByPopup[popupWindow];
+        for (const auto& key : pending) {
+            const auto iterator = threadState.states.find(key);
+            if (iterator == threadState.states.end()) {
+                continue;
+            }
+
+            iterator->second->Apply(popupWindow);
+            owned.insert(key);
+        }
     }
 }
 
-void RestoreModernTextStatesForPopup(HWND popupWindow) {
+void RestoreModernTextStatesForPopup(HWND popupWindow,
+                                     bool clearOwnership) {
     if (!g_modernTextStatesForThread) {
         return;
     }
 
-    for (const auto& [key, state] :
-         *g_modernTextStatesForThread) {
-        if (state->PopupWindow() == popupWindow) {
-            state->Restore();
+    auto& threadState = *g_modernTextStatesForThread;
+    const auto ownerIterator =
+        threadState.ownedByPopup.find(popupWindow);
+    if (ownerIterator == threadState.ownedByPopup.end()) {
+        return;
+    }
+
+    for (const auto& key : ownerIterator->second) {
+        const auto stateIterator = threadState.states.find(key);
+        if (stateIterator == threadState.states.end()) {
+            continue;
+        }
+
+        stateIterator->second->Restore(clearOwnership);
+        if (clearOwnership) {
+            threadState.pending.insert(key);
         }
     }
+
+    if (clearOwnership) {
+        threadState.ownedByPopup.erase(ownerIterator);
+    }
+}
+
+void RemoveModernTextState(ModernThreadState& threadState,
+                           const ModernElementKey& key) {
+    threadState.pending.erase(key);
+    const auto stateIterator = threadState.states.find(key);
+    if (stateIterator == threadState.states.end()) {
+        return;
+    }
+
+    if (const HWND popupWindow =
+            stateIterator->second->PopupWindow()) {
+        if (auto ownerIterator =
+                threadState.ownedByPopup.find(popupWindow);
+            ownerIterator != threadState.ownedByPopup.end()) {
+            ownerIterator->second.erase(key);
+            if (ownerIterator->second.empty()) {
+                threadState.ownedByPopup.erase(ownerIterator);
+            }
+        }
+    }
+
+    stateIterator->second->Restore(true);
+    threadState.states.erase(stateIterator);
 }
 
 void CleanupModernTextStatesForCurrentThread() {
@@ -1555,8 +1644,8 @@ void CleanupModernTextStatesForCurrentThread() {
     }
 
     for (const auto& [key, state] :
-         *g_modernTextStatesForThread) {
-        state->Restore();
+         g_modernTextStatesForThread->states) {
+        state->Restore(true);
     }
     g_modernTextStatesForThread.reset();
     UnregisterModernTextStateThread();
@@ -1628,20 +1717,23 @@ private:
             std::make_shared<ModernTextState<Element, SourceAccess>>(
                 element);
         const ModernElementKey key{this, handle};
-        auto& states = *g_modernTextStatesForThread;
-        if (auto iterator = states.find(key);
-            iterator != states.end()) {
-            iterator->second->Restore();
-            iterator->second = state;
-        } else {
-            if (states.empty()) {
-                RegisterModernTextStateThread();
-            }
-            states.emplace(key, state);
+        auto& threadState = *g_modernTextStatesForThread;
+        if (threadState.states.contains(key)) {
+            RemoveModernTextState(threadState, key);
         }
+        if (threadState.states.empty()) {
+            RegisterModernTextStateThread();
+        }
+        threadState.states.emplace(key, state);
 
-        state->Apply(
-            GetMostRecentModernPopupForThread(GetCurrentThreadId()));
+        const HWND popupWindow =
+            GetMostRecentModernPopupForThread(GetCurrentThreadId());
+        if (popupWindow) {
+            state->Apply(popupWindow);
+            threadState.ownedByPopup[popupWindow].insert(key);
+        } else {
+            threadState.pending.insert(key);
+        }
         return true;
     }
 
@@ -1654,7 +1746,8 @@ private:
         }
 
         const ModernElementKey key{this, element.Handle};
-        auto& states = *g_modernTextStatesForThread;
+        auto& threadState = *g_modernTextStatesForThread;
+        auto& states = threadState.states;
 
         if (mutationType == Add &&
             g_modernUiText.load(std::memory_order_relaxed)) {
@@ -1690,20 +1783,20 @@ private:
             } else {
                 if (TryRegisterSource<
                         wux::Controls::ToolTip,
-                        TooltipContentAccess>(
+                        TooltipContentAccess<
+                            wux::Controls::ContentControl>>(
                         element.Handle, inspectable) ||
                     TryRegisterSource<
                         mux::Controls::ToolTip,
-                        TooltipContentAccess>(
+                        TooltipContentAccess<
+                            mux::Controls::ContentControl>>(
                         element.Handle, inspectable)) {
                     return S_OK;
                 }
             }
         } else if (mutationType == Remove) {
-            if (auto iterator = states.find(key);
-                iterator != states.end()) {
-                iterator->second->Restore();
-                states.erase(iterator);
+            if (states.contains(key)) {
+                RemoveModernTextState(threadState, key);
                 if (states.empty()) {
                     UnregisterModernTextStateThread();
                 }
@@ -2049,6 +2142,18 @@ void CALLBACK ModernPopupWinEventProc(
         return;
     }
 
+    if (event == EVENT_OBJECT_DESTROY) {
+        {
+            std::lock_guard<std::mutex> guard(
+                g_visibleModernPopupsMutex);
+            g_visibleModernPopups.erase(window);
+        }
+        // The in-context callback still runs on the popup's UI thread even
+        // after the HWND is no longer valid.
+        RestoreModernTextStatesForPopup(window, true);
+        return;
+    }
+
     DWORD processId;
     const DWORD threadId =
         GetWindowThreadProcessId(window, &processId);
@@ -2064,8 +2169,7 @@ void CALLBACK ModernPopupWinEventProc(
 
         RequestXamlDiagnosticsInitialization();
         ApplyModernTextStatesForPopup(window);
-    } else if (event == EVENT_OBJECT_HIDE ||
-               event == EVENT_OBJECT_DESTROY) {
+    } else if (event == EVENT_OBJECT_HIDE) {
         bool wasTracked;
         {
             std::lock_guard<std::mutex> guard(
@@ -2075,7 +2179,7 @@ void CALLBACK ModernPopupWinEventProc(
         }
 
         if (wasTracked) {
-            RestoreModernTextStatesForPopup(window);
+            RestoreModernTextStatesForPopup(window, false);
         }
     }
 }
@@ -2240,8 +2344,12 @@ bool InstallHook(Function target,
 }
 
 bool HookClassicTooltipThemeDrawing() {
-    HMODULE themeModule = LoadLibraryExW(
-        L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    HMODULE themeModule = GetModuleHandleW(L"uxtheme.dll");
+    if (!themeModule) {
+        themeModule = LoadLibraryExW(
+            L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+        g_loadedUxThemeModule = themeModule;
+    }
     if (!themeModule) {
         Wh_Log(L"Couldn't load uxtheme.dll");
         return false;
@@ -2334,6 +2442,10 @@ bool HookClassicTooltipThemeDrawing() {
         Wh_Log(L"Couldn't find DrawThemeTextEx");
     }
 
+    if (!hooked && g_loadedUxThemeModule) {
+        FreeLibrary(g_loadedUxThemeModule);
+        g_loadedUxThemeModule = nullptr;
+    }
     return hooked;
 }
 
@@ -2427,6 +2539,10 @@ void Wh_ModAfterInit() {
 void Wh_ModUninit() {
     RestoreRewrittenMenuItems();
     ClearTrackedClassicTooltipThemes();
+    if (g_loadedUxThemeModule) {
+        FreeLibrary(g_loadedUxThemeModule);
+        g_loadedUxThemeModule = nullptr;
+    }
     if (g_modernUiText.load(std::memory_order_relaxed)) {
         UninitializeModernUi();
     }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,18 +2,20 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.8
+// @version         0.1.9
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
 // @include         explorer.exe
 // @architecture    x86-64
+// @compilerOptions -lcomctl32 -lole32 -loleaut32 -lruntimeobject
 // ==/WindhawkMod==
 
 // Source code is published under the GNU General Public License v3.0.
 //
-// The Win32 menu and DirectWrite hook techniques are based in part on the
-// open-source Windhawk "Text Replace" mod by m417z.
+// The Win32 menu hook technique is based in part on the open-source Windhawk
+// "Text Replace" mod by m417z. The XAML diagnostics connection is based on the
+// Windows 11 styler mods by m417z and ExplorerTAP from TranslucentTB.
 
 // ==WindhawkModReadme==
 /*
@@ -55,17 +57,17 @@ keyboard shortcut text are also preserved.
   Existing tooltip controls are discovered when the mod is enabled in a
   running Explorer. Basic or classic-theme tooltips drawn directly with
   `DrawTextW` aren't covered.
-- Windows 11 XAML context menus and pointer tooltips use an experimental,
-  display-only DirectWrite hook. Taskbar thumbnail previews and XAML popups
-  related to them are explicitly excluded. While an eligible popup is visible,
-  other XAML text laid out on the same UI thread can also be transformed;
-  unrelated Explorer threads remain unaffected. This path is disabled by
-  default; enable `modernUiText` to opt in.
+- Windows 11 XAML context menus and pointer tooltips are handled at the XAML
+  element level. Only `TextBlock` elements below a `MenuFlyoutPresenter` or
+  `ToolTip` are changed; ordinary XAML text and taskbar thumbnail previews are
+  outside this scope. Popup visibility is maintained from accessibility
+  show/hide/destroy events, and modified text is restored when an element is
+  unloaded. This path is disabled by default; enable `modernUiText` to opt in.
 
-The modern path is intentionally conservative and can miss text if a Windows
-build uses a different popup window class. It remains opt-in because
-DirectWrite doesn't identify the target XAML element; disable `modernUiText`
-again if it causes a problem.
+The modern path supports both Windows.UI.Xaml and Microsoft.UI.Xaml content
+hosted by Explorer. XAML Diagnostics allows one consumer per XAML connection,
+so another diagnostics-based customization tool can prevent this path from
+initializing.
 
 The mod is injected only into `explorer.exe`. Start, Search, and some shell
 flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
@@ -73,10 +75,11 @@ flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
 
 The mod doesn't edit system files, registry values, or file names. A file name
 shown in a classic menu can nevertheless be displayed with inserted spaces.
-The modern DirectWrite path changes display text only. The classic path updates
-strings stored in active `HMENU` objects, so menu text read through
-accessibility APIs also contains the inserted spaces while the popup is open.
-Rewritten strings are recorded and restored when the popup closes.
+The modern path temporarily changes target `TextBlock` values and restores
+them when the elements are unloaded. The classic path updates strings stored in
+active `HMENU` objects, so menu text read through accessibility APIs also
+contains the inserted spaces while the popup is open. Rewritten strings are
+recorded and restored when the popup closes.
 */
 // ==/WindhawkModReadme==
 
@@ -89,8 +92,8 @@ Rewritten strings are recorded and restored when the popup closes.
   $name: Classic Win32 tooltips
   $description: Process text in legacy tooltips such as notification-area icon tooltips.
 - modernUiText: false
-  $name: Windows 11 context menus and tooltips (experimental)
-  $description: Process DirectWrite text in Explorer XAML context menus and pointer tooltips.
+  $name: Windows 11 context menus and tooltips
+  $description: Process text elements in Explorer XAML context menus and pointer tooltips.
 - characterMode: unicode
   $name: Non-CJK character set
   $description: Choose which letters and digits form a spacing boundary with CJK.
@@ -100,10 +103,13 @@ Rewritten strings are recorded and restored when the popup closes.
 */
 // ==/WindhawkModSettings==
 
+#include <xamlom.h>
+
 #include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <cwchar>
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <string>
@@ -115,9 +121,18 @@ Rewritten strings are recorded and restored when the popup closes.
 #include <windows.h>
 
 #include <commctrl.h>  // TOOLTIPS_CLASSW
-#include <dwrite.h>
 #include <uxtheme.h>
 #include <vsstyle.h>
+
+#undef GetCurrentTime
+
+#include <winrt/base.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Microsoft.UI.Xaml.Media.h>
+#include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.h>
 
 namespace {
 
@@ -947,6 +962,12 @@ bool IsClassicTooltipWindow(HWND window) {
            _wcsicmp(className, TOOLTIPS_CLASSW) == 0;
 }
 
+bool IsClassicTooltipTarget(HTHEME theme, HDC dc) {
+    const HWND window = dc ? WindowFromDC(dc) : nullptr;
+    return window ? IsClassicTooltipWindow(window)
+                  : IsTrackedClassicTooltipTheme(theme);
+}
+
 BOOL CALLBACK EnumExistingClassicTooltipWindow(HWND window, LPARAM) {
     DWORD processId;
     GetWindowThreadProcessId(window, &processId);
@@ -1062,7 +1083,7 @@ HRESULT WINAPI GetThemeTextExtentHook(HTHEME theme,
     if (!g_classicTooltips.load(std::memory_order_relaxed) ||
         g_rewritingClassicTooltipText ||
         !IsClassicTooltipTextPart(partId) ||
-        !IsTrackedClassicTooltipTheme(theme)) {
+        !IsClassicTooltipTarget(theme, dc)) {
         return g_originalGetThemeTextExtent(
             theme, dc, partId, stateId, text, textLength, textFlags,
             boundingRectangle, extentRectangle);
@@ -1099,7 +1120,7 @@ HRESULT WINAPI DrawThemeTextHook(HTHEME theme,
     if (!g_classicTooltips.load(std::memory_order_relaxed) ||
         g_rewritingClassicTooltipText ||
         !IsClassicTooltipTextPart(partId) ||
-        !IsTrackedClassicTooltipTheme(theme)) {
+        !IsClassicTooltipTarget(theme, dc)) {
         return g_originalDrawThemeText(
             theme, dc, partId, stateId, text, textLength, textFlags,
             textFlags2, rectangle);
@@ -1135,7 +1156,7 @@ HRESULT WINAPI DrawThemeTextExHook(HTHEME theme,
     if (!g_classicTooltips.load(std::memory_order_relaxed) ||
         g_rewritingClassicTooltipText ||
         !IsClassicTooltipTextPart(partId) ||
-        !IsTrackedClassicTooltipTheme(theme)) {
+        !IsClassicTooltipTarget(theme, dc)) {
         return g_originalDrawThemeTextEx(
             theme, dc, partId, stateId, text, textLength, textFlags,
             rectangle, options);
@@ -1160,137 +1181,38 @@ HRESULT WINAPI DrawThemeTextExHook(HTHEME theme,
 }
 
 // -------------------------------------------------------------------------
-// Windows 11 XAML popup detection
+// Windows 11 XAML context menus and tooltips
 // -------------------------------------------------------------------------
 
-using CreateWindowExW_t = decltype(&CreateWindowExW);
-using CreateWindowInBand_t = HWND(WINAPI*)(
-    DWORD exStyle,
-    LPCWSTR className,
-    LPCWSTR windowName,
-    DWORD style,
-    int x,
-    int y,
-    int width,
-    int height,
-    HWND parent,
-    HMENU menu,
-    HINSTANCE instance,
-    PVOID parameter,
-    DWORD band);
-using CreateWindowInBandEx_t = HWND(WINAPI*)(
-    DWORD exStyle,
-    LPCWSTR className,
-    LPCWSTR windowName,
-    DWORD style,
-    int x,
-    int y,
-    int width,
-    int height,
-    HWND parent,
-    HMENU menu,
-    HINSTANCE instance,
-    PVOID parameter,
-    DWORD band,
-    DWORD typeFlags);
+namespace wf = winrt::Windows::Foundation;
+namespace wux = winrt::Windows::UI::Xaml;
+namespace mux = winrt::Microsoft::UI::Xaml;
 
-CreateWindowExW_t g_originalCreateWindowExW;
-CreateWindowInBand_t g_originalCreateWindowInBand;
-CreateWindowInBandEx_t g_originalCreateWindowInBandEx;
-
-enum class ModernWindowKind {
-    Other,
-    Popup,
-    TaskbarThumbnail,
-};
-
-struct TrackedModernWindow {
+struct VisibleModernPopup {
     DWORD threadId;
-    ModernWindowKind kind;
 };
 
-std::mutex g_trackedModernWindowsMutex;
-std::unordered_map<HWND, TrackedModernWindow>
-    g_trackedModernWindows;
-std::atomic_uint g_trackedModernWindowCount{0};
-std::atomic_uint g_trackedModernPopupCount{0};
+std::mutex g_visibleModernPopupsMutex;
+std::unordered_map<HWND, VisibleModernPopup> g_visibleModernPopups;
+HWINEVENTHOOK g_modernPopupWinEventHook;
 
-void UpdateTrackedModernWindowCountsLocked() {
-    unsigned int popupCount = 0;
-    for (const auto& entry : g_trackedModernWindows) {
-        if (entry.second.kind == ModernWindowKind::Popup) {
-            ++popupCount;
-        }
-    }
-
-    g_trackedModernWindowCount.store(
-        static_cast<unsigned int>(
-            g_trackedModernWindows.size()),
-        std::memory_order_relaxed);
-    g_trackedModernPopupCount.store(
-        popupCount, std::memory_order_relaxed);
+bool IsModernPopupClassName(LPCWSTR className) {
+    return className &&
+           (_wcsicmp(className, L"Xaml_WindowedPopupClass") == 0 ||
+            _wcsicmp(className,
+                     L"Microsoft.UI.Content.PopupWindowSiteBridge") == 0);
 }
 
-ModernWindowKind ClassifyModernWindowClassName(LPCWSTR className) {
-    if (!className) {
-        return ModernWindowKind::Other;
-    }
-
-    if (_wcsicmp(className, L"Xaml_WindowedPopupClass") == 0) {
-        return ModernWindowKind::Popup;
-    }
-
-    if (_wcsicmp(className, L"TaskListThumbnailWnd") == 0) {
-        return ModernWindowKind::TaskbarThumbnail;
-    }
-
-    return ModernWindowKind::Other;
-}
-
-ModernWindowKind ClassifyModernWindow(HWND window) {
+bool IsModernPopupWindow(HWND window) {
     wchar_t className[128];
-    const int length = GetClassNameW(window, className, ARRAYSIZE(className));
-    return length > 0 ? ClassifyModernWindowClassName(className)
-                      : ModernWindowKind::Other;
+    return window &&
+           GetClassNameW(window, className, ARRAYSIZE(className)) > 0 &&
+           IsModernPopupClassName(className);
 }
 
-bool HasWindowClass(HWND window, LPCWSTR expectedClassName) {
-    if (!window) {
-        return false;
-    }
-
-    wchar_t className[128];
-    const int length = GetClassNameW(window, className, ARRAYSIZE(className));
-    return length > 0 && _wcsicmp(className, expectedClassName) == 0;
-}
-
-bool IsTaskbarThumbnailSurface(HWND window) {
-    if (!window) {
-        return false;
-    }
-
-    const HWND root = GetAncestor(window, GA_ROOT);
-    const HWND rootOwner = GetAncestor(window, GA_ROOTOWNER);
-    const HWND candidates[] = {window, root, rootOwner};
-
-    for (HWND candidate : candidates) {
-        if (HasWindowClass(candidate, L"TaskListThumbnailWnd") ||
-            HasWindowClass(candidate, L"XamlExplorerHostIslandWindow")) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-bool IsCursorInsideTaskbarThumbnailSurface() {
-    POINT cursor;
-    return GetCursorPos(&cursor) &&
-           IsTaskbarThumbnailSurface(WindowFromPoint(cursor));
-}
-
-bool TrackModernWindow(HWND window, ModernWindowKind kind) {
-    if (!window || kind == ModernWindowKind::Other) {
+bool TrackVisibleModernPopup(HWND window) {
+    if (!window || !IsWindowVisible(window) ||
+        !IsModernPopupWindow(window)) {
         return false;
     }
 
@@ -1301,362 +1223,718 @@ bool TrackModernWindow(HWND window, ModernWindowKind kind) {
         return false;
     }
 
-    bool inserted;
-    {
-        std::lock_guard<std::mutex> guard(
-            g_trackedModernWindowsMutex);
-        const auto [iterator, wasInserted] =
-            g_trackedModernWindows.try_emplace(
-                window, TrackedModernWindow{threadId, kind});
-        if (!wasInserted) {
-            iterator->second = {threadId, kind};
-        }
-        inserted = wasInserted;
-        UpdateTrackedModernWindowCountsLocked();
-    }
-
-    if (inserted) {
-        if (kind == ModernWindowKind::TaskbarThumbnail) {
-            Wh_Log(L"Tracking excluded taskbar thumbnail");
-        } else {
-            Wh_Log(L"Tracking modern popup");
-        }
-    }
+    std::lock_guard<std::mutex> guard(g_visibleModernPopupsMutex);
+    g_visibleModernPopups[window] = {threadId};
     return true;
 }
 
-bool TrackModernWindowIfRelevant(HWND window) {
-    const ModernWindowKind kind = ClassifyModernWindow(window);
-    return TrackModernWindow(window, kind);
-}
+struct FindVisibleModernPopupData {
+    bool found;
+};
 
-void TrackCreatedModernWindow(HWND window, LPCWSTR className) {
-    if (!window) {
-        return;
-    }
-
-    const ModernWindowKind kind =
-        className && !IS_INTRESOURCE(className)
-            ? ClassifyModernWindowClassName(className)
-            : ClassifyModernWindow(window);
-    TrackModernWindow(window, kind);
-}
-
-BOOL CALLBACK EnumExistingModernWindow(HWND window, LPARAM) {
-    DWORD processId;
-    GetWindowThreadProcessId(window, &processId);
-    if (processId == GetCurrentProcessId()) {
-        TrackModernWindowIfRelevant(window);
+BOOL CALLBACK FindVisibleModernPopupForThread(HWND window, LPARAM parameter) {
+    auto* data =
+        reinterpret_cast<FindVisibleModernPopupData*>(parameter);
+    if (IsWindowVisible(window) && IsModernPopupWindow(window)) {
+        data->found = true;
+        TrackVisibleModernPopup(window);
+        return FALSE;
     }
 
     return TRUE;
 }
 
-void DiscoverExistingModernWindows() {
-    EnumWindows(EnumExistingModernWindow, 0);
-}
-
-void ClearTrackedModernWindows() {
-    std::lock_guard<std::mutex> guard(
-        g_trackedModernWindowsMutex);
-    g_trackedModernWindows.clear();
-    g_trackedModernWindowCount.store(0, std::memory_order_relaxed);
-    g_trackedModernPopupCount.store(0, std::memory_order_relaxed);
-}
-
-bool IsModernPopupActiveForCurrentThread() {
-    if (g_trackedModernPopupCount.load(
-            std::memory_order_relaxed) == 0) {
-        return false;
-    }
-
-    const DWORD currentThreadId = GetCurrentThreadId();
-    bool popupActive = false;
-    bool taskbarThumbnailActive = false;
-    bool removedWindow = false;
-
+bool IsModernPopupVisibleOnThread(DWORD threadId) {
     {
         std::lock_guard<std::mutex> guard(
-            g_trackedModernWindowsMutex);
-        for (auto iterator = g_trackedModernWindows.begin();
-             iterator != g_trackedModernWindows.end();) {
+            g_visibleModernPopupsMutex);
+        for (auto iterator = g_visibleModernPopups.begin();
+             iterator != g_visibleModernPopups.end();) {
             if (!IsWindow(iterator->first) ||
-                ClassifyModernWindow(iterator->first) !=
-                    iterator->second.kind) {
-                iterator =
-                    g_trackedModernWindows.erase(iterator);
-                removedWindow = true;
+                !IsWindowVisible(iterator->first) ||
+                !IsModernPopupWindow(iterator->first)) {
+                iterator = g_visibleModernPopups.erase(iterator);
                 continue;
             }
 
-            if (IsWindowVisible(iterator->first)) {
-                if (iterator->second.kind ==
-                        ModernWindowKind::TaskbarThumbnail ||
-                    (iterator->second.kind ==
-                         ModernWindowKind::Popup &&
-                     IsTaskbarThumbnailSurface(
-                         iterator->first))) {
-                    taskbarThumbnailActive = true;
-                } else if (
-                    iterator->second.threadId ==
-                        currentThreadId &&
-                    iterator->second.kind ==
-                        ModernWindowKind::Popup) {
-                    popupActive = true;
-                }
+            if (iterator->second.threadId == threadId) {
+                return true;
             }
 
             ++iterator;
         }
+    }
 
-        if (removedWindow) {
-            UpdateTrackedModernWindowCountsLocked();
+    // SHOW normally populates the map before XAML Loaded runs. This fallback
+    // covers an already-visible popup and delayed out-of-context delivery.
+    FindVisibleModernPopupData data{};
+    EnumThreadWindows(
+        threadId, FindVisibleModernPopupForThread,
+        reinterpret_cast<LPARAM>(&data));
+    return data.found;
+}
+
+BOOL CALLBACK DiscoverVisibleModernPopup(HWND window, LPARAM) {
+    DWORD processId;
+    GetWindowThreadProcessId(window, &processId);
+    if (processId == GetCurrentProcessId() &&
+        IsWindowVisible(window)) {
+        TrackVisibleModernPopup(window);
+    }
+
+    return TRUE;
+}
+
+void ClearVisibleModernPopups() {
+    std::lock_guard<std::mutex> guard(g_visibleModernPopupsMutex);
+    g_visibleModernPopups.clear();
+}
+
+bool IsTargetModernAncestorClass(std::wstring_view className) {
+    return className.ends_with(L".MenuFlyoutPresenter") ||
+           className.ends_with(L".ToolTip");
+}
+
+template <typename TextBlock, typename VisualTreeHelper>
+bool IsTargetModernTextElement(const TextBlock& textBlock) {
+    auto current = VisualTreeHelper::GetParent(textBlock);
+    for (unsigned int depth = 0; depth < 64; ++depth) {
+        if (!current) {
+            return false;
+        }
+
+        const auto className = winrt::get_class_name(current);
+        if (IsTargetModernAncestorClass(
+                std::wstring_view(className.c_str(), className.size()))) {
+            return true;
+        }
+
+        current = VisualTreeHelper::GetParent(current);
+    }
+
+    return false;
+}
+
+class ModernTextStateBase {
+public:
+    explicit ModernTextStateBase(DWORD threadId)
+        : m_threadId(threadId) {}
+    virtual ~ModernTextStateBase() = default;
+
+    DWORD ThreadId() const {
+        return m_threadId;
+    }
+
+    virtual void Apply() = 0;
+    virtual void Restore() = 0;
+    virtual void Detach() = 0;
+
+private:
+    DWORD m_threadId;
+};
+
+std::mutex g_modernTextStatesMutex;
+std::vector<std::weak_ptr<ModernTextStateBase>> g_modernTextStates;
+
+void RegisterModernTextState(
+    const std::shared_ptr<ModernTextStateBase>& state) {
+    std::lock_guard<std::mutex> guard(g_modernTextStatesMutex);
+    g_modernTextStates.emplace_back(state);
+}
+
+void RefreshModernTextStates(DWORD threadId, bool apply) {
+    std::vector<std::shared_ptr<ModernTextStateBase>> states;
+    {
+        std::lock_guard<std::mutex> guard(g_modernTextStatesMutex);
+        auto output = g_modernTextStates.begin();
+        for (auto iterator = g_modernTextStates.begin();
+             iterator != g_modernTextStates.end(); ++iterator) {
+            if (auto state = iterator->lock()) {
+                *output++ = *iterator;
+                if (state->ThreadId() == threadId) {
+                    states.push_back(std::move(state));
+                }
+            }
+        }
+        g_modernTextStates.erase(output, g_modernTextStates.end());
+    }
+
+    for (const auto& state : states) {
+        apply ? state->Apply() : state->Restore();
+    }
+}
+
+template <typename TextBlock, typename VisualTreeHelper>
+class ModernTextState final
+    : public ModernTextStateBase,
+      public std::enable_shared_from_this<
+          ModernTextState<TextBlock, VisualTreeHelper>> {
+public:
+    explicit ModernTextState(const TextBlock& textBlock)
+        : ModernTextStateBase(GetCurrentThreadId()),
+          m_textBlock(winrt::make_weak(textBlock)) {}
+
+    void Attach() {
+        auto textBlock = m_textBlock.get();
+        if (!textBlock) {
+            return;
+        }
+
+        const auto self = this->shared_from_this();
+        m_loadedToken = textBlock.Loaded(
+            [self](const auto&, const auto&) {
+                self->Apply();
+            });
+        m_unloadedToken = textBlock.Unloaded(
+            [self](const auto&, const auto&) {
+                self->Restore();
+            });
+        m_attached = true;
+    }
+
+    void Apply() override {
+        if (!g_modernUiText.load(std::memory_order_relaxed) ||
+            !IsModernPopupVisibleOnThread(ThreadId())) {
+            return;
+        }
+
+        try {
+            auto textBlock = m_textBlock.get();
+            if (!textBlock || !textBlock.IsLoaded() ||
+                !IsTargetModernTextElement<TextBlock, VisualTreeHelper>(
+                    textBlock)) {
+                return;
+            }
+
+            if (m_modified) {
+                const auto current = textBlock.Text();
+                if (std::wstring_view(current.c_str(), current.size()) ==
+                    m_spacedText) {
+                    return;
+                }
+
+                // The app updated the text while the popup was open. Use the
+                // new value instead of restoring stale text over it.
+                m_modified = false;
+                m_originalText.clear();
+                m_spacedText.clear();
+            }
+
+            const auto current = textBlock.Text();
+            const std::wstring_view original(current.c_str(),
+                                             current.size());
+            if (!ContainsCjkCodePoint(original)) {
+                return;
+            }
+
+            std::wstring spaced = AddCjkSpacing(original, false);
+            if (spaced.size() == original.size()) {
+                return;
+            }
+
+            m_originalText.assign(original);
+            m_spacedText = std::move(spaced);
+            m_modified = true;
+            textBlock.Text(winrt::hstring(m_spacedText));
+            Wh_Log(L"Applied CJK spacing (modern XAML TextBlock)");
+        } catch (const winrt::hresult_error& error) {
+            Wh_Log(L"Couldn't update modern XAML text: 0x%08X",
+                   error.code());
         }
     }
 
-    if (!popupActive || taskbarThumbnailActive) {
-        return false;
-    }
-
-    return !IsCursorInsideTaskbarThumbnailSurface();
-}
-
-HWND WINAPI CreateWindowExWHook(
-    DWORD exStyle,
-    LPCWSTR className,
-    LPCWSTR windowName,
-    DWORD style,
-    int x,
-    int y,
-    int width,
-    int height,
-    HWND parent,
-    HMENU menu,
-    HINSTANCE instance,
-    PVOID parameter) {
-    HWND window = g_originalCreateWindowExW(
-        exStyle, className, windowName, style, x, y, width, height,
-        parent, menu, instance, parameter);
-    TrackCreatedModernWindow(window, className);
-    return window;
-}
-
-HWND WINAPI CreateWindowInBandHook(
-    DWORD exStyle,
-    LPCWSTR className,
-    LPCWSTR windowName,
-    DWORD style,
-    int x,
-    int y,
-    int width,
-    int height,
-    HWND parent,
-    HMENU menu,
-    HINSTANCE instance,
-    PVOID parameter,
-    DWORD band) {
-    HWND window = g_originalCreateWindowInBand(
-        exStyle, className, windowName, style, x, y, width, height,
-        parent, menu, instance, parameter, band);
-    TrackCreatedModernWindow(window, className);
-    return window;
-}
-
-HWND WINAPI CreateWindowInBandExHook(
-    DWORD exStyle,
-    LPCWSTR className,
-    LPCWSTR windowName,
-    DWORD style,
-    int x,
-    int y,
-    int width,
-    int height,
-    HWND parent,
-    HMENU menu,
-    HINSTANCE instance,
-    PVOID parameter,
-    DWORD band,
-    DWORD typeFlags) {
-    HWND window = g_originalCreateWindowInBandEx(
-        exStyle, className, windowName, style, x, y, width, height,
-        parent, menu, instance, parameter, band, typeFlags);
-    TrackCreatedModernWindow(window, className);
-    return window;
-}
-
-// -------------------------------------------------------------------------
-// DirectWrite text layout used by Windows 11 XAML popups
-// -------------------------------------------------------------------------
-
-using IDWriteFactory_CreateTextLayout_t =
-    HRESULT(STDMETHODCALLTYPE*)(IDWriteFactory* factory,
-                                const WCHAR* text,
-                                UINT32 textLength,
-                                IDWriteTextFormat* textFormat,
-                                FLOAT maxWidth,
-                                FLOAT maxHeight,
-                                IDWriteTextLayout** textLayout);
-
-using IDWriteFactory_CreateGdiCompatibleTextLayout_t =
-    HRESULT(STDMETHODCALLTYPE*)(IDWriteFactory* factory,
-                                const WCHAR* text,
-                                UINT32 textLength,
-                                IDWriteTextFormat* textFormat,
-                                FLOAT layoutWidth,
-                                FLOAT layoutHeight,
-                                FLOAT pixelsPerDip,
-                                const DWRITE_MATRIX* transform,
-                                BOOL useGdiNatural,
-                                IDWriteTextLayout** textLayout);
-
-IDWriteFactory_CreateTextLayout_t g_originalCreateTextLayout;
-IDWriteFactory_CreateGdiCompatibleTextLayout_t
-    g_originalCreateGdiCompatibleTextLayout;
-
-HRESULT CreateTextLayoutWithSpacing(
-    IDWriteFactory_CreateTextLayout_t originalFunction,
-    const wchar_t* source,
-    IDWriteFactory* factory,
-    const WCHAR* text,
-    UINT32 textLength,
-    IDWriteTextFormat* textFormat,
-    FLOAT maxWidth,
-    FLOAT maxHeight,
-    IDWriteTextLayout** textLayout) {
-    if (g_modernUiText.load(std::memory_order_relaxed) && text) {
-        const std::wstring_view original(text, textLength);
-        if (!ContainsCjkCodePoint(original) ||
-            !IsModernPopupActiveForCurrentThread()) {
-            return originalFunction(factory, text, textLength, textFormat,
-                                    maxWidth, maxHeight, textLayout);
+    void Restore() override {
+        if (!m_modified) {
+            return;
         }
 
-        const std::wstring spaced = AddCjkSpacing(original, false);
-        if (spaced.size() != original.size()) {
-            Wh_Log(L"Applied CJK spacing (%s)", source);
-            return originalFunction(
-                factory, spaced.c_str(), static_cast<UINT32>(spaced.size()),
-                textFormat, maxWidth, maxHeight, textLayout);
+        try {
+            auto textBlock = m_textBlock.get();
+            if (textBlock) {
+                const auto current = textBlock.Text();
+                if (std::wstring_view(current.c_str(), current.size()) ==
+                    m_spacedText) {
+                    textBlock.Text(winrt::hstring(m_originalText));
+                }
+            }
+        } catch (const winrt::hresult_error& error) {
+            Wh_Log(L"Couldn't restore modern XAML text: 0x%08X",
+                   error.code());
+        }
+
+        m_modified = false;
+        m_originalText.clear();
+        m_spacedText.clear();
+    }
+
+    void Detach() override {
+        Restore();
+        if (!m_attached) {
+            return;
+        }
+
+        try {
+            auto textBlock = m_textBlock.get();
+            if (textBlock) {
+                textBlock.Loaded(m_loadedToken);
+                textBlock.Unloaded(m_unloadedToken);
+            }
+        } catch (const winrt::hresult_error& error) {
+            Wh_Log(L"Couldn't detach modern XAML events: 0x%08X",
+                   error.code());
+        }
+
+        m_attached = false;
+    }
+
+private:
+    winrt::weak_ref<TextBlock> m_textBlock;
+    winrt::event_token m_loadedToken{};
+    winrt::event_token m_unloadedToken{};
+    bool m_attached = false;
+    bool m_modified = false;
+    std::wstring m_originalText;
+    std::wstring m_spacedText;
+};
+
+class VisualTreeWatcher
+    : public winrt::implements<VisualTreeWatcher,
+                               IVisualTreeServiceCallback2,
+                               winrt::non_agile> {
+public:
+    explicit VisualTreeWatcher(winrt::com_ptr<IUnknown> site)
+        : m_xamlDiagnostics(site.as<IXamlDiagnostics>()) {
+        AddRef();
+        HANDLE thread = CreateThread(
+            nullptr, 0,
+            [](LPVOID parameter) -> DWORD {
+                auto* watcher =
+                    static_cast<VisualTreeWatcher*>(parameter);
+                const HRESULT result =
+                    watcher->m_xamlDiagnostics
+                        .as<IVisualTreeService3>()
+                        ->AdviseVisualTreeChange(watcher);
+                if (FAILED(result)) {
+                    Wh_Log(L"AdviseVisualTreeChange failed: 0x%08X",
+                           result);
+                }
+                watcher->Release();
+                return 0;
+            },
+            this, 0, nullptr);
+        if (thread) {
+            CloseHandle(thread);
+        } else {
+            Release();
+            Wh_Log(L"Couldn't create XAML watcher thread");
         }
     }
 
-    return originalFunction(factory, text, textLength, textFormat, maxWidth,
-                            maxHeight, textLayout);
-}
-
-HRESULT CreateGdiCompatibleTextLayoutWithSpacing(
-    IDWriteFactory_CreateGdiCompatibleTextLayout_t originalFunction,
-    const wchar_t* source,
-    IDWriteFactory* factory,
-    const WCHAR* text,
-    UINT32 textLength,
-    IDWriteTextFormat* textFormat,
-    FLOAT layoutWidth,
-    FLOAT layoutHeight,
-    FLOAT pixelsPerDip,
-    const DWRITE_MATRIX* transform,
-    BOOL useGdiNatural,
-    IDWriteTextLayout** textLayout) {
-    if (g_modernUiText.load(std::memory_order_relaxed) && text) {
-        const std::wstring_view original(text, textLength);
-        if (!ContainsCjkCodePoint(original) ||
-            !IsModernPopupActiveForCurrentThread()) {
-            return originalFunction(
-                factory, text, textLength, textFormat, layoutWidth,
-                layoutHeight, pixelsPerDip, transform, useGdiNatural,
-                textLayout);
+    void UnadviseVisualTreeChange() {
+        const HRESULT result =
+            m_xamlDiagnostics.as<IVisualTreeService3>()
+                ->UnadviseVisualTreeChange(this);
+        if (FAILED(result)) {
+            Wh_Log(L"UnadviseVisualTreeChange failed: 0x%08X",
+                   result);
         }
 
-        const std::wstring spaced = AddCjkSpacing(original, false);
-        if (spaced.size() != original.size()) {
-            Wh_Log(L"Applied CJK spacing (%s)", source);
-            return originalFunction(
-                factory, spaced.c_str(), static_cast<UINT32>(spaced.size()),
-                textFormat, layoutWidth, layoutHeight, pixelsPerDip, transform,
-                useGdiNatural, textLayout);
+        for (auto& [handle, state] : m_textStates) {
+            state->Detach();
+        }
+        m_textStates.clear();
+    }
+
+private:
+    wf::IInspectable FromHandle(InstanceHandle handle) {
+        wf::IInspectable object;
+        winrt::check_hresult(
+            m_xamlDiagnostics->GetIInspectableFromHandle(
+                handle,
+                reinterpret_cast<::IInspectable**>(
+                    winrt::put_abi(object))));
+        return object;
+    }
+
+    template <typename TextBlock, typename VisualTreeHelper>
+    void RegisterTextBlock(InstanceHandle handle,
+                           const TextBlock& textBlock) {
+        if (!IsTargetModernTextElement<TextBlock, VisualTreeHelper>(
+                textBlock)) {
+            return;
+        }
+
+        auto state = std::make_shared<
+            ModernTextState<TextBlock, VisualTreeHelper>>(textBlock);
+        state->Attach();
+        RegisterModernTextState(state);
+        state->Apply();
+
+        if (auto iterator = m_textStates.find(handle);
+            iterator != m_textStates.end()) {
+            iterator->second->Detach();
+            iterator->second = std::move(state);
+        } else {
+            m_textStates.emplace(handle, std::move(state));
         }
     }
 
-    return originalFunction(factory, text, textLength, textFormat, layoutWidth,
-                            layoutHeight, pixelsPerDip, transform,
-                            useGdiNatural, textLayout);
+    HRESULT STDMETHODCALLTYPE OnVisualTreeChange(
+        ParentChildRelation,
+        VisualElement element,
+        VisualMutationType mutationType) override try {
+        if (mutationType == Add &&
+            g_modernUiText.load(std::memory_order_relaxed)) {
+            const std::wstring_view type(
+                element.Type ? element.Type : L"");
+            if (!type.ends_with(L".TextBlock")) {
+                return S_OK;
+            }
+
+            const auto inspectable = FromHandle(element.Handle);
+            if (auto textBlock =
+                    inspectable.try_as<
+                        wux::Controls::TextBlock>()) {
+                RegisterTextBlock<
+                    wux::Controls::TextBlock,
+                    wux::Media::VisualTreeHelper>(
+                        element.Handle, textBlock);
+            } else if (auto textBlock =
+                           inspectable.try_as<
+                               mux::Controls::TextBlock>()) {
+                RegisterTextBlock<
+                    mux::Controls::TextBlock,
+                    mux::Media::VisualTreeHelper>(
+                        element.Handle, textBlock);
+            }
+        } else if (mutationType == Remove) {
+            if (auto iterator = m_textStates.find(element.Handle);
+                iterator != m_textStates.end()) {
+                iterator->second->Detach();
+                m_textStates.erase(iterator);
+            }
+        }
+
+        return S_OK;
+    } catch (...) {
+        Wh_Log(L"XAML visual-tree callback failed: 0x%08X",
+               winrt::to_hresult());
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE OnElementStateChanged(
+        InstanceHandle,
+        VisualElementState,
+        LPCWSTR) noexcept override {
+        return S_OK;
+    }
+
+    winrt::com_ptr<IXamlDiagnostics> m_xamlDiagnostics;
+    std::unordered_map<
+        InstanceHandle,
+        std::shared_ptr<ModernTextStateBase>> m_textStates;
+};
+
+std::mutex g_visualTreeWatchersMutex;
+std::vector<winrt::com_ptr<VisualTreeWatcher>>
+    g_visualTreeWatchers;
+std::atomic_bool g_stoppingModernUi{false};
+
+HMODULE GetCurrentModuleHandle() {
+    HMODULE module;
+    if (!GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            reinterpret_cast<LPCWSTR>(&GetCurrentModuleHandle),
+            &module)) {
+        return nullptr;
+    }
+
+    return module;
 }
 
-HRESULT STDMETHODCALLTYPE CreateTextLayoutHook(
-    IDWriteFactory* factory,
-    const WCHAR* text,
-    UINT32 textLength,
-    IDWriteTextFormat* textFormat,
-    FLOAT maxWidth,
-    FLOAT maxHeight,
-    IDWriteTextLayout** textLayout) {
-    return CreateTextLayoutWithSpacing(
-        g_originalCreateTextLayout, L"modern/DirectWrite/CreateTextLayout",
-        factory, text, textLength, textFormat, maxWidth, maxHeight,
-        textLayout);
+class WindhawkTap
+    : public winrt::implements<WindhawkTap,
+                               IObjectWithSite,
+                               winrt::non_agile> {
+public:
+    HRESULT STDMETHODCALLTYPE SetSite(IUnknown* site) override try {
+        m_site.copy_from(site);
+        if (!site || g_stoppingModernUi.load(
+                         std::memory_order_relaxed)) {
+            return S_OK;
+        }
+
+        // Balance the reference added when XAML Diagnostics loads this module.
+        if (HMODULE module = GetCurrentModuleHandle()) {
+            FreeLibrary(module);
+        }
+
+        auto watcher =
+            winrt::make_self<VisualTreeWatcher>(m_site);
+        {
+            std::lock_guard<std::mutex> guard(
+                g_visualTreeWatchersMutex);
+            g_visualTreeWatchers.push_back(watcher);
+        }
+        m_watcher = std::move(watcher);
+        return S_OK;
+    } catch (...) {
+        const HRESULT result = winrt::to_hresult();
+        Wh_Log(L"Couldn't create XAML watcher: 0x%08X", result);
+        return result;
+    }
+
+    HRESULT STDMETHODCALLTYPE GetSite(
+        REFIID interfaceId,
+        void** object) noexcept override {
+        return m_site.as(interfaceId, object);
+    }
+
+private:
+    winrt::com_ptr<IUnknown> m_site;
+    winrt::com_ptr<VisualTreeWatcher> m_watcher;
+};
+
+template <typename Class>
+struct SimpleFactory
+    : winrt::implements<SimpleFactory<Class>,
+                        IClassFactory,
+                        winrt::non_agile> {
+    HRESULT STDMETHODCALLTYPE CreateInstance(
+        IUnknown* outer,
+        REFIID interfaceId,
+        void** object) override try {
+        if (outer) {
+            return CLASS_E_NOAGGREGATION;
+        }
+
+        *object = nullptr;
+        return winrt::make<Class>().as(interfaceId, object);
+    } catch (...) {
+        return winrt::to_hresult();
+    }
+
+    HRESULT STDMETHODCALLTYPE LockServer(BOOL) noexcept override {
+        return S_OK;
+    }
+};
+
+// {3245D18D-2C18-4EA3-9A10-9C5A2B553976}
+constexpr CLSID CLSID_CjkSpacerTap = {
+    0x3245d18d,
+    0x2c18,
+    0x4ea3,
+    {0x9a, 0x10, 0x9c, 0x5a, 0x2b, 0x55, 0x39, 0x76}};
+
+}  // namespace
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdll-attribute-on-redeclaration"
+
+__declspec(dllexport) _Use_decl_annotations_
+STDAPI DllGetClassObject(REFCLSID classId,
+                         REFIID interfaceId,
+                         void** object) try {
+    if (classId != CLSID_CjkSpacerTap) {
+        return CLASS_E_CLASSNOTAVAILABLE;
+    }
+
+    *object = nullptr;
+    return winrt::make<SimpleFactory<WindhawkTap>>().as(
+        interfaceId, object);
+} catch (...) {
+    return winrt::to_hresult();
 }
 
-HRESULT STDMETHODCALLTYPE CreateGdiCompatibleTextLayoutHook(
-    IDWriteFactory* factory,
-    const WCHAR* text,
-    UINT32 textLength,
-    IDWriteTextFormat* textFormat,
-    FLOAT layoutWidth,
-    FLOAT layoutHeight,
-    FLOAT pixelsPerDip,
-    const DWRITE_MATRIX* transform,
-    BOOL useGdiNatural,
-    IDWriteTextLayout** textLayout) {
-    return CreateGdiCompatibleTextLayoutWithSpacing(
-        g_originalCreateGdiCompatibleTextLayout,
-        L"modern/DirectWrite/CreateGdiCompatibleTextLayout", factory, text,
-        textLength, textFormat, layoutWidth, layoutHeight, pixelsPerDip,
-        transform, useGdiNatural, textLayout);
+__declspec(dllexport) _Use_decl_annotations_
+STDAPI DllCanUnloadNow() {
+    return winrt::get_module_lock() ? S_FALSE : S_OK;
 }
 
-bool HookDirectWrite() {
-    HMODULE dwrite =
-        LoadLibraryExW(L"dwrite.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-    if (!dwrite) {
-        Wh_Log(L"Couldn't load dwrite.dll");
-        return false;
+#pragma clang diagnostic pop
+
+namespace {
+
+using InitializeXamlDiagnosticsEx_t =
+    decltype(&InitializeXamlDiagnosticsEx);
+
+std::mutex g_xamlDiagnosticsInitializationMutex;
+bool g_windowsUiXamlDiagnosticsConnected;
+bool g_microsoftUiXamlDiagnosticsConnected;
+
+HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
+                              LPCWSTR connectionPrefix) {
+    const auto initialize =
+        reinterpret_cast<InitializeXamlDiagnosticsEx_t>(
+            GetProcAddress(xamlModule,
+                           "InitializeXamlDiagnosticsEx"));
+    if (!initialize) {
+        return HRESULT_FROM_WIN32(GetLastError());
     }
 
-    using DWriteCreateFactory_t =
-        HRESULT(WINAPI*)(DWRITE_FACTORY_TYPE, REFIID, IUnknown**);
-    const auto createFactory = reinterpret_cast<DWriteCreateFactory_t>(
-        GetProcAddress(dwrite, "DWriteCreateFactory"));
-    if (!createFactory) {
-        Wh_Log(L"Couldn't find DWriteCreateFactory");
-        return false;
+    const HMODULE module = GetCurrentModuleHandle();
+    if (!module) {
+        return HRESULT_FROM_WIN32(GetLastError());
     }
 
-    IDWriteFactory* factory = nullptr;
-    const HRESULT result =
-        createFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory),
-                      reinterpret_cast<IUnknown**>(&factory));
-    if (FAILED(result) || !factory) {
-        Wh_Log(L"DirectWrite factory creation failed: 0x%08X", result);
-        return false;
+    wchar_t modulePath[MAX_PATH];
+    const DWORD pathLength =
+        GetModuleFileNameW(module, modulePath,
+                           ARRAYSIZE(modulePath));
+    if (!pathLength || pathLength == ARRAYSIZE(modulePath)) {
+        return HRESULT_FROM_WIN32(GetLastError());
     }
 
-    void** vtable = *reinterpret_cast<void***>(factory);
-    const bool textLayoutHooked = Wh_SetFunctionHook(
-        vtable[18], reinterpret_cast<void*>(CreateTextLayoutHook),
-        reinterpret_cast<void**>(&g_originalCreateTextLayout));
-    const bool gdiLayoutHooked = Wh_SetFunctionHook(
-        vtable[19],
-        reinterpret_cast<void*>(CreateGdiCompatibleTextLayoutHook),
-        reinterpret_cast<void**>(
-            &g_originalCreateGdiCompatibleTextLayout));
-
-    factory->Release();
-
-    if (!textLayoutHooked || !gdiLayoutHooked) {
-        Wh_Log(L"Couldn't install one or more DirectWrite hooks");
+    HRESULT result = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+    for (int index = 1; index <= 10000; ++index) {
+        wchar_t connectionName[256];
+        _snwprintf_s(connectionName, _TRUNCATE, L"%s%d",
+                     connectionPrefix, index);
+        result = initialize(
+            connectionName, GetCurrentProcessId(), L"",
+            modulePath, CLSID_CjkSpacerTap, nullptr);
+        if (result != HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+            break;
+        }
     }
 
-    return textLayoutHooked || gdiLayoutHooked;
+    return result;
+}
+
+void EnsureModernXamlDiagnostics() {
+    if (g_stoppingModernUi.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> guard(
+        g_xamlDiagnosticsInitializationMutex);
+
+    if (!g_windowsUiXamlDiagnosticsConnected) {
+        if (HMODULE module =
+                GetModuleHandleW(L"Windows.UI.Xaml.dll")) {
+            const HRESULT result = InjectXamlDiagnostics(
+                module, L"VisualDiagConnection");
+            if (SUCCEEDED(result)) {
+                g_windowsUiXamlDiagnosticsConnected = true;
+                Wh_Log(L"Connected to Windows.UI.Xaml diagnostics");
+            } else if (result !=
+                       HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+                Wh_Log(L"Windows.UI.Xaml diagnostics failed: "
+                       L"0x%08X", result);
+            }
+        }
+    }
+
+    if (!g_microsoftUiXamlDiagnosticsConnected) {
+        if (HMODULE module = GetModuleHandleW(
+                L"Microsoft.Internal.FrameworkUdk.dll")) {
+            const HRESULT result = InjectXamlDiagnostics(
+                module, L"WinUIVisualDiagConnection");
+            if (SUCCEEDED(result)) {
+                g_microsoftUiXamlDiagnosticsConnected = true;
+                Wh_Log(L"Connected to Microsoft.UI.Xaml diagnostics");
+            } else if (result !=
+                       HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+                Wh_Log(L"Microsoft.UI.Xaml diagnostics failed: "
+                       L"0x%08X", result);
+            }
+        }
+    }
+}
+
+void CALLBACK ModernPopupWinEventProc(
+    HWINEVENTHOOK,
+    DWORD event,
+    HWND window,
+    LONG objectId,
+    LONG childId,
+    DWORD,
+    DWORD) {
+    if (!window || objectId != OBJID_WINDOW ||
+        childId != CHILDID_SELF ||
+        !g_modernUiText.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    DWORD processId;
+    const DWORD threadId =
+        GetWindowThreadProcessId(window, &processId);
+    if (!threadId || processId != GetCurrentProcessId()) {
+        return;
+    }
+
+    if (event == EVENT_OBJECT_SHOW) {
+        if (!TrackVisibleModernPopup(window)) {
+            return;
+        }
+
+        EnsureModernXamlDiagnostics();
+        if (GetCurrentThreadId() == threadId) {
+            RefreshModernTextStates(threadId, true);
+        }
+    } else if (event == EVENT_OBJECT_HIDE ||
+               event == EVENT_OBJECT_DESTROY) {
+        bool wasTracked;
+        {
+            std::lock_guard<std::mutex> guard(
+                g_visibleModernPopupsMutex);
+            wasTracked =
+                g_visibleModernPopups.erase(window) != 0;
+        }
+
+        if (wasTracked && GetCurrentThreadId() == threadId) {
+            // Restore on the UI thread which generated the in-context event.
+            // Loaded applies spacing if a reusable popup is shown again.
+            RefreshModernTextStates(threadId, false);
+        }
+    }
+}
+
+bool InitializeModernUi() {
+    g_stoppingModernUi.store(false, std::memory_order_relaxed);
+
+    g_modernPopupWinEventHook = SetWinEventHook(
+        EVENT_OBJECT_DESTROY, EVENT_OBJECT_HIDE,
+        GetCurrentModuleHandle(), ModernPopupWinEventProc,
+        GetCurrentProcessId(), 0, WINEVENT_INCONTEXT);
+    if (!g_modernPopupWinEventHook) {
+        Wh_Log(L"In-context popup event hook failed, trying "
+               L"out-of-context");
+        g_modernPopupWinEventHook = SetWinEventHook(
+            EVENT_OBJECT_DESTROY, EVENT_OBJECT_HIDE, nullptr,
+            ModernPopupWinEventProc, GetCurrentProcessId(), 0,
+            WINEVENT_OUTOFCONTEXT);
+    }
+
+    EnumWindows(DiscoverVisibleModernPopup, 0);
+    EnsureModernXamlDiagnostics();
+    return g_modernPopupWinEventHook != nullptr;
+}
+
+void UninitializeModernUi() {
+    g_stoppingModernUi.store(true, std::memory_order_relaxed);
+
+    if (g_modernPopupWinEventHook) {
+        UnhookWinEvent(g_modernPopupWinEventHook);
+        g_modernPopupWinEventHook = nullptr;
+    }
+
+    std::vector<winrt::com_ptr<VisualTreeWatcher>> watchers;
+    {
+        std::lock_guard<std::mutex> guard(
+            g_visualTreeWatchersMutex);
+        watchers.swap(g_visualTreeWatchers);
+    }
+    for (const auto& watcher : watchers) {
+        watcher->UnadviseVisualTreeChange();
+    }
+
+    {
+        std::lock_guard<std::mutex> guard(g_modernTextStatesMutex);
+        g_modernTextStates.clear();
+    }
+    ClearVisibleModernPopups();
 }
 
 template <typename Function>
@@ -1838,41 +2116,7 @@ BOOL Wh_ModInit() {
     }
 
     if (modernUiTextEnabled) {
-        installedAnyHook |= InstallHook(
-            CreateWindowExW, CreateWindowExWHook,
-            &g_originalCreateWindowExW, L"CreateWindowExW");
-
-        HMODULE user32Module =
-            GetModuleHandleW(L"user32.dll");
-        if (user32Module) {
-            const auto createWindowInBand =
-                reinterpret_cast<CreateWindowInBand_t>(
-                    GetProcAddress(user32Module, "CreateWindowInBand"));
-            if (createWindowInBand) {
-                installedAnyHook |= InstallHook(
-                    createWindowInBand, CreateWindowInBandHook,
-                    &g_originalCreateWindowInBand,
-                    L"CreateWindowInBand");
-            } else {
-                Wh_Log(L"Couldn't find CreateWindowInBand");
-            }
-
-            const auto createWindowInBandEx =
-                reinterpret_cast<CreateWindowInBandEx_t>(
-                    GetProcAddress(user32Module, "CreateWindowInBandEx"));
-            if (createWindowInBandEx) {
-                installedAnyHook |= InstallHook(
-                    createWindowInBandEx, CreateWindowInBandExHook,
-                    &g_originalCreateWindowInBandEx,
-                    L"CreateWindowInBandEx");
-            } else {
-                Wh_Log(L"Couldn't find CreateWindowInBandEx");
-            }
-        } else {
-            Wh_Log(L"Couldn't find user32.dll");
-        }
-
-        installedAnyHook |= HookDirectWrite();
+        installedAnyHook |= InitializeModernUi();
     }
 
     Wh_Log(L"CJK Spacer initialized (classicMenus=%d, "
@@ -1888,15 +2132,14 @@ void Wh_ModAfterInit() {
         DiscoverExistingClassicTooltipThemes();
     }
 
-    if (g_modernUiText.load(std::memory_order_relaxed)) {
-        DiscoverExistingModernWindows();
-    }
 }
 
 void Wh_ModUninit() {
     RestoreRewrittenMenuItems();
     ClearTrackedClassicTooltipThemes();
-    ClearTrackedModernWindows();
+    if (g_modernUiText.load(std::memory_order_relaxed)) {
+        UninitializeModernUi();
+    }
     Wh_Log(L"CJK Spacer uninitialized");
 }
 

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -70,8 +70,10 @@ hosted by Explorer. XAML Diagnostics allows one consumer per XAML connection,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
 initializing. Connection attempts are scheduled outside the Windows loader
-path so XAML modules that load later are handled without doing COM activation
-under the loader lock.
+path; a single-flight worker retains requests that arrive while it is running,
+tracks the Windows.UI.Xaml and Microsoft.UI.Xaml connections independently,
+and retries only the connection that was lost. The worker pins the mod image
+until `FreeLibraryAndExitThread`, so it cannot execute unloaded mod code.
 
 The mod is injected only into `explorer.exe`. Start, Search, and some shell
 flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
@@ -1039,7 +1041,7 @@ HTHEME WINAPI OpenThemeDataForDpiHook(HWND window,
 }
 
 HRESULT WINAPI CloseThemeDataHook(HTHEME theme) {
-    if (g_classicTooltipThemeCount.load(std::memory_order_relaxed) != 0) {
+    if (IsTrackedClassicTooltipTheme(theme)) {
         UntrackClassicTooltipTheme(theme);
     }
     return g_originalCloseThemeData(theme);
@@ -1462,6 +1464,20 @@ void CleanupModernTextStatesForCurrentThread() {
     UnregisterModernTextStateThread();
 }
 
+HMODULE AcquireCurrentModuleReference();
+void RequestModernXamlDiagnosticsInitialization();
+
+enum class XamlDiagnosticsFlavor {
+    None,
+    Windows,
+    Microsoft,
+};
+
+extern std::atomic_bool g_windowsUiXamlDiagnosticsConnected;
+extern std::atomic_bool g_microsoftUiXamlDiagnosticsConnected;
+extern std::atomic_bool g_stoppingModernUi;
+extern thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics;
+
 class VisualTreeWatcher
     : public winrt::implements<VisualTreeWatcher,
                                IVisualTreeServiceCallback2,
@@ -1469,6 +1485,11 @@ class VisualTreeWatcher
 public:
     explicit VisualTreeWatcher(winrt::com_ptr<IUnknown> site)
         : m_xamlDiagnostics(site.as<IXamlDiagnostics>()) {
+        m_moduleReference = AcquireCurrentModuleReference();
+        if (!m_moduleReference) {
+            winrt::throw_hresult(HRESULT_FROM_WIN32(GetLastError()));
+        }
+
         AddRef();
         HANDLE thread = CreateThread(
             nullptr, 0,
@@ -1490,15 +1511,20 @@ public:
                         watcher->UnadviseVisualTreeChange();
                     }
                 }
+                HMODULE module = watcher->m_moduleReference;
                 watcher->Release();
-                return 0;
+                FreeLibraryAndExitThread(module, 0);
             },
             this, 0, nullptr);
         if (thread) {
             CloseHandle(thread);
         } else {
+            const DWORD error = GetLastError();
             Release();
+            FreeLibrary(m_moduleReference);
+            m_moduleReference = nullptr;
             Wh_Log(L"Couldn't create XAML watcher thread");
+            winrt::throw_hresult(HRESULT_FROM_WIN32(error));
         }
     }
 
@@ -1567,7 +1593,8 @@ private:
         auto& states = threadState.states;
 
         if (mutationType == Add &&
-            g_modernUiText.load(std::memory_order_relaxed)) {
+            g_modernUiText.load(std::memory_order_relaxed) &&
+            !g_stoppingModernUi.load(std::memory_order_relaxed)) {
             const std::wstring_view type(
                 element.Type ? element.Type : L"");
             const bool isMenuSource = IsModernMenuSourceType(type);
@@ -1635,6 +1662,7 @@ private:
     }
 
     winrt::com_ptr<IXamlDiagnostics> m_xamlDiagnostics;
+    HMODULE m_moduleReference = nullptr;
     std::atomic_bool m_advised{false};
     std::atomic_bool m_unadviseRequested{false};
 };
@@ -1701,7 +1729,29 @@ public:
 
         m_site.copy_from(site);
         if (!site) {
+            const XamlDiagnosticsFlavor disconnectedFlavor =
+                m_flavor;
+            m_flavor = XamlDiagnosticsFlavor::None;
+            if (disconnectedFlavor ==
+                XamlDiagnosticsFlavor::Windows) {
+                g_windowsUiXamlDiagnosticsConnected.store(
+                    false, std::memory_order_release);
+            } else if (disconnectedFlavor ==
+                       XamlDiagnosticsFlavor::Microsoft) {
+                g_microsoftUiXamlDiagnosticsConnected.store(
+                    false, std::memory_order_release);
+            }
+            if (disconnectedFlavor != XamlDiagnosticsFlavor::None &&
+                !g_stoppingModernUi.load(
+                    std::memory_order_relaxed)) {
+                RequestModernXamlDiagnosticsInitialization();
+            }
             return S_OK;
+        }
+
+        if (g_connectingXamlDiagnostics !=
+            XamlDiagnosticsFlavor::None) {
+            m_flavor = g_connectingXamlDiagnostics;
         }
 
         // Balance the reference added when XAML Diagnostics loads this module.
@@ -1741,6 +1791,7 @@ public:
 private:
     winrt::com_ptr<IUnknown> m_site;
     winrt::com_ptr<VisualTreeWatcher> m_watcher;
+    XamlDiagnosticsFlavor m_flavor = XamlDiagnosticsFlavor::None;
 };
 
 template <typename Class>
@@ -1807,13 +1858,17 @@ using InitializeXamlDiagnosticsEx_t =
     decltype(&InitializeXamlDiagnosticsEx);
 
 std::mutex g_xamlDiagnosticsInitializationMutex;
-bool g_windowsUiXamlDiagnosticsConnected;
-bool g_microsoftUiXamlDiagnosticsConnected;
+std::atomic_bool g_windowsUiXamlDiagnosticsConnected{false};
+std::atomic_bool g_microsoftUiXamlDiagnosticsConnected{false};
 std::atomic_bool g_xamlDiagnosticsWorkerRunning{false};
+std::atomic_bool g_xamlDiagnosticsRequestPending{false};
 thread_local bool g_loadingXamlDiagnostics;
+thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics =
+    XamlDiagnosticsFlavor::None;
 
 HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
-                              LPCWSTR connectionPrefix) {
+                              LPCWSTR connectionPrefix,
+                              XamlDiagnosticsFlavor flavor) {
     const auto initialize =
         reinterpret_cast<InitializeXamlDiagnosticsEx_t>(
             GetProcAddress(xamlModule,
@@ -1844,9 +1899,13 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
         wchar_t connectionName[256];
         _snwprintf_s(connectionName, _TRUNCATE, L"%s%d",
                      connectionPrefix, index);
+        const XamlDiagnosticsFlavor previousFlavor =
+            g_connectingXamlDiagnostics;
+        g_connectingXamlDiagnostics = flavor;
         result = initialize(
             connectionName, GetCurrentProcessId(), L"",
             modulePath, CLSID_CjkSpacerTap, nullptr);
+        g_connectingXamlDiagnostics = previousFlavor;
         if (result != HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
             break;
         }
@@ -1879,19 +1938,22 @@ void EnsureModernXamlDiagnostics() {
         return;
     }
 
-    if (!g_windowsUiXamlDiagnosticsConnected) {
+    if (!g_windowsUiXamlDiagnosticsConnected.load(
+            std::memory_order_acquire)) {
         if (HMODULE module =
                 GetModuleHandleW(L"Windows.UI.Xaml.dll")) {
             const uint64_t watcherGeneration =
                 g_visualTreeWatcherGeneration.load(
                     std::memory_order_acquire);
             const HRESULT result = InjectXamlDiagnostics(
-                module, L"VisualDiagConnection");
+                module, L"VisualDiagConnection",
+                XamlDiagnosticsFlavor::Windows);
             if (SUCCEEDED(result) &&
                 g_visualTreeWatcherGeneration.load(
                     std::memory_order_acquire) >
                     watcherGeneration) {
-                g_windowsUiXamlDiagnosticsConnected = true;
+                g_windowsUiXamlDiagnosticsConnected.store(
+                    true, std::memory_order_release);
                 Wh_Log(L"Connected to Windows.UI.Xaml diagnostics");
             } else if (SUCCEEDED(result)) {
                 Wh_Log(L"Windows.UI.Xaml diagnostics returned success "
@@ -1907,19 +1969,22 @@ void EnsureModernXamlDiagnostics() {
         }
     }
 
-    if (!g_microsoftUiXamlDiagnosticsConnected) {
+    if (!g_microsoftUiXamlDiagnosticsConnected.load(
+            std::memory_order_acquire)) {
         if (HMODULE module = GetModuleHandleW(
                 L"Microsoft.Internal.FrameworkUdk.dll")) {
             const uint64_t watcherGeneration =
                 g_visualTreeWatcherGeneration.load(
                     std::memory_order_acquire);
             const HRESULT result = InjectXamlDiagnostics(
-                module, L"WinUIVisualDiagConnection");
+                module, L"WinUIVisualDiagConnection",
+                XamlDiagnosticsFlavor::Microsoft);
             if (SUCCEEDED(result) &&
                 g_visualTreeWatcherGeneration.load(
                     std::memory_order_acquire) >
                     watcherGeneration) {
-                g_microsoftUiXamlDiagnosticsConnected = true;
+                g_microsoftUiXamlDiagnosticsConnected.store(
+                    true, std::memory_order_release);
                 Wh_Log(L"Connected to Microsoft.UI.Xaml diagnostics");
             } else if (SUCCEEDED(result)) {
                 Wh_Log(L"Microsoft.UI.Xaml diagnostics returned success "
@@ -1940,6 +2005,9 @@ void RequestModernXamlDiagnosticsInitialization() {
     if (g_stoppingModernUi.load(std::memory_order_relaxed)) {
         return;
     }
+
+    g_xamlDiagnosticsRequestPending.store(
+        true, std::memory_order_release);
 
     bool expected = false;
     if (!g_xamlDiagnosticsWorkerRunning.compare_exchange_strong(
@@ -1963,13 +2031,24 @@ void RequestModernXamlDiagnosticsInitialization() {
             HMODULE module = static_cast<HMODULE>(parameter);
             const HRESULT initializeResult =
                 CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-            EnsureModernXamlDiagnostics();
+            while (!g_stoppingModernUi.load(
+                       std::memory_order_relaxed) &&
+                   g_xamlDiagnosticsRequestPending.exchange(
+                       false, std::memory_order_acq_rel)) {
+                EnsureModernXamlDiagnostics();
+            }
             if (SUCCEEDED(initializeResult)) {
                 CoUninitialize();
             }
 
             g_xamlDiagnosticsWorkerRunning.store(
                 false, std::memory_order_release);
+            if (g_xamlDiagnosticsRequestPending.load(
+                    std::memory_order_acquire) &&
+                !g_stoppingModernUi.load(
+                    std::memory_order_relaxed)) {
+                RequestModernXamlDiagnosticsInitialization();
+            }
             FreeLibraryAndExitThread(module, 0);
         },
         module, 0, nullptr);
@@ -2296,7 +2375,7 @@ BOOL Wh_ModInit() {
 
     if (!classicMenusEnabled && !classicTooltipsEnabled &&
         !modernUiTextEnabled) {
-        Wh_Log(L"CJK Spacer has no enabled UI targets");
+        Wh_Log(L"No enabled UI targets");
         return FALSE;
     }
 
@@ -2350,7 +2429,7 @@ BOOL Wh_ModInit() {
         }
     }
 
-    Wh_Log(L"CJK Spacer initialized (classicMenus=%d, "
+    Wh_Log(L"Initialized (classicMenus=%d, "
            L"classicTooltips=%d, modern=%d, unicode=%d)",
            g_classicMenus.load(), g_classicTooltips.load(),
            g_modernUiText.load(),
@@ -2378,7 +2457,7 @@ void Wh_ModUninit() {
     if (g_modernUiText.load(std::memory_order_relaxed)) {
         UninitializeModernUi();
     }
-    Wh_Log(L"CJK Spacer uninitialized");
+    Wh_Log(L"Uninitialized");
 }
 
 BOOL Wh_ModSettingsChanged(BOOL* reload) {

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips; modern XAML UI is opt-in and best-effort because it may conflict with other XAML Diagnostics mods
-// @version         0.1.25
+// @version         0.1.26
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -69,8 +69,11 @@ excluded.
   Explorer itself hosts.
   Context menus shown by third-party notification-area icon processes are
   outside the injected `explorer.exe` process and aren't covered.
-  Classic menu bars and window system menus do not use these popup APIs and
-  aren't covered.
+  Construction-time hooks also see menu-bar dropdowns created with
+  `CreatePopupMenu`, even when user32 displays them without `TrackPopupMenu*`.
+  Such pending changes are restored when the menu is destroyed, the mod
+  unloads, or the record expires during later popup activity. Window system
+  menus that aren't built through the hooked popup APIs remain outside scope.
 - Classic Win32 tooltips, including legacy notification-area icon tooltips, are
   rewritten only through theme handles opened for the `TOOLTIP` class, covering
   both text measurement and drawing without touching unrelated GDI text.
@@ -117,7 +120,8 @@ The modern path temporarily changes target source values on their XAML UI
 threads and restores them when the source leaves the visual tree or the mod
 unloads. The classic path updates
 strings stored in active `HMENU` objects, so menu text read through
-accessibility APIs also contains the inserted spaces while the popup is open.
+accessibility APIs also contains the inserted spaces until the corresponding
+record is restored.
 Other menu-cleanup mods that match items by their displayed text, such as
 Remove Context Menu Items, may therefore need rules that account for the
 temporary spaces while the popup is open.
@@ -138,7 +142,7 @@ also need compatible DC targets to keep sizing consistent; disable
 /*
 - classicMenus: true
   $name: Classic context menus
-  $description: Process classic Win32 popup-menu text during construction and display; temporary live-menu changes can affect other text-matching menu mods until the popup closes.
+  $description: Process classic Win32 popup-menu text during construction and display; temporary live-menu changes can affect other text-matching menu mods until restoration.
 - classicTooltips: true
   $name: Classic Win32 tooltips
   $description: Process text in legacy tooltips such as notification-area icon tooltips.
@@ -166,7 +170,6 @@ also need compatible DC targets to keep sizing consistent; disable
 #include <functional>
 #include <memory>
 #include <mutex>
-#include <new>
 #include <optional>
 #include <shared_mutex>
 #include <string>
@@ -479,6 +482,7 @@ struct RewrittenMenuItem {
     HMENU rootMenu;
     HMENU menu;
     UINT index;
+    ULONGLONG recordedAt;
     std::wstring original;
     std::wstring spaced;
 };
@@ -488,6 +492,7 @@ constexpr UINT kUnknownMenuItemIndex = static_cast<UINT>(-1);
 std::mutex g_rewrittenMenuItemsMutex;
 std::vector<RewrittenMenuItem> g_rewrittenMenuItems;
 std::atomic_uint g_rewrittenMenuItemCount{0};
+std::atomic<ULONGLONG> g_nextRewrittenMenuCleanupTick{0};
 thread_local unsigned int g_classicPopupMenuDepth = 0;
 thread_local HMENU g_classicPopupRootMenu = nullptr;
 thread_local bool g_restoringClassicMenuText = false;
@@ -497,6 +502,10 @@ std::unordered_set<HMENU> g_createdClassicPopupMenus;
 std::atomic_uint g_createdClassicPopupMenuCount{0};
 
 constexpr unsigned int kMaxMenuDepth = 16;
+constexpr size_t kMaxPendingRewrittenMenuItems = 1024;
+constexpr size_t kPendingRewrittenMenuTarget = 768;
+constexpr ULONGLONG kPendingRewrittenMenuLifetimeMs = 30000;
+constexpr ULONGLONG kRewrittenMenuCleanupIntervalMs = 30000;
 
 class ScopedBoolValue final {
 public:
@@ -562,7 +571,9 @@ void CollectMenuTreeHandles(
 }
 
 bool IsCreatedClassicPopupMenu(HMENU menu) {
-    if (!menu) {
+    if (!menu ||
+        g_createdClassicPopupMenuCount.load(
+            std::memory_order_relaxed) == 0) {
         return false;
     }
 
@@ -601,8 +612,7 @@ HMENU WINAPI CreatePopupMenuHook() {
 BOOL WINAPI DestroyMenuHook(HMENU menu) {
     if (g_rewrittenMenuItemCount.load(
             std::memory_order_relaxed) == 0 &&
-        g_createdClassicPopupMenuCount.load(
-            std::memory_order_relaxed) == 0) {
+        !IsCreatedClassicPopupMenu(menu)) {
         return g_originalDestroyMenu(menu);
     }
 
@@ -731,11 +741,10 @@ BOOL WINAPI InsertMenuWHook(HMENU menu,
                             UINT position,
                             UINT flags,
                             UINT_PTR itemId,
-                            LPCWSTR newItem) {
-    if (!g_restoringClassicMenuText &&
-        ShouldRewriteClassicMenuDuringConstruction(menu) &&
-        g_classicMenus.load(std::memory_order_relaxed) && newItem &&
-        IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem)) {
+    LPCWSTR newItem) {
+    if (!g_restoringClassicMenuText && newItem &&
+        IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem) &&
+        ShouldRewriteClassicMenuDuringConstruction(menu)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
         if (spaced != newItem) {
             Wh_Log(L"Applied CJK spacing (classic/InsertMenuW)");
@@ -773,11 +782,10 @@ BOOL WINAPI InsertMenuWHook(HMENU menu,
 BOOL WINAPI AppendMenuWHook(HMENU menu,
                             UINT flags,
                             UINT_PTR itemId,
-                            LPCWSTR newItem) {
-    if (!g_restoringClassicMenuText &&
-        ShouldRewriteClassicMenuDuringConstruction(menu) &&
-        g_classicMenus.load(std::memory_order_relaxed) && newItem &&
-        IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem)) {
+    LPCWSTR newItem) {
+    if (!g_restoringClassicMenuText && newItem &&
+        IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem) &&
+        ShouldRewriteClassicMenuDuringConstruction(menu)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
         if (spaced != newItem) {
             Wh_Log(L"Applied CJK spacing (classic/AppendMenuW)");
@@ -801,11 +809,10 @@ BOOL WINAPI ModifyMenuWHook(HMENU menu,
                             UINT position,
                             UINT flags,
                             UINT_PTR itemId,
-                            LPCWSTR newItem) {
-    if (!g_restoringClassicMenuText &&
-        ShouldRewriteClassicMenuDuringConstruction(menu) &&
-        g_classicMenus.load(std::memory_order_relaxed) && newItem &&
-        IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem)) {
+    LPCWSTR newItem) {
+    if (!g_restoringClassicMenuText && newItem &&
+        IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem) &&
+        ShouldRewriteClassicMenuDuringConstruction(menu)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
         if (spaced != newItem) {
             Wh_Log(L"Applied CJK spacing (classic/ModifyMenuW)");
@@ -892,54 +899,8 @@ int FindMenuItemIndexByText(HMENU menu,
     return -1;
 }
 
-void RememberRewrittenMenuItem(HMENU menu,
-                               UINT index,
-                               std::wstring original,
-                               std::wstring spaced) {
-    std::lock_guard<std::mutex> guard(g_rewrittenMenuItemsMutex);
-
-    constexpr size_t kRewrittenMenuCleanupThreshold = 256;
-    if (g_rewrittenMenuItems.size() >=
-        kRewrittenMenuCleanupThreshold) {
-        // Popup teardown normally clears this vector. If a menu is destroyed
-        // before teardown, remove only entries that can no longer be restored;
-        // never evict a live entry just to enforce an arbitrary cap.
-        std::erase_if(g_rewrittenMenuItems, [](const auto& item) {
-            return !IsMenu(item.menu);
-        });
-    }
-
-    g_rewrittenMenuItems.push_back(
-        {g_classicPopupRootMenu, menu, index, std::move(original),
-         std::move(spaced)});
-    g_rewrittenMenuItemCount.store(
-        static_cast<unsigned int>(g_rewrittenMenuItems.size()),
-        std::memory_order_relaxed);
-}
-
-void RestoreRewrittenMenuItems(HMENU rootMenu = nullptr) {
-    std::vector<RewrittenMenuItem> items;
-    {
-        std::lock_guard<std::mutex> guard(
-            g_rewrittenMenuItemsMutex);
-        if (!rootMenu) {
-            items.swap(g_rewrittenMenuItems);
-        } else {
-            for (auto iterator = g_rewrittenMenuItems.begin();
-                 iterator != g_rewrittenMenuItems.end();) {
-                if (iterator->rootMenu == rootMenu) {
-                    items.push_back(std::move(*iterator));
-                    iterator = g_rewrittenMenuItems.erase(iterator);
-                } else {
-                    ++iterator;
-                }
-            }
-        }
-        g_rewrittenMenuItemCount.store(
-            static_cast<unsigned int>(g_rewrittenMenuItems.size()),
-            std::memory_order_relaxed);
-    }
-
+void RestoreRewrittenMenuItemRecords(
+    std::vector<RewrittenMenuItem> items) {
     ScopedBoolValue restoringGuard(g_restoringClassicMenuText, true);
     for (auto iterator = items.rbegin(); iterator != items.rend();
          ++iterator) {
@@ -974,15 +935,115 @@ void RestoreRewrittenMenuItems(HMENU rootMenu = nullptr) {
     }
 }
 
+void RememberRewrittenMenuItem(HMENU menu,
+                               UINT index,
+                               std::wstring original,
+                               std::wstring spaced) {
+    const ULONGLONG now = GetTickCount64();
+    std::vector<RewrittenMenuItem> expiredItems;
+    {
+        std::lock_guard<std::mutex> guard(g_rewrittenMenuItemsMutex);
+        const bool reachedHardLimit =
+            g_rewrittenMenuItems.size() >=
+            kMaxPendingRewrittenMenuItems;
+        if (reachedHardLimit ||
+            now >= g_nextRewrittenMenuCleanupTick.load(
+                       std::memory_order_relaxed)) {
+            g_nextRewrittenMenuCleanupTick.store(
+                now + kRewrittenMenuCleanupIntervalMs,
+                std::memory_order_relaxed);
+
+            // A popup normally gets a root in TrackPopupMenu* and is restored
+            // as soon as it closes. Menu-bar dropdowns and abandoned popup
+            // menus can remain pending, so periodically restore old live
+            // records and discard records whose HMENU is already invalid.
+            std::erase_if(
+                g_rewrittenMenuItems,
+                [&](RewrittenMenuItem& item) {
+                    if (!IsMenu(item.menu)) {
+                        return true;
+                    }
+                    if (!item.rootMenu && item.menu != menu &&
+                        now - item.recordedAt >=
+                            kPendingRewrittenMenuLifetimeMs) {
+                        expiredItems.push_back(std::move(item));
+                        return true;
+                    }
+                    return false;
+                });
+
+            if (g_rewrittenMenuItems.size() >=
+                kMaxPendingRewrittenMenuItems) {
+                size_t pendingToRemove =
+                    g_rewrittenMenuItems.size() -
+                    kPendingRewrittenMenuTarget;
+                std::erase_if(
+                    g_rewrittenMenuItems,
+                    [&](RewrittenMenuItem& item) {
+                        if (pendingToRemove && !item.rootMenu &&
+                            item.menu != menu) {
+                            expiredItems.push_back(std::move(item));
+                            --pendingToRemove;
+                            return true;
+                        }
+                        return false;
+                    });
+            }
+
+            g_rewrittenMenuItemCount.store(
+                static_cast<unsigned int>(
+                    g_rewrittenMenuItems.size()),
+                std::memory_order_relaxed);
+        }
+    }
+
+    RestoreRewrittenMenuItemRecords(std::move(expiredItems));
+
+    {
+        std::lock_guard<std::mutex> guard(g_rewrittenMenuItemsMutex);
+        g_rewrittenMenuItems.push_back(
+            {g_classicPopupRootMenu, menu, index, now,
+             std::move(original), std::move(spaced)});
+        g_rewrittenMenuItemCount.store(
+            static_cast<unsigned int>(g_rewrittenMenuItems.size()),
+            std::memory_order_relaxed);
+    }
+}
+
+void RestoreRewrittenMenuItems(HMENU rootMenu = nullptr) {
+    std::vector<RewrittenMenuItem> items;
+    {
+        std::lock_guard<std::mutex> guard(
+            g_rewrittenMenuItemsMutex);
+        if (!rootMenu) {
+            items.swap(g_rewrittenMenuItems);
+        } else {
+            for (auto iterator = g_rewrittenMenuItems.begin();
+                 iterator != g_rewrittenMenuItems.end();) {
+                if (iterator->rootMenu == rootMenu) {
+                    items.push_back(std::move(*iterator));
+                    iterator = g_rewrittenMenuItems.erase(iterator);
+                } else {
+                    ++iterator;
+                }
+            }
+        }
+        g_rewrittenMenuItemCount.store(
+            static_cast<unsigned int>(g_rewrittenMenuItems.size()),
+            std::memory_order_relaxed);
+    }
+
+    RestoreRewrittenMenuItemRecords(std::move(items));
+}
+
 BOOL WINAPI InsertMenuItemWHook(HMENU menu,
                                 UINT item,
                                 BOOL byPosition,
                                 LPCMENUITEMINFOW itemInfo) {
     if (!g_restoringClassicMenuText &&
-        ShouldRewriteClassicMenuDuringConstruction(menu) &&
-        g_classicMenus.load(std::memory_order_relaxed) &&
         MenuItemInfoContainsString(itemInfo) &&
-        ContainsCjkCodePoint(itemInfo->dwTypeData)) {
+        ContainsCjkCodePoint(itemInfo->dwTypeData) &&
+        ShouldRewriteClassicMenuDuringConstruction(menu)) {
         const std::wstring spaced = AddCjkSpacing(itemInfo->dwTypeData);
         if (spaced != itemInfo->dwTypeData) {
             Wh_Log(L"Applied CJK spacing (classic/InsertMenuItemW)");
@@ -1027,10 +1088,9 @@ BOOL WINAPI SetMenuItemInfoWHook(HMENU menu,
                                  BOOL byPosition,
                                  LPCMENUITEMINFOW itemInfo) {
     if (!g_restoringClassicMenuText &&
-        ShouldRewriteClassicMenuDuringConstruction(menu) &&
-        g_classicMenus.load(std::memory_order_relaxed) &&
         MenuItemInfoContainsString(itemInfo) &&
-        ContainsCjkCodePoint(itemInfo->dwTypeData)) {
+        ContainsCjkCodePoint(itemInfo->dwTypeData) &&
+        ShouldRewriteClassicMenuDuringConstruction(menu)) {
         const std::wstring spaced = AddCjkSpacing(itemInfo->dwTypeData);
         if (spaced != itemInfo->dwTypeData) {
             Wh_Log(L"Applied CJK spacing (classic/SetMenuItemInfoW)");
@@ -1114,17 +1174,13 @@ BOOL WINAPI TrackPopupMenuHook(HMENU menu,
                                int reserved,
                                HWND owner,
                                const RECT* rect) {
-    if (g_classicMenus.load(std::memory_order_relaxed)) {
-        ClassicPopupMenuStateGuard stateGuard(menu);
-        AssociatePendingRewrittenMenuItems(menu);
-        RewriteMenuTree(menu);
-        const BOOL result = g_originalTrackPopupMenu(
-            menu, flags, x, y, reserved, owner, rect);
-        RestoreRewrittenMenuItems(menu);
-        return result;
-    }
-
-    return g_originalTrackPopupMenu(menu, flags, x, y, reserved, owner, rect);
+    ClassicPopupMenuStateGuard stateGuard(menu);
+    AssociatePendingRewrittenMenuItems(menu);
+    RewriteMenuTree(menu);
+    const BOOL result = g_originalTrackPopupMenu(
+        menu, flags, x, y, reserved, owner, rect);
+    RestoreRewrittenMenuItems(menu);
+    return result;
 }
 
 BOOL WINAPI TrackPopupMenuExHook(HMENU menu,
@@ -1133,17 +1189,13 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU menu,
                                  int y,
                                  HWND owner,
                                  LPTPMPARAMS parameters) {
-    if (g_classicMenus.load(std::memory_order_relaxed)) {
-        ClassicPopupMenuStateGuard stateGuard(menu);
-        AssociatePendingRewrittenMenuItems(menu);
-        RewriteMenuTree(menu);
-        const BOOL result = g_originalTrackPopupMenuEx(
-            menu, flags, x, y, owner, parameters);
-        RestoreRewrittenMenuItems(menu);
-        return result;
-    }
-
-    return g_originalTrackPopupMenuEx(menu, flags, x, y, owner, parameters);
+    ClassicPopupMenuStateGuard stateGuard(menu);
+    AssociatePendingRewrittenMenuItems(menu);
+    RewriteMenuTree(menu);
+    const BOOL result = g_originalTrackPopupMenuEx(
+        menu, flags, x, y, owner, parameters);
+    RestoreRewrittenMenuItems(menu);
+    return result;
 }
 
 // -------------------------------------------------------------------------
@@ -1427,8 +1479,7 @@ HRESULT WINAPI GetThemeTextExtentHook(HTHEME theme,
                                       DWORD textFlags,
                                       LPCRECT boundingRectangle,
                                       LPRECT extentRectangle) {
-    if (!g_classicTooltips.load(std::memory_order_relaxed) ||
-        g_rewritingClassicTooltipText ||
+    if (g_rewritingClassicTooltipText ||
         !IsClassicTooltipTextPart(partId) ||
         !IsClassicTooltipTarget(theme, dc)) {
         return g_originalGetThemeTextExtent(
@@ -1464,8 +1515,7 @@ HRESULT WINAPI DrawThemeTextHook(HTHEME theme,
                                  DWORD textFlags,
                                  DWORD textFlags2,
                                  LPCRECT rectangle) {
-    if (!g_classicTooltips.load(std::memory_order_relaxed) ||
-        g_rewritingClassicTooltipText ||
+    if (g_rewritingClassicTooltipText ||
         !IsClassicTooltipTextPart(partId) ||
         !IsClassicTooltipTarget(theme, dc)) {
         return g_originalDrawThemeText(
@@ -1500,8 +1550,7 @@ HRESULT WINAPI DrawThemeTextExHook(HTHEME theme,
                                    DWORD textFlags,
                                    LPRECT rectangle,
                                    const DTTOPTS* options) {
-    if (!g_classicTooltips.load(std::memory_order_relaxed) ||
-        g_rewritingClassicTooltipText ||
+    if (g_rewritingClassicTooltipText ||
         !IsClassicTooltipTextPart(partId) ||
         !IsClassicTooltipTarget(theme, dc)) {
         return g_originalDrawThemeTextEx(
@@ -1844,13 +1893,20 @@ public:
             [](LPVOID parameter) -> DWORD {
                 auto* watcher =
                     static_cast<VisualTreeWatcher*>(parameter);
-                const HRESULT result =
-                    watcher->m_xamlDiagnostics
-                        .as<IVisualTreeService3>()
-                        ->AdviseVisualTreeChange(watcher);
+                HRESULT result;
+                try {
+                    result = watcher->m_xamlDiagnostics
+                                 .as<IVisualTreeService3>()
+                                 ->AdviseVisualTreeChange(watcher);
+                } catch (...) {
+                    result = winrt::to_hresult();
+                }
                 if (FAILED(result)) {
-                    Wh_Log(L"AdviseVisualTreeChange failed: 0x%08X",
-                           result);
+                    if (!g_stoppingModernUi.load(
+                            std::memory_order_acquire)) {
+                        Wh_Log(L"AdviseVisualTreeChange failed: 0x%08X",
+                               result);
+                    }
                 } else {
                     watcher->m_advised.store(
                         true, std::memory_order_release);
@@ -2782,35 +2838,42 @@ bool HookClassicTooltipThemeDrawing() {
             GetProcAddress(themeModule, "DrawThemeTextEx"));
 
     if (!g_getWindowTheme || !openThemeData || !openThemeDataEx ||
-        !openThemeDataForDpi || !closeThemeData ||
-        !getThemeTextExtent || !drawThemeText || !drawThemeTextEx) {
+        !closeThemeData || !getThemeTextExtent ||
+        !drawThemeText || !drawThemeTextEx) {
         Wh_Log(L"Couldn't resolve all required uxtheme functions");
         return false;
     }
 
-    return InstallHook(
-               openThemeData, OpenThemeDataHook,
-               &g_originalOpenThemeData, L"OpenThemeData") &&
-           InstallHook(
-               openThemeDataEx, OpenThemeDataExHook,
-               &g_originalOpenThemeDataEx, L"OpenThemeDataEx") &&
+    if (!InstallHook(
+            openThemeData, OpenThemeDataHook,
+            &g_originalOpenThemeData, L"OpenThemeData") ||
+        !InstallHook(
+            openThemeDataEx, OpenThemeDataExHook,
+            &g_originalOpenThemeDataEx, L"OpenThemeDataEx") ||
+        !InstallHook(
+            closeThemeData, CloseThemeDataHook,
+            &g_originalCloseThemeData, L"CloseThemeData") ||
+        !InstallHook(
+            getThemeTextExtent, GetThemeTextExtentHook,
+            &g_originalGetThemeTextExtent,
+            L"GetThemeTextExtent") ||
+        !InstallHook(
+            drawThemeText, DrawThemeTextHook,
+            &g_originalDrawThemeText, L"DrawThemeText") ||
+        !InstallHook(
+            drawThemeTextEx, DrawThemeTextExHook,
+            &g_originalDrawThemeTextEx, L"DrawThemeTextEx")) {
+        return false;
+    }
+
+    // OpenThemeDataForDpi was added in Windows 10 version 1703. Older
+    // systems still get complete classic Tooltip coverage through the
+    // Vista-era theme APIs above, except for DPI-specific theme handles.
+    return !openThemeDataForDpi ||
            InstallHook(
                openThemeDataForDpi, OpenThemeDataForDpiHook,
                &g_originalOpenThemeDataForDpi,
-               L"OpenThemeDataForDpi") &&
-           InstallHook(
-               closeThemeData, CloseThemeDataHook,
-               &g_originalCloseThemeData, L"CloseThemeData") &&
-           InstallHook(
-               getThemeTextExtent, GetThemeTextExtentHook,
-               &g_originalGetThemeTextExtent,
-               L"GetThemeTextExtent") &&
-           InstallHook(
-               drawThemeText, DrawThemeTextHook,
-               &g_originalDrawThemeText, L"DrawThemeText") &&
-           InstallHook(
-               drawThemeTextEx, DrawThemeTextExHook,
-               &g_originalDrawThemeTextEx, L"DrawThemeTextEx");
+               L"OpenThemeDataForDpi");
 }
 
 bool ReadUnicodeLettersAndDigitsSetting() {

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer menus, tooltips, and popups
-// @version         0.1.4
+// @version         0.1.5
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -50,16 +50,21 @@ keyboard shortcut text are also preserved.
   `explorer.exe`.
 - Classic Win32 tooltips, including legacy notification-area icon tooltips, are
   rewritten only through theme handles opened for the `TOOLTIP` class, covering
-  both text measurement and drawing without touching unrelated GDI text.
+  both text measurement and drawing without touching unrelated GDI text. Basic
+  or classic-theme tooltips drawn directly with `DrawTextW` aren't covered.
 - Windows 11 XAML popup text uses an experimental, display-only
   DirectWrite hook. This includes context menus, tooltips, and other Explorer
-  flyouts. Tracking is scoped to the popup's UI thread so it doesn't enable
-  rewriting on unrelated Explorer or taskbar threads. Taskbar thumbnail
-  previews are explicitly excluded.
+  flyouts. While a tracked popup is visible, other XAML text laid out on the
+  same UI thread can also be transformed; unrelated Explorer threads remain
+  unaffected. Taskbar thumbnail previews are explicitly excluded.
 
 The modern path is intentionally conservative and can miss text if a Windows
 build uses a different popup window class. Disable `modernUiText` if it causes
 a problem.
+
+The mod is injected only into `explorer.exe`. Start, Search, and some shell
+flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
+`ShellExperienceHost.exe` are outside its scope.
 
 The mod doesn't edit system files, registry values, or file names. A file name
 shown in a classic menu can nevertheless be displayed with inserted spaces.
@@ -927,13 +932,40 @@ HRESULT WINAPI DrawThemeTextExHook(HTHEME theme,
 // Windows 11 XAML popup detection
 // -------------------------------------------------------------------------
 
-using ShowWindow_t = decltype(&ShowWindow);
-using SetWindowPos_t = decltype(&SetWindowPos);
-using DestroyWindow_t = decltype(&DestroyWindow);
+using CreateWindowExW_t = decltype(&CreateWindowExW);
+using CreateWindowInBand_t = HWND(WINAPI*)(
+    DWORD exStyle,
+    LPCWSTR className,
+    LPCWSTR windowName,
+    DWORD style,
+    int x,
+    int y,
+    int width,
+    int height,
+    HWND parent,
+    HMENU menu,
+    HINSTANCE instance,
+    PVOID parameter,
+    DWORD band);
+using CreateWindowInBandEx_t = HWND(WINAPI*)(
+    DWORD exStyle,
+    LPCWSTR className,
+    LPCWSTR windowName,
+    DWORD style,
+    int x,
+    int y,
+    int width,
+    int height,
+    HWND parent,
+    HMENU menu,
+    HINSTANCE instance,
+    PVOID parameter,
+    DWORD band,
+    DWORD typeFlags);
 
-ShowWindow_t g_originalShowWindow;
-SetWindowPos_t g_originalSetWindowPos;
-DestroyWindow_t g_originalDestroyWindow;
+CreateWindowExW_t g_originalCreateWindowExW;
+CreateWindowInBand_t g_originalCreateWindowInBand;
+CreateWindowInBandEx_t g_originalCreateWindowInBandEx;
 
 enum class ModernWindowKind {
     Other,
@@ -986,20 +1018,29 @@ bool TrackModernWindow(HWND window, ModernWindowKind kind) {
         return false;
     }
 
+    bool inserted;
     {
         std::lock_guard<std::mutex> guard(
             g_trackedModernWindowsMutex);
-        g_trackedModernWindows[window] = {threadId, kind};
+        const auto [iterator, wasInserted] =
+            g_trackedModernWindows.try_emplace(
+                window, TrackedModernWindow{threadId, kind});
+        if (!wasInserted) {
+            iterator->second = {threadId, kind};
+        }
+        inserted = wasInserted;
         g_trackedModernWindowCount.store(
             static_cast<unsigned int>(
                 g_trackedModernWindows.size()),
             std::memory_order_relaxed);
     }
 
-    if (kind == ModernWindowKind::TaskbarThumbnail) {
-        Wh_Log(L"Tracking excluded taskbar thumbnail");
-    } else {
-        Wh_Log(L"Tracking modern popup");
+    if (inserted) {
+        if (kind == ModernWindowKind::TaskbarThumbnail) {
+            Wh_Log(L"Tracking excluded taskbar thumbnail");
+        } else {
+            Wh_Log(L"Tracking modern popup");
+        }
     }
     return true;
 }
@@ -1009,24 +1050,30 @@ bool TrackModernWindowIfRelevant(HWND window) {
     return TrackModernWindow(window, kind);
 }
 
-void UntrackModernWindow(HWND window) {
-    std::lock_guard<std::mutex> guard(
-        g_trackedModernWindowsMutex);
-    g_trackedModernWindows.erase(window);
-    g_trackedModernWindowCount.store(
-        static_cast<unsigned int>(g_trackedModernWindows.size()),
-        std::memory_order_relaxed);
-}
-
-bool IsModernWindowTracked(HWND window) {
-    if (g_trackedModernWindowCount.load(
-            std::memory_order_relaxed) == 0) {
-        return false;
+void TrackCreatedModernWindow(HWND window, LPCWSTR className) {
+    if (!window) {
+        return;
     }
 
-    std::lock_guard<std::mutex> guard(
-        g_trackedModernWindowsMutex);
-    return g_trackedModernWindows.contains(window);
+    const ModernWindowKind kind =
+        className && !IS_INTRESOURCE(className)
+            ? ClassifyModernWindowClassName(className)
+            : ClassifyModernWindow(window);
+    TrackModernWindow(window, kind);
+}
+
+BOOL CALLBACK EnumExistingModernWindow(HWND window, LPARAM) {
+    DWORD processId;
+    GetWindowThreadProcessId(window, &processId);
+    if (processId == GetCurrentProcessId()) {
+        TrackModernWindowIfRelevant(window);
+    }
+
+    return TRUE;
+}
+
+void DiscoverExistingModernWindows() {
+    EnumWindows(EnumExistingModernWindow, 0);
 }
 
 void ClearTrackedModernWindows() {
@@ -1076,88 +1123,67 @@ bool IsModernPopupActiveForCurrentThread() {
     return popupActive && !taskbarThumbnailActive;
 }
 
-BOOL WINAPI ShowWindowHook(HWND window, int command) {
-    const bool modernUiEnabled =
-        g_modernUiText.load(std::memory_order_relaxed);
-    const bool showing = command != SW_HIDE;
-    if (!modernUiEnabled &&
-        g_trackedModernWindowCount.load(
-            std::memory_order_relaxed) == 0) {
-        return g_originalShowWindow(window, command);
-    }
-
-    bool tracked = IsModernWindowTracked(window);
-
-    if (!tracked) {
-        if (!modernUiEnabled || !showing) {
-            return g_originalShowWindow(window, command);
-        }
-
-        tracked = TrackModernWindowIfRelevant(window);
-        if (!tracked) {
-            return g_originalShowWindow(window, command);
-        }
-    }
-
-    const BOOL result = g_originalShowWindow(window, command);
-
-    if (tracked &&
-        (!showing || !IsWindow(window) ||
-         !IsWindowVisible(window))) {
-        UntrackModernWindow(window);
-    }
-
-    return result;
+HWND WINAPI CreateWindowExWHook(
+    DWORD exStyle,
+    LPCWSTR className,
+    LPCWSTR windowName,
+    DWORD style,
+    int x,
+    int y,
+    int width,
+    int height,
+    HWND parent,
+    HMENU menu,
+    HINSTANCE instance,
+    PVOID parameter) {
+    HWND window = g_originalCreateWindowExW(
+        exStyle, className, windowName, style, x, y, width, height,
+        parent, menu, instance, parameter);
+    TrackCreatedModernWindow(window, className);
+    return window;
 }
 
-BOOL WINAPI SetWindowPosHook(HWND window,
-                            HWND insertAfter,
-                            int x,
-                            int y,
-                            int width,
-                            int height,
-                            UINT flags) {
-    const bool modernUiEnabled =
-        g_modernUiText.load(std::memory_order_relaxed);
-    const bool showing = (flags & SWP_SHOWWINDOW) != 0;
-    if ((!modernUiEnabled || !showing) &&
-        g_trackedModernWindowCount.load(
-            std::memory_order_relaxed) == 0) {
-        return g_originalSetWindowPos(
-            window, insertAfter, x, y, width, height, flags);
-    }
-
-    bool tracked = IsModernWindowTracked(window);
-
-    if (!tracked) {
-        if (!modernUiEnabled ||
-            (!showing && !IsWindowVisible(window))) {
-            return g_originalSetWindowPos(
-                window, insertAfter, x, y, width, height, flags);
-        }
-
-        tracked = TrackModernWindowIfRelevant(window);
-        if (!tracked) {
-            return g_originalSetWindowPos(
-                window, insertAfter, x, y, width, height, flags);
-        }
-    }
-
-    const BOOL result = g_originalSetWindowPos(
-        window, insertAfter, x, y, width, height, flags);
-
-    if (tracked &&
-        (!result || (flags & SWP_HIDEWINDOW) ||
-         !IsWindow(window) || !IsWindowVisible(window))) {
-        UntrackModernWindow(window);
-    }
-
-    return result;
+HWND WINAPI CreateWindowInBandHook(
+    DWORD exStyle,
+    LPCWSTR className,
+    LPCWSTR windowName,
+    DWORD style,
+    int x,
+    int y,
+    int width,
+    int height,
+    HWND parent,
+    HMENU menu,
+    HINSTANCE instance,
+    PVOID parameter,
+    DWORD band) {
+    HWND window = g_originalCreateWindowInBand(
+        exStyle, className, windowName, style, x, y, width, height,
+        parent, menu, instance, parameter, band);
+    TrackCreatedModernWindow(window, className);
+    return window;
 }
 
-BOOL WINAPI DestroyWindowHook(HWND window) {
-    UntrackModernWindow(window);
-    return g_originalDestroyWindow(window);
+HWND WINAPI CreateWindowInBandExHook(
+    DWORD exStyle,
+    LPCWSTR className,
+    LPCWSTR windowName,
+    DWORD style,
+    int x,
+    int y,
+    int width,
+    int height,
+    HWND parent,
+    HMENU menu,
+    HINSTANCE instance,
+    PVOID parameter,
+    DWORD band,
+    DWORD typeFlags) {
+    HWND window = g_originalCreateWindowInBandEx(
+        exStyle, className, windowName, style, x, y, width, height,
+        parent, menu, instance, parameter, band, typeFlags);
+    TrackCreatedModernWindow(window, className);
+    return window;
 }
 
 // -------------------------------------------------------------------------
@@ -1199,10 +1225,10 @@ HRESULT CreateTextLayoutWithSpacing(
     FLOAT maxWidth,
     FLOAT maxHeight,
     IDWriteTextLayout** textLayout) {
-    if (g_modernUiText.load(std::memory_order_relaxed) && text &&
-        IsModernPopupActiveForCurrentThread()) {
+    if (g_modernUiText.load(std::memory_order_relaxed) && text) {
         const std::wstring_view original(text, textLength);
-        if (!ContainsCjkCodePoint(original)) {
+        if (!ContainsCjkCodePoint(original) ||
+            !IsModernPopupActiveForCurrentThread()) {
             return originalFunction(factory, text, textLength, textFormat,
                                     maxWidth, maxHeight, textLayout);
         }
@@ -1233,10 +1259,10 @@ HRESULT CreateGdiCompatibleTextLayoutWithSpacing(
     const DWRITE_MATRIX* transform,
     BOOL useGdiNatural,
     IDWriteTextLayout** textLayout) {
-    if (g_modernUiText.load(std::memory_order_relaxed) && text &&
-        IsModernPopupActiveForCurrentThread()) {
+    if (g_modernUiText.load(std::memory_order_relaxed) && text) {
         const std::wstring_view original(text, textLength);
-        if (!ContainsCjkCodePoint(original)) {
+        if (!ContainsCjkCodePoint(original) ||
+            !IsModernPopupActiveForCurrentThread()) {
             return originalFunction(
                 factory, text, textLength, textFormat, layoutWidth,
                 layoutHeight, pixelsPerDip, transform, useGdiNatural,
@@ -1464,45 +1490,86 @@ void LoadSettings() {
 BOOL Wh_ModInit() {
     LoadSettings();
 
-    if (!g_classicMenus.load(std::memory_order_relaxed) &&
-        !g_classicTooltips.load(std::memory_order_relaxed) &&
-        !g_modernUiText.load(std::memory_order_relaxed)) {
+    const bool classicMenusEnabled =
+        g_classicMenus.load(std::memory_order_relaxed);
+    const bool classicTooltipsEnabled =
+        g_classicTooltips.load(std::memory_order_relaxed);
+    const bool modernUiTextEnabled =
+        g_modernUiText.load(std::memory_order_relaxed);
+
+    if (!classicMenusEnabled && !classicTooltipsEnabled &&
+        !modernUiTextEnabled) {
         Wh_Log(L"CJK Spacer has no enabled UI targets");
         return FALSE;
     }
 
     bool installedAnyHook = false;
 
-    installedAnyHook |= InstallHook(InsertMenuW, InsertMenuWHook,
-                                    &g_originalInsertMenuW, L"InsertMenuW");
-    installedAnyHook |= InstallHook(AppendMenuW, AppendMenuWHook,
-                                    &g_originalAppendMenuW, L"AppendMenuW");
-    installedAnyHook |= InstallHook(ModifyMenuW, ModifyMenuWHook,
-                                    &g_originalModifyMenuW, L"ModifyMenuW");
-    installedAnyHook |=
-        InstallHook(InsertMenuItemW, InsertMenuItemWHook,
-                    &g_originalInsertMenuItemW, L"InsertMenuItemW");
-    installedAnyHook |=
-        InstallHook(SetMenuItemInfoW, SetMenuItemInfoWHook,
-                    &g_originalSetMenuItemInfoW, L"SetMenuItemInfoW");
-    installedAnyHook |=
-        InstallHook(TrackPopupMenu, TrackPopupMenuHook,
-                    &g_originalTrackPopupMenu, L"TrackPopupMenu");
-    installedAnyHook |=
-        InstallHook(TrackPopupMenuEx, TrackPopupMenuExHook,
-                    &g_originalTrackPopupMenuEx, L"TrackPopupMenuEx");
+    if (classicMenusEnabled) {
+        installedAnyHook |= InstallHook(
+            InsertMenuW, InsertMenuWHook, &g_originalInsertMenuW,
+            L"InsertMenuW");
+        installedAnyHook |= InstallHook(
+            AppendMenuW, AppendMenuWHook, &g_originalAppendMenuW,
+            L"AppendMenuW");
+        installedAnyHook |= InstallHook(
+            ModifyMenuW, ModifyMenuWHook, &g_originalModifyMenuW,
+            L"ModifyMenuW");
+        installedAnyHook |= InstallHook(
+            InsertMenuItemW, InsertMenuItemWHook,
+            &g_originalInsertMenuItemW, L"InsertMenuItemW");
+        installedAnyHook |= InstallHook(
+            SetMenuItemInfoW, SetMenuItemInfoWHook,
+            &g_originalSetMenuItemInfoW, L"SetMenuItemInfoW");
+        installedAnyHook |= InstallHook(
+            TrackPopupMenu, TrackPopupMenuHook,
+            &g_originalTrackPopupMenu, L"TrackPopupMenu");
+        installedAnyHook |= InstallHook(
+            TrackPopupMenuEx, TrackPopupMenuExHook,
+            &g_originalTrackPopupMenuEx, L"TrackPopupMenuEx");
+    }
 
-    installedAnyHook |= HookClassicTooltipThemeDrawing();
+    if (classicTooltipsEnabled) {
+        installedAnyHook |= HookClassicTooltipThemeDrawing();
+    }
 
-    installedAnyHook |= InstallHook(ShowWindow, ShowWindowHook,
-                                    &g_originalShowWindow, L"ShowWindow");
-    installedAnyHook |= InstallHook(SetWindowPos, SetWindowPosHook,
-                    &g_originalSetWindowPos, L"SetWindowPos");
-    installedAnyHook |= InstallHook(DestroyWindow, DestroyWindowHook,
-                                    &g_originalDestroyWindow,
-                                    L"DestroyWindow");
+    if (modernUiTextEnabled) {
+        installedAnyHook |= InstallHook(
+            CreateWindowExW, CreateWindowExWHook,
+            &g_originalCreateWindowExW, L"CreateWindowExW");
 
-    installedAnyHook |= HookDirectWrite();
+        HMODULE user32Module = LoadLibraryExW(
+            L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+        if (user32Module) {
+            const auto createWindowInBand =
+                reinterpret_cast<CreateWindowInBand_t>(
+                    GetProcAddress(user32Module, "CreateWindowInBand"));
+            if (createWindowInBand) {
+                installedAnyHook |= InstallHook(
+                    createWindowInBand, CreateWindowInBandHook,
+                    &g_originalCreateWindowInBand,
+                    L"CreateWindowInBand");
+            } else {
+                Wh_Log(L"Couldn't find CreateWindowInBand");
+            }
+
+            const auto createWindowInBandEx =
+                reinterpret_cast<CreateWindowInBandEx_t>(
+                    GetProcAddress(user32Module, "CreateWindowInBandEx"));
+            if (createWindowInBandEx) {
+                installedAnyHook |= InstallHook(
+                    createWindowInBandEx, CreateWindowInBandExHook,
+                    &g_originalCreateWindowInBandEx,
+                    L"CreateWindowInBandEx");
+            } else {
+                Wh_Log(L"Couldn't find CreateWindowInBandEx");
+            }
+        } else {
+            Wh_Log(L"Couldn't load user32.dll");
+        }
+
+        installedAnyHook |= HookDirectWrite();
+    }
 
     Wh_Log(L"CJK Spacer initialized (classicMenus=%d, "
            L"classicTooltips=%d, modern=%d, unicode=%d)",
@@ -1512,6 +1579,12 @@ BOOL Wh_ModInit() {
     return installedAnyHook ? TRUE : FALSE;
 }
 
+void Wh_ModAfterInit() {
+    if (g_modernUiText.load(std::memory_order_relaxed)) {
+        DiscoverExistingModernWindows();
+    }
+}
+
 void Wh_ModUninit() {
     RestoreRewrittenMenuItems();
     ClearTrackedClassicTooltipThemes();
@@ -1519,25 +1592,7 @@ void Wh_ModUninit() {
     Wh_Log(L"CJK Spacer uninitialized");
 }
 
-void Wh_ModSettingsChanged() {
-    const bool classicMenusWasEnabled =
-        g_classicMenus.load(std::memory_order_relaxed);
-    const bool modernUiWasEnabled =
-        g_modernUiText.load(std::memory_order_relaxed);
-    LoadSettings();
-
-    if (classicMenusWasEnabled &&
-        !g_classicMenus.load(std::memory_order_relaxed)) {
-        RestoreRewrittenMenuItems();
-    }
-    if (modernUiWasEnabled &&
-        !g_modernUiText.load(std::memory_order_relaxed)) {
-        ClearTrackedModernWindows();
-    }
-
-    Wh_Log(L"CJK Spacer settings changed (classicMenus=%d, "
-           L"classicTooltips=%d, modern=%d, unicode=%d)",
-           g_classicMenus.load(), g_classicTooltips.load(),
-           g_modernUiText.load(),
-           g_unicodeLettersAndDigits.load());
+BOOL Wh_ModSettingsChanged(BOOL* reload) {
+    *reload = TRUE;
+    return TRUE;
 }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips; modern XAML UI is opt-in and best-effort because it may conflict with other XAML Diagnostics mods
-// @version         0.1.21
+// @version         0.1.22
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -52,6 +52,9 @@ After:
 The transformation is idempotent. Punctuation and existing whitespace break a
 boundary and are preserved. Win32 `&` mnemonic markers and tab-separated
 keyboard shortcut text are also preserved.
+Hiragana, fullwidth Katakana, and halfwidth Katakana letters are all
+classified as CJK characters for boundary detection; kana punctuation remains
+excluded.
 
 ## Supported UI
 
@@ -223,10 +226,12 @@ bool IsCjkCodePoint(uint32_t codePoint) {
         return true;
     }
 
-    // CJK radicals, Kangxi radicals, kana, Bopomofo, Hangul compatibility
-    // Jamo, CJK strokes, and Katakana phonetic extensions. CJK punctuation is
-    // deliberately excluded except for the ideographic iteration mark and
-    // ideographic zero.
+    // CJK radicals, Kangxi radicals, Hiragana, fullwidth Katakana, Bopomofo,
+    // Hangul compatibility Jamo, CJK strokes, and Katakana phonetic
+    // extensions. All Hiragana and Katakana letters, including halfwidth
+    // Katakana below, are treated as CJK for spacing purposes. Kana/CJK
+    // punctuation is deliberately excluded except for the ideographic
+    // iteration mark and ideographic zero.
     const bool isKana =
         IsInRange(codePoint, 0x3040, 0x30FF) &&
         codePoint != 0x30A0 && codePoint != 0x30FB;
@@ -467,6 +472,39 @@ std::vector<RewrittenMenuItem> g_rewrittenMenuItems;
 thread_local unsigned int g_classicPopupMenuDepth = 0;
 thread_local HMENU g_classicPopupRootMenu = nullptr;
 thread_local bool g_restoringClassicMenuText = false;
+
+class ScopedBoolValue final {
+public:
+    ScopedBoolValue(bool& value, bool replacement)
+        : m_value(value), m_previous(value) {
+        m_value = replacement;
+    }
+
+    ~ScopedBoolValue() {
+        m_value = m_previous;
+    }
+
+private:
+    bool& m_value;
+    bool m_previous;
+};
+
+class ClassicPopupMenuStateGuard final {
+public:
+    explicit ClassicPopupMenuStateGuard(HMENU rootMenu)
+        : m_previousRootMenu(g_classicPopupRootMenu) {
+        g_classicPopupRootMenu = rootMenu;
+        ++g_classicPopupMenuDepth;
+    }
+
+    ~ClassicPopupMenuStateGuard() {
+        --g_classicPopupMenuDepth;
+        g_classicPopupRootMenu = m_previousRootMenu;
+    }
+
+private:
+    HMENU m_previousRootMenu;
+};
 
 void RememberRewrittenMenuItem(HMENU menu,
                                UINT index,
@@ -715,8 +753,7 @@ void RestoreRewrittenMenuItems(HMENU rootMenu = nullptr) {
         }
     }
 
-    const bool wasRestoring = g_restoringClassicMenuText;
-    g_restoringClassicMenuText = true;
+    ScopedBoolValue restoringGuard(g_restoringClassicMenuText, true);
     for (auto iterator = items.rbegin(); iterator != items.rend();
          ++iterator) {
         if (!IsMenu(iterator->menu)) {
@@ -748,7 +785,6 @@ void RestoreRewrittenMenuItems(HMENU rootMenu = nullptr) {
             iterator->menu, static_cast<UINT>(index), TRUE,
             &replacement);
     }
-    g_restoringClassicMenuText = wasRestoring;
 }
 
 BOOL WINAPI InsertMenuItemWHook(HMENU menu,
@@ -888,15 +924,11 @@ BOOL WINAPI TrackPopupMenuHook(HMENU menu,
                                HWND owner,
                                const RECT* rect) {
     if (g_classicMenus.load(std::memory_order_relaxed)) {
-        const HMENU previousRootMenu = g_classicPopupRootMenu;
-        g_classicPopupRootMenu = menu;
-        ++g_classicPopupMenuDepth;
+        ClassicPopupMenuStateGuard stateGuard(menu);
         RewriteMenuTree(menu);
         const BOOL result = g_originalTrackPopupMenu(
             menu, flags, x, y, reserved, owner, rect);
         RestoreRewrittenMenuItems(menu);
-        --g_classicPopupMenuDepth;
-        g_classicPopupRootMenu = previousRootMenu;
         return result;
     }
 
@@ -910,15 +942,11 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU menu,
                                  HWND owner,
                                  LPTPMPARAMS parameters) {
     if (g_classicMenus.load(std::memory_order_relaxed)) {
-        const HMENU previousRootMenu = g_classicPopupRootMenu;
-        g_classicPopupRootMenu = menu;
-        ++g_classicPopupMenuDepth;
+        ClassicPopupMenuStateGuard stateGuard(menu);
         RewriteMenuTree(menu);
         const BOOL result = g_originalTrackPopupMenuEx(
             menu, flags, x, y, owner, parameters);
         RestoreRewrittenMenuItems(menu);
-        --g_classicPopupMenuDepth;
-        g_classicPopupRootMenu = previousRootMenu;
         return result;
     }
 
@@ -933,6 +961,7 @@ using OpenThemeData_t = decltype(&OpenThemeData);
 using OpenThemeDataEx_t = decltype(&OpenThemeDataEx);
 using OpenThemeDataForDpi_t = decltype(&OpenThemeDataForDpi);
 using CloseThemeData_t = decltype(&CloseThemeData);
+using GetWindowTheme_t = decltype(&GetWindowTheme);
 using GetThemeTextExtent_t = decltype(&GetThemeTextExtent);
 using DrawThemeText_t = decltype(&DrawThemeText);
 using DrawThemeTextEx_t = decltype(&DrawThemeTextEx);
@@ -941,21 +970,27 @@ OpenThemeData_t g_originalOpenThemeData;
 OpenThemeDataEx_t g_originalOpenThemeDataEx;
 OpenThemeDataForDpi_t g_originalOpenThemeDataForDpi;
 CloseThemeData_t g_originalCloseThemeData;
+GetWindowTheme_t g_getWindowTheme;
 GetThemeTextExtent_t g_originalGetThemeTextExtent;
 DrawThemeText_t g_originalDrawThemeText;
 DrawThemeTextEx_t g_originalDrawThemeTextEx;
 HMODULE g_loadedUxThemeModule;
 std::shared_mutex g_classicTooltipThemesMutex;
-// A theme handle can be shared by multiple tooltip windows. Keep a reference
-// count for matching OpenThemeData calls so CloseThemeData can release the
-// right number of references without letting the last window overwrite the
-// rest.
-std::unordered_map<HTHEME, unsigned int> g_classicTooltipThemes;
+struct ClassicTooltipTheme {
+    unsigned int references = 0;
+    bool hasTooltipWindow = false;
+};
+
+// A theme handle can be shared by multiple tooltip windows. Count every
+// matching OpenThemeData call, while separately remembering whether at least
+// one real tooltips_class32 window owns the handle for draw-time filtering.
+std::unordered_map<HTHEME, ClassicTooltipTheme> g_classicTooltipThemes;
 std::vector<HTHEME> g_discoveredClassicTooltipThemes;
 std::atomic_uint g_classicTooltipThemeCount{0};
 thread_local bool g_rewritingClassicTooltipText = false;
 
 void ClearUxThemeFunctionPointers() {
+    g_getWindowTheme = nullptr;
     g_originalOpenThemeData = nullptr;
     g_originalOpenThemeDataEx = nullptr;
     g_originalOpenThemeDataForDpi = nullptr;
@@ -999,11 +1034,13 @@ bool IsTrackedClassicTooltipTheme(HTHEME theme) {
 
     std::shared_lock<std::shared_mutex> guard(
         g_classicTooltipThemesMutex);
-    return g_classicTooltipThemes.contains(theme);
+    const auto iterator = g_classicTooltipThemes.find(theme);
+    return iterator != g_classicTooltipThemes.end() &&
+           iterator->second.hasTooltipWindow;
 }
 
 void TrackClassicTooltipTheme(HTHEME theme, HWND window) {
-    if (!theme || !window || !IsClassicTooltipWindow(window)) {
+    if (!theme) {
         return;
     }
 
@@ -1012,9 +1049,12 @@ void TrackClassicTooltipTheme(HTHEME theme, HWND window) {
         std::lock_guard<std::shared_mutex> guard(
             g_classicTooltipThemesMutex);
         auto [iterator, wasInserted] =
-            g_classicTooltipThemes.try_emplace(theme, 0);
+            g_classicTooltipThemes.try_emplace(theme);
         inserted = wasInserted;
-        ++iterator->second;
+        ++iterator->second.references;
+        if (window && IsClassicTooltipWindow(window)) {
+            iterator->second.hasTooltipWindow = true;
+        }
         g_classicTooltipThemeCount.store(
             static_cast<unsigned int>(g_classicTooltipThemes.size()),
             std::memory_order_relaxed);
@@ -1039,7 +1079,7 @@ bool UntrackClassicTooltipTheme(HTHEME theme) {
         return false;
     }
 
-    if (--iterator->second == 0) {
+    if (--iterator->second.references == 0) {
         g_classicTooltipThemes.erase(iterator);
         g_classicTooltipThemeCount.store(
             static_cast<unsigned int>(g_classicTooltipThemes.size()),
@@ -1078,15 +1118,23 @@ BOOL CALLBACK EnumExistingClassicTooltipWindow(HWND window, LPARAM) {
     DWORD processId;
     GetWindowThreadProcessId(window, &processId);
     if (processId == GetCurrentProcessId() &&
-        IsClassicTooltipWindow(window) && g_originalOpenThemeData &&
-        g_originalCloseThemeData) {
+        IsClassicTooltipWindow(window) && g_getWindowTheme &&
+        g_originalOpenThemeData && g_originalCloseThemeData) {
         // GetWindowTheme does not add a theme-data reference. Open the
         // handle ourselves so the discovery entry can be released exactly
         // once during module teardown.
+        const HTHEME windowTheme = g_getWindowTheme(window);
         if (HTHEME theme =
                 g_originalOpenThemeData(window, L"TOOLTIP")) {
-            TrackClassicTooltipTheme(theme, window);
-            g_discoveredClassicTooltipThemes.push_back(theme);
+            if (theme == windowTheme) {
+                TrackClassicTooltipTheme(theme, window);
+                g_discoveredClassicTooltipThemes.push_back(theme);
+            } else {
+                // A different DPI/theme context may resolve a different
+                // cached handle. Do not retain a handle the control does not
+                // actually use.
+                g_originalCloseThemeData(theme);
+            }
         }
     }
 
@@ -1094,7 +1142,8 @@ BOOL CALLBACK EnumExistingClassicTooltipWindow(HWND window, LPARAM) {
 }
 
 void DiscoverExistingClassicTooltipThemes() {
-    if (g_originalOpenThemeData && g_originalCloseThemeData) {
+    if (g_getWindowTheme && g_originalOpenThemeData &&
+        g_originalCloseThemeData) {
         EnumWindows(EnumExistingClassicTooltipWindow, 0);
     }
 }
@@ -1107,7 +1156,6 @@ void CloseDiscoveredClassicTooltipThemes() {
 
     for (HTHEME theme : g_discoveredClassicTooltipThemes) {
         g_originalCloseThemeData(theme);
-        UntrackClassicTooltipTheme(theme);
     }
     g_discoveredClassicTooltipThemes.clear();
 }
@@ -1210,12 +1258,12 @@ HRESULT WINAPI GetThemeTextExtentHook(HTHEME theme,
 
     Wh_Log(L"Applied CJK spacing "
            L"(classic tooltip/GetThemeTextExtent)");
-    g_rewritingClassicTooltipText = true;
+    ScopedBoolValue rewritingGuard(
+        g_rewritingClassicTooltipText, true);
     const HRESULT result = g_originalGetThemeTextExtent(
         theme, dc, partId, stateId, spaced.c_str(),
         static_cast<int>(spaced.size()), textFlags,
         boundingRectangle, extentRectangle);
-    g_rewritingClassicTooltipText = false;
     return result;
 }
 
@@ -1246,12 +1294,12 @@ HRESULT WINAPI DrawThemeTextHook(HTHEME theme,
     }
 
     Wh_Log(L"Applied CJK spacing (classic tooltip/DrawThemeText)");
-    g_rewritingClassicTooltipText = true;
+    ScopedBoolValue rewritingGuard(
+        g_rewritingClassicTooltipText, true);
     const HRESULT result = g_originalDrawThemeText(
         theme, dc, partId, stateId, spaced.c_str(),
         static_cast<int>(spaced.size()), textFlags, textFlags2,
         rectangle);
-    g_rewritingClassicTooltipText = false;
     return result;
 }
 
@@ -1282,12 +1330,12 @@ HRESULT WINAPI DrawThemeTextExHook(HTHEME theme,
     }
 
     Wh_Log(L"Applied CJK spacing (classic tooltip/DrawThemeTextEx)");
-    g_rewritingClassicTooltipText = true;
+    ScopedBoolValue rewritingGuard(
+        g_rewritingClassicTooltipText, true);
     const HRESULT result = g_originalDrawThemeTextEx(
         theme, dc, partId, stateId, spaced.c_str(),
         static_cast<int>(spaced.size()), textFlags, rectangle,
         options);
-    g_rewritingClassicTooltipText = false;
     return result;
 }
 
@@ -1567,14 +1615,14 @@ void CleanupModernTextStatesForCurrentThread() {
 }
 
 HMODULE AcquireCurrentModuleReference();
-void RequestModernXamlDiagnosticsInitialization(
-    bool retryFailedConnections = false);
-
 enum class XamlDiagnosticsFlavor {
     None,
     Windows,
     Microsoft,
 };
+
+void RequestModernXamlDiagnosticsInitialization(
+    XamlDiagnosticsFlavor retryFlavor = XamlDiagnosticsFlavor::None);
 
 extern std::atomic_bool g_windowsUiXamlDiagnosticsConnected;
 extern std::atomic_bool g_microsoftUiXamlDiagnosticsConnected;
@@ -1869,19 +1917,16 @@ public:
                 XamlDiagnosticsFlavor::Windows) {
                 g_windowsUiXamlDiagnosticsConnected.store(
                     false, std::memory_order_release);
-                g_windowsUiXamlDiagnosticsAttempted.store(
-                    false, std::memory_order_release);
             } else if (disconnectedFlavor ==
                        XamlDiagnosticsFlavor::Microsoft) {
                 g_microsoftUiXamlDiagnosticsConnected.store(
-                    false, std::memory_order_release);
-                g_microsoftUiXamlDiagnosticsAttempted.store(
                     false, std::memory_order_release);
             }
             if (disconnectedFlavor != XamlDiagnosticsFlavor::None &&
                 !g_stoppingModernUi.load(
                     std::memory_order_relaxed)) {
-                RequestModernXamlDiagnosticsInitialization();
+                RequestModernXamlDiagnosticsInitialization(
+                    disconnectedFlavor);
             }
             return S_OK;
         }
@@ -2181,19 +2226,20 @@ bool NeedsXamlDiagnosticsConnection() {
 }
 
 void RequestModernXamlDiagnosticsInitialization(
-    bool retryFailedConnections) {
+    XamlDiagnosticsFlavor retryFlavor) {
     const uint64_t generation =
         g_modernUiGeneration.load(std::memory_order_acquire);
     if (!IsCurrentModernUiGeneration(generation)) {
         return;
     }
 
-    if (retryFailedConnections) {
-        // A new XAML module load or a previously established connection being
-        // torn down is an explicit retry opportunity. Window creation alone
-        // must not keep retrying a connection another diagnostics tool denied.
+    // A new XAML module load or a previously established connection being
+    // torn down is an explicit retry opportunity. Window creation alone must
+    // not keep retrying a connection another diagnostics tool denied.
+    if (retryFlavor == XamlDiagnosticsFlavor::Windows) {
         g_windowsUiXamlDiagnosticsAttempted.store(
             false, std::memory_order_release);
+    } else if (retryFlavor == XamlDiagnosticsFlavor::Microsoft) {
         g_microsoftUiXamlDiagnosticsAttempted.store(
             false, std::memory_order_release);
     }
@@ -2288,26 +2334,44 @@ void RequestModernXamlDiagnosticsInitialization(
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 LoadLibraryExW_t g_originalLoadLibraryExW;
 
-bool IsXamlDiagnosticsTriggerModule(LPCWSTR path) {
+PCWSTR GetModuleFileNamePart(LPCWSTR path) {
     if (!path) {
-        return false;
+        return nullptr;
     }
 
     PCWSTR fileName = wcsrchr(path, L'\\');
-    fileName = fileName ? fileName + 1 : path;
-    return _wcsicmp(fileName, L"Windows.UI.Xaml.dll") == 0 ||
-           _wcsicmp(fileName,
-                    L"Microsoft.Internal.FrameworkUdk.dll") == 0 ||
-           _wcsicmp(fileName, L"CoreMessagingXP.dll") == 0;
+    return fileName ? fileName + 1 : path;
+}
+
+XamlDiagnosticsFlavor GetXamlDiagnosticsTriggerFlavor(LPCWSTR path) {
+    const PCWSTR fileName = GetModuleFileNamePart(path);
+    if (!fileName) {
+        return XamlDiagnosticsFlavor::None;
+    }
+
+    if (_wcsicmp(fileName, L"Windows.UI.Xaml.dll") == 0) {
+        return XamlDiagnosticsFlavor::Windows;
+    }
+    if (_wcsicmp(fileName,
+                 L"Microsoft.Internal.FrameworkUdk.dll") == 0) {
+        return XamlDiagnosticsFlavor::Microsoft;
+    }
+    return XamlDiagnosticsFlavor::None;
+}
+
+bool IsXamlDiagnosticsTriggerModule(LPCWSTR path) {
+    const PCWSTR fileName = GetModuleFileNamePart(path);
+    return GetXamlDiagnosticsTriggerFlavor(path) !=
+               XamlDiagnosticsFlavor::None ||
+           (fileName && _wcsicmp(fileName, L"CoreMessagingXP.dll") == 0);
 }
 
 bool IsXamlDiagnosticsTriggerModuleLoaded(LPCWSTR path) {
-    if (!path) {
+    const PCWSTR fileName = GetModuleFileNamePart(path);
+    if (!fileName) {
         return false;
     }
 
-    PCWSTR fileName = wcsrchr(path, L'\\');
-    fileName = fileName ? fileName + 1 : path;
     return GetModuleHandleW(fileName) != nullptr;
 }
 
@@ -2316,6 +2380,8 @@ HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
                                   DWORD flags) {
     const bool triggerModule =
         IsXamlDiagnosticsTriggerModule(fileName);
+    const XamlDiagnosticsFlavor triggerFlavor =
+        GetXamlDiagnosticsTriggerFlavor(fileName);
     const bool triggerModuleWasLoaded =
         triggerModule &&
         IsXamlDiagnosticsTriggerModuleLoaded(fileName);
@@ -2327,7 +2393,9 @@ HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
         // Don't load the TAP or activate COM while the caller might hold the
         // Windows loader lock.
         RequestModernXamlDiagnosticsInitialization(
-            !triggerModuleWasLoaded);
+            !triggerModuleWasLoaded
+                ? triggerFlavor
+                : XamlDiagnosticsFlavor::None);
     }
     return module;
 }
@@ -2372,7 +2440,8 @@ void OnModernXamlHostWindowCreated(HWND window,
                                    HWND parent,
                                    LPCWSTR className,
                                    LPCWSTR source) {
-    if (!IsModernXamlHostWindow(window, parent, className)) {
+    if (!g_modernUiText.load(std::memory_order_relaxed) ||
+        !IsModernXamlHostWindow(window, parent, className)) {
         return;
     }
 
@@ -2672,6 +2741,12 @@ bool HookClassicTooltipThemeDrawing() {
     }
 
     bool hooked = false;
+
+    g_getWindowTheme = reinterpret_cast<GetWindowTheme_t>(
+        GetProcAddress(themeModule, "GetWindowTheme"));
+    if (!g_getWindowTheme) {
+        Wh_Log(L"Couldn't find GetWindowTheme");
+    }
 
     const auto openThemeData =
         reinterpret_cast<OpenThemeData_t>(

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -8,7 +8,7 @@
 // @license         GPL-3.0
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -luxtheme
 // ==/WindhawkMod==
 
 // Source code is published under the GNU General Public License v3.0.

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -30,6 +30,16 @@ Examples:
 - `使用 VS Code 打开` is unchanged
 - `打开(&O)` is unchanged
 
+## Screenshot
+
+Before:
+
+![Before enabling CJK Spacer](https://raw.githubusercontent.com/aenerv7/Dox/main/Windhawk/CJKSpacer/Before.png)
+
+After:
+
+![After enabling CJK Spacer](https://raw.githubusercontent.com/aenerv7/Dox/main/Windhawk/CJKSpacer/After.png)
+
 The transformation is idempotent. Punctuation and existing whitespace break a
 boundary and are preserved. Win32 `&` mnemonic markers and tab-separated
 keyboard shortcut text are also preserved.

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.12
+// @version         0.1.13
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -61,14 +61,14 @@ keyboard shortcut text are also preserved.
   source-element level. Only plain local string values in the `Text` source of
   XAML menu items and `ToolTip.Content` are changed; bindings, styles,
   presenter `TextBlock` values, ordinary XAML text, and taskbar thumbnail
-  previews are untouched. Popup visibility is maintained from accessibility
-  show/hide/destroy events, and each source is restored only when its owning
-  popup closes. This path is disabled by default; enable `modernUiText` to opt
-  in.
+  previews are untouched. A source is changed when XAML Diagnostics reports
+  that it was added and restored when it is removed or the mod unloads. This
+  path is disabled by default; enable `modernUiText` to opt in.
 
 The modern path supports both Windows.UI.Xaml and Microsoft.UI.Xaml content
 hosted by Explorer. XAML Diagnostics allows one consumer per XAML connection,
-so another diagnostics-based customization tool can prevent this path from
+so another diagnostics-based customization tool, including Windows 11 Taskbar
+Styler or Windows 11 File Explorer Styler, can prevent this path from
 initializing.
 
 The mod is injected only into `explorer.exe`. Start, Search, and some shell
@@ -78,7 +78,8 @@ flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
 The mod doesn't edit system files, registry values, or file names. A file name
 shown in a classic menu can nevertheless be displayed with inserted spaces.
 The modern path temporarily changes target source values on their XAML UI
-threads and restores them with their owning popup. The classic path updates
+threads and restores them when the source leaves the visual tree or the mod
+unloads. The classic path updates
 strings stored in active `HMENU` objects, so menu text read through
 accessibility APIs also contains the inserted spaces while the popup is open.
 Rewritten strings are recorded and restored when the popup closes.
@@ -95,7 +96,7 @@ Rewritten strings are recorded and restored when the popup closes.
   $description: Process text in legacy tooltips such as notification-area icon tooltips.
 - modernUiText: false
   $name: Windows 11 context menus and tooltips
-  $description: Process text elements in Explorer XAML context menus and pointer tooltips.
+  $description: Process text elements in Explorer XAML context menus and pointer tooltips. Uses exclusive XAML Diagnostics connections and can conflict with Windows 11 Taskbar Styler, Windows 11 File Explorer Styler, or other diagnostics-based tools.
 - characterMode: unicode
   $name: Non-CJK character set
   $description: Choose which letters and digits form a spacing boundary with CJK.
@@ -1191,126 +1192,6 @@ namespace wf = winrt::Windows::Foundation;
 namespace wux = winrt::Windows::UI::Xaml;
 namespace mux = winrt::Microsoft::UI::Xaml;
 
-struct VisibleModernPopup {
-    DWORD threadId;
-    uint64_t sequence;
-};
-
-std::mutex g_visibleModernPopupsMutex;
-std::unordered_map<HWND, VisibleModernPopup> g_visibleModernPopups;
-uint64_t g_nextModernPopupSequence;
-HWINEVENTHOOK g_modernPopupWinEventHook;
-
-bool IsModernPopupClassName(LPCWSTR className) {
-    return className &&
-           (_wcsicmp(className, L"Xaml_WindowedPopupClass") == 0 ||
-            _wcsicmp(className,
-                     L"Microsoft.UI.Content.PopupWindowSiteBridge") == 0);
-}
-
-bool IsModernPopupWindow(HWND window) {
-    wchar_t className[128];
-    return window &&
-           GetClassNameW(window, className, ARRAYSIZE(className)) > 0 &&
-           IsModernPopupClassName(className);
-}
-
-bool TrackVisibleModernPopup(HWND window, bool requireVisible) {
-    if (!window ||
-        (requireVisible && !IsWindowVisible(window)) ||
-        !IsModernPopupWindow(window)) {
-        return false;
-    }
-
-    DWORD processId;
-    const DWORD threadId =
-        GetWindowThreadProcessId(window, &processId);
-    if (!threadId || processId != GetCurrentProcessId()) {
-        return false;
-    }
-
-    std::lock_guard<std::mutex> guard(g_visibleModernPopupsMutex);
-    g_visibleModernPopups[window] = {
-        threadId, ++g_nextModernPopupSequence};
-    return true;
-}
-
-bool IsTrackedModernPopup(HWND window, DWORD threadId) {
-    std::lock_guard<std::mutex> guard(g_visibleModernPopupsMutex);
-    const auto iterator = g_visibleModernPopups.find(window);
-    return iterator != g_visibleModernPopups.end() &&
-           iterator->second.threadId == threadId &&
-           IsWindow(window) && IsModernPopupWindow(window);
-}
-
-struct FindVisibleModernPopupData {
-    HWND window;
-};
-
-BOOL CALLBACK FindVisibleModernPopupForThread(HWND window, LPARAM parameter) {
-    auto* data =
-        reinterpret_cast<FindVisibleModernPopupData*>(parameter);
-    if (IsWindowVisible(window) && IsModernPopupWindow(window)) {
-        data->window = window;
-        TrackVisibleModernPopup(window, true);
-        return FALSE;
-    }
-
-    return TRUE;
-}
-
-HWND GetMostRecentModernPopupForThread(DWORD threadId) {
-    HWND result = nullptr;
-    uint64_t latestSequence = 0;
-    {
-        std::lock_guard<std::mutex> guard(
-            g_visibleModernPopupsMutex);
-        for (auto iterator = g_visibleModernPopups.begin();
-             iterator != g_visibleModernPopups.end();) {
-            if (!IsWindow(iterator->first) ||
-                !IsModernPopupWindow(iterator->first)) {
-                iterator = g_visibleModernPopups.erase(iterator);
-                continue;
-            }
-
-            if (iterator->second.threadId == threadId &&
-                iterator->second.sequence > latestSequence) {
-                result = iterator->first;
-                latestSequence = iterator->second.sequence;
-            }
-
-            ++iterator;
-        }
-    }
-
-    if (result) {
-        return result;
-    }
-
-    // Covers a popup that was already visible when the mod was enabled.
-    FindVisibleModernPopupData data{};
-    EnumThreadWindows(
-        threadId, FindVisibleModernPopupForThread,
-        reinterpret_cast<LPARAM>(&data));
-    return data.window;
-}
-
-BOOL CALLBACK DiscoverVisibleModernPopup(HWND window, LPARAM) {
-    DWORD processId;
-    GetWindowThreadProcessId(window, &processId);
-    if (processId == GetCurrentProcessId() &&
-        IsWindowVisible(window)) {
-        TrackVisibleModernPopup(window, true);
-    }
-
-    return TRUE;
-}
-
-void ClearVisibleModernPopups() {
-    std::lock_guard<std::mutex> guard(g_visibleModernPopupsMutex);
-    g_visibleModernPopups.clear();
-}
-
 template <typename Element, typename DependencyProperty>
 bool ReadLocalStringValue(const Element& element,
                           DependencyProperty property,
@@ -1371,9 +1252,8 @@ struct TooltipContentAccess {
 class ModernTextStateBase {
 public:
     virtual ~ModernTextStateBase() = default;
-    virtual void Apply(HWND popupWindow) = 0;
-    virtual void Restore(bool clearOwnership) = 0;
-    virtual HWND PopupWindow() const = 0;
+    virtual void Apply() = 0;
+    virtual void Restore() = 0;
 };
 
 template <typename Element, typename SourceAccess>
@@ -1382,23 +1262,12 @@ public:
     explicit ModernTextState(const Element& element)
         : m_element(winrt::make_weak(element)) {}
 
-    void Apply(HWND popupWindow) override {
-        const DWORD threadId = GetCurrentThreadId();
-        if (!g_modernUiText.load(std::memory_order_relaxed) ||
-            !popupWindow ||
-            !IsTrackedModernPopup(popupWindow, threadId)) {
+    void Apply() override {
+        if (!g_modernUiText.load(std::memory_order_relaxed)) {
             return;
         }
 
         try {
-            if (m_popupWindow && m_popupWindow != popupWindow) {
-                if (IsTrackedModernPopup(m_popupWindow, threadId)) {
-                    return;
-                }
-                Restore(true);
-            }
-            m_popupWindow = popupWindow;
-
             auto element = m_element.get();
             if (!element) {
                 return;
@@ -1414,8 +1283,8 @@ public:
                     return;
                 }
 
-                // The application updated the source while the popup was
-                // visible. Preserve that update and use it as the new source.
+                // The application updated the source while it was tracked.
+                // Preserve that update and use it as the new source.
                 m_modified = false;
                 m_originalText.clear();
                 m_spacedText.clear();
@@ -1442,11 +1311,8 @@ public:
         }
     }
 
-    void Restore(bool clearOwnership) override {
+    void Restore() override {
         if (!m_modified) {
-            if (clearOwnership) {
-                m_popupWindow = nullptr;
-            }
             return;
         }
 
@@ -1465,20 +1331,12 @@ public:
         }
 
         m_modified = false;
-        if (clearOwnership) {
-            m_popupWindow = nullptr;
-        }
         m_originalText.clear();
         m_spacedText.clear();
     }
 
-    HWND PopupWindow() const override {
-        return m_popupWindow;
-    }
-
 private:
     winrt::weak_ref<Element> m_element;
-    HWND m_popupWindow = nullptr;
     bool m_modified = false;
     std::wstring m_originalText;
     std::wstring m_spacedText;
@@ -1516,27 +1374,73 @@ using ModernTextStateMap =
                        std::shared_ptr<ModernTextStateBase>,
                        ModernElementKeyHash>;
 
-using ModernElementKeySet =
-    std::unordered_set<ModernElementKey, ModernElementKeyHash>;
-
 struct ModernThreadState {
     ModernTextStateMap states;
-    // Newly observed sources wait for the next popup SHOW. Ownership is kept
-    // across HIDE so another popup can't claim a cached source.
-    ModernElementKeySet pending;
-    std::unordered_map<HWND, ModernElementKeySet> ownedByPopup;
 };
 
 thread_local std::optional<ModernThreadState>
     g_modernTextStatesForThread{std::in_place};
 
 std::mutex g_modernTextStateThreadsMutex;
-std::unordered_set<DWORD> g_modernTextStateThreads;
+std::unordered_map<DWORD, uint64_t> g_modernTextStateThreads;
+
+bool GetThreadCreationTime(HANDLE thread, uint64_t* creationTime) {
+    FILETIME creation;
+    FILETIME exit;
+    FILETIME kernel;
+    FILETIME user;
+    if (!GetThreadTimes(thread, &creation, &exit, &kernel, &user)) {
+        return false;
+    }
+
+    ULARGE_INTEGER value;
+    value.LowPart = creation.dwLowDateTime;
+    value.HighPart = creation.dwHighDateTime;
+    *creationTime = value.QuadPart;
+    return true;
+}
+
+bool IsRegisteredThreadAlive(DWORD threadId, uint64_t creationTime) {
+    HANDLE thread = OpenThread(
+        SYNCHRONIZE | THREAD_QUERY_LIMITED_INFORMATION,
+        FALSE, threadId);
+    if (!thread) {
+        return false;
+    }
+
+    uint64_t currentCreationTime;
+    const bool alive =
+        WaitForSingleObject(thread, 0) == WAIT_TIMEOUT &&
+        GetThreadCreationTime(thread, &currentCreationTime) &&
+        currentCreationTime == creationTime;
+    CloseHandle(thread);
+    return alive;
+}
+
+void PruneModernTextStateThreadsLocked() {
+    for (auto iterator = g_modernTextStateThreads.begin();
+         iterator != g_modernTextStateThreads.end();) {
+        if (!IsRegisteredThreadAlive(iterator->first,
+                                     iterator->second)) {
+            iterator = g_modernTextStateThreads.erase(iterator);
+        } else {
+            ++iterator;
+        }
+    }
+}
 
 void RegisterModernTextStateThread() {
+    uint64_t creationTime;
+    if (!GetThreadCreationTime(GetCurrentThread(),
+                               &creationTime)) {
+        Wh_Log(L"Couldn't read the current thread creation time");
+        return;
+    }
+
     std::lock_guard<std::mutex> guard(
         g_modernTextStateThreadsMutex);
-    g_modernTextStateThreads.insert(GetCurrentThreadId());
+    PruneModernTextStateThreadsLocked();
+    g_modernTextStateThreads[GetCurrentThreadId()] = creationTime;
 }
 
 void UnregisterModernTextStateThread() {
@@ -1545,96 +1449,14 @@ void UnregisterModernTextStateThread() {
     g_modernTextStateThreads.erase(GetCurrentThreadId());
 }
 
-void ApplyModernTextStatesForPopup(HWND popupWindow) {
-    if (!g_modernTextStatesForThread) {
-        return;
-    }
-
-    auto& threadState = *g_modernTextStatesForThread;
-    if (auto ownerIterator =
-            threadState.ownedByPopup.find(popupWindow);
-        ownerIterator != threadState.ownedByPopup.end()) {
-        for (auto iterator = ownerIterator->second.begin();
-             iterator != ownerIterator->second.end();) {
-            const auto stateIterator =
-                threadState.states.find(*iterator);
-            if (stateIterator == threadState.states.end()) {
-                iterator = ownerIterator->second.erase(iterator);
-                continue;
-            }
-
-            stateIterator->second->Apply(popupWindow);
-            ++iterator;
-        }
-    }
-
-    ModernElementKeySet pending;
-    pending.swap(threadState.pending);
-    if (!pending.empty()) {
-        auto& owned = threadState.ownedByPopup[popupWindow];
-        for (const auto& key : pending) {
-            const auto iterator = threadState.states.find(key);
-            if (iterator == threadState.states.end()) {
-                continue;
-            }
-
-            iterator->second->Apply(popupWindow);
-            owned.insert(key);
-        }
-    }
-}
-
-void RestoreModernTextStatesForPopup(HWND popupWindow,
-                                     bool clearOwnership) {
-    if (!g_modernTextStatesForThread) {
-        return;
-    }
-
-    auto& threadState = *g_modernTextStatesForThread;
-    const auto ownerIterator =
-        threadState.ownedByPopup.find(popupWindow);
-    if (ownerIterator == threadState.ownedByPopup.end()) {
-        return;
-    }
-
-    for (const auto& key : ownerIterator->second) {
-        const auto stateIterator = threadState.states.find(key);
-        if (stateIterator == threadState.states.end()) {
-            continue;
-        }
-
-        stateIterator->second->Restore(clearOwnership);
-        if (clearOwnership) {
-            threadState.pending.insert(key);
-        }
-    }
-
-    if (clearOwnership) {
-        threadState.ownedByPopup.erase(ownerIterator);
-    }
-}
-
 void RemoveModernTextState(ModernThreadState& threadState,
                            const ModernElementKey& key) {
-    threadState.pending.erase(key);
     const auto stateIterator = threadState.states.find(key);
     if (stateIterator == threadState.states.end()) {
         return;
     }
 
-    if (const HWND popupWindow =
-            stateIterator->second->PopupWindow()) {
-        if (auto ownerIterator =
-                threadState.ownedByPopup.find(popupWindow);
-            ownerIterator != threadState.ownedByPopup.end()) {
-            ownerIterator->second.erase(key);
-            if (ownerIterator->second.empty()) {
-                threadState.ownedByPopup.erase(ownerIterator);
-            }
-        }
-    }
-
-    stateIterator->second->Restore(true);
+    stateIterator->second->Restore();
     threadState.states.erase(stateIterator);
 }
 
@@ -1645,7 +1467,7 @@ void CleanupModernTextStatesForCurrentThread() {
 
     for (const auto& [key, state] :
          g_modernTextStatesForThread->states) {
-        state->Restore(true);
+        state->Restore();
     }
     g_modernTextStatesForThread.reset();
     UnregisterModernTextStateThread();
@@ -1671,6 +1493,13 @@ public:
                 if (FAILED(result)) {
                     Wh_Log(L"AdviseVisualTreeChange failed: 0x%08X",
                            result);
+                } else {
+                    watcher->m_advised.store(
+                        true, std::memory_order_release);
+                    if (watcher->m_unadviseRequested.load(
+                            std::memory_order_acquire)) {
+                        watcher->UnadviseVisualTreeChange();
+                    }
                 }
                 watcher->Release();
                 return 0;
@@ -1685,6 +1514,13 @@ public:
     }
 
     void UnadviseVisualTreeChange() {
+        m_unadviseRequested.store(true,
+                                  std::memory_order_release);
+        if (!m_advised.exchange(false,
+                                std::memory_order_acq_rel)) {
+            return;
+        }
+
         const HRESULT result =
             m_xamlDiagnostics.as<IVisualTreeService3>()
                 ->UnadviseVisualTreeChange(this);
@@ -1725,15 +1561,7 @@ private:
             RegisterModernTextStateThread();
         }
         threadState.states.emplace(key, state);
-
-        const HWND popupWindow =
-            GetMostRecentModernPopupForThread(GetCurrentThreadId());
-        if (popupWindow) {
-            state->Apply(popupWindow);
-            threadState.ownedByPopup[popupWindow].insert(key);
-        } else {
-            threadState.pending.insert(key);
-        }
+        state->Apply();
         return true;
     }
 
@@ -1818,6 +1646,8 @@ private:
     }
 
     winrt::com_ptr<IXamlDiagnostics> m_xamlDiagnostics;
+    std::atomic_bool m_advised{false};
+    std::atomic_bool m_unadviseRequested{false};
 };
 
 std::mutex g_visualTreeWatchersMutex;
@@ -1825,6 +1655,21 @@ std::mutex g_visualTreeWatchersMutex;
     std::optional<std::vector<winrt::com_ptr<VisualTreeWatcher>>>
         g_visualTreeWatchers{std::in_place};
 std::atomic_bool g_stoppingModernUi{false};
+std::atomic_uint64_t g_visualTreeWatcherGeneration;
+
+bool RemoveVisualTreeWatcher(VisualTreeWatcher* watcher) {
+    std::lock_guard<std::mutex> guard(g_visualTreeWatchersMutex);
+    if (!g_visualTreeWatchers) {
+        return false;
+    }
+
+    const size_t previousSize = g_visualTreeWatchers->size();
+    std::erase_if(*g_visualTreeWatchers,
+                  [watcher](const auto& candidate) {
+                      return candidate.get() == watcher;
+                  });
+    return g_visualTreeWatchers->size() != previousSize;
+}
 
 HMODULE GetCurrentModuleHandle() {
     HMODULE module;
@@ -1845,6 +1690,13 @@ class WindhawkTap
                                winrt::non_agile> {
 public:
     HRESULT STDMETHODCALLTYPE SetSite(IUnknown* site) override try {
+        if (m_watcher) {
+            if (RemoveVisualTreeWatcher(m_watcher.get())) {
+                m_watcher->UnadviseVisualTreeChange();
+            }
+            m_watcher = nullptr;
+        }
+
         m_site.copy_from(site);
         if (!site) {
             return S_OK;
@@ -1855,20 +1707,22 @@ public:
             FreeLibrary(module);
         }
 
-        if (g_stoppingModernUi.load(std::memory_order_relaxed)) {
-            return S_OK;
-        }
-
-        auto watcher =
-            winrt::make_self<VisualTreeWatcher>(m_site);
         {
             std::lock_guard<std::mutex> guard(
                 g_visualTreeWatchersMutex);
-            if (g_visualTreeWatchers) {
-                g_visualTreeWatchers->push_back(watcher);
+            if (g_stoppingModernUi.load(
+                    std::memory_order_relaxed) ||
+                !g_visualTreeWatchers) {
+                return S_OK;
             }
+
+            auto watcher =
+                winrt::make_self<VisualTreeWatcher>(m_site);
+            g_visualTreeWatchers->push_back(watcher);
+            g_visualTreeWatcherGeneration.fetch_add(
+                1, std::memory_order_release);
+            m_watcher = std::move(watcher);
         }
-        m_watcher = std::move(watcher);
         return S_OK;
     } catch (...) {
         const HRESULT result = winrt::to_hresult();
@@ -1951,13 +1805,8 @@ using InitializeXamlDiagnosticsEx_t =
     decltype(&InitializeXamlDiagnosticsEx);
 
 std::mutex g_xamlDiagnosticsInitializationMutex;
-std::mutex g_xamlDiagnosticsWorkerMutex;
 bool g_windowsUiXamlDiagnosticsConnected;
 bool g_microsoftUiXamlDiagnosticsConnected;
-HANDLE g_xamlDiagnosticsWakeEvent;
-HANDLE g_xamlDiagnosticsWorkerThread;
-std::atomic_bool g_stopXamlDiagnosticsWorker{false};
-std::atomic_uint64_t g_nextXamlDiagnosticsAttemptTick{0};
 
 HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
                               LPCWSTR connectionPrefix) {
@@ -1984,6 +1833,10 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
 
     HRESULT result = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
     for (int index = 1; index <= 10000; ++index) {
+        if (g_stoppingModernUi.load(std::memory_order_relaxed)) {
+            return HRESULT_FROM_WIN32(ERROR_CANCELLED);
+        }
+
         wchar_t connectionName[256];
         _snwprintf_s(connectionName, _TRUNCATE, L"%s%d",
                      connectionPrefix, index);
@@ -2005,17 +1858,32 @@ void EnsureModernXamlDiagnostics() {
 
     std::lock_guard<std::mutex> guard(
         g_xamlDiagnosticsInitializationMutex);
+    if (g_stoppingModernUi.load(std::memory_order_relaxed)) {
+        return;
+    }
 
     if (!g_windowsUiXamlDiagnosticsConnected) {
         if (HMODULE module =
                 GetModuleHandleW(L"Windows.UI.Xaml.dll")) {
+            const uint64_t watcherGeneration =
+                g_visualTreeWatcherGeneration.load(
+                    std::memory_order_acquire);
             const HRESULT result = InjectXamlDiagnostics(
                 module, L"VisualDiagConnection");
-            if (SUCCEEDED(result)) {
+            if (SUCCEEDED(result) &&
+                g_visualTreeWatcherGeneration.load(
+                    std::memory_order_acquire) >
+                    watcherGeneration) {
                 g_windowsUiXamlDiagnosticsConnected = true;
                 Wh_Log(L"Connected to Windows.UI.Xaml diagnostics");
+            } else if (SUCCEEDED(result)) {
+                Wh_Log(L"Windows.UI.Xaml diagnostics returned success "
+                       L"without creating a watcher; another diagnostics "
+                       L"tool probably blocked the connection");
             } else if (result !=
-                       HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+                           HRESULT_FROM_WIN32(ERROR_NOT_FOUND) &&
+                       result !=
+                           HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
                 Wh_Log(L"Windows.UI.Xaml diagnostics failed: "
                        L"0x%08X", result);
             }
@@ -2025,13 +1893,25 @@ void EnsureModernXamlDiagnostics() {
     if (!g_microsoftUiXamlDiagnosticsConnected) {
         if (HMODULE module = GetModuleHandleW(
                 L"Microsoft.Internal.FrameworkUdk.dll")) {
+            const uint64_t watcherGeneration =
+                g_visualTreeWatcherGeneration.load(
+                    std::memory_order_acquire);
             const HRESULT result = InjectXamlDiagnostics(
                 module, L"WinUIVisualDiagConnection");
-            if (SUCCEEDED(result)) {
+            if (SUCCEEDED(result) &&
+                g_visualTreeWatcherGeneration.load(
+                    std::memory_order_acquire) >
+                    watcherGeneration) {
                 g_microsoftUiXamlDiagnosticsConnected = true;
                 Wh_Log(L"Connected to Microsoft.UI.Xaml diagnostics");
+            } else if (SUCCEEDED(result)) {
+                Wh_Log(L"Microsoft.UI.Xaml diagnostics returned success "
+                       L"without creating a watcher; another diagnostics "
+                       L"tool probably blocked the connection");
             } else if (result !=
-                       HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
+                           HRESULT_FROM_WIN32(ERROR_NOT_FOUND) &&
+                       result !=
+                           HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
                 Wh_Log(L"Microsoft.UI.Xaml diagnostics failed: "
                        L"0x%08X", result);
             }
@@ -2039,149 +1919,37 @@ void EnsureModernXamlDiagnostics() {
     }
 }
 
-DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
-    const HANDLE wakeEvent = static_cast<HANDLE>(parameter);
-    const HRESULT initializeResult =
-        CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-    while (WaitForSingleObject(wakeEvent, INFINITE) ==
-           WAIT_OBJECT_0) {
-        if (g_stopXamlDiagnosticsWorker.load(
-                std::memory_order_relaxed)) {
-            break;
-        }
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+LoadLibraryExW_t g_originalLoadLibraryExW;
+thread_local bool g_loadingXamlDiagnostics;
+
+bool IsXamlDiagnosticsTriggerModule(LPCWSTR path) {
+    if (!path) {
+        return false;
+    }
+
+    PCWSTR fileName = wcsrchr(path, L'\\');
+    fileName = fileName ? fileName + 1 : path;
+    return _wcsicmp(fileName, L"Windows.UI.Xaml.dll") == 0 ||
+           _wcsicmp(fileName,
+                    L"Microsoft.Internal.FrameworkUdk.dll") == 0 ||
+           _wcsicmp(fileName, L"CoreMessagingXP.dll") == 0;
+}
+
+HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
+                                  HANDLE file,
+                                  DWORD flags) {
+    HMODULE module =
+        g_originalLoadLibraryExW(fileName, file, flags);
+    if (module &&
+        !g_loadingXamlDiagnostics &&
+        g_modernUiText.load(std::memory_order_relaxed) &&
+        IsXamlDiagnosticsTriggerModule(fileName)) {
+        g_loadingXamlDiagnostics = true;
         EnsureModernXamlDiagnostics();
+        g_loadingXamlDiagnostics = false;
     }
-
-    if (SUCCEEDED(initializeResult)) {
-        CoUninitialize();
-    }
-    return 0;
-}
-
-bool StartXamlDiagnosticsWorker() {
-    g_stopXamlDiagnosticsWorker.store(
-        false, std::memory_order_relaxed);
-    const HANDLE wakeEvent =
-        CreateEventW(nullptr, FALSE, FALSE, nullptr);
-    if (!wakeEvent) {
-        return false;
-    }
-
-    const HANDLE workerThread = CreateThread(
-        nullptr, 0, XamlDiagnosticsWorkerProc, wakeEvent, 0, nullptr);
-    if (!workerThread) {
-        CloseHandle(wakeEvent);
-        return false;
-    }
-
-    {
-        std::lock_guard<std::mutex> guard(
-            g_xamlDiagnosticsWorkerMutex);
-        g_xamlDiagnosticsWakeEvent = wakeEvent;
-        g_xamlDiagnosticsWorkerThread = workerThread;
-    }
-    return true;
-}
-
-void RequestXamlDiagnosticsInitialization() {
-    std::lock_guard<std::mutex> guard(
-        g_xamlDiagnosticsWorkerMutex);
-    if (!g_xamlDiagnosticsWakeEvent ||
-        g_stoppingModernUi.load(std::memory_order_relaxed)) {
-        return;
-    }
-
-    const uint64_t now = GetTickCount64();
-    uint64_t next =
-        g_nextXamlDiagnosticsAttemptTick.load(
-            std::memory_order_relaxed);
-    if (now < next ||
-        !g_nextXamlDiagnosticsAttemptTick.compare_exchange_strong(
-            next, now + 10000, std::memory_order_relaxed)) {
-        return;
-    }
-
-    SetEvent(g_xamlDiagnosticsWakeEvent);
-}
-
-void StopXamlDiagnosticsWorker() {
-    HANDLE workerThread;
-    HANDLE wakeEvent;
-    {
-        std::lock_guard<std::mutex> guard(
-            g_xamlDiagnosticsWorkerMutex);
-        workerThread = g_xamlDiagnosticsWorkerThread;
-        wakeEvent = g_xamlDiagnosticsWakeEvent;
-        if (!workerThread) {
-            return;
-        }
-
-        g_xamlDiagnosticsWorkerThread = nullptr;
-        g_xamlDiagnosticsWakeEvent = nullptr;
-        g_stopXamlDiagnosticsWorker.store(
-            true, std::memory_order_relaxed);
-        SetEvent(wakeEvent);
-    }
-
-    WaitForSingleObject(workerThread, INFINITE);
-    CloseHandle(workerThread);
-    CloseHandle(wakeEvent);
-}
-
-void CALLBACK ModernPopupWinEventProc(
-    HWINEVENTHOOK,
-    DWORD event,
-    HWND window,
-    LONG objectId,
-    LONG childId,
-    DWORD,
-    DWORD) {
-    if (!window || objectId != OBJID_WINDOW ||
-        childId != CHILDID_SELF ||
-        !g_modernUiText.load(std::memory_order_relaxed)) {
-        return;
-    }
-
-    if (event == EVENT_OBJECT_DESTROY) {
-        {
-            std::lock_guard<std::mutex> guard(
-                g_visibleModernPopupsMutex);
-            g_visibleModernPopups.erase(window);
-        }
-        // The in-context callback still runs on the popup's UI thread even
-        // after the HWND is no longer valid.
-        RestoreModernTextStatesForPopup(window, true);
-        return;
-    }
-
-    DWORD processId;
-    const DWORD threadId =
-        GetWindowThreadProcessId(window, &processId);
-    if (!threadId || processId != GetCurrentProcessId() ||
-        GetCurrentThreadId() != threadId) {
-        return;
-    }
-
-    if (event == EVENT_OBJECT_SHOW) {
-        if (!TrackVisibleModernPopup(window, false)) {
-            return;
-        }
-
-        RequestXamlDiagnosticsInitialization();
-        ApplyModernTextStatesForPopup(window);
-    } else if (event == EVENT_OBJECT_HIDE) {
-        bool wasTracked;
-        {
-            std::lock_guard<std::mutex> guard(
-                g_visibleModernPopupsMutex);
-            wasTracked =
-                g_visibleModernPopups.erase(window) != 0;
-        }
-
-        if (wasTracked) {
-            RestoreModernTextStatesForPopup(window, false);
-        }
-    }
+    return module;
 }
 
 using RunFromWindowThreadProc_t = void(WINAPI*)(PVOID parameter);
@@ -2228,12 +1996,10 @@ bool RunFromWindowThread(HWND window,
     }
 
     RunParameter run{procedure, parameter};
-    DWORD_PTR messageResult;
-    const LRESULT sent = SendMessageTimeoutW(
-        window, message, 0, reinterpret_cast<LPARAM>(&run),
-        SMTO_ABORTIFHUNG, 5000, &messageResult);
+    SendMessageW(window, message, 0,
+                 reinterpret_cast<LPARAM>(&run));
     UnhookWindowsHookEx(hook);
-    return sent != 0;
+    return true;
 }
 
 HWND FindWindowForThread(DWORD threadId) {
@@ -2254,38 +2020,19 @@ HWND FindWindowForThread(DWORD threadId) {
     return result;
 }
 
-bool InitializeModernUi() {
+void InitializeModernUi() {
     g_stoppingModernUi.store(false, std::memory_order_relaxed);
-    g_nextXamlDiagnosticsAttemptTick.store(
-        0, std::memory_order_relaxed);
-
-    if (!StartXamlDiagnosticsWorker()) {
-        Wh_Log(L"Couldn't start the XAML diagnostics worker");
-        return false;
+    {
+        std::lock_guard<std::mutex> guard(
+            g_visualTreeWatchersMutex);
+        if (!g_visualTreeWatchers) {
+            g_visualTreeWatchers.emplace();
+        }
     }
-
-    g_modernPopupWinEventHook = SetWinEventHook(
-        EVENT_OBJECT_DESTROY, EVENT_OBJECT_HIDE,
-        GetCurrentModuleHandle(), ModernPopupWinEventProc,
-        GetCurrentProcessId(), 0, WINEVENT_INCONTEXT);
-    if (!g_modernPopupWinEventHook) {
-        Wh_Log(L"Couldn't install the modern popup event hook");
-        StopXamlDiagnosticsWorker();
-        return false;
-    }
-
-    EnumWindows(DiscoverVisibleModernPopup, 0);
-    return true;
 }
 
 void UninitializeModernUi() {
     g_stoppingModernUi.store(true, std::memory_order_relaxed);
-
-    if (g_modernPopupWinEventHook) {
-        UnhookWinEvent(g_modernPopupWinEventHook);
-        g_modernPopupWinEventHook = nullptr;
-    }
-    StopXamlDiagnosticsWorker();
 
     std::vector<winrt::com_ptr<VisualTreeWatcher>> watchers;
     {
@@ -2300,18 +2047,23 @@ void UninitializeModernUi() {
         watcher->UnadviseVisualTreeChange();
     }
 
-    std::vector<DWORD> stateThreads;
+    std::vector<std::pair<DWORD, uint64_t>> stateThreads;
     {
         std::lock_guard<std::mutex> guard(
             g_modernTextStateThreadsMutex);
-        stateThreads.assign(
-            g_modernTextStateThreads.begin(),
-            g_modernTextStateThreads.end());
+        PruneModernTextStateThreadsLocked();
+        stateThreads.assign(g_modernTextStateThreads.begin(),
+                            g_modernTextStateThreads.end());
     }
 
-    for (DWORD threadId : stateThreads) {
+    for (const auto& [threadId, creationTime] : stateThreads) {
+        if (!IsRegisteredThreadAlive(threadId, creationTime)) {
+            continue;
+        }
+
         const HWND window = FindWindowForThread(threadId);
         if (!window ||
+            !IsRegisteredThreadAlive(threadId, creationTime) ||
             !RunFromWindowThread(
                 window,
                 [](PVOID) {
@@ -2325,7 +2077,6 @@ void UninitializeModernUi() {
         }
     }
 
-    ClearVisibleModernPopups();
 }
 
 template <typename Function>
@@ -2515,7 +2266,10 @@ BOOL Wh_ModInit() {
     }
 
     if (modernUiTextEnabled) {
-        installedAnyHook |= InitializeModernUi();
+        InitializeModernUi();
+        installedAnyHook |= InstallHook(
+            LoadLibraryExW, LoadLibraryExWHook,
+            &g_originalLoadLibraryExW, L"LoadLibraryExW");
     }
 
     Wh_Log(L"CJK Spacer initialized (classicMenus=%d, "
@@ -2532,7 +2286,7 @@ void Wh_ModAfterInit() {
     }
 
     if (g_modernUiText.load(std::memory_order_relaxed)) {
-        RequestXamlDiagnosticsInitialization();
+        EnsureModernXamlDiagnostics();
     }
 }
 

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.7
+// @version         0.1.8
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -59,11 +59,13 @@ keyboard shortcut text are also preserved.
   display-only DirectWrite hook. Taskbar thumbnail previews and XAML popups
   related to them are explicitly excluded. While an eligible popup is visible,
   other XAML text laid out on the same UI thread can also be transformed;
-  unrelated Explorer threads remain unaffected.
+  unrelated Explorer threads remain unaffected. This path is disabled by
+  default; enable `modernUiText` to opt in.
 
 The modern path is intentionally conservative and can miss text if a Windows
-build uses a different popup window class. Disable `modernUiText` if it causes
-a problem.
+build uses a different popup window class. It remains opt-in because
+DirectWrite doesn't identify the target XAML element; disable `modernUiText`
+again if it causes a problem.
 
 The mod is injected only into `explorer.exe`. Start, Search, and some shell
 flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
@@ -86,7 +88,7 @@ Rewritten strings are recorded and restored when the popup closes.
 - classicTooltips: true
   $name: Classic Win32 tooltips
   $description: Process text in legacy tooltips such as notification-area icon tooltips.
-- modernUiText: true
+- modernUiText: false
   $name: Windows 11 context menus and tooltips (experimental)
   $description: Process DirectWrite text in Explorer XAML context menus and pointer tooltips.
 - characterMode: unicode
@@ -112,7 +114,7 @@ Rewritten strings are recorded and restored when the popup closes.
 
 #include <windows.h>
 
-#include <commctrl.h>
+#include <commctrl.h>  // TOOLTIPS_CLASSW
 #include <dwrite.h>
 #include <uxtheme.h>
 #include <vsstyle.h>
@@ -128,7 +130,7 @@ enum class CharacterKind {
 
 std::atomic_bool g_classicMenus{true};
 std::atomic_bool g_classicTooltips{true};
-std::atomic_bool g_modernUiText{true};
+std::atomic_bool g_modernUiText{false};
 std::atomic_bool g_unicodeLettersAndDigits{true};
 
 bool IsHighSurrogate(wchar_t value) {
@@ -232,6 +234,10 @@ bool IsAsciiLetterOrDigit(uint32_t codePoint) {
 }
 
 bool IsUnicodeLetterOrDigit(uint32_t codePoint) {
+    if (codePoint < 0x80) {
+        return IsAsciiLetterOrDigit(codePoint);
+    }
+
     // Fullwidth Latin letters and digits already have ideographic advance
     // widths, so inserting an extra ASCII space is typographically redundant.
     if (IsInRange(codePoint, 0xFF10, 0xFF19) ||
@@ -407,6 +413,9 @@ void RememberRewrittenMenuItem(HMENU menu,
                                UINT index,
                                std::wstring original,
                                std::wstring spaced);
+int FindMenuItemIndexByText(
+    HMENU menu,
+    const std::wstring& expectedText);
 
 bool IsStringMenuFlags(UINT flags) {
     return !(flags & (MF_BITMAP | MF_OWNERDRAW | MF_SEPARATOR));
@@ -456,12 +465,18 @@ BOOL WINAPI InsertMenuWHook(HMENU menu,
             const BOOL result = g_originalInsertMenuW(
                 menu, position, flags, itemId, spaced.c_str());
             if (result) {
-                const int index = FindMenuItemIndex(
-                    menu,
-                    (flags & MF_BYPOSITION)
-                        ? position
-                        : static_cast<UINT>(itemId),
-                    (flags & MF_BYPOSITION) != 0);
+                int index;
+                if (flags & MF_BYPOSITION) {
+                    index = FindMenuItemIndex(
+                        menu, position, true);
+                } else if (flags & MF_POPUP) {
+                    index = FindMenuItemIndexByText(
+                        menu, spaced);
+                } else {
+                    index = FindMenuItemIndex(
+                        menu, static_cast<UINT>(itemId),
+                        false);
+                }
                 if (index >= 0) {
                     RememberRewrittenMenuItem(
                         menu, static_cast<UINT>(index), newItem, spaced);
@@ -758,8 +773,13 @@ void RewriteMenuTree(HMENU menu, unsigned int depth = 0) {
                     replacement.fMask = MIIM_STRING;
                     replacement.dwTypeData =
                         const_cast<wchar_t*>(spaced.c_str());
-                    if (SetMenuItemInfoW(
-                            menu, index, TRUE, &replacement)) {
+                    const BOOL rewritten =
+                        g_originalSetMenuItemInfoW
+                            ? g_originalSetMenuItemInfoW(
+                                  menu, index, TRUE, &replacement)
+                            : SetMenuItemInfoW(
+                                  menu, index, TRUE, &replacement);
+                    if (rewritten) {
                         RememberRewrittenMenuItem(
                             menu, index, std::move(original), spaced);
                     }
@@ -941,6 +961,12 @@ BOOL CALLBACK EnumExistingClassicTooltipWindow(HWND window, LPARAM) {
 BOOL CALLBACK EnumExistingClassicTooltipTopLevelWindow(
     HWND window,
     LPARAM) {
+    DWORD processId;
+    GetWindowThreadProcessId(window, &processId);
+    if (processId != GetCurrentProcessId()) {
+        return TRUE;
+    }
+
     EnumExistingClassicTooltipWindow(window, 0);
     EnumChildWindows(
         window, EnumExistingClassicTooltipWindow, 0);
@@ -1187,6 +1213,23 @@ std::mutex g_trackedModernWindowsMutex;
 std::unordered_map<HWND, TrackedModernWindow>
     g_trackedModernWindows;
 std::atomic_uint g_trackedModernWindowCount{0};
+std::atomic_uint g_trackedModernPopupCount{0};
+
+void UpdateTrackedModernWindowCountsLocked() {
+    unsigned int popupCount = 0;
+    for (const auto& entry : g_trackedModernWindows) {
+        if (entry.second.kind == ModernWindowKind::Popup) {
+            ++popupCount;
+        }
+    }
+
+    g_trackedModernWindowCount.store(
+        static_cast<unsigned int>(
+            g_trackedModernWindows.size()),
+        std::memory_order_relaxed);
+    g_trackedModernPopupCount.store(
+        popupCount, std::memory_order_relaxed);
+}
 
 ModernWindowKind ClassifyModernWindowClassName(LPCWSTR className) {
     if (!className) {
@@ -1269,10 +1312,7 @@ bool TrackModernWindow(HWND window, ModernWindowKind kind) {
             iterator->second = {threadId, kind};
         }
         inserted = wasInserted;
-        g_trackedModernWindowCount.store(
-            static_cast<unsigned int>(
-                g_trackedModernWindows.size()),
-            std::memory_order_relaxed);
+        UpdateTrackedModernWindowCountsLocked();
     }
 
     if (inserted) {
@@ -1321,10 +1361,11 @@ void ClearTrackedModernWindows() {
         g_trackedModernWindowsMutex);
     g_trackedModernWindows.clear();
     g_trackedModernWindowCount.store(0, std::memory_order_relaxed);
+    g_trackedModernPopupCount.store(0, std::memory_order_relaxed);
 }
 
 bool IsModernPopupActiveForCurrentThread() {
-    if (g_trackedModernWindowCount.load(
+    if (g_trackedModernPopupCount.load(
             std::memory_order_relaxed) == 0) {
         return false;
     }
@@ -1369,10 +1410,7 @@ bool IsModernPopupActiveForCurrentThread() {
         }
 
         if (removedWindow) {
-            g_trackedModernWindowCount.store(
-                static_cast<unsigned int>(
-                    g_trackedModernWindows.size()),
-                std::memory_order_relaxed);
+            UpdateTrackedModernWindowCountsLocked();
         }
     }
 

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -990,9 +990,11 @@ bool TrackModernWindow(HWND window, ModernWindowKind kind) {
             std::memory_order_relaxed);
     }
 
-    Wh_Log(kind == ModernWindowKind::TaskbarThumbnail
-               ? L"Tracking excluded taskbar thumbnail"
-               : L"Tracking modern popup");
+    if (kind == ModernWindowKind::TaskbarThumbnail) {
+        Wh_Log(L"Tracking excluded taskbar thumbnail");
+    } else {
+        Wh_Log(L"Tracking modern popup");
+    }
     return true;
 }
 

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips; modern XAML UI is opt-in and best-effort because it may conflict with other XAML Diagnostics mods
-// @version         0.1.26
+// @version         0.1.27
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -97,10 +97,13 @@ hosted by Explorer. Each named XAML Diagnostics connection allows one consumer,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
 initializing. Connection attempts are scheduled outside the Windows loader
-  path; a single-flight worker retains requests that arrive while it is running,
+  path; one managed worker retains requests that arrive while it is running,
   tracks the Windows.UI.Xaml and Microsoft.UI.Xaml connections independently,
-  and retries only the connection that was lost. The worker pins the mod image
-  until `FreeLibraryAndExitThread`, so it cannot execute unloaded mod code.
+  and retries only the connection that was lost. It doesn't add a module
+  reference: the worker is signaled to stop and joined before Windhawk removes
+  hooks. Asynchronous visual-tree watcher setup threads are tracked by handle
+  and joined at the same point, so the engine's single module reference remains
+  sufficient.
   `Wh_ModAfterInit` covers XAML modules that are already loaded, while the
   `LoadLibraryExW` hook covers modules loaded later, including the
   `CoreMessagingXP.dll` static-import path used by
@@ -176,6 +179,7 @@ also need compatible DC targets to keep sizing consistent; disable
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <windows.h>
@@ -1859,7 +1863,6 @@ void CleanupModernTextStatesForCurrentThread() {
     }
 }
 
-HMODULE AcquireCurrentModuleReference();
 enum class XamlDiagnosticsFlavor {
     None,
     Windows,
@@ -1875,6 +1878,66 @@ extern std::atomic_bool g_windowsUiXamlDiagnosticsAttempted;
 extern std::atomic_bool g_microsoftUiXamlDiagnosticsAttempted;
 extern thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics;
 
+struct XamlWatcherThreadNode {
+    HANDLE thread;
+    XamlWatcherThreadNode* next;
+};
+
+std::mutex g_xamlWatcherThreadsMutex;
+XamlWatcherThreadNode* g_xamlWatcherThreads;
+
+HANDLE CreateTrackedXamlWatcherThread(LPTHREAD_START_ROUTINE startRoutine,
+                                      void* parameter) {
+    auto* node = static_cast<XamlWatcherThreadNode*>(
+        HeapAlloc(GetProcessHeap(), 0, sizeof(XamlWatcherThreadNode)));
+    if (!node) {
+        SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+        return nullptr;
+    }
+
+    std::lock_guard<std::mutex> guard(g_xamlWatcherThreadsMutex);
+    if (g_stoppingModernUi.load(std::memory_order_acquire)) {
+        HeapFree(GetProcessHeap(), 0, node);
+        SetLastError(ERROR_OPERATION_ABORTED);
+        return nullptr;
+    }
+
+    node->thread =
+        CreateThread(nullptr, 0, startRoutine, parameter, 0, nullptr);
+    if (!node->thread) {
+        const DWORD error = GetLastError();
+        HeapFree(GetProcessHeap(), 0, node);
+        SetLastError(error);
+        return nullptr;
+    }
+
+    node->next = g_xamlWatcherThreads;
+    g_xamlWatcherThreads = node;
+    return node->thread;
+}
+
+void WaitForXamlWatcherThreads() {
+    XamlWatcherThreadNode* threads;
+    {
+        std::lock_guard<std::mutex> guard(g_xamlWatcherThreadsMutex);
+        threads = std::exchange(g_xamlWatcherThreads, nullptr);
+    }
+
+    while (threads) {
+        XamlWatcherThreadNode* next = threads->next;
+        const DWORD waitResult =
+            WaitForSingleObject(threads->thread, INFINITE);
+        if (waitResult != WAIT_OBJECT_0) {
+            Wh_Log(L"Couldn't wait for a XAML watcher thread: %u",
+                   waitResult == WAIT_FAILED ? GetLastError()
+                                             : ERROR_GEN_FAILURE);
+        }
+        CloseHandle(threads->thread);
+        HeapFree(GetProcessHeap(), 0, threads);
+        threads = next;
+    }
+}
+
 class VisualTreeWatcher
     : public winrt::implements<VisualTreeWatcher,
                                IVisualTreeServiceCallback2,
@@ -1882,14 +1945,8 @@ class VisualTreeWatcher
 public:
     explicit VisualTreeWatcher(winrt::com_ptr<IUnknown> site)
         : m_xamlDiagnostics(site.as<IXamlDiagnostics>()) {
-        m_moduleReference = AcquireCurrentModuleReference();
-        if (!m_moduleReference) {
-            winrt::throw_hresult(HRESULT_FROM_WIN32(GetLastError()));
-        }
-
         AddRef();
-        HANDLE thread = CreateThread(
-            nullptr, 0,
+        HANDLE thread = CreateTrackedXamlWatcherThread(
             [](LPVOID parameter) -> DWORD {
                 auto* watcher =
                     static_cast<VisualTreeWatcher*>(parameter);
@@ -1915,19 +1972,16 @@ public:
                         watcher->UnadviseVisualTreeChange();
                     }
                 }
-                HMODULE module = watcher->m_moduleReference;
                 watcher->Release();
-                FreeLibraryAndExitThread(module, 0);
+                return 0;
             },
-            this, 0, nullptr);
-        if (thread) {
-            CloseHandle(thread);
-        } else {
+            this);
+        if (!thread) {
             const DWORD error = GetLastError();
             Release();
-            FreeLibrary(m_moduleReference);
-            m_moduleReference = nullptr;
-            Wh_Log(L"Couldn't create XAML watcher thread");
+            if (error != ERROR_OPERATION_ABORTED) {
+                Wh_Log(L"Couldn't create XAML watcher thread: %u", error);
+            }
             winrt::throw_hresult(HRESULT_FROM_WIN32(error));
         }
     }
@@ -2083,7 +2137,6 @@ private:
     }
 
     winrt::com_ptr<IXamlDiagnostics> m_xamlDiagnostics;
-    HMODULE m_moduleReference = nullptr;
     std::atomic_bool m_advised{false};
     std::atomic_bool m_unadviseRequested{false};
 };
@@ -2115,19 +2168,6 @@ HMODULE GetCurrentModuleHandle() {
             GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
                 GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
             reinterpret_cast<LPCWSTR>(&GetCurrentModuleHandle),
-            &module)) {
-        return nullptr;
-    }
-
-    return module;
-}
-
-HMODULE AcquireCurrentModuleReference() {
-    HMODULE module;
-    if (!GetModuleHandleExW(
-            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-            reinterpret_cast<LPCWSTR>(
-                &AcquireCurrentModuleReference),
             &module)) {
         return nullptr;
     }
@@ -2283,8 +2323,10 @@ std::atomic_bool g_windowsUiXamlDiagnosticsConnected{false};
 std::atomic_bool g_microsoftUiXamlDiagnosticsConnected{false};
 std::atomic_bool g_windowsUiXamlDiagnosticsAttempted{false};
 std::atomic_bool g_microsoftUiXamlDiagnosticsAttempted{false};
-std::atomic_bool g_xamlDiagnosticsWorkerRunning{false};
 std::atomic_bool g_xamlDiagnosticsRequestPending{false};
+std::mutex g_xamlDiagnosticsWorkerMutex;
+HANDLE g_xamlDiagnosticsWorkerThread;
+HANDLE g_xamlDiagnosticsWorkerWakeEvent;
 thread_local bool g_loadingXamlDiagnostics;
 thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics =
     XamlDiagnosticsFlavor::None;
@@ -2437,6 +2479,30 @@ bool NeedsXamlDiagnosticsConnection() {
             GetModuleHandleW(L"Microsoft.Internal.FrameworkUdk.dll"));
 }
 
+DWORD WINAPI XamlDiagnosticsWorkerProc(LPVOID parameter) {
+    const HANDLE wakeEvent = static_cast<HANDLE>(parameter);
+    const HRESULT initializeResult =
+        CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    for (;;) {
+        const DWORD waitResult = WaitForSingleObject(wakeEvent, INFINITE);
+        if (waitResult != WAIT_OBJECT_0 ||
+            g_stoppingModernUi.load(std::memory_order_acquire)) {
+            break;
+        }
+
+        while (!g_stoppingModernUi.load(std::memory_order_acquire) &&
+               g_xamlDiagnosticsRequestPending.exchange(
+                   false, std::memory_order_acq_rel)) {
+            EnsureModernXamlDiagnostics();
+        }
+    }
+
+    if (SUCCEEDED(initializeResult)) {
+        CoUninitialize();
+    }
+    return 0;
+}
+
 void RequestModernXamlDiagnosticsInitialization(
     XamlDiagnosticsFlavor retryFlavor) {
     if (g_stoppingModernUi.load(std::memory_order_acquire)) {
@@ -2463,65 +2529,44 @@ void RequestModernXamlDiagnosticsInitialization(
     g_xamlDiagnosticsRequestPending.store(
         true, std::memory_order_release);
 
-    bool expected = false;
-    if (!g_xamlDiagnosticsWorkerRunning.compare_exchange_strong(
-            expected, true, std::memory_order_acq_rel)) {
+    std::lock_guard<std::mutex> guard(
+        g_xamlDiagnosticsWorkerMutex);
+    if (g_stoppingModernUi.load(std::memory_order_acquire) ||
+        !g_xamlDiagnosticsWorkerWakeEvent) {
         return;
     }
 
-    // Do not hold a mutex across these calls. The request can originate from
-    // LoadLibraryExW, whose caller may still own the Windows loader lock.
-    // The worker isn't joined during unload, so keep the mod image loaded
-    // until the worker exits through FreeLibraryAndExitThread.
-    HMODULE module = AcquireCurrentModuleReference();
-    if (!module) {
-        if (!g_stoppingModernUi.load(std::memory_order_acquire)) {
-            g_xamlDiagnosticsWorkerRunning.store(
-                false, std::memory_order_release);
-            Wh_Log(L"Couldn't retain the mod for XAML diagnostics");
+    SetEvent(g_xamlDiagnosticsWorkerWakeEvent);
+}
+
+void StopModernXamlDiagnosticsWorker() {
+    HANDLE thread;
+    HANDLE wakeEvent;
+    {
+        std::lock_guard<std::mutex> guard(
+            g_xamlDiagnosticsWorkerMutex);
+        thread = std::exchange(g_xamlDiagnosticsWorkerThread, nullptr);
+        wakeEvent = std::exchange(
+            g_xamlDiagnosticsWorkerWakeEvent, nullptr);
+        if (wakeEvent) {
+            SetEvent(wakeEvent);
         }
-        return;
     }
 
-    HANDLE thread = CreateThread(
-        nullptr, 0,
-        [](LPVOID parameter) -> DWORD {
-            const HMODULE module = static_cast<HMODULE>(parameter);
-            const HRESULT initializeResult =
-                CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-            while (!g_stoppingModernUi.load(std::memory_order_acquire) &&
-                   g_xamlDiagnosticsRequestPending.exchange(
-                       false, std::memory_order_acq_rel)) {
-                EnsureModernXamlDiagnostics();
-            }
-            if (SUCCEEDED(initializeResult)) {
-                CoUninitialize();
-            }
-
-            if (!g_stoppingModernUi.load(std::memory_order_acquire)) {
-                g_xamlDiagnosticsWorkerRunning.store(
-                    false, std::memory_order_release);
-                if (g_xamlDiagnosticsRequestPending.load(
-                        std::memory_order_acquire)) {
-                    RequestModernXamlDiagnosticsInitialization();
-                }
-            }
-            FreeLibraryAndExitThread(module, 0);
-        },
-        module, 0, nullptr);
-    if (!thread) {
-        const DWORD error = GetLastError();
-        if (!g_stoppingModernUi.load(std::memory_order_acquire)) {
-            g_xamlDiagnosticsWorkerRunning.store(
-                false, std::memory_order_release);
-            Wh_Log(L"Couldn't create the XAML diagnostics thread: %u",
-                   error);
+    if (thread) {
+        const DWORD waitResult = WaitForSingleObject(thread, INFINITE);
+        if (waitResult != WAIT_OBJECT_0) {
+            Wh_Log(L"Couldn't wait for the XAML diagnostics thread: %u",
+                   waitResult == WAIT_FAILED ? GetLastError()
+                                             : ERROR_GEN_FAILURE);
         }
-        FreeLibrary(module);
-        return;
+        CloseHandle(thread);
     }
-
-    CloseHandle(thread);
+    if (wakeEvent) {
+        CloseHandle(wakeEvent);
+    }
+    g_xamlDiagnosticsRequestPending.store(
+        false, std::memory_order_release);
 }
 
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
@@ -2681,7 +2726,7 @@ HWND FindWindowForThread(DWORD threadId) {
     return parameter.xamlHost ? parameter.xamlHost : parameter.first;
 }
 
-void InitializeModernUi() {
+bool InitializeModernUi() {
     g_stoppingModernUi.store(true, std::memory_order_release);
     g_windowsUiXamlDiagnosticsConnected.store(
         false, std::memory_order_release);
@@ -2691,12 +2736,33 @@ void InitializeModernUi() {
         false, std::memory_order_release);
     g_microsoftUiXamlDiagnosticsAttempted.store(
         false, std::memory_order_release);
-    g_xamlDiagnosticsWorkerRunning.store(
-        false, std::memory_order_release);
     g_xamlDiagnosticsRequestPending.store(
         false, std::memory_order_release);
     g_visualTreeWatcherGeneration.store(
         0, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> guard(
+            g_xamlDiagnosticsWorkerMutex);
+        g_xamlDiagnosticsWorkerThread = nullptr;
+        g_xamlDiagnosticsWorkerWakeEvent =
+            CreateEventW(nullptr, FALSE, FALSE, nullptr);
+        if (!g_xamlDiagnosticsWorkerWakeEvent) {
+            Wh_Log(L"Couldn't create the XAML diagnostics worker event: %u",
+                   GetLastError());
+            return false;
+        }
+        g_xamlDiagnosticsWorkerThread = CreateThread(
+            nullptr, 0, XamlDiagnosticsWorkerProc,
+            g_xamlDiagnosticsWorkerWakeEvent, 0, nullptr);
+        if (!g_xamlDiagnosticsWorkerThread) {
+            const DWORD error = GetLastError();
+            CloseHandle(g_xamlDiagnosticsWorkerWakeEvent);
+            g_xamlDiagnosticsWorkerWakeEvent = nullptr;
+            Wh_Log(L"Couldn't create the XAML diagnostics thread: %u",
+                   error);
+            return false;
+        }
+    }
     {
         std::lock_guard<std::mutex> guard(
             g_visualTreeWatchersMutex);
@@ -2710,10 +2776,13 @@ void InitializeModernUi() {
         g_modernTextStateThreads.clear();
     }
     g_stoppingModernUi.store(false, std::memory_order_release);
+    return true;
 }
 
 void UninitializeModernUi() {
     g_stoppingModernUi.store(true, std::memory_order_release);
+    StopModernXamlDiagnosticsWorker();
+    WaitForXamlWatcherThreads();
 
     std::vector<winrt::com_ptr<VisualTreeWatcher>> watchers;
     {
@@ -2943,7 +3012,9 @@ BOOL Wh_ModInit() {
             Wh_Log(L"Couldn't find kernelbase!LoadLibraryExW");
             return FALSE;
         }
-        InitializeModernUi();
+        if (!InitializeModernUi()) {
+            return FALSE;
+        }
     }
 
     Wh_Log(L"Initialized (classicMenus=%d, "
@@ -2966,9 +3037,12 @@ void Wh_ModAfterInit() {
 
 void Wh_ModBeforeUninit() {
     if (g_modernUiText.load(std::memory_order_relaxed)) {
-        // Stop new COM callbacks before Windhawk begins removing function
-        // hooks. UninitializeModernUi performs the owning-thread restoration.
+        // Stop new COM callbacks and wait for the diagnostics worker before
+        // Windhawk begins removing hooks. UninitializeModernUi performs the
+        // owning-thread restoration after hook removal.
         g_stoppingModernUi.store(true, std::memory_order_release);
+        StopModernXamlDiagnosticsWorker();
+        WaitForXamlWatcherThreads();
     }
 }
 

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer menus, tooltips, and popups
-// @version         0.1.2
+// @version         0.1.3
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -54,7 +54,8 @@ keyboard shortcut text are also preserved.
 - Windows 11 XAML/WinUI popup text uses an experimental, display-only
   DirectWrite hook. This includes context menus, tooltips, and other Explorer
   flyouts. Tracking is scoped to the popup's UI thread so it doesn't enable
-  rewriting on unrelated Explorer or taskbar threads.
+  rewriting on unrelated Explorer or taskbar threads. Taskbar thumbnail
+  previews are explicitly excluded.
 
 The modern path is intentionally conservative and can miss text if a Windows
 build uses a different popup window class. Disable `modernUiText` if it causes
@@ -927,30 +928,49 @@ ShowWindow_t g_originalShowWindow;
 SetWindowPos_t g_originalSetWindowPos;
 DestroyWindow_t g_originalDestroyWindow;
 
-struct TrackedModernPopup {
-    DWORD threadId;
+enum class ModernWindowKind {
+    Other,
+    Popup,
+    TaskbarThumbnail,
 };
 
-std::mutex g_trackedModernPopupsMutex;
-std::unordered_map<HWND, TrackedModernPopup>
-    g_trackedModernPopups;
-std::atomic_uint g_trackedModernPopupCount{0};
+struct TrackedModernWindow {
+    DWORD threadId;
+    ModernWindowKind kind;
+};
 
-bool IsModernPopupClassName(LPCWSTR className) {
-    return className &&
-           (_wcsicmp(className, L"Xaml_WindowedPopupClass") == 0 ||
-           _wcsicmp(className,
-                    L"Microsoft.UI.Content.PopupWindowSiteBridge") == 0);
+std::mutex g_trackedModernWindowsMutex;
+std::unordered_map<HWND, TrackedModernWindow>
+    g_trackedModernWindows;
+std::atomic_uint g_trackedModernWindowCount{0};
+
+ModernWindowKind ClassifyModernWindowClassName(LPCWSTR className) {
+    if (!className) {
+        return ModernWindowKind::Other;
+    }
+
+    if (_wcsicmp(className, L"Xaml_WindowedPopupClass") == 0 ||
+        _wcsicmp(className,
+                 L"Microsoft.UI.Content.PopupWindowSiteBridge") == 0) {
+        return ModernWindowKind::Popup;
+    }
+
+    if (_wcsicmp(className, L"TaskListThumbnailWnd") == 0) {
+        return ModernWindowKind::TaskbarThumbnail;
+    }
+
+    return ModernWindowKind::Other;
 }
 
-bool IsModernPopupWindow(HWND window) {
+ModernWindowKind ClassifyModernWindow(HWND window) {
     wchar_t className[128];
     const int length = GetClassNameW(window, className, ARRAYSIZE(className));
-    return length > 0 && IsModernPopupClassName(className);
+    return length > 0 ? ClassifyModernWindowClassName(className)
+                      : ModernWindowKind::Other;
 }
 
-bool TrackModernPopup(HWND window) {
-    if (!window) {
+bool TrackModernWindow(HWND window, ModernWindowKind kind) {
+    if (!window || kind == ModernWindowKind::Other) {
         return false;
     }
 
@@ -962,71 +982,85 @@ bool TrackModernPopup(HWND window) {
 
     {
         std::lock_guard<std::mutex> guard(
-            g_trackedModernPopupsMutex);
-        g_trackedModernPopups[window] = {threadId};
-        g_trackedModernPopupCount.store(
+            g_trackedModernWindowsMutex);
+        g_trackedModernWindows[window] = {threadId, kind};
+        g_trackedModernWindowCount.store(
             static_cast<unsigned int>(
-                g_trackedModernPopups.size()),
+                g_trackedModernWindows.size()),
             std::memory_order_relaxed);
     }
 
-    Wh_Log(L"Tracking modern popup");
+    Wh_Log(kind == ModernWindowKind::TaskbarThumbnail
+               ? L"Tracking excluded taskbar thumbnail"
+               : L"Tracking modern popup");
     return true;
 }
 
-void UntrackModernPopup(HWND window) {
+bool TrackModernWindowIfRelevant(HWND window) {
+    const ModernWindowKind kind = ClassifyModernWindow(window);
+    return TrackModernWindow(window, kind);
+}
+
+void UntrackModernWindow(HWND window) {
     std::lock_guard<std::mutex> guard(
-        g_trackedModernPopupsMutex);
-    g_trackedModernPopups.erase(window);
-    g_trackedModernPopupCount.store(
-        static_cast<unsigned int>(g_trackedModernPopups.size()),
+        g_trackedModernWindowsMutex);
+    g_trackedModernWindows.erase(window);
+    g_trackedModernWindowCount.store(
+        static_cast<unsigned int>(g_trackedModernWindows.size()),
         std::memory_order_relaxed);
 }
 
-bool IsModernPopupTracked(HWND window) {
-    if (g_trackedModernPopupCount.load(
+bool IsModernWindowTracked(HWND window) {
+    if (g_trackedModernWindowCount.load(
             std::memory_order_relaxed) == 0) {
         return false;
     }
 
     std::lock_guard<std::mutex> guard(
-        g_trackedModernPopupsMutex);
-    return g_trackedModernPopups.contains(window);
+        g_trackedModernWindowsMutex);
+    return g_trackedModernWindows.contains(window);
 }
 
-void ClearTrackedModernPopups() {
+void ClearTrackedModernWindows() {
     std::lock_guard<std::mutex> guard(
-        g_trackedModernPopupsMutex);
-    g_trackedModernPopups.clear();
-    g_trackedModernPopupCount.store(0, std::memory_order_relaxed);
+        g_trackedModernWindowsMutex);
+    g_trackedModernWindows.clear();
+    g_trackedModernWindowCount.store(0, std::memory_order_relaxed);
 }
 
 bool IsModernPopupActiveForCurrentThread() {
     const DWORD currentThreadId = GetCurrentThreadId();
-    bool active = false;
+    bool popupActive = false;
+    bool taskbarThumbnailActive = false;
 
     std::lock_guard<std::mutex> guard(
-        g_trackedModernPopupsMutex);
-    for (auto iterator = g_trackedModernPopups.begin();
-         iterator != g_trackedModernPopups.end();) {
+        g_trackedModernWindowsMutex);
+    for (auto iterator = g_trackedModernWindows.begin();
+         iterator != g_trackedModernWindows.end();) {
         if (!IsWindow(iterator->first)) {
-            iterator = g_trackedModernPopups.erase(iterator);
-            g_trackedModernPopupCount.store(
+            iterator = g_trackedModernWindows.erase(iterator);
+            g_trackedModernWindowCount.store(
                 static_cast<unsigned int>(
-                    g_trackedModernPopups.size()),
+                    g_trackedModernWindows.size()),
                 std::memory_order_relaxed);
             continue;
         }
 
         if (iterator->second.threadId == currentThreadId &&
             IsWindowVisible(iterator->first)) {
-            active = true;
+            if (iterator->second.kind ==
+                ModernWindowKind::TaskbarThumbnail) {
+                taskbarThumbnailActive = true;
+            } else if (iterator->second.kind ==
+                       ModernWindowKind::Popup) {
+                popupActive = true;
+            }
         }
 
         ++iterator;
     }
 
-    return active;
+    return popupActive && !taskbarThumbnailActive;
 }
 
 BOOL WINAPI ShowWindowHook(HWND window, int command) {
@@ -1034,20 +1068,22 @@ BOOL WINAPI ShowWindowHook(HWND window, int command) {
         g_modernUiText.load(std::memory_order_relaxed);
     const bool showing = command != SW_HIDE;
     if (!modernUiEnabled &&
-        g_trackedModernPopupCount.load(
+        g_trackedModernWindowCount.load(
             std::memory_order_relaxed) == 0) {
         return g_originalShowWindow(window, command);
     }
 
-    bool tracked = IsModernPopupTracked(window);
+    bool tracked = IsModernWindowTracked(window);
 
     if (!tracked) {
-        if (!modernUiEnabled || !showing ||
-            !IsModernPopupWindow(window)) {
+        if (!modernUiEnabled || !showing) {
             return g_originalShowWindow(window, command);
         }
 
-        tracked = TrackModernPopup(window);
+        tracked = TrackModernWindowIfRelevant(window);
+        if (!tracked) {
+            return g_originalShowWindow(window, command);
+        }
     }
 
     const BOOL result = g_originalShowWindow(window, command);
@@ -1055,7 +1091,7 @@ BOOL WINAPI ShowWindowHook(HWND window, int command) {
     if (tracked &&
         (!showing || !IsWindow(window) ||
          !IsWindowVisible(window))) {
-        UntrackModernPopup(window);
+        UntrackModernWindow(window);
     }
 
     return result;
@@ -1072,22 +1108,26 @@ BOOL WINAPI SetWindowPosHook(HWND window,
         g_modernUiText.load(std::memory_order_relaxed);
     const bool showing = (flags & SWP_SHOWWINDOW) != 0;
     if ((!modernUiEnabled || !showing) &&
-        g_trackedModernPopupCount.load(
+        g_trackedModernWindowCount.load(
             std::memory_order_relaxed) == 0) {
         return g_originalSetWindowPos(
             window, insertAfter, x, y, width, height, flags);
     }
 
-    bool tracked = IsModernPopupTracked(window);
+    bool tracked = IsModernWindowTracked(window);
 
     if (!tracked) {
-        if (!modernUiEnabled || !showing ||
-            !IsModernPopupWindow(window)) {
+        if (!modernUiEnabled ||
+            (!showing && !IsWindowVisible(window))) {
             return g_originalSetWindowPos(
                 window, insertAfter, x, y, width, height, flags);
         }
 
-        tracked = TrackModernPopup(window);
+        tracked = TrackModernWindowIfRelevant(window);
+        if (!tracked) {
+            return g_originalSetWindowPos(
+                window, insertAfter, x, y, width, height, flags);
+        }
     }
 
     const BOOL result = g_originalSetWindowPos(
@@ -1095,16 +1135,15 @@ BOOL WINAPI SetWindowPosHook(HWND window,
 
     if (tracked &&
         (!result || (flags & SWP_HIDEWINDOW) ||
-         !IsWindow(window) ||
-         (showing && !IsWindowVisible(window)))) {
-        UntrackModernPopup(window);
+         !IsWindow(window) || !IsWindowVisible(window))) {
+        UntrackModernWindow(window);
     }
 
     return result;
 }
 
 BOOL WINAPI DestroyWindowHook(HWND window) {
-    UntrackModernPopup(window);
+    UntrackModernWindow(window);
     return g_originalDestroyWindow(window);
 }
 
@@ -1485,7 +1524,7 @@ BOOL Wh_ModInit() {
 
 void Wh_ModUninit() {
     RestoreRewrittenMenuItems();
-    ClearTrackedModernPopups();
+    ClearTrackedModernWindows();
     Wh_Log(L"CJK Spacer uninitialized");
 }
 
@@ -1502,7 +1541,7 @@ void Wh_ModSettingsChanged() {
     }
     if (modernUiWasEnabled &&
         !g_modernUiText.load(std::memory_order_relaxed)) {
-        ClearTrackedModernPopups();
+        ClearTrackedModernWindows();
     }
 
     Wh_Log(L"CJK Spacer settings changed (classicMenus=%d, "

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips; modern XAML UI is opt-in and best-effort because it may conflict with other XAML Diagnostics mods
-// @version         0.1.22
+// @version         0.1.23
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -30,7 +30,10 @@ XAML Diagnostics connection permits only one consumer, and tools such as
 Taskbar Styler or File Explorer Styler may already use or block those
 connections. Enable it explicitly if you want those menus and pointer
 tooltips processed. `classicMenus` still covers the Win32 menu opened through
-"Show more options".
+"Show more options". The modern path is intentionally retained as an opt-in,
+best-effort implementation because it covers the primary Windows 11 menu; the
+connection conflict is left visible to the user rather than silently dropping
+that coverage.
 
 Examples:
 
@@ -78,8 +81,9 @@ excluded.
 - Windows 11 XAML context menus and pointer tooltips are handled at the XAML
   source-element level. Only plain local string values in the `Text` source of
   XAML menu items and `ToolTip.Content` are changed; bindings, styles,
-  presenter `TextBlock` values, ordinary XAML text, and taskbar thumbnail
-  previews are untouched. A source is changed when XAML Diagnostics reports
+  presenter `TextBlock` values and ordinary XAML text are untouched. Taskbar
+  thumbnail preview content is normally not a plain local string and therefore
+  is not changed. A source is changed when XAML Diagnostics reports
   that it was added and restored when it is removed or the mod unloads. This
   path is disabled by default; enable `modernUiText` to opt in.
 
@@ -118,9 +122,16 @@ accessibility APIs also contains the inserted spaces while the popup is open.
 Other menu-cleanup mods that match items by their displayed text, such as
 Remove Context Menu Items, may therefore need rules that account for the
 temporary spaces while the popup is open.
+Text Replace targets the same classic menu APIs but performs literal
+substitutions, so it cannot express this CJK/non-CJK boundary rule; when both
+mods are enabled, their hook order can affect which temporary text each sees.
 Rewritten strings are recorded and restored when the popup closes. If multiple
 items have identical rewritten text, text-based fallback restoration can select
 the first match; the idempotent transformation does not compound spaces.
+If a displayed popup item is changed dynamically, Windows may not remeasure it;
+the added spaces can clip on uncommon paths. Tooltip measurement and drawing
+also need compatible DC targets to keep sizing consistent; disable
+`classicTooltips` if a specific control clips after spacing.
 */
 // ==/WindhawkModReadme==
 
@@ -128,7 +139,7 @@ the first match; the idempotent transformation does not compound spaces.
 /*
 - classicMenus: true
   $name: Classic context menus
-  $description: Process classic Win32 popup-menu text.
+  $description: Process classic Win32 popup-menu text; temporary live-menu changes can affect other text-matching menu mods while the popup is open.
 - classicTooltips: true
   $name: Classic Win32 tooltips
   $description: Process text in legacy tooltips such as notification-area icon tooltips.
@@ -308,6 +319,9 @@ bool IsUnicodeLetterOrDigit(uint32_t codePoint) {
         return false;
     }
 
+    // GetStringTypeW classifies UTF-16 code units. Supplementary-plane
+    // letters represented by surrogate pairs therefore aren't reliably
+    // reported as Unicode letters/digits and remain Other in unicode mode.
     wchar_t utf16[2];
     int length;
 
@@ -804,12 +818,16 @@ BOOL WINAPI InsertMenuItemWHook(HMENU menu,
             const BOOL result = g_originalInsertMenuItemW(
                 menu, item, byPosition, &copy);
             if (result) {
-                const int index = FindMenuItemIndex(
-                    menu,
-                    byPosition || !(itemInfo->fMask & MIIM_ID)
-                        ? item
-                        : itemInfo->wID,
-                    byPosition != FALSE);
+                // Without MIIM_ID, item identifies the insertion anchor, not
+                // the new item. Leave the index unknown so restoration uses
+                // the spaced text fallback instead of recording the anchor.
+                const int index =
+                    !byPosition && !(itemInfo->fMask & MIIM_ID)
+                        ? -1
+                        : FindMenuItemIndex(
+                              menu,
+                              byPosition ? item : itemInfo->wID,
+                              byPosition != FALSE);
                 const int insertedIndex =
                     index >= 0
                         ? index
@@ -1155,7 +1173,7 @@ void CloseDiscoveredClassicTooltipThemes() {
     }
 
     for (HTHEME theme : g_discoveredClassicTooltipThemes) {
-        g_originalCloseThemeData(theme);
+        CloseThemeData(theme);
     }
     g_discoveredClassicTooltipThemes.clear();
 }
@@ -1194,8 +1212,11 @@ HTHEME WINAPI OpenThemeDataForDpiHook(HWND window,
 }
 
 HRESULT WINAPI CloseThemeDataHook(HTHEME theme) {
-    UntrackClassicTooltipTheme(theme);
-    return g_originalCloseThemeData(theme);
+    const HRESULT result = g_originalCloseThemeData(theme);
+    if (SUCCEEDED(result)) {
+        UntrackClassicTooltipTheme(theme);
+    }
+    return result;
 }
 
 bool IsClassicTooltipTextPart(int partId) {
@@ -2121,17 +2142,7 @@ void EnsureModernXamlDiagnostics(uint64_t generation) {
         return;
     }
 
-    struct LoadingGuard {
-        explicit LoadingGuard(bool& flag) : flag(flag) {
-            flag = true;
-        }
-
-        ~LoadingGuard() {
-            flag = false;
-        }
-
-        bool& flag;
-    } loadingGuard(g_loadingXamlDiagnostics);
+    ScopedBoolValue loadingGuard(g_loadingXamlDiagnostics, true);
 
     std::lock_guard<std::mutex> guard(
         g_xamlDiagnosticsInitializationMutex);

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -1,14 +1,13 @@
 // ==WindhawkMod==
 // @id              cjk-spacer
 // @name            CJK Spacer
-// @description     Add spaces between CJK characters and letters or digits in Explorer menus and tooltips
+// @description     Add spaces between CJK characters and letters or digits in Explorer menus, tooltips, and popups
 // @version         0.1.2
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32
 // ==/WindhawkMod==
 
 // Source code is published under the GNU General Public License v3.0.
@@ -52,19 +51,20 @@ keyboard shortcut text are also preserved.
 - Classic Win32 tooltips, including legacy notification-area icon tooltips, are
   rewritten only through theme handles opened for the `TOOLTIP` class, covering
   both text measurement and drawing without touching unrelated GDI text.
-- Windows 11 context menus and XAML/WinUI tooltips use an experimental,
-  display-only DirectWrite hook. UI Automation is used when a popup is shown to
-  distinguish menus and tooltips from other Explorer flyouts.
+- Windows 11 XAML/WinUI popup text uses an experimental, display-only
+  DirectWrite hook. This includes context menus, tooltips, and other Explorer
+  flyouts. Tracking is scoped to the popup's UI thread so it doesn't enable
+  rewriting on unrelated Explorer or taskbar threads.
 
 The modern path is intentionally conservative and can miss text if a Windows
-build exposes a different popup accessibility tree. Disable `modernUiText` if
-it causes a problem.
+build uses a different popup window class. Disable `modernUiText` if it causes
+a problem.
 
 The mod doesn't edit system files, registry values, or file names. The modern
 DirectWrite path changes display text only. The classic path updates strings
 stored in `HMENU` objects, so menu text read through accessibility APIs also
-contains the inserted spaces. Resource-loaded classic menus can retain those
-strings after the mod is disabled until Explorer restarts.
+contains the inserted spaces while the mod is enabled. Strings rewritten just
+before display are recorded and restored when the mod is disabled.
 */
 // ==/WindhawkModReadme==
 
@@ -77,8 +77,8 @@ strings after the mod is disabled until Explorer restarts.
   $name: Classic Win32 tooltips
   $description: Process text in legacy tooltips such as notification-area icon tooltips.
 - modernUiText: true
-  $name: Windows 11 menus and tooltips (experimental)
-  $description: Process DirectWrite text in Explorer XAML/WinUI context menus and tooltips.
+  $name: Windows 11 popup text (experimental)
+  $description: Process DirectWrite text in Explorer XAML/WinUI menus, tooltips, and flyouts.
 - characterMode: unicode
   $name: Non-CJK character set
   $description: Choose which letters and digits form a spacing boundary with CJK.
@@ -88,16 +88,18 @@ strings after the mod is disabled until Explorer restarts.
 */
 // ==/WindhawkModSettings==
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
+#include <cstring>
 #include <cwchar>
+#include <mutex>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include <dwrite.h>
-#include <initguid.h>
-#include <uiautomation.h>
 #include <uxtheme.h>
 #include <windows.h>
 
@@ -114,7 +116,6 @@ std::atomic_bool g_classicMenus{true};
 std::atomic_bool g_classicTooltips{true};
 std::atomic_bool g_modernUiText{true};
 std::atomic_bool g_unicodeLettersAndDigits{true};
-std::atomic_uint g_activeModernPopupCount{0};
 
 bool IsHighSurrogate(wchar_t value) {
     return value >= 0xD800 && value <= 0xDBFF;
@@ -272,10 +273,6 @@ bool NeedsSpace(CharacterKind left, CharacterKind right) {
            (left == CharacterKind::Word && right == CharacterKind::Cjk);
 }
 
-// A token is a base code point, its combining marks/variation selectors, and
-// an optional Win32 mnemonic '&' prefix. Keeping the prefix in the token makes
-// "打开&Open" become "打开 &Open", which Windows displays as "打开 Open"
-// while preserving the O mnemonic.
 bool ContainsCjkCodePoint(std::wstring_view text) {
     size_t offset = 0;
     while (offset < text.size()) {
@@ -291,6 +288,10 @@ bool ContainsCjkCodePoint(std::wstring_view text) {
     return false;
 }
 
+// A token is a base code point, its combining marks/variation selectors, and
+// an optional Win32 mnemonic '&' prefix. Keeping the prefix in the token makes
+// "打开&Open" become "打开 &Open", which Windows displays as "打开 Open"
+// while preserving the O mnemonic.
 std::wstring AddCjkSpacing(std::wstring_view text,
                            bool preserveMnemonics = true) {
     std::wstring result;
@@ -371,6 +372,16 @@ SetMenuItemInfoW_t g_originalSetMenuItemInfoW;
 TrackPopupMenu_t g_originalTrackPopupMenu;
 TrackPopupMenuEx_t g_originalTrackPopupMenuEx;
 
+struct RewrittenMenuItem {
+    HMENU menu;
+    UINT index;
+    std::wstring original;
+    std::wstring spaced;
+};
+
+std::mutex g_rewrittenMenuItemsMutex;
+std::vector<RewrittenMenuItem> g_rewrittenMenuItems;
+
 bool IsStringMenuFlags(UINT flags) {
     return !(flags & (MF_BITMAP | MF_OWNERDRAW | MF_SEPARATOR));
 }
@@ -441,6 +452,102 @@ bool MenuItemInfoContainsString(const MENUITEMINFOW* itemInfo) {
            (itemInfo->fMask & MIIM_TYPE);
 }
 
+MENUITEMINFOW CopyMenuItemInfoForRewrite(
+    const MENUITEMINFOW* itemInfo) {
+    MENUITEMINFOW copy = {};
+    const size_t copySize =
+        itemInfo->cbSize < sizeof(copy) ? itemInfo->cbSize
+                                        : sizeof(copy);
+    std::memcpy(&copy, itemInfo, copySize);
+    return copy;
+}
+
+bool ReadMenuItemText(HMENU menu,
+                      UINT index,
+                      std::wstring* text) {
+    MENUITEMINFOW itemInfo = {};
+    itemInfo.cbSize = sizeof(itemInfo);
+    itemInfo.fMask = MIIM_FTYPE | MIIM_STRING;
+    if (!GetMenuItemInfoW(menu, index, TRUE, &itemInfo) ||
+        (itemInfo.fType &
+         (MFT_BITMAP | MFT_OWNERDRAW | MFT_SEPARATOR))) {
+        return false;
+    }
+
+    std::vector<wchar_t> buffer(itemInfo.cch + 1);
+    itemInfo.dwTypeData = buffer.data();
+    itemInfo.cch = static_cast<UINT>(buffer.size());
+    if (!GetMenuItemInfoW(menu, index, TRUE, &itemInfo)) {
+        return false;
+    }
+
+    text->assign(buffer.data(), itemInfo.cch);
+    return true;
+}
+
+void RememberRewrittenMenuItem(HMENU menu,
+                               UINT index,
+                               std::wstring original,
+                               std::wstring spaced) {
+    std::lock_guard<std::mutex> guard(g_rewrittenMenuItemsMutex);
+
+    if (g_rewrittenMenuItems.size() >= 256) {
+        std::erase_if(g_rewrittenMenuItems, [](const auto& item) {
+            return !IsMenu(item.menu);
+        });
+    }
+
+    for (auto& item : g_rewrittenMenuItems) {
+        if (item.menu == menu && item.index == index) {
+            if (item.spaced != spaced) {
+                item.original = std::move(original);
+                item.spaced = std::move(spaced);
+            }
+            return;
+        }
+    }
+
+    g_rewrittenMenuItems.push_back(
+        {menu, index, std::move(original), std::move(spaced)});
+}
+
+void RestoreRewrittenMenuItems() {
+    std::vector<RewrittenMenuItem> items;
+    {
+        std::lock_guard<std::mutex> guard(
+            g_rewrittenMenuItemsMutex);
+        items.swap(g_rewrittenMenuItems);
+    }
+
+    for (auto iterator = items.rbegin(); iterator != items.rend();
+         ++iterator) {
+        if (!IsMenu(iterator->menu)) {
+            continue;
+        }
+
+        std::wstring current;
+        if (!ReadMenuItemText(iterator->menu, iterator->index,
+                              &current) ||
+            current != iterator->spaced) {
+            continue;
+        }
+
+        MENUITEMINFOW replacement = {};
+        replacement.cbSize = sizeof(replacement);
+        replacement.fMask = MIIM_STRING;
+        replacement.dwTypeData =
+            const_cast<wchar_t*>(iterator->original.c_str());
+
+        if (g_originalSetMenuItemInfoW) {
+            g_originalSetMenuItemInfoW(
+                iterator->menu, iterator->index, TRUE, &replacement);
+        } else {
+            SetMenuItemInfoW(
+                iterator->menu, iterator->index, TRUE, &replacement);
+        }
+    }
+}
+
 BOOL WINAPI InsertMenuItemWHook(HMENU menu,
                                 UINT item,
                                 BOOL byPosition,
@@ -450,9 +557,9 @@ BOOL WINAPI InsertMenuItemWHook(HMENU menu,
         const std::wstring spaced = AddCjkSpacing(itemInfo->dwTypeData);
         if (spaced != itemInfo->dwTypeData) {
             Wh_Log(L"Applied CJK spacing (classic/InsertMenuItemW)");
-            MENUITEMINFOW copy = *itemInfo;
+            MENUITEMINFOW copy =
+                CopyMenuItemInfoForRewrite(itemInfo);
             copy.dwTypeData = const_cast<wchar_t*>(spaced.c_str());
-            copy.cch = static_cast<UINT>(spaced.size());
             return g_originalInsertMenuItemW(menu, item, byPosition, &copy);
         }
     }
@@ -469,9 +576,9 @@ BOOL WINAPI SetMenuItemInfoWHook(HMENU menu,
         const std::wstring spaced = AddCjkSpacing(itemInfo->dwTypeData);
         if (spaced != itemInfo->dwTypeData) {
             Wh_Log(L"Applied CJK spacing (classic/SetMenuItemInfoW)");
-            MENUITEMINFOW copy = *itemInfo;
+            MENUITEMINFOW copy =
+                CopyMenuItemInfoForRewrite(itemInfo);
             copy.dwTypeData = const_cast<wchar_t*>(spaced.c_str());
-            copy.cch = static_cast<UINT>(spaced.size());
             return g_originalSetMenuItemInfoW(menu, item, byPosition, &copy);
         }
     }
@@ -495,12 +602,8 @@ void RewriteMenuTree(HMENU menu) {
               (MFT_BITMAP | MFT_OWNERDRAW | MFT_SEPARATOR));
 
         if (isTextItem && itemInfo.cch > 0) {
-            std::vector<wchar_t> buffer(itemInfo.cch + 1);
-            itemInfo.dwTypeData = buffer.data();
-            itemInfo.cch = static_cast<UINT>(buffer.size());
-
-            if (GetMenuItemInfoW(menu, index, TRUE, &itemInfo)) {
-                const std::wstring original(buffer.data(), itemInfo.cch);
+            std::wstring original;
+            if (ReadMenuItemText(menu, index, &original)) {
                 const std::wstring spaced = AddCjkSpacing(original);
                 if (spaced != original) {
                     Wh_Log(L"Applied CJK spacing (classic/pre-display)");
@@ -510,8 +613,11 @@ void RewriteMenuTree(HMENU menu) {
                     replacement.fMask = MIIM_STRING;
                     replacement.dwTypeData =
                         const_cast<wchar_t*>(spaced.c_str());
-                    replacement.cch = static_cast<UINT>(spaced.size());
-                    SetMenuItemInfoW(menu, index, TRUE, &replacement);
+                    if (SetMenuItemInfoW(
+                            menu, index, TRUE, &replacement)) {
+                        RememberRewrittenMenuItem(
+                            menu, index, std::move(original), spaced);
+                    }
                 }
             }
         }
@@ -557,6 +663,7 @@ using OpenThemeData_t = decltype(&OpenThemeData);
 using OpenThemeDataEx_t = decltype(&OpenThemeDataEx);
 using OpenThemeDataForDpi_t = decltype(&OpenThemeDataForDpi);
 using CloseThemeData_t = decltype(&CloseThemeData);
+using GetThemeTextExtent_t = decltype(&GetThemeTextExtent);
 using DrawThemeText_t = decltype(&DrawThemeText);
 using DrawThemeTextEx_t = decltype(&DrawThemeTextEx);
 
@@ -564,6 +671,7 @@ OpenThemeData_t g_originalOpenThemeData;
 OpenThemeDataEx_t g_originalOpenThemeDataEx;
 OpenThemeDataForDpi_t g_originalOpenThemeDataForDpi;
 CloseThemeData_t g_originalCloseThemeData;
+GetThemeTextExtent_t g_originalGetThemeTextExtent;
 DrawThemeText_t g_originalDrawThemeText;
 DrawThemeTextEx_t g_originalDrawThemeTextEx;
 
@@ -580,8 +688,15 @@ bool IsClassicTooltipThemeClassList(LPCWSTR classList) {
     constexpr wchar_t needle[] = L"tooltip";
     constexpr size_t needleLength = ARRAYSIZE(needle) - 1;
     for (const wchar_t* cursor = classList; *cursor; ++cursor) {
-        if (_wcsnicmp(cursor, needle, needleLength) == 0) {
-            return true;
+        const bool startsToken =
+            cursor == classList || cursor[-1] == L':' ||
+            cursor[-1] == L';';
+        if (startsToken &&
+            _wcsnicmp(cursor, needle, needleLength) == 0) {
+            const wchar_t trailing = cursor[needleLength];
+            if (trailing == L'\0' || trailing == L';') {
+                return true;
+            }
         }
     }
 
@@ -694,6 +809,42 @@ bool BuildSpacedClassicTooltipText(LPCWSTR text,
     return spaced->size() != original.size();
 }
 
+HRESULT WINAPI GetThemeTextExtentHook(HTHEME theme,
+                                      HDC dc,
+                                      int partId,
+                                      int stateId,
+                                      LPCWSTR text,
+                                      int textLength,
+                                      DWORD textFlags,
+                                      LPCRECT boundingRectangle,
+                                      LPRECT extentRectangle) {
+    if (!g_classicTooltips.load(std::memory_order_relaxed) ||
+        g_rewritingClassicTooltipText ||
+        !IsTrackedClassicTooltipTheme(theme)) {
+        return g_originalGetThemeTextExtent(
+            theme, dc, partId, stateId, text, textLength, textFlags,
+            boundingRectangle, extentRectangle);
+    }
+
+    std::wstring spaced;
+    if (!BuildSpacedClassicTooltipText(
+            text, textLength, textFlags, &spaced)) {
+        return g_originalGetThemeTextExtent(
+            theme, dc, partId, stateId, text, textLength, textFlags,
+            boundingRectangle, extentRectangle);
+    }
+
+    Wh_Log(L"Applied CJK spacing "
+           L"(classic tooltip/GetThemeTextExtent)");
+    g_rewritingClassicTooltipText = true;
+    const HRESULT result = g_originalGetThemeTextExtent(
+        theme, dc, partId, stateId, spaced.c_str(),
+        static_cast<int>(spaced.size()), textFlags,
+        boundingRectangle, extentRectangle);
+    g_rewritingClassicTooltipText = false;
+    return result;
+}
+
 HRESULT WINAPI DrawThemeTextHook(HTHEME theme,
                                  HDC dc,
                                  int partId,
@@ -765,7 +916,7 @@ HRESULT WINAPI DrawThemeTextExHook(HTHEME theme,
 }
 
 // -------------------------------------------------------------------------
-// Windows 11 XAML/WinUI menu and tooltip detection
+// Windows 11 XAML/WinUI popup detection
 // -------------------------------------------------------------------------
 
 using ShowWindow_t = decltype(&ShowWindow);
@@ -776,26 +927,20 @@ ShowWindow_t g_originalShowWindow;
 SetWindowPos_t g_originalSetWindowPos;
 DestroyWindow_t g_originalDestroyWindow;
 
-enum class ModernPopupKind : ULONG_PTR {
-    Unclassified = 0,
-    Menu = 1,
-    ToolTip = 2,
+struct TrackedModernPopup {
+    DWORD threadId;
 };
 
-constexpr wchar_t kModernPopupKindProperty[] =
-    L"CJKSpacer_ModernPopupKind";
-
-thread_local bool g_detectingModernPopupKind = false;
+std::mutex g_trackedModernPopupsMutex;
+std::unordered_map<HWND, TrackedModernPopup>
+    g_trackedModernPopups;
+std::atomic_uint g_trackedModernPopupCount{0};
 
 bool IsModernPopupClassName(LPCWSTR className) {
-    if (!className ||
-        reinterpret_cast<ULONG_PTR>(className) <= 0xFFFF) {
-        return false;
-    }
-
-    return _wcsicmp(className, L"Xaml_WindowedPopupClass") == 0 ||
+    return className &&
+           (_wcsicmp(className, L"Xaml_WindowedPopupClass") == 0 ||
            _wcsicmp(className,
-                    L"Microsoft.UI.Content.PopupWindowSiteBridge") == 0;
+                    L"Microsoft.UI.Content.PopupWindowSiteBridge") == 0);
 }
 
 bool IsModernPopupWindow(HWND window) {
@@ -804,151 +949,113 @@ bool IsModernPopupWindow(HWND window) {
     return length > 0 && IsModernPopupClassName(className);
 }
 
-template <typename Interface>
-void ReleaseComInterface(Interface*& value) {
-    if (value) {
-        value->Release();
-        value = nullptr;
-    }
-}
-
-bool PopupContainsControlType(IUIAutomation* automation,
-                              IUIAutomationElement* root,
-                              CONTROLTYPEID controlType) {
-    VARIANT propertyValue = {};
-    propertyValue.vt = VT_I4;
-    propertyValue.lVal = controlType;
-
-    IUIAutomationCondition* condition = nullptr;
-    HRESULT result = automation->CreatePropertyCondition(
-        UIA_ControlTypePropertyId, propertyValue, &condition);
-    if (FAILED(result) || !condition) {
-        return false;
-    }
-
-    IUIAutomationElement* match = nullptr;
-    result = root->FindFirst(TreeScope_Subtree, condition, &match);
-    const bool found = SUCCEEDED(result) && match;
-    ReleaseComInterface(condition);
-    ReleaseComInterface(match);
-    return found;
-}
-
-ModernPopupKind DetectModernPopupKind(HWND window) {
-    if (g_detectingModernPopupKind) {
-        return ModernPopupKind::Unclassified;
-    }
-
-    g_detectingModernPopupKind = true;
-
-    CO_MTA_USAGE_COOKIE mtaCookie;
-    const bool mtaUsageIncreased =
-        SUCCEEDED(CoIncrementMTAUsage(&mtaCookie));
-
-    IUIAutomation* automation = nullptr;
-    IUIAutomationElement* root = nullptr;
-    ModernPopupKind kind = ModernPopupKind::Unclassified;
-
-    HRESULT result = CoCreateInstance(
-        CLSID_CUIAutomation, nullptr, CLSCTX_INPROC_SERVER,
-        IID_PPV_ARGS(&automation));
-    if (SUCCEEDED(result) && automation) {
-        result = automation->ElementFromHandle(window, &root);
-    }
-
-    if (SUCCEEDED(result) && root) {
-        if (PopupContainsControlType(automation, root,
-                                     UIA_MenuControlTypeId)) {
-            kind = ModernPopupKind::Menu;
-        } else if (PopupContainsControlType(
-                       automation, root, UIA_ToolTipControlTypeId)) {
-            kind = ModernPopupKind::ToolTip;
-        }
-    }
-
-    ReleaseComInterface(root);
-    ReleaseComInterface(automation);
-
-    if (mtaUsageIncreased) {
-        CoDecrementMTAUsage(mtaCookie);
-    }
-
-    g_detectingModernPopupKind = false;
-    return kind;
-}
-
-ModernPopupKind GetTrackedModernPopupKind(HWND window) {
-    return static_cast<ModernPopupKind>(
-        reinterpret_cast<ULONG_PTR>(
-            GetPropW(window, kModernPopupKindProperty)));
-}
-
-bool IsSupportedModernPopupKind(ModernPopupKind kind) {
-    return kind == ModernPopupKind::Menu ||
-           kind == ModernPopupKind::ToolTip;
-}
-
 bool TrackModernPopup(HWND window) {
-    if (GetTrackedModernPopupKind(window) !=
-        ModernPopupKind::Unclassified) {
-        return true;
-    }
-
-    const ModernPopupKind kind = DetectModernPopupKind(window);
-    if (!IsSupportedModernPopupKind(kind)) {
+    if (!window) {
         return false;
     }
 
-    if (!SetPropW(window, kModernPopupKindProperty,
-                  reinterpret_cast<HANDLE>(
-                      static_cast<ULONG_PTR>(kind)))) {
+    const DWORD threadId =
+        GetWindowThreadProcessId(window, nullptr);
+    if (!threadId) {
         return false;
     }
 
-    g_activeModernPopupCount.fetch_add(1, std::memory_order_relaxed);
-    Wh_Log(L"Tracking modern %s popup",
-           kind == ModernPopupKind::Menu ? L"menu" : L"tooltip");
+    {
+        std::lock_guard<std::mutex> guard(
+            g_trackedModernPopupsMutex);
+        g_trackedModernPopups[window] = {threadId};
+        g_trackedModernPopupCount.store(
+            static_cast<unsigned int>(
+                g_trackedModernPopups.size()),
+            std::memory_order_relaxed);
+    }
+
+    Wh_Log(L"Tracking modern popup");
     return true;
 }
 
 void UntrackModernPopup(HWND window) {
-    const ModernPopupKind kind = GetTrackedModernPopupKind(window);
-    if (!IsSupportedModernPopupKind(kind)) {
-        return;
-    }
-
-    RemovePropW(window, kModernPopupKindProperty);
-    const unsigned int previous =
-        g_activeModernPopupCount.fetch_sub(1, std::memory_order_relaxed);
-    if (previous == 0) {
-        g_activeModernPopupCount.store(0, std::memory_order_relaxed);
-    }
+    std::lock_guard<std::mutex> guard(
+        g_trackedModernPopupsMutex);
+    g_trackedModernPopups.erase(window);
+    g_trackedModernPopupCount.store(
+        static_cast<unsigned int>(g_trackedModernPopups.size()),
+        std::memory_order_relaxed);
 }
 
-bool IsModernPopupActive() {
-    return g_activeModernPopupCount.load(std::memory_order_relaxed) != 0;
+bool IsModernPopupTracked(HWND window) {
+    if (g_trackedModernPopupCount.load(
+            std::memory_order_relaxed) == 0) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> guard(
+        g_trackedModernPopupsMutex);
+    return g_trackedModernPopups.contains(window);
+}
+
+void ClearTrackedModernPopups() {
+    std::lock_guard<std::mutex> guard(
+        g_trackedModernPopupsMutex);
+    g_trackedModernPopups.clear();
+    g_trackedModernPopupCount.store(0, std::memory_order_relaxed);
+}
+
+bool IsModernPopupActiveForCurrentThread() {
+    const DWORD currentThreadId = GetCurrentThreadId();
+    bool active = false;
+
+    std::lock_guard<std::mutex> guard(
+        g_trackedModernPopupsMutex);
+    for (auto iterator = g_trackedModernPopups.begin();
+         iterator != g_trackedModernPopups.end();) {
+        if (!IsWindow(iterator->first)) {
+            iterator = g_trackedModernPopups.erase(iterator);
+            g_trackedModernPopupCount.store(
+                static_cast<unsigned int>(
+                    g_trackedModernPopups.size()),
+                std::memory_order_relaxed);
+            continue;
+        }
+
+        if (iterator->second.threadId == currentThreadId &&
+            IsWindowVisible(iterator->first)) {
+            active = true;
+        }
+
+        ++iterator;
+    }
+
+    return active;
 }
 
 BOOL WINAPI ShowWindowHook(HWND window, int command) {
     const bool modernUiEnabled =
         g_modernUiText.load(std::memory_order_relaxed);
-    const bool isModernPopup = IsModernPopupWindow(window);
     const bool showing = command != SW_HIDE;
+    if (!modernUiEnabled &&
+        g_trackedModernPopupCount.load(
+            std::memory_order_relaxed) == 0) {
+        return g_originalShowWindow(window, command);
+    }
 
-    if (modernUiEnabled && isModernPopup && showing) {
-        TrackModernPopup(window);
+    bool tracked = IsModernPopupTracked(window);
+
+    if (!tracked) {
+        if (!modernUiEnabled || !showing ||
+            !IsModernPopupWindow(window)) {
+            return g_originalShowWindow(window, command);
+        }
+
+        tracked = TrackModernPopup(window);
     }
 
     const BOOL result = g_originalShowWindow(window, command);
 
-    if (isModernPopup) {
-        if (!showing || !IsWindowVisible(window)) {
-            UntrackModernPopup(window);
-        } else if (modernUiEnabled &&
-                   GetTrackedModernPopupKind(window) ==
-                   ModernPopupKind::Unclassified) {
-            TrackModernPopup(window);
-        }
+    if (tracked &&
+        (!showing || !IsWindow(window) ||
+         !IsWindowVisible(window))) {
+        UntrackModernPopup(window);
     }
 
     return result;
@@ -963,24 +1070,34 @@ BOOL WINAPI SetWindowPosHook(HWND window,
                             UINT flags) {
     const bool modernUiEnabled =
         g_modernUiText.load(std::memory_order_relaxed);
-    const bool isModernPopup = IsModernPopupWindow(window);
+    const bool showing = (flags & SWP_SHOWWINDOW) != 0;
+    if ((!modernUiEnabled || !showing) &&
+        g_trackedModernPopupCount.load(
+            std::memory_order_relaxed) == 0) {
+        return g_originalSetWindowPos(
+            window, insertAfter, x, y, width, height, flags);
+    }
 
-    if (modernUiEnabled && isModernPopup &&
-        (flags & SWP_SHOWWINDOW)) {
-        TrackModernPopup(window);
+    bool tracked = IsModernPopupTracked(window);
+
+    if (!tracked) {
+        if (!modernUiEnabled || !showing ||
+            !IsModernPopupWindow(window)) {
+            return g_originalSetWindowPos(
+                window, insertAfter, x, y, width, height, flags);
+        }
+
+        tracked = TrackModernPopup(window);
     }
 
     const BOOL result = g_originalSetWindowPos(
         window, insertAfter, x, y, width, height, flags);
 
-    if (isModernPopup && result) {
-        if (flags & SWP_HIDEWINDOW) {
-            UntrackModernPopup(window);
-        } else if (modernUiEnabled && (flags & SWP_SHOWWINDOW) &&
-                   GetTrackedModernPopupKind(window) ==
-                       ModernPopupKind::Unclassified) {
-            TrackModernPopup(window);
-        }
+    if (tracked &&
+        (!result || (flags & SWP_HIDEWINDOW) ||
+         !IsWindow(window) ||
+         (showing && !IsWindowVisible(window)))) {
+        UntrackModernPopup(window);
     }
 
     return result;
@@ -992,7 +1109,7 @@ BOOL WINAPI DestroyWindowHook(HWND window) {
 }
 
 // -------------------------------------------------------------------------
-// DirectWrite text layout used by the Windows 11 menu
+// DirectWrite text layout used by Windows 11 XAML/WinUI popups
 // -------------------------------------------------------------------------
 
 using IDWriteFactory_CreateTextLayout_t =
@@ -1031,7 +1148,7 @@ HRESULT CreateTextLayoutWithSpacing(
     FLOAT maxHeight,
     IDWriteTextLayout** textLayout) {
     if (g_modernUiText.load(std::memory_order_relaxed) && text &&
-        IsModernPopupActive()) {
+        IsModernPopupActiveForCurrentThread()) {
         const std::wstring_view original(text, textLength);
         if (!ContainsCjkCodePoint(original)) {
             return originalFunction(factory, text, textLength, textFormat,
@@ -1065,7 +1182,7 @@ HRESULT CreateGdiCompatibleTextLayoutWithSpacing(
     BOOL useGdiNatural,
     IDWriteTextLayout** textLayout) {
     if (g_modernUiText.load(std::memory_order_relaxed) && text &&
-        IsModernPopupActive()) {
+        IsModernPopupActiveForCurrentThread()) {
         const std::wstring_view original(text, textLength);
         if (!ContainsCjkCodePoint(original)) {
             return originalFunction(
@@ -1259,6 +1376,18 @@ bool HookClassicTooltipThemeDrawing() {
         Wh_Log(L"Couldn't find CloseThemeData");
     }
 
+    const auto getThemeTextExtent =
+        reinterpret_cast<GetThemeTextExtent_t>(
+            GetProcAddress(themeModule, "GetThemeTextExtent"));
+    if (getThemeTextExtent) {
+        hooked |= InstallHook(
+            getThemeTextExtent, GetThemeTextExtentHook,
+            &g_originalGetThemeTextExtent,
+            L"GetThemeTextExtent");
+    } else {
+        Wh_Log(L"Couldn't find GetThemeTextExtent");
+    }
+
     const auto drawThemeText =
         reinterpret_cast<DrawThemeText_t>(
             GetProcAddress(themeModule, "DrawThemeText"));
@@ -1355,11 +1484,27 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModUninit() {
+    RestoreRewrittenMenuItems();
+    ClearTrackedModernPopups();
     Wh_Log(L"CJK Spacer uninitialized");
 }
 
 void Wh_ModSettingsChanged() {
+    const bool classicMenusWasEnabled =
+        g_classicMenus.load(std::memory_order_relaxed);
+    const bool modernUiWasEnabled =
+        g_modernUiText.load(std::memory_order_relaxed);
     LoadSettings();
+
+    if (classicMenusWasEnabled &&
+        !g_classicMenus.load(std::memory_order_relaxed)) {
+        RestoreRewrittenMenuItems();
+    }
+    if (modernUiWasEnabled &&
+        !g_modernUiText.load(std::memory_order_relaxed)) {
+        ClearTrackedModernPopups();
+    }
+
     Wh_Log(L"CJK Spacer settings changed (classicMenus=%d, "
            L"classicTooltips=%d, modern=%d, unicode=%d)",
            g_classicMenus.load(), g_classicTooltips.load(),

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips; modern XAML UI is opt-in and best-effort because it may conflict with other XAML Diagnostics mods
-// @version         0.1.23
+// @version         0.1.24
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -61,12 +61,14 @@ excluded.
 
 ## Supported UI
 
-- Classic Win32 popup menus are rewritten through public `HMENU` APIs. This
-  happens only while `TrackPopupMenu` is active, including items added or
-  changed while the menu is open. It covers File Explorer, desktop, taskbar,
-  and jump-list context menus that Explorer itself hosts. Context menus shown
-  by third-party notification-area icon processes are outside the injected
-  `explorer.exe` process and aren't covered.
+- Classic Win32 popup menus are rewritten through public `HMENU` APIs. Menus
+  created through `CreatePopupMenu` are handled while they are constructed,
+  then associated with their `TrackPopupMenu` call and restored when the popup
+  closes. Existing popup handles are also scanned immediately before display.
+  It covers File Explorer, desktop, taskbar, and jump-list context menus that
+  Explorer itself hosts.
+  Context menus shown by third-party notification-area icon processes are
+  outside the injected `explorer.exe` process and aren't covered.
   Classic menu bars and window system menus do not use these popup APIs and
   aren't covered.
 - Classic Win32 tooltips, including legacy notification-area icon tooltips, are
@@ -139,7 +141,7 @@ also need compatible DC targets to keep sizing consistent; disable
 /*
 - classicMenus: true
   $name: Classic context menus
-  $description: Process classic Win32 popup-menu text; temporary live-menu changes can affect other text-matching menu mods while the popup is open.
+  $description: Process classic Win32 popup-menu text during construction and display; temporary live-menu changes can affect other text-matching menu mods until the popup closes.
 - classicTooltips: true
   $name: Classic Win32 tooltips
   $description: Process text in legacy tooltips such as notification-area icon tooltips.
@@ -173,6 +175,7 @@ also need compatible DC targets to keep sizing consistent; disable
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <windows.h>
@@ -460,6 +463,8 @@ using AppendMenuW_t = decltype(&AppendMenuW);
 using ModifyMenuW_t = decltype(&ModifyMenuW);
 using InsertMenuItemW_t = decltype(&InsertMenuItemW);
 using SetMenuItemInfoW_t = decltype(&SetMenuItemInfoW);
+using CreatePopupMenu_t = decltype(&CreatePopupMenu);
+using DestroyMenu_t = decltype(&DestroyMenu);
 using TrackPopupMenu_t = decltype(&TrackPopupMenu);
 using TrackPopupMenuEx_t = decltype(&TrackPopupMenuEx);
 
@@ -468,6 +473,8 @@ AppendMenuW_t g_originalAppendMenuW;
 ModifyMenuW_t g_originalModifyMenuW;
 InsertMenuItemW_t g_originalInsertMenuItemW;
 SetMenuItemInfoW_t g_originalSetMenuItemInfoW;
+CreatePopupMenu_t g_originalCreatePopupMenu;
+DestroyMenu_t g_originalDestroyMenu;
 TrackPopupMenu_t g_originalTrackPopupMenu;
 TrackPopupMenuEx_t g_originalTrackPopupMenuEx;
 
@@ -486,6 +493,11 @@ std::vector<RewrittenMenuItem> g_rewrittenMenuItems;
 thread_local unsigned int g_classicPopupMenuDepth = 0;
 thread_local HMENU g_classicPopupRootMenu = nullptr;
 thread_local bool g_restoringClassicMenuText = false;
+
+std::shared_mutex g_createdClassicPopupMenusMutex;
+std::unordered_set<HMENU> g_createdClassicPopupMenus;
+
+constexpr unsigned int kMaxMenuDepth = 16;
 
 class ScopedBoolValue final {
 public:
@@ -528,6 +540,123 @@ int FindMenuItemIndexByText(
     HMENU menu,
     const std::wstring& expectedText);
 
+void CollectMenuTreeHandles(
+    HMENU menu,
+    std::unordered_set<HMENU>* handles,
+    unsigned int depth = 0) {
+    if (!menu || !handles || depth >= kMaxMenuDepth ||
+        !handles->insert(menu).second) {
+        return;
+    }
+
+    const int itemCount = GetMenuItemCount(menu);
+    for (int index = 0; index < itemCount; ++index) {
+        MENUITEMINFOW itemInfo = {};
+        itemInfo.cbSize = sizeof(itemInfo);
+        itemInfo.fMask = MIIM_SUBMENU;
+        if (GetMenuItemInfoW(menu, index, TRUE, &itemInfo) &&
+            itemInfo.hSubMenu) {
+            CollectMenuTreeHandles(
+                itemInfo.hSubMenu, handles, depth + 1);
+        }
+    }
+}
+
+bool IsCreatedClassicPopupMenu(HMENU menu) {
+    if (!menu) {
+        return false;
+    }
+
+    std::shared_lock<std::shared_mutex> guard(
+        g_createdClassicPopupMenusMutex);
+    return g_createdClassicPopupMenus.contains(menu);
+}
+
+bool ShouldRewriteClassicMenuDuringConstruction(HMENU menu) {
+    return g_classicPopupMenuDepth > 0 ||
+           IsCreatedClassicPopupMenu(menu);
+}
+
+HMENU WINAPI CreatePopupMenuHook() {
+    HMENU menu = g_originalCreatePopupMenu();
+    if (menu) {
+        std::lock_guard<std::shared_mutex> guard(
+            g_createdClassicPopupMenusMutex);
+        g_createdClassicPopupMenus.insert(menu);
+    }
+    return menu;
+}
+
+BOOL WINAPI DestroyMenuHook(HMENU menu) {
+    std::unordered_set<HMENU> menuTree;
+    CollectMenuTreeHandles(menu, &menuTree);
+
+    std::vector<RewrittenMenuItem> removedItems;
+
+    {
+        std::lock_guard<std::mutex> guard(
+            g_rewrittenMenuItemsMutex);
+        for (auto iterator = g_rewrittenMenuItems.begin();
+             iterator != g_rewrittenMenuItems.end();) {
+            if (menuTree.contains(iterator->menu)) {
+                removedItems.push_back(std::move(*iterator));
+                iterator = g_rewrittenMenuItems.erase(iterator);
+            } else {
+                ++iterator;
+            }
+        }
+    }
+
+    {
+        std::lock_guard<std::shared_mutex> guard(
+            g_createdClassicPopupMenusMutex);
+        for (HMENU handle : menuTree) {
+            g_createdClassicPopupMenus.erase(handle);
+        }
+    }
+
+    const BOOL result = g_originalDestroyMenu(menu);
+    if (!result) {
+        {
+            std::lock_guard<std::mutex> guard(
+                g_rewrittenMenuItemsMutex);
+            for (auto& item : removedItems) {
+                g_rewrittenMenuItems.push_back(std::move(item));
+            }
+        }
+
+        {
+            std::lock_guard<std::shared_mutex> guard(
+                g_createdClassicPopupMenusMutex);
+            for (HMENU handle : menuTree) {
+                if (IsMenu(handle)) {
+                    g_createdClassicPopupMenus.insert(handle);
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+void AssociatePendingRewrittenMenuItems(HMENU rootMenu) {
+    std::unordered_set<HMENU> menuTree;
+    CollectMenuTreeHandles(rootMenu, &menuTree);
+
+    std::lock_guard<std::mutex> guard(g_rewrittenMenuItemsMutex);
+    for (auto& item : g_rewrittenMenuItems) {
+        if (!item.rootMenu && menuTree.contains(item.menu)) {
+            item.rootMenu = rootMenu;
+        }
+    }
+}
+
+void ClearCreatedClassicPopupMenus() {
+    std::lock_guard<std::shared_mutex> guard(
+        g_createdClassicPopupMenusMutex);
+    g_createdClassicPopupMenus.clear();
+}
+
 bool IsStringMenuFlags(UINT flags) {
     return !(flags & (MF_BITMAP | MF_OWNERDRAW | MF_SEPARATOR));
 }
@@ -568,7 +697,8 @@ BOOL WINAPI InsertMenuWHook(HMENU menu,
                             UINT flags,
                             UINT_PTR itemId,
                             LPCWSTR newItem) {
-    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+    if (!g_restoringClassicMenuText &&
+        ShouldRewriteClassicMenuDuringConstruction(menu) &&
         g_classicMenus.load(std::memory_order_relaxed) && newItem &&
         IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
@@ -609,7 +739,8 @@ BOOL WINAPI AppendMenuWHook(HMENU menu,
                             UINT flags,
                             UINT_PTR itemId,
                             LPCWSTR newItem) {
-    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+    if (!g_restoringClassicMenuText &&
+        ShouldRewriteClassicMenuDuringConstruction(menu) &&
         g_classicMenus.load(std::memory_order_relaxed) && newItem &&
         IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
@@ -636,7 +767,8 @@ BOOL WINAPI ModifyMenuWHook(HMENU menu,
                             UINT flags,
                             UINT_PTR itemId,
                             LPCWSTR newItem) {
-    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+    if (!g_restoringClassicMenuText &&
+        ShouldRewriteClassicMenuDuringConstruction(menu) &&
         g_classicMenus.load(std::memory_order_relaxed) && newItem &&
         IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
@@ -805,7 +937,8 @@ BOOL WINAPI InsertMenuItemWHook(HMENU menu,
                                 UINT item,
                                 BOOL byPosition,
                                 LPCMENUITEMINFOW itemInfo) {
-    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+    if (!g_restoringClassicMenuText &&
+        ShouldRewriteClassicMenuDuringConstruction(menu) &&
         g_classicMenus.load(std::memory_order_relaxed) &&
         MenuItemInfoContainsString(itemInfo) &&
         ContainsCjkCodePoint(itemInfo->dwTypeData)) {
@@ -852,7 +985,8 @@ BOOL WINAPI SetMenuItemInfoWHook(HMENU menu,
                                  UINT item,
                                  BOOL byPosition,
                                  LPCMENUITEMINFOW itemInfo) {
-    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+    if (!g_restoringClassicMenuText &&
+        ShouldRewriteClassicMenuDuringConstruction(menu) &&
         g_classicMenus.load(std::memory_order_relaxed) &&
         MenuItemInfoContainsString(itemInfo) &&
         ContainsCjkCodePoint(itemInfo->dwTypeData)) {
@@ -879,8 +1013,6 @@ BOOL WINAPI SetMenuItemInfoWHook(HMENU menu,
 
     return g_originalSetMenuItemInfoW(menu, item, byPosition, itemInfo);
 }
-
-constexpr unsigned int kMaxMenuDepth = 16;
 
 void RewriteMenuTree(HMENU menu, unsigned int depth = 0) {
     if (!menu || depth >= kMaxMenuDepth) {
@@ -943,6 +1075,7 @@ BOOL WINAPI TrackPopupMenuHook(HMENU menu,
                                const RECT* rect) {
     if (g_classicMenus.load(std::memory_order_relaxed)) {
         ClassicPopupMenuStateGuard stateGuard(menu);
+        AssociatePendingRewrittenMenuItems(menu);
         RewriteMenuTree(menu);
         const BOOL result = g_originalTrackPopupMenu(
             menu, flags, x, y, reserved, owner, rect);
@@ -961,6 +1094,7 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU menu,
                                  LPTPMPARAMS parameters) {
     if (g_classicMenus.load(std::memory_order_relaxed)) {
         ClassicPopupMenuStateGuard stateGuard(menu);
+        AssociatePendingRewrittenMenuItems(menu);
         RewriteMenuTree(menu);
         const BOOL result = g_originalTrackPopupMenuEx(
             menu, flags, x, y, owner, parameters);
@@ -2888,6 +3022,12 @@ BOOL Wh_ModInit() {
 
     if (classicMenusEnabled) {
         installedAnyHook |= InstallHook(
+            CreatePopupMenu, CreatePopupMenuHook,
+            &g_originalCreatePopupMenu, L"CreatePopupMenu");
+        installedAnyHook |= InstallHook(
+            DestroyMenu, DestroyMenuHook,
+            &g_originalDestroyMenu, L"DestroyMenu");
+        installedAnyHook |= InstallHook(
             InsertMenuW, InsertMenuWHook, &g_originalInsertMenuW,
             L"InsertMenuW");
         installedAnyHook |= InstallHook(
@@ -2983,6 +3123,7 @@ void Wh_ModAfterInit() {
 
 void Wh_ModUninit() {
     RestoreRewrittenMenuItems();
+    ClearCreatedClassicPopupMenus();
     CloseDiscoveredClassicTooltipThemes();
     ClearTrackedClassicTooltipThemes();
     if (g_modernUiText.load(std::memory_order_relaxed)) {

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              cjk-spacer
 // @name            CJK Spacer
-// @description     Add spaces between CJK characters and letters or digits in Explorer menus, tooltips, and popups
-// @version         0.1.5
+// @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
+// @version         0.1.6
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -46,17 +46,18 @@ keyboard shortcut text are also preserved.
 ## Supported UI
 
 - Classic Win32 popup menus are rewritten through public `HMENU` APIs. This
-  includes File Explorer, desktop, taskbar, tray, and jump-list menus hosted by
-  `explorer.exe`.
+  happens only while `TrackPopupMenu` is active, including items added or
+  changed while the menu is open. It covers File Explorer, desktop, taskbar,
+  tray, and jump-list context menus hosted by `explorer.exe`.
 - Classic Win32 tooltips, including legacy notification-area icon tooltips, are
   rewritten only through theme handles opened for the `TOOLTIP` class, covering
   both text measurement and drawing without touching unrelated GDI text. Basic
   or classic-theme tooltips drawn directly with `DrawTextW` aren't covered.
-- Windows 11 XAML popup text uses an experimental, display-only
-  DirectWrite hook. This includes context menus, tooltips, and other Explorer
-  flyouts. While a tracked popup is visible, other XAML text laid out on the
-  same UI thread can also be transformed; unrelated Explorer threads remain
-  unaffected. Taskbar thumbnail previews are explicitly excluded.
+- Windows 11 XAML context menus and pointer tooltips use an experimental,
+  display-only DirectWrite hook. Taskbar thumbnail previews and XAML popups
+  related to them are explicitly excluded. While an eligible popup is visible,
+  other XAML text laid out on the same UI thread can also be transformed;
+  unrelated Explorer threads remain unaffected.
 
 The modern path is intentionally conservative and can miss text if a Windows
 build uses a different popup window class. Disable `modernUiText` if it causes
@@ -69,9 +70,9 @@ flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
 The mod doesn't edit system files, registry values, or file names. A file name
 shown in a classic menu can nevertheless be displayed with inserted spaces.
 The modern DirectWrite path changes display text only. The classic path updates
-strings stored in `HMENU` objects, so menu text read through accessibility APIs
-also contains the inserted spaces while the mod is enabled. Strings rewritten
-just before display are recorded and restored when the mod is disabled.
+strings stored in active `HMENU` objects, so menu text read through
+accessibility APIs also contains the inserted spaces while the popup is open.
+Rewritten strings are recorded and restored when the popup closes.
 */
 // ==/WindhawkModReadme==
 
@@ -84,8 +85,8 @@ just before display are recorded and restored when the mod is disabled.
   $name: Classic Win32 tooltips
   $description: Process text in legacy tooltips such as notification-area icon tooltips.
 - modernUiText: true
-  $name: Windows 11 popup text (experimental)
-  $description: Process DirectWrite text in Explorer XAML menus, tooltips, and flyouts.
+  $name: Windows 11 context menus and tooltips (experimental)
+  $description: Process DirectWrite text in Explorer XAML context menus and pointer tooltips.
 - characterMode: unicode
   $name: Non-CJK character set
   $description: Choose which letters and digits form a spacing boundary with CJK.
@@ -383,6 +384,7 @@ TrackPopupMenu_t g_originalTrackPopupMenu;
 TrackPopupMenuEx_t g_originalTrackPopupMenuEx;
 
 struct RewrittenMenuItem {
+    HMENU rootMenu;
     HMENU menu;
     UINT index;
     std::wstring original;
@@ -391,9 +393,43 @@ struct RewrittenMenuItem {
 
 std::mutex g_rewrittenMenuItemsMutex;
 std::vector<RewrittenMenuItem> g_rewrittenMenuItems;
+thread_local unsigned int g_classicPopupMenuDepth = 0;
+thread_local HMENU g_classicPopupRootMenu = nullptr;
+thread_local bool g_restoringClassicMenuText = false;
+
+void RememberRewrittenMenuItem(HMENU menu,
+                               UINT index,
+                               std::wstring original,
+                               std::wstring spaced);
 
 bool IsStringMenuFlags(UINT flags) {
     return !(flags & (MF_BITMAP | MF_OWNERDRAW | MF_SEPARATOR));
+}
+
+int FindMenuItemIndex(HMENU menu, UINT item, bool byPosition) {
+    const int itemCount = GetMenuItemCount(menu);
+    if (itemCount < 0) {
+        return -1;
+    }
+
+    if (byPosition) {
+        return item < static_cast<UINT>(itemCount)
+                   ? static_cast<int>(item)
+                   : -1;
+    }
+
+    for (int index = 0; index < itemCount; ++index) {
+        MENUITEMINFOW itemInfo = {};
+        itemInfo.cbSize = sizeof(itemInfo);
+        itemInfo.fMask = MIIM_ID;
+        if (GetMenuItemInfoW(
+                menu, index, TRUE, &itemInfo) &&
+            itemInfo.wID == item) {
+            return index;
+        }
+    }
+
+    return -1;
 }
 
 BOOL WINAPI InsertMenuWHook(HMENU menu,
@@ -401,13 +437,27 @@ BOOL WINAPI InsertMenuWHook(HMENU menu,
                             UINT flags,
                             UINT_PTR itemId,
                             LPCWSTR newItem) {
-    if (g_classicMenus.load(std::memory_order_relaxed) && newItem &&
+    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+        g_classicMenus.load(std::memory_order_relaxed) && newItem &&
         IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
         if (spaced != newItem) {
             Wh_Log(L"Applied CJK spacing (classic/InsertMenuW)");
-            return g_originalInsertMenuW(menu, position, flags, itemId,
-                                         spaced.c_str());
+            const BOOL result = g_originalInsertMenuW(
+                menu, position, flags, itemId, spaced.c_str());
+            if (result) {
+                const int index = FindMenuItemIndex(
+                    menu,
+                    (flags & MF_BYPOSITION)
+                        ? position
+                        : static_cast<UINT>(itemId),
+                    (flags & MF_BYPOSITION) != 0);
+                if (index >= 0) {
+                    RememberRewrittenMenuItem(
+                        menu, static_cast<UINT>(index), newItem, spaced);
+                }
+            }
+            return result;
         }
     }
 
@@ -418,12 +468,22 @@ BOOL WINAPI AppendMenuWHook(HMENU menu,
                             UINT flags,
                             UINT_PTR itemId,
                             LPCWSTR newItem) {
-    if (g_classicMenus.load(std::memory_order_relaxed) && newItem &&
+    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+        g_classicMenus.load(std::memory_order_relaxed) && newItem &&
         IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
         if (spaced != newItem) {
             Wh_Log(L"Applied CJK spacing (classic/AppendMenuW)");
-            return g_originalAppendMenuW(menu, flags, itemId, spaced.c_str());
+            const BOOL result = g_originalAppendMenuW(
+                menu, flags, itemId, spaced.c_str());
+            if (result) {
+                const int index = GetMenuItemCount(menu) - 1;
+                if (index >= 0) {
+                    RememberRewrittenMenuItem(
+                        menu, static_cast<UINT>(index), newItem, spaced);
+                }
+            }
+            return result;
         }
     }
 
@@ -435,13 +495,21 @@ BOOL WINAPI ModifyMenuWHook(HMENU menu,
                             UINT flags,
                             UINT_PTR itemId,
                             LPCWSTR newItem) {
-    if (g_classicMenus.load(std::memory_order_relaxed) && newItem &&
+    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+        g_classicMenus.load(std::memory_order_relaxed) && newItem &&
         IsStringMenuFlags(flags) && ContainsCjkCodePoint(newItem)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
         if (spaced != newItem) {
             Wh_Log(L"Applied CJK spacing (classic/ModifyMenuW)");
-            return g_originalModifyMenuW(menu, position, flags, itemId,
-                                         spaced.c_str());
+            const int index = FindMenuItemIndex(
+                menu, position, (flags & MF_BYPOSITION) != 0);
+            const BOOL result = g_originalModifyMenuW(
+                menu, position, flags, itemId, spaced.c_str());
+            if (result && index >= 0) {
+                RememberRewrittenMenuItem(
+                    menu, static_cast<UINT>(index), newItem, spaced);
+            }
+            return result;
         }
     }
 
@@ -508,7 +576,8 @@ void RememberRewrittenMenuItem(HMENU menu,
     }
 
     for (auto& item : g_rewrittenMenuItems) {
-        if (item.menu == menu && item.index == index) {
+        if (item.rootMenu == g_classicPopupRootMenu &&
+            item.menu == menu && item.index == index) {
             if (item.spaced != spaced) {
                 item.original = std::move(original);
                 item.spaced = std::move(spaced);
@@ -518,17 +587,32 @@ void RememberRewrittenMenuItem(HMENU menu,
     }
 
     g_rewrittenMenuItems.push_back(
-        {menu, index, std::move(original), std::move(spaced)});
+        {g_classicPopupRootMenu, menu, index, std::move(original),
+         std::move(spaced)});
 }
 
-void RestoreRewrittenMenuItems() {
+void RestoreRewrittenMenuItems(HMENU rootMenu = nullptr) {
     std::vector<RewrittenMenuItem> items;
     {
         std::lock_guard<std::mutex> guard(
             g_rewrittenMenuItemsMutex);
-        items.swap(g_rewrittenMenuItems);
+        if (!rootMenu) {
+            items.swap(g_rewrittenMenuItems);
+        } else {
+            for (auto iterator = g_rewrittenMenuItems.begin();
+                 iterator != g_rewrittenMenuItems.end();) {
+                if (iterator->rootMenu == rootMenu) {
+                    items.push_back(std::move(*iterator));
+                    iterator = g_rewrittenMenuItems.erase(iterator);
+                } else {
+                    ++iterator;
+                }
+            }
+        }
     }
 
+    const bool wasRestoring = g_restoringClassicMenuText;
+    g_restoringClassicMenuText = true;
     for (auto iterator = items.rbegin(); iterator != items.rend();
          ++iterator) {
         if (!IsMenu(iterator->menu)) {
@@ -551,13 +635,15 @@ void RestoreRewrittenMenuItems() {
         SetMenuItemInfoW(
             iterator->menu, iterator->index, TRUE, &replacement);
     }
+    g_restoringClassicMenuText = wasRestoring;
 }
 
 BOOL WINAPI InsertMenuItemWHook(HMENU menu,
                                 UINT item,
                                 BOOL byPosition,
                                 LPCMENUITEMINFOW itemInfo) {
-    if (g_classicMenus.load(std::memory_order_relaxed) &&
+    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+        g_classicMenus.load(std::memory_order_relaxed) &&
         MenuItemInfoContainsString(itemInfo) &&
         ContainsCjkCodePoint(itemInfo->dwTypeData)) {
         const std::wstring spaced = AddCjkSpacing(itemInfo->dwTypeData);
@@ -566,7 +652,22 @@ BOOL WINAPI InsertMenuItemWHook(HMENU menu,
             MENUITEMINFOW copy =
                 CopyMenuItemInfoForRewrite(itemInfo);
             copy.dwTypeData = const_cast<wchar_t*>(spaced.c_str());
-            return g_originalInsertMenuItemW(menu, item, byPosition, &copy);
+            const BOOL result = g_originalInsertMenuItemW(
+                menu, item, byPosition, &copy);
+            if (result) {
+                const int index = FindMenuItemIndex(
+                    menu,
+                    byPosition || !(itemInfo->fMask & MIIM_ID)
+                        ? item
+                        : itemInfo->wID,
+                    byPosition != FALSE);
+                if (index >= 0) {
+                    RememberRewrittenMenuItem(
+                        menu, static_cast<UINT>(index),
+                        itemInfo->dwTypeData, spaced);
+                }
+            }
+            return result;
         }
     }
 
@@ -577,16 +678,26 @@ BOOL WINAPI SetMenuItemInfoWHook(HMENU menu,
                                  UINT item,
                                  BOOL byPosition,
                                  LPCMENUITEMINFOW itemInfo) {
-    if (g_classicMenus.load(std::memory_order_relaxed) &&
+    if (!g_restoringClassicMenuText && g_classicPopupMenuDepth > 0 &&
+        g_classicMenus.load(std::memory_order_relaxed) &&
         MenuItemInfoContainsString(itemInfo) &&
         ContainsCjkCodePoint(itemInfo->dwTypeData)) {
         const std::wstring spaced = AddCjkSpacing(itemInfo->dwTypeData);
         if (spaced != itemInfo->dwTypeData) {
             Wh_Log(L"Applied CJK spacing (classic/SetMenuItemInfoW)");
+            const int index = FindMenuItemIndex(
+                menu, item, byPosition != FALSE);
             MENUITEMINFOW copy =
                 CopyMenuItemInfoForRewrite(itemInfo);
             copy.dwTypeData = const_cast<wchar_t*>(spaced.c_str());
-            return g_originalSetMenuItemInfoW(menu, item, byPosition, &copy);
+            const BOOL result = g_originalSetMenuItemInfoW(
+                menu, item, byPosition, &copy);
+            if (result && index >= 0) {
+                RememberRewrittenMenuItem(
+                    menu, static_cast<UINT>(index),
+                    itemInfo->dwTypeData, spaced);
+            }
+            return result;
         }
     }
 
@@ -644,7 +755,16 @@ BOOL WINAPI TrackPopupMenuHook(HMENU menu,
                                HWND owner,
                                const RECT* rect) {
     if (g_classicMenus.load(std::memory_order_relaxed)) {
+        const HMENU previousRootMenu = g_classicPopupRootMenu;
+        g_classicPopupRootMenu = menu;
+        ++g_classicPopupMenuDepth;
         RewriteMenuTree(menu);
+        const BOOL result = g_originalTrackPopupMenu(
+            menu, flags, x, y, reserved, owner, rect);
+        RestoreRewrittenMenuItems(menu);
+        --g_classicPopupMenuDepth;
+        g_classicPopupRootMenu = previousRootMenu;
+        return result;
     }
 
     return g_originalTrackPopupMenu(menu, flags, x, y, reserved, owner, rect);
@@ -657,7 +777,16 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU menu,
                                  HWND owner,
                                  LPTPMPARAMS parameters) {
     if (g_classicMenus.load(std::memory_order_relaxed)) {
+        const HMENU previousRootMenu = g_classicPopupRootMenu;
+        g_classicPopupRootMenu = menu;
+        ++g_classicPopupMenuDepth;
         RewriteMenuTree(menu);
+        const BOOL result = g_originalTrackPopupMenuEx(
+            menu, flags, x, y, owner, parameters);
+        RestoreRewrittenMenuItems(menu);
+        --g_classicPopupMenuDepth;
+        g_classicPopupRootMenu = previousRootMenu;
+        return result;
     }
 
     return g_originalTrackPopupMenuEx(menu, flags, x, y, owner, parameters);
@@ -1006,6 +1135,41 @@ ModernWindowKind ClassifyModernWindow(HWND window) {
                       : ModernWindowKind::Other;
 }
 
+bool HasWindowClass(HWND window, LPCWSTR expectedClassName) {
+    if (!window) {
+        return false;
+    }
+
+    wchar_t className[128];
+    const int length = GetClassNameW(window, className, ARRAYSIZE(className));
+    return length > 0 && _wcsicmp(className, expectedClassName) == 0;
+}
+
+bool IsTaskbarThumbnailSurface(HWND window) {
+    if (!window) {
+        return false;
+    }
+
+    const HWND root = GetAncestor(window, GA_ROOT);
+    const HWND rootOwner = GetAncestor(window, GA_ROOTOWNER);
+    const HWND candidates[] = {window, root, rootOwner};
+
+    for (HWND candidate : candidates) {
+        if (HasWindowClass(candidate, L"TaskListThumbnailWnd") ||
+            HasWindowClass(candidate, L"XamlExplorerHostIslandWindow")) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool IsCursorInsideTaskbarThumbnailSurface() {
+    POINT cursor;
+    return GetCursorPos(&cursor) &&
+           IsTaskbarThumbnailSurface(WindowFromPoint(cursor));
+}
+
 bool TrackModernWindow(HWND window, ModernWindowKind kind) {
     if (!window || kind == ModernWindowKind::Other) {
         return false;
@@ -1089,6 +1253,10 @@ bool IsModernPopupActiveForCurrentThread() {
         return false;
     }
 
+    if (IsCursorInsideTaskbarThumbnailSurface()) {
+        return false;
+    }
+
     const DWORD currentThreadId = GetCurrentThreadId();
     bool popupActive = false;
     bool taskbarThumbnailActive = false;
@@ -1106,13 +1274,14 @@ bool IsModernPopupActiveForCurrentThread() {
             continue;
         }
 
-        if (iterator->second.threadId == currentThreadId &&
-            IsWindowVisible(iterator->first)) {
+        if (IsWindowVisible(iterator->first)) {
             if (iterator->second.kind ==
-                ModernWindowKind::TaskbarThumbnail) {
+                    ModernWindowKind::TaskbarThumbnail ||
+                (iterator->second.kind == ModernWindowKind::Popup &&
+                 IsTaskbarThumbnailSurface(iterator->first))) {
                 taskbarThumbnailActive = true;
-            } else if (iterator->second.kind ==
-                       ModernWindowKind::Popup) {
+            } else if (iterator->second.threadId == currentThreadId &&
+                       iterator->second.kind == ModernWindowKind::Popup) {
                 popupActive = true;
             }
         }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips; modern XAML UI is opt-in and best-effort because it may conflict with other XAML Diagnostics mods
-// @version         0.1.24
+// @version         0.1.25
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -94,22 +94,19 @@ hosted by Explorer. Each named XAML Diagnostics connection allows one consumer,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
 initializing. Connection attempts are scheduled outside the Windows loader
-path; a single-flight worker retains requests that arrive while it is running,
-tracks the Windows.UI.Xaml and Microsoft.UI.Xaml connections independently,
-and retries only the connection that was lost. The worker pins the mod image
-until `FreeLibraryAndExitThread`, so it cannot execute unloaded mod code.
-In addition to the XAML DLL load hook, creation of the Explorer/taskbar XAML
-host windows is used as an independent initialization trigger, so a module
-loaded through a static import, delay-load helper, or lower-level loader path
-still gets a connection attempt after an Explorer restart.
-If a connection attempt is denied or otherwise fails, host-window creation does
-not retry it repeatedly; a newly loaded XAML module or an established
-connection being disconnected provides the next retry opportunity.
+  path; a single-flight worker retains requests that arrive while it is running,
+  tracks the Windows.UI.Xaml and Microsoft.UI.Xaml connections independently,
+  and retries only the connection that was lost. The worker pins the mod image
+  until `FreeLibraryAndExitThread`, so it cannot execute unloaded mod code.
+  `Wh_ModAfterInit` covers XAML modules that are already loaded, while the
+  `LoadLibraryExW` hook covers modules loaded later, including the
+  `CoreMessagingXP.dll` static-import path used by
+  `Microsoft.Internal.FrameworkUdk.dll`.
+  If a connection attempt is denied or otherwise fails, a newly loaded XAML
+  module or an established connection being disconnected provides the next
+  retry opportunity.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
 consumers, enabling this path can show its confirmation dialog.
-Each reload switches to a new modern-UI generation, so detached workers and
-watcher callbacks from an older load cannot reuse its connection state.
-
 The mod is injected only into `explorer.exe`. Start, Search, and some shell
 flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
 `ShellExperienceHost.exe` are outside its scope.
@@ -490,12 +487,14 @@ constexpr UINT kUnknownMenuItemIndex = static_cast<UINT>(-1);
 
 std::mutex g_rewrittenMenuItemsMutex;
 std::vector<RewrittenMenuItem> g_rewrittenMenuItems;
+std::atomic_uint g_rewrittenMenuItemCount{0};
 thread_local unsigned int g_classicPopupMenuDepth = 0;
 thread_local HMENU g_classicPopupRootMenu = nullptr;
 thread_local bool g_restoringClassicMenuText = false;
 
 std::shared_mutex g_createdClassicPopupMenusMutex;
 std::unordered_set<HMENU> g_createdClassicPopupMenus;
+std::atomic_uint g_createdClassicPopupMenuCount{0};
 
 constexpr unsigned int kMaxMenuDepth = 16;
 
@@ -582,12 +581,31 @@ HMENU WINAPI CreatePopupMenuHook() {
     if (menu) {
         std::lock_guard<std::shared_mutex> guard(
             g_createdClassicPopupMenusMutex);
+        constexpr size_t kCreatedPopupCleanupThreshold = 256;
+        if (g_createdClassicPopupMenus.size() >=
+            kCreatedPopupCleanupThreshold) {
+            std::erase_if(g_createdClassicPopupMenus,
+                          [](HMENU candidate) {
+                              return !IsMenu(candidate);
+                          });
+        }
         g_createdClassicPopupMenus.insert(menu);
+        g_createdClassicPopupMenuCount.store(
+            static_cast<unsigned int>(
+                g_createdClassicPopupMenus.size()),
+            std::memory_order_relaxed);
     }
     return menu;
 }
 
 BOOL WINAPI DestroyMenuHook(HMENU menu) {
+    if (g_rewrittenMenuItemCount.load(
+            std::memory_order_relaxed) == 0 &&
+        g_createdClassicPopupMenuCount.load(
+            std::memory_order_relaxed) == 0) {
+        return g_originalDestroyMenu(menu);
+    }
+
     std::unordered_set<HMENU> menuTree;
     CollectMenuTreeHandles(menu, &menuTree);
 
@@ -605,6 +623,9 @@ BOOL WINAPI DestroyMenuHook(HMENU menu) {
                 ++iterator;
             }
         }
+        g_rewrittenMenuItemCount.store(
+            static_cast<unsigned int>(g_rewrittenMenuItems.size()),
+            std::memory_order_relaxed);
     }
 
     {
@@ -613,6 +634,10 @@ BOOL WINAPI DestroyMenuHook(HMENU menu) {
         for (HMENU handle : menuTree) {
             g_createdClassicPopupMenus.erase(handle);
         }
+        g_createdClassicPopupMenuCount.store(
+            static_cast<unsigned int>(
+                g_createdClassicPopupMenus.size()),
+            std::memory_order_relaxed);
     }
 
     const BOOL result = g_originalDestroyMenu(menu);
@@ -623,6 +648,10 @@ BOOL WINAPI DestroyMenuHook(HMENU menu) {
             for (auto& item : removedItems) {
                 g_rewrittenMenuItems.push_back(std::move(item));
             }
+            g_rewrittenMenuItemCount.store(
+                static_cast<unsigned int>(
+                    g_rewrittenMenuItems.size()),
+                std::memory_order_relaxed);
         }
 
         {
@@ -633,6 +662,10 @@ BOOL WINAPI DestroyMenuHook(HMENU menu) {
                     g_createdClassicPopupMenus.insert(handle);
                 }
             }
+            g_createdClassicPopupMenuCount.store(
+                static_cast<unsigned int>(
+                    g_createdClassicPopupMenus.size()),
+                std::memory_order_relaxed);
         }
     }
 
@@ -655,6 +688,8 @@ void ClearCreatedClassicPopupMenus() {
     std::lock_guard<std::shared_mutex> guard(
         g_createdClassicPopupMenusMutex);
     g_createdClassicPopupMenus.clear();
+    g_createdClassicPopupMenuCount.store(0,
+                                         std::memory_order_relaxed);
 }
 
 bool IsStringMenuFlags(UINT flags) {
@@ -877,6 +912,9 @@ void RememberRewrittenMenuItem(HMENU menu,
     g_rewrittenMenuItems.push_back(
         {g_classicPopupRootMenu, menu, index, std::move(original),
          std::move(spaced)});
+    g_rewrittenMenuItemCount.store(
+        static_cast<unsigned int>(g_rewrittenMenuItems.size()),
+        std::memory_order_relaxed);
 }
 
 void RestoreRewrittenMenuItems(HMENU rootMenu = nullptr) {
@@ -897,6 +935,9 @@ void RestoreRewrittenMenuItems(HMENU rootMenu = nullptr) {
                 }
             }
         }
+        g_rewrittenMenuItemCount.store(
+            static_cast<unsigned int>(g_rewrittenMenuItems.size()),
+            std::memory_order_relaxed);
     }
 
     ScopedBoolValue restoringGuard(g_restoringClassicMenuText, true);
@@ -1126,7 +1167,6 @@ GetWindowTheme_t g_getWindowTheme;
 GetThemeTextExtent_t g_originalGetThemeTextExtent;
 DrawThemeText_t g_originalDrawThemeText;
 DrawThemeTextEx_t g_originalDrawThemeTextEx;
-HMODULE g_loadedUxThemeModule;
 std::shared_mutex g_classicTooltipThemesMutex;
 struct ClassicTooltipTheme {
     unsigned int references = 0;
@@ -1140,17 +1180,6 @@ std::unordered_map<HTHEME, ClassicTooltipTheme> g_classicTooltipThemes;
 std::vector<HTHEME> g_discoveredClassicTooltipThemes;
 std::atomic_uint g_classicTooltipThemeCount{0};
 thread_local bool g_rewritingClassicTooltipText = false;
-
-void ClearUxThemeFunctionPointers() {
-    g_getWindowTheme = nullptr;
-    g_originalOpenThemeData = nullptr;
-    g_originalOpenThemeDataEx = nullptr;
-    g_originalOpenThemeDataForDpi = nullptr;
-    g_originalCloseThemeData = nullptr;
-    g_originalGetThemeTextExtent = nullptr;
-    g_originalDrawThemeText = nullptr;
-    g_originalDrawThemeTextEx = nullptr;
-}
 
 bool IsClassicTooltipThemeClassList(LPCWSTR classList) {
     if (!classList) {
@@ -1224,13 +1253,20 @@ bool UntrackClassicTooltipTheme(HTHEME theme) {
         return false;
     }
 
+    {
+        std::shared_lock<std::shared_mutex> guard(
+            g_classicTooltipThemesMutex);
+        if (!g_classicTooltipThemes.contains(theme)) {
+            return false;
+        }
+    }
+
     std::lock_guard<std::shared_mutex> guard(
         g_classicTooltipThemesMutex);
     const auto iterator = g_classicTooltipThemes.find(theme);
     if (iterator == g_classicTooltipThemes.end()) {
         return false;
     }
-
     if (--iterator->second.references == 0) {
         g_classicTooltipThemes.erase(iterator);
         g_classicTooltipThemeCount.store(
@@ -1301,11 +1337,8 @@ void DiscoverExistingClassicTooltipThemes() {
 }
 
 void CloseDiscoveredClassicTooltipThemes() {
-    if (!g_originalCloseThemeData) {
-        g_discoveredClassicTooltipThemes.clear();
-        return;
-    }
-
+    // Windhawk removes hooks before Wh_ModUninit. Use the linked import here,
+    // not the trampoline that was valid while the hooks were active.
     for (HTHEME theme : g_discoveredClassicTooltipThemes) {
         CloseThemeData(theme);
     }
@@ -1677,6 +1710,7 @@ struct ModernThreadState {
 thread_local std::optional<ModernThreadState>
     g_modernTextStatesForThread{std::in_place};
 
+extern std::atomic_bool g_stoppingModernUi;
 std::mutex g_modernTextStateThreadsMutex;
 std::unordered_map<DWORD, uint64_t> g_modernTextStateThreads;
 
@@ -1725,18 +1759,25 @@ void PruneModernTextStateThreadsLocked() {
     }
 }
 
-void RegisterModernTextStateThread() {
+bool RegisterModernTextStateThread() {
     uint64_t creationTime;
     if (!GetThreadCreationTime(GetCurrentThread(),
                                &creationTime)) {
         Wh_Log(L"Couldn't read the current thread creation time");
-        return;
+        return false;
     }
 
     std::lock_guard<std::mutex> guard(
         g_modernTextStateThreadsMutex);
+    // Pair the thread ID with its creation time. A dead UI thread's ID can be
+    // recycled by a new thread that also owns windows; without this fingerprint
+    // unload could dispatch cleanup into that unrelated thread.
+    if (g_stoppingModernUi.load(std::memory_order_acquire)) {
+        return false;
+    }
     PruneModernTextStateThreadsLocked();
     g_modernTextStateThreads[GetCurrentThreadId()] = creationTime;
+    return true;
 }
 
 void UnregisterModernTextStateThread() {
@@ -1747,13 +1788,12 @@ void UnregisterModernTextStateThread() {
 
 void RemoveModernTextState(ModernThreadState& threadState,
                            const ModernElementKey& key) {
-    const auto stateIterator = threadState.states.find(key);
-    if (stateIterator == threadState.states.end()) {
+    auto node = threadState.states.extract(key);
+    if (node.empty()) {
         return;
     }
 
-    stateIterator->second->Restore();
-    threadState.states.erase(stateIterator);
+    node.mapped()->Restore();
 }
 
 void CleanupModernTextStatesForCurrentThread() {
@@ -1761,12 +1801,13 @@ void CleanupModernTextStatesForCurrentThread() {
         return;
     }
 
-    for (const auto& [key, state] :
-         g_modernTextStatesForThread->states) {
-        state->Restore();
-    }
+    ModernTextStateMap states;
+    states.swap(g_modernTextStatesForThread->states);
     g_modernTextStatesForThread.reset();
     UnregisterModernTextStateThread();
+    for (const auto& [key, state] : states) {
+        state->Restore();
+    }
 }
 
 HMODULE AcquireCurrentModuleReference();
@@ -1783,22 +1824,15 @@ extern std::atomic_bool g_windowsUiXamlDiagnosticsConnected;
 extern std::atomic_bool g_microsoftUiXamlDiagnosticsConnected;
 extern std::atomic_bool g_windowsUiXamlDiagnosticsAttempted;
 extern std::atomic_bool g_microsoftUiXamlDiagnosticsAttempted;
-extern std::atomic_bool g_stoppingModernUi;
-extern std::atomic_uint64_t g_modernUiGeneration;
 extern thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics;
-extern thread_local uint64_t g_connectingXamlDiagnosticsGeneration;
-
-bool IsCurrentModernUiGeneration(uint64_t generation);
 
 class VisualTreeWatcher
     : public winrt::implements<VisualTreeWatcher,
                                IVisualTreeServiceCallback2,
                                winrt::non_agile> {
 public:
-    explicit VisualTreeWatcher(winrt::com_ptr<IUnknown> site,
-                               uint64_t generation)
-        : m_xamlDiagnostics(site.as<IXamlDiagnostics>()),
-          m_generation(generation) {
+    explicit VisualTreeWatcher(winrt::com_ptr<IUnknown> site)
+        : m_xamlDiagnostics(site.as<IXamlDiagnostics>()) {
         m_moduleReference = AcquireCurrentModuleReference();
         if (!m_moduleReference) {
             winrt::throw_hresult(HRESULT_FROM_WIN32(GetLastError()));
@@ -1842,7 +1876,7 @@ public:
         }
     }
 
-    void UnadviseVisualTreeChange() {
+    void UnadviseVisualTreeChange() noexcept {
         m_unadviseRequested.store(true,
                                   std::memory_order_release);
         if (!m_advised.exchange(false,
@@ -1850,9 +1884,13 @@ public:
             return;
         }
 
-        const HRESULT result =
-            m_xamlDiagnostics.as<IVisualTreeService3>()
-                ->UnadviseVisualTreeChange(this);
+        HRESULT result;
+        try {
+            result = m_xamlDiagnostics.as<IVisualTreeService3>()
+                         ->UnadviseVisualTreeChange(this);
+        } catch (...) {
+            result = winrt::to_hresult();
+        }
         if (FAILED(result)) {
             Wh_Log(L"UnadviseVisualTreeChange failed: 0x%08X",
                    result);
@@ -1888,11 +1926,16 @@ private:
             std::make_unique<ModernTextState<Element, SourceAccess>>(
                 element);
         if (!state->Apply()) {
+            if (threadState.states.empty()) {
+                UnregisterModernTextStateThread();
+            }
             return false;
         }
 
-        if (threadState.states.empty()) {
-            RegisterModernTextStateThread();
+        if (threadState.states.empty() &&
+            !RegisterModernTextStateThread()) {
+            state->Restore();
+            return false;
         }
         threadState.states.emplace(key, std::move(state));
         return true;
@@ -1902,7 +1945,7 @@ private:
         ParentChildRelation,
         VisualElement element,
         VisualMutationType mutationType) override try {
-        if (!IsCurrentModernUiGeneration(m_generation)) {
+        if (g_stoppingModernUi.load(std::memory_order_acquire)) {
             return S_OK;
         }
 
@@ -1985,7 +2028,6 @@ private:
 
     winrt::com_ptr<IXamlDiagnostics> m_xamlDiagnostics;
     HMODULE m_moduleReference = nullptr;
-    uint64_t m_generation;
     std::atomic_bool m_advised{false};
     std::atomic_bool m_unadviseRequested{false};
 };
@@ -1996,13 +2038,6 @@ std::optional<std::vector<winrt::com_ptr<VisualTreeWatcher>>>
         g_visualTreeWatchers{std::in_place};
 std::atomic_bool g_stoppingModernUi{false};
 std::atomic_uint64_t g_visualTreeWatcherGeneration;
-std::atomic_uint64_t g_modernUiGeneration{0};
-
-bool IsCurrentModernUiGeneration(uint64_t generation) {
-    return generation ==
-               g_modernUiGeneration.load(std::memory_order_acquire) &&
-           !g_stoppingModernUi.load(std::memory_order_acquire);
-}
 
 bool RemoveVisualTreeWatcher(VisualTreeWatcher* watcher) {
     std::lock_guard<std::mutex> guard(g_visualTreeWatchersMutex);
@@ -2059,12 +2094,6 @@ public:
 
         m_site.copy_from(site);
         if (!site) {
-            if (m_generation !=
-                g_modernUiGeneration.load(std::memory_order_acquire)) {
-                m_flavor = XamlDiagnosticsFlavor::None;
-                return S_OK;
-            }
-
             const XamlDiagnosticsFlavor disconnectedFlavor =
                 m_flavor;
             m_flavor = XamlDiagnosticsFlavor::None;
@@ -2086,11 +2115,6 @@ public:
             return S_OK;
         }
 
-        m_generation =
-            g_connectingXamlDiagnosticsGeneration != 0
-                ? g_connectingXamlDiagnosticsGeneration
-                : g_modernUiGeneration.load(
-                      std::memory_order_acquire);
         if (g_connectingXamlDiagnostics !=
             XamlDiagnosticsFlavor::None) {
             m_flavor = g_connectingXamlDiagnostics;
@@ -2104,14 +2128,13 @@ public:
         {
             std::lock_guard<std::mutex> guard(
                 g_visualTreeWatchersMutex);
-            if (!IsCurrentModernUiGeneration(m_generation) ||
+            if (g_stoppingModernUi.load(std::memory_order_acquire) ||
                 !g_visualTreeWatchers) {
                 return S_OK;
             }
 
             auto watcher =
-                winrt::make_self<VisualTreeWatcher>(
-                    m_site, m_generation);
+                winrt::make_self<VisualTreeWatcher>(m_site);
             g_visualTreeWatchers->push_back(watcher);
             g_visualTreeWatcherGeneration.fetch_add(
                 1, std::memory_order_release);
@@ -2134,7 +2157,6 @@ private:
     winrt::com_ptr<IUnknown> m_site;
     winrt::com_ptr<VisualTreeWatcher> m_watcher;
     XamlDiagnosticsFlavor m_flavor = XamlDiagnosticsFlavor::None;
-    uint64_t m_generation = 0;
 };
 
 template <typename Class>
@@ -2210,17 +2232,10 @@ std::atomic_bool g_xamlDiagnosticsRequestPending{false};
 thread_local bool g_loadingXamlDiagnostics;
 thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics =
     XamlDiagnosticsFlavor::None;
-thread_local uint64_t g_connectingXamlDiagnosticsGeneration = 0;
-
-struct ModernDiagnosticsWorkerContext {
-    HMODULE module;
-    uint64_t generation;
-};
 
 HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
                               LPCWSTR connectionPrefix,
-                              XamlDiagnosticsFlavor flavor,
-                              uint64_t generation) {
+                              XamlDiagnosticsFlavor flavor) {
     const auto initialize =
         reinterpret_cast<InitializeXamlDiagnosticsEx_t>(
             GetProcAddress(xamlModule,
@@ -2244,7 +2259,7 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
 
     HRESULT result = HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
     for (int index = 1; index <= 10000; ++index) {
-        if (!IsCurrentModernUiGeneration(generation)) {
+        if (g_stoppingModernUi.load(std::memory_order_acquire)) {
             return HRESULT_FROM_WIN32(ERROR_CANCELLED);
         }
 
@@ -2253,15 +2268,11 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
                      connectionPrefix, index);
         const XamlDiagnosticsFlavor previousFlavor =
             g_connectingXamlDiagnostics;
-        const uint64_t previousGeneration =
-            g_connectingXamlDiagnosticsGeneration;
         g_connectingXamlDiagnostics = flavor;
-        g_connectingXamlDiagnosticsGeneration = generation;
         result = initialize(
             connectionName, GetCurrentProcessId(), L"",
             modulePath, CLSID_CjkSpacerTap, nullptr);
         g_connectingXamlDiagnostics = previousFlavor;
-        g_connectingXamlDiagnosticsGeneration = previousGeneration;
         if (result != HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) {
             break;
         }
@@ -2270,8 +2281,8 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
     return result;
 }
 
-void EnsureModernXamlDiagnostics(uint64_t generation) {
-    if (!IsCurrentModernUiGeneration(generation) ||
+void EnsureModernXamlDiagnostics() {
+    if (g_stoppingModernUi.load(std::memory_order_acquire) ||
         g_loadingXamlDiagnostics) {
         return;
     }
@@ -2280,7 +2291,7 @@ void EnsureModernXamlDiagnostics(uint64_t generation) {
 
     std::lock_guard<std::mutex> guard(
         g_xamlDiagnosticsInitializationMutex);
-    if (!IsCurrentModernUiGeneration(generation)) {
+    if (g_stoppingModernUi.load(std::memory_order_acquire)) {
         return;
     }
 
@@ -2297,9 +2308,9 @@ void EnsureModernXamlDiagnostics(uint64_t generation) {
                     std::memory_order_acquire);
             const HRESULT result = InjectXamlDiagnostics(
                 module, L"VisualDiagConnection",
-                XamlDiagnosticsFlavor::Windows, generation);
+                XamlDiagnosticsFlavor::Windows);
             if (SUCCEEDED(result) &&
-                IsCurrentModernUiGeneration(generation) &&
+                !g_stoppingModernUi.load(std::memory_order_acquire) &&
                 g_visualTreeWatcherGeneration.load(
                     std::memory_order_acquire) >
                     watcherGeneration) {
@@ -2333,9 +2344,9 @@ void EnsureModernXamlDiagnostics(uint64_t generation) {
                     std::memory_order_acquire);
             const HRESULT result = InjectXamlDiagnostics(
                 module, L"WinUIVisualDiagConnection",
-                XamlDiagnosticsFlavor::Microsoft, generation);
+                XamlDiagnosticsFlavor::Microsoft);
             if (SUCCEEDED(result) &&
-                IsCurrentModernUiGeneration(generation) &&
+                !g_stoppingModernUi.load(std::memory_order_acquire) &&
                 g_visualTreeWatcherGeneration.load(
                     std::memory_order_acquire) >
                     watcherGeneration) {
@@ -2372,15 +2383,12 @@ bool NeedsXamlDiagnosticsConnection() {
 
 void RequestModernXamlDiagnosticsInitialization(
     XamlDiagnosticsFlavor retryFlavor) {
-    const uint64_t generation =
-        g_modernUiGeneration.load(std::memory_order_acquire);
-    if (!IsCurrentModernUiGeneration(generation)) {
+    if (g_stoppingModernUi.load(std::memory_order_acquire)) {
         return;
     }
 
     // A new XAML module load or a previously established connection being
-    // torn down is an explicit retry opportunity. Window creation alone must
-    // not keep retrying a connection another diagnostics tool denied.
+    // torn down is an explicit retry opportunity.
     if (retryFlavor == XamlDiagnosticsFlavor::Windows) {
         g_windowsUiXamlDiagnosticsAttempted.store(
             false, std::memory_order_release);
@@ -2389,9 +2397,9 @@ void RequestModernXamlDiagnosticsInitialization(
             false, std::memory_order_release);
     }
 
-    // Host-window creation can be noisy. Once all currently loaded XAML
-    // diagnostics connections are established, avoid creating another worker
-    // until SetSite(nullptr) explicitly marks one as disconnected.
+    // Once all currently loaded XAML diagnostics connections are established,
+    // avoid creating another worker until SetSite(nullptr) explicitly marks
+    // one as disconnected.
     if (!NeedsXamlDiagnosticsConnection()) {
         return;
     }
@@ -2411,44 +2419,30 @@ void RequestModernXamlDiagnosticsInitialization(
     // until the worker exits through FreeLibraryAndExitThread.
     HMODULE module = AcquireCurrentModuleReference();
     if (!module) {
-        if (IsCurrentModernUiGeneration(generation)) {
+        if (!g_stoppingModernUi.load(std::memory_order_acquire)) {
             g_xamlDiagnosticsWorkerRunning.store(
                 false, std::memory_order_release);
+            Wh_Log(L"Couldn't retain the mod for XAML diagnostics");
         }
-        Wh_Log(L"Couldn't retain the mod for XAML diagnostics");
         return;
     }
 
-    auto context = std::unique_ptr<ModernDiagnosticsWorkerContext>(
-        new (std::nothrow) ModernDiagnosticsWorkerContext{
-            module, generation});
-    if (!context) {
-        g_xamlDiagnosticsWorkerRunning.store(
-            false, std::memory_order_release);
-        FreeLibrary(module);
-        Wh_Log(L"Couldn't allocate the XAML diagnostics context");
-        return;
-    }
     HANDLE thread = CreateThread(
         nullptr, 0,
         [](LPVOID parameter) -> DWORD {
-            auto context = std::unique_ptr<ModernDiagnosticsWorkerContext>(
-                static_cast<ModernDiagnosticsWorkerContext*>(parameter));
-            const HMODULE module = context->module;
-            const uint64_t generation = context->generation;
-            context.reset();
+            const HMODULE module = static_cast<HMODULE>(parameter);
             const HRESULT initializeResult =
                 CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-            while (IsCurrentModernUiGeneration(generation) &&
+            while (!g_stoppingModernUi.load(std::memory_order_acquire) &&
                    g_xamlDiagnosticsRequestPending.exchange(
                        false, std::memory_order_acq_rel)) {
-                EnsureModernXamlDiagnostics(generation);
+                EnsureModernXamlDiagnostics();
             }
             if (SUCCEEDED(initializeResult)) {
                 CoUninitialize();
             }
 
-            if (IsCurrentModernUiGeneration(generation)) {
+            if (!g_stoppingModernUi.load(std::memory_order_acquire)) {
                 g_xamlDiagnosticsWorkerRunning.store(
                     false, std::memory_order_release);
                 if (g_xamlDiagnosticsRequestPending.load(
@@ -2458,21 +2452,19 @@ void RequestModernXamlDiagnosticsInitialization(
             }
             FreeLibraryAndExitThread(module, 0);
         },
-        context.get(), 0, nullptr);
+        module, 0, nullptr);
     if (!thread) {
         const DWORD error = GetLastError();
-        context.reset();
-        if (IsCurrentModernUiGeneration(generation)) {
+        if (!g_stoppingModernUi.load(std::memory_order_acquire)) {
             g_xamlDiagnosticsWorkerRunning.store(
                 false, std::memory_order_release);
+            Wh_Log(L"Couldn't create the XAML diagnostics thread: %u",
+                   error);
         }
         FreeLibrary(module);
-        Wh_Log(L"Couldn't create the XAML diagnostics thread: %u",
-               error);
         return;
     }
 
-    context.release();
     CloseHandle(thread);
 }
 
@@ -2545,12 +2537,6 @@ HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
     return module;
 }
 
-bool IsTextualWindowClassName(LPCWSTR className) {
-    return className &&
-           (reinterpret_cast<ULONG_PTR>(className) &
-            ~static_cast<ULONG_PTR>(0xFFFF)) != 0;
-}
-
 bool IsModernXamlHostClassName(LPCWSTR className) {
     return className &&
            (_wcsicmp(
@@ -2559,142 +2545,6 @@ bool IsModernXamlHostClassName(LPCWSTR className) {
             _wcsicmp(className, L"XamlExplorerHostIslandWindow") == 0 ||
             _wcsicmp(
                 className, L"XamlExplorerHostIslandWindow_WASDK") == 0);
-}
-
-bool IsModernXamlHostWindow(HWND window,
-                            HWND parent,
-                            LPCWSTR className) {
-    if (!window || !IsTextualWindowClassName(className)) {
-        return false;
-    }
-
-    if (_wcsicmp(
-            className,
-            L"Windows.UI.Composition.DesktopWindowContentBridge") == 0) {
-        wchar_t parentClassName[64];
-        return parent &&
-               GetClassNameW(
-                   parent, parentClassName, ARRAYSIZE(parentClassName)) > 0 &&
-               _wcsicmp(parentClassName, L"Shell_TrayWnd") == 0;
-    }
-
-    return IsModernXamlHostClassName(className);
-}
-
-void OnModernXamlHostWindowCreated(HWND window,
-                                   HWND parent,
-                                   LPCWSTR className,
-                                   LPCWSTR source) {
-    if (!g_modernUiText.load(std::memory_order_relaxed) ||
-        !IsModernXamlHostWindow(window, parent, className)) {
-        return;
-    }
-
-    Wh_Log(L"Modern XAML initialization requested by %s (%s)",
-           source, className);
-    // Window creation is an independent trigger from LoadLibraryExW. It also
-    // covers XAML modules mapped through static imports, delay-load helpers,
-    // or lower-level loader calls that don't pass through our loader hook.
-    RequestModernXamlDiagnosticsInitialization();
-}
-
-using CreateWindowExW_t = decltype(&CreateWindowExW);
-CreateWindowExW_t g_originalCreateWindowExW;
-
-HWND WINAPI CreateWindowExWHook(DWORD exStyle,
-                                LPCWSTR className,
-                                LPCWSTR windowName,
-                                DWORD style,
-                                int x,
-                                int y,
-                                int width,
-                                int height,
-                                HWND parent,
-                                HMENU menu,
-                                HINSTANCE instance,
-                                PVOID parameter) {
-    HWND window = g_originalCreateWindowExW(
-        exStyle, className, windowName, style, x, y, width, height,
-        parent, menu, instance, parameter);
-    OnModernXamlHostWindowCreated(
-        window, parent, className, L"CreateWindowExW");
-    return window;
-}
-
-using CreateWindowInBand_t = HWND(WINAPI*)(
-    DWORD exStyle,
-    LPCWSTR className,
-    LPCWSTR windowName,
-    DWORD style,
-    int x,
-    int y,
-    int width,
-    int height,
-    HWND parent,
-    HMENU menu,
-    HINSTANCE instance,
-    PVOID parameter,
-    DWORD band);
-CreateWindowInBand_t g_originalCreateWindowInBand;
-
-HWND WINAPI CreateWindowInBandHook(DWORD exStyle,
-                                    LPCWSTR className,
-                                    LPCWSTR windowName,
-                                    DWORD style,
-                                    int x,
-                                    int y,
-                                    int width,
-                                    int height,
-                                    HWND parent,
-                                    HMENU menu,
-                                    HINSTANCE instance,
-                                    PVOID parameter,
-                                    DWORD band) {
-    HWND window = g_originalCreateWindowInBand(
-        exStyle, className, windowName, style, x, y, width, height,
-        parent, menu, instance, parameter, band);
-    OnModernXamlHostWindowCreated(
-        window, parent, className, L"CreateWindowInBand");
-    return window;
-}
-
-using CreateWindowInBandEx_t = HWND(WINAPI*)(
-    DWORD exStyle,
-    LPCWSTR className,
-    LPCWSTR windowName,
-    DWORD style,
-    int x,
-    int y,
-    int width,
-    int height,
-    HWND parent,
-    HMENU menu,
-    HINSTANCE instance,
-    PVOID parameter,
-    DWORD band,
-    DWORD typeFlags);
-CreateWindowInBandEx_t g_originalCreateWindowInBandEx;
-
-HWND WINAPI CreateWindowInBandExHook(DWORD exStyle,
-                                      LPCWSTR className,
-                                      LPCWSTR windowName,
-                                      DWORD style,
-                                      int x,
-                                      int y,
-                                      int width,
-                                      int height,
-                                      HWND parent,
-                                      HMENU menu,
-                                      HINSTANCE instance,
-                                      PVOID parameter,
-                                      DWORD band,
-                                      DWORD typeFlags) {
-    HWND window = g_originalCreateWindowInBandEx(
-        exStyle, className, windowName, style, x, y, width, height,
-        parent, menu, instance, parameter, band, typeFlags);
-    OnModernXamlHostWindowCreated(
-        window, parent, className, L"CreateWindowInBandEx");
-    return window;
 }
 
 using RunFromWindowThreadProc_t = void(WINAPI*)(PVOID parameter);
@@ -2777,7 +2627,6 @@ HWND FindWindowForThread(DWORD threadId) {
 
 void InitializeModernUi() {
     g_stoppingModernUi.store(true, std::memory_order_release);
-    g_modernUiGeneration.fetch_add(1, std::memory_order_acq_rel);
     g_windowsUiXamlDiagnosticsConnected.store(
         false, std::memory_order_release);
     g_microsoftUiXamlDiagnosticsConnected.store(
@@ -2871,113 +2720,97 @@ bool InstallHook(Function target,
     return true;
 }
 
+bool HookClassicMenus() {
+    return InstallHook(
+               CreatePopupMenu, CreatePopupMenuHook,
+               &g_originalCreatePopupMenu, L"CreatePopupMenu") &&
+           InstallHook(
+               DestroyMenu, DestroyMenuHook,
+               &g_originalDestroyMenu, L"DestroyMenu") &&
+           InstallHook(
+               InsertMenuW, InsertMenuWHook,
+               &g_originalInsertMenuW, L"InsertMenuW") &&
+           InstallHook(
+               AppendMenuW, AppendMenuWHook,
+               &g_originalAppendMenuW, L"AppendMenuW") &&
+           InstallHook(
+               ModifyMenuW, ModifyMenuWHook,
+               &g_originalModifyMenuW, L"ModifyMenuW") &&
+           InstallHook(
+               InsertMenuItemW, InsertMenuItemWHook,
+               &g_originalInsertMenuItemW, L"InsertMenuItemW") &&
+           InstallHook(
+               SetMenuItemInfoW, SetMenuItemInfoWHook,
+               &g_originalSetMenuItemInfoW, L"SetMenuItemInfoW") &&
+           InstallHook(
+               TrackPopupMenu, TrackPopupMenuHook,
+               &g_originalTrackPopupMenu, L"TrackPopupMenu") &&
+           InstallHook(
+               TrackPopupMenuEx, TrackPopupMenuExHook,
+               &g_originalTrackPopupMenuEx, L"TrackPopupMenuEx");
+}
+
 bool HookClassicTooltipThemeDrawing() {
     HMODULE themeModule = GetModuleHandleW(L"uxtheme.dll");
     if (!themeModule) {
-        themeModule = LoadLibraryExW(
-            L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-        if (themeModule) {
-            g_loadedUxThemeModule = themeModule;
-        }
-    }
-    if (!themeModule) {
-        Wh_Log(L"Couldn't load uxtheme.dll");
+        Wh_Log(L"Couldn't find linked uxtheme.dll");
         return false;
     }
 
-    bool hooked = false;
-
     g_getWindowTheme = reinterpret_cast<GetWindowTheme_t>(
         GetProcAddress(themeModule, "GetWindowTheme"));
-    if (!g_getWindowTheme) {
-        Wh_Log(L"Couldn't find GetWindowTheme");
-    }
-
     const auto openThemeData =
         reinterpret_cast<OpenThemeData_t>(
             GetProcAddress(themeModule, "OpenThemeData"));
-    if (openThemeData) {
-        hooked |= InstallHook(
-            openThemeData, OpenThemeDataHook,
-            &g_originalOpenThemeData, L"OpenThemeData");
-    } else {
-        Wh_Log(L"Couldn't find OpenThemeData");
-    }
-
     const auto openThemeDataEx =
         reinterpret_cast<OpenThemeDataEx_t>(
             GetProcAddress(themeModule, "OpenThemeDataEx"));
-    if (openThemeDataEx) {
-        hooked |= InstallHook(
-            openThemeDataEx, OpenThemeDataExHook,
-            &g_originalOpenThemeDataEx, L"OpenThemeDataEx");
-    } else {
-        Wh_Log(L"Couldn't find OpenThemeDataEx");
-    }
-
     const auto openThemeDataForDpi =
         reinterpret_cast<OpenThemeDataForDpi_t>(
             GetProcAddress(themeModule, "OpenThemeDataForDpi"));
-    if (openThemeDataForDpi) {
-        hooked |= InstallHook(
-            openThemeDataForDpi, OpenThemeDataForDpiHook,
-            &g_originalOpenThemeDataForDpi,
-            L"OpenThemeDataForDpi");
-    } else {
-        Wh_Log(L"Couldn't find OpenThemeDataForDpi");
-    }
-
     const auto closeThemeData =
         reinterpret_cast<CloseThemeData_t>(
             GetProcAddress(themeModule, "CloseThemeData"));
-    if (closeThemeData) {
-        hooked |= InstallHook(
-            closeThemeData, CloseThemeDataHook,
-            &g_originalCloseThemeData, L"CloseThemeData");
-    } else {
-        Wh_Log(L"Couldn't find CloseThemeData");
-    }
-
     const auto getThemeTextExtent =
         reinterpret_cast<GetThemeTextExtent_t>(
             GetProcAddress(themeModule, "GetThemeTextExtent"));
-    if (getThemeTextExtent) {
-        hooked |= InstallHook(
-            getThemeTextExtent, GetThemeTextExtentHook,
-            &g_originalGetThemeTextExtent,
-            L"GetThemeTextExtent");
-    } else {
-        Wh_Log(L"Couldn't find GetThemeTextExtent");
-    }
-
     const auto drawThemeText =
         reinterpret_cast<DrawThemeText_t>(
             GetProcAddress(themeModule, "DrawThemeText"));
-    if (drawThemeText) {
-        hooked |= InstallHook(
-            drawThemeText, DrawThemeTextHook,
-            &g_originalDrawThemeText, L"DrawThemeText");
-    } else {
-        Wh_Log(L"Couldn't find DrawThemeText");
-    }
-
     const auto drawThemeTextEx =
         reinterpret_cast<DrawThemeTextEx_t>(
             GetProcAddress(themeModule, "DrawThemeTextEx"));
-    if (drawThemeTextEx) {
-        hooked |= InstallHook(
-            drawThemeTextEx, DrawThemeTextExHook,
-            &g_originalDrawThemeTextEx, L"DrawThemeTextEx");
-    } else {
-        Wh_Log(L"Couldn't find DrawThemeTextEx");
+
+    if (!g_getWindowTheme || !openThemeData || !openThemeDataEx ||
+        !openThemeDataForDpi || !closeThemeData ||
+        !getThemeTextExtent || !drawThemeText || !drawThemeTextEx) {
+        Wh_Log(L"Couldn't resolve all required uxtheme functions");
+        return false;
     }
 
-    if (!hooked && g_loadedUxThemeModule) {
-        FreeLibrary(g_loadedUxThemeModule);
-        g_loadedUxThemeModule = nullptr;
-        ClearUxThemeFunctionPointers();
-    }
-    return hooked;
+    return InstallHook(
+               openThemeData, OpenThemeDataHook,
+               &g_originalOpenThemeData, L"OpenThemeData") &&
+           InstallHook(
+               openThemeDataEx, OpenThemeDataExHook,
+               &g_originalOpenThemeDataEx, L"OpenThemeDataEx") &&
+           InstallHook(
+               openThemeDataForDpi, OpenThemeDataForDpiHook,
+               &g_originalOpenThemeDataForDpi,
+               L"OpenThemeDataForDpi") &&
+           InstallHook(
+               closeThemeData, CloseThemeDataHook,
+               &g_originalCloseThemeData, L"CloseThemeData") &&
+           InstallHook(
+               getThemeTextExtent, GetThemeTextExtentHook,
+               &g_originalGetThemeTextExtent,
+               L"GetThemeTextExtent") &&
+           InstallHook(
+               drawThemeText, DrawThemeTextHook,
+               &g_originalDrawThemeText, L"DrawThemeText") &&
+           InstallHook(
+               drawThemeTextEx, DrawThemeTextExHook,
+               &g_originalDrawThemeTextEx, L"DrawThemeTextEx");
 }
 
 bool ReadUnicodeLettersAndDigitsSetting() {
@@ -3018,71 +2851,16 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
-    bool installedAnyHook = false;
-
-    if (classicMenusEnabled) {
-        installedAnyHook |= InstallHook(
-            CreatePopupMenu, CreatePopupMenuHook,
-            &g_originalCreatePopupMenu, L"CreatePopupMenu");
-        installedAnyHook |= InstallHook(
-            DestroyMenu, DestroyMenuHook,
-            &g_originalDestroyMenu, L"DestroyMenu");
-        installedAnyHook |= InstallHook(
-            InsertMenuW, InsertMenuWHook, &g_originalInsertMenuW,
-            L"InsertMenuW");
-        installedAnyHook |= InstallHook(
-            AppendMenuW, AppendMenuWHook, &g_originalAppendMenuW,
-            L"AppendMenuW");
-        installedAnyHook |= InstallHook(
-            ModifyMenuW, ModifyMenuWHook, &g_originalModifyMenuW,
-            L"ModifyMenuW");
-        installedAnyHook |= InstallHook(
-            InsertMenuItemW, InsertMenuItemWHook,
-            &g_originalInsertMenuItemW, L"InsertMenuItemW");
-        installedAnyHook |= InstallHook(
-            SetMenuItemInfoW, SetMenuItemInfoWHook,
-            &g_originalSetMenuItemInfoW, L"SetMenuItemInfoW");
-        installedAnyHook |= InstallHook(
-            TrackPopupMenu, TrackPopupMenuHook,
-            &g_originalTrackPopupMenu, L"TrackPopupMenu");
-        installedAnyHook |= InstallHook(
-            TrackPopupMenuEx, TrackPopupMenuExHook,
-            &g_originalTrackPopupMenuEx, L"TrackPopupMenuEx");
+    if (classicMenusEnabled && !HookClassicMenus()) {
+        return FALSE;
     }
 
-    if (classicTooltipsEnabled) {
-        installedAnyHook |= HookClassicTooltipThemeDrawing();
+    if (classicTooltipsEnabled &&
+        !HookClassicTooltipThemeDrawing()) {
+        return FALSE;
     }
 
     if (modernUiTextEnabled) {
-        InitializeModernUi();
-        installedAnyHook |= InstallHook(
-            CreateWindowExW, CreateWindowExWHook,
-            &g_originalCreateWindowExW, L"CreateWindowExW");
-
-        HMODULE user32Module = GetModuleHandleW(L"user32.dll");
-        if (user32Module) {
-            const auto createWindowInBand =
-                reinterpret_cast<CreateWindowInBand_t>(
-                    GetProcAddress(user32Module, "CreateWindowInBand"));
-            if (createWindowInBand) {
-                installedAnyHook |= InstallHook(
-                    createWindowInBand, CreateWindowInBandHook,
-                    &g_originalCreateWindowInBand,
-                    L"CreateWindowInBand");
-            }
-
-            const auto createWindowInBandEx =
-                reinterpret_cast<CreateWindowInBandEx_t>(
-                    GetProcAddress(user32Module, "CreateWindowInBandEx"));
-            if (createWindowInBandEx) {
-                installedAnyHook |= InstallHook(
-                    createWindowInBandEx, CreateWindowInBandExHook,
-                    &g_originalCreateWindowInBandEx,
-                    L"CreateWindowInBandEx");
-            }
-        }
-
         HMODULE kernelBaseModule =
             GetModuleHandleW(L"kernelbase.dll");
         const auto loadLibraryExW =
@@ -3092,13 +2870,17 @@ BOOL Wh_ModInit() {
                                      "LoadLibraryExW"))
                 : nullptr;
         if (loadLibraryExW) {
-            installedAnyHook |= InstallHook(
-                loadLibraryExW, LoadLibraryExWHook,
-                &g_originalLoadLibraryExW,
-                L"kernelbase!LoadLibraryExW");
+            if (!InstallHook(
+                    loadLibraryExW, LoadLibraryExWHook,
+                    &g_originalLoadLibraryExW,
+                    L"kernelbase!LoadLibraryExW")) {
+                return FALSE;
+            }
         } else {
             Wh_Log(L"Couldn't find kernelbase!LoadLibraryExW");
+            return FALSE;
         }
+        InitializeModernUi();
     }
 
     Wh_Log(L"Initialized (classicMenus=%d, "
@@ -3106,9 +2888,7 @@ BOOL Wh_ModInit() {
            g_classicMenus.load(), g_classicTooltips.load(),
            g_modernUiText.load(),
            g_unicodeLettersAndDigits.load());
-    // The modern path can still initialize against XAML modules that are
-    // already loaded even if the late-load notification hook is unavailable.
-    return installedAnyHook || modernUiTextEnabled ? TRUE : FALSE;
+    return TRUE;
 }
 
 void Wh_ModAfterInit() {
@@ -3121,6 +2901,14 @@ void Wh_ModAfterInit() {
     }
 }
 
+void Wh_ModBeforeUninit() {
+    if (g_modernUiText.load(std::memory_order_relaxed)) {
+        // Stop new COM callbacks before Windhawk begins removing function
+        // hooks. UninitializeModernUi performs the owning-thread restoration.
+        g_stoppingModernUi.store(true, std::memory_order_release);
+    }
+}
+
 void Wh_ModUninit() {
     RestoreRewrittenMenuItems();
     ClearCreatedClassicPopupMenus();
@@ -3128,10 +2916,6 @@ void Wh_ModUninit() {
     ClearTrackedClassicTooltipThemes();
     if (g_modernUiText.load(std::memory_order_relaxed)) {
         UninitializeModernUi();
-    }
-    if (g_loadedUxThemeModule) {
-        FreeLibrary(g_loadedUxThemeModule);
-        g_loadedUxThemeModule = nullptr;
     }
     Wh_Log(L"Uninitialized");
 }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -1,14 +1,14 @@
 // ==WindhawkMod==
 // @id              cjk-spacer
 // @name            CJK Spacer
-// @description     Add spaces between CJK characters and letters or digits in File Explorer context-menu text
-// @version         0.1.0
+// @description     Add spaces between CJK characters and letters or digits in Explorer menus and tooltips
+// @version         0.1.1
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -ldwrite
+// @compilerOptions -lole32
 // ==/WindhawkMod==
 
 // Source code is published under the GNU General Public License v3.0.
@@ -21,7 +21,7 @@
 # CJK Spacer
 
 Adds a normal ASCII space at a direct boundary between a CJK character and a
-letter or digit in File Explorer context-menu UI text.
+letter or digit in UI text hosted by `explorer.exe`.
 
 Examples:
 
@@ -34,20 +34,24 @@ The transformation is idempotent. Punctuation and existing whitespace break a
 boundary and are preserved. Win32 `&` mnemonic markers and tab-separated
 keyboard shortcut text are also preserved.
 
-## Menu implementations
+## Supported UI
 
-- Classic menus are rewritten through public Win32 `HMENU` APIs.
-- The Windows 11 menu uses an experimental, display-only DirectWrite hook while
-  a XAML/WinUI popup window is being created or displayed.
+- Classic Win32 popup menus are rewritten through public `HMENU` APIs. This
+  includes File Explorer, desktop, taskbar, tray, and jump-list menus hosted by
+  `explorer.exe`.
+- Windows 11 context menus and XAML/WinUI tooltips use an experimental,
+  display-only DirectWrite hook. UI Automation is used when a popup is shown to
+  distinguish menus and tooltips from other Explorer flyouts.
 
-The modern-menu path is intentionally conservative, but Windows doesn't expose
-a supported global filter for menu titles. It can miss text on some Windows
-builds, and it can also affect text in another Explorer XAML popup while that
-popup is visible. Disable `modernMenus` if it causes a problem.
+The modern path is intentionally conservative and can miss text if a Windows
+build exposes a different popup accessibility tree. Disable `modernUiText` if
+it causes a problem.
 
-This mod changes only text rendered by `explorer.exe`. It doesn't edit system
-files, registry values, file names, or the text returned to assistive
-technologies.
+The mod doesn't edit system files, registry values, or file names. The modern
+DirectWrite path changes display text only. The classic path updates strings
+stored in `HMENU` objects, so menu text read through accessibility APIs also
+contains the inserted spaces. Resource-loaded classic menus can retain those
+strings after the mod is disabled until Explorer restarts.
 */
 // ==/WindhawkModReadme==
 
@@ -56,18 +60,15 @@ technologies.
 - classicMenus: true
   $name: Classic context menus
   $description: Process classic Win32 popup-menu text.
-- modernMenus: true
-  $name: Windows 11 context menus (experimental)
-  $description: Process text rendered while an Explorer XAML/WinUI popup is active.
+- modernUiText: true
+  $name: Windows 11 menus and tooltips (experimental)
+  $description: Process DirectWrite text in Explorer XAML/WinUI context menus and tooltips.
 - characterMode: unicode
   $name: Non-CJK character set
   $description: Choose which letters and digits form a spacing boundary with CJK.
   $options:
   - unicode: Unicode letters and digits
   - ascii: ASCII letters and digits only
-- debugLogging: false
-  $name: Debug logging
-  $description: Log each changed menu string to Windhawk's log output.
 */
 // ==/WindhawkModSettings==
 
@@ -79,6 +80,8 @@ technologies.
 #include <vector>
 
 #include <dwrite.h>
+#include <initguid.h>
+#include <uiautomation.h>
 #include <windows.h>
 
 namespace {
@@ -91,16 +94,9 @@ enum class CharacterKind {
 };
 
 std::atomic_bool g_classicMenus{true};
-std::atomic_bool g_modernMenus{true};
+std::atomic_bool g_modernUiText{true};
 std::atomic_bool g_unicodeLettersAndDigits{true};
-std::atomic_bool g_debugLogging{false};
-
-// XAML usually creates or shows its popup before laying out the menu text.
-// This short activity window covers layout that happens before the popup HWND
-// becomes visible.
-std::atomic<ULONGLONG> g_modernPopupActivityUntil{0};
-std::atomic<ULONGLONG> g_lastPopupScanTick{0};
-std::atomic_bool g_lastPopupScanResult{false};
+std::atomic_uint g_activeModernPopupCount{0};
 
 bool IsHighSurrogate(wchar_t value) {
     return value >= 0xD800 && value <= 0xDBFF;
@@ -137,8 +133,10 @@ bool IsCjkCodePoint(uint32_t codePoint) {
 
     // CJK radicals, Kangxi radicals, kana, Bopomofo, Hangul compatibility
     // Jamo, CJK strokes, and Katakana phonetic extensions. CJK punctuation is
-    // deliberately excluded.
+    // deliberately excluded except for the ideographic iteration mark and
+    // ideographic zero.
     if (IsInRange(codePoint, 0x2E80, 0x2FDF) ||
+        codePoint == 0x3005 || codePoint == 0x3007 ||
         IsInRange(codePoint, 0x3040, 0x30FF) ||
         IsInRange(codePoint, 0x3100, 0x318F) ||
         IsInRange(codePoint, 0x31A0, 0x31BF) ||
@@ -187,6 +185,7 @@ bool IsExtendingCodePoint(uint32_t codePoint) {
            IsInRange(codePoint, 0x20D0, 0x20FF) ||
            IsInRange(codePoint, 0xFE00, 0xFE0F) ||
            IsInRange(codePoint, 0xFE20, 0xFE2F) ||
+           IsInRange(codePoint, 0xFF9E, 0xFF9F) ||
            IsInRange(codePoint, 0xE0100, 0xE01EF);
 }
 
@@ -197,6 +196,14 @@ bool IsAsciiLetterOrDigit(uint32_t codePoint) {
 }
 
 bool IsUnicodeLetterOrDigit(uint32_t codePoint) {
+    // Fullwidth Latin letters and digits already have ideographic advance
+    // widths, so inserting an extra ASCII space is typographically redundant.
+    if (IsInRange(codePoint, 0xFF10, 0xFF19) ||
+        IsInRange(codePoint, 0xFF21, 0xFF3A) ||
+        IsInRange(codePoint, 0xFF41, 0xFF5A)) {
+        return false;
+    }
+
     wchar_t utf16[2];
     int length;
 
@@ -251,7 +258,23 @@ bool NeedsSpace(CharacterKind left, CharacterKind right) {
 // an optional Win32 mnemonic '&' prefix. Keeping the prefix in the token makes
 // "打开&Open" become "打开 &Open", which Windows displays as "打开 Open"
 // while preserving the O mnemonic.
-std::wstring AddCjkSpacing(std::wstring_view text) {
+bool ContainsCjkCodePoint(std::wstring_view text) {
+    size_t offset = 0;
+    while (offset < text.size()) {
+        size_t codeUnitCount;
+        const uint32_t codePoint =
+            DecodeCodePoint(text, offset, &codeUnitCount);
+        if (IsCjkCodePoint(codePoint)) {
+            return true;
+        }
+        offset += codeUnitCount;
+    }
+
+    return false;
+}
+
+std::wstring AddCjkSpacing(std::wstring_view text,
+                           bool preserveMnemonics = true) {
     std::wstring result;
     result.reserve(text.size() + 4);
 
@@ -261,7 +284,7 @@ std::wstring AddCjkSpacing(std::wstring_view text) {
     while (offset < text.size()) {
         const size_t tokenStart = offset;
 
-        if (text[offset] == L'&') {
+        if (preserveMnemonics && text[offset] == L'&') {
             if (offset + 1 < text.size() && text[offset + 1] == L'&') {
                 // An escaped ampersand is visible punctuation.
                 result.append(text.substr(offset, 2));
@@ -310,19 +333,6 @@ std::wstring AddCjkSpacing(std::wstring_view text) {
     return result;
 }
 
-void LogReplacement(const wchar_t* source,
-                    std::wstring_view before,
-                    std::wstring_view after) {
-    if (!g_debugLogging.load(std::memory_order_relaxed)) {
-        return;
-    }
-
-    const std::wstring beforeCopy(before);
-    const std::wstring afterCopy(after);
-    Wh_Log(L"%s: \"%s\" -> \"%s\"", source, beforeCopy.c_str(),
-           afterCopy.c_str());
-}
-
 // -------------------------------------------------------------------------
 // Classic Win32 menus
 // -------------------------------------------------------------------------
@@ -356,7 +366,7 @@ BOOL WINAPI InsertMenuWHook(HMENU menu,
         IsStringMenuFlags(flags)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
         if (spaced != newItem) {
-            LogReplacement(L"classic/InsertMenuW", newItem, spaced);
+            Wh_Log(L"Applied CJK spacing (classic/InsertMenuW)");
             return g_originalInsertMenuW(menu, position, flags, itemId,
                                          spaced.c_str());
         }
@@ -373,7 +383,7 @@ BOOL WINAPI AppendMenuWHook(HMENU menu,
         IsStringMenuFlags(flags)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
         if (spaced != newItem) {
-            LogReplacement(L"classic/AppendMenuW", newItem, spaced);
+            Wh_Log(L"Applied CJK spacing (classic/AppendMenuW)");
             return g_originalAppendMenuW(menu, flags, itemId, spaced.c_str());
         }
     }
@@ -390,7 +400,7 @@ BOOL WINAPI ModifyMenuWHook(HMENU menu,
         IsStringMenuFlags(flags)) {
         const std::wstring spaced = AddCjkSpacing(newItem);
         if (spaced != newItem) {
-            LogReplacement(L"classic/ModifyMenuW", newItem, spaced);
+            Wh_Log(L"Applied CJK spacing (classic/ModifyMenuW)");
             return g_originalModifyMenuW(menu, position, flags, itemId,
                                          spaced.c_str());
         }
@@ -421,8 +431,7 @@ BOOL WINAPI InsertMenuItemWHook(HMENU menu,
         MenuItemInfoContainsString(itemInfo)) {
         const std::wstring spaced = AddCjkSpacing(itemInfo->dwTypeData);
         if (spaced != itemInfo->dwTypeData) {
-            LogReplacement(L"classic/InsertMenuItemW", itemInfo->dwTypeData,
-                           spaced);
+            Wh_Log(L"Applied CJK spacing (classic/InsertMenuItemW)");
             MENUITEMINFOW copy = *itemInfo;
             copy.dwTypeData = const_cast<wchar_t*>(spaced.c_str());
             copy.cch = static_cast<UINT>(spaced.size());
@@ -441,8 +450,7 @@ BOOL WINAPI SetMenuItemInfoWHook(HMENU menu,
         MenuItemInfoContainsString(itemInfo)) {
         const std::wstring spaced = AddCjkSpacing(itemInfo->dwTypeData);
         if (spaced != itemInfo->dwTypeData) {
-            LogReplacement(L"classic/SetMenuItemInfoW", itemInfo->dwTypeData,
-                           spaced);
+            Wh_Log(L"Applied CJK spacing (classic/SetMenuItemInfoW)");
             MENUITEMINFOW copy = *itemInfo;
             copy.dwTypeData = const_cast<wchar_t*>(spaced.c_str());
             copy.cch = static_cast<UINT>(spaced.size());
@@ -477,7 +485,7 @@ void RewriteMenuTree(HMENU menu) {
                 const std::wstring original(buffer.data(), itemInfo.cch);
                 const std::wstring spaced = AddCjkSpacing(original);
                 if (spaced != original) {
-                    LogReplacement(L"classic/pre-display", original, spaced);
+                    Wh_Log(L"Applied CJK spacing (classic/pre-display)");
 
                     MENUITEMINFOW replacement = {};
                     replacement.cbSize = sizeof(replacement);
@@ -485,12 +493,7 @@ void RewriteMenuTree(HMENU menu) {
                     replacement.dwTypeData =
                         const_cast<wchar_t*>(spaced.c_str());
                     replacement.cch = static_cast<UINT>(spaced.size());
-                    if (g_originalSetMenuItemInfoW) {
-                        g_originalSetMenuItemInfoW(menu, index, TRUE,
-                                                   &replacement);
-                    } else {
-                        SetMenuItemInfoW(menu, index, TRUE, &replacement);
-                    }
+                    SetMenuItemInfoW(menu, index, TRUE, &replacement);
                 }
             }
         }
@@ -529,31 +532,37 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU menu,
 }
 
 // -------------------------------------------------------------------------
-// Windows 11 XAML/WinUI popup detection
+// Windows 11 XAML/WinUI menu and tooltip detection
 // -------------------------------------------------------------------------
 
-using CreateWindowExW_t = decltype(&CreateWindowExW);
 using ShowWindow_t = decltype(&ShowWindow);
 using SetWindowPos_t = decltype(&SetWindowPos);
+using DestroyWindow_t = decltype(&DestroyWindow);
 
-CreateWindowExW_t g_originalCreateWindowExW;
 ShowWindow_t g_originalShowWindow;
 SetWindowPos_t g_originalSetWindowPos;
+DestroyWindow_t g_originalDestroyWindow;
 
-bool IsStringClassName(LPCWSTR className) {
-    return className &&
-           reinterpret_cast<ULONG_PTR>(className) > 0xFFFF;
-}
+enum class ModernPopupKind : ULONG_PTR {
+    Unclassified = 0,
+    Menu = 1,
+    ToolTip = 2,
+};
+
+constexpr wchar_t kModernPopupKindProperty[] =
+    L"CJKSpacer_ModernPopupKind";
+
+thread_local bool g_detectingModernPopupKind = false;
 
 bool IsModernPopupClassName(LPCWSTR className) {
-    if (!IsStringClassName(className)) {
+    if (!className ||
+        reinterpret_cast<ULONG_PTR>(className) <= 0xFFFF) {
         return false;
     }
 
     return _wcsicmp(className, L"Xaml_WindowedPopupClass") == 0 ||
            _wcsicmp(className,
-                    L"Microsoft.UI.Content.PopupWindowSiteBridge") == 0 ||
-           wcsstr(className, L"PopupWindowSiteBridge") != nullptr;
+                    L"Microsoft.UI.Content.PopupWindowSiteBridge") == 0;
 }
 
 bool IsModernPopupWindow(HWND window) {
@@ -562,104 +571,191 @@ bool IsModernPopupWindow(HWND window) {
     return length > 0 && IsModernPopupClassName(className);
 }
 
-void MarkModernPopupActivity() {
-    g_modernPopupActivityUntil.store(GetTickCount64() + 1000,
-                                     std::memory_order_relaxed);
+template <typename Interface>
+void ReleaseComInterface(Interface*& value) {
+    if (value) {
+        value->Release();
+        value = nullptr;
+    }
 }
 
-HWND WINAPI CreateWindowExWHook(DWORD extendedStyle,
-                                LPCWSTR className,
-                                LPCWSTR windowName,
-                                DWORD style,
-                                int x,
-                                int y,
-                                int width,
-                                int height,
-                                HWND parent,
-                                HMENU menu,
-                                HINSTANCE instance,
-                                LPVOID parameter) {
-    if (g_modernMenus.load(std::memory_order_relaxed) &&
-        IsModernPopupClassName(className)) {
-        MarkModernPopupActivity();
+bool PopupContainsControlType(IUIAutomation* automation,
+                              IUIAutomationElement* root,
+                              CONTROLTYPEID controlType) {
+    VARIANT propertyValue = {};
+    propertyValue.vt = VT_I4;
+    propertyValue.lVal = controlType;
+
+    IUIAutomationCondition* condition = nullptr;
+    HRESULT result = automation->CreatePropertyCondition(
+        UIA_ControlTypePropertyId, propertyValue, &condition);
+    if (FAILED(result) || !condition) {
+        return false;
     }
 
-    HWND window = g_originalCreateWindowExW(
-        extendedStyle, className, windowName, style, x, y, width, height,
-        parent, menu, instance, parameter);
-
-    if (g_modernMenus.load(std::memory_order_relaxed) && window &&
-        IsModernPopupWindow(window)) {
-        MarkModernPopupActivity();
-    }
-
-    return window;
+    IUIAutomationElement* match = nullptr;
+    result = root->FindFirst(TreeScope_Subtree, condition, &match);
+    const bool found = SUCCEEDED(result) && match;
+    ReleaseComInterface(condition);
+    ReleaseComInterface(match);
+    return found;
 }
 
-BOOL WINAPI ShowWindowHook(HWND window, int command) {
-    if (g_modernMenus.load(std::memory_order_relaxed) &&
-        command != SW_HIDE && IsModernPopupWindow(window)) {
-        MarkModernPopupActivity();
+ModernPopupKind DetectModernPopupKind(HWND window) {
+    if (g_detectingModernPopupKind) {
+        return ModernPopupKind::Unclassified;
     }
 
-    return g_originalShowWindow(window, command);
-}
+    g_detectingModernPopupKind = true;
 
-BOOL WINAPI SetWindowPosHook(HWND window,
-                             HWND insertAfter,
-                             int x,
-                             int y,
-                             int width,
-                             int height,
-                             UINT flags) {
-    if (g_modernMenus.load(std::memory_order_relaxed) &&
-        (flags & SWP_SHOWWINDOW) && IsModernPopupWindow(window)) {
-        MarkModernPopupActivity();
+    CO_MTA_USAGE_COOKIE mtaCookie;
+    const bool mtaUsageIncreased =
+        SUCCEEDED(CoIncrementMTAUsage(&mtaCookie));
+
+    IUIAutomation* automation = nullptr;
+    IUIAutomationElement* root = nullptr;
+    ModernPopupKind kind = ModernPopupKind::Unclassified;
+
+    HRESULT result = CoCreateInstance(
+        CLSID_CUIAutomation, nullptr, CLSCTX_INPROC_SERVER,
+        IID_PPV_ARGS(&automation));
+    if (SUCCEEDED(result) && automation) {
+        result = automation->ElementFromHandle(window, &root);
     }
 
-    return g_originalSetWindowPos(window, insertAfter, x, y, width, height,
-                                  flags);
-}
-
-struct PopupScanContext {
-    DWORD processId;
-    bool found;
-};
-
-BOOL CALLBACK FindVisibleModernPopup(HWND window, LPARAM parameter) {
-    auto* context = reinterpret_cast<PopupScanContext*>(parameter);
-
-    DWORD processId;
-    GetWindowThreadProcessId(window, &processId);
-    if (processId == context->processId && IsWindowVisible(window) &&
-        IsModernPopupWindow(window)) {
-        context->found = true;
-        return FALSE;
+    if (SUCCEEDED(result) && root) {
+        if (PopupContainsControlType(automation, root,
+                                     UIA_MenuControlTypeId)) {
+            kind = ModernPopupKind::Menu;
+        } else if (PopupContainsControlType(
+                       automation, root, UIA_ToolTipControlTypeId)) {
+            kind = ModernPopupKind::ToolTip;
+        }
     }
 
-    return TRUE;
+    ReleaseComInterface(root);
+    ReleaseComInterface(automation);
+
+    if (mtaUsageIncreased) {
+        CoDecrementMTAUsage(mtaCookie);
+    }
+
+    g_detectingModernPopupKind = false;
+    return kind;
 }
 
-bool IsModernPopupActive() {
-    const ULONGLONG now = GetTickCount64();
-    if (now <=
-        g_modernPopupActivityUntil.load(std::memory_order_relaxed)) {
+ModernPopupKind GetTrackedModernPopupKind(HWND window) {
+    return static_cast<ModernPopupKind>(
+        reinterpret_cast<ULONG_PTR>(
+            GetPropW(window, kModernPopupKindProperty)));
+}
+
+bool IsSupportedModernPopupKind(ModernPopupKind kind) {
+    return kind == ModernPopupKind::Menu ||
+           kind == ModernPopupKind::ToolTip;
+}
+
+bool TrackModernPopup(HWND window) {
+    if (GetTrackedModernPopupKind(window) !=
+        ModernPopupKind::Unclassified) {
         return true;
     }
 
-    const ULONGLONG lastScan =
-        g_lastPopupScanTick.load(std::memory_order_relaxed);
-    if (now >= lastScan && now - lastScan < 50) {
-        return g_lastPopupScanResult.load(std::memory_order_relaxed);
+    const ModernPopupKind kind = DetectModernPopupKind(window);
+    if (!IsSupportedModernPopupKind(kind)) {
+        return false;
     }
 
-    PopupScanContext context = {GetCurrentProcessId(), false};
-    EnumWindows(FindVisibleModernPopup,
-                reinterpret_cast<LPARAM>(&context));
+    if (!SetPropW(window, kModernPopupKindProperty,
+                  reinterpret_cast<HANDLE>(
+                      static_cast<ULONG_PTR>(kind)))) {
+        return false;
+    }
 
-    g_lastPopupScanResult.store(context.found, std::memory_order_relaxed);
-    g_lastPopupScanTick.store(now, std::memory_order_relaxed);
-    return context.found;
+    g_activeModernPopupCount.fetch_add(1, std::memory_order_relaxed);
+    Wh_Log(L"Tracking modern %s popup",
+           kind == ModernPopupKind::Menu ? L"menu" : L"tooltip");
+    return true;
+}
+
+void UntrackModernPopup(HWND window) {
+    const ModernPopupKind kind = GetTrackedModernPopupKind(window);
+    if (!IsSupportedModernPopupKind(kind)) {
+        return;
+    }
+
+    RemovePropW(window, kModernPopupKindProperty);
+    const unsigned int previous =
+        g_activeModernPopupCount.fetch_sub(1, std::memory_order_relaxed);
+    if (previous == 0) {
+        g_activeModernPopupCount.store(0, std::memory_order_relaxed);
+    }
+}
+
+bool IsModernPopupActive() {
+    return g_activeModernPopupCount.load(std::memory_order_relaxed) != 0;
+}
+
+BOOL WINAPI ShowWindowHook(HWND window, int command) {
+    const bool modernUiEnabled =
+        g_modernUiText.load(std::memory_order_relaxed);
+    const bool isModernPopup = IsModernPopupWindow(window);
+    const bool showing = command != SW_HIDE;
+
+    if (modernUiEnabled && isModernPopup && showing) {
+        TrackModernPopup(window);
+    }
+
+    const BOOL result = g_originalShowWindow(window, command);
+
+    if (isModernPopup) {
+        if (!showing || !IsWindowVisible(window)) {
+            UntrackModernPopup(window);
+        } else if (modernUiEnabled &&
+                   GetTrackedModernPopupKind(window) ==
+                   ModernPopupKind::Unclassified) {
+            TrackModernPopup(window);
+        }
+    }
+
+    return result;
+}
+
+BOOL WINAPI SetWindowPosHook(HWND window,
+                            HWND insertAfter,
+                            int x,
+                            int y,
+                            int width,
+                            int height,
+                            UINT flags) {
+    const bool modernUiEnabled =
+        g_modernUiText.load(std::memory_order_relaxed);
+    const bool isModernPopup = IsModernPopupWindow(window);
+
+    if (modernUiEnabled && isModernPopup &&
+        (flags & SWP_SHOWWINDOW)) {
+        TrackModernPopup(window);
+    }
+
+    const BOOL result = g_originalSetWindowPos(
+        window, insertAfter, x, y, width, height, flags);
+
+    if (isModernPopup && result) {
+        if (flags & SWP_HIDEWINDOW) {
+            UntrackModernPopup(window);
+        } else if (modernUiEnabled && (flags & SWP_SHOWWINDOW) &&
+                   GetTrackedModernPopupKind(window) ==
+                       ModernPopupKind::Unclassified) {
+            TrackModernPopup(window);
+        }
+    }
+
+    return result;
+}
+
+BOOL WINAPI DestroyWindowHook(HWND window) {
+    UntrackModernPopup(window);
+    return g_originalDestroyWindow(window);
 }
 
 // -------------------------------------------------------------------------
@@ -690,9 +786,6 @@ using IDWriteFactory_CreateGdiCompatibleTextLayout_t =
 IDWriteFactory_CreateTextLayout_t g_originalCreateTextLayout;
 IDWriteFactory_CreateGdiCompatibleTextLayout_t
     g_originalCreateGdiCompatibleTextLayout;
-IDWriteFactory_CreateTextLayout_t g_originalCoreCreateTextLayout;
-IDWriteFactory_CreateGdiCompatibleTextLayout_t
-    g_originalCoreCreateGdiCompatibleTextLayout;
 
 HRESULT CreateTextLayoutWithSpacing(
     IDWriteFactory_CreateTextLayout_t originalFunction,
@@ -704,11 +797,17 @@ HRESULT CreateTextLayoutWithSpacing(
     FLOAT maxWidth,
     FLOAT maxHeight,
     IDWriteTextLayout** textLayout) {
-    if (g_modernMenus.load(std::memory_order_relaxed) && text) {
+    if (g_modernUiText.load(std::memory_order_relaxed) && text &&
+        IsModernPopupActive()) {
         const std::wstring_view original(text, textLength);
-        const std::wstring spaced = AddCjkSpacing(original);
-        if (spaced.size() != original.size() && IsModernPopupActive()) {
-            LogReplacement(source, original, spaced);
+        if (!ContainsCjkCodePoint(original)) {
+            return originalFunction(factory, text, textLength, textFormat,
+                                    maxWidth, maxHeight, textLayout);
+        }
+
+        const std::wstring spaced = AddCjkSpacing(original, false);
+        if (spaced.size() != original.size()) {
+            Wh_Log(L"Applied CJK spacing (%s)", source);
             return originalFunction(
                 factory, spaced.c_str(), static_cast<UINT32>(spaced.size()),
                 textFormat, maxWidth, maxHeight, textLayout);
@@ -732,11 +831,19 @@ HRESULT CreateGdiCompatibleTextLayoutWithSpacing(
     const DWRITE_MATRIX* transform,
     BOOL useGdiNatural,
     IDWriteTextLayout** textLayout) {
-    if (g_modernMenus.load(std::memory_order_relaxed) && text) {
+    if (g_modernUiText.load(std::memory_order_relaxed) && text &&
+        IsModernPopupActive()) {
         const std::wstring_view original(text, textLength);
-        const std::wstring spaced = AddCjkSpacing(original);
-        if (spaced.size() != original.size() && IsModernPopupActive()) {
-            LogReplacement(source, original, spaced);
+        if (!ContainsCjkCodePoint(original)) {
+            return originalFunction(
+                factory, text, textLength, textFormat, layoutWidth,
+                layoutHeight, pixelsPerDip, transform, useGdiNatural,
+                textLayout);
+        }
+
+        const std::wstring spaced = AddCjkSpacing(original, false);
+        if (spaced.size() != original.size()) {
+            Wh_Log(L"Applied CJK spacing (%s)", source);
             return originalFunction(
                 factory, spaced.c_str(), static_cast<UINT32>(spaced.size()),
                 textFormat, layoutWidth, layoutHeight, pixelsPerDip, transform,
@@ -777,38 +884,6 @@ HRESULT STDMETHODCALLTYPE CreateGdiCompatibleTextLayoutHook(
     return CreateGdiCompatibleTextLayoutWithSpacing(
         g_originalCreateGdiCompatibleTextLayout,
         L"modern/DirectWrite/CreateGdiCompatibleTextLayout", factory, text,
-        textLength, textFormat, layoutWidth, layoutHeight, pixelsPerDip,
-        transform, useGdiNatural, textLayout);
-}
-
-HRESULT STDMETHODCALLTYPE CoreCreateTextLayoutHook(
-    IDWriteFactory* factory,
-    const WCHAR* text,
-    UINT32 textLength,
-    IDWriteTextFormat* textFormat,
-    FLOAT maxWidth,
-    FLOAT maxHeight,
-    IDWriteTextLayout** textLayout) {
-    return CreateTextLayoutWithSpacing(
-        g_originalCoreCreateTextLayout,
-        L"modern/DWriteCore/CreateTextLayout", factory, text, textLength,
-        textFormat, maxWidth, maxHeight, textLayout);
-}
-
-HRESULT STDMETHODCALLTYPE CoreCreateGdiCompatibleTextLayoutHook(
-    IDWriteFactory* factory,
-    const WCHAR* text,
-    UINT32 textLength,
-    IDWriteTextFormat* textFormat,
-    FLOAT layoutWidth,
-    FLOAT layoutHeight,
-    FLOAT pixelsPerDip,
-    const DWRITE_MATRIX* transform,
-    BOOL useGdiNatural,
-    IDWriteTextLayout** textLayout) {
-    return CreateGdiCompatibleTextLayoutWithSpacing(
-        g_originalCoreCreateGdiCompatibleTextLayout,
-        L"modern/DWriteCore/CreateGdiCompatibleTextLayout", factory, text,
         textLength, textFormat, layoutWidth, layoutHeight, pixelsPerDip,
         transform, useGdiNatural, textLayout);
 }
@@ -878,31 +953,16 @@ bool HookDirectWrite() {
         Wh_Log(L"Couldn't load dwrite.dll");
     }
 
-    // Windows App SDK uses the same IDWriteFactory ABI through DWriteCore.
-    // Don't load a second copy from an arbitrary location; hook it only when
-    // Explorer already has the module loaded.
-    HMODULE dwriteCore = GetModuleHandleW(L"DWriteCore.dll");
-    if (dwriteCore) {
-        hooked |= HookDWriteFactory(
-            dwriteCore, "DWriteCoreCreateFactory",
-            reinterpret_cast<void*>(CoreCreateTextLayoutHook),
-            &g_originalCoreCreateTextLayout,
-            reinterpret_cast<void*>(
-                CoreCreateGdiCompatibleTextLayoutHook),
-            &g_originalCoreCreateGdiCompatibleTextLayout, L"DWriteCore");
-    } else if (g_debugLogging.load(std::memory_order_relaxed)) {
-        Wh_Log(L"DWriteCore.dll isn't loaded in Explorer; skipping it");
-    }
-
     return hooked;
 }
 
 template <typename Function>
 bool InstallHook(Function target,
-                 void* hook,
+                 Function hook,
                  Function* original,
                  const wchar_t* name) {
-    if (!Wh_SetFunctionHook(reinterpret_cast<void*>(target), hook,
+    if (!Wh_SetFunctionHook(reinterpret_cast<void*>(target),
+                            reinterpret_cast<void*>(hook),
                             reinterpret_cast<void**>(original))) {
         Wh_Log(L"Couldn't hook %s", name);
         return false;
@@ -914,19 +974,15 @@ bool InstallHook(Function target,
 void LoadSettings() {
     g_classicMenus.store(Wh_GetIntSetting(L"classicMenus") != 0,
                          std::memory_order_relaxed);
-    g_modernMenus.store(Wh_GetIntSetting(L"modernMenus") != 0,
-                        std::memory_order_relaxed);
-    g_debugLogging.store(Wh_GetIntSetting(L"debugLogging") != 0,
+    g_modernUiText.store(Wh_GetIntSetting(L"modernUiText") != 0,
                          std::memory_order_relaxed);
 
     PCWSTR characterMode = Wh_GetStringSetting(L"characterMode");
     const bool unicodeMode =
-        characterMode && _wcsicmp(characterMode, L"ascii") != 0;
+        _wcsicmp(characterMode, L"ascii") != 0;
     g_unicodeLettersAndDigits.store(unicodeMode,
                                     std::memory_order_relaxed);
-    if (characterMode) {
-        Wh_FreeStringSetting(characterMode);
-    }
+    Wh_FreeStringSetting(characterMode);
 }
 
 }  // namespace
@@ -934,50 +990,45 @@ void LoadSettings() {
 BOOL Wh_ModInit() {
     LoadSettings();
 
+    if (!g_classicMenus.load(std::memory_order_relaxed) &&
+        !g_modernUiText.load(std::memory_order_relaxed)) {
+        Wh_Log(L"CJK Spacer has no enabled UI targets");
+        return FALSE;
+    }
+
     bool installedAnyHook = false;
 
-    installedAnyHook |= InstallHook(InsertMenuW,
-                                    reinterpret_cast<void*>(InsertMenuWHook),
+    installedAnyHook |= InstallHook(InsertMenuW, InsertMenuWHook,
                                     &g_originalInsertMenuW, L"InsertMenuW");
-    installedAnyHook |= InstallHook(AppendMenuW,
-                                    reinterpret_cast<void*>(AppendMenuWHook),
+    installedAnyHook |= InstallHook(AppendMenuW, AppendMenuWHook,
                                     &g_originalAppendMenuW, L"AppendMenuW");
-    installedAnyHook |= InstallHook(ModifyMenuW,
-                                    reinterpret_cast<void*>(ModifyMenuWHook),
+    installedAnyHook |= InstallHook(ModifyMenuW, ModifyMenuWHook,
                                     &g_originalModifyMenuW, L"ModifyMenuW");
     installedAnyHook |=
-        InstallHook(InsertMenuItemW,
-                    reinterpret_cast<void*>(InsertMenuItemWHook),
+        InstallHook(InsertMenuItemW, InsertMenuItemWHook,
                     &g_originalInsertMenuItemW, L"InsertMenuItemW");
     installedAnyHook |=
-        InstallHook(SetMenuItemInfoW,
-                    reinterpret_cast<void*>(SetMenuItemInfoWHook),
+        InstallHook(SetMenuItemInfoW, SetMenuItemInfoWHook,
                     &g_originalSetMenuItemInfoW, L"SetMenuItemInfoW");
     installedAnyHook |=
-        InstallHook(TrackPopupMenu,
-                    reinterpret_cast<void*>(TrackPopupMenuHook),
+        InstallHook(TrackPopupMenu, TrackPopupMenuHook,
                     &g_originalTrackPopupMenu, L"TrackPopupMenu");
     installedAnyHook |=
-        InstallHook(TrackPopupMenuEx,
-                    reinterpret_cast<void*>(TrackPopupMenuExHook),
+        InstallHook(TrackPopupMenuEx, TrackPopupMenuExHook,
                     &g_originalTrackPopupMenuEx, L"TrackPopupMenuEx");
 
-    installedAnyHook |=
-        InstallHook(CreateWindowExW,
-                    reinterpret_cast<void*>(CreateWindowExWHook),
-                    &g_originalCreateWindowExW, L"CreateWindowExW");
-    installedAnyHook |= InstallHook(ShowWindow,
-                                    reinterpret_cast<void*>(ShowWindowHook),
+    installedAnyHook |= InstallHook(ShowWindow, ShowWindowHook,
                                     &g_originalShowWindow, L"ShowWindow");
-    installedAnyHook |=
-        InstallHook(SetWindowPos,
-                    reinterpret_cast<void*>(SetWindowPosHook),
+    installedAnyHook |= InstallHook(SetWindowPos, SetWindowPosHook,
                     &g_originalSetWindowPos, L"SetWindowPos");
+    installedAnyHook |= InstallHook(DestroyWindow, DestroyWindowHook,
+                                    &g_originalDestroyWindow,
+                                    L"DestroyWindow");
 
     installedAnyHook |= HookDirectWrite();
 
     Wh_Log(L"CJK Spacer initialized (classic=%d, modern=%d, unicode=%d)",
-           g_classicMenus.load(), g_modernMenus.load(),
+           g_classicMenus.load(), g_modernUiText.load(),
            g_unicodeLettersAndDigits.load());
     return installedAnyHook ? TRUE : FALSE;
 }
@@ -989,6 +1040,6 @@ void Wh_ModUninit() {
 void Wh_ModSettingsChanged() {
     LoadSettings();
     Wh_Log(L"CJK Spacer settings changed (classic=%d, modern=%d, unicode=%d)",
-           g_classicMenus.load(), g_modernMenus.load(),
+           g_classicMenus.load(), g_modernUiText.load(),
            g_unicodeLettersAndDigits.load());
 }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.13
+// @version         0.1.14
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -69,7 +69,9 @@ The modern path supports both Windows.UI.Xaml and Microsoft.UI.Xaml content
 hosted by Explorer. XAML Diagnostics allows one consumer per XAML connection,
 so another diagnostics-based customization tool, including Windows 11 Taskbar
 Styler or Windows 11 File Explorer Styler, can prevent this path from
-initializing.
+initializing. Connection attempts are scheduled outside the Windows loader
+path so XAML modules that load later are handled without doing COM activation
+under the loader lock.
 
 The mod is injected only into `explorer.exe`. Start, Search, and some shell
 flyouts hosted by `StartMenuExperienceHost.exe`, `SearchHost.exe`, or
@@ -1278,18 +1280,6 @@ public:
                 return;
             }
 
-            if (m_modified) {
-                if (current == m_spacedText) {
-                    return;
-                }
-
-                // The application updated the source while it was tracked.
-                // Preserve that update and use it as the new source.
-                m_modified = false;
-                m_originalText.clear();
-                m_spacedText.clear();
-            }
-
             if (!ContainsCjkCodePoint(current)) {
                 return;
             }
@@ -1439,7 +1429,6 @@ void RegisterModernTextStateThread() {
 
     std::lock_guard<std::mutex> guard(
         g_modernTextStateThreadsMutex);
-    PruneModernTextStateThreadsLocked();
     g_modernTextStateThreads[GetCurrentThreadId()] = creationTime;
 }
 
@@ -1684,6 +1673,19 @@ HMODULE GetCurrentModuleHandle() {
     return module;
 }
 
+HMODULE AcquireCurrentModuleReference() {
+    HMODULE module;
+    if (!GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+            reinterpret_cast<LPCWSTR>(
+                &AcquireCurrentModuleReference),
+            &module)) {
+        return nullptr;
+    }
+
+    return module;
+}
+
 class WindhawkTap
     : public winrt::implements<WindhawkTap,
                                IObjectWithSite,
@@ -1807,6 +1809,8 @@ using InitializeXamlDiagnosticsEx_t =
 std::mutex g_xamlDiagnosticsInitializationMutex;
 bool g_windowsUiXamlDiagnosticsConnected;
 bool g_microsoftUiXamlDiagnosticsConnected;
+std::atomic_bool g_xamlDiagnosticsWorkerRunning{false};
+thread_local bool g_loadingXamlDiagnostics;
 
 HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
                               LPCWSTR connectionPrefix) {
@@ -1852,9 +1856,22 @@ HRESULT InjectXamlDiagnostics(HMODULE xamlModule,
 }
 
 void EnsureModernXamlDiagnostics() {
-    if (g_stoppingModernUi.load(std::memory_order_relaxed)) {
+    if (g_stoppingModernUi.load(std::memory_order_relaxed) ||
+        g_loadingXamlDiagnostics) {
         return;
     }
+
+    struct LoadingGuard {
+        explicit LoadingGuard(bool& flag) : flag(flag) {
+            flag = true;
+        }
+
+        ~LoadingGuard() {
+            flag = false;
+        }
+
+        bool& flag;
+    } loadingGuard(g_loadingXamlDiagnostics);
 
     std::lock_guard<std::mutex> guard(
         g_xamlDiagnosticsInitializationMutex);
@@ -1919,9 +1936,58 @@ void EnsureModernXamlDiagnostics() {
     }
 }
 
+void RequestModernXamlDiagnosticsInitialization() {
+    if (g_stoppingModernUi.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    bool expected = false;
+    if (!g_xamlDiagnosticsWorkerRunning.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel)) {
+        return;
+    }
+
+    // The worker isn't joined during unload, so keep the mod image loaded
+    // until the worker exits through FreeLibraryAndExitThread.
+    HMODULE module = AcquireCurrentModuleReference();
+    if (!module) {
+        g_xamlDiagnosticsWorkerRunning.store(
+            false, std::memory_order_release);
+        Wh_Log(L"Couldn't retain the mod for XAML diagnostics");
+        return;
+    }
+
+    HANDLE thread = CreateThread(
+        nullptr, 0,
+        [](LPVOID parameter) -> DWORD {
+            HMODULE module = static_cast<HMODULE>(parameter);
+            const HRESULT initializeResult =
+                CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+            EnsureModernXamlDiagnostics();
+            if (SUCCEEDED(initializeResult)) {
+                CoUninitialize();
+            }
+
+            g_xamlDiagnosticsWorkerRunning.store(
+                false, std::memory_order_release);
+            FreeLibraryAndExitThread(module, 0);
+        },
+        module, 0, nullptr);
+    if (!thread) {
+        const DWORD error = GetLastError();
+        g_xamlDiagnosticsWorkerRunning.store(
+            false, std::memory_order_release);
+        FreeLibrary(module);
+        Wh_Log(L"Couldn't create the XAML diagnostics thread: %u",
+               error);
+        return;
+    }
+
+    CloseHandle(thread);
+}
+
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 LoadLibraryExW_t g_originalLoadLibraryExW;
-thread_local bool g_loadingXamlDiagnostics;
 
 bool IsXamlDiagnosticsTriggerModule(LPCWSTR path) {
     if (!path) {
@@ -1942,12 +2008,11 @@ HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
     HMODULE module =
         g_originalLoadLibraryExW(fileName, file, flags);
     if (module &&
-        !g_loadingXamlDiagnostics &&
         g_modernUiText.load(std::memory_order_relaxed) &&
         IsXamlDiagnosticsTriggerModule(fileName)) {
-        g_loadingXamlDiagnostics = true;
-        EnsureModernXamlDiagnostics();
-        g_loadingXamlDiagnostics = false;
+        // Don't load the TAP or activate COM while the caller might hold the
+        // Windows loader lock.
+        RequestModernXamlDiagnosticsInitialization();
     }
     return module;
 }
@@ -2267,9 +2332,22 @@ BOOL Wh_ModInit() {
 
     if (modernUiTextEnabled) {
         InitializeModernUi();
-        installedAnyHook |= InstallHook(
-            LoadLibraryExW, LoadLibraryExWHook,
-            &g_originalLoadLibraryExW, L"LoadLibraryExW");
+        HMODULE kernelBaseModule =
+            GetModuleHandleW(L"kernelbase.dll");
+        const auto loadLibraryExW =
+            kernelBaseModule
+                ? reinterpret_cast<LoadLibraryExW_t>(
+                      GetProcAddress(kernelBaseModule,
+                                     "LoadLibraryExW"))
+                : nullptr;
+        if (loadLibraryExW) {
+            installedAnyHook |= InstallHook(
+                loadLibraryExW, LoadLibraryExWHook,
+                &g_originalLoadLibraryExW,
+                L"kernelbase!LoadLibraryExW");
+        } else {
+            Wh_Log(L"Couldn't find kernelbase!LoadLibraryExW");
+        }
     }
 
     Wh_Log(L"CJK Spacer initialized (classicMenus=%d, "
@@ -2286,7 +2364,7 @@ void Wh_ModAfterInit() {
     }
 
     if (g_modernUiText.load(std::memory_order_relaxed)) {
-        EnsureModernXamlDiagnostics();
+        RequestModernXamlDiagnosticsInitialization();
     }
 }
 

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -2,7 +2,7 @@
 // @id              cjk-spacer
 // @name            CJK Spacer
 // @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips
-// @version         0.1.6
+// @version         0.1.7
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -51,8 +51,10 @@ keyboard shortcut text are also preserved.
   tray, and jump-list context menus hosted by `explorer.exe`.
 - Classic Win32 tooltips, including legacy notification-area icon tooltips, are
   rewritten only through theme handles opened for the `TOOLTIP` class, covering
-  both text measurement and drawing without touching unrelated GDI text. Basic
-  or classic-theme tooltips drawn directly with `DrawTextW` aren't covered.
+  both text measurement and drawing without touching unrelated GDI text.
+  Existing tooltip controls are discovered when the mod is enabled in a
+  running Explorer. Basic or classic-theme tooltips drawn directly with
+  `DrawTextW` aren't covered.
 - Windows 11 XAML context menus and pointer tooltips use an experimental,
   display-only DirectWrite hook. Taskbar thumbnail previews and XAML popups
   related to them are explicitly excluded. While an eligible popup is visible,
@@ -101,15 +103,19 @@ Rewritten strings are recorded and restored when the popup closes.
 #include <cstring>
 #include <cwchar>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+#include <windows.h>
+
+#include <commctrl.h>
 #include <dwrite.h>
 #include <uxtheme.h>
-#include <windows.h>
+#include <vsstyle.h>
 
 namespace {
 
@@ -413,6 +419,10 @@ int FindMenuItemIndex(HMENU menu, UINT item, bool byPosition) {
     }
 
     if (byPosition) {
+        if (item == static_cast<UINT>(-1)) {
+            return itemCount > 0 ? itemCount - 1 : -1;
+        }
+
         return item < static_cast<UINT>(itemCount)
                    ? static_cast<int>(item)
                    : -1;
@@ -563,6 +573,21 @@ bool ReadMenuItemText(HMENU menu,
     return true;
 }
 
+int FindMenuItemIndexByText(HMENU menu,
+                            const std::wstring& expectedText) {
+    const int itemCount = GetMenuItemCount(menu);
+    for (int index = 0; index < itemCount; ++index) {
+        std::wstring current;
+        if (ReadMenuItemText(
+                menu, static_cast<UINT>(index), &current) &&
+            current == expectedText) {
+            return index;
+        }
+    }
+
+    return -1;
+}
+
 void RememberRewrittenMenuItem(HMENU menu,
                                UINT index,
                                std::wstring original,
@@ -573,17 +598,6 @@ void RememberRewrittenMenuItem(HMENU menu,
         std::erase_if(g_rewrittenMenuItems, [](const auto& item) {
             return !IsMenu(item.menu);
         });
-    }
-
-    for (auto& item : g_rewrittenMenuItems) {
-        if (item.rootMenu == g_classicPopupRootMenu &&
-            item.menu == menu && item.index == index) {
-            if (item.spaced != spaced) {
-                item.original = std::move(original);
-                item.spaced = std::move(spaced);
-            }
-            return;
-        }
     }
 
     g_rewrittenMenuItems.push_back(
@@ -619,11 +633,16 @@ void RestoreRewrittenMenuItems(HMENU rootMenu = nullptr) {
             continue;
         }
 
+        int index = static_cast<int>(iterator->index);
         std::wstring current;
-        if (!ReadMenuItemText(iterator->menu, iterator->index,
-                              &current) ||
+        if (!ReadMenuItemText(
+                iterator->menu, iterator->index, &current) ||
             current != iterator->spaced) {
-            continue;
+            index = FindMenuItemIndexByText(
+                iterator->menu, iterator->spaced);
+            if (index < 0) {
+                continue;
+            }
         }
 
         MENUITEMINFOW replacement = {};
@@ -633,7 +652,8 @@ void RestoreRewrittenMenuItems(HMENU rootMenu = nullptr) {
             const_cast<wchar_t*>(iterator->original.c_str());
 
         SetMenuItemInfoW(
-            iterator->menu, iterator->index, TRUE, &replacement);
+            iterator->menu, static_cast<UINT>(index), TRUE,
+            &replacement);
     }
     g_restoringClassicMenuText = wasRestoring;
 }
@@ -704,7 +724,13 @@ BOOL WINAPI SetMenuItemInfoWHook(HMENU menu,
     return g_originalSetMenuItemInfoW(menu, item, byPosition, itemInfo);
 }
 
-void RewriteMenuTree(HMENU menu) {
+constexpr unsigned int kMaxMenuDepth = 16;
+
+void RewriteMenuTree(HMENU menu, unsigned int depth = 0) {
+    if (!menu || depth >= kMaxMenuDepth) {
+        return;
+    }
+
     const int itemCount = GetMenuItemCount(menu);
     for (int index = 0; index < itemCount; ++index) {
         MENUITEMINFOW itemInfo = {};
@@ -742,7 +768,7 @@ void RewriteMenuTree(HMENU menu) {
         }
 
         if (itemInfo.hSubMenu) {
-            RewriteMenuTree(itemInfo.hSubMenu);
+            RewriteMenuTree(itemInfo.hSubMenu, depth + 1);
         }
     }
 }
@@ -800,6 +826,7 @@ using OpenThemeData_t = decltype(&OpenThemeData);
 using OpenThemeDataEx_t = decltype(&OpenThemeDataEx);
 using OpenThemeDataForDpi_t = decltype(&OpenThemeDataForDpi);
 using CloseThemeData_t = decltype(&CloseThemeData);
+using GetWindowTheme_t = decltype(&GetWindowTheme);
 using GetThemeTextExtent_t = decltype(&GetThemeTextExtent);
 using DrawThemeText_t = decltype(&DrawThemeText);
 using DrawThemeTextEx_t = decltype(&DrawThemeTextEx);
@@ -808,11 +835,12 @@ OpenThemeData_t g_originalOpenThemeData;
 OpenThemeDataEx_t g_originalOpenThemeDataEx;
 OpenThemeDataForDpi_t g_originalOpenThemeDataForDpi;
 CloseThemeData_t g_originalCloseThemeData;
+GetWindowTheme_t g_getWindowTheme;
 GetThemeTextExtent_t g_originalGetThemeTextExtent;
 DrawThemeText_t g_originalDrawThemeText;
 DrawThemeTextEx_t g_originalDrawThemeTextEx;
 
-std::mutex g_classicTooltipThemesMutex;
+std::shared_mutex g_classicTooltipThemesMutex;
 std::unordered_set<HTHEME> g_classicTooltipThemes;
 std::atomic_uint g_classicTooltipThemeCount{0};
 thread_local bool g_rewritingClassicTooltipText = false;
@@ -847,7 +875,8 @@ bool IsTrackedClassicTooltipTheme(HTHEME theme) {
         return false;
     }
 
-    std::lock_guard<std::mutex> guard(g_classicTooltipThemesMutex);
+    std::shared_lock<std::shared_mutex> guard(
+        g_classicTooltipThemesMutex);
     return g_classicTooltipThemes.contains(theme);
 }
 
@@ -858,7 +887,8 @@ void TrackClassicTooltipTheme(HTHEME theme) {
 
     bool inserted;
     {
-        std::lock_guard<std::mutex> guard(g_classicTooltipThemesMutex);
+        std::lock_guard<std::shared_mutex> guard(
+            g_classicTooltipThemesMutex);
         inserted = g_classicTooltipThemes.insert(theme).second;
         g_classicTooltipThemeCount.store(
             static_cast<unsigned int>(g_classicTooltipThemes.size()),
@@ -875,7 +905,8 @@ void UntrackClassicTooltipTheme(HTHEME theme) {
         return;
     }
 
-    std::lock_guard<std::mutex> guard(g_classicTooltipThemesMutex);
+    std::lock_guard<std::shared_mutex> guard(
+        g_classicTooltipThemesMutex);
     g_classicTooltipThemes.erase(theme);
     g_classicTooltipThemeCount.store(
         static_cast<unsigned int>(g_classicTooltipThemes.size()),
@@ -883,9 +914,44 @@ void UntrackClassicTooltipTheme(HTHEME theme) {
 }
 
 void ClearTrackedClassicTooltipThemes() {
-    std::lock_guard<std::mutex> guard(g_classicTooltipThemesMutex);
+    std::lock_guard<std::shared_mutex> guard(
+        g_classicTooltipThemesMutex);
     g_classicTooltipThemes.clear();
     g_classicTooltipThemeCount.store(0, std::memory_order_relaxed);
+}
+
+bool IsClassicTooltipWindow(HWND window) {
+    wchar_t className[64];
+    return GetClassNameW(
+               window, className, ARRAYSIZE(className)) > 0 &&
+           _wcsicmp(className, TOOLTIPS_CLASSW) == 0;
+}
+
+BOOL CALLBACK EnumExistingClassicTooltipWindow(HWND window, LPARAM) {
+    DWORD processId;
+    GetWindowThreadProcessId(window, &processId);
+    if (processId == GetCurrentProcessId() &&
+        IsClassicTooltipWindow(window)) {
+        TrackClassicTooltipTheme(g_getWindowTheme(window));
+    }
+
+    return TRUE;
+}
+
+BOOL CALLBACK EnumExistingClassicTooltipTopLevelWindow(
+    HWND window,
+    LPARAM) {
+    EnumExistingClassicTooltipWindow(window, 0);
+    EnumChildWindows(
+        window, EnumExistingClassicTooltipWindow, 0);
+    return TRUE;
+}
+
+void DiscoverExistingClassicTooltipThemes() {
+    if (g_getWindowTheme) {
+        EnumWindows(
+            EnumExistingClassicTooltipTopLevelWindow, 0);
+    }
 }
 
 HTHEME WINAPI OpenThemeDataHook(HWND window, LPCWSTR classList) {
@@ -926,6 +992,13 @@ HRESULT WINAPI CloseThemeDataHook(HTHEME theme) {
     return g_originalCloseThemeData(theme);
 }
 
+bool IsClassicTooltipTextPart(int partId) {
+    return partId == TTP_STANDARD ||
+           partId == TTP_STANDARDTITLE ||
+           partId == TTP_BALLOON ||
+           partId == TTP_BALLOONTITLE;
+}
+
 bool BuildSpacedClassicTooltipText(LPCWSTR text,
                                    int textLength,
                                    DWORD textFlags,
@@ -962,6 +1035,7 @@ HRESULT WINAPI GetThemeTextExtentHook(HTHEME theme,
                                       LPRECT extentRectangle) {
     if (!g_classicTooltips.load(std::memory_order_relaxed) ||
         g_rewritingClassicTooltipText ||
+        !IsClassicTooltipTextPart(partId) ||
         !IsTrackedClassicTooltipTheme(theme)) {
         return g_originalGetThemeTextExtent(
             theme, dc, partId, stateId, text, textLength, textFlags,
@@ -998,6 +1072,7 @@ HRESULT WINAPI DrawThemeTextHook(HTHEME theme,
                                  LPCRECT rectangle) {
     if (!g_classicTooltips.load(std::memory_order_relaxed) ||
         g_rewritingClassicTooltipText ||
+        !IsClassicTooltipTextPart(partId) ||
         !IsTrackedClassicTooltipTheme(theme)) {
         return g_originalDrawThemeText(
             theme, dc, partId, stateId, text, textLength, textFlags,
@@ -1033,6 +1108,7 @@ HRESULT WINAPI DrawThemeTextExHook(HTHEME theme,
                                    const DTTOPTS* options) {
     if (!g_classicTooltips.load(std::memory_order_relaxed) ||
         g_rewritingClassicTooltipText ||
+        !IsClassicTooltipTextPart(partId) ||
         !IsTrackedClassicTooltipTheme(theme)) {
         return g_originalDrawThemeTextEx(
             theme, dc, partId, stateId, text, textLength, textFlags,
@@ -1253,43 +1329,58 @@ bool IsModernPopupActiveForCurrentThread() {
         return false;
     }
 
-    if (IsCursorInsideTaskbarThumbnailSurface()) {
-        return false;
-    }
-
     const DWORD currentThreadId = GetCurrentThreadId();
     bool popupActive = false;
     bool taskbarThumbnailActive = false;
+    bool removedWindow = false;
 
-    std::lock_guard<std::mutex> guard(
-        g_trackedModernWindowsMutex);
-    for (auto iterator = g_trackedModernWindows.begin();
-         iterator != g_trackedModernWindows.end();) {
-        if (!IsWindow(iterator->first)) {
-            iterator = g_trackedModernWindows.erase(iterator);
+    {
+        std::lock_guard<std::mutex> guard(
+            g_trackedModernWindowsMutex);
+        for (auto iterator = g_trackedModernWindows.begin();
+             iterator != g_trackedModernWindows.end();) {
+            if (!IsWindow(iterator->first) ||
+                ClassifyModernWindow(iterator->first) !=
+                    iterator->second.kind) {
+                iterator =
+                    g_trackedModernWindows.erase(iterator);
+                removedWindow = true;
+                continue;
+            }
+
+            if (IsWindowVisible(iterator->first)) {
+                if (iterator->second.kind ==
+                        ModernWindowKind::TaskbarThumbnail ||
+                    (iterator->second.kind ==
+                         ModernWindowKind::Popup &&
+                     IsTaskbarThumbnailSurface(
+                         iterator->first))) {
+                    taskbarThumbnailActive = true;
+                } else if (
+                    iterator->second.threadId ==
+                        currentThreadId &&
+                    iterator->second.kind ==
+                        ModernWindowKind::Popup) {
+                    popupActive = true;
+                }
+            }
+
+            ++iterator;
+        }
+
+        if (removedWindow) {
             g_trackedModernWindowCount.store(
                 static_cast<unsigned int>(
                     g_trackedModernWindows.size()),
                 std::memory_order_relaxed);
-            continue;
         }
-
-        if (IsWindowVisible(iterator->first)) {
-            if (iterator->second.kind ==
-                    ModernWindowKind::TaskbarThumbnail ||
-                (iterator->second.kind == ModernWindowKind::Popup &&
-                 IsTaskbarThumbnailSurface(iterator->first))) {
-                taskbarThumbnailActive = true;
-            } else if (iterator->second.threadId == currentThreadId &&
-                       iterator->second.kind == ModernWindowKind::Popup) {
-                popupActive = true;
-            }
-        }
-
-        ++iterator;
     }
 
-    return popupActive && !taskbarThumbnailActive;
+    if (!popupActive || taskbarThumbnailActive) {
+        return false;
+    }
+
+    return !IsCursorInsideTaskbarThumbnailSurface();
 }
 
 HWND WINAPI CreateWindowExWHook(
@@ -1555,6 +1646,12 @@ bool HookClassicTooltipThemeDrawing() {
 
     bool hooked = false;
 
+    g_getWindowTheme = reinterpret_cast<GetWindowTheme_t>(
+        GetProcAddress(themeModule, "GetWindowTheme"));
+    if (!g_getWindowTheme) {
+        Wh_Log(L"Couldn't find GetWindowTheme");
+    }
+
     const auto openThemeData =
         reinterpret_cast<OpenThemeData_t>(
             GetProcAddress(themeModule, "OpenThemeData"));
@@ -1707,8 +1804,8 @@ BOOL Wh_ModInit() {
             CreateWindowExW, CreateWindowExWHook,
             &g_originalCreateWindowExW, L"CreateWindowExW");
 
-        HMODULE user32Module = LoadLibraryExW(
-            L"user32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+        HMODULE user32Module =
+            GetModuleHandleW(L"user32.dll");
         if (user32Module) {
             const auto createWindowInBand =
                 reinterpret_cast<CreateWindowInBand_t>(
@@ -1734,7 +1831,7 @@ BOOL Wh_ModInit() {
                 Wh_Log(L"Couldn't find CreateWindowInBandEx");
             }
         } else {
-            Wh_Log(L"Couldn't load user32.dll");
+            Wh_Log(L"Couldn't find user32.dll");
         }
 
         installedAnyHook |= HookDirectWrite();
@@ -1749,6 +1846,10 @@ BOOL Wh_ModInit() {
 }
 
 void Wh_ModAfterInit() {
+    if (g_classicTooltips.load(std::memory_order_relaxed)) {
+        DiscoverExistingClassicTooltipThemes();
+    }
+
     if (g_modernUiText.load(std::memory_order_relaxed)) {
         DiscoverExistingModernWindows();
     }

--- a/mods/cjk-spacer.wh.cpp
+++ b/mods/cjk-spacer.wh.cpp
@@ -1,8 +1,8 @@
 // ==WindhawkMod==
 // @id              cjk-spacer
 // @name            CJK Spacer
-// @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips; modern XAML UI is opt-in and may conflict with other XAML Diagnostics mods
-// @version         0.1.20
+// @description     Add spaces between CJK characters and letters or digits in Explorer context menus and tooltips; modern XAML UI is opt-in and best-effort because it may conflict with other XAML Diagnostics mods
+// @version         0.1.21
 // @author          aenerv7
 // @github          https://github.com/aenerv7
 // @license         GPL-3.0
@@ -93,6 +93,9 @@ In addition to the XAML DLL load hook, creation of the Explorer/taskbar XAML
 host windows is used as an independent initialization trigger, so a module
 loaded through a static import, delay-load helper, or lower-level loader path
 still gets a connection attempt after an Explorer restart.
+If a connection attempt is denied or otherwise fails, host-window creation does
+not retry it repeatedly; a newly loaded XAML module or an established
+connection being disconnected provides the next retry opportunity.
 When Taskbar Styler is configured to alert on competing XAML Diagnostics
 consumers, enabling this path can show its confirmation dialog.
 Each reload switches to a new modern-UI generation, so detached workers and
@@ -930,7 +933,6 @@ using OpenThemeData_t = decltype(&OpenThemeData);
 using OpenThemeDataEx_t = decltype(&OpenThemeDataEx);
 using OpenThemeDataForDpi_t = decltype(&OpenThemeDataForDpi);
 using CloseThemeData_t = decltype(&CloseThemeData);
-using GetWindowTheme_t = decltype(&GetWindowTheme);
 using GetThemeTextExtent_t = decltype(&GetThemeTextExtent);
 using DrawThemeText_t = decltype(&DrawThemeText);
 using DrawThemeTextEx_t = decltype(&DrawThemeTextEx);
@@ -939,21 +941,21 @@ OpenThemeData_t g_originalOpenThemeData;
 OpenThemeDataEx_t g_originalOpenThemeDataEx;
 OpenThemeDataForDpi_t g_originalOpenThemeDataForDpi;
 CloseThemeData_t g_originalCloseThemeData;
-GetWindowTheme_t g_getWindowTheme;
 GetThemeTextExtent_t g_originalGetThemeTextExtent;
 DrawThemeText_t g_originalDrawThemeText;
 DrawThemeTextEx_t g_originalDrawThemeTextEx;
 HMODULE g_loadedUxThemeModule;
 std::shared_mutex g_classicTooltipThemesMutex;
-// A theme handle can be shared by multiple tooltip windows. Keep one entry
-// per matching OpenThemeData call so CloseThemeData can release the right
-// number of references without letting the last window overwrite the rest.
-std::unordered_map<HTHEME, std::vector<HWND>> g_classicTooltipThemes;
+// A theme handle can be shared by multiple tooltip windows. Keep a reference
+// count for matching OpenThemeData calls so CloseThemeData can release the
+// right number of references without letting the last window overwrite the
+// rest.
+std::unordered_map<HTHEME, unsigned int> g_classicTooltipThemes;
+std::vector<HTHEME> g_discoveredClassicTooltipThemes;
 std::atomic_uint g_classicTooltipThemeCount{0};
 thread_local bool g_rewritingClassicTooltipText = false;
 
 void ClearUxThemeFunctionPointers() {
-    g_getWindowTheme = nullptr;
     g_originalOpenThemeData = nullptr;
     g_originalOpenThemeDataEx = nullptr;
     g_originalOpenThemeDataForDpi = nullptr;
@@ -1010,9 +1012,9 @@ void TrackClassicTooltipTheme(HTHEME theme, HWND window) {
         std::lock_guard<std::shared_mutex> guard(
             g_classicTooltipThemesMutex);
         auto [iterator, wasInserted] =
-            g_classicTooltipThemes.try_emplace(theme);
+            g_classicTooltipThemes.try_emplace(theme, 0);
         inserted = wasInserted;
-        iterator->second.push_back(window);
+        ++iterator->second;
         g_classicTooltipThemeCount.store(
             static_cast<unsigned int>(g_classicTooltipThemes.size()),
             std::memory_order_relaxed);
@@ -1037,10 +1039,7 @@ bool UntrackClassicTooltipTheme(HTHEME theme) {
         return false;
     }
 
-    if (!iterator->second.empty()) {
-        iterator->second.pop_back();
-    }
-    if (iterator->second.empty()) {
+    if (--iterator->second == 0) {
         g_classicTooltipThemes.erase(iterator);
         g_classicTooltipThemeCount.store(
             static_cast<unsigned int>(g_classicTooltipThemes.size()),
@@ -1079,17 +1078,38 @@ BOOL CALLBACK EnumExistingClassicTooltipWindow(HWND window, LPARAM) {
     DWORD processId;
     GetWindowThreadProcessId(window, &processId);
     if (processId == GetCurrentProcessId() &&
-        IsClassicTooltipWindow(window)) {
-        TrackClassicTooltipTheme(g_getWindowTheme(window), window);
+        IsClassicTooltipWindow(window) && g_originalOpenThemeData &&
+        g_originalCloseThemeData) {
+        // GetWindowTheme does not add a theme-data reference. Open the
+        // handle ourselves so the discovery entry can be released exactly
+        // once during module teardown.
+        if (HTHEME theme =
+                g_originalOpenThemeData(window, L"TOOLTIP")) {
+            TrackClassicTooltipTheme(theme, window);
+            g_discoveredClassicTooltipThemes.push_back(theme);
+        }
     }
 
     return TRUE;
 }
 
 void DiscoverExistingClassicTooltipThemes() {
-    if (g_getWindowTheme) {
+    if (g_originalOpenThemeData && g_originalCloseThemeData) {
         EnumWindows(EnumExistingClassicTooltipWindow, 0);
     }
+}
+
+void CloseDiscoveredClassicTooltipThemes() {
+    if (!g_originalCloseThemeData) {
+        g_discoveredClassicTooltipThemes.clear();
+        return;
+    }
+
+    for (HTHEME theme : g_discoveredClassicTooltipThemes) {
+        g_originalCloseThemeData(theme);
+        UntrackClassicTooltipTheme(theme);
+    }
+    g_discoveredClassicTooltipThemes.clear();
 }
 
 HTHEME WINAPI OpenThemeDataHook(HWND window, LPCWSTR classList) {
@@ -1547,7 +1567,8 @@ void CleanupModernTextStatesForCurrentThread() {
 }
 
 HMODULE AcquireCurrentModuleReference();
-void RequestModernXamlDiagnosticsInitialization();
+void RequestModernXamlDiagnosticsInitialization(
+    bool retryFailedConnections = false);
 
 enum class XamlDiagnosticsFlavor {
     None,
@@ -1557,6 +1578,8 @@ enum class XamlDiagnosticsFlavor {
 
 extern std::atomic_bool g_windowsUiXamlDiagnosticsConnected;
 extern std::atomic_bool g_microsoftUiXamlDiagnosticsConnected;
+extern std::atomic_bool g_windowsUiXamlDiagnosticsAttempted;
+extern std::atomic_bool g_microsoftUiXamlDiagnosticsAttempted;
 extern std::atomic_bool g_stoppingModernUi;
 extern std::atomic_uint64_t g_modernUiGeneration;
 extern thread_local XamlDiagnosticsFlavor g_connectingXamlDiagnostics;
@@ -1846,9 +1869,13 @@ public:
                 XamlDiagnosticsFlavor::Windows) {
                 g_windowsUiXamlDiagnosticsConnected.store(
                     false, std::memory_order_release);
+                g_windowsUiXamlDiagnosticsAttempted.store(
+                    false, std::memory_order_release);
             } else if (disconnectedFlavor ==
                        XamlDiagnosticsFlavor::Microsoft) {
                 g_microsoftUiXamlDiagnosticsConnected.store(
+                    false, std::memory_order_release);
+                g_microsoftUiXamlDiagnosticsAttempted.store(
                     false, std::memory_order_release);
             }
             if (disconnectedFlavor != XamlDiagnosticsFlavor::None &&
@@ -1976,6 +2003,8 @@ using InitializeXamlDiagnosticsEx_t =
 std::mutex g_xamlDiagnosticsInitializationMutex;
 std::atomic_bool g_windowsUiXamlDiagnosticsConnected{false};
 std::atomic_bool g_microsoftUiXamlDiagnosticsConnected{false};
+std::atomic_bool g_windowsUiXamlDiagnosticsAttempted{false};
+std::atomic_bool g_microsoftUiXamlDiagnosticsAttempted{false};
 std::atomic_bool g_xamlDiagnosticsWorkerRunning{false};
 std::atomic_bool g_xamlDiagnosticsRequestPending{false};
 thread_local bool g_loadingXamlDiagnostics;
@@ -2066,9 +2095,13 @@ void EnsureModernXamlDiagnostics(uint64_t generation) {
     }
 
     if (!g_windowsUiXamlDiagnosticsConnected.load(
+            std::memory_order_acquire) &&
+        !g_windowsUiXamlDiagnosticsAttempted.load(
             std::memory_order_acquire)) {
         if (HMODULE module =
                 GetModuleHandleW(L"Windows.UI.Xaml.dll")) {
+            g_windowsUiXamlDiagnosticsAttempted.store(
+                true, std::memory_order_release);
             const uint64_t watcherGeneration =
                 g_visualTreeWatcherGeneration.load(
                     std::memory_order_acquire);
@@ -2098,9 +2131,13 @@ void EnsureModernXamlDiagnostics(uint64_t generation) {
     }
 
     if (!g_microsoftUiXamlDiagnosticsConnected.load(
+            std::memory_order_acquire) &&
+        !g_microsoftUiXamlDiagnosticsAttempted.load(
             std::memory_order_acquire)) {
         if (HMODULE module = GetModuleHandleW(
                 L"Microsoft.Internal.FrameworkUdk.dll")) {
+            g_microsoftUiXamlDiagnosticsAttempted.store(
+                true, std::memory_order_release);
             const uint64_t watcherGeneration =
                 g_visualTreeWatcherGeneration.load(
                     std::memory_order_acquire);
@@ -2133,17 +2170,32 @@ void EnsureModernXamlDiagnostics(uint64_t generation) {
 bool NeedsXamlDiagnosticsConnection() {
     return (!g_windowsUiXamlDiagnosticsConnected.load(
                  std::memory_order_acquire) &&
+            !g_windowsUiXamlDiagnosticsAttempted.load(
+                std::memory_order_acquire) &&
             GetModuleHandleW(L"Windows.UI.Xaml.dll")) ||
            (!g_microsoftUiXamlDiagnosticsConnected.load(
                  std::memory_order_acquire) &&
+            !g_microsoftUiXamlDiagnosticsAttempted.load(
+                std::memory_order_acquire) &&
             GetModuleHandleW(L"Microsoft.Internal.FrameworkUdk.dll"));
 }
 
-void RequestModernXamlDiagnosticsInitialization() {
+void RequestModernXamlDiagnosticsInitialization(
+    bool retryFailedConnections) {
     const uint64_t generation =
         g_modernUiGeneration.load(std::memory_order_acquire);
     if (!IsCurrentModernUiGeneration(generation)) {
         return;
+    }
+
+    if (retryFailedConnections) {
+        // A new XAML module load or a previously established connection being
+        // torn down is an explicit retry opportunity. Window creation alone
+        // must not keep retrying a connection another diagnostics tool denied.
+        g_windowsUiXamlDiagnosticsAttempted.store(
+            false, std::memory_order_release);
+        g_microsoftUiXamlDiagnosticsAttempted.store(
+            false, std::memory_order_release);
     }
 
     // Host-window creation can be noisy. Once all currently loaded XAML
@@ -2249,17 +2301,33 @@ bool IsXamlDiagnosticsTriggerModule(LPCWSTR path) {
            _wcsicmp(fileName, L"CoreMessagingXP.dll") == 0;
 }
 
+bool IsXamlDiagnosticsTriggerModuleLoaded(LPCWSTR path) {
+    if (!path) {
+        return false;
+    }
+
+    PCWSTR fileName = wcsrchr(path, L'\\');
+    fileName = fileName ? fileName + 1 : path;
+    return GetModuleHandleW(fileName) != nullptr;
+}
+
 HMODULE WINAPI LoadLibraryExWHook(LPCWSTR fileName,
                                   HANDLE file,
                                   DWORD flags) {
+    const bool triggerModule =
+        IsXamlDiagnosticsTriggerModule(fileName);
+    const bool triggerModuleWasLoaded =
+        triggerModule &&
+        IsXamlDiagnosticsTriggerModuleLoaded(fileName);
     HMODULE module =
         g_originalLoadLibraryExW(fileName, file, flags);
     if (module &&
         g_modernUiText.load(std::memory_order_relaxed) &&
-        IsXamlDiagnosticsTriggerModule(fileName)) {
+        triggerModule) {
         // Don't load the TAP or activate COM while the caller might hold the
         // Windows loader lock.
-        RequestModernXamlDiagnosticsInitialization();
+        RequestModernXamlDiagnosticsInitialization(
+            !triggerModuleWasLoaded);
     }
     return module;
 }
@@ -2500,6 +2568,10 @@ void InitializeModernUi() {
         false, std::memory_order_release);
     g_microsoftUiXamlDiagnosticsConnected.store(
         false, std::memory_order_release);
+    g_windowsUiXamlDiagnosticsAttempted.store(
+        false, std::memory_order_release);
+    g_microsoftUiXamlDiagnosticsAttempted.store(
+        false, std::memory_order_release);
     g_xamlDiagnosticsWorkerRunning.store(
         false, std::memory_order_release);
     g_xamlDiagnosticsRequestPending.store(
@@ -2600,12 +2672,6 @@ bool HookClassicTooltipThemeDrawing() {
     }
 
     bool hooked = false;
-
-    g_getWindowTheme = reinterpret_cast<GetWindowTheme_t>(
-        GetProcAddress(themeModule, "GetWindowTheme"));
-    if (!g_getWindowTheme) {
-        Wh_Log(L"Couldn't find GetWindowTheme");
-    }
 
     const auto openThemeData =
         reinterpret_cast<OpenThemeData_t>(
@@ -2831,6 +2897,7 @@ void Wh_ModAfterInit() {
 
 void Wh_ModUninit() {
     RestoreRewrittenMenuItems();
+    CloseDiscoveredClassicTooltipThemes();
     ClearTrackedClassicTooltipThemes();
     if (g_modernUiText.load(std::memory_order_relaxed)) {
         UninitializeModernUi();


### PR DESCRIPTION
Adds the CJK Spacer mod, which inserts spaces between CJK characters and Unicode letters or digits in context-menu and tooltip text hosted by `explorer.exe`; existing whitespace remains unchanged.

Classic Win32 menu handling is limited to the lifetime of `TrackPopupMenu` / `TrackPopupMenuEx`. Existing items are rewritten immediately before display, dynamically added or changed items are handled only while the popup is active, and recorded strings are restored as soon as the popup closes. Restoration treats the recorded index as a hint and falls back to locating the spaced text if insertions shifted menu indices. The insertion hooks also cover append operations and `MF_POPUP | MF_BYCOMMAND` forms.

Classic tooltips are scoped to uxtheme handles opened for the `TOOLTIP` class. `GetThemeTextExtent` handles measurement, while `DrawThemeText` and `DrawThemeTextEx` handle drawing. The hot path first rejects untracked theme handles; when the HDC maps to a window, that window must also be `tooltips_class32`, which protects against a stale or reused theme handle affecting another control. Existing tooltip windows are discovered when the mod is enabled in a running Explorer. Unthemed tooltips drawn directly with `DrawTextW` remain outside this path.

The opt-in `modernUiText` path uses XAML Diagnostics for both Windows.UI.Xaml and Microsoft.UI.Xaml. It changes source properties on standard `MenuFlyoutItem` / `MenuFlyoutSubItem` controls and `ToolTip.Content`, rather than assigning presenter `TextBlock.Text`. Only values that `ReadLocalValue` identifies as plain local strings are eligible; bindings, styles, expressions, unrelated XAML text, and taskbar thumbnail previews remain untouched.

Modern sources are now processed directly from their XAML visual-tree lifetime: a supported source is changed on its Add mutation and restored on Remove or mod unload. There is no popup-HWND ownership guess, pending set, accessibility event hook, or sticky cached-popup mapping. State remains per UI thread, and unload restoration uses the standard blocking `SendMessage` dispatch so its stack parameter cannot outlive the call. The thread registry stores each thread's creation-time fingerprint and explicitly prunes dead or reused IDs during registration and unload snapshotting, without putting a mutex-taking unregister operation in a thread-local destructor.

XAML Diagnostics connection requests come from `Wh_ModAfterInit` and a hook on the real `kernelbase.dll!LoadLibraryExW` implementation, covering both already-loaded and late-loaded Windows.UI.Xaml/Microsoft.UI.Xaml modules. The loader hook only schedules a single-flight worker; requests arriving while it runs remain pending and are consumed before the worker exits. WUX and MUX connection state is tracked independently, and `SetSite(nullptr)` clears and re-requests only the connection that was lost. COM activation and TAP loading happen outside the loader path. Each worker pins the mod image until `FreeLibraryAndExitThread`, so unload never joins a possibly blocked connection thread and the worker never executes unloaded code. The visual-tree advise thread also pins the image for its own lifetime. Reentrancy protection lives inside `EnsureModernXamlDiagnostics`, covering every caller, and the 10,000-name probe observes the stop flag. A connection is marked successful only when `SetSite` actually adds a watcher, so a diagnostics-handling mod that returns `S_OK` while blocking the call cannot create a false-positive connection. Watcher replacement and `SetSite(nullptr)` explicitly unadvise and release the old watcher, including an advise/unadvise race guard. The setting and README name Windows 11 Taskbar Styler and Windows 11 File Explorer Styler as potential exclusive-connection conflicts.

Hook groups are installed only for enabled features. Settings changes request a full Windhawk reload so disabling a feature removes its hooks and tracked state. The mod is injected only into `explorer.exe`; Start, Search, and shell flyouts hosted by other processes are explicitly documented as out of scope.

The implementation was written by ChatGPT from requirements provided by @aenerv7, then compiled and tested by @aenerv7 in Windhawk.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

Not applicable (new mod).

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [x] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify):
- - [ ] Other (please specify):

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.

