### PR TITLE
Make start-menu-open-real-file-location work for search results

### DIFF
--- a/mods/start-menu-open-real-file-location.wh.cpp
+++ b/mods/start-menu-open-real-file-location.wh.cpp
@@ -2,13 +2,14 @@
 // @id              start-menu-open-real-file-location
 // @name            Start Menu Open Real File Location
 // @description     Makes Open file location select a Start menu shortcut's target instead of the shortcut itself
-// @version         1.0.0
+// @version         1.1.0
 // @author          Alchemy
 // @github          https://github.com/alchemyyy
 // @license         MIT
 // @include         StartMenuExperienceHost.exe
 // @include         SearchHost.exe
 // @include         SearchApp.exe
+// @include         RuntimeBroker.exe
 // @architecture    x86-64
 // @compilerOptions -lole32
 // ==/WindhawkMod==
@@ -60,6 +61,7 @@ using UniqueWideString = std::unique_ptr<WCHAR, CoTaskMemoryDeleter>;
 SHOpenFolderAndSelectItemsFunction s_windowsStorageOriginal = nullptr;
 SHOpenFolderAndSelectItemsFunction s_shell32Original = nullptr;
 HMODULE s_windowsStorageModule = nullptr;
+bool s_isSearchProcess = false;
 
 void ReleaseWindowsStorageModule() {
     if (!s_windowsStorageModule) {
@@ -159,7 +161,7 @@ HRESULT HandleSHOpenFolderAndSelectItems(
     DWORD flags,
     void* returnAddress) {
     if (!folderPidl || childCount != 0 || childPidls ||
-        !IsAppResolverCaller(returnAddress)) {
+        (!s_isSearchProcess && !IsAppResolverCaller(returnAddress))) {
         return originalFunction(folderPidl, childCount, childPidls, flags);
     }
 
@@ -204,6 +206,9 @@ HRESULT WINAPI Shell32SHOpenFolderAndSelectItemsHook(
 }  // namespace
 
 BOOL Wh_ModInit() {
+    s_isSearchProcess = GetModuleHandleW(L"SearchHost.exe") ||
+                        GetModuleHandleW(L"SearchApp.exe");
+
     s_windowsStorageModule = LoadLibraryExW(
         L"Windows.Storage.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     HMODULE shell32Module = GetModuleHandleW(L"shell32.dll");

--- a/mods/start-menu-open-real-file-location.wh.cpp
+++ b/mods/start-menu-open-real-file-location.wh.cpp
@@ -61,7 +61,6 @@ using UniqueWideString = std::unique_ptr<WCHAR, CoTaskMemoryDeleter>;
 SHOpenFolderAndSelectItemsFunction s_windowsStorageOriginal = nullptr;
 SHOpenFolderAndSelectItemsFunction s_shell32Original = nullptr;
 HMODULE s_windowsStorageModule = nullptr;
-bool s_isSearchProcess = false;
 
 void ReleaseWindowsStorageModule() {
     if (!s_windowsStorageModule) {
@@ -161,7 +160,7 @@ HRESULT HandleSHOpenFolderAndSelectItems(
     DWORD flags,
     void* returnAddress) {
     if (!folderPidl || childCount != 0 || childPidls ||
-        (!s_isSearchProcess && !IsAppResolverCaller(returnAddress))) {
+        !IsAppResolverCaller(returnAddress)) {
         return originalFunction(folderPidl, childCount, childPidls, flags);
     }
 
@@ -206,9 +205,6 @@ HRESULT WINAPI Shell32SHOpenFolderAndSelectItemsHook(
 }  // namespace
 
 BOOL Wh_ModInit() {
-    s_isSearchProcess = GetModuleHandleW(L"SearchHost.exe") ||
-                        GetModuleHandleW(L"SearchApp.exe");
-
     s_windowsStorageModule = LoadLibraryExW(
         L"Windows.Storage.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
     HMODULE shell32Module = GetModuleHandleW(L"shell32.dll");


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Fixed start-menu-open-real-file-location.wh.cpp so it works for search results as well.

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
