### PR TITLE
feat: add Charging Sound mod to play custom audio when AC power is connected

### DIFF
--- a/mods/charging-sound.wh.cpp
+++ b/mods/charging-sound.wh.cpp
@@ -1,0 +1,155 @@
+// ==WindhawkMod==
+// @id              charging-sound
+// @name            Charging Sound
+// @description     Plays a custom sound when the laptop is plugged in
+// @version         1.0
+// @author          khonloi
+// @github          https://github.com/khonloi
+// @include         explorer.exe
+// @compilerOptions -luser32 -lwinmm
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Charging Sound
+Plays a custom `.wav` sound whenever you connect your laptop to a charger (AC
+power). By default it plays the Windows Notify Messaging sound.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- soundPath: "C:\\Windows\\Media\\Windows Notify Messaging.wav"
+  $name: Sound File Path
+  $description: The absolute path to a .wav file to play when plugged in.
+*/
+// ==/WindhawkModSettings==
+
+#include <mmsystem.h>
+#include <windows.h>
+#include <string>
+
+const GUID MY_GUID_ACDC_POWER_SOURCE = {
+    0x5d3e9a59,
+    0xe9d5,
+    0x4b00,
+    {0xa6, 0xbd, 0xff, 0x34, 0xfa, 0xc0, 0xbc, 0x27}};
+
+struct {
+    std::wstring soundPath;
+} settings;
+
+HWND g_hwnd = NULL;
+HANDLE g_hThread = NULL;
+DWORD g_threadId = 0;
+int g_previousACStatus = -1;
+
+LRESULT CALLBACK PowerWindowProc(HWND hwnd,
+                                 UINT uMsg,
+                                 WPARAM wParam,
+                                 LPARAM lParam) {
+    if (uMsg == WM_POWERBROADCAST) {
+        if (wParam == PBT_APMPOWERSTATUSCHANGE) {
+            SYSTEM_POWER_STATUS sps;
+            if (GetSystemPowerStatus(&sps)) {
+                int currentACStatus = sps.ACLineStatus;
+                Wh_Log(
+                    L"Power status change detected. Current ACLineStatus: %d",
+                    currentACStatus);
+
+                // Only trigger if we have a valid previous state and it
+                // actually changed
+                if (g_previousACStatus != -1 &&
+                    currentACStatus != g_previousACStatus) {
+                    if (currentACStatus == 1) {  // Plugged in
+                        Wh_Log(L"Laptop plugged in. Playing sound: %s",
+                               settings.soundPath.c_str());
+                        PlaySoundW(settings.soundPath.c_str(), NULL,
+                                   SND_FILENAME | SND_ASYNC | SND_NODEFAULT);
+                    } else if (currentACStatus == 0) {  // Unplugged
+                        Wh_Log(L"Laptop unplugged.");
+                    }
+                }
+                g_previousACStatus = currentACStatus;
+            }
+        }
+    }
+    return DefWindowProc(hwnd, uMsg, wParam, lParam);
+}
+
+DWORD WINAPI PowerNotifyThread(LPVOID lpParam) {
+    Wh_Log(L"PowerNotifyThread started.");
+
+    // Initialize the previous status to the current status so it doesn't play
+    // immediately on launch
+    SYSTEM_POWER_STATUS sps;
+    if (GetSystemPowerStatus(&sps)) {
+        g_previousACStatus = sps.ACLineStatus;
+    }
+
+    WNDCLASSEXW wc = {0};
+    wc.cbSize = sizeof(WNDCLASSEXW);
+    wc.lpfnWndProc = PowerWindowProc;
+    wc.hInstance = GetModuleHandle(NULL);
+    wc.lpszClassName = L"WindhawkChargingSoundHiddenWindow";
+
+    RegisterClassExW(&wc);
+
+    g_hwnd = CreateWindowExW(0, wc.lpszClassName, L"WindhawkChargingSound",
+                             WS_OVERLAPPED, 0, 0, 0, 0, NULL, NULL,
+                             wc.hInstance, NULL);
+
+    if (g_hwnd) {
+        Wh_Log(L"Hidden window created successfully.");
+
+        MSG msg;
+        while (GetMessage(&msg, NULL, 0, 0)) {
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
+        }
+
+        DestroyWindow(g_hwnd);
+    } else {
+        Wh_Log(L"CreateWindowExW failed with error: %d", GetLastError());
+    }
+
+    UnregisterClassW(wc.lpszClassName, wc.hInstance);
+    Wh_Log(L"PowerNotifyThread exited.");
+    return 0;
+}
+
+void LoadSettings() {
+    PCWSTR soundPath = Wh_GetStringSetting(L"soundPath");
+    if (soundPath) {
+        settings.soundPath = soundPath;
+        Wh_FreeStringSetting(soundPath);
+    } else {
+        settings.soundPath =
+            L"C:\\Windows\\Media\\Windows Notify Messaging.wav";
+    }
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"Init");
+    LoadSettings();
+    g_hThread = CreateThread(NULL, 0, PowerNotifyThread, NULL, 0, &g_threadId);
+    return TRUE;
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"Uninit");
+    if (g_threadId != 0) {
+        PostThreadMessage(g_threadId, WM_QUIT, 0, 0);
+        if (g_hThread) {
+            WaitForSingleObject(g_hThread, INFINITE);
+            CloseHandle(g_hThread);
+            g_hThread = NULL;
+        }
+        g_threadId = 0;
+    }
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L"SettingsChanged");
+    LoadSettings();
+}

--- a/mods/charging-sound.wh.cpp
+++ b/mods/charging-sound.wh.cpp
@@ -20,18 +20,18 @@ Please note that this mod only works on devices with a battery (e.g. laptops).
 */
 // ==/WindhawkModReadme==
 
+// clang-format off
 // ==WindhawkModSettings==
 /*
 - soundPath: "Notification.IM"
   $name: Plugged-in Sound File Path
-  $description: "The absolute path to a .wav file or a system sound alias (e.g.,
-Notification.IM) to play when plugged in."
+  $description: "The absolute path to a .wav file or a system sound alias (e.g., Notification.IM) to play when plugged in."
 - unpluggedSoundPath: ""
   $name: Unplugged Sound File Path
-  $description: "The absolute path to a .wav file or a system sound alias to
-play when unplugged. Leave empty to disable."
+  $description: "The absolute path to a .wav file or a system sound alias to play when unplugged. Leave empty to disable."
 */
 // ==/WindhawkModSettings==
+// clang-format on
 
 #include <mmsystem.h>
 #include <windows.h>

--- a/mods/charging-sound.wh.cpp
+++ b/mods/charging-sound.wh.cpp
@@ -2,7 +2,7 @@
 // @id              charging-sound
 // @name            Charging Sound
 // @description     Plays a custom sound when the laptop is plugged in or unplugged
-// @version         1.4
+// @version         1.5
 // @author          khonloi
 // @github          https://github.com/khonloi
 // @license         MIT
@@ -29,6 +29,9 @@ Please note that this mod only works on devices with a battery (e.g. laptops).
 - unpluggedSoundPath: ""
   $name: Unplugged Sound File Path
   $description: "The absolute path to a .wav file or a system sound alias to play when unplugged. Leave empty to disable."
+- suppressWhenBusy: true
+  $name: Don't play while busy
+  $description: "Skip the sound when a full-screen app is running, presentation mode is active, or notifications are otherwise suppressed."
 */
 // ==/WindhawkModSettings==
 // clang-format on
