### PR TITLE
Add Win-X Hot Corners 1.3.0

### DIFF
--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         4.4.2
+// @version         4.4.4
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -75,16 +75,6 @@ the zones you want on it. A zone you do not list does nothing.
 - **Right-click → Zones & settings...** — the dashboard: a tab per display,
   a picture of that screen with each zone showing what it does, and the timings
   actually in effect for whichever zone you point at.
-
-### Upgrading from 4.1.x
-
-Earlier versions had no settings page and stored the layout themselves. Your
-zones keep running untouched, so nothing breaks on upgrade — everything else on
-the settings page is live immediately. Re-enter the zones there when you are
-ready; the moment one display is listed, the old layout is ignored.
-
-The startup log names any globals you had customised in the old version, since
-those now come from the settings page and need setting again there.
 
 If the tray icon is hidden, it is in the overflow area — drag it onto the
 taskbar to keep it there.
@@ -273,489 +263,10 @@ Hot corners are disabled when any excluded process is the foreground window.
 
 # Changelog
 
-## What's New in v4.4.2
+## 4.4.4
 
-- **The tray icon stops saying "paused" when a suspension ends.** The corners
-  came back on their own, and the menu was right, but the icon stayed dimmed
-  for the rest of the session — the one piece of feedback you actually look at.
-- **New action: Disabled here.** Setting a zone to this on a named display
-  excludes that screen from a shared `*` zone. Leaving a zone unset still means
-  "not configured" and still falls through to `*`; there was previously no way
-  to say the other thing.
-- **The dashboard no longer marks a zone broken when the wildcard rescues it.**
-  A display-specific zone with unparseable arguments is skipped in favour of
-  the `*` entry, and the preview now follows that same order instead of
-  reporting a zone as dead when it fires perfectly well.
-- **Clearing the last zone on the settings page no longer resurrects a pre-4.2
-  layout.** The handover is one-way once the settings page has owned the
-  configuration.
-- Display changes and taskbar moves queue a rebuild rather than doing it inside
-  the broadcast handler, so the sender is not blocked and a burst of work-area
-  messages collapses into one rebuild instead of resetting every cooldown
-  several times.
-- The dashboard's tab strip no longer runs off the window edge with several
-  displays; labels ellipsise and every tab stays clickable.
-- Readme: removed a paragraph that still argued against having a settings page,
-  and corrected the monitor-list sample and the references to a "selector" the
-  dashboard no longer has.
-
-## What's New in v4.4.1
-
-Two places where a value you changed still had no effect, and two where the
-window could tell you something untrue.
-
-- **Every setting on the page is live immediately after upgrading.** The globals
-  used to be applied only once you had listed a display there, so anyone coming
-  from 4.1.x had a page full of fields that did nothing — change *Cooldown* from
-  300 to 800, see nothing happen. The page owns them all now; only the zone list
-  still falls back to a stored layout. The startup log names any globals you had
-  customised in the old version so you know what to set again.
-- **The tray's "skip while fullscreen" and "skip while dragging" toggles are
-  gone.** They wrote a key that only the upgrade path read, so toggling one
-  worked until the next reload put it back. They are settings, and a mod cannot
-  write its own settings, so the tray copy could only ever drift. They live on
-  the settings page alone. Enable and suspend stay — those have no page
-  equivalent.
-- **Left-click on the tray icon toggles the hot corners**, which is what the
-  readme always said it did; it had been opening the dashboard. The icon dims
-  when they are off, and the dashboard is still the menu's first item.
-- **A zone whose arguments cannot be read is marked, not drawn as working.** A
-  key combination that does not parse, or an Alternate action missing its `|`,
-  used to appear on the preview like any other configured zone while never
-  firing.
-- **The tray menu anchors to the icon even when Windows refuses the GUID
-  registration**, which is the one case the anchoring was added for.
-- **Show Desktop uses the documented `IShellDispatch4::ToggleDesktop`** instead
-  of an undocumented private message to a window the mod does not own. The old
-  route stays as a fallback.
-- **Moving or auto-hiding a taskbar on a secondary display rebuilds the zones.**
-  The polled check only ever saw the primary display's work area, so with
-  *Keep zones out of the taskbar* on, that display's zones stayed put.
-- Dropped the comctl32 dependency — nothing used it after the 4.3.0 rewrite.
-- Clearing one display's name on the settings page no longer drops every
-  display listed after it.
-- Clicking the tray icon immediately after closing the dashboard reopens it
-  rather than doing nothing.
-
-## What's New in v4.4.0
-
-- **Every edge is now three separate zones** — start, middle and end. The two
-  outer stretches used to share one configuration, so `ABC` was impossible.
-- **Neighbouring segments with the same action merge back into one.** That is
-  what makes `AAA`, `AAB`, `ABB` and `ABC` all expressible without a mode
-  switch, and it is not just tidiness: three adjacent zones sharing an action
-  would each re-arm as the pointer crossed a seam, firing repeatedly as you
-  slid along the edge. Segments merge only when they are identical — same
-  action, arguments and overrides.
-- **Your existing layout still works.** A stored edge fills both outer
-  segments, and the middle too when no centre was configured, which reproduces
-  the old geometry exactly — the three identical segments coalesce straight
-  back into the single edge-wide zone you had.
-- **Knock works on corners.** It always did — it is a per-zone setting — but
-  nothing said so. There is a section about it in the readme now.
-- **The tray menu opens at the tray icon** instead of wherever the pointer
-  happened to be, and follows the taskbar to whichever edge it is docked on.
-- **New icon**, and the dashboard window has one again — it lost its icon in
-  4.3.0 when the window was rewritten.
-
-## What's New in v4.3.0
-
-The dashboard is now a picture of your configuration rather than a form.
-
-- **A tab per display**, labelled with its name and carrying a count of how many
-  zones you have set up on it, so "did I configure anything on that screen?" is
-  answerable at a glance. A display that is not plugged in keeps its tab, marked
-  with a dot — its configuration is still real.
-- **The screen is drawn at its real aspect ratio**, so a portrait or ultrawide
-  display looks like one.
-- **Each zone shows what it does.** Side strips read vertically, which is the
-  only way a name like "Notification Centre" fits inside one.
-- **Point at a zone and the panel below shows every timing in effect for it** —
-  size, delay, pass-through guard, knock, cooldown and modifier — with each one
-  marked *global* or *this zone*. A zone inherits five numbers it never used to
-  show, so "why did this one fire late?" was unanswerable without reading the
-  configuration by hand. Click to pin a zone, click again to release it.
-- **Zones taken from the "All displays" configuration say so**, instead of
-  looking like they belong to the display you are viewing.
-- The editing controls are gone. Everything is configured on the settings page,
-  and the window follows it live — change a setting in Windhawk and the picture
-  updates without reopening.
-
-## What's New in v4.2.1
-
-**The settings page is back.** It went away in 4.1.0 because forty settings in
-one flat list was unusable. Windhawk v2 renders them as collapsible groups, so
-that reason is gone.
-
-- **Zones, timings and everything else are configured in Settings.** Add a
-  display, then add only the zones you want on it — no more scrolling past
-  twelve entries to reach the one you use.
-- **Nothing breaks on upgrade.** A layout saved by 4.1.x keeps running exactly
-  as it did, globals included, and the log says so at startup. It is ignored
-  only once you list a display on the settings page.
-- **The dashboard no longer saves.** It was a second surface writing the same
-  store, which is what caused the configuration-swapping bug in 4.1.4. It now
-  tells you to edit in Settings rather than reporting a save that did nothing.
-
-## What's New in v4.1.4
-
-Review fixes, the first of which could lose a display's configuration.
-
-- **The editor bound each configuration to a list position instead of to a
-  display.** Detection has always matched zones by display name, but the
-  dashboard read and wrote whichever stored group sat at the same index as the
-  entry in its dropdown. That list is ordered primary first, then left to right,
-  so making another display primary or unplugging one renumbered it — and the
-  editor would then show one display's zones under another's name, and overwrite
-  them there on save. Each entry is now matched to its stored group by name, a
-  display configured for the first time takes the lowest free group, and a
-  display that is not currently plugged in keeps the group it owns.
-- **Custom Command could silently fail for URLs, shortcuts and folders.** Those
-  go through shell extensions that need COM, and the worker thread running them
-  had no apartment. It initialises one now, and both `ShellExecuteEx` calls ask
-  the shell not to return before it is finished, since that thread has no
-  message loop.
-- **A cooldown consumed the visit.** Walking into a zone shortly after anything
-  else fired and then parking there never fired at all — you had to leave and
-  come back. A cooldown is now a wait rather than a refusal, so staying put
-  outlasts it.
-- **Lock and blank the display no longer blocks unload** for up to ten seconds
-  while it waits out the blanking delay.
-- Argument fields stop input at the length the mod can actually store, rather
-  than truncating past it in silence.
-- The readme no longer claims a 16 ms sample rate without qualification: the
-  wait expires on a system timer tick, so it is 16-31 ms in practice.
-- Dropped an unused header, a brush that was created and destroyed but never
-  used, and a monitor-matching branch that could never be reached.
-
-## What's New in v4.1.3
-
-- **Fixed a crash on unload.** Every thread is given three seconds to stop
-  before the mod frees the locks they share, and a thread that misses that
-  deadline makes the mod leak them instead — freeing something a live thread is
-  still using is undefined behaviour inside Windhawk's own process. The tray
-  thread was the one exception: its timeout was logged and then ignored, so a
-  tray thread that had not finished could have its locks deleted underneath it.
-  It now counts like the others. Waits also treat a failed wait as "still
-  running" rather than as success.
-- **The tray's on/off toggle is serialised with the rest.** It wrote its key
-  outside the reload lock, so a reload running at that moment could put the old
-  value back and leave the switch disagreeing with what was stored.
-
-## What's New in v4.1.2
-
-Two more review fixes, both about threads.
-
-- **Two reloads could finish out of order.** Reloading builds the whole
-  configuration off to the side and swaps it in at the end — which is what keeps
-  the settings lock held briefly, but meant two reloads started close together
-  could publish in the wrong order, leaving the live configuration stale against
-  what was actually saved. Saving from the dashboard, resetting, and the tray's
-  own toggles now hold one lock across both the write and the reload that reads
-  it back, so a reload always sees a settled store.
-- **A failed cursor read slowed detection to the idle rate.** `GetCursorPos`
-  failing is transient, and the zones are still armed while it does — so the
-  right answer is to try again on the next 16 ms tick, not to wait 100 ms. Only
-  the states where nothing can fire at all use the idle rate, which is what the
-  documentation already claimed.
-
-## What's New in v4.1.1
-
-Review fixes on top of v4.1.0, one of them a real race.
-
-- **Fixed: a reload could briefly publish an empty zone set.** Loading the
-  configuration was two steps — write the defaults, then lay the stored values
-  over them — each taking the settings lock separately. In the gap the mod held
-  a complete, plausible, *wrong* configuration with no zones in it. Four of the
-  six things that trigger a reload run on a different thread from the detection
-  loop, and that loop re-checks the display layout twice a second, so a rebuild
-  landing in the gap would arm nothing and log "No zones are active". Loading is
-  now one transaction: the whole configuration is built off to the side and
-  swapped in under a single lock.
-- **That lock is also held for far less time.** It used to cover several hundred
-  value-store reads, an action built per zone, and two log writes — while the
-  detection thread, the action worker and the tray menu all waited on it.
-- **The adaptive poll rate is gone.** v4.1.0 eased the sampling interval off
-  while the cursor was far from every zone. Whichever way that decision is
-  made, it is made from a sample taken *before* the user starts moving, so a
-  flick could cross a zone entirely between two samples. On the outer perimeter
-  that costs a late trigger, because the pointer stops against the screen edge —
-  but a corner shared with a second monitor has no edge to stop against, and
-  there it was a lost one. Detection is back to a flat 16 ms whenever a zone
-  could fire; it still idles at 100 ms when the mod is switched off, suspended,
-  or has no zones armed, where nothing can be missed because nothing can fire.
-- **The dashboard's Reset button said "Reset to Windhawk settings".** There is
-  no Windhawk settings page to go back to. It now says what it does.
-- **The monitor list in the log** still told you to copy a name into the
-  "Monitor" setting, which no longer exists.
-
-## What's New in v4.1.0
-
-**The Settings page is gone. Everything is in the tray icon now.**
-
-- **One place to configure this mod, not two.** The Windhawk Settings page has
-  been removed entirely. Twelve zones per display, each with a forty-entry
-  action list and six timing overrides, had grown into a tree that was faster
-  to give up on than to navigate — and because a mod cannot write its own
-  settings from code, anything you changed in the dashboard could never be
-  written back to it. The two disagreed the moment you touched either one. The
-  dashboard won: right-click the tray icon → **Zones & settings...**
-- **If you configured this mod on the Settings page, set it up again from the
-  dashboard.** Configurations already saved from the dashboard are untouched.
-- **Reset actually resets.** The dashboard's Reset button left the numeric
-  options — sizes, delays, cooldown — behind in storage: still applied, no
-  longer shown anywhere. It now clears everything it can write.
-- **Fixed: per-display zones could be attributed to the wrong display.** The
-  editor matched a stored configuration to the monitor selector by list
-  position rather than by monitor, so a configuration written for one display
-  could appear under **All monitors** — and saving it then fired it on every
-  display.
-- **Verbose logging is gone as a setting.** Every log it gated was once per
-  trigger, never on the polling path, so there was nothing to gate. Suppressed
-  triggers now log once per run instead of once per cooldown, which is what the
-  setting was really protecting you from.
-- **The tray menu's reset** now says what it does — it clears the three toggles
-  above it, and nothing else. Wiping your zones is the dashboard's Reset
-  button, which asks first.
-- **The options are grouped.** Fourteen fields in one flat column, in no
-  particular order, is a wall. They now sit under four headings — how big the
-  zones are, when a zone fires, when to stay out of the way, everything else —
-  and every field still explains itself on hover.
-
-**Behaviour**
-
-- **A fullscreen app now only silences the display it is on.** Launching a game
-  on one monitor used to disable the hot corners on *every* monitor, which is
-  the opposite of why anyone owns a second screen. When Windows will not say
-  which display is involved, the old behaviour still applies and all displays
-  are suppressed.
-- **A split edge alternates as one edge.** With a centre action assigned, an
-  edge becomes two strips either side of the centre — but it is still one edge,
-  and **Alternate Key Press** / **Alternate Command** kept a separate A/B
-  position for each half. Walking into the left strip and then the right gave
-  you A twice. They now share one position.
-- **The detection thread idles when nothing can fire.** It sampled the cursor
-  every 16 ms even with the mod switched off, suspended, or with no zones
-  armed. Those three cases now tick at 100 ms. *(v4.1.0 also eased off while
-  the cursor was merely far away; v4.1.1 removed that — see below.)*
-
-## What's New in v4.0.5
-
-- **Fixed: "Turn Off Monitors", "Start Screen Saver" and "Lock and Turn Off
-  Monitors" could stall every other action behind them.** They ask every
-  window on the desktop to act, and the old call waited up to half a second
-  for *each* one — so a single slow application could tie up the action
-  thread for seconds while the mod appeared to have stopped responding. The
-  request is now sent without waiting.
-- Added a note on which smaller mods overlap with this one, so it is easier to
-  tell which is the right tool.
-- Internal tidying: dropped snapshot fields nothing read, the theme helper
-  resolves its entry point once instead of on every control, and the tray
-  icon's mask is explicitly zeroed rather than left undefined.
-
-## What's New in v4.0.4
-
-- **Fixed: disabling or reloading the mod with the settings window open could
-  crash Windhawk.** Shutdown stopped every thread except the one running that
-  window, then freed the locks it was still using. It now closes the window
-  and waits for it, and if it will not close, leaves the locks alone rather
-  than pulling them out from under it.
-- **Fixed: a failed key injection could leave a modifier stuck down.** If the
-  key presses went through but the releases did not, the key stayed logically
-  held for the rest of the session — a stuck Win or Ctrl that nothing on
-  screen explains. The releases are now replayed after a partial send.
-- **Fixed: opening the settings window leaked an icon every time.**
-- Saving a configuration for a display beyond the eighth now says so in the
-  log instead of appearing to work and losing the edit on the next reload.
-- A Custom Command of just `uac;` with nothing after it no longer tries to
-  relaunch Windhawk itself with elevation.
-- Settings shared between the tray, the settings window and the detection
-  loop are read and written atomically.
-
-## What's New in v4.0.3
-
-- **Fixed: the mod would not load at all.** "Require a modifier key" offered a
-  dropdown whose values were numbers, and Windhawk only accepts text values for
-  a dropdown — it refused to parse the settings before any of the mod ran. The
-  choices are now stored by name (`none`, `ctrl`, `alt`, `shift`, `win`); a
-  configuration saved by an earlier version keeps working.
-
-## What's New in v4.0.2
-
-- **Fixed: zones could stop matching after a display change.** Windows reports
-  a layout that changed while it was being read as a buffer error, and that is
-  precisely when this runs — a layout change is what calls it. The mod treated
-  that as fatal and dropped every display name for the rebuild, leaving zones
-  bound to a name unmatched until the next display change. It now re-reads
-  instead.
-- Documentation corrections: two identical displays are the one case where
-  changing the primary display can move a configuration, because the ` #2`
-  suffix follows listed order rather than the display itself. That is now
-  stated instead of implied otherwise.
-
-## What's New in v4.0.1
-
-- **Fixed: stray text showing through the per-zone settings panel.** The
-  preview's hover card was drawn into the same strip of the window that the
-  per-zone fields occupy, so it was never readable and its lines leaked out
-  through the gaps between the fields. The card is gone — the panel below the
-  preview already shows those values for the selected zone, and clicking a
-  zone in the preview selects it.
-- **Fixed: tooltips were unreadable dark-on-dark.** A themed tooltip silently
-  ignores the colour messages that were meant to restyle it, so it kept the
-  system colours while the rest of the dashboard followed the palette.
-  Tooltips now use the dashboard's own background, text colour and font, in
-  both light and dark themes.
-- The dashboard window now clips its children, so nothing painted by the
-  window can leave residue underneath a control.
-- **Fixed a crash risk when opening the dashboard.** It listed your monitors
-  by reading the detection thread's own monitor table, which that thread
-  clears and rebuilds whenever the display layout is re-checked — freeing the
-  name strings mid-read. The names now travel inside the same immutable
-  snapshot the detection loop already uses.
-
-## What's New in v4.0.0
-
-- **Per-zone settings.** Size, delay, pass-through guard, knock window,
-  cooldown and required modifier can each be overridden for a single zone.
-  Blank means inherit, so existing configurations behave exactly as before.
-- The dashboard follows the system light/dark theme instead of being fixed
-  dark, which made it near-unreadable on a light desktop.
-- Preview fixes: edges are split around their centre blocks, so hovering a
-  centre no longer highlights the whole edge.
-
-## What's New in v3.9.0
-
-- **Settings dashboard**, opened from the tray icon: all twelve zones per
-  monitor, the global options, and a clickable preview of your screen.
-  Windhawk's own settings page stays available and can be restored at any
-  time with *Reset to Windhawk settings*.
-
-## What's New in v3.8.0
-
-- **Tray icon** with enable/suspend controls and quick access to the log.
-
-## What's New in v3.7.0
-
-- **Alternating actions** — one zone that runs two different actions on
-  successive triggers, written as `first|second` in the argument field.
-- **Keep zones off the taskbar**, so an edge zone stops at the work area
-  instead of fighting the taskbar's peek-at-desktop strip.
-
-## What's New in v3.6.0
-
-- **Knock to activate** — require entering a zone twice in quick succession.
-- **Modifier gating** — zones stay inert unless a chosen key is held.
-- **Edge-centre zones**, plus four new actions.
-- v3.6.1: the display actually blanks after *Lock and Turn Off Monitors*.
-  `WM_SYSCOMMAND` was posted to the foreground window, which is null once
-  `LockWorkStation` has switched desktop; it is now broadcast.
-
-## What's New in v3.5.0
-
-- First public release.
-
-## What's New in v3.4.0
-
-- **16 new actions**, so common shortcuts no longer need a Virtual Key Press:
-  Switch to Last Window (Alt+Tab), Task Switcher (Ctrl+Alt+Tab), Minimize,
-  Maximize, Snap Left/Right, Close Window, File Explorer, Settings, Search,
-  Clipboard History, Screenshot, Project, and Virtual Desktop Next/Previous/New.
-
-## What's New in v3.3.0
-
-- **Extended keys are now flagged correctly.** Arrow keys, Home/End/PgUp/PgDn,
-  Insert/Delete, the Win keys, right Ctrl/Alt and the media keys sit on the
-  E0-prefixed part of the keyboard. Injected without `KEYEVENTF_EXTENDEDKEY`
-  they resolve to their numpad twins, so a Virtual Key Press using
-  `Win+Right` (snap) or any arrow/navigation key silently did the wrong thing.
-- **Unquoted paths containing spaces now launch.** `C:\Program Files\Tool\t.exe -x`
-  was split into `C:\Program` plus arguments and failed with file-not-found.
-  The executable is now rebuilt token by token until it names a real file.
-  Bare commands (`notepad.exe`) are untouched so the shell still resolves them
-  via PATH, and quoted paths behave exactly as before.
-- **Windows 11 shell surfaces hosted outside explorer.exe** — Start
-  (`StartMenuExperienceHost.exe`), Search (`SearchHost.exe`), Action Center —
-  are no longer mistaken for fullscreen apps. Matched by exact process name,
-  not a `*Host.exe` suffix rule, which would also match ordinary applications.
-
-## What's New in v3.2.0 — stability
-
-Spamming the zones could make the whole desktop stagger. Four causes, all fixed:
-
-- **Stuck modifier keys.** Key injection used to release any modifier you were
-  physically holding and re-press it afterwards. If you let go in between, that
-  re-press had no matching release and the modifier stayed logically held down
-  for the rest of the session — a stuck Win or Ctrl key breaks every app at
-  once. Removed: every key the mod presses is now released in the same batch.
-- **Burst injection.** A sweep across several zones queued a burst of shell
-  commands that the worker replayed back-to-back — four Win+Tab injections in
-  40 ms in one report. There is now a hard 250 ms floor between any two
-  actions, and the queue holds 2 instead of 8 so a backlog is dropped rather
-  than replayed late.
-- **Logging on the hot path.** Every trigger wrote to `OutputDebugString`,
-  which takes a machine-wide lock — that stalls *other* Windhawk mods, not
-  just this one. Per-trigger logging is now off by default (**Verbose
-  logging**). Errors and startup info are still always logged.
-- **Unsafe teardown.** If a thread was still busy (e.g. blocked on a UAC
-  prompt) the mod freed the locks it was using. It now leaks them instead —
-  the process exits immediately after, so a leak is free and a use-after-free
-  is not.
-
-Also: the display-layout poll ran 5 system calls every 16 ms; it now runs
-twice a second, leaving the tick to one cursor read plus a few comparisons.
-
-## What's New in v3.1.0
-
-- **Fixed: zones stopped working while Task View / Start / Search was open.**
-  Those are shell surfaces that exactly match the monitor size, so the
-  fullscreen-app guard classified them as fullscreen games and suppressed
-  every trigger until they closed. v2.x was immune only by accident — it ran
-  inside explorer.exe and skipped windows belonging to its own process, and
-  Task View *is* explorer.exe. Moving to a dedicated process silently
-  invalidated that test. The guard now compares against the shell's process,
-  which is what was always meant.
-- Removed a 150 ms diagnostic delay per action that could back up the queue.
-- Zone sizes are clamped per monitor so the eight zones can never overlap:
-  a corner larger than half the screen, or an edge thicker than the corner
-  box, previously made one zone shadow another (only the first was reachable).
-
-## What's New in v3.0.2
-
-- **Zones no longer fire when you just pass through them.** A corner cannot be
-  reached without crossing the edge strip beside it, so moving into a corner
-  fired the edge action ~30 ms before the corner one. With a toggle bound to
-  both (Task View, Show Desktop) that opened and instantly re-closed — looking
-  exactly like the mod did nothing. The new **Pass-through guard** setting
-  (80 ms) requires the cursor to settle, so only the zone you stop in fires.
-- `SendInput` failures are now logged instead of silently discarded.
-- Each trigger logs the foreground window before and after, so a cancelled
-  toggle is visible in the log rather than looking like success.
-
-## What's New in v3.0.1
-
-- Fixed the mod never loading. v3.0.0 kept the `@architecture x86-64` line
-  from v2.x, but `windhawk.exe` is a 32-bit process — so the mod was only ever
-  built as a 64-bit DLL and Windhawk had nothing to inject. No logs, no zones,
-  no sign of life. Tool mods must not restrict architecture.
-
-## What's New in v3.0.0
-
-- **Runs as a dedicated process** instead of injecting into explorer.exe.
-  Detection no longer shares a thread with the taskbar — that shared thread
-  was why zones fired seconds late or not at all.
-- **Polled detection replaces the low-level mouse hook.** The old hook was
-  installed on explorer's taskbar thread; whenever that thread was busy,
-  Windows skipped the callback and could silently remove the hook. Polling is
-  immune to that, to UIPI, and to elevated foreground apps — and it stops
-  routing every mouse event on the system through explorer.
-- **Monitors identified by friendly name**, not by position in a sorted list.
-- **Per-monitor DPI awareness pinned explicitly**, fixing zones landing at
-  the wrong coordinates on mixed-scaling multi-monitor setups.
-- **Actions run on a worker thread**, so a slow launch can never delay
-  detection.
-- Display-layout changes are picked up even when Windows doesn't send
-  `WM_DISPLAYCHANGE` (docking, monitor wake, RDP reconnect).
+First release. Earlier version numbers exist only in the development
+repository and were never published, so there is nothing to upgrade from.
 
 ## Support
 
@@ -853,6 +364,8 @@ listing, but it only takes one link, so the rest live here.
           $name: Size override (px)
           $description: >-
             Corner square, or edge strip thickness. -1 keeps the global value.
+            An edge is one strip, so its three segments share a thickness: the
+            first segment that sets one decides it for the whole edge.
         - delay: -1
           $name: Activation delay override (ms)
           $description: -1 keeps the global value.
@@ -889,8 +402,8 @@ listing, but it only takes one link, so the rest live here.
         cooldowns stay separate.
   $name: Displays
   $description: >-
-    Leave this empty to keep using a layout saved by an older version of the
-    mod. As soon as you add a display here, this list takes over completely.
+    Add one entry per display you want to configure, or a single entry with
+    *  as the name to cover every display at once.
 
 - cornerSize: 6
   $name: Corner size (px)
@@ -2441,7 +1954,7 @@ static std::function<void()> MakeExecutor(CornerAction action,
     //
     // Deliberately built as two extra action types rather than by giving every
     // zone a second action + args. That would have doubled a settings block
-    // that is already twelve zones long, for a feature most zones will never
+    // that is already sixteen zones long, for a feature most zones will never
     // use. Here the two halves live in the existing Args field, split on "|",
     // so nothing about the zone structure, the hit test or the detection loop
     // changes at all.
@@ -2687,10 +2200,15 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
             if (zc->action == CornerAction::AlternateKeypress ||
                 zc->action == CornerAction::AlternateCommand)
             {
-                // zc->executor is deliberately not used for these two: each
-                // copy carries its own flip flag, and the segments of one edge
-                // have to share one. The stored executor still earns its keep
-                // as the dashboard's "do the arguments parse?" test.
+                // zc->executor is deliberately not used for these two: every
+                // MakeExecutor call builds a fresh flip flag, so reusing the
+                // stored one would restart the alternation on each rebuild.
+                // Keyed per zone, which is what the readme promises - each zone
+                // alternates independently. Identical neighbouring segments
+                // have already coalesced into one zone before they reach here,
+                // so a merged edge alternates as a unit for free. The stored
+                // executor still earns its keep as the dashboard's
+                // "do the arguments parse?" test.
                 if (!altExec[z])
                     altExec[z] = MakeExecutor(zc->action, zc->args);
                 hz.exec = altExec[z];
@@ -2797,11 +2315,53 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
     return set;
 }
 
+// True when two zone sets would behave identically. Only what the detection
+// loop and the actions actually read - the executors are rebuilt every time
+// and never compare equal, so comparing them would make this always false.
+static bool SameZoneSet(const ZoneSet *a, const ZoneSet *b)
+{
+    if (!a || !b || a->zones.size() != b->zones.size() ||
+        a->disableDuringDrag != b->disableDuringDrag)
+        return false;
+    for (size_t i = 0; i < a->zones.size(); i++)
+    {
+        const HitZone &x = a->zones[i], &y = b->zones[i];
+        if (memcmp(&x.rect, &y.rect, sizeof(RECT)) != 0 || x.zone != y.zone ||
+            x.monitor != y.monitor || x.delay != y.delay ||
+            x.settle != y.settle || x.knock != y.knock ||
+            x.cooldown != y.cooldown || x.modifier != y.modifier ||
+            x.label != y.label)
+            return false;
+    }
+    return true;
+}
+
 // Detection thread only.
 static void RebuildZones()
 {
     RefreshMonitors();
     auto set = BuildZoneSet();
+
+    // Recorded before the early return below. TopologyChanged compares against
+    // these, so leaving them stale after a no-op rebuild would make it report a
+    // change on every poll and rebuild forever.
+    g_topoCount = GetSystemMetrics(SM_CMONITORS);
+    g_topoVirtual = {GetSystemMetrics(SM_XVIRTUALSCREEN),
+                     GetSystemMetrics(SM_YVIRTUALSCREEN),
+                     GetSystemMetrics(SM_CXVIRTUALSCREEN),
+                     GetSystemMetrics(SM_CYVIRTUALSCREEN)};
+    SystemParametersInfoW(SPI_GETWORKAREA, 0, &g_topoWorkArea, 0);
+
+    // Appbar registrations and taskbar changes broadcast SPI_SETWORKAREA
+    // several times in a row, and a rebuild resets every cooldown and
+    // alternation position and re-logs the whole zone list. When the result is
+    // identical there is nothing to publish, so skip the swap and the reset.
+    std::shared_ptr<const ZoneSet> current;
+    EnterCriticalSection(&g_zonesLock);
+    current = g_zones;
+    LeaveCriticalSection(&g_zonesLock);
+    if (SameZoneSet(current.get(), set.get()))
+        return;
 
     EnterCriticalSection(&g_zonesLock);
     g_zones = set;
@@ -2814,12 +2374,33 @@ static void RebuildZones()
     g_lastExitTick.assign(set->zones.size(), 0);
     g_knockSatisfied = true;
 
-    g_topoCount = GetSystemMetrics(SM_CMONITORS);
-    g_topoVirtual = {GetSystemMetrics(SM_XVIRTUALSCREEN),
-                     GetSystemMetrics(SM_YVIRTUALSCREEN),
-                     GetSystemMetrics(SM_CXVIRTUALSCREEN),
-                     GetSystemMetrics(SM_CYVIRTUALSCREEN)};
-    SystemParametersInfoW(SPI_GETWORKAREA, 0, &g_topoWorkArea, 0);
+    // A rebuild is not a gesture. With the state above cleared, a pointer that
+    // has not moved looks to the next tick like a fresh entry - and with every
+    // cooldown zeroed too, nothing stops it firing once the dwell elapses. That
+    // made the action run on mod enable, on any settings change, and on every
+    // WM_DISPLAYCHANGE or work-area broadcast, which includes a monitor waking
+    // up. Parking the pointer in a corner after using it is the normal way to
+    // use hot corners, so this was easy to hit, and a corner bound to Lock or
+    // Sleep would do that thing unprompted.
+    //
+    // Adopting the zone the cursor is already in, with the visit already spent,
+    // means only leaving and coming back can arm it.
+    POINT pt;
+    if (GetCursorPos(&pt))
+    {
+        for (size_t i = 0; i < set->zones.size(); i++)
+        {
+            const RECT &r = set->zones[i].rect;
+            if (pt.x >= r.left && pt.x < r.right && pt.y >= r.top &&
+                pt.y < r.bottom)
+            {
+                g_activeZone = (int)i;
+                g_enterTick = GetTickCount64();
+                g_firedThisEntry = true;
+                break;
+            }
+        }
+    }
 }
 
 // WM_DISPLAYCHANGE is not delivered for every layout change that matters —
@@ -2980,9 +2561,21 @@ static DWORD DetectTick()
     if (!zones || zones->zones.empty())
         return kIdleTickMs;
 
+    // GetCursorPos fails for a process on the default desktop once the input
+    // desktop is the secure one, so a locked machine used to spin this thread
+    // at the full rate all night with no possible way for a zone to be hit.
+    // A single failure is still treated as transient - it is usually a desktop
+    // switch in progress - but a run of them backs off to the idle rate, and
+    // the first success restores it.
+    static int consecutiveFailures = 0;
     POINT pt;
     if (!GetCursorPos(&pt))
-        return kTickMs;   // transient, and zones are armed - do not slow down
+    {
+        if (consecutiveFailures < 10)
+            consecutiveFailures++;
+        return consecutiveFailures >= 10 ? kIdleTickMs : kTickMs;
+    }
+    consecutiveFailures = 0;
 
     int idx = -1;
     for (size_t i = 0; i < zones->zones.size(); i++)
@@ -3120,9 +2713,11 @@ static LRESULT CALLBACK DetectWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
     if (uMsg == WM_DISPLAYCHANGE ||
         (uMsg == WM_SETTINGCHANGE && wParam == SPI_SETWORKAREA))
     {
-        Wh_Log(uMsg == WM_DISPLAYCHANGE
-                   ? L"WM_DISPLAYCHANGE — queueing a zone rebuild"
-                   : L"Work area changed — queueing a zone rebuild");
+        // Wh_Log concatenates its first argument onto a string literal, so it
+        // has to be one - a ternary here is a syntax error in a real build.
+        Wh_Log(L"%s — queueing a zone rebuild",
+               uMsg == WM_DISPLAYCHANGE ? L"WM_DISPLAYCHANGE"
+                                        : L"Work area changed");
         PostMessage(hWnd, WM_APP_REBUILD, 0, 0);
         return 0;
     }
@@ -3431,42 +3026,6 @@ static void UpdateTrayIcon(bool add)
         DestroyIcon(nid.hIcon);
 }
 
-// =====================================================================
-// Reading a pre-4.2 layout
-// =====================================================================
-//
-// Nothing writes any of this any more - the settings page is the only store.
-// It is read once per reload, and only when the settings page has no displays
-// on it, so that upgrading from a version that had no settings page does not
-// silently discard a zone layout that took effort to enter.
-//
-// One key per field rather than a packed string, which is what those versions
-// wrote: wordy, but readable if it ever needs debugging by hand.
-
-static constexpr int kMaxGuiConfigs = 8;
-
-static std::wstring GetStrValue(const wchar_t *name)
-{
-    WCHAR buf[512] = {};
-    if (Wh_GetStringValue(name, buf, ARRAYSIZE(buf)) == 0)
-        return L"";
-    return buf;
-}
-
-static std::wstring GuiKey(int cfg, int zone, const wchar_t *what)
-{
-    wchar_t k[64];
-    if (zone < 0)
-        _snwprintf_s(k, _countof(k), _TRUNCATE, L"g%d.%s", cfg, what);
-    else
-        _snwprintf_s(k, _countof(k), _TRUNCATE, L"g%d.z%d.%s", cfg, zone, what);
-    return k;
-}
-
-// The saved zone layout, or an empty vector if there is not one yet. Returns it
-// rather than assigning g_settings.monitorConfigs: this reads several hundred
-// value-store keys and builds a std::function per zone, and holding
-// g_settingsLock across all of that would stall the detection thread, the
 // action worker and the tray menu.
 // =====================================================================
 // Windhawk settings page
@@ -3539,7 +3098,7 @@ static std::wstring GetSettingStr(const wchar_t *fmt, int a, int b = -1)
 {
     PCWSTR raw = (b < 0) ? Wh_GetStringSetting(fmt, a)
                          : Wh_GetStringSetting(fmt, a, b);
-    std::wstring out = raw ? raw : L"";
+    std::wstring out = raw;   // Wh_GetStringSetting returns L"", never NULL
     Wh_FreeStringSetting(raw);
     return out;
 }
@@ -3549,7 +3108,7 @@ static std::wstring GetSettingStr(const wchar_t *fmt, int a, int b = -1)
 static std::wstring GetSettingStr(const wchar_t *name)
 {
     PCWSTR raw = Wh_GetStringSetting(name);
-    std::wstring out = raw ? raw : L"";
+    std::wstring out = raw;   // Wh_GetStringSetting returns L"", never NULL
     Wh_FreeStringSetting(raw);
     return out;
 }
@@ -3662,86 +3221,6 @@ static void ApplySettingsGlobals(ModSettings &s)
     }
 }
 
-static std::vector<MonitorZoneConfig> ReadDashboardZones()
-{
-    std::vector<MonitorZoneConfig> configs;
-    if (Wh_GetIntValue(L"gui_active", 0) == 0)
-        return configs;
-
-    for (int i = 0; i < kMaxGuiConfigs; i++)
-    {
-        std::wstring id = GetStrValue(GuiKey(i, -1, L"id").c_str());
-        if (id.empty())
-            continue;
-
-        MonitorZoneConfig cfg;
-        cfg.monitorId = id;
-
-        // The store predates the edge split, so its twelve slots have to be
-        // spread across sixteen. A stored edge fills both outer segments; it
-        // also fills the middle when nothing was stored for the centre, which
-        // is what reproduces the old geometry exactly - back then an edge with
-        // no centre configured was one rectangle spanning the whole edge, and
-        // three identical segments coalesce back into exactly that.
-        static const struct
-        {
-            int edge;                 // legacy slot 4-7
-            int centre;               // legacy slot 8-11
-            Zone start, middle, end;
-        } kSpread[] = {
-            {4, 8, ZONE_TOP_START, ZONE_TOP_MIDDLE, ZONE_TOP_END},
-            {5, 9, ZONE_BOTTOM_START, ZONE_BOTTOM_MIDDLE, ZONE_BOTTOM_END},
-            {6, 10, ZONE_LEFT_START, ZONE_LEFT_MIDDLE, ZONE_LEFT_END},
-            {7, 11, ZONE_RIGHT_START, ZONE_RIGHT_MIDDLE, ZONE_RIGHT_END},
-        };
-
-        auto readSlot = [&](int z, ZoneConfig &dst)
-        {
-            std::wstring a = GetStrValue(GuiKey(i, z, L"a").c_str());
-            std::wstring g = GetStrValue(GuiKey(i, z, L"g").c_str());
-            CornerAction act = ParseActionType(a);
-            dst.action = act;
-            dst.args = g;
-            dst.executor = MakeExecutor(act, g);
-            dst.tuning.size = Wh_GetIntValue(GuiKey(i, z, L"sz").c_str(), -1);
-            dst.tuning.delay = Wh_GetIntValue(GuiKey(i, z, L"dl").c_str(), -1);
-            dst.tuning.settle = Wh_GetIntValue(GuiKey(i, z, L"gd").c_str(), -1);
-            dst.tuning.knock = Wh_GetIntValue(GuiKey(i, z, L"kn").c_str(), -1);
-            dst.tuning.cooldown = Wh_GetIntValue(GuiKey(i, z, L"cd").c_str(), -1);
-            dst.tuning.modifier = Wh_GetIntValue(GuiKey(i, z, L"md").c_str(), -1);
-            return act != CornerAction::Nothing;
-        };
-
-        bool any = false;
-        for (int z = ZONE_TOP_LEFT; z <= ZONE_BOTTOM_RIGHT; z++)
-            any |= readSlot(z, cfg.zones[z]);
-
-        for (const auto &sp : kSpread)
-        {
-            ZoneConfig edge, centre;
-            bool hasEdge = readSlot(sp.edge, edge);
-            bool hasCentre = readSlot(sp.centre, centre);
-
-            if (hasEdge)
-            {
-                cfg.zones[sp.start] = edge;
-                cfg.zones[sp.end] = edge;
-                if (!hasCentre)
-                    cfg.zones[sp.middle] = edge;
-                any = true;
-            }
-            if (hasCentre)
-            {
-                cfg.zones[sp.middle] = centre;
-                any = true;
-            }
-        }
-
-        if (any)
-            configs.push_back(std::move(cfg));
-    }
-    return configs;
-}
 
 // The whole of this mod's configuration, read and applied as one transaction.
 //
@@ -3771,67 +3250,7 @@ static void ReloadConfig()
     g_trayEnabled = (v < 0) ? true : (v != 0);
 
     s.monitorConfigs = ReadSettingsZones();
-    const bool fromSettings = !s.monitorConfigs.empty();
-
-    // The settings page always owns the globals. Applying them only on the
-    // settings path meant that anyone upgrading had a page full of fields that
-    // did nothing and no way to tell: change Cooldown from 300 to 800, see
-    // nothing happen. Only the zone list falls back to the stored layout.
     ApplySettingsGlobals(s);
-
-    // The handover is one-way. Without this, a user who lists a display and
-    // later sets its zones back to Nothing drops out of fromSettings and the
-    // pre-4.2 layout comes back from the dead, which is not what clearing a
-    // zone asks for.
-    if (fromSettings && Wh_GetIntValue(L"settings_owner", 0) == 0)
-        Wh_SetIntValue(L"settings_owner", 1);
-
-    bool legacy = false;
-    std::wstring dropped;
-
-    if (!fromSettings && Wh_GetIntValue(L"settings_owner", 0) == 0 &&
-        Wh_GetIntValue(L"gui_active", 0) != 0)
-    {
-        legacy = true;
-        s.monitorConfigs = ReadDashboardZones();
-
-        // The stored globals are no longer applied, so name the ones that were
-        // customised. Reverting them silently would look like the mod losing a
-        // setting; naming them says exactly what to re-enter and where.
-        static const struct
-        {
-            const wchar_t *key;
-            const wchar_t *name;
-        } kOldGlobals[] = {
-            {L"ovr_corner", L"Corner size"},
-            {L"ovr_edge", L"Edge thickness"},
-            {L"ovr_centre", L"Edge centre width"},
-            {L"ovr_delay", L"Activation delay"},
-            {L"ovr_settle", L"Pass-through guard"},
-            {L"ovr_knock", L"Knock window"},
-            {L"ovr_cooldown", L"Cooldown"},
-            {L"ovr_modifier", L"Required modifier"},
-            {L"ovr_taskbar", L"Keep zones out of the taskbar"},
-            {L"ovr_lockblank", L"Lock-then-blank delay"},
-            {L"ovr_monnames", L"List display names in the log"},
-            {L"ovr_fullscreen", L"Skip while fullscreen"},
-            {L"ovr_drag", L"Skip while dragging"},
-        };
-        for (const auto &o : kOldGlobals)
-        {
-            if (Wh_GetIntValue(o.key, -1) < 0)
-                continue;
-            if (!dropped.empty())
-                dropped += L", ";
-            dropped += o.name;
-        }
-        if (!GetStrValue(L"ovr_excluded").empty())
-        {
-            if (!dropped.empty())
-                dropped += L", ";
-            dropped += L"Excluded applications";
-        }
-    }
 
     // Copied out before the move, so the summary can be logged after the lock
     // is released - Wh_Log goes through OutputDebugString and takes a
@@ -3846,23 +3265,10 @@ static void ReloadConfig()
     g_settings = std::move(s);
     LeaveCriticalSection(&g_settingsLock);
 
-    if (legacy)
+    if (zoneCount)
     {
-        Wh_Log(L"Zones are coming from a layout saved by an older version (%d "
-               L"configuration%s). Everything else on this mod's Settings page "
-               L"is live. Re-enter the zones there to take them over - as soon "
-               L"as one display is listed, this layout is ignored.",
-               zoneCount, zoneCount == 1 ? L"" : L"s");
-        if (!dropped.empty())
-            Wh_Log(L"These were customised in the old version and are now taken "
-                   L"from the Settings page instead, so set them again there if "
-                   L"you still want them: %s.",
-                   dropped.c_str());
-    }
-    else if (zoneCount)
-    {
-        Wh_Log(L"Using the Settings page (%d display%s configured)",
-               zoneCount, zoneCount == 1 ? L"" : L"s");
+        Wh_Log(L"%d display%s configured", zoneCount,
+               zoneCount == 1 ? L"" : L"s");
     }
     else
     {
@@ -4073,7 +3479,7 @@ static HWND g_hDashWnd = nullptr;
 // change it.
 struct Palette
 {
-    COLORREF bg, panel, text, dim, field, fieldText, border, accent, accentText;
+    COLORREF bg, text, dim, field, border, accent, accentText;
 };
 static Palette g_pal;
 static bool g_lightTheme = false;
@@ -4101,15 +3507,23 @@ static void BuildPalette()
     g_lightTheme = SystemUsesLightTheme();
     if (g_lightTheme)
     {
-        g_pal = {RGB(243, 243, 243), RGB(251, 251, 251), RGB(26, 26, 26),
-                 RGB(95, 95, 95),    RGB(255, 255, 255), RGB(26, 26, 26),
-                 RGB(214, 214, 214), RGB(0, 95, 184),    RGB(255, 255, 255)};
+        g_pal = {/* bg     */ RGB(243, 243, 243),
+                 /* text   */ RGB(26, 26, 26),
+                 /* dim    */ RGB(95, 95, 95),
+                 /* field  */ RGB(255, 255, 255),
+                 /* border */ RGB(214, 214, 214),
+                 /* accent */ RGB(0, 95, 184),
+                 /* on-acc */ RGB(255, 255, 255)};
     }
     else
     {
-        g_pal = {RGB(32, 32, 32),    RGB(43, 43, 43),   RGB(255, 255, 255),
-                 RGB(170, 170, 170), RGB(45, 45, 45),   RGB(255, 255, 255),
-                 RGB(70, 70, 70),    RGB(76, 194, 255), RGB(0, 0, 0)};
+        g_pal = {/* bg     */ RGB(32, 32, 32),
+                 /* text   */ RGB(255, 255, 255),
+                 /* dim    */ RGB(170, 170, 170),
+                 /* field  */ RGB(45, 45, 45),
+                 /* border */ RGB(70, 70, 70),
+                 /* accent */ RGB(76, 194, 255),
+                 /* on-acc */ RGB(0, 0, 0)};
     }
 }
 
@@ -4156,7 +3570,6 @@ struct DashState
 
     std::vector<DisplayView> displays;
     ModSettings globals;         // what an inherited value resolves to
-    bool legacy = false;         // running a layout saved before 4.2
 
     int activeTab = 0;
     int hoverZone = -1;
@@ -4286,6 +3699,34 @@ static RECT ZoneRectInDiagram(Zone z, const RECT &d)
 }
 
 static bool ZoneIsCorner(Zone z) { return z <= ZONE_BOTTOM_RIGHT; }
+
+// The three segments of the edge a zone belongs to, or false for a corner.
+// An edge is one strip, so its thickness is a property of the trio rather than
+// of whichever segment you happen to be looking at.
+static bool EdgeTrio(Zone z, Zone out[3])
+{
+    struct Run
+    {
+        Zone lo, mid, hi;
+    };
+    static const Run kRuns[] = {
+        {ZONE_TOP_START, ZONE_TOP_MIDDLE, ZONE_TOP_END},
+        {ZONE_BOTTOM_START, ZONE_BOTTOM_MIDDLE, ZONE_BOTTOM_END},
+        {ZONE_LEFT_START, ZONE_LEFT_MIDDLE, ZONE_LEFT_END},
+        {ZONE_RIGHT_START, ZONE_RIGHT_MIDDLE, ZONE_RIGHT_END},
+    };
+    for (const Run &r : kRuns)
+    {
+        if (z >= r.lo && z <= r.hi)
+        {
+            out[0] = r.lo;
+            out[1] = r.mid;
+            out[2] = r.hi;
+            return true;
+        }
+    }
+    return false;
+}
 
 // The left and right strips are tall and narrow. Rotating the text is the only
 // way a label such as "Notification Centre" fits inside one.
@@ -5032,6 +4473,40 @@ static void DashPaintDetail(DashState *s, HDC hdc, const RECT &client)
         int own = TuningField(zv.tuning, i);
         bool overridden = own >= 0;
         int value = overridden ? own : GlobalField(s->globals, i, (Zone)zone);
+        std::wstring from = overridden ? L"this zone" : L"global";
+
+        // Size on an edge belongs to the strip, not the segment: all three get
+        // the same thickness, taken from the first that asks for one. Reporting
+        // this segment's own override made the panel claim 10 px while the
+        // picture and the pointer both used the 20 px its neighbour asked for.
+        Zone trio[3];
+        if (i == 0 && EdgeTrio((Zone)zone, trio))
+        {
+            int owner = -1;
+            for (Zone t : trio)
+            {
+                if (dv.zones[t].tuning.size > 0)
+                {
+                    owner = (int)t;
+                    break;
+                }
+            }
+            if (owner < 0)
+            {
+                overridden = false;
+                value = s->globals.edgeSize;
+                from = L"global";
+            }
+            else
+            {
+                overridden = true;
+                value = dv.zones[owner].tuning.size;
+                from = (owner == zone) ? L"this zone"
+                                       : std::wstring(L"whole edge, set on ") +
+                                             ZoneToString((Zone)owner);
+            }
+        }
+
         std::wstring text = FormatTuning(i, value);
 
         SetTextColor(hdc, g_pal.dim);
@@ -5044,8 +4519,8 @@ static void DashPaintDetail(DashState *s, HDC hdc, const RECT &client)
 
         SetTextColor(hdc, overridden ? g_pal.accent : g_pal.dim);
         r = {cFrom, y, right, y + Sc(Lay::DetRowH, d)};
-        DrawTextW(hdc, overridden ? L"this zone" : L"global", -1, &r,
-                  DT_LEFT | DT_SINGLELINE);
+        DrawTextW(hdc, from.c_str(), -1, &r,
+                  DT_LEFT | DT_SINGLELINE | DT_END_ELLIPSIS);
 
         y += Sc(Lay::DetRowH, d);
     }
@@ -5080,7 +4555,7 @@ static int DashHitTab(DashState *s, POINT pt)
 }
 
 // Posted when the configuration changes underneath an open window.
-#define WM_APP_DASH_REFRESH (WM_APP + 21)
+static constexpr UINT WM_APP_DASH_REFRESH = WM_APP + 21;
 
 static void DashMakeFonts(DashState *s)
 {

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         1.2.0
+// @version         1.2.1
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -121,6 +121,14 @@ action again**:
 
 The two halves are independent, so a release does not have to undo the entry —
 open Quick Settings on arrival and mute on departure if that is useful to you.
+
+One caveat on Show desktop specifically. It sends Win+D, which *toggles*
+minimise-all against whatever the current state is — the old shell button was a
+true peek with no state of its own, and Windows exposes no API for that any
+more. Rest in the corner and leave, and it behaves as a peek. But activate a
+window while the desktop is showing and you have changed what the second Win+D
+does, so the release can minimise rather than restore. Every other toggle
+— Mute, Keep awake — is unaffected.
 
 A hold only ever releases what it actually engaged, so a pointer that clips the
 corner without staying long enough to fire leaves nothing behind. Disabling the
@@ -774,12 +782,18 @@ enum Zone
     ZONE_COUNT = 16,
 };
 
+// Values for ZoneTuning::modifier and ModSettings::requireModifier. Named
+// together rather than one of them, so the set reads as an enumeration rather
+// than as one arbitrary special case.
+static constexpr int kModifierNone = 0;
+static constexpr int kModifierCtrl = 1;
+static constexpr int kModifierAlt = 2;
+static constexpr int kModifierShift = 3;
+static constexpr int kModifierWin = 4;
+
 // Per-zone overrides. Every numeric field uses -1 for "inherit the global
 // value", so an untouched zone behaves exactly as it did before per-zone
 // settings existed and old configurations keep working unchanged.
-// Values for ZoneTuning::modifier and ModSettings::requireModifier.
-static constexpr int kModifierWin = 4;
-
 struct ZoneTuning
 {
     int size = -1;      // corner square / edge strip thickness, px
@@ -787,7 +801,7 @@ struct ZoneTuning
     int settle = -1;    // pass-through guard, ms
     int knock = -1;     // knock window, ms
     int cooldown = -1;  // per-zone cooldown, ms
-    int modifier = -1;  // 0 none, 1 Ctrl, 2 Alt, 3 Shift, 4 Win
+    int modifier = -1;  // kModifier* above, or -1 to inherit
 };
 
 struct ZoneConfig
@@ -883,6 +897,12 @@ struct ZoneSet
         std::wstring id;
         int width = 0;
         int height = 0;
+        // BuildZoneSet clamps against the work area when "Keep zones out of
+        // the taskbar" is on, so the dashboard needs both to report the size a
+        // zone will really use rather than one measured against a rect the
+        // builder did not use.
+        int workWidth = 0;
+        int workHeight = 0;
         bool primary = false;
     };
     std::vector<MonitorSummary> monitors;
@@ -1438,6 +1458,14 @@ static void RefreshMonitors()
             m.id += L" #" + std::to_wstring(n);
     }
 
+}
+
+// Split out of RefreshMonitors so it can be called past RebuildZones' no-op
+// check. An SPI_SETWORKAREA burst dispatches one rebuild per broadcast and the
+// result is usually identical, so printing from RefreshMonitors put five-plus
+// lines in the log per broadcast for a change nobody made.
+static void LogMonitors()
+{
     if (!g_showMonitorNames)
         return;
 
@@ -2427,6 +2455,8 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
         ms.id = mon.id;
         ms.width = mon.rcMonitor.right - mon.rcMonitor.left;
         ms.height = mon.rcMonitor.bottom - mon.rcMonitor.top;
+        ms.workWidth = mon.rcWork.right - mon.rcWork.left;
+        ms.workHeight = mon.rcWork.bottom - mon.rcWork.top;
         ms.primary = mon.isPrimary;
         set->monitors.push_back(std::move(ms));
     }
@@ -2713,6 +2743,7 @@ static void RebuildZones()
         return;
 
     // Past the no-op check, so this describes a change that actually happened.
+    LogMonitors();
     if (set->zones.empty())
     {
         Wh_Log(L"No zones are active - every zone is set to \"Nothing\", or "
@@ -2810,6 +2841,14 @@ static bool EnqueueAction(const HitZone &hz)
         g_queue.push_back(hz);
     LeaveCriticalSection(&g_queueLock);
     SetEvent(g_hWorkEvent);
+    if (!queued)
+    {
+        // The caller has already spent the visit and stamped both cooldowns by
+        // the time it learns this, so the zone stays dead until the pointer
+        // leaves and comes back. Users are asked to paste this log when a zone
+        // misbehaves, and silence here is exactly the case it cannot answer.
+        Wh_Log(L"DROPPED (action queue full): %s", hz.label.c_str());
+    }
     return queued;
 }
 
@@ -2983,11 +3022,11 @@ static bool RequiredModifierHeld(int which)
 {
     switch (which)
     {
-    case 1: return (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
-    case 2: return (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
-    case 3: return (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
-    case 4: return (GetAsyncKeyState(VK_LWIN) & 0x8000) != 0 ||
-                   (GetAsyncKeyState(VK_RWIN) & 0x8000) != 0;
+    case kModifierCtrl:  return (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
+    case kModifierAlt:   return (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
+    case kModifierShift: return (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
+    case kModifierWin:   return (GetAsyncKeyState(VK_LWIN) & 0x8000) != 0 ||
+                                (GetAsyncKeyState(VK_RWIN) & 0x8000) != 0;
     default: return true;  // no modifier required
     }
 }
@@ -3596,15 +3635,15 @@ static int ParseZoneName(const std::wstring &s)
 static int ParseModifierName(const std::wstring &s)
 {
     if (s == L"NONE")
-        return 0;
+        return kModifierNone;
     if (s == L"CTRL")
-        return 1;
+        return kModifierCtrl;
     if (s == L"ALT")
-        return 2;
+        return kModifierAlt;
     if (s == L"SHIFT")
-        return 3;
+        return kModifierShift;
     if (s == L"WIN")
-        return 4;
+        return kModifierWin;
     return -1;   // INHERIT, empty, or anything unrecognised
 }
 
@@ -4091,6 +4130,11 @@ struct DisplayView
     std::wstring id;
     int width = 0;
     int height = 0;
+    // The working area, so the detail panel can clamp against the same rect
+    // BuildZoneSet used - which is this one when "Keep zones out of the
+    // taskbar" is on, and the full monitor otherwise.
+    int workWidth = 0;
+    int workHeight = 0;
     bool primary = false;
     bool present = true;        // attached right now
     bool wildcard = false;      // the "*" configuration
@@ -4585,6 +4629,8 @@ static void DashBuildSnapshot(DashState *s)
             dv.id = m.id;
             dv.width = m.width;
             dv.height = m.height;
+            dv.workWidth = m.workWidth;
+            dv.workHeight = m.workHeight;
             dv.primary = m.primary;
             dv.present = true;
             DashFillZones(dv, cfgs);
@@ -5028,11 +5074,17 @@ static void DashPaintDetail(DashState *s, HDC hdc, const RECT &client)
     else if (zv.releaseAction != CornerAction::Nothing)
     {
         wchar_t hold[256];
-        _snwprintf_s(hold, _countof(hold), _TRUNCATE,
-                     L"Held: runs %s again when the pointer leaves",
-                     zv.releaseAction == CornerAction::SameAsEntry
-                         ? ActionToString(zv.action)
-                         : ActionToString(zv.releaseAction));
+        // "again" is only true when the release repeats the entry. With a
+        // different release action it read as though that action was the
+        // entry - "runs Mute again" on a zone that opens Quick Settings.
+        if (zv.releaseAction == CornerAction::SameAsEntry)
+            _snwprintf_s(hold, _countof(hold), _TRUNCATE,
+                         L"Held: runs %s again when the pointer leaves",
+                         ActionToString(zv.action));
+        else
+            _snwprintf_s(hold, _countof(hold), _TRUNCATE,
+                         L"Held: runs %s when the pointer leaves",
+                         ActionToString(zv.releaseAction));
         r = {left, y, right, y + Sc(16, d)};
         DrawTextW(hdc, hold, -1, &r,
                   DT_LEFT | DT_SINGLELINE | DT_END_ELLIPSIS);
@@ -5114,7 +5166,16 @@ static void DashPaintDetail(DashState *s, HDC hdc, const RECT &client)
         // goes to ask why a zone is not the size they set.
         if (i == 0 && dv.width > 0 && dv.height > 0)
         {
-            int span = dv.width < dv.height ? dv.width : dv.height;
+            // Same rect BuildZoneSet measures against, or the panel reports a
+            // size the zone does not use.
+            int mw = dv.width, mh = dv.height;
+            if (s->globals.avoidTaskbar && dv.workWidth > 0 &&
+                dv.workHeight > 0)
+            {
+                mw = dv.workWidth;
+                mh = dv.workHeight;
+            }
+            int span = mw < mh ? mw : mh;
             int effective = ClampZoneSize(value, span);
 
             Zone corners[2];

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -8,7 +8,7 @@
 // @donateUrl       https://ko-fi.com/losthusky_
 // @license         MIT
 // @include         windhawk.exe
-// @compilerOptions -ladvapi32 -lgdi32 -lole32 -lpowrprof -lshell32 -luser32
+// @compilerOptions -ladvapi32 -lgdi32 -lole32 -lpowrprof -lshell32 -luser32 -luuid
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         4.4.5
+// @version         1.0.0
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -261,12 +261,59 @@ Hot corners are disabled when any excluded process is the foreground window.
 
 **Example:** `photoshop.exe;premiere.exe;blender.exe`
 
-# Changelog
+# Why it works this way
 
-## 4.4.5
+Not a changelog — this is the first release. These are the decisions that are
+easy to second-guess later, and the reason each one went the way it did.
 
-First release. Earlier version numbers exist only in the development
-repository and were never published, so there is nothing to upgrade from.
+**Polling, not a mouse hook.** A `WH_MOUSE_LL` hook sits directly on the system
+input path: every mouse event in every process waits for it, and if it is slow
+even once Windows silently unhooks it (`LowLevelHooksTimeout`). A dedicated
+thread sampling the cursor costs a `GetCursorPos` per tick and cannot make your
+mouse stutter. The tick asks for 16 ms and gets 16–31 ms, because that is the
+system timer resolution.
+
+**Its own process, not injected into Explorer.** The mod does nothing to other
+processes, so there is no reason to be inside one. An Explorer crash cannot take
+it down, and it cannot take Explorer down.
+
+**Displays are bound by name, not by position.** Enumeration order changes
+whenever you rearrange screens or make a different one primary. Friendly names
+come from the display's EDID and survive that, so your corners stay on the
+screen you set them on. Two identical models are the exception — they get a
+` #2` suffix handed out in enumeration order, so that pair *can* swap.
+
+**The settings page is the only place anything is stored.** A Windhawk mod can
+read its settings but cannot write them, so a mod that also edits its own
+configuration in its own window will always end up with two copies that
+disagree. The dashboard is a picture of what the settings produced, and nothing
+else. It reads the resolved configuration rather than the stored one, which is
+what stops it from ever disagreeing with what actually fires.
+
+**Each edge is three segments that merge back together.** Three separate zones
+carrying the same action would each re-arm as the pointer crossed a seam, so
+sliding along an edge would fire it repeatedly. Segments that resolve
+identically are coalesced into one zone before detection ever sees them, which
+is what makes "all three the same" genuinely one edge-wide zone.
+
+**Zones can never overlap.** Each edge's thickness is clamped to the smaller of
+the two corners it runs between. That one rule is what keeps all sixteen zones
+disjoint no matter which sizes you pick, without any special cases.
+
+**A cooldown is a wait, not a refusal.** Landing in a corner while a cooldown is
+running does not spend the visit — the dwell simply outlasts it and the zone
+fires. Marking the visit spent meant parking in a corner did nothing at all and
+you had to leave and come back.
+
+**A rebuild is not a gesture.** Enabling the mod, changing a setting or waking a
+monitor rebuilds the zones, and the pointer may already be sitting in one. The
+rebuild adopts that zone with the visit already spent, so a corner bound to
+*Lock* cannot lock the machine because a display woke up.
+
+**The fullscreen and excluded-app checks run on the worker thread**, not on the
+sampling thread, so a slow `OpenProcess` can never delay cursor sampling. The
+cost is that a suppressed trigger still consumes its cooldown — a wait nobody
+can perceive, traded for a sampling path that never stalls.
 
 ## Support
 
@@ -3053,9 +3100,10 @@ static void UpdateTrayIcon(bool add)
 // =====================================================================
 //
 // The settings page is the configuration surface; the dashboard only shows
-// what it produced. Two surfaces writing the same store is what produced the
-// 4.1.3 and 4.1.4 bugs, where the dashboard addressed configurations by list
-// position and overwrote the wrong one.
+// what it produced. A mod can read its settings but not write them, so a
+// second surface that also edits the configuration can only ever diverge from
+// this one - during development that showed up as an editor addressing stored
+// configurations by list position and overwriting the wrong display.
 //
 // Precedence, decided once per reload:
 //
@@ -3879,10 +3927,10 @@ static void ApplyModernFrame(HWND hWnd)
 // Reading the live configuration
 // =====================================================================
 //
-// The dashboard reads what ReloadConfig already resolved, not the value store.
-// That is what makes it correct for a settings-page layout and a pre-4.2 one
-// without knowing which is in use, and it is why it can no longer drift from
-// what actually fires.
+// The dashboard reads what ReloadConfig already resolved, rather than reading
+// the settings itself. Resolving twice is how a picture starts disagreeing
+// with what actually fires; reading the resolved result makes that impossible
+// by construction.
 
 static const wchar_t *kTuningNames[] = {
     L"Size", L"Activation delay", L"Pass-through guard",

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         1.1.6
+// @version         1.1.7
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -2482,7 +2482,21 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
             hz.args = zc->args;
             hz.releaseAction = zc->releaseAction;
             hz.releaseArgs = zc->releaseArgs;
-            hz.releaseExec = zc->releaseExecutor;
+            // "The same action again" means exactly that: the same executor,
+            // not another one built from the same settings. It matters for the
+            // Alternate actions, whose executor carries a flip flag - a second
+            // copy has its own, so the release would run its own sequence
+            // instead of continuing the entry's. The stored release executor is
+            // also built once per configuration rather than per monitor, so on
+            // two displays the entry flags advanced independently while the
+            // release flag advanced once per trigger anywhere, and the pair
+            // drifted apart after the first trigger on the second display.
+            //
+            // For every non-alternating action the two are equivalent, so this
+            // changes nothing for Show Desktop, Mute or Keep awake.
+            hz.releaseExec = zc->releaseAction == CornerAction::SameAsEntry
+                                 ? hz.exec
+                                 : zc->releaseExecutor;
             hz.label = mon.id + L" " + ZoneToString(z) + L" -> " +
                        ActionToString(zc->action);
             set->zones.push_back(std::move(hz));
@@ -3423,7 +3437,6 @@ static void UpdateTrayIcon(bool add)
         DestroyIcon(nid.hIcon);
 }
 
-// action worker and the tray menu.
 // =====================================================================
 // Windhawk settings page
 // =====================================================================
@@ -3437,9 +3450,11 @@ static void UpdateTrayIcon(bool add)
 // Precedence, decided once per reload:
 //
 //   1. Displays configured on the settings page win outright.
-//   2. Otherwise, a layout saved by an older version still runs, so upgrading
-//      never silently wipes a configuration that took effort to enter.
-//   3. Otherwise, settings supply the globals and no zones are active.
+//   2. Otherwise, settings supply the globals and no zones are active.
+//
+// There used to be a step between the two for a zone layout saved before the
+// settings page existed. That migration path was removed in 4.4.4 and the
+// value store now holds nothing but the enable flag.
 
 static int ParseZoneName(const std::wstring &s)
 {
@@ -3649,9 +3664,8 @@ static void ApplySettingsGlobals(ModSettings &s)
 // zones are active". Four of the six callers run on a thread other than the
 // one that starts the mod, so that window was reachable.
 //
-// The settings page owns every global. The value store is read only for the
-// enable flag and, on the upgrade path, for a zone layout saved before the
-// settings page came back - never for anything a page field also controls,
+// The settings page owns every global. The value store is read for the enable
+// flag and nothing else - never for anything a page field also controls,
 // because the two would then disagree with nothing on screen saying which won.
 static void ReloadConfig()
 {
@@ -3884,7 +3898,11 @@ static void HandleTrayCommand(UINT id)
 // what makes it look native.
 
 static HANDLE g_hDashThread = nullptr;
-static HWND g_hDashWnd = nullptr;
+// Written by the dashboard thread, read by Windhawk's thread
+// (WhTool_ModSettingsChanged, WhTool_ModUninit) and the tray thread
+// (OpenDashboard). g_trayEnabled, g_suspendUntil and g_trayUseGuid are all
+// atomic for the same reason; this one was missed.
+static std::atomic<HWND> g_hDashWnd{nullptr};
 
 // The dashboard followed the system theme in neither direction before: it was
 // hard-coded dark, so on a light desktop the text was near-invisible. The
@@ -5392,11 +5410,12 @@ static DWORD WINAPI DashThread(LPVOID)
 
 static void OpenDashboard()
 {
-    if (g_hDashWnd && IsWindow(g_hDashWnd))
+    HWND hDash = g_hDashWnd.load();
+    if (hDash && IsWindow(hDash))
     {
         // Already open — bring it forward rather than making a second one.
-        ShowWindow(g_hDashWnd, SW_RESTORE);
-        SetForegroundWindow(g_hDashWnd);
+        ShowWindow(hDash, SW_RESTORE);
+        SetForegroundWindow(hDash);
         return;
     }
     if (g_hDashThread)
@@ -5471,6 +5490,13 @@ static LRESULT CALLBACK TrayWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
 
 static DWORD WINAPI TrayThread(LPVOID)
 {
+    // The detection and dashboard threads both pin this; the tray one did not.
+    // UpdateTrayIcon -> MakeTrayIcon reads GetSystemMetrics(SM_CXSMICON), and
+    // it is called both from here and from Windhawk's thread, which can be in a
+    // different awareness context - so the icon could be built at the wrong
+    // size on a mixed-scaling setup depending on who asked for it.
+    PinThreadDpiPerMonitorV2();
+
     const wchar_t *kClass = L"WindhawkHotCornersTray";
     HINSTANCE hInst = GetModuleHandle(nullptr);
 
@@ -5575,8 +5601,8 @@ void WhTool_ModSettingsChanged()
     if (g_hDetectWnd)
         PostMessage(g_hDetectWnd, WM_APP_REBUILD, 0, 0);
     // An open dashboard is showing the configuration that just changed.
-    if (g_hDashWnd)
-        PostMessage(g_hDashWnd, WM_APP_DASH_REFRESH, 0, 0);
+    if (HWND hDash = g_hDashWnd.load())
+        PostMessage(hDash, WM_APP_DASH_REFRESH, 0, 0);
 }
 
 void WhTool_ModUninit()
@@ -5633,8 +5659,8 @@ void WhTool_ModUninit()
     // and it takes g_settingsLock and g_zonesLock. Nothing below may free
     // those while it is alive. Its loop only ends when its window does, so
     // close the window rather than signalling the stop event.
-    if (g_hDashWnd)
-        PostMessage(g_hDashWnd, WM_CLOSE, 0, 0);
+    if (HWND hDash = g_hDashWnd.load())
+        PostMessage(hDash, WM_CLOSE, 0, 0);
 
     if (g_hDashThread)
     {

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         1.1.9
+// @version         1.2.0
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -157,57 +157,57 @@ the window and the next one puts it back.
 | Action | Description |
 |--------|-------------|
 | Task View | Overview of all windows (Win+Tab) |
-| Switch to Last Window | Jump straight back to the previous window (Alt+Tab) |
-| Task Switcher | Persistent switcher you can click through (Ctrl+Alt+Tab) |
-| Virtual Desktop — Next / Previous / New | Move between or create desktops |
-| Close Virtual Desktop | Close the current desktop |
+| Switch to last window | Jump straight back to the previous window (Alt+Tab) |
+| Task switcher | Persistent switcher you can click through (Ctrl+Alt+Tab) |
+| Next / Previous / New virtual desktop | Move between or create desktops |
+| Close virtual desktop | Close the current desktop |
 
 **Windows**
 
 | Action | Description |
 |--------|-------------|
-| Show Desktop | Toggle desktop visibility |
-| Hide Other Windows | Minimize all except the active window (Win+Home) |
-| Minimize Active Window | Win+Down |
-| Maximize Active Window | Win+Up |
-| Snap Window Left / Right | Win+Left / Win+Right |
-| Close Active Window | Alt+F4 |
+| Show desktop | Toggle desktop visibility |
+| Hide other windows | Minimize all except the active window (Win+Home) |
+| Minimise window | Win+Down |
+| Maximise window | Win+Up |
+| Snap left / Snap right | Win+Left / Win+Right |
+| Close window | Alt+F4 |
 
 **System**
 
 | Action | Description |
 |--------|-------------|
-| Start Menu | Open the Start menu |
+| Start menu | Open the Start menu |
 | Search | Win+S |
 | Settings | Win+I |
 | File Explorer | Win+E |
 | Quick Settings | Win+A |
-| Notification Center | Win+N |
-| Clipboard History | Win+V |
-| Screenshot / Snip | Win+Shift+S |
-| Project / Second Screen | Win+P |
+| Notification Centre | Win+N |
+| Clipboard history | Win+V |
+| Screenshot | Win+Shift+S |
+| Project display | Win+P |
 | Task Manager | Open Task Manager |
-| Mute Volume | Toggle system mute |
+| Mute | Toggle system mute |
 
 **Power**
 
 | Action | Description |
 |--------|-------------|
-| Lock Computer | Lock the workstation instantly |
-| Lock and Turn Off Monitors | Lock, then blank the displays |
-| Keep Awake On / Off | Suspend or restore screensaver and sleep |
+| Lock | Lock the workstation instantly |
+| Lock and turn monitors off | Lock, then blank the displays |
+| Keep awake on / off | Suspend or restore screensaver and sleep |
 | Sleep | Put the computer to sleep |
-| Turn Off Monitors | Power off all displays |
-| Start Screen Saver | Activate the screen saver |
+| Turn monitors off | Power off all displays |
+| Start screensaver | Activate the screen saver |
 
 **Custom**
 
 | Action | Description |
 |--------|-------------|
-| Virtual Key Press | Send any key combination, or several in sequence |
-| Alternate Key Press | Two combinations, fired alternately (`Alt+S | Alt+H`) |
-| Alternate Command | Two commands, fired alternately |
-| Custom Command | Launch any executable, path, or URL |
+| Send key press | Send any key combination, or several in sequence |
+| Alternate key press | Two combinations, fired alternately (`Alt+S | Alt+H`) |
+| Alternate command | Two commands, fired alternately |
+| Custom command | Launch any executable, path, or URL |
 | Nothing | Disabled (default) |
 
 ### Arguments
@@ -742,7 +742,7 @@ enum class CornerAction
 // Zone IDs: 0-3 corners, then each edge as three independently configurable
 // segments running between the two corners it touches.
 //
-// Before 4.4 an edge was one zone plus an optional centre, so the two outer
+// An edge used to be one zone plus an optional centre, so the two outer
 // stretches always did the same thing. Splitting them into start/middle/end
 // makes every pattern expressible - ABC, AAB, ABB - and setting all three the
 // same gives one edge-wide zone, because BuildZoneSet coalesces neighbouring
@@ -777,6 +777,9 @@ enum Zone
 // Per-zone overrides. Every numeric field uses -1 for "inherit the global
 // value", so an untouched zone behaves exactly as it did before per-zone
 // settings existed and old configurations keep working unchanged.
+// Values for ZoneTuning::modifier and ModSettings::requireModifier.
+static constexpr int kModifierWin = 4;
+
 struct ZoneTuning
 {
     int size = -1;      // corner square / edge strip thickness, px
@@ -888,6 +891,10 @@ struct ZoneSet
     // them there; a second copy here would just be a second thing to keep
     // in step.
     bool disableDuringDrag = true;
+    // Carried only so RebuildZones can name them in the log it prints past its
+    // no-op check; detection never reads these.
+    int cornerSizeCfg = 0;
+    int edgeSizeCfg = 0;
 };
 
 // =====================================================================
@@ -1470,15 +1477,28 @@ static std::wstring ProcessNameOfWindow(HWND hwnd)
     if (!hProc)
         return L"";
 
-    WCHAR exePath[MAX_PATH];
-    DWORD pathLen = MAX_PATH;
-    BOOL ok = QueryFullProcessImageNameW(hProc, 0, exePath, &pathLen);
+    // MAX_PATH is not the limit for a process image path, and the failure is
+    // silent in the worst way: QueryFullProcessImageNameW returns
+    // ERROR_INSUFFICIENT_BUFFER, this returns L"", and the Excluded
+    // applications list then never matches that process - while
+    // IsForegroundAppExcluded caches the empty answer until the foreground
+    // window changes.
+    std::wstring exePath(MAX_PATH, L'\0');
+    DWORD pathLen = (DWORD)exePath.size();
+    BOOL ok = QueryFullProcessImageNameW(hProc, 0, exePath.data(), &pathLen);
+    if (!ok && GetLastError() == ERROR_INSUFFICIENT_BUFFER)
+    {
+        exePath.assign(32768, L'\0');
+        pathLen = (DWORD)exePath.size();
+        ok = QueryFullProcessImageNameW(hProc, 0, exePath.data(), &pathLen);
+    }
     CloseHandle(hProc);
     if (!ok)
         return L"";
+    exePath.resize(pathLen);
 
-    const wchar_t *fileName = wcsrchr(exePath, L'\\');
-    return fileName ? fileName + 1 : exePath;
+    size_t slash = exePath.find_last_of(L'\\');
+    return slash == std::wstring::npos ? exePath : exePath.substr(slash + 1);
 }
 
 static bool IsShellUiWindow(HWND hwnd)
@@ -2097,42 +2117,42 @@ static const wchar_t *ActionToString(CornerAction a)
     case CornerAction::Nothing: return L"Nothing";
     case CornerAction::DisabledHere: return L"Disabled here";
     case CornerAction::SameAsEntry: return L"the same action again";
-    case CornerAction::ShowDesktop: return L"Show Desktop";
+    case CornerAction::ShowDesktop: return L"Show desktop";
     case CornerAction::TaskView: return L"Task View";
-    case CornerAction::ScreenSaver: return L"Screen Saver";
-    case CornerAction::MonitorsOff: return L"Turn Off Monitors";
+    case CornerAction::ScreenSaver: return L"Start screensaver";
+    case CornerAction::MonitorsOff: return L"Turn monitors off";
     case CornerAction::QuickSettings: return L"Quick Settings";
-    case CornerAction::NotificationCenter: return L"Notification Center";
-    case CornerAction::StartMenu: return L"Start Menu";
-    case CornerAction::HideOthers: return L"Hide Other Windows";
+    case CornerAction::NotificationCenter: return L"Notification Centre";
+    case CornerAction::StartMenu: return L"Start menu";
+    case CornerAction::HideOthers: return L"Hide other windows";
     case CornerAction::Mute: return L"Mute";
     case CornerAction::TaskManager: return L"Task Manager";
-    case CornerAction::Lock: return L"Lock Computer";
+    case CornerAction::Lock: return L"Lock";
     case CornerAction::Sleep: return L"Sleep";
-    case CornerAction::SwitchLastWindow: return L"Switch to Last Window";
-    case CornerAction::TaskSwitcher: return L"Task Switcher";
-    case CornerAction::MinimizeWindow: return L"Minimize Window";
-    case CornerAction::MaximizeWindow: return L"Maximize Window";
-    case CornerAction::SnapLeft: return L"Snap Left";
-    case CornerAction::SnapRight: return L"Snap Right";
-    case CornerAction::CloseWindow: return L"Close Window";
+    case CornerAction::SwitchLastWindow: return L"Switch to last window";
+    case CornerAction::TaskSwitcher: return L"Task switcher";
+    case CornerAction::MinimizeWindow: return L"Minimise window";
+    case CornerAction::MaximizeWindow: return L"Maximise window";
+    case CornerAction::SnapLeft: return L"Snap left";
+    case CornerAction::SnapRight: return L"Snap right";
+    case CornerAction::CloseWindow: return L"Close window";
     case CornerAction::FileExplorer: return L"File Explorer";
     case CornerAction::SettingsApp: return L"Settings";
     case CornerAction::Search: return L"Search";
-    case CornerAction::ClipboardHistory: return L"Clipboard History";
+    case CornerAction::ClipboardHistory: return L"Clipboard history";
     case CornerAction::Screenshot: return L"Screenshot";
-    case CornerAction::ProjectDisplay: return L"Project";
-    case CornerAction::VDesktopNext: return L"Virtual Desktop Next";
-    case CornerAction::VDesktopPrev: return L"Virtual Desktop Previous";
-    case CornerAction::VDesktopNew: return L"Virtual Desktop New";
-    case CornerAction::VDesktopClose: return L"Virtual Desktop Close";
-    case CornerAction::LockAndMonitorsOff: return L"Lock and Turn Off Monitors";
-    case CornerAction::KeepAwakeOn: return L"Keep Awake On";
-    case CornerAction::KeepAwakeOff: return L"Keep Awake Off";
-    case CornerAction::AlternateKeypress: return L"Alternate Key Press";
-    case CornerAction::AlternateCommand: return L"Alternate Command";
-    case CornerAction::SendKeypress: return L"Virtual Key Press";
-    case CornerAction::StartProcess: return L"Custom Command";
+    case CornerAction::ProjectDisplay: return L"Project display";
+    case CornerAction::VDesktopNext: return L"Next virtual desktop";
+    case CornerAction::VDesktopPrev: return L"Previous virtual desktop";
+    case CornerAction::VDesktopNew: return L"New virtual desktop";
+    case CornerAction::VDesktopClose: return L"Close virtual desktop";
+    case CornerAction::LockAndMonitorsOff: return L"Lock and turn monitors off";
+    case CornerAction::KeepAwakeOn: return L"Keep awake on";
+    case CornerAction::KeepAwakeOff: return L"Keep awake off";
+    case CornerAction::AlternateKeypress: return L"Alternate key press";
+    case CornerAction::AlternateCommand: return L"Alternate command";
+    case CornerAction::SendKeypress: return L"Send key press";
+    case CornerAction::StartProcess: return L"Custom command";
     }
     return L"Unknown";
 }
@@ -2324,6 +2344,37 @@ static bool SameZoneConfig(const ZoneConfig *a, const ZoneConfig *b)
            x.modifier == y.modifier;
 }
 
+// Both the zone builder and the dashboard need the *effective* size, not the
+// configured one, and they used to disagree: the panel printed the number from
+// the settings under a column headed IN EFFECT while the zone actually fired at
+// the clamped size. One function, called from both.
+static int ClampZoneSize(int requested, int span)
+{
+    int v = requested < 1 ? 1 : requested;
+    if (v > span / 2)
+        v = span / 2;
+    return v < 1 ? 1 : v;
+}
+
+// The two corners an edge runs between; its thickness can never exceed the
+// smaller of them, which is the rule that keeps all sixteen zones disjoint.
+static bool EdgeCorners(Zone z, Zone out[2])
+{
+    switch (z)
+    {
+    case ZONE_TOP_START: case ZONE_TOP_MIDDLE: case ZONE_TOP_END:
+        out[0] = ZONE_TOP_LEFT;    out[1] = ZONE_TOP_RIGHT;    return true;
+    case ZONE_BOTTOM_START: case ZONE_BOTTOM_MIDDLE: case ZONE_BOTTOM_END:
+        out[0] = ZONE_BOTTOM_LEFT; out[1] = ZONE_BOTTOM_RIGHT; return true;
+    case ZONE_LEFT_START: case ZONE_LEFT_MIDDLE: case ZONE_LEFT_END:
+        out[0] = ZONE_TOP_LEFT;    out[1] = ZONE_BOTTOM_LEFT;  return true;
+    case ZONE_RIGHT_START: case ZONE_RIGHT_MIDDLE: case ZONE_RIGHT_END:
+        out[0] = ZONE_TOP_RIGHT;   out[1] = ZONE_BOTTOM_RIGHT; return true;
+    default:
+        return false;
+    }
+}
+
 // Caller must hold g_settingsLock.
 static const ZoneConfig *ResolveZone(const MonitorInfo &mon, Zone zone)
 {
@@ -2402,13 +2453,7 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
         {
             const ZoneConfig *zc = zoneCfg(z);
             int v = (zc && zc->tuning.size > 0) ? zc->tuning.size : fallback;
-            if (v < 1)
-                v = 1;
-            if (v > span / 2)
-                v = span / 2;
-            if (v < 1)
-                v = 1;
-            return v;
+            return ClampZoneSize(v, span);
         };
 
         int csTL = sizeOf(ZONE_TOP_LEFT, csCfg);
@@ -2592,19 +2637,12 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
     }
     LeaveCriticalSection(&g_settingsLock);
 
-    if (set->zones.empty())
-    {
-        Wh_Log(L"No zones are active - every zone is set to \"Nothing\", or "
-               L"no configuration matches a connected monitor.");
-    }
-    else
-    {
-        Wh_Log(L"Active zones (%d)   corner %dpx, edge %dpx:",
-               (int)set->zones.size(), csCfg, esCfg);
-        for (const auto &z : set->zones)
-            Wh_Log(L"   %s", z.label.c_str());
-    }
-
+    // Deliberately not logged here. An SPI_SETWORKAREA burst calls this once
+    // per broadcast and the result is usually identical, so logging at build
+    // time repeated the whole zone list several times for a change nobody made.
+    // RebuildZones logs past its no-op check instead.
+    set->cornerSizeCfg = csCfg;
+    set->edgeSizeCfg = esCfg;
     return set;
 }
 
@@ -2673,6 +2711,20 @@ static void RebuildZones()
     LeaveCriticalSection(&g_zonesLock);
     if (SameZoneSet(current.get(), set.get()))
         return;
+
+    // Past the no-op check, so this describes a change that actually happened.
+    if (set->zones.empty())
+    {
+        Wh_Log(L"No zones are active - every zone is set to \"Nothing\", or "
+               L"no configuration matches a connected monitor.");
+    }
+    else
+    {
+        Wh_Log(L"Active zones (%d)   corner %dpx, edge %dpx:",
+               (int)set->zones.size(), set->cornerSizeCfg, set->edgeSizeCfg);
+        for (const auto &z : set->zones)
+            Wh_Log(L"   %s", z.label.c_str());
+    }
 
     // The state reset below forgets which zone was held, so let go first while
     // the old set is still the one those indices refer to.
@@ -2880,6 +2932,25 @@ static DWORD WINAPI ActionWorkerThread(LPVOID)
             // Calling an empty std::function throws, and an exception escaping
             // this thread would kill it silently — every zone would stop
             // working with no indication why.
+            // The Start-menu mask in SendKeys only covers actions that go
+            // through it. Lock, Sleep, Task Manager, Custom command and the
+            // Keep awake pair never do, so on a Win-guarded zone the user's
+            // Win key-down stayed unmatched and letting go opened Start - the
+            // same behaviour SendKeys exists to suppress, on the other half of
+            // the action list. One tap here makes it uniform. Ctrl alone does
+            // nothing, and a second tap for a key-based action is harmless.
+            if (job.modifier == kModifierWin &&
+                ((GetAsyncKeyState(VK_LWIN) & 0x8000) ||
+                 (GetAsyncKeyState(VK_RWIN) & 0x8000)))
+            {
+                INPUT tap[2] = {};
+                tap[0].type = INPUT_KEYBOARD;
+                tap[0].ki.wVk = VK_CONTROL;
+                tap[1] = tap[0];
+                tap[1].ki.dwFlags = KEYEVENTF_KEYUP;
+                SendInput(2, tap, sizeof(INPUT));
+            }
+
             if (job.exec)
                 job.exec();
 
@@ -3247,6 +3318,13 @@ static DWORD g_dwTrayThreadId = 0;
 static std::atomic<HWND> g_hTrayWnd{nullptr};
 static UINT g_taskbarCreatedMsg = 0;
 static constexpr UINT WM_APP_TRAY = WM_APP + 10;
+
+// Posted so the icon is always rebuilt on the tray thread. MakeTrayIcon reads
+// GetSystemMetrics(SM_CXSMICON), which is DPI-context sensitive, and
+// WhTool_ModSettingsChanged runs on Windhawk's thread in whatever context that
+// happens to be - which is what pinning the tray thread was for. It also keeps
+// Shell_NotifyIcon, which round-trips to the shell, off that thread.
+static constexpr UINT WM_APP_TRAY_REFRESH = WM_APP + 11;
 static constexpr UINT_PTR kTrayIconId = 1;
 // Fires once when a suspension expires, purely so the icon stops saying
 // "paused". Detection needs no timer - it re-reads the deadline every tick.
@@ -3479,7 +3557,7 @@ static void UpdateTrayIcon(bool add)
 //   2. Otherwise, settings supply the globals and no zones are active.
 //
 // There used to be a step between the two for a zone layout saved before the
-// settings page existed. That migration path was removed in 4.4.4 and the
+// settings page existed. That migration path is gone and the
 // value store now holds nothing but the enable flag.
 
 static int ParseZoneName(const std::wstring &s)
@@ -3605,9 +3683,12 @@ static std::vector<MonitorZoneConfig> ReadSettingsZones()
                 GetSettingStr(L"displays[%d].zones[%d].releaseArgs", i, z);
             cfg.zones[zi].releaseAction = rel;
             cfg.zones[zi].releaseArgs = relArgs;
-            if (rel == CornerAction::SameAsEntry)
-                cfg.zones[zi].releaseExecutor = MakeExecutor(act, args);
-            else if (rel != CornerAction::Nothing)
+            // Nothing is built for SameAsEntry on purpose: BuildZoneSet
+            // substitutes the entry executor for that case, so a second one
+            // would never be read - and for an Alternate entry it would carry
+            // its own flip flag, which is the drift that substitution fixed.
+            if (rel != CornerAction::Nothing &&
+                rel != CornerAction::SameAsEntry)
                 cfg.zones[zi].releaseExecutor = MakeExecutor(rel, relArgs);
             cfg.zones[zi].tuning.size =
                 Wh_GetIntSetting(L"displays[%d].zones[%d].size", i, z);
@@ -4484,11 +4565,17 @@ static void DashBuildSnapshot(DashState *s)
     std::vector<MonitorZoneConfig> cfgs;
     {
         EnterCriticalSection(&g_settingsLock);
-        cfgs = g_settings.monitorConfigs;
+        // One deep copy, not two. Copying g_settings already duplicates every
+        // configuration - each with its std::function executors and strings -
+        // so take the copy and then steal that vector out of it, rather than
+        // copying monitorConfigs separately and clearing the duplicate
+        // afterwards. The detection thread can be waiting on this lock inside
+        // BuildZoneSet, and the second pass was paid for with its latency.
         s->globals = g_settings;
+        cfgs = std::move(s->globals.monitorConfigs);
         LeaveCriticalSection(&g_settingsLock);
     }
-    s->globals.monitorConfigs.clear();   // not needed, and it is not small
+    s->globals.monitorConfigs.clear();   // moved-from, but say so explicitly
 
     if (snap)
     {
@@ -4803,7 +4890,6 @@ static void DashPaintDiagram(DashState *s, HDC hdc)
                 // Getting this backwards puts the whole label outside its own
                 // strip, where the clip rect shears it in half and it reads as
                 // two labels colliding. Rendered rather than reasoned about:
-                // scripts/probe-vtext.cpp draws all three candidates.
                 TextOutW(hdc, cx - ts.cy / 2, cy + ts.cx / 2, lab.c_str(),
                          (int)lab.size());
                 SelectClipRgn(hdc, nullptr);
@@ -5018,6 +5104,40 @@ static void DashPaintDetail(DashState *s, HDC hdc, const RECT &client)
                 from = (owner == zone) ? L"this zone"
                                        : std::wstring(L"whole edge, set on ") +
                                              ZoneToString((Zone)owner);
+            }
+        }
+
+        // Report what the zone will actually use, not what was typed. Both
+        // clamps below are applied by BuildZoneSet before anything fires, so
+        // without them an edge thickness of 40 next to 6 px corners printed
+        // "40 px" under a column headed IN EFFECT - in the one place a user
+        // goes to ask why a zone is not the size they set.
+        if (i == 0 && dv.width > 0 && dv.height > 0)
+        {
+            int span = dv.width < dv.height ? dv.width : dv.height;
+            int effective = ClampZoneSize(value, span);
+
+            Zone corners[2];
+            if (EdgeCorners((Zone)zone, corners))
+            {
+                int cap = span;
+                for (Zone c : corners)
+                {
+                    int cs = dv.zones[c].tuning.size > 0
+                                 ? dv.zones[c].tuning.size
+                                 : s->globals.cornerSize;
+                    cs = ClampZoneSize(cs, span);
+                    if (cs < cap)
+                        cap = cs;
+                }
+                if (effective > cap)
+                    effective = cap;
+            }
+
+            if (effective != value)
+            {
+                from += L", clamped";
+                value = effective;
             }
         }
 
@@ -5511,6 +5631,11 @@ static LRESULT CALLBACK TrayWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
         HandleTrayCommand(LOWORD(wParam));
         return 0;
     }
+    if (uMsg == WM_APP_TRAY_REFRESH)
+    {
+        UpdateTrayIcon(wParam != 0);
+        return 0;
+    }
     // The suspension has run out; repaint the icon so it stops saying "paused".
     if (uMsg == WM_TIMER && wParam == kSuspendTimerId)
     {
@@ -5633,7 +5758,8 @@ BOOL WhTool_ModInit()
 void WhTool_ModSettingsChanged()
 {
     ReloadConfig();
-    UpdateTrayIcon(false);
+    if (HWND hTray = g_hTrayWnd.load())
+        PostMessage(hTray, WM_APP_TRAY_REFRESH, 0, 0);
     // The zone rebuild has to happen on the detection thread, which owns the
     // DPI context and the monitor list. Post, never send — Windhawk's thread
     // must not block on ours.
@@ -5677,9 +5803,20 @@ void WhTool_ModUninit()
     // that thread never waits on anything Windhawk's thread holds.
     if (HWND hDetect = g_hDetectWnd.load())
     {
+        // The detection thread only dispatches sent messages when it comes
+        // back round to PeekMessage - WaitForSingleObject does not pump them -
+        // so this budget has to cover a tick that happens to be inside
+        // RebuildZones (QueryDisplayConfig with up to three attempts, an
+        // EnumDisplayMonitors, a DisplayConfigGetDeviceInfo pair per path).
+        // 500 ms could expire in there, and losing this message strands exactly
+        // the peeked desktop it exists to restore. 2 s still fits inside the
+        // 3 s join budget below.
         DWORD_PTR unused = 0;
-        SendMessageTimeout(hDetect, WM_APP_RELEASE_HOLD, 0, 0,
-                           SMTO_ABORTIFHUNG, 500, &unused);
+        if (!SendMessageTimeout(hDetect, WM_APP_RELEASE_HOLD, 0, 0,
+                                SMTO_ABORTIFHUNG, 2000, &unused))
+        {
+            Wh_Log(L"Hold release timed out; a held zone may not be undone");
+        }
     }
 
     if (g_hStopEvent)

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         1.0.1
+// @version         1.1.3
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -61,10 +61,10 @@ If all you want is one specific behaviour, a smaller mod may suit you better:
   and an end, configured separately. Give neighbouring parts the same action and
   they merge back into one, so you get whichever of `ABC`, `AAB`, `ABB` or `AAA`
   you want without a mode switch. See *Dividing an edge*.
-- **Knock to trigger** — set a knock window on any zone, corners included, and a
-  single arrival does nothing: you have to leave and come back within the window.
-  Handy on a corner you brush past often.
-- **Configurable zone size**, optional dwell delay, and a cooldown timer.
+- **Five ways to trigger** — on arrival, after a dwell, on a double knock, only
+  while a modifier is held, or press-and-hold to peek. They combine freely, and
+  any of them works on any zone. See *Ways to trigger a zone*.
+- **Configurable zone size** and a cooldown timer.
 - **Fullscreen protection** — auto-detects games, presentations, and D3D
   fullscreen apps.
 - **Drag protection** — zones don't fire while a mouse button is held.
@@ -85,6 +85,97 @@ the zones you want on it. A zone you do not list does nothing.
 
 If the tray icon is hidden, it is in the overflow area — drag it onto the
 taskbar to keep it there.
+
+## Ways to trigger a zone
+
+A zone does not have to fire the instant you touch it. There are five trigger
+styles, every one of them works on every zone — corners and edge segments alike —
+and they combine: a corner can require a knock *and* a held modifier *and* a
+dwell before it does anything.
+
+### Arrival
+
+The default. Reach the zone, the action runs.
+
+![Task View opening as the pointer reaches the top-left corner](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/trigger-arrival.gif)
+
+A short **pass-through guard** (80 ms out of the box) keeps a zone quiet when you
+were only travelling across it on the way somewhere else. If actions still fire
+while you are just moving around, raise it before you reach for anything else.
+
+### Dwell
+
+Set **Activation delay** and the pointer has to rest in the zone that long before
+it fires. Leave early and nothing happens.
+
+![Quick Settings appearing after the pointer rests on the top edge](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/trigger-dwell.gif)
+
+Use this on a zone you pass through constantly. 300–500 ms is deliberate without
+feeling sluggish; past about a second it stops feeling like a hot corner.
+
+### Knock
+
+Set **Knock window** and a single arrival never fires. The zone arms only when
+you leave and come straight back within that many milliseconds — a double-knock.
+
+![Leaving and re-entering the bottom-right corner to switch windows](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/trigger-knock.gif)
+
+This is the one to reach for on a corner you brush past often but want to keep
+for something disruptive. 400 ms is a comfortable knock; below about 200 ms it
+starts to demand real intent. `0` turns it off.
+
+Knock and dwell answer the same question differently: dwell asks you to wait,
+knock asks you to be deliberate without waiting at all.
+
+### Hold to peek
+
+Older Windows had a thin Show Desktop button past the clock — rest the pointer on
+it and the desktop peeked through, move away and every window came back. Windows
+11 dropped it. Any zone here can work that way.
+
+Set **Hold — action when the pointer leaves** and the zone stops being fire-once.
+The action runs on arrival, and the release action runs when the pointer leaves.
+For anything that toggles — Show Desktop, Mute, Keep Awake — pick **The same
+action again**:
+
+| Setting | Value |
+| --- | --- |
+| Zone | `Top-right corner` |
+| Action | `Show desktop` |
+| Hold — action when the pointer leaves | `The same action again` |
+
+![Resting in the top-right corner to peek at the desktop, windows returning on leaving](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/trigger-hold.gif)
+
+The two halves are independent, so a release does not have to undo the entry —
+open Quick Settings on arrival and mute on departure if that is useful to you.
+
+A hold only ever releases what it actually engaged, so a pointer that clips the
+corner without staying long enough to fire leaves nothing behind. Disabling the
+mod, suspending it, or a display waking up all release a held zone first — a
+peeked desktop can never be left stuck.
+
+### With a modifier held
+
+Set **Required modifier**, globally or on one zone, and that zone only fires
+while Ctrl, Alt, Shift or Win is down. Every other time you hit the corner it is
+inert.
+
+![Snapping a window left with Ctrl held while touching the left edge](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/trigger-modifier.gif)
+
+The key is checked continuously rather than only on arrival, so you can park the
+pointer in the corner first and press the key afterwards — the zone fires the
+moment the key goes down. Either order works.
+
+### Not a trigger, but often confused with one
+
+**Alternate key press** and **Alternate command** change *what* a zone does
+rather than *when* it fires — the same corner runs the left action, then the
+right one, then the left again. Combine either with any trigger above.
+
+![One edge maximising a window, then restoring it on the next visit](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/trigger-alternate.gif)
+
+Above, the right edge is set to `Win+Up | Win+Down`: the first visit maximises
+the window and the next one puts it back.
 
 ## Available Actions
 
@@ -170,16 +261,6 @@ cooldowns stay separate, because a merged zone could only carry one cooldown.
 Merging is not cosmetic. Three separate zones all running Task View would each
 re-arm as the pointer crossed a seam, so sliding along the edge would fire it
 repeatedly; one merged zone fires once.
-
-## Knock to trigger
-
-Set **Knock window** on a zone — globally, or per zone — and a single arrival
-never fires it. The zone arms only when you leave and come back within that many
-milliseconds. `0` turns it off.
-
-This works on every zone, corners included, so a corner you keep brushing past
-on the way to something else can be made deliberate. 400 ms is a comfortable
-double-knock; below about 200 ms it starts to need intent.
 
 ## Identifying your monitors
 
@@ -268,10 +349,11 @@ Hot corners are disabled when any excluded process is the foreground window.
 
 **Example:** `photoshop.exe;premiere.exe;blender.exe`
 
-# Why it works this way
+## Why it works this way
 
-Not a changelog — this is the first release. These are the decisions that are
-easy to second-guess later, and the reason each one went the way it did.
+If you have wondered why a setting behaves the way it does, or you are weighing
+this against another hot-corners tool, here is the reasoning behind the choices
+that are easiest to second-guess.
 
 **Polling, not a mouse hook.** A `WH_MOUSE_LL` hook sits directly on the system
 input path: every mouse event in every process waits for it, and if it is slow
@@ -317,15 +399,32 @@ monitor rebuilds the zones, and the pointer may already be sitting in one. The
 rebuild adopts that zone with the visit already spent, so a corner bound to
 *Lock* cannot lock the machine because a display woke up.
 
+**A held modifier is released before a key action, and never re-pressed.**
+Windows merges whatever you are physically holding into an injected shortcut, so
+without this a Ctrl-guarded zone bound to *Snap left* would send Ctrl+Win+Left
+and switch virtual desktop instead — or, on a single desktop, do nothing at all.
+Restoring the key afterwards sounds tidier and is a trap: if you let go in
+between, a key-down goes out with no matching key-up and the modifier is stuck
+down for the rest of the session. A stray key-up cannot cause that, so this
+releases and stops there.
+
 **The fullscreen and excluded-app checks run on the worker thread**, not on the
 sampling thread, so a slow `OpenProcess` can never delay cursor sampling. The
 cost is that a suppressed trigger still consumes its cooldown — a wait nobody
 can perceive, traded for a sampling path that never stalls.
 
-## Support
+## Bugs and requests
 
-Windhawk renders the `@donateUrl` in the metadata block as a Donate button in the mod
-listing, but it only takes one link, so the rest live here.
+Please open an issue at
+[github.com/DhakadG/my-windhawk-mods](https://github.com/DhakadG/my-windhawk-mods/issues).
+If a zone is not firing, this mod's log (Windhawk → this mod → **Advanced** →
+**Mod log**) says which zone the pointer entered and why nothing happened, and
+pasting that in saves a round trip.
+
+## Support the mod
+
+This is free and always will be. If it earned you back some clicks and you feel
+like buying me a coffee:
 
 - [Ko-fi](https://ko-fi.com/losthusky_)
 - [Buy Me a Coffee](https://www.buymeacoffee.com/losthusky_)
@@ -414,6 +513,40 @@ listing, but it only takes one link, so the rest live here.
             as  Ctrl+Shift+Esc . Custom command takes an executable, path or
             URL. The two Alternate actions take both halves separated by a
             vertical bar, for example  Alt+S | Alt+H .
+        - releaseAction: ACTION_NOTHING
+          $name: Hold - action when the pointer leaves
+          $description: >-
+            Leave this as Nothing for a normal zone, which fires once on
+            arrival. Set anything else and the zone becomes a hold zone: the
+            action above runs when the pointer arrives, and this one runs when
+            it leaves again. That is what the old Show Desktop button did -
+            peek while the pointer rests on it, put everything back when it
+            moves away.
+
+            "The same action again" is what you want for a toggle such as Show
+            Desktop, Mute or Keep Awake, and it stays in step if you change the
+            action above later.
+          $options:
+          - ACTION_NOTHING: "Nothing (fire once on arrival)"
+          - ACTION_SAME: The same action again
+          - ACTION_SHOW_DESKTOP: Show desktop
+          - ACTION_TASK_VIEW: Task View
+          - ACTION_QUICK_SETTINGS: Quick Settings
+          - ACTION_NOTIFICATION_CENTER: Notification Centre
+          - ACTION_START_MENU: Start menu
+          - ACTION_MUTE: Mute
+          - ACTION_MINIMIZE: Minimise window
+          - ACTION_MAXIMIZE: Maximise window
+          - ACTION_KEEP_AWAKE_ON: Keep awake on
+          - ACTION_KEEP_AWAKE_OFF: Keep awake off
+          - ACTION_SEND_KEYPRESS: Send key press
+          - ACTION_START_PROCESS: Custom command
+        - releaseArgs: ""
+          $name: Hold - release arguments
+          $description: >-
+            Only used when the release action is Send key press or Custom
+            command. Ignored by "The same action again", which reuses the
+            arguments above.
         - size: -1
           $name: Size override (px)
           $description: >-
@@ -553,6 +686,11 @@ enum class CornerAction
     // second falls through to the "*" entry, so this is what lets one screen
     // opt out of a shared zone without abandoning the wildcard everywhere.
     DisabledHere,
+    // Release-action only: repeat whatever the zone does on entry. Every
+    // toggle - Show Desktop, Mute, Keep Awake - wants exactly this, so it
+    // saves picking the same entry twice and keeps the pair in step if the
+    // entry action is later changed.
+    SameAsEntry,
     ShowDesktop,
     TaskView,
     ScreenSaver,
@@ -645,6 +783,15 @@ struct ZoneConfig
     std::wstring args;
     std::function<void()> executor;
     ZoneTuning tuning;
+
+    // Hold: a second action fired when the pointer leaves the zone again.
+    // Anything other than Nothing here turns the zone into a hold zone, which
+    // is what the old Show Desktop button did - peek while the pointer is on
+    // it, put everything back when it leaves. Setting this to "the same action"
+    // covers every toggle, which is the common case.
+    CornerAction releaseAction = CornerAction::Nothing;
+    std::wstring releaseArgs;
+    std::function<void()> releaseExecutor;
 };
 
 struct MonitorZoneConfig
@@ -678,6 +825,18 @@ struct HitZone
     // the rebuild was skipped and the old executor stayed live.
     CornerAction action = CornerAction::Nothing;
     std::wstring args;
+
+    // Set only on a hold zone. The detection loop queues this when the pointer
+    // leaves, if the zone had already fired on the way in.
+    std::function<void()> releaseExec;
+    CornerAction releaseAction = CornerAction::Nothing;
+    std::wstring releaseArgs;
+
+    // Queue bookkeeping, set per job rather than per zone. The detection thread
+    // decides that a release is *owed*; only the worker knows whether the entry
+    // it would undo actually ran, because the gates live there.
+    bool engagesHold = false;
+    bool isRelease = false;
 
     // Resolved once at build time - zone override if set, otherwise the
     // global. The detection loop therefore never has to know that per-zone
@@ -819,6 +978,11 @@ static int g_activeZone = -1;
 static ULONGLONG g_enterTick = 0;
 static bool g_firedThisEntry = false;
 static bool g_knockSatisfied = true;
+// A hold zone has engaged and owes its release. Kept apart from
+// g_firedThisEntry because the two answer different questions: that one is
+// "has this visit been spent", which stays true after a release so the zone
+// cannot re-fire without leaving first.
+static bool g_holdEngaged = false;
 static std::vector<ULONGLONG> g_lastFireTick;
 // When each zone was last left, for knock detection.
 static std::vector<ULONGLONG> g_lastExitTick;
@@ -1449,15 +1613,18 @@ static bool IsForegroundAppExcluded(const std::vector<std::wstring> &excluded)
 // Sends key-down for all VKs in order, then key-up in reverse order, as one
 // atomic SendInput batch.
 //
-// Earlier versions also released any modifier the user was physically holding
-// and re-pressed it afterwards. That was removed deliberately: re-pressing is
-// only correct if the key is still held when the restore runs. If the user let
-// go in between — or the restore SendInput failed, or the thread was torn down
-// between the two calls — a key-down was injected with no matching key-up and
-// the modifier stayed logically stuck down for the whole session. A stuck Win
-// or Ctrl key breaks every application at once, which is far worse than the
-// problem it solved (a held Shift leaking into the injected combo).
-// Every key this function presses, it releases in the same batch.
+// Any modifier the user is physically holding is released first, so it cannot
+// leak into the injected combination. It is never re-pressed afterwards, and
+// that asymmetry is the whole point: an earlier version restored the key and
+// could leave it logically stuck down for the rest of the session, because a
+// re-press is only correct if the key is still held when the restore runs. If
+// the user let go in between — or the restore SendInput failed, or the thread
+// was torn down between the two calls — a key-down went out with no matching
+// key-up. A stuck Win or Ctrl breaks every application at once.
+//
+// A key-up carries no such risk in either direction, so releasing is kept and
+// restoring is not. Every key this function presses, it releases in the same
+// batch.
 // Keys that live on the E0-prefixed part of the keyboard. Injected without
 // KEYEVENTF_EXTENDEDKEY they resolve to their numpad twins, so Win+Right
 // (snap) or a custom combo using arrows/Home/End would do nothing or move the
@@ -1503,14 +1670,44 @@ static void SendKeys(const std::vector<WORD> &vks)
     if (vks.empty())
         return;
 
+    // A modifier the user is physically holding cannot be masked by SendInput:
+    // Windows merges it into whatever this batch presses. A zone with a
+    // required modifier guarantees that happens on every trigger, and it
+    // silently changes the action rather than failing — Snap left (Win+Left)
+    // fired from a Ctrl zone arrives as Ctrl+Win+Left, which switches virtual
+    // desktop, or does nothing whatsoever when there is only one desktop.
+    //
+    // Injecting a release first is safe in the way the old release-then-
+    // re-press pair described above was not. An extra key-up can never leave a
+    // key logically stuck, and the user's own release still delivers its
+    // key-up afterwards. Nothing is re-pressed here, deliberately.
+    static const WORD kMods[] = {VK_LCONTROL, VK_RCONTROL, VK_LMENU, VK_RMENU,
+                                 VK_LSHIFT,   VK_RSHIFT,   VK_LWIN,  VK_RWIN};
+    std::vector<INPUT> inputs;
+    for (WORD mod : kMods)
+    {
+        if (!(GetAsyncKeyState(mod) & 0x8000))
+            continue;
+        // Part of the batch already: it presses and releases this one itself.
+        if (std::find(vks.begin(), vks.end(), mod) != vks.end())
+            continue;
+        INPUT up = {};
+        up.type = INPUT_KEYBOARD;
+        up.ki.wVk = mod;
+        up.ki.dwFlags =
+            (IsExtendedKey(mod) ? KEYEVENTF_EXTENDEDKEY : 0) | KEYEVENTF_KEYUP;
+        inputs.push_back(up);
+    }
+    const size_t pre = inputs.size();
+
     size_t n = vks.size();
-    std::vector<INPUT> inputs(n * 2);
+    inputs.resize(pre + n * 2);
 
     for (size_t i = 0; i < n; i++)
     {
-        inputs[i].type = INPUT_KEYBOARD;
-        inputs[i].ki.wVk = vks[i];
-        inputs[i].ki.dwFlags =
+        inputs[pre + i].type = INPUT_KEYBOARD;
+        inputs[pre + i].ki.wVk = vks[i];
+        inputs[pre + i].ki.dwFlags =
             IsExtendedKey(vks[i]) ? KEYEVENTF_EXTENDEDKEY : 0;
     }
     for (size_t i = 0; i < n; i++)
@@ -1519,9 +1716,9 @@ static void SendKeys(const std::vector<WORD> &vks)
         // not from vks[i] — the release order is reversed, so using the wrong
         // index would tag the extended bit onto the wrong key.
         WORD vk = vks[n - 1 - i];
-        inputs[n + i].type = INPUT_KEYBOARD;
-        inputs[n + i].ki.wVk = vk;
-        inputs[n + i].ki.dwFlags =
+        inputs[pre + n + i].type = INPUT_KEYBOARD;
+        inputs[pre + n + i].ki.wVk = vk;
+        inputs[pre + n + i].ki.dwFlags =
             (IsExtendedKey(vk) ? KEYEVENTF_EXTENDEDKEY : 0) | KEYEVENTF_KEYUP;
     }
 
@@ -1543,7 +1740,7 @@ static void SendKeys(const std::vector<WORD> &vks)
         // and releasing a key that is already up does nothing, so replay all
         // of them. Nothing was pressed if nothing was sent.
         if (sent > 0)
-            SendInput((UINT)n, inputs.data() + n, sizeof(INPUT));
+            SendInput((UINT)n, inputs.data() + pre + n, sizeof(INPUT));
     }
     else
     {
@@ -1813,6 +2010,7 @@ static CornerAction ParseActionType(const std::wstring &raw)
     static const std::unordered_map<std::wstring, CornerAction> map = {
         {L"ACTION_NOTHING", CornerAction::Nothing},
         {L"ACTION_DISABLED_HERE", CornerAction::DisabledHere},
+        {L"ACTION_SAME", CornerAction::SameAsEntry},
         {L"ACTION_SHOW_DESKTOP", CornerAction::ShowDesktop},
         {L"ACTION_TASK_VIEW", CornerAction::TaskView},
         {L"ACTION_SCREENSAVER", CornerAction::ScreenSaver},
@@ -1861,6 +2059,7 @@ static const wchar_t *ActionToString(CornerAction a)
     {
     case CornerAction::Nothing: return L"Nothing";
     case CornerAction::DisabledHere: return L"Disabled here";
+    case CornerAction::SameAsEntry: return L"the same action again";
     case CornerAction::ShowDesktop: return L"Show Desktop";
     case CornerAction::TaskView: return L"Task View";
     case CornerAction::ScreenSaver: return L"Screen Saver";
@@ -1945,6 +2144,7 @@ static std::function<void()> MakeExecutor(CornerAction action,
     {
     case CornerAction::Nothing: return nullptr;
     case CornerAction::DisabledHere: return nullptr;
+    case CornerAction::SameAsEntry: return nullptr;   // resolved by the caller
     case CornerAction::ShowDesktop: return ActionShowDesktop;
     case CornerAction::TaskView: return ActionTaskView;
     case CornerAction::ScreenSaver: return ActionScreenSaver;
@@ -2077,7 +2277,9 @@ static bool SameZoneConfig(const ZoneConfig *a, const ZoneConfig *b)
         return true;
     if (!a || !b)
         return false;
-    if (a->action != b->action || a->args != b->args)
+    if (a->action != b->action || a->args != b->args ||
+        a->releaseAction != b->releaseAction ||
+        a->releaseArgs != b->releaseArgs)
         return false;
     const ZoneTuning &x = a->tuning, &y = b->tuning;
     return x.size == y.size && x.delay == y.delay && x.settle == y.settle &&
@@ -2257,6 +2459,9 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
 
             hz.action = zc->action;
             hz.args = zc->args;
+            hz.releaseAction = zc->releaseAction;
+            hz.releaseArgs = zc->releaseArgs;
+            hz.releaseExec = zc->releaseExecutor;
             hz.label = mon.id + L" " + ZoneToString(z) + L" -> " +
                        ActionToString(zc->action);
             set->zones.push_back(std::move(hz));
@@ -2344,6 +2549,10 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
     return set;
 }
 
+// Defined with the detection loop, which owns the state it touches; a rebuild
+// has to let go of a held zone before it forgets which one that was.
+static void ReleaseHeldZone(const std::shared_ptr<const ZoneSet> &zones);
+
 // True when two zone sets would behave identically. Only what the detection
 // loop and the actions actually read - the executors are rebuilt every time
 // and never compare equal, so comparing them would make this always false.
@@ -2369,7 +2578,9 @@ static bool SameZoneSet(const ZoneSet *a, const ZoneSet *b)
         const HitZone &x = a->zones[i], &y = b->zones[i];
         if (memcmp(&x.rect, &y.rect, sizeof(RECT)) != 0 || x.zone != y.zone ||
             x.monitor != y.monitor || x.action != y.action ||
-            x.args != y.args || x.delay != y.delay || x.settle != y.settle ||
+            x.args != y.args || x.releaseAction != y.releaseAction ||
+            x.releaseArgs != y.releaseArgs ||
+            x.delay != y.delay || x.settle != y.settle ||
             x.knock != y.knock || x.cooldown != y.cooldown ||
             x.modifier != y.modifier || x.label != y.label)
             return false;
@@ -2404,6 +2615,10 @@ static void RebuildZones()
     if (SameZoneSet(current.get(), set.get()))
         return;
 
+    // The state reset below forgets which zone was held, so let go first while
+    // the old set is still the one those indices refer to.
+    ReleaseHeldZone(current);
+
     EnterCriticalSection(&g_zonesLock);
     g_zones = set;
     LeaveCriticalSection(&g_zonesLock);
@@ -2414,6 +2629,9 @@ static void RebuildZones()
     g_lastFireTick.assign(set->zones.size(), 0);
     g_lastExitTick.assign(set->zones.size(), 0);
     g_knockSatisfied = true;
+    // ReleaseHeldZone above already let go against the old set; this only
+    // makes sure nothing carries into the new one.
+    g_holdEngaged = false;
 
     // A rebuild is not a gesture. With the state above cleared, a pointer that
     // has not moved looks to the next tick like a fresh entry - and with every
@@ -2468,10 +2686,27 @@ static bool TopologyChanged()
 static void EnqueueAction(const HitZone &hz)
 {
     EnterCriticalSection(&g_queueLock);
-    if (g_queue.size() < kMaxQueue)
+    // A release is never dropped. The cap is there to bound a runaway burst of
+    // new work, but discarding the half that undoes something already done is
+    // how a peeked desktop gets stuck with no way back.
+    if (g_queue.size() < kMaxQueue || hz.isRelease)
         g_queue.push_back(hz);
     LeaveCriticalSection(&g_queueLock);
     SetEvent(g_hWorkEvent);
+}
+
+// A hold zone's second half, queued when the pointer leaves. The copy carries
+// the release executor in exec, so the worker needs no special case for it.
+static void EnqueueRelease(const HitZone &hz)
+{
+    if (!hz.releaseExec)
+        return;
+    HitZone rel = hz;
+    rel.exec = hz.releaseExec;
+    rel.label = hz.label + L"  (released)";
+    rel.engagesHold = false;
+    rel.isRelease = true;
+    EnqueueAction(rel);
 }
 
 static DWORD WINAPI ActionWorkerThread(LPVOID)
@@ -2524,23 +2759,48 @@ static DWORD WINAPI ActionWorkerThread(LPVOID)
             // fullscreen game has focus re-queues the job every cooldown.
             // Report the first skip of a run, then stay quiet until something
             // actually fires. Only this thread touches the flag.
+            // Whether the entry half of a hold actually ran. Only this thread
+            // touches it, and the queue is FIFO, so the entry job is always
+            // seen before the release it pairs with - no synchronisation and no
+            // race with the detection thread's own view of the hold.
+            static bool holdActive = false;
+
             static bool skipLogged = false;
-            HMONITOR fsMon = checkFullscreen ? FullScreenMonitor() : nullptr;
-            if (fsMon && (fsMon == kAllMonitors || fsMon == job.monitor))
+            if (job.isRelease)
             {
-                if (!skipLogged)
-                    Wh_Log(L"SKIP (fullscreen): %s", job.label.c_str());
-                skipLogged = true;
-                continue;
+                // Deliberately not gated. The gates decide whether to *start*
+                // something; refusing to undo something already done would
+                // leave the desktop peeked with no way back - a fullscreen app
+                // appearing while the pointer rests in the corner is exactly
+                // when that would happen.
+                if (!holdActive)
+                {
+                    // The entry was suppressed or never made it onto the queue,
+                    // so there is nothing to undo. Releasing anyway is how a
+                    // hold zone ends up *hiding* your windows on the way out.
+                    Wh_Log(L"SKIP (nothing engaged): %s", job.label.c_str());
+                    continue;
+                }
             }
-            if (IsForegroundAppExcluded(excluded))
+            else
             {
-                if (!skipLogged)
-                    Wh_Log(L"SKIP (excluded app): %s", job.label.c_str());
-                skipLogged = true;
-                continue;
+                HMONITOR fsMon = checkFullscreen ? FullScreenMonitor() : nullptr;
+                if (fsMon && (fsMon == kAllMonitors || fsMon == job.monitor))
+                {
+                    if (!skipLogged)
+                        Wh_Log(L"SKIP (fullscreen): %s", job.label.c_str());
+                    skipLogged = true;
+                    continue;
+                }
+                if (IsForegroundAppExcluded(excluded))
+                {
+                    if (!skipLogged)
+                        Wh_Log(L"SKIP (excluded app): %s", job.label.c_str());
+                    skipLogged = true;
+                    continue;
+                }
+                skipLogged = false;
             }
-            skipLogged = false;
 
             {
                 WCHAR fgClass[64] = L"?";
@@ -2555,6 +2815,13 @@ static DWORD WINAPI ActionWorkerThread(LPVOID)
             // working with no indication why.
             if (job.exec)
                 job.exec();
+
+            // Recorded only now, past the gates and the execution, so a hold is
+            // owed a release exactly when its entry half really happened.
+            if (job.isRelease)
+                holdActive = false;
+            else if (job.engagesHold)
+                holdActive = true;
         }
     }
     CoUninitialize();
@@ -2588,19 +2855,43 @@ static bool AnyMouseButtonDown()
            (GetAsyncKeyState(VK_XBUTTON2) & 0x8000);
 }
 
+// Anything that stops detection has to let go of a held zone first, or the
+// hold's second half never runs and whatever it engaged stays engaged - a
+// peeked desktop that will not come back is a far worse failure than a missed
+// trigger. Safe to call when nothing is held.
+static void ReleaseHeldZone(const std::shared_ptr<const ZoneSet> &zones)
+{
+    if (!g_holdEngaged)
+        return;
+    g_holdEngaged = false;
+    if (zones && g_activeZone >= 0 && g_activeZone < (int)zones->zones.size())
+        EnqueueRelease(zones->zones[g_activeZone]);
+    // g_activeZone is deliberately left alone, and the visit stays spent.
+    // Clearing it would make the next tick read a pointer that has not moved
+    // as a fresh entry, so re-enabling the mod while it rests in a corner
+    // would fire that corner - the same trap a rebuild used to fall into.
+    g_firedThisEntry = true;
+}
+
 // Returns how long the caller should wait before ticking again.
 static DWORD DetectTick()
 {
-    if (!g_trayEnabled.load() || GetTickCount64() < g_suspendUntil.load())
-        return kIdleTickMs;
-
     std::shared_ptr<const ZoneSet> zones;
     EnterCriticalSection(&g_zonesLock);
     zones = g_zones;
     LeaveCriticalSection(&g_zonesLock);
 
-    if (!zones || zones->zones.empty())
+    if (!g_trayEnabled.load() || GetTickCount64() < g_suspendUntil.load())
+    {
+        ReleaseHeldZone(zones);
         return kIdleTickMs;
+    }
+
+    if (!zones || zones->zones.empty())
+    {
+        ReleaseHeldZone(zones);
+        return kIdleTickMs;
+    }
 
     // GetCursorPos fails for a process on the default desktop once the input
     // desktop is the secure one, so a locked machine used to spin this thread
@@ -2650,6 +2941,9 @@ static DWORD DetectTick()
         // be recognised as the second half of a knock.
         if (g_activeZone >= 0 && g_activeZone < (int)g_lastExitTick.size())
             g_lastExitTick[g_activeZone] = now;
+
+        // A hold zone's second half, for the zone being left.
+        ReleaseHeldZone(zones);
 
         g_activeZone = idx;
         g_enterTick = now;
@@ -2725,7 +3019,16 @@ static DWORD DetectTick()
     if (idx < (int)g_lastFireTick.size())
         g_lastFireTick[idx] = now;
 
-    EnqueueAction(zones->zones[idx]);
+    // Only a zone that actually engaged owes a release, so this is set here
+    // rather than at entry - a pass-through that never fired leaves nothing
+    // behind to undo. This tracks that a release has been *queued*; whether it
+    // runs is the worker's call, since the gates it would be suppressed by live
+    // there and this thread must not wait on them.
+    g_holdEngaged = (bool)zones->zones[idx].releaseExec;
+
+    HitZone job = zones->zones[idx];
+    job.engagesHold = (bool)job.releaseExec;
+    EnqueueAction(job);
     return next;
 }
 
@@ -3197,6 +3500,21 @@ static std::vector<MonitorZoneConfig> ReadSettingsZones()
             cfg.zones[zi].action = act;
             cfg.zones[zi].args = args;
             cfg.zones[zi].executor = MakeExecutor(act, args);
+
+            // Hold: "the same action again" is resolved here rather than in
+            // MakeExecutor, which has no way to know what the entry action was.
+            // An Alternate entry gets its own flip flag for the release half,
+            // which is right - the pair alternates as one.
+            CornerAction rel = ParseActionType(
+                GetSettingStr(L"displays[%d].zones[%d].releaseAction", i, z));
+            std::wstring relArgs =
+                GetSettingStr(L"displays[%d].zones[%d].releaseArgs", i, z);
+            cfg.zones[zi].releaseAction = rel;
+            cfg.zones[zi].releaseArgs = relArgs;
+            if (rel == CornerAction::SameAsEntry)
+                cfg.zones[zi].releaseExecutor = MakeExecutor(act, args);
+            else if (rel != CornerAction::Nothing)
+                cfg.zones[zi].releaseExecutor = MakeExecutor(rel, relArgs);
             cfg.zones[zi].tuning.size =
                 Wh_GetIntSetting(L"displays[%d].zones[%d].size", i, z);
             cfg.zones[zi].tuning.delay =
@@ -3585,6 +3903,8 @@ struct ZoneView
     ZoneTuning tuning;          // -1 in a field means "inherited"
     bool fromWildcard = false;
     bool invalid = false;       // configured, but its arguments do not parse
+    CornerAction releaseAction = CornerAction::Nothing;   // hold zone if set
+    std::wstring releaseArgs;
 };
 
 struct DisplayView
@@ -4044,6 +4364,8 @@ static void DashFillZones(DisplayView &dv,
         dv.zones[z].args = hit->args;
         dv.zones[z].tuning = hit->tuning;
         dv.zones[z].fromWildcard = wild;
+        dv.zones[z].releaseAction = hit->releaseAction;
+        dv.zones[z].releaseArgs = hit->releaseArgs;
         dv.configured++;
     }
 }
@@ -4124,6 +4446,36 @@ static void DashBuildSnapshot(DashState *s)
 // =====================================================================
 // Painting
 // =====================================================================
+
+// Trims a label to fit `maxPx` along the baseline, ending in an ellipsis.
+// Returns false when not even the ellipsis fits, so the caller can skip the
+// label rather than draw a fragment of one.
+static bool FitLabel(HDC hdc, std::wstring &s, int maxPx)
+{
+    SIZE sz = {};
+    GetTextExtentPoint32W(hdc, s.c_str(), (int)s.size(), &sz);
+    if (sz.cx <= maxPx)
+        return true;
+
+    static const wchar_t kEllipsis[] = L"…";
+    SIZE es = {};
+    GetTextExtentPoint32W(hdc, kEllipsis, 1, &es);
+    if (es.cx > maxPx)
+        return false;
+
+    while (!s.empty())
+    {
+        s.pop_back();
+        std::wstring t = s + kEllipsis;
+        GetTextExtentPoint32W(hdc, t.c_str(), (int)t.size(), &sz);
+        if (sz.cx <= maxPx)
+        {
+            s = t;
+            return true;
+        }
+    }
+    return false;
+}
 
 static HFONT DashMakeFont(UINT dpi, int pt, bool bold, int escapement)
 {
@@ -4331,23 +4683,33 @@ static void DashPaintDiagram(DashState *s, HDC hdc)
         if (ZoneIsVertical((Zone)z))
         {
             // A rotated font draws from a baseline rather than into a rect, so
-            // the text is measured and placed by hand. DT_* alignment does not
-            // apply to escapement.
+            // the text is measured and placed by hand - DT_END_ELLIPSIS does
+            // not apply to a font with escapement, and clipping the overflow
+            // instead left half a glyph hard against the next segment's half
+            // glyph, which read as two labels overlapping.
             SelectObject(hdc, s->hFontVert);
-            SIZE ts = {};
-            GetTextExtentPoint32W(hdc, name, (int)wcslen(name), &ts);
-            int bh = widest.bottom - widest.top;
-            int cx = (widest.left + widest.right) / 2;
-            int cy = (widest.top + widest.bottom) / 2;
-            // Clip to the strip so a long name cannot escape the screen box.
-            IntersectClipRect(hdc, widest.left, widest.top, widest.right,
-                              widest.bottom);
-            // At 90 degrees the advance runs up the screen and the glyphs hang
-            // to the left of the baseline, so the baseline sits at the right of
-            // the band and the run starts at its bottom.
-            int y = cy + (ts.cx > bh ? bh / 2 : ts.cx / 2);
-            TextOutW(hdc, cx + ts.cy / 2, y, name, (int)wcslen(name));
-            SelectClipRgn(hdc, nullptr);
+            int pad = Sc(6, d);
+            int room = (widest.bottom - widest.top) - pad * 2;
+            std::wstring lab = name;
+            if (room > 0 && FitLabel(hdc, lab, room))
+            {
+                SIZE ts = {};
+                GetTextExtentPoint32W(hdc, lab.c_str(), (int)lab.size(), &ts);
+                int cx = (widest.left + widest.right) / 2;
+                int cy = (widest.top + widest.bottom) / 2;
+                IntersectClipRect(hdc, widest.left, widest.top, widest.right,
+                                  widest.bottom);
+                // At 90 degrees the advance runs up the screen and the glyphs
+                // hang to the *right* of the baseline, so the baseline sits at
+                // the left of the band and the run starts at its bottom.
+                // Getting this backwards puts the whole label outside its own
+                // strip, where the clip rect shears it in half and it reads as
+                // two labels colliding. Rendered rather than reasoned about:
+                // scripts/probe-vtext.cpp draws all three candidates.
+                TextOutW(hdc, cx - ts.cy / 2, cy + ts.cx / 2, lab.c_str(),
+                         (int)lab.size());
+                SelectClipRgn(hdc, nullptr);
+            }
         }
         else
         {
@@ -4478,6 +4840,18 @@ static void DashPaintDetail(DashState *s, HDC hdc, const RECT &client)
                   L"This zone will not fire - its arguments could not be read.",
                   -1, &r, DT_LEFT | DT_SINGLELINE | DT_END_ELLIPSIS);
         SetTextColor(hdc, g_pal.dim);
+    }
+    else if (zv.releaseAction != CornerAction::Nothing)
+    {
+        wchar_t hold[256];
+        _snwprintf_s(hold, _countof(hold), _TRUNCATE,
+                     L"Held: runs %s again when the pointer leaves",
+                     zv.releaseAction == CornerAction::SameAsEntry
+                         ? ActionToString(zv.action)
+                         : ActionToString(zv.releaseAction));
+        r = {left, y, right, y + Sc(16, d)};
+        DrawTextW(hdc, hold, -1, &r,
+                  DT_LEFT | DT_SINGLELINE | DT_END_ELLIPSIS);
     }
     else if (zv.fromWildcard)
     {
@@ -5426,3 +5800,5 @@ void Wh_ModUninit() {
     WhTool_ModUninit();
     ExitProcess(0);
 }
+
+

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         1.1.8
+// @version         1.1.9
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -15,76 +15,49 @@
 /*
 # Win-X Hot Corners
 
-macOS-style hot corners **and screen edges** for Windows 10/11 with **full
-multi-monitor support**.
-
-Instantly trigger configurable actions when your cursor reaches any screen
-corner or edge. Configure different actions for each zone on each monitor
-independently.
+macOS-style hot corners **and screen edges** for Windows 10 and 11, with full
+multi-monitor support. Throw the pointer into a corner or against an edge and
+something happens — which corner, which edge, and what happens are all yours.
 
 ![Throwing the pointer into the top-left corner opens Task View](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/hot-corners.gif)
-
-The tray icon's **Zones & settings** window shows what each zone does on each
-display, and the timings actually in effect for whichever one you point at:
-
-![The Zones and settings window](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/dashboard.png)
 
 Inspired by [WinXCorners](https://github.com/vhanla/winxcorners), rebuilt as a
 Windhawk mod.
 
-### Related mods
+## Quick start
 
-If all you want is one specific behaviour, a smaller mod may suit you better:
+Everything lives on this mod's settings page. Out of the box no zone is
+configured, so nothing fires until you add one.
 
-- **edge-hot-corner-desktop-switch** — hovering the left or right screen edge
-  switches virtual desktop. This mod does that too, as one of the actions you
-  can assign, but if it is the only thing you are after that one is far
-  simpler.
-- **hotcorner-hotkeys** — sends a key combination from a corner. Different
-  trigger model: it dispatches on a hotkey rather than on hover.
+1. Open the settings page and add a **display**. Put `*` in the name field to
+   mean "every monitor" — you can get specific later.
+2. Add a **zone** to it, pick the corner or edge, and pick an action.
+3. Save. That is it; there is no restart.
 
-## Features
+A first set worth trying, if you want something concrete:
 
-- **Bounded latency** — a dedicated detection thread asks to sample the cursor
-  every 16 ms (one system timer tick, so 16-31 ms in practice) and only idles
-  when nothing could fire anyway. Nothing can starve it:
-  not a busy explorer, not an elevated foreground app, not a slow action.
-- **Zero impact on the rest of the system** — no global mouse hook, so your
-  games and apps keep their input path to themselves.
-- **Monitors identified by name** — zones bind to a display's friendly name
-  (e.g. `Dell U2720Q`), so rearranging your desktop or changing which display
-  is primary never reshuffles your configuration. (Two displays of the same
-  model are the one exception — see *Identifying your monitors*.)
-- **Per-monitor DPI correct** — detection runs per-monitor-DPI-aware, so
-  zones land in the right place on mixed-scaling setups.
-- **Screen edges, in three parts** — each edge is split into a start, a middle
-  and an end, configured separately. Give neighbouring parts the same action and
-  they merge back into one, so you get whichever of `ABC`, `AAB`, `ABB` or `AAA`
-  you want without a mode switch. See *Dividing an edge*.
-- **Five ways to trigger** — on arrival, after a dwell, on a double knock, only
-  while a modifier is held, or press-and-hold to peek. They combine freely, and
-  any of them works on any zone. See *Ways to trigger a zone*.
-- **Configurable zone size** and a cooldown timer.
-- **Fullscreen protection** — auto-detects games, presentations, and D3D
-  fullscreen apps.
-- **Drag protection** — zones don't fire while a mouse button is held.
-- **App exclusions** — blacklist processes that need corner/edge clicks.
+| Zone | Action | Why |
+| --- | --- | --- |
+| Top-left corner | Task View | The classic. Nothing else lives up there. |
+| Top-right corner | Show desktop, **Hold** set to *The same action again* | Peek at the desktop, move away to put it back. |
+| Bottom-left corner | Start menu | It is where the Start button already is. |
+| Bottom-right corner | Switch to last window | Set **Knock window** to `400` so a stray brush past it does nothing. |
 
-## Configuring
+Then read *Ways to trigger a zone* — the trigger style matters more than the
+action for whether this feels good or infuriating.
 
-**Settings page** — zones, timings and everything else. Add a display, then add
-the zones you want on it. A zone you do not list does nothing.
+## At a glance
 
-**Tray icon**, next to the clock:
-
-- **Left-click** — turn the hot corners on or off. The icon dims when they are off.
-- **Right-click** — suspend for a while, or reset the enable state.
-- **Right-click → Zones & settings...** — the dashboard: a tab per display,
-  a picture of that screen with each zone showing what it does, and the timings
-  actually in effect for whichever zone you point at.
-
-If the tray icon is hidden, it is in the overflow area — drag it onto the
-taskbar to keep it there.
+- **16 zones per display** — four corners, and four edges split into three
+  segments each.
+- **38 actions**, plus any key combination and any command you can name.
+- **Five trigger styles** that combine: arrival, dwell, knock, held modifier,
+  press-and-hold.
+- **Per-monitor everything** — zones bind to a display's name, not its position,
+  so rearranging screens never reshuffles your configuration.
+- **Stays out of the way** — no global mouse hook, so your games and apps keep
+  their input path to themselves. Suppressed automatically while a window is
+  fullscreen and while you are dragging.
 
 ## Ways to trigger a zone
 
@@ -177,7 +150,7 @@ right one, then the left again. Combine either with any trigger above.
 Above, the right edge is set to `Win+Up | Win+Down`: the first visit maximises
 the window and the next one puts it back.
 
-## Available Actions
+## Actions
 
 **Switching**
 
@@ -237,15 +210,53 @@ the window and the next one puts it back.
 | Custom Command | Launch any executable, path, or URL |
 | Nothing | Disabled (default) |
 
-## Dividing an edge
+### Arguments
+
+Four actions take an argument. The rest ignore the field.
+
+**Send key press** — one combination is `Modifier+Key`. Separate several with
+semicolons and they are sent **one after another**, not merged into a single
+chord: `Ctrl+C;Alt+Tab` sends Ctrl+C, then Alt+Tab.
+
+> Modifiers are Ctrl, Alt, Shift and Win. Keys are A-Z, 0-9, F1-F24, Enter,
+> Space, Tab, Escape, Home, End, Delete, the arrows, and so on.
+> Examples: `Ctrl+Shift+Esc`, `Alt+F4`, `Win+L`
+
+**Custom command** — any executable, file, folder or URL. Environment variables
+such as `%AppData%` are expanded. Prefix with `uac;` to request elevation.
+
+> Examples: `notepad.exe`, `C:\Windows\System32\cmd.exe`,
+> `%AppData%\my_script.bat`, `https://example.com`, `uac;cmd.exe`
+
+**Alternate key press** and **Alternate command** — two of the above separated
+by `|`. The zone fires the left one, then the right one, then the left again.
+
+> `Alt+S | Alt+H` — one corner shows notes, then hides them
+> `notepad.exe | calc.exe`
+
+Each side accepts everything the single version does, so `Ctrl+C;Ctrl+V |
+Alt+Tab` is valid. Every zone alternates independently, and the position resets
+whenever settings or the display layout change.
+
+## Shaping the zones
+
+**Corner size** is the side of the square you have to reach. **Edge thickness**
+is how far in the strip along an edge extends. Both are in pixels, both can be
+overridden per zone, and neither can make two zones overlap: each edge's
+thickness is clamped to the smaller of the two corners it runs between.
+
+Small is not always better. A 1-2 px corner is technically reachable, because
+the pointer stops dead at the screen boundary, but a 6-15 px one is far more
+forgiving on a high-DPI display without ever being hit by accident.
+
+### Each edge is three segments
 
 Every edge runs between the two corners it touches and is divided into three
-segments — for the top and bottom edge those are **left, centre, right**; for
-the left and right edge, **top, middle, bottom**. The centre segment's width is
-the *Edge centre width* setting, as a percentage of the edge.
+parts — for the top and bottom edge those are **left, centre, right**; for the
+left and right edge, **top, middle, bottom**. The centre's width is the *Edge
+centre width* setting, as a percentage of the edge.
 
-You do not choose a "mode". Configure the three segments and the mod works out
-the shape:
+You do not choose a "mode". Configure the three segments and the shape follows:
 
 | You set | You get |
 | --- | --- |
@@ -263,13 +274,24 @@ Merging is not cosmetic. Three separate zones all running Task View would each
 re-arm as the pointer crossed a seam, so sliding along the edge would fire it
 repeatedly; one merged zone fires once.
 
-## Identifying your monitors
+## Across multiple monitors
 
-The dashboard has one tab per display, labelled with its name, so normally there
-is nothing to identify — a display that is not plugged in keeps its tab, marked
-with a dot. The names also go to this mod's log every time it loads or your
-display layout changes, which is the place to copy an exact name from when you
-are filling in the settings page:
+Zones bind to a display's **name**, not its position, so rearranging your
+screens or changing which one is primary never repoints a configuration at the
+wrong monitor.
+
+Put `*` in the **Display** field to apply one configuration everywhere.
+Resolution is **per zone**: a name-matched entry wins for the zones it defines,
+and `*` supplies the rest — so you can share most of a layout and override a
+single corner on a single display. To remove a zone on one screen rather than
+replace it, set it to **Disabled here**; leaving it unset means "not
+configured", which falls through to `*`.
+
+### Finding a display's name
+
+The dashboard has a tab per display, labelled with its name, so usually there is
+nothing to look up. The names also go to this mod's log every time it loads or
+your layout changes, which is the place to copy an exact one from:
 
 ```
 +-- Your monitors ---------------------------------------
@@ -281,74 +303,55 @@ are filling in the settings page:
 +--------------------------------------------------------
 ```
 
-Copy the text inside the quotes. If you own two identical displays they get a
-` #2`, ` #3` suffix so each stays separately configurable. Those suffixes are
-handed out in listed order — primary first, then left to right — so unlike the
-names themselves they are not fixed: making the other twin primary swaps which
-one is ` #2`, and swaps the configuration with it. Check the log after such a
-change.
+Copy the text inside the quotes. Two identical displays get a ` #2`, ` #3`
+suffix so each stays separately configurable — but those suffixes are handed out
+in listed order (primary first, then left to right), so unlike the names
+themselves they can move. Making the other twin primary swaps which one is ` #2`
+and swaps the configuration with it. Check the log after a change like that.
 
-Putting `*` in the **Display** field applies one configuration to every screen.
+### Corners between two screens are a trap
 
-Resolution is **per zone**: a name-matched entry wins over `*` for the zones
-it defines, and `*` supplies the rest. So you can put a shared config on `*`
-and override just one corner on one display. To exclude a screen from a shared
-zone rather than replace it, set that zone to **Disabled here** — leaving it
-unset means "not configured", which falls through to `*`.
+Windows lets the pointer cross freely between adjacent monitors, so a corner on
+a shared boundary has nothing to stop the cursor against. It is hard to hit on
+purpose and easy to hit by accident. Prefer the outer perimeter of your
+arrangement — the pointer physically stops there, and that is what makes hot
+corners feel reliable on macOS.
 
-## A note on inner corners
+## The tray icon and dashboard
 
-Windows lets the pointer cross freely between adjacent monitors, so corners
-along a shared boundary have nothing to stop the cursor against. They are hard
-to hit on purpose and easy to hit by accident. Prefer the outer perimeter of
-your desktop arrangement — the pointer physically stops there, which is what
-makes hot corners feel reliable on macOS.
+![The Zones and settings window](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/dashboard.png)
 
-## Virtual Key Press Format
+**Right-click → Zones & settings…** opens the window above: a tab per display, a
+diagram of that screen with each zone's action drawn in it, and — for whichever
+zone you point at — the timings actually in effect, each marked *global* or
+*this zone*. It is a read-only picture of what the settings page produced, so it
+can never disagree with what actually fires.
 
-One combination is `Modifier+Key`. Separate several with semicolons and they
-are sent **one after another**, not merged into a single chord — `Ctrl+C;Alt+Tab`
-sends Ctrl+C, then Alt+Tab.
+**Left-click** turns the hot corners on and off; the icon dims when they are
+off. **Right-click** also offers a temporary suspend.
 
-**Modifiers:** Ctrl, Alt, Shift, Win
-**Keys:** A-Z, 0-9, F1-F24, Enter, Space, Tab, Escape, Home, End, Delete,
-Left, Right, Up, Down, etc.
+If the icon is hidden, it is in the overflow area — drag it onto the taskbar to
+keep it there.
 
-**Examples:** `Ctrl+Shift+Esc`, `Alt+F4`, `Win+L`
+## Staying out of your way
 
-## Alternate Key Press / Alternate Command
+Four separate guards, because a hot corner that fires while you are working is
+worse than one that never fires at all.
 
-Two actions separated by `|`. The zone fires the left one, then the right
-one, then the left again — the "different action on the second trigger" case:
+| Setting | What it does |
+| --- | --- |
+| **Pass-through guard** | Ignores a zone you were merely travelling across. 80 ms by default. Raise this first if things fire while you are just moving around. |
+| **Cooldown** | Minimum gap between two firings of the same zone. A cooldown is a wait, not a refusal — park in the corner and it fires once the wait is over. |
+| **Skip while a window is fullscreen** | Suppresses zones on the display the fullscreen window is on, so games and presentations are left alone. |
+| **Skip while dragging** | Nothing fires while a mouse button is held, so dragging a window or selecting text into a corner is safe. |
 
-```
-Alt+S | Alt+H            one corner shows notes, then hides them
-notepad.exe | calc.exe
-```
+**Excluded applications** takes a semicolon-separated list of process names,
+case-insensitive: `photoshop.exe;premiere.exe;blender.exe`. Every zone goes
+quiet while one of those is in the foreground — for apps that need the corners
+and edges for themselves.
 
-Each side accepts everything the single-action version does, so
-`Ctrl+C;Ctrl+V | Alt+Tab` is valid. Every zone alternates independently, and
-the position resets whenever settings or the display layout change.
-
-## Custom Command Format
-
-Any executable path, file, folder, or URL. Environment variables like
-`%AppData%` are expanded automatically.
-
-**Examples:**
-- `notepad.exe`
-- `C:\Windows\System32\cmd.exe`
-- `%AppData%\my_script.bat`
-- `https://example.com`
-
-Prefix with `uac;` to request elevation: `uac;cmd.exe`
-
-## App Exclusions
-
-Semicolon-separated list of process names (case-insensitive).
-Hot corners are disabled when any excluded process is the foreground window.
-
-**Example:** `photoshop.exe;premiere.exe;blender.exe`
+**Keep zones out of the taskbar** shrinks each display's zones to its working
+area, if you would rather a bottom corner not sit behind the taskbar.
 
 ## Why it works this way
 
@@ -413,6 +416,16 @@ releases and stops there.
 sampling thread, so a slow `OpenProcess` can never delay cursor sampling. The
 cost is that a suppressed trigger still consumes its cooldown — a wait nobody
 can perceive, traded for a sampling path that never stalls.
+
+## Related mods
+
+If all you want is one specific behaviour, a smaller mod may suit you better:
+
+- **edge-hot-corner-desktop-switch** — hovering the left or right screen edge
+  switches virtual desktop. This mod does that too, as one of the actions you
+  can assign, but if it is the only thing you are after that one is far simpler.
+- **hotcorner-hotkeys** — sends a key combination from a corner. Different
+  trigger model: it dispatches on a hotkey rather than on hover.
 
 ## Bugs and requests
 
@@ -2440,7 +2453,12 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
         // two displays still alternate independently.
         std::function<void()> altExec[ZONE_COUNT];
 
-        auto add = [&](Zone z, RECT rect)
+        // spanned says how many of an edge's three segments this zone covers,
+        // so the label can say so. The log is what users are asked to paste
+        // when a zone misbehaves, and a merged edge reporting itself as
+        // "Top edge, left" while actually spanning the whole edge sent more
+        // than one report down the wrong path.
+        auto add = [&](Zone z, RECT rect, int spanned = 1)
         {
             const ZoneConfig *zc = ResolveZone(mon, z);
             if (!zc)
@@ -2500,7 +2518,10 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
             hz.releaseExec = zc->releaseAction == CornerAction::SameAsEntry
                                  ? hz.exec
                                  : zc->releaseExecutor;
-            hz.label = mon.id + L" " + ZoneToString(z) + L" -> " +
+            const wchar_t *span = spanned >= 3   ? L" (whole edge)"
+                                 : spanned == 2 ? L" (two segments)"
+                                                : L"";
+            hz.label = mon.id + L" " + ZoneToString(z) + span + L" -> " +
                        ActionToString(zc->action);
             set->zones.push_back(std::move(hz));
         };
@@ -2555,7 +2576,7 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
                 while (j < 3 && SameZoneConfig(zc, ResolveZone(mon, seg[j])))
                     j++;
                 if (zc && bound[j] > bound[i])
-                    add(seg[i], rectFor(bound[i], bound[j]));
+                    add(seg[i], rectFor(bound[i], bound[j]), j - i);
                 i = j;
             }
         };

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         4.0.3
+// @version         4.1.1
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @license         MIT
@@ -24,11 +24,22 @@ independently.
 Inspired by [WinXCorners](https://github.com/vhanla/winxcorners), rebuilt as a
 Windhawk mod.
 
+### Related mods
+
+If all you want is one specific behaviour, a smaller mod may suit you better:
+
+- **edge-hot-corner-desktop-switch** — hovering the left or right screen edge
+  switches virtual desktop. This mod does that too, as one of the actions you
+  can assign, but if it is the only thing you are after that one is far
+  simpler.
+- **hotcorner-hotkeys** — sends a key combination from a corner. Different
+  trigger model: it dispatches on a hotkey rather than on hover.
+
 ## Features
 
 - **Bounded latency** — a dedicated detection thread samples the cursor every
-  ~16 ms. Nothing can starve it: not a busy explorer, not an elevated
-  foreground app, not a slow action.
+  ~16 ms, and only idles when nothing could fire anyway. Nothing can starve it:
+  not a busy explorer, not an elevated foreground app, not a slow action.
 - **Zero impact on the rest of the system** — no global mouse hook, so your
   games and apps keep their input path to themselves.
 - **Monitors identified by name** — zones bind to a display's friendly name
@@ -44,6 +55,31 @@ Windhawk mod.
   fullscreen apps.
 - **Drag protection** — zones don't fire while a mouse button is held.
 - **App exclusions** — blacklist processes that need corner/edge clicks.
+
+## Configuring — look in your system tray, not here
+
+**This mod has no Settings page.** Everything is configured from the tray icon
+it adds, next to the clock:
+
+- **Left-click** — turn the hot corners on or off.
+- **Right-click** — a quick menu: suspend for a while, skip while an app is
+  fullscreen, skip while dragging.
+- **Right-click → Zones & settings...** — the dashboard, where zones, timings
+  and everything else live.
+
+The dashboard is a normal window with a live preview of your screen, so you
+click the corner you want and pick its action. Every field explains itself on
+hover.
+
+This is deliberate. Twelve zones on each of up to eight displays, each with a
+forty-entry action list and six timing overrides, is not something a settings
+form can present without becoming a tree nobody can navigate — and a Windhawk
+mod cannot write its own settings from code, so any change made in the mod's
+own UI could not be written back. Two places to configure one thing, disagreeing
+the moment you touched either. Now there is one.
+
+If the tray icon is hidden, it is in the overflow area — drag it onto the
+taskbar to keep it there.
 
 ## Available Actions
 
@@ -106,9 +142,10 @@ Windhawk mod.
 
 ## Identifying your monitors
 
-Set **Monitor** to the display's friendly name. The exact names for your
-displays are written to this mod's log every time it loads or your display
-layout changes — open the log and look for lines like:
+The dashboard's monitor selector lists your displays by name, so normally there
+is nothing to identify. The names also go to this mod's log every time it loads
+or your display layout changes, which is the place to check when a display is
+unplugged and you want to know which configuration belonged to it:
 
 ```
 Monitor 1 [PRIMARY] id='Dell U2720Q' device=\\.\DISPLAY1 (0,0)-(3840,2160)
@@ -122,11 +159,8 @@ names themselves they are not fixed: making the other twin primary swaps which
 one is ` #2`, and swaps the configuration with it. Check the log after such a
 change.
 
-Special values:
-
-- `*` — applies to every monitor (use this for one shared configuration)
-- *(empty)* — falls back to the numeric **Monitor Number** field, for
-  configurations carried over from v2.x
+The selector's first entry, **All monitors** (`*`), applies one configuration
+to every display.
 
 Resolution is **per zone**: a name-matched entry wins over `*` for the zones
 it defines, and `*` supplies the rest. So you can put a shared config on `*`
@@ -187,6 +221,119 @@ Hot corners are disabled when any excluded process is the foreground window.
 **Example:** `photoshop.exe;premiere.exe;blender.exe`
 
 # Changelog
+
+## What's New in v4.1.1
+
+Review fixes on top of v4.1.0, one of them a real race.
+
+- **Fixed: a reload could briefly publish an empty zone set.** Loading the
+  configuration was two steps — write the defaults, then lay the stored values
+  over them — each taking the settings lock separately. In the gap the mod held
+  a complete, plausible, *wrong* configuration with no zones in it. Four of the
+  six things that trigger a reload run on a different thread from the detection
+  loop, and that loop re-checks the display layout twice a second, so a rebuild
+  landing in the gap would arm nothing and log "No zones are active". Loading is
+  now one transaction: the whole configuration is built off to the side and
+  swapped in under a single lock.
+- **That lock is also held for far less time.** It used to cover several hundred
+  value-store reads, an action built per zone, and two log writes — while the
+  detection thread, the action worker and the tray menu all waited on it.
+- **The adaptive poll rate is gone.** v4.1.0 eased the sampling interval off
+  while the cursor was far from every zone. Whichever way that decision is
+  made, it is made from a sample taken *before* the user starts moving, so a
+  flick could cross a zone entirely between two samples. On the outer perimeter
+  that costs a late trigger, because the pointer stops against the screen edge —
+  but a corner shared with a second monitor has no edge to stop against, and
+  there it was a lost one. Detection is back to a flat 16 ms whenever a zone
+  could fire; it still idles at 100 ms when the mod is switched off, suspended,
+  or has no zones armed, where nothing can be missed because nothing can fire.
+- **The dashboard's Reset button said "Reset to Windhawk settings".** There is
+  no Windhawk settings page to go back to. It now says what it does.
+- **The monitor list in the log** still told you to copy a name into the
+  "Monitor" setting, which no longer exists.
+
+## What's New in v4.1.0
+
+**The Settings page is gone. Everything is in the tray icon now.**
+
+- **One place to configure this mod, not two.** The Windhawk Settings page has
+  been removed entirely. Twelve zones per display, each with a forty-entry
+  action list and six timing overrides, had grown into a tree that was faster
+  to give up on than to navigate — and because a mod cannot write its own
+  settings from code, anything you changed in the dashboard could never be
+  written back to it. The two disagreed the moment you touched either one. The
+  dashboard won: right-click the tray icon → **Zones & settings...**
+- **If you configured this mod on the Settings page, set it up again from the
+  dashboard.** Configurations already saved from the dashboard are untouched.
+- **Reset actually resets.** The dashboard's Reset button left the numeric
+  options — sizes, delays, cooldown — behind in storage: still applied, no
+  longer shown anywhere. It now clears everything it can write.
+- **Fixed: per-display zones could be attributed to the wrong display.** The
+  editor matched a stored configuration to the monitor selector by list
+  position rather than by monitor, so a configuration written for one display
+  could appear under **All monitors** — and saving it then fired it on every
+  display.
+- **Verbose logging is gone as a setting.** Every log it gated was once per
+  trigger, never on the polling path, so there was nothing to gate. Suppressed
+  triggers now log once per run instead of once per cooldown, which is what the
+  setting was really protecting you from.
+- **The tray menu's reset** now says what it does — it clears the three toggles
+  above it, and nothing else. Wiping your zones is the dashboard's Reset
+  button, which asks first.
+- **The options are grouped.** Fourteen fields in one flat column, in no
+  particular order, is a wall. They now sit under four headings — how big the
+  zones are, when a zone fires, when to stay out of the way, everything else —
+  and every field still explains itself on hover.
+
+**Behaviour**
+
+- **A fullscreen app now only silences the display it is on.** Launching a game
+  on one monitor used to disable the hot corners on *every* monitor, which is
+  the opposite of why anyone owns a second screen. When Windows will not say
+  which display is involved, the old behaviour still applies and all displays
+  are suppressed.
+- **A split edge alternates as one edge.** With a centre action assigned, an
+  edge becomes two strips either side of the centre — but it is still one edge,
+  and **Alternate Key Press** / **Alternate Command** kept a separate A/B
+  position for each half. Walking into the left strip and then the right gave
+  you A twice. They now share one position.
+- **The detection thread idles when nothing can fire.** It sampled the cursor
+  every 16 ms even with the mod switched off, suspended, or with no zones
+  armed. Those three cases now tick at 100 ms. *(v4.1.0 also eased off while
+  the cursor was merely far away; v4.1.1 removed that — see below.)*
+
+## What's New in v4.0.5
+
+- **Fixed: "Turn Off Monitors", "Start Screen Saver" and "Lock and Turn Off
+  Monitors" could stall every other action behind them.** They ask every
+  window on the desktop to act, and the old call waited up to half a second
+  for *each* one — so a single slow application could tie up the action
+  thread for seconds while the mod appeared to have stopped responding. The
+  request is now sent without waiting.
+- Added a note on which smaller mods overlap with this one, so it is easier to
+  tell which is the right tool.
+- Internal tidying: dropped snapshot fields nothing read, the theme helper
+  resolves its entry point once instead of on every control, and the tray
+  icon's mask is explicitly zeroed rather than left undefined.
+
+## What's New in v4.0.4
+
+- **Fixed: disabling or reloading the mod with the settings window open could
+  crash Windhawk.** Shutdown stopped every thread except the one running that
+  window, then freed the locks it was still using. It now closes the window
+  and waits for it, and if it will not close, leaves the locks alone rather
+  than pulling them out from under it.
+- **Fixed: a failed key injection could leave a modifier stuck down.** If the
+  key presses went through but the releases did not, the key stayed logically
+  held for the rest of the session — a stuck Win or Ctrl that nothing on
+  screen explains. The releases are now replayed after a partial send.
+- **Fixed: opening the settings window leaked an icon every time.**
+- Saving a configuration for a display beyond the eighth now says so in the
+  log instead of appearing to work and losing the edit on the next reload.
+- A Custom Command of just `uac;` with nothing after it no longer tries to
+  relaunch Windhawk itself with elevation.
+- Settings shared between the tray, the settings window and the detection
+  loop are read and written atomically.
 
 ## What's New in v4.0.3
 
@@ -375,671 +522,6 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
 */
 // ==/WindhawkModReadme==
 
-// ==WindhawkModSettings==
-/*
-- CornerSize: 6
-  $name: Corner activation size (pixels)
-  $description: >-
-    How many pixels from the screen corner activate the hot corner.
-    Smaller values require more precision; larger values are easier to hit.
-- EdgeSize: 6
-  $name: Edge activation size (pixels)
-  $description: >-
-    How many pixels along the screen edge activate the hot edge.
-    Only applies to edge zones, not corners.
-- ActivationDelay: 0
-  $name: Activation delay (ms)
-  $description: >-
-    Delay in milliseconds before the action triggers. 0 = instant.
-    Use 200-500 ms to prevent accidental triggers.
-- SettleMs: 80
-  $name: Pass-through guard (ms)
-  $description: >-
-    How long the cursor must stay in a zone before it counts as entered.
-    You cannot reach a corner without crossing the edge next to it, so
-    without this a fast move into a corner fires the edge action too — and
-    if both are a toggle (like Task View) they cancel out and nothing seems
-    to happen. 80 ms is imperceptible and blocks pass-through firing.
-    Set to 0 only if you use corners or edges but never both.
-- LockBlankDelayMs: 1200
-  $name: Delay before blanking after lock (ms)
-  $description: >-
-    Used only by the "Lock and Turn Off Monitors" action. Locking counts as
-    activity, so the display is blanked a moment later - blank too early and
-    it simply wakes back up. If your screen stays on after locking, raise
-    this; if it blanks before the lock screen appears, lower it.
-- ShowMonitorNames: true
-  $name: List my monitors in the log
-  $description: >-
-    Writes your connected displays to this mod's log every time it loads or
-    your display layout changes, so you can copy a name straight into the
-    Monitor field below instead of guessing it. Harmless to leave on - it
-    only writes a few lines, and only when something actually changes.
-- VerboseLogging: false
-  $name: Verbose logging
-  $description: >-
-    Log every trigger and key injection. Off by default: these logs go through
-    OutputDebugString, which takes a system-wide lock, so logging on every
-    trigger can stutter other Windhawk mods. Turn on only while diagnosing.
-    Errors and startup information are always logged.
-- AvoidTaskbar: false
-  $name: Keep zones off the taskbar
-  $description: >-
-    Build the zones from the desktop work area instead of the whole screen, so
-    they stop at the edge of the taskbar. Turn this on if a bottom corner is
-    fighting the taskbar's own "peek at desktop" strip, or if you keep
-    triggering a corner while aiming for a taskbar button. Off by default,
-    because putting a zone on top of the taskbar is a perfectly reasonable
-    thing to want.
-- CenterZonePercent: 20
-  $name: Centre zone width (% of the edge)
-  $description: >-
-    How much of each edge the centre zone occupies, as a percentage. Only
-    has any effect on edges where you have actually assigned a centre action.
-    The rest of the edge stays as the normal edge zone, split either side.
-- KnockWindowMs: 0
-  $name: Knock to activate (ms)
-  $description: >-
-    Require the cursor to enter a zone TWICE in quick succession, like knocking
-    on a door, before anything happens. A single entry does nothing at all.
-    This is the strongest protection against accidental triggers. 0 turns it
-    off; 400 is a comfortable starting point. The two entries must be within
-    this many milliseconds of each other.
-- RequireModifier: none
-  $name: Require a modifier key
-  $description: >-
-    Only fire while this key is held down. Makes hot corners completely inert
-    the rest of the time, which suits people who work near the screen edges.
-    Combines with everything else - the zone still has to be entered normally.
-  $options:
-  - none: None - zones always active
-  - ctrl: Ctrl
-  - alt: Alt
-  - shift: Shift
-  - win: Win
-- CooldownMs: 300
-  $name: Cooldown between triggers (ms)
-  $description: >-
-    Minimum time between sequential triggers of the same zone.
-    Prevents double-firing when cursor twitches. 0 = no cooldown.
-- DisableOnFullscreen: true
-  $name: Disable on fullscreen apps
-  $description: >-
-    Don't trigger hot corners when a fullscreen application (game, video,
-    presentation) is the foreground window.
-- DisableDuringDrag: true
-  $name: Disable during mouse drag
-  $description: >-
-    Don't trigger hot corners while any mouse button is held down.
-- ExcludedProcesses: ""
-  $name: Excluded processes (blacklist)
-  $description: >-
-    Semicolon-separated list of process names. Hot corners are disabled
-    when any of these processes is the foreground window.
-    Example: photoshop.exe;premiere.exe;blender.exe
-- MonitorCorners:
-  - - MonitorId: ""
-      $name: Monitor
-      $description: >-
-        The display's friendly name, e.g. Dell U2720Q. The exact names for
-        your displays are written to this mod's log every time it loads.
-        Use * for all monitors. Leave empty to fall back to the numeric
-        Monitor Number field below.
-    - Monitor: 0
-      $name: Monitor Number (legacy fallback)
-      $description: >-
-        Only used when Monitor above is left empty. 0 = all monitors,
-        1 = primary, 2 = second, etc. Prefer the name field — numbers shift
-        when you rearrange displays.
-    - TopLeft: ACTION_NOTHING
-      $name: Top-Left Corner
-      $options:
-      - ACTION_NOTHING: Nothing
-      - ACTION_SHOW_DESKTOP: Show Desktop
-      - ACTION_TASK_VIEW: Task View (Win+Tab)
-      - ACTION_SCREENSAVER: Start Screen Saver
-      - ACTION_MONITORS_OFF: Turn Off Monitors
-      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
-      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
-      - ACTION_START_MENU: Start Menu
-      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
-      - ACTION_MUTE: Mute Volume
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_LOCK: Lock Computer
-      - ACTION_SLEEP: Sleep
-      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
-      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
-      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
-      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
-      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
-      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
-      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
-      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
-      - ACTION_SETTINGS: Settings (Win+I)
-      - ACTION_SEARCH: Search (Win+S)
-      - ACTION_CLIPBOARD: Clipboard History (Win+V)
-      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
-      - ACTION_PROJECT: Project / Second Screen (Win+P)
-      - ACTION_VDESK_NEXT: Virtual Desktop - Next
-      - ACTION_VDESK_PREV: Virtual Desktop - Previous
-      - ACTION_VDESK_NEW: Virtual Desktop - New
-      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
-      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
-      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
-      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
-      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
-      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
-      - ACTION_SEND_KEYPRESS: Virtual Key Press
-      - ACTION_START_PROCESS: Custom Command
-    - TopLeftArgs: ""
-      $name: Top-Left Args
-      $description: >-
-        For Virtual Key Press (e.g. Ctrl+Shift+Esc) or Custom Command
-        (e.g. notepad.exe) only.
-    - TopRight: ACTION_NOTHING
-      $name: Top-Right Corner
-      $options:
-      - ACTION_NOTHING: Nothing
-      - ACTION_SHOW_DESKTOP: Show Desktop
-      - ACTION_TASK_VIEW: Task View (Win+Tab)
-      - ACTION_SCREENSAVER: Start Screen Saver
-      - ACTION_MONITORS_OFF: Turn Off Monitors
-      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
-      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
-      - ACTION_START_MENU: Start Menu
-      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
-      - ACTION_MUTE: Mute Volume
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_LOCK: Lock Computer
-      - ACTION_SLEEP: Sleep
-      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
-      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
-      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
-      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
-      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
-      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
-      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
-      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
-      - ACTION_SETTINGS: Settings (Win+I)
-      - ACTION_SEARCH: Search (Win+S)
-      - ACTION_CLIPBOARD: Clipboard History (Win+V)
-      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
-      - ACTION_PROJECT: Project / Second Screen (Win+P)
-      - ACTION_VDESK_NEXT: Virtual Desktop - Next
-      - ACTION_VDESK_PREV: Virtual Desktop - Previous
-      - ACTION_VDESK_NEW: Virtual Desktop - New
-      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
-      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
-      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
-      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
-      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
-      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
-      - ACTION_SEND_KEYPRESS: Virtual Key Press
-      - ACTION_START_PROCESS: Custom Command
-    - TopRightArgs: ""
-      $name: Top-Right Args
-      $description: >-
-        For Virtual Key Press or Custom Command only.
-    - BottomLeft: ACTION_NOTHING
-      $name: Bottom-Left Corner
-      $options:
-      - ACTION_NOTHING: Nothing
-      - ACTION_SHOW_DESKTOP: Show Desktop
-      - ACTION_TASK_VIEW: Task View (Win+Tab)
-      - ACTION_SCREENSAVER: Start Screen Saver
-      - ACTION_MONITORS_OFF: Turn Off Monitors
-      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
-      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
-      - ACTION_START_MENU: Start Menu
-      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
-      - ACTION_MUTE: Mute Volume
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_LOCK: Lock Computer
-      - ACTION_SLEEP: Sleep
-      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
-      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
-      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
-      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
-      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
-      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
-      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
-      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
-      - ACTION_SETTINGS: Settings (Win+I)
-      - ACTION_SEARCH: Search (Win+S)
-      - ACTION_CLIPBOARD: Clipboard History (Win+V)
-      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
-      - ACTION_PROJECT: Project / Second Screen (Win+P)
-      - ACTION_VDESK_NEXT: Virtual Desktop - Next
-      - ACTION_VDESK_PREV: Virtual Desktop - Previous
-      - ACTION_VDESK_NEW: Virtual Desktop - New
-      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
-      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
-      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
-      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
-      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
-      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
-      - ACTION_SEND_KEYPRESS: Virtual Key Press
-      - ACTION_START_PROCESS: Custom Command
-    - BottomLeftArgs: ""
-      $name: Bottom-Left Args
-      $description: >-
-        For Virtual Key Press or Custom Command only.
-    - BottomRight: ACTION_NOTHING
-      $name: Bottom-Right Corner
-      $options:
-      - ACTION_NOTHING: Nothing
-      - ACTION_SHOW_DESKTOP: Show Desktop
-      - ACTION_TASK_VIEW: Task View (Win+Tab)
-      - ACTION_SCREENSAVER: Start Screen Saver
-      - ACTION_MONITORS_OFF: Turn Off Monitors
-      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
-      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
-      - ACTION_START_MENU: Start Menu
-      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
-      - ACTION_MUTE: Mute Volume
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_LOCK: Lock Computer
-      - ACTION_SLEEP: Sleep
-      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
-      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
-      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
-      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
-      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
-      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
-      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
-      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
-      - ACTION_SETTINGS: Settings (Win+I)
-      - ACTION_SEARCH: Search (Win+S)
-      - ACTION_CLIPBOARD: Clipboard History (Win+V)
-      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
-      - ACTION_PROJECT: Project / Second Screen (Win+P)
-      - ACTION_VDESK_NEXT: Virtual Desktop - Next
-      - ACTION_VDESK_PREV: Virtual Desktop - Previous
-      - ACTION_VDESK_NEW: Virtual Desktop - New
-      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
-      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
-      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
-      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
-      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
-      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
-      - ACTION_SEND_KEYPRESS: Virtual Key Press
-      - ACTION_START_PROCESS: Custom Command
-    - BottomRightArgs: ""
-      $name: Bottom-Right Args
-      $description: >-
-        For Virtual Key Press or Custom Command only.
-    - EdgeTop: ACTION_NOTHING
-      $name: Top Edge
-      $options:
-      - ACTION_NOTHING: Nothing
-      - ACTION_SHOW_DESKTOP: Show Desktop
-      - ACTION_TASK_VIEW: Task View (Win+Tab)
-      - ACTION_SCREENSAVER: Start Screen Saver
-      - ACTION_MONITORS_OFF: Turn Off Monitors
-      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
-      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
-      - ACTION_START_MENU: Start Menu
-      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
-      - ACTION_MUTE: Mute Volume
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_LOCK: Lock Computer
-      - ACTION_SLEEP: Sleep
-      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
-      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
-      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
-      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
-      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
-      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
-      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
-      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
-      - ACTION_SETTINGS: Settings (Win+I)
-      - ACTION_SEARCH: Search (Win+S)
-      - ACTION_CLIPBOARD: Clipboard History (Win+V)
-      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
-      - ACTION_PROJECT: Project / Second Screen (Win+P)
-      - ACTION_VDESK_NEXT: Virtual Desktop - Next
-      - ACTION_VDESK_PREV: Virtual Desktop - Previous
-      - ACTION_VDESK_NEW: Virtual Desktop - New
-      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
-      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
-      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
-      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
-      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
-      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
-      - ACTION_SEND_KEYPRESS: Virtual Key Press
-      - ACTION_START_PROCESS: Custom Command
-    - EdgeTopArgs: ""
-      $name: Top Edge Args
-      $description: >-
-        For Virtual Key Press or Custom Command only.
-    - EdgeBottom: ACTION_NOTHING
-      $name: Bottom Edge
-      $options:
-      - ACTION_NOTHING: Nothing
-      - ACTION_SHOW_DESKTOP: Show Desktop
-      - ACTION_TASK_VIEW: Task View (Win+Tab)
-      - ACTION_SCREENSAVER: Start Screen Saver
-      - ACTION_MONITORS_OFF: Turn Off Monitors
-      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
-      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
-      - ACTION_START_MENU: Start Menu
-      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
-      - ACTION_MUTE: Mute Volume
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_LOCK: Lock Computer
-      - ACTION_SLEEP: Sleep
-      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
-      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
-      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
-      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
-      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
-      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
-      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
-      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
-      - ACTION_SETTINGS: Settings (Win+I)
-      - ACTION_SEARCH: Search (Win+S)
-      - ACTION_CLIPBOARD: Clipboard History (Win+V)
-      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
-      - ACTION_PROJECT: Project / Second Screen (Win+P)
-      - ACTION_VDESK_NEXT: Virtual Desktop - Next
-      - ACTION_VDESK_PREV: Virtual Desktop - Previous
-      - ACTION_VDESK_NEW: Virtual Desktop - New
-      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
-      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
-      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
-      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
-      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
-      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
-      - ACTION_SEND_KEYPRESS: Virtual Key Press
-      - ACTION_START_PROCESS: Custom Command
-    - EdgeBottomArgs: ""
-      $name: Bottom Edge Args
-      $description: >-
-        For Virtual Key Press or Custom Command only.
-    - EdgeLeft: ACTION_NOTHING
-      $name: Left Edge
-      $options:
-      - ACTION_NOTHING: Nothing
-      - ACTION_SHOW_DESKTOP: Show Desktop
-      - ACTION_TASK_VIEW: Task View (Win+Tab)
-      - ACTION_SCREENSAVER: Start Screen Saver
-      - ACTION_MONITORS_OFF: Turn Off Monitors
-      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
-      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
-      - ACTION_START_MENU: Start Menu
-      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
-      - ACTION_MUTE: Mute Volume
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_LOCK: Lock Computer
-      - ACTION_SLEEP: Sleep
-      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
-      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
-      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
-      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
-      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
-      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
-      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
-      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
-      - ACTION_SETTINGS: Settings (Win+I)
-      - ACTION_SEARCH: Search (Win+S)
-      - ACTION_CLIPBOARD: Clipboard History (Win+V)
-      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
-      - ACTION_PROJECT: Project / Second Screen (Win+P)
-      - ACTION_VDESK_NEXT: Virtual Desktop - Next
-      - ACTION_VDESK_PREV: Virtual Desktop - Previous
-      - ACTION_VDESK_NEW: Virtual Desktop - New
-      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
-      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
-      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
-      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
-      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
-      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
-      - ACTION_SEND_KEYPRESS: Virtual Key Press
-      - ACTION_START_PROCESS: Custom Command
-    - EdgeLeftArgs: ""
-      $name: Left Edge Args
-      $description: >-
-        For Virtual Key Press or Custom Command only.
-    - EdgeRight: ACTION_NOTHING
-      $name: Right Edge
-      $options:
-      - ACTION_NOTHING: Nothing
-      - ACTION_SHOW_DESKTOP: Show Desktop
-      - ACTION_TASK_VIEW: Task View (Win+Tab)
-      - ACTION_SCREENSAVER: Start Screen Saver
-      - ACTION_MONITORS_OFF: Turn Off Monitors
-      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
-      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
-      - ACTION_START_MENU: Start Menu
-      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
-      - ACTION_MUTE: Mute Volume
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_LOCK: Lock Computer
-      - ACTION_SLEEP: Sleep
-      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
-      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
-      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
-      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
-      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
-      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
-      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
-      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
-      - ACTION_SETTINGS: Settings (Win+I)
-      - ACTION_SEARCH: Search (Win+S)
-      - ACTION_CLIPBOARD: Clipboard History (Win+V)
-      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
-      - ACTION_PROJECT: Project / Second Screen (Win+P)
-      - ACTION_VDESK_NEXT: Virtual Desktop - Next
-      - ACTION_VDESK_PREV: Virtual Desktop - Previous
-      - ACTION_VDESK_NEW: Virtual Desktop - New
-      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
-      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
-      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
-      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
-      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
-      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
-      - ACTION_SEND_KEYPRESS: Virtual Key Press
-      - ACTION_START_PROCESS: Custom Command
-    - EdgeRightArgs: ""
-      $name: Right Edge Args
-      $description: >-
-        For Virtual Key Press or Custom Command only.
-    - CenterTop: ACTION_NOTHING
-      $name: Top Edge Centre
-      $description: >-
-        The middle of that edge. Easier to hit than a corner on a wide
-        display. Leaving this as Nothing keeps the full-length edge zone
-        exactly as it is today.
-      $options:
-      - ACTION_NOTHING: Nothing
-      - ACTION_SHOW_DESKTOP: Show Desktop
-      - ACTION_TASK_VIEW: Task View (Win+Tab)
-      - ACTION_SCREENSAVER: Start Screen Saver
-      - ACTION_MONITORS_OFF: Turn Off Monitors
-      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
-      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
-      - ACTION_START_MENU: Start Menu
-      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
-      - ACTION_MUTE: Mute Volume
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_LOCK: Lock Computer
-      - ACTION_SLEEP: Sleep
-      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
-      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
-      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
-      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
-      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
-      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
-      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
-      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
-      - ACTION_SETTINGS: Settings (Win+I)
-      - ACTION_SEARCH: Search (Win+S)
-      - ACTION_CLIPBOARD: Clipboard History (Win+V)
-      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
-      - ACTION_PROJECT: Project / Second Screen (Win+P)
-      - ACTION_VDESK_NEXT: Virtual Desktop - Next
-      - ACTION_VDESK_PREV: Virtual Desktop - Previous
-      - ACTION_VDESK_NEW: Virtual Desktop - New
-      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
-      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
-      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
-      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
-      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
-      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
-      - ACTION_SEND_KEYPRESS: Virtual Key Press
-      - ACTION_START_PROCESS: Custom Command
-    - CenterTopArgs: ""
-      $name: Top Edge Centre Args
-      $description: >-
-        For Virtual Key Press or Custom Command only.
-    - CenterBottom: ACTION_NOTHING
-      $name: Bottom Edge Centre
-      $description: >-
-        The middle of that edge. Easier to hit than a corner on a wide
-        display. Leaving this as Nothing keeps the full-length edge zone
-        exactly as it is today.
-      $options:
-      - ACTION_NOTHING: Nothing
-      - ACTION_SHOW_DESKTOP: Show Desktop
-      - ACTION_TASK_VIEW: Task View (Win+Tab)
-      - ACTION_SCREENSAVER: Start Screen Saver
-      - ACTION_MONITORS_OFF: Turn Off Monitors
-      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
-      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
-      - ACTION_START_MENU: Start Menu
-      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
-      - ACTION_MUTE: Mute Volume
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_LOCK: Lock Computer
-      - ACTION_SLEEP: Sleep
-      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
-      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
-      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
-      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
-      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
-      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
-      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
-      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
-      - ACTION_SETTINGS: Settings (Win+I)
-      - ACTION_SEARCH: Search (Win+S)
-      - ACTION_CLIPBOARD: Clipboard History (Win+V)
-      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
-      - ACTION_PROJECT: Project / Second Screen (Win+P)
-      - ACTION_VDESK_NEXT: Virtual Desktop - Next
-      - ACTION_VDESK_PREV: Virtual Desktop - Previous
-      - ACTION_VDESK_NEW: Virtual Desktop - New
-      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
-      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
-      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
-      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
-      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
-      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
-      - ACTION_SEND_KEYPRESS: Virtual Key Press
-      - ACTION_START_PROCESS: Custom Command
-    - CenterBottomArgs: ""
-      $name: Bottom Edge Centre Args
-      $description: >-
-        For Virtual Key Press or Custom Command only.
-    - CenterLeft: ACTION_NOTHING
-      $name: Left Edge Centre
-      $description: >-
-        The middle of that edge. Easier to hit than a corner on a wide
-        display. Leaving this as Nothing keeps the full-length edge zone
-        exactly as it is today.
-      $options:
-      - ACTION_NOTHING: Nothing
-      - ACTION_SHOW_DESKTOP: Show Desktop
-      - ACTION_TASK_VIEW: Task View (Win+Tab)
-      - ACTION_SCREENSAVER: Start Screen Saver
-      - ACTION_MONITORS_OFF: Turn Off Monitors
-      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
-      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
-      - ACTION_START_MENU: Start Menu
-      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
-      - ACTION_MUTE: Mute Volume
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_LOCK: Lock Computer
-      - ACTION_SLEEP: Sleep
-      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
-      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
-      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
-      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
-      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
-      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
-      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
-      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
-      - ACTION_SETTINGS: Settings (Win+I)
-      - ACTION_SEARCH: Search (Win+S)
-      - ACTION_CLIPBOARD: Clipboard History (Win+V)
-      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
-      - ACTION_PROJECT: Project / Second Screen (Win+P)
-      - ACTION_VDESK_NEXT: Virtual Desktop - Next
-      - ACTION_VDESK_PREV: Virtual Desktop - Previous
-      - ACTION_VDESK_NEW: Virtual Desktop - New
-      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
-      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
-      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
-      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
-      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
-      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
-      - ACTION_SEND_KEYPRESS: Virtual Key Press
-      - ACTION_START_PROCESS: Custom Command
-    - CenterLeftArgs: ""
-      $name: Left Edge Centre Args
-      $description: >-
-        For Virtual Key Press or Custom Command only.
-    - CenterRight: ACTION_NOTHING
-      $name: Right Edge Centre
-      $description: >-
-        The middle of that edge. Easier to hit than a corner on a wide
-        display. Leaving this as Nothing keeps the full-length edge zone
-        exactly as it is today.
-      $options:
-      - ACTION_NOTHING: Nothing
-      - ACTION_SHOW_DESKTOP: Show Desktop
-      - ACTION_TASK_VIEW: Task View (Win+Tab)
-      - ACTION_SCREENSAVER: Start Screen Saver
-      - ACTION_MONITORS_OFF: Turn Off Monitors
-      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
-      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
-      - ACTION_START_MENU: Start Menu
-      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
-      - ACTION_MUTE: Mute Volume
-      - ACTION_TASK_MANAGER: Task Manager
-      - ACTION_LOCK: Lock Computer
-      - ACTION_SLEEP: Sleep
-      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
-      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
-      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
-      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
-      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
-      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
-      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
-      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
-      - ACTION_SETTINGS: Settings (Win+I)
-      - ACTION_SEARCH: Search (Win+S)
-      - ACTION_CLIPBOARD: Clipboard History (Win+V)
-      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
-      - ACTION_PROJECT: Project / Second Screen (Win+P)
-      - ACTION_VDESK_NEXT: Virtual Desktop - Next
-      - ACTION_VDESK_PREV: Virtual Desktop - Previous
-      - ACTION_VDESK_NEW: Virtual Desktop - New
-      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
-      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
-      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
-      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
-      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
-      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
-      - ACTION_SEND_KEYPRESS: Virtual Key Press
-      - ACTION_START_PROCESS: Custom Command
-    - CenterRightArgs: ""
-      $name: Right Edge Centre Args
-      $description: >-
-        For Virtual Key Press or Custom Command only.
-  $name: Monitor Corner & Edge Configuration
-*/
-// ==/WindhawkModSettings==
-
 #include <windows.h>
 
 #include <commctrl.h>
@@ -1052,6 +534,11 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
 
 #include <algorithm>
 #include <atomic>
+// swprintf_s / _wtoi / memcmp are used directly; they only reached this file
+// through <windows.h> before.
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <cwctype>
 #include <deque>
 #include <functional>
@@ -1181,8 +668,14 @@ struct HitZone
     int knock = 0;
     int cooldown = 300;
     int modifier = 0;
-    int size = 6;
     Zone zone = ZONE_TOP_LEFT;
+
+    // Which display this zone lives on, so the fullscreen guard can suppress
+    // the display a game is actually on and leave the others alone.
+    // ponytail: an HMONITOR, not a rect. It is only stale between a display
+    // change and the rebuild that follows it, and a stale one simply fails to
+    // match, which errs towards firing rather than towards silence.
+    HMONITOR monitor = nullptr;
 };
 
 // The detection loop reads nothing but this snapshot, so it never touches
@@ -1194,11 +687,10 @@ struct ZoneSet
     // snapshot so the dashboard thread can list monitors without reading
     // g_monitors, which the detection thread clears and refills underneath it.
     std::vector<std::wstring> monitorNames;
-    int activationDelay = 0;
-    int settleMs = 80;
-    int knockWindowMs = 0;
-    int requireModifier = 0;
-    int cooldownMs = 0;
+    // Only what the detection loop actually reads. The timings live on each
+    // HitZone, resolved at build time, which is the whole point of resolving
+    // them there; a second copy here would just be a second thing to keep
+    // in step.
     bool disableDuringDrag = true;
 };
 
@@ -1206,7 +698,9 @@ struct ZoneSet
 // Globals
 // =====================================================================
 
-static struct
+// Named, not anonymous, so ReloadConfig can build a whole configuration in a
+// local and swap it in under one lock acquisition.
+struct ModSettings
 {
     int cornerSize = 6;
     int edgeSize = 6;
@@ -1221,7 +715,8 @@ static struct
     bool disableDuringDrag = true;
     std::vector<std::wstring> excludedProcesses;
     std::vector<MonitorZoneConfig> monitorConfigs;
-} g_settings;
+};
+static ModSettings g_settings;
 
 // g_settings is written by Windhawk's thread and read by the detection thread
 // only when it rebuilds zones. Everything the detection loop needs at runtime
@@ -1235,21 +730,19 @@ static std::shared_ptr<const ZoneSet> g_zones;
 
 static std::vector<MonitorInfo> g_monitors; // detection thread only
 
-// Detection thread
+// Detection thread. 16 ms whenever a zone could fire - see DetectTick for why
+// there is no cleverness here. kIdleTickMs is used only on the paths where
+// nothing can fire at all: the mod switched off, suspended, or no zones armed.
 static constexpr DWORD kTickMs = 16;
+static constexpr DWORD kIdleTickMs = 100;
 static HANDLE g_hDetectThread = nullptr;
 static DWORD g_dwDetectThreadId = 0;
 static HWND g_hDetectWnd = nullptr;
 static HANDLE g_hStopEvent = nullptr;
 
-// Per-fire logging is opt-in. Wh_Log goes through OutputDebugString, which
-// takes a machine-wide mutex; spamming it from a hot path serialises every
-// other process that logs — including the other Windhawk mods.
-static bool g_verboseLog = false;
-
 // Prints the monitor list at load and on display changes, so names can be
-// copied into the Monitor setting instead of guessed. Cheap - once per event.
-static bool g_showMonitorNames = true;
+// copied into the monitor selector instead of guessed. Cheap - once per event.
+static std::atomic<bool> g_showMonitorNames{true};
 
 // Master switch and temporary suspend, both driven from the tray icon.
 // Written by the tray thread and read by the detection thread every tick;
@@ -1260,7 +753,7 @@ static std::atomic<ULONGLONG> g_suspendUntil{0};
 // How long to wait after locking before blanking the display. Hardware
 // dependent - the secure-desktop switch takes longer on some machines, and
 // blanking before it settles just wakes the display again.
-static int g_lockBlankDelayMs = 1200;
+static std::atomic<int> g_lockBlankDelayMs{1200};
 
 // Hard floor between any two actions, whatever the zone or the cooldown
 // setting. Actions are user-visible shell operations (Task View, Show Desktop,
@@ -1300,7 +793,6 @@ static RECT g_topoWorkArea = {};
 static constexpr UINT WM_APP_REBUILD = WM_APP + 1;
 
 // Forward declarations
-static void LoadSettings();
 static const wchar_t *ZoneToString(Zone z);
 static const wchar_t *ActionToString(CornerAction a);
 
@@ -1722,7 +1214,7 @@ static void RefreshMonitors()
     // rather than guessed. Once per load and per display change only.
     Wh_Log(L" ");
     Wh_Log(L"+-- Your monitors ---------------------------------------");
-    Wh_Log(L"|  Copy a name below into this mod's \"Monitor\" setting.");
+    Wh_Log(L"|  These are the displays in the dashboard's monitor selector.");
     Wh_Log(L"|  Use  *  to apply one configuration to every monitor.");
     Wh_Log(L"|");
     for (const auto &m : g_monitors)
@@ -1833,40 +1325,51 @@ static bool IsShellUiWindow(HWND hwnd)
     return false;
 }
 
-static bool IsFullScreenAppActive()
+// "Something is fullscreen, but on which display" cannot always be answered.
+// Suppressing everywhere is the safe reading, and is what this mod did on every
+// display before it learned to tell them apart.
+static HMONITOR const kAllMonitors = (HMONITOR)(INT_PTR)-1;
+
+// The display a fullscreen app is on, or nullptr if nothing is fullscreen.
+// A game on one screen used to disable the hot corners on every screen, which
+// is the opposite of why anyone owns a second monitor.
+static HMONITOR FullScreenMonitor()
 {
+    HWND hFgWnd = GetForegroundWindow();
+
     QUERY_USER_NOTIFICATION_STATE state;
     if (SUCCEEDED(SHQueryUserNotificationState(&state)))
     {
         if (state == QUNS_RUNNING_D3D_FULL_SCREEN ||
             state == QUNS_PRESENTATION_MODE)
-            return true;
+            return hFgWnd ? MonitorFromWindow(hFgWnd, MONITOR_DEFAULTTONEAREST)
+                          : kAllMonitors;
     }
 
     // Fallback: exact bounds match for apps that go fullscreen without
     // D3D exclusive mode (browser F11, video players).
-    HWND hFgWnd = GetForegroundWindow();
     if (!hFgWnd || hFgWnd == GetDesktopWindow() || hFgWnd == GetShellWindow())
-        return false;
+        return nullptr;
 
     if (IsShellUiWindow(hFgWnd))
-        return false;
+        return nullptr;
 
     RECT rcWnd;
     if (!GetWindowRect(hFgWnd, &rcWnd))
-        return false;
+        return nullptr;
 
     HMONITOR hMon = MonitorFromWindow(hFgWnd, MONITOR_DEFAULTTONEAREST);
     MONITORINFO mi = {sizeof(mi)};
     if (!GetMonitorInfo(hMon, &mi))
-        return false;
+        return nullptr;
 
     // True fullscreen apps match the monitor exactly. Maximized desktop
     // apps overhang by ~8px due to DWM drop shadows — they won't match.
-    return (rcWnd.left == mi.rcMonitor.left &&
-            rcWnd.top == mi.rcMonitor.top &&
-            rcWnd.right == mi.rcMonitor.right &&
-            rcWnd.bottom == mi.rcMonitor.bottom);
+    bool full = (rcWnd.left == mi.rcMonitor.left &&
+                 rcWnd.top == mi.rcMonitor.top &&
+                 rcWnd.right == mi.rcMonitor.right &&
+                 rcWnd.bottom == mi.rcMonitor.bottom);
+    return full ? hMon : nullptr;
 }
 
 static bool IsForegroundAppExcluded(const std::vector<std::wstring> &excluded)
@@ -1916,13 +1419,10 @@ static bool IsForegroundAppExcluded(const std::vector<std::wstring> &excluded)
 
     for (const auto &name : excluded)
     {
+        // Not logged here: the one caller reports the skip, with the zone that
+        // was suppressed, which is the part worth knowing.
         if (_wcsicmp(cachedName.c_str(), name.c_str()) == 0)
-        {
-            if (g_verboseLog)
-                Wh_Log(L"[EXCLUDE] Foreground app '%s' is blacklisted",
-                       cachedName.c_str());
             return true;
-        }
     }
     return false;
 }
@@ -2010,17 +1510,27 @@ static void SendKeys(const std::vector<WORD> &vks)
             (IsExtendedKey(vk) ? KEYEVENTF_EXTENDEDKEY : 0) | KEYEVENTF_KEYUP;
     }
 
-    // Failures are always reported — a short SendInput means the action
-    // silently did nothing. Success is logged only under verbose logging;
-    // see g_verboseLog for why this is not on by default.
+    // A short SendInput means the action silently did nothing, so it is always
+    // reported. Logging here is safe because it is once per trigger, not once
+    // per poll: Wh_Log goes through OutputDebugString and takes a system-wide
+    // lock, which would matter on a hot path and does not on this one.
     SetLastError(0);
     UINT sent = SendInput((UINT)inputs.size(), inputs.data(), sizeof(INPUT));
     if (sent != inputs.size())
     {
         Wh_Log(L"SendInput FAILED: sent %u/%u, err=%lu (sizeof(INPUT)=%d)",
                sent, (UINT)inputs.size(), GetLastError(), (int)sizeof(INPUT));
+
+        // A short send can stop between a key-down and its matching key-up,
+        // which leaves that key logically held for the rest of the session —
+        // a stuck Win or Ctrl the user cannot clear without logging out. The
+        // release events are already built as the second half of the batch,
+        // and releasing a key that is already up does nothing, so replay all
+        // of them. Nothing was pressed if nothing was sent.
+        if (sent > 0)
+            SendInput((UINT)n, inputs.data() + n, sizeof(INPUT));
     }
-    else if (g_verboseLog)
+    else
     {
         Wh_Log(L"SendInput ok: %u events, first vk=0x%02X", sent,
                (unsigned)vks[0]);
@@ -2065,11 +1575,18 @@ static void ActionTaskView() { SendKeys({VK_LWIN, VK_TAB}); }
 //
 // Broadcasting reaches every top-level window, so at least one will route it.
 // Runs on the worker thread, so the blocking call cannot delay detection.
+// Broadcast, because posting to the foreground window does not work: after
+// LockWorkStation there is no foreground window on this desktop, and the
+// GetDesktopWindow fallback handles nothing.
+//
+// SendNotifyMessage rather than SendMessageTimeout: a broadcast applies the
+// timeout to *every* top-level window in turn, so one slow process could hold
+// the worker thread for seconds and stall every queued action behind it.
+// SendNotifyMessage returns immediately for windows owned by other threads,
+// which is all of them here.
 static void BroadcastSysCommand(WPARAM command, LPARAM param)
 {
-    DWORD_PTR result = 0;
-    SendMessageTimeoutW(HWND_BROADCAST, WM_SYSCOMMAND, command, param,
-                        SMTO_ABORTIFHUNG, 500, &result);
+    SendNotifyMessageW(HWND_BROADCAST, WM_SYSCOMMAND, command, param);
 }
 
 static void ActionScreenSaver()
@@ -2140,7 +1657,7 @@ static void ActionLockAndMonitorsOff()
     // The lock transition itself counts as activity, so blanking too soon
     // just wakes the display straight back up. How long the switch to the
     // secure desktop takes varies by machine, hence the setting.
-    Sleep((DWORD)g_lockBlankDelayMs);
+    Sleep((DWORD)g_lockBlankDelayMs.load());
     BroadcastSysCommand(SC_MONITORPOWER, (LPARAM)2);
 }
 
@@ -2189,6 +1706,12 @@ static void ActionStartProcess(const std::wstring &command)
         verb = L"runas";
         cmd = TrimStr(cmd.substr(4));
     }
+
+    // "uac;" with nothing after it would reach CommandLineToArgvW with an
+    // empty string, which returns the *host process* path as argv[0] — so a
+    // stray prefix would relaunch windhawk.exe elevated.
+    if (cmd.empty())
+        return;
 
     // CommandLineToArgvW handles unquoted paths with spaces correctly.
     std::wstring exe, params;
@@ -2354,52 +1877,6 @@ static const wchar_t *ActionToString(CornerAction a)
     case CornerAction::StartProcess: return L"Custom Command";
     }
     return L"Unknown";
-}
-
-// Inverse of ParseActionType: the stable id a value store / settings file uses.
-static const wchar_t *ActionIdFromEnum(CornerAction a)
-{
-    switch (a)
-    {
-    case CornerAction::Nothing: return L"ACTION_NOTHING";
-    case CornerAction::ShowDesktop: return L"ACTION_SHOW_DESKTOP";
-    case CornerAction::TaskView: return L"ACTION_TASK_VIEW";
-    case CornerAction::ScreenSaver: return L"ACTION_SCREENSAVER";
-    case CornerAction::MonitorsOff: return L"ACTION_MONITORS_OFF";
-    case CornerAction::QuickSettings: return L"ACTION_QUICK_SETTINGS";
-    case CornerAction::NotificationCenter: return L"ACTION_NOTIFICATION_CENTER";
-    case CornerAction::StartMenu: return L"ACTION_START_MENU";
-    case CornerAction::HideOthers: return L"ACTION_HIDE_OTHERS";
-    case CornerAction::Mute: return L"ACTION_MUTE";
-    case CornerAction::TaskManager: return L"ACTION_TASK_MANAGER";
-    case CornerAction::Lock: return L"ACTION_LOCK";
-    case CornerAction::Sleep: return L"ACTION_SLEEP";
-    case CornerAction::SwitchLastWindow: return L"ACTION_SWITCH_LAST";
-    case CornerAction::TaskSwitcher: return L"ACTION_TASK_SWITCHER";
-    case CornerAction::MinimizeWindow: return L"ACTION_MINIMIZE";
-    case CornerAction::MaximizeWindow: return L"ACTION_MAXIMIZE";
-    case CornerAction::SnapLeft: return L"ACTION_SNAP_LEFT";
-    case CornerAction::SnapRight: return L"ACTION_SNAP_RIGHT";
-    case CornerAction::CloseWindow: return L"ACTION_CLOSE_WINDOW";
-    case CornerAction::FileExplorer: return L"ACTION_FILE_EXPLORER";
-    case CornerAction::SettingsApp: return L"ACTION_SETTINGS";
-    case CornerAction::Search: return L"ACTION_SEARCH";
-    case CornerAction::ClipboardHistory: return L"ACTION_CLIPBOARD";
-    case CornerAction::Screenshot: return L"ACTION_SCREENSHOT";
-    case CornerAction::ProjectDisplay: return L"ACTION_PROJECT";
-    case CornerAction::VDesktopNext: return L"ACTION_VDESK_NEXT";
-    case CornerAction::VDesktopPrev: return L"ACTION_VDESK_PREV";
-    case CornerAction::VDesktopNew: return L"ACTION_VDESK_NEW";
-    case CornerAction::VDesktopClose: return L"ACTION_VDESK_CLOSE";
-    case CornerAction::LockAndMonitorsOff: return L"ACTION_LOCK_MONITORS_OFF";
-    case CornerAction::KeepAwakeOn: return L"ACTION_KEEP_AWAKE_ON";
-    case CornerAction::KeepAwakeOff: return L"ACTION_KEEP_AWAKE_OFF";
-    case CornerAction::AlternateKeypress: return L"ACTION_ALTERNATE_KEYPRESS";
-    case CornerAction::AlternateCommand: return L"ACTION_ALTERNATE_COMMAND";
-    case CornerAction::SendKeypress: return L"ACTION_SEND_KEYPRESS";
-    case CornerAction::StartProcess: return L"ACTION_START_PROCESS";
-    }
-    return L"ACTION_NOTHING";
 }
 
 static const wchar_t *ZoneToString(Zone z)
@@ -2615,11 +2092,6 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
     int csCfg = g_settings.cornerSize > 0 ? g_settings.cornerSize : 1;
     int esCfg = g_settings.edgeSize > 0 ? g_settings.edgeSize : 1;
 
-    set->activationDelay = g_settings.activationDelay;
-    set->settleMs = g_settings.settleMs;
-    set->knockWindowMs = g_settings.knockWindowMs;
-    set->requireModifier = g_settings.requireModifier;
-    set->cooldownMs = g_settings.cooldownMs;
     set->disableDuringDrag = g_settings.disableDuringDrag;
 
     for (const auto &mon : g_monitors)
@@ -2672,6 +2144,15 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
         int esLeft = edgeThickness(ZONE_EDGE_LEFT, csTL, csBL);
         int esRight = edgeThickness(ZONE_EDGE_RIGHT, csTR, csBR);
 
+        // An edge with a centre zone becomes two rectangles, but it is still one
+        // edge: walking into the left half and then the right must give A then
+        // B, not A then A. MakeExecutor builds a fresh flip flag on every call,
+        // so build one per zone here and hand out copies - copying a
+        // std::function copies the captured shared_ptr, and that shared flag is
+        // exactly the state the two halves need to agree on. Per monitor, so
+        // two displays still alternate independently.
+        std::function<void()> altExec[ZONE_COUNT];
+
         auto add = [&](Zone z, RECT rect)
         {
             const ZoneConfig *zc = ResolveZone(mon, z);
@@ -2680,14 +2161,14 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
             HitZone hz;
             hz.rect = rect;
             hz.zone = z;
+            hz.monitor = mon.handle;
 
             if (zc->action == CornerAction::AlternateKeypress ||
                 zc->action == CornerAction::AlternateCommand)
             {
-                // Alternating actions keep their flip state inside the
-                // executor, so each zone needs its own rather than a shared
-                // copy from the configuration.
-                hz.exec = MakeExecutor(zc->action, zc->args);
+                if (!altExec[z])
+                    altExec[z] = MakeExecutor(zc->action, zc->args);
+                hz.exec = altExec[z];
                 if (!hz.exec)
                     return;
             }
@@ -2869,23 +2350,29 @@ static DWORD WINAPI ActionWorkerThread(LPVOID)
             excluded = g_settings.excludedProcesses;
             LeaveCriticalSection(&g_settingsLock);
 
-            // Suppression is normal, not an error — logging it every time
-            // would spam hardest in exactly the case it matters least
-            // (holding a corner while a fullscreen game has focus).
-            if (checkFullscreen && IsFullScreenAppActive())
+            // Suppression is normal, not an error, and it spams hardest in the
+            // case it matters least: parking the cursor in a corner while a
+            // fullscreen game has focus re-queues the job every cooldown.
+            // Report the first skip of a run, then stay quiet until something
+            // actually fires. Only this thread touches the flag.
+            static bool skipLogged = false;
+            HMONITOR fsMon = checkFullscreen ? FullScreenMonitor() : nullptr;
+            if (fsMon && (fsMon == kAllMonitors || fsMon == job.monitor))
             {
-                if (g_verboseLog)
+                if (!skipLogged)
                     Wh_Log(L"SKIP (fullscreen): %s", job.label.c_str());
+                skipLogged = true;
                 continue;
             }
             if (IsForegroundAppExcluded(excluded))
             {
-                if (g_verboseLog)
+                if (!skipLogged)
                     Wh_Log(L"SKIP (excluded app): %s", job.label.c_str());
+                skipLogged = true;
                 continue;
             }
+            skipLogged = false;
 
-            if (g_verboseLog)
             {
                 WCHAR fgClass[64] = L"?";
                 GetClassName(GetForegroundWindow(), fgClass,
@@ -2931,10 +2418,11 @@ static bool AnyMouseButtonDown()
            (GetAsyncKeyState(VK_XBUTTON2) & 0x8000);
 }
 
-static void DetectTick()
+// Returns how long the caller should wait before ticking again.
+static DWORD DetectTick()
 {
     if (!g_trayEnabled.load() || GetTickCount64() < g_suspendUntil.load())
-        return;
+        return kIdleTickMs;
 
     std::shared_ptr<const ZoneSet> zones;
     EnterCriticalSection(&g_zonesLock);
@@ -2942,11 +2430,11 @@ static void DetectTick()
     LeaveCriticalSection(&g_zonesLock);
 
     if (!zones || zones->zones.empty())
-        return;
+        return kIdleTickMs;
 
     POINT pt;
     if (!GetCursorPos(&pt))
-        return;
+        return kIdleTickMs;
 
     int idx = -1;
     for (size_t i = 0; i < zones->zones.size(); i++)
@@ -2960,7 +2448,17 @@ static void DetectTick()
         }
     }
 
+    // Full rate whenever a zone could fire, with no exceptions. Two attempts at
+    // easing off while the cursor was far away are gone: both scheduled a long
+    // sleep from a sample taken *before* the user started moving, so a flick
+    // could cross a zone entirely between two samples. On the outer perimeter
+    // that only costs a late trigger, because the pointer stops against the
+    // screen edge - but a corner shared with a second monitor has no edge to
+    // stop against, and there it was a lost one. No polling interval can close
+    // that; only an event source could, and 16 ms of GetCursorPos plus a dozen
+    // rectangle compares was never the cost worth taking the risk for.
     ULONGLONG now = GetTickCount64();
+    const DWORD next = kTickMs;
 
     // Enter/leave edge detection, the same shape macOS uses: a zone fires
     // once on entry and re-arms only after the cursor leaves it.
@@ -2985,15 +2483,15 @@ static void DetectTick()
     }
 
     if (idx < 0 || g_firedThisEntry)
-        return;
+        return next;
 
     if (!g_knockSatisfied)
-        return;
+        return next;
 
     // Checked every tick rather than on entry, so the zone becomes live the
     // moment the modifier goes down while the cursor is already parked.
     if (!RequiredModifierHeld(zones->zones[idx].modifier))
-        return;
+        return next;
 
     // Suppress for the whole visit, not just this tick — otherwise releasing
     // a drag inside a corner would immediately trigger it.
@@ -3002,7 +2500,7 @@ static void DetectTick()
     if (zones->disableDuringDrag && AnyMouseButtonDown())
     {
         g_firedThisEntry = true;
-        return;
+        return next;
     }
 
     // A corner cannot be reached without crossing the edge strip next to it,
@@ -3013,7 +2511,7 @@ static void DetectTick()
     // the zone you actually stop in does.
     int dwell = hz.delay > hz.settle ? hz.delay : hz.settle;
     if (dwell > 0 && (now - g_enterTick) < (ULONGLONG)dwell)
-        return;
+        return next;
 
     if (hz.cooldown > 0 && idx < (int)g_lastFireTick.size())
     {
@@ -3021,7 +2519,7 @@ static void DetectTick()
         if (last != 0 && (now - last) < (ULONGLONG)hz.cooldown)
         {
             g_firedThisEntry = true;
-            return;
+            return next;
         }
     }
 
@@ -3031,7 +2529,7 @@ static void DetectTick()
         (now - g_lastAnyFireTick) < kMinFireIntervalMs)
     {
         g_firedThisEntry = true;
-        return;
+        return next;
     }
 
     g_firedThisEntry = true;
@@ -3040,6 +2538,7 @@ static void DetectTick()
         g_lastFireTick[idx] = now;
 
     EnqueueAction(zones->zones[idx]);
+    return next;
 }
 
 // =====================================================================
@@ -3117,9 +2616,7 @@ static DWORD WINAPI DetectThread(LPVOID)
             }
         }
 
-        DetectTick();
-
-        if (WaitForSingleObject(g_hStopEvent, kTickMs) == WAIT_OBJECT_0)
+        if (WaitForSingleObject(g_hStopEvent, DetectTick()) == WAIT_OBJECT_0)
             break;
     }
 
@@ -3132,185 +2629,6 @@ done:
 }
 
 // =====================================================================
-// Settings
-// =====================================================================
-
-// Windhawk rejects a settings block where a value with $options is not a
-// string, so this one setting is stored by name. Everything downstream — the
-// zones, the value store, the dashboard combo — keeps the 0-4 encoding, so the
-// mapping lives here and nowhere else.
-static int ParseModifierName(const wchar_t *s)
-{
-    static const wchar_t *kNames[] = {L"none", L"ctrl", L"alt", L"shift",
-                                      L"win"};
-    for (int i = 0; i < (int)ARRAYSIZE(kNames); i++)
-        if (_wcsicmp(s, kNames[i]) == 0)
-            return i;
-
-    // Versions up to 4.0.2 stored a number here. Keep those configurations
-    // working instead of silently resetting them to "none".
-    if (s[0] >= L'0' && s[0] <= L'4' && s[1] == L'\0')
-        return s[0] - L'0';
-
-    return 0;
-}
-
-static void LoadSettings()
-{
-    using WindhawkUtils::StringSetting;
-
-    EnterCriticalSection(&g_settingsLock);
-
-    g_settings.cornerSize = Wh_GetIntSetting(L"CornerSize");
-    if (g_settings.cornerSize < 1)
-        g_settings.cornerSize = 6;
-
-    g_settings.edgeSize = Wh_GetIntSetting(L"EdgeSize");
-    if (g_settings.edgeSize < 1)
-        g_settings.edgeSize = 6;
-
-    g_settings.activationDelay = Wh_GetIntSetting(L"ActivationDelay");
-    if (g_settings.activationDelay < 0)
-        g_settings.activationDelay = 0;
-
-    g_settings.settleMs = Wh_GetIntSetting(L"SettleMs");
-    if (g_settings.settleMs < 0)
-        g_settings.settleMs = 0;
-
-    g_settings.knockWindowMs = Wh_GetIntSetting(L"KnockWindowMs");
-    if (g_settings.knockWindowMs < 0)
-        g_settings.knockWindowMs = 0;
-
-    g_settings.requireModifier =
-        ParseModifierName(StringSetting::make(L"RequireModifier").get());
-
-    g_settings.avoidTaskbar = Wh_GetIntSetting(L"AvoidTaskbar") != 0;
-
-    g_settings.centerZonePercent = Wh_GetIntSetting(L"CenterZonePercent");
-    if (g_settings.centerZonePercent < 1)
-        g_settings.centerZonePercent = 1;
-    if (g_settings.centerZonePercent > 90)
-        g_settings.centerZonePercent = 90;
-
-    g_settings.cooldownMs = Wh_GetIntSetting(L"CooldownMs");
-    if (g_settings.cooldownMs < 0)
-        g_settings.cooldownMs = 0;
-
-    g_settings.disableOnFullscreen = Wh_GetIntSetting(L"DisableOnFullscreen");
-    g_settings.disableDuringDrag = Wh_GetIntSetting(L"DisableDuringDrag");
-    g_verboseLog = Wh_GetIntSetting(L"VerboseLogging") != 0;
-    g_showMonitorNames = Wh_GetIntSetting(L"ShowMonitorNames") != 0;
-
-    g_lockBlankDelayMs = Wh_GetIntSetting(L"LockBlankDelayMs");
-    if (g_lockBlankDelayMs < 0)
-        g_lockBlankDelayMs = 0;
-    if (g_lockBlankDelayMs > 10000)
-        g_lockBlankDelayMs = 10000;
-
-    // Excluded processes (semicolon-separated, case-insensitive)
-    g_settings.excludedProcesses.clear();
-    {
-        std::wstring remaining =
-            std::wstring(StringSetting::make(L"ExcludedProcesses").get());
-        while (!remaining.empty())
-        {
-            auto semi = remaining.find(L';');
-            std::wstring token;
-            if (semi != std::wstring::npos)
-            {
-                token = TrimStr(remaining.substr(0, semi));
-                remaining = remaining.substr(semi + 1);
-            }
-            else
-            {
-                token = TrimStr(remaining);
-                remaining.clear();
-            }
-            if (!token.empty())
-                g_settings.excludedProcesses.push_back(ToLowerStr(token));
-        }
-    }
-
-    g_settings.monitorConfigs.clear();
-
-    static const wchar_t *zoneKeys[ZONE_COUNT] = {
-        L"TopLeft", L"TopRight",   L"BottomLeft", L"BottomRight",
-        L"EdgeTop", L"EdgeBottom", L"EdgeLeft",   L"EdgeRight",
-        L"CenterTop", L"CenterBottom", L"CenterLeft", L"CenterRight",
-    };
-
-    for (int i = 0; i < 16; i++)
-    {
-        wchar_t keyBuf[128];
-
-        // An empty action string means there is no entry at this index.
-        _snwprintf_s(keyBuf, _countof(keyBuf), _TRUNCATE,
-                     L"MonitorCorners[%d].TopLeft", i);
-        auto probe = std::wstring(StringSetting::make(keyBuf).get());
-        if (probe.empty())
-            break;
-
-        MonitorZoneConfig cfg;
-
-        _snwprintf_s(keyBuf, _countof(keyBuf), _TRUNCATE,
-                     L"MonitorCorners[%d].MonitorId", i);
-        cfg.monitorId =
-            TrimStr(std::wstring(StringSetting::make(keyBuf).get()));
-
-        _snwprintf_s(keyBuf, _countof(keyBuf), _TRUNCATE,
-                     L"MonitorCorners[%d].Monitor", i);
-        cfg.monitorIndex = Wh_GetIntSetting(keyBuf);
-
-        bool hasAnyAction = false;
-        for (int z = 0; z < ZONE_COUNT; z++)
-        {
-            _snwprintf_s(keyBuf, _countof(keyBuf), _TRUNCATE,
-                         L"MonitorCorners[%d].%s", i, zoneKeys[z]);
-            auto actionStr = std::wstring(StringSetting::make(keyBuf).get());
-
-            _snwprintf_s(keyBuf, _countof(keyBuf), _TRUNCATE,
-                         L"MonitorCorners[%d].%sArgs", i, zoneKeys[z]);
-            auto argsStr = std::wstring(StringSetting::make(keyBuf).get());
-
-            CornerAction action = ParseActionType(actionStr);
-            cfg.zones[z].action = action;
-            cfg.zones[z].args = argsStr;
-            cfg.zones[z].executor = MakeExecutor(action, argsStr);
-
-            if (action != CornerAction::Nothing)
-                hasAnyAction = true;
-        }
-
-        if (!hasAnyAction)
-            continue;
-
-        // The resolved result is printed by BuildZoneSet as "Active zones";
-        // repeating every zone here just doubled the noise.
-        Wh_Log(L"Configuration %d applies to: %s", i + 1,
-               cfg.monitorId.empty()
-                   ? (cfg.monitorIndex == 0
-                          ? L"every monitor (legacy: Monitor Number 0)"
-                          : L"a monitor by number (legacy)")
-                   : cfg.monitorId.c_str());
-
-        g_settings.monitorConfigs.push_back(std::move(cfg));
-    }
-
-    Wh_Log(L"Sizes: corner %dpx, edge %dpx.  Timing: delay %dms, "
-           L"pass-through guard %dms, cooldown %dms.",
-           g_settings.cornerSize, g_settings.edgeSize,
-           g_settings.activationDelay, g_settings.settleMs,
-           g_settings.cooldownMs);
-    Wh_Log(L"Skip while fullscreen: %s.  Skip while dragging: %s.  "
-           L"Excluded apps: %d.",
-           g_settings.disableOnFullscreen ? L"yes" : L"no",
-           g_settings.disableDuringDrag ? L"yes" : L"no",
-           (int)g_settings.excludedProcesses.size());
-
-    LeaveCriticalSection(&g_settingsLock);
-}
-
-// =====================================================================
 // Tray Icon
 // =====================================================================
 //
@@ -3319,11 +2637,9 @@ static void LoadSettings()
 // closes, so hosting it on the detection thread would freeze every zone for
 // as long as the menu is open.
 //
-// Settings that the tray can change are stored as *overrides* in the mod's own
-// value store (Wh_GetIntValue / Wh_SetIntValue). Windhawk settings themselves
-// are read-only from inside a mod, so the tray cannot write what you see on
-// the Settings page. Overrides are applied on top of the settings at load, and
-// "Clear tray overrides" removes them.
+// The icon is also the only way in: this mod has no Windhawk settings page, so
+// left-click toggles, right-click is the quick menu, and the menu's first item
+// opens the dashboard where everything else lives.
 
 static HANDLE g_hTrayThread = nullptr;
 static DWORD g_dwTrayThreadId = 0;
@@ -3374,7 +2690,6 @@ enum TrayCommand
     IDM_RESUME,
     IDM_FULLSCREEN,
     IDM_DRAG,
-    IDM_VERBOSE,
     IDM_CLEAR_OVERRIDES,
     IDM_ABOUT,
 };
@@ -3386,7 +2701,6 @@ static void OpenDashboard();
 static const wchar_t *kOvrEnabled = L"ovr_enabled";
 static const wchar_t *kOvrFullscreen = L"ovr_fullscreen";
 static const wchar_t *kOvrDrag = L"ovr_drag";
-static const wchar_t *kOvrVerbose = L"ovr_verbose";
 
 static HICON MakeTrayIcon(bool enabled)
 {
@@ -3436,7 +2750,11 @@ static HICON MakeTrayIcon(bool enabled)
         }
     }
 
-    HBITMAP hMask = CreateBitmap(sz, sz, 1, 1, nullptr);
+    // Explicitly zeroed. Transparency here comes from the colour bitmap's
+    // alpha channel, so undefined mask bits happen to work, but "happens to"
+    // is not a property worth relying on.
+    std::vector<BYTE> maskBits(((sz + 15) / 16) * 2 * sz, 0);
+    HBITMAP hMask = CreateBitmap(sz, sz, 1, 1, maskBits.data());
     ICONINFO ii = {};
     ii.fIcon = TRUE;
     ii.hbmColor = hColor;
@@ -3513,13 +2831,12 @@ static void UpdateTrayIcon(bool add)
 // Dashboard persistence
 // =====================================================================
 //
-// The dashboard cannot write the Windhawk Settings page — Wh_GetIntSetting is
-// read-only from inside a mod. Everything it changes is therefore stored in
-// the mod's own value store and layered over the settings at load. "Reset to
-// Windhawk settings" clears the whole layer.
+// This is the whole of the mod's persistence. There is no Windhawk settings
+// page to fall back on, so what is written here is what the mod runs with, and
+// a key that has never been written falls back to the default ReloadConfig set.
 //
-// One key per field rather than a packed string: verbose, but it survives
-// partial writes and is readable if anything ever needs debugging by hand.
+// One key per field rather than a packed string: wordy, but it survives partial
+// writes and is readable if anything ever needs debugging by hand.
 
 static constexpr int kMaxGuiConfigs = 8;
 
@@ -3541,14 +2858,17 @@ static std::wstring GuiKey(int cfg, int zone, const wchar_t *what)
     return k;
 }
 
-// Replaces g_settings.monitorConfigs when the dashboard has saved a layout.
-// Caller must hold g_settingsLock.
-static bool ApplyDashboardZones()
+// The saved zone layout, or an empty vector if there is not one yet. Returns it
+// rather than assigning g_settings.monitorConfigs: this reads several hundred
+// value-store keys and builds a std::function per zone, and holding
+// g_settingsLock across all of that would stall the detection thread, the
+// action worker and the tray menu.
+static std::vector<MonitorZoneConfig> ReadDashboardZones()
 {
-    if (Wh_GetIntValue(L"gui_active", 0) == 0)
-        return false;
-
     std::vector<MonitorZoneConfig> configs;
+    if (Wh_GetIntValue(L"gui_active", 0) == 0)
+        return configs;
+
     for (int i = 0; i < kMaxGuiConfigs; i++)
     {
         std::wstring id = GetStrValue(GuiKey(i, -1, L"id").c_str());
@@ -3580,19 +2900,23 @@ static bool ApplyDashboardZones()
         if (any)
             configs.push_back(std::move(cfg));
     }
-
-    if (configs.empty())
-        return false;
-
-    g_settings.monitorConfigs = std::move(configs);
-    Wh_Log(L"Using the dashboard's zone layout (%d configuration%s)",
-           (int)g_settings.monitorConfigs.size(),
-           g_settings.monitorConfigs.size() == 1 ? L"" : L"s");
-    return true;
+    return configs;
 }
 
-static void ClearDashboardConfig()
+// Back to a fresh install. -1 is the "never written" marker every reader tests
+// for, so this is a reset rather than a write of zeroes.
+static void ClearStoredConfig()
 {
+    // Every scalar the dashboard and the tray can write. Missing one here used
+    // to leave it behind after a Reset, still applied but no longer visible.
+    for (const wchar_t *k :
+         {kOvrEnabled, kOvrFullscreen, kOvrDrag, L"ovr_corner", L"ovr_edge",
+          L"ovr_delay", L"ovr_settle", L"ovr_knock", L"ovr_cooldown",
+          L"ovr_centre", L"ovr_modifier", L"ovr_lockblank", L"ovr_taskbar",
+          L"ovr_monnames"})
+        Wh_SetIntValue(k, -1);
+    Wh_SetStringValue(L"ovr_excluded", L"");
+
     Wh_SetIntValue(L"gui_active", 0);
     for (int i = 0; i < kMaxGuiConfigs; i++)
     {
@@ -3607,84 +2931,112 @@ static void ClearDashboardConfig()
     }
 }
 
-static void ApplyTrayOverrides()
+// The whole of this mod's configuration, read and applied as one transaction.
+//
+// Built into a local first, with no lock held: this reads every key in the
+// value store and constructs a std::function per zone, and three other threads
+// want g_settingsLock while that happens - the detection thread in
+// BuildZoneSet, the action worker before every trigger, and the tray thread
+// building its menu. The lock is taken once, for the swap.
+//
+// Doing it in two phases (defaults, then the stored values on top) left a
+// window in which g_settings was a complete, plausible, *wrong* configuration:
+// a rebuild landing in that window published an empty zone set and logged "No
+// zones are active". Four of the six callers run on a thread other than the
+// one that starts the mod, so that window was reachable.
+//
+// Keys still carry the historical "ovr_" prefix - back when there was a
+// Windhawk settings page these were overrides on top of it. They are the
+// configuration itself now; the prefix stays so an existing setup is not
+// orphaned. An unset key reads back as -1, which fails every range test below,
+// so a value the user has never touched simply keeps its default.
+static void ReloadConfig()
 {
-    // Called after LoadSettings so overrides win over the settings page.
+    ModSettings s;   // the member initialisers are the defaults
+
     int v = Wh_GetIntValue(kOvrEnabled, -1);
     g_trayEnabled = (v < 0) ? true : (v != 0);
 
-    // g_settings is read by the worker thread under this lock, so take it
-    // here too rather than writing the fields from underneath it.
-    EnterCriticalSection(&g_settingsLock);
-
     v = Wh_GetIntValue(kOvrFullscreen, -1);
     if (v >= 0)
-        g_settings.disableOnFullscreen = (v != 0);
+        s.disableOnFullscreen = (v != 0);
 
     v = Wh_GetIntValue(kOvrDrag, -1);
     if (v >= 0)
-        g_settings.disableDuringDrag = (v != 0);
+        s.disableDuringDrag = (v != 0);
 
+    auto pull = [](const wchar_t *k, int &dst, int lo, int hi)
+    {
+        int x = Wh_GetIntValue(k, -1);
+        if (x >= lo && x <= hi)
+            dst = x;
+    };
+    pull(L"ovr_corner", s.cornerSize, 1, 500);
+    pull(L"ovr_edge", s.edgeSize, 1, 500);
+    pull(L"ovr_delay", s.activationDelay, 0, 10000);
+    pull(L"ovr_settle", s.settleMs, 0, 10000);
+    pull(L"ovr_knock", s.knockWindowMs, 0, 10000);
+    pull(L"ovr_cooldown", s.cooldownMs, 0, 60000);
+    pull(L"ovr_centre", s.centerZonePercent, 1, 90);
+    pull(L"ovr_modifier", s.requireModifier, 0, 4);
+
+    int x = Wh_GetIntValue(L"ovr_taskbar", -1);
+    if (x >= 0)
+        s.avoidTaskbar = (x != 0);
+
+    // Via a local: pull takes int&, and these two globals are atomic because
+    // other threads read them while this runs.
+    int lockBlank = 1200;
+    pull(L"ovr_lockblank", lockBlank, 0, 10000);
+    g_lockBlankDelayMs = lockBlank;
+    x = Wh_GetIntValue(L"ovr_monnames", -1);
+    g_showMonitorNames = (x < 0) ? true : (x != 0);
+
+    // s starts empty, so clearing the field in the dashboard genuinely clears
+    // the list - no "if the stored string is non-empty" guard needed.
+    std::wstring rest = GetStrValue(L"ovr_excluded");
+    while (!rest.empty())
+    {
+        auto semi = rest.find(L';');
+        std::wstring tok;
+        if (semi != std::wstring::npos)
+        {
+            tok = TrimStr(rest.substr(0, semi));
+            rest = rest.substr(semi + 1);
+        }
+        else
+        {
+            tok = TrimStr(rest);
+            rest.clear();
+        }
+        if (!tok.empty())
+            s.excludedProcesses.push_back(ToLowerStr(tok));
+    }
+
+    s.monitorConfigs = ReadDashboardZones();
+
+    // Copied out before the move, so the summary can be logged after the lock
+    // is released - Wh_Log goes through OutputDebugString and takes a
+    // machine-wide lock of its own.
+    const int zoneCount = (int)s.monitorConfigs.size();
+    const int cs = s.cornerSize, es = s.edgeSize, dl = s.activationDelay;
+    const int st = s.settleMs, cd = s.cooldownMs;
+    const int nx = (int)s.excludedProcesses.size();
+    const bool fs = s.disableOnFullscreen, dg = s.disableDuringDrag;
+
+    EnterCriticalSection(&g_settingsLock);
+    g_settings = std::move(s);
     LeaveCriticalSection(&g_settingsLock);
 
-    v = Wh_GetIntValue(kOvrVerbose, -1);
-    if (v >= 0)
-        g_verboseLog = (v != 0);
-
-    // Everything the dashboard writes.
-    if (Wh_GetIntValue(L"gui_active", 0) != 0)
-    {
-        EnterCriticalSection(&g_settingsLock);
-        auto pull = [](const wchar_t *k, int &dst, int lo, int hi)
-        {
-            int x = Wh_GetIntValue(k, -1);
-            if (x >= lo && x <= hi)
-                dst = x;
-        };
-        pull(L"ovr_corner", g_settings.cornerSize, 1, 500);
-        pull(L"ovr_edge", g_settings.edgeSize, 1, 500);
-        pull(L"ovr_delay", g_settings.activationDelay, 0, 10000);
-        pull(L"ovr_settle", g_settings.settleMs, 0, 10000);
-        pull(L"ovr_knock", g_settings.knockWindowMs, 0, 10000);
-        pull(L"ovr_cooldown", g_settings.cooldownMs, 0, 60000);
-        pull(L"ovr_centre", g_settings.centerZonePercent, 1, 90);
-        pull(L"ovr_modifier", g_settings.requireModifier, 0, 4);
-        pull(L"ovr_lockblank", g_lockBlankDelayMs, 0, 10000);
-
-        int x = Wh_GetIntValue(L"ovr_taskbar", -1);
-        if (x >= 0)
-            g_settings.avoidTaskbar = (x != 0);
-        x = Wh_GetIntValue(L"ovr_monnames", -1);
-        if (x >= 0)
-            g_showMonitorNames = (x != 0);
-
-        std::wstring excl = GetStrValue(L"ovr_excluded");
-        if (!excl.empty())
-        {
-            g_settings.excludedProcesses.clear();
-            std::wstring rest = excl;
-            while (!rest.empty())
-            {
-                auto semi = rest.find(L';');
-                std::wstring tok;
-                if (semi != std::wstring::npos)
-                {
-                    tok = TrimStr(rest.substr(0, semi));
-                    rest = rest.substr(semi + 1);
-                }
-                else
-                {
-                    tok = TrimStr(rest);
-                    rest.clear();
-                }
-                if (!tok.empty())
-                    g_settings.excludedProcesses.push_back(ToLowerStr(tok));
-            }
-        }
-
-        ApplyDashboardZones();
-        LeaveCriticalSection(&g_settingsLock);
-    }
+    if (zoneCount)
+        Wh_Log(L"Using the dashboard's zone layout (%d configuration%s)",
+               zoneCount, zoneCount == 1 ? L"" : L"s");
+    Wh_Log(L"Sizes: corner %dpx, edge %dpx.  Timing: delay %dms, "
+           L"pass-through guard %dms, cooldown %dms.",
+           cs, es, dl, st, cd);
+    Wh_Log(L"Skip while fullscreen: %s.  Skip while dragging: %s.  "
+           L"Excluded apps: %d.",
+           fs ? L"yes" : L"no", dg ? L"yes" : L"no", nx);
 }
 
 static void ShowTrayMenu(POINT pt)
@@ -3695,7 +3047,7 @@ static void ShowTrayMenu(POINT pt)
 
     bool suspended = GetTickCount64() < g_suspendUntil.load();
 
-    AppendMenuW(hMenu, MF_STRING, IDM_SETTINGS, L"Mod Settings...");
+    AppendMenuW(hMenu, MF_STRING, IDM_SETTINGS, L"Zones && settings...");
     SetMenuDefaultItem(hMenu, IDM_SETTINGS, FALSE);
     AppendMenuW(hMenu, MF_SEPARATOR, 0, nullptr);
     AppendMenuW(hMenu, MF_STRING | (g_trayEnabled ? MF_CHECKED : 0),
@@ -3724,12 +3076,10 @@ static void ShowTrayMenu(POINT pt)
                 L"Skip while an app is fullscreen");
     AppendMenuW(hMenu, MF_STRING | (drag ? MF_CHECKED : 0), IDM_DRAG,
                 L"Skip while dragging the mouse");
-    AppendMenuW(hMenu, MF_STRING | (g_verboseLog ? MF_CHECKED : 0),
-                IDM_VERBOSE, L"Verbose logging");
 
     AppendMenuW(hMenu, MF_SEPARATOR, 0, nullptr);
     AppendMenuW(hMenu, MF_STRING, IDM_CLEAR_OVERRIDES,
-                L"Reset to Windhawk settings");
+                L"Reset these toggles");
     AppendMenuW(hMenu, MF_STRING | MF_DISABLED, IDM_ABOUT,
                 L"Win-X Hot Corners " WH_MOD_VERSION);
 
@@ -3799,21 +3149,17 @@ static void HandleTrayCommand(UINT id)
         break;
     }
 
-    case IDM_VERBOSE:
-        g_verboseLog = !g_verboseLog;
-        Wh_SetIntValue(kOvrVerbose, g_verboseLog ? 1 : 0);
-        break;
-
+    // Only the three toggles in this menu, and the suspend timer. Wiping the
+    // zone layout from a menu item with no confirmation would be a trap; the
+    // dashboard's Reset button does that, behind a prompt.
     case IDM_CLEAR_OVERRIDES:
         Wh_SetIntValue(kOvrEnabled, -1);
         Wh_SetIntValue(kOvrFullscreen, -1);
         Wh_SetIntValue(kOvrDrag, -1);
-        Wh_SetIntValue(kOvrVerbose, -1);
         g_suspendUntil = 0;
-        LoadSettings();
-        ApplyTrayOverrides();
+        ReloadConfig();
         RequestRebuild();
-        Wh_Log(L"Tray: overrides cleared, back to the Windhawk settings");
+        Wh_Log(L"Tray: toggles reset to defaults");
         break;
 
     default:
@@ -3908,23 +3254,26 @@ enum DashId
     IDC_TZ_COOLDOWN,
     IDC_TZ_MODIFIER,
     IDC_TZ_LAST,
+    // This order is the order they appear on the Options page, and it has to
+    // stay in step with kOpts: DashSetInt indexes hOpt by (id - IDC_OPT_FIRST).
+    // A static_assert next to kOpts enforces it.
     IDC_OPT_FIRST = 1300,
     IDC_CORNER = IDC_OPT_FIRST,
     IDC_EDGE,
+    IDC_CENTREPCT,
     IDC_DELAY,
     IDC_SETTLE,
     IDC_KNOCK,
     IDC_COOLDOWN,
-    IDC_CENTREPCT,
-    IDC_LOCKBLANK,
     IDC_MODIFIER,
     IDC_EXCLUDED,
     IDC_CB_FULLSCREEN,
     IDC_CB_DRAG,
     IDC_CB_TASKBAR,
+    IDC_LOCKBLANK,
     IDC_CB_MONNAMES,
-    IDC_CB_VERBOSE,
     IDC_OPT_LAST,
+    IDC_OPT_SECTION,   // shared by every group heading; they carry no state
 };
 
 struct DashState
@@ -3937,8 +3286,20 @@ struct DashState
     bool showZones = true;
     int hoverZone = -1;   // zone highlighted in the preview
     int selZone = 0;      // zone whose per-zone settings are being edited
-    ZoneTuning tuning[ZONE_COUNT];
+    ZoneTuning tuning[ZONE_COUNT];   // the slot currently on screen
     int cfgIndex = 0;   // which slot in the value store we are editing
+
+    // Every slot the window has touched, so switching displays does not throw
+    // the previous display's edits away and Save can write all of them. The
+    // controls only ever show one slot; this is where the other ones live.
+    struct Slot
+    {
+        bool loaded = false;
+        int action[ZONE_COUNT] = {};
+        std::wstring args[ZONE_COUNT];
+        ZoneTuning tuning[ZONE_COUNT];
+    };
+    std::vector<Slot> slots;
 
     HWND hMonitor = nullptr;
     HWND hZoneLabel[ZONE_COUNT] = {};
@@ -3946,6 +3307,8 @@ struct DashState
     HWND hZoneArgs[ZONE_COUNT] = {};
     HWND hOpt[IDC_OPT_LAST - IDC_OPT_FIRST] = {};
     HWND hOptLabel[IDC_OPT_LAST - IDC_OPT_FIRST] = {};
+    HWND hOptSection[IDC_OPT_LAST - IDC_OPT_FIRST] = {};   // null except at a
+                                                           // group heading
     HWND hHdrZone = nullptr, hHdrAction = nullptr, hHdrArgs = nullptr;
     HWND hTzTitle = nullptr, hTzHint = nullptr;
     HWND hTz[IDC_TZ_LAST - IDC_TZ_FIRST] = {};
@@ -3953,6 +3316,8 @@ struct DashState
     HWND hTip = nullptr;
     HWND hPageZones = nullptr, hPageOptions = nullptr;
     HWND hSave = nullptr, hCancel = nullptr, hReset = nullptr;
+    // WM_SETICON does not take ownership; whoever created the icon destroys it.
+    HICON hIcon = nullptr;
 };
 
 static int Sc(int px, UINT dpi) { return MulDiv(px, (int)dpi, 96); }
@@ -3966,6 +3331,7 @@ constexpr int Pad = 16;
 constexpr int Gap = 8;
 constexpr int RowH = 30;
 constexpr int CheckH = 26;
+constexpr int SecH = 30;   // group heading plus the air above it
 constexpr int TabH = 28;
 constexpr int CtlH = 24;
 constexpr int BtnH = 32;
@@ -3988,7 +3354,9 @@ constexpr int ZonesLeftH = Pad + TabH + Gap + CtlH + Gap + HdrH + ZONE_COUNT * R
 constexpr int ZonesRightH = Pad + TabH + Gap + CtlH + Gap + DiagH + TzPanelH;
 constexpr int ZonesH = ZonesLeftH > ZonesRightH ? ZonesLeftH : ZonesRightH;
 // Options page: ten labelled controls, five checkboxes.
-constexpr int OptionsH = Pad + TabH + Gap + 10 * RowH + 5 * CheckH;
+// Ten labelled controls, four checkboxes, four group headings. kOpts is
+// declared further down, so a static_assert beside it holds this honest.
+constexpr int OptionsH = Pad + TabH + Gap + 10 * RowH + 4 * CheckH + 4 * SecH;
 
 constexpr int ContentH = ZonesH > OptionsH ? ZonesH : OptionsH;
 constexpr int ClientH = ContentH + Gap * 2 + BtnH + Pad;
@@ -4062,19 +3430,91 @@ static bool ZoneHasTwoParts(Zone z)
 // SetWindowTheme only stops theming a control when *both* strings are empty,
 // and a still-themed control ignores colour messages such as
 // TTM_SETTIPBKCOLOR — which is why the tooltip stayed light.
+// Resolved once: theming runs about forty times while the dashboard is built,
+// and the LoadLibraryEx fallback used to take a reference every time without
+// ever releasing it.
+static HMODULE UxTheme()
+{
+    static HMODULE ux = []() -> HMODULE
+    {
+        HMODULE m = GetModuleHandleW(L"uxtheme.dll");
+        if (!m)
+            m = LoadLibraryExW(L"uxtheme.dll", nullptr,
+                               LOAD_LIBRARY_SEARCH_SYSTEM32);
+        return m;
+    }();
+    return ux;
+}
+
 static void ThemeControl(HWND h, const wchar_t *theme,
                          const wchar_t *subIdList = nullptr)
 {
-    HMODULE ux = GetModuleHandleW(L"uxtheme.dll");
-    if (!ux)
-        ux = LoadLibraryExW(L"uxtheme.dll", nullptr,
-                            LOAD_LIBRARY_SEARCH_SYSTEM32);
-    if (!ux)
-        return;
     using Fn = HRESULT(WINAPI *)(HWND, LPCWSTR, LPCWSTR);
-    auto fn = reinterpret_cast<Fn>(GetProcAddress(ux, "SetWindowTheme"));
+    static Fn fn =
+        UxTheme() ? reinterpret_cast<Fn>(
+                        GetProcAddress(UxTheme(), "SetWindowTheme"))
+                  : nullptr;
     if (fn)
         fn(h, theme, subIdList);
+}
+
+// Dark mode for the standard controls is only reachable through uxtheme
+// exports that have no names, just ordinals. This matters more than it looks:
+// naming a control's theme "DarkMode_CFD" does *nothing* until the process has
+// asked for dark mode here first. Without these two calls the combo boxes,
+// edits, buttons and check boxes stay on the light theme and paint their own
+// text in near-black — over the dark background this window draws — and no
+// amount of WM_CTLCOLOR* can override it, because the theme does that drawing,
+// not the parent.
+//
+// Ordinal 135 is SetPreferredAppMode on 1903 and later, and AllowDarkModeForApp
+// on 1809; both take an int and both do the right thing with ForceDark.
+// Ordinal 133 is AllowDarkModeForWindow. Missing ordinals just leave the window
+// light, which is exactly the old behaviour.
+enum DarkAppMode
+{
+    kAppModeDefault = 0,
+    kAppModeAllowDark = 1,
+    kAppModeForceDark = 2,
+    kAppModeForceLight = 3,
+};
+
+static void SetProcessDarkMode(bool dark)
+{
+    using Fn = int(WINAPI *)(int);
+    static Fn fn = UxTheme() ? reinterpret_cast<Fn>(GetProcAddress(
+                                   UxTheme(), MAKEINTRESOURCEA(135)))
+                             : nullptr;
+    if (fn)
+        fn(dark ? kAppModeForceDark : kAppModeForceLight);
+}
+
+static void AllowDarkModeForControl(HWND h, bool dark)
+{
+    using Fn = BOOL(WINAPI *)(HWND, BOOL);
+    static Fn fn = UxTheme() ? reinterpret_cast<Fn>(GetProcAddress(
+                                   UxTheme(), MAKEINTRESOURCEA(133)))
+                             : nullptr;
+    if (fn)
+        fn(h, dark ? TRUE : FALSE);
+}
+
+// The theme class a control needs depends on what it is: the "common file
+// dialog" classes cover combo boxes and edits, Explorer's cover buttons and
+// check boxes. Getting this wrong is silent - the control simply stays light.
+static void ApplyControlTheme(HWND h, const wchar_t *cls)
+{
+    if (!h)
+        return;
+
+    AllowDarkModeForControl(h, !g_lightTheme);
+
+    if (_wcsicmp(cls, L"BUTTON") == 0)
+        ThemeControl(h, g_lightTheme ? L"Explorer" : L"DarkMode_Explorer");
+    else
+        ThemeControl(h, g_lightTheme ? L"CFD" : L"DarkMode_CFD");
+
+    SendMessageW(h, WM_THEMECHANGED, 0, 0);
 }
 
 // Dark title bar, and Mica where the build supports it. Both are no-ops on
@@ -4164,25 +3604,64 @@ struct OptDef
     const wchar_t *label;
     bool isCheck;
     const wchar_t *tip;
+    // Heading drawn above this row, or nullptr to continue the current group.
+    // Fourteen fields in one flat column was a wall; four short groups is the
+    // same information you can actually scan.
+    const wchar_t *section;
 };
-static const OptDef kOpts[] = {
-    {IDC_CORNER, L"Corner size (px)", false, L"Default size of the four corner squares. Individual corners can override this on the Zones page."},
-    {IDC_EDGE, L"Edge size (px)", false, L"Default thickness of the edge strips. An edge is always clamped to the smaller of the two corners it runs between."},
-    {IDC_DELAY, L"Activation delay (ms)", false, L"How long the cursor must dwell before a zone fires. 0 is immediate."},
-    {IDC_SETTLE, L"Pass-through guard (ms)", false, L"Stops a zone firing when you only cross it. You cannot reach a corner without crossing the edge beside it, so without this both would fire."},
-    {IDC_KNOCK, L"Knock window (ms, 0 = off)", false, L"Require entering a zone twice in quick succession, like knocking. The strongest guard against accidental triggers."},
-    {IDC_COOLDOWN, L"Cooldown (ms)", false, L"Minimum gap before the same zone can fire again."},
-    {IDC_CENTREPCT, L"Centre zone width (%)", false, L"How much of an edge the centre zone takes. Only affects edges where a centre action is assigned."},
-    {IDC_LOCKBLANK, L"Blank delay after lock (ms)", false, L"Only used by the Lock and Turn Off Monitors action. Locking counts as activity, so blanking too early just wakes the display."},
-    {IDC_MODIFIER, L"Require modifier", false, L"Zones stay inert unless this key is held. Individual zones can override it."},
-    {IDC_EXCLUDED, L"Excluded processes", false, L"Semicolon-separated executable names. While one of them is in the foreground, no zone fires. Example: photoshop.exe;blender.exe"},
-    {IDC_CB_FULLSCREEN, L"Skip while an app is fullscreen", true, L"Ignore zones while a game or video is fullscreen. Shell surfaces such as Task View and Start do not count."},
-    {IDC_CB_DRAG, L"Skip while dragging the mouse", true, L"Ignore zones while any mouse button is held, so dragging a window into a corner does not trigger it."},
-    {IDC_CB_TASKBAR, L"Keep zones off the taskbar", true, L"Build zones from the desktop work area, so they stop at the taskbar instead of fighting its peek-at-desktop strip."},
-    {IDC_CB_MONNAMES, L"List my monitors in the log", true, L"Writes your display names to the log so they can be copied into the monitor selector."},
-    {IDC_CB_VERBOSE, L"Verbose logging", true, L"Log every trigger. Off by default because the logging path takes a system-wide lock and can stutter other mods."},
+static constexpr OptDef kOpts[] = {
+    {IDC_CORNER, L"Corner size (px)", false, L"Default size of the four corner squares. Individual corners can override this on the Zones page.", L"How big the zones are"},
+    {IDC_EDGE, L"Edge size (px)", false, L"Default thickness of the edge strips. An edge is always clamped to the smaller of the two corners it runs between.", nullptr},
+    {IDC_CENTREPCT, L"Centre zone width (%)", false, L"How much of an edge the centre zone takes. Only affects edges where a centre action is assigned.", nullptr},
+
+    {IDC_DELAY, L"Activation delay (ms)", false, L"How long the cursor must dwell before a zone fires. 0 is immediate.", L"When a zone fires"},
+    {IDC_SETTLE, L"Pass-through guard (ms)", false, L"Stops a zone firing when you only cross it. You cannot reach a corner without crossing the edge beside it, so without this both would fire.", nullptr},
+    {IDC_KNOCK, L"Knock window (ms, 0 = off)", false, L"Require entering a zone twice in quick succession, like knocking. The strongest guard against accidental triggers.", nullptr},
+    {IDC_COOLDOWN, L"Cooldown (ms)", false, L"Minimum gap before the same zone can fire again.", nullptr},
+    {IDC_MODIFIER, L"Require modifier", false, L"Zones stay inert unless this key is held. Individual zones can override it.", nullptr},
+
+    {IDC_EXCLUDED, L"Excluded processes", false, L"Semicolon-separated executable names. While one of them is in the foreground, no zone fires. Example: photoshop.exe;blender.exe", L"When to stay out of the way"},
+    {IDC_CB_FULLSCREEN, L"Skip while an app is fullscreen", true, L"Ignore zones while a game or video is fullscreen - on that display only, so a game on one screen no longer disables the others. Shell surfaces such as Task View and Start do not count.", nullptr},
+    {IDC_CB_DRAG, L"Skip while dragging the mouse", true, L"Ignore zones while any mouse button is held, so dragging a window into a corner does not trigger it.", nullptr},
+    {IDC_CB_TASKBAR, L"Keep zones off the taskbar", true, L"Build zones from the desktop work area, so they stop at the taskbar instead of fighting its peek-at-desktop strip.", nullptr},
+
+    {IDC_LOCKBLANK, L"Blank delay after lock (ms)", false, L"Only used by the Lock and Turn Off Monitors action. Locking counts as activity, so blanking too early just wakes the display.", L"Everything else"},
+    {IDC_CB_MONNAMES, L"List my monitors in the log", true, L"Writes your display names to the log so they can be copied into the monitor selector.", nullptr},
 };
 static constexpr int kOptCount = ARRAYSIZE(kOpts);
+
+// DashSetInt / DashGetInt reach a control as hOpt[id - IDC_OPT_FIRST], so
+// reordering one of these two lists without the other silently writes the wrong
+// field. Cheaper to catch here than to notice as "the cooldown box edits the
+// corner size".
+static constexpr bool OptIdsMatchOrder()
+{
+    for (int i = 0; i < kOptCount; i++)
+        if (kOpts[i].id != IDC_OPT_FIRST + i)
+            return false;
+    return true;
+}
+static_assert(kOptCount == IDC_OPT_LAST - IDC_OPT_FIRST,
+              "kOpts and the DashId option range have different lengths");
+static_assert(OptIdsMatchOrder(),
+              "kOpts must list the option ids in DashId order");
+
+// The window is sized from Lay::OptionsH before kOpts is visible, so measure
+// the real page here and refuse to build if the two have drifted apart -
+// otherwise adding an option just pushes the last row under the button bar.
+static constexpr int OptionsPageH()
+{
+    int h = Lay::Pad + Lay::TabH + Lay::Gap;
+    for (const auto &o : kOpts)
+    {
+        if (o.section)
+            h += Lay::SecH;
+        h += o.isCheck ? Lay::CheckH : Lay::RowH;
+    }
+    return h;
+}
+static_assert(OptionsPageH() == Lay::OptionsH,
+              "Lay::OptionsH no longer matches kOpts");
 
 // A free function with CALLBACK, not a lambda: a non-capturing lambda decays
 // to a cdecl function pointer, while WNDENUMPROC is __stdcall. They happen to
@@ -4245,6 +3724,8 @@ static void DashLayout(HWND hWnd, DashState *s)
         ShowWindow(s->hOpt[i], sw);
         if (s->hOptLabel[i])
             ShowWindow(s->hOptLabel[i], sw);
+        if (s->hOptSection[i])
+            ShowWindow(s->hOptSection[i], sw);
     }
 
     SetWindowPos(s->hPageZones, nullptr, pad, pad, Sc(96, d), Sc(Lay::TabH, d),
@@ -4288,6 +3769,13 @@ static void DashLayout(HWND hWnd, DashState *s)
     {
         for (int i = 0; i < kOptCount; i++)
         {
+            if (s->hOptSection[i])
+            {
+                SetWindowPos(s->hOptSection[i], nullptr, pad, y + Sc(8, d),
+                             Sc(Lay::OptLblW + Lay::Gap + Lay::OptCtlW, d),
+                             Sc(20, d), SWP_NOZORDER);
+                y += Sc(Lay::SecH, d);
+            }
             if (kOpts[i].isCheck)
             {
                 SetWindowPos(s->hOpt[i], nullptr, pad, y,
@@ -4459,63 +3947,112 @@ static void DashCaptureZoneTuning(DashState *s)
     tn.modifier = (m <= 0) ? -1 : m - 1;
 }
 
+// The monitor name a combo entry stands for. Entry 0 is the wildcard.
+static std::wstring DashSlotMonitorId(DashState *s, int index)
+{
+    if (index <= 0)
+        return L"*";
+    wchar_t buf[256] = {};
+    if (SendMessageW(s->hMonitor, CB_GETLBTEXT, index, (LPARAM)buf) == CB_ERR)
+        return L"";
+    return buf;
+}
+
+// Reads persistence into a slot, once. Everything after that comes from the
+// in-memory copy, so an edit is never re-read over.
+static void DashFillSlotFromStore(DashState *s, int index)
+{
+    if (index < 0 || index >= (int)s->slots.size() || s->slots[index].loaded)
+        return;
+
+    DashState::Slot &sl = s->slots[index];
+    sl.loaded = true;
+
+    // The value store is the only place a zone can come from now. The old
+    // second source - seeding from the Windhawk settings page - went with the
+    // page itself, and with it the bug where the seed was picked by combo
+    // position instead of by monitor, so one display's configuration showed up
+    // under "All monitors" and then fired on every display.
+    for (int z = 0; z < ZONE_COUNT; z++)
+    {
+        std::wstring act = GetStrValue(GuiKey(index, z, L"a").c_str());
+
+        sl.action[z] = 0;
+        for (int a = 0; a < kActionCount; a++)
+        {
+            if (act == kActionIds[a])
+            {
+                sl.action[z] = a;
+                break;
+            }
+        }
+        sl.args[z] = GetStrValue(GuiKey(index, z, L"g").c_str());
+
+        ZoneTuning &tn = sl.tuning[z];
+        tn.size = Wh_GetIntValue(GuiKey(index, z, L"sz").c_str(), -1);
+        tn.delay = Wh_GetIntValue(GuiKey(index, z, L"dl").c_str(), -1);
+        tn.settle = Wh_GetIntValue(GuiKey(index, z, L"gd").c_str(), -1);
+        tn.knock = Wh_GetIntValue(GuiKey(index, z, L"kn").c_str(), -1);
+        tn.cooldown = Wh_GetIntValue(GuiKey(index, z, L"cd").c_str(), -1);
+        tn.modifier = Wh_GetIntValue(GuiKey(index, z, L"md").c_str(), -1);
+    }
+}
+
+// Controls -> the slot they were showing.
+static void DashCaptureSlot(DashState *s)
+{
+    if (s->cfgIndex < 0 || s->cfgIndex >= (int)s->slots.size())
+        return;
+
+    DashCaptureZoneTuning(s);
+    DashState::Slot &sl = s->slots[s->cfgIndex];
+    for (int z = 0; z < ZONE_COUNT; z++)
+    {
+        sl.action[z] =
+            (int)SendMessageW(s->hZoneAction[z], CB_GETCURSEL, 0, 0);
+        if (sl.action[z] < 0)
+            sl.action[z] = 0;
+        wchar_t buf[512] = {};
+        GetWindowTextW(s->hZoneArgs[z], buf, ARRAYSIZE(buf));
+        sl.args[z] = buf;
+        sl.tuning[z] = s->tuning[z];
+    }
+    sl.loaded = true;
+}
+
+// The slot -> the controls.
+static void DashShowSlot(DashState *s)
+{
+    if (s->cfgIndex < 0 || s->cfgIndex >= (int)s->slots.size())
+        return;
+
+    const DashState::Slot &sl = s->slots[s->cfgIndex];
+    for (int z = 0; z < ZONE_COUNT; z++)
+    {
+        SendMessageW(s->hZoneAction[z], CB_SETCURSEL, sl.action[z], 0);
+        SetWindowTextW(s->hZoneArgs[z], sl.args[z].c_str());
+        s->tuning[z] = sl.tuning[z];
+    }
+    DashShowZoneTuning(s);
+}
+
+// Switches the window to whichever display the combo now shows, keeping what
+// was on screen for the previous one.
 static void DashLoadZones(DashState *s)
 {
     int sel = (int)SendMessageW(s->hMonitor, CB_GETCURSEL, 0, 0);
     if (sel < 0)
         sel = 0;
+
+    if (sel != s->cfgIndex)
+        DashCaptureSlot(s);
+
     s->cfgIndex = sel;
+    if (sel >= (int)s->slots.size())
+        s->slots.resize(sel + 1);
 
-    bool fromGui = Wh_GetIntValue(L"gui_active", 0) != 0;
-
-    for (int z = 0; z < ZONE_COUNT; z++)
-    {
-        std::wstring act, args;
-        if (fromGui)
-        {
-            act = GetStrValue(GuiKey(sel, z, L"a").c_str());
-            args = GetStrValue(GuiKey(sel, z, L"g").c_str());
-        }
-        else
-        {
-            // First run: seed from whatever the Windhawk settings say.
-            EnterCriticalSection(&g_settingsLock);
-            if (sel < (int)g_settings.monitorConfigs.size())
-            {
-                act = ActionIdFromEnum(g_settings.monitorConfigs[sel].zones[z].action);
-                args = g_settings.monitorConfigs[sel].zones[z].args;
-            }
-            LeaveCriticalSection(&g_settingsLock);
-        }
-
-        int idx = 0;
-        for (int a = 0; a < kActionCount; a++)
-        {
-            if (act == kActionIds[a])
-            {
-                idx = a;
-                break;
-            }
-        }
-        SendMessageW(s->hZoneAction[z], CB_SETCURSEL, idx, 0);
-        SetWindowTextW(s->hZoneArgs[z], args.c_str());
-
-        ZoneTuning &tn = s->tuning[z];
-        if (fromGui)
-        {
-            tn.size = Wh_GetIntValue(GuiKey(sel, z, L"sz").c_str(), -1);
-            tn.delay = Wh_GetIntValue(GuiKey(sel, z, L"dl").c_str(), -1);
-            tn.settle = Wh_GetIntValue(GuiKey(sel, z, L"gd").c_str(), -1);
-            tn.knock = Wh_GetIntValue(GuiKey(sel, z, L"kn").c_str(), -1);
-            tn.cooldown = Wh_GetIntValue(GuiKey(sel, z, L"cd").c_str(), -1);
-            tn.modifier = Wh_GetIntValue(GuiKey(sel, z, L"md").c_str(), -1);
-        }
-        else
-        {
-            tn = ZoneTuning{};
-        }
-    }
-    DashShowZoneTuning(s);
+    DashFillSlotFromStore(s, sel);
+    DashShowSlot(s);
 }
 
 static void DashLoad(HWND hWnd, DashState *s)
@@ -4537,6 +4074,10 @@ static void DashLoad(HWND hWnd, DashState *s)
     for (const auto &n : names)
         SendMessageW(s->hMonitor, CB_ADDSTRING, 0, (LPARAM)n.c_str());
     SendMessageW(s->hMonitor, CB_SETCURSEL, 0, 0);
+
+    // One slot per combo entry: the wildcard plus every detected display.
+    s->slots.assign(names.size() + 1, DashState::Slot{});
+    s->cfgIndex = 0;
 
     EnterCriticalSection(&g_settingsLock);
     DashSetInt(s, IDC_CORNER, g_settings.cornerSize);
@@ -4566,42 +4107,53 @@ static void DashLoad(HWND hWnd, DashState *s)
     LeaveCriticalSection(&g_settingsLock);
     CheckDlgButton(hWnd, IDC_CB_MONNAMES,
                    g_showMonitorNames ? BST_CHECKED : BST_UNCHECKED);
-    CheckDlgButton(hWnd, IDC_CB_VERBOSE, g_verboseLog ? BST_CHECKED
-                                                      : BST_UNCHECKED);
 
     DashLoadZones(s);
 }
 
 static void DashSave(HWND hWnd, DashState *s)
 {
-    DashCaptureZoneTuning(s);
-    // Zones for the slot currently on screen.
-    int sel = s->cfgIndex;
-    wchar_t monName[256] = {};
-    int cur = (int)SendMessageW(s->hMonitor, CB_GETCURSEL, 0, 0);
-    if (cur == 0)
-        wcscpy_s(monName, L"*");
-    else if (cur > 0)
-        SendMessageW(s->hMonitor, CB_GETLBTEXT, cur, (LPARAM)monName);
+    // Fold what is on screen back into its slot, then write every slot the
+    // window has touched. Writing only the visible one meant a two-monitor
+    // setup could not be configured in a single session: the other display's
+    // edits were still in memory and never reached the store.
+    DashCaptureSlot(s);
 
-    Wh_SetStringValue(GuiKey(sel, -1, L"id").c_str(), monName);
-    for (int z = 0; z < ZONE_COUNT; z++)
+    for (int sel = 0; sel < (int)s->slots.size(); sel++)
     {
-        int idx = (int)SendMessageW(s->hZoneAction[z], CB_GETCURSEL, 0, 0);
-        if (idx < 0 || idx >= kActionCount)
-            idx = 0;
-        wchar_t args[512] = {};
-        GetWindowTextW(s->hZoneArgs[z], args, ARRAYSIZE(args));
-        Wh_SetStringValue(GuiKey(sel, z, L"a").c_str(), kActionIds[idx]);
-        Wh_SetStringValue(GuiKey(sel, z, L"g").c_str(), args);
+        const DashState::Slot &sl = s->slots[sel];
+        if (!sl.loaded)
+            continue;
 
-        const ZoneTuning &tn = s->tuning[z];
-        Wh_SetIntValue(GuiKey(sel, z, L"sz").c_str(), tn.size);
-        Wh_SetIntValue(GuiKey(sel, z, L"dl").c_str(), tn.delay);
-        Wh_SetIntValue(GuiKey(sel, z, L"gd").c_str(), tn.settle);
-        Wh_SetIntValue(GuiKey(sel, z, L"kn").c_str(), tn.knock);
-        Wh_SetIntValue(GuiKey(sel, z, L"cd").c_str(), tn.cooldown);
-        Wh_SetIntValue(GuiKey(sel, z, L"md").c_str(), tn.modifier);
+        // A machine with more displays than the value store has slots would
+        // write keys that ReadDashboardZones' kMaxGuiConfigs loop never reads
+        // back — the edit would vanish on reload with nothing said.
+        if (sel >= kMaxGuiConfigs)
+        {
+            Wh_Log(L"Dashboard: display %d is beyond the %d configuration "
+                   L"slots; not saved",
+                   sel, kMaxGuiConfigs);
+            continue;
+        }
+
+        std::wstring monName = DashSlotMonitorId(s, sel);
+        Wh_SetStringValue(GuiKey(sel, -1, L"id").c_str(), monName.c_str());
+        for (int z = 0; z < ZONE_COUNT; z++)
+        {
+            int idx = sl.action[z];
+            if (idx < 0 || idx >= kActionCount)
+                idx = 0;
+            Wh_SetStringValue(GuiKey(sel, z, L"a").c_str(), kActionIds[idx]);
+            Wh_SetStringValue(GuiKey(sel, z, L"g").c_str(), sl.args[z].c_str());
+
+            const ZoneTuning &tn = sl.tuning[z];
+            Wh_SetIntValue(GuiKey(sel, z, L"sz").c_str(), tn.size);
+            Wh_SetIntValue(GuiKey(sel, z, L"dl").c_str(), tn.delay);
+            Wh_SetIntValue(GuiKey(sel, z, L"gd").c_str(), tn.settle);
+            Wh_SetIntValue(GuiKey(sel, z, L"kn").c_str(), tn.knock);
+            Wh_SetIntValue(GuiKey(sel, z, L"cd").c_str(), tn.cooldown);
+            Wh_SetIntValue(GuiKey(sel, z, L"md").c_str(), tn.modifier);
+        }
     }
     Wh_SetIntValue(L"gui_active", 1);
 
@@ -4625,10 +4177,8 @@ static void DashSave(HWND hWnd, DashState *s)
     Wh_SetIntValue(kOvrDrag, IsDlgButtonChecked(hWnd, IDC_CB_DRAG));
     Wh_SetIntValue(L"ovr_taskbar", IsDlgButtonChecked(hWnd, IDC_CB_TASKBAR));
     Wh_SetIntValue(L"ovr_monnames", IsDlgButtonChecked(hWnd, IDC_CB_MONNAMES));
-    Wh_SetIntValue(kOvrVerbose, IsDlgButtonChecked(hWnd, IDC_CB_VERBOSE));
 
-    LoadSettings();
-    ApplyTrayOverrides();
+    ReloadConfig();
     RequestRebuild();
     UpdateTrayIcon(false);
     Wh_Log(L"Dashboard: settings saved and applied");
@@ -4667,6 +4217,10 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
         s->hField = CreateSolidBrush(g_pal.field);
         s->hPanel = CreateSolidBrush(g_pal.panel);
 
+        // Every control is themed here rather than at its call site: the six
+        // scattered calls this replaces covered the combo boxes and edits and
+        // missed every button and check box, which is why those kept painting
+        // black text on the dark background.
         auto mk = [&](const wchar_t *cls, const wchar_t *txt, DWORD style,
                       int id) -> HWND
         {
@@ -4674,7 +4228,10 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
                                      10, hWnd, (HMENU)(INT_PTR)id,
                                      cs->hInstance, nullptr);
             if (h)
+            {
                 SendMessageW(h, WM_SETFONT, (WPARAM)s->hFont, TRUE);
+                ApplyControlTheme(h, cls);
+            }
             return h;
         };
 
@@ -4686,7 +4243,6 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
         s->hMonitor = mk(L"COMBOBOX", nullptr,
                          CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP,
                          IDC_MONITOR);
-        ThemeControl(s->hMonitor, g_lightTheme ? L"CFD" : L"DarkMode_CFD");
 
         for (int z = 0; z < ZONE_COUNT; z++)
         {
@@ -4695,7 +4251,6 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
                 mk(L"COMBOBOX", nullptr,
                    CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP,
                    IDC_ZONE_ACTION + z);
-            ThemeControl(s->hZoneAction[z], g_lightTheme ? L"CFD" : L"DarkMode_CFD");
             for (int a = 0; a < kActionCount; a++)
             {
                 SendMessageW(s->hZoneAction[z], CB_ADDSTRING, 0,
@@ -4704,11 +4259,15 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
             s->hZoneArgs[z] = mk(L"EDIT", nullptr,
                                  WS_BORDER | ES_AUTOHSCROLL | WS_TABSTOP,
                                  IDC_ZONE_ARGS + z);
-            ThemeControl(s->hZoneArgs[z], g_lightTheme ? L"CFD" : L"DarkMode_CFD");
         }
 
         for (int i = 0; i < kOptCount; i++)
         {
+            s->hOptSection[i] =
+                kOpts[i].section
+                    ? mk(L"STATIC", kOpts[i].section, SS_LEFT, IDC_OPT_SECTION)
+                    : nullptr;
+
             if (kOpts[i].isCheck)
             {
                 s->hOpt[i] = mk(L"BUTTON", kOpts[i].label,
@@ -4734,7 +4293,6 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
                                     WS_BORDER | ES_AUTOHSCROLL | WS_TABSTOP,
                                     kOpts[i].id);
                 }
-                ThemeControl(s->hOpt[i], g_lightTheme ? L"CFD" : L"DarkMode_CFD");
             }
         }
 
@@ -4766,14 +4324,13 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
                                    WS_TABSTOP,
                                kTz[i].id);
             }
-            ThemeControl(s->hTz[i], g_lightTheme ? L"CFD" : L"DarkMode_CFD");
         }
 
         s->hSave = mk(L"BUTTON", L"Save and Apply",
                       BS_DEFPUSHBUTTON | WS_VISIBLE | WS_TABSTOP, IDC_SAVE);
         s->hCancel = mk(L"BUTTON", L"Close",
                         BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP, IDC_CANCEL);
-        s->hReset = mk(L"BUTTON", L"Reset to Windhawk settings",
+        s->hReset = mk(L"BUTTON", L"Reset everything to defaults",
                        BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP, IDC_RESET);
 
         // One tooltip control serving every field. Descriptions live next to
@@ -4822,11 +4379,12 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
                 L"Virtual Key Press, a path or URL for Custom Command, or two "
                 L"of either separated by | for the Alternate actions.");
             tip(s->hReset,
-                L"Discard everything set here and go back to the Windhawk "
-                L"Settings page.");
+                L"Discard every zone and option and start again from the "
+                L"defaults. Asks first.");
         }
 
-        if (HICON ic = MakeTrayIcon(true))
+        s->hIcon = MakeTrayIcon(true);
+        if (HICON ic = s->hIcon)
         {
             SendMessageW(hWnd, WM_SETICON, ICON_SMALL, (LPARAM)ic);
             SendMessageW(hWnd, WM_SETICON, ICON_BIG, (LPARAM)ic);
@@ -4909,7 +4467,13 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
     case WM_CTLCOLORBTN:
         if (s)
         {
-            SetTextColor((HDC)wParam, g_pal.text);
+            // A group heading introduces the fields under it rather than
+            // labelling one of them, and the per-zone hint is an aside. Both
+            // read better set apart from the body text.
+            int cid = GetDlgCtrlID((HWND)lParam);
+            SetTextColor((HDC)wParam, cid == IDC_OPT_SECTION ? g_pal.accent
+                                      : cid == IDC_TZ_HINT   ? g_pal.dim
+                                                             : g_pal.text);
             SetBkColor((HDC)wParam, g_pal.bg);
             return (LRESULT)s->hBg;
         }
@@ -4971,18 +4535,13 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
         if (id == IDC_RESET)
         {
             if (MessageBoxW(hWnd,
-                            L"Discard everything set here and go back to the "
-                            L"Windhawk Settings page?",
+                            L"Discard every zone and option and start again "
+                            L"from the defaults?",
                             L"Win-X Hot Corners", MB_YESNO | MB_ICONQUESTION) ==
                 IDYES)
             {
-                ClearDashboardConfig();
-                Wh_SetIntValue(kOvrEnabled, -1);
-                Wh_SetIntValue(kOvrFullscreen, -1);
-                Wh_SetIntValue(kOvrDrag, -1);
-                Wh_SetIntValue(kOvrVerbose, -1);
-                LoadSettings();
-                ApplyTrayOverrides();
+                ClearStoredConfig();
+                ReloadConfig();
                 RequestRebuild();
                 DashLoad(hWnd, s);
             }
@@ -5024,6 +4583,8 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
                 DeleteObject(s->hField);
             if (s->hPanel)
                 DeleteObject(s->hPanel);
+            if (s->hIcon)
+                DestroyIcon(s->hIcon);
         }
         g_hDashWnd = nullptr;
         PostQuitMessage(0);
@@ -5062,6 +4623,13 @@ static DWORD WINAPI DashThread(LPVOID)
             dpi = 96;
     }
 
+    // Dark mode must be asked for before the window and its controls exist:
+    // the theme classes applied to each control later have no effect until the
+    // process has opted in, and opting in afterwards does not repaint what has
+    // already been created.
+    BuildPalette();
+    SetProcessDarkMode(!g_lightTheme);
+
     // WS_CLIPCHILDREN so the parent can never paint inside a child's rectangle.
     // Without it, anything drawn in WM_PAINT that lands under a control stays
     // on screen as residue, because the child is not repainted to cover it.
@@ -5083,6 +4651,8 @@ static DWORD WINAPI DashThread(LPVOID)
         UnregisterClassW(kClass, hInst);
         return 1;
     }
+
+    AllowDarkModeForControl(hWnd, !g_lightTheme);
 
     g_hDashWnd = hWnd;
     ShowWindow(hWnd, SW_SHOW);
@@ -5113,7 +4683,11 @@ static void OpenDashboard()
     }
     if (g_hDashThread)
     {
-        WaitForSingleObject(g_hDashThread, 0);
+        // Recycle the handle only once the previous thread has actually gone.
+        // Closing it while that thread still runs throws away the only way to
+        // wait for it during uninit, and starts a second dashboard besides.
+        if (WaitForSingleObject(g_hDashThread, 0) != WAIT_OBJECT_0)
+            return;
         CloseHandle(g_hDashThread);
         g_hDashThread = nullptr;
     }
@@ -5208,6 +4782,8 @@ static DWORD WINAPI TrayThread(LPVOID)
 BOOL WhTool_ModInit()
 {
     Wh_Log(L"Win-X Hot Corners v" WH_MOD_VERSION);
+    Wh_Log(L"This mod has no Settings page. Right-click its tray icon (next to "
+           L"the clock) and choose \"Zones & settings...\".");
 
     InitializeCriticalSection(&g_settingsLock);
     InitializeCriticalSection(&g_zonesLock);
@@ -5221,8 +4797,7 @@ BOOL WhTool_ModInit()
         return FALSE;
     }
 
-    LoadSettings();
-    ApplyTrayOverrides();
+    ReloadConfig();
 
     g_hWorkerThread =
         CreateThread(nullptr, 0, ActionWorkerThread, nullptr, 0, nullptr);
@@ -5251,8 +4826,7 @@ BOOL WhTool_ModInit()
 
 void WhTool_ModSettingsChanged()
 {
-    LoadSettings();
-    ApplyTrayOverrides();
+    ReloadConfig();
     UpdateTrayIcon(false);
     // The zone rebuild has to happen on the detection thread, which owns the
     // DPI context and the monitor list. Post, never send — Windhawk's thread
@@ -5281,6 +4855,24 @@ void WhTool_ModUninit()
         PostThreadMessage(g_dwDetectThreadId, WM_QUIT, 0, 0);
 
     bool allStopped = true;
+
+    // The dashboard is a window with its own message loop on its own thread,
+    // and it takes g_settingsLock and g_zonesLock. Nothing below may free
+    // those while it is alive. Its loop only ends when its window does, so
+    // close the window rather than signalling the stop event.
+    if (g_hDashWnd)
+        PostMessage(g_hDashWnd, WM_CLOSE, 0, 0);
+
+    if (g_hDashThread)
+    {
+        if (WaitForSingleObject(g_hDashThread, 3000) == WAIT_TIMEOUT)
+        {
+            Wh_Log(L"Dashboard thread exit timed out");
+            allStopped = false;
+        }
+        CloseHandle(g_hDashThread);
+        g_hDashThread = nullptr;
+    }
 
     if (g_hDetectThread)
     {

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,13 +2,13 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         1.0.0
+// @version         1.0.1
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
 // @license         MIT
 // @include         windhawk.exe
-// @compilerOptions -ladvapi32 -lgdi32 -lole32 -lpowrprof -lshell32 -luser32 -luuid
+// @compilerOptions -ladvapi32 -lgdi32 -lole32 -lpowrprof -lshell32 -luser32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -21,6 +21,13 @@ multi-monitor support**.
 Instantly trigger configurable actions when your cursor reaches any screen
 corner or edge. Configure different actions for each zone on each monitor
 independently.
+
+![Throwing the pointer into the top-left corner opens Task View](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/hot-corners.gif)
+
+The tray icon's **Zones & settings** window shows what each zone does on each
+display, and the timings actually in effect for whichever one you point at:
+
+![The Zones and settings window](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/dashboard.png)
 
 Inspired by [WinXCorners](https://github.com/vhanla/winxcorners), rebuilt as a
 Windhawk mod.
@@ -518,7 +525,6 @@ listing, but it only takes one link, so the rest live here.
 #include <initializer_list>
 #include <powrprof.h>
 #include <shellapi.h>
-#include <shldisp.h>   // IShellDispatch4 / CLSID_Shell, for Show Desktop
 #include <windhawk_api.h>
 
 #include <algorithm>
@@ -535,9 +541,6 @@ listing, but it only takes one link, so the rest live here.
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-// Undocumented Shell command ID for IShellDispatch::ToggleDesktop
-#define SHELL_TRAY_TOGGLE_DESKTOP 407
 
 // =====================================================================
 // Enums & Types
@@ -1556,45 +1559,15 @@ static void SendKeys(std::initializer_list<WORD> vks)
     SendKeys(v);
 }
 
-static void ActionShowDesktop()
-{
-    // IShellDispatch::ToggleDesktop is the documented way to do this. The old
-    // route - WM_COMMAND 407 to Shell_TrayWnd - is an undocumented private
-    // message sent to a window this mod does not own, and the value is only
-    // whatever that class happens to use today. The worker thread has a COM
-    // apartment, so this is available where it is called from.
-    // ToggleDesktop is on IShellDispatch4, not on the base interface.
-    IShellDispatch4 *shell = nullptr;
-    HRESULT hr = CoCreateInstance(CLSID_Shell, nullptr, CLSCTX_INPROC_SERVER,
-                                  IID_PPV_ARGS(&shell));
-    if (SUCCEEDED(hr) && shell)
-    {
-        hr = shell->ToggleDesktop();
-        shell->Release();
-        if (SUCCEEDED(hr))
-            return;
-    }
-
-    // Kept as a fallback rather than deleted: ToggleDesktop needs an apartment,
-    // and the private message is what worked before it.
-    Wh_Log(L"Show Desktop: IShellDispatch unavailable (0x%08X), using the "
-           L"shell message instead",
-           hr);
-
-    // Re-found when the handle goes stale, so this survives explorer restarts.
-    static HWND hTray = nullptr;
-    if (!hTray || !IsWindow(hTray))
-        hTray = FindWindowW(L"Shell_TrayWnd", nullptr);
-    if (!hTray)
-    {
-        Wh_Log(L"Show Desktop: Shell_TrayWnd not found");
-        return;
-    }
-    DWORD_PTR result = 0;
-    SendMessageTimeoutW(hTray, WM_COMMAND,
-                        MAKELONG(SHELL_TRAY_TOGGLE_DESKTOP, 0), 0,
-                        SMTO_ABORTIFHUNG, 2000, &result);
-}
+// Win+D, through the same SendKeys path as every other shortcut action.
+//
+// Two other routes were tried and both are worse. WM_COMMAND 407 to
+// Shell_TrayWnd is an undocumented private message sent to a window this mod
+// does not own. IShellDispatch4::ToggleDesktop is documented, but on Windows 11
+// build 26300 it returns S_OK and does nothing at all - which is the worst
+// possible failure, because there is no error to fall back on. Win+D is a
+// documented user-facing shortcut that the shell implements itself.
+static void ActionShowDesktop() { SendKeys({VK_LWIN, 'D'}); }
 
 static void ActionTaskView() { SendKeys({VK_LWIN, VK_TAB}); }
 

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,13 +2,13 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         4.4.0
+// @version         4.4.1
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
 // @license         MIT
 // @include         windhawk.exe
-// @compilerOptions -ladvapi32 -lcomctl32 -lgdi32 -lole32 -lpowrprof -lshell32 -luser32
+// @compilerOptions -ladvapi32 -lgdi32 -lole32 -lpowrprof -lshell32 -luser32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -70,19 +70,21 @@ the zones you want on it. A zone you do not list does nothing.
 
 **Tray icon**, next to the clock:
 
-- **Left-click** — turn the hot corners on or off.
-- **Right-click** — a quick menu: suspend for a while, skip while an app is
-  fullscreen, skip while dragging.
+- **Left-click** — turn the hot corners on or off. The icon dims when they are off.
+- **Right-click** — suspend for a while, or reset the enable state.
 - **Right-click → Zones & settings...** — the dashboard: a tab per display,
   a picture of that screen with each zone showing what it does, and the timings
   actually in effect for whichever zone you point at.
 
 ### Upgrading from 4.1.x
 
-Earlier versions had no settings page and stored the layout themselves. That
-layout keeps running untouched, so nothing breaks on upgrade — the log says so
-at startup. Re-enter it on the settings page when you are ready; the moment one
-display is listed there, the old layout is ignored.
+Earlier versions had no settings page and stored the layout themselves. Your
+zones keep running untouched, so nothing breaks on upgrade — everything else on
+the settings page is live immediately. Re-enter the zones there when you are
+ready; the moment one display is listed, the old layout is ignored.
+
+The startup log names any globals you had customised in the old version, since
+those now come from the settings page and need setting again there.
 
 This is deliberate. Twelve zones on each of up to eight displays, each with a
 forty-entry action list and six timing overrides, is not something a settings
@@ -271,6 +273,44 @@ Hot corners are disabled when any excluded process is the foreground window.
 **Example:** `photoshop.exe;premiere.exe;blender.exe`
 
 # Changelog
+
+## What's New in v4.4.1
+
+Two places where a value you changed still had no effect, and two where the
+window could tell you something untrue.
+
+- **Every setting on the page is live immediately after upgrading.** The globals
+  used to be applied only once you had listed a display there, so anyone coming
+  from 4.1.x had a page full of fields that did nothing — change *Cooldown* from
+  300 to 800, see nothing happen. The page owns them all now; only the zone list
+  still falls back to a stored layout. The startup log names any globals you had
+  customised in the old version so you know what to set again.
+- **The tray's "skip while fullscreen" and "skip while dragging" toggles are
+  gone.** They wrote a key that only the upgrade path read, so toggling one
+  worked until the next reload put it back. They are settings, and a mod cannot
+  write its own settings, so the tray copy could only ever drift. They live on
+  the settings page alone. Enable and suspend stay — those have no page
+  equivalent.
+- **Left-click on the tray icon toggles the hot corners**, which is what the
+  readme always said it did; it had been opening the dashboard. The icon dims
+  when they are off, and the dashboard is still the menu's first item.
+- **A zone whose arguments cannot be read is marked, not drawn as working.** A
+  key combination that does not parse, or an Alternate action missing its `|`,
+  used to appear on the preview like any other configured zone while never
+  firing.
+- **The tray menu anchors to the icon even when Windows refuses the GUID
+  registration**, which is the one case the anchoring was added for.
+- **Show Desktop uses the documented `IShellDispatch4::ToggleDesktop`** instead
+  of an undocumented private message to a window the mod does not own. The old
+  route stays as a fallback.
+- **Moving or auto-hiding a taskbar on a secondary display rebuilds the zones.**
+  The polled check only ever saw the primary display's work area, so with
+  *Keep zones out of the taskbar* on, that display's zones stayed put.
+- Dropped the comctl32 dependency — nothing used it after the 4.3.0 rewrite.
+- Clearing one display's name on the settings page no longer drops every
+  display listed after it.
+- Clicking the tray icon immediately after closing the dashboard reopens it
+  rather than doing nothing.
 
 ## What's New in v4.4.0
 
@@ -703,8 +743,7 @@ listing, but it only takes one link, so the rest live here.
 
 <!-- Plain links rather than badge images on purpose: this repository only allows
      images from i.imgur.com and raw.githubusercontent.com, so a shields.io badge
-     would not render. To add a platform, add a bullet.
-     Pending accounts: OnlyChai, BuyMeChai — drop the URLs in when they exist. -->
+     would not render. To add a platform, add a bullet. -->
 */
 // ==/WindhawkModReadme==
 
@@ -889,19 +928,18 @@ listing, but it only takes one link, so the rest live here.
 
 #include <windows.h>
 
-#include <commctrl.h>
 #include <windowsx.h>   // GET_X_LPARAM / GET_Y_LPARAM
 #include <initializer_list>
 #include <powrprof.h>
 #include <shellapi.h>
+#include <shldisp.h>   // IShellDispatch4 / CLSID_Shell, for Show Desktop
 #include <windhawk_api.h>
 
 #include <algorithm>
 #include <atomic>
-// swprintf_s / _wtoi / memcmp are used directly; they only reached this file
+// swprintf_s and memcmp are used directly; they only reached this file
 // through <windows.h> before.
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
 #include <cwchar>
 #include <cwctype>
@@ -1794,27 +1832,7 @@ static bool IsForegroundAppExcluded(const std::vector<std::wstring> &excluded)
     if (hFg != cachedHwnd)
     {
         cachedHwnd = hFg;
-        cachedName.clear();
-
-        DWORD pid = 0;
-        GetWindowThreadProcessId(hFg, &pid);
-        if (pid == 0)
-            return false;
-
-        HANDLE hProc =
-            OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-        if (!hProc)
-            return false;
-
-        WCHAR exePath[MAX_PATH];
-        DWORD pathLen = MAX_PATH;
-        BOOL ok = QueryFullProcessImageNameW(hProc, 0, exePath, &pathLen);
-        CloseHandle(hProc);
-        if (!ok)
-            return false;
-
-        const wchar_t *fileName = wcsrchr(exePath, L'\\');
-        cachedName = fileName ? fileName + 1 : exePath;
+        cachedName = ProcessNameOfWindow(hFg);
     }
 
     if (cachedName.empty())
@@ -1949,6 +1967,29 @@ static void SendKeys(std::initializer_list<WORD> vks)
 
 static void ActionShowDesktop()
 {
+    // IShellDispatch::ToggleDesktop is the documented way to do this. The old
+    // route - WM_COMMAND 407 to Shell_TrayWnd - is an undocumented private
+    // message sent to a window this mod does not own, and the value is only
+    // whatever that class happens to use today. The worker thread has a COM
+    // apartment, so this is available where it is called from.
+    // ToggleDesktop is on IShellDispatch4, not on the base interface.
+    IShellDispatch4 *shell = nullptr;
+    HRESULT hr = CoCreateInstance(CLSID_Shell, nullptr, CLSCTX_INPROC_SERVER,
+                                  IID_PPV_ARGS(&shell));
+    if (SUCCEEDED(hr) && shell)
+    {
+        hr = shell->ToggleDesktop();
+        shell->Release();
+        if (SUCCEEDED(hr))
+            return;
+    }
+
+    // Kept as a fallback rather than deleted: ToggleDesktop needs an apartment,
+    // and the private message is what worked before it.
+    Wh_Log(L"Show Desktop: IShellDispatch unavailable (0x%08X), using the "
+           L"shell message instead",
+           hr);
+
     // Re-found when the handle goes stale, so this survives explorer restarts.
     static HWND hTray = nullptr;
     if (!hTray || !IsWindow(hTray))
@@ -3003,6 +3044,13 @@ static DWORD DetectTick()
         (now - g_lastAnyFireTick) < kMinFireIntervalMs)
         return next;
 
+    // The cooldowns are stamped here, before the fullscreen and excluded-app
+    // gates run on the worker, so a suppressed trigger still consumes them.
+    // That is deliberate: those gates call SHQueryUserNotificationState and
+    // OpenProcess, and putting either on the 16 ms sampling path to save a
+    // cooldown the user cannot perceive would be the wrong trade. Rolling the
+    // stamps back from the worker is not an option either - this vector
+    // belongs to the detection thread.
     g_firedThisEntry = true;
     g_lastAnyFireTick = now;
     if (idx < (int)g_lastFireTick.size())
@@ -3025,6 +3073,17 @@ static LRESULT CALLBACK DetectWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
             Wh_Log(L"WM_DISPLAYCHANGE — rebuilding zones");
         else
             Wh_Log(L"Settings changed — rebuilding zones");
+        RebuildZones();
+        return 0;
+    }
+    // The polled topology check reads SPI_GETWORKAREA, which only ever reports
+    // the primary display - so with "keep zones out of the taskbar" on, a
+    // taskbar moved or auto-hidden on a secondary display left that display's
+    // zones at coordinates that no longer matched. This broadcast arrives
+    // whichever display changed.
+    if (uMsg == WM_SETTINGCHANGE && wParam == SPI_SETWORKAREA)
+    {
+        Wh_Log(L"Work area changed — rebuilding zones");
         RebuildZones();
         return 0;
     }
@@ -3108,9 +3167,9 @@ done:
 // closes, so hosting it on the detection thread would freeze every zone for
 // as long as the menu is open.
 //
-// The icon is also the only way in: this mod has no Windhawk settings page, so
-// left-click toggles, right-click is the quick menu, and the menu's first item
-// opens the dashboard where everything else lives.
+// Left-click toggles the hot corners, right-click is the quick menu, and the
+// menu's first item opens the dashboard. Everything configurable lives on the
+// Windhawk settings page; the icon carries only runtime state.
 
 static HANDLE g_hTrayThread = nullptr;
 static DWORD g_dwTrayThreadId = 0;
@@ -3130,7 +3189,9 @@ static const GUID kTrayIconGuid = {
 // Set once NIM_ADD succeeds. NIF_GUID also validates the registering
 // executable's path, so if it is ever rejected we fall back to plain uID
 // identity rather than losing the icon entirely.
-static bool g_trayUseGuid = true;
+// Written by UpdateTrayIcon, which runs on the tray thread, on Windhawk's
+// thread via WhTool_ModSettingsChanged, and at startup.
+static std::atomic<bool> g_trayUseGuid{true};
 
 // NOTIFYICON_VERSION_4 changes what the shell sends:
 //   left-click  -> NIN_SELECT      (rather than WM_LBUTTONUP)
@@ -3159,8 +3220,6 @@ enum TrayCommand
     IDM_SUSPEND_30,
     IDM_SUSPEND_60,
     IDM_RESUME,
-    IDM_FULLSCREEN,
-    IDM_DRAG,
     IDM_CLEAR_OVERRIDES,
     IDM_ABOUT,
 };
@@ -3168,10 +3227,10 @@ enum TrayCommand
 // Defined further down with the dashboard; the tray menu needs it earlier.
 static void OpenDashboard();
 
-// -1 means "no override, use the Windhawk setting"
+// Whether the hot corners are on. Runtime state rather than a setting - it has
+// no equivalent on the settings page, which is why the tray still owns it.
+// -1 means "never written", which reads as on.
 static const wchar_t *kOvrEnabled = L"ovr_enabled";
-static const wchar_t *kOvrFullscreen = L"ovr_fullscreen";
-static const wchar_t *kOvrDrag = L"ovr_drag";
 
 // A screen outline with the top-left corner lit and the other three marked,
 // which is the mod in one glyph. Drawn rather than shipped as a resource:
@@ -3329,15 +3388,16 @@ static void UpdateTrayIcon(bool add)
 }
 
 // =====================================================================
-// Dashboard persistence
+// Reading a pre-4.2 layout
 // =====================================================================
 //
-// This is the whole of the mod's persistence. There is no Windhawk settings
-// page to fall back on, so what is written here is what the mod runs with, and
-// a key that has never been written falls back to the default ReloadConfig set.
+// Nothing writes any of this any more - the settings page is the only store.
+// It is read once per reload, and only when the settings page has no displays
+// on it, so that upgrading from a version that had no settings page does not
+// silently discard a zone layout that took effort to enter.
 //
-// One key per field rather than a packed string: wordy, but it survives partial
-// writes and is readable if anything ever needs debugging by hand.
+// One key per field rather than a packed string, which is what those versions
+// wrote: wordy, but readable if it ever needs debugging by hand.
 
 static constexpr int kMaxGuiConfigs = 8;
 
@@ -3444,11 +3504,14 @@ static std::vector<MonitorZoneConfig> ReadSettingsZones()
 {
     std::vector<MonitorZoneConfig> configs;
 
-    for (int i = 0;; i++)
+    // Scanned to a fixed bound rather than stopping at the first blank, so
+    // clearing one display's name does not silently drop every entry after it.
+    // Reading past the end of a Windhawk array just returns empty strings.
+    for (int i = 0; i < 64; i++)
     {
         std::wstring id = TrimStr(GetSettingStr(L"displays[%d].monitor", i));
         if (id.empty())
-            break;
+            continue;
 
         MonitorZoneConfig cfg;
         cfg.monitorId = id;
@@ -3640,11 +3703,10 @@ static std::vector<MonitorZoneConfig> ReadDashboardZones()
 // zones are active". Four of the six callers run on a thread other than the
 // one that starts the mod, so that window was reachable.
 //
-// Keys still carry the historical "ovr_" prefix - back when there was a
-// Windhawk settings page these were overrides on top of it. They are the
-// configuration itself now; the prefix stays so an existing setup is not
-// orphaned. An unset key reads back as -1, which fails every range test below,
-// so a value the user has never touched simply keeps its default.
+// The settings page owns every global. The value store is read only for the
+// enable flag and, on the upgrade path, for a zone layout saved before the
+// settings page came back - never for anything a page field also controls,
+// because the two would then disagree with nothing on screen saying which won.
 static void ReloadConfig()
 {
     EnterCriticalSection(&g_reloadLock);
@@ -3656,78 +3718,57 @@ static void ReloadConfig()
 
     s.monitorConfigs = ReadSettingsZones();
     const bool fromSettings = !s.monitorConfigs.empty();
+
+    // The settings page always owns the globals. Applying them only on the
+    // settings path meant that anyone upgrading had a page full of fields that
+    // did nothing and no way to tell: change Cooldown from 300 to 800, see
+    // nothing happen. Only the zone list falls back to the stored layout.
+    ApplySettingsGlobals(s);
+
     bool legacy = false;
+    std::wstring dropped;
 
-    if (fromSettings)
+    if (!fromSettings && Wh_GetIntValue(L"gui_active", 0) != 0)
     {
-        ApplySettingsGlobals(s);
-    }
-    else if (Wh_GetIntValue(L"gui_active", 0) != 0)
-    {
-        // A layout from before the settings page existed. Reproduce the old
-        // behaviour exactly - defaults, then the stored "ovr_" overrides -
-        // so upgrading does not quietly change how anything behaves.
         legacy = true;
-
-        v = Wh_GetIntValue(kOvrFullscreen, -1);
-        if (v >= 0)
-            s.disableOnFullscreen = (v != 0);
-
-        v = Wh_GetIntValue(kOvrDrag, -1);
-        if (v >= 0)
-            s.disableDuringDrag = (v != 0);
-
-        auto pull = [](const wchar_t *k, int &dst, int lo, int hi)
-        {
-            int x = Wh_GetIntValue(k, -1);
-            if (x >= lo && x <= hi)
-                dst = x;
-        };
-        pull(L"ovr_corner", s.cornerSize, 1, 500);
-        pull(L"ovr_edge", s.edgeSize, 1, 500);
-        pull(L"ovr_delay", s.activationDelay, 0, 10000);
-        pull(L"ovr_settle", s.settleMs, 0, 10000);
-        pull(L"ovr_knock", s.knockWindowMs, 0, 10000);
-        pull(L"ovr_cooldown", s.cooldownMs, 0, 60000);
-        pull(L"ovr_centre", s.centerZonePercent, 1, 90);
-        pull(L"ovr_modifier", s.requireModifier, 0, 4);
-
-        int x = Wh_GetIntValue(L"ovr_taskbar", -1);
-        if (x >= 0)
-            s.avoidTaskbar = (x != 0);
-
-        // Via a local: pull takes int&, and these two globals are atomic
-        // because other threads read them while this runs.
-        int lockBlank = 1200;
-        pull(L"ovr_lockblank", lockBlank, 0, 10000);
-        g_lockBlankDelayMs = lockBlank;
-        x = Wh_GetIntValue(L"ovr_monnames", -1);
-        g_showMonitorNames = (x < 0) ? true : (x != 0);
-
-        std::wstring rest = GetStrValue(L"ovr_excluded");
-        while (!rest.empty())
-        {
-            auto semi = rest.find(L';');
-            std::wstring tok;
-            if (semi != std::wstring::npos)
-            {
-                tok = TrimStr(rest.substr(0, semi));
-                rest = rest.substr(semi + 1);
-            }
-            else
-            {
-                tok = TrimStr(rest);
-                rest.clear();
-            }
-            if (!tok.empty())
-                s.excludedProcesses.push_back(ToLowerStr(tok));
-        }
-
         s.monitorConfigs = ReadDashboardZones();
-    }
-    else
-    {
-        ApplySettingsGlobals(s);
+
+        // The stored globals are no longer applied, so name the ones that were
+        // customised. Reverting them silently would look like the mod losing a
+        // setting; naming them says exactly what to re-enter and where.
+        static const struct
+        {
+            const wchar_t *key;
+            const wchar_t *name;
+        } kOldGlobals[] = {
+            {L"ovr_corner", L"Corner size"},
+            {L"ovr_edge", L"Edge thickness"},
+            {L"ovr_centre", L"Edge centre width"},
+            {L"ovr_delay", L"Activation delay"},
+            {L"ovr_settle", L"Pass-through guard"},
+            {L"ovr_knock", L"Knock window"},
+            {L"ovr_cooldown", L"Cooldown"},
+            {L"ovr_modifier", L"Required modifier"},
+            {L"ovr_taskbar", L"Keep zones out of the taskbar"},
+            {L"ovr_lockblank", L"Lock-then-blank delay"},
+            {L"ovr_monnames", L"List display names in the log"},
+            {L"ovr_fullscreen", L"Skip while fullscreen"},
+            {L"ovr_drag", L"Skip while dragging"},
+        };
+        for (const auto &o : kOldGlobals)
+        {
+            if (Wh_GetIntValue(o.key, -1) < 0)
+                continue;
+            if (!dropped.empty())
+                dropped += L", ";
+            dropped += o.name;
+        }
+        if (!GetStrValue(L"ovr_excluded").empty())
+        {
+            if (!dropped.empty())
+                dropped += L", ";
+            dropped += L"Excluded applications";
+        }
     }
 
     // Copied out before the move, so the summary can be logged after the lock
@@ -3745,10 +3786,16 @@ static void ReloadConfig()
 
     if (legacy)
     {
-        Wh_Log(L"Using a layout saved by an older version (%d configuration%s). "
-               L"Re-enter it on this mod's Settings page to take it over - "
-               L"as soon as one display is listed there, this one is ignored.",
+        Wh_Log(L"Zones are coming from a layout saved by an older version (%d "
+               L"configuration%s). Everything else on this mod's Settings page "
+               L"is live. Re-enter the zones there to take them over - as soon "
+               L"as one display is listed, this layout is ignored.",
                zoneCount, zoneCount == 1 ? L"" : L"s");
+        if (!dropped.empty())
+            Wh_Log(L"These were customised in the old version and are now taken "
+                   L"from the Settings page instead, so set them again there if "
+                   L"you still want them: %s.",
+                   dropped.c_str());
     }
     else if (zoneCount)
     {
@@ -3796,21 +3843,14 @@ static void ShowTrayMenu(POINT pt)
     AppendMenuW(hMenu, MF_POPUP, (UINT_PTR)hSuspend,
                 suspended ? L"Suspended..." : L"Suspend for");
 
-    AppendMenuW(hMenu, MF_SEPARATOR, 0, nullptr);
-
-    EnterCriticalSection(&g_settingsLock);
-    bool fs = g_settings.disableOnFullscreen;
-    bool drag = g_settings.disableDuringDrag;
-    LeaveCriticalSection(&g_settingsLock);
-
-    AppendMenuW(hMenu, MF_STRING | (fs ? MF_CHECKED : 0), IDM_FULLSCREEN,
-                L"Skip while an app is fullscreen");
-    AppendMenuW(hMenu, MF_STRING | (drag ? MF_CHECKED : 0), IDM_DRAG,
-                L"Skip while dragging the mouse");
-
+    // "Skip while fullscreen" and "Skip while dragging" used to live here. They
+    // are settings, not runtime state, and a mod cannot write its own settings,
+    // so the tray copy could only ever diverge - toggling one worked until the
+    // next reload put it back. They belong to the settings page alone now;
+    // enable and suspend stay because neither has a page equivalent.
     AppendMenuW(hMenu, MF_SEPARATOR, 0, nullptr);
     AppendMenuW(hMenu, MF_STRING, IDM_CLEAR_OVERRIDES,
-                L"Reset these toggles");
+                L"Reset enable and suspend");
     AppendMenuW(hMenu, MF_STRING | MF_DISABLED, IDM_ABOUT,
                 L"Win-X Hot Corners " WH_MOD_VERSION);
 
@@ -3819,10 +3859,15 @@ static void ShowTrayMenu(POINT pt)
     // time; anchoring puts it in the one spot muscle memory expects, which is
     // what every other tray menu does.
     UINT align = TPM_RIGHTBUTTON;
+    // Mirror however the icon was actually registered. Passing the GUID after
+    // UpdateTrayIcon has fallen back to plain uID identity makes the lookup
+    // fail, and the menu quietly stops anchoring - the one case this exists for.
     NOTIFYICONIDENTIFIER nii = {sizeof(nii)};
     nii.hWnd = g_hTrayWnd;
-    nii.uID = (UINT)kTrayIconId;
-    nii.guidItem = kTrayIconGuid;
+    if (g_trayUseGuid)
+        nii.guidItem = kTrayIconGuid;
+    else
+        nii.uID = (UINT)kTrayIconId;
     RECT icon = {};
     if (SUCCEEDED(Shell_NotifyIconGetRect(&nii, &icon)))
     {
@@ -3908,47 +3953,17 @@ static void HandleTrayCommand(UINT id)
         Wh_Log(L"Tray: resumed");
         break;
 
-    // These two mutate the live configuration and write the key behind it, so
-    // they take g_reloadLock for the same reason a save does: a reload landing
-    // between the two halves would either lose the toggle or read it twice.
-    case IDM_FULLSCREEN:
-    {
-        EnterCriticalSection(&g_reloadLock);
-        EnterCriticalSection(&g_settingsLock);
-        g_settings.disableOnFullscreen = !g_settings.disableOnFullscreen;
-        int v = g_settings.disableOnFullscreen ? 1 : 0;
-        LeaveCriticalSection(&g_settingsLock);
-        Wh_SetIntValue(kOvrFullscreen, v);
-        LeaveCriticalSection(&g_reloadLock);
-        break;
-    }
-
-    case IDM_DRAG:
-    {
-        EnterCriticalSection(&g_reloadLock);
-        EnterCriticalSection(&g_settingsLock);
-        g_settings.disableDuringDrag = !g_settings.disableDuringDrag;
-        int v = g_settings.disableDuringDrag ? 1 : 0;
-        LeaveCriticalSection(&g_settingsLock);
-        Wh_SetIntValue(kOvrDrag, v);
-        LeaveCriticalSection(&g_reloadLock);
-        RequestRebuild();
-        break;
-    }
-
-    // Only the three toggles in this menu, and the suspend timer. Wiping the
-    // zone layout from a menu item with no confirmation would be a trap; the
-    // dashboard's Reset button does that, behind a prompt.
+    // Only what this menu owns: the enable flag and the suspend timer. Wiping
+    // the zone layout from a menu item with no confirmation would be a trap,
+    // and everything else now lives on the settings page.
     case IDM_CLEAR_OVERRIDES:
         EnterCriticalSection(&g_reloadLock);
         Wh_SetIntValue(kOvrEnabled, -1);
-        Wh_SetIntValue(kOvrFullscreen, -1);
-        Wh_SetIntValue(kOvrDrag, -1);
         g_suspendUntil = 0;
         ReloadConfig();
         LeaveCriticalSection(&g_reloadLock);
         RequestRebuild();
-        Wh_Log(L"Tray: toggles reset to defaults");
+        Wh_Log(L"Tray: enable and suspend reset to defaults");
         break;
 
     default:
@@ -4035,6 +4050,7 @@ struct ZoneView
     std::wstring args;
     ZoneTuning tuning;          // -1 in a field means "inherited"
     bool fromWildcard = false;
+    bool invalid = false;       // configured, but its arguments do not parse
 };
 
 struct DisplayView
@@ -4203,8 +4219,7 @@ static bool ZoneIsVertical(Zone z)
 // subIdList is nullptr for "keep the default part list", which is what naming
 // a theme (DarkMode_CFD) wants. Disabling theming outright is the exception:
 // SetWindowTheme only stops theming a control when *both* strings are empty,
-// and a still-themed control ignores colour messages such as
-// TTM_SETTIPBKCOLOR — which is why the tooltip stayed light.
+// and a still-themed control ignores colour messages entirely.
 // Resolved once: theming runs about forty times while the dashboard is built,
 // and the LoadLibraryEx fallback used to take a reference every time without
 // ever releasing it.
@@ -4430,6 +4445,12 @@ static void DashFillZones(DisplayView &dv,
         dv.zones[z].args = hit->args;
         dv.zones[z].tuning = hit->tuning;
         dv.zones[z].fromWildcard = wild;
+        // BuildZoneSet also requires an executor, and MakeExecutor returns null
+        // when the arguments do not parse - an unparseable key combination, or
+        // an Alternate action missing its "|". Drawing those as ordinary
+        // configured zones would make the picture disagree with what fires,
+        // which is the one thing this window must not do. Shown, but marked.
+        dv.zones[z].invalid = !hit->executor;
         dv.configured++;
     }
 }
@@ -4652,13 +4673,17 @@ static void DashPaintDiagram(DashState *s, HDC hdc)
     HBRUSH unset = CreateSolidBrush(g_pal.border);
     HBRUSH hot = CreateSolidBrush(g_lightTheme ? RGB(0, 70, 140)
                                                : RGB(120, 215, 255));
+    // A zone that is configured but cannot fire needs to look wrong at a
+    // glance, not merely be explained in the panel below.
+    HBRUSH broken = CreateSolidBrush(g_lightTheme ? RGB(176, 60, 40)
+                                                  : RGB(220, 110, 90));
 
     for (int z = 0; z < ZONE_COUNT; z++)
     {
         const ZoneView &zv = dv.zones[z];
         bool on = zv.action != CornerAction::Nothing;
         bool live = (z == s->hoverZone || z == s->selZone);
-        HBRUSH b = live ? hot : (on ? set : unset);
+        HBRUSH b = live ? hot : (zv.invalid ? broken : (on ? set : unset));
 
         RECT widest = ZoneRectInDiagram((Zone)z, dg);
         if (widest.right <= widest.left || widest.bottom <= widest.top)
@@ -4713,6 +4738,7 @@ static void DashPaintDiagram(DashState *s, HDC hdc)
     DeleteObject(set);
     DeleteObject(unset);
     DeleteObject(hot);
+    DeleteObject(broken);
 
     // Caption under the box.
     SelectObject(hdc, s->hFontSmall);
@@ -4815,7 +4841,16 @@ static void DashPaintDetail(DashState *s, HDC hdc, const RECT &client)
     DrawTextW(hdc, line, -1, &r, DT_LEFT | DT_SINGLELINE | DT_END_ELLIPSIS);
     y += Sc(18, d);
 
-    if (zv.fromWildcard)
+    if (zv.invalid)
+    {
+        SetTextColor(hdc, g_lightTheme ? RGB(176, 60, 40) : RGB(220, 110, 90));
+        r = {left, y, right, y + Sc(16, d)};
+        DrawTextW(hdc,
+                  L"This zone will not fire - its arguments could not be read.",
+                  -1, &r, DT_LEFT | DT_SINGLELINE | DT_END_ELLIPSIS);
+        SetTextColor(hdc, g_pal.dim);
+    }
+    else if (zv.fromWildcard)
     {
         r = {left, y, right, y + Sc(16, d)};
         DrawTextW(hdc, L"Inherited from the \"All displays\" configuration", -1,
@@ -5165,10 +5200,6 @@ static DWORD WINAPI DashThread(LPVOID)
 {
     PinThreadDpiPerMonitorV2();
 
-    // TOOLTIPS_CLASS lives in comctl32 and needs the library initialised.
-    INITCOMMONCONTROLSEX icc = {sizeof(icc), ICC_WIN95_CLASSES};
-    InitCommonControlsEx(&icc);
-
     const wchar_t *kClass = L"WindhawkHotCornersDash";
     HINSTANCE hInst = GetModuleHandle(nullptr);
 
@@ -5222,6 +5253,27 @@ static DWORD WINAPI DashThread(LPVOID)
 
     AllowDarkModeForControl(hWnd, !g_lightTheme);
 
+    // The frame above was sized from the system DPI, but the layout inside is
+    // computed from the window's own. They agree on the usual setup and can
+    // disagree if the primary display's scaling changed without a sign-out, so
+    // resize to whatever the window actually landed on.
+    {
+        HMODULE u = GetModuleHandleW(L"user32.dll");
+        using Fn = UINT(WINAPI *)(HWND);
+        UINT real = dpi;
+        if (auto fn = (Fn)GetProcAddress(u, "GetDpiForWindow"))
+            if (UINT v = fn(hWnd))
+                real = v;
+        if (real != dpi)
+        {
+            RECT want = {0, 0, Sc(Lay::ClientW, real), Sc(Lay::ClientH, real)};
+            AdjustWindowRectEx(&want, style, FALSE, 0);
+            SetWindowPos(hWnd, nullptr, 0, 0, want.right - want.left,
+                         want.bottom - want.top,
+                         SWP_NOZORDER | SWP_NOMOVE | SWP_NOACTIVATE);
+        }
+    }
+
     g_hDashWnd = hWnd;
     ShowWindow(hWnd, SW_SHOW);
     SetForegroundWindow(hWnd);
@@ -5257,8 +5309,17 @@ static void OpenDashboard()
         // Recycle the handle only once the previous thread has actually gone.
         // Closing it while that thread still runs throws away the only way to
         // wait for it during uninit, and starts a second dashboard besides.
-        if (WaitForSingleObject(g_hDashThread, 0) != WAIT_OBJECT_0)
+        //
+        // Waited on briefly rather than abandoned: the window has just been
+        // closed and the thread is already unwinding, so this returns almost
+        // at once. Returning immediately meant that clicking the tray icon
+        // right after closing the dashboard silently did nothing.
+        if (WaitForSingleObject(g_hDashThread, 500) != WAIT_OBJECT_0)
+        {
+            Wh_Log(L"The previous dashboard window is still closing; try again "
+                   L"in a moment.");
             return;
+        }
         CloseHandle(g_hDashThread);
         g_hDashThread = nullptr;
     }
@@ -5284,7 +5345,11 @@ static LRESULT CALLBACK TrayWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
         }
         else if (ev == NIN_SELECT || ev == NIN_KEYSELECT || ev == WM_LBUTTONUP)
         {
-            OpenDashboard();
+            // Toggle rather than open the dashboard. The icon already shows
+            // enabled state, so the feedback is immediate, and the dashboard
+            // is the menu's default item - which leaves the one-click action
+            // for the thing you actually do repeatedly.
+            HandleTrayCommand(IDM_ENABLED);
         }
         return 0;
     }
@@ -5513,21 +5578,26 @@ void WhTool_ModUninit()
 // https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
 //
 // The mod will load and run in a dedicated windhawk.exe process.
+//
+// Paste the code below as part of the mod code, and use these callbacks:
+// * WhTool_ModInit
+// * WhTool_ModSettingsChanged
+// * WhTool_ModUninit
+//
+// Currently, other callbacks are not supported.
 
 bool g_isToolModProcessLauncher;
 HANDLE g_toolModProcessMutex;
 
-void WINAPI EntryPoint_Hook()
-{
+void WINAPI EntryPoint_Hook() {
+    Wh_Log(L">");
     ExitThread(0);
 }
 
-BOOL Wh_ModInit()
-{
+BOOL Wh_ModInit() {
     DWORD sessionId;
     if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
-        sessionId == 0)
-    {
+        sessionId == 0) {
         return FALSE;
     }
 
@@ -5535,31 +5605,25 @@ BOOL Wh_ModInit()
     bool isToolModProcess = false;
     bool isCurrentToolModProcess = false;
     int argc;
-    LPWSTR *argv = CommandLineToArgvW(GetCommandLine(), &argc);
-    if (!argv)
-    {
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
+    if (!argv) {
         Wh_Log(L"CommandLineToArgvW failed");
         return FALSE;
     }
 
-    for (int i = 1; i < argc; i++)
-    {
+    for (int i = 1; i < argc; i++) {
         if (wcscmp(argv[i], L"-service") == 0 ||
             wcscmp(argv[i], L"-service-start") == 0 ||
-            wcscmp(argv[i], L"-service-stop") == 0)
-        {
+            wcscmp(argv[i], L"-service-stop") == 0) {
             isExcluded = true;
             break;
         }
     }
 
-    for (int i = 1; i < argc - 1; i++)
-    {
-        if (wcscmp(argv[i], L"-tool-mod") == 0)
-        {
+    for (int i = 1; i < argc - 1; i++) {
+        if (wcscmp(argv[i], L"-tool-mod") == 0) {
             isToolModProcess = true;
-            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0)
-            {
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0) {
                 isCurrentToolModProcess = true;
             }
             break;
@@ -5568,46 +5632,40 @@ BOOL Wh_ModInit()
 
     LocalFree(argv);
 
-    if (isExcluded)
-    {
+    if (isExcluded) {
         return FALSE;
     }
 
-    if (isCurrentToolModProcess)
-    {
+    if (isCurrentToolModProcess) {
         g_toolModProcessMutex =
             CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
-        if (!g_toolModProcessMutex)
-        {
+        if (!g_toolModProcessMutex) {
             Wh_Log(L"CreateMutex failed");
             ExitProcess(1);
         }
 
-        if (GetLastError() == ERROR_ALREADY_EXISTS)
-        {
+        if (GetLastError() == ERROR_ALREADY_EXISTS) {
             Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
-            CloseHandle(g_toolModProcessMutex);
             ExitProcess(1);
         }
 
-        if (!WhTool_ModInit())
-        {
+        if (!WhTool_ModInit()) {
             ExitProcess(1);
         }
 
-        IMAGE_DOS_HEADER *dosHeader =
-            (IMAGE_DOS_HEADER *)GetModuleHandle(nullptr);
-        IMAGE_NT_HEADERS *ntHeaders =
-            (IMAGE_NT_HEADERS *)((BYTE *)dosHeader + dosHeader->e_lfanew);
+        IMAGE_DOS_HEADER* dosHeader =
+            (IMAGE_DOS_HEADER*)GetModuleHandle(nullptr);
+        IMAGE_NT_HEADERS* ntHeaders =
+            (IMAGE_NT_HEADERS*)((BYTE*)dosHeader + dosHeader->e_lfanew);
+
         DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
-        void *entryPoint = (BYTE *)dosHeader + entryPointRVA;
+        void* entryPoint = (BYTE*)dosHeader + entryPointRVA;
 
-        Wh_SetFunctionHook(entryPoint, (void *)EntryPoint_Hook, nullptr);
+        Wh_SetFunctionHook(entryPoint, (void*)EntryPoint_Hook, nullptr);
         return TRUE;
     }
 
-    if (isToolModProcess)
-    {
+    if (isToolModProcess) {
         return FALSE;
     }
 
@@ -5615,83 +5673,77 @@ BOOL Wh_ModInit()
     return TRUE;
 }
 
-void Wh_ModAfterInit()
-{
-    if (!g_isToolModProcessLauncher)
-    {
+void Wh_ModAfterInit() {
+    if (!g_isToolModProcessLauncher) {
         return;
     }
 
     WCHAR currentProcessPath[MAX_PATH];
-    DWORD length = GetModuleFileName(nullptr, currentProcessPath,
-                                     ARRAYSIZE(currentProcessPath));
-    if (length == 0 || length == ARRAYSIZE(currentProcessPath))
-    {
-        Wh_Log(L"GetModuleFileName failed");
-        return;
+    switch (GetModuleFileName(nullptr, currentProcessPath,
+                              ARRAYSIZE(currentProcessPath))) {
+        case 0:
+        case ARRAYSIZE(currentProcessPath):
+            Wh_Log(L"GetModuleFileName failed");
+            return;
     }
 
-    WCHAR commandLine[MAX_PATH * 2];
+    WCHAR
+    commandLine[MAX_PATH + 2 +
+                (sizeof(L" -tool-mod \"" WH_MOD_ID "\"") / sizeof(WCHAR)) - 1];
     swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
                WH_MOD_ID);
 
     HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
-    if (!kernelModule)
-    {
+    if (!kernelModule) {
         kernelModule = GetModuleHandle(L"kernel32.dll");
-    }
-    if (!kernelModule)
-    {
-        Wh_Log(L"GetModuleHandle failed");
-        return;
+        if (!kernelModule) {
+            Wh_Log(L"No kernelbase.dll/kernel32.dll");
+            return;
+        }
     }
 
-    using CreateProcessInternalW_t = BOOL(WINAPI *)(
+    using CreateProcessInternalW_t = BOOL(WINAPI*)(
         HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
         LPSECURITY_ATTRIBUTES lpProcessAttributes,
-        LPSECURITY_ATTRIBUTES lpThreadAttributes, BOOL bInheritHandles,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, WINBOOL bInheritHandles,
         DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
         LPSTARTUPINFOW lpStartupInfo,
-        LPPROCESS_INFORMATION lpProcessInformation, PHANDLE hNewToken);
+        LPPROCESS_INFORMATION lpProcessInformation,
+        PHANDLE hRestrictedUserToken);
     CreateProcessInternalW_t pCreateProcessInternalW =
         (CreateProcessInternalW_t)GetProcAddress(kernelModule,
                                                  "CreateProcessInternalW");
-    if (!pCreateProcessInternalW)
-    {
-        Wh_Log(L"GetProcAddress failed");
+    if (!pCreateProcessInternalW) {
+        Wh_Log(L"No CreateProcessInternalW");
         return;
     }
 
-    STARTUPINFO si = {sizeof(si)};
-    si.dwFlags = STARTF_FORCEOFFFEEDBACK;
-    PROCESS_INFORMATION pi = {0};
-    if (pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
-                                nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
-                                nullptr, nullptr, &si, &pi, nullptr))
-    {
-        CloseHandle(pi.hProcess);
-        CloseHandle(pi.hThread);
+    STARTUPINFO si{
+        .cb = sizeof(STARTUPINFO),
+        .dwFlags = STARTF_FORCEOFFFEEDBACK,
+    };
+    PROCESS_INFORMATION pi;
+    if (!pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
+                                 nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
+                                 nullptr, nullptr, &si, &pi, nullptr)) {
+        Wh_Log(L"CreateProcess failed");
+        return;
     }
-    else
-    {
-        Wh_Log(L"CreateProcessInternalW failed");
-    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
 }
 
-void Wh_ModSettingsChanged()
-{
-    if (g_isToolModProcessLauncher)
-    {
+void Wh_ModSettingsChanged() {
+    if (g_isToolModProcessLauncher) {
         return;
     }
 
     WhTool_ModSettingsChanged();
 }
 
-void Wh_ModUninit()
-{
-    if (g_isToolModProcessLauncher)
-    {
+void Wh_ModUninit() {
+    if (g_isToolModProcessLauncher) {
         return;
     }
 

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         4.0.2
+// @version         4.0.3
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @license         MIT
@@ -187,6 +187,14 @@ Hot corners are disabled when any excluded process is the foreground window.
 **Example:** `photoshop.exe;premiere.exe;blender.exe`
 
 # Changelog
+
+## What's New in v4.0.3
+
+- **Fixed: the mod would not load at all.** "Require a modifier key" offered a
+  dropdown whose values were numbers, and Windhawk only accepts text values for
+  a dropdown — it refused to parse the settings before any of the mod ran. The
+  choices are now stored by name (`none`, `ctrl`, `alt`, `shift`, `win`); a
+  configuration saved by an earlier version keeps working.
 
 ## What's New in v4.0.2
 
@@ -437,18 +445,18 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
     This is the strongest protection against accidental triggers. 0 turns it
     off; 400 is a comfortable starting point. The two entries must be within
     this many milliseconds of each other.
-- RequireModifier: 0
+- RequireModifier: none
   $name: Require a modifier key
   $description: >-
     Only fire while this key is held down. Makes hot corners completely inert
     the rest of the time, which suits people who work near the screen edges.
     Combines with everything else - the zone still has to be entered normally.
   $options:
-  - 0: None - zones always active
-  - 1: Ctrl
-  - 2: Alt
-  - 3: Shift
-  - 4: Win
+  - none: None - zones always active
+  - ctrl: Ctrl
+  - alt: Alt
+  - shift: Shift
+  - win: Win
 - CooldownMs: 300
   $name: Cooldown between triggers (ms)
   $description: >-
@@ -3127,6 +3135,26 @@ done:
 // Settings
 // =====================================================================
 
+// Windhawk rejects a settings block where a value with $options is not a
+// string, so this one setting is stored by name. Everything downstream — the
+// zones, the value store, the dashboard combo — keeps the 0-4 encoding, so the
+// mapping lives here and nowhere else.
+static int ParseModifierName(const wchar_t *s)
+{
+    static const wchar_t *kNames[] = {L"none", L"ctrl", L"alt", L"shift",
+                                      L"win"};
+    for (int i = 0; i < (int)ARRAYSIZE(kNames); i++)
+        if (_wcsicmp(s, kNames[i]) == 0)
+            return i;
+
+    // Versions up to 4.0.2 stored a number here. Keep those configurations
+    // working instead of silently resetting them to "none".
+    if (s[0] >= L'0' && s[0] <= L'4' && s[1] == L'\0')
+        return s[0] - L'0';
+
+    return 0;
+}
+
 static void LoadSettings()
 {
     using WindhawkUtils::StringSetting;
@@ -3153,9 +3181,8 @@ static void LoadSettings()
     if (g_settings.knockWindowMs < 0)
         g_settings.knockWindowMs = 0;
 
-    g_settings.requireModifier = Wh_GetIntSetting(L"RequireModifier");
-    if (g_settings.requireModifier < 0 || g_settings.requireModifier > 4)
-        g_settings.requireModifier = 0;
+    g_settings.requireModifier =
+        ParseModifierName(StringSetting::make(L"RequireModifier").get());
 
     g_settings.avoidTaskbar = Wh_GetIntSetting(L"AvoidTaskbar") != 0;
 

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         1.2.1
+// @version         1.3.0
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -19,7 +19,7 @@ macOS-style hot corners **and screen edges** for Windows 10 and 11, with full
 multi-monitor support. Throw the pointer into a corner or against an edge and
 something happens — which corner, which edge, and what happens are all yours.
 
-![Throwing the pointer into the top-left corner opens Task View](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/hot-corners.gif)
+![Throwing the pointer into the bottom-left corner opens the Start menu](https://raw.githubusercontent.com/DhakadG/my-windhawk-mods/main/docs/media/hot-corners.gif)
 
 Inspired by [WinXCorners](https://github.com/vhanla/winxcorners), rebuilt as a
 Windhawk mod.
@@ -351,7 +351,7 @@ worse than one that never fires at all.
 | **Pass-through guard** | Ignores a zone you were merely travelling across. 80 ms by default. Raise this first if things fire while you are just moving around. |
 | **Cooldown** | Minimum gap between two firings of the same zone. A cooldown is a wait, not a refusal — park in the corner and it fires once the wait is over. |
 | **Skip while a window is fullscreen** | Suppresses zones on the display the fullscreen window is on, so games and presentations are left alone. |
-| **Skip while dragging** | Nothing fires while a mouse button is held, so dragging a window or selecting text into a corner is safe. |
+| **Skip while dragging** | A zone reached with a mouse button held does not fire, and stays inert until you leave and come back - so dragging a window or selecting text into a corner is safe, and letting go there does not set it off either. |
 
 **Excluded applications** takes a semicolon-separated list of process names,
 case-insensitive: `photoshop.exe;premiere.exe;blender.exe`. Every zone goes
@@ -440,8 +440,9 @@ If all you want is one specific behaviour, a smaller mod may suit you better:
 Please open an issue at
 [github.com/DhakadG/my-windhawk-mods](https://github.com/DhakadG/my-windhawk-mods/issues).
 If a zone is not firing, this mod's log (Windhawk → this mod → **Advanced** →
-**Mod log**) says which zone the pointer entered and why nothing happened, and
-pasting that in saves a round trip.
+**Mod log**) names the zone the pointer entered and the gate that held it back -
+a knock it is waiting on, a modifier that is not down, a cooldown that has not
+elapsed - and pasting that in saves a round trip.
 
 ## Support the mod
 
@@ -930,7 +931,7 @@ struct ModSettings
     int activationDelay = 0;
     int settleMs = 80;
     int knockWindowMs = 0;   // 0 = knock mode off
-    int requireModifier = 0; // 0 none, 1 Ctrl, 2 Alt, 3 Shift, 4 Win
+    int requireModifier = kModifierNone;  // one of the kModifier* values
     int centerZonePercent = 20;
     bool avoidTaskbar = false;
     int cooldownMs = 300;
@@ -1023,6 +1024,12 @@ static bool g_knockSatisfied = true;
 // "has this visit been spent", which stays true after a release so the zone
 // cannot re-fire without leaving first.
 static bool g_holdEngaged = false;
+
+// Which gate was reported for the current visit, so a refusal is logged once
+// per entry instead of once every 16 ms tick. The readme tells users to paste
+// this log when a corner does nothing, and every silent gate below was a
+// question it could not answer.
+static const wchar_t *g_gateLogged = nullptr;
 static std::vector<ULONGLONG> g_lastFireTick;
 // When each zone was last left, for knock detection.
 static std::vector<ULONGLONG> g_lastExitTick;
@@ -2376,6 +2383,55 @@ static bool SameZoneConfig(const ZoneConfig *a, const ZoneConfig *b)
 // configured one, and they used to disagree: the panel printed the number from
 // the settings under a column headed IN EFFECT while the zone actually fired at
 // the clamped size. One function, called from both.
+// The rectangle zones are laid out in. Normally that is rcWork, which already
+// excludes a docked taskbar and any appbars - but an auto-hidden taskbar
+// reserves nothing, so rcWork is the whole monitor and "Keep zones out of the
+// taskbar" silently did nothing in exactly the case it is most wanted: the
+// bottom edge and bottom corners land on the reveal strip, so hovering them
+// fires the zone *and* pops the taskbar over it.
+//
+// Verified on this machine that a docked taskbar does shrink rcWork (1728 ->
+// 1680), so the ordinary path is unchanged; the auto-hide branch below is the
+// only new behaviour and it only runs when the setting is on.
+static RECT ZoneBounds(const MonitorInfo &mon, bool avoidTaskbar)
+{
+    if (!avoidTaskbar)
+        return mon.rcMonitor;
+
+    RECT r = mon.rcWork;
+
+    APPBARDATA state = {};
+    state.cbSize = sizeof(state);
+    if (!(SHAppBarMessage(ABM_GETSTATE, &state) & ABS_AUTOHIDE))
+        return r;
+
+    APPBARDATA pos = {};
+    pos.cbSize = sizeof(pos);
+    if (!SHAppBarMessage(ABM_GETTASKBARPOS, &pos))
+        return r;
+
+    // Only the display the taskbar is actually on, and only the edge it is
+    // docked to - subtracting a rect that does not touch this monitor would
+    // shrink the wrong screen.
+    RECT hit;
+    if (!IntersectRect(&hit, &r, &pos.rc))
+        return r;
+
+    switch (pos.uEdge)
+    {
+    case ABE_BOTTOM: r.bottom = hit.top;    break;
+    case ABE_TOP:    r.top    = hit.bottom; break;
+    case ABE_LEFT:   r.left   = hit.right;  break;
+    case ABE_RIGHT:  r.right  = hit.left;   break;
+    default: break;
+    }
+
+    // Never hand back something degenerate; the zone maths assumes a real box.
+    if (r.right - r.left < 16 || r.bottom - r.top < 16)
+        return mon.rcWork;
+    return r;
+}
+
 static int ClampZoneSize(int requested, int span)
 {
     int v = requested < 1 ? 1 : requested;
@@ -2463,11 +2519,7 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
 
     for (const auto &mon : g_monitors)
     {
-        // rcWork is the monitor minus the taskbar and any docked appbars, so
-        // using it is a complete fix for zones colliding with the taskbar,
-        // including the taskbar's own "peek at desktop" strip.
-        const RECT &r =
-            g_settings.avoidTaskbar ? mon.rcWork : mon.rcMonitor;
+        const RECT r = ZoneBounds(mon, g_settings.avoidTaskbar);
         LONG centrePct = g_settings.centerZonePercent;
 
         int span = (r.right - r.left) < (r.bottom - r.top)
@@ -3017,7 +3069,7 @@ static DWORD WINAPI ActionWorkerThread(LPVOID)
 // Detection
 // =====================================================================
 
-// 0 none, 1 Ctrl, 2 Alt, 3 Shift, 4 Win
+// Takes one of the kModifier* values.
 static bool RequiredModifierHeld(int which)
 {
     switch (which)
@@ -3133,6 +3185,7 @@ static DWORD DetectTick()
         g_activeZone = idx;
         g_enterTick = now;
         g_firedThisEntry = false;
+        g_gateLogged = nullptr;
 
         // Knock mode: a single entry never fires. The zone only arms when it
         // is re-entered soon after being left.
@@ -3146,13 +3199,28 @@ static DWORD DetectTick()
     if (idx < 0 || g_firedThisEntry)
         return next;
 
+    // Reported once per visit, not once per tick.
+    auto gate = [&](const wchar_t *why)
+    {
+        if (g_gateLogged == why)
+            return;
+        g_gateLogged = why;
+        Wh_Log(L"HELD BACK (%s): %s", why, zones->zones[idx].label.c_str());
+    };
+
     if (!g_knockSatisfied)
+    {
+        gate(L"knock window - leave and re-enter to arm it");
         return next;
+    }
 
     // Checked every tick rather than on entry, so the zone becomes live the
     // moment the modifier goes down while the cursor is already parked.
     if (!RequiredModifierHeld(zones->zones[idx].modifier))
+    {
+        gate(L"required modifier not held");
         return next;
+    }
 
     // Suppress for the whole visit, not just this tick — otherwise releasing
     // a drag inside a corner would immediately trigger it.
@@ -3160,6 +3228,7 @@ static DWORD DetectTick()
 
     if (zones->disableDuringDrag && AnyMouseButtonDown())
     {
+        gate(L"a mouse button is held - skip while dragging");
         g_firedThisEntry = true;
         return next;
     }
@@ -3172,7 +3241,11 @@ static DWORD DetectTick()
     // the zone you actually stop in does.
     int dwell = hz.delay > hz.settle ? hz.delay : hz.settle;
     if (dwell > 0 && (now - g_enterTick) < (ULONGLONG)dwell)
+    {
+        gate(hz.delay > hz.settle ? L"waiting out the activation delay"
+                                  : L"waiting out the pass-through guard");
         return next;
+    }
 
     // Neither cooldown sets g_firedThisEntry: they are a wait, not a refusal.
     // Marking the visit spent meant that walking into a corner shortly after
@@ -3183,14 +3256,20 @@ static DWORD DetectTick()
     {
         ULONGLONG last = g_lastFireTick[idx];
         if (last != 0 && (now - last) < (ULONGLONG)hz.cooldown)
+        {
+            gate(L"this zone's cooldown has not elapsed");
             return next;
+        }
     }
 
     // Global floor across all zones. The per-zone cooldown alone does not stop
     // a sweep through several different zones from queueing a burst.
     if (g_lastAnyFireTick != 0 &&
         (now - g_lastAnyFireTick) < kMinFireIntervalMs)
+    {
+        gate(L"another zone fired a moment ago");
         return next;
+    }
 
     // The cooldowns are stamped here, before the fullscreen and excluded-app
     // gates run on the worker, so a suppressed trigger still consumes them.
@@ -4288,6 +4367,23 @@ static bool ZoneIsCorner(Zone z) { return z <= ZONE_BOTTOM_RIGHT; }
 // The three segments of the edge a zone belongs to, or false for a corner.
 // An edge is one strip, so its thickness is a property of the trio rather than
 // of whichever segment you happen to be looking at.
+// AdjustWindowRectEx computes the non-client size at *system* DPI, but these
+// threads are per-monitor-V2, so on a 150-200% display the frame came out a few
+// pixels short of what the fixed Lay:: layout assumes and the last detail row
+// sat against the bottom edge. AdjustWindowRectExForDpi takes the same
+// arguments plus the DPI already in hand; it is Win10 1607+, so it is resolved
+// the same way GetDpiForWindow is, and falls back to the old call when absent.
+static void AdjustWindowRectForDpi(RECT *r, DWORD style, UINT dpi)
+{
+    using Fn = BOOL(WINAPI *)(LPRECT, DWORD, BOOL, DWORD, UINT);
+    static Fn fn = (Fn)GetProcAddress(GetModuleHandleW(L"user32.dll"),
+                                      "AdjustWindowRectExForDpi");
+    if (fn && dpi)
+        fn(r, style, FALSE, 0, dpi);
+    else
+        AdjustWindowRectEx(r, style, FALSE, 0);
+}
+
 static bool EdgeTrio(Zone z, Zone out[3])
 {
     struct Run
@@ -4490,6 +4586,8 @@ static std::wstring FormatTuning(int i, int value)
         _snwprintf_s(buf, _countof(buf), _TRUNCATE, L"%d px", value);
     else if (i == 5)
     {
+        // Indexed by the kModifier* values, so this order is not free to
+        // change independently of them.
         static const wchar_t *kMods[] = {L"None", L"Ctrl", L"Alt", L"Shift",
                                          L"Win"};
         return (value >= 0 && value < 5) ? kMods[value] : L"None";
@@ -5556,7 +5654,7 @@ static DWORD WINAPI DashThread(LPVOID)
     DWORD style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX |
                   WS_CLIPCHILDREN;
     RECT need = {0, 0, Sc(Lay::ClientW, dpi), Sc(Lay::ClientH, dpi)};
-    AdjustWindowRectEx(&need, style, FALSE, 0);
+    AdjustWindowRectForDpi(&need, style, dpi);
     int w = need.right - need.left;
     int h = need.bottom - need.top;
     int x = (GetSystemMetrics(SM_CXSCREEN) - w) / 2;
@@ -5588,7 +5686,7 @@ static DWORD WINAPI DashThread(LPVOID)
         if (real != dpi)
         {
             RECT want = {0, 0, Sc(Lay::ClientW, real), Sc(Lay::ClientH, real)};
-            AdjustWindowRectEx(&want, style, FALSE, 0);
+            AdjustWindowRectForDpi(&want, style, real);
             SetWindowPos(hWnd, nullptr, 0, 0, want.right - want.left,
                          want.bottom - want.top,
                          SWP_NOZORDER | SWP_NOMOVE | SWP_NOACTIVATE);
@@ -5707,6 +5805,14 @@ static LRESULT CALLBACK TrayWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
     // Explorer restarted and threw away every tray icon; put ours back.
     if (g_taskbarCreatedMsg && uMsg == g_taskbarCreatedMsg)
     {
+        // The GUID may have been abandoned for a reason that has just gone
+        // away. A tool-mod process can start before Explorer has a taskbar, and
+        // then *both* add attempts fail - which the fallback reads as "the GUID
+        // was refused" and latches off for the session. That costs the icon its
+        // stable identity, so the user's "always show this icon" choice stops
+        // sticking across reboots and it shares plain uID space with every
+        // other tray-owning mod in windhawk.exe.
+        g_trayUseGuid = true;
         UpdateTrayIcon(true);
         return 0;
     }

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -1,0 +1,2800 @@
+// ==WindhawkMod==
+// @id              win-x-hotcorners
+// @name            Win-X Hot Corners
+// @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
+// @version         3.5.0
+// @author          lost_husky
+// @github          https://github.com/DhakadG
+// @license         MIT
+// @include         windhawk.exe
+// @compilerOptions -lcomctl32 -lpowrprof -lshell32 -luser32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Win-X Hot Corners
+
+macOS-style hot corners **and screen edges** for Windows 10/11 with **full
+multi-monitor support**.
+
+Instantly trigger configurable actions when your cursor reaches any screen
+corner or edge. Configure different actions for each zone on each monitor
+independently.
+
+Inspired by [WinXCorners](https://github.com/vhanla/winxcorners), rebuilt as a
+Windhawk mod.
+
+## Features
+
+- **Bounded latency** — a dedicated detection thread samples the cursor every
+  ~16 ms. Nothing can starve it: not a busy explorer, not an elevated
+  foreground app, not a slow action.
+- **Zero impact on the rest of the system** — no global mouse hook, so your
+  games and apps keep their input path to themselves.
+- **Monitors identified by name** — zones bind to a display's friendly name
+  (e.g. `Dell U2720Q`), so rearranging your desktop or changing which display
+  is primary never reshuffles your configuration.
+- **Per-monitor DPI correct** — detection runs per-monitor-DPI-aware, so
+  zones land in the right place on mixed-scaling setups.
+- **Screen edges** — trigger actions on the top, bottom, left, or right edge
+  of any monitor.
+- **Configurable zone size**, optional dwell delay, and a cooldown timer.
+- **Fullscreen protection** — auto-detects games, presentations, and D3D
+  fullscreen apps.
+- **Drag protection** — zones don't fire while a mouse button is held.
+- **App exclusions** — blacklist processes that need corner/edge clicks.
+
+## Available Actions
+
+**Switching**
+
+| Action | Description |
+|--------|-------------|
+| Task View | Overview of all windows (Win+Tab) |
+| Switch to Last Window | Jump straight back to the previous window (Alt+Tab) |
+| Task Switcher | Persistent switcher you can click through (Ctrl+Alt+Tab) |
+| Virtual Desktop — Next / Previous / New | Move between or create desktops |
+
+**Windows**
+
+| Action | Description |
+|--------|-------------|
+| Show Desktop | Toggle desktop visibility |
+| Hide Other Windows | Minimize all except the active window (Win+Home) |
+| Minimize Active Window | Win+Down |
+| Maximize Active Window | Win+Up |
+| Snap Window Left / Right | Win+Left / Win+Right |
+| Close Active Window | Alt+F4 |
+
+**System**
+
+| Action | Description |
+|--------|-------------|
+| Start Menu | Open the Start menu |
+| Search | Win+S |
+| Settings | Win+I |
+| File Explorer | Win+E |
+| Quick Settings | Win+A |
+| Notification Center | Win+N |
+| Clipboard History | Win+V |
+| Screenshot / Snip | Win+Shift+S |
+| Project / Second Screen | Win+P |
+| Task Manager | Open Task Manager |
+| Mute Volume | Toggle system mute |
+
+**Power**
+
+| Action | Description |
+|--------|-------------|
+| Lock Computer | Lock the workstation instantly |
+| Sleep | Put the computer to sleep |
+| Turn Off Monitors | Power off all displays |
+| Start Screen Saver | Activate the screen saver |
+
+**Custom**
+
+| Action | Description |
+|--------|-------------|
+| Virtual Key Press | Send any key combination, or several in sequence |
+| Custom Command | Launch any executable, path, or URL |
+| Nothing | Disabled (default) |
+
+## Identifying your monitors
+
+Set **Monitor** to the display's friendly name. The exact names for your
+displays are written to this mod's log every time it loads or your display
+layout changes — open the log and look for lines like:
+
+```
+Monitor 1 [PRIMARY] id='Dell U2720Q' device=\\.\DISPLAY1 (0,0)-(3840,2160)
+Monitor 2           id='BOE0998'     device=\\.\DISPLAY2 (3840,0)-(5760,1080)
+```
+
+Copy the text inside the quotes. If you own two identical displays they get a
+` #2`, ` #3` suffix so each stays separately configurable.
+
+Special values:
+
+- `*` — applies to every monitor (use this for one shared configuration)
+- *(empty)* — falls back to the numeric **Monitor Number** field, for
+  configurations carried over from v2.x
+
+Resolution is **per zone**: a name-matched entry wins over `*` for the zones
+it defines, and `*` supplies the rest. So you can put a shared config on `*`
+and override just one corner on one display.
+
+## A note on inner corners
+
+Windows lets the pointer cross freely between adjacent monitors, so corners
+along a shared boundary have nothing to stop the cursor against. They are hard
+to hit on purpose and easy to hit by accident. Prefer the outer perimeter of
+your desktop arrangement — the pointer physically stops there, which is what
+makes hot corners feel reliable on macOS.
+
+## Virtual Key Press Format
+
+One combination is `Modifier+Key`. Separate several with semicolons and they
+are sent **one after another**, not merged into a single chord — `Ctrl+C;Alt+Tab`
+sends Ctrl+C, then Alt+Tab.
+
+**Modifiers:** Ctrl, Alt, Shift, Win
+**Keys:** A-Z, 0-9, F1-F24, Enter, Space, Tab, Escape, Home, End, Delete,
+Left, Right, Up, Down, etc.
+
+**Examples:** `Ctrl+Shift+Esc`, `Alt+F4`, `Win+L`
+
+## Custom Command Format
+
+Any executable path, file, folder, or URL. Environment variables like
+`%AppData%` are expanded automatically.
+
+**Examples:**
+- `notepad.exe`
+- `C:\Windows\System32\cmd.exe`
+- `%AppData%\my_script.bat`
+- `https://example.com`
+
+Prefix with `uac;` to request elevation: `uac;cmd.exe`
+
+## App Exclusions
+
+Semicolon-separated list of process names (case-insensitive).
+Hot corners are disabled when any excluded process is the foreground window.
+
+**Example:** `photoshop.exe;premiere.exe;blender.exe`
+
+## What's New in v3.4.0
+
+- **16 new actions**, so common shortcuts no longer need a Virtual Key Press:
+  Switch to Last Window (Alt+Tab), Task Switcher (Ctrl+Alt+Tab), Minimize,
+  Maximize, Snap Left/Right, Close Window, File Explorer, Settings, Search,
+  Clipboard History, Screenshot, Project, and Virtual Desktop Next/Previous/New.
+
+## What's New in v3.3.0
+
+- **Extended keys are now flagged correctly.** Arrow keys, Home/End/PgUp/PgDn,
+  Insert/Delete, the Win keys, right Ctrl/Alt and the media keys sit on the
+  E0-prefixed part of the keyboard. Injected without `KEYEVENTF_EXTENDEDKEY`
+  they resolve to their numpad twins, so a Virtual Key Press using
+  `Win+Right` (snap) or any arrow/navigation key silently did the wrong thing.
+- **Unquoted paths containing spaces now launch.** `C:\Program Files\Tool\t.exe -x`
+  was split into `C:\Program` plus arguments and failed with file-not-found.
+  The executable is now rebuilt token by token until it names a real file.
+  Bare commands (`notepad.exe`) are untouched so the shell still resolves them
+  via PATH, and quoted paths behave exactly as before.
+- **Windows 11 shell surfaces hosted outside explorer.exe** — Start
+  (`StartMenuExperienceHost.exe`), Search (`SearchHost.exe`), Action Center —
+  are no longer mistaken for fullscreen apps. Matched by exact process name,
+  not a `*Host.exe` suffix rule, which would also match ordinary applications.
+
+## What's New in v3.2.0 — stability
+
+Spamming the zones could make the whole desktop stagger. Four causes, all fixed:
+
+- **Stuck modifier keys.** Key injection used to release any modifier you were
+  physically holding and re-press it afterwards. If you let go in between, that
+  re-press had no matching release and the modifier stayed logically held down
+  for the rest of the session — a stuck Win or Ctrl key breaks every app at
+  once. Removed: every key the mod presses is now released in the same batch.
+- **Burst injection.** A sweep across several zones queued a burst of shell
+  commands that the worker replayed back-to-back — four Win+Tab injections in
+  40 ms in one report. There is now a hard 250 ms floor between any two
+  actions, and the queue holds 2 instead of 8 so a backlog is dropped rather
+  than replayed late.
+- **Logging on the hot path.** Every trigger wrote to `OutputDebugString`,
+  which takes a machine-wide lock — that stalls *other* Windhawk mods, not
+  just this one. Per-trigger logging is now off by default (**Verbose
+  logging**). Errors and startup info are still always logged.
+- **Unsafe teardown.** If a thread was still busy (e.g. blocked on a UAC
+  prompt) the mod freed the locks it was using. It now leaks them instead —
+  the process exits immediately after, so a leak is free and a use-after-free
+  is not.
+
+Also: the display-layout poll ran 5 system calls every 16 ms; it now runs
+twice a second, leaving the tick to one cursor read plus a few comparisons.
+
+## What's New in v3.1.0
+
+- **Fixed: zones stopped working while Task View / Start / Search was open.**
+  Those are shell surfaces that exactly match the monitor size, so the
+  fullscreen-app guard classified them as fullscreen games and suppressed
+  every trigger until they closed. v2.x was immune only by accident — it ran
+  inside explorer.exe and skipped windows belonging to its own process, and
+  Task View *is* explorer.exe. Moving to a dedicated process silently
+  invalidated that test. The guard now compares against the shell's process,
+  which is what was always meant.
+- Removed a 150 ms diagnostic delay per action that could back up the queue.
+- Zone sizes are clamped per monitor so the eight zones can never overlap:
+  a corner larger than half the screen, or an edge thicker than the corner
+  box, previously made one zone shadow another (only the first was reachable).
+
+## What's New in v3.0.2
+
+- **Zones no longer fire when you just pass through them.** A corner cannot be
+  reached without crossing the edge strip beside it, so moving into a corner
+  fired the edge action ~30 ms before the corner one. With a toggle bound to
+  both (Task View, Show Desktop) that opened and instantly re-closed — looking
+  exactly like the mod did nothing. The new **Pass-through guard** setting
+  (80 ms) requires the cursor to settle, so only the zone you stop in fires.
+- `SendInput` failures are now logged instead of silently discarded.
+- Each trigger logs the foreground window before and after, so a cancelled
+  toggle is visible in the log rather than looking like success.
+
+## What's New in v3.0.1
+
+- Fixed the mod never loading. v3.0.0 kept the `@architecture x86-64` line
+  from v2.x, but `windhawk.exe` is a 32-bit process — so the mod was only ever
+  built as a 64-bit DLL and Windhawk had nothing to inject. No logs, no zones,
+  no sign of life. Tool mods must not restrict architecture.
+
+## What's New in v3.0.0
+
+- **Runs as a dedicated process** instead of injecting into explorer.exe.
+  Detection no longer shares a thread with the taskbar — that shared thread
+  was why zones fired seconds late or not at all.
+- **Polled detection replaces the low-level mouse hook.** The old hook was
+  installed on explorer's taskbar thread; whenever that thread was busy,
+  Windows skipped the callback and could silently remove the hook. Polling is
+  immune to that, to UIPI, and to elevated foreground apps — and it stops
+  routing every mouse event on the system through explorer.
+- **Monitors identified by friendly name**, not by position in a sorted list.
+- **Per-monitor DPI awareness pinned explicitly**, fixing zones landing at
+  the wrong coordinates on mixed-scaling multi-monitor setups.
+- **Actions run on a worker thread**, so a slow launch can never delay
+  detection.
+- Display-layout changes are picked up even when Windows doesn't send
+  `WM_DISPLAYCHANGE` (docking, monitor wake, RDP reconnect).
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- CornerSize: 6
+  $name: Corner activation size (pixels)
+  $description: >-
+    How many pixels from the screen corner activate the hot corner.
+    Smaller values require more precision; larger values are easier to hit.
+- EdgeSize: 6
+  $name: Edge activation size (pixels)
+  $description: >-
+    How many pixels along the screen edge activate the hot edge.
+    Only applies to edge zones, not corners.
+- ActivationDelay: 0
+  $name: Activation delay (ms)
+  $description: >-
+    Delay in milliseconds before the action triggers. 0 = instant.
+    Use 200-500 ms to prevent accidental triggers.
+- SettleMs: 80
+  $name: Pass-through guard (ms)
+  $description: >-
+    How long the cursor must stay in a zone before it counts as entered.
+    You cannot reach a corner without crossing the edge next to it, so
+    without this a fast move into a corner fires the edge action too — and
+    if both are a toggle (like Task View) they cancel out and nothing seems
+    to happen. 80 ms is imperceptible and blocks pass-through firing.
+    Set to 0 only if you use corners or edges but never both.
+- ShowMonitorNames: true
+  $name: List my monitors in the log
+  $description: >-
+    Writes your connected displays to this mod's log every time it loads or
+    your display layout changes, so you can copy a name straight into the
+    Monitor field above instead of guessing it. Harmless to leave on - it
+    only writes a few lines, and only when something actually changes.
+- VerboseLogging: false
+  $name: Verbose logging
+  $description: >-
+    Log every trigger and key injection. Off by default: these logs go through
+    OutputDebugString, which takes a system-wide lock, so logging on every
+    trigger can stutter other Windhawk mods. Turn on only while diagnosing.
+    Errors and startup information are always logged.
+- CooldownMs: 300
+  $name: Cooldown between triggers (ms)
+  $description: >-
+    Minimum time between sequential triggers of the same zone.
+    Prevents double-firing when cursor twitches. 0 = no cooldown.
+- DisableOnFullscreen: true
+  $name: Disable on fullscreen apps
+  $description: >-
+    Don't trigger hot corners when a fullscreen application (game, video,
+    presentation) is the foreground window.
+- DisableDuringDrag: true
+  $name: Disable during mouse drag
+  $description: >-
+    Don't trigger hot corners while any mouse button is held down.
+- ExcludedProcesses: ""
+  $name: Excluded processes (blacklist)
+  $description: >-
+    Semicolon-separated list of process names. Hot corners are disabled
+    when any of these processes is the foreground window.
+    Example: photoshop.exe;premiere.exe;blender.exe
+- MonitorCorners:
+  - - MonitorId: ""
+      $name: Monitor
+      $description: >-
+        The display's friendly name, e.g. Dell U2720Q. The exact names for
+        your displays are written to this mod's log every time it loads.
+        Use * for all monitors. Leave empty to fall back to the numeric
+        Monitor Number field below.
+    - Monitor: 0
+      $name: Monitor Number (legacy fallback)
+      $description: >-
+        Only used when Monitor above is left empty. 0 = all monitors,
+        1 = primary, 2 = second, etc. Prefer the name field — numbers shift
+        when you rearrange displays.
+    - TopLeft: ACTION_NOTHING
+      $name: Top-Left Corner
+      $options:
+      - ACTION_NOTHING: Nothing
+      - ACTION_SHOW_DESKTOP: Show Desktop
+      - ACTION_TASK_VIEW: Task View (Win+Tab)
+      - ACTION_SCREENSAVER: Start Screen Saver
+      - ACTION_MONITORS_OFF: Turn Off Monitors
+      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
+      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
+      - ACTION_START_MENU: Start Menu
+      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
+      - ACTION_MUTE: Mute Volume
+      - ACTION_TASK_MANAGER: Task Manager
+      - ACTION_LOCK: Lock Computer
+      - ACTION_SLEEP: Sleep
+      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
+      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
+      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
+      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
+      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
+      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
+      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
+      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
+      - ACTION_SETTINGS: Settings (Win+I)
+      - ACTION_SEARCH: Search (Win+S)
+      - ACTION_CLIPBOARD: Clipboard History (Win+V)
+      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
+      - ACTION_PROJECT: Project / Second Screen (Win+P)
+      - ACTION_VDESK_NEXT: Virtual Desktop - Next
+      - ACTION_VDESK_PREV: Virtual Desktop - Previous
+      - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_SEND_KEYPRESS: Virtual Key Press
+      - ACTION_START_PROCESS: Custom Command
+    - TopLeftArgs: ""
+      $name: Top-Left Args
+      $description: >-
+        For Virtual Key Press (e.g. Ctrl+Shift+Esc) or Custom Command
+        (e.g. notepad.exe) only.
+    - TopRight: ACTION_NOTHING
+      $name: Top-Right Corner
+      $options:
+      - ACTION_NOTHING: Nothing
+      - ACTION_SHOW_DESKTOP: Show Desktop
+      - ACTION_TASK_VIEW: Task View (Win+Tab)
+      - ACTION_SCREENSAVER: Start Screen Saver
+      - ACTION_MONITORS_OFF: Turn Off Monitors
+      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
+      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
+      - ACTION_START_MENU: Start Menu
+      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
+      - ACTION_MUTE: Mute Volume
+      - ACTION_TASK_MANAGER: Task Manager
+      - ACTION_LOCK: Lock Computer
+      - ACTION_SLEEP: Sleep
+      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
+      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
+      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
+      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
+      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
+      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
+      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
+      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
+      - ACTION_SETTINGS: Settings (Win+I)
+      - ACTION_SEARCH: Search (Win+S)
+      - ACTION_CLIPBOARD: Clipboard History (Win+V)
+      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
+      - ACTION_PROJECT: Project / Second Screen (Win+P)
+      - ACTION_VDESK_NEXT: Virtual Desktop - Next
+      - ACTION_VDESK_PREV: Virtual Desktop - Previous
+      - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_SEND_KEYPRESS: Virtual Key Press
+      - ACTION_START_PROCESS: Custom Command
+    - TopRightArgs: ""
+      $name: Top-Right Args
+      $description: >-
+        For Virtual Key Press or Custom Command only.
+    - BottomLeft: ACTION_NOTHING
+      $name: Bottom-Left Corner
+      $options:
+      - ACTION_NOTHING: Nothing
+      - ACTION_SHOW_DESKTOP: Show Desktop
+      - ACTION_TASK_VIEW: Task View (Win+Tab)
+      - ACTION_SCREENSAVER: Start Screen Saver
+      - ACTION_MONITORS_OFF: Turn Off Monitors
+      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
+      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
+      - ACTION_START_MENU: Start Menu
+      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
+      - ACTION_MUTE: Mute Volume
+      - ACTION_TASK_MANAGER: Task Manager
+      - ACTION_LOCK: Lock Computer
+      - ACTION_SLEEP: Sleep
+      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
+      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
+      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
+      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
+      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
+      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
+      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
+      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
+      - ACTION_SETTINGS: Settings (Win+I)
+      - ACTION_SEARCH: Search (Win+S)
+      - ACTION_CLIPBOARD: Clipboard History (Win+V)
+      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
+      - ACTION_PROJECT: Project / Second Screen (Win+P)
+      - ACTION_VDESK_NEXT: Virtual Desktop - Next
+      - ACTION_VDESK_PREV: Virtual Desktop - Previous
+      - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_SEND_KEYPRESS: Virtual Key Press
+      - ACTION_START_PROCESS: Custom Command
+    - BottomLeftArgs: ""
+      $name: Bottom-Left Args
+      $description: >-
+        For Virtual Key Press or Custom Command only.
+    - BottomRight: ACTION_NOTHING
+      $name: Bottom-Right Corner
+      $options:
+      - ACTION_NOTHING: Nothing
+      - ACTION_SHOW_DESKTOP: Show Desktop
+      - ACTION_TASK_VIEW: Task View (Win+Tab)
+      - ACTION_SCREENSAVER: Start Screen Saver
+      - ACTION_MONITORS_OFF: Turn Off Monitors
+      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
+      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
+      - ACTION_START_MENU: Start Menu
+      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
+      - ACTION_MUTE: Mute Volume
+      - ACTION_TASK_MANAGER: Task Manager
+      - ACTION_LOCK: Lock Computer
+      - ACTION_SLEEP: Sleep
+      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
+      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
+      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
+      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
+      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
+      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
+      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
+      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
+      - ACTION_SETTINGS: Settings (Win+I)
+      - ACTION_SEARCH: Search (Win+S)
+      - ACTION_CLIPBOARD: Clipboard History (Win+V)
+      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
+      - ACTION_PROJECT: Project / Second Screen (Win+P)
+      - ACTION_VDESK_NEXT: Virtual Desktop - Next
+      - ACTION_VDESK_PREV: Virtual Desktop - Previous
+      - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_SEND_KEYPRESS: Virtual Key Press
+      - ACTION_START_PROCESS: Custom Command
+    - BottomRightArgs: ""
+      $name: Bottom-Right Args
+      $description: >-
+        For Virtual Key Press or Custom Command only.
+    - EdgeTop: ACTION_NOTHING
+      $name: Top Edge
+      $options:
+      - ACTION_NOTHING: Nothing
+      - ACTION_SHOW_DESKTOP: Show Desktop
+      - ACTION_TASK_VIEW: Task View (Win+Tab)
+      - ACTION_SCREENSAVER: Start Screen Saver
+      - ACTION_MONITORS_OFF: Turn Off Monitors
+      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
+      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
+      - ACTION_START_MENU: Start Menu
+      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
+      - ACTION_MUTE: Mute Volume
+      - ACTION_TASK_MANAGER: Task Manager
+      - ACTION_LOCK: Lock Computer
+      - ACTION_SLEEP: Sleep
+      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
+      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
+      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
+      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
+      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
+      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
+      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
+      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
+      - ACTION_SETTINGS: Settings (Win+I)
+      - ACTION_SEARCH: Search (Win+S)
+      - ACTION_CLIPBOARD: Clipboard History (Win+V)
+      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
+      - ACTION_PROJECT: Project / Second Screen (Win+P)
+      - ACTION_VDESK_NEXT: Virtual Desktop - Next
+      - ACTION_VDESK_PREV: Virtual Desktop - Previous
+      - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_SEND_KEYPRESS: Virtual Key Press
+      - ACTION_START_PROCESS: Custom Command
+    - EdgeTopArgs: ""
+      $name: Top Edge Args
+      $description: >-
+        For Virtual Key Press or Custom Command only.
+    - EdgeBottom: ACTION_NOTHING
+      $name: Bottom Edge
+      $options:
+      - ACTION_NOTHING: Nothing
+      - ACTION_SHOW_DESKTOP: Show Desktop
+      - ACTION_TASK_VIEW: Task View (Win+Tab)
+      - ACTION_SCREENSAVER: Start Screen Saver
+      - ACTION_MONITORS_OFF: Turn Off Monitors
+      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
+      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
+      - ACTION_START_MENU: Start Menu
+      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
+      - ACTION_MUTE: Mute Volume
+      - ACTION_TASK_MANAGER: Task Manager
+      - ACTION_LOCK: Lock Computer
+      - ACTION_SLEEP: Sleep
+      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
+      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
+      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
+      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
+      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
+      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
+      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
+      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
+      - ACTION_SETTINGS: Settings (Win+I)
+      - ACTION_SEARCH: Search (Win+S)
+      - ACTION_CLIPBOARD: Clipboard History (Win+V)
+      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
+      - ACTION_PROJECT: Project / Second Screen (Win+P)
+      - ACTION_VDESK_NEXT: Virtual Desktop - Next
+      - ACTION_VDESK_PREV: Virtual Desktop - Previous
+      - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_SEND_KEYPRESS: Virtual Key Press
+      - ACTION_START_PROCESS: Custom Command
+    - EdgeBottomArgs: ""
+      $name: Bottom Edge Args
+      $description: >-
+        For Virtual Key Press or Custom Command only.
+    - EdgeLeft: ACTION_NOTHING
+      $name: Left Edge
+      $options:
+      - ACTION_NOTHING: Nothing
+      - ACTION_SHOW_DESKTOP: Show Desktop
+      - ACTION_TASK_VIEW: Task View (Win+Tab)
+      - ACTION_SCREENSAVER: Start Screen Saver
+      - ACTION_MONITORS_OFF: Turn Off Monitors
+      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
+      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
+      - ACTION_START_MENU: Start Menu
+      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
+      - ACTION_MUTE: Mute Volume
+      - ACTION_TASK_MANAGER: Task Manager
+      - ACTION_LOCK: Lock Computer
+      - ACTION_SLEEP: Sleep
+      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
+      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
+      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
+      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
+      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
+      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
+      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
+      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
+      - ACTION_SETTINGS: Settings (Win+I)
+      - ACTION_SEARCH: Search (Win+S)
+      - ACTION_CLIPBOARD: Clipboard History (Win+V)
+      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
+      - ACTION_PROJECT: Project / Second Screen (Win+P)
+      - ACTION_VDESK_NEXT: Virtual Desktop - Next
+      - ACTION_VDESK_PREV: Virtual Desktop - Previous
+      - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_SEND_KEYPRESS: Virtual Key Press
+      - ACTION_START_PROCESS: Custom Command
+    - EdgeLeftArgs: ""
+      $name: Left Edge Args
+      $description: >-
+        For Virtual Key Press or Custom Command only.
+    - EdgeRight: ACTION_NOTHING
+      $name: Right Edge
+      $options:
+      - ACTION_NOTHING: Nothing
+      - ACTION_SHOW_DESKTOP: Show Desktop
+      - ACTION_TASK_VIEW: Task View (Win+Tab)
+      - ACTION_SCREENSAVER: Start Screen Saver
+      - ACTION_MONITORS_OFF: Turn Off Monitors
+      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
+      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
+      - ACTION_START_MENU: Start Menu
+      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
+      - ACTION_MUTE: Mute Volume
+      - ACTION_TASK_MANAGER: Task Manager
+      - ACTION_LOCK: Lock Computer
+      - ACTION_SLEEP: Sleep
+      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
+      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
+      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
+      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
+      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
+      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
+      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
+      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
+      - ACTION_SETTINGS: Settings (Win+I)
+      - ACTION_SEARCH: Search (Win+S)
+      - ACTION_CLIPBOARD: Clipboard History (Win+V)
+      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
+      - ACTION_PROJECT: Project / Second Screen (Win+P)
+      - ACTION_VDESK_NEXT: Virtual Desktop - Next
+      - ACTION_VDESK_PREV: Virtual Desktop - Previous
+      - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_SEND_KEYPRESS: Virtual Key Press
+      - ACTION_START_PROCESS: Custom Command
+    - EdgeRightArgs: ""
+      $name: Right Edge Args
+      $description: >-
+        For Virtual Key Press or Custom Command only.
+  $name: Monitor Corner & Edge Configuration
+*/
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+
+#include <commctrl.h> // windhawk_utils.h needs SUBCLASSPROC from here
+#include <initializer_list>
+#include <powrprof.h>
+#include <shellapi.h>
+#include <windhawk_api.h>
+#include <windhawk_utils.h>
+
+#include <algorithm>
+#include <cwctype>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// Undocumented Shell command ID for IShellDispatch::ToggleDesktop
+#define SHELL_TRAY_TOGGLE_DESKTOP 407
+
+// =====================================================================
+// Enums & Types
+// =====================================================================
+
+enum class CornerAction
+{
+    Nothing,
+    ShowDesktop,
+    TaskView,
+    ScreenSaver,
+    MonitorsOff,
+    QuickSettings,
+    NotificationCenter,
+    StartMenu,
+    HideOthers,
+    Mute,
+    TaskManager,
+    Lock,
+    Sleep,
+    SwitchLastWindow,
+    TaskSwitcher,
+    MinimizeWindow,
+    MaximizeWindow,
+    SnapLeft,
+    SnapRight,
+    CloseWindow,
+    FileExplorer,
+    SettingsApp,
+    Search,
+    ClipboardHistory,
+    Screenshot,
+    ProjectDisplay,
+    VDesktopNext,
+    VDesktopPrev,
+    VDesktopNew,
+    SendKeypress,
+    StartProcess,
+};
+
+// Zone IDs: 0-3 = corners, 4-7 = edges
+enum Zone
+{
+    ZONE_TOP_LEFT = 0,
+    ZONE_TOP_RIGHT = 1,
+    ZONE_BOTTOM_LEFT = 2,
+    ZONE_BOTTOM_RIGHT = 3,
+    ZONE_EDGE_TOP = 4,
+    ZONE_EDGE_BOTTOM = 5,
+    ZONE_EDGE_LEFT = 6,
+    ZONE_EDGE_RIGHT = 7,
+    ZONE_COUNT = 8,
+};
+
+struct ZoneConfig
+{
+    CornerAction action = CornerAction::Nothing;
+    std::wstring args;
+    std::function<void()> executor;
+};
+
+struct MonitorZoneConfig
+{
+    std::wstring monitorId; // friendly name, "*" for all, or "" to use index
+    int monitorIndex = 0;   // legacy fallback, only used when monitorId empty
+    ZoneConfig zones[ZONE_COUNT];
+};
+
+struct MonitorInfo
+{
+    HMONITOR handle;
+    RECT rcMonitor;
+    bool isPrimary;
+    int index;           // 1-based, legacy ordinal assigned after sorting
+    std::wstring device; // GDI name, e.g. \\.\DISPLAY1
+    std::wstring id;     // friendly name, suffixed if duplicated
+};
+
+// A resolved, ready-to-fire zone. Owns its executor so the whole set can be
+// published as an immutable snapshot and read without touching g_settings.
+struct HitZone
+{
+    RECT rect;
+    std::function<void()> exec;
+    std::wstring label; // "Dell U2720Q TopLeft -> TaskView", for logging
+};
+
+// The detection loop reads nothing but this snapshot, so it never touches
+// g_settings and never takes a lock on the timing-critical path.
+struct ZoneSet
+{
+    std::vector<HitZone> zones;
+    int activationDelay = 0;
+    int settleMs = 80;
+    int cooldownMs = 0;
+    bool disableDuringDrag = true;
+};
+
+// =====================================================================
+// Globals
+// =====================================================================
+
+static struct
+{
+    int cornerSize = 6;
+    int edgeSize = 6;
+    int activationDelay = 0;
+    int settleMs = 80;
+    int cooldownMs = 300;
+    bool disableOnFullscreen = true;
+    bool disableDuringDrag = true;
+    std::vector<std::wstring> excludedProcesses;
+    std::vector<MonitorZoneConfig> monitorConfigs;
+} g_settings;
+
+// g_settings is written by Windhawk's thread and read by the detection thread
+// only when it rebuilds zones. Everything the detection loop needs at runtime
+// lives in the published ZoneSet instead, so this is never taken per tick.
+static CRITICAL_SECTION g_settingsLock;
+
+// Published zone snapshot. Swapped wholesale on rebuild; readers take a
+// shared_ptr copy, so an in-flight tick can never see a half-rebuilt vector.
+static CRITICAL_SECTION g_zonesLock;
+static std::shared_ptr<const ZoneSet> g_zones;
+
+static std::vector<MonitorInfo> g_monitors; // detection thread only
+
+// Detection thread
+static constexpr DWORD kTickMs = 16;
+static HANDLE g_hDetectThread = nullptr;
+static DWORD g_dwDetectThreadId = 0;
+static HWND g_hDetectWnd = nullptr;
+static HANDLE g_hStopEvent = nullptr;
+
+// Per-fire logging is opt-in. Wh_Log goes through OutputDebugString, which
+// takes a machine-wide mutex; spamming it from a hot path serialises every
+// other process that logs — including the other Windhawk mods.
+static bool g_verboseLog = false;
+
+// Prints the monitor list at load and on display changes, so names can be
+// copied into the Monitor setting instead of guessed. Cheap - once per event.
+static bool g_showMonitorNames = true;
+
+// Hard floor between any two actions, whatever the zone or the cooldown
+// setting. Actions are user-visible shell operations (Task View, Show Desktop,
+// launching a process); replaying a queued burst of them back-to-back is what
+// made the desktop stagger. This is a safety limit, not a preference, so it is
+// deliberately not configurable.
+static constexpr ULONGLONG kMinFireIntervalMs = 250;
+static ULONGLONG g_lastAnyFireTick = 0;
+
+// Action worker thread
+static HANDLE g_hWorkerThread = nullptr;
+static HANDLE g_hWorkEvent = nullptr;
+static CRITICAL_SECTION g_queueLock;
+static std::deque<HitZone> g_queue;
+// Small on purpose: the rate limiter should stop bursts before they queue, so
+// a backlog means something went wrong. Dropping is safer than replaying a
+// pile of stale shell commands seconds after the user made the gesture.
+static constexpr size_t kMaxQueue = 2;
+
+// Detection state (detection thread only)
+static int g_activeZone = -1;
+static ULONGLONG g_enterTick = 0;
+static bool g_firedThisEntry = false;
+static std::vector<ULONGLONG> g_lastFireTick;
+
+// Cached display topology, for catching layout changes Windows doesn't
+// announce (docking, monitor wake, RDP reconnect).
+static int g_topoCount = -1;
+static RECT g_topoVirtual = {};
+
+static constexpr UINT WM_APP_REBUILD = WM_APP + 1;
+
+// Forward declarations
+static void LoadSettings();
+static const wchar_t *ZoneToString(Zone z);
+static const wchar_t *ActionToString(CornerAction a);
+
+// =====================================================================
+// String Utilities
+// =====================================================================
+
+static std::wstring TrimStr(const std::wstring &s)
+{
+    auto start = s.find_first_not_of(L" \t\r\n");
+    if (start == std::wstring::npos)
+        return L"";
+    auto end = s.find_last_not_of(L" \t\r\n");
+    return s.substr(start, end - start + 1);
+}
+
+static std::wstring ToUpperStr(const std::wstring &s)
+{
+    std::wstring r = s;
+    std::transform(r.begin(), r.end(), r.begin(), ::towupper);
+    return r;
+}
+
+static std::wstring ToLowerStr(const std::wstring &s)
+{
+    std::wstring r = s;
+    std::transform(r.begin(), r.end(), r.begin(), ::towlower);
+    return r;
+}
+
+// =====================================================================
+// DPI
+// =====================================================================
+
+// Monitor rects and GetCursorPos return true physical coordinates only when
+// the calling thread is per-monitor aware. On a mixed-scaling setup a
+// system-aware thread gets virtualized rects instead, which puts the zones at
+// the wrong coordinates on the secondary display.
+static void PinThreadDpiPerMonitorV2()
+{
+    using pfnSetThreadDpiAwarenessContext = HANDLE(WINAPI *)(HANDLE);
+    HMODULE hUser32 = GetModuleHandleW(L"user32.dll");
+    if (!hUser32)
+        return;
+    auto pSet = (pfnSetThreadDpiAwarenessContext)GetProcAddress(
+        hUser32, "SetThreadDpiAwarenessContext");
+    if (pSet)
+        pSet((HANDLE)-4); // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+}
+
+// =====================================================================
+// Key Parsing (for Virtual Key Press action)
+// =====================================================================
+
+static const std::unordered_map<std::wstring, UINT> g_modifierMap = {
+    {L"ALT", MOD_ALT},
+    {L"CTRL", MOD_CONTROL},
+    {L"SHIFT", MOD_SHIFT},
+    {L"WIN", MOD_WIN},
+};
+
+static const std::unordered_map<std::wstring, WORD> g_vkMap = {
+    // Letters
+    {L"A", 0x41},
+    {L"B", 0x42},
+    {L"C", 0x43},
+    {L"D", 0x44},
+    {L"E", 0x45},
+    {L"F", 0x46},
+    {L"G", 0x47},
+    {L"H", 0x48},
+    {L"I", 0x49},
+    {L"J", 0x4A},
+    {L"K", 0x4B},
+    {L"L", 0x4C},
+    {L"M", 0x4D},
+    {L"N", 0x4E},
+    {L"O", 0x4F},
+    {L"P", 0x50},
+    {L"Q", 0x51},
+    {L"R", 0x52},
+    {L"S", 0x53},
+    {L"T", 0x54},
+    {L"U", 0x55},
+    {L"V", 0x56},
+    {L"W", 0x57},
+    {L"X", 0x58},
+    {L"Y", 0x59},
+    {L"Z", 0x5A},
+    // Numbers
+    {L"0", 0x30},
+    {L"1", 0x31},
+    {L"2", 0x32},
+    {L"3", 0x33},
+    {L"4", 0x34},
+    {L"5", 0x35},
+    {L"6", 0x36},
+    {L"7", 0x37},
+    {L"8", 0x38},
+    {L"9", 0x39},
+    // Function keys
+    {L"F1", VK_F1},
+    {L"F2", VK_F2},
+    {L"F3", VK_F3},
+    {L"F4", VK_F4},
+    {L"F5", VK_F5},
+    {L"F6", VK_F6},
+    {L"F7", VK_F7},
+    {L"F8", VK_F8},
+    {L"F9", VK_F9},
+    {L"F10", VK_F10},
+    {L"F11", VK_F11},
+    {L"F12", VK_F12},
+    {L"F13", VK_F13},
+    {L"F14", VK_F14},
+    {L"F15", VK_F15},
+    {L"F16", VK_F16},
+    {L"F17", VK_F17},
+    {L"F18", VK_F18},
+    {L"F19", VK_F19},
+    {L"F20", VK_F20},
+    {L"F21", VK_F21},
+    {L"F22", VK_F22},
+    {L"F23", VK_F23},
+    {L"F24", VK_F24},
+    // Common keys
+    {L"ENTER", VK_RETURN},
+    {L"RETURN", VK_RETURN},
+    {L"TAB", VK_TAB},
+    {L"SPACE", VK_SPACE},
+    {L"BACKSPACE", VK_BACK},
+    {L"ESCAPE", VK_ESCAPE},
+    {L"ESC", VK_ESCAPE},
+    {L"DELETE", VK_DELETE},
+    {L"DEL", VK_DELETE},
+    {L"INSERT", VK_INSERT},
+    {L"HOME", VK_HOME},
+    {L"END", VK_END},
+    {L"PAGEUP", VK_PRIOR},
+    {L"PAGEDOWN", VK_NEXT},
+    {L"LEFT", VK_LEFT},
+    {L"RIGHT", VK_RIGHT},
+    {L"UP", VK_UP},
+    {L"DOWN", VK_DOWN},
+    {L"PRINTSCREEN", VK_SNAPSHOT},
+    {L"PAUSE", VK_PAUSE},
+    {L"CAPSLOCK", VK_CAPITAL},
+    {L"NUMLOCK", VK_NUMLOCK},
+    {L"SCROLLLOCK", VK_SCROLL},
+    // Numpad
+    {L"NUMPAD0", VK_NUMPAD0},
+    {L"NUMPAD1", VK_NUMPAD1},
+    {L"NUMPAD2", VK_NUMPAD2},
+    {L"NUMPAD3", VK_NUMPAD3},
+    {L"NUMPAD4", VK_NUMPAD4},
+    {L"NUMPAD5", VK_NUMPAD5},
+    {L"NUMPAD6", VK_NUMPAD6},
+    {L"NUMPAD7", VK_NUMPAD7},
+    {L"NUMPAD8", VK_NUMPAD8},
+    {L"NUMPAD9", VK_NUMPAD9},
+    {L"MULTIPLY", VK_MULTIPLY},
+    {L"ADD", VK_ADD},
+    {L"SUBTRACT", VK_SUBTRACT},
+    {L"DECIMAL", VK_DECIMAL},
+    {L"DIVIDE", VK_DIVIDE},
+    // Media
+    {L"VOLUMEMUTE", VK_VOLUME_MUTE},
+    {L"VOLUMEUP", VK_VOLUME_UP},
+    {L"VOLUMEDOWN", VK_VOLUME_DOWN},
+    {L"MEDIAPLAYPAUSE", VK_MEDIA_PLAY_PAUSE},
+    {L"MEDIANEXT", VK_MEDIA_NEXT_TRACK},
+    {L"MEDIAPREV", VK_MEDIA_PREV_TRACK},
+    {L"MEDIASTOP", VK_MEDIA_STOP},
+    // Specific modifier VKs for keypress use
+    {L"LWIN", VK_LWIN},
+    {L"RWIN", VK_RWIN},
+    {L"LSHIFT", VK_LSHIFT},
+    {L"RSHIFT", VK_RSHIFT},
+    {L"LCTRL", VK_LCONTROL},
+    {L"RCTRL", VK_RCONTROL},
+    {L"LALT", VK_LMENU},
+    {L"RALT", VK_RMENU},
+};
+
+// Parses "Modifier+Key" into VK codes (modifiers first, key last), returning
+// one vector per semicolon-separated combo so they can be sent in sequence.
+// Flattening them into a single vector would turn "Ctrl+C;Alt+Tab" into one
+// Ctrl+Alt+C+Tab chord instead of two separate keystrokes.
+static std::vector<std::vector<WORD>> ParseKeyCombo(const std::wstring &input)
+{
+    std::vector<std::vector<WORD>> allCombos;
+    std::wstring remaining = input;
+
+    while (!remaining.empty())
+    {
+        std::wstring combo;
+        auto semi = remaining.find(L';');
+        if (semi != std::wstring::npos)
+        {
+            combo = TrimStr(remaining.substr(0, semi));
+            remaining = remaining.substr(semi + 1);
+        }
+        else
+        {
+            combo = TrimStr(remaining);
+            remaining.clear();
+        }
+
+        if (combo.empty())
+            continue;
+
+        std::vector<WORD> modifiers;
+        WORD mainKey = 0;
+
+        // Split on '+'
+        size_t start = 0;
+        while (start < combo.size())
+        {
+            auto plus = combo.find(L'+', start);
+            std::wstring token;
+            if (plus != std::wstring::npos)
+            {
+                token = TrimStr(combo.substr(start, plus - start));
+                start = plus + 1;
+            }
+            else
+            {
+                token = TrimStr(combo.substr(start));
+                start = combo.size();
+            }
+
+            if (token.empty())
+                continue;
+            std::wstring upper = ToUpperStr(token);
+
+            // Check if it's a modifier
+            auto modIt = g_modifierMap.find(upper);
+            if (modIt != g_modifierMap.end())
+            {
+                if (modIt->second == MOD_CONTROL)
+                    modifiers.push_back(VK_LCONTROL);
+                else if (modIt->second == MOD_ALT)
+                    modifiers.push_back(VK_LMENU);
+                else if (modIt->second == MOD_SHIFT)
+                    modifiers.push_back(VK_LSHIFT);
+                else if (modIt->second == MOD_WIN)
+                    modifiers.push_back(VK_LWIN);
+                continue;
+            }
+
+            // Check VK map
+            auto vkIt = g_vkMap.find(upper);
+            if (vkIt != g_vkMap.end())
+            {
+                mainKey = vkIt->second;
+            }
+            else
+            {
+                Wh_Log(L"Unknown key token: '%s'", token.c_str());
+            }
+        }
+
+        std::vector<WORD> keys = modifiers;
+        if (mainKey)
+            keys.push_back(mainKey);
+        if (!keys.empty())
+            allCombos.push_back(std::move(keys));
+    }
+
+    return allCombos;
+}
+
+// =====================================================================
+// Monitor Identity
+// =====================================================================
+
+// Maps GDI device name (\\.\DISPLAY1) -> monitor friendly name.
+// Friendly names come from the display's EDID and are stable across reboots,
+// unlike enumeration order, which changes whenever displays are rearranged or
+// a different display is made primary.
+static void QueryMonitorFriendlyNames(
+    std::unordered_map<std::wstring, std::wstring> &out)
+{
+    UINT32 pathCount = 0, modeCount = 0;
+    if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &pathCount,
+                                    &modeCount) != ERROR_SUCCESS)
+    {
+        Wh_Log(L"GetDisplayConfigBufferSizes failed");
+        return;
+    }
+
+    std::vector<DISPLAYCONFIG_PATH_INFO> paths(pathCount);
+    std::vector<DISPLAYCONFIG_MODE_INFO> modes(modeCount);
+    if (QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &pathCount, paths.data(),
+                           &modeCount, modes.data(), nullptr) != ERROR_SUCCESS)
+    {
+        Wh_Log(L"QueryDisplayConfig failed");
+        return;
+    }
+
+    for (UINT32 i = 0; i < pathCount; i++)
+    {
+        DISPLAYCONFIG_SOURCE_DEVICE_NAME src = {};
+        src.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+        src.header.size = sizeof(src);
+        src.header.adapterId = paths[i].sourceInfo.adapterId;
+        src.header.id = paths[i].sourceInfo.id;
+        if (DisplayConfigGetDeviceInfo(&src.header) != ERROR_SUCCESS)
+            continue;
+
+        DISPLAYCONFIG_TARGET_DEVICE_NAME tgt = {};
+        tgt.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+        tgt.header.size = sizeof(tgt);
+        tgt.header.adapterId = paths[i].targetInfo.adapterId;
+        tgt.header.id = paths[i].targetInfo.id;
+        if (DisplayConfigGetDeviceInfo(&tgt.header) != ERROR_SUCCESS)
+            continue;
+
+        std::wstring name = tgt.monitorFriendlyDeviceName;
+
+        // Internal panels (laptop screens) often report an empty friendly
+        // name. Fall back to the model token in the device path, which looks
+        // like \\?\DISPLAY#BOE0998#5&...
+        if (name.empty())
+        {
+            std::wstring path = tgt.monitorDevicePath;
+            size_t first = path.find(L'#');
+            if (first != std::wstring::npos)
+            {
+                size_t second = path.find(L'#', first + 1);
+                if (second != std::wstring::npos)
+                    name = path.substr(first + 1, second - first - 1);
+            }
+        }
+
+        if (!name.empty())
+            out[src.viewGdiDeviceName] = name;
+    }
+}
+
+static BOOL CALLBACK MonitorEnumProc(HMONITOR hMonitor, HDC, LPRECT,
+                                     LPARAM lParam)
+{
+    auto *monitors = reinterpret_cast<std::vector<MonitorInfo> *>(lParam);
+    MONITORINFOEXW mi = {};
+    mi.cbSize = sizeof(mi);
+    if (GetMonitorInfoW(hMonitor, (MONITORINFO *)&mi))
+    {
+        MonitorInfo info;
+        info.handle = hMonitor;
+        info.rcMonitor = mi.rcMonitor;
+        info.isPrimary = (mi.dwFlags & MONITORINFOF_PRIMARY) != 0;
+        info.index = 0;
+        info.device = mi.szDevice;
+        monitors->push_back(std::move(info));
+    }
+    return TRUE;
+}
+
+// Must run on the detection thread (per-monitor DPI context).
+static void RefreshMonitors()
+{
+    g_monitors.clear();
+    EnumDisplayMonitors(nullptr, nullptr, MonitorEnumProc,
+                        (LPARAM)&g_monitors);
+
+    // Ordinals are kept only as a legacy fallback for v2.x configs.
+    std::sort(g_monitors.begin(), g_monitors.end(),
+              [](const MonitorInfo &a, const MonitorInfo &b)
+              {
+                  if (a.isPrimary != b.isPrimary)
+                      return a.isPrimary;
+                  if (a.rcMonitor.left != b.rcMonitor.left)
+                      return a.rcMonitor.left < b.rcMonitor.left;
+                  return a.rcMonitor.top < b.rcMonitor.top;
+              });
+
+    std::unordered_map<std::wstring, std::wstring> friendly;
+    QueryMonitorFriendlyNames(friendly);
+
+    std::unordered_map<std::wstring, int> nameUses;
+    for (int i = 0; i < (int)g_monitors.size(); i++)
+    {
+        MonitorInfo &m = g_monitors[i];
+        m.index = i + 1;
+
+        auto it = friendly.find(m.device);
+        m.id = (it != friendly.end()) ? it->second : m.device;
+
+        // Two identical displays report the same EDID name. Suffix the
+        // duplicates so each keeps its own configurable identity.
+        int n = ++nameUses[ToLowerStr(m.id)];
+        if (n > 1)
+            m.id += L" #" + std::to_wstring(n);
+    }
+
+    if (!g_showMonitorNames)
+        return;
+
+    // Printed so the name can be copied straight into the Monitor setting,
+    // rather than guessed. Once per load and per display change only.
+    Wh_Log(L" ");
+    Wh_Log(L"+-- Your monitors ---------------------------------------");
+    Wh_Log(L"|  Copy a name below into this mod's \"Monitor\" setting.");
+    Wh_Log(L"|  Use  *  to apply one configuration to every monitor.");
+    Wh_Log(L"|");
+    for (const auto &m : g_monitors)
+    {
+        Wh_Log(L"|   %d. \"%s\"%s   %ld x %ld  at (%ld, %ld)", m.index,
+               m.id.c_str(), m.isPrimary ? L"   [primary]" : L"",
+               m.rcMonitor.right - m.rcMonitor.left,
+               m.rcMonitor.bottom - m.rcMonitor.top, m.rcMonitor.left,
+               m.rcMonitor.top);
+    }
+    Wh_Log(L"+--------------------------------------------------------");
+    Wh_Log(L" ");
+}
+
+// =====================================================================
+// Fullscreen / Exclusion Gates (worker thread only)
+// =====================================================================
+
+// Task View, the Start menu, Search, Action Center and the desktop are shell
+// surfaces that are legitimately monitor-sized, so the bounds test below
+// mistakes them for fullscreen apps and blocks every trigger while they are
+// open. v2.x excluded them with `fgPid == GetCurrentProcessId()` because it
+// ran inside explorer.exe; once the mod moved to its own process that test
+// silently stopped matching anything. Compare against the *shell's* pid
+// instead, which is what was actually meant.
+// Lowercase exe name of the window's owning process, or empty on failure.
+static std::wstring ProcessNameOfWindow(HWND hwnd)
+{
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hwnd, &pid);
+    if (pid == 0)
+        return L"";
+
+    HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (!hProc)
+        return L"";
+
+    WCHAR exePath[MAX_PATH];
+    DWORD pathLen = MAX_PATH;
+    BOOL ok = QueryFullProcessImageNameW(hProc, 0, exePath, &pathLen);
+    CloseHandle(hProc);
+    if (!ok)
+        return L"";
+
+    const wchar_t *fileName = wcsrchr(exePath, L'\\');
+    return fileName ? fileName + 1 : exePath;
+}
+
+static bool IsShellUiWindow(HWND hwnd)
+{
+    // Not cached: explorer restarts change the pid, and this only runs when
+    // a zone actually fires.
+    HWND hShell = GetShellWindow();
+    if (hShell)
+    {
+        DWORD shellPid = 0, fgPid = 0;
+        GetWindowThreadProcessId(hShell, &shellPid);
+        GetWindowThreadProcessId(hwnd, &fgPid);
+        if (shellPid && fgPid == shellPid)
+            return true;
+    }
+
+    WCHAR cls[64];
+    if (GetClassName(hwnd, cls, ARRAYSIZE(cls)) <= 0)
+        return false;
+
+    // Belt and braces for shell UI hosted outside explorer.exe.
+    static const wchar_t *kShellClasses[] = {
+        L"Shell_TrayWnd",
+        L"Shell_SecondaryTrayWnd",
+        L"WorkerW",
+        L"Progman",
+        L"MultitaskingViewFrame",         // Task View, Windows 10
+        L"XamlExplorerHostIslandWindow",  // Task View / Alt-Tab, Windows 11
+    };
+    for (const wchar_t *k : kShellClasses)
+    {
+        if (_wcsicmp(cls, k) == 0)
+            return true;
+    }
+
+    // Windows 11 moved several shell surfaces out of explorer.exe, so the
+    // shell-pid test above misses them. Matched by exact process name rather
+    // than a "*Host.exe" suffix rule, which would also swallow ordinary
+    // applications that happen to be named that way.
+    //
+    // Deliberately NOT keyed on the Windows.UI.Core.CoreWindow class: every
+    // UWP app uses it, so excluding that class would stop a genuinely
+    // fullscreen UWP game or video player from being detected as fullscreen.
+    static const wchar_t *kShellHostProcesses[] = {
+        L"StartMenuExperienceHost.exe",
+        L"SearchHost.exe",
+        L"SearchApp.exe",
+        L"ShellExperienceHost.exe",
+        L"ShellHost.exe",
+        L"TextInputHost.exe",
+    };
+    std::wstring proc = ProcessNameOfWindow(hwnd);
+    if (!proc.empty())
+    {
+        for (const wchar_t *p : kShellHostProcesses)
+        {
+            if (_wcsicmp(proc.c_str(), p) == 0)
+                return true;
+        }
+    }
+
+    return false;
+}
+
+static bool IsFullScreenAppActive()
+{
+    QUERY_USER_NOTIFICATION_STATE state;
+    if (SUCCEEDED(SHQueryUserNotificationState(&state)))
+    {
+        if (state == QUNS_RUNNING_D3D_FULL_SCREEN ||
+            state == QUNS_PRESENTATION_MODE)
+            return true;
+    }
+
+    // Fallback: exact bounds match for apps that go fullscreen without
+    // D3D exclusive mode (browser F11, video players).
+    HWND hFgWnd = GetForegroundWindow();
+    if (!hFgWnd || hFgWnd == GetDesktopWindow() || hFgWnd == GetShellWindow())
+        return false;
+
+    if (IsShellUiWindow(hFgWnd))
+        return false;
+
+    RECT rcWnd;
+    if (!GetWindowRect(hFgWnd, &rcWnd))
+        return false;
+
+    HMONITOR hMon = MonitorFromWindow(hFgWnd, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO mi = {sizeof(mi)};
+    if (!GetMonitorInfo(hMon, &mi))
+        return false;
+
+    // True fullscreen apps match the monitor exactly. Maximized desktop
+    // apps overhang by ~8px due to DWM drop shadows — they won't match.
+    return (rcWnd.left == mi.rcMonitor.left &&
+            rcWnd.top == mi.rcMonitor.top &&
+            rcWnd.right == mi.rcMonitor.right &&
+            rcWnd.bottom == mi.rcMonitor.bottom);
+}
+
+static bool IsForegroundAppExcluded(const std::vector<std::wstring> &excluded)
+{
+    if (excluded.empty())
+        return false;
+
+    HWND hFg = GetForegroundWindow();
+    if (!hFg)
+        return false;
+
+    // OpenProcess + QueryFullProcessImageName is the expensive part and the
+    // foreground window rarely changes between triggers, so cache the
+    // resolved name — not the verdict, which would go stale when the
+    // blacklist is edited.
+    static HWND cachedHwnd = nullptr;
+    static std::wstring cachedName;
+
+    if (hFg != cachedHwnd)
+    {
+        cachedHwnd = hFg;
+        cachedName.clear();
+
+        DWORD pid = 0;
+        GetWindowThreadProcessId(hFg, &pid);
+        if (pid == 0)
+            return false;
+
+        HANDLE hProc =
+            OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+        if (!hProc)
+            return false;
+
+        WCHAR exePath[MAX_PATH];
+        DWORD pathLen = MAX_PATH;
+        BOOL ok = QueryFullProcessImageNameW(hProc, 0, exePath, &pathLen);
+        CloseHandle(hProc);
+        if (!ok)
+            return false;
+
+        const wchar_t *fileName = wcsrchr(exePath, L'\\');
+        cachedName = fileName ? fileName + 1 : exePath;
+    }
+
+    if (cachedName.empty())
+        return false;
+
+    for (const auto &name : excluded)
+    {
+        if (_wcsicmp(cachedName.c_str(), name.c_str()) == 0)
+        {
+            if (g_verboseLog)
+                Wh_Log(L"[EXCLUDE] Foreground app '%s' is blacklisted",
+                       cachedName.c_str());
+            return true;
+        }
+    }
+    return false;
+}
+
+// =====================================================================
+// Action Implementations
+// =====================================================================
+
+// Sends key-down for all VKs in order, then key-up in reverse order, as one
+// atomic SendInput batch.
+//
+// Earlier versions also released any modifier the user was physically holding
+// and re-pressed it afterwards. That was removed deliberately: re-pressing is
+// only correct if the key is still held when the restore runs. If the user let
+// go in between — or the restore SendInput failed, or the thread was torn down
+// between the two calls — a key-down was injected with no matching key-up and
+// the modifier stayed logically stuck down for the whole session. A stuck Win
+// or Ctrl key breaks every application at once, which is far worse than the
+// problem it solved (a held Shift leaking into the injected combo).
+// Every key this function presses, it releases in the same batch.
+// Keys that live on the E0-prefixed part of the keyboard. Injected without
+// KEYEVENTF_EXTENDEDKEY they resolve to their numpad twins, so Win+Right
+// (snap) or a custom combo using arrows/Home/End would do nothing or move the
+// caret instead. Verified that adding the flag to VK_LWIN does not disturb
+// Win+Tab, which is the combo already in use.
+static bool IsExtendedKey(WORD vk)
+{
+    switch (vk)
+    {
+    case VK_INSERT:
+    case VK_DELETE:
+    case VK_HOME:
+    case VK_END:
+    case VK_PRIOR:
+    case VK_NEXT:
+    case VK_LEFT:
+    case VK_RIGHT:
+    case VK_UP:
+    case VK_DOWN:
+    case VK_LWIN:
+    case VK_RWIN:
+    case VK_APPS:
+    case VK_DIVIDE:
+    case VK_NUMLOCK:
+    case VK_RMENU:
+    case VK_RCONTROL:
+    case VK_SNAPSHOT:
+    case VK_VOLUME_MUTE:
+    case VK_VOLUME_DOWN:
+    case VK_VOLUME_UP:
+    case VK_MEDIA_NEXT_TRACK:
+    case VK_MEDIA_PREV_TRACK:
+    case VK_MEDIA_STOP:
+    case VK_MEDIA_PLAY_PAUSE:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static void SendKeys(const std::vector<WORD> &vks)
+{
+    if (vks.empty())
+        return;
+
+    size_t n = vks.size();
+    std::vector<INPUT> inputs(n * 2);
+
+    for (size_t i = 0; i < n; i++)
+    {
+        inputs[i].type = INPUT_KEYBOARD;
+        inputs[i].ki.wVk = vks[i];
+        inputs[i].ki.dwFlags =
+            IsExtendedKey(vks[i]) ? KEYEVENTF_EXTENDEDKEY : 0;
+    }
+    for (size_t i = 0; i < n; i++)
+    {
+        // The flag must be derived from the key this entry actually releases,
+        // not from vks[i] — the release order is reversed, so using the wrong
+        // index would tag the extended bit onto the wrong key.
+        WORD vk = vks[n - 1 - i];
+        inputs[n + i].type = INPUT_KEYBOARD;
+        inputs[n + i].ki.wVk = vk;
+        inputs[n + i].ki.dwFlags =
+            (IsExtendedKey(vk) ? KEYEVENTF_EXTENDEDKEY : 0) | KEYEVENTF_KEYUP;
+    }
+
+    // Failures are always reported — a short SendInput means the action
+    // silently did nothing. Success is logged only under verbose logging;
+    // see g_verboseLog for why this is not on by default.
+    SetLastError(0);
+    UINT sent = SendInput((UINT)inputs.size(), inputs.data(), sizeof(INPUT));
+    if (sent != inputs.size())
+    {
+        Wh_Log(L"SendInput FAILED: sent %u/%u, err=%lu (sizeof(INPUT)=%d)",
+               sent, (UINT)inputs.size(), GetLastError(), (int)sizeof(INPUT));
+    }
+    else if (g_verboseLog)
+    {
+        Wh_Log(L"SendInput ok: %u events, first vk=0x%02X", sent,
+               (unsigned)vks[0]);
+    }
+}
+
+// Convenience overload for initializer lists
+static void SendKeys(std::initializer_list<WORD> vks)
+{
+    std::vector<WORD> v(vks);
+    SendKeys(v);
+}
+
+static void ActionShowDesktop()
+{
+    // Re-found when the handle goes stale, so this survives explorer restarts.
+    static HWND hTray = nullptr;
+    if (!hTray || !IsWindow(hTray))
+        hTray = FindWindowW(L"Shell_TrayWnd", nullptr);
+    if (!hTray)
+    {
+        Wh_Log(L"Show Desktop: Shell_TrayWnd not found");
+        return;
+    }
+    DWORD_PTR result = 0;
+    SendMessageTimeoutW(hTray, WM_COMMAND,
+                        MAKELONG(SHELL_TRAY_TOGGLE_DESKTOP, 0), 0,
+                        SMTO_ABORTIFHUNG, 2000, &result);
+}
+
+static void ActionTaskView() { SendKeys({VK_LWIN, VK_TAB}); }
+
+static void ActionScreenSaver()
+{
+    HWND hTarget = GetForegroundWindow();
+    if (!hTarget)
+        hTarget = GetDesktopWindow();
+    PostMessage(hTarget, WM_SYSCOMMAND, SC_SCREENSAVE, 0);
+}
+
+static void ActionMonitorsOff()
+{
+    HWND hTarget = GetForegroundWindow();
+    if (!hTarget)
+        hTarget = GetDesktopWindow();
+    PostMessage(hTarget, WM_SYSCOMMAND, SC_MONITORPOWER, (LPARAM)2);
+}
+
+static void ActionQuickSettings() { SendKeys({VK_LWIN, 'A'}); }
+static void ActionNotificationCenter() { SendKeys({VK_LWIN, 'N'}); }
+static void ActionStartMenu() { SendKeys({VK_LWIN}); }
+static void ActionHideOthers() { SendKeys({VK_LWIN, VK_HOME}); }
+static void ActionMute() { SendKeys({VK_VOLUME_MUTE}); }
+
+static void ActionTaskManager()
+{
+    WCHAR sysDir[MAX_PATH];
+    GetSystemDirectory(sysDir, MAX_PATH);
+    std::wstring path = std::wstring(sysDir) + L"\\Taskmgr.exe";
+
+    SHELLEXECUTEINFO sei = {sizeof(sei)};
+    sei.fMask = SEE_MASK_FLAG_NO_UI;
+    sei.lpVerb = L"open";
+    sei.lpFile = path.c_str();
+    sei.nShow = SW_SHOW;
+    if (!ShellExecuteEx(&sei))
+    {
+        DWORD err = GetLastError();
+        if (err != ERROR_CANCELLED)
+            Wh_Log(L"Failed to open Task Manager: %lu", err);
+    }
+}
+
+// Alt+Tab pressed and released as one batch performs the "quick swap" back to
+// the previously focused window rather than opening the persistent switcher.
+static void ActionSwitchLastWindow() { SendKeys({VK_LMENU, VK_TAB}); }
+
+// Ctrl+Alt+Tab opens the switcher and leaves it up, so it can be navigated
+// with the mouse after the cursor triggered it.
+static void ActionTaskSwitcher() { SendKeys({VK_LCONTROL, VK_LMENU, VK_TAB}); }
+
+static void ActionMinimizeWindow() { SendKeys({VK_LWIN, VK_DOWN}); }
+static void ActionMaximizeWindow() { SendKeys({VK_LWIN, VK_UP}); }
+static void ActionSnapLeft() { SendKeys({VK_LWIN, VK_LEFT}); }
+static void ActionSnapRight() { SendKeys({VK_LWIN, VK_RIGHT}); }
+static void ActionCloseWindow() { SendKeys({VK_LMENU, VK_F4}); }
+static void ActionFileExplorer() { SendKeys({VK_LWIN, 'E'}); }
+static void ActionSettingsApp() { SendKeys({VK_LWIN, 'I'}); }
+static void ActionSearch() { SendKeys({VK_LWIN, 'S'}); }
+static void ActionClipboardHistory() { SendKeys({VK_LWIN, 'V'}); }
+static void ActionScreenshot() { SendKeys({VK_LWIN, VK_LSHIFT, 'S'}); }
+static void ActionProjectDisplay() { SendKeys({VK_LWIN, 'P'}); }
+static void ActionVDesktopNext() { SendKeys({VK_LWIN, VK_LCONTROL, VK_RIGHT}); }
+static void ActionVDesktopPrev() { SendKeys({VK_LWIN, VK_LCONTROL, VK_LEFT}); }
+static void ActionVDesktopNew() { SendKeys({VK_LWIN, VK_LCONTROL, 'D'}); }
+
+static void ActionLock() { LockWorkStation(); }
+
+static void ActionSleep()
+{
+    // SetSuspendState(hibernate, force, disableWakeEvent)
+    SetSuspendState(FALSE, FALSE, FALSE);
+}
+
+static void ActionStartProcess(const std::wstring &command)
+{
+    if (command.empty())
+        return;
+
+    std::wstring cmd = command;
+    std::wstring verb = L"open";
+
+    // Expand environment variables (%AppData%, %USERPROFILE%, etc.)
+    WCHAR expandedBuf[4096];
+    DWORD expandedLen = ExpandEnvironmentStringsW(cmd.c_str(), expandedBuf,
+                                                  ARRAYSIZE(expandedBuf));
+    if (expandedLen > 0 && expandedLen <= ARRAYSIZE(expandedBuf))
+        cmd = expandedBuf;
+
+    if (cmd.length() > 4 && _wcsnicmp(cmd.c_str(), L"uac;", 4) == 0)
+    {
+        verb = L"runas";
+        cmd = TrimStr(cmd.substr(4));
+    }
+
+    // CommandLineToArgvW handles unquoted paths with spaces correctly.
+    std::wstring exe, params;
+    int argc = 0;
+    LPWSTR *argv = CommandLineToArgvW(cmd.c_str(), &argc);
+    if (argv && argc > 0)
+    {
+        exe = argv[0];
+        int firstArg = 1;
+
+        // CommandLineToArgvW splits on spaces, so an unquoted path such as
+        // C:\Program Files\Tool\tool.exe -x yields "C:\Program" plus the rest
+        // as arguments and the launch fails. Glue tokens back onto the
+        // executable until one names a file that exists.
+        //
+        // Guarded on argv[0] not resolving, so bare commands keep working:
+        // "notepad.exe" is not a file relative to us, but the shell resolves
+        // it via App Paths/PATH, and we must not disturb that.
+        if (argc > 1 &&
+            GetFileAttributesW(exe.c_str()) == INVALID_FILE_ATTRIBUTES)
+        {
+            std::wstring joined = exe;
+            for (int i = 1; i < argc; i++)
+            {
+                joined += L' ';
+                joined += argv[i];
+                if (GetFileAttributesW(joined.c_str()) !=
+                    INVALID_FILE_ATTRIBUTES)
+                {
+                    exe = joined;
+                    firstArg = i + 1;
+                    break;
+                }
+            }
+        }
+
+        for (int i = firstArg; i < argc; i++)
+        {
+            if (!params.empty())
+                params += L' ';
+            if (wcschr(argv[i], L' '))
+            {
+                params += L'"';
+                params += argv[i];
+                params += L'"';
+            }
+            else
+            {
+                params += argv[i];
+            }
+        }
+        LocalFree(argv);
+    }
+    else
+    {
+        exe = cmd;
+    }
+
+    SHELLEXECUTEINFO sei = {sizeof(sei)};
+    sei.fMask = SEE_MASK_FLAG_NO_UI;
+    sei.lpVerb = verb.c_str();
+    sei.lpFile = exe.c_str();
+    sei.lpParameters = params.empty() ? nullptr : params.c_str();
+    sei.nShow = SW_SHOWNORMAL;
+    if (!ShellExecuteEx(&sei))
+    {
+        DWORD err = GetLastError();
+        if (err != ERROR_CANCELLED)
+            Wh_Log(L"ShellExecuteEx failed: %lu", err);
+    }
+}
+
+// =====================================================================
+// Action Type Parsing
+// =====================================================================
+
+static CornerAction ParseActionType(const std::wstring &raw)
+{
+    static const std::unordered_map<std::wstring, CornerAction> map = {
+        {L"ACTION_NOTHING", CornerAction::Nothing},
+        {L"ACTION_SHOW_DESKTOP", CornerAction::ShowDesktop},
+        {L"ACTION_TASK_VIEW", CornerAction::TaskView},
+        {L"ACTION_SCREENSAVER", CornerAction::ScreenSaver},
+        {L"ACTION_MONITORS_OFF", CornerAction::MonitorsOff},
+        {L"ACTION_QUICK_SETTINGS", CornerAction::QuickSettings},
+        {L"ACTION_NOTIFICATION_CENTER", CornerAction::NotificationCenter},
+        {L"ACTION_START_MENU", CornerAction::StartMenu},
+        {L"ACTION_HIDE_OTHERS", CornerAction::HideOthers},
+        {L"ACTION_MUTE", CornerAction::Mute},
+        {L"ACTION_TASK_MANAGER", CornerAction::TaskManager},
+        {L"ACTION_LOCK", CornerAction::Lock},
+        {L"ACTION_SLEEP", CornerAction::Sleep},
+        {L"ACTION_SWITCH_LAST", CornerAction::SwitchLastWindow},
+        {L"ACTION_TASK_SWITCHER", CornerAction::TaskSwitcher},
+        {L"ACTION_MINIMIZE", CornerAction::MinimizeWindow},
+        {L"ACTION_MAXIMIZE", CornerAction::MaximizeWindow},
+        {L"ACTION_SNAP_LEFT", CornerAction::SnapLeft},
+        {L"ACTION_SNAP_RIGHT", CornerAction::SnapRight},
+        {L"ACTION_CLOSE_WINDOW", CornerAction::CloseWindow},
+        {L"ACTION_FILE_EXPLORER", CornerAction::FileExplorer},
+        {L"ACTION_SETTINGS", CornerAction::SettingsApp},
+        {L"ACTION_SEARCH", CornerAction::Search},
+        {L"ACTION_CLIPBOARD", CornerAction::ClipboardHistory},
+        {L"ACTION_SCREENSHOT", CornerAction::Screenshot},
+        {L"ACTION_PROJECT", CornerAction::ProjectDisplay},
+        {L"ACTION_VDESK_NEXT", CornerAction::VDesktopNext},
+        {L"ACTION_VDESK_PREV", CornerAction::VDesktopPrev},
+        {L"ACTION_VDESK_NEW", CornerAction::VDesktopNew},
+        {L"ACTION_SEND_KEYPRESS", CornerAction::SendKeypress},
+        {L"ACTION_START_PROCESS", CornerAction::StartProcess},
+    };
+
+    auto it = map.find(ToUpperStr(TrimStr(raw)));
+    return (it != map.end()) ? it->second : CornerAction::Nothing;
+}
+
+static const wchar_t *ActionToString(CornerAction a)
+{
+    switch (a)
+    {
+    case CornerAction::Nothing: return L"Nothing";
+    case CornerAction::ShowDesktop: return L"Show Desktop";
+    case CornerAction::TaskView: return L"Task View";
+    case CornerAction::ScreenSaver: return L"Screen Saver";
+    case CornerAction::MonitorsOff: return L"Turn Off Monitors";
+    case CornerAction::QuickSettings: return L"Quick Settings";
+    case CornerAction::NotificationCenter: return L"Notification Center";
+    case CornerAction::StartMenu: return L"Start Menu";
+    case CornerAction::HideOthers: return L"Hide Other Windows";
+    case CornerAction::Mute: return L"Mute";
+    case CornerAction::TaskManager: return L"Task Manager";
+    case CornerAction::Lock: return L"Lock Computer";
+    case CornerAction::Sleep: return L"Sleep";
+    case CornerAction::SwitchLastWindow: return L"Switch to Last Window";
+    case CornerAction::TaskSwitcher: return L"Task Switcher";
+    case CornerAction::MinimizeWindow: return L"Minimize Window";
+    case CornerAction::MaximizeWindow: return L"Maximize Window";
+    case CornerAction::SnapLeft: return L"Snap Left";
+    case CornerAction::SnapRight: return L"Snap Right";
+    case CornerAction::CloseWindow: return L"Close Window";
+    case CornerAction::FileExplorer: return L"File Explorer";
+    case CornerAction::SettingsApp: return L"Settings";
+    case CornerAction::Search: return L"Search";
+    case CornerAction::ClipboardHistory: return L"Clipboard History";
+    case CornerAction::Screenshot: return L"Screenshot";
+    case CornerAction::ProjectDisplay: return L"Project";
+    case CornerAction::VDesktopNext: return L"Virtual Desktop Next";
+    case CornerAction::VDesktopPrev: return L"Virtual Desktop Previous";
+    case CornerAction::VDesktopNew: return L"Virtual Desktop New";
+    case CornerAction::SendKeypress: return L"Virtual Key Press";
+    case CornerAction::StartProcess: return L"Custom Command";
+    }
+    return L"Unknown";
+}
+
+static const wchar_t *ZoneToString(Zone z)
+{
+    switch (z)
+    {
+    case ZONE_TOP_LEFT: return L"Top-left corner";
+    case ZONE_TOP_RIGHT: return L"Top-right corner";
+    case ZONE_BOTTOM_LEFT: return L"Bottom-left corner";
+    case ZONE_BOTTOM_RIGHT: return L"Bottom-right corner";
+    case ZONE_EDGE_TOP: return L"Top edge";
+    case ZONE_EDGE_BOTTOM: return L"Bottom edge";
+    case ZONE_EDGE_LEFT: return L"Left edge";
+    case ZONE_EDGE_RIGHT: return L"Right edge";
+    default: return L"None";
+    }
+}
+
+// Creates an action executor from action type and args
+static std::function<void()> MakeExecutor(CornerAction action,
+                                          const std::wstring &args)
+{
+    switch (action)
+    {
+    case CornerAction::Nothing: return nullptr;
+    case CornerAction::ShowDesktop: return ActionShowDesktop;
+    case CornerAction::TaskView: return ActionTaskView;
+    case CornerAction::ScreenSaver: return ActionScreenSaver;
+    case CornerAction::MonitorsOff: return ActionMonitorsOff;
+    case CornerAction::QuickSettings: return ActionQuickSettings;
+    case CornerAction::NotificationCenter: return ActionNotificationCenter;
+    case CornerAction::StartMenu: return ActionStartMenu;
+    case CornerAction::HideOthers: return ActionHideOthers;
+    case CornerAction::Mute: return ActionMute;
+    case CornerAction::TaskManager: return ActionTaskManager;
+    case CornerAction::Lock: return ActionLock;
+    case CornerAction::Sleep: return ActionSleep;
+    case CornerAction::SwitchLastWindow: return ActionSwitchLastWindow;
+    case CornerAction::TaskSwitcher: return ActionTaskSwitcher;
+    case CornerAction::MinimizeWindow: return ActionMinimizeWindow;
+    case CornerAction::MaximizeWindow: return ActionMaximizeWindow;
+    case CornerAction::SnapLeft: return ActionSnapLeft;
+    case CornerAction::SnapRight: return ActionSnapRight;
+    case CornerAction::CloseWindow: return ActionCloseWindow;
+    case CornerAction::FileExplorer: return ActionFileExplorer;
+    case CornerAction::SettingsApp: return ActionSettingsApp;
+    case CornerAction::Search: return ActionSearch;
+    case CornerAction::ClipboardHistory: return ActionClipboardHistory;
+    case CornerAction::Screenshot: return ActionScreenshot;
+    case CornerAction::ProjectDisplay: return ActionProjectDisplay;
+    case CornerAction::VDesktopNext: return ActionVDesktopNext;
+    case CornerAction::VDesktopPrev: return ActionVDesktopPrev;
+    case CornerAction::VDesktopNew: return ActionVDesktopNew;
+    case CornerAction::SendKeypress:
+    {
+        auto combos = ParseKeyCombo(args);
+        if (combos.empty())
+        {
+            Wh_Log(L"SendKeypress: no valid keys parsed from '%s'",
+                   args.c_str());
+            return nullptr;
+        }
+        return [combos]()
+        {
+            for (const auto &keys : combos)
+                SendKeys(keys);
+        };
+    }
+    case CornerAction::StartProcess:
+    {
+        std::wstring cmd = TrimStr(args);
+        if (cmd.empty())
+        {
+            Wh_Log(L"StartProcess: empty command");
+            return nullptr;
+        }
+        return [cmd]() { ActionStartProcess(cmd); };
+    }
+    }
+    return nullptr;
+}
+
+// =====================================================================
+// Zone Building
+// =====================================================================
+
+// Resolves one zone for one monitor. A name-matched config wins; otherwise a
+// wildcard config supplies the action. Resolution is per zone, so a wildcard
+// entry can cover most zones while one display overrides a single corner.
+// Caller must hold g_settingsLock.
+static const ZoneConfig *ResolveZone(const MonitorInfo &mon, Zone zone)
+{
+    // 1. Exact friendly-name match
+    for (const auto &cfg : g_settings.monitorConfigs)
+    {
+        if (cfg.monitorId.empty() || cfg.monitorId == L"*")
+            continue;
+        if (_wcsicmp(cfg.monitorId.c_str(), mon.id.c_str()) != 0)
+            continue;
+        const auto &zc = cfg.zones[zone];
+        if (zc.action != CornerAction::Nothing && zc.executor)
+            return &zc;
+    }
+
+    // 2. Legacy numeric ordinal, for configs carried over from v2.x
+    for (const auto &cfg : g_settings.monitorConfigs)
+    {
+        if (!cfg.monitorId.empty() || cfg.monitorIndex != mon.index)
+            continue;
+        const auto &zc = cfg.zones[zone];
+        if (zc.action != CornerAction::Nothing && zc.executor)
+            return &zc;
+    }
+
+    // 3. Wildcard
+    for (const auto &cfg : g_settings.monitorConfigs)
+    {
+        if (cfg.monitorId != L"*" &&
+            !(cfg.monitorId.empty() && cfg.monitorIndex == 0))
+            continue;
+        const auto &zc = cfg.zones[zone];
+        if (zc.action != CornerAction::Nothing && zc.executor)
+            return &zc;
+    }
+
+    return nullptr;
+}
+
+// Builds an immutable snapshot containing only zones that actually do
+// something, with the action already resolved. The detection loop therefore
+// does nothing per tick but compare rectangles.
+static std::shared_ptr<const ZoneSet> BuildZoneSet()
+{
+    auto set = std::make_shared<ZoneSet>();
+
+    EnterCriticalSection(&g_settingsLock);
+
+    int csCfg = g_settings.cornerSize > 0 ? g_settings.cornerSize : 1;
+    int esCfg = g_settings.edgeSize > 0 ? g_settings.edgeSize : 1;
+
+    set->activationDelay = g_settings.activationDelay;
+    set->settleMs = g_settings.settleMs;
+    set->cooldownMs = g_settings.cooldownMs;
+    set->disableDuringDrag = g_settings.disableDuringDrag;
+
+    for (const auto &mon : g_monitors)
+    {
+        const RECT &r = mon.rcMonitor;
+
+        // Clamp per monitor so the eight zones are provably disjoint and the
+        // hit test's first-match-wins can never hide one behind another:
+        //   - a corner bigger than half the screen would overlap its opposite
+        //   - an edge strip thicker than the corner box would overlap the
+        //     perpendicular edge (EdgeTop vs EdgeLeft), and only whichever
+        //     was added first would ever fire
+        int span = (r.right - r.left) < (r.bottom - r.top)
+                       ? (r.right - r.left)
+                       : (r.bottom - r.top);
+        int cs = csCfg;
+        if (cs > span / 2)
+            cs = span / 2;
+        if (cs < 1)
+            cs = 1;
+        int es = esCfg > cs ? cs : esCfg;
+
+        if (cs != csCfg || es != esCfg)
+        {
+            Wh_Log(L"  [%s] sizes clamped: corner %d->%d, edge %d->%d",
+                   mon.id.c_str(), csCfg, cs, esCfg, es);
+        }
+
+        auto add = [&](Zone z, RECT rect)
+        {
+            const ZoneConfig *zc = ResolveZone(mon, z);
+            if (!zc)
+                return;
+            HitZone hz;
+            hz.rect = rect;
+            hz.exec = zc->executor;
+            hz.label = mon.id + L" " + ZoneToString(z) + L" -> " +
+                       ActionToString(zc->action);
+            set->zones.push_back(std::move(hz));
+        };
+
+        // Corners
+        add(ZONE_TOP_LEFT, {r.left, r.top, r.left + cs, r.top + cs});
+        add(ZONE_TOP_RIGHT, {r.right - cs, r.top, r.right, r.top + cs});
+        add(ZONE_BOTTOM_LEFT, {r.left, r.bottom - cs, r.left + cs, r.bottom});
+        add(ZONE_BOTTOM_RIGHT,
+            {r.right - cs, r.bottom - cs, r.right, r.bottom});
+
+        // Edges — the side strip with the corner zones carved out
+        if (r.left + cs < r.right - cs)
+        {
+            add(ZONE_EDGE_TOP,
+                {r.left + cs, r.top, r.right - cs, r.top + es});
+            add(ZONE_EDGE_BOTTOM,
+                {r.left + cs, r.bottom - es, r.right - cs, r.bottom});
+        }
+        if (r.top + cs < r.bottom - cs)
+        {
+            add(ZONE_EDGE_LEFT,
+                {r.left, r.top + cs, r.left + es, r.bottom - cs});
+            add(ZONE_EDGE_RIGHT,
+                {r.right - es, r.top + cs, r.right, r.bottom - cs});
+        }
+    }
+
+    LeaveCriticalSection(&g_settingsLock);
+
+    if (set->zones.empty())
+    {
+        Wh_Log(L"No zones are active - every zone is set to \"Nothing\", or "
+               L"no configuration matches a connected monitor.");
+    }
+    else
+    {
+        Wh_Log(L"Active zones (%d)   corner %dpx, edge %dpx:",
+               (int)set->zones.size(), csCfg, esCfg);
+        for (const auto &z : set->zones)
+            Wh_Log(L"   %s", z.label.c_str());
+    }
+
+    return set;
+}
+
+// Detection thread only.
+static void RebuildZones()
+{
+    RefreshMonitors();
+    auto set = BuildZoneSet();
+
+    EnterCriticalSection(&g_zonesLock);
+    g_zones = set;
+    LeaveCriticalSection(&g_zonesLock);
+
+    g_activeZone = -1;
+    g_firedThisEntry = false;
+    g_lastAnyFireTick = 0;
+    g_lastFireTick.assign(set->zones.size(), 0);
+
+    g_topoCount = GetSystemMetrics(SM_CMONITORS);
+    g_topoVirtual = {GetSystemMetrics(SM_XVIRTUALSCREEN),
+                     GetSystemMetrics(SM_YVIRTUALSCREEN),
+                     GetSystemMetrics(SM_CXVIRTUALSCREEN),
+                     GetSystemMetrics(SM_CYVIRTUALSCREEN)};
+}
+
+// WM_DISPLAYCHANGE is not delivered for every layout change that matters —
+// docking, monitor wake, and RDP reconnect frequently skip it, leaving zones
+// at coordinates that no longer exist. These metrics are a few cheap reads.
+static bool TopologyChanged()
+{
+    RECT v = {GetSystemMetrics(SM_XVIRTUALSCREEN),
+              GetSystemMetrics(SM_YVIRTUALSCREEN),
+              GetSystemMetrics(SM_CXVIRTUALSCREEN),
+              GetSystemMetrics(SM_CYVIRTUALSCREEN)};
+    return GetSystemMetrics(SM_CMONITORS) != g_topoCount ||
+           memcmp(&v, &g_topoVirtual, sizeof(v)) != 0;
+}
+
+// =====================================================================
+// Action Worker Thread
+// =====================================================================
+
+static void EnqueueAction(const HitZone &hz)
+{
+    EnterCriticalSection(&g_queueLock);
+    if (g_queue.size() < kMaxQueue)
+        g_queue.push_back(hz);
+    LeaveCriticalSection(&g_queueLock);
+    SetEvent(g_hWorkEvent);
+}
+
+static DWORD WINAPI ActionWorkerThread(LPVOID)
+{
+    HANDLE waits[2] = {g_hStopEvent, g_hWorkEvent};
+    for (;;)
+    {
+        DWORD r = WaitForMultipleObjects(2, waits, FALSE, INFINITE);
+        if (r == WAIT_OBJECT_0 || r == WAIT_FAILED)
+            break;
+
+        for (;;)
+        {
+            HitZone job;
+            bool have = false;
+            EnterCriticalSection(&g_queueLock);
+            if (!g_queue.empty())
+            {
+                job = std::move(g_queue.front());
+                g_queue.pop_front();
+                have = true;
+            }
+            LeaveCriticalSection(&g_queueLock);
+            if (!have)
+                break;
+
+            // The gates live here, not on the detection thread, so a slow
+            // SHQueryUserNotificationState or OpenProcess can never delay the
+            // next cursor sample.
+            bool checkFullscreen;
+            std::vector<std::wstring> excluded;
+            EnterCriticalSection(&g_settingsLock);
+            checkFullscreen = g_settings.disableOnFullscreen;
+            excluded = g_settings.excludedProcesses;
+            LeaveCriticalSection(&g_settingsLock);
+
+            // Suppression is normal, not an error — logging it every time
+            // would spam hardest in exactly the case it matters least
+            // (holding a corner while a fullscreen game has focus).
+            if (checkFullscreen && IsFullScreenAppActive())
+            {
+                if (g_verboseLog)
+                    Wh_Log(L"SKIP (fullscreen): %s", job.label.c_str());
+                continue;
+            }
+            if (IsForegroundAppExcluded(excluded))
+            {
+                if (g_verboseLog)
+                    Wh_Log(L"SKIP (excluded app): %s", job.label.c_str());
+                continue;
+            }
+
+            if (g_verboseLog)
+            {
+                WCHAR fgClass[64] = L"?";
+                GetClassName(GetForegroundWindow(), fgClass,
+                             ARRAYSIZE(fgClass));
+                Wh_Log(L"FIRE: %s (foreground '%s')", job.label.c_str(),
+                       fgClass);
+            }
+
+            // Calling an empty std::function throws, and an exception escaping
+            // this thread would kill it silently — every zone would stop
+            // working with no indication why.
+            if (job.exec)
+                job.exec();
+        }
+    }
+    return 0;
+}
+
+// =====================================================================
+// Detection
+// =====================================================================
+
+static bool AnyMouseButtonDown()
+{
+    return (GetAsyncKeyState(VK_LBUTTON) & 0x8000) ||
+           (GetAsyncKeyState(VK_RBUTTON) & 0x8000) ||
+           (GetAsyncKeyState(VK_MBUTTON) & 0x8000) ||
+           (GetAsyncKeyState(VK_XBUTTON1) & 0x8000) ||
+           (GetAsyncKeyState(VK_XBUTTON2) & 0x8000);
+}
+
+static void DetectTick()
+{
+    std::shared_ptr<const ZoneSet> zones;
+    EnterCriticalSection(&g_zonesLock);
+    zones = g_zones;
+    LeaveCriticalSection(&g_zonesLock);
+
+    if (!zones || zones->zones.empty())
+        return;
+
+    POINT pt;
+    if (!GetCursorPos(&pt))
+        return;
+
+    int idx = -1;
+    for (size_t i = 0; i < zones->zones.size(); i++)
+    {
+        const RECT &z = zones->zones[i].rect;
+        if (pt.x >= z.left && pt.x < z.right && pt.y >= z.top &&
+            pt.y < z.bottom)
+        {
+            idx = (int)i;
+            break;
+        }
+    }
+
+    ULONGLONG now = GetTickCount64();
+
+    // Enter/leave edge detection, the same shape macOS uses: a zone fires
+    // once on entry and re-arms only after the cursor leaves it.
+    if (idx != g_activeZone)
+    {
+        g_activeZone = idx;
+        g_enterTick = now;
+        g_firedThisEntry = false;
+    }
+
+    if (idx < 0 || g_firedThisEntry)
+        return;
+
+    // Suppress for the whole visit, not just this tick — otherwise releasing
+    // a drag inside a corner would immediately trigger it.
+    if (zones->disableDuringDrag && AnyMouseButtonDown())
+    {
+        g_firedThisEntry = true;
+        return;
+    }
+
+    // A corner cannot be reached without crossing the edge strip next to it,
+    // so a fast transit would fire the edge and then the corner milliseconds
+    // apart. With a toggle action bound to both (e.g. Task View) that opens
+    // and instantly re-closes, looking exactly like nothing happened.
+    // Requiring the cursor to settle means a pass-through never fires; only
+    // the zone you actually stop in does.
+    int dwell = zones->activationDelay > zones->settleMs ? zones->activationDelay
+                                                         : zones->settleMs;
+    if (dwell > 0 && (now - g_enterTick) < (ULONGLONG)dwell)
+        return;
+
+    if (zones->cooldownMs > 0 && idx < (int)g_lastFireTick.size())
+    {
+        ULONGLONG last = g_lastFireTick[idx];
+        if (last != 0 && (now - last) < (ULONGLONG)zones->cooldownMs)
+        {
+            g_firedThisEntry = true;
+            return;
+        }
+    }
+
+    // Global floor across all zones. The per-zone cooldown alone does not stop
+    // a sweep through several different zones from queueing a burst.
+    if (g_lastAnyFireTick != 0 &&
+        (now - g_lastAnyFireTick) < kMinFireIntervalMs)
+    {
+        g_firedThisEntry = true;
+        return;
+    }
+
+    g_firedThisEntry = true;
+    g_lastAnyFireTick = now;
+    if (idx < (int)g_lastFireTick.size())
+        g_lastFireTick[idx] = now;
+
+    EnqueueAction(zones->zones[idx]);
+}
+
+// =====================================================================
+// Detection Thread
+// =====================================================================
+
+static LRESULT CALLBACK DetectWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
+                                      LPARAM lParam)
+{
+    if (uMsg == WM_DISPLAYCHANGE || uMsg == WM_APP_REBUILD)
+    {
+        if (uMsg == WM_DISPLAYCHANGE)
+            Wh_Log(L"WM_DISPLAYCHANGE — rebuilding zones");
+        else
+            Wh_Log(L"Settings changed — rebuilding zones");
+        RebuildZones();
+        return 0;
+    }
+    return DefWindowProc(hWnd, uMsg, wParam, lParam);
+}
+
+static DWORD WINAPI DetectThread(LPVOID)
+{
+    // Everything that reads coordinates must agree on the DPI context.
+    PinThreadDpiPerMonitorV2();
+
+    const wchar_t *kClass = L"WindhawkHotCornersDetect";
+    HINSTANCE hInst = GetModuleHandle(nullptr);
+
+    WNDCLASS wc = {};
+    wc.lpfnWndProc = DetectWndProc;
+    wc.hInstance = hInst;
+    wc.lpszClassName = kClass;
+    RegisterClass(&wc);
+
+    // Must be a top-level window, not HWND_MESSAGE — message-only windows do
+    // not receive the WM_DISPLAYCHANGE broadcast.
+    g_hDetectWnd = CreateWindowEx(WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE, kClass,
+                                  nullptr, WS_POPUP, 0, 0, 0, 0, nullptr,
+                                  nullptr, hInst, nullptr);
+    if (!g_hDetectWnd)
+    {
+        Wh_Log(L"Failed to create detection window");
+        UnregisterClass(kClass, hInst);
+        return 1;
+    }
+
+    RebuildZones();
+
+    constexpr ULONGLONG kTopoCheckMs = 500;
+    ULONGLONG lastTopoCheck = GetTickCount64();
+
+    for (;;)
+    {
+        MSG msg;
+        while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
+        {
+            if (msg.message == WM_QUIT)
+                goto done;
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
+        }
+
+        // Display layout changes are a human-scale event; checking twice a
+        // second is plenty and keeps the 16 ms tick down to one GetCursorPos
+        // plus a few rectangle compares.
+        ULONGLONG nowTick = GetTickCount64();
+        if (nowTick - lastTopoCheck >= kTopoCheckMs)
+        {
+            lastTopoCheck = nowTick;
+            if (TopologyChanged())
+            {
+                Wh_Log(L"Display topology changed — rebuilding");
+                RebuildZones();
+            }
+        }
+
+        DetectTick();
+
+        if (WaitForSingleObject(g_hStopEvent, kTickMs) == WAIT_OBJECT_0)
+            break;
+    }
+
+done:
+    DestroyWindow(g_hDetectWnd);
+    g_hDetectWnd = nullptr;
+    UnregisterClass(kClass, hInst);
+    Wh_Log(L"Detection thread exiting");
+    return 0;
+}
+
+// =====================================================================
+// Settings
+// =====================================================================
+
+static void LoadSettings()
+{
+    using WindhawkUtils::StringSetting;
+
+    EnterCriticalSection(&g_settingsLock);
+
+    g_settings.cornerSize = Wh_GetIntSetting(L"CornerSize");
+    if (g_settings.cornerSize < 1)
+        g_settings.cornerSize = 6;
+
+    g_settings.edgeSize = Wh_GetIntSetting(L"EdgeSize");
+    if (g_settings.edgeSize < 1)
+        g_settings.edgeSize = 6;
+
+    g_settings.activationDelay = Wh_GetIntSetting(L"ActivationDelay");
+    if (g_settings.activationDelay < 0)
+        g_settings.activationDelay = 0;
+
+    g_settings.settleMs = Wh_GetIntSetting(L"SettleMs");
+    if (g_settings.settleMs < 0)
+        g_settings.settleMs = 0;
+
+    g_settings.cooldownMs = Wh_GetIntSetting(L"CooldownMs");
+    if (g_settings.cooldownMs < 0)
+        g_settings.cooldownMs = 0;
+
+    g_settings.disableOnFullscreen = Wh_GetIntSetting(L"DisableOnFullscreen");
+    g_settings.disableDuringDrag = Wh_GetIntSetting(L"DisableDuringDrag");
+    g_verboseLog = Wh_GetIntSetting(L"VerboseLogging") != 0;
+    g_showMonitorNames = Wh_GetIntSetting(L"ShowMonitorNames") != 0;
+
+    // Excluded processes (semicolon-separated, case-insensitive)
+    g_settings.excludedProcesses.clear();
+    {
+        std::wstring remaining =
+            std::wstring(StringSetting::make(L"ExcludedProcesses").get());
+        while (!remaining.empty())
+        {
+            auto semi = remaining.find(L';');
+            std::wstring token;
+            if (semi != std::wstring::npos)
+            {
+                token = TrimStr(remaining.substr(0, semi));
+                remaining = remaining.substr(semi + 1);
+            }
+            else
+            {
+                token = TrimStr(remaining);
+                remaining.clear();
+            }
+            if (!token.empty())
+                g_settings.excludedProcesses.push_back(ToLowerStr(token));
+        }
+    }
+
+    g_settings.monitorConfigs.clear();
+
+    static const wchar_t *zoneKeys[ZONE_COUNT] = {
+        L"TopLeft", L"TopRight",   L"BottomLeft", L"BottomRight",
+        L"EdgeTop", L"EdgeBottom", L"EdgeLeft",   L"EdgeRight",
+    };
+
+    for (int i = 0; i < 16; i++)
+    {
+        wchar_t keyBuf[128];
+
+        // An empty action string means there is no entry at this index.
+        _snwprintf_s(keyBuf, _countof(keyBuf), _TRUNCATE,
+                     L"MonitorCorners[%d].TopLeft", i);
+        auto probe = std::wstring(StringSetting::make(keyBuf).get());
+        if (probe.empty())
+            break;
+
+        MonitorZoneConfig cfg;
+
+        _snwprintf_s(keyBuf, _countof(keyBuf), _TRUNCATE,
+                     L"MonitorCorners[%d].MonitorId", i);
+        cfg.monitorId =
+            TrimStr(std::wstring(StringSetting::make(keyBuf).get()));
+
+        _snwprintf_s(keyBuf, _countof(keyBuf), _TRUNCATE,
+                     L"MonitorCorners[%d].Monitor", i);
+        cfg.monitorIndex = Wh_GetIntSetting(keyBuf);
+
+        bool hasAnyAction = false;
+        for (int z = 0; z < ZONE_COUNT; z++)
+        {
+            _snwprintf_s(keyBuf, _countof(keyBuf), _TRUNCATE,
+                         L"MonitorCorners[%d].%s", i, zoneKeys[z]);
+            auto actionStr = std::wstring(StringSetting::make(keyBuf).get());
+
+            _snwprintf_s(keyBuf, _countof(keyBuf), _TRUNCATE,
+                         L"MonitorCorners[%d].%sArgs", i, zoneKeys[z]);
+            auto argsStr = std::wstring(StringSetting::make(keyBuf).get());
+
+            CornerAction action = ParseActionType(actionStr);
+            cfg.zones[z].action = action;
+            cfg.zones[z].args = argsStr;
+            cfg.zones[z].executor = MakeExecutor(action, argsStr);
+
+            if (action != CornerAction::Nothing)
+                hasAnyAction = true;
+        }
+
+        if (!hasAnyAction)
+            continue;
+
+        // The resolved result is printed by BuildZoneSet as "Active zones";
+        // repeating every zone here just doubled the noise.
+        Wh_Log(L"Configuration %d applies to: %s", i + 1,
+               cfg.monitorId.empty()
+                   ? (cfg.monitorIndex == 0
+                          ? L"every monitor (legacy: Monitor Number 0)"
+                          : L"a monitor by number (legacy)")
+                   : cfg.monitorId.c_str());
+
+        g_settings.monitorConfigs.push_back(std::move(cfg));
+    }
+
+    Wh_Log(L"Sizes: corner %dpx, edge %dpx.  Timing: delay %dms, "
+           L"pass-through guard %dms, cooldown %dms.",
+           g_settings.cornerSize, g_settings.edgeSize,
+           g_settings.activationDelay, g_settings.settleMs,
+           g_settings.cooldownMs);
+    Wh_Log(L"Skip while fullscreen: %s.  Skip while dragging: %s.  "
+           L"Excluded apps: %d.",
+           g_settings.disableOnFullscreen ? L"yes" : L"no",
+           g_settings.disableDuringDrag ? L"yes" : L"no",
+           (int)g_settings.excludedProcesses.size());
+
+    LeaveCriticalSection(&g_settingsLock);
+}
+
+// =====================================================================
+// Tool Mod Entry Points
+// =====================================================================
+
+BOOL WhTool_ModInit()
+{
+    Wh_Log(L"Win-X Hot Corners v" WH_MOD_VERSION);
+
+    InitializeCriticalSection(&g_settingsLock);
+    InitializeCriticalSection(&g_zonesLock);
+    InitializeCriticalSection(&g_queueLock);
+
+    g_hStopEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+    g_hWorkEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+    if (!g_hStopEvent || !g_hWorkEvent)
+    {
+        Wh_Log(L"Failed to create events");
+        return FALSE;
+    }
+
+    LoadSettings();
+
+    g_hWorkerThread =
+        CreateThread(nullptr, 0, ActionWorkerThread, nullptr, 0, nullptr);
+    if (!g_hWorkerThread)
+    {
+        Wh_Log(L"Failed to create worker thread");
+        return FALSE;
+    }
+
+    g_hDetectThread =
+        CreateThread(nullptr, 0, DetectThread, nullptr, 0, &g_dwDetectThreadId);
+    if (!g_hDetectThread)
+    {
+        Wh_Log(L"Failed to create detection thread");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+void WhTool_ModSettingsChanged()
+{
+    LoadSettings();
+    // The zone rebuild has to happen on the detection thread, which owns the
+    // DPI context and the monitor list. Post, never send — Windhawk's thread
+    // must not block on ours.
+    if (g_hDetectWnd)
+        PostMessage(g_hDetectWnd, WM_APP_REBUILD, 0, 0);
+}
+
+void WhTool_ModUninit()
+{
+    if (g_hStopEvent)
+        SetEvent(g_hStopEvent);
+
+    if (g_dwDetectThreadId)
+        PostThreadMessage(g_dwDetectThreadId, WM_QUIT, 0, 0);
+
+    bool allStopped = true;
+
+    if (g_hDetectThread)
+    {
+        if (WaitForSingleObject(g_hDetectThread, 3000) == WAIT_TIMEOUT)
+        {
+            Wh_Log(L"Detection thread exit timed out");
+            allStopped = false;
+        }
+        CloseHandle(g_hDetectThread);
+        g_hDetectThread = nullptr;
+    }
+
+    if (g_hWorkerThread)
+    {
+        // Can legitimately still be inside ShellExecuteEx (a UAC prompt keeps
+        // it there indefinitely).
+        if (WaitForSingleObject(g_hWorkerThread, 3000) == WAIT_TIMEOUT)
+        {
+            Wh_Log(L"Worker thread exit timed out");
+            allStopped = false;
+        }
+        CloseHandle(g_hWorkerThread);
+        g_hWorkerThread = nullptr;
+    }
+
+    // Freeing objects a live thread is still using is undefined behaviour
+    // inside the host process. If a thread refused to stop, leak instead:
+    // this path is immediately followed by ExitProcess, so the leak costs
+    // nothing and cannot crash anything on the way out.
+    if (!allStopped)
+    {
+        Wh_Log(L"A thread did not stop; leaking sync objects rather than "
+               L"freeing them from under it");
+        return;
+    }
+
+    if (g_hStopEvent)
+    {
+        CloseHandle(g_hStopEvent);
+        g_hStopEvent = nullptr;
+    }
+    if (g_hWorkEvent)
+    {
+        CloseHandle(g_hWorkEvent);
+        g_hWorkEvent = nullptr;
+    }
+
+    DeleteCriticalSection(&g_queueLock);
+    DeleteCriticalSection(&g_zonesLock);
+    DeleteCriticalSection(&g_settingsLock);
+
+    Wh_Log(L"Uninit done");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Windhawk tool mod implementation for mods which don't need to inject to other
+// processes or hook other functions. Context:
+// https://github.com/ramensoftware/windhawk/wiki/Mods-as-tools:-Running-mods-in-a-dedicated-process
+//
+// The mod will load and run in a dedicated windhawk.exe process.
+
+bool g_isToolModProcessLauncher;
+HANDLE g_toolModProcessMutex;
+
+void WINAPI EntryPoint_Hook()
+{
+    ExitThread(0);
+}
+
+BOOL Wh_ModInit()
+{
+    DWORD sessionId;
+    if (ProcessIdToSessionId(GetCurrentProcessId(), &sessionId) &&
+        sessionId == 0)
+    {
+        return FALSE;
+    }
+
+    bool isExcluded = false;
+    bool isToolModProcess = false;
+    bool isCurrentToolModProcess = false;
+    int argc;
+    LPWSTR *argv = CommandLineToArgvW(GetCommandLine(), &argc);
+    if (!argv)
+    {
+        Wh_Log(L"CommandLineToArgvW failed");
+        return FALSE;
+    }
+
+    for (int i = 1; i < argc; i++)
+    {
+        if (wcscmp(argv[i], L"-service") == 0 ||
+            wcscmp(argv[i], L"-service-start") == 0 ||
+            wcscmp(argv[i], L"-service-stop") == 0)
+        {
+            isExcluded = true;
+            break;
+        }
+    }
+
+    for (int i = 1; i < argc - 1; i++)
+    {
+        if (wcscmp(argv[i], L"-tool-mod") == 0)
+        {
+            isToolModProcess = true;
+            if (wcscmp(argv[i + 1], WH_MOD_ID) == 0)
+            {
+                isCurrentToolModProcess = true;
+            }
+            break;
+        }
+    }
+
+    LocalFree(argv);
+
+    if (isExcluded)
+    {
+        return FALSE;
+    }
+
+    if (isCurrentToolModProcess)
+    {
+        g_toolModProcessMutex =
+            CreateMutex(nullptr, TRUE, L"windhawk-tool-mod_" WH_MOD_ID);
+        if (!g_toolModProcessMutex)
+        {
+            Wh_Log(L"CreateMutex failed");
+            ExitProcess(1);
+        }
+
+        if (GetLastError() == ERROR_ALREADY_EXISTS)
+        {
+            Wh_Log(L"Tool mod already running (%s)", WH_MOD_ID);
+            CloseHandle(g_toolModProcessMutex);
+            ExitProcess(1);
+        }
+
+        if (!WhTool_ModInit())
+        {
+            ExitProcess(1);
+        }
+
+        IMAGE_DOS_HEADER *dosHeader =
+            (IMAGE_DOS_HEADER *)GetModuleHandle(nullptr);
+        IMAGE_NT_HEADERS *ntHeaders =
+            (IMAGE_NT_HEADERS *)((BYTE *)dosHeader + dosHeader->e_lfanew);
+        DWORD entryPointRVA = ntHeaders->OptionalHeader.AddressOfEntryPoint;
+        void *entryPoint = (BYTE *)dosHeader + entryPointRVA;
+
+        Wh_SetFunctionHook(entryPoint, (void *)EntryPoint_Hook, nullptr);
+        return TRUE;
+    }
+
+    if (isToolModProcess)
+    {
+        return FALSE;
+    }
+
+    g_isToolModProcessLauncher = true;
+    return TRUE;
+}
+
+void Wh_ModAfterInit()
+{
+    if (!g_isToolModProcessLauncher)
+    {
+        return;
+    }
+
+    WCHAR currentProcessPath[MAX_PATH];
+    DWORD length = GetModuleFileName(nullptr, currentProcessPath,
+                                     ARRAYSIZE(currentProcessPath));
+    if (length == 0 || length == ARRAYSIZE(currentProcessPath))
+    {
+        Wh_Log(L"GetModuleFileName failed");
+        return;
+    }
+
+    WCHAR commandLine[MAX_PATH * 2];
+    swprintf_s(commandLine, L"\"%s\" -tool-mod \"%s\"", currentProcessPath,
+               WH_MOD_ID);
+
+    HMODULE kernelModule = GetModuleHandle(L"kernelbase.dll");
+    if (!kernelModule)
+    {
+        kernelModule = GetModuleHandle(L"kernel32.dll");
+    }
+    if (!kernelModule)
+    {
+        Wh_Log(L"GetModuleHandle failed");
+        return;
+    }
+
+    using CreateProcessInternalW_t = BOOL(WINAPI *)(
+        HANDLE hUserToken, LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+        LPSECURITY_ATTRIBUTES lpProcessAttributes,
+        LPSECURITY_ATTRIBUTES lpThreadAttributes, BOOL bInheritHandles,
+        DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory,
+        LPSTARTUPINFOW lpStartupInfo,
+        LPPROCESS_INFORMATION lpProcessInformation, PHANDLE hNewToken);
+    CreateProcessInternalW_t pCreateProcessInternalW =
+        (CreateProcessInternalW_t)GetProcAddress(kernelModule,
+                                                 "CreateProcessInternalW");
+    if (!pCreateProcessInternalW)
+    {
+        Wh_Log(L"GetProcAddress failed");
+        return;
+    }
+
+    STARTUPINFO si = {sizeof(si)};
+    si.dwFlags = STARTF_FORCEOFFFEEDBACK;
+    PROCESS_INFORMATION pi = {0};
+    if (pCreateProcessInternalW(nullptr, currentProcessPath, commandLine,
+                                nullptr, nullptr, FALSE, NORMAL_PRIORITY_CLASS,
+                                nullptr, nullptr, &si, &pi, nullptr))
+    {
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+    }
+    else
+    {
+        Wh_Log(L"CreateProcessInternalW failed");
+    }
+}
+
+void Wh_ModSettingsChanged()
+{
+    if (g_isToolModProcessLauncher)
+    {
+        return;
+    }
+
+    WhTool_ModSettingsChanged();
+}
+
+void Wh_ModUninit()
+{
+    if (g_isToolModProcessLauncher)
+    {
+        return;
+    }
+
+    WhTool_ModUninit();
+    ExitProcess(0);
+}

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,12 +2,13 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         4.1.1
+// @version         4.4.0
 // @author          lost_husky
 // @github          https://github.com/DhakadG
+// @donateUrl       https://ko-fi.com/losthusky_
 // @license         MIT
 // @include         windhawk.exe
-// @compilerOptions -ladvapi32 -lcomctl32 -lgdi32 -lpowrprof -lshell32 -luser32
+// @compilerOptions -ladvapi32 -lcomctl32 -lgdi32 -lole32 -lpowrprof -lshell32 -luser32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -37,8 +38,9 @@ If all you want is one specific behaviour, a smaller mod may suit you better:
 
 ## Features
 
-- **Bounded latency** — a dedicated detection thread samples the cursor every
-  ~16 ms, and only idles when nothing could fire anyway. Nothing can starve it:
+- **Bounded latency** — a dedicated detection thread asks to sample the cursor
+  every 16 ms (one system timer tick, so 16-31 ms in practice) and only idles
+  when nothing could fire anyway. Nothing can starve it:
   not a busy explorer, not an elevated foreground app, not a slow action.
 - **Zero impact on the rest of the system** — no global mouse hook, so your
   games and apps keep their input path to themselves.
@@ -48,28 +50,39 @@ If all you want is one specific behaviour, a smaller mod may suit you better:
   model are the one exception — see *Identifying your monitors*.)
 - **Per-monitor DPI correct** — detection runs per-monitor-DPI-aware, so
   zones land in the right place on mixed-scaling setups.
-- **Screen edges** — trigger actions on the top, bottom, left, or right edge
-  of any monitor.
+- **Screen edges, in three parts** — each edge is split into a start, a middle
+  and an end, configured separately. Give neighbouring parts the same action and
+  they merge back into one, so you get whichever of `ABC`, `AAB`, `ABB` or `AAA`
+  you want without a mode switch. See *Dividing an edge*.
+- **Knock to trigger** — set a knock window on any zone, corners included, and a
+  single arrival does nothing: you have to leave and come back within the window.
+  Handy on a corner you brush past often.
 - **Configurable zone size**, optional dwell delay, and a cooldown timer.
 - **Fullscreen protection** — auto-detects games, presentations, and D3D
   fullscreen apps.
 - **Drag protection** — zones don't fire while a mouse button is held.
 - **App exclusions** — blacklist processes that need corner/edge clicks.
 
-## Configuring — look in your system tray, not here
+## Configuring
 
-**This mod has no Settings page.** Everything is configured from the tray icon
-it adds, next to the clock:
+**Settings page** — zones, timings and everything else. Add a display, then add
+the zones you want on it. A zone you do not list does nothing.
+
+**Tray icon**, next to the clock:
 
 - **Left-click** — turn the hot corners on or off.
 - **Right-click** — a quick menu: suspend for a while, skip while an app is
   fullscreen, skip while dragging.
-- **Right-click → Zones & settings...** — the dashboard, where zones, timings
-  and everything else live.
+- **Right-click → Zones & settings...** — the dashboard: a tab per display,
+  a picture of that screen with each zone showing what it does, and the timings
+  actually in effect for whichever zone you point at.
 
-The dashboard is a normal window with a live preview of your screen, so you
-click the corner you want and pick its action. Every field explains itself on
-hover.
+### Upgrading from 4.1.x
+
+Earlier versions had no settings page and stored the layout themselves. That
+layout keeps running untouched, so nothing breaks on upgrade — the log says so
+at startup. Re-enter it on the settings page when you are ready; the moment one
+display is listed there, the old layout is ignored.
 
 This is deliberate. Twelve zones on each of up to eight displays, each with a
 forty-entry action list and six timing overrides, is not something a settings
@@ -140,12 +153,49 @@ taskbar to keep it there.
 | Custom Command | Launch any executable, path, or URL |
 | Nothing | Disabled (default) |
 
+## Dividing an edge
+
+Every edge runs between the two corners it touches and is divided into three
+segments — for the top and bottom edge those are **left, centre, right**; for
+the left and right edge, **top, middle, bottom**. The centre segment's width is
+the *Edge centre width* setting, as a percentage of the edge.
+
+You do not choose a "mode". Configure the three segments and the mod works out
+the shape:
+
+| You set | You get |
+| --- | --- |
+| All three the same | One zone spanning the whole edge |
+| Left + centre same, right different | Two zones |
+| All three different | Three zones |
+| Only the centre | One zone in the middle of the edge |
+| Left and right same, centre unset | Two zones with a dead gap between them |
+
+Neighbouring segments merge only when they are *identical* — same action, same
+arguments, same overrides. Two segments running the same action with different
+cooldowns stay separate, because a merged zone could only carry one cooldown.
+
+Merging is not cosmetic. Three separate zones all running Task View would each
+re-arm as the pointer crossed a seam, so sliding along the edge would fire it
+repeatedly; one merged zone fires once.
+
+## Knock to trigger
+
+Set **Knock window** on a zone — globally, or per zone — and a single arrival
+never fires it. The zone arms only when you leave and come back within that many
+milliseconds. `0` turns it off.
+
+This works on every zone, corners included, so a corner you keep brushing past
+on the way to something else can be made deliberate. 400 ms is a comfortable
+double-knock; below about 200 ms it starts to need intent.
+
 ## Identifying your monitors
 
-The dashboard's monitor selector lists your displays by name, so normally there
-is nothing to identify. The names also go to this mod's log every time it loads
-or your display layout changes, which is the place to check when a display is
-unplugged and you want to know which configuration belonged to it:
+The dashboard has one tab per display, labelled with its name, so normally there
+is nothing to identify — a display that is not plugged in keeps its tab, marked
+with a dot. The names also go to this mod's log every time it loads or your
+display layout changes, which is the place to copy an exact name from when you
+are filling in the settings page:
 
 ```
 Monitor 1 [PRIMARY] id='Dell U2720Q' device=\\.\DISPLAY1 (0,0)-(3840,2160)
@@ -221,6 +271,128 @@ Hot corners are disabled when any excluded process is the foreground window.
 **Example:** `photoshop.exe;premiere.exe;blender.exe`
 
 # Changelog
+
+## What's New in v4.4.0
+
+- **Every edge is now three separate zones** — start, middle and end. The two
+  outer stretches used to share one configuration, so `ABC` was impossible.
+- **Neighbouring segments with the same action merge back into one.** That is
+  what makes `AAA`, `AAB`, `ABB` and `ABC` all expressible without a mode
+  switch, and it is not just tidiness: three adjacent zones sharing an action
+  would each re-arm as the pointer crossed a seam, firing repeatedly as you
+  slid along the edge. Segments merge only when they are identical — same
+  action, arguments and overrides.
+- **Your existing layout still works.** A stored edge fills both outer
+  segments, and the middle too when no centre was configured, which reproduces
+  the old geometry exactly — the three identical segments coalesce straight
+  back into the single edge-wide zone you had.
+- **Knock works on corners.** It always did — it is a per-zone setting — but
+  nothing said so. There is a section about it in the readme now.
+- **The tray menu opens at the tray icon** instead of wherever the pointer
+  happened to be, and follows the taskbar to whichever edge it is docked on.
+- **New icon**, and the dashboard window has one again — it lost its icon in
+  4.3.0 when the window was rewritten.
+
+## What's New in v4.3.0
+
+The dashboard is now a picture of your configuration rather than a form.
+
+- **A tab per display**, labelled with its name and carrying a count of how many
+  zones you have set up on it, so "did I configure anything on that screen?" is
+  answerable at a glance. A display that is not plugged in keeps its tab, marked
+  with a dot — its configuration is still real.
+- **The screen is drawn at its real aspect ratio**, so a portrait or ultrawide
+  display looks like one.
+- **Each zone shows what it does.** Side strips read vertically, which is the
+  only way a name like "Notification Centre" fits inside one.
+- **Point at a zone and the panel below shows every timing in effect for it** —
+  size, delay, pass-through guard, knock, cooldown and modifier — with each one
+  marked *global* or *this zone*. A zone inherits five numbers it never used to
+  show, so "why did this one fire late?" was unanswerable without reading the
+  configuration by hand. Click to pin a zone, click again to release it.
+- **Zones taken from the "All displays" configuration say so**, instead of
+  looking like they belong to the display you are viewing.
+- The editing controls are gone. Everything is configured on the settings page,
+  and the window follows it live — change a setting in Windhawk and the picture
+  updates without reopening.
+
+## What's New in v4.2.1
+
+**The settings page is back.** It went away in 4.1.0 because forty settings in
+one flat list was unusable. Windhawk v2 renders them as collapsible groups, so
+that reason is gone.
+
+- **Zones, timings and everything else are configured in Settings.** Add a
+  display, then add only the zones you want on it — no more scrolling past
+  twelve entries to reach the one you use.
+- **Nothing breaks on upgrade.** A layout saved by 4.1.x keeps running exactly
+  as it did, globals included, and the log says so at startup. It is ignored
+  only once you list a display on the settings page.
+- **The dashboard no longer saves.** It was a second surface writing the same
+  store, which is what caused the configuration-swapping bug in 4.1.4. It now
+  tells you to edit in Settings rather than reporting a save that did nothing.
+
+## What's New in v4.1.4
+
+Review fixes, the first of which could lose a display's configuration.
+
+- **The editor bound each configuration to a list position instead of to a
+  display.** Detection has always matched zones by display name, but the
+  dashboard read and wrote whichever stored group sat at the same index as the
+  entry in its dropdown. That list is ordered primary first, then left to right,
+  so making another display primary or unplugging one renumbered it — and the
+  editor would then show one display's zones under another's name, and overwrite
+  them there on save. Each entry is now matched to its stored group by name, a
+  display configured for the first time takes the lowest free group, and a
+  display that is not currently plugged in keeps the group it owns.
+- **Custom Command could silently fail for URLs, shortcuts and folders.** Those
+  go through shell extensions that need COM, and the worker thread running them
+  had no apartment. It initialises one now, and both `ShellExecuteEx` calls ask
+  the shell not to return before it is finished, since that thread has no
+  message loop.
+- **A cooldown consumed the visit.** Walking into a zone shortly after anything
+  else fired and then parking there never fired at all — you had to leave and
+  come back. A cooldown is now a wait rather than a refusal, so staying put
+  outlasts it.
+- **Lock and blank the display no longer blocks unload** for up to ten seconds
+  while it waits out the blanking delay.
+- Argument fields stop input at the length the mod can actually store, rather
+  than truncating past it in silence.
+- The readme no longer claims a 16 ms sample rate without qualification: the
+  wait expires on a system timer tick, so it is 16-31 ms in practice.
+- Dropped an unused header, a brush that was created and destroyed but never
+  used, and a monitor-matching branch that could never be reached.
+
+## What's New in v4.1.3
+
+- **Fixed a crash on unload.** Every thread is given three seconds to stop
+  before the mod frees the locks they share, and a thread that misses that
+  deadline makes the mod leak them instead — freeing something a live thread is
+  still using is undefined behaviour inside Windhawk's own process. The tray
+  thread was the one exception: its timeout was logged and then ignored, so a
+  tray thread that had not finished could have its locks deleted underneath it.
+  It now counts like the others. Waits also treat a failed wait as "still
+  running" rather than as success.
+- **The tray's on/off toggle is serialised with the rest.** It wrote its key
+  outside the reload lock, so a reload running at that moment could put the old
+  value back and leave the switch disagreeing with what was stored.
+
+## What's New in v4.1.2
+
+Two more review fixes, both about threads.
+
+- **Two reloads could finish out of order.** Reloading builds the whole
+  configuration off to the side and swaps it in at the end — which is what keeps
+  the settings lock held briefly, but meant two reloads started close together
+  could publish in the wrong order, leaving the live configuration stale against
+  what was actually saved. Saving from the dashboard, resetting, and the tray's
+  own toggles now hold one lock across both the write and the reload that reads
+  it back, so a reload always sees a settled store.
+- **A failed cursor read slowed detection to the idle rate.** `GetCursorPos`
+  failing is transient, and the zones are still armed while it does — so the
+  right answer is to try again on the next 16 ms tick, not to wait 100 ms. Only
+  the states where nothing can fire at all use the idle rate, which is what the
+  documentation already claimed.
 
 ## What's New in v4.1.1
 
@@ -519,18 +691,210 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
   detection.
 - Display-layout changes are picked up even when Windows doesn't send
   `WM_DISPLAYCHANGE` (docking, monitor wake, RDP reconnect).
+
+## Support
+
+Windhawk renders the `@donateUrl` in the metadata block as a Donate button in the mod
+listing, but it only takes one link, so the rest live here.
+
+- [Ko-fi](https://ko-fi.com/losthusky_)
+- [Buy Me a Coffee](https://www.buymeacoffee.com/losthusky_)
+- [Playto](https://www.playto.so/losthusky_)
+
+<!-- Plain links rather than badge images on purpose: this repository only allows
+     images from i.imgur.com and raw.githubusercontent.com, so a shields.io badge
+     would not render. To add a platform, add a bullet.
+     Pending accounts: OnlyChai, BuyMeChai — drop the URLs in when they exist. -->
 */
 // ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- displays:
+  - - monitor: "*"
+      $name: Display
+      $description: >-
+        The display's friendly name, exactly as this mod prints it in the log,
+        or  *  to apply this configuration to every display. Open the log, or
+        the dashboard's tab strip, to see the names.
+    - zones:
+      - - zone: TOP_LEFT
+          $name: Zone
+          $options:
+          - TOP_LEFT: Top-left corner
+          - TOP_RIGHT: Top-right corner
+          - BOTTOM_LEFT: Bottom-left corner
+          - BOTTOM_RIGHT: Bottom-right corner
+          - TOP_START: "Top edge: left"
+          - TOP_MIDDLE: "Top edge: centre"
+          - TOP_END: "Top edge: right"
+          - BOTTOM_START: "Bottom edge: left"
+          - BOTTOM_MIDDLE: "Bottom edge: centre"
+          - BOTTOM_END: "Bottom edge: right"
+          - LEFT_START: "Left edge: top"
+          - LEFT_MIDDLE: "Left edge: middle"
+          - LEFT_END: "Left edge: bottom"
+          - RIGHT_START: "Right edge: top"
+          - RIGHT_MIDDLE: "Right edge: middle"
+          - RIGHT_END: "Right edge: bottom"
+        - action: ACTION_NOTHING
+          $name: Action
+          $options:
+          - ACTION_NOTHING: Nothing
+          - ACTION_SHOW_DESKTOP: Show desktop
+          - ACTION_TASK_VIEW: Task View
+          - ACTION_SCREENSAVER: Start screensaver
+          - ACTION_MONITORS_OFF: Turn monitors off
+          - ACTION_QUICK_SETTINGS: Quick Settings
+          - ACTION_NOTIFICATION_CENTER: Notification Centre
+          - ACTION_START_MENU: Start menu
+          - ACTION_HIDE_OTHERS: Hide other windows
+          - ACTION_MUTE: Mute
+          - ACTION_TASK_MANAGER: Task Manager
+          - ACTION_LOCK: Lock
+          - ACTION_SLEEP: Sleep
+          - ACTION_SWITCH_LAST: Switch to last window
+          - ACTION_TASK_SWITCHER: Task switcher
+          - ACTION_MINIMIZE: Minimise window
+          - ACTION_MAXIMIZE: Maximise window
+          - ACTION_SNAP_LEFT: Snap left
+          - ACTION_SNAP_RIGHT: Snap right
+          - ACTION_CLOSE_WINDOW: Close window
+          - ACTION_FILE_EXPLORER: File Explorer
+          - ACTION_SETTINGS: Settings
+          - ACTION_SEARCH: Search
+          - ACTION_CLIPBOARD: Clipboard history
+          - ACTION_SCREENSHOT: Screenshot
+          - ACTION_PROJECT: Project display
+          - ACTION_VDESK_NEXT: Next virtual desktop
+          - ACTION_VDESK_PREV: Previous virtual desktop
+          - ACTION_VDESK_NEW: New virtual desktop
+          - ACTION_VDESK_CLOSE: Close virtual desktop
+          - ACTION_LOCK_MONITORS_OFF: Lock and turn monitors off
+          - ACTION_KEEP_AWAKE_ON: Keep awake on
+          - ACTION_KEEP_AWAKE_OFF: Keep awake off
+          - ACTION_SEND_KEYPRESS: Send key press
+          - ACTION_ALTERNATE_KEYPRESS: Alternate key press
+          - ACTION_START_PROCESS: Custom command
+          - ACTION_ALTERNATE_COMMAND: Alternate command
+        - args: ""
+          $name: Arguments
+          $description: >-
+            Only used by some actions. Send key press takes a combination such
+            as  Ctrl+Shift+Esc . Custom command takes an executable, path or
+            URL. The two Alternate actions take both halves separated by a
+            vertical bar, for example  Alt+S | Alt+H .
+        - size: -1
+          $name: Size override (px)
+          $description: >-
+            Corner square, or edge strip thickness. -1 keeps the global value.
+        - delay: -1
+          $name: Activation delay override (ms)
+          $description: -1 keeps the global value.
+        - settle: -1
+          $name: Pass-through guard override (ms)
+          $description: -1 keeps the global value.
+        - knock: -1
+          $name: Knock window override (ms)
+          $description: -1 keeps the global value. 0 disables knock mode.
+        - cooldown: -1
+          $name: Cooldown override (ms)
+          $description: -1 keeps the global value.
+        - modifier: INHERIT
+          $name: Modifier override
+          $options:
+          - INHERIT: Keep the global value
+          - NONE: None
+          - CTRL: Ctrl
+          - ALT: Alt
+          - SHIFT: Shift
+          - WIN: Win
+      $name: Zones
+      $description: >-
+        One entry per zone you want active on this display. A zone you do not
+        list does nothing. Listing the same zone twice uses the first entry.
+
+        Each edge is three segments. Give them three different actions for
+        three separate zones, or give neighbouring segments the same action
+        and they merge into one - so all three alike is a single edge-wide
+        zone, and left+centre alike with a different right is two.
+
+        "Merge" means identical: same action, same arguments and the same
+        overrides. Two segments running the same action with different
+        cooldowns stay separate.
+  $name: Displays
+  $description: >-
+    Leave this empty to keep using a layout saved by an older version of the
+    mod. As soon as you add a display here, this list takes over completely.
+
+- cornerSize: 6
+  $name: Corner size (px)
+  $description: How far into the corner the pointer has to reach.
+- edgeSize: 6
+  $name: Edge thickness (px)
+- centerPercent: 20
+  $name: Edge centre width (%)
+  $description: How much of each edge the centre zone occupies.
+
+- delay: 0
+  $name: Activation delay (ms)
+  $description: How long the pointer must rest in a zone before it fires.
+- settle: 80
+  $name: Pass-through guard (ms)
+  $description: >-
+    Ignores a zone the pointer is merely travelling through. Raise it if
+    actions fire while you are moving to something else.
+- knock: 0
+  $name: Knock window (ms)
+  $description: >-
+    0 disables knock mode. Above 0, the zone has to be entered twice within
+    this window before it fires.
+- cooldown: 300
+  $name: Cooldown (ms)
+  $description: Minimum gap between two firings of the same zone.
+- requireModifier: NONE
+  $name: Required modifier
+  $description: A key that must be held for any zone to fire.
+  $options:
+  - NONE: None
+  - CTRL: Ctrl
+  - ALT: Alt
+  - SHIFT: Shift
+  - WIN: Win
+
+- disableOnFullscreen: true
+  $name: Skip while a window is fullscreen
+  $description: Only suppresses the display the fullscreen window is on.
+- disableDuringDrag: true
+  $name: Skip while dragging
+- avoidTaskbar: false
+  $name: Keep zones out of the taskbar
+  $description: >-
+    Shrinks each display's zones to its working area, so a corner sitting
+    behind the taskbar cannot be reached.
+- excluded: ""
+  $name: Excluded applications
+  $description: >-
+    Semicolon-separated executable names, for example  game.exe; vlc.exe .
+    Zones do nothing while one of these is in the foreground.
+
+- lockBlankDelay: 1200
+  $name: Lock-then-blank delay (ms)
+  $description: >-
+    How long "Lock and turn monitors off" waits after locking before blanking.
+- showMonitorNames: true
+  $name: List display names in the log
+*/
+// ==/WindhawkModSettings==
 
 #include <windows.h>
 
 #include <commctrl.h>
-#include <windowsx.h>   // GET_X_LPARAM / GET_Y_LPARAM // windhawk_utils.h needs SUBCLASSPROC from here
+#include <windowsx.h>   // GET_X_LPARAM / GET_Y_LPARAM
 #include <initializer_list>
 #include <powrprof.h>
 #include <shellapi.h>
 #include <windhawk_api.h>
-#include <windhawk_utils.h>
 
 #include <algorithm>
 #include <atomic>
@@ -539,6 +903,7 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cwchar>
 #include <cwctype>
 #include <deque>
 #include <functional>
@@ -595,22 +960,39 @@ enum class CornerAction
     StartProcess,
 };
 
-// Zone IDs: 0-3 = corners, 4-7 = edges
+// Zone IDs: 0-3 corners, then each edge as three independently configurable
+// segments running between the two corners it touches.
+//
+// Before 4.4 an edge was one zone plus an optional centre, so the two outer
+// stretches always did the same thing. Splitting them into start/middle/end
+// makes every pattern expressible - ABC, AAB, ABB - and setting all three the
+// same gives one edge-wide zone, because BuildZoneSet coalesces neighbouring
+// segments that resolve identically. That coalescing matters: three separate
+// zones carrying one action would each re-arm as the pointer crossed a seam.
 enum Zone
 {
     ZONE_TOP_LEFT = 0,
     ZONE_TOP_RIGHT = 1,
     ZONE_BOTTOM_LEFT = 2,
     ZONE_BOTTOM_RIGHT = 3,
-    ZONE_EDGE_TOP = 4,
-    ZONE_EDGE_BOTTOM = 5,
-    ZONE_EDGE_LEFT = 6,
-    ZONE_EDGE_RIGHT = 7,
-    ZONE_CENTER_TOP = 8,
-    ZONE_CENTER_BOTTOM = 9,
-    ZONE_CENTER_LEFT = 10,
-    ZONE_CENTER_RIGHT = 11,
-    ZONE_COUNT = 12,
+
+    ZONE_TOP_START = 4,      // left-hand stretch of the top edge
+    ZONE_TOP_MIDDLE = 5,
+    ZONE_TOP_END = 6,        // right-hand stretch
+
+    ZONE_BOTTOM_START = 7,
+    ZONE_BOTTOM_MIDDLE = 8,
+    ZONE_BOTTOM_END = 9,
+
+    ZONE_LEFT_START = 10,    // upper stretch of the left edge
+    ZONE_LEFT_MIDDLE = 11,
+    ZONE_LEFT_END = 12,      // lower stretch
+
+    ZONE_RIGHT_START = 13,
+    ZONE_RIGHT_MIDDLE = 14,
+    ZONE_RIGHT_END = 15,
+
+    ZONE_COUNT = 16,
 };
 
 // Per-zone overrides. Every numeric field uses -1 for "inherit the global
@@ -636,8 +1018,7 @@ struct ZoneConfig
 
 struct MonitorZoneConfig
 {
-    std::wstring monitorId; // friendly name, "*" for all, or "" to use index
-    int monitorIndex = 0;   // legacy fallback, only used when monitorId empty
+    std::wstring monitorId;   // friendly name, or "*" for all displays
     ZoneConfig zones[ZONE_COUNT];
 };
 
@@ -672,7 +1053,7 @@ struct HitZone
 
     // Which display this zone lives on, so the fullscreen guard can suppress
     // the display a game is actually on and leave the others alone.
-    // ponytail: an HMONITOR, not a rect. It is only stale between a display
+    // An HMONITOR, not a rect. It is only stale between a display
     // change and the rebuild that follows it, and a stale one simply fails to
     // match, which errs towards firing rather than towards silence.
     HMONITOR monitor = nullptr;
@@ -683,10 +1064,18 @@ struct HitZone
 struct ZoneSet
 {
     std::vector<HitZone> zones;
-    // Friendly names of the displays this set was built from. They ride in the
-    // snapshot so the dashboard thread can list monitors without reading
-    // g_monitors, which the detection thread clears and refills underneath it.
-    std::vector<std::wstring> monitorNames;
+    // The displays this set was built from. They ride in the snapshot so the
+    // dashboard thread can list monitors without reading g_monitors, which the
+    // detection thread clears and refills underneath it. The size comes along
+    // because the dashboard draws each screen at its real aspect ratio.
+    struct MonitorSummary
+    {
+        std::wstring id;
+        int width = 0;
+        int height = 0;
+        bool primary = false;
+    };
+    std::vector<MonitorSummary> monitors;
     // Only what the detection loop actually reads. The timings live on each
     // HitZone, resolved at build time, which is the whole point of resolving
     // them there; a second copy here would just be a second thing to keep
@@ -722,6 +1111,20 @@ static ModSettings g_settings;
 // only when it rebuilds zones. Everything the detection loop needs at runtime
 // lives in the published ZoneSet instead, so this is never taken per tick.
 static CRITICAL_SECTION g_settingsLock;
+
+// Serialises a whole write-then-reload, so two of them cannot interleave.
+// ReloadConfig builds its result outside g_settingsLock on purpose - that is
+// what keeps the hold short - but it means two reloads racing could publish out
+// of order and leave the older one winning, with the runtime configuration
+// stale against what is actually stored. The dashboard's Save, the dashboard's
+// Reset and the tray's reset take this around their value-store writes *and*
+// the reload that follows, so a reload always sees a settled store. Recursive
+// by nature, which is why those callers can hold it across ReloadConfig's own
+// acquisition.
+//
+// Order is always g_reloadLock then g_settingsLock; nothing takes them the
+// other way round.
+static CRITICAL_SECTION g_reloadLock;
 
 // Published zone snapshot. Swapped wholesale on rebuild; readers take a
 // shared_ptr copy, so an in-flight tick can never see a half-rebuilt vector.
@@ -1086,7 +1489,7 @@ static void QueryMonitorFriendlyNames(
     // the caller to size and query again. Without the retry every friendly
     // name is lost for that rebuild, and every zone bound to a name silently
     // stops matching until the next display change.
-    // ponytail: 3 attempts. A layout that changes three times inside one
+    // 3 attempts. A layout that changes three times inside one
     // rebuild will fix itself on the next WM_DISPLAYCHANGE anyway.
     LONG qc = ERROR_INSUFFICIENT_BUFFER;
     for (int attempt = 0; attempt < 3 && qc == ERROR_INSUFFICIENT_BUFFER;
@@ -1612,7 +2015,10 @@ static void ActionTaskManager()
     std::wstring path = std::wstring(sysDir) + L"\\Taskmgr.exe";
 
     SHELLEXECUTEINFO sei = {sizeof(sei)};
-    sei.fMask = SEE_MASK_FLAG_NO_UI;
+    // NOASYNC because the worker thread has no message loop: without it the
+    // call can return before the shell is finished, and the thread is torn
+    // down at uninit.
+    sei.fMask = SEE_MASK_FLAG_NO_UI | SEE_MASK_NOASYNC;
     sei.lpVerb = L"open";
     sei.lpFile = path.c_str();
     sei.nShow = SW_SHOW;
@@ -1657,7 +2063,13 @@ static void ActionLockAndMonitorsOff()
     // The lock transition itself counts as activity, so blanking too soon
     // just wakes the display straight back up. How long the switch to the
     // secure desktop takes varies by machine, hence the setting.
-    Sleep((DWORD)g_lockBlankDelayMs.load());
+    //
+    // Waiting on the stop event rather than sleeping: this can be up to ten
+    // seconds, and an unload during it would otherwise sit out the whole delay
+    // and then push WhTool_ModUninit into its three-second timeout path.
+    if (WaitForSingleObject(g_hStopEvent, (DWORD)g_lockBlankDelayMs.load()) ==
+        WAIT_OBJECT_0)
+        return;
     BroadcastSysCommand(SC_MONITORPOWER, (LPARAM)2);
 }
 
@@ -1771,7 +2183,10 @@ static void ActionStartProcess(const std::wstring &command)
     }
 
     SHELLEXECUTEINFO sei = {sizeof(sei)};
-    sei.fMask = SEE_MASK_FLAG_NO_UI;
+    // NOASYNC because the worker thread has no message loop: without it the
+    // call can return before the shell is finished, and the thread is torn
+    // down at uninit.
+    sei.fMask = SEE_MASK_FLAG_NO_UI | SEE_MASK_NOASYNC;
     sei.lpVerb = verb.c_str();
     sei.lpFile = exe.c_str();
     sei.lpParameters = params.empty() ? nullptr : params.c_str();
@@ -1887,14 +2302,18 @@ static const wchar_t *ZoneToString(Zone z)
     case ZONE_TOP_RIGHT: return L"Top-right corner";
     case ZONE_BOTTOM_LEFT: return L"Bottom-left corner";
     case ZONE_BOTTOM_RIGHT: return L"Bottom-right corner";
-    case ZONE_EDGE_TOP: return L"Top edge";
-    case ZONE_EDGE_BOTTOM: return L"Bottom edge";
-    case ZONE_EDGE_LEFT: return L"Left edge";
-    case ZONE_EDGE_RIGHT: return L"Right edge";
-    case ZONE_CENTER_TOP: return L"Top edge centre";
-    case ZONE_CENTER_BOTTOM: return L"Bottom edge centre";
-    case ZONE_CENTER_LEFT: return L"Left edge centre";
-    case ZONE_CENTER_RIGHT: return L"Right edge centre";
+    case ZONE_TOP_START: return L"Top edge, left";
+    case ZONE_TOP_MIDDLE: return L"Top edge, centre";
+    case ZONE_TOP_END: return L"Top edge, right";
+    case ZONE_BOTTOM_START: return L"Bottom edge, left";
+    case ZONE_BOTTOM_MIDDLE: return L"Bottom edge, centre";
+    case ZONE_BOTTOM_END: return L"Bottom edge, right";
+    case ZONE_LEFT_START: return L"Left edge, top";
+    case ZONE_LEFT_MIDDLE: return L"Left edge, middle";
+    case ZONE_LEFT_END: return L"Left edge, bottom";
+    case ZONE_RIGHT_START: return L"Right edge, top";
+    case ZONE_RIGHT_MIDDLE: return L"Right edge, middle";
+    case ZONE_RIGHT_END: return L"Right edge, bottom";
     default: return L"None";
     }
 }
@@ -2041,6 +2460,23 @@ static std::function<void()> MakeExecutor(CornerAction action,
 // Resolves one zone for one monitor. A name-matched config wins; otherwise a
 // wildcard config supplies the action. Resolution is per zone, so a wildcard
 // entry can cover most zones while one display overrides a single corner.
+// Two segments of an edge are interchangeable only if everything about them
+// matches - the same action with a different cooldown still has to stay two
+// zones, because the cooldown is what the merged zone would have to carry.
+static bool SameZoneConfig(const ZoneConfig *a, const ZoneConfig *b)
+{
+    if (a == b)
+        return true;
+    if (!a || !b)
+        return false;
+    if (a->action != b->action || a->args != b->args)
+        return false;
+    const ZoneTuning &x = a->tuning, &y = b->tuning;
+    return x.size == y.size && x.delay == y.delay && x.settle == y.settle &&
+           x.knock == y.knock && x.cooldown == y.cooldown &&
+           x.modifier == y.modifier;
+}
+
 // Caller must hold g_settingsLock.
 static const ZoneConfig *ResolveZone(const MonitorInfo &mon, Zone zone)
 {
@@ -2056,21 +2492,10 @@ static const ZoneConfig *ResolveZone(const MonitorInfo &mon, Zone zone)
             return &zc;
     }
 
-    // 2. Legacy numeric ordinal, for configs carried over from v2.x
+    // 2. Wildcard
     for (const auto &cfg : g_settings.monitorConfigs)
     {
-        if (!cfg.monitorId.empty() || cfg.monitorIndex != mon.index)
-            continue;
-        const auto &zc = cfg.zones[zone];
-        if (zc.action != CornerAction::Nothing && zc.executor)
-            return &zc;
-    }
-
-    // 3. Wildcard
-    for (const auto &cfg : g_settings.monitorConfigs)
-    {
-        if (cfg.monitorId != L"*" &&
-            !(cfg.monitorId.empty() && cfg.monitorIndex == 0))
+        if (cfg.monitorId != L"*")
             continue;
         const auto &zc = cfg.zones[zone];
         if (zc.action != CornerAction::Nothing && zc.executor)
@@ -2095,7 +2520,14 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
     set->disableDuringDrag = g_settings.disableDuringDrag;
 
     for (const auto &mon : g_monitors)
-        set->monitorNames.push_back(mon.id);
+    {
+        ZoneSet::MonitorSummary ms;
+        ms.id = mon.id;
+        ms.width = mon.rcMonitor.right - mon.rcMonitor.left;
+        ms.height = mon.rcMonitor.bottom - mon.rcMonitor.top;
+        ms.primary = mon.isPrimary;
+        set->monitors.push_back(std::move(ms));
+    }
 
     for (const auto &mon : g_monitors)
     {
@@ -2139,10 +2571,27 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
             int cap = a < b ? a : b;
             return v > cap ? cap : v;
         };
-        int esTop = edgeThickness(ZONE_EDGE_TOP, csTL, csTR);
-        int esBot = edgeThickness(ZONE_EDGE_BOTTOM, csBL, csBR);
-        int esLeft = edgeThickness(ZONE_EDGE_LEFT, csTL, csBL);
-        int esRight = edgeThickness(ZONE_EDGE_RIGHT, csTR, csBR);
+        // An edge is one strip however many segments it carries, so its
+        // thickness comes from the first segment that asks for one.
+        auto edgeThickness3 = [&](Zone a, Zone b, Zone c, int lim1,
+                                  int lim2) -> int
+        {
+            for (Zone z : {a, b, c})
+            {
+                const ZoneConfig *zc = zoneCfg(z);
+                if (zc && zc->tuning.size > 0)
+                    return edgeThickness(z, lim1, lim2);
+            }
+            return edgeThickness(a, lim1, lim2);
+        };
+        int esTop = edgeThickness3(ZONE_TOP_START, ZONE_TOP_MIDDLE,
+                                   ZONE_TOP_END, csTL, csTR);
+        int esBot = edgeThickness3(ZONE_BOTTOM_START, ZONE_BOTTOM_MIDDLE,
+                                   ZONE_BOTTOM_END, csBL, csBR);
+        int esLeft = edgeThickness3(ZONE_LEFT_START, ZONE_LEFT_MIDDLE,
+                                    ZONE_LEFT_END, csTL, csBL);
+        int esRight = edgeThickness3(ZONE_RIGHT_START, ZONE_RIGHT_MIDDLE,
+                                     ZONE_RIGHT_END, csTR, csBR);
 
         // An edge with a centre zone becomes two rectangles, but it is still one
         // edge: walking into the left half and then the right must give A then
@@ -2196,47 +2645,63 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
         add(ZONE_BOTTOM_RIGHT,
             {r.right - csBR, r.bottom - csBR, r.right, r.bottom});
 
-        // Edges run between the two corners they touch, split around a centre
-        // zone when one is configured.
-        auto addEdge = [&](Zone edge, Zone centre, bool horizontal, LONG lo,
-                           LONG hi, LONG nearSide, LONG farSide)
+        // Edges run between the two corners they touch, divided into three
+        // independently configurable segments.
+        auto addEdge = [&](Zone zStart, Zone zMiddle, Zone zEnd,
+                           bool horizontal, LONG lo, LONG hi, LONG nearSide,
+                           LONG farSide)
         {
+            LONG sp = hi - lo;
+            if (sp <= 0)
+                return;
+
             auto rectFor = [&](LONG a, LONG b) -> RECT
             {
                 return horizontal ? RECT{a, nearSide, b, farSide}
                                   : RECT{nearSide, a, farSide, b};
             };
 
-            const ZoneConfig *centreCfg = ResolveZone(mon, centre);
-            LONG sp = hi - lo;
             LONG width = sp * centrePct / 100;
-
-            if (!centreCfg || width < 1 || width >= sp || sp <= 0)
-            {
-                if (sp > 0)
-                    add(edge, rectFor(lo, hi));
-                return;
-            }
-
-            LONG mid = lo + sp / 2;
-            LONG cLo = mid - width / 2;
+            if (width < 1)
+                width = 1;
+            if (width > sp)
+                width = sp;
+            LONG cLo = lo + sp / 2 - width / 2;
             LONG cHi = cLo + width;
+            if (cLo < lo)
+                cLo = lo;
+            if (cHi > hi)
+                cHi = hi;
 
-            if (cLo > lo)
-                add(edge, rectFor(lo, cLo));
-            add(centre, rectFor(cLo, cHi));
-            if (cHi < hi)
-                add(edge, rectFor(cHi, hi));
+            const Zone seg[3] = {zStart, zMiddle, zEnd};
+            const LONG bound[4] = {lo, cLo, cHi, hi};
+
+            // Coalesce neighbouring segments that resolve to the same thing.
+            // Setting all three alike therefore produces one edge-wide zone
+            // rather than three, which matters for more than tidiness: three
+            // adjacent zones sharing an action would each re-arm - and re-fire
+            // - as the pointer crossed a seam.
+            int i = 0;
+            while (i < 3)
+            {
+                const ZoneConfig *zc = ResolveZone(mon, seg[i]);
+                int j = i + 1;
+                while (j < 3 && SameZoneConfig(zc, ResolveZone(mon, seg[j])))
+                    j++;
+                if (zc && bound[j] > bound[i])
+                    add(seg[i], rectFor(bound[i], bound[j]));
+                i = j;
+            }
         };
 
-        addEdge(ZONE_EDGE_TOP, ZONE_CENTER_TOP, true, r.left + csTL,
-                r.right - csTR, r.top, r.top + esTop);
-        addEdge(ZONE_EDGE_BOTTOM, ZONE_CENTER_BOTTOM, true, r.left + csBL,
-                r.right - csBR, r.bottom - esBot, r.bottom);
-        addEdge(ZONE_EDGE_LEFT, ZONE_CENTER_LEFT, false, r.top + csTL,
-                r.bottom - csBL, r.left, r.left + esLeft);
-        addEdge(ZONE_EDGE_RIGHT, ZONE_CENTER_RIGHT, false, r.top + csTR,
-                r.bottom - csBR, r.right - esRight, r.right);
+        addEdge(ZONE_TOP_START, ZONE_TOP_MIDDLE, ZONE_TOP_END, true,
+                r.left + csTL, r.right - csTR, r.top, r.top + esTop);
+        addEdge(ZONE_BOTTOM_START, ZONE_BOTTOM_MIDDLE, ZONE_BOTTOM_END, true,
+                r.left + csBL, r.right - csBR, r.bottom - esBot, r.bottom);
+        addEdge(ZONE_LEFT_START, ZONE_LEFT_MIDDLE, ZONE_LEFT_END, false,
+                r.top + csTL, r.bottom - csBL, r.left, r.left + esLeft);
+        addEdge(ZONE_RIGHT_START, ZONE_RIGHT_MIDDLE, ZONE_RIGHT_END, false,
+                r.top + csTR, r.bottom - csBR, r.right - esRight, r.right);
     }
     LeaveCriticalSection(&g_settingsLock);
 
@@ -2313,6 +2778,12 @@ static void EnqueueAction(const HitZone &hz)
 
 static DWORD WINAPI ActionWorkerThread(LPVOID)
 {
+    // ShellExecuteEx reaches shell extensions through COM for URLs, .lnk and
+    // .url files, folders and protocol handlers, so a Custom Command pointing
+    // at any of those failed on this thread while it had no apartment - and
+    // failed silently apart from a log line.
+    CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+
     HANDLE waits[2] = {g_hStopEvent, g_hWorkEvent};
     for (;;)
     {
@@ -2388,6 +2859,7 @@ static DWORD WINAPI ActionWorkerThread(LPVOID)
                 job.exec();
         }
     }
+    CoUninitialize();
     return 0;
 }
 
@@ -2434,7 +2906,7 @@ static DWORD DetectTick()
 
     POINT pt;
     if (!GetCursorPos(&pt))
-        return kIdleTickMs;
+        return kTickMs;   // transient, and zones are armed - do not slow down
 
     int idx = -1;
     for (size_t i = 0; i < zones->zones.size(); i++)
@@ -2513,24 +2985,23 @@ static DWORD DetectTick()
     if (dwell > 0 && (now - g_enterTick) < (ULONGLONG)dwell)
         return next;
 
+    // Neither cooldown sets g_firedThisEntry: they are a wait, not a refusal.
+    // Marking the visit spent meant that walking into a corner shortly after
+    // anything else fired and then parking there never fired at all - you had
+    // to leave and come back. Falling through lets the dwell outlast the
+    // cooldown, which is what parking in a corner is asking for.
     if (hz.cooldown > 0 && idx < (int)g_lastFireTick.size())
     {
         ULONGLONG last = g_lastFireTick[idx];
         if (last != 0 && (now - last) < (ULONGLONG)hz.cooldown)
-        {
-            g_firedThisEntry = true;
             return next;
-        }
     }
 
     // Global floor across all zones. The per-zone cooldown alone does not stop
     // a sweep through several different zones from queueing a burst.
     if (g_lastAnyFireTick != 0 &&
         (now - g_lastAnyFireTick) < kMinFireIntervalMs)
-    {
-        g_firedThisEntry = true;
         return next;
-    }
 
     g_firedThisEntry = true;
     g_lastAnyFireTick = now;
@@ -2702,9 +3173,11 @@ static const wchar_t *kOvrEnabled = L"ovr_enabled";
 static const wchar_t *kOvrFullscreen = L"ovr_fullscreen";
 static const wchar_t *kOvrDrag = L"ovr_drag";
 
-static HICON MakeTrayIcon(bool enabled)
+// A screen outline with the top-left corner lit and the other three marked,
+// which is the mod in one glyph. Drawn rather than shipped as a resource:
+// Windhawk mods are a single source file, so there is nowhere to put an .ico.
+static HICON MakeHotCornerIcon(int sz, bool enabled)
 {
-    int sz = GetSystemMetrics(SM_CXSMICON);
     if (sz < 8)
         sz = 16;
 
@@ -2728,24 +3201,47 @@ static HICON MakeTrayIcon(bool enabled)
         return nullptr;
     }
 
-    // A screen outline with one corner lit. Mid-tone colours so it stays
-    // legible on both a light and a dark taskbar.
+    // Mid-tone colours so it stays legible on both a light and a dark taskbar.
     DWORD *px = static_cast<DWORD *>(bits);
-    const DWORD frame = enabled ? 0xFFB0B0B0 : 0xFF707070;
-    const DWORD accent = enabled ? 0xFF4CC2FF : 0xFF707070;
-    int block = sz / 3;
-    if (block < 3)
-        block = 3;
+    const DWORD frame = enabled ? 0xFFB4B4B4 : 0xFF6E6E6E;
+    const DWORD accent = enabled ? 0xFF4CC2FF : 0xFF6E6E6E;
+    const DWORD dim = enabled ? 0xFF7A8A94 : 0xFF5A5A5A;
+
+    int bord = sz >= 32 ? 2 : 1;              // outline thickness
+    int arm = sz / 3;                         // length of a corner mark
+    if (arm < 3)
+        arm = 3;
+    int thick = sz >= 32 ? 3 : 2;             // thickness of a corner mark
 
     for (int y = 0; y < sz; y++)
     {
         for (int x = 0; x < sz; x++)
         {
-            DWORD c = 0;  // transparent
-            if (x == 0 || y == 0 || x == sz - 1 || y == sz - 1)
+            DWORD c = 0;   // transparent
+
+            bool onFrame = x < bord || y < bord || x >= sz - bord ||
+                           y >= sz - bord;
+            if (onFrame)
                 c = frame;
-            if (x < block && y < block)
+
+            // Three corners get an L-shaped bracket, so the glyph reads as
+            // "corners" rather than as a window with a coloured tab.
+            auto bracket = [&](bool right, bool bottom) -> bool
+            {
+                int dx = right ? sz - 1 - x : x;
+                int dy = bottom ? sz - 1 - y : y;
+                return (dx < arm && dy < thick) || (dy < arm && dx < thick);
+            };
+
+            if (bracket(true, false) || bracket(false, true) ||
+                bracket(true, true))
+                c = dim;
+
+            // The top-left one is filled solid: that is the corner the mod is
+            // named for, and a lit corner beats a fourth identical bracket.
+            if (x < arm && y < arm)
                 c = accent;
+
             px[y * sz + x] = c;
         }
     }
@@ -2765,6 +3261,11 @@ static HICON MakeTrayIcon(bool enabled)
     if (hMask)
         DeleteObject(hMask);
     return hIcon;
+}
+
+static HICON MakeTrayIcon(bool enabled)
+{
+    return MakeHotCornerIcon(GetSystemMetrics(SM_CXSMICON), enabled);
 }
 
 static void FillTrayIconData(NOTIFYICONDATAW &nid)
@@ -2863,6 +3364,187 @@ static std::wstring GuiKey(int cfg, int zone, const wchar_t *what)
 // value-store keys and builds a std::function per zone, and holding
 // g_settingsLock across all of that would stall the detection thread, the
 // action worker and the tray menu.
+// =====================================================================
+// Windhawk settings page
+// =====================================================================
+//
+// The settings page is the configuration surface; the dashboard only shows
+// what it produced. Two surfaces writing the same store is what produced the
+// 4.1.3 and 4.1.4 bugs, where the dashboard addressed configurations by list
+// position and overwrote the wrong one.
+//
+// Precedence, decided once per reload:
+//
+//   1. Displays configured on the settings page win outright.
+//   2. Otherwise, a layout saved by an older version still runs, so upgrading
+//      never silently wipes a configuration that took effort to enter.
+//   3. Otherwise, settings supply the globals and no zones are active.
+
+static int ParseZoneName(const std::wstring &s)
+{
+    static const struct
+    {
+        const wchar_t *name;
+        Zone zone;
+    } kMap[] = {
+        {L"TOP_LEFT", ZONE_TOP_LEFT},
+        {L"TOP_RIGHT", ZONE_TOP_RIGHT},
+        {L"BOTTOM_LEFT", ZONE_BOTTOM_LEFT},
+        {L"BOTTOM_RIGHT", ZONE_BOTTOM_RIGHT},
+        {L"TOP_START", ZONE_TOP_START},
+        {L"TOP_MIDDLE", ZONE_TOP_MIDDLE},
+        {L"TOP_END", ZONE_TOP_END},
+        {L"BOTTOM_START", ZONE_BOTTOM_START},
+        {L"BOTTOM_MIDDLE", ZONE_BOTTOM_MIDDLE},
+        {L"BOTTOM_END", ZONE_BOTTOM_END},
+        {L"LEFT_START", ZONE_LEFT_START},
+        {L"LEFT_MIDDLE", ZONE_LEFT_MIDDLE},
+        {L"LEFT_END", ZONE_LEFT_END},
+        {L"RIGHT_START", ZONE_RIGHT_START},
+        {L"RIGHT_MIDDLE", ZONE_RIGHT_MIDDLE},
+        {L"RIGHT_END", ZONE_RIGHT_END},
+    };
+    for (const auto &m : kMap)
+        if (s == m.name)
+            return (int)m.zone;
+    return -1;
+}
+
+// Windhawk only accepts $options on a string setting, so the modifier arrives
+// by name. -1 is the "inherit" marker the zone tuning already uses; the global
+// has no INHERIT option, so its caller maps a negative result onto None.
+static int ParseModifierName(const std::wstring &s)
+{
+    if (s == L"NONE")
+        return 0;
+    if (s == L"CTRL")
+        return 1;
+    if (s == L"ALT")
+        return 2;
+    if (s == L"SHIFT")
+        return 3;
+    if (s == L"WIN")
+        return 4;
+    return -1;   // INHERIT, empty, or anything unrecognised
+}
+
+// Windhawk has no array-length call, so both loops run until the first
+// entry whose required string comes back empty - the standard idiom, and
+// what makes an empty Display name terminate the list.
+static std::wstring GetSettingStr(const wchar_t *fmt, int a, int b = -1)
+{
+    PCWSTR raw = (b < 0) ? Wh_GetStringSetting(fmt, a)
+                         : Wh_GetStringSetting(fmt, a, b);
+    std::wstring out = raw ? raw : L"";
+    Wh_FreeStringSetting(raw);
+    return out;
+}
+
+static std::vector<MonitorZoneConfig> ReadSettingsZones()
+{
+    std::vector<MonitorZoneConfig> configs;
+
+    for (int i = 0;; i++)
+    {
+        std::wstring id = TrimStr(GetSettingStr(L"displays[%d].monitor", i));
+        if (id.empty())
+            break;
+
+        MonitorZoneConfig cfg;
+        cfg.monitorId = id;
+
+        bool seen[ZONE_COUNT] = {};
+        bool any = false;
+
+        for (int z = 0;; z++)
+        {
+            std::wstring zname =
+                GetSettingStr(L"displays[%d].zones[%d].zone", i, z);
+            if (zname.empty())
+                break;
+
+            int zi = ParseZoneName(zname);
+            std::wstring aname =
+                GetSettingStr(L"displays[%d].zones[%d].action", i, z);
+            std::wstring args =
+                GetSettingStr(L"displays[%d].zones[%d].args", i, z);
+
+            // An unknown zone name, or a repeat of one already filled in,
+            // is skipped rather than allowed to overwrite.
+            if (zi < 0 || seen[zi])
+                continue;
+            seen[zi] = true;
+
+            CornerAction act = ParseActionType(aname);
+            cfg.zones[zi].action = act;
+            cfg.zones[zi].args = args;
+            cfg.zones[zi].executor = MakeExecutor(act, args);
+            cfg.zones[zi].tuning.size =
+                Wh_GetIntSetting(L"displays[%d].zones[%d].size", i, z);
+            cfg.zones[zi].tuning.delay =
+                Wh_GetIntSetting(L"displays[%d].zones[%d].delay", i, z);
+            cfg.zones[zi].tuning.settle =
+                Wh_GetIntSetting(L"displays[%d].zones[%d].settle", i, z);
+            cfg.zones[zi].tuning.knock =
+                Wh_GetIntSetting(L"displays[%d].zones[%d].knock", i, z);
+            cfg.zones[zi].tuning.cooldown =
+                Wh_GetIntSetting(L"displays[%d].zones[%d].cooldown", i, z);
+            cfg.zones[zi].tuning.modifier = ParseModifierName(
+                GetSettingStr(L"displays[%d].zones[%d].modifier", i, z));
+
+            if (act != CornerAction::Nothing)
+                any = true;
+        }
+
+        if (any)
+            configs.push_back(std::move(cfg));
+    }
+
+    return configs;
+}
+
+// Every global, straight off the settings page.
+static void ApplySettingsGlobals(ModSettings &s)
+{
+    auto clamp = [](int v, int lo, int hi)
+    { return v < lo ? lo : (v > hi ? hi : v); };
+
+    s.cornerSize = clamp(Wh_GetIntSetting(L"cornerSize"), 1, 500);
+    s.edgeSize = clamp(Wh_GetIntSetting(L"edgeSize"), 1, 500);
+    s.centerZonePercent = clamp(Wh_GetIntSetting(L"centerPercent"), 1, 90);
+    s.activationDelay = clamp(Wh_GetIntSetting(L"delay"), 0, 10000);
+    s.settleMs = clamp(Wh_GetIntSetting(L"settle"), 0, 10000);
+    s.knockWindowMs = clamp(Wh_GetIntSetting(L"knock"), 0, 10000);
+    s.cooldownMs = clamp(Wh_GetIntSetting(L"cooldown"), 0, 60000);
+    int mod = ParseModifierName(GetSettingStr(L"requireModifier", 0));
+    s.requireModifier = (mod < 0) ? 0 : mod;
+    s.disableOnFullscreen = Wh_GetIntSetting(L"disableOnFullscreen") != 0;
+    s.disableDuringDrag = Wh_GetIntSetting(L"disableDuringDrag") != 0;
+    s.avoidTaskbar = Wh_GetIntSetting(L"avoidTaskbar") != 0;
+
+    g_lockBlankDelayMs = clamp(Wh_GetIntSetting(L"lockBlankDelay"), 0, 10000);
+    g_showMonitorNames = Wh_GetIntSetting(L"showMonitorNames") != 0;
+
+    std::wstring rest = GetSettingStr(L"excluded", 0);
+    while (!rest.empty())
+    {
+        auto semi = rest.find(L';');
+        std::wstring tok;
+        if (semi != std::wstring::npos)
+        {
+            tok = TrimStr(rest.substr(0, semi));
+            rest = rest.substr(semi + 1);
+        }
+        else
+        {
+            tok = TrimStr(rest);
+            rest.clear();
+        }
+        if (!tok.empty())
+            s.excludedProcesses.push_back(ToLowerStr(tok));
+    }
+}
+
 static std::vector<MonitorZoneConfig> ReadDashboardZones()
 {
     std::vector<MonitorZoneConfig> configs;
@@ -2876,59 +3558,72 @@ static std::vector<MonitorZoneConfig> ReadDashboardZones()
             continue;
 
         MonitorZoneConfig cfg;
-        cfg.monitorId = (id == L"(unused)") ? L"" : id;
-        cfg.monitorIndex = 0;
+        cfg.monitorId = id;
 
-        bool any = false;
-        for (int z = 0; z < ZONE_COUNT; z++)
+        // The store predates the edge split, so its twelve slots have to be
+        // spread across sixteen. A stored edge fills both outer segments; it
+        // also fills the middle when nothing was stored for the centre, which
+        // is what reproduces the old geometry exactly - back then an edge with
+        // no centre configured was one rectangle spanning the whole edge, and
+        // three identical segments coalesce back into exactly that.
+        static const struct
+        {
+            int edge;                 // legacy slot 4-7
+            int centre;               // legacy slot 8-11
+            Zone start, middle, end;
+        } kSpread[] = {
+            {4, 8, ZONE_TOP_START, ZONE_TOP_MIDDLE, ZONE_TOP_END},
+            {5, 9, ZONE_BOTTOM_START, ZONE_BOTTOM_MIDDLE, ZONE_BOTTOM_END},
+            {6, 10, ZONE_LEFT_START, ZONE_LEFT_MIDDLE, ZONE_LEFT_END},
+            {7, 11, ZONE_RIGHT_START, ZONE_RIGHT_MIDDLE, ZONE_RIGHT_END},
+        };
+
+        auto readSlot = [&](int z, ZoneConfig &dst)
         {
             std::wstring a = GetStrValue(GuiKey(i, z, L"a").c_str());
             std::wstring g = GetStrValue(GuiKey(i, z, L"g").c_str());
             CornerAction act = ParseActionType(a);
-            cfg.zones[z].action = act;
-            cfg.zones[z].args = g;
-            cfg.zones[z].executor = MakeExecutor(act, g);
-            cfg.zones[z].tuning.size = Wh_GetIntValue(GuiKey(i, z, L"sz").c_str(), -1);
-            cfg.zones[z].tuning.delay = Wh_GetIntValue(GuiKey(i, z, L"dl").c_str(), -1);
-            cfg.zones[z].tuning.settle = Wh_GetIntValue(GuiKey(i, z, L"gd").c_str(), -1);
-            cfg.zones[z].tuning.knock = Wh_GetIntValue(GuiKey(i, z, L"kn").c_str(), -1);
-            cfg.zones[z].tuning.cooldown = Wh_GetIntValue(GuiKey(i, z, L"cd").c_str(), -1);
-            cfg.zones[z].tuning.modifier = Wh_GetIntValue(GuiKey(i, z, L"md").c_str(), -1);
-            if (act != CornerAction::Nothing)
+            dst.action = act;
+            dst.args = g;
+            dst.executor = MakeExecutor(act, g);
+            dst.tuning.size = Wh_GetIntValue(GuiKey(i, z, L"sz").c_str(), -1);
+            dst.tuning.delay = Wh_GetIntValue(GuiKey(i, z, L"dl").c_str(), -1);
+            dst.tuning.settle = Wh_GetIntValue(GuiKey(i, z, L"gd").c_str(), -1);
+            dst.tuning.knock = Wh_GetIntValue(GuiKey(i, z, L"kn").c_str(), -1);
+            dst.tuning.cooldown = Wh_GetIntValue(GuiKey(i, z, L"cd").c_str(), -1);
+            dst.tuning.modifier = Wh_GetIntValue(GuiKey(i, z, L"md").c_str(), -1);
+            return act != CornerAction::Nothing;
+        };
+
+        bool any = false;
+        for (int z = ZONE_TOP_LEFT; z <= ZONE_BOTTOM_RIGHT; z++)
+            any |= readSlot(z, cfg.zones[z]);
+
+        for (const auto &sp : kSpread)
+        {
+            ZoneConfig edge, centre;
+            bool hasEdge = readSlot(sp.edge, edge);
+            bool hasCentre = readSlot(sp.centre, centre);
+
+            if (hasEdge)
+            {
+                cfg.zones[sp.start] = edge;
+                cfg.zones[sp.end] = edge;
+                if (!hasCentre)
+                    cfg.zones[sp.middle] = edge;
                 any = true;
+            }
+            if (hasCentre)
+            {
+                cfg.zones[sp.middle] = centre;
+                any = true;
+            }
         }
+
         if (any)
             configs.push_back(std::move(cfg));
     }
     return configs;
-}
-
-// Back to a fresh install. -1 is the "never written" marker every reader tests
-// for, so this is a reset rather than a write of zeroes.
-static void ClearStoredConfig()
-{
-    // Every scalar the dashboard and the tray can write. Missing one here used
-    // to leave it behind after a Reset, still applied but no longer visible.
-    for (const wchar_t *k :
-         {kOvrEnabled, kOvrFullscreen, kOvrDrag, L"ovr_corner", L"ovr_edge",
-          L"ovr_delay", L"ovr_settle", L"ovr_knock", L"ovr_cooldown",
-          L"ovr_centre", L"ovr_modifier", L"ovr_lockblank", L"ovr_taskbar",
-          L"ovr_monnames"})
-        Wh_SetIntValue(k, -1);
-    Wh_SetStringValue(L"ovr_excluded", L"");
-
-    Wh_SetIntValue(L"gui_active", 0);
-    for (int i = 0; i < kMaxGuiConfigs; i++)
-    {
-        Wh_SetStringValue(GuiKey(i, -1, L"id").c_str(), L"");
-        for (int z = 0; z < ZONE_COUNT; z++)
-        {
-            Wh_SetStringValue(GuiKey(i, z, L"a").c_str(), L"");
-            Wh_SetStringValue(GuiKey(i, z, L"g").c_str(), L"");
-            for (const wchar_t *k : {L"sz", L"dl", L"gd", L"kn", L"cd", L"md"})
-                Wh_SetIntValue(GuiKey(i, z, k).c_str(), -1);
-        }
-    }
 }
 
 // The whole of this mod's configuration, read and applied as one transaction.
@@ -2952,68 +3647,88 @@ static void ClearStoredConfig()
 // so a value the user has never touched simply keeps its default.
 static void ReloadConfig()
 {
+    EnterCriticalSection(&g_reloadLock);
+
     ModSettings s;   // the member initialisers are the defaults
 
     int v = Wh_GetIntValue(kOvrEnabled, -1);
     g_trayEnabled = (v < 0) ? true : (v != 0);
 
-    v = Wh_GetIntValue(kOvrFullscreen, -1);
-    if (v >= 0)
-        s.disableOnFullscreen = (v != 0);
+    s.monitorConfigs = ReadSettingsZones();
+    const bool fromSettings = !s.monitorConfigs.empty();
+    bool legacy = false;
 
-    v = Wh_GetIntValue(kOvrDrag, -1);
-    if (v >= 0)
-        s.disableDuringDrag = (v != 0);
-
-    auto pull = [](const wchar_t *k, int &dst, int lo, int hi)
+    if (fromSettings)
     {
-        int x = Wh_GetIntValue(k, -1);
-        if (x >= lo && x <= hi)
-            dst = x;
-    };
-    pull(L"ovr_corner", s.cornerSize, 1, 500);
-    pull(L"ovr_edge", s.edgeSize, 1, 500);
-    pull(L"ovr_delay", s.activationDelay, 0, 10000);
-    pull(L"ovr_settle", s.settleMs, 0, 10000);
-    pull(L"ovr_knock", s.knockWindowMs, 0, 10000);
-    pull(L"ovr_cooldown", s.cooldownMs, 0, 60000);
-    pull(L"ovr_centre", s.centerZonePercent, 1, 90);
-    pull(L"ovr_modifier", s.requireModifier, 0, 4);
-
-    int x = Wh_GetIntValue(L"ovr_taskbar", -1);
-    if (x >= 0)
-        s.avoidTaskbar = (x != 0);
-
-    // Via a local: pull takes int&, and these two globals are atomic because
-    // other threads read them while this runs.
-    int lockBlank = 1200;
-    pull(L"ovr_lockblank", lockBlank, 0, 10000);
-    g_lockBlankDelayMs = lockBlank;
-    x = Wh_GetIntValue(L"ovr_monnames", -1);
-    g_showMonitorNames = (x < 0) ? true : (x != 0);
-
-    // s starts empty, so clearing the field in the dashboard genuinely clears
-    // the list - no "if the stored string is non-empty" guard needed.
-    std::wstring rest = GetStrValue(L"ovr_excluded");
-    while (!rest.empty())
-    {
-        auto semi = rest.find(L';');
-        std::wstring tok;
-        if (semi != std::wstring::npos)
-        {
-            tok = TrimStr(rest.substr(0, semi));
-            rest = rest.substr(semi + 1);
-        }
-        else
-        {
-            tok = TrimStr(rest);
-            rest.clear();
-        }
-        if (!tok.empty())
-            s.excludedProcesses.push_back(ToLowerStr(tok));
+        ApplySettingsGlobals(s);
     }
+    else if (Wh_GetIntValue(L"gui_active", 0) != 0)
+    {
+        // A layout from before the settings page existed. Reproduce the old
+        // behaviour exactly - defaults, then the stored "ovr_" overrides -
+        // so upgrading does not quietly change how anything behaves.
+        legacy = true;
 
-    s.monitorConfigs = ReadDashboardZones();
+        v = Wh_GetIntValue(kOvrFullscreen, -1);
+        if (v >= 0)
+            s.disableOnFullscreen = (v != 0);
+
+        v = Wh_GetIntValue(kOvrDrag, -1);
+        if (v >= 0)
+            s.disableDuringDrag = (v != 0);
+
+        auto pull = [](const wchar_t *k, int &dst, int lo, int hi)
+        {
+            int x = Wh_GetIntValue(k, -1);
+            if (x >= lo && x <= hi)
+                dst = x;
+        };
+        pull(L"ovr_corner", s.cornerSize, 1, 500);
+        pull(L"ovr_edge", s.edgeSize, 1, 500);
+        pull(L"ovr_delay", s.activationDelay, 0, 10000);
+        pull(L"ovr_settle", s.settleMs, 0, 10000);
+        pull(L"ovr_knock", s.knockWindowMs, 0, 10000);
+        pull(L"ovr_cooldown", s.cooldownMs, 0, 60000);
+        pull(L"ovr_centre", s.centerZonePercent, 1, 90);
+        pull(L"ovr_modifier", s.requireModifier, 0, 4);
+
+        int x = Wh_GetIntValue(L"ovr_taskbar", -1);
+        if (x >= 0)
+            s.avoidTaskbar = (x != 0);
+
+        // Via a local: pull takes int&, and these two globals are atomic
+        // because other threads read them while this runs.
+        int lockBlank = 1200;
+        pull(L"ovr_lockblank", lockBlank, 0, 10000);
+        g_lockBlankDelayMs = lockBlank;
+        x = Wh_GetIntValue(L"ovr_monnames", -1);
+        g_showMonitorNames = (x < 0) ? true : (x != 0);
+
+        std::wstring rest = GetStrValue(L"ovr_excluded");
+        while (!rest.empty())
+        {
+            auto semi = rest.find(L';');
+            std::wstring tok;
+            if (semi != std::wstring::npos)
+            {
+                tok = TrimStr(rest.substr(0, semi));
+                rest = rest.substr(semi + 1);
+            }
+            else
+            {
+                tok = TrimStr(rest);
+                rest.clear();
+            }
+            if (!tok.empty())
+                s.excludedProcesses.push_back(ToLowerStr(tok));
+        }
+
+        s.monitorConfigs = ReadDashboardZones();
+    }
+    else
+    {
+        ApplySettingsGlobals(s);
+    }
 
     // Copied out before the move, so the summary can be logged after the lock
     // is released - Wh_Log goes through OutputDebugString and takes a
@@ -3028,15 +3743,31 @@ static void ReloadConfig()
     g_settings = std::move(s);
     LeaveCriticalSection(&g_settingsLock);
 
-    if (zoneCount)
-        Wh_Log(L"Using the dashboard's zone layout (%d configuration%s)",
+    if (legacy)
+    {
+        Wh_Log(L"Using a layout saved by an older version (%d configuration%s). "
+               L"Re-enter it on this mod's Settings page to take it over - "
+               L"as soon as one display is listed there, this one is ignored.",
                zoneCount, zoneCount == 1 ? L"" : L"s");
+    }
+    else if (zoneCount)
+    {
+        Wh_Log(L"Using the Settings page (%d display%s configured)",
+               zoneCount, zoneCount == 1 ? L"" : L"s");
+    }
+    else
+    {
+        Wh_Log(L"No displays are configured. Open this mod's Settings page and "
+               L"add one, then add the zones you want.");
+    }
     Wh_Log(L"Sizes: corner %dpx, edge %dpx.  Timing: delay %dms, "
            L"pass-through guard %dms, cooldown %dms.",
            cs, es, dl, st, cd);
     Wh_Log(L"Skip while fullscreen: %s.  Skip while dragging: %s.  "
            L"Excluded apps: %d.",
            fs ? L"yes" : L"no", dg ? L"yes" : L"no", nx);
+
+    LeaveCriticalSection(&g_reloadLock);
 }
 
 static void ShowTrayMenu(POINT pt)
@@ -3083,9 +3814,53 @@ static void ShowTrayMenu(POINT pt)
     AppendMenuW(hMenu, MF_STRING | MF_DISABLED, IDM_ABOUT,
                 L"Win-X Hot Corners " WH_MOD_VERSION);
 
+    // Anchor to the tray icon rather than to the pointer. A menu that opens
+    // wherever the cursor happened to be lands at a different place every
+    // time; anchoring puts it in the one spot muscle memory expects, which is
+    // what every other tray menu does.
+    UINT align = TPM_RIGHTBUTTON;
+    NOTIFYICONIDENTIFIER nii = {sizeof(nii)};
+    nii.hWnd = g_hTrayWnd;
+    nii.uID = (UINT)kTrayIconId;
+    nii.guidItem = kTrayIconGuid;
+    RECT icon = {};
+    if (SUCCEEDED(Shell_NotifyIconGetRect(&nii, &icon)))
+    {
+        // Open from the icon's outer edge, away from whichever screen edge the
+        // taskbar is docked against, so the menu never covers the icon.
+        APPBARDATA abd = {sizeof(abd)};
+        UINT edge = ABE_BOTTOM;
+        if (SHAppBarMessage(ABM_GETTASKBARPOS, &abd))
+            edge = abd.uEdge;
+
+        switch (edge)
+        {
+        case ABE_TOP:
+            pt.x = (icon.left + icon.right) / 2;
+            pt.y = icon.bottom;
+            align |= TPM_CENTERALIGN | TPM_TOPALIGN;
+            break;
+        case ABE_LEFT:
+            pt.x = icon.right;
+            pt.y = (icon.top + icon.bottom) / 2;
+            align |= TPM_LEFTALIGN | TPM_VCENTERALIGN;
+            break;
+        case ABE_RIGHT:
+            pt.x = icon.left;
+            pt.y = (icon.top + icon.bottom) / 2;
+            align |= TPM_RIGHTALIGN | TPM_VCENTERALIGN;
+            break;
+        default:
+            pt.x = (icon.left + icon.right) / 2;
+            pt.y = icon.top;
+            align |= TPM_CENTERALIGN | TPM_BOTTOMALIGN;
+            break;
+        }
+    }
+
     // Required so the menu dismisses when the user clicks elsewhere.
     SetForegroundWindow(g_hTrayWnd);
-    TrackPopupMenu(hMenu, TPM_RIGHTBUTTON, pt.x, pt.y, 0, g_hTrayWnd, nullptr);
+    TrackPopupMenu(hMenu, align, pt.x, pt.y, 0, g_hTrayWnd, nullptr);
     PostMessage(g_hTrayWnd, WM_NULL, 0, 0);
 
     DestroyMenu(hMenu);
@@ -3106,9 +3881,14 @@ static void HandleTrayCommand(UINT id)
         OpenDashboard();
         return;
 
+    // Same pairing as the two guards below: ReloadConfig reads kOvrEnabled and
+    // republishes g_trayEnabled from it, so a reload straddling this toggle
+    // could put the flag back and leave it disagreeing with the store.
     case IDM_ENABLED:
+        EnterCriticalSection(&g_reloadLock);
         g_trayEnabled = !g_trayEnabled;
         Wh_SetIntValue(kOvrEnabled, g_trayEnabled ? 1 : 0);
+        LeaveCriticalSection(&g_reloadLock);
         g_suspendUntil = 0;
         Wh_Log(L"Tray: hot corners %s", g_trayEnabled ? L"enabled" : L"disabled");
         break;
@@ -3128,23 +3908,30 @@ static void HandleTrayCommand(UINT id)
         Wh_Log(L"Tray: resumed");
         break;
 
+    // These two mutate the live configuration and write the key behind it, so
+    // they take g_reloadLock for the same reason a save does: a reload landing
+    // between the two halves would either lose the toggle or read it twice.
     case IDM_FULLSCREEN:
     {
+        EnterCriticalSection(&g_reloadLock);
         EnterCriticalSection(&g_settingsLock);
         g_settings.disableOnFullscreen = !g_settings.disableOnFullscreen;
         int v = g_settings.disableOnFullscreen ? 1 : 0;
         LeaveCriticalSection(&g_settingsLock);
         Wh_SetIntValue(kOvrFullscreen, v);
+        LeaveCriticalSection(&g_reloadLock);
         break;
     }
 
     case IDM_DRAG:
     {
+        EnterCriticalSection(&g_reloadLock);
         EnterCriticalSection(&g_settingsLock);
         g_settings.disableDuringDrag = !g_settings.disableDuringDrag;
         int v = g_settings.disableDuringDrag ? 1 : 0;
         LeaveCriticalSection(&g_settingsLock);
         Wh_SetIntValue(kOvrDrag, v);
+        LeaveCriticalSection(&g_reloadLock);
         RequestRebuild();
         break;
     }
@@ -3153,11 +3940,13 @@ static void HandleTrayCommand(UINT id)
     // zone layout from a menu item with no confirmation would be a trap; the
     // dashboard's Reset button does that, behind a prompt.
     case IDM_CLEAR_OVERRIDES:
+        EnterCriticalSection(&g_reloadLock);
         Wh_SetIntValue(kOvrEnabled, -1);
         Wh_SetIntValue(kOvrFullscreen, -1);
         Wh_SetIntValue(kOvrDrag, -1);
         g_suspendUntil = 0;
         ReloadConfig();
+        LeaveCriticalSection(&g_reloadLock);
         RequestRebuild();
         Wh_Log(L"Tray: toggles reset to defaults");
         break;
@@ -3233,159 +4022,145 @@ static void BuildPalette()
 
 enum DashId
 {
-    IDC_MONITOR = 1000,
-    IDC_PAGE_ZONES,
-    IDC_PAGE_OPTIONS,
-    IDC_SAVE,
-    IDC_CANCEL,
-    IDC_RESET,
-    IDC_ZONE_ACTION = 1100,           // + zone index
-    IDC_ZONE_ARGS = 1200,             // + zone index
-    IDC_HDR_ZONE = 1250,
-    IDC_HDR_ACTION,
-    IDC_HDR_ARGS,
-    IDC_TZ_TITLE,
-    IDC_TZ_HINT,
-    IDC_TZ_FIRST = 1260,   // six per-zone override fields
-    IDC_TZ_SIZE = IDC_TZ_FIRST,
-    IDC_TZ_DELAY,
-    IDC_TZ_SETTLE,
-    IDC_TZ_KNOCK,
-    IDC_TZ_COOLDOWN,
-    IDC_TZ_MODIFIER,
-    IDC_TZ_LAST,
-    // This order is the order they appear on the Options page, and it has to
-    // stay in step with kOpts: DashSetInt indexes hOpt by (id - IDC_OPT_FIRST).
-    // A static_assert next to kOpts enforces it.
-    IDC_OPT_FIRST = 1300,
-    IDC_CORNER = IDC_OPT_FIRST,
-    IDC_EDGE,
-    IDC_CENTREPCT,
-    IDC_DELAY,
-    IDC_SETTLE,
-    IDC_KNOCK,
-    IDC_COOLDOWN,
-    IDC_MODIFIER,
-    IDC_EXCLUDED,
-    IDC_CB_FULLSCREEN,
-    IDC_CB_DRAG,
-    IDC_CB_TASKBAR,
-    IDC_LOCKBLANK,
-    IDC_CB_MONNAMES,
-    IDC_OPT_LAST,
-    IDC_OPT_SECTION,   // shared by every group heading; they carry no state
+    IDC_CLOSE = 1000,
+};
+
+// A resolved, read-only view of one zone. The dashboard shows what is actually
+// in effect, so it resolves exactly the way ResolveZone does - per zone, own
+// configuration first, then the wildcard. Anything less and the picture would
+// be able to disagree with what fires.
+struct ZoneView
+{
+    CornerAction action = CornerAction::Nothing;
+    std::wstring args;
+    ZoneTuning tuning;          // -1 in a field means "inherited"
+    bool fromWildcard = false;
+};
+
+struct DisplayView
+{
+    std::wstring id;
+    int width = 0;
+    int height = 0;
+    bool primary = false;
+    bool present = true;        // attached right now
+    bool wildcard = false;      // the "*" configuration
+    ZoneView zones[ZONE_COUNT];
+    int configured = 0;
 };
 
 struct DashState
 {
     UINT dpi = 96;
     HFONT hFont = nullptr;
+    HFONT hFontBold = nullptr;
+    HFONT hFontSmall = nullptr;
+    HFONT hFontVert = nullptr;   // rotated 90 degrees, for the side strips
     HBRUSH hBg = nullptr;
-    HBRUSH hField = nullptr;
-    HBRUSH hPanel = nullptr;
-    bool showZones = true;
-    int hoverZone = -1;   // zone highlighted in the preview
-    int selZone = 0;      // zone whose per-zone settings are being edited
-    ZoneTuning tuning[ZONE_COUNT];   // the slot currently on screen
-    int cfgIndex = 0;   // which slot in the value store we are editing
+    HICON hIcon = nullptr;     // title bar / Alt-Tab, big
+    HICON hIconSm = nullptr;   // title bar, small
 
-    // Every slot the window has touched, so switching displays does not throw
-    // the previous display's edits away and Save can write all of them. The
-    // controls only ever show one slot; this is where the other ones live.
-    struct Slot
-    {
-        bool loaded = false;
-        int action[ZONE_COUNT] = {};
-        std::wstring args[ZONE_COUNT];
-        ZoneTuning tuning[ZONE_COUNT];
-    };
-    std::vector<Slot> slots;
+    std::vector<DisplayView> displays;
+    ModSettings globals;         // what an inherited value resolves to
+    bool legacy = false;         // running a layout saved before 4.2
 
-    HWND hMonitor = nullptr;
-    HWND hZoneLabel[ZONE_COUNT] = {};
-    HWND hZoneAction[ZONE_COUNT] = {};
-    HWND hZoneArgs[ZONE_COUNT] = {};
-    HWND hOpt[IDC_OPT_LAST - IDC_OPT_FIRST] = {};
-    HWND hOptLabel[IDC_OPT_LAST - IDC_OPT_FIRST] = {};
-    HWND hOptSection[IDC_OPT_LAST - IDC_OPT_FIRST] = {};   // null except at a
-                                                           // group heading
-    HWND hHdrZone = nullptr, hHdrAction = nullptr, hHdrArgs = nullptr;
-    HWND hTzTitle = nullptr, hTzHint = nullptr;
-    HWND hTz[IDC_TZ_LAST - IDC_TZ_FIRST] = {};
-    HWND hTzLabel[IDC_TZ_LAST - IDC_TZ_FIRST] = {};
-    HWND hTip = nullptr;
-    HWND hPageZones = nullptr, hPageOptions = nullptr;
-    HWND hSave = nullptr, hCancel = nullptr, hReset = nullptr;
-    // WM_SETICON does not take ownership; whoever created the icon destroys it.
-    HICON hIcon = nullptr;
+    int activeTab = 0;
+    int hoverZone = -1;
+    int selZone = -1;
+    std::vector<RECT> tabRects;  // filled while painting, used for hit testing
+
+    HWND hClose = nullptr;
 };
 
 static int Sc(int px, UINT dpi) { return MulDiv(px, (int)dpi, 96); }
 
-// Layout metrics at 96 DPI. The window is sized *from* these rather than the
-// other way round — the first version guessed a window size and the button bar
-// ended up on top of the last rows.
+// Layout metrics at 96 DPI. The window is sized from these rather than the
+// other way round.
 namespace Lay
 {
-constexpr int Pad = 16;
-constexpr int Gap = 8;
-constexpr int RowH = 30;
-constexpr int CheckH = 26;
-constexpr int SecH = 30;   // group heading plus the air above it
-constexpr int TabH = 28;
-constexpr int CtlH = 24;
-constexpr int BtnH = 32;
-constexpr int LblW = 128;
-constexpr int CmbW = 210;
-constexpr int ArgW = 176;
-constexpr int OptLblW = 200;
-constexpr int OptCtlW = 190;
-constexpr int DiagW = 250;
-constexpr int DiagH = 150;
-constexpr int HdrH = 22;      // column-header row
-constexpr int TzRowH = 26;    // per-zone override row
-constexpr int TzPanelH = 14 + 20 + 20 + 6 * TzRowH;
+constexpr int Pad = 18;
+constexpr int Gap = 12;
+constexpr int TabH = 36;
+constexpr int BtnH = 30;
+constexpr int BtnW = 96;
 
-constexpr int LeftBlockW = Pad + LblW + Gap + CmbW + Gap + ArgW;   // 546
-constexpr int ClientW = LeftBlockW + Gap + DiagW + Pad;            // 820
+constexpr int DiagAreaW = 560;   // the box is fitted inside this, and centred
+constexpr int DiagAreaH = 300;
+constexpr int DiagCapH = 20;     // the "3840 x 2160 - primary" caption under it
 
-// Zones page: tabs, monitor combo, twelve rows.
-constexpr int ZonesLeftH = Pad + TabH + Gap + CtlH + Gap + HdrH + ZONE_COUNT * RowH;
-constexpr int ZonesRightH = Pad + TabH + Gap + CtlH + Gap + DiagH + TzPanelH;
-constexpr int ZonesH = ZonesLeftH > ZonesRightH ? ZonesLeftH : ZonesRightH;
-// Options page: ten labelled controls, five checkboxes.
-// Ten labelled controls, four checkboxes, four group headings. kOpts is
-// declared further down, so a static_assert beside it holds this honest.
-constexpr int OptionsH = Pad + TabH + Gap + 10 * RowH + 4 * CheckH + 4 * SecH;
+constexpr int DetHeadH = 56;     // zone name, action, setting key
+constexpr int DetRowH = 21;
+constexpr int DetHdrH = 20;
+constexpr int DetailH = DetHeadH + DetHdrH + 6 * DetRowH;
 
-constexpr int ContentH = ZonesH > OptionsH ? ZonesH : OptionsH;
-constexpr int ClientH = ContentH + Gap * 2 + BtnH + Pad;
+constexpr int ClientW = DiagAreaW + Pad * 2;
+constexpr int ClientH = Pad + TabH + Gap + DiagAreaH + DiagCapH + Gap +
+                        DetailH + Gap + BtnH + Pad;
 }  // namespace Lay
 
-// Where the little screen preview sits, and where each zone sits inside it.
-static RECT DashDiagramRect(UINT dpi)
+// The area the screen box is fitted into.
+static RECT DashDiagramArea(UINT dpi)
 {
     RECT r;
-    r.left = Sc(Lay::LeftBlockW + Lay::Gap, dpi);
-    r.top = Sc(Lay::Pad + Lay::TabH + Lay::Gap + Lay::CtlH + Lay::Gap, dpi);
-    r.right = r.left + Sc(Lay::DiagW, dpi);
-    r.bottom = r.top + Sc(Lay::DiagH, dpi);
+    r.left = Sc(Lay::Pad, dpi);
+    r.top = Sc(Lay::Pad + Lay::TabH + Lay::Gap, dpi);
+    r.right = r.left + Sc(Lay::DiagAreaW, dpi);
+    r.bottom = r.top + Sc(Lay::DiagAreaH, dpi);
     return r;
 }
 
-// Proportions inside the preview, mirroring how the real zones are built:
-// corners in the four corners, edges along the sides with the corners carved
-// out, and a centre block in the middle of each edge.
-// Proportions inside the preview, mirroring how the real zones are built.
-// The edges are split around the centre blocks rather than drawn through
-// them - previously they overlapped, so hovering a centre highlighted the
-// whole edge and the centre punched a hole in it.
-static RECT ZoneRectInDiagram(Zone z, const RECT &d, bool secondHalf)
+// The screen box itself: the display's real aspect ratio, fitted inside the
+// area and centred. A portrait or ultrawide display therefore looks like one
+// instead of being forced into a fixed rectangle.
+static RECT DashDiagramRect(const DashState *s)
+{
+    RECT a = DashDiagramArea(s->dpi);
+    int aw = a.right - a.left, ah = a.bottom - a.top;
+
+    int mw = 16, mh = 9;
+    if (s->activeTab >= 0 && s->activeTab < (int)s->displays.size())
+    {
+        const DisplayView &d = s->displays[s->activeTab];
+        if (d.width > 0 && d.height > 0)
+        {
+            mw = d.width;
+            mh = d.height;
+        }
+    }
+
+    // Fit, never stretch: whichever axis runs out first sets the scale.
+    int w = aw, h = (int)((LONGLONG)aw * mh / mw);
+    if (h > ah)
+    {
+        h = ah;
+        w = (int)((LONGLONG)ah * mw / mh);
+    }
+
+    RECT r;
+    r.left = a.left + (aw - w) / 2;
+    r.top = a.top + (ah - h) / 2;
+    r.right = r.left + w;
+    r.bottom = r.top + h;
+    return r;
+}
+
+// Proportions inside the preview. Deliberately not to scale: the real zones are
+// a few pixels thick and would be invisible. What has to be true is that the
+// blocks tile the border exactly, with no overlap and no gap.
+//
+// The corner block stays square by deriving from the shorter side. The edge
+// band is thick enough to hold a label - at the old c/2 a side strip was too
+// narrow and the text spilled outside the screen box.
+//
+// Every zone is exactly one rectangle now that an edge is three segments
+// rather than one zone wrapped around a centre, which is what removed the
+// old two-part special case and the overlap bug that came with it.
+static RECT ZoneRectInDiagram(Zone z, const RECT &d)
 {
     int w = d.right - d.left, h = d.bottom - d.top;
-    int c = (w < h ? w : h) / 6;         // corner block
-    int t = c / 2;                       // edge thickness
-    int cw = w / 5, ch = h / 5;          // centre block extent
+    int c = (w < h ? w : h) / 5;         // corner block, square
+    int t = c * 62 / 100;                // edge band thickness
+    int cw = w * 22 / 100, ch = h * 22 / 100;   // middle segment extent
     int cx0 = d.left + w / 2 - cw / 2, cx1 = cx0 + cw;
     int cy0 = d.top + h / 2 - ch / 2, cy1 = cy0 + ch;
 
@@ -3396,33 +4171,33 @@ static RECT ZoneRectInDiagram(Zone z, const RECT &d, bool secondHalf)
     case ZONE_BOTTOM_LEFT:   return {d.left, d.bottom - c, d.left + c, d.bottom};
     case ZONE_BOTTOM_RIGHT:  return {d.right - c, d.bottom - c, d.right, d.bottom};
 
-    case ZONE_EDGE_TOP:
-        return secondHalf ? RECT{cx1, d.top, d.right - c, d.top + t}
-                          : RECT{d.left + c, d.top, cx0, d.top + t};
-    case ZONE_EDGE_BOTTOM:
-        return secondHalf ? RECT{cx1, d.bottom - t, d.right - c, d.bottom}
-                          : RECT{d.left + c, d.bottom - t, cx0, d.bottom};
-    case ZONE_EDGE_LEFT:
-        return secondHalf ? RECT{d.left, cy1, d.left + t, d.bottom - c}
-                          : RECT{d.left, d.top + c, d.left + t, cy0};
-    case ZONE_EDGE_RIGHT:
-        return secondHalf ? RECT{d.right - t, cy1, d.right, d.bottom - c}
-                          : RECT{d.right - t, d.top + c, d.right, cy0};
+    case ZONE_TOP_START:     return {d.left + c, d.top, cx0, d.top + t};
+    case ZONE_TOP_MIDDLE:    return {cx0, d.top, cx1, d.top + t};
+    case ZONE_TOP_END:       return {cx1, d.top, d.right - c, d.top + t};
 
-    case ZONE_CENTER_TOP:    return {cx0, d.top, cx1, d.top + t};
-    case ZONE_CENTER_BOTTOM: return {cx0, d.bottom - t, cx1, d.bottom};
-    case ZONE_CENTER_LEFT:   return {d.left, cy0, d.left + t, cy1};
-    case ZONE_CENTER_RIGHT:  return {d.right - t, cy0, d.right, cy1};
+    case ZONE_BOTTOM_START:  return {d.left + c, d.bottom - t, cx0, d.bottom};
+    case ZONE_BOTTOM_MIDDLE: return {cx0, d.bottom - t, cx1, d.bottom};
+    case ZONE_BOTTOM_END:    return {cx1, d.bottom - t, d.right - c, d.bottom};
+
+    case ZONE_LEFT_START:    return {d.left, d.top + c, d.left + t, cy0};
+    case ZONE_LEFT_MIDDLE:   return {d.left, cy0, d.left + t, cy1};
+    case ZONE_LEFT_END:      return {d.left, cy1, d.left + t, d.bottom - c};
+
+    case ZONE_RIGHT_START:   return {d.right - t, d.top + c, d.right, cy0};
+    case ZONE_RIGHT_MIDDLE:  return {d.right - t, cy0, d.right, cy1};
+    case ZONE_RIGHT_END:     return {d.right - t, cy1, d.right, d.bottom - c};
+
     default:                 return {0, 0, 0, 0};
     }
 }
 
-// An edge occupies two rectangles once a centre is carved out of it, so both
-// have to be drawn and both have to be hit-tested.
-static bool ZoneHasTwoParts(Zone z)
+static bool ZoneIsCorner(Zone z) { return z <= ZONE_BOTTOM_RIGHT; }
+
+// The left and right strips are tall and narrow. Rotating the text is the only
+// way a label such as "Notification Centre" fits inside one.
+static bool ZoneIsVertical(Zone z)
 {
-    return z == ZONE_EDGE_TOP || z == ZONE_EDGE_BOTTOM || z == ZONE_EDGE_LEFT ||
-           z == ZONE_EDGE_RIGHT;
+    return z >= ZONE_LEFT_START && z <= ZONE_RIGHT_END;
 }
 
 // subIdList is nullptr for "keep the default part list", which is what naming
@@ -3545,323 +4320,311 @@ static void ApplyModernFrame(HWND hWnd)
         FreeLibrary(dwm);
 }
 
-static const wchar_t *kActionIds[] = {
-    L"ACTION_NOTHING",        L"ACTION_SHOW_DESKTOP",
-    L"ACTION_TASK_VIEW",      L"ACTION_SWITCH_LAST",
-    L"ACTION_TASK_SWITCHER",  L"ACTION_START_MENU",
-    L"ACTION_SEARCH",         L"ACTION_SETTINGS",
-    L"ACTION_FILE_EXPLORER",  L"ACTION_QUICK_SETTINGS",
-    L"ACTION_NOTIFICATION_CENTER", L"ACTION_CLIPBOARD",
-    L"ACTION_SCREENSHOT",     L"ACTION_PROJECT",
-    L"ACTION_TASK_MANAGER",   L"ACTION_MUTE",
-    L"ACTION_MINIMIZE",       L"ACTION_MAXIMIZE",
-    L"ACTION_SNAP_LEFT",      L"ACTION_SNAP_RIGHT",
-    L"ACTION_CLOSE_WINDOW",   L"ACTION_HIDE_OTHERS",
-    L"ACTION_VDESK_NEXT",     L"ACTION_VDESK_PREV",
-    L"ACTION_VDESK_NEW",      L"ACTION_VDESK_CLOSE",
-    L"ACTION_LOCK",           L"ACTION_LOCK_MONITORS_OFF",
-    L"ACTION_MONITORS_OFF",   L"ACTION_SLEEP",
-    L"ACTION_SCREENSAVER",    L"ACTION_KEEP_AWAKE_ON",
-    L"ACTION_KEEP_AWAKE_OFF", L"ACTION_SEND_KEYPRESS",
-    L"ACTION_ALTERNATE_KEYPRESS", L"ACTION_START_PROCESS",
-    L"ACTION_ALTERNATE_COMMAND",
-};
-static constexpr int kActionCount = ARRAYSIZE(kActionIds);
+// =====================================================================
+// Reading the live configuration
+// =====================================================================
+//
+// The dashboard reads what ReloadConfig already resolved, not the value store.
+// That is what makes it correct for a settings-page layout and a pre-4.2 one
+// without knowing which is in use, and it is why it can no longer drift from
+// what actually fires.
 
-// Per-zone override fields. Blank means "inherit the global value", which is
-// why every one of these can be left empty.
-struct TzDef
+static const wchar_t *kTuningNames[] = {
+    L"Size", L"Activation delay", L"Pass-through guard",
+    L"Knock window", L"Cooldown", L"Modifier",
+};
+
+// Pulls one tuning field out by index, keeping the six rows and the six struct
+// members from being wired up twice.
+static int TuningField(const ZoneTuning &t, int i)
 {
-    int id;
-    const wchar_t *label;
-    const wchar_t *tip;
-};
-static const TzDef kTz[] = {
-    {IDC_TZ_SIZE, L"Size (px)",
-     L"How big this corner square or edge strip is, in pixels. Leave blank to "
-     L"use the global corner/edge size."},
-    {IDC_TZ_DELAY, L"Delay (ms)",
-     L"How long the cursor must sit in this zone before it fires. 0 is "
-     L"immediate. Blank inherits the global activation delay."},
-    {IDC_TZ_SETTLE, L"Guard (ms)",
-     L"Stops this zone firing when you merely pass through it on the way "
-     L"somewhere else. Blank inherits the global pass-through guard."},
-    {IDC_TZ_KNOCK, L"Knock (ms)",
-     L"Require entering this zone twice within this many milliseconds, like "
-     L"knocking. 0 disables it. Blank inherits the global setting."},
-    {IDC_TZ_COOLDOWN, L"Cooldown (ms)",
-     L"Minimum gap before this zone can fire again. Blank inherits the global "
-     L"cooldown."},
-    {IDC_TZ_MODIFIER, L"Modifier",
-     L"Only fire this zone while the chosen key is held. Inherit uses the "
-     L"global setting."},
-};
-static constexpr int kTzCount = ARRAYSIZE(kTz);
-
-struct OptDef
-{
-    int id;
-    const wchar_t *label;
-    bool isCheck;
-    const wchar_t *tip;
-    // Heading drawn above this row, or nullptr to continue the current group.
-    // Fourteen fields in one flat column was a wall; four short groups is the
-    // same information you can actually scan.
-    const wchar_t *section;
-};
-static constexpr OptDef kOpts[] = {
-    {IDC_CORNER, L"Corner size (px)", false, L"Default size of the four corner squares. Individual corners can override this on the Zones page.", L"How big the zones are"},
-    {IDC_EDGE, L"Edge size (px)", false, L"Default thickness of the edge strips. An edge is always clamped to the smaller of the two corners it runs between.", nullptr},
-    {IDC_CENTREPCT, L"Centre zone width (%)", false, L"How much of an edge the centre zone takes. Only affects edges where a centre action is assigned.", nullptr},
-
-    {IDC_DELAY, L"Activation delay (ms)", false, L"How long the cursor must dwell before a zone fires. 0 is immediate.", L"When a zone fires"},
-    {IDC_SETTLE, L"Pass-through guard (ms)", false, L"Stops a zone firing when you only cross it. You cannot reach a corner without crossing the edge beside it, so without this both would fire.", nullptr},
-    {IDC_KNOCK, L"Knock window (ms, 0 = off)", false, L"Require entering a zone twice in quick succession, like knocking. The strongest guard against accidental triggers.", nullptr},
-    {IDC_COOLDOWN, L"Cooldown (ms)", false, L"Minimum gap before the same zone can fire again.", nullptr},
-    {IDC_MODIFIER, L"Require modifier", false, L"Zones stay inert unless this key is held. Individual zones can override it.", nullptr},
-
-    {IDC_EXCLUDED, L"Excluded processes", false, L"Semicolon-separated executable names. While one of them is in the foreground, no zone fires. Example: photoshop.exe;blender.exe", L"When to stay out of the way"},
-    {IDC_CB_FULLSCREEN, L"Skip while an app is fullscreen", true, L"Ignore zones while a game or video is fullscreen - on that display only, so a game on one screen no longer disables the others. Shell surfaces such as Task View and Start do not count.", nullptr},
-    {IDC_CB_DRAG, L"Skip while dragging the mouse", true, L"Ignore zones while any mouse button is held, so dragging a window into a corner does not trigger it.", nullptr},
-    {IDC_CB_TASKBAR, L"Keep zones off the taskbar", true, L"Build zones from the desktop work area, so they stop at the taskbar instead of fighting its peek-at-desktop strip.", nullptr},
-
-    {IDC_LOCKBLANK, L"Blank delay after lock (ms)", false, L"Only used by the Lock and Turn Off Monitors action. Locking counts as activity, so blanking too early just wakes the display.", L"Everything else"},
-    {IDC_CB_MONNAMES, L"List my monitors in the log", true, L"Writes your display names to the log so they can be copied into the monitor selector.", nullptr},
-};
-static constexpr int kOptCount = ARRAYSIZE(kOpts);
-
-// DashSetInt / DashGetInt reach a control as hOpt[id - IDC_OPT_FIRST], so
-// reordering one of these two lists without the other silently writes the wrong
-// field. Cheaper to catch here than to notice as "the cooldown box edits the
-// corner size".
-static constexpr bool OptIdsMatchOrder()
-{
-    for (int i = 0; i < kOptCount; i++)
-        if (kOpts[i].id != IDC_OPT_FIRST + i)
-            return false;
-    return true;
-}
-static_assert(kOptCount == IDC_OPT_LAST - IDC_OPT_FIRST,
-              "kOpts and the DashId option range have different lengths");
-static_assert(OptIdsMatchOrder(),
-              "kOpts must list the option ids in DashId order");
-
-// The window is sized from Lay::OptionsH before kOpts is visible, so measure
-// the real page here and refuse to build if the two have drifted apart -
-// otherwise adding an option just pushes the last row under the button bar.
-static constexpr int OptionsPageH()
-{
-    int h = Lay::Pad + Lay::TabH + Lay::Gap;
-    for (const auto &o : kOpts)
+    switch (i)
     {
-        if (o.section)
-            h += Lay::SecH;
-        h += o.isCheck ? Lay::CheckH : Lay::RowH;
+    case 0: return t.size;
+    case 1: return t.delay;
+    case 2: return t.settle;
+    case 3: return t.knock;
+    case 4: return t.cooldown;
+    default: return t.modifier;
     }
-    return h;
-}
-static_assert(OptionsPageH() == Lay::OptionsH,
-              "Lay::OptionsH no longer matches kOpts");
-
-// A free function with CALLBACK, not a lambda: a non-capturing lambda decays
-// to a cdecl function pointer, while WNDENUMPROC is __stdcall. They happen to
-// be interchangeable in 64-bit builds, but this mod is compiled 32-bit where
-// the calling conventions genuinely differ, so the lambda will not convert.
-static BOOL CALLBACK DashSetChildFont(HWND hChild, LPARAM lParam)
-{
-    SendMessageW(hChild, WM_SETFONT, (WPARAM)lParam, TRUE);
-    return TRUE;
 }
 
-static void DashSetInt(DashState *s, int id, int v)
+// The global an unset field falls back to. Size is the odd one out: a corner
+// and an edge inherit different globals.
+static int GlobalField(const ModSettings &g, int i, Zone z)
 {
-    wchar_t b[32];
-    _snwprintf_s(b, _countof(b), _TRUNCATE, L"%d", v);
-    SetWindowTextW(s->hOpt[id - IDC_OPT_FIRST], b);
+    switch (i)
+    {
+    case 0: return (z <= ZONE_BOTTOM_RIGHT) ? g.cornerSize : g.edgeSize;
+    case 1: return g.activationDelay;
+    case 2: return g.settleMs;
+    case 3: return g.knockWindowMs;
+    case 4: return g.cooldownMs;
+    default: return g.requireModifier;
+    }
 }
 
-static int DashGetInt(DashState *s, int id, int fallback)
+static std::wstring FormatTuning(int i, int value)
 {
-    wchar_t b[32] = {};
-    GetWindowTextW(s->hOpt[id - IDC_OPT_FIRST], b, ARRAYSIZE(b));
-    if (!b[0])
-        return fallback;
-    return _wtoi(b);
+    wchar_t buf[64];
+    if (i == 0)
+        _snwprintf_s(buf, _countof(buf), _TRUNCATE, L"%d px", value);
+    else if (i == 5)
+    {
+        static const wchar_t *kMods[] = {L"None", L"Ctrl", L"Alt", L"Shift",
+                                         L"Win"};
+        return (value >= 0 && value < 5) ? kMods[value] : L"None";
+    }
+    else if (i == 3 && value == 0)
+        return L"off";
+    else
+        _snwprintf_s(buf, _countof(buf), _TRUNCATE, L"%d ms", value);
+    return buf;
 }
 
-static void DashLayout(HWND hWnd, DashState *s)
+// Mirrors ResolveZone: the display's own configuration first, then the
+// wildcard, decided per zone rather than per display.
+static void DashFillZones(DisplayView &dv,
+                          const std::vector<MonitorZoneConfig> &cfgs)
 {
-    UINT d = s->dpi;
-    const int pad = Sc(Lay::Pad, d), gap = Sc(Lay::Gap, d);
-    int y;
-
-    // Show only the active page. Doing this first means the button bar below
-    // is positioned against a known set of visible controls.
     for (int z = 0; z < ZONE_COUNT; z++)
     {
-        int sw = s->showZones ? SW_SHOW : SW_HIDE;
-        ShowWindow(s->hZoneLabel[z], sw);
-        ShowWindow(s->hZoneAction[z], sw);
-        ShowWindow(s->hZoneArgs[z], sw);
-    }
-    ShowWindow(s->hMonitor, s->showZones ? SW_SHOW : SW_HIDE);
-    {
-        int sw = s->showZones ? SW_SHOW : SW_HIDE;
-        ShowWindow(s->hHdrZone, sw);
-        ShowWindow(s->hHdrAction, sw);
-        ShowWindow(s->hHdrArgs, sw);
-        ShowWindow(s->hTzTitle, sw);
-        ShowWindow(s->hTzHint, sw);
-        for (int i = 0; i < kTzCount; i++)
+        const ZoneConfig *hit = nullptr;
+        bool wild = false;
+
+        if (!dv.wildcard)
         {
-            ShowWindow(s->hTz[i], sw);
-            ShowWindow(s->hTzLabel[i], sw);
-        }
-    }
-    for (int i = 0; i < kOptCount; i++)
-    {
-        int sw = s->showZones ? SW_HIDE : SW_SHOW;
-        ShowWindow(s->hOpt[i], sw);
-        if (s->hOptLabel[i])
-            ShowWindow(s->hOptLabel[i], sw);
-        if (s->hOptSection[i])
-            ShowWindow(s->hOptSection[i], sw);
-    }
-
-    SetWindowPos(s->hPageZones, nullptr, pad, pad, Sc(96, d), Sc(Lay::TabH, d),
-                 SWP_NOZORDER);
-    SetWindowPos(s->hPageOptions, nullptr, pad + Sc(104, d), pad, Sc(96, d),
-                 Sc(Lay::TabH, d), SWP_NOZORDER);
-
-    y = pad + Sc(Lay::TabH, d) + gap;
-
-    if (s->showZones)
-    {
-        SetWindowPos(s->hMonitor, nullptr, pad, y,
-                     Sc(Lay::LblW + Lay::Gap + Lay::CmbW, d), Sc(320, d),
-                     SWP_NOZORDER);
-        y += Sc(Lay::CtlH, d) + gap;
-
-        // Column headers
-        SetWindowPos(s->hHdrZone, nullptr, pad, y, Sc(Lay::LblW, d),
-                     Sc(18, d), SWP_NOZORDER);
-        SetWindowPos(s->hHdrAction, nullptr, pad + Sc(Lay::LblW + Lay::Gap, d),
-                     y, Sc(Lay::CmbW, d), Sc(18, d), SWP_NOZORDER);
-        SetWindowPos(s->hHdrArgs, nullptr,
-                     pad + Sc(Lay::LblW + Lay::Gap + Lay::CmbW + Lay::Gap, d), y,
-                     Sc(Lay::ArgW, d), Sc(18, d), SWP_NOZORDER);
-        y += Sc(Lay::HdrH, d);
-
-        for (int z = 0; z < ZONE_COUNT; z++)
-        {
-            int rowY = y + z * Sc(Lay::RowH, d);
-            SetWindowPos(s->hZoneLabel[z], nullptr, pad, rowY + Sc(5, d),
-                         Sc(Lay::LblW, d), Sc(20, d), SWP_NOZORDER);
-            SetWindowPos(s->hZoneAction[z], nullptr,
-                         pad + Sc(Lay::LblW + Lay::Gap, d), rowY,
-                         Sc(Lay::CmbW, d), Sc(320, d), SWP_NOZORDER);
-            SetWindowPos(s->hZoneArgs[z], nullptr,
-                         pad + Sc(Lay::LblW + Lay::Gap + Lay::CmbW + Lay::Gap, d),
-                         rowY, Sc(Lay::ArgW, d), Sc(Lay::CtlH, d), SWP_NOZORDER);
-        }
-    }
-    else
-    {
-        for (int i = 0; i < kOptCount; i++)
-        {
-            if (s->hOptSection[i])
+            for (const auto &cfg : cfgs)
             {
-                SetWindowPos(s->hOptSection[i], nullptr, pad, y + Sc(8, d),
-                             Sc(Lay::OptLblW + Lay::Gap + Lay::OptCtlW, d),
-                             Sc(20, d), SWP_NOZORDER);
-                y += Sc(Lay::SecH, d);
-            }
-            if (kOpts[i].isCheck)
-            {
-                SetWindowPos(s->hOpt[i], nullptr, pad, y,
-                             Sc(Lay::OptLblW + Lay::Gap + Lay::OptCtlW, d),
-                             Sc(22, d), SWP_NOZORDER);
-                y += Sc(Lay::CheckH, d);
-            }
-            else
-            {
-                SetWindowPos(s->hOptLabel[i], nullptr, pad, y + Sc(5, d),
-                             Sc(Lay::OptLblW, d), Sc(20, d), SWP_NOZORDER);
-                bool combo = (kOpts[i].id == IDC_MODIFIER);
-                bool wide = (kOpts[i].id == IDC_EXCLUDED);
-                SetWindowPos(s->hOpt[i], nullptr,
-                             pad + Sc(Lay::OptLblW + Lay::Gap, d), y,
-                             Sc(wide ? Lay::OptCtlW + Lay::DiagW : Lay::OptCtlW, d),
-                             combo ? Sc(200, d) : Sc(Lay::CtlH, d), SWP_NOZORDER);
-                y += Sc(Lay::RowH, d);
+                if (cfg.monitorId.empty() || cfg.monitorId == L"*")
+                    continue;
+                if (_wcsicmp(cfg.monitorId.c_str(), dv.id.c_str()) != 0)
+                    continue;
+                if (cfg.zones[z].action != CornerAction::Nothing)
+                {
+                    hit = &cfg.zones[z];
+                    break;
+                }
             }
         }
-    }
 
-    if (s->showZones)
-    {
-        RECT dg = DashDiagramRect(d);
-        int px = dg.left;
-        int py = dg.bottom + Sc(14, d);
-        int pw = dg.right - dg.left;
-        SetWindowPos(s->hTzTitle, nullptr, px, py, pw, Sc(18, d), SWP_NOZORDER);
-        py += Sc(20, d);
-        SetWindowPos(s->hTzHint, nullptr, px, py, pw, Sc(16, d), SWP_NOZORDER);
-        py += Sc(20, d);
-        int lw = Sc(96, d);
-        for (int i = 0; i < kTzCount; i++)
+        if (!hit)
         {
-            SetWindowPos(s->hTzLabel[i], nullptr, px, py + Sc(4, d), lw,
-                         Sc(18, d), SWP_NOZORDER);
-            bool combo = (kTz[i].id == IDC_TZ_MODIFIER);
-            SetWindowPos(s->hTz[i], nullptr, px + lw + Sc(6, d), py,
-                         pw - lw - Sc(6, d), combo ? Sc(180, d) : Sc(22, d),
-                         SWP_NOZORDER);
-            py += Sc(Lay::TzRowH, d);
+            for (const auto &cfg : cfgs)
+            {
+                if (cfg.monitorId != L"*")
+                    continue;
+                if (cfg.zones[z].action != CornerAction::Nothing)
+                {
+                    hit = &cfg.zones[z];
+                    wild = !dv.wildcard;
+                    break;
+                }
+            }
         }
+
+        if (!hit)
+            continue;
+
+        dv.zones[z].action = hit->action;
+        dv.zones[z].args = hit->args;
+        dv.zones[z].tuning = hit->tuning;
+        dv.zones[z].fromWildcard = wild;
+        dv.configured++;
     }
-
-    // Button bar sits below the taller of the two pages, always, so it can
-    // never land on top of a control.
-    RECT rc;
-    GetClientRect(hWnd, &rc);
-    int by = rc.bottom - pad - Sc(Lay::BtnH, d);
-    int bx = pad;
-    SetWindowPos(s->hSave, nullptr, bx, by, Sc(130, d), Sc(Lay::BtnH, d),
-                 SWP_NOZORDER);
-    bx += Sc(130 + Lay::Gap, d);
-    SetWindowPos(s->hCancel, nullptr, bx, by, Sc(90, d), Sc(Lay::BtnH, d),
-                 SWP_NOZORDER);
-    bx += Sc(90 + Lay::Gap, d);
-    SetWindowPos(s->hReset, nullptr, bx, by, Sc(210, d), Sc(Lay::BtnH, d),
-                 SWP_NOZORDER);
-
-    InvalidateRect(hWnd, nullptr, TRUE);
 }
 
-// Screen preview: a rectangle with the twelve zones drawn where they actually
-// sit, filled when something is assigned to them. Clicking one jumps to its
-// row, which is far quicker than reading down a list of twelve labels.
-static void DashPaintDiagram(HWND hWnd, DashState *s, HDC hdc)
+static void DashBuildSnapshot(DashState *s)
 {
-    if (!s->showZones)
-        return;
+    s->displays.clear();
+    s->tabRects.clear();
 
+    // Attached displays, with their geometry, come from the published zone
+    // snapshot - g_monitors belongs to the detection thread, which clears and
+    // refills it underneath anyone else.
+    std::shared_ptr<const ZoneSet> snap;
+    EnterCriticalSection(&g_zonesLock);
+    snap = g_zones;
+    LeaveCriticalSection(&g_zonesLock);
+
+    std::vector<MonitorZoneConfig> cfgs;
+    {
+        EnterCriticalSection(&g_settingsLock);
+        cfgs = g_settings.monitorConfigs;
+        s->globals = g_settings;
+        LeaveCriticalSection(&g_settingsLock);
+    }
+    s->globals.monitorConfigs.clear();   // not needed, and it is not small
+
+    if (snap)
+    {
+        for (const auto &m : snap->monitors)
+        {
+            DisplayView dv;
+            dv.id = m.id;
+            dv.width = m.width;
+            dv.height = m.height;
+            dv.primary = m.primary;
+            dv.present = true;
+            DashFillZones(dv, cfgs);
+            s->displays.push_back(std::move(dv));
+        }
+    }
+
+    // A configuration for a display that is not plugged in right now is still
+    // real and still worth seeing, so it gets a tab of its own.
+    for (const auto &cfg : cfgs)
+    {
+        if (cfg.monitorId.empty() || cfg.monitorId == L"*")
+            continue;
+        bool known = false;
+        for (const auto &dv : s->displays)
+            if (_wcsicmp(dv.id.c_str(), cfg.monitorId.c_str()) == 0)
+                known = true;
+        if (known)
+            continue;
+
+        DisplayView dv;
+        dv.id = cfg.monitorId;
+        dv.present = false;
+        DashFillZones(dv, cfgs);
+        s->displays.push_back(std::move(dv));
+    }
+
+    for (const auto &cfg : cfgs)
+    {
+        if (cfg.monitorId != L"*")
+            continue;
+        DisplayView dv;
+        dv.id = L"All displays";
+        dv.wildcard = true;
+        DashFillZones(dv, cfgs);
+        s->displays.push_back(std::move(dv));
+        break;
+    }
+
+    if (s->activeTab >= (int)s->displays.size())
+        s->activeTab = 0;
+}
+
+// =====================================================================
+// Painting
+// =====================================================================
+
+static HFONT DashMakeFont(UINT dpi, int pt, bool bold, int escapement)
+{
+    LOGFONTW lf = {};
+    lf.lfHeight = -Sc(pt, dpi);
+    lf.lfWeight = bold ? FW_SEMIBOLD : FW_NORMAL;
+    lf.lfCharSet = DEFAULT_CHARSET;
+    lf.lfQuality = CLEARTYPE_QUALITY;
+    lf.lfEscapement = escapement;
+    lf.lfOrientation = escapement;
+    wcscpy_s(lf.lfFaceName, LF_FACESIZE, L"Segoe UI");
+    return CreateFontIndirectW(&lf);
+}
+
+static void DashPaintTabs(DashState *s, HDC hdc, const RECT &client)
+{
     UINT d = s->dpi;
-    RECT dg = DashDiagramRect(d);
+    s->tabRects.clear();
+
+    int x = Sc(Lay::Pad, d);
+    int top = Sc(Lay::Pad, d);
+    int h = Sc(Lay::TabH, d);
 
     HFONT old = (HFONT)SelectObject(hdc, s->hFont);
     SetBkMode(hdc, TRANSPARENT);
-    SetTextColor(hdc, g_pal.dim);
-    RECT cap = {dg.left, dg.top - Sc(20, d), dg.right, dg.top - Sc(2, d)};
-    DrawTextW(hdc, L"Your screen — click a zone to jump to it", -1, &cap,
-              DT_LEFT | DT_SINGLELINE);
 
-    HBRUSH screenBrush = CreateSolidBrush(RGB(24, 24, 24));
-    FillRect(hdc, &dg, screenBrush);
-    DeleteObject(screenBrush);
+    for (int i = 0; i < (int)s->displays.size(); i++)
+    {
+        const DisplayView &dv = s->displays[i];
+        bool active = (i == s->activeTab);
 
-    HPEN pen = CreatePen(PS_SOLID, Sc(1, d), RGB(90, 90, 90));
+        wchar_t count[16];
+        _snwprintf_s(count, _countof(count), _TRUNCATE, L"%d", dv.configured);
+
+        SIZE ts = {}, cs = {};
+        SelectObject(hdc, active ? s->hFontBold : s->hFont);
+        GetTextExtentPoint32W(hdc, dv.id.c_str(), (int)dv.id.size(), &ts);
+        SelectObject(hdc, s->hFontSmall);
+        GetTextExtentPoint32W(hdc, count, (int)wcslen(count), &cs);
+
+        int dot = dv.present ? 0 : Sc(14, d);
+        int badge = cs.cx + Sc(12, d);
+        int wTab = Sc(12, d) + dot + ts.cx + Sc(8, d) + badge + Sc(12, d);
+
+        RECT tr = {x, top, x + wTab, top + h};
+        s->tabRects.push_back(tr);
+
+        int tx = tr.left + Sc(12, d);
+
+        // A saved configuration for a display that is not plugged in is not an
+        // error, but it should not read as live either.
+        if (!dv.present)
+        {
+            int r = Sc(3, d);
+            int cy = tr.top + h / 2;
+            HBRUSH db = CreateSolidBrush(g_pal.dim);
+            RECT dr = {tx, cy - r, tx + 2 * r, cy + r};
+            FillRect(hdc, &dr, db);
+            DeleteObject(db);
+            tx += dot;
+        }
+
+        SelectObject(hdc, active ? s->hFontBold : s->hFont);
+        SetTextColor(hdc, active ? g_pal.text : g_pal.dim);
+        RECT lr = {tx, tr.top, tr.right, tr.bottom};
+        DrawTextW(hdc, dv.id.c_str(), -1, &lr,
+                  DT_LEFT | DT_SINGLELINE | DT_VCENTER);
+        tx += ts.cx + Sc(8, d);
+
+        // Configured-zone count, so "have I set anything up on that screen?"
+        // is answerable without clicking through.
+        RECT br = {tx, tr.top + h / 2 - Sc(9, d), tx + badge,
+                   tr.top + h / 2 + Sc(9, d)};
+        HBRUSH bb = CreateSolidBrush(active ? g_pal.accent : g_pal.field);
+        FillRect(hdc, &br, bb);
+        DeleteObject(bb);
+        SelectObject(hdc, s->hFontSmall);
+        SetTextColor(hdc, active ? g_pal.accentText : g_pal.dim);
+        DrawTextW(hdc, count, -1, &br, DT_CENTER | DT_SINGLELINE | DT_VCENTER);
+
+        if (active)
+        {
+            RECT ul = {tr.left + Sc(8, d), tr.bottom - Sc(2, d),
+                       tr.right - Sc(8, d), tr.bottom};
+            HBRUSH ab = CreateSolidBrush(g_pal.accent);
+            FillRect(hdc, &ul, ab);
+            DeleteObject(ab);
+        }
+
+        x += wTab;
+    }
+
+    // Hairline under the whole strip.
+    RECT sep = {Sc(Lay::Pad, d), top + h, client.right - Sc(Lay::Pad, d),
+                top + h + Sc(1, d)};
+    HBRUSH sb = CreateSolidBrush(g_pal.border);
+    FillRect(hdc, &sep, sb);
+    DeleteObject(sb);
+
+    SelectObject(hdc, old);
+}
+
+static void DashPaintDiagram(DashState *s, HDC hdc)
+{
+    UINT d = s->dpi;
+    RECT dg = DashDiagramRect(s);
+
+    HFONT old = (HFONT)SelectObject(hdc, s->hFont);
+    SetBkMode(hdc, TRANSPARENT);
+
+    HBRUSH screen = CreateSolidBrush(g_pal.field);
+    FillRect(hdc, &dg, screen);
+    DeleteObject(screen);
+
+    HPEN pen = CreatePen(PS_SOLID, Sc(1, d), g_pal.border);
     HPEN oldPen = (HPEN)SelectObject(hdc, pen);
     HBRUSH hollow = (HBRUSH)GetStockObject(NULL_BRUSH);
     HBRUSH oldBrush = (HBRUSH)SelectObject(hdc, hollow);
@@ -3870,318 +4633,290 @@ static void DashPaintDiagram(HWND hWnd, DashState *s, HDC hdc)
     SelectObject(hdc, oldPen);
     DeleteObject(pen);
 
-    HBRUSH set = CreateSolidBrush(RGB(76, 194, 255));
-    HBRUSH unset = CreateSolidBrush(RGB(58, 58, 58));
-    HBRUSH sel = CreateSolidBrush(RGB(255, 190, 80));
+    if (s->displays.empty())
+    {
+        SetTextColor(hdc, g_pal.dim);
+        RECT t = dg;
+        DrawTextW(hdc,
+                  L"No displays are configured.\n\n"
+                  L"Open this mod's Settings page in Windhawk, add a display, "
+                  L"then add the zones you want on it.",
+                  -1, &t, DT_CENTER | DT_WORDBREAK | DT_EDITCONTROL);
+        SelectObject(hdc, old);
+        return;
+    }
+
+    const DisplayView &dv = s->displays[s->activeTab];
+
+    HBRUSH set = CreateSolidBrush(g_pal.accent);
+    HBRUSH unset = CreateSolidBrush(g_pal.border);
+    HBRUSH hot = CreateSolidBrush(g_lightTheme ? RGB(0, 70, 140)
+                                               : RGB(120, 215, 255));
 
     for (int z = 0; z < ZONE_COUNT; z++)
     {
-        int idx = (int)SendMessageW(s->hZoneAction[z], CB_GETCURSEL, 0, 0);
-        HBRUSH b = (z == s->hoverZone) ? sel : (idx > 0 ? set : unset);
-        int parts = ZoneHasTwoParts((Zone)z) ? 2 : 1;
-        for (int p = 0; p < parts; p++)
+        const ZoneView &zv = dv.zones[z];
+        bool on = zv.action != CornerAction::Nothing;
+        bool live = (z == s->hoverZone || z == s->selZone);
+        HBRUSH b = live ? hot : (on ? set : unset);
+
+        RECT widest = ZoneRectInDiagram((Zone)z, dg);
+        if (widest.right <= widest.left || widest.bottom <= widest.top)
+            continue;
+        FillRect(hdc, &widest, b);
+
+        if (!on)
+            continue;
+
+        SetTextColor(hdc, live ? (g_lightTheme ? RGB(255, 255, 255)
+                                               : RGB(0, 0, 0))
+                               : g_pal.accentText);
+
+        const wchar_t *name = ActionToString(zv.action);
+
+        if (ZoneIsVertical((Zone)z))
         {
-            RECT r = ZoneRectInDiagram((Zone)z, dg, p == 1);
-            if (r.right > r.left && r.bottom > r.top)
-                FillRect(hdc, &r, b);
+            // A rotated font draws from a baseline rather than into a rect, so
+            // the text is measured and placed by hand. DT_* alignment does not
+            // apply to escapement.
+            SelectObject(hdc, s->hFontVert);
+            SIZE ts = {};
+            GetTextExtentPoint32W(hdc, name, (int)wcslen(name), &ts);
+            int bh = widest.bottom - widest.top;
+            int cx = (widest.left + widest.right) / 2;
+            int cy = (widest.top + widest.bottom) / 2;
+            // Clip to the strip so a long name cannot escape the screen box.
+            IntersectClipRect(hdc, widest.left, widest.top, widest.right,
+                              widest.bottom);
+            // At 90 degrees the advance runs up the screen and the glyphs hang
+            // to the left of the baseline, so the baseline sits at the right of
+            // the band and the run starts at its bottom.
+            int y = cy + (ts.cx > bh ? bh / 2 : ts.cx / 2);
+            TextOutW(hdc, cx + ts.cy / 2, y, name, (int)wcslen(name));
+            SelectClipRgn(hdc, nullptr);
+        }
+        else
+        {
+            SelectObject(hdc, s->hFontSmall);
+            RECT t = widest;
+            InflateRect(&t, -Sc(3, d), -Sc(2, d));
+            // Corners are square and small, so a long name wraps and then
+            // clips; edges are wide and short, so they ellipsise on one line.
+            DrawTextW(hdc, name, -1, &t,
+                      ZoneIsCorner((Zone)z)
+                          ? (DT_CENTER | DT_WORDBREAK | DT_EDITCONTROL)
+                          : (DT_CENTER | DT_SINGLELINE | DT_VCENTER |
+                             DT_END_ELLIPSIS));
         }
     }
 
     DeleteObject(set);
     DeleteObject(unset);
-    DeleteObject(sel);
+    DeleteObject(hot);
 
-    // ponytail: no hover card. It used to be drawn from dg.bottom+10 to
-    // dg.bottom+112 — the exact strip the per-zone panel's controls occupy, so
-    // it was never readable and its leftovers showed through the gaps between
-    // the fields. The panel below already shows the same numbers for the
-    // selected zone, and clicking a zone in the preview selects it.
+    // Caption under the box.
+    SelectObject(hdc, s->hFontSmall);
+    SetTextColor(hdc, g_pal.dim);
+    wchar_t cap[160];
+    if (dv.wildcard)
+        wcscpy_s(cap, _countof(cap),
+                       L"Applies to any display without its own configuration");
+    else if (!dv.present)
+        _snwprintf_s(cap, _countof(cap), _TRUNCATE, L"%s  -  not connected",
+                     dv.id.c_str());
+    else
+        _snwprintf_s(cap, _countof(cap), _TRUNCATE, L"%d x %d%s", dv.width,
+                     dv.height, dv.primary ? L"  -  primary" : L"");
+
+    RECT cr = {DashDiagramArea(d).left, dg.bottom + Sc(4, d),
+               DashDiagramArea(d).right, dg.bottom + Sc(Lay::DiagCapH, d)};
+    DrawTextW(hdc, cap, -1, &cr, DT_CENTER | DT_SINGLELINE);
 
     SelectObject(hdc, old);
 }
-// Fills the zone controls from whichever configuration slot is selected.
-// Pushes the selected zone's overrides into the six panel fields.
-static void DashShowZoneTuning(DashState *s)
+
+static void DashPaintDetail(DashState *s, HDC hdc, const RECT &client)
 {
-    const ZoneTuning &tn = s->tuning[s->selZone];
-    auto put = [&](int id, int v)
+    UINT d = s->dpi;
+    int left = Sc(Lay::Pad, d);
+    int right = client.right - Sc(Lay::Pad, d);
+    int top = Sc(Lay::Pad + Lay::TabH + Lay::Gap + Lay::DiagAreaH +
+                     Lay::DiagCapH + Lay::Gap,
+                 d);
+
+    HFONT old = (HFONT)SelectObject(hdc, s->hFont);
+    SetBkMode(hdc, TRANSPARENT);
+
+    RECT sep = {left, top, right, top + Sc(1, d)};
+    HBRUSH sb = CreateSolidBrush(g_pal.border);
+    FillRect(hdc, &sep, sb);
+    DeleteObject(sb);
+
+    int y = top + Sc(10, d);
+    // Hover wins while the pointer is over a zone; a click pins one so the
+    // panel still reads once the pointer moves away.
+    int zone = (s->hoverZone >= 0) ? s->hoverZone : s->selZone;
+
+    if (s->displays.empty() || zone < 0)
     {
-        wchar_t b[24] = L"";
-        if (v >= 0)
-            _snwprintf_s(b, _countof(b), _TRUNCATE, L"%d", v);
-        SetWindowTextW(s->hTz[id - IDC_TZ_FIRST], b);
-    };
-    put(IDC_TZ_SIZE, tn.size);
-    put(IDC_TZ_DELAY, tn.delay);
-    put(IDC_TZ_SETTLE, tn.settle);
-    put(IDC_TZ_KNOCK, tn.knock);
-    put(IDC_TZ_COOLDOWN, tn.cooldown);
-    SendMessageW(s->hTz[IDC_TZ_MODIFIER - IDC_TZ_FIRST], CB_SETCURSEL,
-                 tn.modifier < 0 ? 0 : tn.modifier + 1, 0);
-
-    std::wstring title =
-        std::wstring(L"Settings for ") + ZoneToString((Zone)s->selZone);
-    SetWindowTextW(s->hTzTitle, title.c_str());
-}
-
-// Reads the six panel fields back into the selected zone. Blank stays -1,
-// which is what "inherit the global value" is stored as.
-static void DashCaptureZoneTuning(DashState *s)
-{
-    ZoneTuning &tn = s->tuning[s->selZone];
-    auto get = [&](int id) -> int
-    {
-        wchar_t b[24] = {};
-        GetWindowTextW(s->hTz[id - IDC_TZ_FIRST], b, ARRAYSIZE(b));
-        if (!b[0])
-            return -1;
-        return _wtoi(b);
-    };
-    tn.size = get(IDC_TZ_SIZE);
-    tn.delay = get(IDC_TZ_DELAY);
-    tn.settle = get(IDC_TZ_SETTLE);
-    tn.knock = get(IDC_TZ_KNOCK);
-    tn.cooldown = get(IDC_TZ_COOLDOWN);
-    int m = (int)SendMessageW(s->hTz[IDC_TZ_MODIFIER - IDC_TZ_FIRST],
-                              CB_GETCURSEL, 0, 0);
-    tn.modifier = (m <= 0) ? -1 : m - 1;
-}
-
-// The monitor name a combo entry stands for. Entry 0 is the wildcard.
-static std::wstring DashSlotMonitorId(DashState *s, int index)
-{
-    if (index <= 0)
-        return L"*";
-    wchar_t buf[256] = {};
-    if (SendMessageW(s->hMonitor, CB_GETLBTEXT, index, (LPARAM)buf) == CB_ERR)
-        return L"";
-    return buf;
-}
-
-// Reads persistence into a slot, once. Everything after that comes from the
-// in-memory copy, so an edit is never re-read over.
-static void DashFillSlotFromStore(DashState *s, int index)
-{
-    if (index < 0 || index >= (int)s->slots.size() || s->slots[index].loaded)
+        SelectObject(hdc, s->hFontSmall);
+        SetTextColor(hdc, g_pal.dim);
+        RECT r = {left, y, right, y + Sc(40, d)};
+        DrawTextW(hdc,
+                  s->displays.empty()
+                      ? L"Nothing to show yet."
+                      : L"Hover or click a zone to see its action and the "
+                        L"settings actually in effect for it.",
+                  -1, &r, DT_LEFT | DT_WORDBREAK);
+        SelectObject(hdc, old);
         return;
+    }
 
-    DashState::Slot &sl = s->slots[index];
-    sl.loaded = true;
+    const DisplayView &dv = s->displays[s->activeTab];
+    const ZoneView &zv = dv.zones[zone];
 
-    // The value store is the only place a zone can come from now. The old
-    // second source - seeding from the Windhawk settings page - went with the
-    // page itself, and with it the bug where the seed was picked by combo
-    // position instead of by monitor, so one display's configuration showed up
-    // under "All monitors" and then fired on every display.
+    SelectObject(hdc, s->hFontBold);
+    SetTextColor(hdc, g_pal.text);
+    RECT r = {left, y, right, y + Sc(18, d)};
+    DrawTextW(hdc, ZoneToString((Zone)zone), -1, &r, DT_LEFT | DT_SINGLELINE);
+    y += Sc(19, d);
+
+    SelectObject(hdc, s->hFontSmall);
+    SetTextColor(hdc, g_pal.dim);
+    wchar_t line[512];
+    if (zv.action == CornerAction::Nothing)
+    {
+        wcscpy_s(line, _countof(line),
+                       L"Not set - this zone does nothing.");
+    }
+    else if (zv.action == CornerAction::AlternateKeypress ||
+             zv.action == CornerAction::AlternateCommand)
+    {
+        std::wstring a, b;
+        if (SplitAlternate(zv.args, a, b))
+            _snwprintf_s(line, _countof(line), _TRUNCATE,
+                         L"%s - alternates between  %s  and  %s",
+                         ActionToString(zv.action), a.c_str(), b.c_str());
+        else
+            _snwprintf_s(line, _countof(line), _TRUNCATE,
+                         L"%s - needs two halves separated by |",
+                         ActionToString(zv.action));
+    }
+    else if (!zv.args.empty())
+    {
+        _snwprintf_s(line, _countof(line), _TRUNCATE, L"%s  -  %s",
+                     ActionToString(zv.action), zv.args.c_str());
+    }
+    else
+    {
+        wcscpy_s(line, _countof(line), ActionToString(zv.action));
+    }
+    r = {left, y, right, y + Sc(18, d)};
+    DrawTextW(hdc, line, -1, &r, DT_LEFT | DT_SINGLELINE | DT_END_ELLIPSIS);
+    y += Sc(18, d);
+
+    if (zv.fromWildcard)
+    {
+        r = {left, y, right, y + Sc(16, d)};
+        DrawTextW(hdc, L"Inherited from the \"All displays\" configuration", -1,
+                  &r, DT_LEFT | DT_SINGLELINE);
+    }
+    y += Sc(19, d);
+
+    if (zv.action == CornerAction::Nothing)
+    {
+        SelectObject(hdc, old);
+        return;
+    }
+
+    // Column headings.
+    int cLabel = left;
+    int cValue = left + Sc(190, d);
+    int cFrom = left + Sc(300, d);
+
+    SetTextColor(hdc, g_pal.dim);
+    r = {cLabel, y, cValue, y + Sc(16, d)};
+    DrawTextW(hdc, L"SETTING", -1, &r, DT_LEFT | DT_SINGLELINE);
+    r = {cValue, y, cFrom, y + Sc(16, d)};
+    DrawTextW(hdc, L"IN EFFECT", -1, &r, DT_LEFT | DT_SINGLELINE);
+    r = {cFrom, y, right, y + Sc(16, d)};
+    DrawTextW(hdc, L"FROM", -1, &r, DT_LEFT | DT_SINGLELINE);
+    y += Sc(Lay::DetHdrH, d);
+
+    // A zone silently inherits five numbers. Showing which ones were
+    // overridden is the whole point of the panel - "why did this one fire
+    // late?" was previously unanswerable without reading the store by hand.
+    for (int i = 0; i < 6; i++)
+    {
+        int own = TuningField(zv.tuning, i);
+        bool overridden = own >= 0;
+        int value = overridden ? own : GlobalField(s->globals, i, (Zone)zone);
+        std::wstring text = FormatTuning(i, value);
+
+        SetTextColor(hdc, g_pal.dim);
+        r = {cLabel, y, cValue, y + Sc(Lay::DetRowH, d)};
+        DrawTextW(hdc, kTuningNames[i], -1, &r, DT_LEFT | DT_SINGLELINE);
+
+        SetTextColor(hdc, g_pal.text);
+        r = {cValue, y, cFrom, y + Sc(Lay::DetRowH, d)};
+        DrawTextW(hdc, text.c_str(), -1, &r, DT_LEFT | DT_SINGLELINE);
+
+        SetTextColor(hdc, overridden ? g_pal.accent : g_pal.dim);
+        r = {cFrom, y, right, y + Sc(Lay::DetRowH, d)};
+        DrawTextW(hdc, overridden ? L"this zone" : L"global", -1, &r,
+                  DT_LEFT | DT_SINGLELINE);
+
+        y += Sc(Lay::DetRowH, d);
+    }
+
+    SelectObject(hdc, old);
+}
+
+// =====================================================================
+// Hit testing
+// =====================================================================
+
+static int DashHitZone(DashState *s, POINT pt)
+{
+    if (s->displays.empty())
+        return -1;
+    RECT dg = DashDiagramRect(s);
     for (int z = 0; z < ZONE_COUNT; z++)
     {
-        std::wstring act = GetStrValue(GuiKey(index, z, L"a").c_str());
-
-        sl.action[z] = 0;
-        for (int a = 0; a < kActionCount; a++)
-        {
-            if (act == kActionIds[a])
-            {
-                sl.action[z] = a;
-                break;
-            }
-        }
-        sl.args[z] = GetStrValue(GuiKey(index, z, L"g").c_str());
-
-        ZoneTuning &tn = sl.tuning[z];
-        tn.size = Wh_GetIntValue(GuiKey(index, z, L"sz").c_str(), -1);
-        tn.delay = Wh_GetIntValue(GuiKey(index, z, L"dl").c_str(), -1);
-        tn.settle = Wh_GetIntValue(GuiKey(index, z, L"gd").c_str(), -1);
-        tn.knock = Wh_GetIntValue(GuiKey(index, z, L"kn").c_str(), -1);
-        tn.cooldown = Wh_GetIntValue(GuiKey(index, z, L"cd").c_str(), -1);
-        tn.modifier = Wh_GetIntValue(GuiKey(index, z, L"md").c_str(), -1);
+        RECT r = ZoneRectInDiagram((Zone)z, dg);
+        if (PtInRect(&r, pt))
+            return z;
     }
+    return -1;
 }
 
-// Controls -> the slot they were showing.
-static void DashCaptureSlot(DashState *s)
+static int DashHitTab(DashState *s, POINT pt)
 {
-    if (s->cfgIndex < 0 || s->cfgIndex >= (int)s->slots.size())
-        return;
-
-    DashCaptureZoneTuning(s);
-    DashState::Slot &sl = s->slots[s->cfgIndex];
-    for (int z = 0; z < ZONE_COUNT; z++)
-    {
-        sl.action[z] =
-            (int)SendMessageW(s->hZoneAction[z], CB_GETCURSEL, 0, 0);
-        if (sl.action[z] < 0)
-            sl.action[z] = 0;
-        wchar_t buf[512] = {};
-        GetWindowTextW(s->hZoneArgs[z], buf, ARRAYSIZE(buf));
-        sl.args[z] = buf;
-        sl.tuning[z] = s->tuning[z];
-    }
-    sl.loaded = true;
+    for (int i = 0; i < (int)s->tabRects.size(); i++)
+        if (PtInRect(&s->tabRects[i], pt))
+            return i;
+    return -1;
 }
 
-// The slot -> the controls.
-static void DashShowSlot(DashState *s)
+// Posted when the configuration changes underneath an open window.
+#define WM_APP_DASH_REFRESH (WM_APP + 21)
+
+static void DashMakeFonts(DashState *s)
 {
-    if (s->cfgIndex < 0 || s->cfgIndex >= (int)s->slots.size())
-        return;
+    if (s->hFont)
+        DeleteObject(s->hFont);
+    if (s->hFontBold)
+        DeleteObject(s->hFontBold);
+    if (s->hFontSmall)
+        DeleteObject(s->hFontSmall);
+    if (s->hFontVert)
+        DeleteObject(s->hFontVert);
 
-    const DashState::Slot &sl = s->slots[s->cfgIndex];
-    for (int z = 0; z < ZONE_COUNT; z++)
-    {
-        SendMessageW(s->hZoneAction[z], CB_SETCURSEL, sl.action[z], 0);
-        SetWindowTextW(s->hZoneArgs[z], sl.args[z].c_str());
-        s->tuning[z] = sl.tuning[z];
-    }
-    DashShowZoneTuning(s);
-}
-
-// Switches the window to whichever display the combo now shows, keeping what
-// was on screen for the previous one.
-static void DashLoadZones(DashState *s)
-{
-    int sel = (int)SendMessageW(s->hMonitor, CB_GETCURSEL, 0, 0);
-    if (sel < 0)
-        sel = 0;
-
-    if (sel != s->cfgIndex)
-        DashCaptureSlot(s);
-
-    s->cfgIndex = sel;
-    if (sel >= (int)s->slots.size())
-        s->slots.resize(sel + 1);
-
-    DashFillSlotFromStore(s, sel);
-    DashShowSlot(s);
-}
-
-static void DashLoad(HWND hWnd, DashState *s)
-{
-    // Monitor selector: one slot per detected display, plus a wildcard.
-    SendMessageW(s->hMonitor, CB_RESETCONTENT, 0, 0);
-    SendMessageW(s->hMonitor, CB_ADDSTRING, 0, (LPARAM)L"All monitors  ( * )");
-    // Take a reference to the snapshot under the lock, then read it outside:
-    // it is immutable and shared_ptr keeps it alive even if the detection
-    // thread publishes a new one mid-loop. Reading g_monitors directly here
-    // was a use-after-free — RefreshMonitors clears that vector and frees
-    // every id string while this thread walks it.
-    EnterCriticalSection(&g_zonesLock);
-    std::shared_ptr<const ZoneSet> snap = g_zones;
-    LeaveCriticalSection(&g_zonesLock);
-    std::vector<std::wstring> names;
-    if (snap)
-        names = snap->monitorNames;
-    for (const auto &n : names)
-        SendMessageW(s->hMonitor, CB_ADDSTRING, 0, (LPARAM)n.c_str());
-    SendMessageW(s->hMonitor, CB_SETCURSEL, 0, 0);
-
-    // One slot per combo entry: the wildcard plus every detected display.
-    s->slots.assign(names.size() + 1, DashState::Slot{});
-    s->cfgIndex = 0;
-
-    EnterCriticalSection(&g_settingsLock);
-    DashSetInt(s, IDC_CORNER, g_settings.cornerSize);
-    DashSetInt(s, IDC_EDGE, g_settings.edgeSize);
-    DashSetInt(s, IDC_DELAY, g_settings.activationDelay);
-    DashSetInt(s, IDC_SETTLE, g_settings.settleMs);
-    DashSetInt(s, IDC_KNOCK, g_settings.knockWindowMs);
-    DashSetInt(s, IDC_COOLDOWN, g_settings.cooldownMs);
-    DashSetInt(s, IDC_CENTREPCT, g_settings.centerZonePercent);
-    DashSetInt(s, IDC_LOCKBLANK, g_lockBlankDelayMs);
-    SendMessageW(s->hOpt[IDC_MODIFIER - IDC_OPT_FIRST], CB_SETCURSEL,
-                 g_settings.requireModifier, 0);
-    std::wstring excl;
-    for (size_t i = 0; i < g_settings.excludedProcesses.size(); i++)
-    {
-        if (i)
-            excl += L";";
-        excl += g_settings.excludedProcesses[i];
-    }
-    SetWindowTextW(s->hOpt[IDC_EXCLUDED - IDC_OPT_FIRST], excl.c_str());
-    CheckDlgButton(hWnd, IDC_CB_FULLSCREEN,
-                   g_settings.disableOnFullscreen ? BST_CHECKED : BST_UNCHECKED);
-    CheckDlgButton(hWnd, IDC_CB_DRAG,
-                   g_settings.disableDuringDrag ? BST_CHECKED : BST_UNCHECKED);
-    CheckDlgButton(hWnd, IDC_CB_TASKBAR,
-                   g_settings.avoidTaskbar ? BST_CHECKED : BST_UNCHECKED);
-    LeaveCriticalSection(&g_settingsLock);
-    CheckDlgButton(hWnd, IDC_CB_MONNAMES,
-                   g_showMonitorNames ? BST_CHECKED : BST_UNCHECKED);
-
-    DashLoadZones(s);
-}
-
-static void DashSave(HWND hWnd, DashState *s)
-{
-    // Fold what is on screen back into its slot, then write every slot the
-    // window has touched. Writing only the visible one meant a two-monitor
-    // setup could not be configured in a single session: the other display's
-    // edits were still in memory and never reached the store.
-    DashCaptureSlot(s);
-
-    for (int sel = 0; sel < (int)s->slots.size(); sel++)
-    {
-        const DashState::Slot &sl = s->slots[sel];
-        if (!sl.loaded)
-            continue;
-
-        // A machine with more displays than the value store has slots would
-        // write keys that ReadDashboardZones' kMaxGuiConfigs loop never reads
-        // back — the edit would vanish on reload with nothing said.
-        if (sel >= kMaxGuiConfigs)
-        {
-            Wh_Log(L"Dashboard: display %d is beyond the %d configuration "
-                   L"slots; not saved",
-                   sel, kMaxGuiConfigs);
-            continue;
-        }
-
-        std::wstring monName = DashSlotMonitorId(s, sel);
-        Wh_SetStringValue(GuiKey(sel, -1, L"id").c_str(), monName.c_str());
-        for (int z = 0; z < ZONE_COUNT; z++)
-        {
-            int idx = sl.action[z];
-            if (idx < 0 || idx >= kActionCount)
-                idx = 0;
-            Wh_SetStringValue(GuiKey(sel, z, L"a").c_str(), kActionIds[idx]);
-            Wh_SetStringValue(GuiKey(sel, z, L"g").c_str(), sl.args[z].c_str());
-
-            const ZoneTuning &tn = sl.tuning[z];
-            Wh_SetIntValue(GuiKey(sel, z, L"sz").c_str(), tn.size);
-            Wh_SetIntValue(GuiKey(sel, z, L"dl").c_str(), tn.delay);
-            Wh_SetIntValue(GuiKey(sel, z, L"gd").c_str(), tn.settle);
-            Wh_SetIntValue(GuiKey(sel, z, L"kn").c_str(), tn.knock);
-            Wh_SetIntValue(GuiKey(sel, z, L"cd").c_str(), tn.cooldown);
-            Wh_SetIntValue(GuiKey(sel, z, L"md").c_str(), tn.modifier);
-        }
-    }
-    Wh_SetIntValue(L"gui_active", 1);
-
-    // Global options.
-    Wh_SetIntValue(L"ovr_corner", DashGetInt(s, IDC_CORNER, 6));
-    Wh_SetIntValue(L"ovr_edge", DashGetInt(s, IDC_EDGE, 6));
-    Wh_SetIntValue(L"ovr_delay", DashGetInt(s, IDC_DELAY, 0));
-    Wh_SetIntValue(L"ovr_settle", DashGetInt(s, IDC_SETTLE, 80));
-    Wh_SetIntValue(L"ovr_knock", DashGetInt(s, IDC_KNOCK, 0));
-    Wh_SetIntValue(L"ovr_cooldown", DashGetInt(s, IDC_COOLDOWN, 300));
-    Wh_SetIntValue(L"ovr_centre", DashGetInt(s, IDC_CENTREPCT, 20));
-    Wh_SetIntValue(L"ovr_lockblank", DashGetInt(s, IDC_LOCKBLANK, 1200));
-    Wh_SetIntValue(L"ovr_modifier",
-                   (int)SendMessageW(s->hOpt[IDC_MODIFIER - IDC_OPT_FIRST],
-                                     CB_GETCURSEL, 0, 0));
-    wchar_t excl[512] = {};
-    GetWindowTextW(s->hOpt[IDC_EXCLUDED - IDC_OPT_FIRST], excl,
-                   ARRAYSIZE(excl));
-    Wh_SetStringValue(L"ovr_excluded", excl);
-    Wh_SetIntValue(kOvrFullscreen, IsDlgButtonChecked(hWnd, IDC_CB_FULLSCREEN));
-    Wh_SetIntValue(kOvrDrag, IsDlgButtonChecked(hWnd, IDC_CB_DRAG));
-    Wh_SetIntValue(L"ovr_taskbar", IsDlgButtonChecked(hWnd, IDC_CB_TASKBAR));
-    Wh_SetIntValue(L"ovr_monnames", IsDlgButtonChecked(hWnd, IDC_CB_MONNAMES));
-
-    ReloadConfig();
-    RequestRebuild();
-    UpdateTrayIcon(false);
-    Wh_Log(L"Dashboard: settings saved and applied");
+    s->hFont = DashMakeFont(s->dpi, 12, false, 0);
+    s->hFontBold = DashMakeFont(s->dpi, 12, true, 0);
+    s->hFontSmall = DashMakeFont(s->dpi, 11, false, 0);
+    // 900 tenths of a degree: bottom-to-top, for the left and right strips.
+    s->hFontVert = DashMakeFont(s->dpi, 11, false, 900);
 }
 
 static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
@@ -4191,385 +4926,210 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
 
     switch (uMsg)
     {
-    case WM_CREATE:
+    case WM_NCCREATE:
     {
         auto *cs = (CREATESTRUCTW *)lParam;
-        s = (DashState *)cs->lpCreateParams;
-        SetWindowLongPtrW(hWnd, GWLP_USERDATA, (LONG_PTR)s);
+        SetWindowLongPtrW(hWnd, GWLP_USERDATA, (LONG_PTR)cs->lpCreateParams);
+        return DefWindowProcW(hWnd, uMsg, wParam, lParam);
+    }
 
-        s->dpi = 96;
+    case WM_CREATE:
+    {
+        s = (DashState *)GetWindowLongPtrW(hWnd, GWLP_USERDATA);
+
+        UINT dpi = 96;
         {
             HMODULE u = GetModuleHandleW(L"user32.dll");
             using Fn = UINT(WINAPI *)(HWND);
             if (auto fn = (Fn)GetProcAddress(u, "GetDpiForWindow"))
-                s->dpi = fn(hWnd);
-            if (!s->dpi)
-                s->dpi = 96;
+                if (UINT v = fn(hWnd))
+                    dpi = v;
         }
+        s->dpi = dpi;
 
-        LOGFONTW lf = {};
-        lf.lfHeight = -MulDiv(9, (int)s->dpi, 72);
-        lf.lfWeight = FW_NORMAL;
-        wcscpy_s(lf.lfFaceName, L"Segoe UI");
-        s->hFont = CreateFontIndirectW(&lf);
-        BuildPalette();
+        DashMakeFonts(s);
         s->hBg = CreateSolidBrush(g_pal.bg);
-        s->hField = CreateSolidBrush(g_pal.field);
-        s->hPanel = CreateSolidBrush(g_pal.panel);
 
-        // Every control is themed here rather than at its call site: the six
-        // scattered calls this replaces covered the combo boxes and edits and
-        // missed every button and check box, which is why those kept painting
-        // black text on the dark background.
-        auto mk = [&](const wchar_t *cls, const wchar_t *txt, DWORD style,
-                      int id) -> HWND
-        {
-            HWND h = CreateWindowExW(0, cls, txt, WS_CHILD | style, 0, 0, 10,
-                                     10, hWnd, (HMENU)(INT_PTR)id,
-                                     cs->hInstance, nullptr);
-            if (h)
-            {
-                SendMessageW(h, WM_SETFONT, (WPARAM)s->hFont, TRUE);
-                ApplyControlTheme(h, cls);
-            }
-            return h;
-        };
+        s->hClose = CreateWindowExW(
+            0, L"BUTTON", L"Close",
+            WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_PUSHBUTTON, 0, 0, 0, 0,
+            hWnd, (HMENU)(INT_PTR)IDC_CLOSE, GetModuleHandle(nullptr), nullptr);
+        SendMessageW(s->hClose, WM_SETFONT, (WPARAM)s->hFont, TRUE);
+        ApplyControlTheme(s->hClose, L"BUTTON");
 
-        s->hPageZones = mk(L"BUTTON", L"Zones", BS_PUSHBUTTON | WS_VISIBLE |
-                                                    WS_TABSTOP, IDC_PAGE_ZONES);
-        s->hPageOptions = mk(L"BUTTON", L"Options",
-                             BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP,
-                             IDC_PAGE_OPTIONS);
-        s->hMonitor = mk(L"COMBOBOX", nullptr,
-                         CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP,
-                         IDC_MONITOR);
+        // Title bar and Alt-Tab. WM_SETICON does not take ownership, so both
+        // handles are kept on the state and destroyed with the window.
+        s->hIcon = MakeHotCornerIcon(GetSystemMetrics(SM_CXICON), true);
+        s->hIconSm = MakeHotCornerIcon(GetSystemMetrics(SM_CXSMICON), true);
+        if (s->hIcon)
+            SendMessageW(hWnd, WM_SETICON, ICON_BIG, (LPARAM)s->hIcon);
+        if (s->hIconSm)
+            SendMessageW(hWnd, WM_SETICON, ICON_SMALL, (LPARAM)s->hIconSm);
 
-        for (int z = 0; z < ZONE_COUNT; z++)
-        {
-            s->hZoneLabel[z] = mk(L"STATIC", ZoneToString((Zone)z), SS_LEFT, 0);
-            s->hZoneAction[z] =
-                mk(L"COMBOBOX", nullptr,
-                   CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP,
-                   IDC_ZONE_ACTION + z);
-            for (int a = 0; a < kActionCount; a++)
-            {
-                SendMessageW(s->hZoneAction[z], CB_ADDSTRING, 0,
-                             (LPARAM)ActionToString(ParseActionType(kActionIds[a])));
-            }
-            s->hZoneArgs[z] = mk(L"EDIT", nullptr,
-                                 WS_BORDER | ES_AUTOHSCROLL | WS_TABSTOP,
-                                 IDC_ZONE_ARGS + z);
-        }
-
-        for (int i = 0; i < kOptCount; i++)
-        {
-            s->hOptSection[i] =
-                kOpts[i].section
-                    ? mk(L"STATIC", kOpts[i].section, SS_LEFT, IDC_OPT_SECTION)
-                    : nullptr;
-
-            if (kOpts[i].isCheck)
-            {
-                s->hOpt[i] = mk(L"BUTTON", kOpts[i].label,
-                                BS_AUTOCHECKBOX | WS_TABSTOP, kOpts[i].id);
-                s->hOptLabel[i] = nullptr;
-            }
-            else
-            {
-                s->hOptLabel[i] = mk(L"STATIC", kOpts[i].label, SS_LEFT, 0);
-                if (kOpts[i].id == IDC_MODIFIER)
-                {
-                    s->hOpt[i] = mk(L"COMBOBOX", nullptr,
-                                    CBS_DROPDOWNLIST | WS_TABSTOP,
-                                    kOpts[i].id);
-                    const wchar_t *mods[] = {L"None", L"Ctrl", L"Alt", L"Shift",
-                                             L"Win"};
-                    for (auto m : mods)
-                        SendMessageW(s->hOpt[i], CB_ADDSTRING, 0, (LPARAM)m);
-                }
-                else
-                {
-                    s->hOpt[i] = mk(L"EDIT", nullptr,
-                                    WS_BORDER | ES_AUTOHSCROLL | WS_TABSTOP,
-                                    kOpts[i].id);
-                }
-            }
-        }
-
-        // Column headers - the argument field previously had no label at all.
-        s->hHdrZone = mk(L"STATIC", L"Zone", SS_LEFT, IDC_HDR_ZONE);
-        s->hHdrAction = mk(L"STATIC", L"Action", SS_LEFT, IDC_HDR_ACTION);
-        s->hHdrArgs = mk(L"STATIC", L"Argument / command", SS_LEFT, IDC_HDR_ARGS);
-
-        s->hTzTitle = mk(L"STATIC", L"Settings for this zone", SS_LEFT,
-                         IDC_TZ_TITLE);
-        s->hTzHint = mk(L"STATIC", L"Leave blank to use the global value.",
-                        SS_LEFT, IDC_TZ_HINT);
-        for (int i = 0; i < kTzCount; i++)
-        {
-            s->hTzLabel[i] = mk(L"STATIC", kTz[i].label, SS_LEFT, 0);
-            if (kTz[i].id == IDC_TZ_MODIFIER)
-            {
-                s->hTz[i] = mk(L"COMBOBOX", nullptr,
-                               CBS_DROPDOWNLIST | WS_TABSTOP, kTz[i].id);
-                const wchar_t *mv[] = {L"Inherit", L"None", L"Ctrl",
-                                       L"Alt",     L"Shift", L"Win"};
-                for (auto v : mv)
-                    SendMessageW(s->hTz[i], CB_ADDSTRING, 0, (LPARAM)v);
-            }
-            else
-            {
-                s->hTz[i] = mk(L"EDIT", nullptr,
-                               WS_BORDER | ES_AUTOHSCROLL | ES_NUMBER |
-                                   WS_TABSTOP,
-                               kTz[i].id);
-            }
-        }
-
-        s->hSave = mk(L"BUTTON", L"Save and Apply",
-                      BS_DEFPUSHBUTTON | WS_VISIBLE | WS_TABSTOP, IDC_SAVE);
-        s->hCancel = mk(L"BUTTON", L"Close",
-                        BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP, IDC_CANCEL);
-        s->hReset = mk(L"BUTTON", L"Reset everything to defaults",
-                       BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP, IDC_RESET);
-
-        // One tooltip control serving every field. Descriptions live next to
-        // the field definitions so a new setting cannot be added without one.
-        s->hTip = CreateWindowExW(WS_EX_TOPMOST, TOOLTIPS_CLASSW, nullptr,
-                                  WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP, 0, 0,
-                                  0, 0, hWnd, nullptr, cs->hInstance, nullptr);
-        if (s->hTip)
-        {
-            SendMessageW(s->hTip, TTM_SETMAXTIPWIDTH, 0, Sc(320, s->dpi));
-            SendMessageW(s->hTip, WM_SETFONT, (WPARAM)s->hFont, TRUE);
-            // A themed tooltip ignores TTM_SETTIPBKCOLOR/TEXTCOLOR outright, so
-            // it kept the system tooltip colours while the rest of the window
-            // followed the palette. Both strings must be empty or theming is
-            // not actually switched off.
-            ThemeControl(s->hTip, L"", L"");
-            SendMessageW(s->hTip, TTM_SETTIPBKCOLOR, (WPARAM)g_pal.panel, 0);
-            SendMessageW(s->hTip, TTM_SETTIPTEXTCOLOR, (WPARAM)g_pal.text, 0);
-            auto tip = [&](HWND ctl, const wchar_t *text)
-            {
-                if (!ctl || !text)
-                    return;
-                TTTOOLINFOW ti = {};
-                ti.cbSize = sizeof(ti);
-                ti.uFlags = TTF_IDISHWND | TTF_SUBCLASS;
-                ti.hwnd = hWnd;
-                ti.uId = (UINT_PTR)ctl;
-                ti.lpszText = const_cast<LPWSTR>(text);
-                SendMessageW(s->hTip, TTM_ADDTOOLW, 0, (LPARAM)&ti);
-            };
-            for (int i = 0; i < kOptCount; i++)
-            {
-                tip(s->hOpt[i], kOpts[i].tip);
-                tip(s->hOptLabel[i], kOpts[i].tip);
-            }
-            for (int i = 0; i < kTzCount; i++)
-            {
-                tip(s->hTz[i], kTz[i].tip);
-                tip(s->hTzLabel[i], kTz[i].tip);
-            }
-            tip(s->hMonitor,
-                L"Which display these zones belong to. Use * to apply one "
-                L"configuration to every monitor.");
-            tip(s->hHdrArgs,
-                L"Extra input for the chosen action: a key combination for "
-                L"Virtual Key Press, a path or URL for Custom Command, or two "
-                L"of either separated by | for the Alternate actions.");
-            tip(s->hReset,
-                L"Discard every zone and option and start again from the "
-                L"defaults. Asks first.");
-        }
-
-        s->hIcon = MakeTrayIcon(true);
-        if (HICON ic = s->hIcon)
-        {
-            SendMessageW(hWnd, WM_SETICON, ICON_SMALL, (LPARAM)ic);
-            SendMessageW(hWnd, WM_SETICON, ICON_BIG, (LPARAM)ic);
-        }
         ApplyModernFrame(hWnd);
-        DashLoad(hWnd, s);
-        DashLayout(hWnd, s);
+        DashBuildSnapshot(s);
         return 0;
     }
 
+    case WM_APP_DASH_REFRESH:
+        if (s)
+        {
+            DashBuildSnapshot(s);
+            InvalidateRect(hWnd, nullptr, TRUE);
+        }
+        return 0;
+
+    case WM_ACTIVATE:
+        // Rebuilt whenever the window comes forward, so editing in Windhawk and
+        // switching back shows the new configuration without a reopen.
+        if (s && LOWORD(wParam) != WA_INACTIVE)
+        {
+            DashBuildSnapshot(s);
+            InvalidateRect(hWnd, nullptr, TRUE);
+        }
+        break;   // DefWindowProc still has focus work to do
+
+    case WM_SIZE:
+        if (s && s->hClose)
+        {
+            RECT rc;
+            GetClientRect(hWnd, &rc);
+            UINT d = s->dpi;
+            int w = Sc(Lay::BtnW, d), h = Sc(Lay::BtnH, d);
+            SetWindowPos(s->hClose, nullptr, rc.right - Sc(Lay::Pad, d) - w,
+                         rc.bottom - Sc(Lay::Pad, d) - h, w, h, SWP_NOZORDER);
+        }
+        return 0;
+
     case WM_ERASEBKGND:
-    {
-        RECT rc;
-        GetClientRect(hWnd, &rc);
-        FillRect((HDC)wParam, &rc,
-                 s && s->hBg ? s->hBg : (HBRUSH)GetStockObject(BLACK_BRUSH));
-        return 1;
-    }
+        return 1;   // WM_PAINT paints every pixel, into a back buffer
 
     case WM_PAINT:
     {
         PAINTSTRUCT ps;
         HDC hdc = BeginPaint(hWnd, &ps);
-        if (s)
-            DashPaintDiagram(hWnd, s, hdc);
+        RECT rc;
+        GetClientRect(hWnd, &rc);
+
+        // Double-buffered: the diagram is redrawn on every mouse move, and
+        // painting it straight to the window flickers badly.
+        HDC mem = CreateCompatibleDC(hdc);
+        HBITMAP bmp = CreateCompatibleBitmap(hdc, rc.right, rc.bottom);
+        HBITMAP oldBmp = (HBITMAP)SelectObject(mem, bmp);
+
+        FillRect(mem, &rc, s->hBg);
+        DashPaintTabs(s, mem, rc);
+        DashPaintDiagram(s, mem);
+        DashPaintDetail(s, mem, rc);
+
+        BitBlt(hdc, 0, 0, rc.right, rc.bottom, mem, 0, 0, SRCCOPY);
+
+        SelectObject(mem, oldBmp);
+        DeleteObject(bmp);
+        DeleteDC(mem);
         EndPaint(hWnd, &ps);
         return 0;
     }
 
     case WM_MOUSEMOVE:
-    case WM_LBUTTONDOWN:
     {
-        if (!s || !s->showZones)
-            break;
         POINT pt = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
-        RECT dg = DashDiagramRect(s->dpi);
-        int hit = -1;
-        // Centres are tested first: they sit inside the span an edge would
-        // otherwise claim, and the first match wins.
-        static const Zone order[ZONE_COUNT] = {
-            ZONE_TOP_LEFT,      ZONE_TOP_RIGHT,     ZONE_BOTTOM_LEFT,
-            ZONE_BOTTOM_RIGHT,  ZONE_CENTER_TOP,    ZONE_CENTER_BOTTOM,
-            ZONE_CENTER_LEFT,   ZONE_CENTER_RIGHT,  ZONE_EDGE_TOP,
-            ZONE_EDGE_BOTTOM,   ZONE_EDGE_LEFT,     ZONE_EDGE_RIGHT};
-        for (int oi = 0; oi < ZONE_COUNT && hit < 0; oi++)
+        int z = DashHitZone(s, pt);
+        if (z != s->hoverZone)
         {
-            Zone z = order[oi];
-            int parts = ZoneHasTwoParts(z) ? 2 : 1;
-            for (int p = 0; p < parts; p++)
-            {
-                RECT r = ZoneRectInDiagram(z, dg, p == 1);
-                if (PtInRect(&r, pt))
-                {
-                    hit = (int)z;
-                    break;
-                }
-            }
+            s->hoverZone = z;
+            InvalidateRect(hWnd, nullptr, FALSE);
         }
-        if (uMsg == WM_MOUSEMOVE)
-        {
-            if (hit != s->hoverZone)
-            {
-                s->hoverZone = hit;
-                // Only the preview changes, so only the preview is repainted.
-                InvalidateRect(hWnd, &dg, TRUE);
-            }
-        }
-        else if (hit >= 0)
-        {
-            DashCaptureZoneTuning(s);
-            s->selZone = hit;
-            DashShowZoneTuning(s);
-            SetFocus(s->hZoneAction[hit]);
-            InvalidateRect(hWnd, nullptr, TRUE);
-        }
+        TRACKMOUSEEVENT tme = {sizeof(tme), TME_LEAVE, hWnd, 0};
+        TrackMouseEvent(&tme);
         return 0;
     }
 
-    case WM_CTLCOLORSTATIC:
-    case WM_CTLCOLORBTN:
-        if (s)
+    case WM_MOUSELEAVE:
+        if (s->hoverZone != -1)
         {
-            // A group heading introduces the fields under it rather than
-            // labelling one of them, and the per-zone hint is an aside. Both
-            // read better set apart from the body text.
-            int cid = GetDlgCtrlID((HWND)lParam);
-            SetTextColor((HDC)wParam, cid == IDC_OPT_SECTION ? g_pal.accent
-                                      : cid == IDC_TZ_HINT   ? g_pal.dim
-                                                             : g_pal.text);
-            SetBkColor((HDC)wParam, g_pal.bg);
-            return (LRESULT)s->hBg;
+            s->hoverZone = -1;
+            InvalidateRect(hWnd, nullptr, FALSE);
         }
-        break;
+        return 0;
 
-    case WM_CTLCOLOREDIT:
-    case WM_CTLCOLORLISTBOX:
-        if (s)
-        {
-            SetTextColor((HDC)wParam, g_pal.fieldText);
-            SetBkColor((HDC)wParam, g_pal.field);
-            return (LRESULT)s->hField;
-        }
-        break;
-
-    case WM_COMMAND:
+    case WM_LBUTTONDOWN:
     {
-        int id = LOWORD(wParam);
-        if (id == IDC_PAGE_ZONES || id == IDC_PAGE_OPTIONS)
+        POINT pt = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+        int tab = DashHitTab(s, pt);
+        if (tab >= 0)
         {
-            s->showZones = (id == IDC_PAGE_ZONES);
-            DashLayout(hWnd, s);
+            if (tab != s->activeTab)
+            {
+                s->activeTab = tab;
+                s->selZone = -1;
+                s->hoverZone = -1;
+                InvalidateRect(hWnd, nullptr, TRUE);
+            }
             return 0;
         }
-        if (id == IDC_MONITOR && HIWORD(wParam) == CBN_SELCHANGE)
+        int z = DashHitZone(s, pt);
+        s->selZone = (z == s->selZone) ? -1 : z;
+        InvalidateRect(hWnd, nullptr, TRUE);
+        return 0;
+    }
+
+    case WM_KEYDOWN:
+        // Left/right walk the tab strip, which is what a tab strip should do.
+        if ((wParam == VK_LEFT || wParam == VK_RIGHT) && !s->displays.empty())
         {
-            DashLoadZones(s);
+            int n = (int)s->displays.size();
+            s->activeTab =
+                (s->activeTab + (wParam == VK_RIGHT ? 1 : n - 1)) % n;
+            s->selZone = -1;
             InvalidateRect(hWnd, nullptr, TRUE);
             return 0;
         }
-        // (int) because IDC_ZONE_ACTION is a DashId and ZONE_COUNT is a Zone:
-        // C++20 deprecates arithmetic between two different enumeration types,
-        // and the mod repository's CI fails the build on any warning.
-        if (id >= IDC_ZONE_ACTION && id < IDC_ZONE_ACTION + (int)ZONE_COUNT)
-        {
-            if (HIWORD(wParam) == CBN_SELCHANGE ||
-                HIWORD(wParam) == CBN_SETFOCUS)
-            {
-                if (HIWORD(wParam) == CBN_SETFOCUS)
-                {
-                    DashCaptureZoneTuning(s);
-                    s->selZone = id - IDC_ZONE_ACTION;
-                    DashShowZoneTuning(s);
-                }
-                InvalidateRect(hWnd, nullptr, TRUE);
-                return 0;
-            }
-        }
-        if (id == IDC_SAVE)
-        {
-            DashSave(hWnd, s);
-            return 0;
-        }
-        if (id == IDC_CANCEL)
+        if (wParam == VK_ESCAPE)
         {
             DestroyWindow(hWnd);
             return 0;
         }
-        if (id == IDC_RESET)
+        break;
+
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLORSTATIC:
+        SetTextColor((HDC)wParam, g_pal.text);
+        SetBkColor((HDC)wParam, g_pal.bg);
+        return (LRESULT)s->hBg;
+
+    case WM_COMMAND:
+        // IDCANCEL is what IsDialogMessage turns Escape into.
+        if (LOWORD(wParam) == IDC_CLOSE || LOWORD(wParam) == IDCANCEL)
         {
-            if (MessageBoxW(hWnd,
-                            L"Discard every zone and option and start again "
-                            L"from the defaults?",
-                            L"Win-X Hot Corners", MB_YESNO | MB_ICONQUESTION) ==
-                IDYES)
-            {
-                ClearStoredConfig();
-                ReloadConfig();
-                RequestRebuild();
-                DashLoad(hWnd, s);
-            }
+            DestroyWindow(hWnd);
             return 0;
         }
         break;
-    }
 
     case WM_DPICHANGED:
     {
         s->dpi = HIWORD(wParam);
-        if (s->hFont)
-            DeleteObject(s->hFont);
-        LOGFONTW lf = {};
-        lf.lfHeight = -MulDiv(9, (int)s->dpi, 72);
-        wcscpy_s(lf.lfFaceName, L"Segoe UI");
-        s->hFont = CreateFontIndirectW(&lf);
-        EnumChildWindows(hWnd, DashSetChildFont, (LPARAM)s->hFont);
-        RECT *r = (RECT *)lParam;
-        SetWindowPos(hWnd, nullptr, r->left, r->top, r->right - r->left,
-                     r->bottom - r->top, SWP_NOZORDER | SWP_NOACTIVATE);
-        DashLayout(hWnd, s);
+        DashMakeFonts(s);
+        SendMessageW(s->hClose, WM_SETFONT, (WPARAM)s->hFont, TRUE);
+        RECT *nr = (RECT *)lParam;
+        SetWindowPos(hWnd, nullptr, nr->left, nr->top, nr->right - nr->left,
+                     nr->bottom - nr->top, SWP_NOZORDER | SWP_NOACTIVATE);
+        InvalidateRect(hWnd, nullptr, TRUE);
         return 0;
     }
 
-    case WM_SIZE:
-        if (s)
-            DashLayout(hWnd, s);
+    case WM_SETTINGCHANGE:
+        // The user switched between light and dark while the window was open.
+        if (lParam && wcscmp((const wchar_t *)lParam, L"ImmersiveColorSet") == 0)
+        {
+            BuildPalette();
+            if (s->hBg)
+                DeleteObject(s->hBg);
+            s->hBg = CreateSolidBrush(g_pal.bg);
+            ApplyModernFrame(hWnd);
+            InvalidateRect(hWnd, nullptr, TRUE);
+        }
         return 0;
 
     case WM_DESTROY:
@@ -4577,19 +5137,27 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
         {
             if (s->hFont)
                 DeleteObject(s->hFont);
+            if (s->hFontBold)
+                DeleteObject(s->hFontBold);
+            if (s->hFontSmall)
+                DeleteObject(s->hFontSmall);
+            if (s->hFontVert)
+                DeleteObject(s->hFontVert);
             if (s->hBg)
                 DeleteObject(s->hBg);
-            if (s->hField)
-                DeleteObject(s->hField);
-            if (s->hPanel)
-                DeleteObject(s->hPanel);
             if (s->hIcon)
                 DestroyIcon(s->hIcon);
+            if (s->hIconSm)
+                DestroyIcon(s->hIconSm);
+            s->hFont = s->hFontBold = s->hFontSmall = s->hFontVert = nullptr;
+            s->hBg = nullptr;
+            s->hIcon = s->hIconSm = nullptr;
         }
         g_hDashWnd = nullptr;
         PostQuitMessage(0);
         return 0;
     }
+
     return DefWindowProcW(hWnd, uMsg, wParam, lParam);
 }
 
@@ -4642,9 +5210,9 @@ static DWORD WINAPI DashThread(LPVOID)
     int x = (GetSystemMetrics(SM_CXSCREEN) - w) / 2;
     int y = (GetSystemMetrics(SM_CYSCREEN) - h) / 2;
 
-    HWND hWnd = CreateWindowExW(0, kClass, L"Win-X Hot Corners — Settings",
-                                style, x, y, w, h, nullptr, nullptr, hInst,
-                                &state);
+    HWND hWnd = CreateWindowExW(0, kClass,
+                                L"Win-X Hot Corners — Zones & settings", style,
+                                x, y, w, h, nullptr, nullptr, hInst, &state);
 
     if (!hWnd)
     {
@@ -4657,6 +5225,9 @@ static DWORD WINAPI DashThread(LPVOID)
     g_hDashWnd = hWnd;
     ShowWindow(hWnd, SW_SHOW);
     SetForegroundWindow(hWnd);
+    // Focus the window itself rather than the Close button, so the arrow keys
+    // reach WM_KEYDOWN and can walk the tab strip. Tab still moves to Close.
+    SetFocus(hWnd);
 
     MSG msg;
     while (GetMessageW(&msg, nullptr, 0, 0))
@@ -4782,10 +5353,12 @@ static DWORD WINAPI TrayThread(LPVOID)
 BOOL WhTool_ModInit()
 {
     Wh_Log(L"Win-X Hot Corners v" WH_MOD_VERSION);
-    Wh_Log(L"This mod has no Settings page. Right-click its tray icon (next to "
-           L"the clock) and choose \"Zones & settings...\".");
+    Wh_Log(L"Zones and timings live on this mod's Settings page. Right-click "
+           L"its tray icon (next to the clock) and choose \"Zones & "
+           L"settings...\" to see what they add up to.");
 
     InitializeCriticalSection(&g_settingsLock);
+    InitializeCriticalSection(&g_reloadLock);
     InitializeCriticalSection(&g_zonesLock);
     InitializeCriticalSection(&g_queueLock);
 
@@ -4833,10 +5406,31 @@ void WhTool_ModSettingsChanged()
     // must not block on ours.
     if (g_hDetectWnd)
         PostMessage(g_hDetectWnd, WM_APP_REBUILD, 0, 0);
+    // An open dashboard is showing the configuration that just changed.
+    if (g_hDashWnd)
+        PostMessage(g_hDashWnd, WM_APP_DASH_REFRESH, 0, 0);
 }
 
 void WhTool_ModUninit()
 {
+    // Declared before the first wait, and every wait feeds it. The tray wait
+    // used to sit above this and only log its timeout - so a tray thread still
+    // blocked on g_reloadLock, or still inside its menu, did not stop the
+    // critical sections below from being deleted out from under it.
+    bool allStopped = true;
+
+    // Only a clean exit counts. WAIT_FAILED means the wait itself broke, which
+    // says nothing about whether the thread is finished, so treat it the same
+    // as a timeout rather than as success.
+    auto waitFor = [&allStopped](HANDLE h, const wchar_t *what)
+    {
+        if (WaitForSingleObject(h, 3000) != WAIT_OBJECT_0)
+        {
+            Wh_Log(L"%s did not exit cleanly", what);
+            allStopped = false;
+        }
+    };
+
     if (g_hStopEvent)
         SetEvent(g_hStopEvent);
 
@@ -4845,16 +5439,13 @@ void WhTool_ModUninit()
 
     if (g_hTrayThread)
     {
-        if (WaitForSingleObject(g_hTrayThread, 3000) == WAIT_TIMEOUT)
-            Wh_Log(L"Tray thread exit timed out");
+        waitFor(g_hTrayThread, L"Tray thread");
         CloseHandle(g_hTrayThread);
         g_hTrayThread = nullptr;
     }
 
     if (g_dwDetectThreadId)
         PostThreadMessage(g_dwDetectThreadId, WM_QUIT, 0, 0);
-
-    bool allStopped = true;
 
     // The dashboard is a window with its own message loop on its own thread,
     // and it takes g_settingsLock and g_zonesLock. Nothing below may free
@@ -4865,22 +5456,14 @@ void WhTool_ModUninit()
 
     if (g_hDashThread)
     {
-        if (WaitForSingleObject(g_hDashThread, 3000) == WAIT_TIMEOUT)
-        {
-            Wh_Log(L"Dashboard thread exit timed out");
-            allStopped = false;
-        }
+        waitFor(g_hDashThread, L"Dashboard thread");
         CloseHandle(g_hDashThread);
         g_hDashThread = nullptr;
     }
 
     if (g_hDetectThread)
     {
-        if (WaitForSingleObject(g_hDetectThread, 3000) == WAIT_TIMEOUT)
-        {
-            Wh_Log(L"Detection thread exit timed out");
-            allStopped = false;
-        }
+        waitFor(g_hDetectThread, L"Detection thread");
         CloseHandle(g_hDetectThread);
         g_hDetectThread = nullptr;
     }
@@ -4889,11 +5472,7 @@ void WhTool_ModUninit()
     {
         // Can legitimately still be inside ShellExecuteEx (a UAC prompt keeps
         // it there indefinitely).
-        if (WaitForSingleObject(g_hWorkerThread, 3000) == WAIT_TIMEOUT)
-        {
-            Wh_Log(L"Worker thread exit timed out");
-            allStopped = false;
-        }
+        waitFor(g_hWorkerThread, L"Worker thread");
         CloseHandle(g_hWorkerThread);
         g_hWorkerThread = nullptr;
     }
@@ -4922,6 +5501,7 @@ void WhTool_ModUninit()
 
     DeleteCriticalSection(&g_queueLock);
     DeleteCriticalSection(&g_zonesLock);
+    DeleteCriticalSection(&g_reloadLock);
     DeleteCriticalSection(&g_settingsLock);
 
     Wh_Log(L"Uninit done");

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         1.1.7
+// @version         1.1.8
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -934,7 +934,10 @@ static constexpr DWORD kTickMs = 16;
 static constexpr DWORD kIdleTickMs = 100;
 static HANDLE g_hDetectThread = nullptr;
 static DWORD g_dwDetectThreadId = 0;
-static HWND g_hDetectWnd = nullptr;
+// Written by the detection thread, read from Windhawk's thread and the tray
+// thread. Same reasoning as g_hDashWnd: without release/acquire, a reader can
+// still see nullptr just after startup and silently drop a rebuild request.
+static std::atomic<HWND> g_hDetectWnd{nullptr};
 static HANDLE g_hStopEvent = nullptr;
 
 // Prints the monitor list at load and on display changes, so a name can be
@@ -3154,7 +3157,7 @@ static DWORD WINAPI DetectThread(LPVOID)
     g_hDetectWnd = CreateWindowEx(WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE, kClass,
                                   nullptr, WS_POPUP, 0, 0, 0, 0, nullptr,
                                   nullptr, hInst, nullptr);
-    if (!g_hDetectWnd)
+    if (!g_hDetectWnd.load())
     {
         Wh_Log(L"Failed to create detection window");
         UnregisterClass(kClass, hInst);
@@ -3196,7 +3199,7 @@ static DWORD WINAPI DetectThread(LPVOID)
     }
 
 done:
-    DestroyWindow(g_hDetectWnd);
+    DestroyWindow(g_hDetectWnd.load());
     g_hDetectWnd = nullptr;
     UnregisterClass(kClass, hInst);
     Wh_Log(L"Detection thread exiting");
@@ -3218,7 +3221,9 @@ done:
 
 static HANDLE g_hTrayThread = nullptr;
 static DWORD g_dwTrayThreadId = 0;
-static HWND g_hTrayWnd = nullptr;
+// Written by the tray thread, read from Windhawk's thread via
+// WhTool_ModSettingsChanged -> UpdateTrayIcon.
+static std::atomic<HWND> g_hTrayWnd{nullptr};
 static UINT g_taskbarCreatedMsg = 0;
 static constexpr UINT WM_APP_TRAY = WM_APP + 10;
 static constexpr UINT_PTR kTrayIconId = 1;
@@ -3380,7 +3385,7 @@ static HICON MakeTrayIcon(bool enabled)
 static void FillTrayIconData(NOTIFYICONDATAW &nid)
 {
     nid.cbSize = sizeof(nid);
-    nid.hWnd = g_hTrayWnd;
+    nid.hWnd = g_hTrayWnd.load();
     nid.uID = (UINT)kTrayIconId;
     if (g_trayUseGuid)
     {
@@ -3391,7 +3396,7 @@ static void FillTrayIconData(NOTIFYICONDATAW &nid)
 
 static void UpdateTrayIcon(bool add)
 {
-    if (!g_hTrayWnd)
+    if (!g_hTrayWnd.load())
         return;
 
     bool active = g_trayEnabled && GetTickCount64() >= g_suspendUntil.load();
@@ -3758,7 +3763,7 @@ static void ShowTrayMenu(POINT pt)
     // UpdateTrayIcon has fallen back to plain uID identity makes the lookup
     // fail, and the menu quietly stops anchoring - the one case this exists for.
     NOTIFYICONIDENTIFIER nii = {sizeof(nii)};
-    nii.hWnd = g_hTrayWnd;
+    nii.hWnd = g_hTrayWnd.load();
     if (g_trayUseGuid)
         nii.guidItem = kTrayIconGuid;
     else
@@ -3799,9 +3804,10 @@ static void ShowTrayMenu(POINT pt)
     }
 
     // Required so the menu dismisses when the user clicks elsewhere.
-    SetForegroundWindow(g_hTrayWnd);
-    TrackPopupMenu(hMenu, align, pt.x, pt.y, 0, g_hTrayWnd, nullptr);
-    PostMessage(g_hTrayWnd, WM_NULL, 0, 0);
+    HWND hTray = g_hTrayWnd.load();
+    SetForegroundWindow(hTray);
+    TrackPopupMenu(hMenu, align, pt.x, pt.y, 0, hTray, nullptr);
+    PostMessage(hTray, WM_NULL, 0, 0);
 
     DestroyMenu(hMenu);
 }
@@ -3809,14 +3815,14 @@ static void ShowTrayMenu(POINT pt)
 // The zone snapshot carries drag/settle, so a change there needs a rebuild.
 static void RequestRebuild()
 {
-    if (g_hDetectWnd)
-        PostMessage(g_hDetectWnd, WM_APP_REBUILD, 0, 0);
+    if (HWND hDetect = g_hDetectWnd.load())
+        PostMessage(hDetect, WM_APP_REBUILD, 0, 0);
 }
 
 static void CancelSuspendTimer()
 {
-    if (g_hTrayWnd)
-        KillTimer(g_hTrayWnd, kSuspendTimerId);
+    if (HWND hTray = g_hTrayWnd.load())
+        KillTimer(hTray, kSuspendTimerId);
 }
 
 static void HandleTrayCommand(UINT id)
@@ -3850,8 +3856,8 @@ static void HandleTrayCommand(UINT id)
         // on their own - but nothing redrew the icon, which stayed dimmed and
         // still said "paused" for the rest of the session. Suspension is
         // exactly when the icon is the thing being looked at.
-        if (g_hTrayWnd)
-            SetTimer(g_hTrayWnd, kSuspendTimerId,
+        if (HWND hTray = g_hTrayWnd.load())
+            SetTimer(hTray, kSuspendTimerId,
                      (UINT)mins * 60 * 1000 + 1000, nullptr);
         Wh_Log(L"Tray: suspended for %d minutes", mins);
         break;
@@ -5388,6 +5394,18 @@ static DWORD WINAPI DashThread(LPVOID)
     }
 
     g_hDashWnd = hWnd;
+
+    // Uninit closes this window by posting WM_CLOSE to g_hDashWnd, which is
+    // only useful once the handle above is published. Opening the dashboard and
+    // unloading the mod in the same instant used to slip between the two: the
+    // post found nullptr, nothing else ever told this thread to stop, and the
+    // loop below parked in GetMessageW forever - so uninit timed out, took its
+    // "leak rather than free from under a live thread" path, and left the
+    // window on screen. The stop event is set before that post, so checking it
+    // here catches every interleaving.
+    if (g_hStopEvent && WaitForSingleObject(g_hStopEvent, 0) == WAIT_OBJECT_0)
+        PostMessage(hWnd, WM_CLOSE, 0, 0);
+
     ShowWindow(hWnd, SW_SHOW);
     SetForegroundWindow(hWnd);
     // Focus the window itself rather than the Close button, so the arrow keys
@@ -5512,7 +5530,7 @@ static DWORD WINAPI TrayThread(LPVOID)
 
     g_hTrayWnd = CreateWindowEx(WS_EX_TOOLWINDOW, kClass, nullptr, WS_POPUP, 0,
                                 0, 0, 0, nullptr, nullptr, hInst, nullptr);
-    if (!g_hTrayWnd)
+    if (!g_hTrayWnd.load())
     {
         Wh_Log(L"Tray: failed to create the icon's window");
         UnregisterClass(kClass, hInst);
@@ -5534,7 +5552,7 @@ static DWORD WINAPI TrayThread(LPVOID)
     Shell_NotifyIconW(NIM_DELETE, &nid);
 
     CancelSuspendTimer();
-    DestroyWindow(g_hTrayWnd);
+    DestroyWindow(g_hTrayWnd.load());
     g_hTrayWnd = nullptr;
     UnregisterClass(kClass, hInst);
     return 0;
@@ -5598,8 +5616,8 @@ void WhTool_ModSettingsChanged()
     // The zone rebuild has to happen on the detection thread, which owns the
     // DPI context and the monitor list. Post, never send — Windhawk's thread
     // must not block on ours.
-    if (g_hDetectWnd)
-        PostMessage(g_hDetectWnd, WM_APP_REBUILD, 0, 0);
+    if (HWND hDetect = g_hDetectWnd.load())
+        PostMessage(hDetect, WM_APP_REBUILD, 0, 0);
     // An open dashboard is showing the configuration that just changed.
     if (HWND hDash = g_hDashWnd.load())
         PostMessage(hDash, WM_APP_DASH_REFRESH, 0, 0);
@@ -5616,13 +5634,17 @@ void WhTool_ModUninit()
     // Only a clean exit counts. WAIT_FAILED means the wait itself broke, which
     // says nothing about whether the thread is finished, so treat it the same
     // as a timeout rather than as success.
+    // Returns whether the thread actually finished, so the caller can decide
+    // whether closing its handle is safe. Closing regardless would contradict
+    // the leak-rather-than-free policy below and throw away the only handle to
+    // a thread this code has just decided is still running.
     auto waitFor = [&allStopped](HANDLE h, const wchar_t *what)
     {
-        if (WaitForSingleObject(h, 3000) != WAIT_OBJECT_0)
-        {
-            Wh_Log(L"%s did not exit cleanly", what);
-            allStopped = false;
-        }
+        if (WaitForSingleObject(h, 3000) == WAIT_OBJECT_0)
+            return true;
+        Wh_Log(L"%s did not exit cleanly", what);
+        allStopped = false;
+        return false;
     };
 
     // Before anything is told to stop: a zone still holding a peek has to be
@@ -5632,10 +5654,10 @@ void WhTool_ModUninit()
     // A timeout rather than a plain SendMessage, because a wedged detection
     // thread must not turn unloading into a hang; it is already the case that
     // that thread never waits on anything Windhawk's thread holds.
-    if (g_hDetectWnd)
+    if (HWND hDetect = g_hDetectWnd.load())
     {
         DWORD_PTR unused = 0;
-        SendMessageTimeout(g_hDetectWnd, WM_APP_RELEASE_HOLD, 0, 0,
+        SendMessageTimeout(hDetect, WM_APP_RELEASE_HOLD, 0, 0,
                            SMTO_ABORTIFHUNG, 500, &unused);
     }
 
@@ -5647,9 +5669,11 @@ void WhTool_ModUninit()
 
     if (g_hTrayThread)
     {
-        waitFor(g_hTrayThread, L"Tray thread");
-        CloseHandle(g_hTrayThread);
-        g_hTrayThread = nullptr;
+        if (waitFor(g_hTrayThread, L"Tray thread"))
+        {
+            CloseHandle(g_hTrayThread);
+            g_hTrayThread = nullptr;
+        }
     }
 
     if (g_dwDetectThreadId)
@@ -5664,25 +5688,31 @@ void WhTool_ModUninit()
 
     if (g_hDashThread)
     {
-        waitFor(g_hDashThread, L"Dashboard thread");
-        CloseHandle(g_hDashThread);
-        g_hDashThread = nullptr;
+        if (waitFor(g_hDashThread, L"Dashboard thread"))
+        {
+            CloseHandle(g_hDashThread);
+            g_hDashThread = nullptr;
+        }
     }
 
     if (g_hDetectThread)
     {
-        waitFor(g_hDetectThread, L"Detection thread");
-        CloseHandle(g_hDetectThread);
-        g_hDetectThread = nullptr;
+        if (waitFor(g_hDetectThread, L"Detection thread"))
+        {
+            CloseHandle(g_hDetectThread);
+            g_hDetectThread = nullptr;
+        }
     }
 
     if (g_hWorkerThread)
     {
         // Can legitimately still be inside ShellExecuteEx (a UAC prompt keeps
         // it there indefinitely).
-        waitFor(g_hWorkerThread, L"Worker thread");
-        CloseHandle(g_hWorkerThread);
-        g_hWorkerThread = nullptr;
+        if (waitFor(g_hWorkerThread, L"Worker thread"))
+        {
+            CloseHandle(g_hWorkerThread);
+            g_hWorkerThread = nullptr;
+        }
     }
 
     // Freeing objects a live thread is still using is undefined behaviour

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         1.1.3
+// @version         1.1.4
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -429,10 +429,6 @@ like buying me a coffee:
 - [Ko-fi](https://ko-fi.com/losthusky_)
 - [Buy Me a Coffee](https://www.buymeacoffee.com/losthusky_)
 - [Playto](https://www.playto.so/losthusky_)
-
-<!-- Plain links rather than badge images on purpose: this repository only allows
-     images from i.imgur.com and raw.githubusercontent.com, so a shields.io badge
-     would not render. To add a platform, add a bullet. -->
 */
 // ==/WindhawkModReadme==
 
@@ -5800,5 +5796,6 @@ void Wh_ModUninit() {
     WhTool_ModUninit();
     ExitProcess(0);
 }
+
 
 

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         4.4.4
+// @version         4.4.5
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -263,7 +263,7 @@ Hot corners are disabled when any excluded process is the foreground window.
 
 # Changelog
 
-## 4.4.4
+## 4.4.5
 
 First release. Earlier version numbers exist only in the development
 repository and were never published, so there is nothing to upgrade from.
@@ -621,6 +621,13 @@ struct HitZone
     RECT rect;
     std::function<void()> exec;
     std::wstring label;  // "Dell U2720Q Top-left corner -> Task View"
+
+    // Carried only so SameZoneSet can tell two sets apart. The label holds the
+    // action's *name* but not its arguments, so without these, changing a
+    // custom command or a key combination produced a set that compared equal -
+    // the rebuild was skipped and the old executor stayed live.
+    CornerAction action = CornerAction::Nothing;
+    std::wstring args;
 
     // Resolved once at build time - zone override if set, otherwise the
     // global. The detection loop therefore never has to know that per-zone
@@ -2228,6 +2235,8 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
             hz.modifier =
                 tn.modifier >= 0 ? tn.modifier : g_settings.requireModifier;
 
+            hz.action = zc->action;
+            hz.args = zc->args;
             hz.label = mon.id + L" " + ZoneToString(z) + L" -> " +
                        ActionToString(zc->action);
             set->zones.push_back(std::move(hz));
@@ -2321,16 +2330,28 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
 static bool SameZoneSet(const ZoneSet *a, const ZoneSet *b)
 {
     if (!a || !b || a->zones.size() != b->zones.size() ||
+        a->monitors.size() != b->monitors.size() ||
         a->disableDuringDrag != b->disableDuringDrag)
         return false;
+
+    // The dashboard reads the monitor summaries, so a display renamed or
+    // resized has to publish even when no zone rectangle moved.
+    for (size_t i = 0; i < a->monitors.size(); i++)
+    {
+        const auto &x = a->monitors[i], &y = b->monitors[i];
+        if (x.id != y.id || x.width != y.width || x.height != y.height ||
+            x.primary != y.primary)
+            return false;
+    }
+
     for (size_t i = 0; i < a->zones.size(); i++)
     {
         const HitZone &x = a->zones[i], &y = b->zones[i];
         if (memcmp(&x.rect, &y.rect, sizeof(RECT)) != 0 || x.zone != y.zone ||
-            x.monitor != y.monitor || x.delay != y.delay ||
-            x.settle != y.settle || x.knock != y.knock ||
-            x.cooldown != y.cooldown || x.modifier != y.modifier ||
-            x.label != y.label)
+            x.monitor != y.monitor || x.action != y.action ||
+            x.args != y.args || x.delay != y.delay || x.settle != y.settle ||
+            x.knock != y.knock || x.cooldown != y.cooldown ||
+            x.modifier != y.modifier || x.label != y.label)
             return false;
     }
     return true;
@@ -4780,6 +4801,11 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
         if (lParam && wcscmp((const wchar_t *)lParam, L"ImmersiveColorSet") == 0)
         {
             BuildPalette();
+            // The palette alone does not reach the Close button: it keeps the
+            // theme it was given at creation, so switching light to dark left a
+            // light button on a dark window.
+            SetProcessDarkMode(!g_lightTheme);
+            ApplyControlTheme(s->hClose, L"BUTTON");
             if (s->hBg)
                 DeleteObject(s->hBg);
             s->hBg = CreateSolidBrush(g_pal.bg);

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -4940,7 +4940,10 @@ static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
             InvalidateRect(hWnd, nullptr, TRUE);
             return 0;
         }
-        if (id >= IDC_ZONE_ACTION && id < IDC_ZONE_ACTION + ZONE_COUNT)
+        // (int) because IDC_ZONE_ACTION is a DashId and ZONE_COUNT is a Zone:
+        // C++20 deprecates arithmetic between two different enumeration types,
+        // and the mod repository's CI fails the build on any warning.
+        if (id >= IDC_ZONE_ACTION && id < IDC_ZONE_ACTION + (int)ZONE_COUNT)
         {
             if (HIWORD(wParam) == CBN_SELCHANGE ||
                 HIWORD(wParam) == CBN_SETFOCUS)

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         1.1.4
+// @version         1.1.6
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -187,6 +187,7 @@ the window and the next one puts it back.
 | Switch to Last Window | Jump straight back to the previous window (Alt+Tab) |
 | Task Switcher | Persistent switcher you can click through (Ctrl+Alt+Tab) |
 | Virtual Desktop — Next / Previous / New | Move between or create desktops |
+| Close Virtual Desktop | Close the current desktop |
 
 **Windows**
 
@@ -993,6 +994,12 @@ static RECT g_topoWorkArea = {};
 
 static constexpr UINT WM_APP_REBUILD = WM_APP + 1;
 
+// Sent (not posted) from WhTool_ModUninit while both threads are still alive,
+// so a hold that is still engaged gets its release queued before anything is
+// told to stop. Posting would not do - the detection thread would never get
+// round to it.
+static constexpr UINT WM_APP_RELEASE_HOLD = WM_APP + 2;
+
 // Forward declarations
 static const wchar_t *ZoneToString(Zone z);
 static const wchar_t *ActionToString(CornerAction a);
@@ -1687,6 +1694,24 @@ static void SendKeys(const std::vector<WORD> &vks)
         // Part of the batch already: it presses and releases this one itself.
         if (std::find(vks.begin(), vks.end(), mod) != vks.end())
             continue;
+        // Windows opens the Start menu on a Win key-up that had no other key
+        // pressed between it and the matching key-down - and that is exactly
+        // the shape produced here, because this release is the first thing in
+        // the batch. So a Win-guarded zone bound to anything without Win in it
+        // (Mute, Lock, Close window) would open Start and then run the action.
+        // Pressing and releasing Ctrl first makes the Win-up no longer solo;
+        // Ctrl alone does nothing, and Ctrl+Win is not a shortcut either. This
+        // is the same masking trick AutoHotkey uses.
+        if (mod == VK_LWIN || mod == VK_RWIN)
+        {
+            INPUT mask = {};
+            mask.type = INPUT_KEYBOARD;
+            mask.ki.wVk = VK_CONTROL;
+            inputs.push_back(mask);
+            mask.ki.dwFlags = KEYEVENTF_KEYUP;
+            inputs.push_back(mask);
+        }
+
         INPUT up = {};
         up.type = INPUT_KEYBOARD;
         up.ki.wVk = mod;
@@ -2679,16 +2704,23 @@ static bool TopologyChanged()
 // Action Worker Thread
 // =====================================================================
 
-static void EnqueueAction(const HitZone &hz)
+// Returns whether the job was actually taken. The caller needs to know: a hold
+// whose entry was dropped must not go on to queue a release, or the zone
+// undoes something that never happened.
+static bool EnqueueAction(const HitZone &hz)
 {
     EnterCriticalSection(&g_queueLock);
     // A release is never dropped. The cap is there to bound a runaway burst of
     // new work, but discarding the half that undoes something already done is
-    // how a peeked desktop gets stuck with no way back.
-    if (g_queue.size() < kMaxQueue || hz.isRelease)
+    // how a peeked desktop gets stuck with no way back. It cannot grow without
+    // bound either: a release is only queued for an entry that was accepted,
+    // so there is at most one outstanding per hold zone.
+    const bool queued = (g_queue.size() < kMaxQueue) || hz.isRelease;
+    if (queued)
         g_queue.push_back(hz);
     LeaveCriticalSection(&g_queueLock);
     SetEvent(g_hWorkEvent);
+    return queued;
 }
 
 // A hold zone's second half, queued when the pointer leaves. The copy carries
@@ -2717,13 +2749,12 @@ static DWORD WINAPI ActionWorkerThread(LPVOID)
     for (;;)
     {
         DWORD r = WaitForMultipleObjects(2, waits, FALSE, INFINITE);
-        if (r == WAIT_OBJECT_0 || r == WAIT_FAILED)
-        {
-            // Release any keep-awake request this thread was holding, so
-            // unloading the mod never leaves the machine unable to sleep.
-            SetThreadExecutionState(ES_CONTINUOUS);
-            break;
-        }
+
+        // On the way out, still drain the queue - but run only the release
+        // half of a hold. Uninit queues that release deliberately, and dropping
+        // it is what strands a peeked desktop; anything else is new work nobody
+        // is waiting for.
+        const bool stopping = (r == WAIT_OBJECT_0 || r == WAIT_FAILED);
 
         for (;;)
         {
@@ -2739,6 +2770,8 @@ static DWORD WINAPI ActionWorkerThread(LPVOID)
             LeaveCriticalSection(&g_queueLock);
             if (!have)
                 break;
+            if (stopping && !job.isRelease)
+                continue;
 
             // The gates live here, not on the detection thread, so a slow
             // SHQueryUserNotificationState or OpenProcess can never delay the
@@ -2818,6 +2851,14 @@ static DWORD WINAPI ActionWorkerThread(LPVOID)
                 holdActive = false;
             else if (job.engagesHold)
                 holdActive = true;
+        }
+
+        if (stopping)
+        {
+            // Release any keep-awake request this thread was holding, so
+            // unloading the mod never leaves the machine unable to sleep.
+            SetThreadExecutionState(ES_CONTINUOUS);
+            break;
         }
     }
     CoUninitialize();
@@ -3020,11 +3061,14 @@ static DWORD DetectTick()
     // behind to undo. This tracks that a release has been *queued*; whether it
     // runs is the worker's call, since the gates it would be suppressed by live
     // there and this thread must not wait on them.
-    g_holdEngaged = (bool)zones->zones[idx].releaseExec;
-
     HitZone job = zones->zones[idx];
     job.engagesHold = (bool)job.releaseExec;
-    EnqueueAction(job);
+
+    // Only owe a release if the entry was actually accepted. A full queue drops
+    // the entry, and arming the release anyway would leave the zone undoing
+    // something that never ran. The worker gates this a second time, from the
+    // far side of the fullscreen and excluded-app checks.
+    g_holdEngaged = EnqueueAction(job) && job.engagesHold;
     return next;
 }
 
@@ -3038,6 +3082,19 @@ static LRESULT CALLBACK DetectWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
     if (uMsg == WM_APP_REBUILD)
     {
         RebuildZones();
+        return 0;
+    }
+    // Unload path. Every other way of stopping detection releases a held zone
+    // on the way out; without this one, unloading the mod with the pointer
+    // parked in a Show Desktop hold zone left every window minimised and
+    // nothing running that could put them back.
+    if (uMsg == WM_APP_RELEASE_HOLD)
+    {
+        std::shared_ptr<const ZoneSet> zones;
+        EnterCriticalSection(&g_zonesLock);
+        zones = g_zones;
+        LeaveCriticalSection(&g_zonesLock);
+        ReleaseHeldZone(zones);
         return 0;
     }
     // Both of these arrive as a SendMessage broadcast, so rebuilding inline
@@ -5541,6 +5598,20 @@ void WhTool_ModUninit()
             allStopped = false;
         }
     };
+
+    // Before anything is told to stop: a zone still holding a peek has to be
+    // undone while both the detection thread and the worker are alive. The
+    // release cannot run here - Keep awake is per-thread and Custom command
+    // needs the worker's COM apartment - so this only asks for it to be queued.
+    // A timeout rather than a plain SendMessage, because a wedged detection
+    // thread must not turn unloading into a hang; it is already the case that
+    // that thread never waits on anything Windhawk's thread holds.
+    if (g_hDetectWnd)
+    {
+        DWORD_PTR unused = 0;
+        SendMessageTimeout(g_hDetectWnd, WM_APP_RELEASE_HOLD, 0, 0,
+                           SMTO_ABORTIFHUNG, 500, &unused);
+    }
 
     if (g_hStopEvent)
         SetEvent(g_hStopEvent);

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,7 +2,7 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         4.4.1
+// @version         4.4.2
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @donateUrl       https://ko-fi.com/losthusky_
@@ -85,13 +85,6 @@ ready; the moment one display is listed, the old layout is ignored.
 
 The startup log names any globals you had customised in the old version, since
 those now come from the settings page and need setting again there.
-
-This is deliberate. Twelve zones on each of up to eight displays, each with a
-forty-entry action list and six timing overrides, is not something a settings
-form can present without becoming a tree nobody can navigate — and a Windhawk
-mod cannot write its own settings from code, so any change made in the mod's
-own UI could not be written back. Two places to configure one thing, disagreeing
-the moment you touched either. Now there is one.
 
 If the tray icon is hidden, it is in the overflow area — drag it onto the
 taskbar to keep it there.
@@ -200,8 +193,13 @@ display layout changes, which is the place to copy an exact name from when you
 are filling in the settings page:
 
 ```
-Monitor 1 [PRIMARY] id='Dell U2720Q' device=\\.\DISPLAY1 (0,0)-(3840,2160)
-Monitor 2           id='BOE0998'     device=\\.\DISPLAY2 (3840,0)-(5760,1080)
++-- Your monitors ---------------------------------------
+|  Copy a name into the "Display" field on this mod's settings page.
+|  Use  *  there to apply one configuration to every monitor.
+|
+|   1. "Dell U2720Q"   [primary]   3840 x 2160  at (0, 0)
+|   2. "BOE0998"                   1920 x 1080  at (3840, 0)
++--------------------------------------------------------
 ```
 
 Copy the text inside the quotes. If you own two identical displays they get a
@@ -211,12 +209,13 @@ names themselves they are not fixed: making the other twin primary swaps which
 one is ` #2`, and swaps the configuration with it. Check the log after such a
 change.
 
-The selector's first entry, **All monitors** (`*`), applies one configuration
-to every display.
+Putting `*` in the **Display** field applies one configuration to every screen.
 
 Resolution is **per zone**: a name-matched entry wins over `*` for the zones
 it defines, and `*` supplies the rest. So you can put a shared config on `*`
-and override just one corner on one display.
+and override just one corner on one display. To exclude a screen from a shared
+zone rather than replace it, set that zone to **Disabled here** — leaving it
+unset means "not configured", which falls through to `*`.
 
 ## A note on inner corners
 
@@ -273,6 +272,32 @@ Hot corners are disabled when any excluded process is the foreground window.
 **Example:** `photoshop.exe;premiere.exe;blender.exe`
 
 # Changelog
+
+## What's New in v4.4.2
+
+- **The tray icon stops saying "paused" when a suspension ends.** The corners
+  came back on their own, and the menu was right, but the icon stayed dimmed
+  for the rest of the session — the one piece of feedback you actually look at.
+- **New action: Disabled here.** Setting a zone to this on a named display
+  excludes that screen from a shared `*` zone. Leaving a zone unset still means
+  "not configured" and still falls through to `*`; there was previously no way
+  to say the other thing.
+- **The dashboard no longer marks a zone broken when the wildcard rescues it.**
+  A display-specific zone with unparseable arguments is skipped in favour of
+  the `*` entry, and the preview now follows that same order instead of
+  reporting a zone as dead when it fires perfectly well.
+- **Clearing the last zone on the settings page no longer resurrects a pre-4.2
+  layout.** The handover is one-way once the settings page has owned the
+  configuration.
+- Display changes and taskbar moves queue a rebuild rather than doing it inside
+  the broadcast handler, so the sender is not blocked and a burst of work-area
+  messages collapses into one rebuild instead of resetting every cooldown
+  several times.
+- The dashboard's tab strip no longer runs off the window edge with several
+  displays; labels ellipsise and every tab stays clickable.
+- Readme: removed a paragraph that still argued against having a settings page,
+  and corrected the monitor-list sample and the references to a "selector" the
+  dashboard no longer has.
 
 ## What's New in v4.4.1
 
@@ -780,6 +805,7 @@ listing, but it only takes one link, so the rest live here.
           $name: Action
           $options:
           - ACTION_NOTHING: Nothing
+          - ACTION_DISABLED_HERE: "Disabled here (ignore the * entry)"
           - ACTION_SHOW_DESKTOP: Show desktop
           - ACTION_TASK_VIEW: Task View
           - ACTION_SCREENSAVER: Start screensaver
@@ -960,6 +986,10 @@ listing, but it only takes one link, so the rest live here.
 enum class CornerAction
 {
     Nothing,
+    // Explicitly off on this display, as opposed to "not configured". Only the
+    // second falls through to the "*" entry, so this is what lets one screen
+    // opt out of a shared zone without abandoning the wildcard everywhere.
+    DisabledHere,
     ShowDesktop,
     TaskView,
     ScreenSaver,
@@ -1181,8 +1211,8 @@ static DWORD g_dwDetectThreadId = 0;
 static HWND g_hDetectWnd = nullptr;
 static HANDLE g_hStopEvent = nullptr;
 
-// Prints the monitor list at load and on display changes, so names can be
-// copied into the monitor selector instead of guessed. Cheap - once per event.
+// Prints the monitor list at load and on display changes, so a name can be
+// copied into the settings page instead of guessed. Cheap - once per event.
 static std::atomic<bool> g_showMonitorNames{true};
 
 // Master switch and temporary suspend, both driven from the tray icon.
@@ -1651,12 +1681,13 @@ static void RefreshMonitors()
     if (!g_showMonitorNames)
         return;
 
-    // Printed so the name can be copied straight into the Monitor setting,
-    // rather than guessed. Once per load and per display change only.
+    // Printed so the name can be copied straight into the settings page rather
+    // than guessed. Once per load and per display change only.
     Wh_Log(L" ");
     Wh_Log(L"+-- Your monitors ---------------------------------------");
-    Wh_Log(L"|  These are the displays in the dashboard's monitor selector.");
-    Wh_Log(L"|  Use  *  to apply one configuration to every monitor.");
+    Wh_Log(L"|  Copy a name into the \"Display\" field on this mod's settings "
+           L"page.");
+    Wh_Log(L"|  Use  *  there to apply one configuration to every monitor.");
     Wh_Log(L"|");
     for (const auto &m : g_monitors)
     {
@@ -1674,13 +1705,6 @@ static void RefreshMonitors()
 // Fullscreen / Exclusion Gates (worker thread only)
 // =====================================================================
 
-// Task View, the Start menu, Search, Action Center and the desktop are shell
-// surfaces that are legitimately monitor-sized, so the bounds test below
-// mistakes them for fullscreen apps and blocks every trigger while they are
-// open. v2.x excluded them with `fgPid == GetCurrentProcessId()` because it
-// ran inside explorer.exe; once the mod moved to its own process that test
-// silently stopped matching anything. Compare against the *shell's* pid
-// instead, which is what was actually meant.
 // Lowercase exe name of the window's owning process, or empty on failure.
 static std::wstring ProcessNameOfWindow(HWND hwnd)
 {
@@ -2248,6 +2272,7 @@ static CornerAction ParseActionType(const std::wstring &raw)
 {
     static const std::unordered_map<std::wstring, CornerAction> map = {
         {L"ACTION_NOTHING", CornerAction::Nothing},
+        {L"ACTION_DISABLED_HERE", CornerAction::DisabledHere},
         {L"ACTION_SHOW_DESKTOP", CornerAction::ShowDesktop},
         {L"ACTION_TASK_VIEW", CornerAction::TaskView},
         {L"ACTION_SCREENSAVER", CornerAction::ScreenSaver},
@@ -2295,6 +2320,7 @@ static const wchar_t *ActionToString(CornerAction a)
     switch (a)
     {
     case CornerAction::Nothing: return L"Nothing";
+    case CornerAction::DisabledHere: return L"Disabled here";
     case CornerAction::ShowDesktop: return L"Show Desktop";
     case CornerAction::TaskView: return L"Task View";
     case CornerAction::ScreenSaver: return L"Screen Saver";
@@ -2378,6 +2404,7 @@ static std::function<void()> MakeExecutor(CornerAction action,
     switch (action)
     {
     case CornerAction::Nothing: return nullptr;
+    case CornerAction::DisabledHere: return nullptr;
     case CornerAction::ShowDesktop: return ActionShowDesktop;
     case CornerAction::TaskView: return ActionTaskView;
     case CornerAction::ScreenSaver: return ActionScreenSaver;
@@ -2529,6 +2556,10 @@ static const ZoneConfig *ResolveZone(const MonitorInfo &mon, Zone zone)
         if (_wcsicmp(cfg.monitorId.c_str(), mon.id.c_str()) != 0)
             continue;
         const auto &zc = cfg.zones[zone];
+        // An explicit opt-out stops here rather than falling through, which is
+        // the whole difference between it and leaving the zone unset.
+        if (zc.action == CornerAction::DisabledHere)
+            return nullptr;
         if (zc.action != CornerAction::Nothing && zc.executor)
             return &zc;
     }
@@ -2656,6 +2687,10 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
             if (zc->action == CornerAction::AlternateKeypress ||
                 zc->action == CornerAction::AlternateCommand)
             {
+                // zc->executor is deliberately not used for these two: each
+                // copy carries its own flip flag, and the segments of one edge
+                // have to share one. The stored executor still earns its keep
+                // as the dashboard's "do the arguments parse?" test.
                 if (!altExec[z])
                     altExec[z] = MakeExecutor(zc->action, zc->args);
                 hz.exec = altExec[z];
@@ -3067,24 +3102,28 @@ static DWORD DetectTick()
 static LRESULT CALLBACK DetectWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
                                       LPARAM lParam)
 {
-    if (uMsg == WM_DISPLAYCHANGE || uMsg == WM_APP_REBUILD)
+    if (uMsg == WM_APP_REBUILD)
     {
-        if (uMsg == WM_DISPLAYCHANGE)
-            Wh_Log(L"WM_DISPLAYCHANGE — rebuilding zones");
-        else
-            Wh_Log(L"Settings changed — rebuilding zones");
         RebuildZones();
         return 0;
     }
-    // The polled topology check reads SPI_GETWORKAREA, which only ever reports
-    // the primary display - so with "keep zones out of the taskbar" on, a
-    // taskbar moved or auto-hidden on a secondary display left that display's
-    // zones at coordinates that no longer matched. This broadcast arrives
-    // whichever display changed.
-    if (uMsg == WM_SETTINGCHANGE && wParam == SPI_SETWORKAREA)
+    // Both of these arrive as a SendMessage broadcast, so rebuilding inline
+    // blocks the sender for a QueryDisplayConfig, an EnumDisplayMonitors and
+    // the whole monitor log dump. SPI_SETWORKAREA also arrives several times
+    // in a row when a taskbar moves, and every rebuild resets each zone's
+    // cooldown and alternation position. Posting returns at once and coalesces
+    // naturally, because the loop drains its queue before the next tick.
+    //
+    // The work-area case is here at all because the polled topology check
+    // reads SPI_GETWORKAREA, which only ever reports the primary display - a
+    // taskbar moved on a secondary one was invisible to it.
+    if (uMsg == WM_DISPLAYCHANGE ||
+        (uMsg == WM_SETTINGCHANGE && wParam == SPI_SETWORKAREA))
     {
-        Wh_Log(L"Work area changed — rebuilding zones");
-        RebuildZones();
+        Wh_Log(uMsg == WM_DISPLAYCHANGE
+                   ? L"WM_DISPLAYCHANGE — queueing a zone rebuild"
+                   : L"Work area changed — queueing a zone rebuild");
+        PostMessage(hWnd, WM_APP_REBUILD, 0, 0);
         return 0;
     }
     return DefWindowProc(hWnd, uMsg, wParam, lParam);
@@ -3177,6 +3216,11 @@ static HWND g_hTrayWnd = nullptr;
 static UINT g_taskbarCreatedMsg = 0;
 static constexpr UINT WM_APP_TRAY = WM_APP + 10;
 static constexpr UINT_PTR kTrayIconId = 1;
+// Fires once when a suspension expires, purely so the icon stops saying
+// "paused". Detection needs no timer - it re-reads the deadline every tick.
+static constexpr UINT_PTR kSuspendTimerId = 2;
+
+static void CancelSuspendTimer();
 
 // A stable GUID gives the icon an identity of its own. Without one it is keyed
 // on the host executable, which for a Windhawk tool mod is windhawk.exe and is
@@ -3500,6 +3544,16 @@ static std::wstring GetSettingStr(const wchar_t *fmt, int a, int b = -1)
     return out;
 }
 
+// For the settings that are not inside an array, where passing an index into a
+// format string with no %d in it just read like a bug.
+static std::wstring GetSettingStr(const wchar_t *name)
+{
+    PCWSTR raw = Wh_GetStringSetting(name);
+    std::wstring out = raw ? raw : L"";
+    Wh_FreeStringSetting(raw);
+    return out;
+}
+
 static std::vector<MonitorZoneConfig> ReadSettingsZones()
 {
     std::vector<MonitorZoneConfig> configs;
@@ -3579,7 +3633,7 @@ static void ApplySettingsGlobals(ModSettings &s)
     s.settleMs = clamp(Wh_GetIntSetting(L"settle"), 0, 10000);
     s.knockWindowMs = clamp(Wh_GetIntSetting(L"knock"), 0, 10000);
     s.cooldownMs = clamp(Wh_GetIntSetting(L"cooldown"), 0, 60000);
-    int mod = ParseModifierName(GetSettingStr(L"requireModifier", 0));
+    int mod = ParseModifierName(GetSettingStr(L"requireModifier"));
     s.requireModifier = (mod < 0) ? 0 : mod;
     s.disableOnFullscreen = Wh_GetIntSetting(L"disableOnFullscreen") != 0;
     s.disableDuringDrag = Wh_GetIntSetting(L"disableDuringDrag") != 0;
@@ -3588,7 +3642,7 @@ static void ApplySettingsGlobals(ModSettings &s)
     g_lockBlankDelayMs = clamp(Wh_GetIntSetting(L"lockBlankDelay"), 0, 10000);
     g_showMonitorNames = Wh_GetIntSetting(L"showMonitorNames") != 0;
 
-    std::wstring rest = GetSettingStr(L"excluded", 0);
+    std::wstring rest = GetSettingStr(L"excluded");
     while (!rest.empty())
     {
         auto semi = rest.find(L';');
@@ -3725,10 +3779,18 @@ static void ReloadConfig()
     // nothing happen. Only the zone list falls back to the stored layout.
     ApplySettingsGlobals(s);
 
+    // The handover is one-way. Without this, a user who lists a display and
+    // later sets its zones back to Nothing drops out of fromSettings and the
+    // pre-4.2 layout comes back from the dead, which is not what clearing a
+    // zone asks for.
+    if (fromSettings && Wh_GetIntValue(L"settings_owner", 0) == 0)
+        Wh_SetIntValue(L"settings_owner", 1);
+
     bool legacy = false;
     std::wstring dropped;
 
-    if (!fromSettings && Wh_GetIntValue(L"gui_active", 0) != 0)
+    if (!fromSettings && Wh_GetIntValue(L"settings_owner", 0) == 0 &&
+        Wh_GetIntValue(L"gui_active", 0) != 0)
     {
         legacy = true;
         s.monitorConfigs = ReadDashboardZones();
@@ -3918,6 +3980,12 @@ static void RequestRebuild()
         PostMessage(g_hDetectWnd, WM_APP_REBUILD, 0, 0);
 }
 
+static void CancelSuspendTimer()
+{
+    if (g_hTrayWnd)
+        KillTimer(g_hTrayWnd, kSuspendTimerId);
+}
+
 static void HandleTrayCommand(UINT id)
 {
     switch (id)
@@ -3935,6 +4003,7 @@ static void HandleTrayCommand(UINT id)
         Wh_SetIntValue(kOvrEnabled, g_trayEnabled ? 1 : 0);
         LeaveCriticalSection(&g_reloadLock);
         g_suspendUntil = 0;
+        CancelSuspendTimer();
         Wh_Log(L"Tray: hot corners %s", g_trayEnabled ? L"enabled" : L"disabled");
         break;
 
@@ -3944,12 +4013,20 @@ static void HandleTrayCommand(UINT id)
     {
         int mins = (id == IDM_SUSPEND_15) ? 15 : (id == IDM_SUSPEND_30) ? 30 : 60;
         g_suspendUntil = GetTickCount64() + (ULONGLONG)mins * 60 * 1000;
+        // Detection re-reads the deadline every tick, so the corners come back
+        // on their own - but nothing redrew the icon, which stayed dimmed and
+        // still said "paused" for the rest of the session. Suspension is
+        // exactly when the icon is the thing being looked at.
+        if (g_hTrayWnd)
+            SetTimer(g_hTrayWnd, kSuspendTimerId,
+                     (UINT)mins * 60 * 1000 + 1000, nullptr);
         Wh_Log(L"Tray: suspended for %d minutes", mins);
         break;
     }
 
     case IDM_RESUME:
         g_suspendUntil = 0;
+        CancelSuspendTimer();
         Wh_Log(L"Tray: resumed");
         break;
 
@@ -3960,6 +4037,7 @@ static void HandleTrayCommand(UINT id)
         EnterCriticalSection(&g_reloadLock);
         Wh_SetIntValue(kOvrEnabled, -1);
         g_suspendUntil = 0;
+        CancelSuspendTimer();
         ReloadConfig();
         LeaveCriticalSection(&g_reloadLock);
         RequestRebuild();
@@ -4405,7 +4483,15 @@ static void DashFillZones(DisplayView &dv,
     for (int z = 0; z < ZONE_COUNT; z++)
     {
         const ZoneConfig *hit = nullptr;
+        // An entry that names an action but produced no executor - an
+        // unparseable key combination, or an Alternate action missing its "|".
+        // ResolveZone skips those and keeps looking, so this has to as well:
+        // marking the zone broken when the wildcard actually rescues it would
+        // be the picture disagreeing with what fires, in the one direction
+        // that matters most.
+        const ZoneConfig *broken = nullptr;
         bool wild = false;
+        bool disabled = false;
 
         if (!dv.wildcard)
         {
@@ -4415,42 +4501,66 @@ static void DashFillZones(DisplayView &dv,
                     continue;
                 if (_wcsicmp(cfg.monitorId.c_str(), dv.id.c_str()) != 0)
                     continue;
-                if (cfg.zones[z].action != CornerAction::Nothing)
+                const ZoneConfig &zc = cfg.zones[z];
+                if (zc.action == CornerAction::DisabledHere)
                 {
-                    hit = &cfg.zones[z];
+                    disabled = true;
                     break;
                 }
+                if (zc.action == CornerAction::Nothing)
+                    continue;
+                if (zc.executor)
+                {
+                    hit = &zc;
+                    break;
+                }
+                if (!broken)
+                    broken = &zc;
             }
         }
 
-        if (!hit)
+        if (!hit && !disabled)
         {
             for (const auto &cfg : cfgs)
             {
                 if (cfg.monitorId != L"*")
                     continue;
-                if (cfg.zones[z].action != CornerAction::Nothing)
+                const ZoneConfig &zc = cfg.zones[z];
+                if (zc.action == CornerAction::Nothing ||
+                    zc.action == CornerAction::DisabledHere)
+                    continue;
+                if (zc.executor)
                 {
-                    hit = &cfg.zones[z];
+                    hit = &zc;
                     wild = !dv.wildcard;
                     break;
                 }
+                if (!broken)
+                    broken = &zc;
             }
         }
 
-        if (!hit)
+        if (disabled)
+        {
+            dv.zones[z].action = CornerAction::DisabledHere;
+            dv.configured++;
             continue;
+        }
+
+        // Nothing resolved, so the unparseable entry really is what the user
+        // gets - nothing at all. That is worth saying out loud.
+        if (!hit)
+        {
+            if (!broken)
+                continue;
+            hit = broken;
+            dv.zones[z].invalid = true;
+        }
 
         dv.zones[z].action = hit->action;
         dv.zones[z].args = hit->args;
         dv.zones[z].tuning = hit->tuning;
         dv.zones[z].fromWildcard = wild;
-        // BuildZoneSet also requires an executor, and MakeExecutor returns null
-        // when the arguments do not parse - an unparseable key combination, or
-        // an Alternate action missing its "|". Drawing those as ordinary
-        // configured zones would make the picture disagree with what fires,
-        // which is the one thing this window must not do. Shown, but marked.
-        dv.zones[z].invalid = !hit->executor;
         dv.configured++;
     }
 }
@@ -4553,11 +4663,40 @@ static void DashPaintTabs(DashState *s, HDC hdc, const RECT &client)
     int x = Sc(Lay::Pad, d);
     int top = Sc(Lay::Pad, d);
     int h = Sc(Lay::TabH, d);
+    const int strip = client.right - Sc(Lay::Pad, d) * 2;
+    const int n = (int)s->displays.size();
 
     HFONT old = (HFONT)SelectObject(hdc, s->hFont);
     SetBkMode(hdc, TRANSPARENT);
 
-    for (int i = 0; i < (int)s->displays.size(); i++)
+    // Natural widths first. Laid out unbounded, four or five displays - or two
+    // long EDID names plus the wildcard tab - ran off the right edge, and the
+    // tabs past it were drawn outside the window and unreachable by mouse.
+    // Nothing here scrolls, so instead every tab is capped at an equal share
+    // and its label ellipsised; the badge and the dot always survive.
+    std::vector<int> width((size_t)n, 0);
+    int total = 0;
+    for (int i = 0; i < n; i++)
+    {
+        const DisplayView &dv = s->displays[i];
+        wchar_t count[16];
+        _snwprintf_s(count, _countof(count), _TRUNCATE, L"%d", dv.configured);
+
+        SIZE ts = {}, cs = {};
+        SelectObject(hdc, i == s->activeTab ? s->hFontBold : s->hFont);
+        GetTextExtentPoint32W(hdc, dv.id.c_str(), (int)dv.id.size(), &ts);
+        SelectObject(hdc, s->hFontSmall);
+        GetTextExtentPoint32W(hdc, count, (int)wcslen(count), &cs);
+
+        int dot = dv.present ? 0 : Sc(14, d);
+        width[(size_t)i] =
+            Sc(12, d) + dot + ts.cx + Sc(8, d) + cs.cx + Sc(12, d) + Sc(12, d);
+        total += width[(size_t)i];
+    }
+
+    const int cap = (n > 0 && total > strip) ? strip / n : 0;
+
+    for (int i = 0; i < n; i++)
     {
         const DisplayView &dv = s->displays[i];
         bool active = (i == s->activeTab);
@@ -4573,7 +4712,9 @@ static void DashPaintTabs(DashState *s, HDC hdc, const RECT &client)
 
         int dot = dv.present ? 0 : Sc(14, d);
         int badge = cs.cx + Sc(12, d);
-        int wTab = Sc(12, d) + dot + ts.cx + Sc(8, d) + badge + Sc(12, d);
+        int wTab = width[(size_t)i];
+        if (cap > 0 && wTab > cap)
+            wTab = cap;
 
         RECT tr = {x, top, x + wTab, top + h};
         s->tabRects.push_back(tr);
@@ -4593,12 +4734,17 @@ static void DashPaintTabs(DashState *s, HDC hdc, const RECT &client)
             tx += dot;
         }
 
+        // The badge is reserved out of the label's space rather than pushed
+        // off the end, so a truncated tab still shows its count.
+        int labelRight = tr.right - Sc(12, d) - badge - Sc(8, d);
+        if (labelRight < tx)
+            labelRight = tx;
         SelectObject(hdc, active ? s->hFontBold : s->hFont);
         SetTextColor(hdc, active ? g_pal.text : g_pal.dim);
-        RECT lr = {tx, tr.top, tr.right, tr.bottom};
+        RECT lr = {tx, tr.top, labelRight, tr.bottom};
         DrawTextW(hdc, dv.id.c_str(), -1, &lr,
-                  DT_LEFT | DT_SINGLELINE | DT_VCENTER);
-        tx += ts.cx + Sc(8, d);
+                  DT_LEFT | DT_SINGLELINE | DT_VCENTER | DT_END_ELLIPSIS);
+        tx = labelRight + Sc(8, d);
 
         // Configured-zone count, so "have I set anything up on that screen?"
         // is answerable without clicking through.
@@ -5358,6 +5504,13 @@ static LRESULT CALLBACK TrayWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
         HandleTrayCommand(LOWORD(wParam));
         return 0;
     }
+    // The suspension has run out; repaint the icon so it stops saying "paused".
+    if (uMsg == WM_TIMER && wParam == kSuspendTimerId)
+    {
+        KillTimer(hWnd, kSuspendTimerId);
+        UpdateTrayIcon(false);
+        return 0;
+    }
     // Explorer restarted and threw away every tray icon; put ours back.
     if (g_taskbarCreatedMsg && uMsg == g_taskbarCreatedMsg)
     {
@@ -5405,6 +5558,7 @@ static DWORD WINAPI TrayThread(LPVOID)
     FillTrayIconData(nid);
     Shell_NotifyIconW(NIM_DELETE, &nid);
 
+    CancelSuspendTimer();
     DestroyWindow(g_hTrayWnd);
     g_hTrayWnd = nullptr;
     UnregisterClass(kClass, hInst);

--- a/mods/win-x-hotcorners.wh.cpp
+++ b/mods/win-x-hotcorners.wh.cpp
@@ -2,12 +2,12 @@
 // @id              win-x-hotcorners
 // @name            Win-X Hot Corners
 // @description     macOS-style hot corners & edges for Windows with full multi-monitor support — trigger actions instantly when your cursor hits any screen corner or edge
-// @version         3.5.0
+// @version         4.0.2
 // @author          lost_husky
 // @github          https://github.com/DhakadG
 // @license         MIT
 // @include         windhawk.exe
-// @compilerOptions -lcomctl32 -lpowrprof -lshell32 -luser32
+// @compilerOptions -ladvapi32 -lcomctl32 -lgdi32 -lpowrprof -lshell32 -luser32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -33,7 +33,8 @@ Windhawk mod.
   games and apps keep their input path to themselves.
 - **Monitors identified by name** — zones bind to a display's friendly name
   (e.g. `Dell U2720Q`), so rearranging your desktop or changing which display
-  is primary never reshuffles your configuration.
+  is primary never reshuffles your configuration. (Two displays of the same
+  model are the one exception — see *Identifying your monitors*.)
 - **Per-monitor DPI correct** — detection runs per-monitor-DPI-aware, so
   zones land in the right place on mixed-scaling setups.
 - **Screen edges** — trigger actions on the top, bottom, left, or right edge
@@ -87,6 +88,8 @@ Windhawk mod.
 | Action | Description |
 |--------|-------------|
 | Lock Computer | Lock the workstation instantly |
+| Lock and Turn Off Monitors | Lock, then blank the displays |
+| Keep Awake On / Off | Suspend or restore screensaver and sleep |
 | Sleep | Put the computer to sleep |
 | Turn Off Monitors | Power off all displays |
 | Start Screen Saver | Activate the screen saver |
@@ -96,6 +99,8 @@ Windhawk mod.
 | Action | Description |
 |--------|-------------|
 | Virtual Key Press | Send any key combination, or several in sequence |
+| Alternate Key Press | Two combinations, fired alternately (`Alt+S | Alt+H`) |
+| Alternate Command | Two commands, fired alternately |
 | Custom Command | Launch any executable, path, or URL |
 | Nothing | Disabled (default) |
 
@@ -111,7 +116,11 @@ Monitor 2           id='BOE0998'     device=\\.\DISPLAY2 (3840,0)-(5760,1080)
 ```
 
 Copy the text inside the quotes. If you own two identical displays they get a
-` #2`, ` #3` suffix so each stays separately configurable.
+` #2`, ` #3` suffix so each stays separately configurable. Those suffixes are
+handed out in listed order — primary first, then left to right — so unlike the
+names themselves they are not fixed: making the other twin primary swaps which
+one is ` #2`, and swaps the configuration with it. Check the log after such a
+change.
 
 Special values:
 
@@ -143,6 +152,20 @@ Left, Right, Up, Down, etc.
 
 **Examples:** `Ctrl+Shift+Esc`, `Alt+F4`, `Win+L`
 
+## Alternate Key Press / Alternate Command
+
+Two actions separated by `|`. The zone fires the left one, then the right
+one, then the left again — the "different action on the second trigger" case:
+
+```
+Alt+S | Alt+H            one corner shows notes, then hides them
+notepad.exe | calc.exe
+```
+
+Each side accepts everything the single-action version does, so
+`Ctrl+C;Ctrl+V | Alt+Tab` is valid. Every zone alternates independently, and
+the position resets whenever settings or the display layout change.
+
 ## Custom Command Format
 
 Any executable path, file, folder, or URL. Environment variables like
@@ -162,6 +185,83 @@ Semicolon-separated list of process names (case-insensitive).
 Hot corners are disabled when any excluded process is the foreground window.
 
 **Example:** `photoshop.exe;premiere.exe;blender.exe`
+
+# Changelog
+
+## What's New in v4.0.2
+
+- **Fixed: zones could stop matching after a display change.** Windows reports
+  a layout that changed while it was being read as a buffer error, and that is
+  precisely when this runs — a layout change is what calls it. The mod treated
+  that as fatal and dropped every display name for the rebuild, leaving zones
+  bound to a name unmatched until the next display change. It now re-reads
+  instead.
+- Documentation corrections: two identical displays are the one case where
+  changing the primary display can move a configuration, because the ` #2`
+  suffix follows listed order rather than the display itself. That is now
+  stated instead of implied otherwise.
+
+## What's New in v4.0.1
+
+- **Fixed: stray text showing through the per-zone settings panel.** The
+  preview's hover card was drawn into the same strip of the window that the
+  per-zone fields occupy, so it was never readable and its lines leaked out
+  through the gaps between the fields. The card is gone — the panel below the
+  preview already shows those values for the selected zone, and clicking a
+  zone in the preview selects it.
+- **Fixed: tooltips were unreadable dark-on-dark.** A themed tooltip silently
+  ignores the colour messages that were meant to restyle it, so it kept the
+  system colours while the rest of the dashboard followed the palette.
+  Tooltips now use the dashboard's own background, text colour and font, in
+  both light and dark themes.
+- The dashboard window now clips its children, so nothing painted by the
+  window can leave residue underneath a control.
+- **Fixed a crash risk when opening the dashboard.** It listed your monitors
+  by reading the detection thread's own monitor table, which that thread
+  clears and rebuilds whenever the display layout is re-checked — freeing the
+  name strings mid-read. The names now travel inside the same immutable
+  snapshot the detection loop already uses.
+
+## What's New in v4.0.0
+
+- **Per-zone settings.** Size, delay, pass-through guard, knock window,
+  cooldown and required modifier can each be overridden for a single zone.
+  Blank means inherit, so existing configurations behave exactly as before.
+- The dashboard follows the system light/dark theme instead of being fixed
+  dark, which made it near-unreadable on a light desktop.
+- Preview fixes: edges are split around their centre blocks, so hovering a
+  centre no longer highlights the whole edge.
+
+## What's New in v3.9.0
+
+- **Settings dashboard**, opened from the tray icon: all twelve zones per
+  monitor, the global options, and a clickable preview of your screen.
+  Windhawk's own settings page stays available and can be restored at any
+  time with *Reset to Windhawk settings*.
+
+## What's New in v3.8.0
+
+- **Tray icon** with enable/suspend controls and quick access to the log.
+
+## What's New in v3.7.0
+
+- **Alternating actions** — one zone that runs two different actions on
+  successive triggers, written as `first|second` in the argument field.
+- **Keep zones off the taskbar**, so an edge zone stops at the work area
+  instead of fighting the taskbar's peek-at-desktop strip.
+
+## What's New in v3.6.0
+
+- **Knock to activate** — require entering a zone twice in quick succession.
+- **Modifier gating** — zones stay inert unless a chosen key is held.
+- **Edge-centre zones**, plus four new actions.
+- v3.6.1: the display actually blanks after *Lock and Turn Off Monitors*.
+  `WM_SYSCOMMAND` was posted to the foreground window, which is null once
+  `LockWorkStation` has switched desktop; it is now broadcast.
+
+## What's New in v3.5.0
+
+- First public release.
 
 ## What's New in v3.4.0
 
@@ -293,12 +393,19 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
     if both are a toggle (like Task View) they cancel out and nothing seems
     to happen. 80 ms is imperceptible and blocks pass-through firing.
     Set to 0 only if you use corners or edges but never both.
+- LockBlankDelayMs: 1200
+  $name: Delay before blanking after lock (ms)
+  $description: >-
+    Used only by the "Lock and Turn Off Monitors" action. Locking counts as
+    activity, so the display is blanked a moment later - blank too early and
+    it simply wakes back up. If your screen stays on after locking, raise
+    this; if it blanks before the lock screen appears, lower it.
 - ShowMonitorNames: true
   $name: List my monitors in the log
   $description: >-
     Writes your connected displays to this mod's log every time it loads or
     your display layout changes, so you can copy a name straight into the
-    Monitor field above instead of guessing it. Harmless to leave on - it
+    Monitor field below instead of guessing it. Harmless to leave on - it
     only writes a few lines, and only when something actually changes.
 - VerboseLogging: false
   $name: Verbose logging
@@ -307,6 +414,41 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
     OutputDebugString, which takes a system-wide lock, so logging on every
     trigger can stutter other Windhawk mods. Turn on only while diagnosing.
     Errors and startup information are always logged.
+- AvoidTaskbar: false
+  $name: Keep zones off the taskbar
+  $description: >-
+    Build the zones from the desktop work area instead of the whole screen, so
+    they stop at the edge of the taskbar. Turn this on if a bottom corner is
+    fighting the taskbar's own "peek at desktop" strip, or if you keep
+    triggering a corner while aiming for a taskbar button. Off by default,
+    because putting a zone on top of the taskbar is a perfectly reasonable
+    thing to want.
+- CenterZonePercent: 20
+  $name: Centre zone width (% of the edge)
+  $description: >-
+    How much of each edge the centre zone occupies, as a percentage. Only
+    has any effect on edges where you have actually assigned a centre action.
+    The rest of the edge stays as the normal edge zone, split either side.
+- KnockWindowMs: 0
+  $name: Knock to activate (ms)
+  $description: >-
+    Require the cursor to enter a zone TWICE in quick succession, like knocking
+    on a door, before anything happens. A single entry does nothing at all.
+    This is the strongest protection against accidental triggers. 0 turns it
+    off; 400 is a comfortable starting point. The two entries must be within
+    this many milliseconds of each other.
+- RequireModifier: 0
+  $name: Require a modifier key
+  $description: >-
+    Only fire while this key is held down. Makes hot corners completely inert
+    the rest of the time, which suits people who work near the screen edges.
+    Combines with everything else - the zone still has to be entered normally.
+  $options:
+  - 0: None - zones always active
+  - 1: Ctrl
+  - 2: Alt
+  - 3: Shift
+  - 4: Win
 - CooldownMs: 300
   $name: Cooldown between triggers (ms)
   $description: >-
@@ -373,6 +515,12 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
       - ACTION_VDESK_NEXT: Virtual Desktop - Next
       - ACTION_VDESK_PREV: Virtual Desktop - Previous
       - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
+      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
+      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
+      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
+      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
+      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
       - ACTION_SEND_KEYPRESS: Virtual Key Press
       - ACTION_START_PROCESS: Custom Command
     - TopLeftArgs: ""
@@ -412,6 +560,12 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
       - ACTION_VDESK_NEXT: Virtual Desktop - Next
       - ACTION_VDESK_PREV: Virtual Desktop - Previous
       - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
+      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
+      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
+      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
+      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
+      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
       - ACTION_SEND_KEYPRESS: Virtual Key Press
       - ACTION_START_PROCESS: Custom Command
     - TopRightArgs: ""
@@ -450,6 +604,12 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
       - ACTION_VDESK_NEXT: Virtual Desktop - Next
       - ACTION_VDESK_PREV: Virtual Desktop - Previous
       - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
+      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
+      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
+      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
+      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
+      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
       - ACTION_SEND_KEYPRESS: Virtual Key Press
       - ACTION_START_PROCESS: Custom Command
     - BottomLeftArgs: ""
@@ -488,6 +648,12 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
       - ACTION_VDESK_NEXT: Virtual Desktop - Next
       - ACTION_VDESK_PREV: Virtual Desktop - Previous
       - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
+      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
+      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
+      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
+      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
+      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
       - ACTION_SEND_KEYPRESS: Virtual Key Press
       - ACTION_START_PROCESS: Custom Command
     - BottomRightArgs: ""
@@ -526,6 +692,12 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
       - ACTION_VDESK_NEXT: Virtual Desktop - Next
       - ACTION_VDESK_PREV: Virtual Desktop - Previous
       - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
+      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
+      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
+      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
+      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
+      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
       - ACTION_SEND_KEYPRESS: Virtual Key Press
       - ACTION_START_PROCESS: Custom Command
     - EdgeTopArgs: ""
@@ -564,6 +736,12 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
       - ACTION_VDESK_NEXT: Virtual Desktop - Next
       - ACTION_VDESK_PREV: Virtual Desktop - Previous
       - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
+      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
+      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
+      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
+      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
+      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
       - ACTION_SEND_KEYPRESS: Virtual Key Press
       - ACTION_START_PROCESS: Custom Command
     - EdgeBottomArgs: ""
@@ -602,6 +780,12 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
       - ACTION_VDESK_NEXT: Virtual Desktop - Next
       - ACTION_VDESK_PREV: Virtual Desktop - Previous
       - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
+      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
+      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
+      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
+      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
+      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
       - ACTION_SEND_KEYPRESS: Virtual Key Press
       - ACTION_START_PROCESS: Custom Command
     - EdgeLeftArgs: ""
@@ -640,10 +824,208 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
       - ACTION_VDESK_NEXT: Virtual Desktop - Next
       - ACTION_VDESK_PREV: Virtual Desktop - Previous
       - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
+      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
+      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
+      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
+      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
+      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
       - ACTION_SEND_KEYPRESS: Virtual Key Press
       - ACTION_START_PROCESS: Custom Command
     - EdgeRightArgs: ""
       $name: Right Edge Args
+      $description: >-
+        For Virtual Key Press or Custom Command only.
+    - CenterTop: ACTION_NOTHING
+      $name: Top Edge Centre
+      $description: >-
+        The middle of that edge. Easier to hit than a corner on a wide
+        display. Leaving this as Nothing keeps the full-length edge zone
+        exactly as it is today.
+      $options:
+      - ACTION_NOTHING: Nothing
+      - ACTION_SHOW_DESKTOP: Show Desktop
+      - ACTION_TASK_VIEW: Task View (Win+Tab)
+      - ACTION_SCREENSAVER: Start Screen Saver
+      - ACTION_MONITORS_OFF: Turn Off Monitors
+      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
+      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
+      - ACTION_START_MENU: Start Menu
+      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
+      - ACTION_MUTE: Mute Volume
+      - ACTION_TASK_MANAGER: Task Manager
+      - ACTION_LOCK: Lock Computer
+      - ACTION_SLEEP: Sleep
+      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
+      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
+      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
+      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
+      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
+      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
+      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
+      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
+      - ACTION_SETTINGS: Settings (Win+I)
+      - ACTION_SEARCH: Search (Win+S)
+      - ACTION_CLIPBOARD: Clipboard History (Win+V)
+      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
+      - ACTION_PROJECT: Project / Second Screen (Win+P)
+      - ACTION_VDESK_NEXT: Virtual Desktop - Next
+      - ACTION_VDESK_PREV: Virtual Desktop - Previous
+      - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
+      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
+      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
+      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
+      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
+      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
+      - ACTION_SEND_KEYPRESS: Virtual Key Press
+      - ACTION_START_PROCESS: Custom Command
+    - CenterTopArgs: ""
+      $name: Top Edge Centre Args
+      $description: >-
+        For Virtual Key Press or Custom Command only.
+    - CenterBottom: ACTION_NOTHING
+      $name: Bottom Edge Centre
+      $description: >-
+        The middle of that edge. Easier to hit than a corner on a wide
+        display. Leaving this as Nothing keeps the full-length edge zone
+        exactly as it is today.
+      $options:
+      - ACTION_NOTHING: Nothing
+      - ACTION_SHOW_DESKTOP: Show Desktop
+      - ACTION_TASK_VIEW: Task View (Win+Tab)
+      - ACTION_SCREENSAVER: Start Screen Saver
+      - ACTION_MONITORS_OFF: Turn Off Monitors
+      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
+      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
+      - ACTION_START_MENU: Start Menu
+      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
+      - ACTION_MUTE: Mute Volume
+      - ACTION_TASK_MANAGER: Task Manager
+      - ACTION_LOCK: Lock Computer
+      - ACTION_SLEEP: Sleep
+      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
+      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
+      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
+      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
+      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
+      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
+      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
+      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
+      - ACTION_SETTINGS: Settings (Win+I)
+      - ACTION_SEARCH: Search (Win+S)
+      - ACTION_CLIPBOARD: Clipboard History (Win+V)
+      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
+      - ACTION_PROJECT: Project / Second Screen (Win+P)
+      - ACTION_VDESK_NEXT: Virtual Desktop - Next
+      - ACTION_VDESK_PREV: Virtual Desktop - Previous
+      - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
+      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
+      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
+      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
+      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
+      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
+      - ACTION_SEND_KEYPRESS: Virtual Key Press
+      - ACTION_START_PROCESS: Custom Command
+    - CenterBottomArgs: ""
+      $name: Bottom Edge Centre Args
+      $description: >-
+        For Virtual Key Press or Custom Command only.
+    - CenterLeft: ACTION_NOTHING
+      $name: Left Edge Centre
+      $description: >-
+        The middle of that edge. Easier to hit than a corner on a wide
+        display. Leaving this as Nothing keeps the full-length edge zone
+        exactly as it is today.
+      $options:
+      - ACTION_NOTHING: Nothing
+      - ACTION_SHOW_DESKTOP: Show Desktop
+      - ACTION_TASK_VIEW: Task View (Win+Tab)
+      - ACTION_SCREENSAVER: Start Screen Saver
+      - ACTION_MONITORS_OFF: Turn Off Monitors
+      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
+      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
+      - ACTION_START_MENU: Start Menu
+      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
+      - ACTION_MUTE: Mute Volume
+      - ACTION_TASK_MANAGER: Task Manager
+      - ACTION_LOCK: Lock Computer
+      - ACTION_SLEEP: Sleep
+      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
+      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
+      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
+      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
+      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
+      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
+      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
+      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
+      - ACTION_SETTINGS: Settings (Win+I)
+      - ACTION_SEARCH: Search (Win+S)
+      - ACTION_CLIPBOARD: Clipboard History (Win+V)
+      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
+      - ACTION_PROJECT: Project / Second Screen (Win+P)
+      - ACTION_VDESK_NEXT: Virtual Desktop - Next
+      - ACTION_VDESK_PREV: Virtual Desktop - Previous
+      - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
+      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
+      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
+      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
+      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
+      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
+      - ACTION_SEND_KEYPRESS: Virtual Key Press
+      - ACTION_START_PROCESS: Custom Command
+    - CenterLeftArgs: ""
+      $name: Left Edge Centre Args
+      $description: >-
+        For Virtual Key Press or Custom Command only.
+    - CenterRight: ACTION_NOTHING
+      $name: Right Edge Centre
+      $description: >-
+        The middle of that edge. Easier to hit than a corner on a wide
+        display. Leaving this as Nothing keeps the full-length edge zone
+        exactly as it is today.
+      $options:
+      - ACTION_NOTHING: Nothing
+      - ACTION_SHOW_DESKTOP: Show Desktop
+      - ACTION_TASK_VIEW: Task View (Win+Tab)
+      - ACTION_SCREENSAVER: Start Screen Saver
+      - ACTION_MONITORS_OFF: Turn Off Monitors
+      - ACTION_QUICK_SETTINGS: Quick Settings (Win+A)
+      - ACTION_NOTIFICATION_CENTER: Notification Center (Win+N)
+      - ACTION_START_MENU: Start Menu
+      - ACTION_HIDE_OTHERS: Hide Other Windows (Win+Home)
+      - ACTION_MUTE: Mute Volume
+      - ACTION_TASK_MANAGER: Task Manager
+      - ACTION_LOCK: Lock Computer
+      - ACTION_SLEEP: Sleep
+      - ACTION_SWITCH_LAST: Switch to Last Window (Alt+Tab)
+      - ACTION_TASK_SWITCHER: Task Switcher (Ctrl+Alt+Tab)
+      - ACTION_MINIMIZE: Minimize Active Window (Win+Down)
+      - ACTION_MAXIMIZE: Maximize Active Window (Win+Up)
+      - ACTION_SNAP_LEFT: Snap Window Left (Win+Left)
+      - ACTION_SNAP_RIGHT: Snap Window Right (Win+Right)
+      - ACTION_CLOSE_WINDOW: Close Active Window (Alt+F4)
+      - ACTION_FILE_EXPLORER: File Explorer (Win+E)
+      - ACTION_SETTINGS: Settings (Win+I)
+      - ACTION_SEARCH: Search (Win+S)
+      - ACTION_CLIPBOARD: Clipboard History (Win+V)
+      - ACTION_SCREENSHOT: Screenshot / Snip (Win+Shift+S)
+      - ACTION_PROJECT: Project / Second Screen (Win+P)
+      - ACTION_VDESK_NEXT: Virtual Desktop - Next
+      - ACTION_VDESK_PREV: Virtual Desktop - Previous
+      - ACTION_VDESK_NEW: Virtual Desktop - New
+      - ACTION_VDESK_CLOSE: Virtual Desktop - Close
+      - ACTION_LOCK_MONITORS_OFF: Lock and Turn Off Monitors
+      - ACTION_KEEP_AWAKE_ON: Keep Awake - On
+      - ACTION_KEEP_AWAKE_OFF: Keep Awake - Off
+      - ACTION_ALTERNATE_KEYPRESS: Alternate Key Press (A then B)
+      - ACTION_ALTERNATE_COMMAND: Alternate Command (A then B)
+      - ACTION_SEND_KEYPRESS: Virtual Key Press
+      - ACTION_START_PROCESS: Custom Command
+    - CenterRightArgs: ""
+      $name: Right Edge Centre Args
       $description: >-
         For Virtual Key Press or Custom Command only.
   $name: Monitor Corner & Edge Configuration
@@ -652,7 +1034,8 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
 
 #include <windows.h>
 
-#include <commctrl.h> // windhawk_utils.h needs SUBCLASSPROC from here
+#include <commctrl.h>
+#include <windowsx.h>   // GET_X_LPARAM / GET_Y_LPARAM // windhawk_utils.h needs SUBCLASSPROC from here
 #include <initializer_list>
 #include <powrprof.h>
 #include <shellapi.h>
@@ -660,6 +1043,7 @@ twice a second, leaving the tick to one cursor read plus a few comparisons.
 #include <windhawk_utils.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cwctype>
 #include <deque>
 #include <functional>
@@ -706,6 +1090,12 @@ enum class CornerAction
     VDesktopNext,
     VDesktopPrev,
     VDesktopNew,
+    VDesktopClose,
+    LockAndMonitorsOff,
+    KeepAwakeOn,
+    KeepAwakeOff,
+    AlternateKeypress,
+    AlternateCommand,
     SendKeypress,
     StartProcess,
 };
@@ -721,7 +1111,24 @@ enum Zone
     ZONE_EDGE_BOTTOM = 5,
     ZONE_EDGE_LEFT = 6,
     ZONE_EDGE_RIGHT = 7,
-    ZONE_COUNT = 8,
+    ZONE_CENTER_TOP = 8,
+    ZONE_CENTER_BOTTOM = 9,
+    ZONE_CENTER_LEFT = 10,
+    ZONE_CENTER_RIGHT = 11,
+    ZONE_COUNT = 12,
+};
+
+// Per-zone overrides. Every numeric field uses -1 for "inherit the global
+// value", so an untouched zone behaves exactly as it did before per-zone
+// settings existed and old configurations keep working unchanged.
+struct ZoneTuning
+{
+    int size = -1;      // corner square / edge strip thickness, px
+    int delay = -1;     // activation delay, ms
+    int settle = -1;    // pass-through guard, ms
+    int knock = -1;     // knock window, ms
+    int cooldown = -1;  // per-zone cooldown, ms
+    int modifier = -1;  // 0 none, 1 Ctrl, 2 Alt, 3 Shift, 4 Win
 };
 
 struct ZoneConfig
@@ -729,6 +1136,7 @@ struct ZoneConfig
     CornerAction action = CornerAction::Nothing;
     std::wstring args;
     std::function<void()> executor;
+    ZoneTuning tuning;
 };
 
 struct MonitorZoneConfig
@@ -742,6 +1150,7 @@ struct MonitorInfo
 {
     HMONITOR handle;
     RECT rcMonitor;
+    RECT rcWork;   // monitor minus taskbar and any docked appbars
     bool isPrimary;
     int index;           // 1-based, legacy ordinal assigned after sorting
     std::wstring device; // GDI name, e.g. \\.\DISPLAY1
@@ -754,7 +1163,18 @@ struct HitZone
 {
     RECT rect;
     std::function<void()> exec;
-    std::wstring label; // "Dell U2720Q TopLeft -> TaskView", for logging
+    std::wstring label;  // "Dell U2720Q Top-left corner -> Task View"
+
+    // Resolved once at build time - zone override if set, otherwise the
+    // global. The detection loop therefore never has to know that per-zone
+    // settings exist.
+    int delay = 0;
+    int settle = 80;
+    int knock = 0;
+    int cooldown = 300;
+    int modifier = 0;
+    int size = 6;
+    Zone zone = ZONE_TOP_LEFT;
 };
 
 // The detection loop reads nothing but this snapshot, so it never touches
@@ -762,8 +1182,14 @@ struct HitZone
 struct ZoneSet
 {
     std::vector<HitZone> zones;
+    // Friendly names of the displays this set was built from. They ride in the
+    // snapshot so the dashboard thread can list monitors without reading
+    // g_monitors, which the detection thread clears and refills underneath it.
+    std::vector<std::wstring> monitorNames;
     int activationDelay = 0;
     int settleMs = 80;
+    int knockWindowMs = 0;
+    int requireModifier = 0;
     int cooldownMs = 0;
     bool disableDuringDrag = true;
 };
@@ -778,6 +1204,10 @@ static struct
     int edgeSize = 6;
     int activationDelay = 0;
     int settleMs = 80;
+    int knockWindowMs = 0;   // 0 = knock mode off
+    int requireModifier = 0; // 0 none, 1 Ctrl, 2 Alt, 3 Shift, 4 Win
+    int centerZonePercent = 20;
+    bool avoidTaskbar = false;
     int cooldownMs = 300;
     bool disableOnFullscreen = true;
     bool disableDuringDrag = true;
@@ -813,6 +1243,17 @@ static bool g_verboseLog = false;
 // copied into the Monitor setting instead of guessed. Cheap - once per event.
 static bool g_showMonitorNames = true;
 
+// Master switch and temporary suspend, both driven from the tray icon.
+// Written by the tray thread and read by the detection thread every tick;
+// atomic because this builds as 32-bit, where a plain 64-bit read can tear.
+static std::atomic<bool> g_trayEnabled{true};
+static std::atomic<ULONGLONG> g_suspendUntil{0};
+
+// How long to wait after locking before blanking the display. Hardware
+// dependent - the secure-desktop switch takes longer on some machines, and
+// blanking before it settles just wakes the display again.
+static int g_lockBlankDelayMs = 1200;
+
 // Hard floor between any two actions, whatever the zone or the cooldown
 // setting. Actions are user-visible shell operations (Task View, Show Desktop,
 // launching a process); replaying a queued burst of them back-to-back is what
@@ -835,12 +1276,18 @@ static constexpr size_t kMaxQueue = 2;
 static int g_activeZone = -1;
 static ULONGLONG g_enterTick = 0;
 static bool g_firedThisEntry = false;
+static bool g_knockSatisfied = true;
 static std::vector<ULONGLONG> g_lastFireTick;
+// When each zone was last left, for knock detection.
+static std::vector<ULONGLONG> g_lastExitTick;
 
 // Cached display topology, for catching layout changes Windows doesn't
 // announce (docking, monitor wake, RDP reconnect).
 static int g_topoCount = -1;
 static RECT g_topoVirtual = {};
+// Also tracked, so moving or auto-hiding the taskbar rebuilds the zones when
+// they are being built from the work area.
+static RECT g_topoWorkArea = {};
 
 static constexpr UINT WM_APP_REBUILD = WM_APP + 1;
 
@@ -1130,19 +1577,36 @@ static void QueryMonitorFriendlyNames(
     std::unordered_map<std::wstring, std::wstring> &out)
 {
     UINT32 pathCount = 0, modeCount = 0;
-    if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &pathCount,
-                                    &modeCount) != ERROR_SUCCESS)
-    {
-        Wh_Log(L"GetDisplayConfigBufferSizes failed");
-        return;
-    }
+    std::vector<DISPLAYCONFIG_PATH_INFO> paths;
+    std::vector<DISPLAYCONFIG_MODE_INFO> modes;
 
-    std::vector<DISPLAYCONFIG_PATH_INFO> paths(pathCount);
-    std::vector<DISPLAYCONFIG_MODE_INFO> modes(modeCount);
-    if (QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &pathCount, paths.data(),
-                           &modeCount, modes.data(), nullptr) != ERROR_SUCCESS)
+    // The display layout can change between sizing the buffers and filling
+    // them — which is exactly when this runs, since a layout change is what
+    // calls it. The API reports that as ERROR_INSUFFICIENT_BUFFER and expects
+    // the caller to size and query again. Without the retry every friendly
+    // name is lost for that rebuild, and every zone bound to a name silently
+    // stops matching until the next display change.
+    // ponytail: 3 attempts. A layout that changes three times inside one
+    // rebuild will fix itself on the next WM_DISPLAYCHANGE anyway.
+    LONG qc = ERROR_INSUFFICIENT_BUFFER;
+    for (int attempt = 0; attempt < 3 && qc == ERROR_INSUFFICIENT_BUFFER;
+         attempt++)
     {
-        Wh_Log(L"QueryDisplayConfig failed");
+        if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &pathCount,
+                                        &modeCount) != ERROR_SUCCESS)
+        {
+            Wh_Log(L"GetDisplayConfigBufferSizes failed");
+            return;
+        }
+
+        paths.assign(pathCount, DISPLAYCONFIG_PATH_INFO{});
+        modes.assign(modeCount, DISPLAYCONFIG_MODE_INFO{});
+        qc = QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &pathCount, paths.data(),
+                                &modeCount, modes.data(), nullptr);
+    }
+    if (qc != ERROR_SUCCESS)
+    {
+        Wh_Log(L"QueryDisplayConfig failed: %ld", qc);
         return;
     }
 
@@ -1197,6 +1661,7 @@ static BOOL CALLBACK MonitorEnumProc(HMONITOR hMonitor, HDC, LPRECT,
         MonitorInfo info;
         info.handle = hMonitor;
         info.rcMonitor = mi.rcMonitor;
+        info.rcWork = mi.rcWork;
         info.isPrimary = (mi.dwFlags & MONITORINFOF_PRIMARY) != 0;
         info.index = 0;
         info.device = mi.szDevice;
@@ -1580,20 +2045,33 @@ static void ActionShowDesktop()
 
 static void ActionTaskView() { SendKeys({VK_LWIN, VK_TAB}); }
 
+// SC_MONITORPOWER and SC_SCREENSAVE only take effect when they reach a window
+// that passes them to DefWindowProc, which is what hands them to the power
+// manager.
+//
+// Posting to GetForegroundWindow is unreliable: an application is free to
+// swallow WM_SYSCOMMAND, and after LockWorkStation the input desktop has
+// switched to Winlogon, so from our desktop it returns null and the old
+// fallback posted to GetDesktopWindow — which handles nothing at all. That is
+// why the display stayed awake after locking.
+//
+// Broadcasting reaches every top-level window, so at least one will route it.
+// Runs on the worker thread, so the blocking call cannot delay detection.
+static void BroadcastSysCommand(WPARAM command, LPARAM param)
+{
+    DWORD_PTR result = 0;
+    SendMessageTimeoutW(HWND_BROADCAST, WM_SYSCOMMAND, command, param,
+                        SMTO_ABORTIFHUNG, 500, &result);
+}
+
 static void ActionScreenSaver()
 {
-    HWND hTarget = GetForegroundWindow();
-    if (!hTarget)
-        hTarget = GetDesktopWindow();
-    PostMessage(hTarget, WM_SYSCOMMAND, SC_SCREENSAVE, 0);
+    BroadcastSysCommand(SC_SCREENSAVE, 0);
 }
 
 static void ActionMonitorsOff()
 {
-    HWND hTarget = GetForegroundWindow();
-    if (!hTarget)
-        hTarget = GetDesktopWindow();
-    PostMessage(hTarget, WM_SYSCOMMAND, SC_MONITORPOWER, (LPARAM)2);
+    BroadcastSysCommand(SC_MONITORPOWER, (LPARAM)2);
 }
 
 static void ActionQuickSettings() { SendKeys({VK_LWIN, 'A'}); }
@@ -1643,6 +2121,37 @@ static void ActionProjectDisplay() { SendKeys({VK_LWIN, 'P'}); }
 static void ActionVDesktopNext() { SendKeys({VK_LWIN, VK_LCONTROL, VK_RIGHT}); }
 static void ActionVDesktopPrev() { SendKeys({VK_LWIN, VK_LCONTROL, VK_LEFT}); }
 static void ActionVDesktopNew() { SendKeys({VK_LWIN, VK_LCONTROL, 'D'}); }
+static void ActionVDesktopClose() { SendKeys({VK_LWIN, VK_LCONTROL, VK_F4}); }
+
+// Lock first, then blank. Blanking first tends to wake the display straight
+// back up, because the switch to the lock screen counts as activity.
+static void ActionLockAndMonitorsOff()
+{
+    LockWorkStation();
+
+    // The lock transition itself counts as activity, so blanking too soon
+    // just wakes the display straight back up. How long the switch to the
+    // secure desktop takes varies by machine, hence the setting.
+    Sleep((DWORD)g_lockBlankDelayMs);
+    BroadcastSysCommand(SC_MONITORPOWER, (LPARAM)2);
+}
+
+// SetThreadExecutionState is per-thread and only holds while that thread
+// lives, so these must run on the action worker — which they do, and which
+// stays alive for the whole session. The worker clears the state on exit.
+static void ActionKeepAwakeOn()
+{
+    SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED |
+                            ES_SYSTEM_REQUIRED);
+    Wh_Log(L"Keep awake ON - screensaver, display sleep and system sleep are "
+           L"suppressed until you trigger Keep Awake Off.");
+}
+
+static void ActionKeepAwakeOff()
+{
+    SetThreadExecutionState(ES_CONTINUOUS);
+    Wh_Log(L"Keep awake OFF - normal power behaviour restored.");
+}
 
 static void ActionLock() { LockWorkStation(); }
 
@@ -1780,6 +2289,12 @@ static CornerAction ParseActionType(const std::wstring &raw)
         {L"ACTION_VDESK_NEXT", CornerAction::VDesktopNext},
         {L"ACTION_VDESK_PREV", CornerAction::VDesktopPrev},
         {L"ACTION_VDESK_NEW", CornerAction::VDesktopNew},
+        {L"ACTION_VDESK_CLOSE", CornerAction::VDesktopClose},
+        {L"ACTION_LOCK_MONITORS_OFF", CornerAction::LockAndMonitorsOff},
+        {L"ACTION_KEEP_AWAKE_ON", CornerAction::KeepAwakeOn},
+        {L"ACTION_KEEP_AWAKE_OFF", CornerAction::KeepAwakeOff},
+        {L"ACTION_ALTERNATE_KEYPRESS", CornerAction::AlternateKeypress},
+        {L"ACTION_ALTERNATE_COMMAND", CornerAction::AlternateCommand},
         {L"ACTION_SEND_KEYPRESS", CornerAction::SendKeypress},
         {L"ACTION_START_PROCESS", CornerAction::StartProcess},
     };
@@ -1821,10 +2336,62 @@ static const wchar_t *ActionToString(CornerAction a)
     case CornerAction::VDesktopNext: return L"Virtual Desktop Next";
     case CornerAction::VDesktopPrev: return L"Virtual Desktop Previous";
     case CornerAction::VDesktopNew: return L"Virtual Desktop New";
+    case CornerAction::VDesktopClose: return L"Virtual Desktop Close";
+    case CornerAction::LockAndMonitorsOff: return L"Lock and Turn Off Monitors";
+    case CornerAction::KeepAwakeOn: return L"Keep Awake On";
+    case CornerAction::KeepAwakeOff: return L"Keep Awake Off";
+    case CornerAction::AlternateKeypress: return L"Alternate Key Press";
+    case CornerAction::AlternateCommand: return L"Alternate Command";
     case CornerAction::SendKeypress: return L"Virtual Key Press";
     case CornerAction::StartProcess: return L"Custom Command";
     }
     return L"Unknown";
+}
+
+// Inverse of ParseActionType: the stable id a value store / settings file uses.
+static const wchar_t *ActionIdFromEnum(CornerAction a)
+{
+    switch (a)
+    {
+    case CornerAction::Nothing: return L"ACTION_NOTHING";
+    case CornerAction::ShowDesktop: return L"ACTION_SHOW_DESKTOP";
+    case CornerAction::TaskView: return L"ACTION_TASK_VIEW";
+    case CornerAction::ScreenSaver: return L"ACTION_SCREENSAVER";
+    case CornerAction::MonitorsOff: return L"ACTION_MONITORS_OFF";
+    case CornerAction::QuickSettings: return L"ACTION_QUICK_SETTINGS";
+    case CornerAction::NotificationCenter: return L"ACTION_NOTIFICATION_CENTER";
+    case CornerAction::StartMenu: return L"ACTION_START_MENU";
+    case CornerAction::HideOthers: return L"ACTION_HIDE_OTHERS";
+    case CornerAction::Mute: return L"ACTION_MUTE";
+    case CornerAction::TaskManager: return L"ACTION_TASK_MANAGER";
+    case CornerAction::Lock: return L"ACTION_LOCK";
+    case CornerAction::Sleep: return L"ACTION_SLEEP";
+    case CornerAction::SwitchLastWindow: return L"ACTION_SWITCH_LAST";
+    case CornerAction::TaskSwitcher: return L"ACTION_TASK_SWITCHER";
+    case CornerAction::MinimizeWindow: return L"ACTION_MINIMIZE";
+    case CornerAction::MaximizeWindow: return L"ACTION_MAXIMIZE";
+    case CornerAction::SnapLeft: return L"ACTION_SNAP_LEFT";
+    case CornerAction::SnapRight: return L"ACTION_SNAP_RIGHT";
+    case CornerAction::CloseWindow: return L"ACTION_CLOSE_WINDOW";
+    case CornerAction::FileExplorer: return L"ACTION_FILE_EXPLORER";
+    case CornerAction::SettingsApp: return L"ACTION_SETTINGS";
+    case CornerAction::Search: return L"ACTION_SEARCH";
+    case CornerAction::ClipboardHistory: return L"ACTION_CLIPBOARD";
+    case CornerAction::Screenshot: return L"ACTION_SCREENSHOT";
+    case CornerAction::ProjectDisplay: return L"ACTION_PROJECT";
+    case CornerAction::VDesktopNext: return L"ACTION_VDESK_NEXT";
+    case CornerAction::VDesktopPrev: return L"ACTION_VDESK_PREV";
+    case CornerAction::VDesktopNew: return L"ACTION_VDESK_NEW";
+    case CornerAction::VDesktopClose: return L"ACTION_VDESK_CLOSE";
+    case CornerAction::LockAndMonitorsOff: return L"ACTION_LOCK_MONITORS_OFF";
+    case CornerAction::KeepAwakeOn: return L"ACTION_KEEP_AWAKE_ON";
+    case CornerAction::KeepAwakeOff: return L"ACTION_KEEP_AWAKE_OFF";
+    case CornerAction::AlternateKeypress: return L"ACTION_ALTERNATE_KEYPRESS";
+    case CornerAction::AlternateCommand: return L"ACTION_ALTERNATE_COMMAND";
+    case CornerAction::SendKeypress: return L"ACTION_SEND_KEYPRESS";
+    case CornerAction::StartProcess: return L"ACTION_START_PROCESS";
+    }
+    return L"ACTION_NOTHING";
 }
 
 static const wchar_t *ZoneToString(Zone z)
@@ -1839,8 +2406,24 @@ static const wchar_t *ZoneToString(Zone z)
     case ZONE_EDGE_BOTTOM: return L"Bottom edge";
     case ZONE_EDGE_LEFT: return L"Left edge";
     case ZONE_EDGE_RIGHT: return L"Right edge";
+    case ZONE_CENTER_TOP: return L"Top edge centre";
+    case ZONE_CENTER_BOTTOM: return L"Bottom edge centre";
+    case ZONE_CENTER_LEFT: return L"Left edge centre";
+    case ZONE_CENTER_RIGHT: return L"Right edge centre";
     default: return L"None";
     }
+}
+
+// Splits "a | b" into its two halves. Both must be non-empty.
+static bool SplitAlternate(const std::wstring &args, std::wstring &first,
+                           std::wstring &second)
+{
+    auto bar = args.find(L'|');
+    if (bar == std::wstring::npos)
+        return false;
+    first = TrimStr(args.substr(0, bar));
+    second = TrimStr(args.substr(bar + 1));
+    return !first.empty() && !second.empty();
 }
 
 // Creates an action executor from action type and args
@@ -1878,6 +2461,65 @@ static std::function<void()> MakeExecutor(CornerAction action,
     case CornerAction::VDesktopNext: return ActionVDesktopNext;
     case CornerAction::VDesktopPrev: return ActionVDesktopPrev;
     case CornerAction::VDesktopNew: return ActionVDesktopNew;
+    case CornerAction::VDesktopClose: return ActionVDesktopClose;
+    case CornerAction::LockAndMonitorsOff: return ActionLockAndMonitorsOff;
+    case CornerAction::KeepAwakeOn: return ActionKeepAwakeOn;
+    case CornerAction::KeepAwakeOff: return ActionKeepAwakeOff;
+    // Alternating actions.
+    //
+    // Deliberately built as two extra action types rather than by giving every
+    // zone a second action + args. That would have doubled a settings block
+    // that is already twelve zones long, for a feature most zones will never
+    // use. Here the two halves live in the existing Args field, split on "|",
+    // so nothing about the zone structure, the hit test or the detection loop
+    // changes at all.
+    //
+    // The alternation flag is a shared_ptr captured by the lambda, so it
+    // travels with the executor and needs no per-zone state anywhere else.
+    // It resets whenever the zone set is rebuilt — settings change, display
+    // change — which is the documented behaviour.
+    case CornerAction::AlternateKeypress:
+    {
+        std::wstring left, right;
+        if (!SplitAlternate(args, left, right))
+        {
+            Wh_Log(L"Alternate Key Press: expected two combinations separated "
+                   L"by | , for example  Alt+S | Alt+H");
+            return nullptr;
+        }
+        auto first = ParseKeyCombo(left);
+        auto second = ParseKeyCombo(right);
+        if (first.empty() || second.empty())
+        {
+            Wh_Log(L"Alternate Key Press: could not parse both sides of '%s'",
+                   args.c_str());
+            return nullptr;
+        }
+        auto useSecond = std::make_shared<bool>(false);
+        return [first, second, useSecond]()
+        {
+            const auto &combos = *useSecond ? second : first;
+            *useSecond = !*useSecond;
+            for (const auto &keys : combos)
+                SendKeys(keys);
+        };
+    }
+    case CornerAction::AlternateCommand:
+    {
+        std::wstring left, right;
+        if (!SplitAlternate(args, left, right))
+        {
+            Wh_Log(L"Alternate Command: expected two commands separated by | ");
+            return nullptr;
+        }
+        auto useSecond = std::make_shared<bool>(false);
+        return [left, right, useSecond]()
+        {
+            const std::wstring &cmd = *useSecond ? right : left;
+            *useSecond = !*useSecond;
+            ActionStartProcess(cmd);
+        };
+    }
     case CornerAction::SendKeypress:
     {
         auto combos = ParseKeyCombo(args);
@@ -1967,34 +2609,60 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
 
     set->activationDelay = g_settings.activationDelay;
     set->settleMs = g_settings.settleMs;
+    set->knockWindowMs = g_settings.knockWindowMs;
+    set->requireModifier = g_settings.requireModifier;
     set->cooldownMs = g_settings.cooldownMs;
     set->disableDuringDrag = g_settings.disableDuringDrag;
 
     for (const auto &mon : g_monitors)
-    {
-        const RECT &r = mon.rcMonitor;
+        set->monitorNames.push_back(mon.id);
 
-        // Clamp per monitor so the eight zones are provably disjoint and the
-        // hit test's first-match-wins can never hide one behind another:
-        //   - a corner bigger than half the screen would overlap its opposite
-        //   - an edge strip thicker than the corner box would overlap the
-        //     perpendicular edge (EdgeTop vs EdgeLeft), and only whichever
-        //     was added first would ever fire
+    for (const auto &mon : g_monitors)
+    {
+        // rcWork is the monitor minus the taskbar and any docked appbars, so
+        // using it is a complete fix for zones colliding with the taskbar,
+        // including the taskbar's own "peek at desktop" strip.
+        const RECT &r =
+            g_settings.avoidTaskbar ? mon.rcWork : mon.rcMonitor;
+        LONG centrePct = g_settings.centerZonePercent;
+
         int span = (r.right - r.left) < (r.bottom - r.top)
                        ? (r.right - r.left)
                        : (r.bottom - r.top);
-        int cs = csCfg;
-        if (cs > span / 2)
-            cs = span / 2;
-        if (cs < 1)
-            cs = 1;
-        int es = esCfg > cs ? cs : esCfg;
 
-        if (cs != csCfg || es != esCfg)
+        // Each zone may set its own size; -1 means inherit. Corners clamp to
+        // half the screen, then each edge clamps to the smaller of the two
+        // corners it runs between - that single rule is what keeps all twelve
+        // zones disjoint no matter what sizes are chosen.
+        auto zoneCfg = [&](Zone z) { return ResolveZone(mon, z); };
+        auto sizeOf = [&](Zone z, int fallback) -> int
         {
-            Wh_Log(L"  [%s] sizes clamped: corner %d->%d, edge %d->%d",
-                   mon.id.c_str(), csCfg, cs, esCfg, es);
-        }
+            const ZoneConfig *zc = zoneCfg(z);
+            int v = (zc && zc->tuning.size > 0) ? zc->tuning.size : fallback;
+            if (v < 1)
+                v = 1;
+            if (v > span / 2)
+                v = span / 2;
+            if (v < 1)
+                v = 1;
+            return v;
+        };
+
+        int csTL = sizeOf(ZONE_TOP_LEFT, csCfg);
+        int csTR = sizeOf(ZONE_TOP_RIGHT, csCfg);
+        int csBL = sizeOf(ZONE_BOTTOM_LEFT, csCfg);
+        int csBR = sizeOf(ZONE_BOTTOM_RIGHT, csCfg);
+
+        auto edgeThickness = [&](Zone z, int a, int b) -> int
+        {
+            int v = sizeOf(z, esCfg);
+            int cap = a < b ? a : b;
+            return v > cap ? cap : v;
+        };
+        int esTop = edgeThickness(ZONE_EDGE_TOP, csTL, csTR);
+        int esBot = edgeThickness(ZONE_EDGE_BOTTOM, csBL, csBR);
+        int esLeft = edgeThickness(ZONE_EDGE_LEFT, csTL, csBL);
+        int esRight = edgeThickness(ZONE_EDGE_RIGHT, csTR, csBR);
 
         auto add = [&](Zone z, RECT rect)
         {
@@ -2003,36 +2671,84 @@ static std::shared_ptr<const ZoneSet> BuildZoneSet()
                 return;
             HitZone hz;
             hz.rect = rect;
-            hz.exec = zc->executor;
+            hz.zone = z;
+
+            if (zc->action == CornerAction::AlternateKeypress ||
+                zc->action == CornerAction::AlternateCommand)
+            {
+                // Alternating actions keep their flip state inside the
+                // executor, so each zone needs its own rather than a shared
+                // copy from the configuration.
+                hz.exec = MakeExecutor(zc->action, zc->args);
+                if (!hz.exec)
+                    return;
+            }
+            else
+            {
+                hz.exec = zc->executor;
+            }
+
+            const ZoneTuning &tn = zc->tuning;
+            hz.delay = tn.delay >= 0 ? tn.delay : g_settings.activationDelay;
+            hz.settle = tn.settle >= 0 ? tn.settle : g_settings.settleMs;
+            hz.knock = tn.knock >= 0 ? tn.knock : g_settings.knockWindowMs;
+            hz.cooldown = tn.cooldown >= 0 ? tn.cooldown : g_settings.cooldownMs;
+            hz.modifier =
+                tn.modifier >= 0 ? tn.modifier : g_settings.requireModifier;
+
             hz.label = mon.id + L" " + ZoneToString(z) + L" -> " +
                        ActionToString(zc->action);
             set->zones.push_back(std::move(hz));
         };
 
-        // Corners
-        add(ZONE_TOP_LEFT, {r.left, r.top, r.left + cs, r.top + cs});
-        add(ZONE_TOP_RIGHT, {r.right - cs, r.top, r.right, r.top + cs});
-        add(ZONE_BOTTOM_LEFT, {r.left, r.bottom - cs, r.left + cs, r.bottom});
+        add(ZONE_TOP_LEFT, {r.left, r.top, r.left + csTL, r.top + csTL});
+        add(ZONE_TOP_RIGHT, {r.right - csTR, r.top, r.right, r.top + csTR});
+        add(ZONE_BOTTOM_LEFT, {r.left, r.bottom - csBL, r.left + csBL, r.bottom});
         add(ZONE_BOTTOM_RIGHT,
-            {r.right - cs, r.bottom - cs, r.right, r.bottom});
+            {r.right - csBR, r.bottom - csBR, r.right, r.bottom});
 
-        // Edges — the side strip with the corner zones carved out
-        if (r.left + cs < r.right - cs)
+        // Edges run between the two corners they touch, split around a centre
+        // zone when one is configured.
+        auto addEdge = [&](Zone edge, Zone centre, bool horizontal, LONG lo,
+                           LONG hi, LONG nearSide, LONG farSide)
         {
-            add(ZONE_EDGE_TOP,
-                {r.left + cs, r.top, r.right - cs, r.top + es});
-            add(ZONE_EDGE_BOTTOM,
-                {r.left + cs, r.bottom - es, r.right - cs, r.bottom});
-        }
-        if (r.top + cs < r.bottom - cs)
-        {
-            add(ZONE_EDGE_LEFT,
-                {r.left, r.top + cs, r.left + es, r.bottom - cs});
-            add(ZONE_EDGE_RIGHT,
-                {r.right - es, r.top + cs, r.right, r.bottom - cs});
-        }
+            auto rectFor = [&](LONG a, LONG b) -> RECT
+            {
+                return horizontal ? RECT{a, nearSide, b, farSide}
+                                  : RECT{nearSide, a, farSide, b};
+            };
+
+            const ZoneConfig *centreCfg = ResolveZone(mon, centre);
+            LONG sp = hi - lo;
+            LONG width = sp * centrePct / 100;
+
+            if (!centreCfg || width < 1 || width >= sp || sp <= 0)
+            {
+                if (sp > 0)
+                    add(edge, rectFor(lo, hi));
+                return;
+            }
+
+            LONG mid = lo + sp / 2;
+            LONG cLo = mid - width / 2;
+            LONG cHi = cLo + width;
+
+            if (cLo > lo)
+                add(edge, rectFor(lo, cLo));
+            add(centre, rectFor(cLo, cHi));
+            if (cHi < hi)
+                add(edge, rectFor(cHi, hi));
+        };
+
+        addEdge(ZONE_EDGE_TOP, ZONE_CENTER_TOP, true, r.left + csTL,
+                r.right - csTR, r.top, r.top + esTop);
+        addEdge(ZONE_EDGE_BOTTOM, ZONE_CENTER_BOTTOM, true, r.left + csBL,
+                r.right - csBR, r.bottom - esBot, r.bottom);
+        addEdge(ZONE_EDGE_LEFT, ZONE_CENTER_LEFT, false, r.top + csTL,
+                r.bottom - csBL, r.left, r.left + esLeft);
+        addEdge(ZONE_EDGE_RIGHT, ZONE_CENTER_RIGHT, false, r.top + csTR,
+                r.bottom - csBR, r.right - esRight, r.right);
     }
-
     LeaveCriticalSection(&g_settingsLock);
 
     if (set->zones.empty())
@@ -2065,12 +2781,15 @@ static void RebuildZones()
     g_firedThisEntry = false;
     g_lastAnyFireTick = 0;
     g_lastFireTick.assign(set->zones.size(), 0);
+    g_lastExitTick.assign(set->zones.size(), 0);
+    g_knockSatisfied = true;
 
     g_topoCount = GetSystemMetrics(SM_CMONITORS);
     g_topoVirtual = {GetSystemMetrics(SM_XVIRTUALSCREEN),
                      GetSystemMetrics(SM_YVIRTUALSCREEN),
                      GetSystemMetrics(SM_CXVIRTUALSCREEN),
                      GetSystemMetrics(SM_CYVIRTUALSCREEN)};
+    SystemParametersInfoW(SPI_GETWORKAREA, 0, &g_topoWorkArea, 0);
 }
 
 // WM_DISPLAYCHANGE is not delivered for every layout change that matters —
@@ -2082,8 +2801,12 @@ static bool TopologyChanged()
               GetSystemMetrics(SM_YVIRTUALSCREEN),
               GetSystemMetrics(SM_CXVIRTUALSCREEN),
               GetSystemMetrics(SM_CYVIRTUALSCREEN)};
+    RECT work = {};
+    SystemParametersInfoW(SPI_GETWORKAREA, 0, &work, 0);
+
     return GetSystemMetrics(SM_CMONITORS) != g_topoCount ||
-           memcmp(&v, &g_topoVirtual, sizeof(v)) != 0;
+           memcmp(&v, &g_topoVirtual, sizeof(v)) != 0 ||
+           memcmp(&work, &g_topoWorkArea, sizeof(work)) != 0;
 }
 
 // =====================================================================
@@ -2106,7 +2829,12 @@ static DWORD WINAPI ActionWorkerThread(LPVOID)
     {
         DWORD r = WaitForMultipleObjects(2, waits, FALSE, INFINITE);
         if (r == WAIT_OBJECT_0 || r == WAIT_FAILED)
+        {
+            // Release any keep-awake request this thread was holding, so
+            // unloading the mod never leaves the machine unable to sleep.
+            SetThreadExecutionState(ES_CONTINUOUS);
             break;
+        }
 
         for (;;)
         {
@@ -2172,6 +2900,20 @@ static DWORD WINAPI ActionWorkerThread(LPVOID)
 // Detection
 // =====================================================================
 
+// 0 none, 1 Ctrl, 2 Alt, 3 Shift, 4 Win
+static bool RequiredModifierHeld(int which)
+{
+    switch (which)
+    {
+    case 1: return (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
+    case 2: return (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
+    case 3: return (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
+    case 4: return (GetAsyncKeyState(VK_LWIN) & 0x8000) != 0 ||
+                   (GetAsyncKeyState(VK_RWIN) & 0x8000) != 0;
+    default: return true;  // no modifier required
+    }
+}
+
 static bool AnyMouseButtonDown()
 {
     return (GetAsyncKeyState(VK_LBUTTON) & 0x8000) ||
@@ -2183,6 +2925,9 @@ static bool AnyMouseButtonDown()
 
 static void DetectTick()
 {
+    if (!g_trayEnabled.load() || GetTickCount64() < g_suspendUntil.load())
+        return;
+
     std::shared_ptr<const ZoneSet> zones;
     EnterCriticalSection(&g_zonesLock);
     zones = g_zones;
@@ -2213,16 +2958,39 @@ static void DetectTick()
     // once on entry and re-arms only after the cursor leaves it.
     if (idx != g_activeZone)
     {
+        // Record when we left the previous zone, so a quick return to it can
+        // be recognised as the second half of a knock.
+        if (g_activeZone >= 0 && g_activeZone < (int)g_lastExitTick.size())
+            g_lastExitTick[g_activeZone] = now;
+
         g_activeZone = idx;
         g_enterTick = now;
         g_firedThisEntry = false;
+
+        // Knock mode: a single entry never fires. The zone only arms when it
+        // is re-entered soon after being left.
+        int knockMs = (idx >= 0) ? zones->zones[idx].knock : 0;
+        g_knockSatisfied =
+            knockMs <= 0 || idx < 0 ||
+            (idx < (int)g_lastExitTick.size() && g_lastExitTick[idx] != 0 &&
+             (now - g_lastExitTick[idx]) <= (ULONGLONG)knockMs);
     }
 
     if (idx < 0 || g_firedThisEntry)
         return;
 
+    if (!g_knockSatisfied)
+        return;
+
+    // Checked every tick rather than on entry, so the zone becomes live the
+    // moment the modifier goes down while the cursor is already parked.
+    if (!RequiredModifierHeld(zones->zones[idx].modifier))
+        return;
+
     // Suppress for the whole visit, not just this tick — otherwise releasing
     // a drag inside a corner would immediately trigger it.
+    const HitZone &hz = zones->zones[idx];
+
     if (zones->disableDuringDrag && AnyMouseButtonDown())
     {
         g_firedThisEntry = true;
@@ -2235,15 +3003,14 @@ static void DetectTick()
     // and instantly re-closes, looking exactly like nothing happened.
     // Requiring the cursor to settle means a pass-through never fires; only
     // the zone you actually stop in does.
-    int dwell = zones->activationDelay > zones->settleMs ? zones->activationDelay
-                                                         : zones->settleMs;
+    int dwell = hz.delay > hz.settle ? hz.delay : hz.settle;
     if (dwell > 0 && (now - g_enterTick) < (ULONGLONG)dwell)
         return;
 
-    if (zones->cooldownMs > 0 && idx < (int)g_lastFireTick.size())
+    if (hz.cooldown > 0 && idx < (int)g_lastFireTick.size())
     {
         ULONGLONG last = g_lastFireTick[idx];
-        if (last != 0 && (now - last) < (ULONGLONG)zones->cooldownMs)
+        if (last != 0 && (now - last) < (ULONGLONG)hz.cooldown)
         {
             g_firedThisEntry = true;
             return;
@@ -2382,6 +3149,22 @@ static void LoadSettings()
     if (g_settings.settleMs < 0)
         g_settings.settleMs = 0;
 
+    g_settings.knockWindowMs = Wh_GetIntSetting(L"KnockWindowMs");
+    if (g_settings.knockWindowMs < 0)
+        g_settings.knockWindowMs = 0;
+
+    g_settings.requireModifier = Wh_GetIntSetting(L"RequireModifier");
+    if (g_settings.requireModifier < 0 || g_settings.requireModifier > 4)
+        g_settings.requireModifier = 0;
+
+    g_settings.avoidTaskbar = Wh_GetIntSetting(L"AvoidTaskbar") != 0;
+
+    g_settings.centerZonePercent = Wh_GetIntSetting(L"CenterZonePercent");
+    if (g_settings.centerZonePercent < 1)
+        g_settings.centerZonePercent = 1;
+    if (g_settings.centerZonePercent > 90)
+        g_settings.centerZonePercent = 90;
+
     g_settings.cooldownMs = Wh_GetIntSetting(L"CooldownMs");
     if (g_settings.cooldownMs < 0)
         g_settings.cooldownMs = 0;
@@ -2390,6 +3173,12 @@ static void LoadSettings()
     g_settings.disableDuringDrag = Wh_GetIntSetting(L"DisableDuringDrag");
     g_verboseLog = Wh_GetIntSetting(L"VerboseLogging") != 0;
     g_showMonitorNames = Wh_GetIntSetting(L"ShowMonitorNames") != 0;
+
+    g_lockBlankDelayMs = Wh_GetIntSetting(L"LockBlankDelayMs");
+    if (g_lockBlankDelayMs < 0)
+        g_lockBlankDelayMs = 0;
+    if (g_lockBlankDelayMs > 10000)
+        g_lockBlankDelayMs = 10000;
 
     // Excluded processes (semicolon-separated, case-insensitive)
     g_settings.excludedProcesses.clear();
@@ -2420,6 +3209,7 @@ static void LoadSettings()
     static const wchar_t *zoneKeys[ZONE_COUNT] = {
         L"TopLeft", L"TopRight",   L"BottomLeft", L"BottomRight",
         L"EdgeTop", L"EdgeBottom", L"EdgeLeft",   L"EdgeRight",
+        L"CenterTop", L"CenterBottom", L"CenterLeft", L"CenterRight",
     };
 
     for (int i = 0; i < 16; i++)
@@ -2494,6 +3284,1894 @@ static void LoadSettings()
 }
 
 // =====================================================================
+// Tray Icon
+// =====================================================================
+//
+// Runs on its own thread with its own window and message loop. That is not
+// decoration: TrackPopupMenu is modal and does not return until the menu
+// closes, so hosting it on the detection thread would freeze every zone for
+// as long as the menu is open.
+//
+// Settings that the tray can change are stored as *overrides* in the mod's own
+// value store (Wh_GetIntValue / Wh_SetIntValue). Windhawk settings themselves
+// are read-only from inside a mod, so the tray cannot write what you see on
+// the Settings page. Overrides are applied on top of the settings at load, and
+// "Clear tray overrides" removes them.
+
+static HANDLE g_hTrayThread = nullptr;
+static DWORD g_dwTrayThreadId = 0;
+static HWND g_hTrayWnd = nullptr;
+static UINT g_taskbarCreatedMsg = 0;
+static constexpr UINT WM_APP_TRAY = WM_APP + 10;
+static constexpr UINT_PTR kTrayIconId = 1;
+
+// A stable GUID gives the icon an identity of its own. Without one it is keyed
+// on the host executable, which for a Windhawk tool mod is windhawk.exe and is
+// therefore shared with every other tray-owning mod — so Windows cannot tell
+// our show/hide preference apart from theirs.
+static const GUID kTrayIconGuid = {
+    0x7c15402a, 0xfbae, 0x41d8,
+    {0xad, 0x28, 0x46, 0xad, 0x02, 0x40, 0x8d, 0x73}};
+
+// Set once NIM_ADD succeeds. NIF_GUID also validates the registering
+// executable's path, so if it is ever rejected we fall back to plain uID
+// identity rather than losing the icon entirely.
+static bool g_trayUseGuid = true;
+
+// NOTIFYICON_VERSION_4 changes what the shell sends:
+//   left-click  -> NIN_SELECT      (rather than WM_LBUTTONUP)
+//   right-click -> WM_CONTEXTMENU  (rather than WM_RBUTTONUP)
+//   keyboard    -> NIN_KEYSELECT
+// and it packs the cursor position into wParam. Both the old and new forms are
+// accepted below so the icon behaves identically if the version call fails.
+#ifndef NIN_SELECT
+#define NIN_SELECT (WM_USER + 0)
+#endif
+#ifndef NIN_KEYSELECT
+#define NIN_KEYSELECT (WM_USER + 1)
+#endif
+#ifndef NOTIFYICON_VERSION_4
+#define NOTIFYICON_VERSION_4 4
+#endif
+#ifndef NIF_SHOWTIP
+#define NIF_SHOWTIP 0x00000080
+#endif
+
+enum TrayCommand
+{
+    IDM_SETTINGS = 100,
+    IDM_ENABLED,
+    IDM_SUSPEND_15,
+    IDM_SUSPEND_30,
+    IDM_SUSPEND_60,
+    IDM_RESUME,
+    IDM_FULLSCREEN,
+    IDM_DRAG,
+    IDM_VERBOSE,
+    IDM_CLEAR_OVERRIDES,
+    IDM_ABOUT,
+};
+
+// Defined further down with the dashboard; the tray menu needs it earlier.
+static void OpenDashboard();
+
+// -1 means "no override, use the Windhawk setting"
+static const wchar_t *kOvrEnabled = L"ovr_enabled";
+static const wchar_t *kOvrFullscreen = L"ovr_fullscreen";
+static const wchar_t *kOvrDrag = L"ovr_drag";
+static const wchar_t *kOvrVerbose = L"ovr_verbose";
+
+static HICON MakeTrayIcon(bool enabled)
+{
+    int sz = GetSystemMetrics(SM_CXSMICON);
+    if (sz < 8)
+        sz = 16;
+
+    BITMAPINFO bmi = {};
+    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth = sz;
+    bmi.bmiHeader.biHeight = -sz;
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    void *bits = nullptr;
+    HDC hdc = GetDC(nullptr);
+    HBITMAP hColor =
+        CreateDIBSection(hdc, &bmi, DIB_RGB_COLORS, &bits, nullptr, 0);
+    ReleaseDC(nullptr, hdc);
+    if (!hColor || !bits)
+    {
+        if (hColor)
+            DeleteObject(hColor);
+        return nullptr;
+    }
+
+    // A screen outline with one corner lit. Mid-tone colours so it stays
+    // legible on both a light and a dark taskbar.
+    DWORD *px = static_cast<DWORD *>(bits);
+    const DWORD frame = enabled ? 0xFFB0B0B0 : 0xFF707070;
+    const DWORD accent = enabled ? 0xFF4CC2FF : 0xFF707070;
+    int block = sz / 3;
+    if (block < 3)
+        block = 3;
+
+    for (int y = 0; y < sz; y++)
+    {
+        for (int x = 0; x < sz; x++)
+        {
+            DWORD c = 0;  // transparent
+            if (x == 0 || y == 0 || x == sz - 1 || y == sz - 1)
+                c = frame;
+            if (x < block && y < block)
+                c = accent;
+            px[y * sz + x] = c;
+        }
+    }
+
+    HBITMAP hMask = CreateBitmap(sz, sz, 1, 1, nullptr);
+    ICONINFO ii = {};
+    ii.fIcon = TRUE;
+    ii.hbmColor = hColor;
+    ii.hbmMask = hMask;
+    HICON hIcon = CreateIconIndirect(&ii);
+
+    DeleteObject(hColor);
+    if (hMask)
+        DeleteObject(hMask);
+    return hIcon;
+}
+
+static void FillTrayIconData(NOTIFYICONDATAW &nid)
+{
+    nid.cbSize = sizeof(nid);
+    nid.hWnd = g_hTrayWnd;
+    nid.uID = (UINT)kTrayIconId;
+    if (g_trayUseGuid)
+    {
+        nid.uFlags |= NIF_GUID;
+        nid.guidItem = kTrayIconGuid;
+    }
+}
+
+static void UpdateTrayIcon(bool add)
+{
+    if (!g_hTrayWnd)
+        return;
+
+    bool active = g_trayEnabled && GetTickCount64() >= g_suspendUntil.load();
+
+    NOTIFYICONDATAW nid = {};
+    nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP | NIF_SHOWTIP;
+    FillTrayIconData(nid);
+    nid.uCallbackMessage = WM_APP_TRAY;
+    nid.hIcon = MakeTrayIcon(active);
+    wcscpy_s(nid.szTip, active ? L"Win-X Hot Corners - active"
+                               : L"Win-X Hot Corners - paused");
+
+    BOOL ok = Shell_NotifyIconW(add ? NIM_ADD : NIM_MODIFY, &nid);
+
+    // NIF_GUID ties the icon to the registering executable's path. If the
+    // shell rejects it, drop the GUID and retry rather than silently ending up
+    // with no icon at all.
+    if (!ok && add && g_trayUseGuid)
+    {
+        Wh_Log(L"Tray: GUID identity refused, falling back to plain icon id");
+        g_trayUseGuid = false;
+        NOTIFYICONDATAW retry = {};
+        retry.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP | NIF_SHOWTIP;
+        FillTrayIconData(retry);
+        retry.uCallbackMessage = WM_APP_TRAY;
+        retry.hIcon = nid.hIcon;
+        wcscpy_s(retry.szTip, nid.szTip);
+        ok = Shell_NotifyIconW(NIM_ADD, &retry);
+    }
+
+    // Opt into the modern notification behaviour. Only meaningful right after
+    // the icon is added.
+    if (ok && add)
+    {
+        NOTIFYICONDATAW ver = {};
+        ver.uFlags = 0;
+        FillTrayIconData(ver);
+        ver.uVersion = NOTIFYICON_VERSION_4;
+        Shell_NotifyIconW(NIM_SETVERSION, &ver);
+    }
+
+    if (nid.hIcon)
+        DestroyIcon(nid.hIcon);
+}
+
+// =====================================================================
+// Dashboard persistence
+// =====================================================================
+//
+// The dashboard cannot write the Windhawk Settings page — Wh_GetIntSetting is
+// read-only from inside a mod. Everything it changes is therefore stored in
+// the mod's own value store and layered over the settings at load. "Reset to
+// Windhawk settings" clears the whole layer.
+//
+// One key per field rather than a packed string: verbose, but it survives
+// partial writes and is readable if anything ever needs debugging by hand.
+
+static constexpr int kMaxGuiConfigs = 8;
+
+static std::wstring GetStrValue(const wchar_t *name)
+{
+    WCHAR buf[512] = {};
+    if (Wh_GetStringValue(name, buf, ARRAYSIZE(buf)) == 0)
+        return L"";
+    return buf;
+}
+
+static std::wstring GuiKey(int cfg, int zone, const wchar_t *what)
+{
+    wchar_t k[64];
+    if (zone < 0)
+        _snwprintf_s(k, _countof(k), _TRUNCATE, L"g%d.%s", cfg, what);
+    else
+        _snwprintf_s(k, _countof(k), _TRUNCATE, L"g%d.z%d.%s", cfg, zone, what);
+    return k;
+}
+
+// Replaces g_settings.monitorConfigs when the dashboard has saved a layout.
+// Caller must hold g_settingsLock.
+static bool ApplyDashboardZones()
+{
+    if (Wh_GetIntValue(L"gui_active", 0) == 0)
+        return false;
+
+    std::vector<MonitorZoneConfig> configs;
+    for (int i = 0; i < kMaxGuiConfigs; i++)
+    {
+        std::wstring id = GetStrValue(GuiKey(i, -1, L"id").c_str());
+        if (id.empty())
+            continue;
+
+        MonitorZoneConfig cfg;
+        cfg.monitorId = (id == L"(unused)") ? L"" : id;
+        cfg.monitorIndex = 0;
+
+        bool any = false;
+        for (int z = 0; z < ZONE_COUNT; z++)
+        {
+            std::wstring a = GetStrValue(GuiKey(i, z, L"a").c_str());
+            std::wstring g = GetStrValue(GuiKey(i, z, L"g").c_str());
+            CornerAction act = ParseActionType(a);
+            cfg.zones[z].action = act;
+            cfg.zones[z].args = g;
+            cfg.zones[z].executor = MakeExecutor(act, g);
+            cfg.zones[z].tuning.size = Wh_GetIntValue(GuiKey(i, z, L"sz").c_str(), -1);
+            cfg.zones[z].tuning.delay = Wh_GetIntValue(GuiKey(i, z, L"dl").c_str(), -1);
+            cfg.zones[z].tuning.settle = Wh_GetIntValue(GuiKey(i, z, L"gd").c_str(), -1);
+            cfg.zones[z].tuning.knock = Wh_GetIntValue(GuiKey(i, z, L"kn").c_str(), -1);
+            cfg.zones[z].tuning.cooldown = Wh_GetIntValue(GuiKey(i, z, L"cd").c_str(), -1);
+            cfg.zones[z].tuning.modifier = Wh_GetIntValue(GuiKey(i, z, L"md").c_str(), -1);
+            if (act != CornerAction::Nothing)
+                any = true;
+        }
+        if (any)
+            configs.push_back(std::move(cfg));
+    }
+
+    if (configs.empty())
+        return false;
+
+    g_settings.monitorConfigs = std::move(configs);
+    Wh_Log(L"Using the dashboard's zone layout (%d configuration%s)",
+           (int)g_settings.monitorConfigs.size(),
+           g_settings.monitorConfigs.size() == 1 ? L"" : L"s");
+    return true;
+}
+
+static void ClearDashboardConfig()
+{
+    Wh_SetIntValue(L"gui_active", 0);
+    for (int i = 0; i < kMaxGuiConfigs; i++)
+    {
+        Wh_SetStringValue(GuiKey(i, -1, L"id").c_str(), L"");
+        for (int z = 0; z < ZONE_COUNT; z++)
+        {
+            Wh_SetStringValue(GuiKey(i, z, L"a").c_str(), L"");
+            Wh_SetStringValue(GuiKey(i, z, L"g").c_str(), L"");
+            for (const wchar_t *k : {L"sz", L"dl", L"gd", L"kn", L"cd", L"md"})
+                Wh_SetIntValue(GuiKey(i, z, k).c_str(), -1);
+        }
+    }
+}
+
+static void ApplyTrayOverrides()
+{
+    // Called after LoadSettings so overrides win over the settings page.
+    int v = Wh_GetIntValue(kOvrEnabled, -1);
+    g_trayEnabled = (v < 0) ? true : (v != 0);
+
+    // g_settings is read by the worker thread under this lock, so take it
+    // here too rather than writing the fields from underneath it.
+    EnterCriticalSection(&g_settingsLock);
+
+    v = Wh_GetIntValue(kOvrFullscreen, -1);
+    if (v >= 0)
+        g_settings.disableOnFullscreen = (v != 0);
+
+    v = Wh_GetIntValue(kOvrDrag, -1);
+    if (v >= 0)
+        g_settings.disableDuringDrag = (v != 0);
+
+    LeaveCriticalSection(&g_settingsLock);
+
+    v = Wh_GetIntValue(kOvrVerbose, -1);
+    if (v >= 0)
+        g_verboseLog = (v != 0);
+
+    // Everything the dashboard writes.
+    if (Wh_GetIntValue(L"gui_active", 0) != 0)
+    {
+        EnterCriticalSection(&g_settingsLock);
+        auto pull = [](const wchar_t *k, int &dst, int lo, int hi)
+        {
+            int x = Wh_GetIntValue(k, -1);
+            if (x >= lo && x <= hi)
+                dst = x;
+        };
+        pull(L"ovr_corner", g_settings.cornerSize, 1, 500);
+        pull(L"ovr_edge", g_settings.edgeSize, 1, 500);
+        pull(L"ovr_delay", g_settings.activationDelay, 0, 10000);
+        pull(L"ovr_settle", g_settings.settleMs, 0, 10000);
+        pull(L"ovr_knock", g_settings.knockWindowMs, 0, 10000);
+        pull(L"ovr_cooldown", g_settings.cooldownMs, 0, 60000);
+        pull(L"ovr_centre", g_settings.centerZonePercent, 1, 90);
+        pull(L"ovr_modifier", g_settings.requireModifier, 0, 4);
+        pull(L"ovr_lockblank", g_lockBlankDelayMs, 0, 10000);
+
+        int x = Wh_GetIntValue(L"ovr_taskbar", -1);
+        if (x >= 0)
+            g_settings.avoidTaskbar = (x != 0);
+        x = Wh_GetIntValue(L"ovr_monnames", -1);
+        if (x >= 0)
+            g_showMonitorNames = (x != 0);
+
+        std::wstring excl = GetStrValue(L"ovr_excluded");
+        if (!excl.empty())
+        {
+            g_settings.excludedProcesses.clear();
+            std::wstring rest = excl;
+            while (!rest.empty())
+            {
+                auto semi = rest.find(L';');
+                std::wstring tok;
+                if (semi != std::wstring::npos)
+                {
+                    tok = TrimStr(rest.substr(0, semi));
+                    rest = rest.substr(semi + 1);
+                }
+                else
+                {
+                    tok = TrimStr(rest);
+                    rest.clear();
+                }
+                if (!tok.empty())
+                    g_settings.excludedProcesses.push_back(ToLowerStr(tok));
+            }
+        }
+
+        ApplyDashboardZones();
+        LeaveCriticalSection(&g_settingsLock);
+    }
+}
+
+static void ShowTrayMenu(POINT pt)
+{
+    HMENU hMenu = CreatePopupMenu();
+    if (!hMenu)
+        return;
+
+    bool suspended = GetTickCount64() < g_suspendUntil.load();
+
+    AppendMenuW(hMenu, MF_STRING, IDM_SETTINGS, L"Mod Settings...");
+    SetMenuDefaultItem(hMenu, IDM_SETTINGS, FALSE);
+    AppendMenuW(hMenu, MF_SEPARATOR, 0, nullptr);
+    AppendMenuW(hMenu, MF_STRING | (g_trayEnabled ? MF_CHECKED : 0),
+                IDM_ENABLED, L"Hot corners enabled");
+
+    HMENU hSuspend = CreatePopupMenu();
+    AppendMenuW(hSuspend, MF_STRING, IDM_SUSPEND_15, L"15 minutes");
+    AppendMenuW(hSuspend, MF_STRING, IDM_SUSPEND_30, L"30 minutes");
+    AppendMenuW(hSuspend, MF_STRING, IDM_SUSPEND_60, L"1 hour");
+    if (suspended)
+    {
+        AppendMenuW(hSuspend, MF_SEPARATOR, 0, nullptr);
+        AppendMenuW(hSuspend, MF_STRING, IDM_RESUME, L"Resume now");
+    }
+    AppendMenuW(hMenu, MF_POPUP, (UINT_PTR)hSuspend,
+                suspended ? L"Suspended..." : L"Suspend for");
+
+    AppendMenuW(hMenu, MF_SEPARATOR, 0, nullptr);
+
+    EnterCriticalSection(&g_settingsLock);
+    bool fs = g_settings.disableOnFullscreen;
+    bool drag = g_settings.disableDuringDrag;
+    LeaveCriticalSection(&g_settingsLock);
+
+    AppendMenuW(hMenu, MF_STRING | (fs ? MF_CHECKED : 0), IDM_FULLSCREEN,
+                L"Skip while an app is fullscreen");
+    AppendMenuW(hMenu, MF_STRING | (drag ? MF_CHECKED : 0), IDM_DRAG,
+                L"Skip while dragging the mouse");
+    AppendMenuW(hMenu, MF_STRING | (g_verboseLog ? MF_CHECKED : 0),
+                IDM_VERBOSE, L"Verbose logging");
+
+    AppendMenuW(hMenu, MF_SEPARATOR, 0, nullptr);
+    AppendMenuW(hMenu, MF_STRING, IDM_CLEAR_OVERRIDES,
+                L"Reset to Windhawk settings");
+    AppendMenuW(hMenu, MF_STRING | MF_DISABLED, IDM_ABOUT,
+                L"Win-X Hot Corners " WH_MOD_VERSION);
+
+    // Required so the menu dismisses when the user clicks elsewhere.
+    SetForegroundWindow(g_hTrayWnd);
+    TrackPopupMenu(hMenu, TPM_RIGHTBUTTON, pt.x, pt.y, 0, g_hTrayWnd, nullptr);
+    PostMessage(g_hTrayWnd, WM_NULL, 0, 0);
+
+    DestroyMenu(hMenu);
+}
+
+// The zone snapshot carries drag/settle, so a change there needs a rebuild.
+static void RequestRebuild()
+{
+    if (g_hDetectWnd)
+        PostMessage(g_hDetectWnd, WM_APP_REBUILD, 0, 0);
+}
+
+static void HandleTrayCommand(UINT id)
+{
+    switch (id)
+    {
+    case IDM_SETTINGS:
+        OpenDashboard();
+        return;
+
+    case IDM_ENABLED:
+        g_trayEnabled = !g_trayEnabled;
+        Wh_SetIntValue(kOvrEnabled, g_trayEnabled ? 1 : 0);
+        g_suspendUntil = 0;
+        Wh_Log(L"Tray: hot corners %s", g_trayEnabled ? L"enabled" : L"disabled");
+        break;
+
+    case IDM_SUSPEND_15:
+    case IDM_SUSPEND_30:
+    case IDM_SUSPEND_60:
+    {
+        int mins = (id == IDM_SUSPEND_15) ? 15 : (id == IDM_SUSPEND_30) ? 30 : 60;
+        g_suspendUntil = GetTickCount64() + (ULONGLONG)mins * 60 * 1000;
+        Wh_Log(L"Tray: suspended for %d minutes", mins);
+        break;
+    }
+
+    case IDM_RESUME:
+        g_suspendUntil = 0;
+        Wh_Log(L"Tray: resumed");
+        break;
+
+    case IDM_FULLSCREEN:
+    {
+        EnterCriticalSection(&g_settingsLock);
+        g_settings.disableOnFullscreen = !g_settings.disableOnFullscreen;
+        int v = g_settings.disableOnFullscreen ? 1 : 0;
+        LeaveCriticalSection(&g_settingsLock);
+        Wh_SetIntValue(kOvrFullscreen, v);
+        break;
+    }
+
+    case IDM_DRAG:
+    {
+        EnterCriticalSection(&g_settingsLock);
+        g_settings.disableDuringDrag = !g_settings.disableDuringDrag;
+        int v = g_settings.disableDuringDrag ? 1 : 0;
+        LeaveCriticalSection(&g_settingsLock);
+        Wh_SetIntValue(kOvrDrag, v);
+        RequestRebuild();
+        break;
+    }
+
+    case IDM_VERBOSE:
+        g_verboseLog = !g_verboseLog;
+        Wh_SetIntValue(kOvrVerbose, g_verboseLog ? 1 : 0);
+        break;
+
+    case IDM_CLEAR_OVERRIDES:
+        Wh_SetIntValue(kOvrEnabled, -1);
+        Wh_SetIntValue(kOvrFullscreen, -1);
+        Wh_SetIntValue(kOvrDrag, -1);
+        Wh_SetIntValue(kOvrVerbose, -1);
+        g_suspendUntil = 0;
+        LoadSettings();
+        ApplyTrayOverrides();
+        RequestRebuild();
+        Wh_Log(L"Tray: overrides cleared, back to the Windhawk settings");
+        break;
+
+    default:
+        return;
+    }
+
+    UpdateTrayIcon(false);
+}
+
+// =====================================================================
+// Settings dashboard
+// =====================================================================
+//
+// A real window rather than a context menu, so every setting is reachable
+// without opening Windhawk. Runs on its own thread with its own message loop
+// and IsDialogMessage, so Tab/arrow navigation works and nothing it does can
+// stall detection.
+//
+// Mica is requested where the OS supports it, but classic Win32 controls paint
+// opaque, so the window is also fully dark-themed — that, not the backdrop, is
+// what makes it look native.
+
+static HANDLE g_hDashThread = nullptr;
+static HWND g_hDashWnd = nullptr;
+
+// The dashboard followed the system theme in neither direction before: it was
+// hard-coded dark, so on a light desktop the text was near-invisible. The
+// palette is now built from the user's actual preference and rebuilt when they
+// change it.
+struct Palette
+{
+    COLORREF bg, panel, text, dim, field, fieldText, border, accent, accentText;
+};
+static Palette g_pal;
+static bool g_lightTheme = false;
+
+static bool SystemUsesLightTheme()
+{
+    HKEY k;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                      L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\"
+                      L"Personalize",
+                      0, KEY_QUERY_VALUE, &k) != ERROR_SUCCESS)
+        return false;
+    DWORD v = 0, cb = sizeof(v), type = 0;
+    bool light = false;
+    if (RegQueryValueExW(k, L"AppsUseLightTheme", nullptr, &type, (LPBYTE)&v,
+                         &cb) == ERROR_SUCCESS &&
+        type == REG_DWORD)
+        light = (v != 0);
+    RegCloseKey(k);
+    return light;
+}
+
+static void BuildPalette()
+{
+    g_lightTheme = SystemUsesLightTheme();
+    if (g_lightTheme)
+    {
+        g_pal = {RGB(243, 243, 243), RGB(251, 251, 251), RGB(26, 26, 26),
+                 RGB(95, 95, 95),    RGB(255, 255, 255), RGB(26, 26, 26),
+                 RGB(214, 214, 214), RGB(0, 95, 184),    RGB(255, 255, 255)};
+    }
+    else
+    {
+        g_pal = {RGB(32, 32, 32),    RGB(43, 43, 43),   RGB(255, 255, 255),
+                 RGB(170, 170, 170), RGB(45, 45, 45),   RGB(255, 255, 255),
+                 RGB(70, 70, 70),    RGB(76, 194, 255), RGB(0, 0, 0)};
+    }
+}
+
+enum DashId
+{
+    IDC_MONITOR = 1000,
+    IDC_PAGE_ZONES,
+    IDC_PAGE_OPTIONS,
+    IDC_SAVE,
+    IDC_CANCEL,
+    IDC_RESET,
+    IDC_ZONE_ACTION = 1100,           // + zone index
+    IDC_ZONE_ARGS = 1200,             // + zone index
+    IDC_HDR_ZONE = 1250,
+    IDC_HDR_ACTION,
+    IDC_HDR_ARGS,
+    IDC_TZ_TITLE,
+    IDC_TZ_HINT,
+    IDC_TZ_FIRST = 1260,   // six per-zone override fields
+    IDC_TZ_SIZE = IDC_TZ_FIRST,
+    IDC_TZ_DELAY,
+    IDC_TZ_SETTLE,
+    IDC_TZ_KNOCK,
+    IDC_TZ_COOLDOWN,
+    IDC_TZ_MODIFIER,
+    IDC_TZ_LAST,
+    IDC_OPT_FIRST = 1300,
+    IDC_CORNER = IDC_OPT_FIRST,
+    IDC_EDGE,
+    IDC_DELAY,
+    IDC_SETTLE,
+    IDC_KNOCK,
+    IDC_COOLDOWN,
+    IDC_CENTREPCT,
+    IDC_LOCKBLANK,
+    IDC_MODIFIER,
+    IDC_EXCLUDED,
+    IDC_CB_FULLSCREEN,
+    IDC_CB_DRAG,
+    IDC_CB_TASKBAR,
+    IDC_CB_MONNAMES,
+    IDC_CB_VERBOSE,
+    IDC_OPT_LAST,
+};
+
+struct DashState
+{
+    UINT dpi = 96;
+    HFONT hFont = nullptr;
+    HBRUSH hBg = nullptr;
+    HBRUSH hField = nullptr;
+    HBRUSH hPanel = nullptr;
+    bool showZones = true;
+    int hoverZone = -1;   // zone highlighted in the preview
+    int selZone = 0;      // zone whose per-zone settings are being edited
+    ZoneTuning tuning[ZONE_COUNT];
+    int cfgIndex = 0;   // which slot in the value store we are editing
+
+    HWND hMonitor = nullptr;
+    HWND hZoneLabel[ZONE_COUNT] = {};
+    HWND hZoneAction[ZONE_COUNT] = {};
+    HWND hZoneArgs[ZONE_COUNT] = {};
+    HWND hOpt[IDC_OPT_LAST - IDC_OPT_FIRST] = {};
+    HWND hOptLabel[IDC_OPT_LAST - IDC_OPT_FIRST] = {};
+    HWND hHdrZone = nullptr, hHdrAction = nullptr, hHdrArgs = nullptr;
+    HWND hTzTitle = nullptr, hTzHint = nullptr;
+    HWND hTz[IDC_TZ_LAST - IDC_TZ_FIRST] = {};
+    HWND hTzLabel[IDC_TZ_LAST - IDC_TZ_FIRST] = {};
+    HWND hTip = nullptr;
+    HWND hPageZones = nullptr, hPageOptions = nullptr;
+    HWND hSave = nullptr, hCancel = nullptr, hReset = nullptr;
+};
+
+static int Sc(int px, UINT dpi) { return MulDiv(px, (int)dpi, 96); }
+
+// Layout metrics at 96 DPI. The window is sized *from* these rather than the
+// other way round — the first version guessed a window size and the button bar
+// ended up on top of the last rows.
+namespace Lay
+{
+constexpr int Pad = 16;
+constexpr int Gap = 8;
+constexpr int RowH = 30;
+constexpr int CheckH = 26;
+constexpr int TabH = 28;
+constexpr int CtlH = 24;
+constexpr int BtnH = 32;
+constexpr int LblW = 128;
+constexpr int CmbW = 210;
+constexpr int ArgW = 176;
+constexpr int OptLblW = 200;
+constexpr int OptCtlW = 190;
+constexpr int DiagW = 250;
+constexpr int DiagH = 150;
+constexpr int HdrH = 22;      // column-header row
+constexpr int TzRowH = 26;    // per-zone override row
+constexpr int TzPanelH = 14 + 20 + 20 + 6 * TzRowH;
+
+constexpr int LeftBlockW = Pad + LblW + Gap + CmbW + Gap + ArgW;   // 546
+constexpr int ClientW = LeftBlockW + Gap + DiagW + Pad;            // 820
+
+// Zones page: tabs, monitor combo, twelve rows.
+constexpr int ZonesLeftH = Pad + TabH + Gap + CtlH + Gap + HdrH + ZONE_COUNT * RowH;
+constexpr int ZonesRightH = Pad + TabH + Gap + CtlH + Gap + DiagH + TzPanelH;
+constexpr int ZonesH = ZonesLeftH > ZonesRightH ? ZonesLeftH : ZonesRightH;
+// Options page: ten labelled controls, five checkboxes.
+constexpr int OptionsH = Pad + TabH + Gap + 10 * RowH + 5 * CheckH;
+
+constexpr int ContentH = ZonesH > OptionsH ? ZonesH : OptionsH;
+constexpr int ClientH = ContentH + Gap * 2 + BtnH + Pad;
+}  // namespace Lay
+
+// Where the little screen preview sits, and where each zone sits inside it.
+static RECT DashDiagramRect(UINT dpi)
+{
+    RECT r;
+    r.left = Sc(Lay::LeftBlockW + Lay::Gap, dpi);
+    r.top = Sc(Lay::Pad + Lay::TabH + Lay::Gap + Lay::CtlH + Lay::Gap, dpi);
+    r.right = r.left + Sc(Lay::DiagW, dpi);
+    r.bottom = r.top + Sc(Lay::DiagH, dpi);
+    return r;
+}
+
+// Proportions inside the preview, mirroring how the real zones are built:
+// corners in the four corners, edges along the sides with the corners carved
+// out, and a centre block in the middle of each edge.
+// Proportions inside the preview, mirroring how the real zones are built.
+// The edges are split around the centre blocks rather than drawn through
+// them - previously they overlapped, so hovering a centre highlighted the
+// whole edge and the centre punched a hole in it.
+static RECT ZoneRectInDiagram(Zone z, const RECT &d, bool secondHalf)
+{
+    int w = d.right - d.left, h = d.bottom - d.top;
+    int c = (w < h ? w : h) / 6;         // corner block
+    int t = c / 2;                       // edge thickness
+    int cw = w / 5, ch = h / 5;          // centre block extent
+    int cx0 = d.left + w / 2 - cw / 2, cx1 = cx0 + cw;
+    int cy0 = d.top + h / 2 - ch / 2, cy1 = cy0 + ch;
+
+    switch (z)
+    {
+    case ZONE_TOP_LEFT:      return {d.left, d.top, d.left + c, d.top + c};
+    case ZONE_TOP_RIGHT:     return {d.right - c, d.top, d.right, d.top + c};
+    case ZONE_BOTTOM_LEFT:   return {d.left, d.bottom - c, d.left + c, d.bottom};
+    case ZONE_BOTTOM_RIGHT:  return {d.right - c, d.bottom - c, d.right, d.bottom};
+
+    case ZONE_EDGE_TOP:
+        return secondHalf ? RECT{cx1, d.top, d.right - c, d.top + t}
+                          : RECT{d.left + c, d.top, cx0, d.top + t};
+    case ZONE_EDGE_BOTTOM:
+        return secondHalf ? RECT{cx1, d.bottom - t, d.right - c, d.bottom}
+                          : RECT{d.left + c, d.bottom - t, cx0, d.bottom};
+    case ZONE_EDGE_LEFT:
+        return secondHalf ? RECT{d.left, cy1, d.left + t, d.bottom - c}
+                          : RECT{d.left, d.top + c, d.left + t, cy0};
+    case ZONE_EDGE_RIGHT:
+        return secondHalf ? RECT{d.right - t, cy1, d.right, d.bottom - c}
+                          : RECT{d.right - t, d.top + c, d.right, cy0};
+
+    case ZONE_CENTER_TOP:    return {cx0, d.top, cx1, d.top + t};
+    case ZONE_CENTER_BOTTOM: return {cx0, d.bottom - t, cx1, d.bottom};
+    case ZONE_CENTER_LEFT:   return {d.left, cy0, d.left + t, cy1};
+    case ZONE_CENTER_RIGHT:  return {d.right - t, cy0, d.right, cy1};
+    default:                 return {0, 0, 0, 0};
+    }
+}
+
+// An edge occupies two rectangles once a centre is carved out of it, so both
+// have to be drawn and both have to be hit-tested.
+static bool ZoneHasTwoParts(Zone z)
+{
+    return z == ZONE_EDGE_TOP || z == ZONE_EDGE_BOTTOM || z == ZONE_EDGE_LEFT ||
+           z == ZONE_EDGE_RIGHT;
+}
+
+// subIdList is nullptr for "keep the default part list", which is what naming
+// a theme (DarkMode_CFD) wants. Disabling theming outright is the exception:
+// SetWindowTheme only stops theming a control when *both* strings are empty,
+// and a still-themed control ignores colour messages such as
+// TTM_SETTIPBKCOLOR — which is why the tooltip stayed light.
+static void ThemeControl(HWND h, const wchar_t *theme,
+                         const wchar_t *subIdList = nullptr)
+{
+    HMODULE ux = GetModuleHandleW(L"uxtheme.dll");
+    if (!ux)
+        ux = LoadLibraryExW(L"uxtheme.dll", nullptr,
+                            LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!ux)
+        return;
+    using Fn = HRESULT(WINAPI *)(HWND, LPCWSTR, LPCWSTR);
+    auto fn = reinterpret_cast<Fn>(GetProcAddress(ux, "SetWindowTheme"));
+    if (fn)
+        fn(h, theme, subIdList);
+}
+
+// Dark title bar, and Mica where the build supports it. Both are no-ops on
+// older Windows, so neither needs a version check.
+static void ApplyModernFrame(HWND hWnd)
+{
+    HMODULE dwm = GetModuleHandleW(L"dwmapi.dll");
+    bool loaded = false;
+    if (!dwm)
+    {
+        dwm = LoadLibraryExW(L"dwmapi.dll", nullptr,
+                             LOAD_LIBRARY_SEARCH_SYSTEM32);
+        loaded = true;
+    }
+    if (!dwm)
+        return;
+
+    using Fn = HRESULT(WINAPI *)(HWND, DWORD, LPCVOID, DWORD);
+    auto fn = reinterpret_cast<Fn>(GetProcAddress(dwm, "DwmSetWindowAttribute"));
+    if (fn)
+    {
+        BOOL dark = g_lightTheme ? FALSE : TRUE;
+        fn(hWnd, 20, &dark, sizeof(dark));   // DWMWA_USE_IMMERSIVE_DARK_MODE
+        int backdrop = 2;                    // DWMSBT_MAINWINDOW (Mica)
+        fn(hWnd, 38, &backdrop, sizeof(backdrop));
+    }
+    if (loaded)
+        FreeLibrary(dwm);
+}
+
+static const wchar_t *kActionIds[] = {
+    L"ACTION_NOTHING",        L"ACTION_SHOW_DESKTOP",
+    L"ACTION_TASK_VIEW",      L"ACTION_SWITCH_LAST",
+    L"ACTION_TASK_SWITCHER",  L"ACTION_START_MENU",
+    L"ACTION_SEARCH",         L"ACTION_SETTINGS",
+    L"ACTION_FILE_EXPLORER",  L"ACTION_QUICK_SETTINGS",
+    L"ACTION_NOTIFICATION_CENTER", L"ACTION_CLIPBOARD",
+    L"ACTION_SCREENSHOT",     L"ACTION_PROJECT",
+    L"ACTION_TASK_MANAGER",   L"ACTION_MUTE",
+    L"ACTION_MINIMIZE",       L"ACTION_MAXIMIZE",
+    L"ACTION_SNAP_LEFT",      L"ACTION_SNAP_RIGHT",
+    L"ACTION_CLOSE_WINDOW",   L"ACTION_HIDE_OTHERS",
+    L"ACTION_VDESK_NEXT",     L"ACTION_VDESK_PREV",
+    L"ACTION_VDESK_NEW",      L"ACTION_VDESK_CLOSE",
+    L"ACTION_LOCK",           L"ACTION_LOCK_MONITORS_OFF",
+    L"ACTION_MONITORS_OFF",   L"ACTION_SLEEP",
+    L"ACTION_SCREENSAVER",    L"ACTION_KEEP_AWAKE_ON",
+    L"ACTION_KEEP_AWAKE_OFF", L"ACTION_SEND_KEYPRESS",
+    L"ACTION_ALTERNATE_KEYPRESS", L"ACTION_START_PROCESS",
+    L"ACTION_ALTERNATE_COMMAND",
+};
+static constexpr int kActionCount = ARRAYSIZE(kActionIds);
+
+// Per-zone override fields. Blank means "inherit the global value", which is
+// why every one of these can be left empty.
+struct TzDef
+{
+    int id;
+    const wchar_t *label;
+    const wchar_t *tip;
+};
+static const TzDef kTz[] = {
+    {IDC_TZ_SIZE, L"Size (px)",
+     L"How big this corner square or edge strip is, in pixels. Leave blank to "
+     L"use the global corner/edge size."},
+    {IDC_TZ_DELAY, L"Delay (ms)",
+     L"How long the cursor must sit in this zone before it fires. 0 is "
+     L"immediate. Blank inherits the global activation delay."},
+    {IDC_TZ_SETTLE, L"Guard (ms)",
+     L"Stops this zone firing when you merely pass through it on the way "
+     L"somewhere else. Blank inherits the global pass-through guard."},
+    {IDC_TZ_KNOCK, L"Knock (ms)",
+     L"Require entering this zone twice within this many milliseconds, like "
+     L"knocking. 0 disables it. Blank inherits the global setting."},
+    {IDC_TZ_COOLDOWN, L"Cooldown (ms)",
+     L"Minimum gap before this zone can fire again. Blank inherits the global "
+     L"cooldown."},
+    {IDC_TZ_MODIFIER, L"Modifier",
+     L"Only fire this zone while the chosen key is held. Inherit uses the "
+     L"global setting."},
+};
+static constexpr int kTzCount = ARRAYSIZE(kTz);
+
+struct OptDef
+{
+    int id;
+    const wchar_t *label;
+    bool isCheck;
+    const wchar_t *tip;
+};
+static const OptDef kOpts[] = {
+    {IDC_CORNER, L"Corner size (px)", false, L"Default size of the four corner squares. Individual corners can override this on the Zones page."},
+    {IDC_EDGE, L"Edge size (px)", false, L"Default thickness of the edge strips. An edge is always clamped to the smaller of the two corners it runs between."},
+    {IDC_DELAY, L"Activation delay (ms)", false, L"How long the cursor must dwell before a zone fires. 0 is immediate."},
+    {IDC_SETTLE, L"Pass-through guard (ms)", false, L"Stops a zone firing when you only cross it. You cannot reach a corner without crossing the edge beside it, so without this both would fire."},
+    {IDC_KNOCK, L"Knock window (ms, 0 = off)", false, L"Require entering a zone twice in quick succession, like knocking. The strongest guard against accidental triggers."},
+    {IDC_COOLDOWN, L"Cooldown (ms)", false, L"Minimum gap before the same zone can fire again."},
+    {IDC_CENTREPCT, L"Centre zone width (%)", false, L"How much of an edge the centre zone takes. Only affects edges where a centre action is assigned."},
+    {IDC_LOCKBLANK, L"Blank delay after lock (ms)", false, L"Only used by the Lock and Turn Off Monitors action. Locking counts as activity, so blanking too early just wakes the display."},
+    {IDC_MODIFIER, L"Require modifier", false, L"Zones stay inert unless this key is held. Individual zones can override it."},
+    {IDC_EXCLUDED, L"Excluded processes", false, L"Semicolon-separated executable names. While one of them is in the foreground, no zone fires. Example: photoshop.exe;blender.exe"},
+    {IDC_CB_FULLSCREEN, L"Skip while an app is fullscreen", true, L"Ignore zones while a game or video is fullscreen. Shell surfaces such as Task View and Start do not count."},
+    {IDC_CB_DRAG, L"Skip while dragging the mouse", true, L"Ignore zones while any mouse button is held, so dragging a window into a corner does not trigger it."},
+    {IDC_CB_TASKBAR, L"Keep zones off the taskbar", true, L"Build zones from the desktop work area, so they stop at the taskbar instead of fighting its peek-at-desktop strip."},
+    {IDC_CB_MONNAMES, L"List my monitors in the log", true, L"Writes your display names to the log so they can be copied into the monitor selector."},
+    {IDC_CB_VERBOSE, L"Verbose logging", true, L"Log every trigger. Off by default because the logging path takes a system-wide lock and can stutter other mods."},
+};
+static constexpr int kOptCount = ARRAYSIZE(kOpts);
+
+// A free function with CALLBACK, not a lambda: a non-capturing lambda decays
+// to a cdecl function pointer, while WNDENUMPROC is __stdcall. They happen to
+// be interchangeable in 64-bit builds, but this mod is compiled 32-bit where
+// the calling conventions genuinely differ, so the lambda will not convert.
+static BOOL CALLBACK DashSetChildFont(HWND hChild, LPARAM lParam)
+{
+    SendMessageW(hChild, WM_SETFONT, (WPARAM)lParam, TRUE);
+    return TRUE;
+}
+
+static void DashSetInt(DashState *s, int id, int v)
+{
+    wchar_t b[32];
+    _snwprintf_s(b, _countof(b), _TRUNCATE, L"%d", v);
+    SetWindowTextW(s->hOpt[id - IDC_OPT_FIRST], b);
+}
+
+static int DashGetInt(DashState *s, int id, int fallback)
+{
+    wchar_t b[32] = {};
+    GetWindowTextW(s->hOpt[id - IDC_OPT_FIRST], b, ARRAYSIZE(b));
+    if (!b[0])
+        return fallback;
+    return _wtoi(b);
+}
+
+static void DashLayout(HWND hWnd, DashState *s)
+{
+    UINT d = s->dpi;
+    const int pad = Sc(Lay::Pad, d), gap = Sc(Lay::Gap, d);
+    int y;
+
+    // Show only the active page. Doing this first means the button bar below
+    // is positioned against a known set of visible controls.
+    for (int z = 0; z < ZONE_COUNT; z++)
+    {
+        int sw = s->showZones ? SW_SHOW : SW_HIDE;
+        ShowWindow(s->hZoneLabel[z], sw);
+        ShowWindow(s->hZoneAction[z], sw);
+        ShowWindow(s->hZoneArgs[z], sw);
+    }
+    ShowWindow(s->hMonitor, s->showZones ? SW_SHOW : SW_HIDE);
+    {
+        int sw = s->showZones ? SW_SHOW : SW_HIDE;
+        ShowWindow(s->hHdrZone, sw);
+        ShowWindow(s->hHdrAction, sw);
+        ShowWindow(s->hHdrArgs, sw);
+        ShowWindow(s->hTzTitle, sw);
+        ShowWindow(s->hTzHint, sw);
+        for (int i = 0; i < kTzCount; i++)
+        {
+            ShowWindow(s->hTz[i], sw);
+            ShowWindow(s->hTzLabel[i], sw);
+        }
+    }
+    for (int i = 0; i < kOptCount; i++)
+    {
+        int sw = s->showZones ? SW_HIDE : SW_SHOW;
+        ShowWindow(s->hOpt[i], sw);
+        if (s->hOptLabel[i])
+            ShowWindow(s->hOptLabel[i], sw);
+    }
+
+    SetWindowPos(s->hPageZones, nullptr, pad, pad, Sc(96, d), Sc(Lay::TabH, d),
+                 SWP_NOZORDER);
+    SetWindowPos(s->hPageOptions, nullptr, pad + Sc(104, d), pad, Sc(96, d),
+                 Sc(Lay::TabH, d), SWP_NOZORDER);
+
+    y = pad + Sc(Lay::TabH, d) + gap;
+
+    if (s->showZones)
+    {
+        SetWindowPos(s->hMonitor, nullptr, pad, y,
+                     Sc(Lay::LblW + Lay::Gap + Lay::CmbW, d), Sc(320, d),
+                     SWP_NOZORDER);
+        y += Sc(Lay::CtlH, d) + gap;
+
+        // Column headers
+        SetWindowPos(s->hHdrZone, nullptr, pad, y, Sc(Lay::LblW, d),
+                     Sc(18, d), SWP_NOZORDER);
+        SetWindowPos(s->hHdrAction, nullptr, pad + Sc(Lay::LblW + Lay::Gap, d),
+                     y, Sc(Lay::CmbW, d), Sc(18, d), SWP_NOZORDER);
+        SetWindowPos(s->hHdrArgs, nullptr,
+                     pad + Sc(Lay::LblW + Lay::Gap + Lay::CmbW + Lay::Gap, d), y,
+                     Sc(Lay::ArgW, d), Sc(18, d), SWP_NOZORDER);
+        y += Sc(Lay::HdrH, d);
+
+        for (int z = 0; z < ZONE_COUNT; z++)
+        {
+            int rowY = y + z * Sc(Lay::RowH, d);
+            SetWindowPos(s->hZoneLabel[z], nullptr, pad, rowY + Sc(5, d),
+                         Sc(Lay::LblW, d), Sc(20, d), SWP_NOZORDER);
+            SetWindowPos(s->hZoneAction[z], nullptr,
+                         pad + Sc(Lay::LblW + Lay::Gap, d), rowY,
+                         Sc(Lay::CmbW, d), Sc(320, d), SWP_NOZORDER);
+            SetWindowPos(s->hZoneArgs[z], nullptr,
+                         pad + Sc(Lay::LblW + Lay::Gap + Lay::CmbW + Lay::Gap, d),
+                         rowY, Sc(Lay::ArgW, d), Sc(Lay::CtlH, d), SWP_NOZORDER);
+        }
+    }
+    else
+    {
+        for (int i = 0; i < kOptCount; i++)
+        {
+            if (kOpts[i].isCheck)
+            {
+                SetWindowPos(s->hOpt[i], nullptr, pad, y,
+                             Sc(Lay::OptLblW + Lay::Gap + Lay::OptCtlW, d),
+                             Sc(22, d), SWP_NOZORDER);
+                y += Sc(Lay::CheckH, d);
+            }
+            else
+            {
+                SetWindowPos(s->hOptLabel[i], nullptr, pad, y + Sc(5, d),
+                             Sc(Lay::OptLblW, d), Sc(20, d), SWP_NOZORDER);
+                bool combo = (kOpts[i].id == IDC_MODIFIER);
+                bool wide = (kOpts[i].id == IDC_EXCLUDED);
+                SetWindowPos(s->hOpt[i], nullptr,
+                             pad + Sc(Lay::OptLblW + Lay::Gap, d), y,
+                             Sc(wide ? Lay::OptCtlW + Lay::DiagW : Lay::OptCtlW, d),
+                             combo ? Sc(200, d) : Sc(Lay::CtlH, d), SWP_NOZORDER);
+                y += Sc(Lay::RowH, d);
+            }
+        }
+    }
+
+    if (s->showZones)
+    {
+        RECT dg = DashDiagramRect(d);
+        int px = dg.left;
+        int py = dg.bottom + Sc(14, d);
+        int pw = dg.right - dg.left;
+        SetWindowPos(s->hTzTitle, nullptr, px, py, pw, Sc(18, d), SWP_NOZORDER);
+        py += Sc(20, d);
+        SetWindowPos(s->hTzHint, nullptr, px, py, pw, Sc(16, d), SWP_NOZORDER);
+        py += Sc(20, d);
+        int lw = Sc(96, d);
+        for (int i = 0; i < kTzCount; i++)
+        {
+            SetWindowPos(s->hTzLabel[i], nullptr, px, py + Sc(4, d), lw,
+                         Sc(18, d), SWP_NOZORDER);
+            bool combo = (kTz[i].id == IDC_TZ_MODIFIER);
+            SetWindowPos(s->hTz[i], nullptr, px + lw + Sc(6, d), py,
+                         pw - lw - Sc(6, d), combo ? Sc(180, d) : Sc(22, d),
+                         SWP_NOZORDER);
+            py += Sc(Lay::TzRowH, d);
+        }
+    }
+
+    // Button bar sits below the taller of the two pages, always, so it can
+    // never land on top of a control.
+    RECT rc;
+    GetClientRect(hWnd, &rc);
+    int by = rc.bottom - pad - Sc(Lay::BtnH, d);
+    int bx = pad;
+    SetWindowPos(s->hSave, nullptr, bx, by, Sc(130, d), Sc(Lay::BtnH, d),
+                 SWP_NOZORDER);
+    bx += Sc(130 + Lay::Gap, d);
+    SetWindowPos(s->hCancel, nullptr, bx, by, Sc(90, d), Sc(Lay::BtnH, d),
+                 SWP_NOZORDER);
+    bx += Sc(90 + Lay::Gap, d);
+    SetWindowPos(s->hReset, nullptr, bx, by, Sc(210, d), Sc(Lay::BtnH, d),
+                 SWP_NOZORDER);
+
+    InvalidateRect(hWnd, nullptr, TRUE);
+}
+
+// Screen preview: a rectangle with the twelve zones drawn where they actually
+// sit, filled when something is assigned to them. Clicking one jumps to its
+// row, which is far quicker than reading down a list of twelve labels.
+static void DashPaintDiagram(HWND hWnd, DashState *s, HDC hdc)
+{
+    if (!s->showZones)
+        return;
+
+    UINT d = s->dpi;
+    RECT dg = DashDiagramRect(d);
+
+    HFONT old = (HFONT)SelectObject(hdc, s->hFont);
+    SetBkMode(hdc, TRANSPARENT);
+    SetTextColor(hdc, g_pal.dim);
+    RECT cap = {dg.left, dg.top - Sc(20, d), dg.right, dg.top - Sc(2, d)};
+    DrawTextW(hdc, L"Your screen — click a zone to jump to it", -1, &cap,
+              DT_LEFT | DT_SINGLELINE);
+
+    HBRUSH screenBrush = CreateSolidBrush(RGB(24, 24, 24));
+    FillRect(hdc, &dg, screenBrush);
+    DeleteObject(screenBrush);
+
+    HPEN pen = CreatePen(PS_SOLID, Sc(1, d), RGB(90, 90, 90));
+    HPEN oldPen = (HPEN)SelectObject(hdc, pen);
+    HBRUSH hollow = (HBRUSH)GetStockObject(NULL_BRUSH);
+    HBRUSH oldBrush = (HBRUSH)SelectObject(hdc, hollow);
+    Rectangle(hdc, dg.left, dg.top, dg.right, dg.bottom);
+    SelectObject(hdc, oldBrush);
+    SelectObject(hdc, oldPen);
+    DeleteObject(pen);
+
+    HBRUSH set = CreateSolidBrush(RGB(76, 194, 255));
+    HBRUSH unset = CreateSolidBrush(RGB(58, 58, 58));
+    HBRUSH sel = CreateSolidBrush(RGB(255, 190, 80));
+
+    for (int z = 0; z < ZONE_COUNT; z++)
+    {
+        int idx = (int)SendMessageW(s->hZoneAction[z], CB_GETCURSEL, 0, 0);
+        HBRUSH b = (z == s->hoverZone) ? sel : (idx > 0 ? set : unset);
+        int parts = ZoneHasTwoParts((Zone)z) ? 2 : 1;
+        for (int p = 0; p < parts; p++)
+        {
+            RECT r = ZoneRectInDiagram((Zone)z, dg, p == 1);
+            if (r.right > r.left && r.bottom > r.top)
+                FillRect(hdc, &r, b);
+        }
+    }
+
+    DeleteObject(set);
+    DeleteObject(unset);
+    DeleteObject(sel);
+
+    // ponytail: no hover card. It used to be drawn from dg.bottom+10 to
+    // dg.bottom+112 — the exact strip the per-zone panel's controls occupy, so
+    // it was never readable and its leftovers showed through the gaps between
+    // the fields. The panel below already shows the same numbers for the
+    // selected zone, and clicking a zone in the preview selects it.
+
+    SelectObject(hdc, old);
+}
+// Fills the zone controls from whichever configuration slot is selected.
+// Pushes the selected zone's overrides into the six panel fields.
+static void DashShowZoneTuning(DashState *s)
+{
+    const ZoneTuning &tn = s->tuning[s->selZone];
+    auto put = [&](int id, int v)
+    {
+        wchar_t b[24] = L"";
+        if (v >= 0)
+            _snwprintf_s(b, _countof(b), _TRUNCATE, L"%d", v);
+        SetWindowTextW(s->hTz[id - IDC_TZ_FIRST], b);
+    };
+    put(IDC_TZ_SIZE, tn.size);
+    put(IDC_TZ_DELAY, tn.delay);
+    put(IDC_TZ_SETTLE, tn.settle);
+    put(IDC_TZ_KNOCK, tn.knock);
+    put(IDC_TZ_COOLDOWN, tn.cooldown);
+    SendMessageW(s->hTz[IDC_TZ_MODIFIER - IDC_TZ_FIRST], CB_SETCURSEL,
+                 tn.modifier < 0 ? 0 : tn.modifier + 1, 0);
+
+    std::wstring title =
+        std::wstring(L"Settings for ") + ZoneToString((Zone)s->selZone);
+    SetWindowTextW(s->hTzTitle, title.c_str());
+}
+
+// Reads the six panel fields back into the selected zone. Blank stays -1,
+// which is what "inherit the global value" is stored as.
+static void DashCaptureZoneTuning(DashState *s)
+{
+    ZoneTuning &tn = s->tuning[s->selZone];
+    auto get = [&](int id) -> int
+    {
+        wchar_t b[24] = {};
+        GetWindowTextW(s->hTz[id - IDC_TZ_FIRST], b, ARRAYSIZE(b));
+        if (!b[0])
+            return -1;
+        return _wtoi(b);
+    };
+    tn.size = get(IDC_TZ_SIZE);
+    tn.delay = get(IDC_TZ_DELAY);
+    tn.settle = get(IDC_TZ_SETTLE);
+    tn.knock = get(IDC_TZ_KNOCK);
+    tn.cooldown = get(IDC_TZ_COOLDOWN);
+    int m = (int)SendMessageW(s->hTz[IDC_TZ_MODIFIER - IDC_TZ_FIRST],
+                              CB_GETCURSEL, 0, 0);
+    tn.modifier = (m <= 0) ? -1 : m - 1;
+}
+
+static void DashLoadZones(DashState *s)
+{
+    int sel = (int)SendMessageW(s->hMonitor, CB_GETCURSEL, 0, 0);
+    if (sel < 0)
+        sel = 0;
+    s->cfgIndex = sel;
+
+    bool fromGui = Wh_GetIntValue(L"gui_active", 0) != 0;
+
+    for (int z = 0; z < ZONE_COUNT; z++)
+    {
+        std::wstring act, args;
+        if (fromGui)
+        {
+            act = GetStrValue(GuiKey(sel, z, L"a").c_str());
+            args = GetStrValue(GuiKey(sel, z, L"g").c_str());
+        }
+        else
+        {
+            // First run: seed from whatever the Windhawk settings say.
+            EnterCriticalSection(&g_settingsLock);
+            if (sel < (int)g_settings.monitorConfigs.size())
+            {
+                act = ActionIdFromEnum(g_settings.monitorConfigs[sel].zones[z].action);
+                args = g_settings.monitorConfigs[sel].zones[z].args;
+            }
+            LeaveCriticalSection(&g_settingsLock);
+        }
+
+        int idx = 0;
+        for (int a = 0; a < kActionCount; a++)
+        {
+            if (act == kActionIds[a])
+            {
+                idx = a;
+                break;
+            }
+        }
+        SendMessageW(s->hZoneAction[z], CB_SETCURSEL, idx, 0);
+        SetWindowTextW(s->hZoneArgs[z], args.c_str());
+
+        ZoneTuning &tn = s->tuning[z];
+        if (fromGui)
+        {
+            tn.size = Wh_GetIntValue(GuiKey(sel, z, L"sz").c_str(), -1);
+            tn.delay = Wh_GetIntValue(GuiKey(sel, z, L"dl").c_str(), -1);
+            tn.settle = Wh_GetIntValue(GuiKey(sel, z, L"gd").c_str(), -1);
+            tn.knock = Wh_GetIntValue(GuiKey(sel, z, L"kn").c_str(), -1);
+            tn.cooldown = Wh_GetIntValue(GuiKey(sel, z, L"cd").c_str(), -1);
+            tn.modifier = Wh_GetIntValue(GuiKey(sel, z, L"md").c_str(), -1);
+        }
+        else
+        {
+            tn = ZoneTuning{};
+        }
+    }
+    DashShowZoneTuning(s);
+}
+
+static void DashLoad(HWND hWnd, DashState *s)
+{
+    // Monitor selector: one slot per detected display, plus a wildcard.
+    SendMessageW(s->hMonitor, CB_RESETCONTENT, 0, 0);
+    SendMessageW(s->hMonitor, CB_ADDSTRING, 0, (LPARAM)L"All monitors  ( * )");
+    // Take a reference to the snapshot under the lock, then read it outside:
+    // it is immutable and shared_ptr keeps it alive even if the detection
+    // thread publishes a new one mid-loop. Reading g_monitors directly here
+    // was a use-after-free — RefreshMonitors clears that vector and frees
+    // every id string while this thread walks it.
+    EnterCriticalSection(&g_zonesLock);
+    std::shared_ptr<const ZoneSet> snap = g_zones;
+    LeaveCriticalSection(&g_zonesLock);
+    std::vector<std::wstring> names;
+    if (snap)
+        names = snap->monitorNames;
+    for (const auto &n : names)
+        SendMessageW(s->hMonitor, CB_ADDSTRING, 0, (LPARAM)n.c_str());
+    SendMessageW(s->hMonitor, CB_SETCURSEL, 0, 0);
+
+    EnterCriticalSection(&g_settingsLock);
+    DashSetInt(s, IDC_CORNER, g_settings.cornerSize);
+    DashSetInt(s, IDC_EDGE, g_settings.edgeSize);
+    DashSetInt(s, IDC_DELAY, g_settings.activationDelay);
+    DashSetInt(s, IDC_SETTLE, g_settings.settleMs);
+    DashSetInt(s, IDC_KNOCK, g_settings.knockWindowMs);
+    DashSetInt(s, IDC_COOLDOWN, g_settings.cooldownMs);
+    DashSetInt(s, IDC_CENTREPCT, g_settings.centerZonePercent);
+    DashSetInt(s, IDC_LOCKBLANK, g_lockBlankDelayMs);
+    SendMessageW(s->hOpt[IDC_MODIFIER - IDC_OPT_FIRST], CB_SETCURSEL,
+                 g_settings.requireModifier, 0);
+    std::wstring excl;
+    for (size_t i = 0; i < g_settings.excludedProcesses.size(); i++)
+    {
+        if (i)
+            excl += L";";
+        excl += g_settings.excludedProcesses[i];
+    }
+    SetWindowTextW(s->hOpt[IDC_EXCLUDED - IDC_OPT_FIRST], excl.c_str());
+    CheckDlgButton(hWnd, IDC_CB_FULLSCREEN,
+                   g_settings.disableOnFullscreen ? BST_CHECKED : BST_UNCHECKED);
+    CheckDlgButton(hWnd, IDC_CB_DRAG,
+                   g_settings.disableDuringDrag ? BST_CHECKED : BST_UNCHECKED);
+    CheckDlgButton(hWnd, IDC_CB_TASKBAR,
+                   g_settings.avoidTaskbar ? BST_CHECKED : BST_UNCHECKED);
+    LeaveCriticalSection(&g_settingsLock);
+    CheckDlgButton(hWnd, IDC_CB_MONNAMES,
+                   g_showMonitorNames ? BST_CHECKED : BST_UNCHECKED);
+    CheckDlgButton(hWnd, IDC_CB_VERBOSE, g_verboseLog ? BST_CHECKED
+                                                      : BST_UNCHECKED);
+
+    DashLoadZones(s);
+}
+
+static void DashSave(HWND hWnd, DashState *s)
+{
+    DashCaptureZoneTuning(s);
+    // Zones for the slot currently on screen.
+    int sel = s->cfgIndex;
+    wchar_t monName[256] = {};
+    int cur = (int)SendMessageW(s->hMonitor, CB_GETCURSEL, 0, 0);
+    if (cur == 0)
+        wcscpy_s(monName, L"*");
+    else if (cur > 0)
+        SendMessageW(s->hMonitor, CB_GETLBTEXT, cur, (LPARAM)monName);
+
+    Wh_SetStringValue(GuiKey(sel, -1, L"id").c_str(), monName);
+    for (int z = 0; z < ZONE_COUNT; z++)
+    {
+        int idx = (int)SendMessageW(s->hZoneAction[z], CB_GETCURSEL, 0, 0);
+        if (idx < 0 || idx >= kActionCount)
+            idx = 0;
+        wchar_t args[512] = {};
+        GetWindowTextW(s->hZoneArgs[z], args, ARRAYSIZE(args));
+        Wh_SetStringValue(GuiKey(sel, z, L"a").c_str(), kActionIds[idx]);
+        Wh_SetStringValue(GuiKey(sel, z, L"g").c_str(), args);
+
+        const ZoneTuning &tn = s->tuning[z];
+        Wh_SetIntValue(GuiKey(sel, z, L"sz").c_str(), tn.size);
+        Wh_SetIntValue(GuiKey(sel, z, L"dl").c_str(), tn.delay);
+        Wh_SetIntValue(GuiKey(sel, z, L"gd").c_str(), tn.settle);
+        Wh_SetIntValue(GuiKey(sel, z, L"kn").c_str(), tn.knock);
+        Wh_SetIntValue(GuiKey(sel, z, L"cd").c_str(), tn.cooldown);
+        Wh_SetIntValue(GuiKey(sel, z, L"md").c_str(), tn.modifier);
+    }
+    Wh_SetIntValue(L"gui_active", 1);
+
+    // Global options.
+    Wh_SetIntValue(L"ovr_corner", DashGetInt(s, IDC_CORNER, 6));
+    Wh_SetIntValue(L"ovr_edge", DashGetInt(s, IDC_EDGE, 6));
+    Wh_SetIntValue(L"ovr_delay", DashGetInt(s, IDC_DELAY, 0));
+    Wh_SetIntValue(L"ovr_settle", DashGetInt(s, IDC_SETTLE, 80));
+    Wh_SetIntValue(L"ovr_knock", DashGetInt(s, IDC_KNOCK, 0));
+    Wh_SetIntValue(L"ovr_cooldown", DashGetInt(s, IDC_COOLDOWN, 300));
+    Wh_SetIntValue(L"ovr_centre", DashGetInt(s, IDC_CENTREPCT, 20));
+    Wh_SetIntValue(L"ovr_lockblank", DashGetInt(s, IDC_LOCKBLANK, 1200));
+    Wh_SetIntValue(L"ovr_modifier",
+                   (int)SendMessageW(s->hOpt[IDC_MODIFIER - IDC_OPT_FIRST],
+                                     CB_GETCURSEL, 0, 0));
+    wchar_t excl[512] = {};
+    GetWindowTextW(s->hOpt[IDC_EXCLUDED - IDC_OPT_FIRST], excl,
+                   ARRAYSIZE(excl));
+    Wh_SetStringValue(L"ovr_excluded", excl);
+    Wh_SetIntValue(kOvrFullscreen, IsDlgButtonChecked(hWnd, IDC_CB_FULLSCREEN));
+    Wh_SetIntValue(kOvrDrag, IsDlgButtonChecked(hWnd, IDC_CB_DRAG));
+    Wh_SetIntValue(L"ovr_taskbar", IsDlgButtonChecked(hWnd, IDC_CB_TASKBAR));
+    Wh_SetIntValue(L"ovr_monnames", IsDlgButtonChecked(hWnd, IDC_CB_MONNAMES));
+    Wh_SetIntValue(kOvrVerbose, IsDlgButtonChecked(hWnd, IDC_CB_VERBOSE));
+
+    LoadSettings();
+    ApplyTrayOverrides();
+    RequestRebuild();
+    UpdateTrayIcon(false);
+    Wh_Log(L"Dashboard: settings saved and applied");
+}
+
+static LRESULT CALLBACK DashWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
+                                    LPARAM lParam)
+{
+    DashState *s = (DashState *)GetWindowLongPtrW(hWnd, GWLP_USERDATA);
+
+    switch (uMsg)
+    {
+    case WM_CREATE:
+    {
+        auto *cs = (CREATESTRUCTW *)lParam;
+        s = (DashState *)cs->lpCreateParams;
+        SetWindowLongPtrW(hWnd, GWLP_USERDATA, (LONG_PTR)s);
+
+        s->dpi = 96;
+        {
+            HMODULE u = GetModuleHandleW(L"user32.dll");
+            using Fn = UINT(WINAPI *)(HWND);
+            if (auto fn = (Fn)GetProcAddress(u, "GetDpiForWindow"))
+                s->dpi = fn(hWnd);
+            if (!s->dpi)
+                s->dpi = 96;
+        }
+
+        LOGFONTW lf = {};
+        lf.lfHeight = -MulDiv(9, (int)s->dpi, 72);
+        lf.lfWeight = FW_NORMAL;
+        wcscpy_s(lf.lfFaceName, L"Segoe UI");
+        s->hFont = CreateFontIndirectW(&lf);
+        BuildPalette();
+        s->hBg = CreateSolidBrush(g_pal.bg);
+        s->hField = CreateSolidBrush(g_pal.field);
+        s->hPanel = CreateSolidBrush(g_pal.panel);
+
+        auto mk = [&](const wchar_t *cls, const wchar_t *txt, DWORD style,
+                      int id) -> HWND
+        {
+            HWND h = CreateWindowExW(0, cls, txt, WS_CHILD | style, 0, 0, 10,
+                                     10, hWnd, (HMENU)(INT_PTR)id,
+                                     cs->hInstance, nullptr);
+            if (h)
+                SendMessageW(h, WM_SETFONT, (WPARAM)s->hFont, TRUE);
+            return h;
+        };
+
+        s->hPageZones = mk(L"BUTTON", L"Zones", BS_PUSHBUTTON | WS_VISIBLE |
+                                                    WS_TABSTOP, IDC_PAGE_ZONES);
+        s->hPageOptions = mk(L"BUTTON", L"Options",
+                             BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP,
+                             IDC_PAGE_OPTIONS);
+        s->hMonitor = mk(L"COMBOBOX", nullptr,
+                         CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP,
+                         IDC_MONITOR);
+        ThemeControl(s->hMonitor, g_lightTheme ? L"CFD" : L"DarkMode_CFD");
+
+        for (int z = 0; z < ZONE_COUNT; z++)
+        {
+            s->hZoneLabel[z] = mk(L"STATIC", ZoneToString((Zone)z), SS_LEFT, 0);
+            s->hZoneAction[z] =
+                mk(L"COMBOBOX", nullptr,
+                   CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP,
+                   IDC_ZONE_ACTION + z);
+            ThemeControl(s->hZoneAction[z], g_lightTheme ? L"CFD" : L"DarkMode_CFD");
+            for (int a = 0; a < kActionCount; a++)
+            {
+                SendMessageW(s->hZoneAction[z], CB_ADDSTRING, 0,
+                             (LPARAM)ActionToString(ParseActionType(kActionIds[a])));
+            }
+            s->hZoneArgs[z] = mk(L"EDIT", nullptr,
+                                 WS_BORDER | ES_AUTOHSCROLL | WS_TABSTOP,
+                                 IDC_ZONE_ARGS + z);
+            ThemeControl(s->hZoneArgs[z], g_lightTheme ? L"CFD" : L"DarkMode_CFD");
+        }
+
+        for (int i = 0; i < kOptCount; i++)
+        {
+            if (kOpts[i].isCheck)
+            {
+                s->hOpt[i] = mk(L"BUTTON", kOpts[i].label,
+                                BS_AUTOCHECKBOX | WS_TABSTOP, kOpts[i].id);
+                s->hOptLabel[i] = nullptr;
+            }
+            else
+            {
+                s->hOptLabel[i] = mk(L"STATIC", kOpts[i].label, SS_LEFT, 0);
+                if (kOpts[i].id == IDC_MODIFIER)
+                {
+                    s->hOpt[i] = mk(L"COMBOBOX", nullptr,
+                                    CBS_DROPDOWNLIST | WS_TABSTOP,
+                                    kOpts[i].id);
+                    const wchar_t *mods[] = {L"None", L"Ctrl", L"Alt", L"Shift",
+                                             L"Win"};
+                    for (auto m : mods)
+                        SendMessageW(s->hOpt[i], CB_ADDSTRING, 0, (LPARAM)m);
+                }
+                else
+                {
+                    s->hOpt[i] = mk(L"EDIT", nullptr,
+                                    WS_BORDER | ES_AUTOHSCROLL | WS_TABSTOP,
+                                    kOpts[i].id);
+                }
+                ThemeControl(s->hOpt[i], g_lightTheme ? L"CFD" : L"DarkMode_CFD");
+            }
+        }
+
+        // Column headers - the argument field previously had no label at all.
+        s->hHdrZone = mk(L"STATIC", L"Zone", SS_LEFT, IDC_HDR_ZONE);
+        s->hHdrAction = mk(L"STATIC", L"Action", SS_LEFT, IDC_HDR_ACTION);
+        s->hHdrArgs = mk(L"STATIC", L"Argument / command", SS_LEFT, IDC_HDR_ARGS);
+
+        s->hTzTitle = mk(L"STATIC", L"Settings for this zone", SS_LEFT,
+                         IDC_TZ_TITLE);
+        s->hTzHint = mk(L"STATIC", L"Leave blank to use the global value.",
+                        SS_LEFT, IDC_TZ_HINT);
+        for (int i = 0; i < kTzCount; i++)
+        {
+            s->hTzLabel[i] = mk(L"STATIC", kTz[i].label, SS_LEFT, 0);
+            if (kTz[i].id == IDC_TZ_MODIFIER)
+            {
+                s->hTz[i] = mk(L"COMBOBOX", nullptr,
+                               CBS_DROPDOWNLIST | WS_TABSTOP, kTz[i].id);
+                const wchar_t *mv[] = {L"Inherit", L"None", L"Ctrl",
+                                       L"Alt",     L"Shift", L"Win"};
+                for (auto v : mv)
+                    SendMessageW(s->hTz[i], CB_ADDSTRING, 0, (LPARAM)v);
+            }
+            else
+            {
+                s->hTz[i] = mk(L"EDIT", nullptr,
+                               WS_BORDER | ES_AUTOHSCROLL | ES_NUMBER |
+                                   WS_TABSTOP,
+                               kTz[i].id);
+            }
+            ThemeControl(s->hTz[i], g_lightTheme ? L"CFD" : L"DarkMode_CFD");
+        }
+
+        s->hSave = mk(L"BUTTON", L"Save and Apply",
+                      BS_DEFPUSHBUTTON | WS_VISIBLE | WS_TABSTOP, IDC_SAVE);
+        s->hCancel = mk(L"BUTTON", L"Close",
+                        BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP, IDC_CANCEL);
+        s->hReset = mk(L"BUTTON", L"Reset to Windhawk settings",
+                       BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP, IDC_RESET);
+
+        // One tooltip control serving every field. Descriptions live next to
+        // the field definitions so a new setting cannot be added without one.
+        s->hTip = CreateWindowExW(WS_EX_TOPMOST, TOOLTIPS_CLASSW, nullptr,
+                                  WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP, 0, 0,
+                                  0, 0, hWnd, nullptr, cs->hInstance, nullptr);
+        if (s->hTip)
+        {
+            SendMessageW(s->hTip, TTM_SETMAXTIPWIDTH, 0, Sc(320, s->dpi));
+            SendMessageW(s->hTip, WM_SETFONT, (WPARAM)s->hFont, TRUE);
+            // A themed tooltip ignores TTM_SETTIPBKCOLOR/TEXTCOLOR outright, so
+            // it kept the system tooltip colours while the rest of the window
+            // followed the palette. Both strings must be empty or theming is
+            // not actually switched off.
+            ThemeControl(s->hTip, L"", L"");
+            SendMessageW(s->hTip, TTM_SETTIPBKCOLOR, (WPARAM)g_pal.panel, 0);
+            SendMessageW(s->hTip, TTM_SETTIPTEXTCOLOR, (WPARAM)g_pal.text, 0);
+            auto tip = [&](HWND ctl, const wchar_t *text)
+            {
+                if (!ctl || !text)
+                    return;
+                TTTOOLINFOW ti = {};
+                ti.cbSize = sizeof(ti);
+                ti.uFlags = TTF_IDISHWND | TTF_SUBCLASS;
+                ti.hwnd = hWnd;
+                ti.uId = (UINT_PTR)ctl;
+                ti.lpszText = const_cast<LPWSTR>(text);
+                SendMessageW(s->hTip, TTM_ADDTOOLW, 0, (LPARAM)&ti);
+            };
+            for (int i = 0; i < kOptCount; i++)
+            {
+                tip(s->hOpt[i], kOpts[i].tip);
+                tip(s->hOptLabel[i], kOpts[i].tip);
+            }
+            for (int i = 0; i < kTzCount; i++)
+            {
+                tip(s->hTz[i], kTz[i].tip);
+                tip(s->hTzLabel[i], kTz[i].tip);
+            }
+            tip(s->hMonitor,
+                L"Which display these zones belong to. Use * to apply one "
+                L"configuration to every monitor.");
+            tip(s->hHdrArgs,
+                L"Extra input for the chosen action: a key combination for "
+                L"Virtual Key Press, a path or URL for Custom Command, or two "
+                L"of either separated by | for the Alternate actions.");
+            tip(s->hReset,
+                L"Discard everything set here and go back to the Windhawk "
+                L"Settings page.");
+        }
+
+        if (HICON ic = MakeTrayIcon(true))
+        {
+            SendMessageW(hWnd, WM_SETICON, ICON_SMALL, (LPARAM)ic);
+            SendMessageW(hWnd, WM_SETICON, ICON_BIG, (LPARAM)ic);
+        }
+        ApplyModernFrame(hWnd);
+        DashLoad(hWnd, s);
+        DashLayout(hWnd, s);
+        return 0;
+    }
+
+    case WM_ERASEBKGND:
+    {
+        RECT rc;
+        GetClientRect(hWnd, &rc);
+        FillRect((HDC)wParam, &rc,
+                 s && s->hBg ? s->hBg : (HBRUSH)GetStockObject(BLACK_BRUSH));
+        return 1;
+    }
+
+    case WM_PAINT:
+    {
+        PAINTSTRUCT ps;
+        HDC hdc = BeginPaint(hWnd, &ps);
+        if (s)
+            DashPaintDiagram(hWnd, s, hdc);
+        EndPaint(hWnd, &ps);
+        return 0;
+    }
+
+    case WM_MOUSEMOVE:
+    case WM_LBUTTONDOWN:
+    {
+        if (!s || !s->showZones)
+            break;
+        POINT pt = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+        RECT dg = DashDiagramRect(s->dpi);
+        int hit = -1;
+        // Centres are tested first: they sit inside the span an edge would
+        // otherwise claim, and the first match wins.
+        static const Zone order[ZONE_COUNT] = {
+            ZONE_TOP_LEFT,      ZONE_TOP_RIGHT,     ZONE_BOTTOM_LEFT,
+            ZONE_BOTTOM_RIGHT,  ZONE_CENTER_TOP,    ZONE_CENTER_BOTTOM,
+            ZONE_CENTER_LEFT,   ZONE_CENTER_RIGHT,  ZONE_EDGE_TOP,
+            ZONE_EDGE_BOTTOM,   ZONE_EDGE_LEFT,     ZONE_EDGE_RIGHT};
+        for (int oi = 0; oi < ZONE_COUNT && hit < 0; oi++)
+        {
+            Zone z = order[oi];
+            int parts = ZoneHasTwoParts(z) ? 2 : 1;
+            for (int p = 0; p < parts; p++)
+            {
+                RECT r = ZoneRectInDiagram(z, dg, p == 1);
+                if (PtInRect(&r, pt))
+                {
+                    hit = (int)z;
+                    break;
+                }
+            }
+        }
+        if (uMsg == WM_MOUSEMOVE)
+        {
+            if (hit != s->hoverZone)
+            {
+                s->hoverZone = hit;
+                // Only the preview changes, so only the preview is repainted.
+                InvalidateRect(hWnd, &dg, TRUE);
+            }
+        }
+        else if (hit >= 0)
+        {
+            DashCaptureZoneTuning(s);
+            s->selZone = hit;
+            DashShowZoneTuning(s);
+            SetFocus(s->hZoneAction[hit]);
+            InvalidateRect(hWnd, nullptr, TRUE);
+        }
+        return 0;
+    }
+
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+        if (s)
+        {
+            SetTextColor((HDC)wParam, g_pal.text);
+            SetBkColor((HDC)wParam, g_pal.bg);
+            return (LRESULT)s->hBg;
+        }
+        break;
+
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+        if (s)
+        {
+            SetTextColor((HDC)wParam, g_pal.fieldText);
+            SetBkColor((HDC)wParam, g_pal.field);
+            return (LRESULT)s->hField;
+        }
+        break;
+
+    case WM_COMMAND:
+    {
+        int id = LOWORD(wParam);
+        if (id == IDC_PAGE_ZONES || id == IDC_PAGE_OPTIONS)
+        {
+            s->showZones = (id == IDC_PAGE_ZONES);
+            DashLayout(hWnd, s);
+            return 0;
+        }
+        if (id == IDC_MONITOR && HIWORD(wParam) == CBN_SELCHANGE)
+        {
+            DashLoadZones(s);
+            InvalidateRect(hWnd, nullptr, TRUE);
+            return 0;
+        }
+        if (id >= IDC_ZONE_ACTION && id < IDC_ZONE_ACTION + ZONE_COUNT)
+        {
+            if (HIWORD(wParam) == CBN_SELCHANGE ||
+                HIWORD(wParam) == CBN_SETFOCUS)
+            {
+                if (HIWORD(wParam) == CBN_SETFOCUS)
+                {
+                    DashCaptureZoneTuning(s);
+                    s->selZone = id - IDC_ZONE_ACTION;
+                    DashShowZoneTuning(s);
+                }
+                InvalidateRect(hWnd, nullptr, TRUE);
+                return 0;
+            }
+        }
+        if (id == IDC_SAVE)
+        {
+            DashSave(hWnd, s);
+            return 0;
+        }
+        if (id == IDC_CANCEL)
+        {
+            DestroyWindow(hWnd);
+            return 0;
+        }
+        if (id == IDC_RESET)
+        {
+            if (MessageBoxW(hWnd,
+                            L"Discard everything set here and go back to the "
+                            L"Windhawk Settings page?",
+                            L"Win-X Hot Corners", MB_YESNO | MB_ICONQUESTION) ==
+                IDYES)
+            {
+                ClearDashboardConfig();
+                Wh_SetIntValue(kOvrEnabled, -1);
+                Wh_SetIntValue(kOvrFullscreen, -1);
+                Wh_SetIntValue(kOvrDrag, -1);
+                Wh_SetIntValue(kOvrVerbose, -1);
+                LoadSettings();
+                ApplyTrayOverrides();
+                RequestRebuild();
+                DashLoad(hWnd, s);
+            }
+            return 0;
+        }
+        break;
+    }
+
+    case WM_DPICHANGED:
+    {
+        s->dpi = HIWORD(wParam);
+        if (s->hFont)
+            DeleteObject(s->hFont);
+        LOGFONTW lf = {};
+        lf.lfHeight = -MulDiv(9, (int)s->dpi, 72);
+        wcscpy_s(lf.lfFaceName, L"Segoe UI");
+        s->hFont = CreateFontIndirectW(&lf);
+        EnumChildWindows(hWnd, DashSetChildFont, (LPARAM)s->hFont);
+        RECT *r = (RECT *)lParam;
+        SetWindowPos(hWnd, nullptr, r->left, r->top, r->right - r->left,
+                     r->bottom - r->top, SWP_NOZORDER | SWP_NOACTIVATE);
+        DashLayout(hWnd, s);
+        return 0;
+    }
+
+    case WM_SIZE:
+        if (s)
+            DashLayout(hWnd, s);
+        return 0;
+
+    case WM_DESTROY:
+        if (s)
+        {
+            if (s->hFont)
+                DeleteObject(s->hFont);
+            if (s->hBg)
+                DeleteObject(s->hBg);
+            if (s->hField)
+                DeleteObject(s->hField);
+            if (s->hPanel)
+                DeleteObject(s->hPanel);
+        }
+        g_hDashWnd = nullptr;
+        PostQuitMessage(0);
+        return 0;
+    }
+    return DefWindowProcW(hWnd, uMsg, wParam, lParam);
+}
+
+static DWORD WINAPI DashThread(LPVOID)
+{
+    PinThreadDpiPerMonitorV2();
+
+    // TOOLTIPS_CLASS lives in comctl32 and needs the library initialised.
+    INITCOMMONCONTROLSEX icc = {sizeof(icc), ICC_WIN95_CLASSES};
+    InitCommonControlsEx(&icc);
+
+    const wchar_t *kClass = L"WindhawkHotCornersDash";
+    HINSTANCE hInst = GetModuleHandle(nullptr);
+
+    WNDCLASSEXW wc = {sizeof(wc)};
+    wc.lpfnWndProc = DashWndProc;
+    wc.hInstance = hInst;
+    wc.lpszClassName = kClass;
+    wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    RegisterClassExW(&wc);
+
+    DashState state;
+
+    UINT dpi = 96;
+    {
+        HMODULE u = GetModuleHandleW(L"user32.dll");
+        using Fn = UINT(WINAPI *)(void);
+        if (auto fn = (Fn)GetProcAddress(u, "GetDpiForSystem"))
+            dpi = fn();
+        if (!dpi)
+            dpi = 96;
+    }
+
+    // WS_CLIPCHILDREN so the parent can never paint inside a child's rectangle.
+    // Without it, anything drawn in WM_PAINT that lands under a control stays
+    // on screen as residue, because the child is not repainted to cover it.
+    DWORD style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX |
+                  WS_CLIPCHILDREN;
+    RECT need = {0, 0, Sc(Lay::ClientW, dpi), Sc(Lay::ClientH, dpi)};
+    AdjustWindowRectEx(&need, style, FALSE, 0);
+    int w = need.right - need.left;
+    int h = need.bottom - need.top;
+    int x = (GetSystemMetrics(SM_CXSCREEN) - w) / 2;
+    int y = (GetSystemMetrics(SM_CYSCREEN) - h) / 2;
+
+    HWND hWnd = CreateWindowExW(0, kClass, L"Win-X Hot Corners — Settings",
+                                style, x, y, w, h, nullptr, nullptr, hInst,
+                                &state);
+
+    if (!hWnd)
+    {
+        UnregisterClassW(kClass, hInst);
+        return 1;
+    }
+
+    g_hDashWnd = hWnd;
+    ShowWindow(hWnd, SW_SHOW);
+    SetForegroundWindow(hWnd);
+
+    MSG msg;
+    while (GetMessageW(&msg, nullptr, 0, 0))
+    {
+        if (!IsDialogMessageW(hWnd, &msg))
+        {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+    }
+
+    UnregisterClassW(kClass, hInst);
+    return 0;
+}
+
+static void OpenDashboard()
+{
+    if (g_hDashWnd && IsWindow(g_hDashWnd))
+    {
+        // Already open — bring it forward rather than making a second one.
+        ShowWindow(g_hDashWnd, SW_RESTORE);
+        SetForegroundWindow(g_hDashWnd);
+        return;
+    }
+    if (g_hDashThread)
+    {
+        WaitForSingleObject(g_hDashThread, 0);
+        CloseHandle(g_hDashThread);
+        g_hDashThread = nullptr;
+    }
+    g_hDashThread = CreateThread(nullptr, 0, DashThread, nullptr, 0, nullptr);
+}
+
+static LRESULT CALLBACK TrayWndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
+                                    LPARAM lParam)
+{
+    if (uMsg == WM_APP_TRAY)
+    {
+        // Under NOTIFYICON_VERSION_4 the event is in the low word of lParam
+        // and the cursor position is in wParam; under the legacy version
+        // lParam is the event on its own. Reading LOWORD(lParam) is correct
+        // for both.
+        UINT ev = LOWORD(lParam);
+        if (ev == WM_CONTEXTMENU || ev == WM_RBUTTONUP)
+        {
+            POINT pt = {GET_X_LPARAM(wParam), GET_Y_LPARAM(wParam)};
+            if (pt.x == 0 && pt.y == 0)
+                GetCursorPos(&pt);  // legacy version does not supply coords
+            ShowTrayMenu(pt);
+        }
+        else if (ev == NIN_SELECT || ev == NIN_KEYSELECT || ev == WM_LBUTTONUP)
+        {
+            OpenDashboard();
+        }
+        return 0;
+    }
+    if (uMsg == WM_COMMAND)
+    {
+        HandleTrayCommand(LOWORD(wParam));
+        return 0;
+    }
+    // Explorer restarted and threw away every tray icon; put ours back.
+    if (g_taskbarCreatedMsg && uMsg == g_taskbarCreatedMsg)
+    {
+        UpdateTrayIcon(true);
+        return 0;
+    }
+    return DefWindowProc(hWnd, uMsg, wParam, lParam);
+}
+
+static DWORD WINAPI TrayThread(LPVOID)
+{
+    const wchar_t *kClass = L"WindhawkHotCornersTray";
+    HINSTANCE hInst = GetModuleHandle(nullptr);
+
+    // Registered before the window exists so an Explorer restart racing our
+    // startup cannot be missed.
+    g_taskbarCreatedMsg = RegisterWindowMessageW(L"TaskbarCreated");
+
+    WNDCLASS wc = {};
+    wc.lpfnWndProc = TrayWndProc;
+    wc.hInstance = hInst;
+    wc.lpszClassName = kClass;
+    RegisterClass(&wc);
+
+    g_hTrayWnd = CreateWindowEx(WS_EX_TOOLWINDOW, kClass, nullptr, WS_POPUP, 0,
+                                0, 0, 0, nullptr, nullptr, hInst, nullptr);
+    if (!g_hTrayWnd)
+    {
+        Wh_Log(L"Tray: failed to create the icon's window");
+        UnregisterClass(kClass, hInst);
+        return 1;
+    }
+
+    UpdateTrayIcon(true);
+
+
+    MSG msg;
+    while (GetMessage(&msg, nullptr, 0, 0))
+    {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+
+    NOTIFYICONDATAW nid = {};
+    FillTrayIconData(nid);
+    Shell_NotifyIconW(NIM_DELETE, &nid);
+
+    DestroyWindow(g_hTrayWnd);
+    g_hTrayWnd = nullptr;
+    UnregisterClass(kClass, hInst);
+    return 0;
+}
+
+// =====================================================================
 // Tool Mod Entry Points
 // =====================================================================
 
@@ -2514,6 +5192,7 @@ BOOL WhTool_ModInit()
     }
 
     LoadSettings();
+    ApplyTrayOverrides();
 
     g_hWorkerThread =
         CreateThread(nullptr, 0, ActionWorkerThread, nullptr, 0, nullptr);
@@ -2531,12 +5210,20 @@ BOOL WhTool_ModInit()
         return FALSE;
     }
 
+    // Non-fatal: losing the tray icon should not take the hot corners with it.
+    g_hTrayThread =
+        CreateThread(nullptr, 0, TrayThread, nullptr, 0, &g_dwTrayThreadId);
+    if (!g_hTrayThread)
+        Wh_Log(L"Tray icon unavailable (thread creation failed)");
+
     return TRUE;
 }
 
 void WhTool_ModSettingsChanged()
 {
     LoadSettings();
+    ApplyTrayOverrides();
+    UpdateTrayIcon(false);
     // The zone rebuild has to happen on the detection thread, which owns the
     // DPI context and the monitor list. Post, never send — Windhawk's thread
     // must not block on ours.
@@ -2548,6 +5235,17 @@ void WhTool_ModUninit()
 {
     if (g_hStopEvent)
         SetEvent(g_hStopEvent);
+
+    if (g_dwTrayThreadId)
+        PostThreadMessage(g_dwTrayThreadId, WM_QUIT, 0, 0);
+
+    if (g_hTrayThread)
+    {
+        if (WaitForSingleObject(g_hTrayThread, 3000) == WAIT_TIMEOUT)
+            Wh_Log(L"Tray thread exit timed out");
+        CloseHandle(g_hTrayThread);
+        g_hTrayThread = nullptr;
+    }
 
     if (g_dwDetectThreadId)
         PostThreadMessage(g_dwDetectThreadId, WM_QUIT, 0, 0);


### PR DESCRIPTION
Adds **Win-X Hot Corners**, a hot corners and screen edges mod for Windows 10 and 11.

Moving the cursor into a screen corner, or against a screen edge, triggers a configurable action. Each monitor gets sixteen independent zones — four corners, and four edges divided into three segments each — with 38 built-in actions plus arbitrary key combinations and commands.

### Notes on the implementation

**Detection does not use a low-level mouse hook.** A `WH_MOUSE_LL` hook has to return within `LowLevelHooksTimeout` or Windows skips the callback and eventually removes the hook, which shows up as corners that intermittently stop working. It also puts the mod on the input path of every application on the system. This mod instead polls the cursor every 16 ms on a dedicated thread in its own tool-mod process, so it adds nothing to system-wide input handling and cannot be starved.

**Monitors are identified by display name** read via `QueryDisplayConfig`, not by position in an enumeration. Rearranging displays or changing which one is primary therefore does not silently repoint a configuration at a different screen. Identical models are disambiguated with a numeric suffix.

**Per-monitor DPI aware.** Each of the mod's threads pins `DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2`, so zone rectangles and cursor coordinates agree on mixed-scaling setups.

**Zone geometry is provably disjoint.** Corner and edge sizes are clamped per monitor so the zones can never overlap, which matters because the hit test is first-match-wins. Each edge's thickness is capped at the smaller of the two corners it runs between, which is what keeps the sixteen zones disjoint under arbitrary per-zone sizes. Neighbouring edge segments that resolve identically are coalesced into one zone before detection sees them, so "all three the same" is genuinely a single edge-wide zone rather than three that re-arm as the pointer crosses a seam.

**Five ways to trigger a zone**, and they combine: on arrival, after a dwell, on a double knock, only while a modifier is held, or press-and-hold — where the zone runs one action on arrival and another when the pointer leaves. That last one restores the Show Desktop button Windows 11 dropped: rest in the corner to peek, move away to restore.

Actions run on a separate worker thread, with a rate limit between them, so a slow launch cannot delay detection and rapid triggering cannot flood the shell. The fullscreen and excluded-application checks run there too, off the sampling path.

**The Windhawk settings page is the only place configuration is stored.** An earlier revision of this pull request argued the opposite and shipped a tray-based editor instead; that was wrong and has been reverted. A mod can read its settings but not write them, so a second surface that also edits configuration can only ever diverge from the page — during development that showed up as an editor addressing stored configurations by list position and overwriting the wrong display.

The tray icon's **Zones & settings** window is therefore read-only: a tab per display, a diagram of that screen with each zone's action drawn in it, and the timings actually in effect for whichever zone you point at, each marked *global* or *this zone*. It reads the resolved configuration rather than the stored one, which is what stops it from disagreeing with what actually fires. Left-clicking the tray icon toggles the mod; right-clicking offers a temporary suspend and opens that window.

### Checklist

- Single file: `mods/win-x-hotcorners.wh.cpp`
- Mod id `win-x-hotcorners` matches the filename
- `@github` is https://github.com/DhakadG, which is the author of this pull request
- Source repository, including the readme's images: https://github.com/DhakadG/my-windhawk-mods
- Licensed MIT, declared in the mod metadata
- Compiles and runs on Windows 11 (26300); CI green on Windhawk 1.6.1, 1.7.3 and 2.0.0-alpha.2


<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* New mod submission — no changelog.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.

