### PR TITLE
Add Windows 7/8.1 'Please Wait' Restorer mod

### DIFF
--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -1,0 +1,480 @@
+// ==WindhawkMod==
+// @id              win7-please-wait-restorer
+// @name            Windows 7/8.1 "Please Wait" Restorer
+// @description     This mod replaces the theme-switch overlay with a self-drawn classic "Please wait" box
+// @version         1.0.0
+// @author          babamohammed
+// @github          https://github.com/babamohammed2022
+// @include         rundll32.exe
+// @include         explorer.exe
+// @include         SystemSettings.exe
+// @compilerOptions -lgdi32 -lGdiplus
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Windows 7/8.1 "Please Wait" Restorer
+
+## About
+
+When changing the Windows theme, this mod shows the small classic
+"Please wait" box from Windows 7/8.1 instead of the modern full-screen effect.
+The text is shown in the Windows display language when it is supported.
+
+## Screenshot
+
+![screenshot](https://raw.githubusercontent.com/babamohammed2022/babamohammed2022/main/PleaseWait.PNG)
+
+## Notes
+
+The mod has been tested on Windows 10 1809 (build 17763) and Windows 10 21H2 (build 19044)
+Other Windows 10/11 versions may work, but are not guaranteed. If Windows
+changes the internal theme component used by this mod, Windhawk disables the
+mod safely instead of forcing it to run. Additionally, the mod is a best-effort implementation using
+documented Windows functions where appliable to improve the stability of the mod.
+
+## Credits
+- Nex - Testing on Windows 10 21H2 and providing feedback
+*/
+// ==/WindhawkModReadme==
+
+#include <windows.h>
+#include <algorithm>
+#include <gdiplus.h>
+#include <windhawk_utils.h>
+
+using namespace Gdiplus;
+
+#ifdef _WIN64
+#define STDCALL __cdecl
+#else
+#define STDCALL __stdcall
+#endif
+
+class CDimmedWindow;
+typedef void(STDCALL* CDimmedWindow_OnPaint_t)(CDimmedWindow* window, HDC hdc);
+static CDimmedWindow_OnPaint_t g_originalOnPaint = nullptr;
+static HMODULE g_themeUi = nullptr;
+
+struct LocalizedText {
+    LANGID language;
+    const wchar_t* text;
+};
+
+// These strings intentionally have no ellipsis, matching the supplied
+// Windows 8.1 Italian reference ("Attendere"). Unicode escapes keep this
+// source portable even when an editor saves it with a legacy code page.
+static const LocalizedText kPleaseWaitTexts[] = {
+    { MAKELANGID(LANG_ENGLISH, SUBLANG_DEFAULT), L"Please wait" },
+    { MAKELANGID(LANG_ITALIAN, SUBLANG_DEFAULT), L"Attendere" },
+    { MAKELANGID(LANG_GERMAN, SUBLANG_DEFAULT), L"Bitte warten" },
+    { MAKELANGID(LANG_FRENCH, SUBLANG_DEFAULT), L"Veuillez patienter" },
+    { MAKELANGID(LANG_SPANISH, SUBLANG_DEFAULT), L"Espere" },
+    { MAKELANGID(LANG_PORTUGUESE, SUBLANG_DEFAULT), L"Aguarde" },
+    { MAKELANGID(LANG_DUTCH, SUBLANG_DEFAULT), L"Een ogenblik geduld" },
+    { MAKELANGID(LANG_POLISH, SUBLANG_DEFAULT), L"Prosz\u0119 czeka\u0107" },
+    { MAKELANGID(LANG_RUSSIAN, SUBLANG_DEFAULT), L"\u041F\u043E\u0434\u043E\u0436\u0434\u0438\u0442\u0435" },
+    { MAKELANGID(LANG_UKRAINIAN, SUBLANG_DEFAULT), L"\u0417\u0430\u0447\u0435\u043A\u0430\u0439\u0442\u0435" },
+    { MAKELANGID(LANG_TURKISH, SUBLANG_DEFAULT), L"L\u00FCtfen bekleyin" },
+    { MAKELANGID(LANG_SWEDISH, SUBLANG_DEFAULT), L"V\u00E4nta" },
+    { MAKELANGID(LANG_NORWEGIAN, SUBLANG_DEFAULT), L"Vent litt" },
+    { MAKELANGID(LANG_DANISH, SUBLANG_DEFAULT), L"Vent venligst" },
+    { MAKELANGID(LANG_FINNISH, SUBLANG_DEFAULT), L"Odota" },
+    { MAKELANGID(LANG_CZECH, SUBLANG_DEFAULT), L"\u010Cekejte pros\u00EDm" },
+    { MAKELANGID(LANG_SLOVAK, SUBLANG_DEFAULT), L"Pros\u00EDm, \u010Dakajte" },
+    { MAKELANGID(LANG_HUNGARIAN, SUBLANG_DEFAULT), L"K\u00E9rem, v\u00E1rjon" },
+    { MAKELANGID(LANG_ROMANIAN, SUBLANG_DEFAULT), L"V\u0103 rug\u0103m a\u0219tepta\u021Bi" },
+    { MAKELANGID(LANG_GREEK, SUBLANG_DEFAULT), L"\u03A0\u03B1\u03C1\u03B1\u03BA\u03B1\u03BB\u03CE \u03C0\u03B5\u03C1\u03B9\u03BC\u03AD\u03BD\u03B5\u03C4\u03B5" },
+    { MAKELANGID(LANG_ARABIC, SUBLANG_DEFAULT), L"\u064A\u0631\u062C\u0649 \u0627\u0644\u0627\u0646\u062A\u0638\u0627\u0631" },
+    { MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT), L"\u05E0\u05D0 \u05D4\u05DE\u05EA\u05DF" },
+    { MAKELANGID(LANG_JAPANESE, SUBLANG_DEFAULT), L"\u3057\u3070\u3089\u304F\u304A\u5F85\u3061\u304F\u3060\u3055\u3044" },
+    { MAKELANGID(LANG_KOREAN, SUBLANG_DEFAULT), L"\uC7A0\uC2DC \uAE30\uB2E4\uB824 \uC8FC\uC2ED\uC2DC\uC624" },
+    { MAKELANGID(LANG_CHINESE_SIMPLIFIED, SUBLANG_DEFAULT), L"\u8BF7\u7A0D\u5019" },
+    { MAKELANGID(LANG_CHINESE_TRADITIONAL, SUBLANG_DEFAULT), L"\u8ACB\u7A0D\u5019" },
+    { MAKELANGID(LANG_CROATIAN, SUBLANG_DEFAULT), L"Pri\u010Dekajte" },
+    { MAKELANGID(LANG_VIETNAMESE, SUBLANG_DEFAULT), L"Vui l\u00F2ng ch\u1EDD" },
+    { MAKELANGID(LANG_INDONESIAN, SUBLANG_DEFAULT), L"Harap tunggu" },
+    { MAKELANGID(LANG_BULGARIAN, SUBLANG_DEFAULT), L"\u041C\u043E\u043B\u044F, \u0438\u0437\u0447\u0430\u043A\u0430\u0439\u0442\u0435" },
+};
+
+static const wchar_t* GetPleaseWaitText()
+{
+    const WORD primaryLanguage = PRIMARYLANGID(GetUserDefaultUILanguage());
+    for (const auto& entry : kPleaseWaitTexts) {
+        if (PRIMARYLANGID(entry.language) == primaryLanguage) {
+            return entry.text;
+        }
+    }
+    return L"Please wait";
+}
+
+// RAII wrappers make all early returns safe: each acquired Win32 handle is
+// released at scope exit, including when a C++ exception is caught above it.
+class ScopedGdiObject {
+public:
+    explicit ScopedGdiObject(HGDIOBJ object = nullptr) : object_(object) {}
+    ~ScopedGdiObject() { if (object_) DeleteObject(object_); }
+    ScopedGdiObject(const ScopedGdiObject&) = delete;
+    ScopedGdiObject& operator=(const ScopedGdiObject&) = delete;
+    HGDIOBJ get() const { return object_; }
+    explicit operator bool() const { return object_ != nullptr; }
+private:
+    HGDIOBJ object_;
+};
+
+class ScopedCompatibleDC {
+public:
+    explicit ScopedCompatibleDC(HDC referenceDc)
+        : dc_(referenceDc ? CreateCompatibleDC(referenceDc) : nullptr) {}
+    ~ScopedCompatibleDC() { if (dc_) DeleteDC(dc_); }
+    ScopedCompatibleDC(const ScopedCompatibleDC&) = delete;
+    ScopedCompatibleDC& operator=(const ScopedCompatibleDC&) = delete;
+    HDC get() const { return dc_; }
+    explicit operator bool() const { return dc_ != nullptr; }
+private:
+    HDC dc_;
+};
+
+class ScopedScreenDC {
+public:
+    ScopedScreenDC() : dc_(GetDC(nullptr)) {}
+    ~ScopedScreenDC() { if (dc_) ReleaseDC(nullptr, dc_); }
+    ScopedScreenDC(const ScopedScreenDC&) = delete;
+    ScopedScreenDC& operator=(const ScopedScreenDC&) = delete;
+    HDC get() const { return dc_; }
+    explicit operator bool() const { return dc_ != nullptr; }
+private:
+    HDC dc_;
+};
+
+class ScopedModule {
+public:
+    explicit ScopedModule(HMODULE module = nullptr) : module_(module) {}
+    ~ScopedModule() { if (module_) FreeLibrary(module_); }
+    ScopedModule(const ScopedModule&) = delete;
+    ScopedModule& operator=(const ScopedModule&) = delete;
+    HMODULE get() const { return module_; }
+    HMODULE release() {
+        HMODULE result = module_;
+        module_ = nullptr;
+        return result;
+    }
+    explicit operator bool() const { return module_ != nullptr; }
+private:
+    HMODULE module_;
+};
+
+class ScopedGdiplus {
+public:
+    ScopedGdiplus() : token_(0), ready_(false) {}
+    ~ScopedGdiplus() { Stop(); }
+    ScopedGdiplus(const ScopedGdiplus&) = delete;
+    ScopedGdiplus& operator=(const ScopedGdiplus&) = delete;
+
+    bool Start() {
+        if (ready_) return true;
+        GdiplusStartupInput startupInput;
+        ready_ = GdiplusStartup(&token_, &startupInput, nullptr) == Ok;
+        return ready_;
+    }
+    void Stop() {
+        if (ready_) {
+            GdiplusShutdown(token_);
+            token_ = 0;
+            ready_ = false;
+        }
+    }
+    bool ready() const { return ready_; }
+private:
+    ULONG_PTR token_;
+    bool ready_;
+};
+
+static ScopedGdiplus g_gdiplus;
+
+class ScopedSelection {
+public:
+    ScopedSelection(HDC dc, HGDIOBJ object) : dc_(dc), old_(HGDI_ERROR) {
+        if (dc_ && object) old_ = SelectObject(dc_, object);
+    }
+    ~ScopedSelection() {
+        if (dc_ && old_ && old_ != HGDI_ERROR) SelectObject(dc_, old_);
+    }
+    ScopedSelection(const ScopedSelection&) = delete;
+    ScopedSelection& operator=(const ScopedSelection&) = delete;
+    bool selected() const { return old_ && old_ != HGDI_ERROR; }
+private:
+    HDC dc_;
+    HGDIOBJ old_;
+};
+
+// Restore the previous wider proportions (216 × 76 px), then enlarge every
+// part by 5%, including the font, borders and spacing: 227 × 80 px at 96 DPI.
+static constexpr int kReferenceBoxWidth = 216;
+static constexpr int kReferenceBoxHeight = 76;
+static constexpr int kBoxSizePercent = 105;
+// User-selected visible-but-moderate desaturation. Brightness stays nearly
+// unchanged while the desktop colours are reduced by 25%.
+static constexpr REAL kBackgroundDesaturation = 0.25f;
+
+static int ScaleForDpi(int pixelsAt96Dpi, int dpi)
+{
+    return MulDiv(pixelsAt96Dpi, dpi > 0 ? dpi : 96, 96);
+}
+
+static int ScaleBoxForDpi(int pixelsAt96Dpi, int dpi)
+{
+    return MulDiv(ScaleForDpi(pixelsAt96Dpi, dpi), kBoxSizePercent, 100);
+}
+
+// Windows 7 displayed one message on the primary monitor. On builds where
+// themeui paints one virtual-desktop surface, convert the primary monitor's
+// screen coordinates to the surface's coordinates. This also keeps the box
+// out of the gap between monitors with different positions/resolutions.
+static RECT GetClassicBoxArea(const RECT& paintArea)
+{
+    const int paintWidth = paintArea.right - paintArea.left;
+    const int paintHeight = paintArea.bottom - paintArea.top;
+    const int virtualWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+    const int virtualHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+
+    if (paintWidth != virtualWidth || paintHeight != virtualHeight) {
+        // This build supplied a monitor-sized paint surface. It is already
+        // the correct coordinate space for the box.
+        return paintArea;
+    }
+
+    const POINT primaryOrigin = { 0, 0 };
+    HMONITOR primaryMonitor = MonitorFromPoint(primaryOrigin, MONITOR_DEFAULTTOPRIMARY);
+    MONITORINFO monitorInfo = {};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if (!primaryMonitor || !GetMonitorInfoW(primaryMonitor, &monitorInfo)) {
+        return paintArea;
+    }
+
+    const int virtualLeft = GetSystemMetrics(SM_XVIRTUALSCREEN);
+    const int virtualTop = GetSystemMetrics(SM_YVIRTUALSCREEN);
+    return {
+        paintArea.left + monitorInfo.rcMonitor.left - virtualLeft,
+        paintArea.top + monitorInfo.rcMonitor.top - virtualTop,
+        paintArea.left + monitorInfo.rcMonitor.right - virtualLeft,
+        paintArea.top + monitorInfo.rcMonitor.bottom - virtualTop
+    };
+}
+
+// The failed first implementation rendered GDI+ directly to CDimmedWindow's
+// paint DC. That DC may be transparent on current builds. This version keeps
+// the same reliable off-screen snapshot/composite/BitBlt design used by Aero
+// Flip 3D Recreation, but uses a true saturation colour matrix instead of its
+// black veil.
+static void PaintSnapshotWithGentleDesaturation(HDC hdc, const RECT& area)
+{
+    const int width = area.right - area.left;
+    const int height = area.bottom - area.top;
+    if (!g_gdiplus.ready() || !hdc || width <= 0 || height <= 0) return;
+
+    ScopedScreenDC screenDc;
+    if (!screenDc) return;
+
+    ScopedCompatibleDC snapshotDc(screenDc.get());
+    ScopedCompatibleDC compositeDc(hdc);
+    if (!snapshotDc || !compositeDc) return;
+
+    ScopedGdiObject snapshotBitmap(CreateCompatibleBitmap(screenDc.get(), width, height));
+    ScopedGdiObject compositeBitmap(CreateCompatibleBitmap(hdc, width, height));
+    if (!snapshotBitmap || !compositeBitmap) return;
+
+    // Selection objects are declared after their bitmaps, so they restore the
+    // old stock bitmaps before the bitmap destructors run.
+    ScopedSelection selectSnapshot(snapshotDc.get(), snapshotBitmap.get());
+    ScopedSelection selectComposite(compositeDc.get(), compositeBitmap.get());
+    if (!selectSnapshot.selected() || !selectComposite.selected()) return;
+
+    const int screenX = GetSystemMetrics(SM_XVIRTUALSCREEN) + area.left;
+    const int screenY = GetSystemMetrics(SM_YVIRTUALSCREEN) + area.top;
+    if (!BitBlt(snapshotDc.get(), 0, 0, width, height, screenDc.get(),
+                screenX, screenY, SRCCOPY | CAPTUREBLT)) {
+        return;
+    }
+
+    Bitmap sourceImage(static_cast<HBITMAP>(snapshotBitmap.get()), nullptr);
+    if (sourceImage.GetLastStatus() != Ok) return;
+
+    const REAL i = kBackgroundDesaturation;
+    const ColorMatrix matrix = {{
+        { 1.0f - 0.70f * i, 0.30f * i,        0.30f * i,        0, 0 },
+        { 0.59f * i,        1.0f - 0.41f * i, 0.59f * i,        0, 0 },
+        { 0.11f * i,        0.11f * i,        1.0f - 0.89f * i, 0, 0 },
+        { 0,                 0,                0,                1, 0 },
+        { 0,                 0,                0,                0, 1 }
+    }};
+
+    ImageAttributes attributes;
+    if (attributes.SetColorMatrix(&matrix, ColorMatrixFlagsDefault,
+                                  ColorAdjustTypeBitmap) != Ok) {
+        return;
+    }
+
+    // Crucially, GDI+ now draws into an ordinary memory DC, not into the
+    // potentially transparent theme overlay DC.
+    Graphics graphics(compositeDc.get());
+    if (graphics.GetLastStatus() != Ok ||
+        graphics.DrawImage(&sourceImage, Rect(0, 0, width, height),
+                           0, 0, width, height, UnitPixel, &attributes) != Ok) {
+        return;
+    }
+
+    // This opaque copy is reliable even when the target overlay does not
+    // support direct GDI+/alpha composition.
+    BitBlt(hdc, area.left, area.top, width, height, compositeDc.get(),
+           0, 0, SRCCOPY);
+}
+
+static void DrawClassicPleaseWaitBox(HDC hdc)
+{
+    if (!hdc) return;
+
+    // On this paint DC, the clipping rectangle is the complete overlay client
+    // area on supported builds. Unlike the old code, no HWND/object-layout
+    // offset is dereferenced to obtain it.
+    RECT paintArea = {};
+    if (GetClipBox(hdc, &paintArea) == ERROR ||
+        paintArea.right <= paintArea.left || paintArea.bottom <= paintArea.top) {
+        return;
+    }
+
+    // This off-screen snapshot/colour-matrix composition is synchronous. If
+    // it fails, it safely skips the backdrop and still draws the classic box.
+    PaintSnapshotWithGentleDesaturation(hdc, paintArea);
+
+    const RECT boxArea = GetClassicBoxArea(paintArea);
+    const int dpi = GetDeviceCaps(hdc, LOGPIXELSX);
+    const int outerWidth = ScaleBoxForDpi(kReferenceBoxWidth, dpi);   // 227 px at 96 DPI
+    const int outerHeight = ScaleBoxForDpi(kReferenceBoxHeight, dpi); // 80 px at 96 DPI
+    const int rim = std::max(1, ScaleBoxForDpi(5, dpi));
+    const int border = std::max(1, ScaleBoxForDpi(1, dpi));
+
+    RECT outer = {
+        boxArea.left + ((boxArea.right - boxArea.left) - outerWidth) / 2,
+        boxArea.top + ((boxArea.bottom - boxArea.top) - outerHeight) / 2,
+        0, 0
+    };
+    outer.right = outer.left + outerWidth;
+    outer.bottom = outer.top + outerHeight;
+
+    RECT darkBorder = outer;
+    InflateRect(&darkBorder, -rim, -rim);
+    RECT content = darkBorder;
+    InflateRect(&content, -border, -border);
+    if (content.right <= content.left || content.bottom <= content.top) return;
+
+    // Colours sampled/approximated from the supplied Windows 8.1 reference:
+    // pale-blue outer rim, slate-grey one-pixel line, white content.
+    ScopedGdiObject outerBrush(CreateSolidBrush(RGB(197, 218, 231)));
+    ScopedGdiObject borderBrush(CreateSolidBrush(RGB(118, 131, 139)));
+    ScopedGdiObject contentBrush(CreateSolidBrush(RGB(255, 255, 255)));
+    if (!outerBrush || !borderBrush || !contentBrush) return;
+    FillRect(hdc, &outer, static_cast<HBRUSH>(outerBrush.get()));
+
+    // The original frame was not a flat blue fill: it had faint horizontal
+    // Aero-like light streaks. Keep them inside the outer rim, so they never
+    // reduce the white text area or the dark inner border's contrast.
+    ScopedGdiObject topStreakBrush(CreateSolidBrush(RGB(231, 241, 247)));
+    ScopedGdiObject bottomStreakBrush(CreateSolidBrush(RGB(177, 208, 225)));
+    const int streakHeight = std::max(1, ScaleBoxForDpi(1, dpi));
+    if (topStreakBrush && bottomStreakBrush && rim > streakHeight) {
+        RECT topStreak = { outer.left + 1, outer.top + 1,
+                           outer.right - 1, outer.top + 1 + streakHeight };
+        RECT bottomStreak = { outer.left + 1, outer.bottom - 1 - streakHeight,
+                              outer.right - 1, outer.bottom - 1 };
+        FillRect(hdc, &topStreak, static_cast<HBRUSH>(topStreakBrush.get()));
+        FillRect(hdc, &bottomStreak, static_cast<HBRUSH>(bottomStreakBrush.get()));
+    }
+
+    FillRect(hdc, &darkBorder, static_cast<HBRUSH>(borderBrush.get()));
+    FillRect(hdc, &content, static_cast<HBRUSH>(contentBrush.get()));
+
+    LOGFONTW fontDescription = {};
+    fontDescription.lfHeight = -ScaleBoxForDpi(12, dpi);
+    fontDescription.lfWeight = FW_BOLD;
+    fontDescription.lfQuality = CLEARTYPE_QUALITY;
+    fontDescription.lfCharSet = DEFAULT_CHARSET;
+    lstrcpynW(fontDescription.lfFaceName, L"Segoe UI", LF_FACESIZE);
+    ScopedGdiObject font(CreateFontIndirectW(&fontDescription));
+    if (!font) return;
+
+    ScopedSelection selectFont(hdc, font.get());
+    SetBkMode(hdc, TRANSPARENT);
+    SetTextColor(hdc, RGB(0, 0, 0));
+    DrawTextW(hdc, GetPleaseWaitText(), -1, &content,
+              DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
+}
+
+void STDCALL CDimmedWindow_OnPaintHook(CDimmedWindow* window, HDC hdc)
+{
+    // This mod deliberately replaces the original overlay paint. Calling the
+    // original here would restore the full-screen Windows 10/11 dimming that
+    // the mod is intended to remove.
+    (void)window;
+    if (!hdc) return;
+
+    try {
+        DrawClassicPleaseWaitBox(hdc);
+    }
+    catch (...) {
+        // A rendering failure must never bring down Explorer, rundll32 or
+        // Settings. RAII objects created by the drawing path are unwound here.
+        Wh_Log(L"Please Wait Restorer: an unexpected C++ exception occurred while drawing; this frame was skipped safely");
+    }
+}
+
+BOOL Wh_ModInit()
+{
+    Wh_Log(L"Please Wait Restorer 1.0.0: initializing safe classic-overlay mode");
+
+    try {
+        // The box remains available if documented GDI+ colour adjustment is
+        // unavailable; only the optional desaturation is skipped.
+        if (!g_gdiplus.Start()) {
+            Wh_Log(L"Please Wait Restorer: GDI+ unavailable; continuing without desaturation");
+        }
+
+        // If initialization returns early or HookSymbols fails, this wrapper
+        // releases the reference acquired by LoadLibrary automatically.
+        ScopedModule themeUi(LoadLibraryW(L"themeui.dll"));
+        if (!themeUi) {
+            Wh_Log(L"themeui.dll could not be loaded; disabling the mod safely");
+            return FALSE;
+        }
+
+        WindhawkUtils::SYMBOL_HOOK hook = {
+            { L"private: void __cdecl CDimmedWindow::OnPaint(struct HDC__ *)" },
+            &g_originalOnPaint,
+            CDimmedWindow_OnPaintHook,
+            false
+        };
+
+        if (!WindhawkUtils::HookSymbols(themeUi.get(), &hook, 1)) {
+            Wh_Log(L"CDimmedWindow::OnPaint was not resolved on this Windows build; disabling the mod safely");
+            return FALSE;
+        }
+
+        // Keep the module loaded for the host process. This avoids unloading
+        // code that may still be used by the hooked Windows component.
+        g_themeUi = themeUi.release();
+        return TRUE;
+    }
+    catch (...) {
+        Wh_Log(L"Please Wait Restorer: an unexpected C++ exception occurred during initialization; disabling safely");
+        return FALSE;
+    }
+}
+
+void Wh_ModUninit()
+{
+    // Windhawk removes the hook before unloading the mod. Do not free
+    // themeui.dll here: it is a Windows module that can still be in use by
+    // the host process, and keeping its normal process lifetime is safest.
+    g_gdiplus.Stop();
+    Wh_Log(L"Please Wait Restorer: unloaded");
+}

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -103,19 +103,9 @@ static void LoadSettings() {
     g_settings.fontSizePercent.store(std::clamp(Wh_GetIntSetting(L"fontSizePercent"), 50, 200));
 
     PCWSTR customText = Wh_GetStringSetting(L"customText");
-    size_t customTextLength = 0;
-    if (customText) {
-        while (customTextLength < 100 && customText[customTextLength])
-            ++customTextLength;
-    }
-    if (customText && customTextLength < 100) {
-        lstrcpynW(g_settings.customText, customText, ARRAYSIZE(g_settings.customText));
-        g_settings.customTextValid.store(true);
-    } else {
-        g_settings.customText[0] = L'\0';
-        g_settings.customTextValid.store(false);
-    }
-    if (customText) Wh_FreeStringSetting(customText);
+    lstrcpynW(g_settings.customText, customText, ARRAYSIZE(g_settings.customText));
+    g_settings.customTextValid.store(g_settings.customText[0] != L'\0');
+    Wh_FreeStringSetting(customText);
 }
 
 struct LocalizedText {
@@ -130,9 +120,9 @@ static const LocalizedText kPleaseWaitTexts[] = {
     { MAKELANGID(LANG_FRENCH, SUBLANG_DEFAULT), L"Veuillez patienter" },
     { MAKELANGID(LANG_SPANISH, SUBLANG_DEFAULT), L"Espere" },
     { MAKELANGID(LANG_PORTUGUESE, SUBLANG_DEFAULT), L"Aguarde" },
-    { MAKELANGID(LANG_DUTCH, SUBLANG_DEFAULT), L"Even ogenblik geduld" },
+    { MAKELANGID(LANG_DUTCH, SUBLANG_DEFAULT), L"Een ogenblik geduld" },
     { MAKELANGID(LANG_POLISH, SUBLANG_DEFAULT), L"Prosz\u0119 czeka\u0107" },
-    { MAKELANGID(LANG_RUSSIAN, SUBLANG_DEFAULT), L"\u041f\u043e\u0434\u043e\u0436\u0434\u0430\u043d\u0438\u0442\u0435" },
+    { MAKELANGID(LANG_RUSSIAN, SUBLANG_DEFAULT), L"\u041f\u043e\u0434\u043e\u0436\u0434\u0438\u0442\u0435" },
     { MAKELANGID(LANG_JAPANESE, SUBLANG_DEFAULT), L"\u3057\u3070\u3089\u304a\u5f85\u3061\u304f\u3060\u3055\u3044" },
     { MAKELANGID(LANG_KOREAN, SUBLANG_DEFAULT), L"\uc7a0\uc2dc \uae30\ub2e4\ub824 \uc8fc\uc2ed\uc2dc\uc624" },
     { MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED), L"\u8bf7\u7a0d\u5019" },
@@ -203,7 +193,7 @@ static UINT GetPrimaryMonitorDpi() {
 
 // Uses only documented GDI APIs. A 32-bit DIB section gives direct access to
 // the captured pixels, so the desaturation is not dependent on GDI+ behavior.
-static bool PaintSnapshotWithGentleDesaturation(HDC hdc, const RECT& area) {
+static bool PaintSnapshotWithGentleDesaturation(HWND hwnd, HDC hdc, const RECT& area) {
     if (!hdc) return false;
     const int width = area.right - area.left;
     const int height = area.bottom - area.top;
@@ -228,9 +218,12 @@ static bool PaintSnapshotWithGentleDesaturation(HDC hdc, const RECT& area) {
     {
         ScopedSelection selection(memoryDc.get(), bitmap.get());
         if (!selection.selected()) { ReleaseDC(nullptr, screen); return false; }
-        const int screenX = GetSystemMetrics(SM_XVIRTUALSCREEN) + area.left;
-        const int screenY = GetSystemMetrics(SM_YVIRTUALSCREEN) + area.top;
-        if (!BitBlt(memoryDc.get(), 0, 0, width, height, screen, screenX, screenY,
+        POINT topLeft = { area.left, area.top };
+        if (!ClientToScreen(hwnd, &topLeft)) {
+            ReleaseDC(nullptr, screen);
+            return false;
+        }
+        if (!BitBlt(memoryDc.get(), 0, 0, width, height, screen, topLeft.x, topLeft.y,
                     SRCCOPY | CAPTUREBLT)) {
             ReleaseDC(nullptr, screen);
             return false;
@@ -278,7 +271,7 @@ static bool DrawClassicPleaseWaitBox(HWND hwnd, HDC hdc) {
     if (!hwnd || !GetClientRect(hwnd, &clientArea)) return false;
     if (clientArea.right <= clientArea.left || clientArea.bottom <= clientArea.top) return false;
 
-    if (!PaintSnapshotWithGentleDesaturation(hdc, clientArea)) return false;
+    if (!PaintSnapshotWithGentleDesaturation(hwnd, hdc, clientArea)) return false;
 
     const RECT boxArea = GetBoxSurfaceArea(clientArea);
     const UINT dpi = GetPrimaryMonitorDpi();
@@ -324,14 +317,12 @@ static bool DrawClassicPleaseWaitBox(HWND hwnd, HDC hdc) {
 
     NONCLIENTMETRICSW metrics = { sizeof(metrics) };
     LOGFONTW fontDescription = {};
-    if (SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(metrics), &metrics, 0)) {
+    if (SystemParametersInfoForDpi(SPI_GETNONCLIENTMETRICS, sizeof(metrics), &metrics, 0, dpi)) {
         fontDescription = metrics.lfMessageFont;
     } else {
-        fontDescription.lfHeight = -12;
+        fontDescription.lfHeight = -ScaleForDpi(12, dpi);
     }
 
-    int baseHeight = fontDescription.lfHeight;
-    fontDescription.lfHeight = -ScaleForDpi(baseHeight < 0 ? -baseHeight : 12, dpi);
     fontDescription.lfHeight = MulDiv(fontDescription.lfHeight, g_settings.fontSizePercent.load(), 100);
     fontDescription.lfWeight = FW_BOLD;
 
@@ -380,11 +371,13 @@ static bool HookThemeUiSymbols(HMODULE themeUi) {
 using LoadLibraryExW_t = decltype(&LoadLibraryExW);
 static LoadLibraryExW_t LoadLibraryExW_Original = nullptr;
 
-static void HandleLoadedModule(HMODULE module) {
-    if (GetModuleHandleW(L"themeui.dll") != module ||
-        g_themeUiHandled.exchange(true))
+static void HandleLoadedModule(HMODULE /*module*/) {
+    if (g_themeUiHandled.load())
         return;
-    if (HookThemeUiSymbols(module))
+    HMODULE themeUi = GetModuleHandleW(L"themeui.dll");
+    if (!themeUi || g_themeUiHandled.exchange(true))
+        return;
+    if (HookThemeUiSymbols(themeUi))
         Wh_ApplyHookOperations();
 }
 

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -34,6 +34,13 @@ included processes. If the private themeui symbol is unavailable on a Windows
 build, the mod remains inactive in that process.
 For specific setups (such as unsupported language), it is recommended to apply the required changes using the mod's settings.
 
+## Known Limitations
+
+When the display scaling (DPI) is changed while the mod is active, the mod may
+behave slightly differently (e.g. the captured backdrop or the classic box may
+look off until the next theme switch). To ensure everything is back to normal,
+it is recommended to restart Explorer or log out and log back in after changing
+the DPI.
 ## Credits
 
 - Nex — Testing on Windows 10 21H2 and providing feedback
@@ -43,9 +50,12 @@ For specific setups (such as unsupported language), it is recommended to apply t
 
 // ==WindhawkModSettings==
 /*
-- desaturationPercent: 20
+- desaturationPercent: 65
   $name: Background desaturation (%)
   $description: This setting changes the amount of color removed from the captured desktop background.
+- desaturationRampMs: 500
+  $name: Desaturation ramp (ms)
+  $description: Duration of the progressive desaturation animation, like in Windows 7. Set to 0 to apply the desaturation instantly.
 - boxSizePercent: 105
   $name: Box size (%)
   $description: This setting changes the size of the classic box, its borders, and its decorative details.
@@ -82,23 +92,66 @@ static std::mutex g_settingsMutex;
 
 struct Settings {
     std::atomic<int> desaturationPercent;
+    std::atomic<int> desaturationRampMs;
     std::atomic<int> boxSizePercent;
     std::atomic<int> fontSizePercent;
     wchar_t customText[256];
     std::atomic<bool> customTextValid;
 };
 
-static Settings g_settings = { 20, 105, 115, L"", false };
+static Settings g_settings = { 65, 500, 105, 115, L"", false };
+
+// ---------------------------------------------------------------------------
+// Sfondo in cache: catturato e desaturato UNA sola volta, con la STESSA
+// semantica di coordinate dell'originale (origine = ClientToScreen(0,0),
+// dimensione = client). Il paint usa sempre questa cache e non ricattura mai
+// lo schermo (che conterrebbe il box del frame precedente -> scie a cascata).
+// Nessuna conversione e nessun ridimensionamento: nessuno zoom a nessun DPI.
+//
+// Il percorso in cache e' usato a OGNI DPI, compreso il 100%: la resa a 100%
+// e' identica a quella verificata a 125%. La desaturazione e' progressiva,
+// come in Windows 7: parte dalla cattura vergine e aumenta nel tempo fino al
+// valore scelto (desaturationRampMs ne regola la durata). La cache registra
+// il DPI (e la finestra) con cui e' stata costruita: se il DPI cambia durante
+// l'esecuzione viene ricostruita subito, senza ambiguita'.
+// ---------------------------------------------------------------------------
+struct BackdropCache {
+    HBITMAP    rawBitmap  = nullptr;   // cattura vergine, mai desaturata
+    HDC        rawDc      = nullptr;   // memory DC con rawBitmap selezionata
+    HBITMAP    workBitmap = nullptr;   // copia di lavoro per la desaturazione per-frame
+    HDC        workDc     = nullptr;   // memory DC con workBitmap selezionata
+    void*      workPixels = nullptr;   // pixel di workBitmap (DIB section 32 bpp)
+    RECT       size       = { 0, 0, 0, 0 };  // dimensione catturata (= client)
+    POINT      origin     = { 0, 0 };  // origine di cattura (ClientToScreen di 0,0)
+    UINT       dpi        = 0;         // DPI effettivo del monitor al momento della cattura
+    HWND       hwnd       = nullptr;   // finestra a cui appartiene la cattura
+    ULONGLONG  startTime  = 0;         // inizio della rampa di desaturazione
+    float      lastAmount = -1.0f;     // ultima desaturazione applicata a workBitmap
+    bool       valid      = false;
+};
+static BackdropCache g_backdropCache;
+static std::recursive_mutex g_cacheMutex;
+
+static void InvalidateBackdropCache() {
+    std::lock_guard<std::recursive_mutex> lock(g_cacheMutex);
+    g_backdropCache.valid = false;
+}
+
 
 static void LoadSettings() {
     std::lock_guard<std::mutex> lock(g_settingsMutex);
-    constexpr int kDefaultDesaturationPercent = 20;
+    constexpr int kDefaultDesaturationPercent = 65;
+    const int oldDesaturationPercent = g_settings.desaturationPercent.load();
     int desaturationPercent = Wh_GetIntSetting(L"desaturationPercent");
     g_settings.desaturationPercent.store(
         desaturationPercent >= 0 && desaturationPercent <= 100
             ? desaturationPercent
             : kDefaultDesaturationPercent
     );
+    // Se cambia la desaturazione, la cache dello sfondo va ricostruita.
+    if (g_settings.desaturationPercent.load() != oldDesaturationPercent)
+        InvalidateBackdropCache();
+    g_settings.desaturationRampMs.store(std::clamp(Wh_GetIntSetting(L"desaturationRampMs"), 0, 10000));
     g_settings.boxSizePercent.store(std::clamp(Wh_GetIntSetting(L"boxSizePercent"), 50, 200));
     g_settings.fontSizePercent.store(std::clamp(Wh_GetIntSetting(L"fontSizePercent"), 50, 200));
 
@@ -154,17 +207,6 @@ private:
     HGDIOBJ object_;
 };
 
-class ScopedDc {
-public:
-    explicit ScopedDc(HDC dc = nullptr) : dc_(dc) {}
-    ~ScopedDc() { if (dc_) DeleteDC(dc_); }
-    ScopedDc(const ScopedDc&) = delete;
-    HDC get() const { return dc_; }
-    explicit operator bool() const { return dc_ != nullptr; }
-private:
-    HDC dc_;
-};
-
 class ScopedSelection {
 public:
     ScopedSelection(HDC dc, HGDIOBJ object) : dc_(dc), old_(dc && object ? SelectObject(dc, object) : HGDIOBJ(HGDI_ERROR)) {}
@@ -191,59 +233,215 @@ static UINT GetPrimaryMonitorDpi() {
     return dpiX;
 }
 
-// Uses only documented GDI APIs. A 32-bit DIB section gives direct access to
-// the captured pixels, so the desaturation is not dependent on GDI+ behavior.
-static bool PaintSnapshotWithGentleDesaturation(HWND hwnd, HDC hdc, const RECT& area) {
-    if (!hdc) return false;
-    const int width = area.right - area.left;
-    const int height = area.bottom - area.top;
-    if (width <= 0 || height <= 0) return false;
-
-    BITMAPINFO bitmapInfo = {};
-    bitmapInfo.bmiHeader.biSize = sizeof(bitmapInfo.bmiHeader);
-    bitmapInfo.bmiHeader.biWidth = width;
-    bitmapInfo.bmiHeader.biHeight = -height;  // top-down, 32-bit BGR DIB
-    bitmapInfo.bmiHeader.biPlanes = 1;
-    bitmapInfo.bmiHeader.biBitCount = 32;
-    bitmapInfo.bmiHeader.biCompression = BI_RGB;
-    void* pixels = nullptr;
-    ScopedGdiObject bitmap(CreateDIBSection(nullptr, &bitmapInfo, DIB_RGB_COLORS,
-                                             &pixels, nullptr, 0));
-    if (!bitmap || !pixels) return false;
-
-    HDC screen = GetDC(nullptr);
-    if (!screen) return false;
-    ScopedDc memoryDc(CreateCompatibleDC(screen));
-    if (!memoryDc) { ReleaseDC(nullptr, screen); return false; }
-    {
-        ScopedSelection selection(memoryDc.get(), bitmap.get());
-        if (!selection.selected()) { ReleaseDC(nullptr, screen); return false; }
-        POINT topLeft = { area.left, area.top };
-        if (!ClientToScreen(hwnd, &topLeft)) {
-            ReleaseDC(nullptr, screen);
-            return false;
-        }
-        if (!BitBlt(memoryDc.get(), 0, 0, width, height, screen, topLeft.x, topLeft.y,
-                    SRCCOPY | CAPTUREBLT)) {
-            ReleaseDC(nullptr, screen);
-            return false;
-        }
-        ReleaseDC(nullptr, screen);
-
-        // BI_RGB 32-bit DIB pixels are B, G, R, unused/reserved. Blend every
-        // channel toward its luminance while leaving the alpha/reserved byte.
-        auto* pixel = static_cast<BYTE*>(pixels);
-        const float amount = g_settings.desaturationPercent.load() / 100.0f;
-        for (size_t i = 0, count = static_cast<size_t>(width) * height; i < count; ++i) {
-            BYTE* color = pixel + i * 4;
-            const float luminance = color[2] * 0.299f + color[1] * 0.587f + color[0] * 0.114f;
-            color[0] = static_cast<BYTE>(color[0] + (luminance - color[0]) * amount);
-            color[1] = static_cast<BYTE>(color[1] + (luminance - color[1]) * amount);
-            color[2] = static_cast<BYTE>(color[2] + (luminance - color[2]) * amount);
-        }
-        BitBlt(hdc, area.left, area.top, width, height, memoryDc.get(), 0, 0, SRCCOPY);
-    }
+// Origine della regione di schermo da catturare: ClientToScreen dell'angolo
+// client, esattamente come nel codice originale del mod. NESSUNA conversione
+// di spazio di coordinate e NESSUN ridimensionamento: la resa resta identica
+// all'originale a ogni DPI (nessuno zoom); la cache elimina le scie.
+static bool GetBackdropOrigin(HWND hwnd, POINT* originOut) {
+    POINT origin = { 0, 0 };
+    if (!ClientToScreen(hwnd, &origin))
+        return false;
+    if (originOut)
+        *originOut = origin;
     return true;
+}
+
+// DPI effettivo del monitor su cui sta la finestra (96 = scala 100%).
+// Indipendente dal livello di DPI-awareness del processo: e' la vera
+// impostazione di scala dell'utente, usato per convalidare la cache.
+static UINT GetMonitorDpiForWindow(HWND hwnd) {
+    HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    UINT dpiX = 96, dpiY = 96;
+    if (monitor) GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY);
+    return dpiX;
+}
+
+// DPI da usare per DISEGNARE nella finestra, coerente con il livello di
+// DPI-awareness del processo: per processi DPI-unaware restituisce 96 (le
+// unita' del DC sono logiche e il sistema scala il risultato), per processi
+// aware il DPI reale del monitor su cui sta la finestra.
+static UINT GetWindowDpi(HWND hwnd) {
+    typedef UINT(WINAPI* GetDpiForWindow_t)(HWND);
+    static const GetDpiForWindow_t getDpiForWindow =
+        (GetDpiForWindow_t)GetProcAddress(GetModuleHandleW(L"user32.dll"), "GetDpiForWindow");
+    if (getDpiForWindow) {
+        const UINT dpi = getDpiForWindow(hwnd);
+        if (dpi != 0)
+            return dpi;
+    }
+    return GetPrimaryMonitorDpi();
+}
+
+
+
+// Cattura lo schermo nell'area client UNA volta sola, con la STESSA semantica
+// dell'originale (origine = ClientToScreen(0,0), dimensione = client): resa
+// identica all'originale a ogni DPI, senza zoom. La cattura resta VERGINE:
+// la desaturazione progressiva viene applicata per-frame sulla copia di
+// lavoro, partendo sempre da questa base pulita (niente scie a cascata).
+static bool BuildBackdropCache(HWND hwnd, const RECT& clientRect, UINT dpi) {
+    POINT origin = {};
+    if (!GetBackdropOrigin(hwnd, &origin))
+        return false;
+    // Dimensione della cattura = dimensione del client DC, come nell'originale:
+    // il blit finale e' sempre 1:1 (nessuno zoom).
+    const int width = clientRect.right - clientRect.left;
+    const int height = clientRect.bottom - clientRect.top;
+    if (width <= 0 || height <= 0)
+        return false;
+
+    std::lock_guard<std::recursive_mutex> lock(g_cacheMutex);
+
+    // Libera la vecchia cache.
+    if (g_backdropCache.rawDc)
+        DeleteDC(g_backdropCache.rawDc);
+    if (g_backdropCache.rawBitmap)
+        DeleteObject(g_backdropCache.rawBitmap);
+    if (g_backdropCache.workDc)
+        DeleteDC(g_backdropCache.workDc);
+    if (g_backdropCache.workBitmap)
+        DeleteObject(g_backdropCache.workBitmap);
+    g_backdropCache = {};
+
+    HDC screenDC = GetDC(nullptr);
+    if (!screenDC)
+        return false;
+
+    BITMAPINFO bmi = {};
+    bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
+    bmi.bmiHeader.biWidth = width;
+    bmi.bmiHeader.biHeight = -height;  // top-down, 32-bit BGR DIB
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    void* rawPixels = nullptr;
+    HBITMAP rawDib = CreateDIBSection(screenDC, &bmi, DIB_RGB_COLORS, &rawPixels, nullptr, 0);
+    void* workPixels = nullptr;
+    HBITMAP workDib = CreateDIBSection(screenDC, &bmi, DIB_RGB_COLORS, &workPixels, nullptr, 0);
+    if (!rawDib || !rawPixels || !workDib || !workPixels) {
+        if (rawDib) DeleteObject(rawDib);
+        if (workDib) DeleteObject(workDib);
+        ReleaseDC(nullptr, screenDC);
+        return false;
+    }
+
+    HDC rawDc = CreateCompatibleDC(screenDC);
+    HDC workDc = CreateCompatibleDC(screenDC);
+    if (!rawDc || !workDc) {
+        if (rawDc) DeleteDC(rawDc);
+        if (workDc) DeleteDC(workDc);
+        DeleteObject(rawDib);
+        DeleteObject(workDib);
+        ReleaseDC(nullptr, screenDC);
+        return false;
+    }
+
+    HGDIOBJ oldRaw = SelectObject(rawDc, rawDib);
+    HGDIOBJ oldWork = SelectObject(workDc, workDib);
+    if (!oldRaw || oldRaw == HGDI_ERROR || !oldWork || oldWork == HGDI_ERROR) {
+        if (oldRaw && oldRaw != HGDI_ERROR) SelectObject(rawDc, oldRaw);
+        if (oldWork && oldWork != HGDI_ERROR) SelectObject(workDc, oldWork);
+        DeleteDC(rawDc);
+        DeleteDC(workDc);
+        DeleteObject(rawDib);
+        DeleteObject(workDib);
+        ReleaseDC(nullptr, screenDC);
+        return false;
+    }
+
+    const bool captured = BitBlt(rawDc, 0, 0, width, height, screenDC,
+                                 origin.x, origin.y, SRCCOPY | CAPTUREBLT);
+    ReleaseDC(nullptr, screenDC);
+    if (!captured) {
+        SelectObject(rawDc, oldRaw);
+        SelectObject(workDc, oldWork);
+        DeleteDC(rawDc);
+        DeleteDC(workDc);
+        DeleteObject(rawDib);
+        DeleteObject(workDib);
+        return false;
+    }
+
+    // Copia iniziale: la copia di lavoro parte dalla cattura vergine.
+    BitBlt(workDc, 0, 0, width, height, rawDc, 0, 0, SRCCOPY);
+
+    g_backdropCache.rawBitmap = rawDib;
+    g_backdropCache.rawDc = rawDc;
+    g_backdropCache.workBitmap = workDib;
+    g_backdropCache.workDc = workDc;
+    g_backdropCache.workPixels = workPixels;
+    g_backdropCache.size = { 0, 0, width, height };
+    g_backdropCache.origin = origin;
+    g_backdropCache.dpi = dpi;
+    g_backdropCache.hwnd = hwnd;
+    g_backdropCache.startTime = GetTickCount64();
+    g_backdropCache.lastAmount = -1.0f;
+    g_backdropCache.valid = true;
+    return true;
+}
+
+// Disegna lo sfondo sull'HDC partendo SEMPRE dalla cattura vergine, con
+// desaturazione progressiva come in Windows 7: all'inizio il colore e'
+// pieno, poi sfuma verso il valore scelto nell'arco di desaturationRampMs
+// millisecondi (0 = applicazione istantanea). La cache ha le stesse
+// dimensioni del client DC, quindi il blit e' SEMPRE 1:1: niente
+// StretchBlt, niente zoom.
+static bool PaintCachedBackdrop(HDC hdc, const RECT& clientRect) {
+    std::lock_guard<std::recursive_mutex> lock(g_cacheMutex);
+    if (!g_backdropCache.valid || !g_backdropCache.rawDc || !g_backdropCache.workDc)
+        return false;
+
+    const int width = clientRect.right - clientRect.left;
+    const int height = clientRect.bottom - clientRect.top;
+    if (width <= 0 || height <= 0)
+        return false;
+
+    // Quanto desaturare in QUESTO frame, in base al tempo trascorso.
+    const float target = g_settings.desaturationPercent.load() / 100.0f;
+    float amount = 0.0f;
+    if (target > 0.0f) {
+        const int rampMs = g_settings.desaturationRampMs.load();
+        const ULONGLONG elapsed = GetTickCount64() - g_backdropCache.startTime;
+        if (rampMs <= 0 || elapsed >= (ULONGLONG)rampMs) {
+            amount = target;  // rampa completata (o disabilitata): valore finale
+        } else {
+            double t = (double)elapsed / (double)rampMs;
+            t = t * t * (3.0 - 2.0 * t);  // smoothstep, come la transizione di Win7
+            amount = target * (float)t;
+        }
+    }
+
+    // Riallaccia l'animazione: finche' la rampa non e' completa, forza un
+    // nuovo paint (senza, con pochi paint la progressivita' si perderebbe).
+    if (amount < target && g_backdropCache.hwnd)
+        InvalidateRect(g_backdropCache.hwnd, nullptr, FALSE);
+
+    // Se la desaturazione non e' cambiata, la copia di lavoro e' gia' pronta:
+    // si evita la copia e il passaggio per-pixel inutili.
+    if (amount != g_backdropCache.lastAmount) {
+        // Riparte SEMPRE dalla cattura vergine: mai dallo schermo (che
+        // conterrebbe il box del frame precedente -> scie a cascata).
+        BitBlt(g_backdropCache.workDc, 0, 0, width, height,
+               g_backdropCache.rawDc, 0, 0, SRCCOPY);
+
+        // Desaturazione in place (BI_RGB 32-bit: byte B, G, R, riservato).
+        if (amount > 0.0f && g_backdropCache.workPixels) {
+            auto* pixel = static_cast<BYTE*>(g_backdropCache.workPixels);
+            const size_t count = (size_t)width * (size_t)height;
+            for (size_t i = 0; i < count; ++i) {
+                BYTE* color = pixel + i * 4;
+                const float luminance = color[2] * 0.299f + color[1] * 0.587f + color[0] * 0.114f;
+                color[0] = static_cast<BYTE>(color[0] + (luminance - color[0]) * amount);
+                color[1] = static_cast<BYTE>(color[1] + (luminance - color[1]) * amount);
+                color[2] = static_cast<BYTE>(color[2] + (luminance - color[2]) * amount);
+            }
+        }
+        g_backdropCache.lastAmount = amount;
+    }
+
+    return BitBlt(hdc, clientRect.left, clientRect.top, width, height,
+                  g_backdropCache.workDc, 0, 0, SRCCOPY);
 }
 
 static RECT GetBoxSurfaceArea(const RECT& clientArea) {
@@ -271,10 +469,10 @@ static bool DrawClassicPleaseWaitBox(HWND hwnd, HDC hdc) {
     if (!hwnd || !GetClientRect(hwnd, &clientArea)) return false;
     if (clientArea.right <= clientArea.left || clientArea.bottom <= clientArea.top) return false;
 
-    if (!PaintSnapshotWithGentleDesaturation(hwnd, hdc, clientArea)) return false;
-
+    // Lo sfondo in cache e' gia' stato disegnato dal hook a OGNI DPI: niente
+    // ricattura qui (includerebbe il box del frame precedente -> scie).
     const RECT boxArea = GetBoxSurfaceArea(clientArea);
-    const UINT dpi = GetPrimaryMonitorDpi();
+    const UINT dpi = GetWindowDpi(hwnd);
     const int boxWidth = ScaleBoxForDpi(210, dpi);
     const int boxHeight = ScaleBoxForDpi(74, dpi);
     const int rim = std::max(1, ScaleBoxForDpi(5, dpi));
@@ -344,16 +542,59 @@ static bool DrawClassicPleaseWaitBox(HWND hwnd, HDC hdc) {
     RestoreDC(hdc, savedDc);
     return true;
 }
-
 static void THISCALL CDimmedWindow_OnPaintHook(CDimmedWindow* window, HDC hdc) {
-    bool drawn = false;
-    if (hdc) {
-        HWND hwnd = WindowFromDC(hdc);
-        drawn = DrawClassicPleaseWaitBox(hwnd, hdc);
+    if (!hdc) {
+        if (g_originalOnPaint) g_originalOnPaint(window, hdc);
+        return;
     }
-    if (!drawn && g_originalOnPaint) {
-        g_originalOnPaint(window, hdc);
+
+    HWND hwnd = WindowFromDC(hdc);
+    RECT clientRect = {};
+    if (!hwnd || !GetClientRect(hwnd, &clientRect)) {
+        if (g_originalOnPaint) g_originalOnPaint(window, hdc);
+        return;
     }
+    if (clientRect.right <= clientRect.left || clientRect.bottom <= clientRect.top) {
+        if (g_originalOnPaint) g_originalOnPaint(window, hdc);
+        return;
+    }
+
+    // DPI effettivo del monitor (96 = scala 100%, 120 = 125%, ...). A OGNI
+    // DPI si usa lo stesso percorso: sfondo in cache con cattura unica per
+    // evitare le scie. Il comportamento a 100% e' identico a quello a 125%.
+    const UINT monitorDpi = GetMonitorDpiForWindow(hwnd);
+    POINT origin = {};
+    const bool haveOrigin = GetBackdropOrigin(hwnd, &origin);
+    const int clientWidth = clientRect.right - clientRect.left;
+    const int clientHeight = clientRect.bottom - clientRect.top;
+
+    {
+        std::lock_guard<std::recursive_mutex> lock(g_cacheMutex);
+
+        // Ricrea la cache se non esiste o se cambia finestra, DPI, dimensione
+        // o posizione: un cambio DPI a runtime invalida subito la cache.
+        if (!g_backdropCache.valid ||
+            !haveOrigin ||
+            g_backdropCache.hwnd != hwnd ||
+            g_backdropCache.dpi != monitorDpi ||
+            g_backdropCache.origin.x != origin.x ||
+            g_backdropCache.origin.y != origin.y ||
+            g_backdropCache.size.right != clientWidth ||
+            g_backdropCache.size.bottom != clientHeight) {
+            if (haveOrigin)
+                BuildBackdropCache(hwnd, clientRect, monitorDpi);
+        }
+
+        // Sfondo: SEMPRE dalla cache, mai dallo schermo (che conterrebbe il
+        // box del frame precedente -> scie a cascata).
+        if (!g_backdropCache.valid || !PaintCachedBackdrop(hdc, clientRect)) {
+            if (g_originalOnPaint) g_originalOnPaint(window, hdc);
+            return;
+        }
+    }
+
+    // Box sopra lo sfondo, senza ricattura.
+    DrawClassicPleaseWaitBox(hwnd, hdc);
 }
 
 static bool HookThemeUiSymbols(HMODULE themeUi) {

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -447,14 +447,17 @@ BOOL Wh_ModInit()
             return FALSE;
         }
 
-        WindhawkUtils::SYMBOL_HOOK hook = {
-            { L"private: void __cdecl CDimmedWindow::OnPaint(struct HDC__ *)" },
-            &g_originalOnPaint,
-            CDimmedWindow_OnPaintHook,
-            false
+        // themeui.dll
+        WindhawkUtils::SYMBOL_HOOK themeUiDllHooks[] = {
+            {
+                { L"private: void __cdecl CDimmedWindow::OnPaint(struct HDC__ *)" },
+                &g_originalOnPaint,
+                CDimmedWindow_OnPaintHook,
+                false
+            }
         };
 
-        if (!WindhawkUtils::HookSymbols(themeUi.get(), &hook, 1)) {
+        if (!WindhawkUtils::HookSymbols(themeUi.get(), themeUiDllHooks, ARRAYSIZE(themeUiDllHooks))) {
             Wh_Log(L"CDimmedWindow::OnPaint was not resolved on this Windows build; disabling the mod safely");
             return FALSE;
         }

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -367,7 +367,7 @@ static void THISCALL CDimmedWindow_OnPaintHook(CDimmedWindow* window, HDC hdc) {
 
 static bool HookThemeUiSymbols(HMODULE themeUi) {
     WindhawkUtils::SYMBOL_HOOK themeuiDllHook = {
-        { { L"private: void " STHICALL L" CDimmedWindow::OnPaint(struct HDC__ *)" } },
+        { L"private: void " STHICALL L" CDimmedWindow::OnPaint(struct HDC__ *)" },
         &g_originalOnPaint, CDimmedWindow_OnPaintHook, false
     };
     if (!WindhawkUtils::HookSymbols(themeUi, &themeuiDllHook, 1)) {

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -8,7 +8,7 @@
 // @include      rundll32.exe
 // @include      explorer.exe
 // @include      SystemSettings.exe
-// @compilerOptions -lgdi32 -lshcore
+// @compilerOptions -lgdi32 -lshcore -lmsimg32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -73,6 +73,7 @@ the DPI.
 #include <windhawk_utils.h>
 #include <algorithm>
 #include <atomic>
+#include <cmath>
 #include <mutex>
 
 #ifdef _WIN64
@@ -102,35 +103,45 @@ struct Settings {
 static Settings g_settings = { 65, 500, 105, 115, L"", false };
 
 // ---------------------------------------------------------------------------
-// Sfondo in cache: catturato e desaturato UNA sola volta, con la STESSA
-// semantica di coordinate dell'originale (origine = ClientToScreen(0,0),
-// dimensione = client). Il paint usa sempre questa cache e non ricattura mai
-// lo schermo (che conterrebbe il box del frame precedente -> scie a cascata).
-// Nessuna conversione e nessun ridimensionamento: nessuno zoom a nessun DPI.
+// Cached backdrop: captured ONCE with the SAME coordinate semantics as the
+// original (origin = ClientToScreen(0,0), size = client). Paint always uses
+// this cache and never recaptures the screen (which would contain the previous
+// frame's box -> cascading trails). No coordinate space conversion and no
+// resizing: rendering is identical at every DPI with no zoom artifacts.
 //
-// Il percorso in cache e' usato a OGNI DPI, compreso il 100%: la resa a 100%
-// e' identica a quella verificata a 125%. La desaturazione e' progressiva,
-// come in Windows 7: parte dalla cattura vergine e aumenta nel tempo fino al
-// valore scelto (desaturationRampMs ne regola la durata). La cache registra
-// il DPI (e la finestra) con cui e' stata costruita: se il DPI cambia durante
-// l'esecuzione viene ricostruita subito, senza ambiguita'.
+// Desaturation is progressive, like in Windows 7: starts from the pristine
+// capture and increases over time to the chosen value (desaturationRampMs
+// controls the duration). The cache records the DPI and window it was built
+// for: if DPI changes during execution it is rebuilt immediately without
+// ambiguity.
 // ---------------------------------------------------------------------------
 struct BackdropCache {
-    HBITMAP    rawBitmap  = nullptr;   // cattura vergine, mai desaturata
-    HDC        rawDc      = nullptr;   // memory DC con rawBitmap selezionata
-    HBITMAP    workBitmap = nullptr;   // copia di lavoro per la desaturazione per-frame
-    HDC        workDc     = nullptr;   // memory DC con workBitmap selezionata
-    void*      workPixels = nullptr;   // pixel di workBitmap (DIB section 32 bpp)
-    RECT       size       = { 0, 0, 0, 0 };  // dimensione catturata (= client)
-    POINT      origin     = { 0, 0 };  // origine di cattura (ClientToScreen di 0,0)
-    UINT       dpi        = 0;         // DPI effettivo del monitor al momento della cattura
-    HWND       hwnd       = nullptr;   // finestra a cui appartiene la cattura
-    ULONGLONG  startTime  = 0;         // inizio della rampa di desaturazione
-    float      lastAmount = -1.0f;     // ultima desaturazione applicata a workBitmap
-    bool       valid      = false;
+    HBITMAP    rawBitmap   = nullptr;  // raw capture, never desaturated
+    HDC        rawDc       = nullptr;  // memory DC with rawBitmap selected
+    HBITMAP    grayBitmap  = nullptr;  // fully desaturated copy, built once at capture time
+    HDC        grayDc      = nullptr;  // memory DC with grayBitmap selected
+    HBITMAP    compBitmap  = nullptr;  // offscreen compositing buffer (backdrop + box)
+    HDC        compDc      = nullptr;  // memory DC with compBitmap selected
+    RECT       size        = { 0, 0, 0, 0 };  // captured size (= client)
+    POINT      origin      = { 0, 0 };  // capture origin (ClientToScreen of 0,0)
+    UINT       dpi         = 0;         // effective monitor DPI at capture time
+    HWND       hwnd        = nullptr;   // window the capture belongs to
+    ULONGLONG  startTime   = 0;         // start of the desaturation ramp
+    bool       valid       = false;
 };
 static BackdropCache g_backdropCache;
 static std::recursive_mutex g_cacheMutex;
+
+static void FreeBackdropCache() {
+    std::lock_guard<std::recursive_mutex> lock(g_cacheMutex);
+    if (g_backdropCache.rawDc) DeleteDC(g_backdropCache.rawDc);
+    if (g_backdropCache.rawBitmap) DeleteObject(g_backdropCache.rawBitmap);
+    if (g_backdropCache.grayDc) DeleteDC(g_backdropCache.grayDc);
+    if (g_backdropCache.grayBitmap) DeleteObject(g_backdropCache.grayBitmap);
+    if (g_backdropCache.compDc) DeleteDC(g_backdropCache.compDc);
+    if (g_backdropCache.compBitmap) DeleteObject(g_backdropCache.compBitmap);
+    g_backdropCache = {};
+}
 
 static void InvalidateBackdropCache() {
     std::lock_guard<std::recursive_mutex> lock(g_cacheMutex);
@@ -148,7 +159,7 @@ static void LoadSettings() {
             ? desaturationPercent
             : kDefaultDesaturationPercent
     );
-    // Se cambia la desaturazione, la cache dello sfondo va ricostruita.
+    // If desaturation changes, the backdrop cache needs rebuilding.
     if (g_settings.desaturationPercent.load() != oldDesaturationPercent)
         InvalidateBackdropCache();
     g_settings.desaturationRampMs.store(std::clamp(Wh_GetIntSetting(L"desaturationRampMs"), 0, 10000));
@@ -233,10 +244,10 @@ static UINT GetPrimaryMonitorDpi() {
     return dpiX;
 }
 
-// Origine della regione di schermo da catturare: ClientToScreen dell'angolo
-// client, esattamente come nel codice originale del mod. NESSUNA conversione
-// di spazio di coordinate e NESSUN ridimensionamento: la resa resta identica
-// all'originale a ogni DPI (nessuno zoom); la cache elimina le scie.
+// Origin of the screen region to capture: ClientToScreen of the client corner,
+// exactly as in the original mod code. No coordinate space conversion and no
+// resizing: rendering stays identical to the original at every DPI with no
+// zoom; the cache eliminates trails entirely.
 static bool GetBackdropOrigin(HWND hwnd, POINT* originOut) {
     POINT origin = { 0, 0 };
     if (!ClientToScreen(hwnd, &origin))
@@ -246,9 +257,9 @@ static bool GetBackdropOrigin(HWND hwnd, POINT* originOut) {
     return true;
 }
 
-// DPI effettivo del monitor su cui sta la finestra (96 = scala 100%).
-// Indipendente dal livello di DPI-awareness del processo: e' la vera
-// impostazione di scala dell'utente, usato per convalidare la cache.
+// Effective DPI of the monitor containing the window (96 = 100% scale).
+// Independent of the process DPI-awareness level: this is the user's true
+// scale setting, used to validate the cache.
 static UINT GetMonitorDpiForWindow(HWND hwnd) {
     HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
     UINT dpiX = 96, dpiY = 96;
@@ -256,10 +267,10 @@ static UINT GetMonitorDpiForWindow(HWND hwnd) {
     return dpiX;
 }
 
-// DPI da usare per DISEGNARE nella finestra, coerente con il livello di
-// DPI-awareness del processo: per processi DPI-unaware restituisce 96 (le
-// unita' del DC sono logiche e il sistema scala il risultato), per processi
-// aware il DPI reale del monitor su cui sta la finestra.
+// DPI to use for DRAWING in the window, consistent with the process
+// DPI-awareness level: for DPI-unaware processes returns 96 (DC units are
+// logical and the system scales the result), for aware processes the real
+// DPI of the monitor containing the window.
 static UINT GetWindowDpi(HWND hwnd) {
     typedef UINT(WINAPI* GetDpiForWindow_t)(HWND);
     static const GetDpiForWindow_t getDpiForWindow =
@@ -274,17 +285,18 @@ static UINT GetWindowDpi(HWND hwnd) {
 
 
 
-// Cattura lo schermo nell'area client UNA volta sola, con la STESSA semantica
-// dell'originale (origine = ClientToScreen(0,0), dimensione = client): resa
-// identica all'originale a ogni DPI, senza zoom. La cattura resta VERGINE:
-// la desaturazione progressiva viene applicata per-frame sulla copia di
-// lavoro, partendo sempre da questa base pulita (niente scie a cascata).
+// Captures the screen in the client area ONCE, with the SAME semantics as the
+// original (origin = ClientToScreen(0,0), size = client): rendering identical
+// to the original at every DPI, without zoom. The capture stays PRISTINE:
+// progressive desaturation is applied per-frame via AlphaBlend between the raw
+// capture and the fully desaturated copy, always starting from this clean base
+// (no cascading trails).
 static bool BuildBackdropCache(HWND hwnd, const RECT& clientRect, UINT dpi) {
     POINT origin = {};
     if (!GetBackdropOrigin(hwnd, &origin))
         return false;
-    // Dimensione della cattura = dimensione del client DC, come nell'originale:
-    // il blit finale e' sempre 1:1 (nessuno zoom).
+    // Capture size = client DC size, as in the original: the final blit is
+    // always 1:1 (no zoom).
     const int width = clientRect.right - clientRect.left;
     const int height = clientRect.bottom - clientRect.top;
     if (width <= 0 || height <= 0)
@@ -292,15 +304,13 @@ static bool BuildBackdropCache(HWND hwnd, const RECT& clientRect, UINT dpi) {
 
     std::lock_guard<std::recursive_mutex> lock(g_cacheMutex);
 
-    // Libera la vecchia cache.
-    if (g_backdropCache.rawDc)
-        DeleteDC(g_backdropCache.rawDc);
-    if (g_backdropCache.rawBitmap)
-        DeleteObject(g_backdropCache.rawBitmap);
-    if (g_backdropCache.workDc)
-        DeleteDC(g_backdropCache.workDc);
-    if (g_backdropCache.workBitmap)
-        DeleteObject(g_backdropCache.workBitmap);
+    // Free the old cache.
+    if (g_backdropCache.rawDc) DeleteDC(g_backdropCache.rawDc);
+    if (g_backdropCache.rawBitmap) DeleteObject(g_backdropCache.rawBitmap);
+    if (g_backdropCache.grayDc) DeleteDC(g_backdropCache.grayDc);
+    if (g_backdropCache.grayBitmap) DeleteObject(g_backdropCache.grayBitmap);
+    if (g_backdropCache.compDc) DeleteDC(g_backdropCache.compDc);
+    if (g_backdropCache.compBitmap) DeleteObject(g_backdropCache.compBitmap);
     g_backdropCache = {};
 
     HDC screenDC = GetDC(nullptr);
@@ -317,35 +327,45 @@ static bool BuildBackdropCache(HWND hwnd, const RECT& clientRect, UINT dpi) {
 
     void* rawPixels = nullptr;
     HBITMAP rawDib = CreateDIBSection(screenDC, &bmi, DIB_RGB_COLORS, &rawPixels, nullptr, 0);
-    void* workPixels = nullptr;
-    HBITMAP workDib = CreateDIBSection(screenDC, &bmi, DIB_RGB_COLORS, &workPixels, nullptr, 0);
-    if (!rawDib || !rawPixels || !workDib || !workPixels) {
+    void* grayPixels = nullptr;
+    HBITMAP grayDib = CreateDIBSection(screenDC, &bmi, DIB_RGB_COLORS, &grayPixels, nullptr, 0);
+    void* compPixels = nullptr;
+    HBITMAP compDib = CreateDIBSection(screenDC, &bmi, DIB_RGB_COLORS, &compPixels, nullptr, 0);
+    if (!rawDib || !rawPixels || !grayDib || !grayPixels || !compDib || !compPixels) {
         if (rawDib) DeleteObject(rawDib);
-        if (workDib) DeleteObject(workDib);
+        if (grayDib) DeleteObject(grayDib);
+        if (compDib) DeleteObject(compDib);
         ReleaseDC(nullptr, screenDC);
         return false;
     }
 
     HDC rawDc = CreateCompatibleDC(screenDC);
-    HDC workDc = CreateCompatibleDC(screenDC);
-    if (!rawDc || !workDc) {
+    HDC grayDc = CreateCompatibleDC(screenDC);
+    HDC compDc = CreateCompatibleDC(screenDC);
+    if (!rawDc || !grayDc || !compDc) {
         if (rawDc) DeleteDC(rawDc);
-        if (workDc) DeleteDC(workDc);
+        if (grayDc) DeleteDC(grayDc);
+        if (compDc) DeleteDC(compDc);
         DeleteObject(rawDib);
-        DeleteObject(workDib);
+        DeleteObject(grayDib);
+        DeleteObject(compDib);
         ReleaseDC(nullptr, screenDC);
         return false;
     }
 
     HGDIOBJ oldRaw = SelectObject(rawDc, rawDib);
-    HGDIOBJ oldWork = SelectObject(workDc, workDib);
-    if (!oldRaw || oldRaw == HGDI_ERROR || !oldWork || oldWork == HGDI_ERROR) {
+    HGDIOBJ oldGray = SelectObject(grayDc, grayDib);
+    HGDIOBJ oldComp = SelectObject(compDc, compDib);
+    if (!oldRaw || oldRaw == HGDI_ERROR || !oldGray || oldGray == HGDI_ERROR || !oldComp || oldComp == HGDI_ERROR) {
         if (oldRaw && oldRaw != HGDI_ERROR) SelectObject(rawDc, oldRaw);
-        if (oldWork && oldWork != HGDI_ERROR) SelectObject(workDc, oldWork);
+        if (oldGray && oldGray != HGDI_ERROR) SelectObject(grayDc, oldGray);
+        if (oldComp && oldComp != HGDI_ERROR) SelectObject(compDc, oldComp);
         DeleteDC(rawDc);
-        DeleteDC(workDc);
+        DeleteDC(grayDc);
+        DeleteDC(compDc);
         DeleteObject(rawDib);
-        DeleteObject(workDib);
+        DeleteObject(grayDib);
+        DeleteObject(compDib);
         ReleaseDC(nullptr, screenDC);
         return false;
     }
@@ -355,94 +375,44 @@ static bool BuildBackdropCache(HWND hwnd, const RECT& clientRect, UINT dpi) {
     ReleaseDC(nullptr, screenDC);
     if (!captured) {
         SelectObject(rawDc, oldRaw);
-        SelectObject(workDc, oldWork);
+        SelectObject(grayDc, oldGray);
+        SelectObject(compDc, oldComp);
         DeleteDC(rawDc);
-        DeleteDC(workDc);
+        DeleteDC(grayDc);
+        DeleteDC(compDc);
         DeleteObject(rawDib);
-        DeleteObject(workDib);
+        DeleteObject(grayDib);
+        DeleteObject(compDib);
         return false;
     }
 
-    // Copia iniziale: la copia di lavoro parte dalla cattura vergine.
-    BitBlt(workDc, 0, 0, width, height, rawDc, 0, 0, SRCCOPY);
+    // Copy raw to gray and fully desaturate it once.
+    BitBlt(grayDc, 0, 0, width, height, rawDc, 0, 0, SRCCOPY);
+    if (grayPixels) {
+        auto* pixel = static_cast<BYTE*>(grayPixels);
+        const size_t count = (size_t)width * (size_t)height;
+        for (size_t i = 0; i < count; ++i) {
+            BYTE* color = pixel + i * 4;
+            const float luminance = color[2] * 0.299f + color[1] * 0.587f + color[0] * 0.114f;
+            color[0] = color[1] = color[2] = static_cast<BYTE>(luminance);
+        }
+    }
 
     g_backdropCache.rawBitmap = rawDib;
     g_backdropCache.rawDc = rawDc;
-    g_backdropCache.workBitmap = workDib;
-    g_backdropCache.workDc = workDc;
-    g_backdropCache.workPixels = workPixels;
+    g_backdropCache.grayBitmap = grayDib;
+    g_backdropCache.grayDc = grayDc;
+    g_backdropCache.compBitmap = compDib;
+    g_backdropCache.compDc = compDc;
     g_backdropCache.size = { 0, 0, width, height };
     g_backdropCache.origin = origin;
     g_backdropCache.dpi = dpi;
     g_backdropCache.hwnd = hwnd;
     g_backdropCache.startTime = GetTickCount64();
-    g_backdropCache.lastAmount = -1.0f;
     g_backdropCache.valid = true;
     return true;
 }
 
-// Disegna lo sfondo sull'HDC partendo SEMPRE dalla cattura vergine, con
-// desaturazione progressiva come in Windows 7: all'inizio il colore e'
-// pieno, poi sfuma verso il valore scelto nell'arco di desaturationRampMs
-// millisecondi (0 = applicazione istantanea). La cache ha le stesse
-// dimensioni del client DC, quindi il blit e' SEMPRE 1:1: niente
-// StretchBlt, niente zoom.
-static bool PaintCachedBackdrop(HDC hdc, const RECT& clientRect) {
-    std::lock_guard<std::recursive_mutex> lock(g_cacheMutex);
-    if (!g_backdropCache.valid || !g_backdropCache.rawDc || !g_backdropCache.workDc)
-        return false;
-
-    const int width = clientRect.right - clientRect.left;
-    const int height = clientRect.bottom - clientRect.top;
-    if (width <= 0 || height <= 0)
-        return false;
-
-    // Quanto desaturare in QUESTO frame, in base al tempo trascorso.
-    const float target = g_settings.desaturationPercent.load() / 100.0f;
-    float amount = 0.0f;
-    if (target > 0.0f) {
-        const int rampMs = g_settings.desaturationRampMs.load();
-        const ULONGLONG elapsed = GetTickCount64() - g_backdropCache.startTime;
-        if (rampMs <= 0 || elapsed >= (ULONGLONG)rampMs) {
-            amount = target;  // rampa completata (o disabilitata): valore finale
-        } else {
-            double t = (double)elapsed / (double)rampMs;
-            t = t * t * (3.0 - 2.0 * t);  // smoothstep, come la transizione di Win7
-            amount = target * (float)t;
-        }
-    }
-
-    // Riallaccia l'animazione: finche' la rampa non e' completa, forza un
-    // nuovo paint (senza, con pochi paint la progressivita' si perderebbe).
-    if (amount < target && g_backdropCache.hwnd)
-        InvalidateRect(g_backdropCache.hwnd, nullptr, FALSE);
-
-    // Se la desaturazione non e' cambiata, la copia di lavoro e' gia' pronta:
-    // si evita la copia e il passaggio per-pixel inutili.
-    if (amount != g_backdropCache.lastAmount) {
-        // Riparte SEMPRE dalla cattura vergine: mai dallo schermo (che
-        // conterrebbe il box del frame precedente -> scie a cascata).
-        BitBlt(g_backdropCache.workDc, 0, 0, width, height,
-               g_backdropCache.rawDc, 0, 0, SRCCOPY);
-
-        // Desaturazione in place (BI_RGB 32-bit: byte B, G, R, riservato).
-        if (amount > 0.0f && g_backdropCache.workPixels) {
-            auto* pixel = static_cast<BYTE*>(g_backdropCache.workPixels);
-            const size_t count = (size_t)width * (size_t)height;
-            for (size_t i = 0; i < count; ++i) {
-                BYTE* color = pixel + i * 4;
-                const float luminance = color[2] * 0.299f + color[1] * 0.587f + color[0] * 0.114f;
-                color[0] = static_cast<BYTE>(color[0] + (luminance - color[0]) * amount);
-                color[1] = static_cast<BYTE>(color[1] + (luminance - color[1]) * amount);
-                color[2] = static_cast<BYTE>(color[2] + (luminance - color[2]) * amount);
-            }
-        }
-        g_backdropCache.lastAmount = amount;
-    }
-
-    return BitBlt(hdc, clientRect.left, clientRect.top, width, height,
-                  g_backdropCache.workDc, 0, 0, SRCCOPY);
-}
 
 static RECT GetBoxSurfaceArea(const RECT& clientArea) {
     const int width = clientArea.right - clientArea.left;
@@ -469,8 +439,8 @@ static bool DrawClassicPleaseWaitBox(HWND hwnd, HDC hdc) {
     if (!hwnd || !GetClientRect(hwnd, &clientArea)) return false;
     if (clientArea.right <= clientArea.left || clientArea.bottom <= clientArea.top) return false;
 
-    // Lo sfondo in cache e' gia' stato disegnato dal hook a OGNI DPI: niente
-    // ricattura qui (includerebbe il box del frame precedente -> scie).
+    // The cached backdrop is already drawn by the hook at EVERY DPI: no
+    // recapture here (which would include the previous frame's box -> trails).
     const RECT boxArea = GetBoxSurfaceArea(clientArea);
     const UINT dpi = GetWindowDpi(hwnd);
     const int boxWidth = ScaleBoxForDpi(210, dpi);
@@ -559,20 +529,30 @@ static void THISCALL CDimmedWindow_OnPaintHook(CDimmedWindow* window, HDC hdc) {
         return;
     }
 
-    // DPI effettivo del monitor (96 = scala 100%, 120 = 125%, ...). A OGNI
-    // DPI si usa lo stesso percorso: sfondo in cache con cattura unica per
-    // evitare le scie. Il comportamento a 100% e' identico a quello a 125%.
     const UINT monitorDpi = GetMonitorDpiForWindow(hwnd);
     POINT origin = {};
     const bool haveOrigin = GetBackdropOrigin(hwnd, &origin);
     const int clientWidth = clientRect.right - clientRect.left;
     const int clientHeight = clientRect.bottom - clientRect.top;
 
+    // Calculate desaturation amount once, before the lock
+    const float target = g_settings.desaturationPercent.load() / 100.0f;
+    float amount = 0.0f;
+    if (target > 0.0f) {
+        const int rampMs = g_settings.desaturationRampMs.load();
+        const ULONGLONG elapsed = GetTickCount64() - g_backdropCache.startTime;
+        if (rampMs <= 0 || elapsed >= (ULONGLONG)rampMs) {
+            amount = target;
+        } else {
+            double t = (double)elapsed / (double)rampMs;
+            t = t * t * (3.0 - 2.0 * t);
+            amount = target * (float)t;
+        }
+    }
+
     {
         std::lock_guard<std::recursive_mutex> lock(g_cacheMutex);
 
-        // Ricrea la cache se non esiste o se cambia finestra, DPI, dimensione
-        // o posizione: un cambio DPI a runtime invalida subito la cache.
         if (!g_backdropCache.valid ||
             !haveOrigin ||
             g_backdropCache.hwnd != hwnd ||
@@ -585,16 +565,36 @@ static void THISCALL CDimmedWindow_OnPaintHook(CDimmedWindow* window, HDC hdc) {
                 BuildBackdropCache(hwnd, clientRect, monitorDpi);
         }
 
-        // Sfondo: SEMPRE dalla cache, mai dallo schermo (che conterrebbe il
-        // box del frame precedente -> scie a cascata).
-        if (!g_backdropCache.valid || !PaintCachedBackdrop(hdc, clientRect)) {
+        if (!g_backdropCache.valid) {
             if (g_originalOnPaint) g_originalOnPaint(window, hdc);
             return;
         }
-    }
 
-    // Box sopra lo sfondo, senza ricattura.
-    DrawClassicPleaseWaitBox(hwnd, hdc);
+        // Compose everything into the offscreen buffer first
+        if (g_backdropCache.compDc) {
+            // Draw backdrop into compDc
+            BitBlt(g_backdropCache.compDc, 0, 0, clientWidth, clientHeight,
+                   g_backdropCache.rawDc, 0, 0, SRCCOPY);
+            
+            // Apply desaturation
+            if (amount > 0.0f) {
+                BLENDFUNCTION bf = { AC_SRC_OVER, 0, (BYTE)lround(amount * 255.0f), 0 };
+                AlphaBlend(g_backdropCache.compDc, 0, 0, clientWidth, clientHeight,
+                           g_backdropCache.grayDc, 0, 0, clientWidth, clientHeight, bf);
+            }
+            
+            // Draw the box on top in the composition buffer
+            DrawClassicPleaseWaitBox(hwnd, g_backdropCache.compDc);
+            
+            // Single blit to screen - no flash
+            BitBlt(hdc, clientRect.left, clientRect.top, clientWidth, clientHeight,
+                   g_backdropCache.compDc, 0, 0, SRCCOPY);
+        }
+        
+        // Keep animation alive
+        if (amount < target && g_backdropCache.hwnd)
+            InvalidateRect(g_backdropCache.hwnd, nullptr, FALSE);
+    }
 }
 
 static bool HookThemeUiSymbols(HMODULE themeUi) {
@@ -667,4 +667,5 @@ void Wh_ModSettingsChanged() {
 
 void Wh_ModUninit() {
     Wh_Log(L">");
+    FreeBackdropCache();
 }

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -84,6 +84,12 @@ class CDimmedWindow;
 using CDimmedWindow_OnPaint_t = void(THISCALL*)(CDimmedWindow*, HDC);
 static CDimmedWindow_OnPaint_t g_originalOnPaint = nullptr;
 
+// Original CDimmedWindow::WndProc (static window procedure of the dimmed
+// window). Hooked so the backdrop cache can be freed on WM_NCDESTROY; the
+// hook is installed/uninstalled together with the OnPaint hook, so no
+// subclass bookkeeping (and no cross-thread subclass removal) is needed.
+static WNDPROC g_originalWndProc = nullptr;
+
 static std::atomic<bool> g_themeUiHandled = false;
 static std::mutex g_settingsMutex;
 
@@ -546,39 +552,54 @@ static void THISCALL CDimmedWindow_OnPaintHook(CDimmedWindow* window, HDC hdc) {
     const int clientWidth = clientRect.right - clientRect.left;
     const int clientHeight = clientRect.bottom - clientRect.top;
 
-    // Calculate desaturation amount once, before the lock
-    const float target = g_settings.desaturationPercent.load() / 100.0f;
-    float amount = 0.0f;
-    if (target > 0.0f) {
-        const int rampMs = g_settings.desaturationRampMs.load();
-        const ULONGLONG elapsed = GetTickCount64() - g_backdropCache.startTime;
-        if (rampMs <= 0 || elapsed >= (ULONGLONG)rampMs) {
-            amount = target;
-        } else {
-            double t = (double)elapsed / (double)rampMs;
-            t = t * t * (3.0 - 2.0 * t);
-            amount = target * (float)t;
-        }
-    }
-
     {
         std::lock_guard<std::recursive_mutex> lock(g_cacheMutex);
 
-        if (!g_backdropCache.valid ||
-            !haveOrigin ||
-            g_backdropCache.hwnd != hwnd ||
-            g_backdropCache.dpi != monitorDpi ||
-            g_backdropCache.origin.x != origin.x ||
-            g_backdropCache.origin.y != origin.y ||
-            g_backdropCache.size.right != clientWidth ||
-            g_backdropCache.size.bottom != clientHeight) {
+        // Use the cache only if it was built for this window and still
+        // matches its current position/size/DPI.
+        const bool cacheMatches =
+            g_backdropCache.valid &&
+            g_backdropCache.hwnd == hwnd &&
+            g_backdropCache.dpi == monitorDpi &&
+            g_backdropCache.origin.x == origin.x &&
+            g_backdropCache.origin.y == origin.y &&
+            g_backdropCache.size.right == clientWidth &&
+            g_backdropCache.size.bottom == clientHeight;
+
+        if (!cacheMatches) {
             if (haveOrigin)
                 BuildBackdropCache(hwnd, clientRect, monitorDpi);
+            // If the origin could not be resolved or the capture failed,
+            // do not fall back to a capture that belongs to a different
+            // window: paint the original content instead.
+            if (!haveOrigin || !g_backdropCache.valid) {
+                if (g_originalOnPaint) g_originalOnPaint(window, hdc);
+                return;
+            }
         }
 
-        if (!g_backdropCache.valid) {
-            if (g_originalOnPaint) g_originalOnPaint(window, hdc);
-            return;
+        // The desaturation amount is computed here, after the cache has
+        // been built, so the ramp always starts from the fresh startTime
+        // that BuildBackdropCache just set. Computing it before the build
+        // meant the first frame saw startTime == 0 (or a stale value from
+        // a previous switch), so elapsed >= rampMs held and the frame
+        // snapped straight to the target desaturation - and because
+        // amount < target was then false, no further frame was scheduled
+        // and the ramp never played at all. Computing it under the lock
+        // also makes the ULONGLONG startTime read atomic (on x86 it was
+        // a potentially torn read).
+        const float target = g_settings.desaturationPercent.load() / 100.0f;
+        float amount = 0.0f;
+        if (target > 0.0f) {
+            const int rampMs = g_settings.desaturationRampMs.load();
+            const ULONGLONG elapsed = GetTickCount64() - g_backdropCache.startTime;
+            if (rampMs <= 0 || elapsed >= (ULONGLONG)rampMs) {
+                amount = target;
+            } else {
+                double t = (double)elapsed / (double)rampMs;
+                t = t * t * (3.0 - 2.0 * t);
+                amount = target * (float)t;
+            }
         }
 
         // Compose everything into the offscreen buffer first
@@ -608,13 +629,45 @@ static void THISCALL CDimmedWindow_OnPaintHook(CDimmedWindow* window, HDC hdc) {
     }
 }
 
+// The dimmed window is destroyed when the theme switch finishes. The cache
+// holds three full-screen 32-bpp DIB sections plus three memory DCs
+// (~25 MB at 1080p, ~100 MB at 4K, more on multi-monitor setups): keeping
+// it until the mod is unloaded would leave that memory resident in the
+// long-lived explorer.exe / SystemSettings.exe process after every switch.
+// Tying the cache lifetime to its window also means a later dimmed window
+// that happens to reuse the same HWND value can never be painted with the
+// previous switch's capture.
+static void FreeBackdropCacheIfForWindow(HWND hwnd) {
+    std::lock_guard<std::recursive_mutex> lock(g_cacheMutex);
+    if (g_backdropCache.hwnd == hwnd)
+        FreeBackdropCache();
+}
+
+static LRESULT CALLBACK CDimmedWindow_WndProcHook(HWND hWnd, UINT uMsg,
+                                                  WPARAM wParam, LPARAM lParam) {
+    if (uMsg == WM_NCDESTROY)
+        FreeBackdropCacheIfForWindow(hWnd);
+    return g_originalWndProc(hWnd, uMsg, wParam, lParam);
+}
+
 static bool HookThemeUiSymbols(HMODULE themeUi) {
-    WindhawkUtils::SYMBOL_HOOK themeuiDllHook = {
-        { L"private: void " STHICALL L" CDimmedWindow::OnPaint(struct HDC__ *)" },
-        &g_originalOnPaint, CDimmedWindow_OnPaintHook, false
+    WindhawkUtils::SYMBOL_HOOK themeuiDllHooks[] = {
+        {
+            { L"private: void " STHICALL L" CDimmedWindow::OnPaint(struct HDC__ *)" },
+            &g_originalOnPaint, CDimmedWindow_OnPaintHook, false
+        },
+        {
+            {
+                // x64 and x86 undecorated names; the first one that matches
+                // the module's symbols is used.
+                L"private: static __int64 __cdecl CDimmedWindow::WndProc(struct HWND__ *,unsigned int,unsigned __int64,__int64)",
+                L"private: static long __stdcall CDimmedWindow::WndProc(struct HWND__ *,unsigned int,unsigned int,long)",
+            },
+            &g_originalWndProc, CDimmedWindow_WndProcHook, false
+        },
     };
-    if (!WindhawkUtils::HookSymbols(themeUi, &themeuiDllHook, 1)) {
-        Wh_Log(L"CDimmedWindow::OnPaint was not resolved");
+    if (!WindhawkUtils::HookSymbols(themeUi, themeuiDllHooks, ARRAYSIZE(themeuiDllHooks))) {
+        Wh_Log(L"CDimmedWindow symbols were not resolved");
         return false;
     }
     return true;
@@ -678,5 +731,8 @@ void Wh_ModSettingsChanged() {
 
 void Wh_ModUninit() {
     Wh_Log(L">");
+    // Windhawk removes the WndProc/OnPaint hooks automatically on unload,
+    // so unlike the subclassing alternative there is no subclass to remove
+    // here (and therefore no cross-thread RemoveWindowSubclass SendMessage).
     FreeBackdropCache();
 }

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -447,7 +447,6 @@ BOOL Wh_ModInit()
             return FALSE;
         }
 
-        // themeui.dll
         WindhawkUtils::SYMBOL_HOOK themeUiDllHooks[] = {
             {
                 { L"private: void __cdecl CDimmedWindow::OnPaint(struct HDC__ *)" },

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -417,16 +417,14 @@ BOOL Wh_ModInit() {
     }
     return TRUE;
 }
-
-BOOL Wh_ModAfterInit() {
+void Wh_ModAfterInit() {
     Wh_Log(L">");
     HMODULE themeUi = GetModuleHandleW(L"themeui.dll");
     if (themeUi && !g_themeUiHandled.exchange(true)) {
         if (!HookThemeUiSymbols(themeUi))
-            return FALSE;
+            return;
         Wh_ApplyHookOperations();
     }
-    return TRUE;
 }
 
 void Wh_ModSettingsChanged() {

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -1,13 +1,13 @@
 // ==WindhawkMod==
-// @id              win7-please-wait-restorer
-// @name            Windows 7/8.1 "Please Wait" Restorer
-// @description     This mod replaces the theme-switch overlay with the classic "Please wait" box from Windows 7/8.1
-// @version         1.0.0
-// @author          babamohammed
-// @github          https://github.com/babamohammed2022
-// @include         rundll32.exe
-// @include         explorer.exe
-// @include         SystemSettings.exe
+// @id           win7-please-wait-restorer
+// @name         Windows 7/8.1 "Please Wait" Restorer
+// @description  This mod replaces the theme-switch overlay with the classic "Please wait" box from Windows 7/8.1.
+// @version      1.0.0
+// @author       babamohammed 
+// @github       https://github.com/babamohammed2022
+// @include      rundll32.exe
+// @include      explorer.exe
+// @include      SystemSettings.exe
 // @compilerOptions -lgdi32 -lshcore
 // ==/WindhawkMod==
 
@@ -15,9 +15,7 @@
 /*
 # Windows 7/8.1 "Please Wait" Restorer
 
-
 ## About
-
 
 This mod shows the small classic "Please wait" box from Windows 7/8.1 while the
 system changes the theme, instead of the modern full-screen overlay. The
@@ -60,62 +58,63 @@ For specific setups (such as unsupported language), it is recommended to apply t
 */
 // ==/WindhawkModSettings==
 
-
 #include <windows.h>
 #include <shellscalingapi.h>
 #include <windhawk_utils.h>
 #include <algorithm>
 #include <atomic>
-
+#include <mutex>
 
 #ifdef _WIN64
 #define THISCALL _cdecl
-#define STHISCALL L"__cdecl"
+#define STHICALL L"__cdecl"
 #else
 #define THISCALL __thiscall
-#define STHISCALL L"__thiscall"
+#define STHICALL L"__thiscall"
 #endif
 
 class CDimmedWindow;
 using CDimmedWindow_OnPaint_t = void(THISCALL*)(CDimmedWindow*, HDC);
 static CDimmedWindow_OnPaint_t g_originalOnPaint = nullptr;
 
-// This plain flag has no destructor, so no code runs during DLL/process
-// teardown.
 static std::atomic<bool> g_themeUiHandled = false;
+static std::mutex g_settingsMutex;
 
 struct Settings {
-    int desaturationPercent;
-    int boxSizePercent;
-    int fontSizePercent;
+    std::atomic<int> desaturationPercent;
+    std::atomic<int> boxSizePercent;
+    std::atomic<int> fontSizePercent;
     wchar_t customText[256];
+    std::atomic<bool> customTextValid;
 };
 
-static Settings g_settings = { 20, 105, 115, L"" };
+static Settings g_settings = { 20, 105, 115, L"", false };
 
 static void LoadSettings() {
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
     constexpr int kDefaultDesaturationPercent = 20;
-    const int desaturationPercent = Wh_GetIntSetting(L"desaturationPercent");
-    // A percentage outside its meaningful 0..100 range is invalid. Restore
-    // the documented default instead of silently turning it into 0 or 100.
-    g_settings.desaturationPercent =
+    int desaturationPercent = Wh_GetIntSetting(L"desaturationPercent");
+    g_settings.desaturationPercent.store(
         desaturationPercent >= 0 && desaturationPercent <= 100
             ? desaturationPercent
-            : kDefaultDesaturationPercent;
-    g_settings.boxSizePercent = std::clamp(Wh_GetIntSetting(L"boxSizePercent"), 50, 200);
-    g_settings.fontSizePercent = std::clamp(Wh_GetIntSetting(L"fontSizePercent"), 50, 200);
+            : kDefaultDesaturationPercent
+    );
+    g_settings.boxSizePercent.store(std::clamp(Wh_GetIntSetting(L"boxSizePercent"), 50, 200));
+    g_settings.fontSizePercent.store(std::clamp(Wh_GetIntSetting(L"fontSizePercent"), 50, 200));
 
     PCWSTR customText = Wh_GetStringSetting(L"customText");
     size_t customTextLength = 0;
     if (customText) {
-        // The caption must be shorter than 100 characters. This bounded scan
-        // also avoids accepting an excessively long setting value.
-        while (customTextLength < 100 && customText[customTextLength]) ++customTextLength;
+        while (customTextLength < 100 && customText[customTextLength])
+            ++customTextLength;
     }
-    if (customText && customTextLength < 100)
+    if (customText && customTextLength < 100) {
         lstrcpynW(g_settings.customText, customText, ARRAYSIZE(g_settings.customText));
-    else
-        g_settings.customText[0] = L'\0';  // fall back to localized text
+        g_settings.customTextValid.store(true);
+    } else {
+        g_settings.customText[0] = L'\0';
+        g_settings.customTextValid.store(false);
+    }
     if (customText) Wh_FreeStringSetting(customText);
 }
 
@@ -131,18 +130,21 @@ static const LocalizedText kPleaseWaitTexts[] = {
     { MAKELANGID(LANG_FRENCH, SUBLANG_DEFAULT), L"Veuillez patienter" },
     { MAKELANGID(LANG_SPANISH, SUBLANG_DEFAULT), L"Espere" },
     { MAKELANGID(LANG_PORTUGUESE, SUBLANG_DEFAULT), L"Aguarde" },
-    { MAKELANGID(LANG_DUTCH, SUBLANG_DEFAULT), L"Een ogenblik geduld" },
+    { MAKELANGID(LANG_DUTCH, SUBLANG_DEFAULT), L"Even ogenblik geduld" },
     { MAKELANGID(LANG_POLISH, SUBLANG_DEFAULT), L"Prosz\u0119 czeka\u0107" },
-    { MAKELANGID(LANG_RUSSIAN, SUBLANG_DEFAULT), L"\u041F\u043E\u0434\u043E\u0436\u0434\u0438\u0442\u0435" },
-    { MAKELANGID(LANG_JAPANESE, SUBLANG_DEFAULT), L"\u3057\u3070\u3089\u304F\u304A\u5F85\u3061\u304F\u3060\u3055\u3044" },
-    { MAKELANGID(LANG_KOREAN, SUBLANG_DEFAULT), L"\uC7A0\uC2DC \uAE30\uB2E4\uB824 \uC8FC\uC2ED\uC2DC\uC624" },
-    { MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED), L"\u8BF7\u7A0D\u5019" },
-    { MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL), L"\u8ACB\u7A0D\u5019" },
-    { MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_HONGKONG), L"\u8ACB\u7A0D\u5019" },
+    { MAKELANGID(LANG_RUSSIAN, SUBLANG_DEFAULT), L"\u041f\u043e\u0434\u043e\u0436\u0434\u0430\u043d\u0438\u0442\u0435" },
+    { MAKELANGID(LANG_JAPANESE, SUBLANG_DEFAULT), L"\u3057\u3070\u3089\u304a\u5f85\u3061\u304f\u3060\u3055\u3044" },
+    { MAKELANGID(LANG_KOREAN, SUBLANG_DEFAULT), L"\uc7a0\uc2dc \uae30\ub2e4\ub824 \uc8fc\uc2ed\uc2dc\uc624" },
+    { MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED), L"\u8bf7\u7a0d\u5019" },
+    { MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL), L"\u8acb\u7a0d\u5019" },
+    { MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_HONGKONG), L"\u8acb\u7a0d\u5019" },
 };
 
 static const wchar_t* GetPleaseWaitText() {
-    if (g_settings.customText[0]) return g_settings.customText;
+    std::lock_guard<std::mutex> lock(g_settingsMutex);
+    if (g_settings.customTextValid.load() && g_settings.customText[0])
+        return g_settings.customText;
+    
     const LANGID uiLanguage = GetUserDefaultUILanguage();
     for (const auto& entry : kPleaseWaitTexts)
         if (entry.language == uiLanguage) return entry.text;
@@ -175,21 +177,20 @@ private:
 
 class ScopedSelection {
 public:
-    ScopedSelection(HDC dc, HGDIOBJ object) : dc_(dc), old_(dc && object ? SelectObject(dc, object) : HGDI_ERROR) {}
+    ScopedSelection(HDC dc, HGDIOBJ object) : dc_(dc), old_(dc && object ? SelectObject(dc, object) : HGDIOBJ(HGDI_ERROR)) {}
     ~ScopedSelection() { if (dc_ && old_ && old_ != HGDI_ERROR) SelectObject(dc_, old_); }
     bool selected() const { return old_ && old_ != HGDI_ERROR; }
 private:
-    HDC dc_; HGDIOBJ old_;
+    HDC dc_;
+    HGDIOBJ old_;
 };
 
 static int ScaleForDpi(int value, UINT dpi) {
     return MulDiv(value, dpi ? dpi : 96, 96);
 }
 
-// In the supplied 96-DPI Windows 7 reference, the outer frame is about
-// 210 x 74 px. The configured box-size percentage is applied uniformly.
 static int ScaleBoxForDpi(int value, UINT dpi) {
-    return MulDiv(ScaleForDpi(value, dpi), g_settings.boxSizePercent, 100);
+    return MulDiv(ScaleForDpi(value, dpi), g_settings.boxSizePercent.load(), 100);
 }
 
 static UINT GetPrimaryMonitorDpi() {
@@ -202,11 +203,11 @@ static UINT GetPrimaryMonitorDpi() {
 
 // Uses only documented GDI APIs. A 32-bit DIB section gives direct access to
 // the captured pixels, so the desaturation is not dependent on GDI+ behavior.
-static void PaintSnapshotWithGentleDesaturation(HDC hdc, const RECT& area) {
-    if (!hdc) return;
+static bool PaintSnapshotWithGentleDesaturation(HDC hdc, const RECT& area) {
+    if (!hdc) return false;
     const int width = area.right - area.left;
     const int height = area.bottom - area.top;
-    if (width <= 0 || height <= 0) return;
+    if (width <= 0 || height <= 0) return false;
 
     BITMAPINFO bitmapInfo = {};
     bitmapInfo.bmiHeader.biSize = sizeof(bitmapInfo.bmiHeader);
@@ -218,28 +219,28 @@ static void PaintSnapshotWithGentleDesaturation(HDC hdc, const RECT& area) {
     void* pixels = nullptr;
     ScopedGdiObject bitmap(CreateDIBSection(nullptr, &bitmapInfo, DIB_RGB_COLORS,
                                              &pixels, nullptr, 0));
-    if (!bitmap || !pixels) return;
+    if (!bitmap || !pixels) return false;
 
     HDC screen = GetDC(nullptr);
-    if (!screen) return;
+    if (!screen) return false;
     ScopedDc memoryDc(CreateCompatibleDC(screen));
-    if (!memoryDc) { ReleaseDC(nullptr, screen); return; }
+    if (!memoryDc) { ReleaseDC(nullptr, screen); return false; }
     {
         ScopedSelection selection(memoryDc.get(), bitmap.get());
-        if (!selection.selected()) { ReleaseDC(nullptr, screen); return; }
+        if (!selection.selected()) { ReleaseDC(nullptr, screen); return false; }
         const int screenX = GetSystemMetrics(SM_XVIRTUALSCREEN) + area.left;
         const int screenY = GetSystemMetrics(SM_YVIRTUALSCREEN) + area.top;
         if (!BitBlt(memoryDc.get(), 0, 0, width, height, screen, screenX, screenY,
                     SRCCOPY | CAPTUREBLT)) {
             ReleaseDC(nullptr, screen);
-            return;
+            return false;
         }
         ReleaseDC(nullptr, screen);
 
         // BI_RGB 32-bit DIB pixels are B, G, R, unused/reserved. Blend every
         // channel toward its luminance while leaving the alpha/reserved byte.
         auto* pixel = static_cast<BYTE*>(pixels);
-        const float amount = g_settings.desaturationPercent / 100.0f;
+        const float amount = g_settings.desaturationPercent.load() / 100.0f;
         for (size_t i = 0, count = static_cast<size_t>(width) * height; i < count; ++i) {
             BYTE* color = pixel + i * 4;
             const float luminance = color[2] * 0.299f + color[1] * 0.587f + color[0] * 0.114f;
@@ -249,98 +250,124 @@ static void PaintSnapshotWithGentleDesaturation(HDC hdc, const RECT& area) {
         }
         BitBlt(hdc, area.left, area.top, width, height, memoryDc.get(), 0, 0, SRCCOPY);
     }
+    return true;
 }
 
-// The paint DC can represent a virtual-desktop-sized surface. Convert the
-// primary monitor rectangle to that surface only in that case.
 static RECT GetBoxSurfaceArea(const RECT& clientArea) {
     const int width = clientArea.right - clientArea.left;
     const int height = clientArea.bottom - clientArea.top;
     if (width != GetSystemMetrics(SM_CXVIRTUALSCREEN) ||
-        height != GetSystemMetrics(SM_CYVIRTUALSCREEN)) return clientArea;
+        height != GetSystemMetrics(SM_CYVIRTUALSCREEN))
+        return clientArea;
 
     MONITORINFO mi = { sizeof(mi) };
     const POINT origin = { 0, 0 };
     HMONITOR primary = MonitorFromPoint(origin, MONITOR_DEFAULTTOPRIMARY);
-    if (!primary || !GetMonitorInfoW(primary, &mi)) return clientArea;
-    return { clientArea.left + mi.rcMonitor.left - GetSystemMetrics(SM_XVIRTUALSCREEN),
-             clientArea.top + mi.rcMonitor.top - GetSystemMetrics(SM_YVIRTUALSCREEN),
-             clientArea.left + mi.rcMonitor.right - GetSystemMetrics(SM_XVIRTUALSCREEN),
-             clientArea.top + mi.rcMonitor.bottom - GetSystemMetrics(SM_YVIRTUALSCREEN) };
+    if (!primary || !GetMonitorInfoW(primary, &mi))
+        return clientArea;
+    return {
+        clientArea.left + mi.rcMonitor.left - GetSystemMetrics(SM_XVIRTUALSCREEN),
+        clientArea.top + mi.rcMonitor.top - GetSystemMetrics(SM_YVIRTUALSCREEN),
+        clientArea.left + mi.rcMonitor.right - GetSystemMetrics(SM_XVIRTUALSCREEN),
+        clientArea.top + mi.rcMonitor.bottom - GetSystemMetrics(SM_YVIRTUALSCREEN)
+    };
 }
 
-static void DrawClassicPleaseWaitBox(HWND window, HDC hdc) {
+static bool DrawClassicPleaseWaitBox(HWND hwnd, HDC hdc) {
     RECT clientArea = {};
-    if (!window || !GetClientRect(window, &clientArea)) return;
-    if (clientArea.right <= clientArea.left || clientArea.bottom <= clientArea.top) return;
+    if (!hwnd || !GetClientRect(hwnd, &clientArea)) return false;
+    if (clientArea.right <= clientArea.left || clientArea.bottom <= clientArea.top) return false;
 
-    PaintSnapshotWithGentleDesaturation(hdc, clientArea);
+    if (!PaintSnapshotWithGentleDesaturation(hdc, clientArea)) return false;
+
     const RECT boxArea = GetBoxSurfaceArea(clientArea);
     const UINT dpi = GetPrimaryMonitorDpi();
-    const int boxWidth = ScaleBoxForDpi(210, dpi);   // 221 px at 96 DPI
-    const int boxHeight = ScaleBoxForDpi(74, dpi);   // 78 px at 96 DPI
+    const int boxWidth = ScaleBoxForDpi(210, dpi);
+    const int boxHeight = ScaleBoxForDpi(74, dpi);
     const int rim = std::max(1, ScaleBoxForDpi(5, dpi));
     const int border = std::max(1, ScaleBoxForDpi(1, dpi));
-    RECT outer = { boxArea.left + ((boxArea.right - boxArea.left) - boxWidth) / 2,
-                   boxArea.top + ((boxArea.bottom - boxArea.top) - boxHeight) / 2, 0, 0 };
-    outer.right = outer.left + boxWidth; outer.bottom = outer.top + boxHeight;
-    // Restore the previous Aero-like presentation while retaining the current
-    // 221 x 78 px (96-DPI) outer dimensions.
+
+    RECT outer = {
+        boxArea.left + ((boxArea.right - boxArea.left) - boxWidth) / 2,
+        boxArea.top + ((boxArea.bottom - boxArea.top) - boxHeight) / 2,
+        0, 0
+    };
+    outer.right = outer.left + boxWidth;
+    outer.bottom = outer.top + boxHeight;
+
     RECT darkBorder = outer;
     InflateRect(&darkBorder, -rim, -rim);
     RECT content = darkBorder;
     InflateRect(&content, -border, -border);
-    if (content.right <= content.left || content.bottom <= content.top) return;
+    if (content.right <= content.left || content.bottom <= content.top) return false;
 
     ScopedGdiObject outerBrush(CreateSolidBrush(RGB(197, 218, 231)));
     ScopedGdiObject borderBrush(CreateSolidBrush(RGB(118, 131, 139)));
     ScopedGdiObject contentBrush(CreateSolidBrush(RGB(255, 255, 255)));
     ScopedGdiObject topStreakBrush(CreateSolidBrush(RGB(231, 241, 247)));
     ScopedGdiObject bottomStreakBrush(CreateSolidBrush(RGB(177, 208, 225)));
-    if (!outerBrush || !borderBrush || !contentBrush) return;
+    if (!outerBrush || !borderBrush || !contentBrush) return false;
 
     FillRect(hdc, &outer, (HBRUSH)outerBrush.get());
+
     const int inset = std::max(1, ScaleBoxForDpi(1, dpi));
     const int streakHeight = std::max(1, ScaleBoxForDpi(1, dpi));
     if (topStreakBrush && bottomStreakBrush && rim > streakHeight) {
-        RECT topStreak = { outer.left + inset, outer.top + inset,
-                           outer.right - inset, outer.top + inset + streakHeight };
-        RECT bottomStreak = { outer.left + inset, outer.bottom - inset - streakHeight,
-                              outer.right - inset, outer.bottom - inset };
+        RECT topStreak = { outer.left + inset, outer.top + inset, outer.right - inset, outer.top + inset + streakHeight };
+        RECT bottomStreak = { outer.left + inset, outer.bottom - inset - streakHeight, outer.right - inset, outer.bottom - inset };
         FillRect(hdc, &topStreak, (HBRUSH)topStreakBrush.get());
         FillRect(hdc, &bottomStreak, (HBRUSH)bottomStreakBrush.get());
     }
+
     FillRect(hdc, &darkBorder, (HBRUSH)borderBrush.get());
     FillRect(hdc, &content, (HBRUSH)contentBrush.get());
 
     NONCLIENTMETRICSW metrics = { sizeof(metrics) };
     LOGFONTW fontDescription = {};
-    if (SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(metrics), &metrics, 0))
+    if (SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(metrics), &metrics, 0)) {
         fontDescription = metrics.lfMessageFont;
-    else
-        fontDescription.lfHeight = -ScaleForDpi(12, dpi);
+    } else {
+        fontDescription.lfHeight = -12;
+    }
 
-    // Keep the system message-font family/charset, but make the caption bold
-    // and 15% larger as requested.
-    fontDescription.lfHeight = MulDiv(fontDescription.lfHeight, g_settings.fontSizePercent, 100);
+    int baseHeight = fontDescription.lfHeight;
+    fontDescription.lfHeight = -ScaleForDpi(baseHeight < 0 ? -baseHeight : 12, dpi);
+    fontDescription.lfHeight = MulDiv(fontDescription.lfHeight, g_settings.fontSizePercent.load(), 100);
     fontDescription.lfWeight = FW_BOLD;
+
     ScopedGdiObject font(CreateFontIndirectW(&fontDescription));
-    if (!font) return;
+    if (!font) return false;
+
+    int savedDc = SaveDC(hdc);
     ScopedSelection selection(hdc, font.get());
-    if (!selection.selected()) return;
+    if (!selection.selected()) {
+        RestoreDC(hdc, savedDc);
+        return false;
+    }
+
     SetBkMode(hdc, TRANSPARENT);
     SetTextColor(hdc, RGB(0, 0, 0));
     DrawTextW(hdc, GetPleaseWaitText(), -1, &content,
               DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS | DT_NOPREFIX);
+
+    RestoreDC(hdc, savedDc);
+    return true;
 }
 
-void THISCALL CDimmedWindow_OnPaintHook(CDimmedWindow* window, HDC hdc) {
-    if (hdc) DrawClassicPleaseWaitBox(WindowFromDC(hdc), hdc);
+static void THISCALL CDimmedWindow_OnPaintHook(CDimmedWindow* window, HDC hdc) {
+    bool drawn = false;
+    if (hdc) {
+        HWND hwnd = WindowFromDC(hdc);
+        drawn = DrawClassicPleaseWaitBox(hwnd, hdc);
+    }
+    if (!drawn && g_originalOnPaint) {
+        g_originalOnPaint(window, hdc);
+    }
 }
 
 static bool HookThemeUiSymbols(HMODULE themeUi) {
     WindhawkUtils::SYMBOL_HOOK themeuiDllHook = {
-        { L"private: void " STHISCALL L" CDimmedWindow::OnPaint(struct HDC__ *)" },
+        { { L"private: void " STHICALL L" CDimmedWindow::OnPaint(struct HDC__ *)" } },
         &g_originalOnPaint, CDimmedWindow_OnPaintHook, false
     };
     if (!WindhawkUtils::HookSymbols(themeUi, &themeuiDllHook, 1)) {
@@ -355,8 +382,10 @@ static LoadLibraryExW_t LoadLibraryExW_Original = nullptr;
 
 static void HandleLoadedModule(HMODULE module) {
     if (GetModuleHandleW(L"themeui.dll") != module ||
-        g_themeUiHandled.exchange(true)) return;
-    if (HookThemeUiSymbols(module)) Wh_ApplyHookOperations();
+        g_themeUiHandled.exchange(true))
+        return;
+    if (HookThemeUiSymbols(module))
+        Wh_ApplyHookOperations();
 }
 
 static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD flags) {
@@ -368,17 +397,34 @@ static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD f
 BOOL Wh_ModInit() {
     Wh_Log(L">");
     LoadSettings();
-    if (HMODULE themeUi = GetModuleHandleW(L"themeui.dll")) {
+    
+    HMODULE themeUi = GetModuleHandleW(L"themeui.dll");
+    if (themeUi) {
         g_themeUiHandled = true;
-        return HookThemeUiSymbols(themeUi) ? TRUE : FALSE;
+        if (!HookThemeUiSymbols(themeUi))
+            return FALSE;
     }
+
     HMODULE kernelBase = GetModuleHandleW(L"kernelbase.dll");
-    auto loadLibraryExW = kernelBase ? (decltype(&LoadLibraryExW))GetProcAddress(kernelBase, "LoadLibraryExW") : nullptr;
-    if (!loadLibraryExW) { Wh_Log(L"kernelbase!LoadLibraryExW was not found"); return FALSE; }
-    if (!WindhawkUtils::SetFunctionHook(loadLibraryExW, LoadLibraryExW_Hook,
-                                        &LoadLibraryExW_Original)) {
+    auto loadLibraryExW = kernelBase ? (LoadLibraryExW_t)GetProcAddress(kernelBase, "LoadLibraryExW") : nullptr;
+    if (!loadLibraryExW) {
+        Wh_Log(L"kernelbase!LoadLibraryExW was not found");
+        return FALSE;
+    }
+    if (!WindhawkUtils::SetFunctionHook(loadLibraryExW, LoadLibraryExW_Hook, &LoadLibraryExW_Original)) {
         Wh_Log(L"Failed to hook kernelbase!LoadLibraryExW");
         return FALSE;
+    }
+    return TRUE;
+}
+
+BOOL Wh_ModAfterInit() {
+    Wh_Log(L">");
+    HMODULE themeUi = GetModuleHandleW(L"themeui.dll");
+    if (themeUi && !g_themeUiHandled.exchange(true)) {
+        if (!HookThemeUiSymbols(themeUi))
+            return FALSE;
+        Wh_ApplyHookOperations();
     }
     return TRUE;
 }

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -1,25 +1,28 @@
 // ==WindhawkMod==
 // @id              win7-please-wait-restorer
 // @name            Windows 7/8.1 "Please Wait" Restorer
-// @description     This mod replaces the theme-switch overlay with a self-drawn classic "Please wait" box
+// @description     This mod replaces the theme-switch overlay with the classic "Please wait" box from Windows 7/8.1
 // @version         1.0.0
 // @author          babamohammed
 // @github          https://github.com/babamohammed2022
 // @include         rundll32.exe
 // @include         explorer.exe
 // @include         SystemSettings.exe
-// @compilerOptions -lgdi32 -lGdiplus
+// @compilerOptions -lgdi32 -lshcore
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
 /*
 # Windows 7/8.1 "Please Wait" Restorer
 
+
 ## About
 
-When changing the Windows theme, this mod shows the small classic
-"Please wait" box from Windows 7/8.1 instead of the modern full-screen effect.
-The text is shown in the Windows display language when it is supported.
+
+This mod shows the small classic "Please wait" box from Windows 7/8.1 while the
+system changes the theme, instead of the modern full-screen overlay. The
+built-in text is localized for several common display languages while unsupported
+languages use English.
 
 ## Screenshot
 
@@ -27,43 +30,100 @@ The text is shown in the Windows display language when it is supported.
 
 ## Notes
 
-The mod has been tested on Windows 10 1809 (build 17763) and Windows 10 21H2 (build 19044)
-Other Windows 10/11 versions may work, but are not guaranteed. If Windows
-changes the internal theme component used by this mod, Windhawk disables the
-mod safely instead of forcing it to run. Additionally, the mod is a best-effort implementation using
-documented Windows functions where appliable to improve the stability of the mod.
+The mod has been tested on Windows 10 1809 and Windows 10 21H2.
+Additionally, the mod only attaches when `themeui.dll` is actually loaded by one of the
+included processes. If the private themeui symbol is unavailable on a Windows
+build, the mod remains inactive in that process.
+For specific setups (such as unsupported language), it is recommended to apply the required changes using the mod's settings.
 
 ## Credits
-- Nex - Testing on Windows 10 21H2 and providing feedback
+
+- Nex — Testing on Windows 10 21H2 and providing feedback
 */
 // ==/WindhawkModReadme==
 
-#include <windows.h>
-#include <algorithm>
-#include <gdiplus.h>
-#include <windhawk_utils.h>
 
-using namespace Gdiplus;
+// ==WindhawkModSettings==
+/*
+- desaturationPercent: 20
+  $name: Background desaturation (%)
+  $description: This setting changes the amount of color removed from the captured desktop background.
+- boxSizePercent: 105
+  $name: Box size (%)
+  $description: This setting changes the size of the classic box, its borders, and its decorative details.
+- fontSizePercent: 115
+  $name: Text size (%)
+  $description: This setting changes the size of the bold system message font used for the caption.
+- customText: ""
+  $name: Custom text
+  $description: This setting serves as an optional replacement for the localized caption. Leave it empty to use the Windows display language.
+*/
+// ==/WindhawkModSettings==
+
+
+#include <windows.h>
+#include <shellscalingapi.h>
+#include <windhawk_utils.h>
+#include <algorithm>
+#include <atomic>
+
 
 #ifdef _WIN64
-#define STDCALL __cdecl
+#define THISCALL _cdecl
+#define STHISCALL L"__cdecl"
 #else
-#define STDCALL __stdcall
+#define THISCALL __thiscall
+#define STHISCALL L"__thiscall"
 #endif
 
 class CDimmedWindow;
-typedef void(STDCALL* CDimmedWindow_OnPaint_t)(CDimmedWindow* window, HDC hdc);
+using CDimmedWindow_OnPaint_t = void(THISCALL*)(CDimmedWindow*, HDC);
 static CDimmedWindow_OnPaint_t g_originalOnPaint = nullptr;
-static HMODULE g_themeUi = nullptr;
+
+// This plain flag has no destructor, so no code runs during DLL/process
+// teardown.
+static std::atomic<bool> g_themeUiHandled = false;
+
+struct Settings {
+    int desaturationPercent;
+    int boxSizePercent;
+    int fontSizePercent;
+    wchar_t customText[256];
+};
+
+static Settings g_settings = { 20, 105, 115, L"" };
+
+static void LoadSettings() {
+    constexpr int kDefaultDesaturationPercent = 20;
+    const int desaturationPercent = Wh_GetIntSetting(L"desaturationPercent");
+    // A percentage outside its meaningful 0..100 range is invalid. Restore
+    // the documented default instead of silently turning it into 0 or 100.
+    g_settings.desaturationPercent =
+        desaturationPercent >= 0 && desaturationPercent <= 100
+            ? desaturationPercent
+            : kDefaultDesaturationPercent;
+    g_settings.boxSizePercent = std::clamp(Wh_GetIntSetting(L"boxSizePercent"), 50, 200);
+    g_settings.fontSizePercent = std::clamp(Wh_GetIntSetting(L"fontSizePercent"), 50, 200);
+
+    PCWSTR customText = Wh_GetStringSetting(L"customText");
+    size_t customTextLength = 0;
+    if (customText) {
+        // The caption must be shorter than 100 characters. This bounded scan
+        // also avoids accepting an excessively long setting value.
+        while (customTextLength < 100 && customText[customTextLength]) ++customTextLength;
+    }
+    if (customText && customTextLength < 100)
+        lstrcpynW(g_settings.customText, customText, ARRAYSIZE(g_settings.customText));
+    else
+        g_settings.customText[0] = L'\0';  // fall back to localized text
+    if (customText) Wh_FreeStringSetting(customText);
+}
 
 struct LocalizedText {
     LANGID language;
     const wchar_t* text;
 };
 
-// These strings intentionally have no ellipsis, matching the supplied
-// Windows 8.1 Italian reference ("Attendere"). Unicode escapes keep this
-// source portable even when an editor saves it with a legacy code page.
 static const LocalizedText kPleaseWaitTexts[] = {
     { MAKELANGID(LANG_ENGLISH, SUBLANG_DEFAULT), L"Please wait" },
     { MAKELANGID(LANG_ITALIAN, SUBLANG_DEFAULT), L"Attendere" },
@@ -74,409 +134,259 @@ static const LocalizedText kPleaseWaitTexts[] = {
     { MAKELANGID(LANG_DUTCH, SUBLANG_DEFAULT), L"Een ogenblik geduld" },
     { MAKELANGID(LANG_POLISH, SUBLANG_DEFAULT), L"Prosz\u0119 czeka\u0107" },
     { MAKELANGID(LANG_RUSSIAN, SUBLANG_DEFAULT), L"\u041F\u043E\u0434\u043E\u0436\u0434\u0438\u0442\u0435" },
-    { MAKELANGID(LANG_UKRAINIAN, SUBLANG_DEFAULT), L"\u0417\u0430\u0447\u0435\u043A\u0430\u0439\u0442\u0435" },
-    { MAKELANGID(LANG_TURKISH, SUBLANG_DEFAULT), L"L\u00FCtfen bekleyin" },
-    { MAKELANGID(LANG_SWEDISH, SUBLANG_DEFAULT), L"V\u00E4nta" },
-    { MAKELANGID(LANG_NORWEGIAN, SUBLANG_DEFAULT), L"Vent litt" },
-    { MAKELANGID(LANG_DANISH, SUBLANG_DEFAULT), L"Vent venligst" },
-    { MAKELANGID(LANG_FINNISH, SUBLANG_DEFAULT), L"Odota" },
-    { MAKELANGID(LANG_CZECH, SUBLANG_DEFAULT), L"\u010Cekejte pros\u00EDm" },
-    { MAKELANGID(LANG_SLOVAK, SUBLANG_DEFAULT), L"Pros\u00EDm, \u010Dakajte" },
-    { MAKELANGID(LANG_HUNGARIAN, SUBLANG_DEFAULT), L"K\u00E9rem, v\u00E1rjon" },
-    { MAKELANGID(LANG_ROMANIAN, SUBLANG_DEFAULT), L"V\u0103 rug\u0103m a\u0219tepta\u021Bi" },
-    { MAKELANGID(LANG_GREEK, SUBLANG_DEFAULT), L"\u03A0\u03B1\u03C1\u03B1\u03BA\u03B1\u03BB\u03CE \u03C0\u03B5\u03C1\u03B9\u03BC\u03AD\u03BD\u03B5\u03C4\u03B5" },
-    { MAKELANGID(LANG_ARABIC, SUBLANG_DEFAULT), L"\u064A\u0631\u062C\u0649 \u0627\u0644\u0627\u0646\u062A\u0638\u0627\u0631" },
-    { MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT), L"\u05E0\u05D0 \u05D4\u05DE\u05EA\u05DF" },
     { MAKELANGID(LANG_JAPANESE, SUBLANG_DEFAULT), L"\u3057\u3070\u3089\u304F\u304A\u5F85\u3061\u304F\u3060\u3055\u3044" },
     { MAKELANGID(LANG_KOREAN, SUBLANG_DEFAULT), L"\uC7A0\uC2DC \uAE30\uB2E4\uB824 \uC8FC\uC2ED\uC2DC\uC624" },
-    { MAKELANGID(LANG_CHINESE_SIMPLIFIED, SUBLANG_DEFAULT), L"\u8BF7\u7A0D\u5019" },
-    { MAKELANGID(LANG_CHINESE_TRADITIONAL, SUBLANG_DEFAULT), L"\u8ACB\u7A0D\u5019" },
-    { MAKELANGID(LANG_CROATIAN, SUBLANG_DEFAULT), L"Pri\u010Dekajte" },
-    { MAKELANGID(LANG_VIETNAMESE, SUBLANG_DEFAULT), L"Vui l\u00F2ng ch\u1EDD" },
-    { MAKELANGID(LANG_INDONESIAN, SUBLANG_DEFAULT), L"Harap tunggu" },
-    { MAKELANGID(LANG_BULGARIAN, SUBLANG_DEFAULT), L"\u041C\u043E\u043B\u044F, \u0438\u0437\u0447\u0430\u043A\u0430\u0439\u0442\u0435" },
+    { MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED), L"\u8BF7\u7A0D\u5019" },
+    { MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL), L"\u8ACB\u7A0D\u5019" },
+    { MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_HONGKONG), L"\u8ACB\u7A0D\u5019" },
 };
 
-static const wchar_t* GetPleaseWaitText()
-{
-    const WORD primaryLanguage = PRIMARYLANGID(GetUserDefaultUILanguage());
-    for (const auto& entry : kPleaseWaitTexts) {
-        if (PRIMARYLANGID(entry.language) == primaryLanguage) {
-            return entry.text;
-        }
-    }
+static const wchar_t* GetPleaseWaitText() {
+    if (g_settings.customText[0]) return g_settings.customText;
+    const LANGID uiLanguage = GetUserDefaultUILanguage();
+    for (const auto& entry : kPleaseWaitTexts)
+        if (entry.language == uiLanguage) return entry.text;
+    for (const auto& entry : kPleaseWaitTexts)
+        if (PRIMARYLANGID(entry.language) == PRIMARYLANGID(uiLanguage)) return entry.text;
     return L"Please wait";
 }
 
-// RAII wrappers make all early returns safe: each acquired Win32 handle is
-// released at scope exit, including when a C++ exception is caught above it.
 class ScopedGdiObject {
 public:
     explicit ScopedGdiObject(HGDIOBJ object = nullptr) : object_(object) {}
     ~ScopedGdiObject() { if (object_) DeleteObject(object_); }
     ScopedGdiObject(const ScopedGdiObject&) = delete;
-    ScopedGdiObject& operator=(const ScopedGdiObject&) = delete;
     HGDIOBJ get() const { return object_; }
     explicit operator bool() const { return object_ != nullptr; }
 private:
     HGDIOBJ object_;
 };
 
-class ScopedCompatibleDC {
+class ScopedDc {
 public:
-    explicit ScopedCompatibleDC(HDC referenceDc)
-        : dc_(referenceDc ? CreateCompatibleDC(referenceDc) : nullptr) {}
-    ~ScopedCompatibleDC() { if (dc_) DeleteDC(dc_); }
-    ScopedCompatibleDC(const ScopedCompatibleDC&) = delete;
-    ScopedCompatibleDC& operator=(const ScopedCompatibleDC&) = delete;
+    explicit ScopedDc(HDC dc = nullptr) : dc_(dc) {}
+    ~ScopedDc() { if (dc_) DeleteDC(dc_); }
+    ScopedDc(const ScopedDc&) = delete;
     HDC get() const { return dc_; }
     explicit operator bool() const { return dc_ != nullptr; }
 private:
     HDC dc_;
 };
-
-class ScopedScreenDC {
-public:
-    ScopedScreenDC() : dc_(GetDC(nullptr)) {}
-    ~ScopedScreenDC() { if (dc_) ReleaseDC(nullptr, dc_); }
-    ScopedScreenDC(const ScopedScreenDC&) = delete;
-    ScopedScreenDC& operator=(const ScopedScreenDC&) = delete;
-    HDC get() const { return dc_; }
-    explicit operator bool() const { return dc_ != nullptr; }
-private:
-    HDC dc_;
-};
-
-class ScopedModule {
-public:
-    explicit ScopedModule(HMODULE module = nullptr) : module_(module) {}
-    ~ScopedModule() { if (module_) FreeLibrary(module_); }
-    ScopedModule(const ScopedModule&) = delete;
-    ScopedModule& operator=(const ScopedModule&) = delete;
-    HMODULE get() const { return module_; }
-    HMODULE release() {
-        HMODULE result = module_;
-        module_ = nullptr;
-        return result;
-    }
-    explicit operator bool() const { return module_ != nullptr; }
-private:
-    HMODULE module_;
-};
-
-class ScopedGdiplus {
-public:
-    ScopedGdiplus() : token_(0), ready_(false) {}
-    ~ScopedGdiplus() { Stop(); }
-    ScopedGdiplus(const ScopedGdiplus&) = delete;
-    ScopedGdiplus& operator=(const ScopedGdiplus&) = delete;
-
-    bool Start() {
-        if (ready_) return true;
-        GdiplusStartupInput startupInput;
-        ready_ = GdiplusStartup(&token_, &startupInput, nullptr) == Ok;
-        return ready_;
-    }
-    void Stop() {
-        if (ready_) {
-            GdiplusShutdown(token_);
-            token_ = 0;
-            ready_ = false;
-        }
-    }
-    bool ready() const { return ready_; }
-private:
-    ULONG_PTR token_;
-    bool ready_;
-};
-
-static ScopedGdiplus g_gdiplus;
 
 class ScopedSelection {
 public:
-    ScopedSelection(HDC dc, HGDIOBJ object) : dc_(dc), old_(HGDI_ERROR) {
-        if (dc_ && object) old_ = SelectObject(dc_, object);
-    }
-    ~ScopedSelection() {
-        if (dc_ && old_ && old_ != HGDI_ERROR) SelectObject(dc_, old_);
-    }
-    ScopedSelection(const ScopedSelection&) = delete;
-    ScopedSelection& operator=(const ScopedSelection&) = delete;
+    ScopedSelection(HDC dc, HGDIOBJ object) : dc_(dc), old_(dc && object ? SelectObject(dc, object) : HGDI_ERROR) {}
+    ~ScopedSelection() { if (dc_ && old_ && old_ != HGDI_ERROR) SelectObject(dc_, old_); }
     bool selected() const { return old_ && old_ != HGDI_ERROR; }
 private:
-    HDC dc_;
-    HGDIOBJ old_;
+    HDC dc_; HGDIOBJ old_;
 };
 
-// Restore the previous wider proportions (216 × 76 px), then enlarge every
-// part by 5%, including the font, borders and spacing: 227 × 80 px at 96 DPI.
-static constexpr int kReferenceBoxWidth = 216;
-static constexpr int kReferenceBoxHeight = 76;
-static constexpr int kBoxSizePercent = 105;
-// User-selected visible-but-moderate desaturation. Brightness stays nearly
-// unchanged while the desktop colours are reduced by 25%.
-static constexpr REAL kBackgroundDesaturation = 0.25f;
-
-static int ScaleForDpi(int pixelsAt96Dpi, int dpi)
-{
-    return MulDiv(pixelsAt96Dpi, dpi > 0 ? dpi : 96, 96);
+static int ScaleForDpi(int value, UINT dpi) {
+    return MulDiv(value, dpi ? dpi : 96, 96);
 }
 
-static int ScaleBoxForDpi(int pixelsAt96Dpi, int dpi)
-{
-    return MulDiv(ScaleForDpi(pixelsAt96Dpi, dpi), kBoxSizePercent, 100);
+// In the supplied 96-DPI Windows 7 reference, the outer frame is about
+// 210 x 74 px. The configured box-size percentage is applied uniformly.
+static int ScaleBoxForDpi(int value, UINT dpi) {
+    return MulDiv(ScaleForDpi(value, dpi), g_settings.boxSizePercent, 100);
 }
 
-// Windows 7 displayed one message on the primary monitor. On builds where
-// themeui paints one virtual-desktop surface, convert the primary monitor's
-// screen coordinates to the surface's coordinates. This also keeps the box
-// out of the gap between monitors with different positions/resolutions.
-static RECT GetClassicBoxArea(const RECT& paintArea)
-{
-    const int paintWidth = paintArea.right - paintArea.left;
-    const int paintHeight = paintArea.bottom - paintArea.top;
-    const int virtualWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN);
-    const int virtualHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
-
-    if (paintWidth != virtualWidth || paintHeight != virtualHeight) {
-        // This build supplied a monitor-sized paint surface. It is already
-        // the correct coordinate space for the box.
-        return paintArea;
-    }
-
-    const POINT primaryOrigin = { 0, 0 };
-    HMONITOR primaryMonitor = MonitorFromPoint(primaryOrigin, MONITOR_DEFAULTTOPRIMARY);
-    MONITORINFO monitorInfo = {};
-    monitorInfo.cbSize = sizeof(monitorInfo);
-    if (!primaryMonitor || !GetMonitorInfoW(primaryMonitor, &monitorInfo)) {
-        return paintArea;
-    }
-
-    const int virtualLeft = GetSystemMetrics(SM_XVIRTUALSCREEN);
-    const int virtualTop = GetSystemMetrics(SM_YVIRTUALSCREEN);
-    return {
-        paintArea.left + monitorInfo.rcMonitor.left - virtualLeft,
-        paintArea.top + monitorInfo.rcMonitor.top - virtualTop,
-        paintArea.left + monitorInfo.rcMonitor.right - virtualLeft,
-        paintArea.top + monitorInfo.rcMonitor.bottom - virtualTop
-    };
+static UINT GetPrimaryMonitorDpi() {
+    const POINT origin = { 0, 0 };
+    HMONITOR monitor = MonitorFromPoint(origin, MONITOR_DEFAULTTOPRIMARY);
+    UINT dpiX = 96, dpiY = 96;
+    if (monitor) GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY);
+    return dpiX;
 }
 
-// The failed first implementation rendered GDI+ directly to CDimmedWindow's
-// paint DC. That DC may be transparent on current builds. This version keeps
-// the same reliable off-screen snapshot/composite/BitBlt design used by Aero
-// Flip 3D Recreation, but uses a true saturation colour matrix instead of its
-// black veil.
-static void PaintSnapshotWithGentleDesaturation(HDC hdc, const RECT& area)
-{
+// Uses only documented GDI APIs. A 32-bit DIB section gives direct access to
+// the captured pixels, so the desaturation is not dependent on GDI+ behavior.
+static void PaintSnapshotWithGentleDesaturation(HDC hdc, const RECT& area) {
+    if (!hdc) return;
     const int width = area.right - area.left;
     const int height = area.bottom - area.top;
-    if (!g_gdiplus.ready() || !hdc || width <= 0 || height <= 0) return;
+    if (width <= 0 || height <= 0) return;
 
-    ScopedScreenDC screenDc;
-    if (!screenDc) return;
+    BITMAPINFO bitmapInfo = {};
+    bitmapInfo.bmiHeader.biSize = sizeof(bitmapInfo.bmiHeader);
+    bitmapInfo.bmiHeader.biWidth = width;
+    bitmapInfo.bmiHeader.biHeight = -height;  // top-down, 32-bit BGR DIB
+    bitmapInfo.bmiHeader.biPlanes = 1;
+    bitmapInfo.bmiHeader.biBitCount = 32;
+    bitmapInfo.bmiHeader.biCompression = BI_RGB;
+    void* pixels = nullptr;
+    ScopedGdiObject bitmap(CreateDIBSection(nullptr, &bitmapInfo, DIB_RGB_COLORS,
+                                             &pixels, nullptr, 0));
+    if (!bitmap || !pixels) return;
 
-    ScopedCompatibleDC snapshotDc(screenDc.get());
-    ScopedCompatibleDC compositeDc(hdc);
-    if (!snapshotDc || !compositeDc) return;
+    HDC screen = GetDC(nullptr);
+    if (!screen) return;
+    ScopedDc memoryDc(CreateCompatibleDC(screen));
+    if (!memoryDc) { ReleaseDC(nullptr, screen); return; }
+    {
+        ScopedSelection selection(memoryDc.get(), bitmap.get());
+        if (!selection.selected()) { ReleaseDC(nullptr, screen); return; }
+        const int screenX = GetSystemMetrics(SM_XVIRTUALSCREEN) + area.left;
+        const int screenY = GetSystemMetrics(SM_YVIRTUALSCREEN) + area.top;
+        if (!BitBlt(memoryDc.get(), 0, 0, width, height, screen, screenX, screenY,
+                    SRCCOPY | CAPTUREBLT)) {
+            ReleaseDC(nullptr, screen);
+            return;
+        }
+        ReleaseDC(nullptr, screen);
 
-    ScopedGdiObject snapshotBitmap(CreateCompatibleBitmap(screenDc.get(), width, height));
-    ScopedGdiObject compositeBitmap(CreateCompatibleBitmap(hdc, width, height));
-    if (!snapshotBitmap || !compositeBitmap) return;
-
-    // Selection objects are declared after their bitmaps, so they restore the
-    // old stock bitmaps before the bitmap destructors run.
-    ScopedSelection selectSnapshot(snapshotDc.get(), snapshotBitmap.get());
-    ScopedSelection selectComposite(compositeDc.get(), compositeBitmap.get());
-    if (!selectSnapshot.selected() || !selectComposite.selected()) return;
-
-    const int screenX = GetSystemMetrics(SM_XVIRTUALSCREEN) + area.left;
-    const int screenY = GetSystemMetrics(SM_YVIRTUALSCREEN) + area.top;
-    if (!BitBlt(snapshotDc.get(), 0, 0, width, height, screenDc.get(),
-                screenX, screenY, SRCCOPY | CAPTUREBLT)) {
-        return;
+        // BI_RGB 32-bit DIB pixels are B, G, R, unused/reserved. Blend every
+        // channel toward its luminance while leaving the alpha/reserved byte.
+        auto* pixel = static_cast<BYTE*>(pixels);
+        const float amount = g_settings.desaturationPercent / 100.0f;
+        for (size_t i = 0, count = static_cast<size_t>(width) * height; i < count; ++i) {
+            BYTE* color = pixel + i * 4;
+            const float luminance = color[2] * 0.299f + color[1] * 0.587f + color[0] * 0.114f;
+            color[0] = static_cast<BYTE>(color[0] + (luminance - color[0]) * amount);
+            color[1] = static_cast<BYTE>(color[1] + (luminance - color[1]) * amount);
+            color[2] = static_cast<BYTE>(color[2] + (luminance - color[2]) * amount);
+        }
+        BitBlt(hdc, area.left, area.top, width, height, memoryDc.get(), 0, 0, SRCCOPY);
     }
-
-    Bitmap sourceImage(static_cast<HBITMAP>(snapshotBitmap.get()), nullptr);
-    if (sourceImage.GetLastStatus() != Ok) return;
-
-    const REAL i = kBackgroundDesaturation;
-    const ColorMatrix matrix = {{
-        { 1.0f - 0.70f * i, 0.30f * i,        0.30f * i,        0, 0 },
-        { 0.59f * i,        1.0f - 0.41f * i, 0.59f * i,        0, 0 },
-        { 0.11f * i,        0.11f * i,        1.0f - 0.89f * i, 0, 0 },
-        { 0,                 0,                0,                1, 0 },
-        { 0,                 0,                0,                0, 1 }
-    }};
-
-    ImageAttributes attributes;
-    if (attributes.SetColorMatrix(&matrix, ColorMatrixFlagsDefault,
-                                  ColorAdjustTypeBitmap) != Ok) {
-        return;
-    }
-
-    // Crucially, GDI+ now draws into an ordinary memory DC, not into the
-    // potentially transparent theme overlay DC.
-    Graphics graphics(compositeDc.get());
-    if (graphics.GetLastStatus() != Ok ||
-        graphics.DrawImage(&sourceImage, Rect(0, 0, width, height),
-                           0, 0, width, height, UnitPixel, &attributes) != Ok) {
-        return;
-    }
-
-    // This opaque copy is reliable even when the target overlay does not
-    // support direct GDI+/alpha composition.
-    BitBlt(hdc, area.left, area.top, width, height, compositeDc.get(),
-           0, 0, SRCCOPY);
 }
 
-static void DrawClassicPleaseWaitBox(HDC hdc)
-{
-    if (!hdc) return;
+// The paint DC can represent a virtual-desktop-sized surface. Convert the
+// primary monitor rectangle to that surface only in that case.
+static RECT GetBoxSurfaceArea(const RECT& clientArea) {
+    const int width = clientArea.right - clientArea.left;
+    const int height = clientArea.bottom - clientArea.top;
+    if (width != GetSystemMetrics(SM_CXVIRTUALSCREEN) ||
+        height != GetSystemMetrics(SM_CYVIRTUALSCREEN)) return clientArea;
 
-    // On this paint DC, the clipping rectangle is the complete overlay client
-    // area on supported builds. Unlike the old code, no HWND/object-layout
-    // offset is dereferenced to obtain it.
-    RECT paintArea = {};
-    if (GetClipBox(hdc, &paintArea) == ERROR ||
-        paintArea.right <= paintArea.left || paintArea.bottom <= paintArea.top) {
-        return;
-    }
+    MONITORINFO mi = { sizeof(mi) };
+    const POINT origin = { 0, 0 };
+    HMONITOR primary = MonitorFromPoint(origin, MONITOR_DEFAULTTOPRIMARY);
+    if (!primary || !GetMonitorInfoW(primary, &mi)) return clientArea;
+    return { clientArea.left + mi.rcMonitor.left - GetSystemMetrics(SM_XVIRTUALSCREEN),
+             clientArea.top + mi.rcMonitor.top - GetSystemMetrics(SM_YVIRTUALSCREEN),
+             clientArea.left + mi.rcMonitor.right - GetSystemMetrics(SM_XVIRTUALSCREEN),
+             clientArea.top + mi.rcMonitor.bottom - GetSystemMetrics(SM_YVIRTUALSCREEN) };
+}
 
-    // This off-screen snapshot/colour-matrix composition is synchronous. If
-    // it fails, it safely skips the backdrop and still draws the classic box.
-    PaintSnapshotWithGentleDesaturation(hdc, paintArea);
+static void DrawClassicPleaseWaitBox(HWND window, HDC hdc) {
+    RECT clientArea = {};
+    if (!window || !GetClientRect(window, &clientArea)) return;
+    if (clientArea.right <= clientArea.left || clientArea.bottom <= clientArea.top) return;
 
-    const RECT boxArea = GetClassicBoxArea(paintArea);
-    const int dpi = GetDeviceCaps(hdc, LOGPIXELSX);
-    const int outerWidth = ScaleBoxForDpi(kReferenceBoxWidth, dpi);   // 227 px at 96 DPI
-    const int outerHeight = ScaleBoxForDpi(kReferenceBoxHeight, dpi); // 80 px at 96 DPI
+    PaintSnapshotWithGentleDesaturation(hdc, clientArea);
+    const RECT boxArea = GetBoxSurfaceArea(clientArea);
+    const UINT dpi = GetPrimaryMonitorDpi();
+    const int boxWidth = ScaleBoxForDpi(210, dpi);   // 221 px at 96 DPI
+    const int boxHeight = ScaleBoxForDpi(74, dpi);   // 78 px at 96 DPI
     const int rim = std::max(1, ScaleBoxForDpi(5, dpi));
     const int border = std::max(1, ScaleBoxForDpi(1, dpi));
-
-    RECT outer = {
-        boxArea.left + ((boxArea.right - boxArea.left) - outerWidth) / 2,
-        boxArea.top + ((boxArea.bottom - boxArea.top) - outerHeight) / 2,
-        0, 0
-    };
-    outer.right = outer.left + outerWidth;
-    outer.bottom = outer.top + outerHeight;
-
+    RECT outer = { boxArea.left + ((boxArea.right - boxArea.left) - boxWidth) / 2,
+                   boxArea.top + ((boxArea.bottom - boxArea.top) - boxHeight) / 2, 0, 0 };
+    outer.right = outer.left + boxWidth; outer.bottom = outer.top + boxHeight;
+    // Restore the previous Aero-like presentation while retaining the current
+    // 221 x 78 px (96-DPI) outer dimensions.
     RECT darkBorder = outer;
     InflateRect(&darkBorder, -rim, -rim);
     RECT content = darkBorder;
     InflateRect(&content, -border, -border);
     if (content.right <= content.left || content.bottom <= content.top) return;
 
-    // Colours sampled/approximated from the supplied Windows 8.1 reference:
-    // pale-blue outer rim, slate-grey one-pixel line, white content.
     ScopedGdiObject outerBrush(CreateSolidBrush(RGB(197, 218, 231)));
     ScopedGdiObject borderBrush(CreateSolidBrush(RGB(118, 131, 139)));
     ScopedGdiObject contentBrush(CreateSolidBrush(RGB(255, 255, 255)));
-    if (!outerBrush || !borderBrush || !contentBrush) return;
-    FillRect(hdc, &outer, static_cast<HBRUSH>(outerBrush.get()));
-
-    // The original frame was not a flat blue fill: it had faint horizontal
-    // Aero-like light streaks. Keep them inside the outer rim, so they never
-    // reduce the white text area or the dark inner border's contrast.
     ScopedGdiObject topStreakBrush(CreateSolidBrush(RGB(231, 241, 247)));
     ScopedGdiObject bottomStreakBrush(CreateSolidBrush(RGB(177, 208, 225)));
+    if (!outerBrush || !borderBrush || !contentBrush) return;
+
+    FillRect(hdc, &outer, (HBRUSH)outerBrush.get());
+    const int inset = std::max(1, ScaleBoxForDpi(1, dpi));
     const int streakHeight = std::max(1, ScaleBoxForDpi(1, dpi));
     if (topStreakBrush && bottomStreakBrush && rim > streakHeight) {
-        RECT topStreak = { outer.left + 1, outer.top + 1,
-                           outer.right - 1, outer.top + 1 + streakHeight };
-        RECT bottomStreak = { outer.left + 1, outer.bottom - 1 - streakHeight,
-                              outer.right - 1, outer.bottom - 1 };
-        FillRect(hdc, &topStreak, static_cast<HBRUSH>(topStreakBrush.get()));
-        FillRect(hdc, &bottomStreak, static_cast<HBRUSH>(bottomStreakBrush.get()));
+        RECT topStreak = { outer.left + inset, outer.top + inset,
+                           outer.right - inset, outer.top + inset + streakHeight };
+        RECT bottomStreak = { outer.left + inset, outer.bottom - inset - streakHeight,
+                              outer.right - inset, outer.bottom - inset };
+        FillRect(hdc, &topStreak, (HBRUSH)topStreakBrush.get());
+        FillRect(hdc, &bottomStreak, (HBRUSH)bottomStreakBrush.get());
     }
+    FillRect(hdc, &darkBorder, (HBRUSH)borderBrush.get());
+    FillRect(hdc, &content, (HBRUSH)contentBrush.get());
 
-    FillRect(hdc, &darkBorder, static_cast<HBRUSH>(borderBrush.get()));
-    FillRect(hdc, &content, static_cast<HBRUSH>(contentBrush.get()));
-
+    NONCLIENTMETRICSW metrics = { sizeof(metrics) };
     LOGFONTW fontDescription = {};
-    fontDescription.lfHeight = -ScaleBoxForDpi(12, dpi);
+    if (SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(metrics), &metrics, 0))
+        fontDescription = metrics.lfMessageFont;
+    else
+        fontDescription.lfHeight = -ScaleForDpi(12, dpi);
+
+    // Keep the system message-font family/charset, but make the caption bold
+    // and 15% larger as requested.
+    fontDescription.lfHeight = MulDiv(fontDescription.lfHeight, g_settings.fontSizePercent, 100);
     fontDescription.lfWeight = FW_BOLD;
-    fontDescription.lfQuality = CLEARTYPE_QUALITY;
-    fontDescription.lfCharSet = DEFAULT_CHARSET;
-    lstrcpynW(fontDescription.lfFaceName, L"Segoe UI", LF_FACESIZE);
     ScopedGdiObject font(CreateFontIndirectW(&fontDescription));
     if (!font) return;
-
-    ScopedSelection selectFont(hdc, font.get());
+    ScopedSelection selection(hdc, font.get());
+    if (!selection.selected()) return;
     SetBkMode(hdc, TRANSPARENT);
     SetTextColor(hdc, RGB(0, 0, 0));
     DrawTextW(hdc, GetPleaseWaitText(), -1, &content,
-              DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
+              DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS | DT_NOPREFIX);
 }
 
-void STDCALL CDimmedWindow_OnPaintHook(CDimmedWindow* window, HDC hdc)
-{
-    // This mod deliberately replaces the original overlay paint. Calling the
-    // original here would restore the full-screen Windows 10/11 dimming that
-    // the mod is intended to remove.
-    (void)window;
-    if (!hdc) return;
-
-    try {
-        DrawClassicPleaseWaitBox(hdc);
-    }
-    catch (...) {
-        // A rendering failure must never bring down Explorer, rundll32 or
-        // Settings. RAII objects created by the drawing path are unwound here.
-        Wh_Log(L"Please Wait Restorer: an unexpected C++ exception occurred while drawing; this frame was skipped safely");
-    }
+void THISCALL CDimmedWindow_OnPaintHook(CDimmedWindow* window, HDC hdc) {
+    if (hdc) DrawClassicPleaseWaitBox(WindowFromDC(hdc), hdc);
 }
 
-BOOL Wh_ModInit()
-{
-    Wh_Log(L"Please Wait Restorer 1.0.0: initializing safe classic-overlay mode");
-
-    try {
-        // The box remains available if documented GDI+ colour adjustment is
-        // unavailable; only the optional desaturation is skipped.
-        if (!g_gdiplus.Start()) {
-            Wh_Log(L"Please Wait Restorer: GDI+ unavailable; continuing without desaturation");
-        }
-
-        // If initialization returns early or HookSymbols fails, this wrapper
-        // releases the reference acquired by LoadLibrary automatically.
-        ScopedModule themeUi(LoadLibraryW(L"themeui.dll"));
-        if (!themeUi) {
-            Wh_Log(L"themeui.dll could not be loaded; disabling the mod safely");
-            return FALSE;
-        }
-
-        WindhawkUtils::SYMBOL_HOOK themeUiDllHooks[] = {
-            {
-                { L"private: void __cdecl CDimmedWindow::OnPaint(struct HDC__ *)" },
-                &g_originalOnPaint,
-                CDimmedWindow_OnPaintHook,
-                false
-            }
-        };
-
-        if (!WindhawkUtils::HookSymbols(themeUi.get(), themeUiDllHooks, ARRAYSIZE(themeUiDllHooks))) {
-            Wh_Log(L"CDimmedWindow::OnPaint was not resolved on this Windows build; disabling the mod safely");
-            return FALSE;
-        }
-
-        // Keep the module loaded for the host process. This avoids unloading
-        // code that may still be used by the hooked Windows component.
-        g_themeUi = themeUi.release();
-        return TRUE;
+static bool HookThemeUiSymbols(HMODULE themeUi) {
+    WindhawkUtils::SYMBOL_HOOK hook = {
+        { L"private: void " STHISCALL L" CDimmedWindow::OnPaint(struct HDC__ *)" },
+        &g_originalOnPaint, CDimmedWindow_OnPaintHook, false
+    };
+    if (!WindhawkUtils::HookSymbols(themeUi, &hook, 1)) {
+        Wh_Log(L"CDimmedWindow::OnPaint was not resolved");
+        return false;
     }
-    catch (...) {
-        Wh_Log(L"Please Wait Restorer: an unexpected C++ exception occurred during initialization; disabling safely");
+    return true;
+}
+
+using LoadLibraryExW_t = decltype(&LoadLibraryExW);
+static LoadLibraryExW_t LoadLibraryExW_Original = nullptr;
+
+static void HandleLoadedModule(HMODULE module) {
+    if (GetModuleHandleW(L"themeui.dll") != module ||
+        g_themeUiHandled.exchange(true)) return;
+    if (HookThemeUiSymbols(module)) Wh_ApplyHookOperations();
+}
+
+static HMODULE WINAPI LoadLibraryExW_Hook(LPCWSTR fileName, HANDLE file, DWORD flags) {
+    HMODULE module = LoadLibraryExW_Original(fileName, file, flags);
+    if (module) HandleLoadedModule(module);
+    return module;
+}
+
+BOOL Wh_ModInit() {
+    Wh_Log(L">");
+    LoadSettings();
+    if (HMODULE themeUi = GetModuleHandleW(L"themeui.dll")) {
+        g_themeUiHandled = true;
+        return HookThemeUiSymbols(themeUi) ? TRUE : FALSE;
+    }
+    HMODULE kernelBase = GetModuleHandleW(L"kernelbase.dll");
+    auto loadLibraryExW = kernelBase ? (decltype(&LoadLibraryExW))GetProcAddress(kernelBase, "LoadLibraryExW") : nullptr;
+    if (!loadLibraryExW) { Wh_Log(L"kernelbase!LoadLibraryExW was not found"); return FALSE; }
+    if (!WindhawkUtils::SetFunctionHook(loadLibraryExW, LoadLibraryExW_Hook,
+                                        &LoadLibraryExW_Original)) {
+        Wh_Log(L"Failed to hook kernelbase!LoadLibraryExW");
         return FALSE;
     }
+    return TRUE;
 }
 
-void Wh_ModUninit()
-{
-    // Windhawk removes the hook before unloading the mod. Do not free
-    // themeui.dll here: it is a Windows module that can still be in use by
-    // the host process, and keeping its normal process lifetime is safest.
-    g_gdiplus.Stop();
-    Wh_Log(L"Please Wait Restorer: unloaded");
+void Wh_ModSettingsChanged() {
+    LoadSettings();
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L">");
 }

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -36,11 +36,7 @@ For specific setups (such as unsupported language), it is recommended to apply t
 
 ## Known Limitations
 
-When the display scaling (DPI) is changed while the mod is active, the mod may
-behave slightly differently (e.g. the captured backdrop or the classic box may
-look off until the next theme switch). To ensure everything is back to normal,
-it is recommended to restart Explorer or log out and log back in after changing
-the DPI.
+On legacy Windows 10 builds (particularly version 1809 and prior), altering the display DPI scaling while the mod is running can result in slight rendering anomalies. For instance, the captured backdrop or classic box may appear misaligned until a subsequent theme change occurs. To ensure full restoration of proper rendering, it is advisable to restart explorer.exe or perform a user logoff/logon cycle following any DPI modification.
 ## Credits
 
 - Nex — Testing on Windows 10 21H2 and providing feedback

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -339,11 +339,11 @@ void THISCALL CDimmedWindow_OnPaintHook(CDimmedWindow* window, HDC hdc) {
 }
 
 static bool HookThemeUiSymbols(HMODULE themeUi) {
-    WindhawkUtils::SYMBOL_HOOK hook = {
+    WindhawkUtils::SYMBOL_HOOK themeuiDllHook = {
         { L"private: void " STHISCALL L" CDimmedWindow::OnPaint(struct HDC__ *)" },
         &g_originalOnPaint, CDimmedWindow_OnPaintHook, false
     };
-    if (!WindhawkUtils::HookSymbols(themeUi, &hook, 1)) {
+    if (!WindhawkUtils::HookSymbols(themeUi, &themeuiDllHook, 1)) {
         Wh_Log(L"CDimmedWindow::OnPaint was not resolved");
         return false;
     }

--- a/mods/win7-please-wait-restorer.wh.cpp
+++ b/mods/win7-please-wait-restorer.wh.cpp
@@ -139,25 +139,22 @@ static void FreeBackdropCache() {
     g_backdropCache = {};
 }
 
-static void InvalidateBackdropCache() {
-    std::lock_guard<std::recursive_mutex> lock(g_cacheMutex);
-    g_backdropCache.valid = false;
-}
-
 
 static void LoadSettings() {
     std::lock_guard<std::mutex> lock(g_settingsMutex);
     constexpr int kDefaultDesaturationPercent = 65;
-    const int oldDesaturationPercent = g_settings.desaturationPercent.load();
+    
     int desaturationPercent = Wh_GetIntSetting(L"desaturationPercent");
     g_settings.desaturationPercent.store(
         desaturationPercent >= 0 && desaturationPercent <= 100
             ? desaturationPercent
             : kDefaultDesaturationPercent
     );
-    // If desaturation changes, the backdrop cache needs rebuilding.
-    if (g_settings.desaturationPercent.load() != oldDesaturationPercent)
-        InvalidateBackdropCache();
+    
+    // REMOVED: InvalidateBackdropCache() call - it caused a lock-order inversion
+    // with g_cacheMutex and isn't needed because desaturationPercent doesn't
+    // affect the cache contents (desaturation is applied per-frame via AlphaBlend).
+    
     g_settings.desaturationRampMs.store(std::clamp(Wh_GetIntSetting(L"desaturationRampMs"), 0, 10000));
     g_settings.boxSizePercent.store(std::clamp(Wh_GetIntSetting(L"boxSizePercent"), 50, 200));
     g_settings.fontSizePercent.store(std::clamp(Wh_GetIntSetting(L"fontSizePercent"), 50, 200));
@@ -190,19 +187,29 @@ static const LocalizedText kPleaseWaitTexts[] = {
     { MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_HONGKONG), L"\u8acb\u7a0d\u5019" },
 };
 
-static const wchar_t* GetPleaseWaitText() {
+static void GetPleaseWaitText(wchar_t (&out)[ARRAYSIZE(Settings::customText)]) {
     std::lock_guard<std::mutex> lock(g_settingsMutex);
-    if (g_settings.customTextValid.load() && g_settings.customText[0])
-        return g_settings.customText;
+    
+    if (g_settings.customText[0]) {
+        lstrcpynW(out, g_settings.customText, ARRAYSIZE(out));
+        return;
+    }
     
     const LANGID uiLanguage = GetUserDefaultUILanguage();
-    for (const auto& entry : kPleaseWaitTexts)
-        if (entry.language == uiLanguage) return entry.text;
-    for (const auto& entry : kPleaseWaitTexts)
-        if (PRIMARYLANGID(entry.language) == PRIMARYLANGID(uiLanguage)) return entry.text;
-    return L"Please wait";
+    for (const auto& entry : kPleaseWaitTexts) {
+        if (entry.language == uiLanguage) {
+            lstrcpynW(out, entry.text, ARRAYSIZE(out));
+            return;
+        }
+    }
+    for (const auto& entry : kPleaseWaitTexts) {
+        if (PRIMARYLANGID(entry.language) == PRIMARYLANGID(uiLanguage)) {
+            lstrcpynW(out, entry.text, ARRAYSIZE(out));
+            return;
+        }
+    }
+    lstrcpynW(out, L"Please wait", ARRAYSIZE(out));
 }
-
 class ScopedGdiObject {
 public:
     explicit ScopedGdiObject(HGDIOBJ object = nullptr) : object_(object) {}
@@ -384,6 +391,10 @@ static bool BuildBackdropCache(HWND hwnd, const RECT& clientRect, UINT dpi) {
 
     // Copy raw to gray and fully desaturate it once.
     BitBlt(grayDc, 0, 0, width, height, rawDc, 0, 0, SRCCOPY);
+    
+    // FIX: Force GDI batch flush before reading pixel data
+    GdiFlush();
+    
     if (grayPixels) {
         auto* pixel = static_cast<BYTE*>(grayPixels);
         const size_t count = (size_t)width * (size_t)height;
@@ -502,7 +513,11 @@ static bool DrawClassicPleaseWaitBox(HWND hwnd, HDC hdc) {
 
     SetBkMode(hdc, TRANSPARENT);
     SetTextColor(hdc, RGB(0, 0, 0));
-    DrawTextW(hdc, GetPleaseWaitText(), -1, &content,
+    
+    // FIX: Use local buffer instead of returning a pointer to shared data
+    wchar_t textBuffer[ARRAYSIZE(Settings::customText)];
+    GetPleaseWaitText(textBuffer);
+    DrawTextW(hdc, textBuffer, -1, &content,
               DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS | DT_NOPREFIX);
 
     RestoreDC(hdc, savedDc);


### PR DESCRIPTION
This mod replaces the theme-switch overlay with a self-drawn classic 'Please wait' box for Windows 7/8.1. It includes localization support for multiple languages.

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog item 1...
* Changelog item 2...

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [X] The submitter, with AI assistance
- - [X] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
