### PR TITLE
Create fix-10-taskbar-notifications.wh.cpp

### DIFF
--- a/mods/fix-10-taskbar-notifications.wh.cpp
+++ b/mods/fix-10-taskbar-notifications.wh.cpp
@@ -5,7 +5,7 @@
 // @version         0.1
 // @author          ilovethisgame
 // @github          https://github.com/bozohi
-// @include         explorer.exe
+// @include         %ProgramData%\Windhawk\Engine\ModsWritable\LegacyStore\explorer.exe
 // @architecture    amd64
 // @license         MIT
 // ==/WindhawkMod==
@@ -14,10 +14,8 @@
 /*
 This mod patches the Explorer shell provided by the Win10 taskbar mod at runtime.
 
-**IF YOUR WINDOWS VERSION IS NOT WINDOWS 11 24H2 OR ABOVE, DO NOT INSTALL THIS!**
-
 **!Important! You MUST install, follow the instructions and run atleast 2 times the [Win10 taskbar mod.](https://windhawk.net/mods/win10-taskbar-on-win11-24h2)**
-**If you don't follow these instructions carefully, explorer may behave in an unexpected (and likely unpleasant) manner.**
+**If you don't follow these instructions carefully, the mod will not apply correctly.**
 
 # Technical details
 
@@ -47,9 +45,9 @@ There is no `NULL` check in that loop, so it is likely that the iterator was nev
 
 static bool patch_applied { false };
 static uint8_t patch_bytes[] { 0xC3, 0x90, 0x90, 0x90, 0x90 }; // ret + 4 nop
-static constexpr size_t patch_size = sizeof patch_bytes;
+static constexpr size_t patch_size { sizeof patch_bytes };
 
-static uint8_t orig_bytes[patch_size] = { 0 };
+static uint8_t orig_bytes[patch_size] { 0 };
 static uint8_t *target;
 
 BOOL Wh_ModInit(void) {
@@ -94,16 +92,19 @@ BOOL Wh_ModInit(void) {
 
     patch_applied = true;
 
+    FlushInstructionCache(GetCurrentProcess(), (void *) target, patch_size);
+
     return TRUE;
 }
 
 void Wh_ModUninit(void) {
     if (!patch_applied) {
-        Wh_Log(L"Patch was not applied, skipping revert");
+        Wh_Log(L"UNINIT: Patch was not applied, skipping revert");
+        return;
     }
 
     if (orig_bytes[0] == 0x00) {
-        Wh_Log(L"Original bytes did not get copied correctly, aborting uninit");
+        Wh_Log(L"UNINIT: Original bytes did not get copied correctly, aborting revert");
         return;
     }
 
@@ -114,9 +115,9 @@ void Wh_ModUninit(void) {
     }
 
     if (!memcpy_s((void *) target, patch_size, orig_bytes, patch_size)) {
-        Wh_Log(L"Original bytes rewritten successfully");
+        Wh_Log(L"UNINIT: Original bytes rewritten successfully");
     } else {
-        Wh_Log(L"FAILED TO REVERT PATCH");
+        Wh_Log(L"UNINIT: FAILED TO REVERT PATCH");
     }
 
     DWORD temp = 0;

--- a/mods/fix-10-taskbar-notifications.wh.cpp
+++ b/mods/fix-10-taskbar-notifications.wh.cpp
@@ -5,14 +5,14 @@
 // @version         0.1
 // @author          ilovethisgame
 // @github          https://github.com/bozohi
-// @include         %ProgramData%\Windhawk\Engine\ModsWritable\LegacyStore\explorer.exe
-// @architecture    amd64
+// @include         explorer.exe
+// @architecture    x86-64
 // @license         MIT
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
 /*
-This mod patches the Explorer shell provided by the Win10 taskbar mod at runtime.
+This mod hooks the function responsible for crashing the Explorer shell provided by the Win10 taskbar mod at runtime.
 
 But it is not confirmed if notifications arrive to the Notification Center.
 Thus, all this mod does is let notifications render without crashing Win10 Explorer but not hand them over to it (probably for the best.)
@@ -27,7 +27,7 @@ When a notification is rendered, it invokes from explorer a method called
 NotificationDataSink::NotificationsAdded(
     NotificationDataSink *this,
     int32_t _arg2,
-    struct NOC_REFINED_NOTIFICATION const **iterator,
+    struct NOC_REFINED_NOTIFICATION *const *iterator,
     uint32_t length
 );
 ```
@@ -45,16 +45,25 @@ There is no `NULL` check in that loop, so it is likely that the iterator was nev
 // ==/WindhawkModReadme==
 
 #include<cstdint>
+#include<windhawk_api.h>
+#include<windhawk_utils.h>
+
+using NotificationsAdded_t = HRESULT (*)(void *pthis, uint32_t arg2, void* const* iterator, uint32_t length);
+
+NotificationsAdded_t NotificationsAdded_orig;
+
+HRESULT NotificationsAdded_hook(void *pthis, uint32_t arg2, void* const* iterator, uint32_t length) {
+    Wh_Log(L"Suppressing %u notification(s)", length);
+
+    return S_OK;
+}
 
 static bool patch_applied { false };
-static uint8_t patch_bytes[] { 0xC3, 0x90, 0x90, 0x90, 0x90 }; // ret + 4 nop
-static constexpr size_t patch_size { sizeof patch_bytes };
 
-static uint8_t orig_bytes[patch_size] { 0 };
 static uint8_t *target;
 
 BOOL Wh_ModInit(void) {
-    Wh_Log(L"Initializing explorer patch");
+    Wh_Log(L"Initializing explorer function hook");
 
     HMODULE explorer { GetModuleHandleW(NULL) };
     if (!explorer) {
@@ -62,69 +71,36 @@ BOOL Wh_ModInit(void) {
         return FALSE;
     }
 
+    auto dos_header = (PIMAGE_DOS_HEADER) explorer;
+    auto nt_headers = (PIMAGE_NT_HEADERS64) ((uint8_t *) explorer + dos_header->e_lfanew);
+
+    if (nt_headers->FileHeader.TimeDateStamp != 0x7AC6EEC3 ||
+        nt_headers->OptionalHeader.SizeOfImage != 0x442000)
+    {
+        Wh_Log(L"Unexpected explorer build, not hooking");
+
+        return FALSE;
+    }
+
     target = (uint8_t *) explorer + 0x14DC40;
-    Wh_Log(L"Target address: 0x%llx", target);
+    Wh_Log(L"NotificationsAdded address: 0x%llx", target);
 
-    if (!memcmp((LPVOID) target, (LPVOID) patch_bytes, patch_size)) {
-        Wh_Log(L"Explorer was already patched, quitting");
-        return TRUE;
-    }
-
-    DWORD old_protect {};
-    if (!VirtualProtect((LPVOID) target, patch_size, PAGE_EXECUTE_READWRITE, &old_protect)) {
-        Wh_Log(L"FAILED TO CHANGE MEMORY PROTECTION: %d", GetLastError());
-        return FALSE;
-    }
-
-    memcpy_s((void *) orig_bytes, patch_size, (const void *) target, patch_size);
-
-    bool failed { false };
-    if (!memcpy_s((void *) target, patch_size, patch_bytes, patch_size)) {
-        Wh_Log(L"Patch applied successfully");
-    } else {
-        Wh_Log(L"FAILED TO APPLY PATCH");
-        failed = true;
-    }
-
-    DWORD temp = 0;
-    VirtualProtect((void *) target, patch_size, old_protect, &temp);
-
-    if (failed) {
-        return FALSE;
-    }
-
-    patch_applied = true;
-
-    FlushInstructionCache(GetCurrentProcess(), (void *) target, patch_size);
+    if (WindhawkUtils::SetFunctionHook(target, (uint8_t *) NotificationsAdded_hook, (uint8_t **) &NotificationsAdded_orig))
+        patch_applied = true;
+    else
+        Wh_Log(L"Error occurred during hooking");
 
     return TRUE;
 }
 
-void Wh_ModUninit(void) {
+void Wh_ModBeforeUninit(void) {
     if (!patch_applied) {
-        Wh_Log(L"UNINIT: Patch was not applied, skipping revert");
+        Wh_Log(L"UNINIT: Hook was not applied, skipping revert");
         return;
     }
 
-    if (orig_bytes[0] == 0x00) {
-        Wh_Log(L"UNINIT: Original bytes did not get copied correctly, aborting revert");
-        return;
-    }
-
-    DWORD old_protect {};
-    if (!VirtualProtect((LPVOID) target, patch_size, PAGE_EXECUTE_READWRITE, &old_protect)) {
-        Wh_Log(L"UNINIT: FAILED TO CHANGE MEMORY PROTECTION: %d", GetLastError());
-        return;
-    }
-
-    if (!memcpy_s((void *) target, patch_size, orig_bytes, patch_size)) {
-        Wh_Log(L"UNINIT: Original bytes rewritten successfully");
-    } else {
-        Wh_Log(L"UNINIT: FAILED TO REVERT PATCH");
-    }
-
-    DWORD temp = 0;
-    VirtualProtect((void *) target, patch_size, old_protect, &temp);
-
-    FlushInstructionCache(GetCurrentProcess(), (void *) target, patch_size);
+    if (Wh_RemoveFunctionHook(target))
+        Wh_Log(L"UNINIT: Hook unapplied successfully");
+    else
+        Wh_Log(L"UNINIT: Error occurred during unhooking");
 }

--- a/mods/fix-10-taskbar-notifications.wh.cpp
+++ b/mods/fix-10-taskbar-notifications.wh.cpp
@@ -14,7 +14,10 @@
 /*
 This mod patches the Explorer shell provided by the Win10 taskbar mod at runtime.
 
-**!Important! You MUST install, follow the instructions and run atleast 2 times the [Win10 taskbar mod.](https://windhawk.net/mods/win10-taskbar-on-win11-24h2)**
+But it is not confirmed if notifications arrive to the Notification Center.
+Thus, all this mod does is let notifications render without crashing Win10 Explorer but not hand them over to it (probably for the best.)
+
+**!Important! You MUST install, follow the instructions and run at least 2 times the [Win10 taskbar mod.](https://windhawk.net/mods/win10-taskbar-on-win11-24h2)**
 **If you don't follow these instructions carefully, the mod will not apply correctly.**
 
 # Technical details
@@ -122,4 +125,6 @@ void Wh_ModUninit(void) {
 
     DWORD temp = 0;
     VirtualProtect((void *) target, patch_size, old_protect, &temp);
+
+    FlushInstructionCache(GetCurrentProcess(), (void *) target, patch_size);
 }

--- a/mods/fix-10-taskbar-notifications.wh.cpp
+++ b/mods/fix-10-taskbar-notifications.wh.cpp
@@ -68,6 +68,7 @@ extern BOOL Wh_ModInit(void) {
     HMODULE explorer { GetModuleHandleW(NULL) };
     if (!explorer) {
         Wh_Log(L"Failed to get explorer base address");
+        
         return FALSE;
     }
 
@@ -87,8 +88,11 @@ extern BOOL Wh_ModInit(void) {
 
     if (WindhawkUtils::SetFunctionHook(target, (uint8_t *) NotificationsAdded_hook, (uint8_t **) &NotificationsAdded_orig))
         patch_applied = true;
-    else
+    else {
         Wh_Log(L"Error occurred during hooking");
+        
+        return FALSE;
+    }
 
     return TRUE;
 }

--- a/mods/fix-10-taskbar-notifications.wh.cpp
+++ b/mods/fix-10-taskbar-notifications.wh.cpp
@@ -46,11 +46,8 @@ There is no `NULL` check in that loop, so it is likely that the iterator was nev
 
 #include<cstdint>
 #include<windhawk_api.h>
-#include<windhawk_utils.h>
 
 using NotificationsAdded_t = HRESULT (*)(void *pthis, uint32_t arg2, void* const* iterator, uint32_t length);
-
-static NotificationsAdded_t NotificationsAdded_orig;
 
 static HRESULT NotificationsAdded_hook(void *pthis, uint32_t arg2, void* const* iterator, uint32_t length) {
     Wh_Log(L"Suppressing %u notification(s)", length);
@@ -58,9 +55,7 @@ static HRESULT NotificationsAdded_hook(void *pthis, uint32_t arg2, void* const* 
     return S_OK;
 }
 
-static bool patch_applied { false };
-
-static uint8_t *target;
+static uint8_t *fn_ptr;
 
 extern BOOL Wh_ModInit(void) {
     Wh_Log(L"Initializing explorer function hook");
@@ -83,28 +78,14 @@ extern BOOL Wh_ModInit(void) {
         return FALSE;
     }
 
-    target = (uint8_t *) explorer + 0x14DC40;
-    Wh_Log(L"NotificationsAdded address: 0x%llx", target);
+    fn_ptr = (uint8_t *) explorer + 0x14DC40;
+    Wh_Log(L"NotificationsAdded address: 0x%p", fn_ptr);
 
-    if (WindhawkUtils::SetFunctionHook(target, (uint8_t *) NotificationsAdded_hook, (uint8_t **) &NotificationsAdded_orig))
-        patch_applied = true;
-    else {
+    if (!Wh_SetFunctionHook(fn_ptr, (void *) NotificationsAdded_hook, nullptr)) {
         Wh_Log(L"Error occurred during hooking");
         
         return FALSE;
     }
 
     return TRUE;
-}
-
-extern void Wh_ModBeforeUninit(void) {
-    if (!patch_applied) {
-        Wh_Log(L"UNINIT: Hook was not applied, skipping revert");
-        return;
-    }
-
-    if (Wh_RemoveFunctionHook(target))
-        Wh_Log(L"UNINIT: Hook unapplied successfully");
-    else
-        Wh_Log(L"UNINIT: Error occurred during unhooking");
 }

--- a/mods/fix-10-taskbar-notifications.wh.cpp
+++ b/mods/fix-10-taskbar-notifications.wh.cpp
@@ -50,9 +50,9 @@ There is no `NULL` check in that loop, so it is likely that the iterator was nev
 
 using NotificationsAdded_t = HRESULT (*)(void *pthis, uint32_t arg2, void* const* iterator, uint32_t length);
 
-NotificationsAdded_t NotificationsAdded_orig;
+static NotificationsAdded_t NotificationsAdded_orig;
 
-HRESULT NotificationsAdded_hook(void *pthis, uint32_t arg2, void* const* iterator, uint32_t length) {
+static HRESULT NotificationsAdded_hook(void *pthis, uint32_t arg2, void* const* iterator, uint32_t length) {
     Wh_Log(L"Suppressing %u notification(s)", length);
 
     return S_OK;
@@ -62,7 +62,7 @@ static bool patch_applied { false };
 
 static uint8_t *target;
 
-BOOL Wh_ModInit(void) {
+extern BOOL Wh_ModInit(void) {
     Wh_Log(L"Initializing explorer function hook");
 
     HMODULE explorer { GetModuleHandleW(NULL) };
@@ -93,7 +93,7 @@ BOOL Wh_ModInit(void) {
     return TRUE;
 }
 
-void Wh_ModBeforeUninit(void) {
+extern void Wh_ModBeforeUninit(void) {
     if (!patch_applied) {
         Wh_Log(L"UNINIT: Hook was not applied, skipping revert");
         return;

--- a/mods/fix-10-taskbar-notifications.wh.cpp
+++ b/mods/fix-10-taskbar-notifications.wh.cpp
@@ -1,0 +1,124 @@
+// ==WindhawkMod==
+// @id              fix-10-taskbar-notifications
+// @name            Fix 11's notifications crash in Win10 taskbar under Win11 24H2+
+// @description     Stops notifications from crashing explorer
+// @version         0.1
+// @author          ilovethisgame
+// @github          https://github.com/bozohi
+// @include         explorer.exe
+// @architecture    amd64
+// @license         MIT
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+This mod patches the Explorer shell provided by the Win10 taskbar mod at runtime.
+
+**IF YOUR WINDOWS VERSION IS NOT WINDOWS 11 24H2 OR ABOVE, DO NOT INSTALL THIS!**
+
+**!Important! You MUST install, follow the instructions and run atleast 2 times the [Win10 taskbar mod.](https://windhawk.net/mods/win10-taskbar-on-win11-24h2)**
+**If you don't follow these instructions carefully, explorer may behave in an unexpected (and likely unpleasant) manner.**
+
+# Technical details
+
+When a notification is rendered, it invokes from explorer a method called 
+```cpp
+NotificationDataSink::NotificationsAdded(
+    NotificationDataSink *this,
+    int32_t _arg2,
+    struct NOC_REFINED_NOTIFICATION const **iterator,
+    uint32_t length
+);
+```
+.
+
+**Given I haven't experienced any destabilization from explorer thus far, I claim that this has something to do with the Notification Center.**
+
+I won't go too deep into details of the function, but the crash is observed as a `NULL` pointer exception when it tries to access `*(iterator + 0x88)` for the first time, which is probably where the actual elements are.
+
+Normally, it would use that pointer to add 0x150 in a do-while loop until the notification thing elements are exhausted, but instead it's just `NULL`.
+I haven't given a look at the iterator memory to see if it's more than just the first element that's `NULL`, or more or all of them are such.
+
+There is no `NULL` check in that loop, so it is likely that the iterator was never supposed to have `NULL` elements in the first place.
+*/
+// ==/WindhawkModReadme==
+
+#include<cstdint>
+
+static bool patch_applied { false };
+static uint8_t patch_bytes[] { 0xC3, 0x90, 0x90, 0x90, 0x90 }; // ret + 4 nop
+static constexpr size_t patch_size = sizeof patch_bytes;
+
+static uint8_t orig_bytes[patch_size] = { 0 };
+static uint8_t *target;
+
+BOOL Wh_ModInit(void) {
+    Wh_Log(L"Initializing explorer patch");
+
+    HMODULE explorer { GetModuleHandleW(NULL) };
+    if (!explorer) {
+        Wh_Log(L"Failed to get explorer base address");
+        return FALSE;
+    }
+
+    target = (uint8_t *) explorer + 0x14DC40;
+    Wh_Log(L"Target address: 0x%llx", target);
+
+    if (!memcmp((LPVOID) target, (LPVOID) patch_bytes, patch_size)) {
+        Wh_Log(L"Explorer was already patched, quitting");
+        return TRUE;
+    }
+
+    DWORD old_protect {};
+    if (!VirtualProtect((LPVOID) target, patch_size, PAGE_EXECUTE_READWRITE, &old_protect)) {
+        Wh_Log(L"FAILED TO CHANGE MEMORY PROTECTION: %d", GetLastError());
+        return FALSE;
+    }
+
+    memcpy_s((void *) orig_bytes, patch_size, (const void *) target, patch_size);
+
+    bool failed { false };
+    if (!memcpy_s((void *) target, patch_size, patch_bytes, patch_size)) {
+        Wh_Log(L"Patch applied successfully");
+    } else {
+        Wh_Log(L"FAILED TO APPLY PATCH");
+        failed = true;
+    }
+
+    DWORD temp = 0;
+    VirtualProtect((void *) target, patch_size, old_protect, &temp);
+
+    if (failed) {
+        return FALSE;
+    }
+
+    patch_applied = true;
+
+    return TRUE;
+}
+
+void Wh_ModUninit(void) {
+    if (!patch_applied) {
+        Wh_Log(L"Patch was not applied, skipping revert");
+    }
+
+    if (orig_bytes[0] == 0x00) {
+        Wh_Log(L"Original bytes did not get copied correctly, aborting uninit");
+        return;
+    }
+
+    DWORD old_protect {};
+    if (!VirtualProtect((LPVOID) target, patch_size, PAGE_EXECUTE_READWRITE, &old_protect)) {
+        Wh_Log(L"UNINIT: FAILED TO CHANGE MEMORY PROTECTION: %d", GetLastError());
+        return;
+    }
+
+    if (!memcpy_s((void *) target, patch_size, orig_bytes, patch_size)) {
+        Wh_Log(L"Original bytes rewritten successfully");
+    } else {
+        Wh_Log(L"FAILED TO REVERT PATCH");
+    }
+
+    DWORD temp = 0;
+    VirtualProtect((void *) target, patch_size, old_protect, &temp);
+}


### PR DESCRIPTION
This is a mod that applies runtime patches regarding 11's notifications so it doesn't crash anymore in Windows 10 explorer mod created by @Anixx .

## Changelog

None

## Mod authorship

This mod was created by:

- - [x] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 