### PR TITLE
MacOS Minimize Animation v3.1.4: add copyright / license notice

### DIFF
--- a/mods/macos-minimize-animation.wh.cpp
+++ b/mods/macos-minimize-animation.wh.cpp
@@ -2,13 +2,21 @@
 // @id              macos-minimize-animation
 // @name            MacOS Minimize Animation
 // @description     Smooth macOS-style genie minimize and restore (open) animations for every window.
-// @version         3.1.3
+// @version         3.1.4
 // @author          Abdullah Masood
 // @github          https://github.com/Abdullah-Masood-05
 // @include         *
 // @compilerOptions -ldwmapi -lgdi32 -ld2d1 -lole32 -loleaut32 -luuid -lshell32
-// @license         MIT
+// @license         All rights reserved
 // ==/WindhawkMod==
+
+// Copyright © 2026 Abdullah Masood
+// All Rights Reserved.
+//
+// This source code is provided for viewing only.
+// You may not copy, modify, redistribute, reuse, create derivative works from,
+// or incorporate any portion of this source code into another project without
+// prior written permission from the copyright holder.
 
 // ==WindhawkModReadme==
 /*


### PR DESCRIPTION
Bumps the version to 3.1.4 and adds the mod's copyright and license notice at the top of the source (the previous v3.1.3 release is unchanged; only the header is added).

For the record: this changes the mod's license metadata from MIT to All Rights Reserved going forward.