### PR TITLE
Only replace text UI fonts (skip icon, symbol, etc. fonts).

### DIFF
--- a/mods/explorer-font-changer.wh.cpp
+++ b/mods/explorer-font-changer.wh.cpp
@@ -203,6 +203,14 @@ namespace util {
     void change_font_in_struct(
         LOGFONTW* font
     ) {
+        const std::wstring_view current_face(font->lfFaceName);
+
+        // Only replace text UI fonts (skip icon, symbol, etc. fonts).
+        if (current_face != L"Segoe UI"sv &&
+            current_face != L"Segoe UI Variable"sv) {
+            return;
+        }
+      
         auto font_name = std::wstring_view(s_font_name.get());
 
         // Check font configuration.


### PR DESCRIPTION
<!-- ⚠️ Please keep the template below intact and fill in the relevant sections. Any additional content can be placed above the template. -->

## Changelog

If this pull request updates an existing mod, describe the changes below:

* Only replace text UI fonts (skip icon, symbol, etc. fonts).

## Mod authorship

If this pull request introduces a new mod, please complete the section below.

This mod was created by:

- - [ ] The submitter, without AI assistance
- - [ ] The submitter, with AI assistance
- - [ ] Claude
- - [ ] ChatGPT
- - [ ] Gemini
- - [ ] Another AI (please specify): 
- - [ ] Other (please specify): 

Please select the options that best apply. Your selection does not affect the acceptance criteria, but it helps reviewers understand the context of the code and provide relevant feedback.