@@ -37,7 +40,6 @@ Please note that this mod only works on devices with a battery (e.g. laptops).
 
 #include <mmsystem.h>
 #include <shellapi.h>
-#include <winnt.h>
 
 #include <cstring>
 #include <mutex>
@@ -49,6 +51,7 @@ Please note that this mod only works on devices with a battery (e.g. laptops).
 struct {
     std::wstring pluggedInSoundPath;
     std::wstring unpluggedSoundPath;
+    bool suppressWhenBusy;
     std::mutex mtx;
 } g_settings;
 
@@ -64,11 +67,18 @@ void PlaySoundPath(const std::wstring& path) {
         return;
     }
 
-    QUERY_USER_NOTIFICATION_STATE quns;
-    if (SUCCEEDED(SHQueryUserNotificationState(&quns))) {
-        if (quns == QUNS_BUSY || quns == QUNS_RUNNING_D3D_FULL_SCREEN ||
-            quns == QUNS_PRESENTATION_MODE || quns == QUNS_APP) {
-            Wh_Log(L"User is busy or in fullscreen. Suppressing sound.");
+    bool suppress = false;
+    {
+        std::lock_guard<std::mutex> lock(g_settings.mtx);
+        suppress = g_settings.suppressWhenBusy;
+    }
+
+    if (suppress) {
+        QUERY_USER_NOTIFICATION_STATE quns;
+        if (SUCCEEDED(SHQueryUserNotificationState(&quns)) &&
+            quns != QUNS_ACCEPTS_NOTIFICATIONS && quns != QUNS_NOT_PRESENT) {
+            Wh_Log(L"Notifications are suppressed (state %d), skipping sound.",
+                   quns);
             return;
         }
     }
@@ -80,13 +90,13 @@ void PlaySoundPath(const std::wstring& path) {
     DWORD flags = SND_ASYNC | SND_NODEFAULT;
 
     if (isFilePath) {
-        if (PlaySoundW(path.c_str(), nullptr, flags | SND_FILENAME)) {
-            return;
+        if (!PlaySoundW(path.c_str(), nullptr, flags | SND_FILENAME)) {
+            Wh_Log(L"PlaySoundW failed for: %s", path.c_str());
         }
-    }
-
-    if (!PlaySoundW(path.c_str(), nullptr, flags | SND_ALIAS)) {
-        Wh_Log(L"PlaySoundW failed for: %s", path.c_str());
+    } else {
+        if (!PlaySoundW(path.c_str(), nullptr, flags | SND_ALIAS | SND_SYSTEM)) {
+            Wh_Log(L"PlaySoundW failed for: %s", path.c_str());
+        }
     }
 }
 
@@ -135,6 +145,7 @@ LRESULT CALLBACK PowerWindowProc(HWND hwnd,
                 }
             }
         }
+        return TRUE;
     }
     return DefWindowProcW(hwnd, uMsg, wParam, lParam);
 }
