### PR TITLE
Update Open in Admin Terminal to v1.17.1

### DIFF
--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -1,7 +1,7 @@
 // ==WindhawkMod==
 // @id              open-in-admin-terminal
 // @name            Open in Admin Terminal
-// @description     Adds an Explorer classic context menu entry to open an elevated terminal in the current or selected folder.
+// @description     Adds Explorer classic context menu entries to open a terminal (elevated or not) in the current or selected folder, and to run script files.
 // @version         1.17.1
 // @author          aimagist
 // @github          https://github.com/aimagist
@@ -133,7 +133,7 @@ Screenshots may show earlier builds, but current releases use runtime classic-me
   $description: Add the selected terminal name to script actions. Disable for shorter labels.
 - scriptExtensions: ".ps1;.bat;.cmd;.vbs;.js"
   $name: Script extensions
-  $description: Semicolon-separated filter for supported script extensions: .ps1, .bat, .cmd, .vbs, and .js.
+  $description: "Semicolon-separated filter for supported script extensions: .ps1, .bat, .cmd, .vbs, and .js."
 - keepOpenAfterScript: true
   $name: Keep terminal open after script
   $description: Terminal stays open after script finishes.

--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -901,7 +901,13 @@ static bool IsScriptHostChoice(const std::wstring& choice) {
 static LaunchSpec BuildScriptLaunchSpec(const Settings& s,
                                         const std::wstring& scriptPath) {
     LaunchSpec interpreter = BuildScriptInterpreterSpec(s, scriptPath);
-    if (!IsScriptHostChoice(s.terminalEffectiveChoice)) {
+    PCWSTR ext = PathFindExtensionW(scriptPath.c_str());
+    bool usesCmdWrapper = _wcsicmp(ext, L".bat") == 0 ||
+                          _wcsicmp(ext, L".cmd") == 0 ||
+                          (s.keepOpenAfterScript &&
+                           (_wcsicmp(ext, L".vbs") == 0 ||
+                            _wcsicmp(ext, L".js") == 0));
+    if (!IsScriptHostChoice(s.terminalEffectiveChoice) || usesCmdWrapper) {
         return interpreter;
     }
 
@@ -1235,18 +1241,39 @@ static bool IsKeyboardContextMenuPoint(const POINT& invocationPoint) {
     return invocationPoint.x == -1 && invocationPoint.y == -1;
 }
 
-static bool IsNavigationPaneContextWindow(const POINT& invocationPoint) {
-    if (IsKeyboardContextMenuPoint(invocationPoint)) {
-        HWND focusedWindow = GetFocus();
-        return focusedWindow && IsNavigationPaneWindow(focusedWindow);
+static bool ShouldUseFocusedNavigationPaneFallback(
+    bool invocationPointIsNavigationPane,
+    bool focusedWindowIsNavigationPane,
+    bool ownerIsShellView) {
+    return !invocationPointIsNavigationPane && focusedWindowIsNavigationPane &&
+           !ownerIsShellView;
+}
+
+static bool IsNavigationPaneContextWindow(HWND hwnd,
+                                          const POINT& invocationPoint,
+                                          bool& useSelectionFallback) {
+    useSelectionFallback = false;
+    bool invocationPointIsNavigationPane = false;
+    if (!IsKeyboardContextMenuPoint(invocationPoint)) {
+        HWND invocationWindow = WindowFromPoint(invocationPoint);
+        invocationPointIsNavigationPane =
+            invocationWindow && IsNavigationPaneWindow(invocationWindow);
+        if (invocationPointIsNavigationPane) {
+            return true;
+        }
     }
 
-    HWND invocationWindow = WindowFromPoint(invocationPoint);
-    return invocationWindow && IsNavigationPaneWindow(invocationWindow);
+    HWND focusedWindow = GetFocus();
+    useSelectionFallback = ShouldUseFocusedNavigationPaneFallback(
+        invocationPointIsNavigationPane,
+        focusedWindow && IsNavigationPaneWindow(focusedWindow),
+        IsShellViewWindow(hwnd));
+    return useSelectionFallback;
 }
 
 static bool ResolveNavigationPaneMenuTarget(HWND hwnd,
                                             const POINT& invocationPoint,
+                                            bool useSelectionFallback,
                                             MenuTarget& targetOut) {
     targetOut = {};
 
@@ -1295,7 +1322,7 @@ static bool ResolveNavigationPaneMenuTarget(HWND hwnd,
             }
         }
 
-        if (!ok && IsKeyboardContextMenuPoint(invocationPoint)) {
+        if (!ok && useSelectionFallback) {
             IShellItemArray* selectedItems = nullptr;
             if (SUCCEEDED(navigationPane->GetSelectedItems(&selectedItems)) &&
                 selectedItems) {
@@ -1331,12 +1358,15 @@ static bool ResolveMenuTarget(HWND hwnd,
                               MenuTarget& targetOut) {
     targetOut = {};
 
-    bool isNavigationPane = IsNavigationPaneContextWindow(invocationPoint);
+    bool useNavigationPaneSelectionFallback = false;
+    bool isNavigationPane = IsNavigationPaneContextWindow(
+        hwnd, invocationPoint, useNavigationPaneSelectionFallback);
     if (isNavigationPane) {
         if (!settings.showOnNavigationPane) {
             return false;
         }
-        return ResolveNavigationPaneMenuTarget(hwnd, invocationPoint, targetOut);
+        return ResolveNavigationPaneMenuTarget(
+            hwnd, invocationPoint, useNavigationPaneSelectionFallback, targetOut);
     }
 
     if (!IsShellViewWindow(hwnd)) {

--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -977,6 +977,10 @@ static bool IsExplorerContextMatch(HWND expectedShellView,
     return true;
 }
 
+static bool ShouldInjectForMenuFlags(UINT flags) {
+    return (flags & TPM_RETURNCMD) != 0;
+}
+
 static IServiceProvider* GetExplorerServiceProviderForHwnd(HWND hwnd) {
     HWND topLevel = GetAncestor(hwnd, GA_ROOT);
     if (!topLevel) {
@@ -1026,15 +1030,15 @@ static IServiceProvider* GetExplorerServiceProviderForHwnd(HWND hwnd) {
                             SID_STopLevelBrowser, IID_IShellBrowser,
                             reinterpret_cast<void**>(&shellBrowser));
                     }
-                    if (shellBrowser && expectedShellView) {
+                    if (shellBrowser) {
                         IShellView* shellView = nullptr;
                         if (SUCCEEDED(shellBrowser->QueryActiveShellView(
                                 &shellView)) && shellView) {
                             shellView->GetWindow(&candidateShellView);
+                            candidateShellTab =
+                                FindShellTabWindow(candidateShellView);
                             shellView->Release();
                         }
-                    } else if (shellBrowser && expectedShellTab) {
-                        shellBrowser->GetWindow(&candidateShellTab);
                     }
                     if (shellBrowser) {
                         shellBrowser->Release();
@@ -2189,7 +2193,7 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
                            _wcsicmp(rootClass, L"CabinetWClass") == 0 ||
                            _wcsicmp(rootClass, L"ExploreWClass") == 0);
 
-    if (menu && eligibleWindow && (flags & TPM_RETURNCMD)) {
+    if (menu && eligibleWindow && ShouldInjectForMenuFlags(flags)) {
         Settings settings = GetSettingsSnapshot();
         POINT invocationPoint = {x, y};
         if (!ResolveMenuTarget(hwnd, settings, invocationPoint, target)) {

--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -202,6 +202,7 @@ static void LaunchTerminalNonElevated(const MenuTarget&);
 static LaunchSpec BuildScriptLaunchSpec(const Settings&, const std::wstring&);
 static bool IsScriptExtension(const std::wstring&, const Settings&);
 static bool IsShellViewWindow(HWND hwnd);
+static bool ResolveSystemExecutablePath(PCWSTR exe, std::wstring& pathOut);
 
 static Settings g_settings;
 static SRWLOCK g_settingsLock = SRWLOCK_INIT;
@@ -478,7 +479,7 @@ static void ResolveSettingsTerminal(Settings& s) {
     }
 
     s.terminalEffectiveChoice = L"cmd";
-    s.terminalDisplayCommand = L"cmd.exe";
+    ResolveSystemExecutablePath(L"cmd.exe", s.terminalDisplayCommand);
 }
 
 static std::wstring GetTerminalDisplayNameForChoice(const std::wstring& choice) {
@@ -782,15 +783,25 @@ static LaunchSpec BuildLaunchSpec(const Settings& s, const std::wstring& target)
                                      ? s.terminalChoice
                                      : s.terminalEffectiveChoice;
     LaunchSpec spec;
-    spec.executable =
-        s.terminalDisplayCommand.empty() ? L"cmd.exe" : s.terminalDisplayCommand;
+    if (s.terminalDisplayCommand.empty()) {
+        ResolveSystemExecutablePath(L"cmd.exe", spec.executable);
+    } else {
+        spec.executable = s.terminalDisplayCommand;
+    }
     spec.workingDirectory = target;
 
     if (choice == L"custom") {
         std::wstring executable;
         std::wstring parameters;
         if (SplitCustomCommand(s.customTerminalCommand, executable, parameters)) {
-            spec.executable = executable;
+            if (PathIsRelativeW(executable.c_str())) {
+                std::wstring resolved;
+                if (!SearchExecutablePath(executable.c_str(), resolved)) {
+                    return {};
+                }
+                executable = std::move(resolved);
+            }
+            spec.executable = std::move(executable);
             spec.parameters = ExpandCustomParameters(parameters, target);
         }
         return spec;

--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -191,6 +191,11 @@ struct MenuTarget {
     std::wstring path;
 };
 
+struct MenuCommandIds {
+    UINT admin = 0;
+    UINT nonElevated = 0;
+};
+
 struct LaunchSpec {
     std::wstring executable;
     std::wstring parameters;
@@ -208,8 +213,8 @@ static bool ResolveSystemExecutablePath(PCWSTR exe, std::wstring& pathOut);
 static Settings g_settings;
 static SRWLOCK g_settingsLock = SRWLOCK_INIT;
 
-static const UINT kMenuCommandId = 0xBF31;
-static const UINT kMenuCommandIdNonElevated = 0xBF32;
+static const UINT kPreferredAdminMenuCommandId = 0xC7E1;
+static const UINT kPreferredNonElevatedMenuCommandId = 0xC7E2;
 
 #ifndef IO_REPARSE_TAG_APPEXECLINK
 #define IO_REPARSE_TAG_APPEXECLINK (0x8000001BL)
@@ -1315,6 +1320,11 @@ static bool IsKeyboardContextMenuPoint(const POINT& invocationPoint) {
     return invocationPoint.x == -1 && invocationPoint.y == -1;
 }
 
+static HWND SelectNavigationPaneWindow(HWND controlWindow,
+                                       HWND fallbackWindow) {
+    return controlWindow ? controlWindow : fallbackWindow;
+}
+
 static bool ShouldUseFocusedNavigationPaneFallback(
     bool invocationPointIsNavigationPane,
     bool focusedWindowIsNavigationPane,
@@ -1379,14 +1389,25 @@ static bool ResolveNavigationPaneMenuTarget(const POINT& invocationPoint,
             SID_SNavigationPane, IID_INameSpaceTreeControl,
             reinterpret_cast<void**>(&navigationPane))) &&
         navigationPane) {
-        IShellBrowser* shellBrowser = nullptr;
         HWND treeWindow = nullptr;
-        if (SUCCEEDED(serviceProvider->QueryService(
-                SID_STopLevelBrowser, IID_IShellBrowser,
-                reinterpret_cast<void**>(&shellBrowser))) &&
-            shellBrowser) {
-            shellBrowser->GetControlWindow(FCW_TREE, &treeWindow);
-            shellBrowser->Release();
+        IOleWindow* oleWindow = nullptr;
+        if (SUCCEEDED(navigationPane->QueryInterface(
+                IID_IOleWindow, reinterpret_cast<void**>(&oleWindow))) &&
+            oleWindow) {
+            oleWindow->GetWindow(&treeWindow);
+            oleWindow->Release();
+        }
+        if (!treeWindow) {
+            IShellBrowser* shellBrowser = nullptr;
+            HWND fallbackWindow = nullptr;
+            if (SUCCEEDED(serviceProvider->QueryService(
+                    SID_STopLevelBrowser, IID_IShellBrowser,
+                    reinterpret_cast<void**>(&shellBrowser))) &&
+                shellBrowser) {
+                shellBrowser->GetControlWindow(FCW_TREE, &fallbackWindow);
+                shellBrowser->Release();
+            }
+            treeWindow = SelectNavigationPaneWindow(treeWindow, fallbackWindow);
         }
 
         POINT clientPoint = invocationPoint;
@@ -1915,8 +1936,18 @@ static Settings GetScriptIconSettings(const Settings& settings,
     return iconSettings;
 }
 
-static void InsertAdminTerminalMenuItem(HMENU menu, const Settings& settings,
-                                        const MenuTarget& target) {
+static UINT ReserveMenuCommandId(HMENU menu, UINT preferred,
+                                 UINT excluded = 0) {
+    for (UINT id = preferred; id < preferred + 0x20; id++) {
+        if (id != excluded && GetMenuState(menu, id, MF_BYCOMMAND) == UINT(-1)) {
+            return id;
+        }
+    }
+    return 0;
+}
+
+static MenuCommandIds InsertAdminTerminalMenuItem(
+    HMENU menu, const Settings& settings, const MenuTarget& target) {
     int itemCount = GetMenuItemCount(menu);
     int insertPos = 0;
     bool separatorAbove = false;
@@ -1954,6 +1985,21 @@ static void InsertAdminTerminalMenuItem(HMENU menu, const Settings& settings,
                           ? settings.scriptMenuEntries == L"normal" ||
                                 settings.scriptMenuEntries == L"both"
                           : settings.showNonElevatedEntry;
+    MenuCommandIds commandIds;
+    if (showAdmin) {
+        commandIds.admin =
+            ReserveMenuCommandId(menu, kPreferredAdminMenuCommandId);
+        if (!commandIds.admin) {
+            return {};
+        }
+    }
+    if (showNormal) {
+        commandIds.nonElevated = ReserveMenuCommandId(
+            menu, kPreferredNonElevatedMenuCommandId, commandIds.admin);
+        if (!commandIds.nonElevated) {
+            return {};
+        }
+    }
     Settings iconSettings = isScript
                                 ? GetScriptIconSettings(settings, target.path)
                                 : settings;
@@ -1990,12 +2036,13 @@ static void InsertAdminTerminalMenuItem(HMENU menu, const Settings& settings,
     }
 
     if (showAdmin) {
-        InsertMenuW(menu, actionPos++, MF_BYPOSITION | MF_STRING, kMenuCommandId,
+        InsertMenuW(menu, actionPos++, MF_BYPOSITION | MF_STRING,
+                    commandIds.admin,
                     adminLabel.c_str());
     }
     if (showNormal) {
         InsertMenuW(menu, actionPos++, MF_BYPOSITION | MF_STRING,
-                    kMenuCommandIdNonElevated, normalLabel.c_str());
+                    commandIds.nonElevated, normalLabel.c_str());
     }
     if (!separatorAbove) {
         InsertMenuW(menu, actionPos, MF_BYPOSITION | MF_SEPARATOR, 0, nullptr);
@@ -2008,7 +2055,7 @@ static void InsertAdminTerminalMenuItem(HMENU menu, const Settings& settings,
             itemInfo.cbSize = sizeof(itemInfo);
             itemInfo.fMask = MIIM_BITMAP;
             itemInfo.hbmpItem = menuBitmap;
-            if (!SetMenuItemInfoW(menu, kMenuCommandId, FALSE, &itemInfo)) {
+            if (!SetMenuItemInfoW(menu, commandIds.admin, FALSE, &itemInfo)) {
                 Wh_Log(L"Menu icon assignment failed");
             } else {
                 Wh_Log(L"Menu icon assigned");
@@ -2025,7 +2072,7 @@ static void InsertAdminTerminalMenuItem(HMENU menu, const Settings& settings,
             itemInfo.cbSize = sizeof(itemInfo);
             itemInfo.fMask = MIIM_BITMAP;
             itemInfo.hbmpItem = menuBitmapNoShield;
-            if (!SetMenuItemInfoW(menu, kMenuCommandIdNonElevated, FALSE,
+            if (!SetMenuItemInfoW(menu, commandIds.nonElevated, FALSE,
                                   &itemInfo)) {
                 Wh_Log(L"Non-elevated menu icon assignment failed");
             } else {
@@ -2035,6 +2082,7 @@ static void InsertAdminTerminalMenuItem(HMENU menu, const Settings& settings,
             Wh_Log(L"Non-elevated menu icon unavailable");
         }
     }
+    return commandIds;
 }
 
 static void LaunchAdminTerminal(const MenuTarget& target) {
@@ -2129,6 +2177,7 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
                                   LPTPMPARAMS params) {
     bool injected = false;
     MenuTarget target;
+    MenuCommandIds commandIds;
 
     HWND root = hwnd ? GetAncestor(hwnd, GA_ROOT) : nullptr;
     WCHAR rootClass[64] = {};
@@ -2157,23 +2206,28 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
             }
             Wh_Log(L"Injection target: kind=%ls path=%ls",
                    TargetKindName(target.kind), target.path.c_str());
-            InsertAdminTerminalMenuItem(menu, settings, target);
-            Wh_Log(L"Injection inserted: position=%ls kind=%ls",
-                   settings.position.c_str(), TargetKindName(target.kind));
-            injected = true;
+            commandIds = InsertAdminTerminalMenuItem(menu, settings, target);
+            injected = commandIds.admin || commandIds.nonElevated;
+            if (injected) {
+                Wh_Log(L"Injection inserted: position=%ls kind=%ls",
+                       settings.position.c_str(), TargetKindName(target.kind));
+            } else {
+                Wh_Log(L"Injection skipped: no free menu command IDs");
+            }
         }
     }
 
     BOOL result = TrackPopupMenuEx_Orig(menu, flags, x, y, hwnd, params);
 
     if (injected && (flags & TPM_RETURNCMD) &&
-        static_cast<UINT>(result) == kMenuCommandId) {
+        commandIds.admin && static_cast<UINT>(result) == commandIds.admin) {
         LaunchAdminTerminal(target);
         return 0;
     }
 
     if (injected && (flags & TPM_RETURNCMD) &&
-        static_cast<UINT>(result) == kMenuCommandIdNonElevated) {
+        commandIds.nonElevated &&
+        static_cast<UINT>(result) == commandIds.nonElevated) {
         LaunchTerminalNonElevated(target);
         return 0;
     }

--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -760,11 +760,17 @@ static bool SplitCustomCommand(const std::wstring& command,
     return !executable.empty();
 }
 
-static void ReplaceAll(std::wstring& value,
-                       const std::wstring& placeholder,
-                       const std::wstring& replacement) {
+static void ExpandCustomPlaceholder(std::wstring& value,
+                                    const std::wstring& placeholder,
+                                    const std::wstring& target) {
     size_t pos = 0;
     while ((pos = value.find(placeholder, pos)) != std::wstring::npos) {
+        bool alreadyQuoted = pos > 0 &&
+                             pos + placeholder.size() < value.size() &&
+                             value[pos - 1] == L'"' &&
+                             value[pos + placeholder.size()] == L'"';
+        std::wstring replacement =
+            alreadyQuoted ? target : QuoteCommandLineArgument(target);
         value.replace(pos, placeholder.size(), replacement);
         pos += replacement.size();
     }
@@ -773,8 +779,8 @@ static void ReplaceAll(std::wstring& value,
 static std::wstring ExpandCustomParameters(const std::wstring& parameters,
                                            const std::wstring& target) {
     std::wstring result = parameters;
-    ReplaceAll(result, L"%V", target);
-    ReplaceAll(result, L"%1", target);
+    ExpandCustomPlaceholder(result, L"%V", target);
+    ExpandCustomPlaceholder(result, L"%1", target);
     return result;
 }
 
@@ -1263,9 +1269,11 @@ static bool IsKeyboardContextMenuPoint(const POINT& invocationPoint) {
 static bool ShouldUseFocusedNavigationPaneFallback(
     bool invocationPointIsNavigationPane,
     bool focusedWindowIsNavigationPane,
-    bool ownerIsShellView) {
-    return !invocationPointIsNavigationPane && focusedWindowIsNavigationPane &&
-           !ownerIsShellView;
+    bool ownerIsShellView,
+    bool invocationPointIsSameExplorerFrame) {
+    return !invocationPointIsNavigationPane &&
+           !invocationPointIsSameExplorerFrame &&
+           focusedWindowIsNavigationPane && !ownerIsShellView;
 }
 
 static bool IsNavigationPaneContextWindow(HWND hwnd,
@@ -1273,6 +1281,7 @@ static bool IsNavigationPaneContextWindow(HWND hwnd,
                                           bool& useSelectionFallback) {
     useSelectionFallback = false;
     bool invocationPointIsNavigationPane = false;
+    bool invocationPointIsSameExplorerFrame = false;
     if (!IsKeyboardContextMenuPoint(invocationPoint)) {
         HWND invocationWindow = WindowFromPoint(invocationPoint);
         invocationPointIsNavigationPane =
@@ -1280,13 +1289,19 @@ static bool IsNavigationPaneContextWindow(HWND hwnd,
         if (invocationPointIsNavigationPane) {
             return true;
         }
+
+        HWND invocationRoot =
+            invocationWindow ? GetAncestor(invocationWindow, GA_ROOT) : nullptr;
+        HWND ownerRoot = GetAncestor(hwnd, GA_ROOT);
+        invocationPointIsSameExplorerFrame =
+            invocationRoot && ownerRoot && invocationRoot == ownerRoot;
     }
 
     HWND focusedWindow = GetFocus();
     useSelectionFallback = ShouldUseFocusedNavigationPaneFallback(
         invocationPointIsNavigationPane,
         focusedWindow && IsNavigationPaneWindow(focusedWindow),
-        IsShellViewWindow(hwnd));
+        IsShellViewWindow(hwnd), invocationPointIsSameExplorerFrame);
     return useSelectionFallback;
 }
 

--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -1360,6 +1360,12 @@ static bool ResolveNavigationPaneMenuTarget(HWND hwnd,
     return ok;
 }
 
+static bool ShouldUseDesktopFolderFallback(bool targetResolved,
+                                           bool sawSelection,
+                                           bool isDesktopShellView) {
+    return !targetResolved && !sawSelection && isDesktopShellView;
+}
+
 static bool ResolveMenuTarget(HWND hwnd,
                               const Settings& settings,
                               const POINT& invocationPoint,
@@ -1396,6 +1402,7 @@ static bool ResolveMenuTarget(HWND hwnd,
     }
 
     bool ok = false;
+    bool sawSelection = false;
     IFolderView* folderView = nullptr;
     if (SUCCEEDED(shellView->QueryInterface(IID_IFolderView,
                                             reinterpret_cast<void**>(&folderView))) &&
@@ -1403,6 +1410,9 @@ static bool ResolveMenuTarget(HWND hwnd,
         int selectedCount = 0;
         bool hasSelectedCount =
             SUCCEEDED(folderView->ItemCount(SVGIO_SELECTION, &selectedCount));
+        if (hasSelectedCount && selectedCount > 0) {
+            sawSelection = true;
+        }
 
         if (hasSelectedCount && selectedCount > 1) {
             ok = false;
@@ -1417,6 +1427,12 @@ static bool ResolveMenuTarget(HWND hwnd,
         } else {
             std::vector<std::wstring> selectedPaths;
             UINT shellSelectedCount = GetSelectedPaths(shellView, selectedPaths, 2);
+            if (shellSelectedCount > 0) {
+                sawSelection = true;
+            }
+            if (!selectedPaths.empty()) {
+                sawSelection = true;
+            }
 
             if (selectedPaths.empty()) {
                 if (!hasSelectedCount && shellSelectedCount == 0) {
@@ -1450,7 +1466,8 @@ static bool ResolveMenuTarget(HWND hwnd,
         folderView->Release();
     }
 
-    if (!ok && isDesktopShellView) {
+    if (ShouldUseDesktopFolderFallback(ok, sawSelection,
+                                       isDesktopShellView)) {
         std::wstring folderPath;
         if (GetDesktopFolderPath(folderPath) && IsDirectoryPath(folderPath)) {
             targetOut.kind = TargetKind::FolderBackground;

--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -201,7 +201,8 @@ static Settings GetSettingsSnapshot();
 static void LaunchTerminalNonElevated(const MenuTarget&);
 static LaunchSpec BuildScriptLaunchSpec(const Settings&, const std::wstring&);
 static bool IsScriptExtension(const std::wstring&, const Settings&);
-static bool IsShellViewWindow(HWND hwnd);
+static HWND FindShellViewWindow(HWND hwnd);
+static HWND FindShellTabWindow(HWND hwnd);
 static bool ResolveSystemExecutablePath(PCWSTR exe, std::wstring& pathOut);
 
 static Settings g_settings;
@@ -218,10 +219,6 @@ static const UINT kMenuCommandIdNonElevated = 0xBF32;
 #define MAXIMUM_REPARSE_DATA_BUFFER_SIZE (16 * 1024)
 #endif
 
-static thread_local HWND g_currentMenuHwnd = nullptr;
-static thread_local bool g_currentMenuEligible = false;
-static thread_local MenuTarget g_currentTarget;
-
 struct MenuBitmapCacheEntry {
     std::wstring key;
     HBITMAP bitmap;
@@ -233,9 +230,6 @@ static std::vector<MenuBitmapCacheEntry> g_menuBitmapCache;
 
 using TrackPopupMenuEx_t = BOOL(WINAPI*)(HMENU, UINT, int, int, HWND, LPTPMPARAMS);
 static TrackPopupMenuEx_t TrackPopupMenuEx_Orig;
-
-using PostMessageW_t = BOOL(WINAPI*)(HWND, UINT, WPARAM, LPARAM);
-static PostMessageW_t PostMessageW_Orig;
 
 static std::wstring GetSettingString(PCWSTR name, const wchar_t* fallback) {
     std::wstring value = fallback;
@@ -760,27 +754,30 @@ static bool SplitCustomCommand(const std::wstring& command,
     return !executable.empty();
 }
 
-static void ExpandCustomPlaceholder(std::wstring& value,
-                                    const std::wstring& placeholder,
-                                    const std::wstring& target) {
-    size_t pos = 0;
-    while ((pos = value.find(placeholder, pos)) != std::wstring::npos) {
-        bool alreadyQuoted = pos > 0 &&
-                             pos + placeholder.size() < value.size() &&
-                             value[pos - 1] == L'"' &&
-                             value[pos + placeholder.size()] == L'"';
-        std::wstring replacement =
-            alreadyQuoted ? target : QuoteCommandLineArgument(target);
-        value.replace(pos, placeholder.size(), replacement);
-        pos += replacement.size();
-    }
-}
-
 static std::wstring ExpandCustomParameters(const std::wstring& parameters,
                                            const std::wstring& target) {
     std::wstring result = parameters;
-    ExpandCustomPlaceholder(result, L"%V", target);
-    ExpandCustomPlaceholder(result, L"%1", target);
+    std::wstring replacement = QuoteCommandLineArgument(target);
+    size_t searchFrom = 0;
+    while ((searchFrom = result.find(L'%', searchFrom)) != std::wstring::npos) {
+        if (searchFrom + 1 >= result.size() ||
+            (result[searchFrom + 1] != L'V' &&
+             result[searchFrom + 1] != L'1')) {
+            searchFrom++;
+            continue;
+        }
+
+        size_t replaceFrom = searchFrom;
+        size_t replaceLength = 2;
+        if (searchFrom > 0 && searchFrom + 2 < result.size() &&
+            result[searchFrom - 1] == L'"' && result[searchFrom + 2] == L'"') {
+            replaceFrom--;
+            replaceLength += 2;
+        }
+
+        result.replace(replaceFrom, replaceLength, replacement);
+        searchFrom = replaceFrom + replacement.size();
+    }
     return result;
 }
 
@@ -962,7 +959,27 @@ static LaunchSpec BuildScriptLaunchSpec(const Settings& s,
     return spec;
 }
 
-static IServiceProvider* GetExplorerServiceProviderForHwnd(HWND topLevel) {
+static bool IsExplorerContextMatch(HWND expectedShellView,
+                                   HWND expectedShellTab,
+                                   HWND candidateShellView,
+                                   HWND candidateShellTab) {
+    if (expectedShellView) {
+        return candidateShellView == expectedShellView;
+    }
+    if (expectedShellTab) {
+        return candidateShellTab == expectedShellTab;
+    }
+    return true;
+}
+
+static IServiceProvider* GetExplorerServiceProviderForHwnd(HWND hwnd) {
+    HWND topLevel = GetAncestor(hwnd, GA_ROOT);
+    if (!topLevel) {
+        topLevel = hwnd;
+    }
+    HWND expectedShellView = FindShellViewWindow(hwnd);
+    HWND expectedShellTab = FindShellTabWindow(hwnd);
+
     IShellWindows* shellWindows = nullptr;
     HRESULT hr = CoCreateInstance(CLSID_ShellWindows, nullptr, CLSCTX_ALL,
                                   IID_IShellWindows,
@@ -992,8 +1009,40 @@ static IServiceProvider* GetExplorerServiceProviderForHwnd(HWND topLevel) {
             HWND browserHwnd = nullptr;
             browser->get_HWND(reinterpret_cast<SHANDLE_PTR*>(&browserHwnd));
             if (browserHwnd == topLevel) {
+                IServiceProvider* candidate = nullptr;
                 browser->QueryInterface(IID_IServiceProvider,
-                                        reinterpret_cast<void**>(&result));
+                                        reinterpret_cast<void**>(&candidate));
+                if (candidate) {
+                    HWND candidateShellView = nullptr;
+                    HWND candidateShellTab = nullptr;
+                    IShellBrowser* shellBrowser = nullptr;
+                    if (expectedShellView || expectedShellTab) {
+                        candidate->QueryService(
+                            SID_STopLevelBrowser, IID_IShellBrowser,
+                            reinterpret_cast<void**>(&shellBrowser));
+                    }
+                    if (shellBrowser && expectedShellView) {
+                        IShellView* shellView = nullptr;
+                        if (SUCCEEDED(shellBrowser->QueryActiveShellView(
+                                &shellView)) && shellView) {
+                            shellView->GetWindow(&candidateShellView);
+                            shellView->Release();
+                        }
+                    } else if (shellBrowser && expectedShellTab) {
+                        shellBrowser->GetWindow(&candidateShellTab);
+                    }
+                    if (shellBrowser) {
+                        shellBrowser->Release();
+                    }
+
+                    if (IsExplorerContextMatch(
+                            expectedShellView, expectedShellTab,
+                            candidateShellView, candidateShellTab)) {
+                        result = candidate;
+                    } else {
+                        candidate->Release();
+                    }
+                }
             }
             browser->Release();
         }
@@ -1004,8 +1053,8 @@ static IServiceProvider* GetExplorerServiceProviderForHwnd(HWND topLevel) {
     return result;
 }
 
-static IShellBrowser* GetShellBrowserForHwnd(HWND topLevel) {
-    IServiceProvider* serviceProvider = GetExplorerServiceProviderForHwnd(topLevel);
+static IShellBrowser* GetShellBrowserForHwnd(HWND hwnd) {
+    IServiceProvider* serviceProvider = GetExplorerServiceProviderForHwnd(hwnd);
     if (!serviceProvider) {
         return nullptr;
     }
@@ -1017,8 +1066,8 @@ static IShellBrowser* GetShellBrowserForHwnd(HWND topLevel) {
     return result;
 }
 
-static IShellView* GetActiveShellViewForHwnd(HWND topLevel) {
-    IShellBrowser* shellBrowser = GetShellBrowserForHwnd(topLevel);
+static IShellView* GetActiveShellViewForHwnd(HWND hwnd) {
+    IShellBrowser* shellBrowser = GetShellBrowserForHwnd(hwnd);
     if (!shellBrowser) {
         return nullptr;
     }
@@ -1301,22 +1350,25 @@ static bool IsNavigationPaneContextWindow(HWND hwnd,
     useSelectionFallback = ShouldUseFocusedNavigationPaneFallback(
         invocationPointIsNavigationPane,
         focusedWindow && IsNavigationPaneWindow(focusedWindow),
-        IsShellViewWindow(hwnd), invocationPointIsSameExplorerFrame);
+        FindShellViewWindow(hwnd) != nullptr,
+        invocationPointIsSameExplorerFrame);
     return useSelectionFallback;
 }
 
-static bool ResolveNavigationPaneMenuTarget(HWND hwnd,
-                                            const POINT& invocationPoint,
+static bool ResolveNavigationPaneMenuTarget(const POINT& invocationPoint,
                                             bool useSelectionFallback,
                                             MenuTarget& targetOut) {
     targetOut = {};
 
-    HWND root = GetAncestor(hwnd, GA_ROOT);
-    if (!root) {
-        root = hwnd;
+    HWND navigationWindow = useSelectionFallback
+                                ? GetFocus()
+                                : WindowFromPoint(invocationPoint);
+    if (!navigationWindow || !IsNavigationPaneWindow(navigationWindow)) {
+        return false;
     }
 
-    IServiceProvider* serviceProvider = GetExplorerServiceProviderForHwnd(root);
+    IServiceProvider* serviceProvider =
+        GetExplorerServiceProviderForHwnd(navigationWindow);
     if (!serviceProvider) {
         return false;
     }
@@ -1406,20 +1458,15 @@ static bool ResolveMenuTarget(HWND hwnd,
             return false;
         }
         return ResolveNavigationPaneMenuTarget(
-            hwnd, invocationPoint, useNavigationPaneSelectionFallback, targetOut);
+            invocationPoint, useNavigationPaneSelectionFallback, targetOut);
     }
 
-    if (!IsShellViewWindow(hwnd)) {
+    if (!FindShellViewWindow(hwnd)) {
         return false;
     }
 
-    HWND root = GetAncestor(hwnd, GA_ROOT);
-    if (!root) {
-        root = hwnd;
-    }
-
     bool isDesktopShellView = IsDesktopShellViewWindow(hwnd);
-    IShellView* shellView = GetActiveShellViewForHwnd(root);
+    IShellView* shellView = GetActiveShellViewForHwnd(hwnd);
     if (!shellView && isDesktopShellView) {
         shellView = GetDesktopShellView();
     }
@@ -1506,13 +1553,13 @@ static bool ResolveMenuTarget(HWND hwnd,
     return ok;
 }
 
-static bool IsShellViewWindow(HWND hwnd) {
+static HWND FindShellViewWindow(HWND hwnd) {
     HWND w = hwnd;
     while (w) {
         WCHAR className[64] = {};
         GetClassNameW(w, className, ARRAYSIZE(className));
         if (_wcsicmp(className, L"SHELLDLL_DefView") == 0) {
-            return true;
+            return w;
         }
 
         HWND parent = GetParent(w);
@@ -1521,7 +1568,25 @@ static bool IsShellViewWindow(HWND hwnd) {
         }
         w = parent;
     }
-    return false;
+    return nullptr;
+}
+
+static HWND FindShellTabWindow(HWND hwnd) {
+    HWND w = hwnd;
+    while (w) {
+        WCHAR className[64] = {};
+        GetClassNameW(w, className, ARRAYSIZE(className));
+        if (_wcsicmp(className, L"ShellTabWindowClass") == 0) {
+            return w;
+        }
+
+        HWND parent = GetParent(w);
+        if (!parent) {
+            parent = GetWindow(w, GW_OWNER);
+        }
+        w = parent;
+    }
+    return nullptr;
 }
 
 static Settings GetSettingsSnapshot() {
@@ -1815,16 +1880,6 @@ static void ClearMenuBitmapCache() {
     ReleaseSRWLockExclusive(&g_menuBitmapLock);
 }
 
-static void ClearCurrentMenuState() {
-    g_currentMenuEligible = false;
-    g_currentTarget = {};
-    g_currentMenuHwnd = nullptr;
-}
-
-static bool ShouldClearMenuStateAfterTracking(UINT flags, BOOL result) {
-    return (flags & TPM_RETURNCMD) || !result;
-}
-
 static std::wstring GetScriptTerminalDisplayName(const Settings& settings,
                                                  const std::wstring& scriptPath) {
     if (UsesSelectedTerminalHost(settings, scriptPath)) {
@@ -2073,7 +2128,7 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
                                   HWND hwnd,
                                   LPTPMPARAMS params) {
     bool injected = false;
-    ClearCurrentMenuState();
+    MenuTarget target;
 
     HWND root = hwnd ? GetAncestor(hwnd, GA_ROOT) : nullptr;
     WCHAR rootClass[64] = {};
@@ -2081,12 +2136,11 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
         GetClassNameW(root, rootClass, ARRAYSIZE(rootClass));
     }
     bool eligibleWindow = hwnd &&
-                          (IsShellViewWindow(hwnd) ||
+                          (FindShellViewWindow(hwnd) ||
                            _wcsicmp(rootClass, L"CabinetWClass") == 0 ||
                            _wcsicmp(rootClass, L"ExploreWClass") == 0);
 
-    if (menu && eligibleWindow) {
-        MenuTarget target;
+    if (menu && eligibleWindow && (flags & TPM_RETURNCMD)) {
         Settings settings = GetSettingsSnapshot();
         POINT invocationPoint = {x, y};
         if (!ResolveMenuTarget(hwnd, settings, invocationPoint, target)) {
@@ -2107,9 +2161,6 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
             Wh_Log(L"Injection inserted: position=%ls kind=%ls",
                    settings.position.c_str(), TargetKindName(target.kind));
             injected = true;
-            g_currentMenuHwnd = hwnd;
-            g_currentMenuEligible = true;
-            g_currentTarget = std::move(target);
         }
     }
 
@@ -2117,48 +2168,17 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
 
     if (injected && (flags & TPM_RETURNCMD) &&
         static_cast<UINT>(result) == kMenuCommandId) {
-        MenuTarget target = g_currentTarget;
-        ClearCurrentMenuState();
         LaunchAdminTerminal(target);
         return 0;
     }
 
     if (injected && (flags & TPM_RETURNCMD) &&
         static_cast<UINT>(result) == kMenuCommandIdNonElevated) {
-        MenuTarget target = g_currentTarget;
-        ClearCurrentMenuState();
         LaunchTerminalNonElevated(target);
         return 0;
     }
 
-    if (ShouldClearMenuStateAfterTracking(flags, result)) {
-        ClearCurrentMenuState();
-    }
     return result;
-}
-
-BOOL WINAPI PostMessageW_Hook(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {
-    if (message == WM_COMMAND &&
-        LOWORD(wParam) == kMenuCommandId &&
-        g_currentMenuEligible &&
-        hwnd == g_currentMenuHwnd) {
-        MenuTarget target = g_currentTarget;
-        ClearCurrentMenuState();
-        LaunchAdminTerminal(target);
-        return TRUE;
-    }
-
-    if (message == WM_COMMAND &&
-        LOWORD(wParam) == kMenuCommandIdNonElevated &&
-        g_currentMenuEligible &&
-        hwnd == g_currentMenuHwnd) {
-        MenuTarget target = g_currentTarget;
-        ClearCurrentMenuState();
-        LaunchTerminalNonElevated(target);
-        return TRUE;
-    }
-
-    return PostMessageW_Orig(hwnd, message, wParam, lParam);
 }
 
 BOOL Wh_ModInit() {
@@ -2184,13 +2204,6 @@ BOOL Wh_ModInit() {
                             reinterpret_cast<void*>(TrackPopupMenuEx_Hook),
                             reinterpret_cast<void**>(&TrackPopupMenuEx_Orig))) {
         Wh_Log(L"Failed to hook TrackPopupMenuEx");
-        return FALSE;
-    }
-
-    if (!Wh_SetFunctionHook(reinterpret_cast<void*>(PostMessageW),
-                            reinterpret_cast<void*>(PostMessageW_Hook),
-                            reinterpret_cast<void**>(&PostMessageW_Orig))) {
-        Wh_Log(L"Failed to hook PostMessageW");
         return FALSE;
     }
 

--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -49,7 +49,7 @@ Screenshots may show earlier builds, but current releases use runtime classic-me
 - The entry is injected only while Explorer's classic menu is open; disabling the mod leaves no registry cleanup behind.
 - The mod intentionally targets filesystem folders and drive roots only, including optional navigation pane and Quick access support.
 - Auto chooses Windows Terminal, PowerShell 7, Windows PowerShell, then Command Prompt. If another built-in preset is unavailable, the mod falls back to Auto instead of hiding the entry.
-- Script actions use the selected terminal when it can host the required Windows interpreter. WSL, Git Bash, and custom commands fall back to PowerShell, Command Prompt, or Windows Script Host and use that actual program name in the menu.
+- Script actions use the selected terminal only when it can safely host the required interpreter. Batch scripts and keep-open Windows Script Host scripts launch through Command Prompt; menu labels show Command Prompt or Windows Script Host. WSL, Git Bash, and custom commands fall back to a compatible Windows interpreter.
 - Diagnostics use Windhawk's built-in logging controls.
 
 ## Version log
@@ -898,16 +898,24 @@ static bool IsScriptHostChoice(const std::wstring& choice) {
            choice == L"alacritty" || choice == L"conemu";
 }
 
+static bool UsesCmdWrapper(const Settings& s, PCWSTR extension) {
+    return _wcsicmp(extension, L".bat") == 0 ||
+           _wcsicmp(extension, L".cmd") == 0 ||
+           (s.keepOpenAfterScript &&
+            (_wcsicmp(extension, L".vbs") == 0 ||
+             _wcsicmp(extension, L".js") == 0));
+}
+
+static bool UsesSelectedTerminalHost(const Settings& s,
+                                     const std::wstring& scriptPath) {
+    return IsScriptHostChoice(s.terminalEffectiveChoice) &&
+           !UsesCmdWrapper(s, PathFindExtensionW(scriptPath.c_str()));
+}
+
 static LaunchSpec BuildScriptLaunchSpec(const Settings& s,
                                         const std::wstring& scriptPath) {
     LaunchSpec interpreter = BuildScriptInterpreterSpec(s, scriptPath);
-    PCWSTR ext = PathFindExtensionW(scriptPath.c_str());
-    bool usesCmdWrapper = _wcsicmp(ext, L".bat") == 0 ||
-                          _wcsicmp(ext, L".cmd") == 0 ||
-                          (s.keepOpenAfterScript &&
-                           (_wcsicmp(ext, L".vbs") == 0 ||
-                            _wcsicmp(ext, L".js") == 0));
-    if (!IsScriptHostChoice(s.terminalEffectiveChoice) || usesCmdWrapper) {
+    if (!UsesSelectedTerminalHost(s, scriptPath)) {
         return interpreter;
     }
 
@@ -1776,7 +1784,7 @@ static bool ShouldClearMenuStateAfterTracking(UINT flags, BOOL result) {
 
 static std::wstring GetScriptTerminalDisplayName(const Settings& settings,
                                                  const std::wstring& scriptPath) {
-    if (IsScriptHostChoice(settings.terminalEffectiveChoice)) {
+    if (UsesSelectedTerminalHost(settings, scriptPath)) {
         return GetTerminalDisplayName(settings);
     }
 
@@ -1798,7 +1806,7 @@ static std::wstring GetScriptTerminalDisplayName(const Settings& settings,
 
 static Settings GetScriptIconSettings(const Settings& settings,
                                       const std::wstring& scriptPath) {
-    if (IsScriptHostChoice(settings.terminalEffectiveChoice)) {
+    if (UsesSelectedTerminalHost(settings, scriptPath)) {
         return settings;
     }
 

--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -133,13 +133,13 @@ Screenshots may show earlier builds, but current releases use runtime classic-me
   $description: Add the selected terminal name to script actions. Disable for shorter labels.
 - scriptExtensions: ".ps1;.bat;.cmd;.vbs;.js"
   $name: Script extensions
-  $description: Semicolon-separated extensions treated as scripts.
+  $description: Semicolon-separated filter for supported script extensions: .ps1, .bat, .cmd, .vbs, and .js.
 - keepOpenAfterScript: true
   $name: Keep terminal open after script
   $description: Terminal stays open after script finishes.
-- scriptExecutionPolicyBypass: true
+- scriptExecutionPolicyBypass: false
   $name: Bypass execution policy for .ps1
-  $description: Adds -ExecutionPolicy Bypass for PowerShell scripts.
+  $description: Adds -ExecutionPolicy Bypass for PowerShell scripts. Disabled by default.
 */
 // ==/WindhawkModSettings==
 
@@ -572,6 +572,26 @@ static bool IsTargetEnabled(const Settings& s, TargetKind kind) {
     return false;
 }
 
+static bool ResolveSystemExecutablePath(PCWSTR exe, std::wstring& pathOut) {
+    pathOut.clear();
+
+    WCHAR systemDirectory[MAX_PATH] = {};
+    UINT length = GetSystemDirectoryW(systemDirectory, ARRAYSIZE(systemDirectory));
+    if (!length || length >= ARRAYSIZE(systemDirectory)) {
+        return false;
+    }
+
+    pathOut.assign(systemDirectory, length);
+    pathOut += L'\\';
+    pathOut += exe;
+    if (!IsFilePath(pathOut)) {
+        pathOut.clear();
+        return false;
+    }
+
+    return true;
+}
+
 static PCWSTR TargetKindName(TargetKind kind) {
     if (kind == TargetKind::FolderBackground) {
         return L"folder-background";
@@ -822,7 +842,7 @@ static LaunchSpec BuildScriptInterpreterSpec(const Settings& s,
             s.terminalEffectiveChoice == L"powershell") {
             spec.executable = s.terminalDisplayCommand;
         } else if (!ResolveTerminalChoiceExecutable(L"pwsh", spec.executable)) {
-            spec.executable = L"powershell.exe";
+            ResolveTerminalChoiceExecutable(L"powershell", spec.executable);
         }
         std::vector<std::wstring> args;
         if (s.keepOpenAfterScript) {
@@ -837,19 +857,24 @@ static LaunchSpec BuildScriptInterpreterSpec(const Settings& s,
         spec.parameters = JoinCommandLineArguments(args);
     } else if (_wcsicmp(ext, L".bat") == 0 ||
                _wcsicmp(ext, L".cmd") == 0) {
-        spec.executable = L"cmd.exe";
+        ResolveSystemExecutablePath(L"cmd.exe", spec.executable);
         spec.parameters =
             std::wstring(s.keepOpenAfterScript ? L"/k " : L"/c ") +
             QuoteCommandLineArgument(scriptPath);
     } else if (_wcsicmp(ext, L".vbs") == 0 ||
                _wcsicmp(ext, L".js") == 0) {
-        std::wstring scriptCommand =
-            L"cscript.exe //nologo " + QuoteCommandLineArgument(scriptPath);
+        std::wstring cscriptPath;
+        if (!ResolveSystemExecutablePath(L"cscript.exe", cscriptPath)) {
+            return spec;
+        }
         if (s.keepOpenAfterScript) {
-            spec.executable = L"cmd.exe";
-            spec.parameters = L"/k " + scriptCommand;
+            if (!ResolveSystemExecutablePath(L"cmd.exe", spec.executable)) {
+                return {};
+            }
+            spec.parameters = L"/k " + QuoteCommandLineArgument(cscriptPath) +
+                              L" //nologo " + QuoteCommandLineArgument(scriptPath);
         } else {
-            spec.executable = L"cscript.exe";
+            spec.executable = std::move(cscriptPath);
             spec.parameters = L"//nologo " + QuoteCommandLineArgument(scriptPath);
         }
     }
@@ -1169,28 +1194,6 @@ static bool GetFilesystemPathFromShellItem(IShellItem* item,
     return ok;
 }
 
-static bool GetSingleFilesystemPathFromShellItemArray(IShellItemArray* items,
-                                                       std::wstring& pathOut) {
-    pathOut.clear();
-    if (!items) {
-        return false;
-    }
-
-    DWORD count = 0;
-    if (FAILED(items->GetCount(&count)) || count != 1) {
-        return false;
-    }
-
-    IShellItem* item = nullptr;
-    if (FAILED(items->GetItemAt(0, &item)) || !item) {
-        return false;
-    }
-
-    bool ok = GetFilesystemPathFromShellItem(item, pathOut);
-    item->Release();
-    return ok;
-}
-
 static bool IsNavigationPaneWindow(HWND hwnd) {
     bool sawNavigationTreeClass = false;
     HWND w = hwnd;
@@ -1216,28 +1219,14 @@ static bool IsNavigationPaneWindow(HWND hwnd) {
     return false;
 }
 
-static bool IsNavigationPaneContextWindow(HWND hwnd) {
-    if (IsNavigationPaneWindow(hwnd)) {
-        return true;
-    }
-
-    HWND focus = GetFocus();
-    if (focus && IsNavigationPaneWindow(focus)) {
-        return true;
-    }
-
-    POINT cursorPos;
-    if (GetCursorPos(&cursorPos)) {
-        HWND underCursor = WindowFromPoint(cursorPos);
-        if (underCursor && IsNavigationPaneWindow(underCursor)) {
-            return true;
-        }
-    }
-
-    return false;
+static bool IsNavigationPaneContextWindow(const POINT& invocationPoint) {
+    HWND invocationWindow = WindowFromPoint(invocationPoint);
+    return invocationWindow && IsNavigationPaneWindow(invocationWindow);
 }
 
-static bool ResolveNavigationPaneMenuTarget(HWND hwnd, MenuTarget& targetOut) {
+static bool ResolveNavigationPaneMenuTarget(HWND hwnd,
+                                            const POINT& invocationPoint,
+                                            MenuTarget& targetOut) {
     targetOut = {};
 
     HWND root = GetAncestor(hwnd, GA_ROOT);
@@ -1266,11 +1255,10 @@ static bool ResolveNavigationPaneMenuTarget(HWND hwnd, MenuTarget& targetOut) {
             shellBrowser->Release();
         }
 
-        POINT cursorPos;
-        if (treeWindow && GetCursorPos(&cursorPos) &&
-            ScreenToClient(treeWindow, &cursorPos)) {
+        POINT clientPoint = invocationPoint;
+        if (treeWindow && ScreenToClient(treeWindow, &clientPoint)) {
             IShellItem* hitItem = nullptr;
-            if (SUCCEEDED(navigationPane->HitTest(&cursorPos, &hitItem)) &&
+            if (SUCCEEDED(navigationPane->HitTest(&clientPoint, &hitItem)) &&
                 hitItem) {
                 std::wstring path;
                 if (GetFilesystemPathFromShellItem(hitItem, path) &&
@@ -1285,23 +1273,6 @@ static bool ResolveNavigationPaneMenuTarget(HWND hwnd, MenuTarget& targetOut) {
             }
         }
 
-        if (!ok && IsNavigationPaneContextWindow(hwnd)) {
-            IShellItemArray* selectedItems = nullptr;
-            if (SUCCEEDED(navigationPane->GetSelectedItems(&selectedItems)) &&
-                selectedItems) {
-                std::wstring path;
-                if (GetSingleFilesystemPathFromShellItemArray(selectedItems,
-                                                               path) &&
-                    IsDirectoryPath(path)) {
-                    targetOut.path = std::move(path);
-                    targetOut.kind = IsDriveRootPath(targetOut.path)
-                                         ? TargetKind::DriveItem
-                                         : TargetKind::FolderItem;
-                    ok = true;
-                }
-                selectedItems->Release();
-            }
-        }
         navigationPane->Release();
     }
 
@@ -1310,21 +1281,17 @@ static bool ResolveNavigationPaneMenuTarget(HWND hwnd, MenuTarget& targetOut) {
 }
 
 static bool ResolveMenuTarget(HWND hwnd,
-                              bool allowNavigationPane,
+                              const Settings& settings,
+                              const POINT& invocationPoint,
                               MenuTarget& targetOut) {
     targetOut = {};
 
-    bool isNavigationPane = IsNavigationPaneContextWindow(hwnd);
+    bool isNavigationPane = IsNavigationPaneContextWindow(invocationPoint);
     if (isNavigationPane) {
-        if (!allowNavigationPane) {
+        if (!settings.showOnNavigationPane) {
             return false;
         }
-        return ResolveNavigationPaneMenuTarget(hwnd, targetOut);
-    }
-
-    if (allowNavigationPane &&
-        ResolveNavigationPaneMenuTarget(hwnd, targetOut)) {
-        return true;
+        return ResolveNavigationPaneMenuTarget(hwnd, invocationPoint, targetOut);
     }
 
     if (!IsShellViewWindow(hwnd)) {
@@ -1388,9 +1355,8 @@ static bool ResolveMenuTarget(HWND hwnd,
                 ok = true;
             } else if (selectedPaths.size() == 1 &&
                        IsFilePath(selectedPaths[0])) {
-                Settings snap = GetSettingsSnapshot();
-                if (snap.showOnScriptFiles &&
-                    IsScriptExtension(selectedPaths[0], snap)) {
+                if (settings.showOnScriptFiles &&
+                    IsScriptExtension(selectedPaths[0], settings)) {
                     targetOut.path = selectedPaths[0];
                     targetOut.kind = TargetKind::ScriptItem;
                     ok = true;
@@ -1735,17 +1701,20 @@ static std::wstring GetScriptTerminalDisplayName(const Settings& settings,
         return GetTerminalDisplayName(settings);
     }
 
-    LaunchSpec interpreter = BuildScriptInterpreterSpec(settings, scriptPath);
-    if (StrStrIW(interpreter.executable.c_str(), L"pwsh")) {
-        return L"PowerShell 7";
-    }
-    if (StrStrIW(interpreter.executable.c_str(), L"powershell")) {
-        return L"Windows PowerShell";
-    }
-    if (StrStrIW(interpreter.executable.c_str(), L"cmd")) {
+    PCWSTR extension = PathFindExtensionW(scriptPath.c_str());
+    if (_wcsicmp(extension, L".bat") == 0 ||
+        _wcsicmp(extension, L".cmd") == 0) {
         return L"Command Prompt";
     }
-    return L"Windows Script Host";
+    if (_wcsicmp(extension, L".vbs") == 0 ||
+        _wcsicmp(extension, L".js") == 0) {
+        return L"Windows Script Host";
+    }
+
+    LaunchSpec interpreter = BuildScriptInterpreterSpec(settings, scriptPath);
+    PCWSTR executableName = PathFindFileNameW(interpreter.executable.c_str());
+    return _wcsicmp(executableName, L"pwsh.exe") == 0 ? L"PowerShell 7"
+                                                       : L"Windows PowerShell";
 }
 
 static Settings GetScriptIconSettings(const Settings& settings,
@@ -1888,6 +1857,11 @@ static void LaunchAdminTerminal(const MenuTarget& target) {
     LaunchSpec launch = (target.kind == TargetKind::ScriptItem)
                             ? BuildScriptLaunchSpec(settings, target.path)
                             : BuildLaunchSpec(settings, target.path);
+    if (launch.executable.empty()) {
+        Wh_Log(L"Launch failed: no executable resolved target=%ls",
+               target.path.c_str());
+        return;
+    }
 
     SHELLEXECUTEINFOW executeInfo = {};
     executeInfo.cbSize = sizeof(executeInfo);
@@ -1925,6 +1899,11 @@ static void LaunchTerminalNonElevated(const MenuTarget& target) {
     LaunchSpec launch = (target.kind == TargetKind::ScriptItem)
                             ? BuildScriptLaunchSpec(settings, target.path)
                             : BuildLaunchSpec(settings, target.path);
+    if (launch.executable.empty()) {
+        Wh_Log(L"Launch failed: no executable resolved target=%ls",
+               target.path.c_str());
+        return;
+    }
 
     SHELLEXECUTEINFOW executeInfo = {};
     executeInfo.cbSize = sizeof(executeInfo);
@@ -1966,10 +1945,21 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
     bool injected = false;
     ClearCurrentMenuState();
 
-    if (menu && hwnd) {
+    HWND root = hwnd ? GetAncestor(hwnd, GA_ROOT) : nullptr;
+    WCHAR rootClass[64] = {};
+    if (root) {
+        GetClassNameW(root, rootClass, ARRAYSIZE(rootClass));
+    }
+    bool eligibleWindow = hwnd &&
+                          (IsShellViewWindow(hwnd) ||
+                           _wcsicmp(rootClass, L"CabinetWClass") == 0 ||
+                           _wcsicmp(rootClass, L"ExploreWClass") == 0);
+
+    if (menu && eligibleWindow) {
         MenuTarget target;
         Settings settings = GetSettingsSnapshot();
-        if (!ResolveMenuTarget(hwnd, settings.showOnNavigationPane, target)) {
+        POINT invocationPoint = {x, y};
+        if (!ResolveMenuTarget(hwnd, settings, invocationPoint, target)) {
             Wh_Log(L"Injection skipped: no eligible filesystem directory target");
         } else if (!IsTargetEnabled(settings, target.kind)) {
             Wh_Log(L"Injection skipped: target kind disabled kind=%ls path=%ls",
@@ -2011,6 +2001,7 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
         return 0;
     }
 
+    ClearCurrentMenuState();
     return result;
 }
 

--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -2,7 +2,7 @@
 // @id              open-in-admin-terminal
 // @name            Open in Admin Terminal
 // @description     Adds an Explorer classic context menu entry to open an elevated terminal in the current or selected folder.
-// @version         1.16
+// @version         1.17.1
 // @author          aimagist
 // @github          https://github.com/aimagist
 // @include         explorer.exe
@@ -21,10 +21,13 @@
 - Right-click a folder background and open an admin terminal in that location
 - Right-click a folder item and open an admin terminal inside it
 - Right-click a drive and open an admin terminal at its root
+- Optionally add a second terminal entry that opens without administrator privileges
+- Optionally run `.ps1`, `.bat`, `.cmd`, `.vbs`, and `.js` script files normally, as administrator, or both
 - Optionally show the entry when right-clicking filesystem folders and drives in the navigation pane and Quick access
 - Choose your preferred terminal: Auto, Windows Terminal, PowerShell 7, Windows PowerShell, Command Prompt, WSL, Git Bash, WezTerm, Alacritty, ConEmu, or a custom command
 - Customize the context menu label, or let the mod use a smart default based on your terminal choice
 - Optionally append the terminal name to a custom label (e.g. "Open elevated (Windows Terminal)")
+- Choose whether script entries include the terminal name or use shorter labels
 
 ## Preview
 
@@ -46,9 +49,12 @@ Screenshots may show earlier builds, but current releases use runtime classic-me
 - The entry is injected only while Explorer's classic menu is open; disabling the mod leaves no registry cleanup behind.
 - The mod intentionally targets filesystem folders and drive roots only, including optional navigation pane and Quick access support.
 - Auto chooses Windows Terminal, PowerShell 7, Windows PowerShell, then Command Prompt. If another built-in preset is unavailable, the mod falls back to Auto instead of hiding the entry.
+- Script actions use the selected terminal when it can host the required Windows interpreter. WSL, Git Bash, and custom commands fall back to PowerShell, Command Prompt, or Windows Script Host and use that actual program name in the menu.
 - Diagnostics use Windhawk's built-in logging controls.
 
 ## Version log
+- 1.17.1: Fix navigation pane menu not appearing: the entry was missing when right-clicking folders or drives in File Explorer’s left sidebar and Quick access. Now it works :)
+- 1.17: Added optional non-elevated terminal entries, configurable normal/elevated script actions (.ps1/.bat/.cmd/.vbs/.js), and shorter script labels. The two extra entry features are opt-in and disabled by default; terminal names remain shown in script entries by default for compatibility.
 - 1.16: Added native UAC shield overlay composition on the terminal menu icon using `SHGetStockIconInfo(SIID_SHIELD)`.
 - 1.15: Added optional navigation pane and Quick access support for filesystem folders and drives.
 - 1.14: Added support for Desktop context menu targets.
@@ -106,6 +112,34 @@ Screenshots may show earlier builds, but current releases use runtime classic-me
 - appendTerminalName: false
   $name: Append terminal name
   $description: When Menu text is set, append the selected terminal name in parentheses.
+- showNonElevatedEntry: false
+  $name: Show non-elevated entry
+  $description: Add a second context menu entry to open a terminal without admin privileges.
+- nonElevatedMenuText: ""
+  $name: Non-elevated menu text
+  $description: Leave empty for auto label based on terminal name.
+- showOnScriptFiles: false
+  $name: Show on script files
+  $description: Add context menu entries when right-clicking supported script files.
+- scriptMenuEntries: admin
+  $name: Script menu entries
+  $description: Choose which actions to show for script files.
+  $options:
+    - admin: Run as administrator
+    - normal: Run normally
+    - both: Show both
+- appendScriptTerminalName: true
+  $name: Append terminal name to script entries
+  $description: Add the selected terminal name to script actions. Disable for shorter labels.
+- scriptExtensions: ".ps1;.bat;.cmd;.vbs;.js"
+  $name: Script extensions
+  $description: Semicolon-separated extensions treated as scripts.
+- keepOpenAfterScript: true
+  $name: Keep terminal open after script
+  $description: Terminal stays open after script finishes.
+- scriptExecutionPolicyBypass: true
+  $name: Bypass execution policy for .ps1
+  $description: Adds -ExecutionPolicy Bypass for PowerShell scripts.
 */
 // ==/WindhawkModSettings==
 
@@ -134,6 +168,14 @@ struct Settings {
     bool showOnDriveItem;
     bool showOnNavigationPane;
     std::wstring position;
+    bool showNonElevatedEntry;
+    std::wstring nonElevatedMenuText;
+    bool showOnScriptFiles;
+    std::wstring scriptMenuEntries;
+    bool appendScriptTerminalName;
+    std::wstring scriptExtensions;
+    bool keepOpenAfterScript;
+    bool scriptExecutionPolicyBypass;
 };
 
 enum class TargetKind {
@@ -141,6 +183,7 @@ enum class TargetKind {
     FolderBackground,
     FolderItem,
     DriveItem,
+    ScriptItem,
 };
 
 struct MenuTarget {
@@ -154,10 +197,17 @@ struct LaunchSpec {
     std::wstring workingDirectory;
 };
 
+static Settings GetSettingsSnapshot();
+static void LaunchTerminalNonElevated(const MenuTarget&);
+static LaunchSpec BuildScriptLaunchSpec(const Settings&, const std::wstring&);
+static bool IsScriptExtension(const std::wstring&, const Settings&);
+static bool IsShellViewWindow(HWND hwnd);
+
 static Settings g_settings;
 static SRWLOCK g_settingsLock = SRWLOCK_INIT;
 
 static const UINT kMenuCommandId = 0xBF31;
+static const UINT kMenuCommandIdNonElevated = 0xBF32;
 
 #ifndef IO_REPARSE_TAG_APPEXECLINK
 #define IO_REPARSE_TAG_APPEXECLINK (0x8000001BL)
@@ -486,6 +536,14 @@ static Settings LoadSettings() {
     s.showOnDriveItem = GetSettingBool(L"showOnDriveItem");
     s.showOnNavigationPane = GetSettingBool(L"showOnNavigationPane");
     s.position = GetSettingString(L"position", L"Top");
+    s.showNonElevatedEntry = GetSettingBool(L"showNonElevatedEntry");
+    s.nonElevatedMenuText = GetSettingString(L"nonElevatedMenuText", L"");
+    s.showOnScriptFiles = GetSettingBool(L"showOnScriptFiles");
+    s.scriptMenuEntries = GetSettingString(L"scriptMenuEntries", L"admin");
+    s.appendScriptTerminalName = GetSettingBool(L"appendScriptTerminalName");
+    s.scriptExtensions = GetSettingString(L"scriptExtensions", L".ps1;.bat;.cmd;.vbs;.js");
+    s.keepOpenAfterScript = GetSettingBool(L"keepOpenAfterScript");
+    s.scriptExecutionPolicyBypass = GetSettingBool(L"scriptExecutionPolicyBypass");
 
     ResolveSettingsTerminal(s);
 
@@ -508,6 +566,9 @@ static bool IsTargetEnabled(const Settings& s, TargetKind kind) {
     if (kind == TargetKind::DriveItem) {
         return s.showOnDriveItem;
     }
+    if (kind == TargetKind::ScriptItem) {
+        return s.showOnScriptFiles;
+    }
     return false;
 }
 
@@ -521,12 +582,42 @@ static PCWSTR TargetKindName(TargetKind kind) {
     if (kind == TargetKind::DriveItem) {
         return L"drive-item";
     }
+    if (kind == TargetKind::ScriptItem) {
+        return L"script-item";
+    }
     return L"none";
 }
 
 static bool IsDirectoryPath(const std::wstring& path) {
     DWORD attrs = GetFileAttributesW(path.c_str());
     return attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+static bool IsScriptExtension(const std::wstring& path, const Settings& s) {
+    PCWSTR ext = PathFindExtensionW(path.c_str());
+    if (!ext || !*ext) {
+        return false;
+    }
+
+    if (_wcsicmp(ext, L".ps1") != 0 && _wcsicmp(ext, L".bat") != 0 &&
+        _wcsicmp(ext, L".cmd") != 0 && _wcsicmp(ext, L".vbs") != 0 &&
+        _wcsicmp(ext, L".js") != 0) {
+        return false;
+    }
+
+    size_t start = 0;
+    while (start <= s.scriptExtensions.size()) {
+        size_t end = s.scriptExtensions.find(L';', start);
+        std::wstring token = TrimString(s.scriptExtensions.substr(start, end - start));
+        if (_wcsicmp(token.c_str(), ext) == 0) {
+            return true;
+        }
+        if (end == std::wstring::npos) {
+            break;
+        }
+        start = end + 1;
+    }
+    return false;
 }
 
 static bool IsDriveRootPath(const std::wstring& path) {
@@ -713,6 +804,93 @@ static LaunchSpec BuildLaunchSpec(const Settings& s, const std::wstring& target)
         return spec;
     }
 
+    return spec;
+}
+
+static LaunchSpec BuildScriptInterpreterSpec(const Settings& s,
+                                             const std::wstring& scriptPath) {
+    LaunchSpec spec;
+    PCWSTR ext = PathFindExtensionW(scriptPath.c_str());
+    size_t separator = scriptPath.find_last_of(L"\\/");
+    spec.workingDirectory = scriptPath.substr(
+        0, separator == 2 && scriptPath.size() > 2 && scriptPath[1] == L':'
+               ? separator + 1
+               : separator);
+
+    if (_wcsicmp(ext, L".ps1") == 0) {
+        if (s.terminalEffectiveChoice == L"pwsh" ||
+            s.terminalEffectiveChoice == L"powershell") {
+            spec.executable = s.terminalDisplayCommand;
+        } else if (!ResolveTerminalChoiceExecutable(L"pwsh", spec.executable)) {
+            spec.executable = L"powershell.exe";
+        }
+        std::vector<std::wstring> args;
+        if (s.keepOpenAfterScript) {
+            args.push_back(L"-NoExit");
+        }
+        if (s.scriptExecutionPolicyBypass) {
+            args.push_back(L"-ExecutionPolicy");
+            args.push_back(L"Bypass");
+        }
+        args.push_back(L"-File");
+        args.push_back(scriptPath);
+        spec.parameters = JoinCommandLineArguments(args);
+    } else if (_wcsicmp(ext, L".bat") == 0 ||
+               _wcsicmp(ext, L".cmd") == 0) {
+        spec.executable = L"cmd.exe";
+        spec.parameters =
+            std::wstring(s.keepOpenAfterScript ? L"/k " : L"/c ") +
+            QuoteCommandLineArgument(scriptPath);
+    } else if (_wcsicmp(ext, L".vbs") == 0 ||
+               _wcsicmp(ext, L".js") == 0) {
+        std::wstring scriptCommand =
+            L"cscript.exe //nologo " + QuoteCommandLineArgument(scriptPath);
+        if (s.keepOpenAfterScript) {
+            spec.executable = L"cmd.exe";
+            spec.parameters = L"/k " + scriptCommand;
+        } else {
+            spec.executable = L"cscript.exe";
+            spec.parameters = L"//nologo " + QuoteCommandLineArgument(scriptPath);
+        }
+    }
+    return spec;
+}
+
+static bool IsScriptHostChoice(const std::wstring& choice) {
+    return choice == L"wt" || choice == L"wezterm" ||
+           choice == L"alacritty" || choice == L"conemu";
+}
+
+static LaunchSpec BuildScriptLaunchSpec(const Settings& s,
+                                        const std::wstring& scriptPath) {
+    LaunchSpec interpreter = BuildScriptInterpreterSpec(s, scriptPath);
+    if (!IsScriptHostChoice(s.terminalEffectiveChoice)) {
+        return interpreter;
+    }
+
+    LaunchSpec spec;
+    spec.executable = s.terminalDisplayCommand;
+    spec.workingDirectory = interpreter.workingDirectory;
+    std::vector<std::wstring> args;
+
+    if (s.terminalEffectiveChoice == L"wt") {
+        args = {L"new-tab", L"-d", interpreter.workingDirectory,
+                interpreter.executable};
+    } else if (s.terminalEffectiveChoice == L"wezterm") {
+        args = {L"start", L"--cwd", interpreter.workingDirectory, L"--",
+                interpreter.executable};
+    } else if (s.terminalEffectiveChoice == L"alacritty") {
+        args = {L"--working-directory", interpreter.workingDirectory, L"-e",
+                interpreter.executable};
+    } else {
+        args = {L"-Dir", interpreter.workingDirectory, L"-run",
+                interpreter.executable};
+    }
+
+    spec.parameters = JoinCommandLineArguments(args);
+    if (!interpreter.parameters.empty()) {
+        spec.parameters += L" " + interpreter.parameters;
+    }
     return spec;
 }
 
@@ -972,6 +1150,25 @@ static UINT GetSelectedPaths(IShellView* shellView,
     return selectedCount;
 }
 
+static bool GetFilesystemPathFromShellItem(IShellItem* item,
+                                           std::wstring& pathOut) {
+    pathOut.clear();
+    if (!item) {
+        return false;
+    }
+
+    PWSTR path = nullptr;
+    bool ok = SUCCEEDED(item->GetDisplayName(SIGDN_FILESYSPATH, &path)) &&
+              path && path[0];
+    if (ok) {
+        pathOut = path;
+    }
+    if (path) {
+        CoTaskMemFree(path);
+    }
+    return ok;
+}
+
 static bool GetSingleFilesystemPathFromShellItemArray(IShellItemArray* items,
                                                        std::wstring& pathOut) {
     pathOut.clear();
@@ -989,16 +1186,7 @@ static bool GetSingleFilesystemPathFromShellItemArray(IShellItemArray* items,
         return false;
     }
 
-    PWSTR path = nullptr;
-    bool ok = SUCCEEDED(item->GetDisplayName(SIGDN_FILESYSPATH, &path)) && path &&
-              path[0];
-    if (ok) {
-        pathOut = path;
-    }
-    if (path) {
-        CoTaskMemFree(path);
-    }
-
+    bool ok = GetFilesystemPathFromShellItem(item, pathOut);
     item->Release();
     return ok;
 }
@@ -1028,6 +1216,27 @@ static bool IsNavigationPaneWindow(HWND hwnd) {
     return false;
 }
 
+static bool IsNavigationPaneContextWindow(HWND hwnd) {
+    if (IsNavigationPaneWindow(hwnd)) {
+        return true;
+    }
+
+    HWND focus = GetFocus();
+    if (focus && IsNavigationPaneWindow(focus)) {
+        return true;
+    }
+
+    POINT cursorPos;
+    if (GetCursorPos(&cursorPos)) {
+        HWND underCursor = WindowFromPoint(cursorPos);
+        if (underCursor && IsNavigationPaneWindow(underCursor)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static bool ResolveNavigationPaneMenuTarget(HWND hwnd, MenuTarget& targetOut) {
     targetOut = {};
 
@@ -1047,19 +1256,51 @@ static bool ResolveNavigationPaneMenuTarget(HWND hwnd, MenuTarget& targetOut) {
             SID_SNavigationPane, IID_INameSpaceTreeControl,
             reinterpret_cast<void**>(&navigationPane))) &&
         navigationPane) {
-        IShellItemArray* selectedItems = nullptr;
-        if (SUCCEEDED(navigationPane->GetSelectedItems(&selectedItems)) &&
-            selectedItems) {
-            std::wstring path;
-            if (GetSingleFilesystemPathFromShellItemArray(selectedItems, path) &&
-                IsDirectoryPath(path)) {
-                targetOut.path = std::move(path);
-                targetOut.kind = IsDriveRootPath(targetOut.path)
-                                     ? TargetKind::DriveItem
-                                     : TargetKind::FolderItem;
-                ok = true;
+        IShellBrowser* shellBrowser = nullptr;
+        HWND treeWindow = nullptr;
+        if (SUCCEEDED(serviceProvider->QueryService(
+                SID_STopLevelBrowser, IID_IShellBrowser,
+                reinterpret_cast<void**>(&shellBrowser))) &&
+            shellBrowser) {
+            shellBrowser->GetControlWindow(FCW_TREE, &treeWindow);
+            shellBrowser->Release();
+        }
+
+        POINT cursorPos;
+        if (treeWindow && GetCursorPos(&cursorPos) &&
+            ScreenToClient(treeWindow, &cursorPos)) {
+            IShellItem* hitItem = nullptr;
+            if (SUCCEEDED(navigationPane->HitTest(&cursorPos, &hitItem)) &&
+                hitItem) {
+                std::wstring path;
+                if (GetFilesystemPathFromShellItem(hitItem, path) &&
+                    IsDirectoryPath(path)) {
+                    targetOut.path = std::move(path);
+                    targetOut.kind = IsDriveRootPath(targetOut.path)
+                                         ? TargetKind::DriveItem
+                                         : TargetKind::FolderItem;
+                    ok = true;
+                }
+                hitItem->Release();
             }
-            selectedItems->Release();
+        }
+
+        if (!ok && IsNavigationPaneContextWindow(hwnd)) {
+            IShellItemArray* selectedItems = nullptr;
+            if (SUCCEEDED(navigationPane->GetSelectedItems(&selectedItems)) &&
+                selectedItems) {
+                std::wstring path;
+                if (GetSingleFilesystemPathFromShellItemArray(selectedItems,
+                                                               path) &&
+                    IsDirectoryPath(path)) {
+                    targetOut.path = std::move(path);
+                    targetOut.kind = IsDriveRootPath(targetOut.path)
+                                         ? TargetKind::DriveItem
+                                         : TargetKind::FolderItem;
+                    ok = true;
+                }
+                selectedItems->Release();
+            }
         }
         navigationPane->Release();
     }
@@ -1073,12 +1314,21 @@ static bool ResolveMenuTarget(HWND hwnd,
                               MenuTarget& targetOut) {
     targetOut = {};
 
-    bool isNavigationPane = IsNavigationPaneWindow(hwnd);
+    bool isNavigationPane = IsNavigationPaneContextWindow(hwnd);
     if (isNavigationPane) {
         if (!allowNavigationPane) {
             return false;
         }
         return ResolveNavigationPaneMenuTarget(hwnd, targetOut);
+    }
+
+    if (allowNavigationPane &&
+        ResolveNavigationPaneMenuTarget(hwnd, targetOut)) {
+        return true;
+    }
+
+    if (!IsShellViewWindow(hwnd)) {
+        return false;
     }
 
     HWND root = GetAncestor(hwnd, GA_ROOT);
@@ -1136,6 +1386,15 @@ static bool ResolveMenuTarget(HWND hwnd,
                 targetOut.kind = IsDriveRootPath(targetOut.path) ? TargetKind::DriveItem
                                                                  : TargetKind::FolderItem;
                 ok = true;
+            } else if (selectedPaths.size() == 1 &&
+                       IsFilePath(selectedPaths[0])) {
+                Settings snap = GetSettingsSnapshot();
+                if (snap.showOnScriptFiles &&
+                    IsScriptExtension(selectedPaths[0], snap)) {
+                    targetOut.path = selectedPaths[0];
+                    targetOut.kind = TargetKind::ScriptItem;
+                    ok = true;
+                }
             }
         }
 
@@ -1408,6 +1667,51 @@ static HBITMAP GetCachedMenuBitmapForTerminal(const Settings& settings) {
     return bitmap;
 }
 
+static HBITMAP GetCachedMenuBitmapNoShield(const Settings& settings) {
+    std::wstring key = GetMenuBitmapCacheKey(settings) + L"\nno-shield";
+
+    AcquireSRWLockShared(&g_menuBitmapLock);
+    for (const auto& entry : g_menuBitmapCache) {
+        if (entry.key == key) {
+            HBITMAP bitmap = entry.bitmap;
+            ReleaseSRWLockShared(&g_menuBitmapLock);
+            return bitmap;
+        }
+    }
+    ReleaseSRWLockShared(&g_menuBitmapLock);
+
+    std::wstring exePath;
+    HBITMAP bitmap = nullptr;
+    if (ResolveExecutablePathForIcon(settings, exePath)) {
+        SHFILEINFOW shfi = {};
+        if (SHGetFileInfoW(exePath.c_str(), FILE_ATTRIBUTE_NORMAL, &shfi,
+                           sizeof(shfi),
+                           SHGFI_ICON | SHGFI_SMALLICON |
+                               SHGFI_USEFILEATTRIBUTES)) {
+            bitmap = CreateMenuBitmapFromIcon(shfi.hIcon, nullptr);
+            if (shfi.hIcon) {
+                DestroyIcon(shfi.hIcon);
+            }
+        }
+    }
+
+    AcquireSRWLockExclusive(&g_menuBitmapLock);
+    for (const auto& entry : g_menuBitmapCache) {
+        if (entry.key == key) {
+            if (bitmap) {
+                DeleteObject(bitmap);
+            }
+            bitmap = entry.bitmap;
+            ReleaseSRWLockExclusive(&g_menuBitmapLock);
+            return bitmap;
+        }
+    }
+    g_menuBitmapCache.push_back({std::move(key), bitmap});
+    ReleaseSRWLockExclusive(&g_menuBitmapLock);
+
+    return bitmap;
+}
+
 static void ClearMenuBitmapCache() {
     AcquireSRWLockExclusive(&g_menuBitmapLock);
     for (const auto& entry : g_menuBitmapCache) {
@@ -1425,7 +1729,40 @@ static void ClearCurrentMenuState() {
     g_currentMenuHwnd = nullptr;
 }
 
-static void InsertAdminTerminalMenuItem(HMENU menu, const Settings& settings) {
+static std::wstring GetScriptTerminalDisplayName(const Settings& settings,
+                                                 const std::wstring& scriptPath) {
+    if (IsScriptHostChoice(settings.terminalEffectiveChoice)) {
+        return GetTerminalDisplayName(settings);
+    }
+
+    LaunchSpec interpreter = BuildScriptInterpreterSpec(settings, scriptPath);
+    if (StrStrIW(interpreter.executable.c_str(), L"pwsh")) {
+        return L"PowerShell 7";
+    }
+    if (StrStrIW(interpreter.executable.c_str(), L"powershell")) {
+        return L"Windows PowerShell";
+    }
+    if (StrStrIW(interpreter.executable.c_str(), L"cmd")) {
+        return L"Command Prompt";
+    }
+    return L"Windows Script Host";
+}
+
+static Settings GetScriptIconSettings(const Settings& settings,
+                                      const std::wstring& scriptPath) {
+    if (IsScriptHostChoice(settings.terminalEffectiveChoice)) {
+        return settings;
+    }
+
+    Settings iconSettings = settings;
+    LaunchSpec interpreter = BuildScriptInterpreterSpec(settings, scriptPath);
+    iconSettings.terminalEffectiveChoice.clear();
+    iconSettings.terminalDisplayCommand = interpreter.executable;
+    return iconSettings;
+}
+
+static void InsertAdminTerminalMenuItem(HMENU menu, const Settings& settings,
+                                        const MenuTarget& target) {
     int itemCount = GetMenuItemCount(menu);
     int insertPos = 0;
     bool separatorAbove = false;
@@ -1457,40 +1794,142 @@ static void InsertAdminTerminalMenuItem(HMENU menu, const Settings& settings) {
         insertPos = 0;
     }
 
-    if (separatorAbove) {
-        InsertMenuW(menu, insertPos, MF_BYPOSITION | MF_SEPARATOR, 0, nullptr);
-        InsertMenuW(menu, insertPos + 1, MF_BYPOSITION | MF_STRING, kMenuCommandId,
-                    settings.menuText.c_str());
+    bool isScript = target.kind == TargetKind::ScriptItem;
+    bool showAdmin = !isScript || settings.scriptMenuEntries != L"normal";
+    bool showNormal = isScript
+                          ? settings.scriptMenuEntries == L"normal" ||
+                                settings.scriptMenuEntries == L"both"
+                          : settings.showNonElevatedEntry;
+    Settings iconSettings = isScript
+                                ? GetScriptIconSettings(settings, target.path)
+                                : settings;
+    std::wstring displayName = isScript
+                                   ? GetScriptTerminalDisplayName(settings, target.path)
+                                   : GetTerminalDisplayName(settings);
+    std::wstring adminLabel;
+    if (isScript) {
+        adminLabel = L"Run script";
+        if (settings.appendScriptTerminalName) {
+            adminLabel += L" in " + displayName;
+        }
+        adminLabel += L" as administrator";
     } else {
-        InsertMenuW(menu, insertPos, MF_BYPOSITION | MF_STRING, kMenuCommandId,
-                    settings.menuText.c_str());
-        InsertMenuW(menu, insertPos + 1, MF_BYPOSITION | MF_SEPARATOR, 0, nullptr);
+        adminLabel = settings.menuText;
     }
-
-    HBITMAP menuBitmap = GetCachedMenuBitmapForTerminal(settings);
-    if (menuBitmap) {
-        MENUITEMINFOW itemInfo = {};
-        itemInfo.cbSize = sizeof(itemInfo);
-        itemInfo.fMask = MIIM_BITMAP;
-        itemInfo.hbmpItem = menuBitmap;
-        if (!SetMenuItemInfoW(menu, kMenuCommandId, FALSE, &itemInfo)) {
-            Wh_Log(L"Menu icon assignment failed");
-        } else {
-            Wh_Log(L"Menu icon assigned");
+    std::wstring normalLabel;
+    if (isScript) {
+        normalLabel = L"Run script";
+        if (settings.appendScriptTerminalName) {
+            normalLabel += L" in " + displayName;
         }
     } else {
-        Wh_Log(L"Menu icon unavailable");
+        normalLabel = settings.nonElevatedMenuText;
+        if (normalLabel.empty()) {
+            normalLabel = L"Open " + displayName + L" here";
+        }
+    }
+
+    int actionPos = insertPos;
+    if (separatorAbove) {
+        InsertMenuW(menu, insertPos, MF_BYPOSITION | MF_SEPARATOR, 0, nullptr);
+        actionPos++;
+    }
+
+    if (showAdmin) {
+        InsertMenuW(menu, actionPos++, MF_BYPOSITION | MF_STRING, kMenuCommandId,
+                    adminLabel.c_str());
+    }
+    if (showNormal) {
+        InsertMenuW(menu, actionPos++, MF_BYPOSITION | MF_STRING,
+                    kMenuCommandIdNonElevated, normalLabel.c_str());
+    }
+    if (!separatorAbove) {
+        InsertMenuW(menu, actionPos, MF_BYPOSITION | MF_SEPARATOR, 0, nullptr);
+    }
+
+    if (showAdmin) {
+        HBITMAP menuBitmap = GetCachedMenuBitmapForTerminal(iconSettings);
+        if (menuBitmap) {
+            MENUITEMINFOW itemInfo = {};
+            itemInfo.cbSize = sizeof(itemInfo);
+            itemInfo.fMask = MIIM_BITMAP;
+            itemInfo.hbmpItem = menuBitmap;
+            if (!SetMenuItemInfoW(menu, kMenuCommandId, FALSE, &itemInfo)) {
+                Wh_Log(L"Menu icon assignment failed");
+            } else {
+                Wh_Log(L"Menu icon assigned");
+            }
+        } else {
+            Wh_Log(L"Menu icon unavailable");
+        }
+    }
+
+    if (showNormal) {
+        HBITMAP menuBitmapNoShield = GetCachedMenuBitmapNoShield(iconSettings);
+        if (menuBitmapNoShield) {
+            MENUITEMINFOW itemInfo = {};
+            itemInfo.cbSize = sizeof(itemInfo);
+            itemInfo.fMask = MIIM_BITMAP;
+            itemInfo.hbmpItem = menuBitmapNoShield;
+            if (!SetMenuItemInfoW(menu, kMenuCommandIdNonElevated, FALSE,
+                                  &itemInfo)) {
+                Wh_Log(L"Non-elevated menu icon assignment failed");
+            } else {
+                Wh_Log(L"Non-elevated menu icon assigned");
+            }
+        } else {
+            Wh_Log(L"Non-elevated menu icon unavailable");
+        }
     }
 }
 
 static void LaunchAdminTerminal(const MenuTarget& target) {
     Settings settings = GetSettingsSnapshot();
-    LaunchSpec launch = BuildLaunchSpec(settings, target.path);
+    LaunchSpec launch = (target.kind == TargetKind::ScriptItem)
+                            ? BuildScriptLaunchSpec(settings, target.path)
+                            : BuildLaunchSpec(settings, target.path);
 
     SHELLEXECUTEINFOW executeInfo = {};
     executeInfo.cbSize = sizeof(executeInfo);
     executeInfo.fMask = SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI;
     executeInfo.lpVerb = L"runas";
+    executeInfo.lpFile = launch.executable.c_str();
+    executeInfo.lpParameters =
+        launch.parameters.empty() ? nullptr : launch.parameters.c_str();
+    executeInfo.lpDirectory =
+        launch.workingDirectory.empty() ? nullptr : launch.workingDirectory.c_str();
+    executeInfo.nShow = SW_SHOWNORMAL;
+
+    POINT cursorPos;
+    if (GetCursorPos(&cursorPos)) {
+        executeInfo.fMask |= SEE_MASK_HMONITOR;
+        executeInfo.hMonitor = MonitorFromPoint(cursorPos, MONITOR_DEFAULTTONEAREST);
+    }
+
+    if (ShellExecuteExW(&executeInfo)) {
+        Wh_Log(L"Launch succeeded: target=%ls executable=%ls parameters=%ls",
+               target.path.c_str(), launch.executable.c_str(),
+               launch.parameters.c_str());
+    } else {
+        DWORD error = GetLastError();
+        if (error != ERROR_CANCELLED) {
+            Wh_Log(L"Launch failed: error=%lu target=%ls executable=%ls parameters=%ls",
+                   error, target.path.c_str(), launch.executable.c_str(),
+                   launch.parameters.c_str());
+        }
+    }
+}
+
+static void LaunchTerminalNonElevated(const MenuTarget& target) {
+    Settings settings = GetSettingsSnapshot();
+    LaunchSpec launch = (target.kind == TargetKind::ScriptItem)
+                            ? BuildScriptLaunchSpec(settings, target.path)
+                            : BuildLaunchSpec(settings, target.path);
+
+    SHELLEXECUTEINFOW executeInfo = {};
+    executeInfo.cbSize = sizeof(executeInfo);
+    executeInfo.fMask = SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI;
+    executeInfo.lpVerb = L"open";
     executeInfo.lpFile = launch.executable.c_str();
     executeInfo.lpParameters =
         launch.parameters.empty() ? nullptr : launch.parameters.c_str();
@@ -1527,8 +1966,7 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
     bool injected = false;
     ClearCurrentMenuState();
 
-    if (menu && hwnd &&
-        (IsShellViewWindow(hwnd) || IsNavigationPaneWindow(hwnd))) {
+    if (menu && hwnd) {
         MenuTarget target;
         Settings settings = GetSettingsSnapshot();
         if (!ResolveMenuTarget(hwnd, settings.showOnNavigationPane, target)) {
@@ -1545,9 +1983,9 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
             }
             Wh_Log(L"Injection target: kind=%ls path=%ls",
                    TargetKindName(target.kind), target.path.c_str());
-            InsertAdminTerminalMenuItem(menu, settings);
-            Wh_Log(L"Injection inserted: position=%ls text=%ls",
-                   settings.position.c_str(), settings.menuText.c_str());
+            InsertAdminTerminalMenuItem(menu, settings, target);
+            Wh_Log(L"Injection inserted: position=%ls kind=%ls",
+                   settings.position.c_str(), TargetKindName(target.kind));
             injected = true;
             g_currentMenuHwnd = hwnd;
             g_currentMenuEligible = true;
@@ -1565,6 +2003,14 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
         return 0;
     }
 
+    if (injected && (flags & TPM_RETURNCMD) &&
+        static_cast<UINT>(result) == kMenuCommandIdNonElevated) {
+        MenuTarget target = g_currentTarget;
+        ClearCurrentMenuState();
+        LaunchTerminalNonElevated(target);
+        return 0;
+    }
+
     return result;
 }
 
@@ -1579,11 +2025,21 @@ BOOL WINAPI PostMessageW_Hook(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
         return TRUE;
     }
 
+    if (message == WM_COMMAND &&
+        LOWORD(wParam) == kMenuCommandIdNonElevated &&
+        g_currentMenuEligible &&
+        hwnd == g_currentMenuHwnd) {
+        MenuTarget target = g_currentTarget;
+        ClearCurrentMenuState();
+        LaunchTerminalNonElevated(target);
+        return TRUE;
+    }
+
     return PostMessageW_Orig(hwnd, message, wParam, lParam);
 }
 
 BOOL Wh_ModInit() {
-    Wh_Log(L"Init v1.16-classic");
+    Wh_Log(L"Init");
 
     g_shellIdListClipboardFormat = RegisterClipboardFormatW(L"Shell IDList Array");
 

--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -689,6 +689,13 @@ static std::wstring QuoteCmdPath(const std::wstring& path) {
     return L'"' + path + L'"';
 }
 
+static std::wstring BuildCmdCommandLine(bool keepOpen,
+                                        const std::wstring& command) {
+    // /s makes cmd strip the outer pair, preserving quotes inside the command.
+    return std::wstring(keepOpen ? L"/s /k \"" : L"/s /c \"") + command +
+           L'"';
+}
+
 static std::wstring JoinCommandLineArguments(
     const std::vector<std::wstring>& args) {
     std::wstring result;
@@ -804,7 +811,8 @@ static LaunchSpec BuildLaunchSpec(const Settings& s, const std::wstring& target)
         return spec;
     }
     if (choice == L"cmd") {
-        spec.parameters = L"/k cd /d " + QuoteCmdPath(target);
+        spec.parameters =
+            BuildCmdCommandLine(true, L"cd /d " + QuoteCmdPath(target));
         return spec;
     }
     if (choice == L"wsl") {
@@ -862,9 +870,8 @@ static LaunchSpec BuildScriptInterpreterSpec(const Settings& s,
     } else if (_wcsicmp(ext, L".bat") == 0 ||
                _wcsicmp(ext, L".cmd") == 0) {
         ResolveSystemExecutablePath(L"cmd.exe", spec.executable);
-        spec.parameters =
-            std::wstring(s.keepOpenAfterScript ? L"/k " : L"/c ") +
-            QuoteCmdPath(scriptPath);
+        spec.parameters = BuildCmdCommandLine(s.keepOpenAfterScript,
+                                              QuoteCmdPath(scriptPath));
     } else if (_wcsicmp(ext, L".vbs") == 0 ||
                _wcsicmp(ext, L".js") == 0) {
         std::wstring cscriptPath;
@@ -875,8 +882,9 @@ static LaunchSpec BuildScriptInterpreterSpec(const Settings& s,
             if (!ResolveSystemExecutablePath(L"cmd.exe", spec.executable)) {
                 return {};
             }
-            spec.parameters = L"/k " + QuoteCmdPath(cscriptPath) +
-                              L" //nologo " + QuoteCmdPath(scriptPath);
+            spec.parameters = BuildCmdCommandLine(
+                true, QuoteCmdPath(cscriptPath) + L" //nologo " +
+                          QuoteCmdPath(scriptPath));
         } else {
             spec.executable = std::move(cscriptPath);
             spec.parameters = L"//nologo " + QuoteCommandLineArgument(scriptPath);

--- a/mods/open-in-admin-terminal.wh.cpp
+++ b/mods/open-in-admin-terminal.wh.cpp
@@ -685,6 +685,10 @@ static std::wstring QuoteCommandLineArgument(const std::wstring& arg) {
     return result;
 }
 
+static std::wstring QuoteCmdPath(const std::wstring& path) {
+    return L'"' + path + L'"';
+}
+
 static std::wstring JoinCommandLineArguments(
     const std::vector<std::wstring>& args) {
     std::wstring result;
@@ -800,7 +804,7 @@ static LaunchSpec BuildLaunchSpec(const Settings& s, const std::wstring& target)
         return spec;
     }
     if (choice == L"cmd") {
-        spec.parameters = L"/k cd /d " + QuoteCommandLineArgument(target);
+        spec.parameters = L"/k cd /d " + QuoteCmdPath(target);
         return spec;
     }
     if (choice == L"wsl") {
@@ -860,7 +864,7 @@ static LaunchSpec BuildScriptInterpreterSpec(const Settings& s,
         ResolveSystemExecutablePath(L"cmd.exe", spec.executable);
         spec.parameters =
             std::wstring(s.keepOpenAfterScript ? L"/k " : L"/c ") +
-            QuoteCommandLineArgument(scriptPath);
+            QuoteCmdPath(scriptPath);
     } else if (_wcsicmp(ext, L".vbs") == 0 ||
                _wcsicmp(ext, L".js") == 0) {
         std::wstring cscriptPath;
@@ -871,8 +875,8 @@ static LaunchSpec BuildScriptInterpreterSpec(const Settings& s,
             if (!ResolveSystemExecutablePath(L"cmd.exe", spec.executable)) {
                 return {};
             }
-            spec.parameters = L"/k " + QuoteCommandLineArgument(cscriptPath) +
-                              L" //nologo " + QuoteCommandLineArgument(scriptPath);
+            spec.parameters = L"/k " + QuoteCmdPath(cscriptPath) +
+                              L" //nologo " + QuoteCmdPath(scriptPath);
         } else {
             spec.executable = std::move(cscriptPath);
             spec.parameters = L"//nologo " + QuoteCommandLineArgument(scriptPath);
@@ -1219,7 +1223,16 @@ static bool IsNavigationPaneWindow(HWND hwnd) {
     return false;
 }
 
+static bool IsKeyboardContextMenuPoint(const POINT& invocationPoint) {
+    return invocationPoint.x == -1 && invocationPoint.y == -1;
+}
+
 static bool IsNavigationPaneContextWindow(const POINT& invocationPoint) {
+    if (IsKeyboardContextMenuPoint(invocationPoint)) {
+        HWND focusedWindow = GetFocus();
+        return focusedWindow && IsNavigationPaneWindow(focusedWindow);
+    }
+
     HWND invocationWindow = WindowFromPoint(invocationPoint);
     return invocationWindow && IsNavigationPaneWindow(invocationWindow);
 }
@@ -1256,7 +1269,8 @@ static bool ResolveNavigationPaneMenuTarget(HWND hwnd,
         }
 
         POINT clientPoint = invocationPoint;
-        if (treeWindow && ScreenToClient(treeWindow, &clientPoint)) {
+        if (!IsKeyboardContextMenuPoint(invocationPoint) && treeWindow &&
+            ScreenToClient(treeWindow, &clientPoint)) {
             IShellItem* hitItem = nullptr;
             if (SUCCEEDED(navigationPane->HitTest(&clientPoint, &hitItem)) &&
                 hitItem) {
@@ -1270,6 +1284,29 @@ static bool ResolveNavigationPaneMenuTarget(HWND hwnd,
                     ok = true;
                 }
                 hitItem->Release();
+            }
+        }
+
+        if (!ok && IsKeyboardContextMenuPoint(invocationPoint)) {
+            IShellItemArray* selectedItems = nullptr;
+            if (SUCCEEDED(navigationPane->GetSelectedItems(&selectedItems)) &&
+                selectedItems) {
+                DWORD count = 0;
+                IShellItem* item = nullptr;
+                if (SUCCEEDED(selectedItems->GetCount(&count)) && count == 1 &&
+                    SUCCEEDED(selectedItems->GetItemAt(0, &item)) && item) {
+                    std::wstring path;
+                    if (GetFilesystemPathFromShellItem(item, path) &&
+                        IsDirectoryPath(path)) {
+                        targetOut.path = std::move(path);
+                        targetOut.kind = IsDriveRootPath(targetOut.path)
+                                             ? TargetKind::DriveItem
+                                             : TargetKind::FolderItem;
+                        ok = true;
+                    }
+                    item->Release();
+                }
+                selectedItems->Release();
             }
         }
 
@@ -1695,6 +1732,10 @@ static void ClearCurrentMenuState() {
     g_currentMenuHwnd = nullptr;
 }
 
+static bool ShouldClearMenuStateAfterTracking(UINT flags, BOOL result) {
+    return (flags & TPM_RETURNCMD) || !result;
+}
+
 static std::wstring GetScriptTerminalDisplayName(const Settings& settings,
                                                  const std::wstring& scriptPath) {
     if (IsScriptHostChoice(settings.terminalEffectiveChoice)) {
@@ -2001,7 +2042,9 @@ BOOL WINAPI TrackPopupMenuEx_Hook(HMENU menu,
         return 0;
     }
 
-    ClearCurrentMenuState();
+    if (ShouldClearMenuStateAfterTracking(flags, result)) {
+        ClearCurrentMenuState();
+    }
     return result;
 }
 


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Fixed the context-menu entry for filesystem folders and drives in Explorer's navigation pane and Quick access.
* Added optional non-elevated terminal entries and configurable normal/elevated script actions for `.ps1`, `.bat`, `.cmd`, `.vbs`, and `.js` files.
* Added configurable script-label terminal-name behavior.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.