### PR TITLE
Add Windows SDR to HDR Tonemapping Fix mod

### DIFF
--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -25,14 +25,30 @@ Based on [dwm_eotf](https://github.com/ledoge/dwm_eotf) by ledoge (GPL-3.0).
 
 ## How it works
 
-On DWM startup, Windhawk injects this mod before Direct3D is initialized. The
-mod locates the known DXBC shader blobs in `dwmcore.dll`'s read-only memory
-sections and patches four floating-point constants that define the sRGB transfer
-function, replacing them with the equivalent pure power-law constants. The shader
-checksums are recalculated so D3D accepts the patched bytecode.
+When DWM starts, Windhawk injects this mod early — ideally before Direct3D
+initializes, so the patched bytecode is what D3D compiles from. The mod walks
+`dwmcore.dll`'s read-only PE sections looking for DXBC shader blobs that contain
+all four sRGB EOTF float constants. When found, those constants are replaced with
+the equivalent pure power-law values and the shader checksum is recalculated so
+D3D accepts the modified bytecode.
 
-When the mod is unloaded (Windhawk disabled, settings changed, or Windows
-shutdown), all patched bytes are restored to their original values.
+When the mod is unloaded while DWM is running (e.g. Windhawk disabled or settings
+changed), all patched bytes are restored in memory. Note that the unload callback
+does not run at process exit, so no restore occurs at Windows shutdown — this is
+harmless since the process is terminating anyway.
+
+## Important: enable injection into dwm.exe
+
+`dwm.exe` is a critical system process. Windhawk does not inject into it by
+default — you must explicitly allow it in **Windhawk's advanced settings**:
+
+1. Open Windhawk → **Advanced settings**
+2. In the **Process inclusion list**, add `dwm.exe`
+3. Click **Save**
+
+Without this step the mod will be silently ignored.
+
+![Windhawk advanced settings](https://i.imgur.com/LRhREtJ.png)
 
 ## Usage
 
@@ -69,9 +85,8 @@ shutdown), all patched bytes are restored to their original values.
   patching or unpatching at runtime has no effect on shaders that are already
   compiled. The flicker is driven by Chrome's own mode-switching and cannot be
   suppressed from the DWM side.
-- The shader checksums in `dwmcore.dll` may change with Windows Updates. If the
-  mod reports patching 0 shaders after an update, the known-checksum list may
-  need updating.
+- If the mod logs "No matching shaders found" after a Windows Update, the shader
+  structure in `dwmcore.dll` has changed. Please file an issue.
 */
 // ==/WindhawkModReadme==
 
@@ -93,7 +108,8 @@ shutdown), all patched bytes are restored to their original values.
 
 #include <windows.h>
 #include <cstring>
-#include <cstdlib>
+#include <cwchar>
+#include <cstdint>
 #include <vector>
 
 // =============================================================================
@@ -103,7 +119,7 @@ shutdown), all patched bytes are restored to their original values.
 // Free for all — MD5 algorithm derived from RSA Data Security, Inc. (1990).
 // =============================================================================
 
-typedef unsigned long DX_UINT4;
+typedef uint32_t DX_UINT4;
 
 struct MD5_CTX_DX
 {
@@ -327,10 +343,11 @@ struct PatchRecord
 };
 
 static std::vector<PatchRecord> g_patches;
-static float g_gamma = 2.2f;
 
-// Known DXBC checksums for the sRGB-EOTF shaders in dwmcore.dll.
-// These are the unmodified ("vanilla") checksums for the target shader blobs.
+// Known DXBC checksums for the four sRGB-EOTF target shaders in dwmcore.dll.
+// Used as the primary selector: dwmcore.dll contains dozens of other shaders
+// that also contain sRGB constants, so constant-only detection over-patches.
+// If these change after a Windows Update, please file an issue.
 static const BYTE kKnownChecksums[4][16] = {
     {0x96, 0xe6, 0xd1, 0x58, 0x92, 0x55, 0xec, 0xcd, 0x1d, 0xd7, 0xd4, 0xdb, 0xec, 0x54, 0xd2, 0x85},
     {0x21, 0x26, 0xb0, 0x37, 0xc1, 0xa2, 0xfb, 0xdd, 0xe3, 0x55, 0xb6, 0xe6, 0xdd, 0x9c, 0xaf, 0x3c},
@@ -373,16 +390,18 @@ static const float kSrgbConsts[4] = {2.4f, 0.04045f, 0.055000f, 0.94786733f};
 static const float kPatchConsts[4] = {0.0f, 0.0f, 0.0f, 1.0f};
 // Index 0 (the exponent) is replaced with the user-chosen gamma, not kPatchConsts[0].
 
-// Searches 'buf' (a copy of a shader blob) for the sRGB splat patterns and
-// patches them in-place. Returns true if at least one substitution was made.
-static bool PatchShaderBuf(BYTE *buf, DWORD size, float gamma)
+// Searches 'buf' (a copy of a shader blob) for the sRGB vec3-splat patterns and
+// patches them in-place. Returns the number of the four constants found (0–4).
+// Callers must require == 4 to ensure all-or-nothing patching.
+static int PatchShaderBuf(BYTE *buf, DWORD size, float gamma)
 {
-    bool changed = false;
+    int found = 0;
     for (int ci = 0; ci < 4; ci++)
     {
         float src = kSrgbConsts[ci];
         float dst = (ci == 0) ? gamma : kPatchConsts[ci];
         float pat[3] = {src, src, src};
+        bool foundThis = false;
         // Search from after the header; stop where a full 12-byte match would overflow.
         for (size_t j = kDXBCHeaderSize; j + sizeof(float) * 3 <= size; j++)
         {
@@ -390,10 +409,33 @@ static bool PatchShaderBuf(BYTE *buf, DWORD size, float gamma)
                 continue;
             float rep[3] = {dst, dst, dst};
             memcpy(buf + j, rep, sizeof(rep));
-            changed = true;
+            foundThis = true;
         }
+        if (foundThis)
+            found++;
     }
-    return changed;
+    return found;
+}
+
+// Returns true if the blob contains at least one valid nested DXBC blob.
+// dwmcore.dll embeds the target leaf shaders inside larger container blobs.
+// Container blobs have sub-blobs; leaf shaders do not. Distinguishing them
+// prevents patching a container as a leaf, which would leave internal
+// sub-blob checksums stale.
+static bool HasDXBCSubBlob(const DXBCHeader *hdr)
+{
+    const BYTE *base = (const BYTE *)hdr;
+    for (size_t k = kDXBCHeaderSize; k + kDXBCHeaderSize <= hdr->size; k++)
+    {
+        const auto *inner = (const DXBCHeader *)(base + k);
+        if (inner->magic[0] == 'D' && inner->magic[1] == 'X' &&
+            inner->magic[2] == 'B' && inner->magic[3] == 'C' &&
+            inner->reserved == 1 &&
+            inner->size >= (DWORD)kDXBCHeaderSize &&
+            k + inner->size <= hdr->size)
+            return true;
+    }
+    return false;
 }
 
 // =============================================================================
@@ -452,7 +494,19 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
         if (hdr->size < (DWORD)kDXBCHeaderSize || i + hdr->size > regionSize)
             continue;
 
-        // Check if this blob's checksum matches one of our targets.
+        // Container blobs embed sub-shaders as nested DXBC blobs; leaf shaders do not.
+        // Track containers so we can fix their checksum after inner shaders are patched.
+        if (HasDXBCSubBlob(hdr))
+        {
+            if (!bigShader)
+                bigShader = hdr;
+            continue;
+        }
+
+        // Leaf blob — match against the known-checksum allowlist.
+        // Many other DWM shaders also contain sRGB constants, so constant-only
+        // detection would over-patch unrelated shaders; checksums select the
+        // correct four. The constant search below acts as a sanity check.
         int matchIdx = -1;
         for (int k = 0; k < 4; k++)
         {
@@ -462,26 +516,22 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
                 break;
             }
         }
-
         if (matchIdx < 0)
-        {
-            // Unknown blob — track as a potential container for inner sub-shaders.
-            if (!bigShader || region + i >= (BYTE *)bigShader + bigShader->size)
-                bigShader = hdr;
             continue;
-        }
 
-        // Found a target shader. Make a working copy, patch it, validate, write back.
+        // Checksum matched — copy the blob, patch the sRGB constants, verify
+        // all four were found, then recompute the DXBC checksum.
         std::vector<BYTE> patched(hdr->size);
         memcpy(patched.data(), hdr, hdr->size);
 
-        if (!PatchShaderBuf(patched.data(), hdr->size, gamma))
+        int constsFound = PatchShaderBuf(patched.data(), hdr->size, gamma);
+        if (constsFound < 4)
         {
-            Wh_Log(L"  Shader #%d matched checksum but no constants found to patch", matchIdx);
+            Wh_Log(L"  Shader #%d: checksum matched but only %d/4 sRGB constants found",
+                   matchIdx, constsFound);
             continue;
         }
 
-        // Recalculate DXBC checksum for the patched copy.
         DWORD newCk[4];
         CalcDXBCChecksum(patched.data(), hdr->size, newCk);
         memcpy(patched.data() + 4, newCk, 16);
@@ -549,9 +599,8 @@ BOOL Wh_ModInit()
         Wh_Log(L"Invalid gamma value, falling back to 2.2");
         gamma = 2.2f;
     }
-    g_gamma = gamma;
 
-    Wh_Log(L"DWM EOTF: target gamma = %.1f", (double)gamma);
+    Wh_Log(L"Target gamma = %.1f", (double)gamma);
 
     // Locate dwmcore.dll (always loaded as a static import of dwm.exe).
     HMODULE hDwmcore = GetModuleHandleW(L"dwmcore.dll");
@@ -567,43 +616,37 @@ BOOL Wh_ModInit()
     BYTE *modBase = (BYTE *)hDwmcore;
     size_t modSize = nt->OptionalHeader.SizeOfImage;
 
-    Wh_Log(L"dwmcore.dll at %p, image size %zu", (void *)modBase, modSize);
+    Wh_Log(L"dwmcore.dll base %p, image size %zu", (void *)modBase, modSize);
 
-    // Walk the virtual memory regions within dwmcore.dll's image range.
-    // The DXBC shader blobs live in PAGE_READONLY sections (typically .rdata).
+    // Walk PE sections instead of VirtualQuery: deterministic regardless of
+    // page-protection fragmentation from other mods or the loader.
     int totalPatched = 0;
-    BYTE *addr = modBase;
-    while (addr < modBase + modSize)
+    auto *sec = IMAGE_FIRST_SECTION(nt);
+    for (WORD s = 0; s < nt->FileHeader.NumberOfSections; s++, sec++)
     {
-        MEMORY_BASIC_INFORMATION mbi{};
-        if (!VirtualQuery(addr, &mbi, sizeof(mbi)))
-            break;
+        // Scan readable, non-writable, non-executable sections only (e.g. .rdata).
+        if (!(sec->Characteristics & IMAGE_SCN_MEM_READ))
+            continue;
+        if (sec->Characteristics & IMAGE_SCN_MEM_EXECUTE)
+            continue;
+        if (sec->Characteristics & IMAGE_SCN_MEM_WRITE)
+            continue;
+        if (sec->Misc.VirtualSize == 0)
+            continue;
 
-        size_t regionSize = mbi.RegionSize;
-        // Clamp to the module boundary.
-        if ((BYTE *)mbi.BaseAddress + regionSize > modBase + modSize)
-            regionSize = (modBase + modSize) - (BYTE *)mbi.BaseAddress;
-
-        if (mbi.State == MEM_COMMIT &&
-            mbi.Protect == PAGE_READONLY &&
-            regionSize > 4096)
-        {
-            Wh_Log(L"Scanning region at %p, size %zu", mbi.BaseAddress, regionSize);
-            totalPatched += ScanRegionForShaders((BYTE *)mbi.BaseAddress, regionSize, gamma);
-        }
-
-        addr = (BYTE *)mbi.BaseAddress + mbi.RegionSize;
+        Wh_Log(L"Scanning section at %p, size %lu",
+               (void *)(modBase + sec->VirtualAddress), sec->Misc.VirtualSize);
+        totalPatched += ScanRegionForShaders(modBase + sec->VirtualAddress,
+                                             sec->Misc.VirtualSize, gamma);
     }
 
     if (totalPatched == 0)
     {
-        Wh_Log(L"No shaders patched. HDR may be off, or dwmcore.dll was updated (checksums changed).");
-    }
-    else
-    {
-        Wh_Log(L"Successfully patched %d shader(s) with gamma %.1f", totalPatched, (double)gamma);
+        Wh_Log(L"No matching shaders found — dwmcore.dll may have been updated.");
+        return FALSE;
     }
 
+    Wh_Log(L"Successfully patched %d shader(s) with gamma %.1f", totalPatched, (double)gamma);
     return TRUE;
 }
 

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -35,7 +35,8 @@ replacing the sRGB curve with a simple power-law gamma. This gives you direct
 control over the SDR-to-HDR tone mapping without permanently modifying any files
 on disk.
 
-Originally based on [dwm_eotf](https://github.com/ledoge/dwm_eotf) by ledoge (GPL-3.0), but expanded
+Originally based on [dwm_eotf](https://github.com/ledoge/dwm_eotf) by ledoge
+(GPL-3.0), but expanded
 
 ## How it works
 
@@ -88,10 +89,8 @@ effect.
 - **Only applies when Windows HDR is enabled.** With HDR off, DWM does not use
   this code path.
 - **Gamma changes require a DWM restart.** D3D compiles the shader bytecode once
-  at startup. Patching the bytecode after that has no effect until DWM recreates
-  its device (which happens on log off/on, display reconfiguration, or toggling
-  Windows HDR off and back on — the last option is the lightest-weight way to
-  apply a new gamma value without a full log-off).
+  at startup. Patching the bytecode after that has no effect until DWM restarts
+  (log off and back on).
 - **Chromium-based browsers and Electron apps** (Chrome, Edge, VS Code, Discord,
   etc.) switch between DWM's SDR compositing path and a direct scRGB path
   depending on tab/window content. Each
@@ -503,8 +502,8 @@ static void LogSrgbNearMisses(const BYTE* region, size_t regionSize) {
         Wh_Log(
             L"  Near-miss at +0x%zx size %lu: c24=%d c04=%d c05=%d c95=%d "
             L"ck=%02x%02x%02x%02x...",
-            i, hdr->size, counts[0], counts[1], counts[2], counts[3],
-            ck[0], ck[1], ck[2], ck[3]);
+            i, hdr->size, counts[0], counts[1], counts[2], counts[3], ck[0],
+            ck[1], ck[2], ck[3]);
     }
 }
 