@@ -204,9 +215,12 @@ void LoadSettings() {
         WindhawkUtils::StringSetting::make(L"pluggedInSoundPath");
     auto unpluggedSoundPath =
         WindhawkUtils::StringSetting::make(L"unpluggedSoundPath");
+    bool suppressWhenBusy = Wh_GetIntSetting(L"suppressWhenBusy") != 0;
+
     std::lock_guard<std::mutex> lock(g_settings.mtx);
     g_settings.pluggedInSoundPath = pluggedInSoundPath.get();
     g_settings.unpluggedSoundPath = unpluggedSoundPath.get();
+    g_settings.suppressWhenBusy = suppressWhenBusy;
 }
 
 BOOL WhTool_ModInit() {
@@ -279,12 +293,14 @@ BOOL Wh_ModInit() {
     bool isExcluded = false;
     bool isToolModProcess = false;
     bool isCurrentToolModProcess = false;
+
     int argc;
     LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
     if (!argv) {
         Wh_Log(L"CommandLineToArgvW failed");
         return FALSE;
     }
+
     for (int i = 1; i < argc; i++) {
         if (wcscmp(argv[i], L"-service") == 0 ||
             wcscmp(argv[i], L"-service-start") == 0 ||
@@ -293,6 +309,7 @@ BOOL Wh_ModInit() {
             break;
         }
     }
+
     for (int i = 1; i < argc - 1; i++) {
         if (wcscmp(argv[i], L"-tool-mod") == 0) {
             isToolModProcess = true;
@@ -321,6 +338,7 @@ BOOL Wh_ModInit() {
             Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
             ExitProcess(1);
         }
+
         if (!WhTool_ModInit()) {
             ExitProcess(1);
         }
@@ -334,6 +352,7 @@ BOOL Wh_ModInit() {
         void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
 
         Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
+        
         return TRUE;
     }
 
@@ -349,6 +368,7 @@ void Wh_ModAfterInit() {
     if (!g_isToolModProcessLauncher) {
         return;
     }
+
     WCHAR currentProcessPath[MAX_PATH];
     switch (GetModuleFileName(nullptr, currentProcessPath,
                               ARRAYSIZE(currentProcessPath))) {
@@ -357,11 +377,13 @@ void Wh_ModAfterInit() {
             Wh_Log(L"GetModuleFileName failed");
             return;
     }
+
     WCHAR
     commandLine[MAX_PATH + 2 +
                 (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
     swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
                WH_MOD_ID);
+
     HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelModule) {
         kernelModule = GetModuleHandle(L"kernel32.dll");
@@ -370,6 +392,7 @@ void Wh_ModAfterInit() {
             return;
         }
     }
+
     using CreateProcessInternalW_t = BOOL(WINAPI*)(
         HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
         LPSECURITY_ATTRIBUTES lpProcessAttributes,
@@ -378,6 +401,7 @@ void Wh_ModAfterInit() {
         LPSTARTUPINFOW lpStartupInfo,
         LPPROCESS_INFORMATION lpProcessInformation,
         PHANDLE hRestrictedUserToken);
+
     CreateProcessInternalW_t pCreateProcessInternalW =
         (CreateProcessInternalW_t)GetProcAddress(kernelModule,
                                                  "CreateProcessInternalW");
@@ -385,6 +409,7 @@ void Wh_ModAfterInit() {
         Wh_Log(L"No CreateProcessInternalW");
         return;
     }
+
     STARTUPINFO si{
         .cb = sizeof(STARTUPINFO),
         .dwFlags = STARTF_FORCEOFFFEEDBACK,
@@ -396,6 +421,7 @@ void Wh_ModAfterInit() {
         Wh_Log(L"CreateProcess failed");
         return;
     }
+
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
 }

--- a/mods/charging-sound.wh.cpp
+++ b/mods/charging-sound.wh.cpp
@@ -2,12 +2,12 @@
 // @id              charging-sound
 // @name            Charging Sound
 // @description     Plays a custom sound when the laptop is plugged in or unplugged
-// @version         1.3
+// @version         1.4
 // @author          khonloi
 // @github          https://github.com/khonloi
 // @license         MIT
 // @include         windhawk.exe
-// @compilerOptions -lwinmm -luuid
+// @compilerOptions -lwinmm -luuid -lshell32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -23,7 +23,7 @@ Please note that this mod only works on devices with a battery (e.g. laptops).
 // clang-format off
 // ==WindhawkModSettings==
 /*
-- soundPath: "Notification.IM"
+- pluggedInSoundPath: "Notification.IM"
   $name: Plugged-in Sound File Path
   $description: "The absolute path to a .wav file or a system sound alias (e.g., Notification.IM) to play when plugged in. Leave empty to disable."
 - unpluggedSoundPath: ""
@@ -33,9 +33,13 @@ Please note that this mod only works on devices with a battery (e.g. laptops).
 // ==/WindhawkModSettings==
 // clang-format on
 
-#include <mmsystem.h>
 #include <windows.h>
+
+#include <mmsystem.h>
+#include <shellapi.h>
 #include <winnt.h>
+
+#include <cstring>
 #include <mutex>
 #include <string>
 #include <utility>
@@ -43,7 +47,7 @@ Please note that this mod only works on devices with a battery (e.g. laptops).
 #include <windhawk_utils.h>
 
 struct {
-    std::wstring soundPath;
+    std::wstring pluggedInSoundPath;
     std::wstring unpluggedSoundPath;
     std::mutex mtx;
 } g_settings;
@@ -60,7 +64,28 @@ void PlaySoundPath(const std::wstring& path) {
         return;
     }
 
-    if (!PlaySoundW(path.c_str(), nullptr, SND_ASYNC | SND_NODEFAULT)) {
+    QUERY_USER_NOTIFICATION_STATE quns;
+    if (SUCCEEDED(SHQueryUserNotificationState(&quns))) {
+        if (quns == QUNS_BUSY || quns == QUNS_RUNNING_D3D_FULL_SCREEN ||
+            quns == QUNS_PRESENTATION_MODE || quns == QUNS_APP) {
+            Wh_Log(L"User is busy or in fullscreen. Suppressing sound.");
+            return;
+        }
+    }
+
+    Wh_Log(L"Playing sound: %s", path.c_str());
+
+    bool isFilePath = path.find(L"\\") != std::wstring::npos ||
+                      path.find(L":") != std::wstring::npos;
+    DWORD flags = SND_ASYNC | SND_NODEFAULT;
+
+    if (isFilePath) {
+        if (PlaySoundW(path.c_str(), nullptr, flags | SND_FILENAME)) {
+            return;
+        }
+    }
+
+    if (!PlaySoundW(path.c_str(), nullptr, flags | SND_ALIAS)) {
         Wh_Log(L"PlaySoundW failed for: %s", path.c_str());
     }
 }
@@ -75,11 +100,11 @@ LRESULT CALLBACK PowerWindowProc(HWND hwnd,
             if (pbs->PowerSetting == GUID_ACDC_POWER_SOURCE &&
                 pbs->DataLength == sizeof(DWORD)) {
                 DWORD currentACStatus;
-                memcpy(&currentACStatus, pbs->Data, sizeof(DWORD));
+                std::memcpy(&currentACStatus, pbs->Data, sizeof(DWORD));
 
-                int previous =
-                    std::exchange(g_lastPowerCondition, (int)currentACStatus);
-                if (previous == (int)currentACStatus || previous == -1) {
+                int state = (currentACStatus == PoAc) ? PoAc : PoDc;
+                int previous = std::exchange(g_lastPowerCondition, state);
+                if (previous == state || previous == -1) {
                     return TRUE;
                 }
 
@@ -88,19 +113,16 @@ LRESULT CALLBACK PowerWindowProc(HWND hwnd,
                     L"%u",
                     currentACStatus);
 
-                if (currentACStatus == PoAc) {  // Plugged in (AC)
+                if (state == PoAc) {  // Plugged in (AC)
                     std::wstring currentSoundPath;
                     {
                         std::lock_guard<std::mutex> lock(g_settings.mtx);
-                        currentSoundPath = g_settings.soundPath;
+                        currentSoundPath = g_settings.pluggedInSoundPath;
                     }
 
-                    Wh_Log(L"Laptop plugged in. Playing sound: %s",
-                           currentSoundPath.c_str());
+                    Wh_Log(L"Laptop plugged in.");
                     PlaySoundPath(currentSoundPath);
-                } else if (currentACStatus == PoDc ||
-                           currentACStatus ==
-                               PoHot) {  // Unplugged (DC or UPS backup)
+                } else if (state == PoDc) {  // Unplugged (DC or UPS backup)
                     std::wstring currentUnpluggedSoundPath;
                     {
                         std::lock_guard<std::mutex> lock(g_settings.mtx);
@@ -108,8 +130,7 @@ LRESULT CALLBACK PowerWindowProc(HWND hwnd,
                             g_settings.unpluggedSoundPath;
                     }
 
-                    Wh_Log(L"Laptop unplugged. Playing sound: %s",
-                           currentUnpluggedSoundPath.c_str());
+                    Wh_Log(L"Laptop unplugged.");
                     PlaySoundPath(currentUnpluggedSoundPath);
                 }
             }
@@ -120,6 +141,11 @@ LRESULT CALLBACK PowerWindowProc(HWND hwnd,
 
 DWORD WINAPI PowerNotifyThread(LPVOID lpParam) {
     Wh_Log(L"PowerNotifyThread started.");
+
+    SYSTEM_POWER_STATUS sps;
+    if (GetSystemPowerStatus(&sps) && sps.ACLineStatus != 255) {
+        g_lastPowerCondition = sps.ACLineStatus == 1 ? PoAc : PoDc;
+    }
 
     MSG msg;
     // Ensure the thread message queue exists, so PostThreadMessageW never
@@ -174,30 +200,31 @@ DWORD WINAPI PowerNotifyThread(LPVOID lpParam) {
 }
 
 void LoadSettings() {
-    auto soundPath = WindhawkUtils::StringSetting::make(L"soundPath");
+    auto pluggedInSoundPath =
+        WindhawkUtils::StringSetting::make(L"pluggedInSoundPath");
     auto unpluggedSoundPath =
         WindhawkUtils::StringSetting::make(L"unpluggedSoundPath");
     std::lock_guard<std::mutex> lock(g_settings.mtx);
-    g_settings.soundPath = soundPath.get();
+    g_settings.pluggedInSoundPath = pluggedInSoundPath.get();
     g_settings.unpluggedSoundPath = unpluggedSoundPath.get();
 }
 
-bool WhTool_ModInit() {
+BOOL WhTool_ModInit() {
     Wh_Log(L"Init");
     LoadSettings();
     g_readyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
     if (!g_readyEvent) {
         Wh_Log(L"Failed to create ready event: %u", GetLastError());
-        return false;
+        return FALSE;
     }
     g_hThread = CreateThread(NULL, 0, PowerNotifyThread, NULL, 0, &g_threadId);
     if (!g_hThread) {
         Wh_Log(L"Failed to create thread: %u", GetLastError());
         CloseHandle(g_readyEvent);
         g_readyEvent = NULL;
-        return false;
+        return FALSE;
     }
-    return true;
+    return TRUE;
 }
 
 void WhTool_ModUninit() {
@@ -252,14 +279,12 @@ BOOL Wh_ModInit() {
     bool isExcluded = false;
     bool isToolModProcess = false;
     bool isCurrentToolModProcess = false;
-
     int argc;
     LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
     if (!argv) {
         Wh_Log(L"CommandLineToArgvW failed");
         return FALSE;
     }
-
     for (int i = 1; i < argc; i++) {
         if (wcscmp(argv[i], L"-service") == 0 ||
             wcscmp(argv[i], L"-service-start") == 0 ||
@@ -268,7 +293,6 @@ BOOL Wh_ModInit() {
             break;
         }
     }
-
     for (int i = 1; i < argc - 1; i++) {
         if (wcscmp(argv[i], L"-tool-mod") == 0) {
             isToolModProcess = true;
@@ -297,7 +321,6 @@ BOOL Wh_ModInit() {
             Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
             ExitProcess(1);
         }
-
         if (!WhTool_ModInit()) {
             ExitProcess(1);
         }
@@ -309,6 +332,7 @@ BOOL Wh_ModInit() {
 
         DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
         void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
+
         Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
         return TRUE;
     }
@@ -325,7 +349,6 @@ void Wh_ModAfterInit() {
     if (!g_isToolModProcessLauncher) {
         return;
     }
-
     WCHAR currentProcessPath[MAX_PATH];
     switch (GetModuleFileName(nullptr, currentProcessPath,
                               ARRAYSIZE(currentProcessPath))) {
@@ -334,13 +357,11 @@ void Wh_ModAfterInit() {
             Wh_Log(L"GetModuleFileName failed");
             return;
     }
-
     WCHAR
     commandLine[MAX_PATH + 2 +
                 (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
     swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
                WH_MOD_ID);
-
     HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelModule) {
         kernelModule = GetModuleHandle(L"kernel32.dll");
@@ -349,7 +370,6 @@ void Wh_ModAfterInit() {
             return;
         }
     }
-
     using CreateProcessInternalW_t = BOOL(WINAPI*)(
         HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
         LPSECURITY_ATTRIBUTES lpProcessAttributes,
@@ -358,7 +378,6 @@ void Wh_ModAfterInit() {
         LPSTARTUPINFOW lpStartupInfo,
         LPPROCESS_INFORMATION lpProcessInformation,
         PHANDLE hRestrictedUserToken);
-
     CreateProcessInternalW_t pCreateProcessInternalW =
         (CreateProcessInternalW_t)GetProcAddress(kernelModule,
                                                  "CreateProcessInternalW");
@@ -366,7 +385,6 @@ void Wh_ModAfterInit() {
         Wh_Log(L"No CreateProcessInternalW");
         return;
     }
-
     STARTUPINFO si{
         .cb = sizeof(STARTUPINFO),
         .dwFlags = STARTF_FORCEOFFFEEDBACK,
@@ -378,7 +396,6 @@ void Wh_ModAfterInit() {
         Wh_Log(L"CreateProcess failed");
         return;
     }
-
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
 }

--- a/mods/charging-sound.wh.cpp
+++ b/mods/charging-sound.wh.cpp
@@ -2,11 +2,11 @@
 // @id              charging-sound
 // @name            Charging Sound
 // @description     Plays a custom sound when the laptop is plugged in
-// @version         1.0
+// @version         1.1
 // @author          khonloi
 // @github          https://github.com/khonloi
-// @include         explorer.exe
-// @compilerOptions -luser32 -lwinmm
+// @include         windhawk.exe
+// @compilerOptions -lwinmm
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -14,45 +14,58 @@
 # Charging Sound
 Plays a custom `.wav` sound whenever you connect your laptop to a charger (AC
 power). By default it plays the Windows Notify Messaging sound.
+
+Please note that this mod only works on devices with a battery (e.g. laptops).
 */
 // ==/WindhawkModReadme==
 
 // ==WindhawkModSettings==
 /*
-- soundPath: "C:\\Windows\\Media\\Windows Notify Messaging.wav"
+- soundPath: "Notification.Messaging"
   $name: Sound File Path
-  $description: The absolute path to a .wav file to play when plugged in.
+  $description: "The absolute path to a .wav file or a system sound alias (e.g.,
+Notification.Messaging) to play when plugged in."
 */
 // ==/WindhawkModSettings==
 
 #include <mmsystem.h>
 #include <windows.h>
+#include <mutex>
 #include <string>
 
-const GUID MY_GUID_ACDC_POWER_SOURCE = {
-    0x5d3e9a59,
-    0xe9d5,
-    0x4b00,
-    {0xa6, 0xbd, 0xff, 0x34, 0xfa, 0xc0, 0xbc, 0x27}};
+#include <windhawk_utils.h>
 
 struct {
     std::wstring soundPath;
+    std::mutex mtx;
 } settings;
 
 HWND g_hwnd = NULL;
 HANDLE g_hThread = NULL;
 DWORD g_threadId = 0;
+HANDLE g_readyEvent = NULL;
 int g_previousACStatus = -1;
 
 LRESULT CALLBACK PowerWindowProc(HWND hwnd,
                                  UINT uMsg,
                                  WPARAM wParam,
                                  LPARAM lParam) {
+    if (uMsg == WM_DESTROY) {
+        PostQuitMessage(0);
+        return 0;
+    }
+
     if (uMsg == WM_POWERBROADCAST) {
         if (wParam == PBT_APMPOWERSTATUSCHANGE) {
             SYSTEM_POWER_STATUS sps;
             if (GetSystemPowerStatus(&sps)) {
                 int currentACStatus = sps.ACLineStatus;
+
+                // Ignore unknown status (255)
+                if (currentACStatus == 255) {
+                    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
+                }
+
                 Wh_Log(
                     L"Power status change detected. Current ACLineStatus: %d",
                     currentACStatus);
@@ -62,10 +75,27 @@ LRESULT CALLBACK PowerWindowProc(HWND hwnd,
                 if (g_previousACStatus != -1 &&
                     currentACStatus != g_previousACStatus) {
                     if (currentACStatus == 1) {  // Plugged in
+                        std::wstring currentSoundPath;
+                        {
+                            std::lock_guard<std::mutex> lock(settings.mtx);
+                            currentSoundPath = settings.soundPath;
+                        }
+
                         Wh_Log(L"Laptop plugged in. Playing sound: %s",
-                               settings.soundPath.c_str());
-                        PlaySoundW(settings.soundPath.c_str(), NULL,
-                                   SND_FILENAME | SND_ASYNC | SND_NODEFAULT);
+                               currentSoundPath.c_str());
+
+                        // Treat it as a file if it looks like a path, otherwise
+                        // as a system sound alias.
+                        bool isFilePath =
+                            currentSoundPath.find(L'\\') != std::wstring::npos;
+                        if (isFilePath) {
+                            PlaySoundW(
+                                currentSoundPath.c_str(), nullptr,
+                                SND_FILENAME | SND_ASYNC | SND_NODEFAULT);
+                        } else {
+                            PlaySoundW(currentSoundPath.c_str(), nullptr,
+                                       SND_ALIAS | SND_ASYNC | SND_NODEFAULT);
+                        }
                     } else if (currentACStatus == 0) {  // Unplugged
                         Wh_Log(L"Laptop unplugged.");
                     }
@@ -74,7 +104,7 @@ LRESULT CALLBACK PowerWindowProc(HWND hwnd,
             }
         }
     }
-    return DefWindowProc(hwnd, uMsg, wParam, lParam);
+    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
 }
 
 DWORD WINAPI PowerNotifyThread(LPVOID lpParam) {
@@ -84,16 +114,22 @@ DWORD WINAPI PowerNotifyThread(LPVOID lpParam) {
     // immediately on launch
     SYSTEM_POWER_STATUS sps;
     if (GetSystemPowerStatus(&sps)) {
-        g_previousACStatus = sps.ACLineStatus;
+        if (sps.ACLineStatus != 255) {
+            g_previousACStatus = sps.ACLineStatus;
+        }
     }
 
     WNDCLASSEXW wc = {0};
     wc.cbSize = sizeof(WNDCLASSEXW);
     wc.lpfnWndProc = PowerWindowProc;
-    wc.hInstance = GetModuleHandle(NULL);
+    // Mod's module handle
+    wc.hInstance = GetModuleHandleW(NULL);
     wc.lpszClassName = L"WindhawkChargingSoundHiddenWindow";
 
-    RegisterClassExW(&wc);
+    if (!RegisterClassExW(&wc)) {
+        Wh_Log(L"RegisterClassExW failed with error: %u", GetLastError());
+        return 1;
+    }
 
     g_hwnd = CreateWindowExW(0, wc.lpszClassName, L"WindhawkChargingSound",
                              WS_OVERLAPPED, 0, 0, 0, 0, NULL, NULL,
@@ -103,14 +139,19 @@ DWORD WINAPI PowerNotifyThread(LPVOID lpParam) {
         Wh_Log(L"Hidden window created successfully.");
 
         MSG msg;
-        while (GetMessage(&msg, NULL, 0, 0)) {
+        // Ensure the thread message queue exists, so PostMessageW never fails.
+        PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+        SetEvent(g_readyEvent);
+
+        while (GetMessageW(&msg, NULL, 0, 0) > 0) {
             TranslateMessage(&msg);
-            DispatchMessage(&msg);
+            DispatchMessageW(&msg);
         }
 
         DestroyWindow(g_hwnd);
+        g_hwnd = NULL;
     } else {
-        Wh_Log(L"CreateWindowExW failed with error: %d", GetLastError());
+        Wh_Log(L"CreateWindowExW failed with error: %u", GetLastError());
     }
 
     UnregisterClassW(wc.lpszClassName, wc.hInstance);
@@ -119,37 +160,215 @@ DWORD WINAPI PowerNotifyThread(LPVOID lpParam) {
 }
 
 void LoadSettings() {
-    PCWSTR soundPath = Wh_GetStringSetting(L"soundPath");
-    if (soundPath) {
-        settings.soundPath = soundPath;
-        Wh_FreeStringSetting(soundPath);
-    } else {
-        settings.soundPath =
-            L"C:\\Windows\\Media\\Windows Notify Messaging.wav";
+    auto soundPath = WindhawkUtils::StringSetting::make(L"soundPath");
+    std::lock_guard<std::mutex> lock(settings.mtx);
+    settings.soundPath =
+        *soundPath ? soundPath.get() : L"Notification.Messaging";
+}
+
+bool WhTool_ModInit() {
+    Wh_Log(L"Init");
+    LoadSettings();
+    g_readyEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (!g_readyEvent) {
+        Wh_Log(L"Failed to create ready event: %u", GetLastError());
+        return false;
     }
+    g_hThread = CreateThread(NULL, 0, PowerNotifyThread, NULL, 0, &g_threadId);
+    if (!g_hThread) {
+        Wh_Log(L"Failed to create thread: %u", GetLastError());
+        CloseHandle(g_readyEvent);
+        g_readyEvent = NULL;
+        return false;
+    }
+    return true;
+}
+
+void WhTool_ModUninit() {
+    Wh_Log(L"Uninit");
+
+    // Stop any playing sound
+    PlaySoundW(nullptr, nullptr, 0);
+
+    if (g_threadId != 0 && g_hThread != NULL) {
+        if (g_readyEvent) {
+            WaitForSingleObject(g_readyEvent, INFINITE);
+        }
+
+        if (g_hwnd) {
+            PostMessageW(g_hwnd, WM_CLOSE, 0, 0);
+        }
+
+        WaitForSingleObject(g_hThread, INFINITE);
+        CloseHandle(g_hThread);
+        g_hThread = NULL;
+        g_threadId = 0;
+        g_hwnd = NULL;
+    }
+
+    if (g_readyEvent) {
+        CloseHandle(g_readyEvent);
+        g_readyEvent = NULL;
+    }
+}
+
+void WhTool_ModSettingsChanged() {
+    Wh_Log(L"SettingsChanged");
+    LoadSettings();
+}
+
+// ============================================================================
+// Tool Mod Boilerplate
+// ============================================================================
+bool g_isToolModProcessLauncher;
+HANDLE g_toolModProcessMutex;
+
+void WINAPI EntryPoint_Hook() {
+    Wh_Log(L">");
+    ExitThread(0);
 }
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"Init");
-    LoadSettings();
-    g_hThread = CreateThread(NULL, 0, PowerNotifyThread, NULL, 0, &g_threadId);
+    DWORD sessionId;
+    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
+        sessionId == 0) {
+        return FALSE;
+    }
+    bool isExcluded = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+    int argc;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
+    if (!argv) {
+        Wh_Log(L"CommandLineToArgvW failed");
+        return FALSE;
+    }
+    for (int i = 1; i < argc; i++) {
+        if (wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0) {
+            isExcluded = true;
+            break;
+        }
+    }
+    for (int i = 1; i < argc - 1; i++) {
+        if (wcscmp(argv[i], L"-tool-mod") == 0) {
+            isToolModProcess = true;
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
+                isCurrentToolModProcess = true;
+            }
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isExcluded) {
+        return FALSE;
+    }
+    if (isCurrentToolModProcess) {
+        g_toolModProcessMutex =
+            CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
+        if (!g_toolModProcessMutex) {
+            Wh_Log(L"CreateMutex failed");
+            ExitProcess(1);
+        }
+
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
+            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
+            ExitProcess(1);
+        }
+        if (!WhTool_ModInit()) {
+            ExitProcess(1);
+        }
+
+        IMAGE_DOS_HEADER* dosHeader =
+            (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
+        IMAGE_NT_HEADERS* ntHeaders =
+            (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
+
+        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
+        void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
+        Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
+        return TRUE;
+    }
+
+    if (isToolModProcess) {
+        return FALSE;
+    }
+
+    g_isToolModProcessLauncher = true;
     return TRUE;
 }
 
-void Wh_ModUninit() {
-    Wh_Log(L"Uninit");
-    if (g_threadId != 0) {
-        PostThreadMessage(g_threadId, WM_QUIT, 0, 0);
-        if (g_hThread) {
-            WaitForSingleObject(g_hThread, INFINITE);
-            CloseHandle(g_hThread);
-            g_hThread = NULL;
-        }
-        g_threadId = 0;
+void Wh_ModAfterInit() {
+    if (!g_isToolModProcessLauncher) {
+        return;
     }
+    WCHAR currentProcessPath[MAX_PATH];
+    switch (GetModuleFileName(nullptr, currentProcessPath,
+                              ARRAYSIZE(currentProcessPath))) {
+        case 0:
+        case ARRAYSIZE(currentProcessPath):
+            Wh_Log(L"GetModuleFileName failed");
+            return;
+    }
+    WCHAR
+    commandLine[MAX_PATH + 2 +
+                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
+    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
+               WH_MOD_ID);
+    HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
+    if (!kernelModule) {
+        kernelModule = GetModuleHandle(L"kernel32.dll");
+        if (!kernelModule) {
+            Wh_Log(L"No kernelbase.dll/kernel32.dll");
+            return;
+        }
+    }
+    using CreateProcessInternalW_t = BOOL(WINAPI*)(
+        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+        LPSECURITY_ATTRIBUTES lpProcessAttributes,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
+        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
+        LPSTARTUPINFOW lpStartupInfo,
+        LPPROCESS_INFORMATION lpProcessInformation,
+        PHANDLE hRestrictedUserToken);
+    CreateProcessInternalW_t pCreateProcessInternalW =
+        (CreateProcessInternalW_t)GetProcAddress(kernelModule,
+                                                 "CreateProcessInternalW");
+    if (!pCreateProcessInternalW) {
+        Wh_Log(L"No CreateProcessInternalW");
+        return;
+    }
+    STARTUPINFO si{
+        .cb = sizeof(STARTUPINFO),
+        .dwFlags = STARTF_FORCEOFFFEEDBACK,
+    };
+    PROCESS_INFORMATION pi;
+    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
+                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
+                                 nullptr, nullptr, &si, &pi, nullptr)) {
+        Wh_Log(L"CreateProcess failed");
+        return;
+    }
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
 }
 
 void Wh_ModSettingsChanged() {
-    Wh_Log(L"SettingsChanged");
-    LoadSettings();
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModSettingsChanged();
+}
+
+void Wh_ModUninit() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModUninit();
+    ExitProcess(0);
 }

--- a/mods/charging-sound.wh.cpp
+++ b/mods/charging-sound.wh.cpp
@@ -1,19 +1,20 @@
 // ==WindhawkMod==
 // @id              charging-sound
 // @name            Charging Sound
-// @description     Plays a custom sound when the laptop is plugged in
-// @version         1.1
+// @description     Plays a custom sound when the laptop is plugged in or unplugged
+// @version         1.2
 // @author          khonloi
 // @github          https://github.com/khonloi
+// @license         MIT
 // @include         windhawk.exe
-// @compilerOptions -lwinmm
+// @compilerOptions -lwinmm -luuid
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
 /*
 # Charging Sound
 Plays a custom `.wav` sound whenever you connect your laptop to a charger (AC
-power). By default it plays the Windows Notify Messaging sound.
+power) or unplug it. By default it plays the Windows Notify Messaging sound.
 
 Please note that this mod only works on devices with a battery (e.g. laptops).
 */
@@ -21,10 +22,14 @@ Please note that this mod only works on devices with a battery (e.g. laptops).
 
 // ==WindhawkModSettings==
 /*
-- soundPath: "Notification.Messaging"
-  $name: Sound File Path
+- soundPath: "Notification.IM"
+  $name: Plugged-in Sound File Path
   $description: "The absolute path to a .wav file or a system sound alias (e.g.,
-Notification.Messaging) to play when plugged in."
+Notification.IM) to play when plugged in."
+- unpluggedSoundPath: ""
+  $name: Unplugged Sound File Path
+  $description: "The absolute path to a .wav file or a system sound alias to
+play when unplugged. Leave empty to disable."
 */
 // ==/WindhawkModSettings==
 
@@ -37,6 +42,7 @@ Notification.Messaging) to play when plugged in."
 
 struct {
     std::wstring soundPath;
+    std::wstring unpluggedSoundPath;
     std::mutex mtx;
 } settings;
 
@@ -44,63 +50,65 @@ HWND g_hwnd = NULL;
 HANDLE g_hThread = NULL;
 DWORD g_threadId = 0;
 HANDLE g_readyEvent = NULL;
-int g_previousACStatus = -1;
+
+bool EndsWithWav(const std::wstring& path) {
+    if (path.length() >= 4) {
+        std::wstring ext = path.substr(path.length() - 4);
+        return _wcsicmp(ext.c_str(), L".wav") == 0;
+    }
+    return false;
+}
+
+void PlaySoundPath(const std::wstring& path) {
+    if (path.empty()) {
+        return;
+    }
+
+    bool isFilePath = EndsWithWav(path);
+    DWORD flags =
+        SND_ASYNC | SND_NODEFAULT | (isFilePath ? SND_FILENAME : SND_ALIAS);
+
+    if (!PlaySoundW(path.c_str(), nullptr, flags)) {
+        Wh_Log(L"PlaySoundW failed for: %s", path.c_str());
+    }
+}
 
 LRESULT CALLBACK PowerWindowProc(HWND hwnd,
                                  UINT uMsg,
                                  WPARAM wParam,
                                  LPARAM lParam) {
-    if (uMsg == WM_DESTROY) {
-        PostQuitMessage(0);
-        return 0;
-    }
-
     if (uMsg == WM_POWERBROADCAST) {
-        if (wParam == PBT_APMPOWERSTATUSCHANGE) {
-            SYSTEM_POWER_STATUS sps;
-            if (GetSystemPowerStatus(&sps)) {
-                int currentACStatus = sps.ACLineStatus;
-
-                // Ignore unknown status (255)
-                if (currentACStatus == 255) {
-                    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
-                }
+        if (wParam == PBT_POWERSETTINGCHANGE) {
+            POWERBROADCAST_SETTING* pbs = (POWERBROADCAST_SETTING*)lParam;
+            if (pbs->PowerSetting == GUID_ACDC_POWER_SOURCE &&
+                pbs->DataLength == sizeof(int)) {
+                int currentACStatus = *(int*)pbs->Data;
 
                 Wh_Log(
                     L"Power status change detected. Current ACLineStatus: %d",
                     currentACStatus);
 
-                // Only trigger if we have a valid previous state and it
-                // actually changed
-                if (g_previousACStatus != -1 &&
-                    currentACStatus != g_previousACStatus) {
-                    if (currentACStatus == 1) {  // Plugged in
-                        std::wstring currentSoundPath;
-                        {
-                            std::lock_guard<std::mutex> lock(settings.mtx);
-                            currentSoundPath = settings.soundPath;
-                        }
-
-                        Wh_Log(L"Laptop plugged in. Playing sound: %s",
-                               currentSoundPath.c_str());
-
-                        // Treat it as a file if it looks like a path, otherwise
-                        // as a system sound alias.
-                        bool isFilePath =
-                            currentSoundPath.find(L'\\') != std::wstring::npos;
-                        if (isFilePath) {
-                            PlaySoundW(
-                                currentSoundPath.c_str(), nullptr,
-                                SND_FILENAME | SND_ASYNC | SND_NODEFAULT);
-                        } else {
-                            PlaySoundW(currentSoundPath.c_str(), nullptr,
-                                       SND_ALIAS | SND_ASYNC | SND_NODEFAULT);
-                        }
-                    } else if (currentACStatus == 0) {  // Unplugged
-                        Wh_Log(L"Laptop unplugged.");
+                if (currentACStatus == 0) {  // Plugged in (AC)
+                    std::wstring currentSoundPath;
+                    {
+                        std::lock_guard<std::mutex> lock(settings.mtx);
+                        currentSoundPath = settings.soundPath;
                     }
+
+                    Wh_Log(L"Laptop plugged in. Playing sound: %s",
+                           currentSoundPath.c_str());
+                    PlaySoundPath(currentSoundPath);
+                } else if (currentACStatus == 1) {  // Unplugged (DC)
+                    std::wstring currentUnpluggedSoundPath;
+                    {
+                        std::lock_guard<std::mutex> lock(settings.mtx);
+                        currentUnpluggedSoundPath = settings.unpluggedSoundPath;
+                    }
+
+                    Wh_Log(L"Laptop unplugged. Playing sound: %s",
+                           currentUnpluggedSoundPath.c_str());
+                    PlaySoundPath(currentUnpluggedSoundPath);
                 }
-                g_previousACStatus = currentACStatus;
             }
         }
     }
@@ -110,19 +118,16 @@ LRESULT CALLBACK PowerWindowProc(HWND hwnd,
 DWORD WINAPI PowerNotifyThread(LPVOID lpParam) {
     Wh_Log(L"PowerNotifyThread started.");
 
-    // Initialize the previous status to the current status so it doesn't play
-    // immediately on launch
-    SYSTEM_POWER_STATUS sps;
-    if (GetSystemPowerStatus(&sps)) {
-        if (sps.ACLineStatus != 255) {
-            g_previousACStatus = sps.ACLineStatus;
-        }
-    }
+    MSG msg;
+    // Ensure the thread message queue exists, so PostThreadMessageW never
+    // fails.
+    PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+    SetEvent(g_readyEvent);
 
     WNDCLASSEXW wc = {0};
     wc.cbSize = sizeof(WNDCLASSEXW);
     wc.lpfnWndProc = PowerWindowProc;
-    // Mod's module handle
+    // Executable's (windhawk.exe) module handle
     wc.hInstance = GetModuleHandleW(NULL);
     wc.lpszClassName = L"WindhawkChargingSoundHiddenWindow";
 
@@ -138,14 +143,21 @@ DWORD WINAPI PowerNotifyThread(LPVOID lpParam) {
     if (g_hwnd) {
         Wh_Log(L"Hidden window created successfully.");
 
-        MSG msg;
-        // Ensure the thread message queue exists, so PostMessageW never fails.
-        PeekMessageW(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
-        SetEvent(g_readyEvent);
+        HPOWERNOTIFY hPowerNotify = RegisterPowerSettingNotification(
+            g_hwnd, &GUID_ACDC_POWER_SOURCE, DEVICE_NOTIFY_WINDOW_HANDLE);
+
+        if (!hPowerNotify) {
+            Wh_Log(L"RegisterPowerSettingNotification failed with error: %u",
+                   GetLastError());
+        }
 
         while (GetMessageW(&msg, NULL, 0, 0) > 0) {
             TranslateMessage(&msg);
             DispatchMessageW(&msg);
+        }
+
+        if (hPowerNotify) {
+            UnregisterPowerSettingNotification(hPowerNotify);
         }
 
         DestroyWindow(g_hwnd);
@@ -161,9 +173,12 @@ DWORD WINAPI PowerNotifyThread(LPVOID lpParam) {
 
 void LoadSettings() {
     auto soundPath = WindhawkUtils::StringSetting::make(L"soundPath");
+    auto unpluggedSoundPath =
+        WindhawkUtils::StringSetting::make(L"unpluggedSoundPath");
     std::lock_guard<std::mutex> lock(settings.mtx);
-    settings.soundPath =
-        *soundPath ? soundPath.get() : L"Notification.Messaging";
+    settings.soundPath = *soundPath ? soundPath.get() : L"Notification.IM";
+    settings.unpluggedSoundPath =
+        *unpluggedSoundPath ? unpluggedSoundPath.get() : L"";
 }
 
 bool WhTool_ModInit() {
@@ -195,9 +210,7 @@ void WhTool_ModUninit() {
             WaitForSingleObject(g_readyEvent, INFINITE);
         }
 
-        if (g_hwnd) {
-            PostMessageW(g_hwnd, WM_CLOSE, 0, 0);
-        }
+        PostThreadMessageW(g_threadId, WM_QUIT, 0, 0);
 
         WaitForSingleObject(g_hThread, INFINITE);
         CloseHandle(g_hThread);

--- a/mods/charging-sound.wh.cpp
+++ b/mods/charging-sound.wh.cpp
@@ -2,7 +2,7 @@
 // @id              charging-sound
 // @name            Charging Sound
 // @description     Plays a custom sound when the laptop is plugged in or unplugged
-// @version         1.2
+// @version         1.3
 // @author          khonloi
 // @github          https://github.com/khonloi
 // @license         MIT
@@ -25,7 +25,7 @@ Please note that this mod only works on devices with a battery (e.g. laptops).
 /*
 - soundPath: "Notification.IM"
   $name: Plugged-in Sound File Path
-  $description: "The absolute path to a .wav file or a system sound alias (e.g., Notification.IM) to play when plugged in."
+  $description: "The absolute path to a .wav file or a system sound alias (e.g., Notification.IM) to play when plugged in. Leave empty to disable."
 - unpluggedSoundPath: ""
   $name: Unplugged Sound File Path
   $description: "The absolute path to a .wav file or a system sound alias to play when unplugged. Leave empty to disable."
@@ -35,8 +35,10 @@ Please note that this mod only works on devices with a battery (e.g. laptops).
 
 #include <mmsystem.h>
 #include <windows.h>
+#include <winnt.h>
 #include <mutex>
 #include <string>
+#include <utility>
 
 #include <windhawk_utils.h>
 
@@ -44,31 +46,21 @@ struct {
     std::wstring soundPath;
     std::wstring unpluggedSoundPath;
     std::mutex mtx;
-} settings;
+} g_settings;
 
-HWND g_hwnd = NULL;
 HANDLE g_hThread = NULL;
 DWORD g_threadId = 0;
 HANDLE g_readyEvent = NULL;
 
-bool EndsWithWav(const std::wstring& path) {
-    if (path.length() >= 4) {
-        std::wstring ext = path.substr(path.length() - 4);
-        return _wcsicmp(ext.c_str(), L".wav") == 0;
-    }
-    return false;
-}
+// -1 = unknown, so the first notification only establishes the baseline.
+int g_lastPowerCondition = -1;
 
 void PlaySoundPath(const std::wstring& path) {
     if (path.empty()) {
         return;
     }
 
-    bool isFilePath = EndsWithWav(path);
-    DWORD flags =
-        SND_ASYNC | SND_NODEFAULT | (isFilePath ? SND_FILENAME : SND_ALIAS);
-
-    if (!PlaySoundW(path.c_str(), nullptr, flags)) {
+    if (!PlaySoundW(path.c_str(), nullptr, SND_ASYNC | SND_NODEFAULT)) {
         Wh_Log(L"PlaySoundW failed for: %s", path.c_str());
     }
 }
@@ -81,28 +73,39 @@ LRESULT CALLBACK PowerWindowProc(HWND hwnd,
         if (wParam == PBT_POWERSETTINGCHANGE) {
             POWERBROADCAST_SETTING* pbs = (POWERBROADCAST_SETTING*)lParam;
             if (pbs->PowerSetting == GUID_ACDC_POWER_SOURCE &&
-                pbs->DataLength == sizeof(int)) {
-                int currentACStatus = *(int*)pbs->Data;
+                pbs->DataLength == sizeof(DWORD)) {
+                DWORD currentACStatus;
+                memcpy(&currentACStatus, pbs->Data, sizeof(DWORD));
+
+                int previous =
+                    std::exchange(g_lastPowerCondition, (int)currentACStatus);
+                if (previous == (int)currentACStatus || previous == -1) {
+                    return TRUE;
+                }
 
                 Wh_Log(
-                    L"Power status change detected. Current ACLineStatus: %d",
+                    L"Power status change detected. Current Power Condition: "
+                    L"%u",
                     currentACStatus);
 
-                if (currentACStatus == 0) {  // Plugged in (AC)
+                if (currentACStatus == PoAc) {  // Plugged in (AC)
                     std::wstring currentSoundPath;
                     {
-                        std::lock_guard<std::mutex> lock(settings.mtx);
-                        currentSoundPath = settings.soundPath;
+                        std::lock_guard<std::mutex> lock(g_settings.mtx);
+                        currentSoundPath = g_settings.soundPath;
                     }
 
                     Wh_Log(L"Laptop plugged in. Playing sound: %s",
                            currentSoundPath.c_str());
                     PlaySoundPath(currentSoundPath);
-                } else if (currentACStatus == 1) {  // Unplugged (DC)
+                } else if (currentACStatus == PoDc ||
+                           currentACStatus ==
+                               PoHot) {  // Unplugged (DC or UPS backup)
                     std::wstring currentUnpluggedSoundPath;
                     {
-                        std::lock_guard<std::mutex> lock(settings.mtx);
-                        currentUnpluggedSoundPath = settings.unpluggedSoundPath;
+                        std::lock_guard<std::mutex> lock(g_settings.mtx);
+                        currentUnpluggedSoundPath =
+                            g_settings.unpluggedSoundPath;
                     }
 
                     Wh_Log(L"Laptop unplugged. Playing sound: %s",
@@ -136,15 +139,15 @@ DWORD WINAPI PowerNotifyThread(LPVOID lpParam) {
         return 1;
     }
 
-    g_hwnd = CreateWindowExW(0, wc.lpszClassName, L"WindhawkChargingSound",
-                             WS_OVERLAPPED, 0, 0, 0, 0, NULL, NULL,
-                             wc.hInstance, NULL);
+    HWND hwnd =
+        CreateWindowExW(0, wc.lpszClassName, L"WindhawkChargingSound", 0, 0, 0,
+                        0, 0, HWND_MESSAGE, NULL, wc.hInstance, NULL);
 
-    if (g_hwnd) {
+    if (hwnd) {
         Wh_Log(L"Hidden window created successfully.");
 
         HPOWERNOTIFY hPowerNotify = RegisterPowerSettingNotification(
-            g_hwnd, &GUID_ACDC_POWER_SOURCE, DEVICE_NOTIFY_WINDOW_HANDLE);
+            hwnd, &GUID_ACDC_POWER_SOURCE, DEVICE_NOTIFY_WINDOW_HANDLE);
 
         if (!hPowerNotify) {
             Wh_Log(L"RegisterPowerSettingNotification failed with error: %u",
@@ -160,8 +163,7 @@ DWORD WINAPI PowerNotifyThread(LPVOID lpParam) {
             UnregisterPowerSettingNotification(hPowerNotify);
         }
 
-        DestroyWindow(g_hwnd);
-        g_hwnd = NULL;
+        DestroyWindow(hwnd);
     } else {
         Wh_Log(L"CreateWindowExW failed with error: %u", GetLastError());
     }
@@ -175,10 +177,9 @@ void LoadSettings() {
     auto soundPath = WindhawkUtils::StringSetting::make(L"soundPath");
     auto unpluggedSoundPath =
         WindhawkUtils::StringSetting::make(L"unpluggedSoundPath");
-    std::lock_guard<std::mutex> lock(settings.mtx);
-    settings.soundPath = *soundPath ? soundPath.get() : L"Notification.IM";
-    settings.unpluggedSoundPath =
-        *unpluggedSoundPath ? unpluggedSoundPath.get() : L"";
+    std::lock_guard<std::mutex> lock(g_settings.mtx);
+    g_settings.soundPath = soundPath.get();
+    g_settings.unpluggedSoundPath = unpluggedSoundPath.get();
 }
 
 bool WhTool_ModInit() {
@@ -216,7 +217,6 @@ void WhTool_ModUninit() {
         CloseHandle(g_hThread);
         g_hThread = NULL;
         g_threadId = 0;
-        g_hwnd = NULL;
     }
 
     if (g_readyEvent) {
@@ -230,6 +230,7 @@ void WhTool_ModSettingsChanged() {
     LoadSettings();
 }
 
+// clang-format off
 // ============================================================================
 // Tool Mod Boilerplate
 // ============================================================================
@@ -247,15 +248,18 @@ BOOL Wh_ModInit() {
         sessionId == 0) {
         return FALSE;
     }
+
     bool isExcluded = false;
     bool isToolModProcess = false;
     bool isCurrentToolModProcess = false;
+
     int argc;
     LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
     if (!argv) {
         Wh_Log(L"CommandLineToArgvW failed");
         return FALSE;
     }
+
     for (int i = 1; i < argc; i++) {
         if (wcscmp(argv[i], L"-service") == 0 ||
             wcscmp(argv[i], L"-service-start") == 0 ||
@@ -264,6 +268,7 @@ BOOL Wh_ModInit() {
             break;
         }
     }
+
     for (int i = 1; i < argc - 1; i++) {
         if (wcscmp(argv[i], L"-tool-mod") == 0) {
             isToolModProcess = true;
@@ -279,6 +284,7 @@ BOOL Wh_ModInit() {
     if (isExcluded) {
         return FALSE;
     }
+
     if (isCurrentToolModProcess) {
         g_toolModProcessMutex =
             CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
@@ -291,6 +297,7 @@ BOOL Wh_ModInit() {
             Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
             ExitProcess(1);
         }
+
         if (!WhTool_ModInit()) {
             ExitProcess(1);
         }
@@ -318,6 +325,7 @@ void Wh_ModAfterInit() {
     if (!g_isToolModProcessLauncher) {
         return;
     }
+
     WCHAR currentProcessPath[MAX_PATH];
     switch (GetModuleFileName(nullptr, currentProcessPath,
                               ARRAYSIZE(currentProcessPath))) {
@@ -326,11 +334,13 @@ void Wh_ModAfterInit() {
             Wh_Log(L"GetModuleFileName failed");
             return;
     }
+
     WCHAR
     commandLine[MAX_PATH + 2 +
                 (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
     swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
                WH_MOD_ID);
+
     HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
     if (!kernelModule) {
         kernelModule = GetModuleHandle(L"kernel32.dll");
@@ -339,6 +349,7 @@ void Wh_ModAfterInit() {
             return;
         }
     }
+
     using CreateProcessInternalW_t = BOOL(WINAPI*)(
         HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
         LPSECURITY_ATTRIBUTES lpProcessAttributes,
@@ -347,6 +358,7 @@ void Wh_ModAfterInit() {
         LPSTARTUPINFOW lpStartupInfo,
         LPPROCESS_INFORMATION lpProcessInformation,
         PHANDLE hRestrictedUserToken);
+
     CreateProcessInternalW_t pCreateProcessInternalW =
         (CreateProcessInternalW_t)GetProcAddress(kernelModule,
                                                  "CreateProcessInternalW");
@@ -354,6 +366,7 @@ void Wh_ModAfterInit() {
         Wh_Log(L"No CreateProcessInternalW");
         return;
     }
+
     STARTUPINFO si{
         .cb = sizeof(STARTUPINFO),
         .dwFlags = STARTF_FORCEOFFFEEDBACK,
@@ -365,6 +378,7 @@ void Wh_ModAfterInit() {
         Wh_Log(L"CreateProcess failed");
         return;
     }
+
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
 }
@@ -385,3 +399,4 @@ void Wh_ModUninit() {
     WhTool_ModUninit();
     ExitProcess(0);
 }
+// clang-format on


### PR DESCRIPTION
Adds a new mod that plays a customizable audio sound when the laptop is plugged into an AC charger. 
By default, it plays the "Windows Notify Messaging" system sound, but users can specify any `.wav` file path in the settings. The mod uses `PBT_APMPOWERSTATUSCHANGE` to reliably detect power state changes in the background.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

N/A - This is a new mod.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [x] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.