### PR TITLE
Add Taskbar Folder Hover Tray mod (native taskbar rendering, folder manager)

### DIFF
--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,12 +2,12 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.44
+// @version         2.0
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lshell32 -lshlwapi -luuid -lgdi32 -lgdiplus -lcomctl32 -ldwmapi -luser32
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lshell32 -lshlwapi -luuid -lgdi32 -lgdiplus -lcomctl32 -ldwmapi -luser32 -luxtheme
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -49,10 +49,14 @@ Windows 11 only.
 **Folders are not configured on the settings page.** They live in the
 **Taskbar Folders** window instead, which you can open in either of two ways:
 
-- Right click any folder button already on the taskbar and choose
-  **Manage folders...**
-- Or, with nothing pinned yet, click the **➕** button the mod puts on the
-  taskbar — it is there only until the first folder is pinned.
+- **Right click a folder button on the taskbar** and choose **Manage folders...**.
+  The buttons are real taskbar items now, so that menu is Windows' own jump list —
+  the entry gets there through the folder's AppUserModelID rather than being drawn
+  by this mod. **Unpin from taskbar** sits on the same menu, for free.
+- Or right click any folder, file or the Desktop background, pick **Show more
+  options** if you get the short Windows 11 menu, then
+  **Taskbar Folders → Manage folders...**. This one works even when nothing is
+  pinned yet, so it is the way in from a standing start.
 
 The quickest way to add one in the first place is straight from Explorer:
 right click any folder in Explorer or on the Desktop, pick **Show more
@@ -74,14 +78,19 @@ context menus are left completely untouched.
 
 ### The Taskbar Folders window
 
-Every folder is listed with its icon and name. From there you can:
+Folders are listed under two headings — **On the taskbar** and **Not pinned** —
+and sorted by name within each. The window follows your Windows app theme, so it
+is dark when the rest of Windows is. From there you can:
 
 | Action | What it does |
 |--------|--------------|
 | **Add...** | Pick any folder and give it a name and icon |
-| **Edit...** | Change the name, folder or icon, and tick or untick **Pinned to the taskbar**. Unticking takes the button off the taskbar **without deleting anything** — the entry stays in the list with its name and icon, and can be pinned again any time |
+| **Edit...** | Change the name, folder or icon, and tick or untick **Pinned to the taskbar**. Double-clicking a row does the same |
 | **Remove** | Forget the entry entirely. The folder itself is never touched |
-| **Drag a row** | Drag it up or down the list to set the left-to-right order of the taskbar buttons |
+| **Pin** / **Unpin** | Moves the selected folder between the two sections. Unpinning takes the button off the taskbar **without deleting anything** — the entry keeps its name and icon and can be pinned again any time |
+
+The list is not reorderable, and does not need to be: **button order is set by
+dragging the buttons on the taskbar**, like any other pinned app.
 
 Each entry has three fields:
 
@@ -90,6 +99,9 @@ Each entry has three fields:
 | Name  | `Apps` | Shown as the title at the top of the hover grid |
 | Folder | `%USERPROFILE%\Desktop` | Environment variables are expanded. `shell:` targets that map to a **filesystem folder** also work (e.g. `shell:Desktop`, `shell:Downloads`). Virtual namespaces such as Control Panel, Recycle Bin, or This PC are not supported — use [Taskbar Folder Menus](https://github.com/ramensoftware/windhawk-mods/blob/main/mods/taskbar-folder-menus.wh.cpp) for those. |
 | Icon | an emoji, `C:\icons\apps.ico`, or `C:\Windows\explorer.exe,0` | Leave empty to use the folder's own icon |
+
+**Open** next to the folder box opens whatever path is currently typed, so a
+path can be checked before it is saved.
 
 A good setup is to make a folder somewhere, fill it with shortcuts to the apps
 you want grouped, and point a button at it.
@@ -139,20 +151,31 @@ settings page Windhawk already draws — hence **Taskbar Folders**.
 
 ## How it is positioned
 
-The Windows 11 taskbar app strip is a WinUI `ItemsRepeater` that refuses to lay out
-any child it did not create itself, so this mod cannot literally become a taskbar
-item. Instead it adds itself as an overlay to the taskbar's root grid and widens the
-margin of the neighbouring app icon to carve out a real gap in the strip, then keeps
-itself seated in that gap on every layout pass. The taskbar re-centers around the
-gap, so the result reads as flush.
+It isn't. Each folder button is a **real pinned taskbar item**, so Windows creates,
+positions and animates it exactly like any pinned app.
 
-Two consequences worth knowing:
+Under the hood each folder gets a shortcut in your Start Menu carrying its own
+AppUserModelID, and that shortcut is pinned with the shell's ordinary
+"pin to taskbar" verb. Everything else follows from the buttons being genuine:
 
-- The buttons cannot be dragged around on the taskbar itself the way real
-  taskbar items can. To change their order, open the **Taskbar Folders** window
-  (right click any folder button > **Manage folders...**) and drag the rows
-  into the order you want — top of the list is the leftmost button.
-- They do not collapse into the overflow button when the taskbar gets full.
+- **Drag them** to reorder, like any other taskbar item. The order is the
+  taskbar's, so it survives restarts and is not stored by this mod.
+- **Right click** gives the normal Windows menu, including
+  **Unpin from taskbar** and a **Manage folders...** entry this mod publishes to
+  the folder's own jump list. Unpinning keeps the entry in the Taskbar Folders
+  window as a draft, so its name and icon are not lost.
+- They collapse into the overflow button when the taskbar fills up.
+- Every animation is Windows' own.
+
+Earlier versions drew an overlay instead, seated in a gap carved by widening a
+neighbouring icon's margin. It could never be exactly right: taskbar positions are
+driven by compositor-thread animations that no other window can sample mid-flight,
+so an overlay is always at least a frame behind. That whole approach, and the
+~2,000 lines that chased it, is gone.
+
+One thing to know: a button's **icon comes from the shortcut**, which means it has
+to be a real icon file. `.ico` files, `app.exe,0` resource specs and a folder's own
+custom icon all work. An **emoji icon falls back** to the standard folder glyph.
 
 ## If you already use Taskbar Folder Menus
 
@@ -183,221 +206,200 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 
 // ==WindhawkModSettings==
 /*
-- openFolderOnClick: true
-  $name: 1. Behavior ▸ Click opens the folder
-  $description: Left clicking a taskbar button opens the folder in File Explorer.
+- behavior:
+  - openFolderOnClick: true
+    $name: Click opens the folder
+    $description: >-
+      Left clicking a folder button opens the folder in File Explorer. Turn this
+      off to make the buttons hover-only — the click is swallowed and the grid is
+      the only way in.
 
-- explorerMenu: true
-  $name: 1. Behavior ▸ Explorer right-click menu
-  $description: >-
-    Adds a "Taskbar Folders" submenu to the classic Explorer and Desktop
-    context menus — the ones behind "Show more options" / Shift+F10, not the
-    short Windows 11 menu, which is XAML and takes no items from a mod. Use it
-    to pin a folder straight to the taskbar, or to move, copy or make a
-    shortcut into a folder that already has a button. Turn this off to keep
-    the mod entirely on the taskbar side — with it off, Explorer's own context
-    menus are left completely alone. Changing this setting reloads the mod,
-    because the menu hook can only be installed or removed at startup.
+  - explorerMenu: true
+    $name: Explorer right-click menu
+    $description: >-
+      Adds a "Taskbar Folders" submenu to the classic Explorer and Desktop
+      context menus — the ones behind "Show more options" / Shift+F10, not the
+      short Windows 11 menu, which is XAML and takes no items from a mod. Use it
+      to pin a folder straight to the taskbar, or to move, copy or make a
+      shortcut into a folder that already has a button. Turn this off to keep
+      the mod entirely on the taskbar side — with it off, Explorer's own context
+      menus are left completely alone. Changing this setting reloads the mod,
+      because the menu hook can only be installed or removed at startup.
 
-- position: beforeApps
-  $name: 1. Behavior ▸ Position
-  $description: Which side of the app icons the buttons sit on.
-  $options:
-  - beforeApps: Before the app icons
-  - afterApps: After the app icons
+  - hoverDelayMs: 0
+    $name: Hover delay (ms)
+    $description: Delay before the grid appears. 0 is instant.
 
-- anchor: firstApp
-  $name: 1. Behavior ▸ Anchor
-  $description: >-
-    Which taskbar element the gap is carved next to. Change this if another mod is
-    fighting for the same anchor. Auto picks the outermost app icon.
-  $options:
-  - firstApp: Outermost App icon
-  - widgets: Widgets button
-  - taskView: Task View button
-  - start: Start button
+  - closeDelayMs: 250
+    $name: Close delay (ms)
+    $description: >-
+      How long the grid stays open after the mouse leaves the button and the grid.
+      Moving onto another taskbar icon counts as leaving.
+  $name: Behavior
+  $description: How the buttons respond to the mouse, and whether the mod touches Explorer at all.
 
-- hoverDelayMs: 0
-  $name: 1. Behavior ▸ Hover delay (ms)
-  $description: Delay before the grid appears. 0 is instant.
+- content:
+  - includeSubfolders: true
+    $name: Show subfolders
+    $description: Include subfolders as entries in the grid.
 
-- closeDelayMs: 250
-  $name: 1. Behavior ▸ Close delay (ms)
-  $description: >-
-    How long the grid stays open after the mouse leaves the button and the grid.
-    Moving onto another taskbar icon counts as leaving.
+  - maxFolderDepth: -1
+    $name: Maximum folder depth
+    $description: >-
+      How many levels of subfolder menus can cascade when you hover a subfolder.
+      -1 is unlimited, 0 means subfolders never open on hover, 1 allows one level
+      of subfolders, and so on. Turn off "Show subfolders" to hide them entirely.
 
-- includeSubfolders: true
-  $name: 2. Content ▸ Show subfolders
-  $description: Include subfolders as entries in the grid.
+  - submenuDelayMs: 150
+    $name: Subfolder open delay (ms)
+    $description: >-
+      How long to rest on a subfolder before its menu opens. A small delay stops
+      menus from firing off while you sweep across the grid. 0 is instant.
 
-- maxFolderDepth: -1
-  $name: 2. Content ▸ Maximum folder depth
-  $description: >-
-    How many levels of subfolder menus can cascade when you hover a subfolder.
-    -1 is unlimited, 0 means subfolders never open on hover, 1 allows one level
-    of subfolders, and so on. Turn off "Show subfolders" to hide them entirely.
+  - submenuCloseDelayMs: 300
+    $name: Subfolder close delay (ms)
+    $description: >-
+      How long a cascaded subfolder menu stays open after the mouse leaves the
+      cell that opened it. Gives you time to move diagonally into the submenu.
 
-- submenuDelayMs: 150
-  $name: 2. Content ▸ Subfolder open delay (ms)
-  $description: >-
-    How long to rest on a subfolder before its menu opens. A small delay stops
-    menus from firing off while you sweep across the grid. 0 is instant.
+  - showHidden: false
+    $name: Show hidden items
+    $description: Include hidden and system files.
 
-- submenuCloseDelayMs: 300
-  $name: 2. Content ▸ Subfolder close delay (ms)
-  $description: >-
-    How long a cascaded subfolder menu stays open after the mouse leaves the
-    cell that opened it. Gives you time to move diagonally into the submenu.
+  - showExtensions: false
+    $name: Show file extensions
+    $description: Shortcut (.lnk) extensions are always hidden.
 
-- showHidden: false
-  $name: 2. Content ▸ Show hidden items
-  $description: Include hidden and system files.
+  - sortBy: name
+    $name: Sort by
+    $description: >-
+      Folders always come first so the entries that cascade stay together at the
+      top. This orders the items within each group.
+    $options:
+    - name: Name
+    - modified: Date modified (newest first)
 
-- showExtensions: false
-  $name: 2. Content ▸ Show file extensions
-  $description: Shortcut (.lnk) extensions are always hidden.
+  - maxItems: 64
+    $name: Maximum items
+    $description: >-
+      Limit how many entries the grid shows and caches. The cache also caps to
+      roughly what can fit on screen (columns × rows, tighter for large icons)
+      and a ~64 MB bitmap budget, so very large maxItems values do not keep
+      hundreds of oversized icons resident. 0 uses that automatic on-screen cap.
 
-- sortBy: name
-  $name: 2. Content ▸ Sort by
-  $description: >-
-    Folders always come first so the entries that cascade stay together at the
-    top. This orders the items within each group.
-  $options:
-  - name: Name
-  - modified: Date modified (newest first)
+  - columns: 0
+    $name: Grid columns
+    $description: 0 chooses a square-ish grid automatically.
+  $name: Content
+  $description: What the hover grid lists, and how much of it.
 
-- maxItems: 60
-  $name: 2. Content ▸ Maximum items
-  $description: >-
-    Limit how many entries the grid shows and caches. The cache also caps to
-    roughly what can fit on screen (columns × rows, tighter for large icons)
-    and a ~64 MB bitmap budget, so very large maxItems values do not keep
-    hundreds of oversized icons resident. 0 uses that automatic on-screen cap.
+- appearance:
+  - itemSize: medium
+    $name: Item size
+    $description: >-
+      Preset size for each item's icon and grid cell. Every step scales both the
+      icon and the overall tray size.
+    $options:
+    - smallest: Smallest
+    - tiny: Tiny
+    - xsmall: Extra small
+    - small: Small
+    - medium: Medium
+    - large: Large
 
-- columns: 0
-  $name: 2. Content ▸ Grid columns
-  $description: 0 chooses a square-ish grid automatically.
+  - showLabels: true
+    $name: Show item labels
+    $description: >-
+      Turn off for an icons-only grid. Icons are centred in the cell when labels
+      are hidden.
 
-- itemSize: small
-  $name: 3. Appearance ▸ Item size
-  $description: >-
-    Preset size for each item's icon and grid cell. Every step scales both the
-    icon and the overall tray size.
-  $options:
-  - smallest: Smallest
-  - tiny: Tiny
-  - xsmall: Extra small
-  - small: Small
-  - medium: Medium
-  - large: Large
+  - fontSize: 13
+    $name: Item label size (px)
 
-- buttonIconSize: 0
-  $name: 3. Appearance ▸ Button icon size (px)
-  $description: 0 matches the size Windows uses for its own taskbar icons.
+  - itemFontWeight: regular
+    $name: Item label weight
+    $options:
+    - regular: Regular
+    - bold: Bold
 
-- showLabels: true
-  $name: 3. Appearance ▸ Show item labels
-  $description: >-
-    Turn off for an icons-only grid. Icons are centred in the cell when labels
-    are hidden.
+  - showTitle: true
+    $name: Show folder title
+    $description: >-
+      The folder name at the top of the main hover grid. Subfolder menus never
+      show one.
 
-- fontSize: 12
-  $name: 3. Appearance ▸ Item label size (px)
+  - titleFontSize: 14
+    $name: Folder title size (px)
+    $description: Size of the name shown at the top of the main hover grid.
 
-- itemFontWeight: bold
-  $name: 3. Appearance ▸ Item label weight
-  $options:
-  - regular: Regular
-  - bold: Bold
+  - titleFontWeight: bold
+    $name: Folder title weight
+    $options:
+    - regular: Regular
+    - bold: Bold
 
-- showTitle: true
-  $name: 3. Appearance ▸ Show folder title
-  $description: >-
-    The folder name at the top of the main hover grid. Subfolder menus never
-    show one.
+  - titleAlign: center
+    $name: Folder title position
+    $description: >-
+      Horizontal position of the folder name on the main hover grid. Subfolder
+      menus never show a title.
+    $options:
+    - left: Left
+    - center: Center
+    - right: Right
 
-- titleFontSize: 13
-  $name: 3. Appearance ▸ Folder title size (px)
-  $description: Size of the name shown at the top of the main hover grid.
+  - roundedCorners: true
+    $name: Rounded grid corners
+    $description: Rounds the corners of the hover grid. Turn off for square ones.
 
-- titleFontWeight: bold
-  $name: 3. Appearance ▸ Folder title weight
-  $options:
-  - regular: Regular
-  - bold: Bold
+  - popupTheme: system
+    $name: Grid theme
+    $description: >-
+      Background and text colours of the hover grid. Windows default follows the
+      system app theme.
+    $options:
+    - system: Windows default
+    - light: Light
+    - dark: Dark
 
-- titleAlign: center
-  $name: 3. Appearance ▸ Folder title position
-  $description: >-
-    Horizontal position of the folder name on the main hover grid. Subfolder
-    menus never show a title.
-  $options:
-  - left: Left
-  - center: Center
-  - right: Right
+  - panelOpacity: 10
+    $name: Grid opacity (%)
+    $description: >-
+      A contrasting outline is added behind the text as the background fades out.
+      At 0 the background is invisible - icons and labels float straight over the
+      desktop - but the grid still takes clicks rather than passing them through
+      to whatever is behind it.
 
-- cornerRadius: 8
-  $name: 3. Appearance ▸ Grid corner radius (px)
+  - blurType: acrylic
+    $name: Blur type
+    $description: >-
+      Gaussian captures the screen behind the grid and blurs it ourselves - a
+      real, adjustable blur radius, but it costs a screen capture and a resample
+      every ~32ms to track a moving background live. Acrylic uses Windows' own
+      GPU-composited blur-behind instead - much cheaper (no capture, no per-frame
+      resample, updates live for free) but the blur radius itself is fixed by
+      Windows, not adjustable; the strength setting below controls the tint's
+      opacity instead of the blur radius. None skips blur entirely - cheaper
+      than either, same as setting the strength below to 0.
+    $options:
+    - acrylic: Acrylic (fixed radius, cheaper)
+    - gaussian: Gaussian (adjustable, more expensive)
+    - none: None
 
-- popupTheme: system
-  $name: 3. Appearance ▸ Grid theme
-  $description: >-
-    Background and text colours of the hover grid. Windows default follows the
-    system app theme.
-  $options:
-  - system: Windows default
-  - light: Light
-  - dark: Dark
+  - blurStrength: 10
+    $name: Blur strength (%)
+    $description: >-
+      Transparent blur layered behind the grid, over whatever is on screen.
+      Independent of the grid opacity above. Ignored when blur type above is
+      None; 0 has the same effect. For Gaussian this is the blur radius; for
+      Acrylic (fixed blur radius) it is instead how opaque the tint over that
+      blur is.
 
-- panelOpacity: 85
-  $name: 3. Appearance ▸ Grid opacity (%)
-  $description: >-
-    A contrasting outline is added behind the text as the background fades out.
-    At 0 the background is invisible - icons and labels float straight over the
-    desktop - but the grid still takes clicks rather than passing them through
-    to whatever is behind it.
-
-- panelBorder: true
-  $name: 3. Appearance ▸ Grid border
-  $description: >-
-    Thin outline around the edge of the grid, plus the border Windows draws on
-    the rounded window. Turn off for a frameless look at low opacity.
-
-- blurType: acrylic
-  $name: 3. Appearance ▸ Blur type
-  $description: >-
-    Gaussian captures the screen behind the grid and blurs it ourselves - a
-    real, adjustable blur radius, but it costs a screen capture and a resample
-    every ~32ms to track a moving background live. Acrylic uses Windows' own
-    GPU-composited blur-behind instead - much cheaper (no capture, no per-frame
-    resample, updates live for free) but the blur radius itself is fixed by
-    Windows, not adjustable; the strength setting below controls the tint's
-    opacity instead of the blur radius. None skips blur entirely - cheaper
-    than either, same as setting the strength below to 0.
-  $options:
-  - acrylic: Acrylic (fixed radius, cheaper)
-  - gaussian: Gaussian (adjustable, more expensive)
-  - none: None
-
-- blurStrength: 40
-  $name: 3. Appearance ▸ Blur strength (%)
-  $description: >-
-    Transparent blur layered behind the grid, over whatever is on screen.
-    Independent of the grid opacity above. Ignored when blur type above is
-    None; 0 has the same effect. For Gaussian this is the blur radius; for
-    Acrylic (fixed blur radius) it is instead how opaque the tint over that
-    blur is.
-
-- gapAbove: 8
-  $name: 3. Appearance ▸ Gap above taskbar (px)
-  $description: Distance between the taskbar and the grid.
-
-- gapBefore: 0
-  $name: 3. Appearance ▸ Padding before buttons (px)
-
-- gapAfter: 0
-  $name: 3. Appearance ▸ Padding after buttons (px)
+  - gapAbove: 8
+    $name: Gap above taskbar (px)
+    $description: Distance between the taskbar and the grid.
+  $name: Appearance
+  $description: How the hover grid looks.
 */
 // ==/WindhawkModSettings==
 
@@ -405,6 +407,7 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 
 #include <windhawk_utils.h>
 
+#include <commctrl.h>
 #include <commoncontrols.h>
 #include <dwmapi.h>
 #include <shellapi.h>
@@ -422,6 +425,7 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 #include <winrt/Windows.UI.ViewManagement.h>
 #include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.UI.Xaml.Input.h>
@@ -520,19 +524,24 @@ struct FolderEntry {
     // (mod storage), false for folders configured in the Settings UI. Only
     // pinned folders can be removed with a taskbar right-click.
     bool pinned = false;
+    // Copied from the store. Ties this entry to its real taskbar item: the
+    // shortcut's AppUserModelID is built from it, so it is how a taskbar button
+    // is resolved back to the folder behind it.
+    std::wstring pinId;
 };
+
+// The one rounded radius, at 96 DPI; ScaleForPopup takes it from there.
+constexpr int kRoundedCornerRadius = 8;
 
 enum class SortMode { Name, Modified };
 enum class BlurType { None, Gaussian, Acrylic };
 
 struct Settings {
     std::vector<FolderEntry> folders;
-    std::wstring position = L"beforeApps";
-    std::wstring anchor = L"firstApp";
     int hoverDelayMs = 0;
     int closeDelayMs = 250;
     int columns = 0;
-    int maxItems = 60;
+    int maxItems = 64;
     bool includeSubfolders = true;
     int maxFolderDepth = -1;
     int submenuDelayMs = 150;
@@ -541,28 +550,27 @@ struct Settings {
     bool showExtensions = false;
     SortMode sortBy = SortMode::Name;
     // Derived from itemSize in LoadSettings(); not settings-bound directly.
-    int cellWidth = 76;
-    int cellHeight = 72;
-    int iconSize = 24;
+    int cellWidth = 92;
+    int cellHeight = 88;
+    int iconSize = 32;
     bool showLabels = true;
-    int fontSize = 12;
+    int fontSize = 13;
     // LOGFONT lfWeight values. See MakePopupFont.
-    int itemFontWeight = FW_BOLD;
+    int itemFontWeight = FW_NORMAL;
     bool showTitle = true;
-    int titleFontSize = 13;
+    int titleFontSize = 14;
     int titleFontWeight = FW_BOLD;
     std::wstring titleAlign = L"center";
-    int cornerRadius = 8;
+    // Kept as a pixel radius rather than a bool because three separate places
+    // need the number: the window region, the blur region and the painted
+    // background. The setting itself is just on or off.
+    int cornerRadius = kRoundedCornerRadius;
     // -1 follows the system app theme; 0 forces light, 1 forces dark.
     int popupThemeOverride = -1;
-    int panelOpacity = 85;
-    bool panelBorder = true;
+    int panelOpacity = 10;
     BlurType blurType = BlurType::Acrylic;
-    int blurStrength = 40;
+    int blurStrength = 10;
     int gapAbove = 8;
-    int gapBefore = 0;
-    int gapAfter = 0;
-    int buttonIconSize = 0;
     bool openFolderOnClick = true;
     // Read from an Explorer window thread inside the TrackPopupMenuEx hook
     // while LoadSettings may be writing it on another.
@@ -638,6 +646,7 @@ bool IsLikelyRemotePath(const std::wstring& p);
 bool IsShellFolderPath(const std::wstring& path);
 void ResolvePendingFolderEntries();
 void ReloadAndRefreshUI();
+void RequestReloadUI();
 
 // Non-zero while a reload is executing. Wh_ModUninit waits this out: a reload
 // parks the taskbar UI thread in a join that pumps sent messages, so uninit's
@@ -857,6 +866,18 @@ struct Entry {
     std::wstring icon;
     uint64_t fileId = 0;
     bool pinned = true;
+    // Stable per-entry identity for the real taskbar pin. Becomes the shortcut's
+    // AppUserModelID, which is what keeps the item from merging into the File
+    // Explorer group (every pin shortcut targets explorer.exe — see Pins) and is
+    // how a taskbar button is recognised as ours later. Generated once, on first
+    // write, and never reused: reusing one would let a deleted entry's pin be
+    // adopted by an unrelated folder.
+    std::wstring pinId;
+    // True once this entry's shortcut has actually been pinned. Without it the
+    // reconcile cannot tell "pinned=1 and not on the taskbar yet" from "pinned=1
+    // and the user just unpinned it from the taskbar" — the first wants pinning,
+    // the second must not be re-pinned or native Unpin would look broken.
+    bool pinApplied = false;
 };
 
 std::wstring GetString(PCWSTR format, int index) {
@@ -885,9 +906,13 @@ std::vector<Entry> Read() {
         std::wstring id = GetString(L"entry[%d].id", i);
         entry.fileId = id.empty() ? 0 : wcstoull(id.c_str(), nullptr, 16);
 
+        entry.pinId = GetString(L"entry[%d].pinId", i);
+
         WCHAR key[64];
         swprintf(key, ARRAYSIZE(key), L"entry[%d].pinned", i);
         entry.pinned = Wh_GetIntValue(key, 1) != 0;
+        swprintf(key, ARRAYSIZE(key), L"entry[%d].pinApplied", i);
+        entry.pinApplied = Wh_GetIntValue(key, 0) != 0;
         entries.push_back(std::move(entry));
     }
     return entries;
@@ -915,15 +940,21 @@ void Write(const std::vector<Entry>& entries) {
         swprintf(idBuf, ARRAYSIZE(idBuf), L"%llx",
                  (unsigned long long)entry.fileId);
         Wh_SetStringValue(key, idBuf);
+        swprintf(key, ARRAYSIZE(key), L"entry[%d].pinId", i);
+        Wh_SetStringValue(key, entry.pinId.c_str());
         swprintf(key, ARRAYSIZE(key), L"entry[%d].pinned", i);
         Wh_SetIntValue(key, entry.pinned ? 1 : 0);
+        swprintf(key, ARRAYSIZE(key), L"entry[%d].pinApplied", i);
+        Wh_SetIntValue(key, entry.pinApplied ? 1 : 0);
     }
 
     // The array shrank: drop the tail so a stale entry cannot reappear if it
     // later grows again.
     for (int i = count; i < previous && i < kMaxEntries; i++) {
         WCHAR key[64];
-        for (PCWSTR field : {L"path", L"name", L"icon", L"id", L"pinned"}) {
+        for (PCWSTR field :
+             {L"path", L"name", L"icon", L"id", L"pinId", L"pinned",
+              L"pinApplied"}) {
             swprintf(key, ARRAYSIZE(key), L"entry[%d].%s", i, field);
             Wh_DeleteValue(key);
         }
@@ -962,6 +993,1018 @@ int IndexOfPath(const std::vector<Entry>& entries, const std::wstring& path) {
 
 }  // namespace FolderStore
 
+////////////////////////////////////////////////////////////////////////////////
+// Real taskbar pins
+//
+// Each pinned folder is a genuine pinned taskbar item, not a drawn overlay. That
+// is what makes the animations exact and dragging work: Windows lays the button
+// out and animates it, so there is nothing to chase.
+//
+// The shape below is not the obvious one, and each part of it was forced by
+// measurement on 25H2 (build 26200) rather than chosen:
+//
+//   * The shortcut targets `explorer.exe <folder>`, never the folder itself. A
+//     .lnk pointing at a bare folder is not pinnable at all — the shell answers
+//     ERROR_NO_ASSOCIATION. Only the app-shaped form is accepted.
+//
+//   * Because every shortcut therefore points at explorer.exe, a unique
+//     AppUserModelID per entry is load-bearing, not decorative: without it the
+//     items collapse into the File Explorer group.
+//
+//   * Pinning goes through the documented shell verb (IContextMenu
+//     "taskbarpin"), not IPinnedList3. The undocumented interface is not needed,
+//     which removes a vtable whose slot order has shifted between Windows
+//     versions before.
+//
+//   * All of it runs on a private STA thread. It must be an STA (the pin COM
+//     class is ThreadingModel=Apartment with no marshaler), and it must not be a
+//     thread dispatching an input-synchronous call — so RunFromWindowThread, which
+//     arrives by SendMessage, cannot be used: every outgoing COM call from there
+//     fails with RPC_E_CANTCALLOUT_ININPUTSYNCCALL having done nothing, which
+//     looks exactly like a permissions refusal and is not one.
+
+namespace Pins {
+
+// Prefix shared by every AppUserModelID this mod creates. Recognising our own
+// taskbar buttons later is a prefix test on this.
+constexpr PCWSTR kAppIdPrefix = L"Kiploom.TaskbarFolderHoverTray.";
+constexpr PCWSTR kPinSubDir = L"Taskbar Folder Hover Tray";
+// Last-resort button icon: the standard Windows folder glyph.
+constexpr PCWSTR kDefaultIconFile = L"%SystemRoot%\\system32\\imageres.dll";
+constexpr int kDefaultIconIndex = 3;
+
+// PKEY_AppUserModel_ID, spelled out so the mod needs neither INITGUID nor a link
+// against propsys.
+const PROPERTYKEY kPKEY_AppUserModel_ID = {
+    {0x9F4C2855,
+     0x9F79,
+     0x4B39,
+     {0xA8, 0xD0, 0xE1, 0xD4, 0x2D, 0xE1, 0xD5, 0xF3}},
+    5};
+
+std::wstring AppIdFor(const std::wstring& pinId) {
+    return std::wstring(kAppIdPrefix) + pinId;
+}
+
+bool IsOurAppId(const std::wstring& appId) {
+    return appId.compare(0, wcslen(kAppIdPrefix), kAppIdPrefix) == 0;
+}
+
+// Where our own shortcuts live. Start Menu\Programs is not cosmetic: the shell
+// builds shell:appsfolder from Start Menu shortcuts carrying an AUMID, and
+// FavoritesResolve prunes pins that no longer resolve to one.
+std::wstring SourceDir() {
+    PWSTR programs = nullptr;
+    if (FAILED(SHGetKnownFolderPath(FOLDERID_Programs, 0, nullptr, &programs)) ||
+        !programs) {
+        return L"";
+    }
+    std::wstring dir = programs;
+    CoTaskMemFree(programs);
+    return dir + L"\\" + kPinSubDir;
+}
+
+// Where the shell keeps a copy of every currently pinned item. Reading this is
+// how a native "Unpin from taskbar" is noticed — the shell removes the item
+// without telling the mod anything.
+std::wstring PinnedDir() {
+    PWSTR appData = nullptr;
+    if (FAILED(SHGetKnownFolderPath(FOLDERID_RoamingAppData, 0, nullptr,
+                                    &appData)) ||
+        !appData) {
+        return L"";
+    }
+    std::wstring dir = appData;
+    CoTaskMemFree(appData);
+    return dir +
+           L"\\Microsoft\\Internet Explorer\\Quick Launch\\User Pinned\\TaskBar";
+}
+
+// A filename that cannot upset the shell, derived from the folder's display
+// name. The taskbar labels the button from the shortcut's file name, so this is
+// what the user sees in the tooltip — keep it clean and keep it stable.
+std::wstring SafeLeaf(const std::wstring& name) {
+    std::wstring out;
+    for (wchar_t c : name) {
+        if (wcschr(L"\\/:*?\"<>|", c) || c < 0x20) {
+            continue;
+        }
+        out += c;
+    }
+    out = Trim(out);
+    // Trailing dots and spaces are legal in the string but not in a filename.
+    while (!out.empty() && (out.back() == L'.' || out.back() == L' ')) {
+        out.pop_back();
+    }
+    if (out.empty()) {
+        out = L"Folder";
+    }
+    if (out.size() > 64) {
+        out.resize(64);
+    }
+    return out;
+}
+
+// `taken` is the leaf names already claimed in this reconcile pass. Two folders
+// may legitimately share a display name, and the shortcuts must not overwrite
+// one another — but the suffix only appears in the genuinely ambiguous case,
+// rather than being carried by every button.
+std::wstring LnkPathFor(const FolderStore::Entry& entry,
+                        std::vector<std::wstring>* taken) {
+    std::wstring dir = SourceDir();
+    if (dir.empty() || entry.pinId.empty()) {
+        return L"";
+    }
+    std::wstring leaf = SafeLeaf(entry.name);
+    std::wstring candidate = leaf;
+    for (int suffix = 2; suffix < 100; suffix++) {
+        bool clash = false;
+        for (const auto& used : *taken) {
+            if (_wcsicmp(used.c_str(), candidate.c_str()) == 0) {
+                clash = true;
+                break;
+            }
+        }
+        if (!clash) {
+            break;
+        }
+        candidate = leaf + L" (" + std::to_wstring(suffix) + L")";
+    }
+    taken->push_back(candidate);
+    return dir + L"\\" + candidate + L".lnk";
+}
+
+// Splits an icon spec ("C:\x\y.dll,3", or a bare path) into file and index.
+// Returns false when the file does not exist, so callers can fall through to the
+// next candidate rather than producing a blank button.
+bool ParseIconSpec(const std::wstring& spec, std::wstring* file, int* index) {
+    if (spec.empty()) {
+        return false;
+    }
+    std::wstring raw = ExpandEnv(Trim(spec));
+    *index = 0;
+    size_t comma = raw.find_last_of(L',');
+    // Guard against "C:,3" style nonsense and against splitting a drive colon.
+    if (comma != std::wstring::npos && comma > 2) {
+        std::wstring tail = Trim(raw.substr(comma + 1));
+        wchar_t* end = nullptr;
+        long parsed = wcstol(tail.c_str(), &end, 10);
+        if (end && *end == L'\0' && !tail.empty()) {
+            *index = (int)parsed;
+            raw = Trim(raw.substr(0, comma));
+        }
+    }
+    if (GetFileAttributesW(raw.c_str()) == INVALID_FILE_ATTRIBUTES) {
+        return false;
+    }
+    *file = raw;
+    return true;
+}
+
+// A .lnk icon has to be a file on disk that the shell can load an icon resource
+// from, so only .ico/.exe/.dll-shaped specs can be used directly.
+//
+// ponytail: emoji and .png icons fall back to the default folder glyph. Giving
+// them real buttons means rendering to an .ico next to the shortcut - the mod
+// already builds these images for the hover grid (MakeButtonContent), so the
+// missing piece is only an HICON -> .ico writer.
+void ResolveIcon(const FolderStore::Entry& entry,
+                 const std::wstring& folderPath,
+                 std::wstring* file,
+                 int* index) {
+    if (ParseIconSpec(entry.icon, file, index)) {
+        return;
+    }
+    if (ParseIconSpec(ReadFolderCustomIcon(folderPath), file, index)) {
+        return;
+    }
+    *file = kDefaultIconFile;
+    *index = kDefaultIconIndex;
+}
+
+// Reads the AppUserModelID off an existing .lnk. Empty when it has none, which
+// is the normal case for shortcuts that are not ours.
+std::wstring ReadShortcutAppId(const std::wstring& lnkPath) {
+    IShellLinkW* link = nullptr;
+    if (FAILED(CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+                                IID_IShellLinkW, (void**)&link)) ||
+        !link) {
+        return L"";
+    }
+
+    std::wstring appId;
+    IPersistFile* persist = nullptr;
+    if (SUCCEEDED(link->QueryInterface(IID_IPersistFile, (void**)&persist)) &&
+        persist) {
+        if (SUCCEEDED(persist->Load(lnkPath.c_str(), STGM_READ))) {
+            IPropertyStore* store = nullptr;
+            if (SUCCEEDED(link->QueryInterface(IID_IPropertyStore,
+                                               (void**)&store)) &&
+                store) {
+                PROPVARIANT pv;
+                PropVariantInit(&pv);
+                if (SUCCEEDED(store->GetValue(kPKEY_AppUserModel_ID, &pv)) &&
+                    pv.vt == VT_LPWSTR && pv.pwszVal) {
+                    appId = pv.pwszVal;
+                }
+                PropVariantClear(&pv);
+                store->Release();
+            }
+        }
+        persist->Release();
+    }
+    link->Release();
+    return appId;
+}
+
+// Writes (or rewrites) the shortcut behind one entry. Rewriting on every
+// reconcile is deliberate: it is how a renamed folder, a changed icon, or a
+// moved target reach an already-pinned button.
+bool WriteShortcut(const FolderStore::Entry& entry,
+                   const std::wstring& folderPath,
+                   const std::wstring& lnkPath) {
+    std::wstring dir = lnkPath.substr(0, lnkPath.find_last_of(L'\\'));
+    SHCreateDirectoryExW(nullptr, dir.c_str(), nullptr);
+    if (GetFileAttributesW(dir.c_str()) == INVALID_FILE_ATTRIBUTES) {
+        Wh_Log(L"Pins: could not create %s", dir.c_str());
+        return false;
+    }
+
+    IShellLinkW* link = nullptr;
+    HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+                                  IID_IShellLinkW, (void**)&link);
+    if (FAILED(hr) || !link) {
+        Wh_Log(L"Pins: CoCreateInstance(ShellLink) failed: 0x%08X", hr);
+        return false;
+    }
+
+    WCHAR explorerPath[MAX_PATH];
+    GetWindowsDirectoryW(explorerPath, ARRAYSIZE(explorerPath));
+    wcscat_s(explorerPath, L"\\explorer.exe");
+    link->SetPath(explorerPath);
+    // Quoted: folder paths routinely contain spaces.
+    std::wstring args = L"\"" + folderPath + L"\"";
+    link->SetArguments(args.c_str());
+    link->SetDescription(entry.name.empty() ? L"Taskbar folder"
+                                            : entry.name.c_str());
+
+    std::wstring iconFile;
+    int iconIndex = 0;
+    ResolveIcon(entry, folderPath, &iconFile, &iconIndex);
+    link->SetIconLocation(iconFile.c_str(), iconIndex);
+
+    bool ok = false;
+    IPropertyStore* store = nullptr;
+    hr = link->QueryInterface(IID_IPropertyStore, (void**)&store);
+    if (SUCCEEDED(hr) && store) {
+        std::wstring appId = AppIdFor(entry.pinId);
+        PROPVARIANT pv;
+        PropVariantInit(&pv);
+        size_t bytes = (appId.size() + 1) * sizeof(WCHAR);
+        pv.pwszVal = (PWSTR)CoTaskMemAlloc(bytes);
+        if (pv.pwszVal) {
+            memcpy(pv.pwszVal, appId.c_str(), bytes);
+            pv.vt = VT_LPWSTR;
+            if (SUCCEEDED(store->SetValue(kPKEY_AppUserModel_ID, pv)) &&
+                SUCCEEDED(store->Commit())) {
+                ok = true;
+            }
+        }
+        PropVariantClear(&pv);
+        store->Release();
+    }
+    if (!ok) {
+        // Without the AUMID the item would merge into the File Explorer group,
+        // which is worse than having no button: it would look like the mod
+        // corrupted the user's existing File Explorer pin.
+        Wh_Log(L"Pins: could not stamp the AppUserModelID, refusing to write %s",
+               lnkPath.c_str());
+        link->Release();
+        return false;
+    }
+
+    IPersistFile* persist = nullptr;
+    hr = link->QueryInterface(IID_IPersistFile, (void**)&persist);
+    if (SUCCEEDED(hr) && persist) {
+        hr = persist->Save(lnkPath.c_str(), TRUE);
+        persist->Release();
+    }
+    link->Release();
+
+    if (FAILED(hr)) {
+        Wh_Log(L"Pins: saving %s failed: 0x%08X", lnkPath.c_str(), hr);
+        return false;
+    }
+    SHChangeNotify(SHCNE_CREATE, SHCNF_PATH | SHCNF_FLUSH, lnkPath.c_str(),
+                   nullptr);
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// "Manage folders..." on the button's own right-click menu
+//
+// That menu belongs to Windows now, and a mod cannot append to it. But it is a
+// jump list, and a jump list is keyed by AppUserModelID — which is ours. So the
+// entry goes on through the documented ICustomDestinationList route instead of
+// being drawn by this mod at all.
+//
+// A jump list task can only launch a command line, and the manager window lives
+// inside explorer.exe, so the task carries a sentinel token and the launch is
+// caught in-process (see the CreateProcessW hook). If that interception ever
+// stops working the task still runs, so it points at explorer.exe: the worst
+// case is a stray Explorer window rather than a dead menu item.
+
+constexpr PCWSTR kManageSentinel = L"--taskbar-folder-hover-tray-manage";
+
+// PKEY_Title, spelled out for the same reason as the AppUserModelID key.
+const PROPERTYKEY kPKEY_Title = {
+    {0xF29F85E0,
+     0x4FF9,
+     0x1068,
+     {0xAB, 0x91, 0x08, 0x00, 0x2B, 0x27, 0xB3, 0xD9}},
+    2};
+
+// A jump list task: a shell link plus a title, which is what the menu shows.
+IShellLinkW* MakeManageTask() {
+    IShellLinkW* link = nullptr;
+    if (FAILED(CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+                                IID_IShellLinkW, (void**)&link)) ||
+        !link) {
+        return nullptr;
+    }
+
+    WCHAR explorerPath[MAX_PATH];
+    GetWindowsDirectoryW(explorerPath, ARRAYSIZE(explorerPath));
+    wcscat_s(explorerPath, L"\\explorer.exe");
+    link->SetPath(explorerPath);
+    link->SetArguments(kManageSentinel);
+    link->SetIconLocation(L"%SystemRoot%\\system32\\imageres.dll", 3);
+
+    // Without a title the shell shows nothing for the task.
+    IPropertyStore* store = nullptr;
+    if (SUCCEEDED(link->QueryInterface(IID_IPropertyStore, (void**)&store)) &&
+        store) {
+        PROPVARIANT pv;
+        PropVariantInit(&pv);
+        PCWSTR title = L"Manage folders...";
+        size_t bytes = (wcslen(title) + 1) * sizeof(WCHAR);
+        pv.pwszVal = (PWSTR)CoTaskMemAlloc(bytes);
+        if (pv.pwszVal) {
+            memcpy(pv.pwszVal, title, bytes);
+            pv.vt = VT_LPWSTR;
+            store->SetValue(kPKEY_Title, pv);
+            store->Commit();
+        }
+        PropVariantClear(&pv);
+        store->Release();
+    }
+    return link;
+}
+
+// Publishes the jump list for one of our pinned items.
+void WriteJumpList(const std::wstring& appId) {
+    ICustomDestinationList* list = nullptr;
+    if (FAILED(CoCreateInstance(CLSID_DestinationList, nullptr,
+                                CLSCTX_INPROC_SERVER,
+                                IID_ICustomDestinationList, (void**)&list)) ||
+        !list) {
+        return;
+    }
+    list->SetAppID(appId.c_str());
+
+    UINT slots = 0;
+    IObjectArray* removed = nullptr;
+    HRESULT hr = list->BeginList(&slots, IID_IObjectArray, (void**)&removed);
+    if (removed) {
+        removed->Release();
+    }
+    if (FAILED(hr)) {
+        Wh_Log(L"Pins: BeginList for %s failed: 0x%08X", appId.c_str(), hr);
+        list->Release();
+        return;
+    }
+
+    IObjectCollection* tasks = nullptr;
+    if (SUCCEEDED(CoCreateInstance(CLSID_EnumerableObjectCollection, nullptr,
+                                   CLSCTX_INPROC_SERVER,
+                                   IID_IObjectCollection, (void**)&tasks)) &&
+        tasks) {
+        if (IShellLinkW* task = MakeManageTask()) {
+            tasks->AddObject(task);
+            task->Release();
+        }
+        if (IObjectArray* array = nullptr;
+            SUCCEEDED(tasks->QueryInterface(IID_IObjectArray,
+                                            (void**)&array)) &&
+            array) {
+            hr = list->AddUserTasks(array);
+            array->Release();
+            if (FAILED(hr)) {
+                Wh_Log(L"Pins: AddUserTasks failed: 0x%08X", hr);
+            }
+        }
+        tasks->Release();
+    }
+
+    hr = list->CommitList();
+    if (FAILED(hr)) {
+        Wh_Log(L"Pins: CommitList for %s failed: 0x%08X", appId.c_str(), hr);
+    }
+    list->Release();
+}
+
+// Invokes a shell verb on a path. Pinning and unpinning are both just verbs, so
+// neither needs the undocumented IPinnedList3.
+bool InvokeVerb(const std::wstring& path, PCSTR verb) {
+    PIDLIST_ABSOLUTE pidl = nullptr;
+    HRESULT hr = SHParseDisplayName(path.c_str(), nullptr, &pidl, 0, nullptr);
+    if (FAILED(hr) || !pidl) {
+        Wh_Log(L"Pins: SHParseDisplayName(%s) failed: 0x%08X", path.c_str(), hr);
+        return false;
+    }
+
+    IShellFolder* parent = nullptr;
+    PCUITEMID_CHILD child = nullptr;
+    hr = SHBindToParent(pidl, IID_IShellFolder, (void**)&parent, &child);
+    if (FAILED(hr) || !parent) {
+        Wh_Log(L"Pins: SHBindToParent failed: 0x%08X", hr);
+        ILFree(pidl);
+        return false;
+    }
+
+    bool ok = false;
+    IContextMenu* menu = nullptr;
+    hr = parent->GetUIObjectOf(nullptr, 1, &child, IID_IContextMenu, nullptr,
+                               (void**)&menu);
+    if (SUCCEEDED(hr) && menu) {
+        if (HMENU hMenu = CreatePopupMenu()) {
+            // Must run first: QueryContextMenu is what makes the handler
+            // enumerate and register its verbs. Without it InvokeCommand cannot
+            // find "taskbarpin" and returns ERROR_NO_ASSOCIATION.
+            menu->QueryContextMenu(hMenu, 0, 1, 0x7FFF, CMF_NORMAL);
+
+            CMINVOKECOMMANDINFO info = {};
+            info.cbSize = sizeof(info);
+            info.lpVerb = verb;
+            info.nShow = SW_SHOWNORMAL;
+            hr = menu->InvokeCommand(&info);
+            ok = SUCCEEDED(hr);
+            if (!ok) {
+                Wh_Log(L"Pins: %S on %s returned 0x%08X", verb, path.c_str(),
+                       hr);
+            }
+            DestroyMenu(hMenu);
+        }
+        menu->Release();
+    } else {
+        Wh_Log(L"Pins: GetUIObjectOf(IContextMenu) failed: 0x%08X", hr);
+    }
+
+    parent->Release();
+    ILFree(pidl);
+    return ok;
+}
+
+// One of this mod's items as the shell currently holds it. `leaf` is the
+// shortcut's file name without the extension, which is exactly what the taskbar
+// labels the button with — and therefore the only reliable way to tie a XAML
+// button back to the entry behind it without hooking the shell's own group type.
+struct PinnedItem {
+    std::wstring leaf;
+    std::wstring appId;
+    std::wstring path;
+};
+
+// Everything currently pinned that belongs to this mod, read from the shell's
+// own copy of the pinned items rather than from anything the mod believes. This
+// is what makes a native "Unpin from taskbar" visible, and what keeps the button
+// labels honest when a shortcut has been renamed underneath a live pin.
+std::vector<PinnedItem> ReadPinnedItems() {
+    std::vector<PinnedItem> items;
+    std::wstring dir = PinnedDir();
+    if (dir.empty()) {
+        return items;
+    }
+
+    WIN32_FIND_DATAW find{};
+    HANDLE handle = FindFirstFileW((dir + L"\\*.lnk").c_str(), &find);
+    if (handle == INVALID_HANDLE_VALUE) {
+        return items;
+    }
+    do {
+        if (find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+            continue;
+        }
+        std::wstring path = dir + L"\\" + find.cFileName;
+        std::wstring appId = ReadShortcutAppId(path);
+        if (appId.empty() || !IsOurAppId(appId)) {
+            continue;
+        }
+        std::wstring leaf = find.cFileName;
+        if (size_t dot = leaf.find_last_of(L'.'); dot != std::wstring::npos) {
+            leaf.resize(dot);
+        }
+        items.push_back({std::move(leaf), std::move(appId), std::move(path)});
+    } while (FindNextFileW(handle, &find));
+    FindClose(handle);
+    return items;
+}
+
+std::vector<std::wstring> ReadPinnedAppIds() {
+    std::vector<std::wstring> appIds;
+    for (auto& item : ReadPinnedItems()) {
+        appIds.push_back(std::move(item.appId));
+    }
+    return appIds;
+}
+
+// Button label -> pin id, published for the taskbar UI thread.
+//
+// Built here rather than read on demand because the taskbar thread needs it
+// during layout, and rebuilding it means opening every pinned shortcut through
+// COM — far too expensive to do on a layout pass. The generation counter lets
+// that thread notice a change without holding the lock to compare.
+[[clang::no_destroy]] std::mutex g_labelMutex;
+[[clang::no_destroy]] std::vector<std::pair<std::wstring, std::wstring>>
+    g_labelToPinId;
+std::atomic<uint32_t> g_labelGeneration{0};
+
+void PublishLabels(const std::vector<PinnedItem>& items) {
+    std::vector<std::pair<std::wstring, std::wstring>> map;
+    for (const auto& item : items) {
+        std::wstring pinId = item.appId.substr(wcslen(kAppIdPrefix));
+        map.emplace_back(item.leaf, std::move(pinId));
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_labelMutex);
+        if (map == g_labelToPinId) {
+            return;
+        }
+        g_labelToPinId = std::move(map);
+    }
+    g_labelGeneration.fetch_add(1, std::memory_order_release);
+}
+
+// A taskbar button's accessible name is the item's label plus whatever state
+// the shell wants to announce — "Games pinned", "Brave - 1 running window
+// pinned", "Cursor - 1 running window". So the label is a prefix, not the whole
+// string, and the remainder has to be one of those recognised annotations.
+//
+// Checking the remainder rather than just taking a prefix match matters: a
+// folder called "Games" must not claim a button for an app called
+// "Games Launcher".
+bool LabelMatchesAccessibleName(const std::wstring& leaf,
+                                const std::wstring& name) {
+    if (leaf.empty() || name.size() < leaf.size()) {
+        return false;
+    }
+    if (_wcsnicmp(name.c_str(), leaf.c_str(), leaf.size()) != 0) {
+        return false;
+    }
+    std::wstring rest = name.substr(leaf.size());
+    if (rest.empty()) {
+        return true;
+    }
+    // "<label> pinned"
+    if (_wcsicmp(rest.c_str(), L" pinned") == 0) {
+        return true;
+    }
+    // "<label> - 1 running window", with or without a trailing " pinned".
+    if (rest.size() > 3 && _wcsnicmp(rest.c_str(), L" - ", 3) == 0) {
+        return true;
+    }
+    return false;
+}
+
+// Empty when this label is not one of ours.
+std::wstring PinIdForLabel(const std::wstring& accessibleName) {
+    std::lock_guard<std::mutex> lock(g_labelMutex);
+    for (const auto& [leaf, pinId] : g_labelToPinId) {
+        if (LabelMatchesAccessibleName(leaf, accessibleName)) {
+            return pinId;
+        }
+    }
+    return L"";
+}
+
+bool Contains(const std::vector<std::wstring>& list, const std::wstring& value) {
+    for (const auto& item : list) {
+        if (_wcsicmp(item.c_str(), value.c_str()) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Brings the real taskbar into line with the store: every pinned entry gets a
+// shortcut and a pin, everything else of ours is removed, and an entry the user
+// unpinned natively is written back to the store as a draft.
+//
+// Written as a reconcile rather than as pin/unpin calls threaded through the
+// eight or so places that mutate the store: it is idempotent, it is the only
+// thing that has to be correct, and it also repairs state after an explorer
+// crash or a manual edit, which per-site calls never would.
+void Reconcile() {
+    std::wstring sourceDir = SourceDir();
+    if (sourceDir.empty()) {
+        Wh_Log(L"Pins: no Start Menu Programs folder, skipping");
+        return;
+    }
+
+    struct Desired {
+        std::wstring appId;
+        std::wstring lnkPath;
+        // The label the taskbar should be showing for this item.
+        std::wstring leaf;
+    };
+    std::vector<Desired> desired;
+    std::vector<std::wstring> keepFiles;
+    std::vector<FolderStore::Entry> todo;
+    std::vector<std::wstring> takenLeaves;
+
+    bool unpinnedByUser = false;
+    bool generatedPinIds = false;
+
+    {
+        std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
+        auto stored = FolderStore::Read();
+        bool storeChanged = false;
+
+        // A pinned entry with no id yet is either new or predates this mod
+        // version; either way it needs one before it can have a shortcut. This
+        // is also the whole of the upgrade path for existing users.
+        for (auto& entry : stored) {
+            if (entry.pinned && entry.pinId.empty()) {
+                GUID guid{};
+                if (FAILED(CoCreateGuid(&guid))) {
+                    continue;
+                }
+                WCHAR buf[40];
+                swprintf(buf, ARRAYSIZE(buf), L"%08lx%04hx%04hx", guid.Data1,
+                         guid.Data2, guid.Data3);
+                entry.pinId = buf;
+                storeChanged = true;
+                generatedPinIds = true;
+            }
+        }
+
+        std::vector<std::wstring> live = ReadPinnedAppIds();
+        // The reverse sync below is only as good as this list. If a native
+        // unpin is not reflected here, the shell is flushing that folder later
+        // than it changes the taskbar, and pin state has to be read from
+        // somewhere else instead.
+        Wh_Log(L"Pins: reconcile - the shell reports %zu of our items pinned",
+               live.size());
+
+        for (auto& entry : stored) {
+            if (!entry.pinned || entry.pinId.empty()) {
+                continue;
+            }
+
+            // Reverse sync. The shell removes a natively-unpinned item without
+            // telling the mod, so "we pinned this once and it is gone now" is
+            // the only evidence that the user unpinned it. Demote it to a draft
+            // rather than re-pinning: re-pinning would make native Unpin look
+            // broken, and the entry keeps its name and icon either way.
+            if (entry.pinApplied && !Contains(live, AppIdFor(entry.pinId))) {
+                Wh_Log(L"Pins: '%s' was unpinned from the taskbar, keeping it "
+                       L"as a draft",
+                       entry.name.c_str());
+                entry.pinned = false;
+                entry.pinApplied = false;
+                storeChanged = true;
+                unpinnedByUser = true;
+                continue;
+            }
+            // Only a copy of what the slow work below needs. Resolving a path
+            // and writing a shortcut both touch the filesystem, and the folder
+            // may be a network share that blocks for the share's timeout — the
+            // store lock is held by the manager window and by the Explorer
+            // right-click pin, neither of which should wait on a dead share.
+            todo.push_back(entry);
+        }
+
+        if (storeChanged) {
+            FolderStore::Write(stored);
+        }
+    }
+
+    for (const auto& entry : todo) {
+        std::wstring folderPath = ResolveFolderPath(ExpandEnv(entry.path));
+        if (folderPath.empty()) {
+            folderPath = ExpandEnv(entry.path);
+        }
+        // A folder that no longer exists would be pruned by the shell anyway;
+        // leave the entry alone so the user can fix the path rather than
+        // silently losing it.
+        if (GetFileAttributesW(folderPath.c_str()) == INVALID_FILE_ATTRIBUTES) {
+            Wh_Log(L"Pins: '%s' does not exist, not pinning", folderPath.c_str());
+            continue;
+        }
+
+        std::wstring lnkPath = LnkPathFor(entry, &takenLeaves);
+        if (lnkPath.empty() || !WriteShortcut(entry, folderPath, lnkPath)) {
+            continue;
+        }
+        keepFiles.push_back(lnkPath);
+
+        std::wstring leaf = lnkPath.substr(lnkPath.find_last_of(L'\\') + 1);
+        leaf.resize(leaf.find_last_of(L'.'));
+        desired.push_back({AppIdFor(entry.pinId), lnkPath, leaf});
+    }
+
+    // Reconcile against the shell's own copies. Pinning copies the shortcut, so
+    // the pinned item keeps whatever name it had when it was pinned — renaming
+    // the source .lnk afterwards does not reach the taskbar, and the button
+    // would sit there labelled with a name the mod no longer uses.
+    for (const auto& item : ReadPinnedItems()) {
+        const Desired* match = nullptr;
+        for (const auto& want : desired) {
+            if (_wcsicmp(want.appId.c_str(), item.appId.c_str()) == 0) {
+                match = &want;
+                break;
+            }
+        }
+        if (!match) {
+            if (InvokeVerb(item.path, "taskbarunpin")) {
+                Wh_Log(L"Pins: unpinned %s", item.leaf.c_str());
+            }
+            continue;
+        }
+        // Same item, stale label: unpin so the loop below pins it afresh under
+        // the right name. Costs its place in the taskbar order, which is why it
+        // only happens when the name genuinely changed.
+        if (_wcsicmp(match->leaf.c_str(), item.leaf.c_str()) != 0) {
+            if (InvokeVerb(item.path, "taskbarunpin")) {
+                Wh_Log(L"Pins: '%s' is now called '%s', re-pinning",
+                       item.leaf.c_str(), match->leaf.c_str());
+            }
+        }
+    }
+
+    std::vector<std::wstring> live = ReadPinnedAppIds();
+
+    for (const auto& item : desired) {
+        if (Contains(live, item.appId)) {
+            continue;
+        }
+        if (InvokeVerb(item.lnkPath, "taskbarpin")) {
+            Wh_Log(L"Pins: pinned %s", item.lnkPath.c_str());
+        }
+    }
+
+    // Sweep our own shortcut directory: a renamed entry leaves its old .lnk
+    // behind, and those accumulate.
+    WIN32_FIND_DATAW find{};
+    HANDLE handle = FindFirstFileW((sourceDir + L"\\*.lnk").c_str(), &find);
+    if (handle != INVALID_HANDLE_VALUE) {
+        do {
+            if (find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+                continue;
+            }
+            std::wstring path = sourceDir + L"\\" + find.cFileName;
+            if (!Contains(keepFiles, path)) {
+                DeleteFileW(path.c_str());
+                SHChangeNotify(SHCNE_DELETE, SHCNF_PATH | SHCNF_FLUSH,
+                               path.c_str(), nullptr);
+            }
+        } while (FindNextFileW(handle, &find));
+        FindClose(handle);
+    }
+
+    // Record what actually ended up on the taskbar. Done once at the end from
+    // the shell's own list rather than from the return value of each pin,
+    // because "the verb returned S_OK" and "there is a button" are not the same
+    // claim — and pinApplied is what the reverse sync above trusts next run.
+    std::vector<PinnedItem> finalItems = ReadPinnedItems();
+    {
+        std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
+        auto stored = FolderStore::Read();
+        std::vector<std::wstring> finalLive;
+        for (const auto& item : finalItems) {
+            finalLive.push_back(item.appId);
+        }
+        bool storeChanged = false;
+        for (auto& entry : stored) {
+            if (entry.pinId.empty()) {
+                continue;
+            }
+            bool applied =
+                entry.pinned && Contains(finalLive, AppIdFor(entry.pinId));
+            if (entry.pinApplied != applied) {
+                entry.pinApplied = applied;
+                storeChanged = true;
+            }
+        }
+        if (storeChanged) {
+            FolderStore::Write(stored);
+        }
+    }
+
+    // Hand the taskbar UI thread the label -> pin id map it needs to recognise
+    // our buttons. Built from what the shell actually holds, so it stays right
+    // even when a pinned copy's name has drifted from the source shortcut.
+    PublishLabels(finalItems);
+
+    // Put "Manage folders..." on each button's own right-click menu. Rewritten
+    // every reconcile rather than once: the jump list is stored per AppID by
+    // the shell, and an item that was unpinned and pinned again comes back
+    // without one.
+    for (const auto& item : finalItems) {
+        WriteJumpList(item.appId);
+    }
+
+    // Both of these mean the loaded folder list no longer matches the store.
+    //
+    // unpinnedByUser: the entry was demoted to a draft, so its button and its
+    // row in the manager window are stale.
+    //
+    // generatedPinIds: Wh_ModInit loads the folder list before this worker has
+    // ever run, so on the first load after an upgrade every entry in g_settings
+    // has an empty pin id — and the pin id is exactly what ties a real taskbar
+    // button back to its folder. Without this reload the buttons exist, the
+    // labels resolve, and nothing matches. Reloading re-reads the store now that
+    // the ids are persisted; the next reconcile generates none, so this does not
+    // recur.
+    if (unpinnedByUser || generatedPinIds) {
+        RequestReloadUI();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// The STA worker
+//
+// Everything above must run here. See the note at the top of the namespace for
+// why it cannot be the taskbar UI thread.
+
+HANDLE g_thread = nullptr;
+HANDLE g_stopEvent = nullptr;  // manual-reset
+HANDLE g_kickEvent = nullptr;  // auto-reset
+
+// Unpinning from the taskbar's own right-click menu is completely silent: it
+// changes nothing the mod owns, so nothing calls RequestReconcile and the entry
+// stays "pinned" in the store until something else happens to trigger a reload
+// — in practice, the next Explorer restart. Watching the shell's own state is
+// the only way to hear about it.
+//
+// Two sources because they can be updated at different moments: the pinned-items
+// folder (which is what ReadPinnedAppIds reads) and the Taskband key the shell
+// keeps the order in. Either firing is treated as "something changed, go look".
+constexpr DWORD kPinWatchDebounceMs = 400;
+
+DWORD WINAPI ThreadProc(void*) {
+    HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    if (FAILED(hr)) {
+        Wh_Log(L"Pins: CoInitializeEx(STA) failed: 0x%08X", hr);
+        return 0;
+    }
+
+    HANDLE dirWatch = INVALID_HANDLE_VALUE;
+    if (std::wstring pinnedDir = PinnedDir(); !pinnedDir.empty()) {
+        dirWatch = FindFirstChangeNotificationW(
+            pinnedDir.c_str(), FALSE,
+            FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE);
+        if (dirWatch == INVALID_HANDLE_VALUE) {
+            Wh_Log(L"Pins: cannot watch %s (%u); a native unpin will only be "
+                   L"noticed on the next reload",
+                   pinnedDir.c_str(), GetLastError());
+        }
+    }
+
+    HKEY taskbandKey = nullptr;
+    HANDLE regEvent = nullptr;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                      L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer"
+                      L"\\Taskband",
+                      0, KEY_NOTIFY, &taskbandKey) == ERROR_SUCCESS) {
+        regEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+    }
+    // Re-arms the registry watch. It is one-shot: every fire needs a new call or
+    // the second change is never heard.
+    auto armRegWatch = [&]() {
+        if (taskbandKey && regEvent) {
+            ResetEvent(regEvent);
+            RegNotifyChangeKeyValue(taskbandKey, TRUE,
+                                    REG_NOTIFY_CHANGE_LAST_SET |
+                                        REG_NOTIFY_CHANGE_NAME,
+                                    regEvent, TRUE);
+        }
+    };
+    armRegWatch();
+
+    HANDLE waits[4];
+    DWORD count = 0;
+    waits[count++] = g_stopEvent;
+    waits[count++] = g_kickEvent;
+    const DWORD dirIndex =
+        dirWatch != INVALID_HANDLE_VALUE ? count : 0xFFFFFFFF;
+    if (dirWatch != INVALID_HANDLE_VALUE) {
+        waits[count++] = dirWatch;
+    }
+    const DWORD regIndex = regEvent ? count : 0xFFFFFFFF;
+    if (regEvent) {
+        waits[count++] = regEvent;
+    }
+
+    // Re-arms whichever watch just fired, so the wait below stays live.
+    auto rearm = [&](DWORD signalled) {
+        if (signalled == dirIndex && dirWatch != INVALID_HANDLE_VALUE) {
+            FindNextChangeNotification(dirWatch);
+        } else if (signalled == regIndex) {
+            armRegWatch();
+        }
+    };
+
+    bool stopping = false;
+    while (!stopping) {
+        DWORD result = WaitForMultipleObjects(count, waits, FALSE, INFINITE);
+        if (result == WAIT_OBJECT_0 || result == WAIT_FAILED) {
+            break;
+        }
+        rearm(result - WAIT_OBJECT_0);
+
+        // Coalesce the burst. One pin or unpin rewrites several files and the
+        // registry, and this mod's own reconcile writes to the same places, so
+        // reacting to each notification separately would mean several redundant
+        // passes per user action — and, worse, reconciling while the shell is
+        // still half way through writing.
+        for (;;) {
+            DWORD more = WaitForMultipleObjects(count, waits, FALSE,
+                                                kPinWatchDebounceMs);
+            if (more == WAIT_TIMEOUT) {
+                break;
+            }
+            if (more == WAIT_OBJECT_0 || more == WAIT_FAILED) {
+                stopping = true;
+                break;
+            }
+            rearm(more - WAIT_OBJECT_0);
+        }
+        if (stopping) {
+            break;
+        }
+
+        Reconcile();
+    }
+
+    if (dirWatch != INVALID_HANDLE_VALUE) {
+        FindCloseChangeNotification(dirWatch);
+    }
+    if (regEvent) {
+        CloseHandle(regEvent);
+    }
+    if (taskbandKey) {
+        RegCloseKey(taskbandKey);
+    }
+    CoUninitialize();
+    return 0;
+}
+
+void RequestReconcile() {
+    if (g_kickEvent) {
+        SetEvent(g_kickEvent);
+    }
+}
+
+void Start() {
+    if (g_thread) {
+        RequestReconcile();
+        return;
+    }
+    g_stopEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+    g_kickEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+    if (!g_stopEvent || !g_kickEvent) {
+        return;
+    }
+    g_thread = CreateThread(nullptr, 0, ThreadProc, nullptr, 0, nullptr);
+    if (g_thread) {
+        RequestReconcile();
+    }
+}
+
+void Stop() {
+    if (g_stopEvent) {
+        SetEvent(g_stopEvent);
+    }
+    if (g_thread) {
+        // Joined, not abandoned: the worker's return address is in this image,
+        // and Windhawk unmaps it as soon as uninit returns.
+        WaitForSingleObject(g_thread, INFINITE);
+        CloseHandle(g_thread);
+        g_thread = nullptr;
+    }
+    if (g_stopEvent) {
+        CloseHandle(g_stopEvent);
+        g_stopEvent = nullptr;
+    }
+    if (g_kickEvent) {
+        CloseHandle(g_kickEvent);
+        g_kickEvent = nullptr;
+    }
+}
+
+}  // namespace Pins
+
 // Fills in the derived fields (resolved path, remote flag) a stored entry
 // needs before the UI can use it, and follows an in-place rename via the
 // recorded NTFS file id. Returns false if `store` was updated and should be
@@ -972,6 +2015,7 @@ bool BuildFolderEntry(FolderStore::Entry* stored, FolderEntry* out) {
     out->icon = stored->icon;
     out->path = ExpandEnv(stored->path);
     out->pinned = stored->pinned;
+    out->pinId = stored->pinId;
 
     if (IsShellFolderPath(out->path)) {
         // shell: targets resolve later, on an STA.
@@ -1062,6 +2106,14 @@ void LoadFolders(std::vector<FolderEntry>* out) {
 
     Wh_Log(L"LoadFolders: %zu button(s) from %zu stored folder(s)",
            out->size(), storedCount);
+
+    // Every path that changes the folder list ends up here — init, a settings
+    // change, a pin or unpin from Explorer, any edit in the manager window — so
+    // this is the one place the real taskbar pins need to be brought back into
+    // line. Asking per mutation instead would mean instrumenting eight call
+    // sites and still missing the ones that only touch the store indirectly.
+    // Non-blocking: it kicks the STA worker and returns.
+    Pins::RequestReconcile();
 }
 
 // True if `path` already has a button on the taskbar. Used to hide the "Pin to
@@ -1124,41 +2176,32 @@ void RemovePinnedFolder(const std::wstring& path) {
 void LoadSettings() {
     LoadFolders(&g_settings.folders);
 
-    g_settings.position = GetStringSetting(L"position");
-    if (g_settings.position.empty()) {
-        g_settings.position = L"beforeApps";
-    }
-    g_settings.anchor = GetStringSetting(L"anchor");
-    if (g_settings.anchor.empty()) {
-        g_settings.anchor = L"firstApp";
-    }
-
     // "type" was the old folders-first option, which is now unconditional.
-    std::wstring sortBy = GetStringSetting(L"sortBy");
+    std::wstring sortBy = GetStringSetting(L"content.sortBy");
     g_settings.sortBy =
         sortBy == L"modified" ? SortMode::Modified : SortMode::Name;
 
     g_settings.hoverDelayMs =
-        std::clamp<int>(Wh_GetIntSetting(L"hoverDelayMs"), 0, 5000);
+        std::clamp<int>(Wh_GetIntSetting(L"behavior.hoverDelayMs"), 0, 5000);
     g_settings.closeDelayMs =
-        std::clamp<int>(Wh_GetIntSetting(L"closeDelayMs"), 0, 5000);
-    g_settings.columns = std::clamp<int>(Wh_GetIntSetting(L"columns"), 0, 24);
+        std::clamp<int>(Wh_GetIntSetting(L"behavior.closeDelayMs"), 0, 5000);
+    g_settings.columns = std::clamp<int>(Wh_GetIntSetting(L"content.columns"), 0, 24);
     g_settings.maxItems =
-        std::clamp<int>(Wh_GetIntSetting(L"maxItems"), 0, 400);
-    g_settings.includeSubfolders = Wh_GetIntSetting(L"includeSubfolders");
+        std::clamp<int>(Wh_GetIntSetting(L"content.maxItems"), 0, 400);
+    g_settings.includeSubfolders = Wh_GetIntSetting(L"content.includeSubfolders");
     g_settings.maxFolderDepth =
-        std::clamp<int>(Wh_GetIntSetting(L"maxFolderDepth"), -1, 32);
+        std::clamp<int>(Wh_GetIntSetting(L"content.maxFolderDepth"), -1, 32);
     g_settings.submenuDelayMs =
-        std::clamp<int>(Wh_GetIntSetting(L"submenuDelayMs"), 0, 5000);
+        std::clamp<int>(Wh_GetIntSetting(L"content.submenuDelayMs"), 0, 5000);
     g_settings.submenuCloseDelayMs =
-        std::clamp<int>(Wh_GetIntSetting(L"submenuCloseDelayMs"), 0, 5000);
-    g_settings.showHidden = Wh_GetIntSetting(L"showHidden");
-    g_settings.showExtensions = Wh_GetIntSetting(L"showExtensions");
+        std::clamp<int>(Wh_GetIntSetting(L"content.submenuCloseDelayMs"), 0, 5000);
+    g_settings.showHidden = Wh_GetIntSetting(L"content.showHidden");
+    g_settings.showExtensions = Wh_GetIntSetting(L"content.showExtensions");
     // Cell padding grows with the icon rather than staying fixed, so the label
     // keeps its room at the small end. The small/medium/large numbers are the
     // originals — the three steps below them were added later, so an existing
     // setting keeps the size it already had.
-    std::wstring itemSize = GetStringSetting(L"itemSize");
+    std::wstring itemSize = GetStringSetting(L"appearance.itemSize");
     if (itemSize == L"smallest") {
         g_settings.iconSize = 12;
         g_settings.cellWidth = 56;
@@ -1171,56 +2214,51 @@ void LoadSettings() {
         g_settings.iconSize = 20;
         g_settings.cellWidth = 70;
         g_settings.cellHeight = 66;
-    } else if (itemSize == L"medium") {
-        g_settings.iconSize = 32;
-        g_settings.cellWidth = 92;
-        g_settings.cellHeight = 88;
+    } else if (itemSize == L"small") {
+        g_settings.iconSize = 24;
+        g_settings.cellWidth = 76;
+        g_settings.cellHeight = 72;
     } else if (itemSize == L"large") {
         g_settings.iconSize = 48;
         g_settings.cellWidth = 120;
         g_settings.cellHeight = 112;
     } else {
-        g_settings.iconSize = 24;
-        g_settings.cellWidth = 76;
-        g_settings.cellHeight = 72;
+        // medium, and anything unrecognised
+        g_settings.iconSize = 32;
+        g_settings.cellWidth = 92;
+        g_settings.cellHeight = 88;
     }
-    g_settings.showLabels = Wh_GetIntSetting(L"showLabels");
-    g_settings.fontSize = std::clamp<int>(Wh_GetIntSetting(L"fontSize"), 6, 48);
-    g_settings.itemFontWeight =
-        ParseFontWeight(GetStringSetting(L"itemFontWeight"), FW_BOLD);
-    g_settings.showTitle = Wh_GetIntSetting(L"showTitle");
+    g_settings.showLabels = Wh_GetIntSetting(L"appearance.showLabels");
+    g_settings.fontSize = std::clamp<int>(Wh_GetIntSetting(L"appearance.fontSize"), 6, 48);
+    g_settings.itemFontWeight = ParseFontWeight(
+        GetStringSetting(L"appearance.itemFontWeight"), FW_NORMAL);
+    g_settings.showTitle = Wh_GetIntSetting(L"appearance.showTitle");
     g_settings.titleFontSize =
-        std::clamp<int>(Wh_GetIntSetting(L"titleFontSize"), 6, 48);
+        std::clamp<int>(Wh_GetIntSetting(L"appearance.titleFontSize"), 6, 48);
     g_settings.titleFontWeight =
-        ParseFontWeight(GetStringSetting(L"titleFontWeight"), FW_BOLD);
-    g_settings.titleAlign = GetStringSetting(L"titleAlign");
+        ParseFontWeight(GetStringSetting(L"appearance.titleFontWeight"), FW_BOLD);
+    g_settings.titleAlign = GetStringSetting(L"appearance.titleAlign");
     if (g_settings.titleAlign != L"left" && g_settings.titleAlign != L"right") {
         g_settings.titleAlign = L"center";
     }
-    g_settings.cornerRadius =
-        std::clamp<int>(Wh_GetIntSetting(L"cornerRadius"), 0, 32);
-    std::wstring popupTheme = GetStringSetting(L"popupTheme");
+    g_settings.cornerRadius = Wh_GetIntSetting(L"appearance.roundedCorners")
+                                  ? kRoundedCornerRadius
+                                  : 0;
+    std::wstring popupTheme = GetStringSetting(L"appearance.popupTheme");
     g_settings.popupThemeOverride =
         popupTheme == L"light" ? 0 : (popupTheme == L"dark" ? 1 : -1);
     g_settings.panelOpacity =
-        std::clamp<int>(Wh_GetIntSetting(L"panelOpacity"), 0, 100);
-    g_settings.panelBorder = Wh_GetIntSetting(L"panelBorder");
-    std::wstring blurType = GetStringSetting(L"blurType");
+        std::clamp<int>(Wh_GetIntSetting(L"appearance.panelOpacity"), 0, 100);
+    std::wstring blurType = GetStringSetting(L"appearance.blurType");
     g_settings.blurType = blurType == L"gaussian" ? BlurType::Gaussian
                           : blurType == L"none"   ? BlurType::None
                                                   : BlurType::Acrylic;
     g_settings.blurStrength =
-        std::clamp<int>(Wh_GetIntSetting(L"blurStrength"), 0, 100);
+        std::clamp<int>(Wh_GetIntSetting(L"appearance.blurStrength"), 0, 100);
     g_settings.gapAbove =
-        std::clamp<int>(Wh_GetIntSetting(L"gapAbove"), 0, 200);
-    g_settings.gapBefore =
-        std::clamp<int>(Wh_GetIntSetting(L"gapBefore"), 0, 200);
-    g_settings.gapAfter =
-        std::clamp<int>(Wh_GetIntSetting(L"gapAfter"), 0, 200);
-    g_settings.buttonIconSize =
-        std::clamp<int>(Wh_GetIntSetting(L"buttonIconSize"), 0, 128);
-    g_settings.openFolderOnClick = Wh_GetIntSetting(L"openFolderOnClick");
-    g_settings.explorerMenu = Wh_GetIntSetting(L"explorerMenu") != 0;
+        std::clamp<int>(Wh_GetIntSetting(L"appearance.gapAbove"), 0, 200);
+    g_settings.openFolderOnClick = Wh_GetIntSetting(L"behavior.openFolderOnClick");
+    g_settings.explorerMenu = Wh_GetIntSetting(L"behavior.explorerMenu") != 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2398,17 +3436,9 @@ constexpr size_t kMaxCachedFolders = 32;
 // Soft ceiling on cached icon bitmaps across all folders (~64 MB).
 constexpr size_t kMaxCachedFolderBytes = 64ull * 1024 * 1024;
 
-enum class ScanRequestKind { Folder, ButtonIcon };
-
 struct ScanRequest {
-    ScanRequestKind kind = ScanRequestKind::Folder;
     std::wstring path;
     int iconPixelSize = 32;
-    // ButtonIcon: extract on the STA scan worker, deliver pixels on the UI thread.
-    int folderIndex = -1;
-    uint32_t iconGeneration = 0;
-    HWND taskbarWnd = nullptr;
-    bool resourceSpec = false;
 };
 
 // Keyed by resolved folder path so subfolders opened on hover share the same
@@ -2828,28 +3858,6 @@ void ScanFolderInto(const std::wstring& path,
 
 void StartScanThread();
 
-// Delivered from the scan STA to the taskbar UI thread (WriteableBitmap only).
-struct ButtonIconDelivery {
-    int folderIndex = -1;
-    uint32_t iconGeneration = 0;
-    int iconExtent = 0;
-    HWND taskbarWnd = nullptr;
-    std::shared_ptr<Gdiplus::Bitmap> bitmap;
-};
-
-void ApplyButtonIconOnUiThread(void* parameter);
-
-void DeliverButtonIconToUi(std::unique_ptr<ButtonIconDelivery> delivery) {
-    if (!delivery || !delivery->taskbarWnd || !delivery->bitmap) {
-        return;
-    }
-    HWND hwnd = delivery->taskbarWnd;
-    ButtonIconDelivery* raw = delivery.release();
-    if (!RunFromWindowThread(hwnd, ApplyButtonIconOnUiThread, raw)) {
-        delete raw;
-    }
-}
-
 void ScanThreadMain() {
     // Shell icon extractors (SHGetFileInfo / IExtractIcon) expect STA. MTA
     // causes many extractions to fail with the generic document icon.
@@ -2908,49 +3916,6 @@ void ScanThreadMain() {
             request.iconPixelSize = 32;
         }
 
-        if (request.kind == ScanRequestKind::ButtonIcon) {
-            std::shared_ptr<Gdiplus::Bitmap> bitmap;
-            if (!request.path.empty()) {
-                const std::wstring checkPath =
-                    request.resourceSpec ? IconSpecFilePart(request.path)
-                                         : request.path;
-                if (IsLikelyRemotePath(checkPath)) {
-                    Wh_Log(L"Skipping button icon for remote path %s",
-                           checkPath.c_str());
-                } else if (request.resourceSpec) {
-                    if (HICON hIcon = ExtractIconFromResourceSpec(
-                            request.path, request.iconPixelSize)) {
-                        bitmap = HIconToBitmap(hIcon, request.iconPixelSize);
-                        DestroyIcon(hIcon);
-                    }
-                } else {
-                    std::wstring resolved = ResolveFolderPath(request.path);
-                    if (!resolved.empty() && !IsLikelyRemotePath(resolved)) {
-                        if (HICON hIcon = GetShellIconForPath(
-                                resolved, request.iconPixelSize)) {
-                            bitmap =
-                                HIconToBitmap(hIcon, request.iconPixelSize);
-                            DestroyIcon(hIcon);
-                        }
-                    }
-                }
-                PumpScanThreadMessages();
-            }
-
-            if (bitmap && !g_unloading &&
-                !g_scanThreadStop.load(std::memory_order_relaxed)) {
-                auto delivery = std::make_unique<ButtonIconDelivery>();
-                delivery->folderIndex = request.folderIndex;
-                delivery->iconGeneration = request.iconGeneration;
-                // iconPixelSize is the extract size (display extent × 2).
-                delivery->iconExtent = std::max(8, request.iconPixelSize / 2);
-                delivery->taskbarWnd = request.taskbarWnd;
-                delivery->bitmap = std::move(bitmap);
-                DeliverButtonIconToUi(std::move(delivery));
-            }
-            continue;
-        }
-
         std::wstring scanPath = request.path;
         if (IsShellFolderPath(scanPath)) {
             scanPath = ResolveFolderPath(scanPath);
@@ -3001,66 +3966,14 @@ void RequestScan(const std::wstring& path, int iconPixelSize) {
         return;
     }
     for (const auto& queued : g_scanQueue) {
-        if (queued.kind == ScanRequestKind::Folder &&
-            queued.iconPixelSize == iconPixelSize &&
+        if (queued.iconPixelSize == iconPixelSize &&
             _wcsicmp(queued.path.c_str(), path.c_str()) == 0) {
             return;
         }
     }
     ScanRequest req;
-    req.kind = ScanRequestKind::Folder;
     req.path = path;
     req.iconPixelSize = iconPixelSize;
-    g_scanQueue.push_back(std::move(req));
-    if (g_scanWorkEvent) {
-        SetEvent(g_scanWorkEvent);
-    }
-}
-
-// Extract a taskbar button icon on the STA scan worker. The UI shows an emoji
-// fallback until ApplyButtonIconOnUiThread installs a WriteableBitmap.
-void RequestButtonIcon(const std::wstring& pathOrSpec,
-                       int iconPixelSize,
-                       int folderIndex,
-                       uint32_t iconGeneration,
-                       HWND taskbarWnd,
-                       bool resourceSpec) {
-    if (pathOrSpec.empty() || g_unloading || !taskbarWnd || folderIndex < 0) {
-        return;
-    }
-
-    const std::wstring checkPath =
-        resourceSpec ? IconSpecFilePart(pathOrSpec) : pathOrSpec;
-    if (IsLikelyRemotePath(checkPath)) {
-        Wh_Log(L"Skipping button icon request for remote path %s",
-               checkPath.c_str());
-        return;
-    }
-
-    StartScanThread();
-
-    std::lock_guard<std::mutex> lock(g_scanMutex);
-    if (g_unloading || g_scanThreadStop.load(std::memory_order_relaxed) ||
-        g_scanThreadJoining.load(std::memory_order_relaxed)) {
-        return;
-    }
-    for (const auto& queued : g_scanQueue) {
-        if (queued.kind == ScanRequestKind::ButtonIcon &&
-            queued.folderIndex == folderIndex &&
-            queued.iconGeneration == iconGeneration &&
-            queued.taskbarWnd == taskbarWnd &&
-            queued.iconPixelSize == iconPixelSize) {
-            return;
-        }
-    }
-    ScanRequest req;
-    req.kind = ScanRequestKind::ButtonIcon;
-    req.path = pathOrSpec;
-    req.iconPixelSize = iconPixelSize;
-    req.folderIndex = folderIndex;
-    req.iconGeneration = iconGeneration;
-    req.taskbarWnd = taskbarWnd;
-    req.resourceSpec = resourceSpec;
     g_scanQueue.push_back(std::move(req));
     if (g_scanWorkEvent) {
         SetEvent(g_scanWorkEvent);
@@ -3198,6 +4111,8 @@ constexpr UINT_PTR kOpenTimerId = 2;
 // Separate from kTickTimerId so the blur's refresh rate isn't tied to (or
 // capped by) the hover/close/submenu poll cadence.
 constexpr UINT_PTR kBlurTimerId = 3;
+constexpr UINT_PTR kItemTooltipTimerId = 4;
+constexpr UINT kItemTooltipDelayMs = 200;
 constexpr UINT kTickTimerMs = 16;
 // 32ms = ~30fps. Fixed rather than matched to the monitor: simpler, and this
 // is capture+resample cost paid on a timer, not a true frame rate - no need
@@ -3217,6 +4132,12 @@ struct PopupLevel {
     std::wstring title;
     std::vector<GridItem> items;
     std::vector<RECT> cellRects;
+    // Parallel to items: whether the label was long enough to lose text to
+    // the ellipsis at last paint. Drives ItemTooltip - see there.
+    std::vector<bool> labelTruncated;
+    // Cell kItemTooltipTimerId is currently counting down for, so the fire
+    // can be ignored if the hover has since moved to a different cell.
+    int tooltipPendingCell = -1;
     RECT rect{};
     RECT anchorRect{};
     int spawnerCell = -1;
@@ -3233,10 +4154,14 @@ struct PopupLevel {
     // Baked into cachedBase by RebuildLevelBase, not drawn separately - see
     // PresentLevel for when this is (re)captured.
     std::unique_ptr<Gdiplus::Bitmap> blurBackdrop;
-    // Size the rounded window region was last built for, so hover repaints do
-    // not rebuild it. See ApplyRoundedRegion.
+    // Size and radius the rounded window region was last built for, so hover
+    // repaints do not rebuild it. See ApplyRoundedRegion. The radius is part of
+    // the key because a settings change can alter it without the window
+    // resizing, which used to leave the old shape in place until the popup
+    // happened to open at a different size.
     int regionW = 0;
     int regionH = 0;
+    int regionRadius = -1;
 };
 
 // Created on the taskbar UI thread, read from the Windhawk engine thread, an
@@ -3339,6 +4264,7 @@ void OpenRootLevel(std::wstring path, RECT anchorRect, std::wstring title);
 void OpenSubLevel(int parentDepth, int cell);
 void CloseLevelsFrom(int depth);
 void CloseChain();
+void HideItemTooltip();
 void StartRetryThread();
 bool EnsurePopupClasses();
 HWND EnsureMenuOwnerWindow();
@@ -3373,18 +4299,15 @@ void ApplyBackdrop(HWND hWnd) {
     // of here - see SetOwnWindowsCaptureExcluded - so the window stays
     // screenshot/recording-visible the rest of the time.
 
-    int corner = DWMWCP_ROUND;
+    int corner = g_settings.cornerRadius > 0 ? DWMWCP_ROUND : DWMWCP_DONOTROUND;
     DwmSetWindowAttribute(hWnd, DWMWA_WINDOW_CORNER_PREFERENCE, &corner,
                           sizeof(corner));
 
     // DWM draws its own 1px border on a rounded window, independent of anything
-    // we paint. That is the outline that survived at opacity 0 - our own border
-    // pen was already skipped there, but this one is system chrome.
-    if (!g_settings.panelBorder) {
-        COLORREF border = DWMWA_COLOR_NONE;
-        DwmSetWindowAttribute(hWnd, DWMWA_BORDER_COLOR, &border,
-                              sizeof(border));
-    }
+    // we paint. That is the outline that survived at opacity 0 even with our
+    // own border pen gone, so it is suppressed here too.
+    COLORREF border = DWMWA_COLOR_NONE;
+    DwmSetWindowAttribute(hWnd, DWMWA_BORDER_COLOR, &border, sizeof(border));
 
     if (auto setWindowCompositionAttribute = GetSetWindowCompositionAttribute()) {
         ACCENT_POLICY accent{};
@@ -3575,23 +4498,37 @@ bool CanExpand(int depth) {
 // Clips the window itself to the same rounded rect the panel is painted with.
 // The blur background and DWM's border are drawn against the window shape, not
 // against our alpha, so without this they kept square corners while the painted
-// background was round. Rebuilt only when the size changes - hover repaints run
-// through PaintLevel too.
+// background was round. Rebuilt only when the size or the radius changes - hover
+// repaints run through PaintLevel too.
+//
+// Two calls, because the window is layered and the acrylic is not ours:
+//
+//  * SetWindowRgn shapes the window, which is what clips our own painting, the
+//    hit testing and DWM's border.
+//  * DwmEnableBlurBehindWindow's hRgnBlur shapes the *blur*. DWM composites the
+//    acrylic as its own layer behind the layered surface, filling the window
+//    rect, and our per-pixel alpha is what lets it show through the corners we
+//    left transparent — so the window region alone never reached it. This is the
+//    documented way to say which part of a window the blur covers.
 void ApplyRoundedRegion(PopupLevel* level, int width, int height) {
     if (!level || !level->hwnd || width <= 0 || height <= 0) {
         return;
     }
-    if (level->regionW == width && level->regionH == height) {
+    int radius = ScaleForPopup(g_settings.cornerRadius);
+    if (level->regionW == width && level->regionH == height &&
+        level->regionRadius == radius) {
         return;
     }
 
-    int radius = ScaleForPopup(g_settings.cornerRadius);
     // CreateRoundRectRgn's ellipse size is the full diameter, and its right and
     // bottom edges are exclusive.
-    HRGN region =
-        radius > 0 ? CreateRoundRectRgn(0, 0, width + 1, height + 1, radius * 2,
-                                        radius * 2)
-                   : CreateRectRgn(0, 0, width, height);
+    auto makeRegion = [&]() -> HRGN {
+        return radius > 0 ? CreateRoundRectRgn(0, 0, width + 1, height + 1,
+                                               radius * 2, radius * 2)
+                          : CreateRectRgn(0, 0, width, height);
+    };
+
+    HRGN region = makeRegion();
     if (!region) {
         return;
     }
@@ -3599,8 +4536,20 @@ void ApplyRoundedRegion(PopupLevel* level, int width, int height) {
     if (SetWindowRgn(level->hwnd, region, FALSE)) {
         level->regionW = width;
         level->regionH = height;
+        level->regionRadius = radius;
     } else {
         DeleteObject(region);
+    }
+
+    // A second, independent region: DwmEnableBlurBehindWindow copies it rather
+    // than taking ownership, so this one is ours to delete.
+    if (HRGN blurRegion = makeRegion()) {
+        DWM_BLURBEHIND blur{};
+        blur.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION;
+        blur.fEnable = TRUE;
+        blur.hRgnBlur = blurRegion;
+        DwmEnableBlurBehindWindow(level->hwnd, &blur);
+        DeleteObject(blurRegion);
     }
 }
 
@@ -3728,6 +4677,17 @@ void DrawCell(Gdiplus::Graphics& g,
     if (g_settings.showLabels && labelRect.Height > 0) {
         DrawStringWithShadow(g, item.displayName.c_str(), font, labelRect,
                              format, textColor, panelAlpha);
+
+        Gdiplus::RectF measuredBox;
+        INT codepointsFitted = 0;
+        INT linesFilled = 0;
+        g.MeasureString(item.displayName.c_str(), -1, &font, labelRect,
+                        &format, &measuredBox, &codepointsFitted,
+                        &linesFilled);
+        if (index < (int)level->labelTruncated.size()) {
+            level->labelTruncated[index] =
+                codepointsFitted < (INT)item.displayName.size();
+        }
     }
 }
 
@@ -3814,6 +4774,7 @@ bool RebuildLevelBase(PopupLevel* level, int width, int height) {
     if (!bitmap || bitmap->GetLastStatus() != Gdiplus::Ok) {
         return false;
     }
+    level->labelTruncated.assign(level->items.size(), false);
 
     Gdiplus::Graphics g(bitmap.get());
     g.SetCompositingQuality(Gdiplus::CompositingQualityHighQuality);
@@ -3836,8 +4797,6 @@ bool RebuildLevelBase(PopupLevel* level, int width, int height) {
     Gdiplus::Color panelColor = dark
                                     ? Gdiplus::Color(panelAlpha, 43, 43, 43)
                                     : Gdiplus::Color(panelAlpha, 249, 249, 249);
-    Gdiplus::Color borderColor =
-        dark ? Gdiplus::Color(40, 255, 255, 255) : Gdiplus::Color(28, 0, 0, 0);
     // White in both themes - the black outline carries the contrast, so the
     // light theme does not need dark text.
     Gdiplus::Color textColor(255, 255, 255, 255);
@@ -3860,8 +4819,8 @@ bool RebuildLevelBase(PopupLevel* level, int width, int height) {
     // the final DIB every repaint instead of forcing a full RebuildLevelBase
     // (icon/badge/text redraws) on every blur tick.
     //
-    // The fill still runs at opacity 0 - see PanelAlpha() - but the border is
-    // optional so nothing of the panel need be left on screen.
+    // The fill still runs at opacity 0 - see PanelAlpha() - so nothing of the
+    // panel need be left on screen.
     //
     // SourceCopy, not the default SourceOver: this Graphics runs at
     // CompositingQualityHighQuality, which is GDI+'s gamma-corrected blend, and
@@ -3876,10 +4835,6 @@ bool RebuildLevelBase(PopupLevel* level, int width, int height) {
     g.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
     g.FillPath(&panelBrush, &panelPath);
     g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
-    if (g_settings.panelBorder) {
-        Gdiplus::Pen borderPen(borderColor, 1.0f);
-        g.DrawPath(&borderPen, &panelPath);
-    }
 
     auto font = MakePopupFont(ScaleForPopup(g_settings.fontSize),
                               g_settings.itemFontWeight);
@@ -4190,6 +5145,7 @@ void CloseLevelsFrom(int depth) {
     while ((int)Levels().size() > depth) {
         auto& level = Levels().back();
         if (level->hwnd) {
+            KillTimer(level->hwnd, kItemTooltipTimerId);
             ShowWindow(level->hwnd, SW_HIDE);
         }
         Levels().pop_back();
@@ -4208,6 +5164,7 @@ void CloseChain() {
     }
     CloseLevelsFrom(0);
     g_outsideSinceTick = 0;
+    HideItemTooltip();
 }
 
 // The seam between two side-by-side cascade grids: just the strip of
@@ -4709,6 +5666,65 @@ void OnTick() {
     }
 }
 
+// One shared standard tooltip control, tracked to the cursor, for grid item
+// labels the ellipsis cut off. Lazily created and never destroyed - it costs
+// nothing sitting hidden, and every popup window uses the same one.
+HWND EnsureItemTooltip() {
+    static HWND tooltip = nullptr;
+    if (tooltip) {
+        return tooltip;
+    }
+    tooltip = CreateWindowExW(WS_EX_TOPMOST, TOOLTIPS_CLASSW, nullptr,
+                              WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP,
+                              CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+                              CW_USEDEFAULT, nullptr, nullptr,
+                              GetCurrentModuleHandle(), nullptr);
+    if (!tooltip) {
+        return nullptr;
+    }
+    TOOLINFOW info{sizeof(info)};
+    info.uFlags = TTF_TRACK | TTF_ABSOLUTE;
+    info.hwnd = nullptr;
+    info.uId = 1;
+    info.lpszText = const_cast<LPWSTR>(L"");
+    SendMessageW(tooltip, TTM_ADDTOOL, 0, (LPARAM)&info);
+    return tooltip;
+}
+
+void HideItemTooltip() {
+    HWND tooltip = EnsureItemTooltip();
+    if (!tooltip) {
+        return;
+    }
+    TOOLINFOW info{sizeof(info)};
+    info.hwnd = nullptr;
+    info.uId = 1;
+    SendMessageW(tooltip, TTM_TRACKACTIVATE, FALSE, (LPARAM)&info);
+}
+
+// screenPt is where the cursor is; the tooltip is offset below-right of it so
+// the pointer doesn't sit on top of its own tip.
+void ShowItemTooltip(const std::wstring& text, POINT screenPt) {
+    HWND tooltip = EnsureItemTooltip();
+    if (!tooltip) {
+        return;
+    }
+    bool dark = IsDarkPopupTheme();
+    SendMessageW(tooltip, TTM_SETTIPBKCOLOR, 0,
+                (LPARAM)(dark ? RGB(43, 43, 43) : RGB(249, 249, 249)));
+    SendMessageW(tooltip, TTM_SETTIPTEXTCOLOR, 0,
+                (LPARAM)(dark ? RGB(255, 255, 255) : RGB(0, 0, 0)));
+
+    TOOLINFOW info{sizeof(info)};
+    info.hwnd = nullptr;
+    info.uId = 1;
+    info.lpszText = const_cast<LPWSTR>(text.c_str());
+    SendMessageW(tooltip, TTM_UPDATETIPTEXT, 0, (LPARAM)&info);
+    SendMessageW(tooltip, TTM_TRACKPOSITION, 0,
+                (LPARAM)MAKELONG(screenPt.x + 16, screenPt.y + 20));
+    SendMessageW(tooltip, TTM_TRACKACTIVATE, TRUE, (LPARAM)&info);
+}
+
 LRESULT CALLBACK PopupWndProc(HWND hWnd,
                               UINT uMsg,
                               WPARAM wParam,
@@ -4761,6 +5777,11 @@ LRESULT CALLBACK PopupWndProc(HWND hWnd,
 
     switch (uMsg) {
         case WM_MOUSEMOVE: {
+            TRACKMOUSEEVENT tme{sizeof(tme)};
+            tme.dwFlags = TME_LEAVE;
+            tme.hwndTrack = hWnd;
+            TrackMouseEvent(&tme);
+
             POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
             int cell = CellFromClientPoint(level, pt);
             if (cell != level->hoverCell) {
@@ -4782,14 +5803,51 @@ LRESULT CALLBACK PopupWndProc(HWND hWnd,
                     g_pendingSubCell = -1;
                 }
             }
+
+            bool truncated =
+                cell >= 0 && cell < (int)level->labelTruncated.size() &&
+                level->labelTruncated[cell];
+            if (cell != level->tooltipPendingCell) {
+                HideItemTooltip();
+                KillTimer(hWnd, kItemTooltipTimerId);
+                level->tooltipPendingCell = truncated ? cell : -1;
+                if (truncated) {
+                    SetTimer(hWnd, kItemTooltipTimerId, kItemTooltipDelayMs,
+                             nullptr);
+                }
+            }
+
             g_outsideSinceTick = 0;
             return 0;
         }
+
+        case WM_TIMER:
+            if (wParam == kItemTooltipTimerId) {
+                KillTimer(hWnd, kItemTooltipTimerId);
+                int cell = level->tooltipPendingCell;
+                if (cell == level->hoverCell && cell >= 0 &&
+                    cell < (int)level->items.size()) {
+                    POINT screenPt;
+                    GetCursorPos(&screenPt);
+                    ShowItemTooltip(level->items[cell].displayName, screenPt);
+                }
+                return 0;
+            }
+            break;
+
+        case WM_MOUSELEAVE:
+            HideItemTooltip();
+            KillTimer(hWnd, kItemTooltipTimerId);
+            level->tooltipPendingCell = -1;
+            return 0;
 
         case WM_LBUTTONDOWN: {
             POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
             level->pressedCell = CellFromClientPoint(level, pt);
             PaintLevel(level);
+            HideItemTooltip();
+            KillTimer(hWnd, kItemTooltipTimerId);
+            level->tooltipPendingCell = -1;
             return 0;
         }
 
@@ -4825,6 +5883,7 @@ LRESULT CALLBACK PopupWndProc(HWND hWnd,
             KillTimer(hWnd, kTickTimerId);
             KillTimer(hWnd, kOpenTimerId);
             KillTimer(hWnd, kBlurTimerId);
+            HideItemTooltip();
             return 0;
     }
 
@@ -5141,97 +6200,49 @@ void OpenSubLevel(int parentDepth, int cell) {
 
 ////////////////////////////////////////////////////////////////////////////////
 // The taskbar buttons
+//
+// There are none any more, and that is the point. The folder buttons are real
+// pinned taskbar items now (see the Pins namespace), so Windows creates, lays
+// out and animates them. All this code has to do is notice which of the shell's
+// buttons are ours and attach hover to them.
+//
+// What used to be here was an overlay: a Grid appended to the taskbar's root,
+// with the neighbouring icon's margin widened to carve a gap, and roughly two
+// thousand lines keeping the overlay seated in that gap — anchor resolution, a
+// strip census, slide animations, settle holds, parked-anchor holds, drag
+// freezes. None of it could ever be exactly right. Taskbar item positions are
+// driven by implicit Windows.UI.Composition animations that interpolate on the
+// compositor thread, and no other HWND can sample an animation mid-flight, so
+// the overlay was always at least a frame behind and worse across inserts and
+// reorders. It was chasing a value it could only predict.
+//
+// Deleting it is what fixed the animations, and dragging came free with it.
 
-constexpr PCWSTR kHostGridName = L"FolderHoverTrayHost";
-constexpr double kFallbackButtonSize = 44.0;
-
-struct ButtonState {
-    Button button{nullptr};
-    // Content wrapper holding [highlightBorder, icon]. Async icon delivery
-    // must swap only the icon child here, not replace button.Content()
-    // wholesale — that would orphan highlightBorder and silently kill hover.
-    Grid contentGrid{nullptr};
-    // Inset visual behind the icon; the button itself stays full-size so the
-    // click/hover hitbox still matches the neighbouring app icon's slot.
-    Border highlightBorder{nullptr};
-    Brush highlightHoverBrush{nullptr};
-    Brush highlightPressedBrush{nullptr};
-    winrt::event_token clickToken{};
+// Hover attached to one genuine Taskbar.TaskListButton. Held per host because
+// the containers belong to that taskbar's repeater and must be released on the
+// thread that owns them.
+struct PinBinding {
+    FrameworkElement button{nullptr};
+    int folderIndex = -1;
     winrt::event_token enterToken{};
     winrt::event_token exitToken{};
-    winrt::event_token pressedToken{};
-    winrt::event_token releasedToken{};
-    winrt::event_token rightTapToken{};
-    int folderIndex = -1;
-    // Bumped when the button is rebuilt so late icon deliveries are ignored.
-    uint32_t iconGeneration = 0;
 };
 
-// One injected host per taskbar window (primary + each secondary monitor).
+// One per taskbar window (primary + each secondary monitor).
 struct TaskbarHost {
     HWND hwnd = nullptr;
-    Grid hostGrid{nullptr};
     Grid trackedRootGrid{nullptr};
-    FrameworkElement anchor{nullptr};
     FrameworkElement cachedRepeater{nullptr};
-    std::vector<ButtonState> buttonStates;
-    Thickness anchorOriginalMargin{};
-    bool hasAnchorOriginalMargin = false;
     winrt::event_token layoutUpdatedToken{};
-    double buttonWidth = kFallbackButtonSize;
-    double buttonHeight = kFallbackButtonSize;
-    ULONGLONG lastAnchorResolveTick = 0;
-    int lastRepeaterChildCount = -1;
-    ULONGLONG lastButtonSizeTick = 0;
-    // hostGrid is positioned by this RenderTransform rather than by Margin.
-    // Margin would feed rootGrid's column-0 measure, so every reposition
-    // changed the taskbar's measured content width, re-centered the app
-    // strip, moved the anchor, and produced a new target — a layout feedback
-    // loop that read as the overlay fighting its own animation. A render
-    // transform is invisible to layout, and TransformToVisual still includes
-    // it, so ComputeHoverAnchorRect keeps working unchanged.
-    TranslateTransform hostTranslate{nullptr};
-    Storyboard slideStoryboard{nullptr};
-    double currentLeft = 0.0;
-    // First placement after injection jumps straight to position; there is
-    // nothing to slide from, and animating it would fly the buttons in from
-    // the taskbar's left edge on every load and settings reload.
-    bool hasPlaced = false;
-    // When the current slide is scheduled to actually start moving, and when
-    // it's due to finish. slideCauseTick/IsClose freeze the open-vs-close
-    // delay for a pending gesture so layout retargets keep the remaining
-    // wait instead of restarting it.
-    ULONGLONG slideStartTick = 0;
-    ULONGLONG slideEndTick = 0;
-    ULONGLONG slideCauseTick = 0;
-    bool slideCauseIsClose = false;
-    // When the target last moved, used to tell a settled open/close (which has
-    // a real icon animation to sync with) from churn (which does not).
-    ULONGLONG lastRetargetTick = 0;
-    // Set when ResolveAnchor just swapped to a different button (the old
-    // anchor closed) rather than the usual smooth shrink/slide. Consumed by
-    // AnimateHostGridLeftTo to skip the open/close sync delay for that one
-    // retarget — see the anchor-changed comment in OnRootGridLayoutUpdated.
-    bool anchorSwapped = false;
-    // Where the anchor was sitting when it was adopted one full reserve-width
-    // clear of the rest of the strip, i.e. parked on the far side of our own
-    // gap. -1 when the anchor was adopted normally. Positioning is held until
-    // the button has actually moved off this spot - see OnRootGridLayoutUpdated.
-    double parkedAnchorX = -1.0;
-    // Consecutive passes held back by the above, capped so a parked anchor
-    // that never moves cannot wedge the overlay.
-    int reserveHolds = 0;
-    // Anchor X as of the previous layout pass, and the tick it last differed
-    // from the pass before that. Windows moves its own icons over ~250ms, and
-    // layout reports the anchor part-way through that move, so a reading that
-    // differs from last pass is a frame of an animation in flight rather than
-    // a resting place. Positioning waits for two passes to agree - see the
-    // settle hold in OnRootGridLayoutUpdated.
-    double lastAnchorX = -1.0;
-    ULONGLONG anchorMovingSince = 0;
-    // Whether positioning is currently frozen for a mouse drag; only used to
-    // log the transitions rather than every pass.
-    bool dragFrozen = false;
+    // Hover on the real pinned items. Rebuilt whenever the realized button set
+    // changes, since ItemsRepeater recycles containers between items.
+    std::vector<PinBinding> pinBindings;
+    int lastPinBindCount = -1;
+    // Identity of the realized children as of the last bind, so the common case
+    // (a layout pass that changed nothing) costs one comparison rather than a
+    // full detach/reattach.
+    std::vector<void*> lastRealizedChildren;
+    uint32_t lastLabelGeneration = 0;
 };
 
 [[clang::no_destroy]] std::optional<std::vector<std::unique_ptr<TaskbarHost>>>
@@ -5256,351 +6267,6 @@ HANDLE g_retryThread = nullptr;
 HANDLE g_retryStopEvent = nullptr;   // manual-reset
 HANDLE g_retryKickEvent = nullptr;   // auto-reset
 SRWLOCK g_retryLock = SRWLOCK_INIT;
-
-// WriteableBitmap's backing store is reachable only through this interop
-// interface, which the C++/WinRT projection does not declare for us.
-struct IBufferByteAccess : IUnknown {
-    virtual HRESULT STDMETHODCALLTYPE Buffer(BYTE** value) = 0;
-};
-
-constexpr GUID kIBufferByteAccessGuid = {
-    0x905a0fef,
-    0xbc53,
-    0x11df,
-    {0x8c, 0x49, 0x00, 0x1e, 0x4f, 0xc6, 0x86, 0xda}};
-
-// WriteableBitmap must be created on the taskbar UI thread.
-// GDI+ Image getters are non-const in the MinGW headers Windhawk ships.
-ImageSource BitmapToImageSource(Gdiplus::Bitmap& bitmap) {
-    try {
-        const int width = (int)bitmap.GetWidth();
-        const int height = (int)bitmap.GetHeight();
-        if (width <= 0 || height <= 0) {
-            return nullptr;
-        }
-
-        Gdiplus::BitmapData bd{};
-        Gdiplus::Rect lockRect(0, 0, width, height);
-        // HIconToBitmap stores PARGB; WriteableBitmap also wants premultiplied
-        // BGRA.
-        if (bitmap.LockBits(&lockRect, Gdiplus::ImageLockModeRead,
-                            PixelFormat32bppPARGB, &bd) != Gdiplus::Ok) {
-            return nullptr;
-        }
-
-        try {
-            winrt::Windows::UI::Xaml::Media::Imaging::WriteableBitmap writeable(
-                width, height);
-            auto buffer = writeable.PixelBuffer();
-            IBufferByteAccess* byteAccess = nullptr;
-            auto* bufferUnknown = (IUnknown*)winrt::get_abi(buffer);
-            if (bufferUnknown &&
-                SUCCEEDED(bufferUnknown->QueryInterface(kIBufferByteAccessGuid,
-                                                        (void**)&byteAccess)) &&
-                byteAccess) {
-                BYTE* dest = nullptr;
-                if (SUCCEEDED(byteAccess->Buffer(&dest)) && dest) {
-                    for (int y = 0; y < height; y++) {
-                        memcpy(dest + (size_t)y * width * 4,
-                               (const BYTE*)bd.Scan0 + (size_t)y * bd.Stride,
-                               (size_t)width * 4);
-                    }
-                }
-                byteAccess->Release();
-            }
-            bitmap.UnlockBits(&bd);
-            writeable.Invalidate();
-            return writeable;
-        } catch (...) {
-            bitmap.UnlockBits(&bd);
-            return nullptr;
-        }
-    } catch (...) {
-        return nullptr;
-    }
-}
-
-void ApplyButtonIconOnUiThread(void* parameter) {
-    std::unique_ptr<ButtonIconDelivery> delivery(
-        static_cast<ButtonIconDelivery*>(parameter));
-    if (g_unloading || !delivery || !delivery->bitmap || !g_taskbarHosts) {
-        return;
-    }
-
-    // Skip if the user switched this slot to a literal emoji icon.
-    if (delivery->folderIndex >= 0) {
-        std::wstring icon;
-        {
-            std::lock_guard<std::mutex> lock(g_foldersMutex);
-            if (delivery->folderIndex < (int)g_settings.folders.size()) {
-                icon = g_settings.folders[delivery->folderIndex].icon;
-            }
-        }
-        if (!icon.empty() && !IconSettingIsFile(icon)) {
-            return;
-        }
-    }
-
-    for (auto& host : *g_taskbarHosts) {
-        if (!host || host->hwnd != delivery->taskbarWnd) {
-            continue;
-        }
-        for (auto& state : host->buttonStates) {
-            if (state.folderIndex != delivery->folderIndex ||
-                state.iconGeneration != delivery->iconGeneration ||
-                !state.button) {
-                continue;
-            }
-            try {
-                auto source = BitmapToImageSource(*delivery->bitmap);
-                if (!source) {
-                    return;
-                }
-                Image image;
-                image.Width(delivery->iconExtent);
-                image.Height(delivery->iconExtent);
-                image.Stretch(Stretch::Uniform);
-                image.HorizontalAlignment(HorizontalAlignment::Center);
-                image.VerticalAlignment(VerticalAlignment::Center);
-                image.Source(source);
-                if (state.contentGrid) {
-                    // Swap just the icon (child 1); leave highlightBorder
-                    // (child 0) in place so the wired hover handlers keep
-                    // pointing at a live element.
-                    auto children = state.contentGrid.Children();
-                    if (children.Size() >= 2) {
-                        children.RemoveAt(1);
-                    }
-                    children.Append(image);
-                } else {
-                    state.button.Content(image);
-                }
-            } catch (...) {
-            }
-            return;
-        }
-    }
-}
-
-void SetButtonBrush(Button const& button, PCWSTR key, Brush const& brush) {
-    button.Resources().Insert(winrt::box_value(winrt::hstring(key)), brush);
-}
-
-Brush MakeBrush(BYTE a, BYTE r, BYTE g, BYTE b) {
-    return SolidColorBrush(
-        winrt::Windows::UI::ColorHelper::FromArgb(a, r, g, b));
-}
-
-// How far the highlight overlay sits inside the button's full (hitbox) rect,
-// horizontally. The vertical inset is whatever is left over after squaring:
-// a TaskListButton is taller than it is wide (its height spans the whole
-// taskbar row), so insetting uniformly left the highlight tall and narrow.
-constexpr double kHighlightInset = 2.0;
-constexpr double kHighlightCornerRadius = 4.0;
-
-// Square highlight sized off the button width, clamped so it can never grow
-// past the button's height and bleed out of the taskbar row.
-double HighlightExtent(double buttonWidth, double buttonHeight) {
-    double extent = buttonWidth - 2.0 * kHighlightInset;
-    extent = std::min(extent, buttonHeight - 2.0 * kHighlightInset);
-    return std::max(extent, 8.0);
-}
-// "Very quick" fade — out is slightly slower so the highlight doesn't snap
-// away while the pointer is still crossing between adjacent buttons.
-constexpr int kHighlightFadeInMs = 90;
-constexpr int kHighlightFadeOutMs = 130;
-
-// Matches the shell's own app-icon states: a flat translucent fill, white on
-// dark themes and black on light ones — no acrylic, no gradient. The taskbar's
-// own backdrop showing through this is what gives it the glassy read.
-//
-// Hover is measured off a screenshot of a real hovered taskbar button rather
-// than taken from the documented 10-18% range, which overshoots badly: a
-// hovered Settings button reads RGB(27,23,23) over an RGB(13,8,8) taskbar,
-// i.e. (27-13)/(255-13) = 5.8% white, not 12%. Press has no such measurement;
-// it keeps the same ~1.5x step over hover it had before.
-constexpr BYTE kHighlightHoverAlpha = 14;    // 0x0E ≈ 5.7%
-constexpr BYTE kHighlightPressedAlpha = 21;  // 0x15 ≈ 8.5%
-
-Brush MakeHighlightBrush(bool dark, bool pressed) {
-    BYTE alpha = pressed ? kHighlightPressedAlpha : kHighlightHoverAlpha;
-    BYTE channel = dark ? 255 : 0;
-    return MakeBrush(alpha, channel, channel, channel);
-}
-
-// Fades the highlight's composition Opacity. A single keyframe at 1.0 means
-// the animation starts from whatever opacity is on screen right now, so an
-// interrupted fade hands off mid-flight instead of snapping — important when
-// the pointer skims across several buttons in a row.
-//
-// This drives the composition visual, not FrameworkElement::Opacity; the two
-// multiply, so the XAML-side value must be left at 1.0 throughout.
-void FadeHighlight(UIElement const& element, float to, int ms) {
-    if (!element) {
-        return;
-    }
-    try {
-        auto visual = ElementCompositionPreview::GetElementVisual(element);
-        auto compositor = visual.Compositor();
-        auto easing =
-            compositor.CreateCubicBezierEasingFunction({0.3f, 0.0f},
-                                                       {0.2f, 1.0f});
-        auto anim = compositor.CreateScalarKeyFrameAnimation();
-        anim.InsertKeyFrame(1.0f, to, easing);
-        anim.Duration(std::chrono::milliseconds(ms));
-        visual.StartAnimation(L"Opacity", anim);
-    } catch (...) {
-        // No composition: jump straight to the target, no fade.
-        try {
-            element.Opacity(to);
-        } catch (...) {
-        }
-    }
-}
-
-void ApplyNativeButtonStyle(Button const& button) {
-    bool dark = IsDarkTheme();
-
-    // The template's own background spans the full button (edge-to-edge,
-    // wider than the icon). It stays fully transparent in every state; a
-    // smaller inset Border drawn in the content plays the hover/press
-    // highlight instead, so the visual shrinks without touching the hitbox.
-    for (PCWSTR key : {L"ButtonBackground", L"ButtonBackgroundPointerOver",
-                       L"ButtonBackgroundPressed", L"ButtonBackgroundDisabled"}) {
-        SetButtonBrush(button, key, MakeBrush(0, 0, 0, 0));
-    }
-
-    for (PCWSTR key : {L"ButtonBorderBrush", L"ButtonBorderBrushPointerOver",
-                       L"ButtonBorderBrushPressed"}) {
-        SetButtonBrush(button, key, MakeBrush(0, 0, 0, 0));
-    }
-
-    auto foreground =
-        dark ? MakeBrush(255, 255, 255, 255) : MakeBrush(255, 26, 26, 26);
-    for (PCWSTR key : {L"ButtonForeground", L"ButtonForegroundPointerOver",
-                       L"ButtonForegroundPressed"}) {
-        SetButtonBrush(button, key, foreground);
-    }
-    button.Foreground(foreground);
-
-    button.BorderThickness({0, 0, 0, 0});
-    button.Padding({0, 0, 0, 0});
-    button.MinWidth(0);
-    button.MinHeight(0);
-    button.CornerRadius({6, 6, 6, 6});
-    // Stretch, not Center: the content is a Grid holding the inset highlight
-    // Border plus the icon. Center-aligning would size that Grid down to the
-    // icon's own bounds, collapsing the highlight behind the opaque icon
-    // pixels. The icon centers itself via its own alignment already.
-    button.HorizontalContentAlignment(HorizontalAlignment::Stretch);
-    button.VerticalContentAlignment(VerticalAlignment::Stretch);
-    button.UseSystemFocusVisuals(false);
-}
-
-UIElement MakeFolderEmojiFallback(int iconExtent) {
-    TextBlock fallback;
-    fallback.Text(L"\U0001F4C1");
-    fallback.FontFamily(FontFamily(L"Segoe UI Emoji"));
-    fallback.FontSize(iconExtent * 0.92);
-    fallback.HorizontalAlignment(HorizontalAlignment::Center);
-    fallback.VerticalAlignment(VerticalAlignment::Center);
-    return fallback;
-}
-
-// Shell icon / resource extraction runs on the STA scan worker. Only XAML
-// BitmapImage (async decode) and emoji TextBlocks stay on the UI thread.
-UIElement MakeButtonContent(const FolderEntry& entry,
-                            double buttonSize,
-                            int folderIndex,
-                            HWND taskbarWnd,
-                            uint32_t iconGeneration) {
-    int iconExtent = g_settings.buttonIconSize > 0
-                         ? g_settings.buttonIconSize
-                         : (int)std::lround(buttonSize * 0.545);
-    iconExtent = std::clamp<int>(iconExtent, 8, 128);
-    const int extractSize = iconExtent * 2;
-
-    // Emoji or any other short literal text.
-    if (!entry.icon.empty() && !IconSettingIsFile(entry.icon)) {
-        TextBlock text;
-        text.Text(entry.icon);
-        text.FontFamily(FontFamily(L"Segoe UI Emoji"));
-        text.FontSize(iconExtent * 0.92);
-        text.HorizontalAlignment(HorizontalAlignment::Center);
-        text.VerticalAlignment(VerticalAlignment::Center);
-        text.TextAlignment(TextAlignment::Center);
-        text.IsTextSelectionEnabled(false);
-        return text;
-    }
-
-    if (!entry.icon.empty()) {
-        std::wstring icon = entry.icon;
-        bool isImageFile = false;
-        for (PCWSTR ext : {L".ico", L".png", L".jpg", L".jpeg", L".bmp",
-                           L".gif", L".tif", L".tiff"}) {
-            size_t len = wcslen(ext);
-            if (icon.size() > len &&
-                _wcsicmp(icon.c_str() + icon.size() - len, ext) == 0) {
-                isImageFile = true;
-                break;
-            }
-        }
-
-        if (isImageFile) {
-            // BitmapImage decodes off-thread; skip sync shell extraction.
-            if (!IsLikelyRemotePath(icon)) {
-                try {
-                    WCHAR url[2048];
-                    DWORD urlLen = ARRAYSIZE(url);
-                    // S_OK only: a real local path was converted to a file://
-                    // URL. UrlCreateFromPathW returns S_FALSE and copies the
-                    // input through unchanged when it is already a URL, so
-                    // SUCCEEDED() here would let an http(s) icon value reach
-                    // BitmapImage.UriSource and have XAML fetch it from a
-                    // remote server inside explorer.exe. The value is not
-                    // always the user's own either — ReadFolderCustomIcon
-                    // takes IconResource straight out of a folder's
-                    // desktop.ini when it is pinned from Explorer.
-                    if (UrlCreateFromPathW(icon.c_str(), url, &urlLen, 0) ==
-                        S_OK) {
-                        Image image;
-                        image.Width(iconExtent);
-                        image.Height(iconExtent);
-                        image.Stretch(Stretch::Uniform);
-                        image.HorizontalAlignment(HorizontalAlignment::Center);
-                        image.VerticalAlignment(VerticalAlignment::Center);
-                        winrt::Windows::UI::Xaml::Media::Imaging::BitmapImage
-                            bitmap;
-                        bitmap.DecodePixelWidth(extractSize);
-                        bitmap.UriSource(winrt::Windows::Foundation::Uri(
-                            winrt::hstring(url)));
-                        image.Source(bitmap);
-                        return image;
-                    }
-                } catch (...) {
-                }
-            }
-            return MakeFolderEmojiFallback(iconExtent);
-        }
-
-        // app.exe,0 / .ico via SHDefExtractIcon — never on the UI thread.
-        RequestButtonIcon(icon, extractSize, folderIndex, iconGeneration,
-                          taskbarWnd, /*resourceSpec=*/true);
-        return MakeFolderEmojiFallback(iconExtent);
-    }
-
-    // No icon configured: folder shell icon on the scan worker. Never call
-    // GetShellIconForPath here. resolvedPath / likelyRemote are filled by
-    // ResolvePendingFolderEntries on this taskbar STA (or the scan STA).
-    if (!entry.path.empty() && !entry.likelyRemote) {
-        const std::wstring& iconPath =
-            !entry.resolvedPath.empty() ? entry.resolvedPath : entry.path;
-        // Unresolved shell: still OK — the scan worker ResolveFolderPath's it.
-        RequestButtonIcon(iconPath, extractSize, folderIndex, iconGeneration,
-                          taskbarWnd, /*resourceSpec=*/false);
-    }
-    return MakeFolderEmojiFallback(iconExtent);
-}
 
 RECT GetElementScreenRect(FrameworkElement const& element) {
     RECT rect{};
@@ -5638,451 +6304,11 @@ FrameworkElement FindTaskbarRepeater(Grid const& rootGrid) {
     return FindChildByName(rootGrid, L"TaskbarFrameRepeater", 6);
 }
 
-// Matching a live taskbar button means the folder buttons stay the right size
-// across taskbar-size changes, DPI changes, and the small-icons setting.
-void UpdateButtonSizeFromTaskbar(FrameworkElement const& repeater,
-                                 double* outWidth,
-                                 double* outHeight) {
-    std::vector<FrameworkElement> children;
-    EnumRepeaterChildren(repeater, &children);
-
-    double width = 0.0;
-    double height = 0.0;
-
-    for (const auto& child : children) {
-        auto className = winrt::get_class_name(child);
-        if (className != L"Taskbar.TaskListButton") {
-            continue;
-        }
-        if (child.ActualWidth() > 1.0 && child.ActualHeight() > 1.0) {
-            width = child.ActualWidth();
-            height = child.ActualHeight();
-            break;
-        }
-    }
-
-    if (width <= 1.0) {
-        for (const auto& child : children) {
-            auto className = winrt::get_class_name(child);
-            if (className != L"Taskbar.ExperienceToggleButton" &&
-                className != L"Taskbar.AugmentedEntryPointButton") {
-                continue;
-            }
-            if (child.ActualWidth() > 1.0 && child.ActualHeight() > 1.0) {
-                width = child.ActualWidth();
-                height = child.ActualHeight();
-                break;
-            }
-        }
-    }
-
-    if (width <= 1.0 || height <= 1.0) {
-        return;
-    }
-
-    if (outWidth) {
-        *outWidth = width;
-    }
-    if (outHeight) {
-        *outHeight = height;
-    }
-}
-
-FrameworkElement ResolveAnchor(FrameworkElement const& repeater,
-                               Grid const& rootGrid) {
-    std::vector<FrameworkElement> children;
-    EnumRepeaterChildren(repeater, &children);
-    if (children.empty()) {
-        return nullptr;
-    }
-
-    bool before = g_settings.position != L"afterApps";
-
-    auto findByClass = [&](PCWSTR className, int skip) -> FrameworkElement {
-        int seen = 0;
-        for (const auto& child : children) {
-            if (winrt::get_class_name(child) != className) {
-                continue;
-            }
-            if (seen++ < skip) {
-                continue;
-            }
-            return child;
-        }
-        return nullptr;
-    };
-
-    if (g_settings.anchor == L"widgets") {
-        if (auto found = findByClass(L"Taskbar.AugmentedEntryPointButton", 0)) {
-            return found;
-        }
-    } else if (g_settings.anchor == L"taskView") {
-        if (auto found = findByClass(L"Taskbar.ExperienceToggleButton", 1)) {
-            return found;
-        }
-    } else if (g_settings.anchor == L"start") {
-        if (auto found = findByClass(L"Taskbar.ExperienceToggleButton", 0)) {
-            return found;
-        }
-    }
-
-    // Auto: the outermost app button on the requested side. The repeater's
-    // realized children are not in layout order, so compare actual positions.
-    FrameworkElement best = nullptr;
-    double bestX = 0.0;
-    for (const auto& child : children) {
-        if (winrt::get_class_name(child) != L"Taskbar.TaskListButton") {
-            continue;
-        }
-        if (child.Visibility() != Visibility::Visible ||
-            child.ActualWidth() <= 1.0) {
-            continue;
-        }
-        try {
-            auto point =
-                child.TransformToVisual(rootGrid).TransformPoint({0, 0});
-            // A button mid-realization (window just opened/closed) reports
-            // ActualWidth before Arrange has placed it, landing at X == 0.
-            // That looks like the leftmost button and would get adopted as
-            // anchor, carving the gap at the wrong spot. Skip unplaced ones.
-            if (point.X <= 0.5) {
-                continue;
-            }
-            if (!best || (before ? point.X < bestX : point.X > bestX)) {
-                best = child;
-                bestX = point.X;
-            }
-        } catch (...) {
-        }
-    }
-    if (best) {
-        return best;
-    }
-
-    for (PCWSTR className : {L"Taskbar.AugmentedEntryPointButton",
-                             L"Taskbar.ExperienceToggleButton"}) {
-        if (auto found = findByClass(className, 0)) {
-            return found;
-        }
-    }
-
-    return nullptr;
-}
-
-// Counts the placed, visible app buttons and measures the strip's left/right
-// extent. The repeater's realized-child count cannot stand in for either:
-// ItemsRepeater recycles containers, so a window opening or closing leaves that
-// count unchanged while the strip visibly grows and shrinks. `exclude` leaves
-// out a button being adopted as the anchor, so the clearance check has the rest
-// of the strip - all of it settled - as its reference.
-int CensusAppStrip(FrameworkElement const& repeater, Grid const& rootGrid,
-                   double* stripLeft, double* stripRight,
-                   FrameworkElement const& exclude = nullptr) {
-    std::vector<FrameworkElement> children;
-    EnumRepeaterChildren(repeater, &children);
-    int count = 0;
-    double left = 0.0;
-    double right = 0.0;
-    for (const auto& child : children) {
-        try {
-            if (exclude && child == exclude) {
-                continue;
-            }
-            if (winrt::get_class_name(child) != L"Taskbar.TaskListButton" ||
-                child.Visibility() != Visibility::Visible ||
-                child.ActualWidth() <= 1.0) {
-                continue;
-            }
-            double x =
-                child.TransformToVisual(rootGrid).TransformPoint({0, 0}).X;
-            if (x <= 0.5) {
-                continue;
-            }
-            if (!count || x < left) {
-                left = x;
-            }
-            if (!count || x + child.ActualWidth() > right) {
-                right = x + child.ActualWidth();
-            }
-            count++;
-        } catch (...) {
-        }
-    }
-    *stripLeft = left;
-    *stripRight = right;
-    return count;
-}
-
-double DesiredHostWidth(TaskbarHost* host) {
-    if (!host || host->buttonStates.empty()) {
-        return 0.0;
-    }
-    return host->buttonWidth * (double)host->buttonStates.size();
-}
-
-// Windows 11's point-to-point shift — the profile its own app icons use when
-// they glide sideways to fill a freed slot or clear space for a new one.
-// 250ms on cubic-bezier(0.55, 0.55, 0, 1): holds initial speed through the
-// first half, then drops momentum just before landing.
-constexpr int kHostGridSlideMs = 250;
-constexpr float kSlideEaseCp1X = 0.55f;
-constexpr float kSlideEaseCp1Y = 0.55f;
-constexpr float kSlideEaseCp2X = 0.0f;
-constexpr float kSlideEaseCp2Y = 1.0f;
-
-// Layout reports the new target well before the taskbar's own icons visibly
-// start moving, so the slide has to be held back to fall in step with them.
-// Closing needs the longer wait (exit animation before survivors fill the
-// slot); opening barely needs any. Open vs close is inferred from which way
-// the gap moves on a centered strip — see AnimateHostGridLeftTo. Both delays
-// are tuned by eye against the real icons, so they are just knobs.
-constexpr int kSlideDelayOpenMs = 50;
-constexpr int kSlideDelayCloseMs = 350;
-
-// A retarget arriving within this long of the previous one means the strip is
-// churning rather than settling - windows opening and closing faster than the
-// slide itself. Comfortably longer than one slide, so a single open or close
-// still gets its full sync delay.
-constexpr ULONGLONG kChurnWindowMs = 400;
-
-// Smallest target change worth a slide. Anything under this is a sample of the
-// anchor taken part-way through Windows' own re-centre rather than a new
-// resting place, and re-aiming at it just restarts the storyboard. Well under
-// the half-button (~22px) that a real open or close moves the anchor by, so no
-// genuine move is swallowed.
-constexpr double kSlideNoiseFloor = 4.0;
-
-// Slides hostGrid to newLeft by animating its RenderTransform.
-//
-// Two earlier approaches failed here and are worth not repeating. A XAML
-// RepositionThemeTransition never fired reliably for a plain Margin set on a
-// standalone Grid outside a panel's own child-change pipeline. Animating the
-// element visual's composition Offset.X didn't survive either, because XAML
-// owns Visual.Offset and rewrites it on every arrange pass.
-//
-// The deeper problem was positioning by Margin at all: hostGrid is a child
-// of rootGrid's column 0, so its Margin fed that column's measure. Each
-// reposition therefore changed the taskbar's measured content width, which
-// re-centered the app strip, which moved the anchor, which yielded a new
-// target — a feedback loop that retargeted the animation every layout pass
-// and looked like the overlay resisting its own movement. Layout ignores a
-// RenderTransform completely, which breaks the loop, and TransformToVisual
-// still accounts for it so ComputeHoverAnchorRect needs no changes.
-//
-// Retargeting mid-slide is handled by pinning the transform's base value to
-// wherever the animation currently has it before starting the next one (a
-// bare Storyboard.Stop would snap back to the base value). The replacement
-// keyframe has no From, so XAML interpolates from that current value —
-// a seamless re-aim toward the new target rather than a restart — and the
-// start delay is skipped because the motion is already underway.
-//
-// Animating a TranslateTransform's X keeps this an *independent* animation:
-// XAML hands transform animations to the compositor, so they run off the UI
-// thread at the monitor's refresh tick and don't stutter when the taskbar
-// thread is busy.
-void AnimateHostGridLeftTo(TaskbarHost* host, double newLeft,
-                           double anchorX = -1.0) {
-    if (!host || !host->hostGrid || !host->hostTranslate) {
-        return;
-    }
-    double previousLeft = host->currentLeft;
-    // Noise floor, not a 1px epsilon. LayoutUpdated fires on every pass of
-    // Windows' own ~250ms re-centre, and the anchor is read mid-flight on each
-    // one, so consecutive targets land a few px apart with nothing having
-    // actually happened. At 1px each of those noise reads cleared the guard and
-    // restarted a full 250ms storyboard, which is most of what churn is.
-    if (std::abs(previousLeft - newLeft) < kSlideNoiseFloor) {
-        return;
-    }
-
-    ULONGLONG now = GetTickCount64();
-    // Still waiting on its BeginTime — visual hasn't started moving, so the
-    // remaining wait carries over rather than resetting to a fresh delay.
-    bool pending = host->slideStoryboard && now < host->slideStartTick;
-    // Already interpolating — re-aim live, no delay of its own.
-    bool animating =
-        host->slideStoryboard && !pending && now < host->slideEndTick;
-
-    // Child-count / width probes lag the layout target on both open and
-    // close, so classify from the move itself. Centered taskbar: opening
-    // grows the app cluster outward, closing shrinks it inward — which way
-    // that shoves our gap depends on beforeApps vs afterApps.
-    bool beforeApps = g_settings.position != L"afterApps";
-    bool isCloseMove =
-        beforeApps ? (newLeft < previousLeft) : (newLeft > previousLeft);
-
-    host->currentLeft = newLeft;
-
-    if (!host->hasPlaced) {
-        host->hasPlaced = true;
-        try {
-            host->hostTranslate.X(newLeft);
-        } catch (...) {
-        }
-        return;
-    }
-
-    // Windows only animates its icons for a settled open or close. Spamming
-    // produces a fresh layout every 100-200ms, so there is no icon slide left
-    // to fall in step with - and waiting out the close delay parks the folder
-    // block on top of icons that have already moved for the whole 350ms. If
-    // the last retarget was recent enough that we are still inside that
-    // window, chase immediately instead.
-    bool churning = host->lastRetargetTick &&
-                    now - host->lastRetargetTick < kChurnWindowMs;
-    // Only an actual retarget counts as churn. Stamping every call armed the
-    // window off a lone settled open too, and since kChurnWindowMs is longer
-    // than kSlideDelayCloseMs, the close that followed it always lost its whole
-    // sync delay - it chased early, landed on icons that hadn't moved yet, and
-    // retargeted again.
-    if (pending || animating) {
-        host->lastRetargetTick = now;
-    }
-
-    int delayMs = 0;
-    if (!animating && !churning) {
-        if (!pending) {
-            host->slideCauseTick = now;
-            host->slideCauseIsClose = isCloseMove;
-        }
-        int causeDelay = host->slideCauseIsClose ? kSlideDelayCloseMs
-                                                 : kSlideDelayOpenMs;
-        long long remain =
-            (long long)host->slideCauseTick + causeDelay - (long long)now;
-        delayMs = remain > 0 ? (int)remain : 0;
-    }
-
-    if (host->anchorSwapped) {
-        // The anchor teleported to a new button instead of sliding — chase
-        // it now instead of waiting out a sync delay for motion that isn't
-        // happening.
-        host->anchorSwapped = false;
-        delayMs = 0;
-    }
-
-    try {
-        if (host->slideStoryboard) {
-            // Only an actually-moving slide has left the base value behind;
-            // a still-pending one never touched it, so there's nothing to
-            // commit back — doing so anyway would read the frozen pre-delay
-            // value, which is already correct, so this is safe either way.
-            double live = host->hostTranslate.X();
-            host->slideStoryboard.Stop();
-            host->hostTranslate.X(live);
-            host->slideStoryboard = nullptr;
-        }
-
-        auto slideSpan = winrt::Windows::Foundation::TimeSpan{
-            std::chrono::milliseconds(kHostGridSlideMs)};
-
-        // CubicEase can't express an arbitrary bezier, so the curve comes
-        // from a KeySpline on a single spline keyframe instead.
-        KeySpline spline;
-        spline.ControlPoint1({kSlideEaseCp1X, kSlideEaseCp1Y});
-        spline.ControlPoint2({kSlideEaseCp2X, kSlideEaseCp2Y});
-
-        SplineDoubleKeyFrame frame;
-        frame.KeyTime(KeyTime{slideSpan});
-        frame.Value(newLeft);
-        frame.KeySpline(spline);
-
-        DoubleAnimationUsingKeyFrames anim;
-        anim.KeyFrames().Append(frame);
-        // Duration is a struct, not a TimeSpan, and its default type is
-        // Automatic (a flat 1s) — the type has to say TimeSpan for the
-        // value to be honoured.
-        anim.Duration(Duration{slideSpan, DurationType::TimeSpan});
-        if (delayMs > 0) {
-            anim.BeginTime(winrt::Windows::Foundation::TimeSpan{
-                std::chrono::milliseconds(delayMs)});
-        }
-
-        Storyboard sb;
-        sb.Children().Append(anim);
-        Storyboard::SetTarget(anim, host->hostTranslate);
-        Storyboard::SetTargetProperty(anim, L"X");
-        host->slideStoryboard = sb;
-        sb.Begin();
-
-        host->slideStartTick = now + delayMs;
-        host->slideEndTick = now + delayMs + kHostGridSlideMs;
-    } catch (...) {
-        // Animation unavailable for whatever reason — still get the element
-        // to the right place, just without the slide. Reads as a one-frame
-        // stutter rather than a wrong position.
-        try {
-            host->slideStoryboard = nullptr;
-            host->hostTranslate.X(newLeft);
-        } catch (...) {
-        }
-    }
-}
-
-void RestoreAnchorMargin(TaskbarHost* host) {
-    if (!host) {
-        return;
-    }
-    if (host->anchor && host->hasAnchorOriginalMargin) {
-        try {
-            // Paired with the reserve written onto the incoming anchor: both
-            // land in the same layout pass, so the strip is never left a pass
-            // either double-reserved or un-reserved.
-            host->anchor.Margin(host->anchorOriginalMargin);
-        } catch (...) {
-        }
-    }
-    host->anchor = nullptr;
-    host->hasAnchorOriginalMargin = false;
-}
-
-void AdoptAnchor(TaskbarHost* host, FrameworkElement const& anchor) {
-    if (!host) {
-        return;
-    }
-    if (host->anchor == anchor) {
-        return;
-    }
-    RestoreAnchorMargin(host);
-    host->anchor = anchor;
-    if (anchor) {
-        try {
-            host->anchorOriginalMargin = anchor.Margin();
-            host->hasAnchorOriginalMargin = true;
-        } catch (...) {
-            host->hasAnchorOriginalMargin = false;
-        }
-    }
-}
-
-TaskbarHost* FindTaskbarHost(HWND hwnd) {
-    if (!g_taskbarHosts) {
-        return nullptr;
-    }
-    for (auto& host : *g_taskbarHosts) {
-        if (host && host->hwnd == hwnd) {
-            return host.get();
-        }
-    }
-    return nullptr;
-}
-
-TaskbarHost* FindTaskbarHostByRootGrid(Grid const& rootGrid) {
-    if (!g_taskbarHosts) {
-        return nullptr;
-    }
-    for (auto& host : *g_taskbarHosts) {
-        if (host && host->trackedRootGrid == rootGrid) {
-            return host.get();
-        }
-    }
-    return nullptr;
-}
-
 // The vertical extent comes from the taskbar window rather than the button, so
 // the corridor covers the whole taskbar height under the button. Horizontally
 // the XAML transform is trusted only if it lands inside the taskbar; otherwise
 // the cursor position, which is definitely over the button, is used instead.
-RECT ComputeHoverAnchorRect(Button const& button) {
+RECT ComputeHoverAnchorRect(FrameworkElement const& button) {
     RECT taskbarRect{};
     if (!g_taskbarWnd || !GetWindowRect(g_taskbarWnd, &taskbarRect)) {
         return RECT{};
@@ -6136,8 +6362,13 @@ std::wstring FolderNameForButton(int folderIndex) {
     return g_settings.folders[folderIndex].name;
 }
 
+// `button` is either the mod's own overlay Button or a real Taskbar.TaskListButton
+// once hover is bound to the genuine pinned item, so it is taken as the common
+// base. ComputeHoverAnchorRect only needs TransformToVisual, which both provide —
+// and on the real button that transform is the one Windows is itself animating,
+// which is the whole point of the switch.
 void OnPointerEnteredButton(int folderIndex,
-                             Button const& button,
+                             FrameworkElement const& button,
                              HWND taskbarWnd) {
     if (g_unloading) {
         return;
@@ -6175,6 +6406,185 @@ void OnPointerEnteredButton(int folderIndex,
     SetTimer(hWnd, kOpenTimerId, (UINT)g_settings.hoverDelayMs, nullptr);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// Hover on the real pinned buttons
+//
+// The genuine taskbar item is a Taskbar.TaskListButton that Windows creates,
+// lays out and animates. Attaching hover to it — rather than to a drawn stand-in
+// parked next to it — is what makes the grid open in exactly the right place
+// while the strip is mid-animation: TransformToVisual is read once, at open
+// time, from the element the compositor is actually moving.
+//
+// Matching resolves the button's label through the shell's own pinned copies to
+// an AppUserModelID, and from there to the folder entry. Comparing the label
+// straight against the name the mod would like to use does not work: pinning
+// copies the shortcut, so a pinned item keeps the name it had when it was
+// pinned even after the source is renamed, and the two drift apart.
+//
+// The label is still the only handle XAML gives us on a taskbar button without
+// hooking the shell's group type, but going through the pinned copy means the
+// comparison is against what is really there rather than what should be.
+
+std::wstring AutomationNameOf(FrameworkElement const& element) {
+    try {
+        auto name = winrt::Windows::UI::Xaml::Automation::AutomationProperties::
+            GetName(element);
+        return std::wstring(name);
+    } catch (...) {
+        return L"";
+    }
+}
+
+// -1 when this button is not one of ours.
+int FolderIndexForTaskListButton(FrameworkElement const& button) {
+    std::wstring label = AutomationNameOf(button);
+    if (label.empty()) {
+        return -1;
+    }
+    std::wstring pinId = Pins::PinIdForLabel(label);
+    if (pinId.empty()) {
+        return -1;
+    }
+    std::lock_guard<std::mutex> lock(g_foldersMutex);
+    for (size_t i = 0; i < g_settings.folders.size(); i++) {
+        if (_wcsicmp(g_settings.folders[i].pinId.c_str(), pinId.c_str()) == 0) {
+            return (int)i;
+        }
+    }
+    // The shell has a pin the loaded folder list knows nothing about. Normally
+    // means g_settings was built before the pin ids existed — see the reload
+    // Pins::Reconcile asks for when it generates them.
+    Wh_Log(L"Pins: '%s' resolves to pin %s, but no loaded folder claims it",
+           label.c_str(), pinId.c_str());
+    return -1;
+}
+
+void OnPointerExitedButton();
+
+// Drops every handler this host attached to a real taskbar button. Must run
+// before rebinding: ItemsRepeater recycles its containers, so the element that
+// was our button a moment ago may now be showing an unrelated app.
+void UnbindPinButtons(TaskbarHost* host) {
+    for (auto& binding : host->pinBindings) {
+        if (!binding.button) {
+            continue;
+        }
+        try {
+            if (binding.enterToken.value) {
+                binding.button.PointerEntered(binding.enterToken);
+            }
+            if (binding.exitToken.value) {
+                binding.button.PointerExited(binding.exitToken);
+            }
+        } catch (...) {
+            // The element can already be torn down; nothing to release then.
+        }
+    }
+    host->pinBindings.clear();
+}
+
+// Attaches hover to whichever realized taskbar buttons are ours right now.
+void RebindPinButtons(TaskbarHost* host) {
+    if (!host || !host->cachedRepeater || g_unloading) {
+        return;
+    }
+
+    std::vector<FrameworkElement> children;
+    EnumRepeaterChildren(host->cachedRepeater, &children);
+
+    // LayoutUpdated fires constantly — on every animation frame of every icon —
+    // and almost none of those passes change which containers exist. Rebinding
+    // each time would detach and reattach handlers dozens of times a second for
+    // no reason, so compare identities first and do nothing in the common case.
+    std::vector<void*> identities;
+    identities.reserve(children.size());
+    for (const auto& child : children) {
+        identities.push_back(winrt::get_abi(child));
+    }
+    // The map is published by the pin worker after a reconcile, which is a
+    // different thread and usually lands when the taskbar is otherwise idle. A
+    // pure identity check would then never rebind — the containers did not
+    // change, only our knowledge of what they mean did.
+    uint32_t labels = Pins::g_labelGeneration.load(std::memory_order_acquire);
+    if (identities == host->lastRealizedChildren &&
+        labels == host->lastLabelGeneration) {
+        return;
+    }
+    host->lastRealizedChildren = std::move(identities);
+    host->lastLabelGeneration = labels;
+
+    UnbindPinButtons(host);
+
+    HWND taskbarWnd = host->hwnd;
+    int matched = 0;
+    for (const auto& child : children) {
+        if (!child || winrt::get_class_name(child) !=
+                          L"Taskbar.TaskListButton") {
+            continue;
+        }
+        int folderIndex = FolderIndexForTaskListButton(child);
+        if (folderIndex < 0) {
+            continue;
+        }
+
+        // Explorer's own tooltip echoes the pinned label, which fights the
+        // grid we open on hover with a second, redundant popup naming the
+        // same folder. Suppress it for buttons we've claimed.
+        ToolTipService::SetToolTip(child, nullptr);
+
+        PinBinding binding;
+        binding.button = child;
+        binding.folderIndex = folderIndex;
+        binding.enterToken = child.PointerEntered(
+            [folderIndex, taskbarWnd](
+                winrt::Windows::Foundation::IInspectable const& sender,
+                winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs const&) {
+                Wh_Log(L"Pins: pointer entered folder button %d", folderIndex);
+                if (auto element = sender.try_as<FrameworkElement>()) {
+                    OnPointerEnteredButton(folderIndex, element, taskbarWnd);
+                }
+            });
+        binding.exitToken = child.PointerExited(
+            [](winrt::Windows::Foundation::IInspectable const&,
+               winrt::Windows::UI::Xaml::Input::PointerRoutedEventArgs const&) {
+                OnPointerExitedButton();
+            });
+        host->pinBindings.push_back(std::move(binding));
+        matched++;
+    }
+
+    size_t knownLabels = 0;
+    {
+        std::lock_guard<std::mutex> lock(Pins::g_labelMutex);
+        knownLabels = Pins::g_labelToPinId.size();
+    }
+
+    // Logged on every real rebind pass, not only when the count changes: a
+    // rebind that keeps failing is exactly the case worth seeing, and this only
+    // runs when the container set or the label map actually changed.
+    Wh_Log(L"Pins: hover bound to %d real taskbar button(s) of %zu realized, "
+           L"%zu label(s) known",
+           matched, children.size(), knownLabels);
+
+    // Say what was on the taskbar and what was being looked for — but only once
+    // the label map exists. Before the first reconcile finishes there is
+    // nothing to match against and the dump would be pure noise.
+    if (matched == 0 && knownLabels > 0) {
+        for (const auto& child : children) {
+            if (child &&
+                winrt::get_class_name(child) == L"Taskbar.TaskListButton") {
+                Wh_Log(L"  saw button named '%s'",
+                       AutomationNameOf(child).c_str());
+            }
+        }
+        std::lock_guard<std::mutex> lock(Pins::g_labelMutex);
+        for (const auto& [leaf, pinId] : Pins::g_labelToPinId) {
+            Wh_Log(L"  wanted '%s' (pin %s)", leaf.c_str(), pinId.c_str());
+        }
+    }
+    host->lastPinBindCount = matched;
+}
+
 // Leaving the button cancels a pending delayed open. Closing an already-open
 // cascade is left to OnTick so moving up into the grid does not dismiss it.
 void OnPointerExitedButton() {
@@ -6186,19 +6596,6 @@ void OnPointerExitedButton() {
     if (!g_levelWindows.empty() && g_levelWindows[0]) {
         KillTimer(g_levelWindows[0], kOpenTimerId);
     }
-}
-
-void OnButtonClicked(int folderIndex) {
-    if (!g_settings.openFolderOnClick) {
-        return;
-    }
-    ResolvePendingFolderEntries();
-    std::wstring path = FolderPathForButton(folderIndex);
-    if (path.empty()) {
-        return;
-    }
-    CloseChain();
-    LaunchPath(path);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -6219,6 +6616,7 @@ constexpr int kIdList = 1001;
 constexpr int kIdAdd = 1002;
 constexpr int kIdEdit = 1003;
 constexpr int kIdRemove = 1004;
+constexpr int kIdTogglePin = 1005;
 constexpr int kIdClose = 1008;
 constexpr int kIdHint = 1009;
 
@@ -6239,6 +6637,7 @@ constexpr int kIdEditNameLabel = 1111;
 constexpr int kIdEditPathLabel = 1112;
 constexpr int kIdEditIconLabel = 1113;
 constexpr int kIdEditIconHint = 1114;
+constexpr int kIdEditOpenPath = 1115;
 
 // Every dimension in this window is written at 96 DPI and goes through
 // Scale()/ScaleFor(). explorer.exe is manifested Per-Monitor-DPI-Aware V2 and
@@ -6254,11 +6653,15 @@ constexpr int kTitleBottom = 21;  // Also the top of the path band.
 constexpr int kPathBottom = 3;    // Path band inset from the row bottom.
 constexpr int kPreviewIcon = 32;  // Edit-dialog icon preview.
 constexpr int kPreviewInset = 4;
+// Section caption band, drawn on top of the row that opens a section rather
+// than as a list item of its own — a header that is not an item cannot be
+// selected, arrowed onto, or counted in an index.
+constexpr int kSectionHeader = 24;
 
 // 96-DPI client size of each window, before AdjustWindowRect.
 constexpr int kMainWidth = 476;
 constexpr int kMainHeight = 400;
-constexpr int kEditWidth = 414;
+constexpr int kEditWidth = 470;
 constexpr int kEditHeight = 306;
 
 int Scale(int value, int dpi) {
@@ -6300,15 +6703,175 @@ std::atomic<bool> g_active{false};
 
 // 96-DPI layout of the main window's children.
 constexpr ChildRect kMainLayout[] = {
-    {kIdList, 12, 12, 452, 300},   {kIdAdd, 12, 324, 76, 26},
-    {kIdEdit, 94, 324, 76, 26},    {kIdRemove, 176, 324, 76, 26},
-    {kIdClose, 388, 324, 76, 26},  {kIdHint, 12, 360, 452, 32},
+    {kIdList, 12, 12, 452, 300},      {kIdAdd, 12, 324, 76, 26},
+    {kIdEdit, 94, 324, 76, 26},       {kIdRemove, 176, 324, 76, 26},
+    {kIdTogglePin, 258, 324, 76, 26}, {kIdClose, 388, 324, 76, 26},
+    {kIdHint, 12, 360, 452, 32},
 };
 
 // The store as last read, in listbox order. Manager-thread only.
 std::vector<FolderStore::Entry> g_rows;
 // One icon per row, parallel to g_rows, owned here and freed on rebuild.
 std::vector<HICON> g_rowIcons;
+
+// Defined with the rest of the row commands, below; PopulateList needs it.
+void UpdatePinButton(HWND hWnd);
+
+// True if this row opens a section. g_rows is sorted pinned-first, so the
+// boundary is wherever the flag changes — plus row 0, which opens the first
+// section whichever kind it is.
+bool StartsSection(size_t index) {
+    if (index >= g_rows.size()) {
+        return false;
+    }
+    return index == 0 || g_rows[index].pinned != g_rows[index - 1].pinned;
+}
+
+PCWSTR SectionCaption(bool pinned) {
+    return pinned ? L"On the taskbar" : L"Not pinned";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Dark mode
+//
+// Plain Win32 controls have no dark mode of their own. Three separate things
+// have to agree: DWM paints the caption, uxtheme paints the controls, and the
+// window paints its own background and owner-drawn rows. Miss any one and the
+// window comes out half-light.
+//
+// The theme is read from the same UISettings cache the hover grid uses, so the
+// manager follows the system app theme without a setting of its own.
+
+bool Dark() {
+    return IsDarkTheme();
+}
+
+COLORREF ClrWindow() {
+    return Dark() ? RGB(32, 32, 32) : GetSysColor(COLOR_WINDOW);
+}
+COLORREF ClrWindowText() {
+    return Dark() ? RGB(255, 255, 255) : GetSysColor(COLOR_WINDOWTEXT);
+}
+COLORREF ClrGrayText() {
+    return Dark() ? RGB(155, 155, 155) : GetSysColor(COLOR_GRAYTEXT);
+}
+COLORREF ClrFace() {
+    return Dark() ? RGB(43, 43, 43) : GetSysColor(COLOR_BTNFACE);
+}
+COLORREF ClrHighlight() {
+    return Dark() ? RGB(0, 90, 158) : GetSysColor(COLOR_HIGHLIGHT);
+}
+COLORREF ClrHighlightText() {
+    return Dark() ? RGB(255, 255, 255) : GetSysColor(COLOR_HIGHLIGHTTEXT);
+}
+COLORREF ClrSeparator() {
+    return Dark() ? RGB(64, 64, 64) : RGB(200, 200, 200);
+}
+COLORREF ClrFieldBorder() {
+    return Dark() ? RGB(72, 72, 72) : GetSysColor(COLOR_3DSHADOW);
+}
+
+// WS_EX_CLIENTEDGE is the classic sunken 3D border, drawn in the non-client
+// area from COLOR_3DHIGHLIGHT and friends. Those are light in both themes and
+// nothing in uxtheme repaints them, which is why the edit boxes and the list
+// kept a white ring on a dark window. In dark mode the style is dropped and the
+// border is painted by the parent instead — see DrawFieldBorders.
+DWORD FieldExStyle() {
+    return Dark() ? 0 : WS_EX_CLIENTEDGE;
+}
+
+// The 1px ring around each borderless field. Drawn by the parent because the
+// pixels sit just outside the child, in the parent's own client area — which
+// also means no subclassing and no WM_NCPAINT.
+void DrawFieldBorders(HWND hWnd, HDC dc, const int* ids, size_t count) {
+    HBRUSH brush = CreateSolidBrush(ClrFieldBorder());
+    if (!brush) {
+        return;
+    }
+    for (size_t i = 0; i < count; i++) {
+        HWND child = GetDlgItem(hWnd, ids[i]);
+        if (!child) {
+            continue;
+        }
+        RECT rc{};
+        GetWindowRect(child, &rc);
+        MapWindowPoints(nullptr, hWnd, (LPPOINT)&rc, 2);
+        InflateRect(&rc, 1, 1);
+        FrameRect(dc, &rc, brush);
+    }
+    DeleteObject(brush);
+}
+
+// Background brushes handed back from WM_CTLCOLOR*, which is called on every
+// paint — so they are cached rather than created per message. Freed in
+// Wh_ModUninit alongside g_fontCache; a brush left behind would leak into
+// Explorer on every disable/enable cycle.
+HBRUSH g_windowBrush = nullptr;
+HBRUSH g_faceBrush = nullptr;
+
+HBRUSH WindowBrush() {
+    if (!g_windowBrush) {
+        g_windowBrush = CreateSolidBrush(ClrWindow());
+    }
+    return g_windowBrush;
+}
+
+HBRUSH FaceBrush() {
+    if (!g_faceBrush) {
+        g_faceBrush = CreateSolidBrush(ClrFace());
+    }
+    return g_faceBrush;
+}
+
+// Dark rendering is per window and has to be asked for before the control
+// paints. AllowDarkModeForWindow is uxtheme ordinal 133 — undocumented, and the
+// same call every dark-mode Win32 app makes.
+//
+// ponytail: if a future build drops or renumbers the ordinal, GetProcAddress
+// returns null and the controls simply stay light. Nothing else breaks, so this
+// is not worth a version check.
+void AllowDarkModeForWindow(HWND hWnd, bool allow) {
+    using Fn = BOOL(WINAPI*)(HWND, BOOL);
+    static Fn fn = []() -> Fn {
+        HMODULE uxtheme = GetModuleHandleW(L"uxtheme.dll");
+        return uxtheme ? (Fn)GetProcAddress(uxtheme, MAKEINTRESOURCEA(133))
+                       : nullptr;
+    }();
+    if (fn) {
+        fn(hWnd, allow);
+    }
+}
+
+// Applied to the window and every child it already has, so it runs at the end
+// of WM_CREATE rather than before the controls exist.
+void ApplyTheme(HWND hWnd) {
+    BOOL dark = Dark();
+    AllowDarkModeForWindow(hWnd, dark != FALSE);
+    // DWMWA_USE_IMMERSIVE_DARK_MODE. Named rather than the literal 20 so the
+    // intent survives; the attribute is documented from Windows 11 on.
+    DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &dark,
+                          sizeof(dark));
+    EnumChildWindows(
+        hWnd,
+        [](HWND child, LPARAM darkParam) -> BOOL {
+            BOOL childDark = (BOOL)darkParam;
+            AllowDarkModeForWindow(child, childDark != FALSE);
+            SetWindowTheme(child, childDark ? L"DarkMode_Explorer" : nullptr,
+                           nullptr);
+            return TRUE;
+        },
+        (LPARAM)dark);
+}
+
+// The one WM_CTLCOLOR* answer every control here wants: our text colours on our
+// background, and the matching brush so the control fills with it. `onFace` is
+// for the ones sitting on the window itself (labels, buttons) rather than in a
+// white field (edits, the listbox).
+LRESULT ThemedCtlColor(HDC dc, bool onFace) {
+    SetTextColor(dc, ClrWindowText());
+    SetBkColor(dc, onFace ? ClrFace() : ClrWindow());
+    return (LRESULT)(onFace ? FaceBrush() : WindowBrush());
+}
 
 // Registers one of the manager's window classes against the current DLL.
 // RegisterModClass handles a stale registration left by a previous load.
@@ -6384,6 +6947,42 @@ void ApplyUiFont(HWND parent, int dpi) {
         (LPARAM)UiFont(dpi));
 }
 
+// A single-line edit control centers its text within whatever height it is
+// given, but the fixed row heights in the layout tables are taller than the
+// UI font needs — the extra room lands below the text rather than split
+// evenly, since the control's own centering math is anchored to its internal
+// leading. Shrinking the control to the font's real line height and
+// recentering it in its original slot removes that slack instead of fighting
+// the control's own centering.
+void CenterSingleLineFields(HWND hWnd, int dpi, const int* ids, size_t count) {
+    HDC dc = GetDC(hWnd);
+    HFONT old = (HFONT)SelectObject(dc, UiFont(dpi));
+    TEXTMETRICW tm{};
+    GetTextMetricsW(dc, &tm);
+    SelectObject(dc, old);
+    ReleaseDC(hWnd, dc);
+
+    int desired = tm.tmHeight + Scale(6, dpi);
+    for (size_t i = 0; i < count; i++) {
+        HWND field = GetDlgItem(hWnd, ids[i]);
+        if (!field) {
+            continue;
+        }
+        RECT rc{};
+        GetWindowRect(field, &rc);
+        MapWindowPoints(nullptr, hWnd, (LPPOINT)&rc, 2);
+        int slot = rc.bottom - rc.top;
+        int height = std::min(desired, slot);
+        int top = rc.top + (slot - height) / 2;
+        MoveWindow(field, rc.left, top, rc.right - rc.left, height, TRUE);
+        // A single-line edit only recomputes where it vertically centers
+        // its text in response to WM_SETFONT, not to a plain resize — so
+        // without resending it here the control keeps centering against the
+        // slot's original, taller height.
+        SendMessageW(field, WM_SETFONT, (WPARAM)UiFont(dpi), TRUE);
+    }
+}
+
 // The icon a row should show: its configured icon spec if it has one that is
 // a file/resource, otherwise the folder's own shell icon. Emoji icons have no
 // HICON — those are drawn as text instead, so this returns null for them.
@@ -6427,11 +7026,33 @@ void PopulateList(HWND hWnd) {
         return;
     }
     int dpi = DpiOf(hWnd);
-    int selected = (int)SendMessageW(list, LB_GETCURSEL, 0, 0);
+    // Kept by path rather than by index: the rows are sorted by name, so an
+    // edit that renames a folder — or a pin toggle, once the row order is no
+    // longer the store's — can move the selected row somewhere else.
+    int previous = (int)SendMessageW(list, LB_GETCURSEL, 0, 0);
+    std::wstring previousPath;
+    if (previous >= 0 && previous < (int)g_rows.size()) {
+        previousPath = g_rows[previous].path;
+    }
 
     SendMessageW(list, LB_RESETCONTENT, 0, 0);
     FreeRowIcons();
     g_rows = FolderStore::Read();
+
+    // The taskbar owns button order now — it is set by dragging the buttons
+    // themselves — so store order says nothing a reader of this list would want.
+    // Pinned first so the two sections are contiguous, then by name within each
+    // so a folder is findable. StrCmpLogicalW rather than a plain compare, so
+    // "Folder 2" lands before "Folder 10" the way Explorer sorts.
+    std::sort(g_rows.begin(), g_rows.end(),
+              [](const FolderStore::Entry& a, const FolderStore::Entry& b) {
+                  if (a.pinned != b.pinned) {
+                      return a.pinned;
+                  }
+                  const std::wstring& an = a.name.empty() ? a.path : a.name;
+                  const std::wstring& bn = b.name.empty() ? b.path : b.name;
+                  return StrCmpLogicalW(an.c_str(), bn.c_str()) < 0;
+              });
 
     for (const auto& entry : g_rows) {
         g_rowIcons.push_back(IconForEntry(entry, Scale(kRowIconSize, dpi)));
@@ -6441,20 +7062,33 @@ void PopulateList(HWND hWnd) {
     }
 
     if (!g_rows.empty()) {
-        int last = (int)g_rows.size() - 1;
-        if (selected < 0) {
-            selected = 0;
+        int selected = -1;
+        if (!previousPath.empty()) {
+            for (size_t i = 0; i < g_rows.size(); i++) {
+                if (FolderStore::SamePath(g_rows[i].path, previousPath)) {
+                    selected = (int)i;
+                    break;
+                }
+            }
         }
-        SendMessageW(list, LB_SETCURSEL, selected < last ? selected : last, 0);
+        // Gone (removed, or its path was edited): fall back to wherever the
+        // selection was, clamped. Only when something was selected before -
+        // a deliberate click into empty space (previous < 0) stays cleared
+        // rather than snapping back to row 0.
+        if (selected < 0 && previous >= 0) {
+            int last = (int)g_rows.size() - 1;
+            selected = previous < last ? previous : last;
+        }
+        if (selected >= 0) {
+            SendMessageW(list, LB_SETCURSEL, selected, 0);
+        }
     }
 
     bool any = !g_rows.empty();
-    for (int id : {kIdEdit, kIdRemove}) {
-        EnableWindow(GetDlgItem(hWnd, id), any);
-    }
+    UpdatePinButton(hWnd);
     SetWindowTextW(GetDlgItem(hWnd, kIdHint),
-                   any ? L"Drag a row to reorder the taskbar buttons. "
-                         L"Double-click to open a folder."
+                   any ? L"Drag the buttons on the taskbar to reorder them. "
+                         L"Double-click a row to edit it."
                        : L"No folders yet. Add one here, or right-click any "
                          L"folder in Explorer and pick Taskbar Folders > Pin.");
     InvalidateRect(list, nullptr, TRUE);
@@ -6479,21 +7113,6 @@ void RefreshAfterStoreChange(HWND hWnd) {
     PopulateList(hWnd);
 }
 
-// True if the store still matches the rows on screen, one for one and in the
-// same order. A reorder commits by index, so it has to be abandoned if the
-// store moved underneath the window (an Explorer pin, a taskbar unpin).
-bool StoreMatchesRows(const std::vector<FolderStore::Entry>& stored) {
-    if (stored.size() != g_rows.size()) {
-        return false;
-    }
-    for (size_t i = 0; i < stored.size(); i++) {
-        if (!FolderStore::SamePath(stored[i].path, g_rows[i].path)) {
-            return false;
-        }
-    }
-    return true;
-}
-
 void DrawRow(LPDRAWITEMSTRUCT dis) {
     if (dis->itemID == (UINT)-1 || dis->itemID >= g_rows.size()) {
         return;
@@ -6505,8 +7124,38 @@ void DrawRow(LPDRAWITEMSTRUCT dis) {
 
     HDC dc = dis->hDC;
     RECT rc = dis->rcItem;
-    FillRect(dc, &rc, GetSysColorBrush(selected ? COLOR_HIGHLIGHT
-                                                : COLOR_WINDOW));
+
+    // A section-opening row is measured one caption band taller than the rest.
+    // The caption is painted first, on the window background, and then the row
+    // proper is drawn in what is left — so the selection highlight stops at the
+    // caption instead of swallowing it.
+    if (StartsSection(dis->itemID)) {
+        RECT band{rc.left, rc.top, rc.right, rc.top + Scale(kSectionHeader, dpi)};
+        HBRUSH bg = CreateSolidBrush(ClrWindow());
+        FillRect(dc, &band, bg);
+        DeleteObject(bg);
+
+        RECT text{band.left + Scale(kIconLeft, dpi), band.top, band.right,
+                  band.bottom};
+        SetBkMode(dc, TRANSPARENT);
+        SetTextColor(dc, ClrGrayText());
+        DrawTextW(dc, SectionCaption(entry.pinned), -1, &text,
+                  DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
+
+        // Hairline under the caption, so the two groups read as separate lists
+        // rather than one list with a label floating in it.
+        RECT rule{band.left + Scale(kIconLeft, dpi), band.bottom - 1,
+                  band.right - Scale(kIconLeft, dpi), band.bottom};
+        HBRUSH line = CreateSolidBrush(ClrSeparator());
+        FillRect(dc, &rule, line);
+        DeleteObject(line);
+
+        rc.top = band.bottom;
+    }
+
+    HBRUSH rowBg = CreateSolidBrush(selected ? ClrHighlight() : ClrWindow());
+    FillRect(dc, &rc, rowBg);
+    DeleteObject(rowBg);
 
     int iconLeft = rc.left + Scale(kIconLeft, dpi);
 
@@ -6521,8 +7170,7 @@ void DrawRow(LPDRAWITEMSTRUCT dis) {
         RECT iconRect{iconLeft, iconTop, iconLeft + iconSize,
                       iconTop + iconSize};
         SetBkMode(dc, TRANSPARENT);
-        SetTextColor(dc, GetSysColor(selected ? COLOR_HIGHLIGHTTEXT
-                                              : COLOR_WINDOWTEXT));
+        SetTextColor(dc, selected ? ClrHighlightText() : ClrWindowText());
         DrawTextW(dc, entry.icon.c_str(), -1, &iconRect,
                   DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
     }
@@ -6532,27 +7180,27 @@ void DrawRow(LPDRAWITEMSTRUCT dis) {
     int bandSplit = rc.top + Scale(kTitleBottom, dpi);
     SetBkMode(dc, TRANSPARENT);
 
+    // No "(not pinned)" suffix any more — the section the row sits in says it.
     std::wstring title = entry.name.empty() ? entry.path : entry.name;
-    if (!entry.pinned) {
-        title += L"   (not pinned)";
-    }
     RECT titleRect{textLeft, rc.top + Scale(kTitleTop, dpi), textRight,
                    bandSplit};
-    SetTextColor(dc, GetSysColor(selected ? COLOR_HIGHLIGHTTEXT
-                                          : COLOR_WINDOWTEXT));
+    SetTextColor(dc, selected ? ClrHighlightText() : ClrWindowText());
     DrawTextW(dc, title.c_str(), -1, &titleRect,
               DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS |
                   DT_NOPREFIX);
 
     RECT pathRect{textLeft, bandSplit, textRight,
                   rc.bottom - Scale(kPathBottom, dpi)};
-    SetTextColor(dc, GetSysColor(selected ? COLOR_HIGHLIGHTTEXT
-                                          : COLOR_GRAYTEXT));
+    SetTextColor(dc, selected ? ClrHighlightText() : ClrGrayText());
     DrawTextW(dc, entry.path.c_str(), -1, &pathRect,
               DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_PATH_ELLIPSIS |
                   DT_NOPREFIX);
 
-    if (dis->itemState & ODS_FOCUS) {
+    // The listbox keeps a caret/focus index even after LB_SETCURSEL(-1)
+    // clears the selection, so ODS_FOCUS alone would leave a focus rect
+    // behind on a deliberately deselected row. Tying it to ODS_SELECTED too
+    // means the rect only ever appears on the actually-selected row.
+    if ((dis->itemState & ODS_FOCUS) && selected) {
         DrawFocusRect(dc, &rc);
     }
 }
@@ -6646,19 +7294,20 @@ struct EditContext {
 // can re-run the same table.
 constexpr ChildRect kEditLayout[] = {
     {kIdEditNameLabel, 14, 14, 300, 16},
-    {kIdEditName, 14, 32, 386, 24},
+    {kIdEditName, 14, 32, 442, 24},
     {kIdEditPathLabel, 14, 62, 300, 16},
-    {kIdEditPath, 14, 80, 300, 24},
-    {kIdEditBrowsePath, 322, 80, 78, 24},
+    {kIdEditPath, 14, 80, 286, 24},
+    {kIdEditBrowsePath, 308, 80, 70, 24},
+    {kIdEditOpenPath, 386, 80, 70, 24},
     {kIdEditIconLabel, 14, 110, 300, 16},
-    {kIdEditIcon, 14, 128, 300, 24},
-    {kIdEditBrowseIcon, 322, 128, 78, 24},
-    {kIdEditIconHint, 14, 158, 386, 32},
+    {kIdEditIcon, 14, 128, 286, 24},
+    {kIdEditBrowseIcon, 308, 128, 70, 24},
+    {kIdEditIconHint, 14, 158, 442, 32},
     {kIdEditPinned, 14, 198, 340, 22},
-    {kIdEditPinnedHint, 32, 222, 322, 32},
-    {kIdEditPreview, 360, 196, 40, 40},
-    {kIdEditOk, 222, 266, 86, 26},
-    {kIdEditCancel, 314, 266, 86, 26},
+    {kIdEditPinnedHint, 32, 222, 378, 32},
+    {kIdEditPreview, 416, 196, 40, 40},
+    {kIdEditOk, 278, 266, 86, 26},
+    {kIdEditCancel, 370, 266, 86, 26},
 };
 
 std::wstring GetControlText(HWND hWnd, int id) {
@@ -6704,16 +7353,18 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
                 int id;
             };
             const Spec specs[] = {
-                {L"STATIC", L"Name", 0, 0, kIdEditNameLabel},
-                {L"EDIT", L"", WS_TABSTOP | ES_AUTOHSCROLL, WS_EX_CLIENTEDGE,
+                {L"STATIC", L"Name", SS_NOTIFY, 0, kIdEditNameLabel},
+                {L"EDIT", L"", WS_TABSTOP | ES_AUTOHSCROLL, FieldExStyle(),
                  kIdEditName},
-                {L"STATIC", L"Folder", 0, 0, kIdEditPathLabel},
-                {L"EDIT", L"", WS_TABSTOP | ES_AUTOHSCROLL, WS_EX_CLIENTEDGE,
+                {L"STATIC", L"Folder", SS_NOTIFY, 0, kIdEditPathLabel},
+                {L"EDIT", L"", WS_TABSTOP | ES_AUTOHSCROLL, FieldExStyle(),
                  kIdEditPath},
                 {L"BUTTON", L"Browse...", WS_TABSTOP | BS_PUSHBUTTON, 0,
                  kIdEditBrowsePath},
-                {L"STATIC", L"Icon", 0, 0, kIdEditIconLabel},
-                {L"EDIT", L"", WS_TABSTOP | ES_AUTOHSCROLL, WS_EX_CLIENTEDGE,
+                {L"BUTTON", L"Open", WS_TABSTOP | BS_PUSHBUTTON, 0,
+                 kIdEditOpenPath},
+                {L"STATIC", L"Icon", SS_NOTIFY, 0, kIdEditIconLabel},
+                {L"EDIT", L"", WS_TABSTOP | ES_AUTOHSCROLL, FieldExStyle(),
                  kIdEditIcon},
                 {L"BUTTON", L"Browse...", WS_TABSTOP | BS_PUSHBUTTON, 0,
                  kIdEditBrowseIcon},
@@ -6721,7 +7372,7 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
                  L"Emoji, an .ico / .png file, or a resource such as "
                  L"C:\\Windows\\explorer.exe,0. Leave empty to use the "
                  L"folder's own icon.",
-                 0, 0, kIdEditIconHint},
+                 SS_NOTIFY, 0, kIdEditIconHint},
                 // Pin state lives here rather than as a list button, so that
                 // what "unpinned" actually means — kept, not deleted — is
                 // spelled out right next to the switch.
@@ -6731,7 +7382,7 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
                  L"Unticked keeps this folder in the list but takes its button "
                  L"off the taskbar. Nothing is deleted, and the folder still "
                  L"cannot be added twice.",
-                 0, 0, kIdEditPinnedHint},
+                 SS_NOTIFY, 0, kIdEditPinnedHint},
                 {L"STATIC", L"", SS_OWNERDRAW, 0, kIdEditPreview},
                 {L"BUTTON", L"Save", WS_TABSTOP | BS_DEFPUSHBUTTON, 0,
                  kIdEditOk},
@@ -6752,6 +7403,12 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
             CheckDlgButton(hWnd, kIdEditPinned,
                            ctx->entry.pinned ? BST_CHECKED : BST_UNCHECKED);
             ApplyUiFont(hWnd, DpiOf(hWnd));
+            static constexpr int kSingleLineFields[] = {kIdEditName,
+                                                         kIdEditPath,
+                                                         kIdEditIcon};
+            CenterSingleLineFields(hWnd, DpiOf(hWnd), kSingleLineFields,
+                                   ARRAYSIZE(kSingleLineFields));
+            ApplyTheme(hWnd);
             RefreshPreview(hWnd, ctx);
             return 0;
         }
@@ -6768,6 +7425,14 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
             int dpi = LOWORD(wParam);
             LayoutChildren(hWnd, kEditLayout, ARRAYSIZE(kEditLayout), dpi);
             ApplyUiFont(hWnd, dpi);
+            static constexpr int kSingleLineFields[] = {kIdEditName,
+                                                         kIdEditPath,
+                                                         kIdEditIcon};
+            CenterSingleLineFields(hWnd, dpi, kSingleLineFields,
+                                   ARRAYSIZE(kSingleLineFields));
+            // The field borders are painted around where the children were, so
+            // moving them leaves the old rings behind.
+            InvalidateRect(hWnd, nullptr, TRUE);
             if (ctx) {
                 RefreshPreview(hWnd, ctx);
             }
@@ -6777,8 +7442,7 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
         case WM_DRAWITEM: {
             auto* dis = (LPDRAWITEMSTRUCT)lParam;
             if (dis->CtlID == kIdEditPreview) {
-                FillRect(dis->hDC, &dis->rcItem,
-                         GetSysColorBrush(COLOR_BTNFACE));
+                FillRect(dis->hDC, &dis->rcItem, FaceBrush());
                 if (ctx && ctx->preview) {
                     int dpi = DpiOf(hWnd);
                     int inset = Scale(kPreviewInset, dpi);
@@ -6790,6 +7454,7 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
                     std::wstring icon = GetControlText(hWnd, kIdEditIcon);
                     if (!icon.empty()) {
                         SetBkMode(dis->hDC, TRANSPARENT);
+                        SetTextColor(dis->hDC, ClrWindowText());
                         DrawTextW(dis->hDC, icon.c_str(), -1, &dis->rcItem,
                                   DT_CENTER | DT_VCENTER | DT_SINGLELINE |
                                       DT_NOPREFIX);
@@ -6800,9 +7465,50 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
             break;
         }
 
+        case WM_CTLCOLORSTATIC:
+        case WM_CTLCOLORBTN:
+            if (!Dark()) {
+                break;
+            }
+            return ThemedCtlColor((HDC)wParam, true);
+
+        case WM_CTLCOLOREDIT:
+            if (!Dark()) {
+                break;
+            }
+            return ThemedCtlColor((HDC)wParam, false);
+
+        case WM_ERASEBKGND: {
+            if (!Dark()) {
+                break;
+            }
+            RECT client{};
+            GetClientRect(hWnd, &client);
+            FillRect((HDC)wParam, &client, FaceBrush());
+            static constexpr int kFields[] = {kIdEditName, kIdEditPath,
+                                              kIdEditIcon};
+            DrawFieldBorders(hWnd, (HDC)wParam, kFields, ARRAYSIZE(kFields));
+            return TRUE;
+        }
+
+        // Clicking a label, hint or the preview swatch has nothing of its own
+        // to do, but it is the only way to click off a text box without
+        // hitting another control — labels don't take focus on their own, so
+        // this hands it to the dialog itself instead, which drops the edit
+        // box's selection highlight the same as WM_LBUTTONDOWN below does for
+        // the gaps between controls.
+        case WM_LBUTTONDOWN: {
+            SetFocus(hWnd);
+            return 0;
+        }
+
         case WM_COMMAND: {
             int id = LOWORD(wParam);
-            if (id == kIdEditBrowsePath) {
+            if (id == kIdEditNameLabel || id == kIdEditPathLabel ||
+                id == kIdEditIconLabel || id == kIdEditIconHint ||
+                id == kIdEditPinnedHint || id == kIdEditPreview) {
+                SetFocus(hWnd);
+            } else if (id == kIdEditBrowsePath) {
                 std::wstring start =
                     ExpandEnv(GetControlText(hWnd, kIdEditPath));
                 std::wstring picked = BrowseForFolder(hWnd, start);
@@ -6822,6 +7528,15 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
                                         ReadFolderCustomIcon(picked).c_str());
                     }
                     RefreshPreview(hWnd, ctx);
+                }
+            } else if (id == kIdEditOpenPath) {
+                // Opens whatever is typed, not what was saved: the point is to
+                // check a path before committing to it.
+                std::wstring typed =
+                    ExpandEnv(GetControlText(hWnd, kIdEditPath));
+                if (!typed.empty()) {
+                    std::wstring target = ResolveFolderPath(typed);
+                    LaunchPath(target.empty() ? typed : target);
                 }
             } else if (id == kIdEditBrowseIcon) {
                 std::wstring picked = BrowseForIconFile(hWnd);
@@ -6951,6 +7666,52 @@ bool RunEditDialog(HWND owner, EditContext* ctx, PCWSTR title) {
     return ctx->accepted;
 }
 
+// Flips the pinned flag on the selected row. Same as the tick box in the edit
+// dialog, reachable in one click — and, like it, unpinning keeps the entry with
+// its name and icon rather than deleting anything.
+//
+// Committed by path for the same reason edit and remove are: the store is shared
+// with the taskbar UI thread and an Explorer window thread, so an index taken
+// before the read could point at a different folder by the time it is written.
+void TogglePinSelected(HWND hWnd) {
+    int index = SelectedIndex(hWnd);
+    if (index < 0 || g_unloading) {
+        return;
+    }
+    std::wstring path = g_rows[index].path;
+
+    bool gone = false;
+    {
+        std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
+        auto stored = FolderStore::Read();
+        int at = FolderStore::IndexOfPath(stored, path);
+        if (at < 0) {
+            gone = true;
+        } else {
+            stored[at].pinned = !stored[at].pinned;
+            FolderStore::Write(stored);
+        }
+    }
+    if (gone) {
+        Wh_Log(L"Pin toggle: '%s' is no longer in the store", path.c_str());
+        PopulateList(hWnd);
+        return;
+    }
+    RefreshAfterStoreChange(hWnd);
+}
+
+// "Pin" or "Unpin", whichever the selected row is not. Disabled with nothing
+// selected, so the label it happens to be showing then does not matter.
+void UpdatePinButton(HWND hWnd) {
+    int index = SelectedIndex(hWnd);
+    bool selected = index >= 0;
+    for (int id : {kIdEdit, kIdRemove, kIdTogglePin}) {
+        EnableWindow(GetDlgItem(hWnd, id), selected);
+    }
+    bool pinned = selected && g_rows[index].pinned;
+    SetDlgItemTextW(hWnd, kIdTogglePin, pinned ? L"Unpin" : L"Pin");
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Main window
 
@@ -7057,252 +7818,28 @@ void RemoveSelected(HWND hWnd) {
     RefreshAfterStoreChange(hWnd);
 }
 
-
-// Moves a row to a new position, taking the rest of the list with it, rather
-// than swapping the two ends — dragging row 0 to the bottom should slide
-// everything else up one, not trade places with the last row.
-void MoveRow(HWND hWnd, int from, int to) {
-    if (from < 0 || to < 0 || from >= (int)g_rows.size() ||
-        to >= (int)g_rows.size() || from == to || g_unloading) {
-        return;
-    }
-
-    // Unlike edit and remove, a reorder is about positions, so there is no
-    // path to re-find it by: if the store no longer matches the rows the drag
-    // started from, the move is meaningless and the list is just refreshed.
-    bool stale = false;
-    {
-        std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
-        auto stored = FolderStore::Read();
-        if (!StoreMatchesRows(stored)) {
-            stale = true;
-        } else {
-            FolderStore::Entry moved = stored[from];
-            stored.erase(stored.begin() + from);
-            stored.insert(stored.begin() + to, std::move(moved));
-            FolderStore::Write(stored);
-        }
-    }
-    if (stale) {
-        Wh_Log(L"Reorder: the store changed under the window; refreshing");
-        PopulateList(hWnd);
-        return;
-    }
-    RefreshAfterStoreChange(hWnd);
-    SendMessageW(GetDlgItem(hWnd, kIdList), LB_SETCURSEL, to, 0);
-}
-
-void OpenSelected(HWND hWnd) {
-    int index = SelectedIndex(hWnd);
-    if (index < 0) {
-        return;
-    }
-    std::wstring target = ResolveFolderPath(ExpandEnv(g_rows[index].path));
-    LaunchPath(target.empty() ? ExpandEnv(g_rows[index].path) : target);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Drag to reorder
-//
-// A stock listbox has no reordering of its own, so the drag is tracked by
-// subclassing it: press picks up the row under the cursor, motion draws an
-// insertion line, release commits the move. Kept on the listbox rather than
-// the parent so the mouse capture and the hit testing share one coordinate
-// space.
-
-int g_dragFrom = -1;      // Row being dragged, -1 when not dragging.
-int g_dragTo = -1;        // Insertion point currently drawn.
-bool g_dragArmed = false; // Button down, but not yet past the drag threshold.
-POINT g_dragStart{};
-
-// Insertion index for a cursor position: the gap the row would drop into, so
-// the value can legitimately equal the row count (drop at the end).
-int InsertIndexAt(HWND list, POINT pt) {
-    int top = (int)SendMessageW(list, LB_GETTOPINDEX, 0, 0);
-    RECT client{};
-    GetClientRect(list, &client);
-    if (pt.y < 0) {
-        return top;
-    }
-    int rowHeight = Scale(kRowHeight, DpiOf(list));
-    int offset = (pt.y + rowHeight / 2) / rowHeight;
-    int index = top + offset;
-    int count = (int)g_rows.size();
-    return index < 0 ? 0 : (index > count ? count : index);
-}
-
-void DrawInsertionLine(HWND list, int index) {
-    if (index < 0) {
-        return;
-    }
-    int top = (int)SendMessageW(list, LB_GETTOPINDEX, 0, 0);
-    RECT client{};
-    GetClientRect(list, &client);
-    int y = (index - top) * Scale(kRowHeight, DpiOf(list));
-    if (y < 0) {
-        return;
-    }
-    // A drop at the very end can land a row-height past the last painted row;
-    // pull it back inside so it is still visible.
-    if (y > client.bottom - 2) {
-        y = client.bottom - 2;
-    }
-    HDC dc = GetDC(list);
-    // R2_NOT so the same call erases it again, no repaint needed.
-    int oldRop = SetROP2(dc, R2_NOT);
-    HPEN pen = CreatePen(PS_SOLID, 2, RGB(0, 0, 0));
-    HGDIOBJ oldPen = SelectObject(dc, pen);
-    MoveToEx(dc, client.left + 2, y, nullptr);
-    LineTo(dc, client.right - 2, y);
-    SelectObject(dc, oldPen);
-    DeleteObject(pen);
-    SetROP2(dc, oldRop);
-    ReleaseDC(list, dc);
-}
-
-void EndDrag(HWND list, bool commit) {
-    if (g_dragTo >= 0) {
-        DrawInsertionLine(list, g_dragTo);  // Erase.
-    }
-    int from = g_dragFrom;
-    int to = g_dragTo;
-    // Cleared before releasing capture: that sends WM_CAPTURECHANGED straight
-    // back here, and the -1 is what stops it recursing.
-    g_dragFrom = -1;
-    g_dragTo = -1;
-    g_dragArmed = false;
-    if (GetCapture() == list) {
-        ReleaseCapture();
-    }
-    if (!commit || from < 0 || to < 0) {
-        return;
-    }
-    // The insertion index counts gaps, so dropping below the dragged row
-    // shifts the target down by the row that is about to be removed.
-    if (to > from) {
-        to--;
-    }
-    if (to != from) {
-        MoveRow(GetParent(list), from, to);
-    }
-}
-
-LRESULT CALLBACK ListSubclassProc(HWND list,
-                                  UINT msg,
-                                  WPARAM wParam,
-                                  LPARAM lParam,
-                                  DWORD_PTR /*dwRefData*/) {
-    switch (msg) {
-        // Handled here in full, never forwarded. A stock listbox runs its own
-        // nested modal loop from WM_LBUTTONDOWN to track drag-selection, and
-        // that loop swallows every WM_MOUSEMOVE and WM_LBUTTONUP until the
-        // button comes back up — so a drag started below would never see
-        // another message. Selecting the row by hand costs little and keeps
-        // the message flow ours.
-        case WM_LBUTTONDOWN: {
-            POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
-            int top = (int)SendMessageW(list, LB_GETTOPINDEX, 0, 0);
-            int row = top + pt.y / Scale(kRowHeight, DpiOf(list));
-            if (pt.y < 0 || row < 0 || row >= (int)g_rows.size()) {
-                return 0;
-            }
-            SetFocus(list);
-            if ((int)SendMessageW(list, LB_GETCURSEL, 0, 0) != row) {
-                SendMessageW(list, LB_SETCURSEL, row, 0);
-                SendMessageW(GetParent(list), WM_COMMAND,
-                             MAKEWPARAM(kIdList, LBN_SELCHANGE),
-                             (LPARAM)list);
-            }
-            g_dragArmed = true;
-            g_dragStart = pt;
-            SetCapture(list);
+// A single-select listbox never lets go of its selection on its own — a click
+// below the last row just does nothing, and there is no other way to clear
+// it. LB_ITEMFROMPOINT's high word flags a point outside every row's client
+// area, which is what turns that click into an explicit deselect. Clicks
+// that land on a row are left to the default handling (including on the
+// already-selected row) so a click always does the one obvious thing instead
+// of alternating select/deselect on repeat clicks at the same spot.
+LRESULT CALLBACK ListSubclassProc(HWND hWnd, UINT msg, WPARAM wParam,
+                                  LPARAM lParam, UINT_PTR /*subclassId*/,
+                                  DWORD_PTR /*refData*/) {
+    if (msg == WM_LBUTTONDOWN) {
+        LRESULT hit = SendMessageW(hWnd, LB_ITEMFROMPOINT, 0, lParam);
+        if (HIWORD(hit) != 0) {
+            SendMessageW(hWnd, LB_SETCURSEL, (WPARAM)-1, 0);
+            HWND parent = GetParent(hWnd);
+            SendMessageW(parent, WM_COMMAND,
+                        MAKEWPARAM(GetDlgCtrlID(hWnd), LBN_SELCHANGE),
+                        (LPARAM)hWnd);
             return 0;
         }
-
-        // Also ours, for the same reason — and the parent still needs the
-        // notification to open the folder.
-        case WM_LBUTTONDBLCLK: {
-            POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
-            int top = (int)SendMessageW(list, LB_GETTOPINDEX, 0, 0);
-            int row = top + pt.y / Scale(kRowHeight, DpiOf(list));
-            if (pt.y >= 0 && row >= 0 && row < (int)g_rows.size()) {
-                SendMessageW(list, LB_SETCURSEL, row, 0);
-                SendMessageW(GetParent(list), WM_COMMAND,
-                             MAKEWPARAM(kIdList, LBN_DBLCLK), (LPARAM)list);
-            }
-            return 0;
-        }
-
-        case WM_MOUSEMOVE: {
-            POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
-            if (g_dragArmed && g_dragFrom < 0) {
-                // Only start a drag once the pointer has actually travelled,
-                // so an ordinary click still just selects. Capture is already
-                // held from WM_LBUTTONDOWN.
-                if (labs(pt.y - g_dragStart.y) >= GetSystemMetrics(SM_CYDRAG) ||
-                    labs(pt.x - g_dragStart.x) >= GetSystemMetrics(SM_CXDRAG)) {
-                    g_dragFrom =
-                        (int)SendMessageW(list, LB_GETCURSEL, 0, 0);
-                    if (g_dragFrom < 0 ||
-                        g_dragFrom >= (int)g_rows.size()) {
-                        g_dragFrom = -1;
-                        g_dragArmed = false;
-                    } else {
-                        SetCursor(LoadCursorW(nullptr, IDC_SIZENS));
-                    }
-                }
-            }
-            if (g_dragFrom >= 0) {
-                int target = InsertIndexAt(list, pt);
-                if (target != g_dragTo) {
-                    if (g_dragTo >= 0) {
-                        DrawInsertionLine(list, g_dragTo);  // Erase old.
-                    }
-                    g_dragTo = target;
-                    DrawInsertionLine(list, g_dragTo);
-                }
-                SetCursor(LoadCursorW(nullptr, IDC_SIZENS));
-                return 0;
-            }
-            break;
-        }
-
-        case WM_LBUTTONUP:
-            if (g_dragFrom >= 0) {
-                EndDrag(list, true);
-            } else {
-                // Armed but never dragged: an ordinary click, already handled
-                // on the way down. Just let the capture go.
-                g_dragArmed = false;
-                if (GetCapture() == list) {
-                    ReleaseCapture();
-                }
-            }
-            return 0;
-
-        // Losing capture (Alt+Tab, a message box) has to abandon the drag, or
-        // the insertion line is left painted with no way to clear it.
-        case WM_CAPTURECHANGED:
-            if (g_dragFrom >= 0) {
-                EndDrag(list, false);
-            }
-            g_dragArmed = false;
-            break;
-
-        case WM_KEYDOWN:
-            if (wParam == VK_ESCAPE && g_dragFrom >= 0) {
-                EndDrag(list, false);
-                return 0;
-            }
-            break;
-
-        case WM_DESTROY:
-            g_dragFrom = -1;
-            g_dragTo = -1;
-            g_dragArmed = false;
-            break;
     }
-    return DefSubclassProc(list, msg, wParam, lParam);
+    return DefSubclassProc(hWnd, msg, wParam, lParam);
 }
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
@@ -7310,12 +7847,11 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         case WM_CREATE: {
             HINSTANCE instance = GetCurrentModuleHandle();
             HWND list = CreateWindowExW(
-                WS_EX_CLIENTEDGE, L"LISTBOX", nullptr,
+                FieldExStyle(), L"LISTBOX", nullptr,
                 WS_CHILD | WS_VISIBLE | WS_VSCROLL | WS_TABSTOP | LBS_NOTIFY |
-                    LBS_OWNERDRAWFIXED,
+                    LBS_OWNERDRAWVARIABLE,
                 0, 0, 0, 0, hWnd, (HMENU)(INT_PTR)kIdList, instance, nullptr);
-            WindhawkUtils::SetWindowSubclassFromAnyThread(list,
-                                                          ListSubclassProc, 0);
+            SetWindowSubclass(list, ListSubclassProc, 0, 0);
 
             struct ButtonSpec {
                 int id;
@@ -7324,6 +7860,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             const ButtonSpec buttons[] = {{kIdAdd, L"Add..."},
                                           {kIdEdit, L"Edit..."},
                                           {kIdRemove, L"Remove"},
+                                          {kIdTogglePin, L"Pin"},
                                           {kIdClose, L"Close"}};
             for (const auto& b : buttons) {
                 CreateWindowExW(0, L"BUTTON", b.text,
@@ -7340,25 +7877,66 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             LayoutChildren(hWnd, kMainLayout, ARRAYSIZE(kMainLayout),
                            DpiOf(hWnd));
             ApplyUiFont(hWnd, DpiOf(hWnd));
+            ApplyTheme(hWnd);
             PopulateList(hWnd);
             return 0;
         }
 
+        // One message per item, sent as it is added — by which point g_rows is
+        // already filled, so the section boundary is known. A row that opens a
+        // section carries its caption band as extra height rather than the
+        // caption being a list item of its own.
+        //
+        // The parent's DPI, not the listbox's: this can arrive before the
+        // listbox has an HWND. Same monitor either way.
         case WM_MEASUREITEM: {
             auto* mis = (LPMEASUREITEMSTRUCT)lParam;
             if (mis->CtlID == kIdList) {
-                // Sent while the listbox is being created, before its own
-                // HWND exists — hence the parent's DPI, which is the same
-                // monitor.
-                mis->itemHeight = Scale(kRowHeight, DpiOf(hWnd));
+                int dpi = DpiOf(hWnd);
+                mis->itemHeight = Scale(kRowHeight, dpi);
+                if (StartsSection(mis->itemID)) {
+                    mis->itemHeight += Scale(kSectionHeader, dpi);
+                }
                 return TRUE;
             }
             break;
         }
 
-        // Dragged to a monitor at another scale. LB_SETITEMHEIGHT because
-        // WM_MEASUREITEM is not sent again for an existing owner-draw listbox,
-        // and PopulateList because the row icons were extracted at the old
+        // The listbox and the buttons paint themselves; these are the surfaces
+        // they ask the parent about. Without them a dark window still shows
+        // white label and edit backgrounds.
+        case WM_CTLCOLORSTATIC:
+        case WM_CTLCOLORBTN:
+            if (!Dark()) {
+                break;
+            }
+            return ThemedCtlColor((HDC)wParam, true);
+
+        case WM_CTLCOLORLISTBOX:
+        case WM_CTLCOLOREDIT:
+            if (!Dark()) {
+                break;
+            }
+            return ThemedCtlColor((HDC)wParam, false);
+
+        // The class background brush is COLOR_BTNFACE, which is light. Painting
+        // it here rather than swapping the class brush keeps one window class
+        // working for both themes.
+        case WM_ERASEBKGND: {
+            if (!Dark()) {
+                break;
+            }
+            RECT client{};
+            GetClientRect(hWnd, &client);
+            FillRect((HDC)wParam, &client, FaceBrush());
+            static constexpr int kFields[] = {kIdList};
+            DrawFieldBorders(hWnd, (HDC)wParam, kFields, ARRAYSIZE(kFields));
+            return TRUE;
+        }
+
+        // Dragged to a monitor at another scale. PopulateList is what fixes the
+        // rows: it resets the list content, which makes the listbox ask for
+        // every item's height again, and it re-extracts the row icons at the new
         // pixel size.
         case WM_DPICHANGED: {
             const RECT* suggested = (const RECT*)lParam;
@@ -7369,10 +7947,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             int dpi = LOWORD(wParam);
             LayoutChildren(hWnd, kMainLayout, ARRAYSIZE(kMainLayout), dpi);
             ApplyUiFont(hWnd, dpi);
-            if (HWND list = GetDlgItem(hWnd, kIdList)) {
-                SendMessageW(list, LB_SETITEMHEIGHT, 0,
-                             Scale(kRowHeight, dpi));
-            }
+            InvalidateRect(hWnd, nullptr, TRUE);
             PopulateList(hWnd);
             return 0;
         }
@@ -7395,10 +7970,16 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 EditSelected(hWnd);
             } else if (id == kIdRemove) {
                 RemoveSelected(hWnd);
+            } else if (id == kIdTogglePin) {
+                TogglePinSelected(hWnd);
             } else if (id == kIdClose) {
                 DestroyWindow(hWnd);
             } else if (id == kIdList && code == LBN_DBLCLK) {
-                OpenSelected(hWnd);
+                EditSelected(hWnd);
+            } else if (id == kIdList && code == LBN_SELCHANGE) {
+                // Pin/Unpin names the action, so it has to follow the
+                // selection rather than only the store.
+                UpdatePinButton(hWnd);
             }
             return 0;
         }
@@ -7413,12 +7994,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             return 0;
 
         case WM_DESTROY:
-            // Unsubclass before the listbox goes away, so a reopened window
-            // does not chain onto a stale subclass entry.
-            if (HWND list = GetDlgItem(hWnd, kIdList)) {
-                WindhawkUtils::RemoveWindowSubclassFromAnyThread(
-                    list, ListSubclassProc);
-            }
             FreeRowIcons();
             g_wnd = nullptr;
             PostQuitMessage(0);
@@ -7659,355 +8234,20 @@ void PlayPressBounce(UIElement const& element) {
     }
 }
 
-// The open right-click flyout, so teardown can close it before the lambdas
-// behind its items are unmapped.
-//
-// no_destroy: Wh_ModUninit does not run when Explorer terminates (sign-out,
-// restart, reboot) — only the CRT destructors of globals do, on the shutdown
-// thread, after every other thread has been killed. Releasing a strong XAML
-// reference there is exactly the UI-thread-affinity case that crashes. Cleared
-// with `g_buttonMenuFlyout = nullptr` in the Closed handler and in teardown,
-// which is what actually releases it.
-[[clang::no_destroy]] MenuFlyout g_buttonMenuFlyout{nullptr};
-
-FontIcon MakeMenuGlyph(const wchar_t* glyph) {
-    FontIcon icon;
-    icon.FontFamily(FontFamily(L"Segoe Fluent Icons"));
-    icon.FontSize(16);
-    icon.Glyph(glyph);
-    return icon;
+TaskbarHost* FindTaskbarHost(HWND taskbarWnd) {
+    if (!g_taskbarHosts) {
+        return nullptr;
+    }
+    for (auto& host : *g_taskbarHosts) {
+        if (host && host->hwnd == taskbarWnd) {
+            return host.get();
+        }
+    }
+    return nullptr;
 }
 
-// Right-click on a taskbar folder button: unpin it, or open the manager.
-// A XAML MenuFlyout rather than TrackPopupMenuEx, so the menu picks up the
-// system's Win11 menu styling (rounded, acrylic, icon column) instead of the
-// classic Win32 look.
-// Unpinning keeps the entry as a draft rather than deleting it, so its name
-// and icon survive and the folder can be pinned again later without being
-// set up from scratch. Deleting outright is a manager-window action.
-void OnButtonRightClicked(int folderIndex, Button const& button) {
-    if (g_unloading || !button) {
-        return;
-    }
-    std::wstring path = FolderPathForButton(folderIndex);
-    if (path.empty()) {
-        return;
-    }
-
-    // Right-click dismisses the hover tray, like right-clicking any other
-    // taskbar button closes its preview — including a delayed open that has
-    // not fired yet.
-    OnPointerExitedButton();
-    CloseChain();
-
-    if (auto content = button.Content().try_as<Panel>()) {
-        // Bounce the icon layer only; the hover highlight stays put.
-        if (content.Children().Size() > 1) {
-            PlayPressBounce(content.Children().GetAt(1));
-        }
-    }
-
-    try {
-        MenuFlyout flyout;
-        // The taskbar XAML island is only a taskbar tall — without this the
-        // menu is clipped to it instead of getting its own popup window.
-        flyout.ShouldConstrainToRootBounds(false);
-        flyout.Placement(Primitives::FlyoutPlacementMode::Top);
-
-        MenuFlyoutItem unpin;
-        unpin.Text(L"Unpin from taskbar");
-        unpin.Icon(MakeMenuGlyph(L""));  // unpin
-        unpin.Click([path](winrt::Windows::Foundation::IInspectable const&,
-                           RoutedEventArgs const&) {
-            if (g_unloading) {
-                return;
-            }
-            // Keeps the entry as a draft rather than forgetting it, so its
-            // name and icon survive and it can be pinned again from the
-            // manager.
-            RemovePinnedFolder(path);
-            // Deferred: the reload destroys this button and unhooks the
-            // handlers this lambda is running inside, and the flyout is
-            // anchored to it. The owner window lives on this same taskbar UI
-            // thread, so the post lands right after the flyout unwinds.
-            RequestReloadUI();
-        });
-
-        MenuFlyoutItem manage;
-        manage.Text(L"Manage folders...");
-        manage.Icon(MakeMenuGlyph(L""));  // folder
-        manage.Click([](winrt::Windows::Foundation::IInspectable const&,
-                        RoutedEventArgs const&) {
-            if (g_unloading) {
-                return;
-            }
-            FolderManager::Open();
-        });
-
-        flyout.Items().Append(unpin);
-        flyout.Items().Append(manage);
-        flyout.Closed([](winrt::Windows::Foundation::IInspectable const&,
-                         winrt::Windows::Foundation::IInspectable const&) {
-            g_buttonMenuFlyout = nullptr;
-        });
-
-        g_buttonMenuFlyout = flyout;
-        flyout.ShowAt(button);
-    } catch (...) {
-        g_buttonMenuFlyout = nullptr;
-    }
-}
-
-Grid BuildHostGrid(TaskbarHost* host) {
-    Grid hostGrid;
-    hostGrid.Name(kHostGridName);
-    hostGrid.HorizontalAlignment(HorizontalAlignment::Left);
-    hostGrid.VerticalAlignment(VerticalAlignment::Center);
-    hostGrid.Height(host->buttonHeight);
-
-    // Horizontal position lives here, not in Margin — see
-    // AnimateHostGridLeftTo for why Margin caused a layout feedback loop.
-    TranslateTransform translate;
-    hostGrid.RenderTransform(translate);
-    host->hostTranslate = translate;
-    host->slideStoryboard = nullptr;
-    host->currentLeft = 0.0;
-    host->slideStartTick = 0;
-    host->slideEndTick = 0;
-    host->hasPlaced = false;
-    host->slideCauseTick = 0;
-    host->slideCauseIsClose = false;
-    host->lastRetargetTick = 0;
-    host->parkedAnchorX = -1.0;
-    host->reserveHolds = 0;
-    host->lastAnchorX = -1.0;
-    host->anchorMovingSince = 0;
-    host->dragFrozen = false;
-
-    host->buttonStates.clear();
-
-    // Snapshot under the mutex — ResolvePendingFolderEntries / LoadFolders may
-    // mutate g_settings.folders from another thread while we build UI.
-    std::vector<FolderEntry> folders;
-    {
-        std::lock_guard<std::mutex> lock(g_foldersMutex);
-        folders = g_settings.folders;
-    }
-
-    // No buttons at all — a fresh install, or every folder unpinned — means
-    // nothing on the taskbar to right-click, and the Taskbar Folders window is
-    // only reachable from a button. Stand in a single "add a folder" button so
-    // there is always a way in. It is not in the store and has no entry of its
-    // own: an emoji icon and an empty path, which every index-taking path
-    // (hover, click, right-click) already treats as "nothing to open", since
-    // FolderPathForButton returns empty for it.
-    const bool placeholder = folders.empty();
-    if (placeholder) {
-        FolderEntry add;
-        add.name = L"Add a folder";
-        add.icon = L"➕";
-        folders.push_back(std::move(add));
-    }
-
-    for (size_t i = 0; i < folders.size(); i++) {
-        const auto& entry = folders[i];
-
-        ColumnDefinition column;
-        column.Width({1.0, GridUnitType::Auto});
-        hostGrid.ColumnDefinitions().Append(column);
-
-        Button button;
-        button.Name(L"FolderHoverTrayButton_" + winrt::to_hstring((int)i));
-        button.Width(host->buttonWidth);
-        button.Height(host->buttonHeight);
-        ApplyNativeButtonStyle(button);
-
-        ButtonState state;
-        state.button = button;
-        state.folderIndex = (int)i;
-        state.iconGeneration =
-            g_buttonIconGeneration.fetch_add(1, std::memory_order_relaxed);
-
-        bool dark = IsDarkTheme();
-        state.highlightHoverBrush = MakeHighlightBrush(dark, /*pressed=*/false);
-        state.highlightPressedBrush =
-            MakeHighlightBrush(dark, /*pressed=*/true);
-
-        Border highlight;
-        double highlightExtent =
-            HighlightExtent(host->buttonWidth, host->buttonHeight);
-        highlight.Width(highlightExtent);
-        highlight.Height(highlightExtent);
-        highlight.HorizontalAlignment(HorizontalAlignment::Center);
-        highlight.VerticalAlignment(VerticalAlignment::Center);
-        highlight.CornerRadius({kHighlightCornerRadius, kHighlightCornerRadius,
-                                 kHighlightCornerRadius, kHighlightCornerRadius});
-        // Fill only, no rim — the shell's own icon highlight has no stroke.
-        highlight.Background(state.highlightHoverBrush);
-        highlight.IsHitTestVisible(false);
-        // Hidden until hover. Set on the composition visual, not the XAML
-        // Opacity property, so FadeHighlight's animation isn't multiplied
-        // against a zero on the element itself.
-        try {
-            ElementCompositionPreview::GetElementVisual(highlight).Opacity(
-                0.0f);
-        } catch (...) {
-            highlight.Opacity(0.0);
-        }
-        state.highlightBorder = highlight;
-
-        Grid content;
-        content.Children().Append(highlight);
-        content.Children().Append(MakeButtonContent(
-            entry, host->buttonHeight, (int)i, host->hwnd,
-            state.iconGeneration));
-        button.Content(content);
-        state.contentGrid = content;
-
-        // No taskbar-button tooltip; the folder name is shown in the hover
-        // grid. The placeholder has no grid to show it in, so it says what it
-        // is on hover instead.
-        if (placeholder) {
-            ToolTipService::SetToolTip(
-                button, winrt::box_value(winrt::hstring(
-                            L"Add a folder to the taskbar")));
-        } else {
-            ToolTipService::SetToolTip(button, nullptr);
-        }
-
-        Grid::SetColumn(button, (int)i);
-        hostGrid.Children().Append(button);
-
-        int folderIndex = (int)i;
-        HWND taskbarWnd = host->hwnd;
-        state.clickToken = button.Click(
-            [folderIndex, placeholder](
-                winrt::Windows::Foundation::IInspectable const&,
-                RoutedEventArgs const&) {
-                if (placeholder) {
-                    if (!g_unloading) {
-                        FolderManager::Open();
-                    }
-                    return;
-                }
-                OnButtonClicked(folderIndex);
-            });
-        Border highlightRef = highlight;
-        Brush hoverBrushRef = state.highlightHoverBrush;
-        Brush pressedBrushRef = state.highlightPressedBrush;
-        state.enterToken = button.PointerEntered(
-            [folderIndex, taskbarWnd, highlightRef, hoverBrushRef](
-                winrt::Windows::Foundation::IInspectable const& sender,
-                winrt::Windows::UI::Xaml::Input::
-                    PointerRoutedEventArgs const&) {
-                try {
-                    highlightRef.Background(hoverBrushRef);
-                } catch (...) {
-                }
-                FadeHighlight(highlightRef, 1.0f, kHighlightFadeInMs);
-                if (auto button = sender.try_as<Button>()) {
-                    OnPointerEnteredButton(folderIndex, button, taskbarWnd);
-                }
-            });
-        state.exitToken = button.PointerExited(
-            [highlightRef](
-                winrt::Windows::Foundation::IInspectable const&,
-                winrt::Windows::UI::Xaml::Input::
-                    PointerRoutedEventArgs const&) {
-                FadeHighlight(highlightRef, 0.0f, kHighlightFadeOutMs);
-                OnPointerExitedButton();
-            });
-        // Press/release only re-tint; the highlight is already faded in.
-        state.pressedToken = button.PointerPressed(
-            [highlightRef, pressedBrushRef](
-                winrt::Windows::Foundation::IInspectable const&,
-                winrt::Windows::UI::Xaml::Input::
-                    PointerRoutedEventArgs const&) {
-                try {
-                    highlightRef.Background(pressedBrushRef);
-                } catch (...) {
-                }
-            });
-        state.releasedToken = button.PointerReleased(
-            [highlightRef, hoverBrushRef](
-                winrt::Windows::Foundation::IInspectable const&,
-                winrt::Windows::UI::Xaml::Input::
-                    PointerRoutedEventArgs const&) {
-                try {
-                    highlightRef.Background(hoverBrushRef);
-                } catch (...) {
-                }
-            });
-        state.rightTapToken = button.RightTapped(
-            [folderIndex, placeholder](
-                winrt::Windows::Foundation::IInspectable const& sender,
-                winrt::Windows::UI::Xaml::Input::RightTappedRoutedEventArgs const&
-                    args) {
-                // Unpin/hide is offered for every folder button now, regardless
-                // of whether it came from Settings or the Explorer pin action.
-                args.Handled(true);
-                // Nothing to unpin on the placeholder — either button opens the
-                // manager, which is the only thing it is there for.
-                if (placeholder) {
-                    if (!g_unloading) {
-                        FolderManager::Open();
-                    }
-                    return;
-                }
-                OnButtonRightClicked(folderIndex, sender.try_as<Button>());
-            });
-
-        host->buttonStates.push_back(std::move(state));
-    }
-
-    hostGrid.Width(DesiredHostWidth(host));
-    return hostGrid;
-}
-
-void ClearButtonState(TaskbarHost* host) {
-    if (!host) {
-        return;
-    }
-    // Its item handlers live in this DLL — never leave it open across a
-    // rebuild or an unload.
-    if (g_buttonMenuFlyout) {
-        try {
-            g_buttonMenuFlyout.Hide();
-        } catch (...) {
-        }
-        g_buttonMenuFlyout = nullptr;
-    }
-    for (auto& state : host->buttonStates) {
-        if (!state.button) {
-            continue;
-        }
-        try {
-            if (state.clickToken.value) {
-                state.button.Click(state.clickToken);
-            }
-            if (state.enterToken.value) {
-                state.button.PointerEntered(state.enterToken);
-            }
-            if (state.exitToken.value) {
-                state.button.PointerExited(state.exitToken);
-            }
-            if (state.pressedToken.value) {
-                state.button.PointerPressed(state.pressedToken);
-            }
-            if (state.releasedToken.value) {
-                state.button.PointerReleased(state.releasedToken);
-            }
-            if (state.rightTapToken.value) {
-                state.button.RightTapped(state.rightTapToken);
-            }
-            ToolTipService::SetToolTip(state.button, nullptr);
-            state.button.Content(nullptr);
-        } catch (...) {
-        }
-    }
-    host->buttonStates.clear();
-}
-
+// Releases everything this host attached to elements the taskbar owns. Nothing
+// of ours is in the visual tree any more, so this is only handlers.
 void RemoveHostGrid(TaskbarHost* host) {
     if (!host) {
         return;
@@ -8021,32 +8261,13 @@ void RemoveHostGrid(TaskbarHost* host) {
     }
     host->layoutUpdatedToken = {};
 
-    RestoreAnchorMargin(host);
-    ClearButtonState(host);
+    // The taskbar keeps its buttons after the mod is gone, so a handler left
+    // attached would outlive the image it lives in.
+    UnbindPinButtons(host);
+    host->lastRealizedChildren.clear();
+    host->lastPinBindCount = -1;
+    host->lastLabelGeneration = 0;
 
-    // Detach hostGrid from wherever it's actually parented right now, not
-    // from host->trackedRootGrid's children. If FindTaskbarRootGrid ever
-    // resolves a different (but still live) RootGrid object on a later pass
-    // than the one hostGrid was originally appended under, searching that
-    // mismatched trackedRootGrid finds nothing to remove and leaves the old
-    // hostGrid orphaned but still attached and rendering - a second, stuck
-    // copy of the folder buttons that nothing else catches, since it isn't
-    // moving or overlapping its own (correct) anchor.
-    if (host->hostGrid) {
-        try {
-            if (auto panel =
-                    VisualTreeHelper::GetParent(host->hostGrid).try_as<Panel>()) {
-                auto children = panel.Children();
-                uint32_t index;
-                if (children.IndexOf(host->hostGrid, index)) {
-                    children.RemoveAt(index);
-                }
-            }
-        } catch (...) {
-        }
-    }
-
-    host->hostGrid = nullptr;
     host->trackedRootGrid = nullptr;
     host->cachedRepeater = nullptr;
 }
@@ -8063,25 +8284,19 @@ void RemoveAllHostGrids() {
     g_injectionLive = false;
 }
 
-// Layout passes during an icon slide come every ~15ms, so this covers the
-// taskbar's own 250ms slide with room to spare while still guaranteeing the
-// overlay gives in and moves if a reserve-sized target is genuinely correct.
-constexpr int kMaxReserveHolds = 24;
-
-// How far the anchor has to move between two layout passes to count as still
-// in flight. Below this it is measurement jitter on a button that has stopped.
-constexpr double kAnchorSettleEpsilon = 0.5;
-// Ceiling on how long positioning will wait for the anchor to stop moving.
-// Comfortably past Windows' own ~250ms icon slide, so a real settle always
-// wins the race; it exists only so an anchor that somehow never stops (a
-// perpetual animation, a stuck arrange) cannot wedge the overlay in place.
-constexpr ULONGLONG kMaxAnchorSettleMs = 600;
-
+// Keeps hover attached to the real pinned buttons as the taskbar changes.
+//
+// This is all that is left of a function that used to be ~270 lines: anchor
+// resolution, a strip census, reserve holds, settle holds, drag freezes and a
+// slide animation, all of it trying to predict where Windows was about to put
+// an icon. None of that is needed once the button belongs to the shell.
 void OnRootGridLayoutUpdated(TaskbarHost* host) {
-    if (g_unloading || !host || !host->hostGrid || !host->trackedRootGrid) {
+    if (g_unloading || !host || !host->trackedRootGrid) {
         return;
     }
 
+    // Reached from a XAML delegate, so a WinRT failure must not unwind into the
+    // framework's own frame.
     try {
         FrameworkElement repeater = host->cachedRepeater;
         bool repeaterLooksDead = false;
@@ -8098,244 +8313,11 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
             return;
         }
 
-        ULONGLONG now = GetTickCount64();
-
-        if (now - host->lastButtonSizeTick > 250) {
-            host->lastButtonSizeTick = now;
-            double previousWidth = host->buttonWidth;
-            double previousHeight = host->buttonHeight;
-            UpdateButtonSizeFromTaskbar(repeater, &host->buttonWidth,
-                                        &host->buttonHeight);
-
-            if (std::abs(previousWidth - host->buttonWidth) > 0.5 ||
-                std::abs(previousHeight - host->buttonHeight) > 0.5) {
-                double highlightExtent =
-                    HighlightExtent(host->buttonWidth, host->buttonHeight);
-                for (auto& state : host->buttonStates) {
-                    if (state.button) {
-                        state.button.Width(host->buttonWidth);
-                        state.button.Height(host->buttonHeight);
-                    }
-                    // The highlight is explicitly sized, so it does not
-                    // follow the button on its own.
-                    if (state.highlightBorder) {
-                        state.highlightBorder.Width(highlightExtent);
-                        state.highlightBorder.Height(highlightExtent);
-                    }
-                }
-                host->hostGrid.Height(host->buttonHeight);
-                host->hostGrid.Width(DesiredHostWidth(host));
-            }
-        }
-
-        // ActualWidth alone is a bad liveness check: Windows shrinks a
-        // closing button's width toward 0 as part of its own close
-        // animation, which isn't the anchor going away. Test detachment
-        // from the tree instead so a closing-but-still-present button
-        // doesn't trigger a needless re-resolve (and the churn/flicker
-        // that comes with it) on every window close.
-        // A new app button lands and settles at its final position within a
-        // tick or two — well inside the 250ms re-resolve throttle below.
-        // Left on the throttle alone, a newly-opened window can render past
-        // our still-stale reserved gap for up to 250ms, appearing to the
-        // right of hostGrid before the next re-resolve catches it and pulls
-        // hostGrid past it. React the moment the child count itself moves
-        // instead of waiting out the throttle.
-        int childCount = VisualTreeHelper::GetChildrenCount(repeater);
-        bool childCountChanged = childCount != host->lastRepeaterChildCount;
-        host->lastRepeaterChildCount = childCount;
-
-        bool anchorLooksDead = !host->anchor || !host->anchor.Parent();
-        if (anchorLooksDead || childCountChanged ||
-            now - host->lastAnchorResolveTick > 250) {
-            host->lastAnchorResolveTick = now;
-            if (auto resolved =
-                    ResolveAnchor(repeater, host->trackedRootGrid)) {
-                if (resolved != host->anchor) {
-                    // The anchor itself just closed and a different button
-                    // was promoted in its place — a discontinuous swap, not
-                    // a smooth shrink/slide. There's no icon animation left
-                    // to stay in sync with, so the open/close delay in
-                    // AnimateHostGridLeftTo (there to match Windows' own
-                    // icon-slide timing) would just leave hostGrid parked
-                    // over the new anchor's slot for a few hundred ms.
-                    host->anchorSwapped = true;
-                    double rx = -1.0;
-                    double rw = -1.0;
-                    try {
-                        rw = resolved.ActualWidth();
-                        rx = resolved.TransformToVisual(host->trackedRootGrid)
-                                 .TransformPoint({0, 0})
-                                 .X;
-                    } catch (...) {
-                    }
-
-                    // Our reserve is a Margin on the outgoing anchor, so a
-                    // button realized on its outer side is laid out exactly
-                    // one reserve-width clear of it - parked on the far side
-                    // of our own gap - and only closes up once the reserve has
-                    // migrated across and the taskbar has slid it home. That
-                    // separation is the reliable signal, measured directly
-                    // here. (Watching the retarget distance instead cannot
-                    // work: the target is anchorX + buttonWidth, so the move
-                    // is reserve + a button on the way out and reserve + the
-                    // re-centre on the way back - never the reserve itself.)
-                    // Clearance is measured against the rest of the strip, not
-                    // against the outgoing anchor: that anchor is frequently
-                    // still sliding home from the previous cycle, so the
-                    // distance to it reads anything (127 in one trace where
-                    // the real clearance was a full reserve). Everything
-                    // except the incoming button is settled, so its outer edge
-                    // is a stable reference. Tolerance stays a whole button -
-                    // the two cases are far apart anyway (a parked button sits
-                    // a reserve out, a normal adoption lands touching).
-                    double reserve = DesiredHostWidth(host) +
-                                     g_settings.gapBefore + g_settings.gapAfter;
-                    double slack = host->buttonWidth > 1.0 ? host->buttonWidth
-                                                           : kFallbackButtonSize;
-                    double stripLeft = 0.0;
-                    double stripRight = 0.0;
-                    int others = CensusAppStrip(repeater, host->trackedRootGrid,
-                                                &stripLeft, &stripRight,
-                                                resolved);
-                    host->parkedAnchorX = -1.0;
-                    if (others > 0 && rx > 0.5 && reserve > slack) {
-                        double clearance = (g_settings.position != L"afterApps")
-                                               ? stripLeft - (rx + rw)
-                                               : rx - stripRight;
-                        if (std::abs(clearance - reserve) <= slack) {
-                            host->parkedAnchorX = rx;
-                        }
-                    }
-                }
-                AdoptAnchor(host, resolved);
-            }
-        }
-
-        if (!host->anchor || !host->hasAnchorOriginalMargin) {
-            return;
-        }
-
-        bool before = g_settings.position != L"afterApps";
-        double desiredGap =
-            DesiredHostWidth(host) + g_settings.gapBefore + g_settings.gapAfter;
-
-        auto currentMargin = host->anchor.Margin();
-        auto target = host->anchorOriginalMargin;
-        bool marginChanged = false;
-        if (before) {
-            target.Left = host->anchorOriginalMargin.Left + desiredGap;
-            if (std::abs(currentMargin.Left - target.Left) > 1.0) {
-                host->anchor.Margin(target);
-                marginChanged = true;
-            }
-        } else {
-            target.Right = host->anchorOriginalMargin.Right + desiredGap;
-            if (std::abs(currentMargin.Right - target.Right) > 1.0) {
-                host->anchor.Margin(target);
-                marginChanged = true;
-            }
-        }
-
-        // TransformToVisual below still reads the pre-change position on
-        // this pass (the margin write hasn't been laid out yet), so
-        // computing hostGrid's position now would jump it a full gap-width
-        // onto the neighbouring icon for one frame. The margin write itself
-        // queues another LayoutUpdated; let that pass place hostGrid once
-        // the anchor has actually moved.
-        if (marginChanged) {
-            return;
-        }
-
-        // Dragging a taskbar button moves that button under the cursor - the
-        // element itself, no swap, no window opening or closing - so it can
-        // wander to the outer end of the strip and drag the folder block along
-        // with it (anchorX walking 1098 -> 1291 -> 1334 in a trace, with the
-        // block chasing). Rearranging apps should not move the overlay at all,
-        // so freeze positioning while the primary button is held and settle
-        // once on release. The margin above is still maintained, so the
-        // reserved gap does not collapse mid-drag.
-        bool dragging = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0;
-        host->dragFrozen = dragging;
-        if (dragging) {
-            return;
-        }
-
-        auto point = host->anchor.TransformToVisual(host->trackedRootGrid)
-                         .TransformPoint({0, 0});
-
-        // ItemsRepeater can recycle the container backing our anchor to
-        // represent a different, off-screen item (e.g. the closing-window
-        // placeholder parked at a large negative X) while it's still
-        // attached to the tree, so Parent() alone doesn't catch it. Same
-        // sentinel check ResolveAnchor uses when picking an anchor: bail
-        // and force an immediate re-resolve instead of animating to the
-        // bogus coordinate.
-        if (point.X <= 0.5) {
-            // hostGrid stays wherever it was until the re-resolve lands.
-            host->lastAnchorResolveTick = 0;
-            return;
-        }
-
-        // Windows slides its own icons over ~250ms and layout reports the
-        // anchor part-way through that slide, so a reading that differs from
-        // the previous pass is a frame of a move in flight, not a resting
-        // place. Committing to one parks the folder block at a coordinate the
-        // taskbar was only passing through - and if no further layout pass
-        // happens to land after the icons settle, it stays parked there for as
-        // long as it takes something else to disturb the tree (a full second
-        // in the traces, ending in a visible pop). Waiting for two consecutive
-        // passes to agree costs one pass (~15ms) on a genuine open or close and
-        // makes every intermediate frame a no-op, so the block simply stays put
-        // through the taskbar's animation and moves once, to the right place.
-        bool anchorSettled =
-            host->lastAnchorX >= 0.0 &&
-            std::abs(point.X - host->lastAnchorX) <= kAnchorSettleEpsilon;
-        if (!anchorSettled && host->anchorMovingSince == 0) {
-            host->anchorMovingSince = now;
-        }
-        bool settleTimedOut =
-            host->anchorMovingSince &&
-            now - host->anchorMovingSince > kMaxAnchorSettleMs;
-        host->lastAnchorX = point.X;
-        if (host->hasPlaced && !anchorSettled && !settleTimedOut) {
-            return;
-        }
-        host->anchorMovingSince = 0;
-
-        double left;
-        if (before) {
-            left = point.X - desiredGap + g_settings.gapBefore;
-        } else {
-            left = point.X + host->anchor.ActualWidth() + g_settings.gapBefore;
-        }
-
-        // Adopting a button parked past our own reserve is correct - it really
-        // is the new outermost one - but positioning off it while it is still
-        // out there throws the folder block a reserve-width sideways and back.
-        // Hold until the taskbar has started sliding it home, then track it
-        // in normally. Capped so a button that never moves cannot wedge us.
-        if (host->hasPlaced && host->parkedAnchorX >= 0.0 &&
-            host->reserveHolds < kMaxReserveHolds &&
-            std::abs(point.X - host->parkedAnchorX) < 4.0) {
-            host->reserveHolds++;
-            return;
-        }
-        host->parkedAnchorX = -1.0;
-        host->reserveHolds = 0;
-
-        AnimateHostGridLeftTo(host, left, point.X);
+        // Cheap: compares the realized container identities and the label map
+        // generation, and returns immediately unless something actually
+        // changed. LayoutUpdated fires on every animation frame.
+        RebindPinButtons(host);
     } catch (...) {
-        // A XAML call threw, most likely the anchor was recycled out from
-        // under us mid-access. cachedRepeater is the only thing actually
-        // stale here; drop just that and let the next pass re-resolve the
-        // repeater (and, if the anchor really is gone, ResolveAnchor will
-        // pick a new one on the anchorLooksDead branch above). Restoring
-        // the anchor's margin here would be racing an anchor that's still
-        // alive, and if that restore itself no-ops or throws, the next
-        // AdoptAnchor snapshots the still-widened margin as "original",
-        // doubling the gap permanently.
-        host->cachedRepeater = nullptr;
     }
 }
 
@@ -8367,13 +8349,12 @@ bool InjectHostGridForTaskbar(HWND taskbarWnd) {
         return false;
     }
 
-    // Leave a seated host alone on retry; only rebuild when the taskbar root
-    // was replaced (Explorer rebuild) or the host grid was detached.
+    // Leave a live host alone on retry; only rebuild when the taskbar root was
+    // replaced, which is what an Explorer rebuild looks like from here.
     if (auto* existing = FindTaskbarHost(taskbarWnd)) {
         bool stillLive = false;
         try {
-            stillLive = existing->trackedRootGrid == rootGrid &&
-                        existing->hostGrid && existing->hostGrid.Parent();
+            stillLive = existing->trackedRootGrid == rootGrid;
         } catch (...) {
             stillLive = false;
         }
@@ -8394,22 +8375,13 @@ bool InjectHostGridForTaskbar(HWND taskbarWnd) {
     auto host = std::make_unique<TaskbarHost>();
     host->hwnd = taskbarWnd;
     host->cachedRepeater = repeater;
-    host->lastButtonSizeTick = GetTickCount64();
-    UpdateButtonSizeFromTaskbar(repeater, &host->buttonWidth,
-                                &host->buttonHeight);
-
     host->trackedRootGrid = rootGrid;
-    host->hostGrid = BuildHostGrid(host.get());
 
-    Grid::SetColumn(host->hostGrid, 0);
-    Canvas::SetZIndex(host->hostGrid, 1000);
-    host->hostGrid.Margin({0, 0, 0, 0});
-    rootGrid.Children().Append(host->hostGrid);
-
-    if (auto anchor = ResolveAnchor(repeater, rootGrid)) {
-        AdoptAnchor(host.get(), anchor);
-    }
-    host->lastAnchorResolveTick = GetTickCount64();
+    // Nothing is added to the visual tree. The buttons are real pinned taskbar
+    // items that Windows already created; all that is attached here is hover on
+    // the ones that are ours, plus a layout hook to keep that attached as the
+    // repeater recycles its containers.
+    RebindPinButtons(host.get());
 
     TaskbarHost* raw = host.get();
     host->layoutUpdatedToken = rootGrid.LayoutUpdated(
@@ -8418,9 +8390,7 @@ bool InjectHostGridForTaskbar(HWND taskbarWnd) {
             OnRootGridLayoutUpdated(raw);
         });
 
-    Wh_Log(L"Injected %d folder button(s) on taskbar %p, size %.1fx%.1f",
-           (int)host->buttonStates.size(), taskbarWnd, host->buttonWidth,
-           host->buttonHeight);
+    Wh_Log(L"Watching taskbar %p for folder buttons", taskbarWnd);
 
     TaskbarHosts().push_back(std::move(host));
     return true;
@@ -8669,6 +8639,141 @@ void WINAPI TrayUI_StartTaskbar_Hook(void* pThis) {
     }
 }
 
+// Click interception.
+//
+// The shortcut behind a folder button targets `explorer.exe "<folder>"`, so a
+// left click opens the folder — which is exactly what `openFolderOnClick: true`
+// means, and it costs no hook at all. Only the false case needs anything: swallow
+// the activation so the button is hover-only, as it was before the buttons were
+// real.
+//
+// Right click does not come through here (it goes via _HandleShellContextMenu),
+// so the native jump list is unaffected. The eCLICKACTION value is logged rather
+// than filtered on: its members are not in the public PDB, and every action that
+// does reach this function is an activation we want swallowed.
+//
+// All three symbols are optional. If a future build renames one, the click falls
+// through and Explorer opens the folder — the same thing the true setting does,
+// which is a sane place to degrade to.
+using CTaskBtnGroup_GetGroup_t = void*(WINAPI*)(void* pThis);
+CTaskBtnGroup_GetGroup_t CTaskBtnGroup_GetGroup_Original;
+
+using CTaskGroup_GetAppID_t = PCWSTR(WINAPI*)(void* pThis);
+CTaskGroup_GetAppID_t CTaskGroup_GetAppID_Original;
+
+using CTaskListWnd__HandleClick_t = void(WINAPI*)(void* pThis,
+                                                 void* taskBtnGroup,
+                                                 int taskItemIndex,
+                                                 int clickAction,
+                                                 int a5,
+                                                 int a6);
+CTaskListWnd__HandleClick_t CTaskListWnd__HandleClick_Original;
+
+void WINAPI CTaskListWnd__HandleClick_Hook(void* pThis,
+                                           void* taskBtnGroup,
+                                           int taskItemIndex,
+                                           int clickAction,
+                                           int a5,
+                                           int a6) {
+    if (!g_unloading && !g_settings.openFolderOnClick && taskBtnGroup &&
+        CTaskBtnGroup_GetGroup_Original && CTaskGroup_GetAppID_Original) {
+        // GetAppID lives on CTaskGroup, which is the class behind ITaskGroup;
+        // the interface is its first base, so the pointer passes straight
+        // through. Same call the other taskbar mods make.
+        void* taskGroup = CTaskBtnGroup_GetGroup_Original(taskBtnGroup);
+        PCWSTR appId = taskGroup ? CTaskGroup_GetAppID_Original(taskGroup)
+                                 : nullptr;
+        if (appId && Pins::IsOurAppId(appId)) {
+            Wh_Log(L"Swallowing click (action %d) on folder button %s",
+                   clickAction, appId);
+            return;
+        }
+    }
+
+    CTaskListWnd__HandleClick_Original(pThis, taskBtnGroup, taskItemIndex,
+                                       clickAction, a5, a6);
+}
+
+// Getting out of the shell's way.
+//
+// Two things the taskbar shows on its own overlap the hover grid, and neither
+// clears itself, because from the shell's point of view nothing has happened:
+//
+//  * The thumbnail preview of whatever app was hovered before. Moving from an
+//    app button onto a folder button leaves it up, floating over the grid that
+//    just opened. _SetHotItem is where the shell decides which button is hot, so
+//    it is the exact moment to tell it to drop the preview.
+//
+//  * The hover grid itself, when the folder button is right-clicked. The pointer
+//    never leaves the button, so PointerExited never fires and the grid sits
+//    under the jump list. _OnJumpViewShown fires whichever way the jump list was
+//    summoned.
+//
+// Both hooks are optional. Without them the two surfaces overlap, which is what
+// happens today — annoying, not broken.
+using CTaskListWnd_DismissAllSecondaryUI_t = void(WINAPI*)(void* pThis);
+CTaskListWnd_DismissAllSecondaryUI_t CTaskListWnd_DismissAllSecondaryUI_Original;
+
+using CTaskListWnd__SetHotItem_t = void(WINAPI*)(void* pThis,
+                                                void* taskBtnGroup,
+                                                int taskItemIndex,
+                                                int flags);
+CTaskListWnd__SetHotItem_t CTaskListWnd__SetHotItem_Original;
+
+using CTaskListWnd__OnJumpViewShown_t = void(WINAPI*)(void* pThis,
+                                                     void* appId);
+CTaskListWnd__OnJumpViewShown_t CTaskListWnd__OnJumpViewShown_Original;
+
+// True if this button group is one of ours. Null-safe on both hooks.
+bool TaskBtnGroupIsOurs(void* taskBtnGroup) {
+    if (!taskBtnGroup || !CTaskBtnGroup_GetGroup_Original ||
+        !CTaskGroup_GetAppID_Original) {
+        return false;
+    }
+    void* taskGroup = CTaskBtnGroup_GetGroup_Original(taskBtnGroup);
+    PCWSTR appId =
+        taskGroup ? CTaskGroup_GetAppID_Original(taskGroup) : nullptr;
+    return appId && Pins::IsOurAppId(appId);
+}
+
+// The last group the shell made hot, so the dismiss fires once on arrival
+// rather than on every mouse move within the same button. Taskbar UI thread
+// only, and only ever compared for identity — never dereferenced, so a freed
+// group is harmless.
+void* g_lastHotGroup = nullptr;
+
+void WINAPI CTaskListWnd__SetHotItem_Hook(void* pThis,
+                                          void* taskBtnGroup,
+                                          int taskItemIndex,
+                                          int flags) {
+    bool arriving = taskBtnGroup && taskBtnGroup != g_lastHotGroup;
+    g_lastHotGroup = taskBtnGroup;
+
+    CTaskListWnd__SetHotItem_Original(pThis, taskBtnGroup, taskItemIndex, flags);
+
+    // After the original, so the shell has finished its own hot-item work
+    // before being asked to drop the preview — and only on arrival, or a right
+    // click that re-hots the same button would dismiss the jump list it just
+    // opened.
+    if (arriving && !g_unloading && CTaskListWnd_DismissAllSecondaryUI_Original &&
+        TaskBtnGroupIsOurs(taskBtnGroup)) {
+        CTaskListWnd_DismissAllSecondaryUI_Original(pThis);
+    }
+}
+
+void WINAPI CTaskListWnd__OnJumpViewShown_Hook(void* pThis, void* appId) {
+    CTaskListWnd__OnJumpViewShown_Original(pThis, appId);
+    if (g_unloading) {
+        return;
+    }
+    // Closed for any jump list, not only ours: the grid is a hover surface, and
+    // a menu opening anywhere on the taskbar means the user has moved on from
+    // it. Runs on the taskbar UI thread, which is what owns the grid windows.
+    Wh_Log(L"A jump list opened; closing the hover grid");
+    OnPointerExitedButton();
+    CloseChain();
+}
+
 bool HookTaskbarDllSymbols() {
     HMODULE module =
         LoadLibraryEx(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
@@ -8707,6 +8812,42 @@ bool HookTaskbarDllSymbols() {
             &TrayUI_StartTaskbar_Original,
             TrayUI_StartTaskbar_Hook,
         },
+        {
+            {LR"(protected: void __cdecl CTaskListWnd::_HandleClick(struct ITaskBtnGroup *,int,enum CTaskListWnd::eCLICKACTION,int,int))"},
+            &CTaskListWnd__HandleClick_Original,
+            CTaskListWnd__HandleClick_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(public: virtual struct ITaskGroup * __cdecl CTaskBtnGroup::GetGroup(void))"},
+            &CTaskBtnGroup_GetGroup_Original,
+            nullptr,
+            true,  // optional
+        },
+        {
+            {LR"(public: virtual unsigned short const * __cdecl CTaskGroup::GetAppID(void))"},
+            &CTaskGroup_GetAppID_Original,
+            nullptr,
+            true,  // optional
+        },
+        {
+            {LR"(public: virtual void __cdecl CTaskListWnd::DismissAllSecondaryUI(void))"},
+            &CTaskListWnd_DismissAllSecondaryUI_Original,
+            nullptr,
+            true,  // optional
+        },
+        {
+            {LR"(protected: void __cdecl CTaskListWnd::_SetHotItem(struct ITaskBtnGroup *,int,enum SetHotItemFlags))"},
+            &CTaskListWnd__SetHotItem_Original,
+            CTaskListWnd__SetHotItem_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(protected: void __cdecl CTaskListWnd::_OnJumpViewShown(struct HSTRING__ *))"},
+            &CTaskListWnd__OnJumpViewShown_Original,
+            CTaskListWnd__OnJumpViewShown_Hook,
+            true,  // optional
+        },
     };
 
     return WindhawkUtils::HookSymbols(module, taskbarDllHooks,
@@ -8727,6 +8868,10 @@ bool HookTaskbarDllSymbols() {
 namespace AddToTaskbar {
 
 constexpr UINT kMinId = 0xC901;
+// Sits above every dynamic id (pin, then three folder-count-sized ranges for
+// move/copy/shortcut), so it cannot collide however many folders are configured
+// — FolderStore caps the list at 200.
+constexpr UINT kIdManage = kMinId + 1000;
 
 std::wstring LeafName(const std::wstring& path) {
     size_t pos = path.find_last_of(L"\\/");
@@ -9077,6 +9222,16 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
                     L"Copy as shortcut");
         anyItem = true;
     }
+    // Always offered, and the only remaining way in. The folder buttons are real
+    // taskbar items now, so their right-click menu belongs to the shell — it
+    // gives a native "Unpin from taskbar" for free, but there is nowhere on it
+    // to hang "Manage folders...". This entry is the replacement, and unlike the
+    // old one it is reachable when nothing is pinned at all.
+    if (anyItem) {
+        AppendMenuW(foldersMenu, MF_SEPARATOR, 0, nullptr);
+    }
+    AppendMenuW(foldersMenu, MF_STRING, kIdManage, L"Manage folders...");
+    anyItem = true;
     if (!anyItem) {
         DestroyMenu(foldersMenu);
     } else {
@@ -9173,6 +9328,11 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
         return result;
     }
 
+    if (result == kIdManage) {
+        FolderManager::Open();
+        return 0;
+    }
+
     if (canPin && result == kMinId) {
         AddPinnedFolder(path, LeafName(path));
         // Deferred: this is the UI thread of the Explorer window the user just
@@ -9212,10 +9372,56 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
 }  // namespace AddToTaskbar
 
 ////////////////////////////////////////////////////////////////////////////////
+// The jump list's "Manage folders..." task
+//
+// The shell launches a jump list task as an ordinary command line, and the
+// manager window lives in this process, so the launch is caught here instead of
+// being allowed to start anything. CreateProcessW is the choke point: whatever
+// the shell does above it — ShellExecute, link resolution, its own launcher —
+// it has to come through here to start a process.
+
+decltype(&CreateProcessW) CreateProcessW_Original;
+
+BOOL WINAPI CreateProcessW_Hook(LPCWSTR applicationName,
+                                LPWSTR commandLine,
+                                LPSECURITY_ATTRIBUTES processAttributes,
+                                LPSECURITY_ATTRIBUTES threadAttributes,
+                                BOOL inheritHandles,
+                                DWORD creationFlags,
+                                LPVOID environment,
+                                LPCWSTR currentDirectory,
+                                LPSTARTUPINFOW startupInfo,
+                                LPPROCESS_INFORMATION processInformation) {
+    // Deliberately the cheapest possible test, and first: explorer.exe starts a
+    // lot of processes and this hook is on all of them.
+    if (commandLine && wcsstr(commandLine, Pins::kManageSentinel)) {
+        Wh_Log(L"Opening the folder manager from the jump list");
+        FolderManager::Open();
+        // Nothing is launched. Reported as a cancelled launch rather than a
+        // failure so the shell treats it as the user backing out, which it does
+        // silently, instead of showing an error for a task that did exactly
+        // what it was asked to.
+        SetLastError(ERROR_CANCELLED);
+        return FALSE;
+    }
+
+    return CreateProcessW_Original(applicationName, commandLine,
+                                   processAttributes, threadAttributes,
+                                   inheritHandles, creationFlags, environment,
+                                   currentDirectory, startupInfo,
+                                   processInformation);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Mod entry points
 
 BOOL Wh_ModInit() {
     Wh_Log(L"Init");
+
+    // Before LoadSettings: LoadFolders ends with Pins::RequestReconcile, and the
+    // worker has to exist for that kick to land. Start() only creates the thread
+    // and signals; the reconcile itself runs on that thread.
+    Pins::Start();
 
     LoadSettings();
     ResetFolderData();
@@ -9256,6 +9462,17 @@ BOOL Wh_ModInit() {
         // integration.
         Wh_Log(L"Failed to hook TrackPopupMenuEx; Explorer right-click "
                L"integration will be unavailable");
+    }
+
+    // Catches the "Manage folders..." jump list task. Every launch path ends at
+    // CreateProcessW, whatever the shell does above it, so this is the one
+    // place that cannot be missed. Non-fatal: without it the task falls through
+    // and opens an Explorer window instead of the manager.
+    if (!Wh_SetFunctionHook((void*)CreateProcessW,
+                            (void*)CreateProcessW_Hook,
+                            (void**)&CreateProcessW_Original)) {
+        Wh_Log(L"Failed to hook CreateProcessW; the jump list's Manage "
+               L"folders task will not open the manager");
     }
 
     // Scan thread starts lazily on the first RequestScan (hover / inject).
@@ -9348,6 +9565,11 @@ void Wh_ModUninit() {
     FolderManager::CloseAndWait();
     StopRetryThread();
     StopScanThread();
+    // Joins its STA worker. Deliberately does not unpin anything: the pins are
+    // real taskbar items the user arranged, and disabling the mod for a moment
+    // must not throw that away. A reconcile on the next load fixes up whatever
+    // drifted meanwhile.
+    Pins::Stop();
 
     // DestroyWindow / XAML teardown must run on the creating UI thread. Prefer
     // a mod-owned window (level popup or menu owner) when the taskbar HWND is
@@ -9517,6 +9739,15 @@ void Wh_ModUninit() {
         DeleteObject(font);
     }
     FolderManager::g_fontCache.clear();
+
+    // Same reasoning for the dark-mode background brushes.
+    for (HBRUSH* brush :
+         {&FolderManager::g_windowBrush, &FolderManager::g_faceBrush}) {
+        if (*brush) {
+            DeleteObject(*brush);
+            *brush = nullptr;
+        }
+    }
 
     if (g_gdiplusToken) {
         Gdiplus::GdiplusShutdown(g_gdiplusToken);

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.38
+// @version         1.39
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
@@ -678,14 +678,21 @@ int ParseFontWeight(const std::wstring& value, int fallback) {
     return fallback;
 }
 
-// An icon setting is a file reference if it looks like a path, otherwise it is
-// literal text to render (an emoji).
+std::wstring IconSpecFilePart(const std::wstring& spec);
+
+// An icon setting is a file reference if it looks like a path or an
+// "app.exe,<index>" resource spec, otherwise it is literal text to render (an
+// emoji).
 bool IconSettingIsFile(const std::wstring& icon) {
     if (icon.size() < 3) {
         return false;
     }
     if (icon.find(L'\\') != std::wstring::npos ||
         icon.find(L'/') != std::wstring::npos) {
+        return true;
+    }
+    // Bare "explorer.exe,0" — no directory, no drive letter.
+    if (IconSpecFilePart(icon) != icon) {
         return true;
     }
     return icon[1] == L':';
@@ -1535,23 +1542,15 @@ PCWSTR PopupFontName() {
                                               : L"Segoe UI";
 }
 
-// Grid text is Arial. FontFamily construction succeeds even for a missing
-// family but leaves the object in a state GDI+ renders as boxes, so an absent
-// Arial falls back to the system popup font.
-std::wstring PopupTextFontName() {
-    Gdiplus::FontFamily arial(L"Arial");
-    if (arial.GetLastStatus() == Gdiplus::Ok) {
-        return L"Arial";
-    }
-    return PopupFontName();
-}
-
 // Built from a LOGFONT rather than a FontFamily + FontStyle so lfWeight goes to
 // the GDI font mapper, which resolves it against the family's real members.
 // Falls back to the FontFamily path if the mapper gives us something GDI+
 // cannot use.
 std::unique_ptr<Gdiplus::Font> MakePopupFont(int sizePx, int weight) {
-    std::wstring name = PopupTextFontName();
+    // Segoe UI Variable Text matches the surrounding shell and carries the CJK
+    // /Thai/Devanagari/emoji coverage a grid of filenames needs; Arial would
+    // drop those to GDI+ per-glyph font linking.
+    std::wstring name = PopupFontName();
 
     LOGFONTW lf{};
     // Negative lfHeight is the em size in pixels, matching what UnitPixel meant
@@ -6277,10 +6276,10 @@ POINT CenterOnMonitor(POINT anchor, int width, int height) {
 // metrics sized for the *system* DPI, which is what made a scaled window show
 // an oversized font. Cached per DPI so moving between monitors does not leak
 // an HFONT per WM_DPICHANGED; the manager only ever sees a couple of values.
-//
-// no_destroy for the same reason as every other global here: the CRT teardown
-// at Explorer exit must not touch it.
-[[clang::no_destroy]] std::vector<std::pair<int, HFONT>> g_fontCache;
+// Freed in Wh_ModUninit — the vector's own destructor is a plain heap free, so
+// it needs no no_destroy, but the handles it holds would leak into Explorer
+// across every disable/enable cycle.
+std::vector<std::pair<int, HFONT>> g_fontCache;
 
 HFONT UiFont(int dpi) {
     for (const auto& cached : g_fontCache) {
@@ -9396,6 +9395,13 @@ void Wh_ModUninit() {
     UnregisterClassW(kMenuOwnerClassName, instance);
     UnregisterClassW(FolderManager::kClassName, instance);
     UnregisterClassW(FolderManager::kEditClassName, instance);
+
+    // The manager thread is joined by now, so nothing has these selected into a
+    // DC. DeleteObject is a no-op on the DEFAULT_GUI_FONT stock fallback.
+    for (auto& [dpi, font] : FolderManager::g_fontCache) {
+        DeleteObject(font);
+    }
+    FolderManager::g_fontCache.clear();
 
     if (g_gdiplusToken) {
         Gdiplus::GdiplusShutdown(g_gdiplusToken);

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -166,7 +166,9 @@ AppUserModelID, and that shortcut is pinned with the shell's ordinary
 "pin to taskbar" verb. Everything else follows from the buttons being genuine:
 
 - **Drag them** to reorder, like any other taskbar item. The order is the
-  taskbar's, so it survives restarts and is not stored by this mod.
+  taskbar's, so it survives restarts and is not stored by this mod — but it
+  is not preserved across a disable/enable or a settings-page save either,
+  since those unpin and later re-pin every button at the end of the strip.
 - **Right click** gives the normal Windows menu, including
   **Unpin from taskbar** and a **Manage folders...** entry this mod publishes to
   the folder's own jump list. Unpinning keeps the entry in the Taskbar Folders
@@ -175,10 +177,15 @@ AppUserModelID, and that shortcut is pinned with the shell's ordinary
 - Every animation is Windows' own.
 
 **Disabling or uninstalling the mod unpins every button it created**, deletes
-their Start Menu shortcuts and their jump lists — nothing it wrote to the
-shell is left behind. The folder list itself (names, paths, icons) stays in
-the mod's own settings, unpinned, so turning it back on does not mean
-re-adding every folder from scratch.
+their Start Menu shortcuts and their jump lists, and clears the folder list
+itself — nothing it wrote is left behind, and turning it back on starts from
+an empty list rather than silently recreating what was there before.
+
+This cleanup runs from `Wh_ModUninit`, so it does not run on an unclean exit
+(Explorer crashing or being killed, or a hard reboot, while the mod is still
+enabled). If that happens, the leftovers are the shortcuts under
+`%AppData%\Microsoft\Windows\Start Menu\Programs\Taskbar Folder Hover Tray` —
+delete that folder and unpin any of its buttons still on the taskbar by hand.
 
 Earlier versions drew an overlay instead, seated in a gap carved by widening a
 neighbouring icon's margin. It could never be exactly right: taskbar positions are
@@ -221,14 +228,6 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 // ==WindhawkModSettings==
 /*
 - behavior:
-  - openManager: false
-    $name: Open the Taskbar Folders window
-    $description: >-
-      There is no button widget on a Windhawk settings page, so this checkbox
-      is the closest thing to one: tick it to open the Taskbar Folders window
-      immediately. It does not save any state of its own and is left however
-      you leave it — untick and tick again to reopen the window.
-
   - openFolderOnClick: true
     $name: Click opens the folder
     $description: >-
@@ -456,6 +455,7 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 #include <atomic>
 #include <chrono>
 #include <cmath>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -1031,6 +1031,10 @@ int IndexOfPath(const std::vector<Entry>& entries, const std::wstring& path) {
 //     arrives by SendMessage, cannot be used: every outgoing COM call from there
 //     fails with RPC_E_CANTCALLOUT_ININPUTSYNCCALL having done nothing, which
 //     looks exactly like a permissions refusal and is not one.
+
+// Pumps the calling STA's message queue. Defined with the scan thread further
+// down; forward-declared here so the pin worker (also an STA) can use it.
+void PumpScanThreadMessages();
 
 namespace Pins {
 
@@ -1926,6 +1930,7 @@ void Reconcile() {
                 dropped = true;
                 break;
             }
+            PumpScanThreadMessages();
             Sleep(25);
         }
         Wh_Log(L"Pins: waited %llums for %s to drop from the pinned list: %s",
@@ -2058,6 +2063,14 @@ HANDLE g_thread = nullptr;
 HANDLE g_stopEvent = nullptr;  // manual-reset
 HANDLE g_kickEvent = nullptr;  // auto-reset
 
+// Set by Stop() before it signals g_stopEvent, run by ThreadProc itself right
+// before it uninitializes COM and exits. This is a known-good STA — the pin
+// verb's COM class is ThreadingModel=Apartment with no marshaler, so cleanup
+// that invokes it must run on an apartment that is guaranteed to still be
+// alive, not on whatever arbitrary thread called Stop(). Safe without a lock:
+// the write happens-before the SetEvent that wakes the worker to read it.
+std::function<void()> g_finalAction;
+
 // Unpinning from the taskbar's own right-click menu is completely silent: it
 // changes nothing the mod owns, so nothing calls RequestReconcile and the entry
 // stays "pinned" in the store until something else happens to trigger a reload
@@ -2147,10 +2160,14 @@ DWORD WINAPI ThreadProc(void*) {
 
     bool stopping = false;
     while (!stopping) {
-        DWORD result =
-            WaitForMultipleObjects(count, waits, FALSE, kReconcilePollMs);
+        DWORD result = MsgWaitForMultipleObjects(count, waits, FALSE,
+                                                  kReconcilePollMs, QS_ALLINPUT);
         if (result == WAIT_OBJECT_0 || result == WAIT_FAILED) {
             break;
+        }
+        if (result == WAIT_OBJECT_0 + count) {
+            PumpScanThreadMessages();
+            continue;
         }
         if (result != WAIT_TIMEOUT) {
             rearm(result - WAIT_OBJECT_0);
@@ -2162,14 +2179,18 @@ DWORD WINAPI ThreadProc(void*) {
         // passes per user action — and, worse, reconciling while the shell is
         // still half way through writing.
         for (;;) {
-            DWORD more = WaitForMultipleObjects(count, waits, FALSE,
-                                                kPinWatchDebounceMs);
+            DWORD more = MsgWaitForMultipleObjects(
+                count, waits, FALSE, kPinWatchDebounceMs, QS_ALLINPUT);
             if (more == WAIT_TIMEOUT) {
                 break;
             }
             if (more == WAIT_OBJECT_0 || more == WAIT_FAILED) {
                 stopping = true;
                 break;
+            }
+            if (more == WAIT_OBJECT_0 + count) {
+                PumpScanThreadMessages();
+                continue;
             }
             rearm(more - WAIT_OBJECT_0);
         }
@@ -2188,6 +2209,10 @@ DWORD WINAPI ThreadProc(void*) {
     }
     if (taskbandKey) {
         RegCloseKey(taskbandKey);
+    }
+    if (g_finalAction) {
+        g_finalAction();
+        g_finalAction = nullptr;
     }
     CoUninitialize();
     return 0;
@@ -2215,7 +2240,18 @@ void Start() {
     }
 }
 
-void Stop() {
+// finalAction, if given, runs on the worker's own STA right before it
+// uninitializes COM and exits — see g_finalAction above.
+void Stop(std::function<void()> finalAction = nullptr) {
+    if (finalAction) {
+        if (g_thread) {
+            g_finalAction = std::move(finalAction);
+        } else {
+            // Worker never started this session (Start() failed, or was never
+            // called) — nowhere else to run it, so run it here directly.
+            finalAction();
+        }
+    }
     if (g_stopEvent) {
         SetEvent(g_stopEvent);
     }
@@ -2418,11 +2454,8 @@ void RemovePinnedFolder(const std::wstring& path) {
 // there first), not lazily on first Wh_ModSettingsChanged call — that call
 // only fires after a change, so a lazy static would initialize itself from
 // the value the user just ticked and miss that very rising edge.
-bool g_lastOpenManager = false;
-
 void LoadSettings() {
     LoadFolders(&g_settings.folders);
-    g_lastOpenManager = Wh_GetIntSetting(L"behavior.openManager") != 0;
 
     // "type" was the old folders-first option, which is now unconditional.
     std::wstring sortBy = GetStringSetting(L"content.sortBy");
@@ -6744,7 +6777,13 @@ void UnbindPinButtons(TaskbarHost* host) {
             if (binding.exitToken.value) {
                 binding.button.PointerExited(binding.exitToken);
             }
-            ToolTipService::SetToolTip(binding.button, binding.savedTooltip);
+            if (binding.savedTooltip ==
+                winrt::Windows::UI::Xaml::DependencyProperty::UnsetValue()) {
+                binding.button.ClearValue(ToolTipService::ToolTipProperty());
+            } else {
+                binding.button.SetValue(ToolTipService::ToolTipProperty(),
+                                        binding.savedTooltip);
+            }
         } catch (...) {
             // The element can already be torn down; nothing to release then.
         }
@@ -6806,15 +6845,40 @@ void RebindPinButtons(TaskbarHost* host) {
 
     UnbindPinButtons(host);
 
-    HWND taskbarWnd = host->hwnd;
-    int matched = 0;
-    for (const auto& child : children) {
+    // Resolve every realized button's folder index up front so a folder whose
+    // label prefix-matches two different realized buttons (e.g. our own
+    // "Games" next to an unrelated app whose title happens to start the same
+    // way) can be caught before either one is bound. Binding the wrong one
+    // would silently steal hover from that other app's button; binding
+    // neither just means this folder's button does nothing until the name
+    // collision goes away.
+    std::unordered_map<int, int> folderIndexCounts;
+    std::vector<int> childFolderIndex(children.size(), -1);
+    for (size_t i = 0; i < children.size(); i++) {
+        const auto& child = children[i];
         if (!child || winrt::get_class_name(child) !=
                           L"Taskbar.TaskListButton") {
             continue;
         }
         int folderIndex = FolderIndexForTaskListButton(child);
+        childFolderIndex[i] = folderIndex;
+        if (folderIndex >= 0) {
+            folderIndexCounts[folderIndex]++;
+        }
+    }
+
+    HWND taskbarWnd = host->hwnd;
+    int matched = 0;
+    for (size_t i = 0; i < children.size(); i++) {
+        const auto& child = children[i];
+        int folderIndex = childFolderIndex[i];
         if (folderIndex < 0) {
+            continue;
+        }
+        if (folderIndexCounts[folderIndex] > 1) {
+            Wh_Log(L"Pins: '%s' matches more than one realized taskbar "
+                   L"button; leaving all of them unbound",
+                   AutomationNameOf(child).c_str());
             continue;
         }
 
@@ -6822,7 +6886,7 @@ void RebindPinButtons(TaskbarHost* host) {
         // grid we open on hover with a second, redundant popup naming the
         // same folder. Suppress it for buttons we've claimed, saving the
         // shell's value so UnbindPinButtons can restore it later.
-        auto savedTooltip = ToolTipService::GetToolTip(child);
+        auto savedTooltip = child.ReadLocalValue(ToolTipService::ToolTipProperty());
         ToolTipService::SetToolTip(child, nullptr);
 
         PinBinding binding;
@@ -8117,15 +8181,13 @@ void RemoveSelected(HWND hWnd) {
 // Unpins every real taskbar button, deletes their Start Menu shortcuts and
 // their per-AppID jump lists — everything InvokeVerb's "taskbarpin" and
 // WriteJumpList put in place. Shared by the user-facing "Remove all folder
-// buttons" action (clearStore = true, wipes the folder list too) and the
-// automatic cleanup Wh_ModUninit runs on every disable/uninstall
-// (clearStore = false, folders keep their pinned=true intent — only
-// pinApplied is cleared — so the next Reconcile() this mod runs, whether
-// from a real re-enable or a code-update reload, silently re-pins them).
+// buttons" action and the automatic cleanup Wh_ModUninit runs on every
+// disable/uninstall, so nothing this mod wrote — on the taskbar, in the
+// Start Menu, or in its own folder list — outlives either path.
 //
 // CoInitializeEx is refcounted per thread, so this is safe to call whether or
 // not the calling thread already has COM up (Wh_ModUninit's does not).
-void RemoveAllFolderButtonsCore(bool clearStore) {
+void RemoveAllFolderButtonsCore() {
     struct ComInit {
         HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
         ~ComInit() {
@@ -8134,6 +8196,18 @@ void RemoveAllFolderButtonsCore(bool clearStore) {
             }
         }
     } com;
+
+    // The pin verb's COM class is ThreadingModel=Apartment with no marshaler,
+    // so every InvokeVerb below silently fails if this thread is not really
+    // an STA (RPC_E_CHANGED_MODE means it is already an MTA, which is exactly
+    // that case). Bail loudly rather than grinding through a no-op sweep that
+    // looks like it ran.
+    if (FAILED(com.hr)) {
+        Wh_Log(L"RemoveAllFolderButtonsCore: CoInitializeEx(STA) failed: "
+               L"0x%08X; skipping unpin sweep",
+               com.hr);
+        return;
+    }
 
     for (const auto& item : Pins::ReadPinnedItems()) {
         Pins::InvokeVerb(item.path, "taskbarunpin");
@@ -8162,18 +8236,7 @@ void RemoveAllFolderButtonsCore(bool clearStore) {
     }
 
     std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
-    if (clearStore) {
-        FolderStore::Write({});
-    } else {
-        auto stored = FolderStore::Read();
-        for (auto& entry : stored) {
-            // Not entry.pinned: that is the user's intent and must survive
-            // this pass so a later Reconcile() re-pins automatically.
-            // pinApplied is state, and now false is the truth.
-            entry.pinApplied = false;
-        }
-        FolderStore::Write(stored);
-    }
+    FolderStore::Write({});
 }
 
 void RemoveAllFolderButtons(HWND hWnd) {
@@ -8187,7 +8250,7 @@ void RemoveAllFolderButtons(HWND hWnd) {
         return;
     }
 
-    RemoveAllFolderButtonsCore(/*clearStore=*/true);
+    RemoveAllFolderButtonsCore();
     RefreshAfterStoreChange(hWnd);
 }
 
@@ -8195,13 +8258,17 @@ void RemoveAllFolderButtons(HWND hWnd) {
 // way it was. Called from Wh_ModUninit, which fires on every disable and
 // every uninstall alike (Windhawk does not distinguish the two, and neither
 // does it distinguish a real disable from the reload after a code-update
-// save) — so the real taskbar pins, their Start Menu shortcuts and their
-// jump lists never outlive this pass. The folder list itself keeps its
-// pinned intent, so the next Reconcile() (from a real re-enable, or from
-// the Wh_ModInit that follows an update reload moments later) puts
-// everything straight back without the user re-adding anything.
+// save) — so the real taskbar pins, their Start Menu shortcuts, their jump
+// lists and the folder list itself never outlive this pass. Nothing survives
+// a disable: a re-enable starts from the default, empty folder list rather
+// than silently recreating whatever was configured before.
+//
+// This does mean a code-update / settings-page save (which Windhawk routes
+// through the same Wh_ModUninit -> Wh_ModInit path as a real disable, with no
+// way to tell the two apart from here) wipes the folder list too, not just
+// the code reload it looks like from the user's side.
 void UnpinAllForDisable() {
-    RemoveAllFolderButtonsCore(/*clearStore=*/false);
+    RemoveAllFolderButtonsCore();
 }
 
 // A single-select listbox never lets go of its selection on its own — a click
@@ -9916,18 +9983,6 @@ void ReloadAndRefreshUI() {
 BOOL Wh_ModSettingsChanged(BOOL* bReload) {
     Wh_Log(L"SettingsChanged");
 
-    // A checkbox-as-link: openManager has no persisted meaning of its own, it
-    // is just the closest thing Windhawk's settings page has to a button.
-    // Every rising edge (false -> true) opens the manager; the box is left
-    // however the user leaves it. g_lastOpenManager is seeded in
-    // LoadSettings() at Wh_ModInit, not lazily here, so the very first tick
-    // after a mod (re)load is itself seen as a rising edge.
-    bool openManager = Wh_GetIntSetting(L"behavior.openManager") != 0;
-    if (openManager && !g_lastOpenManager) {
-        FolderManager::Open();
-    }
-    g_lastOpenManager = openManager;
-
     RequestReloadUI();
 
     return TRUE;
@@ -9945,12 +10000,16 @@ void Wh_ModUninit() {
     // Disabling (or uninstalling — Wh_ModUninit does not see a difference)
     // must leave the system as it was: real taskbar pins, Start Menu
     // shortcuts and jump lists this mod created do not get to outlive it.
-    // Stop and join the reconcile worker first: it can be mid-Reconcile()
-    // (pinned-dir watch, Taskband watch, or the periodic poll — the unpins
-    // below even fire the dir watch) and would otherwise re-create pins and
-    // Start Menu shortcuts the sweep below just removed.
-    Pins::Stop();
-    FolderManager::UnpinAllForDisable();
+    // Stop the reconcile worker, but run the disable-time unpin sweep as its
+    // very last action before it joins: it can be mid-Reconcile() (pinned-dir
+    // watch, Taskband watch, or the periodic poll — the unpins below even
+    // fire the dir watch) and would otherwise re-create pins and Start Menu
+    // shortcuts the sweep just removed. Running the sweep there, rather than
+    // here on this arbitrary Windhawk engine thread, also guarantees it runs
+    // on a real STA — the pin verb's COM class has no marshaler, so every
+    // InvokeVerb from a thread that isn't one silently fails and leaves every
+    // pinned button, Start Menu shortcut and jump list behind.
+    Pins::Stop(&FolderManager::UnpinAllForDisable);
 
     // DestroyWindow / XAML teardown must run on the creating UI thread. Prefer
     // a mod-owned window (level popup or menu owner) when the taskbar HWND is

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -7755,6 +7755,34 @@ std::wstring EscapeMenuLabel(const std::wstring& s) {
     return out;
 }
 
+// Position (by-position index) of the top-level item whose visible text
+// matches `label`, ignoring '&' mnemonics and any trailing "\taccelerator".
+// Returns -1 if not found.
+int FindMenuItemPositionByLabel(HMENU menu, PCWSTR label) {
+    int count = GetMenuItemCount(menu);
+    for (int i = 0; i < count; i++) {
+        WCHAR buf[256];
+        int len = GetMenuStringW(menu, i, buf, ARRAYSIZE(buf), MF_BYPOSITION);
+        if (len <= 0) {
+            continue;
+        }
+        std::wstring text(buf, len);
+        if (PCWSTR tab = wcschr(text.c_str(), L'\t')) {
+            text.resize(tab - text.c_str());
+        }
+        std::wstring stripped;
+        for (wchar_t c : text) {
+            if (c != L'&') {
+                stripped += c;
+            }
+        }
+        if (_wcsicmp(stripped.c_str(), label) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
 // The shell view that owns `hwnd`, or null if there is not one — which is also
 // what says "this is an Explorer or Desktop context menu, not some other
 // TrackPopupMenuEx caller in the process".
@@ -7994,10 +8022,37 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
     if (!anyItem) {
         DestroyMenu(foldersMenu);
     } else {
-        if (GetMenuItemCount(hMenu) > 0) {
-            AppendMenuW(hMenu, MF_SEPARATOR, 0, nullptr);
+        // Sit right under "Pin to taskbar" so it reads as a related action,
+        // falling back to right under "Give access to" when Explorer didn't
+        // offer a pin item (e.g. the item is already pinned).
+        int afterPos = FindMenuItemPositionByLabel(hMenu, L"Pin to taskbar");
+        if (afterPos < 0) {
+            afterPos = FindMenuItemPositionByLabel(hMenu, L"Give access to");
         }
-        AppendMenuW(hMenu, MF_POPUP, (UINT_PTR)foldersMenu, L"Taskbar Folders");
+        if (afterPos >= 0) {
+            InsertMenuW(hMenu, afterPos + 1, MF_BYPOSITION | MF_POPUP,
+                        (UINT_PTR)foldersMenu, L"Taskbar Folders");
+        } else {
+            if (GetMenuItemCount(hMenu) > 0) {
+                AppendMenuW(hMenu, MF_SEPARATOR, 0, nullptr);
+            }
+            AppendMenuW(hMenu, MF_POPUP, (UINT_PTR)foldersMenu,
+                        L"Taskbar Folders");
+        }
+
+        // Explorer applies dark-mode/background MENUINFO across the whole
+        // menu tree it builds via SetMenuInfo(..., MIM_APPLYTOSUBMENUS)
+        // before handing off to TrackPopupMenuEx. Our submenu is created
+        // afterward, inside this hook, so it never inherits that pass —
+        // copying the parent's MENUINFO onto it (with MIM_APPLYTOSUBMENUS so
+        // it cascades down to Move/Copy/Copy as shortcut too) is what fixes
+        // the classic light-mode square border that otherwise shows up only
+        // on menus this mod injects.
+        MENUINFO parentInfo{sizeof(parentInfo)};
+        parentInfo.fMask = MIM_STYLE | MIM_BACKGROUND | MIM_APPLYTOSUBMENUS;
+        if (GetMenuInfo(hMenu, &parentInfo)) {
+            SetMenuInfo(foldersMenu, &parentInfo);
+        }
     }
 
     // Submenus we inject (MF_POPUP with our own CreatePopupMenu() handles)

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.29
+// @version         1.30
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
@@ -353,16 +353,6 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 
 - gapAfter: 0
   $name: 3. Appearance ▸ Padding after buttons (px)
-
-- debugAnimLog: false
-  $name: 9. Debug ▸ Position trace logging
-  $description: Traces folder-button positioning to the Windhawk debug
-    console, one [ANIM] line per event - WINDOW (a window opened or closed),
-    ANCHOR (the anchored app icon was swapped), MARGIN (the reserved gap was
-    rewritten), SLIDE (the buttons were retargeted), RECYCLED/EXCEPTION - plus
-    GAP or OVERLAP when the settled distance between the folder buttons and
-    the app strip is not the configured padding, with every app icon's
-    position at that moment.
 */
 // ==/WindhawkModSettings==
 
@@ -487,21 +477,9 @@ struct Settings {
     // Read from an Explorer window thread inside the TrackPopupMenuEx hook
     // while LoadSettings may be writing it on another.
     std::atomic<bool> explorerMenu{true};
-    bool debugAnimLog = false;
 };
 
 Settings g_settings;
-
-// One-line-per-event trace, all under the same [ANIM] prefix so the whole
-// sequence (window opened, anchor swapped, margin rewritten, slide retargeted,
-// gap went bad) reads in order in the Windhawk log and filters with one grep.
-// Every call is off unless the debug setting is on.
-#define ANIM_TRACE(fmt, ...)                       \
-    do {                                           \
-        if (g_settings.debugAnimLog) {             \
-            Wh_Log(L"[ANIM] " fmt, ##__VA_ARGS__); \
-        }                                          \
-    } while (0)
 
 // Guards FolderEntry::resolvedPath / likelyRemote fills from STA resolve helpers
 // while UI and the scan worker may read them.
@@ -1072,7 +1050,6 @@ void LoadSettings() {
         std::clamp<int>(Wh_GetIntSetting(L"buttonIconSize"), 0, 128);
     g_settings.openFolderOnClick = Wh_GetIntSetting(L"openFolderOnClick");
     g_settings.explorerMenu = Wh_GetIntSetting(L"explorerMenu") != 0;
-    g_settings.debugAnimLog = Wh_GetIntSetting(L"debugAnimLog") != 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4579,18 +4556,6 @@ struct TaskbarHost {
     // AnimateHostGridLeftTo to skip the open/close sync delay for that one
     // retarget — see the anchor-changed comment in OnRootGridLayoutUpdated.
     bool anchorSwapped = false;
-    // First tick the settled gap looked wrong (0 = it looks fine), and whether
-    // that stretch has already been logged, so one bad stretch produces one
-    // error line plus one recovery line instead of one per layout pass. See
-    // CheckHostGridHealth.
-    ULONGLONG dbgBadSince = 0;
-    bool dbgBadLogged = false;
-    // Placed/visible app buttons last pass and when that count last moved -
-    // the only reliable "a window opened/closed" signal available (see
-    // CensusAppStrip). A retarget bigger than a button with no recent change
-    // here has no legitimate cause and gets flagged.
-    int dbgVisibleButtons = -1;
-    ULONGLONG dbgLastWindowTick = 0;
     // Where the anchor was sitting when it was adopted one full reserve-width
     // clear of the rest of the strip, i.e. parked on the far side of our own
     // gap. -1 when the anchor was adopted normally. Positioning is held until
@@ -5147,14 +5112,12 @@ FrameworkElement ResolveAnchor(FrameworkElement const& repeater,
     return nullptr;
 }
 
-// Debug-only census of the app strip. The repeater's realized-child count is
-// not a usable open/close signal: ItemsRepeater recycles containers, so a
-// window opening or closing leaves the count unchanged - a full trace of
-// spammed open/close produced zero count changes while the strip visibly grew
-// and shrank. What does move is the number of *placed, visible*
-// TaskListButtons, so that stands in for "a window opened/closed" here, with
-// the strip's own left/right extent alongside it so the re-centre that follows
-// is visible on the same line.
+// Counts the placed, visible app buttons and measures the strip's left/right
+// extent. The repeater's realized-child count cannot stand in for either:
+// ItemsRepeater recycles containers, so a window opening or closing leaves that
+// count unchanged while the strip visibly grows and shrinks. `exclude` leaves
+// out a button being adopted as the anchor, so the clearance check has the rest
+// of the strip - all of it settled - as its reference.
 int CensusAppStrip(FrameworkElement const& repeater, Grid const& rootGrid,
                    double* stripLeft, double* stripRight,
                    FrameworkElement const& exclude = nullptr) {
@@ -5332,7 +5295,6 @@ void AnimateHostGridLeftTo(TaskbarHost* host, double newLeft,
         delayMs = remain > 0 ? (int)remain : 0;
     }
 
-    bool wasAnchorSwap = host->anchorSwapped;
     if (host->anchorSwapped) {
         // The anchor teleported to a new button instead of sliding — chase
         // it now instead of waiting out a sync delay for motion that isn't
@@ -5387,58 +5349,13 @@ void AnimateHostGridLeftTo(TaskbarHost* host, double newLeft,
 
         host->slideStartTick = now + delayMs;
         host->slideEndTick = now + delayMs + kHostGridSlideMs;
-
-        // retarget=1 means this replaced a slide that was already moving or
-        // still waiting - a burst of those between two WINDOW lines is the
-        // signature of the target thrashing rather than settling.
-        double delta = newLeft - previousLeft;
-        ANIM_TRACE(L"SLIDE t=%llu host=%p %.2f->%.2f (%+.2f) anchorX=%.2f "
-                   L"delay=%d close=%d retarget=%d swapped=%d churn=%d",
-                   now, host->hwnd, previousLeft, newLeft, delta, anchorX,
-                   delayMs, (int)isCloseMove, (int)(pending || animating),
-                   (int)wasAnchorSwap, (int)churning);
-
-        // The reserve is a Margin on the anchor button, so in the repeater's
-        // horizontal layout the anchor occupies its own width *plus* the
-        // reserve - and any button inserted to its outer side is laid out on
-        // the far side of our gap, at anchorX + anchorWidth + reserve. That
-        // button is visible and placed, so ResolveAnchor adopts it, the
-        // reserve moves onto it, and the whole thing walks another reserve
-        // further out. A retarget of exactly one reserve width is that loop,
-        // and it is the visible large gap. Distinct from the ordinary
-        // half-a-button re-centre a real open/close produces.
-        double reserve =
-            DesiredHostWidth(host) + g_settings.gapBefore + g_settings.gapAfter;
-        if (reserve > 1.0 && std::abs(std::abs(delta) - reserve) < 4.0) {
-            ANIM_TRACE(L"RESERVE-JUMP t=%llu host=%p retarget %+.2f == the "
-                       L"reserved width (%.2f) — a new app button was laid "
-                       L"out past our own reserve and adopted as the anchor; "
-                       L"self-inflicted, anchorX=%.2f swapped=%d",
-                       now, host->hwnd, delta, reserve, anchorX,
-                       (int)wasAnchorSwap);
-        } else if (std::abs(delta) > host->buttonWidth &&
-                   now - host->dbgLastWindowTick > 500) {
-            // Bigger than one button, no window change behind it: the target
-            // is wrong for some other reason (anchor measured mid-recycle).
-            ANIM_TRACE(L"SUSPECT t=%llu host=%p retarget %+.2f (>1 button) "
-                       L"with no window change for %llums — anchorX=%.2f "
-                       L"anchorSwapped=%d",
-                       now, host->hwnd, delta, now - host->dbgLastWindowTick,
-                       anchorX, (int)wasAnchorSwap);
-        }
     } catch (...) {
         // Animation unavailable for whatever reason — still get the element
-        // to the right place, just without the slide. This is exactly the
-        // kind of thing that produces a one-frame jump/overlap, so it's
-        // worth an error even though the element ends up in the right spot.
+        // to the right place, just without the slide. Reads as a one-frame
+        // stutter rather than a wrong position.
         try {
             host->slideStoryboard = nullptr;
             host->hostTranslate.X(newLeft);
-            ANIM_TRACE(L"SNAP t=%llu host=%p %.2f->%.2f close=%d delay=%d — "
-                       L"storyboard threw, snapped instead (reads as a "
-                       L"stutter)",
-                       now, host->hwnd, previousLeft, newLeft,
-                       (int)isCloseMove, delayMs);
         } catch (...) {
         }
     }
@@ -5450,14 +5367,9 @@ void RestoreAnchorMargin(TaskbarHost* host) {
     }
     if (host->anchor && host->hasAnchorOriginalMargin) {
         try {
-            // Paired with the MARGIN write on the incoming anchor. The two
-            // land in the same layout pass, so seeing only one of them in the
-            // log means the strip spent a pass either double-reserved or
-            // un-reserved - a full 264px of width appearing or vanishing.
-            ANIM_TRACE(L"RESTORE t=%llu host=%p anchor=%p margin -> %.2f/%.2f",
-                       GetTickCount64(), host->hwnd, winrt::get_abi(host->anchor),
-                       host->anchorOriginalMargin.Left,
-                       host->anchorOriginalMargin.Right);
+            // Paired with the reserve written onto the incoming anchor: both
+            // land in the same layout pass, so the strip is never left a pass
+            // either double-reserved or un-reserved.
             host->anchor.Margin(host->anchorOriginalMargin);
         } catch (...) {
         }
@@ -7201,8 +7113,6 @@ Grid BuildHostGrid(TaskbarHost* host) {
     host->slideCauseTick = 0;
     host->slideCauseIsClose = false;
     host->lastRetargetTick = 0;
-    host->dbgBadSince = 0;
-    host->dbgBadLogged = false;
     host->parkedAnchorX = -1.0;
     host->reserveHolds = 0;
     host->lastAnchorX = -1.0;
@@ -7488,52 +7398,6 @@ void RemoveAllHostGrids() {
     g_injectionLive = false;
 }
 
-// Only called once a health check below has already decided something is
-// wrong. Dumps every realized child of the app-icon repeater - taskbar
-// buttons, the widgets/task-view/start toggles, everything - with its class,
-// X position (relative to rootGrid, same space AnchorX/hostGrid use), width,
-// and visibility, so the error line above it is followed by the full picture
-// of where every icon actually was that frame. Apps move between the start
-// button, task view, the widgets button, and either side of the app strip
-// depending on pin state and window count, so this is unfiltered: every
-// child, no assumptions about which slot anything is in.
-void LogRepeaterPositions(TaskbarHost* host, FrameworkElement const& repeater,
-                           PCWSTR tag) {
-    if (!repeater || !host || !host->trackedRootGrid) {
-        return;
-    }
-    std::vector<FrameworkElement> children;
-    EnumRepeaterChildren(repeater, &children);
-    ANIM_TRACE(L"%s   repeater children=%zu (host=%p)", tag, children.size(),
-               host->hwnd);
-    for (size_t i = 0; i < children.size(); i++) {
-        auto const& child = children[i];
-        try {
-            auto className = winrt::get_class_name(child);
-            double x = -99999.0;
-            try {
-                auto point = child.TransformToVisual(host->trackedRootGrid)
-                                 .TransformPoint({0, 0});
-                x = point.X;
-            } catch (...) {
-            }
-            ANIM_TRACE(L"%s     [%zu] class=%s x=%.2f w=%.2f h=%.2f vis=%d "
-                       L"opacity=%.2f",
-                       tag, i, className.c_str(), x, child.ActualWidth(),
-                       child.ActualHeight(), (int)child.Visibility(),
-                       child.Opacity());
-        } catch (...) {
-            ANIM_TRACE(L"%s     [%zu] <threw reading child>", tag, i);
-        }
-    }
-}
-
-// How far the settled gap may differ from the configured padding before it
-// counts as wrong, and how long it has to stay wrong before it's logged. The
-// second number matters: a single layout pass routinely lands in the window
-// between the anchor moving and our retarget being handed to the compositor,
-// and that transient is normal. A gap that's still wrong a few hundred ms
-// after the last slide finished is the actual bug being hunted.
 // Layout passes during an icon slide come every ~15ms, so this covers the
 // taskbar's own 250ms slide with room to spare while still guaranteeing the
 // overlay gives in and moves if a reserve-sized target is genuinely correct.
@@ -7547,119 +7411,6 @@ constexpr double kAnchorSettleEpsilon = 0.5;
 // wins the race; it exists only so an anchor that somehow never stops (a
 // perpetual animation, a stuck arrange) cannot wedge the overlay in place.
 constexpr ULONGLONG kMaxAnchorSettleMs = 600;
-
-constexpr double kGapTolerancePx = 2.0;
-constexpr ULONGLONG kBadGapSettleMs = 400;
-
-// Checked once per layout pass against the anchor position just measured by
-// OnRootGridLayoutUpdated, using hostGrid's live RenderTransform X (where it
-// visibly is right now, not the animation's target). One failure mode: the
-// space between the folder block and the app strip is not the configured
-// padding once everything has stopped moving — negative means they overlap,
-// too large means a leftover gap.
-// Silent while a slide is pending or running (the gap is supposed to be wrong
-// then), and silent until a wrong gap has persisted past kBadGapSettleMs. One
-// bad stretch logs exactly one error line (plus the full repeater dump) and
-// one recovery line carrying how long it lasted.
-void CheckHostGridHealth(TaskbarHost* host, FrameworkElement const& repeater,
-                          bool before, double anchorX, double anchorWidth) {
-    if (!g_settings.debugAnimLog || !host || !host->hostGrid ||
-        !host->trackedRootGrid || !host->hasPlaced) {
-        return;
-    }
-
-    double hostWidth = DesiredHostWidth(host);
-    if (hostWidth <= 1.0) {
-        return;
-    }
-
-    ULONGLONG now = GetTickCount64();
-    double liveLeft = host->hostTranslate ? host->hostTranslate.X() : host->currentLeft;
-    double rootWidth = 0.0;
-    try {
-        rootWidth = host->trackedRootGrid.ActualWidth();
-    } catch (...) {
-    }
-
-    double gap;
-    double expectedGap;
-    if (before) {
-        // hostGrid sits left of the anchor: gap is the space between its
-        // right edge and the anchor's left edge.
-        gap = anchorX - (liveLeft + hostWidth);
-        expectedGap = g_settings.gapAfter;
-    } else {
-        // hostGrid sits right of the anchor: gap is the space between the
-        // anchor's right edge and hostGrid's left edge.
-        gap = liveLeft - (anchorX + anchorWidth);
-        expectedGap = g_settings.gapBefore;
-    }
-
-    // Mid-slide, or still waiting on the slide's start delay: hostGrid is on
-    // its way somewhere, so its distance from the anchor means nothing yet.
-    if (host->slideStoryboard && now < host->slideEndTick) {
-        host->dbgBadSince = 0;
-        host->dbgBadLogged = false;
-        return;
-    }
-
-    if (std::abs(gap - expectedGap) <= kGapTolerancePx) {
-        if (host->dbgBadLogged) {
-            ANIM_TRACE(L"GAP-OK t=%llu host=%p gap=%.2f liveLeft=%.2f "
-                       L"(was wrong for %llums)",
-                       now, host->hwnd, gap, liveLeft,
-                       now - host->dbgBadSince);
-        }
-        host->dbgBadSince = 0;
-        host->dbgBadLogged = false;
-        return;
-    }
-
-    if (!host->dbgBadSince) {
-        host->dbgBadSince = now;
-        return;
-    }
-    if (host->dbgBadLogged || now - host->dbgBadSince < kBadGapSettleMs) {
-        return;
-    }
-    host->dbgBadLogged = true;
-
-    bool visible = true;
-    double opacity = 1.0;
-    try {
-        visible = host->hostGrid.Visibility() == Visibility::Visible;
-        opacity = host->hostGrid.Opacity();
-    } catch (...) {
-    }
-
-    PCWSTR kind = gap < 0 ? L"OVERLAP" : L"GAP";
-    ANIM_TRACE(L"%s t=%llu host=%p before=%d gap=%.2f expected=%.2f "
-               L"off-by=%.2f stuck=%llums",
-               kind, now, host->hwnd, (int)before, gap, expectedGap,
-               gap - expectedGap, now - host->dbgBadSince);
-    ANIM_TRACE(L"%s   hostGrid: liveLeft=%.2f target=%.2f width=%.2f "
-               L"rightEdge=%.2f visible=%d opacity=%.2f rootWidth=%.2f",
-               kind, liveLeft, host->currentLeft, hostWidth,
-               liveLeft + hostWidth, (int)visible, opacity, rootWidth);
-    double marginSide = -1.0;
-    try {
-        auto margin = host->anchor.Margin();
-        marginSide = before ? margin.Left : margin.Right;
-    } catch (...) {
-    }
-    double originalSide = before ? host->anchorOriginalMargin.Left
-                                 : host->anchorOriginalMargin.Right;
-    ANIM_TRACE(L"%s   anchor: x=%.2f width=%.2f margin=%.2f original=%.2f "
-               L"reserved=%.2f children=%d",
-               kind, anchorX, anchorWidth, marginSide, originalSide,
-               marginSide - originalSide, host->lastRepeaterChildCount);
-    ANIM_TRACE(L"%s   slide: lastEnd=%lld ms ago storyboard=%d close=%d "
-               L"anchorSwapped=%d",
-               kind, (long long)now - (long long)host->slideEndTick,
-               (int)(bool)host->slideStoryboard, (int)host->slideCauseIsClose,
-               (int)host->anchorSwapped);
-    LogRepeaterPositions(host, repeater, kind);
-}
 
 void OnRootGridLayoutUpdated(TaskbarHost* host) {
     if (g_unloading || !host || !host->hostGrid || !host->trackedRootGrid) {
@@ -7729,26 +7480,6 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
         bool childCountChanged = childCount != host->lastRepeaterChildCount;
         host->lastRepeaterChildCount = childCount;
 
-        // Every WINDOW line is one window opening or closing. Counted from the
-        // placed/visible buttons rather than childCountChanged above, which
-        // never moves at all (recycling) - see CensusAppStrip. Head of the
-        // causal chain for everything logged below.
-        if (g_settings.debugAnimLog) {
-            double stripLeft = 0.0;
-            double stripRight = 0.0;
-            int visible = CensusAppStrip(repeater, host->trackedRootGrid,
-                                         &stripLeft, &stripRight);
-            if (visible != host->dbgVisibleButtons) {
-                ANIM_TRACE(L"WINDOW t=%llu host=%p buttons %d->%d (%+d) "
-                           L"strip=[%.2f..%.2f] w=%.2f realized=%d",
-                           now, host->hwnd, host->dbgVisibleButtons, visible,
-                           visible - host->dbgVisibleButtons, stripLeft,
-                           stripRight, stripRight - stripLeft, childCount);
-                host->dbgVisibleButtons = visible;
-                host->dbgLastWindowTick = now;
-            }
-        }
-
         bool anchorLooksDead = !host->anchor || !host->anchor.Parent();
         if (anchorLooksDead || childCountChanged ||
             now - host->lastAnchorResolveTick > 250) {
@@ -7764,34 +7495,13 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
                     // icon-slide timing) would just leave hostGrid parked
                     // over the new anchor's slot for a few hundred ms.
                     host->anchorSwapped = true;
-                    // The margin the new anchor is adopted with is snapshotted
-                    // as its "original", so it is worth seeing: if it were
-                    // already carrying a reserved gap from a previous
-                    // adoption, that gap would be baked in and doubled.
-                    double m = -1.0;
                     double rx = -1.0;
                     double rw = -1.0;
-                    winrt::hstring cls;
                     try {
-                        auto margin = resolved.Margin();
-                        m = (g_settings.position != L"afterApps")
-                                ? margin.Left
-                                : margin.Right;
-                        cls = winrt::get_class_name(resolved);
                         rw = resolved.ActualWidth();
                         rx = resolved.TransformToVisual(host->trackedRootGrid)
                                  .TransformPoint({0, 0})
                                  .X;
-                    } catch (...) {
-                    }
-                    double oldX = -1.0;
-                    try {
-                        if (host->anchor) {
-                            oldX = host->anchor
-                                       .TransformToVisual(host->trackedRootGrid)
-                                       .TransformPoint({0, 0})
-                                       .X;
-                        }
                     } catch (...) {
                     }
 
@@ -7824,24 +7534,14 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
                                                 &stripLeft, &stripRight,
                                                 resolved);
                     host->parkedAnchorX = -1.0;
-                    double clearance = 0.0;
                     if (others > 0 && rx > 0.5 && reserve > slack) {
-                        clearance = (g_settings.position != L"afterApps")
-                                        ? stripLeft - (rx + rw)
-                                        : rx - stripRight;
+                        double clearance = (g_settings.position != L"afterApps")
+                                               ? stripLeft - (rx + rw)
+                                               : rx - stripRight;
                         if (std::abs(clearance - reserve) <= slack) {
                             host->parkedAnchorX = rx;
                         }
                     }
-
-                    ANIM_TRACE(L"ANCHOR t=%llu host=%p swap %p(x=%.2f)->%p "
-                               L"class=%s x=%.2f w=%.2f margin=%.2f "
-                               L"(adopted as original) oldDead=%d "
-                               L"clearance=%.2f/%.2f parked=%d",
-                               now, host->hwnd, winrt::get_abi(host->anchor),
-                               oldX, winrt::get_abi(resolved), cls.c_str(), rx,
-                               rw, m, (int)anchorLooksDead, clearance, reserve,
-                               (int)(host->parkedAnchorX >= 0.0));
                 }
                 AdoptAnchor(host, resolved);
             }
@@ -7879,14 +7579,6 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
         // queues another LayoutUpdated; let that pass place hostGrid once
         // the anchor has actually moved.
         if (marginChanged) {
-            ANIM_TRACE(L"MARGIN t=%llu host=%p %s %.2f->%.2f (original=%.2f "
-                       L"reserve=%.2f)",
-                       now, host->hwnd, before ? L"left" : L"right",
-                       before ? currentMargin.Left : currentMargin.Right,
-                       before ? target.Left : target.Right,
-                       before ? host->anchorOriginalMargin.Left
-                              : host->anchorOriginalMargin.Right,
-                       desiredGap);
             return;
         }
 
@@ -7899,12 +7591,7 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
         // once on release. The margin above is still maintained, so the
         // reserved gap does not collapse mid-drag.
         bool dragging = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0;
-        if (dragging != host->dragFrozen) {
-            host->dragFrozen = dragging;
-            ANIM_TRACE(L"DRAG t=%llu host=%p primary button %s — positioning %s",
-                       now, host->hwnd, dragging ? L"down" : L"up",
-                       dragging ? L"frozen" : L"resumed");
-        }
+        host->dragFrozen = dragging;
         if (dragging) {
             return;
         }
@@ -7920,13 +7607,7 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
         // and force an immediate re-resolve instead of animating to the
         // bogus coordinate.
         if (point.X <= 0.5) {
-            // Anchor container got recycled to an off-screen item. hostGrid
-            // stays wherever it was while this repeats, so a run of these
-            // lines explains a gap that just sits there.
-            ANIM_TRACE(L"RECYCLED t=%llu host=%p anchor=%p x=%.2f — forcing "
-                       L"re-resolve (this container was adopted %llums ago)",
-                       now, host->hwnd, winrt::get_abi(host->anchor), point.X,
-                       now - host->lastAnchorResolveTick);
+            // hostGrid stays wherever it was until the re-resolve lands.
             host->lastAnchorResolveTick = 0;
             return;
         }
@@ -7955,11 +7636,6 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
         if (host->hasPlaced && !anchorSettled && !settleTimedOut) {
             return;
         }
-        if (settleTimedOut && !anchorSettled) {
-            ANIM_TRACE(L"SETTLE t=%llu host=%p anchor still moving after %llums "
-                       L"(x=%.2f) — giving in and positioning off it anyway",
-                       now, host->hwnd, now - host->anchorMovingSince, point.X);
-        }
         host->anchorMovingSince = 0;
 
         double left;
@@ -7978,20 +7654,10 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
             host->reserveHolds < kMaxReserveHolds &&
             std::abs(point.X - host->parkedAnchorX) < 4.0) {
             host->reserveHolds++;
-            ANIM_TRACE(L"HOLD t=%llu host=%p anchor still parked at %.2f, one "
-                       L"reserve (%.2f) clear of the strip — holding (%d/%d)",
-                       now, host->hwnd, point.X, desiredGap,
-                       host->reserveHolds, kMaxReserveHolds);
             return;
         }
         host->parkedAnchorX = -1.0;
         host->reserveHolds = 0;
-
-        // Checked against the anchor position just measured above, before
-        // handing the new target to the animation - this is what's actually
-        // on screen right now, this frame.
-        CheckHostGridHealth(host, repeater, before, point.X,
-                             host->anchor.ActualWidth());
 
         AnimateHostGridLeftTo(host, left, point.X);
     } catch (...) {
@@ -8004,14 +7670,6 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
         // alive, and if that restore itself no-ops or throws, the next
         // AdoptAnchor snapshots the still-widened margin as "original",
         // doubling the gap permanently.
-        ANIM_TRACE(L"EXCEPTION host=%p; a XAML call threw while "
-                   L"reading/positioning the anchor or hostGrid (anchor "
-                   L"likely recycled mid-access) — dropping cachedRepeater "
-                   L"and re-resolving next tick. currentLeft(target)=%.2f "
-                   L"liveX=%.2f anchorPresent=%d",
-                   host->hwnd, host->currentLeft,
-                   host->hostTranslate ? host->hostTranslate.X() : -1.0,
-                   (int)(bool)host->anchor);
         host->cachedRepeater = nullptr;
     }
 }
@@ -8655,7 +8313,19 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
         }
     } menuActive(hwnd);
 
-    HWND defView = g_settings.explorerMenu ? FindShellViewWindow(hwnd) : nullptr;
+    // TPM_RETURNCMD is a precondition for injecting anything, not just for
+    // reading the result below: without it the menu posts WM_COMMAND with the
+    // chosen id to hwnd instead of returning it, so the mod's own action would
+    // silently never run and an id in the kMinId range would be handed to a
+    // window proc that may map an unrecognised command onto an IContextMenu
+    // verb offset. CDefView passes the flag, but this hook is process-wide and
+    // FindShellViewWindow only checks that hwnd sits under a SHELLDLL_DefView —
+    // any other caller in explorer.exe that happens to satisfy that (a shell
+    // extension with its own menu, a future shell build, another mod) must be
+    // left alone.
+    HWND defView = ((flags & TPM_RETURNCMD) && g_settings.explorerMenu)
+                       ? FindShellViewWindow(hwnd)
+                       : nullptr;
     if (!defView) {
         return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
     }
@@ -8823,7 +8493,10 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
         result = TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
     }
 
-    if (!(flags & TPM_RETURNCMD) || result < kMinId) {
+    // TPM_RETURNCMD is guaranteed here — nothing is injected without it — so
+    // result is the chosen command id, and anything below kMinId belongs to
+    // Explorer.
+    if (result < kMinId) {
         return result;
     }
 

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.39
+// @version         1.40
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
@@ -701,6 +701,13 @@ bool IconSettingIsFile(const std::wstring& icon) {
 // 64-bit NTFS file id for a directory, stable across in-place renames; 0 on
 // failure. Used to re-find a pinned folder after it gets renamed on disk.
 uint64_t GetDirFileId(const std::wstring& path) {
+    // CreateFileW on an offline share blocks for the network timeout. 0 is the
+    // same "no rename recovery for this entry" BuildFolderEntry already gives
+    // remote paths, so every caller — the edit dialog's Save, the Explorer pin
+    // flow, FindRenamedSibling — degrades the same way.
+    if (IsLikelyRemotePath(path)) {
+        return 0;
+    }
     HANDLE h = CreateFileW(path.c_str(), 0,
                             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                             nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS,
@@ -6320,13 +6327,21 @@ HICON IconForEntry(const FolderStore::Entry& entry, int pixelSize) {
         if (!IconSettingIsFile(icon)) {
             return nullptr;  // Emoji or other literal text.
         }
-        if (HICON hIcon = ExtractIconFromResourceSpec(icon, pixelSize)) {
-            return hIcon;
+        if (!IsLikelyRemotePath(IconSpecFilePart(icon))) {
+            if (HICON hIcon = ExtractIconFromResourceSpec(icon, pixelSize)) {
+                return hIcon;
+            }
         }
     }
     std::wstring target = ResolveFolderPath(ExpandEnv(entry.path));
     if (target.empty()) {
         target = ExpandEnv(entry.path);
+    }
+    // SHGetFileInfoW on an offline share blocks for the network timeout, and a
+    // manager thread stuck in there cannot process the WM_CLOSE CloseAndWait
+    // posts — so uninit would hang with it. DrawRow copes with a null icon.
+    if (IsLikelyRemotePath(target)) {
+        return nullptr;
     }
     return GetShellIconForPath(target, pixelSize);
 }

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -1,0 +1,7795 @@
+// ==WindhawkMod==
+// @id              taskbar-folder-hover-tray
+// @name            Taskbar Folder Hover Tray
+// @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
+// @version         1.25
+// @author          Kiploom
+// @github          https://github.com/Kiploom
+// @include         explorer.exe
+// @architecture    x86-64
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lshell32 -lshlwapi -luuid -lgdi32 -lgdiplus -ldwmapi -luser32
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# Taskbar Folder Hover Tray
+
+Adds one or more **folder shortcut buttons** directly into the Windows 11 taskbar,
+sitting flush with your pinned and running app icons. **Hover** a button and a grid
+of that folder's contents appears instantly above the taskbar - move your mouse
+straight up and click an item. No clicking the taskbar first.
+
+Windows 11 only.
+
+![Hover tray with cascading subfolders](https://raw.githubusercontent.com/Kiploom/images/main/taskbar-folder-hover-tray-cascade.png)
+
+![Folder grid above the taskbar](https://raw.githubusercontent.com/Kiploom/images/main/taskbar-folder-hover-tray-grid.png)
+
+## Features
+
+- Buttons are sized from a live taskbar button, so they match your app icons
+  exactly at any taskbar size and DPI.
+- The hover grid opens with **zero delay** - folder contents and icons are scanned
+  and cached on a background thread.
+- A "corridor" between the button and the grid keeps the grid open while you move
+  your mouse up to it, so there is no dead zone.
+- Subfolders cascade: rest on a subfolder and its own grid opens beside the first
+  one, as deep as you like. **Maximum folder depth** caps the nesting - `-1` is
+  unlimited, `0` stops subfolders from opening on hover, `1` allows one level.
+- Subfolders are listed first in every grid and carry a folder badge in the
+  accent colour on the corner of their icon, so what cascades is obvious at a
+  glance. Folder shortcuts (`.lnk` pointing at a folder) cascade the same way.
+- Set each button's icon to an **emoji**, an **`.ico` / `.png` file**, or an
+  **`app.exe,0`** icon resource. Leave it empty to use the folder's own icon.
+- Left click an item to open it, right click for the full Windows shell context menu.
+- Folder buttons are injected on the primary taskbar and every secondary-monitor taskbar.
+
+## Adding folders
+
+**Folders are not configured on the settings page.** They live in the
+**Taskbar Folders** window instead, which you can open in either of two ways:
+
+- Right click any folder button already on the taskbar and choose
+  **Manage folders...**
+- Or, in this mod's settings, switch on **Open the folder manager** and save.
+
+The quickest way to add one in the first place is straight from Explorer:
+right click any folder in Explorer or on the Desktop and pick
+**Taskbar Folders -> Pin**. It becomes a button immediately, taking its name
+and its custom icon (Properties > Customize > Change Icon) from the folder
+itself. That same menu appears on files and shortcuts too — use it to move,
+copy, or make a shortcut into a folder that already has a button.
+
+### The Taskbar Folders window
+
+Every folder is listed with its icon and name. From there you can:
+
+| Action | What it does |
+|--------|--------------|
+| **Add...** | Pick any folder and give it a name and icon |
+| **Edit...** | Change the name, folder or icon, and tick or untick **Pinned to the taskbar**. Unticking takes the button off the taskbar **without deleting anything** — the entry stays in the list with its name and icon, and can be pinned again any time |
+| **Remove** | Forget the entry entirely. The folder itself is never touched |
+| **Drag a row** | Drag it up or down the list to set the left-to-right order of the taskbar buttons |
+
+Each entry has three fields:
+
+| Field | Example | Notes |
+|-------|---------|-------|
+| Name  | `Apps` | Shown as the title at the top of the hover grid |
+| Folder | `%USERPROFILE%\Desktop` | Environment variables are expanded. `shell:` targets that map to a **filesystem folder** also work (e.g. `shell:Desktop`, `shell:Downloads`). Virtual namespaces such as Control Panel, Recycle Bin, or This PC are not supported — use [Taskbar Folder Menus](https://github.com/ramensoftware/windhawk-mods/blob/main/mods/taskbar-folder-menus.wh.cpp) for those. |
+| Icon | an emoji, `C:\icons\apps.ico`, or `C:\Windows\explorer.exe,0` | Leave empty to use the folder's own icon |
+
+A good setup is to make a folder somewhere, fill it with shortcuts to the apps
+you want grouped, and point a button at it.
+
+A folder can only appear once. If it is already in the list as an unpinned
+draft, pinning it again re-uses that entry rather than creating a second one.
+
+### Why folders are not on the settings page
+
+Short version: **Windhawk gives a mod no way to change its own settings**, so a
+folder list living there could only ever be edited by hand, and nothing the mod
+does — pinning, unpinning, renaming, reordering — could ever be written back
+into it.
+
+The longer version, because this trips people up:
+
+A Windhawk mod gets two separate stores. **Settings** is the list you see on
+this page; the mod API can only *read* it (`Wh_GetStringSetting` and friends).
+**Storage** is a private per-mod area the mod can freely read and write
+(`Wh_SetStringValue`). There is no supported call anywhere that writes a
+setting.
+
+That is a deliberate design choice, and Windows enforces it: Windhawk keeps mod
+settings in `HKLM\SOFTWARE\Windhawk\Engine\Mods\...`, a registry key that grants
+standard users **read access only**. This mod runs inside `explorer.exe`, which
+is not elevated. Any attempt to open that key for writing fails outright with
+access denied — it is not a matter of finding the right API.
+
+So a settings-page folder list leaves two bad options:
+
+1. **Two lists that never agree.** Folders added on the settings page and
+   folders pinned from Explorer live in different places. Pin something and it
+   does not appear on the settings page; unpin something configured there and
+   the mod cannot remove the row, only learn to ignore it. Every one of those
+   mismatches is a bug report waiting to happen.
+2. **A UAC prompt for every change.** The write *can* be forced through by
+   handing a `.reg` file to an elevated `reg.exe`. It works. It also means a
+   Windows administrator prompt every single time you pin or unpin a folder,
+   which is an absurd price for what is really just bookkeeping — and a scary
+   one, since nothing about adding a folder shortcut should look like it needs
+   admin rights.
+
+Keeping the whole list in the mod's own Storage avoids both. One list, one
+source of truth, edits apply instantly, and nothing ever asks for elevation.
+The trade-off is that it needs its own window instead of riding along on the
+settings page Windhawk already draws — hence **Taskbar Folders**.
+
+Folders you had configured on the settings page before this change are imported
+into it automatically the first time this version runs; nothing is lost.
+
+## How it is positioned
+
+The Windows 11 taskbar app strip is a WinUI `ItemsRepeater` that refuses to lay out
+any child it did not create itself, so this mod cannot literally become a taskbar
+item. Instead it adds itself as an overlay to the taskbar's root grid and widens the
+margin of the neighbouring app icon to carve out a real gap in the strip, then keeps
+itself seated in that gap on every layout pass. The taskbar re-centers around the
+gap, so the result reads as flush.
+
+Two consequences worth knowing:
+
+- The buttons cannot be dragged around on the taskbar itself the way real
+  taskbar items can. To change their order, open the **Taskbar Folders** window
+  (right click any folder button > **Manage folders...**) and drag the rows
+  into the order you want — top of the list is the leftmost button.
+- They do not collapse into the overflow button when the taskbar gets full.
+
+## If you already use Taskbar Folder Menus
+
+[Taskbar Folder Menus](https://github.com/ramensoftware/windhawk-mods/blob/main/mods/taskbar-folder-menus.wh.cpp)
+(`taskbar-folder-menus` by sb4ssman) is a solid alternative for browsing folders
+from the taskbar. Both support configurable folder/shortcut buttons, `shell:`
+targets and environment-variable expansion, subfolders that expand on hover,
+shell context menus on items, and browsing folder contents without minimizing
+windows. Pick based on placement and UI — you typically want one or the other,
+not both.
+
+| | Taskbar Folder Hover Tray (this) | Taskbar Folder Menus |
+|---|---|---|
+| Placement | Carved gap inside the **app icon strip** (flush with pinned/running apps) | Next to the **system tray** / notification area |
+| Open | **Hover** opens immediately | **Click** opens |
+| UI | Custom-drawn **icon grid** popup | **Native Shell** cascading menus |
+| Buttons | Sized from live taskbar app buttons; emoji/custom icons optional | Compact tray buttons with emoji labels and extensive tray grid layout options |
+
+Choose **Taskbar Folder Menus** for tray-side buttons and native Shell menus.
+Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
+
+## Known Conflicts
+
+**Windows 11 Taskbar Styler** can restyle these buttons if one of its rules matches
+`Button`. If a folder button suddenly looks wrong, check for a broad rule there.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- manageFolders: false
+  $name: 1. Behavior ▸ Open the folder manager
+  $description: >-
+    Which folders appear on your taskbar is NOT set here — it is set in the
+    Taskbar Folders window. Switch this on and save to open it, then add, edit,
+    reorder, pin, unpin and remove folders there, each with its own name and
+    icon. This is a button rather than a preference: switching it off again
+    does nothing, so just leave it wherever it lands. You can also open the
+    same window at any time by right clicking a folder button on the taskbar.
+    Why it works this way is explained under Details.
+
+- openFolderOnClick: true
+  $name: 1. Behavior ▸ Click opens the folder
+  $description: Left clicking a taskbar button opens the folder in File Explorer.
+
+- position: beforeApps
+  $name: 1. Behavior ▸ Position
+  $description: Which side of the app icons the buttons sit on.
+  $options:
+  - beforeApps: Before the app icons
+  - afterApps: After the app icons
+
+- anchor: firstApp
+  $name: 1. Behavior ▸ Anchor
+  $description: >-
+    Which taskbar element the gap is carved next to. Change this if another mod is
+    fighting for the same anchor. Auto picks the outermost app icon.
+  $options:
+  - firstApp: Outermost App icon
+  - widgets: Widgets button
+  - taskView: Task View button
+  - start: Start button
+
+- hoverDelayMs: 0
+  $name: 1. Behavior ▸ Hover delay (ms)
+  $description: Delay before the grid appears. 0 is instant.
+
+- closeDelayMs: 250
+  $name: 1. Behavior ▸ Close delay (ms)
+  $description: >-
+    How long the grid stays open after the mouse leaves the button and the grid.
+    Moving onto another taskbar icon counts as leaving.
+
+- includeSubfolders: true
+  $name: 2. Content ▸ Show subfolders
+  $description: Include subfolders as entries in the grid.
+
+- maxFolderDepth: -1
+  $name: 2. Content ▸ Maximum folder depth
+  $description: >-
+    How many levels of subfolder menus can cascade when you hover a subfolder.
+    -1 is unlimited, 0 means subfolders never open on hover, 1 allows one level
+    of subfolders, and so on. Turn off "Show subfolders" to hide them entirely.
+
+- submenuDelayMs: 150
+  $name: 2. Content ▸ Subfolder open delay (ms)
+  $description: >-
+    How long to rest on a subfolder before its menu opens. A small delay stops
+    menus from firing off while you sweep across the grid. 0 is instant.
+
+- submenuCloseDelayMs: 300
+  $name: 2. Content ▸ Subfolder close delay (ms)
+  $description: >-
+    How long a cascaded subfolder menu stays open after the mouse leaves the
+    cell that opened it. Gives you time to move diagonally into the submenu.
+
+- showHidden: false
+  $name: 2. Content ▸ Show hidden items
+  $description: Include hidden and system files.
+
+- showExtensions: false
+  $name: 2. Content ▸ Show file extensions
+  $description: Shortcut (.lnk) extensions are always hidden.
+
+- sortBy: name
+  $name: 2. Content ▸ Sort by
+  $description: >-
+    Folders always come first so the entries that cascade stay together at the
+    top. This orders the items within each group.
+  $options:
+  - name: Name
+  - modified: Date modified (newest first)
+
+- maxItems: 60
+  $name: 2. Content ▸ Maximum items
+  $description: >-
+    Limit how many entries the grid shows and caches. The cache also caps to
+    roughly what can fit on screen (columns × rows, tighter for large icons)
+    and a ~64 MB bitmap budget, so very large maxItems values do not keep
+    hundreds of oversized icons resident. 0 uses that automatic on-screen cap.
+
+- columns: 0
+  $name: 2. Content ▸ Grid columns
+  $description: 0 chooses a square-ish grid automatically.
+
+- itemSize: medium
+  $name: 3. Appearance ▸ Item size
+  $description: >-
+    Preset size for each item's icon and grid cell. Small/large scale both the
+    icon and the overall tray size.
+  $options:
+  - small: Small
+  - medium: Medium
+  - large: Large
+
+- buttonIconSize: 0
+  $name: 3. Appearance ▸ Button icon size (px)
+  $description: 0 matches the size Windows uses for its own taskbar icons.
+
+- fontSize: 12
+  $name: 3. Appearance ▸ Item label size (px)
+
+- itemFontFamily: ""
+  $name: 3. Appearance ▸ Item label font
+  $description: >-
+    Font family for item labels, e.g. "Segoe UI". Leave empty to match the
+    system font.
+
+- itemFontWeight: regular
+  $name: 3. Appearance ▸ Item label weight
+  $options:
+  - regular: Regular
+  - bold: Bold
+
+- titleFontSize: 13
+  $name: 3. Appearance ▸ Folder title size (px)
+  $description: Size of the name shown at the top of the main hover grid.
+
+- titleFontFamily: ""
+  $name: 3. Appearance ▸ Folder title font
+  $description: >-
+    Font family for the folder title, e.g. "Segoe UI". Leave empty to match
+    the system font.
+
+- titleFontWeight: bold
+  $name: 3. Appearance ▸ Folder title weight
+  $options:
+  - regular: Regular
+  - bold: Bold
+
+- titleAlign: center
+  $name: 3. Appearance ▸ Folder title position
+  $description: >-
+    Horizontal position of the folder name on the main hover grid. Subfolder
+    menus never show a title.
+  $options:
+  - left: Left
+  - center: Center
+  - right: Right
+
+- cornerRadius: 8
+  $name: 3. Appearance ▸ Grid corner radius (px)
+
+- panelOpacity: 85
+  $name: 3. Appearance ▸ Grid opacity (%)
+
+- acrylic: true
+  $name: 3. Appearance ▸ Acrylic blur
+  $description: Blur the desktop behind the grid. Turn off if it looks wrong.
+
+- gapAbove: 8
+  $name: 3. Appearance ▸ Gap above taskbar (px)
+  $description: Distance between the taskbar and the grid.
+
+- gapBefore: 0
+  $name: 3. Appearance ▸ Padding before buttons (px)
+
+- gapAfter: 0
+  $name: 3. Appearance ▸ Padding after buttons (px)
+*/
+// ==/WindhawkModSettings==
+
+#undef GetCurrentTime
+
+#include <windhawk_utils.h>
+
+#include <commoncontrols.h>
+#include <dwmapi.h>
+#include <shellapi.h>
+#include <shlobj.h>
+#include <shlwapi.h>
+#include <shobjidl.h>
+#include <windowsx.h>
+
+#include <gdiplus.h>
+#include <objidl.h>
+
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Windows.UI.ViewManagement.h>
+#include <winrt/Windows.UI.Composition.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Windows.UI.Xaml.Hosting.h>
+#include <winrt/Windows.UI.Xaml.Input.h>
+#include <winrt/Windows.UI.Xaml.Media.Animation.h>
+#include <winrt/Windows.UI.Xaml.Media.Imaging.h>
+#include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.UI.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#ifndef SEE_MASK_ASYNCOK
+#define SEE_MASK_ASYNCOK 0x00100000
+#endif
+#ifndef CMIC_MASK_ASYNCOK
+#define CMIC_MASK_ASYNCOK SEE_MASK_ASYNCOK
+#endif
+#ifndef CMIC_MASK_PTINVOKE
+#define CMIC_MASK_PTINVOKE 0x20000000
+#endif
+
+using namespace winrt::Windows::UI::Xaml;
+using namespace winrt::Windows::UI::Xaml::Controls;
+using namespace winrt::Windows::UI::Xaml::Media;
+using namespace winrt::Windows::UI::Xaml::Media::Animation;
+using namespace winrt::Windows::UI::Xaml::Hosting;
+
+#ifndef DWMWA_WINDOW_CORNER_PREFERENCE
+#define DWMWA_WINDOW_CORNER_PREFERENCE 33
+#endif
+#ifndef DWMWCP_ROUND
+#define DWMWCP_ROUND 2
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// Settings
+
+struct FolderEntry {
+    std::wstring name;
+    std::wstring path;          // Expanded settings path (may be shell:...)
+    std::wstring resolvedPath;  // Filesystem path; shell: filled on an STA later
+    std::wstring icon;
+    bool likelyRemote = false;  // IsLikelyRemotePath(resolvedPath), after resolve
+    bool resolveFailed = false; // shell: that does not map to a filesystem folder
+    // True for folders added via the Explorer/Desktop "Pin to Taskbar" action
+    // (mod storage), false for folders configured in the Settings UI. Only
+    // pinned folders can be removed with a taskbar right-click.
+    bool pinned = false;
+};
+
+enum class SortMode { Name, Modified };
+
+struct Settings {
+    std::vector<FolderEntry> folders;
+    std::wstring position = L"beforeApps";
+    std::wstring anchor = L"firstApp";
+    int hoverDelayMs = 0;
+    int closeDelayMs = 250;
+    int columns = 0;
+    int maxItems = 60;
+    bool includeSubfolders = true;
+    int maxFolderDepth = -1;
+    int submenuDelayMs = 150;
+    int submenuCloseDelayMs = 300;
+    bool showHidden = false;
+    bool showExtensions = false;
+    SortMode sortBy = SortMode::Name;
+    // Derived from itemSize in LoadSettings(); not settings-bound directly.
+    int cellWidth = 92;
+    int cellHeight = 88;
+    int iconSize = 32;
+    int fontSize = 12;
+    std::wstring itemFontFamily;
+    bool itemFontBold = false;
+    int titleFontSize = 13;
+    std::wstring titleFontFamily;
+    bool titleFontBold = true;
+    std::wstring titleAlign = L"center";
+    int cornerRadius = 8;
+    int panelOpacity = 85;
+    bool acrylic = true;
+    int gapAbove = 8;
+    int gapBefore = 0;
+    int gapAfter = 0;
+    int buttonIconSize = 0;
+    bool openFolderOnClick = true;
+};
+
+Settings g_settings;
+// Guards FolderEntry::resolvedPath / likelyRemote fills from STA resolve helpers
+// while UI and the scan worker may read them.
+std::mutex g_foldersMutex;
+
+std::atomic<bool> g_unloading{false};
+
+////////////////////////////////////////////////////////////////////////////////
+// Small helpers
+
+// Returns this mod's DLL HINSTANCE. GetModuleHandle(nullptr) would return
+// explorer.exe, which is wrong for RegisterClass/CreateWindowEx/UnregisterClass.
+HINSTANCE GetCurrentModuleHandle() {
+    HINSTANCE hInst = nullptr;
+    GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                          GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                      (LPCWSTR)&GetCurrentModuleHandle, &hInst);
+    return hInst;
+}
+
+std::wstring ResolveFolderPath(const std::wstring& raw);
+bool IsLikelyRemotePath(const std::wstring& p);
+bool IsShellFolderPath(const std::wstring& path);
+void ResolvePendingFolderEntries();
+void ReloadAndRefreshUI();
+
+std::wstring Trim(std::wstring s) {
+    size_t b = s.find_first_not_of(L" \t\r\n");
+    if (b == std::wstring::npos) {
+        return L"";
+    }
+    size_t e = s.find_last_not_of(L" \t\r\n");
+    return s.substr(b, e - b + 1);
+}
+
+std::wstring ExpandEnv(const std::wstring& s) {
+    if (s.find(L'%') == std::wstring::npos) {
+        return s;
+    }
+    DWORD needed = ExpandEnvironmentStringsW(s.c_str(), nullptr, 0);
+    if (!needed) {
+        return s;
+    }
+    std::wstring out(needed, L'\0');
+    DWORD written = ExpandEnvironmentStringsW(s.c_str(), out.data(), needed);
+    if (!written) {
+        return s;
+    }
+    out.resize(written - 1);
+    return out;
+}
+
+std::wstring GetStringSetting(PCWSTR name) {
+    return WindhawkUtils::StringSetting::make(name).get();
+}
+
+// An icon setting is a file reference if it looks like a path, otherwise it is
+// literal text to render (an emoji).
+bool IconSettingIsFile(const std::wstring& icon) {
+    if (icon.size() < 3) {
+        return false;
+    }
+    if (icon.find(L'\\') != std::wstring::npos ||
+        icon.find(L'/') != std::wstring::npos) {
+        return true;
+    }
+    return icon[1] == L':';
+}
+
+// 64-bit NTFS file id for a directory, stable across in-place renames; 0 on
+// failure. Used to re-find a pinned folder after it gets renamed on disk.
+uint64_t GetDirFileId(const std::wstring& path) {
+    HANDLE h = CreateFileW(path.c_str(), 0,
+                            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                            nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS,
+                            nullptr);
+    if (h == INVALID_HANDLE_VALUE) {
+        return 0;
+    }
+    BY_HANDLE_FILE_INFORMATION info{};
+    bool ok = GetFileInformationByHandle(h, &info);
+    CloseHandle(h);
+    if (!ok) {
+        return 0;
+    }
+    return (static_cast<uint64_t>(info.nFileIndexHigh) << 32) | info.nFileIndexLow;
+}
+
+// A renamed folder keeps the same parent, so if oldPath no longer resolves,
+// scan its parent for a subfolder whose file id still matches. Returns the
+// new full path, or empty if no match.
+// ponytail: 64-bit nFileIndex id, NTFS only. ReFS/64-bit-unstable volumes
+// would need FILE_ID_INFO (128-bit) if that ever matters here.
+std::wstring FindRenamedSibling(const std::wstring& oldPath, uint64_t fileId) {
+    if (fileId == 0) {
+        return L"";
+    }
+    size_t pos = oldPath.find_last_of(L"\\/");
+    if (pos == std::wstring::npos) {
+        return L"";
+    }
+    std::wstring parent = oldPath.substr(0, pos);
+    WIN32_FIND_DATAW fd;
+    HANDLE h = FindFirstFileW((parent + L"\\*").c_str(), &fd);
+    if (h == INVALID_HANDLE_VALUE) {
+        return L"";
+    }
+    std::wstring found;
+    do {
+        if (!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ||
+            wcscmp(fd.cFileName, L".") == 0 || wcscmp(fd.cFileName, L"..") == 0) {
+            continue;
+        }
+        std::wstring candidate = parent + L"\\" + fd.cFileName;
+        if (GetDirFileId(candidate) == fileId) {
+            found = candidate;
+            break;
+        }
+    } while (FindNextFileW(h, &fd));
+    FindClose(h);
+    return found;
+}
+
+// A folder's own custom icon (Properties > Customize > Change Icon), read
+// from its desktop.ini as the "path,index" spec the Icon setting already
+// accepts. Empty when the folder has no custom icon.
+std::wstring ReadFolderCustomIcon(const std::wstring& folderPath) {
+    std::wstring iniPath = folderPath + L"\\desktop.ini";
+    WCHAR buf[1024]{};
+    if (GetPrivateProfileStringW(L".ShellClassInfo", L"IconResource", L"", buf,
+                                 ARRAYSIZE(buf), iniPath.c_str()) > 0) {
+        return ExpandEnv(Trim(buf));
+    }
+    if (GetPrivateProfileStringW(L".ShellClassInfo", L"IconFile", L"", buf,
+                                 ARRAYSIZE(buf), iniPath.c_str()) == 0) {
+        return L"";
+    }
+    std::wstring file = ExpandEnv(Trim(buf));
+    int index =
+        GetPrivateProfileIntW(L".ShellClassInfo", L"IconIndex", 0,
+                              iniPath.c_str());
+    return file + L"," + std::to_wstring(index);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Folder store
+//
+// The single source of truth for every folder button, kept in the mod's own
+// writable storage. Settings deliberately holds no folder list: a mod cannot
+// write to its own Windhawk settings without administrator rights, so a list
+// living there could never be edited from the manager window, from an Explorer
+// right-click pin, or from an unpin on the taskbar.
+//
+// A compact array, no holes, because the order is the taskbar button order:
+//   entryCount, entry[i].path / .name / .icon / .id / .pinned
+// An unpinned entry is a draft — kept with its name and icon, just not shown
+// on the taskbar, and still blocking a second copy of the same folder.
+namespace FolderStore {
+
+constexpr int kMaxEntries = 200;
+
+struct Entry {
+    std::wstring path;
+    std::wstring name;
+    std::wstring icon;
+    uint64_t fileId = 0;
+    bool pinned = true;
+};
+
+std::wstring GetString(PCWSTR format, int index) {
+    WCHAR key[64];
+    swprintf(key, ARRAYSIZE(key), format, index);
+    WCHAR buf[1024]{};
+    Wh_GetStringValue(key, buf, ARRAYSIZE(buf));
+    return Trim(buf);
+}
+
+std::vector<Entry> Read() {
+    std::vector<Entry> entries;
+    int count = Wh_GetIntValue(L"entryCount", 0);
+    if (count > kMaxEntries) {
+        count = kMaxEntries;
+    }
+    for (int i = 0; i < count; i++) {
+        Entry entry;
+        entry.path = GetString(L"entry[%d].path", i);
+        if (entry.path.empty()) {
+            continue;
+        }
+        entry.name = GetString(L"entry[%d].name", i);
+        entry.icon = GetString(L"entry[%d].icon", i);
+        std::wstring id = GetString(L"entry[%d].id", i);
+        entry.fileId = id.empty() ? 0 : wcstoull(id.c_str(), nullptr, 16);
+
+        WCHAR key[64];
+        swprintf(key, ARRAYSIZE(key), L"entry[%d].pinned", i);
+        entry.pinned = Wh_GetIntValue(key, 1) != 0;
+        entries.push_back(std::move(entry));
+    }
+    return entries;
+}
+
+void Write(const std::vector<Entry>& entries) {
+    int previous = Wh_GetIntValue(L"entryCount", 0);
+    int count = (int)entries.size();
+    if (count > kMaxEntries) {
+        count = kMaxEntries;
+    }
+
+    for (int i = 0; i < count; i++) {
+        const Entry& entry = entries[i];
+        WCHAR key[64];
+        swprintf(key, ARRAYSIZE(key), L"entry[%d].path", i);
+        Wh_SetStringValue(key, entry.path.c_str());
+        swprintf(key, ARRAYSIZE(key), L"entry[%d].name", i);
+        Wh_SetStringValue(key, entry.name.c_str());
+        swprintf(key, ARRAYSIZE(key), L"entry[%d].icon", i);
+        Wh_SetStringValue(key, entry.icon.c_str());
+        swprintf(key, ARRAYSIZE(key), L"entry[%d].id", i);
+        WCHAR idBuf[20];
+        swprintf(idBuf, ARRAYSIZE(idBuf), L"%llx",
+                 (unsigned long long)entry.fileId);
+        Wh_SetStringValue(key, idBuf);
+        swprintf(key, ARRAYSIZE(key), L"entry[%d].pinned", i);
+        Wh_SetIntValue(key, entry.pinned ? 1 : 0);
+    }
+
+    // The array shrank: drop the tail so a stale entry cannot reappear if it
+    // later grows again.
+    for (int i = count; i < previous && i < kMaxEntries; i++) {
+        WCHAR key[64];
+        for (PCWSTR field : {L"path", L"name", L"icon", L"id", L"pinned"}) {
+            swprintf(key, ARRAYSIZE(key), L"entry[%d].%s", i, field);
+            Wh_DeleteValue(key);
+        }
+    }
+
+    Wh_SetIntValue(L"entryCount", count);
+}
+
+// Index of the entry backing `path`, comparing the resolved filesystem path so
+// that a shell: entry and its real folder count as the same thing. -1 if none.
+int IndexOfPath(const std::vector<Entry>& entries, const std::wstring& path) {
+    std::wstring wanted = ResolveFolderPath(ExpandEnv(path));
+    if (wanted.empty()) {
+        wanted = ExpandEnv(path);
+    }
+    for (size_t i = 0; i < entries.size(); i++) {
+        std::wstring existing = ResolveFolderPath(ExpandEnv(entries[i].path));
+        if (existing.empty()) {
+            existing = ExpandEnv(entries[i].path);
+        }
+        if (_wcsicmp(existing.c_str(), wanted.c_str()) == 0) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+// One-time import of the two pre-manager lists: folders configured in the
+// Windhawk settings UI, and folders pinned into the old `pinned[]` storage.
+// Settings rows the user had "unpinned" (the old hidden[] list) come across as
+// drafts rather than vanishing.
+void MigrateLegacy() {
+    if (Wh_GetIntValue(L"storeVersion", 0) >= 2) {
+        return;
+    }
+
+    std::vector<std::wstring> hidden;
+    int hiddenCount = Wh_GetIntValue(L"hiddenCount", 0);
+    for (int i = 0; i < hiddenCount; i++) {
+        std::wstring path = GetString(L"hidden[%d].path", i);
+        if (!path.empty()) {
+            hidden.push_back(path);
+        }
+    }
+
+    std::vector<Entry> entries = Read();
+
+    for (int i = 0; i < 64; i++) {
+        auto rawPath =
+            WindhawkUtils::StringSetting::make(L"folders[%d].path", i);
+        std::wstring path = Trim(std::wstring(rawPath.get()));
+        if (path.empty()) {
+            continue;
+        }
+        auto rawName =
+            WindhawkUtils::StringSetting::make(L"folders[%d].name", i);
+        auto rawIcon =
+            WindhawkUtils::StringSetting::make(L"folders[%d].icon", i);
+
+        Entry entry;
+        entry.path = ExpandEnv(path);
+        entry.name = Trim(std::wstring(rawName.get()));
+        entry.icon = Trim(std::wstring(rawIcon.get()));
+        entry.fileId = GetDirFileId(entry.path);
+        entry.pinned = true;
+        for (const auto& h : hidden) {
+            if (_wcsicmp(h.c_str(), entry.path.c_str()) == 0) {
+                entry.pinned = false;  // Was unpinned before; keep as a draft.
+                break;
+            }
+        }
+        if (IndexOfPath(entries, entry.path) < 0) {
+            entries.push_back(std::move(entry));
+        }
+    }
+
+    int pinnedCount = Wh_GetIntValue(L"pinnedCount", 0);
+    for (int i = 0; i < pinnedCount; i++) {
+        Entry entry;
+        entry.path = GetString(L"pinned[%d].path", i);
+        if (entry.path.empty()) {
+            continue;
+        }
+        entry.name = GetString(L"pinned[%d].name", i);
+        entry.icon = GetString(L"pinned[%d].icon", i);
+        std::wstring id = GetString(L"pinned[%d].id", i);
+        entry.fileId = id.empty() ? GetDirFileId(entry.path)
+                                  : wcstoull(id.c_str(), nullptr, 16);
+        entry.pinned = true;
+        if (IndexOfPath(entries, entry.path) < 0) {
+            entries.push_back(std::move(entry));
+        }
+    }
+
+    Write(entries);
+    Wh_SetIntValue(L"storeVersion", 2);
+    Wh_Log(L"Migrated %zu folder(s) into the manager store", entries.size());
+
+    // The legacy keys are left in place on purpose: downgrading to an older
+    // build of the mod should still find its folders.
+}
+
+}  // namespace FolderStore
+
+// Fills in the derived fields (resolved path, remote flag) a stored entry
+// needs before the UI can use it, and follows an in-place rename via the
+// recorded NTFS file id. Returns false if `store` was updated and should be
+// written back.
+bool BuildFolderEntry(FolderStore::Entry* stored, FolderEntry* out) {
+    bool unchanged = true;
+    out->name = stored->name;
+    out->icon = stored->icon;
+    out->path = ExpandEnv(stored->path);
+    out->pinned = stored->pinned;
+
+    if (IsShellFolderPath(out->path)) {
+        // shell: targets resolve later, on an STA.
+        out->resolvedPath.clear();
+        out->likelyRemote = false;
+        out->resolveFailed = false;
+    } else {
+        out->resolvedPath = ResolveFolderPath(out->path);
+        out->likelyRemote = IsLikelyRemotePath(out->resolvedPath);
+        out->resolveFailed = out->resolvedPath.empty();
+
+        // Folder missing under its stored path: it may have been renamed in
+        // place. Find it by file id under the same parent and follow it.
+        if (out->resolveFailed && stored->fileId != 0) {
+            std::wstring renamed =
+                FindRenamedSibling(out->path, stored->fileId);
+            if (!renamed.empty()) {
+                size_t slash = renamed.find_last_of(L"\\/");
+                std::wstring leaf = slash == std::wstring::npos
+                                        ? renamed
+                                        : renamed.substr(slash + 1);
+                // Only replace a name the user never customised.
+                bool nameWasLeaf =
+                    stored->name.empty() ||
+                    _wcsicmp(stored->name.c_str(),
+                             out->path.substr(out->path.find_last_of(L"\\/") + 1)
+                                 .c_str()) == 0;
+                out->path = renamed;
+                out->resolvedPath = ResolveFolderPath(out->path);
+                out->likelyRemote = IsLikelyRemotePath(out->resolvedPath);
+                out->resolveFailed = out->resolvedPath.empty();
+                stored->path = renamed;
+                if (nameWasLeaf) {
+                    stored->name = leaf;
+                    out->name = leaf;
+                }
+                unchanged = false;
+            }
+        }
+    }
+
+    if (out->name.empty()) {
+        out->name = out->path;
+    }
+    return unchanged;
+}
+
+void LoadFolders(std::vector<FolderEntry>* out) {
+    // String-only load: no CoInitialize / SHParseDisplayName. Wh_ModInit can
+    // run on Explorer's main thread before the process starts executing; creating
+    // then destroying an STA there is unsafe. shell: paths stay unresolved
+    // until ResolvePendingFolderEntries on the taskbar UI STA or scan STA.
+    std::lock_guard<std::mutex> lock(g_foldersMutex);
+    out->clear();
+
+    auto stored = FolderStore::Read();
+    bool storeUnchanged = true;
+    for (auto& entry : stored) {
+        FolderEntry loaded;
+        if (!BuildFolderEntry(&entry, &loaded)) {
+            storeUnchanged = false;
+        }
+        // Drafts stay in the store but get no taskbar button.
+        if (entry.pinned) {
+            out->push_back(std::move(loaded));
+        }
+    }
+    if (!storeUnchanged) {
+        FolderStore::Write(stored);
+    }
+
+    Wh_Log(L"LoadFolders: %zu button(s) from %zu stored folder(s)",
+           out->size(), stored.size());
+}
+
+// True if `path` already has a stored entry — pinned or draft. Used to hide
+// the "Pin to Taskbar" menu item and to reject duplicates, so that a folder
+// kept as a draft cannot be pinned a second time as a separate copy.
+bool IsAlreadyTaskbarFolder(const std::wstring& path) {
+    auto stored = FolderStore::Read();
+    return FolderStore::IndexOfPath(stored, path) >= 0;
+}
+
+// Adds a folder as a new taskbar button, persisted in the mod's own storage.
+// Caller must refresh (LoadSettings + UI teardown/rebuild) for it to appear.
+// No-op (returns false) if the folder already has an entry, draft included.
+bool AddPinnedFolder(const std::wstring& path, const std::wstring& name) {
+    auto stored = FolderStore::Read();
+    if (FolderStore::IndexOfPath(stored, path) >= 0) {
+        return false;
+    }
+    FolderStore::Entry entry;
+    entry.path = path;
+    entry.name = name;
+    // No icon field in the right-click pin flow, so this is the only chance to
+    // pick up a custom folder icon.
+    entry.icon = ReadFolderCustomIcon(path);
+    entry.fileId = GetDirFileId(path);
+    entry.pinned = true;
+    stored.push_back(std::move(entry));
+    FolderStore::Write(stored);
+    Wh_Log(L"Pinned '%s'", path.c_str());
+    return true;
+}
+
+// Unpins without forgetting: the entry stays as a draft, keeping its name and
+// icon, and still blocks a duplicate pin of the same folder.
+void RemovePinnedFolder(const std::wstring& path) {
+    auto stored = FolderStore::Read();
+    int index = FolderStore::IndexOfPath(stored, path);
+    if (index < 0) {
+        Wh_Log(L"Unpin: '%s' has no stored entry", path.c_str());
+        return;
+    }
+    stored[index].pinned = false;
+    FolderStore::Write(stored);
+    Wh_Log(L"Unpinned '%s' (kept as a draft)", path.c_str());
+}
+
+void LoadSettings() {
+    LoadFolders(&g_settings.folders);
+
+    g_settings.position = GetStringSetting(L"position");
+    if (g_settings.position.empty()) {
+        g_settings.position = L"beforeApps";
+    }
+    g_settings.anchor = GetStringSetting(L"anchor");
+    if (g_settings.anchor.empty()) {
+        g_settings.anchor = L"firstApp";
+    }
+
+    // "type" was the old folders-first option, which is now unconditional.
+    std::wstring sortBy = GetStringSetting(L"sortBy");
+    g_settings.sortBy =
+        sortBy == L"modified" ? SortMode::Modified : SortMode::Name;
+
+    g_settings.hoverDelayMs =
+        std::clamp<int>(Wh_GetIntSetting(L"hoverDelayMs"), 0, 5000);
+    g_settings.closeDelayMs =
+        std::clamp<int>(Wh_GetIntSetting(L"closeDelayMs"), 0, 5000);
+    g_settings.columns = std::clamp<int>(Wh_GetIntSetting(L"columns"), 0, 24);
+    g_settings.maxItems =
+        std::clamp<int>(Wh_GetIntSetting(L"maxItems"), 0, 400);
+    g_settings.includeSubfolders = Wh_GetIntSetting(L"includeSubfolders");
+    g_settings.maxFolderDepth =
+        std::clamp<int>(Wh_GetIntSetting(L"maxFolderDepth"), -1, 32);
+    g_settings.submenuDelayMs =
+        std::clamp<int>(Wh_GetIntSetting(L"submenuDelayMs"), 0, 5000);
+    g_settings.submenuCloseDelayMs =
+        std::clamp<int>(Wh_GetIntSetting(L"submenuCloseDelayMs"), 0, 5000);
+    g_settings.showHidden = Wh_GetIntSetting(L"showHidden");
+    g_settings.showExtensions = Wh_GetIntSetting(L"showExtensions");
+    std::wstring itemSize = GetStringSetting(L"itemSize");
+    if (itemSize == L"small") {
+        g_settings.iconSize = 24;
+        g_settings.cellWidth = 76;
+        g_settings.cellHeight = 72;
+    } else if (itemSize == L"large") {
+        g_settings.iconSize = 48;
+        g_settings.cellWidth = 120;
+        g_settings.cellHeight = 112;
+    } else {
+        g_settings.iconSize = 32;
+        g_settings.cellWidth = 92;
+        g_settings.cellHeight = 88;
+    }
+    g_settings.fontSize = std::clamp<int>(Wh_GetIntSetting(L"fontSize"), 6, 48);
+    g_settings.itemFontFamily = GetStringSetting(L"itemFontFamily");
+    g_settings.itemFontBold = GetStringSetting(L"itemFontWeight") == L"bold";
+    g_settings.titleFontSize =
+        std::clamp<int>(Wh_GetIntSetting(L"titleFontSize"), 6, 48);
+    g_settings.titleFontFamily = GetStringSetting(L"titleFontFamily");
+    g_settings.titleFontBold =
+        GetStringSetting(L"titleFontWeight") != L"regular";
+    g_settings.titleAlign = GetStringSetting(L"titleAlign");
+    if (g_settings.titleAlign != L"left" && g_settings.titleAlign != L"right") {
+        g_settings.titleAlign = L"center";
+    }
+    g_settings.cornerRadius =
+        std::clamp<int>(Wh_GetIntSetting(L"cornerRadius"), 0, 32);
+    g_settings.panelOpacity =
+        std::clamp<int>(Wh_GetIntSetting(L"panelOpacity"), 5, 100);
+    g_settings.acrylic = Wh_GetIntSetting(L"acrylic");
+    g_settings.gapAbove =
+        std::clamp<int>(Wh_GetIntSetting(L"gapAbove"), 0, 200);
+    g_settings.gapBefore =
+        std::clamp<int>(Wh_GetIntSetting(L"gapBefore"), 0, 200);
+    g_settings.gapAfter =
+        std::clamp<int>(Wh_GetIntSetting(L"gapAfter"), 0, 200);
+    g_settings.buttonIconSize =
+        std::clamp<int>(Wh_GetIntSetting(L"buttonIconSize"), 0, 128);
+    g_settings.openFolderOnClick = Wh_GetIntSetting(L"openFolderOnClick");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// taskbar.dll plumbing
+//
+// Shared boilerplate from the Windhawk taskbar mods: reach the taskbar's
+// XamlRoot through CTaskBand -> TaskbarHost, and marshal work onto the taskbar
+// UI thread.
+
+using CTaskBand_GetTaskbarHost_t = void*(WINAPI*)(void* pThis, void* result);
+CTaskBand_GetTaskbarHost_t CTaskBand_GetTaskbarHost_Original;
+
+using CSecondaryTaskBand_GetTaskbarHost_t = void*(WINAPI*)(void* pThis,
+                                                           void* result);
+CSecondaryTaskBand_GetTaskbarHost_t CSecondaryTaskBand_GetTaskbarHost_Original;
+
+using TaskbarHost_FrameHeight_t = int(WINAPI*)(void* pThis);
+TaskbarHost_FrameHeight_t TaskbarHost_FrameHeight_Original;
+
+using std__Ref_count_base__Decref_t = void(WINAPI*)(void* pThis);
+std__Ref_count_base__Decref_t std__Ref_count_base__Decref_Original;
+
+void* CTaskBand_ITaskListWndSite_vftable;
+void* CSecondaryTaskBand_ITaskListWndSite_vftable;
+
+HWND FindCurrentProcessTaskbarWnd() {
+    HWND hTaskbarWnd = nullptr;
+
+    EnumWindows(
+        [](HWND hWnd, LPARAM lParam) -> BOOL {
+            DWORD dwProcessId;
+            WCHAR className[32];
+            if (GetWindowThreadProcessId(hWnd, &dwProcessId) &&
+                dwProcessId == GetCurrentProcessId() &&
+                GetClassName(hWnd, className, ARRAYSIZE(className)) &&
+                _wcsicmp(className, L"Shell_TrayWnd") == 0) {
+                *reinterpret_cast<HWND*>(lParam) = hWnd;
+                return FALSE;
+            }
+            return TRUE;
+        },
+        reinterpret_cast<LPARAM>(&hTaskbarWnd));
+
+    return hTaskbarWnd;
+}
+
+XamlRoot XamlRootFromTaskbarHostSharedPtr(void* taskbarHostSharedPtr[2]) {
+    if (!taskbarHostSharedPtr[0] || !taskbarHostSharedPtr[1]) {
+        if (taskbarHostSharedPtr[1] && std__Ref_count_base__Decref_Original) {
+            std__Ref_count_base__Decref_Original(taskbarHostSharedPtr[1]);
+        }
+        return nullptr;
+    }
+    if (!TaskbarHost_FrameHeight_Original ||
+        !std__Ref_count_base__Decref_Original) {
+        return nullptr;
+    }
+
+    size_t taskbarElementIUnknownOffset = 0x10;
+
+#if defined(_M_X64)
+    {
+        // 48:83EC 28 | sub rsp,28
+        // 48:83C1 48 | add rcx,48
+        const BYTE* b = (const BYTE*)TaskbarHost_FrameHeight_Original;
+        if (b[0] == 0x48 && b[1] == 0x83 && b[2] == 0xEC && b[4] == 0x48 &&
+            b[5] == 0x83 && b[6] == 0xC1 && b[7] <= 0x7F) {
+            taskbarElementIUnknownOffset = b[7];
+        } else {
+            Wh_Log(L"Unsupported TaskbarHost::FrameHeight");
+        }
+    }
+#elif defined(_M_ARM64)
+    {
+        // 7f2303d5 pacibsp
+        // fd7bbfa9 stp     fp, lr, [sp, #-0x10]!
+        // fd030091 mov     fp, sp
+        // 080c41f8 ldr     x8, [x0, #0x10]!
+        const DWORD* p = (const DWORD*)TaskbarHost_FrameHeight_Original;
+        if (p[0] == 0xD503237F && (p[1] & 0xFFC07FFF) == 0xA9807BFD &&
+            p[2] == 0x910003FD && (p[3] & 0xFFF00FE0) == 0xF8400C00) {
+            taskbarElementIUnknownOffset = (p[3] >> 12) & 0xFF;
+        } else {
+            Wh_Log(L"Unsupported TaskbarHost::FrameHeight");
+        }
+    }
+#else
+#error "Unsupported architecture"
+#endif
+
+    auto* taskbarElementIUnknown =
+        *(IUnknown**)((BYTE*)taskbarHostSharedPtr[0] +
+                      taskbarElementIUnknownOffset);
+
+    FrameworkElement taskbarElement = nullptr;
+    if (taskbarElementIUnknown) {
+        taskbarElementIUnknown->QueryInterface(
+            winrt::guid_of<FrameworkElement>(), winrt::put_abi(taskbarElement));
+    }
+
+    auto result = taskbarElement ? taskbarElement.XamlRoot() : nullptr;
+
+    std__Ref_count_base__Decref_Original(taskbarHostSharedPtr[1]);
+
+    return result;
+}
+
+XamlRoot GetPrimaryTaskbarXamlRoot(HWND hTaskbarWnd) {
+    if (!CTaskBand_GetTaskbarHost_Original ||
+        !CTaskBand_ITaskListWndSite_vftable) {
+        return nullptr;
+    }
+
+    HWND hTaskSwWnd = (HWND)GetProp(hTaskbarWnd, L"TaskbandHWND");
+    if (!hTaskSwWnd) {
+        return nullptr;
+    }
+
+    void* taskBand = (void*)GetWindowLongPtr(hTaskSwWnd, 0);
+    if (!taskBand) {
+        return nullptr;
+    }
+
+    void* taskBandForTaskListWndSite = taskBand;
+    for (int i = 0; *(void**)taskBandForTaskListWndSite !=
+                    CTaskBand_ITaskListWndSite_vftable;
+         i++) {
+        if (i == 20) {
+            return nullptr;
+        }
+        taskBandForTaskListWndSite = (void**)taskBandForTaskListWndSite + 1;
+    }
+
+    void* taskbarHostSharedPtr[2]{};
+    CTaskBand_GetTaskbarHost_Original(taskBandForTaskListWndSite,
+                                      taskbarHostSharedPtr);
+    return XamlRootFromTaskbarHostSharedPtr(taskbarHostSharedPtr);
+}
+
+XamlRoot GetSecondaryTaskbarXamlRoot(HWND hSecondaryTaskbarWnd) {
+    if (!CSecondaryTaskBand_GetTaskbarHost_Original ||
+        !CSecondaryTaskBand_ITaskListWndSite_vftable) {
+        return nullptr;
+    }
+
+    HWND hTaskSwWnd =
+        (HWND)FindWindowEx(hSecondaryTaskbarWnd, nullptr, L"WorkerW", nullptr);
+    if (!hTaskSwWnd) {
+        return nullptr;
+    }
+
+    void* taskBand = (void*)GetWindowLongPtr(hTaskSwWnd, 0);
+    if (!taskBand) {
+        return nullptr;
+    }
+
+    void* taskBandForTaskListWndSite = taskBand;
+    for (int i = 0; *(void**)taskBandForTaskListWndSite !=
+                    CSecondaryTaskBand_ITaskListWndSite_vftable;
+         i++) {
+        if (i == 20) {
+            return nullptr;
+        }
+        taskBandForTaskListWndSite = (void**)taskBandForTaskListWndSite + 1;
+    }
+
+    void* taskbarHostSharedPtr[2]{};
+    CSecondaryTaskBand_GetTaskbarHost_Original(taskBandForTaskListWndSite,
+                                               taskbarHostSharedPtr);
+    return XamlRootFromTaskbarHostSharedPtr(taskbarHostSharedPtr);
+}
+
+XamlRoot GetTaskbarXamlRoot(HWND hTaskbarWnd) {
+    WCHAR className[32];
+    if (!GetClassName(hTaskbarWnd, className, ARRAYSIZE(className))) {
+        return nullptr;
+    }
+    if (_wcsicmp(className, L"Shell_TrayWnd") == 0) {
+        return GetPrimaryTaskbarXamlRoot(hTaskbarWnd);
+    }
+    if (_wcsicmp(className, L"Shell_SecondaryTrayWnd") == 0) {
+        return GetSecondaryTaskbarXamlRoot(hTaskbarWnd);
+    }
+    return nullptr;
+}
+
+using RunFromWindowThreadProc_t = void(WINAPI*)(void* parameter);
+
+bool RunFromWindowThread(HWND hWnd,
+                         RunFromWindowThreadProc_t proc,
+                         void* procParam) {
+    static const UINT runFromWindowThreadRegisteredMsg =
+        RegisterWindowMessage(L"Windhawk_RunFromWindowThread_" WH_MOD_ID);
+
+    struct RUN_FROM_WINDOW_THREAD_PARAM {
+        RunFromWindowThreadProc_t proc;
+        void* procParam;
+    };
+
+    DWORD dwThreadId = GetWindowThreadProcessId(hWnd, nullptr);
+    if (dwThreadId == 0) {
+        return false;
+    }
+
+    if (dwThreadId == GetCurrentThreadId()) {
+        proc(procParam);
+        return true;
+    }
+
+    HHOOK hook = SetWindowsHookEx(
+        WH_CALLWNDPROC,
+        [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
+            if (nCode == HC_ACTION) {
+                const CWPSTRUCT* cwp = (const CWPSTRUCT*)lParam;
+                if (cwp->message == runFromWindowThreadRegisteredMsg) {
+                    RUN_FROM_WINDOW_THREAD_PARAM* param =
+                        (RUN_FROM_WINDOW_THREAD_PARAM*)cwp->lParam;
+                    param->proc(param->procParam);
+                }
+            }
+            return CallNextHookEx(nullptr, nCode, wParam, lParam);
+        },
+        nullptr, dwThreadId);
+    if (!hook) {
+        return false;
+    }
+
+    RUN_FROM_WINDOW_THREAD_PARAM param;
+    param.proc = proc;
+    param.procParam = procParam;
+    SendMessage(hWnd, runFromWindowThreadRegisteredMsg, 0, (LPARAM)&param);
+
+    UnhookWindowsHookEx(hook);
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Visual tree helpers
+
+FrameworkElement FindChildByName(FrameworkElement const& element,
+                                 std::wstring_view name,
+                                 int maxDepth = 24) {
+    if (!element || maxDepth <= 0) {
+        return nullptr;
+    }
+    int count = VisualTreeHelper::GetChildrenCount(element);
+    for (int i = 0; i < count; i++) {
+        auto child =
+            VisualTreeHelper::GetChild(element, i).try_as<FrameworkElement>();
+        if (!child) {
+            continue;
+        }
+        if (child.Name() == name) {
+            return child;
+        }
+        if (auto found = FindChildByName(child, name, maxDepth - 1)) {
+            return found;
+        }
+    }
+    return nullptr;
+}
+
+Grid FindTaskbarRootGrid(FrameworkElement const& root) {
+    if (!root) {
+        return nullptr;
+    }
+    FrameworkElement taskbarFrame = nullptr;
+    int count = VisualTreeHelper::GetChildrenCount(root);
+    for (int i = 0; i < count; i++) {
+        auto child =
+            VisualTreeHelper::GetChild(root, i).try_as<FrameworkElement>();
+        if (child && winrt::get_class_name(child) == L"Taskbar.TaskbarFrame") {
+            taskbarFrame = child;
+            break;
+        }
+    }
+    if (!taskbarFrame) {
+        return nullptr;
+    }
+    auto rootGrid = FindChildByName(taskbarFrame, L"RootGrid", 4);
+    return rootGrid ? rootGrid.try_as<Grid>() : nullptr;
+}
+
+// The repeater's realized children are not in layout order, so anything that
+// depends on "leftmost" or "rightmost" is resolved geometrically instead.
+void EnumRepeaterChildren(FrameworkElement const& repeater,
+                          std::vector<FrameworkElement>* out) {
+    out->clear();
+    if (!repeater) {
+        return;
+    }
+    int count = VisualTreeHelper::GetChildrenCount(repeater);
+    for (int i = 0; i < count; i++) {
+        auto child =
+            VisualTreeHelper::GetChild(repeater, i).try_as<FrameworkElement>();
+        if (child) {
+            out->push_back(child);
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// GDI+ and icon helpers
+
+ULONG_PTR g_gdiplusToken = 0;
+
+struct ThemeCache {
+    bool dark = true;
+    BYTE accentR = 0;
+    BYTE accentG = 120;
+    BYTE accentB = 215;
+    bool variableFontAvailable = false;
+    bool resolved = false;
+};
+
+ThemeCache g_themeCache;
+
+void RefreshThemeCache() {
+    try {
+        winrt::Windows::UI::ViewManagement::UISettings settings;
+        auto bg = settings.GetColorValue(
+            winrt::Windows::UI::ViewManagement::UIColorType::Background);
+        g_themeCache.dark = ((int)bg.R + bg.G + bg.B) < 384;
+
+        auto accent = settings.GetColorValue(
+            winrt::Windows::UI::ViewManagement::UIColorType::Accent);
+        g_themeCache.accentR = accent.R;
+        g_themeCache.accentG = accent.G;
+        g_themeCache.accentB = accent.B;
+    } catch (...) {
+        g_themeCache.dark = true;
+        g_themeCache.accentR = 0;
+        g_themeCache.accentG = 120;
+        g_themeCache.accentB = 215;
+    }
+
+    Gdiplus::FontFamily probe(L"Segoe UI Variable Text");
+    g_themeCache.variableFontAvailable = probe.IsAvailable() != FALSE;
+    g_themeCache.resolved = true;
+}
+
+bool IsDarkTheme() {
+    if (!g_themeCache.resolved) {
+        RefreshThemeCache();
+    }
+    return g_themeCache.dark;
+}
+
+Gdiplus::Color GetAccentGdipColor(BYTE alpha) {
+    if (!g_themeCache.resolved) {
+        RefreshThemeCache();
+    }
+    return Gdiplus::Color(alpha, g_themeCache.accentR, g_themeCache.accentG,
+                          g_themeCache.accentB);
+}
+
+PCWSTR PopupFontName() {
+    if (!g_themeCache.resolved) {
+        RefreshThemeCache();
+    }
+    return g_themeCache.variableFontAvailable ? L"Segoe UI Variable Text"
+                                              : L"Segoe UI";
+}
+
+// Falls back to the system popup font when |custom| is empty or names a font
+// that isn't installed (FontFamily construction succeeds either way, but a
+// missing family leaves it in a bad state that GDI+ renders as boxes).
+std::wstring ResolvePopupFontName(const std::wstring& custom) {
+    if (!custom.empty()) {
+        Gdiplus::FontFamily family(custom.c_str());
+        if (family.GetLastStatus() == Gdiplus::Ok) {
+            return custom;
+        }
+    }
+    return PopupFontName();
+}
+
+// True when the alpha channel carries real transparency (partial alpha, or a
+// mix of fully transparent and opaque). All-0 or all-255 means the AND mask
+// must supply transparency instead — common for classic XOR+mask icons.
+bool IconPixelsHaveUsefulAlpha(const BYTE* bgra,
+                               int width,
+                               int height,
+                               int stride) {
+    if (!bgra || width <= 0 || height <= 0) {
+        return false;
+    }
+    bool sawTransparent = false;
+    bool sawOpaque = false;
+    bool sawPartial = false;
+    for (int y = 0; y < height; y++) {
+        const BYTE* row = bgra + (size_t)y * stride;
+        for (int x = 0; x < width; x++) {
+            BYTE a = row[(size_t)x * 4 + 3];
+            if (a == 0) {
+                sawTransparent = true;
+            } else if (a == 255) {
+                sawOpaque = true;
+            } else {
+                sawPartial = true;
+            }
+            if (sawPartial || (sawTransparent && sawOpaque)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// AND mask bit: 1/white = transparent, 0/black = opaque. Bits are MSB-first
+// within each byte; rows are DWORD-aligned.
+bool IconMaskBitTransparent(const BYTE* maskBits,
+                            int maskWidthBytes,
+                            int x,
+                            int y) {
+    const BYTE* row = maskBits + (size_t)y * maskWidthBytes;
+    BYTE b = row[x >> 3];
+    return (b & (0x80 >> (x & 7))) != 0;
+}
+
+// Pull a top-down 32bpp BGRA copy of an HBITMAP via GetDIBits (preserves the
+// alpha byte for existing 32bpp sources on modern Windows).
+bool CopyHbitmapToBgra32(HBITMAP hbm,
+                         std::vector<BYTE>* out,
+                         int* outW,
+                         int* outH) {
+    if (!hbm || !out || !outW || !outH) {
+        return false;
+    }
+    BITMAP bm{};
+    if (!GetObject(hbm, sizeof(bm), &bm) || bm.bmWidth <= 0 ||
+        bm.bmHeight <= 0) {
+        return false;
+    }
+    const int w = bm.bmWidth;
+    const int h = bm.bmHeight;
+
+    BITMAPINFO bi{};
+    bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bi.bmiHeader.biWidth = w;
+    bi.bmiHeader.biHeight = -h;  // top-down
+    bi.bmiHeader.biPlanes = 1;
+    bi.bmiHeader.biBitCount = 32;
+    bi.bmiHeader.biCompression = BI_RGB;
+
+    out->assign((size_t)w * h * 4, 0);
+    HDC hdc = GetDC(nullptr);
+    if (!hdc) {
+        return false;
+    }
+    int got = GetDIBits(hdc, hbm, 0, h, out->data(), &bi, DIB_RGB_COLORS);
+    ReleaseDC(nullptr, hdc);
+    if (got != h) {
+        return false;
+    }
+    *outW = w;
+    *outH = h;
+    return true;
+}
+
+// Clear junk RGB under transparent pixels and premultiply for PARGB drawing.
+// Classic XOR icons often leave white/gray in alpha==0 cells; SourceOver onto a
+// dark PARGB panel then reads as a faint lighter veil. Near-zero alpha with
+// near-white/near-black RGB (mask/DrawIconEx noise) is treated as fully clear
+// so soft edges of modern icons are preserved.
+void SanitizeAndPremultiplyBgra(BYTE* bgra,
+                                int width,
+                                int height,
+                                int stride) {
+    if (!bgra || width <= 0 || height <= 0) {
+        return;
+    }
+    for (int y = 0; y < height; y++) {
+        BYTE* row = bgra + (size_t)y * stride;
+        for (int x = 0; x < width; x++) {
+            BYTE* p = row + (size_t)x * 4;
+            BYTE b = p[0], g = p[1], r = p[2], a = p[3];
+            if (a == 0) {
+                p[0] = p[1] = p[2] = 0;
+                continue;
+            }
+            if (a < 8) {
+                const int mx = (std::max)((int)r, (std::max)((int)g, (int)b));
+                const int mn = (std::min)((int)r, (std::min)((int)g, (int)b));
+                const bool nearWhite = mn >= 220;
+                const bool nearBlack = mx <= 35;
+                if (nearWhite || nearBlack) {
+                    p[0] = p[1] = p[2] = p[3] = 0;
+                    continue;
+                }
+            }
+            p[0] = (BYTE)((int)b * a / 255);
+            p[1] = (BYTE)((int)g * a / 255);
+            p[2] = (BYTE)((int)r * a / 255);
+        }
+    }
+}
+
+// After scaling/filtering a PARGB bitmap, re-clear fully transparent pixels and
+// clamp channels so rgb never exceeds alpha (invalid premul from bicubic).
+void SanitizeParGbBitmap(Gdiplus::Bitmap* bmp) {
+    if (!bmp) {
+        return;
+    }
+    const int w = (int)bmp->GetWidth();
+    const int h = (int)bmp->GetHeight();
+    if (w <= 0 || h <= 0) {
+        return;
+    }
+    Gdiplus::BitmapData bd{};
+    Gdiplus::Rect lockRect(0, 0, w, h);
+    if (bmp->LockBits(&lockRect,
+                      (Gdiplus::ImageLockMode)(Gdiplus::ImageLockModeRead |
+                                               Gdiplus::ImageLockModeWrite),
+                      PixelFormat32bppPARGB, &bd) != Gdiplus::Ok) {
+        return;
+    }
+    for (int y = 0; y < h; y++) {
+        BYTE* row = (BYTE*)bd.Scan0 + (size_t)y * bd.Stride;
+        for (int x = 0; x < w; x++) {
+            BYTE* p = row + (size_t)x * 4;
+            BYTE a = p[3];
+            if (a == 0) {
+                p[0] = p[1] = p[2] = 0;
+                continue;
+            }
+            if (a < 8) {
+                const int mx =
+                    (std::max)((int)p[0], (std::max)((int)p[1], (int)p[2]));
+                // Premultiplied near-white junk is still bright relative to alpha.
+                const bool brightJunk = mx >= (int)a * 200 / 255 && mx >= 6;
+                const bool nearBlack = mx <= 2;
+                if (brightJunk || nearBlack) {
+                    p[0] = p[1] = p[2] = p[3] = 0;
+                    continue;
+                }
+            }
+            if (p[0] > a) {
+                p[0] = a;
+            }
+            if (p[1] > a) {
+                p[1] = a;
+            }
+            if (p[2] > a) {
+                p[2] = a;
+            }
+        }
+    }
+    bmp->UnlockBits(&bd);
+}
+
+// Apply the icon's 1-bit AND mask as alpha. For color icons the mask matches
+// the color size (or a double-height legacy layout); for monochrome icons the
+// AND plane is the top half. Destination may differ in size from the mask —
+// coordinates are mapped so scaled DrawIconEx buffers still work.
+void ApplyIconAndMaskToBgra(BYTE* bgra,
+                            int width,
+                            int height,
+                            HBITMAP hbmMask,
+                            bool monoIcon) {
+    if (!bgra || !hbmMask || width <= 0 || height <= 0) {
+        return;
+    }
+
+    BITMAP bmMask{};
+    if (!GetObject(hbmMask, sizeof(bmMask), &bmMask) || bmMask.bmWidth <= 0 ||
+        bmMask.bmHeight <= 0) {
+        return;
+    }
+
+    const int maskW = bmMask.bmWidth;
+    const int maskH = bmMask.bmHeight;
+    int andRows;
+    if (monoIcon) {
+        andRows = maskH / 2;
+    } else if (maskH >= height * 2 && height > 0) {
+        andRows = height;
+    } else {
+        andRows = maskH;
+    }
+    if (andRows <= 0) {
+        return;
+    }
+
+    struct {
+        BITMAPINFOHEADER bmiHeader;
+        RGBQUAD bmiColors[2];
+    } bi{};
+    bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bi.bmiHeader.biWidth = maskW;
+    bi.bmiHeader.biHeight = -maskH;  // top-down
+    bi.bmiHeader.biPlanes = 1;
+    bi.bmiHeader.biBitCount = 1;
+    bi.bmiHeader.biCompression = BI_RGB;
+    bi.bmiColors[0] = {0, 0, 0, 0};
+    bi.bmiColors[1] = {255, 255, 255, 0};
+
+    const int maskStride = ((maskW + 31) / 32) * 4;
+    std::vector<BYTE> maskBits((size_t)maskStride * maskH, 0);
+
+    HDC hdc = GetDC(nullptr);
+    if (!hdc) {
+        return;
+    }
+    int got = GetDIBits(hdc, hbmMask, 0, maskH, maskBits.data(),
+                        reinterpret_cast<BITMAPINFO*>(&bi), DIB_RGB_COLORS);
+    ReleaseDC(nullptr, hdc);
+    if (got <= 0) {
+        return;
+    }
+
+    for (int y = 0; y < height; y++) {
+        const int my = (y * andRows) / height;
+        BYTE* row = bgra + (size_t)y * width * 4;
+        for (int x = 0; x < width; x++) {
+            const int mx = (x * maskW) / width;
+            if (IconMaskBitTransparent(maskBits.data(), maskStride, mx, my)) {
+                row[(size_t)x * 4 + 0] = 0;
+                row[(size_t)x * 4 + 1] = 0;
+                row[(size_t)x * 4 + 2] = 0;
+                row[(size_t)x * 4 + 3] = 0;
+            } else if (row[(size_t)x * 4 + 3] == 0) {
+                // Opaque under the mask but alpha was never filled — make solid.
+                row[(size_t)x * 4 + 3] = 255;
+            }
+        }
+    }
+}
+
+// `bgra` must already be premultiplied (SanitizeAndPremultiplyBgra). Output is
+// PixelFormat32bppPARGB to match RebuildLevelBase / UpdateLayeredWindow.
+std::shared_ptr<Gdiplus::Bitmap> BitmapFromBgraScaled(const BYTE* bgra,
+                                                      int srcW,
+                                                      int srcH,
+                                                      int size) {
+    if (!bgra || srcW <= 0 || srcH <= 0 || size <= 0) {
+        return nullptr;
+    }
+
+    std::shared_ptr<Gdiplus::Bitmap> result;
+    try {
+        Gdiplus::Bitmap source(srcW, srcH, srcW * 4, PixelFormat32bppPARGB,
+                               const_cast<BYTE*>(bgra));
+        if (source.GetLastStatus() != Gdiplus::Ok) {
+            return nullptr;
+        }
+        result =
+            std::make_shared<Gdiplus::Bitmap>(size, size, PixelFormat32bppPARGB);
+        if (!result || result->GetLastStatus() != Gdiplus::Ok) {
+            return nullptr;
+        }
+        Gdiplus::Graphics g(result.get());
+        if (g.GetLastStatus() != Gdiplus::Ok) {
+            return nullptr;
+        }
+        g.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
+        g.Clear(Gdiplus::Color(0, 0, 0, 0));
+        g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
+        g.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBicubic);
+        g.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
+        if (g.DrawImage(&source, 0, 0, size, size) != Gdiplus::Ok) {
+            return nullptr;
+        }
+        SanitizeParGbBitmap(result.get());
+    } catch (...) {
+        return nullptr;
+    }
+    return result;
+}
+
+// Convert HICON to a sized 32bpp PARGB bitmap for every icon type:
+// 1) Prefer color-plane pixels that already carry useful alpha (modern ARGB).
+// 2) Otherwise apply the 1-bit AND mask (black=opaque, white=transparent) so
+//    classic XOR+mask icons never keep white/black bogus backgrounds.
+// 3) Sanitize transparent RGB + premultiply, then scale as PARGB.
+// 4) Last resort: DrawIconEx onto a zero-cleared 32bpp DIB, then mask if needed.
+std::shared_ptr<Gdiplus::Bitmap> HIconToBitmap(HICON hIcon, int size) {
+    if (!hIcon || size <= 0) {
+        return nullptr;
+    }
+
+    ICONINFO ii{};
+    if (GetIconInfo(hIcon, &ii)) {
+        const bool monoIcon = (ii.hbmColor == nullptr);
+        std::vector<BYTE> bgra;
+        int srcW = 0;
+        int srcH = 0;
+        bool havePixels = false;
+
+        if (ii.hbmColor) {
+            havePixels = CopyHbitmapToBgra32(ii.hbmColor, &bgra, &srcW, &srcH);
+        } else if (ii.hbmMask) {
+            // Monochrome: reconstruct color from the XOR (bottom) half via
+            // DrawIconEx onto a cleared DIB at the mask's logical size.
+            BITMAP bmMask{};
+            if (GetObject(ii.hbmMask, sizeof(bmMask), &bmMask) &&
+                bmMask.bmWidth > 0 && bmMask.bmHeight >= 2) {
+                srcW = bmMask.bmWidth;
+                srcH = bmMask.bmHeight / 2;
+                BITMAPINFO bi{};
+                bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+                bi.bmiHeader.biWidth = srcW;
+                bi.bmiHeader.biHeight = -srcH;
+                bi.bmiHeader.biPlanes = 1;
+                bi.bmiHeader.biBitCount = 32;
+                bi.bmiHeader.biCompression = BI_RGB;
+
+                HDC hScreen = GetDC(nullptr);
+                if (hScreen) {
+                    HDC hMem = CreateCompatibleDC(hScreen);
+                    ReleaseDC(nullptr, hScreen);
+                    if (hMem) {
+                        void* bits = nullptr;
+                        HBITMAP hDib = CreateDIBSection(hMem, &bi, DIB_RGB_COLORS,
+                                                        &bits, nullptr, 0);
+                        if (hDib && bits) {
+                            HGDIOBJ old = SelectObject(hMem, hDib);
+                            memset(bits, 0, (size_t)srcW * srcH * 4);
+                            DrawIconEx(hMem, 0, 0, hIcon, srcW, srcH, 0, nullptr,
+                                       DI_NORMAL);
+                            SelectObject(hMem, old);
+                            GdiFlush();
+                            bgra.assign((BYTE*)bits,
+                                        (BYTE*)bits + (size_t)srcW * srcH * 4);
+                            havePixels = true;
+                            DeleteObject(hDib);
+                        }
+                        DeleteDC(hMem);
+                    }
+                }
+            }
+        }
+
+        if (havePixels && srcW > 0 && srcH > 0) {
+            if (!IconPixelsHaveUsefulAlpha(bgra.data(), srcW, srcH, srcW * 4) &&
+                ii.hbmMask) {
+                ApplyIconAndMaskToBgra(bgra.data(), srcW, srcH, ii.hbmMask,
+                                       monoIcon);
+            }
+            SanitizeAndPremultiplyBgra(bgra.data(), srcW, srcH, srcW * 4);
+            auto scaled =
+                BitmapFromBgraScaled(bgra.data(), srcW, srcH, size);
+            if (ii.hbmColor) {
+                DeleteObject(ii.hbmColor);
+            }
+            if (ii.hbmMask) {
+                DeleteObject(ii.hbmMask);
+            }
+            if (scaled) {
+                return scaled;
+            }
+        } else {
+            if (ii.hbmColor) {
+                DeleteObject(ii.hbmColor);
+            }
+            if (ii.hbmMask) {
+                DeleteObject(ii.hbmMask);
+            }
+        }
+    }
+
+    // Last resort: DrawIconEx into a zero-cleared 32bpp DIB, then re-apply the
+    // AND mask when the draw left a useless alpha channel (XOR garbage RGB
+    // such as opaque white in transparent cells).
+    BITMAPINFO bi{};
+    bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bi.bmiHeader.biWidth = size;
+    bi.bmiHeader.biHeight = -size;  // top-down
+    bi.bmiHeader.biPlanes = 1;
+    bi.bmiHeader.biBitCount = 32;
+    bi.bmiHeader.biCompression = BI_RGB;
+
+    HDC hScreenDC = GetDC(nullptr);
+    if (!hScreenDC) {
+        return nullptr;
+    }
+    HDC hMemDC = CreateCompatibleDC(hScreenDC);
+    ReleaseDC(nullptr, hScreenDC);
+    if (!hMemDC) {
+        return nullptr;
+    }
+
+    void* bits = nullptr;
+    HBITMAP hBmp =
+        CreateDIBSection(hMemDC, &bi, DIB_RGB_COLORS, &bits, nullptr, 0);
+    if (!hBmp || !bits) {
+        DeleteDC(hMemDC);
+        return nullptr;
+    }
+
+    HGDIOBJ hOld = SelectObject(hMemDC, hBmp);
+    memset(bits, 0, (size_t)size * size * 4);
+    DrawIconEx(hMemDC, 0, 0, hIcon, size, size, 0, nullptr, DI_NORMAL);
+    SelectObject(hMemDC, hOld);
+    GdiFlush();
+
+    BYTE* px = (BYTE*)bits;
+    if (!IconPixelsHaveUsefulAlpha(px, size, size, size * 4)) {
+        ICONINFO maskInfo{};
+        if (GetIconInfo(hIcon, &maskInfo)) {
+            ApplyIconAndMaskToBgra(px, size, size, maskInfo.hbmMask,
+                                   maskInfo.hbmColor == nullptr);
+            if (maskInfo.hbmColor) {
+                DeleteObject(maskInfo.hbmColor);
+            }
+            if (maskInfo.hbmMask) {
+                DeleteObject(maskInfo.hbmMask);
+            }
+        } else {
+            // No mask available: opaque where any color was drawn.
+            for (size_t i = 0; i < (size_t)size * size * 4; i += 4) {
+                if (px[i] || px[i + 1] || px[i + 2]) {
+                    px[i + 3] = 255;
+                }
+            }
+        }
+    }
+    SanitizeAndPremultiplyBgra(px, size, size, size * 4);
+
+    std::shared_ptr<Gdiplus::Bitmap> result;
+    try {
+        result =
+            std::make_shared<Gdiplus::Bitmap>(size, size, PixelFormat32bppPARGB);
+        if (result->GetLastStatus() == Gdiplus::Ok) {
+            Gdiplus::BitmapData bd{};
+            Gdiplus::Rect lockRect(0, 0, size, size);
+            if (result->LockBits(&lockRect, Gdiplus::ImageLockModeWrite,
+                                 PixelFormat32bppPARGB, &bd) == Gdiplus::Ok) {
+                for (int y = 0; y < size; y++) {
+                    memcpy((BYTE*)bd.Scan0 + (size_t)y * bd.Stride,
+                           px + (size_t)y * size * 4, (size_t)size * 4);
+                }
+                result->UnlockBits(&bd);
+                SanitizeParGbBitmap(result.get());
+            } else {
+                result.reset();
+            }
+        } else {
+            result.reset();
+        }
+    } catch (...) {
+        result.reset();
+    }
+
+    DeleteObject(hBmp);
+    DeleteDC(hMemDC);
+
+    return result;
+}
+
+// Not exported by the MinGW uuid library, so it is spelled out here.
+constexpr GUID kIImageListGuid = {
+    0x46eb5926,
+    0x582e,
+    0x4017,
+    {0x9f, 0xdf, 0xe8, 0x99, 0x8d, 0xaa, 0x09, 0x50}};
+
+// Pick the system image list whose native size best covers the requested size.
+int ShilForSize(int pixelSize) {
+    if (pixelSize <= 16) {
+        return SHIL_SMALL;
+    }
+    if (pixelSize <= 32) {
+        return SHIL_LARGE;
+    }
+    if (pixelSize <= 48) {
+        return SHIL_EXTRALARGE;
+    }
+    return SHIL_JUMBO;
+}
+
+bool PathIsLnkFile(const std::wstring& path) {
+    return path.size() >= 4 &&
+           _wcsicmp(path.c_str() + (path.size() - 4), L".lnk") == 0;
+}
+
+// SHDefExtractIconW does not composite the shortcut overlay arrow.
+HICON ExtractIconDef(const std::wstring& path, int index, int pixelSize) {
+    HICON hLarge = nullptr;
+    HICON hSmall = nullptr;
+    if (SUCCEEDED(SHDefExtractIconW(path.c_str(), index, 0, &hLarge, &hSmall,
+                                    (UINT)pixelSize)) &&
+        hLarge) {
+        if (hSmall) {
+            DestroyIcon(hSmall);
+        }
+        return hLarge;
+    }
+    if (hSmall) {
+        return hSmall;
+    }
+    return nullptr;
+}
+
+// System image list index without drawing overlays (no SHGFI_LINKOVERLAY /
+// SHGFI_ICON, which bake the shortcut arrow into .lnk icons).
+HICON GetShellIconFromImageList(const std::wstring& path, int pixelSize) {
+    SHFILEINFOW sfi{};
+    if (!SHGetFileInfoW(path.c_str(), 0, &sfi, sizeof(sfi),
+                        SHGFI_SYSICONINDEX)) {
+        return nullptr;
+    }
+
+    HICON hIcon = nullptr;
+    IImageList* imageList = nullptr;
+    if (SUCCEEDED(SHGetImageList(ShilForSize(pixelSize), kIImageListGuid,
+                                 (void**)&imageList)) &&
+        imageList) {
+        imageList->GetIcon(sfi.iIcon, ILD_TRANSPARENT, &hIcon);
+        imageList->Release();
+    }
+    return hIcon;
+}
+
+// Resolve a .lnk's custom icon location or target path and extract without the
+// shell link overlay.
+HICON GetIconFromShortcutFile(const std::wstring& lnkPath, int pixelSize) {
+    IShellLinkW* link = nullptr;
+    if (FAILED(CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+                                IID_IShellLinkW, (void**)&link)) ||
+        !link) {
+        return nullptr;
+    }
+
+    IPersistFile* persist = nullptr;
+    HRESULT hr = link->QueryInterface(IID_IPersistFile, (void**)&persist);
+    if (FAILED(hr) || !persist) {
+        link->Release();
+        return nullptr;
+    }
+
+    hr = persist->Load(lnkPath.c_str(), STGM_READ);
+    persist->Release();
+    if (FAILED(hr)) {
+        link->Release();
+        return nullptr;
+    }
+
+    WCHAR iconLoc[MAX_PATH]{};
+    int iconIndex = 0;
+    hr = link->GetIconLocation(iconLoc, ARRAYSIZE(iconLoc), &iconIndex);
+    if (SUCCEEDED(hr) && iconLoc[0]) {
+        WCHAR expanded[MAX_PATH]{};
+        PCWSTR file = iconLoc;
+        DWORD expandedLen =
+            ExpandEnvironmentStringsW(iconLoc, expanded, ARRAYSIZE(expanded));
+        if (expandedLen > 0 && expandedLen <= ARRAYSIZE(expanded)) {
+            file = expanded;
+        }
+        HICON hIcon = ExtractIconDef(file, iconIndex, pixelSize);
+        if (hIcon) {
+            link->Release();
+            return hIcon;
+        }
+    }
+
+    WCHAR target[MAX_PATH]{};
+    hr = link->GetPath(target, ARRAYSIZE(target), nullptr, SLGP_RAWPATH);
+    if (FAILED(hr) || !target[0]) {
+        hr = link->GetPath(target, ARRAYSIZE(target), nullptr, 0);
+    }
+    link->Release();
+    if (FAILED(hr) || !target[0]) {
+        return nullptr;
+    }
+
+    WCHAR expandedTarget[MAX_PATH]{};
+    PCWSTR useTarget = target;
+    DWORD targetLen = ExpandEnvironmentStringsW(target, expandedTarget,
+                                                ARRAYSIZE(expandedTarget));
+    if (targetLen > 0 && targetLen <= ARRAYSIZE(expandedTarget)) {
+        useTarget = expandedTarget;
+    }
+
+    if (HICON hIcon = ExtractIconDef(useTarget, 0, pixelSize)) {
+        return hIcon;
+    }
+    return GetShellIconFromImageList(useTarget, pixelSize);
+}
+
+HICON GetShellIconForPath(const std::wstring& path, int pixelSize) {
+    // Prefer paths that never composite SHGFI_LINKOVERLAY / shortcut arrows.
+    if (PathIsLnkFile(path)) {
+        if (HICON hIcon = GetIconFromShortcutFile(path, pixelSize)) {
+            return hIcon;
+        }
+        // Extracting from the .lnk itself still avoids the overlay arrow.
+        if (HICON hIcon = ExtractIconDef(path, 0, pixelSize)) {
+            return hIcon;
+        }
+    } else if (HICON hIcon = ExtractIconDef(path, 0, pixelSize)) {
+        return hIcon;
+    }
+
+    if (HICON hIcon = GetShellIconFromImageList(path, pixelSize)) {
+        return hIcon;
+    }
+
+    // Last resort — SHGFI_ICON may include the shortcut overlay for .lnk files.
+    SHFILEINFOW sfi{};
+    UINT flags =
+        SHGFI_ICON | (pixelSize <= 16 ? SHGFI_SMALLICON : SHGFI_LARGEICON);
+    if (SHGetFileInfoW(path.c_str(), 0, &sfi, sizeof(sfi), flags)) {
+        return sfi.hIcon;
+    }
+    return nullptr;
+}
+
+// Accepts "C:\path\app.exe,3" as well as a plain image or icon file path.
+HICON ExtractIconFromResourceSpec(const std::wstring& spec, int pixelSize) {
+    std::wstring file = spec;
+    int index = 0;
+
+    size_t comma = spec.find_last_of(L',');
+    if (comma != std::wstring::npos && comma + 1 < spec.size()) {
+        PCWSTR numStart = spec.c_str() + comma + 1;
+        WCHAR* end = nullptr;
+        long parsed = wcstol(numStart, &end, 10);
+        if (end && *end == L'\0') {
+            file = spec.substr(0, comma);
+            index = (int)parsed;
+        }
+    }
+
+    if (HICON hIcon = ExtractIconDef(file, index, pixelSize)) {
+        return hIcon;
+    }
+    return GetShellIconFromImageList(file, pixelSize);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Folder scanning and caching
+
+struct GridItem {
+    std::wstring displayName;
+    std::wstring fullPath;
+    // When a .lnk points at a folder we cascade against the target path, but
+    // keep the shortcut itself here so its custom icon still shows.
+    std::wstring iconPath;
+    bool isFolder = false;
+    ULONGLONG modified = 0;
+    std::shared_ptr<Gdiplus::Bitmap> icon;
+};
+
+struct FolderData {
+    std::vector<GridItem> items;
+    bool ready = false;
+    ULONGLONG scannedAtTick = 0;
+    // LRU bookkeeping for FolderCache eviction (separate from scan freshness).
+    ULONGLONG lastUsedTick = 0;
+    int scannedIconSize = 0;
+    // Approximate resident bytes of icon pixel buffers (width*height*4).
+    size_t approxBytes = 0;
+};
+
+// Bound folder-path → FolderData entries. PrefetchSubfolders can enqueue many
+// paths; without a cap the map grows without bound across a session.
+constexpr size_t kMaxCachedFolders = 32;
+// Soft ceiling on cached icon bitmaps across all folders (~64 MB).
+constexpr size_t kMaxCachedFolderBytes = 64ull * 1024 * 1024;
+
+enum class ScanRequestKind { Folder, ButtonIcon };
+
+struct ScanRequest {
+    ScanRequestKind kind = ScanRequestKind::Folder;
+    std::wstring path;
+    int iconPixelSize = 32;
+    // ButtonIcon: extract on the STA scan worker, deliver pixels on the UI thread.
+    int folderIndex = -1;
+    uint32_t iconGeneration = 0;
+    HWND taskbarWnd = nullptr;
+    bool resourceSpec = false;
+};
+
+// Keyed by resolved folder path so subfolders opened on hover share the same
+// cache as the folders configured on the taskbar.
+std::mutex g_cacheMutex;
+[[clang::no_destroy]] std::optional<
+    std::unordered_map<std::wstring, std::shared_ptr<FolderData>>>
+    g_folderCache{std::in_place};
+
+std::unordered_map<std::wstring, std::shared_ptr<FolderData>>& FolderCache() {
+    if (!g_folderCache) {
+        g_folderCache.emplace();
+    }
+    return *g_folderCache;
+}
+
+// How many GridItems (with bitmaps) to retain per cached folder. Prefer an
+// on-screen capacity related to ComputeLevelLayout (columns × ~rows) over the
+// raw maxItems ceiling — large iconSize values leave few cells visible, and
+// caching hundreds of 256–512 px bitmaps is pure RAM waste.
+int MaxCachedItemsPerFolder() {
+    int cols = g_settings.columns > 0 ? g_settings.columns : 12;
+    int maxRows = 16;
+    if (g_settings.iconSize >= 128) {
+        maxRows = 6;
+    } else if (g_settings.iconSize >= 64) {
+        maxRows = 10;
+    }
+    int screenCap = std::clamp(cols * maxRows, 24, 192);
+    if (g_settings.maxItems > 0) {
+        return std::min(g_settings.maxItems, screenCap);
+    }
+    return screenCap;
+}
+
+size_t EstimateFolderDataBytes(const FolderData& data) {
+    size_t bytes = 0;
+    const int fallbackPx = data.scannedIconSize > 0 ? data.scannedIconSize : 32;
+    const size_t fallbackIconBytes =
+        (size_t)fallbackPx * (size_t)fallbackPx * 4;
+    for (const auto& item : data.items) {
+        if (!item.icon) {
+            continue;
+        }
+        const UINT w = item.icon->GetWidth();
+        const UINT h = item.icon->GetHeight();
+        if (w > 0 && h > 0) {
+            bytes += (size_t)w * (size_t)h * 4;
+        } else {
+            bytes += fallbackIconBytes;
+        }
+    }
+    return bytes;
+}
+
+// Caller must hold g_cacheMutex. Drops least-recently-used entries until both
+// the entry cap and the approximate byte budget are satisfied. Never erases
+// keepKey (the entry just inserted/used). Erasing only releases the cache's
+// shared_ptr; open PopupLevels that copied items (and their shared_ptr icons)
+// keep working.
+void EvictFolderCacheIfNeeded(const std::wstring& keepKey) {
+    auto& cache = FolderCache();
+    auto totalBytes = [&]() -> size_t {
+        size_t sum = 0;
+        for (const auto& entry : cache) {
+            if (entry.second) {
+                sum += entry.second->approxBytes;
+            }
+        }
+        return sum;
+    };
+
+    while (cache.size() > kMaxCachedFolders ||
+           (cache.size() > 1 && totalBytes() > kMaxCachedFolderBytes)) {
+        auto oldest = cache.end();
+        for (auto it = cache.begin(); it != cache.end(); ++it) {
+            if (it->first == keepKey) {
+                continue;
+            }
+            if (oldest == cache.end() ||
+                it->second->lastUsedTick < oldest->second->lastUsedTick) {
+                oldest = it;
+            }
+        }
+        if (oldest == cache.end()) {
+            break;
+        }
+        cache.erase(oldest);
+    }
+}
+
+// UNC shares and mapped/unavailable network drives — shell I/O on these can
+// block for the full SMB/WebDAV timeout. Used to skip sync work on the UI
+// thread and to bound scan-thread hangs.
+bool IsLikelyRemotePath(const std::wstring& p) {
+    if (p.empty()) {
+        return false;
+    }
+    if (PathIsUNCW(p.c_str())) {
+        return true;
+    }
+    if (p.size() >= 2 && p[1] == L':') {
+        WCHAR root[4] = {p[0], L':', L'\\', 0};
+        UINT type = GetDriveTypeW(root);
+        return type == DRIVE_REMOTE || type == DRIVE_NO_ROOT_DIR;
+    }
+    return false;
+}
+
+// File portion of an "app.exe,3" icon resource spec (or the whole string).
+std::wstring IconSpecFilePart(const std::wstring& spec) {
+    size_t comma = spec.find_last_of(L',');
+    if (comma != std::wstring::npos && comma + 1 < spec.size()) {
+        PCWSTR numStart = spec.c_str() + comma + 1;
+        WCHAR* end = nullptr;
+        (void)wcstol(numStart, &end, 10);
+        if (end && *end == L'\0') {
+            return spec.substr(0, comma);
+        }
+    }
+    return spec;
+}
+
+std::mutex g_scanMutex;
+std::vector<ScanRequest> g_scanQueue;
+// Atomic: ScanFolderInto reads this outside the mutex during icon extraction.
+std::atomic<bool> g_scanThreadStop{false};
+// True while StopScanThread has swapped the worker out and is joining — blocks
+// StartScanThread from spawning a sibling against handles about to be closed.
+std::atomic<bool> g_scanThreadJoining{false};
+// Manual-reset stop + auto-reset work. Idle wait is MsgWaitForMultipleObjects
+// with QS_ALLINPUT (no 50 ms poll). Created lazily with the scan thread.
+HANDLE g_scanStopEvent = nullptr;
+HANDLE g_scanWorkEvent = nullptr;
+// optional + no_destroy: a bare std::thread aborts Explorer on process exit if
+// it is still joinable when globals are destroyed.
+[[clang::no_destroy]] std::optional<std::thread> g_scanThread;
+
+// Shell icon handlers on an STA thread may create windows and post messages.
+// Pump while idle/between extractions so a wait without a message loop cannot
+// hang forever; stop still wakes via g_scanStopEvent + g_scanThreadStop.
+void PumpScanThreadMessages() {
+    MSG msg;
+    while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+        if (msg.message == WM_QUIT) {
+            // Do not tear down the scan thread on an unexpected WM_QUIT.
+            continue;
+        }
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+}
+
+std::wstring CacheKey(const std::wstring& path) {
+    std::wstring key = path;
+    CharLowerBuffW(key.data(), (DWORD)key.size());
+    return key;
+}
+
+bool IsShellFolderPath(const std::wstring& path) {
+    return path.size() > 6 && _wcsnicmp(path.c_str(), L"shell:", 6) == 0;
+}
+
+// A `shell:` target is resolved to a filesystem path so the plain directory
+// walk below can handle every configured folder the same way. The shell:
+// branch needs a live COM apartment — call only from the scan STA or the
+// taskbar UI thread, never from Wh_ModInit / LoadFolders.
+std::wstring ResolveFolderPath(const std::wstring& raw) {
+    if (IsShellFolderPath(raw)) {
+        PIDLIST_ABSOLUTE pidl = nullptr;
+        if (SUCCEEDED(
+                SHParseDisplayName(raw.c_str(), nullptr, &pidl, 0, nullptr)) &&
+            pidl) {
+            WCHAR buf[MAX_PATH]{};
+            bool ok = SHGetPathFromIDListW(pidl, buf);
+            CoTaskMemFree(pidl);
+            if (ok && buf[0]) {
+                return buf;
+            }
+        }
+        return L"";
+    }
+
+    std::wstring path = raw;
+    while (path.size() > 3 && (path.back() == L'\\' || path.back() == L'/')) {
+        path.pop_back();
+    }
+    return path;
+}
+
+void ResolveFolderEntry(FolderEntry& entry) {
+    if (entry.resolveFailed || !entry.resolvedPath.empty()) {
+        return;
+    }
+    std::wstring resolved = ResolveFolderPath(entry.path);
+    if (resolved.empty()) {
+        entry.resolveFailed = true;
+        Wh_Log(L"Folder path does not resolve to a filesystem folder: %s",
+               entry.path.c_str());
+        return;
+    }
+    entry.resolvedPath = std::move(resolved);
+    entry.likelyRemote = IsLikelyRemotePath(entry.resolvedPath);
+}
+
+// Fill FolderEntry::resolvedPath for any still-pending shell: entries. Must run
+// on an STA that already owns COM (taskbar UI or scan worker) — no CoInit here.
+void ResolvePendingFolderEntries() {
+    std::lock_guard<std::mutex> lock(g_foldersMutex);
+    for (auto& entry : g_settings.folders) {
+        if (entry.resolvedPath.empty() && !entry.resolveFailed) {
+            ResolveFolderEntry(entry);
+        }
+    }
+}
+
+std::wstring MakeDisplayName(const std::wstring& fileName, bool isFolder) {
+    if (isFolder) {
+        return fileName;
+    }
+    size_t dot = fileName.find_last_of(L'.');
+    if (dot == std::wstring::npos || dot == 0) {
+        return fileName;
+    }
+    std::wstring ext = fileName.substr(dot);
+    // Windows always hides shortcut extensions, regardless of the user's
+    // setting.
+    if (_wcsicmp(ext.c_str(), L".lnk") == 0 ||
+        _wcsicmp(ext.c_str(), L".url") == 0) {
+        return fileName.substr(0, dot);
+    }
+    if (!g_settings.showExtensions) {
+        return fileName.substr(0, dot);
+    }
+    return fileName;
+}
+
+// Folder shortcuts (.lnk whose target is a directory) are files to
+// FindFirstFile, but Explorer treats them as folders. Resolve the target so
+// they can cascade.
+std::wstring ResolveFolderShortcutTarget(const std::wstring& path) {
+    size_t len = path.size();
+    if (len < 5 || _wcsicmp(path.c_str() + (len - 4), L".lnk") != 0) {
+        return {};
+    }
+
+    IShellLinkW* link = nullptr;
+    if (FAILED(CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+                                IID_IShellLinkW, (void**)&link)) ||
+        !link) {
+        return {};
+    }
+
+    IPersistFile* persist = nullptr;
+    HRESULT hr = link->QueryInterface(IID_IPersistFile, (void**)&persist);
+    if (FAILED(hr) || !persist) {
+        link->Release();
+        return {};
+    }
+
+    hr = persist->Load(path.c_str(), STGM_READ);
+    persist->Release();
+    if (FAILED(hr)) {
+        link->Release();
+        return {};
+    }
+
+    // Skip Resolve(): it can hang on unreachable network targets and may show
+    // UI.
+    WCHAR target[MAX_PATH]{};
+    hr = link->GetPath(target, ARRAYSIZE(target), nullptr, SLGP_RAWPATH);
+    if (FAILED(hr) || !target[0]) {
+        hr = link->GetPath(target, ARRAYSIZE(target), nullptr, 0);
+    }
+    link->Release();
+
+    if (FAILED(hr) || !target[0]) {
+        return {};
+    }
+
+    // GetFileAttributesW on an offline share blocks for the network timeout.
+    if (IsLikelyRemotePath(target)) {
+        return {};
+    }
+
+    DWORD attrs = GetFileAttributesW(target);
+    if (attrs == INVALID_FILE_ATTRIBUTES ||
+        (attrs & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+        return {};
+    }
+
+    std::wstring resolved = target;
+    while (resolved.size() > 3 &&
+           (resolved.back() == L'\\' || resolved.back() == L'/')) {
+        resolved.pop_back();
+    }
+    return resolved;
+}
+
+void ScanFolderInto(const std::wstring& path,
+                    int iconPixelSize,
+                    FolderData* out) {
+    out->items.clear();
+    out->scannedIconSize = iconPixelSize;
+    out->approxBytes = 0;
+
+    if (path.empty()) {
+        return;
+    }
+
+    // FindFirstFileExW on an offline share blocks StopScanThread's join.
+    if (IsLikelyRemotePath(path)) {
+        Wh_Log(L"Skipping scan of remote/unavailable path %s", path.c_str());
+        return;
+    }
+
+    std::wstring pattern = path + L"\\*";
+    WIN32_FIND_DATAW fd{};
+    HANDLE hFind = FindFirstFileExW(pattern.c_str(), FindExInfoBasic, &fd,
+                                    FindExSearchNameMatch, nullptr,
+                                    FIND_FIRST_EX_LARGE_FETCH);
+    if (hFind == INVALID_HANDLE_VALUE) {
+        return;
+    }
+
+    do {
+        if (g_unloading || g_scanThreadStop) {
+            break;
+        }
+        if (wcscmp(fd.cFileName, L".") == 0 ||
+            wcscmp(fd.cFileName, L"..") == 0) {
+            continue;
+        }
+
+        bool isRealDir = (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+        std::wstring itemPath = path + L"\\" + fd.cFileName;
+        std::wstring iconPath;
+
+        bool isFolder = isRealDir;
+        if (!isFolder) {
+            std::wstring target = ResolveFolderShortcutTarget(itemPath);
+            if (!target.empty()) {
+                isFolder = true;
+                iconPath = itemPath;
+                itemPath = std::move(target);
+            }
+        }
+
+        if (isFolder && !g_settings.includeSubfolders) {
+            continue;
+        }
+        if (!g_settings.showHidden &&
+            (fd.dwFileAttributes &
+             (FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM))) {
+            continue;
+        }
+        if (_wcsicmp(fd.cFileName, L"desktop.ini") == 0) {
+            continue;
+        }
+
+        GridItem item;
+        item.isFolder = isFolder;
+        item.fullPath = std::move(itemPath);
+        item.iconPath = std::move(iconPath);
+        // Use the on-disk kind for the label so .lnk extensions stay stripped.
+        item.displayName = MakeDisplayName(fd.cFileName, isRealDir);
+        item.modified = ((ULONGLONG)fd.ftLastWriteTime.dwHighDateTime << 32) |
+                        fd.ftLastWriteTime.dwLowDateTime;
+        out->items.push_back(std::move(item));
+    } while (FindNextFileW(hFind, &fd));
+
+    FindClose(hFind);
+
+    // Folders always lead, so the things that cascade sit together at the top
+    // of the grid. The sort setting then orders within each group.
+    std::sort(out->items.begin(), out->items.end(),
+              [](const GridItem& a, const GridItem& b) {
+                  if (a.isFolder != b.isFolder) {
+                      return a.isFolder;
+                  }
+                  if (g_settings.sortBy == SortMode::Modified &&
+                      a.modified != b.modified) {
+                      return a.modified > b.modified;
+                  }
+                  return StrCmpLogicalW(a.displayName.c_str(),
+                                        b.displayName.c_str()) < 0;
+              });
+
+    // Trim before icon extraction so we never allocate bitmaps we will discard.
+    const int cacheCap = MaxCachedItemsPerFolder();
+    if ((int)out->items.size() > cacheCap) {
+        out->items.resize(cacheCap);
+    }
+
+    for (auto& item : out->items) {
+        if (g_unloading || g_scanThreadStop) {
+            break;
+        }
+        const std::wstring& iconSource =
+            item.iconPath.empty() ? item.fullPath : item.iconPath;
+        if (IsLikelyRemotePath(iconSource)) {
+            // Leave null icon; PaintLevel draws without it.
+            PumpScanThreadMessages();
+            continue;
+        }
+        HICON hIcon = GetShellIconForPath(iconSource, iconPixelSize);
+        if (hIcon) {
+            item.icon = HIconToBitmap(hIcon, iconPixelSize);
+            DestroyIcon(hIcon);
+        }
+        // Keep the STA responsive for in-process shell icon handlers.
+        PumpScanThreadMessages();
+    }
+
+    out->approxBytes = EstimateFolderDataBytes(*out);
+}
+
+void StartScanThread();
+
+// Delivered from the scan STA to the taskbar UI thread (WriteableBitmap only).
+struct ButtonIconDelivery {
+    int folderIndex = -1;
+    uint32_t iconGeneration = 0;
+    int iconExtent = 0;
+    HWND taskbarWnd = nullptr;
+    std::shared_ptr<Gdiplus::Bitmap> bitmap;
+};
+
+void ApplyButtonIconOnUiThread(void* parameter);
+
+void DeliverButtonIconToUi(std::unique_ptr<ButtonIconDelivery> delivery) {
+    if (!delivery || !delivery->taskbarWnd || !delivery->bitmap) {
+        return;
+    }
+    HWND hwnd = delivery->taskbarWnd;
+    ButtonIconDelivery* raw = delivery.release();
+    if (!RunFromWindowThread(hwnd, ApplyButtonIconOnUiThread, raw)) {
+        delete raw;
+    }
+}
+
+void ScanThreadMain() {
+    // Shell icon extractors (SHGetFileInfo / IExtractIcon) expect STA. MTA
+    // causes many extractions to fail with the generic document icon.
+    winrt::init_apartment(winrt::apartment_type::single_threaded);
+
+    // Resolve shell: folder settings on this STA (no CoInitializeEx). Also
+    // re-run when settings reload restarts the worker.
+    ResolvePendingFolderEntries();
+
+    // Capture event handles once; StopScanThread closes them only after join.
+    HANDLE stopEvent = g_scanStopEvent;
+    HANDLE workEvent = g_scanWorkEvent;
+
+    for (;;) {
+        ScanRequest request;
+        {
+            std::unique_lock<std::mutex> lock(g_scanMutex);
+            for (;;) {
+                if (g_scanThreadStop.load(std::memory_order_relaxed)) {
+                    winrt::uninit_apartment();
+                    return;
+                }
+                if (!g_scanQueue.empty()) {
+                    break;
+                }
+
+                lock.unlock();
+                // Event-driven idle: sleep until stop, work, or an STA message.
+                // No timed poll — keeps Explorer out of a permanent 20 Hz wake.
+                HANDLE waits[] = {stopEvent, workEvent};
+                DWORD w = MsgWaitForMultipleObjects(2, waits, FALSE, INFINITE,
+                                                    QS_ALLINPUT);
+                if (w == WAIT_OBJECT_0) {
+                    winrt::uninit_apartment();
+                    return;
+                }
+                if (w == WAIT_OBJECT_0 + 2) {
+                    PumpScanThreadMessages();
+                } else if (w == WAIT_FAILED) {
+                    Wh_Log(L"Scan thread MsgWaitForMultipleObjects failed (%u)",
+                           GetLastError());
+                    Sleep(10);
+                }
+                // WAIT_OBJECT_0+1 (work) or after pump: re-check the queue.
+                lock.lock();
+            }
+
+            request = std::move(g_scanQueue.front());
+            g_scanQueue.erase(g_scanQueue.begin());
+        }
+
+        // Settings may have reloaded with new shell: entries while we idled.
+        ResolvePendingFolderEntries();
+
+        if (request.iconPixelSize <= 0) {
+            request.iconPixelSize = 32;
+        }
+
+        if (request.kind == ScanRequestKind::ButtonIcon) {
+            std::shared_ptr<Gdiplus::Bitmap> bitmap;
+            if (!request.path.empty()) {
+                const std::wstring checkPath =
+                    request.resourceSpec ? IconSpecFilePart(request.path)
+                                         : request.path;
+                if (IsLikelyRemotePath(checkPath)) {
+                    Wh_Log(L"Skipping button icon for remote path %s",
+                           checkPath.c_str());
+                } else if (request.resourceSpec) {
+                    if (HICON hIcon = ExtractIconFromResourceSpec(
+                            request.path, request.iconPixelSize)) {
+                        bitmap = HIconToBitmap(hIcon, request.iconPixelSize);
+                        DestroyIcon(hIcon);
+                    }
+                } else {
+                    std::wstring resolved = ResolveFolderPath(request.path);
+                    if (!resolved.empty() && !IsLikelyRemotePath(resolved)) {
+                        if (HICON hIcon = GetShellIconForPath(
+                                resolved, request.iconPixelSize)) {
+                            bitmap =
+                                HIconToBitmap(hIcon, request.iconPixelSize);
+                            DestroyIcon(hIcon);
+                        }
+                    }
+                }
+                PumpScanThreadMessages();
+            }
+
+            if (bitmap && !g_unloading &&
+                !g_scanThreadStop.load(std::memory_order_relaxed)) {
+                auto delivery = std::make_unique<ButtonIconDelivery>();
+                delivery->folderIndex = request.folderIndex;
+                delivery->iconGeneration = request.iconGeneration;
+                // iconPixelSize is the extract size (display extent × 2).
+                delivery->iconExtent = std::max(8, request.iconPixelSize / 2);
+                delivery->taskbarWnd = request.taskbarWnd;
+                delivery->bitmap = std::move(bitmap);
+                DeliverButtonIconToUi(std::move(delivery));
+            }
+            continue;
+        }
+
+        std::wstring scanPath = request.path;
+        if (IsShellFolderPath(scanPath)) {
+            scanPath = ResolveFolderPath(scanPath);
+        }
+        if (scanPath.empty()) {
+            Wh_Log(L"Skipping scan; unresolved path %s", request.path.c_str());
+            continue;
+        }
+
+        auto fresh = std::make_shared<FolderData>();
+        ScanFolderInto(scanPath, request.iconPixelSize, fresh.get());
+        fresh->ready = true;
+        fresh->scannedAtTick = GetTickCount64();
+        fresh->lastUsedTick = fresh->scannedAtTick;
+
+        if (g_unloading ||
+            g_scanThreadStop.load(std::memory_order_relaxed)) {
+            break;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(g_cacheMutex);
+            const std::wstring key = CacheKey(scanPath);
+            FolderCache()[key] = fresh;
+            EvictFolderCacheIfNeeded(key);
+        }
+
+        Wh_Log(L"Scanned %s: %d items", scanPath.c_str(),
+               (int)fresh->items.size());
+    }
+
+    winrt::uninit_apartment();
+}
+
+void RequestScan(const std::wstring& path, int iconPixelSize) {
+    if (path.empty() || g_unloading) {
+        return;
+    }
+
+    // Lazy start (and restart after StopScanThread). Safe from the UI thread:
+    // StartScanThread only creates the worker; Stop during uninit sets
+    // g_unloading / g_scanThreadStop first so a raced enqueue is dropped.
+    StartScanThread();
+
+    std::lock_guard<std::mutex> lock(g_scanMutex);
+    if (g_unloading || g_scanThreadStop.load(std::memory_order_relaxed) ||
+        g_scanThreadJoining.load(std::memory_order_relaxed)) {
+        return;
+    }
+    for (const auto& queued : g_scanQueue) {
+        if (queued.kind == ScanRequestKind::Folder &&
+            queued.iconPixelSize == iconPixelSize &&
+            _wcsicmp(queued.path.c_str(), path.c_str()) == 0) {
+            return;
+        }
+    }
+    ScanRequest req;
+    req.kind = ScanRequestKind::Folder;
+    req.path = path;
+    req.iconPixelSize = iconPixelSize;
+    g_scanQueue.push_back(std::move(req));
+    if (g_scanWorkEvent) {
+        SetEvent(g_scanWorkEvent);
+    }
+}
+
+// Extract a taskbar button icon on the STA scan worker. The UI shows an emoji
+// fallback until ApplyButtonIconOnUiThread installs a WriteableBitmap.
+void RequestButtonIcon(const std::wstring& pathOrSpec,
+                       int iconPixelSize,
+                       int folderIndex,
+                       uint32_t iconGeneration,
+                       HWND taskbarWnd,
+                       bool resourceSpec) {
+    if (pathOrSpec.empty() || g_unloading || !taskbarWnd || folderIndex < 0) {
+        return;
+    }
+
+    const std::wstring checkPath =
+        resourceSpec ? IconSpecFilePart(pathOrSpec) : pathOrSpec;
+    if (IsLikelyRemotePath(checkPath)) {
+        Wh_Log(L"Skipping button icon request for remote path %s",
+               checkPath.c_str());
+        return;
+    }
+
+    StartScanThread();
+
+    std::lock_guard<std::mutex> lock(g_scanMutex);
+    if (g_unloading || g_scanThreadStop.load(std::memory_order_relaxed) ||
+        g_scanThreadJoining.load(std::memory_order_relaxed)) {
+        return;
+    }
+    for (const auto& queued : g_scanQueue) {
+        if (queued.kind == ScanRequestKind::ButtonIcon &&
+            queued.folderIndex == folderIndex &&
+            queued.iconGeneration == iconGeneration &&
+            queued.taskbarWnd == taskbarWnd &&
+            queued.iconPixelSize == iconPixelSize) {
+            return;
+        }
+    }
+    ScanRequest req;
+    req.kind = ScanRequestKind::ButtonIcon;
+    req.path = pathOrSpec;
+    req.iconPixelSize = iconPixelSize;
+    req.folderIndex = folderIndex;
+    req.iconGeneration = iconGeneration;
+    req.taskbarWnd = taskbarWnd;
+    req.resourceSpec = resourceSpec;
+    g_scanQueue.push_back(std::move(req));
+    if (g_scanWorkEvent) {
+        SetEvent(g_scanWorkEvent);
+    }
+}
+
+std::shared_ptr<FolderData> GetFolderData(const std::wstring& path) {
+    if (path.empty()) {
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> lock(g_cacheMutex);
+    auto found = FolderCache().find(CacheKey(path));
+    if (found == FolderCache().end()) {
+        return nullptr;
+    }
+    found->second->lastUsedTick = GetTickCount64();
+    return found->second;
+}
+
+// Returns the cached contents, queueing a scan when the entry is missing,
+// stale, or was rendered at a different icon size. Never blocks.
+std::shared_ptr<FolderData> GetFolderDataAndRefresh(const std::wstring& path,
+                                                    int iconPixelSize) {
+    auto data = GetFolderData(path);
+    if (!data || !data->ready || data->scannedIconSize != iconPixelSize ||
+        GetTickCount64() - data->scannedAtTick > 5000) {
+        RequestScan(path, iconPixelSize);
+    }
+    return data;
+}
+
+void StartScanThread() {
+    std::lock_guard<std::mutex> lock(g_scanMutex);
+    if (g_unloading ||
+        g_scanThreadJoining.load(std::memory_order_relaxed)) {
+        return;
+    }
+    // Already running. Never clear stop while a join is in progress —
+    // g_scanThreadJoining blocks spawn; RequestScan also drops work.
+    if (g_scanThread) {
+        return;
+    }
+
+    if (!g_scanStopEvent) {
+        g_scanStopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        if (!g_scanStopEvent) {
+            Wh_Log(L"CreateEventW for scan stop failed (%u)", GetLastError());
+            return;
+        }
+    } else {
+        ResetEvent(g_scanStopEvent);
+    }
+    if (!g_scanWorkEvent) {
+        g_scanWorkEvent = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+        if (!g_scanWorkEvent) {
+            Wh_Log(L"CreateEventW for scan work failed (%u)", GetLastError());
+            CloseHandle(g_scanStopEvent);
+            g_scanStopEvent = nullptr;
+            return;
+        }
+    }
+
+    g_scanThreadStop.store(false, std::memory_order_relaxed);
+    g_scanThread.emplace(ScanThreadMain);
+}
+
+void StopScanThread() {
+    std::optional<std::thread> thread;
+    HANDLE stopEvent = nullptr;
+    HANDLE workEvent = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_scanMutex);
+        g_scanThreadStop.store(true, std::memory_order_relaxed);
+        g_scanThreadJoining.store(true, std::memory_order_relaxed);
+        g_scanQueue.clear();
+        if (g_scanStopEvent) {
+            SetEvent(g_scanStopEvent);
+        }
+        // Move globals out under the lock so RequestScan/StartScanThread cannot
+        // touch the thread or SetEvent a handle we are about to close.
+        thread.swap(g_scanThread);
+        std::swap(stopEvent, g_scanStopEvent);
+        std::swap(workEvent, g_scanWorkEvent);
+    }
+    if (thread && thread->joinable()) {
+        thread->join();
+    }
+    if (stopEvent) {
+        CloseHandle(stopEvent);
+    }
+    if (workEvent) {
+        CloseHandle(workEvent);
+    }
+    g_scanThreadJoining.store(false, std::memory_order_relaxed);
+}
+
+void ResetFolderData() {
+    std::lock_guard<std::mutex> lock(g_cacheMutex);
+    FolderCache().clear();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// The hover grid window
+//
+// A XAML Popup would be clipped to the taskbar's XAML island, which is only as
+// tall as the taskbar, so the grid is a real top-level layered window instead.
+// Per-pixel alpha gives antialiased rounded corners and makes hit testing
+// outside the panel fall through automatically.
+
+constexpr PCWSTR kPopupClassName = L"WH_TaskbarFolderHoverTray_Grid";
+constexpr PCWSTR kMenuOwnerClassName = L"WH_TaskbarFolderHoverTray_MenuOwner";
+constexpr UINT_PTR kTickTimerId = 1;
+constexpr UINT_PTR kOpenTimerId = 2;
+constexpr UINT kTickTimerMs = 50;
+// Hard cap on cascade depth so a symlink loop cannot exhaust window handles.
+constexpr int kMaxLevels = 16;
+
+// One grid in the cascade. Level 0 hangs off a taskbar button; deeper levels
+// hang off the cell in their parent that opened them.
+struct PopupLevel {
+    HWND hwnd = nullptr;
+    int depth = 0;
+    std::wstring path;
+    // Only filled for the root (taskbar) grid; subfolder menus leave this
+    // empty.
+    std::wstring title;
+    std::vector<GridItem> items;
+    std::vector<RECT> cellRects;
+    RECT rect{};
+    RECT anchorRect{};
+    int spawnerCell = -1;
+    int hoverCell = -1;
+    int pressedCell = -1;
+    bool loading = false;
+    // Static content (panel, icons, labels) without hover/press chrome. Hover
+    // changes blit this and overlay the highlight instead of repainting all cells.
+    std::unique_ptr<Gdiplus::Bitmap> cachedBase;
+    int cachedBaseW = 0;
+    int cachedBaseH = 0;
+    bool baseDirty = true;
+};
+
+HWND g_menuOwnerWnd = nullptr;
+HWND g_taskbarWnd = nullptr;
+
+// Windows are created lazily, one per depth, and reused across cascades.
+std::vector<HWND> g_levelWindows;
+[[clang::no_destroy]] std::optional<std::vector<std::unique_ptr<PopupLevel>>>
+    g_levels{std::in_place};
+
+std::vector<std::unique_ptr<PopupLevel>>& Levels() {
+    if (!g_levels) {
+        g_levels.emplace();
+    }
+    return *g_levels;
+}
+
+RECT g_rootAnchorRect{};
+int g_popupDpi = 96;
+std::atomic<bool> g_menuActive{false};
+// True while a shell verb is queued (PostMessage) or running via InvokeCommand.
+std::atomic<bool> g_invokeActive{false};
+ULONGLONG g_outsideSinceTick = 0;
+
+std::wstring g_pendingRootPath;
+std::wstring g_pendingRootTitle;
+RECT g_pendingRootRect{};
+
+int g_pendingSubDepth = -1;
+int g_pendingSubCell = -1;
+ULONGLONG g_pendingSubSinceTick = 0;
+ULONGLONG g_closeDeeperSinceTick = 0;
+
+IContextMenu2* g_activeContextMenu2 = nullptr;
+IContextMenu3* g_activeContextMenu3 = nullptr;
+
+// Deferred shell verb: stash after TrackPopupMenuEx so PopupWndProc /
+// ShowItemContextMenu can return before InvokeCommand (and any modal UI).
+struct PendingShellCommand {
+    IContextMenu* contextMenu = nullptr;
+    int commandOffset = -1;
+    POINT invokePoint{};
+};
+PendingShellCommand g_pendingShellCommand;
+
+// Posted to g_menuOwnerWnd after the context menu loop unwinds.
+constexpr UINT WM_APP_INVOKE_SHELL_VERB = WM_APP + 41;
+
+// Both take their arguments by value: reopening a level destroys the PopupLevel
+// the caller may have read them from.
+void OpenRootLevel(std::wstring path, RECT anchorRect, std::wstring title);
+void OpenSubLevel(int parentDepth, int cell);
+void CloseLevelsFrom(int depth);
+void CloseChain();
+void StartRetryThread();
+bool EnsurePopupClasses();
+HWND EnsureMenuOwnerWindow();
+
+int ScaleForPopup(int value) {
+    return MulDiv(value, g_popupDpi, 96);
+}
+
+struct AccentPolicy {
+    int accentState;
+    int accentFlags;
+    unsigned int gradientColor;
+    int animationId;
+};
+
+struct WindowCompositionAttributeData {
+    int attribute;
+    void* data;
+    size_t dataSize;
+};
+
+void ApplyBackdrop(HWND hWnd) {
+    int corner = DWMWCP_ROUND;
+    DwmSetWindowAttribute(hWnd, DWMWA_WINDOW_CORNER_PREFERENCE, &corner,
+                          sizeof(corner));
+
+    if (!g_settings.acrylic) {
+        return;
+    }
+
+    using SetWindowCompositionAttribute_t =
+        BOOL(WINAPI*)(HWND, WindowCompositionAttributeData*);
+    static auto setWindowCompositionAttribute =
+        (SetWindowCompositionAttribute_t)GetProcAddress(
+            GetModuleHandleW(L"user32.dll"), "SetWindowCompositionAttribute");
+    if (!setWindowCompositionAttribute) {
+        return;
+    }
+
+    // ACCENT_ENABLE_ACRYLICBLURBEHIND with a nearly transparent tint; the
+    // visible panel colour is painted by us so the blur only adds depth.
+    AccentPolicy policy{};
+    policy.accentState = 4;
+    policy.accentFlags = 0;
+    policy.gradientColor = IsDarkTheme() ? 0x20000000 : 0x20FFFFFF;
+    policy.animationId = 0;
+
+    WindowCompositionAttributeData data{};
+    data.attribute = 19;  // WCA_ACCENT_POLICY
+    data.data = &policy;
+    data.dataSize = sizeof(policy);
+    setWindowCompositionAttribute(hWnd, &data);
+}
+
+void AddRoundedRect(Gdiplus::GraphicsPath* path,
+                    const Gdiplus::Rect& rect,
+                    int radius) {
+    if (radius <= 0) {
+        path->AddRectangle(rect);
+        return;
+    }
+    int d = radius * 2;
+    d = std::min<int>(d, std::min<int>(rect.Width, rect.Height));
+    path->AddArc(rect.X, rect.Y, d, d, 180.0f, 90.0f);
+    path->AddArc(rect.GetRight() - d, rect.Y, d, d, 270.0f, 90.0f);
+    path->AddArc(rect.GetRight() - d, rect.GetBottom() - d, d, d, 0.0f, 90.0f);
+    path->AddArc(rect.X, rect.GetBottom() - d, d, d, 90.0f, 90.0f);
+    path->CloseFigure();
+}
+
+// A minimal folder silhouette: a body whose top edge steps up on the left to
+// form the tab. Kept as straight edges so it stays crisp at badge sizes.
+void AddFolderGlyphPath(Gdiplus::GraphicsPath* path,
+                        const Gdiplus::RectF& box) {
+    Gdiplus::REAL step = box.Height * 0.24f;
+    Gdiplus::PointF pts[6] = {
+        {box.X, box.Y},
+        {box.X + box.Width * 0.42f, box.Y},
+        {box.X + box.Width * 0.54f, box.Y + step},
+        {box.X + box.Width, box.Y + step},
+        {box.X + box.Width, box.Y + box.Height},
+        {box.X, box.Y + box.Height},
+    };
+    path->AddPolygon(pts, 6);
+}
+
+// Extra top band reserved for the root folder title. Subfolder menus skip this.
+int RootTitleBandHeight(const PopupLevel* level) {
+    if (!level || level->depth != 0 || level->title.empty()) {
+        return 0;
+    }
+    return ScaleForPopup(8) + ScaleForPopup(g_settings.titleFontSize) +
+           ScaleForPopup(10);
+}
+
+// Fills level->cellRects and returns the required window size in physical
+// pixels. When maxHeight > 0, auto columns are derived from how many rows fit
+// in that height so large folders go wide instead of tall-and-narrow. When
+// maxWidth > 0, columns are capped so the grid stays on the monitor; items
+// beyond cols*rows are trimmed from level->items.
+SIZE ComputeLevelLayout(PopupLevel* level,
+                        int maxHeight = 0,
+                        int maxWidth = 0) {
+    int itemCount = (int)level->items.size();
+    int padding = ScaleForPopup(8);
+    int cellW = ScaleForPopup(g_settings.cellWidth);
+    int cellH = ScaleForPopup(g_settings.cellHeight);
+    int titleBand = RootTitleBandHeight(level);
+
+    int count = std::max<int>(itemCount, 1);
+    int cols;
+    if (g_settings.columns > 0) {
+        cols = std::min<int>(g_settings.columns, count);
+    } else if (maxHeight > 0 && cellH > 0) {
+        int usable = std::max(0, maxHeight - padding * 2 - titleBand);
+        int maxRows = std::max<int>(1, usable / cellH);
+        cols = (count + maxRows - 1) / maxRows;
+        cols = std::clamp<int>(cols, 1, count);
+        // Prefer a squarer grid when it still fits the available height.
+        int squareCols = (int)std::ceil(std::sqrt((double)count));
+        squareCols = std::clamp<int>(squareCols, cols, count);
+        int squareRows = (count + squareCols - 1) / squareCols;
+        if (squareRows <= maxRows) {
+            cols = squareCols;
+        }
+    } else {
+        cols = (int)std::ceil(std::sqrt((double)count));
+        cols = std::clamp<int>(cols, 1, 6);
+        cols = std::min<int>(cols, count);
+    }
+
+    if (maxWidth > 0 && cellW > 0) {
+        int maxCols = std::max(1, (maxWidth - padding * 2) / cellW);
+        cols = std::min(cols, maxCols);
+    }
+
+    int rows = (count + cols - 1) / cols;
+
+    if (maxHeight > 0 && cellH > 0) {
+        int usable = maxHeight - padding * 2 - titleBand;
+        int maxRows = std::max<int>(1, usable / cellH);
+        while (rows > maxRows && cols < count) {
+            cols++;
+            rows = (count + cols - 1) / cols;
+        }
+        // Height growth can widen past the monitor — re-apply the width cap.
+        if (maxWidth > 0 && cellW > 0) {
+            int maxCols = std::max(1, (maxWidth - padding * 2) / cellW);
+            if (cols > maxCols) {
+                cols = maxCols;
+                rows = (count + cols - 1) / cols;
+            }
+        }
+        if (rows > maxRows) {
+            rows = maxRows;
+        }
+    }
+
+    // Drop items that would fall outside the visible cols*rows grid.
+    int capacity = cols * std::max(rows, 1);
+    if (itemCount > capacity) {
+        level->items.resize(capacity);
+        itemCount = capacity;
+        count = std::max<int>(itemCount, 1);
+        rows = itemCount > 0 ? (itemCount + cols - 1) / cols : 1;
+    }
+
+    level->cellRects.clear();
+    level->cellRects.reserve(itemCount);
+    for (int i = 0; i < itemCount; i++) {
+        int r = i / cols;
+        int c = i % cols;
+        RECT cell;
+        cell.left = padding + c * cellW;
+        cell.top = padding + titleBand + r * cellH;
+        cell.right = cell.left + cellW;
+        cell.bottom = cell.top + cellH;
+        level->cellRects.push_back(cell);
+    }
+
+    SIZE size;
+    size.cx = padding * 2 + cols * cellW;
+    size.cy = padding * 2 + titleBand + rows * cellH;
+    if (itemCount == 0) {
+        // Leave room for the "Loading" / "Empty folder" message.
+        size.cx = padding * 2 + cellW * 2;
+        size.cy = std::max<int>(size.cy, padding * 2 + titleBand + cellH);
+    }
+    if (maxHeight > 0) {
+        size.cy = std::min<int>(size.cy, maxHeight);
+    }
+    if (maxWidth > 0) {
+        size.cx = std::min<int>(size.cx, maxWidth);
+    }
+    return size;
+}
+
+bool CanExpand(int depth) {
+    if (g_settings.maxFolderDepth < 0) {
+        return depth + 1 < kMaxLevels;
+    }
+    return depth < g_settings.maxFolderDepth && depth + 1 < kMaxLevels;
+}
+
+void InvalidateLevelBase(PopupLevel* level) {
+    if (!level) {
+        return;
+    }
+    level->baseDirty = true;
+    level->cachedBase.reset();
+    level->cachedBaseW = 0;
+    level->cachedBaseH = 0;
+}
+
+// Icon, folder badge, and label for one grid cell. Shared by the static base
+// paint and the hover/press cell overlay so the two stay visually identical.
+void DrawCell(Gdiplus::Graphics& g,
+              PopupLevel* level,
+              int index,
+              const Gdiplus::Color& textColor,
+              const Gdiplus::Color& badgeFillColor,
+              const Gdiplus::Color& badgeMarkColor,
+              const Gdiplus::Color& badgeRingColor,
+              Gdiplus::Font& font,
+              Gdiplus::StringFormat& format) {
+    if (!level || index < 0 || index >= (int)level->cellRects.size() ||
+        index >= (int)level->items.size()) {
+        return;
+    }
+
+    const RECT& cell = level->cellRects[index];
+    int cellW = cell.right - cell.left;
+    int cellH = cell.bottom - cell.top;
+    const GridItem& item = level->items[index];
+
+    int iconSize = ScaleForPopup(g_settings.iconSize);
+    int iconTop = ScaleForPopup(10);
+    int labelGap = ScaleForPopup(6);
+    bool expandable = CanExpand(level->depth);
+
+    Gdiplus::Rect iconRect(cell.left + (cellW - iconSize) / 2,
+                           cell.top + iconTop, iconSize, iconSize);
+    if (item.icon) {
+        g.DrawImage(item.icon.get(), iconRect);
+    }
+
+    if (item.isFolder && expandable) {
+        int badge = std::max<int>(14, (iconSize * 54 + 50) / 100);
+        int badgeLeft = iconRect.GetRight() - badge + badge / 4;
+        int badgeTop = iconRect.GetBottom() - badge + badge / 4;
+        Gdiplus::Rect badgeRect(badgeLeft, badgeTop, badge, badge);
+
+        Gdiplus::GraphicsPath badgePath;
+        AddRoundedRect(&badgePath, badgeRect, badge / 2);
+        Gdiplus::SolidBrush badgeBrush(badgeFillColor);
+        g.FillPath(&badgeBrush, &badgePath);
+        Gdiplus::Pen badgeRing(badgeRingColor, 1.0f);
+        g.DrawPath(&badgeRing, &badgePath);
+
+        Gdiplus::REAL glyphW = badge * 0.58f;
+        Gdiplus::REAL glyphH = glyphW * 0.80f;
+        Gdiplus::RectF glyphBox(
+            badgeLeft + (badge - glyphW) / 2.0f,
+            badgeTop + (badge - glyphH) / 2.0f + badge * 0.02f, glyphW, glyphH);
+        Gdiplus::GraphicsPath glyphPath;
+        AddFolderGlyphPath(&glyphPath, glyphBox);
+        Gdiplus::SolidBrush markBrush(badgeMarkColor);
+        g.FillPath(&markBrush, &glyphPath);
+    }
+
+    Gdiplus::SolidBrush textBrush(textColor);
+    Gdiplus::RectF labelRect(
+        (Gdiplus::REAL)(cell.left + ScaleForPopup(4)),
+        (Gdiplus::REAL)(cell.top + iconTop + iconSize + labelGap),
+        (Gdiplus::REAL)(cellW - ScaleForPopup(8)),
+        (Gdiplus::REAL)(cellH - iconTop - iconSize - labelGap -
+                        ScaleForPopup(4)));
+    if (labelRect.Height > 0) {
+        g.DrawString(item.displayName.c_str(), -1, &font, labelRect, &format,
+                     &textBrush);
+    }
+}
+
+// Paints the static panel (no hover/press chrome) into level->cachedBase.
+bool RebuildLevelBase(PopupLevel* level, int width, int height) {
+    auto bitmap = std::make_unique<Gdiplus::Bitmap>(width, height,
+                                                    PixelFormat32bppPARGB);
+    if (!bitmap || bitmap->GetLastStatus() != Gdiplus::Ok) {
+        return false;
+    }
+
+    Gdiplus::Graphics g(bitmap.get());
+    g.SetCompositingQuality(Gdiplus::CompositingQualityHighQuality);
+    g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+    g.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBicubic);
+    g.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
+    g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAlias);
+    g.Clear(Gdiplus::Color(0, 0, 0, 0));
+
+    bool dark = IsDarkTheme();
+    BYTE panelAlpha =
+        (BYTE)std::clamp<int>(g_settings.panelOpacity * 255 / 100, 10, 255);
+    Gdiplus::Color panelColor = dark
+                                    ? Gdiplus::Color(panelAlpha, 43, 43, 43)
+                                    : Gdiplus::Color(panelAlpha, 249, 249, 249);
+    Gdiplus::Color borderColor =
+        dark ? Gdiplus::Color(40, 255, 255, 255) : Gdiplus::Color(28, 0, 0, 0);
+    Gdiplus::Color textColor = dark ? Gdiplus::Color(255, 255, 255, 255)
+                                    : Gdiplus::Color(255, 26, 26, 26);
+    Gdiplus::Color badgeFillColor = GetAccentGdipColor(255);
+    bool lightAccent = ((int)badgeFillColor.GetR() + badgeFillColor.GetG() +
+                        badgeFillColor.GetB()) > 500;
+    Gdiplus::Color badgeMarkColor = lightAccent
+                                        ? Gdiplus::Color(255, 20, 20, 20)
+                                        : Gdiplus::Color(255, 255, 255, 255);
+    Gdiplus::Color badgeRingColor =
+        dark ? Gdiplus::Color(160, 0, 0, 0) : Gdiplus::Color(70, 255, 255, 255);
+
+    int radius = ScaleForPopup(g_settings.cornerRadius);
+    Gdiplus::Rect panelRect(0, 0, width - 1, height - 1);
+    Gdiplus::GraphicsPath panelPath;
+    AddRoundedRect(&panelPath, panelRect, radius);
+
+    Gdiplus::SolidBrush panelBrush(panelColor);
+    g.FillPath(&panelBrush, &panelPath);
+    Gdiplus::Pen borderPen(borderColor, 1.0f);
+    g.DrawPath(&borderPen, &panelPath);
+
+    Gdiplus::FontFamily family(
+        ResolvePopupFontName(g_settings.itemFontFamily).c_str());
+    Gdiplus::Font font(&family, (Gdiplus::REAL)ScaleForPopup(g_settings.fontSize),
+                       g_settings.itemFontBold ? Gdiplus::FontStyleBold
+                                                : Gdiplus::FontStyleRegular,
+                       Gdiplus::UnitPixel);
+    Gdiplus::SolidBrush textBrush(textColor);
+
+    Gdiplus::StringFormat format;
+    format.SetAlignment(Gdiplus::StringAlignmentCenter);
+    format.SetLineAlignment(Gdiplus::StringAlignmentNear);
+    format.SetTrimming(Gdiplus::StringTrimmingEllipsisCharacter);
+    format.SetFormatFlags(Gdiplus::StringFormatFlagsLineLimit);
+
+    int titleBand = RootTitleBandHeight(level);
+    if (titleBand > 0) {
+        Gdiplus::FontFamily titleFamily(
+            ResolvePopupFontName(g_settings.titleFontFamily).c_str());
+        Gdiplus::Font titleFont(
+            &titleFamily, (Gdiplus::REAL)ScaleForPopup(g_settings.titleFontSize),
+            g_settings.titleFontBold ? Gdiplus::FontStyleBold
+                                      : Gdiplus::FontStyleRegular,
+            Gdiplus::UnitPixel);
+        Gdiplus::StringFormat titleFormat;
+        if (g_settings.titleAlign == L"left") {
+            titleFormat.SetAlignment(Gdiplus::StringAlignmentNear);
+        } else if (g_settings.titleAlign == L"right") {
+            titleFormat.SetAlignment(Gdiplus::StringAlignmentFar);
+        } else {
+            titleFormat.SetAlignment(Gdiplus::StringAlignmentCenter);
+        }
+        titleFormat.SetLineAlignment(Gdiplus::StringAlignmentCenter);
+        titleFormat.SetTrimming(Gdiplus::StringTrimmingEllipsisCharacter);
+        titleFormat.SetFormatFlags(Gdiplus::StringFormatFlagsNoWrap);
+
+        int pad = ScaleForPopup(12);
+        Gdiplus::RectF titleRect(
+            (Gdiplus::REAL)pad, (Gdiplus::REAL)ScaleForPopup(4),
+            (Gdiplus::REAL)(width - pad * 2),
+            (Gdiplus::REAL)(titleBand - ScaleForPopup(4)));
+        g.DrawString(level->title.c_str(), -1, &titleFont, titleRect,
+                     &titleFormat, &textBrush);
+    }
+
+    if (level->items.empty()) {
+        Gdiplus::StringFormat centered;
+        centered.SetAlignment(Gdiplus::StringAlignmentCenter);
+        centered.SetLineAlignment(Gdiplus::StringAlignmentCenter);
+        PCWSTR message = level->loading ? L"Loading..." : L"Empty folder";
+        Gdiplus::RectF area(0.0f, (Gdiplus::REAL)titleBand, (Gdiplus::REAL)width,
+                            (Gdiplus::REAL)(height - titleBand));
+        g.DrawString(message, -1, &font, area, &centered, &textBrush);
+    }
+
+    for (size_t i = 0; i < level->items.size() && i < level->cellRects.size();
+         i++) {
+        DrawCell(g, level, (int)i, textColor, badgeFillColor, badgeMarkColor,
+                 badgeRingColor, font, format);
+    }
+
+    level->cachedBase = std::move(bitmap);
+    level->cachedBaseW = width;
+    level->cachedBaseH = height;
+    level->baseDirty = false;
+    return true;
+}
+
+void PaintLevel(PopupLevel* level) {
+    if (!level || !level->hwnd) {
+        return;
+    }
+
+    int width = level->rect.right - level->rect.left;
+    int height = level->rect.bottom - level->rect.top;
+    if (width <= 0 || height <= 0) {
+        return;
+    }
+
+    if (level->baseDirty || !level->cachedBase || level->cachedBaseW != width ||
+        level->cachedBaseH != height) {
+        if (!RebuildLevelBase(level, width, height)) {
+            return;
+        }
+    }
+
+    HDC hScreenDC = GetDC(nullptr);
+    if (!hScreenDC) {
+        return;
+    }
+    HDC hMemDC = CreateCompatibleDC(hScreenDC);
+    if (!hMemDC) {
+        ReleaseDC(nullptr, hScreenDC);
+        return;
+    }
+
+    BITMAPINFO bi{};
+    bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bi.bmiHeader.biWidth = width;
+    bi.bmiHeader.biHeight = -height;
+    bi.bmiHeader.biPlanes = 1;
+    bi.bmiHeader.biBitCount = 32;
+    bi.bmiHeader.biCompression = BI_RGB;
+
+    void* bits = nullptr;
+    HBITMAP hBmp =
+        CreateDIBSection(hMemDC, &bi, DIB_RGB_COLORS, &bits, nullptr, 0);
+    if (!hBmp || !bits) {
+        if (hBmp) {
+            DeleteObject(hBmp);
+        }
+        DeleteDC(hMemDC);
+        ReleaseDC(nullptr, hScreenDC);
+        return;
+    }
+    HGDIOBJ hOldBmp = SelectObject(hMemDC, hBmp);
+
+    {
+        Gdiplus::Bitmap surface(width, height, width * 4, PixelFormat32bppPARGB,
+                                (BYTE*)bits);
+        Gdiplus::Graphics g(&surface);
+        g.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
+        g.SetInterpolationMode(Gdiplus::InterpolationModeNearestNeighbor);
+        g.Clear(Gdiplus::Color(0, 0, 0, 0));
+        g.DrawImage(level->cachedBase.get(), 0, 0, width, height);
+
+        g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
+        g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+        g.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBicubic);
+        g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAlias);
+
+        bool dark = IsDarkTheme();
+        Gdiplus::Color hoverColor =
+            dark ? Gdiplus::Color(28, 255, 255, 255) : Gdiplus::Color(18, 0, 0, 0);
+        Gdiplus::Color pressColor =
+            dark ? Gdiplus::Color(46, 255, 255, 255) : Gdiplus::Color(32, 0, 0, 0);
+        Gdiplus::Color textColor = dark ? Gdiplus::Color(255, 255, 255, 255)
+                                        : Gdiplus::Color(255, 26, 26, 26);
+        Gdiplus::Color badgeFillColor = GetAccentGdipColor(255);
+        bool lightAccent = ((int)badgeFillColor.GetR() + badgeFillColor.GetG() +
+                            badgeFillColor.GetB()) > 500;
+        Gdiplus::Color badgeMarkColor = lightAccent
+                                            ? Gdiplus::Color(255, 20, 20, 20)
+                                            : Gdiplus::Color(255, 255, 255, 255);
+        Gdiplus::Color badgeRingColor = dark ? Gdiplus::Color(160, 0, 0, 0)
+                                             : Gdiplus::Color(70, 255, 255, 255);
+
+        Gdiplus::FontFamily family(
+            ResolvePopupFontName(g_settings.itemFontFamily).c_str());
+        Gdiplus::Font font(&family,
+                           (Gdiplus::REAL)ScaleForPopup(g_settings.fontSize),
+                           g_settings.itemFontBold ? Gdiplus::FontStyleBold
+                                                    : Gdiplus::FontStyleRegular,
+                           Gdiplus::UnitPixel);
+        Gdiplus::StringFormat format;
+        format.SetAlignment(Gdiplus::StringAlignmentCenter);
+        format.SetLineAlignment(Gdiplus::StringAlignmentNear);
+        format.SetTrimming(Gdiplus::StringTrimmingEllipsisCharacter);
+        format.SetFormatFlags(Gdiplus::StringFormatFlagsLineLimit);
+
+        // Highlight under icon/label: clear only inside the rounded path, then
+        // fill highlight and DrawCell. A full-cell SourceCopy FillRectangle
+        // (added with cachedBase in v1.5) left a sharp translucent fringe in the
+        // ScaleForPopup(2) inset margin that did not match the base panel alpha.
+        auto repaintCell = [&](int cellIndex, bool pressed) {
+            if (cellIndex < 0 || cellIndex >= (int)level->cellRects.size() ||
+                cellIndex >= (int)level->items.size()) {
+                return;
+            }
+            const RECT& cell = level->cellRects[cellIndex];
+            int cellW = cell.right - cell.left;
+            int cellH = cell.bottom - cell.top;
+
+            Gdiplus::Rect highlight(
+                cell.left + ScaleForPopup(2), cell.top + ScaleForPopup(2),
+                cellW - ScaleForPopup(4), cellH - ScaleForPopup(4));
+            Gdiplus::GraphicsPath highlightPath;
+            AddRoundedRect(&highlightPath, highlight, ScaleForPopup(6));
+
+            bool darkPanel = IsDarkTheme();
+            BYTE panelAlpha = (BYTE)std::clamp<int>(
+                g_settings.panelOpacity * 255 / 100, 10, 255);
+            Gdiplus::Color panelColor =
+                darkPanel ? Gdiplus::Color(panelAlpha, 43, 43, 43)
+                          : Gdiplus::Color(panelAlpha, 249, 249, 249);
+
+            // Erase-then-overlay in two separate AA passes left a 1px fringe at
+            // the highlight's rounded edge (each pass antialiases against a
+            // different backdrop). Pre-blend the overlay onto the panel color
+            // and paint it in one SourceCopy pass instead.
+            const Gdiplus::Color& overlay = pressed ? pressColor : hoverColor;
+            float a = overlay.GetA() / 255.0f;
+            Gdiplus::Color blended(
+                panelAlpha,
+                (BYTE)(panelColor.GetR() * (1 - a) + overlay.GetR() * a),
+                (BYTE)(panelColor.GetG() * (1 - a) + overlay.GetG() * a),
+                (BYTE)(panelColor.GetB() * (1 - a) + overlay.GetB() * a));
+            Gdiplus::SolidBrush highlightBrush(blended);
+            g.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
+            g.FillPath(&highlightBrush, &highlightPath);
+            g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
+
+            DrawCell(g, level, cellIndex, textColor, badgeFillColor,
+                     badgeMarkColor, badgeRingColor, font, format);
+        };
+
+        if (level->hoverCell >= 0 && level->hoverCell != level->pressedCell) {
+            repaintCell(level->hoverCell, false);
+        }
+        if (level->pressedCell >= 0) {
+            repaintCell(level->pressedCell, true);
+        }
+    }
+
+    POINT ptSrc{0, 0};
+    POINT ptDst{level->rect.left, level->rect.top};
+    SIZE size{width, height};
+    BLENDFUNCTION blend{};
+    blend.BlendOp = AC_SRC_OVER;
+    blend.SourceConstantAlpha = 255;
+    blend.AlphaFormat = AC_SRC_ALPHA;
+    UpdateLayeredWindow(level->hwnd, hScreenDC, &ptDst, &size, hMemDC, &ptSrc, 0,
+                        &blend, ULW_ALPHA);
+
+    SelectObject(hMemDC, hOldBmp);
+    DeleteObject(hBmp);
+    DeleteDC(hMemDC);
+    ReleaseDC(nullptr, hScreenDC);
+}
+
+PopupLevel* LevelFromHwnd(HWND hWnd) {
+    for (auto& level : Levels()) {
+        if (level->hwnd == hWnd) {
+            return level.get();
+        }
+    }
+    return nullptr;
+}
+
+int CellFromClientPoint(PopupLevel* level, POINT pt) {
+    for (size_t i = 0; i < level->cellRects.size() && i < level->items.size();
+         i++) {
+        if (PtInRect(&level->cellRects[i], pt)) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+// Hides every level at or below `depth`, deepest first.
+void CloseLevelsFrom(int depth) {
+    if (depth < 0) {
+        depth = 0;
+    }
+    while ((int)Levels().size() > depth) {
+        auto& level = Levels().back();
+        if (level->hwnd) {
+            ShowWindow(level->hwnd, SW_HIDE);
+        }
+        Levels().pop_back();
+    }
+    if (g_pendingSubDepth >= depth - 1) {
+        g_pendingSubDepth = -1;
+        g_pendingSubCell = -1;
+    }
+    g_closeDeeperSinceTick = 0;
+}
+
+void CloseChain() {
+    if (!Levels().empty() && Levels()[0]->hwnd) {
+        KillTimer(Levels()[0]->hwnd, kTickTimerId);
+    }
+    CloseLevelsFrom(0);
+    g_outsideSinceTick = 0;
+}
+
+RECT BridgingRect(const RECT& a, const RECT& b) {
+    RECT bridge;
+    bridge.left = std::min<LONG>(a.left, b.left);
+    bridge.right = std::max<LONG>(a.right, b.right);
+    bridge.top = std::min<LONG>(a.top, b.top);
+    bridge.bottom = std::max<LONG>(a.bottom, b.bottom);
+    return bridge;
+}
+
+// The dead-zone-free path from the taskbar button up into the root grid. Only
+// the gap BETWEEN them counts - the taskbar strip itself is excluded, so moving
+// to another app on the taskbar closes the menu instead of keeping it stuck
+// open.
+bool CursorInRootCorridor(POINT pt) {
+    if (Levels().empty()) {
+        return false;
+    }
+
+    const RECT& anchor = g_rootAnchorRect;
+    const RECT& popup = Levels()[0]->rect;
+
+    RECT gap{};
+    gap.left = std::min<LONG>(anchor.left, popup.left);
+    gap.right = std::max<LONG>(anchor.right, popup.right);
+
+    if (popup.bottom <= anchor.top) {
+        // Normal bottom taskbar: popup sits above the button.
+        gap.top = popup.bottom;
+        gap.bottom = anchor.top;
+    } else if (popup.top >= anchor.bottom) {
+        // Top taskbar: popup sits below the button.
+        gap.top = anchor.bottom;
+        gap.bottom = popup.top;
+    } else {
+        return false;
+    }
+
+    // PtInRect excludes the bottom edge; inflate a zero-height seam so a
+    // gapAbove of 0 still lets the cursor cross into the grid.
+    if (gap.bottom <= gap.top) {
+        gap.bottom = gap.top + 1;
+    }
+
+    return PtInRect(&gap, pt);
+}
+
+// The cascade stays open while the cursor is over the taskbar button, over any
+// open grid, in the gap from the button up into the root grid, or in the band
+// bridging two consecutive grids. The taskbar strip outside the button is NOT
+// part of the live path.
+bool CursorIsInLivePath() {
+    POINT pt;
+    if (!GetCursorPos(&pt) || Levels().empty()) {
+        return false;
+    }
+
+    if (PtInRect(&g_rootAnchorRect, pt)) {
+        return true;
+    }
+
+    for (const auto& level : Levels()) {
+        if (PtInRect(&level->rect, pt)) {
+            return true;
+        }
+    }
+
+    if (CursorInRootCorridor(pt)) {
+        return true;
+    }
+
+    for (size_t i = 1; i < Levels().size(); i++) {
+        RECT bridge = BridgingRect(Levels()[i - 1]->rect, Levels()[i]->rect);
+        if (PtInRect(&bridge, pt)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// The deepest open grid containing the cursor, or -1 when it is elsewhere.
+int LevelIndexUnderCursor() {
+    POINT pt;
+    if (!GetCursorPos(&pt)) {
+        return -1;
+    }
+    for (int i = (int)Levels().size() - 1; i >= 0; i--) {
+        if (PtInRect(&Levels()[i]->rect, pt)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+void ClearPendingShellCommand() {
+    if (g_pendingShellCommand.contextMenu) {
+        g_pendingShellCommand.contextMenu->Release();
+    }
+    g_pendingShellCommand = {};
+    g_invokeActive = false;
+}
+
+void InvokePendingShellCommand(HWND owner) {
+    IContextMenu* contextMenu = g_pendingShellCommand.contextMenu;
+    int commandOffset = g_pendingShellCommand.commandOffset;
+    POINT invokePoint = g_pendingShellCommand.invokePoint;
+    g_pendingShellCommand = {};
+    if (!contextMenu || commandOffset < 0) {
+        if (contextMenu) {
+            contextMenu->Release();
+        }
+        g_invokeActive = false;
+        return;
+    }
+
+    // Keep g_invokeActive true for the duration of InvokeCommand so uninit
+    // waits. CMIC_MASK_ASYNCOK lets many verbs return quickly; some still show
+    // modal UI on this thread despite the flag.
+    struct InvokeActiveGuard {
+        InvokeActiveGuard() { g_invokeActive = true; }
+        ~InvokeActiveGuard() { g_invokeActive = false; }
+        InvokeActiveGuard(const InvokeActiveGuard&) = delete;
+        InvokeActiveGuard& operator=(const InvokeActiveGuard&) = delete;
+    } invokeActiveGuard;
+
+    CMINVOKECOMMANDINFOEX info{};
+    info.cbSize = sizeof(info);
+    info.fMask = CMIC_MASK_UNICODE | CMIC_MASK_ASYNCOK | CMIC_MASK_PTINVOKE;
+    info.hwnd = owner;
+    info.lpVerb = MAKEINTRESOURCEA(commandOffset);
+    info.lpVerbW = MAKEINTRESOURCEW(commandOffset);
+    info.nShow = SW_SHOWNORMAL;
+    info.ptInvoke = invokePoint;
+
+    HRESULT hr = contextMenu->InvokeCommand(
+        reinterpret_cast<CMINVOKECOMMANDINFO*>(&info));
+    if (FAILED(hr)) {
+        Wh_Log(L"InvokeCommand failed hr=0x%08X offset=%d", hr, commandOffset);
+    }
+    contextMenu->Release();
+}
+
+void ShowItemContextMenu(std::wstring path, POINT screenPt) {
+    if (g_unloading) {
+        return;
+    }
+    if (!g_menuOwnerWnd ||
+        GetWindowThreadProcessId(g_menuOwnerWnd, nullptr) !=
+            GetCurrentThreadId()) {
+        return;
+    }
+    if (path.empty()) {
+        return;
+    }
+
+    struct CoTaskMemDeleter {
+        void operator()(void* p) const noexcept { CoTaskMemFree(p); }
+    };
+    using UniquePidlAbs =
+        std::unique_ptr<ITEMIDLIST, CoTaskMemDeleter>;
+
+    PIDLIST_ABSOLUTE rawPidl = nullptr;
+    if (FAILED(SHParseDisplayName(path.c_str(), nullptr, &rawPidl, 0,
+                                  nullptr)) ||
+        !rawPidl) {
+        return;
+    }
+    UniquePidlAbs pidl(rawPidl);
+
+    winrt::com_ptr<IShellFolder> parentFolder;
+    PCUITEMID_CHILD child = nullptr;
+    if (FAILED(SHBindToParent(pidl.get(), IID_PPV_ARGS(parentFolder.put()),
+                              &child)) ||
+        !parentFolder) {
+        return;
+    }
+
+    winrt::com_ptr<IContextMenu> contextMenu;
+    if (FAILED(parentFolder->GetUIObjectOf(g_menuOwnerWnd, 1, &child,
+                                           IID_IContextMenu, nullptr,
+                                           contextMenu.put_void())) ||
+        !contextMenu) {
+        return;
+    }
+
+    HMENU menu = CreatePopupMenu();
+    if (!menu) {
+        return;
+    }
+    struct MenuGuard {
+        HMENU h = nullptr;
+        explicit MenuGuard(HMENU menu) : h(menu) {}
+        ~MenuGuard() {
+            if (h) {
+                DestroyMenu(h);
+            }
+        }
+        MenuGuard(const MenuGuard&) = delete;
+        MenuGuard& operator=(const MenuGuard&) = delete;
+    } menuGuard(menu);
+
+    if (FAILED(contextMenu->QueryContextMenu(menu, 0, 1, 0x7FFF,
+                                             CMF_NORMAL | CMF_EXPLORE))) {
+        return;
+    }
+
+    UINT cmd = 0;
+    {
+        // Raised only while TrackPopupMenuEx runs — cleared before the verb
+        // is invoked so Wh_ModUninit does not EndMenu-wait on verb dialogs.
+        // RAII so a shell-extension exception cannot leave the flag stuck.
+        struct MenuActiveGuard {
+            MenuActiveGuard() { g_menuActive = true; }
+            ~MenuActiveGuard() { g_menuActive = false; }
+            MenuActiveGuard(const MenuActiveGuard&) = delete;
+            MenuActiveGuard& operator=(const MenuActiveGuard&) = delete;
+        } menuActiveGuard;
+
+        g_activeContextMenu3 = nullptr;
+        g_activeContextMenu2 = nullptr;
+        if (FAILED(contextMenu->QueryInterface(IID_IContextMenu3,
+                                               (void**)&g_activeContextMenu3))) {
+            contextMenu->QueryInterface(IID_IContextMenu2,
+                                        (void**)&g_activeContextMenu2);
+        }
+
+        // A never-shown 0x0 owner cannot become foreground; park a 1x1
+        // window at the click so TrackPopupMenuEx dismisses correctly.
+        SetWindowPos(g_menuOwnerWnd, HWND_TOPMOST, screenPt.x, screenPt.y, 1, 1,
+                     SWP_SHOWWINDOW);
+        SetForegroundWindow(g_menuOwnerWnd);
+        cmd = TrackPopupMenuEx(menu,
+                               TPM_RETURNCMD | TPM_RIGHTBUTTON |
+                                   TPM_LEFTALIGN | TPM_BOTTOMALIGN,
+                               screenPt.x, screenPt.y, g_menuOwnerWnd,
+                               nullptr);
+        PostMessageW(g_menuOwnerWnd, WM_NULL, 0, 0);
+
+        if (g_activeContextMenu3) {
+            g_activeContextMenu3->Release();
+            g_activeContextMenu3 = nullptr;
+        }
+        if (g_activeContextMenu2) {
+            g_activeContextMenu2->Release();
+            g_activeContextMenu2 = nullptr;
+        }
+    }  // g_menuActive = false before any verb runs
+
+    ShowWindow(g_menuOwnerWnd, SW_HIDE);
+
+    if (!cmd || g_unloading) {
+        return;
+    }
+
+    // Dismiss the hover chain before the shell verb runs so Explorer
+    // windows are not covered by stale grids.
+    CloseChain();
+
+    // Defer InvokeCommand until after PopupWndProc (WM_RBUTTONUP) returns —
+    // same pattern as taskbar-folder-menus. Keep IContextMenu alive across
+    // the post; ASYNCOK lets many verbs leave this thread quickly.
+    ClearPendingShellCommand();
+    g_pendingShellCommand.contextMenu = contextMenu.detach();
+    g_pendingShellCommand.commandOffset = (int)cmd - 1;
+    g_pendingShellCommand.invokePoint = screenPt;
+    g_invokeActive = true;
+    if (!PostMessageW(g_menuOwnerWnd, WM_APP_INVOKE_SHELL_VERB, 0, 0)) {
+        Wh_Log(L"PostMessage WM_APP_INVOKE_SHELL_VERB failed (error %u); "
+               L"invoking inline",
+               GetLastError());
+        InvokePendingShellCommand(g_menuOwnerWnd);
+    }
+}
+
+// Plain verb-based open - no SEE_MASK_INVOKEIDLIST. INVOKEIDLIST binds the
+// shell namespace object and invokes it via IContextMenu, which contends with
+// the background scan/icon-extraction threads' own shell-namespace COM calls;
+// combined with SEE_MASK_ASYNCOK (which returns success before that invoke
+// finishes), a contended invoke could get silently dropped - ShellExecuteExW
+// reports success but no window ever appears. A folder has no custom verb
+// handler to invoke, so the fast lpVerb path is both simpler and correct.
+void LaunchPath(const std::wstring& path) {
+    if (path.empty()) {
+        return;
+    }
+
+    SHELLEXECUTEINFOW info{};
+    info.cbSize = sizeof(info);
+    info.fMask = SEE_MASK_FLAG_NO_UI;
+    info.lpFile = path.c_str();
+    info.lpVerb = L"open";
+    info.nShow = SW_SHOWNORMAL;
+    if (!ShellExecuteExW(&info)) {
+        Wh_Log(L"ShellExecuteEx failed for %s (error %u)", path.c_str(),
+               GetLastError());
+    }
+}
+
+LRESULT CALLBACK MenuOwnerWndProc(HWND hWnd,
+                                  UINT uMsg,
+                                  WPARAM wParam,
+                                  LPARAM lParam) {
+    // New monitors create Shell_SecondaryTrayWnd without StartTaskbar; kick a
+    // retry so secondary taskbars still get folder buttons.
+    if (uMsg == WM_DISPLAYCHANGE && !g_unloading) {
+        StartRetryThread();
+    }
+
+    if (uMsg == WM_APP_INVOKE_SHELL_VERB) {
+        // Runs after ShowItemContextMenu / PopupWndProc have returned.
+        if (g_unloading) {
+            ClearPendingShellCommand();
+        } else {
+            InvokePendingShellCommand(hWnd);
+        }
+        return 0;
+    }
+
+    if (uMsg == WM_INITMENUPOPUP || uMsg == WM_DRAWITEM ||
+        uMsg == WM_MEASUREITEM || uMsg == WM_MENUCHAR) {
+        if (g_activeContextMenu3) {
+            LRESULT result = 0;
+            if (SUCCEEDED(g_activeContextMenu3->HandleMenuMsg2(
+                    uMsg, wParam, lParam, &result))) {
+                return result;
+            }
+        }
+        if (g_activeContextMenu2 &&
+            SUCCEEDED(
+                g_activeContextMenu2->HandleMenuMsg(uMsg, wParam, lParam))) {
+            return uMsg == WM_INITMENUPOPUP ? 0 : TRUE;
+        }
+    }
+    return DefWindowProc(hWnd, uMsg, wParam, lParam);
+}
+
+// Re-copies any level still waiting on its first scan. Levels resize as their
+// contents arrive, so this reopens rather than just repainting.
+void RefreshLoadingLevels() {
+    for (size_t i = 0; i < Levels().size(); i++) {
+        auto* level = Levels()[i].get();
+        if (!level->loading) {
+            continue;
+        }
+        auto data = GetFolderData(level->path);
+        if (!data || !data->ready) {
+            continue;
+        }
+        // Copied out first: reopening destroys the level these came from.
+        std::wstring path = level->path;
+        std::wstring title = level->title;
+        RECT anchorRect = level->anchorRect;
+        int spawnerCell = level->spawnerCell;
+        if (i == 0) {
+            OpenRootLevel(std::move(path), anchorRect, std::move(title));
+        } else {
+            OpenSubLevel((int)i - 1, spawnerCell);
+        }
+        return;
+    }
+}
+
+// Queues scans for the subfolders of a level so cascading into one is instant.
+// Capped so a folder full of folders does not flood the scan thread.
+void PrefetchSubfolders(PopupLevel* level) {
+    if (!CanExpand(level->depth)) {
+        return;
+    }
+    constexpr int kMaxPrefetch = 12;
+    int iconPixelSize = ScaleForPopup(g_settings.iconSize);
+    int queued = 0;
+    for (const auto& item : level->items) {
+        if (queued >= kMaxPrefetch) {
+            break;
+        }
+        if (item.isFolder && !GetFolderData(item.fullPath)) {
+            RequestScan(item.fullPath, iconPixelSize);
+            queued++;
+        }
+    }
+}
+
+// Drives the cascade: opens a pending submenu once its dwell time elapses,
+// retires levels the cursor has moved away from, and dismisses the chain when
+// the cursor leaves the live path. Runs on level 0's window only.
+void OnTick() {
+    if (g_menuActive) {
+        g_outsideSinceTick = 0;
+        g_closeDeeperSinceTick = 0;
+        return;
+    }
+
+    RefreshLoadingLevels();
+
+    ULONGLONG now = GetTickCount64();
+
+    if (!CursorIsInLivePath()) {
+        if (g_outsideSinceTick == 0) {
+            g_outsideSinceTick = now;
+        } else if (now - g_outsideSinceTick >=
+                   (ULONGLONG)g_settings.closeDelayMs) {
+            CloseChain();
+        }
+        return;
+    }
+    g_outsideSinceTick = 0;
+
+    int cursorLevel = LevelIndexUnderCursor();
+
+    // Retire anything deeper than the grid the cursor is in, unless the cursor
+    // is still resting on the cell that opened the next one down.
+    if (cursorLevel >= 0 && (int)Levels().size() > cursorLevel + 1) {
+        auto* level = Levels()[cursorLevel].get();
+        bool onSpawner =
+            level->hoverCell >= 0 &&
+            level->hoverCell == Levels()[cursorLevel + 1]->spawnerCell;
+        if (onSpawner) {
+            g_closeDeeperSinceTick = 0;
+        } else if (g_closeDeeperSinceTick == 0) {
+            g_closeDeeperSinceTick = now;
+        } else if (now - g_closeDeeperSinceTick >=
+                   (ULONGLONG)g_settings.submenuCloseDelayMs) {
+            CloseLevelsFrom(cursorLevel + 1);
+        }
+    } else {
+        g_closeDeeperSinceTick = 0;
+    }
+
+    if (g_pendingSubDepth >= 0 &&
+        now - g_pendingSubSinceTick >= (ULONGLONG)g_settings.submenuDelayMs) {
+        int depth = g_pendingSubDepth;
+        int cell = g_pendingSubCell;
+        g_pendingSubDepth = -1;
+        g_pendingSubCell = -1;
+        OpenSubLevel(depth, cell);
+    }
+}
+
+LRESULT CALLBACK PopupWndProc(HWND hWnd,
+                              UINT uMsg,
+                              WPARAM wParam,
+                              LPARAM lParam) {
+    // The open-delay timer fires before any level exists, so it is handled
+    // before the level lookup.
+    if (uMsg == WM_TIMER && wParam == kOpenTimerId) {
+        KillTimer(hWnd, kOpenTimerId);
+        std::wstring path = std::move(g_pendingRootPath);
+        std::wstring title = std::move(g_pendingRootTitle);
+        g_pendingRootPath.clear();
+        g_pendingRootTitle.clear();
+        POINT cursor{};
+        // The cursor may have moved on during the delay.
+        if (!path.empty() && GetCursorPos(&cursor) &&
+            PtInRect(&g_pendingRootRect, cursor)) {
+            OpenRootLevel(std::move(path), g_pendingRootRect, std::move(title));
+        }
+        return 0;
+    }
+
+    if (uMsg == WM_TIMER && wParam == kTickTimerId) {
+        OnTick();
+        return 0;
+    }
+
+    // Theme/display messages do not need a live level; handle them even when
+    // the HWND is a reused shell with no PopupLevel attached yet. Top-level
+    // popups receive WM_SETTINGCHANGE broadcasts even while hidden, so only
+    // dismiss an open chain — otherwise every SPI broadcast would CloseChain
+    // and cancel pending opens. Monitor reinject is owned by MenuOwnerWndProc.
+    if (uMsg == WM_DISPLAYCHANGE || uMsg == WM_SETTINGCHANGE ||
+        uMsg == WM_THEMECHANGED) {
+        RefreshThemeCache();
+        if (!Levels().empty()) {
+            CloseChain();
+        }
+        return 0;
+    }
+
+    PopupLevel* level = LevelFromHwnd(hWnd);
+    if (!level) {
+        return DefWindowProc(hWnd, uMsg, wParam, lParam);
+    }
+
+    switch (uMsg) {
+        case WM_MOUSEMOVE: {
+            POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+            int cell = CellFromClientPoint(level, pt);
+            if (cell != level->hoverCell) {
+                level->hoverCell = cell;
+                PaintLevel(level);
+
+                bool expandable =
+                    cell >= 0 && cell < (int)level->items.size() &&
+                    level->items[cell].isFolder && CanExpand(level->depth);
+                int alreadyOpen = (int)Levels().size() > level->depth + 1
+                                      ? Levels()[level->depth + 1]->spawnerCell
+                                      : -1;
+                if (expandable && cell != alreadyOpen) {
+                    g_pendingSubDepth = level->depth;
+                    g_pendingSubCell = cell;
+                    g_pendingSubSinceTick = GetTickCount64();
+                } else {
+                    g_pendingSubDepth = -1;
+                    g_pendingSubCell = -1;
+                }
+            }
+            g_outsideSinceTick = 0;
+            return 0;
+        }
+
+        case WM_LBUTTONDOWN: {
+            POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+            level->pressedCell = CellFromClientPoint(level, pt);
+            PaintLevel(level);
+            return 0;
+        }
+
+        case WM_LBUTTONUP: {
+            POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+            int cell = CellFromClientPoint(level, pt);
+            int pressed = level->pressedCell;
+            level->pressedCell = -1;
+            if (cell >= 0 && cell == pressed &&
+                cell < (int)level->items.size()) {
+                std::wstring path = level->items[cell].fullPath;
+                CloseChain();
+                LaunchPath(path);
+            } else {
+                PaintLevel(level);
+            }
+            return 0;
+        }
+
+        case WM_RBUTTONUP: {
+            POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+            int cell = CellFromClientPoint(level, pt);
+            if (cell >= 0 && cell < (int)level->items.size()) {
+                POINT screenPt = pt;
+                ClientToScreen(hWnd, &screenPt);
+                ShowItemContextMenu(std::wstring(level->items[cell].fullPath),
+                                    screenPt);
+            }
+            return 0;
+        }
+
+        case WM_DESTROY:
+            KillTimer(hWnd, kTickTimerId);
+            KillTimer(hWnd, kOpenTimerId);
+            return 0;
+    }
+
+    return DefWindowProc(hWnd, uMsg, wParam, lParam);
+}
+
+bool EnsurePopupClasses() {
+    enum class ClassState { Untried, Ok, Failed };
+    static ClassState classState = ClassState::Untried;
+    if (classState != ClassState::Untried) {
+        return classState == ClassState::Ok;
+    }
+
+    HINSTANCE instance = GetCurrentModuleHandle();
+    WNDCLASSEXW popupClass{};
+    popupClass.cbSize = sizeof(popupClass);
+    popupClass.lpfnWndProc = PopupWndProc;
+    popupClass.hInstance = instance;
+    popupClass.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    popupClass.lpszClassName = kPopupClassName;
+    ATOM popupAtom = RegisterClassExW(&popupClass);
+
+    WNDCLASSEXW ownerClass{};
+    ownerClass.cbSize = sizeof(ownerClass);
+    ownerClass.lpfnWndProc = MenuOwnerWndProc;
+    ownerClass.hInstance = instance;
+    ownerClass.lpszClassName = kMenuOwnerClassName;
+    ATOM ownerAtom = RegisterClassExW(&ownerClass);
+
+    if (!popupAtom || !ownerAtom) {
+        Wh_Log(L"RegisterClassExW failed (error %u); hover grids disabled",
+               GetLastError());
+        if (popupAtom) {
+            UnregisterClassW(kPopupClassName, instance);
+        }
+        if (ownerAtom) {
+            UnregisterClassW(kMenuOwnerClassName, instance);
+        }
+        classState = ClassState::Failed;
+        return false;
+    }
+
+    classState = ClassState::Ok;
+    return true;
+}
+
+HWND EnsureMenuOwnerWindow() {
+    if (g_menuOwnerWnd) {
+        // DestroyWindow/CreateWindow must run on the owning thread; a wrong-
+        // thread caller cannot replace the window safely.
+        if (GetWindowThreadProcessId(g_menuOwnerWnd, nullptr) !=
+            GetCurrentThreadId()) {
+            Wh_Log(L"Menu owner window belongs to a different thread; refusing "
+                   L"to use or recreate it from this thread");
+            return nullptr;
+        }
+        return g_menuOwnerWnd;
+    }
+    if (!EnsurePopupClasses()) {
+        return nullptr;
+    }
+
+    // Top-level so it receives WM_DISPLAYCHANGE when a monitor is plugged in.
+    // Kept hidden until a shell context menu needs an activatable owner.
+    // Must be created on the taskbar UI thread (via InjectHostGrids /
+    // EnsureLevelWindow).
+    g_menuOwnerWnd = CreateWindowExW(
+        WS_EX_TOOLWINDOW, kMenuOwnerClassName, L"", WS_POPUP, 0, 0, 0, 0,
+        nullptr, nullptr, GetCurrentModuleHandle(), nullptr);
+    if (!g_menuOwnerWnd) {
+        Wh_Log(L"Failed to create menu owner window (error %u)", GetLastError());
+    }
+    return g_menuOwnerWnd;
+}
+
+// Returns the reusable window for the given cascade depth, creating it on first
+// use. Depth 0's window also owns the tick timer.
+HWND EnsureLevelWindow(int depth) {
+    if (depth < 0 || depth >= kMaxLevels) {
+        return nullptr;
+    }
+    if (depth < (int)g_levelWindows.size() && g_levelWindows[depth]) {
+        return g_levelWindows[depth];
+    }
+
+    if (!EnsurePopupClasses()) {
+        return nullptr;
+    }
+    // Best-effort: owner is only required for shell context menus. A failure
+    // must not block creating the hover grid window itself.
+    EnsureMenuOwnerWindow();
+
+    HWND hWnd = CreateWindowExW(
+        WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE,
+        kPopupClassName, L"", WS_POPUP, 0, 0, 10, 10, nullptr, nullptr,
+        GetCurrentModuleHandle(), nullptr);
+    if (!hWnd) {
+        Wh_Log(L"Failed to create the hover grid window (error %u)",
+               GetLastError());
+        return nullptr;
+    }
+
+    ApplyBackdrop(hWnd);
+
+    if ((int)g_levelWindows.size() <= depth) {
+        g_levelWindows.resize(depth + 1, nullptr);
+    }
+    g_levelWindows[depth] = hWnd;
+    return hWnd;
+}
+
+void UpdatePopupDpi() {
+    // Sub-levels intentionally keep the root's DPI so a cascade that spills
+    // onto another monitor does not suddenly change cell sizes mid-gesture.
+    HWND reference = g_taskbarWnd;
+    if (!reference && !g_levelWindows.empty()) {
+        reference = g_levelWindows[0];
+    }
+    if (reference) {
+        int dpi = (int)GetDpiForWindow(reference);
+        g_popupDpi = dpi > 0 ? dpi : 96;
+    }
+}
+
+// Seats a level at its depth and retires anything deeper. The window at this
+// depth stays mapped, so reopening the same depth resizes in place instead of
+// blinking.
+PopupLevel* InstallLevel(std::unique_ptr<PopupLevel> level) {
+    int depth = level->depth;
+    CloseLevelsFrom(depth + 1);
+    if ((int)Levels().size() <= depth) {
+        Levels().resize(depth);
+        Levels().push_back(std::move(level));
+    } else {
+        Levels()[depth] = std::move(level);
+    }
+    return Levels()[depth].get();
+}
+
+// Places and shows a level's window, then paints it.
+void PresentLevel(PopupLevel* level, const SIZE& size) {
+    level->rect.right = level->rect.left + size.cx;
+    level->rect.bottom = level->rect.top + size.cy;
+    InvalidateLevelBase(level);
+
+    SetWindowPos(level->hwnd, HWND_TOPMOST, level->rect.left, level->rect.top,
+                 size.cx, size.cy, SWP_NOACTIVATE | SWP_SHOWWINDOW);
+    PaintLevel(level);
+}
+
+void OpenRootLevel(std::wstring path, RECT anchorRect, std::wstring title) {
+    if (g_unloading || path.empty()) {
+        return;
+    }
+
+    HWND hWnd = EnsureLevelWindow(0);
+    if (!hWnd) {
+        return;
+    }
+
+    UpdatePopupDpi();
+
+    auto level = std::make_unique<PopupLevel>();
+    level->hwnd = hWnd;
+    level->depth = 0;
+    level->path = path;
+    level->title = std::move(title);
+    level->anchorRect = anchorRect;
+
+    auto data =
+        GetFolderDataAndRefresh(path, ScaleForPopup(g_settings.iconSize));
+    level->loading = true;
+    if (data && data->ready) {
+        level->items = data->items;
+        level->loading = false;
+    }
+
+    g_rootAnchorRect = anchorRect;
+    g_outsideSinceTick = 0;
+
+    HMONITOR monitor = MonitorFromRect(&anchorRect, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO monitorInfo{};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    GetMonitorInfoW(monitor, &monitorInfo);
+    const RECT& screen = monitorInfo.rcMonitor;
+
+    int gap = ScaleForPopup(g_settings.gapAbove);
+    int availableAbove = anchorRect.top - gap - screen.top;
+    int availableBelow = screen.bottom - anchorRect.bottom - gap;
+    int maxHeight = std::max(availableAbove, availableBelow);
+    if (maxHeight < ScaleForPopup(96)) {
+        maxHeight = std::max(ScaleForPopup(96),
+                             (int)(screen.bottom - screen.top) - ScaleForPopup(16));
+    }
+    int maxWidth =
+        std::max(0, (int)(screen.right - screen.left) - ScaleForPopup(8));
+
+    SIZE size = ComputeLevelLayout(level.get(), maxHeight, maxWidth);
+
+    int centerX = (anchorRect.left + anchorRect.right) / 2;
+    int left = centerX - size.cx / 2;
+
+    // Prefer above the taskbar; never flip below a bottom taskbar where the
+    // grid would land past the monitor edge.
+    if (availableAbove >= size.cy) {
+        level->rect.top = anchorRect.top - gap - size.cy;
+    } else if (availableBelow >= size.cy) {
+        level->rect.top = anchorRect.bottom + gap;
+    } else if (availableAbove >= availableBelow) {
+        level->rect.top = screen.top;
+    } else {
+        level->rect.top = std::max<int>(screen.top, screen.bottom - size.cy);
+    }
+    level->rect.top = std::clamp<int>(
+        level->rect.top, screen.top,
+        std::max<int>(screen.top, screen.bottom - size.cy));
+    int loLeft = screen.left + ScaleForPopup(4);
+    int hiLeft = screen.right - size.cx - ScaleForPopup(4);
+    level->rect.left =
+        hiLeft <= loLeft ? screen.left : std::clamp(left, loLeft, hiLeft);
+
+    auto* installed = InstallLevel(std::move(level));
+    PresentLevel(installed, size);
+    PrefetchSubfolders(installed);
+
+    SetTimer(hWnd, kTickTimerId, kTickTimerMs, nullptr);
+}
+
+// Opens the grid for the subfolder in `cell` of the level at `parentDepth`,
+// cascading to the side of the parent like a normal submenu.
+void OpenSubLevel(int parentDepth, int cell) {
+    if (g_unloading || parentDepth < 0 || parentDepth >= (int)Levels().size()) {
+        return;
+    }
+
+    auto* parent = Levels()[parentDepth].get();
+    if (cell < 0 || cell >= (int)parent->items.size() ||
+        !parent->items[cell].isFolder || !CanExpand(parentDepth)) {
+        return;
+    }
+
+    int depth = parentDepth + 1;
+    HWND hWnd = EnsureLevelWindow(depth);
+    if (!hWnd) {
+        return;
+    }
+
+    auto level = std::make_unique<PopupLevel>();
+    level->hwnd = hWnd;
+    level->depth = depth;
+    level->path = parent->items[cell].fullPath;
+    level->spawnerCell = cell;
+
+    RECT cellScreenRect = parent->cellRects[cell];
+    OffsetRect(&cellScreenRect, parent->rect.left, parent->rect.top);
+    level->anchorRect = cellScreenRect;
+
+    auto data = GetFolderDataAndRefresh(level->path,
+                                        ScaleForPopup(g_settings.iconSize));
+    level->loading = true;
+    if (data && data->ready) {
+        level->items = data->items;
+        level->loading = false;
+    }
+
+    HMONITOR monitor = MonitorFromRect(&parent->rect, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO monitorInfo{};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    GetMonitorInfoW(monitor, &monitorInfo);
+    const RECT& screen = monitorInfo.rcMonitor;
+    const RECT& screenWork = monitorInfo.rcWork;
+
+    // Cap height to the work area (excludes the taskbar) and width to the
+    // parent monitor so cascade grids stay on-screen.
+    int maxHeight = std::max(
+        0, (int)(screenWork.bottom - screenWork.top) - ScaleForPopup(16));
+    int maxWidth =
+        std::max(0, (int)(screen.right - screen.left) - ScaleForPopup(8));
+    SIZE size = ComputeLevelLayout(level.get(), maxHeight, maxWidth);
+
+    int seam = ScaleForPopup(2);
+    int left = parent->rect.right + seam;
+    if (left + size.cx > screen.right) {
+        int flipped = parent->rect.left - seam - size.cx;
+        left = flipped >= screen.left
+                   ? flipped
+                   : std::max<int>(screen.left, screen.right - size.cx);
+    }
+
+    // Top-aligned with the cell that opened it, kept within the work area.
+    int top = cellScreenRect.top - ScaleForPopup(8);
+    top = std::clamp<int>(
+        top, screenWork.top,
+        std::max<int>(screenWork.top, screenWork.bottom - size.cy));
+
+    int loLeft = screen.left;
+    int hiLeft = screen.right - size.cx;
+    level->rect.left =
+        hiLeft <= loLeft ? screen.left : std::clamp(left, loLeft, hiLeft);
+    level->rect.top = top;
+
+    auto* installed = InstallLevel(std::move(level));
+    PresentLevel(installed, size);
+    PrefetchSubfolders(installed);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// The taskbar buttons
+
+constexpr PCWSTR kHostGridName = L"FolderHoverTrayHost";
+constexpr double kFallbackButtonSize = 44.0;
+
+struct ButtonState {
+    Button button{nullptr};
+    // Content wrapper holding [highlightBorder, icon]. Async icon delivery
+    // must swap only the icon child here, not replace button.Content()
+    // wholesale — that would orphan highlightBorder and silently kill hover.
+    Grid contentGrid{nullptr};
+    // Inset visual behind the icon; the button itself stays full-size so the
+    // click/hover hitbox still matches the neighbouring app icon's slot.
+    Border highlightBorder{nullptr};
+    Brush highlightHoverBrush{nullptr};
+    Brush highlightPressedBrush{nullptr};
+    winrt::event_token clickToken{};
+    winrt::event_token enterToken{};
+    winrt::event_token exitToken{};
+    winrt::event_token pressedToken{};
+    winrt::event_token releasedToken{};
+    winrt::event_token rightTapToken{};
+    int folderIndex = -1;
+    // Bumped when the button is rebuilt so late icon deliveries are ignored.
+    uint32_t iconGeneration = 0;
+};
+
+// One injected host per taskbar window (primary + each secondary monitor).
+struct TaskbarHost {
+    HWND hwnd = nullptr;
+    Grid hostGrid{nullptr};
+    Grid trackedRootGrid{nullptr};
+    FrameworkElement anchor{nullptr};
+    FrameworkElement cachedRepeater{nullptr};
+    std::vector<ButtonState> buttonStates;
+    Thickness anchorOriginalMargin{};
+    bool hasAnchorOriginalMargin = false;
+    winrt::event_token layoutUpdatedToken{};
+    double buttonWidth = kFallbackButtonSize;
+    double buttonHeight = kFallbackButtonSize;
+    ULONGLONG lastAnchorResolveTick = 0;
+    ULONGLONG lastButtonSizeTick = 0;
+    // hostGrid is positioned by this RenderTransform rather than by Margin.
+    // Margin would feed rootGrid's column-0 measure, so every reposition
+    // changed the taskbar's measured content width, re-centered the app
+    // strip, moved the anchor, and produced a new target — a layout feedback
+    // loop that read as the overlay fighting its own animation. A render
+    // transform is invisible to layout, and TransformToVisual still includes
+    // it, so ComputeHoverAnchorRect keeps working unchanged.
+    TranslateTransform hostTranslate{nullptr};
+    Storyboard slideStoryboard{nullptr};
+    double currentLeft = 0.0;
+    // First placement after injection jumps straight to position; there is
+    // nothing to slide from, and animating it would fly the buttons in from
+    // the taskbar's left edge on every load and settings reload.
+    bool hasPlaced = false;
+    // When the current slide is scheduled to actually start moving, and when
+    // it's due to finish. slideCauseTick/IsClose freeze the open-vs-close
+    // delay for a pending gesture so layout retargets keep the remaining
+    // wait instead of restarting it.
+    ULONGLONG slideStartTick = 0;
+    ULONGLONG slideEndTick = 0;
+    ULONGLONG slideCauseTick = 0;
+    bool slideCauseIsClose = false;
+};
+
+[[clang::no_destroy]] std::optional<std::vector<std::unique_ptr<TaskbarHost>>>
+    g_taskbarHosts{std::in_place};
+
+std::vector<std::unique_ptr<TaskbarHost>>& TaskbarHosts() {
+    if (!g_taskbarHosts) {
+        g_taskbarHosts.emplace();
+    }
+    return *g_taskbarHosts;
+}
+
+std::atomic<bool> g_injectionLive{false};
+std::atomic<uint32_t> g_buttonIconGeneration{1};
+
+// Lifetime retry worker: stays alive until StopRetryThread (settings/uninit).
+// StartRetryThread ensures the worker exists and SetEvent(kick) — never joins
+// from a window proc. A HANDLE has no destructor that aborts at process exit.
+// StopRetryThread joins with MsgWaitForMultipleObjects so settings/uninit can
+// wait without deadlocking on inbound SendMessage.
+HANDLE g_retryThread = nullptr;
+HANDLE g_retryStopEvent = nullptr;   // manual-reset
+HANDLE g_retryKickEvent = nullptr;   // auto-reset
+SRWLOCK g_retryLock = SRWLOCK_INIT;
+
+// WriteableBitmap's backing store is reachable only through this interop
+// interface, which the C++/WinRT projection does not declare for us.
+struct IBufferByteAccess : IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE Buffer(BYTE** value) = 0;
+};
+
+constexpr GUID kIBufferByteAccessGuid = {
+    0x905a0fef,
+    0xbc53,
+    0x11df,
+    {0x8c, 0x49, 0x00, 0x1e, 0x4f, 0xc6, 0x86, 0xda}};
+
+// WriteableBitmap must be created on the taskbar UI thread.
+// GDI+ Image getters are non-const in the MinGW headers Windhawk ships.
+ImageSource BitmapToImageSource(Gdiplus::Bitmap& bitmap) {
+    try {
+        const int width = (int)bitmap.GetWidth();
+        const int height = (int)bitmap.GetHeight();
+        if (width <= 0 || height <= 0) {
+            return nullptr;
+        }
+
+        Gdiplus::BitmapData bd{};
+        Gdiplus::Rect lockRect(0, 0, width, height);
+        // HIconToBitmap stores PARGB; WriteableBitmap also wants premultiplied
+        // BGRA.
+        if (bitmap.LockBits(&lockRect, Gdiplus::ImageLockModeRead,
+                            PixelFormat32bppPARGB, &bd) != Gdiplus::Ok) {
+            return nullptr;
+        }
+
+        try {
+            winrt::Windows::UI::Xaml::Media::Imaging::WriteableBitmap writeable(
+                width, height);
+            auto buffer = writeable.PixelBuffer();
+            IBufferByteAccess* byteAccess = nullptr;
+            auto* bufferUnknown = (IUnknown*)winrt::get_abi(buffer);
+            if (bufferUnknown &&
+                SUCCEEDED(bufferUnknown->QueryInterface(kIBufferByteAccessGuid,
+                                                        (void**)&byteAccess)) &&
+                byteAccess) {
+                BYTE* dest = nullptr;
+                if (SUCCEEDED(byteAccess->Buffer(&dest)) && dest) {
+                    for (int y = 0; y < height; y++) {
+                        memcpy(dest + (size_t)y * width * 4,
+                               (const BYTE*)bd.Scan0 + (size_t)y * bd.Stride,
+                               (size_t)width * 4);
+                    }
+                }
+                byteAccess->Release();
+            }
+            bitmap.UnlockBits(&bd);
+            writeable.Invalidate();
+            return writeable;
+        } catch (...) {
+            bitmap.UnlockBits(&bd);
+            return nullptr;
+        }
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void ApplyButtonIconOnUiThread(void* parameter) {
+    std::unique_ptr<ButtonIconDelivery> delivery(
+        static_cast<ButtonIconDelivery*>(parameter));
+    if (g_unloading || !delivery || !delivery->bitmap || !g_taskbarHosts) {
+        return;
+    }
+
+    // Skip if the user switched this slot to a literal emoji icon.
+    if (delivery->folderIndex >= 0) {
+        std::wstring icon;
+        {
+            std::lock_guard<std::mutex> lock(g_foldersMutex);
+            if (delivery->folderIndex < (int)g_settings.folders.size()) {
+                icon = g_settings.folders[delivery->folderIndex].icon;
+            }
+        }
+        if (!icon.empty() && !IconSettingIsFile(icon)) {
+            return;
+        }
+    }
+
+    for (auto& host : *g_taskbarHosts) {
+        if (!host || host->hwnd != delivery->taskbarWnd) {
+            continue;
+        }
+        for (auto& state : host->buttonStates) {
+            if (state.folderIndex != delivery->folderIndex ||
+                state.iconGeneration != delivery->iconGeneration ||
+                !state.button) {
+                continue;
+            }
+            try {
+                auto source = BitmapToImageSource(*delivery->bitmap);
+                if (!source) {
+                    return;
+                }
+                Image image;
+                image.Width(delivery->iconExtent);
+                image.Height(delivery->iconExtent);
+                image.Stretch(Stretch::Uniform);
+                image.HorizontalAlignment(HorizontalAlignment::Center);
+                image.VerticalAlignment(VerticalAlignment::Center);
+                image.Source(source);
+                if (state.contentGrid) {
+                    // Swap just the icon (child 1); leave highlightBorder
+                    // (child 0) in place so the wired hover handlers keep
+                    // pointing at a live element.
+                    auto children = state.contentGrid.Children();
+                    if (children.Size() >= 2) {
+                        children.RemoveAt(1);
+                    }
+                    children.Append(image);
+                } else {
+                    state.button.Content(image);
+                }
+            } catch (...) {
+            }
+            return;
+        }
+    }
+}
+
+void SetButtonBrush(Button const& button, PCWSTR key, Brush const& brush) {
+    button.Resources().Insert(winrt::box_value(winrt::hstring(key)), brush);
+}
+
+Brush MakeBrush(BYTE a, BYTE r, BYTE g, BYTE b) {
+    return SolidColorBrush(
+        winrt::Windows::UI::ColorHelper::FromArgb(a, r, g, b));
+}
+
+// How far the highlight overlay sits inside the button's full (hitbox) rect,
+// horizontally. The vertical inset is whatever is left over after squaring:
+// a TaskListButton is taller than it is wide (its height spans the whole
+// taskbar row), so insetting uniformly left the highlight tall and narrow.
+constexpr double kHighlightInset = 2.0;
+constexpr double kHighlightCornerRadius = 4.0;
+
+// Square highlight sized off the button width, clamped so it can never grow
+// past the button's height and bleed out of the taskbar row.
+double HighlightExtent(double buttonWidth, double buttonHeight) {
+    double extent = buttonWidth - 2.0 * kHighlightInset;
+    extent = std::min(extent, buttonHeight - 2.0 * kHighlightInset);
+    return std::max(extent, 8.0);
+}
+// "Very quick" fade — out is slightly slower so the highlight doesn't snap
+// away while the pointer is still crossing between adjacent buttons.
+constexpr int kHighlightFadeInMs = 90;
+constexpr int kHighlightFadeOutMs = 130;
+
+// Matches the shell's own app-icon states: a flat translucent fill, white on
+// dark themes and black on light ones — no acrylic, no gradient. The taskbar's
+// own backdrop showing through this is what gives it the glassy read.
+//
+// Hover is measured off a screenshot of a real hovered taskbar button rather
+// than taken from the documented 10-18% range, which overshoots badly: a
+// hovered Settings button reads RGB(27,23,23) over an RGB(13,8,8) taskbar,
+// i.e. (27-13)/(255-13) = 5.8% white, not 12%. Press has no such measurement;
+// it keeps the same ~1.5x step over hover it had before.
+constexpr BYTE kHighlightHoverAlpha = 14;    // 0x0E ≈ 5.7%
+constexpr BYTE kHighlightPressedAlpha = 21;  // 0x15 ≈ 8.5%
+
+Brush MakeHighlightBrush(bool dark, bool pressed) {
+    BYTE alpha = pressed ? kHighlightPressedAlpha : kHighlightHoverAlpha;
+    BYTE channel = dark ? 255 : 0;
+    return MakeBrush(alpha, channel, channel, channel);
+}
+
+// Fades the highlight's composition Opacity. A single keyframe at 1.0 means
+// the animation starts from whatever opacity is on screen right now, so an
+// interrupted fade hands off mid-flight instead of snapping — important when
+// the pointer skims across several buttons in a row.
+//
+// This drives the composition visual, not FrameworkElement::Opacity; the two
+// multiply, so the XAML-side value must be left at 1.0 throughout.
+void FadeHighlight(UIElement const& element, float to, int ms) {
+    if (!element) {
+        return;
+    }
+    try {
+        auto visual = ElementCompositionPreview::GetElementVisual(element);
+        auto compositor = visual.Compositor();
+        auto easing =
+            compositor.CreateCubicBezierEasingFunction({0.3f, 0.0f},
+                                                       {0.2f, 1.0f});
+        auto anim = compositor.CreateScalarKeyFrameAnimation();
+        anim.InsertKeyFrame(1.0f, to, easing);
+        anim.Duration(std::chrono::milliseconds(ms));
+        visual.StartAnimation(L"Opacity", anim);
+    } catch (...) {
+        // No composition: jump straight to the target, no fade.
+        try {
+            element.Opacity(to);
+        } catch (...) {
+        }
+    }
+}
+
+void ApplyNativeButtonStyle(Button const& button) {
+    bool dark = IsDarkTheme();
+
+    // The template's own background spans the full button (edge-to-edge,
+    // wider than the icon). It stays fully transparent in every state; a
+    // smaller inset Border drawn in the content plays the hover/press
+    // highlight instead, so the visual shrinks without touching the hitbox.
+    for (PCWSTR key : {L"ButtonBackground", L"ButtonBackgroundPointerOver",
+                       L"ButtonBackgroundPressed", L"ButtonBackgroundDisabled"}) {
+        SetButtonBrush(button, key, MakeBrush(0, 0, 0, 0));
+    }
+
+    for (PCWSTR key : {L"ButtonBorderBrush", L"ButtonBorderBrushPointerOver",
+                       L"ButtonBorderBrushPressed"}) {
+        SetButtonBrush(button, key, MakeBrush(0, 0, 0, 0));
+    }
+
+    auto foreground =
+        dark ? MakeBrush(255, 255, 255, 255) : MakeBrush(255, 26, 26, 26);
+    for (PCWSTR key : {L"ButtonForeground", L"ButtonForegroundPointerOver",
+                       L"ButtonForegroundPressed"}) {
+        SetButtonBrush(button, key, foreground);
+    }
+    button.Foreground(foreground);
+
+    button.BorderThickness({0, 0, 0, 0});
+    button.Padding({0, 0, 0, 0});
+    button.MinWidth(0);
+    button.MinHeight(0);
+    button.CornerRadius({6, 6, 6, 6});
+    // Stretch, not Center: the content is a Grid holding the inset highlight
+    // Border plus the icon. Center-aligning would size that Grid down to the
+    // icon's own bounds, collapsing the highlight behind the opaque icon
+    // pixels. The icon centers itself via its own alignment already.
+    button.HorizontalContentAlignment(HorizontalAlignment::Stretch);
+    button.VerticalContentAlignment(VerticalAlignment::Stretch);
+    button.UseSystemFocusVisuals(false);
+}
+
+UIElement MakeFolderEmojiFallback(int iconExtent) {
+    TextBlock fallback;
+    fallback.Text(L"\U0001F4C1");
+    fallback.FontFamily(FontFamily(L"Segoe UI Emoji"));
+    fallback.FontSize(iconExtent * 0.92);
+    fallback.HorizontalAlignment(HorizontalAlignment::Center);
+    fallback.VerticalAlignment(VerticalAlignment::Center);
+    return fallback;
+}
+
+// Shell icon / resource extraction runs on the STA scan worker. Only XAML
+// BitmapImage (async decode) and emoji TextBlocks stay on the UI thread.
+UIElement MakeButtonContent(const FolderEntry& entry,
+                            double buttonSize,
+                            int folderIndex,
+                            HWND taskbarWnd,
+                            uint32_t iconGeneration) {
+    int iconExtent = g_settings.buttonIconSize > 0
+                         ? g_settings.buttonIconSize
+                         : (int)std::lround(buttonSize * 0.545);
+    iconExtent = std::clamp<int>(iconExtent, 8, 128);
+    const int extractSize = iconExtent * 2;
+
+    // Emoji or any other short literal text.
+    if (!entry.icon.empty() && !IconSettingIsFile(entry.icon)) {
+        TextBlock text;
+        text.Text(entry.icon);
+        text.FontFamily(FontFamily(L"Segoe UI Emoji"));
+        text.FontSize(iconExtent * 0.92);
+        text.HorizontalAlignment(HorizontalAlignment::Center);
+        text.VerticalAlignment(VerticalAlignment::Center);
+        text.TextAlignment(TextAlignment::Center);
+        text.IsTextSelectionEnabled(false);
+        return text;
+    }
+
+    if (!entry.icon.empty()) {
+        std::wstring icon = entry.icon;
+        bool isImageFile = false;
+        for (PCWSTR ext : {L".ico", L".png", L".jpg", L".jpeg", L".bmp",
+                           L".gif", L".tif", L".tiff"}) {
+            size_t len = wcslen(ext);
+            if (icon.size() > len &&
+                _wcsicmp(icon.c_str() + icon.size() - len, ext) == 0) {
+                isImageFile = true;
+                break;
+            }
+        }
+
+        if (isImageFile) {
+            // BitmapImage decodes off-thread; skip sync shell extraction.
+            if (!IsLikelyRemotePath(icon)) {
+                try {
+                    WCHAR url[2048];
+                    DWORD urlLen = ARRAYSIZE(url);
+                    if (SUCCEEDED(UrlCreateFromPathW(icon.c_str(), url, &urlLen,
+                                                     0))) {
+                        Image image;
+                        image.Width(iconExtent);
+                        image.Height(iconExtent);
+                        image.Stretch(Stretch::Uniform);
+                        image.HorizontalAlignment(HorizontalAlignment::Center);
+                        image.VerticalAlignment(VerticalAlignment::Center);
+                        winrt::Windows::UI::Xaml::Media::Imaging::BitmapImage
+                            bitmap;
+                        bitmap.DecodePixelWidth(extractSize);
+                        bitmap.UriSource(winrt::Windows::Foundation::Uri(
+                            winrt::hstring(url)));
+                        image.Source(bitmap);
+                        return image;
+                    }
+                } catch (...) {
+                }
+            }
+            return MakeFolderEmojiFallback(iconExtent);
+        }
+
+        // app.exe,0 / .ico via SHDefExtractIcon — never on the UI thread.
+        RequestButtonIcon(icon, extractSize, folderIndex, iconGeneration,
+                          taskbarWnd, /*resourceSpec=*/true);
+        return MakeFolderEmojiFallback(iconExtent);
+    }
+
+    // No icon configured: folder shell icon on the scan worker. Never call
+    // GetShellIconForPath here. resolvedPath / likelyRemote are filled by
+    // ResolvePendingFolderEntries on this taskbar STA (or the scan STA).
+    if (!entry.path.empty() && !entry.likelyRemote) {
+        const std::wstring& iconPath =
+            !entry.resolvedPath.empty() ? entry.resolvedPath : entry.path;
+        // Unresolved shell: still OK — the scan worker ResolveFolderPath's it.
+        RequestButtonIcon(iconPath, extractSize, folderIndex, iconGeneration,
+                          taskbarWnd, /*resourceSpec=*/false);
+    }
+    return MakeFolderEmojiFallback(iconExtent);
+}
+
+RECT GetElementScreenRect(FrameworkElement const& element) {
+    RECT rect{};
+    if (!element || !g_taskbarWnd) {
+        return rect;
+    }
+    try {
+        auto transform = element.TransformToVisual(nullptr);
+        auto point = transform.TransformPoint({0, 0});
+
+        double scale = 1.0;
+        if (auto xamlRoot = element.XamlRoot()) {
+            scale = xamlRoot.RasterizationScale();
+        }
+        if (scale <= 0.0) {
+            scale = 1.0;
+        }
+
+        POINT origin{0, 0};
+        ClientToScreen(g_taskbarWnd, &origin);
+
+        rect.left = origin.x + (LONG)std::lround(point.X * scale);
+        rect.top = origin.y + (LONG)std::lround(point.Y * scale);
+        rect.right =
+            rect.left + (LONG)std::lround(element.ActualWidth() * scale);
+        rect.bottom =
+            rect.top + (LONG)std::lround(element.ActualHeight() * scale);
+    } catch (...) {
+        rect = RECT{};
+    }
+    return rect;
+}
+
+FrameworkElement FindTaskbarRepeater(Grid const& rootGrid) {
+    return FindChildByName(rootGrid, L"TaskbarFrameRepeater", 6);
+}
+
+// Matching a live taskbar button means the folder buttons stay the right size
+// across taskbar-size changes, DPI changes, and the small-icons setting.
+void UpdateButtonSizeFromTaskbar(FrameworkElement const& repeater,
+                                 double* outWidth,
+                                 double* outHeight) {
+    std::vector<FrameworkElement> children;
+    EnumRepeaterChildren(repeater, &children);
+
+    double width = 0.0;
+    double height = 0.0;
+
+    for (const auto& child : children) {
+        auto className = winrt::get_class_name(child);
+        if (className != L"Taskbar.TaskListButton") {
+            continue;
+        }
+        if (child.ActualWidth() > 1.0 && child.ActualHeight() > 1.0) {
+            width = child.ActualWidth();
+            height = child.ActualHeight();
+            break;
+        }
+    }
+
+    if (width <= 1.0) {
+        for (const auto& child : children) {
+            auto className = winrt::get_class_name(child);
+            if (className != L"Taskbar.ExperienceToggleButton" &&
+                className != L"Taskbar.AugmentedEntryPointButton") {
+                continue;
+            }
+            if (child.ActualWidth() > 1.0 && child.ActualHeight() > 1.0) {
+                width = child.ActualWidth();
+                height = child.ActualHeight();
+                break;
+            }
+        }
+    }
+
+    if (width <= 1.0 || height <= 1.0) {
+        return;
+    }
+
+    if (outWidth) {
+        *outWidth = width;
+    }
+    if (outHeight) {
+        *outHeight = height;
+    }
+}
+
+FrameworkElement ResolveAnchor(FrameworkElement const& repeater,
+                               Grid const& rootGrid) {
+    std::vector<FrameworkElement> children;
+    EnumRepeaterChildren(repeater, &children);
+    if (children.empty()) {
+        return nullptr;
+    }
+
+    bool before = g_settings.position != L"afterApps";
+
+    auto findByClass = [&](PCWSTR className, int skip) -> FrameworkElement {
+        int seen = 0;
+        for (const auto& child : children) {
+            if (winrt::get_class_name(child) != className) {
+                continue;
+            }
+            if (seen++ < skip) {
+                continue;
+            }
+            return child;
+        }
+        return nullptr;
+    };
+
+    if (g_settings.anchor == L"widgets") {
+        if (auto found = findByClass(L"Taskbar.AugmentedEntryPointButton", 0)) {
+            return found;
+        }
+    } else if (g_settings.anchor == L"taskView") {
+        if (auto found = findByClass(L"Taskbar.ExperienceToggleButton", 1)) {
+            return found;
+        }
+    } else if (g_settings.anchor == L"start") {
+        if (auto found = findByClass(L"Taskbar.ExperienceToggleButton", 0)) {
+            return found;
+        }
+    }
+
+    // Auto: the outermost app button on the requested side. The repeater's
+    // realized children are not in layout order, so compare actual positions.
+    FrameworkElement best = nullptr;
+    double bestX = 0.0;
+    for (const auto& child : children) {
+        if (winrt::get_class_name(child) != L"Taskbar.TaskListButton") {
+            continue;
+        }
+        if (child.Visibility() != Visibility::Visible ||
+            child.ActualWidth() <= 1.0) {
+            continue;
+        }
+        try {
+            auto point =
+                child.TransformToVisual(rootGrid).TransformPoint({0, 0});
+            // A button mid-realization (window just opened/closed) reports
+            // ActualWidth before Arrange has placed it, landing at X == 0.
+            // That looks like the leftmost button and would get adopted as
+            // anchor, carving the gap at the wrong spot. Skip unplaced ones.
+            if (point.X <= 0.5) {
+                continue;
+            }
+            if (!best || (before ? point.X < bestX : point.X > bestX)) {
+                best = child;
+                bestX = point.X;
+            }
+        } catch (...) {
+        }
+    }
+    if (best) {
+        return best;
+    }
+
+    for (PCWSTR className : {L"Taskbar.AugmentedEntryPointButton",
+                             L"Taskbar.ExperienceToggleButton"}) {
+        if (auto found = findByClass(className, 0)) {
+            return found;
+        }
+    }
+
+    return nullptr;
+}
+
+double DesiredHostWidth(TaskbarHost* host) {
+    if (!host || host->buttonStates.empty()) {
+        return 0.0;
+    }
+    return host->buttonWidth * (double)host->buttonStates.size();
+}
+
+// Windows 11's point-to-point shift — the profile its own app icons use when
+// they glide sideways to fill a freed slot or clear space for a new one.
+// 250ms on cubic-bezier(0.55, 0.55, 0, 1): holds initial speed through the
+// first half, then drops momentum just before landing.
+constexpr int kHostGridSlideMs = 250;
+constexpr float kSlideEaseCp1X = 0.55f;
+constexpr float kSlideEaseCp1Y = 0.55f;
+constexpr float kSlideEaseCp2X = 0.0f;
+constexpr float kSlideEaseCp2Y = 1.0f;
+
+// Layout reports the new target well before the taskbar's own icons visibly
+// start moving, so the slide has to be held back to fall in step with them.
+// Closing needs the longer wait (exit animation before survivors fill the
+// slot); opening barely needs any. Open vs close is inferred from which way
+// the gap moves on a centered strip — see AnimateHostGridLeftTo. Both delays
+// are tuned by eye against the real icons, so they are just knobs.
+constexpr int kSlideDelayOpenMs = 50;
+constexpr int kSlideDelayCloseMs = 350;
+
+// Slides hostGrid to newLeft by animating its RenderTransform.
+//
+// Two earlier approaches failed here and are worth not repeating. A XAML
+// RepositionThemeTransition never fired reliably for a plain Margin set on a
+// standalone Grid outside a panel's own child-change pipeline. Animating the
+// element visual's composition Offset.X didn't survive either, because XAML
+// owns Visual.Offset and rewrites it on every arrange pass.
+//
+// The deeper problem was positioning by Margin at all: hostGrid is a child
+// of rootGrid's column 0, so its Margin fed that column's measure. Each
+// reposition therefore changed the taskbar's measured content width, which
+// re-centered the app strip, which moved the anchor, which yielded a new
+// target — a feedback loop that retargeted the animation every layout pass
+// and looked like the overlay resisting its own movement. Layout ignores a
+// RenderTransform completely, which breaks the loop, and TransformToVisual
+// still accounts for it so ComputeHoverAnchorRect needs no changes.
+//
+// Retargeting mid-slide is handled by pinning the transform's base value to
+// wherever the animation currently has it before starting the next one (a
+// bare Storyboard.Stop would snap back to the base value). The replacement
+// keyframe has no From, so XAML interpolates from that current value —
+// a seamless re-aim toward the new target rather than a restart — and the
+// start delay is skipped because the motion is already underway.
+//
+// Animating a TranslateTransform's X keeps this an *independent* animation:
+// XAML hands transform animations to the compositor, so they run off the UI
+// thread at the monitor's refresh tick and don't stutter when the taskbar
+// thread is busy.
+void AnimateHostGridLeftTo(TaskbarHost* host, double newLeft) {
+    if (!host || !host->hostGrid || !host->hostTranslate) {
+        return;
+    }
+    double previousLeft = host->currentLeft;
+    if (std::abs(previousLeft - newLeft) < 1.0) {
+        return;
+    }
+
+    ULONGLONG now = GetTickCount64();
+    // Still waiting on its BeginTime — visual hasn't started moving, so the
+    // remaining wait carries over rather than resetting to a fresh delay.
+    bool pending = host->slideStoryboard && now < host->slideStartTick;
+    // Already interpolating — re-aim live, no delay of its own.
+    bool animating =
+        host->slideStoryboard && !pending && now < host->slideEndTick;
+
+    // Child-count / width probes lag the layout target on both open and
+    // close, so classify from the move itself. Centered taskbar: opening
+    // grows the app cluster outward, closing shrinks it inward — which way
+    // that shoves our gap depends on beforeApps vs afterApps.
+    bool beforeApps = g_settings.position != L"afterApps";
+    bool isCloseMove =
+        beforeApps ? (newLeft < previousLeft) : (newLeft > previousLeft);
+
+    host->currentLeft = newLeft;
+
+    if (!host->hasPlaced) {
+        host->hasPlaced = true;
+        try {
+            host->hostTranslate.X(newLeft);
+        } catch (...) {
+        }
+        return;
+    }
+
+    int delayMs = 0;
+    if (!animating) {
+        if (!pending) {
+            host->slideCauseTick = now;
+            host->slideCauseIsClose = isCloseMove;
+        }
+        int causeDelay = host->slideCauseIsClose ? kSlideDelayCloseMs
+                                                 : kSlideDelayOpenMs;
+        long long remain =
+            (long long)host->slideCauseTick + causeDelay - (long long)now;
+        delayMs = remain > 0 ? (int)remain : 0;
+    }
+
+    try {
+        if (host->slideStoryboard) {
+            // Only an actually-moving slide has left the base value behind;
+            // a still-pending one never touched it, so there's nothing to
+            // commit back — doing so anyway would read the frozen pre-delay
+            // value, which is already correct, so this is safe either way.
+            double live = host->hostTranslate.X();
+            host->slideStoryboard.Stop();
+            host->hostTranslate.X(live);
+            host->slideStoryboard = nullptr;
+        }
+
+        auto slideSpan = winrt::Windows::Foundation::TimeSpan{
+            std::chrono::milliseconds(kHostGridSlideMs)};
+
+        // CubicEase can't express an arbitrary bezier, so the curve comes
+        // from a KeySpline on a single spline keyframe instead.
+        KeySpline spline;
+        spline.ControlPoint1({kSlideEaseCp1X, kSlideEaseCp1Y});
+        spline.ControlPoint2({kSlideEaseCp2X, kSlideEaseCp2Y});
+
+        SplineDoubleKeyFrame frame;
+        frame.KeyTime(KeyTime{slideSpan});
+        frame.Value(newLeft);
+        frame.KeySpline(spline);
+
+        DoubleAnimationUsingKeyFrames anim;
+        anim.KeyFrames().Append(frame);
+        // Duration is a struct, not a TimeSpan, and its default type is
+        // Automatic (a flat 1s) — the type has to say TimeSpan for the
+        // value to be honoured.
+        anim.Duration(Duration{slideSpan, DurationType::TimeSpan});
+        if (delayMs > 0) {
+            anim.BeginTime(winrt::Windows::Foundation::TimeSpan{
+                std::chrono::milliseconds(delayMs)});
+        }
+
+        Storyboard sb;
+        sb.Children().Append(anim);
+        Storyboard::SetTarget(anim, host->hostTranslate);
+        Storyboard::SetTargetProperty(anim, L"X");
+        host->slideStoryboard = sb;
+        sb.Begin();
+
+        host->slideStartTick = now + delayMs;
+        host->slideEndTick = now + delayMs + kHostGridSlideMs;
+    } catch (...) {
+        // Animation unavailable for whatever reason — still get the element
+        // to the right place, just without the slide.
+        try {
+            host->slideStoryboard = nullptr;
+            host->hostTranslate.X(newLeft);
+        } catch (...) {
+        }
+    }
+}
+
+void RestoreAnchorMargin(TaskbarHost* host) {
+    if (!host) {
+        return;
+    }
+    if (host->anchor && host->hasAnchorOriginalMargin) {
+        try {
+            host->anchor.Margin(host->anchorOriginalMargin);
+        } catch (...) {
+        }
+    }
+    host->anchor = nullptr;
+    host->hasAnchorOriginalMargin = false;
+}
+
+void AdoptAnchor(TaskbarHost* host, FrameworkElement const& anchor) {
+    if (!host) {
+        return;
+    }
+    if (host->anchor == anchor) {
+        return;
+    }
+    RestoreAnchorMargin(host);
+    host->anchor = anchor;
+    if (anchor) {
+        try {
+            host->anchorOriginalMargin = anchor.Margin();
+            host->hasAnchorOriginalMargin = true;
+        } catch (...) {
+            host->hasAnchorOriginalMargin = false;
+        }
+    }
+}
+
+TaskbarHost* FindTaskbarHost(HWND hwnd) {
+    if (!g_taskbarHosts) {
+        return nullptr;
+    }
+    for (auto& host : *g_taskbarHosts) {
+        if (host && host->hwnd == hwnd) {
+            return host.get();
+        }
+    }
+    return nullptr;
+}
+
+TaskbarHost* FindTaskbarHostByRootGrid(Grid const& rootGrid) {
+    if (!g_taskbarHosts) {
+        return nullptr;
+    }
+    for (auto& host : *g_taskbarHosts) {
+        if (host && host->trackedRootGrid == rootGrid) {
+            return host.get();
+        }
+    }
+    return nullptr;
+}
+
+// The vertical extent comes from the taskbar window rather than the button, so
+// the corridor covers the whole taskbar height under the button. Horizontally
+// the XAML transform is trusted only if it lands inside the taskbar; otherwise
+// the cursor position, which is definitely over the button, is used instead.
+RECT ComputeHoverAnchorRect(Button const& button) {
+    RECT taskbarRect{};
+    if (!g_taskbarWnd || !GetWindowRect(g_taskbarWnd, &taskbarRect)) {
+        return RECT{};
+    }
+
+    RECT rect = GetElementScreenRect(button);
+    LONG width = rect.right - rect.left;
+
+    if (width <= 0 || rect.left < taskbarRect.left ||
+        rect.right > taskbarRect.right) {
+        POINT cursor{};
+        if (!GetCursorPos(&cursor)) {
+            return RECT{};
+        }
+        LONG half = width > 0 ? width / 2 : 22;
+        if (half <= 0) {
+            half = 22;
+        }
+        rect.left = cursor.x - half;
+        rect.right = cursor.x + half;
+        Wh_Log(L"Button rect fell outside the taskbar, using the cursor instead");
+    }
+
+    rect.top = taskbarRect.top;
+    rect.bottom = taskbarRect.bottom;
+    return rect;
+}
+
+std::wstring FolderPathForButton(int folderIndex) {
+    std::lock_guard<std::mutex> lock(g_foldersMutex);
+    if (folderIndex < 0 || folderIndex >= (int)g_settings.folders.size()) {
+        return L"";
+    }
+    const FolderEntry& entry = g_settings.folders[folderIndex];
+    if (!entry.resolvedPath.empty()) {
+        return entry.resolvedPath;
+    }
+    // Unresolved shell: not a filesystem path — OpenRootLevel / FindFirstFile
+    // must wait for ResolvePendingFolderEntries on an STA.
+    if (IsShellFolderPath(entry.path)) {
+        return L"";
+    }
+    return entry.path;
+}
+
+std::wstring FolderNameForButton(int folderIndex) {
+    std::lock_guard<std::mutex> lock(g_foldersMutex);
+    if (folderIndex < 0 || folderIndex >= (int)g_settings.folders.size()) {
+        return L"";
+    }
+    return g_settings.folders[folderIndex].name;
+}
+
+void OnPointerEnteredButton(int folderIndex,
+                             Button const& button,
+                             HWND taskbarWnd) {
+    if (g_unloading) {
+        return;
+    }
+
+    if (taskbarWnd) {
+        g_taskbarWnd = taskbarWnd;
+    }
+
+    // Taskbar UI STA: finish any pending shell: resolve before open/scan.
+    ResolvePendingFolderEntries();
+    std::wstring path = FolderPathForButton(folderIndex);
+    if (path.empty()) {
+        return;
+    }
+    std::wstring title = FolderNameForButton(folderIndex);
+
+    RECT buttonRect = ComputeHoverAnchorRect(button);
+    if (buttonRect.right <= buttonRect.left) {
+        return;
+    }
+
+    if (g_settings.hoverDelayMs <= 0) {
+        OpenRootLevel(std::move(path), buttonRect, std::move(title));
+        return;
+    }
+
+    HWND hWnd = EnsureLevelWindow(0);
+    if (!hWnd) {
+        return;
+    }
+    g_pendingRootPath = std::move(path);
+    g_pendingRootTitle = std::move(title);
+    g_pendingRootRect = buttonRect;
+    SetTimer(hWnd, kOpenTimerId, (UINT)g_settings.hoverDelayMs, nullptr);
+}
+
+// Leaving the button cancels a pending delayed open. Closing an already-open
+// cascade is left to OnTick so moving up into the grid does not dismiss it.
+void OnPointerExitedButton() {
+    if (g_pendingRootPath.empty()) {
+        return;
+    }
+    g_pendingRootPath.clear();
+    g_pendingRootTitle.clear();
+    if (!g_levelWindows.empty() && g_levelWindows[0]) {
+        KillTimer(g_levelWindows[0], kOpenTimerId);
+    }
+}
+
+void OnButtonClicked(int folderIndex) {
+    if (!g_settings.openFolderOnClick) {
+        return;
+    }
+    ResolvePendingFolderEntries();
+    std::wstring path = FolderPathForButton(folderIndex);
+    if (path.empty()) {
+        return;
+    }
+    CloseChain();
+    LaunchPath(path);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Folder manager window
+//
+// The only place folder buttons are configured. Windhawk's settings page
+// cannot hold the list: a mod cannot write to its own settings without
+// administrator rights, so a list living there could never be edited by the
+// Explorer right-click pin, by an unpin on the taskbar, or from here.
+// A plain Win32 window on its own thread, touching only the mod's own
+// storage, needs no elevation at all.
+namespace FolderManager {
+
+constexpr PCWSTR kClassName = L"WH_TaskbarFolderHoverTray_Manager";
+constexpr PCWSTR kEditClassName = L"WH_TaskbarFolderHoverTray_ManagerEdit";
+
+constexpr int kIdList = 1001;
+constexpr int kIdAdd = 1002;
+constexpr int kIdEdit = 1003;
+constexpr int kIdRemove = 1004;
+constexpr int kIdClose = 1008;
+constexpr int kIdHint = 1009;
+
+// Edit-dialog controls.
+constexpr int kIdEditName = 1101;
+constexpr int kIdEditPath = 1102;
+constexpr int kIdEditIcon = 1103;
+constexpr int kIdEditPinned = 1104;
+constexpr int kIdEditBrowsePath = 1105;
+constexpr int kIdEditBrowseIcon = 1106;
+constexpr int kIdEditOk = 1107;
+constexpr int kIdEditCancel = 1108;
+constexpr int kIdEditPreview = 1109;
+constexpr int kIdEditPinnedHint = 1110;
+
+constexpr int kRowHeight = 40;
+constexpr int kRowIconSize = 24;
+
+// Owned by the manager thread once it starts; only ever read elsewhere to
+// find an existing window or ask it to close.
+std::atomic<HWND> g_wnd{nullptr};
+std::atomic<bool> g_active{false};
+
+// The store as last read, in listbox order. Manager-thread only.
+std::vector<FolderStore::Entry> g_rows;
+// One icon per row, parallel to g_rows, owned here and freed on rebuild.
+std::vector<HICON> g_rowIcons;
+
+// Registers one of the manager's window classes against the current DLL.
+//
+// Recompiling the mod unloads this DLL and loads a new copy, but a window
+// class registered by the old one survives in the process with its
+// lpfnWndProc still pointing at the freed image. Reusing it — which is what
+// treating ERROR_CLASS_ALREADY_EXISTS as success amounts to — hands
+// CreateWindowEx a dangling procedure and takes Explorer down with the first
+// message. So a stale registration is torn down and replaced rather than
+// adopted. Wh_ModUninit unregisters both classes for the same reason; this is
+// the belt to that pair of braces, since an Explorer crash (or any unclean
+// unload) skips the tidy path.
+bool EnsureClass(PCWSTR name, WNDPROC proc) {
+    HINSTANCE instance = GetCurrentModuleHandle();
+    WNDCLASSEXW wc{};
+    wc.cbSize = sizeof(wc);
+    wc.lpfnWndProc = proc;
+    wc.hInstance = instance;
+    wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+    wc.hbrBackground = (HBRUSH)(COLOR_BTNFACE + 1);
+    wc.lpszClassName = name;
+
+    if (RegisterClassExW(&wc)) {
+        return true;
+    }
+    if (GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
+        Wh_Log(L"Manager: RegisterClassExW('%s') failed (error %u)", name,
+               GetLastError());
+        return false;
+    }
+
+    // Left behind by an earlier load of this mod. Unregistering fails while
+    // any window of the class still exists, and there should be none.
+    if (!UnregisterClassW(name, instance)) {
+        Wh_Log(L"Manager: stale class '%s' could not be unregistered "
+               L"(error %u)",
+               name, GetLastError());
+        return false;
+    }
+    if (!RegisterClassExW(&wc)) {
+        Wh_Log(L"Manager: re-registering '%s' failed (error %u)", name,
+               GetLastError());
+        return false;
+    }
+    Wh_Log(L"Manager: replaced a stale '%s' class from a previous load", name);
+    return true;
+}
+
+// Top-left corner that centres a width x height window on the monitor
+// `anchor` falls on, clamped to that monitor's work area so the title bar can
+// never land under a taskbar.
+POINT CenterOnMonitor(POINT anchor, int width, int height) {
+    MONITORINFO info{};
+    info.cbSize = sizeof(info);
+    HMONITOR monitor = MonitorFromPoint(anchor, MONITOR_DEFAULTTONEAREST);
+    if (!monitor || !GetMonitorInfoW(monitor, &info)) {
+        return POINT{CW_USEDEFAULT, CW_USEDEFAULT};
+    }
+    const RECT& work = info.rcWork;
+    POINT pos{work.left + ((work.right - work.left) - width) / 2,
+              work.top + ((work.bottom - work.top) - height) / 2};
+    if (pos.x < work.left) {
+        pos.x = work.left;
+    }
+    if (pos.y < work.top) {
+        pos.y = work.top;
+    }
+    return pos;
+}
+
+HFONT UiFont() {
+    static HFONT font = [] {
+        NONCLIENTMETRICSW ncm{};
+        ncm.cbSize = sizeof(ncm);
+        if (SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncm), &ncm,
+                                  0)) {
+            if (HFONT themed = CreateFontIndirectW(&ncm.lfMessageFont)) {
+                return themed;
+            }
+        }
+        return (HFONT)GetStockObject(DEFAULT_GUI_FONT);
+    }();
+    return font;
+}
+
+void ApplyUiFont(HWND parent) {
+    EnumChildWindows(
+        parent,
+        [](HWND child, LPARAM f) -> BOOL {
+            SendMessageW(child, WM_SETFONT, (WPARAM)f, TRUE);
+            return TRUE;
+        },
+        (LPARAM)UiFont());
+}
+
+// The icon a row should show: its configured icon spec if it has one that is
+// a file/resource, otherwise the folder's own shell icon. Emoji icons have no
+// HICON — those are drawn as text instead, so this returns null for them.
+HICON IconForEntry(const FolderStore::Entry& entry, int pixelSize) {
+    std::wstring icon = entry.icon;
+    if (!icon.empty()) {
+        if (!IconSettingIsFile(icon)) {
+            return nullptr;  // Emoji or other literal text.
+        }
+        if (HICON hIcon = ExtractIconFromResourceSpec(icon, pixelSize)) {
+            return hIcon;
+        }
+    }
+    std::wstring target = ResolveFolderPath(ExpandEnv(entry.path));
+    if (target.empty()) {
+        target = ExpandEnv(entry.path);
+    }
+    return GetShellIconForPath(target, pixelSize);
+}
+
+void FreeRowIcons() {
+    for (HICON icon : g_rowIcons) {
+        if (icon) {
+            DestroyIcon(icon);
+        }
+    }
+    g_rowIcons.clear();
+}
+
+void PopulateList(HWND hWnd) {
+    HWND list = GetDlgItem(hWnd, kIdList);
+    int selected = (int)SendMessageW(list, LB_GETCURSEL, 0, 0);
+
+    SendMessageW(list, LB_RESETCONTENT, 0, 0);
+    FreeRowIcons();
+    g_rows = FolderStore::Read();
+
+    for (const auto& entry : g_rows) {
+        g_rowIcons.push_back(IconForEntry(entry, kRowIconSize));
+        // Text comes from g_rows during WM_DRAWITEM; the item itself only
+        // needs to exist.
+        SendMessageW(list, LB_ADDSTRING, 0, (LPARAM)L"");
+    }
+
+    if (!g_rows.empty()) {
+        int last = (int)g_rows.size() - 1;
+        if (selected < 0) {
+            selected = 0;
+        }
+        SendMessageW(list, LB_SETCURSEL, selected < last ? selected : last, 0);
+    }
+
+    bool any = !g_rows.empty();
+    for (int id : {kIdEdit, kIdRemove}) {
+        EnableWindow(GetDlgItem(hWnd, id), any);
+    }
+    SetWindowTextW(GetDlgItem(hWnd, kIdHint),
+                   any ? L"Drag a row to reorder the taskbar buttons. "
+                         L"Double-click to open a folder."
+                       : L"No folders yet. Add one here, or right-click any "
+                         L"folder in Explorer and pick Taskbar Folders > Pin.");
+    InvalidateRect(list, nullptr, TRUE);
+}
+
+int SelectedIndex(HWND hWnd) {
+    int sel = (int)SendMessageW(GetDlgItem(hWnd, kIdList), LB_GETCURSEL, 0, 0);
+    return (sel >= 0 && sel < (int)g_rows.size()) ? sel : -1;
+}
+
+// Applies a changed store and refreshes both the taskbar and this window.
+void CommitStore(HWND hWnd, const std::vector<FolderStore::Entry>& entries) {
+    FolderStore::Write(entries);
+    if (!g_unloading) {
+        ReloadAndRefreshUI();
+    }
+    PopulateList(hWnd);
+}
+
+void DrawRow(LPDRAWITEMSTRUCT dis) {
+    if (dis->itemID == (UINT)-1 || dis->itemID >= g_rows.size()) {
+        return;
+    }
+    const FolderStore::Entry& entry = g_rows[dis->itemID];
+    bool selected = (dis->itemState & ODS_SELECTED) != 0;
+
+    HDC dc = dis->hDC;
+    RECT rc = dis->rcItem;
+    FillRect(dc, &rc, GetSysColorBrush(selected ? COLOR_HIGHLIGHT
+                                                : COLOR_WINDOW));
+
+    int iconTop = rc.top + (kRowHeight - kRowIconSize) / 2;
+    HICON icon = dis->itemID < g_rowIcons.size() ? g_rowIcons[dis->itemID]
+                                                 : nullptr;
+    if (icon) {
+        DrawIconEx(dc, rc.left + 8, iconTop, icon, kRowIconSize, kRowIconSize,
+                   0, nullptr, DI_NORMAL);
+    } else if (!entry.icon.empty()) {
+        // Emoji icon: draw the text itself, centred in the icon slot.
+        RECT iconRect{rc.left + 8, iconTop, rc.left + 8 + kRowIconSize,
+                      iconTop + kRowIconSize};
+        SetBkMode(dc, TRANSPARENT);
+        SetTextColor(dc, GetSysColor(selected ? COLOR_HIGHLIGHTTEXT
+                                              : COLOR_WINDOWTEXT));
+        DrawTextW(dc, entry.icon.c_str(), -1, &iconRect,
+                  DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
+    }
+
+    int textLeft = rc.left + 8 + kRowIconSize + 10;
+    SetBkMode(dc, TRANSPARENT);
+
+    std::wstring title = entry.name.empty() ? entry.path : entry.name;
+    if (!entry.pinned) {
+        title += L"   (not pinned)";
+    }
+    RECT titleRect{textLeft, rc.top + 4, rc.right - 8, rc.top + 21};
+    SetTextColor(dc, GetSysColor(selected ? COLOR_HIGHLIGHTTEXT
+                                          : COLOR_WINDOWTEXT));
+    DrawTextW(dc, title.c_str(), -1, &titleRect,
+              DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS |
+                  DT_NOPREFIX);
+
+    RECT pathRect{textLeft, rc.top + 21, rc.right - 8, rc.bottom - 3};
+    SetTextColor(dc, GetSysColor(selected ? COLOR_HIGHLIGHTTEXT
+                                          : COLOR_GRAYTEXT));
+    DrawTextW(dc, entry.path.c_str(), -1, &pathRect,
+              DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_PATH_ELLIPSIS |
+                  DT_NOPREFIX);
+
+    if (dis->itemState & ODS_FOCUS) {
+        DrawFocusRect(dc, &rc);
+    }
+}
+
+// Shell folder picker, seeded with `initial`. Empty return means cancelled.
+std::wstring BrowseForFolder(HWND owner, const std::wstring& initial) {
+    std::wstring chosen;
+    IFileDialog* dialog = nullptr;
+    if (FAILED(CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC,
+                                IID_PPV_ARGS(&dialog)))) {
+        return chosen;
+    }
+
+    DWORD options = 0;
+    dialog->GetOptions(&options);
+    dialog->SetOptions(options | FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM);
+
+    if (!initial.empty()) {
+        IShellItem* item = nullptr;
+        if (SUCCEEDED(SHCreateItemFromParsingName(initial.c_str(), nullptr,
+                                                  IID_PPV_ARGS(&item)))) {
+            dialog->SetFolder(item);
+            item->Release();
+        }
+    }
+
+    if (SUCCEEDED(dialog->Show(owner))) {
+        IShellItem* result = nullptr;
+        if (SUCCEEDED(dialog->GetResult(&result))) {
+            PWSTR path = nullptr;
+            if (SUCCEEDED(result->GetDisplayName(SIGDN_FILESYSPATH, &path))) {
+                chosen = path;
+                CoTaskMemFree(path);
+            }
+            result->Release();
+        }
+    }
+    dialog->Release();
+    return chosen;
+}
+
+std::wstring BrowseForIconFile(HWND owner) {
+    std::wstring chosen;
+    IFileDialog* dialog = nullptr;
+    if (FAILED(CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC,
+                                IID_PPV_ARGS(&dialog)))) {
+        return chosen;
+    }
+
+    COMDLG_FILTERSPEC filters[] = {
+        {L"Icons and images", L"*.ico;*.png;*.jpg;*.jpeg;*.bmp"},
+        {L"Programs and libraries", L"*.exe;*.dll"},
+        {L"All files", L"*.*"}};
+    dialog->SetFileTypes(ARRAYSIZE(filters), filters);
+
+    DWORD options = 0;
+    dialog->GetOptions(&options);
+    dialog->SetOptions(options | FOS_FORCEFILESYSTEM | FOS_FILEMUSTEXIST);
+
+    if (SUCCEEDED(dialog->Show(owner))) {
+        IShellItem* result = nullptr;
+        if (SUCCEEDED(dialog->GetResult(&result))) {
+            PWSTR path = nullptr;
+            if (SUCCEEDED(result->GetDisplayName(SIGDN_FILESYSPATH, &path))) {
+                chosen = path;
+                CoTaskMemFree(path);
+            }
+            result->Release();
+        }
+    }
+    dialog->Release();
+    return chosen;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Edit dialog
+
+// Passed to the edit window and written back in place when it is accepted.
+struct EditContext {
+    FolderStore::Entry entry;
+    // -1 when adding, otherwise the index being edited — so a path collision
+    // with the entry's own row is not treated as a duplicate.
+    int index = -1;
+    bool accepted = false;
+    HICON preview = nullptr;
+};
+
+std::wstring GetControlText(HWND hWnd, int id) {
+    HWND control = GetDlgItem(hWnd, id);
+    int length = GetWindowTextLengthW(control);
+    std::wstring text(length + 1, L'\0');
+    GetWindowTextW(control, text.data(), length + 1);
+    text.resize(length);
+    return Trim(text);
+}
+
+void RefreshPreview(HWND hWnd, EditContext* ctx) {
+    FolderStore::Entry probe;
+    probe.path = GetControlText(hWnd, kIdEditPath);
+    probe.icon = GetControlText(hWnd, kIdEditIcon);
+    if (ctx->preview) {
+        DestroyIcon(ctx->preview);
+    }
+    ctx->preview = probe.path.empty() ? nullptr : IconForEntry(probe, 32);
+    InvalidateRect(GetDlgItem(hWnd, kIdEditPreview), nullptr, TRUE);
+}
+
+LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
+                             LPARAM lParam) {
+    auto* ctx = (EditContext*)GetWindowLongPtrW(hWnd, GWLP_USERDATA);
+
+    switch (msg) {
+        case WM_CREATE: {
+            auto* create = (CREATESTRUCTW*)lParam;
+            ctx = (EditContext*)create->lpCreateParams;
+            SetWindowLongPtrW(hWnd, GWLP_USERDATA, (LONG_PTR)ctx);
+
+            HINSTANCE instance = GetCurrentModuleHandle();
+            struct Field {
+                PCWSTR label;
+                int editId;
+                int browseId;
+                PCWSTR browseText;
+                int y;
+            };
+            const Field fields[] = {
+                {L"Name", kIdEditName, 0, nullptr, 14},
+                {L"Folder", kIdEditPath, kIdEditBrowsePath, L"Browse...", 62},
+                {L"Icon", kIdEditIcon, kIdEditBrowseIcon, L"Browse...", 110},
+            };
+            for (const auto& f : fields) {
+                CreateWindowExW(0, L"STATIC", f.label, WS_CHILD | WS_VISIBLE,
+                                14, f.y, 300, 16, hWnd, nullptr, instance,
+                                nullptr);
+                int editWidth = f.browseId ? 300 : 386;
+                CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", L"",
+                                WS_CHILD | WS_VISIBLE | WS_TABSTOP |
+                                    ES_AUTOHSCROLL,
+                                14, f.y + 18, editWidth, 24, hWnd,
+                                (HMENU)(INT_PTR)f.editId, instance, nullptr);
+                if (f.browseId) {
+                    CreateWindowExW(0, L"BUTTON", f.browseText,
+                                    WS_CHILD | WS_VISIBLE | WS_TABSTOP |
+                                        BS_PUSHBUTTON,
+                                    322, f.y + 18, 78, 24, hWnd,
+                                    (HMENU)(INT_PTR)f.browseId, instance,
+                                    nullptr);
+                }
+            }
+
+            CreateWindowExW(0, L"STATIC",
+                            L"Emoji, an .ico / .png file, or a resource such "
+                            L"as C:\\Windows\\explorer.exe,0. Leave empty to "
+                            L"use the folder's own icon.",
+                            WS_CHILD | WS_VISIBLE, 14, 158, 386, 32, hWnd,
+                            nullptr, instance, nullptr);
+
+            // Pin state lives here rather than as a list button, so that what
+            // "unpinned" actually means — kept, not deleted — is spelled out
+            // right next to the switch.
+            CreateWindowExW(0, L"BUTTON", L"Pinned to the taskbar",
+                            WS_CHILD | WS_VISIBLE | WS_TABSTOP |
+                                BS_AUTOCHECKBOX,
+                            14, 198, 340, 22, hWnd,
+                            (HMENU)(INT_PTR)kIdEditPinned, instance, nullptr);
+            CreateWindowExW(0, L"STATIC",
+                            L"Unticked keeps this folder in the list but takes "
+                            L"its button off the taskbar. Nothing is deleted, "
+                            L"and the folder still cannot be added twice.",
+                            WS_CHILD | WS_VISIBLE, 32, 222, 322, 32, hWnd,
+                            (HMENU)(INT_PTR)kIdEditPinnedHint, instance,
+                            nullptr);
+
+            CreateWindowExW(0, L"STATIC", L"",
+                            WS_CHILD | WS_VISIBLE | SS_OWNERDRAW, 360, 196, 40,
+                            40, hWnd, (HMENU)(INT_PTR)kIdEditPreview, instance,
+                            nullptr);
+
+            CreateWindowExW(0, L"BUTTON", L"Save",
+                            WS_CHILD | WS_VISIBLE | WS_TABSTOP |
+                                BS_DEFPUSHBUTTON,
+                            222, 266, 86, 26, hWnd,
+                            (HMENU)(INT_PTR)kIdEditOk, instance, nullptr);
+            CreateWindowExW(0, L"BUTTON", L"Cancel",
+                            WS_CHILD | WS_VISIBLE | WS_TABSTOP |
+                                BS_PUSHBUTTON,
+                            314, 266, 86, 26, hWnd,
+                            (HMENU)(INT_PTR)kIdEditCancel, instance, nullptr);
+
+            SetDlgItemTextW(hWnd, kIdEditName, ctx->entry.name.c_str());
+            SetDlgItemTextW(hWnd, kIdEditPath, ctx->entry.path.c_str());
+            SetDlgItemTextW(hWnd, kIdEditIcon, ctx->entry.icon.c_str());
+            CheckDlgButton(hWnd, kIdEditPinned,
+                           ctx->entry.pinned ? BST_CHECKED : BST_UNCHECKED);
+            ApplyUiFont(hWnd);
+            RefreshPreview(hWnd, ctx);
+            return 0;
+        }
+
+        case WM_DRAWITEM: {
+            auto* dis = (LPDRAWITEMSTRUCT)lParam;
+            if (dis->CtlID == kIdEditPreview) {
+                FillRect(dis->hDC, &dis->rcItem,
+                         GetSysColorBrush(COLOR_BTNFACE));
+                if (ctx && ctx->preview) {
+                    DrawIconEx(dis->hDC, dis->rcItem.left + 4,
+                               dis->rcItem.top + 4, ctx->preview, 32, 32, 0,
+                               nullptr, DI_NORMAL);
+                } else if (ctx) {
+                    std::wstring icon = GetControlText(hWnd, kIdEditIcon);
+                    if (!icon.empty()) {
+                        SetBkMode(dis->hDC, TRANSPARENT);
+                        DrawTextW(dis->hDC, icon.c_str(), -1, &dis->rcItem,
+                                  DT_CENTER | DT_VCENTER | DT_SINGLELINE |
+                                      DT_NOPREFIX);
+                    }
+                }
+                return TRUE;
+            }
+            break;
+        }
+
+        case WM_COMMAND: {
+            int id = LOWORD(wParam);
+            if (id == kIdEditBrowsePath) {
+                std::wstring start =
+                    ExpandEnv(GetControlText(hWnd, kIdEditPath));
+                std::wstring picked = BrowseForFolder(hWnd, start);
+                if (!picked.empty()) {
+                    SetDlgItemTextW(hWnd, kIdEditPath, picked.c_str());
+                    // Fill a blank name and icon from the folder itself, the
+                    // same way an Explorer pin does.
+                    if (GetControlText(hWnd, kIdEditName).empty()) {
+                        size_t slash = picked.find_last_of(L"\\/");
+                        SetDlgItemTextW(hWnd, kIdEditName,
+                                        slash == std::wstring::npos
+                                            ? picked.c_str()
+                                            : picked.c_str() + slash + 1);
+                    }
+                    if (GetControlText(hWnd, kIdEditIcon).empty()) {
+                        SetDlgItemTextW(hWnd, kIdEditIcon,
+                                        ReadFolderCustomIcon(picked).c_str());
+                    }
+                    RefreshPreview(hWnd, ctx);
+                }
+            } else if (id == kIdEditBrowseIcon) {
+                std::wstring picked = BrowseForIconFile(hWnd);
+                if (!picked.empty()) {
+                    SetDlgItemTextW(hWnd, kIdEditIcon, picked.c_str());
+                    RefreshPreview(hWnd, ctx);
+                }
+            } else if ((id == kIdEditPath || id == kIdEditIcon) &&
+                       HIWORD(wParam) == EN_KILLFOCUS) {
+                RefreshPreview(hWnd, ctx);
+            } else if (id == kIdEditOk) {
+                std::wstring path = GetControlText(hWnd, kIdEditPath);
+                if (path.empty()) {
+                    MessageBoxW(hWnd, L"A folder path is required.",
+                                L"Taskbar Folders", MB_OK | MB_ICONWARNING);
+                    return 0;
+                }
+                // Same folder as another row would mean two buttons for one
+                // folder, which is also what blocks re-pinning a draft.
+                auto stored = FolderStore::Read();
+                int clash = FolderStore::IndexOfPath(stored, path);
+                if (clash >= 0 && clash != ctx->index) {
+                    MessageBoxW(hWnd,
+                                L"That folder is already in the list. Edit "
+                                L"the existing entry instead.",
+                                L"Taskbar Folders", MB_OK | MB_ICONWARNING);
+                    return 0;
+                }
+                ctx->entry.name = GetControlText(hWnd, kIdEditName);
+                ctx->entry.path = path;
+                ctx->entry.icon = GetControlText(hWnd, kIdEditIcon);
+                ctx->entry.pinned =
+                    IsDlgButtonChecked(hWnd, kIdEditPinned) == BST_CHECKED;
+                ctx->entry.fileId = GetDirFileId(ExpandEnv(path));
+                ctx->accepted = true;
+                DestroyWindow(hWnd);
+            } else if (id == kIdEditCancel) {
+                DestroyWindow(hWnd);
+            }
+            return 0;
+        }
+
+        case WM_CLOSE:
+            DestroyWindow(hWnd);
+            return 0;
+
+        case WM_DESTROY:
+            if (ctx && ctx->preview) {
+                DestroyIcon(ctx->preview);
+                ctx->preview = nullptr;
+            }
+            PostQuitMessage(0);
+            return 0;
+    }
+    return DefWindowProcW(hWnd, msg, wParam, lParam);
+}
+
+// Runs the edit window modally against `owner`, using a nested message loop
+// (there is no dialog resource to feed DialogBox). Returns true if saved.
+bool RunEditDialog(HWND owner, EditContext* ctx, PCWSTR title) {
+    HINSTANCE instance = GetCurrentModuleHandle();
+    if (!EnsureClass(kEditClassName, EditWndProc)) {
+        return false;
+    }
+
+    RECT rect{0, 0, 414, 306};
+    AdjustWindowRect(&rect, WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU, FALSE);
+    int width = rect.right - rect.left;
+    int height = rect.bottom - rect.top;
+
+    // Centre over the manager, then let CenterOnMonitor pull it back onto the
+    // work area of whichever monitor that lands on.
+    RECT ownerRect{};
+    GetWindowRect(owner, &ownerRect);
+    POINT ownerCenter{(ownerRect.left + ownerRect.right) / 2,
+                      (ownerRect.top + ownerRect.bottom) / 2};
+    POINT pos = CenterOnMonitor(ownerCenter, width, height);
+
+    HWND hWnd = CreateWindowExW(WS_EX_DLGMODALFRAME, kEditClassName, title,
+                                WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU, pos.x,
+                                pos.y, width, height, owner, nullptr, instance,
+                                ctx);
+    if (!hWnd) {
+        return false;
+    }
+
+    EnableWindow(owner, FALSE);
+    ShowWindow(hWnd, SW_SHOW);
+    SetFocus(GetDlgItem(hWnd, kIdEditName));
+
+    MSG msg;
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        if (!IsDialogMessageW(hWnd, &msg)) {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+    }
+
+    EnableWindow(owner, TRUE);
+    SetForegroundWindow(owner);
+    return ctx->accepted;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Main window
+
+void EditSelected(HWND hWnd) {
+    int index = SelectedIndex(hWnd);
+    if (index < 0) {
+        return;
+    }
+    EditContext ctx;
+    ctx.entry = g_rows[index];
+    ctx.index = index;
+    if (!RunEditDialog(hWnd, &ctx, L"Edit folder")) {
+        return;
+    }
+    auto stored = FolderStore::Read();
+    if (index < (int)stored.size()) {
+        stored[index] = ctx.entry;
+        CommitStore(hWnd, stored);
+    }
+}
+
+void AddNew(HWND hWnd) {
+    EditContext ctx;
+    ctx.entry.pinned = true;
+    if (!RunEditDialog(hWnd, &ctx, L"Add folder")) {
+        return;
+    }
+    auto stored = FolderStore::Read();
+    stored.push_back(ctx.entry);
+    CommitStore(hWnd, stored);
+}
+
+void RemoveSelected(HWND hWnd) {
+    int index = SelectedIndex(hWnd);
+    if (index < 0) {
+        return;
+    }
+    std::wstring name = g_rows[index].name.empty() ? g_rows[index].path
+                                                   : g_rows[index].name;
+    std::wstring prompt = L"Remove \"" + name +
+                          L"\" from the list?\n\nThe folder itself is not "
+                          L"touched — only this button. To keep the entry but "
+                          L"take it off the taskbar, use Unpin instead.";
+    if (MessageBoxW(hWnd, prompt.c_str(), L"Taskbar Folders",
+                    MB_OKCANCEL | MB_ICONQUESTION) != IDOK) {
+        return;
+    }
+    auto stored = FolderStore::Read();
+    if (index < (int)stored.size()) {
+        stored.erase(stored.begin() + index);
+        CommitStore(hWnd, stored);
+    }
+}
+
+
+// Moves a row to a new position, taking the rest of the list with it, rather
+// than swapping the two ends — dragging row 0 to the bottom should slide
+// everything else up one, not trade places with the last row.
+void MoveRow(HWND hWnd, int from, int to) {
+    auto stored = FolderStore::Read();
+    if (from < 0 || to < 0 || from >= (int)stored.size() ||
+        to >= (int)stored.size() || from == to) {
+        return;
+    }
+    FolderStore::Entry moved = stored[from];
+    stored.erase(stored.begin() + from);
+    stored.insert(stored.begin() + to, std::move(moved));
+    FolderStore::Write(stored);
+    if (!g_unloading) {
+        ReloadAndRefreshUI();
+    }
+    PopulateList(hWnd);
+    SendMessageW(GetDlgItem(hWnd, kIdList), LB_SETCURSEL, to, 0);
+}
+
+void OpenSelected(HWND hWnd) {
+    int index = SelectedIndex(hWnd);
+    if (index < 0) {
+        return;
+    }
+    std::wstring target = ResolveFolderPath(ExpandEnv(g_rows[index].path));
+    LaunchPath(target.empty() ? ExpandEnv(g_rows[index].path) : target);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Drag to reorder
+//
+// A stock listbox has no reordering of its own, so the drag is tracked by
+// subclassing it: press picks up the row under the cursor, motion draws an
+// insertion line, release commits the move. Kept on the listbox rather than
+// the parent so the mouse capture and the hit testing share one coordinate
+// space.
+
+WNDPROC g_listOriginalProc = nullptr;
+int g_dragFrom = -1;      // Row being dragged, -1 when not dragging.
+int g_dragTo = -1;        // Insertion point currently drawn.
+bool g_dragArmed = false; // Button down, but not yet past the drag threshold.
+POINT g_dragStart{};
+
+// Insertion index for a cursor position: the gap the row would drop into, so
+// the value can legitimately equal the row count (drop at the end).
+int InsertIndexAt(HWND list, POINT pt) {
+    int top = (int)SendMessageW(list, LB_GETTOPINDEX, 0, 0);
+    RECT client{};
+    GetClientRect(list, &client);
+    if (pt.y < 0) {
+        return top;
+    }
+    int offset = (pt.y + kRowHeight / 2) / kRowHeight;
+    int index = top + offset;
+    int count = (int)g_rows.size();
+    return index < 0 ? 0 : (index > count ? count : index);
+}
+
+void DrawInsertionLine(HWND list, int index) {
+    if (index < 0) {
+        return;
+    }
+    int top = (int)SendMessageW(list, LB_GETTOPINDEX, 0, 0);
+    RECT client{};
+    GetClientRect(list, &client);
+    int y = (index - top) * kRowHeight;
+    if (y < 0) {
+        return;
+    }
+    // A drop at the very end can land a row-height past the last painted row;
+    // pull it back inside so it is still visible.
+    if (y > client.bottom - 2) {
+        y = client.bottom - 2;
+    }
+    HDC dc = GetDC(list);
+    // R2_NOT so the same call erases it again, no repaint needed.
+    int oldRop = SetROP2(dc, R2_NOT);
+    HPEN pen = CreatePen(PS_SOLID, 2, RGB(0, 0, 0));
+    HGDIOBJ oldPen = SelectObject(dc, pen);
+    MoveToEx(dc, client.left + 2, y, nullptr);
+    LineTo(dc, client.right - 2, y);
+    SelectObject(dc, oldPen);
+    DeleteObject(pen);
+    SetROP2(dc, oldRop);
+    ReleaseDC(list, dc);
+}
+
+void EndDrag(HWND list, bool commit) {
+    if (g_dragTo >= 0) {
+        DrawInsertionLine(list, g_dragTo);  // Erase.
+    }
+    int from = g_dragFrom;
+    int to = g_dragTo;
+    // Cleared before releasing capture: that sends WM_CAPTURECHANGED straight
+    // back here, and the -1 is what stops it recursing.
+    g_dragFrom = -1;
+    g_dragTo = -1;
+    g_dragArmed = false;
+    if (GetCapture() == list) {
+        ReleaseCapture();
+    }
+    if (!commit || from < 0 || to < 0) {
+        return;
+    }
+    // The insertion index counts gaps, so dropping below the dragged row
+    // shifts the target down by the row that is about to be removed.
+    if (to > from) {
+        to--;
+    }
+    if (to != from) {
+        MoveRow(GetParent(list), from, to);
+    }
+}
+
+LRESULT CALLBACK ListSubclassProc(HWND list, UINT msg, WPARAM wParam,
+                                  LPARAM lParam) {
+    switch (msg) {
+        // Handled here in full, never forwarded. A stock listbox runs its own
+        // nested modal loop from WM_LBUTTONDOWN to track drag-selection, and
+        // that loop swallows every WM_MOUSEMOVE and WM_LBUTTONUP until the
+        // button comes back up — so a drag started below would never see
+        // another message. Selecting the row by hand costs little and keeps
+        // the message flow ours.
+        case WM_LBUTTONDOWN: {
+            POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+            int top = (int)SendMessageW(list, LB_GETTOPINDEX, 0, 0);
+            int row = top + pt.y / kRowHeight;
+            if (pt.y < 0 || row < 0 || row >= (int)g_rows.size()) {
+                return 0;
+            }
+            SetFocus(list);
+            if ((int)SendMessageW(list, LB_GETCURSEL, 0, 0) != row) {
+                SendMessageW(list, LB_SETCURSEL, row, 0);
+                SendMessageW(GetParent(list), WM_COMMAND,
+                             MAKEWPARAM(kIdList, LBN_SELCHANGE),
+                             (LPARAM)list);
+            }
+            g_dragArmed = true;
+            g_dragStart = pt;
+            SetCapture(list);
+            return 0;
+        }
+
+        // Also ours, for the same reason — and the parent still needs the
+        // notification to open the folder.
+        case WM_LBUTTONDBLCLK: {
+            POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+            int top = (int)SendMessageW(list, LB_GETTOPINDEX, 0, 0);
+            int row = top + pt.y / kRowHeight;
+            if (pt.y >= 0 && row >= 0 && row < (int)g_rows.size()) {
+                SendMessageW(list, LB_SETCURSEL, row, 0);
+                SendMessageW(GetParent(list), WM_COMMAND,
+                             MAKEWPARAM(kIdList, LBN_DBLCLK), (LPARAM)list);
+            }
+            return 0;
+        }
+
+        case WM_MOUSEMOVE: {
+            POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+            if (g_dragArmed && g_dragFrom < 0) {
+                // Only start a drag once the pointer has actually travelled,
+                // so an ordinary click still just selects. Capture is already
+                // held from WM_LBUTTONDOWN.
+                if (labs(pt.y - g_dragStart.y) >= GetSystemMetrics(SM_CYDRAG) ||
+                    labs(pt.x - g_dragStart.x) >= GetSystemMetrics(SM_CXDRAG)) {
+                    g_dragFrom =
+                        (int)SendMessageW(list, LB_GETCURSEL, 0, 0);
+                    if (g_dragFrom < 0 ||
+                        g_dragFrom >= (int)g_rows.size()) {
+                        g_dragFrom = -1;
+                        g_dragArmed = false;
+                    } else {
+                        SetCursor(LoadCursorW(nullptr, IDC_SIZENS));
+                    }
+                }
+            }
+            if (g_dragFrom >= 0) {
+                int target = InsertIndexAt(list, pt);
+                if (target != g_dragTo) {
+                    if (g_dragTo >= 0) {
+                        DrawInsertionLine(list, g_dragTo);  // Erase old.
+                    }
+                    g_dragTo = target;
+                    DrawInsertionLine(list, g_dragTo);
+                }
+                SetCursor(LoadCursorW(nullptr, IDC_SIZENS));
+                return 0;
+            }
+            break;
+        }
+
+        case WM_LBUTTONUP:
+            if (g_dragFrom >= 0) {
+                EndDrag(list, true);
+            } else {
+                // Armed but never dragged: an ordinary click, already handled
+                // on the way down. Just let the capture go.
+                g_dragArmed = false;
+                if (GetCapture() == list) {
+                    ReleaseCapture();
+                }
+            }
+            return 0;
+
+        // Losing capture (Alt+Tab, a message box) has to abandon the drag, or
+        // the insertion line is left painted with no way to clear it.
+        case WM_CAPTURECHANGED:
+            if (g_dragFrom >= 0) {
+                EndDrag(list, false);
+            }
+            g_dragArmed = false;
+            break;
+
+        case WM_KEYDOWN:
+            if (wParam == VK_ESCAPE && g_dragFrom >= 0) {
+                EndDrag(list, false);
+                return 0;
+            }
+            break;
+
+        case WM_DESTROY:
+            g_dragFrom = -1;
+            g_dragTo = -1;
+            g_dragArmed = false;
+            break;
+    }
+    return CallWindowProcW(g_listOriginalProc, list, msg, wParam, lParam);
+}
+
+LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    switch (msg) {
+        case WM_CREATE: {
+            HINSTANCE instance = GetCurrentModuleHandle();
+            HWND list = CreateWindowExW(
+                WS_EX_CLIENTEDGE, L"LISTBOX", nullptr,
+                WS_CHILD | WS_VISIBLE | WS_VSCROLL | WS_TABSTOP | LBS_NOTIFY |
+                    LBS_OWNERDRAWFIXED,
+                12, 12, 452, 300, hWnd, (HMENU)(INT_PTR)kIdList, instance,
+                nullptr);
+            g_listOriginalProc = (WNDPROC)SetWindowLongPtrW(
+                list, GWLP_WNDPROC, (LONG_PTR)ListSubclassProc);
+
+            struct ButtonSpec {
+                int id;
+                PCWSTR text;
+                int x;
+                int y;
+                int width;
+            };
+            const ButtonSpec buttons[] = {
+                {kIdAdd, L"Add...", 12, 324, 76},
+                {kIdEdit, L"Edit...", 94, 324, 76},
+                {kIdRemove, L"Remove", 176, 324, 76},
+                {kIdClose, L"Close", 388, 324, 76},
+            };
+            for (const auto& b : buttons) {
+                CreateWindowExW(0, L"BUTTON", b.text,
+                                WS_CHILD | WS_VISIBLE | WS_TABSTOP |
+                                    BS_PUSHBUTTON,
+                                b.x, b.y, b.width, 26, hWnd,
+                                (HMENU)(INT_PTR)b.id, instance, nullptr);
+            }
+
+            CreateWindowExW(0, L"STATIC", L"", WS_CHILD | WS_VISIBLE, 12, 360,
+                            452, 32, hWnd, (HMENU)(INT_PTR)kIdHint, instance,
+                            nullptr);
+
+            ApplyUiFont(hWnd);
+            PopulateList(hWnd);
+            return 0;
+        }
+
+        case WM_MEASUREITEM: {
+            auto* mis = (LPMEASUREITEMSTRUCT)lParam;
+            if (mis->CtlID == kIdList) {
+                mis->itemHeight = kRowHeight;
+                return TRUE;
+            }
+            break;
+        }
+
+        case WM_DRAWITEM: {
+            auto* dis = (LPDRAWITEMSTRUCT)lParam;
+            if (dis->CtlID == kIdList) {
+                DrawRow(dis);
+                return TRUE;
+            }
+            break;
+        }
+
+        case WM_COMMAND: {
+            int id = LOWORD(wParam);
+            int code = HIWORD(wParam);
+            if (id == kIdAdd) {
+                AddNew(hWnd);
+            } else if (id == kIdEdit) {
+                EditSelected(hWnd);
+            } else if (id == kIdRemove) {
+                RemoveSelected(hWnd);
+            } else if (id == kIdClose) {
+                DestroyWindow(hWnd);
+            } else if (id == kIdList && code == LBN_DBLCLK) {
+                OpenSelected(hWnd);
+            }
+            return 0;
+        }
+
+        // Posted when the folder list changed underneath an open window.
+        case WM_APP:
+            PopulateList(hWnd);
+            return 0;
+
+        case WM_CLOSE:
+            DestroyWindow(hWnd);
+            return 0;
+
+        case WM_DESTROY:
+            // Unsubclass before the listbox goes away, so a reopened window
+            // does not chain its proc onto a stale one.
+            if (g_listOriginalProc) {
+                SetWindowLongPtrW(GetDlgItem(hWnd, kIdList), GWLP_WNDPROC,
+                                  (LONG_PTR)g_listOriginalProc);
+                g_listOriginalProc = nullptr;
+            }
+            FreeRowIcons();
+            g_wnd = nullptr;
+            PostQuitMessage(0);
+            return 0;
+    }
+    return DefWindowProcW(hWnd, msg, wParam, lParam);
+}
+
+// Runs the whole window — class, creation, message loop — on one dedicated
+// thread, so nothing here can stall the taskbar UI thread that opened it.
+// `anchor` is where the user invoked it from, captured before the thread
+// started, so the window lands on the monitor they were working on rather
+// than wherever Windows would have cascaded it.
+void ThreadMain(POINT anchor) {
+    // Shell icon extraction and the folder picker both need an apartment.
+    HRESULT comInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+
+    HINSTANCE instance = GetCurrentModuleHandle();
+    if (!EnsureClass(kClassName, WndProc)) {
+        if (SUCCEEDED(comInit)) {
+            CoUninitialize();
+        }
+        g_active = false;
+        return;
+    }
+
+    RECT rect{0, 0, 476, 400};
+    AdjustWindowRect(&rect, WS_OVERLAPPEDWINDOW, FALSE);
+    int width = rect.right - rect.left;
+    int height = rect.bottom - rect.top;
+    POINT pos = CenterOnMonitor(anchor, width, height);
+    HWND hWnd = CreateWindowExW(
+        WS_EX_APPWINDOW, kClassName, L"Taskbar Folders",
+        WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX, pos.x, pos.y,
+        width, height, nullptr, nullptr, instance, nullptr);
+    if (!hWnd) {
+        Wh_Log(L"Manager: CreateWindowExW failed (error %u)", GetLastError());
+        if (SUCCEEDED(comInit)) {
+            CoUninitialize();
+        }
+        g_active = false;
+        return;
+    }
+
+    g_wnd = hWnd;
+    ShowWindow(hWnd, SW_SHOW);
+    SetForegroundWindow(hWnd);
+
+    MSG msg;
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+        if (!IsDialogMessageW(hWnd, &msg)) {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+    }
+
+    g_wnd = nullptr;
+    if (SUCCEEDED(comInit)) {
+        CoUninitialize();
+    }
+    g_active = false;
+}
+
+// Brings an already-open window forward instead of opening a second one.
+void Open() {
+    if (HWND existing = g_wnd.load()) {
+        SetForegroundWindow(existing);
+        return;
+    }
+    if (g_unloading || g_active.exchange(true)) {
+        return;
+    }
+    // Read on the caller's thread, while the click that opened this is still
+    // where it happened, to pick the monitor the user is actually looking at.
+    POINT anchor{};
+    if (!GetCursorPos(&anchor)) {
+        anchor = POINT{0, 0};
+    }
+    std::thread(ThreadMain, anchor).detach();
+}
+
+// Asks the window to close and waits for its thread to unwind, so the DLL is
+// not unloaded out from under a live message loop.
+void CloseAndWait() {
+    if (HWND existing = g_wnd.load()) {
+        PostMessageW(existing, WM_CLOSE, 0, 0);
+    }
+    for (int i = 0; g_active && i < 250; i++) {
+        Sleep(20);
+    }
+    if (g_active) {
+        Wh_Log(L"Uninit: folder manager window still open after wait");
+    }
+}
+
+}  // namespace FolderManager
+
+// Quick scale-down-and-back on the button content, matching the feedback the
+// Win11 taskbar gives its own pinned buttons when they are activated.
+constexpr int kPressBounceMs = 250;
+constexpr float kPressBounceScale = 0.86f;
+
+void PlayPressBounce(UIElement const& element) {
+    auto target = element.try_as<FrameworkElement>();
+    if (!target) {
+        return;
+    }
+    try {
+        auto visual = ElementCompositionPreview::GetElementVisual(target);
+        visual.CenterPoint({(float)target.ActualWidth() / 2.0f,
+                            (float)target.ActualHeight() / 2.0f, 0.0f});
+        auto compositor = visual.Compositor();
+        auto easing = compositor.CreateCubicBezierEasingFunction({0.3f, 0.0f},
+                                                                 {0.2f, 1.0f});
+        auto anim = compositor.CreateVector3KeyFrameAnimation();
+        anim.InsertKeyFrame(0.0f, {1.0f, 1.0f, 1.0f});
+        anim.InsertKeyFrame(0.35f,
+                            {kPressBounceScale, kPressBounceScale, 1.0f},
+                            easing);
+        anim.InsertKeyFrame(1.0f, {1.0f, 1.0f, 1.0f}, easing);
+        anim.Duration(std::chrono::milliseconds(kPressBounceMs));
+        visual.StartAnimation(L"Scale", anim);
+    } catch (...) {
+    }
+}
+
+// The open right-click flyout, so teardown can close it before the lambdas
+// behind its items are unmapped.
+MenuFlyout g_buttonMenuFlyout{nullptr};
+
+FontIcon MakeMenuGlyph(const wchar_t* glyph) {
+    FontIcon icon;
+    icon.FontFamily(FontFamily(L"Segoe Fluent Icons"));
+    icon.FontSize(16);
+    icon.Glyph(glyph);
+    return icon;
+}
+
+// Right-click on a taskbar folder button: unpin it, or open the manager.
+// A XAML MenuFlyout rather than TrackPopupMenuEx, so the menu picks up the
+// system's Win11 menu styling (rounded, acrylic, icon column) instead of the
+// classic Win32 look.
+// Unpinning keeps the entry as a draft rather than deleting it, so its name
+// and icon survive and the folder can be pinned again later without being
+// set up from scratch. Deleting outright is a manager-window action.
+void OnButtonRightClicked(int folderIndex, Button const& button) {
+    if (g_unloading || !button) {
+        return;
+    }
+    std::wstring path = FolderPathForButton(folderIndex);
+    if (path.empty()) {
+        return;
+    }
+
+    // Right-click dismisses the hover tray, like right-clicking any other
+    // taskbar button closes its preview — including a delayed open that has
+    // not fired yet.
+    OnPointerExitedButton();
+    CloseChain();
+
+    if (auto content = button.Content().try_as<Panel>()) {
+        // Bounce the icon layer only; the hover highlight stays put.
+        if (content.Children().Size() > 1) {
+            PlayPressBounce(content.Children().GetAt(1));
+        }
+    }
+
+    try {
+        MenuFlyout flyout;
+        // The taskbar XAML island is only a taskbar tall — without this the
+        // menu is clipped to it instead of getting its own popup window.
+        flyout.ShouldConstrainToRootBounds(false);
+        flyout.Placement(Primitives::FlyoutPlacementMode::Top);
+
+        MenuFlyoutItem unpin;
+        unpin.Text(L"Unpin from taskbar");
+        unpin.Icon(MakeMenuGlyph(L""));  // unpin
+        unpin.Click([path](winrt::Windows::Foundation::IInspectable const&,
+                           RoutedEventArgs const&) {
+            if (g_unloading) {
+                return;
+            }
+            // Keeps the entry as a draft rather than forgetting it, so its
+            // name and icon survive and it can be pinned again from the
+            // manager.
+            RemovePinnedFolder(path);
+            ReloadAndRefreshUI();
+        });
+
+        MenuFlyoutItem manage;
+        manage.Text(L"Manage folders...");
+        manage.Icon(MakeMenuGlyph(L""));  // folder
+        manage.Click([](winrt::Windows::Foundation::IInspectable const&,
+                        RoutedEventArgs const&) {
+            if (g_unloading) {
+                return;
+            }
+            FolderManager::Open();
+        });
+
+        flyout.Items().Append(unpin);
+        flyout.Items().Append(manage);
+        flyout.Closed([](winrt::Windows::Foundation::IInspectable const&,
+                         winrt::Windows::Foundation::IInspectable const&) {
+            g_buttonMenuFlyout = nullptr;
+        });
+
+        g_buttonMenuFlyout = flyout;
+        flyout.ShowAt(button);
+    } catch (...) {
+        g_buttonMenuFlyout = nullptr;
+    }
+}
+
+Grid BuildHostGrid(TaskbarHost* host) {
+    Grid hostGrid;
+    hostGrid.Name(kHostGridName);
+    hostGrid.HorizontalAlignment(HorizontalAlignment::Left);
+    hostGrid.VerticalAlignment(VerticalAlignment::Center);
+    hostGrid.Height(host->buttonHeight);
+
+    // Horizontal position lives here, not in Margin — see
+    // AnimateHostGridLeftTo for why Margin caused a layout feedback loop.
+    TranslateTransform translate;
+    hostGrid.RenderTransform(translate);
+    host->hostTranslate = translate;
+    host->slideStoryboard = nullptr;
+    host->currentLeft = 0.0;
+    host->slideStartTick = 0;
+    host->slideEndTick = 0;
+    host->hasPlaced = false;
+    host->slideCauseTick = 0;
+    host->slideCauseIsClose = false;
+
+    host->buttonStates.clear();
+
+    // Snapshot under the mutex — ResolvePendingFolderEntries / LoadFolders may
+    // mutate g_settings.folders from another thread while we build UI.
+    std::vector<FolderEntry> folders;
+    {
+        std::lock_guard<std::mutex> lock(g_foldersMutex);
+        folders = g_settings.folders;
+    }
+
+    for (size_t i = 0; i < folders.size(); i++) {
+        const auto& entry = folders[i];
+
+        ColumnDefinition column;
+        column.Width({1.0, GridUnitType::Auto});
+        hostGrid.ColumnDefinitions().Append(column);
+
+        Button button;
+        button.Name(L"FolderHoverTrayButton_" + winrt::to_hstring((int)i));
+        button.Width(host->buttonWidth);
+        button.Height(host->buttonHeight);
+        ApplyNativeButtonStyle(button);
+
+        ButtonState state;
+        state.button = button;
+        state.folderIndex = (int)i;
+        state.iconGeneration =
+            g_buttonIconGeneration.fetch_add(1, std::memory_order_relaxed);
+
+        bool dark = IsDarkTheme();
+        state.highlightHoverBrush = MakeHighlightBrush(dark, /*pressed=*/false);
+        state.highlightPressedBrush =
+            MakeHighlightBrush(dark, /*pressed=*/true);
+
+        Border highlight;
+        double highlightExtent =
+            HighlightExtent(host->buttonWidth, host->buttonHeight);
+        highlight.Width(highlightExtent);
+        highlight.Height(highlightExtent);
+        highlight.HorizontalAlignment(HorizontalAlignment::Center);
+        highlight.VerticalAlignment(VerticalAlignment::Center);
+        highlight.CornerRadius({kHighlightCornerRadius, kHighlightCornerRadius,
+                                 kHighlightCornerRadius, kHighlightCornerRadius});
+        // Fill only, no rim — the shell's own icon highlight has no stroke.
+        highlight.Background(state.highlightHoverBrush);
+        highlight.IsHitTestVisible(false);
+        // Hidden until hover. Set on the composition visual, not the XAML
+        // Opacity property, so FadeHighlight's animation isn't multiplied
+        // against a zero on the element itself.
+        try {
+            ElementCompositionPreview::GetElementVisual(highlight).Opacity(
+                0.0f);
+        } catch (...) {
+            highlight.Opacity(0.0);
+        }
+        state.highlightBorder = highlight;
+
+        Grid content;
+        content.Children().Append(highlight);
+        content.Children().Append(MakeButtonContent(
+            entry, host->buttonHeight, (int)i, host->hwnd,
+            state.iconGeneration));
+        button.Content(content);
+        state.contentGrid = content;
+
+        // No taskbar-button tooltip; the folder name is shown in the hover
+        // grid.
+        ToolTipService::SetToolTip(button, nullptr);
+
+        Grid::SetColumn(button, (int)i);
+        hostGrid.Children().Append(button);
+
+        int folderIndex = (int)i;
+        HWND taskbarWnd = host->hwnd;
+        state.clickToken = button.Click(
+            [folderIndex](winrt::Windows::Foundation::IInspectable const&,
+                          RoutedEventArgs const&) {
+                OnButtonClicked(folderIndex);
+            });
+        Border highlightRef = highlight;
+        Brush hoverBrushRef = state.highlightHoverBrush;
+        Brush pressedBrushRef = state.highlightPressedBrush;
+        state.enterToken = button.PointerEntered(
+            [folderIndex, taskbarWnd, highlightRef, hoverBrushRef](
+                winrt::Windows::Foundation::IInspectable const& sender,
+                winrt::Windows::UI::Xaml::Input::
+                    PointerRoutedEventArgs const&) {
+                try {
+                    highlightRef.Background(hoverBrushRef);
+                } catch (...) {
+                }
+                FadeHighlight(highlightRef, 1.0f, kHighlightFadeInMs);
+                if (auto button = sender.try_as<Button>()) {
+                    OnPointerEnteredButton(folderIndex, button, taskbarWnd);
+                }
+            });
+        state.exitToken = button.PointerExited(
+            [highlightRef](
+                winrt::Windows::Foundation::IInspectable const&,
+                winrt::Windows::UI::Xaml::Input::
+                    PointerRoutedEventArgs const&) {
+                FadeHighlight(highlightRef, 0.0f, kHighlightFadeOutMs);
+                OnPointerExitedButton();
+            });
+        // Press/release only re-tint; the highlight is already faded in.
+        state.pressedToken = button.PointerPressed(
+            [highlightRef, pressedBrushRef](
+                winrt::Windows::Foundation::IInspectable const&,
+                winrt::Windows::UI::Xaml::Input::
+                    PointerRoutedEventArgs const&) {
+                try {
+                    highlightRef.Background(pressedBrushRef);
+                } catch (...) {
+                }
+            });
+        state.releasedToken = button.PointerReleased(
+            [highlightRef, hoverBrushRef](
+                winrt::Windows::Foundation::IInspectable const&,
+                winrt::Windows::UI::Xaml::Input::
+                    PointerRoutedEventArgs const&) {
+                try {
+                    highlightRef.Background(hoverBrushRef);
+                } catch (...) {
+                }
+            });
+        state.rightTapToken = button.RightTapped(
+            [folderIndex](
+                winrt::Windows::Foundation::IInspectable const& sender,
+                winrt::Windows::UI::Xaml::Input::RightTappedRoutedEventArgs const&
+                    args) {
+                // Unpin/hide is offered for every folder button now, regardless
+                // of whether it came from Settings or the Explorer pin action.
+                args.Handled(true);
+                OnButtonRightClicked(folderIndex, sender.try_as<Button>());
+            });
+
+        host->buttonStates.push_back(std::move(state));
+    }
+
+    hostGrid.Width(DesiredHostWidth(host));
+    return hostGrid;
+}
+
+void ClearButtonState(TaskbarHost* host) {
+    if (!host) {
+        return;
+    }
+    // Its item handlers live in this DLL — never leave it open across a
+    // rebuild or an unload.
+    if (g_buttonMenuFlyout) {
+        try {
+            g_buttonMenuFlyout.Hide();
+        } catch (...) {
+        }
+        g_buttonMenuFlyout = nullptr;
+    }
+    for (auto& state : host->buttonStates) {
+        if (!state.button) {
+            continue;
+        }
+        try {
+            if (state.clickToken.value) {
+                state.button.Click(state.clickToken);
+            }
+            if (state.enterToken.value) {
+                state.button.PointerEntered(state.enterToken);
+            }
+            if (state.exitToken.value) {
+                state.button.PointerExited(state.exitToken);
+            }
+            if (state.pressedToken.value) {
+                state.button.PointerPressed(state.pressedToken);
+            }
+            if (state.releasedToken.value) {
+                state.button.PointerReleased(state.releasedToken);
+            }
+            if (state.rightTapToken.value) {
+                state.button.RightTapped(state.rightTapToken);
+            }
+            ToolTipService::SetToolTip(state.button, nullptr);
+            state.button.Content(nullptr);
+        } catch (...) {
+        }
+    }
+    host->buttonStates.clear();
+}
+
+void RemoveHostGrid(TaskbarHost* host) {
+    if (!host) {
+        return;
+    }
+
+    if (host->trackedRootGrid && host->layoutUpdatedToken.value) {
+        try {
+            host->trackedRootGrid.LayoutUpdated(host->layoutUpdatedToken);
+        } catch (...) {
+        }
+    }
+    host->layoutUpdatedToken = {};
+
+    RestoreAnchorMargin(host);
+    ClearButtonState(host);
+
+    if (host->trackedRootGrid) {
+        try {
+            auto children = host->trackedRootGrid.Children();
+            for (int i = (int)children.Size() - 1; i >= 0; i--) {
+                auto child = children.GetAt(i).try_as<FrameworkElement>();
+                if (child && child.Name() == kHostGridName) {
+                    children.RemoveAt(i);
+                }
+            }
+        } catch (...) {
+        }
+    }
+
+    host->hostGrid = nullptr;
+    host->trackedRootGrid = nullptr;
+    host->cachedRepeater = nullptr;
+}
+
+void RemoveAllHostGrids() {
+    if (!g_taskbarHosts) {
+        g_injectionLive = false;
+        return;
+    }
+    for (auto& host : *g_taskbarHosts) {
+        RemoveHostGrid(host.get());
+    }
+    g_taskbarHosts->clear();
+    g_injectionLive = false;
+}
+
+// Runs on every layout pass, so every branch is guarded by a tolerance check to
+// avoid feeding layout back into itself.
+void OnRootGridLayoutUpdated(TaskbarHost* host) {
+    if (g_unloading || !host || !host->hostGrid || !host->trackedRootGrid) {
+        return;
+    }
+
+    try {
+        FrameworkElement repeater = host->cachedRepeater;
+        bool repeaterLooksDead = false;
+        try {
+            repeaterLooksDead = !repeater || repeater.ActualWidth() <= 1.0;
+        } catch (...) {
+            repeaterLooksDead = true;
+        }
+        if (repeaterLooksDead) {
+            repeater = FindTaskbarRepeater(host->trackedRootGrid);
+            host->cachedRepeater = repeater;
+        }
+        if (!repeater) {
+            return;
+        }
+
+        ULONGLONG now = GetTickCount64();
+
+        if (now - host->lastButtonSizeTick > 250) {
+            host->lastButtonSizeTick = now;
+            double previousWidth = host->buttonWidth;
+            double previousHeight = host->buttonHeight;
+            UpdateButtonSizeFromTaskbar(repeater, &host->buttonWidth,
+                                        &host->buttonHeight);
+
+            if (std::abs(previousWidth - host->buttonWidth) > 0.5 ||
+                std::abs(previousHeight - host->buttonHeight) > 0.5) {
+                double highlightExtent =
+                    HighlightExtent(host->buttonWidth, host->buttonHeight);
+                for (auto& state : host->buttonStates) {
+                    if (state.button) {
+                        state.button.Width(host->buttonWidth);
+                        state.button.Height(host->buttonHeight);
+                    }
+                    // The highlight is explicitly sized, so it does not
+                    // follow the button on its own.
+                    if (state.highlightBorder) {
+                        state.highlightBorder.Width(highlightExtent);
+                        state.highlightBorder.Height(highlightExtent);
+                    }
+                }
+                host->hostGrid.Height(host->buttonHeight);
+                host->hostGrid.Width(DesiredHostWidth(host));
+            }
+        }
+
+        // ActualWidth alone is a bad liveness check: Windows shrinks a
+        // closing button's width toward 0 as part of its own close
+        // animation, which isn't the anchor going away. Test detachment
+        // from the tree instead so a closing-but-still-present button
+        // doesn't trigger a needless re-resolve (and the churn/flicker
+        // that comes with it) on every window close.
+        bool anchorLooksDead = !host->anchor || !host->anchor.Parent();
+        if (anchorLooksDead || now - host->lastAnchorResolveTick > 250) {
+            host->lastAnchorResolveTick = now;
+            if (auto resolved =
+                    ResolveAnchor(repeater, host->trackedRootGrid)) {
+                AdoptAnchor(host, resolved);
+            }
+        }
+
+        if (!host->anchor || !host->hasAnchorOriginalMargin) {
+            return;
+        }
+
+        bool before = g_settings.position != L"afterApps";
+        double desiredGap =
+            DesiredHostWidth(host) + g_settings.gapBefore + g_settings.gapAfter;
+
+        auto currentMargin = host->anchor.Margin();
+        auto target = host->anchorOriginalMargin;
+        bool marginChanged = false;
+        if (before) {
+            target.Left = host->anchorOriginalMargin.Left + desiredGap;
+            if (std::abs(currentMargin.Left - target.Left) > 1.0) {
+                host->anchor.Margin(target);
+                marginChanged = true;
+            }
+        } else {
+            target.Right = host->anchorOriginalMargin.Right + desiredGap;
+            if (std::abs(currentMargin.Right - target.Right) > 1.0) {
+                host->anchor.Margin(target);
+                marginChanged = true;
+            }
+        }
+
+        // TransformToVisual below still reads the pre-change position on
+        // this pass (the margin write hasn't been laid out yet), so
+        // computing hostGrid's position now would jump it a full gap-width
+        // onto the neighbouring icon for one frame. The margin write itself
+        // queues another LayoutUpdated; let that pass place hostGrid once
+        // the anchor has actually moved.
+        if (marginChanged) {
+            return;
+        }
+
+        auto point = host->anchor.TransformToVisual(host->trackedRootGrid)
+                         .TransformPoint({0, 0});
+
+        double left;
+        if (before) {
+            left = point.X - desiredGap + g_settings.gapBefore;
+        } else {
+            left = point.X + host->anchor.ActualWidth() + g_settings.gapBefore;
+        }
+
+        AnimateHostGridLeftTo(host, left);
+    } catch (...) {
+        // A XAML call threw, most likely the anchor was recycled out from
+        // under us mid-access. cachedRepeater is the only thing actually
+        // stale here; drop just that and let the next pass re-resolve the
+        // repeater (and, if the anchor really is gone, ResolveAnchor will
+        // pick a new one on the anchorLooksDead branch above). Restoring
+        // the anchor's margin here would be racing an anchor that's still
+        // alive, and if that restore itself no-ops or throws, the next
+        // AdoptAnchor snapshots the still-widened margin as "original",
+        // doubling the gap permanently.
+        host->cachedRepeater = nullptr;
+    }
+}
+
+bool InjectHostGridForTaskbar(HWND taskbarWnd) {
+    if (!taskbarWnd || g_settings.folders.empty()) {
+        return false;
+    }
+
+    auto xamlRoot = GetTaskbarXamlRoot(taskbarWnd);
+    if (!xamlRoot) {
+        Wh_Log(L"No taskbar XamlRoot yet for %p", taskbarWnd);
+        return false;
+    }
+
+    auto root = xamlRoot.Content().try_as<FrameworkElement>();
+    if (!root) {
+        return false;
+    }
+
+    auto rootGrid = FindTaskbarRootGrid(root);
+    if (!rootGrid) {
+        Wh_Log(L"Taskbar RootGrid not found yet for %p", taskbarWnd);
+        return false;
+    }
+
+    auto repeater = FindTaskbarRepeater(rootGrid);
+    if (!repeater) {
+        Wh_Log(L"TaskbarFrameRepeater not found yet for %p", taskbarWnd);
+        return false;
+    }
+
+    // Leave a seated host alone on retry; only rebuild when the taskbar root
+    // was replaced (Explorer rebuild) or the host grid was detached.
+    if (auto* existing = FindTaskbarHost(taskbarWnd)) {
+        bool stillLive = false;
+        try {
+            stillLive = existing->trackedRootGrid == rootGrid &&
+                        existing->hostGrid && existing->hostGrid.Parent();
+        } catch (...) {
+            stillLive = false;
+        }
+        if (stillLive) {
+            return true;
+        }
+
+        RemoveHostGrid(existing);
+        auto& hosts = TaskbarHosts();
+        hosts.erase(std::remove_if(hosts.begin(), hosts.end(),
+                                   [taskbarWnd](
+                                       const std::unique_ptr<TaskbarHost>& h) {
+                                       return h && h->hwnd == taskbarWnd;
+                                   }),
+                    hosts.end());
+    }
+
+    auto host = std::make_unique<TaskbarHost>();
+    host->hwnd = taskbarWnd;
+    host->cachedRepeater = repeater;
+    host->lastButtonSizeTick = GetTickCount64();
+    UpdateButtonSizeFromTaskbar(repeater, &host->buttonWidth,
+                                &host->buttonHeight);
+
+    host->trackedRootGrid = rootGrid;
+    host->hostGrid = BuildHostGrid(host.get());
+
+    Grid::SetColumn(host->hostGrid, 0);
+    Canvas::SetZIndex(host->hostGrid, 1000);
+    host->hostGrid.Margin({0, 0, 0, 0});
+    rootGrid.Children().Append(host->hostGrid);
+
+    if (auto anchor = ResolveAnchor(repeater, rootGrid)) {
+        AdoptAnchor(host.get(), anchor);
+    }
+    host->lastAnchorResolveTick = GetTickCount64();
+
+    TaskbarHost* raw = host.get();
+    host->layoutUpdatedToken = rootGrid.LayoutUpdated(
+        [raw](winrt::Windows::Foundation::IInspectable const&,
+              winrt::Windows::Foundation::IInspectable const&) {
+            OnRootGridLayoutUpdated(raw);
+        });
+
+    Wh_Log(L"Injected %d folder button(s) on taskbar %p, size %.1fx%.1f",
+           (int)host->buttonStates.size(), taskbarWnd, host->buttonWidth,
+           host->buttonHeight);
+
+    TaskbarHosts().push_back(std::move(host));
+    return true;
+}
+
+bool InjectHostGridsOnTaskbarThread() {
+    // Reached via RunFromWindowThread / WH_CALLWNDPROC — not a XAML delegate —
+    // so WinRT failures must not unwind through user32's callback frame.
+    try {
+        // Register classes and create the menu owner on this (taskbar) thread so
+        // DestroyWindow / UnregisterClass later stay same-thread-safe.
+        EnsureMenuOwnerWindow();
+
+        // Taskbar UI thread already has an STA — resolve shell: paths here so
+        // hover/open and RequestScan see filesystem paths (no CoInitializeEx).
+        ResolvePendingFolderEntries();
+
+        if (g_settings.folders.empty()) {
+            Wh_Log(L"No folders configured, nothing to inject");
+            RemoveAllHostGrids();
+            return true;
+        }
+
+        // Drop hosts for taskbar HWNDs that no longer exist (unplugged monitors)
+        // without tearing down every seated host on each retry.
+        if (g_taskbarHosts) {
+            auto& hosts = *g_taskbarHosts;
+            for (auto it = hosts.begin(); it != hosts.end();) {
+                if (*it && !IsWindow((*it)->hwnd)) {
+                    RemoveHostGrid(it->get());
+                    it = hosts.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+        }
+
+        struct EnumState {
+            int found = 0;
+            int injected = 0;
+        } state;
+
+        // Primary and secondary tray windows share the explorer taskbar UI thread
+        // on Windows 11, matching other Windhawk taskbar mods.
+        EnumThreadWindows(
+            GetCurrentThreadId(),
+            [](HWND hWnd, LPARAM lParam) -> BOOL {
+                auto* state = reinterpret_cast<EnumState*>(lParam);
+                WCHAR className[32];
+                if (!GetClassName(hWnd, className, ARRAYSIZE(className))) {
+                    return TRUE;
+                }
+                if (_wcsicmp(className, L"Shell_TrayWnd") != 0 &&
+                    _wcsicmp(className, L"Shell_SecondaryTrayWnd") != 0) {
+                    return TRUE;
+                }
+                state->found++;
+                if (InjectHostGridForTaskbar(hWnd)) {
+                    state->injected++;
+                } else {
+                    Wh_Log(L"Inject failed for %s %p", className, hWnd);
+                }
+                return TRUE;
+            },
+            reinterpret_cast<LPARAM>(&state));
+
+        if (g_taskbarHosts && !g_taskbarHosts->empty()) {
+            g_taskbarWnd = (*g_taskbarHosts)[0]->hwnd;
+            UpdatePopupDpi();
+            int iconPixelSize = ScaleForPopup(g_settings.iconSize);
+            for (size_t i = 0; i < g_settings.folders.size(); i++) {
+                RequestScan(FolderPathForButton((int)i), iconPixelSize);
+            }
+        }
+
+        g_injectionLive = state.found > 0 && state.injected == state.found;
+        Wh_Log(L"Taskbar inject: %d/%d windows, %d hosts", state.injected,
+               state.found,
+               g_taskbarHosts ? (int)g_taskbarHosts->size() : 0);
+        return g_injectionLive;
+    } catch (const winrt::hresult_error& e) {
+        Wh_Log(L"Injection failed: %s", e.message().c_str());
+        return false;
+    } catch (...) {
+        Wh_Log(L"Injection failed");
+        return false;
+    }
+}
+
+bool ApplyOnWindowThread(RunFromWindowThreadProc_t proc) {
+    HWND taskbarWnd = FindCurrentProcessTaskbarWnd();
+    if (!taskbarWnd) {
+        Wh_Log(L"ApplyOnWindowThread: no taskbar window found");
+        return false;
+    }
+    if (!g_taskbarWnd) {
+        g_taskbarWnd = taskbarWnd;
+    }
+    if (!RunFromWindowThread(taskbarWnd, proc, nullptr)) {
+        Wh_Log(L"ApplyOnWindowThread: RunFromWindowThread failed (error %u)",
+               GetLastError());
+        return false;
+    }
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Injection retries
+//
+// The taskbar is rebuilt on theme changes, Explorer restarts and DPI changes,
+// so injection is retried with a backoff until it sticks.
+
+DWORD WINAPI RetryThreadProc(void* param) {
+    HANDLE stopEvent = static_cast<HANDLE>(param);
+    // Capture kick once; StopRetryThread closes it only after this thread joins.
+    HANDLE kickEvent = g_retryKickEvent;
+    static const DWORD delays[] = {0,    500,  1000,  2000,
+                                   4000, 8000, 15000, 30000};
+
+    for (;;) {
+        HANDLE waits[] = {stopEvent, kickEvent};
+        DWORD wake = WaitForMultipleObjects(2, waits, FALSE, INFINITE);
+        if (wake == WAIT_OBJECT_0 || wake == WAIT_FAILED) {
+            return 0;  // stop (or wait failed)
+        }
+        if (g_unloading ||
+            WaitForSingleObject(stopEvent, 0) != WAIT_TIMEOUT) {
+            return 0;
+        }
+
+        g_injectionLive = false;
+
+        for (size_t i = 0; i < ARRAYSIZE(delays) && !g_unloading; i++) {
+            if (delays[i] &&
+                WaitForSingleObject(stopEvent, delays[i]) != WAIT_TIMEOUT) {
+                return 0;
+            }
+            if (g_unloading) {
+                return 0;
+            }
+
+            ApplyOnWindowThread([](void*) { InjectHostGridsOnTaskbarThread(); });
+
+            if (g_injectionLive || g_unloading) {
+                break;
+            }
+        }
+        // Success or exhaustion: wait for the next kick (e.g. secondary
+        // TrayUI::StartTaskbar) instead of exiting — avoids the one-shot
+        // exit race that could drop a re-injection request.
+    }
+}
+
+void StopRetryThread() {
+    AcquireSRWLockExclusive(&g_retryLock);
+    HANDLE retryThread = g_retryThread;
+    HANDLE retryStopEvent = g_retryStopEvent;
+    HANDLE retryKickEvent = g_retryKickEvent;
+    g_retryThread = nullptr;
+    g_retryStopEvent = nullptr;
+    g_retryKickEvent = nullptr;
+    if (retryStopEvent) {
+        SetEvent(retryStopEvent);
+    }
+    ReleaseSRWLockExclusive(&g_retryLock);
+
+    if (retryThread) {
+        // Pump sent messages while waiting so a worker blocked in SendMessage
+        // to this UI thread cannot deadlock the join. Only settings/uninit
+        // should call this; window procs use StartRetryThread (non-blocking).
+        DWORD result;
+        do {
+            result = MsgWaitForMultipleObjects(1, &retryThread, FALSE, INFINITE,
+                                               QS_SENDMESSAGE);
+            if (result == WAIT_OBJECT_0 + 1) {
+                MSG msg;
+                PeekMessageW(&msg, nullptr, 0, 0, PM_NOREMOVE);
+            }
+        } while (result == WAIT_OBJECT_0 + 1);
+        CloseHandle(retryThread);
+    }
+    if (retryStopEvent) {
+        CloseHandle(retryStopEvent);
+    }
+    if (retryKickEvent) {
+        CloseHandle(retryKickEvent);
+    }
+}
+
+// Non-blocking: safe from window procedures. Ensures the lifetime worker exists
+// and kicks it. StopRetryThread still joins for Wh_ModSettingsChanged / uninit.
+void StartRetryThread() {
+    AcquireSRWLockExclusive(&g_retryLock);
+    if (g_unloading) {
+        ReleaseSRWLockExclusive(&g_retryLock);
+        return;
+    }
+
+    if (!g_retryStopEvent) {
+        g_retryStopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        if (!g_retryStopEvent) {
+            Wh_Log(L"CreateEventW for retry stop failed (%u)", GetLastError());
+            ReleaseSRWLockExclusive(&g_retryLock);
+            return;
+        }
+    }
+    if (!g_retryKickEvent) {
+        g_retryKickEvent = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+        if (!g_retryKickEvent) {
+            Wh_Log(L"CreateEventW for retry kick failed (%u)", GetLastError());
+            CloseHandle(g_retryStopEvent);
+            g_retryStopEvent = nullptr;
+            ReleaseSRWLockExclusive(&g_retryLock);
+            return;
+        }
+    }
+
+    if (!g_retryThread) {
+        HANDLE stopEvent = g_retryStopEvent;
+        g_retryThread =
+            CreateThread(nullptr, 0, RetryThreadProc, stopEvent, 0, nullptr);
+        if (!g_retryThread) {
+            Wh_Log(L"CreateThread for retry failed (%u)", GetLastError());
+            CloseHandle(g_retryStopEvent);
+            CloseHandle(g_retryKickEvent);
+            g_retryStopEvent = nullptr;
+            g_retryKickEvent = nullptr;
+            ReleaseSRWLockExclusive(&g_retryLock);
+            return;
+        }
+    }
+
+    SetEvent(g_retryKickEvent);
+    ReleaseSRWLockExclusive(&g_retryLock);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Hooks
+
+using TrayUI_StartTaskbar_t = void(WINAPI*)(void* pThis);
+TrayUI_StartTaskbar_t TrayUI_StartTaskbar_Original;
+
+void WINAPI TrayUI_StartTaskbar_Hook(void* pThis) {
+    Wh_Log(L"TrayUI::StartTaskbar");
+    TrayUI_StartTaskbar_Original(pThis);
+    if (!g_unloading) {
+        StartRetryThread();
+    }
+}
+
+bool HookTaskbarDllSymbols() {
+    HMODULE module =
+        LoadLibraryEx(L"taskbar.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!module) {
+        Wh_Log(L"Failed to load taskbar.dll");
+        return false;
+    }
+
+    WindhawkUtils::SYMBOL_HOOK taskbarDllHooks[] = {
+        {
+            {LR"(const CTaskBand::`vftable'{for `ITaskListWndSite'})"},
+            &CTaskBand_ITaskListWndSite_vftable,
+        },
+        {
+            {LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CTaskBand::GetTaskbarHost(void)const )"},
+            &CTaskBand_GetTaskbarHost_Original,
+        },
+        {
+            {LR"(const CSecondaryTaskBand::`vftable'{for `ITaskListWndSite'})"},
+            &CSecondaryTaskBand_ITaskListWndSite_vftable,
+        },
+        {
+            {LR"(public: virtual class std::shared_ptr<class TaskbarHost> __cdecl CSecondaryTaskBand::GetTaskbarHost(void)const )"},
+            &CSecondaryTaskBand_GetTaskbarHost_Original,
+        },
+        {
+            {LR"(public: int __cdecl TaskbarHost::FrameHeight(void)const )"},
+            &TaskbarHost_FrameHeight_Original,
+        },
+        {
+            {LR"(public: void __cdecl std::_Ref_count_base::_Decref(void))"},
+            &std__Ref_count_base__Decref_Original,
+        },
+        {
+            {LR"(public: virtual void __cdecl TrayUI::StartTaskbar(void))"},
+            &TrayUI_StartTaskbar_Original,
+            TrayUI_StartTaskbar_Hook,
+        },
+    };
+
+    return WindhawkUtils::HookSymbols(module, taskbarDllHooks,
+                                      ARRAYSIZE(taskbarDllHooks));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Explorer/Desktop right-click integration
+//
+// Hooks TrackPopupMenuEx, which explorer.exe calls right before showing the
+// classic ("Show more options") context menu for a shell view (an Explorer
+// window or the desktop). A right-clicked file or shortcut gets
+// move/copy-into-folder entries (files also get "Copy as shortcut"); a
+// right-clicked plain folder gets a pin option plus a shortcut-into-folder
+// entry. Same technique as the published "Explorer Context Menu Custom
+// Items" Windhawk mod.
+
+namespace AddToTaskbar {
+
+constexpr UINT kMinId = 0xC901;
+
+std::wstring LeafName(const std::wstring& path) {
+    size_t pos = path.find_last_of(L"\\/");
+    std::wstring leaf = pos == std::wstring::npos ? path : path.substr(pos + 1);
+    if (PathIsLnkFile(leaf)) {
+        leaf.resize(leaf.size() - 4);
+    }
+    return leaf;
+}
+
+// Win32 menus treat '&' as an accelerator marker; double it so names like
+// "R&D" render literally instead of showing an underlined "D".
+std::wstring EscapeMenuLabel(const std::wstring& s) {
+    std::wstring out;
+    for (wchar_t c : s) {
+        if (c == L'&') {
+            out += L'&';
+        }
+        out += c;
+    }
+    return out;
+}
+
+bool IsShellViewWindow(HWND hwnd) {
+    for (HWND h = hwnd; h; h = GetParent(h)) {
+        WCHAR cls[64]{};
+        GetClassNameW(h, cls, ARRAYSIZE(cls));
+        if (wcscmp(cls, L"SHELLDLL_DefView") == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Path of the single selected item in the shell view owning `hwnd`, or empty
+// (no selection, multi-selection, or not a real shell view).
+std::wstring GetSelectedPath(HWND hwnd) {
+    std::wstring result;
+    IShellBrowser* browser = (IShellBrowser*)SendMessageW(hwnd, WM_USER + 7, 0, 0);
+    for (HWND h = hwnd; !browser && h; h = GetParent(h)) {
+        browser = (IShellBrowser*)SendMessageW(h, WM_USER + 7, 0, 0);
+    }
+    if (!browser) {
+        return result;
+    }
+
+    IShellView* view = nullptr;
+    if (FAILED(browser->QueryActiveShellView(&view)) || !view) {
+        return result;
+    }
+
+    IDataObject* dataObj = nullptr;
+    if (SUCCEEDED(view->GetItemObject(SVGIO_SELECTION, IID_PPV_ARGS(&dataObj))) &&
+        dataObj) {
+        FORMATETC fmt{CF_HDROP, nullptr, DVASPECT_CONTENT, -1, TYMED_HGLOBAL};
+        STGMEDIUM stg{};
+        if (SUCCEEDED(dataObj->GetData(&fmt, &stg))) {
+            if (HDROP drop = (HDROP)GlobalLock(stg.hGlobal)) {
+                if (DragQueryFileW(drop, 0xFFFFFFFF, nullptr, 0) == 1) {
+                    WCHAR buf[MAX_PATH]{};
+                    DragQueryFileW(drop, 0, buf, ARRAYSIZE(buf));
+                    result = buf;
+                }
+                GlobalUnlock(stg.hGlobal);
+            }
+            ReleaseStgMedium(&stg);
+        }
+        dataObj->Release();
+    }
+    view->Release();
+    return result;
+}
+
+bool MoveOrCopy(const std::wstring& src, const std::wstring& destDir, bool move) {
+    if (destDir.empty()) {
+        return false;
+    }
+    // pFrom/pTo need double-null termination.
+    std::wstring from = src + L'\0';
+    std::wstring to = destDir + L'\0';
+    SHFILEOPSTRUCTW op{};
+    op.wFunc = move ? FO_MOVE : FO_COPY;
+    op.pFrom = from.c_str();
+    op.pTo = to.c_str();
+    op.fFlags = FOF_NOCONFIRMMKDIR | FOF_NOERRORUI | FOF_RENAMEONCOLLISION;
+    return SHFileOperationW(&op) == 0;
+}
+
+// Creates a .lnk to `target` inside `destDir`. Returns the new .lnk path, or
+// empty on failure.
+std::wstring CreateShortcutIn(const std::wstring& target,
+                              const std::wstring& destDir) {
+    if (destDir.empty()) {
+        return L"";
+    }
+    IShellLinkW* link = nullptr;
+    if (FAILED(CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+                                IID_IShellLinkW, (void**)&link)) ||
+        !link) {
+        return L"";
+    }
+    link->SetPath(target.c_str());
+
+    IPersistFile* persist = nullptr;
+    if (FAILED(link->QueryInterface(IID_IPersistFile, (void**)&persist)) ||
+        !persist) {
+        link->Release();
+        return L"";
+    }
+
+    std::wstring name = LeafName(target);
+    std::wstring lnkPath = destDir + L"\\" + name + L".lnk";
+    for (int i = 2; GetFileAttributesW(lnkPath.c_str()) != INVALID_FILE_ATTRIBUTES &&
+                    i < 100;
+         i++) {
+        lnkPath = destDir + L"\\" + name + L" (" + std::to_wstring(i) + L").lnk";
+    }
+
+    HRESULT hr = persist->Save(lnkPath.c_str(), TRUE);
+    persist->Release();
+    link->Release();
+    return SUCCEEDED(hr) ? lnkPath : L"";
+}
+
+decltype(&TrackPopupMenuEx) TrackPopupMenuEx_orig;
+
+BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
+                                 UINT flags,
+                                 int x,
+                                 int y,
+                                 HWND hwnd,
+                                 LPTPMPARAMS params) {
+    if (!IsShellViewWindow(hwnd)) {
+        return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
+    }
+
+    struct ComInit {
+        HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+        ~ComInit() {
+            if (SUCCEEDED(hr)) {
+                CoUninitialize();
+            }
+        }
+    } com;
+
+    std::wstring path = GetSelectedPath(hwnd);
+    DWORD attrs =
+        path.empty() ? INVALID_FILE_ATTRIBUTES : GetFileAttributesW(path.c_str());
+    if (attrs == INVALID_FILE_ATTRIBUTES) {
+        return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
+    }
+    bool isLnk = PathIsLnkFile(path);
+    bool isDir = (attrs & FILE_ATTRIBUTE_DIRECTORY) && !isLnk;
+
+    std::vector<FolderEntry> folders;
+    {
+        std::lock_guard<std::mutex> lock(g_foldersMutex);
+        folders = g_settings.folders;
+    }
+
+    // One "Taskbar Folders" item on the real menu: Pin (folders only, and only
+    // if not already a taskbar folder), then Move/Copy (any non-folder) or
+    // Copy as shortcut (folders and regular files), each hoverable into the
+    // folder list. Submenus attach via MF_POPUP, so explorer.exe's own
+    // DestroyMenu(hMenu) tears them all down — nothing here owns cleanup.
+    size_t n = folders.size();
+    UINT moveBase = kMinId + 1;
+    UINT copyBase = moveBase + (UINT)n;
+    UINT shortcutBase = copyBase + (UINT)n;
+
+    bool canPin = isDir && !IsAlreadyTaskbarFolder(path);
+    bool showMoveCopy = !isDir && n > 0;
+    bool showShortcut = !isLnk && n > 0;
+
+    auto buildDestinationSubmenu = [&](PCWSTR header, UINT idBase) {
+        HMENU sub = CreatePopupMenu();
+        AppendMenuW(sub, MF_STRING | MF_GRAYED | MF_DISABLED, 0, header);
+        AppendMenuW(sub, MF_SEPARATOR, 0, nullptr);
+        for (size_t i = 0; i < n; i++) {
+            AppendMenuW(sub, MF_STRING, idBase + (UINT)i,
+                        EscapeMenuLabel(folders[i].name).c_str());
+        }
+        return sub;
+    };
+
+    HMENU foldersMenu = CreatePopupMenu();
+    bool anyItem = false;
+    if (canPin) {
+        std::wstring label =
+            L"Pin \"" + EscapeMenuLabel(LeafName(path)) + L"\" to Taskbar";
+        AppendMenuW(foldersMenu, MF_STRING, kMinId, label.c_str());
+        anyItem = true;
+        if (showMoveCopy || showShortcut) {
+            AppendMenuW(foldersMenu, MF_SEPARATOR, 0, nullptr);
+        }
+    }
+    if (showMoveCopy) {
+        HMENU moveSub = buildDestinationSubmenu(L"Move to...", moveBase);
+        AppendMenuW(foldersMenu, MF_POPUP, (UINT_PTR)moveSub, L"Move");
+        HMENU copySub = buildDestinationSubmenu(L"Copy to...", copyBase);
+        AppendMenuW(foldersMenu, MF_POPUP, (UINT_PTR)copySub, L"Copy");
+        anyItem = true;
+    }
+    if (showShortcut) {
+        HMENU shortcutSub =
+            buildDestinationSubmenu(L"Make shortcut in...", shortcutBase);
+        AppendMenuW(foldersMenu, MF_POPUP, (UINT_PTR)shortcutSub,
+                    L"Copy as shortcut");
+        anyItem = true;
+    }
+    if (!anyItem) {
+        DestroyMenu(foldersMenu);
+    } else {
+        if (GetMenuItemCount(hMenu) > 0) {
+            AppendMenuW(hMenu, MF_SEPARATOR, 0, nullptr);
+        }
+        AppendMenuW(hMenu, MF_POPUP, (UINT_PTR)foldersMenu, L"Taskbar Folders");
+    }
+
+    // Submenus we inject (MF_POPUP with our own CreatePopupMenu() handles)
+    // aren't part of explorer's IContextMenu tree, so explorer's own
+    // dark-mode/rounded-corner treatment for nested popups skips them —
+    // they render with the classic light-mode square border. Each nested
+    // popup spawns a new "#32768" window while TrackPopupMenuEx_orig pumps
+    // its own message loop below, so a scoped CBT hook catches all of them.
+    HHOOK cbtHook = SetWindowsHookExW(
+        WH_CBT,
+        [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
+            if (nCode == HCBT_CREATEWND) {
+                HWND hWnd = (HWND)wParam;
+                CBT_CREATEWNDW* cbt = (CBT_CREATEWNDW*)lParam;
+                LPCWSTR cls = cbt->lpcs->lpszClass;
+                if (IS_INTRESOURCE(cls) && LOWORD((ULONG_PTR)cls) == 32768) {
+                    BOOL dark = TRUE;
+                    DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+                                          &dark, sizeof(dark));
+                    int corner = DWMWCP_ROUND;
+                    DwmSetWindowAttribute(hWnd, DWMWA_WINDOW_CORNER_PREFERENCE,
+                                          &corner, sizeof(corner));
+                }
+            }
+            return CallNextHookEx(nullptr, nCode, wParam, lParam);
+        },
+        nullptr, GetCurrentThreadId());
+
+    UINT result = TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
+
+    if (cbtHook) {
+        UnhookWindowsHookEx(cbtHook);
+    }
+
+    if (!(flags & TPM_RETURNCMD) || result < kMinId) {
+        return result;
+    }
+
+    if (canPin && result == kMinId) {
+        AddPinnedFolder(path, LeafName(path));
+        ReloadAndRefreshUI();
+        return 0;
+    }
+
+    bool move = false;
+    bool asShortcut = false;
+    size_t idx = 0;
+    if (result >= moveBase && result < moveBase + n) {
+        move = true;
+        idx = result - moveBase;
+    } else if (result >= copyBase && result < copyBase + n) {
+        move = false;
+        idx = result - copyBase;
+    } else if (result >= shortcutBase && result < shortcutBase + n) {
+        move = false;
+        asShortcut = true;
+        idx = result - shortcutBase;
+    } else {
+        return result;
+    }
+
+    std::wstring destDir = folders[idx].resolvedPath.empty() ? folders[idx].path
+                                                              : folders[idx].resolvedPath;
+    if (asShortcut) {
+        CreateShortcutIn(path, destDir);
+        return 0;
+    }
+    MoveOrCopy(path, destDir, move);
+    return 0;
+}
+
+}  // namespace AddToTaskbar
+
+////////////////////////////////////////////////////////////////////////////////
+// Mod entry points
+
+BOOL Wh_ModInit() {
+    Wh_Log(L"Init");
+
+    // Brings folders across from the two pre-manager lists (the old Settings
+    // array and the old pinned[] storage) the first time this build runs.
+    FolderStore::MigrateLegacy();
+    LoadSettings();
+    ResetFolderData();
+
+    Gdiplus::GdiplusStartupInput startupInput;
+    if (Gdiplus::GdiplusStartup(&g_gdiplusToken, &startupInput, nullptr) !=
+        Gdiplus::Ok) {
+        Wh_Log(L"GdiplusStartup failed");
+        return FALSE;
+    }
+
+    if (!HookTaskbarDllSymbols()) {
+        Wh_Log(
+            L"Failed to hook taskbar.dll, the taskbar XamlRoot is unreachable");
+        Gdiplus::GdiplusShutdown(g_gdiplusToken);
+        g_gdiplusToken = 0;
+        return FALSE;
+    }
+
+    if (!Wh_SetFunctionHook((void*)TrackPopupMenuEx,
+                            (void*)AddToTaskbar::TrackPopupMenuExHook,
+                            (void**)&AddToTaskbar::TrackPopupMenuEx_orig)) {
+        // Non-fatal: the rest of the mod works without the right-click
+        // integration.
+        Wh_Log(L"Failed to hook TrackPopupMenuEx; Explorer right-click "
+               L"integration will be unavailable");
+    }
+
+    // Scan thread starts lazily on the first RequestScan (hover / inject).
+    return TRUE;
+}
+
+void Wh_ModAfterInit() {
+    Wh_Log(L"AfterInit");
+    // Menu owner / popup classes are created on the taskbar UI thread during
+    // InjectHostGridsOnTaskbarThread (and EnsureLevelWindow), not here.
+    StartRetryThread();
+}
+
+// Tears down UI, reloads settings (+ pinned folders), and restarts. Shared by
+// Wh_ModSettingsChanged and the Explorer right-click "pin to taskbar" action.
+void ReloadAndRefreshUI() {
+    StopRetryThread();
+    // The scan thread reads g_settings, so it has to be parked before
+    // reloading.
+    StopScanThread();
+
+    if (!ApplyOnWindowThread([](void*) {
+            CloseChain();
+            RemoveAllHostGrids();
+            // Popup HWNDs keep the acrylic accent applied at create time;
+            // destroy them so the next hover recreates with the current setting.
+            for (HWND hWnd : g_levelWindows) {
+                if (hWnd) {
+                    DestroyWindow(hWnd);
+                }
+            }
+            g_levelWindows.clear();
+        })) {
+        Wh_Log(L"ReloadAndRefreshUI: failed to tear down UI on taskbar thread");
+    }
+
+    LoadSettings();
+    ResetFolderData();
+
+    // Scan thread restarts lazily on the next RequestScan.
+    StartRetryThread();
+}
+
+void Wh_ModSettingsChanged() {
+    Wh_Log(L"SettingsChanged");
+    ReloadAndRefreshUI();
+    if (HWND manager = FolderManager::g_wnd.load()) {
+        // Mirror the new list if the manager happens to be open.
+        PostMessageW(manager, WM_APP, 0, 0);
+    }
+
+    // "Open the folder manager" acts as a button: it fires when switched on,
+    // and switching it off again is a no-op. Windhawk's settings schema has no
+    // button widget, and a mod cannot clear the flag itself, so the previous
+    // value is tracked here to catch the off -> on edge only.
+    int manage = Wh_GetIntSetting(L"manageFolders");
+    if (manage && !Wh_GetIntValue(L"manageFoldersPrev", 0)) {
+        FolderManager::Open();
+    }
+    Wh_SetIntValue(L"manageFoldersPrev", manage);
+}
+
+void Wh_ModUninit() {
+    Wh_Log(L"Uninit");
+
+    g_unloading = true;
+    // Before anything is torn down: the manager runs its own message loop on
+    // its own thread, and unloading the DLL under it would crash Explorer.
+    FolderManager::CloseAndWait();
+    StopRetryThread();
+    StopScanThread();
+
+    // DestroyWindow / XAML teardown must run on the creating UI thread. Prefer
+    // a mod-owned window (level popup or menu owner) when the taskbar HWND is
+    // already gone — never DestroyWindow from this Windhawk callback thread.
+    auto teardownOnUiThread = [](void*) {
+        ClearPendingShellCommand();
+        CloseChain();
+        RemoveAllHostGrids();
+
+        for (HWND hWnd : g_levelWindows) {
+            if (hWnd) {
+                DestroyWindow(hWnd);
+            }
+        }
+        g_levelWindows.clear();
+
+        if (g_menuOwnerWnd) {
+            DestroyWindow(g_menuOwnerWnd);
+            g_menuOwnerWnd = nullptr;
+        }
+
+        g_taskbarHosts.reset();
+    };
+
+    HWND threadWnd = nullptr;
+    for (HWND h : g_levelWindows) {
+        if (h) {
+            threadWnd = h;
+            break;
+        }
+    }
+    if (!threadWnd) {
+        threadWnd = g_menuOwnerWnd;
+    }
+    if (!threadWnd) {
+        threadWnd = FindCurrentProcessTaskbarWnd();
+    }
+
+    // ShowItemContextMenu runs a modal TrackPopupMenuEx loop on the UI thread.
+    // Teardown via RunFromWindowThread would destroy windows and let Windhawk
+    // unload the DLL while that frame is still live — EndMenu/CANCELMODE first
+    // and wait for g_menuActive to clear (same pattern as taskbar-folder-menus).
+    if (threadWnd && g_menuActive) {
+        for (int i = 0; g_menuActive && i < 100; i++) {
+            RunFromWindowThread(
+                threadWnd,
+                [](void*) {
+                    if (g_menuActive && !EndMenu() && g_menuOwnerWnd) {
+                        SendMessageW(g_menuOwnerWnd, WM_CANCELMODE, 0, 0);
+                    }
+                },
+                nullptr);
+            Sleep(20);
+        }
+        if (g_menuActive) {
+            Wh_Log(L"Uninit: shell context menu still active after wait");
+        }
+    }
+
+    // Also wait out a deferred/synchronous shell verb. ASYNCOK usually makes
+    // this short; verbs that ignore it and show modal UI can still outlive
+    // this wait — see CMIC_MASK_ASYNCOK on the invoke path.
+    if (g_invokeActive) {
+        for (int i = 0; g_invokeActive && i < 100; i++) {
+            Sleep(20);
+        }
+        if (g_invokeActive) {
+            Wh_Log(L"Uninit: shell verb still active after wait");
+        }
+    }
+
+    if (threadWnd) {
+        if (!RunFromWindowThread(threadWnd, teardownOnUiThread, nullptr)) {
+            Wh_Log(L"Uninidt: RunFromWindowThread failed (error %u); windows "
+                   L"may leak and UnregisterClass may fail",
+                   GetLastError());
+        }
+    } else {
+        // No mod-owned or taskbar window — nothing left that can dangle into
+        // unmapped code; retain no_destroy host state rather than tearing it
+        // down from the wrong thread.
+        Wh_Log(L"No mod-owned or taskbar window at uninit; retaining host state");
+    }
+
+    g_levels.reset();
+    {
+        std::lock_guard<std::mutex> lock(g_cacheMutex);
+        g_folderCache.reset();
+    }
+
+    // The window procedures live in this DLL, so the classes must not outlive
+    // it. A class left behind keeps pointing at the unloaded image, and the
+    // next load would build a window on a dangling procedure.
+    HINSTANCE instance = GetCurrentModuleHandle();
+    UnregisterClassW(kPopupClassName, instance);
+    UnregisterClassW(kMenuOwnerClassName, instance);
+    UnregisterClassW(FolderManager::kClassName, instance);
+    UnregisterClassW(FolderManager::kEditClassName, instance);
+
+    if (g_gdiplusToken) {
+        Gdiplus::GdiplusShutdown(g_gdiplusToken);
+        g_gdiplusToken = 0;
+    }
+}

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -74,9 +74,12 @@ XAML and takes no menu items from a mod like this. If you would rather it were
 one click away, a mod such as **explorer-context-menu-classic** makes the
 classic menu the default one.
 
-If you would rather the mod stayed entirely on the taskbar side, turn off
-**Explorer right-click menu** in the settings; with it off, Explorer and Desktop
-context menus are left completely untouched.
+If you would rather the mod stayed off the Explorer/Desktop menus, turn off
+**Explorer right-click menu** in the settings; with it off, Pin / Move / Copy
+disappear from that menu, leaving only **Manage folders...** — kept there on
+purpose, since it is the only remaining way to open the manager once nothing
+is pinned. The settings page also has an **Open the Taskbar Folders window**
+checkbox that opens it directly, since Windhawk settings have no button widget.
 
 ### The Taskbar Folders window
 
@@ -171,6 +174,12 @@ AppUserModelID, and that shortcut is pinned with the shell's ordinary
 - They collapse into the overflow button when the taskbar fills up.
 - Every animation is Windows' own.
 
+**Disabling or uninstalling the mod unpins every button it created**, deletes
+their Start Menu shortcuts and their jump lists — nothing it wrote to the
+shell is left behind. The folder list itself (names, paths, icons) stays in
+the mod's own settings, unpinned, so turning it back on does not mean
+re-adding every folder from scratch.
+
 Earlier versions drew an overlay instead, seated in a gap carved by widening a
 neighbouring icon's margin. It could never be exactly right: taskbar positions are
 driven by compositor-thread animations that no other window can sample mid-flight,
@@ -212,6 +221,14 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 // ==WindhawkModSettings==
 /*
 - behavior:
+  - openManager: false
+    $name: Open the Taskbar Folders window
+    $description: >-
+      There is no button widget on a Windhawk settings page, so this checkbox
+      is the closest thing to one: tick it to open the Taskbar Folders window
+      immediately. It does not save any state of its own and is left however
+      you leave it — untick and tick again to reopen the window.
+
   - openFolderOnClick: true
     $name: Click opens the folder
     $description: >-
@@ -226,10 +243,9 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
       context menus — the ones behind "Show more options" / Shift+F10, not the
       short Windows 11 menu, which is XAML and takes no items from a mod. Use it
       to pin a folder straight to the taskbar, or to move, copy or make a
-      shortcut into a folder that already has a button. Turn this off to keep
-      the mod entirely on the taskbar side — with it off, Explorer's own context
-      menus are left completely alone. Changing this setting reloads the mod,
-      because the menu hook can only be installed or removed at startup.
+      shortcut into a folder that already has a button. Turn this off to drop
+      Pin / Move / Copy from that submenu; "Manage folders..." stays either way,
+      since it is the only way to reach the manager when nothing is pinned yet.
 
   - hoverDelayMs: 0
     $name: Hover delay (ms)
@@ -585,11 +601,6 @@ Settings g_settings;
 std::mutex g_foldersMutex;
 
 std::atomic<bool> g_unloading{false};
-
-// Value of the explorerMenu setting this load was built around: the
-// TrackPopupMenuEx hook is installed (or not) once, in Wh_ModInit.
-// Wh_ModSettingsChanged compares against it to know when a reload is needed.
-bool g_explorerMenuHooked = false;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Small helpers
@@ -1431,6 +1442,23 @@ void WriteJumpList(const std::wstring& appId) {
     list->Release();
 }
 
+// Undoes WriteJumpList: drops the AppID's jump list from the shell's
+// CustomDestinations store entirely, rather than just emptying it.
+void DeleteJumpList(const std::wstring& appId) {
+    ICustomDestinationList* list = nullptr;
+    if (FAILED(CoCreateInstance(CLSID_DestinationList, nullptr,
+                                CLSCTX_INPROC_SERVER,
+                                IID_ICustomDestinationList, (void**)&list)) ||
+        !list) {
+        return;
+    }
+    HRESULT hr = list->DeleteList(appId.c_str());
+    if (FAILED(hr)) {
+        Wh_Log(L"Pins: DeleteList for %s failed: 0x%08X", appId.c_str(), hr);
+    }
+    list->Release();
+}
+
 // Invokes a shell verb on a path. Pinning and unpinning are both just verbs, so
 // neither needs the undocumented IPinnedList3.
 bool InvokeVerb(const std::wstring& path, PCSTR verb) {
@@ -1637,6 +1665,18 @@ void Reconcile() {
         return;
     }
 
+    // One read of the shell's pinned items, reused everywhere below that
+    // nothing has yet changed pin state — this is what previously cost four
+    // full ReadPinnedItems()/ReadPinnedAppIds() COM round-trips per pass.
+    // Re-read only after something that can actually change what is pinned
+    // (the unpin/pin loops further down).
+    std::vector<PinnedItem> initialPinnedItems = ReadPinnedItems();
+    std::vector<std::wstring> initialPinnedAppIds;
+    initialPinnedAppIds.reserve(initialPinnedItems.size());
+    for (const auto& item : initialPinnedItems) {
+        initialPinnedAppIds.push_back(item.appId);
+    }
+
     struct Desired {
         std::wstring appId;
         std::wstring lnkPath;
@@ -1675,7 +1715,7 @@ void Reconcile() {
             }
         }
 
-        std::vector<std::wstring> live = ReadPinnedAppIds();
+        const std::vector<std::wstring>& live = initialPinnedAppIds;
         // The reverse sync below is only as good as this list. If a native
         // unpin is not reflected here, the shell is flushing that folder later
         // than it changes the taskbar, and pin state has to be read from
@@ -1817,7 +1857,7 @@ void Reconcile() {
     // before asking for the re-pin is what a manual unpin-then-later-pin from
     // the real taskbar menu gets for free just by not being instantaneous.
     std::unordered_set<std::wstring> renamedAppIds;
-    for (const auto& item : ReadPinnedItems()) {
+    for (const auto& item : initialPinnedItems) {
         const Desired* match = nullptr;
         for (const auto& want : desired) {
             if (_wcsicmp(want.appId.c_str(), item.appId.c_str()) == 0) {
@@ -2009,7 +2049,12 @@ constexpr DWORD kPinWatchDebounceMs = 400;
 // renamed on disk. This is the safety net that catches that case: it bounds
 // how long a plain Explorer rename can sit unreflected on the taskbar without
 // needing an unrelated pin/unpin to shake a reconcile loose.
-constexpr DWORD kReconcilePollMs = 10000;
+// A rename showing up within a minute or two is fine — this is only a safety
+// net for a case the event-driven watches above (pinned-items copy, Taskband
+// key) do not cover, not something that needs sub-minute latency. Long enough
+// that a dozen-pin taskbar is not walked through COM every few seconds
+// forever for the rare case this actually catches anything.
+constexpr DWORD kReconcilePollMs = 120000;
 
 DWORD WINAPI ThreadProc(void*) {
     HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
@@ -6692,8 +6737,30 @@ void RebindPinButtons(TaskbarHost* host) {
     // pure identity check would then never rebind — the containers did not
     // change, only our knowledge of what they mean did.
     uint32_t labels = Pins::g_labelGeneration.load(std::memory_order_acquire);
-    if (identities == host->lastRealizedChildren &&
-        labels == host->lastLabelGeneration) {
+    bool identityUnchanged = identities == host->lastRealizedChildren &&
+                              labels == host->lastLabelGeneration;
+
+    // Neither of the above catches a drag-to-reorder: ItemsRepeater recycles
+    // TaskListButton containers in place, so the realized identity set can
+    // stay byte-for-byte the same while a container starts showing a
+    // different pinned item — and PublishLabels does not bump the generation
+    // either, since a reorder does not change the (leaf, pinId) map, only
+    // which container each leaf is realized on. Re-reading each already-bound
+    // button's live label is the only way to notice that; it is a handful of
+    // AutomationNameOf() calls on bound buttons only, not a rebuild of
+    // anything.
+    bool bindingsStale = false;
+    if (identityUnchanged) {
+        for (const auto& binding : host->pinBindings) {
+            if (!binding.button || FolderIndexForTaskListButton(
+                                        binding.button) != binding.folderIndex) {
+                bindingsStale = true;
+                break;
+            }
+        }
+    }
+
+    if (identityUnchanged && !bindingsStale) {
         return;
     }
     host->lastRealizedChildren = std::move(identities);
@@ -8009,23 +8076,29 @@ void RemoveSelected(HWND hWnd) {
     RefreshAfterStoreChange(hWnd);
 }
 
-// The mod deliberately leaves its taskbar buttons, source shortcuts and
-// per-AppID jump lists in place on unload/disable (nothing else cleans those
-// up, since they are also how a reload picks the state back up) — this is the
-// explicit escape hatch for a user who wants them gone for good.
-void RemoveAllFolderButtons(HWND hWnd) {
-    std::wstring prompt =
-        L"Remove all folder buttons from the taskbar?\n\nThis unpins every "
-        L"folder button this mod created, deletes their Start Menu "
-        L"shortcuts, and clears the folder list. This cannot be undone.";
-    if (MessageBoxW(hWnd, prompt.c_str(), L"Taskbar Folders",
-                    MB_OKCANCEL | MB_ICONWARNING) != IDOK ||
-        g_unloading) {
-        return;
-    }
+// Unpins every real taskbar button, deletes their Start Menu shortcuts and
+// their per-AppID jump lists — everything InvokeVerb's "taskbarpin" and
+// WriteJumpList put in place. Shared by the user-facing "Remove all folder
+// buttons" action (clearStore = true, wipes the folder list too) and the
+// automatic cleanup Wh_ModUninit runs on every disable/uninstall
+// (clearStore = false, folders survive as unpinned drafts so a later
+// re-enable can re-pin them without retyping anything).
+//
+// CoInitializeEx is refcounted per thread, so this is safe to call whether or
+// not the calling thread already has COM up (Wh_ModUninit's does not).
+void RemoveAllFolderButtonsCore(bool clearStore) {
+    struct ComInit {
+        HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+        ~ComInit() {
+            if (SUCCEEDED(hr)) {
+                CoUninitialize();
+            }
+        }
+    } com;
 
     for (const auto& item : Pins::ReadPinnedItems()) {
         Pins::InvokeVerb(item.path, "taskbarunpin");
+        Pins::DeleteJumpList(item.appId);
     }
 
     std::wstring dir = Pins::SourceDir();
@@ -8049,12 +8122,41 @@ void RemoveAllFolderButtons(HWND hWnd) {
         RemoveDirectoryW(dir.c_str());
     }
 
-    {
-        std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
+    std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
+    if (clearStore) {
         FolderStore::Write({});
+    } else {
+        auto stored = FolderStore::Read();
+        for (auto& entry : stored) {
+            entry.pinned = false;
+        }
+        FolderStore::Write(stored);
+    }
+}
+
+void RemoveAllFolderButtons(HWND hWnd) {
+    std::wstring prompt =
+        L"Remove all folder buttons from the taskbar?\n\nThis unpins every "
+        L"folder button this mod created, deletes their Start Menu "
+        L"shortcuts, and clears the folder list. This cannot be undone.";
+    if (MessageBoxW(hWnd, prompt.c_str(), L"Taskbar Folders",
+                    MB_OKCANCEL | MB_ICONWARNING) != IDOK ||
+        g_unloading) {
+        return;
     }
 
+    RemoveAllFolderButtonsCore(/*clearStore=*/true);
     RefreshAfterStoreChange(hWnd);
+}
+
+// Windhawk's core principle is that disabling a mod puts the system back the
+// way it was. Called from Wh_ModUninit, which fires on every disable and
+// every uninstall alike (Windhawk does not distinguish the two) — so the
+// real taskbar pins, their Start Menu shortcuts and their jump lists never
+// outlive the mod being off. The folder list itself is kept, marked unpinned,
+// so turning the mod back on does not lose it.
+void UnpinAllForDisable() {
+    RemoveAllFolderButtonsCore(/*clearStore=*/false);
 }
 
 // A single-select listbox never lets go of its selection on its own — a click
@@ -9355,9 +9457,8 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
     // any other caller in explorer.exe that happens to satisfy that (a shell
     // extension with its own menu, a future shell build, another mod) must be
     // left alone.
-    HWND defView = ((flags & TPM_RETURNCMD) && g_settings.explorerMenu)
-                       ? FindShellViewWindow(hwnd)
-                       : nullptr;
+    HWND defView =
+        (flags & TPM_RETURNCMD) ? FindShellViewWindow(hwnd) : nullptr;
     if (!defView) {
         return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
     }
@@ -9404,9 +9505,14 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
     UINT copyBase = moveBase + (UINT)n;
     UINT shortcutBase = copyBase + (UINT)n;
 
-    bool canPin = isDir && !IsPinnedTaskbarFolder(path);
-    bool showMoveCopy = !isDir && n > 0;
-    bool showShortcut = !isLnk && n > 0;
+    // "Manage folders..." below is always offered regardless of this setting —
+    // it is the only entrance to the manager when nothing is pinned yet. What
+    // the setting actually suppresses is everything that writes into Explorer:
+    // Pin / Move / Copy / Copy as shortcut.
+    bool menuEnabled = g_settings.explorerMenu;
+    bool canPin = menuEnabled && isDir && !IsPinnedTaskbarFolder(path);
+    bool showMoveCopy = menuEnabled && !isDir && n > 0;
+    bool showShortcut = menuEnabled && !isLnk && n > 0;
 
     auto buildDestinationSubmenu = [&](PCWSTR header, UINT idBase) {
         HMENU sub = CreatePopupMenu();
@@ -9665,22 +9771,15 @@ BOOL Wh_ModInit() {
 
     Pins::Start();
 
-    // Only when the Explorer integration is on: with it off, every context
-    // menu in the process stays entirely untouched by this mod, so nothing in
-    // the menu path can affect Explorer at all. Windhawk has no way to remove
-    // a function hook without reloading, so Wh_ModSettingsChanged asks for a
-    // reload when the setting stops matching what was installed here.
-    //
-    // Tracks the setting as of this load, not whether the hook took: a failed
-    // hook would not be fixed by reloading, and asking for one on every save
-    // would just churn.
-    g_explorerMenuHooked = g_settings.explorerMenu;
-    if (!g_settings.explorerMenu) {
-        Wh_Log(L"Explorer right-click integration is off; not hooking "
-               L"TrackPopupMenuEx");
-    } else if (!WindhawkUtils::SetFunctionHook(
-                   TrackPopupMenuEx, AddToTaskbar::TrackPopupMenuExHook,
-                   &AddToTaskbar::TrackPopupMenuEx_orig)) {
+    // Always hooked: TrackPopupMenuExHook reads g_settings.explorerMenu live
+    // on every call and uses it only to suppress the Pin / Move / Copy items,
+    // never the "Manage folders..." entry — that stays reachable even with
+    // the setting off, since it is the only way into the manager from a
+    // standing start. Hooking unconditionally also means the setting takes
+    // effect immediately, with no reload needed.
+    if (!WindhawkUtils::SetFunctionHook(
+            TrackPopupMenuEx, AddToTaskbar::TrackPopupMenuExHook,
+            &AddToTaskbar::TrackPopupMenuEx_orig)) {
         // Non-fatal: the rest of the mod works without the right-click
         // integration.
         Wh_Log(L"Failed to hook TrackPopupMenuEx; Explorer right-click "
@@ -9772,16 +9871,19 @@ void ReloadAndRefreshUI() {
 BOOL Wh_ModSettingsChanged(BOOL* bReload) {
     Wh_Log(L"SettingsChanged");
 
-    // The TrackPopupMenuEx hook can only be installed or removed at load time,
-    // so toggling the Explorer integration asks Windhawk for a reload instead
-    // of leaving the new value to take effect at some unrelated later point.
-    // The UI is rebuilt by the reload, so RequestReloadUI would be redundant.
-    bool reload = (Wh_GetIntSetting(L"behavior.explorerMenu") != 0) != g_explorerMenuHooked;
-    if (reload) {
-        *bReload = TRUE;
-    } else {
-        RequestReloadUI();
+    // A checkbox-as-link: openManager has no persisted meaning of its own, it
+    // is just the closest thing Windhawk's settings page has to a button.
+    // Every rising edge (false -> true, including a fresh unchecked ->
+    // checked as this reads it here) opens the manager; the box is left
+    // however the user leaves it.
+    static bool lastOpenManager = Wh_GetIntSetting(L"behavior.openManager") != 0;
+    bool openManager = Wh_GetIntSetting(L"behavior.openManager") != 0;
+    if (openManager && !lastOpenManager) {
+        FolderManager::Open();
     }
+    lastOpenManager = openManager;
+
+    RequestReloadUI();
 
     return TRUE;
 }
@@ -9795,10 +9897,13 @@ void Wh_ModUninit() {
     FolderManager::CloseAndWait();
     StopRetryThread();
     StopScanThread();
-    // Joins its STA worker. Deliberately does not unpin anything: the pins are
-    // real taskbar items the user arranged, and disabling the mod for a moment
-    // must not throw that away. A reconcile on the next load fixes up whatever
-    // drifted meanwhile.
+    // Disabling (or uninstalling — Wh_ModUninit does not see a difference)
+    // must leave the system as it was: real taskbar pins, Start Menu
+    // shortcuts and jump lists this mod created do not get to outlive it.
+    // Runs before Pins::Stop() below, while its COM-using helpers are still
+    // safe to call.
+    FolderManager::UnpinAllForDisable();
+    // Joins its STA worker.
     Pins::Stop();
 
     // DestroyWindow / XAML teardown must run on the creating UI thread. Prefer

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.40
+// @version         1.41
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
@@ -770,6 +770,13 @@ std::wstring FindRenamedSibling(const std::wstring& oldPath, uint64_t fileId) {
 // from its desktop.ini as the "path,index" spec the Icon setting already
 // accepts. Empty when the folder has no custom icon.
 std::wstring ReadFolderCustomIcon(const std::wstring& folderPath) {
+    // GetPrivateProfileStringW opens the file, so an offline share blocks for
+    // the network timeout — on the Explorer UI thread in the pin flow. An empty
+    // spec is a valid entry: MakeButtonContent falls back to the folder's own
+    // shell icon.
+    if (IsLikelyRemotePath(folderPath)) {
+        return L"";
+    }
     std::wstring iniPath = folderPath + L"\\desktop.ini";
     WCHAR buf[1024]{};
     if (GetPrivateProfileStringW(L".ShellClassInfo", L"IconResource", L"", buf,
@@ -8939,8 +8946,16 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
     } com;
 
     std::wstring path = GetSelectedPath(defView);
-    DWORD attrs =
-        path.empty() ? INVALID_FILE_ATTRIBUTES : GetFileAttributesW(path.c_str());
+    // This runs on the Explorer browser thread with that window's context menu
+    // waiting on us to return, and Explorer's own QueryContextMenu work is
+    // already done — a GetFileAttributesW on an offline share would freeze the
+    // whole window for the network timeout purely to decide whether to add our
+    // item. Degrade to no submenu, same as everywhere else the mod meets a
+    // remote path.
+    if (path.empty() || IsLikelyRemotePath(path)) {
+        return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
+    }
+    DWORD attrs = GetFileAttributesW(path.c_str());
     if (attrs == INVALID_FILE_ATTRIBUTES) {
         return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
     }

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.30
+// @version         1.38
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
@@ -293,30 +293,30 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
   $name: 3. Appearance ▸ Button icon size (px)
   $description: 0 matches the size Windows uses for its own taskbar icons.
 
+- showLabels: true
+  $name: 3. Appearance ▸ Show item labels
+  $description: >-
+    Turn off for an icons-only grid. Icons are centred in the cell when labels
+    are hidden.
+
 - fontSize: 12
   $name: 3. Appearance ▸ Item label size (px)
 
-- itemFontFamily: ""
-  $name: 3. Appearance ▸ Item label font
-  $description: >-
-    Font family for item labels, e.g. "Segoe UI". Leave empty to match the
-    system font.
-
-- itemFontWeight: regular
+- itemFontWeight: bold
   $name: 3. Appearance ▸ Item label weight
   $options:
   - regular: Regular
   - bold: Bold
 
+- showTitle: true
+  $name: 3. Appearance ▸ Show folder title
+  $description: >-
+    The folder name at the top of the main hover grid. Subfolder menus never
+    show one.
+
 - titleFontSize: 13
   $name: 3. Appearance ▸ Folder title size (px)
   $description: Size of the name shown at the top of the main hover grid.
-
-- titleFontFamily: ""
-  $name: 3. Appearance ▸ Folder title font
-  $description: >-
-    Font family for the folder title, e.g. "Segoe UI". Leave empty to match
-    the system font.
 
 - titleFontWeight: bold
   $name: 3. Appearance ▸ Folder title weight
@@ -337,12 +337,54 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 - cornerRadius: 8
   $name: 3. Appearance ▸ Grid corner radius (px)
 
+- popupTheme: system
+  $name: 3. Appearance ▸ Grid theme
+  $description: >-
+    Background and text colours of the hover grid. Windows default follows the
+    system app theme.
+  $options:
+  - system: Windows default
+  - light: Light
+  - dark: Dark
+
 - panelOpacity: 85
   $name: 3. Appearance ▸ Grid opacity (%)
+  $description: >-
+    A contrasting outline is added behind the text as the background fades out.
+    At 0 the background is invisible - icons and labels float straight over the
+    desktop - but the grid still takes clicks rather than passing them through
+    to whatever is behind it.
 
-- acrylic: true
-  $name: 3. Appearance ▸ Acrylic blur
-  $description: Blur the desktop behind the grid. Turn off if it looks wrong.
+- panelBorder: true
+  $name: 3. Appearance ▸ Grid border
+  $description: >-
+    Thin outline around the edge of the grid, plus the border Windows draws on
+    the rounded window. Turn off for a frameless look at low opacity.
+
+- blurType: gaussian
+  $name: 3. Appearance ▸ Blur type
+  $description: >-
+    Gaussian captures the screen behind the grid and blurs it ourselves - a
+    real, adjustable blur radius, but it costs a screen capture and a resample
+    every ~32ms to track a moving background live. Acrylic uses Windows' own
+    GPU-composited blur-behind instead - much cheaper (no capture, no per-frame
+    resample, updates live for free) but the blur radius itself is fixed by
+    Windows, not adjustable; the strength setting below controls the tint's
+    opacity instead of the blur radius. None skips blur entirely - cheaper
+    than either, same as setting the strength below to 0.
+  $options:
+  - none: None
+  - gaussian: Gaussian (adjustable, more expensive)
+  - acrylic: Acrylic (fixed radius, cheaper)
+
+- blurStrength: 40
+  $name: 3. Appearance ▸ Blur strength (%)
+  $description: >-
+    Transparent blur layered behind the grid, over whatever is on screen.
+    Independent of the grid opacity above. Ignored when blur type above is
+    None; 0 has the same effect. For Gaussian this is the blur radius; for
+    Acrylic (fixed blur radius) it is instead how opaque the tint over that
+    blur is.
 
 - gapAbove: 8
   $name: 3. Appearance ▸ Gap above taskbar (px)
@@ -421,6 +463,45 @@ using namespace winrt::Windows::UI::Xaml::Hosting;
 #ifndef DWMWCP_ROUND
 #define DWMWCP_ROUND 2
 #endif
+// Windows 10 2004+. Marks a window invisible to BitBlt/PrintWindow/desktop
+// capture, so CaptureBlurredBackdrop can grab the screen behind our own grid
+// window without that window's own pixels showing up in the shot - no need
+// to hide it first.
+#ifndef WDA_EXCLUDEFROMCAPTURE
+#define WDA_EXCLUDEFROMCAPTURE 0x00000011
+#endif
+
+// Undocumented SetWindowCompositionAttribute accent policy - the same
+// mechanism Windows itself uses for acrylic flyouts. Not in any public
+// header, so declared by hand and loaded dynamically (see
+// GetSetWindowCompositionAttribute).
+enum ACCENT_STATE {
+    ACCENT_DISABLED = 0,
+    ACCENT_ENABLE_ACRYLICBLURBEHIND = 4,
+};
+struct ACCENT_POLICY {
+    ACCENT_STATE AccentState;
+    DWORD AccentFlags;
+    DWORD GradientColor;  // 0xAABBGGRR
+    DWORD AnimationId;
+};
+enum WINDOWCOMPOSITIONATTRIB {
+    WCA_ACCENT_POLICY = 19,
+};
+struct WINDOWCOMPOSITIONATTRIBDATA {
+    WINDOWCOMPOSITIONATTRIB Attrib;
+    PVOID pvData;
+    SIZE_T cbData;
+};
+using SetWindowCompositionAttributeFn =
+    BOOL(WINAPI*)(HWND, WINDOWCOMPOSITIONATTRIBDATA*);
+
+SetWindowCompositionAttributeFn GetSetWindowCompositionAttribute() {
+    static SetWindowCompositionAttributeFn fn =
+        reinterpret_cast<SetWindowCompositionAttributeFn>(GetProcAddress(
+            GetModuleHandleW(L"user32.dll"), "SetWindowCompositionAttribute"));
+    return fn;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Settings
@@ -439,6 +520,7 @@ struct FolderEntry {
 };
 
 enum class SortMode { Name, Modified };
+enum class BlurType { None, Gaussian, Acrylic };
 
 struct Settings {
     std::vector<FolderEntry> folders;
@@ -459,16 +541,21 @@ struct Settings {
     int cellWidth = 92;
     int cellHeight = 88;
     int iconSize = 32;
+    bool showLabels = true;
     int fontSize = 12;
-    std::wstring itemFontFamily;
-    bool itemFontBold = false;
+    // LOGFONT lfWeight values. See MakePopupFont.
+    int itemFontWeight = FW_BOLD;
+    bool showTitle = true;
     int titleFontSize = 13;
-    std::wstring titleFontFamily;
-    bool titleFontBold = true;
+    int titleFontWeight = FW_BOLD;
     std::wstring titleAlign = L"center";
     int cornerRadius = 8;
+    // -1 follows the system app theme; 0 forces light, 1 forces dark.
+    int popupThemeOverride = -1;
     int panelOpacity = 85;
-    bool acrylic = true;
+    bool panelBorder = true;
+    BlurType blurType = BlurType::Gaussian;
+    int blurStrength = 40;
     int gapAbove = 8;
     int gapBefore = 0;
     int gapAfter = 0;
@@ -577,6 +664,18 @@ std::wstring ExpandEnv(const std::wstring& s) {
 
 std::wstring GetStringSetting(PCWSTR name) {
     return WindhawkUtils::StringSetting::make(name).get();
+}
+
+// Weight settings are stored as LOGFONT lfWeight values so MakePopupFont can
+// hand them straight to the GDI font mapper.
+int ParseFontWeight(const std::wstring& value, int fallback) {
+    if (value == L"regular") {
+        return FW_NORMAL;
+    }
+    if (value == L"bold") {
+        return FW_BOLD;
+    }
+    return fallback;
 }
 
 // An icon setting is a file reference if it looks like a path, otherwise it is
@@ -1023,23 +1122,33 @@ void LoadSettings() {
         g_settings.cellWidth = 92;
         g_settings.cellHeight = 88;
     }
+    g_settings.showLabels = Wh_GetIntSetting(L"showLabels");
     g_settings.fontSize = std::clamp<int>(Wh_GetIntSetting(L"fontSize"), 6, 48);
-    g_settings.itemFontFamily = GetStringSetting(L"itemFontFamily");
-    g_settings.itemFontBold = GetStringSetting(L"itemFontWeight") == L"bold";
+    g_settings.itemFontWeight =
+        ParseFontWeight(GetStringSetting(L"itemFontWeight"), FW_BOLD);
+    g_settings.showTitle = Wh_GetIntSetting(L"showTitle");
     g_settings.titleFontSize =
         std::clamp<int>(Wh_GetIntSetting(L"titleFontSize"), 6, 48);
-    g_settings.titleFontFamily = GetStringSetting(L"titleFontFamily");
-    g_settings.titleFontBold =
-        GetStringSetting(L"titleFontWeight") != L"regular";
+    g_settings.titleFontWeight =
+        ParseFontWeight(GetStringSetting(L"titleFontWeight"), FW_BOLD);
     g_settings.titleAlign = GetStringSetting(L"titleAlign");
     if (g_settings.titleAlign != L"left" && g_settings.titleAlign != L"right") {
         g_settings.titleAlign = L"center";
     }
     g_settings.cornerRadius =
         std::clamp<int>(Wh_GetIntSetting(L"cornerRadius"), 0, 32);
+    std::wstring popupTheme = GetStringSetting(L"popupTheme");
+    g_settings.popupThemeOverride =
+        popupTheme == L"light" ? 0 : (popupTheme == L"dark" ? 1 : -1);
     g_settings.panelOpacity =
-        std::clamp<int>(Wh_GetIntSetting(L"panelOpacity"), 5, 100);
-    g_settings.acrylic = Wh_GetIntSetting(L"acrylic");
+        std::clamp<int>(Wh_GetIntSetting(L"panelOpacity"), 0, 100);
+    g_settings.panelBorder = Wh_GetIntSetting(L"panelBorder");
+    std::wstring blurType = GetStringSetting(L"blurType");
+    g_settings.blurType = blurType == L"acrylic"   ? BlurType::Acrylic
+                          : blurType == L"none"    ? BlurType::None
+                                                    : BlurType::Gaussian;
+    g_settings.blurStrength =
+        std::clamp<int>(Wh_GetIntSetting(L"blurStrength"), 0, 100);
     g_settings.gapAbove =
         std::clamp<int>(Wh_GetIntSetting(L"gapAbove"), 0, 200);
     g_settings.gapBefore =
@@ -1399,6 +1508,17 @@ bool IsDarkTheme() {
     return g_themeCache.dark;
 }
 
+// Theme the hover grid paints itself with: the popupTheme setting when it
+// forces light or dark, the system app theme otherwise. The taskbar button
+// highlight keeps following the system unconditionally so it stays consistent
+// with the shell's own icons.
+bool IsDarkPopupTheme() {
+    if (g_settings.popupThemeOverride >= 0) {
+        return g_settings.popupThemeOverride != 0;
+    }
+    return IsDarkTheme();
+}
+
 Gdiplus::Color GetAccentGdipColor(BYTE alpha) {
     if (!g_themeCache.resolved) {
         RefreshThemeCache();
@@ -1415,17 +1535,48 @@ PCWSTR PopupFontName() {
                                               : L"Segoe UI";
 }
 
-// Falls back to the system popup font when |custom| is empty or names a font
-// that isn't installed (FontFamily construction succeeds either way, but a
-// missing family leaves it in a bad state that GDI+ renders as boxes).
-std::wstring ResolvePopupFontName(const std::wstring& custom) {
-    if (!custom.empty()) {
-        Gdiplus::FontFamily family(custom.c_str());
-        if (family.GetLastStatus() == Gdiplus::Ok) {
-            return custom;
-        }
+// Grid text is Arial. FontFamily construction succeeds even for a missing
+// family but leaves the object in a state GDI+ renders as boxes, so an absent
+// Arial falls back to the system popup font.
+std::wstring PopupTextFontName() {
+    Gdiplus::FontFamily arial(L"Arial");
+    if (arial.GetLastStatus() == Gdiplus::Ok) {
+        return L"Arial";
     }
     return PopupFontName();
+}
+
+// Built from a LOGFONT rather than a FontFamily + FontStyle so lfWeight goes to
+// the GDI font mapper, which resolves it against the family's real members.
+// Falls back to the FontFamily path if the mapper gives us something GDI+
+// cannot use.
+std::unique_ptr<Gdiplus::Font> MakePopupFont(int sizePx, int weight) {
+    std::wstring name = PopupTextFontName();
+
+    LOGFONTW lf{};
+    // Negative lfHeight is the em size in pixels, matching what UnitPixel meant
+    // to the FontFamily constructor this replaced.
+    lf.lfHeight = -sizePx;
+    lf.lfWeight = weight;
+    lf.lfCharSet = DEFAULT_CHARSET;
+    lf.lfOutPrecision = OUT_TT_PRECIS;
+    lf.lfQuality = CLEARTYPE_QUALITY;
+    wcsncpy_s(lf.lfFaceName, name.c_str(), _TRUNCATE);
+
+    if (HDC hdc = GetDC(nullptr)) {
+        auto font = std::make_unique<Gdiplus::Font>(hdc, &lf);
+        ReleaseDC(nullptr, hdc);
+        if (font && font->GetLastStatus() == Gdiplus::Ok) {
+            return font;
+        }
+    }
+
+    Gdiplus::FontFamily fallbackFamily(name.c_str());
+    return std::make_unique<Gdiplus::Font>(
+        &fallbackFamily, (Gdiplus::REAL)sizePx,
+        weight >= FW_BOLD ? Gdiplus::FontStyleBold
+                              : Gdiplus::FontStyleRegular,
+        Gdiplus::UnitPixel);
 }
 
 // True when the alpha channel carries real transparency (partial alpha, or a
@@ -1721,6 +1872,68 @@ std::shared_ptr<Gdiplus::Bitmap> BitmapFromBgraScaled(const BYTE* bgra,
     return result;
 }
 
+// An icon is treated as artwork centred in an oversized slot, rather than as an
+// icon with its own generous padding, only when it covers less than this much of
+// its canvas. Real icons run 80-100%; a 48px icon in a 256px slot is 19%.
+constexpr int kIconCanvasFillPercent = 62;
+
+// SHIL_JUMBO image-list entries are 256x256 slots, and an app whose icon has no
+// 256px variant gets its smaller artwork centred in that slot instead of scaled
+// up to fill it. Scaling the whole slot down to the requested size then renders
+// the artwork at a fraction of that size. Crop back to the artwork when it fills
+// only a small part of the canvas; ordinary icons are left untouched.
+bool CropIconCanvasPadding(std::vector<BYTE>& bgra, int* w, int* h) {
+    int width = *w;
+    int height = *h;
+    if (width <= 0 || height <= 0 ||
+        bgra.size() < (size_t)width * height * 4) {
+        return false;
+    }
+
+    int minX = width;
+    int minY = height;
+    int maxX = -1;
+    int maxY = -1;
+    for (int y = 0; y < height; y++) {
+        const BYTE* row = bgra.data() + (size_t)y * width * 4;
+        for (int x = 0; x < width; x++) {
+            if (row[x * 4 + 3] == 0) {
+                continue;
+            }
+            minX = std::min(minX, x);
+            maxX = std::max(maxX, x);
+            minY = std::min(minY, y);
+            maxY = std::max(maxY, y);
+        }
+    }
+    if (maxX < minX || maxY < minY) {
+        return false;  // Fully transparent; nothing to crop to.
+    }
+
+    int contentW = maxX - minX + 1;
+    int contentH = maxY - minY + 1;
+    if (contentW * 100 > width * kIconCanvasFillPercent ||
+        contentH * 100 > height * kIconCanvasFillPercent) {
+        return false;
+    }
+
+    // Square, centred on the artwork, so the aspect ratio survives the scale.
+    int side = std::min({std::max(contentW, contentH), width, height});
+    int left = std::clamp((minX + maxX) / 2 - side / 2, 0, width - side);
+    int top = std::clamp((minY + maxY) / 2 - side / 2, 0, height - side);
+
+    std::vector<BYTE> cropped((size_t)side * side * 4);
+    for (int y = 0; y < side; y++) {
+        memcpy(cropped.data() + (size_t)y * side * 4,
+               bgra.data() + (size_t)(top + y) * width * 4 + (size_t)left * 4,
+               (size_t)side * 4);
+    }
+    bgra.swap(cropped);
+    *w = side;
+    *h = side;
+    return true;
+}
+
 // Convert HICON to a sized 32bpp PARGB bitmap for every icon type:
 // 1) Prefer color-plane pixels that already carry useful alpha (modern ARGB).
 // 2) Otherwise apply the 1-bit AND mask (black=opaque, white=transparent) so
@@ -1790,6 +2003,7 @@ std::shared_ptr<Gdiplus::Bitmap> HIconToBitmap(HICON hIcon, int size) {
                 ApplyIconAndMaskToBgra(bgra.data(), srcW, srcH, ii.hbmMask,
                                        monoIcon);
             }
+            CropIconCanvasPadding(bgra, &srcW, &srcH);
             SanitizeAndPremultiplyBgra(bgra.data(), srcW, srcH, srcW * 4);
             auto scaled =
                 BitmapFromBgraScaled(bgra.data(), srcW, srcH, size);
@@ -2909,7 +3123,14 @@ constexpr PCWSTR kPopupClassName = L"WH_TaskbarFolderHoverTray_Grid";
 constexpr PCWSTR kMenuOwnerClassName = L"WH_TaskbarFolderHoverTray_MenuOwner";
 constexpr UINT_PTR kTickTimerId = 1;
 constexpr UINT_PTR kOpenTimerId = 2;
-constexpr UINT kTickTimerMs = 50;
+// Separate from kTickTimerId so the blur's refresh rate isn't tied to (or
+// capped by) the hover/close/submenu poll cadence.
+constexpr UINT_PTR kBlurTimerId = 3;
+constexpr UINT kTickTimerMs = 16;
+// 32ms = ~30fps. Fixed rather than matched to the monitor: simpler, and this
+// is capture+resample cost paid on a timer, not a true frame rate - no need
+// to chase 144/240Hz for a hover popup's backdrop.
+constexpr UINT kBlurTimerMs = 32;
 // Hard cap on cascade depth so a symlink loop cannot exhaust window handles.
 constexpr int kMaxLevels = 16;
 
@@ -2936,6 +3157,14 @@ struct PopupLevel {
     int cachedBaseW = 0;
     int cachedBaseH = 0;
     bool baseDirty = true;
+    // Screen capture behind the panel's rect, softened by CaptureBlurredBackdrop.
+    // Baked into cachedBase by RebuildLevelBase, not drawn separately - see
+    // PresentLevel for when this is (re)captured.
+    std::unique_ptr<Gdiplus::Bitmap> blurBackdrop;
+    // Size the rounded window region was last built for, so hover repaints do
+    // not rebuild it. See ApplyRoundedRegion.
+    int regionW = 0;
+    int regionH = 0;
 };
 
 // Created on the taskbar UI thread, read from the Windhawk engine thread, an
@@ -2954,6 +3183,20 @@ std::vector<std::unique_ptr<PopupLevel>>& Levels() {
         g_levels.emplace();
     }
     return *g_levels;
+}
+
+// Leaving WDA_EXCLUDEFROMCAPTURE set permanently kept the grid out of every
+// screenshot tool, not just our own BitBlt in CaptureBlurredBackdrop - the
+// whole tray would vanish from Snipping Tool/PrtScn/OBS any time it was open.
+// Toggled on for the few milliseconds our own capture runs, then back off
+// immediately after, so only that instant is blind to it.
+void SetOwnWindowsCaptureExcluded(bool excluded) {
+    DWORD affinity = excluded ? WDA_EXCLUDEFROMCAPTURE : WDA_NONE;
+    for (HWND hWnd : g_levelWindows) {
+        if (hWnd) {
+            SetWindowDisplayAffinity(hWnd, affinity);
+        }
+    }
 }
 
 RECT g_rootAnchorRect{};
@@ -3032,50 +3275,65 @@ int ScaleForPopup(int value) {
     return MulDiv(value, g_popupDpi, 96);
 }
 
-struct AccentPolicy {
-    int accentState;
-    int accentFlags;
-    unsigned int gradientColor;
-    int animationId;
-};
+// Physical icon size in the grid. With labels hidden the icon grows to fill the
+// cell instead of leaving the label's share of it empty. Icons are extracted at
+// this size too, not upscaled from a cached bitmap made at the configured one.
+int PopupIconPixelSize() {
+    int size = ScaleForPopup(g_settings.iconSize);
+    if (!g_settings.showLabels) {
+        int fit = std::min<int>(ScaleForPopup(g_settings.cellWidth),
+                                ScaleForPopup(g_settings.cellHeight)) -
+                  ScaleForPopup(8) * 2;
+        size = std::max<int>(size, fit);
+    }
+    return size;
+}
 
-struct WindowCompositionAttributeData {
-    int attribute;
-    void* data;
-    size_t dataSize;
-};
-
+// Gaussian blur is rendered ourselves (see CaptureBlurredBackdrop): capturing
+// and blurring the screen by hand costs a BitBlt + resample every
+// kBlurTimerMs, but gives a real, adjustable, untinted blur radius. Acrylic
+// instead hands the backdrop to DWM's own SetWindowCompositionAttribute
+// accent below - much cheaper (no capture, no resample, updates live for
+// free) but the blur radius itself is fixed by Windows; only the tint's
+// opacity is ours to adjust, via GradientColor's alpha.
 void ApplyBackdrop(HWND hWnd) {
+    // Capture exclusion is applied transiently around our own BitBlt instead
+    // of here - see SetOwnWindowsCaptureExcluded - so the window stays
+    // screenshot/recording-visible the rest of the time.
+
     int corner = DWMWCP_ROUND;
     DwmSetWindowAttribute(hWnd, DWMWA_WINDOW_CORNER_PREFERENCE, &corner,
                           sizeof(corner));
 
-    if (!g_settings.acrylic) {
-        return;
+    // DWM draws its own 1px border on a rounded window, independent of anything
+    // we paint. That is the outline that survived at opacity 0 - our own border
+    // pen was already skipped there, but this one is system chrome.
+    if (!g_settings.panelBorder) {
+        COLORREF border = DWMWA_COLOR_NONE;
+        DwmSetWindowAttribute(hWnd, DWMWA_BORDER_COLOR, &border,
+                              sizeof(border));
     }
 
-    using SetWindowCompositionAttribute_t =
-        BOOL(WINAPI*)(HWND, WindowCompositionAttributeData*);
-    static auto setWindowCompositionAttribute =
-        (SetWindowCompositionAttribute_t)GetProcAddress(
-            GetModuleHandleW(L"user32.dll"), "SetWindowCompositionAttribute");
-    if (!setWindowCompositionAttribute) {
-        return;
+    if (auto setWindowCompositionAttribute = GetSetWindowCompositionAttribute()) {
+        ACCENT_POLICY accent{};
+        if (g_settings.blurType == BlurType::Acrylic &&
+            g_settings.blurStrength > 0) {
+            accent.AccentState = ACCENT_ENABLE_ACRYLICBLURBEHIND;
+            // Grayscale tint (R=G=B), so byte order within GradientColor
+            // doesn't matter. Strength is the tint's opacity, not the blur
+            // radius - Windows fixes that itself.
+            bool dark = IsDarkPopupTheme();
+            DWORD rgb = dark ? 0x2B2B2Bu : 0xF9F9F9u;
+            BYTE alpha =
+                (BYTE)(std::clamp(g_settings.blurStrength, 1, 100) * 255 / 100);
+            accent.GradientColor = ((DWORD)alpha << 24) | rgb;
+        } else {
+            accent.AccentState = ACCENT_DISABLED;
+        }
+        WINDOWCOMPOSITIONATTRIBDATA data{WCA_ACCENT_POLICY, &accent,
+                                         sizeof(accent)};
+        setWindowCompositionAttribute(hWnd, &data);
     }
-
-    // ACCENT_ENABLE_ACRYLICBLURBEHIND with a nearly transparent tint; the
-    // visible panel colour is painted by us so the blur only adds depth.
-    AccentPolicy policy{};
-    policy.accentState = 4;
-    policy.accentFlags = 0;
-    policy.gradientColor = IsDarkTheme() ? 0x20000000 : 0x20FFFFFF;
-    policy.animationId = 0;
-
-    WindowCompositionAttributeData data{};
-    data.attribute = 19;  // WCA_ACCENT_POLICY
-    data.data = &policy;
-    data.dataSize = sizeof(policy);
-    setWindowCompositionAttribute(hWnd, &data);
 }
 
 void AddRoundedRect(Gdiplus::GraphicsPath* path,
@@ -3092,6 +3350,19 @@ void AddRoundedRect(Gdiplus::GraphicsPath* path,
     path->AddArc(rect.GetRight() - d, rect.GetBottom() - d, d, d, 0.0f, 90.0f);
     path->AddArc(rect.X, rect.GetBottom() - d, d, d, 90.0f, 90.0f);
     path->CloseFigure();
+}
+
+// Signed distance from (px, py) to the boundary of an axis-aligned rounded
+// rect of half-extents (hw, hh) and corner radius r, both centered on the
+// origin. <=0 inside/on the shape, growing positive outward - the standard
+// rounded-box SDF. Gives the panel's own Gaussian blur a smoothly
+// antialiased edge (PaintLevel), rather than GDI+'s aliased region-clip.
+float RoundedBoxSDF(float px, float py, float hw, float hh, float r) {
+    float qx = std::abs(px) - (hw - r);
+    float qy = std::abs(py) - (hh - r);
+    float ax = std::max(qx, 0.0f);
+    float ay = std::max(qy, 0.0f);
+    return std::sqrt(ax * ax + ay * ay) + std::min(std::max(qx, qy), 0.0f) - r;
 }
 
 // A minimal folder silhouette: a body whose top edge steps up on the left to
@@ -3112,7 +3383,8 @@ void AddFolderGlyphPath(Gdiplus::GraphicsPath* path,
 
 // Extra top band reserved for the root folder title. Subfolder menus skip this.
 int RootTitleBandHeight(const PopupLevel* level) {
-    if (!level || level->depth != 0 || level->title.empty()) {
+    if (!level || !g_settings.showTitle || level->depth != 0 ||
+        level->title.empty()) {
         return 0;
     }
     return ScaleForPopup(8) + ScaleForPopup(g_settings.titleFontSize) +
@@ -3228,6 +3500,38 @@ bool CanExpand(int depth) {
     return depth < g_settings.maxFolderDepth && depth + 1 < kMaxLevels;
 }
 
+// Clips the window itself to the same rounded rect the panel is painted with.
+// The blur background and DWM's border are drawn against the window shape, not
+// against our alpha, so without this they kept square corners while the painted
+// background was round. Rebuilt only when the size changes - hover repaints run
+// through PaintLevel too.
+void ApplyRoundedRegion(PopupLevel* level, int width, int height) {
+    if (!level || !level->hwnd || width <= 0 || height <= 0) {
+        return;
+    }
+    if (level->regionW == width && level->regionH == height) {
+        return;
+    }
+
+    int radius = ScaleForPopup(g_settings.cornerRadius);
+    // CreateRoundRectRgn's ellipse size is the full diameter, and its right and
+    // bottom edges are exclusive.
+    HRGN region =
+        radius > 0 ? CreateRoundRectRgn(0, 0, width + 1, height + 1, radius * 2,
+                                        radius * 2)
+                   : CreateRectRgn(0, 0, width, height);
+    if (!region) {
+        return;
+    }
+    // On success the window owns the region; do not delete it here.
+    if (SetWindowRgn(level->hwnd, region, FALSE)) {
+        level->regionW = width;
+        level->regionH = height;
+    } else {
+        DeleteObject(region);
+    }
+}
+
 void InvalidateLevelBase(PopupLevel* level) {
     if (!level) {
         return;
@@ -3238,11 +3542,57 @@ void InvalidateLevelBase(PopupLevel* level) {
     level->cachedBaseH = 0;
 }
 
+// Floor for the panel fill's alpha. UpdateLayeredWindow hit-tests against the
+// alpha channel: a 0-alpha pixel is click-through straight to whatever is
+// behind the grid, so without a floor the gaps between icons stop taking
+// clicks/WM_MOUSEMOVE. 1/255 is the standard "invisible but still hit-tests"
+// value for layered windows - premultiplied, it rounds a near-black or
+// near-white fill down to a 0 or 1 RGB component, which is not distinguishable
+// from true transparency on screen.
+constexpr int kHitTestAlpha = 1;
+
+BYTE PanelAlpha() {
+    return (BYTE)std::clamp<int>(g_settings.panelOpacity * 255 / 100,
+                                 kHitTestAlpha, 255);
+}
+
+
+// Grid text is white in both themes, so the outline is always black. Eight
+// offsets at one scaled pixel: corners covered, edge crisp.
+//
+// On a dark panel the outline only has to work once the desktop starts showing
+// through, so it fades in as the panel fades out. On a light panel white text
+// needs the outline at every opacity or it disappears into the panel, so there
+// it stays at full strength.
+void DrawStringWithShadow(Gdiplus::Graphics& g,
+                          PCWSTR text,
+                          Gdiplus::Font& font,
+                          const Gdiplus::RectF& rect,
+                          Gdiplus::StringFormat& format,
+                          const Gdiplus::Color& textColor,
+                          BYTE panelAlpha) {
+    int outline = IsDarkPopupTheme() ? 255 - panelAlpha : 255;
+    if (outline > 0) {
+        Gdiplus::SolidBrush outlineBrush(Gdiplus::Color((BYTE)outline, 0, 0, 0));
+        Gdiplus::REAL d = (Gdiplus::REAL)std::max<int>(1, ScaleForPopup(1));
+        const Gdiplus::REAL offsets[8][2] = {{-d, -d}, {0, -d}, {d, -d}, {-d, 0},
+                                             {d, 0},   {-d, d}, {0, d},  {d, d}};
+        for (const auto& off : offsets) {
+            Gdiplus::RectF outlineRect = rect;
+            outlineRect.Offset(off[0], off[1]);
+            g.DrawString(text, -1, &font, outlineRect, &format, &outlineBrush);
+        }
+    }
+    Gdiplus::SolidBrush textBrush(textColor);
+    g.DrawString(text, -1, &font, rect, &format, &textBrush);
+}
+
 // Icon, folder badge, and label for one grid cell. Shared by the static base
 // paint and the hover/press cell overlay so the two stay visually identical.
 void DrawCell(Gdiplus::Graphics& g,
               PopupLevel* level,
               int index,
+              BYTE panelAlpha,
               const Gdiplus::Color& textColor,
               const Gdiplus::Color& badgeFillColor,
               const Gdiplus::Color& badgeMarkColor,
@@ -3259,9 +3609,12 @@ void DrawCell(Gdiplus::Graphics& g,
     int cellH = cell.bottom - cell.top;
     const GridItem& item = level->items[index];
 
-    int iconSize = ScaleForPopup(g_settings.iconSize);
-    int iconTop = ScaleForPopup(10);
+    int iconSize = PopupIconPixelSize();
     int labelGap = ScaleForPopup(6);
+    // With labels hidden the icon owns the whole cell, so centre it instead of
+    // leaving it parked at the top over empty space.
+    int iconTop = g_settings.showLabels ? ScaleForPopup(10)
+                                        : (cellH - iconSize) / 2;
     bool expandable = CanExpand(level->depth);
 
     Gdiplus::Rect iconRect(cell.left + (cellW - iconSize) / 2,
@@ -3294,17 +3647,92 @@ void DrawCell(Gdiplus::Graphics& g,
         g.FillPath(&markBrush, &glyphPath);
     }
 
-    Gdiplus::SolidBrush textBrush(textColor);
     Gdiplus::RectF labelRect(
         (Gdiplus::REAL)(cell.left + ScaleForPopup(4)),
         (Gdiplus::REAL)(cell.top + iconTop + iconSize + labelGap),
         (Gdiplus::REAL)(cellW - ScaleForPopup(8)),
         (Gdiplus::REAL)(cellH - iconTop - iconSize - labelGap -
                         ScaleForPopup(4)));
-    if (labelRect.Height > 0) {
-        g.DrawString(item.displayName.c_str(), -1, &font, labelRect, &format,
-                     &textBrush);
+    if (g_settings.showLabels && labelRect.Height > 0) {
+        DrawStringWithShadow(g, item.displayName.c_str(), font, labelRect,
+                             format, textColor, panelAlpha);
     }
+}
+
+// Captures the desktop behind screenRect and softens it with a cheap,
+// tint-free blur: shrink heavily (the resampling itself is what blurs it),
+// then stretch back up. Higher strength shrinks further, so there is more
+// for the upscale to smooth over - a real, adjustable blur radius, unlike
+// DWM's fixed-radius accent blur. Safe to call with the level's own window
+// visible and covering screenRect: capture exclusion is toggled on for just
+// the BitBlt below (see SetOwnWindowsCaptureExcluded), so that window's
+// pixels don't show up in its own blur without staying invisible to
+// screenshot tools the rest of the time.
+std::unique_ptr<Gdiplus::Bitmap> CaptureBlurredBackdrop(const RECT& screenRect,
+                                                        int strength) {
+    int width = screenRect.right - screenRect.left;
+    int height = screenRect.bottom - screenRect.top;
+    if (width <= 0 || height <= 0 || strength <= 0) {
+        return nullptr;
+    }
+
+    HDC hScreenDC = GetDC(nullptr);
+    if (!hScreenDC) {
+        return nullptr;
+    }
+    HDC hMemDC = CreateCompatibleDC(hScreenDC);
+    HBITMAP hBmp =
+        hMemDC ? CreateCompatibleBitmap(hScreenDC, width, height) : nullptr;
+
+    std::unique_ptr<Gdiplus::Bitmap> captured;
+    if (hMemDC && hBmp) {
+        HGDIOBJ old = SelectObject(hMemDC, hBmp);
+        SetOwnWindowsCaptureExcluded(true);
+        BitBlt(hMemDC, 0, 0, width, height, hScreenDC, screenRect.left,
+              screenRect.top, SRCCOPY);
+        SetOwnWindowsCaptureExcluded(false);
+        SelectObject(hMemDC, old);
+        captured.reset(Gdiplus::Bitmap::FromHBITMAP(hBmp, nullptr));
+    }
+    if (hBmp) {
+        DeleteObject(hBmp);
+    }
+    if (hMemDC) {
+        DeleteDC(hMemDC);
+    }
+    ReleaseDC(nullptr, hScreenDC);
+
+    if (!captured || captured->GetLastStatus() != Gdiplus::Ok) {
+        return nullptr;
+    }
+
+    float shrink = 1.0f + (float)std::clamp(strength, 0, 100) / 100.0f * 14.0f;
+    int smallW = std::max(1, (int)(width / shrink));
+    int smallH = std::max(1, (int)(height / shrink));
+
+    Gdiplus::Bitmap small(smallW, smallH, PixelFormat32bppRGB);
+    if (small.GetLastStatus() != Gdiplus::Ok) {
+        return nullptr;
+    }
+    {
+        Gdiplus::Graphics g(&small);
+        g.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBilinear);
+        g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
+        g.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
+        g.DrawImage(captured.get(), 0, 0, smallW, smallH);
+    }
+
+    auto result = std::make_unique<Gdiplus::Bitmap>(width, height,
+                                                     PixelFormat32bppRGB);
+    if (!result || result->GetLastStatus() != Gdiplus::Ok) {
+        return nullptr;
+    }
+    Gdiplus::Graphics g(result.get());
+    g.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBicubic);
+    g.SetSmoothingMode(Gdiplus::SmoothingModeNone);
+    g.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
+    g.DrawImage(&small, 0, 0, width, height);
+    return result;
 }
 
 // Paints the static panel (no hover/press chrome) into level->cachedBase.
@@ -3320,19 +3748,27 @@ bool RebuildLevelBase(PopupLevel* level, int width, int height) {
     g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
     g.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBicubic);
     g.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
-    g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAlias);
+    // GridFit, not plain AntiAlias: without grid fitting GDI+ places stems on
+    // fractional pixels, which is what made labels look thin and grainy. Only
+    // the GridFit variants hint the outline onto the pixel grid. ClearType is
+    // not an option here - subpixel AA has no defined result on the
+    // transparent PARGB surface a layered window needs.
+    g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAliasGridFit);
     g.Clear(Gdiplus::Color(0, 0, 0, 0));
 
-    bool dark = IsDarkTheme();
-    BYTE panelAlpha =
-        (BYTE)std::clamp<int>(g_settings.panelOpacity * 255 / 100, 10, 255);
+    bool dark = IsDarkPopupTheme();
+    // 0 = gamma 1.0. The GDI+ default of 4 eats the edge coverage of light
+    // glyphs, and grid text is always light. Tuning knob if a font renders off.
+    g.SetTextContrast(0);
+    BYTE panelAlpha = PanelAlpha();
     Gdiplus::Color panelColor = dark
                                     ? Gdiplus::Color(panelAlpha, 43, 43, 43)
                                     : Gdiplus::Color(panelAlpha, 249, 249, 249);
     Gdiplus::Color borderColor =
         dark ? Gdiplus::Color(40, 255, 255, 255) : Gdiplus::Color(28, 0, 0, 0);
-    Gdiplus::Color textColor = dark ? Gdiplus::Color(255, 255, 255, 255)
-                                    : Gdiplus::Color(255, 26, 26, 26);
+    // White in both themes - the black outline carries the contrast, so the
+    // light theme does not need dark text.
+    Gdiplus::Color textColor(255, 255, 255, 255);
     Gdiplus::Color badgeFillColor = GetAccentGdipColor(255);
     bool lightAccent = ((int)badgeFillColor.GetR() + badgeFillColor.GetG() +
                         badgeFillColor.GetB()) > 500;
@@ -3347,18 +3783,34 @@ bool RebuildLevelBase(PopupLevel* level, int width, int height) {
     Gdiplus::GraphicsPath panelPath;
     AddRoundedRect(&panelPath, panelRect, radius);
 
+    // Blur is not baked in here - see PaintLevel. It is re-captured far more
+    // often than icons/text/fill change, so it is composited straight into
+    // the final DIB every repaint instead of forcing a full RebuildLevelBase
+    // (icon/badge/text redraws) on every blur tick.
+    //
+    // The fill still runs at opacity 0 - see PanelAlpha() - but the border is
+    // optional so nothing of the panel need be left on screen.
+    //
+    // SourceCopy, not the default SourceOver: this Graphics runs at
+    // CompositingQualityHighQuality, which is GDI+'s gamma-corrected blend, and
+    // gamma-correcting an alpha of kHitTestAlpha against the transparent
+    // surface rounds it straight back down to 0 - which is exactly the
+    // click-through hole PanelAlpha()'s floor exists to prevent. The fill is
+    // the first thing drawn onto a just-cleared bitmap, so there is nothing
+    // underneath for SourceOver to preserve anyway; copying writes the alpha
+    // byte verbatim. Antialiasing still applies, so the rounded corners keep
+    // their partial-alpha edge.
     Gdiplus::SolidBrush panelBrush(panelColor);
+    g.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
     g.FillPath(&panelBrush, &panelPath);
-    Gdiplus::Pen borderPen(borderColor, 1.0f);
-    g.DrawPath(&borderPen, &panelPath);
+    g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
+    if (g_settings.panelBorder) {
+        Gdiplus::Pen borderPen(borderColor, 1.0f);
+        g.DrawPath(&borderPen, &panelPath);
+    }
 
-    Gdiplus::FontFamily family(
-        ResolvePopupFontName(g_settings.itemFontFamily).c_str());
-    Gdiplus::Font font(&family, (Gdiplus::REAL)ScaleForPopup(g_settings.fontSize),
-                       g_settings.itemFontBold ? Gdiplus::FontStyleBold
-                                                : Gdiplus::FontStyleRegular,
-                       Gdiplus::UnitPixel);
-    Gdiplus::SolidBrush textBrush(textColor);
+    auto font = MakePopupFont(ScaleForPopup(g_settings.fontSize),
+                              g_settings.itemFontWeight);
 
     Gdiplus::StringFormat format;
     format.SetAlignment(Gdiplus::StringAlignmentCenter);
@@ -3368,13 +3820,8 @@ bool RebuildLevelBase(PopupLevel* level, int width, int height) {
 
     int titleBand = RootTitleBandHeight(level);
     if (titleBand > 0) {
-        Gdiplus::FontFamily titleFamily(
-            ResolvePopupFontName(g_settings.titleFontFamily).c_str());
-        Gdiplus::Font titleFont(
-            &titleFamily, (Gdiplus::REAL)ScaleForPopup(g_settings.titleFontSize),
-            g_settings.titleFontBold ? Gdiplus::FontStyleBold
-                                      : Gdiplus::FontStyleRegular,
-            Gdiplus::UnitPixel);
+        auto titleFont = MakePopupFont(ScaleForPopup(g_settings.titleFontSize),
+                                       g_settings.titleFontWeight);
         Gdiplus::StringFormat titleFormat;
         if (g_settings.titleAlign == L"left") {
             titleFormat.SetAlignment(Gdiplus::StringAlignmentNear);
@@ -3392,8 +3839,8 @@ bool RebuildLevelBase(PopupLevel* level, int width, int height) {
             (Gdiplus::REAL)pad, (Gdiplus::REAL)ScaleForPopup(4),
             (Gdiplus::REAL)(width - pad * 2),
             (Gdiplus::REAL)(titleBand - ScaleForPopup(4)));
-        g.DrawString(level->title.c_str(), -1, &titleFont, titleRect,
-                     &titleFormat, &textBrush);
+        DrawStringWithShadow(g, level->title.c_str(), *titleFont, titleRect,
+                             titleFormat, textColor, panelAlpha);
     }
 
     if (level->items.empty()) {
@@ -3403,13 +3850,14 @@ bool RebuildLevelBase(PopupLevel* level, int width, int height) {
         PCWSTR message = level->loading ? L"Loading..." : L"Empty folder";
         Gdiplus::RectF area(0.0f, (Gdiplus::REAL)titleBand, (Gdiplus::REAL)width,
                             (Gdiplus::REAL)(height - titleBand));
-        g.DrawString(message, -1, &font, area, &centered, &textBrush);
+        DrawStringWithShadow(g, message, *font, area, centered, textColor,
+                             panelAlpha);
     }
 
     for (size_t i = 0; i < level->items.size() && i < level->cellRects.size();
          i++) {
-        DrawCell(g, level, (int)i, textColor, badgeFillColor, badgeMarkColor,
-                 badgeRingColor, font, format);
+        DrawCell(g, level, (int)i, panelAlpha, textColor, badgeFillColor,
+                 badgeMarkColor, badgeRingColor, *font, format);
     }
 
     level->cachedBase = std::move(bitmap);
@@ -3475,20 +3923,81 @@ void PaintLevel(PopupLevel* level) {
         g.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
         g.SetInterpolationMode(Gdiplus::InterpolationModeNearestNeighbor);
         g.Clear(Gdiplus::Color(0, 0, 0, 0));
-        g.DrawImage(level->cachedBase.get(), 0, 0, width, height);
 
+        // Blur goes down first, edged to the same rounded shape cachedBase's
+        // own fill/border/icons are clipped to (see RebuildLevelBase), so it
+        // never shows square corners under the panel. Composited fresh every
+        // repaint - re-captured far more often than icons/text change - while
+        // cachedBase underneath is cheap to reuse as-is.
+        //
+        // Written by hand via RoundedBoxSDF, not a GDI+ region clip: region
+        // clipping is always hard-edged in GDI+ regardless of SmoothingMode.
+        // Small (~1px) antialiasing band, just enough to not be a hard cut,
+        // matching the fill/border's own AntiAlias smoothing on top.
+        if (level->blurBackdrop &&
+            level->blurBackdrop->GetWidth() == (UINT)width &&
+            level->blurBackdrop->GetHeight() == (UINT)height) {
+            Gdiplus::Rect full(0, 0, width, height);
+            Gdiplus::BitmapData srcData;
+            if (level->blurBackdrop->LockBits(&full, Gdiplus::ImageLockModeRead,
+                                              PixelFormat32bppRGB,
+                                              &srcData) == Gdiplus::Ok) {
+                float radius = (float)ScaleForPopup(g_settings.cornerRadius);
+                float hw = (width - 1) / 2.0f;
+                float hh = (height - 1) / 2.0f;
+                constexpr float kEdgeAA = 1.0f;
+                for (int y = 0; y < height; y++) {
+                    auto* src =
+                        (uint32_t*)((BYTE*)srcData.Scan0 + y * srcData.Stride);
+                    auto* dst = (uint32_t*)((BYTE*)bits + y * width * 4);
+                    for (int x = 0; x < width; x++) {
+                        float d = RoundedBoxSDF((float)x - hw, (float)y - hh,
+                                                hw, hh, radius);
+                        float alpha =
+                            255.0f * (1.0f - std::clamp((d + kEdgeAA * 0.5f) /
+                                                        kEdgeAA,
+                                                    0.0f, 1.0f));
+                        if (alpha <= 0.0f) {
+                            continue;
+                        }
+                        uint32_t px = src[x];
+                        BYTE a = (BYTE)(alpha + 0.5f);
+                        BYTE b = (BYTE)(px & 0xFF);
+                        BYTE g8 = (BYTE)((px >> 8) & 0xFF);
+                        BYTE r = (BYTE)((px >> 16) & 0xFF);
+                        dst[x] = ((uint32_t)a << 24) | ((r * a / 255) << 16) |
+                                ((g8 * a / 255) << 8) | (b * a / 255);
+                    }
+                }
+                level->blurBackdrop->UnlockBits(&srcData);
+            }
+        }
+
+        // Point overload, not the dest-rect one: with the default
+        // PixelOffsetModeNone a dest-rect DrawImage lands the 1:1 blit on a
+        // half-pixel offset and resamples the whole base, smearing every glyph.
+        // SourceOver, not SourceCopy: cachedBase's own alpha (panel fill,
+        // transparent corners) has to blend with the blur just drawn, not
+        // stomp it.
         g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
+        g.DrawImage(level->cachedBase.get(), 0, 0);
+
         g.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
         g.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBicubic);
-        g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAlias);
+        g.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHalf);
+        // Must match RebuildLevelBase - a hovered cell is repainted here and
+        // would otherwise not look like the same text as its neighbours.
+        g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAliasGridFit);
 
-        bool dark = IsDarkTheme();
+        bool dark = IsDarkPopupTheme();
+        // Must match RebuildLevelBase, or a hovered cell's text would not look
+        // like its neighbours'.
+        g.SetTextContrast(0);
         Gdiplus::Color hoverColor =
             dark ? Gdiplus::Color(28, 255, 255, 255) : Gdiplus::Color(18, 0, 0, 0);
         Gdiplus::Color pressColor =
             dark ? Gdiplus::Color(46, 255, 255, 255) : Gdiplus::Color(32, 0, 0, 0);
-        Gdiplus::Color textColor = dark ? Gdiplus::Color(255, 255, 255, 255)
-                                        : Gdiplus::Color(255, 26, 26, 26);
+        Gdiplus::Color textColor(255, 255, 255, 255);
         Gdiplus::Color badgeFillColor = GetAccentGdipColor(255);
         bool lightAccent = ((int)badgeFillColor.GetR() + badgeFillColor.GetG() +
                             badgeFillColor.GetB()) > 500;
@@ -3498,13 +4007,8 @@ void PaintLevel(PopupLevel* level) {
         Gdiplus::Color badgeRingColor = dark ? Gdiplus::Color(160, 0, 0, 0)
                                              : Gdiplus::Color(70, 255, 255, 255);
 
-        Gdiplus::FontFamily family(
-            ResolvePopupFontName(g_settings.itemFontFamily).c_str());
-        Gdiplus::Font font(&family,
-                           (Gdiplus::REAL)ScaleForPopup(g_settings.fontSize),
-                           g_settings.itemFontBold ? Gdiplus::FontStyleBold
-                                                    : Gdiplus::FontStyleRegular,
-                           Gdiplus::UnitPixel);
+        auto font = MakePopupFont(ScaleForPopup(g_settings.fontSize),
+                                  g_settings.itemFontWeight);
         Gdiplus::StringFormat format;
         format.SetAlignment(Gdiplus::StringAlignmentCenter);
         format.SetLineAlignment(Gdiplus::StringAlignmentNear);
@@ -3530,31 +4034,23 @@ void PaintLevel(PopupLevel* level) {
             Gdiplus::GraphicsPath highlightPath;
             AddRoundedRect(&highlightPath, highlight, ScaleForPopup(6));
 
-            bool darkPanel = IsDarkTheme();
-            BYTE panelAlpha = (BYTE)std::clamp<int>(
-                g_settings.panelOpacity * 255 / 100, 10, 255);
-            Gdiplus::Color panelColor =
-                darkPanel ? Gdiplus::Color(panelAlpha, 43, 43, 43)
-                          : Gdiplus::Color(panelAlpha, 249, 249, 249);
+            BYTE panelAlpha = PanelAlpha();
 
-            // Erase-then-overlay in two separate AA passes left a 1px fringe at
-            // the highlight's rounded edge (each pass antialiases against a
-            // different backdrop). Pre-blend the overlay onto the panel color
-            // and paint it in one SourceCopy pass instead.
+            // SourceOver straight onto whatever is already there (panel fill,
+            // and/or the blur backdrop composited further up) instead of
+            // erasing to a solid panelColor and recomputing alpha from
+            // panelAlpha alone. That erase used to throw away the blur
+            // backdrop's own opacity underneath the cell - with panelOpacity
+            // low, the recomputed alpha came out far below
+            // the blur's, punching a hole straight through to the real desktop
+            // instead of the blurred one. SourceOver only ever raises alpha
+            // (outA = srcA + dstA*(1-srcA)), so it can't create that hole.
             const Gdiplus::Color& overlay = pressed ? pressColor : hoverColor;
-            float a = overlay.GetA() / 255.0f;
-            Gdiplus::Color blended(
-                panelAlpha,
-                (BYTE)(panelColor.GetR() * (1 - a) + overlay.GetR() * a),
-                (BYTE)(panelColor.GetG() * (1 - a) + overlay.GetG() * a),
-                (BYTE)(panelColor.GetB() * (1 - a) + overlay.GetB() * a));
-            Gdiplus::SolidBrush highlightBrush(blended);
-            g.SetCompositingMode(Gdiplus::CompositingModeSourceCopy);
+            Gdiplus::SolidBrush highlightBrush(overlay);
             g.FillPath(&highlightBrush, &highlightPath);
-            g.SetCompositingMode(Gdiplus::CompositingModeSourceOver);
 
-            DrawCell(g, level, cellIndex, textColor, badgeFillColor,
-                     badgeMarkColor, badgeRingColor, font, format);
+            DrawCell(g, level, cellIndex, panelAlpha, textColor, badgeFillColor,
+                     badgeMarkColor, badgeRingColor, *font, format);
         };
 
         if (level->hoverCell >= 0 && level->hoverCell != level->pressedCell) {
@@ -3574,11 +4070,25 @@ void PaintLevel(PopupLevel* level) {
     blend.AlphaFormat = AC_SRC_ALPHA;
     UpdateLayeredWindow(level->hwnd, hScreenDC, &ptDst, &size, hMemDC, &ptSrc, 0,
                         &blend, ULW_ALPHA);
+    ApplyRoundedRegion(level, width, height);
 
     SelectObject(hMemDC, hOldBmp);
     DeleteObject(hBmp);
     DeleteDC(hMemDC);
     ReleaseDC(nullptr, hScreenDC);
+}
+
+// Only captures for Gaussian - Acrylic's blur comes live from DWM's own
+// compositor via the accent policy set in ApplyBackdrop, so there is nothing
+// for us to capture or composite per-frame.
+void CaptureLevelBlur(PopupLevel* level) {
+    if (g_settings.blurType != BlurType::Gaussian ||
+        g_settings.blurStrength <= 0) {
+        level->blurBackdrop.reset();
+        return;
+    }
+    level->blurBackdrop =
+        CaptureBlurredBackdrop(level->rect, g_settings.blurStrength);
 }
 
 PopupLevel* LevelFromHwnd(HWND hWnd) {
@@ -3622,17 +4132,43 @@ void CloseLevelsFrom(int depth) {
 void CloseChain() {
     if (!Levels().empty() && Levels()[0]->hwnd) {
         KillTimer(Levels()[0]->hwnd, kTickTimerId);
+        KillTimer(Levels()[0]->hwnd, kBlurTimerId);
     }
     CloseLevelsFrom(0);
     g_outsideSinceTick = 0;
 }
 
+// The seam between two side-by-side cascade grids: just the strip of
+// horizontal gap facing edge-to-edge, clipped to the vertical span where the
+// two rects actually overlap. Used to be the full bounding box of both rects
+// (min/max of every edge), which - whenever one grid was taller than the
+// other, as any parent/subfolder pair with a different item count is -
+// swallowed the dead space below (or above) the shorter one into the live
+// path too, so hovering there kept the whole cascade open instead of closing
+// it.
 RECT BridgingRect(const RECT& a, const RECT& b) {
-    RECT bridge;
-    bridge.left = std::min<LONG>(a.left, b.left);
-    bridge.right = std::max<LONG>(a.right, b.right);
-    bridge.top = std::min<LONG>(a.top, b.top);
-    bridge.bottom = std::max<LONG>(a.bottom, b.bottom);
+    RECT bridge{};
+    if (b.left >= a.right) {
+        bridge.left = a.right;
+        bridge.right = b.left;
+    } else if (a.left >= b.right) {
+        bridge.left = b.right;
+        bridge.right = a.left;
+    } else {
+        // Not actually side-by-side (shouldn't happen for cascade levels) -
+        // fall back to the old full-bounds behavior rather than a bogus
+        // empty/negative-width strip.
+        bridge.left = std::min<LONG>(a.left, b.left);
+        bridge.right = std::max<LONG>(a.right, b.right);
+    }
+    bridge.top = std::max<LONG>(a.top, b.top);
+    bridge.bottom = std::min<LONG>(a.bottom, b.bottom);
+    if (bridge.bottom <= bridge.top) {
+        // PtInRect excludes the bottom edge; inflate a zero-height overlap
+        // into a 1px seam so two rects that just touch top/bottom still
+        // bridge, same trick as CursorInRootCorridor.
+        bridge.bottom = bridge.top + 1;
+    }
     return bridge;
 }
 
@@ -4005,7 +4541,7 @@ void PrefetchSubfolders(PopupLevel* level) {
         return;
     }
     constexpr int kMaxPrefetch = 12;
-    int iconPixelSize = ScaleForPopup(g_settings.iconSize);
+    int iconPixelSize = PopupIconPixelSize();
     int queued = 0;
     for (const auto& item : level->items) {
         if (queued >= kMaxPrefetch) {
@@ -4015,6 +4551,33 @@ void PrefetchSubfolders(PopupLevel* level) {
             RequestScan(item.fullPath, iconPixelSize);
             queued++;
         }
+    }
+}
+
+// Re-captures every open level's blurred backdrop and repaints it, so the
+// blur tracks a moving/changing background live instead of freezing whatever
+// was behind the grid at the moment it opened. Runs off its own kBlurTimerId
+// (kBlurTimerMs), separate from kTickTimerMs so raising/lowering the
+// hover/close poll rate doesn't also have to raise (or cap) the blur's.
+// Gaussian only - Acrylic's blur is live from DWM already, nothing to
+// re-capture (see CaptureLevelBlur).
+//
+// Deliberately does not touch level->baseDirty: blur is composited straight
+// into PaintLevel's DIB (see there), not baked into cachedBase, so this stays
+// a cheap BitBlt + resample + composite - no icon/text/badge GDI+ redraw -
+// on every one of these ticks.
+void RefreshBlurBackdrops() {
+    if (g_settings.blurType != BlurType::Gaussian ||
+        g_settings.blurStrength <= 0) {
+        return;
+    }
+    for (auto& levelPtr : Levels()) {
+        PopupLevel* level = levelPtr.get();
+        if (!level || !level->hwnd || !IsWindowVisible(level->hwnd)) {
+            continue;
+        }
+        CaptureLevelBlur(level);
+        PaintLevel(level);
     }
 }
 
@@ -4097,6 +4660,11 @@ LRESULT CALLBACK PopupWndProc(HWND hWnd,
 
     if (uMsg == WM_TIMER && wParam == kTickTimerId) {
         OnTick();
+        return 0;
+    }
+
+    if (uMsg == WM_TIMER && wParam == kBlurTimerId) {
+        RefreshBlurBackdrops();
         return 0;
     }
 
@@ -4184,6 +4752,7 @@ LRESULT CALLBACK PopupWndProc(HWND hWnd,
         case WM_DESTROY:
             KillTimer(hWnd, kTickTimerId);
             KillTimer(hWnd, kOpenTimerId);
+            KillTimer(hWnd, kBlurTimerId);
             return 0;
     }
 
@@ -4315,15 +4884,31 @@ PopupLevel* InstallLevel(std::unique_ptr<PopupLevel> level) {
     return Levels()[depth].get();
 }
 
-// Places and shows a level's window, then paints it.
+// Paints a level's window, then shows it - deliberately in that order. The
+// window at this depth is reused across opens, so it can still be carrying
+// the previous open's bitmap; showing it before PaintLevel/UpdateLayeredWindow
+// replaces that content flashes the stale frame at the new position/size for
+// however long capture+repaint takes. That flash reads as a glitch most
+// visibly when blur is on, since the stale backdrop can differ sharply from
+// the real one, but it existed for plain content too. PaintLevel's own
+// UpdateLayeredWindow call already places and sizes the window (that is what
+// ptDst/size are for); the SetWindowPos below only has to raise it topmost
+// and make it visible, hidden window content updates just fine.
 void PresentLevel(PopupLevel* level, const SIZE& size) {
     level->rect.right = level->rect.left + size.cx;
     level->rect.bottom = level->rect.top + size.cy;
     InvalidateLevelBase(level);
 
+    // SetOwnWindowsCaptureExcluded keeps this window's own pixels out of its
+    // own Gaussian capture only for the instant that capture runs, so no need
+    // to hide it first. RefreshBlurBackdrops re-captures this on every tick
+    // to track a moving/changing background live (Gaussian only - Acrylic's
+    // blur is live from DWM already).
+    CaptureLevelBlur(level);
+
+    PaintLevel(level);
     SetWindowPos(level->hwnd, HWND_TOPMOST, level->rect.left, level->rect.top,
                  size.cx, size.cy, SWP_NOACTIVATE | SWP_SHOWWINDOW);
-    PaintLevel(level);
 }
 
 void OpenRootLevel(std::wstring path, RECT anchorRect, std::wstring title) {
@@ -4346,7 +4931,7 @@ void OpenRootLevel(std::wstring path, RECT anchorRect, std::wstring title) {
     level->anchorRect = anchorRect;
 
     auto data =
-        GetFolderDataAndRefresh(path, ScaleForPopup(g_settings.iconSize));
+        GetFolderDataAndRefresh(path, PopupIconPixelSize());
     level->loading = true;
     if (data && data->ready) {
         level->items = data->items;
@@ -4402,6 +4987,7 @@ void OpenRootLevel(std::wstring path, RECT anchorRect, std::wstring title) {
     PrefetchSubfolders(installed);
 
     SetTimer(hWnd, kTickTimerId, kTickTimerMs, nullptr);
+    SetTimer(hWnd, kBlurTimerId, kBlurTimerMs, nullptr);
 }
 
 // Opens the grid for the subfolder in `cell` of the level at `parentDepth`,
@@ -4433,8 +5019,7 @@ void OpenSubLevel(int parentDepth, int cell) {
     OffsetRect(&cellScreenRect, parent->rect.left, parent->rect.top);
     level->anchorRect = cellScreenRect;
 
-    auto data = GetFolderDataAndRefresh(level->path,
-                                        ScaleForPopup(g_settings.iconSize));
+    auto data = GetFolderDataAndRefresh(level->path, PopupIconPixelSize());
     level->loading = true;
     if (data && data->ready) {
         level->items = data->items;
@@ -7823,7 +8408,7 @@ bool InjectHostGridsOnTaskbarThread() {
         if (g_taskbarHosts && !g_taskbarHosts->empty()) {
             g_taskbarWnd = (*g_taskbarHosts)[0]->hwnd;
             UpdatePopupDpi();
-            int iconPixelSize = ScaleForPopup(g_settings.iconSize);
+            int iconPixelSize = PopupIconPixelSize();
             for (size_t i = 0; i < g_settings.folders.size(); i++) {
                 RequestScan(FolderPathForButton((int)i), iconPixelSize);
             }
@@ -8607,8 +9192,10 @@ void ReloadAndRefreshUI() {
     if (!ApplyOnWindowThread([](void*) {
             CloseChain();
             RemoveAllHostGrids();
-            // Popup HWNDs keep the acrylic accent applied at create time;
-            // destroy them so the next hover recreates with the current setting.
+            // Popup HWNDs keep the DWM corner/border attributes ApplyBackdrop
+            // set at create time; destroy them so the next hover recreates
+            // with the current settings. Blur strength itself is re-read
+            // every PresentLevel and needs no recreation.
             for (HWND hWnd : g_levelWindows) {
                 if (hWnd) {
                     DestroyWindow(hWnd);

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -78,8 +78,7 @@ If you would rather the mod stayed off the Explorer/Desktop menus, turn off
 **Explorer right-click menu** in the settings; with it off, Pin / Move / Copy
 disappear from that menu, leaving only **Manage folders...** — kept there on
 purpose, since it is the only remaining way to open the manager once nothing
-is pinned. The settings page also has an **Open the Taskbar Folders window**
-checkbox that opens it directly, since Windhawk settings have no button widget.
+is pinned.
 
 ### The Taskbar Folders window
 
@@ -176,16 +175,54 @@ AppUserModelID, and that shortcut is pinned with the shell's ordinary
 - They collapse into the overflow button when the taskbar fills up.
 - Every animation is Windows' own.
 
-**Disabling or uninstalling the mod unpins every button it created**, deletes
-their Start Menu shortcuts and their jump lists, and clears the folder list
-itself — nothing it wrote is left behind, and turning it back on starts from
-an empty list rather than silently recreating what was there before.
+## What this writes, and what happens when you disable it
 
-This cleanup runs from `Wh_ModUninit`, so it does not run on an unclean exit
+Because the buttons are genuine pinned items, the mod cannot keep its state
+entirely to itself. For each folder on the taskbar it writes:
+
+- a shortcut in `%AppData%\Microsoft\Windows\Start Menu\Programs\Taskbar
+  Folder Hover Tray`, carrying the folder's AppUserModelID and icon,
+- the taskbar pin itself, made with the shell's ordinary "pin to taskbar" verb —
+  which is the shell writing its own pinned-items folder and `Taskband` key, the
+  same as pinning any app by hand,
+- a jump list for that AppUserModelID, holding the **Manage folders...** task.
+
+The folder list — names, paths, icons, pinned or not — lives in the mod's own
+private Windhawk storage, and nowhere else.
+
+One visible side effect of the Start Menu shortcuts: Windows enumerates that
+folder for **Start → All apps** and for Start/taskbar search, so each folder
+button also shows up there under a **Taskbar Folder Hover Tray** group. That is
+the price of a real pin — the shell resolves a taskbar pin through its Start
+Menu shortcut — and it disappears with the shortcuts when the mod is disabled.
+
+**Disabling or uninstalling the mod unpins every button it created** and deletes
+their Start Menu shortcuts and their jump lists, so nothing it put on the taskbar
+or in your Start Menu is left behind.
+
+**The folder list survives.** Windhawk runs the same unload path for a real
+disable, for a mod update, for a settings-page save and for an engine restart,
+and cannot tell them apart, so wiping the list there would mean an update
+silently deleted your folders. Instead the entries are kept and re-pinned the
+next time the mod loads. Uninstalling drops them too — Windhawk deletes a mod's
+storage itself when the mod is removed — and **Remove all folder buttons...** in
+the Taskbar Folders window is the explicit, confirmed way to forget everything
+without uninstalling.
+
+While the mod is disabled, nothing of it runs, so nothing is left running or
+hooked; while it is *enabled*, the pins and shortcuts above are live. Note that
+the taskbar order is the taskbar's own, so the buttons come back at the end of
+the strip rather than where you dragged them.
+
+The unpin sweep runs from `Wh_ModUninit`, so it does not run on an unclean exit
 (Explorer crashing or being killed, or a hard reboot, while the mod is still
-enabled). If that happens, the leftovers are the shortcuts under
+enabled), and it cannot run at all if the mod was uninstalled while Explorer was
+not running. If that happens, the leftovers are the shortcuts under
 `%AppData%\Microsoft\Windows\Start Menu\Programs\Taskbar Folder Hover Tray` —
-delete that folder and unpin any of its buttons still on the taskbar by hand.
+delete that folder and unpin any of its buttons still on the taskbar by hand. As
+long as the mod is enabled it also sweeps on its own: every reconcile unpins any
+of its buttons that are no longer in the folder list, so leftovers from an
+unclean exit are cleaned up the next time it loads.
 
 Earlier versions drew an overlay instead, seated in a gap carved by widening a
 neighbouring icon's margin. It could never be exactly right: taskbar positions are
@@ -8181,13 +8218,20 @@ void RemoveSelected(HWND hWnd) {
 // Unpins every real taskbar button, deletes their Start Menu shortcuts and
 // their per-AppID jump lists — everything InvokeVerb's "taskbarpin" and
 // WriteJumpList put in place. Shared by the user-facing "Remove all folder
-// buttons" action and the automatic cleanup Wh_ModUninit runs on every
-// disable/uninstall, so nothing this mod wrote — on the taskbar, in the
-// Start Menu, or in its own folder list — outlives either path.
+// buttons" action and the automatic cleanup Wh_ModUninit runs on every unload,
+// so nothing this mod wrote outside its own storage outlives either path.
+//
+// clearStore separates the two callers. The user-facing action means "forget
+// everything" and empties the folder list. The unload path must not: Windhawk
+// routes a mod update, a settings-page save and an engine restart through the
+// same Wh_ModUninit as a real disable, and wiping the list there would delete
+// the user's configuration every time the mod is updated. Windhawk removes the
+// mod's storage itself when the mod is uninstalled, so the unload path only has
+// to undo what it put outside that storage.
 //
 // CoInitializeEx is refcounted per thread, so this is safe to call whether or
 // not the calling thread already has COM up (Wh_ModUninit's does not).
-void RemoveAllFolderButtonsCore() {
+void RemoveAllFolderButtonsCore(bool clearStore) {
     struct ComInit {
         HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
         ~ComInit() {
@@ -8236,7 +8280,27 @@ void RemoveAllFolderButtonsCore() {
     }
 
     std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
-    FolderStore::Write({});
+    if (clearStore) {
+        FolderStore::Write({});
+        return;
+    }
+
+    // Keep every entry, including its pinned flag, and only clear pinApplied.
+    // That flag is what Reconcile's reverse sync trusts: "we pinned this and it
+    // is gone now" is how a native Unpin from taskbar is detected. Leaving it
+    // set would make the next load read the sweep above as the user unpinning
+    // everything and demote every entry to a draft.
+    auto stored = FolderStore::Read();
+    bool changed = false;
+    for (auto& entry : stored) {
+        if (entry.pinApplied) {
+            entry.pinApplied = false;
+            changed = true;
+        }
+    }
+    if (changed) {
+        FolderStore::Write(stored);
+    }
 }
 
 void RemoveAllFolderButtons(HWND hWnd) {
@@ -8250,25 +8314,26 @@ void RemoveAllFolderButtons(HWND hWnd) {
         return;
     }
 
-    RemoveAllFolderButtonsCore();
+    RemoveAllFolderButtonsCore(/*clearStore=*/true);
     RefreshAfterStoreChange(hWnd);
 }
 
 // Windhawk's core principle is that disabling a mod puts the system back the
-// way it was. Called from Wh_ModUninit, which fires on every disable and
-// every uninstall alike (Windhawk does not distinguish the two, and neither
-// does it distinguish a real disable from the reload after a code-update
-// save) — so the real taskbar pins, their Start Menu shortcuts, their jump
-// lists and the folder list itself never outlive this pass. Nothing survives
-// a disable: a re-enable starts from the default, empty folder list rather
-// than silently recreating whatever was configured before.
+// way it was. Called from Wh_ModUninit, which fires on every unload alike — a
+// user disable, an uninstall, a mod update, a settings-page save and an engine
+// restart are indistinguishable from here — so everything this mod put outside
+// its own storage goes: the real taskbar pins, their Start Menu shortcuts and
+// their jump lists.
 //
-// This does mean a code-update / settings-page save (which Windhawk routes
-// through the same Wh_ModUninit -> Wh_ModInit path as a real disable, with no
-// way to tell the two apart from here) wipes the folder list too, not just
-// the code reload it looks like from the user's side.
+// The folder list itself stays. It is the user's configuration, it lives in the
+// mod's private Windhawk storage (which Windhawk deletes on its own when the mod
+// is uninstalled), and it is the one thing here that cannot be reconstructed.
+// Wiping it on every unload would mean publishing an update silently deleted
+// every user's folders. A re-enable therefore re-pins what was configured, and
+// "Remove all folder buttons..." in the manager stays the explicit, confirmed
+// way to forget everything.
 void UnpinAllForDisable() {
-    RemoveAllFolderButtonsCore();
+    RemoveAllFolderButtonsCore(/*clearStore=*/false);
 }
 
 // A single-select listbox never lets go of its selection on its own — a click
@@ -9873,12 +9938,19 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
+    // Only the hover half needs these symbols, and they are the part a Windows
+    // update breaks. Everything else — the folder store, the pin reconcile, the
+    // Explorer menu, the jump-list verb — does not, so carry on without them
+    // rather than returning FALSE. Returning FALSE here would strand the pinned
+    // buttons from the last working session with no in-mod way to remove them:
+    // no manager entry, no jump-list handler, and no disable-time sweep either,
+    // since Wh_ModUninit only runs for a mod that loaded. Every symbol below is
+    // null-checked at its call sites, and the hooks that bind hover simply never
+    // install.
     if (!HookTaskbarDllSymbols()) {
-        Wh_Log(
-            L"Failed to hook taskbar.dll, the taskbar XamlRoot is unreachable");
-        Gdiplus::GdiplusShutdown(g_gdiplusToken);
-        g_gdiplusToken = 0;
-        return FALSE;
+        Wh_Log(L"Failed to hook taskbar.dll, the taskbar XamlRoot is "
+               L"unreachable; hover will not bind, the folder buttons and the "
+               L"manager still work");
     }
 
     Pins::Start();

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.26
+// @version         1.27
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
@@ -59,6 +59,10 @@ right click any folder in Explorer or on the Desktop and pick
 and its custom icon (Properties > Customize > Change Icon) from the folder
 itself. That same menu appears on files and shortcuts too — use it to move,
 copy, or make a shortcut into a folder that already has a button.
+
+If you would rather the mod stayed entirely on the taskbar side, turn off
+**Explorer right-click menu** in the settings; with it off, Explorer and Desktop
+context menus are left completely untouched.
 
 ### The Taskbar Folders window
 
@@ -188,6 +192,17 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 - openFolderOnClick: true
   $name: 1. Behavior ▸ Click opens the folder
   $description: Left clicking a taskbar button opens the folder in File Explorer.
+
+- explorerMenu: true
+  $name: 1. Behavior ▸ Explorer right-click menu
+  $description: >-
+    Adds a "Taskbar Folders" submenu to Explorer and Desktop context menus, for
+    pinning a folder straight to the taskbar and for moving, copying or making
+    a shortcut into a folder that already has a button. Turn this off to keep
+    the mod entirely on the taskbar side — with it off, Explorer's own context
+    menus are left completely alone. Switching it back on takes effect after
+    the mod is reloaded (toggle the mod off and on, or restart Explorer),
+    because the menu hook is only installed at startup.
 
 - position: beforeApps
   $name: 1. Behavior ▸ Position
@@ -464,6 +479,9 @@ struct Settings {
     int gapAfter = 0;
     int buttonIconSize = 0;
     bool openFolderOnClick = true;
+    // Read from an Explorer window thread inside the TrackPopupMenuEx hook
+    // while LoadSettings may be writing it on another.
+    std::atomic<bool> explorerMenu{true};
 };
 
 Settings g_settings;
@@ -627,6 +645,21 @@ namespace FolderStore {
 
 constexpr int kMaxEntries = 200;
 
+// Read/modify/write runs on three threads: the manager thread, the taskbar UI
+// thread (unpin) and an Explorer window thread (the context-menu pin). Write()
+// rewrites the entries, deletes the tail, then updates entryCount, so an
+// unlocked interleave can persist a truncated or mixed list.
+//
+// Recursive because the read-modify-write callers hold it across Read()+Write()
+// and those lock it too. Lock order is g_foldersMutex then this one, which is
+// what LoadFolders takes; nothing may hold this one across ReloadAndRefreshUI,
+// since that reaches LoadFolders and would invert the order.
+//
+// no_destroy: Wh_ModUninit does not run when Explorer terminates, but CRT
+// destructors of globals do, on a shutdown thread — a mutex must not be
+// destroyed out from under a thread that could still be holding it.
+[[clang::no_destroy]] std::recursive_mutex g_mutex;
+
 struct Entry {
     std::wstring path;
     std::wstring name;
@@ -644,6 +677,7 @@ std::wstring GetString(PCWSTR format, int index) {
 }
 
 std::vector<Entry> Read() {
+    std::lock_guard<std::recursive_mutex> lock(g_mutex);
     std::vector<Entry> entries;
     int count = Wh_GetIntValue(L"entryCount", 0);
     if (count > kMaxEntries) {
@@ -669,6 +703,7 @@ std::vector<Entry> Read() {
 }
 
 void Write(const std::vector<Entry>& entries) {
+    std::lock_guard<std::recursive_mutex> lock(g_mutex);
     int previous = Wh_GetIntValue(L"entryCount", 0);
     int count = (int)entries.size();
     if (count > kMaxEntries) {
@@ -706,19 +741,28 @@ void Write(const std::vector<Entry>& entries) {
     Wh_SetIntValue(L"entryCount", count);
 }
 
-// Index of the entry backing `path`, comparing the resolved filesystem path so
-// that a shell: entry and its real folder count as the same thing. -1 if none.
-int IndexOfPath(const std::vector<Entry>& entries, const std::wstring& path) {
-    std::wstring wanted = ResolveFolderPath(ExpandEnv(path));
-    if (wanted.empty()) {
-        wanted = ExpandEnv(path);
+// The comparison key for a stored path: resolved to a filesystem path so that
+// a shell: entry and its real folder count as the same thing.
+std::wstring MatchKey(const std::wstring& path) {
+    std::wstring key = ResolveFolderPath(ExpandEnv(path));
+    return key.empty() ? ExpandEnv(path) : key;
+}
+
+// True if two stored paths name the same folder. Exposed so callers can find
+// an entry by path rather than by a store index another thread may have
+// shifted underneath them.
+bool SamePath(const std::wstring& a, const std::wstring& b) {
+    if (a.empty() || b.empty()) {
+        return false;
     }
+    return _wcsicmp(MatchKey(a).c_str(), MatchKey(b).c_str()) == 0;
+}
+
+// Index of the entry backing `path`, or -1 if none.
+int IndexOfPath(const std::vector<Entry>& entries, const std::wstring& path) {
+    std::wstring wanted = MatchKey(path);
     for (size_t i = 0; i < entries.size(); i++) {
-        std::wstring existing = ResolveFolderPath(ExpandEnv(entries[i].path));
-        if (existing.empty()) {
-            existing = ExpandEnv(entries[i].path);
-        }
-        if (_wcsicmp(existing.c_str(), wanted.c_str()) == 0) {
+        if (_wcsicmp(MatchKey(entries[i].path).c_str(), wanted.c_str()) == 0) {
             return (int)i;
         }
     }
@@ -730,6 +774,8 @@ int IndexOfPath(const std::vector<Entry>& entries, const std::wstring& path) {
 // Settings rows the user had "unpinned" (the old hidden[] list) come across as
 // drafts rather than vanishing.
 void MigrateLegacy() {
+    // Held across the whole read-modify-write, like every other store mutation.
+    std::lock_guard<std::recursive_mutex> lock(g_mutex);
     if (Wh_GetIntValue(L"storeVersion", 0) >= 2) {
         return;
     }
@@ -867,24 +913,32 @@ void LoadFolders(std::vector<FolderEntry>* out) {
     std::lock_guard<std::mutex> lock(g_foldersMutex);
     out->clear();
 
-    auto stored = FolderStore::Read();
-    bool storeUnchanged = true;
-    for (auto& entry : stored) {
-        FolderEntry loaded;
-        if (!BuildFolderEntry(&entry, &loaded)) {
-            storeUnchanged = false;
+    // Store lock second, and only around the read-modify-write: the rename
+    // fix-up below writes back what it just read. See FolderStore::g_mutex for
+    // why the order is g_foldersMutex first.
+    size_t storedCount = 0;
+    {
+        std::lock_guard<std::recursive_mutex> storeLock(FolderStore::g_mutex);
+        auto stored = FolderStore::Read();
+        storedCount = stored.size();
+        bool storeUnchanged = true;
+        for (auto& entry : stored) {
+            FolderEntry loaded;
+            if (!BuildFolderEntry(&entry, &loaded)) {
+                storeUnchanged = false;
+            }
+            // Drafts stay in the store but get no taskbar button.
+            if (entry.pinned) {
+                out->push_back(std::move(loaded));
+            }
         }
-        // Drafts stay in the store but get no taskbar button.
-        if (entry.pinned) {
-            out->push_back(std::move(loaded));
+        if (!storeUnchanged) {
+            FolderStore::Write(stored);
         }
-    }
-    if (!storeUnchanged) {
-        FolderStore::Write(stored);
     }
 
     Wh_Log(L"LoadFolders: %zu button(s) from %zu stored folder(s)",
-           out->size(), stored.size());
+           out->size(), storedCount);
 }
 
 // True if `path` already has a stored entry — pinned or draft. Used to hide
@@ -899,6 +953,9 @@ bool IsAlreadyTaskbarFolder(const std::wstring& path) {
 // Caller must refresh (LoadSettings + UI teardown/rebuild) for it to appear.
 // No-op (returns false) if the folder already has an entry, draft included.
 bool AddPinnedFolder(const std::wstring& path, const std::wstring& name) {
+    // Held across read-modify-write: the manager thread and the taskbar UI
+    // thread mutate the same store.
+    std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
     auto stored = FolderStore::Read();
     if (FolderStore::IndexOfPath(stored, path) >= 0) {
         return false;
@@ -920,6 +977,7 @@ bool AddPinnedFolder(const std::wstring& path, const std::wstring& name) {
 // Unpins without forgetting: the entry stays as a draft, keeping its name and
 // icon, and still blocks a duplicate pin of the same folder.
 void RemovePinnedFolder(const std::wstring& path) {
+    std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
     auto stored = FolderStore::Read();
     int index = FolderStore::IndexOfPath(stored, path);
     if (index < 0) {
@@ -1004,6 +1062,7 @@ void LoadSettings() {
     g_settings.buttonIconSize =
         std::clamp<int>(Wh_GetIntSetting(L"buttonIconSize"), 0, 128);
     g_settings.openFolderOnClick = Wh_GetIntSetting(L"openFolderOnClick");
+    g_settings.explorerMenu = Wh_GetIntSetting(L"explorerMenu") != 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2814,6 +2873,27 @@ void StopScanThread() {
         std::swap(workEvent, g_scanWorkEvent);
     }
     if (thread && thread->joinable()) {
+        // Pump sent messages while waiting. The worker delivers button icons
+        // with a blocking SendMessage to the taskbar UI thread
+        // (DeliverButtonIconToUi -> RunFromWindowThread), and the taskbar
+        // right-click unpin reaches here from that very thread — a plain
+        // join() would leave both blocked forever and hang the taskbar. The
+        // g_scanThreadStop check before the delivery narrows that window but
+        // cannot close it. Same shape as StopRetryThread.
+        HANDLE handle = (HANDLE)thread->native_handle();
+        DWORD result;
+        do {
+            result = MsgWaitForMultipleObjects(1, &handle, FALSE, INFINITE,
+                                               QS_SENDMESSAGE);
+            if (result == WAIT_OBJECT_0 + 1) {
+                MSG msg;
+                PeekMessageW(&msg, nullptr, 0, 0, PM_NOREMOVE);
+            } else if (result == WAIT_FAILED) {
+                Wh_Log(L"StopScanThread: MsgWaitForMultipleObjects failed (%u)",
+                       GetLastError());
+                break;
+            }
+        } while (result == WAIT_OBJECT_0 + 1);
         thread->join();
     }
     if (stopEvent) {
@@ -2916,6 +2996,12 @@ PendingShellCommand g_pendingShellCommand;
 
 // Posted to g_menuOwnerWnd after the context menu loop unwinds.
 constexpr UINT WM_APP_INVOKE_SHELL_VERB = WM_APP + 41;
+
+// Posted to g_menuOwnerWnd so a reload asked for by a XAML flyout item runs
+// after that item's own Click handler has returned. ReloadAndRefreshUI tears
+// down the very button the flyout is anchored to and unhooks the handlers it
+// is running inside, so it must not run inline from there.
+constexpr UINT WM_APP_RELOAD_UI = WM_APP + 42;
 
 // Both take their arguments by value: reopening a level destroys the PopupLevel
 // the caller may have read them from.
@@ -3840,6 +3926,15 @@ LRESULT CALLBACK MenuOwnerWndProc(HWND hWnd,
             ClearPendingShellCommand();
         } else {
             InvokePendingShellCommand(hWnd);
+        }
+        return 0;
+    }
+
+    if (uMsg == WM_APP_RELOAD_UI) {
+        // Runs after the button flyout's Click handler has returned, so the
+        // teardown is not re-entering the flyout item it was invoked from.
+        if (!g_unloading) {
+            ReloadAndRefreshUI();
         }
         return 0;
     }
@@ -5345,14 +5440,77 @@ constexpr int kIdEditOk = 1107;
 constexpr int kIdEditCancel = 1108;
 constexpr int kIdEditPreview = 1109;
 constexpr int kIdEditPinnedHint = 1110;
+// Static labels carry ids too, so WM_DPICHANGED can lay them out from the same
+// table WM_CREATE built them from.
+constexpr int kIdEditNameLabel = 1111;
+constexpr int kIdEditPathLabel = 1112;
+constexpr int kIdEditIconLabel = 1113;
+constexpr int kIdEditIconHint = 1114;
 
+// Every dimension in this window is written at 96 DPI and goes through
+// Scale()/ScaleFor(). explorer.exe is manifested Per-Monitor-DPI-Aware V2 and
+// threads it creates inherit that context, so plain Win32 windows here get no
+// automatic scaling at all: without this a 150% display would show a small
+// window wrapped around a large system font.
 constexpr int kRowHeight = 40;
 constexpr int kRowIconSize = 24;
+constexpr int kIconLeft = 8;      // Row icon inset from the row's left edge.
+constexpr int kTextGap = 10;      // Icon-to-text gap.
+constexpr int kTitleTop = 4;      // Row title band, measured from the row top.
+constexpr int kTitleBottom = 21;  // Also the top of the path band.
+constexpr int kPathBottom = 3;    // Path band inset from the row bottom.
+constexpr int kPreviewIcon = 32;  // Edit-dialog icon preview.
+constexpr int kPreviewInset = 4;
+
+// 96-DPI client size of each window, before AdjustWindowRect.
+constexpr int kMainWidth = 476;
+constexpr int kMainHeight = 400;
+constexpr int kEditWidth = 414;
+constexpr int kEditHeight = 306;
+
+int Scale(int value, int dpi) {
+    return MulDiv(value, dpi, 96);
+}
+
+// The DPI of the monitor a window is on. Read per use rather than cached in a
+// global, so everything stays correct after the window is dragged to another
+// monitor; GetDpiForWindow is a cheap cached window property.
+int DpiOf(HWND hWnd) {
+    UINT dpi = hWnd ? GetDpiForWindow(hWnd) : 0;
+    return dpi ? (int)dpi : 96;
+}
+
+// Where a child sits at 96 DPI. One table per window, so WM_CREATE and
+// WM_DPICHANGED lay out from the same numbers.
+struct ChildRect {
+    int id;
+    int x;
+    int y;
+    int cx;
+    int cy;
+};
+
+void LayoutChildren(HWND hWnd, const ChildRect* items, size_t count, int dpi) {
+    for (size_t i = 0; i < count; i++) {
+        HWND child = GetDlgItem(hWnd, items[i].id);
+        if (child) {
+            MoveWindow(child, Scale(items[i].x, dpi), Scale(items[i].y, dpi),
+                       Scale(items[i].cx, dpi), Scale(items[i].cy, dpi), TRUE);
+        }
+    }
+}
 
 // Owned by the manager thread once it starts; only ever read elsewhere to
 // find an existing window or ask it to close.
 std::atomic<HWND> g_wnd{nullptr};
 std::atomic<bool> g_active{false};
+
+// 96-DPI layout of the main window's children.
+constexpr ChildRect kMainLayout[] = {
+    {kIdList, 12, 12, 452, 300},   {kIdAdd, 12, 324, 76, 26},
+    {kIdEdit, 94, 324, 76, 26},    {kIdRemove, 176, 324, 76, 26},
+    {kIdClose, 388, 324, 76, 26},  {kIdHint, 12, 360, 452, 32},
+};
 
 // The store as last read, in listbox order. Manager-thread only.
 std::vector<FolderStore::Entry> g_rows;
@@ -5428,29 +5586,43 @@ POINT CenterOnMonitor(POINT anchor, int width, int height) {
     return pos;
 }
 
-HFONT UiFont() {
-    static HFONT font = [] {
-        NONCLIENTMETRICSW ncm{};
-        ncm.cbSize = sizeof(ncm);
-        if (SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncm), &ncm,
-                                  0)) {
-            if (HFONT themed = CreateFontIndirectW(&ncm.lfMessageFont)) {
-                return themed;
-            }
+// The message font at a given DPI. SystemParametersInfoW would hand back
+// metrics sized for the *system* DPI, which is what made a scaled window show
+// an oversized font. Cached per DPI so moving between monitors does not leak
+// an HFONT per WM_DPICHANGED; the manager only ever sees a couple of values.
+//
+// no_destroy for the same reason as every other global here: the CRT teardown
+// at Explorer exit must not touch it.
+[[clang::no_destroy]] std::vector<std::pair<int, HFONT>> g_fontCache;
+
+HFONT UiFont(int dpi) {
+    for (const auto& cached : g_fontCache) {
+        if (cached.first == dpi) {
+            return cached.second;
         }
-        return (HFONT)GetStockObject(DEFAULT_GUI_FONT);
-    }();
+    }
+    HFONT font = nullptr;
+    NONCLIENTMETRICSW ncm{};
+    ncm.cbSize = sizeof(ncm);
+    if (SystemParametersInfoForDpi(SPI_GETNONCLIENTMETRICS, sizeof(ncm), &ncm,
+                                   0, (UINT)dpi)) {
+        font = CreateFontIndirectW(&ncm.lfMessageFont);
+    }
+    if (!font) {
+        font = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
+    }
+    g_fontCache.emplace_back(dpi, font);
     return font;
 }
 
-void ApplyUiFont(HWND parent) {
+void ApplyUiFont(HWND parent, int dpi) {
     EnumChildWindows(
         parent,
         [](HWND child, LPARAM f) -> BOOL {
             SendMessageW(child, WM_SETFONT, (WPARAM)f, TRUE);
             return TRUE;
         },
-        (LPARAM)UiFont());
+        (LPARAM)UiFont(dpi));
 }
 
 // The icon a row should show: its configured icon spec if it has one that is
@@ -5484,6 +5656,10 @@ void FreeRowIcons() {
 
 void PopulateList(HWND hWnd) {
     HWND list = GetDlgItem(hWnd, kIdList);
+    if (!list) {
+        return;
+    }
+    int dpi = DpiOf(hWnd);
     int selected = (int)SendMessageW(list, LB_GETCURSEL, 0, 0);
 
     SendMessageW(list, LB_RESETCONTENT, 0, 0);
@@ -5491,7 +5667,7 @@ void PopulateList(HWND hWnd) {
     g_rows = FolderStore::Read();
 
     for (const auto& entry : g_rows) {
-        g_rowIcons.push_back(IconForEntry(entry, kRowIconSize));
+        g_rowIcons.push_back(IconForEntry(entry, Scale(kRowIconSize, dpi)));
         // Text comes from g_rows during WM_DRAWITEM; the item itself only
         // needs to exist.
         SendMessageW(list, LB_ADDSTRING, 0, (LPARAM)L"");
@@ -5522,13 +5698,32 @@ int SelectedIndex(HWND hWnd) {
     return (sel >= 0 && sel < (int)g_rows.size()) ? sel : -1;
 }
 
-// Applies a changed store and refreshes both the taskbar and this window.
-void CommitStore(HWND hWnd, const std::vector<FolderStore::Entry>& entries) {
-    FolderStore::Write(entries);
+// Refreshes the taskbar and this window after the store was changed.
+//
+// Must be called with FolderStore::g_mutex released: ReloadAndRefreshUI reaches
+// LoadFolders, which takes g_foldersMutex and then the store lock, so holding
+// the store lock across this would invert the order. Every caller therefore
+// scopes its read-modify-write to a block and calls this after it.
+void RefreshAfterStoreChange(HWND hWnd) {
     if (!g_unloading) {
         ReloadAndRefreshUI();
     }
     PopulateList(hWnd);
+}
+
+// True if the store still matches the rows on screen, one for one and in the
+// same order. A reorder commits by index, so it has to be abandoned if the
+// store moved underneath the window (an Explorer pin, a taskbar unpin).
+bool StoreMatchesRows(const std::vector<FolderStore::Entry>& stored) {
+    if (stored.size() != g_rows.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < stored.size(); i++) {
+        if (!FolderStore::SamePath(stored[i].path, g_rows[i].path)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 void DrawRow(LPDRAWITEMSTRUCT dis) {
@@ -5537,22 +5732,26 @@ void DrawRow(LPDRAWITEMSTRUCT dis) {
     }
     const FolderStore::Entry& entry = g_rows[dis->itemID];
     bool selected = (dis->itemState & ODS_SELECTED) != 0;
+    int dpi = DpiOf(dis->hwndItem);
+    int iconSize = Scale(kRowIconSize, dpi);
 
     HDC dc = dis->hDC;
     RECT rc = dis->rcItem;
     FillRect(dc, &rc, GetSysColorBrush(selected ? COLOR_HIGHLIGHT
                                                 : COLOR_WINDOW));
 
-    int iconTop = rc.top + (kRowHeight - kRowIconSize) / 2;
+    int iconLeft = rc.left + Scale(kIconLeft, dpi);
+
+    int iconTop = rc.top + (Scale(kRowHeight, dpi) - iconSize) / 2;
     HICON icon = dis->itemID < g_rowIcons.size() ? g_rowIcons[dis->itemID]
                                                  : nullptr;
     if (icon) {
-        DrawIconEx(dc, rc.left + 8, iconTop, icon, kRowIconSize, kRowIconSize,
-                   0, nullptr, DI_NORMAL);
+        DrawIconEx(dc, iconLeft, iconTop, icon, iconSize, iconSize, 0, nullptr,
+                   DI_NORMAL);
     } else if (!entry.icon.empty()) {
         // Emoji icon: draw the text itself, centred in the icon slot.
-        RECT iconRect{rc.left + 8, iconTop, rc.left + 8 + kRowIconSize,
-                      iconTop + kRowIconSize};
+        RECT iconRect{iconLeft, iconTop, iconLeft + iconSize,
+                      iconTop + iconSize};
         SetBkMode(dc, TRANSPARENT);
         SetTextColor(dc, GetSysColor(selected ? COLOR_HIGHLIGHTTEXT
                                               : COLOR_WINDOWTEXT));
@@ -5560,21 +5759,25 @@ void DrawRow(LPDRAWITEMSTRUCT dis) {
                   DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
     }
 
-    int textLeft = rc.left + 8 + kRowIconSize + 10;
+    int textLeft = iconLeft + iconSize + Scale(kTextGap, dpi);
+    int textRight = rc.right - Scale(kIconLeft, dpi);
+    int bandSplit = rc.top + Scale(kTitleBottom, dpi);
     SetBkMode(dc, TRANSPARENT);
 
     std::wstring title = entry.name.empty() ? entry.path : entry.name;
     if (!entry.pinned) {
         title += L"   (not pinned)";
     }
-    RECT titleRect{textLeft, rc.top + 4, rc.right - 8, rc.top + 21};
+    RECT titleRect{textLeft, rc.top + Scale(kTitleTop, dpi), textRight,
+                   bandSplit};
     SetTextColor(dc, GetSysColor(selected ? COLOR_HIGHLIGHTTEXT
                                           : COLOR_WINDOWTEXT));
     DrawTextW(dc, title.c_str(), -1, &titleRect,
               DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS |
                   DT_NOPREFIX);
 
-    RECT pathRect{textLeft, rc.top + 21, rc.right - 8, rc.bottom - 3};
+    RECT pathRect{textLeft, bandSplit, textRight,
+                  rc.bottom - Scale(kPathBottom, dpi)};
     SetTextColor(dc, GetSysColor(selected ? COLOR_HIGHLIGHTTEXT
                                           : COLOR_GRAYTEXT));
     DrawTextW(dc, entry.path.c_str(), -1, &pathRect,
@@ -5662,11 +5865,32 @@ std::wstring BrowseForIconFile(HWND owner) {
 // Passed to the edit window and written back in place when it is accepted.
 struct EditContext {
     FolderStore::Entry entry;
-    // -1 when adding, otherwise the index being edited — so a path collision
-    // with the entry's own row is not treated as a duplicate.
-    int index = -1;
+    // Path of the entry being edited, empty when adding — so a collision with
+    // the entry's own row is not treated as a duplicate. Matched by path
+    // rather than by a store index, because the store can change on another
+    // thread while this dialog is up.
+    std::wstring originalPath;
     bool accepted = false;
     HICON preview = nullptr;
+};
+
+// 96-DPI layout of the edit dialog. Every control has an id so WM_DPICHANGED
+// can re-run the same table.
+constexpr ChildRect kEditLayout[] = {
+    {kIdEditNameLabel, 14, 14, 300, 16},
+    {kIdEditName, 14, 32, 386, 24},
+    {kIdEditPathLabel, 14, 62, 300, 16},
+    {kIdEditPath, 14, 80, 300, 24},
+    {kIdEditBrowsePath, 322, 80, 78, 24},
+    {kIdEditIconLabel, 14, 110, 300, 16},
+    {kIdEditIcon, 14, 128, 300, 24},
+    {kIdEditBrowseIcon, 322, 128, 78, 24},
+    {kIdEditIconHint, 14, 158, 386, 32},
+    {kIdEditPinned, 14, 198, 340, 22},
+    {kIdEditPinnedHint, 32, 222, 322, 32},
+    {kIdEditPreview, 360, 196, 40, 40},
+    {kIdEditOk, 222, 266, 86, 26},
+    {kIdEditCancel, 314, 266, 86, 26},
 };
 
 std::wstring GetControlText(HWND hWnd, int id) {
@@ -5685,7 +5909,9 @@ void RefreshPreview(HWND hWnd, EditContext* ctx) {
     if (ctx->preview) {
         DestroyIcon(ctx->preview);
     }
-    ctx->preview = probe.path.empty() ? nullptr : IconForEntry(probe, 32);
+    ctx->preview = probe.path.empty()
+                       ? nullptr
+                       : IconForEntry(probe, Scale(kPreviewIcon, DpiOf(hWnd)));
     InvalidateRect(GetDlgItem(hWnd, kIdEditPreview), nullptr, TRUE);
 }
 
@@ -5700,84 +5926,83 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
             SetWindowLongPtrW(hWnd, GWLP_USERDATA, (LONG_PTR)ctx);
 
             HINSTANCE instance = GetCurrentModuleHandle();
-            struct Field {
-                PCWSTR label;
-                int editId;
-                int browseId;
-                PCWSTR browseText;
-                int y;
+            // Created at 0,0 and positioned by LayoutChildren below, so the
+            // creation path and WM_DPICHANGED share one set of numbers.
+            struct Spec {
+                PCWSTR cls;
+                PCWSTR text;
+                DWORD style;
+                DWORD exStyle;
+                int id;
             };
-            const Field fields[] = {
-                {L"Name", kIdEditName, 0, nullptr, 14},
-                {L"Folder", kIdEditPath, kIdEditBrowsePath, L"Browse...", 62},
-                {L"Icon", kIdEditIcon, kIdEditBrowseIcon, L"Browse...", 110},
+            const Spec specs[] = {
+                {L"STATIC", L"Name", 0, 0, kIdEditNameLabel},
+                {L"EDIT", L"", WS_TABSTOP | ES_AUTOHSCROLL, WS_EX_CLIENTEDGE,
+                 kIdEditName},
+                {L"STATIC", L"Folder", 0, 0, kIdEditPathLabel},
+                {L"EDIT", L"", WS_TABSTOP | ES_AUTOHSCROLL, WS_EX_CLIENTEDGE,
+                 kIdEditPath},
+                {L"BUTTON", L"Browse...", WS_TABSTOP | BS_PUSHBUTTON, 0,
+                 kIdEditBrowsePath},
+                {L"STATIC", L"Icon", 0, 0, kIdEditIconLabel},
+                {L"EDIT", L"", WS_TABSTOP | ES_AUTOHSCROLL, WS_EX_CLIENTEDGE,
+                 kIdEditIcon},
+                {L"BUTTON", L"Browse...", WS_TABSTOP | BS_PUSHBUTTON, 0,
+                 kIdEditBrowseIcon},
+                {L"STATIC",
+                 L"Emoji, an .ico / .png file, or a resource such as "
+                 L"C:\\Windows\\explorer.exe,0. Leave empty to use the "
+                 L"folder's own icon.",
+                 0, 0, kIdEditIconHint},
+                // Pin state lives here rather than as a list button, so that
+                // what "unpinned" actually means — kept, not deleted — is
+                // spelled out right next to the switch.
+                {L"BUTTON", L"Pinned to the taskbar",
+                 WS_TABSTOP | BS_AUTOCHECKBOX, 0, kIdEditPinned},
+                {L"STATIC",
+                 L"Unticked keeps this folder in the list but takes its button "
+                 L"off the taskbar. Nothing is deleted, and the folder still "
+                 L"cannot be added twice.",
+                 0, 0, kIdEditPinnedHint},
+                {L"STATIC", L"", SS_OWNERDRAW, 0, kIdEditPreview},
+                {L"BUTTON", L"Save", WS_TABSTOP | BS_DEFPUSHBUTTON, 0,
+                 kIdEditOk},
+                {L"BUTTON", L"Cancel", WS_TABSTOP | BS_PUSHBUTTON, 0,
+                 kIdEditCancel},
             };
-            for (const auto& f : fields) {
-                CreateWindowExW(0, L"STATIC", f.label, WS_CHILD | WS_VISIBLE,
-                                14, f.y, 300, 16, hWnd, nullptr, instance,
-                                nullptr);
-                int editWidth = f.browseId ? 300 : 386;
-                CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", L"",
-                                WS_CHILD | WS_VISIBLE | WS_TABSTOP |
-                                    ES_AUTOHSCROLL,
-                                14, f.y + 18, editWidth, 24, hWnd,
-                                (HMENU)(INT_PTR)f.editId, instance, nullptr);
-                if (f.browseId) {
-                    CreateWindowExW(0, L"BUTTON", f.browseText,
-                                    WS_CHILD | WS_VISIBLE | WS_TABSTOP |
-                                        BS_PUSHBUTTON,
-                                    322, f.y + 18, 78, 24, hWnd,
-                                    (HMENU)(INT_PTR)f.browseId, instance,
-                                    nullptr);
-                }
+            for (const auto& s : specs) {
+                CreateWindowExW(s.exStyle, s.cls, s.text,
+                                WS_CHILD | WS_VISIBLE | s.style, 0, 0, 0, 0,
+                                hWnd, (HMENU)(INT_PTR)s.id, instance, nullptr);
             }
-
-            CreateWindowExW(0, L"STATIC",
-                            L"Emoji, an .ico / .png file, or a resource such "
-                            L"as C:\\Windows\\explorer.exe,0. Leave empty to "
-                            L"use the folder's own icon.",
-                            WS_CHILD | WS_VISIBLE, 14, 158, 386, 32, hWnd,
-                            nullptr, instance, nullptr);
-
-            // Pin state lives here rather than as a list button, so that what
-            // "unpinned" actually means — kept, not deleted — is spelled out
-            // right next to the switch.
-            CreateWindowExW(0, L"BUTTON", L"Pinned to the taskbar",
-                            WS_CHILD | WS_VISIBLE | WS_TABSTOP |
-                                BS_AUTOCHECKBOX,
-                            14, 198, 340, 22, hWnd,
-                            (HMENU)(INT_PTR)kIdEditPinned, instance, nullptr);
-            CreateWindowExW(0, L"STATIC",
-                            L"Unticked keeps this folder in the list but takes "
-                            L"its button off the taskbar. Nothing is deleted, "
-                            L"and the folder still cannot be added twice.",
-                            WS_CHILD | WS_VISIBLE, 32, 222, 322, 32, hWnd,
-                            (HMENU)(INT_PTR)kIdEditPinnedHint, instance,
-                            nullptr);
-
-            CreateWindowExW(0, L"STATIC", L"",
-                            WS_CHILD | WS_VISIBLE | SS_OWNERDRAW, 360, 196, 40,
-                            40, hWnd, (HMENU)(INT_PTR)kIdEditPreview, instance,
-                            nullptr);
-
-            CreateWindowExW(0, L"BUTTON", L"Save",
-                            WS_CHILD | WS_VISIBLE | WS_TABSTOP |
-                                BS_DEFPUSHBUTTON,
-                            222, 266, 86, 26, hWnd,
-                            (HMENU)(INT_PTR)kIdEditOk, instance, nullptr);
-            CreateWindowExW(0, L"BUTTON", L"Cancel",
-                            WS_CHILD | WS_VISIBLE | WS_TABSTOP |
-                                BS_PUSHBUTTON,
-                            314, 266, 86, 26, hWnd,
-                            (HMENU)(INT_PTR)kIdEditCancel, instance, nullptr);
+            LayoutChildren(hWnd, kEditLayout, ARRAYSIZE(kEditLayout),
+                           DpiOf(hWnd));
 
             SetDlgItemTextW(hWnd, kIdEditName, ctx->entry.name.c_str());
             SetDlgItemTextW(hWnd, kIdEditPath, ctx->entry.path.c_str());
             SetDlgItemTextW(hWnd, kIdEditIcon, ctx->entry.icon.c_str());
             CheckDlgButton(hWnd, kIdEditPinned,
                            ctx->entry.pinned ? BST_CHECKED : BST_UNCHECKED);
-            ApplyUiFont(hWnd);
+            ApplyUiFont(hWnd, DpiOf(hWnd));
             RefreshPreview(hWnd, ctx);
+            return 0;
+        }
+
+        // Dragged to a monitor at another scale: take the frame Windows
+        // suggests, then re-run the layout, the font and the preview icon at
+        // the new DPI.
+        case WM_DPICHANGED: {
+            const RECT* suggested = (const RECT*)lParam;
+            SetWindowPos(hWnd, nullptr, suggested->left, suggested->top,
+                         suggested->right - suggested->left,
+                         suggested->bottom - suggested->top,
+                         SWP_NOZORDER | SWP_NOACTIVATE);
+            int dpi = LOWORD(wParam);
+            LayoutChildren(hWnd, kEditLayout, ARRAYSIZE(kEditLayout), dpi);
+            ApplyUiFont(hWnd, dpi);
+            if (ctx) {
+                RefreshPreview(hWnd, ctx);
+            }
             return 0;
         }
 
@@ -5787,9 +6012,12 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
                 FillRect(dis->hDC, &dis->rcItem,
                          GetSysColorBrush(COLOR_BTNFACE));
                 if (ctx && ctx->preview) {
-                    DrawIconEx(dis->hDC, dis->rcItem.left + 4,
-                               dis->rcItem.top + 4, ctx->preview, 32, 32, 0,
-                               nullptr, DI_NORMAL);
+                    int dpi = DpiOf(hWnd);
+                    int inset = Scale(kPreviewInset, dpi);
+                    int size = Scale(kPreviewIcon, dpi);
+                    DrawIconEx(dis->hDC, dis->rcItem.left + inset,
+                               dis->rcItem.top + inset, ctx->preview, size,
+                               size, 0, nullptr, DI_NORMAL);
                 } else if (ctx) {
                     std::wstring icon = GetControlText(hWnd, kIdEditIcon);
                     if (!icon.empty()) {
@@ -5845,9 +6073,12 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
                 }
                 // Same folder as another row would mean two buttons for one
                 // folder, which is also what blocks re-pinning a draft.
+                // Compared by path, not by index: the store may have been
+                // changed on another thread since this dialog opened.
                 auto stored = FolderStore::Read();
                 int clash = FolderStore::IndexOfPath(stored, path);
-                if (clash >= 0 && clash != ctx->index) {
+                if (clash >= 0 &&
+                    !FolderStore::SamePath(path, ctx->originalPath)) {
                     MessageBoxW(hWnd,
                                 L"That folder is already in the list. Edit "
                                 L"the existing entry instead.",
@@ -5872,12 +6103,16 @@ LRESULT CALLBACK EditWndProc(HWND hWnd, UINT msg, WPARAM wParam,
             DestroyWindow(hWnd);
             return 0;
 
+        // No PostQuitMessage: RunEditDialog's nested loop ends on this window
+        // going away instead. A WM_QUIT here would be consumed by that loop,
+        // and if the main window had been closed at the same time (which is
+        // what mod teardown does) its own quit would be the one swallowed,
+        // leaving the outer loop blocked in GetMessage forever.
         case WM_DESTROY:
             if (ctx && ctx->preview) {
                 DestroyIcon(ctx->preview);
                 ctx->preview = nullptr;
             }
-            PostQuitMessage(0);
             return 0;
     }
     return DefWindowProcW(hWnd, msg, wParam, lParam);
@@ -5891,8 +6126,12 @@ bool RunEditDialog(HWND owner, EditContext* ctx, PCWSTR title) {
         return false;
     }
 
-    RECT rect{0, 0, 414, 306};
-    AdjustWindowRect(&rect, WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU, FALSE);
+    // Sized at the owner's DPI: this window opens centred over it, so that is
+    // the monitor it lands on.
+    int dpi = DpiOf(owner);
+    RECT rect{0, 0, Scale(kEditWidth, dpi), Scale(kEditHeight, dpi)};
+    AdjustWindowRectExForDpi(&rect, WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU,
+                             FALSE, WS_EX_DLGMODALFRAME, (UINT)dpi);
     int width = rect.right - rect.left;
     int height = rect.bottom - rect.top;
 
@@ -5916,22 +6155,42 @@ bool RunEditDialog(HWND owner, EditContext* ctx, PCWSTR title) {
     ShowWindow(hWnd, SW_SHOW);
     SetFocus(GetDlgItem(hWnd, kIdEditName));
 
+    // Ends when this window is destroyed, rather than on WM_QUIT. DestroyWindow
+    // runs synchronously inside the DispatchMessageW below, so the check right
+    // after it is what breaks the loop. A WM_QUIT that does arrive belongs to
+    // the outer loop (mod teardown posts WM_CLOSE to every window on this
+    // thread) and is put back, so the outer loop still sees it.
     MSG msg;
-    while (GetMessageW(&msg, nullptr, 0, 0) > 0) {
+    while (IsWindow(hWnd)) {
+        BOOL got = GetMessageW(&msg, nullptr, 0, 0);
+        if (got == 0) {
+            PostQuitMessage((int)msg.wParam);
+            break;
+        }
+        if (got == -1) {
+            break;
+        }
         if (!IsDialogMessageW(hWnd, &msg)) {
             TranslateMessage(&msg);
             DispatchMessageW(&msg);
         }
     }
 
-    EnableWindow(owner, TRUE);
-    SetForegroundWindow(owner);
+    if (IsWindow(owner)) {
+        EnableWindow(owner, TRUE);
+        SetForegroundWindow(owner);
+    }
     return ctx->accepted;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Main window
 
+// Rows are committed by path rather than by their listbox index. The store is
+// shared with the taskbar UI thread (unpin) and an Explorer window thread (the
+// context-menu pin), so it can gain or lose entries while a modal dialog or a
+// confirmation box is up — and an index taken before that would then write to,
+// or delete, a different folder than the one on screen.
 void EditSelected(HWND hWnd) {
     int index = SelectedIndex(hWnd);
     if (index < 0) {
@@ -5939,26 +6198,58 @@ void EditSelected(HWND hWnd) {
     }
     EditContext ctx;
     ctx.entry = g_rows[index];
-    ctx.index = index;
-    if (!RunEditDialog(hWnd, &ctx, L"Edit folder")) {
+    ctx.originalPath = g_rows[index].path;
+    if (!RunEditDialog(hWnd, &ctx, L"Edit folder") || g_unloading) {
         return;
     }
-    auto stored = FolderStore::Read();
-    if (index < (int)stored.size()) {
-        stored[index] = ctx.entry;
-        CommitStore(hWnd, stored);
+
+    bool gone = false;
+    {
+        std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
+        auto stored = FolderStore::Read();
+        int at = FolderStore::IndexOfPath(stored, ctx.originalPath);
+        if (at < 0) {
+            gone = true;
+        } else {
+            stored[at] = ctx.entry;
+            FolderStore::Write(stored);
+        }
     }
+    if (gone) {
+        Wh_Log(L"Edit: '%s' is no longer in the store; discarding the edit",
+               ctx.originalPath.c_str());
+        PopulateList(hWnd);
+        return;
+    }
+    RefreshAfterStoreChange(hWnd);
 }
 
 void AddNew(HWND hWnd) {
     EditContext ctx;
     ctx.entry.pinned = true;
-    if (!RunEditDialog(hWnd, &ctx, L"Add folder")) {
+    if (!RunEditDialog(hWnd, &ctx, L"Add folder") || g_unloading) {
         return;
     }
-    auto stored = FolderStore::Read();
-    stored.push_back(ctx.entry);
-    CommitStore(hWnd, stored);
+
+    bool duplicate = false;
+    {
+        std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
+        auto stored = FolderStore::Read();
+        // The dialog already checked, but another thread may have pinned the
+        // same folder while it was open.
+        if (FolderStore::IndexOfPath(stored, ctx.entry.path) >= 0) {
+            duplicate = true;
+        } else {
+            stored.push_back(ctx.entry);
+            FolderStore::Write(stored);
+        }
+    }
+    if (duplicate) {
+        Wh_Log(L"Add: '%s' was added elsewhere first", ctx.entry.path.c_str());
+        PopulateList(hWnd);
+        return;
+    }
+    RefreshAfterStoreChange(hWnd);
 }
 
 void RemoveSelected(HWND hWnd) {
@@ -5966,21 +6257,36 @@ void RemoveSelected(HWND hWnd) {
     if (index < 0) {
         return;
     }
-    std::wstring name = g_rows[index].name.empty() ? g_rows[index].path
-                                                   : g_rows[index].name;
+    std::wstring path = g_rows[index].path;
+    std::wstring name = g_rows[index].name.empty() ? path : g_rows[index].name;
     std::wstring prompt = L"Remove \"" + name +
                           L"\" from the list?\n\nThe folder itself is not "
                           L"touched — only this button. To keep the entry but "
                           L"take it off the taskbar, use Unpin instead.";
     if (MessageBoxW(hWnd, prompt.c_str(), L"Taskbar Folders",
-                    MB_OKCANCEL | MB_ICONQUESTION) != IDOK) {
+                    MB_OKCANCEL | MB_ICONQUESTION) != IDOK ||
+        g_unloading) {
         return;
     }
-    auto stored = FolderStore::Read();
-    if (index < (int)stored.size()) {
-        stored.erase(stored.begin() + index);
-        CommitStore(hWnd, stored);
+
+    bool gone = false;
+    {
+        std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
+        auto stored = FolderStore::Read();
+        int at = FolderStore::IndexOfPath(stored, path);
+        if (at < 0) {
+            gone = true;
+        } else {
+            stored.erase(stored.begin() + at);
+            FolderStore::Write(stored);
+        }
     }
+    if (gone) {
+        Wh_Log(L"Remove: '%s' is no longer in the store", path.c_str());
+        PopulateList(hWnd);
+        return;
+    }
+    RefreshAfterStoreChange(hWnd);
 }
 
 
@@ -5988,19 +6294,33 @@ void RemoveSelected(HWND hWnd) {
 // than swapping the two ends — dragging row 0 to the bottom should slide
 // everything else up one, not trade places with the last row.
 void MoveRow(HWND hWnd, int from, int to) {
-    auto stored = FolderStore::Read();
-    if (from < 0 || to < 0 || from >= (int)stored.size() ||
-        to >= (int)stored.size() || from == to) {
+    if (from < 0 || to < 0 || from >= (int)g_rows.size() ||
+        to >= (int)g_rows.size() || from == to || g_unloading) {
         return;
     }
-    FolderStore::Entry moved = stored[from];
-    stored.erase(stored.begin() + from);
-    stored.insert(stored.begin() + to, std::move(moved));
-    FolderStore::Write(stored);
-    if (!g_unloading) {
-        ReloadAndRefreshUI();
+
+    // Unlike edit and remove, a reorder is about positions, so there is no
+    // path to re-find it by: if the store no longer matches the rows the drag
+    // started from, the move is meaningless and the list is just refreshed.
+    bool stale = false;
+    {
+        std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
+        auto stored = FolderStore::Read();
+        if (!StoreMatchesRows(stored)) {
+            stale = true;
+        } else {
+            FolderStore::Entry moved = stored[from];
+            stored.erase(stored.begin() + from);
+            stored.insert(stored.begin() + to, std::move(moved));
+            FolderStore::Write(stored);
+        }
     }
-    PopulateList(hWnd);
+    if (stale) {
+        Wh_Log(L"Reorder: the store changed under the window; refreshing");
+        PopulateList(hWnd);
+        return;
+    }
+    RefreshAfterStoreChange(hWnd);
     SendMessageW(GetDlgItem(hWnd, kIdList), LB_SETCURSEL, to, 0);
 }
 
@@ -6036,7 +6356,8 @@ int InsertIndexAt(HWND list, POINT pt) {
     if (pt.y < 0) {
         return top;
     }
-    int offset = (pt.y + kRowHeight / 2) / kRowHeight;
+    int rowHeight = Scale(kRowHeight, DpiOf(list));
+    int offset = (pt.y + rowHeight / 2) / rowHeight;
     int index = top + offset;
     int count = (int)g_rows.size();
     return index < 0 ? 0 : (index > count ? count : index);
@@ -6049,7 +6370,7 @@ void DrawInsertionLine(HWND list, int index) {
     int top = (int)SendMessageW(list, LB_GETTOPINDEX, 0, 0);
     RECT client{};
     GetClientRect(list, &client);
-    int y = (index - top) * kRowHeight;
+    int y = (index - top) * Scale(kRowHeight, DpiOf(list));
     if (y < 0) {
         return;
     }
@@ -6113,7 +6434,7 @@ LRESULT CALLBACK ListSubclassProc(HWND list,
         case WM_LBUTTONDOWN: {
             POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
             int top = (int)SendMessageW(list, LB_GETTOPINDEX, 0, 0);
-            int row = top + pt.y / kRowHeight;
+            int row = top + pt.y / Scale(kRowHeight, DpiOf(list));
             if (pt.y < 0 || row < 0 || row >= (int)g_rows.size()) {
                 return 0;
             }
@@ -6135,7 +6456,7 @@ LRESULT CALLBACK ListSubclassProc(HWND list,
         case WM_LBUTTONDBLCLK: {
             POINT pt{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
             int top = (int)SendMessageW(list, LB_GETTOPINDEX, 0, 0);
-            int row = top + pt.y / kRowHeight;
+            int row = top + pt.y / Scale(kRowHeight, DpiOf(list));
             if (pt.y >= 0 && row >= 0 && row < (int)g_rows.size()) {
                 SendMessageW(list, LB_SETCURSEL, row, 0);
                 SendMessageW(GetParent(list), WM_COMMAND,
@@ -6224,37 +6545,33 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 WS_EX_CLIENTEDGE, L"LISTBOX", nullptr,
                 WS_CHILD | WS_VISIBLE | WS_VSCROLL | WS_TABSTOP | LBS_NOTIFY |
                     LBS_OWNERDRAWFIXED,
-                12, 12, 452, 300, hWnd, (HMENU)(INT_PTR)kIdList, instance,
-                nullptr);
+                0, 0, 0, 0, hWnd, (HMENU)(INT_PTR)kIdList, instance, nullptr);
             WindhawkUtils::SetWindowSubclassFromAnyThread(list,
                                                           ListSubclassProc, 0);
 
             struct ButtonSpec {
                 int id;
                 PCWSTR text;
-                int x;
-                int y;
-                int width;
             };
-            const ButtonSpec buttons[] = {
-                {kIdAdd, L"Add...", 12, 324, 76},
-                {kIdEdit, L"Edit...", 94, 324, 76},
-                {kIdRemove, L"Remove", 176, 324, 76},
-                {kIdClose, L"Close", 388, 324, 76},
-            };
+            const ButtonSpec buttons[] = {{kIdAdd, L"Add..."},
+                                          {kIdEdit, L"Edit..."},
+                                          {kIdRemove, L"Remove"},
+                                          {kIdClose, L"Close"}};
             for (const auto& b : buttons) {
                 CreateWindowExW(0, L"BUTTON", b.text,
                                 WS_CHILD | WS_VISIBLE | WS_TABSTOP |
                                     BS_PUSHBUTTON,
-                                b.x, b.y, b.width, 26, hWnd,
-                                (HMENU)(INT_PTR)b.id, instance, nullptr);
+                                0, 0, 0, 0, hWnd, (HMENU)(INT_PTR)b.id,
+                                instance, nullptr);
             }
 
-            CreateWindowExW(0, L"STATIC", L"", WS_CHILD | WS_VISIBLE, 12, 360,
-                            452, 32, hWnd, (HMENU)(INT_PTR)kIdHint, instance,
+            CreateWindowExW(0, L"STATIC", L"", WS_CHILD | WS_VISIBLE, 0, 0, 0,
+                            0, hWnd, (HMENU)(INT_PTR)kIdHint, instance,
                             nullptr);
 
-            ApplyUiFont(hWnd);
+            LayoutChildren(hWnd, kMainLayout, ARRAYSIZE(kMainLayout),
+                           DpiOf(hWnd));
+            ApplyUiFont(hWnd, DpiOf(hWnd));
             PopulateList(hWnd);
             return 0;
         }
@@ -6262,10 +6579,34 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         case WM_MEASUREITEM: {
             auto* mis = (LPMEASUREITEMSTRUCT)lParam;
             if (mis->CtlID == kIdList) {
-                mis->itemHeight = kRowHeight;
+                // Sent while the listbox is being created, before its own
+                // HWND exists — hence the parent's DPI, which is the same
+                // monitor.
+                mis->itemHeight = Scale(kRowHeight, DpiOf(hWnd));
                 return TRUE;
             }
             break;
+        }
+
+        // Dragged to a monitor at another scale. LB_SETITEMHEIGHT because
+        // WM_MEASUREITEM is not sent again for an existing owner-draw listbox,
+        // and PopulateList because the row icons were extracted at the old
+        // pixel size.
+        case WM_DPICHANGED: {
+            const RECT* suggested = (const RECT*)lParam;
+            SetWindowPos(hWnd, nullptr, suggested->left, suggested->top,
+                         suggested->right - suggested->left,
+                         suggested->bottom - suggested->top,
+                         SWP_NOZORDER | SWP_NOACTIVATE);
+            int dpi = LOWORD(wParam);
+            LayoutChildren(hWnd, kMainLayout, ARRAYSIZE(kMainLayout), dpi);
+            ApplyUiFont(hWnd, dpi);
+            if (HWND list = GetDlgItem(hWnd, kIdList)) {
+                SendMessageW(list, LB_SETITEMHEIGHT, 0,
+                             Scale(kRowHeight, dpi));
+            }
+            PopulateList(hWnd);
+            return 0;
         }
 
         case WM_DRAWITEM: {
@@ -6336,15 +6677,29 @@ void ThreadMain(POINT anchor) {
         return;
     }
 
-    RECT rect{0, 0, 476, 400};
-    AdjustWindowRect(&rect, WS_OVERLAPPEDWINDOW, FALSE);
-    int width = rect.right - rect.left;
-    int height = rect.bottom - rect.top;
-    POINT pos = CenterOnMonitor(anchor, width, height);
-    HWND hWnd = CreateWindowExW(
-        WS_EX_APPWINDOW, kClassName, L"Taskbar Folders",
-        WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX, pos.x, pos.y,
-        width, height, nullptr, nullptr, instance, nullptr);
+    // explorer.exe is Per-Monitor-DPI-Aware V2 and this thread inherits that,
+    // so nothing here scales on its own. The window is created at the anchor
+    // with a provisional size purely to put it on the right monitor; its DPI
+    // is only knowable once it exists, so the real size is applied below,
+    // before it is ever shown. WM_CREATE already lays the children out at the
+    // final DPI — GetDpiForWindow is correct from creation.
+    const DWORD style =
+        WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
+    HWND hWnd = CreateWindowExW(WS_EX_APPWINDOW, kClassName, L"Taskbar Folders",
+                                style, anchor.x, anchor.y, kMainWidth,
+                                kMainHeight, nullptr, nullptr, instance,
+                                nullptr);
+    if (hWnd) {
+        int dpi = DpiOf(hWnd);
+        RECT rect{0, 0, Scale(kMainWidth, dpi), Scale(kMainHeight, dpi)};
+        AdjustWindowRectExForDpi(&rect, style, FALSE, WS_EX_APPWINDOW,
+                                 (UINT)dpi);
+        int width = rect.right - rect.left;
+        int height = rect.bottom - rect.top;
+        POINT pos = CenterOnMonitor(anchor, width, height);
+        SetWindowPos(hWnd, nullptr, pos.x, pos.y, width, height,
+                     SWP_NOZORDER | SWP_NOACTIVATE);
+    }
     if (!hWnd) {
         Wh_Log(L"Manager: CreateWindowExW failed (error %u)", GetLastError());
         if (SUCCEEDED(comInit)) {
@@ -6373,6 +6728,17 @@ void ThreadMain(POINT anchor) {
     g_active = false;
 }
 
+// The manager thread itself, kept rather than detached so CloseAndWait can
+// wait on the thread instead of polling a flag that is cleared before the
+// thread has finished unwinding through this DLL's image.
+//
+// no_destroy for the same reason as g_scanThread: destroying a joinable
+// std::thread calls std::terminate, and CRT teardown at Explorer exit must not
+// touch it. g_threadMutex guards the slot — Open() can be called from the
+// taskbar UI thread while Wh_ModUninit runs CloseAndWait on another.
+[[clang::no_destroy]] std::optional<std::thread> g_thread;
+[[clang::no_destroy]] std::mutex g_threadMutex;
+
 // Brings an already-open window forward instead of opening a second one.
 void Open() {
     if (HWND existing = g_wnd.load()) {
@@ -6388,21 +6754,98 @@ void Open() {
     if (!GetCursorPos(&anchor)) {
         anchor = POINT{0, 0};
     }
-    std::thread(ThreadMain, anchor).detach();
+    try {
+        std::lock_guard<std::mutex> lock(g_threadMutex);
+        // Reap the previous run before reusing the slot: assigning over a
+        // joinable std::thread calls std::terminate.
+        if (g_thread) {
+            if (g_thread->joinable()) {
+                g_thread->join();
+            }
+            g_thread.reset();
+        }
+        g_thread.emplace(ThreadMain, anchor);
+    } catch (...) {
+        Wh_Log(L"Manager: could not start its thread");
+        g_active = false;
+    }
 }
 
 // Asks the window to close and waits for its thread to unwind, so the DLL is
 // not unloaded out from under a live message loop.
 void CloseAndWait() {
-    if (HWND existing = g_wnd.load()) {
-        PostMessageW(existing, WM_CLOSE, 0, 0);
+    std::optional<std::thread> thread;
+    {
+        std::lock_guard<std::mutex> lock(g_threadMutex);
+        thread.swap(g_thread);
     }
-    for (int i = 0; g_active && i < 250; i++) {
-        Sleep(20);
+    if (!thread) {
+        return;
     }
-    if (g_active) {
-        Wh_Log(L"Uninit: folder manager window still open after wait");
+    if (!thread->joinable() ||
+        GetThreadId((HANDLE)thread->native_handle()) == GetCurrentThreadId()) {
+        // Never reached today (only Wh_ModUninit calls this), but joining
+        // ourselves would deadlock outright.
+        thread->detach();
+        return;
     }
+
+    // WM_CLOSE to *every* window on that thread, not only the main one: a
+    // Remove confirmation MessageBox or an open IFileDialog runs its own modal
+    // loop, and nothing but closing that window dismisses it — which is what
+    // used to leave the thread running past the old five-second give-up, with
+    // the DLL then unloaded out from under it. The main window goes last so a
+    // modal child is never orphaned by its owner being destroyed first.
+    HANDLE handle = (HANDLE)thread->native_handle();
+    auto closeAllWindows = [handle] {
+        HWND main = g_wnd.load();
+        if (DWORD threadId = GetThreadId(handle)) {
+            EnumThreadWindows(
+                threadId,
+                [](HWND hWnd, LPARAM mainWnd) -> BOOL {
+                    if (hWnd != (HWND)mainWnd) {
+                        PostMessageW(hWnd, WM_CLOSE, 0, 0);
+                    }
+                    return TRUE;
+                },
+                (LPARAM)main);
+        }
+        if (main) {
+            PostMessageW(main, WM_CLOSE, 0, 0);
+        }
+    };
+
+    closeAllWindows();
+    // Pumping sent messages matters as much here as in StopScanThread: this
+    // wait must not be what blocks a thread trying to SendMessage into it. The
+    // two-second timeout only exists to re-close a modal that appeared after
+    // the first round; the wait itself is unbounded on purpose, because
+    // returning early is exactly what would let Windhawk unload this DLL with
+    // the manager thread still executing inside it.
+    for (int elapsedMs = 0;;) {
+        DWORD result =
+            MsgWaitForMultipleObjects(1, &handle, FALSE, 2000, QS_SENDMESSAGE);
+        if (result == WAIT_OBJECT_0) {
+            break;
+        }
+        if (result == WAIT_OBJECT_0 + 1) {
+            MSG msg;
+            PeekMessageW(&msg, nullptr, 0, 0, PM_NOREMOVE);
+            continue;
+        }
+        if (result == WAIT_FAILED) {
+            Wh_Log(L"CloseAndWait: MsgWaitForMultipleObjects failed (%u)",
+                   GetLastError());
+            break;
+        }
+        elapsedMs += 2000;
+        if (elapsedMs % 10000 == 0) {
+            Wh_Log(L"Uninit: still waiting on the folder manager thread (%d s)",
+                   elapsedMs / 1000);
+        }
+        closeAllWindows();
+    }
+    thread->join();
 }
 
 }  // namespace FolderManager
@@ -6438,7 +6881,14 @@ void PlayPressBounce(UIElement const& element) {
 
 // The open right-click flyout, so teardown can close it before the lambdas
 // behind its items are unmapped.
-MenuFlyout g_buttonMenuFlyout{nullptr};
+//
+// no_destroy: Wh_ModUninit does not run when Explorer terminates (sign-out,
+// restart, reboot) — only the CRT destructors of globals do, on the shutdown
+// thread, after every other thread has been killed. Releasing a strong XAML
+// reference there is exactly the UI-thread-affinity case that crashes. Cleared
+// with `g_buttonMenuFlyout = nullptr` in the Closed handler and in teardown,
+// which is what actually releases it.
+[[clang::no_destroy]] MenuFlyout g_buttonMenuFlyout{nullptr};
 
 FontIcon MakeMenuGlyph(const wchar_t* glyph) {
     FontIcon icon;
@@ -6496,7 +6946,16 @@ void OnButtonRightClicked(int folderIndex, Button const& button) {
             // name and icon survive and it can be pinned again from the
             // manager.
             RemovePinnedFolder(path);
-            ReloadAndRefreshUI();
+            // Deferred: the reload destroys this button and unhooks the
+            // handlers this lambda is running inside, and the flyout is
+            // anchored to it. The owner window lives on this same taskbar UI
+            // thread, so the post lands right after the flyout unwinds.
+            if (!g_menuOwnerWnd ||
+                !PostMessageW(g_menuOwnerWnd, WM_APP_RELOAD_UI, 0, 0)) {
+                Wh_Log(L"Unpin: no menu owner window to defer the reload to; "
+                       L"reloading inline");
+                ReloadAndRefreshUI();
+            }
         });
 
         MenuFlyoutItem manage;
@@ -7318,24 +7777,45 @@ std::wstring EscapeMenuLabel(const std::wstring& s) {
     return out;
 }
 
-bool IsShellViewWindow(HWND hwnd) {
+// The shell view that owns `hwnd`, or null if there is not one — which is also
+// what says "this is an Explorer or Desktop context menu, not some other
+// TrackPopupMenuEx caller in the process".
+HWND FindShellViewWindow(HWND hwnd) {
     for (HWND h = hwnd; h; h = GetParent(h)) {
         WCHAR cls[64]{};
         GetClassNameW(h, cls, ARRAYSIZE(cls));
         if (wcscmp(cls, L"SHELLDLL_DefView") == 0) {
-            return true;
+            return h;
         }
     }
-    return false;
+    return nullptr;
 }
 
-// Path of the single selected item in the shell view owning `hwnd`, or empty
-// (no selection, multi-selection, or not a real shell view).
-std::wstring GetSelectedPath(HWND hwnd) {
+// CWM_GETISHELLBROWSER. Undocumented, and WM_USER-relative, so it means
+// something entirely different to every window class that does not implement
+// it — which is why it is only ever sent to the classes known to answer it,
+// rather than up an arbitrary parent chain that ends at Progman or WorkerW.
+constexpr UINT CWM_GETISHELLBROWSER = WM_USER + 7;
+
+bool AnswersGetIShellBrowser(HWND hwnd) {
+    WCHAR cls[64]{};
+    GetClassNameW(hwnd, cls, ARRAYSIZE(cls));
+    return wcscmp(cls, L"SHELLDLL_DefView") == 0 ||
+           wcscmp(cls, L"ShellTabWindowClass") == 0 ||
+           wcscmp(cls, L"CabinetWClass") == 0;
+}
+
+// Path of the single selected item in the shell view `defView`, or empty (no
+// selection, multi-selection, or no browser). The returned IShellBrowser is
+// not reference-counted by the message, so it is not released here.
+std::wstring GetSelectedPath(HWND defView) {
     std::wstring result;
-    IShellBrowser* browser = (IShellBrowser*)SendMessageW(hwnd, WM_USER + 7, 0, 0);
-    for (HWND h = hwnd; !browser && h; h = GetParent(h)) {
-        browser = (IShellBrowser*)SendMessageW(h, WM_USER + 7, 0, 0);
+    IShellBrowser* browser = nullptr;
+    for (HWND h = defView; !browser && h; h = GetParent(h)) {
+        if (AnswersGetIShellBrowser(h)) {
+            browser = (IShellBrowser*)SendMessageW(h, CWM_GETISHELLBROWSER, 0,
+                                                   0);
+        }
     }
     if (!browser) {
         return result;
@@ -7419,6 +7899,11 @@ std::wstring CreateShortcutIn(const std::wstring& target,
     return SUCCEEDED(hr) ? lnkPath : L"";
 }
 
+// Theme for the menu popups created while the CBT hook below is installed.
+// A WH_CBT hook procedure has to be a plain function pointer, so the value it
+// needs is parked here instead of captured.
+std::atomic<bool> g_menuDark{true};
+
 decltype(&TrackPopupMenuEx) TrackPopupMenuEx_orig;
 
 BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
@@ -7427,7 +7912,8 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
                                  int y,
                                  HWND hwnd,
                                  LPTPMPARAMS params) {
-    if (!IsShellViewWindow(hwnd)) {
+    HWND defView = g_settings.explorerMenu ? FindShellViewWindow(hwnd) : nullptr;
+    if (!defView) {
         return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
     }
 
@@ -7440,7 +7926,7 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
         }
     } com;
 
-    std::wstring path = GetSelectedPath(hwnd);
+    std::wstring path = GetSelectedPath(defView);
     DWORD attrs =
         path.empty() ? INVALID_FILE_ATTRIBUTES : GetFileAttributesW(path.c_str());
     if (attrs == INVALID_FILE_ATTRIBUTES) {
@@ -7516,10 +8002,17 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
 
     // Submenus we inject (MF_POPUP with our own CreatePopupMenu() handles)
     // aren't part of explorer's IContextMenu tree, so explorer's own
-    // dark-mode/rounded-corner treatment for nested popups skips them —
-    // they render with the classic light-mode square border. Each nested
-    // popup spawns a new "#32768" window while TrackPopupMenuEx_orig pumps
-    // its own message loop below, so a scoped CBT hook catches all of them.
+    // dark-mode/rounded-corner treatment for nested popups skips them — they
+    // render with the classic light-mode square border. Each nested popup
+    // spawns a new "#32768" window while TrackPopupMenuEx_orig pumps its own
+    // message loop below, so a scoped CBT hook catches all of them.
+    //
+    // The hook is thread-wide for the duration of that call, so it also sees
+    // Explorer's own submenus (Open with, Send to, New) — forcing dark on
+    // those would darken them on a light theme. Resolved once here rather than
+    // inside the hook, which cannot capture and should not be doing WinRT work
+    // while a menu is coming up.
+    g_menuDark = IsDarkTheme();
     HHOOK cbtHook = SetWindowsHookExW(
         WH_CBT,
         [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
@@ -7528,7 +8021,7 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
                 CBT_CREATEWNDW* cbt = (CBT_CREATEWNDW*)lParam;
                 LPCWSTR cls = cbt->lpcs->lpszClass;
                 if (IS_INTRESOURCE(cls) && LOWORD((ULONG_PTR)cls) == 32768) {
-                    BOOL dark = TRUE;
+                    BOOL dark = g_menuDark.load() ? TRUE : FALSE;
                     DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
                                           &dark, sizeof(dark));
                     int corner = DWMWCP_ROUND;
@@ -7612,9 +8105,18 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
-    if (!Wh_SetFunctionHook((void*)TrackPopupMenuEx,
-                            (void*)AddToTaskbar::TrackPopupMenuExHook,
-                            (void**)&AddToTaskbar::TrackPopupMenuEx_orig)) {
+    // Only when the Explorer integration is on: with it off, every context
+    // menu in the process stays entirely untouched by this mod, so nothing in
+    // the menu path can affect Explorer at all. Windhawk has no way to remove
+    // a function hook without reloading, so turning the setting back on takes
+    // effect on the next load — which is what its description says.
+    if (!g_settings.explorerMenu) {
+        Wh_Log(L"Explorer right-click integration is off; not hooking "
+               L"TrackPopupMenuEx");
+    } else if (!Wh_SetFunctionHook(
+                   (void*)TrackPopupMenuEx,
+                   (void*)AddToTaskbar::TrackPopupMenuExHook,
+                   (void**)&AddToTaskbar::TrackPopupMenuEx_orig)) {
         // Non-fatal: the rest of the mod works without the right-click
         // integration.
         Wh_Log(L"Failed to hook TrackPopupMenuEx; Explorer right-click "
@@ -7660,15 +8162,26 @@ void ReloadAndRefreshUI() {
 
     // Scan thread restarts lazily on the next RequestScan.
     StartRetryThread();
+
+    // Every store change routes through here — the Explorer pin, the taskbar
+    // unpin, a settings reload — so this is where an open manager window finds
+    // out its list is stale. Without it the window keeps showing (and
+    // committing against) rows that no longer match the store.
+    //
+    // Skipped when the manager thread is the caller: it refreshes its own list
+    // synchronously right after this returns, and a queued WM_APP would land
+    // afterwards and clear the selection it had just restored.
+    if (HWND manager = FolderManager::g_wnd.load()) {
+        if (GetWindowThreadProcessId(manager, nullptr) !=
+            GetCurrentThreadId()) {
+            PostMessageW(manager, WM_APP, 0, 0);
+        }
+    }
 }
 
 void Wh_ModSettingsChanged() {
     Wh_Log(L"SettingsChanged");
     ReloadAndRefreshUI();
-    if (HWND manager = FolderManager::g_wnd.load()) {
-        // Mirror the new list if the manager happens to be open.
-        PostMessageW(manager, WM_APP, 0, 0);
-    }
 
     // "Open the folder manager" acts as a button: it fires when switched on,
     // and switching it off again is a no-op. Windhawk's settings schema has no

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.43
+// @version         1.44
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
@@ -279,12 +279,15 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
   $name: 2. Content ▸ Grid columns
   $description: 0 chooses a square-ish grid automatically.
 
-- itemSize: medium
+- itemSize: small
   $name: 3. Appearance ▸ Item size
   $description: >-
-    Preset size for each item's icon and grid cell. Small/large scale both the
+    Preset size for each item's icon and grid cell. Every step scales both the
     icon and the overall tray size.
   $options:
+  - smallest: Smallest
+  - tiny: Tiny
+  - xsmall: Extra small
   - small: Small
   - medium: Medium
   - large: Large
@@ -361,7 +364,7 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
     Thin outline around the edge of the grid, plus the border Windows draws on
     the rounded window. Turn off for a frameless look at low opacity.
 
-- blurType: gaussian
+- blurType: acrylic
   $name: 3. Appearance ▸ Blur type
   $description: >-
     Gaussian captures the screen behind the grid and blurs it ourselves - a
@@ -373,9 +376,9 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
     opacity instead of the blur radius. None skips blur entirely - cheaper
     than either, same as setting the strength below to 0.
   $options:
-  - none: None
-  - gaussian: Gaussian (adjustable, more expensive)
   - acrylic: Acrylic (fixed radius, cheaper)
+  - gaussian: Gaussian (adjustable, more expensive)
+  - none: None
 
 - blurStrength: 40
   $name: 3. Appearance ▸ Blur strength (%)
@@ -538,9 +541,9 @@ struct Settings {
     bool showExtensions = false;
     SortMode sortBy = SortMode::Name;
     // Derived from itemSize in LoadSettings(); not settings-bound directly.
-    int cellWidth = 92;
-    int cellHeight = 88;
-    int iconSize = 32;
+    int cellWidth = 76;
+    int cellHeight = 72;
+    int iconSize = 24;
     bool showLabels = true;
     int fontSize = 12;
     // LOGFONT lfWeight values. See MakePopupFont.
@@ -554,7 +557,7 @@ struct Settings {
     int popupThemeOverride = -1;
     int panelOpacity = 85;
     bool panelBorder = true;
-    BlurType blurType = BlurType::Gaussian;
+    BlurType blurType = BlurType::Acrylic;
     int blurStrength = 40;
     int gapAbove = 8;
     int gapBefore = 0;
@@ -1151,19 +1154,35 @@ void LoadSettings() {
         std::clamp<int>(Wh_GetIntSetting(L"submenuCloseDelayMs"), 0, 5000);
     g_settings.showHidden = Wh_GetIntSetting(L"showHidden");
     g_settings.showExtensions = Wh_GetIntSetting(L"showExtensions");
+    // Cell padding grows with the icon rather than staying fixed, so the label
+    // keeps its room at the small end. The small/medium/large numbers are the
+    // originals — the three steps below them were added later, so an existing
+    // setting keeps the size it already had.
     std::wstring itemSize = GetStringSetting(L"itemSize");
-    if (itemSize == L"small") {
-        g_settings.iconSize = 24;
-        g_settings.cellWidth = 76;
-        g_settings.cellHeight = 72;
+    if (itemSize == L"smallest") {
+        g_settings.iconSize = 12;
+        g_settings.cellWidth = 56;
+        g_settings.cellHeight = 52;
+    } else if (itemSize == L"tiny") {
+        g_settings.iconSize = 16;
+        g_settings.cellWidth = 62;
+        g_settings.cellHeight = 58;
+    } else if (itemSize == L"xsmall") {
+        g_settings.iconSize = 20;
+        g_settings.cellWidth = 70;
+        g_settings.cellHeight = 66;
+    } else if (itemSize == L"medium") {
+        g_settings.iconSize = 32;
+        g_settings.cellWidth = 92;
+        g_settings.cellHeight = 88;
     } else if (itemSize == L"large") {
         g_settings.iconSize = 48;
         g_settings.cellWidth = 120;
         g_settings.cellHeight = 112;
     } else {
-        g_settings.iconSize = 32;
-        g_settings.cellWidth = 92;
-        g_settings.cellHeight = 88;
+        g_settings.iconSize = 24;
+        g_settings.cellWidth = 76;
+        g_settings.cellHeight = 72;
     }
     g_settings.showLabels = Wh_GetIntSetting(L"showLabels");
     g_settings.fontSize = std::clamp<int>(Wh_GetIntSetting(L"fontSize"), 6, 48);
@@ -1187,9 +1206,9 @@ void LoadSettings() {
         std::clamp<int>(Wh_GetIntSetting(L"panelOpacity"), 0, 100);
     g_settings.panelBorder = Wh_GetIntSetting(L"panelBorder");
     std::wstring blurType = GetStringSetting(L"blurType");
-    g_settings.blurType = blurType == L"acrylic"   ? BlurType::Acrylic
-                          : blurType == L"none"    ? BlurType::None
-                                                    : BlurType::Gaussian;
+    g_settings.blurType = blurType == L"gaussian" ? BlurType::Gaussian
+                          : blurType == L"none"   ? BlurType::None
+                                                  : BlurType::Acrylic;
     g_settings.blurStrength =
         std::clamp<int>(Wh_GetIntSetting(L"blurStrength"), 0, 100);
     g_settings.gapAbove =
@@ -9353,20 +9372,6 @@ void Wh_ModUninit() {
         g_taskbarHosts.reset();
     };
 
-    HWND threadWnd = nullptr;
-    for (HWND h : g_levelWindows) {
-        if (h) {
-            threadWnd = h;
-            break;
-        }
-    }
-    if (!threadWnd) {
-        threadWnd = g_menuOwnerWnd;
-    }
-    if (!threadWnd) {
-        threadWnd = FindCurrentProcessTaskbarWnd();
-    }
-
     // Every one of these waits is unbounded on purpose, for the reason
     // FolderManager::CloseAndWait spells out: Wh_ModUninit runs on a Windhawk
     // engine thread, not on any Explorer UI thread, so blocking here does not
@@ -9389,6 +9394,34 @@ void Wh_ModUninit() {
             Sleep(kUninitWaitPollMs);
         }
     };
+
+    // First, before any window handle is picked: a reload already past
+    // MenuOwnerWndProc's g_unloading check destroys every level window and
+    // clears g_levelWindows, so a handle latched ahead of this wait would be
+    // dead by the time it is used — and RunFromWindowThread would then skip the
+    // teardown entirely, leaving g_menuOwnerWnd (which no reload destroys) alive
+    // with its WndProc in the image about to be unmapped. The reload also parks
+    // the taskbar UI thread in joins that pump sent messages, so waiting here
+    // keeps the teardown send below from running re-entrantly inside one.
+    // Nothing to cancel, and it cannot restart a worker behind us:
+    // StartRetryThread bails on g_unloading.
+    waitOut(L"a UI reload", [] { return g_reloadInFlight.load() > 0; }, [] {});
+
+    // g_menuOwnerWnd first: it lives on the same taskbar UI thread and nothing
+    // but the teardown itself destroys it, so it is the stable choice. A level
+    // window and then the taskbar itself are the fallbacks.
+    HWND threadWnd = g_menuOwnerWnd;
+    if (!threadWnd) {
+        for (HWND h : g_levelWindows) {
+            if (h) {
+                threadWnd = h;
+                break;
+            }
+        }
+    }
+    if (!threadWnd) {
+        threadWnd = FindCurrentProcessTaskbarWnd();
+    }
 
     // ShowItemContextMenu runs a modal TrackPopupMenuEx loop on the UI thread.
     // Teardown via RunFromWindowThread would destroy windows and let Windhawk
@@ -9443,15 +9476,12 @@ void Wh_ModUninit() {
     // user does — see CMIC_MASK_ASYNCOK on the invoke path. Nothing to cancel.
     waitOut(L"a shell verb", [] { return g_invokeActive.load(); }, [] {});
 
-    // And a reload already past MenuOwnerWndProc's g_unloading check. It parks
-    // the taskbar UI thread in StopRetryThread/StopScanThread joins that pump
-    // sent messages, so the teardown send below runs re-entrantly inside it and
-    // this function would return — unmapping the image — with LoadSettings and
-    // the rest of ReloadAndRefreshUI still owed on that thread. Nothing to
-    // cancel, and it cannot restart a worker behind us: StartRetryThread bails
-    // on g_unloading. Waiting here also means the teardown send lands after the
-    // reload is done rather than inside its join.
-    waitOut(L"a UI reload", [] { return g_reloadInFlight.load() > 0; }, [] {});
+    // The waits above run for as long as the user does, so re-validate rather
+    // than trust a handle picked before them. The teardown is the one thing
+    // that must not be skipped.
+    if (threadWnd && !IsWindow(threadWnd)) {
+        threadWnd = FindCurrentProcessTaskbarWnd();
+    }
 
     if (threadWnd) {
         if (!RunFromWindowThread(threadWnd, teardownOnUiThread, nullptr)) {

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -363,6 +363,16 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 
 - gapAfter: 0
   $name: 3. Appearance ▸ Padding after buttons (px)
+
+- debugAnimLog: false
+  $name: 9. Debug ▸ Position trace logging
+  $description: Traces folder-button positioning to the Windhawk debug
+    console, one [ANIM] line per event - WINDOW (a window opened or closed),
+    ANCHOR (the anchored app icon was swapped), MARGIN (the reserved gap was
+    rewritten), SLIDE (the buttons were retargeted), RECYCLED/EXCEPTION - plus
+    GAP or OVERLAP when the settled distance between the folder buttons and
+    the app strip is not the configured padding, with every app icon's
+    position at that moment.
 */
 // ==/WindhawkModSettings==
 
@@ -487,9 +497,22 @@ struct Settings {
     // Read from an Explorer window thread inside the TrackPopupMenuEx hook
     // while LoadSettings may be writing it on another.
     std::atomic<bool> explorerMenu{true};
+    bool debugAnimLog = false;
 };
 
 Settings g_settings;
+
+// One-line-per-event trace, all under the same [ANIM] prefix so the whole
+// sequence (window opened, anchor swapped, margin rewritten, slide retargeted,
+// gap went bad) reads in order in the Windhawk log and filters with one grep.
+// Every call is off unless the debug setting is on.
+#define ANIM_TRACE(fmt, ...)                       \
+    do {                                           \
+        if (g_settings.debugAnimLog) {             \
+            Wh_Log(L"[ANIM] " fmt, ##__VA_ARGS__); \
+        }                                          \
+    } while (0)
+
 // Guards FolderEntry::resolvedPath / likelyRemote fills from STA resolve helpers
 // while UI and the scan worker may read them.
 std::mutex g_foldersMutex;
@@ -1059,6 +1082,7 @@ void LoadSettings() {
         std::clamp<int>(Wh_GetIntSetting(L"buttonIconSize"), 0, 128);
     g_settings.openFolderOnClick = Wh_GetIntSetting(L"openFolderOnClick");
     g_settings.explorerMenu = Wh_GetIntSetting(L"explorerMenu") != 0;
+    g_settings.debugAnimLog = Wh_GetIntSetting(L"debugAnimLog") != 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4533,6 +4557,7 @@ struct TaskbarHost {
     double buttonWidth = kFallbackButtonSize;
     double buttonHeight = kFallbackButtonSize;
     ULONGLONG lastAnchorResolveTick = 0;
+    int lastRepeaterChildCount = -1;
     ULONGLONG lastButtonSizeTick = 0;
     // hostGrid is positioned by this RenderTransform rather than by Margin.
     // Margin would feed rootGrid's column-0 measure, so every reposition
@@ -4556,6 +4581,45 @@ struct TaskbarHost {
     ULONGLONG slideEndTick = 0;
     ULONGLONG slideCauseTick = 0;
     bool slideCauseIsClose = false;
+    // When the target last moved, used to tell a settled open/close (which has
+    // a real icon animation to sync with) from churn (which does not).
+    ULONGLONG lastRetargetTick = 0;
+    // Set when ResolveAnchor just swapped to a different button (the old
+    // anchor closed) rather than the usual smooth shrink/slide. Consumed by
+    // AnimateHostGridLeftTo to skip the open/close sync delay for that one
+    // retarget — see the anchor-changed comment in OnRootGridLayoutUpdated.
+    bool anchorSwapped = false;
+    // First tick the settled gap looked wrong (0 = it looks fine), and whether
+    // that stretch has already been logged, so one bad stretch produces one
+    // error line plus one recovery line instead of one per layout pass. See
+    // CheckHostGridHealth.
+    ULONGLONG dbgBadSince = 0;
+    bool dbgBadLogged = false;
+    // Placed/visible app buttons last pass and when that count last moved -
+    // the only reliable "a window opened/closed" signal available (see
+    // CensusAppStrip). A retarget bigger than a button with no recent change
+    // here has no legitimate cause and gets flagged.
+    int dbgVisibleButtons = -1;
+    ULONGLONG dbgLastWindowTick = 0;
+    // Where the anchor was sitting when it was adopted one full reserve-width
+    // clear of the rest of the strip, i.e. parked on the far side of our own
+    // gap. -1 when the anchor was adopted normally. Positioning is held until
+    // the button has actually moved off this spot - see OnRootGridLayoutUpdated.
+    double parkedAnchorX = -1.0;
+    // Consecutive passes held back by the above, capped so a parked anchor
+    // that never moves cannot wedge the overlay.
+    int reserveHolds = 0;
+    // Anchor X as of the previous layout pass, and the tick it last differed
+    // from the pass before that. Windows moves its own icons over ~250ms, and
+    // layout reports the anchor part-way through that move, so a reading that
+    // differs from last pass is a frame of an animation in flight rather than
+    // a resting place. Positioning waits for two passes to agree - see the
+    // settle hold in OnRootGridLayoutUpdated.
+    double lastAnchorX = -1.0;
+    ULONGLONG anchorMovingSince = 0;
+    // Whether positioning is currently frozen for a mouse drag; only used to
+    // log the transitions rather than every pass.
+    bool dragFrozen = false;
 };
 
 [[clang::no_destroy]] std::optional<std::vector<std::unique_ptr<TaskbarHost>>>
@@ -5084,6 +5148,52 @@ FrameworkElement ResolveAnchor(FrameworkElement const& repeater,
     return nullptr;
 }
 
+// Debug-only census of the app strip. The repeater's realized-child count is
+// not a usable open/close signal: ItemsRepeater recycles containers, so a
+// window opening or closing leaves the count unchanged - a full trace of
+// spammed open/close produced zero count changes while the strip visibly grew
+// and shrank. What does move is the number of *placed, visible*
+// TaskListButtons, so that stands in for "a window opened/closed" here, with
+// the strip's own left/right extent alongside it so the re-centre that follows
+// is visible on the same line.
+int CensusAppStrip(FrameworkElement const& repeater, Grid const& rootGrid,
+                   double* stripLeft, double* stripRight,
+                   FrameworkElement const& exclude = nullptr) {
+    std::vector<FrameworkElement> children;
+    EnumRepeaterChildren(repeater, &children);
+    int count = 0;
+    double left = 0.0;
+    double right = 0.0;
+    for (const auto& child : children) {
+        try {
+            if (exclude && child == exclude) {
+                continue;
+            }
+            if (winrt::get_class_name(child) != L"Taskbar.TaskListButton" ||
+                child.Visibility() != Visibility::Visible ||
+                child.ActualWidth() <= 1.0) {
+                continue;
+            }
+            double x =
+                child.TransformToVisual(rootGrid).TransformPoint({0, 0}).X;
+            if (x <= 0.5) {
+                continue;
+            }
+            if (!count || x < left) {
+                left = x;
+            }
+            if (!count || x + child.ActualWidth() > right) {
+                right = x + child.ActualWidth();
+            }
+            count++;
+        } catch (...) {
+        }
+    }
+    *stripLeft = left;
+    *stripRight = right;
+    return count;
+}
+
 double DesiredHostWidth(TaskbarHost* host) {
     if (!host || host->buttonStates.empty()) {
         return 0.0;
@@ -5109,6 +5219,19 @@ constexpr float kSlideEaseCp2Y = 1.0f;
 // are tuned by eye against the real icons, so they are just knobs.
 constexpr int kSlideDelayOpenMs = 50;
 constexpr int kSlideDelayCloseMs = 350;
+
+// A retarget arriving within this long of the previous one means the strip is
+// churning rather than settling - windows opening and closing faster than the
+// slide itself. Comfortably longer than one slide, so a single open or close
+// still gets its full sync delay.
+constexpr ULONGLONG kChurnWindowMs = 400;
+
+// Smallest target change worth a slide. Anything under this is a sample of the
+// anchor taken part-way through Windows' own re-centre rather than a new
+// resting place, and re-aiming at it just restarts the storyboard. Well under
+// the half-button (~22px) that a real open or close moves the anchor by, so no
+// genuine move is swallowed.
+constexpr double kSlideNoiseFloor = 4.0;
 
 // Slides hostGrid to newLeft by animating its RenderTransform.
 //
@@ -5138,12 +5261,18 @@ constexpr int kSlideDelayCloseMs = 350;
 // XAML hands transform animations to the compositor, so they run off the UI
 // thread at the monitor's refresh tick and don't stutter when the taskbar
 // thread is busy.
-void AnimateHostGridLeftTo(TaskbarHost* host, double newLeft) {
+void AnimateHostGridLeftTo(TaskbarHost* host, double newLeft,
+                           double anchorX = -1.0) {
     if (!host || !host->hostGrid || !host->hostTranslate) {
         return;
     }
     double previousLeft = host->currentLeft;
-    if (std::abs(previousLeft - newLeft) < 1.0) {
+    // Noise floor, not a 1px epsilon. LayoutUpdated fires on every pass of
+    // Windows' own ~250ms re-centre, and the anchor is read mid-flight on each
+    // one, so consecutive targets land a few px apart with nothing having
+    // actually happened. At 1px each of those noise reads cleared the guard and
+    // restarted a full 250ms storyboard, which is most of what churn is.
+    if (std::abs(previousLeft - newLeft) < kSlideNoiseFloor) {
         return;
     }
 
@@ -5174,8 +5303,25 @@ void AnimateHostGridLeftTo(TaskbarHost* host, double newLeft) {
         return;
     }
 
+    // Windows only animates its icons for a settled open or close. Spamming
+    // produces a fresh layout every 100-200ms, so there is no icon slide left
+    // to fall in step with - and waiting out the close delay parks the folder
+    // block on top of icons that have already moved for the whole 350ms. If
+    // the last retarget was recent enough that we are still inside that
+    // window, chase immediately instead.
+    bool churning = host->lastRetargetTick &&
+                    now - host->lastRetargetTick < kChurnWindowMs;
+    // Only an actual retarget counts as churn. Stamping every call armed the
+    // window off a lone settled open too, and since kChurnWindowMs is longer
+    // than kSlideDelayCloseMs, the close that followed it always lost its whole
+    // sync delay - it chased early, landed on icons that hadn't moved yet, and
+    // retargeted again.
+    if (pending || animating) {
+        host->lastRetargetTick = now;
+    }
+
     int delayMs = 0;
-    if (!animating) {
+    if (!animating && !churning) {
         if (!pending) {
             host->slideCauseTick = now;
             host->slideCauseIsClose = isCloseMove;
@@ -5185,6 +5331,15 @@ void AnimateHostGridLeftTo(TaskbarHost* host, double newLeft) {
         long long remain =
             (long long)host->slideCauseTick + causeDelay - (long long)now;
         delayMs = remain > 0 ? (int)remain : 0;
+    }
+
+    bool wasAnchorSwap = host->anchorSwapped;
+    if (host->anchorSwapped) {
+        // The anchor teleported to a new button instead of sliding — chase
+        // it now instead of waiting out a sync delay for motion that isn't
+        // happening.
+        host->anchorSwapped = false;
+        delayMs = 0;
     }
 
     try {
@@ -5233,12 +5388,58 @@ void AnimateHostGridLeftTo(TaskbarHost* host, double newLeft) {
 
         host->slideStartTick = now + delayMs;
         host->slideEndTick = now + delayMs + kHostGridSlideMs;
+
+        // retarget=1 means this replaced a slide that was already moving or
+        // still waiting - a burst of those between two WINDOW lines is the
+        // signature of the target thrashing rather than settling.
+        double delta = newLeft - previousLeft;
+        ANIM_TRACE(L"SLIDE t=%llu host=%p %.2f->%.2f (%+.2f) anchorX=%.2f "
+                   L"delay=%d close=%d retarget=%d swapped=%d churn=%d",
+                   now, host->hwnd, previousLeft, newLeft, delta, anchorX,
+                   delayMs, (int)isCloseMove, (int)(pending || animating),
+                   (int)wasAnchorSwap, (int)churning);
+
+        // The reserve is a Margin on the anchor button, so in the repeater's
+        // horizontal layout the anchor occupies its own width *plus* the
+        // reserve - and any button inserted to its outer side is laid out on
+        // the far side of our gap, at anchorX + anchorWidth + reserve. That
+        // button is visible and placed, so ResolveAnchor adopts it, the
+        // reserve moves onto it, and the whole thing walks another reserve
+        // further out. A retarget of exactly one reserve width is that loop,
+        // and it is the visible large gap. Distinct from the ordinary
+        // half-a-button re-centre a real open/close produces.
+        double reserve =
+            DesiredHostWidth(host) + g_settings.gapBefore + g_settings.gapAfter;
+        if (reserve > 1.0 && std::abs(std::abs(delta) - reserve) < 4.0) {
+            ANIM_TRACE(L"RESERVE-JUMP t=%llu host=%p retarget %+.2f == the "
+                       L"reserved width (%.2f) — a new app button was laid "
+                       L"out past our own reserve and adopted as the anchor; "
+                       L"self-inflicted, anchorX=%.2f swapped=%d",
+                       now, host->hwnd, delta, reserve, anchorX,
+                       (int)wasAnchorSwap);
+        } else if (std::abs(delta) > host->buttonWidth &&
+                   now - host->dbgLastWindowTick > 500) {
+            // Bigger than one button, no window change behind it: the target
+            // is wrong for some other reason (anchor measured mid-recycle).
+            ANIM_TRACE(L"SUSPECT t=%llu host=%p retarget %+.2f (>1 button) "
+                       L"with no window change for %llums — anchorX=%.2f "
+                       L"anchorSwapped=%d",
+                       now, host->hwnd, delta, now - host->dbgLastWindowTick,
+                       anchorX, (int)wasAnchorSwap);
+        }
     } catch (...) {
         // Animation unavailable for whatever reason — still get the element
-        // to the right place, just without the slide.
+        // to the right place, just without the slide. This is exactly the
+        // kind of thing that produces a one-frame jump/overlap, so it's
+        // worth an error even though the element ends up in the right spot.
         try {
             host->slideStoryboard = nullptr;
             host->hostTranslate.X(newLeft);
+            ANIM_TRACE(L"SNAP t=%llu host=%p %.2f->%.2f close=%d delay=%d — "
+                       L"storyboard threw, snapped instead (reads as a "
+                       L"stutter)",
+                       now, host->hwnd, previousLeft, newLeft,
+                       (int)isCloseMove, delayMs);
         } catch (...) {
         }
     }
@@ -5250,6 +5451,14 @@ void RestoreAnchorMargin(TaskbarHost* host) {
     }
     if (host->anchor && host->hasAnchorOriginalMargin) {
         try {
+            // Paired with the MARGIN write on the incoming anchor. The two
+            // land in the same layout pass, so seeing only one of them in the
+            // log means the strip spent a pass either double-reserved or
+            // un-reserved - a full 264px of width appearing or vanishing.
+            ANIM_TRACE(L"RESTORE t=%llu host=%p anchor=%p margin -> %.2f/%.2f",
+                       GetTickCount64(), host->hwnd, winrt::get_abi(host->anchor),
+                       host->anchorOriginalMargin.Left,
+                       host->anchorOriginalMargin.Right);
             host->anchor.Margin(host->anchorOriginalMargin);
         } catch (...) {
         }
@@ -6980,6 +7189,14 @@ Grid BuildHostGrid(TaskbarHost* host) {
     host->hasPlaced = false;
     host->slideCauseTick = 0;
     host->slideCauseIsClose = false;
+    host->lastRetargetTick = 0;
+    host->dbgBadSince = 0;
+    host->dbgBadLogged = false;
+    host->parkedAnchorX = -1.0;
+    host->reserveHolds = 0;
+    host->lastAnchorX = -1.0;
+    host->anchorMovingSince = 0;
+    host->dragFrozen = false;
 
     host->buttonStates.clear();
 
@@ -7184,13 +7401,22 @@ void RemoveHostGrid(TaskbarHost* host) {
     RestoreAnchorMargin(host);
     ClearButtonState(host);
 
-    if (host->trackedRootGrid) {
+    // Detach hostGrid from wherever it's actually parented right now, not
+    // from host->trackedRootGrid's children. If FindTaskbarRootGrid ever
+    // resolves a different (but still live) RootGrid object on a later pass
+    // than the one hostGrid was originally appended under, searching that
+    // mismatched trackedRootGrid finds nothing to remove and leaves the old
+    // hostGrid orphaned but still attached and rendering - a second, stuck
+    // copy of the folder buttons that nothing else catches, since it isn't
+    // moving or overlapping its own (correct) anchor.
+    if (host->hostGrid) {
         try {
-            auto children = host->trackedRootGrid.Children();
-            for (int i = (int)children.Size() - 1; i >= 0; i--) {
-                auto child = children.GetAt(i).try_as<FrameworkElement>();
-                if (child && child.Name() == kHostGridName) {
-                    children.RemoveAt(i);
+            if (auto panel =
+                    VisualTreeHelper::GetParent(host->hostGrid).try_as<Panel>()) {
+                auto children = panel.Children();
+                uint32_t index;
+                if (children.IndexOf(host->hostGrid, index)) {
+                    children.RemoveAt(index);
                 }
             }
         } catch (...) {
@@ -7214,8 +7440,179 @@ void RemoveAllHostGrids() {
     g_injectionLive = false;
 }
 
-// Runs on every layout pass, so every branch is guarded by a tolerance check to
-// avoid feeding layout back into itself.
+// Only called once a health check below has already decided something is
+// wrong. Dumps every realized child of the app-icon repeater - taskbar
+// buttons, the widgets/task-view/start toggles, everything - with its class,
+// X position (relative to rootGrid, same space AnchorX/hostGrid use), width,
+// and visibility, so the error line above it is followed by the full picture
+// of where every icon actually was that frame. Apps move between the start
+// button, task view, the widgets button, and either side of the app strip
+// depending on pin state and window count, so this is unfiltered: every
+// child, no assumptions about which slot anything is in.
+void LogRepeaterPositions(TaskbarHost* host, FrameworkElement const& repeater,
+                           PCWSTR tag) {
+    if (!repeater || !host || !host->trackedRootGrid) {
+        return;
+    }
+    std::vector<FrameworkElement> children;
+    EnumRepeaterChildren(repeater, &children);
+    ANIM_TRACE(L"%s   repeater children=%zu (host=%p)", tag, children.size(),
+               host->hwnd);
+    for (size_t i = 0; i < children.size(); i++) {
+        auto const& child = children[i];
+        try {
+            auto className = winrt::get_class_name(child);
+            double x = -99999.0;
+            try {
+                auto point = child.TransformToVisual(host->trackedRootGrid)
+                                 .TransformPoint({0, 0});
+                x = point.X;
+            } catch (...) {
+            }
+            ANIM_TRACE(L"%s     [%zu] class=%s x=%.2f w=%.2f h=%.2f vis=%d "
+                       L"opacity=%.2f",
+                       tag, i, className.c_str(), x, child.ActualWidth(),
+                       child.ActualHeight(), (int)child.Visibility(),
+                       child.Opacity());
+        } catch (...) {
+            ANIM_TRACE(L"%s     [%zu] <threw reading child>", tag, i);
+        }
+    }
+}
+
+// How far the settled gap may differ from the configured padding before it
+// counts as wrong, and how long it has to stay wrong before it's logged. The
+// second number matters: a single layout pass routinely lands in the window
+// between the anchor moving and our retarget being handed to the compositor,
+// and that transient is normal. A gap that's still wrong a few hundred ms
+// after the last slide finished is the actual bug being hunted.
+// Layout passes during an icon slide come every ~15ms, so this covers the
+// taskbar's own 250ms slide with room to spare while still guaranteeing the
+// overlay gives in and moves if a reserve-sized target is genuinely correct.
+constexpr int kMaxReserveHolds = 24;
+
+// How far the anchor has to move between two layout passes to count as still
+// in flight. Below this it is measurement jitter on a button that has stopped.
+constexpr double kAnchorSettleEpsilon = 0.5;
+// Ceiling on how long positioning will wait for the anchor to stop moving.
+// Comfortably past Windows' own ~250ms icon slide, so a real settle always
+// wins the race; it exists only so an anchor that somehow never stops (a
+// perpetual animation, a stuck arrange) cannot wedge the overlay in place.
+constexpr ULONGLONG kMaxAnchorSettleMs = 600;
+
+constexpr double kGapTolerancePx = 2.0;
+constexpr ULONGLONG kBadGapSettleMs = 400;
+
+// Checked once per layout pass against the anchor position just measured by
+// OnRootGridLayoutUpdated, using hostGrid's live RenderTransform X (where it
+// visibly is right now, not the animation's target). One failure mode: the
+// space between the folder block and the app strip is not the configured
+// padding once everything has stopped moving — negative means they overlap,
+// too large means a leftover gap.
+// Silent while a slide is pending or running (the gap is supposed to be wrong
+// then), and silent until a wrong gap has persisted past kBadGapSettleMs. One
+// bad stretch logs exactly one error line (plus the full repeater dump) and
+// one recovery line carrying how long it lasted.
+void CheckHostGridHealth(TaskbarHost* host, FrameworkElement const& repeater,
+                          bool before, double anchorX, double anchorWidth) {
+    if (!g_settings.debugAnimLog || !host || !host->hostGrid ||
+        !host->trackedRootGrid || !host->hasPlaced) {
+        return;
+    }
+
+    double hostWidth = DesiredHostWidth(host);
+    if (hostWidth <= 1.0) {
+        return;
+    }
+
+    ULONGLONG now = GetTickCount64();
+    double liveLeft = host->hostTranslate ? host->hostTranslate.X() : host->currentLeft;
+    double rootWidth = 0.0;
+    try {
+        rootWidth = host->trackedRootGrid.ActualWidth();
+    } catch (...) {
+    }
+
+    double gap;
+    double expectedGap;
+    if (before) {
+        // hostGrid sits left of the anchor: gap is the space between its
+        // right edge and the anchor's left edge.
+        gap = anchorX - (liveLeft + hostWidth);
+        expectedGap = g_settings.gapAfter;
+    } else {
+        // hostGrid sits right of the anchor: gap is the space between the
+        // anchor's right edge and hostGrid's left edge.
+        gap = liveLeft - (anchorX + anchorWidth);
+        expectedGap = g_settings.gapBefore;
+    }
+
+    // Mid-slide, or still waiting on the slide's start delay: hostGrid is on
+    // its way somewhere, so its distance from the anchor means nothing yet.
+    if (host->slideStoryboard && now < host->slideEndTick) {
+        host->dbgBadSince = 0;
+        host->dbgBadLogged = false;
+        return;
+    }
+
+    if (std::abs(gap - expectedGap) <= kGapTolerancePx) {
+        if (host->dbgBadLogged) {
+            ANIM_TRACE(L"GAP-OK t=%llu host=%p gap=%.2f liveLeft=%.2f "
+                       L"(was wrong for %llums)",
+                       now, host->hwnd, gap, liveLeft,
+                       now - host->dbgBadSince);
+        }
+        host->dbgBadSince = 0;
+        host->dbgBadLogged = false;
+        return;
+    }
+
+    if (!host->dbgBadSince) {
+        host->dbgBadSince = now;
+        return;
+    }
+    if (host->dbgBadLogged || now - host->dbgBadSince < kBadGapSettleMs) {
+        return;
+    }
+    host->dbgBadLogged = true;
+
+    bool visible = true;
+    double opacity = 1.0;
+    try {
+        visible = host->hostGrid.Visibility() == Visibility::Visible;
+        opacity = host->hostGrid.Opacity();
+    } catch (...) {
+    }
+
+    PCWSTR kind = gap < 0 ? L"OVERLAP" : L"GAP";
+    ANIM_TRACE(L"%s t=%llu host=%p before=%d gap=%.2f expected=%.2f "
+               L"off-by=%.2f stuck=%llums",
+               kind, now, host->hwnd, (int)before, gap, expectedGap,
+               gap - expectedGap, now - host->dbgBadSince);
+    ANIM_TRACE(L"%s   hostGrid: liveLeft=%.2f target=%.2f width=%.2f "
+               L"rightEdge=%.2f visible=%d opacity=%.2f rootWidth=%.2f",
+               kind, liveLeft, host->currentLeft, hostWidth,
+               liveLeft + hostWidth, (int)visible, opacity, rootWidth);
+    double marginSide = -1.0;
+    try {
+        auto margin = host->anchor.Margin();
+        marginSide = before ? margin.Left : margin.Right;
+    } catch (...) {
+    }
+    double originalSide = before ? host->anchorOriginalMargin.Left
+                                 : host->anchorOriginalMargin.Right;
+    ANIM_TRACE(L"%s   anchor: x=%.2f width=%.2f margin=%.2f original=%.2f "
+               L"reserved=%.2f children=%d",
+               kind, anchorX, anchorWidth, marginSide, originalSide,
+               marginSide - originalSide, host->lastRepeaterChildCount);
+    ANIM_TRACE(L"%s   slide: lastEnd=%lld ms ago storyboard=%d close=%d "
+               L"anchorSwapped=%d",
+               kind, (long long)now - (long long)host->slideEndTick,
+               (int)(bool)host->slideStoryboard, (int)host->slideCauseIsClose,
+               (int)host->anchorSwapped);
+    LogRepeaterPositions(host, repeater, kind);
+}
+
 void OnRootGridLayoutUpdated(TaskbarHost* host) {
     if (g_unloading || !host || !host->hostGrid || !host->trackedRootGrid) {
         return;
@@ -7273,11 +7670,131 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
         // from the tree instead so a closing-but-still-present button
         // doesn't trigger a needless re-resolve (and the churn/flicker
         // that comes with it) on every window close.
+        // A new app button lands and settles at its final position within a
+        // tick or two — well inside the 250ms re-resolve throttle below.
+        // Left on the throttle alone, a newly-opened window can render past
+        // our still-stale reserved gap for up to 250ms, appearing to the
+        // right of hostGrid before the next re-resolve catches it and pulls
+        // hostGrid past it. React the moment the child count itself moves
+        // instead of waiting out the throttle.
+        int childCount = VisualTreeHelper::GetChildrenCount(repeater);
+        bool childCountChanged = childCount != host->lastRepeaterChildCount;
+        host->lastRepeaterChildCount = childCount;
+
+        // Every WINDOW line is one window opening or closing. Counted from the
+        // placed/visible buttons rather than childCountChanged above, which
+        // never moves at all (recycling) - see CensusAppStrip. Head of the
+        // causal chain for everything logged below.
+        if (g_settings.debugAnimLog) {
+            double stripLeft = 0.0;
+            double stripRight = 0.0;
+            int visible = CensusAppStrip(repeater, host->trackedRootGrid,
+                                         &stripLeft, &stripRight);
+            if (visible != host->dbgVisibleButtons) {
+                ANIM_TRACE(L"WINDOW t=%llu host=%p buttons %d->%d (%+d) "
+                           L"strip=[%.2f..%.2f] w=%.2f realized=%d",
+                           now, host->hwnd, host->dbgVisibleButtons, visible,
+                           visible - host->dbgVisibleButtons, stripLeft,
+                           stripRight, stripRight - stripLeft, childCount);
+                host->dbgVisibleButtons = visible;
+                host->dbgLastWindowTick = now;
+            }
+        }
+
         bool anchorLooksDead = !host->anchor || !host->anchor.Parent();
-        if (anchorLooksDead || now - host->lastAnchorResolveTick > 250) {
+        if (anchorLooksDead || childCountChanged ||
+            now - host->lastAnchorResolveTick > 250) {
             host->lastAnchorResolveTick = now;
             if (auto resolved =
                     ResolveAnchor(repeater, host->trackedRootGrid)) {
+                if (resolved != host->anchor) {
+                    // The anchor itself just closed and a different button
+                    // was promoted in its place — a discontinuous swap, not
+                    // a smooth shrink/slide. There's no icon animation left
+                    // to stay in sync with, so the open/close delay in
+                    // AnimateHostGridLeftTo (there to match Windows' own
+                    // icon-slide timing) would just leave hostGrid parked
+                    // over the new anchor's slot for a few hundred ms.
+                    host->anchorSwapped = true;
+                    // The margin the new anchor is adopted with is snapshotted
+                    // as its "original", so it is worth seeing: if it were
+                    // already carrying a reserved gap from a previous
+                    // adoption, that gap would be baked in and doubled.
+                    double m = -1.0;
+                    double rx = -1.0;
+                    double rw = -1.0;
+                    winrt::hstring cls;
+                    try {
+                        auto margin = resolved.Margin();
+                        m = (g_settings.position != L"afterApps")
+                                ? margin.Left
+                                : margin.Right;
+                        cls = winrt::get_class_name(resolved);
+                        rw = resolved.ActualWidth();
+                        rx = resolved.TransformToVisual(host->trackedRootGrid)
+                                 .TransformPoint({0, 0})
+                                 .X;
+                    } catch (...) {
+                    }
+                    double oldX = -1.0;
+                    try {
+                        if (host->anchor) {
+                            oldX = host->anchor
+                                       .TransformToVisual(host->trackedRootGrid)
+                                       .TransformPoint({0, 0})
+                                       .X;
+                        }
+                    } catch (...) {
+                    }
+
+                    // Our reserve is a Margin on the outgoing anchor, so a
+                    // button realized on its outer side is laid out exactly
+                    // one reserve-width clear of it - parked on the far side
+                    // of our own gap - and only closes up once the reserve has
+                    // migrated across and the taskbar has slid it home. That
+                    // separation is the reliable signal, measured directly
+                    // here. (Watching the retarget distance instead cannot
+                    // work: the target is anchorX + buttonWidth, so the move
+                    // is reserve + a button on the way out and reserve + the
+                    // re-centre on the way back - never the reserve itself.)
+                    // Clearance is measured against the rest of the strip, not
+                    // against the outgoing anchor: that anchor is frequently
+                    // still sliding home from the previous cycle, so the
+                    // distance to it reads anything (127 in one trace where
+                    // the real clearance was a full reserve). Everything
+                    // except the incoming button is settled, so its outer edge
+                    // is a stable reference. Tolerance stays a whole button -
+                    // the two cases are far apart anyway (a parked button sits
+                    // a reserve out, a normal adoption lands touching).
+                    double reserve = DesiredHostWidth(host) +
+                                     g_settings.gapBefore + g_settings.gapAfter;
+                    double slack = host->buttonWidth > 1.0 ? host->buttonWidth
+                                                           : kFallbackButtonSize;
+                    double stripLeft = 0.0;
+                    double stripRight = 0.0;
+                    int others = CensusAppStrip(repeater, host->trackedRootGrid,
+                                                &stripLeft, &stripRight,
+                                                resolved);
+                    host->parkedAnchorX = -1.0;
+                    double clearance = 0.0;
+                    if (others > 0 && rx > 0.5 && reserve > slack) {
+                        clearance = (g_settings.position != L"afterApps")
+                                        ? stripLeft - (rx + rw)
+                                        : rx - stripRight;
+                        if (std::abs(clearance - reserve) <= slack) {
+                            host->parkedAnchorX = rx;
+                        }
+                    }
+
+                    ANIM_TRACE(L"ANCHOR t=%llu host=%p swap %p(x=%.2f)->%p "
+                               L"class=%s x=%.2f w=%.2f margin=%.2f "
+                               L"(adopted as original) oldDead=%d "
+                               L"clearance=%.2f/%.2f parked=%d",
+                               now, host->hwnd, winrt::get_abi(host->anchor),
+                               oldX, winrt::get_abi(resolved), cls.c_str(), rx,
+                               rw, m, (int)anchorLooksDead, clearance, reserve,
+                               (int)(host->parkedAnchorX >= 0.0));
+                }
                 AdoptAnchor(host, resolved);
             }
         }
@@ -7314,11 +7831,88 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
         // queues another LayoutUpdated; let that pass place hostGrid once
         // the anchor has actually moved.
         if (marginChanged) {
+            ANIM_TRACE(L"MARGIN t=%llu host=%p %s %.2f->%.2f (original=%.2f "
+                       L"reserve=%.2f)",
+                       now, host->hwnd, before ? L"left" : L"right",
+                       before ? currentMargin.Left : currentMargin.Right,
+                       before ? target.Left : target.Right,
+                       before ? host->anchorOriginalMargin.Left
+                              : host->anchorOriginalMargin.Right,
+                       desiredGap);
+            return;
+        }
+
+        // Dragging a taskbar button moves that button under the cursor - the
+        // element itself, no swap, no window opening or closing - so it can
+        // wander to the outer end of the strip and drag the folder block along
+        // with it (anchorX walking 1098 -> 1291 -> 1334 in a trace, with the
+        // block chasing). Rearranging apps should not move the overlay at all,
+        // so freeze positioning while the primary button is held and settle
+        // once on release. The margin above is still maintained, so the
+        // reserved gap does not collapse mid-drag.
+        bool dragging = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0;
+        if (dragging != host->dragFrozen) {
+            host->dragFrozen = dragging;
+            ANIM_TRACE(L"DRAG t=%llu host=%p primary button %s — positioning %s",
+                       now, host->hwnd, dragging ? L"down" : L"up",
+                       dragging ? L"frozen" : L"resumed");
+        }
+        if (dragging) {
             return;
         }
 
         auto point = host->anchor.TransformToVisual(host->trackedRootGrid)
                          .TransformPoint({0, 0});
+
+        // ItemsRepeater can recycle the container backing our anchor to
+        // represent a different, off-screen item (e.g. the closing-window
+        // placeholder parked at a large negative X) while it's still
+        // attached to the tree, so Parent() alone doesn't catch it. Same
+        // sentinel check ResolveAnchor uses when picking an anchor: bail
+        // and force an immediate re-resolve instead of animating to the
+        // bogus coordinate.
+        if (point.X <= 0.5) {
+            // Anchor container got recycled to an off-screen item. hostGrid
+            // stays wherever it was while this repeats, so a run of these
+            // lines explains a gap that just sits there.
+            ANIM_TRACE(L"RECYCLED t=%llu host=%p anchor=%p x=%.2f — forcing "
+                       L"re-resolve (this container was adopted %llums ago)",
+                       now, host->hwnd, winrt::get_abi(host->anchor), point.X,
+                       now - host->lastAnchorResolveTick);
+            host->lastAnchorResolveTick = 0;
+            return;
+        }
+
+        // Windows slides its own icons over ~250ms and layout reports the
+        // anchor part-way through that slide, so a reading that differs from
+        // the previous pass is a frame of a move in flight, not a resting
+        // place. Committing to one parks the folder block at a coordinate the
+        // taskbar was only passing through - and if no further layout pass
+        // happens to land after the icons settle, it stays parked there for as
+        // long as it takes something else to disturb the tree (a full second
+        // in the traces, ending in a visible pop). Waiting for two consecutive
+        // passes to agree costs one pass (~15ms) on a genuine open or close and
+        // makes every intermediate frame a no-op, so the block simply stays put
+        // through the taskbar's animation and moves once, to the right place.
+        bool anchorSettled =
+            host->lastAnchorX >= 0.0 &&
+            std::abs(point.X - host->lastAnchorX) <= kAnchorSettleEpsilon;
+        if (!anchorSettled && host->anchorMovingSince == 0) {
+            host->anchorMovingSince = now;
+        }
+        bool settleTimedOut =
+            host->anchorMovingSince &&
+            now - host->anchorMovingSince > kMaxAnchorSettleMs;
+        host->lastAnchorX = point.X;
+        if (host->hasPlaced && !anchorSettled && !settleTimedOut) {
+            return;
+        }
+        if (settleTimedOut && !anchorSettled) {
+            ANIM_TRACE(L"SETTLE t=%llu host=%p anchor still moving after %llums "
+                       L"(x=%.2f) — giving in and positioning off it anyway",
+                       now, host->hwnd, now - host->anchorMovingSince, point.X);
+        }
+        host->anchorMovingSince = 0;
 
         double left;
         if (before) {
@@ -7327,7 +7921,31 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
             left = point.X + host->anchor.ActualWidth() + g_settings.gapBefore;
         }
 
-        AnimateHostGridLeftTo(host, left);
+        // Adopting a button parked past our own reserve is correct - it really
+        // is the new outermost one - but positioning off it while it is still
+        // out there throws the folder block a reserve-width sideways and back.
+        // Hold until the taskbar has started sliding it home, then track it
+        // in normally. Capped so a button that never moves cannot wedge us.
+        if (host->hasPlaced && host->parkedAnchorX >= 0.0 &&
+            host->reserveHolds < kMaxReserveHolds &&
+            std::abs(point.X - host->parkedAnchorX) < 4.0) {
+            host->reserveHolds++;
+            ANIM_TRACE(L"HOLD t=%llu host=%p anchor still parked at %.2f, one "
+                       L"reserve (%.2f) clear of the strip — holding (%d/%d)",
+                       now, host->hwnd, point.X, desiredGap,
+                       host->reserveHolds, kMaxReserveHolds);
+            return;
+        }
+        host->parkedAnchorX = -1.0;
+        host->reserveHolds = 0;
+
+        // Checked against the anchor position just measured above, before
+        // handing the new target to the animation - this is what's actually
+        // on screen right now, this frame.
+        CheckHostGridHealth(host, repeater, before, point.X,
+                             host->anchor.ActualWidth());
+
+        AnimateHostGridLeftTo(host, left, point.X);
     } catch (...) {
         // A XAML call threw, most likely the anchor was recycled out from
         // under us mid-access. cachedRepeater is the only thing actually
@@ -7338,6 +7956,14 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
         // alive, and if that restore itself no-ops or throws, the next
         // AdoptAnchor snapshots the still-widened margin as "original",
         // doubling the gap permanently.
+        ANIM_TRACE(L"EXCEPTION host=%p; a XAML call threw while "
+                   L"reading/positioning the anchor or hostGrid (anchor "
+                   L"likely recycled mid-access) — dropping cachedRepeater "
+                   L"and re-resolving next tick. currentLeft(target)=%.2f "
+                   L"liveX=%.2f anchorPresent=%d",
+                   host->hwnd, host->currentLeft,
+                   host->hostTranslate ? host->hostTranslate.X() : -1.0,
+                   (int)(bool)host->anchor);
         host->cachedRepeater = nullptr;
     }
 }

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -27,8 +27,8 @@ Windows 11 only.
 
 ## Features
 
-- Buttons are sized from a live taskbar button, so they match your app icons
-  exactly at any taskbar size and DPI.
+- Buttons are real taskbar items - pin, unpin, drag to reorder, and they collapse
+  into overflow like any other taskbar icon.
 - The hover grid opens with **zero delay** - folder contents and icons are scanned
   and cached on a background thread.
 - A "corridor" between the button and the grid keeps the grid open while you move
@@ -39,8 +39,10 @@ Windows 11 only.
 - Subfolders are listed first in every grid and carry a folder badge in the
   accent colour on the corner of their icon, so what cascades is obvious at a
   glance. Folder shortcuts (`.lnk` pointing at a folder) cascade the same way.
-- Set each button's icon to an **emoji**, an **`.ico` / `.png` file**, or an
-  **`app.exe,0`** icon resource. Leave it empty to use the folder's own icon.
+- Set each button's icon to an **`.ico` file** or an **`app.exe,0`** / `.dll,N`
+  icon resource - those are the specs Windows can turn into a real shortcut icon.
+  An emoji or a `.png` is accepted in the field but falls back to the standard
+  folder glyph on the button, same as leaving it empty.
 - Left click an item to open it, right click for the full Windows shell context menu.
 - Folder buttons are injected on the primary taskbar and every secondary-monitor taskbar.
 
@@ -90,15 +92,17 @@ is dark when the rest of Windows is. From there you can:
 | **Pin** / **Unpin** | Moves the selected folder between the two sections. Unpinning takes the button off the taskbar **without deleting anything** — the entry keeps its name and icon and can be pinned again any time |
 
 The list is not reorderable, and does not need to be: **button order is set by
-dragging the buttons on the taskbar**, like any other pinned app.
+dragging the buttons on the taskbar**, like any other pinned app. Renaming a
+pinned folder unpins and re-pins its button under the new name, so it jumps to
+the end of the taskbar and has to be dragged back into place.
 
 Each entry has three fields:
 
 | Field | Example | Notes |
 |-------|---------|-------|
-| Name  | `Apps` | Shown as the title at the top of the hover grid |
+| Name  | `Apps` | Shown as the title at the top of the hover grid. Avoid naming a folder the same as (or a prefix of) a pinned app's name — the mod matches taskbar buttons to folders by their visible label, and a same-named app button can be mistaken for the folder's, suppressing its tooltip and opening the folder grid on hover instead |
 | Folder | `%USERPROFILE%\Desktop` | Environment variables are expanded. `shell:` targets that map to a **filesystem folder** also work (e.g. `shell:Desktop`, `shell:Downloads`). Virtual namespaces such as Control Panel, Recycle Bin, or This PC are not supported — use [Taskbar Folder Menus](https://github.com/ramensoftware/windhawk-mods/blob/main/mods/taskbar-folder-menus.wh.cpp) for those. |
-| Icon | an emoji, `C:\icons\apps.ico`, or `C:\Windows\explorer.exe,0` | Leave empty to use the folder's own icon |
+| Icon | `C:\icons\apps.ico` or `C:\Windows\explorer.exe,0` | Leave empty to use the folder's own icon. An emoji or `.png` is accepted here but shows as the standard folder glyph on the button |
 
 **Open** next to the folder box opens whatever path is currently typed, so a
 path can be checked before it is saved.
@@ -174,8 +178,9 @@ so an overlay is always at least a frame behind. That whole approach, and the
 ~2,000 lines that chased it, is gone.
 
 One thing to know: a button's **icon comes from the shortcut**, which means it has
-to be a real icon file. `.ico` files, `app.exe,0` resource specs and a folder's own
-custom icon all work. An **emoji icon falls back** to the standard folder glyph.
+to be a real icon resource. `.ico` files, `app.exe,0` / `.dll,N` resource specs and
+a folder's own custom icon all work. An **emoji or `.png` icon falls back** to the
+standard folder glyph - Windows shortcuts can't point their icon at either.
 
 ## If you already use Taskbar Folder Menus
 
@@ -189,10 +194,10 @@ not both.
 
 | | Taskbar Folder Hover Tray (this) | Taskbar Folder Menus |
 |---|---|---|
-| Placement | Carved gap inside the **app icon strip** (flush with pinned/running apps) | Next to the **system tray** / notification area |
+| Placement | Real taskbar buttons in the **app icon strip** (flush with pinned/running apps) | Next to the **system tray** / notification area |
 | Open | **Hover** opens immediately | **Click** opens |
 | UI | Custom-drawn **icon grid** popup | **Native Shell** cascading menus |
-| Buttons | Sized from live taskbar app buttons; emoji/custom icons optional | Compact tray buttons with emoji labels and extensive tray grid layout options |
+| Buttons | Native taskbar buttons; `.ico`/resource icons optional | Compact tray buttons with emoji labels and extensive tray grid layout options |
 
 Choose **Taskbar Folder Menus** for tray-side buttons and native Shell menus.
 Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
@@ -421,16 +426,12 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.UI.ViewManagement.h>
 #include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
-#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.UI.Xaml.Input.h>
-#include <winrt/Windows.UI.Xaml.Media.Animation.h>
-#include <winrt/Windows.UI.Xaml.Media.Imaging.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.h>
 #include <winrt/Windows.UI.h>
@@ -446,6 +447,7 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 #include <string_view>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #ifndef SEE_MASK_ASYNCOK
@@ -461,7 +463,6 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 using namespace winrt::Windows::UI::Xaml;
 using namespace winrt::Windows::UI::Xaml::Controls;
 using namespace winrt::Windows::UI::Xaml::Media;
-using namespace winrt::Windows::UI::Xaml::Media::Animation;
 using namespace winrt::Windows::UI::Xaml::Hosting;
 
 #ifndef DWMWA_WINDOW_CORNER_PREFERENCE
@@ -806,7 +807,7 @@ std::wstring FindRenamedSibling(const std::wstring& oldPath, uint64_t fileId) {
 std::wstring ReadFolderCustomIcon(const std::wstring& folderPath) {
     // GetPrivateProfileStringW opens the file, so an offline share blocks for
     // the network timeout — on the Explorer UI thread in the pin flow. An empty
-    // spec is a valid entry: MakeButtonContent falls back to the folder's own
+    // spec is a valid entry: ResolveIcon falls back to the folder's own
     // shell icon.
     if (IsLikelyRemotePath(folderPath)) {
         return L"";
@@ -855,10 +856,7 @@ constexpr int kMaxEntries = 200;
 // what LoadFolders takes; nothing may hold this one across ReloadAndRefreshUI,
 // since that reaches LoadFolders and would invert the order.
 //
-// no_destroy: Wh_ModUninit does not run when Explorer terminates, but CRT
-// destructors of globals do, on a shutdown thread — a mutex must not be
-// destroyed out from under a thread that could still be holding it.
-[[clang::no_destroy]] std::recursive_mutex g_mutex;
+std::recursive_mutex g_mutex;
 
 struct Entry {
     std::wstring path;
@@ -1166,7 +1164,7 @@ bool ParseIconSpec(const std::wstring& spec, std::wstring* file, int* index) {
 //
 // ponytail: emoji and .png icons fall back to the default folder glyph. Giving
 // them real buttons means rendering to an .ico next to the shortcut - the mod
-// already builds these images for the hover grid (MakeButtonContent), so the
+// already builds these images for the hover grid (HIconToBitmap), so the
 // missing piece is only an HICON -> .ico writer.
 void ResolveIcon(const FolderStore::Entry& entry,
                  const std::wstring& folderPath,
@@ -1217,9 +1215,24 @@ std::wstring ReadShortcutAppId(const std::wstring& lnkPath) {
     return appId;
 }
 
-// Writes (or rewrites) the shortcut behind one entry. Rewriting on every
-// reconcile is deliberate: it is how a renamed folder, a changed icon, or a
-// moved target reach an already-pinned button.
+// pinId -> signature of what was last written for it. Reconcile runs on a
+// single dedicated worker thread (see ThreadProc below), so this needs no
+// lock. Lets a reorder-drag reconcile (which touches every pinned entry, not
+// just the moved one) skip the .lnk rewrite and jump list COM round-trip for
+// every entry whose content did not actually change.
+std::unordered_map<std::wstring, std::wstring> g_shortcutSignatures;
+
+std::wstring ShortcutSignature(const FolderStore::Entry& entry,
+                               const std::wstring& folderPath,
+                               const std::wstring& lnkPath) {
+    return entry.name + L"\x1f" + folderPath + L"\x1f" + entry.icon + L"\x1f" +
+           lnkPath;
+}
+
+// Writes (or rewrites) the shortcut behind one entry. Callers gate this on
+// g_shortcutSignatures so it only actually runs when something changed, but
+// this function itself always writes - it is how a renamed folder, a changed
+// icon, or a moved target reach an already-pinned button.
 bool WriteShortcut(const FolderStore::Entry& entry,
                    const std::wstring& folderPath,
                    const std::wstring& lnkPath) {
@@ -1362,6 +1375,11 @@ IShellLinkW* MakeManageTask() {
 }
 
 // Publishes the jump list for one of our pinned items.
+// AppIDs whose jump list is already known to be on the shell's copy, so
+// Reconcile (see below) does not redo the ICustomDestinationList round-trip
+// for every pinned item on every pass.
+std::unordered_set<std::wstring> g_jumpListWritten;
+
 void WriteJumpList(const std::wstring& appId) {
     ICustomDestinationList* list = nullptr;
     if (FAILED(CoCreateInstance(CLSID_DestinationList, nullptr,
@@ -1524,9 +1542,8 @@ std::vector<std::wstring> ReadPinnedAppIds() {
 // during layout, and rebuilding it means opening every pinned shortcut through
 // COM — far too expensive to do on a layout pass. The generation counter lets
 // that thread notice a change without holding the lock to compare.
-[[clang::no_destroy]] std::mutex g_labelMutex;
-[[clang::no_destroy]] std::vector<std::pair<std::wstring, std::wstring>>
-    g_labelToPinId;
+std::mutex g_labelMutex;
+std::vector<std::pair<std::wstring, std::wstring>> g_labelToPinId;
 std::atomic<uint32_t> g_labelGeneration{0};
 
 void PublishLabels(const std::vector<PinnedItem>& items) {
@@ -1547,44 +1564,53 @@ void PublishLabels(const std::vector<PinnedItem>& items) {
 
 // A taskbar button's accessible name is the item's label plus whatever state
 // the shell wants to announce — "Games pinned", "Brave - 1 running window
-// pinned", "Cursor - 1 running window". So the label is a prefix, not the whole
-// string, and the remainder has to be one of those recognised annotations.
-//
-// Checking the remainder rather than just taking a prefix match matters: a
-// folder called "Games" must not claim a button for an app called
-// "Games Launcher".
+// pinned", "Cursor - 1 running window" in English, but the annotation itself
+// is locale text ("Games angeheftet" in German, etc). So rather than
+// whitelist annotation strings, the label is treated as a prefix full stop,
+// and PinIdForLabel below picks the exact/longest match among our own labels
+// to keep "Games" from claiming a button actually named "Games Launcher".
 bool LabelMatchesAccessibleName(const std::wstring& leaf,
                                 const std::wstring& name) {
     if (leaf.empty() || name.size() < leaf.size()) {
         return false;
     }
-    if (_wcsnicmp(name.c_str(), leaf.c_str(), leaf.size()) != 0) {
-        return false;
-    }
-    std::wstring rest = name.substr(leaf.size());
-    if (rest.empty()) {
-        return true;
-    }
-    // "<label> pinned"
-    if (_wcsicmp(rest.c_str(), L" pinned") == 0) {
-        return true;
-    }
-    // "<label> - 1 running window", with or without a trailing " pinned".
-    if (rest.size() > 3 && _wcsnicmp(rest.c_str(), L" - ", 3) == 0) {
-        return true;
-    }
-    return false;
+    return _wcsnicmp(name.c_str(), leaf.c_str(), leaf.size()) == 0;
 }
 
-// Empty when this label is not one of ours.
+// Empty when this label is not one of ours, or when it is ambiguous between
+// two of our own labels (e.g. folders named "Games" and "Games Launcher" both
+// prefix-match the same button) — in that case, skip rather than guess.
+//
+// ponytail: only disambiguates against our own labels, not every other
+// realized taskbar button's label. A folder literally named as a prefix of
+// some other app's title ("Games" vs. a real "Games Launcher" app) can still
+// mismatch. Add cross-button disambiguation (bridge XAML button -> AppID via
+// CTaskGroup::GetAppID) if that turns out to matter in practice.
 std::wstring PinIdForLabel(const std::wstring& accessibleName) {
     std::lock_guard<std::mutex> lock(g_labelMutex);
+    const std::wstring* bestLeaf = nullptr;
+    std::wstring bestPinId;
+    bool ambiguous = false;
     for (const auto& [leaf, pinId] : g_labelToPinId) {
-        if (LabelMatchesAccessibleName(leaf, accessibleName)) {
+        if (!LabelMatchesAccessibleName(leaf, accessibleName)) {
+            continue;
+        }
+        if (leaf.size() == accessibleName.size()) {
+            // Exact match wins outright.
             return pinId;
         }
+        if (!bestLeaf || leaf.size() > bestLeaf->size()) {
+            bestLeaf = &leaf;
+            bestPinId = pinId;
+            ambiguous = false;
+        } else if (leaf.size() == bestLeaf->size()) {
+            ambiguous = true;
+        }
     }
-    return L"";
+    if (!bestLeaf || ambiguous) {
+        return L"";
+    }
+    return bestPinId;
 }
 
 bool Contains(const std::vector<std::wstring>& list, const std::wstring& value) {
@@ -1624,6 +1650,7 @@ void Reconcile() {
 
     bool unpinnedByUser = false;
     bool generatedPinIds = false;
+    bool renamedOnDisk = false;
 
     {
         std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
@@ -1676,6 +1703,43 @@ void Reconcile() {
                 unpinnedByUser = true;
                 continue;
             }
+            // Follow an in-place rename done outside the mod (Explorer's own
+            // F2/right-click Rename on the folder itself, not the mod's Name
+            // field). BuildFolderEntry already does this, but only runs on
+            // Wh_ModInit / a settings reload — nothing previously watched the
+            // pinned folders themselves, so a plain Explorer rename never
+            // reached the taskbar button until something unrelated forced a
+            // reload. Reconcile already runs on every taskbar/pin change and
+            // periodically (see kReconcilePollMs below), so doing the same
+            // fileId lookup here catches it without waiting on that.
+            std::wstring expandedPath = ExpandEnv(entry.path);
+            if (!IsShellFolderPath(expandedPath) && entry.fileId != 0 &&
+                !IsLikelyRemotePath(expandedPath) &&
+                !DirectoryExists(ResolveFolderPath(expandedPath))) {
+                std::wstring renamed =
+                    FindRenamedSibling(expandedPath, entry.fileId);
+                if (!renamed.empty()) {
+                    size_t slash = expandedPath.find_last_of(L"\\/");
+                    std::wstring oldLeaf = slash == std::wstring::npos
+                                               ? expandedPath
+                                               : expandedPath.substr(slash + 1);
+                    bool nameWasLeaf = entry.name.empty() ||
+                                       _wcsicmp(entry.name.c_str(),
+                                                oldLeaf.c_str()) == 0;
+                    Wh_Log(L"Pins: '%s' was renamed to '%s' on disk, following",
+                           expandedPath.c_str(), renamed.c_str());
+                    entry.path = renamed;
+                    if (nameWasLeaf) {
+                        size_t newSlash = renamed.find_last_of(L"\\/");
+                        entry.name = newSlash == std::wstring::npos
+                                         ? renamed
+                                         : renamed.substr(newSlash + 1);
+                    }
+                    storeChanged = true;
+                    renamedOnDisk = true;
+                }
+            }
+
             // Only a copy of what the slow work below needs. Resolving a path
             // and writing a shortcut both touch the filesystem, and the folder
             // may be a network share that blocks for the share's timeout — the
@@ -1694,17 +1758,43 @@ void Reconcile() {
         if (folderPath.empty()) {
             folderPath = ExpandEnv(entry.path);
         }
-        // A folder that no longer exists would be pruned by the shell anyway;
-        // leave the entry alone so the user can fix the path rather than
-        // silently losing it.
-        if (GetFileAttributesW(folderPath.c_str()) == INVALID_FILE_ATTRIBUTES) {
-            Wh_Log(L"Pins: '%s' does not exist, not pinning", folderPath.c_str());
+        bool resolves =
+            GetFileAttributesW(folderPath.c_str()) != INVALID_FILE_ATTRIBUTES;
+
+        std::wstring lnkPath = LnkPathFor(entry, &takenLeaves);
+        if (lnkPath.empty()) {
             continue;
         }
 
-        std::wstring lnkPath = LnkPathFor(entry, &takenLeaves);
-        if (lnkPath.empty() || !WriteShortcut(entry, folderPath, lnkPath)) {
-            continue;
+        if (!resolves) {
+            // Offline share, unplugged drive, or a drive letter not yet
+            // remapped at logon: this is likely transient, not gone. Keep
+            // whatever shortcut was last written for it so the taskbar button
+            // is neither unpinned nor swept below - losing its position is
+            // worse than leaving a stale button up while the folder is
+            // unreachable. Only skip entirely when there is nothing to keep.
+            if (GetFileAttributesW(lnkPath.c_str()) == INVALID_FILE_ATTRIBUTES) {
+                Wh_Log(L"Pins: '%s' does not exist and was never pinned, "
+                       L"skipping",
+                       folderPath.c_str());
+                continue;
+            }
+            Wh_Log(L"Pins: '%s' does not currently resolve, keeping existing "
+                   L"pin",
+                   folderPath.c_str());
+        } else {
+            std::wstring signature = ShortcutSignature(entry, folderPath, lnkPath);
+            auto cached = g_shortcutSignatures.find(entry.pinId);
+            bool unchanged = cached != g_shortcutSignatures.end() &&
+                             cached->second == signature &&
+                             GetFileAttributesW(lnkPath.c_str()) !=
+                                 INVALID_FILE_ATTRIBUTES;
+            if (!unchanged) {
+                if (!WriteShortcut(entry, folderPath, lnkPath)) {
+                    continue;
+                }
+                g_shortcutSignatures[entry.pinId] = signature;
+            }
         }
         keepFiles.push_back(lnkPath);
 
@@ -1717,6 +1807,16 @@ void Reconcile() {
     // the pinned item keeps whatever name it had when it was pinned — renaming
     // the source .lnk afterwards does not reach the taskbar, and the button
     // would sit there labelled with a name the mod no longer uses.
+    //
+    // renamedAppIds tracks which of our own appIds got unpinned here for a
+    // stale label. Explorer does not appear to treat "unpin AppID X, pin AppID
+    // X again" as two real operations when they land back to back on the same
+    // pass with no real elapsed time between them - the re-pin silently has no
+    // effect, even though both InvokeCommand calls return success. Waiting
+    // below for the unpin to actually drop off the shell's own pinned list
+    // before asking for the re-pin is what a manual unpin-then-later-pin from
+    // the real taskbar menu gets for free just by not being instantaneous.
+    std::unordered_set<std::wstring> renamedAppIds;
     for (const auto& item : ReadPinnedItems()) {
         const Desired* match = nullptr;
         for (const auto& want : desired) {
@@ -1739,17 +1839,48 @@ void Reconcile() {
                 Wh_Log(L"Pins: '%s' is now called '%s', re-pinning",
                        item.leaf.c_str(), match->leaf.c_str());
             }
+            renamedAppIds.insert(item.appId);
         }
+    }
+
+    // Give each rename's unpin real wall-clock time to actually drop off the
+    // shell's pinned list before the pin loop below runs - see the comment
+    // above. Bounded so a share/permission hiccup that leaves the unpin
+    // stuck cannot hang this worker thread indefinitely; the next debounced
+    // pass will just try again.
+    if (!renamedAppIds.empty()) {
+        Wh_Log(L"Pins: %zu renamed item(s) to wait on before re-pinning",
+               renamedAppIds.size());
+    }
+    for (const auto& appId : renamedAppIds) {
+        ULONGLONG start = GetTickCount64();
+        bool dropped = false;
+        for (int waited = 0; waited < 2000; waited += 25) {
+            if (!Contains(ReadPinnedAppIds(), appId)) {
+                dropped = true;
+                break;
+            }
+            Sleep(25);
+        }
+        Wh_Log(L"Pins: waited %llums for %s to drop from the pinned list: %s",
+               GetTickCount64() - start, appId.c_str(),
+               dropped ? L"dropped" : L"still there, giving up for now");
     }
 
     std::vector<std::wstring> live = ReadPinnedAppIds();
 
     for (const auto& item : desired) {
-        if (Contains(live, item.appId)) {
+        bool wasRenamed = renamedAppIds.count(item.appId) != 0;
+        if (Contains(live, item.appId) && !wasRenamed) {
             continue;
         }
+        Wh_Log(L"Pins: pinning %s (renamed=%d, still-live=%d)",
+               item.lnkPath.c_str(), wasRenamed, Contains(live, item.appId));
         if (InvokeVerb(item.lnkPath, "taskbarpin")) {
             Wh_Log(L"Pins: pinned %s", item.lnkPath.c_str());
+        } else {
+            Wh_Log(L"Pins: pin attempt for %s did not succeed",
+                   item.lnkPath.c_str());
         }
     }
 
@@ -1806,12 +1937,28 @@ void Reconcile() {
     // even when a pinned copy's name has drifted from the source shortcut.
     PublishLabels(finalItems);
 
-    // Put "Manage folders..." on each button's own right-click menu. Rewritten
-    // every reconcile rather than once: the jump list is stored per AppID by
-    // the shell, and an item that was unpinned and pinned again comes back
-    // without one.
-    for (const auto& item : finalItems) {
-        WriteJumpList(item.appId);
+    // Put "Manage folders..." on each button's own right-click menu. Needs
+    // rewriting after an item was unpinned and pinned again - the jump list
+    // is stored per AppID by the shell, and it does not come back on its own
+    // - so g_jumpListWritten is cleared for any AppID that drops off the
+    // taskbar, forcing the next reconcile that sees it again to redo it. An
+    // AppID that stayed pinned across this pass already has its jump list.
+    {
+        std::unordered_set<std::wstring> stillLive;
+        for (const auto& item : finalItems) {
+            stillLive.insert(item.appId);
+            if (g_jumpListWritten.insert(item.appId).second) {
+                WriteJumpList(item.appId);
+            }
+        }
+        for (auto it = g_jumpListWritten.begin();
+             it != g_jumpListWritten.end();) {
+            if (stillLive.count(*it)) {
+                ++it;
+            } else {
+                it = g_jumpListWritten.erase(it);
+            }
+        }
     }
 
     // Both of these mean the loaded folder list no longer matches the store.
@@ -1826,7 +1973,11 @@ void Reconcile() {
     // labels resolve, and nothing matches. Reloading re-reads the store now that
     // the ids are persisted; the next reconcile generates none, so this does not
     // recur.
-    if (unpinnedByUser || generatedPinIds) {
+    //
+    // renamedOnDisk: an Explorer rename updated the store's path/name under
+    // the entry, so g_settings.folders still points hover and the scan
+    // thread at the pre-rename path until this reloads it.
+    if (unpinnedByUser || generatedPinIds || renamedOnDisk) {
         RequestReloadUI();
     }
 }
@@ -1851,6 +2002,14 @@ HANDLE g_kickEvent = nullptr;  // auto-reset
 // folder (which is what ReadPinnedAppIds reads) and the Taskband key the shell
 // keeps the order in. Either firing is treated as "something changed, go look".
 constexpr DWORD kPinWatchDebounceMs = 400;
+
+// Nothing watches the pinned folders themselves - only the shell's own
+// pinned-items copy and the Taskband key are watched, both of which are about
+// pin *state*, not about the folder Explorer's F2/right-click Rename just
+// renamed on disk. This is the safety net that catches that case: it bounds
+// how long a plain Explorer rename can sit unreflected on the taskbar without
+// needing an unrelated pin/unpin to shake a reconcile loose.
+constexpr DWORD kReconcilePollMs = 10000;
 
 DWORD WINAPI ThreadProc(void*) {
     HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
@@ -1917,11 +2076,14 @@ DWORD WINAPI ThreadProc(void*) {
 
     bool stopping = false;
     while (!stopping) {
-        DWORD result = WaitForMultipleObjects(count, waits, FALSE, INFINITE);
+        DWORD result =
+            WaitForMultipleObjects(count, waits, FALSE, kReconcilePollMs);
         if (result == WAIT_OBJECT_0 || result == WAIT_FAILED) {
             break;
         }
-        rearm(result - WAIT_OBJECT_0);
+        if (result != WAIT_TIMEOUT) {
+            rearm(result - WAIT_OBJECT_0);
+        }
 
         // Coalesce the burst. One pin or unpin rewrites several files and the
         // registry, and this mod's own reconcile writes to the same places, so
@@ -2131,6 +2293,14 @@ bool IsPinnedTaskbarFolder(const std::wstring& path) {
 // than becoming a second entry for the same folder. No-op (returns false) only
 // if the folder is already pinned.
 bool AddPinnedFolder(const std::wstring& path, const std::wstring& name) {
+    // Gathered before the lock: both do filesystem I/O (desktop.ini, a file
+    // handle for the id), and the rest of the code carefully keeps that kind
+    // of I/O off FolderStore::g_mutex (see the todo copy in Reconcile). Wasted
+    // if this turns out to be a re-pin of an existing entry, but that is
+    // cheaper than blocking every other store access on it.
+    std::wstring icon = ReadFolderCustomIcon(path);
+    uint64_t fileId = GetDirFileId(path);
+
     // Held across read-modify-write: the manager thread and the taskbar UI
     // thread mutate the same store.
     std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
@@ -2149,8 +2319,8 @@ bool AddPinnedFolder(const std::wstring& path, const std::wstring& name) {
     entry.name = name;
     // No icon field in the right-click pin flow, so this is the only chance to
     // pick up a custom folder icon.
-    entry.icon = ReadFolderCustomIcon(path);
-    entry.fileId = GetDirFileId(path);
+    entry.icon = std::move(icon);
+    entry.fileId = fileId;
     entry.pinned = true;
     stored.push_back(std::move(entry));
     FolderStore::Write(stored);
@@ -2479,9 +2649,9 @@ bool RunFromWindowThread(HWND hWnd,
                     // The hook is thread-wide, so a second in-flight call from
                     // another thread puts a second copy of this proc in the
                     // chain — and both copies match this one message and this
-                    // one param. Running the callback twice would make
-                    // ApplyButtonIconOnUiThread adopt an already-deleted
-                    // ButtonIconDelivery. Claim it instead: the param lives on
+                    // one param. Running the callback twice would double-run
+                    // the caller's proc against a param it may have already
+                    // torn down. Claim it instead: the param lives on
                     // the sender's stack and both copies run synchronously on
                     // this thread, so no lock is needed (and a lock held across
                     // SendMessage is the hazard the rest of the mod avoids).
@@ -2507,10 +2677,10 @@ bool RunFromWindowThread(HWND hWnd,
 
     // A window destroyed between GetWindowThreadProcessId and the send makes
     // SendMessage return without dispatching, so the hook never fires. Report
-    // that honestly: DeliverButtonIconToUi hands ownership over on a true and
-    // would leak the delivery, and Wh_ModUninit would skip its teardown and the
-    // warning that goes with it. Whichever hook copy ran the callback cleared
-    // param.proc, so this is already the answer.
+    // that honestly: a caller that hands ownership over on a true return would
+    // leak whatever it passed, and Wh_ModUninit's teardown call would skip its
+    // warning on a false negative. Whichever hook copy ran the callback
+    // cleared param.proc, so this is already the answer.
     return param.proc == nullptr;
 }
 
@@ -4059,13 +4229,10 @@ void StopScanThread() {
         std::swap(workEvent, g_scanWorkEvent);
     }
     if (thread && thread->joinable()) {
-        // Pump sent messages while waiting. The worker delivers button icons
-        // with a blocking SendMessage to the taskbar UI thread
-        // (DeliverButtonIconToUi -> RunFromWindowThread), and the taskbar
-        // right-click unpin reaches here from that very thread — a plain
-        // join() would leave both blocked forever and hang the taskbar. The
-        // g_scanThreadStop check before the delivery narrows that window but
-        // cannot close it. Same shape as StopRetryThread.
+        // Pump sent messages while waiting: this worker runs an STA apartment,
+        // and COM's cross-apartment marshaling reaches STA threads via sent
+        // messages, so a plain join() risks deadlocking whatever thread is
+        // blocked sending into it. Same shape as StopRetryThread.
         HANDLE handle = (HANDLE)thread->native_handle();
         DWORD result;
         do {
@@ -4265,6 +4432,7 @@ void OpenSubLevel(int parentDepth, int cell);
 void CloseLevelsFrom(int depth);
 void CloseChain();
 void HideItemTooltip();
+void DestroyItemTooltip();
 void StartRetryThread();
 bool EnsurePopupClasses();
 HWND EnsureMenuOwnerWindow();
@@ -5667,18 +5835,20 @@ void OnTick() {
 }
 
 // One shared standard tooltip control, tracked to the cursor, for grid item
-// labels the ellipsis cut off. Lazily created and never destroyed - it costs
-// nothing sitting hidden, and every popup window uses the same one.
+// labels the ellipsis cut off. Lazily created; DestroyItemTooltip below tears
+// it down on unload, since the HWND belongs to this DLL's image and a fresh
+// one would otherwise be created (and leaked) on every reload.
+HWND g_itemTooltip = nullptr;
+
 HWND EnsureItemTooltip() {
-    static HWND tooltip = nullptr;
-    if (tooltip) {
-        return tooltip;
+    if (g_itemTooltip) {
+        return g_itemTooltip;
     }
-    tooltip = CreateWindowExW(WS_EX_TOPMOST, TOOLTIPS_CLASSW, nullptr,
-                              WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP,
-                              CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
-                              CW_USEDEFAULT, nullptr, nullptr,
-                              GetCurrentModuleHandle(), nullptr);
+    HWND tooltip = CreateWindowExW(WS_EX_TOPMOST, TOOLTIPS_CLASSW, nullptr,
+                                   WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP,
+                                   CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+                                   CW_USEDEFAULT, nullptr, nullptr,
+                                   GetCurrentModuleHandle(), nullptr);
     if (!tooltip) {
         return nullptr;
     }
@@ -5688,18 +5858,30 @@ HWND EnsureItemTooltip() {
     info.uId = 1;
     info.lpszText = const_cast<LPWSTR>(L"");
     SendMessageW(tooltip, TTM_ADDTOOL, 0, (LPARAM)&info);
+    g_itemTooltip = tooltip;
     return tooltip;
 }
 
+// Must run on the tooltip's creating UI thread, like the rest of
+// teardownOnUiThread.
+void DestroyItemTooltip() {
+    if (g_itemTooltip) {
+        DestroyWindow(g_itemTooltip);
+        g_itemTooltip = nullptr;
+    }
+}
+
 void HideItemTooltip() {
-    HWND tooltip = EnsureItemTooltip();
-    if (!tooltip) {
+    // No-op rather than EnsureItemTooltip: nothing was ever shown, so there is
+    // nothing to hide, and creating one here just to hide it is wasted on
+    // every teardown.
+    if (!g_itemTooltip) {
         return;
     }
     TOOLINFOW info{sizeof(info)};
     info.hwnd = nullptr;
     info.uId = 1;
-    SendMessageW(tooltip, TTM_TRACKACTIVATE, FALSE, (LPARAM)&info);
+    SendMessageW(g_itemTooltip, TTM_TRACKACTIVATE, FALSE, (LPARAM)&info);
 }
 
 // screenPt is where the cursor is; the tooltip is offset below-right of it so
@@ -6226,6 +6408,10 @@ struct PinBinding {
     int folderIndex = -1;
     winrt::event_token enterToken{};
     winrt::event_token exitToken{};
+    // The shell's tooltip, saved before we clear it, so unbinding can put it
+    // back rather than leaving the container tooltip-less for whatever the
+    // shell realizes there next.
+    winrt::Windows::Foundation::IInspectable savedTooltip{nullptr};
 };
 
 // One per taskbar window (primary + each secondary monitor).
@@ -6256,7 +6442,6 @@ std::vector<std::unique_ptr<TaskbarHost>>& TaskbarHosts() {
 }
 
 std::atomic<bool> g_injectionLive{false};
-std::atomic<uint32_t> g_buttonIconGeneration{1};
 
 // Lifetime retry worker: stays alive until StopRetryThread (settings/uninit).
 // StartRetryThread ensures the worker exists and SetEvent(kick) — never joins
@@ -6476,6 +6661,7 @@ void UnbindPinButtons(TaskbarHost* host) {
             if (binding.exitToken.value) {
                 binding.button.PointerExited(binding.exitToken);
             }
+            ToolTipService::SetToolTip(binding.button, binding.savedTooltip);
         } catch (...) {
             // The element can already be torn down; nothing to release then.
         }
@@ -6529,12 +6715,15 @@ void RebindPinButtons(TaskbarHost* host) {
 
         // Explorer's own tooltip echoes the pinned label, which fights the
         // grid we open on hover with a second, redundant popup naming the
-        // same folder. Suppress it for buttons we've claimed.
+        // same folder. Suppress it for buttons we've claimed, saving the
+        // shell's value so UnbindPinButtons can restore it later.
+        auto savedTooltip = ToolTipService::GetToolTip(child);
         ToolTipService::SetToolTip(child, nullptr);
 
         PinBinding binding;
         binding.button = child;
         binding.folderIndex = folderIndex;
+        binding.savedTooltip = savedTooltip;
         binding.enterToken = child.PointerEntered(
             [folderIndex, taskbarWnd](
                 winrt::Windows::Foundation::IInspectable const& sender,
@@ -6619,6 +6808,7 @@ constexpr int kIdRemove = 1004;
 constexpr int kIdTogglePin = 1005;
 constexpr int kIdClose = 1008;
 constexpr int kIdHint = 1009;
+constexpr int kIdRemoveAll = 1010;
 
 // Edit-dialog controls.
 constexpr int kIdEditName = 1101;
@@ -6660,7 +6850,7 @@ constexpr int kSectionHeader = 24;
 
 // 96-DPI client size of each window, before AdjustWindowRect.
 constexpr int kMainWidth = 476;
-constexpr int kMainHeight = 400;
+constexpr int kMainHeight = 434;
 constexpr int kEditWidth = 470;
 constexpr int kEditHeight = 306;
 
@@ -6707,6 +6897,7 @@ constexpr ChildRect kMainLayout[] = {
     {kIdEdit, 94, 324, 76, 26},       {kIdRemove, 176, 324, 76, 26},
     {kIdTogglePin, 258, 324, 76, 26}, {kIdClose, 388, 324, 76, 26},
     {kIdHint, 12, 360, 452, 32},
+    {kIdRemoveAll, 12, 396, 200, 26},
 };
 
 // The store as last read, in listbox order. Manager-thread only.
@@ -7818,6 +8009,54 @@ void RemoveSelected(HWND hWnd) {
     RefreshAfterStoreChange(hWnd);
 }
 
+// The mod deliberately leaves its taskbar buttons, source shortcuts and
+// per-AppID jump lists in place on unload/disable (nothing else cleans those
+// up, since they are also how a reload picks the state back up) — this is the
+// explicit escape hatch for a user who wants them gone for good.
+void RemoveAllFolderButtons(HWND hWnd) {
+    std::wstring prompt =
+        L"Remove all folder buttons from the taskbar?\n\nThis unpins every "
+        L"folder button this mod created, deletes their Start Menu "
+        L"shortcuts, and clears the folder list. This cannot be undone.";
+    if (MessageBoxW(hWnd, prompt.c_str(), L"Taskbar Folders",
+                    MB_OKCANCEL | MB_ICONWARNING) != IDOK ||
+        g_unloading) {
+        return;
+    }
+
+    for (const auto& item : Pins::ReadPinnedItems()) {
+        Pins::InvokeVerb(item.path, "taskbarunpin");
+    }
+
+    std::wstring dir = Pins::SourceDir();
+    if (!dir.empty()) {
+        WIN32_FIND_DATAW find{};
+        HANDLE handle = FindFirstFileW((dir + L"\\*.lnk").c_str(), &find);
+        if (handle != INVALID_HANDLE_VALUE) {
+            do {
+                if (find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+                    continue;
+                }
+                std::wstring path = dir + L"\\" + find.cFileName;
+                DeleteFileW(path.c_str());
+                SHChangeNotify(SHCNE_DELETE, SHCNF_PATH | SHCNF_FLUSH,
+                              path.c_str(), nullptr);
+            } while (FindNextFileW(handle, &find));
+            FindClose(handle);
+        }
+        // Only removes it if it is now empty, which it is unless something
+        // else put a file there.
+        RemoveDirectoryW(dir.c_str());
+    }
+
+    {
+        std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
+        FolderStore::Write({});
+    }
+
+    RefreshAfterStoreChange(hWnd);
+}
+
 // A single-select listbox never lets go of its selection on its own — a click
 // below the last row just does nothing, and there is no other way to clear
 // it. LB_ITEMFROMPOINT's high word flags a point outside every row's client
@@ -7861,7 +8100,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                                           {kIdEdit, L"Edit..."},
                                           {kIdRemove, L"Remove"},
                                           {kIdTogglePin, L"Pin"},
-                                          {kIdClose, L"Close"}};
+                                          {kIdClose, L"Close"},
+                                          {kIdRemoveAll,
+                                           L"Remove all folder buttons..."}};
             for (const auto& b : buttons) {
                 CreateWindowExW(0, L"BUTTON", b.text,
                                 WS_CHILD | WS_VISIBLE | WS_TABSTOP |
@@ -7974,6 +8215,8 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 TogglePinSelected(hWnd);
             } else if (id == kIdClose) {
                 DestroyWindow(hWnd);
+            } else if (id == kIdRemoveAll) {
+                RemoveAllFolderButtons(hWnd);
             } else if (id == kIdList && code == LBN_DBLCLK) {
                 EditSelected(hWnd);
             } else if (id == kIdList && code == LBN_SELCHANGE) {
@@ -8077,10 +8320,11 @@ void ThreadMain(POINT anchor) {
 //
 // no_destroy for the same reason as g_scanThread: destroying a joinable
 // std::thread calls std::terminate, and CRT teardown at Explorer exit must not
-// touch it. g_threadMutex guards the slot — Open() can be called from the
-// taskbar UI thread while Wh_ModUninit runs CloseAndWait on another.
+// touch it.
 [[clang::no_destroy]] std::optional<std::thread> g_thread;
-[[clang::no_destroy]] std::mutex g_threadMutex;
+// Guards the slot above — Open() can be called from the taskbar UI thread
+// while Wh_ModUninit runs CloseAndWait on another.
+std::mutex g_threadMutex;
 
 // Brings an already-open window forward instead of opening a second one.
 void Open() {
@@ -8204,35 +8448,6 @@ void CloseAndWait() {
 }
 
 }  // namespace FolderManager
-
-// Quick scale-down-and-back on the button content, matching the feedback the
-// Win11 taskbar gives its own pinned buttons when they are activated.
-constexpr int kPressBounceMs = 250;
-constexpr float kPressBounceScale = 0.86f;
-
-void PlayPressBounce(UIElement const& element) {
-    auto target = element.try_as<FrameworkElement>();
-    if (!target) {
-        return;
-    }
-    try {
-        auto visual = ElementCompositionPreview::GetElementVisual(target);
-        visual.CenterPoint({(float)target.ActualWidth() / 2.0f,
-                            (float)target.ActualHeight() / 2.0f, 0.0f});
-        auto compositor = visual.Compositor();
-        auto easing = compositor.CreateCubicBezierEasingFunction({0.3f, 0.0f},
-                                                                 {0.2f, 1.0f});
-        auto anim = compositor.CreateVector3KeyFrameAnimation();
-        anim.InsertKeyFrame(0.0f, {1.0f, 1.0f, 1.0f});
-        anim.InsertKeyFrame(0.35f,
-                            {kPressBounceScale, kPressBounceScale, 1.0f},
-                            easing);
-        anim.InsertKeyFrame(1.0f, {1.0f, 1.0f, 1.0f}, easing);
-        anim.Duration(std::chrono::milliseconds(kPressBounceMs));
-        visual.StartAnimation(L"Scale", anim);
-    } catch (...) {
-    }
-}
 
 TaskbarHost* FindTaskbarHost(HWND taskbarWnd) {
     if (!g_taskbarHosts) {
@@ -8408,9 +8623,9 @@ bool InjectHostGridsOnTaskbarThread() {
         // hover/open and RequestScan see filesystem paths (no CoInitializeEx).
         ResolvePendingFolderEntries();
 
-        // An empty folder list is not an early-out: BuildHostGrid stands in the
-        // "add a folder" placeholder button, the only route to the manager when
-        // there is no real button to right-click.
+        // An empty folder list is not an early-out: InjectHostGridForTaskbar
+        // still seats a host so a later settings reload that adds folders can
+        // bind buttons immediately, without waiting on the retry cycle.
         //
         // Drop hosts for taskbar HWNDs that no longer exist (unplugged monitors)
         // without tearing down every seated host on each retry.
@@ -9090,8 +9305,8 @@ std::atomic<bool> g_menuDark{true};
 // the hwnd handed to TrackPopupMenuEx, which belongs to the thread running that
 // menu, and EndMenu only cancels the calling thread's menu — so uninit needs
 // every owner, not whichever one entered last.
-[[clang::no_destroy]] std::mutex g_explorerMenuMutex;
-[[clang::no_destroy]] std::vector<HWND> g_explorerMenuOwners;
+std::mutex g_explorerMenuMutex;
+std::vector<HWND> g_explorerMenuOwners;
 
 bool ExplorerMenuOwnersSnapshot(std::vector<HWND>* out) {
     std::lock_guard<std::mutex> lock(g_explorerMenuMutex);
@@ -9107,6 +9322,13 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
                                  int y,
                                  HWND hwnd,
                                  LPTPMPARAMS params) {
+    // Teardown is already waiting on every registered owner in
+    // g_explorerMenuOwners (see Wh_ModUninit); injecting menu items this late
+    // would just add one more owner to wait out for no benefit.
+    if (g_unloading) {
+        return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
+    }
+
     struct MenuActiveGuard {
         HWND owner;
         explicit MenuActiveGuard(HWND ownerWnd) : owner(ownerWnd) {
@@ -9418,11 +9640,11 @@ BOOL WINAPI CreateProcessW_Hook(LPCWSTR applicationName,
 BOOL Wh_ModInit() {
     Wh_Log(L"Init");
 
-    // Before LoadSettings: LoadFolders ends with Pins::RequestReconcile, and the
-    // worker has to exist for that kick to land. Start() only creates the thread
-    // and signals; the reconcile itself runs on that thread.
-    Pins::Start();
-
+    // LoadFolders ends with Pins::RequestReconcile, which is a no-op with no
+    // worker yet. Pins::Start() below kicks a reconcile itself once it starts
+    // the thread, so nothing depends on starting the worker this early -- and
+    // starting it late means a return FALSE below leaves no thread running in
+    // an image Windhawk is about to unmap.
     LoadSettings();
     ResetFolderData();
 
@@ -9441,6 +9663,8 @@ BOOL Wh_ModInit() {
         return FALSE;
     }
 
+    Pins::Start();
+
     // Only when the Explorer integration is on: with it off, every context
     // menu in the process stays entirely untouched by this mod, so nothing in
     // the menu path can affect Explorer at all. Windhawk has no way to remove
@@ -9454,10 +9678,9 @@ BOOL Wh_ModInit() {
     if (!g_settings.explorerMenu) {
         Wh_Log(L"Explorer right-click integration is off; not hooking "
                L"TrackPopupMenuEx");
-    } else if (!Wh_SetFunctionHook(
-                   (void*)TrackPopupMenuEx,
-                   (void*)AddToTaskbar::TrackPopupMenuExHook,
-                   (void**)&AddToTaskbar::TrackPopupMenuEx_orig)) {
+    } else if (!WindhawkUtils::SetFunctionHook(
+                   TrackPopupMenuEx, AddToTaskbar::TrackPopupMenuExHook,
+                   &AddToTaskbar::TrackPopupMenuEx_orig)) {
         // Non-fatal: the rest of the mod works without the right-click
         // integration.
         Wh_Log(L"Failed to hook TrackPopupMenuEx; Explorer right-click "
@@ -9468,9 +9691,16 @@ BOOL Wh_ModInit() {
     // CreateProcessW, whatever the shell does above it, so this is the one
     // place that cannot be missed. Non-fatal: without it the task falls through
     // and opens an Explorer window instead of the manager.
-    if (!Wh_SetFunctionHook((void*)CreateProcessW,
-                            (void*)CreateProcessW_Hook,
-                            (void**)&CreateProcessW_Original)) {
+    //
+    // Resolved from kernelbase.dll rather than linked via kernel32's
+    // CreateProcessW: the implementation lives in kernelbase, and callers that
+    // bind through the API set (api-ms-win-core-processthreads-l1-*) reach it
+    // directly, bypassing the kernel32 export this hook would otherwise patch.
+    auto pCreateProcessW = (decltype(&CreateProcessW))GetProcAddress(
+        GetModuleHandleW(L"kernelbase.dll"), "CreateProcessW");
+    if (!pCreateProcessW || !WindhawkUtils::SetFunctionHook(
+                                 pCreateProcessW, CreateProcessW_Hook,
+                                 &CreateProcessW_Original)) {
         Wh_Log(L"Failed to hook CreateProcessW; the jump list's Manage "
                L"folders task will not open the manager");
     }
@@ -9546,7 +9776,7 @@ BOOL Wh_ModSettingsChanged(BOOL* bReload) {
     // so toggling the Explorer integration asks Windhawk for a reload instead
     // of leaving the new value to take effect at some unrelated later point.
     // The UI is rebuilt by the reload, so RequestReloadUI would be redundant.
-    bool reload = (Wh_GetIntSetting(L"explorerMenu") != 0) != g_explorerMenuHooked;
+    bool reload = (Wh_GetIntSetting(L"behavior.explorerMenu") != 0) != g_explorerMenuHooked;
     if (reload) {
         *bReload = TRUE;
     } else {
@@ -9577,6 +9807,7 @@ void Wh_ModUninit() {
     auto teardownOnUiThread = [](void*) {
         ClearPendingShellCommand();
         CloseChain();
+        DestroyItemTooltip();
         RemoveAllHostGrids();
 
         for (HWND hWnd : g_levelWindows) {
@@ -9707,7 +9938,7 @@ void Wh_ModUninit() {
 
     if (threadWnd) {
         if (!RunFromWindowThread(threadWnd, teardownOnUiThread, nullptr)) {
-            Wh_Log(L"Uninidt: RunFromWindowThread failed (error %u); windows "
+            Wh_Log(L"Uninit: RunFromWindowThread failed (error %u); windows "
                    L"may leak and UnregisterClass may fail",
                    GetLastError());
         }

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.27
+// @version         1.28
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
@@ -51,7 +51,8 @@ Windows 11 only.
 
 - Right click any folder button already on the taskbar and choose
   **Manage folders...**
-- Or, in this mod's settings, switch on **Open the folder manager** and save.
+- Or, with nothing pinned yet, click the **➕** button the mod puts on the
+  taskbar — it is there only until the first folder is pinned.
 
 The quickest way to add one in the first place is straight from Explorer:
 right click any folder in Explorer or on the Desktop, pick **Show more
@@ -182,17 +183,6 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 
 // ==WindhawkModSettings==
 /*
-- manageFolders: false
-  $name: 1. Behavior ▸ Open the folder manager
-  $description: >-
-    Which folders appear on your taskbar is NOT set here — it is set in the
-    Taskbar Folders window. Switch this on and save to open it, then add, edit,
-    reorder, pin, unpin and remove folders there, each with its own name and
-    icon. This is a button rather than a preference: switching it off again
-    does nothing, so just leave it wherever it lands. You can also open the
-    same window at any time by right clicking a folder button on the taskbar.
-    Why it works this way is explained under Details.
-
 - openFolderOnClick: true
   $name: 1. Behavior ▸ Click opens the folder
   $description: Left clicking a taskbar button opens the folder in File Explorer.
@@ -4940,8 +4930,17 @@ UIElement MakeButtonContent(const FolderEntry& entry,
                 try {
                     WCHAR url[2048];
                     DWORD urlLen = ARRAYSIZE(url);
-                    if (SUCCEEDED(UrlCreateFromPathW(icon.c_str(), url, &urlLen,
-                                                     0))) {
+                    // S_OK only: a real local path was converted to a file://
+                    // URL. UrlCreateFromPathW returns S_FALSE and copies the
+                    // input through unchanged when it is already a URL, so
+                    // SUCCEEDED() here would let an http(s) icon value reach
+                    // BitmapImage.UriSource and have XAML fetch it from a
+                    // remote server inside explorer.exe. The value is not
+                    // always the user's own either — ReadFolderCustomIcon
+                    // takes IconResource straight out of a folder's
+                    // desktop.ini when it is pinned from Explorer.
+                    if (UrlCreateFromPathW(icon.c_str(), url, &urlLen, 0) ==
+                        S_OK) {
                         Image image;
                         image.Width(iconExtent);
                         image.Height(iconExtent);
@@ -7208,6 +7207,21 @@ Grid BuildHostGrid(TaskbarHost* host) {
         folders = g_settings.folders;
     }
 
+    // No buttons at all — a fresh install, or every folder unpinned — means
+    // nothing on the taskbar to right-click, and the Taskbar Folders window is
+    // only reachable from a button. Stand in a single "add a folder" button so
+    // there is always a way in. It is not in the store and has no entry of its
+    // own: an emoji icon and an empty path, which every index-taking path
+    // (hover, click, right-click) already treats as "nothing to open", since
+    // FolderPathForButton returns empty for it.
+    const bool placeholder = folders.empty();
+    if (placeholder) {
+        FolderEntry add;
+        add.name = L"Add a folder";
+        add.icon = L"➕";
+        folders.push_back(std::move(add));
+    }
+
     for (size_t i = 0; i < folders.size(); i++) {
         const auto& entry = folders[i];
 
@@ -7264,8 +7278,15 @@ Grid BuildHostGrid(TaskbarHost* host) {
         state.contentGrid = content;
 
         // No taskbar-button tooltip; the folder name is shown in the hover
-        // grid.
-        ToolTipService::SetToolTip(button, nullptr);
+        // grid. The placeholder has no grid to show it in, so it says what it
+        // is on hover instead.
+        if (placeholder) {
+            ToolTipService::SetToolTip(
+                button, winrt::box_value(winrt::hstring(
+                            L"Add a folder to the taskbar")));
+        } else {
+            ToolTipService::SetToolTip(button, nullptr);
+        }
 
         Grid::SetColumn(button, (int)i);
         hostGrid.Children().Append(button);
@@ -7273,8 +7294,15 @@ Grid BuildHostGrid(TaskbarHost* host) {
         int folderIndex = (int)i;
         HWND taskbarWnd = host->hwnd;
         state.clickToken = button.Click(
-            [folderIndex](winrt::Windows::Foundation::IInspectable const&,
-                          RoutedEventArgs const&) {
+            [folderIndex, placeholder](
+                winrt::Windows::Foundation::IInspectable const&,
+                RoutedEventArgs const&) {
+                if (placeholder) {
+                    if (!g_unloading) {
+                        FolderManager::Open();
+                    }
+                    return;
+                }
                 OnButtonClicked(folderIndex);
             });
         Border highlightRef = highlight;
@@ -7324,13 +7352,21 @@ Grid BuildHostGrid(TaskbarHost* host) {
                 }
             });
         state.rightTapToken = button.RightTapped(
-            [folderIndex](
+            [folderIndex, placeholder](
                 winrt::Windows::Foundation::IInspectable const& sender,
                 winrt::Windows::UI::Xaml::Input::RightTappedRoutedEventArgs const&
                     args) {
                 // Unpin/hide is offered for every folder button now, regardless
                 // of whether it came from Settings or the Explorer pin action.
                 args.Handled(true);
+                // Nothing to unpin on the placeholder — either button opens the
+                // manager, which is the only thing it is there for.
+                if (placeholder) {
+                    if (!g_unloading) {
+                        FolderManager::Open();
+                    }
+                    return;
+                }
                 OnButtonRightClicked(folderIndex, sender.try_as<Button>());
             });
 
@@ -7969,7 +8005,7 @@ void OnRootGridLayoutUpdated(TaskbarHost* host) {
 }
 
 bool InjectHostGridForTaskbar(HWND taskbarWnd) {
-    if (!taskbarWnd || g_settings.folders.empty()) {
+    if (!taskbarWnd) {
         return false;
     }
 
@@ -8067,12 +8103,10 @@ bool InjectHostGridsOnTaskbarThread() {
         // hover/open and RequestScan see filesystem paths (no CoInitializeEx).
         ResolvePendingFolderEntries();
 
-        if (g_settings.folders.empty()) {
-            Wh_Log(L"No folders configured, nothing to inject");
-            RemoveAllHostGrids();
-            return true;
-        }
-
+        // An empty folder list is not an early-out: BuildHostGrid stands in the
+        // "add a folder" placeholder button, the only route to the manager when
+        // there is no real button to right-click.
+        //
         // Drop hosts for taskbar HWNDs that no longer exist (unplugged monitors)
         // without tearing down every seated host on each retry.
         if (g_taskbarHosts) {
@@ -8558,6 +8592,22 @@ std::wstring CreateShortcutIn(const std::wstring& target,
 // needs is parked here instead of captured.
 std::atomic<bool> g_menuDark{true};
 
+// An Explorer/Desktop context menu opened through this hook keeps a frame of
+// this DLL live for as long as the menu is up (TrackPopupMenuEx_orig runs the
+// menu's modal loop), and for part of that time a WH_CBT hook whose proc is also
+// in this DLL is installed. Wh_ModUninit has to wait that out — or Windhawk
+// FreeLibrary's the image and dismissing the menu returns into unmapped memory.
+// Not hypothetical: Wh_ModSettingsChanged asks for a reload whenever
+// explorerMenu changes.
+//
+// Every path through the hook is counted, including the ones that pass straight
+// to the original — those block in the modal loop just the same, with the return
+// address still inside this DLL. The owner is the hwnd handed to
+// TrackPopupMenuEx, which belongs to the thread running the menu; EndMenu only
+// cancels the calling thread's menu, so uninit has to drive it from there.
+std::atomic<int> g_explorerMenuActive{0};
+std::atomic<HWND> g_explorerMenuOwner{nullptr};
+
 decltype(&TrackPopupMenuEx) TrackPopupMenuEx_orig;
 
 BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
@@ -8566,6 +8616,18 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
                                  int y,
                                  HWND hwnd,
                                  LPTPMPARAMS params) {
+    struct MenuActiveGuard {
+        explicit MenuActiveGuard(HWND owner) {
+            g_explorerMenuOwner = owner;
+            g_explorerMenuActive.fetch_add(1);
+        }
+        ~MenuActiveGuard() {
+            if (g_explorerMenuActive.fetch_sub(1) == 1) {
+                g_explorerMenuOwner = nullptr;
+            }
+        }
+    } menuActive(hwnd);
+
     HWND defView = g_settings.explorerMenu ? FindShellViewWindow(hwnd) : nullptr;
     if (!defView) {
         return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
@@ -8693,31 +8755,45 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
     // those would darken them on a light theme. Resolved once here rather than
     // inside the hook, which cannot capture and should not be doing WinRT work
     // while a menu is coming up.
+    //
+    // Scoped so the hook comes out even if TrackPopupMenuEx_orig unwinds
+    // unexpectedly — its proc lives in this DLL and must not stay registered
+    // once the menu is done with.
     g_menuDark = IsDarkTheme();
-    HHOOK cbtHook = SetWindowsHookExW(
-        WH_CBT,
-        [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
-            if (nCode == HCBT_CREATEWND) {
-                HWND hWnd = (HWND)wParam;
-                CBT_CREATEWNDW* cbt = (CBT_CREATEWNDW*)lParam;
-                LPCWSTR cls = cbt->lpcs->lpszClass;
-                if (IS_INTRESOURCE(cls) && LOWORD((ULONG_PTR)cls) == 32768) {
-                    BOOL dark = g_menuDark.load() ? TRUE : FALSE;
-                    DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
-                                          &dark, sizeof(dark));
-                    int corner = DWMWCP_ROUND;
-                    DwmSetWindowAttribute(hWnd, DWMWA_WINDOW_CORNER_PREFERENCE,
-                                          &corner, sizeof(corner));
+    UINT result;
+    {
+        struct CbtHookGuard {
+            HHOOK hook = nullptr;
+            ~CbtHookGuard() {
+                if (hook) {
+                    UnhookWindowsHookEx(hook);
                 }
             }
-            return CallNextHookEx(nullptr, nCode, wParam, lParam);
-        },
-        nullptr, GetCurrentThreadId());
+        } cbtGuard;
+        cbtGuard.hook = SetWindowsHookExW(
+            WH_CBT,
+            [](int nCode, WPARAM wParam, LPARAM lParam) -> LRESULT {
+                if (nCode == HCBT_CREATEWND) {
+                    HWND hWnd = (HWND)wParam;
+                    CBT_CREATEWNDW* cbt = (CBT_CREATEWNDW*)lParam;
+                    LPCWSTR cls = cbt->lpcs->lpszClass;
+                    if (IS_INTRESOURCE(cls) &&
+                        LOWORD((ULONG_PTR)cls) == 32768) {
+                        BOOL dark = g_menuDark.load() ? TRUE : FALSE;
+                        DwmSetWindowAttribute(hWnd,
+                                              DWMWA_USE_IMMERSIVE_DARK_MODE,
+                                              &dark, sizeof(dark));
+                        int corner = DWMWCP_ROUND;
+                        DwmSetWindowAttribute(hWnd,
+                                              DWMWA_WINDOW_CORNER_PREFERENCE,
+                                              &corner, sizeof(corner));
+                    }
+                }
+                return CallNextHookEx(nullptr, nCode, wParam, lParam);
+            },
+            nullptr, GetCurrentThreadId());
 
-    UINT result = TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
-
-    if (cbtHook) {
-        UnhookWindowsHookEx(cbtHook);
+        result = TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
     }
 
     if (!(flags & TPM_RETURNCMD) || result < kMinId) {
@@ -8880,16 +8956,6 @@ BOOL Wh_ModSettingsChanged(BOOL* bReload) {
         RequestReloadUI();
     }
 
-    // "Open the folder manager" acts as a button: it fires when switched on,
-    // and switching it off again is a no-op. Windhawk's settings schema has no
-    // button widget, and a mod cannot clear the flag itself, so the previous
-    // value is tracked here to catch the off -> on edge only. Tracked even on
-    // the reload path, so the edge is not replayed after the reload.
-    int manage = Wh_GetIntSetting(L"manageFolders");
-    if (manage && !Wh_GetIntValue(L"manageFoldersPrev", 0) && !reload) {
-        FolderManager::Open();
-    }
-    Wh_SetIntValue(L"manageFoldersPrev", manage);
     return TRUE;
 }
 
@@ -8958,6 +9024,32 @@ void Wh_ModUninit() {
         }
         if (g_menuActive) {
             Wh_Log(L"Uninit: shell context menu still active after wait");
+        }
+    }
+
+    // Same problem, other menu: a classic Explorer/Desktop context menu opened
+    // through TrackPopupMenuExHook is pumping its modal loop inside a frame of
+    // this DLL, with no mod-owned window involved. EndMenu only cancels the
+    // calling thread's menu, so it has to be driven onto the owner window's
+    // thread — that is the Explorer window the user right-clicked in, not the
+    // taskbar.
+    if (AddToTaskbar::g_explorerMenuActive) {
+        for (int i = 0; AddToTaskbar::g_explorerMenuActive && i < 100; i++) {
+            HWND owner = AddToTaskbar::g_explorerMenuOwner.load();
+            if (owner && IsWindow(owner)) {
+                RunFromWindowThread(
+                    owner,
+                    [](void* param) {
+                        if (!EndMenu()) {
+                            SendMessageW((HWND)param, WM_CANCELMODE, 0, 0);
+                        }
+                    },
+                    owner);
+            }
+            Sleep(20);
+        }
+        if (AddToTaskbar::g_explorerMenuActive) {
+            Wh_Log(L"Uninit: Explorer context menu still active after wait");
         }
     }
 

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.41
+// @version         1.42
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
@@ -736,6 +736,8 @@ bool DirectoryExists(const std::wstring& path) {
 // new full path, or empty if no match.
 // ponytail: 64-bit nFileIndex id, NTFS only. ReFS/64-bit-unstable volumes
 // would need FILE_ID_INFO (128-bit) if that ever matters here.
+constexpr int kRenameSearchBudget = 512;
+
 std::wstring FindRenamedSibling(const std::wstring& oldPath, uint64_t fileId) {
     if (fileId == 0) {
         return L"";
@@ -751,10 +753,23 @@ std::wstring FindRenamedSibling(const std::wstring& oldPath, uint64_t fileId) {
         return L"";
     }
     std::wstring found;
+    // One CreateFileW per subfolder, and this runs on Explorer's main thread
+    // during Wh_ModInit and on the taskbar UI thread on every reload. A rename
+    // hits within the first handful of candidates; the case that would sweep a
+    // whole tree is a deleted pinned folder, which keeps its fileId and misses
+    // forever. Bound the sweep rather than stall the taskbar on a parent with
+    // thousands of subdirectories.
+    int budget = kRenameSearchBudget;
     do {
         if (!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ||
             wcscmp(fd.cFileName, L".") == 0 || wcscmp(fd.cFileName, L"..") == 0) {
             continue;
+        }
+        if (budget-- <= 0) {
+            Wh_Log(L"Rename search for '%s' gave up after %d candidates under "
+                   L"'%s'",
+                   oldPath.c_str(), kRenameSearchBudget, parent.c_str());
+            break;
         }
         std::wstring candidate = parent + L"\\" + fd.cFileName;
         if (GetDirFileId(candidate) == fileId) {
@@ -1397,7 +1412,19 @@ bool RunFromWindowThread(HWND hWnd,
                 if (cwp->message == runFromWindowThreadRegisteredMsg) {
                     RUN_FROM_WINDOW_THREAD_PARAM* param =
                         (RUN_FROM_WINDOW_THREAD_PARAM*)cwp->lParam;
-                    param->proc(param->procParam);
+                    // The hook is thread-wide, so a second in-flight call from
+                    // another thread puts a second copy of this proc in the
+                    // chain — and both copies match this one message and this
+                    // one param. Running the callback twice would make
+                    // ApplyButtonIconOnUiThread adopt an already-deleted
+                    // ButtonIconDelivery. Claim it instead: the param lives on
+                    // the sender's stack and both copies run synchronously on
+                    // this thread, so no lock is needed (and a lock held across
+                    // SendMessage is the hazard the rest of the mod avoids).
+                    if (auto proc = param->proc) {
+                        param->proc = nullptr;
+                        proc(param->procParam);
+                    }
                 }
             }
             return CallNextHookEx(nullptr, nCode, wParam, lParam);

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.28
+// @version         1.29
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
@@ -6947,6 +6947,18 @@ void Open() {
     }
     try {
         std::lock_guard<std::mutex> lock(g_threadMutex);
+        // Re-checked under the lock, the same way StartScanThread and
+        // StartRetryThread do it: CloseAndWait takes this mutex after
+        // g_unloading is set, so either it sees this thread and joins it, or
+        // this sees the flag and never starts one. The check above the lock is
+        // only a fast path — on its own it loses the race where CloseAndWait
+        // swaps out an empty slot between that check and the emplace below,
+        // leaving a fresh message loop running in an image about to be
+        // unmapped.
+        if (g_unloading) {
+            g_active = false;
+            return;
+        }
         // Reap the previous run before reusing the slot: assigning over a
         // joinable std::thread calls std::terminate.
         if (g_thread) {
@@ -8602,11 +8614,22 @@ std::atomic<bool> g_menuDark{true};
 //
 // Every path through the hook is counted, including the ones that pass straight
 // to the original — those block in the modal loop just the same, with the return
-// address still inside this DLL. The owner is the hwnd handed to
-// TrackPopupMenuEx, which belongs to the thread running the menu; EndMenu only
-// cancels the calling thread's menu, so uninit has to drive it from there.
-std::atomic<int> g_explorerMenuActive{0};
-std::atomic<HWND> g_explorerMenuOwner{nullptr};
+// address still inside this DLL. Note the frame outlives the menu: a chosen
+// Move/Copy runs SHFileOperationW after TrackPopupMenuEx_orig has returned, so
+// an entry can stay live for as long as that operation takes.
+//
+// One entry per live call rather than a count and a single owner: the owner is
+// the hwnd handed to TrackPopupMenuEx, which belongs to the thread running that
+// menu, and EndMenu only cancels the calling thread's menu — so uninit needs
+// every owner, not whichever one entered last.
+[[clang::no_destroy]] std::mutex g_explorerMenuMutex;
+[[clang::no_destroy]] std::vector<HWND> g_explorerMenuOwners;
+
+bool ExplorerMenuOwnersSnapshot(std::vector<HWND>* out) {
+    std::lock_guard<std::mutex> lock(g_explorerMenuMutex);
+    *out = g_explorerMenuOwners;
+    return !out->empty();
+}
 
 decltype(&TrackPopupMenuEx) TrackPopupMenuEx_orig;
 
@@ -8617,13 +8640,17 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
                                  HWND hwnd,
                                  LPTPMPARAMS params) {
     struct MenuActiveGuard {
-        explicit MenuActiveGuard(HWND owner) {
-            g_explorerMenuOwner = owner;
-            g_explorerMenuActive.fetch_add(1);
+        HWND owner;
+        explicit MenuActiveGuard(HWND ownerWnd) : owner(ownerWnd) {
+            std::lock_guard<std::mutex> lock(g_explorerMenuMutex);
+            g_explorerMenuOwners.push_back(owner);
         }
         ~MenuActiveGuard() {
-            if (g_explorerMenuActive.fetch_sub(1) == 1) {
-                g_explorerMenuOwner = nullptr;
+            std::lock_guard<std::mutex> lock(g_explorerMenuMutex);
+            auto it = std::find(g_explorerMenuOwners.begin(),
+                                g_explorerMenuOwners.end(), owner);
+            if (it != g_explorerMenuOwners.end()) {
+                g_explorerMenuOwners.erase(it);
             }
         }
     } menuActive(hwnd);
@@ -9006,37 +9033,66 @@ void Wh_ModUninit() {
         threadWnd = FindCurrentProcessTaskbarWnd();
     }
 
+    // Every one of these waits is unbounded on purpose, for the reason
+    // FolderManager::CloseAndWait spells out: Wh_ModUninit runs on a Windhawk
+    // engine thread, not on any Explorer UI thread, so blocking here does not
+    // freeze the shell — while falling through early is exactly what unmaps the
+    // image with one of these frames still executing inside it. Cancellation is
+    // attempted for the first couple of seconds only; past that, whatever is
+    // still live is work that has to finish on its own (a folder copy can run
+    // for minutes) and re-asking every 20ms is pointless.
+    constexpr int kUninitWaitPollMs = 50;
+    constexpr int kUninitCancelForMs = 2000;
+    constexpr int kUninitLogEveryMs = 5000;
+    auto waitOut = [](PCWSTR what, auto stillLive, auto attemptCancel) {
+        for (int elapsedMs = 0; stillLive(); elapsedMs += kUninitWaitPollMs) {
+            if (elapsedMs < kUninitCancelForMs) {
+                attemptCancel();
+            } else if (elapsedMs % kUninitLogEveryMs == 0) {
+                Wh_Log(L"Uninit: still waiting on %s (%d s)", what,
+                       elapsedMs / 1000);
+            }
+            Sleep(kUninitWaitPollMs);
+        }
+    };
+
     // ShowItemContextMenu runs a modal TrackPopupMenuEx loop on the UI thread.
     // Teardown via RunFromWindowThread would destroy windows and let Windhawk
-    // unload the DLL while that frame is still live — EndMenu/CANCELMODE first
-    // and wait for g_menuActive to clear (same pattern as taskbar-folder-menus).
-    if (threadWnd && g_menuActive) {
-        for (int i = 0; g_menuActive && i < 100; i++) {
-            RunFromWindowThread(
-                threadWnd,
-                [](void*) {
-                    if (g_menuActive && !EndMenu() && g_menuOwnerWnd) {
-                        SendMessageW(g_menuOwnerWnd, WM_CANCELMODE, 0, 0);
-                    }
-                },
-                nullptr);
-            Sleep(20);
-        }
-        if (g_menuActive) {
-            Wh_Log(L"Uninit: shell context menu still active after wait");
-        }
+    // unload the DLL while that frame is still live — EndMenu/CANCELMODE first,
+    // then wait for g_menuActive to clear (same pattern as taskbar-folder-menus).
+    if (threadWnd) {
+        waitOut(
+            L"a shell context menu", [] { return g_menuActive.load(); },
+            [threadWnd] {
+                RunFromWindowThread(
+                    threadWnd,
+                    [](void*) {
+                        if (g_menuActive && !EndMenu() && g_menuOwnerWnd) {
+                            SendMessageW(g_menuOwnerWnd, WM_CANCELMODE, 0, 0);
+                        }
+                    },
+                    nullptr);
+            });
     }
 
     // Same problem, other menu: a classic Explorer/Desktop context menu opened
     // through TrackPopupMenuExHook is pumping its modal loop inside a frame of
     // this DLL, with no mod-owned window involved. EndMenu only cancels the
-    // calling thread's menu, so it has to be driven onto the owner window's
-    // thread — that is the Explorer window the user right-clicked in, not the
-    // taskbar.
-    if (AddToTaskbar::g_explorerMenuActive) {
-        for (int i = 0; AddToTaskbar::g_explorerMenuActive && i < 100; i++) {
-            HWND owner = AddToTaskbar::g_explorerMenuOwner.load();
-            if (owner && IsWindow(owner)) {
+    // calling thread's menu, so it has to be driven onto each owner window's
+    // thread — those are Explorer windows the user right-clicked in, not the
+    // taskbar. A live entry can also be post-menu work (SHFileOperationW for a
+    // Move/Copy), which no amount of EndMenu will cut short.
+    std::vector<HWND> menuOwners;
+    waitOut(
+        L"an Explorer context menu",
+        [&menuOwners] {
+            return AddToTaskbar::ExplorerMenuOwnersSnapshot(&menuOwners);
+        },
+        [&menuOwners] {
+            for (HWND owner : menuOwners) {
+                if (!IsWindow(owner)) {
+                    continue;
+                }
                 RunFromWindowThread(
                     owner,
                     [](void* param) {
@@ -9046,24 +9102,12 @@ void Wh_ModUninit() {
                     },
                     owner);
             }
-            Sleep(20);
-        }
-        if (AddToTaskbar::g_explorerMenuActive) {
-            Wh_Log(L"Uninit: Explorer context menu still active after wait");
-        }
-    }
+        });
 
     // Also wait out a deferred/synchronous shell verb. ASYNCOK usually makes
-    // this short; verbs that ignore it and show modal UI can still outlive
-    // this wait — see CMIC_MASK_ASYNCOK on the invoke path.
-    if (g_invokeActive) {
-        for (int i = 0; g_invokeActive && i < 100; i++) {
-            Sleep(20);
-        }
-        if (g_invokeActive) {
-            Wh_Log(L"Uninit: shell verb still active after wait");
-        }
-    }
+    // this short; verbs that ignore it and show modal UI take as long as the
+    // user does — see CMIC_MASK_ASYNCOK on the invoke path. Nothing to cancel.
+    waitOut(L"a shell verb", [] { return g_invokeActive.load(); }, [] {});
 
     if (threadWnd) {
         if (!RunFromWindowThread(threadWnd, teardownOnUiThread, nullptr)) {

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,7 +2,7 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.42
+// @version         1.43
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
@@ -635,6 +635,13 @@ bool IsLikelyRemotePath(const std::wstring& p);
 bool IsShellFolderPath(const std::wstring& path);
 void ResolvePendingFolderEntries();
 void ReloadAndRefreshUI();
+
+// Non-zero while a reload is executing. Wh_ModUninit waits this out: a reload
+// parks the taskbar UI thread in a join that pumps sent messages, so uninit's
+// own teardown send is dispatched re-entrantly and uninit would otherwise
+// return — and let the image be unmapped — with the rest of ReloadAndRefreshUI
+// still to run on that thread.
+std::atomic<int> g_reloadInFlight{0};
 
 std::wstring Trim(std::wstring s) {
     size_t b = s.find_first_not_of(L" \t\r\n");
@@ -1441,7 +1448,13 @@ bool RunFromWindowThread(HWND hWnd,
 
     UnhookWindowsHookEx(hook);
 
-    return true;
+    // A window destroyed between GetWindowThreadProcessId and the send makes
+    // SendMessage return without dispatching, so the hook never fires. Report
+    // that honestly: DeliverButtonIconToUi hands ownership over on a true and
+    // would leak the delivery, and Wh_ModUninit would skip its teardown and the
+    // warning that goes with it. Whichever hook copy ran the callback cleared
+    // param.proc, so this is already the answer.
+    return param.proc == nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9240,6 +9253,11 @@ void Wh_ModAfterInit() {
 // Tears down UI, reloads settings (+ pinned folders), and restarts. Shared by
 // Wh_ModSettingsChanged and the Explorer right-click "pin to taskbar" action.
 void ReloadAndRefreshUI() {
+    struct InFlightGuard {
+        InFlightGuard() { g_reloadInFlight++; }
+        ~InFlightGuard() { g_reloadInFlight--; }
+    } inFlight;
+
     StopRetryThread();
     // The scan thread reads g_settings, so it has to be parked before
     // reloading.
@@ -9424,6 +9442,16 @@ void Wh_ModUninit() {
     // this short; verbs that ignore it and show modal UI take as long as the
     // user does — see CMIC_MASK_ASYNCOK on the invoke path. Nothing to cancel.
     waitOut(L"a shell verb", [] { return g_invokeActive.load(); }, [] {});
+
+    // And a reload already past MenuOwnerWndProc's g_unloading check. It parks
+    // the taskbar UI thread in StopRetryThread/StopScanThread joins that pump
+    // sent messages, so the teardown send below runs re-entrantly inside it and
+    // this function would return — unmapping the image — with LoadSettings and
+    // the rest of ReloadAndRefreshUI still owed on that thread. Nothing to
+    // cancel, and it cannot restart a worker behind us: StartRetryThread bails
+    // on g_unloading. Waiting here also means the teardown send lands after the
+    // reload is done rather than inside its join.
+    waitOut(L"a UI reload", [] { return g_reloadInFlight.load() > 0; }, [] {});
 
     if (threadWnd) {
         if (!RunFromWindowThread(threadWnd, teardownOnUiThread, nullptr)) {

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -2,12 +2,12 @@
 // @id              taskbar-folder-hover-tray
 // @name            Taskbar Folder Hover Tray
 // @description     Adds folder shortcut buttons flush inside the Windows 11 taskbar app icons. Hovering one instantly opens a grid of the folder's contents that you can move into and click.
-// @version         1.25
+// @version         1.26
 // @author          Kiploom
 // @github          https://github.com/Kiploom
 // @include         explorer.exe
 // @architecture    x86-64
-// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lshell32 -lshlwapi -luuid -lgdi32 -lgdiplus -ldwmapi -luser32
+// @compilerOptions -lole32 -loleaut32 -lruntimeobject -lshell32 -lshlwapi -luuid -lgdi32 -lgdiplus -lcomctl32 -ldwmapi -luser32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -6022,7 +6022,6 @@ void OpenSelected(HWND hWnd) {
 // the parent so the mouse capture and the hit testing share one coordinate
 // space.
 
-WNDPROC g_listOriginalProc = nullptr;
 int g_dragFrom = -1;      // Row being dragged, -1 when not dragging.
 int g_dragTo = -1;        // Insertion point currently drawn.
 bool g_dragArmed = false; // Button down, but not yet past the drag threshold.
@@ -6099,8 +6098,11 @@ void EndDrag(HWND list, bool commit) {
     }
 }
 
-LRESULT CALLBACK ListSubclassProc(HWND list, UINT msg, WPARAM wParam,
-                                  LPARAM lParam) {
+LRESULT CALLBACK ListSubclassProc(HWND list,
+                                  UINT msg,
+                                  WPARAM wParam,
+                                  LPARAM lParam,
+                                  DWORD_PTR /*dwRefData*/) {
     switch (msg) {
         // Handled here in full, never forwarded. A stock listbox runs its own
         // nested modal loop from WM_LBUTTONDOWN to track drag-selection, and
@@ -6211,7 +6213,7 @@ LRESULT CALLBACK ListSubclassProc(HWND list, UINT msg, WPARAM wParam,
             g_dragArmed = false;
             break;
     }
-    return CallWindowProcW(g_listOriginalProc, list, msg, wParam, lParam);
+    return DefSubclassProc(list, msg, wParam, lParam);
 }
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
@@ -6224,8 +6226,8 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                     LBS_OWNERDRAWFIXED,
                 12, 12, 452, 300, hWnd, (HMENU)(INT_PTR)kIdList, instance,
                 nullptr);
-            g_listOriginalProc = (WNDPROC)SetWindowLongPtrW(
-                list, GWLP_WNDPROC, (LONG_PTR)ListSubclassProc);
+            WindhawkUtils::SetWindowSubclassFromAnyThread(list,
+                                                          ListSubclassProc, 0);
 
             struct ButtonSpec {
                 int id;
@@ -6303,11 +6305,10 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 
         case WM_DESTROY:
             // Unsubclass before the listbox goes away, so a reopened window
-            // does not chain its proc onto a stale one.
-            if (g_listOriginalProc) {
-                SetWindowLongPtrW(GetDlgItem(hWnd, kIdList), GWLP_WNDPROC,
-                                  (LONG_PTR)g_listOriginalProc);
-                g_listOriginalProc = nullptr;
+            // does not chain onto a stale subclass entry.
+            if (HWND list = GetDlgItem(hWnd, kIdList)) {
+                WindhawkUtils::RemoveWindowSubclassFromAnyThread(
+                    list, ListSubclassProc);
             }
             FreeRowIcons();
             g_wnd = nullptr;

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -54,11 +54,18 @@ Windows 11 only.
 - Or, in this mod's settings, switch on **Open the folder manager** and save.
 
 The quickest way to add one in the first place is straight from Explorer:
-right click any folder in Explorer or on the Desktop and pick
+right click any folder in Explorer or on the Desktop, pick **Show more
+options** (or press Shift+F10 to go straight there), and choose
 **Taskbar Folders -> Pin**. It becomes a button immediately, taking its name
 and its custom icon (Properties > Customize > Change Icon) from the folder
 itself. That same menu appears on files and shortcuts too — use it to move,
 copy, or make a shortcut into a folder that already has a button.
+
+The entry is on the classic context menu, the one behind **Show more
+options**, and not on the short Windows 11 menu that opens first — that one is
+XAML and takes no menu items from a mod like this. If you would rather it were
+one click away, a mod such as **explorer-context-menu-classic** makes the
+classic menu the default one.
 
 If you would rather the mod stayed entirely on the taskbar side, turn off
 **Explorer right-click menu** in the settings; with it off, Explorer and Desktop
@@ -196,9 +203,11 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
 - explorerMenu: true
   $name: 1. Behavior ▸ Explorer right-click menu
   $description: >-
-    Adds a "Taskbar Folders" submenu to Explorer and Desktop context menus, for
-    pinning a folder straight to the taskbar and for moving, copying or making
-    a shortcut into a folder that already has a button. Turn this off to keep
+    Adds a "Taskbar Folders" submenu to the classic Explorer and Desktop
+    context menus — the ones behind "Show more options" / Shift+F10, not the
+    short Windows 11 menu, which is XAML and takes no items from a mod. Use it
+    to pin a folder straight to the taskbar, or to move, copy or make a
+    shortcut into a folder that already has a button. Turn this off to keep
     the mod entirely on the taskbar side — with it off, Explorer's own context
     menus are left completely alone. Switching it back on takes effect after
     the mod is reloaded (toggle the mod off and on, or restart Explorer),
@@ -572,6 +581,13 @@ uint64_t GetDirFileId(const std::wstring& path) {
     return (static_cast<uint64_t>(info.nFileIndexHigh) << 32) | info.nFileIndexLow;
 }
 
+bool DirectoryExists(const std::wstring& path) {
+    DWORD attrs = path.empty() ? INVALID_FILE_ATTRIBUTES
+                               : GetFileAttributesW(path.c_str());
+    return attrs != INVALID_FILE_ATTRIBUTES &&
+           (attrs & FILE_ATTRIBUTE_DIRECTORY);
+}
+
 // A renamed folder keeps the same parent, so if oldPath no longer resolves,
 // scan its parent for a subfolder whose file id still matches. Returns the
 // new full path, or empty if no match.
@@ -871,7 +887,16 @@ bool BuildFolderEntry(FolderStore::Entry* stored, FolderEntry* out) {
 
         // Folder missing under its stored path: it may have been renamed in
         // place. Find it by file id under the same parent and follow it.
-        if (out->resolveFailed && stored->fileId != 0) {
+        //
+        // The trigger is the folder not being on disk, not ResolveFolderPath
+        // failing — for a filesystem path that only strips trailing slashes,
+        // so it never fails. Remote paths are left alone: a stat on an offline
+        // share blocks for the SMB timeout, and this runs on Explorer's main
+        // thread during Wh_ModInit. A miss changes nothing (no rename found,
+        // or a drive that is merely unplugged keeps its path and starts
+        // working again when it comes back).
+        if (!out->resolveFailed && !out->likelyRemote && stored->fileId != 0 &&
+            !DirectoryExists(out->resolvedPath)) {
             std::wstring renamed =
                 FindRenamedSibling(out->path, stored->fileId);
             if (!renamed.empty()) {
@@ -941,24 +966,33 @@ void LoadFolders(std::vector<FolderEntry>* out) {
            out->size(), storedCount);
 }
 
-// True if `path` already has a stored entry — pinned or draft. Used to hide
-// the "Pin to Taskbar" menu item and to reject duplicates, so that a folder
-// kept as a draft cannot be pinned a second time as a separate copy.
-bool IsAlreadyTaskbarFolder(const std::wstring& path) {
+// True if `path` already has a button on the taskbar. Used to hide the "Pin to
+// Taskbar" menu item — a draft deliberately does not count, so a folder that
+// was unpinned can be pinned again from Explorer.
+bool IsPinnedTaskbarFolder(const std::wstring& path) {
     auto stored = FolderStore::Read();
-    return FolderStore::IndexOfPath(stored, path) >= 0;
+    int index = FolderStore::IndexOfPath(stored, path);
+    return index >= 0 && stored[index].pinned;
 }
 
 // Adds a folder as a new taskbar button, persisted in the mod's own storage.
 // Caller must refresh (LoadSettings + UI teardown/rebuild) for it to appear.
-// No-op (returns false) if the folder already has an entry, draft included.
+// An existing draft is re-pinned in place, keeping its name and icon, rather
+// than becoming a second entry for the same folder. No-op (returns false) only
+// if the folder is already pinned.
 bool AddPinnedFolder(const std::wstring& path, const std::wstring& name) {
     // Held across read-modify-write: the manager thread and the taskbar UI
     // thread mutate the same store.
     std::lock_guard<std::recursive_mutex> lock(FolderStore::g_mutex);
     auto stored = FolderStore::Read();
-    if (FolderStore::IndexOfPath(stored, path) >= 0) {
-        return false;
+    if (int index = FolderStore::IndexOfPath(stored, path); index >= 0) {
+        if (stored[index].pinned) {
+            return false;
+        }
+        stored[index].pinned = true;
+        FolderStore::Write(stored);
+        Wh_Log(L"Re-pinned the draft entry for '%s'", path.c_str());
+        return true;
     }
     FolderStore::Entry entry;
     entry.path = path;
@@ -2951,7 +2985,10 @@ struct PopupLevel {
     bool baseDirty = true;
 };
 
-HWND g_menuOwnerWnd = nullptr;
+// Created on the taskbar UI thread, read from the Windhawk engine thread, an
+// Explorer browser thread and the folder manager thread when they ask for a
+// reload — see RequestReloadUI.
+std::atomic<HWND> g_menuOwnerWnd{nullptr};
 HWND g_taskbarWnd = nullptr;
 
 // Windows are created lazily, one per depth, and reused across cascades.
@@ -3002,6 +3039,31 @@ constexpr UINT WM_APP_INVOKE_SHELL_VERB = WM_APP + 41;
 // down the very button the flyout is anchored to and unhooks the handlers it
 // is running inside, so it must not run inline from there.
 constexpr UINT WM_APP_RELOAD_UI = WM_APP + 42;
+
+// The only way anything should ask for a reload.
+//
+// Four threads want one — the Windhawk engine on a settings change, the
+// taskbar UI thread on unpin, an Explorer browser thread on a right-click
+// pin, the manager thread on any edit — and ReloadAndRefreshUI is not safe to
+// run concurrently or inline on most of them: it joins the scan and retry
+// workers (so a slow shell icon handler would freeze the Explorer window the
+// user just right-clicked in) and it rebuilds g_settings, which two threads
+// doing it at once is a data race on the string members.
+//
+// Posting to the one window owned by the taskbar UI thread serializes every
+// request through that thread's message loop for free. A mutex could not:
+// ReloadAndRefreshUI SendMessages to the taskbar thread, so if that thread
+// were the one blocked in lock(), it would never dispatch the send and both
+// threads would hang.
+void RequestReloadUI() {
+    HWND owner = g_menuOwnerWnd.load();
+    if (!owner || !PostMessageW(owner, WM_APP_RELOAD_UI, 0, 0)) {
+        // Before the taskbar UI is up (a settings change during init) there is
+        // no message loop to defer to, and no other thread to race with.
+        Wh_Log(L"RequestReloadUI: no owner window; reloading inline");
+        ReloadAndRefreshUI();
+    }
+}
 
 // Both take their arguments by value: reopening a level destroys the PopupLevel
 // the caller may have read them from.
@@ -5700,13 +5762,14 @@ int SelectedIndex(HWND hWnd) {
 
 // Refreshes the taskbar and this window after the store was changed.
 //
-// Must be called with FolderStore::g_mutex released: ReloadAndRefreshUI reaches
-// LoadFolders, which takes g_foldersMutex and then the store lock, so holding
-// the store lock across this would invert the order. Every caller therefore
-// scopes its read-modify-write to a block and calls this after it.
+// The taskbar half is deferred to the taskbar UI thread (see RequestReloadUI),
+// so this returns without blocking the manager thread on two worker joins. The
+// window's own list is repopulated here and now, from the store this thread
+// just wrote; the reload posts a WM_APP back afterwards, which repopulates
+// again from the same store and keeps the selected index either way.
 void RefreshAfterStoreChange(HWND hWnd) {
     if (!g_unloading) {
-        ReloadAndRefreshUI();
+        RequestReloadUI();
     }
     PopulateList(hWnd);
 }
@@ -6950,12 +7013,7 @@ void OnButtonRightClicked(int folderIndex, Button const& button) {
             // handlers this lambda is running inside, and the flyout is
             // anchored to it. The owner window lives on this same taskbar UI
             // thread, so the post lands right after the flyout unwinds.
-            if (!g_menuOwnerWnd ||
-                !PostMessageW(g_menuOwnerWnd, WM_APP_RELOAD_UI, 0, 0)) {
-                Wh_Log(L"Unpin: no menu owner window to defer the reload to; "
-                       L"reloading inline");
-                ReloadAndRefreshUI();
-            }
+            RequestReloadUI();
         });
 
         MenuFlyoutItem manage;
@@ -7848,7 +7906,15 @@ std::wstring GetSelectedPath(HWND defView) {
     return result;
 }
 
-bool MoveOrCopy(const std::wstring& src, const std::wstring& destDir, bool move) {
+// `owner` is the Explorer window the menu came from: it owns the shell's
+// progress and error dialogs, so they cannot end up behind it or ownerless.
+// ponytail: SHFileOperation, not IFileOperation — the flags below cover undo
+// and error reporting; move to IFileOperation if this ever needs per-item
+// results or an elevation prompt.
+bool MoveOrCopy(HWND owner,
+                const std::wstring& src,
+                const std::wstring& destDir,
+                bool move) {
     if (destDir.empty()) {
         return false;
     }
@@ -7856,11 +7922,18 @@ bool MoveOrCopy(const std::wstring& src, const std::wstring& destDir, bool move)
     std::wstring from = src + L'\0';
     std::wstring to = destDir + L'\0';
     SHFILEOPSTRUCTW op{};
+    op.hwnd = owner;
     op.wFunc = move ? FO_MOVE : FO_COPY;
     op.pFrom = from.c_str();
     op.pTo = to.c_str();
-    op.fFlags = FOF_NOCONFIRMMKDIR | FOF_NOERRORUI | FOF_RENAMEONCOLLISION;
-    return SHFileOperationW(&op) == 0;
+    // FOF_ALLOWUNDO: a mis-click on a menu that sits right next to Explorer's
+    // own commands has to be undoable with Ctrl+Z, and a move without it is
+    // permanent. No FOF_NOERRORUI either — access denied or a file in use is
+    // the shell's error to report, and swallowing it looks like nothing
+    // happened.
+    op.fFlags =
+        FOF_NOCONFIRMMKDIR | FOF_ALLOWUNDO | FOF_RENAMEONCOLLISION;
+    return SHFileOperationW(&op) == 0 && !op.fAnyOperationsAborted;
 }
 
 // Creates a .lnk to `target` inside `destDir`. Returns the new .lnk path, or
@@ -7896,7 +7969,14 @@ std::wstring CreateShortcutIn(const std::wstring& target,
     HRESULT hr = persist->Save(lnkPath.c_str(), TRUE);
     persist->Release();
     link->Release();
-    return SUCCEEDED(hr) ? lnkPath : L"";
+    if (FAILED(hr)) {
+        return L"";
+    }
+    // Writing the file is not enough: a window already showing destDir only
+    // learns about the new shortcut from a change notification.
+    SHChangeNotify(SHCNE_CREATE, SHCNF_PATH | SHCNF_FLUSH, lnkPath.c_str(),
+                   nullptr);
+    return lnkPath;
 }
 
 // Theme for the menu popups created while the CBT hook below is installed.
@@ -7951,7 +8031,7 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
     UINT copyBase = moveBase + (UINT)n;
     UINT shortcutBase = copyBase + (UINT)n;
 
-    bool canPin = isDir && !IsAlreadyTaskbarFolder(path);
+    bool canPin = isDir && !IsPinnedTaskbarFolder(path);
     bool showMoveCopy = !isDir && n > 0;
     bool showShortcut = !isLnk && n > 0;
 
@@ -8045,7 +8125,10 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
 
     if (canPin && result == kMinId) {
         AddPinnedFolder(path, LeafName(path));
-        ReloadAndRefreshUI();
+        // Deferred: this is the UI thread of the Explorer window the user just
+        // right-clicked in, and a reload joins the scan worker, which can sit
+        // in a slow shell icon handler for a while.
+        RequestReloadUI();
         return 0;
     }
 
@@ -8072,7 +8155,7 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
         CreateShortcutIn(path, destDir);
         return 0;
     }
-    MoveOrCopy(path, destDir, move);
+    MoveOrCopy(hwnd, path, destDir, move);
     return 0;
 }
 
@@ -8168,9 +8251,10 @@ void ReloadAndRefreshUI() {
     // out its list is stale. Without it the window keeps showing (and
     // committing against) rows that no longer match the store.
     //
-    // Skipped when the manager thread is the caller: it refreshes its own list
-    // synchronously right after this returns, and a queued WM_APP would land
-    // afterwards and clear the selection it had just restored.
+    // Since reloads run on the taskbar UI thread, this always posts when the
+    // manager is open — including for the manager's own edits, which already
+    // repopulated synchronously. The extra pass is a no-op beyond a redraw:
+    // PopulateList reads the same store and keeps the selected index.
     if (HWND manager = FolderManager::g_wnd.load()) {
         if (GetWindowThreadProcessId(manager, nullptr) !=
             GetCurrentThreadId()) {
@@ -8181,7 +8265,7 @@ void ReloadAndRefreshUI() {
 
 void Wh_ModSettingsChanged() {
     Wh_Log(L"SettingsChanged");
-    ReloadAndRefreshUI();
+    RequestReloadUI();
 
     // "Open the folder manager" acts as a button: it fires when switched on,
     // and switching it off again is a no-op. Windhawk's settings schema has no

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -1525,16 +1525,29 @@ struct PinnedItem {
 // own copy of the pinned items rather than from anything the mod believes. This
 // is what makes a native "Unpin from taskbar" visible, and what keeps the button
 // labels honest when a shortcut has been renamed underneath a live pin.
-std::vector<PinnedItem> ReadPinnedItems() {
+// ok, if given, is set to false when the read could not be trusted (the
+// pinned-items folder couldn't be resolved, or listing it failed for a
+// reason other than "no shortcuts there yet"). Callers that treat an empty
+// result as "user unpinned everything" must check this before acting on it.
+std::vector<PinnedItem> ReadPinnedItems(bool* ok = nullptr) {
     std::vector<PinnedItem> items;
+    if (ok) {
+        *ok = true;
+    }
     std::wstring dir = PinnedDir();
     if (dir.empty()) {
+        if (ok) {
+            *ok = false;
+        }
         return items;
     }
 
     WIN32_FIND_DATAW find{};
     HANDLE handle = FindFirstFileW((dir + L"\\*.lnk").c_str(), &find);
     if (handle == INVALID_HANDLE_VALUE) {
+        if (ok && GetLastError() != ERROR_FILE_NOT_FOUND) {
+            *ok = false;
+        }
         return items;
     }
     do {
@@ -1602,7 +1615,15 @@ bool LabelMatchesAccessibleName(const std::wstring& leaf,
     if (leaf.empty() || name.size() < leaf.size()) {
         return false;
     }
-    return _wcsnicmp(name.c_str(), leaf.c_str(), leaf.size()) == 0;
+    if (_wcsnicmp(name.c_str(), leaf.c_str(), leaf.size()) != 0) {
+        return false;
+    }
+    // The shell's state annotation is always appended after a separator
+    // ("Games pinned", "Games angeheftet"), so a bare prefix match still
+    // claims unrelated apps whose name happens to start the same way
+    // ("Discord" for a folder named "D"). Require the match to end on a
+    // word boundary.
+    return name.size() == leaf.size() || !iswalnum(name[leaf.size()]);
 }
 
 // Empty when this label is not one of ours, or when it is ambiguous between
@@ -1670,7 +1691,8 @@ void Reconcile() {
     // full ReadPinnedItems()/ReadPinnedAppIds() COM round-trips per pass.
     // Re-read only after something that can actually change what is pinned
     // (the unpin/pin loops further down).
-    std::vector<PinnedItem> initialPinnedItems = ReadPinnedItems();
+    bool pinnedItemsOk = true;
+    std::vector<PinnedItem> initialPinnedItems = ReadPinnedItems(&pinnedItemsOk);
     std::vector<std::wstring> initialPinnedAppIds;
     initialPinnedAppIds.reserve(initialPinnedItems.size());
     for (const auto& item : initialPinnedItems) {
@@ -1733,7 +1755,11 @@ void Reconcile() {
             // the only evidence that the user unpinned it. Demote it to a draft
             // rather than re-pinning: re-pinning would make native Unpin look
             // broken, and the entry keeps its name and icon either way.
-            if (entry.pinApplied && !Contains(live, AppIdFor(entry.pinId))) {
+            // Only trust this when the read itself succeeded — a failed read
+            // to resolve/list the pinned-items folder also comes back empty,
+            // and treating that the same way would demote every entry at once.
+            if (pinnedItemsOk && entry.pinApplied &&
+                !Contains(live, AppIdFor(entry.pinId))) {
                 Wh_Log(L"Pins: '%s' was unpinned from the taskbar, keeping it "
                        L"as a draft",
                        entry.name.c_str());
@@ -2388,8 +2414,15 @@ void RemovePinnedFolder(const std::wstring& path) {
     Wh_Log(L"Unpinned '%s' (kept as a draft)", path.c_str());
 }
 
+// Seeded from the setting's on-disk value at Wh_ModInit (LoadSettings runs
+// there first), not lazily on first Wh_ModSettingsChanged call — that call
+// only fires after a change, so a lazy static would initialize itself from
+// the value the user just ticked and miss that very rising edge.
+bool g_lastOpenManager = false;
+
 void LoadSettings() {
     LoadFolders(&g_settings.folders);
+    g_lastOpenManager = Wh_GetIntSetting(L"behavior.openManager") != 0;
 
     // "type" was the old folders-first option, which is now unconditional.
     std::wstring sortBy = GetStringSetting(L"content.sortBy");
@@ -6100,8 +6133,13 @@ LRESULT CALLBACK PopupWndProc(HWND hWnd,
             if (cell >= 0 && cell < (int)level->items.size()) {
                 POINT screenPt = pt;
                 ClientToScreen(hWnd, &screenPt);
-                ShowItemContextMenu(std::wstring(level->items[cell].fullPath),
-                                    screenPt);
+                const GridItem& item = level->items[cell];
+                // iconPath holds the .lnk when fullPath was replaced by its
+                // resolved folder target; the menu must act on what the user
+                // actually sees in the cell.
+                const std::wstring& menuPath =
+                    item.iconPath.empty() ? item.fullPath : item.iconPath;
+                ShowItemContextMenu(menuPath, screenPt);
             }
             return 0;
         }
@@ -8081,8 +8119,9 @@ void RemoveSelected(HWND hWnd) {
 // WriteJumpList put in place. Shared by the user-facing "Remove all folder
 // buttons" action (clearStore = true, wipes the folder list too) and the
 // automatic cleanup Wh_ModUninit runs on every disable/uninstall
-// (clearStore = false, folders survive as unpinned drafts so a later
-// re-enable can re-pin them without retyping anything).
+// (clearStore = false, folders keep their pinned=true intent — only
+// pinApplied is cleared — so the next Reconcile() this mod runs, whether
+// from a real re-enable or a code-update reload, silently re-pins them).
 //
 // CoInitializeEx is refcounted per thread, so this is safe to call whether or
 // not the calling thread already has COM up (Wh_ModUninit's does not).
@@ -8128,7 +8167,10 @@ void RemoveAllFolderButtonsCore(bool clearStore) {
     } else {
         auto stored = FolderStore::Read();
         for (auto& entry : stored) {
-            entry.pinned = false;
+            // Not entry.pinned: that is the user's intent and must survive
+            // this pass so a later Reconcile() re-pins automatically.
+            // pinApplied is state, and now false is the truth.
+            entry.pinApplied = false;
         }
         FolderStore::Write(stored);
     }
@@ -8151,10 +8193,13 @@ void RemoveAllFolderButtons(HWND hWnd) {
 
 // Windhawk's core principle is that disabling a mod puts the system back the
 // way it was. Called from Wh_ModUninit, which fires on every disable and
-// every uninstall alike (Windhawk does not distinguish the two) — so the
-// real taskbar pins, their Start Menu shortcuts and their jump lists never
-// outlive the mod being off. The folder list itself is kept, marked unpinned,
-// so turning the mod back on does not lose it.
+// every uninstall alike (Windhawk does not distinguish the two, and neither
+// does it distinguish a real disable from the reload after a code-update
+// save) — so the real taskbar pins, their Start Menu shortcuts and their
+// jump lists never outlive this pass. The folder list itself keeps its
+// pinned intent, so the next Reconcile() (from a real re-enable, or from
+// the Wh_ModInit that follows an update reload moments later) puts
+// everything straight back without the user re-adding anything.
 void UnpinAllForDisable() {
     RemoveAllFolderButtonsCore(/*clearStore=*/false);
 }
@@ -9873,15 +9918,15 @@ BOOL Wh_ModSettingsChanged(BOOL* bReload) {
 
     // A checkbox-as-link: openManager has no persisted meaning of its own, it
     // is just the closest thing Windhawk's settings page has to a button.
-    // Every rising edge (false -> true, including a fresh unchecked ->
-    // checked as this reads it here) opens the manager; the box is left
-    // however the user leaves it.
-    static bool lastOpenManager = Wh_GetIntSetting(L"behavior.openManager") != 0;
+    // Every rising edge (false -> true) opens the manager; the box is left
+    // however the user leaves it. g_lastOpenManager is seeded in
+    // LoadSettings() at Wh_ModInit, not lazily here, so the very first tick
+    // after a mod (re)load is itself seen as a rising edge.
     bool openManager = Wh_GetIntSetting(L"behavior.openManager") != 0;
-    if (openManager && !lastOpenManager) {
+    if (openManager && !g_lastOpenManager) {
         FolderManager::Open();
     }
-    lastOpenManager = openManager;
+    g_lastOpenManager = openManager;
 
     RequestReloadUI();
 
@@ -9900,11 +9945,12 @@ void Wh_ModUninit() {
     // Disabling (or uninstalling — Wh_ModUninit does not see a difference)
     // must leave the system as it was: real taskbar pins, Start Menu
     // shortcuts and jump lists this mod created do not get to outlive it.
-    // Runs before Pins::Stop() below, while its COM-using helpers are still
-    // safe to call.
-    FolderManager::UnpinAllForDisable();
-    // Joins its STA worker.
+    // Stop and join the reconcile worker first: it can be mid-Reconcile()
+    // (pinned-dir watch, Taskband watch, or the periodic poll — the unpins
+    // below even fire the dir watch) and would otherwise re-create pins and
+    // Start Menu shortcuts the sweep below just removed.
     Pins::Stop();
+    FolderManager::UnpinAllForDisable();
 
     // DestroyWindow / XAML teardown must run on the creating UI thread. Prefer
     // a mod-owned window (level popup or menu owner) when the taskbar HWND is

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -136,9 +136,6 @@ source of truth, edits apply instantly, and nothing ever asks for elevation.
 The trade-off is that it needs its own window instead of riding along on the
 settings page Windhawk already draws — hence **Taskbar Folders**.
 
-Folders you had configured on the settings page before this change are imported
-into it automatically the first time this version runs; nothing is lost.
-
 ## How it is positioned
 
 The Windows 11 taskbar app strip is a WinUI `ItemsRepeater` that refuses to lay out
@@ -209,9 +206,8 @@ Choose **this mod** for a hover-opened icon grid seated in the app icon strip.
     to pin a folder straight to the taskbar, or to move, copy or make a
     shortcut into a folder that already has a button. Turn this off to keep
     the mod entirely on the taskbar side — with it off, Explorer's own context
-    menus are left completely alone. Switching it back on takes effect after
-    the mod is reloaded (toggle the mod off and on, or restart Explorer),
-    because the menu hook is only installed at startup.
+    menus are left completely alone. Changing this setting reloads the mod,
+    because the menu hook can only be installed or removed at startup.
 
 - position: beforeApps
   $name: 1. Behavior ▸ Position
@@ -500,6 +496,11 @@ std::mutex g_foldersMutex;
 
 std::atomic<bool> g_unloading{false};
 
+// Value of the explorerMenu setting this load was built around: the
+// TrackPopupMenuEx hook is installed (or not) once, in Wh_ModInit.
+// Wh_ModSettingsChanged compares against it to know when a reload is needed.
+bool g_explorerMenuHooked = false;
+
 ////////////////////////////////////////////////////////////////////////////////
 // Small helpers
 
@@ -511,6 +512,44 @@ HINSTANCE GetCurrentModuleHandle() {
                           GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                       (LPCWSTR)&GetCurrentModuleHandle, &hInst);
     return hInst;
+}
+
+// Registers one of the mod's window classes against the current DLL.
+//
+// Recompiling the mod unloads this DLL and loads a new copy, but a window
+// class registered by the old one survives in the process with its
+// lpfnWndProc still pointing at the freed image. Reusing it — which is what
+// treating ERROR_CLASS_ALREADY_EXISTS as success amounts to — hands
+// CreateWindowEx a dangling procedure and takes Explorer down with the first
+// message. So a stale registration is torn down and replaced rather than
+// adopted. Wh_ModUninit unregisters the classes for the same reason; this is
+// the belt to that pair of braces, since an Explorer crash (or any unclean
+// unload) skips the tidy path.
+bool RegisterModClass(const WNDCLASSEXW& wc) {
+    if (RegisterClassExW(&wc)) {
+        return true;
+    }
+    if (GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
+        Wh_Log(L"RegisterClassExW('%s') failed (error %u)", wc.lpszClassName,
+               GetLastError());
+        return false;
+    }
+
+    // Left behind by an earlier load of this mod. Unregistering fails while
+    // any window of the class still exists, and there should be none.
+    if (!UnregisterClassW(wc.lpszClassName, wc.hInstance)) {
+        Wh_Log(L"stale class '%s' could not be unregistered (error %u)",
+               wc.lpszClassName, GetLastError());
+        return false;
+    }
+    if (!RegisterClassExW(&wc)) {
+        Wh_Log(L"re-registering '%s' failed (error %u)", wc.lpszClassName,
+               GetLastError());
+        return false;
+    }
+    Wh_Log(L"replaced a stale '%s' class from a previous load",
+           wc.lpszClassName);
+    return true;
 }
 
 std::wstring ResolveFolderPath(const std::wstring& raw);
@@ -783,83 +822,6 @@ int IndexOfPath(const std::vector<Entry>& entries, const std::wstring& path) {
         }
     }
     return -1;
-}
-
-// One-time import of the two pre-manager lists: folders configured in the
-// Windhawk settings UI, and folders pinned into the old `pinned[]` storage.
-// Settings rows the user had "unpinned" (the old hidden[] list) come across as
-// drafts rather than vanishing.
-void MigrateLegacy() {
-    // Held across the whole read-modify-write, like every other store mutation.
-    std::lock_guard<std::recursive_mutex> lock(g_mutex);
-    if (Wh_GetIntValue(L"storeVersion", 0) >= 2) {
-        return;
-    }
-
-    std::vector<std::wstring> hidden;
-    int hiddenCount = Wh_GetIntValue(L"hiddenCount", 0);
-    for (int i = 0; i < hiddenCount; i++) {
-        std::wstring path = GetString(L"hidden[%d].path", i);
-        if (!path.empty()) {
-            hidden.push_back(path);
-        }
-    }
-
-    std::vector<Entry> entries = Read();
-
-    for (int i = 0; i < 64; i++) {
-        auto rawPath =
-            WindhawkUtils::StringSetting::make(L"folders[%d].path", i);
-        std::wstring path = Trim(std::wstring(rawPath.get()));
-        if (path.empty()) {
-            continue;
-        }
-        auto rawName =
-            WindhawkUtils::StringSetting::make(L"folders[%d].name", i);
-        auto rawIcon =
-            WindhawkUtils::StringSetting::make(L"folders[%d].icon", i);
-
-        Entry entry;
-        entry.path = ExpandEnv(path);
-        entry.name = Trim(std::wstring(rawName.get()));
-        entry.icon = Trim(std::wstring(rawIcon.get()));
-        entry.fileId = GetDirFileId(entry.path);
-        entry.pinned = true;
-        for (const auto& h : hidden) {
-            if (_wcsicmp(h.c_str(), entry.path.c_str()) == 0) {
-                entry.pinned = false;  // Was unpinned before; keep as a draft.
-                break;
-            }
-        }
-        if (IndexOfPath(entries, entry.path) < 0) {
-            entries.push_back(std::move(entry));
-        }
-    }
-
-    int pinnedCount = Wh_GetIntValue(L"pinnedCount", 0);
-    for (int i = 0; i < pinnedCount; i++) {
-        Entry entry;
-        entry.path = GetString(L"pinned[%d].path", i);
-        if (entry.path.empty()) {
-            continue;
-        }
-        entry.name = GetString(L"pinned[%d].name", i);
-        entry.icon = GetString(L"pinned[%d].icon", i);
-        std::wstring id = GetString(L"pinned[%d].id", i);
-        entry.fileId = id.empty() ? GetDirFileId(entry.path)
-                                  : wcstoull(id.c_str(), nullptr, 16);
-        entry.pinned = true;
-        if (IndexOfPath(entries, entry.path) < 0) {
-            entries.push_back(std::move(entry));
-        }
-    }
-
-    Write(entries);
-    Wh_SetIntValue(L"storeVersion", 2);
-    Wh_Log(L"Migrated %zu folder(s) into the manager store", entries.size());
-
-    // The legacy keys are left in place on purpose: downgrading to an older
-    // build of the mod should still find its folders.
 }
 
 }  // namespace FolderStore
@@ -4238,10 +4200,12 @@ LRESULT CALLBACK PopupWndProc(HWND hWnd,
 }
 
 bool EnsurePopupClasses() {
-    enum class ClassState { Untried, Ok, Failed };
-    static ClassState classState = ClassState::Untried;
-    if (classState != ClassState::Untried) {
-        return classState == ClassState::Ok;
+    // Only success is cached. A failure is not latched: it can come from a
+    // class a previous load left registered behind windows that outlived it,
+    // and latching would disable every hover grid for the rest of the session.
+    static bool registered = false;
+    if (registered) {
+        return true;
     }
 
     HINSTANCE instance = GetCurrentModuleHandle();
@@ -4251,29 +4215,19 @@ bool EnsurePopupClasses() {
     popupClass.hInstance = instance;
     popupClass.hCursor = LoadCursor(nullptr, IDC_ARROW);
     popupClass.lpszClassName = kPopupClassName;
-    ATOM popupAtom = RegisterClassExW(&popupClass);
 
     WNDCLASSEXW ownerClass{};
     ownerClass.cbSize = sizeof(ownerClass);
     ownerClass.lpfnWndProc = MenuOwnerWndProc;
     ownerClass.hInstance = instance;
     ownerClass.lpszClassName = kMenuOwnerClassName;
-    ATOM ownerAtom = RegisterClassExW(&ownerClass);
 
-    if (!popupAtom || !ownerAtom) {
-        Wh_Log(L"RegisterClassExW failed (error %u); hover grids disabled",
-               GetLastError());
-        if (popupAtom) {
-            UnregisterClassW(kPopupClassName, instance);
-        }
-        if (ownerAtom) {
-            UnregisterClassW(kMenuOwnerClassName, instance);
-        }
-        classState = ClassState::Failed;
+    if (!RegisterModClass(popupClass) || !RegisterModClass(ownerClass)) {
+        Wh_Log(L"hover grid classes unavailable; hover grids disabled");
         return false;
     }
 
-    classState = ClassState::Ok;
+    registered = true;
     return true;
 }
 
@@ -5580,50 +5534,16 @@ std::vector<FolderStore::Entry> g_rows;
 std::vector<HICON> g_rowIcons;
 
 // Registers one of the manager's window classes against the current DLL.
-//
-// Recompiling the mod unloads this DLL and loads a new copy, but a window
-// class registered by the old one survives in the process with its
-// lpfnWndProc still pointing at the freed image. Reusing it — which is what
-// treating ERROR_CLASS_ALREADY_EXISTS as success amounts to — hands
-// CreateWindowEx a dangling procedure and takes Explorer down with the first
-// message. So a stale registration is torn down and replaced rather than
-// adopted. Wh_ModUninit unregisters both classes for the same reason; this is
-// the belt to that pair of braces, since an Explorer crash (or any unclean
-// unload) skips the tidy path.
+// RegisterModClass handles a stale registration left by a previous load.
 bool EnsureClass(PCWSTR name, WNDPROC proc) {
-    HINSTANCE instance = GetCurrentModuleHandle();
     WNDCLASSEXW wc{};
     wc.cbSize = sizeof(wc);
     wc.lpfnWndProc = proc;
-    wc.hInstance = instance;
+    wc.hInstance = GetCurrentModuleHandle();
     wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
     wc.hbrBackground = (HBRUSH)(COLOR_BTNFACE + 1);
     wc.lpszClassName = name;
-
-    if (RegisterClassExW(&wc)) {
-        return true;
-    }
-    if (GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
-        Wh_Log(L"Manager: RegisterClassExW('%s') failed (error %u)", name,
-               GetLastError());
-        return false;
-    }
-
-    // Left behind by an earlier load of this mod. Unregistering fails while
-    // any window of the class still exists, and there should be none.
-    if (!UnregisterClassW(name, instance)) {
-        Wh_Log(L"Manager: stale class '%s' could not be unregistered "
-               L"(error %u)",
-               name, GetLastError());
-        return false;
-    }
-    if (!RegisterClassExW(&wc)) {
-        Wh_Log(L"Manager: re-registering '%s' failed (error %u)", name,
-               GetLastError());
-        return false;
-    }
-    Wh_Log(L"Manager: replaced a stale '%s' class from a previous load", name);
-    return true;
+    return RegisterModClass(wc);
 }
 
 // Top-left corner that centres a width x height window on the monitor
@@ -8167,9 +8087,6 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
 BOOL Wh_ModInit() {
     Wh_Log(L"Init");
 
-    // Brings folders across from the two pre-manager lists (the old Settings
-    // array and the old pinned[] storage) the first time this build runs.
-    FolderStore::MigrateLegacy();
     LoadSettings();
     ResetFolderData();
 
@@ -8191,8 +8108,13 @@ BOOL Wh_ModInit() {
     // Only when the Explorer integration is on: with it off, every context
     // menu in the process stays entirely untouched by this mod, so nothing in
     // the menu path can affect Explorer at all. Windhawk has no way to remove
-    // a function hook without reloading, so turning the setting back on takes
-    // effect on the next load — which is what its description says.
+    // a function hook without reloading, so Wh_ModSettingsChanged asks for a
+    // reload when the setting stops matching what was installed here.
+    //
+    // Tracks the setting as of this load, not whether the hook took: a failed
+    // hook would not be fixed by reloading, and asking for one on every save
+    // would just churn.
+    g_explorerMenuHooked = g_settings.explorerMenu;
     if (!g_settings.explorerMenu) {
         Wh_Log(L"Explorer right-click integration is off; not hooking "
                L"TrackPopupMenuEx");
@@ -8263,19 +8185,31 @@ void ReloadAndRefreshUI() {
     }
 }
 
-void Wh_ModSettingsChanged() {
+BOOL Wh_ModSettingsChanged(BOOL* bReload) {
     Wh_Log(L"SettingsChanged");
-    RequestReloadUI();
+
+    // The TrackPopupMenuEx hook can only be installed or removed at load time,
+    // so toggling the Explorer integration asks Windhawk for a reload instead
+    // of leaving the new value to take effect at some unrelated later point.
+    // The UI is rebuilt by the reload, so RequestReloadUI would be redundant.
+    bool reload = (Wh_GetIntSetting(L"explorerMenu") != 0) != g_explorerMenuHooked;
+    if (reload) {
+        *bReload = TRUE;
+    } else {
+        RequestReloadUI();
+    }
 
     // "Open the folder manager" acts as a button: it fires when switched on,
     // and switching it off again is a no-op. Windhawk's settings schema has no
     // button widget, and a mod cannot clear the flag itself, so the previous
-    // value is tracked here to catch the off -> on edge only.
+    // value is tracked here to catch the off -> on edge only. Tracked even on
+    // the reload path, so the edge is not replayed after the reload.
     int manage = Wh_GetIntSetting(L"manageFolders");
-    if (manage && !Wh_GetIntValue(L"manageFoldersPrev", 0)) {
+    if (manage && !Wh_GetIntValue(L"manageFoldersPrev", 0) && !reload) {
         FolderManager::Open();
     }
     Wh_SetIntValue(L"manageFoldersPrev", manage);
+    return TRUE;
 }
 
 void Wh_ModUninit() {

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -200,14 +200,19 @@ Menu shortcut — and it disappears with the shortcuts when the mod is disabled.
 their Start Menu shortcuts and their jump lists, so nothing it put on the taskbar
 or in your Start Menu is left behind.
 
-**The folder list survives.** Windhawk runs the same unload path for a real
-disable, for a mod update, for a settings-page save and for an engine restart,
-and cannot tell them apart, so wiping the list there would mean an update
-silently deleted your folders. Instead the entries are kept and re-pinned the
-next time the mod loads. Uninstalling drops them too — Windhawk deletes a mod's
-storage itself when the mod is removed — and **Remove all folder buttons...** in
-the Taskbar Folders window is the explicit, confirmed way to forget everything
-without uninstalling.
+**The folder list survives a mod update, a settings-page save and an engine
+restart** — Windhawk runs the same unload path for all of those as for a real
+disable, and cannot tell them apart from inside the mod, so wiping the list on
+every one of them would mean an update silently deleted your folders. Instead
+the entries are kept and re-pinned the next time the mod loads, *unless* the
+version the mod loads with is the same one it last loaded with — which is the
+one case that isn't an update, and means a real disable/enable happened. That
+case wipes the folder list too, so disabling and re-enabling the mod resets it
+completely, the same as a fresh install. Uninstalling drops the list either
+way — Windhawk deletes a mod's storage itself when the mod is removed — and
+**Remove all folder buttons...** in the Taskbar Folders window is the
+explicit, confirmed way to forget everything without disabling or
+uninstalling.
 
 While the mod is disabled, nothing of it runs, so nothing is left running or
 hooked; while it is *enabled*, the pins and shortcuts above are live. Note that
@@ -1035,6 +1040,30 @@ int IndexOfPath(const std::vector<Entry>& entries, const std::wstring& path) {
         }
     }
     return -1;
+}
+
+// Bump this alongside the `@version` line in the metadata block at the top of
+// the file. It is the only signal Wh_ModInit has for telling a real
+// disable/enable cycle apart from a mod update: Windhawk calls Wh_ModUninit
+// then Wh_ModInit for both, and for an engine restart, with nothing in the
+// callbacks themselves saying which happened — see the reset note in
+// Wh_ModInit.
+constexpr PCWSTR kVersionMarker = L"2.0";
+
+// True the first time this is called after a real disable/enable — i.e. the
+// version marker stored last time this mod loaded still reads the same as
+// this build's, so nothing about this load came from installing a new
+// version. False on a fresh install (no marker stored yet) or a genuine
+// update (the marker changed), which both must leave the folder list alone.
+//
+// Always rewrites the marker to the current version, so this can only be
+// called once per load — Wh_ModInit is the only caller.
+bool ConsumeVersionResetSignal() {
+    WCHAR buf[64]{};
+    Wh_GetStringValue(L"versionMarker", buf, ARRAYSIZE(buf));
+    bool sameVersion = wcscmp(buf, kVersionMarker) == 0;
+    Wh_SetStringValue(L"versionMarker", kVersionMarker);
+    return sameVersion;
 }
 
 }  // namespace FolderStore
@@ -2100,6 +2129,11 @@ HANDLE g_thread = nullptr;
 HANDLE g_stopEvent = nullptr;  // manual-reset
 HANDLE g_kickEvent = nullptr;  // auto-reset
 
+// Guards g_thread/g_stopEvent/g_kickEvent so RequestReconcile (reached from
+// LoadFolders on the taskbar UI thread at the end of every reload) cannot
+// SetEvent a handle that Stop() is in the middle of closing.
+std::mutex g_mutex;
+
 // Set by Stop() before it signals g_stopEvent, run by ThreadProc itself right
 // before it uninitializes COM and exits. This is a known-good STA — the pin
 // verb's COM class is ThreadingModel=Apartment with no marshaler, so cleanup
@@ -2256,14 +2290,18 @@ DWORD WINAPI ThreadProc(void*) {
 }
 
 void RequestReconcile() {
+    std::lock_guard<std::mutex> lock(g_mutex);
     if (g_kickEvent) {
         SetEvent(g_kickEvent);
     }
 }
 
 void Start() {
+    std::lock_guard<std::mutex> lock(g_mutex);
     if (g_thread) {
-        RequestReconcile();
+        if (g_kickEvent) {
+            SetEvent(g_kickEvent);
+        }
         return;
     }
     g_stopEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
@@ -2273,39 +2311,50 @@ void Start() {
     }
     g_thread = CreateThread(nullptr, 0, ThreadProc, nullptr, 0, nullptr);
     if (g_thread) {
-        RequestReconcile();
+        SetEvent(g_kickEvent);
     }
 }
 
 // finalAction, if given, runs on the worker's own STA right before it
 // uninitializes COM and exits — see g_finalAction above.
 void Stop(std::function<void()> finalAction = nullptr) {
-    if (finalAction) {
-        if (g_thread) {
-            g_finalAction = std::move(finalAction);
-        } else {
-            // Worker never started this session (Start() failed, or was never
-            // called) — nowhere else to run it, so run it here directly.
-            finalAction();
+    HANDLE thread;
+    HANDLE stopEvent;
+    HANDLE kickEvent;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        if (finalAction) {
+            if (g_thread) {
+                g_finalAction = std::move(finalAction);
+            } else {
+                // Worker never started this session (Start() failed, or was
+                // never called) — nowhere else to run it, run it here.
+                finalAction();
+            }
         }
+        if (g_stopEvent) {
+            SetEvent(g_stopEvent);
+        }
+        // Move globals out under the lock so RequestReconcile/Start cannot
+        // SetEvent or touch a handle we are about to close.
+        thread = g_thread;
+        g_thread = nullptr;
+        stopEvent = g_stopEvent;
+        g_stopEvent = nullptr;
+        kickEvent = g_kickEvent;
+        g_kickEvent = nullptr;
     }
-    if (g_stopEvent) {
-        SetEvent(g_stopEvent);
-    }
-    if (g_thread) {
+    if (thread) {
         // Joined, not abandoned: the worker's return address is in this image,
         // and Windhawk unmaps it as soon as uninit returns.
-        WaitForSingleObject(g_thread, INFINITE);
-        CloseHandle(g_thread);
-        g_thread = nullptr;
+        WaitForSingleObject(thread, INFINITE);
+        CloseHandle(thread);
     }
-    if (g_stopEvent) {
-        CloseHandle(g_stopEvent);
-        g_stopEvent = nullptr;
+    if (stopEvent) {
+        CloseHandle(stopEvent);
     }
-    if (g_kickEvent) {
-        CloseHandle(g_kickEvent);
-        g_kickEvent = nullptr;
+    if (kickEvent) {
+        CloseHandle(kickEvent);
     }
 }
 
@@ -6759,9 +6808,13 @@ void OnPointerEnteredButton(int folderIndex,
 // copies the shortcut, so a pinned item keeps the name it had when it was
 // pinned even after the source is renamed, and the two drift apart.
 //
-// The label is still the only handle XAML gives us on a taskbar button without
-// hooking the shell's group type, but going through the pinned copy means the
-// comparison is against what is really there rather than what should be.
+// The label is a prefix match against the announced (localized) accessible
+// name, which an unrelated pinned app's title can also satisfy ("Work" against
+// "Work Chat - 1 running window"). TaskListButtonIsPin below closes that gap by
+// bridging the XAML button to its real native ITaskGroup and checking the
+// AppID the shell actually put there — see "XAML button -> native ITaskGroup
+// bridge" further down — falling back to the label match alone only when that
+// bridge is unavailable.
 
 std::wstring AutomationNameOf(FrameworkElement const& element) {
     try {
@@ -6773,6 +6826,113 @@ std::wstring AutomationNameOf(FrameworkElement const& element) {
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// XAML button -> native ITaskGroup bridge
+//
+// The label match above can be fooled by an unrelated pinned app whose
+// announced name happens to start with a folder's leaf on a word boundary
+// ("Work" matching "Work Chat - 1 running window"), because the accessible
+// name is the only handle XAML gives a Taskbar.TaskListButton directly. The
+// click path (CTaskListWnd__HandleClick_Hook) does not have this problem: it
+// already compares CTaskGroup::GetAppID() against Pins::IsOurAppId on the
+// native ITaskGroup it gets from the click. GetTaskGroupFromTaskListButton
+// gets that same native pointer from the XAML side, so a label match can be
+// verified against the real AppID before hover is ever bound to it.
+//
+// Bridging works by asking the view model behind the container for its
+// ITaskItem, then calling ReportClicked with a sentinel LauncherOptions
+// pointer instead of a real one. ReportClicked's implementation runs down
+// into CTaskListWnd::HandleClick with that same pointer; the hook below
+// recognizes the sentinel, stashes the ITaskGroup it was called with, and
+// returns immediately without doing the real (launcher) work of a click.
+// Same technique the published "Taskbar Numberer" mod uses to tell same-app
+// windows apart.
+//
+// All of this is optional: every symbol here is resolved with `optional`, so
+// on a taskbar.dll build where one is missing, GetTaskGroupFromTaskListButton
+// just returns null and callers fall back to trusting the label match alone
+// — no worse than before this bridge existed.
+using TryGetItemFromContainer_TaskListWindowViewModel_t =
+    void*(WINAPI*)(void** output, UIElement const* container);
+TryGetItemFromContainer_TaskListWindowViewModel_t
+    TryGetItemFromContainer_TaskListWindowViewModel_Original;
+
+using TaskListWindowViewModel_get_TaskItem_t = int(WINAPI*)(void* pThis,
+                                                             void** taskItem);
+TaskListWindowViewModel_get_TaskItem_t
+    TaskListWindowViewModel_get_TaskItem_Original;
+
+using TaskItem_ReportClicked_t = int(WINAPI*)(void* pThis, void* param);
+TaskItem_ReportClicked_t TaskItem_ReportClicked_Original;
+
+using CTaskListWnd_HandleClick_t = HRESULT(WINAPI*)(void* pThis,
+                                                     void* taskGroup,
+                                                     void* taskItem,
+                                                     void** launcherOptions);
+CTaskListWnd_HandleClick_t CTaskListWnd_HandleClick_Original;
+
+using CTaskGroup_GetAppID_t = PCWSTR(WINAPI*)(void* pThis);
+CTaskGroup_GetAppID_t CTaskGroup_GetAppID_Original;
+
+// Address-of is the sentinel itself; the content never matters.
+WCHAR g_clickSentinel[] = L"pins-click-sentinel";
+void* g_clickSentinel_TaskGroup = nullptr;
+
+HRESULT WINAPI CTaskListWnd_HandleClick_Hook(void* pThis,
+                                             void* taskGroup,
+                                             void* taskItem,
+                                             void** launcherOptions) {
+    if (launcherOptions && *launcherOptions == &g_clickSentinel) {
+        g_clickSentinel_TaskGroup = taskGroup;
+        return S_OK;
+    }
+    return CTaskListWnd_HandleClick_Original(pThis, taskGroup, taskItem,
+                                             launcherOptions);
+}
+
+// Null if the bridge is unavailable (missing symbol) or this button's
+// container has no task item behind it yet.
+void* GetTaskGroupFromTaskListButton(UIElement const& element) {
+    if (!TryGetItemFromContainer_TaskListWindowViewModel_Original ||
+        !TaskListWindowViewModel_get_TaskItem_Original ||
+        !TaskItem_ReportClicked_Original || !CTaskListWnd_HandleClick_Original) {
+        return nullptr;
+    }
+
+    winrt::com_ptr<IUnknown> windowViewModel;
+    TryGetItemFromContainer_TaskListWindowViewModel_Original(
+        windowViewModel.put_void(), &element);
+    if (!windowViewModel) {
+        return nullptr;
+    }
+
+    winrt::com_ptr<IUnknown> taskItem;
+    TaskListWindowViewModel_get_TaskItem_Original(windowViewModel.get(),
+                                                  taskItem.put_void());
+    if (!taskItem) {
+        return nullptr;
+    }
+
+    g_clickSentinel_TaskGroup = nullptr;
+    void* sentinel = &g_clickSentinel;
+    TaskItem_ReportClicked_Original(taskItem.get(), &sentinel);
+    return g_clickSentinel_TaskGroup;
+}
+
+// True only once verified against the real ITaskGroup's AppID — never trusts
+// the label match alone when the bridge above is available.
+bool TaskListButtonIsPin(FrameworkElement const& button,
+                        const std::wstring& pinId) {
+    void* taskGroup = GetTaskGroupFromTaskListButton(button);
+    if (!taskGroup || !CTaskGroup_GetAppID_Original) {
+        // Bridge unavailable on this build — nothing to verify against, so
+        // fall back to trusting the label match that got us here.
+        return true;
+    }
+    PCWSTR appId = CTaskGroup_GetAppID_Original(taskGroup);
+    return appId && Pins::AppIdFor(pinId) == appId;
+}
+
 // -1 when this button is not one of ours.
 int FolderIndexForTaskListButton(FrameworkElement const& button) {
     std::wstring label = AutomationNameOf(button);
@@ -6781,6 +6941,12 @@ int FolderIndexForTaskListButton(FrameworkElement const& button) {
     }
     std::wstring pinId = Pins::PinIdForLabel(label);
     if (pinId.empty()) {
+        return -1;
+    }
+    if (!TaskListButtonIsPin(button, pinId)) {
+        Wh_Log(L"Pins: '%s' label-matches pin %s but its real AppID says "
+               L"otherwise; leaving it unbound",
+               label.c_str(), pinId.c_str());
         return -1;
     }
     std::lock_guard<std::mutex> lock(g_foldersMutex);
@@ -8224,8 +8390,11 @@ void RemoveSelected(HWND hWnd) {
 // clearStore separates the two callers. The user-facing action means "forget
 // everything" and empties the folder list. The unload path must not: Windhawk
 // routes a mod update, a settings-page save and an engine restart through the
-// same Wh_ModUninit as a real disable, and wiping the list there would delete
-// the user's configuration every time the mod is updated. Windhawk removes the
+// same Wh_ModUninit as a real disable, and wiping the list here would delete
+// the user's configuration every time the mod is updated. (A real disable
+// followed by re-enable does still wipe the list — that happens separately,
+// from Wh_ModInit's version-marker check, once it is clear no update was
+// involved; see FolderStore::ConsumeVersionResetSignal.) Windhawk removes the
 // mod's storage itself when the mod is uninstalled, so the unload path only has
 // to undo what it put outside that storage.
 //
@@ -8325,13 +8494,15 @@ void RemoveAllFolderButtons(HWND hWnd) {
 // its own storage goes: the real taskbar pins, their Start Menu shortcuts and
 // their jump lists.
 //
-// The folder list itself stays. It is the user's configuration, it lives in the
-// mod's private Windhawk storage (which Windhawk deletes on its own when the mod
-// is uninstalled), and it is the one thing here that cannot be reconstructed.
-// Wiping it on every unload would mean publishing an update silently deleted
-// every user's folders. A re-enable therefore re-pins what was configured, and
-// "Remove all folder buttons..." in the manager stays the explicit, confirmed
-// way to forget everything.
+// The folder list itself stays here — clearStore is always false on this path.
+// It is the user's configuration, it lives in the mod's private Windhawk
+// storage (which Windhawk deletes on its own when the mod is uninstalled), and
+// wiping it on every unload would mean publishing an update silently deleted
+// every user's folders. A re-enable therefore re-pins what was configured...
+// unless Wh_ModInit's version-marker check finds this load was not an update,
+// in which case it wipes the list right after this sweep runs. "Remove all
+// folder buttons..." in the manager stays the explicit, confirmed way to
+// forget everything without waiting on a disable/enable cycle.
 void UnpinAllForDisable() {
     RemoveAllFolderButtonsCore(/*clearStore=*/false);
 }
@@ -9152,8 +9323,9 @@ void WINAPI TrayUI_StartTaskbar_Hook(void* pThis) {
 using CTaskBtnGroup_GetGroup_t = void*(WINAPI*)(void* pThis);
 CTaskBtnGroup_GetGroup_t CTaskBtnGroup_GetGroup_Original;
 
-using CTaskGroup_GetAppID_t = PCWSTR(WINAPI*)(void* pThis);
-CTaskGroup_GetAppID_t CTaskGroup_GetAppID_Original;
+// CTaskGroup_GetAppID_t / CTaskGroup_GetAppID_Original are declared earlier,
+// next to GetTaskGroupFromTaskListButton, which needs them in scope before
+// this point in the file.
 
 using CTaskListWnd__HandleClick_t = void(WINAPI*)(void* pThis,
                                                  void* taskBtnGroup,
@@ -9342,10 +9514,59 @@ bool HookTaskbarDllSymbols() {
             CTaskListWnd__OnJumpViewShown_Hook,
             true,  // optional
         },
+        {
+            {LR"(public: virtual long __cdecl CTaskListWnd::HandleClick(struct ITaskGroup *,struct ITaskItem *,struct winrt::Windows::System::LauncherOptions const &))"},
+            &CTaskListWnd_HandleClick_Original,
+            CTaskListWnd_HandleClick_Hook,
+            true,  // optional
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::WindowsUdk::UI::Shell::implementation::TaskItem,struct winrt::WindowsUdk::UI::Shell::ITaskItem>::ReportClicked(void *))"},
+            &TaskItem_ReportClicked_Original,
+            nullptr,
+            true,  // optional
+        },
     };
 
     return WindhawkUtils::HookSymbols(module, taskbarDllHooks,
                                       ARRAYSIZE(taskbarDllHooks));
+}
+
+// The two symbols GetTaskGroupFromTaskListButton needs to walk from a XAML
+// container to its view model live in the taskbar's own WinRT view assembly,
+// not in taskbar.dll — its module name has changed across Windows 11
+// releases, hence trying both. Optional like everything else in
+// HookTaskbarDllSymbols: on failure the bridge just stays unavailable and
+// label matches are trusted as-is, same as before it existed.
+bool HookTaskbarViewDllSymbols() {
+    HMODULE module = GetModuleHandle(L"Taskbar.View.dll");
+    if (!module) {
+        module = GetModuleHandle(L"ExplorerExtensions.dll");
+    }
+    if (!module) {
+        Wh_Log(L"Taskbar.View.dll/ExplorerExtensions.dll not loaded yet; "
+               L"the AppID verification bridge will be unavailable this "
+               L"session");
+        return false;
+    }
+
+    WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {
+        {
+            {LR"(struct winrt::Taskbar::TaskListWindowViewModel __cdecl TryGetItemFromContainer<struct winrt::Taskbar::TaskListWindowViewModel>(struct winrt::Windows::UI::Xaml::UIElement const &))"},
+            &TryGetItemFromContainer_TaskListWindowViewModel_Original,
+            nullptr,
+            true,  // optional
+        },
+        {
+            {LR"(public: virtual int __cdecl winrt::impl::produce<struct winrt::Taskbar::implementation::TaskListWindowViewModel,struct winrt::Taskbar::ITaskListWindowViewModel>::get_TaskItem(void * *))"},
+            &TaskListWindowViewModel_get_TaskItem_Original,
+            nullptr,
+            true,  // optional
+        },
+    };
+
+    return WindhawkUtils::HookSymbols(module, taskbarViewDllHooks,
+                                      ARRAYSIZE(taskbarViewDllHooks));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9429,6 +9650,24 @@ HWND FindShellViewWindow(HWND hwnd) {
         }
     }
     return nullptr;
+}
+
+// True if `defView` (from FindShellViewWindow) is the desktop's shell view
+// rather than a regular Explorer window's — the desktop's SHELLDLL_DefView
+// sits under Progman (or WorkerW, on setups where the desktop's icon layer
+// has been reparented there), while every other shell view sits under
+// CabinetWClass. This is what lets the background click below tell "empty
+// desktop, no item selected" apart from "empty space in a folder window,
+// no item selected" — only the former gets a menu.
+bool IsDesktopShellView(HWND defView) {
+    for (HWND h = defView; h; h = GetParent(h)) {
+        WCHAR cls[64]{};
+        GetClassNameW(h, cls, ARRAYSIZE(cls));
+        if (wcscmp(cls, L"Progman") == 0 || wcscmp(cls, L"WorkerW") == 0) {
+            return true;
+        }
+    }
+    return false;
 }
 
 // CWM_GETISHELLBROWSER. Undocumented, and WM_USER-relative, so it means
@@ -9650,21 +9889,39 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
     } com;
 
     std::wstring path = GetSelectedPath(defView);
-    // This runs on the Explorer browser thread with that window's context menu
-    // waiting on us to return, and Explorer's own QueryContextMenu work is
-    // already done — a GetFileAttributesW on an offline share would freeze the
-    // whole window for the network timeout purely to decide whether to add our
-    // item. Degrade to no submenu, same as everywhere else the mod meets a
-    // remote path.
-    if (path.empty() || IsLikelyRemotePath(path)) {
+    // No selection: normally nothing to hang a menu on, and every other empty-
+    // space right-click (a folder window's background) is left alone. The one
+    // exception is the desktop's own background — right-clicking it with
+    // nothing selected still gets a "Taskbar Folders" entry, just with nothing
+    // in it but "Manage folders...", since there is no item here to pin, move
+    // or copy.
+    bool desktopBackground = false;
+    if (path.empty()) {
+        if (!IsDesktopShellView(defView)) {
+            return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
+        }
+        desktopBackground = true;
+    } else if (IsLikelyRemotePath(path)) {
+        // This runs on the Explorer browser thread with that window's context
+        // menu waiting on us to return, and Explorer's own QueryContextMenu
+        // work is already done — a GetFileAttributesW on an offline share
+        // would freeze the whole window for the network timeout purely to
+        // decide whether to add our item. Degrade to no submenu, same as
+        // everywhere else the mod meets a remote path.
         return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
     }
-    DWORD attrs = GetFileAttributesW(path.c_str());
-    if (attrs == INVALID_FILE_ATTRIBUTES) {
-        return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
+
+    DWORD attrs = 0;
+    bool isLnk = false;
+    bool isDir = false;
+    if (!desktopBackground) {
+        attrs = GetFileAttributesW(path.c_str());
+        if (attrs == INVALID_FILE_ATTRIBUTES) {
+            return TrackPopupMenuEx_orig(hMenu, flags, x, y, hwnd, params);
+        }
+        isLnk = PathIsLnkFile(path);
+        isDir = (attrs & FILE_ATTRIBUTE_DIRECTORY) && !isLnk;
     }
-    bool isLnk = PathIsLnkFile(path);
-    bool isDir = (attrs & FILE_ATTRIBUTE_DIRECTORY) && !isLnk;
 
     std::vector<FolderEntry> folders;
     {
@@ -9688,8 +9945,8 @@ BOOL WINAPI TrackPopupMenuExHook(HMENU hMenu,
     // Pin / Move / Copy / Copy as shortcut.
     bool menuEnabled = g_settings.explorerMenu;
     bool canPin = menuEnabled && isDir && !IsPinnedTaskbarFolder(path);
-    bool showMoveCopy = menuEnabled && !isDir && n > 0;
-    bool showShortcut = menuEnabled && !isLnk && n > 0;
+    bool showMoveCopy = menuEnabled && !desktopBackground && !isDir && n > 0;
+    bool showShortcut = menuEnabled && !desktopBackground && !isLnk && n > 0;
 
     auto buildDestinationSubmenu = [&](PCWSTR header, UINT idBase) {
         HMENU sub = CreatePopupMenu();
@@ -9929,6 +10186,20 @@ BOOL Wh_ModInit() {
     // starting it late means a return FALSE below leaves no thread running in
     // an image Windhawk is about to unmap.
     LoadSettings();
+
+    // Same-version marker from the last load means nothing about this load
+    // came from installing a new version — the only remaining explanation
+    // Windhawk's callbacks leave room for is a real user disable/enable (an
+    // engine or Explorer restart with no update also looks like this, and
+    // gets swept the same way; there is no callback that tells those apart
+    // either). A version change, or no marker at all on a fresh install,
+    // means the folder list must survive. See FolderStore::kVersionMarker
+    // and the "What this writes" README section above.
+    if (FolderStore::ConsumeVersionResetSignal()) {
+        Wh_Log(L"Version marker unchanged since last load; wiping the "
+               L"folder list as a disable/enable reset");
+        FolderStore::Write({});
+    }
     ResetFolderData();
 
     Gdiplus::GdiplusStartupInput startupInput;
@@ -9951,6 +10222,17 @@ BOOL Wh_ModInit() {
         Wh_Log(L"Failed to hook taskbar.dll, the taskbar XamlRoot is "
                L"unreachable; hover will not bind, the folder buttons and the "
                L"manager still work");
+    }
+
+    // Best-effort only: by the time a taskbar mod loads, Explorer's taskbar
+    // XAML view is already up in virtually every real case, so this almost
+    // always succeeds here. If it doesn't (a very early injection), the
+    // AppID verification bridge just stays off for the session and folder
+    // buttons fall back to trusting the label match alone, same as before
+    // the bridge existed.
+    if (!HookTaskbarViewDllSymbols()) {
+        Wh_Log(L"AppID verification bridge unavailable; folder button "
+               L"matching falls back to the label heuristic alone");
     }
 
     Pins::Start();
@@ -10002,6 +10284,13 @@ void Wh_ModAfterInit() {
 // Tears down UI, reloads settings (+ pinned folders), and restarts. Shared by
 // Wh_ModSettingsChanged and the Explorer right-click "pin to taskbar" action.
 void ReloadAndRefreshUI() {
+    if (g_unloading) {
+        // A pin action's context menu can outlive uninit's wait for an
+        // in-flight reload (RequestReloadUI runs after the modal menu
+        // returns) — don't start a fresh one during teardown.
+        return;
+    }
+
     struct InFlightGuard {
         InFlightGuard() { g_reloadInFlight++; }
         ~InFlightGuard() { g_reloadInFlight--; }
@@ -10069,6 +10358,41 @@ void Wh_ModUninit() {
     FolderManager::CloseAndWait();
     StopRetryThread();
     StopScanThread();
+
+    // Every one of these waits is unbounded on purpose, for the reason
+    // FolderManager::CloseAndWait spells out: Wh_ModUninit runs on a Windhawk
+    // engine thread, not on any Explorer UI thread, so blocking here does not
+    // freeze the shell — while falling through early is exactly what unmaps the
+    // image with one of these frames still executing inside it. Cancellation is
+    // attempted for the first couple of seconds only; past that, whatever is
+    // still live is work that has to finish on its own (a folder copy can run
+    // for minutes) and re-asking every 20ms is pointless.
+    constexpr int kUninitWaitPollMs = 50;
+    constexpr int kUninitCancelForMs = 2000;
+    constexpr int kUninitLogEveryMs = 5000;
+    auto waitOut = [](PCWSTR what, auto stillLive, auto attemptCancel) {
+        for (int elapsedMs = 0; stillLive(); elapsedMs += kUninitWaitPollMs) {
+            if (elapsedMs < kUninitCancelForMs) {
+                attemptCancel();
+            } else if (elapsedMs % kUninitLogEveryMs == 0) {
+                Wh_Log(L"Uninit: still waiting on %s (%d s)", what,
+                       elapsedMs / 1000);
+            }
+            Sleep(kUninitWaitPollMs);
+        }
+    };
+
+    // Wait out any reload already in flight BEFORE Pins::Stop closes the
+    // worker's event handles: ReloadAndRefreshUI ends with
+    // Pins::RequestReconcile, which touches those handles from the taskbar UI
+    // thread with no synchronization of its own beyond what Pins now does
+    // internally — a reload that finished after the handles were closed could
+    // otherwise SetEvent a recycled, unrelated handle value in Explorer.
+    // Nothing to cancel, and it cannot restart a worker behind us:
+    // StartRetryThread bails on g_unloading, and ReloadAndRefreshUI now bails
+    // on g_unloading too.
+    waitOut(L"a UI reload", [] { return g_reloadInFlight.load() > 0; }, [] {});
+
     // Disabling (or uninstalling — Wh_ModUninit does not see a difference)
     // must leave the system as it was: real taskbar pins, Start Menu
     // shortcuts and jump lists this mod created do not get to outlive it.
@@ -10107,29 +10431,6 @@ void Wh_ModUninit() {
         g_taskbarHosts.reset();
     };
 
-    // Every one of these waits is unbounded on purpose, for the reason
-    // FolderManager::CloseAndWait spells out: Wh_ModUninit runs on a Windhawk
-    // engine thread, not on any Explorer UI thread, so blocking here does not
-    // freeze the shell — while falling through early is exactly what unmaps the
-    // image with one of these frames still executing inside it. Cancellation is
-    // attempted for the first couple of seconds only; past that, whatever is
-    // still live is work that has to finish on its own (a folder copy can run
-    // for minutes) and re-asking every 20ms is pointless.
-    constexpr int kUninitWaitPollMs = 50;
-    constexpr int kUninitCancelForMs = 2000;
-    constexpr int kUninitLogEveryMs = 5000;
-    auto waitOut = [](PCWSTR what, auto stillLive, auto attemptCancel) {
-        for (int elapsedMs = 0; stillLive(); elapsedMs += kUninitWaitPollMs) {
-            if (elapsedMs < kUninitCancelForMs) {
-                attemptCancel();
-            } else if (elapsedMs % kUninitLogEveryMs == 0) {
-                Wh_Log(L"Uninit: still waiting on %s (%d s)", what,
-                       elapsedMs / 1000);
-            }
-            Sleep(kUninitWaitPollMs);
-        }
-    };
-
     // First, before any window handle is picked: a reload already past
     // MenuOwnerWndProc's g_unloading check destroys every level window and
     // clears g_levelWindows, so a handle latched ahead of this wait would be
@@ -10138,9 +10439,7 @@ void Wh_ModUninit() {
     // with its WndProc in the image about to be unmapped. The reload also parks
     // the taskbar UI thread in joins that pump sent messages, so waiting here
     // keeps the teardown send below from running re-entrantly inside one.
-    // Nothing to cancel, and it cannot restart a worker behind us:
-    // StartRetryThread bails on g_unloading.
-    waitOut(L"a UI reload", [] { return g_reloadInFlight.load() > 0; }, [] {});
+    // (Already waited out above, before Pins::Stop.)
 
     // g_menuOwnerWnd first: it lives on the same taskbar UI thread and nothing
     // but the teardown itself destroys it, so it is the stable choice. A level

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -9550,8 +9550,8 @@ bool HookTaskbarViewDllSymbols() {
         return false;
     }
 
-    // Taskbar.View.dll / ExplorerExtensions.dll
-    WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {
+    // Taskbar.View.dll, ExplorerExtensions.dll
+    WindhawkUtils::SYMBOL_HOOK taskbarViewHooks[] = {
         {
             {LR"(struct winrt::Taskbar::TaskListWindowViewModel __cdecl TryGetItemFromContainer<struct winrt::Taskbar::TaskListWindowViewModel>(struct winrt::Windows::UI::Xaml::UIElement const &))"},
             &TryGetItemFromContainer_TaskListWindowViewModel_Original,
@@ -9566,8 +9566,8 @@ bool HookTaskbarViewDllSymbols() {
         },
     };
 
-    return WindhawkUtils::HookSymbols(module, taskbarViewDllHooks,
-                                      ARRAYSIZE(taskbarViewDllHooks));
+    return WindhawkUtils::HookSymbols(module, taskbarViewHooks,
+                                      ARRAYSIZE(taskbarViewHooks));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/mods/taskbar-folder-hover-tray.wh.cpp
+++ b/mods/taskbar-folder-hover-tray.wh.cpp
@@ -9550,6 +9550,7 @@ bool HookTaskbarViewDllSymbols() {
         return false;
     }
 
+    // Taskbar.View.dll / ExplorerExtensions.dll
     WindhawkUtils::SYMBOL_HOOK taskbarViewDllHooks[] = {
         {
             {LR"(struct winrt::Taskbar::TaskListWindowViewModel __cdecl TryGetItemFromContainer<struct winrt::Taskbar::TaskListWindowViewModel>(struct winrt::Windows::UI::Xaml::UIElement const &))"},


### PR DESCRIPTION
## Summary

Supersedes #4936 with a substantially expanded version of `taskbar-folder-hover-tray`.
The previous PR already shipped the core hover-tray experience (flush taskbar
buttons, cascading icon grids, acrylic popups, secondary monitors, and several
rounds of AI-review hardening through v1.24). This update keeps that foundation
and replaces how folders are managed.

### V1 update (on top of the manager work below) — native taskbar rendering

The buttons and grid are no longer an overlay window drawn on top of the
taskbar. Folder buttons are now **real pinned taskbar items**, matched to
their manager entries through the AppUserModelID:

- **No more overlay** — the mod stopped drawing its own button strip; it pins
  real taskbar buttons and hooks their hover/click instead. Unpin, drag
  reordering, and (now) the right-click menu are Windows' own.
- **`Manage folders...` moved onto the button's own jump list** (right-click
  a folder button on the taskbar), on top of the existing Explorer/Desktop
  context-menu entry point.
- A native unpin is now noticed immediately, without waiting for an Explorer
  restart, and pin IDs regenerate + reload so buttons stay matched to their
  folder entries.
- **Folder manager reworked**: dark field borders, corner radius is now a
  rounded on/off switch instead of a slider, and the acrylic blur shape now
  follows the rounded corners instead of a fixed rectangle.
- **Settings reorganized** with new, more sensible defaults, and five
  settings that only existed for the overlay were removed outright.
- Left-click now correctly swallows the click when `openFolderOnClick` is off.

![Cascading grid on the new taskbar rendering](https://raw.githubusercontent.com/Kiploom/images/main/taskbar-folder-hover-tray-cascade.png)
![Folder grid on the new taskbar rendering](https://raw.githubusercontent.com/Kiploom/images/main/taskbar-folder-hover-tray-grid.png)

### What shipped in #4936 (still here)

- Folder shortcut buttons carved into the Windows 11 **app icon strip**, sized
  from a live taskbar button
- **Hover-opened** cascading icon grids with a mouse corridor, subfolder badges,
  shell context menus, and left-click launch
- Primary + secondary taskbar injection, acrylic blur, theme/accent awareness
- `shell:` filesystem targets, env-var expansion, LRU folder cache, async icon
  extraction, remote-path guards, and the review fixes already landed on that PR

### What this PR adds on top of #4936

#### 1. Taskbar Folders manager (replaces the settings-page folder list)
- Folders are no longer edited as a Windhawk **settings** array (mods cannot write
  settings back, and Explorer runs unelevated against a read-only HKLM key)
- New native **Taskbar Folders** window is the single source of truth, persisted
  in mod **Storage** (`Wh_SetStringValue` / `Wh_SetIntValue`)
- Open it via taskbar button right-click → **Manage folders...**, or by toggling
  **Open the folder manager** in settings and saving
- Add / Edit / Remove, drag-reorder rows (left-to-right taskbar order), and
  **Pinned to the taskbar** as a draft flag — unpin keeps name/icon without
  deleting the entry
<img width="489" height="439" alt="Screenshot 2026-08-03 232523" src="https://github.com/user-attachments/assets/fe48f7a8-d6d3-43ac-9907-7f21ae999ddc" />
<img width="478" height="434" alt="Screenshot 2026-08-03 232536" src="https://github.com/user-attachments/assets/1b415d64-37bc-4ee6-8779-916d577c02cc" />

#### 2. Explorer / Desktop integration
- Shell context-menu hook adds a **Taskbar Folders** submenu:
  - **Pin "…" to Taskbar** for folders not already in the store
  - **Move to… / Copy to… / Create shortcut in…** into existing pinned folders
- Pins pick up the folder's name and custom icon (Properties → Customize)
- Duplicate pins reuse an existing draft entry instead of creating a second one
<img width="765" height="175" alt="image" src="https://github.com/user-attachments/assets/740ae096-b044-42f9-9d97-9cc32f7b80c4" />
<img width="685" height="206" alt="image" src="https://github.com/user-attachments/assets/b54d86eb-2ae2-4a15-9646-4dc3a2b095b5" />


#### 3. Migration from the old settings list
- First run of this version imports previous settings-page folders and any older
  `pinned[]` storage entries into the manager store
- Previously "hidden/unpinned" settings rows come across as drafts

#### 4. Settings / appearance cleanup
- Removed the `folders:` settings array; added `manageFolders` open-manager action
- Replaced raw `cellWidth` / `cellHeight` / `iconSize` with an **Item size**
  preset (`small` / `medium` / `large`)
- Added item + title **font family** and **font weight** controls
- Grouped settings under Behavior / Content / Appearance
- Known-conflicts note trimmed to Taskbar Styler (Fluent Media Player note removed)

#### 5. UX polish tied to the new workflow
- Taskbar button context menu: Unpin / Manage folders
- Manager list drag insertion line, edit dialog with folder/icon browse,
  press-bounce / highlight polish on tray interaction

### Scope / size
- Single catalog file: `mods/taskbar-folder-hover-tray.wh.cpp`
- Version: **2.0** — V1 release candidate: native taskbar rendering
  (real pinned buttons, no overlay), revamped folder manager, and better
  settings organization/defaults, on top of everything below

### Note for automated reviewers
Catalog overlap with `taskbar-folder-menus` is acknowledged and documented in the
mod readme for end users. Do **not** re-raise coexistence in subsequent AI review
rounds; that decision is for the human maintainer. Focus on new technical defects
in the manager / storage / Explorer-menu paths.


## Test plan
- [ ] Install from this PR on Windows 11; confirm buttons still sit flush with apps
- [ ] Migrate: with folders configured from #4936 settings, upgrade and confirm they appear in Taskbar Folders
- [ ] Open manager via settings toggle and via taskbar right-click → Manage folders...
- [ ] Add / edit / drag-reorder / unpin-as-draft / remove; confirm taskbar updates live
- [ ] Explorer/Desktop: Pin a folder; Move/Copy/Shortcut into a pinned folder
- [ ] Hover grid still opens instantly; nested folders cascade; right-click shell menu works
- [ ] Secondary monitor taskbar injection still works
- [ ] Acrylic on/off recreates popups cleanly; theme change does not break hover

## Mod authorship
This mod was created by:

- [x] The submitter, with AI assistance (Cursor (Grok / Cursor agent) & Claude (Sonnet + Opus))

The human author and submitter is Grant Benson ([@Kiploom](https://github.com/Kiploom)).

