### PR TITLE
Add startup-app.delay-fix.wh.cpp

### DIFF
--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -67,8 +67,6 @@ EXTERN_C NTSYSAPI NTSTATUS NTAPI NtQueryKey(
     HANDLE keyHandle, KEY_INFORMATION_CLASS keyInformationClass,
     PVOID keyInformation, ULONG length, PULONG resultLength);
 
-EXTERN_C NTSYSAPI NTSTATUS NTAPI RtlNtStatusFromDosError(ULONG dosError);
-
 using NtOpenKey_t = NTSTATUS(NTAPI*)(PHANDLE keyHandle,
                                      ACCESS_MASK desiredAccess,
                                      POBJECT_ATTRIBUTES objectAttributes);
@@ -144,13 +142,24 @@ bool IsSerializeOpen(const OBJECT_ATTRIBUTES* objectAttributes) {
     return IsSerializePath(path);
 }
 
-NTSTATUS DuplicateRedirectKey(PHANDLE keyHandle, ACCESS_MASK desiredAccess) {
+NTSTATUS DuplicateRedirectKeyHandle(PHANDLE keyHandle,
+                                    ACCESS_MASK desiredAccess) {
     HANDLE duplicate = nullptr;
     DWORD options = desiredAccess & MAXIMUM_ALLOWED ? DUPLICATE_SAME_ACCESS : 0;
     if (!DuplicateHandle(GetCurrentProcess(), g_redirectKey,
                          GetCurrentProcess(), &duplicate, desiredAccess, FALSE,
                          options)) {
-        return RtlNtStatusFromDosError(GetLastError());
+        switch (GetLastError()) {
+            case ERROR_ACCESS_DENIED:
+                return STATUS_ACCESS_DENIED;
+            case ERROR_INVALID_HANDLE:
+                return STATUS_INVALID_HANDLE;
+            case ERROR_NOT_ENOUGH_MEMORY:
+            case ERROR_OUTOFMEMORY:
+                return STATUS_NO_MEMORY;
+            default:
+                return STATUS_UNSUCCESSFUL;
+        }
     }
 
     *keyHandle = duplicate;
@@ -160,7 +169,7 @@ NTSTATUS DuplicateRedirectKey(PHANDLE keyHandle, ACCESS_MASK desiredAccess) {
 NTSTATUS NTAPI NtOpenKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
                               POBJECT_ATTRIBUTES objectAttributes) {
     if (IsSerializeOpen(objectAttributes)) {
-        return DuplicateRedirectKey(keyHandle, desiredAccess);
+        return DuplicateRedirectKeyHandle(keyHandle, desiredAccess);
     }
     return NtOpenKey_orig(keyHandle, desiredAccess, objectAttributes);
 }
@@ -169,7 +178,7 @@ NTSTATUS NTAPI NtOpenKeyEx_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
                                 POBJECT_ATTRIBUTES objectAttributes,
                                 ULONG openOptions) {
     if (IsSerializeOpen(objectAttributes)) {
-        return DuplicateRedirectKey(keyHandle, desiredAccess);
+        return DuplicateRedirectKeyHandle(keyHandle, desiredAccess);
     }
     return NtOpenKeyEx_orig(keyHandle, desiredAccess, objectAttributes,
                             openOptions);

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -1,375 +1,252 @@
 // ==WindhawkMod==
 // @id              startup-app-delay-fix
 // @name            Startup App Delay Fix
-// @description     Restores WaitforIdleState=0 whenever Windhawk starts
-// @version         1.0
+// @description     Removes the delay Windows applies to startup applications after sign-in
+// @version         1.1
 // @author          meteoni
 // @github          https://github.com/Meteony
-// @include         windhawk.exe
-// @compilerOptions -ladvapi32 -lshell32
+// @include         explorer.exe
+// @compilerOptions -lntdll
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
-Windows intentionally delays startup applications after sign-in to reduce system load, which can cause many apps to open minutes after system startup. 
+Windows intentionally delays startup applications after sign-in to reduce
+system load, which can cause apps to open minutes after startup.
 
-![Key](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/startup-app-delay-fix/startup-app-delay-fix.png)
+This mod makes Explorer see `WaitforIdleState` as zero when it reads the
+startup-item serialization settings. It doesn't create or modify registry
+values, so disabling the mod restores Windows' normal behavior immediately.
 
-This can be disabled by setting the following registry value:
-
-`HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Serialize
-WaitforIdleState    REG_DWORD    0`
-
-However, some Windows updates reset this value. This mod automates 
-the process of checking and setting that key as a more persistent fix.   
+Only `WaitforIdleState` is overridden. The related `StartupDelayInMSec` value
+is left unchanged.
 */
 // ==/WindhawkModReadme==
 
-#include <windows.h>
-#include <shellapi.h>
-#include <strsafe.h>
+#include <ntdef.h>
+#include <ntstatus.h>
 
-// Registry repair logic
+#include <cstring>
+#include <string>
 
-constexpr wchar_t kRegistryPath[] =
-    L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Serialize";
-
+constexpr wchar_t kKeyPathSuffix[] =
+    L"\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Serialize";
 constexpr wchar_t kValueName[] = L"WaitforIdleState";
-constexpr DWORD kDesiredValue = 0;
 
-bool EnsureStartupDelayFix() {
-    HKEY key = nullptr;
-    DWORD disposition = 0;
+typedef enum _KEY_INFORMATION_CLASS {
+    KeyBasicInformation,
+    KeyNodeInformation,
+    KeyFullInformation,
+    KeyNameInformation,
+} KEY_INFORMATION_CLASS;
 
-    LSTATUS status = RegCreateKeyExW(
-        HKEY_CURRENT_USER,
-        kRegistryPath,
-        0,
-        nullptr,
-        REG_OPTION_NON_VOLATILE,
-        KEY_QUERY_VALUE | KEY_SET_VALUE | KEY_WOW64_64KEY,
-        nullptr,
-        &key,
-        &disposition
-    );
+typedef struct _KEY_NAME_INFORMATION {
+    ULONG NameLength;
+    WCHAR Name[1];
+} KEY_NAME_INFORMATION, *PKEY_NAME_INFORMATION;
 
-    if (status != ERROR_SUCCESS) {
-        Wh_Log(
-            L"Failed to open or create HKCU\\%s: error %ld",
-            kRegistryPath,
-            status
-        );
+typedef enum _KEY_VALUE_INFORMATION_CLASS {
+    KeyValueBasicInformation,
+    KeyValueFullInformation,
+    KeyValuePartialInformation,
+    KeyValueFullInformationAlign64,
+    KeyValuePartialInformationAlign64,
+} KEY_VALUE_INFORMATION_CLASS;
+
+struct KEY_VALUE_BASIC_INFORMATION_LOCAL {
+    ULONG TitleIndex;
+    ULONG Type;
+    ULONG NameLength;
+    WCHAR Name[1];
+};
+
+struct KEY_VALUE_FULL_INFORMATION_LOCAL {
+    ULONG TitleIndex;
+    ULONG Type;
+    ULONG DataOffset;
+    ULONG DataLength;
+    ULONG NameLength;
+    WCHAR Name[1];
+};
+
+struct KEY_VALUE_PARTIAL_INFORMATION_LOCAL {
+    ULONG TitleIndex;
+    ULONG Type;
+    ULONG DataLength;
+    UCHAR Data[1];
+};
+
+EXTERN_C NTSYSAPI NTSTATUS NTAPI NtQueryKey(
+    HANDLE keyHandle, KEY_INFORMATION_CLASS keyInformationClass,
+    PVOID keyInformation, ULONG length, PULONG resultLength);
+
+using NtQueryValueKey_t = NTSTATUS(NTAPI*)(
+    HANDLE keyHandle, PUNICODE_STRING valueName,
+    KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
+    PVOID keyValueInformation, ULONG length, PULONG resultLength);
+NtQueryValueKey_t NtQueryValueKey_orig;
+
+bool GetKeyPath(HANDLE key, std::wstring* path) {
+    ULONG size = 0;
+    NTSTATUS status = NtQueryKey(key, KeyNameInformation, nullptr, 0, &size);
+    if (status != STATUS_BUFFER_TOO_SMALL &&
+        status != STATUS_BUFFER_OVERFLOW) {
         return false;
     }
 
-    DWORD existingValue = 0;
-    DWORD existingType = 0;
-    DWORD existingSize = sizeof(existingValue);
-
-    status = RegQueryValueExW(
-        key,
-        kValueName,
-        nullptr,
-        &existingType,
-        reinterpret_cast<BYTE*>(&existingValue),
-        &existingSize
-    );
-
-    if (status == ERROR_SUCCESS &&
-        existingType == REG_DWORD &&
-        existingSize == sizeof(DWORD) &&
-        existingValue == kDesiredValue) {
-        Wh_Log(
-            L"%s is already correctly set to %lu",
-            kValueName,
-            kDesiredValue
-        );
-
-        RegCloseKey(key);
-        return true;
-    }
-
-    bool valueWasMissing = status == ERROR_FILE_NOT_FOUND;
-
-    status = RegSetValueExW(
-        key,
-        kValueName,
-        0,
-        REG_DWORD,
-        reinterpret_cast<const BYTE*>(&kDesiredValue),
-        sizeof(kDesiredValue)
-    );
-
-    RegCloseKey(key);
-
-    if (status != ERROR_SUCCESS) {
-        Wh_Log(
-            L"Failed to set %s: error %ld",
-            kValueName,
-            status
-        );
+    std::wstring buffer((size + sizeof(wchar_t) - 1) / sizeof(wchar_t), L'\0');
+    auto info = reinterpret_cast<KEY_NAME_INFORMATION*>(buffer.data());
+    status = NtQueryKey(key, KeyNameInformation, info, size, &size);
+    if (status < 0) {
         return false;
     }
 
-    if (disposition == REG_CREATED_NEW_KEY) {
-        Wh_Log(
-            L"Created Serialize registry key and set %s to %lu",
-            kValueName,
-            kDesiredValue
-        );
-    } else if (valueWasMissing) {
-        Wh_Log(
-            L"Created missing %s value and set it to %lu",
-            kValueName,
-            kDesiredValue
-        );
-    } else {
-        Wh_Log(
-            L"Repaired %s and set it to %lu",
-            kValueName,
-            kDesiredValue
-        );
-    }
-
+    path->assign(info->Name, info->NameLength / sizeof(wchar_t));
     return true;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// One-shot tool callbacks
+bool IsTargetQuery(HANDLE key, const UNICODE_STRING* valueName) {
+    constexpr size_t valueNameLength = ARRAYSIZE(kValueName) - 1;
+    if (!valueName || !valueName->Buffer ||
+        valueName->Length != valueNameLength * sizeof(wchar_t) ||
+        _wcsnicmp(valueName->Buffer, kValueName, valueNameLength) != 0) {
+        return false;
+    }
 
-BOOL WhTool_ModInit() {
-    const bool success = EnsureStartupDelayFix();
+    std::wstring path;
+    if (!GetKeyPath(key, &path)) {
+        return false;
+    }
 
-    // This is a one-shot tool. The dedicated process is no longer needed after
-    // the registry value has been checked and repaired.
-    ExitProcess(success ? 0 : 1);
-
-    return FALSE;
+    size_t suffixLength = ARRAYSIZE(kKeyPathSuffix) - 1;
+    return path.length() >= suffixLength &&
+           _wcsnicmp(path.c_str() + path.length() - suffixLength,
+                      kKeyPathSuffix, suffixLength) == 0;
 }
 
-void WhTool_ModSettingsChanged() {
+ULONG AlignUp(ULONG value, ULONG alignment) {
+    return (value + alignment - 1) & ~(alignment - 1);
 }
 
-void WhTool_ModUninit() {
+NTSTATUS FillValueInformation(const UNICODE_STRING* valueName,
+                              KEY_VALUE_INFORMATION_CLASS informationClass,
+                              void* buffer, ULONG bufferLength,
+                              ULONG* resultLength) {
+    ULONG dataOffset;
+    ULONG requiredLength;
+
+    switch (informationClass) {
+        case KeyValueBasicInformation: {
+            ULONG nameOffset = FIELD_OFFSET(KEY_VALUE_BASIC_INFORMATION_LOCAL,
+                                            Name);
+            requiredLength = nameOffset + valueName->Length;
+            if (resultLength) {
+                *resultLength = requiredLength;
+            }
+            if (!buffer || bufferLength < nameOffset) {
+                return STATUS_BUFFER_TOO_SMALL;
+            }
+            auto info = static_cast<KEY_VALUE_BASIC_INFORMATION_LOCAL*>(buffer);
+            info->TitleIndex = 0;
+            info->Type = REG_DWORD;
+            info->NameLength = valueName->Length;
+            ULONG copiedNameLength =
+                min(valueName->Length, bufferLength - nameOffset);
+            std::memcpy(info->Name, valueName->Buffer, copiedNameLength);
+            return bufferLength < requiredLength ? STATUS_BUFFER_OVERFLOW
+                                                 : STATUS_SUCCESS;
+        }
+
+        case KeyValueFullInformation:
+        case KeyValueFullInformationAlign64: {
+            ULONG nameOffset = FIELD_OFFSET(KEY_VALUE_FULL_INFORMATION_LOCAL,
+                                            Name);
+            ULONG alignment = informationClass == KeyValueFullInformationAlign64
+                                  ? 8
+                                  : 4;
+            dataOffset = AlignUp(nameOffset + valueName->Length, alignment);
+            requiredLength = dataOffset + sizeof(DWORD);
+            if (resultLength) {
+                *resultLength = requiredLength;
+            }
+            if (!buffer || bufferLength < nameOffset) {
+                return STATUS_BUFFER_TOO_SMALL;
+            }
+            auto info = static_cast<KEY_VALUE_FULL_INFORMATION_LOCAL*>(buffer);
+            info->TitleIndex = 0;
+            info->Type = REG_DWORD;
+            info->DataOffset = dataOffset;
+            info->DataLength = sizeof(DWORD);
+            info->NameLength = valueName->Length;
+            ULONG copiedNameLength =
+                min(valueName->Length, bufferLength - nameOffset);
+            std::memcpy(info->Name, valueName->Buffer, copiedNameLength);
+            if (bufferLength < requiredLength) {
+                return STATUS_BUFFER_OVERFLOW;
+            }
+            *reinterpret_cast<DWORD*>(static_cast<BYTE*>(buffer) + dataOffset) =
+                0;
+            return STATUS_SUCCESS;
+        }
+
+        case KeyValuePartialInformation:
+        case KeyValuePartialInformationAlign64: {
+            dataOffset = informationClass == KeyValuePartialInformationAlign64
+                             ? 16
+                             : FIELD_OFFSET(KEY_VALUE_PARTIAL_INFORMATION_LOCAL,
+                                            Data);
+            requiredLength = dataOffset + sizeof(DWORD);
+            if (resultLength) {
+                *resultLength = requiredLength;
+            }
+            constexpr ULONG headerLength =
+                FIELD_OFFSET(KEY_VALUE_PARTIAL_INFORMATION_LOCAL, Data);
+            if (!buffer || bufferLength < headerLength) {
+                return STATUS_BUFFER_TOO_SMALL;
+            }
+            auto info =
+                static_cast<KEY_VALUE_PARTIAL_INFORMATION_LOCAL*>(buffer);
+            info->TitleIndex = 0;
+            info->Type = REG_DWORD;
+            info->DataLength = sizeof(DWORD);
+            if (bufferLength < requiredLength) {
+                return STATUS_BUFFER_OVERFLOW;
+            }
+            *reinterpret_cast<DWORD*>(static_cast<BYTE*>(buffer) + dataOffset) =
+                0;
+            return STATUS_SUCCESS;
+        }
+    }
+
+    return STATUS_INVALID_INFO_CLASS;
 }
 
-/*
-Windhawk tool-mod implementation
+NTSTATUS NTAPI NtQueryValueKey_hook(
+    HANDLE keyHandle, PUNICODE_STRING valueName,
+    KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
+    PVOID keyValueInformation, ULONG length, PULONG resultLength) {
+    NTSTATUS status = NtQueryValueKey_orig(
+        keyHandle, valueName, keyValueInformationClass, keyValueInformation,
+        length, resultLength);
 
-https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
+    if (!IsTargetQuery(keyHandle, valueName)) {
+        return status;
+    }
 
-This launches the mod in a separate windhawk.exe process.
-*/
-bool g_isToolModProcessLauncher = false;
-HANDLE g_toolModProcessMutex = nullptr;
-
-void WINAPI EntryPoint_Hook() {
-    ExitThread(0);
+    return FillValueInformation(valueName, keyValueInformationClass,
+                                keyValueInformation, length, resultLength);
 }
 
 BOOL Wh_ModInit() {
-    DWORD sessionId = 0;
-
-    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
-        sessionId == 0) {
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    void* ntQueryValueKey =
+        reinterpret_cast<void*>(GetProcAddress(ntdll, "NtQueryValueKey"));
+    if (!ntQueryValueKey) {
+        Wh_Log(L"Failed to find NtQueryValueKey");
         return FALSE;
     }
 
-    bool isExcluded = false;
-    bool isToolModProcess = false;
-    bool isCurrentToolModProcess = false;
-
-    int argc = 0;
-    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-
-    if (!argv) {
-        Wh_Log(L"CommandLineToArgvW failed");
-        return FALSE;
-    }
-
-    for (int i = 1; i < argc; i++) {
-        if (wcscmp(argv[i], L"-service") == 0 ||
-            wcscmp(argv[i], L"-service-start") == 0 ||
-            wcscmp(argv[i], L"-service-stop") == 0) {
-            isExcluded = true;
-            break;
-        }
-    }
-
-    for (int i = 1; i < argc - 1; i++) {
-        if (wcscmp(argv[i], L"-tool-mod") == 0) {
-            isToolModProcess = true;
-
-            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
-                isCurrentToolModProcess = true;
-            }
-
-            break;
-        }
-    }
-
-    LocalFree(argv);
-
-    if (isExcluded) {
-        return FALSE;
-    }
-
-    if (isCurrentToolModProcess) {
-        g_toolModProcessMutex =
-            CreateMutexW(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
-
-        if (!g_toolModProcessMutex) {
-            Wh_Log(L"CreateMutex failed: error %lu", GetLastError());
-            ExitProcess(1);
-        }
-
-        if (GetLastError() == ERROR_ALREADY_EXISTS) {
-            Wh_Log(L"Tool mod is already running: %s", WH_MOD_ID);
-            ExitProcess(1);
-        }
-
-        if (!WhTool_ModInit()) {
-            ExitProcess(1);
-        }
-
-        IMAGE_DOS_HEADER* dosHeader =
-            reinterpret_cast<IMAGE_DOS_HEADER*>(GetModuleHandleW(nullptr));
-
-        IMAGE_NT_HEADERS* ntHeaders =
-            reinterpret_cast<IMAGE_NT_HEADERS*>(
-                reinterpret_cast<BYTE*>(dosHeader) + dosHeader->e_lfanew
-            );
-
-        DWORD entryPointRVA =
-            ntHeaders->OptionalHeader.AddressOfEntryPoint;
-
-        void* entryPoint =
-            reinterpret_cast<BYTE*>(dosHeader) + entryPointRVA;
-
-        Wh_SetFunctionHook(
-            entryPoint,
-            reinterpret_cast<void*>(EntryPoint_Hook),
-            nullptr
-        );
-
-        return TRUE;
-    }
-
-    if (isToolModProcess) {
-        return FALSE;
-    }
-
-    g_isToolModProcessLauncher = true;
+    Wh_SetFunctionHook(ntQueryValueKey,
+                       reinterpret_cast<void*>(NtQueryValueKey_hook),
+                       reinterpret_cast<void**>(&NtQueryValueKey_orig));
     return TRUE;
-}
-
-void Wh_ModAfterInit() {
-    if (!g_isToolModProcessLauncher) {
-        return;
-    }
-
-    wchar_t currentProcessPath[MAX_PATH];
-
-    DWORD pathLength = GetModuleFileNameW(
-        nullptr,
-        currentProcessPath,
-        ARRAYSIZE(currentProcessPath)
-    );
-
-    if (pathLength == 0 || pathLength == ARRAYSIZE(currentProcessPath)) {
-        Wh_Log(L"GetModuleFileNameW failed: error %lu", GetLastError());
-        return;
-    }
-
-    wchar_t commandLine[MAX_PATH + 2 +
-                        (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") /
-                         sizeof(wchar_t))];
-
-    HRESULT formatResult = StringCchPrintfW(commandLine, ARRAYSIZE(commandLine),
-                                            L"\"%s\" -tool-mod \"%s\"",
-                                            currentProcessPath, WH_MOD_ID);
-
-    if (FAILED(formatResult)) {
-        Wh_Log(L"Failed to construct tool-mod command line: HRESULT 0x%08X",
-               static_cast<unsigned int>(formatResult));
-        return;
-    }
-
-    HMODULE kernelModule = GetModuleHandleW(L"kernelbase.dll");
-
-    if (!kernelModule) {
-        kernelModule = GetModuleHandleW(L"kernel32.dll");
-
-        if (!kernelModule) {
-            Wh_Log(L"Could not find kernelbase.dll or kernel32.dll");
-            return;
-        }
-    }
-
-    using CreateProcessInternalW_t = BOOL(WINAPI*)(
-        HANDLE hUserToken,
-        LPCWSTR lpApplicationName,
-        LPWSTR lpCommandLine,
-        LPSECURITY_ATTRIBUTES lpProcessAttributes,
-        LPSECURITY_ATTRIBUTES lpThreadAttributes,
-        BOOL bInheritHandles,
-        DWORD dwCreationFlags,
-        LPVOID lpEnvironment,
-        LPCWSTR lpCurrentDirectory,
-        LPSTARTUPINFOW lpStartupInfo,
-        LPPROCESS_INFORMATION lpProcessInformation,
-        PHANDLE hRestrictedUserToken
-    );
-
-    auto createProcessInternalW =
-        reinterpret_cast<CreateProcessInternalW_t>(
-            GetProcAddress(kernelModule, "CreateProcessInternalW")
-        );
-
-    if (!createProcessInternalW) {
-        Wh_Log(L"CreateProcessInternalW was not found");
-        return;
-    }
-
-    STARTUPINFOW startupInfo{};
-    startupInfo.cb = sizeof(startupInfo);
-    startupInfo.dwFlags = STARTF_FORCEOFFFEEDBACK;
-
-    PROCESS_INFORMATION processInformation{};
-
-    if (!createProcessInternalW(
-            nullptr,
-            currentProcessPath,
-            commandLine,
-            nullptr,
-            nullptr,
-            FALSE,
-            NORMAL_PRIORITY_CLASS,
-            nullptr,
-            nullptr,
-            &startupInfo,
-            &processInformation,
-            nullptr)) {
-        Wh_Log(L"CreateProcessInternalW failed: error %lu", GetLastError());
-        return;
-    }
-
-    CloseHandle(processInformation.hProcess);
-    CloseHandle(processInformation.hThread);
-}
-
-void Wh_ModSettingsChanged() {
-    if (g_isToolModProcessLauncher) {
-        return;
-    }
-
-    WhTool_ModSettingsChanged();
-}
-
-void Wh_ModUninit() {
-    if (g_isToolModProcessLauncher) {
-        return;
-    }
-
-    WhTool_ModUninit();
-    ExitProcess(0);
 }

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -146,24 +146,19 @@ bool IsSerializeOpen(const OBJECT_ATTRIBUTES* objectAttributes) {
     return IsSerializePath(path);
 }
 
-NTSTATUS DuplicateRedirectKeyHandle(PHANDLE keyHandle,
-                                    ACCESS_MASK desiredAccess) {
+bool DuplicateRedirectKeyHandle(PHANDLE keyHandle, ACCESS_MASK desiredAccess) {
+    ACCESS_MASK access =
+        desiredAccess & ~(static_cast<ACCESS_MASK>(KEY_WOW64_32KEY) |
+                          static_cast<ACCESS_MASK>(KEY_WOW64_64KEY) |
+                          ACCESS_SYSTEM_SECURITY);
+    DWORD options = access & MAXIMUM_ALLOWED ? DUPLICATE_SAME_ACCESS : 0;
+
     HANDLE duplicate = nullptr;
-    DWORD options = desiredAccess & MAXIMUM_ALLOWED ? DUPLICATE_SAME_ACCESS : 0;
     if (!DuplicateHandle(GetCurrentProcess(), g_redirectKey,
-                         GetCurrentProcess(), &duplicate, desiredAccess, FALSE,
+                         GetCurrentProcess(), &duplicate, access, FALSE,
                          options)) {
-        switch (GetLastError()) {
-            case ERROR_ACCESS_DENIED:
-                return STATUS_ACCESS_DENIED;
-            case ERROR_INVALID_HANDLE:
-                return STATUS_INVALID_HANDLE;
-            case ERROR_NOT_ENOUGH_MEMORY:
-            case ERROR_OUTOFMEMORY:
-                return STATUS_NO_MEMORY;
-            default:
-                return STATUS_UNSUCCESSFUL;
-        }
+        Wh_Log(L"DuplicateHandle failed: %u", GetLastError());
+        return false;
     }
 
     *keyHandle = duplicate;
@@ -174,13 +169,14 @@ NTSTATUS DuplicateRedirectKeyHandle(PHANDLE keyHandle,
                L"(access=0x%08X)",
                desiredAccess);
     }
-    return STATUS_SUCCESS;
+    return true;
 }
 
 NTSTATUS NTAPI NtOpenKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
                               POBJECT_ATTRIBUTES objectAttributes) {
-    if (IsSerializeOpen(objectAttributes)) {
-        return DuplicateRedirectKeyHandle(keyHandle, desiredAccess);
+    if (IsSerializeOpen(objectAttributes) &&
+        DuplicateRedirectKeyHandle(keyHandle, desiredAccess)) {
+        return STATUS_SUCCESS;
     }
     return NtOpenKey_orig(keyHandle, desiredAccess, objectAttributes);
 }
@@ -188,8 +184,9 @@ NTSTATUS NTAPI NtOpenKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
 NTSTATUS NTAPI NtOpenKeyEx_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
                                 POBJECT_ATTRIBUTES objectAttributes,
                                 ULONG openOptions) {
-    if (IsSerializeOpen(objectAttributes)) {
-        return DuplicateRedirectKeyHandle(keyHandle, desiredAccess);
+    if (IsSerializeOpen(objectAttributes) &&
+        DuplicateRedirectKeyHandle(keyHandle, desiredAccess)) {
+        return STATUS_SUCCESS;
     }
     return NtOpenKeyEx_orig(keyHandle, desiredAccess, objectAttributes,
                             openOptions);

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -1,0 +1,375 @@
+// ==WindhawkMod==
+// @id              startup-app-delay-fix
+// @name            Startup App Delay Fix
+// @description     Restores WaitforIdleState=0 whenever Windhawk starts
+// @version         1.0
+// @author          meteoni
+// @github          https://github.com/Meteony
+// @include         windhawk.exe
+// @compilerOptions -ladvapi32 -lshell32
+// ==/WindhawkMod==
+// ==WindhawkModReadme==
+/*
+Windows intentionally delays startup applications after sign-in to reduce system load, which can cause many apps to open minutes after system startup. 
+
+![Key](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/startup-app-delay-fix/startup-app-delay-fix.png)
+
+This can be disabled by setting the following registry value:
+
+`HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Serialize
+WaitforIdleState    REG_DWORD    0`
+
+However, some Windows updates reset this value. This mod automates 
+the process of checking and setting that key as a more persistent fix.   
+*/
+// ==/WindhawkModReadme==
+
+#include <windows.h>
+#include <shellapi.h>
+#include <strsafe.h>
+
+// Registry repair logic
+
+constexpr wchar_t kRegistryPath[] =
+    L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Serialize";
+
+constexpr wchar_t kValueName[] = L"WaitforIdleState";
+constexpr DWORD kDesiredValue = 0;
+
+bool EnsureStartupDelayFix() {
+    HKEY key = nullptr;
+    DWORD disposition = 0;
+
+    LSTATUS status = RegCreateKeyExW(
+        HKEY_CURRENT_USER,
+        kRegistryPath,
+        0,
+        nullptr,
+        REG_OPTION_NON_VOLATILE,
+        KEY_QUERY_VALUE | KEY_SET_VALUE | KEY_WOW64_64KEY,
+        nullptr,
+        &key,
+        &disposition
+    );
+
+    if (status != ERROR_SUCCESS) {
+        Wh_Log(
+            L"Failed to open or create HKCU\\%s: error %ld",
+            kRegistryPath,
+            status
+        );
+        return false;
+    }
+
+    DWORD existingValue = 0;
+    DWORD existingType = 0;
+    DWORD existingSize = sizeof(existingValue);
+
+    status = RegQueryValueExW(
+        key,
+        kValueName,
+        nullptr,
+        &existingType,
+        reinterpret_cast<BYTE*>(&existingValue),
+        &existingSize
+    );
+
+    if (status == ERROR_SUCCESS &&
+        existingType == REG_DWORD &&
+        existingSize == sizeof(DWORD) &&
+        existingValue == kDesiredValue) {
+        Wh_Log(
+            L"%s is already correctly set to %lu",
+            kValueName,
+            kDesiredValue
+        );
+
+        RegCloseKey(key);
+        return true;
+    }
+
+    bool valueWasMissing = status == ERROR_FILE_NOT_FOUND;
+
+    status = RegSetValueExW(
+        key,
+        kValueName,
+        0,
+        REG_DWORD,
+        reinterpret_cast<const BYTE*>(&kDesiredValue),
+        sizeof(kDesiredValue)
+    );
+
+    RegCloseKey(key);
+
+    if (status != ERROR_SUCCESS) {
+        Wh_Log(
+            L"Failed to set %s: error %ld",
+            kValueName,
+            status
+        );
+        return false;
+    }
+
+    if (disposition == REG_CREATED_NEW_KEY) {
+        Wh_Log(
+            L"Created Serialize registry key and set %s to %lu",
+            kValueName,
+            kDesiredValue
+        );
+    } else if (valueWasMissing) {
+        Wh_Log(
+            L"Created missing %s value and set it to %lu",
+            kValueName,
+            kDesiredValue
+        );
+    } else {
+        Wh_Log(
+            L"Repaired %s and set it to %lu",
+            kValueName,
+            kDesiredValue
+        );
+    }
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// One-shot tool callbacks
+
+BOOL WhTool_ModInit() {
+    const bool success = EnsureStartupDelayFix();
+
+    // This is a one-shot tool. The dedicated process is no longer needed after
+    // the registry value has been checked and repaired.
+    ExitProcess(success ? 0 : 1);
+
+    return FALSE;
+}
+
+void WhTool_ModSettingsChanged() {
+}
+
+void WhTool_ModUninit() {
+}
+
+/*
+Windhawk tool-mod implementation
+
+https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
+
+This launches the mod in a separate windhawk.exe process.
+*/
+bool g_isToolModProcessLauncher = false;
+HANDLE g_toolModProcessMutex = nullptr;
+
+void WINAPI EntryPoint_Hook() {
+    ExitThread(0);
+}
+
+BOOL Wh_ModInit() {
+    DWORD sessionId = 0;
+
+    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
+        sessionId == 0) {
+        return FALSE;
+    }
+
+    bool isExcluded = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+
+    int argc = 0;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+
+    if (!argv) {
+        Wh_Log(L"CommandLineToArgvW failed");
+        return FALSE;
+    }
+
+    for (int i = 1; i < argc; i++) {
+        if (wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0) {
+            isExcluded = true;
+            break;
+        }
+    }
+
+    for (int i = 1; i < argc - 1; i++) {
+        if (wcscmp(argv[i], L"-tool-mod") == 0) {
+            isToolModProcess = true;
+
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
+                isCurrentToolModProcess = true;
+            }
+
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isExcluded) {
+        return FALSE;
+    }
+
+    if (isCurrentToolModProcess) {
+        g_toolModProcessMutex =
+            CreateMutexW(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
+
+        if (!g_toolModProcessMutex) {
+            Wh_Log(L"CreateMutex failed: error %lu", GetLastError());
+            ExitProcess(1);
+        }
+
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
+            Wh_Log(L"Tool mod is already running: %s", WH_MOD_ID);
+            ExitProcess(1);
+        }
+
+        if (!WhTool_ModInit()) {
+            ExitProcess(1);
+        }
+
+        IMAGE_DOS_HEADER* dosHeader =
+            reinterpret_cast<IMAGE_DOS_HEADER*>(GetModuleHandleW(nullptr));
+
+        IMAGE_NT_HEADERS* ntHeaders =
+            reinterpret_cast<IMAGE_NT_HEADERS*>(
+                reinterpret_cast<BYTE*>(dosHeader) + dosHeader->e_lfanew
+            );
+
+        DWORD entryPointRVA =
+            ntHeaders->OptionalHeader.AddressOfEntryPoint;
+
+        void* entryPoint =
+            reinterpret_cast<BYTE*>(dosHeader) + entryPointRVA;
+
+        Wh_SetFunctionHook(
+            entryPoint,
+            reinterpret_cast<void*>(EntryPoint_Hook),
+            nullptr
+        );
+
+        return TRUE;
+    }
+
+    if (isToolModProcess) {
+        return FALSE;
+    }
+
+    g_isToolModProcessLauncher = true;
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    if (!g_isToolModProcessLauncher) {
+        return;
+    }
+
+    wchar_t currentProcessPath[MAX_PATH];
+
+    DWORD pathLength = GetModuleFileNameW(
+        nullptr,
+        currentProcessPath,
+        ARRAYSIZE(currentProcessPath)
+    );
+
+    if (pathLength == 0 || pathLength == ARRAYSIZE(currentProcessPath)) {
+        Wh_Log(L"GetModuleFileNameW failed: error %lu", GetLastError());
+        return;
+    }
+
+    wchar_t commandLine[MAX_PATH + 2 +
+                        (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") /
+                         sizeof(wchar_t))];
+
+    HRESULT formatResult = StringCchPrintfW(commandLine, ARRAYSIZE(commandLine),
+                                            L"\"%s\" -tool-mod \"%s\"",
+                                            currentProcessPath, WH_MOD_ID);
+
+    if (FAILED(formatResult)) {
+        Wh_Log(L"Failed to construct tool-mod command line: HRESULT 0x%08X",
+               static_cast<unsigned int>(formatResult));
+        return;
+    }
+
+    HMODULE kernelModule = GetModuleHandleW(L"kernelbase.dll");
+
+    if (!kernelModule) {
+        kernelModule = GetModuleHandleW(L"kernel32.dll");
+
+        if (!kernelModule) {
+            Wh_Log(L"Could not find kernelbase.dll or kernel32.dll");
+            return;
+        }
+    }
+
+    using CreateProcessInternalW_t = BOOL(WINAPI*)(
+        HANDLE hUserToken,
+        LPCWSTR lpApplicationName,
+        LPWSTR lpCommandLine,
+        LPSECURITY_ATTRIBUTES lpProcessAttributes,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes,
+        BOOL bInheritHandles,
+        DWORD dwCreationFlags,
+        LPVOID lpEnvironment,
+        LPCWSTR lpCurrentDirectory,
+        LPSTARTUPINFOW lpStartupInfo,
+        LPPROCESS_INFORMATION lpProcessInformation,
+        PHANDLE hRestrictedUserToken
+    );
+
+    auto createProcessInternalW =
+        reinterpret_cast<CreateProcessInternalW_t>(
+            GetProcAddress(kernelModule, "CreateProcessInternalW")
+        );
+
+    if (!createProcessInternalW) {
+        Wh_Log(L"CreateProcessInternalW was not found");
+        return;
+    }
+
+    STARTUPINFOW startupInfo{};
+    startupInfo.cb = sizeof(startupInfo);
+    startupInfo.dwFlags = STARTF_FORCEOFFFEEDBACK;
+
+    PROCESS_INFORMATION processInformation{};
+
+    if (!createProcessInternalW(
+            nullptr,
+            currentProcessPath,
+            commandLine,
+            nullptr,
+            nullptr,
+            FALSE,
+            NORMAL_PRIORITY_CLASS,
+            nullptr,
+            nullptr,
+            &startupInfo,
+            &processInformation,
+            nullptr)) {
+        Wh_Log(L"CreateProcessInternalW failed: error %lu", GetLastError());
+        return;
+    }
+
+    CloseHandle(processInformation.hProcess);
+    CloseHandle(processInformation.hThread);
+}
+
+void Wh_ModSettingsChanged() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModSettingsChanged();
+}
+
+void Wh_ModUninit() {
+    if (g_isToolModProcessLauncher) {
+        return;
+    }
+
+    WhTool_ModUninit();
+    ExitProcess(0);
+}

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -34,6 +34,7 @@ doesn't change delays configured by other systems, such as Task Scheduler.
 #include <ntdef.h>
 #include <ntstatus.h>
 
+#include <atomic>
 #include <cwchar>
 #include <string>
 #include <string_view>
@@ -82,6 +83,7 @@ NtOpenKeyEx_t NtOpenKeyEx_orig;
 
 HKEY g_redirectKey;
 bool g_ownsRedirectKey;
+std::atomic<bool> g_loggedSuccessfulRedirect{false};
 
 bool GetKeyPath(HANDLE key, std::wstring* path) {
     ULONG size = 0;
@@ -165,6 +167,13 @@ NTSTATUS DuplicateRedirectKeyHandle(PHANDLE keyHandle,
     }
 
     *keyHandle = duplicate;
+    bool expected = false;
+    if (g_loggedSuccessfulRedirect.compare_exchange_strong(
+            expected, true, std::memory_order_relaxed)) {
+        Wh_Log(L"Redirected Explorer Serialize open to volatile key "
+               L"(access=0x%08X)",
+               desiredAccess);
+    }
     return STATUS_SUCCESS;
 }
 

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -23,8 +23,8 @@ The redirect key is in-memory only. The mod deletes it on a normal disable,
 and Windows discards it when the user registry hive unloads at sign-out or
 shutdown if Explorer exits unexpectedly.
 
-The settings are read when Explorer starts, so enabling or disabling the mod
-takes effect after the next sign-in or Explorer restart.
+Windows reads the startup-delay values when Explorer starts, so enabling or
+disabling the mod takes effect after the next sign-in or Explorer restart.
 
 This only affects the delay Explorer applies to startup-item processing. It
 doesn't change delays configured by other systems, such as Task Scheduler.

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -19,17 +19,26 @@ values, so disabling the mod restores Windows' normal behavior immediately.
 
 Only `WaitforIdleState` is overridden. The related `StartupDelayInMSec` value
 is left unchanged.
+
+The setting is read when Explorer starts. Enabling or disabling the mod during
+a session takes effect after the next sign-in or Explorer restart.
 */
 // ==/WindhawkModReadme==
 
 #include <ntdef.h>
 #include <ntstatus.h>
+#include <windhawk_utils.h>
 
+#include <algorithm>
 #include <cstring>
 #include <string>
+#include <unordered_set>
 
 constexpr wchar_t kKeyPathSuffix[] =
     L"\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Serialize";
+constexpr wchar_t kExplorerPathSuffix[] =
+    L"\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer";
+constexpr wchar_t kUserHivePrefix[] = L"\\REGISTRY\\USER\\";
 constexpr wchar_t kValueName[] = L"WaitforIdleState";
 
 typedef enum _KEY_INFORMATION_CLASS {
@@ -49,7 +58,6 @@ typedef enum _KEY_VALUE_INFORMATION_CLASS {
     KeyValueFullInformation,
     KeyValuePartialInformation,
     KeyValueFullInformationAlign64,
-    KeyValuePartialInformationAlign64,
 } KEY_VALUE_INFORMATION_CLASS;
 
 struct KEY_VALUE_BASIC_INFORMATION_LOCAL {
@@ -85,6 +93,30 @@ using NtQueryValueKey_t = NTSTATUS(NTAPI*)(
     PVOID keyValueInformation, ULONG length, PULONG resultLength);
 NtQueryValueKey_t NtQueryValueKey_orig;
 
+using NtOpenKey_t = NTSTATUS(NTAPI*)(PHANDLE keyHandle,
+                                     ACCESS_MASK desiredAccess,
+                                     POBJECT_ATTRIBUTES objectAttributes);
+NtOpenKey_t NtOpenKey_orig;
+
+using NtOpenKeyEx_t = NTSTATUS(NTAPI*)(PHANDLE keyHandle,
+                                       ACCESS_MASK desiredAccess,
+                                       POBJECT_ATTRIBUTES objectAttributes,
+                                       ULONG openOptions);
+NtOpenKeyEx_t NtOpenKeyEx_orig;
+
+using NtClose_t = NTSTATUS(NTAPI*)(HANDLE handle);
+NtClose_t NtClose_orig;
+
+SRWLOCK g_virtualKeyHandlesLock = SRWLOCK_INIT;
+std::unordered_set<HANDLE> g_virtualKeyHandles;
+
+bool IsVirtualKey(HANDLE key) {
+    AcquireSRWLockShared(&g_virtualKeyHandlesLock);
+    bool found = g_virtualKeyHandles.find(key) != g_virtualKeyHandles.end();
+    ReleaseSRWLockShared(&g_virtualKeyHandlesLock);
+    return found;
+}
+
 bool GetKeyPath(HANDLE key, std::wstring* path) {
     ULONG size = 0;
     NTSTATUS status = NtQueryKey(key, KeyNameInformation, nullptr, 0, &size);
@@ -112,15 +144,143 @@ bool IsTargetQuery(HANDLE key, const UNICODE_STRING* valueName) {
         return false;
     }
 
+    if (IsVirtualKey(key)) {
+        return true;
+    }
+
     std::wstring path;
     if (!GetKeyPath(key, &path)) {
         return false;
     }
-
     size_t suffixLength = ARRAYSIZE(kKeyPathSuffix) - 1;
-    return path.length() >= suffixLength &&
+    constexpr size_t userHivePrefixLength = ARRAYSIZE(kUserHivePrefix) - 1;
+    return path.length() >= userHivePrefixLength + suffixLength &&
+           _wcsnicmp(path.c_str(), kUserHivePrefix, userHivePrefixLength) == 0 &&
            _wcsnicmp(path.c_str() + path.length() - suffixLength,
                       kKeyPathSuffix, suffixLength) == 0;
+}
+
+bool IsTargetOpen(const OBJECT_ATTRIBUTES* objectAttributes) {
+    if (!objectAttributes || !objectAttributes->ObjectName ||
+        !objectAttributes->ObjectName->Buffer) {
+        return false;
+    }
+
+    const UNICODE_STRING* objectName = objectAttributes->ObjectName;
+    std::wstring path(objectName->Buffer,
+                      objectName->Length / sizeof(wchar_t));
+    if (objectAttributes->RootDirectory &&
+        (path.empty() || path.front() != L'\\')) {
+        std::wstring rootPath;
+        if (!GetKeyPath(objectAttributes->RootDirectory, &rootPath)) {
+            return false;
+        }
+        if (!path.empty()) {
+            rootPath += L'\\';
+            rootPath += path;
+        }
+        path = rootPath;
+    }
+
+    constexpr size_t userHivePrefixLength = ARRAYSIZE(kUserHivePrefix) - 1;
+    constexpr size_t suffixLength = ARRAYSIZE(kKeyPathSuffix) - 1;
+    return path.length() >= userHivePrefixLength + suffixLength &&
+           _wcsnicmp(path.c_str(), kUserHivePrefix, userHivePrefixLength) == 0 &&
+           _wcsnicmp(path.c_str() + path.length() - suffixLength,
+                      kKeyPathSuffix, suffixLength) == 0;
+}
+
+void RememberVirtualKey(HANDLE key) {
+    AcquireSRWLockExclusive(&g_virtualKeyHandlesLock);
+    g_virtualKeyHandles.insert(key);
+    ReleaseSRWLockExclusive(&g_virtualKeyHandlesLock);
+}
+
+NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
+                                POBJECT_ATTRIBUTES objectAttributes,
+                                ULONG openOptions, bool useNtOpenKeyEx) {
+    const UNICODE_STRING* objectName = objectAttributes->ObjectName;
+    std::wstring parentName(objectName->Buffer,
+                            objectName->Length / sizeof(wchar_t));
+    constexpr wchar_t serializeComponent[] = L"\\Serialize";
+    constexpr size_t serializeComponentLength =
+        ARRAYSIZE(serializeComponent) - 1;
+
+    if (parentName.length() >= serializeComponentLength &&
+        _wcsicmp(parentName.c_str() + parentName.length() -
+                     serializeComponentLength,
+                 serializeComponent) == 0) {
+        parentName.resize(parentName.length() - serializeComponentLength);
+    } else if (objectAttributes->RootDirectory &&
+               _wcsicmp(parentName.c_str(), L"Serialize") == 0) {
+        HANDLE duplicate = nullptr;
+        DWORD options = desiredAccess & MAXIMUM_ALLOWED ? DUPLICATE_SAME_ACCESS
+                                                       : 0;
+        if (!DuplicateHandle(GetCurrentProcess(), objectAttributes->RootDirectory,
+                             GetCurrentProcess(), &duplicate, desiredAccess,
+                             FALSE, options)) {
+            return STATUS_UNSUCCESSFUL;
+        }
+        *keyHandle = duplicate;
+        RememberVirtualKey(duplicate);
+        return STATUS_SUCCESS;
+    } else {
+        return STATUS_OBJECT_NAME_NOT_FOUND;
+    }
+
+    UNICODE_STRING parentObjectName{
+        .Length = static_cast<USHORT>(parentName.length() * sizeof(wchar_t)),
+        .MaximumLength =
+            static_cast<USHORT>(parentName.length() * sizeof(wchar_t)),
+        .Buffer = parentName.data(),
+    };
+    OBJECT_ATTRIBUTES parentAttributes = *objectAttributes;
+    parentAttributes.ObjectName = &parentObjectName;
+
+    NTSTATUS status = useNtOpenKeyEx
+                          ? NtOpenKeyEx_orig(keyHandle, desiredAccess,
+                                             &parentAttributes, openOptions)
+                          : NtOpenKey_orig(keyHandle, desiredAccess,
+                                           &parentAttributes);
+    if (status == STATUS_SUCCESS) {
+        RememberVirtualKey(*keyHandle);
+    }
+    return status;
+}
+
+bool IsMissingStatus(NTSTATUS status) {
+    return status == STATUS_OBJECT_NAME_NOT_FOUND ||
+           status == STATUS_OBJECT_PATH_NOT_FOUND;
+}
+
+NTSTATUS NTAPI NtOpenKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
+                              POBJECT_ATTRIBUTES objectAttributes) {
+    NTSTATUS status =
+        NtOpenKey_orig(keyHandle, desiredAccess, objectAttributes);
+    if (IsMissingStatus(status) && IsTargetOpen(objectAttributes)) {
+        return OpenParentAsVirtualKey(keyHandle, desiredAccess, objectAttributes,
+                                      0, false);
+    }
+    return status;
+}
+
+NTSTATUS NTAPI NtOpenKeyEx_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
+                                POBJECT_ATTRIBUTES objectAttributes,
+                                ULONG openOptions) {
+    NTSTATUS status = NtOpenKeyEx_orig(keyHandle, desiredAccess,
+                                       objectAttributes, openOptions);
+    if (IsMissingStatus(status) && IsTargetOpen(objectAttributes)) {
+        return OpenParentAsVirtualKey(keyHandle, desiredAccess, objectAttributes,
+                                      openOptions, true);
+    }
+    return status;
+}
+
+NTSTATUS NTAPI NtClose_hook(HANDLE handle) {
+    AcquireSRWLockExclusive(&g_virtualKeyHandlesLock);
+    g_virtualKeyHandles.erase(handle);
+    ReleaseSRWLockExclusive(&g_virtualKeyHandlesLock);
+    return NtClose_orig(handle);
 }
 
 ULONG AlignUp(ULONG value, ULONG alignment) {
@@ -150,7 +310,7 @@ NTSTATUS FillValueInformation(const UNICODE_STRING* valueName,
             info->Type = REG_DWORD;
             info->NameLength = valueName->Length;
             ULONG copiedNameLength =
-                min(valueName->Length, bufferLength - nameOffset);
+                std::min<ULONG>(valueName->Length, bufferLength - nameOffset);
             std::memcpy(info->Name, valueName->Buffer, copiedNameLength);
             return bufferLength < requiredLength ? STATUS_BUFFER_OVERFLOW
                                                  : STATUS_SUCCESS;
@@ -178,7 +338,7 @@ NTSTATUS FillValueInformation(const UNICODE_STRING* valueName,
             info->DataLength = sizeof(DWORD);
             info->NameLength = valueName->Length;
             ULONG copiedNameLength =
-                min(valueName->Length, bufferLength - nameOffset);
+                std::min<ULONG>(valueName->Length, bufferLength - nameOffset);
             std::memcpy(info->Name, valueName->Buffer, copiedNameLength);
             if (bufferLength < requiredLength) {
                 return STATUS_BUFFER_OVERFLOW;
@@ -188,12 +348,9 @@ NTSTATUS FillValueInformation(const UNICODE_STRING* valueName,
             return STATUS_SUCCESS;
         }
 
-        case KeyValuePartialInformation:
-        case KeyValuePartialInformationAlign64: {
-            dataOffset = informationClass == KeyValuePartialInformationAlign64
-                             ? 16
-                             : FIELD_OFFSET(KEY_VALUE_PARTIAL_INFORMATION_LOCAL,
-                                            Data);
+        case KeyValuePartialInformation: {
+            dataOffset = FIELD_OFFSET(KEY_VALUE_PARTIAL_INFORMATION_LOCAL,
+                                      Data);
             requiredLength = dataOffset + sizeof(DWORD);
             if (resultLength) {
                 *resultLength = requiredLength;
@@ -228,25 +385,59 @@ NTSTATUS NTAPI NtQueryValueKey_hook(
         keyHandle, valueName, keyValueInformationClass, keyValueInformation,
         length, resultLength);
 
+    if (IsVirtualKey(keyHandle) && !IsTargetQuery(keyHandle, valueName)) {
+        return STATUS_OBJECT_NAME_NOT_FOUND;
+    }
+
     if (!IsTargetQuery(keyHandle, valueName)) {
         return status;
     }
 
-    return FillValueInformation(valueName, keyValueInformationClass,
-                                keyValueInformation, length, resultLength);
+    if (status != STATUS_SUCCESS && status != STATUS_OBJECT_NAME_NOT_FOUND &&
+        status != STATUS_OBJECT_PATH_NOT_FOUND &&
+        status != STATUS_BUFFER_TOO_SMALL &&
+        status != STATUS_BUFFER_OVERFLOW) {
+        return status;
+    }
+
+    switch (keyValueInformationClass) {
+        case KeyValueBasicInformation:
+        case KeyValueFullInformation:
+        case KeyValuePartialInformation:
+        case KeyValueFullInformationAlign64:
+            break;
+        default:
+            return status;
+    }
+
+    status = FillValueInformation(valueName, keyValueInformationClass,
+                                  keyValueInformation, length, resultLength);
+    if (status == STATUS_SUCCESS) {
+        Wh_Log(L"Reporting WaitforIdleState=0");
+    }
+    return status;
 }
 
 BOOL Wh_ModInit() {
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    void* ntQueryValueKey =
-        reinterpret_cast<void*>(GetProcAddress(ntdll, "NtQueryValueKey"));
-    if (!ntQueryValueKey) {
-        Wh_Log(L"Failed to find NtQueryValueKey");
+    auto ntQueryValueKey = reinterpret_cast<NtQueryValueKey_t>(
+        GetProcAddress(ntdll, "NtQueryValueKey"));
+    auto ntOpenKey = reinterpret_cast<NtOpenKey_t>(
+        GetProcAddress(ntdll, "NtOpenKey"));
+    auto ntOpenKeyEx = reinterpret_cast<NtOpenKeyEx_t>(
+        GetProcAddress(ntdll, "NtOpenKeyEx"));
+    auto ntClose =
+        reinterpret_cast<NtClose_t>(GetProcAddress(ntdll, "NtClose"));
+    if (!ntQueryValueKey || !ntOpenKey || !ntOpenKeyEx || !ntClose) {
+        Wh_Log(L"Failed to find required ntdll registry functions");
         return FALSE;
     }
 
-    Wh_SetFunctionHook(ntQueryValueKey,
-                       reinterpret_cast<void*>(NtQueryValueKey_hook),
-                       reinterpret_cast<void**>(&NtQueryValueKey_orig));
+    WindhawkUtils::SetFunctionHook(ntQueryValueKey, NtQueryValueKey_hook,
+                                   &NtQueryValueKey_orig);
+    WindhawkUtils::SetFunctionHook(ntOpenKey, NtOpenKey_hook, &NtOpenKey_orig);
+    WindhawkUtils::SetFunctionHook(ntOpenKeyEx, NtOpenKeyEx_hook,
+                                   &NtOpenKeyEx_orig);
+    WindhawkUtils::SetFunctionHook(ntClose, NtClose_hook, &NtClose_orig);
     return TRUE;
 }

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -13,6 +13,8 @@
 Windows intentionally delays startup applications after sign-in to reduce
 system load, which can cause apps to open minutes after startup.
 
+![Key](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/startup-app-delay-fix/startup-app-delay-fix.png)
+
 This mod redirects Explorer's startup-serialization key to a dedicated,
 volatile key where both `WaitforIdleState` and `StartupDelayInMSec` are zero.
 It never creates, modifies, or deletes the user's real `Serialize` key.

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -6,7 +6,7 @@
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
-// @compilerOptions -lntdll -lshell32
+// @compilerOptions -lntdll
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
@@ -27,8 +27,6 @@ a session takes effect after the next sign-in or Explorer restart.
 
 #include <ntdef.h>
 #include <ntstatus.h>
-#include <shlobj.h>
-#include <strsafe.h>
 #include <windhawk_utils.h>
 
 #include <algorithm>
@@ -111,46 +109,6 @@ NtClose_t NtClose_orig;
 
 SRWLOCK g_virtualKeyHandlesLock = SRWLOCK_INIT;
 std::unordered_set<HANDLE> g_virtualKeyHandles;
-wchar_t g_debugLogPath[MAX_PATH];
-
-// Temporary diagnostics. Revert the dedicated debug commit before submission.
-void InitializeDebugLog() {
-    if (FAILED(SHGetFolderPathW(nullptr, CSIDL_DESKTOPDIRECTORY, nullptr,
-                                SHGFP_TYPE_CURRENT, g_debugLogPath)) ||
-        FAILED(StringCchCatW(g_debugLogPath, ARRAYSIZE(g_debugLogPath),
-                             L"\\startup-app-delay-fix-hook.log"))) {
-        g_debugLogPath[0] = L'\0';
-    }
-}
-
-void LogDebugEvent(const char* eventName, NTSTATUS status = STATUS_SUCCESS,
-                   LONG detail = 0) {
-    if (!g_debugLogPath[0]) {
-        return;
-    }
-
-    HANDLE file = CreateFileW(g_debugLogPath, FILE_APPEND_DATA,
-                              FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
-                              OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (file == INVALID_HANDLE_VALUE) {
-        return;
-    }
-
-    SYSTEMTIME time;
-    GetLocalTime(&time);
-    char line[192];
-    int length = sprintf_s(
-        line, sizeof(line),
-        "%04u-%02u-%02u %02u:%02u:%02u.%03u  %s  status=0x%08lX detail=%ld\r\n",
-        time.wYear, time.wMonth, time.wDay, time.wHour, time.wMinute,
-        time.wSecond, time.wMilliseconds, eventName,
-        static_cast<unsigned long>(status), detail);
-    if (length > 0) {
-        DWORD written;
-        WriteFile(file, line, static_cast<DWORD>(length), &written, nullptr);
-    }
-    CloseHandle(file);
-}
 
 bool IsVirtualKey(HANDLE key) {
     AcquireSRWLockShared(&g_virtualKeyHandlesLock);
@@ -265,8 +223,6 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
         }
         *keyHandle = duplicate;
         RememberVirtualKey(duplicate);
-        LogDebugEvent("Substituted missing Serialize key", STATUS_SUCCESS,
-                      useNtOpenKeyEx);
         return STATUS_SUCCESS;
     } else {
         return STATUS_OBJECT_NAME_NOT_FOUND;
@@ -288,8 +244,6 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
                                            &parentAttributes);
     if (status == STATUS_SUCCESS) {
         RememberVirtualKey(*keyHandle);
-        LogDebugEvent("Substituted missing Serialize key", status,
-                      useNtOpenKeyEx);
     }
     return status;
 }
@@ -460,15 +414,11 @@ NTSTATUS NTAPI NtQueryValueKey_hook(
                                   keyValueInformation, length, resultLength);
     if (status == STATUS_SUCCESS) {
         Wh_Log(L"Reporting WaitforIdleState=0");
-        LogDebugEvent("Reported WaitforIdleState=0", status,
-                      keyValueInformationClass);
     }
     return status;
 }
 
 BOOL Wh_ModInit() {
-    InitializeDebugLog();
-    LogDebugEvent("Wh_ModInit");
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
     auto ntQueryValueKey = reinterpret_cast<NtQueryValueKey_t>(
         GetProcAddress(ntdll, "NtQueryValueKey"));

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -13,7 +13,8 @@
 Windows intentionally delays startup applications after sign-in to reduce
 system load, which can cause apps to open minutes after startup.
 
-![Key](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/startup-app-delay-fix/startup-app-delay-fix.png)
+Common fix (which the mod intends to emulate): 
+![Common Fix](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/startup-app-delay-fix/startup-app-delay-fix.png)
 
 This mod redirects Explorer's startup-serialization key to a dedicated,
 volatile key where both `WaitforIdleState` and `StartupDelayInMSec` are zero.

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -278,7 +278,7 @@ bool InitializeRedirectKey() {
         }
     }
 
-    g_ownsRedirectKey = true;
+    g_ownsRedirectKey = created;
     Wh_Log(L"Initialized volatile Serialize redirect key");
     return true;
 }

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -2,11 +2,11 @@
 // @id              startup-app-delay-fix
 // @name            Startup App Delay Fix
 // @description     Removes the delay Windows applies to startup applications after sign-in
-// @version         1.2
+// @version         1.3
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
-// @compilerOptions -lntdll
+// @compilerOptions -ladvapi32 -lntdll
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
@@ -17,7 +17,11 @@ This mod makes Explorer see both `WaitforIdleState` and `StartupDelayInMSec` as
 zero when it reads the startup-item serialization settings. It leaves no
 persistent registry changes behind.
 
-The setting is read when Explorer starts, so enabling or disabling the mod
+If the `Serialize` key is missing, the mod creates it as a volatile, in-memory
+key. The creating instance deletes it on a normal disable; otherwise it is
+discarded when the user registry hive unloads at sign-out or shutdown.
+
+The settings are read when Explorer starts, so enabling or disabling the mod
 takes effect after the next sign-in or Explorer restart.
 */
 // ==/WindhawkModReadme==
@@ -27,12 +31,13 @@ takes effect after the next sign-in or Explorer restart.
 #include <windhawk_utils.h>
 
 #include <algorithm>
-#include <atomic>
 #include <cstring>
 #include <string>
 #include <string_view>
 #include <vector>
 
+constexpr wchar_t kRegistryPath[] =
+    L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Serialize";
 constexpr wchar_t kKeyPathSuffix[] =
     L"\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Serialize";
 constexpr wchar_t kUserHivePrefix[] = L"\\REGISTRY\\USER\\";
@@ -93,48 +98,7 @@ using NtQueryValueKey_t = NTSTATUS(NTAPI*)(
     PVOID keyValueInformation, ULONG length, PULONG resultLength);
 NtQueryValueKey_t NtQueryValueKey_orig;
 
-using NtEnumerateValueKey_t = NTSTATUS(NTAPI*)(
-    HANDLE keyHandle, ULONG index,
-    KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
-    PVOID keyValueInformation, ULONG length, PULONG resultLength);
-NtEnumerateValueKey_t NtEnumerateValueKey_orig;
-
-using NtOpenKey_t = NTSTATUS(NTAPI*)(PHANDLE keyHandle,
-                                     ACCESS_MASK desiredAccess,
-                                     POBJECT_ATTRIBUTES objectAttributes);
-NtOpenKey_t NtOpenKey_orig;
-
-using NtOpenKeyEx_t = NTSTATUS(NTAPI*)(PHANDLE keyHandle,
-                                       ACCESS_MASK desiredAccess,
-                                       POBJECT_ATTRIBUTES objectAttributes,
-                                       ULONG openOptions);
-NtOpenKeyEx_t NtOpenKeyEx_orig;
-
-using NtCreateKey_t = NTSTATUS(NTAPI*)(
-    PHANDLE keyHandle, ACCESS_MASK desiredAccess,
-    POBJECT_ATTRIBUTES objectAttributes, ULONG titleIndex,
-    PUNICODE_STRING klass, ULONG createOptions, PULONG disposition);
-NtCreateKey_t NtCreateKey_orig;
-
-using NtClose_t = NTSTATUS(NTAPI*)(HANDLE handle);
-NtClose_t NtClose_orig;
-
-constexpr size_t kVirtualKeyCapacity = 16;
-std::atomic<HANDLE> g_virtualKeyHandles[kVirtualKeyCapacity]{};
-std::atomic<size_t> g_virtualKeyHandleCount{0};
-
-bool IsVirtualKey(HANDLE key) {
-    if (!key ||
-        g_virtualKeyHandleCount.load(std::memory_order_relaxed) == 0) {
-        return false;
-    }
-    for (auto& slot : g_virtualKeyHandles) {
-        if (slot.load(std::memory_order_relaxed) == key) {
-            return true;
-        }
-    }
-    return false;
-}
+HKEY g_createdSerializeKey;
 
 bool GetKeyPath(HANDLE key, std::wstring* path) {
     ULONG size = 0;
@@ -179,215 +143,13 @@ bool IsSerializePath(std::wstring_view path) {
                       kKeyPathSuffix, suffixLength) == 0;
 }
 
-bool IsSerializeKey(HANDLE key) {
-    if (IsVirtualKey(key)) {
-        return true;
-    }
-
-    std::wstring path;
-    return GetKeyPath(key, &path) && IsSerializePath(path);
-}
-
 bool IsTargetQuery(HANDLE key, const UNICODE_STRING* valueName) {
     if (!IsTargetValueName(valueName)) {
         return false;
     }
 
-    return IsSerializeKey(key);
-}
-
-bool IsTargetOpen(const OBJECT_ATTRIBUTES* objectAttributes) {
-    if (!objectAttributes || !objectAttributes->ObjectName ||
-        !objectAttributes->ObjectName->Buffer) {
-        return false;
-    }
-
-    const UNICODE_STRING* objectName = objectAttributes->ObjectName;
-    std::wstring_view name(objectName->Buffer,
-                           objectName->Length / sizeof(wchar_t));
-    constexpr std::wstring_view serializeName = L"Serialize";
-    if (name.length() < serializeName.length() ||
-        _wcsnicmp(name.data() + name.length() - serializeName.length(),
-                   serializeName.data(), serializeName.length()) != 0) {
-        return false;
-    }
-
-    std::wstring path(objectName->Buffer,
-                      objectName->Length / sizeof(wchar_t));
-    if (objectAttributes->RootDirectory &&
-        (path.empty() || path.front() != L'\\')) {
-        std::wstring rootPath;
-        if (!GetKeyPath(objectAttributes->RootDirectory, &rootPath)) {
-            return false;
-        }
-        if (!path.empty()) {
-            rootPath += L'\\';
-            rootPath += path;
-        }
-        path = rootPath;
-    }
-
-    return IsSerializePath(path);
-}
-
-bool RememberVirtualKey(HANDLE key) {
-    for (auto& slot : g_virtualKeyHandles) {
-        HANDLE expected = nullptr;
-        if (slot.compare_exchange_strong(expected, key,
-                                         std::memory_order_relaxed)) {
-            g_virtualKeyHandleCount.fetch_add(1, std::memory_order_relaxed);
-            return true;
-        }
-    }
-    return false;
-}
-
-void ForgetVirtualKey(HANDLE key) {
-    for (auto& slot : g_virtualKeyHandles) {
-        HANDLE expected = key;
-        if (slot.compare_exchange_strong(expected, nullptr,
-                                         std::memory_order_relaxed)) {
-            g_virtualKeyHandleCount.fetch_sub(1, std::memory_order_relaxed);
-            return;
-        }
-    }
-}
-
-// A tracked handle is only a read-only backing handle for value queries. It
-// must never be used as a real registry key for child opens or other namespace
-// operations, because it actually refers to the parent Explorer key. NtQueryKey
-// isn't spoofed, so metadata and KeyNameInformation still describe the parent.
-NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle,
-                                POBJECT_ATTRIBUTES objectAttributes,
-                                ULONG openOptions, bool useNtOpenKeyEx,
-                                NTSTATUS originalStatus) {
-    const UNICODE_STRING* objectName = objectAttributes->ObjectName;
-    std::wstring parentName(objectName->Buffer,
-                            objectName->Length / sizeof(wchar_t));
-    constexpr wchar_t serializeComponent[] = L"\\Serialize";
-    constexpr size_t serializeComponentLength =
-        ARRAYSIZE(serializeComponent) - 1;
-
-    if (parentName.length() >= serializeComponentLength &&
-        _wcsicmp(parentName.c_str() + parentName.length() -
-                     serializeComponentLength,
-                 serializeComponent) == 0) {
-        parentName.resize(parentName.length() - serializeComponentLength);
-    } else if (objectAttributes->RootDirectory &&
-               _wcsicmp(parentName.c_str(), L"Serialize") == 0) {
-        HANDLE duplicate = nullptr;
-        if (!DuplicateHandle(GetCurrentProcess(), objectAttributes->RootDirectory,
-                             GetCurrentProcess(), &duplicate, KEY_QUERY_VALUE,
-                             FALSE, 0)) {
-            return originalStatus;
-        }
-        *keyHandle = duplicate;
-        if (!RememberVirtualKey(duplicate)) {
-            NtClose_orig(duplicate);
-            *keyHandle = nullptr;
-            return originalStatus;
-        }
-        return STATUS_SUCCESS;
-    } else {
-        return originalStatus;
-    }
-
-    UNICODE_STRING parentObjectName{
-        .Length = static_cast<USHORT>(parentName.length() * sizeof(wchar_t)),
-        .MaximumLength =
-            static_cast<USHORT>(parentName.length() * sizeof(wchar_t)),
-        .Buffer = parentName.data(),
-    };
-    OBJECT_ATTRIBUTES parentAttributes = *objectAttributes;
-    parentAttributes.Length = sizeof(parentAttributes);
-    parentAttributes.ObjectName = &parentObjectName;
-
-    NTSTATUS status = useNtOpenKeyEx
-                          ? NtOpenKeyEx_orig(keyHandle, KEY_QUERY_VALUE,
-                                             &parentAttributes, openOptions)
-                          : NtOpenKey_orig(keyHandle, KEY_QUERY_VALUE,
-                                           &parentAttributes);
-    if (status == STATUS_SUCCESS) {
-        if (!RememberVirtualKey(*keyHandle)) {
-            NtClose_orig(*keyHandle);
-            *keyHandle = nullptr;
-            return originalStatus;
-        }
-    }
-    return status;
-}
-
-bool IsMissingStatus(NTSTATUS status) {
-    return status == STATUS_OBJECT_NAME_NOT_FOUND ||
-           status == STATUS_OBJECT_PATH_NOT_FOUND;
-}
-
-constexpr ACCESS_MASK kNonReadAccess =
-    KEY_SET_VALUE | KEY_CREATE_SUB_KEY | KEY_CREATE_LINK | DELETE | WRITE_DAC |
-    WRITE_OWNER | GENERIC_WRITE | GENERIC_ALL | MAXIMUM_ALLOWED;
-
-NTSTATUS NTAPI NtOpenKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
-                              POBJECT_ATTRIBUTES objectAttributes) {
-    if (objectAttributes && objectAttributes->RootDirectory &&
-        IsVirtualKey(objectAttributes->RootDirectory)) {
-        return STATUS_OBJECT_NAME_NOT_FOUND;
-    }
-
-    NTSTATUS status =
-        NtOpenKey_orig(keyHandle, desiredAccess, objectAttributes);
-    if (IsMissingStatus(status) && !(desiredAccess & kNonReadAccess) &&
-        IsTargetOpen(objectAttributes)) {
-        NTSTATUS virtualStatus = OpenParentAsVirtualKey(
-            keyHandle, objectAttributes, 0, false, status);
-        if (virtualStatus == STATUS_SUCCESS) {
-            Wh_Log(L"Substituting missing Serialize key (access=0x%08X)",
-                   desiredAccess);
-        }
-        return virtualStatus;
-    }
-    return status;
-}
-
-NTSTATUS NTAPI NtOpenKeyEx_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
-                                POBJECT_ATTRIBUTES objectAttributes,
-                                ULONG openOptions) {
-    if (objectAttributes && objectAttributes->RootDirectory &&
-        IsVirtualKey(objectAttributes->RootDirectory)) {
-        return STATUS_OBJECT_NAME_NOT_FOUND;
-    }
-
-    NTSTATUS status = NtOpenKeyEx_orig(keyHandle, desiredAccess,
-                                       objectAttributes, openOptions);
-    if (IsMissingStatus(status) && !(desiredAccess & kNonReadAccess) &&
-        IsTargetOpen(objectAttributes)) {
-        NTSTATUS virtualStatus = OpenParentAsVirtualKey(
-            keyHandle, objectAttributes, openOptions, true, status);
-        if (virtualStatus == STATUS_SUCCESS) {
-            Wh_Log(L"Substituting missing Serialize key (access=0x%08X)",
-                   desiredAccess);
-        }
-        return virtualStatus;
-    }
-    return status;
-}
-
-NTSTATUS NTAPI NtCreateKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
-                                POBJECT_ATTRIBUTES objectAttributes,
-                                ULONG titleIndex, PUNICODE_STRING klass,
-                                ULONG createOptions, PULONG disposition) {
-    if (objectAttributes && objectAttributes->RootDirectory &&
-        IsVirtualKey(objectAttributes->RootDirectory)) {
-        return STATUS_ACCESS_DENIED;
-    }
-    return NtCreateKey_orig(keyHandle, desiredAccess, objectAttributes,
-                            titleIndex, klass, createOptions, disposition);
-}
-
-NTSTATUS NTAPI NtClose_hook(HANDLE handle) {
-    if (g_virtualKeyHandleCount.load(std::memory_order_relaxed) != 0) {
-        ForgetVirtualKey(handle);
-    }
-    return NtClose_orig(handle);
+    std::wstring path;
+    return GetKeyPath(key, &path) && IsSerializePath(path);
 }
 
 ULONG AlignUp(ULONG value, ULONG alignment) {
@@ -485,35 +247,15 @@ NTSTATUS FillValueInformation(const UNICODE_STRING* valueName,
     return unsupportedStatus;
 }
 
-UNICODE_STRING GetTargetValueName(size_t targetIndex) {
-    const wchar_t* targetName = kValueNames[targetIndex];
-    size_t targetLength = wcslen(targetName);
-    return {
-        .Length = static_cast<USHORT>(targetLength * sizeof(wchar_t)),
-        .MaximumLength =
-            static_cast<USHORT>((targetLength + 1) * sizeof(wchar_t)),
-        .Buffer = const_cast<PWSTR>(targetName),
-    };
-}
-
 NTSTATUS NTAPI NtQueryValueKey_hook(
     HANDLE keyHandle, PUNICODE_STRING valueName,
     KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
     PVOID keyValueInformation, ULONG length, PULONG resultLength) {
-    bool virtualKey = IsVirtualKey(keyHandle);
-    NTSTATUS status;
-    if (virtualKey) {
-        if (!IsTargetValueName(valueName)) {
-            return STATUS_OBJECT_NAME_NOT_FOUND;
-        }
-        status = STATUS_OBJECT_NAME_NOT_FOUND;
-    } else {
-        status = NtQueryValueKey_orig(
-            keyHandle, valueName, keyValueInformationClass,
-            keyValueInformation, length, resultLength);
-        if (!IsTargetQuery(keyHandle, valueName)) {
-            return status;
-        }
+    NTSTATUS status = NtQueryValueKey_orig(
+        keyHandle, valueName, keyValueInformationClass, keyValueInformation,
+        length, resultLength);
+    if (!IsTargetQuery(keyHandle, valueName)) {
+        return status;
     }
 
     if (status != STATUS_SUCCESS && status != STATUS_OBJECT_NAME_NOT_FOUND &&
@@ -534,54 +276,50 @@ NTSTATUS NTAPI NtQueryValueKey_hook(
     return status;
 }
 
-NTSTATUS NTAPI NtEnumerateValueKey_hook(
-    HANDLE keyHandle, ULONG index,
-    KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
-    PVOID keyValueInformation, ULONG length, PULONG resultLength) {
-    if (IsVirtualKey(keyHandle)) {
-        if (index >= ARRAYSIZE(kValueNames)) {
-            return STATUS_NO_MORE_ENTRIES;
-        }
-        UNICODE_STRING valueName = GetTargetValueName(index);
-        return FillValueInformation(&valueName, keyValueInformationClass,
-                                    keyValueInformation, length, resultLength,
-                                    STATUS_INVALID_INFO_CLASS);
-    }
-    return NtEnumerateValueKey_orig(keyHandle, index,
-                                    keyValueInformationClass,
-                                    keyValueInformation, length, resultLength);
-}
-
 BOOL Wh_ModInit() {
+    DWORD disposition;
+    HKEY serializeKey;
+    LSTATUS createStatus = RegCreateKeyExW(
+        HKEY_CURRENT_USER, kRegistryPath, 0, nullptr, REG_OPTION_VOLATILE,
+        KEY_READ, nullptr, &serializeKey, &disposition);
+    if (createStatus != ERROR_SUCCESS) {
+        Wh_Log(L"Failed to open or create volatile Serialize key: %ld",
+               createStatus);
+        return FALSE;
+    } else if (disposition == REG_CREATED_NEW_KEY) {
+        g_createdSerializeKey = serializeKey;
+        Wh_Log(L"Created volatile Serialize key");
+    } else {
+        RegCloseKey(serializeKey);
+    }
+
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
     auto ntQueryValueKey = reinterpret_cast<NtQueryValueKey_t>(
         GetProcAddress(ntdll, "NtQueryValueKey"));
-    auto ntOpenKey = reinterpret_cast<NtOpenKey_t>(
-        GetProcAddress(ntdll, "NtOpenKey"));
-    auto ntEnumerateValueKey = reinterpret_cast<NtEnumerateValueKey_t>(
-        GetProcAddress(ntdll, "NtEnumerateValueKey"));
-    auto ntOpenKeyEx = reinterpret_cast<NtOpenKeyEx_t>(
-        GetProcAddress(ntdll, "NtOpenKeyEx"));
-    auto ntCreateKey = reinterpret_cast<NtCreateKey_t>(
-        GetProcAddress(ntdll, "NtCreateKey"));
-    auto ntClose =
-        reinterpret_cast<NtClose_t>(GetProcAddress(ntdll, "NtClose"));
-    if (!ntQueryValueKey || !ntEnumerateValueKey || !ntOpenKey ||
-        !ntOpenKeyEx || !ntCreateKey || !ntClose) {
-        Wh_Log(L"Failed to find required ntdll registry functions");
+    if (!ntQueryValueKey) {
+        Wh_Log(L"Failed to find NtQueryValueKey");
+        if (g_createdSerializeKey) {
+            RegCloseKey(g_createdSerializeKey);
+            g_createdSerializeKey = nullptr;
+            RegDeleteKeyW(HKEY_CURRENT_USER, kRegistryPath);
+        }
         return FALSE;
     }
 
     WindhawkUtils::SetFunctionHook(ntQueryValueKey, NtQueryValueKey_hook,
                                    &NtQueryValueKey_orig);
-    WindhawkUtils::SetFunctionHook(ntEnumerateValueKey,
-                                   NtEnumerateValueKey_hook,
-                                   &NtEnumerateValueKey_orig);
-    WindhawkUtils::SetFunctionHook(ntOpenKey, NtOpenKey_hook, &NtOpenKey_orig);
-    WindhawkUtils::SetFunctionHook(ntOpenKeyEx, NtOpenKeyEx_hook,
-                                   &NtOpenKeyEx_orig);
-    WindhawkUtils::SetFunctionHook(ntCreateKey, NtCreateKey_hook,
-                                   &NtCreateKey_orig);
-    WindhawkUtils::SetFunctionHook(ntClose, NtClose_hook, &NtClose_orig);
     return TRUE;
+}
+
+void Wh_ModUninit() {
+    if (!g_createdSerializeKey) {
+        return;
+    }
+
+    RegCloseKey(g_createdSerializeKey);
+    g_createdSerializeKey = nullptr;
+    LSTATUS status = RegDeleteKeyW(HKEY_CURRENT_USER, kRegistryPath);
+    if (status != ERROR_SUCCESS && status != ERROR_FILE_NOT_FOUND) {
+        Wh_Log(L"Failed to delete volatile Serialize key: %ld", status);
+    }
 }

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -6,7 +6,7 @@
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
-// @compilerOptions -lntdll -lshell32
+// @compilerOptions -lntdll
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
@@ -27,8 +27,6 @@ a session takes effect after the next sign-in or Explorer restart.
 
 #include <ntdef.h>
 #include <ntstatus.h>
-#include <shlobj.h>
-#include <strsafe.h>
 #include <windhawk_utils.h>
 
 #include <algorithm>
@@ -119,46 +117,6 @@ NtClose_t NtClose_orig;
 SRWLOCK g_virtualKeyHandlesLock = SRWLOCK_INIT;
 std::unordered_set<HANDLE> g_virtualKeyHandles;
 std::atomic<size_t> g_virtualKeyHandleCount{0};
-wchar_t g_debugLogPath[MAX_PATH];
-
-// Temporary reboot diagnostics. Revert this commit before submission.
-void InitializeDebugLog() {
-    if (FAILED(SHGetFolderPathW(nullptr, CSIDL_DESKTOPDIRECTORY, nullptr,
-                                SHGFP_TYPE_CURRENT, g_debugLogPath)) ||
-        FAILED(StringCchCatW(g_debugLogPath, ARRAYSIZE(g_debugLogPath),
-                             L"\\startup-app-delay-fix-hook.log"))) {
-        g_debugLogPath[0] = L'\0';
-    }
-}
-
-void LogDebugEvent(const char* eventName, NTSTATUS status = STATUS_SUCCESS,
-                   LONG detail = 0) {
-    if (!g_debugLogPath[0]) {
-        return;
-    }
-
-    HANDLE file = CreateFileW(g_debugLogPath, FILE_APPEND_DATA,
-                              FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
-                              OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (file == INVALID_HANDLE_VALUE) {
-        return;
-    }
-
-    SYSTEMTIME time;
-    GetLocalTime(&time);
-    char line[192];
-    int length = sprintf_s(
-        line, sizeof(line),
-        "%04u-%02u-%02u %02u:%02u:%02u.%03u  %s  status=0x%08lX detail=%ld\r\n",
-        time.wYear, time.wMonth, time.wDay, time.wHour, time.wMinute,
-        time.wSecond, time.wMilliseconds, eventName,
-        static_cast<unsigned long>(status), detail);
-    if (length > 0) {
-        DWORD written;
-        WriteFile(file, line, static_cast<DWORD>(length), &written, nullptr);
-    }
-    CloseHandle(file);
-}
 
 bool IsVirtualKey(HANDLE key) {
     if (g_virtualKeyHandleCount.load(std::memory_order_relaxed) == 0) {
@@ -290,8 +248,6 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle,
         }
         *keyHandle = duplicate;
         RememberVirtualKey(duplicate);
-        LogDebugEvent("Substituted missing Serialize key", STATUS_SUCCESS,
-                      useNtOpenKeyEx);
         return STATUS_SUCCESS;
     } else {
         return originalStatus;
@@ -313,8 +269,6 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle,
                                            &parentAttributes);
     if (status == STATUS_SUCCESS) {
         RememberVirtualKey(*keyHandle);
-        LogDebugEvent("Substituted missing Serialize key", status,
-                      useNtOpenKeyEx);
     }
     return status;
 }
@@ -499,8 +453,6 @@ NTSTATUS NTAPI NtQueryValueKey_hook(
                                   keyValueInformation, length, resultLength);
     if (status == STATUS_SUCCESS) {
         Wh_Log(L"Reporting WaitforIdleState=0");
-        LogDebugEvent("Reported WaitforIdleState=0", status,
-                      keyValueInformationClass);
     }
     return status;
 }
@@ -518,8 +470,6 @@ NTSTATUS NTAPI NtEnumerateValueKey_hook(
 }
 
 BOOL Wh_ModInit() {
-    InitializeDebugLog();
-    LogDebugEvent("Wh_ModInit");
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
     auto ntQueryValueKey = reinterpret_cast<NtQueryValueKey_t>(
         GetProcAddress(ntdll, "NtQueryValueKey"));

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -33,6 +33,7 @@ doesn't change delays configured by other systems, such as Task Scheduler.
 
 #include <ntdef.h>
 #include <ntstatus.h>
+#include <windhawk_utils.h>
 
 #include <atomic>
 #include <cwchar>
@@ -317,12 +318,10 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
-    if (!Wh_SetFunctionHook(reinterpret_cast<void*>(ntOpenKey),
-                            reinterpret_cast<void*>(NtOpenKey_hook),
-                            reinterpret_cast<void**>(&NtOpenKey_orig)) ||
-        !Wh_SetFunctionHook(reinterpret_cast<void*>(ntOpenKeyEx),
-                            reinterpret_cast<void*>(NtOpenKeyEx_hook),
-                            reinterpret_cast<void**>(&NtOpenKeyEx_orig))) {
+    if (!WindhawkUtils::SetFunctionHook(ntOpenKey, NtOpenKey_hook,
+                                        &NtOpenKey_orig) ||
+        !WindhawkUtils::SetFunctionHook(ntOpenKeyEx, NtOpenKeyEx_hook,
+                                        &NtOpenKeyEx_orig)) {
         Wh_Log(L"Failed to register registry-open hooks");
         DeleteRedirectKey();
         return FALSE;

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -198,6 +198,31 @@ bool VerifyOwner(HKEY key) {
            wcscmp(owner, kOwnerValue) == 0;
 }
 
+bool IsVolatileKey(HKEY key) {
+    wchar_t probeName[96];
+    swprintf_s(probeName, ARRAYSIZE(probeName),
+               L"WhVolatileProbe_%lu_%llX", GetCurrentProcessId(),
+               static_cast<unsigned long long>(GetTickCount64()));
+
+    HKEY probeKey;
+    DWORD disposition;
+    LSTATUS status = RegCreateKeyExW(
+        key, probeName, 0, nullptr, REG_OPTION_NON_VOLATILE,
+        KEY_READ | DELETE, nullptr, &probeKey, &disposition);
+    if (status == ERROR_CHILD_MUST_BE_VOLATILE) {
+        return true;
+    }
+    if (status != ERROR_SUCCESS) {
+        return false;
+    }
+
+    if (disposition == REG_CREATED_NEW_KEY) {
+        NtDeleteKey(probeKey);
+    }
+    RegCloseKey(probeKey);
+    return false;
+}
+
 bool InitializeRedirectKey() {
     DWORD disposition;
     LSTATUS status = RegCreateKeyExW(
@@ -210,8 +235,9 @@ bool InitializeRedirectKey() {
     }
 
     bool created = disposition == REG_CREATED_NEW_KEY;
-    if (!created && !VerifyOwner(g_redirectKey)) {
-        Wh_Log(L"Existing redirect key isn't owned by this mod");
+    if (!created &&
+        (!VerifyOwner(g_redirectKey) || !IsVolatileKey(g_redirectKey))) {
+        Wh_Log(L"Existing redirect key isn't an owned volatile key");
         RegCloseKey(g_redirectKey);
         g_redirectKey = nullptr;
         return false;

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -222,6 +222,9 @@ void RememberVirtualKey(HANDLE key) {
     ReleaseSRWLockExclusive(&g_virtualKeyHandlesLock);
 }
 
+// A tracked handle is only a read-only backing handle for value queries. It
+// must never be used as a real registry key for child opens or other namespace
+// operations, because it actually refers to the parent Explorer key.
 NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle,
                                 POBJECT_ATTRIBUTES objectAttributes,
                                 ULONG openOptions, bool useNtOpenKeyEx,
@@ -284,6 +287,11 @@ constexpr ACCESS_MASK kNonReadAccess =
 
 NTSTATUS NTAPI NtOpenKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
                               POBJECT_ATTRIBUTES objectAttributes) {
+    if (objectAttributes && objectAttributes->RootDirectory &&
+        IsVirtualKey(objectAttributes->RootDirectory)) {
+        return STATUS_OBJECT_NAME_NOT_FOUND;
+    }
+
     NTSTATUS status =
         NtOpenKey_orig(keyHandle, desiredAccess, objectAttributes);
     if (IsMissingStatus(status) && !(desiredAccess & kNonReadAccess) &&
@@ -297,6 +305,11 @@ NTSTATUS NTAPI NtOpenKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
 NTSTATUS NTAPI NtOpenKeyEx_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
                                 POBJECT_ATTRIBUTES objectAttributes,
                                 ULONG openOptions) {
+    if (objectAttributes && objectAttributes->RootDirectory &&
+        IsVirtualKey(objectAttributes->RootDirectory)) {
+        return STATUS_OBJECT_NAME_NOT_FOUND;
+    }
+
     NTSTATUS status = NtOpenKeyEx_orig(keyHandle, desiredAccess,
                                        objectAttributes, openOptions);
     if (IsMissingStatus(status) && !(desiredAccess & kNonReadAccess) &&

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -2,7 +2,7 @@
 // @id              startup-app-delay-fix
 // @name            Startup App Delay Fix
 // @description     Removes the delay Windows applies to startup applications after sign-in
-// @version         1.3
+// @version         1.4
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
@@ -10,18 +10,16 @@
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
-![Key](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/startup-app-delay-fix/startup-app-delay-fix.png)
-
 Windows intentionally delays startup applications after sign-in to reduce
 system load, which can cause apps to open minutes after startup.
 
-This mod makes Explorer see both `WaitforIdleState` and `StartupDelayInMSec` as
-zero when it reads the startup-item serialization settings. It leaves no
-persistent registry changes behind.
+This mod redirects Explorer's startup-serialization key to a dedicated,
+volatile key where both `WaitforIdleState` and `StartupDelayInMSec` are zero.
+It never creates, modifies, or deletes the user's real `Serialize` key.
 
-If the `Serialize` key is missing, the mod creates it as a volatile, in-memory
-key. The creating instance deletes it on a normal disable; otherwise it is
-discarded when the user registry hive unloads at sign-out or shutdown.
+The redirect key is in-memory only. The mod deletes it on a normal disable,
+and Windows discards it when the user registry hive unloads at sign-out or
+shutdown if Explorer exits unexpectedly.
 
 The settings are read when Explorer starts, so enabling or disabling the mod
 takes effect after the next sign-in or Explorer restart.
@@ -35,19 +33,19 @@ doesn't change delays configured by other systems, such as Task Scheduler.
 #include <ntstatus.h>
 #include <windhawk_utils.h>
 
-#include <algorithm>
-#include <cstring>
 #include <cwchar>
 #include <string>
 #include <string_view>
 #include <vector>
 
-constexpr wchar_t kRegistryPath[] =
-    L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Serialize";
-constexpr wchar_t kKeyPathSuffix[] =
+constexpr wchar_t kRedirectRegistryPath[] =
+    L"Software\\Windhawk_" WH_MOD_ID L"_Redirect";
+constexpr wchar_t kOwnerValueName[] = L"Owner";
+constexpr wchar_t kOwnerValue[] = WH_MOD_ID;
+constexpr wchar_t kSerializePathSuffix[] =
     L"\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Serialize";
 constexpr wchar_t kUserHivePrefix[] = L"\\REGISTRY\\USER\\";
-constexpr const wchar_t* kValueNames[] = {
+constexpr const wchar_t* kDelayValueNames[] = {
     L"WaitforIdleState",
     L"StartupDelayInMSec",
 };
@@ -64,47 +62,31 @@ typedef struct _KEY_NAME_INFORMATION {
     WCHAR Name[1];
 } KEY_NAME_INFORMATION, *PKEY_NAME_INFORMATION;
 
-typedef enum _KEY_VALUE_INFORMATION_CLASS {
-    KeyValueBasicInformation,
-    KeyValueFullInformation,
-    KeyValuePartialInformation,
-    KeyValueFullInformationAlign64,
-} KEY_VALUE_INFORMATION_CLASS;
-
-struct KEY_VALUE_BASIC_INFORMATION_LOCAL {
-    ULONG TitleIndex;
-    ULONG Type;
-    ULONG NameLength;
-    WCHAR Name[1];
-};
-
-struct KEY_VALUE_FULL_INFORMATION_LOCAL {
-    ULONG TitleIndex;
-    ULONG Type;
-    ULONG DataOffset;
-    ULONG DataLength;
-    ULONG NameLength;
-    WCHAR Name[1];
-};
-
-struct KEY_VALUE_PARTIAL_INFORMATION_LOCAL {
-    ULONG TitleIndex;
-    ULONG Type;
-    ULONG DataLength;
-    UCHAR Data[1];
-};
-
 EXTERN_C NTSYSAPI NTSTATUS NTAPI NtQueryKey(
     HANDLE keyHandle, KEY_INFORMATION_CLASS keyInformationClass,
     PVOID keyInformation, ULONG length, PULONG resultLength);
 
-using NtQueryValueKey_t = NTSTATUS(NTAPI*)(
-    HANDLE keyHandle, PUNICODE_STRING valueName,
-    KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
-    PVOID keyValueInformation, ULONG length, PULONG resultLength);
-NtQueryValueKey_t NtQueryValueKey_orig;
+EXTERN_C NTSYSAPI NTSTATUS NTAPI RtlNtStatusFromDosError(ULONG dosError);
 
-HKEY g_createdSerializeKey;
+using NtOpenKey_t = NTSTATUS(NTAPI*)(PHANDLE keyHandle,
+                                     ACCESS_MASK desiredAccess,
+                                     POBJECT_ATTRIBUTES objectAttributes);
+NtOpenKey_t NtOpenKey_orig;
+
+using NtOpenKeyEx_t = NTSTATUS(NTAPI*)(PHANDLE keyHandle,
+                                       ACCESS_MASK desiredAccess,
+                                       POBJECT_ATTRIBUTES objectAttributes,
+                                       ULONG openOptions);
+NtOpenKeyEx_t NtOpenKeyEx_orig;
+
+using NtCreateKey_t = NTSTATUS(NTAPI*)(
+    PHANDLE keyHandle, ACCESS_MASK desiredAccess,
+    POBJECT_ATTRIBUTES objectAttributes, ULONG titleIndex,
+    PUNICODE_STRING klass, ULONG createOptions, PULONG disposition);
+NtCreateKey_t NtCreateKey_orig;
+
+HKEY g_redirectKey;
+bool g_ownsRedirectKey;
 
 bool GetKeyPath(HANDLE key, std::wstring* path) {
     ULONG size = 0;
@@ -125,207 +107,201 @@ bool GetKeyPath(HANDLE key, std::wstring* path) {
     return true;
 }
 
-bool IsTargetValueName(const UNICODE_STRING* valueName) {
-    if (!valueName || !valueName->Buffer) {
-        return false;
-    }
-
-    for (const wchar_t* targetName : kValueNames) {
-        size_t targetLength = wcslen(targetName);
-        if (valueName->Length == targetLength * sizeof(wchar_t) &&
-            _wcsnicmp(valueName->Buffer, targetName, targetLength) == 0) {
-            return true;
-        }
-    }
-    return false;
-}
-
 bool IsSerializePath(std::wstring_view path) {
     constexpr size_t userHivePrefixLength = ARRAYSIZE(kUserHivePrefix) - 1;
-    constexpr size_t suffixLength = ARRAYSIZE(kKeyPathSuffix) - 1;
+    constexpr size_t suffixLength = ARRAYSIZE(kSerializePathSuffix) - 1;
     return path.length() >= userHivePrefixLength + suffixLength &&
            _wcsnicmp(path.data(), kUserHivePrefix, userHivePrefixLength) == 0 &&
            _wcsnicmp(path.data() + path.length() - suffixLength,
-                      kKeyPathSuffix, suffixLength) == 0;
+                      kSerializePathSuffix, suffixLength) == 0;
 }
 
-bool IsTargetQuery(HANDLE key, const UNICODE_STRING* valueName) {
-    if (!IsTargetValueName(valueName)) {
+bool IsSerializeOpen(const OBJECT_ATTRIBUTES* objectAttributes) {
+    if (!objectAttributes || !objectAttributes->ObjectName ||
+        !objectAttributes->ObjectName->Buffer) {
         return false;
     }
 
-    std::wstring path;
-    return GetKeyPath(key, &path) && IsSerializePath(path);
-}
-
-ULONG AlignUp(ULONG value, ULONG alignment) {
-    return (value + alignment - 1) & ~(alignment - 1);
-}
-
-NTSTATUS FillValueInformation(const UNICODE_STRING* valueName,
-                              KEY_VALUE_INFORMATION_CLASS informationClass,
-                              void* buffer, ULONG bufferLength,
-                              ULONG* resultLength,
-                              NTSTATUS unsupportedStatus) {
-    ULONG dataOffset;
-    ULONG requiredLength;
-
-    switch (informationClass) {
-        case KeyValueBasicInformation: {
-            ULONG nameOffset = FIELD_OFFSET(KEY_VALUE_BASIC_INFORMATION_LOCAL,
-                                            Name);
-            requiredLength = nameOffset + valueName->Length;
-            if (resultLength) {
-                *resultLength = requiredLength;
-            }
-            if (!buffer || bufferLength < nameOffset) {
-                return STATUS_BUFFER_TOO_SMALL;
-            }
-            auto info = static_cast<KEY_VALUE_BASIC_INFORMATION_LOCAL*>(buffer);
-            info->TitleIndex = 0;
-            info->Type = REG_DWORD;
-            info->NameLength = valueName->Length;
-            ULONG copiedNameLength =
-                std::min<ULONG>(valueName->Length, bufferLength - nameOffset);
-            std::memcpy(info->Name, valueName->Buffer, copiedNameLength);
-            return bufferLength < requiredLength ? STATUS_BUFFER_OVERFLOW
-                                                 : STATUS_SUCCESS;
-        }
-
-        case KeyValueFullInformation:
-        case KeyValueFullInformationAlign64: {
-            ULONG nameOffset = FIELD_OFFSET(KEY_VALUE_FULL_INFORMATION_LOCAL,
-                                            Name);
-            ULONG alignment = informationClass == KeyValueFullInformationAlign64
-                                  ? 8
-                                  : 4;
-            dataOffset = AlignUp(nameOffset + valueName->Length, alignment);
-            requiredLength = dataOffset + sizeof(DWORD);
-            if (resultLength) {
-                *resultLength = requiredLength;
-            }
-            if (!buffer || bufferLength < nameOffset) {
-                return STATUS_BUFFER_TOO_SMALL;
-            }
-            auto info = static_cast<KEY_VALUE_FULL_INFORMATION_LOCAL*>(buffer);
-            info->TitleIndex = 0;
-            info->Type = REG_DWORD;
-            info->DataOffset = dataOffset;
-            info->DataLength = sizeof(DWORD);
-            info->NameLength = valueName->Length;
-            ULONG copiedNameLength =
-                std::min<ULONG>(valueName->Length, bufferLength - nameOffset);
-            std::memcpy(info->Name, valueName->Buffer, copiedNameLength);
-            if (bufferLength < requiredLength) {
-                return STATUS_BUFFER_OVERFLOW;
-            }
-            *reinterpret_cast<DWORD*>(static_cast<BYTE*>(buffer) + dataOffset) =
-                0;
-            return STATUS_SUCCESS;
-        }
-
-        case KeyValuePartialInformation: {
-            dataOffset = FIELD_OFFSET(KEY_VALUE_PARTIAL_INFORMATION_LOCAL,
-                                      Data);
-            requiredLength = dataOffset + sizeof(DWORD);
-            if (resultLength) {
-                *resultLength = requiredLength;
-            }
-            constexpr ULONG headerLength =
-                FIELD_OFFSET(KEY_VALUE_PARTIAL_INFORMATION_LOCAL, Data);
-            if (!buffer || bufferLength < headerLength) {
-                return STATUS_BUFFER_TOO_SMALL;
-            }
-            auto info =
-                static_cast<KEY_VALUE_PARTIAL_INFORMATION_LOCAL*>(buffer);
-            info->TitleIndex = 0;
-            info->Type = REG_DWORD;
-            info->DataLength = sizeof(DWORD);
-            if (bufferLength < requiredLength) {
-                return STATUS_BUFFER_OVERFLOW;
-            }
-            *reinterpret_cast<DWORD*>(static_cast<BYTE*>(buffer) + dataOffset) =
-                0;
-            return STATUS_SUCCESS;
-        }
+    const UNICODE_STRING* objectName = objectAttributes->ObjectName;
+    std::wstring_view name(objectName->Buffer,
+                           objectName->Length / sizeof(wchar_t));
+    constexpr std::wstring_view serializeName = L"Serialize";
+    if (name.length() < serializeName.length() ||
+        _wcsnicmp(name.data() + name.length() - serializeName.length(),
+                   serializeName.data(), serializeName.length()) != 0) {
+        return false;
     }
 
-    return unsupportedStatus;
+    std::wstring path(name);
+    if (objectAttributes->RootDirectory &&
+        (path.empty() || path.front() != L'\\')) {
+        std::wstring rootPath;
+        if (!GetKeyPath(objectAttributes->RootDirectory, &rootPath)) {
+            return false;
+        }
+        if (!path.empty()) {
+            rootPath += L'\\';
+            rootPath += path;
+        }
+        path = rootPath;
+    }
+
+    return IsSerializePath(path);
 }
 
-NTSTATUS NTAPI NtQueryValueKey_hook(
-    HANDLE keyHandle, PUNICODE_STRING valueName,
-    KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
-    PVOID keyValueInformation, ULONG length, PULONG resultLength) {
-    NTSTATUS status = NtQueryValueKey_orig(
-        keyHandle, valueName, keyValueInformationClass, keyValueInformation,
-        length, resultLength);
-    if (!IsTargetQuery(keyHandle, valueName)) {
+NTSTATUS DuplicateRedirectKey(PHANDLE keyHandle, ACCESS_MASK desiredAccess) {
+    HANDLE duplicate = nullptr;
+    DWORD options = desiredAccess & MAXIMUM_ALLOWED ? DUPLICATE_SAME_ACCESS : 0;
+    if (!DuplicateHandle(GetCurrentProcess(), g_redirectKey,
+                         GetCurrentProcess(), &duplicate, desiredAccess, FALSE,
+                         options)) {
+        return RtlNtStatusFromDosError(GetLastError());
+    }
+
+    *keyHandle = duplicate;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS NTAPI NtOpenKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
+                              POBJECT_ATTRIBUTES objectAttributes) {
+    if (IsSerializeOpen(objectAttributes)) {
+        return DuplicateRedirectKey(keyHandle, desiredAccess);
+    }
+    return NtOpenKey_orig(keyHandle, desiredAccess, objectAttributes);
+}
+
+NTSTATUS NTAPI NtOpenKeyEx_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
+                                POBJECT_ATTRIBUTES objectAttributes,
+                                ULONG openOptions) {
+    if (IsSerializeOpen(objectAttributes)) {
+        return DuplicateRedirectKey(keyHandle, desiredAccess);
+    }
+    return NtOpenKeyEx_orig(keyHandle, desiredAccess, objectAttributes,
+                            openOptions);
+}
+
+NTSTATUS NTAPI NtCreateKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
+                                POBJECT_ATTRIBUTES objectAttributes,
+                                ULONG titleIndex, PUNICODE_STRING klass,
+                                ULONG createOptions, PULONG disposition) {
+    if (IsSerializeOpen(objectAttributes)) {
+        NTSTATUS status = DuplicateRedirectKey(keyHandle, desiredAccess);
+        if (status == STATUS_SUCCESS && disposition) {
+            *disposition = REG_OPENED_EXISTING_KEY;
+        }
         return status;
     }
+    return NtCreateKey_orig(keyHandle, desiredAccess, objectAttributes,
+                            titleIndex, klass, createOptions, disposition);
+}
 
-    if (status != STATUS_SUCCESS && status != STATUS_OBJECT_NAME_NOT_FOUND &&
-        status != STATUS_OBJECT_PATH_NOT_FOUND &&
-        status != STATUS_BUFFER_TOO_SMALL &&
-        status != STATUS_BUFFER_OVERFLOW) {
-        return status;
+bool VerifyOwner(HKEY key) {
+    wchar_t owner[ARRAYSIZE(kOwnerValue)];
+    DWORD type;
+    DWORD size = sizeof(owner);
+    LSTATUS status = RegQueryValueExW(
+        key, kOwnerValueName, nullptr, &type, reinterpret_cast<BYTE*>(owner),
+        &size);
+    return status == ERROR_SUCCESS && type == REG_SZ &&
+           size == sizeof(kOwnerValue) &&
+           wcscmp(owner, kOwnerValue) == 0;
+}
+
+bool InitializeRedirectKey() {
+    DWORD disposition;
+    LSTATUS status = RegCreateKeyExW(
+        HKEY_CURRENT_USER, kRedirectRegistryPath, 0, nullptr,
+        REG_OPTION_VOLATILE, KEY_ALL_ACCESS, nullptr, &g_redirectKey,
+        &disposition);
+    if (status != ERROR_SUCCESS) {
+        Wh_Log(L"Failed to create redirect key: %ld", status);
+        return false;
     }
 
-    status = FillValueInformation(valueName, keyValueInformationClass,
-                                  keyValueInformation, length, resultLength,
-                                  status);
-    if (status == STATUS_SUCCESS) {
-        Wh_Log(L"Reporting %.*s=0",
-               static_cast<int>(valueName->Length / sizeof(wchar_t)),
-               valueName->Buffer);
+    bool created = disposition == REG_CREATED_NEW_KEY;
+    if (!created && !VerifyOwner(g_redirectKey)) {
+        Wh_Log(L"Existing redirect key isn't owned by this mod");
+        RegCloseKey(g_redirectKey);
+        g_redirectKey = nullptr;
+        return false;
     }
-    return status;
+
+    if (created) {
+        status = RegSetValueExW(
+            g_redirectKey, kOwnerValueName, 0, REG_SZ,
+            reinterpret_cast<const BYTE*>(kOwnerValue), sizeof(kOwnerValue));
+        if (status != ERROR_SUCCESS) {
+            Wh_Log(L"Failed to mark redirect-key ownership: %ld", status);
+            RegCloseKey(g_redirectKey);
+            g_redirectKey = nullptr;
+            RegDeleteKeyW(HKEY_CURRENT_USER, kRedirectRegistryPath);
+            return false;
+        }
+    }
+
+    DWORD zero = 0;
+    for (const wchar_t* valueName : kDelayValueNames) {
+        status = RegSetValueExW(
+            g_redirectKey, valueName, 0, REG_DWORD,
+            reinterpret_cast<const BYTE*>(&zero), sizeof(zero));
+        if (status != ERROR_SUCCESS) {
+            Wh_Log(L"Failed to initialize %s: %ld", valueName, status);
+            RegCloseKey(g_redirectKey);
+            g_redirectKey = nullptr;
+            if (created) {
+                RegDeleteKeyW(HKEY_CURRENT_USER, kRedirectRegistryPath);
+            }
+            return false;
+        }
+    }
+
+    g_ownsRedirectKey = true;
+    Wh_Log(L"Initialized volatile Serialize redirect key");
+    return true;
+}
+
+void DeleteRedirectKey() {
+    if (g_redirectKey) {
+        RegCloseKey(g_redirectKey);
+        g_redirectKey = nullptr;
+    }
+    if (!g_ownsRedirectKey) {
+        return;
+    }
+
+    g_ownsRedirectKey = false;
+    LSTATUS status = RegDeleteKeyW(HKEY_CURRENT_USER, kRedirectRegistryPath);
+    if (status != ERROR_SUCCESS && status != ERROR_FILE_NOT_FOUND) {
+        Wh_Log(L"Failed to delete volatile redirect key: %ld", status);
+    }
 }
 
 BOOL Wh_ModInit() {
-    DWORD disposition;
-    HKEY serializeKey;
-    LSTATUS createStatus = RegCreateKeyExW(
-        HKEY_CURRENT_USER, kRegistryPath, 0, nullptr, REG_OPTION_VOLATILE,
-        KEY_READ, nullptr, &serializeKey, &disposition);
-    if (createStatus != ERROR_SUCCESS) {
-        Wh_Log(L"Failed to open or create volatile Serialize key: %ld",
-               createStatus);
+    if (!InitializeRedirectKey()) {
         return FALSE;
-    } else if (disposition == REG_CREATED_NEW_KEY) {
-        g_createdSerializeKey = serializeKey;
-        Wh_Log(L"Created volatile Serialize key");
-    } else {
-        RegCloseKey(serializeKey);
     }
 
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    auto ntQueryValueKey = reinterpret_cast<NtQueryValueKey_t>(
-        GetProcAddress(ntdll, "NtQueryValueKey"));
-    if (!ntQueryValueKey) {
-        Wh_Log(L"Failed to find NtQueryValueKey");
-        if (g_createdSerializeKey) {
-            RegCloseKey(g_createdSerializeKey);
-            g_createdSerializeKey = nullptr;
-            RegDeleteKeyW(HKEY_CURRENT_USER, kRegistryPath);
-        }
+    auto ntOpenKey = reinterpret_cast<NtOpenKey_t>(
+        GetProcAddress(ntdll, "NtOpenKey"));
+    auto ntOpenKeyEx = reinterpret_cast<NtOpenKeyEx_t>(
+        GetProcAddress(ntdll, "NtOpenKeyEx"));
+    auto ntCreateKey = reinterpret_cast<NtCreateKey_t>(
+        GetProcAddress(ntdll, "NtCreateKey"));
+    if (!ntOpenKey || !ntOpenKeyEx || !ntCreateKey) {
+        Wh_Log(L"Failed to find required ntdll registry functions");
+        DeleteRedirectKey();
         return FALSE;
     }
 
-    WindhawkUtils::SetFunctionHook(ntQueryValueKey, NtQueryValueKey_hook,
-                                   &NtQueryValueKey_orig);
+    WindhawkUtils::SetFunctionHook(ntOpenKey, NtOpenKey_hook, &NtOpenKey_orig);
+    WindhawkUtils::SetFunctionHook(ntOpenKeyEx, NtOpenKeyEx_hook,
+                                   &NtOpenKeyEx_orig);
+    WindhawkUtils::SetFunctionHook(ntCreateKey, NtCreateKey_hook,
+                                   &NtCreateKey_orig);
     return TRUE;
 }
 
 void Wh_ModUninit() {
-    if (!g_createdSerializeKey) {
-        return;
-    }
-
-    RegCloseKey(g_createdSerializeKey);
-    g_createdSerializeKey = nullptr;
-    LSTATUS status = RegDeleteKeyW(HKEY_CURRENT_USER, kRegistryPath);
-    if (status != ERROR_SUCCESS && status != ERROR_FILE_NOT_FOUND) {
-        Wh_Log(L"Failed to delete volatile Serialize key: %ld", status);
-    }
+    DeleteRedirectKey();
 }

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -10,6 +10,8 @@
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
+![Key](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/startup-app-delay-fix/startup-app-delay-fix.png)
+
 Windows intentionally delays startup applications after sign-in to reduce
 system load, which can cause apps to open minutes after startup.
 

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -119,10 +119,13 @@ NtCreateKey_t NtCreateKey_orig;
 using NtClose_t = NTSTATUS(NTAPI*)(HANDLE handle);
 NtClose_t NtClose_orig;
 
-std::atomic<HANDLE> g_virtualKeyHandles[8]{};
+constexpr size_t kVirtualKeyCapacity = 16;
+std::atomic<HANDLE> g_virtualKeyHandles[kVirtualKeyCapacity]{};
+std::atomic<size_t> g_virtualKeyHandleCount{0};
 
 bool IsVirtualKey(HANDLE key) {
-    if (!key) {
+    if (!key ||
+        g_virtualKeyHandleCount.load(std::memory_order_relaxed) == 0) {
         return false;
     }
     for (auto& slot : g_virtualKeyHandles) {
@@ -232,6 +235,7 @@ bool RememberVirtualKey(HANDLE key) {
         HANDLE expected = nullptr;
         if (slot.compare_exchange_strong(expected, key,
                                          std::memory_order_relaxed)) {
+            g_virtualKeyHandleCount.fetch_add(1, std::memory_order_relaxed);
             return true;
         }
     }
@@ -243,6 +247,7 @@ void ForgetVirtualKey(HANDLE key) {
         HANDLE expected = key;
         if (slot.compare_exchange_strong(expected, nullptr,
                                          std::memory_order_relaxed)) {
+            g_virtualKeyHandleCount.fetch_sub(1, std::memory_order_relaxed);
             return;
         }
     }
@@ -379,7 +384,9 @@ NTSTATUS NTAPI NtCreateKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
 }
 
 NTSTATUS NTAPI NtClose_hook(HANDLE handle) {
-    ForgetVirtualKey(handle);
+    if (g_virtualKeyHandleCount.load(std::memory_order_relaxed) != 0) {
+        ForgetVirtualKey(handle);
+    }
     return NtClose_orig(handle);
 }
 

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -292,7 +292,8 @@ void DeleteRedirectKey() {
     if (g_ownsRedirectKey) {
         NTSTATUS status = NtDeleteKey(g_redirectKey);
         if (status != STATUS_SUCCESS &&
-            status != STATUS_OBJECT_NAME_NOT_FOUND) {
+            status != STATUS_OBJECT_NAME_NOT_FOUND &&
+            status != STATUS_KEY_DELETED) {
             Wh_Log(L"Failed to delete volatile redirect key: 0x%08X", status);
         }
     }

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -30,14 +30,15 @@ a session takes effect after the next sign-in or Explorer restart.
 #include <windhawk_utils.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cstring>
 #include <string>
+#include <string_view>
 #include <unordered_set>
+#include <vector>
 
 constexpr wchar_t kKeyPathSuffix[] =
     L"\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Serialize";
-constexpr wchar_t kExplorerPathSuffix[] =
-    L"\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer";
 constexpr wchar_t kUserHivePrefix[] = L"\\REGISTRY\\USER\\";
 constexpr wchar_t kValueName[] = L"WaitforIdleState";
 
@@ -93,6 +94,12 @@ using NtQueryValueKey_t = NTSTATUS(NTAPI*)(
     PVOID keyValueInformation, ULONG length, PULONG resultLength);
 NtQueryValueKey_t NtQueryValueKey_orig;
 
+using NtEnumerateValueKey_t = NTSTATUS(NTAPI*)(
+    HANDLE keyHandle, ULONG index,
+    KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
+    PVOID keyValueInformation, ULONG length, PULONG resultLength);
+NtEnumerateValueKey_t NtEnumerateValueKey_orig;
+
 using NtOpenKey_t = NTSTATUS(NTAPI*)(PHANDLE keyHandle,
                                      ACCESS_MASK desiredAccess,
                                      POBJECT_ATTRIBUTES objectAttributes);
@@ -109,8 +116,12 @@ NtClose_t NtClose_orig;
 
 SRWLOCK g_virtualKeyHandlesLock = SRWLOCK_INIT;
 std::unordered_set<HANDLE> g_virtualKeyHandles;
+std::atomic<size_t> g_virtualKeyHandleCount{0};
 
 bool IsVirtualKey(HANDLE key) {
+    if (g_virtualKeyHandleCount.load(std::memory_order_relaxed) == 0) {
+        return false;
+    }
     AcquireSRWLockShared(&g_virtualKeyHandlesLock);
     bool found = g_virtualKeyHandles.find(key) != g_virtualKeyHandles.end();
     ReleaseSRWLockShared(&g_virtualKeyHandlesLock);
@@ -125,7 +136,7 @@ bool GetKeyPath(HANDLE key, std::wstring* path) {
         return false;
     }
 
-    std::wstring buffer((size + sizeof(wchar_t) - 1) / sizeof(wchar_t), L'\0');
+    std::vector<BYTE> buffer(size);
     auto info = reinterpret_cast<KEY_NAME_INFORMATION*>(buffer.data());
     status = NtQueryKey(key, KeyNameInformation, info, size, &size);
     if (status < 0) {
@@ -136,11 +147,15 @@ bool GetKeyPath(HANDLE key, std::wstring* path) {
     return true;
 }
 
-bool IsTargetQuery(HANDLE key, const UNICODE_STRING* valueName) {
+bool IsTargetValueName(const UNICODE_STRING* valueName) {
     constexpr size_t valueNameLength = ARRAYSIZE(kValueName) - 1;
-    if (!valueName || !valueName->Buffer ||
-        valueName->Length != valueNameLength * sizeof(wchar_t) ||
-        _wcsnicmp(valueName->Buffer, kValueName, valueNameLength) != 0) {
+    return valueName && valueName->Buffer &&
+           valueName->Length == valueNameLength * sizeof(wchar_t) &&
+           _wcsnicmp(valueName->Buffer, kValueName, valueNameLength) == 0;
+}
+
+bool IsTargetQuery(HANDLE key, const UNICODE_STRING* valueName) {
+    if (!IsTargetValueName(valueName)) {
         return false;
     }
 
@@ -167,6 +182,15 @@ bool IsTargetOpen(const OBJECT_ATTRIBUTES* objectAttributes) {
     }
 
     const UNICODE_STRING* objectName = objectAttributes->ObjectName;
+    std::wstring_view name(objectName->Buffer,
+                           objectName->Length / sizeof(wchar_t));
+    constexpr std::wstring_view serializeName = L"Serialize";
+    if (name.length() < serializeName.length() ||
+        _wcsnicmp(name.data() + name.length() - serializeName.length(),
+                   serializeName.data(), serializeName.length()) != 0) {
+        return false;
+    }
+
     std::wstring path(objectName->Buffer,
                       objectName->Length / sizeof(wchar_t));
     if (objectAttributes->RootDirectory &&
@@ -192,13 +216,16 @@ bool IsTargetOpen(const OBJECT_ATTRIBUTES* objectAttributes) {
 
 void RememberVirtualKey(HANDLE key) {
     AcquireSRWLockExclusive(&g_virtualKeyHandlesLock);
-    g_virtualKeyHandles.insert(key);
+    if (g_virtualKeyHandles.insert(key).second) {
+        g_virtualKeyHandleCount.fetch_add(1, std::memory_order_relaxed);
+    }
     ReleaseSRWLockExclusive(&g_virtualKeyHandlesLock);
 }
 
-NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
+NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle,
                                 POBJECT_ATTRIBUTES objectAttributes,
-                                ULONG openOptions, bool useNtOpenKeyEx) {
+                                ULONG openOptions, bool useNtOpenKeyEx,
+                                NTSTATUS originalStatus) {
     const UNICODE_STRING* objectName = objectAttributes->ObjectName;
     std::wstring parentName(objectName->Buffer,
                             objectName->Length / sizeof(wchar_t));
@@ -214,18 +241,16 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
     } else if (objectAttributes->RootDirectory &&
                _wcsicmp(parentName.c_str(), L"Serialize") == 0) {
         HANDLE duplicate = nullptr;
-        DWORD options = desiredAccess & MAXIMUM_ALLOWED ? DUPLICATE_SAME_ACCESS
-                                                       : 0;
         if (!DuplicateHandle(GetCurrentProcess(), objectAttributes->RootDirectory,
-                             GetCurrentProcess(), &duplicate, desiredAccess,
-                             FALSE, options)) {
-            return STATUS_UNSUCCESSFUL;
+                             GetCurrentProcess(), &duplicate, KEY_QUERY_VALUE,
+                             FALSE, 0)) {
+            return originalStatus;
         }
         *keyHandle = duplicate;
         RememberVirtualKey(duplicate);
         return STATUS_SUCCESS;
     } else {
-        return STATUS_OBJECT_NAME_NOT_FOUND;
+        return originalStatus;
     }
 
     UNICODE_STRING parentObjectName{
@@ -238,9 +263,9 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
     parentAttributes.ObjectName = &parentObjectName;
 
     NTSTATUS status = useNtOpenKeyEx
-                          ? NtOpenKeyEx_orig(keyHandle, desiredAccess,
+                          ? NtOpenKeyEx_orig(keyHandle, KEY_QUERY_VALUE,
                                              &parentAttributes, openOptions)
-                          : NtOpenKey_orig(keyHandle, desiredAccess,
+                          : NtOpenKey_orig(keyHandle, KEY_QUERY_VALUE,
                                            &parentAttributes);
     if (status == STATUS_SUCCESS) {
         RememberVirtualKey(*keyHandle);
@@ -253,13 +278,18 @@ bool IsMissingStatus(NTSTATUS status) {
            status == STATUS_OBJECT_PATH_NOT_FOUND;
 }
 
+constexpr ACCESS_MASK kNonReadAccess =
+    KEY_SET_VALUE | KEY_CREATE_SUB_KEY | KEY_CREATE_LINK | DELETE | WRITE_DAC |
+    WRITE_OWNER | GENERIC_WRITE | GENERIC_ALL | MAXIMUM_ALLOWED;
+
 NTSTATUS NTAPI NtOpenKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
                               POBJECT_ATTRIBUTES objectAttributes) {
     NTSTATUS status =
         NtOpenKey_orig(keyHandle, desiredAccess, objectAttributes);
-    if (IsMissingStatus(status) && IsTargetOpen(objectAttributes)) {
-        return OpenParentAsVirtualKey(keyHandle, desiredAccess, objectAttributes,
-                                      0, false);
+    if (IsMissingStatus(status) && !(desiredAccess & kNonReadAccess) &&
+        IsTargetOpen(objectAttributes)) {
+        return OpenParentAsVirtualKey(keyHandle, objectAttributes, 0, false,
+                                      status);
     }
     return status;
 }
@@ -269,17 +299,22 @@ NTSTATUS NTAPI NtOpenKeyEx_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
                                 ULONG openOptions) {
     NTSTATUS status = NtOpenKeyEx_orig(keyHandle, desiredAccess,
                                        objectAttributes, openOptions);
-    if (IsMissingStatus(status) && IsTargetOpen(objectAttributes)) {
-        return OpenParentAsVirtualKey(keyHandle, desiredAccess, objectAttributes,
-                                      openOptions, true);
+    if (IsMissingStatus(status) && !(desiredAccess & kNonReadAccess) &&
+        IsTargetOpen(objectAttributes)) {
+        return OpenParentAsVirtualKey(keyHandle, objectAttributes, openOptions,
+                                      true, status);
     }
     return status;
 }
 
 NTSTATUS NTAPI NtClose_hook(HANDLE handle) {
-    AcquireSRWLockExclusive(&g_virtualKeyHandlesLock);
-    g_virtualKeyHandles.erase(handle);
-    ReleaseSRWLockExclusive(&g_virtualKeyHandlesLock);
+    if (g_virtualKeyHandleCount.load(std::memory_order_relaxed) != 0) {
+        AcquireSRWLockExclusive(&g_virtualKeyHandlesLock);
+        if (g_virtualKeyHandles.erase(handle)) {
+            g_virtualKeyHandleCount.fetch_sub(1, std::memory_order_relaxed);
+        }
+        ReleaseSRWLockExclusive(&g_virtualKeyHandlesLock);
+    }
     return NtClose_orig(handle);
 }
 
@@ -381,16 +416,20 @@ NTSTATUS NTAPI NtQueryValueKey_hook(
     HANDLE keyHandle, PUNICODE_STRING valueName,
     KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
     PVOID keyValueInformation, ULONG length, PULONG resultLength) {
-    NTSTATUS status = NtQueryValueKey_orig(
-        keyHandle, valueName, keyValueInformationClass, keyValueInformation,
-        length, resultLength);
-
-    if (IsVirtualKey(keyHandle) && !IsTargetQuery(keyHandle, valueName)) {
-        return STATUS_OBJECT_NAME_NOT_FOUND;
-    }
-
-    if (!IsTargetQuery(keyHandle, valueName)) {
-        return status;
+    bool virtualKey = IsVirtualKey(keyHandle);
+    NTSTATUS status;
+    if (virtualKey) {
+        if (!IsTargetValueName(valueName)) {
+            return STATUS_OBJECT_NAME_NOT_FOUND;
+        }
+        status = STATUS_OBJECT_NAME_NOT_FOUND;
+    } else {
+        status = NtQueryValueKey_orig(
+            keyHandle, valueName, keyValueInformationClass,
+            keyValueInformation, length, resultLength);
+        if (!IsTargetQuery(keyHandle, valueName)) {
+            return status;
+        }
     }
 
     if (status != STATUS_SUCCESS && status != STATUS_OBJECT_NAME_NOT_FOUND &&
@@ -418,23 +457,41 @@ NTSTATUS NTAPI NtQueryValueKey_hook(
     return status;
 }
 
+NTSTATUS NTAPI NtEnumerateValueKey_hook(
+    HANDLE keyHandle, ULONG index,
+    KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
+    PVOID keyValueInformation, ULONG length, PULONG resultLength) {
+    if (IsVirtualKey(keyHandle)) {
+        return STATUS_NO_MORE_ENTRIES;
+    }
+    return NtEnumerateValueKey_orig(keyHandle, index,
+                                    keyValueInformationClass,
+                                    keyValueInformation, length, resultLength);
+}
+
 BOOL Wh_ModInit() {
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
     auto ntQueryValueKey = reinterpret_cast<NtQueryValueKey_t>(
         GetProcAddress(ntdll, "NtQueryValueKey"));
     auto ntOpenKey = reinterpret_cast<NtOpenKey_t>(
         GetProcAddress(ntdll, "NtOpenKey"));
+    auto ntEnumerateValueKey = reinterpret_cast<NtEnumerateValueKey_t>(
+        GetProcAddress(ntdll, "NtEnumerateValueKey"));
     auto ntOpenKeyEx = reinterpret_cast<NtOpenKeyEx_t>(
         GetProcAddress(ntdll, "NtOpenKeyEx"));
     auto ntClose =
         reinterpret_cast<NtClose_t>(GetProcAddress(ntdll, "NtClose"));
-    if (!ntQueryValueKey || !ntOpenKey || !ntOpenKeyEx || !ntClose) {
+    if (!ntQueryValueKey || !ntEnumerateValueKey || !ntOpenKey ||
+        !ntOpenKeyEx || !ntClose) {
         Wh_Log(L"Failed to find required ntdll registry functions");
         return FALSE;
     }
 
     WindhawkUtils::SetFunctionHook(ntQueryValueKey, NtQueryValueKey_hook,
                                    &NtQueryValueKey_orig);
+    WindhawkUtils::SetFunctionHook(ntEnumerateValueKey,
+                                   NtEnumerateValueKey_hook,
+                                   &NtEnumerateValueKey_orig);
     WindhawkUtils::SetFunctionHook(ntOpenKey, NtOpenKey_hook, &NtOpenKey_orig);
     WindhawkUtils::SetFunctionHook(ntOpenKeyEx, NtOpenKeyEx_hook,
                                    &NtOpenKeyEx_orig);

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -23,6 +23,9 @@ discarded when the user registry hive unloads at sign-out or shutdown.
 
 The settings are read when Explorer starts, so enabling or disabling the mod
 takes effect after the next sign-in or Explorer restart.
+
+This only affects the delay Explorer applies to startup-item processing. It
+doesn't change delays configured by other systems, such as Task Scheduler.
 */
 // ==/WindhawkModReadme==
 
@@ -32,6 +35,7 @@ takes effect after the next sign-in or Explorer restart.
 
 #include <algorithm>
 #include <cstring>
+#include <cwchar>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -6,7 +6,7 @@
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
-// @compilerOptions -lntdll
+// @compilerOptions -lntdll -lshell32
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
@@ -27,6 +27,8 @@ a session takes effect after the next sign-in or Explorer restart.
 
 #include <ntdef.h>
 #include <ntstatus.h>
+#include <shlobj.h>
+#include <strsafe.h>
 #include <windhawk_utils.h>
 
 #include <algorithm>
@@ -109,6 +111,46 @@ NtClose_t NtClose_orig;
 
 SRWLOCK g_virtualKeyHandlesLock = SRWLOCK_INIT;
 std::unordered_set<HANDLE> g_virtualKeyHandles;
+wchar_t g_debugLogPath[MAX_PATH];
+
+// Temporary diagnostics. Revert the dedicated debug commit before submission.
+void InitializeDebugLog() {
+    if (FAILED(SHGetFolderPathW(nullptr, CSIDL_DESKTOPDIRECTORY, nullptr,
+                                SHGFP_TYPE_CURRENT, g_debugLogPath)) ||
+        FAILED(StringCchCatW(g_debugLogPath, ARRAYSIZE(g_debugLogPath),
+                             L"\\startup-app-delay-fix-hook.log"))) {
+        g_debugLogPath[0] = L'\0';
+    }
+}
+
+void LogDebugEvent(const char* eventName, NTSTATUS status = STATUS_SUCCESS,
+                   LONG detail = 0) {
+    if (!g_debugLogPath[0]) {
+        return;
+    }
+
+    HANDLE file = CreateFileW(g_debugLogPath, FILE_APPEND_DATA,
+                              FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+                              OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+        return;
+    }
+
+    SYSTEMTIME time;
+    GetLocalTime(&time);
+    char line[192];
+    int length = sprintf_s(
+        line, sizeof(line),
+        "%04u-%02u-%02u %02u:%02u:%02u.%03u  %s  status=0x%08lX detail=%ld\r\n",
+        time.wYear, time.wMonth, time.wDay, time.wHour, time.wMinute,
+        time.wSecond, time.wMilliseconds, eventName,
+        static_cast<unsigned long>(status), detail);
+    if (length > 0) {
+        DWORD written;
+        WriteFile(file, line, static_cast<DWORD>(length), &written, nullptr);
+    }
+    CloseHandle(file);
+}
 
 bool IsVirtualKey(HANDLE key) {
     AcquireSRWLockShared(&g_virtualKeyHandlesLock);
@@ -223,6 +265,8 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
         }
         *keyHandle = duplicate;
         RememberVirtualKey(duplicate);
+        LogDebugEvent("Substituted missing Serialize key", STATUS_SUCCESS,
+                      useNtOpenKeyEx);
         return STATUS_SUCCESS;
     } else {
         return STATUS_OBJECT_NAME_NOT_FOUND;
@@ -244,6 +288,8 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
                                            &parentAttributes);
     if (status == STATUS_SUCCESS) {
         RememberVirtualKey(*keyHandle);
+        LogDebugEvent("Substituted missing Serialize key", status,
+                      useNtOpenKeyEx);
     }
     return status;
 }
@@ -414,11 +460,15 @@ NTSTATUS NTAPI NtQueryValueKey_hook(
                                   keyValueInformation, length, resultLength);
     if (status == STATUS_SUCCESS) {
         Wh_Log(L"Reporting WaitforIdleState=0");
+        LogDebugEvent("Reported WaitforIdleState=0", status,
+                      keyValueInformationClass);
     }
     return status;
 }
 
 BOOL Wh_ModInit() {
+    InitializeDebugLog();
+    LogDebugEvent("Wh_ModInit");
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
     auto ntQueryValueKey = reinterpret_cast<NtQueryValueKey_t>(
         GetProcAddress(ntdll, "NtQueryValueKey"));

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -229,6 +229,9 @@ bool IsVolatileKey(HKEY key) {
     return false;
 }
 
+// A value-read hook isn't sufficient because Serialize commonly doesn't exist,
+// so Explorer's key open fails before it can query either value. Redirect the
+// observed NtOpenKey/NtOpenKeyEx paths to a real volatile key instead.
 bool InitializeRedirectKey() {
     DWORD disposition;
     LSTATUS status = RegCreateKeyExW(

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -199,10 +199,9 @@ bool VerifyOwner(HKEY key) {
     LSTATUS status = RegQueryValueExW(
         key, kOwnerValueName, nullptr, &type, reinterpret_cast<BYTE*>(owner),
         &size);
-    return status == ERROR_SUCCESS && type == REG_SZ &&
-           size == sizeof(kOwnerValue) &&
-           wcscmp(owner, kOwnerValue) == 0;
-}
+return status == ERROR_SUCCESS && type == REG_SZ &&
+       size == sizeof(kOwnerValue) &&
+       memcmp(owner, kOwnerValue, sizeof(kOwnerValue)) == 0;}
 
 bool IsVolatileKey(HKEY key) {
     wchar_t probeName[96];

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -6,7 +6,7 @@
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
-// @compilerOptions -lntdll
+// @compilerOptions -lntdll -lshell32
 // ==/WindhawkMod==
 // ==WindhawkModReadme==
 /*
@@ -27,6 +27,8 @@ a session takes effect after the next sign-in or Explorer restart.
 
 #include <ntdef.h>
 #include <ntstatus.h>
+#include <shlobj.h>
+#include <strsafe.h>
 #include <windhawk_utils.h>
 
 #include <algorithm>
@@ -117,6 +119,46 @@ NtClose_t NtClose_orig;
 SRWLOCK g_virtualKeyHandlesLock = SRWLOCK_INIT;
 std::unordered_set<HANDLE> g_virtualKeyHandles;
 std::atomic<size_t> g_virtualKeyHandleCount{0};
+wchar_t g_debugLogPath[MAX_PATH];
+
+// Temporary reboot diagnostics. Revert this commit before submission.
+void InitializeDebugLog() {
+    if (FAILED(SHGetFolderPathW(nullptr, CSIDL_DESKTOPDIRECTORY, nullptr,
+                                SHGFP_TYPE_CURRENT, g_debugLogPath)) ||
+        FAILED(StringCchCatW(g_debugLogPath, ARRAYSIZE(g_debugLogPath),
+                             L"\\startup-app-delay-fix-hook.log"))) {
+        g_debugLogPath[0] = L'\0';
+    }
+}
+
+void LogDebugEvent(const char* eventName, NTSTATUS status = STATUS_SUCCESS,
+                   LONG detail = 0) {
+    if (!g_debugLogPath[0]) {
+        return;
+    }
+
+    HANDLE file = CreateFileW(g_debugLogPath, FILE_APPEND_DATA,
+                              FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+                              OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+        return;
+    }
+
+    SYSTEMTIME time;
+    GetLocalTime(&time);
+    char line[192];
+    int length = sprintf_s(
+        line, sizeof(line),
+        "%04u-%02u-%02u %02u:%02u:%02u.%03u  %s  status=0x%08lX detail=%ld\r\n",
+        time.wYear, time.wMonth, time.wDay, time.wHour, time.wMinute,
+        time.wSecond, time.wMilliseconds, eventName,
+        static_cast<unsigned long>(status), detail);
+    if (length > 0) {
+        DWORD written;
+        WriteFile(file, line, static_cast<DWORD>(length), &written, nullptr);
+    }
+    CloseHandle(file);
+}
 
 bool IsVirtualKey(HANDLE key) {
     if (g_virtualKeyHandleCount.load(std::memory_order_relaxed) == 0) {
@@ -248,6 +290,8 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle,
         }
         *keyHandle = duplicate;
         RememberVirtualKey(duplicate);
+        LogDebugEvent("Substituted missing Serialize key", STATUS_SUCCESS,
+                      useNtOpenKeyEx);
         return STATUS_SUCCESS;
     } else {
         return originalStatus;
@@ -269,6 +313,8 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle,
                                            &parentAttributes);
     if (status == STATUS_SUCCESS) {
         RememberVirtualKey(*keyHandle);
+        LogDebugEvent("Substituted missing Serialize key", status,
+                      useNtOpenKeyEx);
     }
     return status;
 }
@@ -453,6 +499,8 @@ NTSTATUS NTAPI NtQueryValueKey_hook(
                                   keyValueInformation, length, resultLength);
     if (status == STATUS_SUCCESS) {
         Wh_Log(L"Reporting WaitforIdleState=0");
+        LogDebugEvent("Reported WaitforIdleState=0", status,
+                      keyValueInformationClass);
     }
     return status;
 }
@@ -470,6 +518,8 @@ NTSTATUS NTAPI NtEnumerateValueKey_hook(
 }
 
 BOOL Wh_ModInit() {
+    InitializeDebugLog();
+    LogDebugEvent("Wh_ModInit");
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
     auto ntQueryValueKey = reinterpret_cast<NtQueryValueKey_t>(
         GetProcAddress(ntdll, "NtQueryValueKey"));

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -31,7 +31,6 @@ doesn't change delays configured by other systems, such as Task Scheduler.
 
 #include <ntdef.h>
 #include <ntstatus.h>
-#include <windhawk_utils.h>
 
 #include <cwchar>
 #include <string>
@@ -78,12 +77,6 @@ using NtOpenKeyEx_t = NTSTATUS(NTAPI*)(PHANDLE keyHandle,
                                        POBJECT_ATTRIBUTES objectAttributes,
                                        ULONG openOptions);
 NtOpenKeyEx_t NtOpenKeyEx_orig;
-
-using NtCreateKey_t = NTSTATUS(NTAPI*)(
-    PHANDLE keyHandle, ACCESS_MASK desiredAccess,
-    POBJECT_ATTRIBUTES objectAttributes, ULONG titleIndex,
-    PUNICODE_STRING klass, ULONG createOptions, PULONG disposition);
-NtCreateKey_t NtCreateKey_orig;
 
 HKEY g_redirectKey;
 bool g_ownsRedirectKey;
@@ -180,21 +173,6 @@ NTSTATUS NTAPI NtOpenKeyEx_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
                             openOptions);
 }
 
-NTSTATUS NTAPI NtCreateKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
-                                POBJECT_ATTRIBUTES objectAttributes,
-                                ULONG titleIndex, PUNICODE_STRING klass,
-                                ULONG createOptions, PULONG disposition) {
-    if (IsSerializeOpen(objectAttributes)) {
-        NTSTATUS status = DuplicateRedirectKey(keyHandle, desiredAccess);
-        if (status == STATUS_SUCCESS && disposition) {
-            *disposition = REG_OPENED_EXISTING_KEY;
-        }
-        return status;
-    }
-    return NtCreateKey_orig(keyHandle, desiredAccess, objectAttributes,
-                            titleIndex, klass, createOptions, disposition);
-}
-
 bool VerifyOwner(HKEY key) {
     wchar_t owner[ARRAYSIZE(kOwnerValue)];
     DWORD type;
@@ -286,19 +264,22 @@ BOOL Wh_ModInit() {
         GetProcAddress(ntdll, "NtOpenKey"));
     auto ntOpenKeyEx = reinterpret_cast<NtOpenKeyEx_t>(
         GetProcAddress(ntdll, "NtOpenKeyEx"));
-    auto ntCreateKey = reinterpret_cast<NtCreateKey_t>(
-        GetProcAddress(ntdll, "NtCreateKey"));
-    if (!ntOpenKey || !ntOpenKeyEx || !ntCreateKey) {
+    if (!ntOpenKey || !ntOpenKeyEx) {
         Wh_Log(L"Failed to find required ntdll registry functions");
         DeleteRedirectKey();
         return FALSE;
     }
 
-    WindhawkUtils::SetFunctionHook(ntOpenKey, NtOpenKey_hook, &NtOpenKey_orig);
-    WindhawkUtils::SetFunctionHook(ntOpenKeyEx, NtOpenKeyEx_hook,
-                                   &NtOpenKeyEx_orig);
-    WindhawkUtils::SetFunctionHook(ntCreateKey, NtCreateKey_hook,
-                                   &NtCreateKey_orig);
+    if (!Wh_SetFunctionHook(reinterpret_cast<void*>(ntOpenKey),
+                            reinterpret_cast<void*>(NtOpenKey_hook),
+                            reinterpret_cast<void**>(&NtOpenKey_orig)) ||
+        !Wh_SetFunctionHook(reinterpret_cast<void*>(ntOpenKeyEx),
+                            reinterpret_cast<void*>(NtOpenKeyEx_hook),
+                            reinterpret_cast<void**>(&NtOpenKeyEx_orig))) {
+        Wh_Log(L"Failed to register registry-open hooks");
+        DeleteRedirectKey();
+        return FALSE;
+    }
     return TRUE;
 }
 

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -14,14 +14,14 @@ Windows intentionally delays startup applications after sign-in to reduce
 system load, which can cause apps to open minutes after startup.
 
 This mod makes Explorer see `WaitforIdleState` as zero when it reads the
-startup-item serialization settings. It doesn't create or modify registry
-values, so disabling the mod restores Windows' normal behavior immediately.
+startup-item serialization settings. It leaves no persistent registry changes
+behind.
 
 Only `WaitforIdleState` is overridden. The related `StartupDelayInMSec` value
 is left unchanged.
 
-The setting is read when Explorer starts. Enabling or disabling the mod during
-a session takes effect after the next sign-in or Explorer restart.
+The setting is read when Explorer starts, so enabling or disabling the mod
+takes effect after the next sign-in or Explorer restart.
 */
 // ==/WindhawkModReadme==
 
@@ -53,6 +53,20 @@ typedef struct _KEY_NAME_INFORMATION {
     ULONG NameLength;
     WCHAR Name[1];
 } KEY_NAME_INFORMATION, *PKEY_NAME_INFORMATION;
+
+struct KEY_FULL_INFORMATION_LOCAL {
+    LARGE_INTEGER LastWriteTime;
+    ULONG TitleIndex;
+    ULONG ClassOffset;
+    ULONG ClassLength;
+    ULONG SubKeys;
+    ULONG MaxNameLen;
+    ULONG MaxClassLen;
+    ULONG Values;
+    ULONG MaxValueNameLen;
+    ULONG MaxValueDataLen;
+    WCHAR Class[1];
+};
 
 typedef enum _KEY_VALUE_INFORMATION_CLASS {
     KeyValueBasicInformation,
@@ -154,25 +168,30 @@ bool IsTargetValueName(const UNICODE_STRING* valueName) {
            _wcsnicmp(valueName->Buffer, kValueName, valueNameLength) == 0;
 }
 
-bool IsTargetQuery(HANDLE key, const UNICODE_STRING* valueName) {
-    if (!IsTargetValueName(valueName)) {
-        return false;
-    }
+bool IsSerializePath(std::wstring_view path) {
+    constexpr size_t userHivePrefixLength = ARRAYSIZE(kUserHivePrefix) - 1;
+    constexpr size_t suffixLength = ARRAYSIZE(kKeyPathSuffix) - 1;
+    return path.length() >= userHivePrefixLength + suffixLength &&
+           _wcsnicmp(path.data(), kUserHivePrefix, userHivePrefixLength) == 0 &&
+           _wcsnicmp(path.data() + path.length() - suffixLength,
+                      kKeyPathSuffix, suffixLength) == 0;
+}
 
+bool IsSerializeKey(HANDLE key) {
     if (IsVirtualKey(key)) {
         return true;
     }
 
     std::wstring path;
-    if (!GetKeyPath(key, &path)) {
+    return GetKeyPath(key, &path) && IsSerializePath(path);
+}
+
+bool IsTargetQuery(HANDLE key, const UNICODE_STRING* valueName) {
+    if (!IsTargetValueName(valueName)) {
         return false;
     }
-    size_t suffixLength = ARRAYSIZE(kKeyPathSuffix) - 1;
-    constexpr size_t userHivePrefixLength = ARRAYSIZE(kUserHivePrefix) - 1;
-    return path.length() >= userHivePrefixLength + suffixLength &&
-           _wcsnicmp(path.c_str(), kUserHivePrefix, userHivePrefixLength) == 0 &&
-           _wcsnicmp(path.c_str() + path.length() - suffixLength,
-                      kKeyPathSuffix, suffixLength) == 0;
+
+    return IsSerializeKey(key);
 }
 
 bool IsTargetOpen(const OBJECT_ATTRIBUTES* objectAttributes) {
@@ -206,12 +225,7 @@ bool IsTargetOpen(const OBJECT_ATTRIBUTES* objectAttributes) {
         path = rootPath;
     }
 
-    constexpr size_t userHivePrefixLength = ARRAYSIZE(kUserHivePrefix) - 1;
-    constexpr size_t suffixLength = ARRAYSIZE(kKeyPathSuffix) - 1;
-    return path.length() >= userHivePrefixLength + suffixLength &&
-           _wcsnicmp(path.c_str(), kUserHivePrefix, userHivePrefixLength) == 0 &&
-           _wcsnicmp(path.c_str() + path.length() - suffixLength,
-                      kKeyPathSuffix, suffixLength) == 0;
+    return IsSerializePath(path);
 }
 
 void RememberVirtualKey(HANDLE key) {
@@ -263,6 +277,7 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle,
         .Buffer = parentName.data(),
     };
     OBJECT_ATTRIBUTES parentAttributes = *objectAttributes;
+    parentAttributes.Length = sizeof(parentAttributes);
     parentAttributes.ObjectName = &parentObjectName;
 
     NTSTATUS status = useNtOpenKeyEx
@@ -296,8 +311,13 @@ NTSTATUS NTAPI NtOpenKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
         NtOpenKey_orig(keyHandle, desiredAccess, objectAttributes);
     if (IsMissingStatus(status) && !(desiredAccess & kNonReadAccess) &&
         IsTargetOpen(objectAttributes)) {
-        return OpenParentAsVirtualKey(keyHandle, objectAttributes, 0, false,
-                                      status);
+        NTSTATUS virtualStatus = OpenParentAsVirtualKey(
+            keyHandle, objectAttributes, 0, false, status);
+        if (virtualStatus == STATUS_SUCCESS) {
+            Wh_Log(L"Substituting missing Serialize key (access=0x%08X)",
+                   desiredAccess);
+        }
+        return virtualStatus;
     }
     return status;
 }
@@ -314,14 +334,20 @@ NTSTATUS NTAPI NtOpenKeyEx_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
                                        objectAttributes, openOptions);
     if (IsMissingStatus(status) && !(desiredAccess & kNonReadAccess) &&
         IsTargetOpen(objectAttributes)) {
-        return OpenParentAsVirtualKey(keyHandle, objectAttributes, openOptions,
-                                      true, status);
+        NTSTATUS virtualStatus = OpenParentAsVirtualKey(
+            keyHandle, objectAttributes, openOptions, true, status);
+        if (virtualStatus == STATUS_SUCCESS) {
+            Wh_Log(L"Substituting missing Serialize key (access=0x%08X)",
+                   desiredAccess);
+        }
+        return virtualStatus;
     }
     return status;
 }
 
 NTSTATUS NTAPI NtClose_hook(HANDLE handle) {
-    if (g_virtualKeyHandleCount.load(std::memory_order_relaxed) != 0) {
+    if (g_virtualKeyHandleCount.load(std::memory_order_relaxed) != 0 &&
+        IsVirtualKey(handle)) {
         AcquireSRWLockExclusive(&g_virtualKeyHandlesLock);
         if (g_virtualKeyHandles.erase(handle)) {
             g_virtualKeyHandleCount.fetch_sub(1, std::memory_order_relaxed);
@@ -425,6 +451,69 @@ NTSTATUS FillValueInformation(const UNICODE_STRING* valueName,
     return STATUS_INVALID_INFO_CLASS;
 }
 
+bool IsSupportedValueInformationClass(
+    KEY_VALUE_INFORMATION_CLASS informationClass) {
+    switch (informationClass) {
+        case KeyValueBasicInformation:
+        case KeyValueFullInformation:
+        case KeyValuePartialInformation:
+        case KeyValueFullInformationAlign64:
+            return true;
+        default:
+            return false;
+    }
+}
+
+UNICODE_STRING GetTargetValueName() {
+    return {
+        .Length = static_cast<USHORT>((ARRAYSIZE(kValueName) - 1) *
+                                      sizeof(wchar_t)),
+        .MaximumLength = static_cast<USHORT>(sizeof(kValueName)),
+        .Buffer = const_cast<PWSTR>(kValueName),
+    };
+}
+
+bool IsTargetValueAtIndex(HANDLE keyHandle, ULONG index) {
+    alignas(KEY_VALUE_BASIC_INFORMATION_LOCAL) BYTE buffer[128];
+    ULONG resultLength = 0;
+    NTSTATUS status = NtEnumerateValueKey_orig(
+        keyHandle, index, KeyValueBasicInformation, buffer, sizeof(buffer),
+        &resultLength);
+    if (status != STATUS_SUCCESS && status != STATUS_BUFFER_OVERFLOW) {
+        return false;
+    }
+
+    auto info = reinterpret_cast<KEY_VALUE_BASIC_INFORMATION_LOCAL*>(buffer);
+    constexpr ULONG targetNameLength =
+        (ARRAYSIZE(kValueName) - 1) * sizeof(wchar_t);
+    constexpr ULONG nameOffset =
+        FIELD_OFFSET(KEY_VALUE_BASIC_INFORMATION_LOCAL, Name);
+    return info->NameLength == targetNameLength &&
+           resultLength >= nameOffset + targetNameLength &&
+           _wcsnicmp(info->Name, kValueName, ARRAYSIZE(kValueName) - 1) == 0;
+}
+
+bool GetValueCount(HANDLE keyHandle, ULONG* valueCount) {
+    KEY_FULL_INFORMATION_LOCAL info{};
+    ULONG resultLength = 0;
+    NTSTATUS status = NtQueryKey(keyHandle, KeyFullInformation, &info,
+                                 sizeof(info), &resultLength);
+    if (status != STATUS_SUCCESS && status != STATUS_BUFFER_OVERFLOW) {
+        return false;
+    }
+    *valueCount = info.Values;
+    return true;
+}
+
+bool ContainsTargetValue(HANDLE keyHandle, ULONG valueCount) {
+    for (ULONG index = 0; index < valueCount; index++) {
+        if (IsTargetValueAtIndex(keyHandle, index)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 NTSTATUS NTAPI NtQueryValueKey_hook(
     HANDLE keyHandle, PUNICODE_STRING valueName,
     KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
@@ -452,14 +541,8 @@ NTSTATUS NTAPI NtQueryValueKey_hook(
         return status;
     }
 
-    switch (keyValueInformationClass) {
-        case KeyValueBasicInformation:
-        case KeyValueFullInformation:
-        case KeyValuePartialInformation:
-        case KeyValueFullInformationAlign64:
-            break;
-        default:
-            return status;
+    if (!IsSupportedValueInformationClass(keyValueInformationClass)) {
+        return status;
     }
 
     status = FillValueInformation(valueName, keyValueInformationClass,
@@ -474,12 +557,43 @@ NTSTATUS NTAPI NtEnumerateValueKey_hook(
     HANDLE keyHandle, ULONG index,
     KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
     PVOID keyValueInformation, ULONG length, PULONG resultLength) {
-    if (IsVirtualKey(keyHandle)) {
-        return STATUS_NO_MORE_ENTRIES;
-    }
-    return NtEnumerateValueKey_orig(keyHandle, index,
-                                    keyValueInformationClass,
+    bool virtualKey = IsVirtualKey(keyHandle);
+    if (virtualKey) {
+        if (index != 0) {
+            return STATUS_NO_MORE_ENTRIES;
+        }
+        if (!IsSupportedValueInformationClass(keyValueInformationClass)) {
+            return STATUS_INVALID_INFO_CLASS;
+        }
+        UNICODE_STRING valueName = GetTargetValueName();
+        return FillValueInformation(&valueName, keyValueInformationClass,
                                     keyValueInformation, length, resultLength);
+    }
+
+    NTSTATUS status = NtEnumerateValueKey_orig(
+        keyHandle, index, keyValueInformationClass, keyValueInformation, length,
+        resultLength);
+    if (!IsSerializeKey(keyHandle) ||
+        !IsSupportedValueInformationClass(keyValueInformationClass)) {
+        return status;
+    }
+
+    bool targetAtIndex = IsTargetValueAtIndex(keyHandle, index);
+    if (!targetAtIndex && status != STATUS_NO_MORE_ENTRIES) {
+        return status;
+    }
+
+    if (!targetAtIndex) {
+        ULONG valueCount;
+        if (!GetValueCount(keyHandle, &valueCount) || index != valueCount ||
+            ContainsTargetValue(keyHandle, valueCount)) {
+            return status;
+        }
+    }
+
+    UNICODE_STRING valueName = GetTargetValueName();
+    return FillValueInformation(&valueName, keyValueInformationClass,
+                                keyValueInformation, length, resultLength);
 }
 
 BOOL Wh_ModInit() {

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -67,6 +67,8 @@ EXTERN_C NTSYSAPI NTSTATUS NTAPI NtQueryKey(
     HANDLE keyHandle, KEY_INFORMATION_CLASS keyInformationClass,
     PVOID keyInformation, ULONG length, PULONG resultLength);
 
+EXTERN_C NTSYSAPI NTSTATUS NTAPI NtDeleteKey(HANDLE keyHandle);
+
 using NtOpenKey_t = NTSTATUS(NTAPI*)(PHANDLE keyHandle,
                                      ACCESS_MASK desiredAccess,
                                      POBJECT_ATTRIBUTES objectAttributes);
@@ -221,9 +223,9 @@ bool InitializeRedirectKey() {
             reinterpret_cast<const BYTE*>(kOwnerValue), sizeof(kOwnerValue));
         if (status != ERROR_SUCCESS) {
             Wh_Log(L"Failed to mark redirect-key ownership: %ld", status);
+            NtDeleteKey(g_redirectKey);
             RegCloseKey(g_redirectKey);
             g_redirectKey = nullptr;
-            RegDeleteKeyW(HKEY_CURRENT_USER, kRedirectRegistryPath);
             return false;
         }
     }
@@ -235,11 +237,11 @@ bool InitializeRedirectKey() {
             reinterpret_cast<const BYTE*>(&zero), sizeof(zero));
         if (status != ERROR_SUCCESS) {
             Wh_Log(L"Failed to initialize %s: %ld", valueName, status);
+            if (created) {
+                NtDeleteKey(g_redirectKey);
+            }
             RegCloseKey(g_redirectKey);
             g_redirectKey = nullptr;
-            if (created) {
-                RegDeleteKeyW(HKEY_CURRENT_USER, kRedirectRegistryPath);
-            }
             return false;
         }
     }
@@ -250,19 +252,22 @@ bool InitializeRedirectKey() {
 }
 
 void DeleteRedirectKey() {
-    if (g_redirectKey) {
-        RegCloseKey(g_redirectKey);
-        g_redirectKey = nullptr;
-    }
-    if (!g_ownsRedirectKey) {
+    if (!g_redirectKey) {
+        g_ownsRedirectKey = false;
         return;
     }
 
-    g_ownsRedirectKey = false;
-    LSTATUS status = RegDeleteKeyW(HKEY_CURRENT_USER, kRedirectRegistryPath);
-    if (status != ERROR_SUCCESS && status != ERROR_FILE_NOT_FOUND) {
-        Wh_Log(L"Failed to delete volatile redirect key: %ld", status);
+    if (g_ownsRedirectKey) {
+        NTSTATUS status = NtDeleteKey(g_redirectKey);
+        if (status != STATUS_SUCCESS &&
+            status != STATUS_OBJECT_NAME_NOT_FOUND) {
+            Wh_Log(L"Failed to delete volatile redirect key: 0x%08X", status);
+        }
     }
+
+    RegCloseKey(g_redirectKey);
+    g_redirectKey = nullptr;
+    g_ownsRedirectKey = false;
 }
 
 BOOL Wh_ModInit() {

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -2,7 +2,7 @@
 // @id              startup-app-delay-fix
 // @name            Startup App Delay Fix
 // @description     Removes the delay Windows applies to startup applications after sign-in
-// @version         1.1
+// @version         1.2
 // @author          meteoni
 // @github          https://github.com/Meteony
 // @include         explorer.exe
@@ -13,12 +13,9 @@
 Windows intentionally delays startup applications after sign-in to reduce
 system load, which can cause apps to open minutes after startup.
 
-This mod makes Explorer see `WaitforIdleState` as zero when it reads the
-startup-item serialization settings. It leaves no persistent registry changes
-behind.
-
-Only `WaitforIdleState` is overridden. The related `StartupDelayInMSec` value
-is left unchanged.
+This mod makes Explorer see both `WaitforIdleState` and `StartupDelayInMSec` as
+zero when it reads the startup-item serialization settings. It leaves no
+persistent registry changes behind.
 
 The setting is read when Explorer starts, so enabling or disabling the mod
 takes effect after the next sign-in or Explorer restart.
@@ -40,7 +37,10 @@ takes effect after the next sign-in or Explorer restart.
 constexpr wchar_t kKeyPathSuffix[] =
     L"\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Serialize";
 constexpr wchar_t kUserHivePrefix[] = L"\\REGISTRY\\USER\\";
-constexpr wchar_t kValueName[] = L"WaitforIdleState";
+constexpr const wchar_t* kValueNames[] = {
+    L"WaitforIdleState",
+    L"StartupDelayInMSec",
+};
 
 typedef enum _KEY_INFORMATION_CLASS {
     KeyBasicInformation,
@@ -162,10 +162,18 @@ bool GetKeyPath(HANDLE key, std::wstring* path) {
 }
 
 bool IsTargetValueName(const UNICODE_STRING* valueName) {
-    constexpr size_t valueNameLength = ARRAYSIZE(kValueName) - 1;
-    return valueName && valueName->Buffer &&
-           valueName->Length == valueNameLength * sizeof(wchar_t) &&
-           _wcsnicmp(valueName->Buffer, kValueName, valueNameLength) == 0;
+    if (!valueName || !valueName->Buffer) {
+        return false;
+    }
+
+    for (const wchar_t* targetName : kValueNames) {
+        size_t targetLength = wcslen(targetName);
+        if (valueName->Length == targetLength * sizeof(wchar_t) &&
+            _wcsnicmp(valueName->Buffer, targetName, targetLength) == 0) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool IsSerializePath(std::wstring_view path) {
@@ -464,33 +472,43 @@ bool IsSupportedValueInformationClass(
     }
 }
 
-UNICODE_STRING GetTargetValueName() {
+UNICODE_STRING GetTargetValueName(size_t targetIndex) {
+    const wchar_t* targetName = kValueNames[targetIndex];
+    size_t targetLength = wcslen(targetName);
     return {
-        .Length = static_cast<USHORT>((ARRAYSIZE(kValueName) - 1) *
-                                      sizeof(wchar_t)),
-        .MaximumLength = static_cast<USHORT>(sizeof(kValueName)),
-        .Buffer = const_cast<PWSTR>(kValueName),
+        .Length = static_cast<USHORT>(targetLength * sizeof(wchar_t)),
+        .MaximumLength =
+            static_cast<USHORT>((targetLength + 1) * sizeof(wchar_t)),
+        .Buffer = const_cast<PWSTR>(targetName),
     };
 }
 
-bool IsTargetValueAtIndex(HANDLE keyHandle, ULONG index) {
+int GetTargetValueAtIndex(HANDLE keyHandle, ULONG index) {
     alignas(KEY_VALUE_BASIC_INFORMATION_LOCAL) BYTE buffer[128];
     ULONG resultLength = 0;
     NTSTATUS status = NtEnumerateValueKey_orig(
         keyHandle, index, KeyValueBasicInformation, buffer, sizeof(buffer),
         &resultLength);
     if (status != STATUS_SUCCESS && status != STATUS_BUFFER_OVERFLOW) {
-        return false;
+        return -1;
     }
 
     auto info = reinterpret_cast<KEY_VALUE_BASIC_INFORMATION_LOCAL*>(buffer);
-    constexpr ULONG targetNameLength =
-        (ARRAYSIZE(kValueName) - 1) * sizeof(wchar_t);
     constexpr ULONG nameOffset =
         FIELD_OFFSET(KEY_VALUE_BASIC_INFORMATION_LOCAL, Name);
-    return info->NameLength == targetNameLength &&
-           resultLength >= nameOffset + targetNameLength &&
-           _wcsnicmp(info->Name, kValueName, ARRAYSIZE(kValueName) - 1) == 0;
+    for (size_t targetIndex = 0; targetIndex < ARRAYSIZE(kValueNames);
+         targetIndex++) {
+        const wchar_t* targetName = kValueNames[targetIndex];
+        ULONG targetNameLength =
+            static_cast<ULONG>(wcslen(targetName) * sizeof(wchar_t));
+        if (info->NameLength == targetNameLength &&
+            resultLength >= nameOffset + targetNameLength &&
+            _wcsnicmp(info->Name, targetName,
+                       targetNameLength / sizeof(wchar_t)) == 0) {
+            return static_cast<int>(targetIndex);
+        }
+    }
+    return -1;
 }
 
 bool GetValueCount(HANDLE keyHandle, ULONG* valueCount) {
@@ -505,13 +523,14 @@ bool GetValueCount(HANDLE keyHandle, ULONG* valueCount) {
     return true;
 }
 
-bool ContainsTargetValue(HANDLE keyHandle, ULONG valueCount) {
+void FindPresentTargetValues(HANDLE keyHandle, ULONG valueCount,
+                             bool* present) {
     for (ULONG index = 0; index < valueCount; index++) {
-        if (IsTargetValueAtIndex(keyHandle, index)) {
-            return true;
+        int targetIndex = GetTargetValueAtIndex(keyHandle, index);
+        if (targetIndex >= 0) {
+            present[targetIndex] = true;
         }
     }
-    return false;
 }
 
 NTSTATUS NTAPI NtQueryValueKey_hook(
@@ -548,7 +567,9 @@ NTSTATUS NTAPI NtQueryValueKey_hook(
     status = FillValueInformation(valueName, keyValueInformationClass,
                                   keyValueInformation, length, resultLength);
     if (status == STATUS_SUCCESS) {
-        Wh_Log(L"Reporting WaitforIdleState=0");
+        Wh_Log(L"Reporting %.*s=0",
+               static_cast<int>(valueName->Length / sizeof(wchar_t)),
+               valueName->Buffer);
     }
     return status;
 }
@@ -559,13 +580,13 @@ NTSTATUS NTAPI NtEnumerateValueKey_hook(
     PVOID keyValueInformation, ULONG length, PULONG resultLength) {
     bool virtualKey = IsVirtualKey(keyHandle);
     if (virtualKey) {
-        if (index != 0) {
+        if (index >= ARRAYSIZE(kValueNames)) {
             return STATUS_NO_MORE_ENTRIES;
         }
         if (!IsSupportedValueInformationClass(keyValueInformationClass)) {
             return STATUS_INVALID_INFO_CLASS;
         }
-        UNICODE_STRING valueName = GetTargetValueName();
+        UNICODE_STRING valueName = GetTargetValueName(index);
         return FillValueInformation(&valueName, keyValueInformationClass,
                                     keyValueInformation, length, resultLength);
     }
@@ -578,20 +599,36 @@ NTSTATUS NTAPI NtEnumerateValueKey_hook(
         return status;
     }
 
-    bool targetAtIndex = IsTargetValueAtIndex(keyHandle, index);
-    if (!targetAtIndex && status != STATUS_NO_MORE_ENTRIES) {
+    int targetAtIndex = GetTargetValueAtIndex(keyHandle, index);
+    if (targetAtIndex < 0 && status != STATUS_NO_MORE_ENTRIES) {
         return status;
     }
 
-    if (!targetAtIndex) {
+    size_t targetIndex;
+    if (targetAtIndex >= 0) {
+        targetIndex = targetAtIndex;
+    } else {
         ULONG valueCount;
-        if (!GetValueCount(keyHandle, &valueCount) || index != valueCount ||
-            ContainsTargetValue(keyHandle, valueCount)) {
+        if (!GetValueCount(keyHandle, &valueCount) || index < valueCount) {
+            return status;
+        }
+
+        bool present[ARRAYSIZE(kValueNames)]{};
+        FindPresentTargetValues(keyHandle, valueCount, present);
+        ULONG missingIndex = index - valueCount;
+        targetIndex = ARRAYSIZE(kValueNames);
+        for (size_t i = 0; i < ARRAYSIZE(kValueNames); i++) {
+            if (!present[i] && missingIndex-- == 0) {
+                targetIndex = i;
+                break;
+            }
+        }
+        if (targetIndex == ARRAYSIZE(kValueNames)) {
             return status;
         }
     }
 
-    UNICODE_STRING valueName = GetTargetValueName();
+    UNICODE_STRING valueName = GetTargetValueName(targetIndex);
     return FillValueInformation(&valueName, keyValueInformationClass,
                                 keyValueInformation, length, resultLength);
 }

--- a/mods/startup-app-delay-fix.wh.cpp
+++ b/mods/startup-app-delay-fix.wh.cpp
@@ -31,7 +31,6 @@ takes effect after the next sign-in or Explorer restart.
 #include <cstring>
 #include <string>
 #include <string_view>
-#include <unordered_set>
 #include <vector>
 
 constexpr wchar_t kKeyPathSuffix[] =
@@ -53,20 +52,6 @@ typedef struct _KEY_NAME_INFORMATION {
     ULONG NameLength;
     WCHAR Name[1];
 } KEY_NAME_INFORMATION, *PKEY_NAME_INFORMATION;
-
-struct KEY_FULL_INFORMATION_LOCAL {
-    LARGE_INTEGER LastWriteTime;
-    ULONG TitleIndex;
-    ULONG ClassOffset;
-    ULONG ClassLength;
-    ULONG SubKeys;
-    ULONG MaxNameLen;
-    ULONG MaxClassLen;
-    ULONG Values;
-    ULONG MaxValueNameLen;
-    ULONG MaxValueDataLen;
-    WCHAR Class[1];
-};
 
 typedef enum _KEY_VALUE_INFORMATION_CLASS {
     KeyValueBasicInformation,
@@ -125,21 +110,27 @@ using NtOpenKeyEx_t = NTSTATUS(NTAPI*)(PHANDLE keyHandle,
                                        ULONG openOptions);
 NtOpenKeyEx_t NtOpenKeyEx_orig;
 
+using NtCreateKey_t = NTSTATUS(NTAPI*)(
+    PHANDLE keyHandle, ACCESS_MASK desiredAccess,
+    POBJECT_ATTRIBUTES objectAttributes, ULONG titleIndex,
+    PUNICODE_STRING klass, ULONG createOptions, PULONG disposition);
+NtCreateKey_t NtCreateKey_orig;
+
 using NtClose_t = NTSTATUS(NTAPI*)(HANDLE handle);
 NtClose_t NtClose_orig;
 
-SRWLOCK g_virtualKeyHandlesLock = SRWLOCK_INIT;
-std::unordered_set<HANDLE> g_virtualKeyHandles;
-std::atomic<size_t> g_virtualKeyHandleCount{0};
+std::atomic<HANDLE> g_virtualKeyHandles[8]{};
 
 bool IsVirtualKey(HANDLE key) {
-    if (g_virtualKeyHandleCount.load(std::memory_order_relaxed) == 0) {
+    if (!key) {
         return false;
     }
-    AcquireSRWLockShared(&g_virtualKeyHandlesLock);
-    bool found = g_virtualKeyHandles.find(key) != g_virtualKeyHandles.end();
-    ReleaseSRWLockShared(&g_virtualKeyHandlesLock);
-    return found;
+    for (auto& slot : g_virtualKeyHandles) {
+        if (slot.load(std::memory_order_relaxed) == key) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool GetKeyPath(HANDLE key, std::wstring* path) {
@@ -236,17 +227,31 @@ bool IsTargetOpen(const OBJECT_ATTRIBUTES* objectAttributes) {
     return IsSerializePath(path);
 }
 
-void RememberVirtualKey(HANDLE key) {
-    AcquireSRWLockExclusive(&g_virtualKeyHandlesLock);
-    if (g_virtualKeyHandles.insert(key).second) {
-        g_virtualKeyHandleCount.fetch_add(1, std::memory_order_relaxed);
+bool RememberVirtualKey(HANDLE key) {
+    for (auto& slot : g_virtualKeyHandles) {
+        HANDLE expected = nullptr;
+        if (slot.compare_exchange_strong(expected, key,
+                                         std::memory_order_relaxed)) {
+            return true;
+        }
     }
-    ReleaseSRWLockExclusive(&g_virtualKeyHandlesLock);
+    return false;
+}
+
+void ForgetVirtualKey(HANDLE key) {
+    for (auto& slot : g_virtualKeyHandles) {
+        HANDLE expected = key;
+        if (slot.compare_exchange_strong(expected, nullptr,
+                                         std::memory_order_relaxed)) {
+            return;
+        }
+    }
 }
 
 // A tracked handle is only a read-only backing handle for value queries. It
 // must never be used as a real registry key for child opens or other namespace
-// operations, because it actually refers to the parent Explorer key.
+// operations, because it actually refers to the parent Explorer key. NtQueryKey
+// isn't spoofed, so metadata and KeyNameInformation still describe the parent.
 NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle,
                                 POBJECT_ATTRIBUTES objectAttributes,
                                 ULONG openOptions, bool useNtOpenKeyEx,
@@ -272,7 +277,11 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle,
             return originalStatus;
         }
         *keyHandle = duplicate;
-        RememberVirtualKey(duplicate);
+        if (!RememberVirtualKey(duplicate)) {
+            NtClose_orig(duplicate);
+            *keyHandle = nullptr;
+            return originalStatus;
+        }
         return STATUS_SUCCESS;
     } else {
         return originalStatus;
@@ -294,7 +303,11 @@ NTSTATUS OpenParentAsVirtualKey(PHANDLE keyHandle,
                           : NtOpenKey_orig(keyHandle, KEY_QUERY_VALUE,
                                            &parentAttributes);
     if (status == STATUS_SUCCESS) {
-        RememberVirtualKey(*keyHandle);
+        if (!RememberVirtualKey(*keyHandle)) {
+            NtClose_orig(*keyHandle);
+            *keyHandle = nullptr;
+            return originalStatus;
+        }
     }
     return status;
 }
@@ -353,15 +366,20 @@ NTSTATUS NTAPI NtOpenKeyEx_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
     return status;
 }
 
-NTSTATUS NTAPI NtClose_hook(HANDLE handle) {
-    if (g_virtualKeyHandleCount.load(std::memory_order_relaxed) != 0 &&
-        IsVirtualKey(handle)) {
-        AcquireSRWLockExclusive(&g_virtualKeyHandlesLock);
-        if (g_virtualKeyHandles.erase(handle)) {
-            g_virtualKeyHandleCount.fetch_sub(1, std::memory_order_relaxed);
-        }
-        ReleaseSRWLockExclusive(&g_virtualKeyHandlesLock);
+NTSTATUS NTAPI NtCreateKey_hook(PHANDLE keyHandle, ACCESS_MASK desiredAccess,
+                                POBJECT_ATTRIBUTES objectAttributes,
+                                ULONG titleIndex, PUNICODE_STRING klass,
+                                ULONG createOptions, PULONG disposition) {
+    if (objectAttributes && objectAttributes->RootDirectory &&
+        IsVirtualKey(objectAttributes->RootDirectory)) {
+        return STATUS_ACCESS_DENIED;
     }
+    return NtCreateKey_orig(keyHandle, desiredAccess, objectAttributes,
+                            titleIndex, klass, createOptions, disposition);
+}
+
+NTSTATUS NTAPI NtClose_hook(HANDLE handle) {
+    ForgetVirtualKey(handle);
     return NtClose_orig(handle);
 }
 
@@ -372,7 +390,8 @@ ULONG AlignUp(ULONG value, ULONG alignment) {
 NTSTATUS FillValueInformation(const UNICODE_STRING* valueName,
                               KEY_VALUE_INFORMATION_CLASS informationClass,
                               void* buffer, ULONG bufferLength,
-                              ULONG* resultLength) {
+                              ULONG* resultLength,
+                              NTSTATUS unsupportedStatus) {
     ULONG dataOffset;
     ULONG requiredLength;
 
@@ -456,20 +475,7 @@ NTSTATUS FillValueInformation(const UNICODE_STRING* valueName,
         }
     }
 
-    return STATUS_INVALID_INFO_CLASS;
-}
-
-bool IsSupportedValueInformationClass(
-    KEY_VALUE_INFORMATION_CLASS informationClass) {
-    switch (informationClass) {
-        case KeyValueBasicInformation:
-        case KeyValueFullInformation:
-        case KeyValuePartialInformation:
-        case KeyValueFullInformationAlign64:
-            return true;
-        default:
-            return false;
-    }
+    return unsupportedStatus;
 }
 
 UNICODE_STRING GetTargetValueName(size_t targetIndex) {
@@ -481,56 +487,6 @@ UNICODE_STRING GetTargetValueName(size_t targetIndex) {
             static_cast<USHORT>((targetLength + 1) * sizeof(wchar_t)),
         .Buffer = const_cast<PWSTR>(targetName),
     };
-}
-
-int GetTargetValueAtIndex(HANDLE keyHandle, ULONG index) {
-    alignas(KEY_VALUE_BASIC_INFORMATION_LOCAL) BYTE buffer[128];
-    ULONG resultLength = 0;
-    NTSTATUS status = NtEnumerateValueKey_orig(
-        keyHandle, index, KeyValueBasicInformation, buffer, sizeof(buffer),
-        &resultLength);
-    if (status != STATUS_SUCCESS && status != STATUS_BUFFER_OVERFLOW) {
-        return -1;
-    }
-
-    auto info = reinterpret_cast<KEY_VALUE_BASIC_INFORMATION_LOCAL*>(buffer);
-    constexpr ULONG nameOffset =
-        FIELD_OFFSET(KEY_VALUE_BASIC_INFORMATION_LOCAL, Name);
-    for (size_t targetIndex = 0; targetIndex < ARRAYSIZE(kValueNames);
-         targetIndex++) {
-        const wchar_t* targetName = kValueNames[targetIndex];
-        ULONG targetNameLength =
-            static_cast<ULONG>(wcslen(targetName) * sizeof(wchar_t));
-        if (info->NameLength == targetNameLength &&
-            resultLength >= nameOffset + targetNameLength &&
-            _wcsnicmp(info->Name, targetName,
-                       targetNameLength / sizeof(wchar_t)) == 0) {
-            return static_cast<int>(targetIndex);
-        }
-    }
-    return -1;
-}
-
-bool GetValueCount(HANDLE keyHandle, ULONG* valueCount) {
-    KEY_FULL_INFORMATION_LOCAL info{};
-    ULONG resultLength = 0;
-    NTSTATUS status = NtQueryKey(keyHandle, KeyFullInformation, &info,
-                                 sizeof(info), &resultLength);
-    if (status != STATUS_SUCCESS && status != STATUS_BUFFER_OVERFLOW) {
-        return false;
-    }
-    *valueCount = info.Values;
-    return true;
-}
-
-void FindPresentTargetValues(HANDLE keyHandle, ULONG valueCount,
-                             bool* present) {
-    for (ULONG index = 0; index < valueCount; index++) {
-        int targetIndex = GetTargetValueAtIndex(keyHandle, index);
-        if (targetIndex >= 0) {
-            present[targetIndex] = true;
-        }
-    }
 }
 
 NTSTATUS NTAPI NtQueryValueKey_hook(
@@ -560,12 +516,9 @@ NTSTATUS NTAPI NtQueryValueKey_hook(
         return status;
     }
 
-    if (!IsSupportedValueInformationClass(keyValueInformationClass)) {
-        return status;
-    }
-
     status = FillValueInformation(valueName, keyValueInformationClass,
-                                  keyValueInformation, length, resultLength);
+                                  keyValueInformation, length, resultLength,
+                                  status);
     if (status == STATUS_SUCCESS) {
         Wh_Log(L"Reporting %.*s=0",
                static_cast<int>(valueName->Length / sizeof(wchar_t)),
@@ -578,59 +531,18 @@ NTSTATUS NTAPI NtEnumerateValueKey_hook(
     HANDLE keyHandle, ULONG index,
     KEY_VALUE_INFORMATION_CLASS keyValueInformationClass,
     PVOID keyValueInformation, ULONG length, PULONG resultLength) {
-    bool virtualKey = IsVirtualKey(keyHandle);
-    if (virtualKey) {
+    if (IsVirtualKey(keyHandle)) {
         if (index >= ARRAYSIZE(kValueNames)) {
             return STATUS_NO_MORE_ENTRIES;
         }
-        if (!IsSupportedValueInformationClass(keyValueInformationClass)) {
-            return STATUS_INVALID_INFO_CLASS;
-        }
         UNICODE_STRING valueName = GetTargetValueName(index);
         return FillValueInformation(&valueName, keyValueInformationClass,
+                                    keyValueInformation, length, resultLength,
+                                    STATUS_INVALID_INFO_CLASS);
+    }
+    return NtEnumerateValueKey_orig(keyHandle, index,
+                                    keyValueInformationClass,
                                     keyValueInformation, length, resultLength);
-    }
-
-    NTSTATUS status = NtEnumerateValueKey_orig(
-        keyHandle, index, keyValueInformationClass, keyValueInformation, length,
-        resultLength);
-    if (!IsSerializeKey(keyHandle) ||
-        !IsSupportedValueInformationClass(keyValueInformationClass)) {
-        return status;
-    }
-
-    int targetAtIndex = GetTargetValueAtIndex(keyHandle, index);
-    if (targetAtIndex < 0 && status != STATUS_NO_MORE_ENTRIES) {
-        return status;
-    }
-
-    size_t targetIndex;
-    if (targetAtIndex >= 0) {
-        targetIndex = targetAtIndex;
-    } else {
-        ULONG valueCount;
-        if (!GetValueCount(keyHandle, &valueCount) || index < valueCount) {
-            return status;
-        }
-
-        bool present[ARRAYSIZE(kValueNames)]{};
-        FindPresentTargetValues(keyHandle, valueCount, present);
-        ULONG missingIndex = index - valueCount;
-        targetIndex = ARRAYSIZE(kValueNames);
-        for (size_t i = 0; i < ARRAYSIZE(kValueNames); i++) {
-            if (!present[i] && missingIndex-- == 0) {
-                targetIndex = i;
-                break;
-            }
-        }
-        if (targetIndex == ARRAYSIZE(kValueNames)) {
-            return status;
-        }
-    }
-
-    UNICODE_STRING valueName = GetTargetValueName(targetIndex);
-    return FillValueInformation(&valueName, keyValueInformationClass,
-                                keyValueInformation, length, resultLength);
 }
 
 BOOL Wh_ModInit() {
@@ -643,10 +555,12 @@ BOOL Wh_ModInit() {
         GetProcAddress(ntdll, "NtEnumerateValueKey"));
     auto ntOpenKeyEx = reinterpret_cast<NtOpenKeyEx_t>(
         GetProcAddress(ntdll, "NtOpenKeyEx"));
+    auto ntCreateKey = reinterpret_cast<NtCreateKey_t>(
+        GetProcAddress(ntdll, "NtCreateKey"));
     auto ntClose =
         reinterpret_cast<NtClose_t>(GetProcAddress(ntdll, "NtClose"));
     if (!ntQueryValueKey || !ntEnumerateValueKey || !ntOpenKey ||
-        !ntOpenKeyEx || !ntClose) {
+        !ntOpenKeyEx || !ntCreateKey || !ntClose) {
         Wh_Log(L"Failed to find required ntdll registry functions");
         return FALSE;
     }
@@ -659,6 +573,8 @@ BOOL Wh_ModInit() {
     WindhawkUtils::SetFunctionHook(ntOpenKey, NtOpenKey_hook, &NtOpenKey_orig);
     WindhawkUtils::SetFunctionHook(ntOpenKeyEx, NtOpenKeyEx_hook,
                                    &NtOpenKeyEx_orig);
+    WindhawkUtils::SetFunctionHook(ntCreateKey, NtCreateKey_hook,
+                                   &NtCreateKey_orig);
     WindhawkUtils::SetFunctionHook(ntClose, NtClose_hook, &NtClose_orig);
     return TRUE;
 }


### PR DESCRIPTION

## Changelog

Windows intentionally delays startup applications after sign-in to reduce
system load, which can cause apps to open minutes after startup.

Common fix (which the mod intends to emulate): 
![Common Fix](https://raw.githubusercontent.com/Meteony/meteoni-assets/main/startup-app-delay-fix/startup-app-delay-fix.png)

This mod redirects Explorer's startup-serialization key to a dedicated,
volatile key where both `WaitforIdleState` and `StartupDelayInMSec` are zero.
It never creates, modifies, or deletes the user's real `Serialize` key.

The redirect key is in-memory only. The mod deletes it on a normal disable,
and Windows discards it when the user registry hive unloads at sign-out or
shutdown if Explorer exits unexpectedly.

Windows reads the startup-delay values when Explorer starts, so enabling or
disabling the mod takes effect after the next sign-in or Explorer restart.

This only affects the delay Explorer applies to startup-item processing. It
doesn't change delays configured by other systems, such as Task Scheduler.


## Mod authorship

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [X] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