@@ -516,13 +515,15 @@ static void LogSrgbNearMisses(const BYTE* region, size_t regionSize) {
 // A leaf blob qualifies if it contains all four sRGB vec3-splat constants each
 // exactly once — a signature unique to the decode path.
 // Returns the number of blobs successfully patched. Increments skippedCount for
-// each blob that qualified but could not be written (VirtualProtect failure or
-// container checksum failure), enabling the caller to enforce all-or-nothing.
+// each blob that qualified but could not be written (VirtualProtect failure),
+// enabling the caller to enforce all-or-nothing.
 //
 // Container handling: dwmcore.dll embeds leaf shaders inside larger DXBC
 // container blobs. The container's checksum must be recalculated after any
 // inner leaf is patched.
-static int ScanRegionForShaders(BYTE* region, size_t regionSize, float gamma,
+static int ScanRegionForShaders(BYTE* region,
+                                size_t regionSize,
+                                float gamma,
                                 int& skippedCount) {
     int numPatched = 0;
 
@@ -531,30 +532,13 @@ static int ScanRegionForShaders(BYTE* region, size_t regionSize, float gamma,
     size_t containerPatchBase =
         0;  // g_patches index when the current container was accepted
 
-    // Finalizes a container whose inner shaders have been patched. Runs
-    // ChecksumRoundTrips here (deferred from container acceptance) so the MD5
-    // cost is only paid when qualifying leaves were actually found inside.
-    // Recomputes the container checksum and writes it back. On any failure,
-    // rolls back all inner leaf patches and increments skippedCount.
+    // Finalizes a container whose inner shaders have been patched: recomputes
+    // the container checksum over the now-modified body and writes it back.
+    // ChecksumRoundTrips was already verified at acceptance time (before any
+    // inner bytes changed); running it here against modified content would
+    // always fail. Rolls back inner patches and increments skippedCount if the
+    // checksum write fails.
     auto FinalizeContainer = [&](DXBCHeader* container) -> bool {
-        // Deferred round-trip check: verify before writing.
-        if (!ChecksumRoundTrips(container)) {
-            size_t toRollBack = g_patches.size() - containerPatchBase;
-            Wh_Log(
-                L"  Container at %p: checksum did not round-trip — rolling "
-                L"back %zu leaf patch(es)",
-                (void*)container, toRollBack);
-            while (g_patches.size() > containerPatchBase) {
-                auto& rec = g_patches.back();
-                WriteMemorySafe(rec.addr, rec.original.data(),
-                                rec.original.size());
-                g_patches.pop_back();
-                numPatched--;
-            }
-            skippedCount += (int)toRollBack;
-            return false;
-        }
-
         PatchRecord bigRec;
         bigRec.addr = (BYTE*)container + 4;
         bigRec.original.assign(bigRec.addr, bigRec.addr + 16);
@@ -614,9 +598,21 @@ static int ScanRegionForShaders(BYTE* region, size_t regionSize, float gamma,
         // shaders are patched.
         if (HasDXBCSubBlob(hdr)) {
             if (!bigShader) {
-                // Accept the container; the ChecksumRoundTrips verification is
-                // deferred to FinalizeContainer so the MD5 is only computed
-                // when qualifying leaves are actually found inside.
+                // Pre-flight: verify our checksum function can reproduce this
+                // container's own hash before any inner bytes are modified.
+                // Must run here, not in FinalizeContainer — after patching
+                // inner leaves the container body changes and round-trip always
+                // fails.
+                if (!ChecksumRoundTrips(hdr)) {
+                    Wh_Log(
+                        L"  Container at %p: checksum did not round-trip, "
+                        L"skipping",
+                        (void*)hdr);
+                    i +=
+                        hdr->size -
+                        4;  // loop will add 4 more, landing just after the blob
+                    continue;
+                }
                 bigShader = hdr;
                 containerPatchBase = g_patches.size();
             } else {
@@ -793,15 +789,16 @@ BOOL Wh_ModInit() {
 
         Wh_Log(L"Scanning section at %p, size %lu",
                (void*)(modBase + sec->VirtualAddress), sec->Misc.VirtualSize);
-        totalPatched += ScanRegionForShaders(modBase + sec->VirtualAddress,
-                                             sec->Misc.VirtualSize, gamma,
-                                             totalSkipped);
+        totalPatched +=
+            ScanRegionForShaders(modBase + sec->VirtualAddress,
+                                 sec->Misc.VirtualSize, gamma, totalSkipped);
     }
 
     if (totalSkipped > 0) {
         // At least one qualified blob was not successfully patched. DWM would
         // have a mix of patched and unpatched EOTF shaders, reproducing the
-        // intermittent sRGB reversion. Revert everything for a consistent state.
+        // intermittent sRGB reversion. Revert everything for a consistent
+        // state.
         Wh_Log(
             L"Partial patch (%d written, %d skipped) — reverting to avoid "
             L"inconsistent SDR rendering",

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -1,7 +1,8 @@
 // ==WindhawkMod==
 // @id              dwm-eotf-gamma
 // @name            Windows SDR to HDR Tonemapping Fix
-// @description     Replaces DWM's sRGB EOTF with a pure power-law gamma for SDR-to-HDR tone mapping
+// @description     Replaces DWM's sRGB EOTF with a pure power-law gamma for
+// SDR-to-HDR tone mapping
 // @version         1.0
 // @author          millerpb
 // @github          https://github.com/millerpb
@@ -14,14 +15,17 @@
 /*
 # Windows SDR to HDR Tonemapping Fix
 
-Viewing SDR content while using HDR in Windows causes washed out darker tones like shadows. This corrects
-it so that Windows uses a standard gamma curve. It should not affect native HDR content like games and movies.
+Viewing SDR content while using HDR in Windows causes washed out darker tones
+like shadows. This corrects it so that Windows uses a standard gamma curve. It
+should not affect native HDR content like games and movies.
 
 Simple, accurate sRGB with a simple power-law gamma curve that you can control.
 
 ![Comparison Image](https://i.imgur.com/GwegdeU.png)
 
-See examples and read more on the [win11hdr-srgb-to-gamma2.2-icm GitHub](https://github.com/dylanraga/win11hdr-srgb-to-gamma2.2-icm), an alternative icc based solution by dylanraga
+See examples and read more on the [win11hdr-srgb-to-gamma2.2-icm
+GitHub](https://github.com/dylanraga/win11hdr-srgb-to-gamma2.2-icm), an
+alternative icc based solution by dylanraga
 
 ## DWM EOTF Gamma Curve
 
@@ -39,14 +43,14 @@ Based on [dwm_eotf](https://github.com/ledoge/dwm_eotf) by ledoge (GPL-3.0).
 When DWM starts, Windhawk injects this mod early, ideally before Direct3D
 initializes, so the patched bytecode is what D3D compiles from. The mod walks
 `dwmcore.dll`'s read-only PE sections looking for DXBC shader blobs that contain
-all four sRGB EOTF float constants. When found, those constants are replaced with
-the equivalent pure power-law values and the shader checksum is recalculated so
-D3D accepts the modified bytecode.
+all four sRGB EOTF float constants. When found, those constants are replaced
+with the equivalent pure power-law values and the shader checksum is
+recalculated so D3D accepts the modified bytecode.
 
-When the mod is unloaded while DWM is running (e.g. Windhawk disabled or settings
-changed), all patched bytes are restored in memory. Note that the unload callback
-does not run at process exit, so no restore occurs at Windows shutdown; this is
-harmless since the process is terminating anyway.
+When the mod is unloaded while DWM is running (e.g. Windhawk disabled or
+settings changed), all patched bytes are restored in memory. Note that the
+unload callback does not run at process exit, so no restore occurs at Windows
+shutdown; this is harmless since the process is terminating anyway.
 
 ## Important: enable injection into dwm.exe
 
@@ -66,7 +70,8 @@ Without this step the mod will be silently ignored.
 1. Enable **Windows HDR** in display settings.
 2. Install and enable this mod.
 3. Select your preferred gamma value in the settings below.
-4. **Log off and back in** (or otherwise restart DWM) for the change to take effect.
+4. **Log off and back in** (or otherwise restart DWM) for the change to take
+effect.
 5. To change the gamma value later, update the setting and restart DWM again.
 
 ## Gamma reference
@@ -96,8 +101,9 @@ Without this step the mod will be silently ignored.
   patching or unpatching at runtime has no effect on shaders that are already
   compiled. The flicker is driven by Chrome's own mode-switching and cannot be
   suppressed from the DWM side.
-- If the mod logs "No matching shaders found" after a Windows Update, the shader
-  structure in `dwmcore.dll` has changed. Please file an issue.
+- If the mod logs "No target shaders found" after a Windows Update, the shader
+  structure in `dwmcore.dll` has changed (verified against 10.0.26100.8521).
+  Please file an issue.
 */
 // ==/WindhawkModReadme==
 
@@ -117,12 +123,12 @@ Without this step the mod will be silently ignored.
 */
 // ==/WindhawkModSettings==
 
+#include <windhawk_utils.h>
 #include <windows.h>
+#include <cstdint>
 #include <cstring>
 #include <cwchar>
-#include <cstdint>
 #include <vector>
-#include <windhawk_utils.h>
 
 // =============================================================================
 // DXBC Checksum — AMD DXBCChecksum (modified MD5 used by Microsoft for DXBC)
@@ -133,18 +139,16 @@ Without this step the mod will be silently ignored.
 
 typedef uint32_t DX_UINT4;
 
-struct MD5_CTX_DX
-{
+struct MD5_CTX_DX {
     DX_UINT4 i[2];
     DX_UINT4 buf[4];
     unsigned char in[64];
 };
 
 static const unsigned char kMD5Padding[64] = {
-    0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 #define DX_F(x, y, z) (((x) & (y)) | ((~x) & (z)))
 #define DX_G(x, y, z) (((x) & (z)) | ((y) & (~z)))
@@ -176,8 +180,7 @@ static const unsigned char kMD5Padding[64] = {
         (a) += (b);                                        \
     }
 
-static void DX_MD5Transform(DX_UINT4 *buf, DX_UINT4 *in)
-{
+static void DX_MD5Transform(DX_UINT4* buf, DX_UINT4* in) {
     DX_UINT4 a = buf[0], b = buf[1], c = buf[2], d = buf[3];
     DX_FF(a, b, c, d, in[0], 7, 3614090360u);
     DX_FF(d, a, b, c, in[1], 12, 3905402710u);
@@ -249,8 +252,7 @@ static void DX_MD5Transform(DX_UINT4 *buf, DX_UINT4 *in)
     buf[3] += d;
 }
 
-static void DX_MD5Init(MD5_CTX_DX *ctx)
-{
+static void DX_MD5Init(MD5_CTX_DX* ctx) {
     ctx->i[0] = ctx->i[1] = 0;
     ctx->buf[0] = 0x67452301u;
     ctx->buf[1] = 0xefcdab89u;
@@ -258,21 +260,23 @@ static void DX_MD5Init(MD5_CTX_DX *ctx)
     ctx->buf[3] = 0x10325476u;
 }
 
-static void DX_MD5Update(MD5_CTX_DX *ctx, const unsigned char *data, unsigned int len)
-{
+static void DX_MD5Update(MD5_CTX_DX* ctx,
+                         const unsigned char* data,
+                         unsigned int len) {
     int mdi = (int)((ctx->i[0] >> 3) & 0x3F);
     if ((ctx->i[0] + ((DX_UINT4)len << 3)) < ctx->i[0])
         ctx->i[1]++;
     ctx->i[0] += (DX_UINT4)len << 3;
     ctx->i[1] += (DX_UINT4)len >> 29;
-    while (len--)
-    {
+    while (len--) {
         ctx->in[mdi++] = *data++;
-        if (mdi == 0x40)
-        {
+        if (mdi == 0x40) {
             DX_UINT4 tmp[16];
             for (unsigned i = 0, ii = 0; i < 16; i++, ii += 4)
-                tmp[i] = ((DX_UINT4)ctx->in[ii + 3] << 24) | ((DX_UINT4)ctx->in[ii + 2] << 16) | ((DX_UINT4)ctx->in[ii + 1] << 8) | (DX_UINT4)ctx->in[ii];
+                tmp[i] = ((DX_UINT4)ctx->in[ii + 3] << 24) |
+                         ((DX_UINT4)ctx->in[ii + 2] << 16) |
+                         ((DX_UINT4)ctx->in[ii + 1] << 8) |
+                         (DX_UINT4)ctx->in[ii];
             DX_MD5Transform(ctx->buf, tmp);
             mdi = 0;
         }
@@ -280,11 +284,11 @@ static void DX_MD5Update(MD5_CTX_DX *ctx, const unsigned char *data, unsigned in
 }
 
 // Computes the DXBC-variant MD5 checksum for a shader blob.
-// pData must point to the start of the DXBC header; dwSize is the full shader size.
-// The checksum is written into dwHash[4].
-static void CalcDXBCChecksum(const BYTE *pData, DWORD dwSize, DWORD dwHash[4])
-{
-    static const DWORD kHashOffset = 0x14; // skip magic(4) + checksum(16) = 20 bytes
+// pData must point to the start of the DXBC header; dwSize is the full shader
+// size. The checksum is written into dwHash[4].
+static void CalcDXBCChecksum(const BYTE* pData, DWORD dwSize, DWORD dwHash[4]) {
+    static const DWORD kHashOffset =
+        0x14;  // skip magic(4) + checksum(16) = 20 bytes
     MD5_CTX_DX ctx;
     DX_MD5Init(&ctx);
 
@@ -298,26 +302,23 @@ static void CalcDXBCChecksum(const BYTE *pData, DWORD dwSize, DWORD dwHash[4])
 
     DWORD lastChunkSize = dwSize - fullChunksSize;
     DWORD paddingSize = 64 - lastChunkSize;
-    const BYTE *lastChunk = pData + fullChunksSize;
+    const BYTE* lastChunk = pData + fullChunksSize;
 
-    if (lastChunkSize >= 56)
-    {
+    if (lastChunkSize >= 56) {
         DX_MD5Update(&ctx, lastChunk, lastChunkSize);
         DX_MD5Update(&ctx, kMD5Padding, paddingSize);
         DX_UINT4 blk[16] = {};
         blk[0] = numBits;
         blk[15] = (numBits >> 2) | 1;
         DX_MD5Transform(ctx.buf, blk);
-    }
-    else
-    {
-        DX_MD5Update(&ctx, (const unsigned char *)&numBits, 4);
+    } else {
+        DX_MD5Update(&ctx, (const unsigned char*)&numBits, 4);
         if (lastChunkSize)
             DX_MD5Update(&ctx, lastChunk, lastChunkSize);
         lastChunkSize += sizeof(DWORD);
         paddingSize -= sizeof(DWORD);
         memcpy(&ctx.in[lastChunkSize], kMD5Padding, paddingSize);
-        ((DX_UINT4 *)ctx.in)[15] = (numBits >> 2) | 1;
+        ((DX_UINT4*)ctx.in)[15] = (numBits >> 2) | 1;
         DX_UINT4 blk[16];
         memcpy(blk, ctx.in, 64);
         DX_MD5Transform(ctx.buf, blk);
@@ -331,40 +332,52 @@ static void CalcDXBCChecksum(const BYTE *pData, DWORD dwSize, DWORD dwHash[4])
 // =============================================================================
 
 #pragma pack(push, 1)
-struct DXBCHeader
-{
-    char magic[4];     // "DXBC"
-    DWORD checksum[4]; // DXBC-MD5 checksum (bytes 4–19)
-    DWORD reserved;    // always 1
-    DWORD size;        // total blob size in bytes
+struct DXBCHeader {
+    char magic[4];      // "DXBC"
+    DWORD checksum[4];  // DXBC-MD5 checksum (bytes 4–19)
+    DWORD reserved;     // always 1
+    DWORD size;         // total blob size in bytes
 };
 #pragma pack(pop)
 
 static_assert(sizeof(DXBCHeader) == 28, "DXBCHeader size mismatch");
-static const size_t kDXBCHeaderSize = sizeof(DXBCHeader); // 28
+static const size_t kDXBCHeaderSize = sizeof(DXBCHeader);  // 28
 
 // =============================================================================
 // Patch state
 // =============================================================================
 
 // Records the original bytes of a patched memory range so we can restore them.
-struct PatchRecord
-{
-    BYTE *addr;
+struct PatchRecord {
+    BYTE* addr;
     std::vector<BYTE> original;
 };
 
 static std::vector<PatchRecord> g_patches;
 
 // Known DXBC checksums for the four sRGB-EOTF target shaders in dwmcore.dll.
+// Verified against dwmcore.dll 10.0.26100.8521 (Windows 11 24H2).
+//
 // Used as the primary selector: dwmcore.dll contains dozens of other shaders
-// that also contain sRGB constants, so constant-only detection over-patches.
-// If these change after a Windows Update, please file an issue.
+// that also contain sRGB constants, so constant-only detection alone
+// over-patches. A content-based fallback (accept leaf blobs containing all four
+// sRGB splats exactly once, require exactly four such blobs) was considered and
+// deferred: it would survive Windows Updates that recompile these shaders but
+// requires non-trivial cross-section state tracking. Left as a future
+// improvement.
+//
+// If these change after a Windows Update, please file an issue. The
+// per-constant replacement counts logged at INFO level help identify the new
+// shader blobs.
 static const BYTE kKnownChecksums[4][16] = {
-    {0x96, 0xe6, 0xd1, 0x58, 0x92, 0x55, 0xec, 0xcd, 0x1d, 0xd7, 0xd4, 0xdb, 0xec, 0x54, 0xd2, 0x85},
-    {0x21, 0x26, 0xb0, 0x37, 0xc1, 0xa2, 0xfb, 0xdd, 0xe3, 0x55, 0xb6, 0xe6, 0xdd, 0x9c, 0xaf, 0x3c},
-    {0x2c, 0x89, 0x26, 0xff, 0xe2, 0x29, 0xf0, 0x5d, 0x96, 0x7c, 0x72, 0x66, 0x8d, 0xc3, 0xad, 0xdb},
-    {0xf6, 0x93, 0xbf, 0xbb, 0xaf, 0x24, 0xb3, 0xd9, 0x36, 0x63, 0x54, 0xbe, 0x88, 0x98, 0xa7, 0xf5},
+    {0x96, 0xe6, 0xd1, 0x58, 0x92, 0x55, 0xec, 0xcd, 0x1d, 0xd7, 0xd4, 0xdb,
+     0xec, 0x54, 0xd2, 0x85},
+    {0x21, 0x26, 0xb0, 0x37, 0xc1, 0xa2, 0xfb, 0xdd, 0xe3, 0x55, 0xb6, 0xe6,
+     0xdd, 0x9c, 0xaf, 0x3c},
+    {0x2c, 0x89, 0x26, 0xff, 0xe2, 0x29, 0xf0, 0x5d, 0x96, 0x7c, 0x72, 0x66,
+     0x8d, 0xc3, 0xad, 0xdb},
+    {0xf6, 0x93, 0xbf, 0xbb, 0xaf, 0x24, 0xb3, 0xd9, 0x36, 0x63, 0x54, 0xbe,
+     0x88, 0x98, 0xa7, 0xf5},
 };
 
 // =============================================================================
@@ -373,13 +386,12 @@ static const BYTE kKnownChecksums[4][16] = {
 
 // Write bytes to an arbitrary (potentially read-only) address in the current
 // process by temporarily relaxing page protection.
-static bool WriteMemorySafe(void *dst, const void *src, size_t size)
-{
+static bool WriteMemorySafe(void* dst, const void* src, size_t size) {
     DWORD oldProt = 0;
     if (!VirtualProtect(dst, size, PAGE_READWRITE, &oldProt))
         return false;
     memcpy(dst, src, size);
-    VirtualProtect(dst, size, oldProt, &oldProt); // restore; ignore error
+    VirtualProtect(dst, size, oldProt, &oldProt);  // restore; ignore error
     return true;
 }
 
@@ -400,27 +412,28 @@ static bool WriteMemorySafe(void *dst, const void *src, size_t size)
 
 static const float kSrgbConsts[4] = {2.4f, 0.04045f, 0.055000f, 0.94786733f};
 static const float kPatchConsts[4] = {0.0f, 0.0f, 0.0f, 1.0f};
-// Index 0 (the exponent) is replaced with the user-chosen gamma, not kPatchConsts[0].
+// Index 0 (the exponent) is replaced with the user-chosen gamma, not
+// kPatchConsts[0].
 
 // Searches 'buf' (a copy of a shader blob) for the sRGB vec3-splat patterns and
-// patches them in-place. Fills counts[4] with the number of replacements made for
-// each constant. Returns the number of constants that had at least one match (0–4).
-// Callers must require == 4 to ensure all-or-nothing patching, and should log the
-// individual counts: some constants (e.g. 0.055) appear in both decode and encode
-// paths, so a count > 1 indicates unexpected overlap that would corrupt unintended code.
-static int PatchShaderBuf(BYTE *buf, DWORD size, float gamma, int counts[4])
-{
+// patches them in-place. Fills counts[4] with the number of replacements made
+// for each constant. Returns the number of constants that had at least one
+// match (0–4). Callers must require == 4 to ensure all-or-nothing patching, and
+// should log the individual counts: some constants (e.g. 0.055) appear in both
+// decode and encode paths, so a count > 1 indicates unexpected overlap that
+// would corrupt unintended code.
+static int PatchShaderBuf(BYTE* buf, DWORD size, float gamma, int counts[4]) {
     int found = 0;
-    for (int ci = 0; ci < 4; ci++)
-    {
+    for (int ci = 0; ci < 4; ci++) {
         float src = kSrgbConsts[ci];
         float dst = (ci == 0) ? gamma : kPatchConsts[ci];
         float pat[3] = {src, src, src};
         counts[ci] = 0;
-        // Search from after the header; stop where a full 12-byte match would overflow.
-        // DXBC constants are DWORD-aligned, so step by 4 for correctness and speed.
-        for (size_t j = kDXBCHeaderSize; j + sizeof(float) * 3 <= size; j += 4)
-        {
+        // Search from after the header; stop where a full 12-byte match would
+        // overflow. DXBC constants are DWORD-aligned, so step by 4 for
+        // correctness and speed.
+        for (size_t j = kDXBCHeaderSize; j + sizeof(float) * 3 <= size;
+             j += 4) {
             if (memcmp(pat, buf + j, sizeof(pat)) != 0)
                 continue;
             float rep[3] = {dst, dst, dst};
@@ -438,17 +451,15 @@ static int PatchShaderBuf(BYTE *buf, DWORD size, float gamma, int counts[4])
 // Container blobs have sub-blobs; leaf shaders do not. Distinguishing them
 // prevents patching a container as a leaf, which would leave internal
 // sub-blob checksums stale.
-static bool HasDXBCSubBlob(const DXBCHeader *hdr)
-{
-    const BYTE *base = (const BYTE *)hdr;
-    // DXBC sub-blobs are at DWORD-aligned offsets within a container (verified).
-    for (size_t k = kDXBCHeaderSize; k + kDXBCHeaderSize <= hdr->size; k += 4)
-    {
-        const auto *inner = (const DXBCHeader *)(base + k);
+static bool HasDXBCSubBlob(const DXBCHeader* hdr) {
+    const BYTE* base = (const BYTE*)hdr;
+    // DXBC sub-blobs are at DWORD-aligned offsets within a container
+    // (verified).
+    for (size_t k = kDXBCHeaderSize; k + kDXBCHeaderSize <= hdr->size; k += 4) {
+        const auto* inner = (const DXBCHeader*)(base + k);
         if (inner->magic[0] == 'D' && inner->magic[1] == 'X' &&
             inner->magic[2] == 'B' && inner->magic[3] == 'C' &&
-            inner->reserved == 1 &&
-            inner->size >= (DWORD)kDXBCHeaderSize &&
+            inner->reserved == 1 && inner->size >= (DWORD)kDXBCHeaderSize &&
             k + inner->size <= hdr->size)
             return true;
     }
@@ -456,12 +467,11 @@ static bool HasDXBCSubBlob(const DXBCHeader *hdr)
 }
 
 // Returns true if CalcDXBCChecksum reproduces the blob's own embedded checksum.
-// Used as a pre-flight check before writing a new checksum into a container blob
-// that is not on the known-checksum allowlist.
-static bool ChecksumRoundTrips(const DXBCHeader *hdr)
-{
+// Used as a pre-flight check before writing a new checksum into a container
+// blob that is not on the known-checksum allowlist.
+static bool ChecksumRoundTrips(const DXBCHeader* hdr) {
     DWORD verify[4];
-    CalcDXBCChecksum((const BYTE *)hdr, hdr->size, verify);
+    CalcDXBCChecksum((const BYTE*)hdr, hdr->size, verify);
     return memcmp(verify, hdr->checksum, 16) == 0;
 }
 
@@ -471,62 +481,67 @@ static bool ChecksumRoundTrips(const DXBCHeader *hdr)
 
 // Scans a read-only committed memory region for DXBC shader blobs, patches any
 // that match the known checksums, and appends restoration records to g_patches.
-// Accumulates matched-shader bits into matchedMask (bit i = kKnownChecksums[i] patched).
-// Returns the number of individual shaders patched.
+// Accumulates matched-shader bits into matchedMask (bit i = kKnownChecksums[i]
+// patched). Returns the number of individual shaders patched.
 //
 // "Big shader" handling: dwmcore.dll embeds the target shaders as sub-blobs
 // inside larger DXBC container blobs. The container's own checksum must be
 // recalculated after its inner shaders are patched.
-static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma, unsigned &matchedMask)
-{
+static int ScanRegionForShaders(BYTE* region,
+                                size_t regionSize,
+                                float gamma,
+                                unsigned& matchedMask) {
     int numPatched = 0;
 
-    DXBCHeader *bigShader = nullptr;   // enclosing container blob, if any
-    bool bigPatched = false;           // did we patch any sub-shader inside it?
-    size_t containerPatchBase = 0;     // g_patches index when the current container was accepted
-    unsigned containerMatchedBits = 0; // matchedMask bits set for the current container's leaves
+    DXBCHeader* bigShader = nullptr;  // enclosing container blob, if any
+    bool bigPatched = false;          // did we patch any sub-shader inside it?
+    size_t containerPatchBase =
+        0;  // g_patches index when the current container was accepted
+    unsigned containerMatchedBits =
+        0;  // matchedMask bits set for the current container's leaves
 
     // Finalizes a container whose inner shaders have been patched: saves its
     // original checksum, recomputes it, and writes it back. If the write fails,
     // rolls back all leaf patches belonging to this container and clears their
-    // bits from matchedMask so Wh_ModInit's all-or-nothing check stays accurate.
-    auto FinalizeContainer = [&](DXBCHeader *container) -> bool
-    {
+    // bits from matchedMask so Wh_ModInit's all-or-nothing check stays
+    // accurate.
+    auto FinalizeContainer = [&](DXBCHeader* container) -> bool {
         PatchRecord bigRec;
-        bigRec.addr = (BYTE *)container + 4;
+        bigRec.addr = (BYTE*)container + 4;
         bigRec.original.assign(bigRec.addr, bigRec.addr + 16);
         g_patches.push_back(std::move(bigRec));
 
         DWORD newCk[4];
-        CalcDXBCChecksum((const BYTE *)container, container->size, newCk);
-        if (!WriteMemorySafe((BYTE *)container + 4, newCk, 16))
-        {
-            g_patches.pop_back(); // remove the checksum record we just pushed
+        CalcDXBCChecksum((const BYTE*)container, container->size, newCk);
+        if (!WriteMemorySafe((BYTE*)container + 4, newCk, 16)) {
+            g_patches.pop_back();  // remove the checksum record we just pushed
             size_t toRollBack = g_patches.size() - containerPatchBase;
-            Wh_Log(L"  VirtualProtect failed for container at %p — rolling back %zu leaf patch(es)",
-                   (void *)container, toRollBack);
-            while (g_patches.size() > containerPatchBase)
-            {
-                auto &rec = g_patches.back();
-                WriteMemorySafe(rec.addr, rec.original.data(), rec.original.size());
+            Wh_Log(
+                L"  VirtualProtect failed for container at %p — rolling back "
+                L"%zu leaf patch(es)",
+                (void*)container, toRollBack);
+            while (g_patches.size() > containerPatchBase) {
+                auto& rec = g_patches.back();
+                WriteMemorySafe(rec.addr, rec.original.data(),
+                                rec.original.size());
                 g_patches.pop_back();
                 numPatched--;
             }
-            matchedMask &= ~containerMatchedBits; // un-mark the rolled-back shaders
+            matchedMask &=
+                ~containerMatchedBits;  // un-mark the rolled-back shaders
             return false;
         }
-        Wh_Log(L"  Fixed container checksum at %p", (void *)container);
+        Wh_Log(L"  Fixed container checksum at %p", (void*)container);
         return true;
     };
 
-    // All DXBC blobs in dwmcore.dll's .rdata are DWORD-aligned (verified by scanning
-    // the binary: 0 of 404 occurrences are unaligned). Step by 4 for speed.
-    for (size_t i = 0; i + kDXBCHeaderSize <= regionSize; i += 4)
-    {
+    // All DXBC blobs in dwmcore.dll's .rdata are DWORD-aligned (verified by
+    // scanning the binary: 0 of 404 occurrences are unaligned). Step by 4 for
+    // speed.
+    for (size_t i = 0; i + kDXBCHeaderSize <= regionSize; i += 4) {
         // If we have advanced past the end of the current container blob,
         // finalize it if we patched any inner shaders.
-        if (bigShader && region + i >= (BYTE *)bigShader + bigShader->size)
-        {
+        if (bigShader && region + i >= (BYTE*)bigShader + bigShader->size) {
             if (bigPatched)
                 FinalizeContainer(bigShader);
             bigShader = nullptr;
@@ -534,7 +549,7 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma, un
             containerMatchedBits = 0;
         }
 
-        auto *hdr = (DXBCHeader *)(region + i);
+        auto* hdr = (DXBCHeader*)(region + i);
 
         // Validate DXBC magic and reserved field.
         if (hdr->magic[0] != 'D' || hdr->magic[1] != 'X' ||
@@ -547,33 +562,38 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma, un
         if (hdr->size < (DWORD)kDXBCHeaderSize || i + hdr->size > regionSize)
             continue;
 
-        // Container blobs embed sub-shaders as nested DXBC blobs; leaf shaders do not.
-        // Track containers so we can fix their checksum after inner shaders are patched.
-        if (HasDXBCSubBlob(hdr))
-        {
-            if (!bigShader)
-            {
-                // Pre-flight: verify our checksum routine reproduces this blob's own
-                // hash before we commit to overwriting it. An unlisted container whose
-                // hash doesn't round-trip is skipped to avoid silent corruption.
-                if (!ChecksumRoundTrips(hdr))
-                {
-                    Wh_Log(L"  Container at %p: checksum did not round-trip, skipping", (void *)hdr);
-                    i += hdr->size - 4; // loop will add 4 more, landing just after the blob
+        // Container blobs embed sub-shaders as nested DXBC blobs; leaf shaders
+        // do not. Track containers so we can fix their checksum after inner
+        // shaders are patched.
+        if (HasDXBCSubBlob(hdr)) {
+            if (!bigShader) {
+                // Pre-flight: verify our checksum routine reproduces this
+                // blob's own hash before we commit to overwriting it. An
+                // unlisted container whose hash doesn't round-trip is skipped
+                // to avoid silent corruption.
+                if (!ChecksumRoundTrips(hdr)) {
+                    Wh_Log(
+                        L"  Container at %p: checksum did not round-trip, "
+                        L"skipping",
+                        (void*)hdr);
+                    i +=
+                        hdr->size -
+                        4;  // loop will add 4 more, landing just after the blob
                     continue;
                 }
                 bigShader = hdr;
                 containerPatchBase = g_patches.size();
                 containerMatchedBits = 0;
-            }
-            else
-            {
-                // A nested container inside the current one: multi-level nesting is
-                // not supported. Skip past the inner blob so its leaves are not
-                // patched without a proper container fixup.
-                Wh_Log(L"  Nested container at %p inside %p — skipping unsupported nesting depth",
-                       (void *)hdr, (void *)bigShader);
-                i += hdr->size - 4; // loop will add 4 more, landing just after the blob
+            } else {
+                // A nested container inside the current one: multi-level
+                // nesting is not supported. Skip past the inner blob so its
+                // leaves are not patched without a proper container fixup.
+                Wh_Log(
+                    L"  Nested container at %p inside %p — skipping "
+                    L"unsupported nesting depth",
+                    (void*)hdr, (void*)bigShader);
+                i += hdr->size -
+                     4;  // loop will add 4 more, landing just after the blob
             }
             continue;
         }
@@ -583,10 +603,8 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma, un
         // detection would over-patch unrelated shaders; checksums select the
         // correct four. The constant search below acts as a sanity check.
         int matchIdx = -1;
-        for (int k = 0; k < 4; k++)
-        {
-            if (memcmp(kKnownChecksums[k], hdr->checksum, 16) == 0)
-            {
+        for (int k = 0; k < 4; k++) {
+            if (memcmp(kKnownChecksums[k], hdr->checksum, 16) == 0) {
                 matchIdx = k;
                 break;
             }
@@ -594,22 +612,24 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma, un
         if (matchIdx < 0)
             continue;
 
-        // Verify our checksum implementation can reproduce this blob's exact hash
-        // before rewriting it. A wrong hash here makes D3D reject the shader,
-        // which in DWM means a compositor failure rather than a cosmetic glitch.
-        if (!ChecksumRoundTrips(hdr))
-        {
-            Wh_Log(L"  Shader #%d at %p: checksum did not round-trip, skipping", matchIdx, (void *)hdr);
+        // Verify our checksum implementation can reproduce this blob's exact
+        // hash before rewriting it. A wrong hash here makes D3D reject the
+        // shader, which in DWM means a compositor failure rather than a
+        // cosmetic glitch.
+        if (!ChecksumRoundTrips(hdr)) {
+            Wh_Log(L"  Shader #%d at %p: checksum did not round-trip, skipping",
+                   matchIdx, (void*)hdr);
             continue;
         }
 
         // Verify the leaf actually lies within the tracked container's bounds
-        // before attributing the patch to that container. A positional false-positive
-        // (a blob that looked like a container but preceded the real one) would
-        // otherwise get its checksum overwritten for leaves it doesn't contain.
-        bool insideContainer = bigShader &&
-                               (BYTE *)hdr >= (BYTE *)bigShader &&
-                               (BYTE *)hdr + hdr->size <= (BYTE *)bigShader + bigShader->size;
+        // before attributing the patch to that container. A positional
+        // false-positive (a blob that looked like a container but preceded the
+        // real one) would otherwise get its checksum overwritten for leaves it
+        // doesn't contain.
+        bool insideContainer =
+            bigShader && (BYTE*)hdr >= (BYTE*)bigShader &&
+            (BYTE*)hdr + hdr->size <= (BYTE*)bigShader + bigShader->size;
 
         // Checksum matched — copy the blob, patch the sRGB constants, verify
         // all four were found, then recompute the DXBC checksum.
@@ -617,15 +637,29 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma, un
         memcpy(patched.data(), hdr, hdr->size);
 
         int counts[4] = {};
-        int constsFound = PatchShaderBuf(patched.data(), hdr->size, gamma, counts);
-        if (constsFound < 4)
-        {
-            Wh_Log(L"  Shader #%d: checksum matched but only %d/4 sRGB constants found",
-                   matchIdx, constsFound);
+        int constsFound =
+            PatchShaderBuf(patched.data(), hdr->size, gamma, counts);
+        if (constsFound < 4) {
+            Wh_Log(
+                L"  Shader #%d: checksum matched but only %d/4 sRGB constants "
+                L"found",
+                matchIdx, constsFound);
             continue;
         }
-        for (int ci = 0; ci < 4; ci++)
-            Wh_Log(L"  Shader #%d: constant %d replaced %d time(s)", matchIdx, ci, counts[ci]);
+        bool countsOk = true;
+        for (int ci = 0; ci < 4; ci++) {
+            Wh_Log(L"  Shader #%d: constant %d replaced %d time(s)", matchIdx,
+                   ci, counts[ci]);
+            if (counts[ci] != 1)
+                countsOk = false;
+        }
+        if (!countsOk) {
+            Wh_Log(
+                L"  Shader #%d: expected each constant exactly once — skipping "
+                L"to avoid corruption",
+                matchIdx);
+            continue;
+        }
 
         DWORD newCk[4];
         CalcDXBCChecksum(patched.data(), hdr->size, newCk);
@@ -633,26 +667,26 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma, un
 
         // Save the original bytes for later restoration.
         PatchRecord rec;
-        rec.addr = (BYTE *)hdr;
+        rec.addr = (BYTE*)hdr;
         rec.original.assign(rec.addr, rec.addr + hdr->size);
 
         // Write the patched shader back into the (read-only) memory region.
-        if (!WriteMemorySafe((BYTE *)hdr, patched.data(), hdr->size))
-        {
-            Wh_Log(L"  VirtualProtect failed for shader #%d at %p", matchIdx, (void *)hdr);
+        if (!WriteMemorySafe((BYTE*)hdr, patched.data(), hdr->size)) {
+            Wh_Log(L"  VirtualProtect failed for shader #%d at %p", matchIdx,
+                   (void*)hdr);
             continue;
         }
 
         g_patches.push_back(std::move(rec));
         numPatched++;
         matchedMask |= 1u << matchIdx;
-        if (insideContainer)
-        {
+        if (insideContainer) {
             containerMatchedBits |= 1u << matchIdx;
             bigPatched = true;
         }
 
-        Wh_Log(L"  Patched shader #%d at %p (size %lu)", matchIdx, (void *)hdr, hdr->size);
+        Wh_Log(L"  Patched shader #%d at %p (size %lu)", matchIdx, (void*)hdr,
+               hdr->size);
     }
 
     // Handle a container blob that reaches the very end of the region.
@@ -663,15 +697,15 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma, un
 }
 
 // Restores all patched memory regions to their original bytes.
-static void RestoreAllPatches()
-{
+static void RestoreAllPatches() {
     // Iterate in reverse so sub-shader records (added first) are restored after
-    // their container checksum records (added last), giving a consistent final state.
-    for (auto it = g_patches.rbegin(); it != g_patches.rend(); ++it)
-    {
-        if (!WriteMemorySafe(it->addr, it->original.data(), it->original.size()))
+    // their container checksum records (added last), giving a consistent final
+    // state.
+    for (auto it = g_patches.rbegin(); it != g_patches.rend(); ++it) {
+        if (!WriteMemorySafe(it->addr, it->original.data(),
+                             it->original.size()))
             Wh_Log(L"  VirtualProtect failed restoring %zu bytes at %p",
-                   it->original.size(), (void *)it->addr);
+                   it->original.size(), (void*)it->addr);
     }
     g_patches.clear();
 }
@@ -680,24 +714,24 @@ static void RestoreAllPatches()
 // Windhawk callbacks
 // =============================================================================
 
-BOOL Wh_ModInit()
-{
-    // Resolve the gamma setting via lookup table to avoid locale-dependent wcstof
-    // behaviour: a locale with ',' as the decimal separator would silently parse
-    // "2.2" as 2.0, which passes a range check without any visible error.
-    static const struct
-    {
-        const wchar_t *str;
+BOOL Wh_ModInit() {
+    // Resolve the gamma setting via lookup table to avoid locale-dependent
+    // wcstof behaviour: a locale with ',' as the decimal separator would
+    // silently parse "2.2" as 2.0, which passes a range check without any
+    // visible error.
+    static const struct {
+        const wchar_t* str;
         float val;
-    } kGammaOptions[] = {
-        {L"1.8", 1.8f}, {L"2.0", 2.0f}, {L"2.2", 2.2f}, {L"2.4", 2.4f}, {L"2.6", 2.6f}};
+    } kGammaOptions[] = {{L"1.8", 1.8f},
+                         {L"2.0", 2.0f},
+                         {L"2.2", 2.2f},
+                         {L"2.4", 2.4f},
+                         {L"2.6", 2.6f}};
     float gamma = 2.2f;
     {
         auto gammaSetting = WindhawkUtils::StringSetting::make(L"GammaCurve");
-        for (const auto &opt : kGammaOptions)
-        {
-            if (wcscmp(gammaSetting, opt.str) == 0)
-            {
+        for (const auto& opt : kGammaOptions) {
+            if (wcscmp(gammaSetting, opt.str) == 0) {
                 gamma = opt.val;
                 break;
             }
@@ -712,27 +746,27 @@ BOOL Wh_ModInit()
     // LoadLibraryExW hook. (Verified: "dwmcore.dll" appears in dwm.exe's
     // raw import-table bytes at a fixed offset.)
     HMODULE hDwmcore = GetModuleHandleW(L"dwmcore.dll");
-    if (!hDwmcore)
-    {
+    if (!hDwmcore) {
         Wh_Log(L"dwmcore.dll not found — unexpected, please file an issue");
         return FALSE;
     }
 
     // Determine the module's address range from its PE header.
-    auto *dos = (IMAGE_DOS_HEADER *)hDwmcore;
-    auto *nt = (IMAGE_NT_HEADERS *)((BYTE *)hDwmcore + dos->e_lfanew);
-    BYTE *modBase = (BYTE *)hDwmcore;
+    auto* dos = (IMAGE_DOS_HEADER*)hDwmcore;
+    auto* nt = (IMAGE_NT_HEADERS*)((BYTE*)hDwmcore + dos->e_lfanew);
+    BYTE* modBase = (BYTE*)hDwmcore;
     size_t modSize = nt->OptionalHeader.SizeOfImage;
 
-    Wh_Log(L"dwmcore.dll base %p, image size %zu", (void *)modBase, modSize);
+    Wh_Log(L"dwmcore.dll base %p, image size %zu", (void*)modBase, modSize);
 
     // Walk PE sections instead of VirtualQuery: deterministic regardless of
     // page-protection fragmentation from other mods or the loader.
     unsigned matchedMask = 0;
-    auto *sec = IMAGE_FIRST_SECTION(nt);
-    for (WORD s = 0; s < nt->FileHeader.NumberOfSections; s++, sec++)
-    {
-        // Scan readable, non-writable, non-executable sections only (e.g. .rdata).
+    int totalPatched = 0;
+    auto* sec = IMAGE_FIRST_SECTION(nt);
+    for (WORD s = 0; s < nt->FileHeader.NumberOfSections; s++, sec++) {
+        // Scan readable, non-writable, non-executable sections only (e.g.
+        // .rdata).
         if (!(sec->Characteristics & IMAGE_SCN_MEM_READ))
             continue;
         if (sec->Characteristics & IMAGE_SCN_MEM_EXECUTE)
@@ -743,42 +777,47 @@ BOOL Wh_ModInit()
             continue;
 
         Wh_Log(L"Scanning section at %p, size %lu",
-               (void *)(modBase + sec->VirtualAddress), sec->Misc.VirtualSize);
-        ScanRegionForShaders(modBase + sec->VirtualAddress,
-                             sec->Misc.VirtualSize, gamma, matchedMask);
+               (void*)(modBase + sec->VirtualAddress), sec->Misc.VirtualSize);
+        totalPatched +=
+            ScanRegionForShaders(modBase + sec->VirtualAddress,
+                                 sec->Misc.VirtualSize, gamma, matchedMask);
     }
 
-    if (matchedMask == 0)
-    {
-        // No target shaders found at all. Most likely HDR is disabled (the patched
-        // code path is only active when the display is in HDR mode) or dwmcore.dll
-        // was updated and its shader checksums changed.
-        Wh_Log(L"No target shaders found — HDR may be off, or dwmcore.dll checksums changed after a Windows Update");
+    if (matchedMask == 0) {
+        // No target shaders found. The DXBC blobs live in dwmcore.dll's .rdata
+        // and are present regardless of HDR state, so matchedMask == 0 means
+        // the known checksums no longer match — dwmcore.dll was recompiled by a
+        // Windows Update.
+        Wh_Log(
+            L"No target shaders found — dwmcore.dll checksums changed after a "
+            L"Windows Update; please file an issue");
         return FALSE;
     }
-    if (matchedMask != 0xFu)
-    {
-        // Partial patch: some but not all of the four target shaders were found.
-        // Leaving DWM with a mix of power-law and sRGB surfaces would produce
-        // inconsistent rendering, so revert everything.
-        Wh_Log(L"Partial patch (mask 0x%X of 0xF) — reverting to avoid inconsistent SDR rendering", matchedMask);
+    if (matchedMask != 0xFu) {
+        // Partial patch: some but not all of the four target shaders were
+        // found. Leaving DWM with a mix of power-law and sRGB surfaces would
+        // produce inconsistent rendering, so revert everything.
+        Wh_Log(
+            L"Partial patch (mask 0x%X of 0xF) — reverting to avoid "
+            L"inconsistent SDR rendering",
+            matchedMask);
         RestoreAllPatches();
         return FALSE;
     }
-    Wh_Log(L"All 4 target shaders patched with gamma %.1f", (double)gamma);
+    Wh_Log(L"All 4 target shaders patched (%d blob(s) written) with gamma %.1f",
+           totalPatched, (double)gamma);
     return TRUE;
 }
 
-void Wh_ModBeforeUninit()
-{
+void Wh_ModBeforeUninit() {
     Wh_Log(L"Restoring original shader bytes");
     RestoreAllPatches();
 }
 
 // When the user changes the gamma setting, reload the mod so Wh_ModInit runs
-// again with the new value. DWM must be restarted for the new shaders to compile.
-BOOL Wh_ModSettingsChanged(BOOL *bReload)
-{
+// again with the new value. DWM must be restarted for the new shaders to
+// compile.
+BOOL Wh_ModSettingsChanged(BOOL* bReload) {
     *bReload = TRUE;
     return TRUE;
 }

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -82,7 +82,7 @@ effect.
 | 2.0   | Compromise between 1.8 and 2.2 |
 | 2.2   | **Default** - Standard PC/monitor target, sRGB average and Display P3 |
 | 2.3   | Compromise between 2.2 and 2.4 |
-| 2.4   | Broadcast and HDTV, Rec. 709 / BT.1886 |
+| 2.4   | Broadcast and HDTV, Rec.709 / BT.1886 |
 | 2.6   | Dark and high contrast, Digital cinema projection, DCI-P3 |
 
 ## Known limitations
@@ -123,9 +123,9 @@ effect.
   $options:
     - "1.8": "1.8 (Bright and low contrast, legacy Mac standard)"
     - "2.0": "2.0"
-    - "2.2": "2.2 (**Default** - Standard PC/monitor target, sRGB average and Display P3)"
+    - "2.2": "2.2 (Default - Standard PC/monitor target, sRGB average and Display P3)"
     - "2.3": "2.3"
-    - "2.4": "2.4 (Broadcast and HDTV, Rec. 709 / BT.1886)"
+    - "2.4": "2.4 (Broadcast and HDTV, Rec.709 / BT.1886)"
     - "2.6": "2.6 (Dark and high contrast, Digital cinema projection, DCI-P3)"
 */
 // ==/WindhawkModSettings==
@@ -140,8 +140,28 @@ effect.
 // =============================================================================
 // DXBC Checksum — AMD DXBCChecksum (modified MD5 used by Microsoft for DXBC)
 // Source: https://github.com/GPUOpen-Archive/common-src-ShaderUtils
-// Copyright 2008-2016 Advanced Micro Devices, Inc. All rights reserved.
-// Free for all — MD5 algorithm derived from RSA Data Security, Inc. (1990).
+//
+// Copyright (c) 2016-2018 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// MD5 algorithm derived from RSA Data Security, Inc. (1990).
 // =============================================================================
 
 typedef uint32_t DX_UINT4;
@@ -405,14 +425,17 @@ static const float kPatchConsts[3] = {0.0f, 0.0f, 1.0f};
 // with at least one match. Used to pre-screen blobs before allocating a copy
 // and to count qualifying leaves inside skipped containers.
 static int ScanSrgbSplats(const BYTE* blob, DWORD size, int counts[4]) {
-    for (int ci = 0; ci < 4; ci++)
+    // Precompute the four vec3-splat patterns once before scanning.
+    float pats[4][3];
+    for (int ci = 0; ci < 4; ci++) {
+        pats[ci][0] = pats[ci][1] = pats[ci][2] = kSrgbConsts[ci];
         counts[ci] = 0;
+    }
     int found = 0;
     for (size_t j = kDXBCHeaderSize; j + sizeof(float) * 3 <= size; j += 4) {
         const BYTE* p = blob + j;
         for (int ci = 0; ci < 4; ci++) {
-            float pat[3] = {kSrgbConsts[ci], kSrgbConsts[ci], kSrgbConsts[ci]};
-            if (memcmp(p, pat, sizeof(pat)) == 0)
+            if (memcmp(p, pats[ci], sizeof(float) * 3) == 0)
                 counts[ci]++;
         }
     }

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -7,7 +7,7 @@
 // @github          https://github.com/millerpb
 // @license         GPL-3.0-or-later
 // @include         dwm.exe
-// @architecture    amd64
+// @architecture    x86-64
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -1,8 +1,8 @@
+// clang-format off
 // ==WindhawkMod==
 // @id              dwm-eotf-gamma
 // @name            Windows SDR to HDR Tonemapping Fix
-// @description     Replaces DWM's sRGB EOTF with a pure power-law gamma for
-// SDR-to-HDR tone mapping
+// @description     Replaces DWM's sRGB EOTF with a pure power-law gamma for SDR-to-HDR tone mapping
 // @version         1.0
 // @author          millerpb
 // @github          https://github.com/millerpb
@@ -122,6 +122,7 @@ effect.
     - "2.6": "2.6 (dark / high contrast)"
 */
 // ==/WindhawkModSettings==
+// clang-format on
 
 #include <windhawk_utils.h>
 #include <windows.h>

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -80,7 +80,7 @@ effect.
 |-------|-------------|
 | 1.8   | Bright and low contrast, legacy Mac standard |
 | 2.0   | Compromise between 1.8 and 2.2 |
-| 2.2   | Standard PC/monitor target, sRGB average and Display P3 |
+| 2.2   | **Default** - Standard PC/monitor target, sRGB average and Display P3 |
 | 2.3   | Compromise between 2.2 and 2.4 |
 | 2.4   | Broadcast and HDTV, Rec. 709 / BT.1886 |
 | 2.6   | Dark and high contrast, Digital cinema projection, DCI-P3 |
@@ -123,7 +123,7 @@ effect.
   $options:
     - "1.8": "1.8 (Bright and low contrast, legacy Mac standard)"
     - "2.0": "2.0"
-    - "2.2": "2.2 (Standard PC/monitor target, sRGB average and Display P3)"
+    - "2.2": "2.2 (**Default** - Standard PC/monitor target, sRGB average and Display P3)"
     - "2.3": "2.3"
     - "2.4": "2.4 (Broadcast and HDTV, Rec. 709 / BT.1886)"
     - "2.6": "2.6 (Dark and high contrast, Digital cinema projection, DCI-P3)"

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -35,7 +35,7 @@ replacing the sRGB curve with a simple power-law gamma. This gives you direct
 control over the SDR-to-HDR tone mapping without permanently modifying any files
 on disk.
 
-Based on [dwm_eotf](https://github.com/ledoge/dwm_eotf) by ledoge (GPL-3.0).
+Originally based on [dwm_eotf](https://github.com/ledoge/dwm_eotf) by ledoge (GPL-3.0), but expanded
 
 ## How it works
 
@@ -100,9 +100,8 @@ effect.
   patching or unpatching at runtime has no effect on shaders that are already
   compiled. The flicker is driven by Chrome's own mode-switching and cannot be
   suppressed from the DWM side.
-- If the mod logs "No target shaders found" after a Windows Update, the shader
-  structure in `dwmcore.dll` has changed (verified against 10.0.26100.8521).
-  Please file an issue.
+- If the mod logs "No sRGB EOTF shaders found" after a Windows Update, the
+  constant encoding in `dwmcore.dll` has changed format. Please file an issue.
 - If the desktop stops rendering correctly after enabling this mod, boot into
   Safe Mode (Windhawk does not inject there) or start Windhawk with
   `windhawk.exe -safe-mode`, then disable or uninstall the mod.
@@ -357,30 +356,13 @@ struct PatchRecord {
 
 static std::vector<PatchRecord> g_patches;
 
-// Known DXBC checksums for the four sRGB-EOTF target shaders in dwmcore.dll.
-// Verified against dwmcore.dll 10.0.26100.8521 (Windows 11 24H2).
-//
-// Used as the primary selector: dwmcore.dll contains dozens of other shaders
-// that also contain sRGB constants, so constant-only detection alone
-// over-patches. A content-based fallback (accept leaf blobs containing all four
-// sRGB splats exactly once, require exactly four such blobs) was considered and
-// deferred: it would survive Windows Updates that recompile these shaders but
-// requires non-trivial cross-section state tracking. Left as a future
-// improvement.
-//
-// If these change after a Windows Update, please file an issue. The
-// per-constant replacement counts logged at INFO level help identify the new
-// shader blobs.
-static const BYTE kKnownChecksums[4][16] = {
-    {0x96, 0xe6, 0xd1, 0x58, 0x92, 0x55, 0xec, 0xcd, 0x1d, 0xd7, 0xd4, 0xdb,
-     0xec, 0x54, 0xd2, 0x85},
-    {0x21, 0x26, 0xb0, 0x37, 0xc1, 0xa2, 0xfb, 0xdd, 0xe3, 0x55, 0xb6, 0xe6,
-     0xdd, 0x9c, 0xaf, 0x3c},
-    {0x2c, 0x89, 0x26, 0xff, 0xe2, 0x29, 0xf0, 0x5d, 0x96, 0x7c, 0x72, 0x66,
-     0x8d, 0xc3, 0xad, 0xdb},
-    {0xf6, 0x93, 0xbf, 0xbb, 0xaf, 0x24, 0xb3, 0xd9, 0x36, 0x63, 0x54, 0xbe,
-     0x88, 0x98, 0xa7, 0xf5},
-};
+// The sRGB EOTF signature — all four vec3-splat constants present exactly once
+// in a leaf blob — is unique to the decode path and covers all ~37 shader
+// variants across DWM's compositing code paths. A checksum allowlist was used
+// previously (verified against dwmcore.dll 10.0.26100.8521) but only covered
+// four of the thirty-seven variants, causing the remaining unpatched shaders to
+// revert to sRGB EOTF during window focus and resize events. Content-based
+// detection is now the sole selector and requires no per-build maintenance.
 
 // =============================================================================
 // Memory helpers
@@ -517,32 +499,25 @@ static void LogSrgbCandidates(const BYTE* region, size_t regionSize) {
 // Region scanner
 // =============================================================================
 
-// Scans a read-only committed memory region for DXBC shader blobs, patches any
-// that match the known checksums, and appends restoration records to g_patches.
-// Accumulates matched-shader bits into matchedMask (bit i = kKnownChecksums[i]
-// patched). Returns the number of individual shaders patched.
+// Scans a read-only PE section for sRGB EOTF leaf DXBC blobs and patches them.
+// A leaf blob qualifies if it contains all four sRGB vec3-splat constants each
+// exactly once — a signature unique to the decode path. Returns the number of
+// blobs patched.
 //
-// "Big shader" handling: dwmcore.dll embeds the target shaders as sub-blobs
-// inside larger DXBC container blobs. The container's own checksum must be
-// recalculated after its inner shaders are patched.
-static int ScanRegionForShaders(BYTE* region,
-                                size_t regionSize,
-                                float gamma,
-                                unsigned& matchedMask) {
+// Container handling: dwmcore.dll embeds leaf shaders inside larger DXBC
+// container blobs. The container's checksum must be recalculated after any
+// inner leaf is patched.
+static int ScanRegionForShaders(BYTE* region, size_t regionSize, float gamma) {
     int numPatched = 0;
 
     DXBCHeader* bigShader = nullptr;  // enclosing container blob, if any
     bool bigPatched = false;          // did we patch any sub-shader inside it?
     size_t containerPatchBase =
         0;  // g_patches index when the current container was accepted
-    unsigned containerMatchedBits =
-        0;  // matchedMask bits set for the current container's leaves
 
     // Finalizes a container whose inner shaders have been patched: saves its
     // original checksum, recomputes it, and writes it back. If the write fails,
-    // rolls back all leaf patches belonging to this container and clears their
-    // bits from matchedMask so Wh_ModInit's all-or-nothing check stays
-    // accurate.
+    // rolls back all leaf patches belonging to this container.
     auto FinalizeContainer = [&](DXBCHeader* container) -> bool {
         PatchRecord bigRec;
         bigRec.addr = (BYTE*)container + 4;
@@ -565,8 +540,6 @@ static int ScanRegionForShaders(BYTE* region,
                 g_patches.pop_back();
                 numPatched--;
             }
-            matchedMask &=
-                ~containerMatchedBits;  // un-mark the rolled-back shaders
             return false;
         }
         Wh_Log(L"  Fixed container checksum at %p", (void*)container);
@@ -584,7 +557,6 @@ static int ScanRegionForShaders(BYTE* region,
                 FinalizeContainer(bigShader);
             bigShader = nullptr;
             bigPatched = false;
-            containerMatchedBits = 0;
         }
 
         auto* hdr = (DXBCHeader*)(region + i);
@@ -621,7 +593,6 @@ static int ScanRegionForShaders(BYTE* region,
                 }
                 bigShader = hdr;
                 containerPatchBase = g_patches.size();
-                containerMatchedBits = 0;
             } else {
                 // A nested container inside the current one: multi-level
                 // nesting is not supported. Skip past the inner blob so its
@@ -636,66 +607,42 @@ static int ScanRegionForShaders(BYTE* region,
             continue;
         }
 
-        // Leaf blob — match against the known-checksum allowlist.
-        // Many other DWM shaders also contain sRGB constants, so constant-only
-        // detection would over-patch unrelated shaders; checksums select the
-        // correct four. The constant search below acts as a sanity check.
-        int matchIdx = -1;
-        for (int k = 0; k < 4; k++) {
-            if (memcmp(kKnownChecksums[k], hdr->checksum, 16) == 0) {
-                matchIdx = k;
-                break;
-            }
-        }
-        if (matchIdx < 0)
-            continue;
-
-        // Verify our checksum implementation can reproduce this blob's exact
-        // hash before rewriting it. A wrong hash here makes D3D reject the
-        // shader, which in DWM means a compositor failure rather than a
-        // cosmetic glitch.
-        if (!ChecksumRoundTrips(hdr)) {
-            Wh_Log(L"  Shader #%d at %p: checksum did not round-trip, skipping",
-                   matchIdx, (void*)hdr);
-            continue;
-        }
-
-        // Verify the leaf actually lies within the tracked container's bounds
-        // before attributing the patch to that container. A positional
-        // false-positive (a blob that looked like a container but preceded the
-        // real one) would otherwise get its checksum overwritten for leaves it
-        // doesn't contain.
+        // Leaf blob: use content-based detection. The four sRGB EOTF vec3-splat
+        // constants together are unique to the decode path — any leaf
+        // containing all four (each exactly once) is an sRGB EOTF shader
+        // regardless of its compiled checksum. This covers all ~37 shader
+        // variants in DWM.
         bool insideContainer =
             bigShader && (BYTE*)hdr >= (BYTE*)bigShader &&
             (BYTE*)hdr + hdr->size <= (BYTE*)bigShader + bigShader->size;
 
-        // Checksum matched — copy the blob, patch the sRGB constants, verify
-        // all four were found, then recompute the DXBC checksum.
+        // Copy the blob and attempt to patch the sRGB constants.
         std::vector<BYTE> patched(hdr->size);
         memcpy(patched.data(), hdr, hdr->size);
 
         int counts[4] = {};
         int constsFound =
             PatchShaderBuf(patched.data(), hdr->size, gamma, counts);
-        if (constsFound < 4) {
-            Wh_Log(
-                L"  Shader #%d: checksum matched but only %d/4 sRGB constants "
-                L"found",
-                matchIdx, constsFound);
-            continue;
-        }
+        if (constsFound < 4)
+            continue;  // not an sRGB EOTF shader — discard the copy
+
         bool countsOk = true;
         for (int ci = 0; ci < 4; ci++) {
-            Wh_Log(L"  Shader #%d: constant %d replaced %d time(s)", matchIdx,
-                   ci, counts[ci]);
-            if (counts[ci] != 1)
+            if (counts[ci] != 1) {
+                Wh_Log(L"  Blob at %p: constant %d count %d != 1 — skipping",
+                       (void*)hdr, ci, counts[ci]);
                 countsOk = false;
+            }
         }
-        if (!countsOk) {
-            Wh_Log(
-                L"  Shader #%d: expected each constant exactly once — skipping "
-                L"to avoid corruption",
-                matchIdx);
+        if (!countsOk)
+            continue;
+
+        // Pre-flight: verify our checksum implementation reproduces this blob's
+        // own hash before writing a new one. A wrong hash makes D3D reject the
+        // shader, causing a compositor failure rather than a cosmetic glitch.
+        if (!ChecksumRoundTrips(hdr)) {
+            Wh_Log(L"  Blob at %p: checksum did not round-trip, skipping",
+                   (void*)hdr);
             continue;
         }
 
@@ -715,20 +662,16 @@ static int ScanRegionForShaders(BYTE* region,
         // same bytes — the same window as delta writes. Delta writes would
         // reduce COW pages and PatchRecord size but not improve correctness.
         if (!WriteMemorySafe((BYTE*)hdr, patched.data(), hdr->size)) {
-            Wh_Log(L"  VirtualProtect failed for shader #%d at %p", matchIdx,
-                   (void*)hdr);
+            Wh_Log(L"  VirtualProtect failed for blob at %p", (void*)hdr);
             continue;
         }
 
         g_patches.push_back(std::move(rec));
         numPatched++;
-        matchedMask |= 1u << matchIdx;
-        if (insideContainer) {
-            containerMatchedBits |= 1u << matchIdx;
+        if (insideContainer)
             bigPatched = true;
-        }
 
-        Wh_Log(L"  Patched shader #%d at %p (size %lu)", matchIdx, (void*)hdr,
+        Wh_Log(L"  Patched sRGB EOTF shader at %p (size %lu)", (void*)hdr,
                hdr->size);
         i += hdr->size - 4;  // skip the blob body; loop adds 4
     }
@@ -805,7 +748,6 @@ BOOL Wh_ModInit() {
 
     // Walk PE sections instead of VirtualQuery: deterministic regardless of
     // page-protection fragmentation from other mods or the loader.
-    unsigned matchedMask = 0;
     int totalPatched = 0;
     auto* sec = IMAGE_FIRST_SECTION(nt);
     for (WORD s = 0; s < nt->FileHeader.NumberOfSections; s++, sec++) {
@@ -822,17 +764,17 @@ BOOL Wh_ModInit() {
 
         Wh_Log(L"Scanning section at %p, size %lu",
                (void*)(modBase + sec->VirtualAddress), sec->Misc.VirtualSize);
-        totalPatched +=
-            ScanRegionForShaders(modBase + sec->VirtualAddress,
-                                 sec->Misc.VirtualSize, gamma, matchedMask);
+        totalPatched += ScanRegionForShaders(modBase + sec->VirtualAddress,
+                                             sec->Misc.VirtualSize, gamma);
     }
 
-    // If the allowlist didn't match all four shaders, run a read-only candidate
-    // scan to log checksums of sRGB-matching blobs in this build. This gives
-    // reporters something to paste into an issue without manual extraction.
-    if (matchedMask != 0xFu) {
-        Wh_Log(L"Scanning for sRGB candidates (matchedMask=0x%X)...",
-               matchedMask);
+    if (totalPatched == 0) {
+        // No sRGB EOTF shaders found. The vec3-splat constant encoding may have
+        // changed in a Windows Update. Run LogSrgbCandidates to log any blobs
+        // that partially match, to help diagnose format changes.
+        Wh_Log(
+            L"No sRGB EOTF shaders found — dwmcore.dll format may have "
+            L"changed; scanning for partial matches...");
         auto* dSec = IMAGE_FIRST_SECTION(nt);
         for (WORD s = 0; s < nt->FileHeader.NumberOfSections; s++, dSec++) {
             if (!(dSec->Characteristics & IMAGE_SCN_MEM_READ) ||
@@ -843,31 +785,10 @@ BOOL Wh_ModInit() {
             LogSrgbCandidates(modBase + dSec->VirtualAddress,
                               dSec->Misc.VirtualSize);
         }
-    }
-
-    if (matchedMask == 0) {
-        // No target shaders found. The DXBC blobs live in dwmcore.dll's .rdata
-        // and are present regardless of HDR state, so matchedMask == 0 means
-        // the known checksums no longer match — dwmcore.dll was recompiled by a
-        // Windows Update.
-        Wh_Log(
-            L"No target shaders found — dwmcore.dll checksums changed after a "
-            L"Windows Update; please file an issue");
         return FALSE;
     }
-    if (matchedMask != 0xFu) {
-        // Partial patch: some but not all of the four target shaders were
-        // found. Leaving DWM with a mix of power-law and sRGB surfaces would
-        // produce inconsistent rendering, so revert everything.
-        Wh_Log(
-            L"Partial patch (mask 0x%X of 0xF) — reverting to avoid "
-            L"inconsistent SDR rendering",
-            matchedMask);
-        RestoreAllPatches();
-        return FALSE;
-    }
-    Wh_Log(L"All 4 target shaders patched (%d blob(s) written) with gamma %.1f",
-           totalPatched, (double)gamma);
+    Wh_Log(L"Patched %d sRGB EOTF shader(s) with gamma %.1f", totalPatched,
+           (double)gamma);
     return TRUE;
 }
 

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -1,0 +1,622 @@
+// ==WindhawkMod==
+// @id              dwm-eotf-gamma
+// @name            DWM EOTF Gamma Curve
+// @description     Replaces DWM's sRGB EOTF with a pure power-law gamma for SDR-to-HDR tone mapping
+// @version         1.0
+// @author          millerpb
+// @github          https://github.com/millerpb
+// @license         GPL-3.0-or-later
+// @include         dwm.exe
+// @architecture    amd64
+// ==/WindhawkMod==
+
+// ==WindhawkModReadme==
+/*
+# DWM EOTF Gamma Curve
+
+When Windows HDR is enabled, DWM converts SDR content to HDR scRGB using the
+sRGB EOTF — an ~2.2 power curve with a linear toe segment near black. This mod
+patches the DXBC shader bytecode embedded in `dwmcore.dll` at DWM startup,
+replacing the sRGB curve with a simple power-law gamma. This gives you direct
+control over the SDR-to-HDR tone mapping without permanently modifying any files
+on disk.
+
+Based on [dwm_eotf](https://github.com/ledoge/dwm_eotf) by ledoge (GPL-3.0).
+
+## How it works
+
+On DWM startup, Windhawk injects this mod before Direct3D is initialized. The
+mod locates the known DXBC shader blobs in `dwmcore.dll`'s read-only memory
+sections and patches four floating-point constants that define the sRGB transfer
+function, replacing them with the equivalent pure power-law constants. The shader
+checksums are recalculated so D3D accepts the patched bytecode.
+
+When the mod is unloaded (Windhawk disabled, settings changed, or Windows
+shutdown), all patched bytes are restored to their original values.
+
+## Usage
+
+1. Enable **Windows HDR** in display settings.
+2. Install and enable this mod.
+3. Select your preferred gamma value in the settings below.
+4. **Log off and back in** (or otherwise restart DWM) for the change to take effect.
+5. To change the gamma value later, update the setting and restart DWM again.
+
+## Gamma reference
+
+| Value | Description |
+|-------|-------------|
+| 1.8   | Brighter highlights; old Apple/Mac standard |
+| 2.0   | Moderately bright midpoint |
+| 2.2   | Closest to the perceptual average of sRGB |
+| 2.4   | sRGB peak exponent |
+| 2.6   | Darker midtones, punchier contrast |
+
+## Known limitations
+
+- **Only applies when Windows HDR is enabled.** With HDR off, DWM does not use
+  this code path.
+- **Gamma changes require a DWM restart.** D3D compiles the shader bytecode once
+  at startup. Patching the bytecode after that has no effect until DWM recreates
+  its device (which happens on log off/on, or on display reconfiguration).
+- **Chromium-based browsers and Electron apps** (Chrome, Edge, VS Code, Discord,
+  etc.) switch between DWM's SDR compositing path and a direct scRGB path
+  depending on tab/window content. Each
+  transition passes one or two frames through DWM's patched SDR shader, which
+  can produce a brief tone-mapping flicker. A per-app exclusion list is not
+  feasible: the shader bytecode is patched once at DWM startup before Direct3D
+  compiles it, the compiled shader objects are global across all windows, and
+  patching or unpatching at runtime has no effect on shaders that are already
+  compiled. The flicker is driven by Chrome's own mode-switching and cannot be
+  suppressed from the DWM side.
+- The shader checksums in `dwmcore.dll` may change with Windows Updates. If the
+  mod reports patching 0 shaders after an update, the known-checksum list may
+  need updating.
+*/
+// ==/WindhawkModReadme==
+
+// ==WindhawkModSettings==
+/*
+- GammaCurve: "2.2"
+  $name: Gamma Curve
+  $description: >
+    Power-law gamma exponent used for SDR-to-HDR EOTF conversion.
+    Log off and back in after changing for the new value to take effect.
+  $options:
+    - "1.8": "1.8 (bright, old Mac standard)"
+    - "2.0": "2.0"
+    - "2.2": "2.2 (sRGB average)"
+    - "2.4": "2.4 (sRGB peak)"
+    - "2.6": "2.6 (dark / high contrast)"
+*/
+// ==/WindhawkModSettings==
+
+#include <windows.h>
+#include <cstring>
+#include <cstdlib>
+#include <vector>
+
+// =============================================================================
+// DXBC Checksum — AMD DXBCChecksum (modified MD5 used by Microsoft for DXBC)
+// Source: https://github.com/GPUOpen-Archive/common-src-ShaderUtils
+// Copyright 2008-2016 Advanced Micro Devices, Inc. All rights reserved.
+// Free for all — MD5 algorithm derived from RSA Data Security, Inc. (1990).
+// =============================================================================
+
+typedef unsigned long DX_UINT4;
+
+struct MD5_CTX_DX
+{
+    DX_UINT4 i[2];
+    DX_UINT4 buf[4];
+    unsigned char in[64];
+};
+
+static const unsigned char kMD5Padding[64] = {
+    0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+#define DX_F(x, y, z) (((x) & (y)) | ((~x) & (z)))
+#define DX_G(x, y, z) (((x) & (z)) | ((y) & (~z)))
+#define DX_H(x, y, z) ((x) ^ (y) ^ (z))
+#define DX_I(x, y, z) ((y) ^ ((x) | (~z)))
+#define DX_RL(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
+#define DX_FF(a, b, c, d, x, s, ac)                        \
+    {                                                      \
+        (a) += DX_F((b), (c), (d)) + (x) + (DX_UINT4)(ac); \
+        (a) = DX_RL((a), (s));                             \
+        (a) += (b);                                        \
+    }
+#define DX_GG(a, b, c, d, x, s, ac)                        \
+    {                                                      \
+        (a) += DX_G((b), (c), (d)) + (x) + (DX_UINT4)(ac); \
+        (a) = DX_RL((a), (s));                             \
+        (a) += (b);                                        \
+    }
+#define DX_HH(a, b, c, d, x, s, ac)                        \
+    {                                                      \
+        (a) += DX_H((b), (c), (d)) + (x) + (DX_UINT4)(ac); \
+        (a) = DX_RL((a), (s));                             \
+        (a) += (b);                                        \
+    }
+#define DX_II(a, b, c, d, x, s, ac)                        \
+    {                                                      \
+        (a) += DX_I((b), (c), (d)) + (x) + (DX_UINT4)(ac); \
+        (a) = DX_RL((a), (s));                             \
+        (a) += (b);                                        \
+    }
+
+static void DX_MD5Transform(DX_UINT4 *buf, DX_UINT4 *in)
+{
+    DX_UINT4 a = buf[0], b = buf[1], c = buf[2], d = buf[3];
+    DX_FF(a, b, c, d, in[0], 7, 3614090360u);
+    DX_FF(d, a, b, c, in[1], 12, 3905402710u);
+    DX_FF(c, d, a, b, in[2], 17, 606105819u);
+    DX_FF(b, c, d, a, in[3], 22, 3250441966u);
+    DX_FF(a, b, c, d, in[4], 7, 4118548399u);
+    DX_FF(d, a, b, c, in[5], 12, 1200080426u);
+    DX_FF(c, d, a, b, in[6], 17, 2821735955u);
+    DX_FF(b, c, d, a, in[7], 22, 4249261313u);
+    DX_FF(a, b, c, d, in[8], 7, 1770035416u);
+    DX_FF(d, a, b, c, in[9], 12, 2336552879u);
+    DX_FF(c, d, a, b, in[10], 17, 4294925233u);
+    DX_FF(b, c, d, a, in[11], 22, 2304563134u);
+    DX_FF(a, b, c, d, in[12], 7, 1804603682u);
+    DX_FF(d, a, b, c, in[13], 12, 4254626195u);
+    DX_FF(c, d, a, b, in[14], 17, 2792965006u);
+    DX_FF(b, c, d, a, in[15], 22, 1236535329u);
+    DX_GG(a, b, c, d, in[1], 5, 4129170786u);
+    DX_GG(d, a, b, c, in[6], 9, 3225465664u);
+    DX_GG(c, d, a, b, in[11], 14, 643717713u);
+    DX_GG(b, c, d, a, in[0], 20, 3921069994u);
+    DX_GG(a, b, c, d, in[5], 5, 3593408605u);
+    DX_GG(d, a, b, c, in[10], 9, 38016083u);
+    DX_GG(c, d, a, b, in[15], 14, 3634488961u);
+    DX_GG(b, c, d, a, in[4], 20, 3889429448u);
+    DX_GG(a, b, c, d, in[9], 5, 568446438u);
+    DX_GG(d, a, b, c, in[14], 9, 3275163606u);
+    DX_GG(c, d, a, b, in[3], 14, 4107603335u);
+    DX_GG(b, c, d, a, in[8], 20, 1163531501u);
+    DX_GG(a, b, c, d, in[13], 5, 2850285829u);
+    DX_GG(d, a, b, c, in[2], 9, 4243563512u);
+    DX_GG(c, d, a, b, in[7], 14, 1735328473u);
+    DX_GG(b, c, d, a, in[12], 20, 2368359562u);
+    DX_HH(a, b, c, d, in[5], 4, 4294588738u);
+    DX_HH(d, a, b, c, in[8], 11, 2272392833u);
+    DX_HH(c, d, a, b, in[11], 16, 1839030562u);
+    DX_HH(b, c, d, a, in[14], 23, 4259657740u);
+    DX_HH(a, b, c, d, in[1], 4, 2763975236u);
+    DX_HH(d, a, b, c, in[4], 11, 1272893353u);
+    DX_HH(c, d, a, b, in[7], 16, 4139469664u);
+    DX_HH(b, c, d, a, in[10], 23, 3200236656u);
+    DX_HH(a, b, c, d, in[13], 4, 681279174u);
+    DX_HH(d, a, b, c, in[0], 11, 3936430074u);
+    DX_HH(c, d, a, b, in[3], 16, 3572445317u);
+    DX_HH(b, c, d, a, in[6], 23, 76029189u);
+    DX_HH(a, b, c, d, in[9], 4, 3654602809u);
+    DX_HH(d, a, b, c, in[12], 11, 3873151461u);
+    DX_HH(c, d, a, b, in[15], 16, 530742520u);
+    DX_HH(b, c, d, a, in[2], 23, 3299628645u);
+    DX_II(a, b, c, d, in[0], 6, 4096336452u);
+    DX_II(d, a, b, c, in[7], 10, 1126891415u);
+    DX_II(c, d, a, b, in[14], 15, 2878612391u);
+    DX_II(b, c, d, a, in[5], 21, 4237533241u);
+    DX_II(a, b, c, d, in[12], 6, 1700485571u);
+    DX_II(d, a, b, c, in[3], 10, 2399980690u);
+    DX_II(c, d, a, b, in[10], 15, 4293915773u);
+    DX_II(b, c, d, a, in[1], 21, 2240044497u);
+    DX_II(a, b, c, d, in[8], 6, 1873313359u);
+    DX_II(d, a, b, c, in[15], 10, 4264355552u);
+    DX_II(c, d, a, b, in[6], 15, 2734768916u);
+    DX_II(b, c, d, a, in[13], 21, 1309151649u);
+    DX_II(a, b, c, d, in[4], 6, 4149444226u);
+    DX_II(d, a, b, c, in[11], 10, 3174756917u);
+    DX_II(c, d, a, b, in[2], 15, 718787259u);
+    DX_II(b, c, d, a, in[9], 21, 3951481745u);
+    buf[0] += a;
+    buf[1] += b;
+    buf[2] += c;
+    buf[3] += d;
+}
+
+static void DX_MD5Init(MD5_CTX_DX *ctx)
+{
+    ctx->i[0] = ctx->i[1] = 0;
+    ctx->buf[0] = 0x67452301u;
+    ctx->buf[1] = 0xefcdab89u;
+    ctx->buf[2] = 0x98badcfeu;
+    ctx->buf[3] = 0x10325476u;
+}
+
+static void DX_MD5Update(MD5_CTX_DX *ctx, const unsigned char *data, unsigned int len)
+{
+    int mdi = (int)((ctx->i[0] >> 3) & 0x3F);
+    if ((ctx->i[0] + ((DX_UINT4)len << 3)) < ctx->i[0])
+        ctx->i[1]++;
+    ctx->i[0] += (DX_UINT4)len << 3;
+    ctx->i[1] += (DX_UINT4)len >> 29;
+    while (len--)
+    {
+        ctx->in[mdi++] = *data++;
+        if (mdi == 0x40)
+        {
+            DX_UINT4 tmp[16];
+            for (unsigned i = 0, ii = 0; i < 16; i++, ii += 4)
+                tmp[i] = ((DX_UINT4)ctx->in[ii + 3] << 24) | ((DX_UINT4)ctx->in[ii + 2] << 16) | ((DX_UINT4)ctx->in[ii + 1] << 8) | (DX_UINT4)ctx->in[ii];
+            DX_MD5Transform(ctx->buf, tmp);
+            mdi = 0;
+        }
+    }
+}
+
+// Computes the DXBC-variant MD5 checksum for a shader blob.
+// pData must point to the start of the DXBC header; dwSize is the full shader size.
+// The checksum is written into dwHash[4].
+static void CalcDXBCChecksum(BYTE *pData, DWORD dwSize, DWORD dwHash[4])
+{
+    static const DWORD kHashOffset = 0x14; // skip magic(4) + checksum(16) = 20 bytes
+    MD5_CTX_DX ctx;
+    DX_MD5Init(&ctx);
+
+    dwSize -= kHashOffset;
+    pData += kHashOffset;
+
+    DWORD numBits = dwSize * 8;
+    DWORD fullChunksSize = dwSize & 0xFFFFFFC0u;
+
+    DX_MD5Update(&ctx, pData, fullChunksSize);
+
+    DWORD lastChunkSize = dwSize - fullChunksSize;
+    DWORD paddingSize = 64 - lastChunkSize;
+    const BYTE *lastChunk = pData + fullChunksSize;
+
+    if (lastChunkSize >= 56)
+    {
+        DX_MD5Update(&ctx, lastChunk, lastChunkSize);
+        DX_MD5Update(&ctx, kMD5Padding, paddingSize);
+        DX_UINT4 blk[16] = {};
+        blk[0] = numBits;
+        blk[15] = (numBits >> 2) | 1;
+        DX_MD5Transform(ctx.buf, blk);
+    }
+    else
+    {
+        DX_MD5Update(&ctx, (const unsigned char *)&numBits, 4);
+        if (lastChunkSize)
+            DX_MD5Update(&ctx, lastChunk, lastChunkSize);
+        lastChunkSize += sizeof(DWORD);
+        paddingSize -= sizeof(DWORD);
+        memcpy(&ctx.in[lastChunkSize], kMD5Padding, paddingSize);
+        ((DX_UINT4 *)ctx.in)[15] = (numBits >> 2) | 1;
+        DX_UINT4 blk[16];
+        memcpy(blk, ctx.in, 64);
+        DX_MD5Transform(ctx.buf, blk);
+    }
+
+    memcpy(dwHash, ctx.buf, 4 * sizeof(DWORD));
+}
+
+// =============================================================================
+// DXBC structure layout
+// =============================================================================
+
+#pragma pack(push, 1)
+struct DXBCHeader
+{
+    char magic[4];     // "DXBC"
+    DWORD checksum[4]; // DXBC-MD5 checksum (bytes 4–19)
+    DWORD reserved;    // always 1
+    DWORD size;        // total blob size in bytes
+};
+#pragma pack(pop)
+
+static_assert(sizeof(DXBCHeader) == 28, "DXBCHeader size mismatch");
+static const size_t kDXBCHeaderSize = sizeof(DXBCHeader); // 28
+
+// =============================================================================
+// Patch state
+// =============================================================================
+
+// Records the original bytes of a patched memory range so we can restore them.
+struct PatchRecord
+{
+    BYTE *addr;
+    std::vector<BYTE> original;
+};
+
+static std::vector<PatchRecord> g_patches;
+static float g_gamma = 2.2f;
+
+// Known DXBC checksums for the sRGB-EOTF shaders in dwmcore.dll.
+// These are the unmodified ("vanilla") checksums for the target shader blobs.
+static const BYTE kKnownChecksums[4][16] = {
+    {0x96, 0xe6, 0xd1, 0x58, 0x92, 0x55, 0xec, 0xcd, 0x1d, 0xd7, 0xd4, 0xdb, 0xec, 0x54, 0xd2, 0x85},
+    {0x21, 0x26, 0xb0, 0x37, 0xc1, 0xa2, 0xfb, 0xdd, 0xe3, 0x55, 0xb6, 0xe6, 0xdd, 0x9c, 0xaf, 0x3c},
+    {0x2c, 0x89, 0x26, 0xff, 0xe2, 0x29, 0xf0, 0x5d, 0x96, 0x7c, 0x72, 0x66, 0x8d, 0xc3, 0xad, 0xdb},
+    {0xf6, 0x93, 0xbf, 0xbb, 0xaf, 0x24, 0xb3, 0xd9, 0x36, 0x63, 0x54, 0xbe, 0x88, 0x98, 0xa7, 0xf5},
+};
+
+// =============================================================================
+// Memory helpers
+// =============================================================================
+
+// Write bytes to an arbitrary (potentially read-only) address in the current
+// process by temporarily relaxing page protection.
+static bool WriteMemorySafe(void *dst, const void *src, size_t size)
+{
+    DWORD oldProt = 0;
+    if (!VirtualProtect(dst, size, PAGE_READWRITE, &oldProt))
+        return false;
+    memcpy(dst, src, size);
+    VirtualProtect(dst, size, oldProt, &oldProt); // restore; ignore error
+    return true;
+}
+
+// =============================================================================
+// Shader patching logic
+// =============================================================================
+
+// The sRGB EOTF is encoded in shader bytecode as four float constants,
+// each stored as three identical consecutive 32-bit values (a vec3 splat):
+//
+//   2.4f        — the exponent
+//   0.04045f    — the linear-toe threshold
+//   0.055000f   — the linear-toe offset
+//   0.94786733f — the linear-toe scale (1.0 / 1.055)
+//
+// Replacing them with {gamma, 0, 0, 1} converts the piecewise sRGB curve into
+// the simple power-law: out = in ^ gamma.
+
+static const float kSrgbConsts[4] = {2.4f, 0.04045f, 0.055000f, 0.94786733f};
+static const float kPatchConsts[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+// Index 0 (the exponent) is replaced with the user-chosen gamma, not kPatchConsts[0].
+
+// Searches 'buf' (a copy of a shader blob) for the sRGB splat patterns and
+// patches them in-place. Returns true if at least one substitution was made.
+static bool PatchShaderBuf(BYTE *buf, DWORD size, float gamma)
+{
+    bool changed = false;
+    for (int ci = 0; ci < 4; ci++)
+    {
+        float src = kSrgbConsts[ci];
+        float dst = (ci == 0) ? gamma : kPatchConsts[ci];
+        float pat[3] = {src, src, src};
+        // Search from after the header; stop where a full 12-byte match would overflow.
+        for (size_t j = kDXBCHeaderSize; j + sizeof(float) * 3 <= size; j++)
+        {
+            if (memcmp(pat, buf + j, sizeof(pat)) != 0)
+                continue;
+            float rep[3] = {dst, dst, dst};
+            memcpy(buf + j, rep, sizeof(rep));
+            changed = true;
+        }
+    }
+    return changed;
+}
+
+// =============================================================================
+// Region scanner
+// =============================================================================
+
+// Scans a read-only committed memory region for DXBC shader blobs, patches any
+// that match the known checksums, and appends restoration records to g_patches.
+// Returns the number of individual shaders patched.
+//
+// "Big shader" handling: dwmcore.dll embeds the target shaders as sub-blobs
+// inside larger DXBC container blobs. The container's own checksum must be
+// recalculated after its inner shaders are patched.
+static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
+{
+    int numPatched = 0;
+
+    DXBCHeader *bigShader = nullptr; // enclosing container blob, if any
+    bool bigPatched = false;         // did we patch any sub-shader inside it?
+
+    for (size_t i = 0; i + kDXBCHeaderSize <= regionSize; i++)
+    {
+        // If we have advanced past the end of the current container blob,
+        // finalize it: save its original checksum and write the new one.
+        if (bigShader && region + i >= (BYTE *)bigShader + bigShader->size)
+        {
+            if (bigPatched)
+            {
+                // Save the original checksum of the big shader (bytes 4–19).
+                PatchRecord bigRec;
+                bigRec.addr = (BYTE *)bigShader + 4;
+                bigRec.original.assign(bigRec.addr, bigRec.addr + 16);
+                g_patches.push_back(std::move(bigRec));
+
+                // Recompute and write back the container checksum.
+                DWORD newCk[4];
+                CalcDXBCChecksum((BYTE *)bigShader, bigShader->size, newCk);
+                WriteMemorySafe((BYTE *)bigShader + 4, newCk, 16);
+
+                Wh_Log(L"  Fixed container checksum at %p", (void *)bigShader);
+            }
+            bigShader = nullptr;
+            bigPatched = false;
+        }
+
+        auto *hdr = (DXBCHeader *)(region + i);
+
+        // Validate DXBC magic and reserved field.
+        if (hdr->magic[0] != 'D' || hdr->magic[1] != 'X' ||
+            hdr->magic[2] != 'B' || hdr->magic[3] != 'C')
+            continue;
+        if (hdr->reserved != 1)
+            continue;
+
+        // Basic size sanity: must fit within the remaining region.
+        if (hdr->size < (DWORD)kDXBCHeaderSize || i + hdr->size > regionSize)
+            continue;
+
+        // Check if this blob's checksum matches one of our targets.
+        int matchIdx = -1;
+        for (int k = 0; k < 4; k++)
+        {
+            if (memcmp(kKnownChecksums[k], hdr->checksum, 16) == 0)
+            {
+                matchIdx = k;
+                break;
+            }
+        }
+
+        if (matchIdx < 0)
+        {
+            // Unknown blob — track as a potential container for inner sub-shaders.
+            if (!bigShader || region + i >= (BYTE *)bigShader + bigShader->size)
+                bigShader = hdr;
+            continue;
+        }
+
+        // Found a target shader. Make a working copy, patch it, validate, write back.
+        std::vector<BYTE> patched(hdr->size);
+        memcpy(patched.data(), hdr, hdr->size);
+
+        if (!PatchShaderBuf(patched.data(), hdr->size, gamma))
+        {
+            Wh_Log(L"  Shader #%d matched checksum but no constants found to patch", matchIdx);
+            continue;
+        }
+
+        // Recalculate DXBC checksum for the patched copy.
+        DWORD newCk[4];
+        CalcDXBCChecksum(patched.data(), hdr->size, newCk);
+        memcpy(patched.data() + 4, newCk, 16);
+
+        // Save the original bytes for later restoration.
+        PatchRecord rec;
+        rec.addr = (BYTE *)hdr;
+        rec.original.assign(rec.addr, rec.addr + hdr->size);
+
+        // Write the patched shader back into the (read-only) memory region.
+        if (!WriteMemorySafe((BYTE *)hdr, patched.data(), hdr->size))
+        {
+            Wh_Log(L"  VirtualProtect failed for shader #%d at %p", matchIdx, (void *)hdr);
+            continue;
+        }
+
+        g_patches.push_back(std::move(rec));
+        numPatched++;
+        if (bigShader)
+            bigPatched = true;
+
+        Wh_Log(L"  Patched shader #%d at %p (size %lu)", matchIdx, (void *)hdr, hdr->size);
+    }
+
+    // Handle a container blob that reaches the very end of the region.
+    if (bigShader && bigPatched)
+    {
+        PatchRecord bigRec;
+        bigRec.addr = (BYTE *)bigShader + 4;
+        bigRec.original.assign(bigRec.addr, bigRec.addr + 16);
+        g_patches.push_back(std::move(bigRec));
+
+        DWORD newCk[4];
+        CalcDXBCChecksum((BYTE *)bigShader, bigShader->size, newCk);
+        WriteMemorySafe((BYTE *)bigShader + 4, newCk, 16);
+
+        Wh_Log(L"  Fixed trailing container checksum at %p", (void *)bigShader);
+    }
+
+    return numPatched;
+}
+
+// Restores all patched memory regions to their original bytes.
+static void RestoreAllPatches()
+{
+    // Iterate in reverse so sub-shader records (added first) are restored after
+    // their container checksum records (added last), giving a consistent final state.
+    for (auto it = g_patches.rbegin(); it != g_patches.rend(); ++it)
+        WriteMemorySafe(it->addr, it->original.data(), it->original.size());
+    g_patches.clear();
+}
+
+// =============================================================================
+// Windhawk callbacks
+// =============================================================================
+
+BOOL Wh_ModInit()
+{
+    // Read the user's gamma setting.
+    PCWSTR gammaStr = Wh_GetStringSetting(L"GammaCurve");
+    float gamma = wcstof(gammaStr, nullptr);
+    Wh_FreeStringSetting(gammaStr);
+    if (gamma < 1.0f || gamma > 10.0f)
+    {
+        Wh_Log(L"Invalid gamma value, falling back to 2.2");
+        gamma = 2.2f;
+    }
+    g_gamma = gamma;
+
+    Wh_Log(L"DWM EOTF: target gamma = %.1f", (double)gamma);
+
+    // Locate dwmcore.dll (always loaded as a static import of dwm.exe).
+    HMODULE hDwmcore = GetModuleHandleW(L"dwmcore.dll");
+    if (!hDwmcore)
+    {
+        Wh_Log(L"dwmcore.dll not found in process — aborting");
+        return FALSE;
+    }
+
+    // Determine the module's address range from its PE header.
+    auto *dos = (IMAGE_DOS_HEADER *)hDwmcore;
+    auto *nt = (IMAGE_NT_HEADERS *)((BYTE *)hDwmcore + dos->e_lfanew);
+    BYTE *modBase = (BYTE *)hDwmcore;
+    size_t modSize = nt->OptionalHeader.SizeOfImage;
+
+    Wh_Log(L"dwmcore.dll at %p, image size %zu", (void *)modBase, modSize);
+
+    // Walk the virtual memory regions within dwmcore.dll's image range.
+    // The DXBC shader blobs live in PAGE_READONLY sections (typically .rdata).
+    int totalPatched = 0;
+    BYTE *addr = modBase;
+    while (addr < modBase + modSize)
+    {
+        MEMORY_BASIC_INFORMATION mbi{};
+        if (!VirtualQuery(addr, &mbi, sizeof(mbi)))
+            break;
+
+        size_t regionSize = mbi.RegionSize;
+        // Clamp to the module boundary.
+        if ((BYTE *)mbi.BaseAddress + regionSize > modBase + modSize)
+            regionSize = (modBase + modSize) - (BYTE *)mbi.BaseAddress;
+
+        if (mbi.State == MEM_COMMIT &&
+            mbi.Protect == PAGE_READONLY &&
+            regionSize > 4096)
+        {
+            Wh_Log(L"Scanning region at %p, size %zu", mbi.BaseAddress, regionSize);
+            totalPatched += ScanRegionForShaders((BYTE *)mbi.BaseAddress, regionSize, gamma);
+        }
+
+        addr = (BYTE *)mbi.BaseAddress + mbi.RegionSize;
+    }
+
+    if (totalPatched == 0)
+    {
+        Wh_Log(L"No shaders patched. HDR may be off, or dwmcore.dll was updated (checksums changed).");
+    }
+    else
+    {
+        Wh_Log(L"Successfully patched %d shader(s) with gamma %.1f", totalPatched, (double)gamma);
+    }
+
+    return TRUE;
+}
+
+void Wh_ModBeforeUninit()
+{
+    Wh_Log(L"DWM EOTF: restoring original shader bytes");
+    RestoreAllPatches();
+}
+
+// When the user changes the gamma setting, reload the mod so Wh_ModInit runs
+// again with the new value. DWM must be restarted for the new shaders to compile.
+BOOL Wh_ModSettingsChanged(BOOL *bReload)
+{
+    *bReload = TRUE;
+    return TRUE;
+}

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -56,7 +56,7 @@ shutdown; this is harmless since the process is terminating anyway.
 `dwm.exe` is a critical system process. Windhawk does not inject into it by
 default — you must explicitly allow it in **Windhawk's advanced settings**:
 
-1. Open Windhawk → **Advanced settings**
+1. Open Windhawk → **Advanced settings** → **More advanced settings**
 2. In the **Process inclusion list**, add `dwm.exe`
 3. Click **Save**
 
@@ -103,6 +103,9 @@ effect.
 - If the mod logs "No target shaders found" after a Windows Update, the shader
   structure in `dwmcore.dll` has changed (verified against 10.0.26100.8521).
   Please file an issue.
+- If the desktop stops rendering correctly after enabling this mod, boot into
+  Safe Mode (Windhawk does not inject there) or start Windhawk with
+  `windhawk.exe -safe-mode`, then disable or uninstall the mod.
 */
 // ==/WindhawkModReadme==
 
@@ -410,9 +413,9 @@ static bool WriteMemorySafe(void* dst, const void* src, size_t size) {
 // the simple power-law: out = in ^ gamma.
 
 static const float kSrgbConsts[4] = {2.4f, 0.04045f, 0.055000f, 0.94786733f};
-static const float kPatchConsts[4] = {0.0f, 0.0f, 0.0f, 1.0f};
-// Index 0 (the exponent) is replaced with the user-chosen gamma, not
-// kPatchConsts[0].
+// Replacement values for sRGB constants 1–3; constant 0 (the exponent) is
+// replaced with the user-chosen gamma instead and has no slot here.
+static const float kPatchConsts[3] = {0.0f, 0.0f, 1.0f};
 
 // Searches 'buf' (a copy of a shader blob) for the sRGB vec3-splat patterns and
 // patches them in-place. Fills counts[4] with the number of replacements made
@@ -425,7 +428,7 @@ static int PatchShaderBuf(BYTE* buf, DWORD size, float gamma, int counts[4]) {
     int found = 0;
     for (int ci = 0; ci < 4; ci++) {
         float src = kSrgbConsts[ci];
-        float dst = (ci == 0) ? gamma : kPatchConsts[ci];
+        float dst = (ci == 0) ? gamma : kPatchConsts[ci - 1];
         float pat[3] = {src, src, src};
         counts[ci] = 0;
         // Search from after the header; stop where a full 12-byte match would
@@ -472,6 +475,42 @@ static bool ChecksumRoundTrips(const DXBCHeader* hdr) {
     DWORD verify[4];
     CalcDXBCChecksum((const BYTE*)hdr, hdr->size, verify);
     return memcmp(verify, hdr->checksum, 16) == 0;
+}
+
+// =============================================================================
+// Diagnostic pass
+// =============================================================================
+
+// Read-only scan: logs the DXBC checksum of every leaf blob in 'region' that
+// carries all four sRGB vec3-splat constants exactly once. Called when the
+// allowlist doesn't yield a full match so that a reporter on an updated build
+// can paste the output into an issue instead of extracting blobs by hand.
+// Over-matching here is harmless — nothing is written.
+static void LogSrgbCandidates(const BYTE* region, size_t regionSize) {
+    for (size_t i = 0; i + kDXBCHeaderSize <= regionSize; i += 4) {
+        const auto* hdr = (const DXBCHeader*)(region + i);
+        if (hdr->magic[0] != 'D' || hdr->magic[1] != 'X' ||
+            hdr->magic[2] != 'B' || hdr->magic[3] != 'C' ||
+            hdr->reserved != 1 || hdr->size < (DWORD)kDXBCHeaderSize ||
+            i + hdr->size > regionSize || HasDXBCSubBlob(hdr))
+            continue;
+
+        std::vector<BYTE> tmp(hdr->size);
+        memcpy(tmp.data(), hdr, hdr->size);
+        int counts[4] = {};
+        if (PatchShaderBuf(tmp.data(), hdr->size, 2.2f, counts) != 4 ||
+            counts[0] != 1 || counts[1] != 1 || counts[2] != 1 ||
+            counts[3] != 1)
+            continue;
+
+        const auto* ck = (const BYTE*)hdr->checksum;
+        Wh_Log(
+            L"  sRGB candidate at +0x%zx size %lu checksum "
+            L"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+            i, hdr->size, ck[0], ck[1], ck[2], ck[3], ck[4], ck[5], ck[6],
+            ck[7], ck[8], ck[9], ck[10], ck[11], ck[12], ck[13], ck[14],
+            ck[15]);
+    }
 }
 
 // =============================================================================
@@ -669,7 +708,12 @@ static int ScanRegionForShaders(BYTE* region,
         rec.addr = (BYTE*)hdr;
         rec.original.assign(rec.addr, rec.addr + hdr->size);
 
-        // Write the patched shader back into the (read-only) memory region.
+        // Writing the whole blob rather than only the changed bytes: patched
+        // differs from the original solely in the ~48 bytes of splat constants
+        // and the 16-byte checksum, so memcpy replays every other byte at its
+        // current value. A concurrent reader can only observe changes to those
+        // same bytes — the same window as delta writes. Delta writes would
+        // reduce COW pages and PatchRecord size but not improve correctness.
         if (!WriteMemorySafe((BYTE*)hdr, patched.data(), hdr->size)) {
             Wh_Log(L"  VirtualProtect failed for shader #%d at %p", matchIdx,
                    (void*)hdr);
@@ -686,6 +730,7 @@ static int ScanRegionForShaders(BYTE* region,
 
         Wh_Log(L"  Patched shader #%d at %p (size %lu)", matchIdx, (void*)hdr,
                hdr->size);
+        i += hdr->size - 4;  // skip the blob body; loop adds 4
     }
 
     // Handle a container blob that reaches the very end of the region.
@@ -780,6 +825,24 @@ BOOL Wh_ModInit() {
         totalPatched +=
             ScanRegionForShaders(modBase + sec->VirtualAddress,
                                  sec->Misc.VirtualSize, gamma, matchedMask);
+    }
+
+    // If the allowlist didn't match all four shaders, run a read-only candidate
+    // scan to log checksums of sRGB-matching blobs in this build. This gives
+    // reporters something to paste into an issue without manual extraction.
+    if (matchedMask != 0xFu) {
+        Wh_Log(L"Scanning for sRGB candidates (matchedMask=0x%X)...",
+               matchedMask);
+        auto* dSec = IMAGE_FIRST_SECTION(nt);
+        for (WORD s = 0; s < nt->FileHeader.NumberOfSections; s++, dSec++) {
+            if (!(dSec->Characteristics & IMAGE_SCN_MEM_READ) ||
+                (dSec->Characteristics & IMAGE_SCN_MEM_EXECUTE) ||
+                (dSec->Characteristics & IMAGE_SCN_MEM_WRITE) ||
+                dSec->Misc.VirtualSize == 0)
+                continue;
+            LogSrgbCandidates(modBase + dSec->VirtualAddress,
+                              dSec->Misc.VirtualSize);
+        }
     }
 
     if (matchedMask == 0) {

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -1,6 +1,6 @@
 // ==WindhawkMod==
 // @id              dwm-eotf-gamma
-// @name            DWM EOTF Gamma Curve
+// @name            Windows SDR to HDR Tonemapping Fix
 // @description     Replaces DWM's sRGB EOTF with a pure power-law gamma for SDR-to-HDR tone mapping
 // @version         1.0
 // @author          millerpb
@@ -12,10 +12,14 @@
 
 // ==WindhawkModReadme==
 /*
-# DWM EOTF Gamma Curve
+# Windows SDR to HDR Tonemapping Fix
+
+Correct Windows' SDR-to-HDR tonemapping. No more washed out midtones or crushed shadows — just a simple power-law gamma curve that you can control.
+
+## DWM EOTF Gamma Curve
 
 When Windows HDR is enabled, DWM converts SDR content to HDR scRGB using the
-sRGB EOTF — an ~2.2 power curve with a linear toe segment near black. This mod
+sRGB EOTF (a ~2.2 power curve with a linear toe segment near black). This mod
 patches the DXBC shader bytecode embedded in `dwmcore.dll` at DWM startup,
 replacing the sRGB curve with a simple power-law gamma. This gives you direct
 control over the SDR-to-HDR tone mapping without permanently modifying any files
@@ -25,7 +29,7 @@ Based on [dwm_eotf](https://github.com/ledoge/dwm_eotf) by ledoge (GPL-3.0).
 
 ## How it works
 
-When DWM starts, Windhawk injects this mod early — ideally before Direct3D
+When DWM starts, Windhawk injects this mod early, ideally before Direct3D
 initializes, so the patched bytecode is what D3D compiles from. The mod walks
 `dwmcore.dll`'s read-only PE sections looking for DXBC shader blobs that contain
 all four sRGB EOTF float constants. When found, those constants are replaced with
@@ -34,7 +38,7 @@ D3D accepts the modified bytecode.
 
 When the mod is unloaded while DWM is running (e.g. Windhawk disabled or settings
 changed), all patched bytes are restored in memory. Note that the unload callback
-does not run at process exit, so no restore occurs at Windows shutdown — this is
+does not run at process exit, so no restore occurs at Windows shutdown; this is
 harmless since the process is terminating anyway.
 
 ## Important: enable injection into dwm.exe
@@ -111,6 +115,7 @@ Without this step the mod will be silently ignored.
 #include <cwchar>
 #include <cstdint>
 #include <vector>
+#include <windhawk_utils.h>
 
 // =============================================================================
 // DXBC Checksum — AMD DXBCChecksum (modified MD5 used by Microsoft for DXBC)
@@ -270,7 +275,7 @@ static void DX_MD5Update(MD5_CTX_DX *ctx, const unsigned char *data, unsigned in
 // Computes the DXBC-variant MD5 checksum for a shader blob.
 // pData must point to the start of the DXBC header; dwSize is the full shader size.
 // The checksum is written into dwHash[4].
-static void CalcDXBCChecksum(BYTE *pData, DWORD dwSize, DWORD dwHash[4])
+static void CalcDXBCChecksum(const BYTE *pData, DWORD dwSize, DWORD dwHash[4])
 {
     static const DWORD kHashOffset = 0x14; // skip magic(4) + checksum(16) = 20 bytes
     MD5_CTX_DX ctx;
@@ -391,9 +396,12 @@ static const float kPatchConsts[4] = {0.0f, 0.0f, 0.0f, 1.0f};
 // Index 0 (the exponent) is replaced with the user-chosen gamma, not kPatchConsts[0].
 
 // Searches 'buf' (a copy of a shader blob) for the sRGB vec3-splat patterns and
-// patches them in-place. Returns the number of the four constants found (0–4).
-// Callers must require == 4 to ensure all-or-nothing patching.
-static int PatchShaderBuf(BYTE *buf, DWORD size, float gamma)
+// patches them in-place. Fills counts[4] with the number of replacements made for
+// each constant. Returns the number of constants that had at least one match (0–4).
+// Callers must require == 4 to ensure all-or-nothing patching, and should log the
+// individual counts: some constants (e.g. 0.055) appear in both decode and encode
+// paths, so a count > 1 indicates unexpected overlap that would corrupt unintended code.
+static int PatchShaderBuf(BYTE *buf, DWORD size, float gamma, int counts[4])
 {
     int found = 0;
     for (int ci = 0; ci < 4; ci++)
@@ -401,17 +409,18 @@ static int PatchShaderBuf(BYTE *buf, DWORD size, float gamma)
         float src = kSrgbConsts[ci];
         float dst = (ci == 0) ? gamma : kPatchConsts[ci];
         float pat[3] = {src, src, src};
-        bool foundThis = false;
+        counts[ci] = 0;
         // Search from after the header; stop where a full 12-byte match would overflow.
-        for (size_t j = kDXBCHeaderSize; j + sizeof(float) * 3 <= size; j++)
+        // DXBC constants are DWORD-aligned, so step by 4 for correctness and speed.
+        for (size_t j = kDXBCHeaderSize; j + sizeof(float) * 3 <= size; j += 4)
         {
             if (memcmp(pat, buf + j, sizeof(pat)) != 0)
                 continue;
             float rep[3] = {dst, dst, dst};
             memcpy(buf + j, rep, sizeof(rep));
-            foundThis = true;
+            counts[ci]++;
         }
-        if (foundThis)
+        if (counts[ci] > 0)
             found++;
     }
     return found;
@@ -438,6 +447,16 @@ static bool HasDXBCSubBlob(const DXBCHeader *hdr)
     return false;
 }
 
+// Returns true if CalcDXBCChecksum reproduces the blob's own embedded checksum.
+// Used as a pre-flight check before writing a new checksum into a container blob
+// that is not on the known-checksum allowlist.
+static bool ChecksumRoundTrips(const DXBCHeader *hdr)
+{
+    DWORD verify[4];
+    CalcDXBCChecksum((const BYTE *)hdr, hdr->size, verify);
+    return memcmp(verify, hdr->checksum, 16) == 0;
+}
+
 // =============================================================================
 // Region scanner
 // =============================================================================
@@ -455,28 +474,47 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
 
     DXBCHeader *bigShader = nullptr; // enclosing container blob, if any
     bool bigPatched = false;         // did we patch any sub-shader inside it?
+    size_t containerPatchBase = 0;   // g_patches index when the current container was accepted
+
+    // Finalizes a container whose inner shaders have been patched: saves its
+    // original checksum, recomputes it, and writes it back. If the write fails,
+    // rolls back all leaf patches belonging to this container.
+    auto FinalizeContainer = [&](DXBCHeader *container) -> bool
+    {
+        PatchRecord bigRec;
+        bigRec.addr = (BYTE *)container + 4;
+        bigRec.original.assign(bigRec.addr, bigRec.addr + 16);
+        g_patches.push_back(std::move(bigRec));
+
+        DWORD newCk[4];
+        CalcDXBCChecksum((const BYTE *)container, container->size, newCk);
+        if (!WriteMemorySafe((BYTE *)container + 4, newCk, 16))
+        {
+            g_patches.pop_back(); // remove the checksum record we just pushed
+            size_t toRollBack = g_patches.size() - containerPatchBase;
+            Wh_Log(L"  VirtualProtect failed for container at %p — rolling back %zu leaf patch(es)",
+                   (void *)container, toRollBack);
+            while (g_patches.size() > containerPatchBase)
+            {
+                auto &rec = g_patches.back();
+                WriteMemorySafe(rec.addr, rec.original.data(), rec.original.size());
+                g_patches.pop_back();
+                numPatched--;
+            }
+            return false;
+        }
+        Wh_Log(L"  Fixed container checksum at %p", (void *)container);
+        return true;
+    };
 
     for (size_t i = 0; i + kDXBCHeaderSize <= regionSize; i++)
     {
         // If we have advanced past the end of the current container blob,
-        // finalize it: save its original checksum and write the new one.
+        // finalize it if we patched any inner shaders.
         if (bigShader && region + i >= (BYTE *)bigShader + bigShader->size)
         {
             if (bigPatched)
-            {
-                // Save the original checksum of the big shader (bytes 4–19).
-                PatchRecord bigRec;
-                bigRec.addr = (BYTE *)bigShader + 4;
-                bigRec.original.assign(bigRec.addr, bigRec.addr + 16);
-                g_patches.push_back(std::move(bigRec));
-
-                // Recompute and write back the container checksum.
-                DWORD newCk[4];
-                CalcDXBCChecksum((BYTE *)bigShader, bigShader->size, newCk);
-                WriteMemorySafe((BYTE *)bigShader + 4, newCk, 16);
-
-                Wh_Log(L"  Fixed container checksum at %p", (void *)bigShader);
-            }
+                FinalizeContainer(bigShader);
             bigShader = nullptr;
             bigPatched = false;
         }
@@ -499,7 +537,27 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
         if (HasDXBCSubBlob(hdr))
         {
             if (!bigShader)
+            {
+                // Pre-flight: verify our checksum routine reproduces this blob's own
+                // hash before we commit to overwriting it. An unlisted container whose
+                // hash doesn't round-trip is skipped to avoid silent corruption.
+                if (!ChecksumRoundTrips(hdr))
+                {
+                    Wh_Log(L"  Container at %p: checksum did not round-trip, skipping", (void *)hdr);
+                    continue;
+                }
                 bigShader = hdr;
+                containerPatchBase = g_patches.size();
+            }
+            else
+            {
+                // A nested container inside the current one: multi-level nesting is
+                // not supported. Skip past the inner blob so its leaves are not
+                // patched without a proper container fixup.
+                Wh_Log(L"  Nested container at %p inside %p — skipping unsupported nesting depth",
+                       (void *)hdr, (void *)bigShader);
+                i += hdr->size - 1; // loop will add 1 more, landing just after the blob
+            }
             continue;
         }
 
@@ -519,18 +577,29 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
         if (matchIdx < 0)
             continue;
 
+        // Verify the leaf actually lies within the tracked container's bounds
+        // before attributing the patch to that container. A positional false-positive
+        // (a blob that looked like a container but preceded the real one) would
+        // otherwise get its checksum overwritten for leaves it doesn't contain.
+        bool insideContainer = bigShader &&
+                               (BYTE *)hdr >= (BYTE *)bigShader &&
+                               (BYTE *)hdr + hdr->size <= (BYTE *)bigShader + bigShader->size;
+
         // Checksum matched — copy the blob, patch the sRGB constants, verify
         // all four were found, then recompute the DXBC checksum.
         std::vector<BYTE> patched(hdr->size);
         memcpy(patched.data(), hdr, hdr->size);
 
-        int constsFound = PatchShaderBuf(patched.data(), hdr->size, gamma);
+        int counts[4] = {};
+        int constsFound = PatchShaderBuf(patched.data(), hdr->size, gamma, counts);
         if (constsFound < 4)
         {
             Wh_Log(L"  Shader #%d: checksum matched but only %d/4 sRGB constants found",
                    matchIdx, constsFound);
             continue;
         }
+        for (int ci = 0; ci < 4; ci++)
+            Wh_Log(L"  Shader #%d: constant %d replaced %d time(s)", matchIdx, ci, counts[ci]);
 
         DWORD newCk[4];
         CalcDXBCChecksum(patched.data(), hdr->size, newCk);
@@ -550,7 +619,7 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
 
         g_patches.push_back(std::move(rec));
         numPatched++;
-        if (bigShader)
+        if (insideContainer)
             bigPatched = true;
 
         Wh_Log(L"  Patched shader #%d at %p (size %lu)", matchIdx, (void *)hdr, hdr->size);
@@ -558,18 +627,7 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
 
     // Handle a container blob that reaches the very end of the region.
     if (bigShader && bigPatched)
-    {
-        PatchRecord bigRec;
-        bigRec.addr = (BYTE *)bigShader + 4;
-        bigRec.original.assign(bigRec.addr, bigRec.addr + 16);
-        g_patches.push_back(std::move(bigRec));
-
-        DWORD newCk[4];
-        CalcDXBCChecksum((BYTE *)bigShader, bigShader->size, newCk);
-        WriteMemorySafe((BYTE *)bigShader + 4, newCk, 16);
-
-        Wh_Log(L"  Fixed trailing container checksum at %p", (void *)bigShader);
-    }
+        FinalizeContainer(bigShader);
 
     return numPatched;
 }
@@ -591,9 +649,7 @@ static void RestoreAllPatches()
 BOOL Wh_ModInit()
 {
     // Read the user's gamma setting.
-    PCWSTR gammaStr = Wh_GetStringSetting(L"GammaCurve");
-    float gamma = wcstof(gammaStr, nullptr);
-    Wh_FreeStringSetting(gammaStr);
+    float gamma = wcstof(WindhawkUtils::StringSetting::make(L"GammaCurve"), nullptr);
     if (gamma < 1.0f || gamma > 10.0f)
     {
         Wh_Log(L"Invalid gamma value, falling back to 2.2");
@@ -652,7 +708,7 @@ BOOL Wh_ModInit()
 
 void Wh_ModBeforeUninit()
 {
-    Wh_Log(L"DWM EOTF: restoring original shader bytes");
+    Wh_Log(L"Restoring original shader bytes");
     RestoreAllPatches();
 }
 

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -18,7 +18,7 @@ Viewing SDR content while using HDR in Windows causes washed out darker tones
 like shadows. This corrects it so that Windows uses a standard gamma curve. It
 should not affect native HDR content like games and movies.
 
-Simple, accurate sRGB with a simple power-law gamma curve that you can control.
+A simple, accurate fix for washed-out SDR shadows in Windows HDR mode.
 
 ![Comparison Image](https://i.imgur.com/GwegdeU.png)
 
@@ -77,7 +77,7 @@ effect.
 
 | Value | Description |
 |-------|-------------|
-| 1.8   | Brighter highlights; old Apple/Mac standard |
+| 1.8   | Raised midtones and shadows; old Apple/Mac standard |
 | 2.0   | Moderately bright midpoint |
 | 2.2   | Closest to the perceptual average of sRGB |
 | 2.4   | sRGB peak exponent |
@@ -89,7 +89,9 @@ effect.
   this code path.
 - **Gamma changes require a DWM restart.** D3D compiles the shader bytecode once
   at startup. Patching the bytecode after that has no effect until DWM recreates
-  its device (which happens on log off/on, or on display reconfiguration).
+  its device (which happens on log off/on, display reconfiguration, or toggling
+  Windows HDR off and back on — the last option is the lightest-weight way to
+  apply a new gamma value without a full log-off).
 - **Chromium-based browsers and Electron apps** (Chrome, Edge, VS Code, Discord,
   etc.) switch between DWM's SDR compositing path and a direct scRGB path
   depending on tab/window content. Each
@@ -463,12 +465,14 @@ static bool ChecksumRoundTrips(const DXBCHeader* hdr) {
 // Diagnostic pass
 // =============================================================================
 
-// Read-only scan: logs the DXBC checksum of every leaf blob in 'region' that
-// carries all four sRGB vec3-splat constants exactly once. Called when the
-// allowlist doesn't yield a full match so that a reporter on an updated build
-// can paste the output into an issue instead of extracting blobs by hand.
-// Over-matching here is harmless — nothing is written.
-static void LogSrgbCandidates(const BYTE* region, size_t regionSize) {
+// Logs every leaf DXBC blob in 'region' that contains any of the four sRGB
+// EOTF constants as raw DWORD values (not necessarily as vec3 splats). Called
+// when content-based detection finds nothing, to help diagnose whether the
+// constant encoding changed. The per-constant counts are informative:
+//   3 = vec3 splat (normal encoding)
+//   4 = splat + Level9 def (also normal)
+//   1 = single scalar occurrence (changed encoding?)
+static void LogSrgbNearMisses(const BYTE* region, size_t regionSize) {
     for (size_t i = 0; i + kDXBCHeaderSize <= regionSize; i += 4) {
         const auto* hdr = (const DXBCHeader*)(region + i);
         if (hdr->magic[0] != 'D' || hdr->magic[1] != 'X' ||
@@ -477,21 +481,30 @@ static void LogSrgbCandidates(const BYTE* region, size_t regionSize) {
             i + hdr->size > regionSize || HasDXBCSubBlob(hdr))
             continue;
 
-        std::vector<BYTE> tmp(hdr->size);
-        memcpy(tmp.data(), hdr, hdr->size);
         int counts[4] = {};
-        if (PatchShaderBuf(tmp.data(), hdr->size, 2.2f, counts) != 4 ||
-            counts[0] != 1 || counts[1] != 1 || counts[2] != 1 ||
-            counts[3] != 1)
+        for (size_t j = kDXBCHeaderSize; j + sizeof(float) <= hdr->size;
+             j += 4) {
+            const BYTE* p = (const BYTE*)hdr + j;
+            for (int ci = 0; ci < 4; ci++) {
+                if (memcmp(p, &kSrgbConsts[ci], sizeof(float)) == 0)
+                    counts[ci]++;
+            }
+        }
+
+        int present = 0;
+        for (int ci = 0; ci < 4; ci++) {
+            if (counts[ci] > 0)
+                present++;
+        }
+        if (present == 0)
             continue;
 
         const auto* ck = (const BYTE*)hdr->checksum;
         Wh_Log(
-            L"  sRGB candidate at +0x%zx size %lu checksum "
-            L"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
-            i, hdr->size, ck[0], ck[1], ck[2], ck[3], ck[4], ck[5], ck[6],
-            ck[7], ck[8], ck[9], ck[10], ck[11], ck[12], ck[13], ck[14],
-            ck[15]);
+            L"  Near-miss at +0x%zx size %lu: c24=%d c04=%d c05=%d c95=%d "
+            L"ck=%02x%02x%02x%02x...",
+            i, hdr->size, counts[0], counts[1], counts[2], counts[3],
+            ck[0], ck[1], ck[2], ck[3]);
     }
 }
 
@@ -501,13 +514,16 @@ static void LogSrgbCandidates(const BYTE* region, size_t regionSize) {
 
 // Scans a read-only PE section for sRGB EOTF leaf DXBC blobs and patches them.
 // A leaf blob qualifies if it contains all four sRGB vec3-splat constants each
-// exactly once — a signature unique to the decode path. Returns the number of
-// blobs patched.
+// exactly once — a signature unique to the decode path.
+// Returns the number of blobs successfully patched. Increments skippedCount for
+// each blob that qualified but could not be written (VirtualProtect failure or
+// container checksum failure), enabling the caller to enforce all-or-nothing.
 //
 // Container handling: dwmcore.dll embeds leaf shaders inside larger DXBC
 // container blobs. The container's checksum must be recalculated after any
 // inner leaf is patched.
-static int ScanRegionForShaders(BYTE* region, size_t regionSize, float gamma) {
+static int ScanRegionForShaders(BYTE* region, size_t regionSize, float gamma,
+                                int& skippedCount) {
     int numPatched = 0;
 
     DXBCHeader* bigShader = nullptr;  // enclosing container blob, if any
@@ -515,10 +531,30 @@ static int ScanRegionForShaders(BYTE* region, size_t regionSize, float gamma) {
     size_t containerPatchBase =
         0;  // g_patches index when the current container was accepted
 
-    // Finalizes a container whose inner shaders have been patched: saves its
-    // original checksum, recomputes it, and writes it back. If the write fails,
-    // rolls back all leaf patches belonging to this container.
+    // Finalizes a container whose inner shaders have been patched. Runs
+    // ChecksumRoundTrips here (deferred from container acceptance) so the MD5
+    // cost is only paid when qualifying leaves were actually found inside.
+    // Recomputes the container checksum and writes it back. On any failure,
+    // rolls back all inner leaf patches and increments skippedCount.
     auto FinalizeContainer = [&](DXBCHeader* container) -> bool {
+        // Deferred round-trip check: verify before writing.
+        if (!ChecksumRoundTrips(container)) {
+            size_t toRollBack = g_patches.size() - containerPatchBase;
+            Wh_Log(
+                L"  Container at %p: checksum did not round-trip — rolling "
+                L"back %zu leaf patch(es)",
+                (void*)container, toRollBack);
+            while (g_patches.size() > containerPatchBase) {
+                auto& rec = g_patches.back();
+                WriteMemorySafe(rec.addr, rec.original.data(),
+                                rec.original.size());
+                g_patches.pop_back();
+                numPatched--;
+            }
+            skippedCount += (int)toRollBack;
+            return false;
+        }
+
         PatchRecord bigRec;
         bigRec.addr = (BYTE*)container + 4;
         bigRec.original.assign(bigRec.addr, bigRec.addr + 16);
@@ -540,6 +576,7 @@ static int ScanRegionForShaders(BYTE* region, size_t regionSize, float gamma) {
                 g_patches.pop_back();
                 numPatched--;
             }
+            skippedCount += (int)toRollBack;
             return false;
         }
         Wh_Log(L"  Fixed container checksum at %p", (void*)container);
@@ -577,20 +614,9 @@ static int ScanRegionForShaders(BYTE* region, size_t regionSize, float gamma) {
         // shaders are patched.
         if (HasDXBCSubBlob(hdr)) {
             if (!bigShader) {
-                // Pre-flight: verify our checksum routine reproduces this
-                // blob's own hash before we commit to overwriting it. An
-                // unlisted container whose hash doesn't round-trip is skipped
-                // to avoid silent corruption.
-                if (!ChecksumRoundTrips(hdr)) {
-                    Wh_Log(
-                        L"  Container at %p: checksum did not round-trip, "
-                        L"skipping",
-                        (void*)hdr);
-                    i +=
-                        hdr->size -
-                        4;  // loop will add 4 more, landing just after the blob
-                    continue;
-                }
+                // Accept the container; the ChecksumRoundTrips verification is
+                // deferred to FinalizeContainer so the MD5 is only computed
+                // when qualifying leaves are actually found inside.
                 bigShader = hdr;
                 containerPatchBase = g_patches.size();
             } else {
@@ -643,6 +669,7 @@ static int ScanRegionForShaders(BYTE* region, size_t regionSize, float gamma) {
         if (!ChecksumRoundTrips(hdr)) {
             Wh_Log(L"  Blob at %p: checksum did not round-trip, skipping",
                    (void*)hdr);
+            skippedCount++;
             continue;
         }
 
@@ -663,6 +690,7 @@ static int ScanRegionForShaders(BYTE* region, size_t regionSize, float gamma) {
         // reduce COW pages and PatchRecord size but not improve correctness.
         if (!WriteMemorySafe((BYTE*)hdr, patched.data(), hdr->size)) {
             Wh_Log(L"  VirtualProtect failed for blob at %p", (void*)hdr);
+            skippedCount++;
             continue;
         }
 
@@ -749,6 +777,7 @@ BOOL Wh_ModInit() {
     // Walk PE sections instead of VirtualQuery: deterministic regardless of
     // page-protection fragmentation from other mods or the loader.
     int totalPatched = 0;
+    int totalSkipped = 0;
     auto* sec = IMAGE_FIRST_SECTION(nt);
     for (WORD s = 0; s < nt->FileHeader.NumberOfSections; s++, sec++) {
         // Scan readable, non-writable, non-executable sections only (e.g.
@@ -765,16 +794,27 @@ BOOL Wh_ModInit() {
         Wh_Log(L"Scanning section at %p, size %lu",
                (void*)(modBase + sec->VirtualAddress), sec->Misc.VirtualSize);
         totalPatched += ScanRegionForShaders(modBase + sec->VirtualAddress,
-                                             sec->Misc.VirtualSize, gamma);
+                                             sec->Misc.VirtualSize, gamma,
+                                             totalSkipped);
     }
 
+    if (totalSkipped > 0) {
+        // At least one qualified blob was not successfully patched. DWM would
+        // have a mix of patched and unpatched EOTF shaders, reproducing the
+        // intermittent sRGB reversion. Revert everything for a consistent state.
+        Wh_Log(
+            L"Partial patch (%d written, %d skipped) — reverting to avoid "
+            L"inconsistent SDR rendering",
+            totalPatched, totalSkipped);
+        RestoreAllPatches();
+        return FALSE;
+    }
     if (totalPatched == 0) {
-        // No sRGB EOTF shaders found. The vec3-splat constant encoding may have
-        // changed in a Windows Update. Run LogSrgbCandidates to log any blobs
-        // that partially match, to help diagnose format changes.
+        // No sRGB EOTF shaders found. The constant encoding may have changed.
+        // Run the near-miss scan to log any blobs with partial matches.
         Wh_Log(
             L"No sRGB EOTF shaders found — dwmcore.dll format may have "
-            L"changed; scanning for partial matches...");
+            L"changed; scanning for near-matches...");
         auto* dSec = IMAGE_FIRST_SECTION(nt);
         for (WORD s = 0; s < nt->FileHeader.NumberOfSections; s++, dSec++) {
             if (!(dSec->Characteristics & IMAGE_SCN_MEM_READ) ||
@@ -782,7 +822,7 @@ BOOL Wh_ModInit() {
                 (dSec->Characteristics & IMAGE_SCN_MEM_WRITE) ||
                 dSec->Misc.VirtualSize == 0)
                 continue;
-            LogSrgbCandidates(modBase + dSec->VirtualAddress,
+            LogSrgbNearMisses(modBase + dSec->VirtualAddress,
                               dSec->Misc.VirtualSize);
         }
         return FALSE;

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -19,7 +19,9 @@ it so that Windows uses a standard gamma curve. It should not affect native HDR 
 
 Simple, accurate sRGB with a simple power-law gamma curve that you can control.
 
-See examples and read more on [GitHub](https://github.com/dylanraga/win11hdr-srgb-to-gamma2.2-icm) by dylanraga
+![Comparison Image](https://i.imgur.com/GwegdeU.png)
+
+See examples and read more on the [win11hdr-srgb-to-gamma2.2-icm GitHub](https://github.com/dylanraga/win11hdr-srgb-to-gamma2.2-icm), an alternative icc based solution by dylanraga
 
 ## DWM EOTF Gamma Curve
 
@@ -439,7 +441,8 @@ static int PatchShaderBuf(BYTE *buf, DWORD size, float gamma, int counts[4])
 static bool HasDXBCSubBlob(const DXBCHeader *hdr)
 {
     const BYTE *base = (const BYTE *)hdr;
-    for (size_t k = kDXBCHeaderSize; k + kDXBCHeaderSize <= hdr->size; k++)
+    // DXBC sub-blobs are at DWORD-aligned offsets within a container (verified).
+    for (size_t k = kDXBCHeaderSize; k + kDXBCHeaderSize <= hdr->size; k += 4)
     {
         const auto *inner = (const DXBCHeader *)(base + k);
         if (inner->magic[0] == 'D' && inner->magic[1] == 'X' &&
@@ -468,22 +471,25 @@ static bool ChecksumRoundTrips(const DXBCHeader *hdr)
 
 // Scans a read-only committed memory region for DXBC shader blobs, patches any
 // that match the known checksums, and appends restoration records to g_patches.
+// Accumulates matched-shader bits into matchedMask (bit i = kKnownChecksums[i] patched).
 // Returns the number of individual shaders patched.
 //
 // "Big shader" handling: dwmcore.dll embeds the target shaders as sub-blobs
 // inside larger DXBC container blobs. The container's own checksum must be
 // recalculated after its inner shaders are patched.
-static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
+static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma, unsigned &matchedMask)
 {
     int numPatched = 0;
 
-    DXBCHeader *bigShader = nullptr; // enclosing container blob, if any
-    bool bigPatched = false;         // did we patch any sub-shader inside it?
-    size_t containerPatchBase = 0;   // g_patches index when the current container was accepted
+    DXBCHeader *bigShader = nullptr;   // enclosing container blob, if any
+    bool bigPatched = false;           // did we patch any sub-shader inside it?
+    size_t containerPatchBase = 0;     // g_patches index when the current container was accepted
+    unsigned containerMatchedBits = 0; // matchedMask bits set for the current container's leaves
 
     // Finalizes a container whose inner shaders have been patched: saves its
     // original checksum, recomputes it, and writes it back. If the write fails,
-    // rolls back all leaf patches belonging to this container.
+    // rolls back all leaf patches belonging to this container and clears their
+    // bits from matchedMask so Wh_ModInit's all-or-nothing check stays accurate.
     auto FinalizeContainer = [&](DXBCHeader *container) -> bool
     {
         PatchRecord bigRec;
@@ -506,13 +512,16 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
                 g_patches.pop_back();
                 numPatched--;
             }
+            matchedMask &= ~containerMatchedBits; // un-mark the rolled-back shaders
             return false;
         }
         Wh_Log(L"  Fixed container checksum at %p", (void *)container);
         return true;
     };
 
-    for (size_t i = 0; i + kDXBCHeaderSize <= regionSize; i++)
+    // All DXBC blobs in dwmcore.dll's .rdata are DWORD-aligned (verified by scanning
+    // the binary: 0 of 404 occurrences are unaligned). Step by 4 for speed.
+    for (size_t i = 0; i + kDXBCHeaderSize <= regionSize; i += 4)
     {
         // If we have advanced past the end of the current container blob,
         // finalize it if we patched any inner shaders.
@@ -522,6 +531,7 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
                 FinalizeContainer(bigShader);
             bigShader = nullptr;
             bigPatched = false;
+            containerMatchedBits = 0;
         }
 
         auto *hdr = (DXBCHeader *)(region + i);
@@ -549,10 +559,12 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
                 if (!ChecksumRoundTrips(hdr))
                 {
                     Wh_Log(L"  Container at %p: checksum did not round-trip, skipping", (void *)hdr);
+                    i += hdr->size - 4; // loop will add 4 more, landing just after the blob
                     continue;
                 }
                 bigShader = hdr;
                 containerPatchBase = g_patches.size();
+                containerMatchedBits = 0;
             }
             else
             {
@@ -561,7 +573,7 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
                 // patched without a proper container fixup.
                 Wh_Log(L"  Nested container at %p inside %p — skipping unsupported nesting depth",
                        (void *)hdr, (void *)bigShader);
-                i += hdr->size - 1; // loop will add 1 more, landing just after the blob
+                i += hdr->size - 4; // loop will add 4 more, landing just after the blob
             }
             continue;
         }
@@ -581,6 +593,15 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
         }
         if (matchIdx < 0)
             continue;
+
+        // Verify our checksum implementation can reproduce this blob's exact hash
+        // before rewriting it. A wrong hash here makes D3D reject the shader,
+        // which in DWM means a compositor failure rather than a cosmetic glitch.
+        if (!ChecksumRoundTrips(hdr))
+        {
+            Wh_Log(L"  Shader #%d at %p: checksum did not round-trip, skipping", matchIdx, (void *)hdr);
+            continue;
+        }
 
         // Verify the leaf actually lies within the tracked container's bounds
         // before attributing the patch to that container. A positional false-positive
@@ -624,8 +645,12 @@ static int ScanRegionForShaders(BYTE *region, size_t regionSize, float gamma)
 
         g_patches.push_back(std::move(rec));
         numPatched++;
+        matchedMask |= 1u << matchIdx;
         if (insideContainer)
+        {
+            containerMatchedBits |= 1u << matchIdx;
             bigPatched = true;
+        }
 
         Wh_Log(L"  Patched shader #%d at %p (size %lu)", matchIdx, (void *)hdr, hdr->size);
     }
@@ -643,7 +668,11 @@ static void RestoreAllPatches()
     // Iterate in reverse so sub-shader records (added first) are restored after
     // their container checksum records (added last), giving a consistent final state.
     for (auto it = g_patches.rbegin(); it != g_patches.rend(); ++it)
-        WriteMemorySafe(it->addr, it->original.data(), it->original.size());
+    {
+        if (!WriteMemorySafe(it->addr, it->original.data(), it->original.size()))
+            Wh_Log(L"  VirtualProtect failed restoring %zu bytes at %p",
+                   it->original.size(), (void *)it->addr);
+    }
     g_patches.clear();
 }
 
@@ -653,21 +682,39 @@ static void RestoreAllPatches()
 
 BOOL Wh_ModInit()
 {
-    // Read the user's gamma setting.
-    float gamma = wcstof(WindhawkUtils::StringSetting::make(L"GammaCurve"), nullptr);
-    if (gamma < 1.0f || gamma > 10.0f)
+    // Resolve the gamma setting via lookup table to avoid locale-dependent wcstof
+    // behaviour: a locale with ',' as the decimal separator would silently parse
+    // "2.2" as 2.0, which passes a range check without any visible error.
+    static const struct
     {
-        Wh_Log(L"Invalid gamma value, falling back to 2.2");
-        gamma = 2.2f;
+        const wchar_t *str;
+        float val;
+    } kGammaOptions[] = {
+        {L"1.8", 1.8f}, {L"2.0", 2.0f}, {L"2.2", 2.2f}, {L"2.4", 2.4f}, {L"2.6", 2.6f}};
+    float gamma = 2.2f;
+    {
+        auto gammaSetting = WindhawkUtils::StringSetting::make(L"GammaCurve");
+        for (const auto &opt : kGammaOptions)
+        {
+            if (wcscmp(gammaSetting, opt.str) == 0)
+            {
+                gamma = opt.val;
+                break;
+            }
+        }
     }
 
     Wh_Log(L"Target gamma = %.1f", (double)gamma);
 
-    // Locate dwmcore.dll (always loaded as a static import of dwm.exe).
+    // Locate dwmcore.dll. It is listed in dwm.exe's PE import directory and is
+    // therefore mapped by the OS loader before any code runs in the process,
+    // so GetModuleHandleW is guaranteed to succeed without needing a
+    // LoadLibraryExW hook. (Verified: "dwmcore.dll" appears in dwm.exe's
+    // raw import-table bytes at a fixed offset.)
     HMODULE hDwmcore = GetModuleHandleW(L"dwmcore.dll");
     if (!hDwmcore)
     {
-        Wh_Log(L"dwmcore.dll not found in process — aborting");
+        Wh_Log(L"dwmcore.dll not found — unexpected, please file an issue");
         return FALSE;
     }
 
@@ -681,7 +728,7 @@ BOOL Wh_ModInit()
 
     // Walk PE sections instead of VirtualQuery: deterministic regardless of
     // page-protection fragmentation from other mods or the loader.
-    int totalPatched = 0;
+    unsigned matchedMask = 0;
     auto *sec = IMAGE_FIRST_SECTION(nt);
     for (WORD s = 0; s < nt->FileHeader.NumberOfSections; s++, sec++)
     {
@@ -697,17 +744,28 @@ BOOL Wh_ModInit()
 
         Wh_Log(L"Scanning section at %p, size %lu",
                (void *)(modBase + sec->VirtualAddress), sec->Misc.VirtualSize);
-        totalPatched += ScanRegionForShaders(modBase + sec->VirtualAddress,
-                                             sec->Misc.VirtualSize, gamma);
+        ScanRegionForShaders(modBase + sec->VirtualAddress,
+                             sec->Misc.VirtualSize, gamma, matchedMask);
     }
 
-    if (totalPatched == 0)
+    if (matchedMask == 0)
     {
-        Wh_Log(L"No matching shaders found — dwmcore.dll may have been updated.");
+        // No target shaders found at all. Most likely HDR is disabled (the patched
+        // code path is only active when the display is in HDR mode) or dwmcore.dll
+        // was updated and its shader checksums changed.
+        Wh_Log(L"No target shaders found — HDR may be off, or dwmcore.dll checksums changed after a Windows Update");
         return FALSE;
     }
-
-    Wh_Log(L"Successfully patched %d shader(s) with gamma %.1f", totalPatched, (double)gamma);
+    if (matchedMask != 0xFu)
+    {
+        // Partial patch: some but not all of the four target shaders were found.
+        // Leaving DWM with a mix of power-law and sRGB surfaces would produce
+        // inconsistent rendering, so revert everything.
+        Wh_Log(L"Partial patch (mask 0x%X of 0xF) — reverting to avoid inconsistent SDR rendering", matchedMask);
+        RestoreAllPatches();
+        return FALSE;
+    }
+    Wh_Log(L"All 4 target shaders patched with gamma %.1f", (double)gamma);
     return TRUE;
 }
 

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -14,7 +14,12 @@
 /*
 # Windows SDR to HDR Tonemapping Fix
 
-Correct Windows' SDR-to-HDR tonemapping. No more washed out midtones or crushed shadows — just a simple power-law gamma curve that you can control.
+Viewing SDR content while using HDR in Windows causes washed out darker tones like shadows. This corrects
+it so that Windows uses a standard gamma curve. It should not affect native HDR content like games and movies.
+
+Simple, accurate sRGB with a simple power-law gamma curve that you can control.
+
+See examples and read more on [GitHub](https://github.com/dylanraga/win11hdr-srgb-to-gamma2.2-icm) by dylanraga
 
 ## DWM EOTF Gamma Curve
 

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -78,11 +78,12 @@ effect.
 
 | Value | Description |
 |-------|-------------|
-| 1.8   | Raised midtones and shadows; old Apple/Mac standard |
-| 2.0   | Moderately bright midpoint |
-| 2.2   | Closest to the perceptual average of sRGB |
-| 2.4   | sRGB peak exponent |
-| 2.6   | Darker midtones, punchier contrast |
+| 1.8   | Bright and low contrast, legacy Mac standard |
+| 2.0   | Compromise between 1.8 and 2.2 |
+| 2.2   | Standard PC/monitor target, sRGB average and Display P3 |
+| 2.3   | Compromise between 2.2 and 2.4 |
+| 2.4   | Broadcast and HDTV, Rec. 709 / BT.1886 |
+| 2.6   | Dark and high contrast, Digital cinema projection, DCI-P3 |
 
 ## Known limitations
 
@@ -91,6 +92,9 @@ effect.
 - **Gamma changes require a DWM restart.** D3D compiles the shader bytecode once
   at startup. Patching the bytecode after that has no effect until DWM restarts
   (log off and back on).
+- **Disabling the mod also requires a DWM restart.** After unloading, shaders
+  already compiled from the patched bytecode retain the power-law curve while
+  newly compiled ones revert, leaving a mixed state until DWM restarts.
 - **Chromium-based browsers and Electron apps** (Chrome, Edge, VS Code, Discord,
   etc.) switch between DWM's SDR compositing path and a direct scRGB path
   depending on tab/window content. Each
@@ -117,11 +121,12 @@ effect.
     Power-law gamma exponent used for SDR-to-HDR EOTF conversion.
     Log off and back in after changing for the new value to take effect.
   $options:
-    - "1.8": "1.8 (bright, old Mac standard)"
+    - "1.8": "1.8 (Bright and low contrast, legacy Mac standard)"
     - "2.0": "2.0"
-    - "2.2": "2.2 (sRGB average)"
-    - "2.4": "2.4 (sRGB peak)"
-    - "2.6": "2.6 (dark / high contrast)"
+    - "2.2": "2.2 (Standard PC/monitor target, sRGB average and Display P3)"
+    - "2.3": "2.3"
+    - "2.4": "2.4 (Broadcast and HDTV, Rec. 709 / BT.1886)"
+    - "2.6": "2.6 (Dark and high contrast, Digital cinema projection, DCI-P3)"
 */
 // ==/WindhawkModSettings==
 
@@ -357,13 +362,8 @@ struct PatchRecord {
 
 static std::vector<PatchRecord> g_patches;
 
-// The sRGB EOTF signature — all four vec3-splat constants present exactly once
-// in a leaf blob — is unique to the decode path and covers all ~37 shader
-// variants across DWM's compositing code paths. A checksum allowlist was used
-// previously (verified against dwmcore.dll 10.0.26100.8521) but only covered
-// four of the thirty-seven variants, causing the remaining unpatched shaders to
-// revert to sRGB EOTF during window focus and resize events. Content-based
-// detection is now the sole selector and requires no per-build maintenance.
+// All four sRGB EOTF vec3-splat constants together uniquely identify the decode
+// path across all ~37 shader variants in DWM's compositing pipeline.
 
 // =============================================================================
 // Memory helpers
@@ -400,35 +400,47 @@ static const float kSrgbConsts[4] = {2.4f, 0.04045f, 0.055000f, 0.94786733f};
 // replaced with the user-chosen gamma instead and has no slot here.
 static const float kPatchConsts[3] = {0.0f, 0.0f, 1.0f};
 
-// Searches 'buf' (a copy of a shader blob) for the sRGB vec3-splat patterns and
-// patches them in-place. Fills counts[4] with the number of replacements made
-// for each constant. Returns the number of constants that had at least one
-// match (0–4). Callers must require == 4 to ensure all-or-nothing patching, and
-// should log the individual counts: some constants (e.g. 0.055) appear in both
-// decode and encode paths, so a count > 1 indicates unexpected overlap that
-// would corrupt unintended code.
-static int PatchShaderBuf(BYTE* buf, DWORD size, float gamma, int counts[4]) {
+// Scans a DXBC blob for the four sRGB EOTF vec3-splat constants. Read-only;
+// fills counts[4] with occurrences of each and returns the number of constants
+// with at least one match. Used to pre-screen blobs before allocating a copy
+// and to count qualifying leaves inside skipped containers.
+static int ScanSrgbSplats(const BYTE* blob, DWORD size, int counts[4]) {
+    for (int ci = 0; ci < 4; ci++)
+        counts[ci] = 0;
     int found = 0;
+    for (size_t j = kDXBCHeaderSize; j + sizeof(float) * 3 <= size; j += 4) {
+        const BYTE* p = blob + j;
+        for (int ci = 0; ci < 4; ci++) {
+            float pat[3] = {kSrgbConsts[ci], kSrgbConsts[ci], kSrgbConsts[ci]};
+            if (memcmp(p, pat, sizeof(pat)) == 0)
+                counts[ci]++;
+        }
+    }
+    for (int ci = 0; ci < 4; ci++)
+        if (counts[ci] > 0)
+            found++;
+    return found;
+}
+
+// Patches 'buf' (a copy of a shader blob) in-place by replacing the four sRGB
+// EOTF vec3-splat constants with their power-law equivalents. Callers must
+// pre-screen with ScanSrgbSplats to confirm all four constants are present
+// exactly once before calling.
+static void PatchShaderBuf(BYTE* buf, DWORD size, float gamma) {
     for (int ci = 0; ci < 4; ci++) {
         float src = kSrgbConsts[ci];
         float dst = (ci == 0) ? gamma : kPatchConsts[ci - 1];
         float pat[3] = {src, src, src};
-        counts[ci] = 0;
-        // Search from after the header; stop where a full 12-byte match would
-        // overflow. DXBC constants are DWORD-aligned, so step by 4 for
-        // correctness and speed.
+        // DXBC constants are DWORD-aligned, so step by 4 for correctness and
+        // speed.
         for (size_t j = kDXBCHeaderSize; j + sizeof(float) * 3 <= size;
              j += 4) {
             if (memcmp(pat, buf + j, sizeof(pat)) != 0)
                 continue;
             float rep[3] = {dst, dst, dst};
             memcpy(buf + j, rep, sizeof(rep));
-            counts[ci]++;
         }
-        if (counts[ci] > 0)
-            found++;
     }
-    return found;
 }
 
 // Returns true if the blob contains at least one valid nested DXBC blob.
@@ -452,12 +464,33 @@ static bool HasDXBCSubBlob(const DXBCHeader* hdr) {
 }
 
 // Returns true if CalcDXBCChecksum reproduces the blob's own embedded checksum.
-// Used as a pre-flight check before writing a new checksum into a container
-// blob that is not on the known-checksum allowlist.
+// Used as a pre-flight check before writing a new checksum.
 static bool ChecksumRoundTrips(const DXBCHeader* hdr) {
     DWORD verify[4];
     CalcDXBCChecksum((const BYTE*)hdr, hdr->size, verify);
     return memcmp(verify, hdr->checksum, 16) == 0;
+}
+
+// Counts leaf DXBC blobs in [region, region+regionSize) that qualify as sRGB
+// EOTF shaders (all four constants present exactly once). Read-only — used to
+// account for blobs inside skipped containers so the all-or-nothing check stays
+// accurate.
+static int CountEotfLeaves(const BYTE* region, size_t regionSize) {
+    int count = 0;
+    for (size_t k = 0; k + kDXBCHeaderSize <= regionSize; k += 4) {
+        const auto* hdr = (const DXBCHeader*)(region + k);
+        if (hdr->magic[0] != 'D' || hdr->magic[1] != 'X' ||
+            hdr->magic[2] != 'B' || hdr->magic[3] != 'C' ||
+            hdr->reserved != 1 || hdr->size < (DWORD)kDXBCHeaderSize ||
+            k + hdr->size > regionSize || HasDXBCSubBlob(hdr))
+            continue;
+        int counts[4];
+        if (ScanSrgbSplats((const BYTE*)hdr, hdr->size, counts) == 4 &&
+            counts[0] == 1 && counts[1] == 1 && counts[2] == 1 &&
+            counts[3] == 1)
+            count++;
+    }
+    return count;
 }
 
 // =============================================================================
@@ -604,10 +637,12 @@ static int ScanRegionForShaders(BYTE* region,
                 // inner leaves the container body changes and round-trip always
                 // fails.
                 if (!ChecksumRoundTrips(hdr)) {
+                    int missed = CountEotfLeaves((const BYTE*)hdr, hdr->size);
                     Wh_Log(
                         L"  Container at %p: checksum did not round-trip, "
-                        L"skipping",
-                        (void*)hdr);
+                        L"skipping (%d EOTF leaf(s) uncounted)",
+                        (void*)hdr, missed);
+                    skippedCount += missed;
                     i +=
                         hdr->size -
                         4;  // loop will add 4 more, landing just after the blob
@@ -616,48 +651,45 @@ static int ScanRegionForShaders(BYTE* region,
                 bigShader = hdr;
                 containerPatchBase = g_patches.size();
             } else {
-                // A nested container inside the current one: multi-level
-                // nesting is not supported. Skip past the inner blob so its
-                // leaves are not patched without a proper container fixup.
+                // A nested container inside the current one: count its EOTF
+                // leaves as skipped before jumping past so the all-or-nothing
+                // check stays accurate.
+                int missed = CountEotfLeaves((const BYTE*)hdr, hdr->size);
                 Wh_Log(
                     L"  Nested container at %p inside %p — skipping "
-                    L"unsupported nesting depth",
-                    (void*)hdr, (void*)bigShader);
+                    L"unsupported nesting depth (%d EOTF leaf(s) uncounted)",
+                    (void*)hdr, (void*)bigShader, missed);
+                skippedCount += missed;
                 i += hdr->size -
                      4;  // loop will add 4 more, landing just after the blob
             }
             continue;
         }
 
-        // Leaf blob: use content-based detection. The four sRGB EOTF vec3-splat
-        // constants together are unique to the decode path — any leaf
-        // containing all four (each exactly once) is an sRGB EOTF shader
-        // regardless of its compiled checksum. This covers all ~37 shader
-        // variants in DWM.
+        // Leaf blob: detect by content — all four sRGB EOTF vec3-splat
+        // constants present exactly once. Pre-screen in-place to avoid
+        // allocation for the ~360 non-EOTF leaves in .rdata.
         bool insideContainer =
             bigShader && (BYTE*)hdr >= (BYTE*)bigShader &&
             (BYTE*)hdr + hdr->size <= (BYTE*)bigShader + bigShader->size;
 
-        // Copy the blob and attempt to patch the sRGB constants.
-        std::vector<BYTE> patched(hdr->size);
-        memcpy(patched.data(), hdr, hdr->size);
-
-        int counts[4] = {};
-        int constsFound =
-            PatchShaderBuf(patched.data(), hdr->size, gamma, counts);
-        if (constsFound < 4)
-            continue;  // not an sRGB EOTF shader — discard the copy
+        int preCounts[4];
+        if (ScanSrgbSplats((const BYTE*)hdr, hdr->size, preCounts) < 4)
+            continue;  // not all four EOTF constants present
 
         bool countsOk = true;
         for (int ci = 0; ci < 4; ci++) {
-            if (counts[ci] != 1) {
+            if (preCounts[ci] != 1) {
                 Wh_Log(L"  Blob at %p: constant %d count %d != 1 — skipping",
-                       (void*)hdr, ci, counts[ci]);
+                       (void*)hdr, ci, preCounts[ci]);
                 countsOk = false;
+                break;
             }
         }
-        if (!countsOk)
+        if (!countsOk) {
+            skippedCount++;
             continue;
+        }
 
         // Pre-flight: verify our checksum implementation reproduces this blob's
         // own hash before writing a new one. A wrong hash makes D3D reject the
@@ -669,6 +701,11 @@ static int ScanRegionForShaders(BYTE* region,
             continue;
         }
 
+        // EOTF leaf confirmed; allocate copy and apply patches.
+        std::vector<BYTE> patched(hdr->size);
+        memcpy(patched.data(), hdr, hdr->size);
+        PatchShaderBuf(patched.data(), hdr->size, gamma);
+
         DWORD newCk[4];
         CalcDXBCChecksum(patched.data(), hdr->size, newCk);
         memcpy(patched.data() + 4, newCk, 16);
@@ -678,12 +715,9 @@ static int ScanRegionForShaders(BYTE* region,
         rec.addr = (BYTE*)hdr;
         rec.original.assign(rec.addr, rec.addr + hdr->size);
 
-        // Writing the whole blob rather than only the changed bytes: patched
-        // differs from the original solely in the ~48 bytes of splat constants
-        // and the 16-byte checksum, so memcpy replays every other byte at its
-        // current value. A concurrent reader can only observe changes to those
-        // same bytes — the same window as delta writes. Delta writes would
-        // reduce COW pages and PatchRecord size but not improve correctness.
+        // Whole-blob write: patched differs from original only in the splat
+        // constants and checksum; unchanged bytes are replayed at their
+        // existing values — same observable window as delta writes.
         if (!WriteMemorySafe((BYTE*)hdr, patched.data(), hdr->size)) {
             Wh_Log(L"  VirtualProtect failed for blob at %p", (void*)hdr);
             skippedCount++;
@@ -726,6 +760,10 @@ static void RestoreAllPatches() {
 // =============================================================================
 
 BOOL Wh_ModInit() {
+    // Defensive reset: Wh_ModBeforeUninit should always clear g_patches before
+    // a reload, but clear it here in case of an abnormal lifecycle.
+    g_patches.clear();
+
     // Resolve the gamma setting via lookup table to avoid locale-dependent
     // wcstof behaviour: a locale with ',' as the decimal separator would
     // silently parse "2.2" as 2.0, which passes a range check without any
@@ -733,11 +771,8 @@ BOOL Wh_ModInit() {
     static const struct {
         const wchar_t* str;
         float val;
-    } kGammaOptions[] = {{L"1.8", 1.8f},
-                         {L"2.0", 2.0f},
-                         {L"2.2", 2.2f},
-                         {L"2.4", 2.4f},
-                         {L"2.6", 2.6f}};
+    } kGammaOptions[] = {{L"1.8", 1.8f}, {L"2.0", 2.0f}, {L"2.2", 2.2f},
+                         {L"2.3", 2.3f}, {L"2.4", 2.4f}, {L"2.6", 2.6f}};
     float gamma = 2.2f;
     {
         auto gammaSetting = WindhawkUtils::StringSetting::make(L"GammaCurve");
@@ -764,7 +799,15 @@ BOOL Wh_ModInit() {
 
     // Determine the module's address range from its PE header.
     auto* dos = (IMAGE_DOS_HEADER*)hDwmcore;
+    if (dos->e_magic != IMAGE_DOS_SIGNATURE) {
+        Wh_Log(L"dwmcore.dll: invalid DOS header");
+        return FALSE;
+    }
     auto* nt = (IMAGE_NT_HEADERS*)((BYTE*)hDwmcore + dos->e_lfanew);
+    if (nt->Signature != IMAGE_NT_SIGNATURE) {
+        Wh_Log(L"dwmcore.dll: invalid NT header");
+        return FALSE;
+    }
     BYTE* modBase = (BYTE*)hDwmcore;
     size_t modSize = nt->OptionalHeader.SizeOfImage;
 

--- a/mods/dwm-eotf-gamma.wh.cpp
+++ b/mods/dwm-eotf-gamma.wh.cpp
@@ -1,4 +1,3 @@
-// clang-format off
 // ==WindhawkMod==
 // @id              dwm-eotf-gamma
 // @name            Windows SDR to HDR Tonemapping Fix
@@ -122,7 +121,6 @@ effect.
     - "2.6": "2.6 (dark / high contrast)"
 */
 // ==/WindhawkModSettings==
-// clang-format on
 
 #include <windhawk_utils.h>
 #include <windows.h>


### PR DESCRIPTION
## Windows SDR to HDR Tonemapping Fix

Adds a new mod (`dwm-eotf-gamma.wh.cpp`) that patches the DXBC shader bytecode in `dwmcore.dll` at DWM startup to replace the sRGB EOTF with a configurable pure power-law gamma for SDR-to-HDR tone mapping.

### What it does

When Windows HDR is enabled, DWM converts SDR content to HDR scRGB using the sRGB EOTF (a ~2.2 power curve with a linear toe segment near black). The result of this is lifted shadows and darker tones on SDR content when in HDR mode. This mod patches the floating-point constants that define that transfer function, replacing them with a simple power-law gamma curve, emulating actual SDR monitor behavior, giving users direct, more accurate, control over the SDR-to-HDR tone mapping without permanently modifying any files on disk.

Based on [dwm_eotf](https://github.com/ledoge/dwm_eotf) by ledoge (GPL-3.0).

Also addresses request https://github.com/ramensoftware/windhawk-mods/issues/2036

### Key details

- Targets `dwm.exe` (x86_64)
- Patches DXBC bytecode in `dwmcore.dll`'s read-only memory at startup; recalculates shader checksums so D3D accepts the patched bytecode
- Fully reversible: all patched bytes are restored when the mod is unloaded
- User-configurable gamma value (default 2.2); supported range ~1.8–2.6
- Requires Windows HDR to be enabled and a DWM restart to take effect

<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Changelog Initial version 1.0

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [x] The submitter, with AI assistance
- - [x] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [x] Other (please specify): 
Based on https://github.com/ledoge/dwm_eotf

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.