### PR TITLE
Fix broken README screenshot links that fail the deploy workflow

### DIFF
--- a/mods/folder-thumbnail-style-switcher.wh.cpp
+++ b/mods/folder-thumbnail-style-switcher.wh.cpp
@@ -2,7 +2,7 @@
 // @id              folder-thumbnail-style-switcher
 // @name            Folder Thumbnail Style Switcher
 // @description     Switch Explorer folder thumbnails between Windows 7, Windows 10, and Windows 11 styles.
-// @version         2.0
+// @version         2.0.1
 // @author          QCQ171-C
 // @github          https://github.com/QCQ171-C
 // @include         explorer.exe
@@ -28,8 +28,8 @@ And you need to clean the thumbnail cache after changing a style!
 |![10 style](https://raw.githubusercontent.com/QCQ171-C/mods-collection/refs/heads/main/Gallery/folder-thumbnail-tweaker/10.PNG)|Original 10 style|
 |![11 style](https://raw.githubusercontent.com/QCQ171-C/mods-collection/refs/heads/main/Gallery/folder-thumbnail-tweaker/11.png)|Original 11 style|
 |![7 style on 10](https://raw.githubusercontent.com/QCQ171-C/mods-collection/refs/heads/main/Gallery/folder-thumbnail-tweaker/10-7.PNG)|7 style on Windows 10|
-|![11 style on 10](https://raw.githubusercontent.com/QCQ171-C/mods-collection/refs/heads/main/Gallery/folder-thumbnail-tweaker/10-11.png)|11 style on Windows 10|
-|![7 style on 11](https://raw.githubusercontent.com/QCQ171-C/mods-collection/refs/heads/main/Gallery/folder-thumbnail-tweaker/11-7.PNG)|7 style on Windows 11|
+|![11 style on 10](https://raw.githubusercontent.com/QCQ171-C/mods-collection/refs/heads/main/Gallery/folder-thumbnail-tweaker/10-11.PNG)|11 style on Windows 10|
+|![7 style on 11](https://raw.githubusercontent.com/QCQ171-C/mods-collection/refs/heads/main/Gallery/folder-thumbnail-tweaker/11-7.png)|7 style on Windows 11|
 |![10 style on 11](https://raw.githubusercontent.com/QCQ171-C/mods-collection/refs/heads/main/Gallery/folder-thumbnail-tweaker/11-10.png)|10 style on 11|
 
 What's the difference🤨? The position and the size of the thumbnails and the shadow are different.


### PR DESCRIPTION
The scheduled Deploy static content workflow keeps failing because \scripts/archive_mod_images.py\ aborts when a README screenshot URL returns 404 (set iteration order makes the failing URL vary between runs).

Fix for \older-thumbnail-style-switcher\ (bumped to **v2.0.1**): two README screenshot URLs had the wrong filename case and 404'd (\11-7.PNG\ -> \11-7.png\, \10-11.png\ -> \10-11.PNG\) — the exact case in the source repo, which is what the commented-out \FETCH_URL_WORKAROUNDS\ in \rchive_mod_images.py\ was working around. The version bump is required because the deploy records one file per version in a mod's history (every commit touching a mod file must have a unique \@version\).

Note: the \xplorer-command-bar\ README URLs with the \xporer-command-bar\ typo were already fixed upstream in v1.1.0 (#5015). All referenced screenshots across the repo now return 200.